### PR TITLE
fix(ci): make the `:latest` image tag follow the release, not the tag push

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -6,7 +6,10 @@ name: docker-images
 #   - push to main: build all images for linux/amd64 + linux/arm64,
 #     push as `:latest` and `:sha-<short>` to
 #     ghcr.io/<owner>/switchroom-<image>.
-#   - tag push v*: same matrix, push as `:<tag>` and `:latest`.
+#   - tag push v*: same matrix, push as `:<tag>` ONLY. `:latest` is NOT
+#     moved here — release.yml's `images-latest` job promotes
+#     `:vX.Y.Z` → `:latest` (via promote.yml) after every release leg is
+#     green. See #3685 and the tag-branch comment in merge-base.
 #   - pull_request: build only (no push) to validate Dockerfile changes.
 #
 # Pipelines (perf rework, follows #2807):
@@ -353,8 +356,17 @@ jobs:
             fi
           fi
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            # #3685: a tag push publishes the VERSION tag only. Moving
+            # :latest here made it follow the TAG PUSH rather than the
+            # release's success — docker-images has no dependency on the
+            # binary build, the release assets or npm, so a red release
+            # still left ghcr.io/switchroom/*:latest on that version.
+            # release.yml's `images-latest` job promotes :vX.Y.Z ->
+            # :latest through promote.yml once every leg is green. The
+            # failure mode is now :latest lagging (recoverable by
+            # dispatching promote.yml) instead of :latest leading.
             TAG_VERSION="${GITHUB_REF#refs/tags/}"
-            TAG_ARGS=(-t "${IMAGE}:${TAG_VERSION}" -t "${IMAGE}:latest")
+            TAG_ARGS=(-t "${IMAGE}:${TAG_VERSION}")
           elif [[ "${{ github.ref }}" == "refs/heads/main" && "$PUSH_LATEST" == "true" ]]; then
             # PR C: keep :latest as the canonical install per
             # docs/operators/install.md, BUT also publish :sha-<7> for
@@ -528,8 +540,9 @@ jobs:
             fi
           fi
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            # Version tag only on a tag push — see merge-base (#3685).
             TAG_VERSION="${GITHUB_REF#refs/tags/}"
-            TAG_ARGS=(-t "${IMAGE}:${TAG_VERSION}" -t "${IMAGE}:latest")
+            TAG_ARGS=(-t "${IMAGE}:${TAG_VERSION}")
           elif [[ "${{ github.ref }}" == "refs/heads/main" && "$PUSH_LATEST" == "true" ]]; then
             TAG_ARGS=(-t "${IMAGE}:latest" -t "${IMAGE}:sha-${SHA_SHORT}")
           else
@@ -604,8 +617,9 @@ jobs:
             fi
           fi
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            # Version tag only on a tag push — see merge-base (#3685).
             TAG_VERSION="${GITHUB_REF#refs/tags/}"
-            echo "tags=${IMAGE}:${TAG_VERSION},${IMAGE}:latest" >> "$GITHUB_OUTPUT"
+            echo "tags=${IMAGE}:${TAG_VERSION}" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.ref }}" == "refs/heads/main" && "$PUSH_LATEST" == "true" ]]; then
             echo "tags=${IMAGE}:latest,${IMAGE}:sha-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
@@ -704,8 +718,9 @@ jobs:
             fi
           fi
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            # Version tag only on a tag push — see merge-base (#3685).
             TAG_VERSION="${GITHUB_REF#refs/tags/}"
-            echo "tags=${IMAGE}:${TAG_VERSION},${IMAGE}:latest" >> "$GITHUB_OUTPUT"
+            echo "tags=${IMAGE}:${TAG_VERSION}" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.ref }}" == "refs/heads/main" && "$PUSH_LATEST" == "true" ]]; then
             echo "tags=${IMAGE}:latest,${IMAGE}:sha-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "merge_group" ]]; then

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -25,9 +25,32 @@ name: promote
 #      conflict), the job fails loudly so the promotion is treated as
 #      "did not happen" rather than "happened with a different image."
 #
-# Matrix fans out across all 8 fleet images. `fail-fast: true` so a
+# Matrix fans out across all 9 fleet images. `fail-fast: true` so a
 # single bad image stops the promotion mid-flight rather than leaving a
 # half-promoted channel.
