### PR TITLE
fix(hindsight): reserve recall slots per bank, sized to the cap the fleet actually deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -555,6 +555,83 @@ deployment failed **and** the OpenRouter hop did not rescue it. The new signal
 warns at ≥2 % and pages at ≥10 % of hindsight LLM calls failing outright
 (measured today: 0/800). No LiteLLM configuration was touched.
 
+### Recall reserves slots per bank, and injected bank composition is now logged
+
+Auto-recall fans out to the agent's own bank and the sender's profile bank,
+merges the results, sorts them globally by `scores.final` and head-slices at
+`recallMaxMemories` — **6 on this fleet**, from
+`defaults.memory.recall.max_memories` in `switchroom.yaml`, which cascades to
+`HINDSIGHT_RECALL_MAX_MEMORIES` and wins over the 8 stamped into the plugin's
+`settings.json`.
+
+That head-slice is winner-take-all across banks. On a turn where both banks
+return more candidates than the cap, nothing stops one bank's score
+distribution from filling every slot, and the agent is handed a dossier about
+its operator with none of its own session memory.
+
+**Scope, stated plainly: this fixes score-based crowd-out among results that
+did return. It does not fix the own-bank timeout.** A timed-out bank
+contributes zero candidates, so reservation is a strict no-op in exactly that
+case. Measured across 1,036 multi-bank non-cache `recall_log.jsonl` rows on this
+host since 2026-07-20: own-dead / profile-alive is 67.0% of turns (83.5% for
+overlord), own-dead / profile-dead 18.0%, and **both-alive — the only state
+where reservation can act at all — 15.1% fleet-wide, 6.4% for overlord** (6.8%
+once you also require more candidates than the cap). The own-bank timeout is a
+larger, separate defect.
+
+The half of this change that *does* address the majority case is the
+**telemetry**. A fully timed-out own bank still logs `result_count == 6`, which
+every existing dashboard reads as success — that is precisely why the own-bank
+timeout outage hid for weeks. Volume cannot see composition, so
+`recall_log.jsonl` now carries `injected_own_bank_count` and
+`injected_additional_bank_count` (always summing to `result_count`), plus
+`reserved_own_slots` / `reserved_additional_slots` for the slots the floors took
+from global relevance. A result with no stamped source bank counts as
+additional, so the own-bank number is never optimistic. This is the field that
+would have caught the outage.
+
+`recall.py` stamps each merged result with its source bank and reserves slot
+**floors** before the head-slice — `recallOwnBankMinSlots` /
+`recallAdditionalBankMinSlots`, cascading from
+`memory.recall.own_bank_min_slots` / `.additional_bank_min_slots`.
+Switchroom-managed agents get **2 own / 1 additional against the deployed cap of
+6**; the vendor default stays 0/0 (the pre-fix head-slice), which is also the
+rollback lever.
+
+Floors, not quotas — and enforced as such. Each side gets at most its floor,
+only if it returned that many, **and only up to half the cap between them**
+(`_reservable_slots`). The other half is always awarded on pure global
+relevance, so composition still moves with the scores in both directions: at cap
+6 with profile-favoured scores the split is 2 own / 4 profile, with own-favoured
+scores 5 own / 1 profile. Without that headroom the shipped floors would be a
+fixed quota — floors of 4 + 2 at a cap of 6 consume the cap exactly, the
+leftover-fill loop never runs, and `scores.final` has no influence on
+composition on any turn where both banks return. The clamp scales with the cap,
+so the invariant holds at 4, 8 or 12 as well. When the floors exceed that budget
+the own-bank floor is honoured first. Selection is re-sorted by relevance
+afterwards, so reservation changes *which* memories are injected, never the
+order they are presented in.
+
+Both env exports are written **unconditionally** (#3774): `~/.hindsight/
+claude-code.json` survives an apply and loads *after* the plugin's
+`settings.json`, so a conditional export would let a stale hand-edited value
+there shadow what switchroom stamps — silently and permanently. Writing the
+resolved effective value every boot makes the environment, applied last, the
+authority. Same resolution as #3759 / #3760.
+
+Not touched: the fan-out architecture itself. Every agent queries exactly two
+banks in parallel under one shared deadline, `additional_banks` is empty
+fleet-wide, and a slow bank cannot block a fast one. That design is sound; slot
+allocation was the only thing wrong with it.
+
+Tests assert composition, never volume, and the load-bearing ones are
+mutation-checked. Deleting the additional-bank floor, deleting the own-bank
+floor, removing the half-cap clamp, or hardcoding either `reserved_*_slots` to 0
+each fails the suite. The anchor cases pin that with floors off *either* bank
+takes all six slots depending on the score regime, that a fully timed-out own
+bank still logs `result_count == 6` while `injected_own_bank_count` reads 0, and
+that flipping the score regime changes the injected composition — the property
+that distinguishes a floor from a quota.
 
 ## v0.19.24 — `:latest` follows the release, hindsight sizes its LLM calls to the real context window, and a self-echoed reply stops duplicating
 

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -771,6 +771,24 @@ export HINDSIGHT_RECALL_QUERY_STOP_TERMS='{{hindsightRecallQueryStopTermsJson}}'
 # into a skipped assignment — lets a stale hand-written claude-code.json shadow
 # the shipped default with every test still green.
 export HINDSIGHT_RECALL_REQUEST_TIMEOUT_SECONDS={{hindsightRecallRequestTimeoutSeconds}}
+# Per-bank slot FLOORS inside the recall count cap. The merged multi-bank set
+# is sorted globally by relevance then head-sliced, which is winner-take-all
+# across banks: when both banks return more candidates than the cap, one bank's
+# score distribution can fill every slot and the agent gets a dossier about its
+# operator and none of its own session memory. Floors, not quotas — recall.py
+# bounds the two floors to HALF the cap between them, so the rest is always won
+# on pure relevance. Switchroom ships 2 own / 1 additional against the deployed
+# cap of 6; 0/0 restores the pure head-slice.
+#
+# EXPORTED UNCONDITIONALLY (#3774), like the two #3757 knobs above. The resolved
+# effective value (memory.recall.own_bank_min_slots / .additional_bank_min_slots
+# from the cascade, else the shipped default) is always written, because
+# ~/.hindsight/claude-code.json survives an apply and loads AFTER the plugin's
+# settings.json — a conditional export would let a stale hand-edited value there
+# shadow what switchroom stamps, silently and permanently.
+# Observe `injected_own_bank_count` via `switchroom memory recall-log <agent>`.
+export HINDSIGHT_RECALL_OWN_BANK_MIN_SLOTS={{hindsightRecallOwnBankMinSlots}}
+export HINDSIGHT_RECALL_ADDITIONAL_BANK_MIN_SLOTS={{hindsightRecallAdditionalBankMinSlots}}
 # Recall fact types (memory.recall.types cascade). Switchroom default is
 # world,experience,observation (the synthesized `observation` tier is ON
 # by default, set in the plugin settings.json). Export only when the

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3159,6 +3159,24 @@ function resolveHindsightRetainConfig(
 }
 
 /**
+ * Per-bank recall slot floors, switchroom's shipped defaults.
+ *
+ * Sized against the cap this fleet actually deploys — 6, from
+ * `defaults.memory.recall.max_memories` in switchroom.yaml, which cascades to
+ * HINDSIGHT_RECALL_MAX_MEMORIES and wins over the 8 stamped into the plugin's
+ * settings.json. recall.py bounds the two floors to half the cap between them
+ * (`_reservable_slots`), so 2 + 1 is the largest pair that is fully honoured at
+ * cap 6 while still leaving three slots to pure global relevance. Floors that
+ * summed to the cap would stop being floors and become a fixed quota.
+ *
+ * These are also the values exported to the environment unconditionally (see
+ * `start.sh.hbs`) so a stale `~/.hindsight/claude-code.json` — which loads
+ * AFTER the plugin's settings.json — cannot shadow them (#3774).
+ */
+const HINDSIGHT_OWN_BANK_MIN_SLOTS_DEFAULT = 2;
+const HINDSIGHT_ADDITIONAL_BANK_MIN_SLOTS_DEFAULT = 1;
+
+/**
  * Merge switchroom-specific overrides into the vendored hindsight
  * plugin's `settings.json`. Idempotent — runs after every plugin
  * copy on every scaffold/reconcile/restart.
@@ -3170,6 +3188,8 @@ function resolveHindsightRetainConfig(
  *     transcript, re-consolidated per fire; paired with the vendor
  *     retain.py divergence)
  *   - `recallMaxMemories`: 12 → 8 (tighter prompt, less model noise)
+ *   - `recallOwnBankMinSlots` / `recallAdditionalBankMinSlots`: 0/0 → 2/1
+ *     (neither bank can take every slot of the deployed cap of 6)
  *
  * Future overrides go here, NOT in the vendor file. The vendor is
  * third-party code and must remain untouched for clean upstream
@@ -3267,6 +3287,38 @@ function renderHindsightSettingsOverrides(
   // in switchroom.yaml — start.sh exports HINDSIGHT_RECALL_TYPES only when
   // overridden, and the env value wins over this settings.json default.
   settings.recallTypes = ["world", "experience", "observation"];
+  // Per-bank slot FLOORS inside recallMaxMemories. The merged multi-bank set
+  // is sorted globally by `scores.final` and head-sliced, which is
+  // winner-take-all across banks: on a turn where both banks return more
+  // candidates than the cap, one bank's score distribution can fill every slot.
+  // The shared `ken-profile` bank is the side that wins in practice (short,
+  // dense, highly-rerankable statements), so the agent is handed a dossier
+  // about its operator and none of its own session memory.
+  //
+  // Scope, stated honestly: this fixes score-based crowd-out among results that
+  // DID return. It does NOT fix the own-bank timeout — a timed-out bank
+  // contributes no candidates, so reservation is a strict no-op there. Across
+  // 1,036 multi-bank non-cache recalls since 2026-07-20, both banks were alive
+  // on 15.1% of turns fleet-wide (6.4% for overlord); own-dead/profile-alive is
+  // 67.0% (83.5% for overlord). The telemetry shipped alongside this
+  // (`injected_own_bank_count`) is what makes THAT case legible — it is the
+  // field that would have caught the own-bank outage, since a fully timed-out
+  // own bank still logs a full `result_count`.
+  //
+  // 2/1 against the cap this fleet actually deploys — which is 6, not the 8
+  // stamped above: `defaults.memory.recall.max_memories: 6` in switchroom.yaml
+  // cascades to HINDSIGHT_RECALL_MAX_MEMORIES, and env wins over settings.json.
+  // FLOORS, not quotas, and enforced as such: recall.py bounds the two floors to
+  // HALF the cap between them (`_reservable_slots`), so at least three of six
+  // slots are always won on pure relevance and composition still moves with the
+  // scores. Floors that summed to the cap (4+2 at 6) would be a fixed quota with
+  // no score influence at all. Each side also gets its floor only if it returned
+  // that many, so a silent bank wastes nothing. Operators re-tune via
+  // memory.recall.own_bank_min_slots / .additional_bank_min_slots in
+  // switchroom.yaml (0/0 = the pre-fix head-slice). Vendor default is 0/0; this
+  // is the switchroom opt-in.
+  settings.recallOwnBankMinSlots = HINDSIGHT_OWN_BANK_MIN_SLOTS_DEFAULT;
+  settings.recallAdditionalBankMinSlots = HINDSIGHT_ADDITIONAL_BANK_MIN_SLOTS_DEFAULT;
   // Phase 6a: on top of the ack-skip, skip recall on plausibly-stateless
   // trivial turns (time/date/day, bare greetings) — saves the ~1-2s
   // recall arm + up to ~1024 injected tokens on turns that never need
@@ -3459,6 +3511,10 @@ interface BuildWorkspaceContextArgs {
   hindsightRecallQueryMaxTokens: number;
   hindsightRecallQueryStopTermsJson: string;
   hindsightRecallRequestTimeoutSeconds: number;
+  // Always resolved (operator override ?? shipped default) — start.sh exports
+  // these unconditionally so a stale claude-code.json cannot shadow them.
+  hindsightRecallOwnBankMinSlots: number;
+  hindsightRecallAdditionalBankMinSlots: number;
   // Phase 1 / 6a opt-out cascade. Comma-joined types + stringified bool,
   // each undefined unless the operator overrode the switchroom default.
   hindsightRecallTypes?: string;
@@ -3506,6 +3562,8 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     hindsightRecallQueryMaxTokens,
     hindsightRecallQueryStopTermsJson,
     hindsightRecallRequestTimeoutSeconds,
+    hindsightRecallOwnBankMinSlots,
+    hindsightRecallAdditionalBankMinSlots,
     hindsightRecallTypes,
     hindsightRecallSkipTrivial,
     hindsightDirectiveCaptureNudge,
@@ -3592,6 +3650,8 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     hindsightRecallQueryMaxTokens,
     hindsightRecallQueryStopTermsJson,
     hindsightRecallRequestTimeoutSeconds,
+    hindsightRecallOwnBankMinSlots,
+    hindsightRecallAdditionalBankMinSlots,
     hindsightRecallTypes,
     hindsightRecallSkipTrivial,
     hindsightDirectiveCaptureNudge,
@@ -4524,6 +4584,17 @@ export function scaffoldAgent(
   const hindsightRecallRequestTimeoutSeconds =
     agentConfig.memory?.recall?.request_timeout_seconds ??
     HINDSIGHT_RECALL_REQUEST_TIMEOUT_SECONDS_DEFAULT;
+  // Per-bank slot floors inside the count cap. Same cascade, but resolved to
+  // the shipped default rather than left undefined: start.sh exports these
+  // UNCONDITIONALLY (#3774). `~/.hindsight/claude-code.json` survives an apply
+  // and loads AFTER the plugin's settings.json, so a conditional export lets a
+  // stale hand-edited value there shadow what switchroom stamps — silently, and
+  // permanently. Exporting the resolved effective value makes env authoritative.
+  const hindsightRecallOwnBankMinSlots =
+    agentConfig.memory?.recall?.own_bank_min_slots ?? HINDSIGHT_OWN_BANK_MIN_SLOTS_DEFAULT;
+  const hindsightRecallAdditionalBankMinSlots =
+    agentConfig.memory?.recall?.additional_bank_min_slots ??
+    HINDSIGHT_ADDITIONAL_BANK_MIN_SLOTS_DEFAULT;
   // Phase 1 / 6a opt-out: undefined unless the operator overrode the
   // switchroom default (observations on, trivial-skip on). Exported only
   // when set (see start.sh.hbs), so an unset value leaves the on-by-default
@@ -4601,6 +4672,8 @@ export function scaffoldAgent(
     hindsightRecallQueryMaxTokens,
     hindsightRecallQueryStopTermsJson,
     hindsightRecallRequestTimeoutSeconds,
+    hindsightRecallOwnBankMinSlots,
+    hindsightRecallAdditionalBankMinSlots,
     hindsightRecallTypes,
     hindsightRecallSkipTrivial,
     hindsightDirectiveCaptureNudge,
@@ -6976,6 +7049,17 @@ function reconcileAgentInner(
   const hindsightRecallRequestTimeoutSeconds =
     agentConfig.memory?.recall?.request_timeout_seconds ??
     HINDSIGHT_RECALL_REQUEST_TIMEOUT_SECONDS_DEFAULT;
+  // Per-bank slot floors inside the count cap. Same cascade, but resolved to
+  // the shipped default rather than left undefined: start.sh exports these
+  // UNCONDITIONALLY (#3774). `~/.hindsight/claude-code.json` survives an apply
+  // and loads AFTER the plugin's settings.json, so a conditional export lets a
+  // stale hand-edited value there shadow what switchroom stamps — silently, and
+  // permanently. Exporting the resolved effective value makes env authoritative.
+  const hindsightRecallOwnBankMinSlots =
+    agentConfig.memory?.recall?.own_bank_min_slots ?? HINDSIGHT_OWN_BANK_MIN_SLOTS_DEFAULT;
+  const hindsightRecallAdditionalBankMinSlots =
+    agentConfig.memory?.recall?.additional_bank_min_slots ??
+    HINDSIGHT_ADDITIONAL_BANK_MIN_SLOTS_DEFAULT;
   // Phase 1 / 6a opt-out: undefined unless the operator overrode the
   // switchroom default (observations on, trivial-skip on). Exported only
   // when set (see start.sh.hbs), so an unset value leaves the on-by-default
@@ -7077,6 +7161,8 @@ function reconcileAgentInner(
       hindsightRecallQueryMaxTokens,
       hindsightRecallQueryStopTermsJson,
       hindsightRecallRequestTimeoutSeconds,
+      hindsightRecallOwnBankMinSlots,
+      hindsightRecallAdditionalBankMinSlots,
       hindsightRecallTypes,
       hindsightRecallSkipTrivial,
       hindsightDirectiveCaptureNudge,
@@ -7862,6 +7948,8 @@ function reconcileAgentInner(
       hindsightRecallQueryMaxTokens,
       hindsightRecallQueryStopTermsJson,
       hindsightRecallRequestTimeoutSeconds,
+      hindsightRecallOwnBankMinSlots,
+      hindsightRecallAdditionalBankMinSlots,
       hindsightRecallTypes,
       hindsightRecallSkipTrivial,
       hindsightDirectiveCaptureNudge,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -579,6 +579,43 @@ export const AgentMemorySchema = z
             "this is a per-request safety net. Was a hardcoded 8 in the " +
             "plugin before #3757.",
           ),
+        own_bank_min_slots: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            "Slots inside `max_memories` reserved as a FLOOR for the agent's " +
+            "own bank when recall fans out to more than one bank. The merged " +
+            "set is sorted globally by relevance and head-sliced, which is " +
+            "winner-take-all across banks: when both banks return more " +
+            "candidates than the cap, one bank's score distribution can fill " +
+            "every slot and the agent gets a dossier about its operator with " +
+            "none of its own session memory. A floor, not a quota: at most " +
+            "this many slots, only if the own bank returned that many, and " +
+            "only up to HALF the cap shared with `additional_bank_min_slots` " +
+            "— the rest is always won on pure relevance, so composition still " +
+            "moves with the scores. Fixes score-based crowd-out only; a " +
+            "timed-out bank returns no candidates and reservation is a no-op " +
+            "there. 0 disables (default). Switchroom-managed agents use 2 " +
+            "against the fleet-deployed cap of 6.",
+          ),
+        additional_bank_min_slots: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            "Slots inside `max_memories` reserved as a FLOOR for the " +
+            "additional (profile / shared / sender) banks. Symmetric with " +
+            "`own_bank_min_slots` — same floor-not-quota semantics, and the " +
+            "two share the same half-of-cap reservation budget. When they sum " +
+            "above that budget the own-bank floor is honoured first. 0 " +
+            "disables (default). Switchroom-managed agents use 1 against the " +
+            "fleet-deployed cap of 6. Observe `injected_own_bank_count` / " +
+            "`injected_additional_bank_count` via " +
+            "`switchroom memory recall-log`.",
+          ),
         types: z
           .array(z.string())
           .optional()
@@ -2852,6 +2889,8 @@ const profileFields = {
           query_max_tokens: z.number().int().min(0).optional(),
           query_stop_terms: z.array(z.string().min(1).regex(/^[\w./-]+$/)).optional(),
           request_timeout_seconds: z.number().int().min(1).optional(),
+          own_bank_min_slots: z.number().int().min(0).optional(),
+          additional_bank_min_slots: z.number().int().min(0).optional(),
           additional_banks: z.array(z.string()).optional(),
           sender_banks: z.record(z.string(), z.string()).optional(),
         })

--- a/tests/scaffold.recall-observations.test.ts
+++ b/tests/scaffold.recall-observations.test.ts
@@ -91,6 +91,34 @@ describe("hindsight recall overrides — observations + trivial-skip", () => {
     expect(s.recallMinOverlap).toBeUndefined();
   });
 
+  // Per-bank slot reservation. The merged multi-bank set is sorted globally by
+  // relevance and head-sliced, which is winner-take-all across banks: when both
+  // banks return more candidates than the cap, one bank's score distribution
+  // can fill every slot. These floors are the switchroom opt-in over the
+  // vendor's 0/0 (pure head-slice).
+  it("reserves a floor of recall slots for each bank, sized to the DEPLOYED cap", () => {
+    const s = settingsAfterInstall();
+    expect(s.recallOwnBankMinSlots).toBe(2);
+    expect(s.recallAdditionalBankMinSlots).toBe(1);
+    // The cap this fleet actually runs is 6 — `defaults.memory.recall
+    // .max_memories: 6` in switchroom.yaml cascades to
+    // HINDSIGHT_RECALL_MAX_MEMORIES, and env wins over the 8 stamped into
+    // settings.json. recall.py bounds the two floors to HALF the cap between
+    // them (`_reservable_slots`), so floors summing above 3 would be silently
+    // clamped and the stamped numbers would be a lie. Pinning against 6 rather
+    // than against `s.recallMaxMemories` is deliberate: asserting against the
+    // stamped 8 is exactly the mistake that let floors of 4/2 look safe when
+    // at the deployed cap they consumed the whole of it and `scores.final`
+    // stopped influencing composition at all.
+    const DEPLOYED_CAP = 6;
+    expect(
+      (s.recallOwnBankMinSlots as number) + (s.recallAdditionalBankMinSlots as number),
+    ).toBeLessThanOrEqual(Math.floor(DEPLOYED_CAP / 2));
+    // Both floors must be non-zero, or one side can still be zeroed out.
+    expect(s.recallOwnBankMinSlots as number).toBeGreaterThan(0);
+    expect(s.recallAdditionalBankMinSlots as number).toBeGreaterThan(0);
+  });
+
   // #2816 tag-filter port — INTENTIONALLY DORMANT (see the decision comment in
   // renderHindsightSettingsOverrides + reference/rfcs/hindsight-synthesis-
   // layers.md). The scaffold must NOT set any recall tag filter: doing so would

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2649,6 +2649,88 @@ describe("reconcileAgent", () => {
     expect(startSh).toContain("export HINDSIGHT_RECALL_MAX_MEMORIES=5");
   });
 
