### PR TITLE
test(inject): per-case tmux sockets kill the kill-server/new-session race (#3733)

### DIFF
--- a/src/agents/inject.integration.test.ts
+++ b/src/agents/inject.integration.test.ts
@@ -15,11 +15,26 @@
  *
  * Skips cleanly when `tmux` is absent so CI environments without the
  * binary don't break.
+ *
+ * Socket discipline (#3733): every test case gets its OWN tmux socket
+ * name. Sharing one socket across cases means `afterEach`'s teardown
+ * races the next `beforeEach`'s `new-session` — the teardown request
+ * returns to the client while the server is still unwinding and
+ * unlinking its socket, so the next connect on that same name can hit
+ * a mid-shutdown server and die with `server exited unexpectedly`
+ * before any assertion runs. That reddened `main` on a diff touching
+ * no tmux code. A distinct socket per case removes the race by
+ * construction rather than by sleeping or retrying — no `new-session`
+ * ever addresses a socket name a previous case has already used. Note
+ * that per-case `kill-session` is NOT a fix: killing a server's last
+ * session terminates the server too, so the same shutdown race
+ * survives, just with a different trigger.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
 import { makeTmuxRunner } from "./inject.js";
 
 function tmuxAvailable(): boolean {
@@ -32,23 +47,76 @@ function tmuxAvailable(): boolean {
 }
 
 const TMUX_PRESENT = tmuxAvailable();
-const SOCKET = `srtest-${process.pid}-${Date.now().toString(36)}`;
+const SOCKET_PREFIX = `srtest-${process.pid}-${Date.now().toString(36)}`;
 const SESSION = "injecttest";
 
-function tmux(args: string[]): { status: number | null; stdout: string; stderr: string } {
-  const r = spawnSync("tmux", ["-L", SOCKET, ...args], {
+/** Sockets handed out so far — the uniqueness invariant is asserted, not assumed. */
+const usedSockets = new Set<string>();
+let socketSeq = 0;
+/** Socket for the case currently running; set by `beforeEach`, cleared by `afterEach`. */
+let socket = "";
+
+function nextSocket(): string {
+  socketSeq += 1;
+  return `${SOCKET_PREFIX}-${socketSeq}`;
+}
+
+/** Path tmux uses for a `-L <name>` socket, so teardown can unlink the stale file. */
+function socketPath(name: string): string {
+  const base = process.env.TMUX_TMPDIR || "/tmp";
+  const uid = typeof process.getuid === "function" ? process.getuid() : 0;
+  return join(base, `tmux-${uid}`, name);
+}
+
+function tmuxOn(
+  sock: string,
+  args: string[],
+): { status: number | null; stdout: string; stderr: string } {
+  const r = spawnSync("tmux", ["-L", sock, ...args], {
     encoding: "utf-8",
     stdio: ["pipe", "pipe", "pipe"],
   });
   return { status: r.status, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
 }
 
+/** Run tmux against the socket owned by the current test case. */
+function tmux(args: string[]): { status: number | null; stdout: string; stderr: string } {
+  if (!socket) throw new Error("tmux() called outside a test case — no socket assigned");
+  return tmuxOn(socket, args);
+}
+
 async function sleep(ms: number): Promise<void> {
   return new Promise((res) => setTimeout(res, ms));
 }
 
+/**
+ * True once no tmux server answers on `sock`. Polls rather than probing
+ * once: `kill-server` returns to the client while the server is still
+ * unwinding, so a single immediate probe would be the very race this
+ * file is fixing. Bounded so a genuinely stray server still fails.
+ */
+function socketIsDead(sock: string, timeoutMs = 3000): boolean {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (tmuxOn(sock, ["has-session", "-t", SESSION]).status !== 0) return true;
+    if (Date.now() >= deadline) return false;
+    // spawnSync round-trip is itself the pause; no busy-spin needed.
+    spawnSync("sleep", ["0.05"]);
+  }
+}
+
 describe.skipIf(!TMUX_PRESENT)("inject — real-tmux argv smoke (#728 regression)", () => {
   beforeEach(() => {
+    // #3733 invariant: this case must not reuse a previous case's
+    // socket generation. Under the old shared-socket fixture this
+    // assertion fails from the second case onward.
+    socket = nextSocket();
+    expect(usedSockets.has(socket)).toBe(false);
+    usedSockets.add(socket);
+
+    // Assigning `socket` BEFORE spawning matters: vitest still runs
+    // `afterEach` when `beforeEach` throws, so a failed spawn can't
+    // leave a stray server behind on this socket.
     // Spawn a fresh detached session that just runs `cat` so anything
     // we send-keys lands in stdin and gets echoed back to the pane.
     const r = tmux([
@@ -70,9 +138,20 @@ describe.skipIf(!TMUX_PRESENT)("inject — real-tmux argv smoke (#728 regression
   });
 
   afterEach(() => {
-    // Best-effort cleanup. `kill-server` nukes the per-socket tmux
-    // server so we don't accumulate sockets between tests / on failure.
-    tmux(["kill-server"]);
+    // Best-effort cleanup. `kill-server` nukes this case's tmux server
+    // so we don't accumulate servers between tests / on failure. No
+    // later case addresses this socket name again, so nothing races
+    // the shutdown (#3733). Unlink the socket file tmux leaves behind
+    // so per-case sockets don't accumulate in $TMUX_TMPDIR either.
+    const retired = socket;
+    socket = "";
+    if (!retired) return;
+    tmuxOn(retired, ["kill-server"]);
+    try {
+      rmSync(socketPath(retired), { force: true });
+    } catch {
+      /* best effort */
+    }
   });
 
   it("argv-shape pre-check: send-keys -l -t <session> <text> + Enter delivers bytes", async () => {
@@ -107,15 +186,15 @@ describe.skipIf(!TMUX_PRESENT)("inject — real-tmux argv smoke (#728 regression
     const runner = makeTmuxRunner("tmux");
 
     // Sanity: hasSession returns true for a session that exists.
-    expect(runner.hasSession(SOCKET, SESSION)).toBe(true);
+    expect(runner.hasSession(socket, SESSION)).toBe(true);
 
     const payload = "/test-payload";
-    runner.send(SOCKET, SESSION, ["send-keys", "-l", payload]);
-    runner.send(SOCKET, SESSION, ["send-keys", "Enter"]);
+    runner.send(socket, SESSION, ["send-keys", "-l", payload]);
+    runner.send(socket, SESSION, ["send-keys", "Enter"]);
 
     await sleep(300);
 
-    const captured = runner.capture(SOCKET, SESSION) ?? "";
+    const captured = runner.capture(socket, SESSION) ?? "";
 
     // The literal slash payload must appear, with no -t/session
     // contamination glued on.
@@ -124,6 +203,27 @@ describe.skipIf(!TMUX_PRESENT)("inject — real-tmux argv smoke (#728 regression
     expect(captured).not.toContain(`${payload}-t${SESSION}`);
     expect(captured).not.toContain(`${payload} -t ${SESSION}`);
     expect(captured).not.toContain(`${payload}-tinjecttest`);
+  });
+
+  it("fixture isolation: no case reuses a socket generation (#3733)", () => {
+    // Runs last, so `usedSockets` holds every socket this describe has
+    // handed out. Under the pre-#3733 fixture (one module-level socket
+    // shared by every case) this file could not reach here green: the
+    // second case's `beforeEach` would already have failed the
+    // "not previously used" assertion.
+    expect(usedSockets.size).toBe(socketSeq);
+    expect(usedSockets.has(socket)).toBe(true);
+
+    // Every retired socket must be dead — a `beforeEach` that threw, or
+    // a teardown that missed, would leave a server behind, and a stray
+    // server is exactly what a later `new-session` would race.
+    for (const retired of usedSockets) {
+      if (retired === socket) continue;
+      expect(socketIsDead(retired)).toBe(true);
+    }
+
+    // And the live socket is genuinely this case's own server.
+    expect(tmuxOn(socket, ["has-session", "-t", SESSION]).status).toBe(0);
   });
 });
 


### PR DESCRIPTION
Fixes #3733.

## Summary

`src/agents/inject.integration.test.ts` shared one module-level tmux socket name across every case. `afterEach` ran `kill-server`; the next `beforeEach` immediately re-created a session on that same name. `kill-server` returns to the client while the server is still unwinding and unlinking its socket, so under load the next connect lands on a mid-shutdown server and the fixture throws `tmux new-session failed: server exited unexpectedly` before any assertion runs — a false red on `main` (run 30233157446, `vitest-shard (3)`).

Each case now gets its own socket generation (`srtest-<pid>-<t36>-<n>`), so no `new-session` ever addresses a socket name a previous case used. Teardown kills that case's server and unlinks its socket file, so per-case sockets don't accumulate. Assertions, not assumptions:

- `beforeEach` asserts its socket was never handed out before — under the old shared-socket shape this fails from the second case onward.
- A new case asserts the whole-file invariant: all sockets distinct, and every retired socket is dead (bounded poll, so the check itself isn't a fresh race).

## Why the issue's suggested shape was not taken

The issue suggested per-case `kill-session` + one `kill-server` in `afterAll`. Verified against tmux 3.5a: killing a server's **last** session terminates the server too (`tmux -L s kill-session -t x` then `list-sessions` → `no server running`, socket file still on disk). That keeps the identical shutdown race with a different trigger. Distinct sockets remove it by construction.

## Test plan

- `vitest run src/agents/inject.integration.test.ts` → 3 passed, 1 skipped.
- **Guard proves the bug:** re-running the file with only `nextSocket()` neutered back to a shared constant (simulating the pre-fix fixture) fails 2 of 3 cases on the uniqueness assertions. The guard would fail on the bug it protects.
- **Race reproduced and closed at the tmux level**, 8-way CPU load, tmux 3.5a: `kill-server` → `new-session` on the **same** socket = 5/600 failures with the exact `server exited unexpectedly` message; the same sequence with **distinct** socket names = 0/600.
- 30 consecutive full-file runs under the same load: 30 pass, 0 fail.
- `npm run lint` green.

## Risk

Test-only; no `src/` runtime change. `makeTmuxRunner` is exercised exactly as before, just against a per-case socket. Residual: the retired-socket deadness probe polls up to 3s before failing, so a genuinely stray server still reds rather than hanging.

Job spec: `reference/jobs/fleet-stays-healthy.md` — a fixture that reds `main` for reasons unrelated to what it guards costs an investigation each time it fires and erodes trust in the CI signal.