### PR TITLE
feat(doctor): detect banks missing their per-bank HNSW partial index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 ## Unreleased
 
+### `switchroom doctor` detects banks with no per-bank vector index
+
+Hindsight creates one PARTIAL vector index per (bank, fact_type) — and creates
+them exactly once, at bank creation, behind `if created:` on an
+`INSERT ... ON CONFLICT (bank_id) DO NOTHING RETURNING bank_id`
+(`engine/retain/bank_utils.py:254`, `engine/retain/fact_storage.py:163`).
+There is no backfill and no reconciliation anywhere, so a bank whose row
+predates the feature — or whose creation raced — never gets its indexes and
+nothing ever notices.
+
+It is invisible because it is not an error. Recall still returns rows, just the
+wrong ones, from a scan rather than a search, and only ever a truncated slice
+of the candidate pool. No exception, no log line, no failed request. On this
+fleet every bank created between 2026-04-14 and 2026-05-31 ran that way for
+roughly three months, with measured recall@100 bounded at 4% or less.
+
+The new `hindsight vector indexes` row asserts that every (bank, fact_type)
+pair at or above 10,000 embedding rows has an index that exists **and** is
+`indisvalid` — a `CREATE INDEX CONCURRENTLY` that failed part-way leaves an
+INVALID index behind that the planner will not use, so treating mere existence
+as sufficient would report that exact broken state as healthy.
+
+Index names are **derived**, not hardcoded, matching the engine's own
+`_bank_index_name`: strip hyphens from `banks.internal_id`, then take the first
+16 characters, as `idx_mu_emb_<worl|expr|obsv>_<uid>`. Doing it in the other
+order keeps two hyphens and yields a name that matches nothing, which would
+report every bank as broken.
+
+The 10,000 floor comes from measured behaviour: the planner stops preferring
+the per-bank partial index below roughly 12,000 rows per pair, so the floor
+sits deliberately underneath that so the row fires while the bank is still
+healthy. Verified against the live fleet — every pair at or above 9,250 rows
+has a valid index, and the largest unindexed pair is `gymbro/world` at 8,128
+rows and rising, which this catches on the day it crosses.
+
+**Detection only.** The repair path belongs upstream in Hindsight; a
+diagnostic command should not take a write lock on a live production table.
+The row's `fix` text says the indexes are never backfilled, because without
+that the natural response is "run apply again", which does nothing.
+
 ### `hindsight.env` can reach every perf knob, and a key it can't reach now fails loudly
 
 Eight Hindsight tuning knobs were emitted unconditionally on both launch paths