+#
+# ─── ALSO THE RELEASE PATH's `:latest` MOVE (#3685) ───────────────────
+#
+# release.yml's `images-latest` job calls this workflow via
+# `workflow_call` with `from: vX.Y.Z, to: latest`, after every release
+# leg is green. docker-images.yml therefore publishes `:vX.Y.Z` only on
+# a tag push and no longer moves `:latest` off the tag event itself.
+#
+# Two consequences, both load-bearing:
+#
+#   1. The matrix must cover EVERY image docker-images publishes on a
+#      tag, or that image's `:latest` silently stops advancing at
+#      release time. `web` was missing here while being in
+#      docker-images' `merge-dependents` matrix — harmless while this
+#      was dispatch-only, a real hole once the release path depends on
+#      it. `tests/release-pipeline-gating.test.ts` (R14) now derives the
+#      expected set from docker-images.yml and fails on any drift.
+#   2. No `${{ }}` inside a `run:` body. This is a release-path workflow
+#      holding `packages: write`, and `inputs.from` / `inputs.to` are
+#      operator-supplied strings on the dispatch path — interpolating
+#      them into the script GitHub writes to the runner's disk is script
+#      injection. They go through `env:` instead. Same rule release.yml
+#      and npm-publish.yml already follow (R8 in the same test).
 
 on:
   workflow_dispatch:
@@ -38,6 +61,18 @@ on:
         type: string
       to:
         description: "Destination tag (e.g. rc, latest)"
+        required: true
+        type: string
+  # Called by release.yml's `images-latest` job. Same two inputs, so
+  # `inputs.from` / `inputs.to` resolve identically on both paths.
+  workflow_call:
+    inputs:
+      from:
+        description: "Source tag (e.g. vX.Y.Z)"
+        required: true
+        type: string
+      to:
+        description: "Destination tag (e.g. latest)"
         required: true
         type: string
 
@@ -55,7 +90,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        image: [base, agent, broker, kernel, hostd, auth-broker, hindsight, voice]
+        # Keep in sync with what docker-images.yml publishes on a tag:
+        # base + the merge-dependents matrix (agent, broker, kernel,
+        # hostd, auth-broker, web) + hindsight + voice. `web` was absent
+        # here until #3685; pinned by R14 in
+        # tests/release-pipeline-gating.test.ts.
+        image: [base, agent, broker, kernel, hostd, auth-broker, web, hindsight, voice]
     steps:
       # NO `docker/setup-buildx-action` here, deliberately. Every step in
       # this job is manifest-only (`imagetools inspect` / `imagetools
@@ -79,26 +119,35 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Precheck — source tag exists
+        env:
+          # Via `env:`, never interpolated into the script body — see the
+          # header. `inputs.*` is operator-supplied on the dispatch path.
+          IMAGE_NAME: ${{ matrix.image }}
+          FROM_TAG: ${{ inputs.from }}
+          TO_TAG: ${{ inputs.to }}
         run: |
-          IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-${{ matrix.image }}"
-          FROM="${IMAGE}:${{ inputs.from }}"
+          set -euo pipefail
+          IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-${IMAGE_NAME}"
+          FROM="${IMAGE}:${FROM_TAG}"
           if ! docker buildx imagetools inspect "$FROM" >/dev/null 2>&1; then
             echo "::error::Source tag ${FROM} not found in registry."
-            echo "::error::Check for typos or wait for the build pipeline to publish :${{ inputs.from }}."
+            echo "::error::Check for typos or wait for the build pipeline to publish :${FROM_TAG}."
             exit 1
           fi
           # Capture source digest for the post-retag verification step.
           SRC_DIGEST=$(docker buildx imagetools inspect "$FROM" --format '{{.Manifest.Digest}}')
           echo "SRC_DIGEST=$SRC_DIGEST" >> "$GITHUB_ENV"
           echo "FROM_REF=$FROM" >> "$GITHUB_ENV"
-          echo "TO_REF=${IMAGE}:${{ inputs.to }}" >> "$GITHUB_ENV"
+          echo "TO_REF=${IMAGE}:${TO_TAG}" >> "$GITHUB_ENV"
 
       - name: Retag (no rebuild)
         run: |
+          set -euo pipefail
           docker buildx imagetools create -t "${TO_REF}" "${FROM_REF}"
 
       - name: Verify digest equality post-retag
         run: |
+          set -euo pipefail
           DST_DIGEST=$(docker buildx imagetools inspect "${TO_REF}" --format '{{.Manifest.Digest}}')
           if [ "${SRC_DIGEST}" != "${DST_DIGEST}" ]; then
             echo "::error::Digest mismatch after retag!"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,10 @@ name: release
 #   images-gate ─────────────────────┬┴─▶ npm (workflow_call → npm-publish.yml)
 #   (waits for docker-images)        │            │
 #                                    └────────────┴──▶ finalize (un-draft)
+#                                                          │
+#                                                          └─▶ images-latest
+#                                                     (workflow_call → promote.yml,
+#                                                      :vX.Y.Z → :latest)
 #
 # Two invariants, both mechanical rather than procedural:
 #
@@ -83,11 +87,26 @@ name: release
 #      `/releases/latest` was v0.19.19, `draft: false`, `assets: []` — every
 #      `curl | sh` install on every platform was 404ing on the download.)
 #