+  it("start.sh exports the per-bank slot floors UNCONDITIONALLY, with the shipped default when unset", () => {
+    // #3774. These two exports are deliberately NOT gated on an operator
+    // override, unlike the recall knobs above. `~/.hindsight/claude-code.json`
+    // survives an apply and loads AFTER the plugin's settings.json (see
+    // vendor/hindsight-memory/scripts/lib/config.py `load_config`), so a
+    // conditional export lets a stale hand-edited value there shadow what
+    // switchroom stamps — silently, permanently, and with every test green.
+    // Writing the resolved effective value on every boot makes env, which is
+    // applied last, the authority. This is the same resolution mandated on
+    // #3759 / #3760.
+    //
+    // What this pins is the OUTCOME — a rendered export carrying the effective
+    // value on an agent with no override. The load-bearing half of the
+    // mechanism is the `?? DEFAULT` resolution in scaffold.ts: drop it and
+    // `undefined` reaches the template, the line renders as a bare
+    // `...MIN_SLOTS=`, `_cast_env("", int)` returns None, the assignment is
+    // skipped, and claude-code.json wins again — mutation-verified, this test
+    // fails on exactly that. Re-adding a `{{#if (isNumber ...)}}` wrapper is,
+    // on its own, behaviour-preserving *because* of that resolution (the value
+    // is never undefined, so the guard is inert), so no test can honestly claim
+    // to catch it alone; what must never regress is the pair, and a missing
+    // export fails the assertions below.
+    const agentConfig = makeAgentConfig();
+    const withMemory = buildSwitchroomConfig(agentConfig, {
+      backend: "hindsight",
+      shared_collection: "shared",
+      config: { provider: "openai", docker_service: true, url: "http://127.0.0.1:18888/mcp/" },
+    });
+    scaffoldAgent("test-agent", agentConfig, tmpDir, telegramConfig, withMemory);
+
+    const startSh = readFileSync(join(tmpDir, "test-agent", "start.sh"), "utf-8");
+    expect(startSh).toContain("export HINDSIGHT_RECALL_OWN_BANK_MIN_SLOTS=2");
+    expect(startSh).toContain("export HINDSIGHT_RECALL_ADDITIONAL_BANK_MIN_SLOTS=1");
+    // And never an empty assignment: `_cast_env("", int)` returns None, the
+    // assignment is skipped, and claude-code.json wins again — the exact
+    // failure mode this test exists to prevent.
+    expect(startSh).not.toContain("export HINDSIGHT_RECALL_OWN_BANK_MIN_SLOTS=\n");
+    expect(startSh).not.toContain("export HINDSIGHT_RECALL_ADDITIONAL_BANK_MIN_SLOTS=\n");
+  });
+
+  it("start.sh exports the per-bank slot floors when the operator overrides them", () => {
+    const agentConfig = makeAgentConfig({
+      memory: {
+        collection: "test-agent",
+        recall: { own_bank_min_slots: 5, additional_bank_min_slots: 1 },
+      },
+    });
+    const withMemory = buildSwitchroomConfig(agentConfig, {
+      backend: "hindsight",
+      shared_collection: "shared",
+      config: { provider: "openai", docker_service: true, url: "http://127.0.0.1:18888/mcp/" },
+    });
+    scaffoldAgent("test-agent", agentConfig, tmpDir, telegramConfig, withMemory);
+
+    const startSh = readFileSync(join(tmpDir, "test-agent", "start.sh"), "utf-8");
+    expect(startSh).toContain("export HINDSIGHT_RECALL_OWN_BANK_MIN_SLOTS=5");
+    expect(startSh).toContain("export HINDSIGHT_RECALL_ADDITIONAL_BANK_MIN_SLOTS=1");
+  });
+
+  it("start.sh exports a slot floor of 0 — the reservation kill-switch, not 'unset'", () => {
+    // 0 disables reservation for that side and restores the pure head-slice.
+    // It must survive the `?? default` resolution rather than being replaced
+    // as nullish/falsy, or an operator's rollback silently leaves the floor in
+    // force.
+    const agentConfig = makeAgentConfig({
+      memory: {
+        collection: "test-agent",
+        recall: { own_bank_min_slots: 0, additional_bank_min_slots: 0 },
+      },
+    });
+    const withMemory = buildSwitchroomConfig(agentConfig, {
+      backend: "hindsight",
+      shared_collection: "shared",
+      config: { provider: "openai", docker_service: true, url: "http://127.0.0.1:18888/mcp/" },
+    });
+    scaffoldAgent("test-agent", agentConfig, tmpDir, telegramConfig, withMemory);
+
+    const startSh = readFileSync(join(tmpDir, "test-agent", "start.sh"), "utf-8");
+    expect(startSh).toContain("export HINDSIGHT_RECALL_OWN_BANK_MIN_SLOTS=0");
+    expect(startSh).toContain("export HINDSIGHT_RECALL_ADDITIONAL_BANK_MIN_SLOTS=0");
+  });
+
   it("start.sh exports HINDSIGHT_RECALL_MAX_MEMORIES=0 when operator explicitly disables the cap", () => {
     // 0 is a meaningful sentinel ("uncapped"), not the same as unset.
     // The template uses an isNumber helper specifically so 0 still

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -29,6 +29,23 @@ DEFAULTS = {
     # formatting. Set to 0 (or any non-positive value) to disable the cap
     # and inject everything Hindsight returns.
     "recallMaxMemories": 12,
+    # Switchroom-local: per-bank slot FLOORS inside `recallMaxMemories`. The
+    # merged multi-bank set is sorted globally by `scores.final` and then
+    # head-sliced, which is winner-take-all across banks: when both banks return
+    # more candidates than the cap, one bank's score distribution can fill every
+    # slot and the agent gets a dossier about its operator with none of its own
+    # working memory. These are FLOORS, not quotas: each side gets at most this
+    # many slots, only if it has that many results, and only up to HALF the cap
+    # between them — the other half is always awarded on pure global relevance,
+    # so composition still moves with the scores. 0 disables reservation for
+    # that side (the pure pre-fix head-slice). Env:
+    # HINDSIGHT_RECALL_OWN_BANK_MIN_SLOTS /
+    # HINDSIGHT_RECALL_ADDITIONAL_BANK_MIN_SLOTS. See recall.py's
+    # `_reserve_bank_slots` and `_reservable_slots`. Vendor default is 0/0
+    # (off); switchroom's scaffold opts in with 2 own / 1 additional against the
+    # cap of 6 its fleet actually deploys.
+    "recallOwnBankMinSlots": 0,
+    "recallAdditionalBankMinSlots": 0,
     "recallTypes": ["world", "experience"],
     # Switchroom-local: when True (default; Ken-approved ON) recall biases
     # toward synthesized `observation`-tier facts. Escape hatch: pin off via
@@ -302,6 +319,11 @@ ENV_OVERRIDES = {
     # agents.<name>.memory.recall.max_memories (cascading through
     # defaults.memory.recall.max_memories) when present in switchroom.yaml.
     "HINDSIGHT_RECALL_MAX_MEMORIES": ("recallMaxMemories", int),
+    # Switchroom-local: per-bank slot floors inside the count cap. Set by
+    # start.sh from agents.<name>.memory.recall.own_bank_min_slots /
+    # .additional_bank_min_slots (cascading through defaults). 0 = off.
+    "HINDSIGHT_RECALL_OWN_BANK_MIN_SLOTS": ("recallOwnBankMinSlots", int),
+    "HINDSIGHT_RECALL_ADDITIONAL_BANK_MIN_SLOTS": ("recallAdditionalBankMinSlots", int),
     # Switchroom-local: recall fact types (comma-separated). Set by start.sh
     # from agents.<name>.memory.recall.types only when the operator overrode
     # the switchroom default (world,experience,observation) — i.e. the

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -596,6 +596,174 @@ def _sort_by_final_score(results):
     return results
 
 
+# Key stamped onto every merged result naming the bank it came from. Private to
+# recall.py (leading underscore) and never rendered: `format_memories`
+# (lib/content.py:294) reads only `text` / `type` / `mentioned_at`, so an extra
+# key cannot leak into the injected `<hindsight_memories>` block.
+SOURCE_BANK_KEY = "_source_bank"
+
+
+def _tag_source_bank(bank_results, bank_id):
+    """Stamp `SOURCE_BANK_KEY` onto each result so slot reservation can tell
+    own-bank memories from additional-bank (profile / shared / sender) ones
+    after the global relevance sort has interleaved them.
+
+    Returns the same list. Non-dict entries are skipped rather than raising:
+    a malformed engine response must not take recall down.
+    """
+    for m in bank_results:
+        if isinstance(m, dict):
+            m[SOURCE_BANK_KEY] = bank_id
+    return bank_results
+
+
+def _reservable_slots(cap):
+    """How many of `cap` slots the per-bank floors may claim between them.
+
+    HALF the cap, rounded down. The other half is always awarded on pure global
+    relevance, and that headroom is what keeps these FLOORS rather than a fixed
+    quota. Without it the mechanism silently inverts at small caps: this fleet
+    runs `defaults.memory.recall.max_memories: 6` (switchroom.yaml — it cascades
+    to HINDSIGHT_RECALL_MAX_MEMORIES, which wins over the 8 stamped into the
+    plugin's settings.json), so floors of 4+2 would consume the entire cap,
+    `scores.final` would have no influence on composition on any turn where both
+    banks return, and the injected set would be a constant 4/2 split regardless
+    of relevance.
+
+    Scaling with the cap rather than clamping against a hardcoded 6 means the
+    invariant holds for any operator cap: at 6 the floors may claim 3, at 12 six,
+    at 4 two, at 1 none (reservation is simply off below cap 2).
+    """
+    if not isinstance(cap, int) or cap <= 0:
+        return 0
+    return cap // 2
+
+
+def _reserve_bank_slots(results, cap, own_bank_id, own_floor, additional_floor):
+    """Head-slice `results` to `cap`, guaranteeing a minimum number of slots to
+    the agent's OWN bank and to the additional (profile / shared / sender) banks.
+
+    Switchroom — profile-bank crowd-out fix. `_sort_by_final_score` above sorts
+    the merged multi-bank set by `scores.final` and the caller then head-slices
+    at `recallMaxMemories`. On a turn where BOTH banks return more candidates
+    than the cap, that head-slice is winner-take-all across banks: nothing stops
+    one bank's score distribution from filling every slot, and the shared
+    `ken-profile` bank's facts routinely outscore the agent's own working memory
+    because a profile bank is dense with short, highly-rerankable statements.
+    The result is an agent handed a dossier about its operator and none of its
+    own session memory.
+
+    Scope, precisely — this fixes score-based crowd-out among results that DID
+    return. It does NOT fix the own-bank timeout: a timed-out bank contributes
+    zero candidates, so `own_take` is 0 and reservation is a strict no-op there.
+    Measured across 1,036 multi-bank non-cache recalls on this host since
+    2026-07-20: own-dead/additional-alive is 67.0% of turns (83.5% for
+    overlord), and both-alive — the only state where reservation can act at all
+    — is 15.1% fleet-wide, 6.4% for overlord (6.8% once you also require more
+    candidates than the cap). The own-bank timeout is a separate, larger defect;
+    the `injected_own_bank_count` telemetry added alongside this is what makes
+    it legible per-turn.
+
+    Floors, not quotas, and enforced as such. Each side is guaranteed AT MOST
+    `floor` slots, only if it actually has that many results, and only up to
+    `_reservable_slots(cap)` (half the cap) between them; every other slot is
+    filled from the remaining candidates in pure global-relevance order. So at
+    the fleet's deployed cap of 6 with the shipped floors 2/1:
+
+      * own returns 10, profile returns 10  -> 2 own + 4 profile (profile-favoured
+                                              scores; own is never zeroed)
+      * own returns 10, profile returns 10  -> 5 own + 1 profile (own-favoured
+                                              scores; profile is never zeroed)
+      * own returns 0,  profile returns 10  -> 6 profile (no wasted slots)
+      * own returns 10, profile returns 0   -> 6 own      (no wasted slots)
+      * own returns 1,  profile returns 10  -> 1 own + 5 profile
+
+    Composition still moves with `scores.final` in both directions — that is the
+    property the half-cap headroom buys and the property a quota would destroy.
+
+    A floor of 0 disables reservation for that side. `cap <= 0` disables the cap
+    entirely (upstream contract) and is a passthrough here. When the floors sum
+    above the reservable half the OWN floor is honoured first — the crowd-out
+    being fixed is one-directional, and the agent's own memory is the side that
+    loses today.
+
+    Selection is stable and the returned list is re-sorted by relevance, so
+    reservation changes WHICH memories are injected, never the order they are
+    presented in. Returns `(selected, reserved_own, reserved_additional)` where
+    the two counts are the slots that would NOT have been won on global score
+    alone — i.e. the observable effect of this function, logged as telemetry.
+    """
+    if not isinstance(cap, int) or cap <= 0 or len(results) <= cap:
+        return results, 0, 0
+
+    baseline_ids = {id(m) for m in results[:cap]}
+
+    own = [m for m in results if _source_bank_of(m) == own_bank_id]
+    additional = [m for m in results if _source_bank_of(m) != own_bank_id]
+
+    # Floors compete for the reservable half only — never for the whole cap.
+    reservable = _reservable_slots(cap)
+    own_take = max(0, min(int(own_floor or 0), len(own), reservable))
+    additional_take = max(
+        0, min(int(additional_floor or 0), len(additional), reservable - own_take)
+    )
+
+    reserved = own[:own_take] + additional[:additional_take]
+    reserved_ids = {id(m) for m in reserved}
+
+    remaining = cap - len(reserved)
+    if remaining > 0:
+        for m in results:
+            if id(m) in reserved_ids:
+                continue
+            reserved.append(m)
+            reserved_ids.add(id(m))
+            remaining -= 1
+            if remaining == 0:
+                break
+
+    _sort_by_final_score(reserved)
+
+    promoted_own = sum(
+        1 for m in reserved if id(m) not in baseline_ids and _source_bank_of(m) == own_bank_id
+    )
+    promoted_additional = sum(
+        1 for m in reserved if id(m) not in baseline_ids and _source_bank_of(m) != own_bank_id
+    )
+    return reserved, promoted_own, promoted_additional
+
+
+def _injected_bank_composition(results, own_bank_id) -> dict:
+    """Own-bank / additional-bank split of the INJECTED set (post-head-slice).
+
+    Returns ``{"injected_own_bank_count", "injected_additional_bank_count"}``.
+    The two always sum to ``result_count``; results with no stamped source bank
+    (only possible from a cached row or a malformed engine response) count as
+    additional, so the own-bank number is never optimistic.
+    """
+    try:
+        own = sum(1 for m in results or [] if _source_bank_of(m) == own_bank_id)
+        return {
+            "injected_own_bank_count": own,
+            "injected_additional_bank_count": len(results or []) - own,
+        }
+    except Exception:
+        # Telemetry must never take recall down.
+        return {
+            "injected_own_bank_count": None,
+            "injected_additional_bank_count": None,
+        }
+
+
+def _source_bank_of(m):
+    """Read a result's stamped source bank, or None when absent/malformed."""
+    if isinstance(m, dict):
+        v = m.get(SOURCE_BANK_KEY)
+        if isinstance(v, str):
+            return v
+    return None
+
+
 def _is_timeout_error(exc: BaseException) -> bool:
     """True if `exc` is (or wraps) a network read/connect timeout.
 
@@ -1515,6 +1683,13 @@ def main():
                 "injected_score_min": None,
                 "injected_score_median": None,
                 "injected_score_max": None,
+                # Bank-composition telemetry — present for a uniformly queryable
+                # schema. Same reason as the score fields above: a cache hit
+                # replays a formatted block, not a per-bank result set.
+                "injected_own_bank_count": None,
+                "injected_additional_bank_count": None,
+                "reserved_own_slots": None,
+                "reserved_additional_slots": None,
                 "cache_hit": True,
                 # A3 stage-1 telemetry keys kept present for a uniformly
                 # queryable schema; a cache hit issues no bank HTTP, so there
@@ -1811,7 +1986,7 @@ def main():
                 )
                 if bank_results:
                     debug_log(config, f"Got {len(bank_results)} memories from bank '{b_id}'")
-                    results = results + bank_results
+                    results = results + _tag_source_bank(bank_results, b_id)
             elif b_outcome.error is not None:
                 # Own bank failure surfaces on stderr (journald signal); extra
                 # banks are debug-only, matching the pre-A3 serial behaviour.
@@ -1880,7 +2055,7 @@ def main():
                 bank_results = response.get("results", []) if isinstance(response, dict) else []
                 if bank_results:
                     debug_log(config, f"Got {len(bank_results)} memories from bank '{b_id}'")
-                    results = results + bank_results
+                    results = results + _tag_source_bank(bank_results, b_id)
             except Exception as e:
                 _bank_timed_out = _is_timeout_error(e)
                 # Non-timeout error → hard outage (see parallel-path note above).
@@ -1980,6 +2155,8 @@ def main():
     recall_max_memories = config.get("recallMaxMemories", 0)
     pre_cap_count = len(results)
     capped = False
+    reserved_own = 0
+    reserved_additional = 0
     if (
         isinstance(recall_max_memories, int)
         and recall_max_memories > 0
@@ -1990,7 +2167,29 @@ def main():
             f"Capping {len(results)} memories to {recall_max_memories} "
             f"(set HINDSIGHT_RECALL_MAX_MEMORIES=0 to disable)",
         )
-        results = results[:recall_max_memories]
+        # Switchroom — per-bank slot reservation. Head-slicing a globally sorted
+        # merged set is winner-take-all across banks: when both banks return more
+        # candidates than the cap, one bank's score distribution can fill every
+        # slot and the agent's own working memory is crowded out entirely.
+        # Guarantee a floor to each side (bounded to half the cap) before the
+        # remaining slots go to pure global relevance. This addresses score-based
+        # crowd-out only — a timed-out bank contributes no candidates and
+        # reservation is a no-op there; see _reserve_bank_slots for the measured
+        # share of turns it can bind on. Floors of 0/0 restore the head-slice.
+        results, reserved_own, reserved_additional = _reserve_bank_slots(
+            results,
+            recall_max_memories,
+            bank_id,
+            config.get("recallOwnBankMinSlots", 0),
+            config.get("recallAdditionalBankMinSlots", 0),
+        )
+        if reserved_own or reserved_additional:
+            debug_log(
+                config,
+                f"Bank slot reservation promoted {reserved_own} own-bank / "
+                f"{reserved_additional} additional-bank memories over "
+                f"higher-scoring ones",
+            )
         capped = True
 
     memories_block = None
@@ -2146,6 +2345,19 @@ def main():
         # alone can't distinguish "reranker is working" from "8 mediocre
         # memories per turn" now that the overlap gate is near-passthrough.
         **_injected_score_stats(results),
+        # Switchroom — injected BANK COMPOSITION. `result_count` above is a
+        # volume signal and cannot distinguish "6 own-bank memories" from "6
+        # profile-bank memories because the own bank timed out", which is
+        # exactly how the own-bank timeout outage stayed invisible for weeks:
+        # a fully-timed-out own bank still logged result_count == cap. These
+        # two counts always sum to `result_count`, so an own-bank collapse is
+        # readable off the log row without joining `bank_timings`.
+        **_injected_bank_composition(results, bank_id),
+        # Slots the reservation floors handed to a side that would have lost
+        # them on global relevance alone — the observable effect of
+        # `_reserve_bank_slots` (0/0 when the floors are off or non-binding).
+        "reserved_own_slots": reserved_own,
+        "reserved_additional_slots": reserved_additional,
         "cache_hit": False,
         # Switchroom A3 stage-1 telemetry (hindsight-leverage PR 1) — per-bank
         # latency + timeout breakdown, directives-fetch latency, total

--- a/vendor/hindsight-memory/scripts/tests/test_recall_bank_slots.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_bank_slots.py
@@ -1,0 +1,509 @@
+"""Switchroom — per-bank slot reservation inside the recall count cap.
+
+The bug these tests guard is compositional, not volumetric. Recall fans out to
+the agent's OWN bank and the sender's profile bank, merges the results, sorts
+them globally by ``scores.final`` and head-slices at ``recallMaxMemories``. That
+head-slice is winner-take-all across banks: on a turn where both banks return
+more candidates than the cap, one bank's score distribution can fill every slot,
+and the agent is handed a dossier about its operator with none of its own
+session memory.
+
+Scope, stated the way the code states it: this is score-based crowd-out among
+results that DID return. A timed-out bank contributes zero candidates, so
+reservation is a strict no-op there — the own-bank timeout is a separate defect,
+and the composition telemetry asserted below (``injected_own_bank_count``) is
+what makes THAT one legible per-turn, since a fully timed-out own bank still
+logs a full ``result_count``.
+
+Two properties are load-bearing and each has a test that fails without it:
+
+  * the floors bind — neither bank can be zeroed out when it returned results;
+  * the floors are FLOORS — they may claim at most half the cap between them,
+    so ``scores.final`` still decides the rest and composition still moves when
+    the score regime flips. Floors summing to the cap (4+2 at the fleet's
+    deployed cap of 6) would be a fixed quota with no score influence at all.
+
+So every test here asserts COMPOSITION (which bank the injected memories came
+from), never just a count. A test that passes when all six injected memories
+come from the profile bank is not a test for this bug.
+
+Stdlib-only (unittest + mock); runs under ``python3 -m unittest discover
+tests/``. Harness mirrors ``test_recall_integration.py``.
+"""
+
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import recall  # noqa: E402
+
+OWN = "test-bank"
+PROFILE = "ken-profile"
+
+# Switchroom's shipped floors, sized against the cap the fleet actually deploys
+# (`defaults.memory.recall.max_memories: 6`, which cascades to
+# HINDSIGHT_RECALL_MAX_MEMORIES and wins over the 8 in settings.json). Kept as
+# named constants so a change to the shipped pair has to come here too.
+SHIPPED_CAP = 6
+SHIPPED_OWN_FLOOR = 2
+SHIPPED_ADDITIONAL_FLOOR = 1
+
+
+def _memory(text, score, mem_id=None):
+    """A recall result carrying the engine's combined relevance score."""
+    return {
+        "text": text,
+        "type": "fact",
+        "mentioned_at": "2026-01-01",
+        "id": mem_id or text,
+        "scores": {"final": score},
+    }
+
+
+class _PerBankClient:
+    """Fake HindsightClient returning a different result set per bank."""
+
+    def __init__(self, per_bank, directives=None, bank_exc=None):
+        self._per_bank = per_bank
+        self._directives = directives or []
+        self._bank_exc = bank_exc or {}
+
+    def list_directives(self, bank_id, active_only=True, timeout=2):
+        return {"items": list(self._directives)}
+
+    def recall(self, bank_id, query, **kwargs):
+        exc = self._bank_exc.get(bank_id)
+        if exc is not None:
+            raise exc
+        # Deep-ish copy: main() stamps a private source-bank key onto results,
+        # and a shared list would leak that between calls.
+        return {"results": [dict(m) for m in self._per_bank.get(bank_id, [])]}
+
+
+def _run_main_with(client, prompt="what did we decide", config_extra=None):
+    hook_input = {
+        "prompt": prompt,
+        "session_id": "test-session",
+        "transcript_path": "",
+        "cwd": "/tmp",
+    }
+    config = {
+        "autoRecall": True,
+        "bankId": OWN,
+        "recallMaxTokens": 1024,
+        "recallBudget": "mid",
+        "recallContextTurns": 1,
+        "recallMaxQueryChars": 800,
+        "recallPromptPreamble": "",
+        "directivesCacheTtlSeconds": 0,
+        "recallAdditionalBanks": [PROFILE],
+    }
+    if config_extra:
+        config.update(config_extra)
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with patch.object(recall, "load_config", return_value=config), patch.object(
+        recall, "get_api_url", return_value="http://localhost:18888"
+    ), patch.object(recall, "HindsightClient", return_value=client), patch.object(
+        recall, "ensure_bank_mission", return_value=None
+    ), patch.object(recall, "write_state", return_value=None), patch(
+        "sys.stdin", new=io.StringIO(json.dumps(hook_input))
+    ), patch("sys.stdout", new=stdout), patch("sys.stderr", new=stderr):
+        recall.main()
+
+    raw = stdout.getvalue()
+    if not raw.strip():
+        return None, raw
+    return json.loads(raw)["hookSpecificOutput"]["additionalContext"], raw
+
+
+class ReserveBankSlotsUnitTests(unittest.TestCase):
+    """`_reserve_bank_slots` in isolation."""
+
+    @staticmethod
+    def _mk(bank, n, base):
+        return [
+            dict(_memory(f"{bank}-{i}", base - i * 0.001), **{recall.SOURCE_BANK_KEY: bank})
+            for i in range(n)
+        ]
+
+    def _select(
+        self,
+        own_n,
+        add_n,
+        cap=SHIPPED_CAP,
+        own_floor=SHIPPED_OWN_FLOOR,
+        add_floor=SHIPPED_ADDITIONAL_FLOOR,
+        favour=PROFILE,
+    ):
+        """Run the real `_reserve_bank_slots` under a chosen score regime.
+
+        `favour` picks which bank's candidates outrank the other's end to end.
+        Both regimes matter: the crowd-out this fixes is symmetric in the code
+        even though the profile-favoured direction is the one seen in
+        production, and a suite that only ever ranks profile above own cannot
+        tell a working additional-bank floor from a missing one.
+        """
+        hi, lo = (0.9, 0.5) if favour == PROFILE else (0.5, 0.9)
+        merged = self._mk(PROFILE, add_n, hi) + self._mk(OWN, own_n, lo)
+        recall._sort_by_final_score(merged)
+        sel, r_own, r_add = recall._reserve_bank_slots(
+            merged, cap, OWN, own_floor, add_floor
+        )
+        banks = [m[recall.SOURCE_BANK_KEY] for m in sel]
+        return sel, banks.count(OWN), banks.count(PROFILE), r_own, r_add
+
+    def test_profile_bank_cannot_take_every_slot(self):
+        """THE BUG. Profile outranks own on every candidate; without floors the
+        head-slice hands it all six slots."""
+        merged = self._mk(PROFILE, 10, 0.9) + self._mk(OWN, 10, 0.5)
+        recall._sort_by_final_score(merged)
+        baseline, _, _ = recall._reserve_bank_slots(merged, SHIPPED_CAP, OWN, 0, 0)
+        self.assertEqual(
+            [m[recall.SOURCE_BANK_KEY] for m in baseline].count(OWN),
+            0,
+            "precondition: with floors off the profile bank takes all six slots",
+        )
+
+        _, own_n, add_n, r_own, r_add = self._select(10, 10)
+        self.assertEqual(own_n, 2, "own bank must keep its reserved floor")
+        self.assertEqual(add_n, 4, "the non-reserved slots still go to relevance")
+        self.assertEqual(r_own, 2, "both own slots were won by reservation")
+        self.assertEqual(r_add, 0)
+
+    def test_own_bank_cannot_take_every_slot_either(self):
+        """B2 anchor — the ADDITIONAL floor, in the score regime where it is the
+        only thing standing between the profile bank and zero slots.
+
+        Own outranks profile on every candidate here, so the head-slice and the
+        own floor both point the same way; delete `additional_take` and the
+        profile bank gets nothing. This is the mirror of the test above and the
+        one the original suite was missing.
+        """
+        merged = self._mk(PROFILE, 10, 0.5) + self._mk(OWN, 10, 0.9)
+        recall._sort_by_final_score(merged)
+        baseline, _, _ = recall._reserve_bank_slots(merged, SHIPPED_CAP, OWN, 0, 0)
+        self.assertEqual(
+            [m[recall.SOURCE_BANK_KEY] for m in baseline].count(PROFILE),
+            0,
+            "precondition: with floors off the own bank takes all six slots",
+        )
+
+        _, own_n, add_n, r_own, r_add = self._select(10, 10, favour=OWN)
+        self.assertEqual(
+            add_n,
+            SHIPPED_ADDITIONAL_FLOOR,
+            "additional-bank floor did not bind — the profile bank was zeroed",
+        )
+        self.assertEqual(own_n, 5)
+        self.assertEqual(
+            r_add,
+            SHIPPED_ADDITIONAL_FLOOR,
+            "the profile slot was won by reservation, not by score",
+        )
+        self.assertEqual(r_own, 0)
+
+    def test_scores_still_decide_composition_at_the_deployed_cap(self):
+        """B1 anchor — floors that consume the whole cap are not floors.
+
+        At the fleet's deployed cap of 6, floors of 4/2 would sum to the cap:
+        `remaining` would be 0, the global-relevance fill loop would never run,
+        and every turn where both banks return would produce the identical 4/2
+        split no matter what `scores.final` said. `_reservable_slots` bounds the
+        floors to half the cap, so composition still moves with the scores —
+        asserted here for BOTH the shipped 2/1 and an operator's oversized 4/2.
+        """
+        for own_floor, add_floor in ((SHIPPED_OWN_FLOOR, SHIPPED_ADDITIONAL_FLOOR), (4, 2)):
+            with self.subTest(floors=(own_floor, add_floor)):
+                _, own_hi, _, _, _ = self._select(
+                    10, 10, own_floor=own_floor, add_floor=add_floor, favour=OWN
+                )
+                _, own_lo, _, _, _ = self._select(
+                    10, 10, own_floor=own_floor, add_floor=add_floor, favour=PROFILE
+                )
+                self.assertGreater(
+                    own_hi,
+                    own_lo,
+                    "composition is identical across score regimes — the floors "
+                    "have become a fixed quota and scores.final is inert",
+                )
+
+    def test_floors_never_claim_more_than_half_the_cap(self):
+        """The headroom invariant itself, across caps. At least ceil(cap/2)
+        slots are always awarded on pure global relevance, so an oversized floor
+        pair can never turn into a quota at any cap an operator picks."""
+        for cap in (2, 4, 6, 8, 12):
+            with self.subTest(cap=cap):
+                # Floors far larger than the cap, i.e. the worst case.
+                _, own_n, add_n, r_own, r_add = self._select(
+                    20, 20, cap=cap, own_floor=99, add_floor=99
+                )
+                self.assertEqual(own_n + add_n, cap)
+                self.assertLessEqual(
+                    r_own + r_add,
+                    cap // 2,
+                    "reservation claimed more than half the cap",
+                )
+
+    def test_floor_is_not_a_quota_when_own_bank_is_silent(self):
+        """A timed-out own bank must not waste its reserved slots."""
+        _, own_n, add_n, _, _ = self._select(0, 10)
+        self.assertEqual(own_n, 0)
+        self.assertEqual(add_n, 6, "unclaimed own slots go to the profile bank")
+
+    def test_floor_is_not_a_quota_when_profile_bank_is_silent(self):
+        _, own_n, add_n, _, _ = self._select(10, 0)
+        self.assertEqual(own_n, 6)
+        self.assertEqual(add_n, 0)
+
+    def test_partial_own_results_take_only_what_they_have(self):
+        _, own_n, add_n, _, _ = self._select(1, 10)
+        self.assertEqual(own_n, 1)
+        self.assertEqual(add_n, 5)
+
+    def test_zero_floors_are_the_pre_fix_head_slice(self):
+        _, own_n, add_n, r_own, r_add = self._select(10, 10, own_floor=0, add_floor=0)
+        self.assertEqual(own_n, 0)
+        self.assertEqual(add_n, 6)
+        self.assertEqual((r_own, r_add), (0, 0))
+
+    def test_own_floor_wins_when_floors_exceed_the_reservation_budget(self):
+        """Floors of 4/2 against a cap of 4 can't both be honoured. The own
+        floor takes the whole reservation budget (half the cap = 2) and the
+        additional floor gets nothing — but the other two slots are still
+        awarded on relevance, so the profile bank is not shut out."""
+        _, own_n, add_n, _, _ = self._select(10, 10, cap=4, own_floor=4, add_floor=2)
+        self.assertEqual(own_n, 2, "own floor clamped to the reservation budget")
+        self.assertEqual(add_n, 2, "the remaining half went to global relevance")
+
+    def test_selection_is_returned_in_relevance_order(self):
+        """Reservation changes WHICH memories are injected, never the order."""
+        sel, _, _, _, _ = self._select(10, 10)
+        scores = [recall._result_final_score(m) for m in sel]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_no_cap_is_passthrough(self):
+        merged = self._mk(PROFILE, 3, 0.9) + self._mk(OWN, 3, 0.5)
+        sel, r_own, r_add = recall._reserve_bank_slots(merged, 0, OWN, 4, 2)
+        self.assertEqual(len(sel), 6)
+        self.assertEqual((r_own, r_add), (0, 0))
+
+    def test_result_set_smaller_than_cap_is_passthrough(self):
+        merged = self._mk(PROFILE, 2, 0.9) + self._mk(OWN, 2, 0.5)
+        sel, r_own, r_add = recall._reserve_bank_slots(merged, 6, OWN, 4, 2)
+        self.assertEqual(len(sel), 4)
+        self.assertEqual((r_own, r_add), (0, 0))
+
+    def test_no_duplicates_and_exact_cap(self):
+        _, own_n, add_n, _, _ = self._select(10, 10)
+        self.assertEqual(own_n + add_n, 6)
+        sel, _, _, _, _ = self._select(10, 10)
+        self.assertEqual(len({id(m) for m in sel}), 6)
+
+    def test_untagged_results_count_as_additional(self):
+        """A result with no stamped source bank must never be credited to the
+        own bank — the own-bank number is never optimistic."""
+        merged = [_memory(f"untagged-{i}", 0.9 - i * 0.01) for i in range(10)]
+        sel, r_own, _ = recall._reserve_bank_slots(merged, 6, OWN, 4, 2)
+        self.assertEqual(len(sel), 6)
+        self.assertEqual(r_own, 0)
+        self.assertEqual(
+            recall._injected_bank_composition(sel, OWN)["injected_own_bank_count"], 0
+        )
+
+
+class _LogTestBase(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp(prefix="recall-slots-test-")
+        self._prev = os.environ.get("CLAUDE_PLUGIN_DATA")
+        os.environ["CLAUDE_PLUGIN_DATA"] = self._tmpdir
+
+    def tearDown(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        if self._prev is None:
+            os.environ.pop("CLAUDE_PLUGIN_DATA", None)
+        else:
+            os.environ["CLAUDE_PLUGIN_DATA"] = self._prev
+
+    def _read_log(self):
+        path = os.path.join(self._tmpdir, "state", "recall_log.jsonl")
+        if not os.path.isfile(path):
+            return []
+        with open(path, encoding="utf-8") as f:
+            return [json.loads(line) for line in f if line.strip()]
+
+
+class SlotReservationIntegrationTests(_LogTestBase):
+    """Wired through main(): the injected block itself must carry own-bank
+    memories, not just the right count of memories."""
+
+    # Every profile memory outranks every own memory — the production shape.
+    PROFILE_MEMS = [_memory(f"profile-fact-{i}", 0.99 - i * 0.001) for i in range(10)]
+    OWN_MEMS = [_memory(f"own-fact-{i}", 0.5 - i * 0.001) for i in range(10)]
+    # The inverted regime. Not hypothetical — `scores.final` is a per-query
+    # rerank, so which bank leads flips with the prompt. It is also the only
+    # regime in which the ADDITIONAL floor is load-bearing.
+    OWN_MEMS_HIGH = [_memory(f"own-fact-{i}", 0.99 - i * 0.001) for i in range(10)]
+    PROFILE_MEMS_LOW = [_memory(f"profile-fact-{i}", 0.5 - i * 0.001) for i in range(10)]
+
+    def _client(self, **kw):
+        return _PerBankClient({OWN: self.OWN_MEMS, PROFILE: self.PROFILE_MEMS}, **kw)
+
+    def _client_own_favoured(self, **kw):
+        return _PerBankClient(
+            {OWN: self.OWN_MEMS_HIGH, PROFILE: self.PROFILE_MEMS_LOW}, **kw
+        )
+
+    def test_without_floors_profile_bank_starves_own_bank(self):
+        """Precondition/regression anchor: this is today's behaviour."""
+        ctx, _ = _run_main_with(
+            self._client(), config_extra={"recallMaxMemories": SHIPPED_CAP}
+        )
+        self.assertIsNotNone(ctx)
+        self.assertNotIn("own-fact-", ctx)
+        e = self._read_log()[0]
+        self.assertEqual(e["result_count"], 6)
+        self.assertEqual(e["injected_own_bank_count"], 0)
+        self.assertEqual(e["injected_additional_bank_count"], 6)
+
+    def test_without_floors_own_bank_starves_profile_bank(self):
+        """The mirror precondition, in the inverted score regime — without the
+        additional floor the profile bank reaches the prompt zero times."""
+        ctx, _ = _run_main_with(
+            self._client_own_favoured(), config_extra={"recallMaxMemories": SHIPPED_CAP}
+        )
+        self.assertIsNotNone(ctx)
+        self.assertNotIn("profile-fact-", ctx)
+        e = self._read_log()[0]
+        self.assertEqual(e["result_count"], 6)
+        self.assertEqual(e["injected_own_bank_count"], 6)
+        self.assertEqual(e["injected_additional_bank_count"], 0)
+
+    def test_floors_guarantee_profile_memories_reach_the_prompt(self):
+        """B2 — end-to-end proof that `recallAdditionalBankMinSlots` does
+        something. Deleting the knob makes this fail: own outranks profile on
+        every candidate, so only the floor puts a profile fact in the prompt."""
+        ctx, _ = _run_main_with(
+            self._client_own_favoured(),
+            config_extra={
+                "recallMaxMemories": SHIPPED_CAP,
+                "recallOwnBankMinSlots": SHIPPED_OWN_FLOOR,
+                "recallAdditionalBankMinSlots": SHIPPED_ADDITIONAL_FLOOR,
+            },
+        )
+        self.assertIsNotNone(ctx)
+        profile_lines = [ln for ln in ctx.splitlines() if "profile-fact-" in ln]
+        self.assertEqual(
+            len(profile_lines),
+            SHIPPED_ADDITIONAL_FLOOR,
+            "additional-bank floor did not reach the injected block",
+        )
+        e = self._read_log()[0]
+        self.assertEqual(e["injected_additional_bank_count"], SHIPPED_ADDITIONAL_FLOOR)
+        self.assertEqual(e["injected_own_bank_count"], 5)
+        self.assertEqual(
+            e["reserved_additional_slots"],
+            SHIPPED_ADDITIONAL_FLOOR,
+            "the profile slot must be recorded as won by reservation, not score",
+        )
+        self.assertEqual(e["reserved_own_slots"], 0)
+
+    def test_floors_guarantee_own_bank_memories_reach_the_prompt(self):
+        ctx, _ = _run_main_with(
+            self._client(),
+            config_extra={
+                "recallMaxMemories": SHIPPED_CAP,
+                "recallOwnBankMinSlots": SHIPPED_OWN_FLOOR,
+                "recallAdditionalBankMinSlots": SHIPPED_ADDITIONAL_FLOOR,
+            },
+        )
+        self.assertIsNotNone(ctx)
+        own_lines = [ln for ln in ctx.splitlines() if "own-fact-" in ln]
+        profile_lines = [ln for ln in ctx.splitlines() if "profile-fact-" in ln]
+        self.assertEqual(
+            len(own_lines), SHIPPED_OWN_FLOOR, "own bank did not get its floor"
+        )
+        # The other four are still won on relevance, not handed out by quota.
+        self.assertEqual(len(profile_lines), 4)
+
+    def test_log_row_records_injected_bank_composition(self):
+        """The field that would have caught the own-bank timeout outage."""
+        _run_main_with(
+            self._client(),
+            config_extra={
+                "recallMaxMemories": SHIPPED_CAP,
+                "recallOwnBankMinSlots": SHIPPED_OWN_FLOOR,
+                "recallAdditionalBankMinSlots": SHIPPED_ADDITIONAL_FLOOR,
+            },
+        )
+        e = self._read_log()[0]
+        self.assertEqual(e["result_count"], 6)
+        self.assertEqual(e["injected_own_bank_count"], SHIPPED_OWN_FLOOR)
+        self.assertEqual(e["injected_additional_bank_count"], 4)
+        self.assertEqual(e["reserved_own_slots"], SHIPPED_OWN_FLOOR)
+        self.assertEqual(e["reserved_additional_slots"], 0)
+
+    def test_own_bank_timeout_is_visible_in_the_log_row(self):
+        """A fully timed-out own bank must NOT look healthy: result_count is
+        still 6, but the composition fields expose the collapse."""
+        import socket
+
+        _run_main_with(
+            self._client(bank_exc={OWN: socket.timeout("timed out")}),
+            config_extra={
+                "recallMaxMemories": SHIPPED_CAP,
+                "recallOwnBankMinSlots": SHIPPED_OWN_FLOOR,
+                "recallAdditionalBankMinSlots": SHIPPED_ADDITIONAL_FLOOR,
+            },
+        )
+        e = self._read_log()[0]
+        self.assertEqual(e["result_count"], 6, "volume telemetry still reads healthy")
+        self.assertEqual(e["injected_own_bank_count"], 0, "composition exposes it")
+        self.assertEqual(e["injected_additional_bank_count"], 6)
+        self.assertTrue(e["deadline_hit"])
+
+    def test_source_bank_key_never_leaks_into_the_injected_block(self):
+        ctx, _ = _run_main_with(
+            self._client(),
+            config_extra={
+                "recallMaxMemories": SHIPPED_CAP,
+                "recallOwnBankMinSlots": SHIPPED_OWN_FLOOR,
+                "recallAdditionalBankMinSlots": SHIPPED_ADDITIONAL_FLOOR,
+            },
+        )
+        self.assertNotIn(recall.SOURCE_BANK_KEY, ctx)
+        self.assertNotIn("ken-profile", ctx)
+
+    def test_serial_mode_tags_source_banks_too(self):
+        """The serial rollback path (HINDSIGHT_RECALL_PARALLEL=false) must not
+        silently lose reservation."""
+        ctx, _ = _run_main_with(
+            self._client(),
+            config_extra={
+                "recallMaxMemories": SHIPPED_CAP,
+                "recallOwnBankMinSlots": SHIPPED_OWN_FLOOR,
+                "recallAdditionalBankMinSlots": SHIPPED_ADDITIONAL_FLOOR,
+                "recallParallel": False,
+            },
+        )
+        self.assertIsNotNone(ctx)
+        self.assertEqual(
+            len([ln for ln in ctx.splitlines() if "own-fact-" in ln]), SHIPPED_OWN_FLOOR
+        )
+        e = self._read_log()[0]
+        self.assertEqual(e["recall_mode"], "serial")
+        self.assertEqual(e["injected_own_bank_count"], SHIPPED_OWN_FLOOR)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Auto-recall merges the agent's own bank and the sender's profile bank, sorts globally by `scores.final`, and head-slices at `recallMaxMemories`. This adds per-bank slot **floors** before that head-slice — bounded so they can never become a quota — plus the telemetry that makes injected bank composition observable.

Reworked after the DO-NOT-MERGE review (B1 / B2 / M1 all addressed, plus #3774).

## Why — stated for the case this actually fixes

The head-slice is winner-take-all across banks. On a turn where **both** banks return more candidates than the cap, nothing stops one bank's score distribution from filling every slot, and the agent is handed a dossier about its operator with none of its own session memory.

**This does not fix the own-bank timeout.** A timed-out bank contributes zero candidates, so `own_take = min(floor, 0, …) = 0` and reservation is a strict no-op in exactly that case. Measured across 1,036 multi-bank non-cache `recall_log.jsonl` rows on this host since 2026-07-20:

| state | share | for overlord |
|---|---|---|
| own dead / profile alive — reservation inert | 67.0% | 83.5% |
| own dead / profile dead — inert | 18.0% | 10.2% |
| **own alive / profile alive — the only actionable state** | **15.1%** | **6.4%** |

(6.8% fleet-wide once you also require more candidates than the cap.) The own-bank timeout is a larger, separate defect.

The half of this PR that *does* address the majority case is the **telemetry**. A fully timed-out own bank still logs `result_count == 6`, which every dashboard reads as success — that is why the outage hid for weeks. `injected_own_bank_count` makes it readable per turn without joining `bank_timings`.

## The cap this fleet actually deploys is 6, not 8

`scaffold.ts` stamps `recallMaxMemories = 8` into `settings.json`, but `defaults.memory.recall.max_memories: 6` in `switchroom.yaml` cascades to `HINDSIGHT_RECALL_MAX_MEMORIES`, and env wins. Confirmed empirically: across 2,015 non-cache log rows since 2026-07-20 the maximum observed `result_count` is 6.

So floors of 4/2 would consume the entire cap — `remaining` is 0, the global-relevance fill loop never runs, and every both-alive turn produces the identical 4/2 split regardless of `scores.final`. That is a quota, not a floor.

**Fix:** `_reservable_slots(cap)` bounds the two floors to **half the cap** between them; the other half is always awarded on pure global relevance. It scales with the cap, so the invariant holds at 4, 8 or 12 too, and cannot be re-broken by an operator raising a floor. The scaffold now ships **2 own / 1 additional against the deployed cap of 6**.

At cap 6 with 10 candidates from each bank:

| score regime | composition |
|---|---|
| profile ≫ own | 2 own / 4 profile |
| own ≫ profile | 5 own / 1 profile |
| own returns 0 | 6 profile (no wasted slots) |
| profile returns 0 | 6 own |
| own returns 1 | 1 own / 5 profile |

Composition still moves with the scores in both directions, and neither bank can be zeroed out. This also resolves the collision with #3761: half of every injected set is still decided by the reranker + merge sort + head-slice.

## What changed

- `recall.py` stamps each merged result with its source bank (`_tag_source_bank`), on **both** the parallel and serial paths.
- `_reserve_bank_slots` reserves floors before the head-slice; `_reservable_slots` enforces the half-cap headroom. Floors exceeding it are clamped, own-first. Selection is re-sorted by relevance, so this changes *which* memories are injected, never their order.
- Knobs `recallOwnBankMinSlots` / `recallAdditionalBankMinSlots`, cascading from `memory.recall.own_bank_min_slots` / `.additional_bank_min_slots`. Vendor default **0/0** = the pre-fix head-slice, which is also the rollback lever; the scaffold opts switchroom agents in at **2/1**.
- **Exports are now unconditional (#3774).** `~/.hindsight/claude-code.json` survives an apply and loads *after* `settings.json`, so a conditional export lets a stale hand-edited value shadow what switchroom stamps — silently and permanently. The resolved effective value is written every boot, making env (applied last) the authority. Same resolution as #3759 / #3760. This subsumes #3774.
- New `recall_log.jsonl` fields: `injected_own_bank_count` / `injected_additional_bank_count` (always summing to `result_count`) and `reserved_own_slots` / `reserved_additional_slots`. An untagged result counts as additional, so the own-bank number is never optimistic.

## Deliberately NOT changed

The fan-out architecture. Every agent queries exactly two banks as parallel daemon threads under one shared deadline; a slow bank cannot block a fast one. Slot allocation was the only thing wrong with it.

## Test plan — mutation-checked

Every test asserts **composition**, never volume. The load-bearing ones were verified by deleting the mechanism they guard:

| mutation | result |
|---|---|
| `additional_take = 0` (delete the additional-bank floor) | **FAILED (2)** — was 740/740 passing before |
| `own_take = 0` | **FAILED (6)** |
| `reservable = cap` (delete the half-cap clamp) | **FAILED (7)** |
| `return …, promoted_own, 0` | **FAILED (2)** |
| `return …, 0, promoted_additional` | **FAILED (2)** |
| drop the `?? DEFAULT` resolution (undefined reaches the template) | **FAILED (1)** — renders a bare `...MIN_SLOTS=`, which `_cast_env("", int)` turns back into "unset" |
| restore the conditional `{{#if isNumber}}` export | **PASSED — reported honestly.** With the value resolved to a number at both call sites the guard is inert, so this is a behaviour-preserving edit and no outcome test can catch it. The pair is what must not regress, and an absent export fails the assertions. Noted in the test's comment. |
| floors back to 4/2 | **FAILED (1)** |

New anchors:

- `test_own_bank_cannot_take_every_slot_either` / `test_floors_guarantee_profile_memories_reach_the_prompt` — B2. Inverted score regime (own outranks profile end to end), where the additional floor is the *only* thing between the profile bank and zero slots. The old suite hardcoded profile > own everywhere, so every `reserved_additional_slots` assertion was `== 0`.
- `test_scores_still_decide_composition_at_the_deployed_cap` — B1. Flipping the score regime must change the injected composition, asserted for both 2/1 and an operator's oversized 4/2.
- `test_floors_never_claim_more_than_half_the_cap` — the headroom invariant across caps 2/4/6/8/12 with absurd floors.
- Plus the reworked originals: floors-are-not-quotas both directions, partial results, 0/0 kill-switch, relevance ordering, no duplicates, cap disabled, untagged results, serial path, and the outage case (`result_count == 6` while `injected_own_bank_count == 0`).

Runs:

- `python3 -m unittest discover tests` in `vendor/hindsight-memory/scripts`: **773 passed** (rebased onto #3760).
- `vitest run tests/scaffold.recall-observations.test.ts tests/scaffold.test.ts tests/config src/config/schema.test.ts`: **474 passed**.
- `tsc --noEmit`: clean.
- Vendored pytest: 257 passed, 1 failed — `test_hooks.py::TestRecallHook::test_graceful_on_api_error`, confirmed pre-existing by running it against a pristine `origin/main` checkout.
- `npm run lint`: clean, all guards.

## Risk

Low and bounded. Inert at 0/0 (the vendor default). The shipped 2/1 binds only when both banks return more than their floor. It cannot reduce the number of injected memories — `_reserve_bank_slots` always fills to the cap when candidates exist. Rollback is `memory.recall.own_bank_min_slots: 0` in `switchroom.yaml`.

Code ≠ runtime: agents load the plugin at boot, so this lands per-agent on restart.

## Job spec

`reference/jobs/remember-across-sessions.md` — the job is the agent remembering *its own* prior work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


