### PR TITLE
docs(claude-md): fix verified CI/lint/release drift, add a Models section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,9 +42,15 @@ Non-negotiable; `reference/vision.md` pillar 3 as an engineering gate.
 - **Prefer the family aliases** `opus` / `sonnet` / `haiku` / `fable` over pinned
   ids: an alias tracks the current flagship, a pinned id goes stale. `fable`
   resolves ONLY through the LiteLLM proxy — `normalizeModelAlias()` folds
-  `claude-fable-5` → `fable`, and `declaredRoutingMode()` (scaffold.ts:1546)
-  routes `fable` / `sr-*` at the router root while other Claude models keep the
-  `/anthropic` passthrough (`src/agents/compose.ts` `ANTHROPIC_BASE_URL` split).
+  `claude-fable-5` → `fable`. **Adding a proxy-only model means editing the
+  repoint `case` in `profiles/_base/start.sh.hbs` (~:1772)** — that is where
+  routing actually moves. `src/agents/compose.ts` bakes `ANTHROPIC_BASE_URL` on
+  model CLASS, so `fable` (a Claude model) starts on the `/anthropic`
+  passthrough and start.sh repoints it to the router root at boot.
+  `declaredRoutingMode()` (`scaffold.ts:1546`) routes nothing: it only encodes
+  the POST-repoint intent so `.routing-mode` can compare landed vs declared.
+  Change the repoint case and that function together or a healthy boot fires a
+  spurious "Routing divergence" alert.
 - **Opus is covered by the adaptive-thinking risk check.**
   `isAdaptiveThinkingOpus()` (`src/config/thinking-effort-risk.ts`) matches
   `opus`, `claude-opus-4*`, `claude-opus-5`, `claude-opus-5-*`; `switchroom

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,13 +31,49 @@ Non-negotiable; `reference/vision.md` pillar 3 as an engineering gate.
 - Opt-in LiteLLM proxy carve-out exists (forwards the OAuth unchanged, fails
   open): `reference/invariants.md` § "Operator-controlled gateway carve-out".
 
+## Models
+
+- **Code default** when `model:` is absent or the literal `"default"` is
+  `claude-sonnet-5` (`SWITCHROOM_DEFAULT_MAIN_MODEL`, `src/agents/scaffold.ts:1509`;
+  `resolveMainModel()` at :1525). `"default"` deliberately does NOT mean the
+  *account* default — claude would pass it through and resolve it to a model
+  the account may not have, 4xx'ing every turn. The live fleet's
+  `defaults.model` lives in the operator's `switchroom.yaml`, not in this repo.
+- **Prefer the family aliases** `opus` / `sonnet` / `haiku` / `fable` over pinned
+  ids: an alias tracks the current flagship, a pinned id goes stale. `fable`
+  resolves ONLY through the LiteLLM proxy — `normalizeModelAlias()` folds
+  `claude-fable-5` → `fable`, and `declaredRoutingMode()` (scaffold.ts:1546)
+  routes `fable` / `sr-*` at the router root while other Claude models keep the
+  `/anthropic` passthrough (`src/agents/compose.ts` `ANTHROPIC_BASE_URL` split).
+- **Opus is covered by the adaptive-thinking risk check.**
+  `isAdaptiveThinkingOpus()` (`src/config/thinking-effort-risk.ts`) matches
+  `opus`, `claude-opus-4*`, `claude-opus-5`, `claude-opus-5-*`; `switchroom
+  doctor` WARNs on those with `thinking_effort` above the `low` floor
+  (`src/cli/doctor.ts:512`). The documented failure is the upstream claude-CLI
+  interleaved-streaming merge bug (#1978): `400 messages.N.content.M: 'thinking'
+  or 'redacted_thinking' blocks in the latest assistant message cannot be
+  modified`. Pin `thinking_effort: low`.
+- **Cron tiering keys off the model STRING** (`src/scheduler/cron-routing.ts`):
+  `sonnet|haiku` ⇒ cheap Tier-1 fresh session; `opus` ⇒ Tier-2 live session; an
+  **unrecognised id also falls to Tier-2** with a `customModelDowngrade` warning
+  — a typo'd or newly-renamed cheap model silently costs full-session tokens.
+- **The `/model` override rides a consume-once carrier** whose shape gate is
+  byte-parity between `profiles/_base/start.sh.hbs` (~:1621) and `MODEL_ARG_RE`
+  in `telegram-plugin/gateway/model-command.ts:64`, pinned by
+  `tests/scaffold.session-model.test.ts`. A string failing the gate is dropped
+  to the configured default with a one-shot operator alert and is never retried.
+  Change one regex, change the other in the same PR.
+- **Never hard-code a token budget against an assumed context window** — derive
+  it from a declared one (`src/setup/hindsight-context-budget.ts`, #3717). The
+  `claude-code` / `anthropic` provider default is `200_000`.
+
 ## Commands
 
 ```bash
 bun install                  # deps (bun.lock)
 bun run dev -- <args>        # run CLI from src/ via bin/switchroom.ts
 npm run build                # node scripts/build.mjs → dist/