-# NOT closed by this: docker-images still moves the `:latest` IMAGE tag on a
-# tag push regardless of the other legs. That is deliberate scope — image
-# tags are retaggable (promote.yml) where npm and `/releases/latest` are not,
-# and folding docker-images into this pipeline would mean restructuring the
-# workflow that also serves every PR and main push. Tracked in #3685.
+#   3. THE `:latest` IMAGE TAG FOLLOWS THE RELEASE, NOT THE TAG PUSH (#3685).
+#      docker-images.yml used to move `:latest` for every image on the tag
+#      push itself, with no dependency on the binary build, the assets or
+#      npm — so a red release left `ghcr.io/switchroom/*:latest` on that
+#      version. It now publishes `:vX.Y.Z` only, and `images-latest` below
+#      promotes `:vX.Y.Z` → `:latest` after `finalize`.
+#
+#      docker-images.yml was NOT folded into this pipeline via
+#      `workflow_call` — it also serves every PR and main push and carries
+#      the `images-ok` required check, so converting it would put the whole
+#      image pipeline at risk to gate one leg. Only the four tag-branch
+#      `imagetools`/`tags=` lines changed there; the matrix, the PR/main
+#      paths and `images-ok` are untouched.
+#
+#      `images-latest` runs LAST, after `finalize`, deliberately. Its
+#      failure mode is then `:latest` LAGGING the release (the previous
+#      good image keeps serving `switchroom update`), recoverable with
+#      `gh workflow run promote.yml -f from=vX.Y.Z -f to=latest`. Running
+#      it before `finalize` would invert that into `:latest` LEADING a
+#      release that never got published — the failure #3685 is about.
 
 on:
   push:
@@ -645,3 +664,39 @@ jobs:
             exit 1
           fi
           echo "Release $EXPECT_TAG is published with a complete asset bundle."
+
+  # #3685: move `ghcr.io/<owner>/switchroom-*:latest` onto this release —
+  # and only now, after every leg (binaries, assets, docker-images, npm,
+  # the un-drafted GitHub Release) is green.
+  #
+  # `needs: finalize` is the whole point of the job: `finalize` already
+  # `needs: [publish, images-gate, npm]`, so depending on it inherits the
+  # full chain. A plain `needs:` (no `always()`, no `!cancelled()`), like
+  # every other job here — R6 in tests/release-pipeline-gating.test.ts
+  # would fail the build otherwise.
+  #
+  # promote.yml does the work rather than an inline `imagetools create`
+  # loop: it already prechecks the source tag, retags without rebuilding
+  # (so the promoted `:latest` carries the same manifest digest and the
+  # signed provenance the tag build attached) and verifies digest equality
+  # afterwards. It stays the operator's hand-promotion surface too, so a
+  # failure here is re-run with
+  # `gh workflow run promote.yml -f from=<tag> -f to=latest`.
+  images-latest:
+    name: promote :vX.Y.Z to :latest
+    needs: finalize
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' &&
+       inputs.dry_run == false &&
+       startsWith(github.ref, 'refs/tags/v'))
+    permissions:
+      # A caller job's block CAPS the called workflow's token (the R11
+      # lesson one axis over): promote.yml's own `packages: write` is a
+      # no-op unless it is granted here too.
+      contents: read
+      packages: write
+    uses: ./.github/workflows/promote.yml
+    with:
+      from: ${{ github.ref_name }}
+      to: latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 ## Unreleased
 
+### `:latest` follows the release succeeding, not the tag push
+
+#3654 made a `v*` tag unable to half-ship for the two legs that cannot be
+walked back — npm lost its tag trigger, and the GitHub Release is held as a
+draft until every leg is green — and explicitly left the third: `docker-images`
+kept its own `tags: ["v*"]` trigger and moved `:latest` for every image on the
+tag push, with no dependency on the binary build, the release assets or npm. A
+tag whose `release` run went red still left `ghcr.io/switchroom/*:latest`
+pointing at that version.
+
+A tag push now publishes `:vX.Y.Z` only, and `release.yml` grew a terminal
+`images-latest` job that promotes `:vX.Y.Z` → `:latest` through `promote.yml`
+once every leg is green. The whole edit inside `docker-images.yml` is four
+tag-branch lines; its matrix, its PR / main-push / `merge_group` paths and the
+`images-ok` required check are untouched. That was the point — the issue's
+cleaner-looking option was to lift `:latest` promotion out of `docker-images`
+into a job `release.yml` calls, but `docker-images` also serves every PR and
+every main push, and restructuring it to gate the one leg that is *recoverable*
+inverts the cost/benefit that justified gating npm.
+
+`images-latest` runs **after** `finalize`, deliberately. Its failure mode is
+then `:latest` LAGGING the release — the previous good image keeps serving
+`switchroom update`, and `gh workflow run promote.yml -f from=vX.Y.Z -f
+to=latest` finishes the job. Running it before `finalize` would invert that
+into `:latest` leading a release that never got published, which is the failure
+being fixed wearing a different hat.
+
+Two things found while wiring it, both now load-bearing rather than incidental:
+
+- **`promote.yml`'s matrix was missing `web`** while `docker-images`'
+  `merge-dependents` matrix had it. Dispatch-only, that was cosmetic; on the
+  release path it means `switchroom-web:latest` silently stops advancing at
+  release time, with nothing failing. The matrix is now the full nine, and the
+  expected set is *derived from `docker-images.yml`* by the test rather than
+  restated, so the next image added cannot reopen the gap.
+- **`promote.yml` interpolated `${{ inputs.from }}` / `${{ inputs.to }}`
+  straight into `run:` bodies.** Those are operator-supplied strings on the
+  dispatch path, in a job holding `packages: write`; they go through `env:` now,
+  the same rule `release.yml` and `npm-publish.yml` already followed.
+
+None of this is observable on a pull request — `release.yml` and `promote.yml`
+have no PR trigger, and `docker-images`' tag branch runs only on a real tag —
+so it is pinned structurally instead. `tests/release-pipeline-gating.test.ts`
+gains R12 (a `v*` tag push publishes the version tag and nothing named
+`latest`), R13 (`release.yml` has a job promoting this run's tag to `:latest`,
+and it `needs:` the un-draft job, so it inherits the whole green chain) and R14
+(matrix coverage). Every rule is proved by mutation against the pre-#3685 tree:
+reconstructing it fires R12 on all four sites, R13 twice and R14 on `web`.
+
+Deliberately NOT done: `docker-images.yml` was not converted into a
+`workflow_call` callee, the `:dev` / `:rc` channels and `promote-to-dev` are
+untouched, and the rollout canary's `--version` assertion stays the guard
+against the `:latest` pull-race — it covers a different failure (a stale pull)
+than this one (a wrong tag).
+
 ### The hindsight LLM token budget is derived from a declared context window (#3717, #3730)
 
 Hindsight's retain / reflect / consolidation calls were sized by hand-tuned

