### PR TITLE
fix(telegram-plugin): total decideContentGateBypass + real teeth on the supersede property tests (#3724, #3726, #3727)

### DIFF
--- a/telegram-plugin/reply-owner-resolve.ts
+++ b/telegram-plugin/reply-owner-resolve.ts
@@ -210,6 +210,15 @@ export function decideContentGateBypass(input: {
   if (input.tier === 'live') return true
   if (input.tier === 'none') return false
   if (input.handbackCouldOwnReply) return false
+  // Total over degenerate input (#3726). TypeScript makes `candidates` mandatory
+  // and the one production caller (`resolveReplyOwnerTurn`) always builds it, so
+  // this cannot fire today — but this module is exported precisely so the
+  // decision can be exercised OUTSIDE the gateway's construction discipline.
+  // Every other defensive branch here fails CLOSED (keep the #3429 content
+  // gate); without this guard the missing-input case instead fails by THROWING
+  // out of the supersede path — a fail-open-by-crash. Matches the module's own
+  // precedent: `latestEndedAccepted` is total over null age/ttl/turnId.
+  if (input.candidates == null) return false
   if (!latestEndedAccepted(input.candidates)) return false
   return (
     input.resolvedTurnId != null &&

--- a/telegram-plugin/tests/reply-owner-resolve.test.ts
+++ b/telegram-plugin/tests/reply-owner-resolve.test.ts
@@ -827,34 +827,181 @@ describe('decideContentGateBypass — corroborated bypass of the #3429 content g
     ).toBe(true)
   })
 
-  // The safety argument, asserted rather than asserted-in-prose: every shape that
-  // bypasses via a model-supplied tier ALSO bypasses with those model-supplied
-  // ids stripped (i.e. by the model simply omitting origin_turn_id / reply_to).
-  // So the widening hands a reply no reach it did not already have.
-  it('ZERO new capability: any corroborated origin/quoted bypass is reachable ' +
-    'with the model-supplied ids stripped', () => {
-    const shapes: Array<{ tier: 'origin' | 'quoted'; id: string; c: ReplyOwnerCandidates }> = [
-      { tier: 'origin', id: OWNER, c: cands({ originTurnId: OWNER }) },
-      { tier: 'quoted', id: OWNER, c: cands({ quotedTurnId: OWNER }) },
-      { tier: 'origin', id: OTHER, c: cands({ originTurnId: OTHER }) },
-      { tier: 'quoted', id: OTHER, c: cands({ quotedTurnId: OTHER, latestEndedTurnId: OTHER }) },
-    ]
-    for (const s of shapes) {
-      const withModelIds = decideContentGateBypass({
-        tier: s.tier,
-        resolvedTurnId: s.id,
-        candidates: s.c,
-        handbackCouldOwnReply: false,
-      })
-      // Strip the model-supplied ids: the framework alone resolves the owner.
-      const stripped: ReplyOwnerCandidates = { ...s.c, originTurnId: null, quotedTurnId: null }
-      const withoutModelIds = decideContentGateBypass({
-        tier: resolveReplyOwnerTier(stripped),
-        resolvedTurnId: resolveReplyOwnerTurnId(stripped),
-        candidates: stripped,
-        handbackCouldOwnReply: false,
-      })
-      if (withModelIds) expect(withoutModelIds).toBe(true)
+  // ─── #3726: total over degenerate input, and it fails CLOSED ───
+  //
+  // TypeScript makes `candidates` mandatory and the gateway always constructs
+  // it, so this is production-unreachable — but the function is EXPORTED, and a
+  // caller without the gateway's construction discipline used to get a
+  // `TypeError` out of the supersede decision path (fail-open-by-crash) instead
+  // of the safe answer. The safe answer is `false`: keep the #3429 content gate.
+  it('#3726: an absent candidate set returns false (fail CLOSED), never throws', () => {
+    for (const tier of ['origin', 'quoted', 'latest-ended'] as const) {
+      for (const absent of [undefined, null]) {
+        expect(
+          decideContentGateBypass({
+            tier,
+            resolvedTurnId: OWNER,
+            candidates: absent as unknown as ReplyOwnerCandidates,
+            handbackCouldOwnReply: false,
+          }),
+        ).toBe(false)
+      }
     }
+  })
+
+  // ─── ZERO new capability, as an EXHAUSTIVE property (#3724) ───
+  //
+  // The safety argument for widening `origin`/`quoted` from a blanket ban to
+  // corroboration: every shape that bypasses via a model-supplied tier ALSO
+  // bypasses with those model-supplied ids stripped (i.e. by the model simply
+  // omitting `origin_turn_id` / `reply_to`). So the widening hands a reply no
+  // reach it did not already have.
+  //
+  // #3724 — the previous form of this test hand-picked four candidate shapes and
+  // guarded its assertion behind `if (withModelIds)`, so one of the four
+  // asserted nothing at all, `handbackCouldOwnReply` was pinned `false`, and
+  // `liveTurnId` was never varied. It could only go red if the corroboration
+  // equality were deleted outright. It is replaced here by an exhaustive sweep
+  // of the whole (small) candidate space that derives `tier`/`resolvedTurnId`
+  // from the REAL resolvers rather than passing them in by hand — and, so the
+  // sweep is evidence rather than decoration, by a companion test that runs the
+  // SAME sweep over deliberately broken decisions and asserts it catches them.
+  const IDS = [null, OWNER, OTHER] as const
+  /** fresh / stale / unbounded (no age+ttl — the documented back-compat path). */
+  const AGES = [
+    { label: 'fresh', ageMs: 30_000 as number | null, ttlMs: DEFAULT_SUPERSEDE_TTL_MS as number | undefined },
+    { label: 'stale', ageMs: DEFAULT_SUPERSEDE_TTL_MS + 1, ttlMs: DEFAULT_SUPERSEDE_TTL_MS },
+    { label: 'unbounded', ageMs: null, ttlMs: undefined },
+  ]
+
+  type Decide = typeof decideContentGateBypass
+
+  /** The module's freshness rule, restated locally so the mutants below can
+   *  differ from the real decision in EXACTLY one respect each. */
+  const freshEnough = (c: ReplyOwnerCandidates): boolean =>
+    c.latestEndedTurnId != null &&
+    (c.latestEndedAgeMs == null || c.latestEndedTtlMs == null
+      ? true
+      : c.latestEndedAgeMs <= c.latestEndedTtlMs)
+
+  /**
+   * Sweep the full candidate space against `decide`, reporting every case that
+   * VIOLATES zero-new-capability (bypasses with the model-supplied ids present
+   * but not with them stripped) plus coverage counters that stop the sweep
+   * silently degrading to all-vacuous.
+   */
+  function sweepZeroNewCapability(decide: Decide): {
+    violations: string[]
+    cases: number
+    bypasses: number
+    modelTierBypasses: number
+  } {
+    const violations: string[] = []
+    let cases = 0
+    let bypasses = 0
+    let modelTierBypasses = 0
+    for (const liveTurnId of IDS)
+      for (const originTurnId of IDS)
+        for (const quotedTurnId of IDS)
+          for (const latestEndedTurnId of IDS)
+            for (const age of AGES)
+              for (const handbackCouldOwnReply of [false, true]) {
+                cases++
+                const c: ReplyOwnerCandidates = {
+                  liveTurnId,
+                  originTurnId,
+                  quotedTurnId,
+                  latestEndedTurnId,
+                  latestEndedAgeMs: age.ageMs,
+                  latestEndedTtlMs: age.ttlMs,
+                }
+                const tier = resolveReplyOwnerTier(c)
+                const withModelIds = decide({
+                  tier,
+                  resolvedTurnId: resolveReplyOwnerTurnId(c),
+                  candidates: c,
+                  handbackCouldOwnReply,
+                })
+                // Strip the model-supplied ids: the FRAMEWORK alone resolves the
+                // owner — the reach the model already had by staying silent.
+                const stripped: ReplyOwnerCandidates = {
+                  ...c,
+                  originTurnId: null,
+                  quotedTurnId: null,
+                }
+                const withoutModelIds = decide({
+                  tier: resolveReplyOwnerTier(stripped),
+                  resolvedTurnId: resolveReplyOwnerTurnId(stripped),
+                  candidates: stripped,
+                  handbackCouldOwnReply,
+                })
+                if (withModelIds) {
+                  bypasses++
+                  if (tier === 'origin' || tier === 'quoted') modelTierBypasses++
+                }
+                if (withModelIds && !withoutModelIds) {
+                  violations.push(
+                    `tier=${tier} live=${liveTurnId} origin=${originTurnId} ` +
+                      `quoted=${quotedTurnId} latestEnded=${latestEndedTurnId} ` +
+                      `age=${age.label} handback=${handbackCouldOwnReply}`,
+                  )
+                }
+              }
+    return { violations, cases, bypasses, modelTierBypasses }
+  }
+
+  it('ZERO new capability over the EXHAUSTIVE candidate space: no shape bypasses ' +
+    'with model-supplied ids that would not bypass without them', () => {
+    const r = sweepZeroNewCapability(decideContentGateBypass)
+    // The property itself — every violating shape is NAMED, not just counted.
+    expect(r.violations).toEqual([])
+    // Non-degeneracy: the sweep must actually cover the space and must actually
+    // reach the branch under test, so it can never quietly become a no-op.
+    expect(r.cases).toBe(IDS.length ** 4 * AGES.length * 2)
+    expect(r.bypasses).toBeGreaterThan(0)
+    // …and specifically, many cases must win their bypass on the WIDENED,
+    // model-steerable `origin`/`quoted` tiers — the thing being vouched for.
+    // Currently exactly 16 of the 486 cases do (no live turn, handback clear,
+    // a fresh-or-unbounded latest-ended id, and the steered id equal to it).
+    expect(r.modelTierBypasses).toBeGreaterThanOrEqual(16)
+  })
+
+  // NON-VACUITY, asserted deterministically rather than demonstrated by hand:
+  // the same sweep is run over mutants that break zero-new-capability in the two
+  // realistic ways #3724 called out. If it could not go red on these, it would
+  // not be evidence for the real function.
+  it('the sweep is NOT vacuous: it catches a bypass that ignores corroboration, ' +
+    'and one that ignores the handback window on the steerable tiers', () => {
+    // Mutant A — the widening WITHOUT the corroboration equality: `origin`/
+    // `quoted` bypass on any resolved turn. This is the Fable silent-edit-over.
+    const ignoresCorroboration: Decide = (input) => {
+      if (input.tier === 'live') return true
+      if (input.tier === 'none') return false
+      if (input.handbackCouldOwnReply) return false
+      if (input.candidates == null) return false
+      if (input.tier === 'origin' || input.tier === 'quoted') return true
+      if (!freshEnough(input.candidates)) return false
+      return input.resolvedTurnId === input.candidates.latestEndedTurnId
+    }
+    const a = sweepZeroNewCapability(ignoresCorroboration)
+    expect(a.violations.length).toBeGreaterThan(0)
+
+    // Mutant B — corroboration kept, handback guard dropped on the steerable
+    // tiers only. The OLD hand-picked test stayed GREEN under exactly this,
+    // because it pinned `handbackCouldOwnReply: false` in every shape.
+    const ignoresHandback: Decide = (input) => {
+      if (input.tier === 'live') return true
+      if (input.tier === 'none') return false
+      const steerable = input.tier === 'origin' || input.tier === 'quoted'
+      if (input.handbackCouldOwnReply && !steerable) return false
+      if (input.candidates == null) return false
+      if (!freshEnough(input.candidates)) return false
+      return (
+        input.resolvedTurnId != null &&
+        input.resolvedTurnId === input.candidates.latestEndedTurnId
+      )
+    }
+    const b = sweepZeroNewCapability(ignoresHandback)
+    expect(b.violations.length).toBeGreaterThan(0)
   })
 })

--- a/telegram-plugin/tests/send-reply-golden.test.ts
+++ b/telegram-plugin/tests/send-reply-golden.test.ts
@@ -1340,6 +1340,66 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     ).toBe(true)
   })
 
