### PR TITLE
perf(hindsight): carry upstream #2968 — one ANN scan per fact type, index-served id lookup (temporary, delete at v0.8.6)

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -125,6 +125,7 @@ jobs:
               - 'tests/docker/hindsight-search-patches.test.ts'
               - 'tests/docker/hindsight-recall-isolation-patches.test.ts'
               - 'tests/docker/hindsight-retry-perturbation-patches.test.ts'
+              - 'tests/docker/hindsight-graph-seed-patch.test.ts'
               - 'tests/docker/dockerfile-hindsight-bakes.test.ts'
               - '.github/workflows/docker-e2e.yml'
 
@@ -341,10 +342,27 @@ jobs:
           SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
         run: npx vitest run tests/docker/hindsight-retry-perturbation-patches.test.ts
 
+      - name: Run the hindsight graph-seed-reuse probe (RED/GREEN, must not skip)
+        # Same contract again, for the TEMPORARY upstream #2968 carry (merge
+        # b475f5cc, landed on upstream main after v0.8.5 was cut). Delete this
+        # step together with the Dockerfile block and the test file when the
+        # base image reaches v0.8.6.
+        #
+        # The bakes test cannot cover the failure that matters here: a carry
+        # that applies but hard-codes graph_seed_threshold keeps every grepped
+        # literal in place while silently NARROWING the graph seed set on any
+        # recall with min_scores.semantic > 0.3. Only running the patched
+        # modules and comparing derived seed ids against the dedicated query's
+        # catches it (measured 2026-07-27 — that mutation, and dropping the
+        # candidate-limit widening, each go red here and nowhere else).
+        env:
+          SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
+        run: npx vitest run tests/docker/hindsight-graph-seed-patch.test.ts
+
       - name: Label-scoped teardown
         if: always()
         run: |
-          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches; do
+          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-graph-seed-patch; do
             ids=$(docker ps -aq --filter "label=switchroom.test=$phase" 2>/dev/null || true)
             if [ -n "$ids" ]; then docker rm -f $ids 2>/dev/null || true; fi
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,6 +298,57 @@ host with CI green.
 Deliberately not done: `recallMaxMemories` was already declarative and is
 untouched.
 
+### Recall stops issuing a duplicate ANN scan per fact type (temporary carry of upstream hindsight #2968)
+
+Every recall ran the same vector scan twice per fact type. Step 2
+(`retrieve_semantic_bm25_combined`) over-fetches semantic candidates for HNSW
+recall; Step 3 then handed the graph retriever no seeds, so
+`LinkExpansionRetriever.retrieve` issued its own
+`ORDER BY embedding <=> $1::vector` — once per fact type, serialized behind the
+connection block Step 2 had just closed. Separately, `fetch_unit_dates` compared
+`id::text = ANY($1)`, casting the indexed primary key and forcing a sequential
+scan.
+
+Upstream fixed both in `vectorize-io/hindsight` PR #2968 (merge `b475f5cc`,
+2026-07-27), citing 302,602 calls / 2,072s of accumulated load for the redundant
+seed query and 120.049ms → 0.240ms median for the id lookup once
+`pk_memory_units` served it. That merge landed **after** v0.8.5 was cut, and
+v0.8.5 is upstream's tip release, so there is nothing to upgrade to.
+`docker/Dockerfile.hindsight` therefore carries the diff as a build-time patch,
+using the same self-verifying mechanism as the existing patches.
+
+**This block is temporary and its removal condition is written into it: delete
+it — with `tests/docker/hindsight-graph-seed-patch.test.ts` and the matching CI
+step — the moment the pinned base reaches upstream v0.8.6.**
+
+Reuse is not unconditional, and that is the whole safety argument. The shared
+pool is only reused when the semantic arm's SQL floor is *no stricter* than the
+graph seed floor; a per-request `min_scores.semantic` above 0.3 makes the pool
+narrower than the dedicated query's result, so the retriever falls back to its
+own query rather than silently returning fewer graph entry points. A quieter
+recall is worse than a slower one.
+
+switchroom shipped its own version of this optimisation and retired it when
+0.8.5 deliberately deleted the parameter it depended on. This is not a
+re-litigation of that: #2968 is upstream reversing its own stance one day later
+and adding the correctness guard the retired patch had to invent for itself. The
+negative guard that keeps the switchroom-authored form dead still stands,
+retargeted to that form's own markers.
+
+One deliberate divergence from upstream's diff: upstream reads the seed floor
+from `config.graph_seed_min_similarity`, a key v0.8.5 does not have (it hardcodes
+`limit=20, threshold=0.3`). The carry mirrors those literals as named constants
+and **asserts the config key is still absent**, so a future base that introduces
+it fails the build instead of quietly ignoring an operator's setting.
+
+Not carried: upstream PR #2502 (`stop emitting unsupported maxItems`). It fixes
+AWS Bedrock Converse rejecting `maxItems` in a structured-output schema. Measured
+against the backend this fleet actually uses (Ollama behind the LiteLLM proxy),
+a consolidation-shaped `json_schema` request with `maxItems` of none / 5 / 100 /
+1000 returned HTTP 200 every time with no latency trend (0.386–0.520s across 12
+calls). `maxItems` is neither rejected nor expensive here, so carrying the patch
+would add a maintenance obligation for no effect.
+
 ### `switchroom doctor` detects banks with no per-bank vector index
 
 Hindsight creates one PARTIAL vector index per (bank, fact_type) — and creates

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -2055,6 +2055,532 @@ ast.parse(t)
 print("switchroom hindsight perturbed-JSON-retry patch: invalid-JSON retries now bypass the proxy response cache and raise temperature instead of replaying the identical request")
 PYEOF
 
