### PR TITLE
fix(hindsight): make consolidation tag-group parallelism an overridable managed key

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2105,7 +2105,7 @@ export const HindsightConfigSchema = z.object({
       "src/setup/hindsight-perf-defaults.ts: RERANKER_LOCAL_FP16, " +
       "RERANKER_LOCAL_BATCH_SIZE, LLM_MAX_CONCURRENT, " +
       "RETAIN/CONSOLIDATION_LLM_MAX_CONCURRENT, LLM_STRICT_SCHEMA, " +
-      "LLM_MAX_RETRIES, " +
+      "LLM_MAX_RETRIES, CONSOLIDATION_LLM_PARALLELISM, " +
       "RECALL_MAX_CANDIDATES_PER_SOURCE, LINK_EXPANSION_PER_ENTITY_LIMIT, " +
       "LINK_EXPANSION_TIMEOUT, LLM_REASONING_EFFORT), the override-only keys " +
       "switchroom manages but ships NO default for " +

--- a/src/setup/hindsight-perf-defaults.test.ts
+++ b/src/setup/hindsight-perf-defaults.test.ts
@@ -173,6 +173,7 @@ describe("hindsightPerfEnv — capability gating", () => {
       "HINDSIGHT_API_LINK_EXPANSION_PER_ENTITY_LIMIT",
       "HINDSIGHT_API_LINK_EXPANSION_TIMEOUT",
       "HINDSIGHT_API_LLM_REASONING_EFFORT",
+      "HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM",
     ];
     expect(HINDSIGHT_PERF_DEFAULTS_UNGATED.map(([k]) => k)).toEqual(UNGATED);
     for (const caps of [
@@ -320,6 +321,7 @@ describe("operator override wins", () => {
     // adding or dropping a managed key must fail here and force the doc update.
     expect([...HINDSIGHT_PERF_ENV_KEYS].sort()).toEqual([
       "HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT",
+      "HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM",
       "HINDSIGHT_API_LINK_EXPANSION_PER_ENTITY_LIMIT",
       "HINDSIGHT_API_LINK_EXPANSION_TIMEOUT",
       "HINDSIGHT_API_LLM_MAX_CONCURRENT",
@@ -418,6 +420,75 @@ describe("HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY (override-only)", () 
     expect(runEnv(runArgs()).get("HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY")).toEqual([
       MAP,
     ]);
+  });
+});
+
+// ── tag-group parallelism, moved into the managed set ─────────────────────
+describe("HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM (managed, was hard-coded)", () => {
+  const KEY = "HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM";
+  const CAPS = [
+    { gpu: false, localLlm: false },
+    { gpu: true, localLlm: false },
+    { gpu: false, localLlm: true },
+    { gpu: true, localLlm: true },
+  ];
+
+  it("is in the managed set, so a hindsight.env line is not silently dropped", () => {
+    // The bug this fixes: the key was emitted unconditionally from a bare
+    // constant in hindsight.ts and was NOT in HINDSIGHT_PERF_ENV_KEYS, so an
+    // operator's yaml line was discarded without a word — it read as durable
+    // config while doing nothing.
+    expect(HINDSIGHT_PERF_ENV_KEYS.has(KEY)).toBe(true);
+    // Defaulted, not override-only: the previous emission was unconditional,
+    // so dropping the default would be a silent behaviour change.
+    expect(HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS.has(KEY)).toBe(false);
+  });
+
+  it.each(CAPS)(
+    "keeps the historical default of 2 on every host (gpu=$gpu localLlm=$localLlm)",
+    (caps) => {
+      // Ungated on purpose. Behind a capability gate this would silently drop
+      // to upstream's 4 on any host lacking the gate — a behaviour change
+      // smuggled in by a refactor.
+      expect(hindsightPerfEnv(caps)).toContainEqual([KEY, "2"]);
+    },
+  );
+
+  it("the operator's value REPLACES the default on BOTH launch paths", () => {
+    const perf = { env: { [KEY]: "3" }, processEnv: {} };
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false, perf);
+    const fromRun = runEnv(runArgs());
+    const fromCompose = composeEnv(
+      generateHindsightComposeSnippet(undefined, undefined, LOOPBACK_LITELLM, false, perf),
+    );
+    // Exactly one value, not the default AND the override: a duplicate emission
+    // would be last-wins by luck on docker-run and ambiguous in compose.
+    expect(fromRun.get(KEY)).toEqual(["3"]);
+    expect(fromCompose.get(KEY)).toEqual(["3"]);
+  });
+
+  it("is emitted exactly once per path when NOT overridden", () => {
+    // Guards the specific regression of moving the key without deleting the
+    // old hard-coded emission: two `-e` flags for one var.
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false, {
+      env: {},
+      processEnv: {},
+    });
+    expect(runEnv(runArgs()).get(KEY)).toEqual(["2"]);
+    expect(
+      composeEnv(
+        generateHindsightComposeSnippet(undefined, undefined, LOOPBACK_LITELLM, false, {
+          env: {},
+          processEnv: {},
+        }),
+      ).get(KEY),
+    ).toEqual(["2"]);
+  });
+
+  it("still reaches the container on a host with NO gated capability", () => {
+    const perf = { env: { [KEY]: "6" }, processEnv: {} };
+    startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, false, perf);
+    expect(runEnv(runArgs()).get(KEY)).toEqual(["6"]);
   });
 });
 

--- a/src/setup/hindsight-perf-defaults.ts
+++ b/src/setup/hindsight-perf-defaults.ts
@@ -327,6 +327,36 @@ export const HINDSIGHT_DEFAULT_LLM_STRICT_SCHEMA = "true";
  */
 export const HINDSIGHT_DEFAULT_LLM_MAX_RETRIES = 2;
 
+/**
+ * Tag groups consolidated concurrently within ONE operation (upstream default
+ * `4`).
+ *
+ * Upstream's `config.py` justifies its 4 as "matches retain_max_concurrent" —
+ * i.e. the value is not absolute, it is pegged to how much LLM concurrency the
+ * deployment has granted. switchroom holds 2, chosen when a consolidation call
+ * was the heaviest thing on a single local backend.
+ *
+ * Moved here from a bare constant in `hindsight.ts` (2026-07-27). The value is
+ * unchanged; what changes is that it is now a MANAGED key, so an operator can
+ * override it through `hindsight.env`. Before this it was emitted
+ * unconditionally on both launch paths with no declarative channel, so a
+ * `hindsight.env` line for it was silently dropped — the exact failure this
+ * module exists to prevent. The right value tracks the host's local LLM slot
+ * count, which switchroom cannot know, so it must be overridable:
+ *
+ * ```yaml
+ * hindsight:
+ *   env:
+ *     # peg to RETAIN_LLM_MAX_CONCURRENT, per upstream's own rationale
+ *     HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM: 3
+ * ```
+ *
+ * Ungated: it assumes no hardware, and the previous emission was unconditional
+ * — putting it behind a capability gate would silently CHANGE the default on
+ * hosts that lack the gate.
+ */
+export const HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM = 2;
+
 /** Emitted on every host — bounded work, no hardware assumption. */
 export const HINDSIGHT_PERF_DEFAULTS_UNGATED: ReadonlyArray<readonly [string, string]> = [
   [
@@ -342,6 +372,10 @@ export const HINDSIGHT_PERF_DEFAULTS_UNGATED: ReadonlyArray<readonly [string, st
     String(HINDSIGHT_DEFAULT_LINK_EXPANSION_TIMEOUT_S),
   ],
   ["HINDSIGHT_API_LLM_REASONING_EFFORT", HINDSIGHT_DEFAULT_LLM_REASONING_EFFORT],
+  [
+    "HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM",
+    String(HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM),
+  ],
 ];
 
 /** Emitted only when the container can reach a GPU. */

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -813,7 +813,10 @@ export function hindsightLlmBudgetEnv(llm?: HindsightLlmConfig): Array<[string, 
 export const HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE =
   HINDSIGHT_CONSOLIDATION_BATCH_SIZE_CEILING;
 export const HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS = 1;
-export const HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM = 2;
+// Re-exported, not defined here: the value now lives in hindsight-perf-defaults
+// so it is a MANAGED key an operator can override via `hindsight.env`. The
+// re-export keeps the existing import sites (and their tests) working.
+export { HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM } from "./hindsight-perf-defaults.js";
 
 /**
  * Per-round memory scope for one consolidation op (upstream default 1000;
@@ -1652,11 +1655,14 @@ export function startHindsight(
     // knobs with confusingly similar upstream names; see the constants above.
     // LLM_PARALLELISM stays at 2 so the subscription-path ceiling (MAX_SLOTS ×
     // LLM_PARALLELISM = 2 concurrent model calls, #2894) is unchanged for any
-    // operator still on `provider: claude-code`. (BATCH_SIZE is emitted above,
-    // by the context budget — a window decision, not a concurrency one.)
+    // operator still on `provider: claude-code`. It is emitted by the managed
+    // perf-defaults block below rather than pinned here, so an operator can
+    // raise it through `hindsight.env` — the ceiling is a DEFAULT, not a law,
+    // and a local backend with more slots should be able to say so.
+    // (BATCH_SIZE is emitted above, by the context budget — a window decision,
+    // not a concurrency one.)
     "-e", `HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}`,
     "-e", `HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT=${HINDSIGHT_DEFAULT_CONSOLIDATION_SLOT_LIMIT}`,
-    "-e", `HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM}`,
     "-e", `HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND}`,
     // Stable worker identity (see HINDSIGHT_DEFAULT_WORKER_ID). Must be on
     // the docker-run path — the entrypoint only fills the var with `:=` when
@@ -2216,11 +2222,12 @@ export function generateHindsightComposeSnippet(
     ...hindsightLlmBudgetEnv(llm).map(([k, v]) => `      - ${k}=${v}`),
     // Consolidation scheduling — compose twin of the docker-run block. Every
     // var here MUST also appear on that path (reserved floor, per-type
-    // ceiling, tag-group parallelism, per-round scope); a var on one path only
-    // is exactly the drift a `switchroom apply` silently drops.
+    // ceiling, per-round scope); a var on one path only is exactly the drift a
+    // `switchroom apply` silently drops. Tag-group parallelism moved to the
+    // managed perf-defaults block below, which is emitted on BOTH paths from
+    // the same resolver, so the twin property still holds for it.
     `      - HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}`,
     `      - HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT=${HINDSIGHT_DEFAULT_CONSOLIDATION_SLOT_LIMIT}`,
-    `      - HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM}`,
     `      - HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND}`,
     `      - HINDSIGHT_API_WORKER_ID=${HINDSIGHT_DEFAULT_WORKER_ID}`,
     // Capability-gated performance defaults — the compose twin of the


### PR DESCRIPTION
## What

`HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM` was emitted unconditionally on both launch paths from a bare constant in `hindsight.ts` (`src/setup/hindsight.ts:816`), and was **not** a member of `HINDSIGHT_PERF_ENV_KEYS`.

So it had a shipped default with no declarative channel. An operator's `hindsight.env` line for it was silently dropped by `resolveHindsightPerfOverrides` while reading, in yaml, as durable config — the precise failure mode the managed-key set exists to prevent, and the one #3728 introduced `HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS` to close for a sibling key.

## Why it matters

The right value is not a property of switchroom. Upstream's `config.py` justifies its own default of 4 as *"matches retain_max_concurrent"* — the knob is pegged to how much LLM concurrency the deployment granted, which tracks the host's local backend slot count.

`RETAIN_LLM_MAX_CONCURRENT` **is** overridable today. So a host that raises retain cannot move parallelism to match; the two drift apart with no way to reconcile them short of setting it imperatively on the container, where the next `switchroom apply` drops it. That is exactly what happened on this deployment.

## How

- Moved the constant into `hindsight-perf-defaults.ts`, added it to `HINDSIGHT_PERF_DEFAULTS_UNGATED`.
- Deleted both hard-coded emissions (docker-run args and the compose snippet).
- `hindsight.ts` re-exports the name, so existing import sites and their tests are untouched.

**No behaviour change.** The value stays 2 on every host.

Two deliberate choices, both to avoid smuggling a behaviour change into a refactor:
- **Ungated**, because the previous emission was unconditional. Behind a capability gate, hosts lacking that gate would silently fall back to upstream's 4.
- **Defaulted, not override-only**, for the same reason — dropping the shipped default would change what unconfigured hosts get.

## Tests

- The key is in the managed set and is *not* override-only.
- The default of 2 still lands on all four capability combinations.
- An operator value **replaces** it on both the docker-run and compose paths.
- It is emitted **exactly once per path** when not overridden.

That last test fails on the obvious way to get this wrong — moving the key but leaving the old emission in place, yielding two `-e` flags for one var. I hit that while writing this, so it is a real guard rather than a decorative one.

The two pinned key-list literals and the `hindsight.env` schema description are deliberate tripwires; both fired and both are updated.