### PR TITLE
fix(status-pin): finish the retarget, unpin on SIGTERM, single-flight the reaper

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -197,7 +197,7 @@ import {
 import type { WebhookGatewayRecord } from '../../src/web/webhook-gateway-record.js'
 import { reconcilePin, type PinBotApi } from '../status-pin-driver.js'
 import type { PinState, DesiredPin } from '../status-pin.js'
-import { decidePinAction, PinRightsCache } from '../status-pin.js'
+import { PinRightsCache } from '../status-pin.js'
 import { formatTurnLifecycle, detectStatusSurfaceDegraded } from './status-surface-log.js'
 import { parseSourceMessageId } from './source-message-id.js'
 import {
@@ -637,6 +637,9 @@ import type { HostdRequest, HostdResponse } from '../../src/host-control/protoco
 import type { AgentAudit } from '../welcome-text.js'
 import { shouldSweepChatAtBoot } from './boot-sweep-filter.js'
 import { createBootSweepGate, runBootPinSweepSteps } from './boot-sweep-gate.js'
+import { runStatusPinReconcile } from './status-pin-retarget.js'
+import { createPeriodicSweepGuard } from './periodic-sweep-guard.js'
+import { withDeadline } from './with-deadline.js'
 import { createStatusPinApi, type PinCapableBot, type RobustApiSeam } from './status-pin-api.js'
 import {
   createDmPinSweeper,
@@ -666,11 +669,9 @@ import { buildCapturedDeliverySnapshot, createCapturedResumeDispatcher } from '.
 import {
   loadStatusPins,
   mutateStatusPinRow,
-  reconcileAndPersistStatusPin,
   runStatusPinBootCleanup,
   withPinReconcileLock,
   type PersistedStatusPin,
-  type StatusPinPersistOp,
 } from './status-pin-store.js'
 import {
   loadActivityCards,
@@ -9069,8 +9070,20 @@ async function runMidSessionCardReaper(): Promise<void> {
   }
 }
 
+// Single-flight: a pass awaits Telegram calls that can park behind a flood-wait
+// for longer than the interval, so ticks fanned out. See periodic-sweep-guard.ts.
+const midSessionReaperGuard = createPeriodicSweepGuard({
+  run: runMidSessionCardReaper,
+  onSkip: () => process.stderr.write(
+    'telegram gateway: mid-session reaper tick skipped — previous pass still running\n',
+  ),
+  onError: (err) => process.stderr.write(
+    `telegram gateway: mid-session reaper pass threw: ${(err as Error).message}\n`,
+  ),
+})
+
 const midSessionCardReaper = isGatewayMain ? setInterval(() => {  // #2996 P0c gate
-  void runMidSessionCardReaper()
+  void midSessionReaperGuard.tick()
 }, MID_SESSION_CARD_REAPER_INTERVAL_MS) : undefined
 midSessionCardReaper?.unref()
 
@@ -9131,12 +9144,12 @@ async function reconcileStatusPinInner(
   // older duplicate-pin concern (two edits both reading prev=null).
   const prev = statusPinState.get(pinKey) ?? null
 
-  const runReconcile = () =>
+  const runReconcileFrom = (from: PinState | null, want: DesiredPin) =>
     reconcilePin({
       api: statusPinApi(),
       chatId,
-      prevState: prev,
-      desired,
+      prevState: from,
+      desired: want,
       rightsCache: statusPinRightsCache,
       onPinRightsDisabled: (chat) => {
         // Logged ONCE per chat per process (#3024). Every subsequent auto-pin
@@ -9155,53 +9168,23 @@ async function reconcileStatusPinInner(
       },
     })
 
-  // Classify the action so we persist INTENT before the pin API call. Only a
-  // fresh `pin` of a message that isn't already our claim opens the leak window
-  // (the API call actually pins something new); everything else (unpin, noop,
-  // re-pin of the same id) clears / leaves the record and is safe to persist
-  // after. See reconcileAndPersistStatusPin for the ordering rationale.
-  const action = decidePinAction(prev, desired)
-  const op: StatusPinPersistOp =
-    action.kind === 'pin'
-      ? { kind: 'pin', messageId: action.messageId }
-      : { kind: 'clear' }
-
-  if (!statusPinPersistEnabled) {
-    // Persistence off (STATIC / feature-off): just reconcile + update Maps.
-    const next = await runReconcile()
-    if (next == null) {
-      statusPinState.delete(pinKey)
-      statusPinChatIds.delete(pinKey)
-      statusPinPinnedAt.delete(pinKey)
-    } else {
-      statusPinState.set(pinKey, next)
-      statusPinChatIds.set(pinKey, chatId)
-      if (!statusPinPinnedAt.has(pinKey)) statusPinPinnedAt.set(pinKey, Date.now())
-    }
-    return
-  }
-
-  // Persist-BEFORE-pin ordering lives in reconcileAndPersistStatusPin: for a
-  // pin it writes a `pending` record first, then confirms it after the API call
-  // lands (or drops it on failure). A crash in the window leaves a pending
-  // record boot cleanup will unpin. In-memory Maps are updated from the result.
-  const next = await reconcileAndPersistStatusPin({
-    path: STATUS_PIN_STORE_PATH,
-    fs: statusPinStoreFs,
+  // Persist ordering + the RETARGET two-leg expansion: status-pin-retarget.ts.
+  await runStatusPinReconcile({
     pinKey,
     chatId,
-    op,
-    applyPin: runReconcile,
+    prev,
+    desired,
+    // persist:null ⇒ no durable row (STATIC / feature-off).
+    persist: statusPinPersistEnabled
+      ? { path: STATUS_PIN_STORE_PATH, fs: statusPinStoreFs }
+      : null,
+    runPin: runReconcileFrom,
+    registries: {
+      state: statusPinState,
+      chatIds: statusPinChatIds,
+      pinnedAt: statusPinPinnedAt,
+    },
   })
-  if (next == null) {
-    statusPinState.delete(pinKey)
-    statusPinChatIds.delete(pinKey)
-    statusPinPinnedAt.delete(pinKey)
-  } else {
-    statusPinState.set(pinKey, next)
-    statusPinChatIds.set(pinKey, chatId)
-    if (!statusPinPinnedAt.has(pinKey)) statusPinPinnedAt.set(pinKey, Date.now())
-  }
 }
 
 // #3207: the per-worker `reconcileWorkerPin(agentId, …)` (keyed `wk:<agentId>`)
@@ -22749,6 +22732,24 @@ async function shutdown(signal: string): Promise<void> {
     budgetMs: SHUTDOWN_DRAIN_BUDGET_MS,
     agentName,
   })
+
+  // Status-pin: unpin everything we own before we exit. `sweepBeforeSelfRestart`
+  // covered the gateway's OWN restart verbs, but SIGTERM/SIGINT — `docker
+  // restart`, a compose bounce, a host reboot: the common path — reached
+  // `process.exit(0)` with every live pin still pinned, leaving it at the top of
+  // the chat until the NEXT boot's cleanup won the mutex and built a bot
+  // (empirically: overlord logged `cleared 1/1 orphaned pin(s) from a prior
+  // session` on a routine 2026-07-27 restart). Runs after the drain (no live
+  // turn to race) and before `bot.api` goes away — `bot.stop()` only stops
+  // polling. Deadline-bounded on purpose: a flood-wait-parked unpin must not
+  // push shutdown into the `forceExitTimer` path, which skips the lock release.
+  try {
+    await withDeadline(unpinAllStatusPins(), 5_000, 'status-pin shutdown sweep timed out')
+  } catch (err) {
+    process.stderr.write(
+      `telegram gateway: shutdown status-pin sweep incomplete: ${(err as Error).message}\n`,
+    )
+  }
 
   // Now finish the cleanup the drain didn't touch.
   inboundCoalescer.reset()

--- a/telegram-plugin/gateway/periodic-sweep-guard.ts
+++ b/telegram-plugin/gateway/periodic-sweep-guard.ts
@@ -1,0 +1,86 @@
+/**
+ * periodic-sweep-guard.ts — single-flight wrapper for an interval-driven sweep.
+ *
+ * Why this exists
+ * ---------------
+ * `runMidSessionCardReaper` (gateway.ts) is dispatched from a `setInterval` as
+ * `void run()`, every 5 minutes by default. Its body awaits REAL Telegram calls:
+ * `robustApiCall` finalize edits for orphaned activity cards, and
+ * `reconcileStatusPin` unpins for stale `wk:` pins. Both retry with backoff and
+ * both can park behind a flood-wait — this gateway took a 62-minute flood ban on
+ * 2026-07-25.
+ *
+ * With no guard, every tick started ANOTHER concurrent pass. During a stall that
+ * is unbounded fan-out: N passes reading the same `status-pins.json`, deciding
+ * the same reaps, and firing duplicate unpins into the very rate limit that was
+ * slowing them down. Concurrent passes also race each other in the store-orphan
+ * branch, which unpins and drops the row OUTSIDE the per-key reconcile lock.
+ *
+ * The guard is deliberately SKIP, not queue: a tick arriving while a pass is
+ * running is dropped. The reaper is a backstop with no deadline, and the next
+ * tick is at most one interval away — queuing would just rebuild the same
+ * pile-up with extra latency.
+ *
+ * It also absorbs a throw out of the pass. The gateway's `unhandledRejection`
+ * handler crashes the process, and a fire-and-forget cosmetic sweep must never
+ * be able to do that (the same rule `reconcileStatusPin` follows after a benign
+ * pin-rights 400 took the whole gateway down, marko 2026-07-01).
+ */
+
+export interface PeriodicSweepGuard {
+  /** Run the sweep unless a pass is already in flight. Never rejects. */
+  tick(): Promise<void>
+  /** True while a pass is in flight. Test/introspection seam. */
+  isRunning(): boolean
+  /** Passes skipped because one was already running. Test/introspection seam. */
+  skipped(): number
+}
+
+/**
+ * Wrap `run` so at most one pass is in flight at a time.
+ *
+ * `onSkip` / `onError` are optional observers (the gateway logs to stderr);
+ * both are themselves absorbed, so a broken logger cannot take down the one
+ * function whose job is to make the sweep un-crashable.
+ */
+export function createPeriodicSweepGuard(args: {
+  run: () => Promise<void>
+  onSkip?: () => void
+  onError?: (err: unknown) => void
+}): PeriodicSweepGuard {
+  let running = false
+  let skippedCount = 0
+
+  const notify = (fn: (() => void) | undefined): void => {
+    if (fn == null) return
+    try {
+      fn()
+    } catch {
+      /* an observer must never break the guard */
+    }
+  }
+
+  return {
+    async tick(): Promise<void> {
+      if (running) {
+        skippedCount += 1
+        notify(args.onSkip)
+        return
+      }
+      running = true
+      try {
+        await args.run()
+      } catch (err) {
+        notify(args.onError == null ? undefined : () => args.onError?.(err))
+      } finally {
+        running = false
+      }
+    },
+    isRunning(): boolean {
+      return running
+    },
+    skipped(): number {
+      return skippedCount
+    },
+  }
+}

--- a/telegram-plugin/gateway/status-pin-retarget.ts
+++ b/telegram-plugin/gateway/status-pin-retarget.ts
@@ -1,0 +1,144 @@
+/**
+ * status-pin-retarget.ts — orchestrates a status-pin RETARGET as two persisted
+ * legs, so a single-shot caller still ends up with the new surface pinned.
+ *
+ * The defect this closes
+ * ----------------------
+ * `decidePinAction(prev, { pinned: true, messageId: NEW })` with a claim on a
+ * DIFFERENT message used to report a bare `unpin`, documented as "a subsequent
+ * desired-pin re-pins the new one on the next reconcile". That is true only for
+ * callers that RE-DRIVE the reconcile:
+ *
+ *   - the worker-activity feed does (`syncPin` runs on every steady-state edit,
+ *     `worker-activity-feed.ts`), so its group-message rotation converges;
+ *   - the FOREGROUND activity card does NOT. `narrative-lane.ts` reconciles
+ *     `fg:<statusKey>` exactly once, inside the `activityMessageId == null`
+ *     OPEN branch; the `else` (edit) branch never touches the pin, and turn-end
+ *     only ever unpins (`turn-end.ts`).
+ *
+ * So when the ack-first reopen path (`feed-reopen-gate.ts`) nulls
+ * `activityMessageId` mid-turn and a FRESH card opens, that one reconcile
+ * unpinned the old card and stopped. The live card ran unpinned for the rest of
+ * the turn, and — because the retarget mapped to a `clear` persist op — the
+ * durable `status-pins.json` row was deleted too, so neither the mid-session
+ * reaper nor the next boot's sweep had anything left to reconcile from.
+ *
+ * Why TWO legs and not one
+ * ------------------------
+ * `reconcileAndPersistStatusPin` carries the persist-BEFORE-pin contract for a
+ * single op. Running the retarget as one `pin`-op leg would write a pending row
+ * naming the NEW id before the OLD one is unpinned — a crash in that window
+ * erases the only durable record of a message that is still pinned. Splitting
+ * it keeps each leg's crash-safety exactly as designed:
+ *
+ *   leg 1  unpin the stale claim, with the row still naming the OLD id;
+ *   leg 2  pin the new message from a null claim, with its own pending row.
+ *
+ * Failure semantics are inherited from `reconcilePin`, not re-invented here: a
+ * leg-1 result that is NON-NULL means the unpin was never confirmed (#3664
+ * Defect B — the old message is provably still pinned and the claim was
+ * deliberately retained). Pinning the new message then would leave two pins in
+ * the chat with a durable record of one, so leg 2 is skipped and the retained
+ * claim is left for the next reconcile / the mid-session reaper / the boot
+ * sweep to retry.
+ *
+ * Dependency-free apart from the pure decision, so it is provable in isolation
+ * (`telegram-plugin/tests/status-pin-retarget.test.ts`); the gateway owns the
+ * wiring of `runLeg` / `commit`.
+ */
+
+import type { DesiredPin, PinState } from '../status-pin.js'
+import { decidePinAction } from '../status-pin.js'
+import type { StatusPinPersistOp, StatusPinStoreFsSeam } from './status-pin-store.js'
+import { reconcileAndPersistStatusPin } from './status-pin-store.js'
+
+/** The three parallel in-memory maps the gateway keys by pinKey. */
+export interface StatusPinRegistries {
+  /** The claim: which message we believe is pinned for this key. */
+  state: Map<string, PinState>
+  /** Which chat that claim lives in (the `wk:` reaper needs it to unpin). */
+  chatIds: Map<string, string>
+  /** When the claim was FIRST taken — the reaper's TTL age. */
+  pinnedAt: Map<string, number>
+}
+
+export interface StatusPinReconcileArgs {
+  pinKey: string
+  chatId: string
+  /** The claim held for this key when the reconcile started. */
+  prev: PinState | null
+  /** What the caller wants pinned for this key now. */
+  desired: DesiredPin
+  /** Durable-store binding, or null when persistence is off (STATIC). */
+  persist: { path: string; fs: StatusPinStoreFsSeam } | null
+  /**
+   * Execute the real Telegram pin/unpin for one leg (the gateway binds
+   * `reconcilePin`). Must never throw — API errors are absorbed inside.
+   */
+  runPin: (from: PinState | null, want: DesiredPin) => Promise<PinState | null>
+  registries: StatusPinRegistries
+}
+
+/**
+ * Drive `prev → desired` for one pin key, expanding a RETARGET into its two
+ * legs. Every other action (pin / unpin / noop) is a single leg, unchanged.
+ *
+ * Each leg is committed to the registries as it lands, so the in-memory claim
+ * never lags the durable row — including the intermediate cleared state between
+ * a retarget's two legs, which is what lets a concurrent reader (the `wk:`
+ * reaper) see an honest snapshot rather than a claim on an unpinned id.
+ *
+ * Callers must hold the per-key reconcile lock (`withPinReconcileLock`); `prev`
+ * is read once by the caller and both legs run inside that critical section.
+ */
+export async function runStatusPinReconcile(args: StatusPinReconcileArgs): Promise<void> {
+  const { pinKey, chatId, prev, desired, persist, runPin, registries } = args
+
+  // Publish a leg's outcome. `pinnedAt` is set only when absent so it keeps the
+  // FIRST-taken timestamp; clearing the claim drops it, so a re-pin ages fresh.
+  const commit = (next: PinState | null): void => {
+    if (next == null) {
+      registries.state.delete(pinKey)
+      registries.chatIds.delete(pinKey)
+      registries.pinnedAt.delete(pinKey)
+      return
+    }
+    registries.state.set(pinKey, next)
+    registries.chatIds.set(pinKey, chatId)
+    if (!registries.pinnedAt.has(pinKey)) registries.pinnedAt.set(pinKey, Date.now())
+  }
+
+  // One leg, with the persist ordering its action requires. Only a fresh `pin`
+  // opens the crash window that persist-BEFORE-pin closes; unpin / noop / re-pin
+  // of the same id clear or leave the row and are safe to persist after.
+  const runLeg = (from: PinState | null, want: DesiredPin): Promise<PinState | null> => {
+    if (persist == null) return runPin(from, want)
+    const legAction = decidePinAction(from, want)
+    const op: StatusPinPersistOp =
+      legAction.kind === 'pin'
+        ? { kind: 'pin', messageId: legAction.messageId }
+        : { kind: 'clear' }
+    return reconcileAndPersistStatusPin({
+      path: persist.path,
+      fs: persist.fs,
+      pinKey,
+      chatId,
+      op,
+      applyPin: () => runPin(from, want),
+    })
+  }
+
+  const action = decidePinAction(prev, desired)
+
+  if (action.kind === 'repin' && desired.pinned) {
+    const afterUnpin = await runLeg(prev, { pinned: false })
+    commit(afterUnpin)
+    // Never-confirmed unpin (#3664 Defect B): keep the retained claim, skip the
+    // pin leg. See the docblock.
+    if (afterUnpin != null) return
+    commit(await runLeg(null, desired))
+    return
+  }
+
+  commit(await runLeg(prev, desired))
+}

--- a/telegram-plugin/status-pin-driver.ts
+++ b/telegram-plugin/status-pin-driver.ts
@@ -86,6 +86,12 @@ export interface ReconcilePinArgs {
  *              success and on a TERMINAL failure (never leave state stuck
  *              pinned). A never-confirmed failure returns prevState so the
  *              still-pinned message keeps a record to retry from (#3664).
+ *   - `repin`: the wanted message CHANGED — unpins the stale claim then pins
+ *              the new message, both in this one call, returning the new
+ *              claim. A never-confirmed unpin aborts the pin leg and retains
+ *              the old claim (the old message is still up and must keep a
+ *              record). Single-shot callers depend on this: they never
+ *              reconcile the key a second time.
  *   - `noop` : returns prevState unchanged.
  */
 export async function reconcilePin(
@@ -94,6 +100,28 @@ export async function reconcilePin(
   const action = decidePinAction(args.prevState, args.desired)
 
   if (action.kind === 'noop') return args.prevState
+
+  if (action.kind === 'repin') {
+    // RETARGET: unpin the stale claim, then pin the new message — BOTH legs in
+    // this one call. Callers that reconcile a key exactly once (the foreground
+    // activity card) have no "next reconcile" to finish the job, so splitting
+    // it left nothing pinned. See the `repin` docblock in status-pin.ts.
+    const afterUnpin = await reconcilePin({
+      ...args,
+      desired: { pinned: false },
+    })
+    // A non-null result here means the unpin was NEVER CONFIRMED (#3664
+    // Defect B): the old message is provably still pinned and the claim was
+    // deliberately retained. Pinning the new one now would leave two pins with
+    // a record of only one. Keep the retained claim and let the next reconcile
+    // / the mid-session reaper / the boot sweep retry.
+    if (afterUnpin != null) return afterUnpin
+    return reconcilePin({
+      ...args,
+      prevState: null,
+      desired: { pinned: true, messageId: action.pinMessageId },
+    })
+  }
 
   if (action.kind === 'unpin') {
     // Skip the unpin API call in a chat the bot can't manage pins in — the

--- a/telegram-plugin/status-pin.ts
+++ b/telegram-plugin/status-pin.ts
@@ -48,6 +48,29 @@ export type PinAction =
    *  or a TERMINAL failure; a never-confirmed failure keeps the claim so the
    *  still-pinned message can be retried (`isUnpinTerminalError`, #3664). */
   | { kind: 'unpin'; messageId: number }
+  /**
+   * RETARGET — the caller still wants something pinned for this key, but a
+   * DIFFERENT message than the one we claim (the surface was re-posted: an
+   * ack-first activity-card reopen, a worker-feed group-message rotation).
+   *
+   * This is ONE action, not two reconciles. It used to be reported as a plain
+   * `unpin`, on the assumption that "a subsequent desired-pin re-pins the new
+   * one on the next reconcile". That assumption holds only for callers that
+   * RE-DRIVE the reconcile (the worker feed's `syncPin`, called on every
+   * steady-state edit). The foreground activity card does not: it reconciles
+   * exactly once, when a card OPENs (`narrative-lane.ts` — the `else` branch
+   * only EDITs and never touches the pin). So a mid-turn card reopen (the
+   * ack-first path in `feed-reopen-gate.ts`, which nulls `activityMessageId`
+   * so a fresh card opens) unpinned the old card and left the NEW one
+   * unpinned for the rest of the turn — the pin vanished exactly when the
+   * turn still needed it.
+   *
+   * Executors MUST complete both legs: unpin `unpinMessageId`, then pin
+   * `pinMessageId`. `reconcilePin` owns the failure semantics (a
+   * never-confirmed unpin retains the OLD claim and skips the pin, so the last
+   * record of a provably-still-pinned message is never lost).
+   */
+  | { kind: 'repin'; unpinMessageId: number; pinMessageId: number }
 
 /**
  * Decide the single pin action for a key given the previously-claimed
@@ -71,10 +94,16 @@ export function decidePinAction(
   if (prev.messageId === desired.messageId) {
     return { kind: 'noop', reason: 'already pinned this message' }
   }
-  // The message we want pinned changed (the feed re-posted after a stale
-  // edit dropped its id). Unpin the old claim; a subsequent desired-pin
-  // re-pins the new one on the next reconcile.
-  return { kind: 'unpin', messageId: prev.messageId }
+  // The message we want pinned changed (the surface was re-posted). Report a
+  // RETARGET, not a bare unpin: the executor must drop the stale claim AND pin
+  // the new message in the same reconcile. Relying on "the next reconcile" to
+  // pin left every single-shot caller (the foreground activity card) with
+  // nothing pinned — see the `repin` docblock above.
+  return {
+    kind: 'repin',
+    unpinMessageId: prev.messageId,
+    pinMessageId: desired.messageId,
+  }
 }
 
 /** Extract a lowercased human description from any thrown value, preferring

--- a/telegram-plugin/tests/periodic-sweep-guard.test.ts
+++ b/telegram-plugin/tests/periodic-sweep-guard.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import { createPeriodicSweepGuard } from "../gateway/periodic-sweep-guard.js";
+
+/**
+ * Single-flight guard for the interval-driven mid-session card reaper.
+ *
+ * Pre-fix the interval dispatched `void runMidSessionCardReaper()` directly, so
+ * a pass that parked behind a flood-wait (this gateway took a 62-minute flood
+ * ban on 2026-07-25) let EVERY subsequent tick start another concurrent pass —
+ * unbounded fan-out racing the same store rows and firing duplicate unpins into
+ * the rate limit that caused the stall. These assert the observable outcome:
+ * the number of times `run` actually started.
+ */
+describe("createPeriodicSweepGuard", () => {
+  /** A pass we can hold open, counting starts and completions. */
+  function heldRun() {
+    let release!: () => void;
+    let gate = new Promise<void>((r) => {
+      release = r;
+    });
+    let starts = 0;
+    let finishes = 0;
+    const run = async () => {
+      starts += 1;
+      await gate;
+      finishes += 1;
+    };
+    return {
+      run,
+      starts: () => starts,
+      finishes: () => finishes,
+      release: () => {
+        release();
+        // Re-arm so a later pass can be held again.
+        gate = new Promise<void>((r) => {
+          release = r;
+        });
+      },
+    };
+  }
+
+  it("runs the pass when idle", async () => {
+    let ran = 0;
+    const g = createPeriodicSweepGuard({
+      run: async () => {
+        ran += 1;
+      },
+    });
+    await g.tick();
+    expect(ran).toBe(1);
+    expect(g.isRunning()).toBe(false);
+    expect(g.skipped()).toBe(0);
+  });
+
+  it("SKIPS every tick that arrives while a pass is still in flight (the fan-out fix)", async () => {
+    const h = heldRun();
+    const skips: number[] = [];
+    const g = createPeriodicSweepGuard({ run: h.run, onSkip: () => skips.push(1) });
+
+    const inFlight = g.tick();
+    await Promise.resolve();
+    expect(g.isRunning()).toBe(true);
+    expect(h.starts()).toBe(1);
+
+    // Ten more interval ticks land during the stall. Pre-fix these were ten
+    // more concurrent passes; now they are dropped.
+    await Promise.all([
+      g.tick(),
+      g.tick(),
+      g.tick(),
+      g.tick(),
+      g.tick(),
+      g.tick(),
+      g.tick(),
+      g.tick(),
+      g.tick(),
+      g.tick(),
+    ]);
+    expect(h.starts()).toBe(1); // still exactly ONE pass ever started
+    expect(g.skipped()).toBe(10);
+    expect(skips).toHaveLength(10);
+
+    h.release();
+    await inFlight;
+    expect(h.finishes()).toBe(1);
+    expect(g.isRunning()).toBe(false);
+  });
+
+  it("re-arms after the in-flight pass settles, so the sweep is not disabled forever", async () => {
+    const h = heldRun();
+    const g = createPeriodicSweepGuard({ run: h.run });
+    const first = g.tick();
+    await Promise.resolve();
+    await g.tick(); // skipped
+    h.release();
+    await first;
+
+    const second = g.tick();
+    await Promise.resolve();
+    expect(h.starts()).toBe(2); // the NEXT tick genuinely ran
+    h.release();
+    await second;
+  });
+
+  it("absorbs a throwing pass: tick never rejects, the guard re-arms, onError sees it", async () => {
+    const seen: unknown[] = [];
+    let calls = 0;
+    const g = createPeriodicSweepGuard({
+      run: async () => {
+        calls += 1;
+        throw new Error(`boom ${calls}`);
+      },
+      onError: (e) => seen.push(e),
+    });
+
+    // A rejection escaping here reaches the gateway's `unhandledRejection`
+    // handler, which CRASHES the process — a cosmetic sweep must never do that.
+    await expect(g.tick()).resolves.toBeUndefined();
+    expect(g.isRunning()).toBe(false);
+    await expect(g.tick()).resolves.toBeUndefined();
+    expect(calls).toBe(2); // a throw does not wedge the running flag
+    expect(seen).toHaveLength(2);
+    expect((seen[0] as Error).message).toBe("boom 1");
+  });
+
+  it("a throwing observer cannot break the guard", async () => {
+    const h = heldRun();
+    const g = createPeriodicSweepGuard({
+      run: h.run,
+      onSkip: () => {
+        throw new Error("broken logger");
+      },
+    });
+    const first = g.tick();
+    await Promise.resolve();
+    await expect(g.tick()).resolves.toBeUndefined();
+    expect(g.skipped()).toBe(1);
+    h.release();
+    await first;
+  });
+
+  it("onError is optional — a throwing pass with no observer is still absorbed", async () => {
+    const g = createPeriodicSweepGuard({
+      run: async () => {
+        throw new Error("boom");
+      },
+    });
+    await expect(g.tick()).resolves.toBeUndefined();
+    expect(g.isRunning()).toBe(false);
+  });
+});

--- a/telegram-plugin/tests/status-pin-retarget.test.ts
+++ b/telegram-plugin/tests/status-pin-retarget.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from "vitest";
+import { runStatusPinReconcile } from "../gateway/status-pin-retarget.js";
+import type { DesiredPin, PinState } from "../status-pin.js";
+
+/**
+ * The orchestrator the gateway's `reconcileStatusPinInner` delegates to.
+ *
+ * The defect it closes: a RETARGET (the caller wants a DIFFERENT message pinned
+ * for a key it already holds a claim on) used to be reported as a bare `unpin`
+ * and stopped there, on the assumption a later reconcile would pin the new
+ * message. The FOREGROUND activity card reconciles `fg:<statusKey>` exactly
+ * once (narrative-lane.ts, the `activityMessageId == null` OPEN branch), so an
+ * ack-first mid-turn reopen left the live card unpinned for the rest of the
+ * turn AND deleted the durable row, putting it out of reach of both the
+ * mid-session reaper and the next boot's sweep.
+ *
+ * These tests drive the module with a fake leg runner and assert the LEG
+ * SEQUENCE — the thing that was wrong — plus the registry bookkeeping.
+ */
+
+/** Records every leg and returns a scripted outcome for it. */
+function legRecorder(outcomes: Array<PinState | null>) {
+  const legs: Array<{ from: PinState | null; want: DesiredPin }> = [];
+  let i = 0;
+  const runPin = async (from: PinState | null, want: DesiredPin) => {
+    legs.push({ from, want });
+    const out = outcomes[i];
+    i += 1;
+    return out ?? null;
+  };
+  return { legs, runPin };
+}
+
+function registries(seed?: { key: string; state: PinState; chatId: string; at: number }) {
+  const r = {
+    state: new Map<string, PinState>(),
+    chatIds: new Map<string, string>(),
+    pinnedAt: new Map<string, number>(),
+  };
+  if (seed) {
+    r.state.set(seed.key, seed.state);
+    r.chatIds.set(seed.key, seed.chatId);
+    r.pinnedAt.set(seed.key, seed.at);
+  }
+  return r;
+}
+
+const KEY = "fg:c:7";
+const CHAT = "-100123";
+
+describe("runStatusPinReconcile — RETARGET", () => {
+  it("runs BOTH legs: unpins the stale claim, then pins the new message", async () => {
+    const { legs, runPin } = legRecorder([null, { messageId: 901 }]);
+    const reg = registries({ key: KEY, state: { messageId: 900 }, chatId: CHAT, at: 1000 });
+
+    await runStatusPinReconcile({
+      pinKey: KEY,
+      chatId: CHAT,
+      prev: { messageId: 900 },
+      desired: { pinned: true, messageId: 901 },
+      persist: null,
+      runPin,
+      registries: reg,
+    });
+
+    // The pre-fix behaviour was legs === [unpin] and nothing pinned.
+    expect(legs).toEqual([
+      { from: { messageId: 900 }, want: { pinned: false } },
+      { from: null, want: { pinned: true, messageId: 901 } },
+    ]);
+    expect(reg.state.get(KEY)).toEqual({ messageId: 901 });
+    expect(reg.chatIds.get(KEY)).toBe(CHAT);
+  });
+
+  it("leg 2 starts from a NULL claim, so it decides a real `pin` (not a noop)", async () => {
+    const { legs, runPin } = legRecorder([null, { messageId: 901 }]);
+    await runStatusPinReconcile({
+      pinKey: KEY,
+      chatId: CHAT,
+      prev: { messageId: 900 },
+      desired: { pinned: true, messageId: 901 },
+      persist: null,
+      runPin,
+      registries: registries(),
+    });
+    expect(legs[1].from).toBeNull();
+  });
+
+  it("re-stamps pinnedAt for the NEW card, so the reaper ages the live message", async () => {
+    const { runPin } = legRecorder([null, { messageId: 901 }]);
+    const reg = registries({ key: KEY, state: { messageId: 900 }, chatId: CHAT, at: 1000 });
+    await runStatusPinReconcile({
+      pinKey: KEY,
+      chatId: CHAT,
+      prev: { messageId: 900 },
+      desired: { pinned: true, messageId: 901 },
+      persist: null,
+      runPin,
+      registries: reg,
+    });
+    // Leg 1 cleared the claim (dropping the old stamp), leg 2 took a fresh one.
+    expect(reg.pinnedAt.get(KEY)).toBeGreaterThan(1000);
+  });
+
+  it("NEVER-CONFIRMED unpin (#3664 Defect B): SKIPS the pin leg and retains the OLD claim", async () => {
+    // A non-null leg-1 result means reconcilePin deliberately kept the claim —
+    // the old message is provably still pinned. Pinning the new one now would
+    // leave TWO pins in the chat with a durable record of one.
+    const { legs, runPin } = legRecorder([{ messageId: 900 }]);
+    const reg = registries({ key: KEY, state: { messageId: 900 }, chatId: CHAT, at: 1000 });
+
+    await runStatusPinReconcile({
+      pinKey: KEY,
+      chatId: CHAT,
+      prev: { messageId: 900 },
+      desired: { pinned: true, messageId: 901 },
+      persist: null,
+      runPin,
+      registries: reg,
+    });
+
+    expect(legs).toHaveLength(1);
+    expect(reg.state.get(KEY)).toEqual({ messageId: 900 });
+    expect(reg.chatIds.get(KEY)).toBe(CHAT);
+    expect(reg.pinnedAt.get(KEY)).toBe(1000); // original age preserved for the TTL gate
+  });
+
+  it("a FAILED pin leg drops the claim entirely (nothing is pinned, nothing is tracked)", async () => {
+    // reconcilePin returns its `from` on a failed pin — here `null`.
+    const { runPin } = legRecorder([null, null]);
+    const reg = registries({ key: KEY, state: { messageId: 900 }, chatId: CHAT, at: 1000 });
+    await runStatusPinReconcile({
+      pinKey: KEY,
+      chatId: CHAT,
+      prev: { messageId: 900 },
+      desired: { pinned: true, messageId: 901 },
+      persist: null,
+      runPin,
+      registries: reg,
+    });
+    expect(reg.state.has(KEY)).toBe(false);
+    expect(reg.chatIds.has(KEY)).toBe(false);
+    expect(reg.pinnedAt.has(KEY)).toBe(false);
+  });
+});
+
+describe("runStatusPinReconcile — single-leg actions are unchanged", () => {
+  it("first pin: one leg, claim + chat + age recorded", async () => {
+    const { legs, runPin } = legRecorder([{ messageId: 900 }]);
+    const reg = registries();
+    await runStatusPinReconcile({
+      pinKey: KEY,
+      chatId: CHAT,
+      prev: null,
+      desired: { pinned: true, messageId: 900 },
+      persist: null,
+      runPin,
+      registries: reg,
+    });
+    expect(legs).toEqual([{ from: null, want: { pinned: true, messageId: 900 } }]);
+    expect(reg.state.get(KEY)).toEqual({ messageId: 900 });
+    expect(reg.pinnedAt.has(KEY)).toBe(true);
+  });
+
+  it("turn-end unpin: one leg, all three registries cleared", async () => {
+    const { legs, runPin } = legRecorder([null]);
+    const reg = registries({ key: KEY, state: { messageId: 900 }, chatId: CHAT, at: 1000 });
+    await runStatusPinReconcile({
+      pinKey: KEY,
+      chatId: CHAT,
+      prev: { messageId: 900 },
+      desired: { pinned: false },
+      persist: null,
+      runPin,
+      registries: reg,
+    });
+    expect(legs).toEqual([{ from: { messageId: 900 }, want: { pinned: false } }]);
+    expect(reg.state.has(KEY)).toBe(false);
+    expect(reg.chatIds.has(KEY)).toBe(false);
+    expect(reg.pinnedAt.has(KEY)).toBe(false);
+  });
+
+  it("steady-state re-pin of the SAME id: still one leg, and the ORIGINAL age is kept", async () => {
+    // 20 edits/turn each re-drive this; the reaper's TTL must measure from the
+    // first pin, not be reset by every edit.
+    const { legs, runPin } = legRecorder([{ messageId: 900 }]);
+    const reg = registries({ key: KEY, state: { messageId: 900 }, chatId: CHAT, at: 1000 });
+    await runStatusPinReconcile({
+      pinKey: KEY,
+      chatId: CHAT,
+      prev: { messageId: 900 },
+      desired: { pinned: true, messageId: 900 },
+      persist: null,
+      runPin,
+      registries: reg,
+    });
+    expect(legs).toHaveLength(1);
+    expect(reg.pinnedAt.get(KEY)).toBe(1000);
+  });
+
+  it("unpin with no claim: one no-op leg, registries stay empty", async () => {
+    const { legs, runPin } = legRecorder([null]);
+    const reg = registries();
+    await runStatusPinReconcile({
+      pinKey: KEY,
+      chatId: CHAT,
+      prev: null,
+      desired: { pinned: false },
+      persist: null,
+      runPin,
+      registries: reg,
+    });
+    expect(legs).toHaveLength(1);
+    expect(reg.state.size).toBe(0);
+  });
+});

--- a/telegram-plugin/tests/status-pin-shutdown-wiring.test.ts
+++ b/telegram-plugin/tests/status-pin-shutdown-wiring.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Status-pin SHUTDOWN + REAPER-DISPATCH wiring fence.
+ *
+ * Both defects here are wiring defects, and gateway.ts cannot be instantiated
+ * in-process (module-eval side effects), so — same pattern as
+ * `boot-pin-sweep-wiring.test.ts` and `silence-liveness-wiring.test.ts` — these
+ * are structural assertions over the source. The BEHAVIOUR they make apply to
+ * the gateway is proven in `status-pin-retarget.test.ts`,
+ * `periodic-sweep-guard.test.ts` and `status-pin.test.ts`.
+ *
+ * D2: `shutdown()` never unpinned. `sweepBeforeSelfRestart()` covered the
+ *     gateway's own restart verbs, but SIGTERM/SIGINT — `docker restart`,
+ *     `switchroom agent restart`, a compose bounce, a host reboot — reached
+ *     `process.exit(0)` with every live pin still pinned (empirically: overlord
+ *     logged `status-pin: cleared 1/1 orphaned pin(s) from a prior session` on
+ *     a routine 2026-07-27 restart, i.e. the NEXT boot had to clean it up).
+ *
+ * D3: the mid-session reaper interval dispatched `void runMidSessionCardReaper()`
+ *     with no single-flight guard, while the pass awaits flood-wait-prone
+ *     Telegram calls.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const gatewaySrc = readFileSync(resolve(__dirname, "..", "gateway", "gateway.ts"), "utf-8");
+
+/** Body of `async function shutdown(...)` up to the next top-level `\nasync function`/`\nfunction`. */
+function shutdownBody(): string {
+  const start = gatewaySrc.indexOf("async function shutdown(signal: string)");
+  expect(start).toBeGreaterThan(-1);
+  const rest = gatewaySrc.slice(start + 1);
+  const end = rest.search(/\n(?:async )?function /);
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+describe("status-pin shutdown wiring (D2)", () => {
+  it("shutdown() unpins the live status pins before exiting", () => {
+    expect(shutdownBody()).toContain("unpinAllStatusPins()");
+  });
+
+  it("the shutdown unpin is guarded, so a throw cannot skip the rest of shutdown", () => {
+    const body = shutdownBody();
+    const idx = body.indexOf("unpinAllStatusPins()");
+    // The nearest preceding statement must open a try — the sweep is
+    // best-effort and must never abort the drain/cleanup that follows it.
+    expect(body.slice(0, idx)).toMatch(/try\s*\{\s*\n\s*await withDeadline\($/);
+  });
+
+  it("the sweep is deadline-bounded, so it cannot push shutdown into force-exit", () => {
+    // forceExitTimer fires at budget+5s and deliberately SKIPS
+    // releaseStartupLock; an unbounded flood-wait-parked unpin here would turn
+    // a clean restart into a stale-lock recovery on the next boot.
+    expect(shutdownBody()).toMatch(/await withDeadline\(unpinAllStatusPins\(\), \d[\d_]*,/);
+  });
+
+  it("runs AFTER the drain and BEFORE the coalescer reset (bot.api still usable)", () => {
+    const body = shutdownBody();
+    const drain = body.indexOf("drainShutdown");
+    const unpin = body.indexOf("unpinAllStatusPins()");
+    const reset = body.indexOf("\n  inboundCoalescer.reset()"); // the statement, not the comment above it
+    expect(drain).toBeGreaterThan(-1);
+    expect(unpin).toBeGreaterThan(drain);
+    expect(reset).toBeGreaterThan(unpin);
+  });
+});
+
+describe("mid-session card reaper dispatch wiring (D3)", () => {
+  it("the interval never calls runMidSessionCardReaper() directly", () => {
+    // The pre-fix shape, verbatim: `void runMidSessionCardReaper()` on a timer.
+    // Only the declaration and the guard's `run:` reference may name it.
+    const invocations =
+      gatewaySrc.match(/(?<!function\s)(?<![.\w])runMidSessionCardReaper\s*\(/g) ?? [];
+    expect(invocations).toEqual([]);
+  });
+
+  it("dispatches through the single-flight guard instead", () => {
+    expect(gatewaySrc).toContain("createPeriodicSweepGuard({");
+    expect(gatewaySrc).toContain("run: runMidSessionCardReaper,");
+    expect(gatewaySrc).toContain("void midSessionReaperGuard.tick()");
+  });
+});
+
+describe("status-pin reconcile wiring (D1)", () => {
+  it("reconcileStatusPinInner delegates to the retarget-aware orchestrator", () => {
+    const start = gatewaySrc.indexOf("async function reconcileStatusPinInner(");
+    expect(start).toBeGreaterThan(-1);
+    const body = gatewaySrc.slice(start, gatewaySrc.indexOf("\n}", start));
+    // A single-leg `reconcileAndPersistStatusPin(...)` call here is exactly the
+    // shape that dropped the pin leg of a retarget on the floor.
+    expect(body).toContain("await runStatusPinReconcile({");
+    expect(body).not.toContain("reconcileAndPersistStatusPin({");
+  });
+});

--- a/telegram-plugin/tests/status-pin-store.test.ts
+++ b/telegram-plugin/tests/status-pin-store.test.ts
@@ -14,6 +14,8 @@ import {
 } from "../gateway/status-pin-store.js";
 import { decidePinAction, type PinState, type DesiredPin } from "../status-pin.js";
 import { reconcilePin, type PinBotApi } from "../status-pin-driver.js";
+import { runStatusPinReconcile } from "../gateway/status-pin-retarget.js";
+import { makeFloodWaitActiveError } from "../retry-api-call.js";
 
 /** In-memory fs seam with an atomic rename, so the store's tmp→rename
  *  crash-safety contract is exercised without touching the real disk. */
@@ -806,32 +808,24 @@ describe("status-pin-store — F2 per-key reconcile serialization", () => {
         unpinCalls.push(id);
       },
     };
-    async function core(
-      pinKey: string,
-      chatId: string,
-      desired: DesiredPin,
-      gate?: Promise<void>,
-    ) {
-      const prev = claims.get(pinKey) ?? null; // read BEFORE the store op (the F2 window)
-      const action = decidePinAction(prev, desired);
-      const op =
-        action.kind === "pin"
-          ? ({ kind: "pin", messageId: action.messageId } as const)
-          : ({ kind: "clear" } as const);
-      const next = await reconcileAndPersistStatusPin({
-        path: PATH,
-        fs,
+    const chatIds = new Map<string, string>();
+    const pinnedAt = new Map<string, number>();
+    // Drives the REAL production orchestrator the gateway calls, so the persist
+    // ordering and the RETARGET two-leg expansion under test are the shipped
+    // ones — not a copy that could drift out from under this suite.
+    function core(pinKey: string, chatId: string, desired: DesiredPin, gate?: Promise<void>) {
+      return runStatusPinReconcile({
         pinKey,
         chatId,
-        op,
-        applyPin: async () => {
+        prev: claims.get(pinKey) ?? null, // read BEFORE the store op (the F2 window)
+        desired,
+        persist: { path: PATH, fs },
+        runPin: async (from, want) => {
           if (gate) await gate; // hold the pin open inside the store lock
-          return reconcilePin({ api, chatId, prevState: prev, desired });
+          return reconcilePin({ api, chatId, prevState: from, desired: want });
         },
-        log: () => {},
+        registries: { state: claims, chatIds, pinnedAt },
       });
-      if (next == null) claims.delete(pinKey);
-      else claims.set(pinKey, next);
     }
     function reconcile(
       pinKey: string,
@@ -914,6 +908,78 @@ describe("status-pin-store — F2 per-key reconcile serialization", () => {
     // The durable row is intact throughout (F1).
     expect(loadStatusPins(PATH, fs)).toEqual([
       { pinKey: "wk:group:g1", chatId: "-100123", messageId: 900 },
+    ]);
+  });
+
+  // ── RETARGET: a single reconcile must leave the NEW surface pinned ────────
+  // The foreground activity card reconciles its `fg:` pin exactly once, when a
+  // card OPENs (narrative-lane.ts). The ack-first reopen path nulls
+  // `activityMessageId` mid-turn, so a fresh card opens and that ONE reconcile
+  // is the only chance to move the pin. It used to emit an unpin and stop:
+  // nothing pinned, and a durable row that had been deleted — so neither the
+  // mid-session reaper nor the next boot's sweep had anything to work from.
+  it("RETARGET: one reconcile unpins the old card, pins the NEW one, and leaves the durable row on the new id", async () => {
+    const { fs } = memFs();
+    const r = makeReconciler(fs, { serialize: true });
+
+    await r.reconcile("fg:c:7", "-100123", { pinned: true, messageId: 900 });
+    expect(r.pinCalls).toEqual([900]);
+    expect(loadStatusPins(PATH, fs)).toEqual([
+      { pinKey: "fg:c:7", chatId: "-100123", messageId: 900 },
+    ]);
+
+    // The card is re-posted mid-turn — ONE reconcile, new message id.
+    await r.reconcile("fg:c:7", "-100123", { pinned: true, messageId: 901 });
+
+    expect(r.unpinCalls).toEqual([900]); // stale card unpinned
+    expect(r.pinCalls).toEqual([900, 901]); // …AND the new card pinned
+    expect(r.claims.get("fg:c:7")).toEqual({ messageId: 901 });
+    // The durable row tracks the message that is genuinely pinned, so the
+    // mid-session reaper and the boot sweep can both still reach it.
+    expect(loadStatusPins(PATH, fs)).toEqual([
+      { pinKey: "fg:c:7", chatId: "-100123", messageId: 901 },
+    ]);
+  });
+
+  it("RETARGET: a never-confirmed unpin keeps the OLD id in the durable row (no unreapable orphan)", async () => {
+    // #3664 Defect B composed with the retarget: the old message is provably
+    // still pinned, so we must NOT pin the new one and must NOT lose the row —
+    // otherwise the chat holds a pin nothing on disk names.
+    const { fs } = memFs();
+    const claims = new Map<string, PinState>();
+    const pinCalls: number[] = [];
+    const unpinCalls: number[] = [];
+    let floodTheUnpin = false;
+    const api: PinBotApi = {
+      pinChatMessage: async (_c, id) => {
+        pinCalls.push(id);
+      },
+      unpinChatMessage: async (_c, id) => {
+        unpinCalls.push(id);
+        if (floodTheUnpin) throw makeFloodWaitActiveError(300, Date.now() + 300_000, null);
+      },
+    };
+    const reconcile = (desired: DesiredPin) =>
+      runStatusPinReconcile({
+        pinKey: "fg:c:8",
+        chatId: "-100123",
+        prev: claims.get("fg:c:8") ?? null,
+        desired,
+        persist: { path: PATH, fs },
+        runPin: (from, want) =>
+          reconcilePin({ api, chatId: "-100123", prevState: from, desired: want }),
+        registries: { state: claims, chatIds: new Map(), pinnedAt: new Map() },
+      });
+
+    await reconcile({ pinned: true, messageId: 900 });
+    floodTheUnpin = true;
+    await reconcile({ pinned: true, messageId: 901 });
+
+    expect(unpinCalls).toEqual([900]); // attempted…
+    expect(pinCalls).toEqual([900]); // …and the pin leg was correctly SKIPPED
+    expect(claims.get("fg:c:8")).toEqual({ messageId: 900 }); // claim retained
+    expect(loadStatusPins(PATH, fs)).toEqual([
+      { pinKey: "fg:c:8", chatId: "-100123", messageId: 900 },
     ]);
   });
 });

--- a/telegram-plugin/tests/status-pin.test.ts
+++ b/telegram-plugin/tests/status-pin.test.ts
@@ -37,9 +37,14 @@ describe('decidePinAction (pure)', () => {
     expect(action.kind).toBe('noop')
   })
 
-  it('unpins the stale claim when the wanted message id changed (feed re-posted)', () => {
+  it('RETARGETS (unpin old + pin new) when the wanted message id changed (surface re-posted)', () => {
+    // Regression: this used to report a bare `unpin`, on the assumption that a
+    // later reconcile would pin the new message. Single-shot callers (the
+    // foreground activity card, which reconciles only when a card OPENs) have
+    // no later reconcile, so the new card was left unpinned for the rest of
+    // the turn. The decision must carry BOTH message ids.
     const action = decidePinAction({ messageId: 42 }, { pinned: true, messageId: 99 })
-    expect(action).toEqual({ kind: 'unpin', messageId: 42 })
+    expect(action).toEqual({ kind: 'repin', unpinMessageId: 42, pinMessageId: 99 })
   })
 })
 
@@ -175,6 +180,127 @@ describe('reconcilePin (driver)', () => {
     const second = await reconcilePin({ ...common, prevState: first })
     expect(second).toBeNull() // flood window closed; unpin landed; claim cleared
     expect(attempts).toBe(2)
+  })
+
+  // ── Retarget (`repin`) — the single-shot-caller leak ──────────────────────
+  // The foreground activity card reconciles its `fg:` pin EXACTLY ONCE, when a
+  // card OPENs (narrative-lane.ts; the edit branch never touches the pin). When
+  // the ack-first reopen path (feed-reopen-gate.ts) nulls `activityMessageId`
+  // and a FRESH card opens mid-turn, that single reconcile must leave the NEW
+  // card pinned. Previously it emitted only an unpin and the turn ran on with
+  // nothing pinned.
+  it('RETARGET: one reconcile unpins the stale message AND pins the new one', async () => {
+    const { api, calls } = fakeApi()
+    const next = await reconcilePin({
+      api,
+      chatId: '123',
+      prevState: { messageId: 42 },
+      desired: { pinned: true, messageId: 99 },
+    })
+    expect(next).toEqual({ messageId: 99 })
+    expect(calls.map((c) => [c.verb, c.messageId])).toEqual([
+      ['unpin', 42],
+      ['pin', 99],
+    ])
+    // The new pin must still be silent.
+    expect((calls[1].opts as Record<string, unknown>).disable_notification).toBe(true)
+  })
+
+  it('RETARGET: a TERMINAL unpin failure still pins the new message', async () => {
+    // "message to unpin not found" means the old surface is already gone — the
+    // retarget must complete, not abort.
+    const calls: { verb: string; messageId: number }[] = []
+    const next = await reconcilePin({
+      api: {
+        pinChatMessage: async (_c, message_id) => {
+          calls.push({ verb: 'pin', messageId: message_id })
+        },
+        unpinChatMessage: async (_c, message_id) => {
+          calls.push({ verb: 'unpin', messageId: message_id })
+          throw grammyError(400, 'Bad Request: message to unpin not found')
+        },
+      },
+      chatId: '123',
+      prevState: { messageId: 42 },
+      desired: { pinned: true, messageId: 99 },
+    })
+    expect(next).toEqual({ messageId: 99 })
+    expect(calls).toEqual([
+      { verb: 'unpin', messageId: 42 },
+      { verb: 'pin', messageId: 99 },
+    ])
+  })
+
+  it('RETARGET: a NEVER-CONFIRMED unpin retains the OLD claim and does NOT pin the new one', async () => {
+    // The old message is provably still pinned (#3664 Defect B). Pinning the
+    // new one now would leave two pins in the chat with a durable record of
+    // only one — the exact orphan class the retain rule exists to prevent.
+    const calls: { verb: string; messageId: number }[] = []
+    const next = await reconcilePin({
+      api: {
+        pinChatMessage: async (_c, message_id) => {
+          calls.push({ verb: 'pin', messageId: message_id })
+        },
+        unpinChatMessage: async (_c, message_id) => {
+          calls.push({ verb: 'unpin', messageId: message_id })
+          throw makeFloodWaitActiveError(300, Date.now() + 300_000, null)
+        },
+      },
+      chatId: '123',
+      prevState: { messageId: 42 },
+      desired: { pinned: true, messageId: 99 },
+    })
+    expect(next).toEqual({ messageId: 42 })
+    expect(calls).toEqual([{ verb: 'unpin', messageId: 42 }])
+  })
+
+  it('RETARGET: a failed pin leg drops the claim (nothing is pinned, nothing is tracked)', async () => {
+    const calls: { verb: string; messageId: number }[] = []
+    const next = await reconcilePin({
+      api: {
+        pinChatMessage: async (_c, message_id) => {
+          calls.push({ verb: 'pin', messageId: message_id })
+          throw new Error('fetch failed')
+        },
+        unpinChatMessage: async (_c, message_id) => {
+          calls.push({ verb: 'unpin', messageId: message_id })
+        },
+      },
+      chatId: '123',
+      prevState: { messageId: 42 },
+      desired: { pinned: true, messageId: 99 },
+    })
+    // prevState for the pin leg is null (the unpin landed), so a failed pin
+    // returns null — no phantom claim on a message we never pinned.
+    expect(next).toBeNull()
+    expect(calls).toEqual([
+      { verb: 'unpin', messageId: 42 },
+      { verb: 'pin', messageId: 99 },
+    ])
+  })
+
+  it('RETARGET: a pin-rights-blocked chat makes NO API calls and drops the claim', async () => {
+    const calls: string[] = []
+    const cache = new PinRightsCache()
+    cache.block('123')
+    const next = await reconcilePin({
+      api: {
+        pinChatMessage: async () => {
+          calls.push('pin')
+        },
+        unpinChatMessage: async () => {
+          calls.push('unpin')
+        },
+      },
+      chatId: '123',
+      prevState: { messageId: 42 },
+      desired: { pinned: true, messageId: 99 },
+      rightsCache: cache,
+    })
+    expect(calls).toEqual([])
+    // unpin leg returns null (claim dropped, nothing worth tracking); the pin
+    // leg is skipped from a null prev and returns null too.
+    expect(next).toBeNull()
   })
 
   it('does NOT claim a message whose pin failed (retries next reconcile)', async () => {


### PR DESCRIPTION
## Summary

Three defects in the progress-card pin lifecycle, found by auditing it end-to-end (created → pinned → updated → finished/errored → unpinned → deleted) rather than by patching the reported symptom.

**D1 — a RETARGET never pinned the new card.** `decidePinAction` reported a bare `unpin` when the wanted message changed, documented as *"a subsequent desired-pin re-pins the new one on the next reconcile"*. That holds only for callers that re-drive the reconcile — the worker feed's `syncPin` does. The **foreground activity card does not**: `narrative-lane.ts:444` reconciles `fg:<statusKey>` exactly once, inside the `activityMessageId == null` OPEN branch (`narrative-lane.ts:387`); the edit branch never touches the pin and `turn-end.ts:262` only unpins. So when the ack-first path (`feed-reopen-gate.ts`) nulled `activityMessageId` mid-turn and a fresh card opened, that one reconcile unpinned the old card **and stopped** — the live card ran unpinned for the rest of the turn. Worse, the retarget mapped to a `clear` persist op, so the durable `status-pins.json` row was deleted too and neither the mid-session reaper nor the next boot's sweep had anything left to reconcile from.

**D2 — `shutdown()` never unpinned.** `sweepBeforeSelfRestart()` covered the gateway's own restart verbs, but SIGTERM/SIGINT — `docker restart`, `switchroom agent restart`, a compose bounce, a host reboot: the common path — reached `process.exit(0)` with every live pin still pinned, leaving it at the top of the chat until the *next* boot won the startup mutex and built a bot.

**D3 — the mid-session reaper had no single-flight guard.** The interval dispatched `void runMidSessionCardReaper()` every 5 minutes while the pass awaits real Telegram calls that retry with backoff and can park behind a flood-wait. Every tick during a stall started another concurrent pass.

## Why

`reference/jobs/know-what-my-agent-is-doing.md`: *"the framework silently pins the status message … and **auto-unpins it when that work completes**"*, and the #3001 restart rule — *"A stale pin glued to the top of the chat for hours is exactly the 'can't tell working from stuck' failure this job exists to prevent."* D1 breaks the pin during work; D2 and D3 break the unpin after it.

### What the evidence contradicted

The trigger for this audit was a report that unpinning is broken. The **historic** imbalance is real — 1227 pins vs 613 unpins on one agent — but its cause was #3664 Defect A (`undefined is not an object (evaluating 'lockedBot.api')` on every boot-cleanup unpin), **already fixed by #3675 and live in v0.19.25**. The post-fix window on the same agent is **98 pins / 98 unpins, balanced**, and live `status-pins.json` across the fleet is clean. So this PR does *not* re-fix that; it fixes three residual defects the audit turned up, one of which (D2) was independently confirmed by a live log line (`status-pin: cleared 1/1 orphaned pin(s) from a prior session` on a routine restart — i.e. the *next* boot was doing the unpinning).

Also checked and found **not** a bug: the trailing space in `wk:group:<chatId> ` is by design (`feedKey = ${chatId} ${threadId ?? ''}`, `worker-activity-feed.ts:669`), and the worker-pin reaper *is* registered and *does* fire in production (observed `worker-pin reaper unpinning wk:group:… reason=terminal source=store-orphan`).

## What changed

- `status-pin.ts` — `decidePinAction` returns a first-class `repin` action instead of a lossy bare `unpin`.
- `status-pin-driver.ts` — `reconcilePin` executes `repin` as both legs in one call, inheriting `#3664` Defect B semantics (a never-confirmed unpin aborts the pin leg and retains the old claim).
- **new** `gateway/status-pin-retarget.ts` — the gateway's orchestrator. A retarget runs as **two persisted legs**: leg 1 unpins while the durable row still names the OLD id (a crash there leaves a reapable record of a message that is genuinely still pinned — writing the new id first would erase it); leg 2 pins the new message from a null claim with its own persist-before-pin pending row. Also owns the `statusPinState`/`statusPinChatIds`/`statusPinPinnedAt` bookkeeping, committed per leg so a concurrent reader never sees a claim on an already-unpinned id.
- **new** `gateway/periodic-sweep-guard.ts` — single-flight wrapper; SKIP not queue (the reaper is a backstop with no deadline), and it absorbs throws so a fire-and-forget cosmetic sweep can never reach the crash-on-`unhandledRejection` handler.
- `gateway.ts` — `shutdown()` sweeps the pins after the drain and before `bot.api` goes away, **deadline-bounded (5s)** so a flood-wait-parked unpin can't push shutdown into the `forceExitTimer` path (which deliberately skips `releaseStartupLock`).

`gateway.ts` lands at **24917 lines — exactly the ratchet ceiling**; all new logic is in modules, none inline.

## Test plan

| suite | what it proves |
|---|---|
| `status-pin.test.ts` (+5) | `decidePinAction` returns `repin`; driver happy path, terminal unpin failure, never-confirmed unpin, failed pin leg, rights-blocked chat (zero API calls) |
| `status-pin-retarget.test.ts` (new, 9) | leg sequence + registry bookkeeping, `pinnedAt` re-stamped for the new card, never-confirmed unpin skips leg 2 and preserves the original TTL age |
| `periodic-sweep-guard.test.ts` (new, 6) | 10 ticks during a stall start **exactly one** pass; re-arms after settle; throwing pass and throwing observer both absorbed |
| `status-pin-shutdown-wiring.test.ts` (new, 7) | structural fences for all three wirings, incl. the deadline bound and the drain/`bot.api` ordering |
| `status-pin-store.test.ts` (+2) | RETARGET persist ordering, and the never-confirmed case keeping the OLD id in the durable row (no unreapable orphan) |

**These fail on the bug they guard**, verified by reverting the source:
- 4 `status-pin.test.ts` retarget cases: `Tests 4 failed | 32 passed` against unfixed `status-pin.ts` + `status-pin-driver.ts`.
- all 7 wiring fences: `Tests 7 failed (7)` against unfixed `gateway.ts`.

Scoped run (41 pin/reaper/narrative/turn-end/feed/shutdown suites): **492 passed**. `npm run lint`: clean, including `check-gateway-line-ratchet` and `check-bot-api-wrapping`. `status-pin-store.test.ts`'s retarget cases now drive the **real** `runStatusPinReconcile` rather than a hand-mirrored copy of the gateway's orchestration, so the suite cannot drift away from what ships.

<sub>The full local vitest run has 136 pre-existing failures in this worktree (missing `mdast-util-from-markdown` etc. and no `dist/` — a symlinked `node_modules`); verified identical counts with `gateway.ts` reverted to `HEAD~1`. CI is the authority.</sub>

## Risk

Medium-low. The change is confined to the status-pin path.

- **The retarget now issues a pin where it previously issued none.** By construction it only fires when the caller asked for a *different* message to be pinned, and the pin leg is skipped whenever the unpin was never confirmed — so it can never produce two simultaneous pins with a record of one.
- **`shutdown()` does new outbound work.** Wrapped in try/catch, deadline-bounded at 5s, and the pre-existing `forceExitTimer` remains the hard backstop. `bot.stop()` only stops polling, so `bot.api` is still usable there.
- **The reaper now skips overlapping ticks.** Strictly fewer API calls; the next tick is at most one interval away.

Reverting is a clean revert — no data-format change (`status-pins.json` rows are unchanged in shape).

## Follow-ups filed (low severity, not fixed here)

- #3809 — a `wk:` claim with a lost chatId is permanently unreapable mid-session
- #3810 — a `wk:<agentId>` store-orphan with no `turnsDb` row is never mid-session reaped
- #3811 — during a bridge flap the reaper can unpin a **live** worker-feed group pin
- #3812 — `clearActivitySummary` deletes the card but leaves the `fg:` claim naming a dead message

🤖 Generated with [Claude Code](https://claude.com/claude-code)