### PR TITLE
docs: refresh stale model ids and correct two Models-section claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,16 +59,29 @@ Non-negotiable; `reference/vision.md` pillar 3 as an engineering gate.
   interleaved-streaming merge bug (#1978): `400 messages.N.content.M: 'thinking'
   or 'redacted_thinking' blocks in the latest assistant message cannot be
   modified`. Pin `thinking_effort: low`.
-- **Cron tiering keys off the model STRING** (`src/scheduler/cron-routing.ts`):
-  `sonnet|haiku` ⇒ cheap Tier-1 fresh session; `opus` ⇒ Tier-2 live session; an
-  **unrecognised id also falls to Tier-2** with a `customModelDowngrade` warning
-  — a typo'd or newly-renamed cheap model silently costs full-session tokens.
+- **Cron tiering keys off the model STRING — but only third**
+  (`src/scheduler/cron-routing.ts`). Two gates decide before the model is
+  consulted: `kind: action` returns `tier: "action"` at `:89` and is
+  flag-independent (a zero-token verb has no Tier-2 fallback, so gating it would
+  silently drop the cron); and the `cheapCronEnabled` kill-switch
+  (`SWITCHROOM_CHEAP_CRON=0|false|off`) short-circuits **every** fire to
+  `{ tier: "main", session: "main" }` at `:97`, leaving `kind`/`model`/`context`
+  inert. Past those, an explicit **`context:` outranks model inference**
+  (`:107`) — only the `else` branch consults `isKnownCheapModel()` (`:109`),
+  where `sonnet|haiku` ⇒ cheap Tier-1 fresh session and `opus` ⇒ Tier-2 live
+  session. An **unrecognised id also falls to Tier-2** with a
+  `customModelDowngrade` warning — a typo'd or newly-renamed cheap model
+  silently costs full-session tokens.
 - **The `/model` override rides a consume-once carrier** whose shape gate is
-  byte-parity between `profiles/_base/start.sh.hbs` (~:1621) and `MODEL_ARG_RE`
-  in `telegram-plugin/gateway/model-command.ts:64`, pinned by
-  `tests/scaffold.session-model.test.ts`. A string failing the gate is dropped
-  to the configured default with a one-shot operator alert and is never retried.
-  Change one regex, change the other in the same PR.
+  byte-parity across **five** sites: four identical `grep -Eq` copies in
+  `profiles/_base/start.sh.hbs` (live-model :1478, last-known-good :1502,
+  migration :1551, carrier :1629) and `MODEL_ARG_RE` in
+  `telegram-plugin/gateway/model-command.ts:64`. A string failing the gate is
+  dropped to the configured default with a one-shot operator alert and is never
+  retried. Change one, change all five in the same PR —
+  `tests/scaffold.session-model.test.ts:194` scrapes every `{0,99}` pattern out
+  of the RENDERED `start.sh`, asserts they are byte-identical, and runs a shared
+  fixture table against both the shell pattern and the TS `isValidModelArg`.
 - **Never hard-code a token budget against an assumed context window** — derive
   it from a declared one (`src/setup/hindsight-context-budget.ts`, #3717). The
   `claude-code` / `anthropic` provider default is `200_000`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,7 @@ The container's entrypoint is the agent's `start.sh`, run as PID 1's child under
 exec claude \
   --dangerously-load-development-channels server:switchroom-telegram \
   --plugin-dir ~/.switchroom/agents/<agent>/plugins \
-  --model claude-opus-4-8 \
+  --model opus \
   --append-system-prompt "$(switchroom workspace render <agent> --stable)"
 ```
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -62,8 +62,8 @@ keeps the "Agent not defined in switchroom.yaml" error, now with a
 hint to use `--profile`.
 
 Model aliases: the bare names `opus`, `sonnet`, `haiku` are accepted
-alongside the full IDs (`claude-opus-4-8`, `claude-sonnet-5`,
-`claude-haiku-4-5`). Use whichever reads cleaner in your config.
+alongside the full IDs (`claude-opus-5`, `claude-sonnet-5`,
+`claude-haiku-4-5-20251001`). Use whichever reads cleaner in your config.
 
 ## Authentication (one OAuth, many agents)
 

--- a/docs/session-optimization.md
+++ b/docs/session-optimization.md
@@ -63,7 +63,7 @@ Route implementation work to cheaper models via sub-agents:
 
 ```yaml
 defaults:
-  model: claude-opus-4-8
+  model: opus
   subagents:
     worker:
       model: sonnet

--- a/evals/README.md
+++ b/evals/README.md
@@ -26,7 +26,7 @@ python evals/run_quality.py --ablation
 python evals/run_quality.py --parallel 10
 
 # Different model
-python evals/run_quality.py --model claude-opus-4-5
+python evals/run_quality.py --model claude-opus-5
 ```
 
 ## Trigger routing evals

--- a/evals/run_quality.py
+++ b/evals/run_quality.py
@@ -17,7 +17,7 @@ EVALS_DIR = Path(__file__).parent
 RESULTS_DIR = EVALS_DIR / "results"
 SKILLS_DIR = EVALS_DIR.parent / "skills"
 
-DEFAULT_MODEL = "claude-sonnet-4-6"
+DEFAULT_MODEL = "claude-sonnet-5"
 
 
 def git_sha() -> str:

--- a/evals/run_trigger.py
+++ b/evals/run_trigger.py
@@ -16,7 +16,7 @@ import yaml
 EVALS_DIR = Path(__file__).parent
 RESULTS_DIR = EVALS_DIR / "results"
 SKILLS_DIR = EVALS_DIR.parent / "skills"
-DEFAULT_MODEL = "claude-sonnet-4-6"
+DEFAULT_MODEL = "claude-sonnet-5"
 
 # Skills exposed to the trigger router. Descriptions are loaded from each
 # SKILL.md frontmatter at runtime so the eval stays in sync with the real

--- a/examples/switchroom.yaml
+++ b/examples/switchroom.yaml
@@ -249,7 +249,7 @@ agents:
   #   topic_emoji: "💻"
   #   bot_token: "vault:telegram-dev-bot-token"     # its own bot
   #   extends: coder                      # inherits from inline profile above
-  #   model: claude-opus-4-8              # override defaults.model for this agent
+  #   model: opus                         # override defaults.model for this agent
   #   memory:
   #     collection: coding
   #   cli_args: ["--effort", "high"]      # escape hatch: extra exec claude flags

--- a/reference/rfcs/cheap-cron-sessions.md
+++ b/reference/rfcs/cheap-cron-sessions.md
@@ -12,6 +12,12 @@ status: Draft, post-review (rev 2)
 **Targets:** `upstream/main` @ v0.14.91
 **Compliance pillar touched:** 3 (Claude-native, subscription-honest), preserved by construction; see §7.
 
+> **Model ids below are as-of-writing (v0.14.91).** `claude-sonnet-4-6` was the
+> then-current `SWITCHROOM_DEFAULT_MAIN_MODEL`; it is `claude-sonnet-5` today
+> (`src/agents/scaffold.ts`). The ids are left unrewritten so the record stays
+> an accurate snapshot — read them as "the default cheap model", not as a
+> current pin.
+
 ---
 
 ## Review verdict (5-lens adversarial, rev 1 → rev 2)

--- a/skills/switchroom-status/SKILL.md
+++ b/skills/switchroom-status/SKILL.md
@@ -85,7 +85,7 @@ assistant — running (2h 14m)
   model: claude-sonnet-5  collection: general
 
 dev — running (45m)
-  model: claude-opus-4-8  collection: coding
+  model: claude-opus-5  collection: coding
 
 coach — stopped
   last run: 3 days ago


### PR DESCRIPTION
Closes #3747, closes #3748.

Filed as two issues; shipped as one PR because both edit the same
`## Models` region of `CLAUDE.md` and would otherwise conflict.

## #3748 — both claims verified TRUE against `origin/main` @ `3118da94`

**1. Cron tiering.** `src/scheduler/cron-routing.ts` consults the model
string *third*, not first:

| order | site | behaviour |
|---|---|---|
| 1 | `:89` | `kind: action` returns `tier: "action"`, flag-independent |
| 2 | `:97` | `cheapCronEnabled` off ⇒ short-circuit to `{ tier: "main", session: "main" }`; `kind`/`model`/`context` inert |
| 3 | `:107` | explicit `context:` wins |
| 4 | `:109` | only the `else` calls `isKnownCheapModel(input.model)` |

`CLAUDE.md` now documents the whole order, keeping the unrecognised-id →
Tier-2 `customModelDowngrade` trap (which was correct as written).

**2. Shape-gate site count.** The issue said five; I counted five.
`grep -rn '{0,99}'` over `profiles/`, `telegram-plugin/`, `src/`:

- `profiles/_base/start.sh.hbs:1478` (live-model)
- `profiles/_base/start.sh.hbs:1502` (last-known-good)
- `profiles/_base/start.sh.hbs:1551` (migration)
- `profiles/_base/start.sh.hbs:1629` (carrier)
- `telegram-plugin/gateway/model-command.ts:64` (`MODEL_ARG_RE`)

All four shell copies are the byte-identical
`^[A-Za-z0-9][]A-Za-z0-9._[/-]{0,99}$`. The sixth `{0,99}` hit is
`tests/scaffold.session-model.test.ts:197`, the scraper that pins them —
not a copy. `CLAUDE.md` previously said "change one regex, change the
other"; it now names all five and cites the test.

## #3747 — stale ids, judged per site

Changed:

| file | from | to | why |
|---|---|---|---|
| `docs/architecture.md:36` | `claude-opus-4-8` | `opus` | illustrative flag list |
| `docs/session-optimization.md:66` | `claude-opus-4-8` | `opus` | illustrative yaml |
| `examples/switchroom.yaml:252` | `claude-opus-4-8` | `opus` | commented example |
| `docs/cli-reference.md:65` | `claude-opus-4-8`, `claude-haiku-4-5` | `claude-opus-5`, `claude-haiku-4-5-20251001` | it is *the* accepted-pins list |
| `skills/switchroom-status/SKILL.md:88` | `claude-opus-4-8` | `claude-opus-5` | depicts a **resolved** id in status output; an alias would misrepresent |
| `evals/run_quality.py:20`, `evals/run_trigger.py:19` | `claude-sonnet-4-6` | `claude-sonnet-5` | live default, tracks `SWITCHROOM_DEFAULT_MAIN_MODEL` (`src/agents/scaffold.ts:1509`); pinned not aliased because both runners write `model` into results JSON for provenance |
| `evals/README.md:29` | `claude-opus-4-5` | `claude-opus-5` | example command |
| `reference/rfcs/cheap-cron-sessions.md` | — | dated note | see below |

`claude-haiku-4-5-20251001` is the canonical haiku pin per
`src/auth/quota.ts:41` (`DEFAULT_PROBE_MODEL`), `src/agents/compose.ts:881`,
and `src/config/schema.ts:1943`.

### Deliberately NOT changed

- **`reference/rfcs/cheap-cron-sessions.md:108,187`** — the RFC declares
  `Targets: upstream/main @ v0.14.91` and quotes then-current line
  numbers. Rewriting its ids would falsify a design record, so it gets a
  dated blockquote saying the ids are as-of-writing and naming the
  current default instead.
- **`skills/mcp-builder/**` and `skills/skill-creator/**`** — vendored
  from `anthropics/skills` pinned at `5128e1865d` (each has a
  `VENDORED.md` with a resync procedure). A local rewrite gets clobbered
  on resync; the fix belongs upstream. This covers the five
  `claude-3-x-sonnet` sites and
  `skills/skill-creator/references/schemas.md:228`
  (`claude-sonnet-4-20250514`), which #3747 listed under Sonnet 4.x but
  is in fact vendored, same as the mcp-builder block.
- **`reference/rfcs/litellm-max-subscription-invariants.md`** — not
  listed in the issue, and correctly so: it already labels
  `claude-sonnet-4-6` as "stale — kept only as a drift-alias source" and
  documents `claude-sonnet-4-6 → claude-sonnet-5` as the drift alias. The
  old id is load-bearing there.
- **`docs/configuration.md:27`** — verified NOT stale, as #3747 itself
  concluded. It states `opus` resolves to Opus 5 and lists
  `claude-opus-4-8` only among *accepted* pins, which remains true
  (`resolveMainModel()` passes any real id through unchanged).
- **`tests/**` fixtures** (e.g. `tests/reconcile.default-model.test.ts:163`,
  `tests/docker/compose-generator.test.ts:3506`) — deliberate pinned
  inputs asserting pass-through of an arbitrary id, not documentation.

## Verification

- Branched off `origin/main` @ `3118da94` after `git fetch origin`.
- `npm run lint` — clean (tsc + all 16 guards).
- No source-behaviour change: the only non-`.md`/`.yaml` edits are the two
  `evals/` `DEFAULT_MODEL` constants, which are offline eval-runner
  defaults not reachable from agent runtime.