### PR TITLE
fix(vault): orphan .vault-token probe asserts a denial that never happens

### DIFF
--- a/src/cli/doctor-vault-broker-durability.test.ts
+++ b/src/cli/doctor-vault-broker-durability.test.ts
@@ -385,14 +385,81 @@ describe("probeOrphanVaultTokens — #1737 / #3289 orphan-token detector", () =>
     expect(r.detail).toContain("all reference a live grant");
   });
 
-  it("FAILS when a token references a grant id absent from the DB", () => {
+  it("FAILS on an orphan whose grant would still be inside its TTL", () => {
+    const NOW = 1_800_000_000_000;
     const r = probeOrphanVaultTokens(fakeConfig(["clerk"]), {
       readTokenId: () => "vg_5e1991",
       grantIdExists: (id) => id !== "vg_5e1991",
+      // minted 2 days ago — well inside the 30d assumed TTL
+      tokenMtimeMs: () => NOW - 2 * 86_400_000,
+      now: () => NOW,
     });
     expect(r.status).toBe("fail");
     expect(r.detail).toContain("clerk=vg_5e1991");
-    expect(r.detail).toContain("DENIES");
+    expect(r.detail).toContain("still inside the assumed 30d grant TTL");
+  });
+
+  // The pre-fix probe asserted "every `vault get` from these agents DENIES".
+  // That is false: the broker's READ-path fall-through treats an unusable
+  // token as no token and serves the standing config ACL
+  // (server-token-fallthrough.test.ts). Guard the wording so the false claim
+  // can't come back, and pin the true consequence.
+  it("never claims the agent is denied — describes grant loss + ACL fall-through", () => {
+    const NOW = 1_800_000_000_000;
+    const fresh = probeOrphanVaultTokens(fakeConfig(["clerk"]), {
+      readTokenId: () => "vg_5e1991",
+      grantIdExists: () => false,
+      tokenMtimeMs: () => NOW - 86_400_000,
+      now: () => NOW,
+    });
+    const old = probeOrphanVaultTokens(fakeConfig(["clerk"]), {
+      readTokenId: () => "vg_5e1991",
+      grantIdExists: () => false,
+      tokenMtimeMs: () => NOW - 90 * 86_400_000,
+      now: () => NOW,
+    });
+    for (const r of [fresh, old]) {
+      expect(r.detail).not.toMatch(/DENIES|every `vault get`/);
+      expect(r.detail).toContain("falls through to the standing config ACL");
+      expect(r.detail).toContain("reachable ONLY via the dynamic grant");
+    }
+  });
+
+  it("WARNs (not fails) on an orphan whose grant TTL has already lapsed", () => {
+    const NOW = 1_800_000_000_000;
+    const r = probeOrphanVaultTokens(fakeConfig(["ziggy"]), {
+      readTokenId: () => "vg_b0c21c",
+      grantIdExists: () => false,
+      // minted 45 days ago — the 30d grant would have expired on its own
+      tokenMtimeMs: () => NOW - 45 * 86_400_000,
+      now: () => NOW,
+    });
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("stale token litter");
+    expect(r.fix).toContain("Safe to remove");
+  });
+
+  it("WARNs (not fails) when the token mtime is unreadable", () => {
+    const r = probeOrphanVaultTokens(fakeConfig(["reggie"]), {
+      readTokenId: () => "vg_a6e428",
+      grantIdExists: () => false,
+      tokenMtimeMs: () => null,
+    });
+    expect(r.status).toBe("warn");
+  });
+
+  it("FAILs on a mixed set but still names the stale tokens", () => {
+    const NOW = 1_800_000_000_000;
+    const r = probeOrphanVaultTokens(fakeConfig(["fresh", "old"]), {
+      readTokenId: (agent) => (agent === "fresh" ? "vg_aaa111" : "vg_bbb222"),
+      grantIdExists: () => false,
+      tokenMtimeMs: (agent) =>
+        agent === "fresh" ? NOW - 86_400_000 : NOW - 90 * 86_400_000,
+      now: () => NOW,
+    });
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("fresh=vg_aaa111");
+    expect(r.detail).toContain("stale litter: old=vg_bbb222");
   });
 
   it("skips when the grants DB can't be read on the host", () => {

--- a/src/cli/doctor-vault-broker-durability.ts
+++ b/src/cli/doctor-vault-broker-durability.ts
@@ -21,7 +21,9 @@
  *     and the host file are the SAME inode (i.e. the bind mount
  *     is wired correctly). Pre-#1737 regression class: orphan
  *     `.vault-token` files referencing grants that no longer
- *     exist in a fresh ephemeral broker DB.
+ *     exist in a fresh ephemeral broker DB. (Such a token does not
+ *     deny the agent — see `probeOrphanVaultTokens` for what it
+ *     actually costs.)
  *   - "vault-audit.log inode-equality" — same pattern for the
  *     audit log. Missing mount → broker writes audit events to
  *     ephemeral container fs, invisible to `switchroom vault
@@ -342,6 +344,7 @@ export function runVaultBrokerDurabilityChecks(
     walStatBroker?: (p: string) => BrokerFileStat;
     grantIdExists?: (id: string) => boolean | null;
     readTokenId?: (agent: string, home: string) => string | null;
+    tokenMtimeMs?: (agent: string, home: string) => number | null;
   },
 ): CheckResult[] {
   const home = homedir();
@@ -371,6 +374,7 @@ export function runVaultBrokerDurabilityChecks(
       home,
       grantIdExists: opts?.grantIdExists,
       readTokenId: opts?.readTokenId,
+      tokenMtimeMs: opts?.tokenMtimeMs,
     }),
     formatBindMountResult(
       "vault-broker: vault-audit.log bind mount (#1025)",
@@ -611,11 +615,46 @@ export function probeGrantsWalDivergence(
 }
 
 /**
+ * The TTL the gateway's `vault_request_access` approval flow mints with
+ * (`telegram-plugin/gateway/callback-query-handlers.ts` — `ttl_seconds:
+ * 30 * 24 * 60 * 60`). Used as the age threshold below; see the TTL note on
+ * `probeOrphanVaultTokens`.
+ */
+const ASSUMED_GRANT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
  * Flag any agent `.vault-token` on disk whose grant id has NO matching row in
- * the grants DB — the exact #1737 / #3289 orphan-token symptom that appears
- * after a broker recreate wipes grants written to an ephemeral (unmounted or
- * un-checkpointed) DB. The token still authenticates format-wise but every
- * `vault get` DENIES because the grant it references is gone.
+ * the grants DB — the #1737 / #3289 orphan-token symptom that appears after a
+ * broker recreate wipes grants written to an ephemeral (unmounted or
+ * un-checkpointed) DB.
+ *
+ * ## What an orphan token actually costs (do not overstate it)
+ *
+ * It does NOT deny the agent's vault traffic. The broker's READ-path
+ * fall-through (`src/vault/broker/server.ts`, and pinned by
+ * `server-token-fallthrough.test.ts`) deliberately treats a token whose grant
+ * is missing or expired as *no token at all* and serves the request from the
+ * agent's standing config ACL — an unusable token must never be MORE
+ * restrictive than presenting none. Only `grant-revoked` hard-denies. So an
+ * agent with an orphan token still reads every key its `switchroom.yaml` ACL
+ * covers; `switchroom vault list` still returns those keys.
+ *
+ * What it DOES cost is real: the dynamic grant is gone, so any key that was
+ * reachable ONLY through that grant — the usual reason a grant gets minted at
+ * all — is no longer reachable by that agent.
+ *
+ * ## TTL recoverability (why this uses mtime)
+ *
+ * The orphaned grant's `expires_at` is NOT recoverable. The token file holds
+ * only `vg_<6 random hex>.<secret>` (`grants.ts` `generateId`) — no timestamp —
+ * and the row that carried `expires_at` is precisely what is missing. The only
+ * age signal left on the host is the token file's own mtime, which is a good
+ * proxy for mint time because the file is written exactly once per mint. So:
+ * mtime + `ASSUMED_GRANT_TTL_MS` past ⇒ the grant would have lapsed on its own
+ * and the file is litter (`warn`); still inside that window ⇒ the grant should
+ * have been alive and its disappearance is the genuine durability signal
+ * (`fail`). Unknown mtime is treated as litter — an unprovable age must not
+ * manufacture a red.
  *
  * @internal exported for testing
  */
@@ -625,6 +664,9 @@ export function probeOrphanVaultTokens(
     home?: string;
     readTokenId?: (agent: string, home: string) => string | null;
     grantIdExists?: (id: string) => boolean | null;
+    /** Token-file mtime in ms, or null when unreadable. Seam for tests. */
+    tokenMtimeMs?: (agent: string, home: string) => number | null;
+    now?: () => number;
   },
 ): CheckResult {
   const name = "vault-broker: no orphan .vault-token grants (#1737 / #3289)";
@@ -632,6 +674,8 @@ export function probeOrphanVaultTokens(
   const agents = Object.keys(config.agents ?? {});
   const readTokenId = opts?.readTokenId ?? defaultReadTokenId;
   const grantIdExists = opts?.grantIdExists ?? defaultGrantIdExists;
+  const tokenMtimeMs = opts?.tokenMtimeMs ?? defaultTokenMtimeMs;
+  const now = opts?.now ?? Date.now;
 
   const tokens: { agent: string; id: string }[] = [];
   for (const agent of agents) {
@@ -662,19 +706,70 @@ export function probeOrphanVaultTokens(
       detail: `${tokens.length} vault-token(s) all reference a live grant row`,
     };
   }
+
+  // Split by whether the vanished grant would still have been in its TTL
+  // window. Only the still-in-window ones are a durability failure.
+  const stale: string[] = [];
+  const durability: string[] = [];
+  for (const o of orphans) {
+    const mtime = tokenMtimeMs(o.agent, home);
+    const ageMs = mtime === null || !Number.isFinite(mtime) ? null : now() - mtime;
+    if (ageMs === null || ageMs > ASSUMED_GRANT_TTL_MS) {
+      stale.push(`${o.agent}=${o.id}`);
+    } else {
+      durability.push(`${o.agent}=${o.id}`);
+    }
+  }
+
+  const consequence =
+    `These agents have LOST the dynamic grant: the broker treats an unusable ` +
+    `token as no token and falls through to the standing config ACL (only ` +
+    `\`grant-revoked\` hard-denies), so config-ACL keys are still served — but ` +
+    `any key reachable ONLY via the dynamic grant is now unreachable for them.`;
+
+  if (durability.length === 0) {
+    return {
+      name,
+      status: "warn",
+      detail:
+        `${stale.length} agent vault-token(s) reference a grant id absent from the ` +
+        `grants DB: ${stale.join(", ")}. Each is older than the ${ASSUMED_GRANT_TTL_MS /
+          86_400_000}d grant TTL (or has no readable mtime), so the grant would ` +
+        `have expired anyway — this is stale token litter, not a durability ` +
+        `failure. ${consequence}`,
+      fix:
+        "Safe to remove (`: > ~/.switchroom/agents/<agent>/.vault-token`), or let " +
+        "the broker's own reaper truncate it on the agent's next `vault get`. " +
+        "Re-mint only if that agent still needs a key its config ACL doesn't cover.",
+    };
+  }
+
+  const staleTail = stale.length
+    ? ` (plus ${stale.length} already past the assumed TTL — stale litter: ${stale.join(", ")})`
+    : "";
   return {
     name,
     status: "fail",
     detail:
-      `${orphans.length} agent vault-token(s) reference a grant id absent from the ` +
-      `grants DB: ${orphans.map((o) => `${o.agent}=${o.id}`).join(", ")}. ` +
-      `This is the classic broker-recreate grant-wipe: every \`vault get\` from ` +
-      `these agents DENIES because the grant no longer exists.`,
+      `${durability.length} agent vault-token(s) reference a grant id absent from ` +
+      `the grants DB while still inside the assumed ${ASSUMED_GRANT_TTL_MS /
+        86_400_000}d grant TTL: ${durability.join(", ")}${staleTail}. A grant that ` +
+      `should still be live has vanished — the classic broker-recreate grant-wipe. ` +
+      consequence,
     fix:
       "Re-mint the grants (`switchroom vault grant <agent> --keys …`). If this " +
       "recurs after a broker recreate, the grants directory bind mount is broken " +
       "— see the `vault-grants dir bind mount` probe above.",
   };
+}
+
+/** Token-file mtime in ms; null when the file is missing or unreadable. */
+function defaultTokenMtimeMs(agent: string, home: string): number | null {
+  try {
+    return statSync(join(home, ".switchroom", "agents", agent, ".vault-token")).mtimeMs;
+  } catch {
+    return null;
+  }
 }
 
 function defaultReadTokenId(agent: string, home: string): string | null {

--- a/src/vault/broker/reap-token-file.test.ts
+++ b/src/vault/broker/reap-token-file.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for the dead-`.vault-token` reaper.
+ *
+ * Pre-fix there was no reaper at all: a token whose grant row had vanished
+ * (or whose TTL had lapsed) sat on disk forever, so `switchroom doctor`'s
+ * orphan probe was a permanent red and the fleet accreted one more orphan per
+ * broker-recreate. Every assertion here fails against that (absent) behaviour.
+ *
+ * Uses real fs against a tmpdir for the outcome assertions that matter
+ * (bytes actually gone, inode preserved), and the injection seams only for
+ * the error path.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { reapUnusableGrantToken } from "./reap-token-file.js";
+
+const TOKEN = "vg_5e1991.deadbeefdeadbeefdeadbeefdeadbeef";
+
+let agentsDir: string;
+
+function writeToken(agent: string, contents: string): string {
+  const dir = join(agentsDir, agent);
+  mkdirSync(dir, { recursive: true });
+  const p = join(dir, ".vault-token");
+  writeFileSync(p, contents, { mode: 0o600 });
+  return p;
+}
+
+beforeEach(() => {
+  agentsDir = mkdtempSync(join(tmpdir(), "reap-token-"));
+});
+afterEach(() => {
+  rmSync(agentsDir, { recursive: true, force: true });
+});
+
+describe("reapUnusableGrantToken", () => {
+  it("truncates the file when the grant row is gone (grant-invalid)", () => {
+    const p = writeToken("clerk", TOKEN);
+    const out = reapUnusableGrantToken({
+      agentsDir,
+      agent: "clerk",
+      presentedToken: TOKEN,
+      reason: "grant-invalid",
+    });
+    expect(out).toBe("reaped");
+    expect(readFileSync(p, "utf8")).toBe("");
+  });
+
+  it("truncates the file when the grant expired", () => {
+    const p = writeToken("ziggy", TOKEN);
+    expect(
+      reapUnusableGrantToken({
+        agentsDir,
+        agent: "ziggy",
+        presentedToken: TOKEN,
+        reason: "grant-expired",
+      }),
+    ).toBe("reaped");
+    expect(readFileSync(p, "utf8")).toBe("");
+  });
+
+  it("preserves the inode (in-place truncate, never rename/unlink)", () => {
+    // Load-bearing: the token file is a BARE-FILE bind mount inside the
+    // broker container. rename(2) over it is EBUSY — observed live on every
+    // mint_grant. Only an in-place O_TRUNC survives, and it keeps the file's
+    // agent-UID ownership too.
+    const p = writeToken("gymbro", TOKEN);
+    const before = statSync(p).ino;
+    reapUnusableGrantToken({
+      agentsDir,
+      agent: "gymbro",
+      presentedToken: TOKEN,
+      reason: "grant-invalid",
+    });
+    expect(statSync(p).ino).toBe(before);
+  });
+
+  it("KEEPS a live grant that merely doesn't cover this key", () => {
+    const p = writeToken("clerk", TOKEN);
+    expect(
+      reapUnusableGrantToken({
+        agentsDir,
+        agent: "clerk",
+        presentedToken: TOKEN,
+        reason: "grant-key-not-allowed",
+      }),
+    ).toBe("kept:reason-not-reapable");
+    expect(readFileSync(p, "utf8")).toBe(TOKEN);
+  });
+
+  it("KEEPS a token a concurrent mint already replaced", () => {
+    const fresher = "vg_ffffff.0000000000000000000000000000ffff";
+    const p = writeToken("clerk", fresher);
+    expect(
+      reapUnusableGrantToken({
+        agentsDir,
+        agent: "clerk",
+        presentedToken: TOKEN,
+        reason: "grant-invalid",
+      }),
+    ).toBe("kept:superseded");
+    expect(readFileSync(p, "utf8")).toBe(fresher);
+  });
+
+  it("no-ops without a socket-bound agent identity", () => {
+    expect(
+      reapUnusableGrantToken({
+        agentsDir,
+        agent: null,
+        presentedToken: TOKEN,
+        reason: "grant-invalid",
+      }),
+    ).toBe("kept:no-agent-identity");
+  });
+
+  it("no-ops when there is nothing on disk", () => {
+    expect(
+      reapUnusableGrantToken({
+        agentsDir,
+        agent: "never-minted",
+        presentedToken: TOKEN,
+        reason: "grant-invalid",
+      }),
+    ).toBe("kept:nothing-on-disk");
+  });
+
+  it("no-ops on an already-empty token file", () => {
+    writeToken("clerk", "");
+    expect(
+      reapUnusableGrantToken({
+        agentsDir,
+        agent: "clerk",
+        presentedToken: TOKEN,
+        reason: "grant-invalid",
+      }),
+    ).toBe("kept:nothing-on-disk");
+  });
+
+  it("swallows a write failure rather than throwing into the get path", () => {
+    expect(
+      reapUnusableGrantToken(
+        { agentsDir, agent: "clerk", presentedToken: TOKEN, reason: "grant-invalid" },
+        {
+          readFile: () => TOKEN,
+          writeFile: () => {
+            throw new Error("EROFS");
+          },
+        },
+      ),
+    ).toBe("kept:io-error");
+  });
+});

--- a/src/vault/broker/reap-token-file.ts
+++ b/src/vault/broker/reap-token-file.ts
@@ -1,0 +1,126 @@
+/**
+ * Deterministic garbage-collection of unusable agent `.vault-token` files.
+ *
+ * ## Why this exists
+ *
+ * When an agent presents a token whose grant row is gone (`grant-invalid`)
+ * or whose grant has lapsed (`grant-expired`), the broker's READ-path
+ * fall-through deliberately treats it as *no token at all* and serves the
+ * agent from its standing config ACL instead (see the fall-through note in
+ * `server.ts`, and `server-token-fallthrough.test.ts`). That behaviour is
+ * correct — an unusable token must never be MORE restrictive than presenting
+ * none — but it also means nothing ever *notices* the dead token. It sits on
+ * disk forever:
+ *
+ *   - `switchroom doctor` reports it as an orphan on every run, permanently;
+ *   - the fleet accretes one more orphan per broker-recreate / TTL lapse;
+ *   - the agent keeps paying a bcrypt validate on every `vault get` for a
+ *     token that can never succeed.
+ *
+ * This module closes the loop at the point where the unusable token is
+ * *already* detected on use: truncate the file back to the empty state that
+ * `apply` pre-creates, so the next call is an honest no-token call.
+ *
+ * ## Why truncate in place, and never rename/unlink
+ *
+ * Each agent's token file is bind-mounted into the broker container as a
+ * **bare file** (`compose.ts`: `…/agents/<a>/.vault-token:/root/.switchroom/
+ * agents/<a>/.vault-token`). A bind-mounted file is a mountpoint: you cannot
+ * `rename(2)` over it or `unlink(2)` it from inside the container — the
+ * kernel returns `EBUSY`. This is not theoretical; the live broker logs it
+ * on every mint, because `mint_grant` uses the tmp+rename atomic-write
+ * pattern:
+ *
+ *   [vault-broker] mint_grant: failed to write token file for agent gymbro:
+ *   EBUSY: resource busy or locked, rename
+ *   '/root/.switchroom/agents/gymbro/.vault-token.tmp.6' ->
+ *   '/root/.switchroom/agents/gymbro/.vault-token'
+ *
+ * An in-place `O_TRUNC` write keeps the same inode, so it works over the
+ * bind mount AND preserves the file's agent-UID ownership and 0600 mode —
+ * no chown needed afterwards, unlike the rename path.
+ *
+ * ## Safety rails
+ *
+ * - Only `grant-invalid` / `grant-expired` are reaped. `grant-key-not-allowed`
+ *   means the grant is ALIVE and merely doesn't cover this key — reaping it
+ *   would destroy a working capability. `grant-revoked` never reaches here
+ *   (it hard-denies upstream) and is deliberately left alone so the operator
+ *   kill-switch stays visible.
+ * - The on-disk bytes must still be the token that was presented. A concurrent
+ *   `mint_grant` may have replaced the file between the agent's read and this
+ *   call; in that case the fresh token wins and we keep it.
+ * - Every failure is swallowed into an outcome code. Reaping is hygiene, never
+ *   a reason to fail a `get`.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Grant-validation failure reasons that mean "this token is dead". */
+const REAPABLE_REASONS = new Set(["grant-invalid", "grant-expired"]);
+
+export type ReapOutcome =
+  /** File truncated to the empty (no-token) state. */
+  | "reaped"
+  /** Reason is not one of the dead-token reasons (e.g. grant-key-not-allowed). */
+  | "kept:reason-not-reapable"
+  /** No socket-bound agent identity, so no token path can be derived. */
+  | "kept:no-agent-identity"
+  /** Nothing on disk, or already empty — nothing to collect. */
+  | "kept:nothing-on-disk"
+  /** On-disk token differs from the presented one — a fresher mint won. */
+  | "kept:superseded"
+  /** Read or write failed (permissions, missing dir, …). */
+  | "kept:io-error";
+
+export interface ReapDeps {
+  readFile?: (path: string) => string;
+  writeFile?: (path: string, data: string) => void;
+}
+
+export interface ReapArgs {
+  /** Host/container agents dir, e.g. `~/.switchroom/agents`. */
+  agentsDir: string;
+  /** Socket-bound agent identity, or null when there is none. */
+  agent: string | null;
+  /** The exact token string the caller presented. */
+  presentedToken: string;
+  /** `validateGrant` failure reason. */
+  reason: string;
+}
+
+/**
+ * Truncate an agent's `.vault-token` when the token it holds is provably
+ * dead. Returns an outcome code describing what happened; never throws.
+ */
+export function reapUnusableGrantToken(args: ReapArgs, deps: ReapDeps = {}): ReapOutcome {
+  const { agentsDir, agent, presentedToken, reason } = args;
+  if (!REAPABLE_REASONS.has(reason)) return "kept:reason-not-reapable";
+  if (!agent) return "kept:no-agent-identity";
+
+  const readFile = deps.readFile ?? ((p: string) => readFileSync(p, "utf8"));
+  const writeFile =
+    deps.writeFile ?? ((p: string, d: string) => writeFileSync(p, d, { mode: 0o600 }));
+
+  const tokenPath = join(agentsDir, agent, ".vault-token");
+
+  let onDisk: string;
+  try {
+    onDisk = readFile(tokenPath);
+  } catch {
+    // ENOENT (never minted) or EACCES — nothing safe to do.
+    return "kept:nothing-on-disk";
+  }
+  if (onDisk.trim() === "") return "kept:nothing-on-disk";
+  if (onDisk.trim() !== presentedToken.trim()) return "kept:superseded";
+
+  try {
+    // In-place O_TRUNC — NOT tmp+rename. See the module header: rename over a
+    // bare-file bind mount is EBUSY, and truncation preserves inode ownership.
+    writeFile(tokenPath, "");
+  } catch {
+    return "kept:io-error";
+  }
+  return "reaped";
+}

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -55,6 +55,7 @@ import { createAuditLogger, callerFromPeer, type AuditLogger } from "./audit-log
 import { safeVaultPath } from "./test-isolation-guard.js";
 import { Database } from "bun:sqlite";
 import { mintGrant, validateGrant, validateGrantForWrite, revokeGrant, listGrants, migrateGrantsSchema } from "../grants.js";
+import { reapUnusableGrantToken } from "./reap-token-file.js";
 import { adminOnlyKeysBeingAdded } from "../admin-only-keys.js";
 import { openGrantsDb } from "../grants-db.js";
 import {
@@ -1406,6 +1407,29 @@ export class VaultBroker {
         // request still produces exactly one audit entry (preserves the
         // #1433 hash-chain). Mirrors the put precedent at the
         // validateGrantForWrite branch.
+        //
+        // …but DO garbage-collect the dead token file. The fall-through is
+        // exactly why an orphaned `.vault-token` is harmless, and also why
+        // nothing ever noticed one: pre-fix, a token whose grant row was
+        // gone (or whose TTL had lapsed) stayed on disk forever — reported
+        // by `switchroom doctor` as a permanent red on every run, and
+        // re-validated (bcrypt) on every single `vault get`. Truncating it
+        // here — at the one place a token is already proven unusable —
+        // makes the next call an honest no-token call and lets the fleet
+        // stop accreting orphans. Only grant-invalid / grant-expired are
+        // reaped; grant-key-not-allowed means the grant is ALIVE and must
+        // be kept. See reap-token-file.ts for why this truncates in place
+        // rather than unlinking (bare-file bind mount ⇒ EBUSY).
+        if (!grantResult.ok) {
+          reapUnusableGrantToken({
+            agentsDir: this.config
+              ? resolveAgentsDir(this.config)
+              : path.join(os.homedir(), ".switchroom", "agents"),
+            agent: agentName,
+            presentedToken: req.token,
+            reason: grantResult.reason,
+          });
+        }
       }
 
       // ── ACL path (no token) ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`switchroom doctor`'s `vault-broker: no orphan .vault-token grants (#1737 / #3289)` probe emits a permanent red on the live fleet with the claim:

> **This is the classic broker-recreate grant-wipe: every `vault get` from these agents DENIES because the grant no longer exists.**

That claim is false. This PR:

1. **Rewrites the detail text** to the consequence the broker code actually produces.
2. **Makes the probe expiry-aware** — an orphan whose grant would already have lapsed is `warn` (litter), not `fail`.
3. **Adds a deterministic reaper** in the broker so a dead token is garbage-collected at the point it is already proven dead, instead of living on disk forever.

## Why

**(1) The denial claim is wrong.** `src/vault/broker/server.ts` (read path, `get`) hard-denies only `grant-revoked`. `grant-invalid` / `grant-expired` / `grant-key-not-allowed` deliberately fall through to the standing config ACL — "an unusable token must never be MORE restrictive than presenting no token". `src/vault/broker/server-token-fallthrough.test.ts` pins exactly that, citing a live repro. Verified on the live fleet: all six flagged agents return populated `switchroom vault list` output and a real `vault get` succeeds.

The true cost is still real and the new wording says so: the agent has **lost its dynamic grant**, so config-ACL keys are still served but any key reachable *only* through that grant is not.

**(2) TTL awareness.** The orphaned grant's `expires_at` is **not recoverable** — the token file holds `vg_<6 random hex>.<secret>` (`grants.ts` `generateId`) with no timestamp, and the row carrying `expires_at` is precisely what is missing. The only age signal left is the token file's mtime, which is a sound mint-time proxy because the file is written exactly once per mint. So: mtime older than the 30d TTL the gateway mints with (`callback-query-handlers.ts`, `ttl_seconds: 30 * 24 * 60 * 60`) ⇒ the grant would have expired anyway ⇒ `warn` "stale token litter, safe to remove". Inside the window ⇒ `fail`, the genuine durability signal. Unreadable mtime ⇒ `warn`; an unprovable age must not manufacture a red. The chosen fallback is stated in the code so the assumption is auditable.

**(3) Nothing ever GC'd these.** That is why the red is permanent and why the fleet accretes one orphan per broker-recreate / TTL lapse. The reaper runs at the one place a token is already proven unusable — the `get` fall-through — and truncates the file back to the empty state `apply` pre-creates.

Two non-obvious constraints, both encoded:

- **In-place `O_TRUNC`, never rename/unlink.** The token file is a **bare-file bind mount** into the broker container (`compose.ts`). You cannot `rename(2)` over or `unlink(2)` a mountpoint from inside the container. This is observed, not theoretical — the live broker logs it on every mint, because `mint_grant` uses tmp+rename: `EBUSY: resource busy or locked, rename '/root/.switchroom/agents/<agent>/.vault-token.tmp.6' -> '/root/.switchroom/agents/<agent>/.vault-token'`. Truncation also preserves the inode, hence the agent-UID ownership and 0600 mode.
- **Only `grant-invalid` / `grant-expired` are reaped.** `grant-key-not-allowed` means the grant is *alive* and merely doesn't cover this key — reaping it would destroy a working capability. `grant-revoked` never reaches the fall-through and stays untouched so the operator kill-switch remains visible. And the on-disk bytes must still equal the presented token, so a concurrent `mint_grant` always wins the race.

The fall-through behaviour itself is **unchanged** — it is correct and deliberate. The durability fix from #1737 / #3289 is working; the six live orphans are pre-fix wreckage.

## Test plan

Scoped, all green:

```
vitest run src/cli/doctor-vault-broker-durability.test.ts src/vault/broker/reap-token-file.test.ts
  → 2 files, 42 tests passed
npm run lint  → tsc + 16 guards clean
bun test src/vault/broker/server-token-fallthrough.test.ts src/vault/broker/server-grants.test.ts
  → 27 pass / 1 fail (pre-existing, see Risk)
```

Every new assertion fails against current `main`:

- `FAILS on an orphan whose grant would still be inside its TTL` — main has no TTL concept.
- `WARNs (not fails) on an orphan whose grant TTL has already lapsed` — main returns `fail`.
- `WARNs (not fails) when the token mtime is unreadable` — main returns `fail`.
- `never claims the agent is denied` — asserts `detail` does **not** match `/DENIES|every \`vault get\`/`; main's string contains both.
- `FAILs on a mixed set but still names the stale tokens` — new split reporting.
- All nine `reapUnusableGrantToken` cases — the function does not exist on main. They assert outcomes on real files in a tmpdir: bytes gone, **inode preserved** (the bind-mount invariant), live-grant token untouched, superseded token untouched, write failure swallowed rather than thrown into the `get` path.

**Honest coverage gap:** the ~10-line call site inside `server.ts` is not exercised end-to-end. The broker bun harness cannot bind a per-agent socket (`/run/switchroom/broker/<agent>/sock`), so `agentName` is `null` there and the reaper correctly no-ops — the same harness limitation already documented at the top of `server-token-fallthrough.test.ts`. The reaper's logic is fully unit-covered; the wiring is a single guarded call.

## Risk

Low.

- **Probe:** report-text and severity only. The one probe test that changed is the one asserting the false claim.
- **Reaper:** the only write is truncating a file that has just been proven to authenticate nothing, guarded by reason + byte-equality, with every failure swallowed into an outcome code so it can never fail a `get`. Worst case it truncates a dead token one call earlier than the operator would have.
- **Severity softening:** deliberate and bounded — only for an orphan whose grant would already have expired on its own. An orphan inside the TTL window still `fail`s, so the genuine durability check is intact.
- **Pre-existing test failure, not from this diff:** `server-token-fallthrough.test.ts` → `list with INVALID token → falls through to no-token list` fails identically on pristine `origin/main` (verified by stashing this diff and re-running). Filed separately rather than footnoted.

## Job spec

`reference/jobs/fleet-stays-healthy.md` — "surface the fleet's own recurring failures ranked by impact, so the operator spends attention only on the worst issues instead of auditing everything". A permanent red that overstates its own severity is the exact anti-outcome: it burns operator attention on a non-incident and trains them to ignore the probe. Serves **always-available**; crosses no invariant.

Ancestry: #1737, #3289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)