+# ── UPSTREAM CARRY: vectorize-io/hindsight PR #2968 ───────────────────────────
+# perf: eliminate redundant graph seed and UUID scans
+#   upstream PR:    https://github.com/vectorize-io/hindsight/pull/2968
+#   merge commit:   b475f5cc
+#   merged:         2026-07-27T10:12:30Z, to upstream `main`
+#   in a release:   NO. v0.8.5 (the digest pinned above) is upstream's tip
+#                   release and predates it.
+#
+# DELETE THIS BLOCK WHEN, and only when, the `FROM` digest above resolves to
+# upstream v0.8.6 or newer — the first release that contains b475f5cc natively.
+# At that point this patch's anchors will no longer match and the build will
+# fail loudly, which is the reminder. Re-assert its absence in
+# tests/docker/dockerfile-hindsight-bakes.test.ts the same way the retired
+# patches are, so it cannot double-apply on a later rebase.
+#
+# WHAT IT DOES — two independent wins in one upstream commit:
+#
+#   1. Graph seeds are derived from the semantic/BM25 over-fetch pool that
+#      `retrieve_semantic_bm25_combined` has ALREADY fetched, instead of each
+#      fact type issuing its own dedicated `ORDER BY embedding <=> $1::vector`
+#      through `_find_semantic_seeds`. A 3-fact-type recall did 4 ANN scans
+#      where 1 suffices. Upstream's production evidence: 302,602 calls /
+#      2,072s accumulated server-side load eliminated. On THIS fleet the same
+#      call rate is 708 recalls in 6h (`docker logs switchroom-hindsight`,
+#      2026-07-27) x 3 fact types ~= 8,500 dedicated ANN seed scans a day.
+#
+#   2. `fetch_unit_dates` compares `memory_units.id` as a UUID instead of
+#      casting the indexed column with `id::text = ANY($1)`, which forced a
+#      sequential scan. Upstream measured 120.049ms -> 0.240ms median (seq scan
+#      -> `pk_memory_units`) and 9.005ms -> 0.0795ms on a 100k-row bench.
+#      Non-canonical inputs (malformed, uppercase, braced, unhyphenated) were
+#      silently ignored by the old text comparison and are still ignored, by
+#      filtering them out BEFORE the cast — so behaviour is preserved, not
+#      merely "fixed".
+#
+# HISTORY YOU NEED BEFORE TOUCHING THIS. switchroom shipped its OWN version of
+# (1) as the `duplicate-ANN-scan` patch in #3699, and RETIRED it in #3768 when
+# bumping to v0.8.5, because 0.8.5 DELETED the `semantic_seeds` parameter our
+# patch depended on and documented the removal as deliberate ("Graph traversal
+# deliberately chooses its own bounded seeds ... reusing their results would
+# silently change graph-retrieval recall behavior"). #2968 is upstream
+# REVERSING that stance one day later, and it lands the correctness guard our
+# retired patch had to invent for itself: the shared pool is reusable only when
+# the semantic arm's SQL floor is at or below the graph seed threshold, so the
+# derived seed set can never be NARROWER than the dedicated query's. This is
+# therefore not a re-litigation of #3768 — it is upstream's own design, carried.
+# The retired switchroom-authored form must still never come back; the negative
+# guards in tests/docker/dockerfile-hindsight-bakes.test.ts target its unique
+# markers (`duplicate-ANN-scan`, `_graph_semantic_seeds`, `semantic_seeds=None`,
+# the leading-underscore `_GRAPH_SEED_*` constants), not the upstream names.
+#
+# DELIBERATE DIVERGENCE FROM THE UPSTREAM DIFF, and why. Upstream main reads the
+# graph seed floor from `get_config().graph_seed_min_similarity`. That config
+# key DOES NOT EXIST in v0.8.5 — the seed call site hardcodes
+# `limit=20, threshold=0.3`. So this carry introduces the two literals as named
+# module constants `GRAPH_SEED_LIMIT` / `GRAPH_SEED_MIN_SIMILARITY` and uses
+# them everywhere upstream uses the config value. That is byte-equivalent to
+# v0.8.5's behaviour. The block ASSERTS the config key is still absent: if a
+# future base adds it, this hardcoded 0.3 would silently ignore an operator's
+# setting, so the build must fail instead.
+#
+# EQUIVALENCE ARGUMENT (why the derived seeds are the same rows). Both queries
+# hit the same table with the same bank_id / fact_type / tags / tag_groups /
+# created-range filters and the same `ORDER BY embedding <=> $1::vector`. The
+# combined arm over-fetches `max(limit * 5, 100)` per fact type, i.e. always
+# >= 100 > GRAPH_SEED_LIMIT, so the top-20 above the seed floor are present in
+# the pool. `semantic_candidate_limit = max(limit, GRAPH_SEED_LIMIT)` stops the
+# Python trim from cutting a seed when `thinking_budget < 20`. And the reuse is
+# DECLINED outright, falling back to upstream's own dedicated query, whenever
+# `sem_min > GRAPH_SEED_MIN_SIMILARITY` (a per-request `min_scores.semantic`
+# above 0.3), because the pool would then be narrower than the seed query's.
+# LinkExpansion consumes seeds by id alone (`seed_ids = list({s.id for s in
+# all_seeds})`), so id-set equality is the whole equivalence relation.
+#
+# Row ORDER is trusted, not re-sorted — unlike the retired switchroom patch,
+# which sorted defensively. That is not a new assumption: v0.8.5's own semantic
+# trim already takes the FIRST `limit` rows per fact type out of the same
+# UNION ALL result, so if the row order were not similarity-ordered the
+# semantic arm would already be wrong.
+#
+# Self-verifying (every anchor is exact-once and every file is re-parsed with
+# `ast.parse`); guarded structurally by
+# tests/docker/dockerfile-hindsight-bakes.test.ts and behaviourally (RED against
+# unpatched upstream / GREEN patched) by
+# tests/docker/hindsight-graph-seed-patch.test.ts.
+RUN python3 - <<'PYEOF'
+import ast
+import pathlib
+
+BASE = pathlib.Path("/app/api/hindsight_api")
+TAG = "switchroom hindsight graph-seed-reuse carry (upstream #2968)"
+
+
+def apply(rel, edits):
+    """Exact-once anchored replacement, then re-parse. Fails loud on drift."""
+    f = BASE / rel
+    s = f.read_text()
+    for label, anchor, repl in edits:
+        n = s.count(anchor)
+        assert n == 1, (
+            f"{TAG}: the {label!r} anchor was found {n}x (expected 1) in {rel}. "
+            "If the base image is now upstream v0.8.6 or newer, this whole patch "
+            "block is ADOPTED — delete it from docker/Dockerfile.hindsight and "
+            "assert its absence in tests/docker/dockerfile-hindsight-bakes.test.ts. "
+            "Otherwise upstream reformatted and the patch must be re-authored."
+        )
+        s = s.replace(anchor, repl, 1)
+    f.write_text(s)
+    ast.parse(s)
+    return s
+
+
+# ---- 0. the divergence guard ------------------------------------------------
+# Upstream main reads this floor from config; v0.8.5 hardcodes 0.3. If a future
+# base introduces the config key, the mirrored constant below would silently
+# ignore the operator's setting, so refuse to build rather than diverge.
+_cfg = (BASE / "config.py").read_text()
+assert "graph_seed_min_similarity" not in _cfg, (
+    f"{TAG}: config.py now defines `graph_seed_min_similarity`, but this patch "
+    "mirrors the v0.8.5 hardcoded 0.3 into GRAPH_SEED_MIN_SIMILARITY. Carrying it "
+    "unchanged would ignore the operator's configured floor — re-author against the "
+    "config value (or delete this block if the base already carries upstream #2968)."
+)
+
+
+# ---- 1. link_expansion_retrieval.py: accept preselected seeds ---------------
+le = apply("engine/search/link_expansion_retrieval.py", [
+    (
+        "seed constants",
+        "logger = logging.getLogger(__name__)\n"
+        "\n"
+        "\n"
+        "async def _find_semantic_seeds(\n",
+
+        "logger = logging.getLogger(__name__)\n"
+        "\n"
+        "# switchroom carry of upstream #2968. Upstream main names these\n"
+        "# GRAPH_SEED_LIMIT and config.graph_seed_min_similarity; v0.8.5 has no such\n"
+        "# config key and hardcodes limit=20/threshold=0.3 at the single call site\n"
+        "# below, so the literals are hoisted here unchanged and shared with\n"
+        "# search/retrieval.py, which needs the SAME numbers to derive an identical\n"
+        "# seed set from the combined semantic pool.\n"
+        "GRAPH_SEED_LIMIT = 20\n"
+        "GRAPH_SEED_MIN_SIMILARITY = 0.3\n"
+        "\n"
+        "\n"
+        "async def _find_semantic_seeds(\n",
+    ),
+    (
+        "retrieve() signature",
+        '        created_before: "datetime | None" = None,\n'
+        "    ) -> tuple[list[RetrievalResult], GraphRetrievalTimings | None]:\n"
+        '        """\n'
+        "        Retrieve facts by expanding links from seeds.\n",
+
+        '        created_before: "datetime | None" = None,\n'
+        "        # switchroom carry of upstream #2968: graph entry points already\n"
+        "        # derived by the caller from the shared semantic candidate pool. An\n"
+        "        # EMPTY list is a real answer (no seeds cleared the floor) and must NOT\n"
+        "        # fall back to a second ANN scan; only None means 'not preselected'.\n"
+        "        preselected_semantic_seeds: list[RetrievalResult] | None = None,\n"
+        "    ) -> tuple[list[RetrievalResult], GraphRetrievalTimings | None]:\n"
+        '        """\n'
+        "        Retrieve facts by expanding links from seeds.\n",
+    ),
+    (
+        "seed fetch",
+        "        async with acquire_with_retry(pool) as conn:\n"
+        "            # Graph traversal deliberately chooses its own bounded seeds. The semantic and temporal\n"
+        "            # retrieval arms have independent candidate limits and thresholds, so reusing their\n"
+        "            # results would silently change graph-retrieval recall behavior.\n"
+        "            seeds_start = time.time()\n"
+        "            all_seeds = await _find_semantic_seeds(\n"
+        "                conn,\n"
+        "                query_embedding_str,\n"
+        "                bank_id,\n"
+        "                fact_type,\n"
+        "                limit=20,\n"
+        "                threshold=0.3,\n"
+        "                tags=tags,\n"
+        "                tags_match=tags_match,\n"
+        "                tag_groups=tag_groups,\n"
+        "                created_after=created_after,\n"
+        "                created_before=created_before,\n"
+        "            )\n"
+        "            timings.seeds_time = time.time() - seeds_start\n",
+
+        "        async with acquire_with_retry(pool) as conn:\n"
+        "            if preselected_semantic_seeds is None:\n"
+        "                # switchroom carry of upstream #2968: the caller could not prove the\n"
+        "                # shared semantic pool covers this arm's threshold (a per-request\n"
+        "                # min_scores.semantic above GRAPH_SEED_MIN_SIMILARITY narrows it), so\n"
+        "                # keep graph retrieval's own query and result semantics. A silently\n"
+        "                # narrowed seed set is a quieter recall, which is worse than a slower one.\n"
+        "                seeds_start = time.time()\n"
+        "                all_seeds = await _find_semantic_seeds(\n"
+        "                    conn,\n"
+        "                    query_embedding_str,\n"
+        "                    bank_id,\n"
+        "                    fact_type,\n"
+        "                    limit=GRAPH_SEED_LIMIT,\n"
+        "                    threshold=GRAPH_SEED_MIN_SIMILARITY,\n"
+        "                    tags=tags,\n"
+        "                    tags_match=tags_match,\n"
+        "                    tag_groups=tag_groups,\n"
+        "                    created_after=created_after,\n"
+        "                    created_before=created_before,\n"
+        "                )\n"
+        "                timings.seeds_time = time.time() - seeds_start\n"
+        "            else:\n"
+        "                all_seeds = preselected_semantic_seeds\n",
+    ),
+])
+
+
+# ---- 2. graph_retrieval.py: the abstract signature --------------------------
+gr = apply("engine/search/graph_retrieval.py", [
+    (
+        "abstract retrieve() signature",
+        "        created_before: datetime | None = None,  # Only include memory_units created before this time\n"
+        "    ) -> tuple[list[RetrievalResult], GraphRetrievalTimings | None]:\n",
+
+        "        created_before: datetime | None = None,  # Only include memory_units created before this time\n"
+        "        # switchroom carry of upstream #2968: graph entry points already fetched by\n"
+        "        # the caller from the shared semantic candidate pool (None = not preselected).\n"
+        "        preselected_semantic_seeds: list[RetrievalResult] | None = None,\n"
+        "    ) -> tuple[list[RetrievalResult], GraphRetrievalTimings | None]:\n",
+    ),
+])
+
+
+# ---- 3. retrieval.py: derive the seeds from the pool already fetched --------
+rt = apply("engine/search/retrieval.py", [
+    (
+        "seed-constant import",
+        "from .link_expansion_retrieval import LinkExpansionRetriever\n",
+        "from .link_expansion_retrieval import (\n"
+        "    GRAPH_SEED_LIMIT,\n"
+        "    GRAPH_SEED_MIN_SIMILARITY,\n"
+        "    LinkExpansionRetriever,\n"
+        ")\n",
+    ),
+    (
+        "SemanticBm25Result dataclass",
+        "# Default graph retriever instance (can be overridden)\n",
+
+        "@dataclass\n"
+        "class SemanticBm25Result:\n"
+        '    """Per-fact-type candidates returned by the shared semantic/BM25 query.\n'
+        "\n"
+        "    switchroom carry of upstream #2968. ``graph_seeds`` is None — meaning the\n"
+        "    graph retriever must issue its own dedicated seed query — whenever the\n"
+        "    semantic arm's SQL floor is STRICTER than GRAPH_SEED_MIN_SIMILARITY, because\n"
+        "    the shared pool would then be narrower than the seed query's own result.\n"
+        '    """\n'
+        "\n"
+        "    semantic: list[RetrievalResult]\n"
+        "    bm25: list[RetrievalResult]\n"
+        "    graph_seeds: list[RetrievalResult] | None\n"
+        "\n"
+        "\n"
+        "# Default graph retriever instance (can be overridden)\n",
+    ),
+    (
+        "combined-retrieval signature",
+        "    min_keyword: float | None = None,\n"
+        ") -> dict[str, tuple[list[RetrievalResult], list[RetrievalResult]]]:\n",
+
+        "    min_keyword: float | None = None,\n"
+        "    # switchroom carry of upstream #2968: the graph arm's seed floor. Passing it\n"
+        "    # lets this query double as the graph seed query when its own floor is no\n"
+        "    # stricter; leaving it None preserves the pre-#2968 behaviour exactly.\n"
+        "    graph_seed_min_similarity: float | None = None,\n"
+        ") -> dict[str, SemanticBm25Result]:\n",
+    ),
+    (
+        "result_dict init",
+        "    Returns:\n"
+        "        Dict mapping fact_type -> (semantic_results, bm25_results)\n"
+        '    """\n'
+        "    result_dict: dict[str, tuple[list[RetrievalResult], list[RetrievalResult]]] = {ft: ([], []) for ft in fact_types}\n",
+
+        "    Returns:\n"
+        "        Candidate groups for each fact type. ``graph_seeds`` is ``None`` when\n"
+        "        the semantic query's threshold is too strict to cover graph entry points.\n"
+        '    """\n'
+        "    result_dict = {ft: SemanticBm25Result(semantic=[], bm25=[], graph_seeds=None) for ft in fact_types}\n",
+    ),
+    (
+        "grouping loop",
+        "    # Group results; trim semantic to limit (over-fetched for HNSW approximation).\n"
+        "    sem_counts: dict[str, int] = {ft: 0 for ft in fact_types}\n"
+        "    for r in rows:\n"
+        "        row = dict(r)\n"
+        '        source = row.pop("source")\n'
+        '        ft = row.get("fact_type")\n'
+        "        if ft not in result_dict:\n"
+        "            continue\n"
+        '        if source == "semantic":\n'
+        "            if sem_counts[ft] < limit:\n"
+        "                result_dict[ft][0].append(RetrievalResult.from_db_row(row))\n"
+        "                sem_counts[ft] += 1\n"
+        "        else:\n"
+        "            result_dict[ft][1].append(RetrievalResult.from_db_row(row))\n"
+        "\n"
+        "    return result_dict\n",
+
+        "    # Group results. The semantic SQL deliberately over-fetches for HNSW recall;\n"
+        "    # when that pool also covers the graph threshold, derive graph entry points\n"
+        "    # from the same ordered rows instead of issuing one duplicate ANN query per\n"
+        "    # fact type (switchroom carry of upstream #2968). Convert only the prefix\n"
+        "    # either consumer can observe, not the entire HNSW over-fetch pool.\n"
+        "    graph_seed_threshold = (\n"
+        "        graph_seed_min_similarity\n"
+        "        if graph_seed_min_similarity is not None and sem_min <= graph_seed_min_similarity\n"
+        "        else None\n"
+        "    )\n"
+        "    semantic_candidate_limit = max(limit, GRAPH_SEED_LIMIT if graph_seed_threshold is not None else 0)\n"
+        "    semantic_candidates: dict[str, list[RetrievalResult]] = {ft: [] for ft in fact_types}\n"
+        "    for r in rows:\n"
+        "        row = dict(r)\n"
+        '        source = row.pop("source")\n'
+        '        ft = row.get("fact_type")\n'
+        "        if ft not in result_dict:\n"
+        "            continue\n"
+        '        if source == "semantic":\n'
+        "            if len(semantic_candidates[ft]) < semantic_candidate_limit:\n"
+        "                semantic_candidates[ft].append(RetrievalResult.from_db_row(row))\n"
+        "        else:\n"
+        "            result_dict[ft].bm25.append(RetrievalResult.from_db_row(row))\n"
+        "\n"
+        "    for ft, candidates in semantic_candidates.items():\n"
+        "        result_dict[ft].semantic.extend(candidates[:limit])\n"
+        "        if graph_seed_threshold is not None:\n"
+        "            result_dict[ft].graph_seeds = [\n"
+        "                candidate\n"
+        "                for candidate in candidates\n"
+        "                if candidate.similarity is not None and candidate.similarity >= graph_seed_threshold\n"
+        "            ][:GRAPH_SEED_LIMIT]\n"
+        "\n"
+        "    return result_dict\n",
+    ),
+    (
+        "combined-retrieval call site",
+        "            min_keyword=min_keyword,\n"
+        "        )\n"
+        "        semantic_bm25_time = time.time() - semantic_bm25_start\n",
+
+        "            min_keyword=min_keyword,\n"
+        "            # switchroom carry of upstream #2968: opt this query in to also\n"
+        "            # producing the graph arm's entry points. v0.8.5 has no\n"
+        "            # config.graph_seed_min_similarity, so the mirrored constant is passed.\n"
+        "            graph_seed_min_similarity=GRAPH_SEED_MIN_SIMILARITY,\n"
+        "        )\n"
+        "        semantic_bm25_time = time.time() - semantic_bm25_start\n",
+    ),
+    (
+        "graph retriever call site",
+        "            created_after=created_after,\n"
+        "            created_before=created_before,\n"
+        "        )\n"
+        "        return ft, results, time.time() - graph_start, graph_timing\n",
+
+        "            created_after=created_after,\n"
+        "            created_before=created_before,\n"
+        "            # switchroom carry of upstream #2968: None here means the shared pool\n"
+        "            # could not be proven to cover this arm's floor, and the retriever\n"
+        "            # falls back to its own dedicated ANN seed query.\n"
+        "            preselected_semantic_seeds=semantic_bm25_results[ft].graph_seeds,\n"
+        "        )\n"
+        "        return ft, results, time.time() - graph_start, graph_timing\n",
+    ),
+    (
+        "per-fact-type unpack",
+        "        semantic_results, bm25_results = semantic_bm25_results.get(ft, ([], []))\n",
+        "        semantic_results = semantic_bm25_results[ft].semantic\n"
+        "        bm25_results = semantic_bm25_results[ft].bm25\n",
+    ),
+])
+
+
+# ---- 4. consolidator.py: the other caller of the combined query -------------
+cons = apply("engine/consolidation/consolidator.py", [
+    (
+        "dedup probe unpack",
+        '    results = grouped.get("observation", ([], []))[0]\n',
+        "    # switchroom carry of upstream #2968: the combined query now returns a\n"
+        "    # SemanticBm25Result per requested fact type (always populated, so the\n"
+        "    # .get() default is dead). This caller passes no graph_seed_min_similarity,\n"
+        "    # so .graph_seeds is None and no extra work is done on its behalf.\n"
+        '    results = grouped["observation"].semantic\n',
+    ),
+])
+
+
+# ---- 5. ops_postgresql.py: index-served UUID lookup -------------------------
+# `id::text = ANY($1)` casts the INDEXED column and forces a sequential scan.
+# Filtering non-canonical inputs out BEFORE casting them to uuid preserves the
+# old predicate's tolerance (malformed / uppercase / braced / unhyphenated ids
+# matched nothing then and match nothing now) while letting pk_memory_units
+# serve the lookup. NOT an f-string here: the `{{8}}` braces are literal and
+# must survive into the module's own f-string quantifiers unchanged.
+ops = apply("engine/db/ops_postgresql.py", [
+    (
+        "fetch_unit_dates predicate",
+        "        return await conn.fetch(\n"
+        '            f"""\n'
+        "            SELECT id, event_date, fact_type\n"
+        "            FROM {mu_table}\n"
+        "            WHERE id::text = ANY($1)\n"
+        '            """,\n'
+        "            unit_ids,\n"
+        "        )\n",
+
+        "        # switchroom carry of upstream #2968: cast only canonical UUID text\n"
+        "        # inputs, never the indexed column. The old ``id::text`` predicate\n"
+        "        # silently ignored malformed, uppercase, braced, and unhyphenated\n"
+        "        # inputs; filtering before the cast preserves that behavior while\n"
+        "        # allowing the primary-key index to serve the lookup.\n"
+        "        return await conn.fetch(\n"
+        '            f"""\n'
+        "            SELECT id, event_date, fact_type\n"
+        "            FROM {mu_table}\n"
+        "            WHERE id = ANY(\n"
+        "                ARRAY(\n"
+        "                    SELECT input.unit_id::uuid\n"
+        "                    FROM unnest($1::text[]) AS input(unit_id)\n"
+        "                    WHERE input.unit_id ~ '^[0-9a-f]{{8}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{12}}$'\n"
+        "                )\n"
+        "            )\n"
+        '            """,\n'
+        "            unit_ids,\n"
+        "        )\n",
+    ),
+])
+
+
+# ---- verification ----------------------------------------------------------
+# Post-replace re-assertions. These are the ones that would catch a patch that
+# applied but landed inert, which the anchor counts above cannot.
+assert "GRAPH_SEED_LIMIT = 20" in le and "GRAPH_SEED_MIN_SIMILARITY = 0.3" in le, (
+    f"{TAG}: the mirrored seed constants are missing from link_expansion_retrieval.py"
+)
+assert "if preselected_semantic_seeds is None:" in le, (
+    f"{TAG}: LinkExpansionRetriever.retrieve does not branch on preselected seeds — "
+    "the dedicated ANN seed query is still unconditional"
+)
+assert "                all_seeds = preselected_semantic_seeds" in le, (
+    f"{TAG}: the preselected-seed branch does not actually use the caller's seeds"
+)
+assert le.count("await _find_semantic_seeds(") == 1, (
+    f"{TAG}: expected exactly one remaining _find_semantic_seeds call site (the fallback)"
+)
+assert "preselected_semantic_seeds: list[RetrievalResult] | None = None," in gr, (
+    f"{TAG}: the abstract GraphRetriever.retrieve signature does not accept preselected "
+    "seeds — a non-LinkExpansion retriever would TypeError at the call site"
+)
+assert "class SemanticBm25Result:" in rt, (
+    f"{TAG}: SemanticBm25Result is missing from search/retrieval.py"
+)
+assert "GRAPH_SEED_MIN_SIMILARITY," in rt, (
+    f"{TAG}: search/retrieval.py does not import the mirrored seed floor"
+)
+assert "graph_seed_min_similarity=GRAPH_SEED_MIN_SIMILARITY," in rt, (
+    f"{TAG}: retrieve_all_fact_types_parallel never opts the combined query in to "
+    "producing graph seeds — the patch would apply and do nothing"
+)
+assert "preselected_semantic_seeds=semantic_bm25_results[ft].graph_seeds," in rt, (
+    f"{TAG}: the graph retriever call site does not forward the derived seeds — "
+    "the duplicate ANN scan is still reachable"
+)
+# The GUARD, not just the derivation. Hard-coding graph_seed_threshold to a
+# non-None value would keep every other assertion here green while silently
+# narrowing the seed set whenever a caller passes min_scores.semantic > 0.3.
+assert (
+    "        if graph_seed_min_similarity is not None and sem_min <= graph_seed_min_similarity\n"
+) in rt, (
+    f"{TAG}: the seed-reuse guard no longer requires the semantic floor to be no "
+    "stricter than the graph floor — a per-request min_scores.semantic above 0.3 "
+    "would silently narrow the graph seed set"
+)
+# The trim must not be able to cut a seed out of the pool it feeds.
+assert (
+    "    semantic_candidate_limit = max(limit, GRAPH_SEED_LIMIT if graph_seed_threshold is not None else 0)\n"
+) in rt, (
+    f"{TAG}: the semantic candidate limit no longer widens to GRAPH_SEED_LIMIT — a "
+    "thinking_budget below 20 would trim rows the dedicated seed query would have returned"
+)
+assert "result_dict[ft][0].append" not in rt and "result_dict[ft][1].append" not in rt, (
+    f"{TAG}: a tuple-shaped result_dict write survives in search/retrieval.py"
+)
+assert "semantic_bm25_results.get(ft, ([], []))" not in rt, (
+    f"{TAG}: a tuple-shaped unpack survives in retrieve_all_fact_types_parallel"
+)
+assert 'grouped.get("observation", ([], []))[0]' not in cons, (
+    f"{TAG}: the consolidation dedup probe still unpacks the old tuple shape — it would "
+    "raise AttributeError on every dedup adjudication"
+)
+assert "id::text = ANY($1)" not in ops, (
+    f"{TAG}: fetch_unit_dates still casts the indexed id column to text — the sequential "
+    "scan is still there"
+)
+assert "SELECT input.unit_id::uuid" in ops, (
+    f"{TAG}: the canonical-UUID pre-filter is missing from fetch_unit_dates"
+)
+# Every OTHER caller of the combined query must have been migrated: a missed one
+# is an AttributeError on a live recall path, not a build failure.
+_stale = []
+for _p in BASE.rglob("*.py"):
+    _t = _p.read_text()
+    if "retrieve_semantic_bm25_combined" not in _t:
+        continue
+    if "([], [])" in _t:
+        _stale.append(str(_p.relative_to(BASE)))
+assert not _stale, (
+    f"{TAG}: {_stale} still reference the old (semantic, bm25) tuple shape of "
+    "retrieve_semantic_bm25_combined — migrate them or the call raises at runtime"
+)
+print(
+    "switchroom hindsight graph-seed-reuse carry (upstream #2968): graph seeds now derive "
+    "from the shared semantic/BM25 over-fetch pool (falling back to the dedicated ANN query "
+    "whenever min_scores.semantic > 0.3), and fetch_unit_dates is served by pk_memory_units "
+    "instead of a sequential scan"
+)
+PYEOF
+
 # Pin the upstream `hindsight` user to UID 11000 to match
 # `HINDSIGHT_DEFAULT_UID` in src/setup/hindsight.ts (and the
 # `auth.consumers[hindsight].uid` value the operator writes in

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -329,6 +329,13 @@ describe("Dockerfile.hindsight shape", () => {
   //    it would fight a deliberate upstream design decision. The latency it
   //    bought is largely absorbed by the per-bank vector indexes that
   //    `hindsight-admin repair-bank` (upstream #2645) now maintains.
+  //
+  //    POSTSCRIPT (2026-07-27): upstream itself reversed that stance one day
+  //    later in PR #2968 (merge b475f5cc), reintroducing seed reuse *with* a
+  //    correctness guard — reuse only when the semantic floor is no stricter
+  //    than the graph seed floor. We now carry THAT (see the #2968 block), so
+  //    the guard below discriminates on the switchroom implementation's own
+  //    markers rather than on the generic `semantic_seeds` token.
   // ---------------------------------------------------------------------
   it("does NOT carry the retired max_turns/ToolSearch patch (upstream ships tools=[])", () => {
     expect(dockerfile).not.toMatch(/switchroom max_turns\/ToolSearch standard-call fix/);
@@ -343,10 +350,19 @@ describe("Dockerfile.hindsight shape", () => {
     expect(dockerfile).not.toMatch(/entity_records/);
   });
 
-  it("does NOT carry the retired duplicate-ANN-scan patch (upstream removed semantic_seeds)", () => {
-    expect(dockerfile).not.toMatch(/duplicate-ANN-scan/);
-    expect(dockerfile).not.toMatch(/semantic_seeds/);
-    expect(dockerfile).not.toMatch(/_find_semantic_seeds/);
+  it("does NOT carry the retired switchroom-authored duplicate-ANN-scan patch", () => {
+    // NOTE: the bare tokens `semantic_seeds` / `_find_semantic_seeds` are NOT
+    // usable as discriminators any more — the upstream #2968 carry below
+    // legitimately reintroduces seed reuse under upstream's OWN design, with
+    // upstream's correctness guard. What must stay dead is the *switchroom*
+    // implementation, whose premise ("the parameter already exists and is
+    // already honoured") 0.8.5 falsified. Its unique markers:
+    expect(dockerfile).not.toMatch(/switchroom hindsight duplicate-ANN-scan patch/);
+    expect(dockerfile).not.toMatch(/def _graph_semantic_seeds\(/);
+    expect(dockerfile).not.toMatch(/semantic_seeds=_graph_semantic_seeds\(/);
+    expect(dockerfile).not.toMatch(/_GRAPH_SEED_LIMIT/);
+    expect(dockerfile).not.toMatch(/_GRAPH_SEED_MIN_SIMILARITY/);
+    expect(dockerfile).not.toMatch(/temporal_seeds/);
   });
 
   it("keeps the cross-encoder saturation fix (assert-guarded, fail-loud)", () => {
@@ -826,6 +842,99 @@ describe("Dockerfile.hindsight shape", () => {
     expect(dockerfile).toMatch(
       /switchroom hindsight perturbed-JSON-retry patch: invalid-JSON retries now bypass the proxy response cache/,
     );
+  });
+
+  it("keeps the upstream #2968 graph-seed-reuse carry (assert-guarded, fail-loud)", () => {
+    // TEMPORARY CARRY. Upstream merged b475f5cc to `main` on 2026-07-27, after
+    // v0.8.5 (the digest pinned in this Dockerfile) was cut, so there is no
+    // release to upgrade to. DELETE the block — and flip this test into a
+    // `does NOT carry` guard alongside the other retired patches — the moment
+    // the FROM digest resolves to v0.8.6 or newer.
+    //
+    // SCOPE: structural, not behavioural. Every assertion here is a substring
+    // match, so it proves the patch is PRESENT, never that it RUNS. The
+    // behavioural gate is tests/docker/hindsight-graph-seed-patch.test.ts,
+    // which applies this block to the pinned image and asserts the derived
+    // seed ids equal the dedicated query's. Do not treat this file as
+    // sufficient.
+
+    // The provenance header must survive edits: without the merge SHA and the
+    // deletion condition, a future rebaser cannot tell an adopted carry from a
+    // switchroom-original patch.
+    expect(dockerfile).toMatch(
+      /# ── UPSTREAM CARRY: vectorize-io\/hindsight PR #2968 ─+/,
+    );
+    expect(dockerfile).toMatch(/#   merge commit:   b475f5cc/);
+    expect(dockerfile).toMatch(
+      /# DELETE THIS BLOCK WHEN, and only when, the `FROM` digest above resolves to\n# upstream v0\.8\.6 or newer/,
+    );
+
+    // The exact-once anchor guard (fail-loud on upstream drift). Shared by all
+    // five patched files via apply().
+    expect(dockerfile).toMatch(
+      /the \{label!r\} anchor was found \{n\}x \(expected 1\) in \{rel\}\./,
+    );
+
+    // The divergence guard. v0.8.5 hardcodes the graph seed floor; upstream
+    // main reads it from config. If a future base introduces the config key,
+    // the mirrored 0.3 would silently ignore the operator's setting, so the
+    // build must fail rather than diverge.
+    expect(dockerfile).toMatch(
+      /assert "graph_seed_min_similarity" not in _cfg,/,
+    );
+
+    // The load-bearing derivation, both halves.
+    expect(dockerfile).toMatch(
+      / +graph_seed_min_similarity=GRAPH_SEED_MIN_SIMILARITY,\\n"/,
+    );
+    expect(dockerfile).toMatch(
+      / +preselected_semantic_seeds=semantic_bm25_results\[ft\]\.graph_seeds,\\n"/,
+    );
+
+    // The CORRECTNESS GUARD is the reason this carry is safe at all: reuse is
+    // declined whenever the semantic arm's floor is stricter than the graph
+    // seed floor, because the shared pool would then be NARROWER than the
+    // dedicated query's result. Hard-coding the threshold would keep every
+    // other assertion green while silently quieting recall.
+    expect(dockerfile).toMatch(
+      /if graph_seed_min_similarity is not None and sem_min <= graph_seed_min_similarity/,
+    );
+    // ...and the trim must not be able to cut a seed out of the pool it feeds
+    // (thinking_budget below GRAPH_SEED_LIMIT).
+    expect(dockerfile).toMatch(
+      /semantic_candidate_limit = max\(limit, GRAPH_SEED_LIMIT if graph_seed_threshold is not None else 0\)/,
+    );
+    // An EMPTY preselected list must NOT re-trigger the scan; only None does.
+    expect(dockerfile).toMatch(/"            if preselected_semantic_seeds is None:\\n"/);
+
+    // The index-served UUID lookup, and the tolerance it must preserve:
+    // non-canonical ids matched nothing under `id::text` and must still match
+    // nothing, so they are filtered out BEFORE the ::uuid cast (which would
+    // otherwise raise 22P02 for the whole query).
+    expect(dockerfile).toMatch(/"            WHERE id = ANY\(\\n"/);
+    expect(dockerfile).toMatch(/SELECT input\.unit_id::uuid/);
+    expect(dockerfile).toMatch(
+      /WHERE input\.unit_id ~ '\^\[0-9a-f\]\{\{8\}\}-/,
+    );
+    expect(dockerfile).toMatch(
+      /assert "id::text = ANY\(\$1\)" not in ops,/,
+    );
+
+    // Post-replace re-assertions (verification-on-build): a patch that applied
+    // but landed inert must fail the build.
+    expect(dockerfile).toMatch(
+      /assert le\.count\("await _find_semantic_seeds\("\) == 1,/,
+    );
+    expect(dockerfile).toMatch(
+      /assert 'grouped\.get\("observation", \(\[\], \[\]\)\)\[0\]' not in cons,/,
+    );
+    // The repo-wide sweep: a missed caller of the reshaped combined query is an
+    // AttributeError on a live recall path, so it must be a build failure.
+    expect(dockerfile).toMatch(/for _p in BASE\.rglob\("\*\.py"\):/);
+    expect(dockerfile).toMatch(/assert not _stale,/);
+    // Every patched file is re-parsed, so a bad splice fails the build rather
+    // than the container.
+    expect(dockerfile).toMatch(/^    ast\.parse\(s\)$/m);
   });
 
   it("preserves upstream's start-all.sh as the post-shim CMD", () => {

--- a/tests/docker/hindsight-graph-seed-patch.test.ts
+++ b/tests/docker/hindsight-graph-seed-patch.test.ts
@@ -1,0 +1,605 @@
+/**
+ * Behavioural proof for the upstream-#2968 graph-seed-reuse carry that
+ * `docker/Dockerfile.hindsight` bakes into the pinned upstream Hindsight image.
+ *
+ * WHAT IS BEING CARRIED, AND WHY IT IS TEMPORARY. vectorize-io/hindsight PR
+ * #2968 (merge b475f5cc, 2026-07-27T10:12:30Z) landed on upstream `main` AFTER
+ * v0.8.5 — the digest this Dockerfile pins, and upstream's tip release — was
+ * cut, so there is no release to upgrade to. The Dockerfile carries the diff as
+ * a build-time patch until the base is >= v0.8.6, at which point the block and
+ * this file are DELETED together.
+ *
+ * WHY A SHAPE TEST IS NOT ENOUGH. `dockerfile-hindsight-bakes.test.ts` pins the
+ * patch block's literals, so it proves the patch is PRESENT, never that it
+ * RUNS. The failure mode this file exists to catch is not an absent patch, it
+ * is a patch that applies and silently NARROWS the graph seed set: hard-code
+ * `graph_seed_threshold` to a non-None value and every literal the bakes test
+ * greps for is still there, while any recall carrying
+ * `min_scores.semantic > 0.3` quietly loses graph entry points. A quieter
+ * recall is worse than a slower one, and only running the patched modules
+ * catches it.
+ *
+ * THE FIVE PROPERTIES DRIVEN HERE, none of which the patch TEXT can show:
+ *
+ *  1. EQUIVALENCE — the seeds derived from the shared semantic/BM25 over-fetch
+ *     pool are the SAME rows, in the same order, that the dedicated
+ *     `_find_semantic_seeds` query returns from the same corpus. The probe runs
+ *     both against one FakeConn that honours whatever floor/limit each SQL
+ *     actually asks for (parsed out of the emitted SQL, not hand-fed), and
+ *     compares ids. The corpus is sized so 22 rows clear the 0.3 floor while
+ *     GRAPH_SEED_LIMIT is 20, so the cap BINDS; and the caller limit (the
+ *     thinking budget) is 5, BELOW that cap, so a patch that trims the pool
+ *     before deriving seeds loses 15 of them and this comparison goes red.
+ *  2. THE CORRECTNESS GUARD — a per-request `min_scores.semantic` of 0.5,
+ *     stricter than the 0.3 graph floor, must DECLINE reuse (`graph_seeds is
+ *     None`) so the retriever falls back to its own query.
+ *  3. OPT-OUT IS EXACT — a caller that passes no `graph_seed_min_similarity`
+ *     (the consolidation dedup probe) gets the pre-#2968 behaviour unchanged.
+ *  4. EMPTY IS AN ANSWER — `preselected_semantic_seeds=[]` means "no row
+ *     cleared the floor" and must NOT re-trigger the scan; only `None` falls
+ *     back. Conflating the two would reinstate the duplicate ANN query on every
+ *     sparse-bank recall, i.e. exactly the cost the carry removes.
+ *  5. THE UUID LOOKUP STAYS TOLERANT — `fetch_unit_dates` must stop casting the
+ *     indexed `id` column (that cast is what forced the sequential scan) WITHOUT
+ *     changing which inputs match. Uppercase, braced, unhyphenated and malformed
+ *     ids matched nothing under `id::text` and must still match nothing; if they
+ *     reached the new `::uuid` cast instead of being filtered out first, Postgres
+ *     would raise 22P02 and fail the whole query.
+ *
+ * MEASUREMENT UPSTREAM CITES: the eliminated graph seed query accounted for
+ * 302,602 calls / 2,072s of accumulated load, and the UUID lookup went
+ * 120.049ms -> 0.240ms median (seq scan -> `pk_memory_units`).
+ *
+ * The patch block is extracted from the Dockerfile itself rather than
+ * duplicated here, so this test cannot drift from what actually ships. It
+ * applies it by `docker exec` (not `docker build`) so it runs on daemons
+ * without buildx, and it never touches the production `switchroom-hindsight`
+ * container.
+ *
+ * SKIP DISCIPLINE: identical to `hindsight-retry-perturbation-patches.test.ts`.
+ * Locally, with no docker or no cached image, this skips (never pull a 6.4GB
+ * third-party image onto a dev box). In CI the `hindsight-probe` job pulls the
+ * pinned digest and sets SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1, under which an
+ * unavailable docker/image is a HARD FAILURE, never a green skip. Both runs
+ * assert a `PROBE_EXECUTED` sentinel so a probe that dies early can never be
+ * mistaken for a pass — and the probe runs each property in an isolated
+ * section so the RED run reports all five rather than dying on the first.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { execFileSync, execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const dockerfile = readFileSync(
+  resolve(root, "docker/Dockerfile.hindsight"),
+  "utf8",
+);
+
+const RUN_ID = randomUUID();
+const TEST_PHASE = "hindsight-graph-seed-patch";
+
+/** The pinned upstream image, read from the Dockerfile so it can never drift. */
+const UPSTREAM_IMAGE = (() => {
+  const m = dockerfile.match(/^FROM\s+(\S+)/m);
+  if (!m) throw new Error("Dockerfile.hindsight has no FROM line");
+  return m[1];
+})();
+
+/** The patch this file proves, named by its unique in-block marker. */
+const PATCH_NAME = "graph-seed-reuse carry (upstream #2968)";
+
+/**
+ * The patch block under test, pulled out of the Dockerfile's
+ * `RUN python3 - <<'PYEOF' ... PYEOF` heredocs by its unique patch name.
+ */
+function patchBlocks(): string[] {
+  const blocks = [
+    ...dockerfile.matchAll(/^RUN python3 - <<'PYEOF'\n([\s\S]*?)^PYEOF$/gm),
+  ].map((m) => m[1]);
+  const hits = blocks.filter((b) => b.includes(PATCH_NAME));
+  if (hits.length !== 1) {
+    throw new Error(
+      `Dockerfile.hindsight contains ${hits.length} "${PATCH_NAME}" RUN blocks ` +
+        `(expected exactly 1) — if the carry was retired because the base image ` +
+        `reached v0.8.6, delete this test with it.`,
+    );
+  }
+  return hits;
+}
+
+/**
+ * Python probe. Exits 0 only when all five properties above hold; prints the
+ * offending assertions otherwise.
+ *
+ * Deliberately asserts OUTCOMES: it runs the real
+ * `retrieve_semantic_bm25_combined` and the real
+ * `LinkExpansionRetriever.retrieve` from the image against a stubbed
+ * connection, and compares the seed ids the two code paths actually produce.
+ * Nothing here greps the patched source.
+ */
+const PROBE = String.raw`
+import asyncio
+import json
+import re
+import sys
+import uuid
+
+failures = []
+
+
+def fail(msg):
+    failures.append(msg)
+
+
+from hindsight_api.engine.search import retrieval as R
+from hindsight_api.engine.search import link_expansion_retrieval as LE
+
+# ── corpus ────────────────────────────────────────────────────────────────
+# 30 observation rows, similarity strictly descending 0.95 -> 0.08. Exactly 22
+# clear the 0.3 graph seed floor, so the GRAPH_SEED_LIMIT=20 cap BINDS: a patch
+# that forgot the cap returns 22 and this probe goes red.
+N = 30
+IDS = [str(uuid.UUID(int=i)) for i in range(N)]
+SIMS = [round(0.95 - 0.03 * i, 4) for i in range(N)]
+ABOVE_FLOOR = [i for i in range(N) if SIMS[i] >= 0.3]
+
+COLS = [
+    "id", "text", "context", "event_date", "occurred_start", "occurred_end",
+    "mentioned_at", "fact_type", "document_id", "chunk_id", "tags", "metadata",
+    "proof_count",
+]
+
+
+def row(i, source):
+    r = {c: None for c in COLS}
+    r["id"] = IDS[i]
+    r["text"] = "obs %d" % i
+    r["fact_type"] = "observation"
+    r["tags"] = []
+    r["metadata"] = {}
+    r["proof_count"] = 1
+    r["similarity"] = SIMS[i]
+    r["bm25_score"] = None
+    r["source"] = source
+    return r
+
+
+class FakeConn:
+    """Answers both queries off the SAME corpus, honouring the floors/limits
+    each SQL actually asks for (parsed out of the SQL, not hand-fed), so the
+    id-set comparison below is a real equivalence check."""
+
+    backend_type = "postgresql"
+
+    def __init__(self):
+        self.queries = []
+        self.seed_query_count = 0
+
+    async def fetch(self, sql, *params):
+        self.queries.append(sql)
+        if "'semantic' AS source" in sql:
+            m = re.search(r">= ([0-9.]+)", sql)
+            lim = int(re.search(r"LIMIT (\d+)\)", sql).group(1))
+            floor = float(m.group(1))
+            sem = [row(i, "semantic") for i in range(N) if SIMS[i] >= floor][:lim]
+            # a couple of BM25 rows so the source discriminator is exercised
+            bm = [row(0, "bm25"), row(7, "bm25")]
+            for b in bm:
+                b["similarity"] = None
+                b["bm25_score"] = 1.0
+            return sem + bm
+        if "LIMIT $5" in sql and ">= $4" in sql:
+            self.seed_query_count += 1
+            threshold, lim = params[3], params[4]
+            return [row(i, "semantic") for i in range(N) if SIMS[i] >= threshold][:lim]
+        raise AssertionError("unexpected SQL: " + sql[:200])
+
+
+async def combined(conn, *, limit, min_semantic, graph_floor):
+    return await R.retrieve_semantic_bm25_combined(
+        conn,
+        "[0,0,0]",
+        "probe query text",
+        "bank-probe",
+        ["observation"],
+        limit,
+        min_semantic=min_semantic,
+        graph_seed_min_similarity=graph_floor,
+    )
+
+
+async def section(label, fn):
+    """Run one section in isolation. On unpatched upstream the very first call
+    raises TypeError (no such kwarg), and the point of this probe is that the
+    RED run still prints every marker rather than dying at line one."""
+    try:
+        await fn()
+    except Exception as e:
+        print("SECTION_RAISED", label, type(e).__name__, str(e).replace("\n", " ")[:200])
+        fail("section %s raised %s: %s" % (label, type(e).__name__, e))
+
+
+async def s1():
+    # ── 1. the derived seeds ARE the dedicated query's rows ───────────────
+    # limit=5 is a deliberately small thinking budget: below GRAPH_SEED_LIMIT,
+    # so a patch that trims the pool to the caller limit before deriving seeds loses 15
+    # of them and this comparison goes red.
+    conn = FakeConn()
+    got = await combined(conn, limit=5, min_semantic=None, graph_floor=LE.GRAPH_SEED_MIN_SIMILARITY)
+    derived = got["observation"].graph_seeds
+    dedicated = await LE._find_semantic_seeds(
+        conn, "[0,0,0]", "bank-probe", "observation",
+        limit=LE.GRAPH_SEED_LIMIT, threshold=LE.GRAPH_SEED_MIN_SIMILARITY,
+    )
+    d_ids = [s.id for s in derived]
+    o_ids = [s.id for s in dedicated]
+    print("DERIVED_SEEDS", len(d_ids))
+    print("DEDICATED_SEEDS", len(o_ids))
+    print("SEED_IDS_EQUAL", d_ids == o_ids)
+    if d_ids != o_ids:
+        fail("derived seed ids != dedicated query ids: %r vs %r" % (d_ids, o_ids))
+    if len(d_ids) != LE.GRAPH_SEED_LIMIT:
+        fail("expected the GRAPH_SEED_LIMIT cap to bind at %d, got %d"
+             % (LE.GRAPH_SEED_LIMIT, len(d_ids)))
+    if len(ABOVE_FLOOR) <= LE.GRAPH_SEED_LIMIT:
+        fail("probe corpus is too small to exercise the seed cap")
+
+    # the semantic arm itself is still trimmed to the caller's limit
+    print("SEMANTIC_TRIMMED", len(got["observation"].semantic))
+    if len(got["observation"].semantic) != 5:
+        fail("semantic results not trimmed to limit: %d" % len(got["observation"].semantic))
+    print("BM25_ROWS", len(got["observation"].bm25))
+    if len(got["observation"].bm25) != 2:
+        fail("bm25 rows lost: %d" % len(got["observation"].bm25))
+    # every seed cleared the floor
+    if any(s.similarity < LE.GRAPH_SEED_MIN_SIMILARITY for s in derived):
+        fail("a derived seed is below the graph floor")
+
+
+async def s2():
+    # ── 2. the correctness guard: a stricter semantic floor DECLINES reuse ─
+    conn2 = FakeConn()
+    strict = await combined(conn2, limit=5, min_semantic=0.5,
+                            graph_floor=LE.GRAPH_SEED_MIN_SIMILARITY)
+    _g = strict["observation"].graph_seeds
+    print("STRICT_FLOOR_GRAPH_SEEDS", "None" if _g is None else len(_g))
+    if strict["observation"].graph_seeds is not None:
+        fail("min_scores.semantic=0.5 > 0.3 still reused the narrowed pool — "
+             "the graph seed set would be silently smaller than upstream's")
+
+
+async def s3():
+    # ── 3. pre-#2968 behaviour is preserved when the caller opts out ───────
+    conn3 = FakeConn()
+    optout = await combined(conn3, limit=5, min_semantic=None, graph_floor=None)
+    _o = optout["observation"].graph_seeds
+    print("OPTOUT_GRAPH_SEEDS", "None" if _o is None else len(_o))
+    if optout["observation"].graph_seeds is not None:
+        fail("graph seeds were derived even though the caller passed no floor")
+
+
+async def s4():
+    # ── 4. retrieve() honours preselection, and [] is NOT a fallback ───────
+    r = LE.LinkExpansionRetriever()
+    probes = {}
+
+    async def spy(*a, **k):
+        probes["seed_query"] = probes.get("seed_query", 0) + 1
+        return []
+
+    import inspect
+    sig = inspect.signature(r.retrieve)
+    print("RETRIEVE_ACCEPTS_PRESELECTED", "preselected_semantic_seeds" in sig.parameters)
+    if "preselected_semantic_seeds" not in sig.parameters:
+        fail("LinkExpansionRetriever.retrieve does not accept preselected_semantic_seeds")
+
+    # Drive the real branch: an EMPTY preselected list must reach the expansion
+    # step with zero seeds and never call _find_semantic_seeds.
+    orig = LE._find_semantic_seeds
+    LE._find_semantic_seeds = spy
+    try:
+        for label, preselected in (("empty", []), ("none", None)):
+            probes.pop("seed_query", None)
+            try:
+                await r.retrieve(
+                    FakeConnPool(), "[0,0,0]", "bank-probe", "observation", 10,
+                    preselected_semantic_seeds=preselected,
+                )
+            except Exception as e:
+                if type(e).__name__ not in ("StopProbe",):
+                    fail("retrieve(%s) raised %s: %s" % (label, type(e).__name__, e))
+            print("SEED_QUERY_CALLS_%s" % label.upper(), probes.get("seed_query", 0))
+            if label == "empty" and probes.get("seed_query", 0) != 0:
+                fail("an EMPTY preselected seed list fell back to a second ANN scan")
+            if label == "none" and probes.get("seed_query", 0) != 1:
+                fail("preselected=None did not fall back to the dedicated seed query")
+    finally:
+        LE._find_semantic_seeds = orig
+
+
+async def s5():
+    # ── 5. fetch_unit_dates is sargable, and keeps its old tolerance ───────
+    from hindsight_api.engine.db import ops_postgresql as OPS
+    captured = {}
+
+    class SqlConn:
+        backend_type = "postgresql"
+
+        async def fetch(self, sql, *params):
+            captured["sql"] = sql
+            captured["params"] = params
+            return []
+
+    await OPS.PostgreSQLOps().fetch_unit_dates(SqlConn(), "memory_units", IDS[:2])
+    sql = captured.get("sql", "")
+    print("UNIT_DATES_CASTS_COLUMN", "id::text = ANY($1)" in sql)
+    if "id::text = ANY($1)" in sql:
+        fail("fetch_unit_dates still casts the indexed id column to text")
+    if "WHERE id = ANY(" not in sql:
+        fail("fetch_unit_dates does not compare the id column directly: " + sql[:300])
+    m = re.search(r"unit_id ~ '(\^[^']+\$)'", sql)
+    if not m:
+        fail("no canonical-UUID pre-filter in fetch_unit_dates SQL")
+    else:
+        pat = re.compile(m.group(1).replace("$", r"\Z"))
+        # must contain hex LETTERS, or the uppercase case is a no-op
+        good = "abcdef01-2345-6789-abcd-ef0123456789"
+        bad = [good.upper(), "{" + good + "}", good.replace("-", ""), "not-a-uuid", ""]
+        kept = [bool(pat.search(good))] + [bool(pat.search(b)) for b in bad]
+        print("UUID_FILTER_KEEPS", json.dumps(kept))
+        if kept != [True, False, False, False, False, False]:
+            fail("the pre-filter changed which inputs are accepted: %r" % kept)
+
+
+async def main():
+    for label, fn in (("1", s1), ("2", s2), ("3", s3), ("4", s4), ("5", s5)):
+        await section(label, fn)
+    print("FAILURES", failures)
+    print("PROBE_EXECUTED")
+
+
+class StopProbe(Exception):
+    pass
+
+
+class _Acq:
+    def __init__(self, c):
+        self.c = c
+
+    async def __aenter__(self):
+        return self.c
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class FakeConnPool:
+    """Backend-shaped pool whose connection aborts the probe at the first
+    expansion query — only the seeding branch is under test here."""
+
+    _wraps_backend = True
+
+    def acquire(self):
+        return _Acq(_ExpansionConn())
+
+
+class _ExpansionConn:
+    backend_type = "postgresql"
+
+    async def fetch(self, sql, *params):
+        if "LIMIT $5" in sql and ">= $4" in sql:
+            raise AssertionError("the raw seed SQL ran despite the spy")
+        raise StopProbe()
+
+    async def fetchrow(self, sql, *params):
+        raise StopProbe()
+
+
+asyncio.run(main())
+sys.exit(1 if failures else 0)
+`;
+
+function hasDocker(): boolean {
+  try {
+    execSync("docker version --format '{{.Server.Version}}'", {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasImage(ref: string): boolean {
+  try {
+    execSync(`docker image inspect ${ref}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * CI marker. When set, this suite MUST really execute — an absent docker or
+ * an absent upstream image becomes a hard failure instead of a green skip.
+ * `.github/workflows/docker-e2e.yml` sets it after pulling the pinned digest.
+ */
+const REQUIRED = process.env.SWITCHROOM_REQUIRE_HINDSIGHT_PROBE === "1";
+
+const dockerOk = hasDocker();
+const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
+
+type ProbeResult = { status: number; stdout: string };
+
+/** Run the probe in a throwaway container, optionally patching first. */
+function runProbe(patched: boolean): ProbeResult {
+  const name = `sr-hs-seed-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
+    0,
+    8,
+  )}`;
+  try {
+    execFileSync(
+      "docker",
+      [
+        "run",
+        "-d",
+        "--name",
+        name,
+        "--label",
+        `switchroom.test=${TEST_PHASE}`,
+        "--label",
+        `switchroom.test.run=${RUN_ID}`,
+        "--user",
+        "root",
+        "--network",
+        "none",
+        UPSTREAM_IMAGE,
+        "sleep",
+        "300",
+      ],
+      { stdio: ["ignore", "ignore", "pipe"] },
+    );
+
+    if (patched) {
+      for (const block of patchBlocks()) {
+        // The block is self-verifying: every anchor is exact-once and every
+        // patched file is re-parsed, so a non-zero exit here means upstream
+        // drifted (or adopted the change) and the carry must be re-authored or
+        // retired. It can never silently no-op.
+        execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
+          input: block,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      }
+    }
+
+    const res = execFileSync(
+      "docker",
+      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
+      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
+    );
+    return { status: 0, stdout: res };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: Buffer | string };
+    return {
+      status: err.status ?? -1,
+      stdout: (err.stdout ?? "").toString(),
+    };
+  } finally {
+    try {
+      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+describe("Dockerfile.hindsight graph-seed probe is real, not a silent skip", () => {
+  it("pins the upstream image by digest so the probe tests the exact shipping bytes", () => {
+    expect(UPSTREAM_IMAGE).toMatch(/@sha256:[0-9a-f]{64}$/);
+  });
+
+  it("extracts exactly the one carried patch block it claims to prove", () => {
+    expect(patchBlocks()).toHaveLength(1);
+  });
+
+  it("hard-fails rather than skipping when CI demands a real run", () => {
+    if (!REQUIRED) {
+      // Local/dev path: skipping is legitimate (never pull a 6.4GB image onto
+      // a dev box), but it must be visible rather than silent.
+      expect(
+        REQUIRED,
+        "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE is unset — the behavioural probe " +
+          "is advisory here. CI's hindsight-probe job sets it after pulling " +
+          `${UPSTREAM_IMAGE}.`,
+      ).toBe(false);
+      return;
+    }
+    expect(
+      dockerOk,
+      "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but the docker daemon is unreachable",
+    ).toBe(true);
+    expect(
+      imageOk,
+      `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but ${UPSTREAM_IMAGE} is not present ` +
+        "locally — the workflow must pull the pinned digest before running this suite",
+    ).toBe(true);
+  });
+});
+
+describe.skipIf(!dockerOk || !imageOk)(
+  "the upstream-#2968 graph-seed-reuse carry changes real behaviour",
+  () => {
+    afterAll(() => {
+      // Label-scoped teardown belt (never an unlabelled bulk removal).
+      try {
+        const ids = execSync(
+          `docker ps -aq --filter label=switchroom.test.run=${RUN_ID}`,
+          { encoding: "utf8" },
+        )
+          .split("\n")
+          .filter(Boolean);
+        if (ids.length) {
+          execFileSync("docker", ["rm", "-f", ...ids], { stdio: "ignore" });
+        }
+      } catch {
+        /* nothing to clean */
+      }
+    });
+
+    it("unpatched upstream is RED — no seed reuse, and the id lookup casts the column", () => {
+      const { status, stdout } = runProbe(false);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED",
+      );
+      expect(status, `probe unexpectedly passed:\n${stdout}`).not.toBe(0);
+
+      // v0.8.5 has neither the shared seed constants nor the plumbing, so the
+      // duplicate ANN scan is unconditional...
+      expect(stdout).toContain("has no attribute 'GRAPH_SEED_MIN_SIMILARITY'");
+      expect(stdout).toContain(
+        "retrieve_semantic_bm25_combined() got an unexpected keyword argument 'graph_seed_min_similarity'",
+      );
+      expect(stdout).toContain("RETRIEVE_ACCEPTS_PRESELECTED False");
+      // ...and fetch_unit_dates still casts the indexed column to text.
+      expect(stdout).toContain("UNIT_DATES_CASTS_COLUMN True");
+    }, 240_000);
+
+    it("upstream + the carried patch block is GREEN on all five properties", () => {
+      const { status, stdout } = runProbe(true);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED",
+      );
+      expect(status, `probe failed:\n${stdout}`).toBe(0);
+      expect(stdout).toContain("FAILURES []");
+      expect(stdout).not.toContain("SECTION_RAISED");
+
+      // 1. EQUIVALENCE, with the cap binding and the small thinking budget not
+      //    starving the seed pool.
+      expect(stdout).toContain("DERIVED_SEEDS 20");
+      expect(stdout).toContain("DEDICATED_SEEDS 20");
+      expect(stdout).toContain("SEED_IDS_EQUAL True");
+      expect(stdout).toContain("SEMANTIC_TRIMMED 5");
+      expect(stdout).toContain("BM25_ROWS 2");
+      // 2. the correctness guard declines reuse under a stricter semantic floor
+      expect(stdout).toContain("STRICT_FLOOR_GRAPH_SEEDS None");
+      // 3. an opting-out caller (the consolidation dedup probe) is unaffected
+      expect(stdout).toContain("OPTOUT_GRAPH_SEEDS None");
+      // 4. [] is an answer; only None falls back to the dedicated ANN query
+      expect(stdout).toContain("RETRIEVE_ACCEPTS_PRESELECTED True");
+      expect(stdout).toContain("SEED_QUERY_CALLS_EMPTY 0");
+      expect(stdout).toContain("SEED_QUERY_CALLS_NONE 1");
+      // 5. the id lookup is sargable AND still ignores non-canonical inputs
+      //    (canonical kept; uppercase / braced / unhyphenated / malformed /
+      //    empty all rejected BEFORE the ::uuid cast that would raise 22P02).
+      expect(stdout).toContain("UNIT_DATES_CASTS_COLUMN False");
+      expect(stdout).toContain(
+        "UUID_FILTER_KEEPS [true, false, false, false, false, false]",
+      );
+    }, 240_000);
+  },
+);


### PR DESCRIPTION
## Summary

Carries **vectorize-io/hindsight#2968** (`perf: eliminate redundant graph seed and UUID scans`, merge `b475f5cc`, merged `2026-07-27T10:12:30Z`) as a build-time patch block in `docker/Dockerfile.hindsight`.

**This is a TEMPORARY carry with an explicit removal condition.** The merge landed on upstream `main` *after* v0.8.5 was cut, and v0.8.5 is upstream's tip release — the digest this Dockerfile already pins. There is nothing to upgrade to. Delete the block, `tests/docker/hindsight-graph-seed-patch.test.ts`, the CI step and the CHANGELOG note the moment the `FROM` digest resolves to **v0.8.6 or newer**. That condition is written into all four places, not just this PR description.

**Only one of the two PRs in scope is carried.** See "Why #2502 is not carried" below.

## Why

Two defects, both in the hot recall path:

1. **A duplicate ANN scan per fact type.** `retrieve_all_fact_types_parallel` Step 2 over-fetches semantic candidates (`max(limit*5, 100)`) for HNSW recall, then Step 3 hands the graph retriever nothing, so `LinkExpansionRetriever.retrieve` issues its own `ORDER BY embedding <=> $1::vector` — once per fact type, serialized behind the connection block Step 2 had just closed. A three-fact-type recall does three vector scans where one is enough. Upstream measured the eliminated query at **302,602 calls / 2,072s** accumulated load.
2. **A sequential scan on the primary key.** `fetch_unit_dates` compared `id::text = ANY($1)`, casting the *indexed* column. Upstream measured **120.049ms → 0.240ms** median once `pk_memory_units` served it, and 9.005ms → 0.0795ms on a 100k-row bench.

### The safety argument

Reuse is **not** unconditional, and that is the whole reason this is carryable. The shared pool is reused only when the semantic arm's SQL floor is *no stricter* than the graph seed floor (`sem_min <= graph_seed_min_similarity`). A per-request `min_scores.semantic` above 0.3 makes the pool narrower than the dedicated query's result, so `graph_seeds` comes back `None` and the retriever falls back to its own query. A quieter recall is worse than a slower one.

Two supporting properties, both proven behaviourally rather than asserted in prose:
- `semantic_candidate_limit = max(limit, GRAPH_SEED_LIMIT)` — a `thinking_budget` below 20 must not trim rows the dedicated seed query would have returned.
- `preselected_semantic_seeds=[]` means "no row cleared the floor" and must **not** re-trigger the scan; only `None` falls back.

### History you need before reviewing

switchroom shipped its own version of (1) in #3699 and **retired it in #3768** when bumping to v0.8.5, because 0.8.5 *deleted* the `semantic_seeds` parameter that patch depended on and documented the removal as deliberate. #2968 is upstream reversing that stance one day later, and it lands the correctness guard the retired patch had to invent for itself. **This is not a re-litigation of #3768 — it is upstream's own design, carried.**

The negative guard keeping the switchroom-authored form dead still stands, but the bare tokens `semantic_seeds` / `_find_semantic_seeds` are no longer discriminators (the upstream carry legitimately uses both names). It is retargeted to that form's *unique* markers: `switchroom hindsight duplicate-ANN-scan patch`, `def _graph_semantic_seeds(`, `semantic_seeds=_graph_semantic_seeds(`, `_GRAPH_SEED_LIMIT`, `_GRAPH_SEED_MIN_SIMILARITY`, `temporal_seeds` — `tests/docker/dockerfile-hindsight-bakes.test.ts:353-366`.

### One deliberate divergence from upstream's diff

Upstream main reads the seed floor from `get_config().graph_seed_min_similarity`. **That key does not exist in v0.8.5** — the call site hardcodes `limit=20, threshold=0.3` (`link_expansion_retrieval.py`). The carry hoists those literals as `GRAPH_SEED_LIMIT` / `GRAPH_SEED_MIN_SIMILARITY` module constants and uses them everywhere upstream uses the config value, which is byte-equivalent to v0.8.5's behaviour.

The block **asserts the config key is still absent**, so a future base that introduces it fails the build rather than silently ignoring an operator's configured floor.

## Why #2502 is not carried

Upstream #2502 (`fix(consolidation): stop emitting unsupported maxItems`, merge `c908fade`) was in scope. It is **not** carried, because it cannot help us.

It affects one thing: the `_ConsolidationBatchResponse.creates` structured-output response model, and only when `max_observations_per_scope > 0`. It was written for **AWS Bedrock Converse rejecting `maxItems`**. We do not use Bedrock.

Rather than assume, I traced the real path — hindsight (`network_mode: host`) → the LiteLLM proxy at `127.0.0.1:4010` (where `HINDSIGHT_API_CONSOLIDATION_LLM_BASE_URL` points) → `gpt-oss:20b` on Ollama 0.32.4 — and ran a controlled 3-rep experiment issuing a consolidation-shaped `json_schema` `response_format` at `maxItems` of none / 5 / 100 / 1000:

| `maxItems` | HTTP | seconds (3 reps) |
|---|---|---|
| absent | 200 | 0.510 / 0.454 / 0.499 |
| 5      | 200 | 0.389 / 0.387 / 0.397 |
| 100    | 200 | 0.499 / 0.392 / 0.519 |
| 1000   | 200 | 0.426 / 0.417 / 0.469 |

`maxItems` is neither rejected nor expensive on our path, and there is no monotonic trend. Carrying #2502 would add a maintenance obligation for no effect.

**Separately:** `HINDSIGHT_API_LLM_SUPPORTS_MAX_ITEMS` defaults to `True` upstream and this PR does not change any default. Setting it to `false` for the fleet would be a `switchroom.yaml` config decision, deliberately out of scope here — and on the evidence above there is no reason to.

## Test plan

Three layers, because a Dockerfile behaviour change with only a grep test is how #3660 shipped a revert nothing caught.

**1. Build-time (self-verifying, fail-loud).** Every anchor is exact-once — `assert n == 1` with a message naming both recovery paths (adopted → delete the block; reformatted → re-author). Every patched file is re-parsed with `ast.parse`. A repo-wide `rglob` sweep fails the build if any caller still expects the old `(semantic, bm25)` tuple shape, because a missed caller would be an `AttributeError` on a live recall path rather than a build failure.

Replayed against the pristine pinned digest (`ghcr.io/vectorize-io/hindsight@sha256:0710076c…`), all nine blocks in order:

```
--- block 8
switchroom hindsight graph-seed-reuse carry (upstream #2968): graph seeds now derive
from the shared semantic/BM25 over-fetch pool ...
== compile check
compileall ok
constants 20 0.3
combined sig has kwarg: True
retrieve sig has kwarg: True
```

Re-running the block against an already-patched tree exits **1**, not 0:

```
AssertionError: switchroom hindsight graph-seed-reuse carry (upstream #2968): the
'seed constants' anchor was found 0x (expected 1) in
engine/search/link_expansion_retrieval.py. If the base image is now upstream v0.8.6
or newer, this whole patch block is ADOPTED — delete it ...
```

**2. Structural.** `tests/docker/dockerfile-hindsight-bakes.test.ts` — 29 passed, including the new positive block pinning the provenance header (PR number, merge SHA, deletion condition), the divergence guard, the correctness guard and the candidate-limit widening; plus the retargeted retired-patch guard.

**3. Behavioural, RED/GREEN.** `tests/docker/hindsight-graph-seed-patch.test.ts` (new) applies the extracted block to the pinned digest in a throwaway labelled container and drives the real modules. Five properties, all comparing outcomes rather than reading source:

- **Equivalence** — the seeds derived from the shared pool are the *same rows in the same order* the dedicated `_find_semantic_seeds` query returns from the same corpus, compared by id. The corpus is sized so 22 rows clear the 0.3 floor against `GRAPH_SEED_LIMIT=20` (the cap **binds**) and the caller limit is 5, *below* the cap.
- The correctness guard declines reuse at `min_scores.semantic=0.5`.
- A caller passing no floor (the consolidation dedup probe) gets pre-#2968 behaviour exactly.
- `preselected=[]` issues **0** seed queries; `preselected=None` issues **1**.
- `fetch_unit_dates` stops casting the indexed column *without* changing which inputs match — canonical kept; uppercase / braced / unhyphenated / malformed / empty all rejected **before** the `::uuid` cast that would otherwise raise 22P02 for the whole query.

Both phases assert a `PROBE_EXECUTED` sentinel, and the probe runs each property in an isolated section so the RED run reports all five rather than dying on the first.

**Mutation-tested** (this is the part the shape test structurally cannot do). Two mutations that leave layers 1 and 2 *fully green*:

| mutation | result |
|---|---|
| hard-code `graph_seed_threshold` (drop the `sem_min <=` guard) | RED — `STRICT_FLOOR_GRAPH_SEEDS 16`, expected `None` |
| `semantic_candidate_limit = limit` (drop the widening) | RED — `DERIVED_SEEDS 5`, `SEED_IDS_EQUAL False` |

Wired into CI as a new `hindsight-probe` step with `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1`, so it can never silently skip; added to the `hindsight` path filter and the label-scoped teardown loop.

Locally: `npm run lint` clean; `npx vitest run tests/docker/` → **418 passed / 33 skipped**; `tests/ci-merge-queue-triggers.test.ts` + `tests/ci-buildx-warm-pull.test.ts` → 62 passed.

## Risk

**Blast radius verified, not assumed.** `retrieve_semantic_bm25_combined` has exactly two callers — `engine/search/retrieval.py` (`retrieve_all_fact_types_parallel`) and `engine/consolidation/consolidator.py` (the dedup probe) — both migrated, with the build-time sweep guarding against a third. `GraphRetriever` has exactly one subclass, `LinkExpansionRetriever`, and the abstract signature is updated alongside it so a future non-LinkExpansion retriever fails at definition rather than `TypeError`-ing at the call site.

The two `.get(ft, default)` / `.get("observation", default)` defaults that the reshape removes were dead: `result_dict` is keyed from the same `fact_types` list the caller passes, and the consolidator hardcodes `["observation"]`.

**Reuse actually engages on this fleet** — `DEFAULT_SEMANTIC_MIN_SIMILARITY = 0.3` with no env override, so `0.3 <= 0.3` holds and the guard admits.

**Known low, filed rather than fixed** (see follow-ups): the carry trusts `UNION ALL` row order rather than re-sorting, which is upstream's own form. That is not a new assumption — v0.8.5's own semantic trim already takes the first `limit` rows out of the same result — but it is now load-bearing for *which* 20 rows become seeds.

Job spec: `reference/jobs/remember-across-sessions.md` — "Relevant, not exhaustive recall" and the durability invariants. This change is a pure latency/load reduction on the recall path, with a guard whose entire purpose is that recall relevance cannot silently narrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
