### PR TITLE
fix(hindsight): band-check the retain lane, name reflect's completion reserve honestly, reconcile window default with base URL

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2019,7 +2019,10 @@ const HindsightPerOpLlmSchema = z
         "window. Absent → inherit " +
         "`hindsight.llm.context_window`, else a per-provider default " +
         "(conservative for non-`claude-code` providers, which usually mean " +
-        "a local llama.cpp/Ollama slot). All three lanes (`retain`, " +
+        "a local llama.cpp/Ollama slot; a self-hosted `base_url` — loopback, " +
+        "RFC1918, `.local`/`.internal` — forces the conservative default too, " +
+        "regardless of the provider NAME, since the endpoint is where the " +
+        "traffic actually terminates). All three lanes (`retain`, " +
         "`reflect`, `consolidation`) are budgeted independently.",
       ),
   })

--- a/src/setup/hindsight-context-budget.ts
+++ b/src/setup/hindsight-context-budget.ts
@@ -49,9 +49,18 @@
  * deterministic preflight is what makes the swap loud instead of silent.
  */
 
+import { isSelfHostedHttpUrl } from "./self-hosted-url.js";
+
 /** Per-op LLM config fields this module cares about (structural subset). */
 export interface ContextBudgetPerOpInput {
   provider?: string;
+  /**
+   * `HINDSIGHT_API_<OP>_LLM_BASE_URL`. Read here (#3723) because the endpoint
+   * is a STRONGER signal than the provider name for "how big is this lane's
+   * window?": a LiteLLM-fronted local box routinely carries the upstream
+   * vendor's name as its provider label.
+   */
+  base_url?: string;
   context_window?: number;
 }
 