--- a/skills/switchroom-release/SKILL.md
+++ b/skills/switchroom-release/SKILL.md
@@ -100,7 +100,8 @@ The tag push triggers `docker-images` and `release`. `release` internally waits 
 
 ### Gate B — the release pipeline (`release.yml`)
 - `gh run list --workflow=release.yml --limit 1` — wait for `completed` / `success`. Expect ~25-30 minutes: four native build legs plus the wait on `docker-images`.
-- Its jobs, in order: `guard` (release exists + held out of `latest`) → `build` ×4 → `bundle` → `publish` (attach) → `images-gate` (wait on docker-images) → `npm` → `finalize` (un-draft). A red job anywhere leaves the release a **draft** and npm **unpublished** — which is the correct, recoverable state.
+- Its jobs, in order: `guard` (release exists + held out of `latest`) → `build` ×4 → `bundle` → `publish` (attach) → `images-gate` (wait on docker-images) → `npm` → `finalize` (un-draft) → `images-latest` (promote `:vX.Y.Z` → `:latest`). A red job anywhere leaves the release a **draft** and npm **unpublished** — which is the correct, recoverable state.
+- `images-latest` is why a tag push no longer moves the `:latest` image tag by itself (#3685). If that last job is the one that failed, every other leg shipped and only the image tag lags: re-run it with `gh workflow run promote.yml -f from=vX.Y.Z -f to=latest`. Don't roll the fleet off `:latest` until it is green — `docker manifest inspect ghcr.io/switchroom/switchroom-agent:latest` should report the same digest as `:vX.Y.Z`.
 - Verify the release page actually has assets **and is no longer a draft**:
   ```bash
   gh release view vX.Y.Z -R switchroom/switchroom --json isDraft,assets \

--- a/tests/release-pipeline-gating.test.ts
+++ b/tests/release-pipeline-gating.test.ts
@@ -46,6 +46,8 @@ interface Job {
   steps?: Step[];
   env?: Record<string, unknown>;
   permissions?: Permissions;
+  with?: Record<string, unknown>;
+  strategy?: { matrix?: Record<string, unknown> };
   "continue-on-error"?: unknown;
 }
 interface Workflow {
@@ -110,10 +112,60 @@ function contentsScope(wf: Workflow, job: Job): string | null {
 }
 
 /**
+ * The body of every `if [[ … refs/tags/v* ]]` branch inside a `run:` block —
+ * i.e. exactly the lines that decide which image tags a `v*` TAG PUSH
+ * publishes. Comment lines are stripped: the branches carry prose about
+ * `:latest` that must not be mistaken for an assignment of it.
+ */
+function tagPushBranches(wf: Workflow): { job: string; step: string; body: string }[] {
+  const out: { job: string; step: string; body: string }[] = [];
+  for (const [id, job] of Object.entries(wf.jobs ?? {})) {
+    for (const s of stepsOf(job)) {
+      const lines = (s.run ?? "").split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i] as string;
+        if (!/refs\/tags\/v\*/.test(line) || !/^\s*(el)?if\b/.test(line)) continue;
+        const body: string[] = [];
+        for (let j = i + 1; j < lines.length; j++) {
+          if (/^\s*(elif|else|fi)\b/.test(lines[j] as string)) break;
+          if (/^\s*#/.test(lines[j] as string)) continue;
+          body.push(lines[j] as string);
+        }
+        out.push({ job: id, step: s.name ?? "?", body: body.join("\n") });
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Every `switchroom-<name>` image docker-images.yml publishes on a tag push:
+ * the `merge-dependents` matrix, plus `base`, plus each standalone build job
+ * identified by its `file: docker/Dockerfile.<name>`.
+ */
+function dockerPublishedImages(docker: Workflow): string[] {
+  const set = new Set<string>(["base"]);
+  const md = docker.jobs?.["merge-dependents"];
+  for (const n of (md?.strategy?.matrix?.image as unknown[] | undefined) ?? []) set.add(String(n));
+  for (const job of Object.values(docker.jobs ?? {})) {
+    for (const s of stepsOf(job)) {
+      const m = /^docker\/Dockerfile\.([\w-]+)$/.exec(String((s as { with?: Record<string, unknown> }).with?.file ?? ""));
+      if (m) set.add(m[1] as string);
+    }
+  }
+  return [...set].sort();
+}
+
+/**
  * The whole rule set, as a list of human-readable problems. Empty = the
  * pipeline cannot half-ship.
  */
-export function auditGating(release: Workflow, npmPublish: Workflow): string[] {
+export function auditGating(
+  release: Workflow,
+  npmPublish: Workflow,
+  docker: Workflow,
+  promote: Workflow,
+): string[] {
   const problems: string[] = [];
   const releaseJobs = Object.entries(release.jobs ?? {});
 
@@ -205,6 +257,9 @@ export function auditGating(release: Workflow, npmPublish: Workflow): string[] {
   for (const [file, wf] of [
     ["release.yml", release],
     ["npm-publish.yml", npmPublish],
+    // promote.yml joined the chain with #3685 — release.yml calls it to
+    // move `:latest`, so the same swallow-nothing rule binds it.
+    ["promote.yml", promote],
   ] as const) {
     for (const [id, job] of Object.entries(wf.jobs ?? {})) {
       const cond = String(job.if ?? "");
@@ -251,6 +306,10 @@ export function auditGating(release: Workflow, npmPublish: Workflow): string[] {
   for (const [file, wf] of [
     ["release.yml", release],
     ["npm-publish.yml", npmPublish],
+    // promote.yml too, since #3685: it is on the release path and holds
+    // `packages: write`, and its `inputs.from` / `inputs.to` are
+    // operator-supplied strings on the workflow_dispatch path.
+    ["promote.yml", promote],
   ] as const) {
     for (const [id, job] of Object.entries(wf.jobs ?? {})) {
       for (const s of stepsOf(job)) {
@@ -361,16 +420,103 @@ export function auditGating(release: Workflow, npmPublish: Workflow): string[] {
     }
   }
 
+  // ── #3685: `:latest` must follow the RELEASE, not the tag push ────────
+  //
+  // docker-images.yml keeps its own `tags: ["v*"]` trigger and runs in
+  // parallel with this pipeline, with no dependency on the binary build,
+  // the release assets or npm. While it also moved `:latest` there, a tag
+  // whose `release` run went red still left `ghcr.io/<owner>/switchroom-*:
+  // latest` pointing at that version — the one half-ship #3654 explicitly
+  // left open. Same reason this file exists at all: none of it is
+  // observable on a PR, and the next time anyone finds out is a release.
+
+  // R12 — a `v*` tag push publishes the VERSION tag only.
+  const tagBranches = tagPushBranches(docker);
+  if (tagBranches.length < 4) {
+    problems.push(
+      `R12: docker-images.yml has ${tagBranches.length} \`refs/tags/v*\` tag-assignment branches; expected at ` +
+        "least 4 (merge-base, merge-dependents, build-hindsight, build-voice). The rule cannot be checked " +
+        "against branches that no longer exist — re-point it at whatever replaced them.",
+    );
+  }
+  for (const b of tagBranches) {
+    if (/latest/.test(b.body)) {
+      problems.push(
+        `R12: docker-images.yml job ${b.job} step "${b.step}" assigns \`:latest\` on a \`v*\` tag push — that ` +
+          "moves it on the TAG, not on the release succeeding, so a red release leaves :latest broken. " +
+          "release.yml's promote job owns :latest now.",
+      );
+    }
+    if (!/TAG_VERSION/.test(b.body)) {
+      problems.push(
+        `R12: docker-images.yml job ${b.job} step "${b.step}" no longer publishes the \`:vX.Y.Z\` version tag on a ` +
+          "tag push — release.yml's images-gate and the :latest promotion both depend on it existing.",
+      );
+    }
+  }
+
+  // R13 — and release.yml is what moves it, strictly after the release is
+  // published. `needs: <the un-draft job>` inherits the whole green chain
+  // (assets + images-gate + npm), so this one edge is the guarantee.
+  if (!promote.on || !Object.prototype.hasOwnProperty.call(promote.on, "workflow_call")) {
+    problems.push("R13: promote.yml has no `workflow_call` trigger — release.yml cannot invoke it.");
+  }
+  const latestEntry = releaseJobs.find(([, j]) => (j.uses ?? "").endsWith("promote.yml"));
+  if (!latestEntry) {
+    problems.push(
+      "R13: release.yml has no job that promotes the release's image tag to `:latest`. With R12 in force nothing " +
+        "else does, so `:latest` would freeze at the last main push forever.",
+    );
+  } else {
+    const [id, job] = latestEntry;
+    const to = String(job.with?.to ?? "");
+    const from = String(job.with?.from ?? "");
+    if (to !== "latest") {
+      problems.push(`R13: the promotion job (${id}) promotes to '${to}', not 'latest'.`);
+    }
+    if (!from.includes("github.ref_name")) {
+      problems.push(
+        `R13: the promotion job (${id}) promotes from '${from}' rather than this run's tag — :latest must land on ` +
+          "the image built for the tag being released.",
+      );
+    }
+    if (undraftEntry && !needsOf(job).includes(undraftEntry[0])) {
+      problems.push(
+        `R13: the promotion job (${id}) does not \`needs: ${undraftEntry[0]}\` — :latest could move for a release ` +
+          "that is still a draft, or whose npm/asset legs failed. That is the #3685 defect with a new owner.",
+      );
+    }
+  }
+
+  // R14 — promote.yml's matrix must cover every image docker-images
+  // publishes on a tag. An image missing from it is one whose `:latest`
+  // silently stops advancing at release time: nothing fails, the tag just
+  // never moves. `web` was exactly this — in docker-images' dependents
+  // matrix, absent from promote.yml — harmless while promote was
+  // dispatch-only, a real hole once the release path depends on it.
+  const expectedImages = dockerPublishedImages(docker);
+  const promoteImages = [
+    ...((promote.jobs?.promote?.strategy?.matrix?.image as unknown[] | undefined) ?? []).map(String),
+  ].sort();
+  const uncovered = expectedImages.filter((n) => !promoteImages.includes(n));
+  if (uncovered.length > 0) {
+    problems.push(
+      `R14: promote.yml's matrix omits [${uncovered.join(", ")}], which docker-images.yml publishes on a tag — ` +
+        "their `:latest` would silently stop advancing at release time.",
+    );
+  }
+
   return problems;
 }
 
 const RELEASE = load("release.yml");
 const NPM = load("npm-publish.yml");
 const DOCKER = load("docker-images.yml");
