### PR TITLE
fix(profiles): pin sub-agent spawn depth + concurrency, and test both

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,7 +424,10 @@ fragment. It binds work on THIS repo too — the five parts, condensed:
    behavior; tests assert outcomes, not just code paths.
 5. **Communicate.** Consolidated messages, always-visible progress, no
    foreground watches over 30s (background + notification), max 15 parallel
-   sub-agents.
+   sub-agents — enforced, not merely advised: `start.sh` /
+   `cron-session.sh` export `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS=15`
+   (below the CLI's own default of 20). Change that export and the
+   dev-protocol prose together.
 
 ## Docker test discipline (HARD RULES)
 

--- a/profiles/_base/cron-session.sh.hbs
+++ b/profiles/_base/cron-session.sh.hbs
@@ -74,6 +74,12 @@ export CLAUDE_CONFIG_DIR="$CRON_CONFIG_DIR"
 # (honouring any value already in the env). See start.sh.hbs for rationale.
 export CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH="${CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH:-2}"
 
+# Pin sub-agent fan-out width below the CLI's own default of 20 — the
+# deterministic half of the dev-protocol's "max 15 parallel sub-agents".
+# Normally inherited from start.sh's env; set here as a belt-and-braces default
+# (honouring any value already in the env). See start.sh.hbs for rationale.
+export CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS="${CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS:-15}"
+
 # Defer the (now full) MCP schema set via tool-search so the cron session keeps
 # its low-context cost — the heavy servers load on demand; switchroom-telegram
 # + hindsight stay alwaysLoad. Normally inherited from start.sh's env; set here

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -685,10 +685,19 @@ unset CLAUDE_CODE_OAUTH_TOKEN
 # out its own sub-agents), so we restore the pre-2.1.217 behaviour. Depth 2
 # = main → sub-agent → grandchild, which covers the one extra level the
 # fleet actually uses; there is no evidence of deeper nesting, so we don't
-# raise it further. (The companion 2.1.217 change — CLAUDE_CODE_MAX_
-# CONCURRENT_SUBAGENTS defaulting to 20 — is already compatible: our fleet
-# self-caps at 15 parallel sub-agents, so the 20 default is left untouched.)
+# raise it further.
 export CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH="${CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH:-2}"
+# Fan-out width. The CLI's own default is 20 (2.1.217's companion change);
+# switchroom deliberately pins it LOWER, at 15, because the dev-protocol
+# fragment every agent boots with ("max 15 parallel sub-agents",
+# profiles/_shared/dev-protocol.md.hbs) is prompt text — a model can ignore
+# it, and nothing else caps the width. This export is the deterministic
+# mechanism behind that sentence: past 15 the CLI refuses the launch instead
+# of relying on the agent to count. 15 rather than 20 keeps a fully fanned-out
+# worker inside the per-container CPU/RAM envelope and leaves headroom for the
+# nested level that SPAWN_DEPTH=2 above permits. Override-able for a one-off
+# wide job; raise both this and the fragment together or they disagree.
+export CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS="${CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS:-15}"
 export TELEGRAM_STATE_DIR="{{agentDir}}/telegram"
 # SWITCHROOM_AGENT_NAME is the canonical "which agent am I" identifier the
 # telegram-plugin reads to detect self-restart commands. We can't rely on

--- a/tests/scaffold.subagent-limits.test.ts
+++ b/tests/scaffold.subagent-limits.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Sub-agent limit pinning — the two env vars that decide how the fleet may
+ * fan out, asserted against the RENDERED boot scripts by EXECUTING them.
+ *
+ * Why this file exists: both limits are load-bearing and were previously
+ * unguarded (`git grep CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH -- tests/ src/`
+ * returned nothing), so deleting either line in an unrelated edit changes
+ * fleet-wide delegation behaviour with no failing test and no visible symptom.
+ *
+ *   CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH=2
+ *     Claude Code 2.1.217 turned NESTED spawning OFF by default. Without this
+ *     export a dispatched @worker silently cannot fan out at all
+ *     (main → sub-agent → grandchild stops working).
+ *
+ *   CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS=15
+ *     The deterministic half of the dev-protocol's "max 15 parallel
+ *     sub-agents". That sentence is prompt text a model can ignore; the CLI's
+ *     own default is 20. This export is what actually enforces the cap
+ *     (`skills/dev-protocol/SKILL.md`: prefer a mechanism over prompt
+ *     discipline).
+ *
+ * OUTCOME, not string-presence: the export lines are extracted from the real
+ * rendered script and run through bash, then read back with `printenv` — which
+ * only sees EXPORTED vars, so this proves the value would actually reach the
+ * `exec claude` child, not merely that a shell variable was assigned. Both the
+ * default and the `${VAR:-N}` override shape are exercised.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent } from "../src/agents/scaffold.js";
+import { renderTemplate } from "../src/agents/profiles.js";
+import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+const DEPTH_VAR = "CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH";
+const WIDTH_VAR = "CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS";
+/** Nesting levels the fleet relies on: main → sub-agent → grandchild. */
+const EXPECTED_DEPTH = "2";
+/** Fan-out width, deliberately below the CLI's own default of 20. */
+const EXPECTED_WIDTH = "15";
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+function makeAgentConfig(): AgentConfig {
+  return { extends: "default", topic_name: "Test Topic", schedule: [] } as unknown as AgentConfig;
+}
+
+function makeSwitchroomConfig(name: string, agentConfig: AgentConfig): SwitchroomConfig {
+  return {
+    switchroom: {
+      version: 1,
+      agents_dir: "~/.switchroom/agents",
+      skills_dir: "~/.switchroom/skills",
+    },
+    telegram: telegramConfig,
+    agents: { [name]: agentConfig },
+  } as unknown as SwitchroomConfig;
+}
+
+/**
+ * Pull the two export lines out of a rendered script, preserving order.
+ * Anchored at column 0 on purpose: an indented copy would be nested inside a
+ * conditional/function and therefore not unconditionally applied at boot.
+ */
+function extractExports(script: string): string[] {
+  return script
+    .split("\n")
+    .filter((l) => new RegExp(`^export (${DEPTH_VAR}|${WIDTH_VAR})=`).test(l));
+}
+
+/**
+ * Execute the extracted export lines in a clean shell and read the values back
+ * with `printenv` (exported-only). `preset` simulates an operator override
+ * already present in the environment.
+ */
+function runExports(lines: string[], preset: Record<string, string> = {}): Record<string, string> {
+  const script = [
+    "set -eu",
+    ...lines,
+    `printf 'DEPTH=%s\\n' "$(printenv ${DEPTH_VAR})"`,
+    `printf 'WIDTH=%s\\n' "$(printenv ${WIDTH_VAR})"`,
+  ].join("\n");
+  const out = execFileSync("bash", ["-c", script], {
+    encoding: "utf-8",
+    env: { PATH: process.env.PATH ?? "/usr/bin:/bin", ...preset },
+  });
+  const depth = out.match(/DEPTH=(.*)/);
+  const width = out.match(/WIDTH=(.*)/);
+  return { depth: depth ? depth[1].trim() : "", width: width ? width[1].trim() : "" };
+}
+
+describe("start.sh: sub-agent spawn depth + concurrency are exported", () => {
+  let tmpDir: string;
+  let startSh: string;
+  let lines: string[];
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-subagent-limits-"));
+    const name = "sl-agent";
+    const config = makeAgentConfig();
+    const res = scaffoldAgent(name, config, tmpDir, telegramConfig, makeSwitchroomConfig(name, config));
+    startSh = readFileSync(join(res.agentDir, "start.sh"), "utf-8");
+    lines = extractExports(startSh);
+  });
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("exports BOTH limits unconditionally at top level", () => {
+    // Fails if either export line is deleted, indented into a conditional, or
+    // renamed — the exact silent-breakage this file guards.
+    expect(lines.some((l) => l.startsWith(`export ${DEPTH_VAR}=`))).toBe(true);
+    expect(lines.some((l) => l.startsWith(`export ${WIDTH_VAR}=`))).toBe(true);
+  });
+
+  it("yields depth=2 and width=15 in the child environment (no env preset)", () => {
+    const { depth, width } = runExports(lines);
+    expect(depth).toBe(EXPECTED_DEPTH);
+    expect(width).toBe(EXPECTED_WIDTH);
+  });
+
+  it("pins the fan-out cap BELOW the claude CLI's own default of 20", () => {
+    // The whole point of the width pin: 20 (the CLI default) would mean the
+    // dev-protocol's "max 15" is prompt-only. Assert the numeric relationship,
+    // not just the literal.
+    const { width } = runExports(lines);
+    const n = Number(width);
+    expect(Number.isInteger(n)).toBe(true);
+    // `De.int({ min: 1 })` in the CLI's env schema rejects <1.
+    expect(n).toBeGreaterThanOrEqual(1);
+    expect(n).toBeLessThan(20);
+    expect(n).toBe(15);
+  });
+
+  it("honours a pre-set value (the ${VAR:-N} override shape)", () => {
+    const { depth, width } = runExports(lines, {
+      [DEPTH_VAR]: "3",
+      [WIDTH_VAR]: "8",
+    });
+    expect(depth).toBe("3");
+    expect(width).toBe("8");
+  });
+
+  it("exports both limits BEFORE `exec claude`, so the CLI actually inherits them", () => {
+    const execIdx = startSh.indexOf("exec claude");
+    expect(execIdx).toBeGreaterThan(-1);
+    for (const v of [DEPTH_VAR, WIDTH_VAR]) {
+      const idx = startSh.indexOf(`export ${v}=`);
+      expect(idx, `${v} not exported`).toBeGreaterThan(-1);
+      expect(idx, `${v} exported after exec claude`).toBeLessThan(execIdx);
+    }
+  });
+
+  it("does not carry the retired claim that the fleet 'self-caps' at 15", () => {
+    // The old comment asserted a self-cap that did not exist anywhere in the
+    // codebase, which is why the 20 default was left in place.
+    expect(startSh).not.toContain("self-caps at 15");
+    expect(startSh).not.toContain("the 20 default is left untouched");
+  });
+});
+
+describe("cron-session.sh: the same two limits are pinned for cron-fired sessions", () => {
+  const CRON_SH = join(__dirname, "..", "profiles", "_base", "cron-session.sh.hbs");
+  const rendered = renderTemplate(CRON_SH, {
+    name: "marko",
+    agentDir: "/state/agent",
+    securityPluginDir: "/opt/switchroom/security-plugin",
+    useSwitchroomPlugin: true,
+    modelQ: "'claude-sonnet-5'",
+    cronModelQ: "'claude-sonnet-5'",
+  });
+  const lines = extractExports(rendered);
+
+  it("exports BOTH limits unconditionally at top level", () => {
+    expect(lines.some((l) => l.startsWith(`export ${DEPTH_VAR}=`))).toBe(true);
+    expect(lines.some((l) => l.startsWith(`export ${WIDTH_VAR}=`))).toBe(true);
+  });
+
+  it("yields depth=2 and width=15 in the child environment (no env preset)", () => {
+    const { depth, width } = runExports(lines);
+    expect(depth).toBe(EXPECTED_DEPTH);
+    expect(width).toBe(EXPECTED_WIDTH);
+  });
+
+  it("honours a pre-set value inherited from start.sh (belt-and-braces default)", () => {
+    // cron-session.sh normally INHERITS these from start.sh's env; its own
+    // defaults must never clobber an inherited/operator value.
+    const { depth, width } = runExports(lines, {
+      [DEPTH_VAR]: "4",
+      [WIDTH_VAR]: "6",
+    });
+    expect(depth).toBe("4");
+    expect(width).toBe("6");
+  });
+});


