### PR TITLE
fix(hindsight): derive the LLM token budget from a declared context window

### DIFF
--- a/docs/operators/hindsight-memory.md
+++ b/docs/operators/hindsight-memory.md
@@ -133,10 +133,66 @@ Per-op fields: `model`, `provider`, `base_url`, `api_key` (all optional,
 endpoint/credential; `api_key` accepts a `vault:` reference). These map to the
 engine's `HINDSIGHT_API_<OP>_LLM_MODEL` / `_PROVIDER` / `_BASE_URL` /
 `_API_KEY` env vars, with the global `HINDSIGHT_API_LLM_*` as the fallback for
-anything unset.
+anything unset. There is one more per-op field, `context_window`, which is not
+an env var at all — see below.
+
+### Declare the backend's context window (`context_window`)
+
+`hindsight.llm.context_window` declares how many tokens the backend serving
+hindsight actually accepts. Switchroom derives the token budget from it —
+consolidation batch size, the retain / consolidation `max_completion_tokens`
+caps, and the reflect `max_context_tokens` cap — so a single call cannot
+overflow the window:
+
+```yaml
+hindsight:
+  llm:
+    provider: litellm
+    model: openai/gpt-oss-20b
+    context_window: 32768        # llama.cpp -c 65536 -np 2 → 32768 per slot
+    consolidation:
+      context_window: 131072     # this lane routes to a big-window model
+```
+
+Absent → a per-provider default: `200000` for `claude-code`, a deliberately
+conservative `32768` for anything else (a non-Claude provider in switchroom
+usually means LiteLLM in front of a local llama.cpp / Ollama slot). All three
+lanes — `retain`, `reflect`, `consolidation` — are budgeted independently, so a
+per-op `context_window` only ratchets that lane.
+
+**Set this if you self-host the backend.** A context overflow on llama.cpp is
+*silent*: with `--context-shift` it discards the oldest tokens and keeps only
+the first `--keep`, which is exactly where the system prompt and JSON schema
+live, so the model then answers conversationally and returns **HTTP 200 with
+`finish_reason: stop`**. Nothing errors; retain and consolidation just quietly
+stop extracting. On the reference fleet that ran undetected for a week at a
+44–47% malformed-response rate, against 2% for the same model on a
+131k-window route. Declaring the window turns it into a loud failure at
+`switchroom memory setup` time instead of never — an over-budget declaration
+aborts the launch with the arithmetic that doesn't fit.
+
+Under-declaring costs throughput (smaller batches, more LLM calls);
+over-declaring corrupts memory. When in doubt, under-declare.
 
 Takes effect on the next `switchroom memory setup` / rollout recreate of the
 hindsight container (env is read at container launch).
+
+### Capability-gated tunings you don't have to set
+
+Switchroom emits these automatically when it can prove the host qualifies, so
+they survive a container recreate instead of having to be re-applied by hand.
+Override any of them through `hindsight.env` (an operator value always wins,
+even when the gate is off).
+
+| Var | Emitted when | Value | Why |
+|-----|--------------|-------|-----|
+| `HINDSIGHT_API_LLM_STRICT_SCHEMA` | LLM endpoint is self-hosted | `true` | Without it a local `gpt-oss:20b` prefixes prose to its JSON; ~45% of retain/consolidation calls then fail to parse. Upstream defaults it `False`. |
+| `HINDSIGHT_API_LLM_MAX_RETRIES` | LLM endpoint is self-hosted | `2` | A local endpoint isn't rate-limited, so upstream's `3` mostly adds latency to a call that will fail the same way. |
+| `HINDSIGHT_API_RERANKER_LOCAL_BATCH_SIZE` | container can reach a GPU | `128` | Upstream's `32` is the CPU/MPS value. Measured on CUDA: rerank of 150 candidates `4.347s → 0.174s`, recall p50 `3.2s → 0.8s`. A 128-wide batch on CPU is a regression, hence the gate. |
+
+"Self-hosted" is decided by `hindsightLocalLlmEnabled()` — a loopback, LAN, or
+`*.local` base URL on `hindsight.llm` or the LiteLLM proxy. The GPU gate is the
+same one that adds `--gpus all`.
 
 **Changing models?** Follow the step-by-step runbook in
 [`hindsight-model-change.md`](hindsight-model-change.md) — it covers the two

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2006,6 +2006,22 @@ const HindsightPerOpLlmSchema = z
         "Per-op API key (upstream `HINDSIGHT_API_<OP>_LLM_API_KEY`). Literal " +
         "or `vault:` reference. Optional passthrough; absent → inherit global.",
       ),
