### PR TITLE
review-fix: unwrap `${{ }}` in R13's `if:` comparison, correct the empty-`if:` rationale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,25 +18,37 @@ That edit is plausible rather than adversarial: the comment block above the job
 names `gh workflow run promote.yml -f from=vX.Y.Z -f to=latest` as the recovery
 lever, so the condition reads like it is *about* dispatch.
 
-R13 now requires the promotion job's `if:` to equal the un-draft job's, compared
-whitespace-insensitively and with both jobs resolved structurally, the same way
-R13 already found them. Equality rather than a literal expression, because the
-requirement is genuinely relative: `:latest` must move in exactly the cases the
-release is published in, no more (a dry run must not move it) and no less. It
-also catches drift in the other direction — change `finalize`'s gating and
-forget the promotion's, and this fires. Four mutations prove it: the narrowing
-above (which fires this rule and no other, which is the proof the hole was
-real), a deleted `if:`, one-sided drift, and a whitespace reflow that must stay
-clean.
+R13 now requires the promotion job's `if:` to equal the un-draft job's, with
+both jobs resolved structurally, the same way R13 already found them. Equality
+rather than a literal expression, because the requirement is genuinely
+relative: `:latest` must move in exactly the cases the release is published in,
+no more and no less. It also catches drift in the other direction — change
+`finalize`'s gating and forget the promotion's, and this fires.
+
+The comparison normalises two spellings GitHub treats as identical: folded-YAML
+whitespace, and the `${{ }}` wrapper (`if: ${{ expr }}` and `if: expr` are the
+same condition, and the wrapped form is what most actions linters write). A
+rule that reddened on a cosmetic edit would get silenced rather than fixed, so
+both have mutations asserting they stay clean.
+
+Six mutations in all: the narrowing above (which fires this rule and no other,
+which is the proof the hole was real), a deleted `if:`, both `if:`s deleted
+(which must blame `finalize` rather than tell you to copy a gate that isn't
+there), one-sided drift, and the two cosmetic edits that must not fire.
+
+Scope worth stating: the pin is relative, so it does not by itself assert that
+either job runs on a tag push at all. Setting *both* conditions to dispatch-only
+still passes — filed as #3742. That failure is loud (the release visibly stays a
+draft) where the one fixed here was silent, which is why it is a follow-up.
 
 Also corrected in the #3685 entry below: it claimed the mutation tests fire R12
 "on all four sites". They reconstruct the regression at three — `merge-base`,
 `merge-dependents` and `build-voice`; `build-hindsight` is never mutated. The
 rule itself iterates all four, so the guarantee held; only the prose overclaimed.
 
-The five remaining review findings are filed rather than fixed: #3736 (R12 only
+The remaining review findings are filed rather than fixed: #3736 (R12 only
 reads the interior of shell tag branches, so two realistic re-additions escape
-it), #3737, #3738, #3739 and #3740.
+it), #3737, #3738, #3739, #3740 and #3742.
 
 ### `:latest` follows the release succeeding, not the tag push
 