### PR DESCRIPTION
## Single concern

Sub-agent limits are pinned and tested. Two gaps, both verified against `origin/main` (`b8e73fed`).

### 1. The spawn-depth export was completely untested

`CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH="${CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH:-2}"` is exported at `profiles/_base/start.sh.hbs:691` and `profiles/_base/cron-session.sh.hbs:75`, and `git grep CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH origin/main -- tests/ src/ telegram-plugin/` returned **nothing**.

It is load-bearing: Claude Code 2.1.217 turned nested spawning off by default, so deleting either line in an unrelated edit silently stops `main -> sub-agent -> grandchild` delegation fleet-wide, with no symptom except workers being unable to fan out.

### 2. The 15-sub-agent cap was prompt-only

"max 15 parallel sub-agents" appears in `profiles/_shared/dev-protocol.md.hbs:14` and `skills/dev-protocol/SKILL.md:121`, and `src/agents/profiles.test.ts:657` asserted only that the *string* was present. `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` appeared **nowhere** in the repo, so the real cap was the CLI's own default of 20.

Worse, the comment at `start.sh.hbs:688-690` claimed:

> our fleet self-caps at 15 parallel sub-agents, so the 20 default is left untouched

That self-cap did not exist. This is a direct violation of the repo's own rule at `skills/dev-protocol/SKILL.md:115-117` — prefer a deterministic mechanism over prompt discipline.

