### PR TITLE
fix(gateway): corroborate model-supplied owner tiers so a self-echoed reply stops duplicating

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -489,7 +489,7 @@ import {
 import {
   resolveReplyOwnerTurnId,
   resolveReplyOwnerTier,
-  type ReplyOwnerTier,
+  type ReplyOwnerTier, type ReplyOwnerCandidates,
   type AnswerDeliveredLatch,
 } from '../reply-owner-resolve.js'
 import { SubagentHandbackMarker } from './subagent-handback-marker.js'
@@ -4037,7 +4037,7 @@ function resolveReplyOwnerTurn(
   liveTurn: CurrentTurn | null,
   chatId: string,
   args: Record<string, unknown>,
-): { turn: CurrentTurn | null; tier: ReplyOwnerTier } {
+): { turn: CurrentTurn | null; tier: ReplyOwnerTier; candidates: ReplyOwnerCandidates } {
   const origin = findTurnByOriginId(args.origin_turn_id as string | undefined)
   const quoted = findTurnByQuotedMessageId(chatId, args.reply_to)
   const latestEnded = findLatestEndedTurnForChat(chatId)
@@ -4054,7 +4054,7 @@ function resolveReplyOwnerTurn(
   // fabricate one.
   const latestEndedAgeMs =
     latestEnded?.endedAt != null ? Date.now() - latestEnded.endedAt : null
-  const candidates = {
+  const candidates: ReplyOwnerCandidates = {
     liveTurnId: liveTurn?.turnId ?? null,
     originTurnId: origin?.turnId ?? null,
     quotedTurnId: quoted?.turnId ?? null,
@@ -4062,15 +4062,14 @@ function resolveReplyOwnerTurn(
     latestEndedAgeMs,
     latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
   }
-  // #3429 — the WINNING tier travels with the turn. A positive tier
-  // (live/origin/quoted) means the reply is this turn's own answer and the
-  // supersede fires regardless of text; the ambiguous `latest-ended` fallback
-  // keeps the content gate (it cannot tell a late own-reply from an async
-  // sub-agent handback). Both derive from the SAME candidates, so the id and the
-  // tier can never disagree.
+  // #3429 — the winning tier AND the candidate set it came from travel with the
+  // turn. Tier alone no longer decides the content-gate bypass: the
+  // model-steerable `origin`/`quoted` tiers must be CORROBORATED against the
+  // framework-derived `latestEndedTurnId` (`decideContentGateBypass`). All three
+  // derive from these SAME candidates, so they can never disagree.
   const tier = resolveReplyOwnerTier(candidates)
   const winnerId = resolveReplyOwnerTurnId(candidates)
-  return { turn: winnerId != null ? (byId.get(winnerId) ?? null) : null, tier }
+  return { turn: winnerId != null ? (byId.get(winnerId) ?? null) : null, tier, candidates }
 }
 
 /**

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -62,7 +62,12 @@ import {
   DEFAULT_SUPERSEDE_TTL_MS,
   type FlushedTurnSupersedeRegistry,
 } from '../flushed-turn-supersede.js'
-import { decideAnswerLatchSuppression, type ReplyOwnerTier } from '../reply-owner-resolve.js'
+import {
+  decideAnswerLatchSuppression,
+  decideContentGateBypass,
+  type ReplyOwnerTier,
+  type ReplyOwnerCandidates,
+} from '../reply-owner-resolve.js'
 import { deriveTelegraphTitle } from '../telegraph.js'
 import {
   mayInjectListenButton,
@@ -726,7 +731,12 @@ export interface SendReplyGatewayDeps {
   assertSendable(f: string): void
   statusKey(chatId: string, threadId?: number | null): string
   streamKey(chatId: string, threadId?: number | null): string
-  resolveReplyOwnerTurn(liveTurn: CurrentTurn | null, chatId: string, args: Record<string, unknown>): { turn: CurrentTurn | null; tier: ReplyOwnerTier }
+  /** Resolves the owner turn AND returns the CANDIDATE SET it was derived from.
+   *  The candidates are load-bearing, not diagnostics: `decideContentGateBypass`
+   *  corroborates a model-steerable `origin`/`quoted` attribution against the
+   *  framework-derived `latestEndedTurnId` inside them before allowing a
+   *  content-gate bypass. */
+  resolveReplyOwnerTurn(liveTurn: CurrentTurn | null, chatId: string, args: Record<string, unknown>): { turn: CurrentTurn | null; tier: ReplyOwnerTier; candidates: ReplyOwnerCandidates }
   findTurnByOriginId(originTurnId: string | null | undefined): CurrentTurn | null
   findTurnByQuotedMessageId(chatId: string, replyTo: unknown): CurrentTurn | null
   resolveAnswerThreadWithLog(
@@ -946,7 +956,11 @@ export async function sendReply(
     // double-send). The quoted / latest-ended recoveries are precisely what the
     // router already did for the same reply, so unifying here makes the two
     // resolvers agree and the late-reply supersede fires by identity.
-    const { turn: ownerTurn, tier: ownerTier } = resolveReplyOwnerTurn(turn, chat_id, args)
+    const {
+      turn: ownerTurn,
+      tier: ownerTier,
+      candidates: ownerCandidates,
+    } = resolveReplyOwnerTurn(turn, chat_id, args)
     const resolvedTurnId = ownerTurn?.turnId ?? null
     // #3429 — pass the (normalized) reply text so the registry CAN apply the
     // new-content gate: identity match + TTL alone also fits a background
@@ -1014,23 +1028,32 @@ export async function sendReply(
       ownerEndedAt != null &&
       handbackAt > ownerEndedAt &&
       now - handbackAt <= DEFAULT_SUPERSEDE_TTL_MS
-    // MUST-FIX 1 (silent-data-loss, PROVEN by Fable 2026-07-21) — restrict the
-    // content-gate BYPASS to the tiers whose attribution is NOT model-steerable:
-    //   - `live`   — the framework-owned live `currentTurn` (not model-derived,
-    //                and `decideSupersede`'s same-turnId check bars it from an
-    //                ended turn's record). Bypasses even a handback window.
+    // MUST-FIX 1 (silent-data-loss, PROVEN by Fable 2026-07-21) + the 2026-07-27
+    // corroboration widening — decided by the pure `decideContentGateBypass` so
+    // the gateway runs the exact code the unit tests exercise. The rule, in
+    // brief (full rationale on that function):
+    //   - `live`   — framework-owned live `currentTurn`; bypasses unconditionally
+    //                (`decideSupersede`'s same-turnId check already bars it from
+    //                a DIFFERENT ended turn's record).
     //   - `latest-ended` — the ambiguous DM/late-reply fallback the marko fix
-    //                actually needs; bypass ONLY when no decoupled completion is
-    //                in the window (marker-absence ⇒ own answer).
-    // The `quoted` / `origin` tiers resolve from MODEL-SUPPLIED args
-    // (`args.reply_to` / `args.origin_turn_id`), so a reply can steer ITSELF onto
-    // a DIFFERENT ended turn's record — with marker-absence they used to bypass
-    // the content gate and silently edit-over that turn's delivered answer (the
-    // #3429 double-loss, executed by Fable). Those tiers therefore NEVER bypass:
-    // they always go through the content gate, so foreign content sends fresh and
-    // only a genuine same-answer reply collapses.
-    const replyIsOwnAnswer =
-      ownerTier === 'live' || (ownerTier === 'latest-ended' && !handbackCouldOwnReply)
+    //                needs; bypass ONLY when no decoupled completion is in the
+    //                window (marker-absence ⇒ own answer).
+    //   - `origin` / `quoted` — MODEL-SUPPLIED attributions, so they bypass ONLY
+    //                when CORROBORATED: the turn they resolve must be the same
+    //                turn the framework-derived, TTL-bounded `latestEndedTurnId`
+    //                resolves, and no handback may be in the window. A reply that
+    //                steers itself onto a DIFFERENT ended turn fails
+    //                corroboration and keeps the content gate, so the Fable
+    //                silent-edit-over stays closed; a reply that merely echoes
+    //                its OWN turn no longer loses the collapse it would have got
+    //                by omitting the echo entirely (the observed 2026-07-27
+    //                `via=origin` duplicate).
+    const replyIsOwnAnswer = decideContentGateBypass({
+      tier: ownerTier,
+      resolvedTurnId,
+      candidates: ownerCandidates,
+      handbackCouldOwnReply,
+    })
     const decision = flushedTurnSupersede.take(
       chat_id,
       gateThreadId,
@@ -1114,7 +1137,12 @@ export async function sendReply(
       if (decision.reason === 'new-content') {
         process.stderr.write(
           `telegram gateway: reply: flush supersede declined — new content (#3429) ` +
-          `chatId=${chat_id} ownerTurnId=${JSON.stringify(resolvedTurnId)}; sending fresh\n`,
+          `chatId=${chat_id} ownerTurnId=${JSON.stringify(resolvedTurnId)} ` +
+          // WHY the bypass didn't apply — without these two fields the
+          // 2026-07-27 duplicate looked like a pure text-matcher failure and
+          // took a log-archive dig to attribute to the tier restriction.
+          `tier=${ownerTier} latestEnded=${JSON.stringify(ownerCandidates.latestEndedTurnId)} ` +
+          `handbackInWindow=${handbackCouldOwnReply}; sending fresh\n`,
         )
       }
       if (suppressByLatch) {

--- a/telegram-plugin/reply-owner-resolve.ts
+++ b/telegram-plugin/reply-owner-resolve.ts
@@ -144,6 +144,80 @@ export function resolveReplyOwnerTurnId(candidates: ReplyOwnerCandidates): strin
 }
 
 /**
+ * Whether the supersede path may BYPASS the #3429 content gate — i.e. treat the
+ * landing reply as this flushed turn's OWN answer and collapse the provisional
+ * flush REGARDLESS of the model having reworded it.
+ *
+ * ## Why this is not simply "the tier is positive"
+ *
+ * The pre-existing rule was `tier === 'live' || (tier === 'latest-ended' &&
+ * !handbackCouldOwnReply)`. `origin` and `quoted` were excluded WHOLESALE
+ * because both derive from MODEL-SUPPLIED args (`args.origin_turn_id` /
+ * `args.reply_to`): a reply can STEER its own attribution onto a DIFFERENT
+ * ended turn and, with the gate bypassed, silently edit over that turn's
+ * delivered answer (the #3429 double-loss, executed by Fable 2026-07-21).
+ *
+ * That wholesale exclusion over-fires. Observed 2026-07-27 on a DM agent (two
+ * answers delivered twice): the answer-ready quiescence flush posted the turn's
+ * composed prose as message A, the model then fired `reply` with a REWORDED
+ * version of the SAME answer, and — because it had echoed `origin_turn_id` back
+ * pointing at its OWN turn — the tier resolved `origin` rather than
+ * `latest-ended`, so no bypass applied and the content gate declined on the
+ * rewording (`reply: flush supersede declined — new content (#3429)`). Message B
+ * shipped as a visible duplicate. Had the model simply OMITTED the echo, the
+ * identical reply would have resolved `latest-ended` and collapsed to ONE
+ * message. The exclusion punished the model for supplying MORE information.
+ *
+ * ## The rule: corroborate the steerable tier, don't blanket-ban it
+ *
+ * A model-supplied attribution is dangerous only when it points somewhere the
+ * FRAMEWORK would not have gone on its own. So `origin`/`quoted` bypass the
+ * content gate IFF the turn they resolve is the SAME turn the framework-derived,
+ * TTL-bounded `latest-ended` candidate resolves — a candidate computed from
+ * `findLatestEndedTurnForChat` with no model input at all.
+ *
+ * This grants ZERO new capability, which is the safety argument: any reply that
+ * reaches the bypass via a corroborated `origin`/`quoted` attribution could
+ * already have reached it by omitting `origin_turn_id`/`reply_to` entirely and
+ * landing on `latest-ended` with the same turn and the same outcome. Steering to
+ * a DIFFERENT ended turn breaks corroboration (`origin` id ≠ latest-ended id),
+ * so the gate holds and the #3429/Fable silent-edit-over defence is untouched.
+ *
+ * `latest-ended` corroborates itself trivially (its resolved id IS the
+ * latest-ended candidate), so the rule below SUBSUMES the previous behaviour on
+ * that tier rather than changing it.
+ *
+ * `live` keeps its unconditional bypass: `currentTurn` is framework-owned, and
+ * `decideSupersede`'s same-turnId requirement already bars it from reaching a
+ * DIFFERENT ended turn's record. `none` never bypasses (nothing to attribute).
+ */
+export function decideContentGateBypass(input: {
+  /** The winning owner tier (`resolveReplyOwnerTier`). */
+  tier: ReplyOwnerTier
+  /** The owner turnId the supersede will act on (`resolveReplyOwnerTurnId`). */
+  resolvedTurnId: string | null
+  /** The SAME candidate set both of the above were derived from — supplies the
+   *  framework-derived `latestEndedTurnId` plus its freshness bound, so the
+   *  corroboration reuses the EXACT TTL rule `resolveReplyOwnerTier` applies
+   *  instead of duplicating it. */
+  candidates: ReplyOwnerCandidates
+  /** True when a decoupled-completion inbound (`subagent_handback`) was enqueued
+   *  in this chat AFTER the owner turn ended and within the supersede TTL — the
+   *  ambiguous window where the late reply might BE that handback rather than
+   *  the turn's own answer. Keeps the content gate on every non-`live` tier. */
+  handbackCouldOwnReply: boolean
+}): boolean {
+  if (input.tier === 'live') return true
+  if (input.tier === 'none') return false
+  if (input.handbackCouldOwnReply) return false
+  if (!latestEndedAccepted(input.candidates)) return false
+  return (
+    input.resolvedTurnId != null &&
+    input.resolvedTurnId === input.candidates.latestEndedTurnId
+  )
+}
+
+/**
  * The answer-delivered latch value — SOURCE-TAGGED (#3426).
  *
  * `false`   — no answer delivered this turn (latch unarmed).

--- a/telegram-plugin/tests/narrative-lane-golden.test.ts
+++ b/telegram-plugin/tests/narrative-lane-golden.test.ts
@@ -35,6 +35,28 @@ import { FlushedTurnSupersedeRegistry } from '../flushed-turn-supersede.js'
 import { BackstopDeliveryLedger } from '../gateway/backstop-delivery.js'
 import { redact } from '../secret-detect/redact.js'
 import type { CurrentTurn, NarrativeLaneDeps } from '../gateway/gateway.js'
+import type { ReplyOwnerTier } from '../reply-owner-resolve.js'
+
+/** The owner-resolution shape `resolveReplyOwnerTurn` returns, including the
+ *  candidate set the content-gate bypass corroborates against. These fixtures
+ *  never exercise the supersede path, so the candidates mirror the resolved turn
+ *  (the corroborated shape) with no override needed. */
+function ownerRes(turn: CurrentTurn | null, tier: ReplyOwnerTier) {
+  const id = turn?.turnId ?? null
+  return {
+    turn,
+    tier,
+    candidates: {
+      liveTurnId: tier === 'live' ? id : null,
+      originTurnId: null,
+      quotedTurnId: null,
+      latestEndedTurnId: id,
+      latestEndedAgeMs: 1_000,
+      latestEndedTtlMs: 60_000,
+    },
+  }
+}
+
 
 const CHAT = '1001'
 
@@ -371,7 +393,7 @@ function makeSendReplyDeps(dedup: OutboundDedupCache) {
     assertSendable: () => {},
     statusKey: key,
     streamKey: key,
-    resolveReplyOwnerTurn: () => ({ turn: null, tier: 'none' as const }),
+    resolveReplyOwnerTurn: () => ownerRes(null, 'none'),
     getLastSubagentHandbackAt: () => null,
     findTurnByOriginId: () => null,
     findTurnByQuotedMessageId: () => null,

--- a/telegram-plugin/tests/reply-owner-resolve.test.ts
+++ b/telegram-plugin/tests/reply-owner-resolve.test.ts
@@ -34,6 +34,7 @@ import {
   resolveReplyOwnerTurnId,
   resolveReplyOwnerTier,
   decideAnswerLatchSuppression,
+  decideContentGateBypass,
   type ReplyOwnerCandidates,
   type AnswerDeliveredLatch,
 } from '../reply-owner-resolve.js'
@@ -682,6 +683,178 @@ describe('resolveReplyOwnerTier — precedence + latest-ended TTL bound', () => 
     for (const s of shapes) {
       // The id the winning tier points at equals what the id resolver returns.
       expect(resolveReplyOwnerTurnId(s)).toBe(idForTier(s))
+    }
+  })
+})
+
+/**
+ * `decideContentGateBypass` — WHEN the supersede path may treat a landing reply
+ * as this flushed turn's own answer and collapse the provisional flush even
+ * though the model REWORDED it.
+ *
+ * The rule replaced a blanket ban on the model-supplied `origin`/`quoted` tiers
+ * with CORROBORATION against the framework-derived `latestEndedTurnId`. The two
+ * properties that matter, both asserted below as outcomes:
+ *
+ *   - it closes the 2026-07-27 duplicate: a reply that echoes `origin_turn_id`
+ *     for its OWN turn now bypasses, exactly as it would have by omitting the
+ *     echo (the blanket ban punished the extra information);
+ *   - it grants ZERO new capability: for every candidate shape, a corroborated
+ *     `origin`/`quoted` bypass is reachable by dropping the model-supplied ids
+ *     and landing on `latest-ended` — so nothing bypasses that could not
+ *     already, and a STEERED attribution (pointing at a different turn than the
+ *     framework resolves) still cannot.
+ */
+describe('decideContentGateBypass — corroborated bypass of the #3429 content gate', () => {
+  const OWNER = 'turn-OWNER'
+  const OTHER = 'turn-OTHER'
+
+  /** Candidates whose framework-derived latest-ended IS `latestEnded`, fresh. */
+  const cands = (over: Partial<ReplyOwnerCandidates> = {}): ReplyOwnerCandidates => ({
+    liveTurnId: null,
+    originTurnId: null,
+    quotedTurnId: null,
+    latestEndedTurnId: OWNER,
+    latestEndedAgeMs: 30_000,
+    latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
+    ...over,
+  })
+
+  it('THE 2026-07-27 INCIDENT: an `origin` echo pointing at the SAME turn the ' +
+    'framework resolves bypasses the gate (pre-fix: banned → visible duplicate)', () => {
+    expect(
+      decideContentGateBypass({
+        tier: 'origin',
+        resolvedTurnId: OWNER,
+        candidates: cands({ originTurnId: OWNER }),
+        handbackCouldOwnReply: false,
+      }),
+    ).toBe(true)
+  })
+
+  it('a `quoted` attribution corroborated the same way also bypasses', () => {
+    expect(
+      decideContentGateBypass({
+        tier: 'quoted',
+        resolvedTurnId: OWNER,
+        candidates: cands({ quotedTurnId: OWNER }),
+        handbackCouldOwnReply: false,
+      }),
+    ).toBe(true)
+  })
+
+  it('THE FABLE VECTOR stays closed: an `origin`/`quoted` attribution STEERED onto ' +
+    'a different turn than the framework resolves never bypasses', () => {
+    for (const tier of ['origin', 'quoted'] as const) {
+      expect(
+        decideContentGateBypass({
+          tier,
+          resolvedTurnId: OTHER,
+          candidates: cands({
+            originTurnId: tier === 'origin' ? OTHER : null,
+            quotedTurnId: tier === 'quoted' ? OTHER : null,
+            latestEndedTurnId: OWNER,
+          }),
+          handbackCouldOwnReply: false,
+        }),
+      ).toBe(false)
+    }
+  })
+
+  it('a decoupled completion in the window keeps the gate on EVERY non-live tier', () => {
+    for (const tier of ['origin', 'quoted', 'latest-ended'] as const) {
+      expect(
+        decideContentGateBypass({
+          tier,
+          resolvedTurnId: OWNER,
+          candidates: cands({
+            originTurnId: tier === 'origin' ? OWNER : null,
+            quotedTurnId: tier === 'quoted' ? OWNER : null,
+          }),
+          handbackCouldOwnReply: true,
+        }),
+      ).toBe(false)
+    }
+  })
+
+  it('`live` bypasses unconditionally — even inside a handback window ' +
+    '(framework-owned, and decideSupersede bars it from another turn record)', () => {
+    expect(
+      decideContentGateBypass({
+        tier: 'live',
+        resolvedTurnId: OWNER,
+        candidates: cands({ liveTurnId: OWNER }),
+        handbackCouldOwnReply: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('`none` never bypasses (nothing to attribute the reply to)', () => {
+    expect(
+      decideContentGateBypass({
+        tier: 'none',
+        resolvedTurnId: null,
+        candidates: cands({ latestEndedTurnId: null }),
+        handbackCouldOwnReply: false,
+      }),
+    ).toBe(false)
+  })
+
+  it('a STALE framework candidate corroborates NOTHING — the F2 freshness bound ' +
+    'still denies a past-TTL turn any bypass authority', () => {
+    const stale = cands({
+      originTurnId: OWNER,
+      latestEndedAgeMs: DEFAULT_SUPERSEDE_TTL_MS + 1,
+    })
+    expect(
+      decideContentGateBypass({
+        tier: 'origin',
+        resolvedTurnId: OWNER,
+        candidates: stale,
+        handbackCouldOwnReply: false,
+      }),
+    ).toBe(false)
+  })
+
+  it('`latest-ended` behaviour is UNCHANGED by the widening (it corroborates itself)', () => {
+    expect(
+      decideContentGateBypass({
+        tier: 'latest-ended',
+        resolvedTurnId: OWNER,
+        candidates: cands(),
+        handbackCouldOwnReply: false,
+      }),
+    ).toBe(true)
+  })
+
+  // The safety argument, asserted rather than asserted-in-prose: every shape that
+  // bypasses via a model-supplied tier ALSO bypasses with those model-supplied
+  // ids stripped (i.e. by the model simply omitting origin_turn_id / reply_to).
+  // So the widening hands a reply no reach it did not already have.
+  it('ZERO new capability: any corroborated origin/quoted bypass is reachable ' +
+    'with the model-supplied ids stripped', () => {
+    const shapes: Array<{ tier: 'origin' | 'quoted'; id: string; c: ReplyOwnerCandidates }> = [
+      { tier: 'origin', id: OWNER, c: cands({ originTurnId: OWNER }) },
+      { tier: 'quoted', id: OWNER, c: cands({ quotedTurnId: OWNER }) },
+      { tier: 'origin', id: OTHER, c: cands({ originTurnId: OTHER }) },
+      { tier: 'quoted', id: OTHER, c: cands({ quotedTurnId: OTHER, latestEndedTurnId: OTHER }) },
+    ]
+    for (const s of shapes) {
+      const withModelIds = decideContentGateBypass({
+        tier: s.tier,
+        resolvedTurnId: s.id,
+        candidates: s.c,
+        handbackCouldOwnReply: false,
+      })
+      // Strip the model-supplied ids: the framework alone resolves the owner.
+      const stripped: ReplyOwnerCandidates = { ...s.c, originTurnId: null, quotedTurnId: null }
+      const withoutModelIds = decideContentGateBypass({
+        tier: resolveReplyOwnerTier(stripped),
+        resolvedTurnId: resolveReplyOwnerTurnId(stripped),
+        candidates: stripped,
+        handbackCouldOwnReply: false,
+      })
+      if (withModelIds) expect(withoutModelIds).toBe(true)
     }
   })
 })

--- a/telegram-plugin/tests/send-reply-golden.test.ts
+++ b/telegram-plugin/tests/send-reply-golden.test.ts
@@ -45,11 +45,50 @@ import {
   type VoiceOutPlan,
 } from '../gateway/outbound-send-path.js'
 import { OutboundDedupCache } from '../recent-outbound-dedup.js'
-import { FlushedTurnSupersedeRegistry } from '../flushed-turn-supersede.js'
+import {
+  FlushedTurnSupersedeRegistry,
+  DEFAULT_SUPERSEDE_TTL_MS,
+  flushedAnswerMatchesReply,
+} from '../flushed-turn-supersede.js'
+import type { ReplyOwnerTier, ReplyOwnerCandidates } from '../reply-owner-resolve.js'
 import { SubagentHandbackMarker, stampsHandbackMarker } from '../gateway/subagent-handback-marker.js'
 import { createPendingInboundBuffer } from '../gateway/pending-inbound-buffer.js'
 import { redact } from '../secret-detect/redact.js'
 import type { CurrentTurn, Access } from '../gateway/gateway.js'
+
+/**
+ * Build the owner-resolution result the gateway's `resolveReplyOwnerTurn`
+ * returns, INCLUDING the candidate set the content-gate bypass corroborates
+ * against (`decideContentGateBypass`).
+ *
+ * Default candidates model the CORROBORATED shape: the resolved turn is also the
+ * framework-derived `latestEndedTurnId`, fresh within the supersede TTL — what
+ * the real resolver produces for a late reply to the chat's most recent turn,
+ * whether or not the model also echoed `origin_turn_id` / `reply_to`. Pass
+ * `over` to model a model-STEERED attribution (an `origin`/`quoted` id pointing
+ * at a turn the framework would NOT have resolved) or a stale latest-ended.
+ */
+function ownerRes(
+  turn: CurrentTurn | null,
+  tier: ReplyOwnerTier,
+  over: Partial<ReplyOwnerCandidates> = {},
+): { turn: CurrentTurn | null; tier: ReplyOwnerTier; candidates: ReplyOwnerCandidates } {
+  const id = turn?.turnId ?? null
+  return {
+    turn,
+    tier,
+    candidates: {
+      liveTurnId: tier === 'live' ? id : null,
+      originTurnId: tier === 'origin' ? id : null,
+      quotedTurnId: tier === 'quoted' ? id : null,
+      latestEndedTurnId: id,
+      latestEndedAgeMs: 30_000,
+      latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
+      ...over,
+    },
+  }
+}
+
 
 // ── fake bot API ──────────────────────────────────────────────────────────
 
@@ -211,7 +250,7 @@ function makeHarness(opts?: {
     assertSendable: () => {},
     statusKey: key,
     streamKey: key,
-    resolveReplyOwnerTurn: () => ({ turn: null, tier: 'none' as const }),
+    resolveReplyOwnerTurn: () => ownerRes(null, 'none'),
     getLastSubagentHandbackAt: () => null,
     findTurnByOriginId: () => null,
     findTurnByQuotedMessageId: () => null,
@@ -640,7 +679,7 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     // is the AMBIGUOUS fallback tier: the content gate applies here, so a
     // genuinely-new handback sends fresh while the turn's own contained answer
     // still supersedes.
-    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'latest-ended' })
+    h.deps.resolveReplyOwnerTurn = () => ownerRes(owner, 'latest-ended')
   }
 
   it('CORE REGRESSION (red pre-fix): a handback with genuinely NEW content sends a ' +
@@ -712,7 +751,7 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     const owner = makeFlushDeliveredEndedTurn()
     // NO registry record (the post-fire pre-record window); owner resolution
     // still recovers the ended flush-armed turn via the latest-ended tier.
-    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'latest-ended' })
+    h.deps.resolveReplyOwnerTurn = () => ownerRes(owner, 'latest-ended')
 
     const res = await sendReply(h.deps, req(HANDBACK))
 
@@ -726,7 +765,7 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     'window is still suppressed (the #2996 Part 2 backstop holds)', async () => {
     const h = makeHarness()
     const owner = makeFlushDeliveredEndedTurn()
-    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'latest-ended' })
+    h.deps.resolveReplyOwnerTurn = () => ownerRes(owner, 'latest-ended')
 
     const res = await sendReply(h.deps, req(FLUSHED_TEXT))
 
@@ -774,7 +813,7 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     // Late DM reply: latest-ended tier (the path the tier discriminator MISSES),
     // and crucially NO subagent_handback was enqueued for this chat after the
     // turn ended — so the reply is the flushed turn's OWN answer.
-    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'latest-ended' })
+    h.deps.resolveReplyOwnerTurn = () => ownerRes(owner, 'latest-ended')
     h.deps.getLastSubagentHandbackAt = () => null
 
     const res = await sendReply(h.deps, req(REWORDED_SAME_TURN_ANSWER))
@@ -801,7 +840,7 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     const h = makeHarness()
     const owner = makeFlushDeliveredEndedTurn()
     seedRecord(h, owner)
-    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'latest-ended' })
+    h.deps.resolveReplyOwnerTurn = () => ownerRes(owner, 'latest-ended')
     // A background sub-agent handback was enqueued for this chat AFTER the turn
     // ended (now-30s) and within the 60s TTL (now-15s) — this reply might BE it.
     h.deps.getLastSubagentHandbackAt = () => Date.now() - 15_000
@@ -838,7 +877,7 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     // `quoted`. A handback IS in flight, so a positive tier must NOT override the
     // #3429 content gate — else the reworded handback text silently edits over
     // the flushed turn's DELIVERED answer (Telegram edits don't re-notify).
-    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'quoted' })
+    h.deps.resolveReplyOwnerTurn = () => ownerRes(owner, 'quoted')
     h.deps.getLastSubagentHandbackAt = () => Date.now() - 15_000
 
     const res = await sendReply(h.deps, req(REWORDED_SAME_TURN_ANSWER))
@@ -865,7 +904,7 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     const h = makeHarness()
     const owner = makeFlushDeliveredEndedTurn()
     seedRecord(h, owner)
-    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'live' })
+    h.deps.resolveReplyOwnerTurn = () => ownerRes(owner, 'live')
     h.deps.getLastSubagentHandbackAt = () => Date.now() - 15_000
 
     const res = await sendReply(h.deps, req(REWORDED_SAME_TURN_ANSWER))
@@ -910,7 +949,7 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     const h = makeHarness()
     const owner = makeFlushDeliveredEndedTurn()
     seedRecord(h, owner)
-    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'latest-ended' })
+    h.deps.resolveReplyOwnerTurn = () => ownerRes(owner, 'latest-ended')
     // The gateway reads the marker the boot-replay stamped (chat-wide gate).
     h.deps.getLastSubagentHandbackAt = (chatId) => marker.lastAtInChat(chatId)
 
