### PR TITLE
perf(hindsight): size embedded pg0 against the container it actually runs in

### DIFF
--- a/docker/hindsight-entrypoint.sh
+++ b/docker/hindsight-entrypoint.sh
@@ -95,6 +95,21 @@ REINDEX_SELFHEAL="${SWITCHROOM_HINDSIGHT_REINDEX_SELFHEAL:-1}"
 # pg0 instance descriptor (holds the embedded-postgres password); the
 # reaper reads it to connect. Overridable for host tests.
 PG0_INSTANCE="${SWITCHROOM_HINDSIGHT_PG0_INSTANCE:-/home/hindsight/.pg0/instances/hindsight/instance.json}"
+# --- pg0 sizing pre-start (#3706) -------------------------------------------
+# Values come from src/setup/hindsight-pg-defaults.ts via `docker run -e` /
+# compose `environment:`. EMPTY OR UNSET DISABLES that flag, and empty/unset
+# for BOTH disables the pre-start entirely — so an older switchroom that does
+# not set them keeps today's behaviour byte for byte. The literal `off` (any
+# case) is the operator's per-knob opt-out.
+PG_EFFECTIVE_CACHE_SIZE="${SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE:-}"
+PG_SHARED_BUFFERS="${SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS:-}"
+# pg0 CLI. The python wheel bundles it; the venv's python minor version is not
+# guaranteed stable, so glob rather than hard-code. Overridable for tests.
+PG0_BIN="${SWITCHROOM_HINDSIGHT_PG0_BIN:-}"
+# Instance name pg0 keys the running server under. Must match the name
+# hindsight_api resolves from HINDSIGHT_API_DB_URL, or its ensure_running()
+# will not adopt ours.
+PG0_NAME="${SWITCHROOM_HINDSIGHT_PG0_NAME:-hindsight}"
 
 log() { echo "switchroom-hindsight-entrypoint: $*" >&2; }
 
@@ -241,6 +256,112 @@ reap_stale_processing_when_ready() {
   ) &
 }
 
+# ---------------------------------------------------------------------------
+# pg0 sizing pre-start (#3706)
+#
+# Hindsight's embedded PostgreSQL is pg0, and pg0 bakes its tuning into the
+# `postgres` child's ARGV:
+#
+#   postgres -D … -F -p 5432 -c work_mem=64MB -c maintenance_work_mem=512MB
+#            -c effective_cache_size=1GB -c shared_buffers=256MB …
+#
+# PostgreSQL ranks the `command line` source ABOVE both postgresql.conf and
+# postgresql.auto.conf, so `ALTER SYSTEM SET` cannot move those two values —
+# verified live: ALTER SYSTEM + pg_reload_conf() left pg_settings reporting the
+# old value with source='command line'.
+#
+# The route that DOES work: hindsight_api's EmbeddedPostgres.ensure_running()
+# (api/hindsight_api/pg0.py) short-circuits when the named instance is already
+# running — it returns the existing URI and never re-applies config. So we
+# start pg0 ourselves, with tuned `-c` flags, before exec'ing the upstream CMD.
+# pg0 MERGES `-c` over its own defaults (verified: a probe started with
+# `-c effective_cache_size=4GB -c shared_buffers=1536MB` kept pg0's work_mem,
+# maintenance_work_mem, max_parallel_maintenance_workers and logging flags).
+#
+# BEST-EFFORT BY CONSTRUCTION. Every failure path returns 0 and leaves pg0
+# unstarted, so hindsight_api starts it exactly as it does today with pg0's own
+# defaults. A sizing change can never be why the container fails to boot.
+#
+# Connection identity is READ from the existing instance descriptor rather than
+# assumed, so we can never rewrite it with different credentials; on first boot
+# (no descriptor) we use hindsight_api's own DEFAULT_USERNAME / DEFAULT_PASSWORD
+# / DEFAULT_DATABASE ("hindsight") and let pg0 auto-allocate the port, which is
+# byte-identical to what EmbeddedPostgres() would have done.
+prestart_pg0() {
+  # Normalise the two knobs; `off` (any case) means "leave pg0's default".
+  case "$(printf '%s' "${PG_EFFECTIVE_CACHE_SIZE}" | tr '[:upper:]' '[:lower:]')" in
+    off) PG_EFFECTIVE_CACHE_SIZE="" ;;
+  esac
+  case "$(printf '%s' "${PG_SHARED_BUFFERS}" | tr '[:upper:]' '[:lower:]')" in
+    off) PG_SHARED_BUFFERS="" ;;
+  esac
+  # Nothing to apply ⇒ do not touch pg0 at all (pre-#3706 behaviour).
+  [ -n "${PG_EFFECTIVE_CACHE_SIZE}" ] || [ -n "${PG_SHARED_BUFFERS}" ] || return 0
+
+  # Only the embedded-pg0 database is ours to pre-start. An operator pointing
+  # hindsight at an external postgres (or a differently-named/ported pg0
+  # instance) must not have a server started underneath them.
+  case "${HINDSIGHT_API_DB_URL:-pg0}" in
+    pg0 | "pg0://${PG0_NAME}") : ;;
+    *)
+      log "pg0 pre-start skipped: HINDSIGHT_API_DB_URL=${HINDSIGHT_API_DB_URL:-} is not the default embedded instance"
+      return 0
+      ;;
+  esac
+
+  _pg0="${PG0_BIN}"
+  if [ -z "${_pg0}" ]; then
+    _pg0="$(command -v pg0 2>/dev/null || ls /app/api/.venv/lib/python3.*/site-packages/pg0/bin/pg0 2>/dev/null | head -1)"
+  fi
+  if [ -z "${_pg0}" ] || [ ! -x "${_pg0}" ]; then
+    log "pg0 pre-start skipped: pg0 binary not found (hindsight_api will start pg0 with its own defaults)"
+    return 0
+  fi
+
+  # Identity: reuse the descriptor when it exists so we never rewrite it.
+  _pu="hindsight"; _pp="hindsight"; _pd="hindsight"; _pport=""
+  if [ -r "${PG0_INSTANCE}" ]; then
+    if { read -r _v_u; read -r _v_d; read -r _v_p; read -r _v_pw; } <<EOF
+$(python3 -c 'import json,sys;d=json.load(open(sys.argv[1]));print(d.get("username","hindsight"));print(d.get("database","hindsight"));print(d.get("port",""));print(d.get("password","hindsight"))' "${PG0_INSTANCE}" 2>/dev/null)
+EOF
+    then
+      if [ -n "${_v_u}" ]; then _pu="${_v_u}"; fi
+      if [ -n "${_v_d}" ]; then _pd="${_v_d}"; fi
+      if [ -n "${_v_pw}" ]; then _pp="${_v_pw}"; fi
+      if [ -n "${_v_p}" ]; then _pport="${_v_p}"; fi
+    fi
+  fi
+
+  # NOTE: `set --` inside a POSIX function shadows only the FUNCTION's
+  # positional parameters; the script's "$@" (the upstream CMD this entrypoint
+  # execs) is restored on return. Every branch below is an `if`, never a bare
+  # `[ … ] && …` — under `set -eu` a false AND-OR list at statement level would
+  # abort the whole entrypoint.
+  set -- start --name "${PG0_NAME}" --username "${_pu}" --password "${_pp}" --database "${_pd}"
+  if [ -n "${_pport}" ]; then set -- "$@" --port "${_pport}"; fi
+  if [ -n "${PG_EFFECTIVE_CACHE_SIZE}" ]; then
+    set -- "$@" -c "effective_cache_size=${PG_EFFECTIVE_CACHE_SIZE}"
+  fi
+  if [ -n "${PG_SHARED_BUFFERS}" ]; then
+    set -- "$@" -c "shared_buffers=${PG_SHARED_BUFFERS}"
+  fi
+
+  if _out="$("${_pg0}" "$@" 2>&1)"; then
+    log "pg0 pre-start ok: name=${PG0_NAME} effective_cache_size=${PG_EFFECTIVE_CACHE_SIZE:-<pg0-default>} shared_buffers=${PG_SHARED_BUFFERS:-<pg0-default>}"
+    return 0
+  fi
+
+  # `already running` is not a failure — some other path won the race and the
+  # instance is up; hindsight_api adopts it either way.
+  if printf '%s' "${_out}" | grep -qi 'already running'; then
+    log "pg0 pre-start: instance ${PG0_NAME} already running; leaving it alone"
+    return 0
+  fi
+
+  log "WARNING: pg0 pre-start failed; falling back to hindsight_api's own pg0 start with pg0 defaults. detail: $(printf '%s' "${_out}" | tr '\n' ' ' | cut -c1-300)"
+  return 0
+}
+
 # 1. Wait for the broker socket. The broker may still be starting on
 # the host when this container boots (no cross-project depends_on).
 i=0