## Env-var name verified against the real binary first

Before writing an export, I confirmed the name is correct for the installed CLI (**2.1.219**, bun-compiled, `/usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe`). It is real and load-bearing there:

- `dPu(){return Z.CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS??uty}` with `uty=20` — env overrides a default of 20.
- Declared `qch=De.int({min:1})` in the CLI's env schema, so `"15"` is parsed as an integer (not left as a string).
- Enforced with a real launch refusal: `Concurrent subagent limit reached. You can run ${n} subagents at once. Do not retry. ... ask them to increase CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS.`

## Changes

- Export `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS="${CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS:-15}"` in `start.sh.hbs` (beside the depth export) and in `cron-session.sh.hbs`, in the same override-able shape.
- Replace the false "self-caps" comment with an accurate one: switchroom pins 15 deliberately, below the CLI default of 20, and why.
- `CLAUDE.md`: note the cap is enforced rather than merely advised (minimal in-place edit, no reflow).
- New `tests/scaffold.subagent-limits.test.ts`.

## The tests assert outcomes, not string presence

The export lines are extracted from the **real rendered** scripts (`scaffoldAgent` for `start.sh`, `renderTemplate` for `cron-session.sh`), executed in `bash`, and read back with **`printenv`** — which only sees *exported* vars, so this proves the values would actually reach the `exec claude` child rather than merely that a shell variable was assigned. Defaults, the `${VAR:-N}` override shape, and the numeric below-20 relationship are all exercised.