@@ -978,7 +1017,7 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     // The topic-A handback's reply is STEERED to topic B (message_thread_id=222)
     // and resolves topic B's ended turn chat-wide (latest-ended), carrying FOREIGN
     // content. The gate read is chat-wide, so the topic-A stamp is seen.
-    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner as CurrentTurn, tier: 'latest-ended' })
+    h.deps.resolveReplyOwnerTurn = () => ownerRes(owner as CurrentTurn, 'latest-ended')
     h.deps.getLastSubagentHandbackAt = (chatId) => marker.lastAtInChat(chatId)
 
     const res = await sendReply(
@@ -1018,7 +1057,7 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
       { turnId: (owner as CurrentTurn).turnId, messageIds: [FLUSH_MSG_ID], text: FLUSHED_TEXT },
       Date.now(),
     )
-    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner as CurrentTurn, tier: 'latest-ended' })
+    h.deps.resolveReplyOwnerTurn = () => ownerRes(owner as CurrentTurn, 'latest-ended')
     h.deps.getLastSubagentHandbackAt = () => null // no handback anywhere
 
     const res = await sendReply(h.deps, req(REWORDED_SAME_TURN_ANSWER, { message_thread_id: TOPIC }))
@@ -1050,7 +1089,7 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     // The reply resolves the flush-delivered ENDED turn via the ambiguous
     // latest-ended tier (no live turn, no positive attribution) and carries
     // FOREIGN content (a worker report, not this turn's answer nor a rewording).
