### PR TITLE
fix(vault): mint_grant token write is in-place O_TRUNC, and fails loudly

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1589,10 +1589,18 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // container too. Source files are pre-created (mode 0600,
   // owned by the agent UID) by `ensureHostMountSources` in
   // apply.ts so docker doesn't auto-create a root-owned directory
-  // here. Broker writes via root with CAP_DAC_OVERRIDE; a
-  // post-write chownSync (server.ts mint_grant) restores agent-UID
-  // ownership after every mint so the agent keeps being able to
-  // read the file from its own peercred identity.
+  // here. Broker writes via root with CAP_DAC_OVERRIDE.
+  //
+  // #3751 — CRITICAL for anything that writes this path from inside the
+  // broker container: because this is a BARE-FILE bind (not a directory
+  // bind), the destination is a MOUNTPOINT. `rename(2)` over it and
+  // `unlink(2)` of it both return EBUSY. mint_grant's tmp+rename publish
+  // therefore failed on every single mint until #3751 replaced it with an
+  // in-place O_TRUNC write (`vault/broker/write-token-file.ts`); the
+  // reaper hit the same wall in #3749 (`reap-token-file.ts`). In-place
+  // also preserves the inode, hence the agent-UID ownership and 0600 mode
+  // apply.ts set — so no post-write chown is needed on the rewrite path,
+  // and the agent keeps reading the file under its own peercred identity.
   for (const a of describeAgents(config, opts.litellmConfirmedAgents)) {
     lines.push(
       `      - ${homePrefix}/.switchroom/agents/${a.name}/.vault-token:/root/.switchroom/agents/${a.name}/.vault-token`,

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -1367,9 +1367,15 @@ export async function ensureHostMountSources(
   // auto-create a directory at this path on a fresh install) and
   // chown to the agent UID so the agent inside the container can
   // read it under its own peercred identity. The broker writes via
-  // CAP_DAC_OVERRIDE so its writes succeed regardless of ownership;
-  // a follow-up chownSync in mint_grant restores the agent UID after
-  // every write so subsequent reads from the agent keep working.
+  // CAP_DAC_OVERRIDE so its writes succeed regardless of ownership.
+  //
+  // #3751: this pre-creation is now load-bearing for ownership too, not
+  // just to stop docker auto-creating a directory here. mint_grant
+  // publishes the token with an IN-PLACE O_TRUNC write (never tmp+rename —
+  // the file is a bare-file bind mount in the broker container and rename
+  // over it is EBUSY), which preserves THIS inode and therefore the
+  // agent-UID ownership set below. The broker only chowns on the path
+  // where it had to create the file itself.
   for (const name of Object.keys(config.agents)) {
     const tokenPath = join(home, ".switchroom", "agents", name, ".vault-token");
     if (!existsSync(tokenPath)) {

--- a/src/vault/broker/server-grants.test.ts
+++ b/src/vault/broker/server-grants.test.ts
@@ -25,7 +25,7 @@ import {
 } from "./protocol.js";
 import type { VaultEntry } from "../vault.js";
 import { createAuditLogger, type AuditEntry } from "./audit-log.js";
-import { migrateGrantsSchema, mintGrant } from "../grants.js";
+import { listGrants, migrateGrantsSchema, mintGrant } from "../grants.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -186,6 +186,85 @@ describe("VaultBroker: grant operations (mint_grant / list_grants / revoke_grant
       const fileContent = fs.readFileSync(expectedPath, "utf8");
       expect(fileContent).toBe(resp.token);
     }
+  });
+
+  // ── mint_grant: token-file publish semantics (#3751) ──────────────────────
+
+  it("mint_grant: rewrites an existing token file IN PLACE, preserving the inode", async () => {
+    // `apply` pre-creates the mount source; on the live fleet that file is
+    // bind-mounted into the broker container as a BARE FILE, i.e. a
+    // mountpoint. rename(2) over it is EBUSY, so the publish must never
+    // replace the inode. Pin that here: same inode, new bytes.
+    const tokenPath = path.join(agentsDir, "myagent", ".vault-token");
+    fs.mkdirSync(path.dirname(tokenPath), { recursive: true });
+    fs.writeFileSync(tokenPath, "vg_oldold.0000", { mode: 0o600 });
+    const before = fs.statSync(tokenPath);
+
+    const resp = await rpc(socketPath, {
+      v: 1, op: "mint_grant", agent: "myagent", keys: ["foo"], ttl_seconds: null,
+    });
+
+    expect(resp.ok).toBe(true);
+    if (!resp.ok || !("token" in resp)) return;
+    const after = fs.statSync(tokenPath);
+    expect(after.ino).toBe(before.ino);
+    expect(fs.readFileSync(tokenPath, "utf8")).toBe(resp.token);
+    // A tmp+rename publish would leave a `.tmp.<pid>` sibling behind when
+    // the rename half fails.
+    expect(fs.readdirSync(path.dirname(tokenPath))).toEqual([".vault-token"]);
+  });
+
+  it("mint_grant: FAILS the RPC when the token file cannot be written", async () => {
+    // A directory at the token path is a real, un-mocked write failure of
+    // the same class as the EBUSY the live broker hits over the bind mount.
+    // Pre-fix the broker logged it and still answered ok:true with a live
+    // grant row — the inconsistency behind #3751.
+    const tokenPath = path.join(agentsDir, "myagent", ".vault-token");
+    fs.mkdirSync(tokenPath, { recursive: true });
+
+    const resp = await rpc(socketPath, {
+      v: 1, op: "mint_grant", agent: "myagent", keys: ["foo"], ttl_seconds: null,
+    });
+
+    expect(resp.ok).toBe(false);
+    if (resp.ok) return;
+    expect(resp.code).toBe("INTERNAL");
+    expect(resp.msg).toContain("Failed to write token file");
+    expect("token" in resp).toBe(false);
+  });
+
+  it("mint_grant: rolls the grant back (revoked) when the token write fails", async () => {
+    const tokenPath = path.join(agentsDir, "myagent", ".vault-token");
+    fs.mkdirSync(tokenPath, { recursive: true });
+
+    await rpc(socketPath, {
+      v: 1, op: "mint_grant", agent: "myagent", keys: ["foo"], ttl_seconds: null,
+    });
+
+    // No live capability may outlive a failed publish: the row stays for
+    // forensics but must be revoked, so listGrants (active only) is empty.
+    expect(listGrants(grantsDb)).toEqual([]);
+    const rows = grantsDb
+      .query<{ id: string; revoked_at: number | null }, []>(
+        "SELECT id, revoked_at FROM vault_grants",
+      )
+      .all();
+    expect(rows.length).toBe(1);
+    expect(rows[0].revoked_at).not.toBeNull();
+  });
+
+  it("mint_grant: audit-logs the token-write failure as an error, not 'allowed'", async () => {
+    const tokenPath = path.join(agentsDir, "myagent", ".vault-token");
+    fs.mkdirSync(tokenPath, { recursive: true });
+
+    await rpc(socketPath, {
+      v: 1, op: "mint_grant", agent: "myagent", keys: ["foo"], ttl_seconds: null,
+    });
+
+    const mintEntries = auditEntries.filter((e) => e.op === "mint_grant");
+    expect(mintEntries.length).toBe(1);
+    expect(mintEntries[0].result).toContain("error:token-write-failed");
+    expect(mintEntries[0].grant_id).toMatch(/^vg_/);
   });
 
   it("mint_grant: audit logs with method:grant and grant_id (no token in log)", async () => {

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -25,8 +25,9 @@
  */
 
 import * as net from "node:net";
-import { mkdirSync, chmodSync, chownSync, existsSync, readFileSync, readdirSync, statSync, unlinkSync, writeFileSync, renameSync } from "node:fs";
+import { mkdirSync, chmodSync, chownSync, existsSync, readFileSync, readdirSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { allocateAgentUid } from "../../agents/compose.js";
+import { writeAgentTokenFile } from "./write-token-file.js";
 import { dirname, resolve, join, basename } from "node:path";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -2606,50 +2607,79 @@ export class VaultBroker {
         return;
       }
 
-      // Write token file atomically at ~/.switchroom/agents/<agent>/.vault-token
-      // (mode 0600).
+      // Publish the token at ~/.switchroom/agents/<agent>/.vault-token.
       //
-      // #225 review-fix: write-then-rename so a cron racing the mint
-      // never reads a partial token. The previous direct writeFileSync left
-      // a one-syscall window where the cron could open the file between
-      // creation and the bytes being committed. Rename is atomic on Linux
-      // for same-filesystem moves.
+      // #3751: this is an IN-PLACE O_TRUNC write, deliberately NOT the
+      // tmp+rename atomic-write pattern that #225 introduced here. The token
+      // file is bind-mounted into this container as a bare file (see the
+      // per-agent loop in src/agents/compose.ts), so it is a mountpoint:
+      // `rename(2)` over it returns EBUSY and the write failed on every
+      // single mint on the live fleet. In-place also preserves the inode,
+      // hence the agent-UID ownership and 0600 mode that a rename silently
+      // destroyed. Same constraint/remedy as the reaper in #3749. See
+      // write-token-file.ts for the full rationale.
+      //
+      // The write is load-bearing, not best-effort: if it fails we must NOT
+      // report a successful mint. A live grant row whose token never reached
+      // disk is the exact inconsistency that made the original EBUSY
+      // invisible for months, so roll the grant back and fail the RPC.
       try {
         const agentsDir = this.config
           ? resolveAgentsDir(this.config)
           : path.join(os.homedir(), ".switchroom", "agents");
-        const tokenDir = path.join(agentsDir, agent);
-        mkdirSync(tokenDir, { recursive: true });
-        const tokenPath = path.join(tokenDir, ".vault-token");
-        const tmpPath = `${tokenPath}.tmp.${process.pid}`;
-        writeFileSync(tmpPath, mintResult.token, { mode: 0o600 });
-        renameSync(tmpPath, tokenPath);
-        // Chown to the agent UID. Without this the file lands root:root
-        // (broker runs as root) — the agent's in-container
-        // `switchroom vault get` would then fall back to the peercred
-        // ACL with no token attached, hitting VAULT-BROKER-DENIED on
-        // every call. Pre-fix this gap was masked because the per-
-        // agent token files weren't bind-mounted into the broker at
-        // all and the write stranded inside the broker's ephemeral
-        // /root/.switchroom. CAP_CHOWN is granted to the broker (see
-        // compose.ts cap_add). Swallow EPERM on dev hosts without
-        // it — the broker still returns the token in the IPC
-        // response, just the on-disk mirror is owner-wrong.
-        try {
-          const uid = allocateAgentUid(agent);
-          chownSync(tokenPath, uid, uid);
-        } catch (chownErr) {
+        const { chownWarning } = writeAgentTokenFile({
+          agentsDir,
+          agent,
+          token: mintResult.token,
+        });
+        if (chownWarning !== null) {
+          // Non-fatal: only reachable on the create path (fresh agent / dev
+          // host without CAP_CHOWN). The bytes are on disk and the token is
+          // still returned over IPC; only the on-disk mirror is owner-wrong.
           process.stderr.write(
-            `[vault-broker] mint_grant: token written but chown failed for agent ${agent}: ` +
-            `${(chownErr as Error).message} (CAP_CHOWN missing?)\n`
+            `[vault-broker] mint_grant: ${chownWarning} (agent ${agent})\n`,
           );
         }
       } catch (err) {
-        // Non-fatal: the token is still returned. File write is best-effort.
+        const msg = err instanceof Error ? err.message : String(err);
+        // Compensating action: the grant row already exists, and its token
+        // was already handed to bcrypt-hashed storage. Revoke it so no live
+        // capability outlives the failed publish — validateGrant hard-denies
+        // a revoked token, so the pair (grant, token file) can never be left
+        // out of sync in the "grant usable, token missing" direction.
+        let rolledBack = false;
+        let rollbackErr: string | null = null;
+        try {
+          rolledBack = revokeGrant(this.grantsDb, mintResult.id);
+        } catch (revokeError) {
+          rollbackErr = revokeError instanceof Error ? revokeError.message : String(revokeError);
+        }
+        const rollbackNote = rolledBack
+          ? "grant rolled back (revoked)"
+          : `GRANT ROLLBACK FAILED — revoke ${mintResult.id} manually${rollbackErr ? `: ${rollbackErr}` : ""}`;
         process.stderr.write(
           `[vault-broker] mint_grant: failed to write token file for agent ${agent}: ` +
-          `${(err as Error).message}\n`
+          `${msg}; ${rollbackNote}\n`
         );
+        this.auditLogger.write({
+          ts: new Date().toISOString(),
+          op: "mint_grant",
+          caller: auditCaller,
+          pid: auditPid,
+          cgroup: auditCgroup,
+          result: `error:token-write-failed:${msg}`,
+          method: "grant",
+          grant_id: mintResult.id,
+        });
+        socket.write(
+          encodeResponse(
+            errorResponse(
+              "INTERNAL",
+              `Failed to write token file for agent ${agent}: ${msg} (${rollbackNote})`,
+            ),
+          ),
+        );
+        return;
       }
 
       this.auditLogger.write({

--- a/src/vault/broker/write-token-file.test.ts
+++ b/src/vault/broker/write-token-file.test.ts
@@ -1,0 +1,153 @@
+/**
+ * #3751 — `mint_grant`'s `.vault-token` publish must be an IN-PLACE
+ * `O_TRUNC` write, and must throw when it does not land.
+ *
+ * These assert real outcomes on real files in a tmpdir:
+ *   - the bytes are actually on disk afterwards;
+ *   - the INODE is preserved across a rewrite (the property that makes the
+ *     write survive a bare-file bind mount and keeps agent-UID ownership) —
+ *     the tmp+rename implementation this replaces fails this assertion;
+ *   - no tmp sibling is left behind / created at any point;
+ *   - a genuine fs failure (EISDIR) and a silent short write both surface as
+ *     a thrown `TokenFileWriteError`, never a swallowed log line.
+ *
+ * Hermetic: everything happens under `mkdtempSync`; `os.homedir()` is never
+ * consulted (see scripts/check-vault-test-hermeticity.mjs).
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { writeAgentTokenFile, TokenFileWriteError } from "./write-token-file.js";
+
+const AGENT = "testagent";
+const TOKEN_A = "vg_aaaaaa.11111111111111111111111111111111";
+const TOKEN_B = "vg_bbbbbb.22222222222222222222222222222222";
+
+describe("writeAgentTokenFile (#3751)", () => {
+  let agentsDir: string;
+  let tokenPath: string;
+
+  beforeEach(() => {
+    agentsDir = fs.mkdtempSync(path.join(os.tmpdir(), "vault-token-write-"));
+    tokenPath = path.join(agentsDir, AGENT, ".vault-token");
+  });
+
+  afterEach(() => {
+    fs.rmSync(agentsDir, { recursive: true, force: true });
+  });
+
+  it("writes the token bytes to disk, creating the agent dir", () => {
+    const res = writeAgentTokenFile({ agentsDir, agent: AGENT, token: TOKEN_A });
+
+    expect(res.tokenPath).toBe(tokenPath);
+    expect(fs.readFileSync(tokenPath, "utf8")).toBe(TOKEN_A);
+    expect(fs.statSync(tokenPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("preserves the inode when the file already exists (the bind-mount property)", () => {
+    // `apply` pre-creates the mount source; the broker only ever rewrites it.
+    fs.mkdirSync(path.join(agentsDir, AGENT), { recursive: true });
+    fs.writeFileSync(tokenPath, TOKEN_A, { mode: 0o600 });
+    const before = fs.statSync(tokenPath);
+
+    writeAgentTokenFile({ agentsDir, agent: AGENT, token: TOKEN_B });
+
+    const after = fs.statSync(tokenPath);
+    // The load-bearing assertion. A tmp+rename publish installs a NEW inode
+    // here (and would fail outright with EBUSY over a real bind mount).
+    expect(after.ino).toBe(before.ino);
+    expect(after.dev).toBe(before.dev);
+    expect(fs.readFileSync(tokenPath, "utf8")).toBe(TOKEN_B);
+  });
+
+  it("preserves the existing owner/mode on rewrite — no chown is attempted", () => {
+    fs.mkdirSync(path.join(agentsDir, AGENT), { recursive: true });
+    // A mode the writer never sets itself, so "0640 afterwards" can only
+    // mean the original inode survived (writeFileSync's `mode` applies on
+    // creation only).
+    fs.writeFileSync(tokenPath, TOKEN_A, { mode: 0o640 });
+    const before = fs.statSync(tokenPath);
+
+    let chownCalls = 0;
+    const res = writeAgentTokenFile(
+      { agentsDir, agent: AGENT, token: TOKEN_B },
+      { chown: () => { chownCalls += 1; } },
+    );
+
+    const after = fs.statSync(tokenPath);
+    expect(after.mode & 0o777).toBe(0o640);
+    expect(after.uid).toBe(before.uid);
+    expect(after.gid).toBe(before.gid);
+    expect(chownCalls).toBe(0);
+    expect(res.chownWarning).toBeNull();
+  });
+
+  it("chowns to the agent UID only when it had to CREATE the file", () => {
+    const chowned: Array<[string, number, number]> = [];
+    const res = writeAgentTokenFile(
+      { agentsDir, agent: AGENT, token: TOKEN_A },
+      { chown: (p, uid, gid) => { chowned.push([p, uid, gid]); }, agentUid: () => 4242 },
+    );
+
+    expect(chowned).toEqual([[tokenPath, 4242, 4242]]);
+    expect(res.chownWarning).toBeNull();
+  });
+
+  it("degrades a create-path chown failure to a warning, not a throw", () => {
+    const res = writeAgentTokenFile(
+      { agentsDir, agent: AGENT, token: TOKEN_A },
+      { chown: () => { throw new Error("EPERM: operation not permitted"); } },
+    );
+
+    // The bytes still landed — the token is usable over IPC — so this must
+    // not fail the mint.
+    expect(fs.readFileSync(tokenPath, "utf8")).toBe(TOKEN_A);
+    expect(res.chownWarning).toContain("EPERM");
+  });
+
+  it("never creates a tmp sibling (regression guard against tmp+rename)", () => {
+    const dir = path.join(agentsDir, AGENT);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(tokenPath, TOKEN_A, { mode: 0o600 });
+
+    writeAgentTokenFile({ agentsDir, agent: AGENT, token: TOKEN_B });
+
+    expect(fs.readdirSync(dir)).toEqual([".vault-token"]);
+  });
+
+  it("throws TokenFileWriteError on a real fs failure (EISDIR)", () => {
+    // A directory at the token path is a genuine, un-mocked write failure —
+    // the same class as the EBUSY the live broker hits on a bind mount.
+    fs.mkdirSync(tokenPath, { recursive: true });
+
+    expect(() => writeAgentTokenFile({ agentsDir, agent: AGENT, token: TOKEN_A })).toThrow(
+      TokenFileWriteError,
+    );
+  });
+
+  it("throws when the write silently does not land (read-back verification)", () => {
+    // Models the exact #3751 failure mode: the write path reports success
+    // but the bytes are not what the caller believes are on disk.
+    fs.mkdirSync(path.join(agentsDir, AGENT), { recursive: true });
+    fs.writeFileSync(tokenPath, TOKEN_A, { mode: 0o600 });
+
+    expect(() =>
+      writeAgentTokenFile(
+        { agentsDir, agent: AGENT, token: TOKEN_B },
+        { writeFile: () => { /* pretend it worked; write nothing */ } },
+      ),
+    ).toThrow(/did not verify after write/);
+  });
+
+  it("throws when the agent dir cannot be created", () => {
+    // agentsDir itself is a file → mkdir of the child fails with ENOTDIR.
+    const filePath = path.join(agentsDir, "not-a-dir");
+    fs.writeFileSync(filePath, "x");
+
+    expect(() =>
+      writeAgentTokenFile({ agentsDir: filePath, agent: AGENT, token: TOKEN_A }),
+    ).toThrow(TokenFileWriteError);
+  });
+});

--- a/src/vault/broker/write-token-file.ts
+++ b/src/vault/broker/write-token-file.ts
@@ -1,0 +1,203 @@
+/**
+ * In-place writer for an agent's `.vault-token` capability-token file.
+ *
+ * ## Why this exists (#3751)
+ *
+ * `mint_grant` used to publish the freshly minted token with the classic
+ * atomic-write dance: `writeFileSync(tmp)` + `renameSync(tmp, tokenPath)`.
+ * That is exactly wrong for this file.
+ *
+ * Each agent's token file is bind-mounted into the broker container as a
+ * **bare file** (`src/agents/compose.ts`, the per-agent
+ * `…/.switchroom/agents/<a>/.vault-token:/root/.switchroom/agents/<a>/.vault-token`
+ * loop). A bind-mounted file IS a mountpoint: `rename(2)` over it — and
+ * `unlink(2)` of it — fail with `EBUSY` from inside the container. So the
+ * write failed on *every* mint on the live fleet:
+ *
+ *   [vault-broker] mint_grant: failed to write token file for agent gymbro:
+ *   EBUSY: resource busy or locked, rename
+ *   '/root/.switchroom/agents/gymbro/.vault-token.tmp.6' ->
+ *   '/root/.switchroom/agents/gymbro/.vault-token'
+ *
+ * …and it went unnoticed for months because the Telegram gateway happens to
+ * write the same token on its own path afterwards, and the broker logged the
+ * failure and shrugged.
+ *
+ * An in-place `O_TRUNC` write (`writeFileSync` with the default `"w"` flag)
+ * keeps the SAME inode, so it:
+ *   - works over the bare-file bind mount (no mountpoint is replaced), and
+ *   - preserves the file's agent-UID ownership and `0600` mode, which the
+ *     tmp+rename path destroyed on every write (a rename installs a
+ *     root-owned inode — see CLAUDE.md "Dev flow & PR hygiene" §2).
+ *
+ * Same constraint and same remedy as the reaper in #3749
+ * (`reap-token-file.ts`), which documented the EBUSY and adopted in-place
+ * `O_TRUNC` for the truncate-to-empty case. This module is the mint-side
+ * counterpart — the write-bytes case — and deliberately keeps the same
+ * shape (injectable fs seams, in-place `writeFileSync`, no rename/unlink)
+ * rather than inventing a second style. They differ in failure policy, and
+ * must: reaping is hygiene and swallows every error into an outcome code,
+ * minting is load-bearing and throws.
+ *
+ * ## Why it throws
+ *
+ * The old callsite swallowed every failure into a stderr line, so the caller
+ * believed the mint had succeeded when the token had never reached disk. A
+ * grant row that exists while its token file does not is precisely the
+ * inconsistent state behind the "grant reported success but the agent still
+ * can't read the secret" symptom. This module therefore treats a failed or
+ * unverified write as a hard error and lets it propagate; `mint_grant` rolls
+ * the grant back and fails the RPC.
+ */
+
+import { chownSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { allocateAgentUid } from "../../agents/agent-uid.js";
+
+/**
+ * Thrown when the token file could not be written, or was written but did
+ * not read back byte-identical. Never swallowed by the caller.
+ */
+export class TokenFileWriteError extends Error {
+  readonly tokenPath: string;
+  constructor(tokenPath: string, message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "TokenFileWriteError";
+    this.tokenPath = tokenPath;
+  }
+}
+
+/** Injection seams — real fs by default; tests override to force failures. */
+export interface WriteAgentTokenFileDeps {
+  mkdir?: (path: string) => void;
+  /** MUST be an in-place truncating write. Never tmp+rename. */
+  writeFile?: (path: string, data: string) => void;
+  readFile?: (path: string) => string;
+  chown?: (path: string, uid: number, gid: number) => void;
+  agentUid?: (agent: string) => number;
+}
+
+export interface WriteAgentTokenFileArgs {
+  /** Resolved agents dir, e.g. `~/.switchroom/agents`. */
+  agentsDir: string;
+  /** Agent slug (already validated by the wire schema). */
+  agent: string;
+  /** The exact token string to publish. */
+  token: string;
+}
+
+export interface WriteAgentTokenFileResult {
+  /** Absolute path that was written. */
+  tokenPath: string;
+  /**
+   * Non-fatal ownership-repair warning, or null. Only populated when the
+   * file had to be CREATED (fresh agent / dev host without the pre-created
+   * mount source) and the follow-up chown failed. On the normal in-place
+   * path the inode — and therefore its ownership — is untouched, so no
+   * chown is required at all.
+   */
+  chownWarning: string | null;
+}
+
+/**
+ * Publish `token` to `<agentsDir>/<agent>/.vault-token`, in place.
+ *
+ * @throws {TokenFileWriteError} if the directory cannot be created, the
+ *   write fails (`EBUSY`, `EISDIR`, `EACCES`, `ENOSPC`, …), or the bytes do
+ *   not read back identical.
+ */
+export function writeAgentTokenFile(
+  args: WriteAgentTokenFileArgs,
+  deps: WriteAgentTokenFileDeps = {},
+): WriteAgentTokenFileResult {
+  const { agentsDir, agent, token } = args;
+
+  const mkdir = deps.mkdir ?? ((p: string) => { mkdirSync(p, { recursive: true }); });
+  // Default flag for writeFileSync is "w" = O_CREAT|O_TRUNC|O_WRONLY — an
+  // in-place truncating write that preserves the inode when the file
+  // already exists. `mode` only applies on creation, which is what we want:
+  // an existing agent-owned 0600 file keeps its own mode.
+  const writeFile =
+    deps.writeFile ?? ((p: string, d: string) => { writeFileSync(p, d, { mode: 0o600 }); });
+  const readFile = deps.readFile ?? ((p: string) => readFileSync(p, "utf8"));
+  const chown = deps.chown ?? ((p: string, uid: number, gid: number) => { chownSync(p, uid, gid); });
+  const agentUid = deps.agentUid ?? allocateAgentUid;
+
+  const tokenDir = join(agentsDir, agent);
+  const tokenPath = join(tokenDir, ".vault-token");
+
+  try {
+    mkdir(tokenDir);
+  } catch (err) {
+    throw new TokenFileWriteError(
+      tokenPath,
+      `cannot create agent token dir ${tokenDir}: ${errText(err)}`,
+      { cause: err },
+    );
+  }
+
+  // Did the file already exist? Decides whether an ownership repair is
+  // needed afterwards (an existing inode keeps its owner through O_TRUNC).
+  let preExisting: boolean;
+  try {
+    readFile(tokenPath);
+    preExisting = true;
+  } catch {
+    preExisting = false;
+  }
+
+  try {
+    writeFile(tokenPath, token);
+  } catch (err) {
+    throw new TokenFileWriteError(
+      tokenPath,
+      `cannot write token file ${tokenPath}: ${errText(err)}`,
+      { cause: err },
+    );
+  }
+
+  // Read back. The whole point of #3751 is that a write we merely *believe*
+  // happened is worse than no write: verify the bytes are actually on disk
+  // before the caller is allowed to report success.
+  let onDisk: string;
+  try {
+    onDisk = readFile(tokenPath);
+  } catch (err) {
+    throw new TokenFileWriteError(
+      tokenPath,
+      `token file ${tokenPath} is unreadable after write: ${errText(err)}`,
+      { cause: err },
+    );
+  }
+  if (onDisk !== token) {
+    throw new TokenFileWriteError(
+      tokenPath,
+      `token file ${tokenPath} did not verify after write ` +
+        `(${onDisk.length} bytes on disk, ${token.length} expected)`,
+    );
+  }
+
+  let chownWarning: string | null = null;
+  if (!preExisting) {
+    // Only the create path needs this. The broker runs as root, so a file
+    // it created lands root:root and the agent — which reads the token from
+    // inside its own container as its own uid — could not open it.
+    // CAP_CHOWN is granted to the broker (compose.ts cap_add); dev hosts
+    // without it degrade to a warning rather than failing the mint, because
+    // the token is still returned over IPC.
+    try {
+      const uid = agentUid(agent);
+      chown(tokenPath, uid, uid);
+    } catch (err) {
+      chownWarning =
+        `token file ${tokenPath} created but chown to the agent UID failed: ` +
+        `${errText(err)} (CAP_CHOWN missing?)`;
+    }
+  }
+
+  return { tokenPath, chownWarning };
+}
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}


### PR DESCRIPTION
## Summary

`mint_grant` published the freshly minted `.vault-token` with tmp+rename. Each agent's token file is bind-mounted into the broker container as a **bare file** (`src/agents/compose.ts:1596-1600`, the per-agent `.vault-token:` loop), so the destination is a **mountpoint** — `rename(2)` over it returns `EBUSY`. The write failed on every single mint, and stayed invisible because the handler caught the error, wrote a stderr line, and still answered `ok:true`.

Two changes, the second as load-bearing as the first:

1. **In-place `O_TRUNC` publish** — new `src/vault/broker/write-token-file.ts`, never tmp+rename. Works over the bare-file bind mount, and preserves the **inode**, hence the agent-UID ownership and `0600` mode that `apply` pre-creates and that a rename silently re-owned to root on every write (CLAUDE.md "Dev flow & PR hygiene" §2 warns about exactly this). Same constraint and same remedy the reaper adopted in #3749 (`reap-token-file.ts`) — this is the mint-side counterpart and keeps that module's shape (injectable fs seams, no rename/unlink). The write is **read-back-verified**: a write we merely believe happened is what made this invisible for months.
2. **A failed write fails the mint.** The handler revokes the grant it just minted, audits `error:token-write-failed:<msg>` instead of `allowed`, and returns `INTERNAL`.

Also corrects the now-false "chownSync after every mint" claims in `compose.ts` and `apply.ts`, and documents the mountpoint constraint *at the bind-mount site* so the next writer doesn't reach for rename again.

## Why

Root cause confirmed in source on `origin/main`, not just from the logs:

- `src/vault/broker/server.ts:2600-2602` (pre-fix): `writeFileSync(tmpPath, …)` + `renameSync(tmpPath, tokenPath)`.
- `src/agents/compose.ts:1596-1600`: `- $HOME/.switchroom/agents/<a>/.vault-token:/root/.switchroom/agents/<a>/.vault-token` — a bare-file bind, one per agent.
- `src/vault/broker/server.ts:2623-2629` (pre-fix): the `catch` swallowed it — *"Non-fatal: the token is still returned. File write is best-effort."*

**On the failure semantics.** The write is not decorative — it is how the capability reaches the agent. So the interesting question is what to do with the grant row that already exists by the time the write fails. Three options were on the table:

- *Log and continue* (status quo): the caller believes a capability was delivered that was not. This is the bug.
- *Fail the RPC, keep the row*: honest to the caller, but leaves a live grant whose token is not on disk — the exact "grant reported success but the agent still can't read the secret" inconsistency, just now with an error message attached.
- *Fail the RPC and revoke the row* (chosen): the compensating action makes the failure atomic from the operator's point of view. `validateGrant` hard-denies a revoked token, so the pair (grant, token file) can never be left out of sync in the dangerous direction — grant usable, token missing. The row survives for forensics rather than being deleted, and if the revoke itself fails the error message names the grant id to revoke by hand.

This is already wired end-to-end: `telegram-plugin/gateway/callback-query-handlers.ts:2489-2492` renders an `error` mint result as **"mint_grant failed: `<msg>`"** in the operator's chat, and returns before its own token write — so the failure now surfaces where a human sees it, instead of in a log line nobody greps.

`chownSync` is kept, but only on the path where the broker had to *create* the file (fresh agent / dev host without the pre-created mount source). On the normal rewrite path the inode — and its ownership — is untouched, so no chown is needed. A create-path chown failure stays a warning: the bytes landed and the token is returned over IPC, so it must not fail the mint.

## Test plan

- **`src/vault/broker/write-token-file.test.ts`** (new, vitest, 9 tests) — real files in a `mkdtemp` tmpdir, no mocked fs on the assertions that matter: bytes land; **`ino` and `dev` preserved** across a rewrite; a pre-existing `0640` file keeps mode + uid + gid with **zero chown calls**; chown happens only on the create path; `readdir` shows no `.tmp` sibling ever exists; a real `EISDIR` and a silent short write both throw `TokenFileWriteError`.
- **`src/vault/broker/server-grants.test.ts`** (+4, bun) — end-to-end over the broker socket: in-place rewrite preserves the inode and leaves no tmp sibling; a write failure returns `ok:false` / `INTERNAL` with no `token` field; the grant row is revoked so `listGrants` is empty and `revoked_at` is set; exactly one audit row, and it is `error:token-write-failed`, not `allowed`.
- **The tests fail on the bug.** Reverting *only* `server.ts` to the pre-fix tmp+rename and re-running the broker suite gives **21 pass / 4 fail** — exactly the four new tests, none of the pre-existing ones.
- Scoped green locally: `write-token-file`, `reap-token-file`, `doctor-vault-broker-durability` (51 vitest), `server-grants` (25 bun), `src/agents/compose*` (14 vitest), `npm run lint` clean including `check-vault-test-hermeticity` (the new test never touches `os.homedir()`).

## Risk

- **Partial write destroys the previous token.** A write that truncates and *then* fails (ENOSPC) leaves partial bytes where a working token was. That degrades to the #3749 read-path fall-through — a partial token is `grant-invalid`, so the agent is served from its standing config ACL — and the mint now fails loudly so the operator re-mints. Not a regression: tmp+rename left the same window open while reporting success. Restoring the old bytes was rejected as more machinery that can itself fail.
- **Behaviour change for callers:** `mint_grant` can now return `INTERNAL` where it previously always returned `ok:true`. The only production caller is the gateway, which already handles the `error` arm (cited above). This is the intended blast radius.
- **No live state was touched** producing this PR: source reads and `docker logs` only. No grant minted, no `.vault-token` written, no broker restarted.

## Pre-existing, filed separately

`src/vault/broker/server-token-fallthrough.test.ts` is red on pristine `origin/main` (`cebe108a`), unrelated to this diff — and it is red *unnoticed* because it is excluded from vitest and absent from `test:bun`, so **it runs in neither CI runner**. `server-per-agent-unlock.test.ts` is orphaned the same way. Filed as #3756 rather than fixed here.

Job spec: `reference/jobs/approve-what-my-agent-can-touch.md` — *"the agent can ask for more but can never self-grant"*. A mint that reports success while the capability never reached the agent breaks the operator's one tap.

Fixes #3751
