### PR TITLE
fix(gateway): latest-ended supersede anchor must be a turn that actually ended

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -717,6 +717,7 @@ import {
 } from './emission-authority.js'
 import { CurrentTurnMap } from './current-turn-map.js'
 import { resolveAnswerThreadId } from './answer-thread-resolve.js'
+import { latestTurnForChat } from './latest-turn-lookup.js'
 import { decideObligationTurnEnd } from './obligation-turn-end.js'
 import { maybeRotate, resolveAgentStateDir, resolveTurnsJsonlPath } from './turns-jsonl-rotate.js'
 import {
@@ -3484,12 +3485,14 @@ export type CurrentTurn = {
   flushedAnswerText: string | null
   // 2026-07 double-reply-on-DM fix (F2 — recency bound). Wall-clock ms the turn
   // ENDED (stamped once by `endCurrentTurnAtomic`), or null while still live.
-  // The `findLatestEndedTurnForChat` supersede tier carries DESTRUCTIVE
-  // authority (it drives message deletion), so `resolveReplyOwnerTurn` only
-  // honours a latest-ended turn whose `endedAt` is within the supersede TTL —
+  // The `latest-ended` supersede tier carries DESTRUCTIVE authority (it drives
+  // message deletion), so `resolveReplyOwnerTurn` only honours a latest-ended
+  // turn whose `endedAt` is non-null (#3725 — the registry is populated at turn
+  // START, so the tail entry may still be RUNNING) AND within the supersede TTL —
   // otherwise a late reply belonging to an OLDER turn could resolve its owner to
-  // a NEWER turn sitting at the registry tail and delete that newer turn's legit
-  // answer. Unbounded routing use of `findLatestEndedTurnForChat` is unaffected.
+  // a NEWER turn at the registry tail and delete that turn's legit answer. The
+  // unbounded ROUTING use (`endedOnly: false`) is unaffected: it only picks a
+  // topic to deliver into and deletes nothing.
   endedAt: number | null
   // #1675 (over-ping safety net): wall-clock ms of the first reply
   // this turn that landed with `disable_notification: false` (a real
@@ -3999,21 +4002,18 @@ const LATE_REPLY_TOPIC_RECOVERY_ENABLED =
   process.env.SWITCHROOM_LATE_REPLY_TOPIC_RECOVERY !== '0'
 
 /**
- * The most-recently-started turn for a chat from the bounded recently-ended
- * registry — the deterministic fallback for a LATE answer reply when the model
- * echoed no `origin_turn_id` and `currentTurn` has already cleared. Iterates in
- * insertion order so the last match is the most recent turn for that chat.
- * Returns null when the chat has no remembered turn (so the caller keeps the
- * legacy result). NB: this is the chat's own most-recent TURN, not the
- * `chatThreadMap` last-seen-any-message heuristic that caused the wrong-topic
- * bug — a late reply almost always belongs to the turn that just ended.
+ * The most recent turn for a chat from the bounded recent-turn registry — the
+ * deterministic fallback for a LATE answer reply when the model echoed no
+ * `origin_turn_id` and `currentTurn` has already cleared. Returns null when the
+ * chat has no matching turn (so the caller keeps the legacy result). NB: this is
+ * the chat's own most-recent TURN, not the `chatThreadMap` last-seen-any-message
+ * heuristic that caused the wrong-topic bug. `endedOnly` selects the consumer's
+ * semantics — routing takes the tail entry even when that turn is still RUNNING;
+ * the destructive `latest-ended` owner tier takes only a genuinely ENDED turn,
+ * because the registry is populated at turn START (#3725; see the module).
  */
-function findLatestEndedTurnForChat(chatId: string): CurrentTurn | null {
-  let latest: CurrentTurn | null = null
-  for (const t of recentTurnsById.values()) {
-    if (t.sessionChatId === chatId) latest = t
-  }
-  return latest
+function findLatestTurnForChat(chatId: string, opts: { endedOnly: boolean }): CurrentTurn | null {
+  return latestTurnForChat(recentTurnsById.values(), chatId, opts)
 }
 
 /**
@@ -4029,7 +4029,7 @@ function findLatestEndedTurnForChat(chatId: string): CurrentTurn | null {
  *   1. the live `currentTurn` passed in (null once the flush nulled the atom);
  *   2. `findTurnByOriginId(origin_turn_id)` — the model echo;
  *   3. `findTurnByQuotedMessageId(chat_id, reply_to)` — framework-owned quote;
- *   4. `findLatestEndedTurnForChat(chat_id)` — the chat's last-ended turn.
+ *   4. `findLatestTurnForChat(chat_id, {endedOnly:true})` — last ENDED turn.
  * Returns the CurrentTurn for the winning id (so callers can read its
  * `answerDelivered` latch), or null when every lookup missed.
  */
@@ -4040,7 +4040,7 @@ function resolveReplyOwnerTurn(
 ): { turn: CurrentTurn | null; tier: ReplyOwnerTier; candidates: ReplyOwnerCandidates } {
   const origin = findTurnByOriginId(args.origin_turn_id as string | undefined)
   const quoted = findTurnByQuotedMessageId(chatId, args.reply_to)
-  const latestEnded = findLatestEndedTurnForChat(chatId)
+  const latestEnded = findLatestTurnForChat(chatId, { endedOnly: true })
   const byId = new Map<string, CurrentTurn>()
   // Populate lowest-precedence first so a higher tier's turn wins the id slot
   // when two lookups resolve the same turn (they carry the same turnId anyway).
@@ -4049,9 +4049,9 @@ function resolveReplyOwnerTurn(
   }
   // F2 — bound the DESTRUCTIVE latest-ended tier to the supersede TTL so a stale
   // latest-ended turn can't inherit deletion authority over a newer turn's flush
-  // record. `endedAt` is null only for a turn still resolvable but not yet ended
-  // (not a supersede risk); leave the age unset then (unbounded) rather than
-  // fabricate one.
+  // record. #3725: the lookup above is `endedOnly`, so `endedAt` is non-null here
+  // and the age is ALWAYS a real number — a not-yet-ended turn is no longer a
+  // candidate at all, and an explicit null age now fails CLOSED downstream.
   const latestEndedAgeMs =
     latestEnded?.endedAt != null ? Date.now() - latestEnded.endedAt : null
   const candidates: ReplyOwnerCandidates = {
@@ -4114,7 +4114,7 @@ function resolveAnswerThreadWithLog(
     explicitThreadId == null &&
     originTurn == null &&
     liveTurn == null
-      ? findLatestEndedTurnForChat(chatId)
+      ? findLatestTurnForChat(chatId, { endedOnly: false })
       : null
   const threadId = resolveAnswerThreadId({
     explicitThreadId,

--- a/telegram-plugin/gateway/latest-turn-lookup.ts
+++ b/telegram-plugin/gateway/latest-turn-lookup.ts
@@ -1,0 +1,60 @@
+/**
+ * The recently-seen-turn registry scan, extracted from `gateway.ts` as a pure
+ * function so its ENDED-ness contract is unit-testable (#3725; gateway.ts is not
+ * importable in tests — the repo's `decideTurnFlush` / `resolveReplyOwnerTurnId`
+ * pattern).
+ *
+ * ## Why `endedOnly` exists (#3725)
+ *
+ * `recentTurnsById` is populated at turn **start** (`rememberRecentTurn` fires
+ * from the `enqueue` lifecycle event in `stream-render.ts`), and the atom is
+ * built with `endedAt: null`; `endedAt` is stamped later, in `turn-end.ts`. So
+ * the registry's tail entry for a chat is the most-recently-STARTED turn, which
+ * may still be RUNNING. The registry is also chat-wide and thread-agnostic, so
+ * on a forum a turn running in ANOTHER topic sits at the tail.
+ *
+ * That distinction is load-bearing because the two consumers want different
+ * things:
+ *
+ *   - **Routing** (`resolveAnswerThreadWithLog`) wants the chat's most recent
+ *     turn whether or not it has ended — it only picks a topic to deliver into,
+ *     and a still-running turn's topic is a perfectly good (indeed better)
+ *     answer than falling back to General. `endedOnly: false`.
+ *   - **Owner resolution** (`resolveReplyOwnerTurn` → the `latest-ended`
+ *     supersede tier) wants a genuinely ENDED turn: that tier carries
+ *     DESTRUCTIVE authority (it drives message deletion) and is bounded by the
+ *     supersede TTL measured from `endedAt`. A turn with `endedAt == null` has
+ *     no age, so it could not be TTL-bounded at all — it was an unbounded
+ *     anchor for the corroborated content-gate bypass (#3725). A still-running
+ *     turn must be resolved by the `live` tier, never by this fallback.
+ *     `endedOnly: true`.
+ */
+
+/** The registry-atom shape this scan needs (structural — `CurrentTurn` in the
+ *  gateway satisfies it without importing the gateway's type). */
+export interface LatestTurnLookupAtom {
+  /** The chat the turn belongs to. */
+  sessionChatId: string
+  /** Wall-clock ms the turn ENDED, or null while it is still running. */
+  endedAt: number | null
+}
+
+/**
+ * The last turn for `chatId` in registry insertion order — i.e. the most recent
+ * one. With `endedOnly: true` the scan skips turns that have not ended yet, so
+ * the result is the most-recently-ended turn (which may NOT be the tail entry).
+ * Returns null when the chat has no matching turn.
+ */
+export function latestTurnForChat<T extends LatestTurnLookupAtom>(
+  turns: Iterable<T>,
+  chatId: string,
+  opts: { endedOnly: boolean },
+): T | null {
+  let latest: T | null = null
+  for (const t of turns) {
+    if (t.sessionChatId !== chatId) continue
+    if (opts.endedOnly && t.endedAt == null) continue
+    latest = t
+  }
+  return latest
+}

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -735,7 +735,8 @@ export interface SendReplyGatewayDeps {
    *  The candidates are load-bearing, not diagnostics: `decideContentGateBypass`
    *  corroborates a model-steerable `origin`/`quoted` attribution against the
    *  framework-derived `latestEndedTurnId` inside them before allowing a
-   *  content-gate bypass. */
+   *  content-gate bypass — an anchor that is an ENDED turn within the supersede
+   *  TTL, never one still running (#3725). */
   resolveReplyOwnerTurn(liveTurn: CurrentTurn | null, chatId: string, args: Record<string, unknown>): { turn: CurrentTurn | null; tier: ReplyOwnerTier; candidates: ReplyOwnerCandidates }
   findTurnByOriginId(originTurnId: string | null | undefined): CurrentTurn | null
   findTurnByQuotedMessageId(chatId: string, replyTo: unknown): CurrentTurn | null
@@ -1012,7 +1013,7 @@ export async function sendReply(
     // owner turn resolved (no record to clobber on the collapse path).
     const gateThreadId = ownerTurn?.sessionThreadId ?? replyThreadId
     // MUST-FIX 2 (dup-audit / Fable) — the content-gate READ is CHAT-WIDE, not
-    // lane-specific: `findLatestEndedTurnForChat` resolves owners chat-wide, so a
+    // lane-specific: `findLatestTurnForChat` resolves owners chat-wide, so a
     // handback in topic A can supersede topic B's ended turn; a thread-keyed gate
     // read (the F2 regression) let a reply dodge that handback by carrying a
     // different `message_thread_id`. Chat-wide makes the gate un-steerable — any
@@ -1041,7 +1042,10 @@ export async function sendReply(
     //   - `origin` / `quoted` — MODEL-SUPPLIED attributions, so they bypass ONLY
     //                when CORROBORATED: the turn they resolve must be the same
     //                turn the framework-derived, TTL-bounded `latestEndedTurnId`
-    //                resolves, and no handback may be in the window. A reply that
+    //                resolves (#3725 — that anchor is a genuinely ENDED turn
+    //                within the TTL; a turn still RUNNING in this chat is not a
+    //                candidate and corroborates nothing), and no handback may be
+    //                in the window. A reply that
     //                steers itself onto a DIFFERENT ended turn fails
     //                corroboration and keeps the content gate, so the Fable
     //                silent-edit-over stays closed; a reply that merely echoes

--- a/telegram-plugin/gateway/subagent-handback-marker.ts
+++ b/telegram-plugin/gateway/subagent-handback-marker.ts
@@ -201,7 +201,7 @@ export class SubagentHandbackMarker {
    * Wall-clock ms of the most recent handback enqueue ANYWHERE in `chatId`
    * (across every topic lane), or null. This is what the content-gate read uses
    * (dup-audit MUST-FIX 2, Fable 2026-07-21): the owner-resolution latest-ended
-   * tier is CHAT-WIDE (`findLatestEndedTurnForChat` ignores thread), so a
+   * tier is CHAT-WIDE (`findLatestTurnForChat` ignores thread), so a
    * background handback in topic A can resolve — and supersede — topic B's
    * ended turn. A thread-SPECIFIC gate read (the F2 regression) let a reply
    * dodge that handback by carrying a different `message_thread_id`, silently

--- a/telegram-plugin/gateway/turn-end.ts
+++ b/telegram-plugin/gateway/turn-end.ts
@@ -436,7 +436,7 @@ function endCurrentTurnAtomic(
   // live feed never opened because its sends failed (the resume-400 signature).
   const turnEndedAt = Date.now()
   // 2026-07 double-reply-on-DM fix (F2) — stamp the turn's end time so the
-  // `findLatestEndedTurnForChat` supersede tier can be recency-bounded to the
+  // `latest-ended` supersede tier can be recency-bounded to the
   // supersede TTL (a stale latest-ended turn must not inherit deletion
   // authority over a newer turn's flush record). Set once; idempotent on the
   // deferRecord flush path (which calls this synchronously before its send).

--- a/telegram-plugin/reply-owner-resolve.ts
+++ b/telegram-plugin/reply-owner-resolve.ts
@@ -25,8 +25,8 @@
  *
  * The DECISIVE divergence: the gateway's *thread-routing* path DID recover the
  * owner turn for the same late reply — via `findTurnByQuotedMessageId` (the
- * framework-owned default quote target) and `findLatestEndedTurnForChat` (the
- * chat's most-recently-ended turn). The supersede resolver chain omitted BOTH
+ * framework-owned default quote target) and `findLatestTurnForChat` (the
+ * chat's most recent turn). The supersede resolver chain omitted BOTH
  * recoveries, so the two resolvers disagreed on who owned the reply. This module
  * unifies them onto ONE precedence so they can never diverge again.
  *
@@ -37,7 +37,7 @@
  * `decideCapturedProseDelivery` — is to extract the decision core into a pure,
  * unit-testable function and have the gateway run the EXACT code the regression
  * tests exercise. The gateway performs the four turn lookups (currentTurn,
- * findTurnByOriginId, findTurnByQuotedMessageId, findLatestEndedTurnForChat) and
+ * findTurnByOriginId, findTurnByQuotedMessageId, findLatestTurnForChat) and
  * feeds their resolved turnIds here; the precedence lives in one place.
  */
 
@@ -56,16 +56,25 @@ export interface ReplyOwnerCandidates {
   /** `findTurnByQuotedMessageId(chat_id, reply_to)` — the framework-owned
    *  quoted message id, resolved with NO model thread assertion. */
   quotedTurnId: string | null
-  /** `findLatestEndedTurnForChat(chat_id)` — the chat's most-recently-ended
-   *  turn. The deterministic late-reply fallback (the DM path's recovery). */
+  /** `findLatestTurnForChat(chat_id, {endedOnly:true})` — the chat's
+   *  most-recently-ENDED turn. The deterministic late-reply fallback (the DM
+   *  path's recovery). #3725: the gateway lookup skips turns that have not
+   *  ended, so this is never a still-running turn. */
   latestEndedTurnId: string | null
   /** Age (ms) of the latest-ended turn — `now - turn.endedAt`. The latest-ended
    *  tier carries DESTRUCTIVE authority (it drives supersede deletion), so it is
    *  honoured ONLY when the turn ended within `latestEndedTtlMs` (the supersede
    *  TTL). Without the bound, a late reply belonging to an OLDER turn could
    *  resolve its owner to a NEWER turn now sitting at the registry tail and
-   *  delete THAT turn's legit answer. Undefined/null ⇒ unbounded (back-compat:
-   *  callers that don't supply an age keep the pre-F2 behaviour). */
+   *  delete THAT turn's legit answer.
+   *
+   *  Two distinct absences (#3725):
+   *    - `undefined` (property omitted) ⇒ unbounded, the pre-F2 back-compat
+   *      escape for callers that don't supply an age at all;
+   *    - explicit `null` ⇒ the caller COMPUTED no age, i.e. its candidate turn
+   *      has no `endedAt` and has NOT ended. That cannot be TTL-bounded, so it
+   *      fails CLOSED (not accepted) rather than granting unbounded authority
+   *      to a turn that is still running. */
   latestEndedAgeMs?: number | null
   /** The supersede TTL bound applied to `latestEndedAgeMs`. Undefined ⇒
    *  unbounded. */
@@ -74,13 +83,17 @@ export interface ReplyOwnerCandidates {
 
 /**
  * Whether the latest-ended candidate is fresh enough to carry supersede
- * (deletion) authority. A missing age or TTL means unbounded (back-compat).
+ * (deletion) authority. An OMITTED age or TTL means unbounded (the pre-F2
+ * back-compat escape); an EXPLICIT null age fails closed (#3725 — the caller
+ * computed no age because its candidate turn has not ended, and an un-ended turn
+ * must be resolved by the `live` tier, never by this destructive fallback).
  */
 function latestEndedAccepted(candidates: ReplyOwnerCandidates): boolean {
   if (candidates.latestEndedTurnId == null) return false
   const age = candidates.latestEndedAgeMs
   const ttl = candidates.latestEndedTtlMs
-  if (age == null || ttl == null) return true
+  if (age === null) return false
+  if (age === undefined || ttl == null) return true
   return age <= ttl
 }
 
@@ -174,7 +187,11 @@ export function resolveReplyOwnerTurnId(candidates: ReplyOwnerCandidates): strin
  * FRAMEWORK would not have gone on its own. So `origin`/`quoted` bypass the
  * content gate IFF the turn they resolve is the SAME turn the framework-derived,
  * TTL-bounded `latest-ended` candidate resolves — a candidate computed from
- * `findLatestEndedTurnForChat` with no model input at all.
+ * `findLatestTurnForChat(chat_id, {endedOnly:true})` with no model input at all.
+ * "TTL-bounded" is enforced, not assumed (#3725): `latestEndedAccepted` demands
+ * an age within `latestEndedTtlMs`, and an anchor turn that has NOT ended (age
+ * explicitly null) is rejected outright rather than treated as unbounded — so a
+ * turn still running in another topic of the same chat can corroborate nothing.
  *
  * This grants ZERO new capability, which is the safety argument: any reply that
  * reaches the bypass via a corroborated `origin`/`quoted` attribution could
@@ -198,8 +215,9 @@ export function decideContentGateBypass(input: {
   resolvedTurnId: string | null
   /** The SAME candidate set both of the above were derived from — supplies the
    *  framework-derived `latestEndedTurnId` plus its freshness bound, so the
-   *  corroboration reuses the EXACT TTL rule `resolveReplyOwnerTier` applies
-   *  instead of duplicating it. */
+   *  corroboration reuses the EXACT rule `resolveReplyOwnerTier` applies
+   *  (`latestEndedAccepted`) instead of duplicating it: within the TTL, and —
+   *  since #3725 — not a turn that is still running. */
   candidates: ReplyOwnerCandidates
   /** True when a decoupled-completion inbound (`subagent_handback`) was enqueued
    *  in this chat AFTER the owner turn ended and within the supersede TTL — the

--- a/telegram-plugin/tests/latest-turn-lookup.test.ts
+++ b/telegram-plugin/tests/latest-turn-lookup.test.ts
@@ -1,0 +1,77 @@
+/**
+ * #3725 — the "latest-ended" supersede anchor was the most-recently-STARTED turn.
+ *
+ * `recentTurnsById` is populated at turn START (`rememberRecentTurn` fires from
+ * the `enqueue` lifecycle event in `stream-render.ts`, and the atom is built with
+ * `endedAt: null`; `endedAt` is stamped later in `turn-end.ts`). The gateway's
+ * lookup had NO `endedAt` filter, so `findLatestEndedTurnForChat` returned the
+ * chat's tail entry even when that turn was still RUNNING — its own docstring
+ * admitted it ("the most-recently-STARTED turn") while the name and every caller
+ * said otherwise. Because the registry is chat-wide and thread-agnostic, a turn
+ * running in ANOTHER topic of the same chat was a live route into that state.
+ *
+ * These tests pin the OUTCOME of the scan (which turn comes back), not the
+ * shape of the code.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { latestTurnForChat, type LatestTurnLookupAtom } from '../gateway/latest-turn-lookup.js'
+
+interface Turn extends LatestTurnLookupAtom {
+  turnId: string
+  sessionThreadId?: number
+}
+
+const CHAT = '12345'
+const OTHER_CHAT = '99999'
+
+/** Registry insertion order = turn-START order (what `rememberRecentTurn` does). */
+const registry = (...turns: Turn[]): Map<string, Turn> =>
+  new Map(turns.map((t) => [t.turnId, t]))
+
+describe('latestTurnForChat — endedOnly (#3725)', () => {
+  it('does NOT return a still-running turn as the latest ENDED turn — it falls ' +
+    'back to the most recent turn that actually ended', () => {
+    // Topic A ended at t=1000; topic B started after and is STILL RUNNING, so it
+    // sits at the registry tail. This is the exact incident shape.
+    const ended = { turnId: 'A#1', sessionChatId: CHAT, endedAt: 1_000, sessionThreadId: 11 }
+    const running = { turnId: 'B#2', sessionChatId: CHAT, endedAt: null, sessionThreadId: 22 }
+    const turns = registry(ended, running)
+    expect(latestTurnForChat(turns.values(), CHAT, { endedOnly: true })).toBe(ended)
+    // The routing consumer still wants the tail entry (running or not) — it only
+    // picks a topic to deliver into and deletes nothing.
+    expect(latestTurnForChat(turns.values(), CHAT, { endedOnly: false })).toBe(running)
+  })
+
+  it('returns NULL when the chat has only a running turn — the destructive tier ' +
+    'gets no anchor at all rather than an unbounded one (fail closed)', () => {
+    const turns = registry({ turnId: 'B#2', sessionChatId: CHAT, endedAt: null })
+    expect(latestTurnForChat(turns.values(), CHAT, { endedOnly: true })).toBeNull()
+    expect(latestTurnForChat(turns.values(), CHAT, { endedOnly: false })).not.toBeNull()
+  })
+
+  it('picks the LAST ended turn in insertion order when several have ended', () => {
+    const turns = registry(
+      { turnId: 'A#1', sessionChatId: CHAT, endedAt: 1_000 },
+      { turnId: 'A#2', sessionChatId: CHAT, endedAt: 2_000 },
+      { turnId: 'B#3', sessionChatId: CHAT, endedAt: null },
+    )
+    expect(latestTurnForChat(turns.values(), CHAT, { endedOnly: true })?.turnId).toBe('A#2')
+  })
+
+  it('never crosses chats (the scan is chat-scoped in BOTH modes)', () => {
+    const turns = registry(
+      { turnId: 'A#1', sessionChatId: CHAT, endedAt: 1_000 },
+      { turnId: 'X#1', sessionChatId: OTHER_CHAT, endedAt: 2_000 },
+      { turnId: 'X#2', sessionChatId: OTHER_CHAT, endedAt: null },
+    )
+    expect(latestTurnForChat(turns.values(), CHAT, { endedOnly: true })?.turnId).toBe('A#1')
+    expect(latestTurnForChat(turns.values(), CHAT, { endedOnly: false })?.turnId).toBe('A#1')
+    expect(latestTurnForChat(turns.values(), 'nobody', { endedOnly: false })).toBeNull()
+  })
+
+  it('an endedAt of 0 counts as ENDED (null is the only "still running" marker)', () => {
+    const turns = registry({ turnId: 'A#1', sessionChatId: CHAT, endedAt: 0 })
+    expect(latestTurnForChat(turns.values(), CHAT, { endedOnly: true })?.turnId).toBe('A#1')
+  })
+})

--- a/telegram-plugin/tests/reply-owner-resolve.test.ts
+++ b/telegram-plugin/tests/reply-owner-resolve.test.ts
@@ -963,9 +963,17 @@ describe('decideContentGateBypass — corroborated bypass of the #3429 content g
     expect(r.bypasses).toBeGreaterThan(0)
     // …and specifically, many cases must win their bypass on the WIDENED,
     // model-steerable `origin`/`quoted` tiers — the thing being vouched for.
-    // Currently exactly 16 of the 486 cases do (no live turn, handback clear,
-    // a fresh-or-unbounded latest-ended id, and the steered id equal to it).
-    expect(r.modelTierBypasses).toBeGreaterThanOrEqual(16)
+    // Exactly 8 of the 486 cases do: no live turn, handback clear, a FRESH
+    // latest-ended id, and the steered id equal to it.
+    //
+    // This floor was 16 before #3725. The other 8 were the `latestEndedAgeMs
+    // == null` (unbounded) shapes, which corroborated a bypass off an anchor
+    // that had never ended. #3725 makes the latest-ended lookup `endedOnly`, so
+    // the age is always a real number and an explicit null age fails CLOSED —
+    // those 8 shapes are now correctly unreachable. Lowering the floor here is
+    // recording that narrowing, not conceding it: the property assertion above
+    // (`violations` empty) is unchanged and still passes.
+    expect(r.modelTierBypasses).toBeGreaterThanOrEqual(8)
   })
 
   // NON-VACUITY, asserted deterministically rather than demonstrated by hand:

--- a/telegram-plugin/tests/reply-owner-resolve.test.ts
+++ b/telegram-plugin/tests/reply-owner-resolve.test.ts
@@ -36,10 +36,12 @@ import {
   decideAnswerLatchSuppression,
   decideContentGateBypass,
   type ReplyOwnerCandidates,
+  type ReplyOwnerTier,
   type AnswerDeliveredLatch,
 } from '../reply-owner-resolve.js'
 import { FlushedTurnSupersedeRegistry, DEFAULT_SUPERSEDE_TTL_MS } from '../flushed-turn-supersede.js'
 import { OutboundDedupCache } from '../recent-outbound-dedup.js'
+import { latestTurnForChat } from '../gateway/latest-turn-lookup.js'
 
 const NONE: ReplyOwnerCandidates = {
   liveTurnId: null,
@@ -856,5 +858,206 @@ describe('decideContentGateBypass — corroborated bypass of the #3429 content g
       })
       if (withModelIds) expect(withoutModelIds).toBe(true)
     }
+  })
+})
+
+/**
+ * #3725 — the "framework-derived, TTL-bounded" supersede anchor was neither
+ * ended nor bounded.
+ *
+ * The gateway's `recentTurnsById` registry is populated at turn START, so its
+ * tail entry for a chat can be a turn that is STILL RUNNING (`endedAt: null`) —
+ * and because the registry is chat-wide and thread-agnostic, a turn running in
+ * another topic of the same chat lands there. The gateway then computed
+ * `latestEndedAgeMs = endedAt != null ? now - endedAt : null`, and
+ * `latestEndedAccepted` treated a null age as UNBOUNDED (its back-compat escape
+ * for callers that supply no age at all). Net effect: a still-running turn
+ * became a corroborating anchor with NO freshness bound, for the widened
+ * `origin`/`quoted` content-gate bypass #3719 leans on.
+ *
+ * The fix is two-layer and both layers fail CLOSED:
+ *   1. the gateway lookup skips turns with no `endedAt` (`latestTurnForChat`
+ *      with `endedOnly: true`), so the anchor is a genuinely ended turn — and
+ *      when the chat has no ended turn, there is NO anchor rather than a
+ *      running one;
+ *   2. `latestEndedAccepted` distinguishes an OMITTED age (undefined ⇒
+ *      back-compat unbounded) from a COMPUTED-null age (⇒ rejected).
+ */
+describe('#3725 — a still-running turn is not a supersede anchor', () => {
+  const CHAT = '12345'
+  const ENDED = 'turn-ENDED'
+  const RUNNING = 'turn-RUNNING'
+
+  interface RegistryTurn { turnId: string; sessionChatId: string; endedAt: number | null }
+
+  const NOW = 1_000_000
+
+  /**
+   * The gateway's candidate construction (`resolveReplyOwnerTurn`), mirrored
+   * here because `gateway.ts` is not importable in tests — the same convention
+   * the rest of this file uses. `scan` selects the FIXED lookup (`endedOnly`)
+   * or the PRE-FIX one (tail entry regardless of `endedAt`), giving the
+   * red-on-main contrast as an assertion rather than prose.
+   */
+  function gatewayCandidates(
+    turns: RegistryTurn[],
+    scan: 'fixed' | 'prefix',
+    over: Partial<ReplyOwnerCandidates> = {},
+  ): ReplyOwnerCandidates {
+    const latestEnded =
+      scan === 'fixed'
+        ? latestTurnForChat(turns, CHAT, { endedOnly: true })
+        : (turns.filter((t) => t.sessionChatId === CHAT).at(-1) ?? null)
+    return {
+      liveTurnId: null,
+      originTurnId: null,
+      quotedTurnId: null,
+      latestEndedTurnId: latestEnded?.turnId ?? null,
+      latestEndedAgeMs: latestEnded?.endedAt != null ? NOW - latestEnded.endedAt : null,
+      latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
+      ...over,
+    }
+  }
+
+  /**
+   * The PRE-FIX resolver semantics, reproduced verbatim for the red-on-main
+   * contrast. BOTH layers of the defect are here: `latestEndedAccepted` treated
+   * a null age as unbounded (`age == null ⇒ true`), and the gateway's scan (the
+   * `'prefix'` mode above) handed it a turn that had not ended, whose age it
+   * therefore computed as null.
+   */
+  function preFixAccepted(c: ReplyOwnerCandidates): boolean {
+    if (c.latestEndedTurnId == null) return false
+    const age = c.latestEndedAgeMs
+    const ttl = c.latestEndedTtlMs
+    if (age == null || ttl == null) return true
+    return age <= ttl
+  }
+  function preFixTier(c: ReplyOwnerCandidates): ReplyOwnerTier {
+    if (c.liveTurnId != null) return 'live'
+    if (c.originTurnId != null) return 'origin'
+    if (c.quotedTurnId != null) return 'quoted'
+    if (preFixAccepted(c)) return 'latest-ended'
+    return 'none'
+  }
+  function preFixOwnerId(c: ReplyOwnerCandidates): string | null {
+    switch (preFixTier(c)) {
+      case 'live': return c.liveTurnId
+      case 'origin': return c.originTurnId
+      case 'quoted': return c.quotedTurnId
+      case 'latest-ended': return c.latestEndedTurnId
+      case 'none': return null
+    }
+  }
+  /** `decideContentGateBypass` as it stood before this fix (same rule, pre-fix
+   *  acceptance). */
+  function preFixBypass(c: ReplyOwnerCandidates): boolean {
+    const tier = preFixTier(c)
+    if (tier === 'live') return true
+    if (tier === 'none') return false
+    if (!preFixAccepted(c)) return false
+    const id = preFixOwnerId(c)
+    return id != null && id === c.latestEndedTurnId
+  }
+
+  /** A chat whose only ended turn is followed by a turn still running in
+   *  another topic — the registry tail is the RUNNING turn. */
+  const registry: RegistryTurn[] = [
+    { turnId: ENDED, sessionChatId: CHAT, endedAt: NOW - 10_000 },
+    { turnId: RUNNING, sessionChatId: CHAT, endedAt: null },
+  ]
+
+  it('the anchor is the ENDED turn, not the running tail entry (pre-fix scan ' +
+    'picked the running turn with a null — unbounded — age)', () => {
+    expect(gatewayCandidates(registry, 'fixed')).toMatchObject({
+      latestEndedTurnId: ENDED,
+      latestEndedAgeMs: 10_000,
+    })
+    expect(gatewayCandidates(registry, 'prefix')).toMatchObject({
+      latestEndedTurnId: RUNNING,
+      latestEndedAgeMs: null,
+    })
+  })
+
+  it('a model-steered `origin` echo of the RUNNING turn gets NO corroborated ' +
+    'bypass — pre-fix it did', () => {
+    const steered = { originTurnId: RUNNING }
+    const fixed = gatewayCandidates(registry, 'fixed', steered)
+    expect(
+      decideContentGateBypass({
+        tier: resolveReplyOwnerTier(fixed),
+        resolvedTurnId: resolveReplyOwnerTurnId(fixed),
+        candidates: fixed,
+        handbackCouldOwnReply: false,
+      }),
+    ).toBe(false)
+    // Red-on-main contrast: the same reply DID bypass the #3429 content gate
+    // before the fix, corroborated by a turn that had not even ended.
+    expect(preFixBypass(gatewayCandidates(registry, 'prefix', steered))).toBe(true)
+  })
+
+  it('a chat with ONLY a running turn yields NO owner and NO bypass (fail ' +
+    'closed), where pre-fix it yielded an unbounded latest-ended owner', () => {
+    const onlyRunning: RegistryTurn[] = [{ turnId: RUNNING, sessionChatId: CHAT, endedAt: null }]
+    const fixed = gatewayCandidates(onlyRunning, 'fixed')
+    expect(fixed.latestEndedTurnId).toBeNull()
+    expect(resolveReplyOwnerTier(fixed)).toBe('none')
+    expect(resolveReplyOwnerTurnId(fixed)).toBeNull()
+    expect(
+      decideContentGateBypass({
+        tier: 'none',
+        resolvedTurnId: null,
+        candidates: fixed,
+        handbackCouldOwnReply: false,
+      }),
+    ).toBe(false)
+
+    const prefix = gatewayCandidates(onlyRunning, 'prefix')
+    expect(preFixTier(prefix)).toBe('latest-ended')
+    expect(preFixOwnerId(prefix)).toBe(RUNNING)
+  })
+
+  it('layer 2: an EXPLICIT null age is rejected outright, while an OMITTED age ' +
+    'keeps the pre-F2 back-compat escape', () => {
+    const base: ReplyOwnerCandidates = {
+      liveTurnId: null,
+      originTurnId: null,
+      quotedTurnId: null,
+      latestEndedTurnId: ENDED,
+      latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
+    }
+    // Computed-null (the caller's candidate turn has not ended) ⇒ closed.
+    expect(resolveReplyOwnerTier({ ...base, latestEndedAgeMs: null })).toBe('none')
+    expect(resolveReplyOwnerTurnId({ ...base, latestEndedAgeMs: null })).toBeNull()
+    expect(
+      decideContentGateBypass({
+        tier: 'origin',
+        resolvedTurnId: ENDED,
+        candidates: { ...base, originTurnId: ENDED, latestEndedAgeMs: null },
+        handbackCouldOwnReply: false,
+      }),
+    ).toBe(false)
+    // Property omitted entirely ⇒ unchanged pre-F2 behaviour.
+    expect(resolveReplyOwnerTier(base)).toBe('latest-ended')
+    expect(resolveReplyOwnerTurnId(base)).toBe(ENDED)
+  })
+
+  it('end-to-end: a late reply while another topic is still running cannot ' +
+    "delete a DIFFERENT turn's flush record", () => {
+    const reg = new FlushedTurnSupersedeRegistry()
+    // The still-running turn holds a fresh flush record of its own.
+    reg.record(CHAT, undefined, { turnId: RUNNING, messageIds: [9001], text: 'A' }, NOW)
+    // A late reply lands with no live turn, no echo, no quote. Pre-fix its owner
+    // resolved to the RUNNING turn (registry tail, unbounded) and the take()
+    // consumed that turn's record; with the fix the owner is the ENDED turn, so
+    // the running turn's record is untouched.
+    const onlyRunning: RegistryTurn[] = [
+      { turnId: ENDED, sessionChatId: CHAT, endedAt: NOW - 10_000 },
+      { turnId: RUNNING, sessionChatId: CHAT, endedAt: null },
+    ]
+    const ownerId = resolveReplyOwnerTurnId(gatewayCandidates(onlyRunning, 'fixed'))
+    expect(ownerId).toBe(ENDED)
+    expect(reg.take(CHAT, undefined, { liveTurnId: ownerId, now: NOW + 10 }).supersede).toBe(false)
+    expect(reg.peek(CHAT, undefined, { liveTurnId: RUNNING, now: NOW + 10 }).supersede).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

Fixes #3725. `findLatestEndedTurnForChat` returned the most-recently-**STARTED** turn for a chat, so the "framework-derived, TTL-bounded" corroboration anchor that #3719 leans on could be a turn that is **still running**, carrying **no freshness bound at all**.

Verified at `origin/main` (`bf8d115d`) — the issue's characterisation is accurate:

- `rememberRecentTurn` has one call site, `gateway/stream-render.ts:433`, fired from the `enqueue` (turn-start) lifecycle event; the atom is built with `endedAt: null` (`stream-render.ts:318`) and `endedAt` is stamped only later at `turn-end.ts:443` (same object, mutated in place).
- The lookup (`gateway.ts:4011-4017`) had no `endedAt` filter — its own docstring said "most-recently-**started**".
- `gateway.ts:4055-4056` therefore computed `latestEndedAgeMs = null` for a running anchor, and `latestEndedAccepted` (`reply-owner-resolve.ts:83`) returned `true` unbounded on a null age (the pre-F2 back-compat escape).
- The registry is chat-wide/thread-agnostic (`subagent-handback-marker.ts:204`), so a turn running in another topic of the same chat sits at the tail — a live route in, not a theoretical one.

## Why this fix

Two layers, **both failing closed**:

1. **The lookup filters on `endedAt != null`** for the destructive consumer. The scan moves out of `gateway.ts` into a pure `telegram-plugin/gateway/latest-turn-lookup.ts` with an explicit `endedOnly` mode:
   - owner resolution (`resolveReplyOwnerTurn` → `latest-ended` supersede tier) passes `endedOnly: true`. A still-running turn belongs to the `live` tier, never to this destructive fallback.
   - **Fail-safe direction when a chat has NO ended turn:** the anchor is `null` ⇒ tier `none` ⇒ no owner, no supersede, no bypass. No bypass beats an unbounded one.
   - the **routing** consumer (`resolveAnswerThreadWithLog`) keeps the old semantics with `endedOnly: false`, deliberately: it only picks a topic to deliver into and deletes nothing, and a running turn's topic is a better answer than falling back to General. That preserves the "unbounded routing use is unaffected" property F2 documented.
2. **The back-compat null-age acceptance is narrowed.** `latestEndedAccepted` now distinguishes an **omitted** age (`undefined` ⇒ unbounded, the pre-F2 escape for callers that supply no age) from a **computed-null** age (explicit `null` ⇒ rejected: the caller's candidate turn has no `endedAt`, so it cannot be TTL-bounded). Layer 1 already prevents the real caller from producing that shape; layer 2 makes the pure module safe on its own terms.

Extraction is also what makes the defect **testable** — `gateway.ts` is not importable in tests, which is why this hole shipped untested.

Five doc comments asserting a "framework-derived, TTL-bounded" anchor are corrected to describe what the code now enforces: `reply-owner-resolve.ts` (the `decideContentGateBypass` docstring + its `candidates` param doc + the `latestEndedAgeMs` field doc), `gateway/outbound-send-path.ts` (the deps doc + the tier-rule comment), and the gateway-side `endedAt` / F2 comments. Stale `findLatestEndedTurnForChat` name references elsewhere are renamed with no behaviour change.

## Test plan

New: `telegram-plugin/tests/latest-turn-lookup.test.ts` (5) and a `#3725` block in `telegram-plugin/tests/reply-owner-resolve.test.ts` (5). They assert outcomes — which turn the scan returns, which tier/owner id resolves, whether the bypass fires, and whether a flush record survives — with the pre-fix scan **and** pre-fix acceptance rule reproduced in-file as the red-on-main contrast (the repo's `oldTwoTierResolve` / `oldBooleanLatchSuppression` pattern).

Includes the required case: an anchor turn that is **still running**, proving the bypass does NOT fire (and that pre-fix it did).

**Red proof** — with the two fix lines reverted (`endedOnly` filter + `age === null` rejection), the new tests fail and every pre-existing test stays green:

```
× #3725 … the anchor is the ENDED turn, not the running tail entry
× #3725 … a model-steered `origin` echo of the RUNNING turn gets NO corroborated bypass
× #3725 … a chat with ONLY a running turn yields NO owner and NO bypass (fail closed)
× #3725 … layer 2: an EXPLICIT null age is rejected outright …
× #3725 … end-to-end: a late reply while another topic is still running cannot delete a DIFFERENT turn's flush record
  Tests  8 failed | 49 passed        (3 of the 5 lookup tests also red)
```

Green with the fix:

- `vitest run telegram-plugin/tests/latest-turn-lookup.test.ts telegram-plugin/tests/reply-owner-resolve.test.ts` → **57 passed**
- Full plugin suite `vitest run telegram-plugin/` → **8315 passed, 3 skipped, 1 failed** — `approval-hold-record.test.ts > falls back to the agent's own state dir when the shared dir is not writable`, an environment artifact of running as **uid 0** (a `0o500` dir is still writable by root); unrelated to this diff and equally red on main in this container.
- Scoped `bun test` (per-topic-current-turn, registry-turns, emission-authority-open-gate) → 64 pass.
- `npm run lint` → clean, including `check-gateway-line-ratchet: clean (gateway.ts = 24916 lines, ratchet 24867, slack 50, main 24867)` — gateway.ts is **unchanged in size** (the extraction offsets the import).

The #3429 / F1 / F2 / MUST-FIX defence tests are untouched and green, including in the red run: the Fable steered-attribution vector, the stale-past-TTL denial, the zero-new-capability property, and the `latest-ended`-unchanged case.

## Risk

- **Behaviour change (intended):** a late reply in a chat whose only recent turn is still running no longer resolves an owner via `latest-ended`. It now delivers as its own message instead of being attributed to — and potentially superseding/suppressing against — a running turn. That is the safe direction (a visible message beats a silent edit-over/drop, the #3429 rule).
- Routing is untouched; no `latestEndedTtlMs` semantics change; no new capability granted anywhere.
- Merge-overlap note: PRs for #3724/#3726/#3727 also touch `reply-owner-resolve.ts` and its test. This diff's edits there are confined to `latestEndedAccepted` (3 lines), two doc blocks, and an appended `describe` at the end of the test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)