### PR TITLE
fix(cards): make the worker card structurally subordinate to the agent card (#3820)

### DIFF
--- a/reference/jobs/know-what-my-agent-is-doing.md
+++ b/reference/jobs/know-what-my-agent-is-doing.md
@@ -46,6 +46,13 @@ close that gap so the user never has to ask.
   narrated in plain language, as it happens, in the conversation.
 - Sub-agent and background work is visible in the same thread. No separate
   surface to hunt for. True in a DM and in a forum channel alike.
+- When a worker card and the agent card are both live, "is this my agent or a
+  background worker?" is answerable from the cards' SHAPE, at phone-glance
+  distance, without reading them. The worker card is structurally subordinate:
+  a `└─ ` on line 1, its whole block indented under the agent card, and a
+  high-contrast `WORKER` type label. Two same-shaped cards differing only by an
+  emoji and one word is the failure (#3820) — worse when the parent narrates
+  the task it delegated, so the two step trails read as duplicates.
 - Failures, limits, crashes, and restarts are always spoken. The user is
   told what happened and what resumes. A worker orphaned by a restart is
   narrated in the worker feed — re-dispatched or named as lost — not silently

--- a/telegram-plugin/status-no-truncate.ts
+++ b/telegram-plugin/status-no-truncate.ts
@@ -124,3 +124,52 @@ export const NESTED_PREFIX = '   ↳ '
  * assertion is what let #3662 ship green and inert.
  */
 export const WORKER_STEP_INDENT = '\u2800\u2800\u2800'
+
+/**
+ * Line-1 prefix that marks a card as structurally SUBORDINATE to the \ud83e\udd16 agent
+ * card (#3820). Worker cards carry it; the agent card never does.
+ *
+ * `\u2514\u2500` (U+2514 BOX DRAWINGS LIGHT UP AND RIGHT + U+2500 BOX DRAWINGS LIGHT
+ * HORIZONTAL) is ordinary ink to Telegram's server-side GFM parser: it is not
+ * a line-start block trigger (`#`, `>`, `-`/`+`/`*`, `N.` \u2014 see
+ * render/line-start-guard.ts for the full trigger set), so it can neither be
+ * promoted to a list/quote/heading nor left-trimmed the way a leading
+ * whitespace run is (the #3662 failure documented on WORKER_STEP_INDENT).
+ *
+ * LENGTH INVARIANT: exactly the same length as `SUBORDINATE_LINE_INDENT`, so
+ * the char-budget arithmetic in `fitCardToBudget` charges one flat per-line
+ * cost instead of special-casing line 1. `status-accent.test.ts` asserts it.
+ */
+export const SUBORDINATE_HEADER_PREFIX = '\u2514\u2500 '
+
+/**
+ * Left indent applied to EVERY line of a subordinate (worker) card after
+ * line 1 \u2014 the whole card block sits one level in from the agent card's left
+ * margin, so "parent vs child" is readable from the block's SHAPE at a glance
+ * on a phone, not from reading its label (#3820).
+ *
+ * Same U+2800 run as `WORKER_STEP_INDENT` and for the same live-verified
+ * reason (category So, not Zs \u2192 survives Telegram's inline left-trim; ASCII
+ * spaces and U+00A0 both render flat). Aliased rather than re-declared so the
+ * two indents can never drift to different glyphs.
+ *
+ * On the combined (2+ worker) card this composes with `WORKER_STEP_INDENT`:
+ * chrome / row headers land at one level, their steps at two.
+ */
+export const SUBORDINATE_LINE_INDENT = WORKER_STEP_INDENT
+
+/**
+ * Apply subordinate-card nesting to a card's pre-rendered lines: line 1 gets
+ * `SUBORDINATE_HEADER_PREFIX`, every later line gets `SUBORDINATE_LINE_INDENT`.
+ *
+ * Prefixes go OUTSIDE the markdown spans (lines arrive already wrapped in
+ * `**` / `_` / `~~`), exactly like `renderStepFeed`'s `indent` parameter, so a
+ * prefix can never land inside an emphasis run and break it.
+ *
+ * Pure; returns a new array. Empty in \u2192 empty out.
+ */
+export function nestSubordinateCardLines(lines: string[]): string[] {
+  return lines.map((line, i) =>
+    i === 0 ? `${SUBORDINATE_HEADER_PREFIX}${line}` : `${SUBORDINATE_LINE_INDENT}${line}`,
+  )
+}

--- a/telegram-plugin/tests/card-type-distinguishability.test.ts
+++ b/telegram-plugin/tests/card-type-distinguishability.test.ts
@@ -1,0 +1,268 @@
+/**
+ * #3820 — the 🤖 agent card and the 🛠 worker card must not be visually
+ * interchangeable when both are live in one chat.
+ *
+ * Both surfaces render through the SAME primitive (`renderStatusCard`,
+ * tool-activity-summary.ts), so before this fix they were byte-for-byte the
+ * same layout — two header lines, the identical `Ns · N tools · Nk tok · model`
+ * stat row, the identical `✓`/`→` step trail — differing only by an emoji and
+ * one word. When a parent narrates the task it delegated, the two cards' step
+ * lines are literally identical strings and the pair reads as a duplicate
+ * rather than as parent + child.
+ *
+ * These tests assert the RENDERED OUTPUT differs structurally, using the same
+ * inputs on both surfaces so a shared-layout regression cannot pass:
+ *   - the worker card's line 1 carries `└─ ` and the agent card's never does;
+ *   - every later worker line carries the subordinate indent;
+ *   - with identical step text and identical stats, NO line of one card equals
+ *     any line of the other.
+ *
+ * Plus the Telegram-reality guards: the prefixes survive the real outbound
+ * markdown guard (`richMessage`) byte-identical, the indent is not whitespace
+ * under any trimming rule (the #3662 lesson), and `└─` is not a line-start
+ * block-construct trigger.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  renderActivityFeed,
+  renderStatusCard,
+  renderCombinedWorkerFeed,
+} from '../tool-activity-summary.js'
+import { renderWorkerActivity, type WorkerActivityView } from '../worker-activity-feed.js'
+import {
+  SUBORDINATE_HEADER_PREFIX,
+  SUBORDINATE_LINE_INDENT,
+  WORKER_STEP_INDENT,
+  STATUS_CARD_CHAR_BUDGET,
+  nestSubordinateCardLines,
+} from '../status-no-truncate.js'
+import { richMessage } from '../rich-send.js'
+
+/** Split a rendered card into display lines, dropping the hard-break padding. */
+function lines(card: string): string[] {
+  return card.split('\n').map((l) => l.replace(/[\u00A0 \t\r]+$/, ''))
+}
+
+/** The exact scenario from the issue: parent narrating the task it delegated. */
+const STEPS = ['PR 2502 details', 'Commits since v0.8.5']
+
+function agentCard(): string {
+  const out = renderActivityFeed(STEPS, false, '', undefined, {
+    label: 'Agent',
+    elapsedMs: 108_000,
+    toolCount: 15,
+    state: 'running',
+    model: 'claude-opus-5',
+    totalTokens: 16_400,
+  })
+  expect(out).not.toBeNull()
+  return out as string
+}
+
+function workerView(over: Partial<WorkerActivityView> = {}): WorkerActivityView {
+  return {
+    description: 'Check upstream hindsight changes',
+    elapsedMs: 108_000,
+    toolCount: 15,
+    latestSummary: '',
+    narrativeLines: STEPS,
+    state: 'running',
+    model: 'claude-opus-5',
+    totalTokens: 16_400,
+    ...over,
+  } as WorkerActivityView
+}
+
+describe('#3820 agent vs worker card distinguishability', () => {
+  it('marks the worker card subordinate on line 1 and never the agent card', () => {
+    const agent = lines(agentCard())
+    const worker = lines(renderWorkerActivity(workerView()))
+
+    expect(worker[0].startsWith(SUBORDINATE_HEADER_PREFIX)).toBe(true)
+    expect(agent[0].startsWith(SUBORDINATE_HEADER_PREFIX)).toBe(false)
+    // The agent card stays flush at the left margin on EVERY line — it is the
+    // parent, so nothing about it may read as nested.
+    for (const l of agent) {
+      expect(l.startsWith(SUBORDINATE_HEADER_PREFIX)).toBe(false)
+      expect(l.startsWith(SUBORDINATE_LINE_INDENT)).toBe(false)
+    }
+  })
+
+  it('indents every worker card line after line 1', () => {
+    const worker = lines(renderWorkerActivity(workerView()))
+    expect(worker.length).toBeGreaterThan(2)
+    for (const l of worker.slice(1)) {
+      expect(l.startsWith(SUBORDINATE_LINE_INDENT)).toBe(true)
+    }
+  })
+
+  it('shares no rendered line between the two cards even with identical steps and stats', () => {
+    // This is the issue's actual symptom: the parent narrates the task it
+    // delegated, so the step text overlaps. On the pre-#3820 renderer the
+    // stat row AND both step lines were byte-identical across the two cards.
+    const agent = lines(agentCard())
+    const worker = lines(renderWorkerActivity(workerView()))
+    const overlap = agent.filter((a) => worker.includes(a))
+    expect(overlap).toEqual([])
+  })
+
+  it('uses a high-contrast caps type label on the worker card only', () => {
+    const agent = agentCard()
+    const worker = renderWorkerActivity(workerView())
+    expect(worker).toContain('🛠 **WORKER**')
+    expect(agent).toContain('🤖 **Agent**')
+    expect(agent).not.toContain('WORKER')
+  })
+
+  it('keeps the terminal (result-block) worker render subordinate too', () => {
+    const worker = lines(
+      renderWorkerActivity(
+        workerView({ state: 'done', latestSummary: 'Rebased and opened the PR.' }),
+      ),
+    )
+    expect(worker[0].startsWith(SUBORDINATE_HEADER_PREFIX)).toBe(true)
+    for (const l of worker.slice(1)) {
+      expect(l.startsWith(SUBORDINATE_LINE_INDENT)).toBe(true)
+    }
+    // The result block is present and nested, not floated back to the margin.
+    expect(worker.some((l) => l.startsWith(`${SUBORDINATE_LINE_INDENT}✅ `))).toBe(true)
+  })
+
+  it('keeps the just-dispatched (starting…) worker render subordinate', () => {
+    // The first state a user ever sees for a worker takes a hand-rolled append
+    // path outside renderStatusCard — the one place a nesting fix can silently
+    // miss.
+    const worker = lines(
+      renderWorkerActivity(workerView({ narrativeLines: [], latestSummary: '' })),
+    )
+    expect(worker[0].startsWith(SUBORDINATE_HEADER_PREFIX)).toBe(true)
+    expect(worker[worker.length - 1]).toBe(`${SUBORDINATE_LINE_INDENT}_starting…_`)
+  })
+
+  it('nests the combined (2+ worker) card and keeps its internal hierarchy', () => {
+    const card = renderCombinedWorkerFeed(
+      [
+        {
+          description: 'Check upstream hindsight changes',
+          elapsedMs: 55_000,
+          toolCount: 9,
+          currentStep: 'Commits since v0.8.5',
+          historyLines: STEPS,
+          ordinal: 1,
+        },
+        {
+          description: 'Fix the card renderer',
+          elapsedMs: 30_000,
+          toolCount: 4,
+          currentStep: 'Reading render.ts',
+          historyLines: ['Reading render.ts'],
+          ordinal: 2,
+        },
+      ],
+      { maxRows: 4 },
+    )
+    expect(card).not.toBeNull()
+    const l = lines(card as string)
+    expect(l[0]).toBe(`${SUBORDINATE_HEADER_PREFIX}🛠 **WORKERS** · _2 running · oldest 55s · 13 tools_`)
+    // Row headers sit at one level; their steps stay one level deeper, so the
+    // card's own parent/child structure survives the shift right.
+    const rowHeaders = l.filter((x) => x.includes('**1. ') || x.includes('**2. '))
+    expect(rowHeaders.length).toBe(2)
+    for (const h of rowHeaders) {
+      expect(h.startsWith(SUBORDINATE_LINE_INDENT)).toBe(true)
+      expect(h.startsWith(SUBORDINATE_LINE_INDENT + WORKER_STEP_INDENT)).toBe(false)
+    }
+    const stepLines = l.filter((x) => x.includes('→ ') || x.includes('✓ '))
+    expect(stepLines.length).toBeGreaterThan(0)
+    for (const s of stepLines) {
+      expect(s.startsWith(SUBORDINATE_LINE_INDENT + WORKER_STEP_INDENT)).toBe(true)
+    }
+  })
+
+  it('stays under the wire char budget on the subordinate over-budget path', () => {
+    // fitCardToBudget has its own line assembly + its own arithmetic; the
+    // per-line nesting cost must be charged there or an oversized worker card
+    // can overflow the wire cap.
+    const huge = Array.from({ length: 500 }, (_, i) => `${i} `.repeat(100))
+    const card = renderStatusCard({
+      header: {
+        emoji: '🛠',
+        label: 'WORKER',
+        description: 'big',
+        elapsedMs: 1000,
+        toolCount: 1,
+        state: 'running',
+      },
+      steps: huge,
+      subordinate: true,
+    })
+    expect(card).not.toBeNull()
+    expect((card as string).length).toBeLessThanOrEqual(STATUS_CARD_CHAR_BUDGET)
+    expect((card as string).startsWith(SUBORDINATE_HEADER_PREFIX)).toBe(true)
+  })
+
+  it('leaves a non-subordinate card byte-identical to the un-nested render', () => {
+    const opts = {
+      header: {
+        emoji: '🤖',
+        label: 'Agent',
+        elapsedMs: 1000,
+        toolCount: 2,
+        state: 'running' as const,
+      },
+      steps: STEPS,
+    }
+    expect(renderStatusCard({ ...opts, subordinate: false })).toBe(renderStatusCard(opts))
+  })
+})
+
+describe('#3820 subordinate prefixes survive Telegram reality', () => {
+  it('passes through the real outbound markdown guard byte-identical', () => {
+    // richMessage() is the ONE adapter every `{ markdown }` wire send funnels
+    // through (rich-send.ts) — it runs the line-start / heading / dollar-math
+    // guards. A prefix that gets escaped there would render as literal markup.
+    for (const card of [
+      agentCard(),
+      renderWorkerActivity(workerView()),
+      renderCombinedWorkerFeed(
+        [{ description: 'a', elapsedMs: 1, toolCount: 1, currentStep: 'b', ordinal: 1 }],
+        { maxRows: 4 },
+      ) as string,
+    ]) {
+      expect(richMessage(card).markdown).toBe(card)
+    }
+  })
+
+  it('uses an indent that no whitespace-trimming rule can eat (#3662 lesson)', () => {
+    // U+00A0 shipped in #3662 and was INERT: Telegram left-trims a leading
+    // Unicode-whitespace run, and U+00A0 is category Zs. Assert the PROPERTY,
+    // not the bytes — a byte-only assertion is what let #3662 ship green.
+    for (const ch of Array.from(SUBORDINATE_LINE_INDENT)) {
+      expect(/\s/.test(ch)).toBe(false)
+      expect(/\p{White_Space}/u.test(ch)).toBe(false)
+      expect(/\p{Zs}/u.test(ch)).toBe(false)
+    }
+  })
+
+  it('uses a header prefix that is ink, not a line-start block trigger', () => {
+    const first = SUBORDINATE_HEADER_PREFIX[0]
+    // Not whitespace (would be trimmed), and not one of the GFM line-start
+    // block-construct triggers guarded in render/line-start-guard.ts.
+    expect(/\s/.test(first)).toBe(false)
+    expect('#>-+*'.includes(first)).toBe(false)
+    expect(/^\d+[.)]/.test(SUBORDINATE_HEADER_PREFIX)).toBe(false)
+  })
+
+  it('charges one flat per-line cost: header prefix and indent are equal length', () => {
+    // fitCardToBudget's arithmetic depends on this invariant.
+    expect(SUBORDINATE_HEADER_PREFIX.length).toBe(SUBORDINATE_LINE_INDENT.length)
+  })
+
+  it('nestSubordinateCardLines is pure and handles the empty case', () => {
+    expect(nestSubordinateCardLines([])).toEqual([])
+    expect(nestSubordinateCardLines(['a', 'b'])).toEqual([
+      `${SUBORDINATE_HEADER_PREFIX}a`,
+      `${SUBORDINATE_LINE_INDENT}b`,
+    ])
+  })
+})

--- a/telegram-plugin/tests/pinned-card-collapse.test.ts
+++ b/telegram-plugin/tests/pinned-card-collapse.test.ts
@@ -33,6 +33,7 @@ import {
   STATUS_CARD_CHAR_BUDGET,
   STATUS_LINE_MAX,
   WORKER_STEP_INDENT,
+  SUBORDINATE_LINE_INDENT,
 } from '../status-no-truncate.js'
 
 /**
@@ -135,27 +136,30 @@ describe('combined worker card survives the pinned-bar collapse (#3666)', () => 
   it('kills the exact artifacts from the report', () => {
     const collapsed = collapsePreview(body)
     // 1. the count/ordinal collision — glance line into row 1's ordinal.
-    //    This seam is owned by the collapse separator (a worker HEADER carries
-    //    no leading indent, so nothing else separates it).
+    //    Since #3820 a worker header also carries the card-level
+    //    SUBORDINATE_LINE_INDENT (the whole worker card nests under the 🤖
+    //    agent card), so this seam is separator + card indent.
     //    (The reported spelling was `3 running1.`; with the packed glance line
     //    the same seam now reads `… 512.3k tok` -> `1. Fix issue`, so assert on
     //    the CURRENT last token of line 1 — an assertion on the old spelling
     //    alone would be vacuously green.)
     expect(collapsed).not.toContain('running1.')
     expect(collapsed).not.toContain('tok1.')
-    expect(collapsed).toContain(`tok${NB}1. Fix issue`)
+    expect(collapsed).toContain(`tok${NB}${SUBORDINATE_LINE_INDENT}1. Fix issue`)
     // 2. the mid-word ✓ (model tag running into the step trail). Here the
     //    separator and WORKER_STEP_INDENT (three U+2800 leading a step line)
     //    stack, so the seam is separator + indent, asserted against both
     //    constants rather than a hardcoded run of spaces.
     expect(collapsed).not.toContain('opus 5✓')
-    expect(collapsed).toContain(`opus 5${NB}${WORKER_STEP_INDENT}✓`)
+    expect(collapsed).toContain(`opus 5${NB}${SUBORDINATE_LINE_INDENT}${WORKER_STEP_INDENT}✓`)
     // 3. the step trail running into the next step, and into the next row's
-    //    header (that last seam is separator-only: headers are unindented).
+    //    header (post-#3820 that last seam is separator + card indent).
     expect(collapsed).not.toContain('gateway.ts→')
-    expect(collapsed).toContain(`gateway.ts${NB}${WORKER_STEP_INDENT}→`)
+    expect(collapsed).toContain(
+      `gateway.ts${NB}${SUBORDINATE_LINE_INDENT}${WORKER_STEP_INDENT}→`,
+    )
     expect(collapsed).not.toContain('search2.')
-    expect(collapsed).toContain(`search${NB}2.`)
+    expect(collapsed).toContain(`search${NB}${SUBORDINATE_LINE_INDENT}2.`)
   })
 
   it('leads with a self-contained glance that ends in a unit word, not a bare number', () => {
@@ -170,20 +174,27 @@ describe('combined worker card survives the pinned-bar collapse (#3666)', () => 
   })
 
   it('CONTROL: the same lines joined without collapseSafe still mash (pre-fix shape)', () => {
-    // Discriminator: re-join the SAME rendered lines with the separator removed
-    // and show the collapsed preview mashes again. Without this, the assertions
+    // Discriminator: re-join rendered card lines with the separator removed and
+    // show the collapsed preview mashes again. Without this, the assertions
     // above could all be passing for reasons unrelated to the fix.
     //
-    // The seams asserted here are the ones the separator alone owns: a worker
-    // HEADER line carries no leading WORKER_STEP_INDENT, so the
-    // glance->row-1 and step->next-row seams have nothing else holding them
-    // apart. (The header->step and step->step seams are separated by the indent
-    // even pre-fix, which is why they are not the control.)
-    const lines = rawCardLines(body).map((l) => l.replace(new RegExp(NB + '$'), ''))
+    // The control runs on the 🤖 AGENT card, not the worker card: since #3820
+    // every line of a worker card after line 1 carries a leading
+    // SUBORDINATE_LINE_INDENT, which separates its seams independently of the
+    // collapse separator — so a worker-card control would no longer isolate the
+    // separator's contribution. The agent card is the surface where the
+    // separator is still the ONLY thing holding the seams apart, which is
+    // exactly what this control must measure.
+    const agent = renderActivityFeed([
+      'Reading gateway.ts',
+      'Searching memory',
+      'Running tests',
+    ])!
+    const lines = rawCardLines(agent).map((l) => l.replace(new RegExp(NB + '$'), ''))
     const preFix = stackCardLines(lines)
     const collapsed = collapsePreview(preFix)
-    expect(collapsed).toContain('tok1.')
-    expect(collapsed).toContain('search2.')
+    expect(collapsed).toContain('gateway.ts✓ Searching')
+    expect(collapsed).toContain('memory→ Running')
     // …and the property assertion itself would have failed on it.
     expect(() => expectNoMashedSeams(preFix)).toThrow()
   })
@@ -217,7 +228,7 @@ describe('single-worker / agent status card survives the collapse too (#3666)', 
     expectNoMashedSeams(body)
     const collapsed = collapsePreview(body)
     expect(collapsed).not.toContain('toolsstarting')
-    expect(collapsed).toContain(`0 tools${NB}starting`)
+    expect(collapsed).toContain(`0 tools${NB}${SUBORDINATE_LINE_INDENT}starting`)
   })
 
   it('the nested child block stays separated even though its indent is ASCII (#3668)', () => {

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -76,7 +76,7 @@ describe('renderWorkerActivity', () => {
 
   it('renders the native header + running status + step feed', () => {
     const out = renderWorkerActivity(view())
-    expect(out).toContain('🛠 **Worker** · _research competitors_')
+    expect(out).toContain('└─ 🛠 **WORKER** · _research competitors_')
     // Unified header: running shows "<elapsed> · N tools" (no "running ·" word).
     expect(out).toContain('_10s · 3 tools_')
     expect(out).toContain('3 tools')
@@ -100,7 +100,7 @@ describe('renderWorkerActivity', () => {
 
   it('shows a "starting…" line when no step has run yet', () => {
     const out = renderWorkerActivity(view({ lastTool: null, latestSummary: '' }))
-    expect(out).toContain('🛠 **Worker**')
+    expect(out).toContain('└─ 🛠 **WORKER**')
     expect(out).toContain('starting…')
     expect(out).not.toContain('→')
   })
@@ -121,7 +121,7 @@ describe('renderWorkerActivity', () => {
     const out = renderWorkerActivity(
       view({ state: 'done', toolCount: 5, latestSummary: 'PR #21 opened' }),
     )
-    expect(out).toContain('🛠 **Worker** · _research competitors_')
+    expect(out).toContain('└─ 🛠 **WORKER** · _research competitors_')
     // Unified done header: "done · N tools · <elapsed>".
     expect(out).toContain('_done · 5 tools · ')
     expect(out).toContain('─────')
@@ -227,7 +227,7 @@ describe('renderWorkerActivity', () => {
         narrativeLines: ['- ran the **full** suite', '`git push`'],
       }),
     )
-    expect(running).toContain('🛠 **Worker** · _Build the sync_')
+    expect(running).toContain('└─ 🛠 **WORKER** · _Build the sync_')
     expect(running).toContain('ran the full suite')
     expect(running).toContain('git push')
     // The CONTENT bold/code markers were stripped — no `**full**`, no backticks.
@@ -298,7 +298,7 @@ describe('createWorkerActivityFeed', () => {
     // #2669: the worker feed body is raw GFM markdown sent through the rich
     // path (the gateway wires sendMessage → sendRichMessage). No parse_mode.
     expect(bot.sent[0].opts?.parse_mode).toBeUndefined()
-    expect(bot.sent[0].text).toContain('🛠 **Worker**')
+    expect(bot.sent[0].text).toContain('└─ 🛠 **WORKER**')
     expect(feed.has('w1')).toBe(true)
   })
 
@@ -932,7 +932,7 @@ describe('createWorkerActivityFeed — heartbeat', () => {
     await drain()
     expect(bot.sent).toHaveLength(1)
     expect(feed.messageIdOf('w1')).toBe(1000)
-    expect(bot.sent[0].text).toContain('🛠 **Worker**')
+    expect(bot.sent[0].text).toContain('└─ 🛠 **WORKER**')
 
     // And it keeps updating: a later heartbeat edits the message with a
     // climbing `· Ns` suffix so the still-alive worker visibly advances.
@@ -1328,7 +1328,7 @@ describe('header row + rolling overflow survive in the unified worker render', (
     )
     const out = renderWorkerActivity(view({ narrativeLines, toolCount: 7 }))
 
-    expect(out).toContain('🛠 **Worker**')
+    expect(out).toContain('└─ 🛠 **WORKER**')
     // Unified running status line.
     expect(out).toContain('_10s · 7 tools_')
     expect(out).toContain('7 tools')
@@ -1344,7 +1344,7 @@ describe('header row + rolling overflow survive in the unified worker render', (
 
     expect(out.length).toBeLessThanOrEqual(4096)
     expect(out).toContain('earlier…')
-    expect(out).toContain('🛠 **Worker**')
+    expect(out).toContain('└─ 🛠 **WORKER**')
     expect(out).toContain('_10s · ')
   })
 
@@ -1359,7 +1359,7 @@ describe('header row + rolling overflow survive in the unified worker render', (
     expect(out.length).toBeLessThanOrEqual(4096)
     const hasBullet = out.includes('→') || out.includes('✓')
     expect(hasBullet).toBe(true)
-    expect(out).toContain('🛠 **Worker**')
+    expect(out).toContain('└─ 🛠 **WORKER**')
     expect(out).toContain('_10s · ')
     expect(isValidWorkerMarkdown(out)).toBe(true)
   })
@@ -1525,7 +1525,7 @@ describe('worker-feed send-gate shed contract', () => {
     await feed.update('w1', 'chat', view({ elapsedMs: clock }))
     expect(bot.sendCalls).toBe(1)
     expect(bot.sent).toHaveLength(1)
-    expect(bot.sent[0].text).toContain('🛠 **Worker**')
+    expect(bot.sent[0].text).toContain('└─ 🛠 **WORKER**')
     expect(feed.has('w1')).toBe(true)
   })
 

--- a/telegram-plugin/tests/worker-feed-coalesce.test.ts
+++ b/telegram-plugin/tests/worker-feed-coalesce.test.ts
@@ -6,7 +6,12 @@ import {
   type WorkerActivityView,
 } from '../worker-activity-feed.js'
 import { renderCombinedWorkerFeed, combinedHistoryDepth } from '../tool-activity-summary.js'
-import { STATUS_CARD_CHAR_BUDGET, WORKER_STEP_INDENT } from '../status-no-truncate.js'
+import {
+  STATUS_CARD_CHAR_BUDGET,
+  WORKER_STEP_INDENT,
+  SUBORDINATE_HEADER_PREFIX,
+  SUBORDINATE_LINE_INDENT,
+} from '../status-no-truncate.js'
 import { COLLAPSE_SAFE_SEPARATOR } from '../card-format.js'
 import { richMessage } from '../rich-send.js'
 import { parseRichEntities, validateRichMarkdown } from './rich-markdown-oracle.js'
@@ -661,7 +666,7 @@ describe('renderCombinedWorkerFeed (pure)', () => {
 
   it('renders one row-block per worker with a running count header', () => {
     const body = renderCombinedWorkerFeed([row(1, 'alpha step'), row(2, 'beta step')], { maxRows: 8 })!
-    expect(body).toContain('Workers')
+    expect(body).toContain('WORKERS')
     expect(body).toContain('2 running')
     expect(body).toContain('task number 1')
     expect(body).toContain('task number 2')
@@ -756,7 +761,7 @@ describe('renderCombinedWorkerFeed (pure)', () => {
       .map((l) => l.trim())
       .filter((l) => l.length > 0)
     const headerAndHistory = bodyLines.filter(
-      (l) => !l.startsWith('🛠') && !l.includes('more working'),
+      (l) => !l.includes('**WORKERS**') && !l.includes('more working'),
     )
     expect(headerAndHistory.length).toBeLessThanOrEqual(24)
   })
@@ -775,7 +780,7 @@ describe('renderCombinedWorkerFeed (pure)', () => {
       .map((l) => l.trim())
       .filter((l) => l.length > 0)
     const headerAndHistory = bodyLines.filter(
-      (l) => !l.startsWith('🛠') && !l.includes('more working'),
+      (l) => !l.includes('**WORKERS**') && !l.includes('more working'),
     )
     expect(headerAndHistory.length).toBeLessThanOrEqual(24)
     expect(body).toContain('+2 more working')
@@ -1287,15 +1292,22 @@ describe('combined worker card — steps indent under their worker (U+2800)', ()
     // Load-bearing: the exact indent bytes. `WORKER_STEP_INDENT` is U+2800 ×3;
     // a plain-ASCII `'   '` indent fails this assertion, so does the U+00A0 run
     // #3662 shipped, and so does flat output with no prefix at all.
+    // Since #3820 the whole card is nested one level under the 🤖 agent card,
+    // so a step sits at SUBORDINATE_LINE_INDENT + WORKER_STEP_INDENT while its
+    // worker header sits at SUBORDINATE_LINE_INDENT alone — the RELATIVE
+    // one-level nesting this test guards is unchanged, just shifted right.
     for (const l of stepLines) {
-      expect(l.startsWith(WORKER_STEP_INDENT)).toBe(true)
+      expect(l.startsWith(SUBORDINATE_LINE_INDENT + WORKER_STEP_INDENT)).toBe(true)
       expect(l.startsWith(BLANK)).toBe(true)
       expect(l.startsWith(' ')).toBe(false)
       expect(l.startsWith(NBSP)).toBe(false)
     }
-    // Workers stay at the left margin so the nesting reads as nesting.
-    for (const l of headerLines) expect(l.startsWith(BLANK)).toBe(false)
-    expect(lines[0].startsWith('🛠')).toBe(true)
+    // Workers stay one level ABOVE their steps so the nesting reads as nesting.
+    for (const l of headerLines) {
+      expect(l.startsWith(SUBORDINATE_LINE_INDENT)).toBe(true)
+      expect(l.startsWith(SUBORDINATE_LINE_INDENT + WORKER_STEP_INDENT)).toBe(false)
+    }
+    expect(lines[0].startsWith(`${SUBORDINATE_HEADER_PREFIX}🛠`)).toBe(true)
   })
 
   it('golden body — each worker header is immediately followed by ITS indented steps', () => {
@@ -1305,7 +1317,8 @@ describe('combined worker card — steps indent under their worker (U+2800)', ()
     // would still pass every one of them. This pins the full line ORDER, which
     // is the actual thing the fix is for: a step must sit under its own worker.
     const body = renderCombinedWorkerFeed(rowsFor(3), { maxRows: 8 })!
-    const I = WORKER_STEP_INDENT
+    const I = SUBORDINATE_LINE_INDENT + WORKER_STEP_INDENT
+    const N = SUBORDINATE_LINE_INDENT
     // `S` is the pinned-bar collapse separator (#3666): every line that is
     // followed by a hard break carries one trailing U+00A0 so the pinned-message
     // bar (which drops the newline and substitutes nothing) does not mash the
@@ -1314,14 +1327,14 @@ describe('combined worker card — steps indent under their worker (U+2800)', ()
     // `WORKER_STEP_INDENT`, which is what this golden is really pinning.
     const S = COLLAPSE_SAFE_SEPARATOR
     expect(linesOf(body)).toEqual([
-      `🛠 **Workers** · _3 running · oldest 3m00s · 9 tools_${S}`,
-      `**1. worker task 1** _· 1m00s · 3 tools_${S}`,
+      `${SUBORDINATE_HEADER_PREFIX}🛠 **WORKERS** · _3 running · oldest 3m00s · 9 tools_${S}`,
+      `${N}**1. worker task 1** _· 1m00s · 3 tools_${S}`,
       `${I}~~_✓ w1 step a_~~${S}`,
       `${I}**→ w1 step b**${S}`,
-      `**2. worker task 2** _· 2m00s · 3 tools_${S}`,
+      `${N}**2. worker task 2** _· 2m00s · 3 tools_${S}`,
       `${I}~~_✓ w2 step a_~~${S}`,
       `${I}**→ w2 step b**${S}`,
-      `**3. worker task 3** _· 3m00s · 3 tools_${S}`,
+      `${N}**3. worker task 3** _· 3m00s · 3 tools_${S}`,
       `${I}~~_✓ w3 step a_~~${S}`,
       `${I}**→ w3 step b**`, // last line: nothing follows it to collide with
     ])
@@ -1442,7 +1455,7 @@ describe('combined worker card — steps indent under their worker (U+2800)', ()
     expect(ents.every((e) => !e.text.includes(NBSP))).toBe(true)
   })
 
-  it('the SINGLE-worker 🛠 card is untouched (no indent on its step lines)', () => {
+  it('the SINGLE-worker 🛠 card nests ONE level (card-level only, no per-worker indent)', () => {
     const single = renderWorkerActivity({
       workerId: 'w1',
       description: 'lone worker',
@@ -1454,16 +1467,19 @@ describe('combined worker card — steps indent under their worker (U+2800)', ()
     })
     expect(single).toContain('~~_✓ step a_~~')
     expect(single).toContain('**→ step b**')
-    // No LEADING indent: the single-worker card has nothing to nest under, so
-    // its step lines must sit flush at the left margin. Asserted per line on the
+    // The lone-worker card has no worker HEADER to nest steps under, so it must
+    // never carry the per-worker indent — but since #3820 the whole card nests
+    // ONE level under the 🤖 agent card, so its body lines sit at exactly
+    // SUBORDINATE_LINE_INDENT and never at two levels. Asserted per line on the
     // leading edge rather than as "no U+00A0 anywhere in the card", because
     // #3666 puts one TRAILING U+00A0 on every hard-broken line of every pinned
-    // card (this one included) as the collapse separator. A regression that
-    // leaked WORKER_STEP_INDENT onto these lines still fails here.
-    for (const l of single.split('\n')) {
-      expect(l.startsWith(BLANK)).toBe(false)
+    // card (this one included) as the collapse separator.
+    const ls = single.split('\n')
+    expect(ls[0].startsWith(SUBORDINATE_HEADER_PREFIX)).toBe(true)
+    for (const l of ls.slice(1)) {
+      expect(l.startsWith(SUBORDINATE_LINE_INDENT)).toBe(true)
+      expect(l.startsWith(SUBORDINATE_LINE_INDENT + WORKER_STEP_INDENT)).toBe(false)
       expect(l.startsWith(NBSP)).toBe(false)
-      expect(l.startsWith(WORKER_STEP_INDENT)).toBe(false)
     }
   })
 })

--- a/telegram-plugin/tests/worker-visibility-prose-silent-harness.test.ts
+++ b/telegram-plugin/tests/worker-visibility-prose-silent-harness.test.ts
@@ -253,7 +253,7 @@ describe('prose-silent background worker — end-to-end visibility harness (PR 2
     expect(h.bot.sent).toHaveLength(1)
     expect(h.feed.messageIdOf(h.agentId)).not.toBeNull()
     expect(h.bot.sent[0].chatId).toBe('chat-42')
-    expect(h.bot.sent[0].text).toContain('🛠 **Worker**')
+    expect(h.bot.sent[0].text).toContain('└─ 🛠 **WORKER**')
 
     // (b) KEEPS UPDATING: later heartbeats edit the message with a climbing
     // `· Ns` suffix so the still-alive worker visibly advances.

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -90,6 +90,8 @@ import {
   STATUS_LINE_MAX,
   NESTED_PREFIX,
   WORKER_STEP_INDENT,
+  SUBORDINATE_LINE_INDENT,
+  nestSubordinateCardLines,
 } from './status-no-truncate.js'
 import { escapeMarkdown, stripMarkdown, truncate, stackCardLines } from './card-format.js'
 import { isTelegramSurfaceTool } from './tool-names.js'
@@ -372,6 +374,18 @@ export interface StatusCardOpts {
    * full recent trail — see WORKER_HISTORY_MAX.
    */
   historyWindow?: number
+  /**
+   * Render this card as structurally SUBORDINATE to the 🤖 agent card (#3820):
+   * line 1 is prefixed with `└─ ` and every later line with
+   * `SUBORDINATE_LINE_INDENT`, so the whole block sits one level in from the
+   * agent card's left margin.
+   *
+   * This is what makes "my agent" vs "a background worker" answerable from the
+   * card's SHAPE without reading its label — the two cards were otherwise
+   * byte-for-byte the same layout, differing only by an emoji + one word.
+   * Worker surfaces pass `true`; the agent card never does.
+   */
+  subordinate?: boolean
 }
 
 /**
@@ -381,7 +395,8 @@ export interface StatusCardOpts {
  * Pipeline: header → escape+clip every raw step/child → rolling-window each
  * group with `+N earlier…` → wrap (parent done-styled when children present;
  * newest-in-progress `→` bold else `✓` italic; NESTED_PREFIX for children) →
- * optional `✓ N steps` footer → optional result block → fitCardToBudget.
+ * optional `✓ N steps` footer → optional result block → subordinate nesting
+ * (#3820, when `opts.subordinate`) → fitCardToBudget.
  */
 export function renderStatusCard(opts: StatusCardOpts): string | null {
   const { header, final = false, liveSuffix = '', stepCount, result } = opts
@@ -453,7 +468,9 @@ export function renderStatusCard(opts: StatusCardOpts): string | null {
   // collapseSafe (#3666): the agent status card and the single-worker card are
   // both PINNED, and Telegram's pinned bar shows them collapsed to one line
   // with the newlines dropped — the separator keeps that preview legible.
-  const joined = stackCardLines(out, { collapseSafe: true })
+  const joined = stackCardLines(opts.subordinate === true ? nestSubordinateCardLines(out) : out, {
+    collapseSafe: true,
+  })
   if (joined.length <= STATUS_CARD_CHAR_BUDGET) return joined
   return fitCardToBudget(opts, headerLines)
 }
@@ -475,6 +492,15 @@ function fitCardToBudget(opts: StatusCardOpts, headerLines: string[]): string {
   const rawSteps = opts.steps.filter((s) => s != null)
   const rawChildren = (opts.childSteps ?? []).map((s) => s.trim()).filter((s) => s.length > 0)
   const hasChildren = rawChildren.length > 0
+  const subordinate = opts.subordinate === true
+  // Subordinate nesting (#3820) costs a fixed prefix on EVERY line — the header
+  // prefix and the body indent are the same length by invariant (see
+  // SUBORDINATE_HEADER_PREFIX), so it is one flat per-line charge rather than a
+  // line-1 special case. Charged into the arithmetic below so the extreme
+  // single-oversized-bullet branch still lands under the wire cap.
+  const nestCost = subordinate ? SUBORDINATE_LINE_INDENT.length : 0
+  const stack = (lines: string[]): string =>
+    stackCardLines(subordinate ? nestSubordinateCardLines(lines) : lines, { collapseSafe: true })
 
   // Fixed footer/result lines (always kept).
   const footerLines: string[] = []
@@ -483,7 +509,9 @@ function fitCardToBudget(opts: StatusCardOpts, headerLines: string[]): string {
     footerLines.push(WORKER_RESULT_RULE)
     footerLines.push(`${result.emoji} _${escapeMarkdown(truncate(result.text, WORKER_RESULT_MAX))}_`)
   }
-  const fixedCost = [...headerLines, ...footerLines].join('\n').length
+  const fixedCost =
+    [...headerLines, ...footerLines].join('\n').length +
+    (headerLines.length + footerLines.length) * nestCost
 
   // The active "body" group whose oldest bullets we drop: children when
   // present (parent collapses to a single "+N" marker), else parent steps.
@@ -507,7 +535,7 @@ function fitCardToBudget(opts: StatusCardOpts, headerLines: string[]): string {
     shown.forEach((esc, i) => lines.push(buildBullet(esc, i === lastIdx)))
     lines.push(...footerLines)
     // collapseSafe: same pinned surface as renderStatusCard (#3666).
-    const candidate = stackCardLines(lines, { collapseSafe: true })
+    const candidate = stack(lines)
     if (candidate.length <= STATUS_CARD_CHAR_BUDGET) return candidate
   }
 
@@ -515,11 +543,12 @@ function fitCardToBudget(opts: StatusCardOpts, headerLines: string[]): string {
   // newest text, then escape, then wrap — re-checking post-escape because
   // escaping can expand the string (& → &amp;).
   const rawNewest = body.length > 0 ? stripMarkdown(body[body.length - 1]).replace(/\s+/g, ' ').trim() : ''
-  const wrapperOverhead = final
-    ? (prefix + '_✓ _').length
-    : (prefix + '**→ **').length + liveSuffix.length
+  const wrapperOverhead =
+    (final ? (prefix + '_✓ _').length : (prefix + '**→ **').length + liveSuffix.length) + nestCost
   const headerFooterCost =
-    fixedCost + (fixedCost > 0 ? 1 : 0) + (parentMarker != null ? parentMarker.length + 1 : 0)
+    fixedCost +
+    (fixedCost > 0 ? 1 : 0) +
+    (parentMarker != null ? parentMarker.length + nestCost + 1 : 0)
   const budget = STATUS_CARD_CHAR_BUDGET - headerFooterCost - wrapperOverhead
   let raw = rawNewest.slice(0, Math.max(0, budget))
   let newest = escapeMarkdown(raw)
@@ -533,7 +562,7 @@ function fitCardToBudget(opts: StatusCardOpts, headerLines: string[]): string {
   if (parentMarker != null) lines.push(parentMarker)
   lines.push(newestLine)
   lines.push(...footerLines)
-  return stackCardLines(lines, { collapseSafe: true })
+  return stack(lines)
 }
 
 /**
@@ -769,7 +798,7 @@ function glanceLine(rows: CombinedWorkerRow[]): string {
   const tok = rows.reduce((n, r) => n + (r.totalTokens ?? 0), 0)
   const toolWord = tools === 1 ? 'tool' : 'tools'
   return (
-    `🛠 **Workers** · _${rows.length} running · oldest ${formatFeedElapsed(oldestMs)}` +
+    `🛠 **WORKERS** · _${rows.length} running · oldest ${formatFeedElapsed(oldestMs)}` +
     ` · ${tools} ${toolWord}${tokenSegment(tok)}_`
   )
 }
@@ -778,13 +807,17 @@ function glanceLine(rows: CombinedWorkerRow[]): string {
  * Render N≥1 live workers into ONE combined feed body (ready Telegram
  * markdown; callers send verbatim — do NOT re-escape). Layout:
  *
- *   🛠 **Workers** · _N running · oldest {elapsed} · {n} tools · {t} tok_
- *   **1. {desc1}** _· {elapsed} · {n} tools_
- *      ~~_✓ {earlier step}_~~
- *      **→ {newest step}**
- *   **2. {desc2}** _· {elapsed} · {n} tools_
- *      **→ {newest step}**
- *   _+M more working…_
+ *   └─ 🛠 **WORKERS** · _N running · oldest {elapsed} · {n} tools · {t} tok_
+ *      **1. {desc1}** _· {elapsed} · {n} tools_
+ *         ~~_✓ {earlier step}_~~
+ *         **→ {newest step}**
+ *      **2. {desc2}** _· {elapsed} · {n} tools_
+ *         **→ {newest step}**
+ *      _+M more working…_
+ *
+ * SUBORDINATION (#3820): line 1 carries `└─ ` and every later line carries
+ * `SUBORDINATE_LINE_INDENT`, so the whole card reads as a child block of the
+ * 🤖 agent card rather than a second top-level card with the same silhouette.
  *
  * INDENT: every step line carries a leading `WORKER_STEP_INDENT` (a U+2800 run
  * — neither ASCII spaces nor U+00A0; Telegram left-trims BOTH, see the
@@ -893,7 +926,17 @@ export function renderCombinedWorkerFeed(
     // renders it collapsed to one line with the newlines dropped and nothing
     // substituted. Without the separator the glance line runs straight into
     // row 1's ordinal and every step glyph mashes into the previous line.
-    return { body: stackCardLines(out, { collapseSafe: true }), bodyLines: bodyOut.length }
+    //
+    // Subordinate nesting (#3820) is applied LAST, over the finished line list:
+    // the glance line takes `└─ ` and every row header / step / spill line takes
+    // one `SUBORDINATE_LINE_INDENT`, so this card reads as a child block of the
+    // 🤖 agent card the same way the single-worker card does. Step lines already
+    // carry WORKER_STEP_INDENT, so they end up one level deeper than their row
+    // header — the intra-card hierarchy is preserved, just shifted right.
+    return {
+      body: stackCardLines(nestSubordinateCardLines(out), { collapseSafe: true }),
+      bodyLines: bodyOut.length,
+    }
   }
 
   // Cap to maxRows first, then shrink the visible set while EITHER the total

--- a/telegram-plugin/uat/assertions.ts
+++ b/telegram-plugin/uat/assertions.ts
@@ -72,6 +72,25 @@ const ACTIVITY_BODY_LINE_RE = /^[→✓↳]/u;
  * Elapsed is `formatFeedElapsed`: `<N>s` under a minute, else `<M>m<SS>s`.
  */
 const LIVENESS_HEADER_L1_RE = /^(?:🤖|🛠[️]?|⚙[️]?)\s+\S/u;
+
+/**
+ * Leading chrome a SUBORDINATE (worker) card carries since #3820: the `└─ `
+ * header prefix on line 1 and a `U+2800` indent run on every later line, which
+ * together make the worker card readable as a child of the 🤖 agent card.
+ *
+ * Every line-shape matcher below must normalise it away first: Telegram
+ * delivers both verbatim, and NEITHER is stripped by `String.trim()` — U+2800
+ * is category So, not whitespace (that property is exactly why it survives
+ * Telegram's own left-trim; see WORKER_STEP_INDENT). Without this, a worker
+ * card's header stops matching `LIVENESS_HEADER_L1_RE` and its body lines stop
+ * matching `ACTIVITY_BODY_LINE_RE`.
+ */
+const SUBORDINATE_CARD_PREFIX_RE = /^(?:└─\s*|\u2800+)+/u;
+
+/** A card line with its subordinate-card nesting chrome removed, trimmed. */
+export function stripCardNesting(line: string): string {
+  return line.replace(SUBORDINATE_CARD_PREFIX_RE, "").trim();
+}
 const LIVENESS_ELAPSED = String.raw`(?:\d+m)?\d+s`;
 const LIVENESS_HEADER_L2_RE = new RegExp(
   `^(?:${LIVENESS_ELAPSED}\\s*·\\s*\\d+\\s+tools?` +
@@ -94,7 +113,7 @@ const LIVENESS_HEADER_L2_RE = new RegExp(
 export function isLivenessCardMessage(m: ObservedMessage): boolean {
   const lines = m.text
     .split("\n")
-    .map((l) => l.trim())
+    .map((l) => stripCardNesting(l))
     .filter((l) => l.length > 0);
   if (lines.length < 2) return false;
   if (!LIVENESS_HEADER_L1_RE.test(lines[0])) return false;
@@ -124,7 +143,7 @@ export function isLivenessCardMessage(m: ObservedMessage): boolean {
 export function isActivityFeedMessage(m: ObservedMessage): boolean {
   const lines = m.text
     .split("\n")
-    .map((l) => l.trim())
+    .map((l) => stripCardNesting(l))
     .filter((l) => l.length > 0);
   if (lines.length === 0) return false;
   if (lines.every((l) => ACTIVITY_FEED_LINE_RE.test(l))) return true;

--- a/telegram-plugin/uat/feed-matcher.test.ts
+++ b/telegram-plugin/uat/feed-matcher.test.ts
@@ -4,6 +4,7 @@ import {
   isFrameworkFallbackText,
   isLivenessCardMessage,
   isWorkerFeedMessage,
+  stripCardNesting,
   WORKER_FEED_RE,
 } from "./assertions.js";
 
@@ -49,6 +50,34 @@ describe("isWorkerFeedMessage", () => {
 
   it("exposes the regex for scenarios that assert on the feed directly", () => {
     expect(WORKER_FEED_RE.test("🛠 Worker · x")).toBe(true);
+  });
+
+  it("still matches the #3820 SUBORDINATE worker card as Telegram delivers it", () => {
+    // Since #3820 the worker card leads with `└─ ` and indents every later line
+    // with a U+2800 run so it reads as a child of the 🤖 agent card. Telegram
+    // strips the bold/italic entities but delivers that chrome verbatim, and
+    // `String.trim()` removes neither (U+2800 is category So, not whitespace) —
+    // so every matcher here has to survive it or recall/reply scenarios start
+    // latching onto worker cards as answers.
+    const nested = "└─ 🛠 WORKER · crawling changelog\n⠀⠀⠀55s · 9 tools · opus 5";
+    expect(isWorkerFeedMessage(feed(nested))).toBe(true);
+  });
+});
+
+describe("#3820 subordinate-card nesting is transparent to the matchers", () => {
+  it("classifies a nested agent-shaped card as the liveness card, not an answer", () => {
+    const nested =
+      "└─ 🛠 WORKER · crawl\n⠀⠀⠀12s · 3 tools\n⠀⠀⠀✓ Reading CLAUDE.md\n⠀⠀⠀→ Searching memory";
+    expect(isLivenessCardMessage(feed(nested))).toBe(true);
+    expect(isActivityFeedMessage(feed(nested))).toBe(true);
+  });
+
+  it("strips the header prefix and the indent, and leaves ordinary prose alone", () => {
+    expect(stripCardNesting("└─ 🛠 WORKER · crawl")).toBe("🛠 WORKER · crawl");
+    expect(stripCardNesting("⠀⠀⠀→ Searching memory")).toBe("→ Searching memory");
+    expect(stripCardNesting("on it, pulling the logs now")).toBe(
+      "on it, pulling the logs now",
+    );
   });
 });
 

--- a/telegram-plugin/uat/scenarios/jtbd-liveness-narration-channel.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-liveness-narration-channel.test.ts
@@ -11,7 +11,11 @@
 
 import { describe, expect, it } from "vitest";
 import { spinUp } from "../harness.js";
-import { isActivityFeedMessage, isFrameworkFallbackText } from "../assertions.js";
+import {
+  isActivityFeedMessage,
+  isFrameworkFallbackText,
+  stripCardNesting,
+} from "../assertions.js";
 import type { ObservedMessage } from "../driver.js";
 
 const AGENT = "test-harness";
@@ -30,7 +34,10 @@ const NARRATED_WORK_PROMPT =
 function narratedBodyLines(text: string): string[] {
   return text
     .split("\n")
-    .map((l) => l.trim())
+    // strip the #3820 subordinate-card nesting (`└─ ` / U+2800 indent) first —
+    // `trim()` removes neither, and a worker card's header/body lines would
+    // otherwise read as model narration
+    .map((l) => stripCardNesting(l))
     .filter((l) => l.length > 0)
     .map((l) => l.replace(/^[→✓↳]+\s*/u, "").trim())
     .filter(

--- a/telegram-plugin/uat/scenarios/jtbd-liveness-narration-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-liveness-narration-dm.test.ts
@@ -17,7 +17,11 @@
 
 import { describe, expect, it } from "vitest";
 import { spinUp } from "../harness.js";
-import { isActivityFeedMessage, isFrameworkFallbackText } from "../assertions.js";
+import {
+  isActivityFeedMessage,
+  isFrameworkFallbackText,
+  stripCardNesting,
+} from "../assertions.js";
 import type { ObservedMessage } from "../driver.js";
 
 /**
@@ -30,7 +34,10 @@ import type { ObservedMessage } from "../driver.js";
 function narratedBodyLines(text: string): string[] {
   return text
     .split("\n")
-    .map((l) => l.trim())
+    // strip the #3820 subordinate-card nesting (`└─ ` / U+2800 indent) first —
+    // `trim()` removes neither, and a worker card's header/body lines would
+    // otherwise read as model narration
+    .map((l) => stripCardNesting(l))
     .filter((l) => l.length > 0)
     // strip glyphs so a `→ Working…` placeholder compares as `Working…`
     .map((l) => l.replace(/^[→✓↳]+\s*/u, "").trim())

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -55,7 +55,11 @@ import {
   truncate,
   COLLAPSE_SAFE_SEPARATOR,
 } from './card-format.js'
-import { WORKER_HISTORY_MAX } from './status-no-truncate.js'
+import {
+  WORKER_HISTORY_MAX,
+  SUBORDINATE_HEADER_PREFIX,
+  SUBORDINATE_LINE_INDENT,
+} from './status-no-truncate.js'
 import {
   renderStatusCard,
   formatStepSuffix,
@@ -164,22 +168,30 @@ export function repeatCountOf(line: string): number {
 
 /**
  * Thin adapter over the unified `renderStatusCard` primitive (emoji 🛠, label
- * 'Worker'): builds the header, passes raw narrative steps (the primitive runs
- * stripMarkdown → collapse ws → clip → escape per line), and on finish passes
- * the cleaned result paragraph as the `result` block.
+ * 'WORKER', `subordinate: true`): builds the header, passes raw narrative steps
+ * (the primitive runs stripMarkdown → collapse ws → clip → escape per line),
+ * and on finish passes the cleaned result paragraph as the `result` block.
  *
  * Layout (running):
- *   🛠 <b>Worker</b> · <i>{description}</i>
- *   <i>{elapsed} · {n} tools</i>
- *   <s><i>✓ {earlier step}</i></s>
- *   <b>→ {newest step}</b>
+ *   └─ 🛠 **WORKER** · _{description}_
+ *      _{elapsed} · {n} tools_
+ *      ~~_✓ {earlier step}_~~
+ *      **→ {newest step}**
  *
  * Layout (finished): the feed renders all-done, then a rule + cleaned result:
- *   🛠 <b>Worker</b> · <i>{description}</i>
- *   <i>done · {n} tools · {elapsed}</i>
- *   <s><i>✓ {step}</i></s>
- *   ─────
- *   ✅ <i>{cleaned result paragraph}</i>
+ *   └─ 🛠 **WORKER** · _{description}_
+ *      _done · {n} tools · {elapsed}_
+ *      ~~_✓ {step}_~~
+ *      ─────
+ *      ✅ _{cleaned result paragraph}_
+ *
+ * SUBORDINATION (#3820): the `└─ ` prefix, the whole-block indent, and the
+ * caps `WORKER` label exist so this card cannot be mistaken for the 🤖 agent
+ * card at a glance on a phone. Before #3820 the two cards differed only by
+ * their emoji and one capitalised word while sharing the identical two-line
+ * header, stat row, and step trail. Do NOT "tidy" any of the three away
+ * individually: each is a separate one-glance cue, and the pair is frequently
+ * live in the same chat at the same time with overlapping step text.
  */
 export function renderWorkerActivity(v: WorkerActivityView, liveSuffix = ''): string {
   const desc = truncate(stripMarkdown(v.description).trim() || 'background task', DESC_MAX)
@@ -201,7 +213,9 @@ export function renderWorkerActivity(v: WorkerActivityView, liveSuffix = ''): st
 
   const header: Parameters<typeof renderStatusCard>[0]['header'] = {
     emoji: '🛠',
-    label: 'Worker',
+    // Caps (#3820, issue option 4): `WORKER` against the agent card's `Agent`
+    // is a high-contrast type label, not a same-shaped word one letter apart.
+    label: 'WORKER',
     description: desc,
     elapsedMs: v.elapsedMs,
     toolCount: v.toolCount,
@@ -237,10 +251,12 @@ export function renderWorkerActivity(v: WorkerActivityView, liveSuffix = ''): st
     // Lone-worker card: window to the w=1 point of Ken's curve (6) so it shows
     // the full recent trail, not the 5-line agent-card default (#3349).
     historyWindow: workerHistoryDepth(1),
+    // Structurally subordinate to the 🤖 agent card (#3820).
+    subordinate: true,
   })
   if (card == null) {
     // Unreachable (header always present) — defensive.
-    return `🛠 **Worker** · _starting…_`
+    return `${SUBORDINATE_HEADER_PREFIX}🛠 **WORKER** · _starting…_`
   }
   if (!finished && steps.length === 0) {
     // Header-only running render → append the starting placeholder with a GFM
@@ -249,7 +265,11 @@ export function renderWorkerActivity(v: WorkerActivityView, liveSuffix = ''): st
     // The collapse separator is carried here too (#3666) — this card is pinned,
     // and a hand-rolled seam would be the one boundary that still mashed in
     // Telegram's pinned bar.
-    return `${card}${COLLAPSE_SAFE_SEPARATOR}  \n_starting…_`
+    // The placeholder is a card BODY line, so it carries the subordinate indent
+    // like every other non-header line (#3820) — otherwise the one render state
+    // a user sees first (a just-dispatched worker) would be the one that isn't
+    // visibly nested.
+    return `${card}${COLLAPSE_SAFE_SEPARATOR}  \n${SUBORDINATE_LINE_INDENT}_starting…_`
   }
   return card
 }
@@ -598,7 +618,8 @@ const COOLDOWN_JITTER_MS = 500
  * tick, so it adds no edit churn / pin storm. Plain voice, no em dash.
  */
 const WORKER_CARD_SUPERSEDED_BODY =
-  '🛠 **Worker** · _continued_\n\n_Live progress moved to a fresh card to stay pinned._'
+  `${SUBORDINATE_HEADER_PREFIX}🛠 **WORKER** · _continued_\n\n` +
+  `${SUBORDINATE_LINE_INDENT}_Live progress moved to a fresh card to stay pinned._`
 
 function extractRetryAfterSecs(err: unknown): number | null {
   if (err == null || typeof err !== 'object') return null


### PR DESCRIPTION
Closes #3820.

## Root cause

Both status surfaces render through **one** primitive — `renderStatusCard` in `telegram-plugin/tool-activity-summary.ts`. The 🤖 agent card reaches it via `renderActivityFeed` / `renderActivityFeedWithNested` (`emoji: '🤖', label: 'Agent'`); the 🛠 worker card via `renderWorkerActivity` in `telegram-plugin/worker-activity-feed.ts` (was `emoji: '🛠', label: 'Worker'`). Same two header lines, same `Ns · N tools · Nk tok · model` stat row, same `✓`/`→` step trail — the cards were identical **by construction**, differing by an emoji and one word.

Worse, when a parent narrates the task it delegated the step text overlaps, so lines are *byte-identical* across the two cards. A test on the pre-fix renderer with identical steps + stats finds **3 fully overlapping lines** (the stat row and both step lines).

That shared primitive is the right seam, so the fix lands there rather than forking a second renderer.

## What changed (issue options 1 + 4)

- New `SUBORDINATE_HEADER_PREFIX` (`└─ `) and `SUBORDINATE_LINE_INDENT` (aliased to `WORKER_STEP_INDENT`, three U+2800) plus `nestSubordinateCardLines()` in `telegram-plugin/status-no-truncate.ts`. The whole worker card block sits one level in from the agent card's left margin — **parent vs child is readable from the block SHAPE**, not from reading the label.
- `renderStatusCard` gains `subordinate?: boolean`. The agent adapters never pass it; a non-subordinate render is byte-identical to before (asserted).
- `fitCardToBudget` charges the flat per-line nesting cost. The two prefixes are equal length by invariant, so no line-1 special case; an over-budget worker card still fits `STATUS_CARD_CHAR_BUDGET`.
- Type label to caps: `Worker` → `WORKER`, `Workers` → `WORKERS`.
- The three hand-rolled seams in `worker-activity-feed.ts` (defensive fallback, `starting…` append, superseded body) nested too — each has its own test.
- Combined 2+ worker card nests one level while keeping its internal hierarchy: row headers at one indent, their steps at two.

## Before / after (real renderer output)

Before — agent:
```
🤖 **Agent**
_1m48s · 15 tools · 16.4k tok · opus 5_
~~_✓ PR 2502 details_~~
**→ Commits since v0.8.5**
```
Before — worker (last three lines byte-identical to the agent card):
```
🛠 **Worker** · _Check upstream hindsight changes_
_55s · 9 tools · 47.5k tok · opus 5_
~~_✓ PR 2502 details_~~
**→ Commits since v0.8.5**
```
After — agent unchanged (byte-identical to baseline). Worker:
```
└─ 🛠 **WORKER** · _Check upstream hindsight changes_
⠀⠀⠀_55s · 9 tools · 47.5k tok · opus 5_
⠀⠀⠀~~_✓ PR 2502 details_~~
⠀⠀⠀**→ Commits since v0.8.5**
```
(the `⠀` are U+2800.)

## Telegram formatting reality — verified, not assumed

- **U+2800 BRAILLE PATTERN BLANK is category So, not Zs**, so no trimming rule (`\s`, `\p{White_Space}`, `\p{Zs}`) can classify it as whitespace, yet it renders as blank width. This is the same indent live-verified on a real phone on 2026-07-26 for the combined card; U+00A0 (shipped in #3662) renders **flat** because Telegram left-trims a leading Zs run. The test asserts the **property**, not the bytes — a byte-only assertion is what let #3662 ship green and inert.
- `└─` is ordinary ink: not one of the line-start block triggers in `render/line-start-guard.ts` (`#`, `>`, `-`/`+`/`*`, `N.`), so it can't be promoted to a list/quote/heading. (`· ` and `> ` are unusable for exactly that reason — documented on `WORKER_STEP_INDENT`.)
- All three card types verified byte-identical through the **real** outbound guard: `richMessage(card).markdown === card`.
- Pin/unpin lifecycle untouched; `pinned-card-collapse.test.ts` updated and its CONTROL re-targeted to the agent card (on a worker card the indent now separates every seam independently, so the old control could no longer isolate the collapse separator's contribution).

## Option 2 — deliberately NOT applied

Dropping the stat row from worker cards. The overlap evidence does show the stat row is one of the three identical lines — but the whole-block indent de-duplicates **all three** at once, and dropping tok/model would undo deliberately shipped features (live-model tag, per-worker token totals). Density isn't the lever; shape is. Filed as a follow-up so the decision is recorded rather than lost.

## Option 3 — deliberately NOT built

Merging worker cards into a `Workers (N)` section of the agent card is a bigger redesign that collides with #3349 / #3519. Nothing in the investigation suggested it's the *only* thing that fixes this. Filed as a follow-up.

## Tests

New `telegram-plugin/tests/card-type-distinguishability.test.ts`, 14 cases — **12 fail on pristine `origin/main`**. They assert rendered output, including the headline one: with identical steps and identical stats, `agent.filter(a => worker.includes(a))` is `[]` (was 3 lines).

`telegram-plugin/uat/assertions.ts` gains `stripCardNesting()` and the matchers use it — `String.trim()` strips neither `└─ ` nor U+2800, so without it a nested worker card would stop matching the liveness/activity matchers.

## Verification

- `npx vitest run telegram-plugin/` — 8366 pass, 1 fail: `approval-hold-record.test.ts > falls back to the agent's own state dir when the shared dir is not writable`, which **also fails on a pristine `origin/main` worktree** (we run as uid 0, so "not writable" can't be simulated). Pre-existing, filed as a follow-up.
- `npm run lint` — rc 0, including `check-bot-api-wrapping` and `check-gateway-line-ratchet`.
- `tsc --noEmit` — exit 0.
- `bun test telegram-plugin/uat/feed-matcher.test.ts` — 26 pass.

## Job spec

`reference/jobs/know-what-my-agent-is-doing.md` — "Good looks like" gains the one-glance distinguishability bullet naming #3820 as the failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