-npm run lint                 # tsc --noEmit + 8 guard scripts (see Lint gates)
+npm run lint                 # tsc --noEmit + 16 guard scripts (see Lint gates)
 npm test                     # vitest run + bun test <explicit file list>
                              #   NOTE: pretest runs a full build first
 npm run test:vitest          # vitest only (src/ + tests/ + telegram-plugin non-bun)
@@ -67,7 +103,13 @@ src/                    switchroom CLI (TypeScript, ES modules, Node ≥20)
                         tabs; ui/ for frontend); separate compose project
   host-control/         hostd dispatch (self-restart verbs)
   worktree/             `switchroom worktree` claim/gc/reaper
+  setup/                first-run setup + hindsight provisioning/budgets
+  self-improve/         self-improvement proposal gating + tier routing
+  hindsight-watch/      memory-quality probe → metrics → thresholds
+  telegram/             CLI-side Telegram helpers (bot setup, access)
+  secret-detect/        secret detection + redaction shared by gateway/issues
   drive|microsoft|notion|linear|litellm|memory|...   integrations
+bin/                    switchroom.ts entry + the hook/boot shell scripts
 telegram-plugin/        the MCP Telegram plugin + gateway (own test suite)
   server.ts             MCP stdio entry;  gateway/ is the long-lived gateway
   tests/                mostly bun test; uat/ is the live mtcute harness
@@ -77,6 +119,9 @@ profiles/               agent profiles; _base/start.sh.hbs = container entry
 skills/                 bundled Claude Code skills
 scripts/                build.mjs + the lint guard scripts
 tests/                  vitest suite for src/;  tests/docker/ = docker e2e