-    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'latest-ended' })
+    h.deps.resolveReplyOwnerTurn = () => ownerRes(owner, 'latest-ended')
     // A decoupled completion IS in the window (the marker stamped it) — so this
     // late reply might BE it. The invariant keeps the content gate.
     h.deps.getLastSubagentHandbackAt = () => Date.now() - 15_000
@@ -1091,25 +1130,31 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     expect(stampsHandbackMarker(undefined)).toBe(false)
   })
 
-  // ─── MUST-FIX 1 (dup-audit / Fable): model-steerable tiers NEVER bypass ───
+  // ─── MUST-FIX 1 (dup-audit / Fable): an UNCORROBORATED steerable tier ───
   //
   // The `quoted`/`origin` tiers resolve from MODEL-supplied args (reply_to /
-  // origin_turn_id), so a reply can steer ITSELF onto a different ended turn's
-  // record. Marker-absence proves "own answer" only for the framework-derived
-  // latest-ended tier — a quoted/origin resolution with no marker is NOT
-  // ownership evidence. Fable executed this exact path (quoted tier, no marker,
-  // foreign content → editMessageText ×1 over the flushed answer). With the tier
-  // restriction, quoted/origin ALWAYS traverse the content gate → foreign content
-  // sends FRESH, the flushed answer untouched. RED on pre-fix code
-  // (replyIsOwnAnswer = tier==='live' || !handbackCouldOwnReply → quoted bypassed).
-  it('MUST-FIX 1: a quoted-tier reply with NO marker and FOREIGN content does NOT ' +
-    'bypass the content gate — FRESH send, flushed answer never edited/deleted', async () => {
+  // origin_turn_id), so a reply can steer ITSELF onto a DIFFERENT ended turn's
+  // record and — with the content gate bypassed — silently edit over that turn's
+  // delivered answer. Fable executed this exact path (quoted tier, no marker,
+  // foreign content → editMessageText ×1 over the flushed answer).
+  //
+  // What blocks it is CORROBORATION, not a blanket tier ban: the steered
+  // attribution points at a turn the FRAMEWORK-derived `latestEndedTurnId` does
+  // NOT resolve, so `decideContentGateBypass` declines and the content gate
+  // holds. The `latestEndedTurnId` override below is what makes this test model
+  // steering rather than a plain self-echo.
+  it('MUST-FIX 1: a quoted-tier reply STEERED onto a different turn than the ' +
+    'framework resolves, with NO marker and FOREIGN content, does NOT bypass the ' +
+    'content gate — FRESH send, flushed answer never edited/deleted', async () => {
     const h = makeHarness()
     const owner = makeFlushDeliveredEndedTurn()
     seedRecord(h, owner)
-    // Model-steered `quoted` attribution to a DIFFERENT ended flushed turn, with
-    // NO decoupled completion anywhere in the chat (the residual F1 vector).
-    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'quoted' })
+    // Model-steered `quoted` attribution onto the flushed turn, while the
+    // framework's own latest-ended candidate is a DIFFERENT, newer turn — the
+    // divergence that proves the attribution is model-driven. No decoupled
+    // completion anywhere in the chat (the residual F1 vector).
+    h.deps.resolveReplyOwnerTurn = () =>
+      ownerRes(owner, 'quoted', { latestEndedTurnId: `${CHAT}:_#ended-99` })
     h.deps.getLastSubagentHandbackAt = () => null
 
     const res = await sendReply(h.deps, req(HANDBACK))
@@ -1140,7 +1185,7 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     const h = makeHarness()
     const owner = makeFlushDeliveredEndedTurn()
     seedRecord(h, owner)
-    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'quoted' })
+    h.deps.resolveReplyOwnerTurn = () => ownerRes(owner, 'quoted')
     h.deps.getLastSubagentHandbackAt = () => null
 
     const res = await sendReply(h.deps, req(CANONICAL_REPLY))
