### PR TITLE
test(ci): pin the `:latest` promotion job's `if:` to the un-draft job's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 ## Unreleased
 
+### The `:latest` promotion job's `if:` is now pinned to the un-draft job's
+
+#3735 asserted that `release.yml`'s `images-latest` job exists, promotes this
+run's tag to `:latest`, and `needs: finalize`. It never asserted the job's
+`if:`. Those are independent — `needs:` orders a job, `if:` decides whether it
+runs at all — so narrowing the condition to the dispatch clause alone
+(`github.event_name == 'workflow_dispatch' && inputs.dry_run == false`) left
+every test and every required check green while the job silently stopped firing
+on tag pushes. The release would still publish, `:vX.Y.Z` would still ship, and
+`:latest` would never advance again. Nothing fails; you find out by diffing
+manifest digests weeks later.
+
+That edit is plausible rather than adversarial: the comment block above the job
+names `gh workflow run promote.yml -f from=vX.Y.Z -f to=latest` as the recovery
+lever, so the condition reads like it is *about* dispatch.
+
+R13 now requires the promotion job's `if:` to equal the un-draft job's, compared
+whitespace-insensitively and with both jobs resolved structurally, the same way
+R13 already found them. Equality rather than a literal expression, because the
+requirement is genuinely relative: `:latest` must move in exactly the cases the
+release is published in, no more (a dry run must not move it) and no less. It
+also catches drift in the other direction — change `finalize`'s gating and
+forget the promotion's, and this fires. Four mutations prove it: the narrowing
+above (which fires this rule and no other, which is the proof the hole was
+real), a deleted `if:`, one-sided drift, and a whitespace reflow that must stay
+clean.
+
+Also corrected in the #3685 entry below: it claimed the mutation tests fire R12
+"on all four sites". They reconstruct the regression at three — `merge-base`,
+`merge-dependents` and `build-voice`; `build-hindsight` is never mutated. The
+rule itself iterates all four, so the guarantee held; only the prose overclaimed.
+
+The five remaining review findings are filed rather than fixed: #3736 (R12 only
+reads the interior of shell tag branches, so two realistic re-additions escape
+it), #3737, #3738, #3739 and #3740.
+
 ### `:latest` follows the release succeeding, not the tag push
 
 #3654 made a `v*` tag unable to half-ship for the two legs that cannot be
@@ -48,8 +84,13 @@ so it is pinned structurally instead. `tests/release-pipeline-gating.test.ts`
 gains R12 (a `v*` tag push publishes the version tag and nothing named
 `latest`), R13 (`release.yml` has a job promoting this run's tag to `:latest`,
 and it `needs:` the un-draft job, so it inherits the whole green chain) and R14
-(matrix coverage). Every rule is proved by mutation against the pre-#3685 tree:
-reconstructing it fires R12 on all four sites, R13 twice and R14 on `web`.
+(matrix coverage). Every rule is proved by mutation against the pre-#3685 tree.
+R12 iterates every `refs/tags/v*` branch in `docker-images.yml`, so the
+guarantee covers all four; the mutations reconstruct the regression at three of
+them — `merge-base` and `merge-dependents` in the `TAG_ARGS` form, `build-voice`
+in the `tags=` output form — which is enough to prove both shapes of the edit
+are caught. R13 and R14 have their own mutations: a deleted promotion job, a
+promotion that no longer waits for the un-draft, and the missing `web`.
 
 Deliberately NOT done: `docker-images.yml` was not converted into a
 `workflow_call` callee, the `:dev` / `:rc` channels and `promote-to-dev` are

--- a/tests/release-pipeline-gating.test.ts
+++ b/tests/release-pipeline-gating.test.ts
@@ -486,6 +486,42 @@ export function auditGating(
           "that is still a draft, or whose npm/asset legs failed. That is the #3685 defect with a new owner.",
       );
     }
