### PR TITLE
feat(memory): make `repair-bank` reachable and hindsight version skew loud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -406,13 +406,15 @@ the live `GET /version`:
 - **unreachable → no row.** The `/health` check already owns "the backend is
   down"; a second red line for the same outage is noise.
 
-The floor tracks the **snapshot**, not any individual feature: it is `0.8.4`,
-the version `docker/Dockerfile.hindsight` actually pins. `repair-bank`'s `0.8.5`
-requirement lives in its own `HINDSIGHT_REPAIR_MIN_API_VERSION` and is enforced
-in the repair preflight, at the moment an operator tries to use it. Fusing the
-two would have shipped a flagship doctor check that was red by construction on
-every running fleet — which trains people to ignore precisely the check meant
-to catch the next outage.
+The floor tracks the **snapshot**, not any individual feature: it is the
+version `docker/Dockerfile.hindsight` actually pins — `0.8.5` since #3768 moved
+the fork onto upstream 0.8.5. `repair-bank`'s own requirement lives in
+`HINDSIGHT_REPAIR_MIN_API_VERSION` and is enforced in the repair preflight, at
+the moment an operator tries to use it. The two constants coincide at `0.8.5`
+today; that is a coincidence of the current pin, not a merge. Fusing them
+shipped, in an earlier revision of this branch, a flagship doctor check that was
+red by construction on every running fleet — which trains people to ignore
+precisely the check meant to catch the next outage.
 
 The fixture test chains constant → snapshot `_meta.hindsight_api_version` →
 the api-version marker in `docker/Dockerfile.hindsight`, so bumping any one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -342,6 +342,70 @@ container's `mem_limit` cgroup, so an agent that raises `tmp_size` *and*
 intends to fill it should raise `resources.memory` alongside. Agents pick the
 new size up when their container is recreated; a running container keeps the
 mount it booted with.
+### `switchroom memory repair` — vector index coverage is reachable, and skew is loud
+
+Hindsight creates a bank's per-`(bank, fact_type)` partial vector indexes when
+the bank is created — instant, because it is empty. A bank that arrives
+**already populated** never takes that path: a logical restore, a
+cross-version upgrade, a vector-extension switch. Recall on such a bank does
+not fail. It falls back to a global index plus a post-filter and quietly
+under-returns.
+
+This fleet ran that way. Several banks returned single-digit semantic
+candidates out of a 100-candidate budget for roughly three months, and nothing
+in switchroom noticed, because every surface that could have noticed was
+checking liveness rather than coverage. Upstream shipped detection and repair
+in 0.8.5 (vectorize-io/hindsight#2645) as `hindsight-admin repair-bank`. It
+lived in a venv inside the container at a path no operator would guess. A
+backend capability nobody can reach is the same as not having it.
+
+- **`switchroom memory repair [--bank <id> | --agent <name> | --all] [--schema
+  <s>] [--dry-run]`.** Runs the admin CLI inside the hindsight container.
+  `--agent` resolves the bank id for you, because operators think in agents.
+  Rebuilds use `CREATE INDEX CONCURRENTLY`, so they never block live traffic;
+  the command is idempotent and re-running is the documented retry.
+- **A first-class verb, not a passthrough.** A passthrough is undiscoverable —
+  you have to already know `repair-bank` exists to type it, which is the exact
+  condition that let the outage run for three months — and it cannot preflight:
+  against a pre-0.8.5 server it yields typer's `No such command 'repair-bank'`,
+  which reads like a typo rather than "your image predates the fix". The verb
+  says the real thing.
+- **Not a doctor auto-fix.** `doctor` stays read-only. `CREATE INDEX
+  CONCURRENTLY` across every bank is a mutation on a live database and deserves
+  explicit operator intent. Detection and repair stay split.
+
+### `switchroom doctor` now checks hindsight version skew
+
+`classifyToolContract` is one-directional: it only notices tools switchroom
+expects and the server *lacks*. A server that grew capabilities stays green
+forever — which is how the fleet ran a backend several versions ahead of its
+own captured contract with three MCP tools and `repair-bank` reachable by
+nobody. Nothing in `src/` tracked the upstream version at all.
+
+`HINDSIGHT_MIN_API_VERSION` (`src/memory/hindsight-tools.ts`) now declares the
+version the committed contract was captured from, and doctor compares it to
+the live `GET /version`:
+
+- **older → fail.** The tools and args switchroom sends may not exist here, and
+  `memory repair` is unavailable.
+- **newer → warn.** Not an error (upstream's MCP changes are additive), but the
+  contract is stale by definition and the drift is silent in both directions.
+  The diff is the capability you are not yet using.
+- **unreachable → no row.** The `/health` check already owns "the backend is
+  down"; a second red line for the same outage is noise.
+
+The fixture test asserts the constant equals the snapshot's
+`_meta.hindsight_api_version`, so bumping one without re-capturing the other
+reds the suite — the check cannot silently stop being a check.
+
+### Corrected: 0.8.4 does emit `consolidation.completed`
+
+`docs/operators/hindsight-memory.md` claimed the 🧠 legibility line was dormant
+because the pinned engine does not emit the webhook. It does, from
+`hindsight_api/engine/memory_engine.py`, in both 0.8.4 and 0.8.5. The gap is on
+the switchroom side: nothing registers a subscription and there is no receiver.
+The work required is a subscription plus a receiver, not an engine bump.
+
 ### The hindsight MCP contract is re-pinned to the surface the fleet actually runs
 
 The golden tools/list snapshot had not been refreshed since 2026-06-07. It

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -373,6 +373,17 @@ backend capability nobody can reach is the same as not having it.
 - **Not a doctor auto-fix.** `doctor` stays read-only. `CREATE INDEX
   CONCURRENTLY` across every bank is a mutation on a live database and deserves
   explicit operator intent. Detection and repair stay split.
+- **A check that cannot fail is not a check.** `--dry-run` reports through the
+  exit code, and every "I could not confirm" path is non-zero: `0` coverage
+  confirmed complete, `3` indexes missing, `4` unverified (no summary line, or
+  **zero banks scanned** — a mistyped `--bank` used to print "✓ Coverage
+  complete … across 0 bank(s)" and exit 0, which `skills/switchroom-health`
+  reported as OK), `1` the check itself failed. The codes skip `2` because the
+  underlying admin CLI is a typer app whose usage error is `2`, and the child's
+  exit code is never re-emitted — a mistyped flag can no longer surface as
+  "coverage missing". The whole verdict is one pure function,
+  `classifyRepairOutcome`, so each of those false greens has a test that reds
+  if the fix is reverted.
 
 ### `switchroom doctor` now checks hindsight version skew
 
@@ -387,16 +398,26 @@ version the committed contract was captured from, and doctor compares it to
 the live `GET /version`:
 
 - **older → fail.** The tools and args switchroom sends may not exist here, and
-  `memory repair` is unavailable.
+  an unknown arg is dropped *silently* — the symptom is a wrong answer, not an
+  error.
 - **newer → warn.** Not an error (upstream's MCP changes are additive), but the
   contract is stale by definition and the drift is silent in both directions.
   The diff is the capability you are not yet using.
 - **unreachable → no row.** The `/health` check already owns "the backend is
   down"; a second red line for the same outage is noise.
 
-The fixture test asserts the constant equals the snapshot's
-`_meta.hindsight_api_version`, so bumping one without re-capturing the other
-reds the suite — the check cannot silently stop being a check.
+The floor tracks the **snapshot**, not any individual feature: it is `0.8.4`,
+the version `docker/Dockerfile.hindsight` actually pins. `repair-bank`'s `0.8.5`
+requirement lives in its own `HINDSIGHT_REPAIR_MIN_API_VERSION` and is enforced
+in the repair preflight, at the moment an operator tries to use it. Fusing the
+two would have shipped a flagship doctor check that was red by construction on
+every running fleet — which trains people to ignore precisely the check meant
+to catch the next outage.
+
+The fixture test chains constant → snapshot `_meta.hindsight_api_version` →
+the api-version marker in `docker/Dockerfile.hindsight`, so bumping any one
+without the others reds the suite — the check cannot silently stop being a
+check.
 
 ### Corrected: 0.8.4 does emit `consolidation.completed`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -140,7 +140,15 @@ switchroom workspace status <agent>               # git status on the workspace
 ```bash
 switchroom debug turn <agent>                     # Dump the exact prompt layering from the last turn
 switchroom memory setup|search|stats|reflect      # Hindsight memory
+switchroom memory repair --all [--dry-run]        # Rebuild per-bank vector index coverage
 ```
+
+`memory repair` is the fix for a bank whose recall silently under-returns —
+one that arrived already populated (restore, cross-version upgrade,
+vector-extension switch) and so never got its per-`(bank, fact_type)` vector
+indexes. Idempotent, `CREATE INDEX CONCURRENTLY`, safe on a live fleet;
+requires hindsight ≥ 0.8.5. See `docs/operators/hindsight-memory.md`.
+
 
 The progress-card driver also writes a per-agent `card-events.jsonl`
 audit log: every edit, pin, unpin, and tool-label transition the user

--- a/docs/operators/hindsight-memory.md
+++ b/docs/operators/hindsight-memory.md
@@ -358,15 +358,28 @@ only through prose:
 
 | Exit | Meaning |
 |------|---------|
-| `0` | Coverage complete — nothing to create. |
-| `2` | Indexes are **missing**. Recall on those banks is under-returning. |
+| `0` | Coverage **confirmed** complete — at least one bank scanned, nothing to create. |
+| `3` | Indexes are **missing**. Recall on those banks is under-returning. |
+| `4` | Coverage **could not be confirmed**: no summary line, or zero banks scanned (a mistyped `--bank`/`--schema` looks exactly like this). Nothing is known to be fine. |
 | `1` | The check/repair itself failed (see output; a re-run is the retry). |
+
+`4` is deliberately not `0`. "The command ran and I learned nothing" is the
+failure mode this whole feature exists to eliminate, so it is never reported as
+a pass. And the meaningful codes avoid `2` on purpose: the underlying admin CLI
+is a typer app that exits `2` on a **usage** error, and `switchroom memory
+repair` never re-emits the child's code — a mistyped flag is `1`, never
+"coverage missing".
 
 Notes:
 
-- **Requires hindsight ≥ 0.8.5.** Against an older server the verb refuses with
-  the reason (rather than the admin CLI's bare `No such command`), and
-  `switchroom doctor` shows a red `hindsight version` line.
+- **Requires hindsight ≥ 0.8.5** (`HINDSIGHT_REPAIR_MIN_API_VERSION`). Against
+  an older server the verb refuses with the reason, rather than the admin CLI's
+  bare `No such command`. This is a *feature* floor and is checked at the point
+  of use only — it deliberately does not make `switchroom doctor` red, because
+  the doctor row tracks the MCP-contract floor (`HINDSIGHT_MIN_API_VERSION`,
+  the version the committed tools/list snapshot was captured from). A standing
+  red row for a capability you are not trying to use just teaches people to
+  ignore doctor.
 - **It will not remove the legacy global index.** `idx_memory_units_embedding`
   survives on instances that predate the per-bank scheme, and `repair-bank`
   does not drop it. Removing it is a manual `DROP INDEX CONCURRENTLY` decision.

--- a/docs/operators/hindsight-memory.md
+++ b/docs/operators/hindsight-memory.md
@@ -64,6 +64,12 @@ docker exec switchroom-hindsight sh -lc '
 
 # 3. Bounce hindsight so the worker re-reads cleanly.
 switchroom agent restart test-harness --wait --force   # or: docker restart switchroom-hindsight
+
+# 4. MANDATORY: rebuild per-bank vector index coverage.
+#    A restored bank arrives populated, so it never hits the create-time index
+#    path — recall silently under-returns until this runs. See "Vector index
+#    coverage" below.
+switchroom memory repair --all
 ```
 
 ## Rolling the base image BACK (schema first, then the digest)
@@ -310,6 +316,63 @@ consolidation queue is advancing — watch for a stuck queue separately
 (see the stale-claim reaper in `hindsight-entrypoint.sh` and the
 `async_operations` `processing`/`pending` counts).
 
+## Vector index coverage (`switchroom memory repair`)
+
+Hindsight creates a bank's per-`(bank, fact_type)` **partial vector indexes**
+at bank-creation time — instant, because the bank is empty. A bank that
+arrives **already populated** never takes that path:
+
+- a logical restore (`switchroom memory` restore, `import-bank`, a `pg_dump`
+  reload),
+- a cross-version upgrade that repopulates rows outside the create path,
+- a vector-extension / backend switch.
+
+Recall on such a bank does not fail. It falls back to the **global** index plus
+a post-filter and quietly **under-returns**. This is not a hypothetical: this
+fleet ran that way, with several banks returning single-digit semantic
+candidates out of a 100-candidate budget, for roughly three months. Nothing
+went red, because every surface was checking liveness rather than coverage.
+
+Upstream shipped detection + repair in **0.8.5**
+([vectorize-io/hindsight#2645](https://github.com/vectorize-io/hindsight/issues/2645)).
+Switchroom exposes it:
+
+```bash
+# See what is missing without touching anything.
+switchroom memory repair --all --dry-run
+
+# Repair one bank, by bank id or by the agent that owns it.
+switchroom memory repair --bank agent_overlord
+switchroom memory repair --agent overlord
+
+# Repair the whole fleet.
+switchroom memory repair --all
+```
+
+Rebuilds use `CREATE INDEX CONCURRENTLY`, so they never block live
+retain/recall/consolidation. The command is **idempotent and safe to re-run** —
+a failed index is dropped, and re-running is the documented retry.
+
+`--dry-run` is scriptable — it reports coverage through the **exit code**, not
+only through prose:
+
+| Exit | Meaning |
+|------|---------|
+| `0` | Coverage complete — nothing to create. |
+| `2` | Indexes are **missing**. Recall on those banks is under-returning. |
+| `1` | The check/repair itself failed (see output; a re-run is the retry). |
+
+Notes:
+
+- **Requires hindsight ≥ 0.8.5.** Against an older server the verb refuses with
+  the reason (rather than the admin CLI's bare `No such command`), and
+  `switchroom doctor` shows a red `hindsight version` line.
+- **It will not remove the legacy global index.** `idx_memory_units_embedding`
+  survives on instances that predate the per-bank scheme, and `repair-bank`
+  does not drop it. Removing it is a manual `DROP INDEX CONCURRENTLY` decision.
+- **Run it after every restore.** The restore path is the single most reliable
+  way to produce a bank with no coverage, and it is silent.
+
 ## Chat-visible memory surfaces (what agents show users)
 
 Memory is no longer entirely invisible. Three operator-visible behaviours
@@ -332,11 +395,19 @@ recall, never per-turn:
 - **Store/correct side (📌 / ✂️)** is a deterministic tool-call observation —
   no model call, no polling. Opt out per-agent/fleet with the env var
   `SWITCHROOM_MEMORY_LEGIBILITY=0` (only the literal `0` disables).
-- **Update side (🧠)** depends on a `consolidation.completed` webhook the
-  pinned hindsight image (v0.8.4) does **not** emit, so the consumer
-  (`telegram-plugin/consolidation-legibility.ts`) stays dormant. It is also
-  OFF by default; an operator opts in with `SWITCHROOM_CONSOLIDATION_LEGIBILITY=1`,
-  but it does nothing until an engine that emits the webhook is pinned.
+- **Update side (🧠)** depends on a `consolidation.completed` webhook and stays
+  dormant — but **not** for the reason this page used to give. It claimed the
+  pinned engine does not emit the event. It does: `WebhookEventType.
+  CONSOLIDATION_COMPLETED` is emitted from `hindsight_api/engine/
+  memory_engine.py` in **both 0.8.4 and 0.8.5**, and the event is in the
+  documented supported set (`retain.completed`, `consolidation.completed`,
+  `memory_defense.triggered`). What is missing is on the switchroom side:
+  nothing registers a webhook subscription with hindsight and there is no
+  receiver endpoint, so the consumer
+  (`telegram-plugin/consolidation-legibility.ts`) is never fed. It is also OFF
+  by default (`SWITCHROOM_CONSOLIDATION_LEGIBILITY=1` to opt in). Enabling it
+  today does nothing; the work required is a subscription + receiver, not an
+  engine bump.
 
 ### Directive-capture nudge + verifier (Phase 3)
 

--- a/skills/switchroom-health/SKILL.md
+++ b/skills/switchroom-health/SKILL.md
@@ -80,6 +80,19 @@ done
 
 # Check Hindsight MCP reachable
 switchroom memory search "test" --agent assistant 2>/dev/null && echo "OK: memory search works" || echo "WARN: memory search failed"
+
+# Reachable is NOT healthy. A bank that arrived already populated (restore,
+# cross-version upgrade, vector-extension switch) never got its per-bank vector
+# indexes, so recall falls back to a global index + post-filter and silently
+# UNDER-RETURNS — a search still "works", it just returns almost nothing.
+# This fleet ran that way for ~3 months. Check coverage, not just liveness.
+# Exit 0 = coverage complete, 2 = indexes missing, 1 = the check itself failed.
+switchroom memory repair --all --dry-run >/tmp/sr-cov.txt 2>&1
+case $? in
+  0) echo "OK: vector index coverage complete" ;;
+  2) echo "FAIL: vector index coverage MISSING — recall is under-returning; run 'switchroom memory repair --all'"; tail -2 /tmp/sr-cov.txt ;;
+  *) echo "WARN: coverage check could not run (hindsight < 0.8.5, container down, or docker unavailable)"; tail -2 /tmp/sr-cov.txt ;;
+esac
 ```
 
 ## Step 3 — Interpret and report
@@ -108,6 +121,8 @@ For common failures, give the exact fix:
 | Fleet on the wrong account | `switchroom auth use <label>` (fleet-wide) or `switchroom auth agent override <agent> <label>` (one agent) |
 | Container unhealthy | `docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml restart switchroom-<name>` |
 | Missing .mcp.json | `switchroom apply` (full reconcile + rewrite compose; bring up via `docker compose ... up -d`) or `switchroom agent reconcile <name>` (targeted) |
+| Recall returns few/no results though hindsight is up (esp. after a restore or upgrade) | Missing per-bank vector index coverage. `switchroom memory repair --all --dry-run` to confirm, then `switchroom memory repair --all`. Idempotent, uses `CREATE INDEX CONCURRENTLY`, safe on a live fleet. Requires hindsight ≥ 0.8.5. |
+| `switchroom doctor` shows a red/amber `hindsight version` line | The running backend drifted from the MCP contract switchroom captured. Older → bump the pinned image (`switchroom memory --update`). Newer → re-capture `tests/fixtures/hindsight-tools-list.snapshot.json`; until then any tool added upstream is invisible to agents. |
 | Bot token unresolved | Check vault: `switchroom vault list` |
 | Memory unreachable | Check Hindsight MCP server is running |
 

--- a/skills/switchroom-health/SKILL.md
+++ b/skills/switchroom-health/SKILL.md
@@ -86,11 +86,15 @@ switchroom memory search "test" --agent assistant 2>/dev/null && echo "OK: memor
 # indexes, so recall falls back to a global index + post-filter and silently
 # UNDER-RETURNS — a search still "works", it just returns almost nothing.
 # This fleet ran that way for ~3 months. Check coverage, not just liveness.
-# Exit 0 = coverage complete, 2 = indexes missing, 1 = the check itself failed.
+# Exit codes are a contract (src/memory/hindsight-repair.ts): 0 = coverage
+# confirmed complete, 3 = indexes MISSING, 4 = coverage could NOT be confirmed
+# (no summary line, or zero banks scanned — a typo'd --bank looks like this),
+# 1 = the check itself failed. 4 is not "fine": it means nothing was verified.
 switchroom memory repair --all --dry-run >/tmp/sr-cov.txt 2>&1
 case $? in
   0) echo "OK: vector index coverage complete" ;;
-  2) echo "FAIL: vector index coverage MISSING — recall is under-returning; run 'switchroom memory repair --all'"; tail -2 /tmp/sr-cov.txt ;;
+  3) echo "FAIL: vector index coverage MISSING — recall is under-returning; run 'switchroom memory repair --all'"; tail -2 /tmp/sr-cov.txt ;;
+  4) echo "WARN: coverage NOT verified — the scan confirmed nothing (check the --bank/--schema names, or the hindsight backend)"; tail -2 /tmp/sr-cov.txt ;;
   *) echo "WARN: coverage check could not run (hindsight < 0.8.5, container down, or docker unavailable)"; tail -2 /tmp/sr-cov.txt ;;
 esac
 ```

--- a/src/cli/doctor-memory.ts
+++ b/src/cli/doctor-memory.ts
@@ -706,7 +706,14 @@ export function checkHindsightContainerHealth(
  * Three outcomes:
  *  - **older than the floor → fail.** The snapshot, the shim fallback manifest
  *    and the args every callsite sends describe a surface this server may not
- *    have, and `switchroom memory repair` is unavailable.
+ *    have.
+ *
+ * The floor is the version the SNAPSHOT was captured from — not the version any
+ * individual feature wants. Feature floors (e.g.
+ * `HINDSIGHT_REPAIR_MIN_API_VERSION`) are enforced at their own point of use,
+ * so this row never goes red over a capability the operator is not trying to
+ * use. A doctor row that is red by construction on the running fleet teaches
+ * people to skip doctor.
  *  - **equal → ok.**
  *  - **newer → warn.** Not an error (upstream's MCP changes are additive), but
  *    the contract is stale by definition and the drift is silent in both
@@ -732,8 +739,9 @@ export function classifyHindsightVersionSkew(live: string | null): CheckResult |
       status: "fail",
       detail:
         `api_version ${live} is OLDER than the ${HINDSIGHT_MIN_API_VERSION} contract ` +
-        `switchroom is pinned to — tools/args the CLI and agents send may not exist ` +
-        `on this server, and \`switchroom memory repair\` (vector-index coverage) is unavailable`,
+        `switchroom captured — tools and args the CLI and agents send may not exist ` +
+        `on this server, and an unknown arg is dropped SILENTLY (isError stays false), ` +
+        `so the symptom is a wrong answer rather than an error`,
       fix:
         "Update the pinned image in `docker/Dockerfile.hindsight` and recreate " +
         "the container with `switchroom memory --update` (a plain restart does " +

