### PR TITLE
chore(hindsight): rebase fork onto upstream v0.8.5, retiring 3 adopted patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,97 @@ mirrored credential belonged to the fallback.
 builders derive `isActive` from it via `effectiveServingLabel`. `active` keeps
 its old meaning for anything that genuinely wants the pin, and a
 pre-`serving` broker degrades to the previous behaviour.
+
+### The Hindsight fork rebases onto upstream v0.8.5, and rolling it back is now documented as two ordered steps
+
+The pinned upstream base moves v0.8.4 → v0.8.5 to pick up `hindsight-admin
+repair-bank` (upstream #2645): per-`(bank, fact_type)` vector indexes never
+self-heal, so a bank populated outside the create-time path falls back to the
+global HNSW index plus a post-filter and under-returns recall candidates.
+Measured on this fleet at the production `hnsw.ef_search=200`, one bank
+returned 55 of 100 requested candidates with 143 rows removed by filter; after
+`repair-bank --all` the same query plans onto the per-bank index and returns
+100/100 with none removed.
+
+This is a fork rebase, not a version bump, so every `# switchroom:` patch block
+was replayed against a pristine 0.8.5 tree and re-classified. Eleven blocks
+become eight, roughly 950 lines lighter: the `max_turns`/ToolSearch fix, the
+`unit_entities` FK-race fix and the duplicate-ANN-scan fix are all retired
+because upstream now does the same thing natively — and upstream's FK-race fix
+is strictly better than ours, because it row-locks the surviving parents so the
+pruner blocks, where ours only resurrected the parent after the fact. The
+retired blocks are asserted **absent**, not merely deleted, so a future rebase
+cannot silently resurrect a patch upstream has adopted.
+
+**The rollback story is the part worth reading.** Bumping the base runs four
+alembic migrations against the persisted memory volume, and one of them drops
+`search_vector` from the `invalidated_memory_units` archive. 0.8.5 no longer
+reads that column — but 0.8.4 requires it: its archive round-trip excludes only
+`"embedding"`, and it carries no special-casing for `search_vector` anywhere.
+So reverting the pinned digest **on its own** is not a rollback. It is a
+rollback into a broken state, where every `invalidate_memory` and every revert
+of an invalidated memory fails with `column "search_vector" does not exist` —
+and the older image will not stop you at boot, because alembic logs "Database
+is at a newer migration revision than this code version knows about" and
+carries on.
+
+The order is: **alembic downgrade first, while the newer image is still
+running** (it is the only one that ships the down-revisions), **then** repoint
+the digest. `docs/operators/hindsight-memory.md` gains a runbook section with
+the exact commands, and the Dockerfile comment says so at the pin.
+
+It also documents what the ordered rollback still costs, because "correct" is
+not "lossless": the re-added column comes back empty — upstream's own migration
+says "comes back empty regardless" — and nothing backfills it. Every memory
+archived while the fleet ran on 0.8.5 therefore returns with a NULL
+`search_vector`, so reverting one out of the archive lands it back in
+`memory_units` silently absent from the BM25 arm of recall. If those memories
+matter, restore from a pre-upgrade dump rather than downgrading in place. The
+word "unused" is gone from every description of the column: it was true on the
+version you roll forward to and false on the version you roll back to, which is
+precisely the wording that made the broken rollback look safe.
+
+The MCP contract fixture moves with the pin rather than after it. The captured
+tool surface, its `_meta.hindsight_api_version` marker and the shim's cold-boot
+`FALLBACK_TOOL_TABLE` are all re-derived from the 0.8.5 image in this same
+commit — the delta is exactly additive and exactly three props
+(`list_memories.tags`, `list_memories.tags_match`,
+`create_mental_model.tags_match`); both wheels register the same 32 tools. The
+derivation was cross-validated by running it against the *previous* pinned
+digest, where it reproduces the committed 0.8.4 capture byte-for-byte. The
+version guard now binds in both directions: on 0.8.4 those props must be
+absent (advertising a prop the server silently ignores makes an agent believe a
+filter was applied), and on 0.8.5 they must be present, so bumping the marker
+without re-capturing the fixture is a red test rather than a green one.
+
+### `HINDSIGHT_CE_DECISIVE_RELATIVE_GAP` is reachable, so the CE-damping patch's rollback knob exists
+
+Switchroom's cross-encoder saturation damping is an unconditional calibration
+change whose failure mode is a silent recall-quality regression with no
+telemetry behind it. The patch was written with that in mind: it reads its
+decisive gap from `HINDSIGHT_CE_DECISIVE_RELATIVE_GAP`, so backing the change
+out is meant to be a container restart with one env var rather than an image
+rebuild.
+
+That knob did not work. The key was absent from `HINDSIGHT_PERF_ENV_KEYS`, and
+`resolveHindsightPerfOverrides` skips unmanaged keys silently, so a
+`hindsight.env` line for it never reached the container — and because the patch
+reads the var once at import, there was no runtime fallback to recover through.
+The documented escape hatch for the riskiest patch in the file was unreachable.
+Same defect class as #3732, #3745 and #3763, with the twist that this key is a
+switchroom-patch knob rather than an upstream one, so it carries no
+`HINDSIGHT_API_` prefix and the sweeps for that prefix never saw it.
+
+It joins `HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS` — managed, but with no shipped
+default, because emitting one would replace the patch's own derived gap with a
+hard-coded constant on every host. Unset still means exactly what it meant
+before. A value at or above ~0.65 clamps the damping exponent to 1.0, i.e.
+upstream ranking with the patch still baked in.
+
+The durable half: a test now derives the env-var name from the Dockerfile patch
+itself and asserts it is a member of the managed set, so a future knob
+documented in a patch block cannot ship unreachable.
+
 ### The lexical-overlap recall gate is removed
 
 Auto-recall ran a `recallMinOverlap` gate between the engine's reranker and the

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -42,7 +42,21 @@
 # and `tools=[]` on the standard claude_code call), both of which were
 # dropped in the same commit as this bump. Applying it runs 4 alembic
 # migrations (head b57a7c9e0d13 → d7b2f8a1c934), one of which drops the
-# unused `search_vector` column from the invalidated_memory_units archive.
+# `search_vector` column from the invalidated_memory_units archive. 0.8.5 no
+# longer reads that column — but 0.8.4 REQUIRES it (its archive round-trip
+# excludes only `"embedding"`, memory_engine.py:6579), so this migration is
+# what makes a naive rollback break. NOT "unused": unused on the version you
+# roll forward to, load-bearing on the one you roll back to.
+#
+# ROLLING BACK IS TWO ORDERED STEPS, NOT ONE: alembic downgrade FIRST (while
+# this image is still running — it is the only one that ships the
+# down-revisions), THEN repoint the digest. Reverting the digest alone leaves
+# every invalidate / revert-of-an-invalidate failing with
+# `column "search_vector" does not exist`, and the older image will NOT stop
+# you at boot — it logs "Database is at a newer migration revision …" and
+# carries on. Full runbook, including the empty-column caveat:
+# docs/operators/hindsight-memory.md § "Rolling the base image BACK".
+#
 # Prior history: v0.8.2→v0.8.4 merged divergent alembic heads and widened
 # bank_id columns; v0.7.1→v0.8.2 fixed the `batch_retain`
 # ForeignKeyViolation on `unit_entities` (switchroom #2392). NOTE: upstream

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -31,11 +31,20 @@
 # from another org; an upstream repoint would otherwise flow into the
 # published hindsight image undetected. Dependabot tracks bumps.
 #
-# Pinned to vectorize-io/hindsight v0.8.4 (digest below; label
-# org.opencontainers.image.version=0.8.4, image revision 92f433c9 = the
-# v0.8.4 tag commit, built 2026-07-01). Bumped from v0.8.2 (sha256:7c069db2…)
-# to pick up 0.8.3 (merges divergent alembic heads, widens bank_id columns)
-# and 0.8.4. Prior history: v0.7.1→v0.8.2 fixed the `batch_retain`
+# Pinned to vectorize-io/hindsight v0.8.5 (digest below; label
+# org.opencontainers.image.version=0.8.5, image revision 705757f3, built
+# 2026-07-22). Bumped from v0.8.4 (sha256:2c60f233…) to pick up
+# `hindsight-admin repair-bank` — upstream #2645: per-(bank, fact_type)
+# vector indexes never self-heal, so banks populated outside the create-time
+# path fall back to the global HNSW + post-filter and silently under-return
+# recall candidates. 0.8.5 ALSO lands natively two fixes switchroom used to
+# carry as patches in this file (the unit_entities FK-race, upstream #2662,
+# and `tools=[]` on the standard claude_code call), both of which were
+# dropped in the same commit as this bump. Applying it runs 4 alembic
+# migrations (head b57a7c9e0d13 → d7b2f8a1c934), one of which drops the
+# unused `search_vector` column from the invalidated_memory_units archive.
+# Prior history: v0.8.2→v0.8.4 merged divergent alembic heads and widened
+# bank_id columns; v0.7.1→v0.8.2 fixed the `batch_retain`
 # ForeignKeyViolation on `unit_entities` (switchroom #2392). NOTE: upstream
 # publishes only `:latest` (no `:vX.Y.Z` tag in ghcr), so the digest IS the
 # version pin. A bump runs DB migrations on the persisted memory volume —
@@ -50,8 +59,8 @@
 # the pinned image makes the shim's cold-boot fallback advertise props the
 # server silently drops, and the agent then believes a filter applied when it
 # did not.
-# switchroom:hindsight-api-version=0.8.4
-FROM ghcr.io/vectorize-io/hindsight:latest@sha256:2c60f233eaba8f51db31adb920a560735aaf6f314e4b63c36c73159742dfa1a7
+# switchroom:hindsight-api-version=0.8.5
+FROM ghcr.io/vectorize-io/hindsight:latest@sha256:0710076cd1539b4f89537d2e5b0ea1e4d179885bc12809a56cf748c538c8c4fb
 
 USER root
 
@@ -181,340 +190,6 @@ f.write_text(s)
 t = f.read_text()
 assert NEW_PATH in t and OLD_SS not in t and 'mkdtemp(prefix="hindsight-claude-code-")' not in t, "switchroom #2392 patch: verification failed"
 print("switchroom #2392: claude_code env isolation neutralized (CLAUDE_CONFIG_DIR=/run/claude-creds, SECURESTORAGE override dropped)")
-PYEOF
-
-# max_turns/ToolSearch standard-call fix: the STANDARD (non-tool) LLM-call
-# path in claude_code_llm.py builds `ClaudeAgentOptions` with
-# `allowed_tools=[]` but WITHOUT `tools=[]`. Clearing allowed_tools does NOT
-# unload the built-in Claude Code CLI tools — they stay resident, so on a
-# plain text-generation call Claude burns its single `max_turns=1` turn on a
-# ToolSearch step and then errors with "Reached maximum number of turns (1)".
-# The provider retries, wasting tokens and intermittently failing memory ops
-# (fact extraction / recall). The TOOL-calling path further down the SAME
-# file already carries the correct shape (`tools=[]` + `max_turns=2`, with a
-# comment) — this patch brings the standard path to parity: drop the built-in
-# CLI tools entirely so ToolSearch can't fire, and give one turn of headroom
-# so a stray tool turn can't wall a tool-less generation. Anchored tightly on
-# the `# Single-turn for API-style interactions` comment so we touch ONLY the
-# standard path, never the tool-calling one. Self-verifying: the build FAILS
-# LOUDLY if upstream reformats this call, so we never silently ship the
-# regression.
-RUN python3 - <<'PYEOF'
-import pathlib
-f = pathlib.Path("/app/api/hindsight_api/engine/providers/claude_code_llm.py")
-s = f.read_text()
-OLD = (
-    "            max_turns=1,  # Single-turn for API-style interactions\n"
-    "            allowed_tools=[],  # Disable tools for standard LLM calls\n"
-)
-NEW = (
-    "            tools=[],  # switchroom: disable built-in CLI tools so ToolSearch can't consume the single turn (max_turns wall / wasted-retry fix)\n"
-    "            max_turns=2,  # switchroom: headroom so a stray ToolSearch turn can't wall a tool-less text-gen call\n"
-    "            allowed_tools=[],  # Disable tools for standard LLM calls\n"
-)
-assert s.count(OLD) == 1, "switchroom max_turns/ToolSearch standard-call fix: the standard-call ClaudeAgentOptions anchor (max_turns=1 # Single-turn for API-style interactions + allowed_tools=[]) was not found exactly once — upstream reformatted the standard-call ClaudeAgentOptions; re-author this patch in docker/Dockerfile.hindsight"
-s = s.replace(OLD, NEW, 1)
-f.write_text(s)
-t = f.read_text()
-assert NEW in t, "switchroom max_turns/ToolSearch standard-call fix: verification failed — patched block not present"
-assert "            tools=[],  # switchroom" in t, "switchroom max_turns/ToolSearch standard-call fix: tools=[] not present on the standard path after patch"
-assert "max_turns=1,  # Single-turn" not in t, "switchroom max_turns/ToolSearch standard-call fix: a bare max_turns=1 standard-call still remains after patch"
-print("switchroom max_turns/ToolSearch standard-call fix: standard LLM call now sends tools=[] + max_turns=2 (ToolSearch can no longer wall the turn)")
-PYEOF
-
-# unit_entities FK-race fix: upstream v0.8.4 defect (to-be-filed upstream issue).
-# Entity resolution (retain Phase-1) and the unit_entities child insert (Phase-2)
-# run in SEPARATE committed transactions. Between them, graph_maintenance's
-# prune_orphan_entities can delete an entity that momentarily has no
-# unit_entities reference — so the Phase-2 bulk_insert_unit_entities then
-# violates fk_unit_entities_entity_id_entities. It is deterministic and
-# NON-retryable, so the memory is silently dropped. It fires on session_handoff
-# re-ingest (observed live). Deterministic repro flips 15/15 RED -> 0/15 with
-# memories persisted once the fix is in.
-#
-# Fix (proven end-to-end on the real retain orchestrator path in an isolated
-# scratch container): Phase-2 re-asserts the parent entity row in the SAME
-# transaction as the child insert (INSERT ... ON CONFLICT DO NOTHING),
-# resurrecting any concurrently-pruned parent before the FK is checked — a live
-# unit's referent is not an orphan. This threads the minimal entity metadata
-# Phase-1 already holds (entity_id, bank_id, canonical_name; the name is NOT NULL
-# and unrecoverable once the row is pruned, so it must be carried through) from
-# resolve_entities_only up through the Phase-1 result into the Phase-2 link call.
-# Callers that don't pass entity_records keep the exact pre-existing behavior.
-#
-# Self-verifying: each anchor asserts exactly-once against unmodified upstream
-# v0.8.4 source; the build FAILS LOUDLY if upstream reformats any of the six
-# touched functions, so we never silently ship a half-applied patch or drop the
-# fix. Guarded by tests/docker/dockerfile-hindsight-bakes.test.ts.
-RUN python3 - <<'PYEOF'
-import pathlib
-
-BASE = pathlib.Path("/app/api/hindsight_api/engine")
-
-
-def apply(rel, edits):
-    f = BASE / rel
-    s = f.read_text()
-    for anchor, repl in edits:
-        n = s.count(anchor)
-        assert n == 1, (
-            f"switchroom hindsight FK-race patch: anchor found {n}x (expected 1) "
-            f"in {rel} — upstream reformatted; re-author this patch in "
-            f"docker/Dockerfile.hindsight. Anchor head: {anchor.splitlines()[0]!r}"
-        )
-        s = s.replace(anchor, repl, 1)
-    f.write_text(s)
-    return s
-
-
-# ---- 1. db/ops_postgresql.py : add idempotent reassert_entities() ----
-ops_new = apply("db/ops_postgresql.py", [
-    (
-        "            bank_id,\n"
-        "            missing_names,\n"
-        "        )\n"
-        "\n"
-        "    async def bulk_insert_unit_entities(",
-        "            bank_id,\n"
-        "            missing_names,\n"
-        "        )\n"
-        "\n"
-        "    async def reassert_entities(\n"
-        "        self,\n"
-        "        conn: DatabaseConnection,\n"
-        "        table: str,\n"
-        "        entity_ids: list,\n"
-        "        bank_ids: list,\n"
-        "        canonical_names: list,\n"
-        "    ) -> None:\n"
-        '        """Re-assert (id, bank_id, canonical_name) entity rows idempotently.\n'
-        "\n"
-        "        Resurrects any parent entity that graph_maintenance.prune_orphan_entities\n"
-        "        deleted in the window between Phase-1 resolution and the Phase-2\n"
-        "        unit_entities child insert. Runs on the SAME connection/transaction as\n"
-        "        the child insert, so the FK is satisfied at check time regardless of\n"
-        "        prune timing. ON CONFLICT DO NOTHING leaves a still-present row untouched.\n"
-        '        """\n'
-        "        await conn.execute(\n"
-        '            f"""\n'
-        "            INSERT INTO {table} (id, bank_id, canonical_name)\n"
-        "            SELECT i, b, n\n"
-        "            FROM unnest($1::uuid[], $2::text[], $3::text[]) AS t(i, b, n)\n"
-        "            ON CONFLICT DO NOTHING\n"
-        '            """,\n'
-        "            entity_ids,\n"
-        "            bank_ids,\n"
-        "            canonical_names,\n"
-        "        )\n"
-        "\n"
-        "    async def bulk_insert_unit_entities(",
-    ),
-])
-
-# ---- 2. entity_resolver.py : entity_records param + same-txn reassert ----
-er_new = apply("entity_resolver.py", [
-    (
-        "        unit_entity_pairs: list[tuple[str, str]] | list[tuple[str, str, datetime | None]],\n"
-        "        conn=None,\n"
-        "    ):",
-        "        unit_entity_pairs: list[tuple[str, str]] | list[tuple[str, str, datetime | None]],\n"
-        "        conn=None,\n"
-        "        entity_records: dict[str, dict] | None = None,\n"
-        "    ):",
-    ),
-    (
-        "            async with acquire_with_retry(self.pool) as conn:\n"
-        "                return await self._link_units_to_entities_batch_impl(conn, normalized)\n"
-        "        else:\n"
-        "            return await self._link_units_to_entities_batch_impl(conn, normalized)",
-        "            async with acquire_with_retry(self.pool) as conn:\n"
-        "                return await self._link_units_to_entities_batch_impl(conn, normalized, entity_records)\n"
-        "        else:\n"
-        "            return await self._link_units_to_entities_batch_impl(conn, normalized, entity_records)",
-    ),
-    (
-        "    async def _link_units_to_entities_batch_impl(self, conn, unit_entity_pairs: list[tuple[str, str, datetime | None]]):",
-        "    async def _link_units_to_entities_batch_impl(self, conn, unit_entity_pairs: list[tuple[str, str, datetime | None]], entity_records: dict[str, dict] | None = None):",
-    ),
-    (
-        "        unit_ids = [p[0] for p in sorted_pairs]\n"
-        "        entity_ids = [p[1] for p in sorted_pairs]\n"
-        "\n"
-        "        await self._ops.bulk_insert_unit_entities(",
-        "        unit_ids = [p[0] for p in sorted_pairs]\n"
-        "        entity_ids = [p[1] for p in sorted_pairs]\n"
-        "\n"
-        "        # Race guard: re-assert the parent entity rows in the SAME transaction\n"
-        "        # as the child insert below, resurrecting any entity that\n"
-        "        # graph_maintenance pruned in the Phase-1 -> Phase-2 window. A live\n"
-        "        # unit's referent is not an orphan. No-op when the rows already exist.\n"
-        "        if entity_records:\n"
-        "            reassert_ids: list = []\n"
-        "            reassert_banks: list = []\n"
-        "            reassert_names: list = []\n"
-        "            seen: set = set()\n"
-        "            for eid in entity_ids:\n"
-        "                if eid in seen:\n"
-        "                    continue\n"
-        "                seen.add(eid)\n"
-        "                rec = entity_records.get(eid)\n"
-        "                if rec is None:\n"
-        "                    rec = entity_records.get(str(eid))\n"
-        "                if not rec:\n"
-        "                    continue\n"
-        '                bank_id = rec.get("bank_id")\n'
-        '                canonical_name = rec.get("canonical_name")\n'
-        "                if bank_id is None or canonical_name is None:\n"
-        "                    continue\n"
-        "                reassert_ids.append(eid)\n"
-        "                reassert_banks.append(bank_id)\n"
-        "                reassert_names.append(canonical_name)\n"
-        "            if reassert_ids:\n"
-        "                await self._ops.reassert_entities(\n"
-        "                    conn,\n"
-        '                    fq_table("entities"),\n'
-        "                    reassert_ids,\n"
-        "                    reassert_banks,\n"
-        "                    reassert_names,\n"
-        "                )\n"
-        "\n"
-        "        await self._ops.bulk_insert_unit_entities(",
-    ),
-])
-
-# ---- 3. retain/types.py : EntityResolutionResult gains entity_records ----
-apply("retain/types.py", [
-    (
-        "    resolved_entity_ids: list[str]\n"
-        "    entity_to_unit: list[tuple]\n"
-        "    unit_to_entity_ids: dict[str, list[str]]\n"
-        "\n"
-        "\n"
-        "@dataclass\n"
-        "class Phase1Result:",
-        "    resolved_entity_ids: list[str]\n"
-        "    entity_to_unit: list[tuple]\n"
-        "    unit_to_entity_ids: dict[str, list[str]]\n"
-        "    # id -> {\"bank_id\":.., \"canonical_name\":..} for the resolved entities so\n"
-        "    # Phase-2's unit_entities child insert can re-assert (resurrect) a parent\n"
-        "    # entity concurrently pruned by graph_maintenance, in the same transaction.\n"
-        "    entity_records: dict[str, dict] | None = None\n"
-        "\n"
-        "\n"
-        "@dataclass\n"
-        "class Phase1Result:",
-    ),
-])
-
-# ---- 4. retain/link_utils.py : build + return entity_records (4-tuple) ----
-apply("retain/link_utils.py", [
-    (
-        '        _log(log_buffer, "  [6.2] Entity resolution (batched): 0 entities", level="debug")\n'
-        "        return [], [], {}",
-        '        _log(log_buffer, "  [6.2] Entity resolution (batched): 0 entities", level="debug")\n'
-        "        return [], [], {}, {}",
-    ),
-    (
-        "    _log(\n"
-        "        log_buffer,\n"
-        '        f"  [6.2] Entity resolution (batched): {len(all_entities_flat)} entities resolved in {time.time() - step_start:.3f}s",\n'
-        '        level="debug",\n'
-        "    )\n"
-        "\n"
-        "    return resolved_entity_ids, entity_to_unit, unit_to_entity_ids",
-        "    _log(\n"
-        "        log_buffer,\n"
-        '        f"  [6.2] Entity resolution (batched): {len(all_entities_flat)} entities resolved in {time.time() - step_start:.3f}s",\n'
-        '        level="debug",\n'
-        "    )\n"
-        "\n"
-        "    # Thread minimal entity metadata (id -> bank_id + canonical_name) so the\n"
-        "    # Phase-2 unit_entities child insert can re-assert a concurrently-pruned\n"
-        "    # parent in the SAME transaction. canonical_name is NOT NULL and gone once\n"
-        "    # graph_maintenance prunes the row, so it must be carried from here.\n"
-        "    entity_records: dict[str, dict] = {}\n"
-        "    for idx, ent in enumerate(all_entities_flat):\n"
-        "        eid = resolved_entity_ids[idx]\n"
-        '        name = ent.get("text")\n'
-        "        if eid is None or not name:\n"
-        "            continue\n"
-        '        entity_records.setdefault(str(eid), {"bank_id": bank_id, "canonical_name": name})\n'
-        "\n"
-        "    return resolved_entity_ids, entity_to_unit, unit_to_entity_ids, entity_records",
-    ),
-])
-
-# ---- 5. retain/entity_processing.py : 4-tuple early return ----
-apply("retain/entity_processing.py", [
-    (
-        "    if not unit_ids or not facts:\n"
-        "        return [], [], {}",
-        "    if not unit_ids or not facts:\n"
-        "        return [], [], {}, {}",
-    ),
-])
-
-# ---- 6. retain/orchestrator.py : unpack + store + thread entity_records ----
-apply("retain/orchestrator.py", [
-    (
-        "        resolved_entity_ids, entity_to_unit, unit_to_entity_ids = await entity_processing.resolve_entities(",
-        "        resolved_entity_ids, entity_to_unit, unit_to_entity_ids, entity_records = await entity_processing.resolve_entities(",
-    ),
-    (
-        "        entities=EntityResolutionResult(\n"
-        "            resolved_entity_ids=resolved_entity_ids,\n"
-        "            entity_to_unit=entity_to_unit,\n"
-        "            unit_to_entity_ids=unit_to_entity_ids,\n"
-        "        ),",
-        "        entities=EntityResolutionResult(\n"
-        "            resolved_entity_ids=resolved_entity_ids,\n"
-        "            entity_to_unit=entity_to_unit,\n"
-        "            unit_to_entity_ids=unit_to_entity_ids,\n"
-        "            entity_records=entity_records,\n"
-        "        ),",
-    ),
-    (
-        "    unit_to_entity_ids: dict[str, list[str]],\n"
-        "    semantic_ann_links: list[tuple],\n"
-        "    skip_semantic_links: bool = False,\n"
-        "    outbox_callback=None,\n"
-        "    ops=None,\n"
-        ") -> list[list[str]]:",
-        "    unit_to_entity_ids: dict[str, list[str]],\n"
-        "    semantic_ann_links: list[tuple],\n"
-        "    skip_semantic_links: bool = False,\n"
-        "    outbox_callback=None,\n"
-        "    ops=None,\n"
-        "    entity_records: dict[str, dict] | None = None,\n"
-        ") -> list[list[str]]:",
-    ),
-    (
-        "        await entity_resolver.link_units_to_entities_batch(unit_entity_pairs, conn=conn)",
-        "        await entity_resolver.link_units_to_entities_batch(\n"
-        "            unit_entity_pairs, conn=conn, entity_records=entity_records\n"
-        "        )",
-    ),
-    (
-        "                        unit_to_entity_ids=phase1.entities.unit_to_entity_ids,\n"
-        "                        semantic_ann_links=[],",
-        "                        unit_to_entity_ids=phase1.entities.unit_to_entity_ids,\n"
-        "                        entity_records=phase1.entities.entity_records,\n"
-        "                        semantic_ann_links=[],",
-    ),
-    (
-        "                    unit_to_entity_ids=phase1.entities.unit_to_entity_ids,\n"
-        "                    semantic_ann_links=phase1.semantic_ann_links,",
-        "                    unit_to_entity_ids=phase1.entities.unit_to_entity_ids,\n"
-        "                    entity_records=phase1.entities.entity_records,\n"
-        "                    semantic_ann_links=phase1.semantic_ann_links,",
-    ),
-])
-
-# ---- Post-conditions: fail loud if any edit silently no-oped ----
-assert "async def reassert_entities(" in ops_new, "switchroom hindsight FK-race patch: reassert_entities missing after patch"
-assert "entity_records.get(str(eid))" in er_new, "switchroom hindsight FK-race patch: reassert lookup fallback missing after patch"
-assert "entity_records=phase1.entities.entity_records" in (BASE / "retain/orchestrator.py").read_text(), "switchroom hindsight FK-race patch: orchestrator threading missing after patch"
-print("switchroom hindsight unit_entities FK-race patch: reassert_entities + entity_records threading applied (Phase-2 resurrects concurrently-pruned parent in same txn)")
 PYEOF
 
 # Cross-encoder saturation fix: `apply_combined_scoring` in
@@ -889,229 +564,6 @@ assert '        return " | ".join(tokens)' in pg, "switchroom hindsight BM25 com
 print("switchroom hindsight BM25 compound-token patch: intact compound tokens appended (strict superset of upstream tokens); native tsquery left as a plain OR join")
 PYEOF
 
-# Duplicate-ANN-scan fix: `retrieve_all_fact_types_parallel` in
-# engine/search/retrieval.py runs the vector-similarity scan TWICE per recall,
-# the second one serialized behind the first.
-#
-#   Step 2 opens one pooled connection and runs the combined semantic + BM25
-#   CTE. The semantic arm is `ORDER BY embedding <=> $1::vector LIMIT n` per
-#   fact_type — the ANN scan.
-#   Step 3 then gathers the per-fact-type graph tasks, and passes
-#   `semantic_seeds=None` into `retriever.retrieve(...)` even though Step 2
-#   just computed exactly those rows. link_expansion_retrieval.py's
-#   `retrieve()` reads
-#       if semantic_seeds: all_seeds = list(semantic_seeds)
-#       else:              all_seeds = await _find_semantic_seeds(...)
-#   and `_find_semantic_seeds` issues its own
-#   `ORDER BY embedding <=> $1::vector LIMIT $5`.
-#
-# So the pipeline does an ANN scan, throws it away for seeding purposes, and
-# then does a second one on a fresh connection AFTER Step 2's `async with`
-# block has exited. Measured on this deployment (foreground recall, n=30):
-# mean 4.218s / p50 4.364s / p90 5.831s end to end, of which the retrieval
-# residual is ~1.73s and graph is ~1.45s of that (84%).
-#
-# Fix: thread Step 2's semantic results through as `semantic_seeds`. The
-# parameter already exists and is already honoured by the receiving code —
-# nothing downstream changes shape.
-#
-# EQUIVALENCE, which is the whole safety argument. `retrieve()` uses the seeds
-# for their IDs ONLY (`seed_ids = list({s.id for s in all_seeds})`), so the
-# seed set is equivalent iff it contains the same unit ids. The two queries are
-# the same query:
-#   * same table, same `bank_id = $2`, same `fact_type`, same
-#     `embedding IS NOT NULL`, same `ORDER BY embedding <=> $1::vector`;
-#   * the same tags / tag_groups / created_after / created_before values, built
-#     by the same helpers — Step 3 forwards the identical arguments Step 2 got;
-#   * the seed query's `threshold=0.3` equals the shipped
-#     DEFAULT_SEMANTIC_MIN_SIMILARITY the arm uses, and `limit=20` is far below
-#     the arm's per-fact-type fetch (max(budget*5, 100) >= 100).
-# The helper therefore re-derives the seed set from the arm's rows: sort by
-# similarity descending, keep >= 0.3, take 20.
-#
-# It returns None (= keep upstream's own query) in the two cases where that
-# derivation is NOT provably the same set:
-#   1. `min_scores.semantic` raised the arm's floor above 0.3. The arm's
-#      candidate pool is then NARROWER than the seed query's, so rows the seed
-#      query would have returned were never fetched. Falling back here is the
-#      difference between a faster recall and a quieter one.
-#   2. The arm's Python trim bit (`len(rows) >= budget`) and every retained row
-#      still cleared 0.3 while fewer than 20 rows exist. Only reachable with a
-#      thinking_budget below 20 (the shipped fixed budgets are 100/300/1000),
-#      but it is the one shape where rows the seed query would have seen could
-#      have been trimmed away.
-# In every other case the trimmed-away rows are provably all below 0.3 (the
-# retained rows are the highest-similarity ones), so they could never have been
-# seeds.
-#
-# The helper sorts explicitly rather than trusting the row order the UNION ALL
-# happened to return, so it introduces NO new ordering assumption of its own —
-# it is at worst exactly as order-dependent as upstream's existing trim, which
-# already decides which semantic rows the user gets.
-#
-# `temporal_seeds` is deliberately left None. Step 2's temporal results come
-# from `retrieve_temporal_combined`, which applies time-bucket coverage
-# selection — a different set with different semantics, and upstream currently
-# passes NO temporal seeds at all, so threading them would ADD seeds and change
-# graph output rather than reproduce it. Out of scope here.
-#
-# Also out of scope, deliberately: the Step2/Step3 serialization itself and the
-# connection budget. This patch removes the duplicate scan only.
-#
-# Self-verifying: the build FAILS LOUDLY if upstream reformats either anchor or
-# retunes `_find_semantic_seeds`' limit/threshold call-site defaults out from
-# under the mirrored constants. Guarded behaviourally by
-# tests/docker/hindsight-search-patches.test.ts and structurally by
-# tests/docker/dockerfile-hindsight-bakes.test.ts.
-RUN python3 - <<'PYEOF'
-import pathlib
-
-f = pathlib.Path("/app/api/hindsight_api/engine/search/retrieval.py")
-s = f.read_text()
-
-# The mirrored constants must still match link_expansion_retrieval's call site,
-# or the derived seed set is not the set upstream would have produced.
-le = pathlib.Path("/app/api/hindsight_api/engine/search/link_expansion_retrieval.py").read_text()
-assert "all_seeds = await _find_semantic_seeds(" in le, "switchroom hindsight duplicate-ANN-scan patch: _find_semantic_seeds call site not found in link_expansion_retrieval.py — upstream restructured the seeding path; re-author this patch"
-assert "                    limit=20,\n                    threshold=0.3,\n" in le, "switchroom hindsight duplicate-ANN-scan patch: _find_semantic_seeds is no longer called with limit=20/threshold=0.3 — the mirrored _GRAPH_SEED_* constants would derive the WRONG seed set; re-author this patch"
-assert "            if semantic_seeds:\n                all_seeds = list(semantic_seeds)\n" in le, "switchroom hindsight duplicate-ANN-scan patch: retrieve() no longer honours semantic_seeds — threading them would be a no-op; re-author this patch"
-assert "seed_ids = list({s.id for s in all_seeds})" in le, "switchroom hindsight duplicate-ANN-scan patch: seeds are no longer consumed by id alone — the equivalence argument (id-set equality) no longer holds; re-author this patch"
-
-# --- 1. the seed-derivation helper -----------------------------------------
-DEF_ANCHOR = "async def retrieve_all_fact_types_parallel(\n"
-
-HELPER = '''# switchroom: mirrors link_expansion_retrieval._find_semantic_seeds' call-site
-# defaults. The build asserts they still match upstream, so a retune fails the
-# image build instead of silently deriving a different seed set.
-_GRAPH_SEED_LIMIT = 20
-_GRAPH_SEED_MIN_SIMILARITY = 0.3
-
-
-def _graph_semantic_seeds(
-    semantic_results: list[RetrievalResult],
-    arm_limit: int,
-    arm_min_similarity: float,
-) -> list[RetrievalResult] | None:
-    """switchroom: re-derive the graph seed set from the semantic arm's rows.
-
-    Returns the seeds LinkExpansionRetriever would have found for itself, so the
-    pipeline stops issuing a second ANN scan (`ORDER BY embedding <=> ...`)
-    serialized behind the one the semantic arm already ran.
-
-    The seeds are consumed by id alone, and both queries are the same query over
-    the same table with the same bank/fact_type/tag/created filters and the same
-    ordering, so the id set is reproducible from the arm's rows: take the rows at
-    or above the seed threshold, best-first, up to the seed limit.
-
-    Returns None (meaning: let upstream run its own query) whenever that is not
-    provably the same set:
-
-    * ``arm_min_similarity`` above the seed threshold. A per-request
-      ``min_scores.semantic`` floor makes the arm's candidate pool NARROWER than
-      the seed query's, so qualifying rows were never fetched.
-    * The arm's trim bit while every retained row still cleared the seed
-      threshold and fewer than the seed limit survived, i.e. rows the seed query
-      would have returned may have been trimmed away.
-
-    An empty list is returned when the arm genuinely found nothing at or above
-    the threshold; upstream treats that as falsy and re-queries, which is
-    harmless because that query returns nothing either.
-    """
-    if arm_min_similarity > _GRAPH_SEED_MIN_SIMILARITY:
-        return None
-    if any(r.similarity is None for r in semantic_results):
-        return None
-
-    # Sorted explicitly: never depend on the row order the UNION ALL returned.
-    ranked = sorted(semantic_results, key=lambda r: r.similarity, reverse=True)
-    seeds = [r for r in ranked if r.similarity >= _GRAPH_SEED_MIN_SIMILARITY][:_GRAPH_SEED_LIMIT]
-
-    if len(seeds) < _GRAPH_SEED_LIMIT and len(seeds) == len(ranked) and len(ranked) >= arm_limit:
-        return None
-    return seeds
-
-
-'''
-
-n = s.count(DEF_ANCHOR)
-assert n == 1, (
-    f"switchroom hindsight duplicate-ANN-scan patch: retrieve_all_fact_types_parallel anchor found {n}x "
-    "(expected 1) in search/retrieval.py — upstream reformatted the signature; re-author this patch "
-    "in docker/Dockerfile.hindsight"
-)
-s = s.replace(DEF_ANCHOR, HELPER + DEF_ANCHOR, 1)
-
-# --- 2. the arm's effective similarity floor, hoisted for the helper --------
-OLD_FLOOR = (
-    "    semantic_bm25_start = time.time()\n"
-    "    temporal_results_by_ft: dict[str, list[RetrievalResult]] = {}\n"
-    "    temporal_time = 0.0\n"
-)
-NEW_FLOOR = (
-    "    semantic_bm25_start = time.time()\n"
-    "    temporal_results_by_ft: dict[str, list[RetrievalResult]] = {}\n"
-    "    temporal_time = 0.0\n"
-    "    # switchroom: the floor retrieve_semantic_bm25_combined will apply to the\n"
-    "    # semantic arm, recomputed here so _graph_semantic_seeds can tell whether\n"
-    "    # the arm's candidate pool covers the graph seed query's.\n"
-    "    _arm_min_similarity = min_semantic if min_semantic is not None else get_config().semantic_min_similarity\n"
-)
-n = s.count(OLD_FLOOR)
-assert n == 1, (
-    f"switchroom hindsight duplicate-ANN-scan patch: Step 2 preamble anchor found {n}x (expected 1) "
-    "in search/retrieval.py — upstream reformatted retrieve_all_fact_types_parallel's Step 2; "
-    "re-author this patch in docker/Dockerfile.hindsight"
-)
-s = s.replace(OLD_FLOOR, NEW_FLOOR, 1)
-
-# The hoisted expression must stay byte-identical to the one inside the arm.
-assert (
-    "    sem_min = min_semantic if min_semantic is not None else config.semantic_min_similarity\n" in s
-), "switchroom hindsight duplicate-ANN-scan patch: retrieve_semantic_bm25_combined no longer derives sem_min as `min_semantic if min_semantic is not None else config.semantic_min_similarity` — the hoisted _arm_min_similarity would no longer describe the arm; re-author this patch"
-
-# --- 3. the call site -------------------------------------------------------
-OLD_CALL = (
-    "            query_text=query_text,\n"
-    "            semantic_seeds=None,\n"
-    "            temporal_seeds=None,\n"
-)
-NEW_CALL = (
-    "            query_text=query_text,\n"
-    "            # switchroom: Step 2 already ran this exact ANN scan. Passing its rows\n"
-    "            # through removes a second, serialized `ORDER BY embedding <=> ...`\n"
-    "            # per fact type. None here means the derivation was not provably\n"
-    "            # equivalent, so upstream runs its own query (correctness first).\n"
-    "            semantic_seeds=_graph_semantic_seeds(\n"
-    "                semantic_bm25_results.get(ft, ([], []))[0],\n"
-    "                thinking_budget,\n"
-    "                _arm_min_similarity,\n"
-    "            ),\n"
-    "            # switchroom: deliberately still None. Step 2's temporal rows come from\n"
-    "            # coverage selection, not from this query, so threading them would ADD\n"
-    "            # seeds rather than reproduce upstream's (which passes none).\n"
-    "            temporal_seeds=None,\n"
-)
-n = s.count(OLD_CALL)
-assert n == 1, (
-    f"switchroom hindsight duplicate-ANN-scan patch: Step 3 retriever.retrieve call site anchor found {n}x "
-    "(expected 1) in search/retrieval.py — upstream reformatted run_graph_for_fact_type; re-author this "
-    "patch in docker/Dockerfile.hindsight"
-)
-s = s.replace(OLD_CALL, NEW_CALL, 1)
-
-f.write_text(s)
-
-t = f.read_text()
-assert "def _graph_semantic_seeds(" in t, "switchroom hindsight duplicate-ANN-scan patch: helper missing after patch"
-assert "_GRAPH_SEED_LIMIT = 20" in t and "_GRAPH_SEED_MIN_SIMILARITY = 0.3" in t, "switchroom hindsight duplicate-ANN-scan patch: mirrored seed constants missing after patch"
-assert "semantic_seeds=_graph_semantic_seeds(" in t, "switchroom hindsight duplicate-ANN-scan patch: call site still passes something other than the derived seeds"
-assert "            semantic_seeds=None,\n" not in t, "switchroom hindsight duplicate-ANN-scan patch: a semantic_seeds=None call site survives — the duplicate ANN scan is still reachable"
-assert t.count("temporal_seeds=None,") == 1, "switchroom hindsight duplicate-ANN-scan patch: temporal_seeds must stay None exactly once (out of scope for this patch)"
-assert "_arm_min_similarity = min_semantic if min_semantic is not None else get_config().semantic_min_similarity" in t, "switchroom hindsight duplicate-ANN-scan patch: hoisted arm floor missing after patch"
-compile(t, str(f), "exec")
-print("switchroom hindsight duplicate-ANN-scan patch: graph expansion now seeds off Step 2's semantic arm (one ANN scan per fact type instead of two); falls back to upstream's own query whenever the derived seed set is not provably identical")
-PYEOF
-
 # Empty-TimeoutError-message fix: both retry loops in
 # engine/providers/litellm_llm.py end their timeout handler with a bare
 # `raise`, which re-raises the asyncio.TimeoutError produced by
@@ -1280,13 +732,21 @@ cfg_new = apply("config.py", [
         "            consolidation_recall_max_concurrent=_consolidation_recall_max_concurrent(os.getenv),\n",
     ),
     (
-        '                f"Reduce reservations or increase HINDSIGHT_API_WORKER_MAX_SLOTS."\n'
+        # switchroom: anchored on the LAST clause of validate() rather than the
+        # worker-slot one — 0.8.5 appended the operation_retention_days /
+        # operation_cleanup_batch_size checks after it, so the old anchor's
+        # trailing `@classmethod` context no longer followed.
+        "        if self.operation_cleanup_batch_size < 1:\n"
+        "            raise ValueError(\n"
+        '                f"{ENV_OPERATION_CLEANUP_BATCH_SIZE} must be >= 1, got {self.operation_cleanup_batch_size}"\n'
         "            )\n"
         "\n"
         "    @classmethod\n"
         '    def from_env(cls) -> "HindsightConfig":\n',
 
-        '                f"Reduce reservations or increase HINDSIGHT_API_WORKER_MAX_SLOTS."\n'
+        "        if self.operation_cleanup_batch_size < 1:\n"
+        "            raise ValueError(\n"
+        '                f"{ENV_OPERATION_CLEANUP_BATCH_SIZE} must be >= 1, got {self.operation_cleanup_batch_size}"\n'
         "            )\n"
         "\n"
         "        # switchroom: the background-recall reservation must leave the foreground a\n"
@@ -1666,13 +1126,18 @@ poller_new = apply("worker/poller.py", [
         '    """\n',
     ),
     (
+        # switchroom: `max_retries` was added to this signature in 0.8.5; it is
+        # carried in the anchor so the patch still binds to the whole parameter
+        # list rather than a prefix that could match a reformatted signature.
         "        slot_reservations: dict[str, int] | None = None,\n"
         "        consolidation_bank_priority: dict[str, int] | None = None,\n"
+        "        max_retries: int = 3,\n"
         "    ):\n",
 
         "        slot_reservations: dict[str, int] | None = None,\n"
         "        slot_limits: dict[str, int] | None = None,\n"
         "        consolidation_bank_priority: dict[str, int] | None = None,\n"
+        "        max_retries: int = 3,\n"
         "    ):\n",
     ),
     (

--- a/docs/operators/hindsight-memory.md
+++ b/docs/operators/hindsight-memory.md
@@ -66,6 +66,101 @@ docker exec switchroom-hindsight sh -lc '
 switchroom agent restart test-harness --wait --force   # or: docker restart switchroom-hindsight
 ```
 
+## Rolling the base image BACK (schema first, then the digest)
+
+`docker/Dockerfile.hindsight` pins upstream Hindsight by digest, and a bump
+runs alembic migrations against the persisted `switchroom-hindsight-data`
+volume. **Rolling forward is one step; rolling back is two, in this order.**
+
+> **Reverting the pinned digest alone is not a rollback.** The older image
+> boots fine and then fails at runtime. Alembic's startup path upgrades to
+> `heads`, and when the database is at a revision the older code has never
+> heard of it logs `Database is at a newer migration revision than this code
+> version knows about … Skipping migrations` and carries on
+> (`hindsight_api/migrations.py`). So nothing stops you at boot; the damage
+> surfaces later, on whichever code path depends on a column the newer
+> schema dropped.
+
+### The order
+
+1. **Downgrade the schema first, while the newer image is still running.**
+   The newer image is the only one that has the down-revisions; the older one
+   cannot reverse migrations it does not ship.
+2. **Then repoint the digest** in `docker/Dockerfile.hindsight`, rebuild /
+   pull, and recreate the container.
+3. Take a `pg_dump` first (see "On-demand backup" above). A downgrade is not
+   guaranteed to be lossless — see the caveat below.
+
+### v0.8.5 → v0.8.4, concretely
+
+0.8.5 advances the head `b57a7c9e0d13` → `d7b2f8a1c934` over four
+migrations. The one that matters for a rollback is
+`e7c3a9f1b2d5_drop_archive_search_vector_column`, which does
+
+```sql
+ALTER TABLE invalidated_memory_units DROP COLUMN IF EXISTS search_vector
+```
+
+**0.8.4 requires that column.** Its archive round-trip builds the column list
+from `memory_units` and excludes only `"embedding"`
+(`engine/memory_engine.py:6579`), where 0.8.5 excludes `"embedding"` *and*
+`"search_vector"`. 0.8.4 has no special-casing for it at all
+(`grep -c search_vector` on 0.8.4's `memory_engine.py` → 0), so on 0.8.4
+against a 0.8.5 schema **every `invalidate_memory`, and every revert of an
+invalidated memory, fails with `column "search_vector" does not exist`.**
+
+Downgrade the whole 0.8.5 chain back to 0.8.4's head *before* repointing the
+digest:
+
+```bash
+docker exec switchroom-hindsight /app/api/.venv/bin/python - <<'PY'
+from pathlib import Path
+from alembic import command
+from alembic.config import Config
+import hindsight_api
+from hindsight_api.migrations import _set_alembic_main_option
+cfg = Config()
+_set_alembic_main_option(
+    cfg, "script_location", str(Path(hindsight_api.__file__).parent / "alembic"))
+_set_alembic_main_option(cfg, "sqlalchemy.url", "<the libpq URL for pg0>")
+command.downgrade(cfg, "b57a7c9e0d13")   # 0.8.4's head
+PY
+```
+
+The other three down-revisions in the chain only drop indexes and maintenance
+routines that 0.8.4 does not use, so the full downgrade is the clean target
+rather than a partial one.
+
+If you would rather not run alembic, the single statement that unblocks 0.8.4
+is the migration's own `_pg_downgrade` body, verbatim and idempotent:
+
+```bash
+docker exec switchroom-hindsight sh -lc '
+  PW=$(python3 -c "import json;print(json.load(open(\"/home/hindsight/.pg0/instances/hindsight/instance.json\"))[\"password\"])")
+  PGPASSWORD="$PW" /home/hindsight/.pg0/installation/*/bin/psql -U hindsight -h /tmp -d hindsight -c \
+    "ALTER TABLE invalidated_memory_units ADD COLUMN IF NOT EXISTS search_vector tsvector"
+'
+```
+
+That leaves `alembic_version` reading a revision 0.8.4 does not know, which
+0.8.4 tolerates (the skip above) — acceptable as an emergency unblock, but the
+alembic downgrade is the state you actually want.
+
+### The caveat: a correct rollback still loses BM25 coverage
+
+**The re-added column comes back empty.** Upstream says so in the migration
+itself — *"Re-added as the original tsvector creation type; comes back empty
+regardless"* — and nothing backfills it. Every memory archived while the fleet
+ran on 0.8.5 therefore has `search_vector IS NULL` after the downgrade. On
+0.8.4 those rows still round-trip, but when one is reverted out of the archive
+it lands back in `memory_units` with a NULL `search_vector`, i.e. **silently
+absent from the BM25 arm of recall** until something re-indexes it. Semantic
+and graph recall are unaffected.
+
+So: the ordered rollback restores *function*, not *fidelity*. If those
+archived memories matter, restore from a pre-upgrade `pg_dump` instead of
+downgrading in place.
+
 ## Self-maintenance (autovacuum + op retention)
 
 The same maintenance loop also, every tick (best-effort, idempotent):

--- a/src/cli/hindsight-mcp-shim.ts
+++ b/src/cli/hindsight-mcp-shim.ts
@@ -115,9 +115,18 @@ export const TOOLS_CACHE_FILENAME = "hindsight-tools-list.json";
  * harmless optimism: hindsight drops an unknown argument SILENTLY and answers
  * isError:false, so an agent that reads `list_memories.tags` off this manifest
  * and issues a tag-scoped query on 0.8.4 receives the UNFILTERED list and
- * believes it was filtered (verified live). The snapshot is therefore a
- * verbatim 0.8.4 capture with no forward-patch, and re-capturing it against
- * 0.8.5 belongs with the image bump in #3768.
+ * believes it was filtered (verified live). The snapshot is therefore always a
+ * capture of the PINNED image with no forward-patch, and re-capturing it is
+ * part of an image bump, not a follow-up to one.
+ *
+ * This table now describes 0.8.5, which the image pins: 0.8.5 registers the
+ * same 32 tools as 0.8.4 plus exactly three props — `list_memories.tags`,
+ * `list_memories.tags_match` and `create_mental_model.tags_match` (derived by
+ * dumping `create_mcp_server(...)`'s registration surface inside each pinned
+ * digest). Byte-equality with
+ * tests/fixtures/hindsight-tools-list.snapshot.json is asserted per tool in
+ * tests/memory.hindsight-contract.fixture.test.ts, so this table cannot drift
+ * in either direction without a red test.
  */
 export const FALLBACK_TOOL_TABLE: Record<string, [string[], string[]]> = {
   cancel_operation: [["operation_id"], ["bank_id", "operation_id"]],
@@ -125,7 +134,7 @@ export const FALLBACK_TOOL_TABLE: Record<string, [string[], string[]]> = {
   clear_mental_model: [["mental_model_id"], ["bank_id", "mental_model_id"]],
   create_bank: [["bank_id"], ["bank_id", "mission", "name"]],
   create_directive: [["content", "name"], ["bank_id", "content", "is_active", "name", "priority", "tags"]],
-  create_mental_model: [["name", "source_query"], ["bank_id", "max_tokens", "mental_model_id", "name", "source_query", "tags", "trigger_refresh_after_consolidation"]],
+  create_mental_model: [["name", "source_query"], ["bank_id", "max_tokens", "mental_model_id", "name", "source_query", "tags", "tags_match", "trigger_refresh_after_consolidation"]],
   delete_bank: [[], ["bank_id"]],
   delete_directive: [["directive_id"], ["bank_id", "directive_id"]],
   delete_document: [["document_id"], ["bank_id", "document_id"]],
@@ -140,7 +149,7 @@ export const FALLBACK_TOOL_TABLE: Record<string, [string[], string[]]> = {
   list_banks: [[], []],
   list_directives: [[], ["active_only", "bank_id", "tags"]],
   list_documents: [[], ["bank_id", "limit", "q"]],
-  list_memories: [[], ["bank_id", "limit", "offset", "q", "type"]],
+  list_memories: [[], ["bank_id", "limit", "offset", "q", "tags", "tags_match", "type"]],
   list_mental_models: [[], ["bank_id", "detail", "tags"]],
   list_operations: [[], ["bank_id", "limit", "status"]],
   list_tags: [[], ["bank_id", "limit", "q"]],

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2149,7 +2149,10 @@ export const HindsightConfigSchema = z.object({
       "(`HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS`: " +
       "HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY — a per-deployment " +
       "`bank-pattern:priority,...` map; unset means upstream's flat " +
-      "created_at FIFO across banks), plus the " +
+      "created_at FIFO across banks; and " +
+      "HINDSIGHT_CE_DECISIVE_RELATIVE_GAP — the rollback knob for " +
+      "switchroom's CE-saturation damping patch, a float; >= ~0.65 backs the " +
+      "damping out entirely, unset means the patch's own derived gap), plus the " +
       "embedded-PostgreSQL (pg0) sizing keys switchroom manages in " +
       "src/setup/hindsight-pg-defaults.ts (`HINDSIGHT_PG_ENV_KEYS`: " +
       "SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE, " +

--- a/src/setup/hindsight-perf-defaults.test.ts
+++ b/src/setup/hindsight-perf-defaults.test.ts
@@ -321,7 +321,7 @@ describe("operator override wins", () => {
     expect(got.size).toBe(0);
   });
 
-  it("is overridable on exactly these twenty-two keys, by name", () => {
+  it("is overridable on exactly these twenty-three keys, by name", () => {
     // Spelled out, NOT derived from the three group arrays. HINDSIGHT_PERF_ENV_KEYS
     // is DEFINED as the union of those arrays, so asserting it equals that union
     // is a tautology — it passes no matter which keys are in the arrays. The
@@ -351,6 +351,10 @@ describe("operator override wins", () => {
       "HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY",
       "HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS",
       "HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT",
+      // Not HINDSIGHT_API_* — a switchroom-patch knob (the CE-damping
+      // rollback hatch), read by the patched reranking module, never by
+      // upstream's config parser. Sorts last.
+      "HINDSIGHT_CE_DECISIVE_RELATIVE_GAP",
     ]);
   });
 
@@ -438,6 +442,67 @@ describe("HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY (override-only)", () 
     expect(runEnv(runArgs()).get("HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY")).toEqual([
       MAP,
     ]);
+  });
+});
+
+// ── the CE-damping rollback hatch ─────────────────────────────────────────
+describe("HINDSIGHT_CE_DECISIVE_RELATIVE_GAP (override-only, patch rollback hatch)", () => {
+  const KEY = "HINDSIGHT_CE_DECISIVE_RELATIVE_GAP";
+  const CAPS = [
+    { gpu: false, localLlm: false },
+    { gpu: true, localLlm: false },
+    { gpu: false, localLlm: true },
+    { gpu: true, localLlm: true },
+  ];
+  /** ≥ ~0.65 clamps the damping exponent to 1.0 — the full back-out value. */
+  const OFF = "1.0";
+
+  it("is managed, so a hindsight.env line for it is not silently discarded", () => {
+    // The bug: switchroom's CE-saturation damping patch documents this var as
+    // its rollback knob, but the key was absent from HINDSIGHT_PERF_ENV_KEYS
+    // and resolveHindsightPerfOverrides drops unmanaged keys without a word.
+    // The patch reads the var ONCE at import, so an unreached value has no
+    // runtime fallback: the documented escape hatch simply did not exist.
+    expect(HINDSIGHT_PERF_ENV_KEYS.has(KEY)).toBe(true);
+    // Override-only, not defaulted: shipping a value would replace the patch's
+    // own derived gap with a hard-coded one on every host.
+    expect(HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS.has(KEY)).toBe(true);
+  });
+
+  it("survives resolveHindsightPerfOverrides from BOTH sources", () => {
+    expect(resolveHindsightPerfOverrides({ [KEY]: OFF }).get(KEY)).toBe(OFF);
+    expect(resolveHindsightPerfOverrides(undefined, { [KEY]: OFF }).get(KEY)).toBe(OFF);
+  });
+
+  it.each(CAPS)(
+    "is NOT emitted on any host when unset (gpu=$gpu localLlm=$localLlm)",
+    (caps) => {
+      // Unset ⇒ the patch's shipped derived gap. Emitting anything here would
+      // turn a rollback hatch into a permanent calibration override.
+      expect(hindsightPerfEnv(caps).map(([k]) => k)).not.toContain(KEY);
+    },
+  );
+
+  it("reaches the docker-run argv AND the compose snippet with the operator's value", () => {
+    // The outcome that matters: the value an operator writes in
+    // switchroom.yaml is actually in the argv that launches the container.
+    // Without the key in the managed set both of these are undefined.
+    const perf = { env: { [KEY]: OFF }, processEnv: {} };
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false, perf);
+    expect(runEnv(runArgs()).get(KEY)).toEqual([OFF]);
+    expect(
+      composeEnv(
+        generateHindsightComposeSnippet(undefined, undefined, LOOPBACK_LITELLM, false, perf),
+      ).get(KEY),
+    ).toEqual([OFF]);
+  });
+
+  it("still reaches the container on a host with NO gated capability", () => {
+    // Cloud endpoint + no GPU: the harshest gating case. A rollback hatch that
+    // works only on GPU boxes is not a rollback hatch.
+    const perf = { env: { [KEY]: "0.7" }, processEnv: {} };
+    startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, false, perf);
+    expect(runEnv(runArgs()).get(KEY)).toEqual(["0.7"]);
   });
 });
 

--- a/src/setup/hindsight-perf-defaults.ts
+++ b/src/setup/hindsight-perf-defaults.ts
@@ -683,9 +683,39 @@ export const HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM: ReadonlyArray<readonly [string, 
  *   env:
  *     HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY: "big-bank:3,busy-bank:2,*:1"
  * ```
+ *
+ * ### `HINDSIGHT_CE_DECISIVE_RELATIVE_GAP`
+ *
+ * The documented rollback knob for switchroom's CE-saturation damping patch
+ * (`docker/Dockerfile.hindsight`, the `reranking.py` block). That patch is
+ * unconditional and its failure mode is a *silent* recall-quality regression
+ * with no telemetry that would surface it, so the patch deliberately reads its
+ * decisive gap from this env var once at import — backing the change out is
+ * meant to be a container restart with one env var, not an image rebuild. Any
+ * value at or above ~0.65 clamps the damping exponent to 1.0, i.e. exactly
+ * upstream ranking behaviour with the patch still baked in.
+ *
+ * Note the name: this is a switchroom-patch knob, not an upstream one, so it
+ * carries NO `HINDSIGHT_API_` prefix and upstream's config parser never sees
+ * it. Only the patched module reads it.
+ *
+ * It is here because an escape hatch that cannot be reached is not an escape
+ * hatch. Absent from this set, `resolveHindsightPerfOverrides` skipped it, so
+ * a `hindsight.env` line for it never reached the container — and because the
+ * patch reads the var once at import, there is no runtime fallback to recover
+ * through. Override-only rather than defaulted: switchroom ships the patch's
+ * own derived gap, and emitting a value here would replace a derived constant
+ * with a hard-coded one on every host.
+ *
+ * ```yaml
+ * hindsight:
+ *   env:
+ *     HINDSIGHT_CE_DECISIVE_RELATIVE_GAP: "1.0"   # damping off, patch inert
+ * ```
  */
 export const HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS: ReadonlySet<string> = new Set([
   "HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY",
+  "HINDSIGHT_CE_DECISIVE_RELATIVE_GAP",
 ]);
 
 /**

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -302,83 +302,50 @@ describe("Dockerfile.hindsight shape", () => {
     );
   });
 
-  it("keeps the max_turns/ToolSearch standard-call fix (assert-guarded, fail-loud)", () => {
-    // The STANDARD LLM-call path in claude_code_llm.py builds
-    // ClaudeAgentOptions with allowed_tools=[] but WITHOUT tools=[], so
-    // the built-in CLI tools stay loaded and ToolSearch burns the single
-    // max_turns=1 turn → "Reached maximum number of turns (1)" → wasted
-    // retries / failed memory ops. This build-time patch brings the
-    // standard path to parity with the tool-calling path (tools=[] +
-    // max_turns=2). It is self-verifying (asserts the anchor exists once
-    // before patching, re-asserts the result). Guard the patch block so
-    // nobody silently deletes it and reintroduces the max_turns wall.
-
-    // The exact-once assert on the pre-patch anchor (fail-loud on drift).
-    expect(dockerfile).toMatch(
-      /assert s\.count\(OLD\) == 1, "switchroom max_turns\/ToolSearch standard-call fix:/,
-    );
-    // The OLD anchor reconstructs the upstream (pre-patch) standard-call shape.
-    expect(dockerfile).toMatch(
-      /max_turns=1,  # Single-turn for API-style interactions/,
-    );
-    // The NEW replacement adds tools=[] + max_turns=2 on the standard path.
-    expect(dockerfile).toMatch(
-      /tools=\[\],  # switchroom: disable built-in CLI tools so ToolSearch/,
-    );
-    expect(dockerfile).toMatch(
+  // ---------------------------------------------------------------------
+  // RETIRED PATCHES — dropped in the v0.8.4 -> v0.8.5 base bump because
+  // upstream now does the same thing natively. These are asserted ABSENT
+  // rather than merely deleted: a patch that upstream has adopted must not
+  // silently reappear on a future rebase, where it would either fail its
+  // own exact-once anchor assert (breaking the build) or double-apply.
+  //
+  //  - max_turns/ToolSearch standard-call fix: 0.8.5 ships `tools=[]` on the
+  //    standard path itself (claude_code_llm.py, alongside its own
+  //    `max_turns=1  # Single-turn for API-style interactions`). With the
+  //    built-in tools unloaded ToolSearch cannot fire, so our extra turn of
+  //    headroom is dead weight.
+  //  - unit_entities FK-race fix: upstream #2662 adds bulk_reassert_entities
+  //    (engine/db/ops_postgresql.py) + reassert_entities_batch
+  //    (entity_resolver.py). Strictly better than ours: it row-LOCKS the
+  //    surviving parents so the pruner blocks, where ours only resurrected
+  //    the parent after the fact.
+  //  - duplicate-ANN-scan fix: 0.8.5 DELETED the `semantic_seeds` parameter
+  //    from LinkExpansionRetriever.retrieve() and documented the removal
+  //    ("Graph traversal deliberately chooses its own bounded seeds ...
+  //    reusing their results would silently change graph-retrieval recall
+  //    behavior"). Our patch's stated safety premise — that the parameter
+  //    already exists and is already honoured — is now false, so re-adding
+  //    it would fight a deliberate upstream design decision. The latency it
+  //    bought is largely absorbed by the per-bank vector indexes that
+  //    `hindsight-admin repair-bank` (upstream #2645) now maintains.
+  // ---------------------------------------------------------------------
+  it("does NOT carry the retired max_turns/ToolSearch patch (upstream ships tools=[])", () => {
+    expect(dockerfile).not.toMatch(/switchroom max_turns\/ToolSearch standard-call fix/);
+    expect(dockerfile).not.toMatch(
       /max_turns=2,  # switchroom: headroom so a stray ToolSearch turn/,
-    );
-    // Post-replace re-assertions must be present (verification-on-build).
-    expect(dockerfile).toMatch(
-      /assert "            tools=\[\],  # switchroom" in t,/,
-    );
-    expect(dockerfile).toMatch(
-      /assert "max_turns=1,  # Single-turn" not in t,/,
     );
   });
 
-  it("keeps the unit_entities FK-race fix (assert-guarded, fail-loud)", () => {
-    // Upstream v0.8.4 defect: retain Phase-1 (entity resolution) and Phase-2
-    // (the unit_entities child insert) run in SEPARATE committed transactions.
-    // graph_maintenance.prune_orphan_entities can delete an entity in that
-    // window (it momentarily has no unit_entities reference), so Phase-2's
-    // bulk_insert_unit_entities then violates fk_unit_entities_entity_id_entities
-    // — deterministic, non-retryable, memory silently dropped (fires on
-    // session_handoff re-ingest). The build-time patch makes Phase-2 re-assert
-    // (resurrect) the parent entity row in the SAME transaction as the child
-    // insert (INSERT ... ON CONFLICT DO NOTHING), threading the entity metadata
-    // Phase-1 already holds. Proven 15/15 RED -> 0/15 with memories persisted on
-    // the real retain orchestrator path. Self-verifying (asserts each anchor
-    // exactly once against unmodified upstream v0.8.4 before patching, re-asserts
-    // the result). Guard the patch block so nobody silently deletes it.
+  it("does NOT carry the retired unit_entities FK-race patch (upstream #2662)", () => {
+    expect(dockerfile).not.toMatch(/switchroom hindsight FK-race patch/);
+    expect(dockerfile).not.toMatch(/reassert_entities/);
+    expect(dockerfile).not.toMatch(/entity_records/);
+  });
 
-    // The exact-once anchor guard (fail-loud on upstream drift).
-    expect(dockerfile).toMatch(
-      /assert n == 1, \(\s*\n\s*f"switchroom hindsight FK-race patch: anchor found \{n\}x/,
-    );
-    // The new idempotent same-txn re-assert op.
-    expect(dockerfile).toMatch(/async def reassert_entities\(/);
-    expect(dockerfile).toMatch(/INSERT INTO \{table\} \(id, bank_id, canonical_name\)/);
-    expect(dockerfile).toMatch(/ON CONFLICT DO NOTHING/);
-    // The entity_records threading param on the link path.
-    expect(dockerfile).toMatch(
-      /entity_records: dict\[str, dict\] \| None = None,/,
-    );
-    // The orchestrator wires entity_records from the Phase-1 result into Phase-2.
-    expect(dockerfile).toMatch(
-      /entity_records=phase1\.entities\.entity_records/,
-    );
-    // Post-replace re-assertions must be present (verification-on-build).
-    expect(dockerfile).toMatch(
-      /assert "async def reassert_entities\(" in ops_new,/,
-    );
-    expect(dockerfile).toMatch(
-      /assert "entity_records\.get\(str\(eid\)\)" in er_new,/,
-    );
-    // The success line proves the block ran to completion.
-    expect(dockerfile).toMatch(
-      /switchroom hindsight unit_entities FK-race patch: reassert_entities \+ entity_records threading applied/,
-    );
+  it("does NOT carry the retired duplicate-ANN-scan patch (upstream removed semantic_seeds)", () => {
+    expect(dockerfile).not.toMatch(/duplicate-ANN-scan/);
+    expect(dockerfile).not.toMatch(/semantic_seeds/);
+    expect(dockerfile).not.toMatch(/_find_semantic_seeds/);
   });
 
   it("keeps the cross-encoder saturation fix (assert-guarded, fail-loud)", () => {
@@ -528,76 +495,6 @@ describe("Dockerfile.hindsight shape", () => {
     expect(dockerfile).toMatch(/assert "compound_fragments" not in pg,/);
     expect(dockerfile).toMatch(
       /switchroom hindsight BM25 compound-token patch: intact compound tokens appended/,
-    );
-  });
-
-  it("keeps the duplicate-ANN-scan fix (assert-guarded, fail-loud)", () => {
-    // retrieve_all_fact_types_parallel ran the vector-similarity scan twice per
-    // recall: Step 2's semantic arm, then `semantic_seeds=None` into the graph
-    // retriever, whose _find_semantic_seeds issues its own
-    // `ORDER BY embedding <=> $1::vector LIMIT $5` per fact type — serialized
-    // behind Step 2's connection block. The patch threads Step 2's rows through
-    // as the seeds. Outcome coverage lives in hindsight-search-patches.test.ts.
-
-    // The exact-once anchor guards (fail-loud on upstream drift), one per site.
-    expect(dockerfile).toMatch(
-      /switchroom hindsight duplicate-ANN-scan patch: retrieve_all_fact_types_parallel anchor found \{n\}x/,
-    );
-    expect(dockerfile).toMatch(
-      /switchroom hindsight duplicate-ANN-scan patch: Step 2 preamble anchor found \{n\}x/,
-    );
-    expect(dockerfile).toMatch(
-      /switchroom hindsight duplicate-ANN-scan patch: Step 3 retriever\.retrieve call site anchor found \{n\}x/,
-    );
-
-    // The mirrored seed constants are only correct while link_expansion still
-    // calls _find_semantic_seeds with them — asserted against that file at
-    // build time, so an upstream retune fails the build rather than silently
-    // deriving a different seed set.
-    expect(dockerfile).toMatch(/_GRAPH_SEED_LIMIT = 20/);
-    expect(dockerfile).toMatch(/_GRAPH_SEED_MIN_SIMILARITY = 0\.3/);
-    expect(dockerfile).toContain(
-      String.raw`assert "                    limit=20,\n                    threshold=0.3,\n" in le,`,
-    );
-    // …and only correct while the seeds are still consumed by id alone, which
-    // is what makes "same id set" the right equivalence relation.
-    expect(dockerfile).toMatch(
-      /assert "seed_ids = list\(\{s\.id for s in all_seeds\}\)" in le,/,
-    );
-    // …and while the receiving branch still honours the parameter at all.
-    expect(dockerfile).toMatch(
-      /assert "            if semantic_seeds:\\n                all_seeds = list\(semantic_seeds\)\\n" in le,/,
-    );
-
-    // Correctness-first fallbacks: decline to derive whenever the arm's pool is
-    // narrower than the seed query's, or the arm's trim may have cut seeds.
-    expect(dockerfile).toMatch(
-      /if arm_min_similarity > _GRAPH_SEED_MIN_SIMILARITY:\n +return None/,
-    );
-    expect(dockerfile).toMatch(
-      /if len\(seeds\) < _GRAPH_SEED_LIMIT and len\(seeds\) == len\(ranked\) and len\(ranked\) >= arm_limit:/,
-    );
-    // Sorted explicitly: no new dependence on UNION ALL row order.
-    expect(dockerfile).toMatch(
-      /ranked = sorted\(semantic_results, key=lambda r: r\.similarity, reverse=True\)/,
-    );
-
-    // Scope guard: this patch does NOT thread temporal seeds. Step 2's temporal
-    // rows are coverage-selected and upstream passes none, so threading them
-    // would ADD seeds rather than reproduce upstream's graph output.
-    expect(dockerfile).toMatch(
-      /assert t\.count\("temporal_seeds=None,"\) == 1,/,
-    );
-
-    // Post-replace re-assertions (verification-on-build), including that no
-    // `semantic_seeds=None` call site survives and that the result still parses.
-    expect(dockerfile).toMatch(/assert "def _graph_semantic_seeds\(" in t,/);
-    expect(dockerfile).toMatch(
-      /assert "            semantic_seeds=None,\\n" not in t,/,
-    );
-    expect(dockerfile).toMatch(/compile\(t, str\(f\), "exec"\)/);
-    expect(dockerfile).toMatch(
-      /switchroom hindsight duplicate-ANN-scan patch: graph expansion now seeds off Step 2's semantic arm/,
     );
   });
 

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -23,6 +23,7 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { HINDSIGHT_PERF_ENV_KEYS } from "../../src/setup/hindsight-perf-defaults.js";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const dockerfile = readFileSync(
@@ -400,6 +401,22 @@ describe("Dockerfile.hindsight shape", () => {
     expect(dockerfile).toMatch(
       /HINDSIGHT_CE_DECISIVE_RELATIVE_GAP=<float>/,
     );
+
+    // …and the knob the image reads must be one switchroom can actually set.
+    // `resolveHindsightPerfOverrides` drops any key outside
+    // HINDSIGHT_PERF_ENV_KEYS silently, and the patch reads this var once at
+    // import, so an unmanaged name here is a documented escape hatch that
+    // cannot be reached from switchroom.yaml at all. Derive the name from the
+    // Dockerfile rather than restating it, so the two cannot drift apart.
+    const envName = dockerfile.match(
+      /_CE_DECISIVE_RELATIVE_GAP_ENV: str = "([A-Z0-9_]+)"/,
+    )?.[1];
+    expect(envName, "the patch must name its env knob").toBeDefined();
+    expect(
+      HINDSIGHT_PERF_ENV_KEYS.has(envName!),
+      `${envName} is read by the baked patch but is not in HINDSIGHT_PERF_ENV_KEYS, ` +
+        "so a hindsight.env line for it is discarded before it reaches the container",
+    ).toBe(true);
 
     // The exponent is derived ONCE PER CALL from the alphas alone. That is what
     // makes a candidate's score a pure function of its own fields — no

--- a/tests/docker/hindsight-search-patches.test.ts
+++ b/tests/docker/hindsight-search-patches.test.ts
@@ -1,12 +1,12 @@
 /**
- * Behavioural proof for the four search/provider patches
+ * Behavioural proof for the three search/provider patches
  * `docker/Dockerfile.hindsight` bakes into the pinned upstream Hindsight
  * image. `dockerfile-hindsight-bakes.test.ts` pins the *shape* of those patch
  * blocks (grep-on-file, runs everywhere). This file proves the *outcome*: it
  * runs the same probe against unpatched upstream (must be RED on every bug)
  * and against upstream + the patch blocks applied (must be GREEN).
  *
- * The four defects, all reproduced live on bank `overlord` before the fix:
+ * The three defects, all reproduced live on bank `overlord` before the fix:
  *
  *  1. Cross-encoder saturation. `apply_combined_scoring` makes
  *     `CE * recency_boost * temporal_boost * proof_count_boost` the only final
@@ -21,11 +21,14 @@
  *  3. Both LiteLLM timeout handlers ended in a bare `raise`, re-raising an
  *     `asyncio.TimeoutError` whose `str()` is empty → an operator-facing
  *     "TimeoutError:" with no cause.
- *  4. `retrieve_all_fact_types_parallel` ran the vector-similarity scan TWICE
- *     per recall. Step 2's semantic arm is an ANN scan; Step 3 then passed
- *     `semantic_seeds=None` into the graph retriever, whose `_find_semantic_seeds`
- *     issues its own `ORDER BY embedding <=> $1::vector LIMIT $5` per fact type,
- *     serialized behind Step 2's connection block.
+ *
+ * (A fourth defect once lived here — `retrieve_all_fact_types_parallel` ran the
+ * vector-similarity scan twice per recall, because Step 3 passed
+ * `semantic_seeds=None` into the graph retriever. Upstream v0.8.5 REMOVED the
+ * `semantic_seeds` parameter outright and documented the removal as deliberate
+ * ("Graph traversal deliberately chooses its own bounded seeds"), so the patch
+ * and its probe were retired in the 0.8.4 -> 0.8.5 base bump rather than
+ * re-anchored. `dockerfile-hindsight-bakes.test.ts` now asserts it stays gone.)
  *
  * Beyond proving those three fixes, the probe pins the properties that make
  * the fixes SAFE, because each was violated by an earlier revision of this
@@ -44,13 +47,6 @@
  *    additive levels and `min_scores.final` are calibrated against.
  *  - `tokenize_query` stays a STRICT SUPERSET of upstream's token list, so the
  *    OR-joined query can only match more documents than upstream, never fewer.
- *  - The seeds the graph expansion is handed are the SAME SET, in the same
- *    order, that upstream's own seed query returns — asserted by calling that
- *    upstream query and diffing, not by trusting the derivation. Where the two
- *    are not provably identical (a `min_scores.semantic` floor above the seed
- *    threshold, or a thinking_budget below the seed cap) the derivation must
- *    decline and let upstream re-query. A faster wrong seed set is a
- *    regression, not a win.
  *
  * The patch blocks are extracted from the Dockerfile itself rather than
  * duplicated here, so this test cannot drift from what actually ships. It
@@ -97,7 +93,7 @@ const UPSTREAM_IMAGE = (() => {
 })();
 
 /**
- * The three patch blocks under test, pulled out of the Dockerfile's
+ * The patch blocks under test, pulled out of the Dockerfile's
  * `RUN python3 - <<'PYEOF' … PYEOF` heredocs by their unique patch names.
  */
 function patchBlocks(): string[] {
@@ -108,7 +104,6 @@ function patchBlocks(): string[] {
     "CE-saturation patch",
     "BM25 compound-token patch",
     "timeout-message patch",
-    "duplicate-ANN-scan patch",
   ];
   return wanted.map((name) => {
     const b = blocks.find((x) => x.includes(name));
@@ -478,187 +473,6 @@ for label, (how, msg) in sorted(timeouts.items()):
     elif "timed out after" not in msg or "scope=" not in msg:
         failures.append("%s timeout message lost the timeout/scope facts: %r" % (label, msg))
 
-# ------------------------------------------------------------------ fix 4
-# Drive the REAL retrieve_all_fact_types_parallel and the REAL
-# LinkExpansionRetriever over an in-memory corpus, and COUNT the
-# vector-similarity scans at the connection. Upstream issues one per fact type
-# on top of Step 2's arm; patched must issue exactly one for the whole recall.
-from hindsight_api.engine.db.ops_postgresql import PostgreSQLOps
-from hindsight_api.engine.search import link_expansion_retrieval as LE
-from hindsight_api.engine.search import retrieval as R
-
-SEED_LIMIT = 20
-SEED_THRESHOLD = 0.3
-
-
-def urow(ft, i, sim):
-    return {
-        "id": "%s-%02d" % (ft, i), "text": "fact %d" % i, "context": None,
-        "event_date": None, "occurred_start": None, "occurred_end": None,
-        "mentioned_at": None, "fact_type": ft, "document_id": None,
-        "chunk_id": None, "tags": None, "metadata": None, "proof_count": 1,
-        "similarity": sim, "bm25_score": None,
-    }
-
-
-# 40 world rows spanning the seed threshold (33 clear 0.3, so BOTH the 20-cap
-# and the threshold bite) plus 5 experience rows that all clear it (under the
-# cap, so the whole set is the seed set).
-CORPUS = [urow("world", i, round(0.95 - 0.02 * i, 4)) for i in range(40)]
-CORPUS += [urow("experience", i, round(0.90 - 0.10 * i, 4)) for i in range(5)]
-
-
-class FakeConn:
-    """Serves the real SQL the engine builds, from the corpus above.
-
-    Discriminates the three query shapes a recall issues so the probe can COUNT
-    ANN scans rather than infer them: the Step 2 combined arm, link_expansion's
-    standalone seed scan, and the graph expansion CTE.
-    """
-
-    backend_type = "postgresql"
-
-    def __init__(self, log):
-        self.log = log
-
-    async def fetch(self, query, *params):
-        if "'semantic' AS source" in query:
-            self.log.append("arm")
-            floor = float(re.search(r"<=> \$1::vector\)\) >= ([0-9.]+)", query).group(1))
-            return [dict(r, source="semantic") for r in CORPUS if r["similarity"] >= floor]
-        if "embedding <=>" in query:
-            # The duplicate scan this patch exists to remove.
-            self.log.append("seed")
-            _emb, _bank, ft, threshold, limit = params[:5]
-            hits = [r for r in CORPUS if r["fact_type"] == ft and r["similarity"] >= threshold]
-            hits.sort(key=lambda r: r["similarity"], reverse=True)
-            return hits[:limit]
-        self.log.append("expand")
-        return []
-
-
-class FakePool:
-    def __init__(self, conn):
-        self.conn = conn
-        self.ops = PostgreSQLOps()
-
-    async def acquire(self):
-        return self.conn
-
-    async def release(self, conn):
-        pass
-
-    def get_size(self):
-        return 1
-
-    def get_idle_size(self):
-        return 1
-
-
-class RecordingRetriever(LE.LinkExpansionRetriever):
-    """The REAL retriever, wrapped only to capture what it was handed."""
-
-    def __init__(self):
-        super().__init__()
-        self.seen = {}
-
-    async def retrieve(self, **kw):
-        self.seen[kw["fact_type"]] = kw["semantic_seeds"]
-        return await super().retrieve(**kw)
-
-
-async def _drive(fact_types, budget=300, min_semantic=None):
-    log = []
-    retriever = RecordingRetriever()
-    await R.retrieve_all_fact_types_parallel(
-        FakePool(FakeConn(log)), "alpha beta", "[0.1,0.2]", "bank-probe",
-        list(fact_types), budget, None, None,
-        graph_retriever=retriever, min_semantic=min_semantic,
-    )
-    return log, retriever.seen
-
-
-def seed_ids(seeds):
-    return None if seeds is None else [s.id for s in seeds]
-
-
-async def _reference(ft):
-    """The seed set upstream's OWN query returns, obtained by calling it."""
-    rows = await LE._find_semantic_seeds(
-        FakeConn([]), "[0.1,0.2]", "bank-probe", ft,
-        limit=SEED_LIMIT, threshold=SEED_THRESHOLD,
-    )
-    return [r.id for r in rows]
-
-
-# The mirrored seed constants are only right while the call site still passes
-# them; upstream retuning either one silently changes which set is equivalent.
-le_src = inspect.getsource(LE.LinkExpansionRetriever.retrieve)
-print("SEED_CALL_SITE_DEFAULTS", "limit=20" in le_src, "threshold=0.3" in le_src)
-if "limit=20" not in le_src or "threshold=0.3" not in le_src:
-    failures.append("link_expansion no longer seeds with limit=20/threshold=0.3 - the derived seed set is calibrated against those")
-
-FT = ["world", "experience"]
-scan_log, delivered = asyncio.run(_drive(FT))
-ref = {ft: asyncio.run(_reference(ft)) for ft in FT}
-
-ann = scan_log.count("arm") + scan_log.count("seed")
-print("ANN_SCANS", ann, "ARM", scan_log.count("arm"), "SEED_QUERIES", scan_log.count("seed"))
-print("REFERENCE_world", len(ref["world"]))
-print("REFERENCE_experience", len(ref["experience"]))
-for ft in FT:
-    print("DELIVERED_%s" % ft, seed_ids(delivered[ft]))
-
-if scan_log.count("seed") != 0:
-    failures.append(
-        "graph expansion still issued %d standalone ANN seed scan(s) after Step 2 already ran one"
-        % scan_log.count("seed")
-    )
-if ann != 1:
-    failures.append("recall issued %d vector-similarity scans (expected exactly 1)" % ann)
-
-# EQUIVALENCE. Same ids, same order, as upstream's own seed query - the whole
-# safety argument, since a narrowed seed set silently narrows recall.
-for ft in FT:
-    got = seed_ids(delivered[ft])
-    if got is None:
-        failures.append("%s: semantic_seeds was None - the graph path re-ran the ANN scan" % ft)
-    elif got != ref[ft]:
-        failures.append("%s: derived seeds %r != upstream seed query %r" % (ft, got, ref[ft]))
-
-# The corpus must keep exercising both bounds, or the equivalence check above
-# degenerates into a tautology.
-if len(ref["world"]) != SEED_LIMIT:
-    failures.append("probe corpus no longer exercises the %d-seed cap (%d)" % (SEED_LIMIT, len(ref["world"])))
-if len(ref["experience"]) >= SEED_LIMIT:
-    failures.append("probe corpus no longer exercises the under-cap case")
-
-# FALLBACK 1: a per-request min_scores.semantic floor ABOVE the seed threshold
-# makes the arm's pool narrower than the seed query's, so rows the seed query
-# would have returned were never fetched. Must decline and let upstream query.
-log_hi, seen_hi = asyncio.run(_drive(["world"], min_semantic=0.5))
-print("HIGH_FLOOR_SEEDS", seed_ids(seen_hi["world"]), "SEED_QUERIES", log_hi.count("seed"))
-if seen_hi["world"] is not None:
-    failures.append("min_scores.semantic=0.5 (above the 0.3 seed threshold) still derived seeds from the narrowed arm")
-if log_hi.count("seed") != 1:
-    failures.append("min_scores.semantic=0.5 did not fall back to upstream's own seed query")
-
-# FALLBACK 2: a thinking_budget below the seed cap can trim away rows the seed
-# query would have returned.
-log_lo, seen_lo = asyncio.run(_drive(["world"], budget=5))
-print("TINY_BUDGET_SEEDS", seed_ids(seen_lo["world"]), "SEED_QUERIES", log_lo.count("seed"))
-if seen_lo["world"] is not None:
-    failures.append("thinking_budget=5 (below the seed cap) still derived seeds from a trimmed arm")
-if log_lo.count("seed") != 1:
-    failures.append("thinking_budget=5 did not fall back to upstream's own seed query")
-
-# temporal_seeds stays out of scope: upstream passes none, and Step 2's temporal
-# rows are a coverage-selected set with different semantics, so threading them
-# would ADD seeds rather than reproduce upstream's behaviour.
-print("TEMPORAL_SEEDS_STILL_NONE", "temporal_seeds=None" in inspect.getsource(R.retrieve_all_fact_types_parallel))
-if "temporal_seeds=None" not in inspect.getsource(R.retrieve_all_fact_types_parallel):
-    failures.append("temporal_seeds is no longer None - that is a separate change with different semantics")
-
 print("FAILURES", failures)
 # Sentinel: proves the probe ran to completion. The harness asserts this, so a
 # probe that dies early or short-circuits can never be mistaken for a pass.
@@ -830,7 +644,7 @@ describe.skipIf(!dockerOk || !imageOk)(
       }
     });
 
-    it("unpatched upstream is RED on all four defects (proves the probe bites)", () => {
+    it("unpatched upstream is RED on all three defects (proves the probe bites)", () => {
       const { status, stdout } = runProbe(false);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED"
@@ -868,15 +682,6 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toMatch(
         /TIMEOUT call_with_tools CAUGHT_BY_ASYNCIO_TIMEOUTERROR ''/
       );
-
-      // Defect 4 — the duplicate ANN scan, counted at the connection: Step 2's
-      // arm plus one standalone seed scan per fact type.
-      expect(stdout).toContain("ANN_SCANS 3 ARM 1 SEED_QUERIES 2");
-      expect(stdout).toContain(
-        "graph expansion still issued 2 standalone ANN seed scan(s) after Step 2 already ran one"
-      );
-      expect(stdout).toContain("DELIVERED_world None");
-      expect(stdout).toContain("DELIVERED_experience None");
     }, 240_000);
 
     it("upstream + the baked patch blocks is GREEN, including every safety property", () => {
@@ -956,40 +761,6 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toMatch(
         /TIMEOUT call_with_tools CAUGHT_BY_ASYNCIO_TIMEOUTERROR 'LiteLLM tool call timed out after 0\.05s on 1 attempts \(TimeoutError, scope=tools\)'/
       );
-
-      // Fix 4: exactly ONE vector-similarity scan for the whole recall — the
-      // arm — and zero standalone seed scans, no matter how many fact types.
-      expect(stdout).toContain("ANN_SCANS 1 ARM 1 SEED_QUERIES 0");
-
-      // … and the seeds the graph expansion actually received are the SAME SET,
-      // in the same order, that upstream's own seed query returns. Diffed
-      // against that query's real output, with both of its bounds biting: the
-      // 20-seed cap on `world` (40 rows, 33 above the 0.3 threshold) and the
-      // under-cap case on `experience` (5 rows).
-      expect(stdout).toContain("SEED_CALL_SITE_DEFAULTS True True");
-      expect(stdout).toContain("REFERENCE_world 20");
-      expect(stdout).toContain("REFERENCE_experience 5");
-      expect(stdout).toContain(
-        "DELIVERED_world ['world-00', 'world-01', 'world-02', 'world-03', " +
-          "'world-04', 'world-05', 'world-06', 'world-07', 'world-08', " +
-          "'world-09', 'world-10', 'world-11', 'world-12', 'world-13', " +
-          "'world-14', 'world-15', 'world-16', 'world-17', 'world-18', " +
-          "'world-19']"
-      );
-      expect(stdout).toContain(
-        "DELIVERED_experience ['experience-00', 'experience-01', " +
-          "'experience-02', 'experience-03', 'experience-04']"
-      );
-
-      // … and it DECLINES rather than guessing wherever the derived set is not
-      // provably the upstream set. Correctness first: a narrowed seed set is a
-      // silently quieter recall, which is worse than a slower one.
-      expect(stdout).toContain("HIGH_FLOOR_SEEDS None SEED_QUERIES 1");
-      expect(stdout).toContain("TINY_BUDGET_SEEDS None SEED_QUERIES 1");
-
-      // … while temporal seeds stay out of scope (upstream passes none, and
-      // Step 2's temporal rows are a differently-selected set).
-      expect(stdout).toContain("TEMPORAL_SEEDS_STILL_NONE True");
     }, 240_000);
   }
 );

--- a/tests/fixtures/hindsight-tools-list.snapshot.json
+++ b/tests/fixtures/hindsight-tools-list.snapshot.json
@@ -1,11 +1,11 @@
 {
  "_meta": {
-  "captured_from": "http://127.0.0.1:18888/mcp/",
+  "captured_from": "docker run <pinned digest>: hindsight_api.api.mcp.create_mcp_server(multi_bank=True) registration surface",
   "server": "switchroom-hindsight",
   "captured_at": "2026-07-27",
-  "hindsight_api_version": "0.8.4",
+  "hindsight_api_version": "0.8.5",
   "count": 32,
-  "note": "Verbatim live tools/list capture from the running hindsight backend (api_version 0.8.4 per GET /version), which is the version docker/Dockerfile.hindsight pins. NOT forward-patched: an earlier revision of this file described the 0.8.5 surface while the fleet ran 0.8.4, which made src/cli/hindsight-mcp-shim.ts's cold-boot fallback advertise three props the server does not accept (list_memories.tags, list_memories.tags_match, create_mental_model.tags_match). Hindsight drops an unknown argument SILENTLY (isError:false), so an agent issuing a tag-filtered list_memories on 0.8.4 gets the UNFILTERED list back and believes it was filtered — a silent wrong answer, which is exactly what this snapshot exists to prevent. The 0.8.5 delta is known and additive (those same three props; no tools added or removed, both wheels register 32) — re-capture this file against 0.8.5 and bump _meta.hindsight_api_version when #3768 bumps the image pin."
+  "note": "Captured in-image from the exact digest docker/Dockerfile.hindsight pins, by building the FastMCP server the backend builds (create_mcp_server(memory, multi_bank=True)) and dumping each tool's JSON-schema required/properties. Cross-validated: the identical derivation run against the PREVIOUS pinned digest (0.8.4, sha256:2c60f233...) reproduces the live HTTP tools/list capture this file previously held, byte-for-byte across all 32 tools \u2014 so the method is equivalent to a live capture. NOT forward-patched: this file must never describe a newer server than the pinned image. Hindsight drops an unknown argument SILENTLY (isError:false), so a prop advertised here but unknown to the server makes an agent believe a filter was applied when it was not \u2014 a silent wrong answer. The 0.8.4 -> 0.8.5 delta is exactly additive and exactly three props (list_memories.tags, list_memories.tags_match, create_mental_model.tags_match); no tool was added or removed, both wheels register 32."
  },
  "tools": {
   "retain": {
@@ -118,6 +118,7 @@
     "name",
     "source_query",
     "tags",
+    "tags_match",
     "trigger_refresh_after_consolidation"
    ]
   },
@@ -200,6 +201,8 @@
     "limit",
     "offset",
     "q",
+    "tags",
+    "tags_match",
     "type"
    ]
   },

--- a/tests/memory.hindsight-contract.fixture.test.ts
+++ b/tests/memory.hindsight-contract.fixture.test.ts
@@ -95,14 +95,37 @@ describe("hindsight contract — golden snapshot integrity", () => {
     ).toBe(pinnedHindsightApiVersion());
   });
 
-  it("does not advertise the 0.8.5-only props while the pinned image is 0.8.4", () => {
-    // Mutation-guard for the fix above, pinned by name so a reintroduction is
-    // caught even if _meta is edited to match. Drop this test in the same
-    // commit that re-captures the snapshot against 0.8.5 (#3768).
-    if (pinnedHindsightApiVersion() !== "0.8.4") return;
-    expect(snapshot.tools.list_memories.props).not.toContain("tags");
-    expect(snapshot.tools.list_memories.props).not.toContain("tags_match");
-    expect(snapshot.tools.create_mental_model.props).not.toContain("tags_match");
+  /**
+   * The 0.8.4 → 0.8.5 delta, pinned by name in BOTH directions.
+   *
+   * These three props are the entire tool-surface difference between the two
+   * wheels (verified by dumping `create_mcp_server(...)`'s registration surface
+   * inside each pinned digest: 32 tools either way, no tool added or removed).
+   * Naming them keeps the mutation-guard the 0.8.4 revision of this test
+   * provided — a snapshot forward-patched to 0.8.5 while the image pins 0.8.4
+   * still reds here even if `_meta` is edited to match — while adding the
+   * mirror obligation: on 0.8.5 the props must actually BE captured, so a
+   * marker bumped without a re-capture cannot pass.
+   */
+  it("carries exactly the tag props the pinned wheel registers — neither ahead nor behind", () => {
+    const pinned = pinnedHindsightApiVersion();
+    const shouldHaveTagProps = pinned !== "0.8.4";
+    const has = (tool: string, prop: string) =>
+      (snapshot.tools[tool]?.props as string[]).includes(prop);
+    for (const [tool, prop] of [
+      ["list_memories", "tags"],
+      ["list_memories", "tags_match"],
+      ["create_mental_model", "tags_match"],
+    ] as const) {
+      expect(
+        has(tool, prop),
+        shouldHaveTagProps
+          ? `${tool}.${prop} exists on ${pinned} but is missing from the snapshot — ` +
+            "the marker was bumped without re-capturing the fixture from the pinned image"
+          : `${tool}.${prop} does not exist on ${pinned}; advertising it makes the shim's ` +
+            "cold-boot manifest promise a filter the server silently ignores",
+      ).toBe(shouldHaveTagProps);
+    }
   });
 
   it("EXPECTED_HINDSIGHT_TOOLS agrees with the captured server truth (required-args, no const/snapshot drift)", () => {


### PR DESCRIPTION
Rebases the switchroom Hindsight fork from upstream **v0.8.4** (`sha256:2c60f233…`) onto **v0.8.5** (`sha256:0710076c…`, rev `705757f3`), to pick up `hindsight-admin repair-bank` — upstream **#2645**: per-`(bank, fact_type)` vector indexes never self-heal, so a bank populated outside the create-time path falls back to the global HNSW index plus a post-filter and under-returns recall candidates.

## Evidence this was real, measured live on the fleet

At the production `hnsw.ef_search=200`, bank `gymbro` / fact_type `world`:

```
Index Scan using idx_memory_units_embedding  (rows=55)
  Filter: (bank_id = 'gymbro' AND fact_type = 'world')
  Rows Removed by Filter: 143
```

55 of 100 requested candidates. After `repair-bank --all` the same query plans onto `idx_mu_emb_worl_b2ed265f96d94c97` and returns **100/100 with zero rows removed**.

`repair-bank` has already been run against the live database (`CREATE INDEX CONCURRENTLY`, no downtime): 21 indexes created across 7 banks, 60 pre-existing left untouched, 0 failed. A second run reports `81 present, 0 created` — idempotent.

## Patch audit

This is a fork rebase, not a version bump, so every `# switchroom:` block was replayed against a pristine 0.8.5 tree and re-classified. **11 → 8 blocks, ~950 lines removed.**

| Patch | Verdict | Reason |
|---|---|---|
| #2392 claude_code env isolation | **KEEP** | Pure switchroom deployment shape (file creds, no OS keychain). Upstream will never accommodate it. |
| max_turns/ToolSearch standard-call | **DROP** | 0.8.5 ships `tools=[]` on the standard path itself, so ToolSearch cannot consume the single turn. |
| unit_entities FK-race | **DROP** | Upstream #2662 adds `bulk_reassert_entities` + `reassert_entities_batch`. Strictly better: it row-LOCKS surviving parents so the pruner blocks, where ours only resurrected after the fact. Largest block in the file. |
| CE-saturation damping | **KEEP** | `reranking.py` is byte-identical 0.8.4 → 0.8.5 — upstream never touched the undamped `CE * recency * temporal * proof`. |
| BM25 compound-token | **KEEP** | `tokenize_query` unchanged; the identifier-shredding bug is still live upstream. See hazard note below. |
| duplicate-ANN-scan | **DROP** | 0.8.5 **deleted** the `semantic_seeds` parameter and documented the removal as deliberate. The patch's own stated safety premise is now false. |
| LiteLLM timeout message | **KEEP** | 0.8.5 improved only the log line; the exhausted-retry path is still a bare `raise`. |
| recall-admission-split | **REWORK** | Need remains (still a single unsplit `_search_semaphore`). Pure anchor drift — re-anchored on validate()'s new last clause. |
| worker-slot-ceiling | **REWORK** | Need remains (still no per-type ceiling). Pure anchor drift — `max_retries: int = 3` was added to `WorkerPoller.__init__`. |
| recall telemetry (`sem=`/`wait_info`) | **KEEP** | switchroom observability; no upstream equivalent. |
| perturbed-JSON-retry | **KEEP** | 0.8.5 still replays a byte-identical request after invalid JSON. |

## Why the retired patches are asserted *absent*, not just deleted

A patch upstream has adopted must not silently reappear on a future rebase, where it would either fail its own exact-once anchor assert (breaking the build) or double-apply. `dockerfile-hindsight-bakes.test.ts` now carries three `not.toMatch` guards with the reasoning inline.

## Test evidence

The behavioural probes read the pinned digest **from the Dockerfile**, so they now run RED/GREEN against 0.8.5 itself:

```
✓ tests/docker/dockerfile-hindsight-bakes.test.ts (28 tests)
✓ tests/docker/hindsight-recall-isolation-patches.test.ts (5 tests)
✓ tests/docker/hindsight-retry-perturbation-patches.test.ts (5 tests)
✓ tests/docker/hindsight-search-patches.test.ts (5 tests)
  Tests  43 passed (43)
```

All 8 retained blocks also replay cleanly against a pristine 0.8.5 source tree, and the result compiles (`compileall` exit 0).

## Forward hazard (not blocking, no conflict today)

0.8.5 adds `HINDSIGHT_API_BM25_MAX_QUERY_TERMS`, implemented as a blind head-truncation `tokens = tokens[:max_query_terms]`. Our BM25 compound-token patch **appends** compounds at the end of the token list, so enabling that cap would silently discard exactly the discriminating tokens the patch exists to preserve. The default is `0` (disabled), so there is no conflict now. If the cap is ever adopted, compounds must be prepended — or truncation made compound-aware — in the same change.

## Rolling this

Bumping the base runs **4 alembic migrations** on the persisted memory volume (head `b57a7c9e0d13` → `d7b2f8a1c934`), one of which drops the `search_vector` column from the `invalidated_memory_units` archive. That column is **not "unused"** — 0.8.5 no longer reads it, but **0.8.4 requires it** (its archive round-trip excludes only `"embedding"`, `engine/memory_engine.py:6579`), so it is unused on the version you roll forward to and load-bearing on the version you roll back to. Back up `switchroom-hindsight-data` first. A pre-upgrade backup has already been taken and CRC-verified.

**Rolling back is two ordered steps, not one.** Reverting the pinned digest on its own is a rollback into a broken state: the older image does not stop you at boot (`hindsight_api/migrations.py` swallows the unknown-revision error and logs "Database is at a newer migration revision than this code version knows about … Skipping migrations"), and then every `invalidate_memory` / revert-invalidation fails with `column "search_vector" does not exist`. The order is **`alembic downgrade b57a7c9e0d13` first, while the 0.8.5 image is still running** (it is the only one shipping the down-revisions), **then** repoint the digest. Even done correctly it is not lossless: the re-added column comes back **empty** and nothing backfills it, so every memory archived while on 0.8.5 returns with a NULL `search_vector` and is silently absent from the BM25 arm of recall after a revert. Full runbook: `docs/operators/hindsight-memory.md` § "Rolling the base image BACK".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
