### PR TITLE
chore: release v0.19.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.19.24 — `:latest` follows the release, hindsight sizes its LLM calls to the real context window, and a self-echoed reply stops duplicating
 
 ### The `:latest` promotion job's `if:` is now pinned to the un-draft job's
 


### PR DESCRIPTION
Consolidates `## Unreleased` under `## v0.19.24`. CHANGELOG-only — no `package.json` bump (placeholder discipline, #2733).

Headline entries:
- `:latest` follows the release succeeding, not the tag push (#3685 / #3735, + the R13 pin in #3741 and #3743)
- hindsight's LLM token budget derived from a declared context window (#3717, #3730)
- a self-echoed reply no longer duplicates the answer (#3719, #3729, #3731)
- consolidation tag-group parallelism is an overridable managed key (#3732)
- cosmetic card/draft edits coalesce instead of being shed (#3718)

🤖 Generated with [Claude Code](https://claude.com/claude-code)