--- a/src/cli/doctor-memory.ts
+++ b/src/cli/doctor-memory.ts
@@ -25,7 +25,11 @@
  * local container (remote URL / no docker / inside an agent container).
  */
 import { execFileSync } from "node:child_process";
-import { EXPECTED_HINDSIGHT_TOOLS } from "../memory/hindsight-tools.js";
+import {
+  EXPECTED_HINDSIGHT_TOOLS,
+  HINDSIGHT_MIN_API_VERSION,
+} from "../memory/hindsight-tools.js";
+import { compareApiVersion, fetchHindsightApiVersion } from "../memory/hindsight-repair.js";
 import {
   HINDSIGHT_DATA_VOLUME,
   HINDSIGHT_DEFAULT_WORKER_ID,
@@ -685,6 +689,83 @@ export function checkHindsightContainerHealth(
   }
 
   return results;
+}
+
+/**
+ * Pure: classify the live hindsight API version against the version the
+ * committed MCP contract was captured from ({@link HINDSIGHT_MIN_API_VERSION}).
+ *
+ * This is the check that was missing while the fleet ran a server three
+ * versions ahead of its own snapshot. Nothing in switchroom tracked the
+ * upstream version at all, so a capability that shipped upstream — new tools,
+ * new accepted props, `repair-bank` — was reachable by nobody and no surface
+ * said so. `classifyToolContract` cannot cover this: it only detects tools
+ * switchroom EXPECTS and the server lacks, never the reverse, so a server that
+ * grew capabilities stays green forever.
+ *
+ * Three outcomes:
+ *  - **older than the floor → fail.** The snapshot, the shim fallback manifest
+ *    and the args every callsite sends describe a surface this server may not
+ *    have, and `switchroom memory repair` is unavailable.
+ *  - **equal → ok.**
+ *  - **newer → warn.** Not an error (upstream's MCP changes are additive), but
+ *    the contract is stale by definition and the drift is silent in both
+ *    directions until someone re-captures it.
+ *
+ * `live === null` (probe failed / not reachable) returns null — no row. The
+ * /health check already owns "the backend is down"; a second red line for the
+ * same outage is noise.
+ */
+export function classifyHindsightVersionSkew(live: string | null): CheckResult | null {
+  if (live === null) return null;
+  const cmp = compareApiVersion(live, HINDSIGHT_MIN_API_VERSION);
+  if (cmp === 0) {
+    return {
+      name: "hindsight version",
+      status: "ok",
+      detail: `api_version ${live} matches the captured MCP contract`,
+    };
+  }
+  if (cmp < 0) {
+    return {
+      name: "hindsight version",
+      status: "fail",
+      detail:
+        `api_version ${live} is OLDER than the ${HINDSIGHT_MIN_API_VERSION} contract ` +
+        `switchroom is pinned to — tools/args the CLI and agents send may not exist ` +
+        `on this server, and \`switchroom memory repair\` (vector-index coverage) is unavailable`,
+      fix:
+        "Update the pinned image in `docker/Dockerfile.hindsight` and recreate " +
+        "the container with `switchroom memory --update` (a plain restart does " +
+        "not re-pull). If the downgrade is deliberate, re-capture " +
+        "tests/fixtures/hindsight-tools-list.snapshot.json from THIS server and " +
+        "lower HINDSIGHT_MIN_API_VERSION to match.",
+    };
+  }
+  return {
+    name: "hindsight version",
+    status: "warn",
+    detail:
+      `api_version ${live} is NEWER than the ${HINDSIGHT_MIN_API_VERSION} contract ` +
+      `switchroom captured — any tool or accepted prop added since is invisible to ` +
+      `agents (the shim's cold-boot manifest is built from that capture)`,
+    fix:
+      "Re-capture tests/fixtures/hindsight-tools-list.snapshot.json from the live " +
+      "server, reconcile EXPECTED_HINDSIGHT_TOOLS + the shim's FALLBACK_TOOL_TABLE, " +
+      "and bump HINDSIGHT_MIN_API_VERSION (src/memory/hindsight-tools.ts). The diff " +
+      "IS the upstream capability you are not yet using.",
+  };
+}
+
+/**
+ * Best-effort async wrapper: probe `<origin>/version` and classify the skew.
+ * Never throws; returns null when there is nothing to report.
+ */
+export async function checkHindsightVersion(
+  mcpUrl: string,
+  opts: { fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+): Promise<CheckResult | null> {
+  return classifyHindsightVersionSkew(await fetchHindsightApiVersion(mcpUrl, opts));
 }
 
 /**

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -33,7 +33,7 @@ import { probeHindsight, isHindsightEnabled, fetchHindsightToolsList, collectPro
 import { HINDSIGHT_DEFAULT_MCP_URL } from "../setup/hindsight.js";
 import { findUnmanagedHindsightEnvKeys } from "../setup/hindsight-perf-defaults.js";
 import { inspectBankHealth, staleMentalModels, corruptedMentalModels, recentUnextracted, ageDays } from "../memory/bank-health.js";
-import { checkHindsightContainerHealth, classifyToolContract, checkHindsightHealthEndpoint, classifyConsolidationBacklog, classifyDirectiveCount } from "./doctor-memory.js";
+import { checkHindsightContainerHealth, classifyToolContract, checkHindsightHealthEndpoint, checkHindsightVersion, classifyConsolidationBacklog, classifyDirectiveCount } from "./doctor-memory.js";
 import { checkAgentRecallHealth } from "./doctor-recall-health.js";
 import { checkHnswPartialIndexes } from "./doctor-hnsw-index.js";
 import { checkHindsightWatchArmed } from "./doctor-hindsight-watch.js";
@@ -1374,6 +1374,14 @@ async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> 
   if (toolsList.ok) {
     results.push(...classifyToolContract(toolsList.tools));
   }
+
+  // Version skew (2026-07-27). classifyToolContract is one-directional: it only
+  // notices tools switchroom expects and the server LACKS. A server that grew
+  // capabilities stays green forever — which is how the fleet ran a backend
+  // several versions ahead of its own captured contract, with `repair-bank`
+  // and three whole MCP tools reachable by nobody. This is the other direction.
+  const versionRow = await checkHindsightVersion(url);
+  if (versionRow) results.push(versionRow);
 
   // Consumer probe (#1245): broker-fed hindsight needs an
   // `auth.consumers[]` entry + a bound per-consumer socket. Replaces

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -26,7 +26,16 @@ import {
   HINDSIGHT_DEFAULT_MCP_URL,
   type LiteLLMHindsightConfig,
 } from "../setup/hindsight.js";
+import {
+  buildRepairBankArgv,
+  classifyRepairPreflight,
+  fetchHindsightApiVersion,
+  parseRepairSummary,
+  HINDSIGHT_CONTAINER_NAME,
+  REPAIR_COVERAGE_MISSING_EXIT,
+} from "../memory/hindsight-repair.js";
 import { getViaBrokerStructured } from "../vault/broker/client.js";
+import { spawn } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { writeConfigFileSync } from "../util/atomic.js";
 import { join } from "node:path";
@@ -787,6 +796,157 @@ export function registerMemoryCommand(program: Command): void {
       }
       console.log();
     });
+
+  // switchroom memory repair — reachability for hindsight 0.8.5's
+  // `hindsight-admin repair-bank`. A bank that arrived already populated
+  // (logical restore, cross-version upgrade, vector-extension switch) never
+  // got its per-(bank, fact_type) partial vector indexes, so recall falls back
+  // to a global index + post-filter and silently under-returns. Seven fleet
+  // banks returned 0-4 candidates out of 100 for ~three months that way. See
+  // src/memory/hindsight-repair.ts for why this is a verb and not a
+  // passthrough or a doctor auto-fix.
+  memory
+    .command("repair")
+    .description(
+      "Verify and rebuild a bank's per-(bank, fact_type) vector index coverage (hindsight >= 0.8.5) — the fix for a restored/upgraded bank whose recall silently under-returns",
+    )
+    .option("--bank <id>", "Bank id to repair (mutually exclusive with --all)")
+    .option("--agent <name>", "Repair the bank belonging to this agent (resolves the bank id for you)")
+    .option("--all", "Repair every bank in the base schema and all discovered tenant schemas")
+    .option("--schema <name>", "Limit to a single schema (default: base + discovered tenant schemas)")
+    .option("--dry-run", "Report what would be repaired without creating or dropping any index")
+    .option("--container <name>", `Hindsight container name (default: ${HINDSIGHT_CONTAINER_NAME})`)
+    .action(
+      withConfigError(
+        async (opts: {
+          bank?: string;
+          agent?: string;
+          all?: boolean;
+          schema?: string;
+          dryRun?: boolean;
+          container?: string;
+        }) => {
+          const config = getConfig(program);
+
+          if (opts.agent && opts.bank) {
+            console.error(chalk.red("Pass either --agent or --bank, not both."));
+            process.exit(1);
+          }
+          let bank = opts.bank;
+          if (opts.agent) {
+            if (!config.agents[opts.agent]) {
+              console.error(
+                chalk.red(`Agent "${opts.agent}" is not defined in switchroom.yaml`),
+              );
+              process.exit(1);
+            }
+            bank = getCollectionForAgent(opts.agent, config);
+            console.log(chalk.gray(`  --agent ${opts.agent} → bank ${bank}`));
+          }
+
+          let argv: string[];
+          try {
+            argv = buildRepairBankArgv({
+              bank,
+              all: opts.all,
+              schema: opts.schema,
+              dryRun: opts.dryRun,
+              container: opts.container,
+            });
+          } catch (err) {
+            console.error(chalk.red(`✗ ${(err as Error).message}`));
+            process.exit(1);
+          }
+
+          if (!isDockerAvailable()) {
+            console.error(
+              chalk.red("✗ Docker is not available — `memory repair` runs the admin CLI inside the hindsight container."),
+            );
+            process.exit(1);
+          }
+
+          // Version preflight: against a pre-0.8.5 server the admin CLI answers
+          // `No such command 'repair-bank'`, which reads like a typo rather
+          // than "your image predates the fix". Say the real thing.
+          const apiUrl =
+            (config.memory?.config?.url as string | undefined) ?? HINDSIGHT_DEFAULT_MCP_URL;
+          const preflight = classifyRepairPreflight(await fetchHindsightApiVersion(apiUrl));
+          if (!preflight.ok) {
+            console.error(chalk.red(`✗ ${preflight.reason}`));
+            process.exit(1);
+          }
+
+          const target = bank ? `bank ${chalk.cyan(bank)}` : chalk.cyan("all banks");
+          console.log(
+            chalk.bold(
+              `\nRepairing vector index coverage for ${target}${opts.dryRun ? chalk.yellow(" (dry run)") : ""}`,
+            ),
+          );
+          console.log(
+            chalk.gray(
+              "  Rebuilds are CREATE INDEX CONCURRENTLY — safe on a live fleet, but not instant on a large bank.\n",
+            ),
+          );
+
+          // Tee rather than inherit: the operator still sees repair-bank's
+          // output live (a large bank is not instant), and we keep a copy so
+          // the summary can drive a machine-readable exit code. A dry run that
+          // found missing coverage must NOT exit 0 — otherwise the only way to
+          // know is to read the prose, which is how this went unnoticed for
+          // three months.
+          const child = spawn("docker", argv, { stdio: ["ignore", "pipe", "inherit"] });
+          let captured = "";
+          child.stdout?.on("data", (chunk: Buffer) => {
+            captured += chunk.toString();
+            process.stdout.write(chunk);
+          });
+          const code: number = await new Promise((resolve) => {
+            child.on("error", () => resolve(127));
+            child.on("close", (c) => resolve(c ?? 1));
+          });
+          if (code !== 0) {
+            console.error(
+              chalk.red(`\n✗ repair-bank exited ${code}.`),
+              chalk.gray(
+                "Failed indexes are dropped, so a re-run is safe and is the documented retry.",
+              ),
+            );
+            process.exit(code);
+          }
+
+          const summary = parseRepairSummary(captured);
+          if (summary === null) {
+            // repair-bank exited 0 without a summary — e.g. a vector backend
+            // with a single global index ("nothing to repair"). Report the
+            // ambiguity instead of claiming coverage is fine.
+            console.log(
+              chalk.yellow("\n⚠ repair-bank exited 0 but printed no summary."),
+              chalk.gray("Read its output above — coverage was NOT confirmed."),
+            );
+            return;
+          }
+          if (opts.dryRun && summary.toCreate > 0) {
+            console.error(
+              chalk.red(
+                `\n✗ ${summary.toCreate} vector index(es) missing across ${summary.banksScanned} bank(s).`,
+              ),
+              chalk.gray(
+                "Recall on those banks silently under-returns. Re-run without --dry-run to fix.",
+              ),
+            );
+            process.exit(REPAIR_COVERAGE_MISSING_EXIT);
+          }
+          console.log(
+            chalk.green("\n✓ repair-bank finished."),
+            chalk.gray(
+              opts.dryRun
+                ? `Coverage complete: ${summary.alreadyPresent} index(es) present across ${summary.banksScanned} bank(s), nothing to create.`
+                : `${summary.created} created, ${summary.alreadyPresent} already present across ${summary.banksScanned} bank(s). Re-run \`switchroom doctor\` to confirm.`,
+            ),
+          );
+        },
+      ),
+    );
 
   // switchroom memory recall-log [agent]
   memory

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -31,8 +31,9 @@ import {
   classifyRepairPreflight,
   fetchHindsightApiVersion,
   parseRepairSummary,
+  classifyRepairOutcome,
   HINDSIGHT_CONTAINER_NAME,
-  REPAIR_COVERAGE_MISSING_EXIT,
+  REPAIR_FAILED_EXIT,
 } from "../memory/hindsight-repair.js";
 import { getViaBrokerStructured } from "../vault/broker/client.js";
 import { spawn } from "node:child_process";
@@ -862,7 +863,7 @@ export function registerMemoryCommand(program: Command): void {
             console.error(
               chalk.red("✗ Docker is not available — `memory repair` runs the admin CLI inside the hindsight container."),
             );
-            process.exit(1);
+            process.exit(REPAIR_FAILED_EXIT);
           }
 
           // Version preflight: against a pre-0.8.5 server the admin CLI answers
@@ -873,7 +874,7 @@ export function registerMemoryCommand(program: Command): void {
           const preflight = classifyRepairPreflight(await fetchHindsightApiVersion(apiUrl));
           if (!preflight.ok) {
             console.error(chalk.red(`✗ ${preflight.reason}`));
-            process.exit(1);
+            process.exit(REPAIR_FAILED_EXIT);
           }
 
           const target = bank ? `bank ${chalk.cyan(bank)}` : chalk.cyan("all banks");
@@ -900,50 +901,27 @@ export function registerMemoryCommand(program: Command): void {
             captured += chunk.toString();
             process.stdout.write(chunk);
           });
-          const code: number = await new Promise((resolve) => {
+          const childExit: number = await new Promise((resolve) => {
             child.on("error", () => resolve(127));
             child.on("close", (c) => resolve(c ?? 1));
           });
-          if (code !== 0) {
-            console.error(
-              chalk.red(`\n✗ repair-bank exited ${code}.`),
-              chalk.gray(
-                "Failed indexes are dropped, so a re-run is safe and is the documented retry.",
-              ),
-            );
-            process.exit(code);
-          }
 
-          const summary = parseRepairSummary(captured);
-          if (summary === null) {
-            // repair-bank exited 0 without a summary — e.g. a vector backend
-            // with a single global index ("nothing to repair"). Report the
-            // ambiguity instead of claiming coverage is fine.
-            console.log(
-              chalk.yellow("\n⚠ repair-bank exited 0 but printed no summary."),
-              chalk.gray("Read its output above — coverage was NOT confirmed."),
-            );
+          // Every verdict — including "I could not tell" — comes from one pure
+          // function so it is testable and so no branch can quietly reach a
+          // green exit. The child's own code is NEVER re-emitted: repair-bank
+          // is a typer app whose usage error is exit 2, and re-emitting it
+          // would collide with this command's own coverage codes.
+          const outcome = classifyRepairOutcome({
+            childExit,
+            summary: parseRepairSummary(captured),
+            dryRun: Boolean(opts.dryRun),
+          });
+          if (outcome.level === "ok") {
+            console.log(chalk.green(`\n✓ ${outcome.headline}`), chalk.gray(outcome.detail));
             return;
           }
-          if (opts.dryRun && summary.toCreate > 0) {
-            console.error(
-              chalk.red(
-                `\n✗ ${summary.toCreate} vector index(es) missing across ${summary.banksScanned} bank(s).`,
-              ),
-              chalk.gray(
-                "Recall on those banks silently under-returns. Re-run without --dry-run to fix.",
-              ),
-            );
-            process.exit(REPAIR_COVERAGE_MISSING_EXIT);
-          }
-          console.log(
-            chalk.green("\n✓ repair-bank finished."),
-            chalk.gray(
-              opts.dryRun
-                ? `Coverage complete: ${summary.alreadyPresent} index(es) present across ${summary.banksScanned} bank(s), nothing to create.`
-                : `${summary.created} created, ${summary.alreadyPresent} already present across ${summary.banksScanned} bank(s). Re-run \`switchroom doctor\` to confirm.`,
-            ),
-          );
+          console.error(chalk.red(`\n✗ ${outcome.headline}`), chalk.gray(outcome.detail));
+          process.exit(outcome.exit);
         },
       ),
     );

--- a/src/memory/hindsight-repair.test.ts
+++ b/src/memory/hindsight-repair.test.ts
@@ -7,9 +7,15 @@ import {
   fetchHindsightApiVersion,
   HINDSIGHT_ADMIN_BIN,
   HINDSIGHT_CONTAINER_NAME,
+  classifyRepairOutcome,
   REPAIR_COVERAGE_MISSING_EXIT,
+  REPAIR_UNVERIFIED_EXIT,
+  REPAIR_FAILED_EXIT,
 } from "./hindsight-repair.js";
-import { HINDSIGHT_MIN_API_VERSION } from "./hindsight-tools.js";
+import {
+  HINDSIGHT_MIN_API_VERSION,
+  HINDSIGHT_REPAIR_MIN_API_VERSION,
+} from "./hindsight-tools.js";
 
 describe("buildRepairBankArgv", () => {
   it("targets the named container and the admin CLI's real in-image path", () => {
@@ -152,11 +158,24 @@ describe("compareApiVersion", () => {
 });
 
 describe("classifyRepairPreflight", () => {
+  /**
+   * The feature floor must NOT be the MCP-contract floor. Fusing them is what
+   * made `switchroom doctor` red-by-construction on the running fleet: the
+   * contract was captured from 0.8.4 but the constant claimed 0.8.5 because
+   * repair-bank needs it. If someone re-fuses them, this reds.
+   */
+  it("uses the repair FEATURE floor, which is above the MCP contract floor", () => {
+    expect(compareApiVersion(HINDSIGHT_REPAIR_MIN_API_VERSION, HINDSIGHT_MIN_API_VERSION))
+      .toBeGreaterThan(0);
+    // The contract floor alone must not admit a server that lacks repair-bank.
+    expect(classifyRepairPreflight(HINDSIGHT_MIN_API_VERSION).ok).toBe(false);
+  });
+
   it("blocks a confirmed pre-0.8.5 server and names the real cause, not a typo", () => {
     const r = classifyRepairPreflight("0.8.4");
     expect(r.ok).toBe(false);
     expect(r.reason).toContain("0.8.4");
-    expect(r.reason).toContain(HINDSIGHT_MIN_API_VERSION);
+    expect(r.reason).toContain(HINDSIGHT_REPAIR_MIN_API_VERSION);
     expect(r.reason).toMatch(/repair-bank/);
   });
 
@@ -197,5 +216,121 @@ describe("fetchHindsightApiVersion", () => {
       throw new Error("ECONNREFUSED");
     }) as unknown as typeof fetch;
     expect(await fetchHindsightApiVersion("http://h/mcp/", { fetchImpl: boom })).toBeNull();
+  });
+});
+
+/**
+ * The verdict logic. Every case here was previously inline in the `memory
+ * repair` action body — untestable, and wrong in two places at once, both of
+ * them FALSE GREENS in the feature written to eliminate false greens.
+ */
+describe("classifyRepairOutcome", () => {
+  const summary = (over: Partial<{
+    schemas: number;
+    banksScanned: number;
+    alreadyPresent: number;
+    created: number;
+    toCreate: number;
+    failed: number;
+  }> = {}) => ({
+    schemas: 1,
+    banksScanned: 14,
+    alreadyPresent: 40,
+    created: 0,
+    toCreate: 0,
+    failed: 0,
+    ...over,
+  });
+
+  it("exits 0 only for a completed scan of at least one bank with nothing outstanding", () => {
+    const o = classifyRepairOutcome({ childExit: 0, summary: summary(), dryRun: true });
+    expect(o.exit).toBe(0);
+    expect(o.level).toBe("ok");
+  });
+
+  /**
+   * REGRESSION (false green #1): a typo'd `--bank` makes repair-bank scan
+   * nothing and print `Done: 1 schema(s), 0 bank(s) scanned, ...`. That used to
+   * render "✓ Coverage complete ... across 0 bank(s)" and exit 0, which the
+   * health skill reported as "OK: vector index coverage complete".
+   */
+  it("does NOT report coverage complete when zero banks were scanned", () => {
+    const o = classifyRepairOutcome({
+      childExit: 0,
+      summary: summary({ banksScanned: 0, alreadyPresent: 0 }),
+      dryRun: true,
+    });
+    expect(o.exit).toBe(REPAIR_UNVERIFIED_EXIT);
+    expect(o.exit).not.toBe(0);
+    expect(o.level).toBe("fail");
+    expect(o.headline).toMatch(/0 bank/);
+    expect(o.headline).not.toMatch(/complete/i);
+  });
+
+  /**
+   * REGRESSION (false green #2): no summary line printed "coverage was NOT
+   * confirmed" and then returned WITHOUT a non-zero exit, so the honest prose
+   * was invisible to every machine consumer.
+   */
+  it("exits non-zero when repair-bank printed no summary — unverified is not success", () => {
+    const o = classifyRepairOutcome({ childExit: 0, summary: null, dryRun: true });
+    expect(o.exit).toBe(REPAIR_UNVERIFIED_EXIT);
+    expect(o.exit).not.toBe(0);
+    expect(o.headline).toMatch(/NOT confirmed/);
+  });
+
+  it("reports missing coverage on a dry run with its own code", () => {
+    const o = classifyRepairOutcome({
+      childExit: 0,
+      summary: summary({ toCreate: 6 }),
+      dryRun: true,
+    });
+    expect(o.exit).toBe(REPAIR_COVERAGE_MISSING_EXIT);
+    expect(o.headline).toContain("6 vector index(es) missing");
+  });
+
+  it("does not treat a completed real repair as missing coverage", () => {
+    // Outside --dry-run, toCreate is not a gap: the indexes were built.
+    const o = classifyRepairOutcome({
+      childExit: 0,
+      summary: summary({ created: 6, toCreate: 0 }),
+      dryRun: false,
+    });
+    expect(o.exit).toBe(0);
+    expect(o.detail).toContain("6 created");
+  });
+
+  it("fails when indexes failed to build even though repair-bank exited 0", () => {
+    const o = classifyRepairOutcome({
+      childExit: 0,
+      summary: summary({ failed: 2 }),
+      dryRun: false,
+    });
+    expect(o.exit).toBe(REPAIR_FAILED_EXIT);
+    expect(o.headline).toContain("2 index(es) failed");
+  });
+
+  /**
+   * The exit-code collision. repair-bank is a typer app: exit 2 is a USAGE
+   * error. Propagating the child's code verbatim made a mistyped flag surface
+   * as this command's "coverage missing" signal.
+   */
+  it("never re-emits the child's exit code, so typer's usage-error 2 cannot read as 'coverage missing'", () => {
+    const o = classifyRepairOutcome({ childExit: 2, summary: null, dryRun: true });
+    expect(o.exit).toBe(REPAIR_FAILED_EXIT);
+    expect(o.exit).not.toBe(REPAIR_COVERAGE_MISSING_EXIT);
+    expect(o.detail).toMatch(/usage error/i);
+  });
+
+  it("keeps the meaningful codes off typer's reserved 2", () => {
+    expect(REPAIR_COVERAGE_MISSING_EXIT).not.toBe(2);
+    expect(REPAIR_UNVERIFIED_EXIT).not.toBe(2);
+    expect(new Set([0, REPAIR_FAILED_EXIT, REPAIR_COVERAGE_MISSING_EXIT, REPAIR_UNVERIFIED_EXIT]).size)
+      .toBe(4);
+  });
+
+  it("translates a spawn failure (127) into the failure code, not a coverage verdict", () => {
+    const o = classifyRepairOutcome({ childExit: 127, summary: null, dryRun: false });
+    expect(o.exit).toBe(REPAIR_FAILED_EXIT);
   });
 });

