### PR TITLE
fix(telegram): coalesce cosmetic card/draft edits instead of shedding them (#3716)

### DIFF
--- a/telegram-plugin/send-gate-degraded.test.ts
+++ b/telegram-plugin/send-gate-degraded.test.ts
@@ -113,7 +113,7 @@ describe('send-gate PR2: cosmetic shedding', () => {
     expect(gate.stats().global.sent).toBe(1)
   })
 
-  it('sheds a cosmetic EDIT while the message-edit window is open', async () => {
+  it('COALESCES a cosmetic EDIT through an open message-edit window instead of shedding it (#3716)', async () => {
     const clock = new FakeClock()
     const { calls, fn } = recorder(clock)
     const gate = createSendGate({
@@ -122,17 +122,35 @@ describe('send-gate PR2: cosmetic shedding', () => {
       // H1: msg-edit scope is keyed `${chat_id}:${messageId}`.
       initialWindows: [{ scopeKey: 'msg-edit:5:42', untilTs: HOUR }],
     })
+    const opts = { chat_id: '5', messageId: 42, priorityClass: 'cosmetic' as const }
 
-    const res = await gate.gate(fn('edit'), {
-      chat_id: '5',
-      messageId: 42,
-      editPayload: 'v1',
-      priorityClass: 'cosmetic',
-    })
+    // A burst of cosmetic edits arrives while the window is wide open. The old
+    // behaviour dropped every one of them (SEND_GATE_SHED), which stranded the
+    // card on whatever body happened to be on screen when the window opened.
+    const p1 = gate.gate(fn('v1'), { ...opts, editPayload: 'v1' })
+    await flush()
+    const p2 = gate.gate(fn('v2'), { ...opts, editPayload: 'v2' })
+    await flush()
+    const p3 = gate.gate(fn('v3'), { ...opts, editPayload: 'v3' })
+    await flush()
 
-    expect(res).toBe(SEND_GATE_SHED)
+    // Nothing has hit the API yet — the window still suppresses the send, which
+    // is the flood protection doing its job.
     expect(calls).toHaveLength(0)
-    expect(gate.stats().global.shed).toBe(1)
+    // ...but nothing was DISCARDED either.
+    expect(gate.stats().global.shed).toBe(0)
+
+    // Walk past the window. Exactly ONE send lands, carrying the NEWEST payload:
+    // the burst was aggregated, not dropped, and not replayed edit-by-edit.
+    await clock.advance(HOUR + 1000)
+    await flush()
+    await Promise.allSettled([p1, p2, p3])
+
+    expect(calls.map((c) => c.label)).toEqual(['v3'])
+    expect(gate.stats().global.sent).toBe(1)
+    expect(gate.stats().global.shed).toBe(0)
+    // v1 and v2 were superseded in the pending slot (last-write-wins).
+    expect(gate.stats().global.coalesced).toBeGreaterThan(0)
   })
 })
 
@@ -343,7 +361,7 @@ describe('send-gate PR2: H1 cross-chat message_id isolation', () => {
     expect(calls.every((c) => c.at === 0)).toBe(true)
   })
 
-  it('a 429 on chat A message 100 does NOT shed chat B message 100 cosmetic edits', async () => {
+  it('a 429 on chat A message 100 does NOT delay chat B message 100 cosmetic edits', async () => {
     const clock = new FakeClock()
     const { calls, fn } = recorder(clock)
     const gate = createSendGate({
@@ -353,14 +371,17 @@ describe('send-gate PR2: H1 cross-chat message_id isolation', () => {
       initialWindows: [{ scopeKey: 'msg-edit:A:100', untilTs: HOUR }],
     })
 
-    // Chat A cosmetic edit → shed (its scope window is open).
-    const rA = await gate.gate(fn('A-edit'), {
+    // Chat A cosmetic edit → deferred, its scope window is open (#3716: deferred,
+    // NOT shed — the edit is held and lands with its state once the window ends).
+    const pA = gate.gate(fn('A-edit'), {
       chat_id: 'A',
       messageId: 100,
       editPayload: 'A-edit',
       priorityClass: 'cosmetic',
     })
-    // Chat B cosmetic edit to the SAME message_id → must NOT shed (different scope).
+    await flush()
+    // Chat B cosmetic edit to the SAME message_id → must be unaffected (different
+    // scope). This is the H1 isolation the test exists to guard.
     const rB = await gate.gate(fn('B-edit'), {
       chat_id: 'B',
       messageId: 100,
@@ -368,10 +389,18 @@ describe('send-gate PR2: H1 cross-chat message_id isolation', () => {
       priorityClass: 'cosmetic',
     })
 
-    expect(rA).toBe(SEND_GATE_SHED) // A shed
-    expect(rB).toBe('B-edit') // B sent
+    expect(rB).toBe('B-edit') // B sent immediately, unblocked by A's window
     expect(calls.map((c) => c.label)).toEqual(['B-edit'])
-    expect(gate.stats().global.shed).toBe(1)
+    // A is still pending, not discarded.
+    expect(gate.stats().global.shed).toBe(0)
+
+    // Once A's window closes, A's edit lands too — nothing was lost.
+    await clock.advance(HOUR + 1000)
+    await flush()
+    await Promise.allSettled([pA])
+
+    expect(calls.map((c) => c.label).sort()).toEqual(['A-edit', 'B-edit'])
+    expect(gate.stats().global.shed).toBe(0)
   })
 })
 

--- a/telegram-plugin/send-gate.ts
+++ b/telegram-plugin/send-gate.ts
@@ -478,6 +478,16 @@ interface MessageEditState {
    * edit budget. Bounded by the budget cap; empty when the backstop is disabled.
    */
   editWindowTs: number[]
+  /**
+   * Set by the driver while it waits out a NON-critical admission, and fired by
+   * `handleEdit` when a `critical` edit is queued for this message meanwhile
+   * (#3716). Since cosmetic edits stopped shedding they now occupy the driver,
+   * so without this a critical edit arriving one tick after the driver dequeued
+   * a cosmetic one would inherit its unbounded wait — re-introducing the
+   * multi-hour reply wedge the critical fail-fast path exists to prevent.
+   * Null whenever no interruptible wait is in flight.
+   */
+  criticalWake: (() => void) | null
 }
 
 function hashPayload(payload: unknown): string {
@@ -669,6 +679,7 @@ export function createSendGate(config: SendGateConfig): SendGate {
         running: false,
         suppressedUntilMs: 0,
         editWindowTs: [],
+        criticalWake: null,
       }
       perMessage.set(key, state)
     }
@@ -826,9 +837,17 @@ export function createSendGate(config: SendGateConfig): SendGate {
    * without consuming if admission cannot happen before it — the caller drops
    * the call as stale (part3-design §2).
    */
-  async function admitLoop(buckets: TokenBucket[], deadline?: number): Promise<boolean> {
+  async function admitLoop(
+    buckets: TokenBucket[],
+    deadline?: number,
+    interrupt?: Interrupt,
+  ): Promise<boolean> {
     let counted = false
     for (;;) {
+      // Checked BEFORE the consume below so an interrupted admission never
+      // spends a token nobody uses (a leaked token would permanently shrink the
+      // bucket's effective rate).
+      if (interrupt?.fired) return false
       const now = clock.now()
       let wait = 0
       for (const b of buckets) wait = Math.max(wait, b.msUntilAvailable(now))
@@ -841,13 +860,17 @@ export function createSendGate(config: SendGateConfig): SendGate {
         counters.queued++
         counted = true
       }
-      await clock.sleep(deadline !== undefined ? Math.min(wait, deadline - now) : wait)
+      const nap = clock.sleep(deadline !== undefined ? Math.min(wait, deadline - now) : wait)
+      // An open flood window makes `wait` as long as the whole ban, so the nap
+      // must be raced rather than awaited outright — otherwise the interrupt is
+      // not observed until the ban has already elapsed.
+      await (interrupt ? Promise.race([nap, interrupt.promise]) : nap)
     }
   }
 
   /** Back-compat unbounded admission (used by the per-message edit driver). */
-  function admit(buckets: TokenBucket[]): Promise<boolean> {
-    return admitLoop(buckets)
+  function admit(buckets: TokenBucket[], interrupt?: Interrupt): Promise<boolean> {
+    return admitLoop(buckets, undefined, interrupt)
   }
 
   // Serializes `critical` sends that must probe the API during an open (short)
@@ -868,6 +891,36 @@ export function createSendGate(config: SendGateConfig): SendGate {
         release()
       }
     })()
+  }
+
+  /**
+   * One-shot abort handle for an in-flight admission wait (#3716). `fired` is
+   * the synchronous check (so the loop can bail before consuming a token) and
+   * `promise` is the async wake (so a nap covering a whole flood ban is cut
+   * short rather than run to completion).
+   */
+  interface Interrupt {
+    fired: boolean
+    promise: Promise<void>
+  }
+
+  /** Create an `Interrupt` plus the trigger that fires it exactly once. */
+  function makeInterrupt(): { interrupt: Interrupt; fire: () => void } {
+    let resolve!: () => void
+    const interrupt: Interrupt = {
+      fired: false,
+      promise: new Promise<void>((r) => {
+        resolve = r
+      }),
+    }
+    return {
+      interrupt,
+      fire: () => {
+        if (interrupt.fired) return
+        interrupt.fired = true
+        resolve()
+      },
+    }
   }
 
   type AdmitOutcome =
@@ -1038,7 +1091,24 @@ export function createSendGate(config: SendGateConfig): SendGate {
           }
           // outcome.result === 'ok' → admitPriority already consumed the buckets.
         } else {
-          await admit(bucketsFor(opts))
+          // #3716: this wait is UNBOUNDED, and since cosmetic edits stopped
+          // shedding it is now reachable for them too — so a `critical` edit
+          // arriving while we sit here must be able to jump the queue instead
+          // of inheriting a whole flood ban's worth of waiting. Yield to it and
+          // re-loop; `p` is superseded rather than dropped, so no state is lost
+          // and its callers ride the send that actually goes out.
+          const { interrupt, fire } = makeInterrupt()
+          state.criticalWake = fire
+          let admitted: boolean
+          try {
+            admitted = await admit(bucketsFor(opts), interrupt)
+          } finally {
+            state.criticalWake = null
+          }
+          if (!admitted) {
+            supersede(state, p)
+            continue
+          }
         }
         // Reserve the send-start time BEFORE awaiting the network so the floor
         // is measured from send start (matches the per-message serialization).
@@ -1084,6 +1154,70 @@ export function createSendGate(config: SendGateConfig): SendGate {
     }
   }
 
+  /**
+   * Hand a dequeued-but-unsent edit back to the queue after the driver yielded
+   * to a higher-priority one (#3716). `p` is by definition OLDER than whatever
+   * is queued now, so last-write-wins says its payload loses — but its callers
+   * must still settle, so they ride the newer edit's result exactly as if they
+   * had coalesced onto it in the first place. With nothing queued (the wake
+   * raced an empty slot) `p` simply goes back.
+   */
+  function supersede(state: MessageEditState, p: PendingEdit): void {
+    const next = state.pending
+    if (!next) {
+      state.pending = p
+      return
+    }
+    next.priorityClass = maxPriority(next.priorityClass, p.priorityClass)
+    next.promise.then(p.resolve, p.reject)
+  }
+
+  /**
+   * The condition that used to trigger the cosmetic-edit shed: no token in some
+   * bucket, or a window covering this message. Kept as the trigger — what
+   * changed in #3716 is the CONSEQUENCE (see `settleForCaller`).
+   */
+  function editUnderPressure(state: MessageEditState, opts: SendGateOpts, now: number): boolean {
+    if (state.suppressedUntilMs > now) return true
+    for (const b of bucketsFor(opts)) {
+      if (b.msUntilAvailable(now) > 0) return true
+    }
+    return false
+  }
+
+  /**
+   * What a queued edit returns to the caller that submitted it (#3716).
+   *
+   * Normally: the shared pending promise, settling with the coalesced send's
+   * outcome. Callers rely on that to pace their own painting, so this is the
+   * path whenever the gate is keeping up.
+   *
+   * Under pressure, a `cosmetic` edit instead settles its caller as soon as it
+   * is QUEUED. Callers serialize their own flushes, so a best-effort paint
+   * parked behind a flood ban would hold a subsequent critical edit hostage
+   * UPSTREAM of the gate — where the fail-fast path can never see it — wedging
+   * the reply path for the length of the ban. Releasing the caller keeps that
+   * path free while the edit itself stays queued and still lands carrying the
+   * newest payload. This is the same trigger the old shed used; the difference
+   * is that the state survives instead of being discarded.
+   */
+  function settleForCaller<T>(
+    state: MessageEditState,
+    pending: PendingEdit,
+    opts: SendGateOpts,
+    priority: PriorityClass,
+    now: number,
+  ): Promise<T> {
+    if (priority !== 'cosmetic' || !editUnderPressure(state, opts, now)) {
+      return pending.promise as Promise<T>
+    }
+    // Nobody may be left awaiting the shared promise, so absorb a rejection here
+    // to keep a failed background paint from surfacing as an unhandled rejection.
+    // (A later `critical`/`useful` coalesce still attaches its own handlers.)
+    void pending.promise.catch(() => {})
+    return Promise.resolve(undefined as unknown as T)
+  }
+
   function handleEdit<T>(fn: () => Promise<T>, opts: SendGateOpts): Promise<T> {
     const messageId = opts.messageId as number
     const key = messageKey(opts.chat_id, messageId)
@@ -1093,22 +1227,39 @@ export function createSendGate(config: SendGateConfig): SendGate {
     maybeEvict(now, existing === undefined)
     const state = existing ?? messageState(key)
 
-    // Cosmetic edits (part3-design §2) shed under pressure — a flood window
-    // covering the scope is open, or a bucket has no token free right now. A
-    // dropped edit costs nothing: the next edit carries the full state. Only an
-    // EXPLICITLY-cosmetic edit sheds; untagged edits keep PR 1's coalescing
-    // behaviour (default = useful), so this never changes an untagged caller.
-    if ((opts.priorityClass ?? 'useful') === 'cosmetic') {
-      let wait = 0
-      for (const b of bucketsFor(opts)) wait = Math.max(wait, b.msUntilAvailable(now))
-      const msgWait = state.suppressedUntilMs > now ? state.suppressedUntilMs - now : 0
-      if (wait > 0 || msgWait > 0) {
-        counters.shed++
-        // Distinguishable from the no-op drop below (undefined): a shed did
-        // NOT land, and edit-driving callers must be able to tell (F1).
-        return Promise.resolve(SEND_GATE_SHED as unknown as T)
-      }
-    }
+    // Cosmetic edits COALESCE under pressure; they are never shed (#3716).
+    //
+    // This previously dropped a cosmetic edit outright whenever a bucket had no
+    // free token or a flood window covered the scope, on the reasoning that "a
+    // dropped edit costs nothing: the next edit carries the full state". That
+    // holds for every edit in a burst EXCEPT the last one — and the last one is
+    // the only edit whose state is still on screen when the burst ends. Dropping
+    // it strands the card on a stale body indefinitely (a progress card frozen
+    // mid-run, a finished task still rendered as running). Pressure is exactly
+    // when bursts end, so the drop was biased toward stranding precisely the
+    // edits that mattered.
+    //
+    // Falling through to the last-write-wins coalescing below loses nothing and
+    // costs no extra flood budget: N queued edits collapse into ONE send that
+    // carries the newest payload, and the driver already paces that send against
+    // the token buckets, the per-message edit floor, and the rolling per-window
+    // cosmetic budget — which DEFERS an over-budget edit rather than dropping it.
+    // Flood safety comes from that pacing, never from discarding state.
+    //
+    // Cost of the change: under a long flood window a cosmetic edit now waits in
+    // the driver instead of resolving immediately as SEND_GATE_SHED. The pending
+    // slot is one-per-message and LRU-bounded by `maxMessageStates`, and the edit
+    // that eventually lands carries the newest state rather than a stale one.
+    // `SEND_GATE_SHED` remains the contract for NON-edit cosmetic sends (typing,
+    // reactions), which carry no state worth preserving.
+    //
+    // What that cost must NOT become is a wait the CALLER inherits. Callers
+    // serialize their own flushes (draft-stream awaits the in-flight paint before
+    // starting the next), so a cosmetic edit that blocked its caller for a whole
+    // flood ban would hold the critical finalize behind it — and the finalize
+    // would never reach the gate to fail fast, wedging the reply path for hours.
+    // That is precisely the failure the gate exists to prevent, so a cosmetic
+    // edit settles its caller as soon as it is QUEUED (see `settleForCaller`).
 
     // N1: the coalesce (last-write-wins) check runs BEFORE the no-op skip. When
     // a distinct edit is already queued, the newest payload always replaces it —
@@ -1135,7 +1286,10 @@ export function createSendGate(config: SendGateConfig): SendGate {
         state.pending.hash = hash
         state.pending.fn = fn as () => Promise<unknown>
       }
-      return state.pending.promise as Promise<T>
+      // The queued edit is critical now — cut short any non-critical admission
+      // the driver is waiting out for this message (#3716).
+      if (state.pending.priorityClass === 'critical') state.criticalWake?.()
+      return settleForCaller<T>(state, state.pending, opts, opts.priorityClass ?? 'useful', now)
     }
 
     // No edit queued → a repeat of the last payload we actually sent is a plain
@@ -1164,8 +1318,15 @@ export function createSendGate(config: SendGateConfig): SendGate {
       priorityClass: opts.priorityClass ?? 'useful',
     }
     state.pending = pending
-    if (!state.running) void drive(state, opts)
-    return promise as Promise<T>
+    if (state.running) {
+      // A driver is mid-flight. If it is waiting out a non-critical admission
+      // and THIS edit is critical, wake it so the critical work does not queue
+      // behind a cosmetic edit's unbounded wait (#3716).
+      if (pending.priorityClass === 'critical') state.criticalWake?.()
+    } else {
+      void drive(state, opts)
+    }
+    return settleForCaller<T>(state, pending, opts, pending.priorityClass, now)
   }
 
   async function gate<T>(fn: () => Promise<T>, opts?: SendGateOpts): Promise<T> {

--- a/telegram-plugin/tests/activity-card-send-gate.test.ts
+++ b/telegram-plugin/tests/activity-card-send-gate.test.ts
@@ -239,10 +239,10 @@ describe('activity card ↔ send gate (#3620)', () => {
     }
   })
 
-  it('a shed card edit is not treated as painted — the newest render survives for the next drain', async () => {
+  it('a card edit starved of tokens is HELD, not shed — the newest render still lands (#3716)', async () => {
     // A one-token-per-minute chat bucket: the card open consumes it, so the
-    // next COSMETIC card edit sheds.
-    const { lane, calls, clock } = makeGatedLane({ perChatPerSec: 1 / 60, perChatBurst: 1 })
+    // next COSMETIC card edit cannot be admitted.
+    const { lane, calls, clock, gate } = makeGatedLane({ perChatPerSec: 1 / 60, perChatBurst: 1 })
     const turn = makeLaneTurn(lane)
 
     lane.showNarrativeStep(turn, 'Opening the card')
@@ -250,17 +250,17 @@ describe('activity card ↔ send gate (#3620)', () => {
     await turn.activityInFlight
     expect(calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(1)
 
-    lane.showNarrativeStep(turn, 'A shed update')
+    lane.showNarrativeStep(turn, 'An update with no token available')
     await clock.advance(10)
     await turn.activityInFlight
-    // Shed → nothing hit the API, and the render is still PENDING (not
-    // mis-recorded as sent), so it is not silently lost.
+    // Nothing hits the API while the bucket is empty — unchanged. What changed
+    // is that the edit is now QUEUED rather than discarded, so the card can no
+    // longer be stranded on a stale body by a burst that ends under pressure.
     expect(calls.filter((c) => c.method === 'editMessageText')).toHaveLength(0)
-    expect(turn.activityPendingRender).not.toBeNull()
-    expect(turn.activityPendingRender).not.toBe(turn.activityLastSentRender)
+    expect(gate.stats().global.shed).toBe(0)
 
     // Once the bucket refills, the next drain paints the NEWEST body — not the
-    // shed intermediate one.
+    // superseded intermediate one.
     lane.showNarrativeStep(turn, 'The newest update')
     await clock.advance(120_000)
     await turn.activityInFlight

--- a/telegram-plugin/tests/stream-controller-send-gate.test.ts
+++ b/telegram-plugin/tests/stream-controller-send-gate.test.ts
@@ -16,12 +16,16 @@
  *     collapse; the latest snapshot lands floor-paced
  *   - the floor is per-message (stream A does not delay stream B)
  *   - the gate's no-op skip drops a repeat payload for the same message
- *   - an open flood window sheds draft edits with ZERO API calls, and the
- *     stream recovers with full state after the window closes
- *   - a shed draft is NOT recorded as delivered — a later flush of the
- *     SAME text (the completed answer) still lands
+ *   - an open flood window COALESCES draft edits with ZERO API calls, and the
+ *     newest state lands once the window closes (#3716 — cosmetic edits are
+ *     never shed; the last edit of a burst is the one still on screen, so
+ *     dropping it stranded the message on a stale body)
+ *   - a draft held through a window still renders the completed answer — a
+ *     later flush of the SAME text is then a benign no-op, not a loss
  *   - the finalize flush is `critical`: never shed; waits out a short
  *     window; fails fast (structured, logged) on a long one
+ *   - shed-honesty (F2+F3) remains wired for any `SEND_GATE_SHED` the retry
+ *     policy does return, pinned directly rather than through the gate
  *   - regression pin: the controller passes messageId / editPayload /
  *     priorityClass through the retry policy on every edit
  *
@@ -32,7 +36,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createStreamController, type RetryPolicy } from '../stream-controller.js'
-import { createSendGate, type Clock, type SendGateConfig } from '../send-gate.js'
+import { createSendGate, SEND_GATE_SHED, type Clock, type SendGateConfig } from '../send-gate.js'
 import { isFloodWaitActiveError } from '../retry-api-call.js'
 import { renderOutboundChunks } from '../render/rich-render.js'
 import { createMockBot, installBotResetHook } from './bot-api.harness.js'
@@ -221,7 +225,7 @@ describe('stream-controller × send gate (#3110)', () => {
     expect(bot.api.editMessageText).toHaveBeenCalledTimes(1)
   })
 
-  it('open flood window: draft edits shed with ZERO API calls; full state lands after it closes', async () => {
+  it('open flood window: draft edits COALESCE with ZERO API calls; newest state lands after it closes (#3716)', async () => {
     const { clock, gate, retry } = makeGatedRetry({ editFloorMs: 1500 })
     const stream = createStreamController({
       bot, chatId: '1', throttleMs: 250, retry, initialMessageId: 7777,
@@ -233,17 +237,24 @@ describe('stream-controller × send gate (#3110)', () => {
     await flush()
     void stream.update('draft b')
     await tick()
-    // Both drafts shed as cosmetic — nothing reached the API.
+    // Flood safety is unchanged — still ZERO API calls while the window is
+    // open. What changed is the mechanism: the drafts are HELD (last-write-
+    // wins), not discarded, so no state is lost.
     expect(bot.api.editMessageText).not.toHaveBeenCalled()
-    expect(gate.stats().global.shed).toBe(2)
+    expect(gate.stats().global.shed).toBe(0)
 
-    await clock.advance(30_000) // window closes
+    await clock.advance(30_000) // window closes → the held draft lands
     void stream.update('draft c — full state')
     await tick()
-    expect(editBodies()).toEqual(['draft c — full state'])
+    await clock.advance(1_500) // clear the per-message edit floor
+
+    // The guarantee is the newest state reaches the screen, never that some
+    // intermediate was dropped to get there.
+    expect(editBodies().at(-1)).toBe('draft c — full state')
+    expect(gate.stats().global.shed).toBe(0)
   })
 
-  it('a shed draft is NOT recorded as delivered: a later finalize of the SAME text still lands', async () => {
+  it('a draft held through a window still renders: the completed answer reaches the screen exactly once', async () => {
     const { clock, gate, retry } = makeGatedRetry({ editFloorMs: 1500 })
     const stream = createStreamController({
       bot, chatId: '1', throttleMs: 250, retry, initialMessageId: 7777,
@@ -253,12 +264,16 @@ describe('stream-controller × send gate (#3110)', () => {
     void stream.update('the completed answer')
     await flush()
     expect(bot.api.editMessageText).not.toHaveBeenCalled()
-    expect(gate.stats().global.shed).toBe(1)
+    expect(gate.stats().global.shed).toBe(0)
 
-    await clock.advance(30_000)
-    // stream_reply done=true with the same text → finalize(text). If the shed
-    // draft had been recorded as on-screen, draft-stream's dedupe would skip
-    // this flush and the completed answer would never render.
+    await clock.advance(30_000) // window closes → the held draft lands
+
+    // stream_reply done=true with the same text → finalize(text). Pre-#3716
+    // the draft was SHED here, and the guarantee was that the stream must not
+    // record it as on-screen so this flush could re-deliver it. Now the draft
+    // is never dropped, so it renders on its own and the identical finalize is
+    // a benign no-op. Either way the user sees the completed answer — and now
+    // it costs one API call instead of two.
     await stream.finalize('the completed answer')
     expect(editBodies()).toEqual(['the completed answer'])
   })
@@ -277,7 +292,7 @@ describe('stream-controller × send gate (#3110)', () => {
     gate.openFloodWindow('global', clock.now() + 30_000) // short: <= 60s fail-fast ceiling
     void stream.update('draft while banned')
     await flush()
-    expect(bot.api.editMessageText).not.toHaveBeenCalled() // draft shed
+    expect(bot.api.editMessageText).not.toHaveBeenCalled() // draft held, not sent
 
     const fin = stream.finalize('the answer')
     await flush()
@@ -286,9 +301,12 @@ describe('stream-controller × send gate (#3110)', () => {
 
     await clock.advance(30_000)
     await fin
+    // The critical finalize coalesced ONTO the held draft and upgraded its
+    // class, so the whole burst resolves as a single send carrying the final
+    // body — the draft is superseded rather than dropped.
     expect(editBodies()).toEqual(['the answer'])
     expect(editTimes).toEqual([30_000])
-    expect(gate.stats().global.shed).toBe(1) // only the draft
+    expect(gate.stats().global.shed).toBe(0) // nothing is shed any more
   })
 
   it('finalize under a LONG window fails fast (structured FLOOD_WAIT_ACTIVE, logged) — no API call, no hang', async () => {
@@ -314,6 +332,40 @@ describe('stream-controller × send gate (#3110)', () => {
     } catch (err) {
       expect(isFloodWaitActiveError(err)).toBe(true)
     }
+  })
+
+  /**
+   * REGRESSION PIN for the trap #3716 opened. Once cosmetic edits stopped
+   * shedding they began OCCUPYING the driver, and draft-stream serializes its
+   * own flushes — so a draft parked behind a 6h ban held the finalize upstream
+   * of the gate, where the fail-fast path could never see it. `failedFast` went
+   * to 0 and the reply path wedged for the length of the ban: the exact failure
+   * the gate was built to eliminate, reintroduced by the fix for a different
+   * one. The preceding test does NOT catch this — it finalizes with no draft in
+   * flight.
+   */
+  it('a draft parked behind a LONG window never wedges the finalize behind it (#3716)', async () => {
+    const { clock, gate, retry } = makeGatedRetry({ editFloorMs: 1500 })
+    const logs: string[] = []
+    const stream = createStreamController({
+      bot, chatId: '1', throttleMs: 250, retry, initialMessageId: 7777,
+      log: (m) => logs.push(m),
+    })
+
+    gate.openFloodWindow('global', clock.now() + 21_397_000) // the 2026-07-12 ban: ~5.9h
+    void stream.update('draft while banned')
+    await flush()
+    expect(gate.stats().global.shed).toBe(0) // held, not dropped
+
+    // The cosmetic draft settles its caller as soon as it is queued, so the
+    // finalize reaches the gate. If it did not, this await never returns.
+    const fin = stream.finalize('the answer')
+    await tick()
+    await fin
+
+    expect(gate.stats().global.failedFast).toBe(1)
+    expect(bot.api.editMessageText).not.toHaveBeenCalled()
+    expect(logs.some((m) => m.includes('FLOOD_WAIT_ACTIVE'))).toBe(true)
   })
 
   it('REGRESSION PIN: every edit passes messageId / editPayload / priorityClass to the retry policy', async () => {
@@ -474,7 +526,7 @@ describe('stream-controller × send gate (#3110)', () => {
     expect(bot.api.editMessageText.mock.calls.length).toBe(editCalls)
   })
 
-  it('a shed TAIL is not recorded as delivered: argument-less finalize() re-flushes and lands it (F2+F3)', async () => {
+  it('a TAIL suppressed by a msg-scoped window is HELD, not lost: the completed answer lands when it closes', async () => {
     const { clock, gate, retry } = makeGatedRetry({
       editFloorMs: 1500,
       globalPerSec: 1000, globalBurst: 100, perChatPerSec: 1000, perChatBurst: 100,
@@ -495,27 +547,81 @@ describe('stream-controller × send gate (#3110)', () => {
     const lastTailId = anchorId + pieceCount - 1
 
     // Flood window scoped to the LAST tail message only (H1 msg-edit scope):
-    // its edit sheds; the anchor and other pieces are unaffected.
+    // its edit is suppressed; the anchor and other pieces are unaffected.
     gate.openFloodWindow(`msg-edit:1:${lastTailId}`, clock.now() + 30_000)
 
     void stream.update(b2)
     await tick()
-    // The changed piece is the suppressed tail → shed, zero edits landed on
-    // it; the flush is reported shed and the snapshot preserved (F2), NOT
-    // recorded as delivered (F3).
+    // The changed piece is the suppressed tail → zero edits land on it while
+    // the window is open. Pre-#3716 it was SHED and the completed answer only
+    // survived because the stream refused to record it as delivered; now the
+    // edit is held by the gate, so the content is safe by construction.
     const tailEdits = () =>
       bot.api.editMessageText.mock.calls.filter(([, id]) => id === lastTailId)
     expect(tailEdits()).toHaveLength(0)
-    expect(gate.stats().global.shed).toBe(1)
-    expect(logs.some((m) => m.includes('shed by send gate'))).toBe(true)
+    expect(gate.stats().global.shed).toBe(0)
+    expect(logs.some((m) => m.includes('shed by send gate'))).toBe(false)
 
-    // Window closes; the gateway-style ARGUMENT-LESS finalize (the
-    // disconnect-flush / turn-end cleanup path) must re-deliver the shed
-    // snapshot — pre-F2 the content was silently lost here.
+    // Window closes → the held tail edit lands on its own. The gateway-style
+    // ARGUMENT-LESS finalize (disconnect-flush / turn-end cleanup) is then a
+    // no-op rather than a rescue.
     await clock.advance(31_000)
     await stream.finalize()
     expect(tailEdits()).toHaveLength(1)
     const [, , tailBody] = tailEdits()[0]
+    expect(String(tailBody)).toContain('tail v2')
+  })
+
+  /**
+   * #3716 removed the gate's cosmetic-EDIT shed, so no edit the stream makes
+   * can return `SEND_GATE_SHED` any more. The sentinel is still the contract
+   * for non-edit cosmetic sends, and the controller's F2/F3 shed-honesty
+   * handling is the guard if any edit path is ever re-tagged — so pin it
+   * directly against the retry seam instead of through the gate, where it
+   * would silently rot into an assertion about behaviour that cannot occur.
+   */
+  it('F2+F3 shed-honesty is still wired: a SHED tail is not recorded as delivered and re-flushes', async () => {
+    const base = ('a_b_c_d_e ').repeat(3000)
+    const b1 = `${base}tail v1`
+    const b2 = `${base}tail v2 — the completed answer`
+    const pieceCount = renderOutboundChunks(b1).length
+    expect(pieceCount).toBeGreaterThan(1)
+
+    // Shed exactly one message id, chosen after the first flush assigns ids.
+    let shedId: number | null = null
+    const retry: RetryPolicy = async (fn, opts) => {
+      if (shedId != null && opts?.messageId === shedId) {
+        return SEND_GATE_SHED as never
+      }
+      return await fn()
+    }
+
+    const logs: string[] = []
+    const stream = createStreamController({
+      bot, chatId: '1', throttleMs: 250, retry, log: (m) => logs.push(m),
+    })
+    void stream.update(b1)
+    await flush()
+    const anchorId = stream.getMessageId() as number
+    shedId = anchorId + pieceCount - 1
+
+    const tailEdits = () =>
+      bot.api.editMessageText.mock.calls.filter(([, id]) => id === shedId)
+
+    void stream.update(b2)
+    await tick()
+    expect(tailEdits()).toHaveLength(0)
+    expect(logs.some((m) => m.includes('shed by send gate'))).toBe(true)
+
+    // The shed piece must NOT have been recorded as on screen: an
+    // argument-less finalize re-delivers the preserved snapshot.
+    shedId = null
+    await stream.finalize()
+    const landed = bot.api.editMessageText.mock.calls.filter(
+      ([, id]) => id === anchorId + pieceCount - 1,
+    )
+    expect(landed).toHaveLength(1)
+    const [, , tailBody] = landed[0]
     expect(String(tailBody)).toContain('tail v2')
   })
 })


### PR DESCRIPTION
Fixes #3716.

## The defect

The send gate dropped a `cosmetic` edit outright whenever a bucket had no free token or a flood window covered the scope. The reasoning was *"a dropped edit costs nothing: the next edit carries the full state"* — which holds for every edit in a burst **except the last one**, and the last one is the only edit whose state is still on screen when the burst ends. Pressure is exactly when bursts end, so the drop was biased toward stranding precisely the edits that mattered: a progress card frozen mid-run, a finished task still rendered as running.

Worse, the shed short-circuited **past** the last-write-wins coalescing sitting directly below it in `handleEdit` — the mechanism that already solves this.

## The fix

Delete the shed and fall through to the coalescing. N queued edits collapse into **one** send carrying the newest payload, so this costs no extra flood budget.

Flood safety never came from discarding state. It comes from the token buckets, the per-message edit floor, and the rolling per-window budget — all of which **defer** an over-budget edit rather than drop it. `SEND_GATE_SHED` remains the contract for non-edit cosmetic sends (typing, reactions), which carry no state worth preserving.

## Two consequences, both handled

Both of these re-introduced the multi-hour reply wedge the gate exists to eliminate, so they are the substance of the diff rather than the one-line shed removal.

**1. Cosmetic edits now occupy the driver.** A `critical` edit arriving one tick after the driver dequeued a cosmetic one inherited its unbounded wait. The driver's non-critical admission is now interruptible: a critical edit queued for the same message wakes it, the cosmetic edit is *superseded* (not dropped — its callers ride the send that actually goes out), and the loop re-dispatches on the critical fail-fast path. The interrupt is checked **before** the token consume so an abandoned admission never leaks a token (a leaked token permanently shrinks the bucket's effective rate).

**2. Callers serialize their own flushes.** A cosmetic paint parked behind a ban held the finalize hostage *upstream* of the gate, where the fail-fast path can never see it. Reproduced: `failedFast` went to 0 and the reply path wedged for the full ~6h ban. Under pressure a cosmetic edit now settles its caller as soon as it is **queued** — the same trigger the old shed used, except the state survives and still lands.

## Tests

- The suites asserting the old shed contract now assert coalescing. The user-visible guarantee (newest state reaches the screen) is unchanged; the mechanism is what moved.
- **Added** a regression pin for the wedge in (2) — no existing test covered it, the nearest one finalizes with no draft in flight.
- **Added** a direct pin keeping the callers' F2/F3 shed-honesty handling covered, now that no edit can return `SEND_GATE_SHED` through the real gate.

## Verification

- `npm run lint` — clean.
- `telegram-plugin` suite: `1 failed | 8291 passed | 3 skipped (8295)`. The single failure is `approval-hold-record.test.ts`, **pre-existing** — it simulates an unwritable directory and the test runner here is uid 0. Confirmed failing identically on clean `origin/main`.
- Full-repo local run has failures confined to root `tests/` (`workspace-dynamic-hook`, `docker/doctor-checks` and friends) that this diff cannot reach — it touches `telegram-plugin/` only. A baseline run on `origin/main` is in flight to confirm the sets match; CI is the authority.

## Follow-ups split out of #3716 (not in this PR)

- No capacity is reserved for the reply path. A critical-token reserve was prototyped and **reverted** — its mechanism is more shedding, which is the opposite of the direction here.
- A `useful` edit can still block its caller unboundedly. Pre-existing, unchanged by this diff.
- `obligation_represent` at 221 firings is chronic, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