--- a/src/cli/doctor-hnsw-index.test.ts
+++ b/src/cli/doctor-hnsw-index.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HNSW_INDEX_MIN_ROWS,
+  buildHnswIndexQuery,
+  checkHnswPartialIndexes,
+  parseHnswIndexOutput,
+  type HnswIndexProbeResult,
+} from "./doctor-hnsw-index.js";
+
+/**
+ * The defect these tests guard.
+ *
+ * Hindsight creates per-bank PARTIAL vector indexes exactly once, at bank
+ * creation, behind `if created:` on an INSERT ... ON CONFLICT DO NOTHING. No
+ * backfill, no reconciliation. A bank that missed that window never gets them
+ * and nothing notices — recall keeps returning rows, just the wrong ones, from
+ * a scan rather than a search. Measured on this fleet: recall@100 bounded at
+ * <=4% across five banks for roughly three months.
+ *
+ * So the assertions are about the OUTCOME an operator needs — "does the check
+ * name a real unindexed bank before recall degrades" — not about the query
+ * string's shape.
+ */
+
+const row = (
+  bankId: string,
+  factType: string,
+  rows: number,
+  present: boolean,
+  indexName = "idx_mu_emb_x_0123456789abcdef",
+) => ({ bankId, factType, rows, indexName, present });
+
+const probeOf = (rows: HnswIndexProbeResult["rows"]) => () => ({ ok: true, rows });
+
+describe("index name derivation", () => {
+  it("strips hyphens BEFORE truncating to 16, exactly as the engine does", () => {
+    // engine/retain/bank_utils.py:_bank_index_name —
+    //   uid = str(internal_id).replace("-", "")[:16]
+    // Truncating the raw UUID text to 16 chars instead would keep two hyphens
+    // and produce a different name, which would make this check report EVERY
+    // bank as broken. Assert the order, in SQL, rather than trusting prose.
+    const sql = buildHnswIndexQuery();
+    expect(sql).toContain("substr(replace(b.internal_id::text, '-', ''), 1, 16)");
+    // The wrong order would be substr(...) wrapped by replace(...).
+    expect(sql).not.toMatch(/replace\(\s*substr/);
+  });
+
+  it("derives all three fact-type suffixes rather than hardcoding one", () => {
+    const sql = buildHnswIndexQuery();
+    for (const [ft, sfx] of [
+      ["world", "worl"],
+      ["experience", "expr"],
+      ["observation", "obsv"],
+    ]) {
+      expect(sql).toContain(`WHEN '${ft}' THEN '${sfx}'`);
+    }
+  });
+
+  it("requires the index to be indisvalid, not merely to exist", () => {
+    // A CONCURRENTLY build that failed part-way leaves an INVALID index in
+    // pg_class that the planner will not use. Accepting mere existence would
+    // report that exact broken state as healthy.
+    expect(buildHnswIndexQuery()).toContain("i.indisvalid");
+  });
+
+  it("filters by the configured floor", () => {
+    expect(buildHnswIndexQuery(4242)).toContain("HAVING count(*) >= 4242");
+  });
+
+  it("counts only rows that actually have an embedding", () => {
+    // A pair with 50k rows and no embeddings needs no vector index; counting
+    // them would fire the row on banks that are fine.
+    expect(buildHnswIndexQuery()).toContain("mu.embedding IS NOT NULL");
+  });
+});
+
+describe("the floor", () => {
+  it("fires below the planner flip point, not after recall has degraded", () => {
+    // Measured: the planner stops preferring the per-bank partial index below
+    // roughly 12,000 rows per (bank, fact_type). A floor at or above that
+    // would only report a bank once its recall was ALREADY degraded.
+    expect(HNSW_INDEX_MIN_ROWS).toBeLessThan(12_000);
+  });
+
+  it("catches gymbro/world on the day it crosses", () => {
+    // The live unindexed pair, 8,128 rows on 2026-07-27 and rising. This is
+    // the case the check exists for, so pin it: at 8,128 it is below the floor
+    // and silent; the moment it reaches the floor it must FAIL by name.
+    const below = checkHnswPartialIndexes({
+      probe: probeOf([row("gymbro", "world", 8_128, false)]),
+    });
+    expect(below.status).toBe("ok");
+
+    const crossed = checkHnswPartialIndexes({
+      probe: probeOf([row("gymbro", "world", HNSW_INDEX_MIN_ROWS, false)]),
+    });
+    expect(crossed.status).toBe("fail");
+    expect(crossed.detail).toContain("gymbro/world");
+  });
+});
+
+describe("the doctor row", () => {
+  it("FAILS and names every unindexed pair, with its row count and index name", () => {
+    const r = checkHnswPartialIndexes({
+      probe: probeOf([
+        row("klanker", "world", 82_298, true),
+        row("gymbro", "world", 14_000, false, "idx_mu_emb_worl_aabbccddeeff0011"),
+        row("reggie", "observation", 11_000, false, "idx_mu_emb_obsv_1122334455667788"),
+      ]),
+    });
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("gymbro/world");
+    expect(r.detail).toContain("reggie/observation");
+    expect(r.detail).toContain("14,000");
+    // Name the object so the operator can go look for it.
+    expect(r.detail).toContain("idx_mu_emb_worl_aabbccddeeff0011");
+    // An indexed bank must not be dragged into the failure.
+    expect(r.detail).not.toContain("klanker");
+  });
+
+  it("passes when every pair above the floor is indexed", () => {
+    const r = checkHnswPartialIndexes({
+      probe: probeOf([
+        row("klanker", "world", 82_298, true),
+        row("overlord", "world", 84_426, true),
+      ]),
+    });
+    expect(r.status).toBe("ok");
+  });
+
+  it("passes on a young fleet where nothing has reached the floor", () => {
+    const r = checkHnswPartialIndexes({ probe: probeOf([]) });
+    expect(r.status).toBe("ok");
+  });
+
+  it("SKIPS rather than FAILS when the database cannot be reached", () => {
+    // A dockerless or remote-backend host has nothing to say here. Failing on
+    // "couldn't look" is how a check earns a permanent place on the ignore
+    // list.
+    const r = checkHnswPartialIndexes({
+      probe: () => ({ ok: false, rows: [], error: "container not running" }),
+    });
+    expect(r.status).toBe("skip");
+    expect(r.detail).toContain("container not running");
+  });
+
+  it("says the indexes are never backfilled, because that is why it is stuck", () => {
+    // Without this the natural operator response is "run apply again", which
+    // does nothing: the create is behind `if created:` on the bank INSERT.
+    const r = checkHnswPartialIndexes({
+      probe: probeOf([row("gymbro", "world", 14_000, false)]),
+    });
+    expect(r.fix).toContain("never backfills");
+  });
+});
+
+describe("output parsing", () => {
+  it("reads a real psql -At -F'|' line", () => {
+    const got = parseHnswIndexOutput(
+      "gymbro|world|8128|idx_mu_emb_worl_aabbccddeeff0011|f\n" +
+        "klanker|world|82298|idx_mu_emb_worl_0011223344556677|t\n",
+    );
+    expect(got).toEqual([
+      row("gymbro", "world", 8128, false, "idx_mu_emb_worl_aabbccddeeff0011"),
+      row("klanker", "world", 82298, true, "idx_mu_emb_worl_0011223344556677"),
+    ]);
+  });
+
+  it("distinguishes t from f rather than treating any value as present", () => {
+    // Inverting or ignoring this flag is the difference between "all clear"
+    // and "five banks are broken", and both readings parse cleanly.
+    const [a, b] = parseHnswIndexOutput(
+      "a|world|20000|idx_a|t\nb|world|20000|idx_b|f\n",
+    );
+    expect(a!.present).toBe(true);
+    expect(b!.present).toBe(false);
+  });
+
+  it("accepts both boolean spellings psql can emit", () => {
+    // An explicit ::text cast yields true/false; bare -At output yields t/f.
+    // A live run against the fleet reported all 17 HEALTHY banks as unindexed
+    // because the parser only knew `t` — silent, total, and it would have
+    // shipped a check that cried wolf on every host.
+    expect(parseHnswIndexOutput("a|world|20000|idx_a|true")[0]!.present).toBe(true);
+    expect(parseHnswIndexOutput("a|world|20000|idx_a|t")[0]!.present).toBe(true);
+    expect(parseHnswIndexOutput("a|world|20000|idx_a|false")[0]!.present).toBe(false);
+    // Fail safe: an unrecognised value must report a problem, never clear one.
+    expect(parseHnswIndexOutput("a|world|20000|idx_a|???")[0]!.present).toBe(false);
+  });
+
+  it("skips noise instead of throwing", () => {
+    // docker exec can prepend warnings; a doctor check must never crash the
+    // command it runs in.
+    expect(
+      parseHnswIndexOutput(
+        "WARNING: something\n\ngymbro|world|8128|idx_x|f\nbad|line\n",
+      ),
+    ).toEqual([row("gymbro", "world", 8128, false, "idx_x")]);
+  });
+});

--- a/src/cli/doctor-hnsw-index.ts
+++ b/src/cli/doctor-hnsw-index.ts
@@ -1,0 +1,279 @@
+/**
+ * Doctor surface: per-bank HNSW partial vector indexes on `memory_units`.
+ *
+ * ## The defect this detects
+ *
+ * Hindsight creates one PARTIAL vector index per (bank, fact_type) —
+ * `WHERE fact_type = ... AND bank_id = ...` — and it creates them exactly
+ * once, at bank creation:
+ *
+ *     engine/retain/bank_utils.py:254  -> ops.create_bank_vector_indexes(...)
+ *     engine/retain/fact_storage.py:163 -> same, from the other create path
+ *
+ * Both callsites are guarded by `if inserted:` / `if created:` on an
+ * `INSERT ... ON CONFLICT (bank_id) DO NOTHING RETURNING bank_id`. So the
+ * indexes are created if and only if THAT statement inserted the bank row.
+ * There is no backfill and no reconciliation anywhere: a bank whose row
+ * predates the feature, or whose creation raced, never gets its indexes and
+ * nothing ever notices. On this fleet every bank created between 2026-04-14
+ * and 2026-05-31 ran without them for roughly three months, with measured
+ * recall@100 bounded at <=4%.
+ *
+ * It is invisible from the outside because it is not an error. Recall still
+ * returns rows — just the wrong ones, from a sequential scan or the global
+ * index, and only ever a truncated slice of the candidate pool. No exception,
+ * no log line, no failed request.
+ *
+ * ## Detection only
+ *
+ * This module reports; it does not repair. Creating the missing indexes is an
+ * upstream (Hindsight) concern and a separate piece of work — building a
+ * `CREATE INDEX` into `switchroom doctor` would mean a diagnostic command
+ * taking a write lock on a live production table.
+ */
+
+import { spawnSync } from "node:child_process";
+
+/**
+ * Module-local per house convention (each doctor-*.ts declares its own).
+ * Includes `skip`, which this check needs: "couldn't reach the database" is
+ * not a failure of the thing being checked.
+ */
+export interface CheckResult {
+  name: string;
+  status: "ok" | "warn" | "fail" | "skip";
+  detail?: string;
+  fix?: string;
+}
+
+/**
+ * Per-(bank, fact_type) embedding-row count at or above which a missing
+ * partial index is reported as a failure.
+ *
+ * Picked from measured behaviour, not from taste. Below roughly 12,000 rows
+ * for a (bank, fact_type) the planner stops preferring the per-bank partial
+ * index anyway, so a missing index there is not yet costing recall quality;
+ * above it, the absence is the difference between a real top-N and a
+ * truncated slice.
+ *
+ * 10,000 sits deliberately BELOW that flip point so the row fires while the
+ * bank is still healthy — a check that only fires once recall has already
+ * degraded has told the operator something they could have measured
+ * themselves. Verified against the live fleet (2026-07-27): every
+ * (bank, fact_type) at or above 9,250 rows has a valid index, and the largest
+ * unindexed pair is `gymbro/world` at 8,128 rows and rising. This floor
+ * catches that pair on the day it crosses, ahead of the degradation.
+ */
+export const HNSW_INDEX_MIN_ROWS = 10_000;
+
+/** Fact types that get a per-bank partial index, and their 4-char suffix. */
+export const HNSW_FACT_TYPE_SUFFIXES: ReadonlyArray<readonly [string, string]> = [
+  ["world", "worl"],
+  ["experience", "expr"],
+  ["observation", "obsv"],
+];
+
+/**
+ * One (bank, fact_type) pair above the floor, and whether its index exists.
+ */
+export interface HnswIndexRow {
+  bankId: string;
+  factType: string;
+  /** Embedding rows for this pair (`embedding IS NOT NULL`). */
+  rows: number;
+  /** The derived index name, so a report names the object to look for. */
+  indexName: string;
+  /** True when a matching index exists AND is `indisvalid`. */
+  present: boolean;
+}
+
+export interface HnswIndexProbeResult {
+  /** False when the probe could not run at all (no docker, container down). */
+  ok: boolean;
+  rows: HnswIndexRow[];
+  /** Populated when `ok` is false. */
+  error?: string;
+}
+
+/**
+ * Build the SQL the probe runs.
+ *
+ * Split out and pure so the DERIVATION is testable without a database. The
+ * index name is derived exactly as the engine derives it
+ * (`engine/retain/bank_utils.py:_bank_index_name`,
+ * `engine/db/ops_postgresql.py:create_bank_vector_indexes`):
+ *
+ *     uid = str(internal_id).replace("-", "")[:16]
+ *     idx = f"idx_mu_emb_{suffix}_{uid}"
+ *
+ * Note the order: hyphens are stripped FIRST, then the first 16 characters are
+ * taken. Truncating the raw UUID text to 16 characters instead would keep two
+ * hyphens and yield a different, wrong name — which would make this check
+ * report every bank as broken. Deriving rather than hardcoding is what keeps
+ * the check correct when a bank is added, and asserting the derivation is what
+ * keeps it honest.
+ *
+ * `indisvalid` is checked, not merely existence: a `CREATE INDEX CONCURRENTLY`
+ * that failed part-way leaves an INVALID index behind, which the planner will
+ * not use. Such an index is present in `pg_class` and useless, so treating
+ * existence as sufficient would report the exact broken state as healthy.
+ */
+export function buildHnswIndexQuery(minRows: number = HNSW_INDEX_MIN_ROWS): string {
+  const suffixCase =
+    "CASE mu.fact_type " +
+    HNSW_FACT_TYPE_SUFFIXES.map(([ft, sfx]) => `WHEN '${ft}' THEN '${sfx}'`).join(" ") +
+    " END";
+  const derivedName =
+    `concat('idx_mu_emb_', ${suffixCase}, '_', ` +
+    `substr(replace(b.internal_id::text, '-', ''), 1, 16))`;
+  return (
+    `SELECT b.bank_id, mu.fact_type, count(*)::text, ${derivedName}, ` +
+    `(EXISTS (SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid ` +
+    `WHERE c.relname = ${derivedName} AND i.indisvalid))::text ` +
+    `FROM memory_units mu JOIN banks b ON b.bank_id = mu.bank_id ` +
+    `WHERE mu.embedding IS NOT NULL ` +
+    `AND mu.fact_type IN (${HNSW_FACT_TYPE_SUFFIXES.map(([ft]) => `'${ft}'`).join(", ")}) ` +
+    `GROUP BY b.bank_id, mu.fact_type, b.internal_id ` +
+    `HAVING count(*) >= ${minRows} ` +
+    `ORDER BY count(*) DESC`
+  );
+}
+
+/**
+ * Parse the psql `-At -F'|'` output into rows.
+ *
+ * Pure, and tolerant of the noise a `docker exec` wrapper can prepend: any
+ * line that is not exactly five pipe-separated fields with a numeric count is
+ * skipped rather than throwing. A doctor check must never crash the command it
+ * runs in.
+ */
+export function parseHnswIndexOutput(stdout: string): HnswIndexRow[] {
+  const out: HnswIndexRow[] = [];
+  for (const line of stdout.split("\n")) {
+    const parts = line.trim().split("|");
+    if (parts.length !== 5) continue;
+    const [bankId, factType, rowsRaw, indexName, presentRaw] = parts as [
+      string,
+      string,
+      string,
+      string,
+      string,
+    ];
+    const rows = Number.parseInt(rowsRaw, 10);
+    if (!Number.isFinite(rows) || bankId === "" || indexName === "") continue;
+    // psql renders a boolean as `t`/`f` in -At mode, but an explicit
+    // `::text` cast renders it as `true`/`false`. Both spellings are accepted
+    // because getting this wrong is silent and total: a live run against the
+    // fleet reported all 17 healthy banks as unindexed purely because the
+    // parser only knew `t`. Anything else is treated as NOT present, so an
+    // unrecognised value fails safe (reports a problem) rather than quietly
+    // clearing a real one.
+    const present = presentRaw === "t" || presentRaw === "true";
+    out.push({ bankId, factType, rows, indexName, present });
+  }
+  return out;
+}
+
+/**
+ * Run the query inside the hindsight container.
+ *
+ * pg0 embeds postgres in the container and keeps the superuser password in
+ * `instances/<name>/instance.json`, so the password is read there and passed
+ * via `PGPASSWORD` in the container's own environment. It is never printed,
+ * never returned, and never reaches a doctor row.
+ *
+ * @internal exported so the check can be tested with an injected probe
+ */
+export function probeHnswIndexes(
+  minRows: number = HNSW_INDEX_MIN_ROWS,
+): HnswIndexProbeResult {
+  const sql = buildHnswIndexQuery(minRows).replace(/"/g, '\\"');
+  const script =
+    `set -e; ` +
+    `META=/home/hindsight/.pg0/instances/hindsight/instance.json; ` +
+    `[ -f "$META" ] || { echo "no pg0 instance metadata" >&2; exit 3; }; ` +
+    `PGPASSWORD=$(python3 -c "import json,sys;print(json.load(open('$META'))['password'])"); ` +
+    `export PGPASSWORD; ` +
+    `PSQL=$(ls -d /home/hindsight/.pg0/installation/*/bin/psql 2>/dev/null | head -1); ` +
+    `[ -n "$PSQL" ] || { echo "psql not found" >&2; exit 3; }; ` +
+    `"$PSQL" -U hindsight -d hindsight -At -F'|' -c "${sql}"`;
+
+  const r = spawnSync("docker", ["exec", "switchroom-hindsight", "sh", "-c", script], {
+    stdio: "pipe",
+    timeout: 15_000,
+    encoding: "utf-8",
+  });
+  if (r.error || r.status !== 0) {
+    return {
+      ok: false,
+      rows: [],
+      error: (r.stderr || r.error?.message || `exit ${r.status}`).toString().trim(),
+    };
+  }
+  return { ok: true, rows: parseHnswIndexOutput(r.stdout ?? "") };
+}
+
+/**
+ * Doctor row: every sufficiently-large (bank, fact_type) has a valid partial
+ * vector index.
+ *
+ * SKIP — not FAIL — when the probe cannot run. A dockerless or remote-backend
+ * host has nothing to say here, and a check that fails on "couldn't look"
+ * teaches operators to ignore it.
+ */
+export function checkHnswPartialIndexes(opts?: {
+  probe?: (minRows: number) => HnswIndexProbeResult;
+  minRows?: number;
+}): CheckResult {
+  const minRows = opts?.minRows ?? HNSW_INDEX_MIN_ROWS;
+  const probe = opts?.probe ?? probeHnswIndexes;
+  const result = probe(minRows);
+
+  if (!result.ok) {
+    return {
+      name: "hindsight vector indexes",
+      status: "skip",
+      detail: `couldn't query the hindsight database (${result.error ?? "unknown"})`,
+    };
+  }
+
+  // Re-apply the floor here even though the query already filters on it. The
+  // floor is the judgement call in this check — "how big is big enough that a
+  // missing index is actually costing recall" — and a judgement call should be
+  // enforced in one place that can be tested without a database, not left to
+  // live only inside a SQL string. It also means a looser probe can never
+  // produce a false FAIL on a small bank.
+  const eligible = result.rows.filter((r) => r.rows >= minRows);
+  const missing = eligible.filter((r) => !r.present);
+  if (missing.length === 0) {
+    return {
+      name: "hindsight vector indexes",
+      status: "ok",
+      detail:
+        result.rows.length === 0
+          ? `no (bank, fact_type) pair has reached ${minRows.toLocaleString()} embedding rows yet`
+          : `all ${eligible.length} pair(s) at or above ${minRows.toLocaleString()} rows have a valid partial index`,
+    };
+  }
+
+  const worst = missing
+    .map((m) => `${m.bankId}/${m.factType} (${m.rows.toLocaleString()} rows, ${m.indexName})`)
+    .join("; ");
+  return {
+    name: "hindsight vector indexes",
+    status: "fail",
+    detail:
+      `${missing.length} (bank, fact_type) pair(s) at or above ${minRows.toLocaleString()} ` +
+      `embedding rows have no valid per-bank partial vector index, so recall on them ` +
+      `scans instead of searching and returns a truncated candidate pool: ${worst}`,
+    fix:
+      "Hindsight creates these once at bank creation and never backfills " +
+      "(engine/retain/bank_utils.py, guarded by `if created:`), so an existing " +
+      "bank cannot repair itself. Create each missing index against the " +
+      "hindsight database, ideally CONCURRENTLY so recall keeps serving, " +
+      "matching the engine's own definition: a partial index on memory_units " +
+      "over the embedding column WHERE fact_type = <type> AND bank_id = <bank>. " +
+      "Verify with `indisvalid` afterwards — a CONCURRENTLY build that fails " +
+      "part-way leaves an INVALID index the planner will not use.",
+  };
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -35,6 +35,7 @@ import { findUnmanagedHindsightEnvKeys } from "../setup/hindsight-perf-defaults.
 import { inspectBankHealth, staleMentalModels, corruptedMentalModels, recentUnextracted, ageDays } from "../memory/bank-health.js";
 import { checkHindsightContainerHealth, classifyToolContract, checkHindsightHealthEndpoint, classifyConsolidationBacklog, classifyDirectiveCount } from "./doctor-memory.js";
 import { checkAgentRecallHealth } from "./doctor-recall-health.js";
+import { checkHnswPartialIndexes } from "./doctor-hnsw-index.js";
 import { runLitellmModelChecks } from "../litellm/model-validation.js";
 import { runLitellmKeyAllowlistChecks } from "../litellm/key-allowlist-check.js";
 import { isVaultReference, parseVaultReference } from "../vault/resolver.js";
@@ -1389,6 +1390,11 @@ async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> 
   // (shm exhaustion or OAuth quota 429). These surface both from the local
   // container's shm config + recent logs; no-ops on a remote/dockerless setup.
   results.push(...checkHindsightContainerHealth());
+
+  // Per-bank partial vector indexes are created ONCE at bank creation and
+  // never backfilled, so a bank that missed that window recalls by scanning —
+  // no error, no log line, just a truncated candidate pool. Detection only.
+  results.push(checkHnswPartialIndexes());
 
   // Memory-down signal (#outage 2026-07): a GET /health != 200 means the
   // backend is down / crash-looping — otherwise invisible, since auto-recall


### PR DESCRIPTION
## Summary

Adds a `switchroom doctor` row that FAILs when a sufficiently-large (bank, fact_type) pair has no valid per-bank partial vector index on `memory_units`.

**Detection only.** The repair path belongs upstream in Hindsight and is explicitly out of scope here.

## The defect

Hindsight creates one PARTIAL vector index per (bank, fact_type) — `WHERE fact_type = ... AND bank_id = ...` — and creates them exactly once, at bank creation:

- `engine/retain/bank_utils.py:254` → `ops.create_bank_vector_indexes(...)`
- `engine/retain/fact_storage.py:163` → same, from the other create path

Both are guarded by `if created:` / `if inserted:` on an `INSERT ... ON CONFLICT (bank_id) DO NOTHING RETURNING bank_id`. So the indexes exist if and only if *that statement* inserted the bank row. There is no backfill and no reconciliation anywhere in the engine — a bank whose row predates the feature, or whose creation raced, never gets them.

It is invisible because **it is not an error**. Recall still returns rows, just the wrong ones, from a scan or the global index, and only ever a truncated slice of the candidate pool. No exception, no log line, no failed request. On this fleet every bank created 2026-04-14..2026-05-31 ran that way for roughly three months, with measured recall@100 bounded at ≤4% (finn 0, marko/world 0, carrie/observation 1, assistant/observation 1, klanker/experience 3).

## What the check does

`src/cli/doctor-hnsw-index.ts`, following the `probePendingRetainsQueue` shape already in `doctor.ts`: a pure query builder, a pure parser, and a thin `spawnSync` docker-exec wrapper with an injectable `probe` so the logic is testable without a database.

**Names are derived, not hardcoded**, matching the engine's own `_bank_index_name` (`engine/retain/bank_utils.py`, `engine/db/ops_postgresql.py:create_bank_vector_indexes`):

```python
uid = str(internal_id).replace("-", "")[:16]
idx = f"idx_mu_emb_{suffix}_{uid}"
```

The order matters and is asserted: hyphens are stripped **first**, then the first 16 characters are taken. Truncating the raw UUID text to 16 characters instead keeps two hyphens and yields a name matching nothing — which would report every bank as broken. Suffixes come from `_BANK_INDEX_FACT_TYPES` (`world`→`worl`, `experience`→`expr`, `observation`→`obsv`).

**`indisvalid` is required, not mere existence.** A `CREATE INDEX CONCURRENTLY` that failed part-way leaves an INVALID index in `pg_class` that the planner will not use. Accepting existence would report that exact broken state as healthy.

## The floor

10,000 embedding rows per (bank, fact_type), and it is enforced in the checker as well as in the SQL — the floor is the judgement call here, so it lives in one place testable without a database, and a looser probe can never produce a false FAIL on a small bank.

Picked from measured behaviour: the planner stops preferring the per-bank partial index below roughly 12,000 rows per pair, so 10,000 sits deliberately **underneath** that flip point. A check that only fires once recall has already degraded has told the operator something they could have measured themselves.

Verified against the live fleet (2026-07-27) — every pair at or above 9,250 rows has a valid index, and the largest unindexed pair is `gymbro/world` at **8,128 rows and rising**. So the row is silent today and fires on the day gymbro crosses, ahead of the degradation. That case is pinned in a test in both directions.

## A false positive caught by running it live

Worth recording, because the unit tests alone did not catch it. The first working version rendered the presence flag as `(EXISTS ...)::text`, which psql renders as `true`/`false` — not the `t`/`f` that bare `-At` output produces, which was all the parser knew. Run against the live fleet it reported **all 17 healthy pairs as unindexed**: silent, total, and it would have shipped a check that cried wolf on every host.

The parser now accepts both spellings, and anything unrecognised is treated as NOT present so it fails safe (reports a problem) rather than quietly clearing a real one. There is a regression test naming this. Post-fix live run:

```
ok | all 17 pair(s) at or above 10,000 rows have a valid partial index
```

which matches a direct SQL query of the same database exactly.

## Test plan

`src/cli/doctor-hnsw-index.test.ts` — 16 tests:

- **Derivation**: hyphen-strip-before-truncate asserted in both directions; all three fact-type suffixes; `indisvalid` required; floor applied; `embedding IS NOT NULL` (a pair with 50k rows and no embeddings needs no vector index, and counting them would fire on banks that are fine).
- **Floor**: pinned below the 12,000 planner flip point, and the `gymbro/world` case both below (silent) and at the floor (FAIL, by name).
- **The row**: FAILs naming every unindexed pair with row count and index name, and does *not* drag a healthy bank into the failure; passes when all indexed; passes on a young fleet; **SKIPs rather than FAILs** when the database is unreachable (a dockerless or remote-backend host has nothing to say, and failing on "couldn't look" is how a check earns a place on the ignore list); the `fix` text states the indexes are never backfilled, because without that the natural response is "run apply again", which does nothing.
- **Parsing**: real psql line, `t` vs `f` distinguished, both boolean spellings, fail-safe on unrecognised, noise skipped rather than thrown (a doctor check must never crash the command it runs in).

Local: `tsc --noEmit` clean; `npm run lint` clean; `src/cli/` 1446 passed.

**Pre-existing failure, not from this change**: `src/cli/apply.test.ts` has 10 failures. Verified by stashing this branch's changes and running it against clean `origin/main` — identical 10 failures. Not touched by this PR; flagged rather than fixed to keep this single-concern.

## Risk

Low, and bounded by construction: the module only reads. `SELECT` plus `pg_index`/`pg_class` lookups, one docker-exec with a 15s timeout, and SKIP on any failure to reach the database. The pg0 superuser password is read from the container's own `instances/hindsight/instance.json` and passed via `PGPASSWORD` inside the container — it is never printed, never returned, and never reaches a doctor row.

The row will FAIL on any fleet that actually has this problem. That is the point; those hosts are silently recalling badly today.