--- a/src/memory/hindsight-repair.test.ts
+++ b/src/memory/hindsight-repair.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildRepairBankArgv,
+  parseRepairSummary,
+  compareApiVersion,
+  classifyRepairPreflight,
+  fetchHindsightApiVersion,
+  HINDSIGHT_ADMIN_BIN,
+  HINDSIGHT_CONTAINER_NAME,
+  REPAIR_COVERAGE_MISSING_EXIT,
+} from "./hindsight-repair.js";
+import { HINDSIGHT_MIN_API_VERSION } from "./hindsight-tools.js";
+
+describe("buildRepairBankArgv", () => {
+  it("targets the named container and the admin CLI's real in-image path", () => {
+    const argv = buildRepairBankArgv({ bank: "agent_overlord" });
+    expect(argv[0]).toBe("exec");
+    expect(argv[1]).toBe(HINDSIGHT_CONTAINER_NAME);
+    // The binary is NOT on the container PATH, so the absolute path must be
+    // in the command or the verb is a no-op that reads like a missing tool.
+    expect(argv.join(" ")).toContain(HINDSIGHT_ADMIN_BIN);
+  });
+
+  it("passes the bank id as a positional arg, never interpolated into the shell string", () => {
+    const hostile = "bank'; rm -rf /; echo '";
+    const argv = buildRepairBankArgv({ bank: hostile });
+    const script = argv[argv.indexOf("-c") + 1];
+    // The value appears only after the `--` separator (i.e. as "$@"), so the
+    // shell never parses it as syntax.
+    expect(script).not.toContain("rm -rf");
+    expect(argv.slice(argv.indexOf("--") + 1)).toContain(hostile);
+  });
+
+  it("forwards --all, --schema and --dry-run to repair-bank", () => {
+    const argv = buildRepairBankArgv({ all: true, schema: "tenant_x", dryRun: true });
+    const cmd = argv.slice(argv.indexOf("--") + 1);
+    expect(cmd).toEqual(["repair-bank", "--all", "--schema", "tenant_x", "--dry-run"]);
+  });
+
+  it("omits --dry-run and --schema when not requested (no accidental no-op run)", () => {
+    const cmd = buildRepairBankArgv({ bank: "b1" }).slice(
+      buildRepairBankArgv({ bank: "b1" }).indexOf("--") + 1,
+    );
+    expect(cmd).toEqual(["repair-bank", "--bank", "b1"]);
+  });
+
+  it("honours an overridden container name", () => {
+    expect(buildRepairBankArgv({ all: true, container: "hs-staging" })[1]).toBe("hs-staging");
+  });
+
+  it("rejects neither --bank nor --all (upstream exit 2, caught before we spawn)", () => {
+    expect(() => buildRepairBankArgv({})).toThrow(/exactly one of/);
+  });
+
+  it("rejects both --bank and --all", () => {
+    expect(() => buildRepairBankArgv({ bank: "b1", all: true })).toThrow(/exactly one of/);
+  });
+
+  it("treats an empty --bank as absent rather than shipping `--bank ''`", () => {
+    expect(() => buildRepairBankArgv({ bank: "" })).toThrow(/exactly one of/);
+    expect(buildRepairBankArgv({ bank: "", all: true })[1]).toBe(HINDSIGHT_CONTAINER_NAME);
+  });
+});
+
+describe("parseRepairSummary", () => {
+  it("extracts the totals from repair-bank's Done line", () => {
+    const out = [
+      "Repairing per-bank vector indexes for all banks across base schema and all discovered tenant schemas...",
+      "  schema 'public': 7 bank(s) scanned, 12 present, 9 created, 0 to-create (dry-run), 0 failed",
+      "Done: 1 schema(s), 7 bank(s) scanned, 12 already present, 9 created, 0 to-create (dry-run), 0 failed",
+    ].join("\n");
+    expect(parseRepairSummary(out)).toEqual({
+      schemas: 1,
+      banksScanned: 7,
+      alreadyPresent: 12,
+      created: 9,
+      toCreate: 0,
+      failed: 0,
+    });
+  });
+
+  it("reports a dry run's pending work in toCreate, with created at zero", () => {
+    const s = parseRepairSummary(
+      "Dry run: no indexes will be created or dropped.\n" +
+        "Done: 2 schema(s), 14 bank(s) scanned, 40 already present, 0 created, 6 to-create (dry-run), 0 failed",
+    );
+    expect(s?.toCreate).toBe(6);
+    expect(s?.created).toBe(0);
+  });
+
+  it("surfaces a non-zero failure count rather than reading as success", () => {
+    const s = parseRepairSummary(
+      "Done: 1 schema(s), 3 bank(s) scanned, 0 already present, 2 created, 0 to-create (dry-run), 1 failed",
+    );
+    expect(s?.failed).toBe(1);
+  });
+
+  it("returns null when the run ended before the summary (unsupported backend / bad db url)", () => {
+    expect(
+      parseRepairSummary(
+        "Configured vector backend does not use per-bank vector indexes — nothing to repair.",
+      ),
+    ).toBeNull();
+    expect(parseRepairSummary("")).toBeNull();
+  });
+});
+
+describe("dry-run coverage exit code", () => {
+  it("is distinct from the generic failure code, so a script can tell them apart", () => {
+    expect(REPAIR_COVERAGE_MISSING_EXIT).not.toBe(0);
+    expect(REPAIR_COVERAGE_MISSING_EXIT).not.toBe(1);
+  });
+
+  it("a dry-run summary with pending work is detectable without reading prose", () => {
+    // The whole point: `toCreate > 0` is the machine-readable signal the CLI
+    // turns into a non-zero exit. Prose being the only signal is how three
+    // months of degraded recall went unnoticed.
+    const s = parseRepairSummary(
+      "Done: 1 schema(s), 7 bank(s) scanned, 3 already present, 0 created, 11 to-create (dry-run), 0 failed",
+    );
+    expect(s!.toCreate > 0).toBe(true);
+  });
+
+  it("a clean dry run reports no pending work", () => {
+    const s = parseRepairSummary(
+      "Done: 1 schema(s), 7 bank(s) scanned, 21 already present, 0 created, 0 to-create (dry-run), 0 failed",
+    );
+    expect(s!.toCreate).toBe(0);
+    expect(s!.alreadyPresent).toBe(21);
+  });
+});
+
+describe("compareApiVersion", () => {
+  it("orders by numeric component, not lexically (0.8.10 > 0.8.9)", () => {
+    expect(compareApiVersion("0.8.10", "0.8.9")).toBeGreaterThan(0);
+  });
+
+  it("treats a missing trailing component as zero", () => {
+    expect(compareApiVersion("0.9", "0.9.0")).toBe(0);
+  });
+
+  it("compares equal versions as equal and is antisymmetric", () => {
+    expect(compareApiVersion("0.8.5", "0.8.5")).toBe(0);
+    expect(compareApiVersion("0.8.4", "0.8.5")).toBeLessThan(0);
+    expect(compareApiVersion("0.8.5", "0.8.4")).toBeGreaterThan(0);
+  });
+
+  it("does not sort a pre-release below its release (deliberately lenient)", () => {
+    expect(compareApiVersion("0.8.5rc1", "0.8.5")).toBe(0);
+    expect(compareApiVersion("0.8.5-dev", "0.8.5")).toBe(0);
+  });
+});
+
+describe("classifyRepairPreflight", () => {
+  it("blocks a confirmed pre-0.8.5 server and names the real cause, not a typo", () => {
+    const r = classifyRepairPreflight("0.8.4");
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain("0.8.4");
+    expect(r.reason).toContain(HINDSIGHT_MIN_API_VERSION);
+    expect(r.reason).toMatch(/repair-bank/);
+  });
+
+  it("allows the floor version and anything newer", () => {
+    expect(classifyRepairPreflight("0.8.5").ok).toBe(true);
+    expect(classifyRepairPreflight("0.9.0").ok).toBe(true);
+  });
+
+  it("allows an unknown version — the escape hatch must work in the degraded state it exists for", () => {
+    expect(classifyRepairPreflight(null).ok).toBe(true);
+  });
+});
+
+describe("fetchHindsightApiVersion", () => {
+  const ok = (body: unknown) =>
+    (async () =>
+      ({ ok: true, status: 200, json: async () => body }) as unknown as Response) as unknown as typeof fetch;
+
+  it("reads api_version from <origin>/version, deriving the origin from the MCP url", async () => {
+    let seen = "";
+    const impl = (async (u: string) => {
+      seen = u;
+      return { ok: true, status: 200, json: async () => ({ api_version: "0.8.5" }) } as unknown as Response;
+    }) as unknown as typeof fetch;
+    expect(await fetchHindsightApiVersion("http://127.0.0.1:18888/mcp/", { fetchImpl: impl })).toBe("0.8.5");
+    expect(seen).toBe("http://127.0.0.1:18888/version");
+  });
+
+  it("returns null on a non-200, an unparseable body, or a missing field", async () => {
+    const bad = (async () => ({ ok: false, status: 500, json: async () => ({}) }) as unknown as Response) as unknown as typeof fetch;
+    expect(await fetchHindsightApiVersion("http://h/mcp/", { fetchImpl: bad })).toBeNull();
+    expect(await fetchHindsightApiVersion("http://h/mcp/", { fetchImpl: ok({}) })).toBeNull();
+    expect(await fetchHindsightApiVersion("http://h/mcp/", { fetchImpl: ok({ api_version: 5 }) })).toBeNull();
+  });
+
+  it("returns null instead of throwing when the request fails", async () => {
+    const boom = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    expect(await fetchHindsightApiVersion("http://h/mcp/", { fetchImpl: boom })).toBeNull();
+  });
+});