+const PROMOTE = load("promote.yml");
 
 describe("release pipeline gating — the real workflows", () => {
   it("has no gating problems", () => {
-    expect(auditGating(RELEASE, NPM)).toEqual([]);
+    expect(auditGating(RELEASE, NPM, DOCKER, PROMOTE)).toEqual([]);
   });
 
   it("keeps npm-publish unreachable from a tag push, and callable by release.yml", () => {
@@ -417,11 +563,13 @@ describe("release pipeline gating — the real workflows", () => {
 });
 
 /** Deep-clone the real workflows and weaken them the way a careless edit would. */
-function mutate(fn: (r: Workflow, n: Workflow) => void): string[] {
+function mutate(fn: (r: Workflow, n: Workflow, d: Workflow, p: Workflow) => void): string[] {
   const r = clone(RELEASE);
   const n = clone(NPM);
-  fn(r, n);
-  return auditGating(r, n);
+  const d = clone(DOCKER);
+  const p = clone(PROMOTE);
+  fn(r, n, d, p);
+  return auditGating(r, n, d, p);
 }
 
 describe("release pipeline gating — every rule is proved by mutation", () => {
@@ -671,6 +819,121 @@ describe("release pipeline gating — every rule is proved by mutation", () => {
       jobDoing(r, "--draft=false")![1].permissions = { actions: "read" };
     });
     expect(p.join("\n")).toMatch(/R11: release\.yml job finalize .*`contents: none`/);
+  });
+
+  // ── R12/R13/R14: the #3685 defect, reproduced ──────────────────────────
+  //
+  // The pre-#3685 tree is the mutation that matters: putting `-t
+  // "${IMAGE}:latest"` back into docker-images' tag branch IS the bug, and
+  // R12 is the only rule that fires on it — which is also why it survived
+  // #3654 unnoticed.
+  it("R12: the pre-#3685 tree — docker-images moving `:latest` on a tag push — is caught", () => {
+    const p = mutate((_r, _n, d) => {
+      const step = stepsOf(d.jobs!["merge-base"]!).find((s) => (s.run ?? "").includes("refs/tags/v*"))!;
+      step.run = step.run!.replace(
+        'TAG_ARGS=(-t "${IMAGE}:${TAG_VERSION}")',
+        'TAG_ARGS=(-t "${IMAGE}:${TAG_VERSION}" -t "${IMAGE}:latest")',
+      );
+    });
+    expect(p.join("\n")).toMatch(/R12: docker-images\.yml job merge-base .*assigns `:latest` on a `v\*` tag push/s);
+  });
+
+  it("R12: the same regression in the hindsight/voice `tags=` form is caught", () => {
+    const p = mutate((_r, _n, d) => {
+      const step = stepsOf(d.jobs!["build-voice"]!).find((s) => (s.run ?? "").includes("refs/tags/v*"))!;
+      step.run = step.run!.replace(
+        'echo "tags=${IMAGE}:${TAG_VERSION}" >> "$GITHUB_OUTPUT"',
+        'echo "tags=${IMAGE}:${TAG_VERSION},${IMAGE}:latest" >> "$GITHUB_OUTPUT"',
+      );
+    });
+    expect(p.join("\n")).toMatch(/R12: docker-images\.yml job build-voice/);
+  });
+
+  it("R12: dropping the version tag from a tag push is caught too", () => {
+    // The over-correction: publishing nothing on a tag would starve both
+    // images-gate and the :latest promotion.
+    const p = mutate((_r, _n, d) => {
+      const step = stepsOf(d.jobs!["merge-dependents"]!).find((s) => (s.run ?? "").includes("refs/tags/v*"))!;
+      step.run = step.run!.replace('TAG_VERSION="${GITHUB_REF#refs/tags/}"', ":").replace(
+        'TAG_ARGS=(-t "${IMAGE}:${TAG_VERSION}")',
+        'TAG_ARGS=(-t "${IMAGE}:x")',
+      );
+    });
+    expect(p.join("\n")).toMatch(/R12: docker-images\.yml job merge-dependents .*no longer publishes/s);
+  });
+
+  it("R12: deleting the tag branches outright cannot vacuously pass", () => {
+    const p = mutate((_r, _n, d) => {
+      for (const job of Object.values(d.jobs!)) {
+        for (const s of stepsOf(job)) {
+          if (s.run) s.run = s.run.replace(/refs\/tags\/v\*/g, "refs/heads/nope");
+        }
+      }
+    });
+    expect(p.join("\n")).toMatch(/R12: docker-images\.yml has 0 `refs\/tags\/v\*` tag-assignment branches/);
+  });
+
+  it("R13: deleting the :latest promotion job is caught", () => {
+    const p = mutate((r) => {
+      const id = Object.entries(r.jobs!).find(([, j]) => (j.uses ?? "").endsWith("promote.yml"))![0];
+      delete r.jobs![id];
+    });
+    expect(p.join("\n")).toMatch(/R13: release\.yml has no job that promotes/);
+  });
+
+  it("R13: promoting :latest without waiting for the release to be published is caught", () => {
+    // The tempting "move it early so the fleet gets it sooner" edit — which
+    // reinstates #3685 inside release.yml instead of docker-images.yml.
+    const p = mutate((r) => {
+      const job = Object.values(r.jobs!).find((j) => (j.uses ?? "").endsWith("promote.yml"))!;
+      job.needs = ["bundle"];
+    });
+    expect(p.join("\n")).toMatch(/R13: the promotion job \(images-latest\) does not `needs: finalize`/);
+  });
+
+  it("R13: promoting the wrong source or destination tag is caught", () => {
+    expect(
+      mutate((r) => {
+        Object.values(r.jobs!).find((j) => (j.uses ?? "").endsWith("promote.yml"))!.with!.to = "rc";
+      }).join("\n"),
+    ).toMatch(/R13: the promotion job \(images-latest\) promotes to 'rc'/);
+    expect(
+      mutate((r) => {
+        Object.values(r.jobs!).find((j) => (j.uses ?? "").endsWith("promote.yml"))!.with!.from = "dev";
+      }).join("\n"),
+    ).toMatch(/R13: the promotion job \(images-latest\) promotes from 'dev'/);
+  });
+
+  it("R13: removing workflow_call from promote.yml is caught", () => {
+    const p = mutate((_r, _n, _d, pr) => {
+      delete (pr.on as Record<string, unknown>).workflow_call;
+    });
+    expect(p.join("\n")).toMatch(/R13: promote\.yml has no `workflow_call` trigger/);
+  });
+
+  it("R14: the `web` gap — an image docker-images tags but promote.yml does not — is caught", () => {
+    // promote.yml really did ship without `web` while docker-images'
+    // merge-dependents matrix had it. Dispatch-only, that was cosmetic;
+    // on the release path it means switchroom-web:latest stops advancing.
+    const p = mutate((_r, _n, _d, pr) => {
+      const m = pr.jobs!.promote!.strategy!.matrix as { image: string[] };
+      m.image = m.image.filter((i) => i !== "web");
+    });
+    expect(p.join("\n")).toMatch(/R14: promote\.yml's matrix omits \[web\]/);
+  });
+
+  it("R14: a new image in docker-images that promote.yml never learns about is caught", () => {
+    const p = mutate((_r, _n, d) => {
+      (d.jobs!["merge-dependents"]!.strategy!.matrix as { image: string[] }).image.push("newthing");
+    });
+    expect(p.join("\n")).toMatch(/R14: promote\.yml's matrix omits \[newthing\]/);
+  });
+
+  it("R8: interpolating an operator-supplied input into promote.yml's run body is caught", () => {
+    const p = mutate((_r, _n, _d, pr) => {
+      stepsOf(pr.jobs!.promote!)[1]!.run = 'echo "${{ inputs.from }}"';
+    });
+    expect(p.join("\n")).toMatch(/R8: promote\.yml/);
   });
 
   // Guards the rule against over-firing: GitHub really does inherit env from


### PR DESCRIPTION
## Summary

`docker-images.yml` kept its own `tags: ["v*"]` trigger and moved `:latest` for every image on the tag push, with no dependency on the binary build, the release assets or npm. A tag whose `release` run went red still left `ghcr.io/switchroom/*:latest` pointing at that version — the one half-ship #3654 explicitly left open (`.github/workflows/release.yml:86-90` at the time).

A `v*` tag push now publishes `:vX.Y.Z` **only**, and `release.yml` grew a terminal `images-latest` job that promotes `:vX.Y.Z` → `:latest` through `promote.yml` once every leg is green.

## Why this shape

The issue listed three candidates. This is shape 1 in its **smallest** form:

- The whole edit inside `docker-images.yml` is four tag-branch lines (`merge-base`, `merge-dependents`, `build-hindsight`, `build-voice`). Its matrix, its PR / main-push / `merge_group` paths and the `images-ok` required check are untouched — the blast radius the issue was worried about. `docker-images.yml` was **not** converted into a `workflow_call` callee.
- `images-latest` runs **after** `finalize`, deliberately. Its failure mode is then `:latest` LAGGING the release (previous good image keeps serving `switchroom update`; `gh workflow run promote.yml -f from=vX.Y.Z -f to=latest` finishes it). Before `finalize` it would invert into `:latest` LEADING a release that never got published — the same defect wearing a different hat.
- `promote.yml` does the work rather than an inline `imagetools create` loop: it already prechecks the source tag, retags without rebuilding (so `:latest` carries the tag build's manifest digest and signed provenance) and verifies digest equality afterwards.

## Two gaps found while wiring it

- **`promote.yml`'s matrix was missing `web`** while `docker-images`' `merge-dependents` matrix has it. Dispatch-only that was cosmetic; on the release path it means `switchroom-web:latest` silently stops advancing, with nothing failing. Now the full nine, and the expected set is *derived from `docker-images.yml`* by the test rather than restated.
- **`promote.yml` interpolated `${{ inputs.from }}` / `${{ inputs.to }}` into `run:` bodies** — operator-supplied strings in a job holding `packages: write`. They go through `env:` now, the rule `release.yml` and `npm-publish.yml` already followed.

## Test plan

None of this is observable on a PR (`release.yml` / `promote.yml` have no PR trigger; the `docker-images` tag branch runs only on a real tag), so it is pinned structurally. `tests/release-pipeline-gating.test.ts` gains three rules, each proved by mutation:

- **R12** — a `v*` tag push assigns nothing named `latest`, and still assigns `:vX.Y.Z`.
- **R13** — `release.yml` has a job promoting this run's tag to `:latest`, and it `needs:` the un-draft job (inheriting assets + images-gate + npm).
- **R14** — `promote.yml`'s matrix covers every image `docker-images` publishes on a tag.

R6 (nothing swallows an upstream failure) and R8 (no `${{ }}` in `run:`) now also cover `promote.yml`.

**Evidence the tests fail on the bug they guard:** reverting the three workflow files and re-running the suite produces R12 on all four sites (`merge-base`, `merge-dependents`, `build-hindsight`, `build-voice`), R13 twice (no promotion job, no `workflow_call` on promote.yml) and R14 on `web`.

Run locally: `npx vitest run tests/release-pipeline-gating.test.ts tests/ci-merge-queue-triggers.test.ts tests/docker/` → 501 passed / 33 skipped. All three workflow files re-verified with `yaml.safe_load`. `npm run lint`: `tsc --noEmit` clean; `check-plugin-references` fails identically on a pristine tree in this worktree (missing `mdast-*` / `@mtcute` deps behind the symlinked `node_modules`) — environment artifact, CI is the authority there.

## Risk

CI plumbing that cannot be smoke-tested by running it. The one path that changes at release time is the image `:latest` move; if `images-latest` fails, every other leg has already shipped and only the image tag lags, recoverable by dispatching `promote.yml`. `docs`/skill guidance updated (`skills/switchroom-release/SKILL.md` Gate B).

Job spec: `reference/jobs/idempotent-update-and-restart.md` — "after running `switchroom update`, the entire stack is at the version switchroom declared and tested as a unit". `:latest` moving on a tag whose release then went red is precisely a stack at a version switchroom did not finish testing. Vision outcome: *always available*.

Closes #3685.