--- a/tests/release-pipeline-gating.test.ts
+++ b/tests/release-pipeline-gating.test.ts
@@ -505,14 +505,31 @@ export function auditGating(
     // real tag push must). Pinning it to `finalize` also catches DRIFT —
     // change the release's trigger gating and forget the promotion's and
     // this fires, which is what a hardcoded string would miss.
-    const normalizeIf = (x: unknown) => String(x ?? "").replace(/\s+/g, " ").trim();
+    // Normalised before comparing, because two spellings GitHub treats as
+    // identical must not fail the rule — a rule that reds on a cosmetic edit
+    // gets silenced rather than fixed. Both conditions are folded YAML
+    // scalars whose continuation lines are more-indented, so YAML really does
+    // preserve their newlines and a re-wrap really does change the parsed
+    // string; and `if: ${{ expr }}` is exactly equivalent to `if: expr`,
+    // which is the form most actions linters and most humans reach for.
+    const normalizeIf = (x: unknown) =>
+      String(x ?? "")
+        .replace(/\s+/g, " ")
+        .trim()
+        .replace(/^\$\{\{\s*(.*?)\s*\}\}$/, "$1")
+        .trim();
     if (undraftEntry) {
       const promoteIf = normalizeIf(job.if);
       const undraftIf = normalizeIf(undraftEntry[1].if);
-      if (promoteIf === "") {
+      // Only meaningful while the un-draft job HAS a gate to copy. If neither
+      // has one, that is the un-draft job's defect, not the promotion's —
+      // fall through to the equality branch so the message blames the right
+      // job instead of pointing at an ungated `finalize` as the model.
+      if (promoteIf === "" && undraftIf !== "") {
         problems.push(
-          `R13: the promotion job (${id}) has no \`if:\` — it must be gated exactly like the un-draft job ` +
-            `(${undraftEntry[0]}), or a dry-run dispatch would move :latest.`,
+          `R13: the promotion job (${id}) has no \`if:\` — it must carry the same EXPLICIT gate as the un-draft ` +
+            `job (${undraftEntry[0]}). It is skipped today only because \`needs: ${undraftEntry[0]}\` propagates ` +
+            "that job's skip, which is one refactor of the `needs:` edge away from not holding.",
         );
       } else if (promoteIf !== undraftIf) {
         problems.push(
@@ -947,12 +964,27 @@ describe("release pipeline gating — every rule is proved by mutation", () => {
   });
 
   it("R13: deleting the promotion job's `if:` entirely is caught", () => {
-    // The other direction: ungated, a `-f dry_run=true` rehearsal dispatch
-    // would move `:latest` for real.
+    // Not because an ungated job would run on a dry run — `needs: finalize`
+    // means a skipped `finalize` skips this too, so the immediate behaviour
+    // is unchanged. It is caught because that safety is INHERITED from one
+    // `needs:` edge rather than stated, and the whole point of R13 is that
+    // `needs:` and `if:` are separate guarantees.
     const p = mutate((r) => {
       delete Object.values(r.jobs!).find((j) => (j.uses ?? "").endsWith("promote.yml"))!.if;
     });
     expect(p.join("\n")).toMatch(/R13: the promotion job \(images-latest\) has no `if:`/);
+  });
+
+  it("R13: with BOTH `if:`s gone, the un-draft job is blamed rather than the promotion", () => {
+    // The empty-`if:` message tells you to copy the un-draft job's gate. If
+    // that job has none either, following it literally could never clear the
+    // error — so this case must fall through to the equality branch, which
+    // names both jobs and the real defect.
+    const p = mutate((r) => {
+      delete Object.values(r.jobs!).find((j) => (j.uses ?? "").endsWith("promote.yml"))!.if;
+      delete jobDoing(r, "--draft=false")![1].if;
+    });
+    expect(p.join("\n")).not.toMatch(/R13: the promotion job \(images-latest\) has no `if:`/);
   });
 
   it("R13: tightening the un-draft job's gating without the promotion job's is caught as drift", () => {
@@ -960,6 +992,8 @@ describe("release pipeline gating — every rule is proved by mutation", () => {
       jobDoing(r, "--draft=false")![1].if = "github.event_name == 'push'";
     });
     expect(p.join("\n")).toMatch(/R13: the promotion job \(images-latest\) has `if:/);
+    // Nothing else reads `finalize`'s `if:`, so this must be the only firing.
+    expect(p.filter((x) => !x.startsWith("R13: the promotion job (images-latest) has `if:"))).toEqual([]);
   });
 
   // Guards the rule against over-firing: the two conditions are written as
@@ -970,6 +1004,17 @@ describe("release pipeline gating — every rule is proved by mutation", () => {
     const p = mutate((r) => {
       const job = Object.values(r.jobs!).find((j) => (j.uses ?? "").endsWith("promote.yml"))!;
       job.if = `  ${String(job.if).replace(/\s+/g, "\n   ")}\n`;
+    });
+    expect(p.join("\n")).not.toMatch(/R13:/);
+  });
+
+  // The other cosmetic edit that must stay clean, and the likelier one:
+  // GitHub treats `if: ${{ expr }}` and `if: expr` as the same condition,
+  // and the wrapped form is what most actions linters and most humans write.
+  it("R13: wrapping the promotion job's `if:` in `${{ }}` changes nothing and stays clean", () => {
+    const p = mutate((r) => {
+      const job = Object.values(r.jobs!).find((j) => (j.uses ?? "").endsWith("promote.yml"))!;
+      job.if = `\${{ ${String(job.if)} }}`;
     });
     expect(p.join("\n")).not.toMatch(/R13:/);
   });


### PR DESCRIPTION
## Summary

Two MAJORs from the adversarial review of #3741, which was enqueued and merged (`5ca017f9`) before the review came back. Both are confined to `tests/release-pipeline-gating.test.ts` and the CHANGELOG entry #3741 added; nothing that ships changes.

## 1. `normalizeIf` was too tight — a `${{ }}` wrapper false-failed R13

GitHub treats `if: ${{ expr }}` and `if: expr` as the same condition. #3741's comparison normalised folded-YAML whitespace but not the wrapper, so wrapping one job's condition and leaving the expression otherwise byte-identical made R13 red.

That is precisely the failure mode #3741 already reasoned about one spelling over — its own comment says a rule that fails on a cosmetic reflow "would get silenced rather than fixed" — and the `${{ }}` form is the likelier edit of the two, since it is what most actions linters and most humans write.

The wrapper is now stripped before comparing, with a mutation asserting the wrapped form stays clean.

## 2. The empty-`if:` branch's stated reason was factually wrong

#3741 justified its empty-`if:` check with "a dry-run dispatch would move `:latest`", in the error message, the test comment, and the CHANGELOG. It would not: the promotion job carries `needs: finalize` (`release.yml:687`), and GitHub skips a job whose `needs` was skipped — so on `-f dry_run=true`, `finalize` skips and an `if:`-less `images-latest` skips with it.

The check is still worth keeping, for the honest reason: that safety is **inherited from one `needs:` edge rather than stated**, and R13 exists exactly because `needs:` and `if:` are separate guarantees. The message now says that instead.

It also no longer fires when the un-draft job has no `if:` either. In that case the old message told you to gate the promotion job "exactly like the un-draft job" — which had no gate — so following it literally could never clear the error, and it blamed the wrong job. That case now falls through to the equality branch, which names both and points at the real defect. Pinned by a new mutation.

## Test plan

- `npx vitest run tests/release-pipeline-gating.test.ts` — 51 passed (49 on `main`; +2).
- `npx tsc --noEmit` clean.
- The three new/changed mutations each fail without their corresponding fix: the `${{ }}` wrap goes red without the unwrap, and the both-`if:`s-deleted case reports the empty-`if:` message without the `undraftIf !== ""` guard.
- No workflow files touched.

## Risk

Very low and one-directional. The normalisation change can only make R13 *less* likely to fire, and only on a form GitHub genuinely treats as equivalent — the substantive narrowing R13 exists to catch still goes red (unchanged mutation, still passing). The `undraftIf !== ""` guard narrows one branch to a case that cannot occur while `finalize` has an `if:`.

## Filed, not fixed

**#3742** — the pin is purely relative, so setting *both* conditions to dispatch-only (or `if: false`) still returns clean. That failure is loud where the one #3741 closed was silent: the release visibly stays a draft and `install.sh` keeps serving the previous version. Wants an absolute anchor assertion, which is a separate change.

Also still open from the #3735 review, unchanged by this PR: #3736 (the important one), #3737, #3738, #3739, #3740.

## Job spec

`reference/jobs/` — same as #3741: this serves **always available**. The rule guards the fleet silently freezing on a stale `:latest` while every release reports success; this PR keeps that rule from crying wolf on a cosmetic edit, which is how guards get deleted. Test-only; crosses no invariant.
