### PR TITLE
fix(hindsight): make the per-scope observation cap an overridable managed key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 ## Unreleased
 
+### The per-scope observation cap is an overridable managed key
+
+`HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE` was emitted unconditionally on both
+launch paths — the `docker run` argv and the compose snippet — from a bare
+constant in `src/setup/hindsight.ts`, and was not a member of
+`HINDSIGHT_PERF_ENV_KEYS`. So it shipped a default with no declarative channel:
+an operator's `hindsight.env` line for it was silently discarded by
+`resolveHindsightPerfOverrides` while reading, in yaml, as durable config.
+That is the same defect #3732 fixed for `CONSOLIDATION_LLM_PARALLELISM`, and
+this one was worse in one respect — its own doc comment told operators to stop
+the container and re-run `docker run -e …`, which is precisely the imperative
+state the next `switchroom apply` throws away. The documentation was advising
+the workaround instead of offering the channel.
+
+It matters because the right value is a property of a deployment, not of
+switchroom. The cap bounds observations per *tag scope*, and switchroom retains
+with `retainTags: ["{session_id}"]`, so a scope is roughly a session. How long
+sessions run, and how much consolidation a host can afford to keep doing for
+one, is something only the operator knows.
+
+The constant moved into `hindsight-perf-defaults.ts` as a member of
+`HINDSIGHT_PERF_DEFAULTS_UNGATED`; both hard-coded emissions are deleted, and
+`hindsight.ts` re-exports the name so existing import sites and their tests are
+untouched. The perf-defaults resolver emits it on both paths from one source,
+so the docker-run/compose twin property still holds.
+
+**The shipped default is unchanged at 1000 on every host.** This PR makes the
+key overridable; it does not change what switchroom ships. Ungated for the same
+reason it is defaulted rather than override-only: the previous emission was
+unconditional, so a capability gate — or dropping the default — would silently
+revert hosts to upstream's `-1` (unlimited) and remove the rail itself, a
+behaviour change smuggled in by a refactor.
+
+Deliberately not done: nothing about vectorize-io/hindsight#1284, the upstream
+unbounded-growth bug for whole-bank consolidation. This cap remains a companion
+safety rail, not a fix for that.
+
+Tests pin the key in the managed set and out of the override-only set; the
+default of 1000 across all four capability combinations; an operator value
+replacing it on both launch paths; and — the one that earns its keep — that it
+is emitted **exactly once per path** when not overridden. Verified by mutation:
+restoring the old docker-run emission alongside the new managed one reddens
+nine assertions, including the pre-existing "never emits a managed key twice"
+and run⇄compose parity guards. The two pinned key-list literals and the
+`hindsight.env` schema description are deliberate tripwires; all three fired
+and were updated. `docs/configuration.md` no longer documents the `docker run
+-e` workaround.
+
 ### The `:latest` promotion job's `if:` is now pinned to the un-draft job's
 
 #3735 asserted that `release.yml`'s `images-latest` job exists, promotes this

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -390,7 +390,13 @@ What this actually caps: per-*tag scope* observation count. Switchroom's vendore
 
 This is **not** a fix for vectorize-io/hindsight#1284 (the upstream unbounded-growth bug for whole-bank consolidation) — that's their work to do. It's a companion guardrail.
 