@@ -178,6 +187,12 @@ export interface HindsightLaneBudget {
   lane: HindsightBudgetLane;
   /** Declared context window (tokens) for this lane's backend. */
   windowTokens: number;
+  /**
+   * `windowTokens` minus the {@link HINDSIGHT_CONTEXT_SAFETY_FRACTION} band —
+   * the budget every lane is actually held to. This, not `windowTokens`, is
+   * what the preflight compares against (#3721).
+   */
+  usableTokens: number;
   windowSource: ContextWindowSource;
   /** Effective provider for this lane (per-op override → global → default). */
   provider: string;
@@ -185,7 +200,7 @@ export interface HindsightLaneBudget {
   maxCompletionTokens: number;
   /** Estimated worst-case PROMPT tokens for one call at the derived settings. */
   estimatedPromptTokens: number;
-  /** `estimatedPromptTokens + maxCompletionTokens` — must fit the window. */
+  /** `estimatedPromptTokens + maxCompletionTokens` — must fit `usableTokens`. */
   worstCaseTotalTokens: number;
 }
 
@@ -195,15 +210,49 @@ export interface HindsightConsolidationBudget extends HindsightLaneBudget {
   batchSize: number;
 }
 
-export interface HindsightReflectBudget extends HindsightLaneBudget {
+/**
+ * The reflect lane. Deliberately NOT an extension of {@link HindsightLaneBudget}:
+ * reflect has no `maxCompletionTokens`, because **upstream exposes no reflect
+ * completion cap** (#3722).
+ *
+ * Verified against the shipped image: `config.py` defines
+ * `HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS` and
+ * `HINDSIGHT_API_CONSOLIDATION_MAX_COMPLETION_TOKENS` and nothing of the kind
+ * for reflect — its only token knobs are `REFLECT_MAX_CONTEXT_TOKENS`,
+ * `REFLECT_MAX_ITERATIONS` and `REFLECT_SOURCE_FACTS_MAX_TOKENS`. So the
+ * completion figure here can only ever be a **reserve held back from the
+ * prompt cap**, never a cap pushed to the backend, and it is named that way so
+ * nobody reads it as an env-var-shaped quantity that failed to be emitted.
+ */
+export interface HindsightReflectBudget {
   lane: "reflect";
+  windowTokens: number;
+  usableTokens: number;
+  windowSource: ContextWindowSource;
+  provider: string;
   /**
    * Derived `HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS` — the reflect loop's
    * accumulated-context bound. Equal to `estimatedPromptTokens`, because for
    * this lane the cap IS the worst-case prompt: the engine forces the final
-   * prompt once accumulation reaches it.
+   * prompt once accumulation reaches it. This is the ONLY reflect number
+   * switchroom emits.
    */
   maxContextTokens: number;
+  /**
+   * Tokens held back from `maxContextTokens` to leave room for reflect's own
+   * answer. **Not enforced at runtime** — see the interface doc: reflect's
+   * completion length is whatever the backend does, so this is a heuristic
+   * reserve, not a guarantee. Sizing it is the only thing switchroom can do.
+   */
+  completionReserveTokens: number;
+  estimatedPromptTokens: number;
+  /**
+   * `maxContextTokens + completionReserveTokens`. A self-consistency check on
+   * the derivation (did we actually hold the reserve back inside the usable
+   * band?), NOT an end-to-end proof — only `maxContextTokens` reaches the
+   * backend.
+   */
+  worstCaseTotalTokens: number;
 }
 
 export interface HindsightContextBudget {
@@ -217,40 +266,91 @@ function clamp(value: number, floor: number, ceiling: number): number {
 }
 
 /**
- * Default window for a provider name. `claude-code` (and a raw `anthropic`
- * provider) get Claude's 200k; everything else gets the conservative local
- * default, because a non-Claude provider in switchroom overwhelmingly means
- * "LiteLLM in front of something local whose window we do not know".
+ * The part of a declared window a lane may actually budget against: the window
+ * minus the {@link HINDSIGHT_CONTEXT_SAFETY_FRACTION} band. Single definition
+ * so no lane can quietly skip the band — the retain lane did exactly that
+ * before #3721, and its worst case (a FIXED 8,000-token prompt estimate plus
+ * the 3,072 completion floor) was checked against the raw window.
  */
-export function defaultContextWindowForProvider(provider: string): number {
+export function usableContextTokens(windowTokens: number): number {
+  return windowTokens - Math.floor(windowTokens * HINDSIGHT_CONTEXT_SAFETY_FRACTION);
+}
+
+/**
+ * Default window for a lane, from `(provider, base_url)` JOINTLY.
+ *
+ * `claude-code` (and a raw `anthropic` provider) get Claude's 200k; everything
+ * else gets the conservative local default, because a non-Claude provider in
+ * switchroom overwhelmingly means "LiteLLM in front of something local whose
+ * window we do not know".
+ *
+ * A **self-hosted `base_url` overrides the provider name** and forces the
+ * conservative window (#3723). Before that, this function read only the
+ * provider name while {@link isSelfHostedHttpUrl}-based
+ * `hindsightLocalLlmEnabled` read only the URL, and the two fail-safed in
+ * OPPOSITE directions — so
+ *
+ * ```yaml
+ * retain: { provider: anthropic, base_url: http://127.0.0.1:4010 }
+ * ```
+ *
+ * was throttled as a local endpoint by the concurrency caps and simultaneously
+ * budgeted for a 200,000-token window here: precisely the silent-overflow
+ * config the preflight exists to reject. The base URL is the stronger signal
+ * (it is where the traffic actually terminates), and both fail-safes now point
+ * the same way — toward the conservative window — because under-declaring
+ * costs throughput while over-declaring corrupts memory.
+ *
+ * @param provider effective provider name for the lane.
+ * @param baseUrl effective `base_url` for the lane, if the operator set one.
+ */
+export function defaultContextWindowForProvider(provider: string, baseUrl?: string): number {
+  const url = baseUrl?.trim();
+  if (url && isSelfHostedHttpUrl(url)) return HINDSIGHT_CONSERVATIVE_CONTEXT_WINDOW;
   const p = provider.trim().toLowerCase();
   if (p === "claude-code" || p === "anthropic") return HINDSIGHT_CLAUDE_CONTEXT_WINDOW;
   return HINDSIGHT_CONSERVATIVE_CONTEXT_WINDOW;
 }
 
 /**
- * Resolve one lane's declared window: per-op override → global → the
- * per-provider default for that lane's EFFECTIVE provider (per-op provider
- * override wins, since a lane can be pointed at a different backend).
+ * Resolve one lane's declared window: per-op override → global → the default
+ * for that lane's EFFECTIVE `(provider, base_url)` pair (the per-op provider
+ * and base URL win, since a lane can be pointed at a different backend).
+ *
+ * An explicitly declared window — per-op or global — always wins over the
+ * default, so `base_url` only ever decides the UNDECLARED case. An operator
+ * who declares a window is taken at their word.
  */
 export function resolveLaneContextWindow(
   lane: HindsightBudgetLane,
   llm?: ContextBudgetLlmInput,
-): { windowTokens: number; windowSource: ContextWindowSource; provider: string } {
+): {
+  windowTokens: number;
+  windowSource: ContextWindowSource;
+  provider: string;
+  baseUrl?: string;
+} {
   const perOp = llm?.[lane];
   const provider = perOp?.provider?.trim() || llm?.provider?.trim() || "claude-code";
+  // Only the lane's OWN base URL. Lanes are budgeted independently, and the
+  // config schema puts `base_url` on the per-op block only — `hindsight.llm`
+  // itself has no global `base_url` field (`HindsightPerOpLlmSchema` in
+  // config/schema.ts, `HindsightPerOpLlmConfig` in hindsight.ts), so there is
+  // nothing to inherit from.
+  const baseUrl = perOp?.base_url?.trim() || undefined;
   const perOpWindow = perOp?.context_window;
   if (typeof perOpWindow === "number" && perOpWindow > 0) {
-    return { windowTokens: Math.floor(perOpWindow), windowSource: "per-op", provider };
+    return { windowTokens: Math.floor(perOpWindow), windowSource: "per-op", provider, baseUrl };
   }
   const globalWindow = llm?.context_window;
   if (typeof globalWindow === "number" && globalWindow > 0) {
-    return { windowTokens: Math.floor(globalWindow), windowSource: "global", provider };
+    return { windowTokens: Math.floor(globalWindow), windowSource: "global", provider, baseUrl };
   }
   return {
-    windowTokens: defaultContextWindowForProvider(provider),
+    windowTokens: defaultContextWindowForProvider(provider, baseUrl),
     windowSource: "provider-default",
     provider,
+    baseUrl,
   };
 }
 
@@ -270,6 +370,15 @@ export function resolveLaneContextWindow(
  * 8,192 / retain completion 6,144 — the values applied by hand to the live
  * container when the incident was diagnosed. For 131k or 200k it lands on
  * the historical batch 12, so a big-window operator loses nothing.
+ *
+ * The retain lane has no batch knob and a FIXED prompt estimate, so nothing in
+ * its derivation shrinks with the window — `usable` binds it only through the
+ * preflight (see {@link assertHindsightContextBudgetFits}), which is why that
+ * check must compare against `usableTokens` and not the raw window (#3721).
+ * Practical effect: the smallest declared window switchroom will accept is
+ * 13,839 tokens (retain's 11,072-token worst case inside an 80% band), up from
+ * 11,072 before the fix. No derived value changed — only which windows the
+ * preflight admits.
  */
 export function resolveHindsightContextBudget(
   llm?: ContextBudgetLlmInput,
@@ -282,7 +391,7 @@ export function resolveHindsightContextBudget(
     HINDSIGHT_CONSOLIDATION_MAX_COMPLETION_FLOOR,
     HINDSIGHT_CONSOLIDATION_MAX_COMPLETION_CEILING,
   );
-  const consUsable = cons.windowTokens - Math.floor(cons.windowTokens * HINDSIGHT_CONTEXT_SAFETY_FRACTION);
+  const consUsable = usableContextTokens(cons.windowTokens);
   const consPromptBudget = consUsable - consMaxCompletion;
   const batchSize = clamp(
     Math.floor(
@@ -307,23 +416,27 @@ export function resolveHindsightContextBudget(
   // budget it as `usable window − room for reflect's own answer`, using the
   // same 3/16 completion share the retain lane gets. Rounded DOWN to a whole
   // thousand purely for legibility in `docker inspect` (32,768 → 20,000).
+  //
+  // The subtracted "room" is a RESERVE, not a cap (#3722): upstream has no
+  // reflect completion knob to emit it into, so holding it back from the
+  // prompt cap is the only enforcement available. See HindsightReflectBudget.
   const refl = resolveLaneContextWindow("reflect", llm);
-  const reflCompletionAllowance = clamp(
+  const reflCompletionReserve = clamp(
     Math.floor((refl.windowTokens * 3) / 16),
     HINDSIGHT_RETAIN_MAX_COMPLETION_FLOOR,
     HINDSIGHT_RETAIN_MAX_COMPLETION_CEILING,
   );
-  const reflUsable =
-    refl.windowTokens - Math.floor(refl.windowTokens * HINDSIGHT_CONTEXT_SAFETY_FRACTION);
+  const reflUsable = usableContextTokens(refl.windowTokens);
   const reflMaxContext = Math.max(
     HINDSIGHT_REFLECT_MAX_CONTEXT_FLOOR,
-    Math.floor((reflUsable - reflCompletionAllowance) / 1000) * 1000,
+    Math.floor((reflUsable - reflCompletionReserve) / 1000) * 1000,
   );
 
   return {
     consolidation: {
       lane: "consolidation",
       windowTokens: cons.windowTokens,
+      usableTokens: consUsable,
       windowSource: cons.windowSource,
       provider: cons.provider,
       batchSize,
@@ -334,16 +447,18 @@ export function resolveHindsightContextBudget(
     reflect: {
       lane: "reflect",
       windowTokens: refl.windowTokens,
+      usableTokens: reflUsable,
       windowSource: refl.windowSource,
       provider: refl.provider,
       maxContextTokens: reflMaxContext,
-      maxCompletionTokens: reflCompletionAllowance,
+      completionReserveTokens: reflCompletionReserve,
       estimatedPromptTokens: reflMaxContext,
-      worstCaseTotalTokens: reflMaxContext + reflCompletionAllowance,
+      worstCaseTotalTokens: reflMaxContext + reflCompletionReserve,
     },
     retain: {
       lane: "retain",
       windowTokens: ret.windowTokens,
+      usableTokens: usableContextTokens(ret.windowTokens),
       windowSource: ret.windowSource,
       provider: ret.provider,
       maxCompletionTokens: retMaxCompletion,
@@ -363,16 +478,58 @@ export class HindsightContextBudgetError extends Error {
   }
 }
 
-function laneFailure(b: HindsightLaneBudget): string | undefined {
-  if (b.worstCaseTotalTokens > b.windowTokens) {
+/**
+ * The lane-shaped subset the preflight checks. Reflect's completion figure is
+ * a reserve rather than a cap (#3722), so it is normalised in here under a
+ * neutral name instead of being called a `maxCompletionTokens` it is not.
+ */
+interface LaneCheck {
+  lane: HindsightBudgetLane;
+  windowTokens: number;
+  usableTokens: number;
+  windowSource: ContextWindowSource;
+  provider: string;
+  estimatedPromptTokens: number;
+  completionTokens: number;
+  /** "completion" for retain/consolidation, "completion reserve" for reflect. */
+  completionLabel: string;
+  worstCaseTotalTokens: number;
+  /** Only retain has upstream's `> retain_chunk_size` boot check. */
+  maxCompletionTokens?: number;
+}
+
+function laneCheck(b: HindsightLaneBudget): LaneCheck {
+  return { ...b, completionTokens: b.maxCompletionTokens, completionLabel: "completion" };
+}
+
+function reflectLaneCheck(b: HindsightReflectBudget): LaneCheck {
+  return {
+    ...b,
+    completionTokens: b.completionReserveTokens,
+    completionLabel: "completion reserve",
+  };
+}
+
+function laneFailure(b: LaneCheck): string | undefined {
+  // Against `usableTokens`, NOT the raw window (#3721). The safety band is the
+  // whole defence against the prompt ESTIMATES being wrong, and an overflow is
+  // silent, so a lane whose worst case only fits by eating the band has no
+  // slack left for the thing the band exists to absorb.
+  if (b.worstCaseTotalTokens > b.usableTokens) {
     return (
       `hindsight ${b.lane}: worst-case ${b.worstCaseTotalTokens} tokens ` +
-      `(${b.estimatedPromptTokens} prompt + ${b.maxCompletionTokens} completion) ` +
-      `exceeds the declared ${b.windowTokens}-token context window ` +
-      `(source: ${b.windowSource}, provider: ${b.provider}).`
+      `(${b.estimatedPromptTokens} prompt + ${b.completionTokens} ${b.completionLabel}) ` +
+      `exceeds the ${b.usableTokens} usable tokens of ` +
+      `the declared ${b.windowTokens}-token context window ` +
+      `(${Math.round(HINDSIGHT_CONTEXT_SAFETY_FRACTION * 100)}% safety band held back; ` +
+      `source: ${b.windowSource}, provider: ${b.provider}).`
     );
   }
-  if (b.lane === "retain" && b.maxCompletionTokens <= HINDSIGHT_UPSTREAM_RETAIN_CHUNK_SIZE) {
+  if (
+    b.lane === "retain" &&
+    b.maxCompletionTokens !== undefined &&
+    b.maxCompletionTokens <= HINDSIGHT_UPSTREAM_RETAIN_CHUNK_SIZE
+  ) {
     return (
       `hindsight retain: derived max_completion_tokens ${b.maxCompletionTokens} is not ` +
       `greater than the upstream retain_chunk_size ${HINDSIGHT_UPSTREAM_RETAIN_CHUNK_SIZE}; ` +
@@ -383,8 +540,9 @@ function laneFailure(b: HindsightLaneBudget): string | undefined {
 }
 
 /**
- * Preflight: fail LOUDLY when the derived budget cannot fit the declared
- * window. This is the whole point of the change.
+ * Preflight: fail LOUDLY when the derived budget cannot fit the **usable** part
+ * of the declared window (window minus the safety band). This is the whole
+ * point of the change.
  *
  * A context overflow on a llama.cpp backend produces a well-formed HTTP 200
  * carrying conversational garbage — no exception, no non-2xx, no
@@ -392,13 +550,25 @@ function laneFailure(b: HindsightLaneBudget): string | undefined {
  * is knowable is HERE, before the container is launched, where it is a pure
  * arithmetic comparison. Prompt discipline can't guarantee this; a throw at
  * setup time can.
+ *
+ * How strong the guarantee is, honestly, per lane (#3722):
+ *
+ *  - **retain / consolidation** — end to end. Both terms are emitted:
+ *    the prompt side via `CONSOLIDATION_LLM_BATCH_SIZE` (retain's prompt is an
+ *    estimate, hence the band) and the completion side via
+ *    `*_MAX_COMPLETION_TOKENS`, which upstream honours.
+ *  - **reflect** — prompt side only. Upstream has `REFLECT_MAX_CONTEXT_TOKENS`
+ *    and NO reflect completion knob, so the completion term in reflect's row
+ *    is a reserve switchroom holds back from the prompt cap, not a bound the
+ *    backend is told about. Reflect's actual answer length is unbounded
+ *    upstream; the check proves the reserve was held back, nothing more.
  */
 export function assertHindsightContextBudgetFits(budget: HindsightContextBudget): void {
   for (const lane of [
-    budget.consolidation,
-    budget.retain,
-    budget.reflect,
-  ] as HindsightLaneBudget[]) {
+    laneCheck(budget.consolidation),
+    laneCheck(budget.retain),
+    reflectLaneCheck(budget.reflect),
+  ]) {
     const failure = laneFailure(lane);
     if (failure) {
       throw new HindsightContextBudgetError(

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -20,6 +20,7 @@ import {
   HINDSIGHT_CONSOLIDATION_BATCH_SIZE_CEILING,
   resolveCheckedHindsightContextBudget,
 } from "./hindsight-context-budget.js";
+import { isLoopbackHttpUrl, isSelfHostedHttpUrl } from "./self-hosted-url.js";
 
 /**
  * Default Hindsight host ports.
@@ -1213,24 +1214,13 @@ export function resolveHindsightLlm(
  */
 
 /**
- * True when `url` resolves to a host-loopback listener (localhost / 127.0.0.1 /
- * ::1). Used to decide whether hindsight must join the host network so the
- * container can reach a LiteLLM base the operator wrote as loopback.
+ * `isLoopbackHttpUrl` / `isSelfHostedHttpUrl` now live in `self-hosted-url.ts`
+ * and are re-exported here so every existing importer is unchanged. They moved
+ * (#3723) because `hindsight-context-budget.ts` must read the SAME self-hosted
+ * signal when defaulting a lane's context window, and it cannot import this
+ * module (this module imports it — cycle).
  */
-export function isLoopbackHttpUrl(url: string): boolean {
-  try {
-    const u = new URL(url.includes("://") ? url : `http://${url}`);
-    // `new URL("http://[::1]:4010").hostname` is "[::1]" — WITH the brackets.
-    // Comparing the raw hostname against "::1" therefore never matched, so an
-    // IPv6-loopback LiteLLM base was silently classified as remote and
-    // hindsightNeedsHostNetwork() left the container on the bridge network
-    // (the silent-retain outage class). Strip the brackets first.
-    const h = (u.hostname || "").toLowerCase().replace(/^\[|\]$/g, "");
-    return h === "localhost" || h === "127.0.0.1" || h === "::1";
-  } catch {
-    return false;
-  }
-}
+export { isLoopbackHttpUrl, isSelfHostedHttpUrl } from "./self-hosted-url.js";
 
 /**
  * Collect every configured LiteLLM / per-op LLM base URL from the same inputs
@@ -1271,42 +1261,6 @@ export function hindsightNeedsHostNetwork(
 ): boolean {
   if (litellm?.baseUrl?.trim()) return true;
   return collectHindsightLlmBaseUrls(llm).some(isLoopbackHttpUrl);
-}
-
-/**
- * True when `url` names an endpoint on this host or this LAN — loopback,
- * RFC1918 private space, link-local, `.local` mDNS, or Docker's
- * `host.docker.internal` bridge alias.
- *
- * This is the "finite slot pool" test, not the "reachable" test: what makes a
- * self-hosted LLM different from a cloud provider is that it serves a handful
- * of fixed slots, so filling them starves every other client on the box.
- * A hostname that is not provably private reads as cloud — the fail-safe
- * direction, since being wrong there just leaves upstream's default in place.
- */
-export function isSelfHostedHttpUrl(url: string): boolean {
-  let host: string;
-  try {
-    const u = new URL(url.includes("://") ? url : `http://${url}`);
-    host = (u.hostname || "").toLowerCase().replace(/^\[|\]$/g, "");
-  } catch {
-    return false;
-  }
-  if (!host) return false;
-  if (isLoopbackHttpUrl(url)) return true;
-  if (host === "host.docker.internal" || host === "gateway.docker.internal") return true;
-  if (host.endsWith(".local") || host.endsWith(".internal")) return true;
-  // IPv6 unique-local (fc00::/7) and link-local (fe80::/10).
-  if (/^f[cd][0-9a-f]{2}:/.test(host) || /^fe[89ab][0-9a-f]:/.test(host)) return true;
-  const v4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (!v4) return false;
-  const [a, b] = [Number(v4[1]), Number(v4[2])];
-  if (a === 10) return true; // 10.0.0.0/8
-  if (a === 127) return true; // 127.0.0.0/8 (bare-IP form isLoopbackHttpUrl misses)
-  if (a === 192 && b === 168) return true; // 192.168.0.0/16
-  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
-  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local
-  return false;
 }
 
 /**

--- a/src/setup/self-hosted-url.ts
+++ b/src/setup/self-hosted-url.ts
@@ -1,0 +1,72 @@
+/**
+ * Self-hosted / loopback URL predicates — the SINGLE definition of "does this
+ * base URL terminate on this host or this LAN?".
+ *
+ * Extracted out of `hindsight.ts` (#3723) so `hindsight-context-budget.ts` can
+ * read the same signal without an import cycle: `hindsight.ts` already imports
+ * the budget module, so the budget module cannot import back. Before this
+ * split, switchroom answered "is this lane talking to a small local model?"
+ * from two different inputs — `hindsightLocalLlmEnabled` from the base URL,
+ * `defaultContextWindowForProvider` from the provider NAME — with opposite
+ * fail-safe directions, so a `provider: anthropic` lane pointed at
+ * `http://127.0.0.1:4010` was throttled as local by one and budgeted for a
+ * 200k window by the other. This module is dependency-free on purpose: both
+ * callers import it, so they can never disagree.
+ */
+
+/**
+ * True when `url` resolves to a host-loopback listener (localhost / 127.0.0.1 /
+ * ::1). Used to decide whether hindsight must join the host network so the
+ * container can reach a LiteLLM base the operator wrote as loopback.
+ */
+export function isLoopbackHttpUrl(url: string): boolean {
+  try {
+    const u = new URL(url.includes("://") ? url : `http://${url}`);
+    // `new URL("http://[::1]:4010").hostname` is "[::1]" — WITH the brackets.
+    // Comparing the raw hostname against "::1" therefore never matched, so an
+    // IPv6-loopback LiteLLM base was silently classified as remote and
+    // hindsightNeedsHostNetwork() left the container on the bridge network
+    // (the silent-retain outage class). Strip the brackets first.
+    const h = (u.hostname || "").toLowerCase().replace(/^\[|\]$/g, "");
+    return h === "localhost" || h === "127.0.0.1" || h === "::1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * True when `url` names an endpoint on this host or this LAN — loopback,
+ * RFC1918 private space, link-local, `.local` mDNS, or Docker's
+ * `host.docker.internal` bridge alias.
+ *
+ * This is the "finite slot pool" test, not the "reachable" test: what makes a
+ * self-hosted LLM different from a cloud provider is that it serves a handful
+ * of fixed slots, so filling them starves every other client on the box.
+ * A hostname that is not provably private reads as cloud — the fail-safe
+ * direction for the concurrency caps, since being wrong there just leaves
+ * upstream's default in place.
+ */
+export function isSelfHostedHttpUrl(url: string): boolean {
+  let host: string;
+  try {
+    const u = new URL(url.includes("://") ? url : `http://${url}`);
+    host = (u.hostname || "").toLowerCase().replace(/^\[|\]$/g, "");
+  } catch {
+    return false;
+  }
+  if (!host) return false;
+  if (isLoopbackHttpUrl(url)) return true;
+  if (host === "host.docker.internal" || host === "gateway.docker.internal") return true;
+  if (host.endsWith(".local") || host.endsWith(".internal")) return true;
+  // IPv6 unique-local (fc00::/7) and link-local (fe80::/10).
+  if (/^f[cd][0-9a-f]{2}:/.test(host) || /^fe[89ab][0-9a-f]:/.test(host)) return true;
+  const v4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!v4) return false;
+  const [a, b] = [Number(v4[1]), Number(v4[2])];
+  if (a === 10) return true; // 10.0.0.0/8
+  if (a === 127) return true; // 127.0.0.0/8 (bare-IP form isLoopbackHttpUrl misses)
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local
+  return false;
+}

--- a/tests/setup/hindsight-context-budget.test.ts
+++ b/tests/setup/hindsight-context-budget.test.ts
@@ -18,18 +18,22 @@ import {
   HINDSIGHT_CONSOLIDATION_PROMPT_OVERHEAD_TOKENS,
   HINDSIGHT_CONSOLIDATION_TOKENS_PER_FACT,
   HINDSIGHT_RETAIN_MAX_COMPLETION_CEILING,
+  HINDSIGHT_RETAIN_PROMPT_ESTIMATE_TOKENS,
   HINDSIGHT_UPSTREAM_REFLECT_MAX_CONTEXT_TOKENS,
   HINDSIGHT_UPSTREAM_RETAIN_CHUNK_SIZE,
   HindsightContextBudgetError,
   assertHindsightContextBudgetFits,
+  defaultContextWindowForProvider,
   resolveCheckedHindsightContextBudget,
   resolveHindsightContextBudget,
   resolveLaneContextWindow,
+  usableContextTokens,
 } from "../../src/setup/hindsight-context-budget.js";
 import {
   HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS,
   generateHindsightComposeSnippet,
   hindsightLlmBudgetEnv,
+  hindsightLocalLlmEnabled,
   startHindsight,
 } from "../../src/setup/hindsight.js";
 
@@ -173,7 +177,7 @@ describe("hindsight context budget — preflight (#3716)", () => {
       HindsightContextBudgetError,
     );
     expect(() => resolveCheckedHindsightContextBudget(tooSmall)).toThrow(
-      /exceeds the declared 4096-token context window/,
+      /exceeds the \d+ usable tokens of the declared 4096-token context window/,
     );
   });
 
@@ -229,6 +233,176 @@ describe("hindsight context budget — preflight (#3716)", () => {
     for (const llm of [undefined, { provider: "litellm" }, { provider: "claude-code" }, localLlm]) {
       expect(() => resolveCheckedHindsightContextBudget(llm)).not.toThrow();
     }
+  });
+});
+
+describe("hindsight context budget — the safety band binds the retain lane too (#3721)", () => {
+  // Retain's worst case pins at 11,072 across this whole band: the prompt term
+  // is the FIXED 8,000-token estimate and the completion term is clamped to the
+  // 3,072 floor. So the raw window it needs is 11,072, but the band it must fit
+  // inside is 0.8 × window — and those two disagree from 11,072 to 13,838.
+  const RETAIN_WORST_CASE = HINDSIGHT_RETAIN_PROMPT_ESTIMATE_TOKENS + 3_072;
+
+  it("pins the arithmetic the band boundaries are derived from", () => {
+    expect(RETAIN_WORST_CASE).toBe(11_072);
+    for (const window of [11_072, 13_838]) {
+      const b = resolveHindsightContextBudget({ provider: "litellm", context_window: window });
+      // The PRE-FIX check — worst case vs the raw window — passes here. That is
+      // what makes the two cases below a regression test rather than a walk of
+      // the code path: on main they did not throw.
+      expect(b.retain.worstCaseTotalTokens).toBe(RETAIN_WORST_CASE);
+      expect(b.retain.worstCaseTotalTokens).toBeLessThanOrEqual(b.retain.windowTokens);
+      expect(b.retain.worstCaseTotalTokens).toBeGreaterThan(b.retain.usableTokens);
+    }
+  });
+
+  it("REJECTS the low edge of the band (11,072 — raw check passes exactly)", () => {
+    const at = { provider: "litellm", context_window: 11_072 };
+    expect(() => resolveCheckedHindsightContextBudget(at)).toThrow(HindsightContextBudgetError);
+    expect(() => resolveCheckedHindsightContextBudget(at)).toThrow(/hindsight retain/);
+    // usable = 11072 − ⌊11072 × 0.2⌋ = 8858.
+    expect(usableContextTokens(11_072)).toBe(8_858);
+  });
+
+  it("REJECTS the high edge of the band (13,838 — usable 11,071, one short)", () => {
+    const at = { provider: "litellm", context_window: 13_838 };
+    expect(usableContextTokens(13_838)).toBe(RETAIN_WORST_CASE - 1);
+    expect(() => resolveCheckedHindsightContextBudget(at)).toThrow(/hindsight retain/);
+  });
+
+  it("ACCEPTS the first window above the band (13,839 — usable 11,072)", () => {
+    expect(usableContextTokens(13_839)).toBe(RETAIN_WORST_CASE);
+    expect(() =>
+      resolveCheckedHindsightContextBudget({ provider: "litellm", context_window: 13_839 }),
+    ).not.toThrow();
+  });
+
+  it("reports the band in the failure text, so the operator can do the sum", () => {
+    try {
+      resolveCheckedHindsightContextBudget({ provider: "litellm", context_window: 12_000 });
+      expect.unreachable("preflight should have thrown");
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toContain("usable tokens");
+      expect(msg).toContain("20% safety band");
+      expect(msg).toContain("declared 12000-token context window");
+    }
+  });
+
+  it("holds EVERY lane to the same band — no lane budgets the raw window", () => {
+    for (const window of [13_839, 16_384, LOCAL_SLOT_WINDOW, 131_072, 200_000]) {
+      const b = resolveHindsightContextBudget({ provider: "litellm", context_window: window });
+      const usable = usableContextTokens(window);
+      for (const lane of [b.retain, b.consolidation, b.reflect]) {
+        expect(lane.usableTokens, `${lane.lane}@${window}`).toBe(usable);
+        expect(lane.worstCaseTotalTokens, `${lane.lane}@${window}`).toBeLessThanOrEqual(usable);
+      }
+    }
+  });
+});
+
+describe("hindsight context budget — reflect's completion figure is a reserve, not a cap (#3722)", () => {
+  it("names it a reserve and never calls it a max-completion cap", () => {
+    // Upstream (config.py in the shipped image) defines
+    // RETAIN_/CONSOLIDATION_MAX_COMPLETION_TOKENS and nothing equivalent for
+    // reflect — its token knobs are REFLECT_MAX_CONTEXT_TOKENS,
+    // REFLECT_MAX_ITERATIONS, REFLECT_SOURCE_FACTS_MAX_TOKENS. So the field
+    // must not be shaped like an env var switchroom forgot to emit.
+    const b = resolveHindsightContextBudget(localLlm);
+    expect(b.reflect.completionReserveTokens).toBe(6_144);
+    expect(b.reflect).not.toHaveProperty("maxCompletionTokens");
+  });
+
+  it("holds the reserve back from the emitted prompt cap", () => {
+    // The reserve is unenforceable at runtime, so the ONLY thing it can do is
+    // shrink the one number that IS emitted. Assert that it did.
+    const b = resolveHindsightContextBudget(localLlm);
+    expect(b.reflect.maxContextTokens).toBeLessThanOrEqual(
+      b.reflect.usableTokens - b.reflect.completionReserveTokens,
+    );
+  });
+
+  it("emits no reflect completion var on either path (upstream has no such knob)", () => {
+    mockedExec.mockReset();
+    mockedExec.mockReturnValue("");
+    startHindsight({ apiPort: 8888, uiPort: 9999 }, undefined, undefined, localLlm);
+    const runEnv = envPairsFromRun();
+    const snippet = generateHindsightComposeSnippet(localLlm);
+    const budgetEnv = hindsightLlmBudgetEnv(localLlm).map(([k]) => k);
+    for (const key of budgetEnv) expect(key).not.toMatch(/REFLECT.*COMPLETION/);
+    expect(runEnv.filter((e) => /REFLECT.*COMPLETION/.test(e))).toEqual([]);
+    expect(snippet).not.toMatch(/REFLECT.*COMPLETION/);
+    // …and the one reflect var that DOES exist upstream is still emitted.
+    expect(budgetEnv).toContain("HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS");
+  });
+});
+
+describe("hindsight context budget — provider name and base URL agree (#3723)", () => {
+  const LOOPBACK = "http://127.0.0.1:4010/v1";
+
+  it("forces the conservative window when a lane's base URL is self-hosted", () => {
+    // The hazardous config: `provider: anthropic` is just a routing label on a
+    // LiteLLM-fronted local box. Pre-fix this returned 200,000 while
+    // hindsightLocalLlmEnabled() called the same endpoint local — the exact
+    // silent-overflow shape the preflight exists to reject.
+    const llm = { retain: { provider: "anthropic", base_url: LOOPBACK } };
+    expect(resolveLaneContextWindow("retain", llm)).toMatchObject({
+      windowTokens: HINDSIGHT_CONSERVATIVE_CONTEXT_WINDOW,
+      windowSource: "provider-default",
+      provider: "anthropic",
+    });
+    expect(defaultContextWindowForProvider("anthropic", LOOPBACK)).toBe(
+      HINDSIGHT_CONSERVATIVE_CONTEXT_WINDOW,
+    );
+    // And the budget really is the ratcheted one, not just the number.
+    expect(resolveHindsightContextBudget(llm).retain.maxCompletionTokens).toBe(6_144);
+  });
+
+  it("agrees with hindsightLocalLlmEnabled on the same config", () => {
+    // The two detectors now read the same input, so they cannot disagree.
+    for (const url of [LOOPBACK, "http://10.0.0.7:11434", "http://ollama.local:11434"]) {
+      const llm = { retain: { provider: "anthropic", base_url: url } };
+      expect(hindsightLocalLlmEnabled(llm), url).toBe(true);
+      expect(resolveLaneContextWindow("retain", llm).windowTokens, url).toBe(
+        HINDSIGHT_CONSERVATIVE_CONTEXT_WINDOW,
+      );
+    }
+  });
+
+  it("leaves a genuinely hosted endpoint on the provider default", () => {
+    const llm = { retain: { provider: "anthropic", base_url: "https://api.anthropic.com" } };
+    expect(hindsightLocalLlmEnabled(llm)).toBe(false);
+    expect(resolveLaneContextWindow("retain", llm).windowTokens).toBe(
+      HINDSIGHT_CLAUDE_CONTEXT_WINDOW,
+    );
+  });
+
+  it("only decides the UNDECLARED case — an explicit window still wins", () => {
+    const llm = {
+      context_window: 131_072,
+      retain: { provider: "anthropic", base_url: LOOPBACK },
+      reflect: { provider: "anthropic", base_url: LOOPBACK, context_window: 65_536 },
+    };
+    expect(resolveLaneContextWindow("retain", llm)).toMatchObject({
+      windowTokens: 131_072,
+      windowSource: "global",
+    });
+    expect(resolveLaneContextWindow("reflect", llm)).toMatchObject({
+      windowTokens: 65_536,
+      windowSource: "per-op",
+    });
+  });
+
+  it("scopes the signal to the lane that carries it", () => {
+    // Lanes are budgeted independently: a loopback retain lane must not drag
+    // an unrelated claude-code consolidation lane down to 32k.
+    const llm = { provider: "claude-code", retain: { base_url: LOOPBACK } };
+    expect(resolveLaneContextWindow("retain", llm).windowTokens).toBe(
+      HINDSIGHT_CONSERVATIVE_CONTEXT_WINDOW,
+    );
+    expect(resolveLaneContextWindow("consolidation", llm).windowTokens).toBe(
+      HINDSIGHT_CLAUDE_CONTEXT_WINDOW,
+    );
   });
 });
 


### PR DESCRIPTION
Closes #3721, closes #3722, closes #3723 — the three LOW findings from the adversarial review of #3717 (merged `0bed9068`). All verified against the code at HEAD before fixing; one issue's characterisation was wrong and is corrected below.

Job spec: `reference/jobs/remember-across-sessions.md` — a silently context-shifted retain/consolidation call is memory that looks stored and is not.

## Summary

**#3721 — the safety band now binds every lane, including retain. VERIFIED as described.**
`consUsable` (`hindsight-context-budget.ts:285`) and `reflUsable` (`:316`) applied the 20% band; retain had no `usable` at all and `laneFailure` (`:366`) compared every lane's worst case against the RAW window. Retain's worst case pins at 11,072 (`HINDSIGHT_RETAIN_PROMPT_ESTIMATE_TOKENS` 8,000 + the 3,072 completion floor), so the issue's band 11,072–13,838 is exact and reproduced.

Fix: one `usableContextTokens()` definition, a `usableTokens` field on every lane budget, and `laneFailure` compares against it. Chosen over deriving `retMaxCompletion` from a `retUsable` deliberately — that alternative would have moved the live retain cap 6,144 → 4,915.

**#3722 — the issue's premise was WRONG; corrected here.**
`reflCompletionAllowance` is not dead code: it feeds `reflMaxContext` (`:316-321`) and is the completion half of reflect's `worstCaseTotalTokens`. The real defect is the second reading the issue offers, and the upstream check settles it:

```
$ docker exec switchroom-hindsight grep -n "MAX_COMPLETION" /app/api/hindsight_api/config.py
490:ENV_RETAIN_MAX_COMPLETION_TOKENS = "HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS"
546:ENV_CONSOLIDATION_MAX_COMPLETION_TOKENS = "HINDSIGHT_API_CONSOLIDATION_MAX_COMPLETION_TOKENS"
```

There is no reflect completion knob upstream — reflect's only token knobs are `REFLECT_MAX_CONTEXT_TOKENS`, `REFLECT_MAX_ITERATIONS`, `REFLECT_SOURCE_FACTS_MAX_TOKENS`. Emitting it (resolution 1) is impossible, so this takes resolution 2: `reflect.maxCompletionTokens` → `completionReserveTokens`, `HindsightReflectBudget` no longer extends `HindsightLaneBudget` (it has no completion cap to carry), and the preflight docstring now says per lane how strong its guarantee is — retain/consolidation end to end, reflect prompt-side only. The arithmetic is unchanged: holding the reserve back from the emitted prompt cap is the only enforcement available, and the check that it *was* held back is still worth running.

**#3723 — verified and fixed at the root.**
`defaultContextWindowForProvider(provider, baseUrl?)` now consults the base URL, and a self-hosted one forces 32,768 regardless of the provider name. Both fail-safes point the same way. `isLoopbackHttpUrl` / `isSelfHostedHttpUrl` moved to a new dependency-free `src/setup/self-hosted-url.ts` and are re-exported from `hindsight.ts` (unchanged for every importer) — the budget module cannot import `hindsight.ts`, which imports it. An explicitly declared window still wins, and the signal is scoped to the lane that carries it (lanes are budgeted independently).

## Does this shift what the live fleet emits? No.

Checked against the real `~/.switchroom/switchroom.yaml`: `hindsight.llm` declares no `context_window` at all, so all three lanes resolve `provider-default` from `provider: litellm` = 32,768, and the loopback `base_url` agrees. Derived budget before and after this PR is byte-identical:

| lane | window | usable | derived | worst case |
|---|---|---|---|---|
| consolidation | 32,768 | 26,215 | batch 6, completion 8,192 | 25,462 |
| retain | 32,768 | 26,215 | completion 6,144 | 14,144 |
| reflect | 32,768 | 26,215 | max-context 20,000 | 26,144 |

No derived value in this PR changes for ANY window — the derivation is untouched. The only behavioural change is which windows the preflight admits: the minimum accepted declared window moves **11,072 → 13,839**. Anything below that could not fit retain's worst case inside the band, which is the point. (Note how tight reflect is at 32k: 26,144 of 26,215 usable, 71 tokens of slack. Not introduced here, but it is the binding lane and worth knowing before anyone edits the reflect share.)

## Test plan

`tests/setup/hindsight-context-budget.test.ts`, three new describe blocks, 12 new tests. Boundary tests are at the exact edges and assert the pre-fix check would have passed:

- 11,072 → throws (`usable` 8,858), and `worstCaseTotalTokens <= windowTokens` is asserted true at the same time, so the test fails on the bug rather than walking the path
- 13,838 → throws (`usable` 11,071, one short)
- 13,839 → passes (`usable` 11,072)
- every lane's `worstCaseTotalTokens <= usableTokens` across 13,839 / 16,384 / 32,768 / 131,072 / 200,000
- reflect exposes `completionReserveTokens` and has NO `maxCompletionTokens`; no `/REFLECT.*COMPLETION/` env on either emit path; `REFLECT_MAX_CONTEXT_TOKENS` still emitted
- `resolveLaneContextWindow("retain", { retain: { provider: "anthropic", base_url: "http://127.0.0.1:4010/v1" } })` → 32,768, and agrees with `hindsightLocalLlmEnabled` on the same config for loopback / RFC1918 / `.local`

Falsification runs (both reverted after):
- reverting `laneFailure` to the raw window → the 3 band tests fail, 32 pass
- removing the `isSelfHostedHttpUrl` line from the default → the 3 #3723 tests fail, 32 pass

Local: `vitest run tests/setup src/setup` 415 passed; `vitest run tests/setup src/setup src/config` 802 passed; `npm run lint` clean (all 17 guards).

## Risk

Low, with one deliberate tightening. An operator who declared a window in 11,072–13,838 gets a `HindsightContextBudgetError` at setup where they previously got a green preflight and a retain lane with zero headroom — that is the intended fix, and the error text now names the usable figure and the band so the sum is checkable. No fleet member is in that range. The `self-hosted-url.ts` extraction is a pure move (bodies unchanged, re-exported), covered by the existing `hindsight-perf-defaults.test.ts` predicate tests which still pass unmodified.

Adjacent work: another branch is editing consolidation constants in `src/setup/hindsight.ts`. This PR touches that file in only two places — the import block and the two moved predicates (~line 1215) — so a conflict is unlikely but flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)