+  // ─── #3727: the F1 RESIDUAL cell, pinned as an ACCEPTED trade-off ───
+  //
+  // Corroborated `origin`/`quoted` + FOREIGN content + NO handback marker in the
+  // window. Both guards pass — the attribution is framework-corroborated, and
+  // nothing says a decoupled completion is outstanding — so the content gate is
+  // BYPASSED and the flushed answer is corrected in place. This is the accepted
+  // outcome, not an oversight, and these tests exist so it can never flip
+  // silently in either direction:
+  //
+  //   - it is NOT new reach. The identical reply reaches the identical outcome
+  //     today by omitting `origin_turn_id` / `reply_to` and landing on
+  //     `latest-ended` with the same turn (the zero-new-capability property,
+  //     swept exhaustively in `reply-owner-resolve.test.ts`).
+  //   - it IS the documented F1 residual: a genuinely decoupled completion that
+  //     fails to stamp the `subagent_handback` marker is indistinguishable from
+  //     the turn's own reworded answer, because rewording cannot be matched
+  //     textually. The MITIGATION is the marker itself — stamped at the single
+  //     buffer chokepoint via `stampsHandbackMarker` (see the F1 tests above,
+  //     which pin the marked case sending FRESH with the flush untouched).
+  //
+  // If a future tightening of the corroboration rule flips this cell to a fresh
+  // send, these go red — decide deliberately, don't drift into it.
+  for (const tier of ['origin', 'quoted'] as const) {
+    it(`#3727 (F1 residual, ACCEPTED): a corroborated \`${tier}\` reply with FOREIGN ` +
+      'content and NO handback marker bypasses the gate — the flushed answer is ' +
+      'edited in place, exactly one message survives', async () => {
+      const h = makeHarness()
+      const owner = makeFlushDeliveredEndedTurn()
+      seedRecord(h, owner)
+      // Corroborated: the model-supplied attribution names the SAME turn the
+      // framework-derived `latestEndedTurnId` resolves (ownerRes's default).
+      h.deps.resolveReplyOwnerTurn = () => ownerRes(owner, tier)
+      // No decoupled completion anywhere in the chat — the residual F1 vector.
+      h.deps.getLastSubagentHandbackAt = () => null
+
+      // The content is genuinely FOREIGN: the gate would have declined it, so
+      // this test cannot pass by accident through `flushedAnswerMatchesReply`.
+      expect(flushedAnswerMatchesReply(FLUSHED_TEXT, HANDBACK)).toBe(false)
+
+      const res = await sendReply(h.deps, req(HANDBACK))
+
+      // OUTCOME: exactly one client-visible message — the flushed message A is
+      // edited into the foreign content; NO second bubble ships.
+      const edits = h.calls.filter((c) => c.method === 'editMessageText')
+      expect(edits).toHaveLength(1)
+      expect(edits[0]!.message_id).toBe(FLUSH_MSG_ID)
+      expect(edits[0]!.text).toContain('migration audit')
+      expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(0)
+      expect(res.content[0]!.text).toMatch(/^sent/)
+      // The flush record is CONSUMED — the provisional answer is gone, not
+      // merely shadowed.
+      expect(
+        h.deps.flushedTurnSupersede.peek(CHAT, undefined, {
+          liveTurnId: OWNER_TURN_ID,
+          now: Date.now(),
+        }).reason,
+      ).toBe('no-record')
+    })
+  }
+
   // A STALE framework candidate must not corroborate anything: the latest-ended
   // freshness bound (F2) is what stops an old turn inheriting deletion authority.
   it('a `origin` echo does NOT bypass when the framework latest-ended candidate ' +


### PR DESCRIPTION
Closes #3724, closes #3726, closes #3727 — the three LOW follow-ups from the adversarial review of #3719, all in the supersede / owner-resolve area. Each was verified against the code at `origin/main` (bf8d115d) before fixing; **all three characterisations held**.

## #3726 — `decideContentGateBypass` was not total (fail-open-by-crash)

`latestEndedAccepted` dereferences `candidates.latestEndedTurnId` (`reply-owner-resolve.ts:80`), so an absent candidate set threw `TypeError` out of the supersede decision path. Production-unreachable today (TS-mandatory param; the one caller `resolveReplyOwnerTurn` always builds it) — but the function is *exported* so the decision can be exercised outside the gateway's construction discipline, and every other defensive branch in it fails **closed** while this one exploded.

Fix: `if (input.candidates == null) return false`, placed with the other fail-closed guards. Test pins `false` (not a throw) for `undefined`/`null` across `origin`/`quoted`/`latest-ended`.

## #3724 — the "ZERO new capability" property test could not fail

The old test hand-picked four shapes and guarded its assertion behind `if (withModelIds)`; shape 3 evaluated `withModelIds === false` and therefore asserted nothing, `handbackCouldOwnReply` was pinned `false` everywhere, and `liveTurnId` was never varied. The property it advertises is true — but the artifact vouching for it wasn't doing so, and #3719's commit message cites it as the safety argument.

Replaced with an **exhaustive sweep**: `liveTurnId × originTurnId × quotedTurnId × latestEndedTurnId` over `{null, OWNER, OTHER}`, × `{fresh, stale, unbounded}` TTL, × `handbackCouldOwnReply ∈ {false, true}` = **486 cases**. `tier` and `resolvedTurnId` come from the real resolvers rather than by hand. Every violating shape is reported by name. Coverage counters (`cases`, `bypasses`, `modelTierBypasses ≥ 16`) stop it silently degrading to vacuous.

**Non-vacuity is a standing assertion, not a one-off**: a companion test runs the same sweep over two mutants — one that drops corroboration on the steerable tiers (the Fable vector), one that drops the handback guard on them — and asserts the sweep catches both.

## #3727 — pin the F1 residual, don't change it

Confirmed against the code that the issue's judgement is right: corroborated `origin`/`quoted` + FOREIGN content + no handback marker bypasses the gate and edits over the flush, and that is the **accepted** outcome — the same reply reaches the same outcome today via `latest-ended` (zero-new-capability), and the mitigation is the `subagent_handback` marker. So it is PINNED, not changed: two golden-path outcome tests (`origin` + `quoted`) asserting exactly one surviving message, the flushed message edited in place, and the flush record consumed, with a comment cross-referencing the residual and where its mitigation lives.

## Evidence

Non-vacuity proof for #3724 — the real implementation was temporarily broken and the new sweep observed going red:

| temporary break | new sweep | old (replaced) test |
|---|---|---|
| `origin`/`quoted` bypass without corroboration | **RED** — 40 named violations | red (also caught) |
| handback guard dropped on the steerable tiers only | **RED** — 16 named violations | **GREEN** ← the gap this PR closes |
| #3726 guard removed | n/a | #3726 test **RED** with `TypeError: Cannot read properties of undefined (reading 'latestEndedTurnId')` |

Scoped runs (worktree, node ≥20 + bun):
- `vitest run telegram-plugin/tests/reply-owner-resolve.test.ts` → **49 passed**
- `vitest run telegram-plugin/tests/send-reply-golden.test.ts` → **45 passed** (both new #3727 cells green)
- `vitest run telegram-plugin` (full plugin suite) → **8317 passed, 3 skipped, 1 failed**. The one failure is `approval-hold-record.test.ts > falls back to the agent's own state dir when the shared dir is not writable`, which **fails identically on pristine `origin/main`** in this container — uid 0 ignores the `0o500` perms the test relies on. Documented root-container env noise, not this diff.
- `npm run lint` → clean, including `check-gateway-line-ratchet` (`gateway.ts` untouched).

The #3429 / F1 / F2 / MUST-FIX defence tests are unmodified and green.

**Note for the merge queue:** a sibling PR for #3725 also touches `telegram-plugin/reply-owner-resolve.ts`. This diff adds exactly one guard line + comment inside `decideContentGateBypass` and does not touch the resolvers, so it should merge cleanly; the test-file overlap is confined to the `decideContentGateBypass` describe block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)