@@ -298,6 +419,13 @@ export CLAUDE_CONFIG_DIR="${CRED_DIR}"
 
 # 4b. Boot-deferred stale-claim reaper (does not block boot; see fn header).
 reap_stale_processing_when_ready || true
+
+# 4c. pg0 sizing pre-start (#3706). MUST run before the exec: hindsight_api's
+# ensure_running() adopts an already-running instance without re-applying
+# config, which is the only reason we can set these at all. Synchronous by
+# necessity (a background race would let hindsight_api win and start pg0
+# untuned); bounded by pg0's own start, and best-effort — see prestart_pg0().
+prestart_pg0 || true
 
 # 5. Hand off to upstream start-all.sh.
 exec "$@"

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2068,7 +2068,13 @@ export const HindsightConfigSchema = z.object({
       "src/setup/hindsight-perf-defaults.ts: RERANKER_LOCAL_FP16, " +
       "LLM_MAX_CONCURRENT, RETAIN/CONSOLIDATION_LLM_MAX_CONCURRENT, " +
       "RECALL_MAX_CANDIDATES_PER_SOURCE, LINK_EXPANSION_PER_ENTITY_LIMIT, " +
-      "LINK_EXPANSION_TIMEOUT, LLM_REASONING_EFFORT). A value set here " +
+      "LINK_EXPANSION_TIMEOUT, LLM_REASONING_EFFORT), plus the " +
+      "embedded-PostgreSQL (pg0) sizing keys switchroom manages in " +
+      "src/setup/hindsight-pg-defaults.ts (`HINDSIGHT_PG_ENV_KEYS`: " +
+      "SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE, " +
+      "SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS — a postgres size string such " +
+      "as `4GB`, or the sentinel `off` to leave pg0's own default for that " +
+      "one knob). A value set here " +
       "REPLACES switchroom's default and is emitted even when the gating " +
       "capability is absent, so an operator can always force a knob. Other " +
       "`HINDSIGHT_API_*` keys are deliberately IGNORED — a blanket " +

--- a/src/setup/hindsight-pg-defaults.test.ts
+++ b/src/setup/hindsight-pg-defaults.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Embedded-PostgreSQL (pg0) sizing defaults.
+ *
+ * What these tests protect, in order of how badly a regression would hurt:
+ *
+ *   1. **The memory budget is arithmetic, not a vibe.** `shared_buffers` is a
+ *      real allocation inside a container with a hard `mem_limit`. The budget
+ *      derivation is asserted against the SAME `HINDSIGHT_DEFAULT_MEM_LIMIT`
+ *      the container is actually created with, so raising one without the
+ *      other goes red.
+ *   2. **The values reach the container, once, on BOTH launch paths.** These
+ *      env vars do nothing on their own — `docker/hindsight-entrypoint.sh`
+ *      reads them. If `startHindsight` emits them and the compose snippet does
+ *      not, half the fleet is silently untuned.
+ *   3. **Operator override wins, and `off` is expressible.** An operator on a
+ *      smaller host must be able to opt a single knob out without losing the
+ *      other.
+ *   4. **Planner coherence.** `effective_cache_size` counts `shared_buffers`
+ *      PLUS the OS page cache, so declaring it *below* `shared_buffers` is
+ *      incoherent by construction and must fail.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { execFileSyncMock } = vi.hoisted(() => ({ execFileSyncMock: vi.fn() }));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, execFileSync: execFileSyncMock };
+});
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  HINDSIGHT_PG_APP_ANON_MIB,
+  HINDSIGHT_PG_DEFAULTS,
+  HINDSIGHT_PG_DEFAULT_EFFECTIVE_CACHE_SIZE_MIB,
+  HINDSIGHT_PG_DEFAULT_SHARED_BUFFERS_MIB,
+  HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE_ENV,
+  HINDSIGHT_PG_ENV_KEYS,
+  HINDSIGHT_PG_MEM_LIMIT_MIB_FOR_DERIVATION,
+  HINDSIGHT_PG_PAGE_CACHE_FLOOR_MIB,
+  HINDSIGHT_PG_SHARED_BUFFERS_BUDGET_MIB,
+  HINDSIGHT_PG_SHARED_BUFFERS_ENV,
+  hindsightPgEnv,
+  pgMib,
+  resolveHindsightPgOverrides,
+} from "./hindsight-pg-defaults.js";
+import {
+  HINDSIGHT_DEFAULT_MEM_LIMIT,
+  HINDSIGHT_DEFAULT_SHM_SIZE,
+  generateHindsightComposeSnippet,
+  hindsightPgEnvPairs,
+  startHindsight,
+} from "./hindsight.js";
+
+beforeEach(() => {
+  execFileSyncMock.mockReset();
+  execFileSyncMock.mockReturnValue(Buffer.from(""));
+});
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+/** The `docker run` argv for the hindsight container itself. */
+function runArgs(): string[] {
+  const call = execFileSyncMock.mock.calls.find(
+    (c) =>
+      c[0] === "docker" &&
+      Array.isArray(c[1]) &&
+      (c[1] as string[])[0] === "run" &&
+      (c[1] as string[]).includes("switchroom-hindsight"),
+  );
+  expect(call, "startHindsight must have issued a `docker run`").toBeDefined();
+  return call![1] as string[];
+}
+
+/** `KEY=VALUE` pairs following a `-e` flag in a docker-run argv. */
+function runEnv(args: string[]): Map<string, string[]> {
+  const out = new Map<string, string[]>();
+  for (let i = 0; i < args.length - 1; i++) {
+    if (args[i] !== "-e") continue;
+    const eq = args[i + 1].indexOf("=");
+    if (eq < 0) continue;
+    const key = args[i + 1].slice(0, eq);
+    const value = args[i + 1].slice(eq + 1);
+    out.set(key, [...(out.get(key) ?? []), value]);
+  }
+  return out;
+}
+
+/** `      - KEY=VALUE` environment lines from a compose snippet. */
+function composeEnv(snippet: string): Map<string, string[]> {
+  const out = new Map<string, string[]>();
+  for (const line of snippet.split("\n")) {
+    const m = line.match(/^ {6}- ([A-Z0-9_]+)=(.*)$/);
+    if (!m) continue;
+    out.set(m[1], [...(out.get(m[1]) ?? []), m[2]]);
+  }
+  return out;
+}
+
+/** Parse a docker size string (`8g`, `512m`, `2G`) to MiB. */
+function dockerSizeToMib(size: string): number {
+  const m = size.trim().match(/^(\d+(?:\.\d+)?)\s*([kmgKMG])?b?$/);
+  expect(m, `unparseable docker size: ${size}`).not.toBeNull();
+  const n = Number(m![1]);
+  switch ((m![2] ?? "m").toLowerCase()) {
+    case "k":
+      return n / 1024;
+    case "g":
+      return n * 1024;
+    default:
+      return n;
+  }
+}
+
+const ENTRYPOINT = resolve(__dirname, "..", "..", "docker", "hindsight-entrypoint.sh");
+
+// ── the derivation ────────────────────────────────────────────────────────
+describe("pg0 memory budget derivation", () => {
+  it("is derived against the REAL container mem_limit, not a stale copy", () => {
+    // hindsight-pg-defaults.ts holds a literal to avoid an import cycle with
+    // hindsight.ts. Drift here means the whole budget below is computed
+    // against a ceiling the container never gets.
+    expect(HINDSIGHT_PG_MEM_LIMIT_MIB_FOR_DERIVATION).toBe(
+      dockerSizeToMib(HINDSIGHT_DEFAULT_MEM_LIMIT),
+    );
+  });
+
+  it("reserves the app working set AND a page-cache floor out of the ceiling", () => {
+    expect(HINDSIGHT_PG_SHARED_BUFFERS_BUDGET_MIB).toBe(
+      HINDSIGHT_PG_MEM_LIMIT_MIB_FOR_DERIVATION -
+        HINDSIGHT_PG_APP_ANON_MIB -
+        HINDSIGHT_PG_PAGE_CACHE_FLOOR_MIB,
+    );
+    // A budget that went non-positive would make every assertion below
+    // vacuously satisfiable by shared_buffers=0.
+    expect(HINDSIGHT_PG_SHARED_BUFFERS_BUDGET_MIB).toBeGreaterThan(0);
+  });
+
+  it("keeps shared_buffers inside the budget", () => {
+    expect(HINDSIGHT_PG_DEFAULT_SHARED_BUFFERS_MIB).toBeLessThanOrEqual(
+      HINDSIGHT_PG_SHARED_BUFFERS_BUDGET_MIB,
+    );
+  });
+
+  it("still raises shared_buffers well above pg0's own 256MB default", () => {
+    // The other half of the budget invariant, and the one a purely
+    // conservative "make it smaller" edit would break silently: the whole
+    // point is a buffer pool that can hold a real hot set of a 12 GB bank.
+    // pg0's default, verified live in `ps` inside switchroom-hindsight.
+    const PG0_OWN_DEFAULT_SHARED_BUFFERS_MIB = 256;
+    expect(HINDSIGHT_PG_DEFAULT_SHARED_BUFFERS_MIB).toBeGreaterThanOrEqual(
+      4 * PG0_OWN_DEFAULT_SHARED_BUFFERS_MIB,
+    );
+  });
+
+  it("declares effective_cache_size at or above shared_buffers", () => {
+    // effective_cache_size counts shared_buffers PLUS the OS page cache, so a
+    // value below the buffer pool is incoherent — it would tell the planner
+    // it has less cache than postgres definitely holds.
+    expect(HINDSIGHT_PG_DEFAULT_EFFECTIVE_CACHE_SIZE_MIB).toBeGreaterThanOrEqual(
+      HINDSIGHT_PG_DEFAULT_SHARED_BUFFERS_MIB,
+    );
+  });
+
+  it("never declares more cache than the container could possibly hold", () => {
+    // effective_cache_size allocates nothing, so over-declaring costs no
+    // memory — but it makes the planner price index scans against cache the
+    // cgroup can never provide. The ceiling is the container's own limit.
+    expect(HINDSIGHT_PG_DEFAULT_EFFECTIVE_CACHE_SIZE_MIB).toBeLessThanOrEqual(
+      HINDSIGHT_PG_MEM_LIMIT_MIB_FOR_DERIVATION,
+    );
+  });
+
+  it("raises effective_cache_size well above pg0's under-declared 1GB", () => {
+    // pg0's default, verified live: `-c effective_cache_size=1GB` against a
+    // 12 GB database whose container was measurably holding 5212 MiB of page
+    // cache. This is the must-ship half of #3706; a revert to 1GB is exactly
+    // the regression this test exists to catch.
+    const PG0_OWN_DEFAULT_EFFECTIVE_CACHE_SIZE_MIB = 1024;
+    expect(HINDSIGHT_PG_DEFAULT_EFFECTIVE_CACHE_SIZE_MIB).toBeGreaterThanOrEqual(
+      3 * PG0_OWN_DEFAULT_EFFECTIVE_CACHE_SIZE_MIB,
+    );
+  });
+
+  it("leaves shm_size alone — shared_buffers is mmap here, not /dev/shm", () => {
+    // The assumption this work started from was that shared_buffers is a
+    // POSIX /dev/shm allocation and therefore needs shm_size raised in
+    // lockstep. Verified FALSE on this build: pg0 runs postgres with
+    // `shared_memory_type=mmap` (and `dynamic_shared_memory_type=posix`), and
+    // a probe instance started with shared_buffers=4GB left /dev/shm at 16 MiB
+    // of 2.0 GiB used. /dev/shm backs only parallel-query DSM segments
+    // (observed peak ~533MB), which 2g already covers. Pinned so a future
+    // "raise it in lockstep" edit has to confront this note first.
+    expect(dockerSizeToMib(HINDSIGHT_DEFAULT_SHM_SIZE)).toBe(2048);
+  });
+});
+
+// ── the resolver ──────────────────────────────────────────────────────────
+describe("resolveHindsightPgOverrides", () => {
+  it("takes an operator value from hindsight.env", () => {
+    const got = resolveHindsightPgOverrides(
+      { [HINDSIGHT_PG_SHARED_BUFFERS_ENV]: "512MB" },
+      {},
+    );
+    expect(got.get(HINDSIGHT_PG_SHARED_BUFFERS_ENV)).toBe("512MB");
+  });
+
+  it("lets hindsight.env beat switchroom's own process environment", () => {
+    const got = resolveHindsightPgOverrides(
+      { [HINDSIGHT_PG_SHARED_BUFFERS_ENV]: "512MB" },
+      { [HINDSIGHT_PG_SHARED_BUFFERS_ENV]: "999MB" },
+    );
+    expect(got.get(HINDSIGHT_PG_SHARED_BUFFERS_ENV)).toBe("512MB");
+  });
+
+  it("still honours a process-env override when hindsight.env is silent", () => {
+    const got = resolveHindsightPgOverrides(undefined, {
+      [HINDSIGHT_PG_SHARED_BUFFERS_ENV]: "999MB",
+    });
+    expect(got.get(HINDSIGHT_PG_SHARED_BUFFERS_ENV)).toBe("999MB");
+  });
+
+  it("ignores keys it does not manage", () => {
+    const got = resolveHindsightPgOverrides(
+      { SWITCHROOM_HINDSIGHT_PG_WORK_MEM: "1GB", HINDSIGHT_API_PORT: "1234" },
+      {},
+    );
+    expect(got.size).toBe(0);
+  });
+
+  it("ignores an empty / whitespace-only value rather than forwarding it", () => {
+    const got = resolveHindsightPgOverrides(
+      { [HINDSIGHT_PG_SHARED_BUFFERS_ENV]: "   " },
+      { [HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE_ENV]: "" },
+    );
+    expect(got.size).toBe(0);
+  });
+
+  it("forwards the `off` sentinel — it is the per-knob opt-out, not an accident", () => {
+    const got = resolveHindsightPgOverrides(
+      { [HINDSIGHT_PG_SHARED_BUFFERS_ENV]: "off" },
+      {},
+    );
+    expect(got.get(HINDSIGHT_PG_SHARED_BUFFERS_ENV)).toBe("off");
+  });
+});
+
+// ── the emitted pairs ─────────────────────────────────────────────────────
+describe("hindsightPgEnv", () => {
+  it("emits both knobs, in MB form, with switchroom's defaults", () => {
+    expect(hindsightPgEnv()).toEqual([
+      [
+        HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE_ENV,
+        pgMib(HINDSIGHT_PG_DEFAULT_EFFECTIVE_CACHE_SIZE_MIB),
+      ],
+      [HINDSIGHT_PG_SHARED_BUFFERS_ENV, pgMib(HINDSIGHT_PG_DEFAULT_SHARED_BUFFERS_MIB)],
+    ]);
+  });
+
+  it("REPLACES the default with the override rather than appending after it", () => {
+    // An appended duplicate would leave the winner to docker's argv semantics.
+    const pairs = hindsightPgEnv(new Map([[HINDSIGHT_PG_SHARED_BUFFERS_ENV, "512MB"]]));
+    expect(pairs.filter(([k]) => k === HINDSIGHT_PG_SHARED_BUFFERS_ENV)).toEqual([
+      [HINDSIGHT_PG_SHARED_BUFFERS_ENV, "512MB"],
+    ]);
+    // ...and the OTHER knob keeps its default: opting one out must not opt
+    // both out.
+    expect(
+      pairs.find(([k]) => k === HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE_ENV)?.[1],
+    ).toBe(pgMib(HINDSIGHT_PG_DEFAULT_EFFECTIVE_CACHE_SIZE_MIB));
+  });
+
+  it("emits every managed key exactly once", () => {
+    const keys = hindsightPgEnv().map(([k]) => k);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(new Set(keys)).toEqual(new Set(HINDSIGHT_PG_ENV_KEYS));
+  });
+
+  it("HINDSIGHT_PG_ENV_KEYS covers exactly the declared defaults", () => {
+    expect([...HINDSIGHT_PG_ENV_KEYS].sort()).toEqual(
+      HINDSIGHT_PG_DEFAULTS.map(([k]) => k).sort(),
+    );
+  });
+});
+
+// ── the launch paths ──────────────────────────────────────────────────────
+describe("pg0 sizing reaches the container on both launch paths", () => {
+  it("startHindsight emits both knobs on the docker-run argv", () => {
+    startHindsight();
+    const env = runEnv(runArgs());
+    expect(env.get(HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE_ENV)).toEqual([
+      pgMib(HINDSIGHT_PG_DEFAULT_EFFECTIVE_CACHE_SIZE_MIB),
+    ]);
+    expect(env.get(HINDSIGHT_PG_SHARED_BUFFERS_ENV)).toEqual([
+      pgMib(HINDSIGHT_PG_DEFAULT_SHARED_BUFFERS_MIB),
+    ]);
+  });
+
+  it("the compose snippet emits the same values", () => {
+    const env = composeEnv(generateHindsightComposeSnippet());
+    expect(env.get(HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE_ENV)).toEqual([
+      pgMib(HINDSIGHT_PG_DEFAULT_EFFECTIVE_CACHE_SIZE_MIB),
+    ]);
+    expect(env.get(HINDSIGHT_PG_SHARED_BUFFERS_ENV)).toEqual([
+      pgMib(HINDSIGHT_PG_DEFAULT_SHARED_BUFFERS_MIB),
+    ]);
+  });
+
+  it("carries an operator override through BOTH paths, key by key", () => {
+    // Deliberately asymmetric: one knob overridden, one left at its default,
+    // so a generator that ignored `perf` entirely fails on the first and a
+    // generator that dropped the defaults fails on the second.
+    const perf = {
+      env: { [HINDSIGHT_PG_SHARED_BUFFERS_ENV]: "768MB" },
+      processEnv: {},
+    };
+    // Guard against a vacuous pin: the override only proves anything if it
+    // differs from the default it replaces.
+    expect(pgMib(HINDSIGHT_PG_DEFAULT_SHARED_BUFFERS_MIB)).not.toBe("768MB");
+
+    startHindsight(undefined, undefined, undefined, undefined, undefined, undefined, perf);
+    const fromRun = runEnv(runArgs());
+    const fromCompose = composeEnv(
+      generateHindsightComposeSnippet(undefined, undefined, undefined, undefined, perf),
+    );
+    for (const key of HINDSIGHT_PG_ENV_KEYS) {
+      expect(fromCompose.get(key) ?? null, `${key} must match across paths`).toEqual(
+        fromRun.get(key) ?? null,
+      );
+    }
+    // Parity alone is symmetric — pin the actual values on BOTH sides.
+    expect(fromRun.get(HINDSIGHT_PG_SHARED_BUFFERS_ENV)).toEqual(["768MB"]);
+    expect(fromCompose.get(HINDSIGHT_PG_SHARED_BUFFERS_ENV)).toEqual(["768MB"]);
+    expect(fromRun.get(HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE_ENV)).toEqual([
+      pgMib(HINDSIGHT_PG_DEFAULT_EFFECTIVE_CACHE_SIZE_MIB),
+    ]);
+    expect(fromCompose.get(HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE_ENV)).toEqual([
+      pgMib(HINDSIGHT_PG_DEFAULT_EFFECTIVE_CACHE_SIZE_MIB),
+    ]);
+  });
+
+  it("both paths derive from hindsightPgEnvPairs for the same inputs", () => {
+    const expected = new Map(hindsightPgEnvPairs());
+    expect(expected.size).toBeGreaterThan(0);
+    startHindsight();
+    const fromRun = runEnv(runArgs());
+    const fromCompose = composeEnv(generateHindsightComposeSnippet());
+    for (const [key, value] of expected) {
+      expect(fromRun.get(key)).toEqual([value]);
+      expect(fromCompose.get(key)).toEqual([value]);
+    }
+  });
+
+  it("never emits a managed key twice in the final argv", () => {
+    startHindsight();
+    const env = runEnv(runArgs());
+    for (const key of HINDSIGHT_PG_ENV_KEYS) {
+      expect(env.get(key)?.length, `${key} emitted more than once`).toBe(1);
+    }
+  });
+
+  it("the entrypoint reads exactly the env vars switchroom emits", () => {
+    // These vars are inert unless the entrypoint consumes them by name. A
+    // rename on either side is a silent no-op tuning change, which is the
+    // worst failure mode available here — everything still boots, nothing is
+    // tuned. Assert the contract on the real script text.
+    const script = readFileSync(ENTRYPOINT, "utf-8");
+    for (const key of HINDSIGHT_PG_ENV_KEYS) {
+      expect(script, `${key} is emitted but never read by the entrypoint`).toContain(
+        `\${${key}:-}`,
+      );
+    }
+  });
+});