Assertions live in a new dedicated file rather than `tests/doctor.test.ts` to avoid conflicting with in-flight #3814.

## Mutation proof

Each guarded line removed in turn, suite re-run, then restored:

| Mutation | Result |
|---|---|
| depth export deleted from `start.sh.hbs` | **3 failed** / 6 passed |
| concurrency export deleted from `start.sh.hbs` | **4 failed** / 5 passed |
| depth export deleted from `cron-session.sh.hbs` | **2 failed** / 7 passed |
| concurrency export deleted from `cron-session.sh.hbs` | **2 failed** / 7 passed |
| concurrency hard-coded to `20` (override shape dropped) | **3 failed** / 6 passed |
| restored | **9 passed** |

## Local verification

- `vitest run tests/scaffold.subagent-limits.test.ts` — 9 passed.
- `tsc --noEmit` — clean.
- All 16 lint guard scripts — pass.
- `tests/cheap-cron-session-render.test.ts`, `src/agents/profiles.test.ts` — pass (no regression from the `.hbs` edits).
- `tests/scaffold.session-model.test.ts` has 13 failures from `EROFS: read-only file system, mkdtemp '/var/tmp/...'`. Confirmed **pre-existing environment noise**: identical failures on pristine `b8e73fed` with a zero diff (stashed and re-ran). This is the fake-binary-harness bucket named in `CLAUDE.md`; CI is the authority.

Auto-merge deliberately **not** enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)