### PR TITLE
docs(ci): merge queue is live — correct the stale status, teach agents the enqueue flow

### DIFF
--- a/.github/MERGE-QUEUE.md
+++ b/.github/MERGE-QUEUE.md
@@ -1,14 +1,23 @@
 # Merge queue — how CI reports on `gh-readonly-queue/...` refs
 
-> **Current state (verified 2026-07-26 13:20 AEST):** the merge queue is
-> **OFF**. Ruleset **16470166** (`main branch protection`) carries only
-> `deletion`, `non_fast_forward` and `required_status_checks` — there is
-> no `merge_queue` rule, and `repository.mergeQueue(branch:"main")` is
-> `null`. It was enabled earlier that day, wedged `main` for the reason
-> below, and was switched back off to unblock merging. **This document
-> and the `merge_group:` triggers it describes are the prerequisite for
-> turning it back on safely** — they are inert while it is off, and they
-> are what stops the outage recurring when it is turned on.
+> **Current state (verified live 2026-07-27 12:50 AEST):** the merge queue
+> is **ON**. Ruleset **16470166** (`main branch protection`) carries a
+> `merge_queue` rule alongside `deletion`, `non_fast_forward` and
+> `required_status_checks`, and `repository.mergeQueue(branch:"main")` is
+> non-null. Configuration: `merge_method: SQUASH`,
+> `grouping_strategy: ALLGREEN`, `min_entries_to_merge: 1`,
+> `min_entries_to_merge_wait_minutes: 5`, `max_entries_to_build: 5`,
+> `max_entries_to_merge: 5`, `check_response_timeout_minutes: 60`.
+>
+> History: enabled 2026-07-26, wedged `main` for the reason below, switched
+> back off the same day to unblock merging. The `merge_group:` triggers this
+> document describes were then added, and the queue was re-enabled. PRs
+> #3717 and #3718 went through on 2026-07-27 with all seven contexts
+> reporting on the queue ref, so the design is confirmed end to end.
+>
+> **The invariants below are now live behaviour, not a precondition.**
+> Breaking one no longer merely makes it unsafe to re-enable the queue — it
+> wedges `main` for everyone, immediately.
 
 Ruleset **16470166** (`main branch protection`) requires exactly these
 status checks (verified live against the ruleset — if this table and the
@@ -31,7 +40,7 @@ When a PR is enqueued, GitHub pushes a temporary
 **on that ref**. A workflow that only triggers on `pull_request` + `push`
 never runs there, so the contexts are never produced and the entry sits in
 `AWAITING_CHECKS` until `check_response_timeout_minutes` **ejects** it
-(60 minutes as the queue was configured on 2026-07-26).
+(60 minutes, per the ruleset's `merge_queue` rule).
 
 Every workflow producing a required context therefore carries a
 `merge_group:` trigger. `tests/ci-merge-queue-triggers.test.ts` enforces
@@ -140,7 +149,7 @@ of bug as the #2816 non-main-dispatch follow-up. Queue builds tag
 ## Diagnosing a stuck queue
 
 ```bash
-# Is the queue even enabled? null == off (it is off as of 2026-07-26).
+# Is the queue even enabled? null == off (it is ON as of 2026-07-27).
 gh api graphql -f query='
   { repository(owner:"switchroom", name:"switchroom") {
       mergeQueue(branch:"main") { id configuration {

--- a/skills/dev-protocol/SKILL.md
+++ b/skills/dev-protocol/SKILL.md
@@ -97,6 +97,19 @@ is not a rebuttal.
 
 - **CI is the full-suite authority.** Local scoped tests are a fast filter,
   never the merge evidence. Never claim done off a local run alone.
+- **`main` is behind a merge queue: `gh pr merge` ENQUEUES, it does not
+  merge.** The command exits 0 and the PR stays `OPEN`. The queue then re-runs
+  all seven required contexts on its own `gh-readonly-queue/main/pr-<n>-<sha>`
+  ref before landing anything, so "green on the PR" is necessary but not
+  sufficient. Never report a PR merged off that exit code — poll until its
+  state is `MERGED` and the commit is an ancestor of `origin/main`. Two flags
+  to know: `--delete-branch` is **rejected outright** while the queue is on
+  (delete the branch after it lands), and `--subject` is ignored, since the
+  queue composes the merge commit from the PR title plus `(#<pr>)` — so the PR
+  title is the commit title, write it accordingly. An entry stuck in
+  `AWAITING_CHECKS` means a required workflow is not listening for
+  `merge_group`; `.github/MERGE-QUEUE.md` owns that failure mode and the
+  invariants that prevent it.
 - **A test that wouldn't fail on the bug it guards is not a test.** Assert the
   observable outcome, not that the code path executed.
 - **Prefer a deterministic mechanism over prompt discipline.** If a check, a

--- a/tests/ci-merge-queue-triggers.test.ts
+++ b/tests/ci-merge-queue-triggers.test.ts
@@ -10,12 +10,15 @@
  * ever produced, and every enqueued PR sat in `AWAITING_CHECKS` until
  * `check_response_timeout_minutes: 60` ejected it. Nothing could merge.
  *
- * The queue was switched back OFF the same day to unblock `main` (as of
- * 2026-07-26 the ruleset has no `merge_queue` rule). These assertions are
- * therefore a PRECONDITION, not a description of live behaviour: they are
- * what makes it safe to turn the queue on again. Do not delete them
- * because "we don't use a merge queue" — that is exactly the state in
- * which the next person turns it on and wedges `main` a second time.
+ * The queue was switched back OFF the same day to unblock `main`, the
+ * `merge_group:` triggers were added, and it was RE-ENABLED: as of
+ * 2026-07-27 the ruleset carries a live `merge_queue` rule and PRs #3717
+ * and #3718 merged through it with all seven contexts reporting on the
+ * queue ref. These assertions are therefore a description of LIVE
+ * behaviour, not a precondition — breaking one wedges `main` for everyone
+ * immediately, rather than merely making it unsafe to re-enable the queue.
+ * Do not delete them because "we don't use a merge queue": that is exactly
+ * the state in which the next person turns it on and wedges `main` again.
  *
  * Why this test has to exist: EVERY invariant below is invisible on a
  * pull request. A PR run exercises the `pull_request` paths only; the


### PR DESCRIPTION
## Why

`.github/MERGE-QUEUE.md` and `tests/ci-merge-queue-triggers.test.ts` both still asserted the merge queue was **OFF**, and that their invariants were a *precondition* for safely turning it back on. It has since been turned back on.

That stale framing is the dangerous kind. It tells the next reader these invariants are hypothetical insurance, when breaking one now wedges `main` for everyone **immediately**.

## Verified live

Against ruleset **16470166**, a `merge_queue` rule is present and `repository.mergeQueue(branch:"main")` is non-null:

| setting | value |
|---|---|
| `merge_method` | `SQUASH` |
| `grouping_strategy` | `ALLGREEN` |
| `min_entries_to_merge` | 1 |
| `min_entries_to_merge_wait_minutes` | 5 |
| `max_entries_to_build` / `max_entries_to_merge` | 5 / 5 |
| `check_response_timeout_minutes` | 60 |

PRs #3717 and #3718 merged through it on 2026-07-27, with all seven required contexts reporting on the `gh-readonly-queue/main/pr-<n>-<sha>` ref. The `merge_group:` triggers the doc describes are confirmed working end to end — this is the design being exercised for real, not a prediction.

I also removed the two other places the doc pinned the OFF state: the ejection timeout is now cited from the ruleset rather than "as configured on 2026-07-26", and the diagnostic snippet's comment no longer tells you the answer to the question it is asking you to look up.

## The agent-facing half

`skills/dev-protocol/SKILL.md` described the pipeline as "merge on CI green" and never mentioned that `main` sits behind a queue. An agent following it hits three surprises, all of which I hit while landing #3718:

1. **`gh pr merge` exits 0 but only ENQUEUES.** The PR stays `OPEN`. Reporting "merged" off that exit code is a false claim — and given the `AWAITING_CHECKS` eject path, the PR may never land at all.
2. **`--delete-branch` is rejected outright** while the queue is on.
3. **`--subject` is ignored** — the queue composes the merge commit from the PR title, so the PR title *is* the commit title.

Section 5 now covers all three plus the `AWAITING_CHECKS` signature, and points at `MERGE-QUEUE.md` for the rest.

## Scope note

Docs and comments only — no workflow, config, or assertion changed, so the queue's behaviour is untouched by this PR. `tests/ci-merge-queue-triggers.test.ts` is edited in its header comment only; all 50 assertions are byte-identical.

## Verification

- `tests/ci-merge-queue-triggers.test.ts`, `tests/skill.test.ts`, `tests/check-claude-md-byte-ratchet.test.ts` — 75 passed.
- `npm run lint` — exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