-You don't need to do anything to opt in. Override by stopping the bundled container and re-running `docker run` with a different `-e HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=N` value, or by editing the generated docker-compose snippet before applying it.
+You don't need to do anything to opt in. To change it, set the key under `hindsight.env` — it's a managed key, so your value replaces switchroom's default on both the `docker run` and `--compose` paths and survives the next `switchroom apply`:
+
+```yaml
+hindsight:
+  env:
+    HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE: 5000
+```
 
 If you run your own Hindsight container outside `switchroom memory --start` (e.g. you point `memory.config.url` at an external server), switchroom doesn't manage that container's env — set the cap on your own image.
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2106,6 +2106,7 @@ export const HindsightConfigSchema = z.object({
       "RERANKER_LOCAL_BATCH_SIZE, LLM_MAX_CONCURRENT, " +
       "RETAIN/CONSOLIDATION_LLM_MAX_CONCURRENT, LLM_STRICT_SCHEMA, " +
       "LLM_MAX_RETRIES, CONSOLIDATION_LLM_PARALLELISM, " +
+      "MAX_OBSERVATIONS_PER_SCOPE, " +
       "RECALL_MAX_CANDIDATES_PER_SOURCE, LINK_EXPANSION_PER_ENTITY_LIMIT, " +
       "LINK_EXPANSION_TIMEOUT, LLM_REASONING_EFFORT), the override-only keys " +
       "switchroom manages but ships NO default for " +

--- a/src/setup/hindsight-perf-defaults.test.ts
+++ b/src/setup/hindsight-perf-defaults.test.ts
@@ -174,6 +174,7 @@ describe("hindsightPerfEnv — capability gating", () => {
       "HINDSIGHT_API_LINK_EXPANSION_TIMEOUT",
       "HINDSIGHT_API_LLM_REASONING_EFFORT",
       "HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM",
+      "HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE",
     ];
     expect(HINDSIGHT_PERF_DEFAULTS_UNGATED.map(([k]) => k)).toEqual(UNGATED);
     for (const caps of [
@@ -312,7 +313,7 @@ describe("operator override wins", () => {
     expect(got.size).toBe(0);
   });
 
-  it("is overridable on exactly these twelve keys, by name", () => {
+  it("is overridable on exactly these thirteen keys, by name", () => {
     // Spelled out, NOT derived from the three group arrays. HINDSIGHT_PERF_ENV_KEYS
     // is DEFINED as the union of those arrays, so asserting it equals that union
     // is a tautology — it passes no matter which keys are in the arrays. The
@@ -328,6 +329,7 @@ describe("operator override wins", () => {
       "HINDSIGHT_API_LLM_MAX_RETRIES",
       "HINDSIGHT_API_LLM_REASONING_EFFORT",
       "HINDSIGHT_API_LLM_STRICT_SCHEMA",
+      "HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE",
       "HINDSIGHT_API_RECALL_MAX_CANDIDATES_PER_SOURCE",
       "HINDSIGHT_API_RERANKER_LOCAL_BATCH_SIZE",
       "HINDSIGHT_API_RERANKER_LOCAL_FP16",
@@ -489,6 +491,76 @@ describe("HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM (managed, was hard-coded)"
     const perf = { env: { [KEY]: "6" }, processEnv: {} };
     startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, false, perf);
     expect(runEnv(runArgs()).get(KEY)).toEqual(["6"]);
+  });
+});
+
+// ── per-scope observation cap, moved into the managed set ─────────────────
+describe("HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE (managed, was hard-coded)", () => {
+  const KEY = "HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE";
+  const CAPS = [
+    { gpu: false, localLlm: false },
+    { gpu: true, localLlm: false },
+    { gpu: false, localLlm: true },
+    { gpu: true, localLlm: true },
+  ];
+
+  it("is in the managed set, so a hindsight.env line is not silently dropped", () => {
+    // The bug this fixes: the key was emitted unconditionally from a bare
+    // constant in hindsight.ts and was NOT in HINDSIGHT_PERF_ENV_KEYS, so an
+    // operator's yaml line was discarded without a word — it read as durable
+    // config while doing nothing, and its own doc comment sent operators to
+    // `docker run -e …` instead, which the next `switchroom apply` discards.
+    expect(HINDSIGHT_PERF_ENV_KEYS.has(KEY)).toBe(true);
+    // Defaulted, not override-only: the previous emission was unconditional,
+    // so dropping the default would be a silent behaviour change.
+    expect(HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS.has(KEY)).toBe(false);
+  });
+
+  it.each(CAPS)(
+    "keeps the shipped default of 1000 on every host (gpu=$gpu localLlm=$localLlm)",
+    (caps) => {
+      // Ungated on purpose. Behind a capability gate this would silently revert
+      // to upstream's -1 (unlimited) on any host lacking the gate — a behaviour
+      // change smuggled in by a refactor, and the removal of the rail itself.
+      expect(hindsightPerfEnv(caps)).toContainEqual([KEY, "1000"]);
+    },
+  );
+
+  it("the operator's value REPLACES the default on BOTH launch paths", () => {
+    const perf = { env: { [KEY]: "5000" }, processEnv: {} };
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false, perf);
+    const fromRun = runEnv(runArgs());
+    const fromCompose = composeEnv(
+      generateHindsightComposeSnippet(undefined, undefined, LOOPBACK_LITELLM, false, perf),
+    );
+    // Exactly one value, not the default AND the override: a duplicate emission
+    // would be last-wins by luck on docker-run and ambiguous in compose.
+    expect(fromRun.get(KEY)).toEqual(["5000"]);
+    expect(fromCompose.get(KEY)).toEqual(["5000"]);
+  });
+
+  it("is emitted exactly once per path when NOT overridden", () => {
+    // Guards the specific regression of moving the key without deleting the
+    // old hard-coded emission: two `-e` flags for one var.
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false, {
+      env: {},
+      processEnv: {},
+    });
+    expect(runEnv(runArgs()).get(KEY)).toEqual(["1000"]);
+    expect(
+      composeEnv(
+        generateHindsightComposeSnippet(undefined, undefined, LOOPBACK_LITELLM, false, {
+          env: {},
+          processEnv: {},
+        }),
+      ).get(KEY),
+    ).toEqual(["1000"]);
+  });
+
+  it("still reaches the container on a host with NO gated capability", () => {
+    const perf = { env: { [KEY]: "250" }, processEnv: {} };
+    startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, false, perf);
+    expect(runEnv(runArgs()).get(KEY)).toEqual(["250"]);
   });
 });
 

--- a/src/setup/hindsight-perf-defaults.ts
+++ b/src/setup/hindsight-perf-defaults.ts
@@ -357,6 +357,47 @@ export const HINDSIGHT_DEFAULT_LLM_MAX_RETRIES = 2;
  */
 export const HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM = 2;
 
+/**
+ * Cap on observations per *tag scope* (upstream default `-1`, unlimited).
+ *
+ * Once a tag scope hits the cap, consolidation stops creating new observations
+ * and only updates/deletes existing ones — bounding the cost of consolidating
+ * a single long-running scope. Tagless observations are unaffected.
+ *
+ * Switchroom retains with `retainTags: ["{session_id}"]` (vendored plugin
+ * default), so a "tag scope" maps roughly to "one session". A very long
+ * Telegram session that runs for weeks can accumulate thousands of
+ * observations under one scope — that is the case 1000 targets. Most sessions
+ * are far below the cap, so for typical agents this is defence-in-depth rather
+ * than an active limit.
+ *
+ * This is NOT a fix for vectorize-io/hindsight#1284 (the upstream
+ * unbounded-growth bug for consolidation across a whole bank); it is a
+ * companion safety rail until that lands.
+ *
+ * Moved here from a bare constant in `hindsight.ts` (2026-07-27). The value is
+ * unchanged; what changes is that it is now a MANAGED key, so an operator can
+ * override it declaratively through `hindsight.env`. Before this it was
+ * emitted unconditionally on both launch paths with no declarative channel, so
+ * a `hindsight.env` line for it was silently dropped and the documented
+ * recourse was to stop the container and re-run `docker run -e …` by hand —
+ * which the next `switchroom apply` throws away. How long a session runs, and
+ * how many observations that is worth keeping, are properties of one
+ * deployment, so the value must be overridable:
+ *
+ * ```yaml
+ * hindsight:
+ *   env:
+ *     # long-lived sessions on a host with room to consolidate them
+ *     HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE: 5000
+ * ```
+ *
+ * Ungated: it assumes no hardware, and the previous emission was
+ * unconditional — putting it behind a capability gate would silently revert
+ * hosts lacking that gate to upstream's unlimited default.
+ */
+export const HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE = 1000;
+
 /** Emitted on every host — bounded work, no hardware assumption. */
 export const HINDSIGHT_PERF_DEFAULTS_UNGATED: ReadonlyArray<readonly [string, string]> = [
   [
@@ -375,6 +416,10 @@ export const HINDSIGHT_PERF_DEFAULTS_UNGATED: ReadonlyArray<readonly [string, st
   [
     "HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM",
     String(HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM),
+  ],
+  [
+    "HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE",
+    String(HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE),
   ],
 ];
 

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -61,29 +61,12 @@ export const HINDSIGHT_DEFAULT_MCP_URL = `http://127.0.0.1:${HINDSIGHT_DEFAULT_A
  */
 export const HINDSIGHT_DEFAULT_API_BASE_URL = HINDSIGHT_DEFAULT_MCP_URL.replace(/\/mcp\/?$/, "");
 
-/**
- * Default cap on observations per *tag scope*.
- *
- * Upstream Hindsight defaults `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE`
- * to `-1` (unlimited). Once a tag scope hits the cap, consolidation
- * stops creating new observations and only updates/deletes existing
- * ones — bounding the cost of consolidating a single long-running
- * scope. Tagless observations are unaffected.
- *
- * Switchroom retains with `retainTags: ["{session_id}"]` (vendored
- * plugin default), so a "tag scope" maps roughly to "one session." A
- * very long Telegram session that runs for weeks can accumulate
- * thousands of observations under one scope — that's the case 1000
- * targets. Most sessions are far below the cap, so for typical
- * agents this is defense-in-depth rather than an active limit.
- *
- * This is NOT a fix for vectorize-io/hindsight#1284 (the upstream
- * unbounded-growth bug for consolidation across a whole bank); it's a
- * companion safety rail until that lands. Operators who want a
- * different value can stop the container and re-run `docker run`
- * with `-e HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=N`.
- */
-export const HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE = 1000;
+// Re-exported, not defined here: the value now lives in hindsight-perf-defaults
+// so it is a MANAGED key an operator can override via `hindsight.env` (rather
+// than by re-running `docker run -e …`, which the next `switchroom apply`
+// discards). The re-export keeps the existing import sites (and their tests)
+// working. See that module for the rationale and the shipped default of 1000.
+export { HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE } from "./hindsight-perf-defaults.js";
 
 /**
  * Default consumer slug for the hindsight broker socket. Path-as-identity
@@ -1619,13 +1602,14 @@ export function startHindsight(
   // HINDSIGHT_API_LLM_* in the engine, so we emit nothing for it.
   const perOpLlm = resolveHindsightPerOpLlm(llm);
 
-  // Non-secret env stays on `-e` — provider name + observation cap are
-  // configuration, not secrets. `HINDSIGHT_API_LLM_PROVIDER=claude-code`
-  // selects the subscription-honest path; `HINDSIGHT_API_LLM_MODEL` pins the
-  // memory-ops model (default HINDSIGHT_DEFAULT_MODEL, or the cheap LiteLLM
-  // default, operator-overridable via `hindsight.llm`).
+  // Non-secret env stays on `-e` — provider name is configuration, not a
+  // secret. `HINDSIGHT_API_LLM_PROVIDER=claude-code` selects the
+  // subscription-honest path; `HINDSIGHT_API_LLM_MODEL` pins the memory-ops
+  // model (default HINDSIGHT_DEFAULT_MODEL, or the cheap LiteLLM default,
+  // operator-overridable via `hindsight.llm`). The per-scope observation cap
+  // is emitted by the managed perf-defaults block below, not pinned here, so
+  // an operator can raise it through `hindsight.env`.
   const envArgs: string[] = [
-    "-e", `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=${HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE}`,
     "-e", `HINDSIGHT_API_LLM_PROVIDER=${llmProvider}`,
     "-e", `HINDSIGHT_API_LLM_MODEL=${llmModel}`,
     // Per-op LLM overrides (only the configured vars — see resolveHindsightPerOpLlm).
@@ -2124,7 +2108,9 @@ export function generateHindsightComposeSnippet(
     ? buildLiteLlmAwareHealthPy(internalApiPort, probeUrl)
     : HINDSIGHT_HEALTHCHECK_PY;
   const environment = [
-    `      - HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=${HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE}`,
+    // The per-scope observation cap moved to the managed perf-defaults block
+    // below, which is emitted on BOTH launch paths from the same resolver, so
+    // the docker-run/compose twin property still holds for it.
     `      - HINDSIGHT_API_LLM_PROVIDER=${llmProvider}`,
     `      - HINDSIGHT_API_LLM_MODEL=${llmModel}`,
     // Per-op LLM overrides (only the configured vars — see resolveHindsightPerOpLlm).


### PR DESCRIPTION
`HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE` was emitted unconditionally on both launch paths — `src/setup/hindsight.ts:1628` (docker-run argv) and `:2127` (compose) — from a bare constant at `:86`, and was **not** a member of `HINDSIGHT_PERF_ENV_KEYS`. So it shipped a default with no declarative channel: an operator's `hindsight.env` line for it was silently dropped by `resolveHindsightPerfOverrides` while reading, in yaml, as durable config.

Same defect class as #3732, and worse in one respect: its own doc comment (`:82-84`) told operators to *"stop the container and re-run `docker run` with `-e …`"* — it documented the imperative workaround, which the next `switchroom apply` throws away, instead of offering a declarative channel. `docs/configuration.md:393` said the same.

It matters because the right value is a property of a deployment, not of switchroom. The cap bounds observations per **tag scope**, and switchroom retains with `retainTags: ["{session_id}"]`, so a scope is roughly one session. How long sessions run, and how much consolidation a host can afford for one, is something only the operator knows.

## What changed

- Constant moved into `src/setup/hindsight-perf-defaults.ts` and added to `HINDSIGHT_PERF_DEFAULTS_UNGATED`.
- Both hard-coded emissions deleted; `hindsight.ts` re-exports the name so existing import sites (and `tests/memory.test.ts:309`) are untouched.
- The perf-defaults resolver emits on both paths from one source, so the docker-run/compose twin property still holds.
- `hindsight.env` schema description and `docs/configuration.md` updated — the latter now shows the yaml override instead of the `docker run -e` workaround.

**The shipped default is unchanged at 1000 on every host.** This PR makes the key overridable; it does not change what switchroom ships. Ungated, and defaulted rather than override-only, for the same reason: the previous emission was unconditional, so a capability gate — or dropping the default — would silently revert hosts to upstream's `-1` (unlimited) and remove the rail itself.

**Deliberately not done:** nothing about vectorize-io/hindsight#1284, the upstream whole-bank unbounded-growth bug. This cap stays a companion rail, not a fix for that.

## Tests

Mirrors #3732's block in `src/setup/hindsight-perf-defaults.test.ts`:

- in `HINDSIGHT_PERF_ENV_KEYS`, not in `HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS`
- default `1000` on all four `{gpu, localLlm}` combinations
- an operator value **replaces** the default on **both** launch paths
- emitted **exactly once per path** when not overridden

Mutation-verified: restoring the old docker-run emission alongside the managed one reddens nine assertions, including the pre-existing `never emits a managed key twice` and run⇄compose parity guards. The two pinned key-list literals were deliberate tripwires; both fired and were updated.

Local: `npx vitest run src/setup/ tests/memory.test.ts` → 250 passed; `npx tsc --noEmit` clean. `npm run lint` fails on the pre-existing `telegram-plugin/` `TS2307` set from the symlinked `node_modules` — byte-identical error list on a stashed tree (same md5), so not from this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)