+    // R13 (gating half) — `needs:` only ORDERS the job; the `if:` decides
+    // whether it runs at all. Those are independent, and only the `needs:`
+    // half was asserted when #3735 landed.
+    //
+    // The hole it leaves is silent by construction. Narrow the promotion
+    // job's `if:` to the dispatch clause alone — `github.event_name ==
+    // 'workflow_dispatch' && inputs.dry_run == false`, a plausible tidy-up
+    // since the comment above the job advertises exactly that recovery
+    // lever — and the job never runs on a tag push. Every leg stays green,
+    // the release publishes, `:vX.Y.Z` ships, and `:latest` never advances
+    // again. Nothing fails; you find out by diffing manifest digests.
+    //
+    // Asserted as equality with the un-draft job's own `if:` rather than a
+    // literal expression, because the requirement really is relative:
+    // `:latest` must move in exactly the circumstances the release is
+    // published in — no more (a dry run must not move it) and no less (a
+    // real tag push must). Pinning it to `finalize` also catches DRIFT —
+    // change the release's trigger gating and forget the promotion's and
+    // this fires, which is what a hardcoded string would miss.
+    const normalizeIf = (x: unknown) => String(x ?? "").replace(/\s+/g, " ").trim();
+    if (undraftEntry) {
+      const promoteIf = normalizeIf(job.if);
+      const undraftIf = normalizeIf(undraftEntry[1].if);
+      if (promoteIf === "") {
+        problems.push(
+          `R13: the promotion job (${id}) has no \`if:\` — it must be gated exactly like the un-draft job ` +
+            `(${undraftEntry[0]}), or a dry-run dispatch would move :latest.`,
+        );
+      } else if (promoteIf !== undraftIf) {
+        problems.push(
+          `R13: the promotion job (${id}) has \`if: ${promoteIf}\` but the un-draft job (${undraftEntry[0]}) has ` +
+            `\`if: ${undraftIf}\` — :latest must move in exactly the cases the release is published in. Narrowing ` +
+            "this one leaves :latest silently frozen on tag pushes with every leg still green.",
+        );
+      }
+    }
   }
 
   // R14 — promote.yml's matrix must cover every image docker-images
@@ -889,6 +925,53 @@ describe("release pipeline gating — every rule is proved by mutation", () => {
       job.needs = ["bundle"];
     });
     expect(p.join("\n")).toMatch(/R13: the promotion job \(images-latest\) does not `needs: finalize`/);