+    context_window: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        "Context window (tokens) of the backend serving THIS op. NOT an " +
+        "upstream env var — switchroom derives the op's token budget " +
+        "(consolidation batch size / max-completion caps / reflect " +
+        "max-context cap) from it so a single call can never overflow the " +
+        "window. Absent → inherit " +
+        "`hindsight.llm.context_window`, else a per-provider default " +
+        "(conservative for non-`claude-code` providers, which usually mean " +
+        "a local llama.cpp/Ollama slot). All three lanes (`retain`, " +
+        "`reflect`, `consolidation`) are budgeted independently.",
+      ),
   })
   .describe(
     "Per-operation LLM override. Every field optional; an unset field (or " +
@@ -2038,6 +2054,24 @@ export const HindsightConfigSchema = z.object({
           "as `ANTHROPIC_MODEL` to the claude subprocess. Serves as the GLOBAL " +
           "default for every op absent a per-op override.",
         ),
+      context_window: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(
+          "GLOBAL context window (tokens) of the backend serving hindsight's " +
+          "LLM ops — the declared size switchroom derives every token budget " +
+          "from. Set this to the real window of whatever you point " +
+          "`hindsight.llm` at (e.g. 32768 for a llama.cpp slot launched with " +
+          "`-c 65536 -np 2`, 131072 for a large-window OpenRouter model). " +
+          "Absent → a per-provider default: 200000 for `claude-code`, a " +
+          "conservative 32768 for everything else. Overflowing a local " +
+          "backend's window does NOT error — llama.cpp context-shift silently " +
+          "drops the system prompt and the model answers conversationally " +
+          "with HTTP 200 — so this value is what makes the failure " +
+          "detectable at setup time instead of never.",
+        ),
       retain: HindsightPerOpLlmSchema.optional().describe(
         "Per-op override for the `retain` LLM op (memory ingestion). Emits " +
         "`HINDSIGHT_API_RETAIN_LLM_*`. Absent → uses the global model/provider.",
@@ -2066,7 +2100,9 @@ export const HindsightConfigSchema = z.object({
       "performance defaults. Only the keys switchroom actually manages are " +
       "honoured (`HINDSIGHT_PERF_ENV_KEYS` in " +
       "src/setup/hindsight-perf-defaults.ts: RERANKER_LOCAL_FP16, " +
-      "LLM_MAX_CONCURRENT, RETAIN/CONSOLIDATION_LLM_MAX_CONCURRENT, " +
+      "RERANKER_LOCAL_BATCH_SIZE, LLM_MAX_CONCURRENT, " +
+      "RETAIN/CONSOLIDATION_LLM_MAX_CONCURRENT, LLM_STRICT_SCHEMA, " +
+      "LLM_MAX_RETRIES, " +
       "RECALL_MAX_CANDIDATES_PER_SOURCE, LINK_EXPANSION_PER_ENTITY_LIMIT, " +
       "LINK_EXPANSION_TIMEOUT, LLM_REASONING_EFFORT), plus the " +
       "embedded-PostgreSQL (pg0) sizing keys switchroom manages in " +

--- a/src/setup/hindsight-context-budget.ts
+++ b/src/setup/hindsight-context-budget.ts
@@ -1,0 +1,433 @@
+/**
+ * Hindsight context budget — derive token knobs from a DECLARED backend
+ * context window instead of hard-coding them.
+ *
+ * ## Why this file exists
+ *
+ * Hindsight's retain / reflect / consolidation calls are sized in tokens
+ * (`HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE`, the `*_MAX_COMPLETION_TOKENS`
+ * caps). Those numbers were tuned when every op ran on Claude behind a 200k
+ * window, and NOTHING in switchroom knew how big the backend's window
+ * actually was. When the fleet moved hindsight to a local llama.cpp/Ollama
+ * backend (`gpt-oss:20b`, launched `-c 65536 -np 2` = a **32,768-token slot**,
+ * `--context-shift --keep 4`), the same numbers started overflowing the
+ * window — and llama.cpp's context shift makes that overflow SILENT:
+ *
+ *   - Over the window, llama.cpp discards the oldest tokens and keeps only
+ *     the first `--keep` (=4). The system prompt carrying the extraction
+ *     instructions and the JSON schema sits at the FRONT, so it is what gets
+ *     discarded, mid-generation.
+ *   - The model is then answering a bare transcript with no instructions, so
+ *     it replies conversationally. Observed verbatim body from LiteLLM
+ *     SpendLogs: `"Got it! If you have any questions or need assistance with
+ *     something specific, just let me know."` Another was a numbered prose
+ *     list where a JSON object was required.
+ *   - Both came back **HTTP 200 with `finish_reason: "stop"`**. There is no
+ *     error signal anywhere in the stack. Retain/consolidation just silently
+ *     stop extracting anything.
+ *
+ * Measured on 24h of live local traffic (LiteLLM_SpendLogs, model
+ * `openai/gpt-oss:20b`, n=695) against that 32,768-token slot:
+ *
+ *   - p50 prompt 5,244 tok; **p90 prompt 32,270 tok**; max 32,754 tok
+ *   - 262/695 = **38%** of calls exceeded 16,384 prompt tokens
+ *   - malformed-response rate: 44% and 47% on the two local boxes, vs **2%**
+ *     on an OpenRouter route with a 131k window — i.e. the variable is the
+ *     window, not the model.
+ *
+ * Ruled out by direct test, do not revisit: the model itself (the real
+ * production prompt + schema passes 10/10 in isolation), `strict: true` vs
+ * `false` (10/10 both), `drop_params`, the `think` / `reasoning_effort`
+ * extra_body params, and LiteLLM pass-through.
+ *
+ * ## The durable fix
+ *
+ * Declare the window (`hindsight.llm.context_window`, per-op overridable) and
+ * DERIVE the token knobs from it, then assert at setup time that the derived
+ * worst case fits. Hard-coding "better" constants would only relocate the
+ * same latent bug to the next backend swap; a declared window plus a
+ * deterministic preflight is what makes the swap loud instead of silent.
+ */
+
+/** Per-op LLM config fields this module cares about (structural subset). */
+export interface ContextBudgetPerOpInput {
+  provider?: string;
+  context_window?: number;
+}
+
+/** `hindsight.llm` fields this module cares about (structural subset). */
+export interface ContextBudgetLlmInput {
+  provider?: string;
+  context_window?: number;
+  retain?: ContextBudgetPerOpInput;
+  reflect?: ContextBudgetPerOpInput;
+  consolidation?: ContextBudgetPerOpInput;
+}
+
+/** The lanes with a derived token budget. */
+export type HindsightBudgetLane = "retain" | "reflect" | "consolidation";
+
+/**
+ * Declared-window default for the `claude-code` provider — the
+ * subscription-honest default path, which is Claude behind a 200k window.
+ * Keeps the historical (pre-budget) behaviour for every existing install.
+ */
+export const HINDSIGHT_CLAUDE_CONTEXT_WINDOW = 200_000;
+
+/**
+ * Declared-window default for every OTHER provider (`litellm`, `openai`,
+ * `openrouter`, …). Deliberately conservative: in switchroom's own fleet
+ * `provider: litellm` points at a loopback proxy in front of local
+ * llama.cpp slots, and a 32,768-token slot is exactly the configuration that
+ * produced the silent-overflow incident above. An operator on a genuinely
+ * large-window route raises it explicitly via `hindsight.llm.context_window`
+ * — under-declaring costs throughput, over-declaring corrupts memory.
+ */
+export const HINDSIGHT_CONSERVATIVE_CONTEXT_WINDOW = 32_768;
+
+/**
+ * Fraction of the declared window held back and never budgeted. Absorbs
+ * tokenizer disagreement (switchroom estimates in tokens, the backend counts
+ * with a different tokenizer), per-request chat-template overhead, and the
+ * long tail above p90 prompt size. 20% of a 32k slot = ~6.5k tokens of slack.
+ */
+export const HINDSIGHT_CONTEXT_SAFETY_FRACTION = 0.2;
+
+/**
+ * Fixed prompt cost of ONE consolidation call, independent of batch size:
+ * system prompt + JSON schema + recall context. Back-derived from the
+ * measured p90 (32,270 prompt tokens at batch size 12) split as
+ * `overhead + batch × per-fact` — see {@link HINDSIGHT_CONSOLIDATION_TOKENS_PER_FACT}.
+ */
+export const HINDSIGHT_CONSOLIDATION_PROMPT_OVERHEAD_TOKENS = 2_270;
+
+/**
+ * Marginal prompt cost of each additional fact in a consolidation batch.
+ * 30,000 / 12 from the same measured p90 decomposition. This is the number
+ * that makes batch size a TOKEN decision rather than a throughput one — the
+ * comment this fix replaced claimed batch size was "tokens-per-call, not
+ * concurrency, so it doesn't affect the ceiling", which was true of the
+ * *quota* ceiling and dead wrong about the *context* ceiling.
+ */
+export const HINDSIGHT_CONSOLIDATION_TOKENS_PER_FACT = 2_500;
+
+/**
+ * Worst-case prompt size of one retain (fact-extraction) call: the chunk
+ * being extracted plus the retain mission, session context and JSON schema.
+ * Sized off the measured p90 for the retain lane rather than the fixed
+ * `retain_chunk_size` (3,000 CHARS upstream) because the surrounding context
+ * dominates.
+ */
+export const HINDSIGHT_RETAIN_PROMPT_ESTIMATE_TOKENS = 8_000;
+
+/**
+ * Batch-size ceiling. 12 is switchroom's historical tuned value (#2894:
+ * bigger batches = fewer LLM calls = less shared-quota pressure), so the
+ * budget only ever ratchets batch size DOWN from it when the declared window
+ * can't fit it. A 200k or 131k window therefore keeps 12 — an operator on a
+ * big-window backend is not penalised by this change.
+ */
+export const HINDSIGHT_CONSOLIDATION_BATCH_SIZE_CEILING = 12;
+
+/** Never emit a batch below this — a batch of 1 is still valid upstream. */
+export const HINDSIGHT_CONSOLIDATION_BATCH_SIZE_FLOOR = 1;
+
+/**
+ * Ceilings on the derived completion caps — past these, more is pure waste.
+ *
+ * The retain ceiling deliberately equals `HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS`
+ * in `hindsight.ts` (#3611's TIME budget: 16384 tokens ≈ 3.4 min at the
+ * slowest measured local rate). Mirrored here rather than imported to keep
+ * this module dependency-free; `tests/setup/hindsight-context-budget.test.ts`
+ * asserts the two stay equal, so the mirror is a check and not a comment. The
+ * effect: on a large window the context budget agrees with the time budget and
+ * changes nothing, and only a small window ratchets retain down.
+ */
+export const HINDSIGHT_CONSOLIDATION_MAX_COMPLETION_CEILING = 16_384;
+export const HINDSIGHT_RETAIN_MAX_COMPLETION_CEILING = 16_384;
+
+/**
+ * Upstream `DEFAULT_RETAIN_CHUNK_SIZE` (config.py). Upstream hard-validates
+ * `retain_max_completion_tokens > retain_chunk_size` and refuses to boot
+ * otherwise, so the retain floor must clear it. Mirrored here so a shrinking
+ * window can never derive a value that bricks the container.
+ */
+export const HINDSIGHT_UPSTREAM_RETAIN_CHUNK_SIZE = 3_000;
+
+/** Floors for the derived completion caps. Retain's clears the upstream check. */
+export const HINDSIGHT_CONSOLIDATION_MAX_COMPLETION_FLOOR = 1_024;
+export const HINDSIGHT_RETAIN_MAX_COMPLETION_FLOOR = HINDSIGHT_UPSTREAM_RETAIN_CHUNK_SIZE + 72;
+
+/**
+ * Upstream `DEFAULT_REFLECT_MAX_CONTEXT_TOKENS` (config.py) — **100,000**.
+ * That is the reflect loop's accumulate-until-you-force-the-final-prompt
+ * bound, and against a 32,768-token slot it is not a bound at all: a long
+ * agentic reflect walks straight through the window and gets context-shifted,
+ * i.e. the same invisible HTTP-200 failure as the consolidation lane. Mirrored
+ * here only so the derivation can be compared against what it replaces.
+ */
+export const HINDSIGHT_UPSTREAM_REFLECT_MAX_CONTEXT_TOKENS = 100_000;
+
+/** Floor on the derived reflect prompt cap — below this, reflect can't work. */
+export const HINDSIGHT_REFLECT_MAX_CONTEXT_FLOOR = 2_048;
+
+/** Where a lane's declared window came from — surfaced in preflight errors. */
+export type ContextWindowSource = "per-op" | "global" | "provider-default";
+
+export interface HindsightLaneBudget {
+  lane: HindsightBudgetLane;
+  /** Declared context window (tokens) for this lane's backend. */
+  windowTokens: number;
+  windowSource: ContextWindowSource;
+  /** Effective provider for this lane (per-op override → global → default). */
+  provider: string;
+  /** Derived `HINDSIGHT_API_<LANE>_MAX_COMPLETION_TOKENS`. */
+  maxCompletionTokens: number;
+  /** Estimated worst-case PROMPT tokens for one call at the derived settings. */
+  estimatedPromptTokens: number;
+  /** `estimatedPromptTokens + maxCompletionTokens` — must fit the window. */
+  worstCaseTotalTokens: number;
+}
+
+export interface HindsightConsolidationBudget extends HindsightLaneBudget {
+  lane: "consolidation";
+  /** Derived `HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE`. */
+  batchSize: number;
+}
+
+export interface HindsightReflectBudget extends HindsightLaneBudget {
+  lane: "reflect";
+  /**
+   * Derived `HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS` — the reflect loop's
+   * accumulated-context bound. Equal to `estimatedPromptTokens`, because for
+   * this lane the cap IS the worst-case prompt: the engine forces the final
+   * prompt once accumulation reaches it.
+   */
+  maxContextTokens: number;
+}
+
+export interface HindsightContextBudget {
+  retain: HindsightLaneBudget;
+  reflect: HindsightReflectBudget;
+  consolidation: HindsightConsolidationBudget;
+}
+
+function clamp(value: number, floor: number, ceiling: number): number {
+  return Math.min(ceiling, Math.max(floor, value));
+}
+
+/**
+ * Default window for a provider name. `claude-code` (and a raw `anthropic`
+ * provider) get Claude's 200k; everything else gets the conservative local
+ * default, because a non-Claude provider in switchroom overwhelmingly means
+ * "LiteLLM in front of something local whose window we do not know".
+ */
+export function defaultContextWindowForProvider(provider: string): number {
+  const p = provider.trim().toLowerCase();
+  if (p === "claude-code" || p === "anthropic") return HINDSIGHT_CLAUDE_CONTEXT_WINDOW;
+  return HINDSIGHT_CONSERVATIVE_CONTEXT_WINDOW;
+}
+
+/**
+ * Resolve one lane's declared window: per-op override → global → the
+ * per-provider default for that lane's EFFECTIVE provider (per-op provider
+ * override wins, since a lane can be pointed at a different backend).
+ */
+export function resolveLaneContextWindow(
+  lane: HindsightBudgetLane,
+  llm?: ContextBudgetLlmInput,
+): { windowTokens: number; windowSource: ContextWindowSource; provider: string } {
+  const perOp = llm?.[lane];
+  const provider = perOp?.provider?.trim() || llm?.provider?.trim() || "claude-code";
+  const perOpWindow = perOp?.context_window;
+  if (typeof perOpWindow === "number" && perOpWindow > 0) {
+    return { windowTokens: Math.floor(perOpWindow), windowSource: "per-op", provider };
+  }
+  const globalWindow = llm?.context_window;
+  if (typeof globalWindow === "number" && globalWindow > 0) {
+    return { windowTokens: Math.floor(globalWindow), windowSource: "global", provider };
+  }
+  return {
+    windowTokens: defaultContextWindowForProvider(provider),
+    windowSource: "provider-default",
+    provider,
+  };
+}
+
+/**
+ * Derive every window-dependent hindsight token knob from the declared
+ * windows. Pure — no IO, no env reads — so both emit paths and the preflight
+ * check can call it and can never disagree.
+ *
+ * Shape of the derivation, per lane:
+ *
+ *   usable          = window − window × SAFETY_FRACTION
+ *   maxCompletion   = clamp(window × laneShare, floor, ceiling)
+ *   promptBudget    = usable − maxCompletion
+ *   batchSize       = clamp(⌊(promptBudget − OVERHEAD) / PER_FACT⌋, 1, 12)
+ *
+ * For a 32,768-token window that lands on batch 6 / consolidation completion
+ * 8,192 / retain completion 6,144 — the values applied by hand to the live
+ * container when the incident was diagnosed. For 131k or 200k it lands on
+ * the historical batch 12, so a big-window operator loses nothing.
+ */
+export function resolveHindsightContextBudget(
+  llm?: ContextBudgetLlmInput,
+): HindsightContextBudget {
+  const cons = resolveLaneContextWindow("consolidation", llm);
+  const ret = resolveLaneContextWindow("retain", llm);
+
+  const consMaxCompletion = clamp(
+    Math.floor(cons.windowTokens / 4),
+    HINDSIGHT_CONSOLIDATION_MAX_COMPLETION_FLOOR,
+    HINDSIGHT_CONSOLIDATION_MAX_COMPLETION_CEILING,
+  );
+  const consUsable = cons.windowTokens - Math.floor(cons.windowTokens * HINDSIGHT_CONTEXT_SAFETY_FRACTION);
+  const consPromptBudget = consUsable - consMaxCompletion;
+  const batchSize = clamp(
+    Math.floor(
+      (consPromptBudget - HINDSIGHT_CONSOLIDATION_PROMPT_OVERHEAD_TOKENS) /
+        HINDSIGHT_CONSOLIDATION_TOKENS_PER_FACT,
+    ),
+    HINDSIGHT_CONSOLIDATION_BATCH_SIZE_FLOOR,
+    HINDSIGHT_CONSOLIDATION_BATCH_SIZE_CEILING,
+  );
+  const consPrompt =
+    HINDSIGHT_CONSOLIDATION_PROMPT_OVERHEAD_TOKENS +
+    batchSize * HINDSIGHT_CONSOLIDATION_TOKENS_PER_FACT;
+
+  const retMaxCompletion = clamp(
+    Math.floor((ret.windowTokens * 3) / 16),
+    HINDSIGHT_RETAIN_MAX_COMPLETION_FLOOR,
+    HINDSIGHT_RETAIN_MAX_COMPLETION_CEILING,
+  );
+
+  // Reflect is a prompt-side cap, not a completion cap: the loop accumulates
+  // context and the engine forces the final prompt when it hits this bound. So
+  // budget it as `usable window − room for reflect's own answer`, using the
+  // same 3/16 completion share the retain lane gets. Rounded DOWN to a whole
+  // thousand purely for legibility in `docker inspect` (32,768 → 20,000).
+  const refl = resolveLaneContextWindow("reflect", llm);
+  const reflCompletionAllowance = clamp(
+    Math.floor((refl.windowTokens * 3) / 16),
+    HINDSIGHT_RETAIN_MAX_COMPLETION_FLOOR,
+    HINDSIGHT_RETAIN_MAX_COMPLETION_CEILING,
+  );
+  const reflUsable =
+    refl.windowTokens - Math.floor(refl.windowTokens * HINDSIGHT_CONTEXT_SAFETY_FRACTION);
+  const reflMaxContext = Math.max(
+    HINDSIGHT_REFLECT_MAX_CONTEXT_FLOOR,
+    Math.floor((reflUsable - reflCompletionAllowance) / 1000) * 1000,
+  );
+
+  return {
+    consolidation: {
+      lane: "consolidation",
+      windowTokens: cons.windowTokens,
+      windowSource: cons.windowSource,
+      provider: cons.provider,
+      batchSize,
+      maxCompletionTokens: consMaxCompletion,
+      estimatedPromptTokens: consPrompt,
+      worstCaseTotalTokens: consPrompt + consMaxCompletion,
+    },
+    reflect: {
+      lane: "reflect",
+      windowTokens: refl.windowTokens,
+      windowSource: refl.windowSource,
+      provider: refl.provider,
+      maxContextTokens: reflMaxContext,
+      maxCompletionTokens: reflCompletionAllowance,
+      estimatedPromptTokens: reflMaxContext,
+      worstCaseTotalTokens: reflMaxContext + reflCompletionAllowance,
+    },
+    retain: {
+      lane: "retain",
+      windowTokens: ret.windowTokens,
+      windowSource: ret.windowSource,
+      provider: ret.provider,
+      maxCompletionTokens: retMaxCompletion,
+      estimatedPromptTokens: HINDSIGHT_RETAIN_PROMPT_ESTIMATE_TOKENS,
+      worstCaseTotalTokens: HINDSIGHT_RETAIN_PROMPT_ESTIMATE_TOKENS + retMaxCompletion,
+    },
+  };
+}
+
+/** Thrown by {@link assertHindsightContextBudgetFits}. */
+export class HindsightContextBudgetError extends Error {
+  readonly lane: HindsightBudgetLane;
+  constructor(lane: HindsightBudgetLane, message: string) {
+    super(message);
+    this.name = "HindsightContextBudgetError";
+    this.lane = lane;
+  }
+}
+
+function laneFailure(b: HindsightLaneBudget): string | undefined {
+  if (b.worstCaseTotalTokens > b.windowTokens) {
+    return (
+      `hindsight ${b.lane}: worst-case ${b.worstCaseTotalTokens} tokens ` +
+      `(${b.estimatedPromptTokens} prompt + ${b.maxCompletionTokens} completion) ` +
+      `exceeds the declared ${b.windowTokens}-token context window ` +
+      `(source: ${b.windowSource}, provider: ${b.provider}).`
+    );
+  }
+  if (b.lane === "retain" && b.maxCompletionTokens <= HINDSIGHT_UPSTREAM_RETAIN_CHUNK_SIZE) {
+    return (
+      `hindsight retain: derived max_completion_tokens ${b.maxCompletionTokens} is not ` +
+      `greater than the upstream retain_chunk_size ${HINDSIGHT_UPSTREAM_RETAIN_CHUNK_SIZE}; ` +
+      `the hindsight container refuses to boot with this combination.`
+    );
+  }
+  return undefined;
+}
+
+/**
+ * Preflight: fail LOUDLY when the derived budget cannot fit the declared
+ * window. This is the whole point of the change.
+ *
+ * A context overflow on a llama.cpp backend produces a well-formed HTTP 200
+ * carrying conversational garbage — no exception, no non-2xx, no
+ * `finish_reason` anomaly, nothing to alert on. The only place the mismatch
+ * is knowable is HERE, before the container is launched, where it is a pure
+ * arithmetic comparison. Prompt discipline can't guarantee this; a throw at
+ * setup time can.
+ */
+export function assertHindsightContextBudgetFits(budget: HindsightContextBudget): void {
+  for (const lane of [
+    budget.consolidation,
+    budget.retain,
+    budget.reflect,
+  ] as HindsightLaneBudget[]) {
+    const failure = laneFailure(lane);
+    if (failure) {
+      throw new HindsightContextBudgetError(
+        lane.lane,
+        `${failure}\n` +
+          `A local backend does NOT error on context overflow — llama.cpp context-shift ` +
+          `silently drops the system prompt and returns HTTP 200 with conversational text ` +
+          `instead of the required JSON, so this must be caught here.\n` +
+          `Fix: raise \`hindsight.llm.context_window\` (or \`hindsight.llm.${lane.lane}.context_window\`) ` +
+          `to the backend's real window, or point the lane at a larger-window model.`,
+      );
+    }
+  }
+}
+
+/**
+ * Derive + assert in one call. Callers get a budget that has already passed
+ * the preflight, so there is no way to render env from an unchecked one.
+ *
+ * The env pairs themselves are emitted by `hindsightLlmBudgetEnv()` in
+ * `hindsight.ts`, which is the single source both the `docker run -e` path
+ * and the generated-compose path already share — the retain completion cap
+ * has a SECOND, time-based bound there (#3611) and the two must be combined
+ * in one place rather than raced from two emitters.
+ */
+export function resolveCheckedHindsightContextBudget(
+  llm?: ContextBudgetLlmInput,
+): HindsightContextBudget {
+  const budget = resolveHindsightContextBudget(llm);
+  assertHindsightContextBudgetFits(budget);
+  return budget;
+}

--- a/src/setup/hindsight-perf-defaults.test.ts
+++ b/src/setup/hindsight-perf-defaults.test.ts
@@ -187,16 +187,20 @@ describe("hindsightPerfEnv — capability gating", () => {
 
   it("declares exactly the gated knobs this PR ships, by name", () => {
     // Same anti-vacuity discipline for the two gated groups: the GPU group
-    // must be FP16 and nothing else, and the local-LLM group must be the
-    // three concurrency caps and nothing else. Without this, quietly moving a
-    // knob between groups (or dropping one) passes every other test here.
+    // must be FP16 plus the CUDA rerank batch size and nothing else, and the
+    // local-LLM group must be the three concurrency caps plus the two
+    // local-endpoint LLM knobs and nothing else. Without this, quietly moving
+    // a knob between groups (or dropping one) passes every other test here.
     expect(HINDSIGHT_PERF_DEFAULTS_GPU.map(([k]) => k)).toEqual([
       "HINDSIGHT_API_RERANKER_LOCAL_FP16",
+      "HINDSIGHT_API_RERANKER_LOCAL_BATCH_SIZE",
     ]);
     expect(HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM.map(([k]) => k)).toEqual([
       "HINDSIGHT_API_LLM_MAX_CONCURRENT",
       "HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT",
       "HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT",
+      "HINDSIGHT_API_LLM_STRICT_SCHEMA",
+      "HINDSIGHT_API_LLM_MAX_RETRIES",
     ]);
   });
 
@@ -306,7 +310,7 @@ describe("operator override wins", () => {
     expect(got.size).toBe(0);
   });
 
-  it("is overridable on exactly these eight keys, by name", () => {
+  it("is overridable on exactly these eleven keys, by name", () => {
     // Spelled out, NOT derived from the three group arrays. HINDSIGHT_PERF_ENV_KEYS
     // is DEFINED as the union of those arrays, so asserting it equals that union
     // is a tautology — it passes no matter which keys are in the arrays. The
@@ -318,8 +322,11 @@ describe("operator override wins", () => {
       "HINDSIGHT_API_LINK_EXPANSION_PER_ENTITY_LIMIT",
       "HINDSIGHT_API_LINK_EXPANSION_TIMEOUT",
       "HINDSIGHT_API_LLM_MAX_CONCURRENT",
+      "HINDSIGHT_API_LLM_MAX_RETRIES",
       "HINDSIGHT_API_LLM_REASONING_EFFORT",
+      "HINDSIGHT_API_LLM_STRICT_SCHEMA",
       "HINDSIGHT_API_RECALL_MAX_CANDIDATES_PER_SOURCE",
+      "HINDSIGHT_API_RERANKER_LOCAL_BATCH_SIZE",
       "HINDSIGHT_API_RERANKER_LOCAL_FP16",
       "HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT",
     ]);
@@ -514,6 +521,104 @@ describe("startHindsight — performance defaults reach the container", () => {
       false,
     );
     expect(runEnv(runArgs()).has("HINDSIGHT_API_LLM_MAX_CONCURRENT")).toBe(false);
+  });
+});
+
+// ── the tunings that used to exist only on the live container ─────────────
+describe("hand-applied container tunings are now emitted by both launch paths", () => {
+  /**
+   * These five values were applied imperatively with `docker exec`/`docker run`
+   * on the live fleet and were therefore destroyed by the next
+   * `switchroom memory setup` (the installed 0.19.23 CLI emits no reference to
+   * any of them). Each is measured-good, so the regression this block guards is
+   * "the recreate silently reverts the fix":
+   *
+   *   • LLM_STRICT_SCHEMA=true    — without it gpt-oss:20b prefixes prose to its
+   *     JSON and ~45% of local retain/consolidation calls fail to parse.
+   *   • LLM_MAX_RETRIES=2         — a local endpoint isn't rate-limited, so
+   *     upstream's 3 mostly adds latency to a call that will fail again.
+   *   • RERANKER_LOCAL_BATCH_SIZE=128 — CUDA value; rerank of 150 candidates
+   *     went 4.347s → 0.174s, recall p50 3.2s → 0.8s.
+   *   • REFLECT_MAX_CONTEXT_TOKENS / CONSOLIDATION_MAX_COMPLETION_TOKENS — now
+   *     DERIVED from the declared context window
+   *     (tests/setup/hindsight-context-budget.test.ts owns their values); here
+   *     we only assert they reach both containers ungated.
+   */
+  const GATED_LOCAL_LLM = [
+    ["HINDSIGHT_API_LLM_STRICT_SCHEMA", "true"],
+    ["HINDSIGHT_API_LLM_MAX_RETRIES", "2"],
+  ] as const;
+  const GATED_GPU = [["HINDSIGHT_API_RERANKER_LOCAL_BATCH_SIZE", "128"]] as const;
+
+  it("emits the local-LLM tunings on BOTH paths when the endpoint is self-hosted", () => {
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false);
+    const fromRun = runEnv(runArgs());
+    const fromCompose = composeEnv(
+      generateHindsightComposeSnippet(undefined, undefined, LOOPBACK_LITELLM, false),
+    );
+    for (const [key, value] of GATED_LOCAL_LLM) {
+      expect(fromRun.get(key), `${key} on docker run`).toEqual([value]);
+      expect(fromCompose.get(key), `${key} on compose`).toEqual([value]);
+    }
+  });
+
+  it("withholds the local-LLM tunings from a cloud endpoint on BOTH paths", () => {
+    // strict-schema costs nothing on a frontier model but IS a hard constraint
+    // some hosted providers reject outright, and retries=2 is a reliability
+    // downgrade against a rate-limited API. Absent capability ⇒ upstream default.
+    startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, true);
+    const fromRun = runEnv(runArgs());
+    const fromCompose = composeEnv(
+      generateHindsightComposeSnippet(undefined, undefined, CLOUD_LITELLM, true),
+    );
+    for (const [key] of GATED_LOCAL_LLM) {
+      expect(fromRun.has(key), `${key} must be absent on docker run`).toBe(false);
+      expect(fromCompose.has(key), `${key} must be absent on compose`).toBe(false);
+    }
+  });
+
+  it("emits the CUDA rerank batch size on BOTH paths only for a GPU host", () => {
+    startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, true);
+    const withGpu = runEnv(runArgs());
+    const withGpuCompose = composeEnv(
+      generateHindsightComposeSnippet(undefined, undefined, CLOUD_LITELLM, true),
+    );
+    for (const [key, value] of GATED_GPU) {
+      expect(withGpu.get(key), `${key} on docker run`).toEqual([value]);
+      expect(withGpuCompose.get(key), `${key} on compose`).toEqual([value]);
+    }
+
+    execFileSyncMock.mockClear();
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false);
+    const noGpu = runEnv(runArgs());
+    const noGpuCompose = composeEnv(
+      generateHindsightComposeSnippet(undefined, undefined, LOOPBACK_LITELLM, false),
+    );
+    for (const [key] of GATED_GPU) {
+      // 32 (upstream's CPU/MPS default) is correct without CUDA — a 128-wide
+      // batch on CPU is a latency regression, not a speed-up.
+      expect(noGpu.has(key), `${key} must be absent on docker run`).toBe(false);
+      expect(noGpuCompose.has(key), `${key} must be absent on compose`).toBe(false);
+    }
+  });
+
+  it("emits the derived context-budget knobs on BOTH paths, ungated", () => {
+    // Unlike the two groups above these are NOT capability-gated: an oversized
+    // prompt corrupts memory on any backend, so the cap ships everywhere. The
+    // cloud/CPU host is the hostile case — if they were gated they'd vanish here.
+    startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, false);
+    const fromRun = runEnv(runArgs());
+    const fromCompose = composeEnv(
+      generateHindsightComposeSnippet(undefined, undefined, CLOUD_LITELLM, false),
+    );
+    for (const key of [
+      "HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS",
+      "HINDSIGHT_API_CONSOLIDATION_MAX_COMPLETION_TOKENS",
+      "HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE",
+    ]) {
+      expect(fromRun.get(key)?.length, `${key} exactly once on docker run`).toBe(1);
+      expect(fromCompose.get(key), `${key} must match across paths`).toEqual(fromRun.get(key));
+    }
   });
 });
 

--- a/src/setup/hindsight-perf-defaults.ts
+++ b/src/setup/hindsight-perf-defaults.ts
@@ -237,6 +237,50 @@ export const HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_MAX_CONCURRENT = 1;
  */
 export const HINDSIGHT_DEFAULT_RERANKER_LOCAL_FP16 = "true";
 
+/**
+ * Local-reranker batch size (upstream default `32`).
+ *
+ * 32 is upstream's CPU/MPS value; the vendored `cross_encoder.py` docstring
+ * names 128+ as the CUDA value, because a GPU is throughput-bound on batch
+ * occupancy rather than per-pair compute. Measured on this host class: rerank
+ * of 150 candidates 4.347s → **0.174s**, and end-to-end recall p50 3.2s →
+ * **0.8s**.
+ *
+ * GPU-gated for the same reason as FP16: on a CPU-only box a 128-pair batch is
+ * a latency spike and a memory spike, not a speed-up. Absent verdict ⇒ off ⇒
+ * upstream's 32.
+ */
+export const HINDSIGHT_DEFAULT_RERANKER_LOCAL_BATCH_SIZE = 128;
+
+/**
+ * Grammar-enforced structured output (upstream default `False`).
+ *
+ * THE fix for the malformed-JSON storm on a local backend. `gpt-oss:20b`
+ * behind llama.cpp answers a schema-constrained request with a prose preamble
+ * often enough that ~45% of local calls failed to parse — and a parse failure
+ * wedges retain/consolidation rather than erroring visibly. Strict schema hands
+ * the provider its strongest schema mode (grammar constraint on llama.cpp), so
+ * the malformed shape becomes unrepresentable rather than merely unlikely.
+ *
+ * Gated on the local-LLM verdict, not hand-set: it is only unambiguously right
+ * where the provider actually supports grammar enforcement, and a hosted
+ * provider that doesn't should keep upstream's default rather than have a
+ * hand-set env var forced on it.
+ */
+export const HINDSIGHT_DEFAULT_LLM_STRICT_SCHEMA = "true";
+
+/**
+ * LLM retry attempts (upstream default `3`).
+ *
+ * Upstream's own performance guide (`performance#timeouts-and-retries`): a
+ * local endpoint is not rate-limited, so aggressive retry mostly adds latency
+ * — a local failure is usually deterministic and will fail again. 2 keeps one
+ * retry for a genuine transient (a slot evicted mid-request) and drops the
+ * third attempt that only ever bought queue time. Local-gated: on a cloud
+ * provider, where a 429 IS transient, upstream's 3 is correct.
+ */
+export const HINDSIGHT_DEFAULT_LLM_MAX_RETRIES = 2;
+
 /** Emitted on every host — bounded work, no hardware assumption. */
 export const HINDSIGHT_PERF_DEFAULTS_UNGATED: ReadonlyArray<readonly [string, string]> = [
   [
@@ -257,6 +301,10 @@ export const HINDSIGHT_PERF_DEFAULTS_UNGATED: ReadonlyArray<readonly [string, st
 /** Emitted only when the container can reach a GPU. */
 export const HINDSIGHT_PERF_DEFAULTS_GPU: ReadonlyArray<readonly [string, string]> = [
   ["HINDSIGHT_API_RERANKER_LOCAL_FP16", HINDSIGHT_DEFAULT_RERANKER_LOCAL_FP16],
+  [
+    "HINDSIGHT_API_RERANKER_LOCAL_BATCH_SIZE",
+    String(HINDSIGHT_DEFAULT_RERANKER_LOCAL_BATCH_SIZE),
+  ],
 ];
 
 /** Emitted only when the LLM endpoint is local/self-hosted. */
@@ -270,6 +318,8 @@ export const HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM: ReadonlyArray<readonly [string, 
     "HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT",
     String(HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_MAX_CONCURRENT),
   ],
+  ["HINDSIGHT_API_LLM_STRICT_SCHEMA", HINDSIGHT_DEFAULT_LLM_STRICT_SCHEMA],
+  ["HINDSIGHT_API_LLM_MAX_RETRIES", String(HINDSIGHT_DEFAULT_LLM_MAX_RETRIES)],
 ];
 
 /**

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -16,6 +16,10 @@ import {
   hindsightPgEnv,
   resolveHindsightPgOverrides,
 } from "./hindsight-pg-defaults.js";
+import {
+  HINDSIGHT_CONSOLIDATION_BATCH_SIZE_CEILING,
+  resolveCheckedHindsightContextBudget,
+} from "./hindsight-context-budget.js";
 
 /**
  * Default Hindsight host ports.
@@ -626,8 +630,17 @@ export function hindsightConsolidationLlmTimeoutSeconds(): number {
  *     {@link HINDSIGHT_RETAIN_CLIENT_DEADLINE_S} equals
  *     `DEFAULT_RETAIN_CLIENT_DEADLINE_S` in the plugin's `retain_split.py`.
  */
-export function hindsightLlmBudgetEnv(): Array<[string, string]> {
-  const maxCompletionTokens = HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS;
+export function hindsightLlmBudgetEnv(llm?: HindsightLlmConfig): Array<[string, string]> {
+  // Second, independent bound on the SAME retain cap: the declared context
+  // window. #3611's 16384 is a TIME budget (don't generate for 12 minutes);
+  // this one is a CONTEXT budget (don't overflow the slot). Both are real
+  // caps, so the tighter wins — see hindsight-context-budget.ts for why an
+  // overflow is invisible and therefore has to be caught here.
+  const contextBudget = resolveCheckedHindsightContextBudget(llm);
+  const maxCompletionTokens = Math.min(
+    HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS,
+    contextBudget.retain.maxCompletionTokens,
+  );
 
   const interactiveS = hindsightInteractiveLlmTimeoutSeconds();
   const retainS = hindsightRetainClientTimeoutSeconds();
@@ -665,6 +678,25 @@ export function hindsightLlmBudgetEnv(): Array<[string, string]> {
     ["HINDSIGHT_API_REFLECT_LLM_TIMEOUT", String(interactiveS)],
     ["HINDSIGHT_API_RETAIN_LLM_TIMEOUT", String(retainS)],
     ["HINDSIGHT_API_CONSOLIDATION_LLM_TIMEOUT", String(consolidationS)],
+    // Consolidation token budget — DERIVED from the declared context window,
+    // not hand-set. Batch size is the number of facts stuffed into one prompt,
+    // so it is the dominant term in prompt size and therefore a context
+    // decision (see the block above HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS).
+    // Upstream's `consolidation_max_completion_tokens` default is None (no
+    // cap at all), which is exactly the unbounded half of the overflow.
+    ["HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE", String(contextBudget.consolidation.batchSize)],
+    [
+      "HINDSIGHT_API_CONSOLIDATION_MAX_COMPLETION_TOKENS",
+      String(contextBudget.consolidation.maxCompletionTokens),
+    ],
+    // Reflect's accumulated-context bound. Upstream defaults it to 100_000 —
+    // three times a 32k slot, i.e. not a bound at all on a local backend: a
+    // long agentic reflect walks straight through the window and is
+    // context-shifted into the same silent HTTP-200 garbage.
+    [
+      "HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS",
+      String(contextBudget.reflect.maxContextTokens),
+    ],
   ];
 }
 
@@ -692,14 +724,48 @@ export function hindsightLlmBudgetEnv(): Array<[string, string]> {
  *   1 × 2 = 2 concurrent claude subprocesses, ceiling.
  * - MAX_MEMORIES_PER_ROUND 100: bounded scope per op → faster slot release,
  *   more re-queue points where the fleet can reclaim the quota.
- * - LLM_BATCH_SIZE 12 (unchanged): facts per LLM call — tokens-per-call, not
- *   concurrency, so it doesn't affect the shared-quota ceiling.
- * Consolidation now drains slower by design; that is the accepted trade for
- * never walling the live fleet. All values remain operator-overridable via
- * the generated compose / -e (raise them only with a dedicated isolated
- * account pinned back on the consumer).
+ * - LLM_BATCH_SIZE: **no longer a constant here.** Derived from the declared
+ *   backend context window — see below and `hindsight-context-budget.ts`.
+ *
+ * Consolidation drains slower by design; that is the accepted trade for never
+ * walling the live fleet. The concurrency values above remain
+ * operator-overridable via the generated compose / -e (raise them only with a
+ * dedicated isolated account pinned back on the consumer).
+ *
+ * ## LLM_BATCH_SIZE is a CONTEXT-WINDOW decision, not only a quota one
+ *
+ * This block used to read: *"LLM_BATCH_SIZE 12 (unchanged): facts per LLM
+ * call — tokens-per-call, not concurrency, so it doesn't affect the
+ * shared-quota ceiling."* That was true of the QUOTA ceiling and actively
+ * misleading about the CONTEXT ceiling, and it went silently wrong the moment
+ * hindsight's backend moved off Claude's 200k window onto a local llama.cpp
+ * slot. Nothing in the codebase knew how big the backend's window was.
+ *
+ * Measured over 24h of live traffic (LiteLLM_SpendLogs, `openai/gpt-oss:20b`,
+ * n=695) against a **32,768-token slot** (`-c 65536 -np 2 --context-shift
+ * --keep 4`):
+ *   - p50 prompt 5,244 tok; **p90 prompt 32,270 tok**; max 32,754 tok — batch
+ *     12 routinely produced prompts that filled the entire window.
+ *   - 262/695 = **38%** of calls exceeded 16,384 prompt tokens.
+ *   - malformed-response rate 44% / 47% on the two local boxes vs **2%** on a
+ *     131k-window OpenRouter route. The variable is the window, not the model.
+ *
+ * And the overflow is INVISIBLE: llama.cpp context-shift discards the oldest
+ * tokens keeping only the first `--keep` (=4), which throws away the system
+ * prompt and JSON schema mid-generation; the model then answers
+ * conversationally and returns **HTTP 200 with `finish_reason: stop`**.
+ *
+ * So batch size and the completion caps are DERIVED from
+ * `hindsight.llm.context_window` and asserted to fit before launch. Picking
+ * "better" constants would only relocate the same latent bug to the next
+ * backend swap.
  */
-export const HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE = 12;
+// Batch-size CEILING — the value the derivation lands on whenever the declared
+// window is large enough to fit it (131k and 200k both are), so a big-window
+// operator keeps the historical tuned 12. The budget only ratchets DOWN from
+// here. Kept under the historical name because that is what it still means.
+export const HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE =
+  HINDSIGHT_CONSOLIDATION_BATCH_SIZE_CEILING;
 export const HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS = 1;
 export const HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM = 2;
 export const HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND = 100;
@@ -1028,6 +1094,12 @@ export interface HindsightLlmConfig {
   provider?: string;
   /** `HINDSIGHT_API_LLM_MODEL`. Default {@link HINDSIGHT_DEFAULT_MODEL}. */
   model?: string;
+  /**
+   * Declared context window (tokens) of the backend. NOT an upstream env var
+   * — switchroom derives the token budget from it (see
+   * `hindsight-context-budget.ts`). Absent → a per-provider default.
+   */
+  context_window?: number;
   /** Per-op override for the `retain` LLM op. Falls back to the global. */
   retain?: HindsightPerOpLlmConfig;
   /** Per-op override for the `reflect` LLM op. Falls back to the global. */
@@ -1053,6 +1125,13 @@ export interface HindsightPerOpLlmConfig {
   base_url?: string;
   /** `HINDSIGHT_API_<OP>_LLM_API_KEY`. snake_case to match the zod config shape. */
   api_key?: string;
+  /**
+   * Declared context window (tokens) for THIS op's backend. Overrides the
+   * global `hindsight.llm.context_window`. Not emitted as env — it drives the
+   * derived token budget. All three lanes are budgeted independently, so a
+   * value here only ratchets this op.
+   */
+  context_window?: number;
 }
 
 /** The three LLM ops that support a per-op model override. */
@@ -1480,12 +1559,15 @@ export function startHindsight(
     // hindsightLlmBudgetEnv() before it returns — against the token budget
     // (the 767.6s runaway, see the constants above) AND against each lane's
     // litellm routing chain (src/litellm/timeout-budget.ts).
-    ...hindsightLlmBudgetEnv().flatMap(([k, v]) => ["-e", `${k}=${v}`]),
+    // …and the CONTEXT budget: consolidation batch size + the two completion
+    // caps, derived from the declared window so a prompt cannot overflow the
+    // backend's slot (an overflow returns HTTP 200 + garbage, never an error).
+    ...hindsightLlmBudgetEnv(llm).flatMap(([k, v]) => ["-e", `${k}=${v}`]),
     // Consolidation concurrency: throttled by #2894 to a hard ceiling of
     // MAX_SLOTS 1 × LLM_PARALLELISM 2 = 2 concurrent model calls (was 18), so
-    // consolidation can never exhaust the shared failover quota. Batch size 12
-    // and per-round scope 100 bound tokens/scope per op. See constants above.
-    "-e", `HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE}`,
+    // consolidation can never exhaust the shared failover quota. Per-round
+    // scope 100 bounds tokens/scope per op. (BATCH_SIZE is emitted above, by
+    // the context budget — it is a window decision, not a concurrency one.)
     "-e", `HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}`,
     "-e", `HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM}`,
     "-e", `HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND}`,
@@ -2040,9 +2122,11 @@ export function generateHindsightComposeSnippet(
     `      - HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT=${HINDSIGHT_DEFAULT_RERANKER_LOCAL_MAX_CONCURRENT}`,
     `      - HINDSIGHT_API_RECALL_MAX_CONCURRENT=${HINDSIGHT_DEFAULT_RECALL_MAX_CONCURRENT}`,
     `      - HINDSIGHT_API_REFLECT_WALL_TIMEOUT=${HINDSIGHT_DEFAULT_REFLECT_WALL_TIMEOUT_S}`,
-    // Retain budget — same derivation + assertion as the docker-run path.
-    ...hindsightLlmBudgetEnv().map(([k, v]) => `      - ${k}=${v}`),
-    `      - HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE}`,
+    // Retain + timeout + CONTEXT budget — same derivation + assertion as the
+    // docker-run path (consolidation batch size, the completion caps and the
+    // reflect context cap all come from here, so the two paths cannot
+    // disagree about the token budget).
+    ...hindsightLlmBudgetEnv(llm).map(([k, v]) => `      - ${k}=${v}`),
     `      - HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}`,
     `      - HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM}`,
     `      - HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND}`,

--- a/tests/setup/hindsight-context-budget.test.ts
+++ b/tests/setup/hindsight-context-budget.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock execFileSync so the docker-run path never actually fires; we only want
+// the argv it would have used.
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+  execFileSync: vi.fn(),
+  execSync: vi.fn(),
+  spawn: vi.fn(),
+  spawnSync: vi.fn(),
+}));
+
+import { execFileSync } from "node:child_process";
+import {
+  HINDSIGHT_CLAUDE_CONTEXT_WINDOW,
+  HINDSIGHT_CONSERVATIVE_CONTEXT_WINDOW,
+  HINDSIGHT_CONSOLIDATION_BATCH_SIZE_CEILING,
+  HINDSIGHT_CONSOLIDATION_PROMPT_OVERHEAD_TOKENS,
+  HINDSIGHT_CONSOLIDATION_TOKENS_PER_FACT,
+  HINDSIGHT_RETAIN_MAX_COMPLETION_CEILING,
+  HINDSIGHT_UPSTREAM_REFLECT_MAX_CONTEXT_TOKENS,
+  HINDSIGHT_UPSTREAM_RETAIN_CHUNK_SIZE,
+  HindsightContextBudgetError,
+  assertHindsightContextBudgetFits,
+  resolveCheckedHindsightContextBudget,
+  resolveHindsightContextBudget,
+  resolveLaneContextWindow,
+} from "../../src/setup/hindsight-context-budget.js";
+import {
+  HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS,
+  generateHindsightComposeSnippet,
+  hindsightLlmBudgetEnv,
+  startHindsight,
+} from "../../src/setup/hindsight.js";
+
+const mockedExec = execFileSync as unknown as ReturnType<typeof vi.fn>;
+
+function envPairsFromRun(): string[] {
+  const runCall = mockedExec.mock.calls.find(
+    (c) => Array.isArray(c[1]) && (c[1] as string[])[0] === "run",
+  );
+  expect(runCall).toBeDefined();
+  const args = runCall![1] as string[];
+  const pairs: string[] = [];
+  for (let i = 0; i < args.length - 1; i++) {
+    if (args[i] === "-e") pairs.push(args[i + 1] as string);
+  }
+  return pairs;
+}
+
+/** The live-fleet backend: llama.cpp `-c 65536 -np 2` = 32,768 per slot. */
+const LOCAL_SLOT_WINDOW = 32_768;
+const localLlm = { provider: "litellm", context_window: LOCAL_SLOT_WINDOW };
+
+describe("hindsight context budget — derivation (#3716)", () => {
+  it("lands on the hand-applied 32k values: batch 6 / consolidation 8192 / retain 6144", () => {
+    const b = resolveHindsightContextBudget(localLlm);
+    expect(b.consolidation.batchSize).toBe(6);
+    expect(b.consolidation.maxCompletionTokens).toBe(8192);
+    expect(b.retain.maxCompletionTokens).toBe(6144);
+  });
+
+  it("keeps worst-case prompt+completion strictly inside a 32k window", () => {
+    // THE regression assertion. On main the emitted batch size was a hard 12,
+    // whose measured p90 prompt was 32,270 tokens against a 32,768 slot — with
+    // an uncapped completion on top, i.e. guaranteed overflow. Recomputing the
+    // pre-fix worst case here proves this test would have failed on the bug.
+    const preFixPrompt =
+      HINDSIGHT_CONSOLIDATION_PROMPT_OVERHEAD_TOKENS +
+      HINDSIGHT_CONSOLIDATION_BATCH_SIZE_CEILING * HINDSIGHT_CONSOLIDATION_TOKENS_PER_FACT;
+    expect(preFixPrompt).toBeGreaterThan(LOCAL_SLOT_WINDOW - 1000);
+
+    const b = resolveHindsightContextBudget(localLlm);
+    expect(b.consolidation.worstCaseTotalTokens).toBeLessThan(LOCAL_SLOT_WINDOW);
+    expect(b.retain.worstCaseTotalTokens).toBeLessThan(LOCAL_SLOT_WINDOW);
+    // …and with real slack, not by a token.
+    expect(LOCAL_SLOT_WINDOW - b.consolidation.worstCaseTotalTokens).toBeGreaterThan(4_000);
+  });
+
+  it("does NOT penalise a large window — batch returns to at least 12", () => {
+    const small = resolveHindsightContextBudget(localLlm);
+    for (const window of [131_072, HINDSIGHT_CLAUDE_CONTEXT_WINDOW]) {
+      const big = resolveHindsightContextBudget({ provider: "litellm", context_window: window });
+      expect(big.consolidation.batchSize).toBeGreaterThanOrEqual(12);
+      expect(big.consolidation.batchSize).toBeGreaterThan(small.consolidation.batchSize);
+      expect(big.consolidation.maxCompletionTokens).toBeGreaterThan(
+        small.consolidation.maxCompletionTokens,
+      );
+      expect(big.retain.maxCompletionTokens).toBeGreaterThan(small.retain.maxCompletionTokens);
+      expect(big.consolidation.worstCaseTotalTokens).toBeLessThan(window);
+    }
+  });
+
+  it("is monotonic in the window — a bigger window is never a smaller batch", () => {
+    let prev = 0;
+    for (const window of [16_384, 32_768, 49_152, 65_536, 131_072, 200_000]) {
+      const b = resolveHindsightContextBudget({ provider: "litellm", context_window: window });
+      expect(b.consolidation.batchSize).toBeGreaterThanOrEqual(prev);
+      expect(b.consolidation.worstCaseTotalTokens).toBeLessThanOrEqual(window);
+      prev = b.consolidation.batchSize;
+    }
+  });
+
+  it("defaults conservatively for a non-claude provider and generously for claude-code", () => {
+    expect(resolveLaneContextWindow("consolidation", { provider: "litellm" })).toMatchObject({
+      windowTokens: HINDSIGHT_CONSERVATIVE_CONTEXT_WINDOW,
+      windowSource: "provider-default",
+    });
+    expect(resolveLaneContextWindow("consolidation", undefined)).toMatchObject({
+      windowTokens: HINDSIGHT_CLAUDE_CONTEXT_WINDOW,
+      windowSource: "provider-default",
+    });
+    // An undeclared litellm backend is assumed local-and-small, so it gets the
+    // ratcheted budget rather than the pre-fix one.
+    expect(resolveHindsightContextBudget({ provider: "litellm" }).consolidation.batchSize).toBe(6);
+  });
+
+  it("resolves per-op window over global over provider default", () => {
+    const llm = {
+      provider: "litellm",
+      context_window: 32_768,
+      consolidation: { context_window: 131_072 },
+    };
+    expect(resolveLaneContextWindow("consolidation", llm)).toMatchObject({
+      windowTokens: 131_072,
+      windowSource: "per-op",
+    });
+    expect(resolveLaneContextWindow("retain", llm)).toMatchObject({
+      windowTokens: 32_768,
+      windowSource: "global",
+    });
+    // Lanes are budgeted independently: the big-window lane keeps batch 12
+    // while the small-window lane stays ratcheted.
+    const b = resolveHindsightContextBudget(llm);
+    expect(b.consolidation.batchSize).toBe(HINDSIGHT_CONSOLIDATION_BATCH_SIZE_CEILING);
+    expect(b.retain.maxCompletionTokens).toBe(6144);
+  });
+
+  it("caps the reflect prompt inside the 32k slot, at the hand-applied 20000", () => {
+    // Upstream's default is 100_000 — three times a llama.cpp slot. That is the
+    // reflect-lane half of the same overflow: a recall-heavy reflect prompt is
+    // built up to this cap, so leaving it at upstream's value guarantees the
+    // context shift on any local backend regardless of the batch size.
+    const b = resolveHindsightContextBudget(localLlm);
+    expect(b.reflect.maxContextTokens).toBe(20_000);
+    expect(b.reflect.worstCaseTotalTokens).toBeLessThan(LOCAL_SLOT_WINDOW);
+    expect(b.reflect.maxContextTokens).toBeLessThan(HINDSIGHT_UPSTREAM_REFLECT_MAX_CONTEXT_TOKENS);
+  });
+
+  it("gives the reflect lane more context on a large window", () => {
+    const small = resolveHindsightContextBudget(localLlm);
+    for (const window of [131_072, HINDSIGHT_CLAUDE_CONTEXT_WINDOW]) {
+      const big = resolveHindsightContextBudget({ provider: "litellm", context_window: window });
+      expect(big.reflect.maxContextTokens).toBeGreaterThan(small.reflect.maxContextTokens);
+      expect(big.reflect.worstCaseTotalTokens).toBeLessThan(window);
+    }
+  });
+
+  it("mirrors the #3611 time-budget cap as the retain ceiling", () => {
+    // The two live in different modules to keep the budget dependency-free;
+    // this is the check that keeps the mirror honest.
+    expect(HINDSIGHT_RETAIN_MAX_COMPLETION_CEILING).toBe(
+      HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS,
+    );
+  });
+});
+
+describe("hindsight context budget — preflight (#3716)", () => {
+  it("REJECTS a window too small to fit the budget", () => {
+    // 4096 is below anything hindsight can run: even batch 1 overflows.
+    const tooSmall = { provider: "litellm", context_window: 4_096 };
+    expect(() => resolveCheckedHindsightContextBudget(tooSmall)).toThrow(
+      HindsightContextBudgetError,
+    );
+    expect(() => resolveCheckedHindsightContextBudget(tooSmall)).toThrow(
+      /exceeds the declared 4096-token context window/,
+    );
+  });
+
+  it("REJECTS a per-op window that is too small even when the global is fine", () => {
+    expect(() =>
+      resolveCheckedHindsightContextBudget({
+        provider: "litellm",
+        context_window: 200_000,
+        retain: { context_window: 8_192 },
+      }),
+    ).toThrow(/hindsight retain/);
+  });
+
+  it("rejects a hand-mutated over-budget config, not just a small window", () => {
+    // Guards the assertion itself: if the derivation is ever bypassed or
+    // edited to emit a bigger cap, the preflight must still catch it.
+    const budget = resolveHindsightContextBudget(localLlm);
+    budget.consolidation.maxCompletionTokens = 24_000;
+    budget.consolidation.worstCaseTotalTokens =
+      budget.consolidation.estimatedPromptTokens + 24_000;
+    expect(() => assertHindsightContextBudgetFits(budget)).toThrow(HindsightContextBudgetError);
+  });
+
+  it("rejects a retain cap that would brick the container on upstream's own check", () => {
+    const budget = resolveHindsightContextBudget(localLlm);
+    budget.retain.maxCompletionTokens = HINDSIGHT_UPSTREAM_RETAIN_CHUNK_SIZE;
+    budget.retain.worstCaseTotalTokens = 0;
+    expect(() => assertHindsightContextBudgetFits(budget)).toThrow(/retain_chunk_size/);
+  });
+
+  it("checks the reflect lane too, not just retain and consolidation", () => {
+    // The reflect lane was added after the first two; without this the lane
+    // could be dropped from the assertion loop and every other preflight test
+    // would still pass.
+    const budget = resolveHindsightContextBudget(localLlm);
+    budget.reflect.maxContextTokens = HINDSIGHT_UPSTREAM_REFLECT_MAX_CONTEXT_TOKENS;
+    budget.reflect.worstCaseTotalTokens = HINDSIGHT_UPSTREAM_REFLECT_MAX_CONTEXT_TOKENS;
+    expect(() => assertHindsightContextBudgetFits(budget)).toThrow(/hindsight reflect/);
+  });
+
+  it("names the config knob to raise, since an overflow is otherwise invisible", () => {
+    try {
+      resolveCheckedHindsightContextBudget({ provider: "litellm", context_window: 4_096 });
+      expect.unreachable("preflight should have thrown");
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toContain("hindsight.llm.context_window");
+      expect(msg).toContain("HTTP 200");
+    }
+  });
+
+  it("accepts every window switchroom ships a default for", () => {
+    for (const llm of [undefined, { provider: "litellm" }, { provider: "claude-code" }, localLlm]) {
+      expect(() => resolveCheckedHindsightContextBudget(llm)).not.toThrow();
+    }
+  });
+});
+
+describe("hindsight context budget — emit paths stay in sync (#3716)", () => {
+  beforeEach(() => {
+    mockedExec.mockReset();
+    mockedExec.mockReturnValue("");
+  });
+
+  it("emits the derived budget on BOTH the docker-run and compose paths", () => {
+    startHindsight({ apiPort: 8888, uiPort: 9999 }, undefined, undefined, localLlm);
+    const runEnv = envPairsFromRun();
+    const snippet = generateHindsightComposeSnippet(localLlm);
+
+    for (const pair of [
+      "HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE=6",
+      "HINDSIGHT_API_CONSOLIDATION_MAX_COMPLETION_TOKENS=8192",
+      "HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS=6144",
+      "HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS=20000",
+    ]) {
+      expect(runEnv, `docker-run must emit ${pair}`).toContain(pair);
+      expect(snippet, `compose must emit ${pair}`).toContain(pair);
+    }
+  });
+
+  it("emits each budget var exactly once (no stale literal shadowing the derived one)", () => {
+    startHindsight({ apiPort: 8888, uiPort: 9999 }, undefined, undefined, localLlm);
+    const runEnv = envPairsFromRun();
+    const snippet = generateHindsightComposeSnippet(localLlm);
+    for (const key of [
+      "HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE",
+      "HINDSIGHT_API_CONSOLIDATION_MAX_COMPLETION_TOKENS",
+      "HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS",
+      "HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS",
+    ]) {
+      expect(runEnv.filter((e) => e.startsWith(`${key}=`)), key).toHaveLength(1);
+      expect(
+        snippet.split("\n").filter((l) => l.includes(`- ${key}=`)),
+        key,
+      ).toHaveLength(1);
+    }
+  });
+
+  it("never leaks context_window itself into the container env", () => {
+    startHindsight({ apiPort: 8888, uiPort: 9999 }, undefined, undefined, {
+      ...localLlm,
+      consolidation: { context_window: 65_536 },
+    });
+    const runEnv = envPairsFromRun();
+    expect(runEnv.some((e) => /CONTEXT_WINDOW/i.test(e))).toBe(false);
+    expect(generateHindsightComposeSnippet(localLlm)).not.toMatch(/CONTEXT_WINDOW/i);
+  });
+
+  it("propagates the preflight failure out of hindsightLlmBudgetEnv", () => {
+    // Both emit paths go through this one function, so a throw here is what
+    // stops an over-budget container ever being launched or written to compose.
+    const tooSmall = { provider: "litellm", context_window: 4_096 };
+    expect(() => hindsightLlmBudgetEnv(tooSmall)).toThrow(HindsightContextBudgetError);
+    expect(() => generateHindsightComposeSnippet(tooSmall)).toThrow(HindsightContextBudgetError);
+  });
+
+  it("takes the tighter of the context cap and the #3611 time cap for retain", () => {
+    // Large window: the time budget binds (16384), unchanged from before.
+    expect(new Map(hindsightLlmBudgetEnv()).get("HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS")).toBe(
+      String(HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS),
+    );
+    // 32k slot: the context budget binds and ratchets it down.
+    const local = new Map(hindsightLlmBudgetEnv(localLlm));
+    expect(Number(local.get("HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS"))).toBeLessThan(
+      HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS,
+    );
+  });
+});


### PR DESCRIPTION
## The bug

Hindsight's LLM ops were sized by hand-tuned constants that knew nothing about
the backend's context window. That was harmless on Claude's 200k window and
became a silent memory-corruption bug the moment the fleet routed hindsight
through LiteLLM to two local Ollama boxes serving `gpt-oss:20b`.

Both boxes launch llama-server with `-c 65536 -np 2 --context-shift --keep 4`
— **32,768 tokens per parallel slot**, with context shift ON.

**The overflow is invisible.** Context shift discards the oldest tokens keeping
only the first `--keep` (=4). That is exactly where the system prompt and the
JSON schema live, so mid-generation the extraction instructions are thrown away
and the model reverts to chatting. It then returns **HTTP 200 with
`finish_reason: stop`**. Verbatim body captured from `LiteLLM_SpendLogs`:

> `Got it! If you have any questions or need assistance with something specific, just let me know.`

Another was a numbered prose list. Nothing in the stack errors — retain and
consolidation just quietly stop extracting.

## The measurements

24h of live traffic, `LiteLLM_SpendLogs`, model `openai/gpt-oss:20b`, n=695,
against a 32,768-token slot:

| Metric | Value |
|---|---|
| p50 prompt | 5,244 tok |
| **p90 prompt** | **32,270 tok** |
| max prompt | 32,754 tok (slot is 32,768) |
| calls over 16,384 prompt tokens | 262/695 = **38%** |
| malformed-response rate, local box A / B | **44% / 47%** |
| malformed-response rate, same model on a 131k OpenRouter route | **2%** |

The variable is the window, not the model. Ruled out by direct test, each
independently: the model itself (the real production prompt + schema passes
10/10 in isolation), `strict: true` vs `false` (10/10 both), `drop_params`,
the `think`/`reasoning_effort` extra_body params, and LiteLLM pass-through.

## What this changes

**1. A declared context window, not new magic constants.** New
`src/setup/hindsight-context-budget.ts` resolves a window per lane —
per-op `hindsight.llm.<lane>.context_window` > global
`hindsight.llm.context_window` > a per-provider default (200000 for
`claude-code`, a deliberately conservative 32768 for anything else, since a
non-Claude provider in switchroom usually means LiteLLM in front of a local
slot). Hardcoding "better" numbers would only relocate the same latent bug to
the next backend swap.

**2. The token settings are derived from it**, so worst-case
`prompt + max_completion_tokens` cannot exceed the window:

| Declared window | batch size | consolidation max_completion | retain max_completion | reflect max_context |
|---|---|---|---|---|
| 32,768 | 6 | 8,192 | 6,144 | 20,000 |
| 131,072 | 12 | 16,384 | 16,384 | 88,000 |
| 200,000 | 12 | 16,384 | 16,384 | 143,000 |

The budget only ever ratchets **down**: 12 is the ceiling, so a big-window
operator keeps the historical tuned value and sees no behaviour change. The
32k row reproduces exactly the values that were hand-applied to the live
container and measured good.

Retain now takes the **tighter** of two independent caps — #3611's 16384 is a
*time* budget (don't generate for 12 minutes), this one is a *context* budget
(don't overflow the slot). Both are real, so `Math.min` composes them rather
than one silently winning.

**3. A startup preflight assertion.** `assertHindsightContextBudgetFits` runs
inside `hindsightLlmBudgetEnv()` — the one function both emit paths already
share — and throws before the container is ever launched or written to compose.
This is the load-bearing part: an overflow produces a well-formed HTTP 200 with
garbage, so it is *undetectable at runtime*. A deterministic check at setup time
is the only durable guarantee. The error names the exact knob to raise and
explains the HTTP-200 failure mode. It also rejects a derived retain cap at or
below upstream's `retain_chunk_size` (3000), which would refuse to boot.

**4. The stale comment is replaced.** It read *"LLM_BATCH_SIZE 12 (unchanged):
facts per LLM call — tokens-per-call, not concurrency, so it doesn't affect the
shared-quota ceiling."* True of the quota ceiling, actively misleading about the
context ceiling. It now carries the measured numbers and the explicit window
dependency.

## Also folded in: five tunings that only existed on the live container

Same defect class — applied imperatively, destroyed by the next
`switchroom memory setup` (the installed 0.19.23 CLI emits no reference to any
of them). All are live and measured-good today:

| Var | Gate | Value | Why |
|---|---|---|---|
| `LLM_STRICT_SCHEMA` | `hindsightLocalLlmEnabled()` | `true` | **Highest priority.** Without it `gpt-oss:20b` prefixes prose to its JSON and ~45% of local retain/consolidation calls fail to parse, wedging both. Upstream defaults it `False`. |
| `LLM_MAX_RETRIES` | `hindsightLocalLlmEnabled()` | `2` | Upstream's own performance guide: a local endpoint isn't rate-limited, so the third attempt mostly adds latency to a call that will fail the same way. |
| `RERANKER_LOCAL_BATCH_SIZE` | `hindsightGpuEnabled()` | `128` | 32 is upstream's CPU/MPS value; `cross_encoder.py` names 128+ for CUDA. Measured: rerank of 150 candidates 4.347s → **0.174s**, end-to-end recall p50 3.2s → **0.8s**. |
| `REFLECT_MAX_CONTEXT_TOKENS` | ungated, derived | 20000 @ 32k | Upstream defaults it to **100,000** — three times a local slot, i.e. not a bound at all. |
| `CONSOLIDATION_MAX_COMPLETION_TOKENS` | ungated, derived | 8192 @ 32k | Upstream default is `None`: literally uncapped. The unbounded half of the overflow. |

The two gated groups follow the existing `=== true` capability discipline —
absent verdict ⇒ off ⇒ upstream's default, and an operator `hindsight.env`
value always wins even when the gate is off.

## Tests

`tests/setup/hindsight-context-budget.test.ts` (new, 21 tests) and 4 new tests
in `src/setup/hindsight-perf-defaults.test.ts`. They assert outcomes, not code
paths:

- The 32k window derives exactly 6 / 8192 / 6144 / 20000 and worst-case total
  lands **strictly inside** the window with >4000 tokens of slack. The test
  also recomputes the pre-fix worst case and asserts it *would* have
  overflowed — so it genuinely fails on the bug it guards.
- A 131k/200k window returns batch size to ≥12 and strictly above the small
  window, and the derivation is monotonic across 16k → 200k.
- The preflight actually **rejects**: a 4096 window, a too-small per-op window
  under a fine global, a hand-mutated over-budget budget object (guarding the
  assertion itself, not just the derivation), a retain cap at
  `retain_chunk_size`, and an inflated reflect cap. And it accepts every window
  switchroom ships a default for.
- Emit-path parity: each derived var appears **exactly once** on both the
  `docker run -e` and generated-compose paths with equal values; both paths
  throw on an over-budget config; `context_window` never leaks into container
  env.
- Each new gated var is present on **both** paths when its gate is true and
  **absent from both** when false (a GPU-less or cloud-LLM host gets neither).

`npm run lint` clean; scoped vitest green (34 files / 751 tests over
`src/setup/`, `tests/setup/`, `src/config/`, `tests/memory.test.ts`, plus the
litellm suites).

## Operator impact

Zero config change required. An existing `claude-code` install is byte-identical
(200k → batch 12, retain 16384). This fleet's `provider: litellm` config
resolves to the conservative 32768 default and reproduces the measured-good
values automatically. Declaring `context_window` is only needed to *raise* the
budget above the conservative default. Documented in
`docs/operators/hindsight-memory.md`: under-declaring costs throughput,
over-declaring corrupts memory, when in doubt under-declare.