--- a/src/setup/hindsight-pg-defaults.ts
+++ b/src/setup/hindsight-pg-defaults.ts
@@ -1,0 +1,259 @@
+/**
+ * Embedded-PostgreSQL (pg0) sizing defaults for the hindsight container.
+ *
+ * ## Why this file exists
+ *
+ * #3700 shipped the container-env half of the hindsight performance work.
+ * This is the other half: the PostgreSQL server parameters, which #3700
+ * deliberately left alone because they are a **different mechanism**.
+ *
+ * Hindsight's DB is embedded pg0. pg0 launches `postgres` with its own tuning
+ * baked into the child's **argv**, verified live inside `switchroom-hindsight`
+ * (2026-07-26):
+ *
+ * ```
+ * /home/hindsight/.pg0/installation/18.1.0/bin/postgres
+ *   -D /home/hindsight/.pg0/instances/hindsight/data -F -p 5432
+ *   -c work_mem=64MB -c maintenance_work_mem=512MB
+ *   -c effective_cache_size=1GB -c shared_buffers=256MB
+ *   -c max_parallel_maintenance_workers=4  … (logging flags)
+ * ```
+ *
+ * Postgres ranks `command line` **above** both `postgresql.conf` and
+ * `postgresql.auto.conf`, so `ALTER SYSTEM SET` cannot move these. Verified,
+ * not assumed — `ALTER SYSTEM SET effective_cache_size='6GB'` +
+ * `pg_reload_conf()` on the live instance left `pg_settings` reporting
+ * `setting=131072` (1GB) with `source='command line'`.
+ *
+ * The one route that works: `EmbeddedPostgres.ensure_running()`
+ * (`/app/api/hindsight_api/pg0.py`) short-circuits when the named instance is
+ * already running — it returns the existing URI without touching the config.
+ * So `docker/hindsight-entrypoint.sh` **pre-starts pg0 with tuned `-c` flags**
+ * before `exec`ing the upstream CMD, and hindsight_api adopts the running,
+ * tuned instance. This module is the single, testable source of the values
+ * that entrypoint receives.
+ *
+ * Verified live that pg0 **merges** operator `-c` flags over its own defaults
+ * rather than replacing them: a probe instance started with
+ * `-c effective_cache_size=4GB -c shared_buffers=1536MB` came up with those
+ * two values AND pg0's untouched `work_mem=64MB`,
+ * `maintenance_work_mem=512MB`, `max_parallel_maintenance_workers=4` and the
+ * logging flags still present in argv.
+ *
+ * ## Two rules, inherited from hindsight-perf-defaults.ts
+ *
+ * 1. **Safe fallback.** The entrypoint's pre-start is best-effort. If pg0 is
+ *    missing, the DB URL is not the default embedded one, or `pg0 start`
+ *    fails for any reason, the entrypoint logs and continues — hindsight_api
+ *    then starts pg0 itself exactly as it does today. A tuning change can
+ *    therefore never be the reason the container fails to boot.
+ * 2. **An operator override always wins**, scoped to
+ *    {@link HINDSIGHT_PG_ENV_KEYS}, resolved with the same precedence as the
+ *    perf defaults (`hindsight.env` over switchroom's own process env).
+ *
+ * ## What was measured, and what was NOT
+ *
+ * Be precise, because the motivating issue (#3706) overstates one thing.
+ *
+ * `EXPLAIN` A/B of the real link-expansion query
+ * (`ops_postgresql.build_entity_expansion_cte` + `build_semantic_causal_cte`,
+ * 20/100/300 seeds, live `overlord` bank) at
+ * `effective_cache_size` 1GB vs 4GB produced **no plan-shape change**: every
+ * variant already used index / bitmap-index scans on `memory_links`, and
+ * `pg_stat_user_tables` shows `memory_links` at 13 sequential scans against
+ * 1,875,153 index scans. So the "the planner is choosing seq scans on
+ * memory_links" framing did **not** reproduce. What the A/B did show is a
+ * total-cost drop of ~12% at 300 seeds — the planner pricing random I/O more
+ * accurately, not choosing a different plan.
+ *
+ * The measured pathology is the one #3700's own header already names: cold
+ * buffer misses (graph/link_expansion p50 0.024s vs p90 1.412s — an I/O
+ * distribution, not an algorithmic one). That is a `shared_buffers` problem,
+ * which is why this module ships both knobs and does not pretend
+ * `effective_cache_size` alone is the fix.
+ */
+
+/**
+ * Container memory ceiling this module sizes against, in MiB.
+ *
+ * Imported as a literal rather than from `hindsight.ts` to keep this module
+ * free of an import cycle (`hindsight.ts` imports THIS file). A test pins the
+ * two equal so they cannot drift.
+ *
+ * @see import("./hindsight.js").HINDSIGHT_DEFAULT_MEM_LIMIT
+ */
+export const HINDSIGHT_PG_MEM_LIMIT_MIB_FOR_DERIVATION = 8 * 1024;
+
+/**
+ * Non-reclaimable anonymous working set of everything ELSE in the container,
+ * in MiB — the API process, the embedding model, the cross-encoder, and
+ * next-server.
+ *
+ * Measured on the live container (2026-07-26): `memory.stat` reported
+ * `anon 2350018560` = 2241 MiB, with `file 5465899008` (5212 MiB of
+ * reclaimable page cache) bringing `memory.current` to the full 8 GiB
+ * ceiling. Rounded UP to 2560 to leave slack for the anon side to grow.
+ */
+export const HINDSIGHT_PG_APP_ANON_MIB = 2560;
+
+/**
+ * Page cache the container must be left able to hold, in MiB.
+ *
+ * `shared_buffers` is not a substitute for the kernel page cache here: pg0
+ * runs Postgres with `shared_memory_type=mmap`, so buffers come out of the
+ * cgroup's anon/shmem accounting and directly displace reclaimable cache.
+ * Reserving a floor keeps the sizing honest instead of letting
+ * `shared_buffers` grow until the container thrashes.
+ */
+export const HINDSIGHT_PG_PAGE_CACHE_FLOOR_MIB = 2048;
+
+/**
+ * The largest `shared_buffers` this container may be given, in MiB.
+ *
+ * Derived, not picked: whatever is left of the memory ceiling once the app's
+ * anonymous working set and the page-cache floor are accounted for.
+ * 8192 − 2560 − 2048 = 3584 MiB.
+ */
+export const HINDSIGHT_PG_SHARED_BUFFERS_BUDGET_MIB =
+  HINDSIGHT_PG_MEM_LIMIT_MIB_FOR_DERIVATION -
+  HINDSIGHT_PG_APP_ANON_MIB -
+  HINDSIGHT_PG_PAGE_CACHE_FLOOR_MIB;
+
+/**
+ * `shared_buffers` (pg0 default `256MB`).
+ *
+ * 256MB against a 12 GB database is ~2% of the bank — every graph traversal
+ * that misses is a kernel round-trip, which is exactly the bimodal
+ * cold/hot distribution measured on `link_expansion` (p50 24ms, p90 1.412s).
+ * 1536MB is 6x that, and 19% of the container's 8 GiB ceiling — under the
+ * conventional "25% of available memory" guidance and comfortably inside
+ * {@link HINDSIGHT_PG_SHARED_BUFFERS_BUDGET_MIB} (3584 MiB), which a test
+ * pins.
+ *
+ * **This does NOT require an `shm_size` change**, contrary to the assumption
+ * this work started from. That assumption is that `shared_buffers` is a POSIX
+ * `/dev/shm` allocation; on this build it is not. Verified live:
+ * `shared_memory_type = mmap` and `dynamic_shared_memory_type = posix`, and a
+ * probe instance started with `shared_buffers=4GB` left `/dev/shm` at 16 MiB
+ * of 2.0 GiB used. `/dev/shm` backs only the parallel-query DSM segments that
+ * `HINDSIGHT_DEFAULT_SHM_SIZE` was raised for (observed peak ~533MB), so 2g
+ * stays correct and is deliberately left alone.
+ */
+export const HINDSIGHT_PG_DEFAULT_SHARED_BUFFERS_MIB = 1536;
+
+/**
+ * `effective_cache_size` (pg0 default `1GB`).
+ *
+ * A pure planner hint — it allocates nothing. It tells the planner how much of
+ * the database it can expect to find in RAM, counting `shared_buffers` **plus**
+ * the OS page cache, and it is the term that prices index scans against
+ * sequential ones.
+ *
+ * 1GB is a ~5x under-declaration of what this container measurably holds: the
+ * live cgroup was carrying 5212 MiB of page cache on top of the 256MB buffer
+ * pool. 4096 MiB is the conservative reading of that — `shared_buffers`
+ * (1536) plus a page-cache assumption (2560) well below the 5212 measured —
+ * so the planner is told the truth without being told to expect cache the
+ * container cannot hold under pressure.
+ *
+ * Honest scope: see the module header. On the link-expansion query this moved
+ * total cost ~12% at 300 seeds and changed no plan shape. It is the cheap,
+ * zero-memory half of the change, not the whole fix.
+ */
+export const HINDSIGHT_PG_DEFAULT_EFFECTIVE_CACHE_SIZE_MIB = 4096;
+
+/** Format a MiB integer the way Postgres wants it on the command line. */
+export function pgMib(mib: number): string {
+  return `${mib}MB`;
+}
+
+/**
+ * Env var carrying the `effective_cache_size` the entrypoint should pass to
+ * `pg0 start`. Empty / unset ⇒ the entrypoint skips that flag.
+ */
+export const HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE_ENV =
+  "SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE";
+
+/** Env var carrying `shared_buffers`. Empty / unset ⇒ flag skipped. */
+export const HINDSIGHT_PG_SHARED_BUFFERS_ENV = "SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS";
+
+/**
+ * The pg0 sizing defaults, in the order the entrypoint receives them.
+ *
+ * Deliberately NOT capability-gated. Unlike the GPU / local-LLM knobs in
+ * hindsight-perf-defaults.ts, these two are sized against
+ * `HINDSIGHT_DEFAULT_MEM_LIMIT` — a value switchroom itself sets on every
+ * host — so the "capability" is already proven by construction. The runtime
+ * safety property is the entrypoint's fallback instead: a pre-start that
+ * cannot apply the values leaves the container running pg0's own defaults.
+ */
+export const HINDSIGHT_PG_DEFAULTS: ReadonlyArray<readonly [string, string]> = [
+  [
+    HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE_ENV,
+    pgMib(HINDSIGHT_PG_DEFAULT_EFFECTIVE_CACHE_SIZE_MIB),
+  ],
+  [HINDSIGHT_PG_SHARED_BUFFERS_ENV, pgMib(HINDSIGHT_PG_DEFAULT_SHARED_BUFFERS_MIB)],
+];
+
+/**
+ * Every key this module manages — and therefore the exact set an operator may
+ * override through `hindsight.env` / switchroom's process environment.
+ */
+export const HINDSIGHT_PG_ENV_KEYS: ReadonlySet<string> = new Set(
+  HINDSIGHT_PG_DEFAULTS.map(([k]) => k),
+);
+
+/**
+ * Resolve the operator's overrides for the managed pg0 keys.
+ *
+ * Same precedence and same empty-value discipline as
+ * {@link import("./hindsight-perf-defaults.js").resolveHindsightPerfOverrides}:
+ * `hindsight.env` beats switchroom's process env, and a blank value is an
+ * accident rather than an override so it is ignored.
+ *
+ * One deliberate difference: the sentinel `"off"` (case-insensitive) IS a
+ * legal override and IS forwarded, because an operator needs a way to disable
+ * a single knob without disabling the other. The entrypoint treats `off` as
+ * "omit this `-c` flag", which restores pg0's own default for it.
+ */
+export function resolveHindsightPgOverrides(
+  configEnv?: Record<string, string | number | boolean> | undefined,
+  processEnv: NodeJS.ProcessEnv = process.env,
+): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const key of HINDSIGHT_PG_ENV_KEYS) {
+    const fromProcess = processEnv[key];
+    if (typeof fromProcess === "string" && fromProcess.trim() !== "") {
+      out.set(key, fromProcess.trim());
+    }
+  }
+  for (const [key, raw] of Object.entries(configEnv ?? {})) {
+    if (!HINDSIGHT_PG_ENV_KEYS.has(key)) continue;
+    const value = String(raw).trim();
+    if (value === "") continue;
+    out.set(key, value);
+  }
+  return out;
+}
+
+/**
+ * The pg0 sizing env pairs to hand the hindsight container.
+ *
+ * Stable declaration order, every managed key emitted exactly once, override
+ * REPLACES the default rather than being appended after it — so there is
+ * never an `-e K=a -e K=b` pair whose winner depends on docker's argv
+ * semantics. Shared verbatim by `startHindsight()` and
+ * `generateHindsightComposeSnippet()` so the two launch paths cannot drift.
+ */
+export function hindsightPgEnv(
+  overrides: ReadonlyMap<string, string> = new Map(),
+): Array<[string, string]> {
+  const out: Array<[string, string]> = [];
+  const emitted = new Set<string>();
+  for (const [key, value] of HINDSIGHT_PG_DEFAULTS) {
+    if (emitted.has(key)) continue;
+    emitted.add(key);
+    out.push([key, overrides.get(key) ?? value]);
+  }
+  return out;
+}

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -12,6 +12,10 @@ import {
   hindsightPerfEnv,
   resolveHindsightPerfOverrides,
 } from "./hindsight-perf-defaults.js";