@@ -1150,5 +1195,168 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     expect(edits[0]!.message_id).toBe(FLUSH_MSG_ID)
     expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(0)
     expect(res.content[0]!.text).toMatch(/^sent/)
+  })
+
+  // ─── 2026-07-27 DM incident: a CORROBORATED `origin` echo must collapse ───
+  //
+  // The observed failure (a DM agent delivered two answers twice — a flushed
+  // copy plus a reworded `reply` copy, each time):
+  //
+  //   1. the answer-ready quiescence flush posted the turn's composed prose as
+  //      message A ("turn-flush firing — N chars without reply tool");
+  //   2. the silent-end Stop hook told the agent its answer had not reached the
+  //      user, so it fired `reply` with a RE-WORDED version of the same answer;
+  //   3. the agent also echoed `origin_turn_id` back — pointing at its OWN turn —
+  //      so owner resolution won on the `origin` tier, not `latest-ended`
+  //      (`reply-route ... via=origin late=true originTurn=<same turn>`);
+  //   4. `origin` was banned outright from the content-gate bypass, so the gate
+  //      ran, the rewording defeated both equality and containment, and the
+  //      gateway logged `flush supersede declined — new content (#3429)` and
+  //      shipped message B — a visible duplicate.
+  //
+  // Note what the incident was NOT: not a captured-prose delivery (this is the
+  // quiescence turn-flush path), and not a text-matcher failure that a smarter
+  // matcher would fix. Rewording is model-dependent and cannot be matched
+  // reliably; the deterministic signal is that the echoed turn is the SAME turn
+  // the framework's own `latestEndedTurnId` resolves. This test drives the REAL
+  // send path over that exact shape.
+  it('2026-07-27 REGRESSION: a reworded same-turn reply that ALSO echoes ' +
+    'origin_turn_id for its own turn collapses to ONE message (corroborated ' +
+    '`origin` tier bypasses the content gate)', async () => {
+    const h = makeHarness()
+    const owner = makeFlushDeliveredEndedTurn()
+    seedRecord(h, owner)
+    // `origin` tier — the model echoed origin_turn_id — but pointing at the SAME
+    // turn the framework-derived latestEndedTurnId resolves (ownerRes's default),
+    // i.e. corroborated: the model gained nothing it couldn't have had by
+    // omitting the echo entirely.
+    h.deps.resolveReplyOwnerTurn = () => ownerRes(owner, 'origin')
+    // No decoupled completion in the window — the reply is this turn's own answer.
+    h.deps.getLastSubagentHandbackAt = () => null
+
+    // The reworded answer defeats BOTH text paths the old gate relied on, so the
+    // test cannot pass by accident through `flushedAnswerMatchesReply`.
+    expect(flushedAnswerMatchesReply(FLUSHED_TEXT, REWORDED_SAME_TURN_ANSWER)).toBe(false)
+
+    const res = await sendReply(h.deps, req(REWORDED_SAME_TURN_ANSWER))
+
+    // OUTCOME: exactly ONE client-visible message. The flushed message A is
+    // corrected in place into the reworded answer; NO second bubble ships.
+    // (Pre-fix this was sendRichMessage ×1 alongside the surviving flush = the
+    // two Telegram messages the user actually received.)
+    const edits = h.calls.filter((c) => c.method === 'editMessageText')
+    expect(edits).toHaveLength(1)
+    expect(edits[0]!.message_id).toBe(FLUSH_MSG_ID)
+    expect(edits[0]!.text).toContain('every one of the twelve agents')
+    expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(0)
+    expect(res.content[0]!.text).toMatch(/^sent/)
+    // Record consumed — the flush is gone, not merely shadowed.
+    expect(
+      h.deps.flushedTurnSupersede.peek(CHAT, undefined, {
+        liveTurnId: OWNER_TURN_ID,
+        now: Date.now(),
+      }).reason,
+    ).toBe('no-record')
+  })
+
+  // The behaviour the old "new content" check was really protecting: an agent
+  // that deliberately sends a SECOND, genuinely different message in the same
+  // turn must not have its first one deleted. This is structural, not textual —
+  // the registry CONSUMES the record on supersede, so the second reply finds
+  // 'no-record' and can never reach the first message. No reply counter needed.
+  it('PRESERVED: a deliberate SECOND reply in the same turn does NOT delete or ' +
+    'edit the first — both messages survive', async () => {
+    const h = makeHarness()
+    const owner = makeFlushDeliveredEndedTurn()
+    seedRecord(h, owner)
+    h.deps.resolveReplyOwnerTurn = () => ownerRes(owner, 'origin')
+    h.deps.getLastSubagentHandbackAt = () => null
+
+    // Reply #1 — the reworded answer; supersedes the flush (one message so far).
+    await sendReply(h.deps, req(REWORDED_SAME_TURN_ANSWER))
+    const afterFirst = h.calls.length
+    expect(h.calls.filter((c) => c.method === 'editMessageText')).toHaveLength(1)
+
+    // Reply #2 — a deliberate follow-up in the SAME turn, genuinely new content.
+    const res = await sendReply(h.deps, req(HANDBACK))
+
+    const later = h.calls.slice(afterFirst)
+    // It ships as its OWN fresh notifying message…
+    const fresh = later.filter((c) => c.method === 'sendRichMessage')
+    expect(fresh).toHaveLength(1)
+    expect(fresh[0]!.text).toContain('migration audit')
+    expect(fresh[0]!.message_id).not.toBe(FLUSH_MSG_ID)
+    // …and it neither deletes nor re-edits the message the first reply owns.
+    expect(later.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
+    expect(later.filter((c) => c.method === 'editMessageText')).toHaveLength(0)
+    expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
+  })
+
+  // Same corroboration rule on the other steerable tier, so a model that quotes
+  // instead of echoing gets the same collapse rather than a duplicate.
+  it('a reworded same-turn reply on a CORROBORATED `quoted` tier also collapses ' +
+    'to one message', async () => {
+    const h = makeHarness()
+    const owner = makeFlushDeliveredEndedTurn()
+    seedRecord(h, owner)
+    h.deps.resolveReplyOwnerTurn = () => ownerRes(owner, 'quoted')
+    h.deps.getLastSubagentHandbackAt = () => null
+
+    const res = await sendReply(h.deps, req(REWORDED_SAME_TURN_ANSWER))
+
+    const edits = h.calls.filter((c) => c.method === 'editMessageText')
+    expect(edits).toHaveLength(1)
+    expect(edits[0]!.message_id).toBe(FLUSH_MSG_ID)
+    expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(0)
+    expect(res.content[0]!.text).toMatch(/^sent/)
+  })
+
+  // The corroboration must not resurrect the handback hazard: even a self-echoed
+  // `origin` attribution keeps the content gate while a decoupled completion is
+  // in the window, because the late reply might BE that completion.
+  it('a corroborated `origin` reply STILL keeps the content gate while a handback ' +
+    'is in the window — foreign content sends FRESH, flush untouched', async () => {
+    const h = makeHarness()
+    const owner = makeFlushDeliveredEndedTurn()
+    seedRecord(h, owner)
+    h.deps.resolveReplyOwnerTurn = () => ownerRes(owner, 'origin')
+    h.deps.getLastSubagentHandbackAt = () => Date.now() - 15_000
+
+    const res = await sendReply(h.deps, req(HANDBACK))
+
+    const fresh = h.calls.filter((c) => c.method === 'sendRichMessage')
+    expect(fresh).toHaveLength(1)
+    expect(fresh[0]!.text).toContain('migration audit')
+    expect(h.calls.filter((c) => c.method === 'editMessageText')).toHaveLength(0)
+    expect(h.calls.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
+    expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
+    // The flushed answer stands — its record is intact for the turn's own replay.
+    expect(
+      h.deps.flushedTurnSupersede.peek(CHAT, undefined, {
+        liveTurnId: OWNER_TURN_ID,
+        replyText: CANONICAL_REPLY,
+        now: Date.now(),
+      }).supersede,
+    ).toBe(true)
+  })
+
+  // A STALE framework candidate must not corroborate anything: the latest-ended
+  // freshness bound (F2) is what stops an old turn inheriting deletion authority.
+  it('a `origin` echo does NOT bypass when the framework latest-ended candidate ' +
+    'is STALE (past the supersede TTL) — content gate holds', async () => {
+    const h = makeHarness()
+    const owner = makeFlushDeliveredEndedTurn()
+    seedRecord(h, owner)
+    h.deps.resolveReplyOwnerTurn = () =>
+      ownerRes(owner, 'origin', { latestEndedAgeMs: DEFAULT_SUPERSEDE_TTL_MS + 1 })
+    h.deps.getLastSubagentHandbackAt = () => null
+
+    const res = await sendReply(h.deps, req(REWORDED_SAME_TURN_ANSWER))
+
+    // Gate held → fresh send, flushed message untouched.
+    expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(1)
+    expect(h.calls.filter((c) => c.method === 'editMessageText')).toHaveLength(0)
+    expect(h.calls.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
+    expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
   })
 })

--- a/telegram-plugin/tests/stream-render-golden.test.ts
+++ b/telegram-plugin/tests/stream-render-golden.test.ts
@@ -39,6 +39,28 @@ import {
   TYPING_REFRESH_MS,
 } from '../typing-emitter.js'
 import type { CurrentTurn } from '../gateway/gateway.js'
+import type { ReplyOwnerTier } from '../reply-owner-resolve.js'
+
+/** The owner-resolution shape `resolveReplyOwnerTurn` returns, including the
+ *  candidate set the content-gate bypass corroborates against. These fixtures
+ *  never exercise the supersede path, so the candidates mirror the resolved turn
+ *  (the corroborated shape) with no override needed. */
+function ownerRes(turn: CurrentTurn | null, tier: ReplyOwnerTier) {
+  const id = turn?.turnId ?? null
+  return {
+    turn,
+    tier,
+    candidates: {
+      liveTurnId: tier === 'live' ? id : null,
+      originTurnId: null,
+      quotedTurnId: null,
+      latestEndedTurnId: id,
+      latestEndedAgeMs: 1_000,
+      latestEndedTtlMs: 60_000,
+    },
+  }
+}
+
 
 const CHAT = '1001'
 
@@ -251,7 +273,7 @@ function makeSendReplyDeps(dedup: OutboundDedupCache, sharedSupersede?: FlushedT
     assertSendable: () => {},
     statusKey: key,
     streamKey: key,
-    resolveReplyOwnerTurn: () => ({ turn: null, tier: 'none' as const }),
+    resolveReplyOwnerTurn: () => ownerRes(null, 'none'),
     getLastSubagentHandbackAt: () => null,
     findTurnByOriginId: () => null,
     findTurnByQuotedMessageId: () => null,
@@ -443,7 +465,7 @@ describe('F3 — flush record() → same-turn reworded reply collapse (end-to-en
     // The model's REAL reply lands late with a REWORDED version of the same
     // answer: no live turn, latest-ended tier, NO handback in flight (CASE A).
     const s = makeSendReplyDeps(new OutboundDedupCache(), supersede)
-    s.deps.resolveReplyOwnerTurn = () => ({ turn, tier: 'latest-ended' as const })
+    s.deps.resolveReplyOwnerTurn = () => ownerRes(turn, 'latest-ended')
     // (getLastSubagentHandbackAt returns null in the base deps → own answer.)
 
     const res = await sendReply(s.deps, req(REWORDED))
@@ -496,7 +518,7 @@ describe('F5 — take()-before-record() interleaving delivers exactly one messag
     ).toBe('no-record') // record genuinely not written yet
 
     const s = makeSendReplyDeps(new OutboundDedupCache(), supersede)
-    s.deps.resolveReplyOwnerTurn = () => ({ turn, tier: 'latest-ended' as const })
+    s.deps.resolveReplyOwnerTurn = () => ownerRes(turn, 'latest-ended')
     // The same answer landing again in the race window → latch backstop suppresses.
     const res = await sendReply(s.deps, req(ANSWER))
 


### PR DESCRIPTION
## Summary

A DM agent delivered the same answer twice, twice in a row: a flushed copy plus a re-worded `reply` copy. The gateway logged, with the right turn already in hand:

```
reply: flush supersede declined — new content (#3429) ownerTurnId="<the flushed turn>"; sending fresh
```

`origin` / `quoted` owner tiers now bypass the #3429 content gate when **corroborated** by the framework-derived `latestEndedTurnId`, instead of being banned outright.

## Why

The sequence: the answer-ready quiescence flush posted the turn's composed prose as message A → the silent-end Stop hook told the agent its answer had not reached the user → the agent fired `reply` with a re-worded version of the same answer. The flushed-turn supersede exists to collapse exactly that.

**It is not the text matcher.** `decideSupersede` already has a content-gate BYPASS for a reply positively attributable to the flushed turn's own answer, and rewording does not block it. The bypass was restricted to `live` + `latest-ended` because `origin` / `quoted` resolve from MODEL-SUPPLIED args (`origin_turn_id` / `reply_to`), so a reply can steer itself onto a *different* ended turn and silently edit over that turn's delivered answer (#3429, the Fable vector).

Here the agent echoed `origin_turn_id` back **pointing at its own turn** — `reply-route ... via=origin late=true` — so the tier resolved `origin`, the blanket ban applied, the content gate ran, and the rewording defeated both equality and containment. Had the agent simply *omitted* the echo, the identical reply would have landed on `latest-ended` and collapsed to one message. The ban punished the model for supplying more information.

**The fix corroborates rather than bans.** `origin` / `quoted` bypass only when the turn they resolve is the same turn the framework-derived, TTL-bounded `latestEndedTurnId` resolves, and no decoupled completion is in the window. This grants **zero new capability** — any corroborated bypass was already reachable by dropping the model-supplied ids and landing on `latest-ended` — so the silent-edit-over stays closed: steering to a different turn breaks corroboration and the gate holds. `latest-ended` corroborates itself (behaviour unchanged); `live` still bypasses unconditionally.

The decision moves into the pure `decideContentGateBypass` (`reply-owner-resolve.ts`), per the repo's `decide*` convention, so the gateway runs the exact code the tests exercise. The decline log now carries `tier=`, `latestEnded=`, `handbackInWindow=` — without them this read as a matcher failure and took a log-archive dig to attribute.

### Deliberately not done

- **No flush-kind field.** The incident was the *quiescence turn-flush*, not the captured-prose path, so restricting the collapse to captured-prose flushes would not have fixed it.
- **No per-turn reply counter.** "Only the first reply of a turn may supersede" is already structural: the registry CONSUMES the record on supersede, so a second reply finds `'no-record'` and can never reach the first message. Pinned by a test rather than a new counter.

## Test plan

- `send-reply-golden`: new outcome regression drives the **real** send path over the incident shape (reworded reply, corroborated `origin`, no handback) and asserts **one** surviving message with the flush corrected in place. It first asserts `flushedAnswerMatchesReply(...) === false`, so it cannot pass through the text path. **Red on the pre-fix rule** (3 new tests fail), green after.
- `send-reply-golden`: a deliberate **second** reply in the same turn neither deletes nor edits the first — both survive.
- The MUST-FIX 1 steering test now encodes the steering it describes (a divergent `latestEndedTurnId`) instead of relying on the tier label alone.
- `reply-owner-resolve`: unit coverage including a zero-new-capability property — every corroborated origin/quoted bypass is reachable with the model-supplied ids stripped.
- Full `telegram-plugin` vitest suite green locally: **504 files, 8307 tests**. `npm run lint` clean (gateway.ts came in 1 line *under* the anti-inflation ratchet).

Job spec: `reference/jobs/` — chat-is-source-of-truth; exactly one answer per turn reaches the user.

## Risk

Low. Strictly widens an existing bypass along a path that grants no new reach. Every #3429 / F1 / F2 defence test stays green unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)