### PR TITLE
chore: release v0.19.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## Unreleased
+## v0.19.25 — hindsight 0.8.5, recall stops timing out on mature banks, and `switchroom memory repair` fixes silently under-returning banks
+
 ### Recall no longer times out on mature banks
 
 Auto-recall was exceeding its client deadline on ~96% of own-bank requests for


### PR DESCRIPTION
Consolidates the `## Unreleased` section under `## v0.19.25`. CHANGELOG-only, per release discipline — no `package.json` bump.

Cut from `01435b9e` (#3771).