+import {
+  hindsightPgEnv,
+  resolveHindsightPgOverrides,
+} from "./hindsight-pg-defaults.js";
 
 /**
  * Default Hindsight host ports.
@@ -1391,6 +1395,22 @@ export function hindsightPerfEnvPairs(
   );
 }
 
+/**
+ * The single derivation of the embedded-PostgreSQL (pg0) sizing env pairs,
+ * shared by {@link startHindsight} and {@link generateHindsightComposeSnippet}
+ * for the same anti-drift reason as {@link hindsightPerfEnvPairs}.
+ *
+ * These are consumed by `docker/hindsight-entrypoint.sh`, which pre-starts pg0
+ * with the corresponding `-c` flags — the ONLY route that works, because
+ * postgres ranks `command line` above `ALTER SYSTEM`. See
+ * src/setup/hindsight-pg-defaults.ts.
+ */
+export function hindsightPgEnvPairs(
+  perf?: HindsightPerfOptions,
+): Array<[string, string]> {
+  return hindsightPgEnv(resolveHindsightPgOverrides(perf?.env, perf?.processEnv));
+}
+
 export function startHindsight(
   ports?: { apiPort: number; uiPort: number },
   litellm?: LiteLLMHindsightConfig,
@@ -1482,6 +1502,13 @@ export function startHindsight(
     // `hindsight.env` replaces the default rather than being appended after
     // it. See src/setup/hindsight-perf-defaults.ts.
     ...hindsightPerfEnvPairs(llm, litellm, gpu, perf).flatMap(([k, v]) => ["-e", `${k}=${v}`]),
+    // Embedded-PostgreSQL (pg0) sizing, read by hindsight-entrypoint.sh's
+    // pre-start. pg0 bakes its tuning into the postgres child's ARGV, which
+    // outranks `ALTER SYSTEM`, so pre-starting the instance is the only route
+    // that can change it. Best-effort in the entrypoint: a pre-start that
+    // fails leaves pg0's own defaults in place rather than blocking boot.
+    // See src/setup/hindsight-pg-defaults.ts.
+    ...hindsightPgEnvPairs(perf).flatMap(([k, v]) => ["-e", `${k}=${v}`]),
   ];
 
   // The `claude-code` provider drives an underlying claude subprocess; pin
@@ -2024,6 +2051,9 @@ export function generateHindsightComposeSnippet(
     // docker-run path's block, from the SAME resolver so the two can never
     // disagree about which knobs a host gets (see hindsightPerfEnvPairs).
     ...hindsightPerfEnvPairs(llm, litellm, gpu, perf).map(([k, v]) => `      - ${k}=${v}`),
+    // pg0 sizing — compose twin of the docker-run block, from the SAME
+    // resolver (see hindsightPgEnvPairs / hindsight-pg-defaults.ts).
+    ...hindsightPgEnvPairs(perf).map(([k, v]) => `      - ${k}=${v}`),
     `    mem_limit: ${HINDSIGHT_DEFAULT_MEM_LIMIT}`,
     `    mem_reservation: ${HINDSIGHT_DEFAULT_MEM_RESERVATION}`,
     `    pids_limit: ${HINDSIGHT_DEFAULT_PIDS_LIMIT}`,

--- a/tests/docker/hindsight-entrypoint.test.ts
+++ b/tests/docker/hindsight-entrypoint.test.ts
@@ -715,6 +715,243 @@ esac
     expect(raw).toMatch(/REINDEX INDEX CONCURRENTLY pk_async_operations/);
   });
 
