### PR TITLE
fix(hindsight): make consolidation throughput defaults durable, and correct the dead rationale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 ## Unreleased
 
+### Consolidation throughput defaults, and the stale rationale behind them
+
+The comment governing switchroom's consolidation knobs asserted that
+consolidation is "LLM-bound via the claude-code provider" where "every
+concurrent op is a live claude (Sonnet) subprocess spending the subscription's
+quota", and throttled everything to a 2-concurrent-call ceiling on that basis
+(the 2026-07-06 429 wall that starved live agent turns). That premise no longer
+describes a deployment that has moved the lane onto local inference —
+`hindsight.llm.consolidation` with `provider: litellm` against a loopback proxy
+has no shared Anthropic quota to exhaust and no per-call cash cost. The binding
+constraint there is local inference slots, not subscription quota. The
+rationale is rewritten to say so, the 2026-07-06 incident is preserved as
+history rather than deleted, and an explicit **restore condition** is recorded:
+if consolidation returns to `provider: claude-code`, these values go back down.
+`MAX_SLOTS` and `LLM_PARALLELISM` are deliberately unchanged, so the
+subscription-path ceiling stays intact for anyone still on the default provider.
+
+- **`HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND` 100 → 500.** A
+  correctness knob, not only a throughput one: the engine sets
+  `stats["mental_models_refreshed"] = 0` on any round that hits the limit
+  (`consolidator.py`), so a bank whose backlog never drops below the limit hits
+  it every round and therefore **never refreshes its mental models**. At 100
+  that described four of the six banks on the fleet that found it.
+- **`HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT` is now emitted, at 6.**
+  switchroom never emitted the per-type slot *ceiling* and so silently
+  inherited upstream's 4 — observed saturated (`consolidation=4/1(avail=0,cap=4)`)
+  while five of the worker's ten slots sat idle. This is the ceiling and is a
+  different knob from `..._MAX_SLOTS`, the reservation floor; upstream's own
+  config warns about the naming.
+- **`HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY` is now settable via
+  `hindsight.env`**, with no shipped default. Upstream claims consolidation work
+  with a flat `ORDER BY created_at` across all banks unless a priority map is
+  configured, so a 29k backlog gets no preference over an 83. The map is the
+  fix, but its content is a list of *this deployment's* bank names, so it lands
+  as a new "managed but defaultless" key (`HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS`):
+  operators get a declarative channel that survives `switchroom apply`, and
+  anyone who does not opt in keeps upstream's flat FIFO unchanged.
+
+Both emit paths (the `docker run -e` argv and the generated compose
+`environment:`) carry every one of these, asserted by a test that checks
+literal values on **both** paths — an assertion written as
+`` `KEY=${THE_CONSTANT}` `` passes no matter what the constant becomes and
+cannot catch the value regression it appears to guard.
+
+`HINDSIGHT_API_LLM_MAX_CONCURRENT` is deliberately **left at 4**. The right
+value is "how many concurrent slots does this operator's local endpoint
+expose", which is a deployment fact rather than a property of switchroom; 4 is
+upstream's own worked example for an unknown shared endpoint. It is already an
+overridable key, so a measured deployment raises it in `hindsight.env`. The
+same note now records that
+`HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT` (default 1) is the *actual*
+ceiling on consolidation inference — it is a process-wide semaphore composed
+with the global cap, so worker slots and `LLM_PARALLELISM` pipeline the non-LLM
+stages but do not multiply concurrent LLM calls.
+
 ### Review policy is stated once, and no longer counts rounds
 
 v0.19.23 bounded adversarial review with a severity gate plus a counted round

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2104,7 +2104,12 @@ export const HindsightConfigSchema = z.object({
       "RETAIN/CONSOLIDATION_LLM_MAX_CONCURRENT, LLM_STRICT_SCHEMA, " +
       "LLM_MAX_RETRIES, " +
       "RECALL_MAX_CANDIDATES_PER_SOURCE, LINK_EXPANSION_PER_ENTITY_LIMIT, " +
-      "LINK_EXPANSION_TIMEOUT, LLM_REASONING_EFFORT), plus the " +
+      "LINK_EXPANSION_TIMEOUT, LLM_REASONING_EFFORT), the override-only keys " +
+      "switchroom manages but ships NO default for " +
+      "(`HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS`: " +
+      "HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY — a per-deployment " +
+      "`bank-pattern:priority,...` map; unset means upstream's flat " +
+      "created_at FIFO across banks), plus the " +
       "embedded-PostgreSQL (pg0) sizing keys switchroom manages in " +
       "src/setup/hindsight-pg-defaults.ts (`HINDSIGHT_PG_ENV_KEYS`: " +
       "SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE, " +

--- a/src/setup/hindsight-perf-defaults.test.ts
+++ b/src/setup/hindsight-perf-defaults.test.ts
@@ -38,6 +38,7 @@ import {
   HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM,
   HINDSIGHT_PERF_DEFAULTS_UNGATED,
   HINDSIGHT_PERF_ENV_KEYS,
+  HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS,
   HINDSIGHT_RECALL_SOURCE_COUNT,
   HINDSIGHT_RERANKER_MAX_CANDIDATES_FOR_DERIVATION,
   hindsightPerfEnv,
@@ -310,7 +311,7 @@ describe("operator override wins", () => {
     expect(got.size).toBe(0);
   });
 
-  it("is overridable on exactly these eleven keys, by name", () => {
+  it("is overridable on exactly these twelve keys, by name", () => {
     // Spelled out, NOT derived from the three group arrays. HINDSIGHT_PERF_ENV_KEYS
     // is DEFINED as the union of those arrays, so asserting it equals that union
     // is a tautology — it passes no matter which keys are in the arrays. The
@@ -329,6 +330,93 @@ describe("operator override wins", () => {
       "HINDSIGHT_API_RERANKER_LOCAL_BATCH_SIZE",
       "HINDSIGHT_API_RERANKER_LOCAL_FP16",
       "HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT",
+      "HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY",
+    ]);
+  });
+
+  it("accepts the override-only bank-priority key even though it has no default", () => {
+    // Managed-but-defaultless: it is in HINDSIGHT_PERF_ENV_KEYS purely so an
+    // operator has a DECLARATIVE channel for it. Without that it could only be
+    // set imperatively on the container, which the next `switchroom apply`
+    // silently drops — the exact regression class this file guards.
+    const got = resolveHindsightPerfOverrides({
+      HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY: "big-bank:3,busy-bank:2,*:1",
+    });
+    expect(got.get("HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY")).toBe(
+      "big-bank:3,busy-bank:2,*:1",
+    );
+  });
+});
+
+// ── the override-only key ─────────────────────────────────────────────────
+describe("HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY (override-only)", () => {
+  const CAPS = [
+    { gpu: false, localLlm: false },
+    { gpu: true, localLlm: false },
+    { gpu: false, localLlm: true },
+    { gpu: true, localLlm: true },
+  ];
+
+  it("is in the managed set but in NO defaults group", () => {
+    expect(HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS.has(
+      "HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY",
+    )).toBe(true);
+    for (const group of [
+      HINDSIGHT_PERF_DEFAULTS_UNGATED,
+      HINDSIGHT_PERF_DEFAULTS_GPU,
+      HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM,
+    ]) {
+      expect(group.map(([k]) => k)).not.toContain(
+        "HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY",
+      );
+    }
+    // …and every override-only key really is absent from every group, so the
+    // "no shipped default" property can't be broken by adding one later.
+    const defaulted = new Set(
+      [
+        ...HINDSIGHT_PERF_DEFAULTS_UNGATED,
+        ...HINDSIGHT_PERF_DEFAULTS_GPU,
+        ...HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM,
+      ].map(([k]) => k),
+    );
+    for (const key of HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS) {
+      expect(defaulted.has(key), `${key} must not have a shipped default`).toBe(false);
+    }
+  });
+
+  it.each(CAPS)(
+    "is NOT emitted on any host when unset (gpu=$gpu localLlm=$localLlm) — flat FIFO preserved",
+    (caps) => {
+      // Hard-coding one deployment's bank names into switchroom's shipped
+      // defaults would push this install's agent names onto every operator.
+      // Unset ⇒ upstream's flat `ORDER BY created_at`, i.e. no behaviour change.
+      const keys = hindsightPerfEnv(caps).map(([k]) => k);
+      expect(keys).not.toContain("HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY");
+    },
+  );
+
+  it("reaches BOTH launch paths, with the operator's value, when set in hindsight.env", () => {
+    const MAP = "big-bank:3,busy-bank:2,*:1";
+    const perf = { env: { HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY: MAP }, processEnv: {} };
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false, perf);
+    const fromRun = runEnv(runArgs());
+    const fromCompose = composeEnv(
+      generateHindsightComposeSnippet(undefined, undefined, LOOPBACK_LITELLM, false, perf),
+    );
+    // Both paths, or the value dies on whichever recreate the operator uses.
+    expect(fromRun.get("HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY")).toEqual([MAP]);
+    expect(fromCompose.get("HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY")).toEqual([MAP]);
+  });
+
+  it("still reaches the container on a host with NO gated capability", () => {
+    // The key belongs to no capability group, so a gate-shaped regression that
+    // only emits grouped keys would silently drop it. Cloud endpoint + no GPU
+    // is the harshest gating case.
+    const MAP = "only-bank:2,*:1";
+    const perf = { env: { HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY: MAP }, processEnv: {} };
+    startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, false, perf);
+    expect(runEnv(runArgs()).get("HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY")).toEqual([
+      MAP,
     ]);
   });
 });

--- a/src/setup/hindsight-perf-defaults.ts
+++ b/src/setup/hindsight-perf-defaults.ts
@@ -218,9 +218,55 @@ export const HINDSIGHT_DEFAULT_LLM_REASONING_EFFORT = "low";
  * reflect always has headroom"), and it matches our load shape: 99.7% of
  * recall traffic is background consolidation, which must never crowd out an
  * interactive reflect.
+ *
+ * **Deliberately left at upstream's worked-example 4 rather than raised to a
+ * specific host's slot count.** The right value is exactly "how many
+ * concurrent slots does this operator's local endpoint expose", which is a
+ * property of the deployment, not of switchroom — 4 is the value upstream
+ * recommends when that number is unknown, and it is safe on the smallest
+ * plausible local box. An operator who has measured their pool raises it
+ * declaratively, and it survives `switchroom apply`:
+ *
+ * ```yaml
+ * hindsight:
+ *   env:
+ *     HINDSIGHT_API_LLM_MAX_CONCURRENT: 6
+ * ```
+ *
+ * Note this is the GLOBAL cap. It does not by itself widen consolidation,
+ * which is separately pinned by
+ * {@link HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_MAX_CONCURRENT} below.
  */
 export const HINDSIGHT_DEFAULT_LLM_MAX_CONCURRENT = 4;
 export const HINDSIGHT_DEFAULT_RETAIN_LLM_MAX_CONCURRENT = 1;
+
+/**
+ * Per-op cap on consolidation LLM calls — and the ACTUAL ceiling on
+ * consolidation throughput.
+ *
+ * Worth stating plainly because it is easy to tune the wrong knob: the engine
+ * composes this with the global cap rather than replacing it — a consolidation
+ * call must acquire this semaphore AND {@link HINDSIGHT_DEFAULT_LLM_MAX_CONCURRENT}
+ * (`llm_wrapper._build_per_op_semaphores` / `_semaphores_for_scope`, "Per-op
+ * acquired first so contention queues on the narrower cap"). At 1 the process
+ * makes at most ONE consolidation LLM call at a time, no matter how many
+ * worker slots, banks or tag-groups are in flight. So raising worker slots
+ * (`HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT`), `LLM_PARALLELISM`, or the
+ * global cap pipelines the non-LLM stages and improves fairness, but only THIS
+ * value multiplies concurrent consolidation inference.
+ *
+ * Kept at 1 by default: it is the guarantee that background consolidation
+ * cannot crowd interactive recall/reflect off a shared local endpoint, which
+ * is upstream's stated reason for the worked example. Raising it is a real
+ * latency trade on the interactive lanes, so it is an operator decision made
+ * declaratively against a measured slot pool, not a shipped default:
+ *
+ * ```yaml
+ * hindsight:
+ *   env:
+ *     HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT: 2
+ * ```
+ */
 export const HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_MAX_CONCURRENT = 1;
 
 /**
@@ -323,19 +369,59 @@ export const HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM: ReadonlyArray<readonly [string, 
 ];
 
 /**
+ * Keys switchroom manages but ships NO default for — emitted only when the
+ * operator sets them in `hindsight.env` / the process environment.
+ *
+ * This is the right shape for a knob whose correct value is a property of one
+ * *deployment* rather than of the software. Baking such a value into a shipped
+ * default hard-codes one installation's facts into a general product; leaving
+ * the key out of the managed set entirely leaves the operator with no
+ * declarative channel at all, which is exactly how a value ends up set
+ * imperatively on a container and silently dropped by the next
+ * `switchroom apply`. Neither is acceptable, so: managed key, no default.
+ *
+ * ### `HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY`
+ *
+ * Upstream's consolidation claim query is a flat `ORDER BY created_at` across
+ * every bank unless a priority map is configured (`ops_postgresql.py`
+ * `claim_tasks`: "When *priority_map* is ``None``, uses the default
+ * ``ORDER BY created_at``"), so a bank with a 29k backlog gets no preference
+ * over one with 83. The map fixes that — but the fix *is* "which banks matter
+ * on this host", and bank names are per-deployment (they are agent names).
+ * Unset ⇒ upstream's flat FIFO, i.e. this key changes nothing for anyone who
+ * does not opt in.
+ *
+ * Format (`config.py` `_parse_bank_priority`): `pattern:priority,...`, higher
+ * priority claimed first, `*` is a wildcard inside a pattern, a bare `*` is
+ * the catch-all for unlisted banks, and every priority must be an integer
+ * `>= 1` — a malformed entry raises at container startup rather than being
+ * ignored, so a typo here fails loudly. Example:
+ *
+ * ```yaml
+ * hindsight:
+ *   env:
+ *     HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY: "big-bank:3,busy-bank:2,*:1"
+ * ```
+ */
+export const HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS: ReadonlySet<string> = new Set([
+  "HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY",
+]);
+
+/**
  * Every key this module manages — and therefore the exact set an operator may
  * override through `hindsight.env` / the process environment.
  *
  * Scoped on purpose: see the "operator override always wins" note at the top
  * of this file for why a blanket `HINDSIGHT_API_*` passthrough is worse.
  */
-export const HINDSIGHT_PERF_ENV_KEYS: ReadonlySet<string> = new Set(
-  [
+export const HINDSIGHT_PERF_ENV_KEYS: ReadonlySet<string> = new Set([
+  ...[
     ...HINDSIGHT_PERF_DEFAULTS_UNGATED,
     ...HINDSIGHT_PERF_DEFAULTS_GPU,
     ...HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM,
   ].map(([k]) => k),
-);
+  ...HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS,
+]);
 
 /**
  * Resolve the operator's overrides for the managed keys.
@@ -409,8 +495,11 @@ export function hindsightPerfEnv(
 
   // An operator override for a key whose capability group is OFF still has to
   // reach the container — otherwise "operator override wins" would silently
-  // mean "operator override is dropped on a GPU-less box". Append those in
-  // key order for determinism.
+  // mean "operator override is dropped on a GPU-less box". This is also the
+  // ONLY path by which a HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS member is emitted:
+  // it belongs to no defaults group, so it appears here exactly when the
+  // operator set it and is absent otherwise. Append in key order for
+  // determinism.
   for (const key of [...overrides.keys()].sort()) {
     if (emitted.has(key)) continue;
     emitted.add(key);

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -701,36 +701,81 @@ export function hindsightLlmBudgetEnv(llm?: HindsightLlmConfig): Array<[string, 
 }
 
 /**
- * Consolidation throughput knobs — throttled HARD for shared-quota safety.
- * Consolidation is LLM-bound via the claude-code provider (observed
- * ~510s/op), and every concurrent op is a live claude (Sonnet) subprocess
- * spending the subscription's quota.
+ * Consolidation throughput knobs.
  *
- * Since 2026-07-05 hindsight is UNPINNED (auth.consumers[hindsight] has no
- * `account:`) — it follows the fleet-active account and shares the SAME
- * live-turn quota the agents use. That makes the hard ceiling on concurrent
- * model calls (MAX_SLOTS × LLM_PARALLELISM) a direct tax on the fleet: on
- * 2026-07-06 an 18-way consolidation fan-out (3 × 6) across multiple banks
- * exhausted the shared account (429 rate-limit wall) and starved live agent
- * turns. Operator decision: hindsight keeps sharing the fleet's failover,
- * but consolidation must NEVER be able to exhaust the quota — so the
- * concurrency ceiling is throttled to 1 × 2 = 2 concurrent model calls
- * (was 18), and per-round scope is cut so an op can't monopolise a slot for
- * long.
+ * ## The binding constraint is LOCAL GPU SLOTS, not subscription quota
  *
- * - MAX_SLOTS 1: at most one bank consolidates at a time (no cross-bank
- *   fan-out — that fan-out is exactly what walled the account).
- * - LLM_PARALLELISM 2: at most two tag-groups in flight within that one op.
- *   1 × 2 = 2 concurrent claude subprocesses, ceiling.
- * - MAX_MEMORIES_PER_ROUND 100: bounded scope per op → faster slot release,
- *   more re-queue points where the fleet can reclaim the quota.
+ * These values used to be throttled to a hard ceiling of 2 concurrent model
+ * calls because consolidation ran on the Anthropic subscription. **That
+ * premise is no longer what this fleet runs.** `hindsight.llm.consolidation`
+ * in switchroom.yaml points the lane at `provider: litellm`, `model:
+ * openai/gpt-oss-20b-consolidation`, `base_url: http://127.0.0.1:4010/v1` —
+ * a loopback LiteLLM proxy routing to self-hosted Ollama boxes on the
+ * tailnet. On that path there is no shared Anthropic quota to exhaust and no
+ * marginal cash cost per call; a consolidation op is a request against a
+ * finite pool of local inference slots.
+ *
+ * The resource to protect changed shape entirely:
+ *
+ *   - OLD: a shared, fleet-wide, *rate-limited* budget where one bad fan-out
+ *     429s the live agents. The only safe answer was a hard low ceiling.
+ *   - NEW: a fixed local slot pool that queues rather than 429s. Over-issuing
+ *     costs latency for the *interactive* lanes (recall / reflect / retain)
+ *     sharing that pool; it cannot wall the fleet's Claude turns.
+ *
+ * Interactive-lane protection therefore lives elsewhere, and this is the knob
+ * to reach for first: `HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT`
+ * (src/setup/hindsight-perf-defaults.ts, default 1) is a process-wide
+ * semaphore on consolidation LLM calls — see the engine's
+ * `llm_wrapper._build_per_op_semaphores`, where a consolidation call must
+ * acquire the per-op semaphore AND the global one. Every knob in THIS block
+ * sits outside that semaphore, so raising them pipelines a consolidation op's
+ * non-LLM stages (recall, embedding, db_write) and improves cross-bank
+ * fairness — it does not multiply concurrent LLM calls.
+ *
+ * - MAX_SLOTS 1: the worker's reserved *floor* for consolidation — one bank
+ *   is always guaranteed a slot. Deliberately NOT the ceiling; see
+ *   {@link HINDSIGHT_DEFAULT_CONSOLIDATION_SLOT_LIMIT}.
+ * - LLM_PARALLELISM 2: at most two tag-groups in flight within one op.
+ * - MAX_MEMORIES_PER_ROUND 500: a correctness knob as much as a throughput
+ *   one — see the constant's own note.
  * - LLM_BATCH_SIZE: **no longer a constant here.** Derived from the declared
  *   backend context window — see below and `hindsight-context-budget.ts`.
  *
- * Consolidation drains slower by design; that is the accepted trade for never
- * walling the live fleet. The concurrency values above remain
- * operator-overridable via the generated compose / -e (raise them only with a
- * dedicated isolated account pinned back on the consumer).
+ * MAX_SLOTS and LLM_PARALLELISM are LEFT at their throttled values. On the
+ * local-inference path they are not the binding constraint, and leaving them
+ * low keeps the subscription-path ceiling intact for any operator who has NOT
+ * moved consolidation off `claude-code` — still switchroom's shipped default
+ * provider ({@link HINDSIGHT_DEFAULT_MODEL} / `resolveHindsightLlm`).
+ *
+ * ## RESTORE CONDITION — before pointing consolidation back at Claude
+ *
+ * If `hindsight.llm.consolidation` (or the global `hindsight.llm`) is ever set
+ * back to `provider: claude-code`, consolidation is once again spending the
+ * fleet's shared subscription quota and **these values must go back down**:
+ * `MAX_MEMORIES_PER_ROUND` to 100 and
+ * {@link HINDSIGHT_DEFAULT_CONSOLIDATION_SLOT_LIMIT} to 1, keeping
+ * MAX_SLOTS × LLM_PARALLELISM at 2. The failure mode that justifies the
+ * throttle is recorded immediately below and has happened for real.
+ *
+ * ## History — why the hard throttle existed (2026-07-06 incident)
+ *
+ * Kept, not deleted: it is the reason to be careful about the restore
+ * condition above.
+ *
+ * Consolidation was LLM-bound via the claude-code provider (observed
+ * ~510s/op), and every concurrent op was a live claude (Sonnet) subprocess
+ * spending the subscription's quota. Since 2026-07-05 hindsight is UNPINNED
+ * (auth.consumers[hindsight] has no `account:`) — it follows the fleet-active
+ * account and shares the SAME live-turn quota the agents use. That made the
+ * hard ceiling on concurrent model calls (MAX_SLOTS × LLM_PARALLELISM) a
+ * direct tax on the fleet: on 2026-07-06 an 18-way consolidation fan-out
+ * (3 × 6) across multiple banks exhausted the shared account (429 rate-limit
+ * wall) and starved live agent turns. Operator decision at the time:
+ * hindsight keeps sharing the fleet's failover, but consolidation must NEVER
+ * be able to exhaust the quota — so the concurrency ceiling was throttled to
+ * 1 × 2 = 2 concurrent model calls (was 18), and per-round scope was cut to
+ * 100 so an op could not monopolise a slot for long.
  *
  * ## LLM_BATCH_SIZE is a CONTEXT-WINDOW decision, not only a quota one
  *
@@ -768,7 +813,92 @@ export const HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE =
   HINDSIGHT_CONSOLIDATION_BATCH_SIZE_CEILING;
 export const HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS = 1;
 export const HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM = 2;
-export const HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND = 100;
+
+/**
+ * Per-round memory scope for one consolidation op (upstream default 1000;
+ * switchroom held this at 100 from the 2026-07-06 quota throttle).
+ *
+ * ## This is a CORRECTNESS knob, not only a throughput one
+ *
+ * The engine SKIPS mental-model refresh entirely on any round that hits this
+ * limit — `engine/consolidation/consolidator.py`:
+ *
+ * ```python
+ * if hit_round_limit:
+ *     stats["mental_models_refreshed"] = 0
+ *     logger.info(f"[CONSOLIDATION] bank={bank_id} skipping mental model refresh "
+ *                 f"(round limit hit, re-queued)")
+ * ```
+ *
+ * That is deliberate upstream behaviour (the next round will handle it), but
+ * it composes badly with a low limit and a large backlog: a bank whose
+ * backlog never drops below the limit hits the limit on EVERY round and
+ * therefore NEVER refreshes its mental models. At 100 that described 4 of the
+ * 6 banks on this fleet (backlogs measured 2026-07-27: 29,625 / 6,238 / 328 /
+ * 165 / 96 / 83 — the top four are all above 100 and the largest was still
+ * rising round over round). Mental models are the standing-answer layer
+ * agents rely on, so "silently never refreshed" is a correctness failure, not
+ * a slow drain.
+ *
+ * 500 is a 5x scope bump with the same shape of bound — it is still a bound,
+ * so a runaway bank still re-queues rather than monopolising a slot, and the
+ * consolidation prompt size per LLM call is unchanged (that is
+ * `LLM_BATCH_SIZE`, derived from the context window). What it costs is a
+ * longer hold on a worker slot per round; what it buys is that a mid-sized
+ * bank now finishes a round and refreshes.
+ *
+ * Raising this was gated on consolidation leaving the shared Anthropic quota
+ * — see the RESTORE CONDITION in the block above.
+ */
+export const HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND = 500;
+
+/**
+ * Per-type worker slot CEILING for consolidation — upstream
+ * `HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT`.
+ *
+ * ## Ceiling vs floor — two different knobs with confusingly similar names
+ *
+ * Upstream's own `config.py` warns about this, and switchroom has been
+ * silently inheriting the wrong one:
+ *
+ *   - {@link HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}
+ *     (`HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS`, 1) is the RESERVED
+ *     FLOOR: slots consolidation is always guaranteed.
+ *   - THIS (`..._SLOT_LIMIT`) is the CEILING: the most slots consolidation may
+ *     hold at once, reserved and shared combined
+ *     (`WORKER_SLOT_LIMIT_TYPES` in `config.py`, whose consolidation entry
+ *     defaults to `4`).
+ *
+ * switchroom never emitted the ceiling, so every install has silently run on
+ * upstream's 4 — and on this fleet that ceiling was observed fully saturated
+ * (`consolidation=4/1(avail=0,cap=4)`, four banks consolidating with more
+ * queued) while only 5 of the worker's 10 total slots were in use. Five idle
+ * slots that consolidation was forbidden from touching.
+ *
+ * (The 4 default and the 10-slot worker pool are pinned by
+ * tests/docker/hindsight-recall-isolation-patches.test.ts, which also proves
+ * `validate()` rejects a ceiling above the pool or below this type's own
+ * reservation — so this value must sit between MAX_SLOTS and 10.)
+ *
+ * 6 of `DEFAULT_WORKER_MAX_SLOTS` = 10 leaves 4 slots for every other op type
+ * (retain, refresh_mental_model, graph_maintenance, import_documents — all
+ * uncapped upstream) while letting consolidation use the idle capacity.
+ *
+ * Be honest about what this buys: consolidation LLM calls are still
+ * serialised by the `CONSOLIDATION_LLM_MAX_CONCURRENT` semaphore (default 1),
+ * so 6 slots do NOT mean 6 concurrent LLM calls. What they mean is that six
+ * banks' non-LLM stages pipeline, and that a small bank is no longer stuck
+ * behind big ones — the claim query is a flat `ORDER BY created_at` across
+ * all banks unless a priority map is configured (`ops_postgresql.py`
+ * `claim_tasks`; see `HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY` in
+ * hindsight-perf-defaults.ts).
+ *
+ * Emitted explicitly rather than left to the upstream default so the value is
+ * legible in `docker inspect` and cannot move under us on an image bump.
+ * Subject to the RESTORE CONDITION above: back to 1 if consolidation returns
+ * to `provider: claude-code`.
+ */
+export const HINDSIGHT_DEFAULT_CONSOLIDATION_SLOT_LIMIT = 6;
 
 /**
  * Container resource caps (memory + pids only; CPU intentionally NOT capped).
@@ -1563,12 +1693,15 @@ export function startHindsight(
     // caps, derived from the declared window so a prompt cannot overflow the
     // backend's slot (an overflow returns HTTP 200 + garbage, never an error).
     ...hindsightLlmBudgetEnv(llm).flatMap(([k, v]) => ["-e", `${k}=${v}`]),
-    // Consolidation concurrency: throttled by #2894 to a hard ceiling of
-    // MAX_SLOTS 1 × LLM_PARALLELISM 2 = 2 concurrent model calls (was 18), so
-    // consolidation can never exhaust the shared failover quota. Per-round
-    // scope 100 bounds tokens/scope per op. (BATCH_SIZE is emitted above, by
-    // the context budget — it is a window decision, not a concurrency one.)
+    // Consolidation scheduling. MAX_SLOTS is the reserved FLOOR (1) and
+    // SLOT_LIMIT the per-type CEILING (6 of the worker's 10) — two different
+    // knobs with confusingly similar upstream names; see the constants above.
+    // LLM_PARALLELISM stays at 2 so the subscription-path ceiling (MAX_SLOTS ×
+    // LLM_PARALLELISM = 2 concurrent model calls, #2894) is unchanged for any
+    // operator still on `provider: claude-code`. (BATCH_SIZE is emitted above,
+    // by the context budget — a window decision, not a concurrency one.)
     "-e", `HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}`,
+    "-e", `HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT=${HINDSIGHT_DEFAULT_CONSOLIDATION_SLOT_LIMIT}`,
     "-e", `HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM}`,
     "-e", `HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND}`,
     // Stable worker identity (see HINDSIGHT_DEFAULT_WORKER_ID). Must be on
@@ -2127,7 +2260,12 @@ export function generateHindsightComposeSnippet(
     // reflect context cap all come from here, so the two paths cannot
     // disagree about the token budget).
     ...hindsightLlmBudgetEnv(llm).map(([k, v]) => `      - ${k}=${v}`),
+    // Consolidation scheduling — compose twin of the docker-run block. Every
+    // var here MUST also appear on that path (reserved floor, per-type
+    // ceiling, tag-group parallelism, per-round scope); a var on one path only
+    // is exactly the drift a `switchroom apply` silently drops.
     `      - HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}`,
+    `      - HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT=${HINDSIGHT_DEFAULT_CONSOLIDATION_SLOT_LIMIT}`,
     `      - HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM}`,
     `      - HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND}`,
     `      - HINDSIGHT_API_WORKER_ID=${HINDSIGHT_DEFAULT_WORKER_ID}`,

--- a/tests/setup/hindsight.test.ts
+++ b/tests/setup/hindsight.test.ts
@@ -45,6 +45,15 @@ function findRunArgs(): string[] {
   return runCall![1] as string[];
 }
 
+/** Every `-e KEY=VALUE` payload from a captured `docker run` argv. */
+function runEnvPairs(args: string[]): string[] {
+  const pairs: string[] = [];
+  for (let i = 0; i < args.length - 1; i++) {
+    if (args[i] === "-e") pairs.push(args[i + 1] as string);
+  }
+  return pairs;
+}
+
 describe("hindsight broker-fed mode (#1245)", () => {
   beforeEach(() => {
     mockedExec.mockReset();
@@ -562,27 +571,95 @@ describe("hindsight broker-fed mode (#1245)", () => {
     );
   });
 
-  it("sets modest consolidation throughput knobs (batch size + slots) on both emit paths", async () => {
+  it("emits every consolidation scheduling var on BOTH emit paths, with the same value", async () => {
     const h = await import("../../src/setup/hindsight.js");
     startHindsight({ apiPort: 8888, uiPort: 9999 });
-    const args = findRunArgs();
-    const envPairs: string[] = [];
-    for (let i = 0; i < args.length - 1; i++) {
-      if (args[i] === "-e") envPairs.push(args[i + 1] as string);
-    }
-    expect(envPairs).toContain(`HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE}`);
-    expect(envPairs).toContain(`HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}`);
-    expect(envPairs).toContain(`HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM}`);
-    expect(envPairs).toContain(`HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND}`);
-    // Subscription-honest ceiling: concurrent model calls = slots × parallelism.
-    // #2894 throttled this to a hard ceiling of 1 × 2 = 2 after an 18-way
-    // fan-out exhausted the shared failover quota (2026-07-06 token-burn).
-    // The old guard (≤24) let that exact 18-way fan-out pass — this pins the
-    // ceiling at ≤2 so any regression that re-raises slots/parallelism trips it.
-    expect(h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS * h.HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM).toBeLessThanOrEqual(2);
+    const envPairs = runEnvPairs(findRunArgs());
     const snippet = h.generateHindsightComposeSnippet();
-    expect(snippet).toContain(`HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM}`);
-    expect(snippet).toContain(`HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND}`);
+
+    // LITERAL values, not `=${constant}`. An assertion written against the
+    // constant it is checking passes no matter what the constant becomes, so
+    // it cannot catch a silent value regression — which is precisely the class
+    // of drift this file exists to prevent.
+    const expected: Array<[string, string]> = [
+      ["HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS", "1"],
+      ["HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT", "6"],
+      ["HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM", "2"],
+      ["HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND", "500"],
+    ];
+    for (const [key, value] of expected) {
+      // docker-run path
+      expect(envPairs, `${key} missing/wrong on the docker-run path`).toContain(
+        `${key}=${value}`,
+      );
+      // compose path — the twin that a `switchroom apply` actually renders.
+      // A var present on only one path is dropped the moment the other path
+      // recreates the container.
+      expect(snippet, `${key} missing/wrong in the compose snippet`).toContain(
+        `      - ${key}=${value}`,
+      );
+    }
+    // …and the constants really are what the literals above claim, so the
+    // exported API and the emitted env can't disagree.
+    expect(h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS).toBe(1);
+    expect(h.HINDSIGHT_DEFAULT_CONSOLIDATION_SLOT_LIMIT).toBe(6);
+    expect(h.HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM).toBe(2);
+    expect(h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND).toBe(500);
+
+    expect(envPairs).toContain(
+      `HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE}`,
+    );
+
+    // Subscription-path ceiling: concurrent model calls = reserved slots ×
+    // parallelism. #2894 throttled this to 1 × 2 = 2 after an 18-way fan-out
+    // exhausted the shared failover quota (2026-07-06 token-burn). switchroom
+    // still ships `claude-code` as the default provider, so an operator who has
+    // NOT moved consolidation onto local inference must keep that ceiling —
+    // this pins it at ≤2 so a regression that re-raises slots/parallelism trips.
+    expect(
+      h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS *
+        h.HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM,
+    ).toBeLessThanOrEqual(2);
+  });
+
+  it("keeps the consolidation slot CEILING above the reserved FLOOR and inside the worker pool", async () => {
+    const h = await import("../../src/setup/hindsight.js");
+    // Two knobs, confusingly similar upstream names (config.py warns about it):
+    // MAX_SLOTS is the reserved floor, SLOT_LIMIT the per-type ceiling.
+    const UPSTREAM_WORKER_MAX_SLOTS = 10;
+
+    // (a) BOOT correctness. HindsightConfig.validate() REJECTS an explicit
+    //     ceiling below the type's own reservation ("the floor is
+    //     unsatisfiable") or above worker_max_slots — both make the container
+    //     refuse to start. Asserted against the same rules pinned in
+    //     tests/docker/hindsight-recall-isolation-patches.test.ts.
+    expect(h.HINDSIGHT_DEFAULT_CONSOLIDATION_SLOT_LIMIT).toBeGreaterThanOrEqual(
+      h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS,
+    );
+    expect(h.HINDSIGHT_DEFAULT_CONSOLIDATION_SLOT_LIMIT).toBeLessThanOrEqual(
+      UPSTREAM_WORKER_MAX_SLOTS,
+    );
+    expect(h.HINDSIGHT_DEFAULT_CONSOLIDATION_SLOT_LIMIT).toBeGreaterThan(0);
+
+    // (b) DESIGN intent, stricter than (a): consolidation must not be able to
+    //     take the whole worker. Every other op type (retain,
+    //     refresh_mental_model, graph_maintenance, import_documents) is
+    //     uncapped upstream, so slots left over are the only thing keeping them
+    //     schedulable while consolidation is saturated.
+    expect(h.HINDSIGHT_DEFAULT_CONSOLIDATION_SLOT_LIMIT).toBeLessThan(
+      UPSTREAM_WORKER_MAX_SLOTS,
+    );
+  });
+
+  it("bounds consolidation per-round scope so a huge bank still re-queues", async () => {
+    const h = await import("../../src/setup/hindsight.js");
+    // The round limit is what forces a re-queue; it must stay a real bound.
+    // It is ALSO a correctness knob: the engine sets
+    // stats["mental_models_refreshed"] = 0 on any round that hits it
+    // (consolidator.py), so a bank permanently above the limit never refreshes
+    // its mental models. Upstream's own default is 1000 — stay at or under it.
+    expect(h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND).toBeGreaterThan(100);
+    expect(h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND).toBeLessThanOrEqual(1000);
   });
 
   it("raises the memory limit to give the throughput bump headroom (8g, was 4g)", async () => {


### PR DESCRIPTION
## Why

The comment block above the consolidation constants in `src/setup/hindsight.ts` justified a hard **2-concurrent-call** throttle on an explicit premise:

> Consolidation is LLM-bound via the claude-code provider … every concurrent op is a live claude (Sonnet) subprocess spending the subscription's quota.

**That premise no longer describes a deployment that has moved the lane onto local inference.** With `hindsight.llm.consolidation` set to `provider: litellm` / `base_url: http://127.0.0.1:4010/v1` against self-hosted models, there is no shared Anthropic quota to exhaust and no marginal cash cost per call. The binding constraint is local inference slots.

Several of the settings this PR makes durable existed only imperatively on a hand-recreated container and would have been dropped by the next `switchroom apply` / `memory setup --recreate` — the same regression class the repo has already eaten twice (see the v0.19.19 note around the retain lane).

## Part 1 — the rationale

Rewritten to state the current reality and the new binding constraint. The 2026-07-06 incident is **preserved as history**, not deleted, because it is the reason to be careful. An explicit **RESTORE CONDITION** is recorded: if consolidation returns to `provider: claude-code`, `MAX_MEMORIES_PER_ROUND` goes back to 100 and `SLOT_LIMIT` back to 1.

`MAX_SLOTS` (1) and `LLM_PARALLELISM` (2) are **deliberately unchanged** — switchroom still ships `claude-code` as the default provider, so the subscription-path ceiling must stay intact for operators who have not moved off it.

## Part 2 — the values

| Var | Before | After | Why |
|---|---|---|---|
| `HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND` | 100 | **500** | Correctness, not just throughput |
| `HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT` | *(never emitted → image default 4)* | **6** | The per-type CEILING, previously inherited silently |
| `HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY` | *(never emitted)* | **no shipped default; settable via `hindsight.env`** | Content is per-deployment |
| `HINDSIGHT_API_LLM_MAX_CONCURRENT` | 4 | **4 (unchanged — see below)** | Already emitted and already overridable |

**Round limit is a correctness knob.** The engine skips mental-model refresh entirely on any round that hits the limit — `engine/consolidation/consolidator.py`:

```python
if hit_round_limit:
    stats["mental_models_refreshed"] = 0
    logger.info(f"[CONSOLIDATION] bank={bank_id} skipping mental model refresh (round limit hit, re-queued)")
```

So a bank whose backlog never drops below the limit hits it on *every* round and therefore **never refreshes its mental models**. At 100 that described four of the six banks on the fleet that found it (backlogs 29,625 / 6,238 / 328 / 165 / 96 / 83).

**Ceiling vs floor.** `..._MAX_SLOTS` is the reservation FLOOR; `..._SLOT_LIMIT` is the per-type CEILING (`WORKER_SLOT_LIMIT_TYPES` in the engine's `config.py`, whose consolidation entry defaults to 4). switchroom never emitted the ceiling, so every install ran on 4 — observed fully saturated (`consolidation=4/1(avail=0,cap=4)`) while only 5 of the worker's 10 slots were in use. 6 of 10 leaves 4 for the other (uncapped) op types.

## Part 3 — the bank-priority judgement call

Hard-coding `overlord:3,klanker:2,*:1` into switchroom's shipped defaults would push one deployment's agent names onto every operator, so it is **not** a shipped default.

`hindsight.env` in `switchroom.yaml` **is** a supported declarative passthrough (`src/config/schema.ts`, scoped to `HINDSIGHT_PERF_ENV_KEYS`) — but it only honours *managed* keys, and this key was not one. So this PR adds `HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS`: managed-but-defaultless keys, emitted only when the operator sets them. Unset ⇒ upstream's flat `ORDER BY created_at`, i.e. **zero behaviour change for anyone who does not opt in**; set ⇒ declarative and survives `switchroom apply`.

## Deliberately NOT changed, with evidence

**`HINDSIGHT_API_LLM_MAX_CONCURRENT` stays at 4.** It is *already* emitted by switchroom — `src/setup/hindsight-perf-defaults.ts` `HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM`, localLlm-gated — so the live value of 4 was never undurable drift. Raising the shipped default to 6 would bake one host's GPU slot count into a general product, which is exactly what that file's own rule 1 forbids. 4 is upstream's worked example for an unknown shared endpoint; a measured deployment raises it in `hindsight.env`, which is durable.

**`CONSOLIDATION_LLM_MAX_CONCURRENT` (1) is the actual ceiling on consolidation inference**, and it is not in this PR. From `engine/llm_wrapper.py`, the per-op semaphore is composed with the global one rather than replacing it:

```python
# Per-op acquired first so contention queues on the narrower cap before
# holding a global slot.
return [per_op, _global_llm_semaphore]
```

At 1, the process makes at most **one** consolidation LLM call at a time regardless of worker slots, banks or tag-groups. So the knobs in this PR pipeline the non-LLM stages (recall / embedding / db_write) and improve cross-bank fairness — they do **not** multiply concurrent LLM calls, and neither does raising the global cap. Raising it is a real latency trade against the interactive lanes, so it is left as a documented operator decision rather than guessed at here. Both facts are now recorded in the source so the next person tunes the right knob.

## Tests

Assertions use **literal** values on **both** emit paths. An assertion written as `` `KEY=${THE_CONSTANT}` `` passes no matter what the constant becomes and cannot catch the value regression it appears to guard — the pre-existing test had exactly that shape, and did not check the compose path for `MAX_SLOTS` at all.

Mutation-verified locally:
- dropping `SLOT_LIMIT` from the **compose path only** → 1 failure
- reverting `500` → `100` → 2 failures
- restored → 74/74 green

New coverage for the override-only key: present in `HINDSIGHT_PERF_ENV_KEYS`, absent from every defaults group, **not** emitted for any of the four capability combinations when unset, and emitted with the operator's value on **both** paths (including on a host with no gated capability at all).

Local: `vitest run src/setup tests/setup` 411/411 pass; `npm run lint` clean. CI is the authority.