+evals/                  Python eval harness (dataset.yaml + run_*.py)
+commands/               bundled slash commands (setup/start/status/stop)
+vendor/                 vendored upstream (hindsight-memory) — don't edit
 reference/              THE DESIGN CONTRACT (see below)
 docs/                   user/operator docs only — design lives in reference/
 ```
@@ -93,6 +138,14 @@ Bun natives — chiefly `bun:sqlite` (history, grants, approval-kernel,
 registry). `npm test` runs both; `npm run test:bun` is the explicit file
 list in `package.json`.
 
+**A third suite gates merges, outside `npm test`.** `ci-tests-python.yml` runs
+`python3 -m unittest discover` in `vendor/hindsight-memory/scripts` (`tests/`),
+`docker/voice-sidecar` and `docker/litellm-pacer`, reporting as the required
+`python-ok` sentinel — touching Python under those paths needs a local
+`unittest` run, not a vitest one. `tests/docker/` (the docker e2e suite) is
+likewise gated in CI by `docker-e2e.yml` → the required `e2e-ok` sentinel, and
+does not run under plain `npm test`.
+
 - **Never import `bun:test` or `bun:sqlite` in a vitest-run file** — vitest
   can't resolve them and the whole suite fails to load. This broke CI
   repeatedly before the `check-bun-test-imports` lint guard landed. If a file
@@ -105,7 +158,7 @@ list in `package.json`.
 **Local env noise vs real failures.** The full local suite has known
 environment-dependent failures: vault SQLite in sandboxes, the fake-binary
 harness, `/tmp` mounted noexec (set an exec-capable `TMPDIR`), socket/root
-container constraints, parallel port contention. The ~73 scenarios under
+container constraints, parallel port contention. The 89 scenarios under
 `telegram-plugin/uat/scenarios/` need live Telegram/mtcute creds and
 fail/skip locally by design.
 
@@ -128,10 +181,13 @@ obligation:
 `npm run lint` = `tsc --noEmit` plus these guard scripts (most have an
 `npm run lint:<name>` alias; see `package.json`):
 `check-plugin-references`, `check-bot-api-wrapping`,
-`check-bun-test-imports`, `check-no-pii-secrets`,
-`check-vault-test-hermeticity`, `check-auth-test-hermeticity`,
+`check-bun-test-imports`, `check-bun-module-mock-scope`,
+`check-no-pii-secrets`, `check-vault-test-hermeticity`,
+`check-auth-test-hermeticity`, `check-agent-state-dir-hermeticity`,
 `check-no-broadcast-delivery`, `check-stale-tool-descriptions`,
-`check-web-subscription-honest`, `check-litellm-config-guard`.
+`check-mcp-instructions-budget`, `check-web-subscription-honest`,
+`check-no-unpinned-npx-playwright`, `check-gateway-line-ratchet`,
+`check-litellm-config-guard`, `check-release-asset-names`.
 
 Traps that bite repeatedly:
 
@@ -172,27 +228,39 @@ Traps that bite repeatedly:
 
 GitHub Push Protection blocks token-shaped literals even in fixtures. Build
 fake tokens by runtime concatenation (`"sk-ant-" + "fake"`); pattern:
-`telegram-plugin/tests/secret-detect-secretlint.test.ts`.
+`telegram-plugin/tests/secret-detect-false-positives.test.ts` (~:86) and
+`telegram-plugin/tests/secret-detect-sanctum.test.ts` (~:18).
 
 ## CI
 
 GitHub Actions is primary and gating. `main` is protected by repository
-Ruleset `16470166` with **4 required checks**: `lint`, `bun-test`, `vitest`,
-`images-ok` (the docker-images sentinel — the individual build jobs are NOT
-required, so matrix/job renames there don't touch branch protection; keep
-`images-ok`'s `needs` list complete instead). Edits to the required list are
-Ruleset edits (`gh api repos/switchroom/switchroom/rulesets/16470166`), not
-classic branch protection.
+Ruleset `16470166` with **7 required checks**: `lint`, `bun-test`, `vitest`,
+`images-ok`, `uat-gate`, `e2e-ok`, `python-ok`. Every one is a *sentinel* —
+the individual heavy/build jobs are NOT required, so matrix/job renames there
+don't touch branch protection; keep each sentinel's `needs` list complete
+instead. Edits to the required list are Ruleset edits (`gh api
+repos/switchroom/switchroom/rulesets/16470166`), not classic branch
+protection.
 
-- **Sentinel pattern:** `lint` / `bun-test` / `vitest` / `uat-gate` are
-  always-running sentinel jobs that aggregate path-gated heavy runs
-  (`lint-run`, `bun-test-run`, `vitest-shard` ×4, `uat-gate-run`). A
-  path-filtered job reporting "skipping" is a PASS for that PR — **skipping
-  ≠ failing**. Don't chase skipped shards.
+- **Sentinel pattern:** all seven are always-running jobs that aggregate
+  path-gated heavy runs — `lint` (`ci-lint.yml` → `lint-run`), `vitest`
+  (`ci-tests-core.yml` → `vitest-shard` ×4), `bun-test`
+  (`ci-tests-plugin.yml` → `bun-test-run`), `python-ok`
+  (`ci-tests-python.yml` → `unittest`), `uat-gate` (`ci-uat.yml` →
+  `uat-gate-run`), `e2e-ok` (`docker-e2e.yml` → `e2e` + `hindsight-probe`),
+  `images-ok` (`docker-images.yml`). A path-filtered job reporting "skipping"
+  is a PASS for that PR — **skipping ≠ failing**. Don't chase skipped shards.
+- **The merge queue is ON** (a `merge_queue` rule on the same ruleset: SQUASH,
+  `ALLGREEN` grouping, 60-min `check_response_timeout`). GitHub pushes a
+  `gh-readonly-queue/...` ref and waits for all seven contexts to report **on
+  that ref**, so every one of those workflows carries a `merge_group:` trigger
+  — dropping one wedges `main`. Rules and invariants: `.github/MERGE-QUEUE.md`,
+  pinned by `tests/ci-merge-queue-triggers.test.ts`.
 - Governance (set 2026-05-17, deliberate): admin-bypass locked
   (`bypass_actors: []` — `gh pr merge --admin` cannot work), no required
-  human review, `strict` up-to-date OFF. Auto-merge repo-wide: `--auto
-  --squash` merges the moment required checks go green. CI recovery lever is
+  human review, `strict` up-to-date **ON** — a branch must be up to date with
+  `origin/main` before it can merge. Auto-merge repo-wide: `--auto --squash`
+  merges the moment required checks go green. CI recovery lever is
   `workflow_dispatch` re-trigger.
 - `gh pr checks <n>` is the source of truth. `mergeStateStatus`: `CLEAN`
   ready, `BLOCKED` pending/failed required check, `DIRTY` merge conflict,
@@ -210,12 +278,17 @@ vitest via `bun run --cwd telegram-plugin test:uat <name>`
 (`vitest.uat.config.ts`). Scenarios: `telegram-plugin/uat/scenarios/`,
 named `jtbd-<job>-{dm,channel}` / `fuzz-*`.
 
-- **`uat-gate` is a sentinel job, NOT ruleset-required** (`ci-uat.yml`; as
-  of 2026-07 it is absent from Ruleset 16470166's 11 required checks, so
-  `--auto --squash` WILL merge past a red `uat-gate` — check it yourself
-  before enabling auto-merge on plugin/agent-path PRs). The heavy `uat-gate-run`
-  fires on the self-hosted `uat-host` runner when plugin/agent paths change
-  and `UAT_GATE_ENABLED` is set; it runs three live scenarios:
+- **`uat-gate` IS a required check** (`ci-uat.yml:230`) — an always-on sentinel
+  in Ruleset 16470166's seven, so `--auto --squash` cannot merge past a red
+  one. It passes when `uat-gate-run` succeeded OR was legitimately skipped
+  (non-UAT PR / gate off), and fails on a real failure or a broken `changes`
+  filter. The heavy `uat-gate-run` fires on the self-hosted `uat-host` runner
+  only when plugin/agent paths change AND the repo var `UAT_GATE_ENABLED` is
+  `true` — **it has been `false` since 2026-07-04** (per-commit live UAT burns
+  subscription quota), so in practice the heavy run is `workflow_dispatch`
+  on-demand only and the sentinel passes on the skip path. It is also
+  deliberately never run on `merge_group` (single self-hosted runner would
+  stall the queue). When it does run, three live scenarios:
   `jtbd-fast-trivial-dm` (real DM round-trip, **hard reply-latency SLA of
   12s** — `HARD_TTFO_MS`), `inbound-no-drop` (rapid-fire no-drop, #2089),
   and `jtbd-rich-formatting-render-dm` (Bot API rich-entity render
@@ -384,12 +457,27 @@ published to npm because publish wasn't gated. Don't let that recur.
   A tag push starts exactly two workflows — `docker-images` and `release` —
   and `release` sequences everything else: attach the four static binaries →
   wait for `docker-images` to conclude `success` for that exact tag+commit →
-  `workflow_call` into `npm-publish.yml` → un-draft the GitHub Release.
-  **`npm-publish.yml` has NO tag trigger.** npm is the only irreversible leg,
-  so it runs last, and it re-proves both preconditions from inside its own
-  run — a hand `workflow_dispatch` cannot half-ship either. Any red leg
-  leaves the release a draft with npm unpublished, which is recoverable;
-  re-dispatch `release.yml --ref vX.Y.Z -f dry_run=false` to resume.
+  `workflow_call` into `npm-publish.yml` → un-draft the GitHub Release →
+  promote `:latest`. **`npm-publish.yml` has NO tag trigger.** npm is the only
+  irreversible leg, so it runs late, and it re-proves both preconditions from
+  inside its own run — a hand `workflow_dispatch` cannot half-ship either. Any
+  red leg leaves the release a draft with npm unpublished, which is
+  recoverable; re-dispatch `release.yml --ref vX.Y.Z -f dry_run=false` to
+  resume.
+- **`:latest` follows the RELEASE, not the tag push (#3735, issue #3685).** A
+  `v*` tag push makes `docker-images.yml` publish `:vX.Y.Z` **only** — it no
+  longer moves `:latest` (only a main push still tags `:latest` + `:sha-<7>`).
+  `release.yml`'s terminal `images-latest` job runs `needs: finalize` (so after
+  binaries, `images-gate`, npm and the un-draft are all green) and
+  `workflow_call`s `promote.yml` with `from: vX.Y.Z, to: latest`, which retags
+  by manifest copy across all 9 images and verifies digest equality. Failure
+  mode is therefore `:latest` **lagging** the release — the previous good image
+  keeps serving installs and `switchroom update` — never `:latest` leading a
+  half-shipped one. Manual recovery: `gh workflow run promote.yml -f
+  from=vX.Y.Z -f to=latest`. `promote.yml`'s matrix must cover every image
+  `docker-images.yml` publishes on a tag or that image's `:latest` silently
+  stops advancing; R14 in `tests/release-pipeline-gating.test.ts` derives the
+  expected set and fails on drift.
 - **The GitHub Release is created as a DRAFT and only `finalize` publishes
   it.** `install.sh` resolves the version from `/releases/latest`, which
   excludes drafts — so an in-flight or failed release leaves the previous

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -509,7 +509,7 @@ export function checkConfig(config: SwitchroomConfig, configPath: string): Check
         : "Add defaults.subagents to switchroom.yaml to enable Sonnet/Haiku delegation. See docs/sub-agents.md for the worker/researcher/reviewer pattern.",
   });
 
-  // Adaptive-thinking effort guard (#1978). Opus 4.x + thinking_effort
+  // Adaptive-thinking effort guard (#1978). Opus 4.x / Opus 5 + thinking_effort
   // above the `low` floor can 400 on thinking blocks when work runs
   // through concurrent sub-agents (an upstream claude CLI merge bug).
   // Resolve each agent's effective model + effort and flag the combo so
@@ -530,11 +530,11 @@ export function checkConfig(config: SwitchroomConfig, configPath: string): Check
     status: effortRisks.length > 0 ? "warn" : "ok",
     detail:
       effortRisks.length > 0
-        ? `${effortRisks.length} agent(s) on Opus 4.x with thinking_effort > low: ${effortRisks.join(", ")}`
+        ? `${effortRisks.length} agent(s) on Opus (4.x/5) with thinking_effort > low: ${effortRisks.join(", ")}`
         : "no risky model/effort combos",
     fix:
       effortRisks.length > 0
-        ? "Pin `thinking_effort: low` for Opus 4.x agents — medium+ can 400 on 'thinking blocks cannot be modified' with concurrent sub-agents (issue #1978). Removing the field is NOT a fix (Opus 4.8 defaults effort=high when unset)."
+        ? "Pin `thinking_effort: low` for Opus 4.x / Opus 5 agents — medium+ can 400 on 'thinking blocks cannot be modified' with concurrent sub-agents (issue #1978). Removing the field is NOT a fix (Opus defaults effort=high when unset)."
         : undefined,
   });
 

--- a/src/config/thinking-effort-risk.ts
+++ b/src/config/thinking-effort-risk.ts
@@ -1,7 +1,7 @@
 /**
  * Model-aware thinking-effort risk guard (#1978).
  *
- * Opus 4.x models use *adaptive thinking* — they emit
+ * Opus 4.x and Opus 5 models use *adaptive thinking* — they emit
  * `thinking`/`redacted_thinking` blocks. switchroom dispatches work to
  * concurrent sub-agents (worker/researcher/reviewer via the Task tool,
  * often `background: true`), and the bundled `claude` CLI can mis-merge
@@ -21,10 +21,11 @@
  * blocks to mis-merge) and is the safe floor; `medium`+ reliably
  * reproduces the 400. The scaffold defaults unset `thinking_effort` to
  * `low` (see SWITCHROOM_DEFAULT_THINKING_EFFORT), so an UNSET value is
- * safe — only an explicit `medium`/`high`/`xhigh`/`max` on an Opus 4.x
- * model is flagged.
+ * safe — only an explicit `medium`/`high`/`xhigh`/`max` on an Opus 4.x /
+ * Opus 5 model is flagged.
  *
- * Scope note: this guard intentionally only flags the Opus 4.x family.
+ * Scope note: this guard intentionally only flags the Opus family — 4.x and
+ * 5, plus the bare `opus` alias (see `isAdaptiveThinkingOpus` below).
  * Sonnet 5 also has adaptive thinking, but the fleet runs Sonnet
  * sub-agents at higher effort without hitting this, so flagging it would
  * be a false alarm. Revisit if the failure is observed on Sonnet.
@@ -64,9 +65,9 @@ export interface ThinkingEffortRisk {
  * Assess whether a (model, thinking_effort) combo risks the adaptive-
  * thinking merge 400. Safe (`risky: false`) when effort is unset (→
  * scaffold floor `low`), when effort is `low`, or when the model isn't an
- * Opus 4.x adaptive-thinking model.
+ * Opus 4.x / Opus 5 adaptive-thinking model.
  *
- * @param model   Resolved model — alias (`opus`) or full id (`claude-opus-4-8`).
+ * @param model   Resolved model — alias (`opus`) or full id (`claude-opus-5`).
  * @param effort  Resolved `thinking_effort` (may be undefined).
  */
 export function assessThinkingEffortRisk(

--- a/telegram-plugin/tests/secret-detect-false-positives.test.ts
+++ b/telegram-plugin/tests/secret-detect-false-positives.test.ts
@@ -82,7 +82,7 @@ describe("secret-detect — DOES still fire on actually-shaped secrets (regressi
   // Locking in so a future regex-tightening doesn't over-shoot.
   // Values constructed at runtime so the source file doesn't trip
   // GitHub Push Protection — same pattern as
-  // secret-detect-secretlint.test.ts:1.
+  // secret-detect-sanctum.test.ts:18 (CLAUDE.md § Secrets in tests).
   const fakeApiKey = `sk-ant-${"a1b2c3d4".repeat(4)}XYZ987`; // sk-ant- + 32 chars
   const fakeBearer = `${"abc123".repeat(8)}.${"def456".repeat(4)}`;
   const fakeRandom = `${"x9zM4kP3qR7sT2vW".repeat(2)}`; // 32 chars, high entropy


### PR DESCRIPTION
## Summary

`CLAUDE.md` had drifted from `origin/main` on several load-bearing facts, and
contradicted itself on the required-check list (CI section said `uat-gate` was
not required; the UAT section built advice on top of that). Every claim below
was re-verified live against the ruleset, the workflow files, or source at
HEAD before writing.

- **CI** — `4 required checks` → the real **7** (`lint`, `bun-test`, `vitest`,
  `images-ok`, `uat-gate`, `e2e-ok`, `python-ok`, per
  `gh api repos/switchroom/switchroom/rulesets/16470166`). `strict` up-to-date
  is **ON** (`strict_required_status_checks_policy: true`), not OFF as
  documented. Added the active `merge_queue` rule + `.github/MERGE-QUEUE.md`
  and the `merge_group:` trigger requirement. All seven sentinels now named
  with their workflow and heavy job.
- **UAT** — the file claimed `uat-gate` is "a sentinel job, NOT ruleset-required
  … `--auto --squash` WILL merge past a red `uat-gate`". That is false and was
  actively dangerous advice. Rewritten: it IS required (`ci-uat.yml:230`),
  passes on success-or-legitimate-skip, and the heavy `uat-gate-run` is
  effectively dispatch-only because the repo var `UAT_GATE_ENABLED` has been
  `false` since 2026-07-04 (verified via `gh api .../actions/variables`).
  Scenario count `~73` → the actual **89** (`ls telegram-plugin/uat/scenarios/*.ts`).
- **Lint** — Commands block said 8 guards, the Lint gates list had 10; the
  `lint` script in `package.json` runs **16**. Number fixed, list completed.
- **Release** — added the #3735 change (issue #3685): a `v*` tag push publishes
  `:vX.Y.Z` only, and `release.yml`'s terminal `images-latest` job
  (`needs: finalize`) `workflow_call`s `promote.yml` with `from: vX.Y.Z,
  to: latest`. Documents the lag failure mode (previous good image keeps
  serving installs) and the recovery dispatch
  `gh workflow run promote.yml -f from=vX.Y.Z -f to=latest`.
- **Repo layout** — added `src/{setup,self-improve,hindsight-watch,telegram,secret-detect}`
  and top-level `bin/`, `evals/`, `commands/`, `vendor/`.
- **Tests** — "two runners, hard boundary" omitted the python suite
  (`ci-tests-python.yml` → required `python-ok`) and the docker e2e suite
  (`docker-e2e.yml` → required `e2e-ok`). Both noted.
- **Broken reference** — `telegram-plugin/tests/secret-detect-secretlint.test.ts`
  does not exist. Repointed to two files that actually demonstrate the
  runtime-concatenation pattern; also fixed the same dead reference inside
  `secret-detect-false-positives.test.ts:84`.
- **New `## Models` section** — the operator's main ask. Code default
  (`claude-sonnet-5`, `scaffold.ts:1509/1525`, and why `"default"` is not the
  account default), alias-over-pinned-id guidance and `fable`'s proxy-only
  routing, the Opus adaptive-thinking risk check with the failure quoted in
  the source's own terms, cron tiering's unrecognised-id → Tier-2 trap, the
  `/model` consume-once carrier shape-gate parity rule, and deriving token
  budgets from a declared context window (#3717).
- **Source prose only** — `src/config/thinking-effort-risk.ts` and
  `src/cli/doctor.ts` still said "Opus 4.x" although `isAdaptiveThinkingOpus()`
  has matched `claude-opus-5*` since it was written. Comments and the operator
  warning now name 4.x **and** 5. **No logic, matcher, or threshold changed.**

## Why

`CLAUDE.md` is the orientation file every agent working this repo reads first,
and agents are the only developers here. A wrong required-check list plus an
inverted `uat-gate` claim is not a cosmetic doc bug: it tells a future agent it
is safe to auto-merge past a red required gate. The lint/scenario/release facts
were all measurably stale against HEAD.

## Test plan

- `tsc --noEmit` — clean.
- Guards: `check-plugin-references`, `check-stale-tool-descriptions`,
  `check-mcp-instructions-budget` (1898/1950), `check-no-pii-secrets`,
  `check-bun-test-imports` — all clean.
- `vitest run src/config/thinking-effort-risk.test.ts tests/docker/doctor-checks.test.ts`
  → 25 passed. `vitest run tests/doctor.test.ts` → 56 passed / 2 skipped.
- `vitest run tests/ci-merge-queue-triggers.test.ts tests/release-pipeline-gating.test.ts`
  → 101 passed (these are the specs that pin the CI/release facts documented here).
- `bun test telegram-plugin/tests/secret-detect-false-positives.test.ts` → 14 passed.
- No test asserts on the doctor warning strings that changed (grepped), so no
  test update was needed.

## Risk

Low. Documentation plus three comment/message-string edits; no behavioural
code. The only user-visible change is the `switchroom doctor` warning wording
for the Opus × `thinking_effort` check.

## Out of scope

Stale model ids across `docs/`, `examples/`, `evals/`, `skills/` and
`reference/rfcs/` are filed separately rather than mixed in here.

Job spec: `reference/jobs/get-better-the-longer-they-run.md` — stale agent
guidance is exactly how agents repeat corrected mistakes. The Models section
also serves `reference/jobs/crons-use-the-model-only-when-it-earns-it.md`
(the unrecognised-model → Tier-2 cost trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)