+  // ── pg0 sizing pre-start (#3706) ───────────────────────────────────────
+  //
+  // pg0 bakes `-c shared_buffers=… -c effective_cache_size=…` into the
+  // `postgres` child's ARGV, and postgres ranks the `command line` source
+  // above `postgresql.auto.conf` — so `ALTER SYSTEM SET` cannot change them
+  // (verified live: ALTER SYSTEM + pg_reload_conf() left pg_settings reporting
+  // the old value with source='command line'). The only route is to start pg0
+  // ourselves with tuned flags BEFORE the exec, because hindsight_api's
+  // EmbeddedPostgres.ensure_running() short-circuits on an already-running
+  // instance.
+  //
+  // These tests drive the entrypoint with a FAKE pg0 that records its argv and
+  // assert the OUTCOME: the tuned flags land, an operator opt-out removes only
+  // the knob it names, and every failure path still reaches `exec` so a sizing
+  // change can never be why the container fails to boot.
+
+  /** Write a fake `pg0` that logs argv (one arg per line) and exits `code`. */
+  function installFakePg0(logPath: string, code = 0): string {
+    const binDir = execTmpDir("swr-fakepg0-");
+    const pg0 = join(binDir, "pg0");
+    writeFileSync(
+      pg0,
+      `#!/bin/sh
+for a in "$@"; do printf '%s\\n' "$a" >> "${logPath}"; done
+[ ${code} -eq 0 ] || echo "fake pg0: could not create shared memory segment" >&2
+exit ${code}
+`,
+      { mode: 0o755 },
+    );
+    return pg0;
+  }
+
+  /**
+   * Boot the entrypoint to completion with extra env, returning stderr + the
+   * exit status. The CMD defaults to one that exits immediately.
+   */
+  function runWithEnv(
+    extraEnv: Record<string, string>,
+    cmd: string[] = ["true"],
+  ): Promise<{ status: number | null; stderr: string }> {
+    return new Promise((res) => {
+      const child = spawn("sh", [ENTRYPOINT, ...cmd], {
+        env: {
+          ...process.env,
+          SWITCHROOM_AUTH_BROKER_SOCKET: socketPath,
+          SWITCHROOM_HINDSIGHT_CRED_DIR: credDir,
+          SWITCHROOM_HINDSIGHT_WAIT_S: "5",
+          SWITCHROOM_HINDSIGHT_REFRESH_S: "0",
+          SWITCHROOM_HINDSIGHT_FETCHER: FETCHER,
+          SWITCHROOM_HINDSIGHT_PG0_INSTANCE: join(dir, "does-not-exist.json"),
+          ...extraEnv,
+        },
+      });
+      let stderr = "";
+      child.stderr.on("data", (d) => (stderr += d.toString("utf8")));
+      const killer = setTimeout(() => {
+        try { child.kill("SIGKILL"); } catch { /* ignore */ }
+      }, 20000);
+      child.on("close", (status) => {
+        clearTimeout(killer);
+        res({ status, stderr });
+      });
+    });
+  }
+
+  /** Read a fake-pg0 argv log back as an array. */
+  function argvOf(logPath: string): string[] {
+    return existsSync(logPath)
+      ? readFileSync(logPath, "utf-8").split("\n").filter((l) => l !== "")
+      : [];
+  }
+
+  it("pre-starts pg0 with BOTH tuned -c flags before exec'ing the CMD", async () => {
+    stopBroker = await startFakeBroker(socketPath);
+    const log = join(dir, "pg0-argv.log");
+    const marker = join(dir, "cmd-ran");
+    const r = await runWithEnv(
+      {
+        SWITCHROOM_HINDSIGHT_PG0_BIN: installFakePg0(log),
+        SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE: "4096MB",
+        SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS: "1536MB",
+      },
+      ["sh", "-c", `touch ${marker}`],
+    );
+    expect(r.status).toBe(0);
+    const argv = argvOf(log);
+    expect(argv[0]).toBe("start");
+    // The flags themselves — the whole point of the change.
+    expect(argv).toContain("effective_cache_size=4096MB");
+    expect(argv).toContain("shared_buffers=1536MB");
+    // ...each introduced by its own `-c`, which is pg0's flag syntax.
+    expect(argv.filter((a) => a === "-c").length).toBe(2);
+    // The instance identity hindsight_api will look for, or it won't adopt ours.
+    expect(argv[argv.indexOf("--name") + 1]).toBe("hindsight");
+    // Ordering matters: pre-start must happen BEFORE the exec, otherwise
+    // hindsight_api wins the race and starts pg0 untuned.
+    expect(r.stderr).toMatch(/pg0 pre-start ok/);
+    expect(existsSync(marker)).toBe(true);
+  }, 20_000);
+
+  it("does NOT touch pg0 at all when neither knob is set (pre-#3706 behaviour)", async () => {
+    // An older switchroom, or an operator who cleared both, must get exactly
+    // today's boot: hindsight_api starts pg0 itself.
+    stopBroker = await startFakeBroker(socketPath);
+    const log = join(dir, "pg0-argv-none.log");
+    const r = await runWithEnv({
+      SWITCHROOM_HINDSIGHT_PG0_BIN: installFakePg0(log),
+      SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE: "",
+      SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS: "",
+    });
+    expect(r.status).toBe(0);
+    expect(argvOf(log)).toEqual([]);
+    expect(r.stderr).not.toMatch(/pg0 pre-start ok/);
+  }, 20_000);
+
+  it("`off` opts out ONE knob and leaves the other applied", async () => {
+    stopBroker = await startFakeBroker(socketPath);
+    const log = join(dir, "pg0-argv-off.log");
+    const r = await runWithEnv({
+      SWITCHROOM_HINDSIGHT_PG0_BIN: installFakePg0(log),
+      SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE: "4096MB",
+      SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS: "OFF",
+    });
+    expect(r.status).toBe(0);
+    const argv = argvOf(log);
+    expect(argv).toContain("effective_cache_size=4096MB");
+    // The sentinel must not leak through as a literal postgres value either —
+    // `shared_buffers=off` would make the server refuse to start.
+    expect(argv.some((a) => a.startsWith("shared_buffers="))).toBe(false);
+  }, 20_000);
+
+  it("a FAILING pg0 pre-start warns loudly but still boots (fallback intact)", async () => {
+    // The safety property the whole design rests on: hindsight_api then starts
+    // pg0 with pg0's own defaults, exactly as before this change.
+    stopBroker = await startFakeBroker(socketPath);
+    const log = join(dir, "pg0-argv-fail.log");
+    const marker = join(dir, "cmd-ran-after-failure");
+    const r = await runWithEnv(
+      {
+        SWITCHROOM_HINDSIGHT_PG0_BIN: installFakePg0(log, 1),
+        SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE: "4096MB",
+        SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS: "1536MB",
+      },
+      ["sh", "-c", `touch ${marker}`],
+    );
+    expect(r.status).toBe(0);
+    expect(existsSync(marker)).toBe(true);
+    expect(r.stderr).toMatch(/WARNING: pg0 pre-start failed/);
+    expect(r.stderr).not.toMatch(/pg0 pre-start ok/);
+  }, 20_000);
+
+  it("skips the pre-start when the DB is not the default embedded instance", async () => {
+    // Starting a server underneath an operator who pointed hindsight at an
+    // external postgres (or a differently-named pg0) would be actively wrong.
+    stopBroker = await startFakeBroker(socketPath);
+    const log = join(dir, "pg0-argv-extdb.log");
+    const r = await runWithEnv({
+      SWITCHROOM_HINDSIGHT_PG0_BIN: installFakePg0(log),
+      SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE: "4096MB",
+      SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS: "1536MB",
+      HINDSIGHT_API_DB_URL: "postgresql://user:pw@db.example.com:5432/hindsight",
+    });
+    expect(r.status).toBe(0);
+    expect(argvOf(log)).toEqual([]);
+    expect(r.stderr).toMatch(/pg0 pre-start skipped/);
+  }, 20_000);
+
+  it("reuses the existing instance's credentials + port instead of rewriting them", async () => {
+    // `pg0 start` REWRITES instance.json. If we passed different credentials
+    // than the live cluster's, hindsight_api's ensure_running() would hand the
+    // engine a URI that cannot authenticate.
+    stopBroker = await startFakeBroker(socketPath);
+    const log = join(dir, "pg0-argv-ident.log");
+    const instance = join(dir, "instance.json");
+    writeFileSync(
+      instance,
+      JSON.stringify({
+        pid: 153,
+        port: 5433,
+        username: "hsuser",
+        password: "hspass",
+        database: "hsdb",
+      }),
+    );
+    const r = await runWithEnv({
+      SWITCHROOM_HINDSIGHT_PG0_BIN: installFakePg0(log),
+      SWITCHROOM_HINDSIGHT_PG0_INSTANCE: instance,
+      // A READABLE descriptor also arms the boot-deferred reaper, whose
+      // background subshell holds the stdio pipes open so `close` never
+      // fires. Disable it — this test is about the pre-start argv only.
+      SWITCHROOM_HINDSIGHT_REAP_STALE_S: "0",
+      SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE: "4096MB",
+      SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS: "1536MB",
+    });
+    expect(r.status).toBe(0);
+    const argv = argvOf(log);
+    expect(argv[argv.indexOf("--username") + 1]).toBe("hsuser");
+    expect(argv[argv.indexOf("--password") + 1]).toBe("hspass");
+    expect(argv[argv.indexOf("--database") + 1]).toBe("hsdb");
+    expect(argv[argv.indexOf("--port") + 1]).toBe("5433");
+  }, 20_000);
+
+  it("falls back to hindsight_api's own defaults when no descriptor exists (first boot)", async () => {
+    // EmbeddedPostgres' DEFAULT_USERNAME/PASSWORD/DATABASE are all
+    // "hindsight", and it passes no port so pg0 auto-allocates. A first boot
+    // must be byte-identical to what hindsight_api itself would have done.
+    stopBroker = await startFakeBroker(socketPath);
+    const log = join(dir, "pg0-argv-firstboot.log");
+    const r = await runWithEnv({
+      SWITCHROOM_HINDSIGHT_PG0_BIN: installFakePg0(log),
+      SWITCHROOM_HINDSIGHT_PG0_INSTANCE: join(dir, "absent.json"),
+      SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE: "4096MB",
+    });
+    expect(r.status).toBe(0);
+    const argv = argvOf(log);
+    expect(argv[argv.indexOf("--username") + 1]).toBe("hindsight");
+    expect(argv[argv.indexOf("--password") + 1]).toBe("hindsight");
+    expect(argv[argv.indexOf("--database") + 1]).toBe("hindsight");
+    expect(argv).not.toContain("--port");
+  }, 20_000);
+
+  it("boots normally when the pg0 binary is missing entirely", async () => {
+    stopBroker = await startFakeBroker(socketPath);
+    const marker = join(dir, "cmd-ran-no-pg0");
+    const r = await runWithEnv(
+      {
+        SWITCHROOM_HINDSIGHT_PG0_BIN: join(dir, "no-such-pg0"),
+        SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE: "4096MB",
+        SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS: "1536MB",
+      },
+      ["sh", "-c", `touch ${marker}`],
+    );
+    expect(r.status).toBe(0);
+    expect(existsSync(marker)).toBe(true);
+    expect(r.stderr).toMatch(/pg0 pre-start skipped: pg0 binary not found/);
+  }, 20_000);
+
   it("Dockerfile pins UID 11000 to match HINDSIGHT_DEFAULT_UID", () => {
     // The broker chowns the per-consumer socket to consumer.uid (mode 0600).
     // If the runtime UID inside hindsight didn't match what the operator


### PR DESCRIPTION
## What

Sizes Hindsight's embedded PostgreSQL (pg0) against the container it actually runs in, instead of pg0's stock defaults.

| knob | before (pg0 default) | after |
|---|---|---|
| `effective_cache_size` | `1GB` | `4096MB` |
| `shared_buffers` | `256MB` | `1536MB` |
| `shm_size` | `2g` | **unchanged — see below** |

## Why the mechanism is unusual

pg0 bakes its tuning into the `postgres` child's **argv** (verified live in `switchroom-hindsight`):

```
postgres -D … -F -p 5432 -c work_mem=64MB -c maintenance_work_mem=512MB
         -c effective_cache_size=1GB -c shared_buffers=256MB …
```

Postgres ranks the `command line` source **above** `postgresql.conf` **and** `postgresql.auto.conf`, so `ALTER SYSTEM SET` cannot move these. Verified, not assumed: `ALTER SYSTEM SET effective_cache_size='6GB'` + `pg_reload_conf()` on the live instance left `pg_settings` reporting `setting=131072` with `source='command line'`. (Reverted with `ALTER SYSTEM RESET`.)

The one route that works: `EmbeddedPostgres.ensure_running()` short-circuits when the named instance is already running and adopts it without re-applying config. So `docker/hindsight-entrypoint.sh` **pre-starts pg0 with tuned `-c` flags** before `exec`ing the CMD. Also verified live that pg0 **merges** operator `-c` flags over its own defaults rather than replacing them — a probe instance kept `work_mem=64MB`, `maintenance_work_mem=512MB`, `max_parallel_maintenance_workers=4` and all logging flags.

## Why these numbers

Measured on the live container (cgroup v2): `memory.max` 8 GiB, `anon` 2241 MiB, `file` 5212 MiB of reclaimable page cache, `shmem` 293 MiB. So `effective_cache_size=1GB` was a ~5x **under**-declaration of what the container measurably holds, and `shared_buffers=256MB` is ~2% of a ~12 GB bank.

Budget is derived, not picked: `8192 (mem_limit) − 2560 (app anon) − 2048 (page-cache floor) = 3584 MiB` available for `shared_buffers`; 1536 is 43% of that budget and 19% of the container ceiling, under the conventional 25% guidance. A test pins the derivation against the real `HINDSIGHT_DEFAULT_MEM_LIMIT` so the two cannot drift.

## Two corrections to the premises this started from

**1. "The planner is choosing seq scans on `memory_links`" did NOT reproduce.** `EXPLAIN` A/B of the real link-expansion query (`build_entity_expansion_cte` + `build_semantic_causal_cte`) at 20/100/300 seeds showed **no Seq Scan in any variant and no plan-shape change** between `effective_cache_size` 1GB and 4GB. `pg_stat_user_tables` has `memory_links` at 13 sequential scans vs 1,875,153 index scans. What `effective_cache_size` buys is ~12% more accurate cost pricing (304528 → 268354 total cost at 300 seeds), not a different plan. The measured pathology is the one #3700's header already named — cold buffer misses (link_expansion p50 0.024s vs p90 1.412s), which is a `shared_buffers` problem. That's why this ships both knobs and doesn't claim `effective_cache_size` alone is the fix.

**2. Raising `shared_buffers` does NOT require raising `shm_size` in lockstep on this build.** The assumption was that `shared_buffers` is a POSIX `/dev/shm` allocation. Verified false: `shared_memory_type = mmap` (and `dynamic_shared_memory_type = posix`), and a probe instance with `shared_buffers=4GB` started fine with `/dev/shm` at 16 MiB of 2.0 GiB used. `/dev/shm` backs only parallel-query DSM segments (observed peak ~533MB), which 2g already covers. `HINDSIGHT_DEFAULT_SHM_SIZE` is therefore **deliberately left at 2g**, and a test pins it there with that rationale so a future "raise it in lockstep" edit has to confront the note.

Also noted, deliberately **not** shipped: `random_page_cost=4` is objectively wrong on this NVMe host and moved the same query's total cost ~2.8x (268354 → 108975). It needs a rotational-disk capability gate, so it's out of scope here.

## Safety

The pre-start is best-effort **by construction** — every path in `prestart_pg0()` returns 0, and the call site is `prestart_pg0 || true`. Missing pg0 binary, a non-embedded `HINDSIGHT_API_DB_URL`, a differently-named instance, or a failed `pg0 start` all log and continue; hindsight_api then starts pg0 exactly as it does today. **A sizing change can never be why the container fails to boot**, and that property has its own test. The pre-existing `-F` (fsync off) in pg0's argv is untouched.

Follows the #3700 pattern: named constants, one resolver shared by `startHindsight()` and `generateHindsightComposeSnippet()` (so the two launch paths cannot drift), operator override via `hindsight.env` then process env, plus an `off` sentinel to opt a single knob out without losing the other.

## Tests

+32 tests (24 new in `src/setup/hindsight-pg-defaults.test.ts`, 8 new in `tests/docker/hindsight-entrypoint.test.ts`). The entrypoint tests drive the real script with a **fake pg0 that records its argv**, asserting outcomes: the tuned flags land, `off` removes only the knob it names, a failing pre-start still reaches `exec`, an existing `instance.json`'s credentials/port are reused rather than rewritten, and first boot is byte-identical to what hindsight_api itself would have done.

**Mutation campaign: 20 mutants, 20 died, 0 survived.** Values (`4096`→`1024`, `1536`→`256`, `1536`→`5000` over-budget, mem-limit drift), wiring (drop the block from docker-run argv / from compose / ignore overrides on either side), resolver behaviour (ignore `hindsight.env`, stop skipping empty values), and every entrypoint behaviour (no call site, no `off` normalisation, downgraded WARNING, no DB-URL guard, ignore the descriptor, `exit 1` instead of fallback, misspelled env var, each `-c` flag dropped individually), plus the `shm_size` pin. A first campaign run was **discarded**: it had been started against a baseline left mutated by an interrupted earlier turn (red baseline ⇒ every verdict void). The reported run asserts a GREEN baseline before mutating and uses literal-substring replacement with an exact-occurrence check, so a missed pattern is a loud `BAD-MUTANT`, never a false "died".

Refs #3706
