### PR TITLE
fix(ci): warm the BuildKit image before buildx boots it

### DIFF
--- a/.github/actions/setup-buildx/action.yml
+++ b/.github/actions/setup-buildx/action.yml
@@ -1,0 +1,45 @@
+name: setup-buildx
+description: |
+  `docker/setup-buildx-action` (docker-container driver) with the BuildKit
+  builder image warmed into the local image store first, behind a bounded
+  transient-only retry.
+
+  Use this ANYWHERE a job needs the docker-container driver. A job that
+  passes `driver: docker` boots no BuildKit container, has no docker.io
+  dependency, and should keep using `docker/setup-buildx-action` directly.
+
+  Rationale, the buildx source that makes the warm-up work, and the
+  measured failure rate live in `warm-buildkit-image.sh` and issue #3815.
+  Pinned by `tests/ci-buildx-warm-pull.test.ts`.
+
+inputs:
+  buildkit-image:
+    description: |
+      BuildKit builder image. Warmed by the pre-pull AND pinned through
+      `driver-opts: image=` so the two can never drift apart — a warm-pull
+      of a ref the driver does not boot is a silent no-op.
+
+      The default is buildx's own `bkimage.DefaultImage`
+      (driver/bkimage/bkimage.go), so this changes no behaviour beyond
+      making the ref explicit.
+    required: false
+    default: "moby/buildkit:buildx-stable-1"
+  warm-attempts:
+    description: Max warm-pull attempts before giving up (never fails the job).
+    required: false
+    default: "4"
+
+runs:
+  using: composite
+  steps:
+    - name: Warm the BuildKit builder image (bounded retry, issue #3815)
+      shell: bash
+      env:
+        BUILDKIT_IMAGE: ${{ inputs.buildkit-image }}
+        BUILDKIT_WARM_ATTEMPTS: ${{ inputs.warm-attempts }}
+      run: bash "${{ github.action_path }}/warm-buildkit-image.sh"
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+      with:
+        driver-opts: image=${{ inputs.buildkit-image }}

--- a/.github/actions/setup-buildx/warm-buildkit-image.sh
+++ b/.github/actions/setup-buildx/warm-buildkit-image.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# Warm the BuildKit builder image into the runner's LOCAL image store
+# before `docker/setup-buildx-action` boots a builder.
+#
+# Why this exists (issue #3815):
+#
+#   `docker/setup-buildx-action`'s default `docker-container` driver boots
+#   BuildKit by pulling `moby/buildkit:buildx-stable-1` from DOCKER HUB.
+#   That pull is unauthenticated, un-retried, and happens before any
+#   `docker/login-action` step. When docker.io is slow the job dies with
+#
+#     #1 [internal] booting buildkit
+#     #1 ERROR: Error response from daemon:
+#        Get "https://registry-1.docker.io/v2/": ... Client.Timeout exceeded
+#
+#   before it has built anything. It killed 19 of the 21 failed image jobs
+#   between 2026-07-16 and 2026-07-27 and ejected four PRs from the merge
+#   queue.
+#
+# Two layers of protection, both load-bearing:
+#
+#   1. This script retries the pull with bounded exponential backoff and
+#      jitter, so a transient docker.io blip usually just costs a few
+#      seconds. Jitter matters: a `docker-images` run fans out to ~13
+#      buildx-booting jobs that all start within seconds of each other.
+#
+#   2. Even if every attempt here fails, buildx's own boot-time pull now
+#      has somewhere to fall back to ONLY if we succeeded — see
+#      buildx v0.35.0 `driver/docker-container/driver.go:108-116`:
+#
+#          // image pulling failed, check if it exists in local image store.
+#          // if not, return pulling error. otherwise log it.
+#          _, errInspect := d.DockerAPI.ImageInspect(ctx, imageName)
+#          found := errInspect == nil
+#          if !found { return err }
+#          l.Wrap("pulling failed, using local image "+imageName, ...)
+#
+#      The fallback has always existed; nothing ever populated the local
+#      store, so `ImageInspect` missed and the pull error was fatal. That
+#      is why "warm the store" — not "retry the boot" — is the fix.
+#
+# HARD RULES:
+#
+#   * This script NEVER fails the job. It is an optimisation in front of
+#     `docker/setup-buildx-action`, which remains the authority on whether
+#     a builder could be created. Exiting non-zero here would turn a
+#     recoverable warm-pull miss into a NEW failure mode. It always
+#     `exit 0`; every give-up path is annotated so it is visible in the
+#     run summary.
+#
+#   * It retries ONLY on recognised transient network/registry errors.
+#     A non-transient error (bad pin, auth, dead daemon) breaks out on the
+#     first attempt. This is what stops the retry from becoming a blanket
+#     "run it again until it works" — and note that the only thing being
+#     retried is a pull of the BUILDER image, which happens before any
+#     Dockerfile is read, so it cannot mask a genuine build failure.
+#
+# Environment:
+#   BUILDKIT_IMAGE             required — image ref to warm
+#   BUILDKIT_WARM_ATTEMPTS     max pull attempts       (default 4)
+#   BUILDKIT_WARM_BASE_DELAY   backoff base in seconds (default 5; 0 disables sleep)
+#   DOCKER_BIN                 docker command          (default "docker")
+
+set -uo pipefail
+
+IMAGE="${BUILDKIT_IMAGE:-}"
+ATTEMPTS="${BUILDKIT_WARM_ATTEMPTS:-4}"
+BASE_DELAY="${BUILDKIT_WARM_BASE_DELAY:-5}"
+DOCKER_BIN="${DOCKER_BIN:-docker}"
+
+if [ -z "$IMAGE" ]; then
+  echo "::warning title=BuildKit warm-pull skipped::BUILDKIT_IMAGE is empty"
+  exit 0
+fi
+
+# Recognised transient failures — retry these.
+TRANSIENT='Client\.Timeout|context deadline exceeded|request canceled|i/o timeout|TLS handshake timeout|connection reset by peer|connection refused|no such host|network is unreachable|dial tcp|temporary failure|unexpected EOF|toomanyrequests|Too Many Requests|received unexpected HTTP status: 5|50[0234] '
+
+# Recognised permanent failures — never retry these. A bad pin or a dead
+# daemon will not fix itself, and retrying only delays the real error that
+# setup-buildx-action is about to report.
+#
+# Deliberately NARROW. Bare `denied` / `unauthorized` / `not found` would
+# swallow Docker Hub's rate-limit and 404-from-a-flaky-CDN responses, which
+# ARE worth retrying — this list is checked first, so an over-broad entry
+# here silently disables the retry for the case it exists to handle.
+FATAL='manifest unknown|manifest for .* not found|repository does not exist|pull access denied|unauthorized:|denied:|invalid reference format|Cannot connect to the Docker daemon'
+
+if "$DOCKER_BIN" image inspect "$IMAGE" >/dev/null 2>&1; then
+  echo "warm-buildkit-image: $IMAGE already in the local image store — nothing to do."
+  exit 0
+fi
+
+out=""
+attempt=1
+while [ "$attempt" -le "$ATTEMPTS" ]; do
+  echo "warm-buildkit-image: $DOCKER_BIN pull $IMAGE (attempt ${attempt}/${ATTEMPTS})"
+
+  if out=$("$DOCKER_BIN" pull "$IMAGE" 2>&1); then
+    printf '%s\n' "$out"
+    if [ "$attempt" -gt 1 ]; then
+      echo "::notice title=BuildKit warm-pull recovered::${IMAGE} pulled on attempt ${attempt}/${ATTEMPTS} after transient registry errors (issue #3815)"
+    fi
+    exit 0
+  fi
+
+  printf '%s\n' "$out"
+
+  if printf '%s' "$out" | grep -Eqi -- "$FATAL"; then
+    echo "::warning title=BuildKit warm-pull failed (not transient)::${IMAGE} — not retrying; letting docker/setup-buildx-action report the real error"
+    exit 0
+  fi
+
+  if ! printf '%s' "$out" | grep -Eqi -- "$TRANSIENT"; then
+    echo "::warning title=BuildKit warm-pull failed (unrecognised error)::${IMAGE} — not retrying; letting docker/setup-buildx-action report the real error"
+    exit 0
+  fi
+
+  if [ "$attempt" -eq "$ATTEMPTS" ]; then
+    break
+  fi
+
+  delay=$(( BASE_DELAY * (1 << (attempt - 1)) ))
+  if [ "$delay" -gt 0 ]; then
+    delay=$(( delay + RANDOM % 5 ))
+  fi
+  echo "::notice title=BuildKit warm-pull retry::transient registry error pulling ${IMAGE}; retrying in ${delay}s (attempt ${attempt}/${ATTEMPTS}, issue #3815)"
+  [ "$delay" -gt 0 ] && sleep "$delay"
+  attempt=$(( attempt + 1 ))
+done
+
+echo "::warning title=BuildKit warm-pull exhausted::${IMAGE} could not be pulled in ${ATTEMPTS} attempts (transient registry errors). docker/setup-buildx-action will try once more and fail loudly if Docker Hub is still unreachable. See issue #3815."
+exit 0

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -249,7 +249,13 @@ jobs:
         run: npm run build
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+        # Composite action, NOT docker/setup-buildx-action directly (#3815) —
+        # this job uses the docker-container driver, which boots BuildKit by
+        # pulling moby/buildkit from Docker Hub before the login below ever
+        # runs. The composite warms that image into the local image store
+        # behind a bounded, transient-only retry first.
+        # Enforced by tests/ci-buildx-warm-pull.test.ts.
+        uses: ./.github/actions/setup-buildx
 
       - name: Log in to GHCR (cache-from + BASE_IMAGE pulls only)
         uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7  # v4.5.1

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -207,7 +207,18 @@ jobs:
         run: npm run build
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+        # Composite action, NOT docker/setup-buildx-action directly (#3815).
+        # The docker-container driver boots BuildKit by pulling
+        # `moby/buildkit:buildx-stable-1` from DOCKER HUB — unauthenticated,
+        # un-retried, and before the GHCR login step below ever runs. 19 of
+        # the 21 failed image jobs between 2026-07-16 and 2026-07-27 died
+        # exactly there, reddening the required `images-ok` sentinel and
+        # ejecting four PRs from the merge queue. The composite warms that
+        # image into the runner's local image store behind a bounded,
+        # transient-only retry first, which also arms buildx's own
+        # "pulling failed, using local image" fallback.
+        # Enforced by tests/ci-buildx-warm-pull.test.ts.
+        uses: ./.github/actions/setup-buildx
 
       - name: Log in to GHCR (push only on main / tags)
         # merge_group excluded: a queue run is validation-only and pushes
@@ -436,7 +447,18 @@ jobs:
         run: npm run build
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+        # Composite action, NOT docker/setup-buildx-action directly (#3815).
+        # The docker-container driver boots BuildKit by pulling
+        # `moby/buildkit:buildx-stable-1` from DOCKER HUB — unauthenticated,
+        # un-retried, and before the GHCR login step below ever runs. 19 of
+        # the 21 failed image jobs between 2026-07-16 and 2026-07-27 died
+        # exactly there, reddening the required `images-ok` sentinel and
+        # ejecting four PRs from the merge queue. The composite warms that
+        # image into the runner's local image store behind a bounded,
+        # transient-only retry first, which also arms buildx's own
+        # "pulling failed, using local image" fallback.
+        # Enforced by tests/ci-buildx-warm-pull.test.ts.
+        uses: ./.github/actions/setup-buildx
 
       - name: Log in to GHCR (push only on main / tags)
         # merge_group excluded: a queue run is validation-only and pushes
@@ -590,7 +612,18 @@ jobs:
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+        # Composite action, NOT docker/setup-buildx-action directly (#3815).
+        # The docker-container driver boots BuildKit by pulling
+        # `moby/buildkit:buildx-stable-1` from DOCKER HUB — unauthenticated,
+        # un-retried, and before the GHCR login step below ever runs. 19 of
+        # the 21 failed image jobs between 2026-07-16 and 2026-07-27 died
+        # exactly there, reddening the required `images-ok` sentinel and
+        # ejecting four PRs from the merge queue. The composite warms that
+        # image into the runner's local image store behind a bounded,
+        # transient-only retry first, which also arms buildx's own
+        # "pulling failed, using local image" fallback.
+        # Enforced by tests/ci-buildx-warm-pull.test.ts.
+        uses: ./.github/actions/setup-buildx
 
       - name: Log in to GHCR (push only on main / tags)
         # merge_group excluded: a queue run is validation-only and pushes
@@ -691,7 +724,18 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+        # Composite action, NOT docker/setup-buildx-action directly (#3815).
+        # The docker-container driver boots BuildKit by pulling
+        # `moby/buildkit:buildx-stable-1` from DOCKER HUB — unauthenticated,
+        # un-retried, and before the GHCR login step below ever runs. 19 of
+        # the 21 failed image jobs between 2026-07-16 and 2026-07-27 died
+        # exactly there, reddening the required `images-ok` sentinel and
+        # ejecting four PRs from the merge queue. The composite warms that
+        # image into the runner's local image store behind a bounded,
+        # transient-only retry first, which also arms buildx's own
+        # "pulling failed, using local image" fallback.
+        # Enforced by tests/ci-buildx-warm-pull.test.ts.
+        uses: ./.github/actions/setup-buildx
 
       - name: Log in to GHCR (push only on main / tags)
         # merge_group excluded: a queue run is validation-only and pushes

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ switchroom-checksums.txt
 
 # Synology NAS thumbnail artifacts
 @eaDir/
+
+# Scratch dir for tests/ci-buildx-warm-pull.test.ts when /tmp is noexec.
+.buildx-warm-test-*/

--- a/tests/ci-buildx-warm-pull.test.ts
+++ b/tests/ci-buildx-warm-pull.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Guard: every workflow job that boots a BuildKit CONTAINER must go through
+ * `.github/actions/setup-buildx`, which warms the builder image with a
+ * bounded, transient-only retry first (issue #3815).
+ *
+ * Why: `docker/setup-buildx-action`'s default `docker-container` driver
+ * pulls `moby/buildkit:buildx-stable-1` from DOCKER HUB to boot BuildKit —
+ * unauthenticated, un-retried, and before any `docker/login-action` step.
+ * Measured over 14,269 completed `docker-images` jobs (2026-07-16 →
+ * 2026-07-27), **19 of the 21 failed build/manifest jobs** were that pull
+ * timing out. It reds the required `images-ok` sentinel and ejected four
+ * PRs (#3693, #3728, #3759, #3813) from the merge queue in two days.
+ *
+ * This is the sibling of `tests/docker/manifest-jobs-no-buildx.test.ts`,
+ * which covers the other half: jobs that never needed a builder at all.
+ * That one says "drop the step"; this one says "if you genuinely need the
+ * docker-container driver, warm the image first".
+ *
+ * Two kinds of assertion here, deliberately:
+ *
+ *   1. Structural — no job may reference `docker/setup-buildx-action`
+ *      directly unless it opts out of the container driver with
+ *      `driver: docker`.
+ *   2. Behavioural — the retry script is EXECUTED against a stub docker
+ *      so the tests fail on the bug they guard: a blanket retry that
+ *      hammers a permanent error, a retry that never fires, or a
+ *      warm-pull that fails the job.
+ */
+
+import { describe, it, expect, afterAll } from 'vitest'
+import { readFileSync, mkdtempSync, writeFileSync, rmSync, chmodSync, existsSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { parse } from 'yaml'
+
+const REPO = resolve(import.meta.dirname, '..')
+const WORKFLOW_DIR = join(REPO, '.github/workflows')
+const ACTION_DIR = join(REPO, '.github/actions/setup-buildx')
+const WARM_SCRIPT = join(ACTION_DIR, 'warm-buildkit-image.sh')
+
+const LOCAL_ACTION = './.github/actions/setup-buildx'
+const UPSTREAM_ACTION = 'docker/setup-buildx-action'
+
+const WORKFLOWS = [
+  'docker-images.yml',
+  'ci-full.yml',
+  'docker-e2e.yml',
+  'promote.yml',
+  'release.yml',
+  'npm-publish.yml',
+  'ci-lint.yml',
+  'ci-tests-core.yml',
+  'ci-tests-plugin.yml',
+  'ci-tests-python.yml',
+  'ci-tests-race-long.yml',
+  'ci-uat.yml',
+  'ci-evals.yml',
+  'ci-infra-watchdog.yml',
+  'ci-claude-latest-canary.yml',
+]
+
+interface Step {
+  uses?: string
+  name?: string
+  with?: Record<string, unknown>
+}
+interface Job {
+  steps?: Step[]
+}
+
+function loadJobs(file: string): Array<[string, Job]> {
+  const raw = readFileSync(join(WORKFLOW_DIR, file), 'utf8')
+  const doc = parse(raw) as { jobs?: Record<string, Job> }
+  return Object.entries(doc.jobs ?? {})
+}
+
+const allJobs = WORKFLOWS.filter((f) => existsSync(join(WORKFLOW_DIR, f))).flatMap((file) =>
+  loadJobs(file).map(([name, job]) => ({ file, name, job, steps: job.steps ?? [] })),
+)
+
+describe('buildx warm-pull guard (#3815)', () => {
+  it('the workflow inventory this test scans actually matches the repo', () => {
+    // Sanity floor: if a workflow is added and not listed above, this test
+    // would silently stop covering it. Cheap to keep honest.
+    expect(allJobs.length).toBeGreaterThan(20)
+    expect(WORKFLOWS.filter((f) => !existsSync(join(WORKFLOW_DIR, f)))).toEqual([])
+  })
+
+  it('no job uses docker/setup-buildx-action directly with the container driver', () => {
+    const offenders: string[] = []
+    for (const { file, name, steps } of allJobs) {
+      for (const step of steps) {
+        if (!(step.uses ?? '').startsWith(UPSTREAM_ACTION)) continue
+        // `driver: docker` boots no BuildKit container, so it has no
+        // docker.io dependency and is legitimately exempt.
+        if ((step.with?.driver ?? '') === 'docker') continue
+        offenders.push(`${file}:${name}`)
+      }
+    }
+    expect(
+      offenders,
+      `job(s) [${offenders.join(', ')}] use ${UPSTREAM_ACTION} with the default ` +
+        `docker-container driver. That boots BuildKit by pulling moby/buildkit ` +
+        `from Docker Hub, un-retried and before any login step — the #3815 flake ` +
+        `(19 of 21 image-job failures, 4 merge-queue ejections). Use ` +
+        `${LOCAL_ACTION} instead, or pass \`driver: docker\` if this job does ` +
+        `not actually need a BuildKit container.`,
+    ).toEqual([])
+  })
+
+  it('the jobs that build images do go through the warm-pull action', () => {
+    // Pins the positive set so the rule above cannot pass vacuously by
+    // everyone simply dropping buildx.
+    const viaLocal = allJobs
+      .filter(({ steps }) => steps.some((s) => (s.uses ?? '') === LOCAL_ACTION))
+      .map(({ file, name }) => `${file}:${name}`)
+      .sort()
+    expect(viaLocal).toEqual([
+      'ci-full.yml:docker-images-build',
+      'docker-images.yml:build-base',
+      'docker-images.yml:build-dependents',
+      'docker-images.yml:build-hindsight',
+      'docker-images.yml:build-voice',
+    ])
+  })
+
+  it('the warmed ref and the ref the driver boots are the same string', () => {
+    // A warm-pull of a ref the driver does not boot is a silent no-op:
+    // `ImageInspect` would miss and the docker.io pull would be fatal
+    // again. Pinning `driver-opts: image=` to the same input is what makes
+    // the two impossible to drift apart — assert the wiring survives.
+    const action = parse(readFileSync(join(ACTION_DIR, 'action.yml'), 'utf8')) as {
+      inputs: Record<string, { default?: string }>
+      runs: { steps: Step[] }
+    }
+    const defaultRef = action.inputs['buildkit-image'].default
+    expect(defaultRef).toBe('moby/buildkit:buildx-stable-1') // buildx bkimage.DefaultImage
+
+    const buildxStep = action.runs.steps.find((s) => (s.uses ?? '').startsWith(UPSTREAM_ACTION))
+    expect(buildxStep, 'the composite must still call setup-buildx-action').toBeTruthy()
+    expect(buildxStep!.with?.['driver-opts']).toBe('image=${{ inputs.buildkit-image }}')
+
+    const warmStep = action.runs.steps[0] as Step & { env?: Record<string, string> }
+    expect(warmStep.env?.BUILDKIT_IMAGE).toBe('${{ inputs.buildkit-image }}')
+  })
+})
+
+/**
+ * These tests need to EXECUTE a stub `docker`, and this repo's dev hosts
+ * (and agent containers) commonly mount /tmp `noexec` — see CLAUDE.md
+ * "Local env noise vs real failures". Probe once and fall back to a
+ * scratch dir inside the worktree so the suite is honest everywhere
+ * instead of failing for an unrelated reason.
+ */
+function execCapableBase(): string {
+  const candidate = mkdtempSync(join(tmpdir(), 'buildx-warm-'))
+  const probe = join(candidate, 'probe.sh')
+  writeFileSync(probe, '#!/usr/bin/env bash\nexit 0\n', { mode: 0o755 })
+  chmodSync(probe, 0o755)
+  try {
+    execFileSync(probe, { stdio: 'ignore' })
+    return candidate
+  } catch {
+    rmSync(candidate, { recursive: true, force: true })
+    return mkdtempSync(join(REPO, '.buildx-warm-test-'))
+  }
+}
+
+describe('warm-buildkit-image.sh behaviour (#3815)', () => {
+  const tmp = execCapableBase()
+  afterAll(() => rmSync(tmp, { recursive: true, force: true }))
+
+  /**
+   * Runs the real script against a stub `docker` whose `pull` fails
+   * `failures` times with `stderr`, then succeeds (unless `alwaysFail`).
+   * `image inspect` always misses, i.e. the image is not warm yet.
+   */
+  function run(opts: {
+    stderr: string
+    failures: number
+    alwaysFail?: boolean
+    attempts?: number
+    inspectHit?: boolean
+  }) {
+    const dir = mkdtempSync(join(tmp, 'case-'))
+    const counter = join(dir, 'pulls')
+    const stub = join(dir, 'docker')
+    writeFileSync(
+      stub,
+      [
+        '#!/usr/bin/env bash',
+        `if [ "$1" = "image" ] && [ "$2" = "inspect" ]; then exit ${opts.inspectHit ? 0 : 1}; fi`,
+        `if [ "$1" = "pull" ]; then`,
+        `  echo x >> "${counter}"`,
+        `  n=$(wc -l < "${counter}")`,
+        `  if [ "${opts.alwaysFail ? 1 : 0}" = "1" ] || [ "$n" -le ${opts.failures} ]; then`,
+        `    printf '%s\\n' ${JSON.stringify(opts.stderr)} >&2`,
+        '    exit 1',
+        '  fi',
+        '  echo "Status: Downloaded newer image"',
+        '  exit 0',
+        'fi',
+        'exit 0',
+      ].join('\n'),
+      { mode: 0o755 },
+    )
+    chmodSync(stub, 0o755)
+    writeFileSync(counter, '')
+
+    const res = execFileSync('bash', [WARM_SCRIPT], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${dir}:${process.env.PATH}`,
+        DOCKER_BIN: stub,
+        BUILDKIT_IMAGE: 'moby/buildkit:buildx-stable-1',
+        BUILDKIT_WARM_ATTEMPTS: String(opts.attempts ?? 4),
+        // No sleeping in tests. The script skips the sleep entirely at 0.
+        BUILDKIT_WARM_BASE_DELAY: '0',
+      },
+    })
+    const pulls = readFileSync(counter, 'utf8').trim() === '' ? 0 : readFileSync(counter, 'utf8').trim().split('\n').length
+    return { out: res, pulls }
+  }
+
+  const TIMEOUT_ERR =
+    'Error response from daemon: Get "https://registry-1.docker.io/v2/": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)'
+
+  it('retries the exact production error and succeeds without failing the job', () => {
+    // The literal error from run 30261146638 / job 89961204337.
+    const { out, pulls } = run({ stderr: TIMEOUT_ERR, failures: 2 })
+    expect(pulls).toBe(3)
+    expect(out).toContain('BuildKit warm-pull recovered')
+  })
+
+  it('retries "context deadline exceeded" too (run 30244997098 shape)', () => {
+    const { pulls } = run({
+      stderr: 'Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded',
+      failures: 1,
+    })
+    expect(pulls).toBe(2)
+  })
+
+  it('retries a Docker Hub rate limit — it is not misfiled as permanent', () => {
+    // 429 is the other real docker.io failure mode and it clears on its
+    // own. It must not be swallowed by an over-broad "denied"/"unauthorized"
+    // entry in the fatal list.
+    const { pulls } = run({
+      stderr:
+        'toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading',
+      failures: 1,
+    })
+    expect(pulls).toBe(2)
+  })
+
+  it('is bounded — it does not retry forever when Docker Hub stays down', () => {
+    const { out, pulls } = run({ stderr: TIMEOUT_ERR, failures: 0, alwaysFail: true, attempts: 3 })
+    expect(pulls).toBe(3)
+    expect(out).toContain('BuildKit warm-pull exhausted')
+  })
+
+  it('does NOT retry a permanent error — the retry is transient-only', () => {
+    // This is the assertion that fails if someone "simplifies" the script
+    // into a blanket retry loop. A bad pin must surface immediately, not
+    // after N pointless round trips.
+    const { out, pulls } = run({
+      stderr: 'Error response from daemon: manifest unknown',
+      failures: 0,
+      alwaysFail: true,
+    })
+    expect(pulls).toBe(1)
+    expect(out).toContain('not transient')
+  })
+
+  it('does NOT retry an unrecognised error', () => {
+    const { pulls } = run({ stderr: 'something nobody has ever seen', failures: 0, alwaysFail: true })
+    expect(pulls).toBe(1)
+  })
+
+  it('never fails the job on any give-up path', () => {
+    // execFileSync throws on a non-zero exit, so reaching these lines at
+    // all is the assertion: the warm-pull is an optimisation in front of
+    // setup-buildx-action and must never become a NEW failure mode.
+    expect(() => run({ stderr: TIMEOUT_ERR, failures: 0, alwaysFail: true, attempts: 2 })).not.toThrow()
+    expect(() => run({ stderr: 'manifest unknown', failures: 0, alwaysFail: true })).not.toThrow()
+  })
+
+  it('skips the pull entirely when the image is already warm', () => {
+    const { out, pulls } = run({ stderr: TIMEOUT_ERR, failures: 0, inspectHit: true })
+    expect(pulls).toBe(0)
+    expect(out).toContain('already in the local image store')
+  })
+})

--- a/tests/docker/manifest-jobs-no-buildx.test.ts
+++ b/tests/docker/manifest-jobs-no-buildx.test.ts
@@ -33,6 +33,10 @@ const WORKFLOWS = ['docker-images.yml', 'promote.yml']
 
 const BUILDX_ACTION = 'docker/setup-buildx-action'
 const BUILD_ACTION = 'docker/build-push-action'
+// Real build jobs now reach setup-buildx-action THROUGH this composite,
+// which warms the BuildKit image with a bounded retry first (#3815). For
+// this file's purposes it is the same thing: a job that sets up a builder.
+const LOCAL_BUILDX_ACTION = './.github/actions/setup-buildx'
 
 interface Step {
   uses?: string
@@ -61,8 +65,16 @@ function isManifestOnly(job: Job): boolean {
   return usesImagetools && !buildsImages
 }
 
+/** Direct reference — what a manifest-only job must never do. */
 function usesBuildx(job: Job): boolean {
   return stepsOf(job).some((s) => (s.uses ?? '').includes(BUILDX_ACTION))
+}
+
+/** Direct OR via the warm-pull composite — "this job sets up a builder". */
+function setsUpBuilder(job: Job): boolean {
+  return stepsOf(job).some(
+    (s) => (s.uses ?? '').includes(BUILDX_ACTION) || (s.uses ?? '') === LOCAL_BUILDX_ACTION,
+  )
 }
 
 describe('manifest-only workflow jobs never set up buildx (no docker.io dependency)', () => {
@@ -109,7 +121,10 @@ describe('manifest-only workflow jobs never set up buildx (no docker.io dependen
     expect(builders.length).toBeGreaterThan(0)
     for (const name of builders) {
       const job = all.find((j) => j.name === name)!.job
-      expect(usesBuildx(job), `build job ${name} must still set up buildx`).toBe(true)
+      expect(
+        setsUpBuilder(job),
+        `build job ${name} must still set up buildx (directly or via ${LOCAL_BUILDX_ACTION})`,
+      ).toBe(true)
     }
   })
 })


### PR DESCRIPTION
Closes #3815.

## Summary

Every `docker-images` build job boots BuildKit through
`docker/setup-buildx-action`'s default `docker-container` driver, which
pulls `moby/buildkit:buildx-stable-1` from **Docker Hub** — unauthenticated,
un-retried, and *before* the `docker/login-action` step (which is a GHCR
login anyway). When docker.io is slow the job dies under
`[internal] booting buildkit` before it has read a Dockerfile, and since
`build-base` / `build-dependents` / `build-hindsight` / `build-voice` are
`needs:` of the required `images-ok` sentinel, that reds a required check.
On a `merge_group` ref it ejects the PR from the queue.

This adds a `.github/actions/setup-buildx` composite that **warms the
builder image into the runner's local image store behind a bounded,
transient-only retry** before handing off to `setup-buildx-action`, and
pins the same ref through `driver-opts: image=` so the warmed ref and the
booted ref cannot drift apart.

Five call sites move to it (`docker-images.yml` build-base / build-dependents
/ build-hindsight / build-voice, `ci-full.yml` docker-images-build).
`ci-full.yml:169` and `docker-e2e.yml:179` are untouched — they already pass
`driver: docker`, boot no BuildKit container, and have no docker.io
dependency.

This is the other half of the fix already in the tree for manifest-only jobs
(`tests/docker/manifest-jobs-no-buildx.test.ts`). That one said "you never
needed a builder, drop the step". This one says "you genuinely need the
container driver, so warm the image first".

## Why

Measured, not guessed. `gh api --paginate` over
`docker-images.yml/runs?created=>=2026-07-13` → 1000 runs (GitHub's
pagination cap), window **2026-07-16T11:39Z → 2026-07-27T11:30Z**; then
`.../runs/<id>/jobs?filter=all` for each (`filter=all` matters — it includes
superseded attempts, so re-run-to-green failures are not silently dropped)
→ **14,269 completed jobs**; then the raw log for every failed
build/manifest job, classified on `booting buildkit` + `registry-1.docker.io`.

- **19 of the 21 failed build/manifest jobs in the window are this flake.**
  The other two: one real `smoke-test` failure, one expired log.
- Zero occurrences before 2026-07-23; **3.7% of the 487 concluded runs
  since** (18 runs).
- **4 merge-queue ejections in two days** — #3693, #3728, #3759, #3813 —
  every one a PR whose own checks were green.
- All 19 on amd64 / `ubuntu-latest`; zero on the `ubuntu-24.04-arm` legs.

## Root cause

buildx v0.35.0
[`driver/docker-container/driver.go:89-116`](https://github.com/docker/buildx/blob/v0.35.0/driver/docker-container/driver.go#L89-L116)
unconditionally `ImagePull`s `bkimage.DefaultImage`
(= `moby/buildkit:buildx-stable-1`). Crucially, lines 108-116:

```go
// image pulling failed, check if it exists in local image store.
// if not, return pulling error. otherwise log it.
_, errInspect := d.DockerAPI.ImageInspect(ctx, imageName)
found := errInspect == nil
if !found { return err }
l.Wrap("pulling failed, using local image "+imageName, ...)
```

The offline fallback has always existed. Nothing ever populated the local
store, so `ImageInspect` missed and the pull error was fatal. That is why
the durable fix is "warm the store", not "retry the boot".

Call sites: `docker-images.yml:210, :439, :593, :694`; `ci-full.yml:252`
(pre-diff line numbers).

## What I verified empirically vs. reasoned about

**Verified live** (on the dev host, with `docker buildx`, cleaned up after):

Tagged the warmed image to an unreachable registry ref so the pull is
guaranteed to fail — an exact stand-in for "Docker Hub is down":

```
# warmed into the local store:
#1 pulling image localhost:1/sr3815-unreachable:v1 0.0s done
#1 pulling failed, using local image localhost:1/sr3815-unreachable:v1 done
#1 creating container buildx_buildkit_sr3815-verify0 0.7s done   → Status: running

# negative control, NOT warmed — reproduces the production failure exactly:
#1 ERROR: Error response from daemon: failed to resolve reference ... connection refused
```

So both halves are proven: `driver-opt image=` is honoured, and the
local-store fallback boots a working builder when the registry is
unreachable.

**Verified locally:** `tests/ci-buildx-warm-pull.test.ts` (12 tests) and
`tests/docker/manifest-jobs-no-buildx.test.ts` green; `tsc --noEmit` clean;
all 15 lint guard scripts exit 0. (`check-plugin-references` fails
identically on pristine `origin/main` in this worktree — `@mtcute/node` and
`mdast-*` are absent from the symlinked `node_modules`. Bucket-3
environment artifact, CI installs properly.)

**NOT verified before merge, and cannot be:** that the retry actually fires
against real Docker Hub on a real hosted runner. Workflow changes only prove
themselves on the runner. What CI on this PR does prove is that the composite
resolves, the warm step runs, and the builds still succeed through it. The
retry path itself will first be exercised the next time docker.io is slow —
and it is annotated (`::notice title=BuildKit warm-pull retry::`) so it is
visible in the run summary when it happens.

## Safety — this cannot mask a build failure

- The only thing retried is a `docker pull` of the **builder** image. It
  happens before any Dockerfile is read, so there is no build outcome to
  mask.
- The retry is **transient-only**: `manifest unknown`, `pull access denied`,
  `unauthorized:`, `invalid reference format`, dead daemon → break on the
  first attempt. Unrecognised errors also do not retry.
- The fatal list is deliberately narrow — bare `denied` / `unauthorized` /
  `not found` would swallow a 429 rate limit, which *is* worth retrying.
  There is a test for that.
- The script **never fails the job** (`exit 0` on every path).
  `setup-buildx-action` stays the authority on whether a builder exists, so
  the warm-pull cannot become a *new* failure mode. Worst case it is a no-op
  and behaviour is exactly what it is today.

## Test plan

`tests/ci-buildx-warm-pull.test.ts` — the behavioural half **executes the
real script** against a stub `docker`, so it fails on the bugs it guards:

- retries the two literal production errors (`Client.Timeout exceeded`,
  `context deadline exceeded`) and a `toomanyrequests` 429
- does **not** retry `manifest unknown` — pull count must be exactly 1
  (this is what fails if someone "simplifies" it into a blanket retry)
- is bounded; never exits non-zero on any give-up path
- skips the pull entirely when the image is already warm

Structural half: no job may use `docker/setup-buildx-action` directly with
the container driver; the five builder jobs are pinned by name; and the
warm-pull ref, the `buildkit-image` default and the `driver-opts: image=`
value must be the same string (a warm-pull of a ref the driver does not boot
is a silent no-op).

Enforcement note, honestly stated: like `tests/ci-merge-queue-triggers.test.ts`,
this is a `readFileSync` guard, so `vitest --changed` cannot select it from a
YAML-only edit on a PR. It runs in the **full suite on `merge_group` and
push-to-main**, which is still pre-merge and gating.

## Alternatives rejected

- **Blanket job-level retry** — masks real build failures. Non-starter.
- **Authenticate to Docker Hub** — no `DOCKERHUB_*` secret exists in this
  repo, and the failure is a TCP/TLS connection timeout, not HTTP 429. Auth
  does not fix a connection that never returns headers.
- **Mirror `moby/buildkit` to GHCR** — genuinely removes docker.io from the
  critical path, but needs a new package, a scheduled sync workflow, and
  staleness monitoring. Worth revisiting if this proves insufficient; the
  composite's `buildkit-image` input is the seam to do it through.
- **`registry-mirrors` in `/etc/docker/daemon.json`** — needs a dockerd
  restart in every job and points the fix at a third-party pull-through
  cache we do not control.

## Deliberately not fixed here

`docker/setup-qemu-action` in `build-hindsight` pulls
`tonistiigi/binfmt:latest` from Docker Hub — the same class of dependency.
Zero measured occurrences in the window, so it is filed as a follow-up
rather than expanded into this PR.

## Risk

Low. No Dockerfile or image content changes. The added `driver-opts:
image=moby/buildkit:buildx-stable-1` is buildx's own default made explicit.
Worst case the warm pull is a no-op.
