### PR TITLE
feat(compose): make the per-agent /tmp tmpfs declarative, default 2g

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,44 @@ Two durable halves, because enumerating today's gaps does not stop the ninth:
   through the managed resolvers. Hard-pinning a new tuning knob now fails the
   suite and has to justify itself.
 
+### An agent's `/tmp` is now declarative, and the fleet default is 2 GiB
+
+Every agent container runs a read-only root filesystem, so the RAM-backed
+`/tmp` is the only scratch space it and its sub-agents get. Its size was
+hard-coded at `1g` in `src/agents/compose.ts` — one `lines.push()` with no
+config path to it at all. The only way to change it was to hand-edit the
+generated compose file, which the next `switchroom apply` overwrites. That is
+imperative state pretending to be config, and the same shape as #3732/#3745:
+a value that is a property of a deployment, shipped with no declarative
+channel.
+
+The measurement that forced it: the root-tier `overlord` container, fanning
+out concurrent sub-agents, sat at **90% of its 1.0 GiB `/tmp`** — 917M used,
+~150M free — and 785M of that was sub-agent working state, mostly repo clones
+plus `bunx` toolchain caches for vitest and typescript. Several workers each
+cloning a repo and installing a toolchain exhaust 1 GiB routinely, and the
+failure mode is bad: clones and installs die with a bare ENOSPC far from the
+cause, mid-task, with no signal that a *mount* is the constraint.
+
+So `resources.tmp_size` joins `memory`, `memory_reservation`, `pids_limit` and
+`cpus` in the existing `resources` block, through the same defaults → profile
+→ per-agent per-field cascade, validated at config-load with the same Docker
+size-string format as `memory` (`4g`, `512m`) rather than failing later at
+`docker compose up`. It is declared in **both** schema mirrors — the
+`profileFields` copy and the `AgentSchema` copy — because that zod object
+strips unknown keys, and a knob present in only one of them parses green and
+does nothing (#3773).
+
+**This changes behaviour on the next `switchroom apply`: an agent with no
+override goes from 1 GiB to 2 GiB.** That is safe as a default because a tmpfs
+is a ceiling, not a reservation — it consumes host RAM only for the pages
+actually written, so an idle agent's footprint is identical and the raise
+costs nothing until something uses it. Those pages are charged against the
+container's `mem_limit` cgroup, so an agent that raises `tmp_size` *and*
+intends to fill it should raise `resources.memory` alongside. Agents pick the
+new size up when their container is recreated; a running container keeps the
+mount it booted with.
+
 ## v0.19.24 — `:latest` follows the release, hindsight sizes its LLM calls to the real context window, and a self-echoed reply stops duplicating
 
 ### The per-scope observation cap is an overridable managed key

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ Each field type has specific merge behavior when values exist at multiple layers
 |---|---|---|
 | **Union** | `tools.allow`, `tools.deny`, `skills` | Combine across layers, dedup |
 | **Per-key merge** | `mcp_servers`, `bundled_skills`, `env`, `subagents` | Agent wins on key conflict |
-| **Per-field merge** | `soul`, `memory`, `session`, `channels` | Agent wins per sub-field |
+| **Per-field merge** | `soul`, `memory`, `session`, `channels`, `resources`, `experimental` | Agent wins per sub-field |
 | **Per-event concat** | `hooks` | Defaults first, then agent |
 | **Concatenate** | `schedule`, `system_prompt_append`, `claude_md_raw`, `cli_args` | Defaults prepended/joined |
 | **Override** | `model`, `extends`, `dangerous_mode`, all other scalars | Agent wins entirely |
@@ -72,6 +72,11 @@ Each field type has specific merge behavior when values exist at multiple layers
 | `channels.telegram.voice_out.speed` | override | Kokoro playback speed, clamped 0.5–2.0. Default 1.1. Ignored by the OpenAI engine. |
 | `channels.telegram.voice_out.max_chars` | override | Per-voice-note chunk size for the OpenAI engine (chars). Default 600; clamped to the engine cap (1200). A longer reply is spoken across sequential notes, never truncated. The kokoro sidecar owns length and ignores this. |
 | `channels.telegram.voice_out.api_key` | override | OpenAI TTS key as a `vault:<key>` reference (only used when `engine='openai'`; default `vault:openai/api-key`). Resolved through the vault broker at use-time. |
+| `resources.memory` | per-field | Hard memory cap (Docker `mem_limit` → cgroup `memory.max`). Docker size string (`6g`, `1.5g`, `512m`). Unset at every layer → the per-profile default in `src/agents/compose.ts` (klanker 8g, coding 4g, conversational/default 3g, lightweight 1g). |
+| `resources.memory_reservation` | per-field | Soft memory floor (Docker `mem_reservation` → cgroup `memory.low`). Protects this much from reclaim under host-wide pressure. Must be ≤ `memory`. |
+| `resources.pids_limit` | per-field | Max processes in the cgroup (`pids.max`). Idle agent ≈ 30 PIDs; `npm test`-style workloads spike past 200. |
+| `resources.cpus` | per-field | CPU quota (Docker `cpus`), fractional OK. Unset at every layer → per-profile default (klanker/coding 2.0, default 1.0, lightweight 0.5). |
+| `resources.tmp_size` | per-field | Size of the container's RAM-backed `/tmp` (`tmpfs: - /tmp:size=<this>,mode=1777`). Docker size string (`4g`, `512m`). **Default `2g`.** The container root FS is read-only, so `/tmp` is the *only* scratch space the agent and its sub-agents get — repo clones, `bunx`/`npx`/`pip` toolchain caches. Raise it for agents that fan out several sub-agents at once (the earlier hard-coded 1g was measured 90% full on a busy root-tier agent, 785M of it concurrent sub-agent clones and caches). A tmpfs is a ceiling, not a reservation: it consumes host RAM only for pages actually written, so raising it costs nothing until used — but those pages count against `resources.memory`, so raise both together. Takes effect when the container is recreated (`switchroom apply`), not on a running one. |
 | `settings_raw` | deep merge | Escape hatch: raw settings.json overrides |
 | `claude_md_raw` | concatenate | Escape hatch: append to CLAUDE.md on scaffold |
 | `cli_args` | concatenate | Escape hatch: extra `exec claude` flags |

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -106,7 +106,32 @@ export interface ResourceDefaults {
   memReservation?: string;
   /** Optional — when set, emitted as `pids_limit` (cgroup pids.max). */
   pidsLimit?: number;
+  /**
+   * Size of the container's RAM-backed `/tmp`, emitted as
+   * `tmpfs: - /tmp:size=<this>,mode=1777`. Always resolved (falls back to
+   * `DEFAULT_TMP_SIZE`) by `resolveResourceDefaults`.
+   */
+  tmpSize: string;
 }
+
+/**
+ * Fleet-wide default size of the per-agent `/tmp` tmpfs — what every agent
+ * gets without a `resources.tmp_size` override at any cascade layer.
+ *
+ * Hard-coded at the emit site as `1g` until 2026-07-27, when the root-tier
+ * `overlord` container was measured at 90% of its 1.0 GiB `/tmp` (917M used,
+ * ~150M free) purely from concurrently-running sub-agents — 785M of it repo
+ * clones plus `bunx` toolchain caches (vitest, typescript). A fan-out of
+ * several workers/reviewers exhausts 1 GiB routinely, and a full /tmp fails
+ * clones and installs with confusing ENOSPC errors.
+ *
+ * 2 GiB is safe as a *default* because a tmpfs is a ceiling, not a
+ * reservation: it consumes host RAM only for pages actually written, so an
+ * idle agent's footprint is unchanged. Those pages are charged against the
+ * container's `mem_limit` cgroup, so an agent that raises this AND intends to
+ * fill it should raise `resources.memory` too.
+ */
+export const DEFAULT_TMP_SIZE = "2g";
 
 // Per-profile defaults. Settings:
 //   - memLimit       hard cap (cgroup memory.max)
@@ -123,6 +148,10 @@ export interface ResourceDefaults {
 //                    multiples of typical peak. klanker (the dedicated
 //                    test runner) gets the highest cap.
 //   - cpus           CPU quota (Docker `cpus`).
+//   - tmpSize        size of the RAM-backed /tmp. Uniform across profiles
+//                    today (DEFAULT_TMP_SIZE); per-profile values are
+//                    possible here, and `resources.tmp_size` overrides it
+//                    at any cascade layer.
 //
 // These are starting points; operators override per-agent via the
 // schema's `resources` block (PR #1190). memLimit is a hard cap
@@ -135,13 +164,20 @@ export interface ResourceDefaults {
 // host capacity; overlord and other per-agent overrides are set separately
 // in switchroom.yaml and are not reflected here.
 const RESOURCE_BY_PROFILE: Record<string, ResourceDefaults> = {
-  klanker: { memLimit: "8g", memReservation: "4g", pidsLimit: 2000, cpus: 2.0 },
+  klanker: {
+    memLimit: "8g",
+    memReservation: "4g",
+    pidsLimit: 2000,
+    cpus: 2.0,
+    tmpSize: DEFAULT_TMP_SIZE,
+  },
   // Conversational profiles — clerk, finn, carrie, coach, etc.
   conversational: {
     memLimit: "3g",
     memReservation: "256m",
     pidsLimit: 500,
     cpus: 1.0,
+    tmpSize: DEFAULT_TMP_SIZE,
   },
   // Lightweight profiles.
   lightweight: {
@@ -149,6 +185,7 @@ const RESOURCE_BY_PROFILE: Record<string, ResourceDefaults> = {
     memReservation: "128m",
     pidsLimit: 500,
     cpus: 0.5,
+    tmpSize: DEFAULT_TMP_SIZE,
   },
   // Coding/worker/researcher.
   coding: {
@@ -156,6 +193,7 @@ const RESOURCE_BY_PROFILE: Record<string, ResourceDefaults> = {
     memReservation: "512m",
     pidsLimit: 1000,
     cpus: 2.0,
+    tmpSize: DEFAULT_TMP_SIZE,
   },
   // Catch-all default.
   default: {
@@ -163,6 +201,7 @@ const RESOURCE_BY_PROFILE: Record<string, ResourceDefaults> = {
     memReservation: "256m",
     pidsLimit: 500,
     cpus: 1.0,
+    tmpSize: DEFAULT_TMP_SIZE,
   },
 };
 
@@ -177,6 +216,7 @@ export interface ResourceOverrides {
   memory_reservation?: string;
   pids_limit?: number;
   cpus?: number;
+  tmp_size?: string;
 }
 
 /**
@@ -242,6 +282,9 @@ export function resolveResourceDefaults(
     }
     if (overrides.pids_limit !== undefined) {
       merged.pidsLimit = overrides.pids_limit;
+    }
+    if (overrides.tmp_size !== undefined) {
+      merged.tmpSize = overrides.tmp_size;
     }
   }
   // Cron-session headroom — only when the operator left the field to defaults.
@@ -2109,7 +2152,9 @@ function emitAgentService(
     lines.push(`    read_only: true`);
   }
   lines.push(`    tmpfs:`);
-  lines.push(`      - /tmp:size=1g,mode=1777`);
+  // Size is operator-tunable via `resources.tmp_size` (defaults → profile →
+  // per-agent cascade); DEFAULT_TMP_SIZE when unset at every layer.
+  lines.push(`      - /tmp:size=${a.resources.tmpSize},mode=1777`);
   lines.push(`    depends_on:`);
   lines.push(`      vault-broker:`);
   lines.push(`        condition: service_started`);

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -1463,3 +1463,65 @@ describe("release.auto_update (KEN-131) — root-only opt-in", () => {
     expect(on.release?.auto_update).toBe(true);
   });
 });
+
+describe("resources.tmp_size — per-agent /tmp tmpfs sizing", () => {
+  const base = {
+    switchroom: { version: 1 },
+    telegram: { bot_token: "x", forum_chat_id: "1" },
+  };
+
+  it("survives AgentSchema parse (NOT stripped — the #3773 silent no-op class)", () => {
+    // The `resources` object is a plain z.object, which STRIPS unknown
+    // keys. If tmp_size is missing from the AgentSchema mirror the key
+    // vanishes at parse and the knob is a silent no-op, exactly the bug
+    // filed as #3773. Assert the resolved value, not the parse success.
+    const a = AgentSchema.parse({ topic_name: "ops", resources: { tmp_size: "4g" } });
+    expect(a.resources?.tmp_size).toBe("4g");
+  });
+
+  it("survives parse at the defaults layer (fleet-wide default)", () => {
+    const cfg = SwitchroomConfigSchema.parse({
+      ...base,
+      defaults: { resources: { tmp_size: "4g" } },
+      agents: {},
+    });
+    expect(cfg.defaults?.resources?.tmp_size).toBe("4g");
+  });
+
+  it("survives parse at the profile layer", () => {
+    const cfg = SwitchroomConfigSchema.parse({
+      ...base,
+      profiles: { roomy: { resources: { tmp_size: "6g" } } },
+      agents: {},
+    });
+    expect(cfg.profiles?.roomy?.resources?.tmp_size).toBe("6g");
+  });
+
+  it("accepts the docker size forms operators actually write", () => {
+    for (const v of ["512m", "1g", "2g", "4g", "1.5g", "1048576k", "2G", "512M"]) {
+      expect(AgentSchema.parse({ topic_name: "ops", resources: { tmp_size: v } }).resources?.tmp_size).toBe(v);
+    }
+  });
+
+  it("rejects garbage at config-load time, not at `docker compose up`", () => {
+    // "0"/"0g" parse as size strings but mount a ZERO-byte /tmp — every
+    // write in the container fails, so they are rejected too.
+    for (const bad of ["big", "4gb", "-1g", "4 g", "", "4gigs", "1e9", "0", "0g", "0.0m"]) {
+      expect(() => AgentSchema.parse({ topic_name: "ops", resources: { tmp_size: bad } })).toThrow();
+    }
+  });
+
+  it("rejects garbage at the defaults layer too", () => {
+    expect(() =>
+      SwitchroomConfigSchema.parse({
+        ...base,
+        defaults: { resources: { tmp_size: "lots" } },
+        agents: {},
+      }),
+    ).toThrow(/tmp_size must be a Docker size string/);
+  });
+
+  it("stays optional — an agent with no resources block still parses", () => {
+    expect(AgentSchema.parse({ topic_name: "ops" }).resources).toBeUndefined();
+  });
+});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2973,6 +2973,30 @@ const profileFields = {
           "back to the per-profile default (klanker/coding 2.0, default 1.0, " +
           "lightweight 0.5).",
         ),
+      tmp_size: z
+        .string()
+        .regex(
+          /^\d+(\.\d+)?[kmgKMG]?$/,
+          "tmp_size must be a Docker size string like '1g', '4g', '512m'",
+        )
+        // Zero is syntactically a valid size string but semantically a
+        // foot-gun the other resource fields don't have: `mem_limit: 0`
+        // means "unlimited" to Docker, whereas a `size=0` tmpfs mounts a
+        // ZERO-byte /tmp and every write in the container fails.
+        .refine((v) => parseFloat(v) > 0, "tmp_size must be greater than zero")
+        .optional()
+        .describe(
+          "Size of the agent container's RAM-backed `/tmp` (Docker " +
+          "`tmpfs: - /tmp:size=<this>,mode=1777`). The container root FS is " +
+          "read-only, so /tmp is the only scratch space the agent and its " +
+          "sub-agents get for repo clones and toolchain caches (bunx/npx/pip) " +
+          "— a fan-out of several sub-agents exhausts the 1g default. A tmpfs " +
+          "only consumes host RAM for the pages actually written, so raising " +
+          "the ceiling costs nothing until it is used; those pages are still " +
+          "charged to the container's `memory` cap, so raise both together. " +
+          "Format: '1g', '4g', '512m'. Default when unset at every cascade " +
+          "layer: '1g'.",
+        ),
     })
     .optional()
     .describe(
@@ -3549,6 +3573,14 @@ export const AgentSchema = z.object({
         .optional(),
       pids_limit: z.number().int().positive().optional(),
       cpus: z.number().positive().optional(),
+      tmp_size: z
+        .string()
+        .regex(
+          /^\d+(\.\d+)?[kmgKMG]?$/,
+          "tmp_size must be a Docker size string like '1g', '4g', '512m'",
+        )
+        .refine((v) => parseFloat(v) > 0, "tmp_size must be greater than zero")
+        .optional(),
     })
     .optional(),
 }).superRefine((agent, ctx) => {

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -31,6 +31,7 @@ import {
   AGENT_UID_MIN,
   AGENT_UID_MAX,
   describeAgents,
+  DEFAULT_TMP_SIZE,
   resolveConfigMountSource,
   CONTAINER_CONFIG_PATH,
 } from "../../src/agents/compose.js";
@@ -44,7 +45,13 @@ interface MakeConfigAgent {
   env?: Record<string, string>;
   model?: string;
   bind_mounts?: Array<{ source: string; target?: string; mode?: "ro" | "rw" }>;
-  resources?: { memory?: string; memory_reservation?: string; pids_limit?: number; cpus?: number };
+  resources?: {
+    memory?: string;
+    memory_reservation?: string;
+    pids_limit?: number;
+    cpus?: number;
+    tmp_size?: string;
+  };
   timezone?: string;
   network_isolation?: "host" | "strict";
   experimental?: { legacy_pty?: boolean; legacy_autoaccept_expect?: boolean };
@@ -475,6 +482,73 @@ describe("generateCompose", () => {
     });
     expect(out).toMatch(/agent-ziggy:[\s\S]*?cpus: 0\.3/); // toFixed(1) rounds
     expect(out).toMatch(/agent-ziggy:[\s\S]*?mem_limit: 1g/); // unchanged
+  });
+
+  // --- /tmp tmpfs sizing (resources.tmp_size) ---
+  //
+  // The size used to be hard-coded `1g` at the emit site with no way to
+  // change it short of hand-editing generated compose (which `apply`
+  // overwrites). It is now cascade-resolved, defaulting to
+  // DEFAULT_TMP_SIZE (2g).
+
+  it("emits DEFAULT_TMP_SIZE for an agent with no tmp_size anywhere", () => {
+    const out = generateCompose({ config: makeConfig({ coach: { extends: "conversational" } }) });
+    expect(out).toMatch(
+      new RegExp(`agent-coach:[\\s\\S]*?- /tmp:size=${DEFAULT_TMP_SIZE},mode=1777`),
+    );
+  });
+
+  it("the fleet-wide /tmp default is 2g (pin — a silent bump must fail here)", () => {
+    // Raised from 1g on 2026-07-27: overlord hit 90% of a 1.0 GiB /tmp
+    // (917M used) from concurrent sub-agent repo clones + bun caches.
+    expect(DEFAULT_TMP_SIZE).toBe("2g");
+    const out = generateCompose({ config: makeConfig({ solo: {} }) });
+    expect(out).toContain("- /tmp:size=2g,mode=1777");
+    expect(out).not.toContain("- /tmp:size=1g,mode=1777");
+  });
+
+  it("agent.resources.tmp_size overrides it for THAT agent only", () => {
+    const out = generateCompose({
+      config: makeConfig({
+        big: { extends: "coding", resources: { tmp_size: "8g" } },
+        small: { extends: "coding" },
+      }),
+    });
+    expect(out).toMatch(/agent-big:[\s\S]*?- \/tmp:size=8g,mode=1777/);
+    // The non-overridden sibling still gets the default — proves the
+    // override is scoped, not a global mutation.
+    expect(out).toMatch(/agent-small:[\s\S]*?- \/tmp:size=2g,mode=1777/);
+    // Unrelated resource fields untouched by the new knob.
+    expect(out).toMatch(/agent-big:[\s\S]*?mem_limit: 4g/);
+  });
+
+  it("defaults.resources.tmp_size cascades, and per-agent wins over it", () => {
+    const config = makeConfig({
+      pinned: { resources: { tmp_size: "512m" } },
+      inherits: {},
+    });
+    config.defaults = { ...(config.defaults ?? {}), resources: { tmp_size: "4g" } };
+    const out = generateCompose({ config });
+    expect(out).toMatch(/agent-inherits:[\s\S]*?- \/tmp:size=4g,mode=1777/);
+    expect(out).toMatch(/agent-pinned:[\s\S]*?- \/tmp:size=512m,mode=1777/);
+  });
+
+  it("profile.resources.tmp_size cascades to agents extending it", () => {
+    const config = makeConfig({ alice: { extends: "roomy" } });
+    config.profiles = {
+      roomy: { resources: { tmp_size: "6g" } },
+    } as unknown as typeof config.profiles;
+    const out = generateCompose({ config });
+    expect(out).toMatch(/agent-alice:[\s\S]*?- \/tmp:size=6g,mode=1777/);
+  });
+
+  it("root-tier agents (no hardening block) still get the resolved tmp_size", () => {
+    // The root agent skips security_opt/cap_drop/read_only but NOT tmpfs;
+    // the emit site sits outside that `if (!a.root)` branch.
+    const out = generateCompose({
+      config: makeConfig({ overseer: { root: true, resources: { tmp_size: "16g" } } }),
+    });
+    expect(out).toMatch(/agent-overseer:[\s\S]*?- \/tmp:size=16g,mode=1777/);
   });
 
   it("strips cap_add and emits a warning", () => {
@@ -1037,7 +1111,7 @@ describe("generateCompose", () => {
       expect(block, `agent-${name} security_opt`).toContain('no-new-privileges:true');
       expect(block, `agent-${name} cap_drop`).toMatch(/cap_drop:\s*\n\s*-\s*"ALL"/);
       expect(block, `agent-${name} read_only`).toContain("read_only: true");
-      expect(block, `agent-${name} tmpfs`).toContain("/tmp:size=1g");
+      expect(block, `agent-${name} tmpfs`).toContain(`/tmp:size=${DEFAULT_TMP_SIZE}`);
     }
   });
 
@@ -3125,7 +3199,7 @@ describe("root-tier debugging agent (root: true)", () => {
     expect(block).not.toContain("read_only: true");
     expect(block).not.toMatch(/cap_drop:\s*\n\s*-\s*"ALL"/);
     // tmpfs /tmp is still present (RAM-backed, capped).
-    expect(block).toContain("/tmp:size=1g");
+    expect(block).toContain(`/tmp:size=${DEFAULT_TMP_SIZE}`);
   });
 
   it("mounts docker.sock, the whole ~/.switchroom tree, and the host root fs", () => {


### PR DESCRIPTION
## Summary

`resources.tmp_size` joins `memory` / `memory_reservation` / `pids_limit` /
`cpus` in the existing `resources` block, cascading **defaults → profile →
per-agent** through the same per-field merge (`mergeAgentConfig`'s existing
`resources` clause — no parallel resolution path).

The `/tmp` tmpfs size was hard-coded at `src/agents/compose.ts` as one
`lines.push(\`      - /tmp:size=1g,mode=1777\`)`. The only way to change it was
hand-editing the generated compose file, which the next `switchroom apply`
overwrites.

**The fleet-wide default also moves `1g` → `2g`** (`DEFAULT_TMP_SIZE`).

## Why

Measured live: the root-tier `overlord` container sat at **90% of its 1.0 GiB
`/tmp`** — 917M used, ~150M free — purely from concurrently-running
sub-agents. 785M of that was sub-agent repo clones plus `bunx` toolchain
caches (vitest, typescript). The container root FS is read-only, so `/tmp` is
the *only* scratch space an agent and its sub-agents get; a fan-out of a few
workers exhausts 1 GiB routinely, and the failure surfaces as a bare ENOSPC
in a clone or install, far from the cause.

2 GiB is safe as a default because **a tmpfs is a ceiling, not a
reservation** — it consumes host RAM only for pages actually written, so an
idle agent's footprint is unchanged. Those pages are charged against the
container's existing `mem_limit` cgroup, so an agent that raises `tmp_size`
*and* intends to fill it should raise `resources.memory` alongside.

Declared in **both** zod mirrors (`profileFields.resources` and the
`AgentSchema.resources` mirror) because that object is a plain `z.object` and
strips unknown keys — a knob present in only one mirror parses green and
silently does nothing (#3773). Format check matches the sibling `memory`
field, plus a zero-rejection refine: `mem_limit: 0` means "unlimited" to
Docker, but a `size=0` tmpfs mounts a zero-byte `/tmp` where every write
fails.

## Test plan

- `tests/docker/compose-generator.test.ts` — default emitted for a
  non-overridden agent; per-agent override scoped to that agent while a
  sibling in the same fleet still gets `2g`; `defaults.` and `profile.`
  cascade with per-agent winning; root-tier agent (which skips the hardening
  block) still gets the resolved size; `DEFAULT_TMP_SIZE` pinned at `"2g"` so
  a silent bump fails.
- `src/config/schema.test.ts` — `tmp_size` survives parse at agent / defaults
  / profile layers (the strip class), accepted size forms, garbage and zero
  rejected at config-load with a clear message.
- **Mutation-checked**: reverting the emit site to hard-coded `1g` fails 8
  tests; deleting the `AgentSchema` mirror key fails 3.
- `npm run lint` clean. `vitest run tests/docker src/config src/agents` →
  1301 passed / 34 skipped.

## Risk

Behaviour change on the next `switchroom apply`: every agent without an
override goes 1g → 2g. Ceiling only, charged to the pre-existing `mem_limit`.
Running containers are unaffected until recreated. No other tmpfs mount is
touched (the hindsight credentials tmpfs in `src/setup/hindsight.ts` is
deliberately left alone).

Job spec: `reference/jobs/extend-without-forking.md` — a property of a
deployment becomes configuration instead of an edit to generated product
output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)