+  });
+
+  // The gating half of R13. `needs:` and `if:` are independent: the mutation
+  // below leaves `needs: finalize`, `with.from`, `with.to` and every other
+  // asserted property untouched, so before this rule existed the whole file
+  // stayed green while `:latest` stopped advancing on every future release.
+  it("R13: narrowing the promotion job's `if:` so it never fires on a tag push is caught", () => {
+    const p = mutate((r) => {
+      const job = Object.values(r.jobs!).find((j) => (j.uses ?? "").endsWith("promote.yml"))!;
+      // The plausible edit: keep only the dispatch clause, because the job's
+      // own comment names `gh workflow run promote.yml` as the recovery
+      // lever. A tag push then skips it silently, forever.
+      job.if = "github.event_name == 'workflow_dispatch' && inputs.dry_run == false";
+    });
+    expect(p.join("\n")).toMatch(/R13: the promotion job \(images-latest\) has `if: .*` but the un-draft job \(finalize\) has/s);
+    // …and this is the ONLY rule that fires on it. That is the proof the
+    // hole was real: every other assertion in this file passes on a tree
+    // whose `:latest` never moves again.
+    expect(p.filter((x) => !x.startsWith("R13: the promotion job (images-latest) has `if:"))).toEqual([]);
+  });
+
+  it("R13: deleting the promotion job's `if:` entirely is caught", () => {
+    // The other direction: ungated, a `-f dry_run=true` rehearsal dispatch
+    // would move `:latest` for real.
+    const p = mutate((r) => {
+      delete Object.values(r.jobs!).find((j) => (j.uses ?? "").endsWith("promote.yml"))!.if;
+    });
+    expect(p.join("\n")).toMatch(/R13: the promotion job \(images-latest\) has no `if:`/);
+  });
+
+  it("R13: tightening the un-draft job's gating without the promotion job's is caught as drift", () => {
+    const p = mutate((r) => {
+      jobDoing(r, "--draft=false")![1].if = "github.event_name == 'push'";
+    });
+    expect(p.join("\n")).toMatch(/R13: the promotion job \(images-latest\) has `if:/);
+  });
+
+  // Guards the rule against over-firing: the two conditions are written as
+  // folded YAML scalars, so re-wrapping one changes the parsed whitespace
+  // without changing the expression. A rule that failed on a reflow would
+  // get silenced rather than fixed.
+  it("R13: re-wrapping the promotion job's `if:` without changing it stays clean", () => {
+    const p = mutate((r) => {
+      const job = Object.values(r.jobs!).find((j) => (j.uses ?? "").endsWith("promote.yml"))!;
+      job.if = `  ${String(job.if).replace(/\s+/g, "\n   ")}\n`;
+    });
+    expect(p.join("\n")).not.toMatch(/R13:/);
   });
 
   it("R13: promoting the wrong source or destination tag is caught", () => {


### PR DESCRIPTION
## Summary

Follow-up to #3735 (merged as `9ce6b45d`). Closes the one MAJOR its adversarial review raised too late to fold in, plus a docs overclaim in the same CHANGELOG entry. Everything else the review found is filed rather than fixed, per the severity gate.

`tests/release-pipeline-gating.test.ts` R13 asserted that `release.yml`'s `images-latest` job exists, promotes this run's tag to `:latest`, and `needs: finalize`. It never asserted the job's `if:`, and R6 only bans `always()` / `cancelled()`.

## Why

`needs:` orders a job; `if:` decides whether it runs at all. They are independent, so the `if:` was unguarded.

Concretely: "tidy" `release.yml:688` down to `if: github.event_name == 'workflow_dispatch' && inputs.dry_run == false` — a plausible edit, since the comment block above the job advertises `gh workflow run promote.yml -f from=vX.Y.Z -f to=latest` as the recovery lever, so the condition reads like it is *about* dispatch. Every test stays green, every required check stays green, and from then on each tag push publishes `:vX.Y.Z` while `:latest` silently never advances again. Nothing fails. You find out by diffing manifest digests.

Today `images-latest`'s `if:` (`release.yml:688-692`) is byte-identical to `finalize`'s (`:621-625`) — verified by parsing the workflow, not by eye.

## What changed

**R13 gains a gating half.** The promotion job's `if:` must equal the un-draft job's, compared whitespace-insensitively. Both jobs are resolved structurally — `uses:` ending in `promote.yml`, and the job whose `run:` contains `--draft=false` — the same way R13 already found them; no job name is hardcoded. An empty `if:` on the promotion job is its own problem (a `-f dry_run=true` rehearsal would move `:latest` for real) and is reported separately.

Equality with `finalize` rather than a literal expression, because the requirement is genuinely relative: `:latest` must move in exactly the circumstances the release is published in — no more, no less. That also makes it a drift detector: change the release's trigger gating and forget the promotion's, and this fires. A hardcoded string would miss that.

**Four mutations prove it:**

- the exact narrowing above — and it fires this rule *and no other*, which is the proof the hole was real: every other assertion in the file passes on a tree whose `:latest` never moves again;
- deleting the `if:` entirely;
- one-sided drift (tighten `finalize`, leave the promotion);
- an over-firing guard: both conditions are folded YAML scalars, so re-wrapping one must stay clean. A rule that failed on a reflow would get silenced rather than fixed.

**CHANGELOG.** The #3685 entry claimed reconstructing the bug "fires R12 on all four sites". The shipped mutations cover three — `merge-base` and `merge-dependents` in the `TAG_ARGS` form, `build-voice` in the `tags=` form; `build-hindsight` is never mutated. The rule itself iterates all four, so the guarantee held and only the prose was wrong. Corrected, and a new `## Unreleased` entry added for this change.

## Test plan

- `npx vitest run tests/release-pipeline-gating.test.ts` — 49 passed (45 before; +4).
- **Red proof against the real file**, not just a clone: applied the exact narrowing to `.github/workflows/release.yml`, re-ran, and `has no gating problems` failed with exactly one problem, the new R13 message. Reverted; `git status` confirms no workflow is modified by this PR.
- `npx tsc --noEmit` clean.
- All four release-path workflows re-parsed with `yaml` (none were changed; verified anyway).

No workflow files are touched. The diff is one test file and `CHANGELOG.md`.

## Risk

Low, and one-directional: this adds an assertion to a test that no production code path reads. The realistic failure is over-firing — R13 going red on a legitimate future edit that deliberately diverges the two conditions. The reflow mutation guards the accidental version of that, and a deliberate divergence should fail: it means someone changed when `:latest` moves relative to when the release publishes, which is exactly the decision that warrants re-reading the rule.

## Filed, not fixed

Per the severity gate — lows are filed, filing is mandatory:

- **#3736** (the important one) — R12 only reads the interior of shell tag branches, so two realistic re-additions re-open #3685 with tests green: appending `-t "${IMAGE}:latest"` to the `imagetools create` line at `docker-images.yml:382`, which sits *outside* the branch, and a new step with a GitHub-level `if: startsWith(github.ref, 'refs/tags/v')`, which R12 cannot see at all.
- **#3737** — nested-`fi` truncation in the same helper.
- **#3738** — R12's `TAG_VERSION` check is presence-only.
- **#3739** — `:latest` is non-monotonic across a release run.
- **#3740** — `promote.yml` has no `concurrency:` group.

## Job spec

`reference/jobs/` — this serves **always available**: `:latest` is what `switchroom update` and the fleet rollout pull, and the failure it guards is the fleet silently freezing on an old image while every release reports success. Advances vision outcome "always available"; crosses no invariant; the change is test-only.