--- a/src/memory/hindsight-repair.test.ts
+++ b/src/memory/hindsight-repair.test.ts
@@ -17,6 +17,22 @@ import {
   HINDSIGHT_REPAIR_MIN_API_VERSION,
 } from "./hindsight-tools.js";
 
+/**
+ * The largest version strictly below `v`, so a floor test follows the constant
+ * instead of hard-coding the version that happens to be the floor today.
+ */
+function justBelow(v: string): string {
+  const parts = v.split(".").map((p) => Number(p));
+  for (let i = parts.length - 1; i >= 0; i--) {
+    if (parts[i] > 0) {
+      parts[i] -= 1;
+      for (let j = i + 1; j < parts.length; j++) parts[j] = 99;
+      return parts.join(".");
+    }
+  }
+  throw new Error(`no version below ${v}`);
+}
+
 describe("buildRepairBankArgv", () => {
   it("targets the named container and the admin CLI's real in-image path", () => {
     const argv = buildRepairBankArgv({ bank: "agent_overlord" });
@@ -159,16 +175,25 @@ describe("compareApiVersion", () => {
 
 describe("classifyRepairPreflight", () => {
   /**
-   * The feature floor must NOT be the MCP-contract floor. Fusing them is what
-   * made `switchroom doctor` red-by-construction on the running fleet: the
-   * contract was captured from 0.8.4 but the constant claimed 0.8.5 because
-   * repair-bank needs it. If someone re-fuses them, this reds.
+   * The feature floor and the MCP-contract floor are separate constants with
+   * separate sources of truth: `HINDSIGHT_MIN_API_VERSION` tracks the committed
+   * tools/list snapshot (chained to `docker/Dockerfile.hindsight` in
+   * tests/memory.hindsight-contract.fixture.test.ts), while
+   * `HINDSIGHT_REPAIR_MIN_API_VERSION` tracks upstream #2645. Fusing them is
+   * what made `switchroom doctor` red-by-construction while the fleet still ran
+   * 0.8.4. They happen to be EQUAL since #3768 pinned the 0.8.5 image, so the
+   * old `REPAIR > MIN` assertion no longer holds and would have been a false
+   * guard; the invariant that survives is directional (the feature floor is
+   * never BELOW the contract floor) plus the preflight being driven by the
+   * feature constant rather than a literal.
    */
-  it("uses the repair FEATURE floor, which is above the MCP contract floor", () => {
+  it("enforces the repair FEATURE floor at the preflight, whatever the contract floor is", () => {
     expect(compareApiVersion(HINDSIGHT_REPAIR_MIN_API_VERSION, HINDSIGHT_MIN_API_VERSION))
-      .toBeGreaterThan(0);
-    // The contract floor alone must not admit a server that lacks repair-bank.
-    expect(classifyRepairPreflight(HINDSIGHT_MIN_API_VERSION).ok).toBe(false);
+      .toBeGreaterThanOrEqual(0);
+    // Driven by the constant, not a hard-coded 0.8.5: raising the feature floor
+    // must keep the preflight refusing everything below the new value.
+    expect(classifyRepairPreflight(justBelow(HINDSIGHT_REPAIR_MIN_API_VERSION)).ok).toBe(false);
+    expect(classifyRepairPreflight(HINDSIGHT_REPAIR_MIN_API_VERSION).ok).toBe(true);
   });
 
   it("blocks a confirmed pre-0.8.5 server and names the real cause, not a typo", () => {

--- a/src/memory/hindsight-repair.ts
+++ b/src/memory/hindsight-repair.ts
@@ -1,0 +1,231 @@
+/**
+ * Reachability for hindsight 0.8.5's `hindsight-admin repair-bank`.
+ *
+ * ## The failure this exists for
+ *
+ * Hindsight creates its per-(bank, fact_type) partial vector indexes when a
+ * bank is first created — instant, because the bank is empty. A bank that
+ * arrives ALREADY POPULATED never takes that path: logical restore, a
+ * cross-version upgrade, a vector-extension switch. Recall on such a bank does
+ * not fail. It falls back to a global index plus a post-filter and quietly
+ * under-returns.
+ *
+ * The fleet ran that way. Seven banks returned 0–4 semantic candidates out of
+ * 100 for roughly three months and nothing in switchroom noticed, because
+ * every surface that could have noticed was checking liveness, not coverage.
+ * Upstream closed the detection/repair half in 0.8.5
+ * (vectorize-io/hindsight#2645) with `repair-bank`, which rebuilds missing OR
+ * invalid coverage using `CREATE INDEX CONCURRENTLY`.
+ *
+ * A backend capability nobody can reach is the same as not having it. The
+ * command lives inside the container's venv at a path no operator would guess,
+ * so this module is the reachable surface: `switchroom memory repair`.
+ *
+ * ## Why a first-class verb and not a passthrough or a doctor auto-fix
+ *
+ * - **Not a raw passthrough** (`switchroom memory admin -- …`). A passthrough
+ *   is undiscoverable — you have to already know `repair-bank` exists to type
+ *   it, which is the exact condition that let the outage run for three months.
+ *   It also cannot preflight: against a pre-0.8.5 server a passthrough yields
+ *   typer's `No such command 'repair-bank'`, which reads like a typo rather
+ *   than "your image is too old". {@link classifyRepairPreflight} turns that
+ *   into the real sentence.
+ * - **Not a doctor auto-fix.** `doctor` is a read-only diagnostic and must stay
+ *   that way; `CREATE INDEX CONCURRENTLY` across every bank is a mutation on a
+ *   live database and deserves explicit operator intent. Doctor's job is to say
+ *   "coverage is missing, run `switchroom memory repair --all`" — the split
+ *   between detection and repair, not the merger of them.
+ *
+ * The argv builder and the output parser are pure so they can be tested
+ * without a container.
+ */
+import { HINDSIGHT_MIN_API_VERSION } from "./hindsight-tools.js";
+
+/** Default name of the local hindsight container. */
+export const HINDSIGHT_CONTAINER_NAME = "switchroom-hindsight";
+
+/**
+ * Absolute path to the admin CLI inside the image. It is installed into the
+ * API's venv and is NOT on the container's default PATH (verified 2026-07-27:
+ * `command -v hindsight-admin` is empty in a running `switchroom-hindsight`),
+ * so the absolute path is the reliable form. We still prefer PATH when it
+ * resolves, in case a future image puts it there.
+ */
+export const HINDSIGHT_ADMIN_BIN = "/app/api/.venv/bin/hindsight-admin";
+
+export interface RepairBankOptions {
+  /** Repair a single bank by id. Mutually exclusive with `all`. */
+  bank?: string;
+  /** Repair every bank in the base schema plus discovered tenant schemas. */
+  all?: boolean;
+  /** Limit to a single schema (defaults to base + discovered tenant schemas). */
+  schema?: string;
+  /** Report what would change without creating or dropping any index. */
+  dryRun?: boolean;
+  /** Override the container name (defaults to `switchroom-hindsight`). */
+  container?: string;
+}
+
+/**
+ * Pure: build the full `docker` argv for a repair-bank run.
+ *
+ * Throws on an option combination upstream would reject with exit 2, so the
+ * error arrives before we spawn anything.
+ *
+ * The `sh -c … --` shape passes user-supplied values as positional args
+ * (`"$@"`), never interpolated into the shell string — a bank id or schema
+ * name containing a quote or `;` cannot become shell syntax.
+ */
+export function buildRepairBankArgv(opts: RepairBankOptions): string[] {
+  const hasBank = typeof opts.bank === "string" && opts.bank.length > 0;
+  if (hasBank === Boolean(opts.all)) {
+    throw new Error("pass exactly one of --bank <id> or --all");
+  }
+
+  const cmdArgs: string[] = ["repair-bank"];
+  if (hasBank) cmdArgs.push("--bank", opts.bank as string);
+  if (opts.all) cmdArgs.push("--all");
+  if (opts.schema) cmdArgs.push("--schema", opts.schema);
+  if (opts.dryRun) cmdArgs.push("--dry-run");
+
+  const script =
+    `if command -v hindsight-admin >/dev/null 2>&1; then exec hindsight-admin "$@"; fi; ` +
+    `exec ${HINDSIGHT_ADMIN_BIN} "$@"`;
+
+  return [
+    "exec",
+    opts.container ?? HINDSIGHT_CONTAINER_NAME,
+    "sh",
+    "-c",
+    script,
+    "--",
+    ...cmdArgs,
+  ];
+}
+
+/**
+ * Exit code for `switchroom memory repair --dry-run` when coverage IS missing.
+ *
+ * Distinct from 1 (the repair itself failed) so a health script can tell
+ * "needs repair" from "repair broke". A dry run that found gaps must not exit
+ * 0: the only other way to know is to read the prose, and prose being the only
+ * signal is how three months of degraded recall went unnoticed.
+ */
+export const REPAIR_COVERAGE_MISSING_EXIT = 2;
+
+/** Totals from repair-bank's final `Done:` line. */
+export interface RepairSummary {
+  schemas: number;
+  banksScanned: number;
+  alreadyPresent: number;
+  created: number;
+  toCreate: number;
+  failed: number;
+}
+
+/**
+ * Pure: parse repair-bank's terminal summary line.
+ *
+ *   `Done: 2 schema(s), 14 bank(s) scanned, 40 already present, 6 created, 0 to-create (dry-run), 0 failed`
+ *
+ * Returns null when the line is absent — which is itself meaningful: the
+ * command exited before reaching it (backend without per-bank indexes, missing
+ * database URL, crash). Callers must not treat a null as success.
+ */
+export function parseRepairSummary(stdout: string): RepairSummary | null {
+  const m = stdout.match(
+    /Done:\s*(\d+)\s+schema\(s\),\s*(\d+)\s+bank\(s\) scanned,\s*(\d+)\s+already present,\s*(\d+)\s+created,\s*(\d+)\s+to-create \(dry-run\),\s*(\d+)\s+failed/,
+  );
+  if (!m) return null;
+  return {
+    schemas: Number(m[1]),
+    banksScanned: Number(m[2]),
+    alreadyPresent: Number(m[3]),
+    created: Number(m[4]),
+    toCreate: Number(m[5]),
+    failed: Number(m[6]),
+  };
+}
+
+/**
+ * Pure: compare two dotted numeric version strings.
+ *
+ * Returns <0 when `a` precedes `b`, 0 when equal, >0 when `a` follows `b`.
+ * Missing components count as 0 (`"0.9"` === `"0.9.0"`). A trailing
+ * non-numeric suffix (`"0.8.5rc1"`, `"0.8.5-dev"`) is ignored on that
+ * component, so a pre-release compares equal to its release rather than
+ * sorting arbitrarily — deliberately lenient, because the consumer is a
+ * warning and a false alarm on an operator's dev build is worse than a miss.
+ */
+export function compareApiVersion(a: string, b: string): number {
+  const part = (v: string, i: number): number => {
+    const raw = v.split(".")[i];
+    if (raw === undefined) return 0;
+    const n = parseInt(raw, 10);
+    return Number.isFinite(n) ? n : 0;
+  };
+  const len = Math.max(a.split(".").length, b.split(".").length);
+  for (let i = 0; i < len; i++) {
+    const d = part(a, i) - part(b, i);
+    if (d !== 0) return d;
+  }
+  return 0;
+}
+
+/**
+ * Best-effort: read the live server's `api_version` from `GET <origin>/version`.
+ *
+ * Derives the origin from the MCP url the same way the /health probe does.
+ * Returns null on any failure (unreachable, non-200, unparseable, no
+ * `api_version` field) — callers decide what an unknown version means, and
+ * every current caller degrades rather than blocking.
+ */
+export async function fetchHindsightApiVersion(
+  mcpUrl: string,
+  opts: { fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+): Promise<string | null> {
+  const doFetch = opts.fetchImpl ?? fetch;
+  const origin = mcpUrl.replace(/\/mcp\/?$/, "").replace(/\/$/, "");
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 4000);
+  try {
+    const res = await doFetch(`${origin}/version`, { signal: controller.signal });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { api_version?: unknown };
+    return typeof body?.api_version === "string" ? body.api_version : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface RepairPreflight {
+  ok: boolean;
+  /** Operator-facing reason when `ok` is false. */
+  reason?: string;
+}
+
+/**
+ * Pure: decide whether `repair-bank` can run against the live server.
+ *
+ * `liveVersion === null` means the version probe failed. We proceed anyway:
+ * refusing on an unknown version would make the escape hatch unavailable in
+ * exactly the degraded state it exists for, and upstream's own arg validation
+ * is the real backstop. Only a *confirmed* older version blocks.
+ */
+export function classifyRepairPreflight(liveVersion: string | null): RepairPreflight {
+  if (liveVersion === null) return { ok: true };
+  if (compareApiVersion(liveVersion, HINDSIGHT_MIN_API_VERSION) < 0) {
+    return {
+      ok: false,
+      reason:
+        `hindsight ${liveVersion} has no \`repair-bank\` command — it lands in ` +
+        `${HINDSIGHT_MIN_API_VERSION} (upstream #2645). Without it there is no ` +
+        `supported way to rebuild a bank's vector-index coverage. Update the ` +
+        `pinned image in docker/Dockerfile.hindsight and recreate the container ` +
+        `with \`switchroom memory --update\`, then re-run this command.`,
+    };
+  }
+  return { ok: true };
+}

--- a/src/memory/hindsight-repair.ts
+++ b/src/memory/hindsight-repair.ts
@@ -39,7 +39,7 @@
  * The argv builder and the output parser are pure so they can be tested
  * without a container.
  */
-import { HINDSIGHT_MIN_API_VERSION } from "./hindsight-tools.js";
+import { HINDSIGHT_REPAIR_MIN_API_VERSION } from "./hindsight-tools.js";
 
 /** Default name of the local hindsight container. */
 export const HINDSIGHT_CONTAINER_NAME = "switchroom-hindsight";
@@ -104,14 +104,51 @@ export function buildRepairBankArgv(opts: RepairBankOptions): string[] {
 }
 
 /**
- * Exit code for `switchroom memory repair --dry-run` when coverage IS missing.
+ * ## Exit codes for `switchroom memory repair`
  *
- * Distinct from 1 (the repair itself failed) so a health script can tell
- * "needs repair" from "repair broke". A dry run that found gaps must not exit
- * 0: the only other way to know is to read the prose, and prose being the only
- * signal is how three months of degraded recall went unnoticed.
+ * These are a contract — `skills/switchroom-health/SKILL.md` branches on them,
+ * and so will any operator cron. Three rules make them trustworthy:
+ *
+ *  1. **They never overlap with the child's.** `repair-bank` is a typer app, so
+ *     it exits 2 on a USAGE error (bad flag, unknown command). An earlier
+ *     revision propagated the child's code verbatim, which meant a typo'd flag
+ *     surfaced as this module's "coverage missing" — a wrong answer, in the
+ *     direction of a false alarm. Every child failure is now translated to
+ *     {@link REPAIR_FAILED_EXIT}, and the codes that carry meaning (3, 4) are
+ *     ones typer does not use.
+ *  2. **Unverified is not success.** "The command exited 0 but I could not
+ *     confirm coverage" gets its own non-zero code
+ *     ({@link REPAIR_UNVERIFIED_EXIT}) rather than falling through to 0. A
+ *     check that cannot fail is not a check, and the failure mode this whole
+ *     feature exists for is precisely a green light over a broken thing.
+ *  3. **Only a confirmed-complete scan of at least one bank exits 0.**
  */
-export const REPAIR_COVERAGE_MISSING_EXIT = 2;
+
+/** The repair (or the attempt to run it) failed. Also the code for a child
+ *  process failure of ANY kind, including typer's usage-error 2. */
+export const REPAIR_FAILED_EXIT = 1;
+
+/**
+ * Coverage IS missing: a `--dry-run` scan completed and found indexes to
+ * create. Distinct from {@link REPAIR_FAILED_EXIT} so a health script can tell
+ * "needs repair" from "repair broke", and distinct from 2 so it can never be
+ * confused with typer's usage error.
+ */
+export const REPAIR_COVERAGE_MISSING_EXIT = 3;
+
+/**
+ * Coverage could NOT be confirmed either way — the run produced no summary
+ * line, or it scanned zero banks (a typo'd `--bank`, a `--schema` that matches
+ * nothing, a backend with a single global index). Nothing is known to be
+ * broken and nothing is known to be fine.
+ *
+ * This exists because both of those cases previously printed reassuring-ish
+ * text and exited **0**, which `skills/switchroom-health/SKILL.md` mapped to
+ * "OK: vector index coverage complete". A scan of zero banks reporting
+ * coverage complete is the same class of false green the feature was written
+ * to eliminate.
+ */
+export const REPAIR_UNVERIFIED_EXIT = 4;
 
 /** Totals from repair-bank's final `Done:` line. */
 export interface RepairSummary {
@@ -216,16 +253,127 @@ export interface RepairPreflight {
  */
 export function classifyRepairPreflight(liveVersion: string | null): RepairPreflight {
   if (liveVersion === null) return { ok: true };
-  if (compareApiVersion(liveVersion, HINDSIGHT_MIN_API_VERSION) < 0) {
+  if (compareApiVersion(liveVersion, HINDSIGHT_REPAIR_MIN_API_VERSION) < 0) {
     return {
       ok: false,
       reason:
         `hindsight ${liveVersion} has no \`repair-bank\` command — it lands in ` +
-        `${HINDSIGHT_MIN_API_VERSION} (upstream #2645). Without it there is no ` +
+        `${HINDSIGHT_REPAIR_MIN_API_VERSION} (upstream #2645). Without it there is no ` +
         `supported way to rebuild a bank's vector-index coverage. Update the ` +
         `pinned image in docker/Dockerfile.hindsight and recreate the container ` +
         `with \`switchroom memory --update\`, then re-run this command.`,
     };
   }
   return { ok: true };
+}
+
+/** What the CLI should print and exit with after a repair-bank run. */
+export interface RepairOutcome {
+  /** Process exit code. See the exit-code contract above. */
+  exit: number;
+  /** Rendering hint: `ok` prints green, `fail` prints red on stderr. */
+  level: "ok" | "fail";
+  /** One-line verdict. */
+  headline: string;
+  /** Follow-up sentence: what it means and what to do. */
+  detail: string;
+}
+
+export interface RepairRunResult {
+  /** Exit code of the `docker exec … repair-bank` child. */
+  childExit: number;
+  /** Parsed summary line, or null when repair-bank never printed one. */
+  summary: RepairSummary | null;
+  /** Whether `--dry-run` was passed. */
+  dryRun: boolean;
+}
+
+/**
+ * Pure: turn a finished repair-bank run into an exit code and honest text.
+ *
+ * Pure and exported so the decision is testable without spawning docker. The
+ * action body that used to hold this logic inline was untestable, and it was
+ * wrong in two places at once — both of them false greens, in the feature whose
+ * entire purpose is to eliminate false greens:
+ *
+ *  - a typo'd `--bank` scanned **zero** banks and printed
+ *    "✓ Coverage complete … across 0 bank(s)", exit 0;
+ *  - a missing summary line printed "coverage was NOT confirmed" and *still*
+ *    exited 0, which the health skill mapped to "OK: coverage complete".
+ *
+ * Both now exit {@link REPAIR_UNVERIFIED_EXIT}. The ordering below is
+ * significant: every "I cannot confirm" case is checked BEFORE the success
+ * path, so adding a field to {@link RepairSummary} can never accidentally
+ * re-open a green path around them.
+ */
+export function classifyRepairOutcome(run: RepairRunResult): RepairOutcome {
+  if (run.childExit !== 0) {
+    return {
+      exit: REPAIR_FAILED_EXIT,
+      level: "fail",
+      headline: `repair-bank exited ${run.childExit}.`,
+      detail:
+        run.childExit === 2
+          ? "Exit 2 from the admin CLI is a usage error — check --bank / --schema spelling. " +
+            "Nothing was repaired and coverage is unknown."
+          : "Failed indexes are dropped, so a re-run is safe and is the documented retry.",
+    };
+  }
+
+  if (run.summary === null) {
+    return {
+      exit: REPAIR_UNVERIFIED_EXIT,
+      level: "fail",
+      headline: "repair-bank exited 0 but printed no summary — coverage was NOT confirmed.",
+      detail:
+        "Read its output above. This is not a pass: a backend with a single global " +
+        "index, an aborted scan, or an output-format change upstream all look like " +
+        "this, and none of them means coverage is complete.",
+    };
+  }
+
+  if (run.summary.banksScanned === 0) {
+    return {
+      exit: REPAIR_UNVERIFIED_EXIT,
+      level: "fail",
+      headline: "repair-bank scanned 0 bank(s) — nothing was checked.",
+      detail:
+        "A scan that examined no bank proves nothing about coverage. Usual cause is a " +
+        "--bank id or --schema name that matches nothing; `switchroom memory banks` " +
+        "lists the real ids.",
+    };
+  }
+
+  if (run.summary.failed > 0) {
+    return {
+      exit: REPAIR_FAILED_EXIT,
+      level: "fail",
+      headline: `${run.summary.failed} index(es) failed to build.`,
+      detail:
+        "Those banks still under-return on recall. Failed indexes are dropped, so " +
+        "re-running is safe and is the documented retry; if it repeats, the hindsight " +
+        "container logs carry the postgres error.",
+    };
+  }
+
+  if (run.dryRun && run.summary.toCreate > 0) {
+    return {
+      exit: REPAIR_COVERAGE_MISSING_EXIT,
+      level: "fail",
+      headline: `${run.summary.toCreate} vector index(es) missing across ${run.summary.banksScanned} bank(s).`,
+      detail:
+        "Recall on those banks silently under-returns. Re-run without --dry-run to fix.",
+    };
+  }
+
+  return {
+    exit: 0,
+    level: "ok",
+    headline: "repair-bank finished.",
+    detail: run.dryRun
+      ? `Coverage complete: ${run.summary.alreadyPresent} index(es) present across ` +
+        `${run.summary.banksScanned} bank(s), nothing to create.`
+      : `${run.summary.created} created, ${run.summary.alreadyPresent} already present ` +
+        `across ${run.summary.banksScanned} bank(s). Re-run \`switchroom doctor\` to confirm.`,
+  };
 }

--- a/src/memory/hindsight-tools.ts
+++ b/src/memory/hindsight-tools.ts
@@ -75,16 +75,22 @@ export interface HindsightToolSpec {
 }
 
 /**
- * The hindsight API version the committed contract was captured from, and the
- * FLOOR switchroom requires.
+ * The hindsight API version the committed MCP contract was captured from, and
+ * the FLOOR switchroom's tool/arg surface requires.
+ *
+ * This tracks `tests/fixtures/hindsight-tools-list.snapshot.json` and NOTHING
+ * ELSE. It is deliberately NOT the floor for any individual backend feature —
+ * see {@link HINDSIGHT_REPAIR_MIN_API_VERSION}. Conflating the two is what made
+ * an earlier revision of this branch ship a doctor row that was guaranteed red
+ * on the running fleet: the snapshot described 0.8.4, the constant claimed
+ * 0.8.5 because `repair-bank` needs 0.8.5, and every `switchroom doctor` run
+ * printed a failure the operator could do nothing about. A flagship check that
+ * is red by construction trains people to ignore it.
  *
  * A floor, not an equality pin, and the distinction is deliberate:
- *  - **Below it** is a hard problem. The snapshot (and therefore
+ *  - **Below it** is a hard problem: the snapshot (and therefore
  *    `EXPECTED_HINDSIGHT_TOOLS`, the shim's fallback manifest, and every arg
- *    the CLI sends) describes a surface the running server may not have, and
- *    `hindsight-admin repair-bank` — the only escape hatch for a bank with
- *    missing per-(bank, fact_type) vector-index coverage — does not exist
- *    before 0.8.5.
+ *    the CLI sends) describes a surface the running server may not have.
  *  - **Above it** is not an error, because upstream's MCP changes have been
  *    additive. It IS a staleness signal: a newer server may advertise tools and
  *    props the snapshot has never heard of, and a capability switchroom cannot
@@ -92,10 +98,26 @@ export interface HindsightToolSpec {
  *    snapshot sat weeks stale while hiding three whole tools.
  *
  * `tests/memory.hindsight-contract.fixture.test.ts` asserts this equals the
- * snapshot's `_meta.hindsight_api_version`, so the two cannot drift apart:
- * bumping one without re-capturing the other reds the suite.
+ * snapshot's `_meta.hindsight_api_version` (which in turn must equal the
+ * api_version `docker/Dockerfile.hindsight` pins), so the three cannot drift
+ * apart: bumping one without re-capturing the others reds the suite.
  */
-export const HINDSIGHT_MIN_API_VERSION = "0.8.5";
+export const HINDSIGHT_MIN_API_VERSION = "0.8.4";
+
+/**
+ * The hindsight version that first ships `hindsight-admin repair-bank`
+ * (vectorize-io/hindsight#2645) — the only supported way to rebuild a bank's
+ * missing per-(bank, fact_type) vector-index coverage.
+ *
+ * A FEATURE floor, separate from {@link HINDSIGHT_MIN_API_VERSION} on purpose.
+ * It gates exactly one thing — `switchroom memory repair`'s preflight, which
+ * turns typer's misleading `No such command 'repair-bank'` into the real
+ * sentence — and it deliberately does NOT gate the MCP contract or produce a
+ * standing doctor row. The image pin catches up in #3768; until then the
+ * operator learns about the gap at the moment they try to use the feature,
+ * which is the only moment the information is actionable.
+ */
+export const HINDSIGHT_REPAIR_MIN_API_VERSION = "0.8.5";
 
 /**
  * The hindsight MCP tools switchroom calls (TS callers, the prompt guidance,

--- a/src/memory/hindsight-tools.ts
+++ b/src/memory/hindsight-tools.ts
@@ -75,6 +75,29 @@ export interface HindsightToolSpec {
 }
 
 /**
+ * The hindsight API version the committed contract was captured from, and the
+ * FLOOR switchroom requires.
+ *
+ * A floor, not an equality pin, and the distinction is deliberate:
+ *  - **Below it** is a hard problem. The snapshot (and therefore
+ *    `EXPECTED_HINDSIGHT_TOOLS`, the shim's fallback manifest, and every arg
+ *    the CLI sends) describes a surface the running server may not have, and
+ *    `hindsight-admin repair-bank` — the only escape hatch for a bank with
+ *    missing per-(bank, fact_type) vector-index coverage — does not exist
+ *    before 0.8.5.
+ *  - **Above it** is not an error, because upstream's MCP changes have been
+ *    additive. It IS a staleness signal: a newer server may advertise tools and
+ *    props the snapshot has never heard of, and a capability switchroom cannot
+ *    see is a capability the fleet does not have. Not hypothetical — the
+ *    snapshot sat weeks stale while hiding three whole tools.
+ *
+ * `tests/memory.hindsight-contract.fixture.test.ts` asserts this equals the
+ * snapshot's `_meta.hindsight_api_version`, so the two cannot drift apart:
+ * bumping one without re-capturing the other reds the suite.
+ */
+export const HINDSIGHT_MIN_API_VERSION = "0.8.5";
+
+/**
  * The hindsight MCP tools switchroom calls (TS callers, the prompt guidance,
  * and the user-profile-refresh hook), with the args the server marks required.
  * `required` is cross-checked against the golden snapshot by the fixture test —

--- a/src/memory/hindsight-tools.ts
+++ b/src/memory/hindsight-tools.ts
@@ -85,7 +85,10 @@ export interface HindsightToolSpec {
  * on the running fleet: the snapshot described 0.8.4, the constant claimed
  * 0.8.5 because `repair-bank` needs 0.8.5, and every `switchroom doctor` run
  * printed a failure the operator could do nothing about. A flagship check that
- * is red by construction trains people to ignore it.
+ * is red by construction trains people to ignore it. The two values COINCIDE
+ * today (#3768 bumped the pinned image to 0.8.5, the version that first ships
+ * `repair-bank`) — that is a coincidence of the moment, not a licence to fuse
+ * them again. This one moves only when the snapshot is re-captured.
  *
  * A floor, not an equality pin, and the distinction is deliberate:
  *  - **Below it** is a hard problem: the snapshot (and therefore
@@ -102,7 +105,7 @@ export interface HindsightToolSpec {
  * api_version `docker/Dockerfile.hindsight` pins), so the three cannot drift
  * apart: bumping one without re-capturing the others reds the suite.
  */
-export const HINDSIGHT_MIN_API_VERSION = "0.8.4";
+export const HINDSIGHT_MIN_API_VERSION = "0.8.5";
 
 /**
  * The hindsight version that first ships `hindsight-admin repair-bank`
@@ -113,9 +116,10 @@ export const HINDSIGHT_MIN_API_VERSION = "0.8.4";
  * It gates exactly one thing — `switchroom memory repair`'s preflight, which
  * turns typer's misleading `No such command 'repair-bank'` into the real
  * sentence — and it deliberately does NOT gate the MCP contract or produce a
- * standing doctor row. The image pin catches up in #3768; until then the
- * operator learns about the gap at the moment they try to use the feature,
- * which is the only moment the information is actionable.
+ * standing doctor row. The image pin caught up in #3768, so on the fleet this
+ * floor is now satisfied; the separation stays because the NEXT feature floor
+ * will not be, and the operator should learn about a gap at the moment they
+ * try to use the feature — the only moment the information is actionable.
  */
 export const HINDSIGHT_REPAIR_MIN_API_VERSION = "0.8.5";
 

--- a/tests/cli.doctor.memory-health.test.ts
+++ b/tests/cli.doctor.memory-health.test.ts
@@ -21,8 +21,13 @@ import {
   CONSOLIDATION_BACKLOG_FAIL,
   type AdvertisedTool,
   MIN_HINDSIGHT_SHM_BYTES,
+  classifyHindsightVersionSkew,
+  checkHindsightVersion,
 } from "../src/cli/doctor-memory.js";
-import { EXPECTED_HINDSIGHT_TOOLS } from "../src/memory/hindsight-tools.js";
+import {
+  EXPECTED_HINDSIGHT_TOOLS,
+  HINDSIGHT_MIN_API_VERSION,
+} from "../src/memory/hindsight-tools.js";
 
 /** The golden snapshot, reshaped into the advertised-tool form the doctor probe
  *  produces — so the unit test exercises the classifier against REAL server
@@ -568,5 +573,57 @@ describe("hindsight dual-writer + LiteLLM silent-outage classifiers (2026-07-19)
     const results = checkHindsightContainerHealth({ exec });
     expect(results.find((r) => r.name === "hindsight network mode")?.status).toBe("fail");
     expect(results.find((r) => r.name === "hindsight LiteLLM reachability")?.status).toBe("fail");
+  });
+});
+
+/**
+ * Version skew. `classifyToolContract` is one-directional — it only notices
+ * tools switchroom expects and the server lacks — so a server that grew
+ * capabilities stays green forever. That one-way blindness is how a
+ * three-month recall outage and an unreachable `repair-bank` went unnoticed.
+ */
+describe("hindsight version skew", () => {
+  it("is ok when the live version matches the captured contract", () => {
+    const r = classifyHindsightVersionSkew(HINDSIGHT_MIN_API_VERSION);
+    expect(r?.status).toBe("ok");
+  });
+
+  it("FAILS on a server older than the contract, and says repair is unavailable", () => {
+    const r = classifyHindsightVersionSkew("0.8.4");
+    expect(r?.status).toBe("fail");
+    expect(r?.detail).toContain("0.8.4");
+    expect(r?.detail).toMatch(/repair/i);
+    expect(r?.fix).toBeTruthy();
+  });
+
+  it("WARNS on a server newer than the contract — a capability nobody can see", () => {
+    const r = classifyHindsightVersionSkew("0.9.0");
+    expect(r?.status).toBe("warn");
+    expect(r?.detail).toContain("0.9.0");
+    // The fix must name what to re-capture, not just complain.
+    expect(r?.fix).toContain("hindsight-tools-list.snapshot.json");
+  });
+
+  it("orders numerically, so 0.8.10 is NEWER than a 0.8.9 contract (not older)", () => {
+    // Guards the lexical-compare bug: "0.8.10" < "0.8.9" as strings.
+    expect(classifyHindsightVersionSkew("0.8.10")?.status).not.toBe("fail");
+  });
+
+  it("emits NO row when the version probe fails — /health already owns the outage", () => {
+    expect(classifyHindsightVersionSkew(null)).toBeNull();
+  });
+
+  it("checkHindsightVersion probes /version and classifies it end to end", async () => {
+    const impl = (async () =>
+      ({ ok: true, status: 200, json: async () => ({ api_version: "0.8.4" }) }) as unknown as Response) as unknown as typeof fetch;
+    const r = await checkHindsightVersion("http://127.0.0.1:18888/mcp/", { fetchImpl: impl });
+    expect(r?.status).toBe("fail");
+  });
+
+  it("checkHindsightVersion returns null (not a throw) when hindsight is unreachable", async () => {
+    const boom = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    expect(await checkHindsightVersion("http://127.0.0.1:18888/mcp/", { fetchImpl: boom })).toBeNull();
   });
 });

--- a/tests/cli.doctor.memory-health.test.ts
+++ b/tests/cli.doctor.memory-health.test.ts
@@ -597,11 +597,14 @@ describe("hindsight version skew", () => {
 
   /**
    * Mutation-guard for the "guaranteed-red flagship check" bug: an earlier
-   * revision set the contract floor to 0.8.5 because `repair-bank` needs
-   * 0.8.5, while the snapshot and docker/Dockerfile.hindsight were both 0.8.4 —
-   * so every `switchroom doctor` run on the actual fleet printed a red row the
-   * operator could not act on. The floor tracks the SNAPSHOT; feature floors
-   * are enforced where the feature is used.
+   * revision of this branch set the contract floor to 0.8.5 because
+   * `repair-bank` needs 0.8.5, while the snapshot and
+   * docker/Dockerfile.hindsight were both still 0.8.4 — so every `switchroom
+   * doctor` run on the actual fleet printed a red row the operator could not
+   * act on. The floor tracks the SNAPSHOT; feature floors are enforced where
+   * the feature is used. The marker is read from the Dockerfile rather than
+   * written down here, so this keeps guarding after the next image bump (it
+   * already survived #3768's 0.8.4 → 0.8.5 roll).
    */
   it("does not fail on the api_version the shipped image pins", () => {
     const dockerfile = readFileSync(

--- a/tests/cli.doctor.memory-health.test.ts
+++ b/tests/cli.doctor.memory-health.test.ts
@@ -588,12 +588,33 @@ describe("hindsight version skew", () => {
     expect(r?.status).toBe("ok");
   });
 
-  it("FAILS on a server older than the contract, and says repair is unavailable", () => {
-    const r = classifyHindsightVersionSkew("0.8.4");
+  it("FAILS on a server older than the captured contract", () => {
+    const r = classifyHindsightVersionSkew("0.7.0");
     expect(r?.status).toBe("fail");
-    expect(r?.detail).toContain("0.8.4");
-    expect(r?.detail).toMatch(/repair/i);
+    expect(r?.detail).toContain("0.7.0");
     expect(r?.fix).toBeTruthy();
+  });
+
+  /**
+   * Mutation-guard for the "guaranteed-red flagship check" bug: an earlier
+   * revision set the contract floor to 0.8.5 because `repair-bank` needs
+   * 0.8.5, while the snapshot and docker/Dockerfile.hindsight were both 0.8.4 —
+   * so every `switchroom doctor` run on the actual fleet printed a red row the
+   * operator could not act on. The floor tracks the SNAPSHOT; feature floors
+   * are enforced where the feature is used.
+   */
+  it("does not fail on the api_version the shipped image pins", () => {
+    const dockerfile = readFileSync(
+      resolve(__dirname, "..", "docker", "Dockerfile.hindsight"),
+      "utf-8",
+    );
+    const marker = dockerfile.match(/^#\s*switchroom:hindsight-api-version=(\S+)\s*$/m);
+    expect(marker, "docker/Dockerfile.hindsight must carry the api-version marker").toBeTruthy();
+    const shipped = marker![1].trim();
+    expect(
+      classifyHindsightVersionSkew(shipped)?.status,
+      `doctor must not be red against the image this repo ships (${shipped})`,
+    ).toBe("ok");
   });
 
   it("WARNS on a server newer than the contract — a capability nobody can see", () => {
@@ -615,9 +636,10 @@ describe("hindsight version skew", () => {
 
   it("checkHindsightVersion probes /version and classifies it end to end", async () => {
     const impl = (async () =>
-      ({ ok: true, status: 200, json: async () => ({ api_version: "0.8.4" }) }) as unknown as Response) as unknown as typeof fetch;
+      ({ ok: true, status: 200, json: async () => ({ api_version: "0.7.0" }) }) as unknown as Response) as unknown as typeof fetch;
     const r = await checkHindsightVersion("http://127.0.0.1:18888/mcp/", { fetchImpl: impl });
     expect(r?.status).toBe("fail");
+    expect(r?.detail).toContain("0.7.0");
   });
 
   it("checkHindsightVersion returns null (not a throw) when hindsight is unreachable", async () => {

--- a/tests/memory.hindsight-contract.fixture.test.ts
+++ b/tests/memory.hindsight-contract.fixture.test.ts
@@ -25,6 +25,7 @@ import {
   HINDSIGHT_TS_CALLSITES,
   HINDSIGHT_PROMPT_TOOLS,
   HINDSIGHT_HOOK_TOOLS,
+  HINDSIGHT_MIN_API_VERSION,
 } from "../src/memory/hindsight-tools.js";
 import { FALLBACK_TOOL_TABLE } from "../src/cli/hindsight-mcp-shim.js";
 
@@ -126,6 +127,19 @@ describe("hindsight contract — golden snapshot integrity", () => {
             "cold-boot manifest promise a filter the server silently ignores",
       ).toBe(shouldHaveTagProps);
     }
+  });
+
+  it("HINDSIGHT_MIN_API_VERSION names the version this snapshot was captured from", () => {
+    // The doctor version-skew check compares the LIVE server against this
+    // constant. If the constant and the snapshot drift apart, doctor reports
+    // "contract matches" while the contract it is defending was captured from
+    // a different server — the check silently stops being a check. Chained to
+    // the assertion above, this transitively pins the floor to the image
+    // docker/Dockerfile.hindsight actually ships.
+    expect(
+      snapshot._meta?.hindsight_api_version,
+      "re-capturing the snapshot must bump HINDSIGHT_MIN_API_VERSION (and vice versa)",
+    ).toBe(HINDSIGHT_MIN_API_VERSION);
   });
 
   it("EXPECTED_HINDSIGHT_TOOLS agrees with the captured server truth (required-args, no const/snapshot drift)", () => {


### PR DESCRIPTION
## Summary

Hindsight creates a bank's per-`(bank, fact_type)` partial vector indexes at bank *creation* — instant, because the bank is empty. A bank that arrives **already populated** (logical restore, cross-version upgrade, vector-extension switch) never takes that path. Recall does not fail; it falls back to a global index plus a post-filter and quietly **under-returns**. This fleet ran that way for ~3 months. Upstream shipped `hindsight-admin repair-bank` in 0.8.5 (vectorize-io/hindsight#2645), inside a venv at a path no operator would guess. This PR makes it reachable as `switchroom memory repair`, and teaches `switchroom doctor` to notice version skew at all.

> **Reworked after review (DO-NOT-MERGE).** Two blockers plus an exit-code collision and a guaranteed-red doctor row. Base **retargeted to `main`** — see Blocker 2.

## What the rework changed

### Blocker 1 — two false greens, in the feature written to eliminate false greens

- A mistyped `--bank` made `repair-bank` scan **zero** banks and print `✓ Coverage complete … across 0 bank(s)`, **exit 0** — which `skills/switchroom-health/SKILL.md` reported as `OK: vector index coverage complete`.
- A missing summary line printed "coverage was NOT confirmed" and then **returned without a non-zero exit**, so the honest prose was invisible to every machine consumer, and the health skill again read it as OK.

Both now exit **4 (unverified)**. The whole verdict moved out of the untestable action body into a pure `classifyRepairOutcome(...)` in `src/memory/hindsight-repair.ts`, ordered so that every "I cannot confirm" case is checked **before** the success path — adding a field to `RepairSummary` cannot accidentally re-open a green path around them. A `failed > 0` summary is also caught even when the child exits 0.

### Blocker 2 — no CI ran at all

Confirmed: every workflow is `on: pull_request: branches: [main]` (`.github/workflows/ci-lint.yml:16-17`, `ci-tests-core.yml:33-34`, …), and this PR targeted the stack branch, so **not one check had ever fired**. Base is now `main`. Until #3762 merges, this PR's diff therefore also contains #3762's commit; the merge order is unchanged — **#3762 first, then this**.

### Exit-code collision with typer

`repair-bank` is a typer app: exit **2** is a *usage* error. The action did `process.exit(code)` with the child's code verbatim, so a mistyped flag surfaced as this command's "coverage missing" signal — a wrong answer, in the false-alarm direction.

| Exit | Meaning |
|---|---|
| `0` | Coverage **confirmed** complete (≥1 bank scanned, nothing outstanding) |
| `1` | The check/repair itself failed — **including any child failure**, typer's `2` among them |
| `3` | Indexes are **missing** (dry run found gaps) |
| `4` | Coverage **could not be confirmed** (no summary line, or 0 banks scanned) |

The child's code is never re-emitted. `skills/switchroom-health/SKILL.md` and `docs/operators/hindsight-memory.md` updated to match.

### The guaranteed-red doctor row

`HINDSIGHT_MIN_API_VERSION` was `0.8.5` because `repair-bank` needs 0.8.5 — while the committed snapshot and `docker/Dockerfile.hindsight` both said 0.8.4. `classifyHindsightVersionSkew` would therefore have printed a **red `hindsight version` row on every `switchroom doctor` run on the actual fleet**, for a capability the operator was not trying to use. A flagship check that is red by construction trains people to skip doctor.

The two floors are now un-fused:

- **`HINDSIGHT_MIN_API_VERSION = "0.8.4"`** — tracks the committed tools/list snapshot and nothing else. On #3762's rework the snapshot is a verbatim 0.8.4 capture chained to the Dockerfile's api-version marker, so `constant → snapshot → image` cannot drift.
- **`HINDSIGHT_REPAIR_MIN_API_VERSION = "0.8.5"`** — a *feature* floor, enforced only in the repair preflight, at the moment an operator tries to use `repair-bank` and the information is actionable. #3768's image bump retires it naturally.

`MIN_API_VERSION` is unchanged in spirit otherwise: the merge order cures the rest, and the stack is not split.

## Tests assert outcomes, and were mutation-checked

- `banksScanned === 0` guard → `if (false)`, and `summary === null` → exit 0: **exactly those 2 tests red**.
- Re-fusing the floors (`HINDSIGHT_MIN_API_VERSION` back to `0.8.5`): **3 tests red** — the repair preflight, the fixture snapshot chain, and a new doctor test asserting doctor is **not** red against the api_version the shipped image pins.

`npm run lint` clean (tsc + 16 guard scripts); scoped vitest green (148 tests across `hindsight-repair`, `cli.doctor.memory-health`, `memory.hindsight-contract.fixture`), plus `tests/cli.memory*`.
