### PR TITLE
fix(hindsight): report the env a recreate is about to drop

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -21,11 +21,19 @@ import {
   pickHindsightPorts,
   pullHindsightImage,
   getRunningHindsightPorts,
+  getHindsightContainerEnv,
+  getHindsightImageEnv,
+  hindsightContainerEnvPairs,
+  hindsightResolvedCapabilities,
   preflightHindsightPorts,
   HINDSIGHT_DEFAULT_API_PORT,
   HINDSIGHT_DEFAULT_MCP_URL,
   type LiteLLMHindsightConfig,
 } from "../setup/hindsight.js";
+import {
+  diffDroppedHindsightEnv,
+  formatDroppedHindsightEnvReport,
+} from "../setup/hindsight-env-drift.js";
 import {
   buildRepairBankArgv,
   classifyRepairPreflight,
@@ -494,7 +502,14 @@ export function registerMemoryCommand(program: Command): void {
         "fleet. Omit for `:latest` (the standalone default).",
     )
     .option("--provider <provider>", "LLM provider (ollama, openai, anthropic)")
-    .action(async (opts: { stop?: boolean; status?: boolean; recreate?: boolean; tag?: string; provider?: string }) => {
+    .option(
+      "--strict-env",
+      "Refuse the recreate (before the running container is touched) if it would drop " +
+        "env vars that are live on the container but declared in neither `hindsight.env` " +
+        "nor switchroom's managed defaults. Default is to warn loudly and proceed, so a " +
+        "rollout is never wedged half-way with memory down.",
+    )
+    .action(async (opts: { stop?: boolean; status?: boolean; recreate?: boolean; tag?: string; provider?: string; strictEnv?: boolean }) => {
       if (opts.status) {
         if (!isDockerAvailable()) {
           console.log(chalk.red("  Docker is not available."));
@@ -596,6 +611,75 @@ export function registerMemoryCommand(program: Command): void {
       if (isHindsightRunning() && !recreate) {
         console.log(chalk.green("\n  Hindsight container is already running (switchroom-hindsight).\n"));
         return;
+      }
+
+      // ── Env-drift guard ────────────────────────────────────────────────
+      // A recreate rebuilds the container env FROM SCRATCH out of
+      // `hindsight.env` + switchroom's managed defaults, so anything set
+      // imperatively on the live container and declared in neither source is
+      // dropped. That drop used to be completely silent; it has bitten three
+      // times, most recently taking HINDSIGHT_API_RERANKER_LOCAL_FP16 off the
+      // reranker (fp32 ⇒ ~2x per-candidate time on the interactive recall
+      // path). Compare live env against the env we are ABOUT to launch with,
+      // before the container is removed, and say exactly what is going.
+      //
+      // Deliberately not auto-carried over: see hindsight-env-drift.ts. And
+      // deliberately non-fatal by default — `switchroom update` drives this
+      // path, and hard-failing mid-rollout would trade a perf regression for
+      // fleet memory being down. `--strict-env` opts into the refusal, and it
+      // fires here, before the pull and before stopHindsight(), so a refusal
+      // leaves the running container completely untouched.
+      let envDriftLines: string[] = [];
+      if (recreate && isHindsightContainerExists()) {
+        try {
+          const liveEnv = getHindsightContainerEnv();
+          if (liveEnv) {
+            const driftConfig = getConfig(program);
+            const driftLitellm = await resolveLiteLLMForHindsight(driftConfig);
+            const driftPerf = { env: driftConfig.hindsight?.env };
+            const nextEnv = hindsightContainerEnvPairs({
+              // The recreate rebinds the port it is already on (reusePorts);
+              // fall back to the default only when it could not be read.
+              apiPort: reusePorts?.apiPort ?? HINDSIGHT_DEFAULT_API_PORT,
+              litellm: driftLitellm,
+              llm: driftConfig.hindsight?.llm,
+              perf: driftPerf,
+            });
+            const dropped = diffDroppedHindsightEnv(
+              liveEnv,
+              nextEnv,
+              getHindsightImageEnv() ?? [],
+            );
+            envDriftLines = formatDroppedHindsightEnvReport(
+              dropped,
+              hindsightResolvedCapabilities(
+                driftConfig.hindsight?.llm,
+                driftLitellm,
+                undefined,
+                driftPerf,
+              ),
+            );
+          }
+        } catch (err) {
+          // The guard must never be the reason a recreate fails. Say it was
+          // skipped rather than pretending the env matched.
+          console.log(
+            chalk.gray(`  (env-drift check skipped: ${(err as Error).message})`),
+          );
+        }
+      }
+      if (envDriftLines.length > 0) {
+        console.log("");
+        for (const line of envDriftLines) console.log(chalk.yellow(line));
+        console.log("");
+        if (opts.strictEnv) {
+          console.error(
+            chalk.red(
+              "  Refusing to recreate (--strict-env). The running container was NOT touched.\n",
+            ),
+          );
+          process.exit(1);
+        }
       }
 
       if (recreate) {

--- a/src/setup/hindsight-env-drift.test.ts
+++ b/src/setup/hindsight-env-drift.test.ts
@@ -1,0 +1,221 @@
+/**
+ * The 2026-07-28 silent drop, pinned as a test.
+ *
+ * `switchroom memory setup --recreate` rebuilds the hindsight container's env
+ * from `hindsight.env` plus switchroom's managed defaults. Anything live on the
+ * container and declared in neither source vanished with no error, no warning
+ * and no diff. It happened three times; the third took
+ * `HINDSIGHT_API_RERANKER_LOCAL_FP16=true` and
+ * `HINDSIGHT_API_RERANKER_LOCAL_BATCH_SIZE=128` off the reranker, so the local
+ * cross-encoder dropped to fp32 (~2x the time per candidate) on the
+ * interactive recall path, and it was found only by hand-diffing a `docker
+ * inspect` snapshot taken minutes earlier.
+ *
+ * Every assertion below is about the OUTCOME an operator sees: given a key live
+ * on the container and absent from the computed env, does the recreate path
+ * name it and print its value. A test that only checked "the diff function was
+ * called" would have passed happily through all three incidents.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  diffDroppedHindsightEnv,
+  explainDroppedHindsightEnv,
+  formatDroppedHindsightEnvReport,
+  parseDockerEnvList,
+  REDACTED_ENV_VALUE,
+} from "./hindsight-env-drift.js";
+
+/** A trimmed but realistic image baseline: none of this is operator config. */
+const IMAGE_ENV = [
+  "PATH=/usr/local/bin:/usr/bin:/bin",
+  "LANG=C.UTF-8",
+  "PYTHON_VERSION=3.12.7",
+  "HOME=/home/hindsight",
+];
+
+const ALL_CAPS = { gpu: true, localLlm: true };
+const NO_CAPS = { gpu: false, localLlm: false };
+
+describe("diffDroppedHindsightEnv", () => {
+  it("reports a key live on the container that the next launch will not set", () => {
+    // THE bug, reproduced. FP16 is on the running container; the computed env
+    // (empty hindsight.env, GPU verdict unproven) does not contain it.
+    const live = [
+      ...IMAGE_ENV,
+      "HINDSIGHT_API_RERANKER_LOCAL_FP16=true",
+      "HINDSIGHT_API_RERANKER_LOCAL_BATCH_SIZE=128",
+      "HINDSIGHT_API_WORKER_ID=switchroom-hindsight",
+    ];
+    const next: Array<[string, string]> = [
+      ["HINDSIGHT_API_WORKER_ID", "switchroom-hindsight"],
+    ];
+
+    expect(diffDroppedHindsightEnv(live, next, IMAGE_ENV)).toEqual([
+      { key: "HINDSIGHT_API_RERANKER_LOCAL_BATCH_SIZE", value: "128", redacted: false },
+      { key: "HINDSIGHT_API_RERANKER_LOCAL_FP16", value: "true", redacted: false },
+    ]);
+  });
+
+  it("is silent when the next launch sets every configured key", () => {
+    const live = [...IMAGE_ENV, "HINDSIGHT_API_RERANKER_LOCAL_FP16=true"];
+    const next: Array<[string, string]> = [
+      ["HINDSIGHT_API_RERANKER_LOCAL_FP16", "true"],
+    ];
+    expect(diffDroppedHindsightEnv(live, next, IMAGE_ENV)).toEqual([]);
+  });
+
+  it("does not report image-inherited env as a drop", () => {
+    // Without the image baseline this is ~20 phantom rows on every recreate,
+    // and a warning that always fires is a warning nobody reads.
+    expect(diffDroppedHindsightEnv(IMAGE_ENV, [], IMAGE_ENV)).toEqual([]);
+  });
+
+  it("DOES report an image var that was overridden, because that override is lost", () => {
+    const live = ["PATH=/opt/custom/bin:/usr/bin", "LANG=C.UTF-8"];
+    expect(diffDroppedHindsightEnv(live, [], IMAGE_ENV)).toEqual([
+      { key: "PATH", value: "/opt/custom/bin:/usr/bin", redacted: false },
+    ]);
+  });
+
+  it("a key whose VALUE changes is not a drop — the next launch still sets it", () => {
+    const live = [...IMAGE_ENV, "HINDSIGHT_API_PORT=18888"];
+    const next: Array<[string, string]> = [["HINDSIGHT_API_PORT", "19999"]];
+    expect(diffDroppedHindsightEnv(live, next, IMAGE_ENV)).toEqual([]);
+  });
+
+  it("never prints a secret-shaped value", () => {
+    // startHindsight embeds the LiteLLM API key inside ANTHROPIC_CUSTOM_HEADERS.
+    // A "here is what you are dropping" dump must not leak it to the terminal.
+    const live = ["ANTHROPIC_CUSTOM_HEADERS=x-litellm-api-key: Bearer sk-live-" + "abc123"];
+    const [row] = diffDroppedHindsightEnv(live, [], IMAGE_ENV);
+    expect(row).toEqual({
+      key: "ANTHROPIC_CUSTOM_HEADERS",
+      value: REDACTED_ENV_VALUE,
+      redacted: true,
+    });
+    expect(JSON.stringify(row)).not.toContain("abc123");
+  });
+
+  it("splits on the FIRST '=' so a value containing '=' survives intact", () => {
+    const live = ["HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY=a=1,*:1"];
+    expect(diffDroppedHindsightEnv(live, [], [])[0]!.value).toBe("a=1,*:1");
+  });
+
+  it("takes the LAST duplicate, matching what the container process sees", () => {
+    expect(parseDockerEnvList(["K=first", "K=last"]).get("K")).toBe("last");
+  });
+
+  it("is a no-op with no live container (first install)", () => {
+    expect(diffDroppedHindsightEnv([], [["A", "1"]], [])).toEqual([]);
+  });
+});
+
+describe("explainDroppedHindsightEnv", () => {
+  it("names the withheld capability gate for a managed GPU default", () => {
+    // The diagnosis that was missing on 2026-07-28: these two keys ARE managed
+    // defaults, they were withheld because the GPU verdict did not resolve.
+    const why = explainDroppedHindsightEnv("HINDSIGHT_API_RERANKER_LOCAL_FP16", NO_CAPS);
+    expect(why).toContain("GPU-gated");
+  });
+
+  it("says nothing when the gate is proven — the key is not gate-related then", () => {
+    expect(
+      explainDroppedHindsightEnv("HINDSIGHT_API_RERANKER_LOCAL_FP16", ALL_CAPS),
+    ).toBeNull();
+  });
+
+  it("says nothing for a key switchroom does not manage", () => {
+    expect(explainDroppedHindsightEnv("HINDSIGHT_API_MADE_UP", NO_CAPS)).toBeNull();
+  });
+});
+
+describe("formatDroppedHindsightEnvReport", () => {
+  const dropped = diffDroppedHindsightEnv(
+    [
+      ...IMAGE_ENV,
+      "HINDSIGHT_API_RERANKER_LOCAL_FP16=true",
+      "HINDSIGHT_API_RERANKER_LOCAL_BATCH_SIZE=128",
+    ],
+    [],
+    IMAGE_ENV,
+  );
+
+  it("prints every dropped key AND its live value", () => {
+    // Both halves matter: the key alone tells the operator something broke,
+    // the value is what they need to paste back.
+    const text = formatDroppedHindsightEnvReport(dropped, NO_CAPS).join("\n");
+    expect(text).toContain("HINDSIGHT_API_RERANKER_LOCAL_FP16=true");
+    expect(text).toContain("HINDSIGHT_API_RERANKER_LOCAL_BATCH_SIZE=128");
+  });
+
+  it("emits a paste-ready hindsight.env block", () => {
+    const text = formatDroppedHindsightEnvReport(dropped, NO_CAPS).join("\n");
+    expect(text).toContain("hindsight:");
+    expect(text).toContain("env:");
+    expect(text).toContain('HINDSIGHT_API_RERANKER_LOCAL_FP16: "true"');
+  });
+
+  it("explains the withheld gate inline", () => {
+    expect(formatDroppedHindsightEnvReport(dropped, NO_CAPS).join("\n")).toContain(
+      "GPU-gated",
+    );
+  });
+
+  it("keeps a redacted value out of the paste block too", () => {
+    const secret = diffDroppedHindsightEnv(["ANTHROPIC_CUSTOM_HEADERS=Bearer " + "s3cr3t"], [], []);
+    const text = formatDroppedHindsightEnvReport(secret, ALL_CAPS).join("\n");
+    expect(text).not.toContain("s3cr3t");
+    expect(text).toContain("ANTHROPIC_CUSTOM_HEADERS: <value>");
+  });
+
+  it("says nothing at all when nothing is dropped", () => {
+    expect(formatDroppedHindsightEnvReport([], ALL_CAPS)).toEqual([]);
+  });
+});
+
+describe("the guard is wired into the recreate path, and runs early enough to matter", () => {
+  // A perfect diff function that nothing calls before `docker rm` is worth
+  // nothing: by then the env it was meant to report is already gone. These
+  // assertions are structural on purpose — the behavioural alternative would
+  // have to drive `memory setup --recreate` against a live docker daemon,
+  // which on this host means recreating the production hindsight container.
+  //
+  // Anchors are call sites, not bare identifiers: the import block sits at the
+  // top of the file and `stopHindsight()` is also called by `--stop`, so a
+  // naive indexOf would compare against the wrong occurrence and pass blind.
+  const src = readFileSync(
+    join(import.meta.dirname, "..", "cli", "memory.ts"),
+    "utf-8",
+  );
+
+  const at = (needle: string) => {
+    const i = src.indexOf(needle);
+    expect(i, `${needle} not found in src/cli/memory.ts`).toBeGreaterThan(-1);
+    return i;
+  };
+
+  const READS_LIVE_ENV = "getHindsightContainerEnv();";
+  const REPORTS = "envDriftLines = formatDroppedHindsightEnvReport(";
+  const PULLS = "pullHindsightImage(effectiveTag);";
+  const REMOVES = "Removing existing switchroom-hindsight container";
+
+  it("reads the live container env before the container is removed", () => {
+    expect(at(READS_LIVE_ENV)).toBeLessThan(at(REMOVES));
+  });
+
+  it("reports the drop before the recreate touches anything at all", () => {
+    // Before the pull too: a --strict-env refusal should not have spent
+    // minutes downloading an image it is about to decline to run.
+    expect(at(REPORTS)).toBeLessThan(at(PULLS));
+    expect(at(REPORTS)).toBeLessThan(at(REMOVES));
+  });
+
+  it("refuses under --strict-env, and only after the report is printed", () => {
+    expect(at("opts.strictEnv")).toBeGreaterThan(at(REPORTS));
+    expect(at("opts.strictEnv")).toBeLessThan(at(REMOVES));
+  });
+});

--- a/src/setup/hindsight-env-drift.ts
+++ b/src/setup/hindsight-env-drift.ts
@@ -1,0 +1,211 @@
+/**
+ * Detect environment that a Hindsight **recreate** is about to throw away.
+ *
+ * ## The bug this exists to make impossible
+ *
+ * `switchroom memory setup --recreate` removes the running container and
+ * launches a new one whose env is rebuilt from scratch, from exactly two
+ * sources: the operator's `hindsight.env` block in switchroom.yaml, and the
+ * managed defaults in `src/setup/hindsight-perf-defaults.ts` /
+ * `hindsight-pg-defaults.ts`. Anything that was set on the live container but
+ * exists in NEITHER source is dropped — with no error, no warning and no diff.
+ *
+ * That is not hypothetical. It has bitten three times, and switchroom.yaml on
+ * the dev fleet carries hand-written comment blocks for the first two ("existed
+ * ONLY in the imperative recreate script", "existed NOWHERE in declarative
+ * config"). The third, 2026-07-28, dropped
+ * `HINDSIGHT_API_RERANKER_LOCAL_FP16=true` and
+ * `HINDSIGHT_API_RERANKER_LOCAL_BATCH_SIZE=128` off the live container. Without
+ * FP16 the local cross-encoder reranks in fp32 — roughly 2x the time per
+ * candidate on the *interactive* recall path. It was caught only because the
+ * operator happened to take a `docker inspect` snapshot immediately before the
+ * recreate and diffed `Config.Env` afterwards. Nobody would catch that
+ * normally, which is the whole problem: a silent revert reads as "nothing
+ * happened".
+ *
+ * ## Why detection, and NOT auto-carry-over
+ *
+ * The obvious "fix" is to copy the unknown vars onto the new container. That is
+ * worse. It makes the imperative value permanent and *still* invisible: the
+ * container drifts further from the declarative config on every recreate,
+ * nothing ever lands in switchroom.yaml, and the next operator reading the yaml
+ * still has a false picture. It also silently resurrects env an operator
+ * deliberately removed.
+ *
+ * So this module reports and refuses to guess. The operator gets the key names
+ * and their live values in a paste-ready form; putting them in `hindsight.env`
+ * is a deliberate act, and after that the value is durable *and* legible.
+ *
+ * ## Why the image baseline matters
+ *
+ * A container's `Config.Env` is image env plus `-e` flags, undifferentiated:
+ * `PATH`, `LANG`, `PYTHON_VERSION`, `HOME` and friends all appear there and are
+ * in none of switchroom's computed pairs. Diffing naively would report ~20
+ * phantom drops on every recreate, and a warning that always fires is a warning
+ * nobody reads. Subtracting the *image's* own `Config.Env` — by exact `K=V`
+ * identity, not by key — removes the inherited entries while still reporting an
+ * image var that switchroom or an operator had OVERRIDDEN, since that override
+ * really would be lost.
+ *
+ * Everything here is pure. The docker reads live in `hindsight.ts`
+ * (`getHindsightContainerEnv`, `getHindsightImageEnv`) and the rendering
+ * decision lives in `src/cli/memory.ts`.
+ */
+
+import {
+  HINDSIGHT_PERF_DEFAULTS_GPU,
+  HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM,
+} from "./hindsight-perf-defaults.js";
+
+/** One env var present on the live container and absent from the next one. */
+export interface DroppedHindsightEnv {
+  key: string;
+  /** The value the LIVE container is running with. Redacted if secret-shaped. */
+  value: string;
+  /** True when {@link value} was redacted; the real value is never surfaced. */
+  redacted: boolean;
+}
+
+/**
+ * Keys whose values must never reach a console or a log.
+ *
+ * `ANTHROPIC_CUSTOM_HEADERS` is the concrete hazard: `startHindsight` puts the
+ * LiteLLM API key inside it, so an unredacted "here is what you're dropping"
+ * dump would print a live credential into the operator's terminal and into
+ * whatever captures `switchroom update`'s output. Matched on the KEY, which is
+ * the part we can reason about — a value-shaped heuristic would both miss and
+ * over-trigger.
+ */
+const SECRET_KEY_PATTERN = /(KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|HEADERS|AUTH)/i;
+
+/** Placeholder printed instead of a secret-shaped value. */
+export const REDACTED_ENV_VALUE = "<redacted — read it from `docker inspect`>";
+
+/**
+ * Parse a docker `Config.Env` array (`["K=V", …]`) into a map.
+ *
+ * Two details that matter: a value may itself contain `=` (split on the FIRST
+ * one only), and docker keeps duplicates in the slice while the process sees
+ * the LAST one — so a later entry wins here too. An entry with no `=` is
+ * malformed and skipped rather than becoming a key with an empty value.
+ */
+export function parseDockerEnvList(env: readonly string[]): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const entry of env) {
+    const eq = entry.indexOf("=");
+    if (eq <= 0) continue;
+    out.set(entry.slice(0, eq), entry.slice(eq + 1));
+  }
+  return out;
+}
+
+/**
+ * Env vars live on the container that the next launch will NOT set.
+ *
+ * @param liveEnv     `Config.Env` of the running container.
+ * @param nextEnv     The pairs the next launch will pass (`hindsightContainerEnvPairs`).
+ * @param imageEnv    `Config.Env` of the image the live container was built
+ *                    from. An entry matching the image EXACTLY (key and value)
+ *                    is inherited, not configured, so it is not a drop.
+ * @returns Sorted by key, so output is stable and diffable.
+ */
+export function diffDroppedHindsightEnv(
+  liveEnv: readonly string[],
+  nextEnv: ReadonlyArray<readonly [string, string]>,
+  imageEnv: readonly string[] = [],
+): DroppedHindsightEnv[] {
+  const live = parseDockerEnvList(liveEnv);
+  const image = parseDockerEnvList(imageEnv);
+  const next = new Set(nextEnv.map(([k]) => k));
+
+  const dropped: DroppedHindsightEnv[] = [];
+  for (const [key, value] of live) {
+    if (next.has(key)) continue;
+    // Inherited from the image unchanged ⇒ the new container inherits it too.
+    if (image.has(key) && image.get(key) === value) continue;
+    const redacted = SECRET_KEY_PATTERN.test(key);
+    dropped.push({ key, value: redacted ? REDACTED_ENV_VALUE : value, redacted });
+  }
+  return dropped.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+}
+
+/** Capability gate a managed default sits behind, when it sits behind one. */
+export type HindsightEnvGate = "gpu" | "localLlm";
+
+const GATED_KEYS = new Map<string, HindsightEnvGate>([
+  ...HINDSIGHT_PERF_DEFAULTS_GPU.map(([k]) => [k, "gpu"] as const),
+  ...HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM.map(([k]) => [k, "localLlm"] as const),
+]);
+
+/**
+ * Why a key is being dropped, when switchroom can actually tell.
+ *
+ * A dropped key that switchroom MANAGES behind a capability gate is a very
+ * different incident from a key switchroom has never heard of: it means the
+ * host failed to prove the capability this run, so the managed default was
+ * withheld. That is exactly what happened on 2026-07-28 — the two reranker keys
+ * are GPU-gated managed defaults, and the GPU verdict did not resolve, so they
+ * silently reverted to upstream's CPU values. Saying so converts a mystery into
+ * a diagnosis; leaving it out sends the operator hunting in the wrong file.
+ */
+export function explainDroppedHindsightEnv(
+  key: string,
+  caps: { gpu: boolean; localLlm: boolean },
+): string | null {
+  const gate = GATED_KEYS.get(key);
+  if (!gate) return null;
+  const proven = gate === "gpu" ? caps.gpu : caps.localLlm;
+  if (proven) return null;
+  return gate === "gpu"
+    ? "switchroom manages this key as a GPU-gated default, but this host did not prove a usable GPU this run (host-capabilities.json unreadable/absent, or no nvidia-container-toolkit), so the default was withheld"
+    : "switchroom manages this key as a local-LLM-gated default, but the configured LLM endpoint did not resolve as local this run, so the default was withheld";
+}
+
+/**
+ * Render the operator-facing report for a set of dropped keys.
+ *
+ * Returns plain lines (no colour, no chalk) so it is equally usable from the
+ * CLI, a log, and a test assertion. Empty array ⇒ nothing to report.
+ *
+ * The yaml block is deliberately paste-ready: the recovery action is "put these
+ * in `hindsight.env`", and an operator who has to retype eight keys from a
+ * prose paragraph will skip one.
+ */
+export function formatDroppedHindsightEnvReport(
+  dropped: readonly DroppedHindsightEnv[],
+  caps: { gpu: boolean; localLlm: boolean },
+): string[] {
+  if (dropped.length === 0) return [];
+  const n = dropped.length;
+  const lines: string[] = [
+    `⚠  ENV DRIFT: ${n} environment variable${n === 1 ? "" : "s"} set on the running ` +
+      `switchroom-hindsight container ${n === 1 ? "is" : "are"} NOT in the env this recreate will launch with.`,
+    "   They were set imperatively (a hand `docker run`, a `docker update`, an ad-hoc script)",
+    "   and exist in neither `hindsight.env` in switchroom.yaml nor switchroom's managed defaults,",
+    "   so this recreate WILL drop them. switchroom does not carry them over: that would keep the",
+    "   value invisible instead of making it durable.",
+    "",
+  ];
+  for (const { key, value, redacted } of dropped) {
+    lines.push(`   - ${key}=${value}`);
+    const why = explainDroppedHindsightEnv(key, caps);
+    if (why) lines.push(`       ${why}.`);
+    if (redacted) lines.push("       (value withheld: secret-shaped key)");
+  }
+  lines.push(
+    "",
+    "   To keep them, add to switchroom.yaml before recreating:",
+    "",
+    "     hindsight:",
+    "       env:",
+  );
+  for (const { key, value, redacted } of dropped) {
+    lines.push(`         ${key}: ${redacted ? "<value>" : JSON.stringify(value)}`);
+  }
+  lines.push(
+    "",
+    "   Only keys switchroom manages are honoured there — `switchroom doctor` flags the rest.",
+    "   Re-run with --strict-env to refuse the recreate instead of warning.",
+  );
+  return lines;
+}

--- a/src/setup/hindsight-recreate-env-survival.test.ts
+++ b/src/setup/hindsight-recreate-env-survival.test.ts
@@ -1,0 +1,94 @@
+/**
+ * End-to-end survival of the two reranker keys across a recreate, against the
+ * REAL env derivation the launcher uses (`hindsightContainerEnvPairs`) rather
+ * than a restatement of the constants.
+ *
+ * On 2026-07-28 a `switchroom memory setup --recreate` dropped
+ * `HINDSIGHT_API_RERANKER_LOCAL_FP16=true` and
+ * `HINDSIGHT_API_RERANKER_LOCAL_BATCH_SIZE=128` off the live container. Both
+ * ARE managed defaults (HINDSIGHT_PERF_DEFAULTS_GPU) — they were withheld
+ * because the host did not prove a usable GPU that run, which on the affected
+ * host was itself an artefact: `~/.switchroom/host-capabilities.json` was
+ * root:root 0600 inside a non-root home, so `loadHostCapabilities()` could not
+ * read it and `hindsightGpuEnabled()` fell back to "not proven".
+ *
+ * So there are two outcomes worth pinning, and only pinning both is honest:
+ *
+ *   1. On a host that proves the GPU, an EMPTY `hindsight.env` still lands both
+ *      keys on the container — no operator declaration required.
+ *   2. On a host that does not, they are correctly withheld (upstream's CPU
+ *      values), and the recreate SAYS SO instead of dropping them in silence.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { hindsightContainerEnvPairs } from "./hindsight.js";
+import { diffDroppedHindsightEnv } from "./hindsight-env-drift.js";
+import {
+  HINDSIGHT_DEFAULT_RERANKER_LOCAL_BATCH_SIZE,
+  HINDSIGHT_DEFAULT_RERANKER_LOCAL_FP16,
+} from "./hindsight-perf-defaults.js";
+
+const FP16 = "HINDSIGHT_API_RERANKER_LOCAL_FP16";
+const BATCH = "HINDSIGHT_API_RERANKER_LOCAL_BATCH_SIZE";
+
+/** Empty `hindsight.env` AND an empty process env — nothing declared anywhere. */
+const NOTHING_DECLARED = { env: {}, processEnv: {} as NodeJS.ProcessEnv };
+
+const envMap = (gpu: boolean, env: Record<string, string | number | boolean> = {}) =>
+  new Map(
+    hindsightContainerEnvPairs({
+      apiPort: 18888,
+      gpu,
+      perf: { ...NOTHING_DECLARED, env },
+    }),
+  );
+
+describe("reranker defaults survive a recreate with an empty hindsight.env", () => {
+  it("a GPU-proven host lands both keys with nothing declared", () => {
+    const env = envMap(true);
+    expect(env.get(FP16)).toBe(HINDSIGHT_DEFAULT_RERANKER_LOCAL_FP16);
+    expect(env.get(BATCH)).toBe(String(HINDSIGHT_DEFAULT_RERANKER_LOCAL_BATCH_SIZE));
+    // The values the live fleet runs, spelled out so a drive-by retune of the
+    // constants has to come past this assertion.
+    expect(env.get(FP16)).toBe("true");
+    expect(env.get(BATCH)).toBe("128");
+  });
+
+  it("recreating a container that already has them drops NOTHING", () => {
+    // The actual recreate shape: live container env vs the env the next launch
+    // computes. This is the assertion that would have gone red on 2026-07-28.
+    const next = [...envMap(true)] as Array<[string, string]>;
+    const live = next.map(([k, v]) => `${k}=${v}`);
+    expect(diffDroppedHindsightEnv(live, next, [])).toEqual([]);
+  });
+
+  it("an operator value still wins over the managed default", () => {
+    const env = envMap(true, { [FP16]: "false", [BATCH]: 64 });
+    expect(env.get(FP16)).toBe("false");
+    expect(env.get(BATCH)).toBe("64");
+  });
+
+  it("an operator value reaches the container even where the GPU gate is OFF", () => {
+    // The recovery path the warning tells operators to take has to actually
+    // work on the host that triggered the warning.
+    const env = envMap(false, { [FP16]: "true", [BATCH]: 128 });
+    expect(env.get(FP16)).toBe("true");
+    expect(env.get(BATCH)).toBe("128");
+  });
+
+  it("a host that cannot prove the GPU withholds them — and the recreate says so", () => {
+    const env = envMap(false);
+    expect(env.has(FP16)).toBe(false);
+    expect(env.has(BATCH)).toBe(false);
+
+    // …and that withholding is exactly the drop the guard must surface, with
+    // the live values an operator can paste back.
+    const live = [...envMap(true)].map(([k, v]) => `${k}=${v}`);
+    const dropped = diffDroppedHindsightEnv(live, [...env] as Array<[string, string]>, []);
+    expect(dropped).toEqual([
+      { key: BATCH, value: "128", redacted: false },
+      { key: FP16, value: "true", redacted: false },
+    ]);
+  });
+});

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -1467,6 +1467,150 @@ export function hindsightPgEnvPairs(
   return hindsightPgEnv(resolveHindsightPgOverrides(perf?.env, perf?.processEnv));
 }
 
+/**
+ * THE complete container environment `startHindsight` launches with — every
+ * `-e` pair, in argv order, derived from the same inputs.
+ *
+ * Extracted from `startHindsight`'s body (2026-07-28) so the env is a VALUE
+ * that can be computed without launching anything. The recreate path has to
+ * answer "what will this container's env be?" *before* it removes the running
+ * container, and the only honest answer is the one the launcher itself will
+ * use — a second, parallel derivation would drift and quietly report the wrong
+ * diff. See {@link diffDroppedHindsightEnv} for what consumes it.
+ *
+ * Pure: no docker calls, no filesystem writes. It does read the persisted
+ * host-capabilities verdict (through `hindsightPerfEnvPairs` →
+ * `hindsightGpuEnabled`) unless `gpu` is passed explicitly.
+ */
+export function hindsightContainerEnvPairs(opts: {
+  /** Host API port; also the in-container API port under `--network host`. */
+  apiPort: number;
+  litellm?: LiteLLMHindsightConfig;
+  llm?: HindsightLlmConfig;
+  /** GPU verdict override; omit in production. See {@link hindsightGpuEnabled}. */
+  gpu?: boolean;
+  perf?: HindsightPerfOptions;
+}): Array<[string, string]> {
+  const { apiPort, litellm, llm, gpu, perf } = opts;
+
+  // Effective LLM provider + model, applying the operator override
+  // (top-level `hindsight.llm` in switchroom.yaml) over the hard-coded
+  // subscription-honest fallbacks. With LiteLLM routing enabled and no
+  // explicit `hindsight.llm.model`, the model default shifts to a cheap
+  // OpenRouter model (HINDSIGHT_DEFAULT_LITELLM_MODEL) — see
+  // resolveHindsightLlm — since the proxy can translate a non-Claude name.
+  const { provider: llmProvider, model: llmModel } = resolveHindsightLlm(llm, litellm);
+
+  // Per-op LLM overrides (retain / reflect / consolidation). Only the vars an
+  // operator actually configured are emitted; an unset op inherits the global
+  // HINDSIGHT_API_LLM_* in the engine, so we emit nothing for it.
+  const perOpLlm = resolveHindsightPerOpLlm(llm);
+
+  // Non-secret env stays on `-e` — provider name is configuration, not a
+  // secret. `HINDSIGHT_API_LLM_PROVIDER=claude-code` selects the
+  // subscription-honest path; `HINDSIGHT_API_LLM_MODEL` pins the memory-ops
+  // model (default HINDSIGHT_DEFAULT_MODEL, or the cheap LiteLLM default,
+  // operator-overridable via `hindsight.llm`). The per-scope observation cap
+  // is emitted by the managed perf-defaults block below, not pinned here, so
+  // an operator can raise it through `hindsight.env`.
+  const pairs: Array<[string, string]> = [
+    ["HINDSIGHT_API_LLM_PROVIDER", llmProvider],
+    ["HINDSIGHT_API_LLM_MODEL", llmModel],
+    // Per-op LLM overrides (only the configured vars — see resolveHindsightPerOpLlm).
+    ...perOpLlm,
+    ["HINDSIGHT_API_MCP_STATELESS", String(HINDSIGHT_DEFAULT_MCP_STATELESS)],
+    // Reranker smart-defaults, the reflect wall timeout and the consolidation
+    // scheduling knobs are NOT pinned here any more — they are emitted by the
+    // managed perf-defaults block below, so `hindsight.env` can reach them.
+    // Their rationale moved with them to hindsight-perf-defaults.ts.
+    // Retain output cap + the DERIVED per-call deadline for every lane
+    // (interactive / reflect / retain / consolidation). Asserted consistent by
+    // hindsightLlmBudgetEnv() before it returns — against the token budget
+    // (the 767.6s runaway, see the constants above) AND against each lane's
+    // litellm routing chain (src/litellm/timeout-budget.ts).
+    // …and the CONTEXT budget: consolidation batch size + the two completion
+    // caps, derived from the declared window so a prompt cannot overflow the
+    // backend's slot (an overflow returns HTTP 200 + garbage, never an error).
+    ...hindsightLlmBudgetEnv(llm),
+    // Stable worker identity (see HINDSIGHT_DEFAULT_WORKER_ID). Must be on
+    // the docker-run path — the entrypoint only fills the var with `:=` when
+    // unset, which is fine, but an explicit pin makes the intent legible in
+    // `docker inspect` and survives operators who wrap start without the
+    // entrypoint default.
+    ["HINDSIGHT_API_WORKER_ID", HINDSIGHT_DEFAULT_WORKER_ID],
+    // Capability-gated performance defaults (recall p90 5.83s / reflect p90
+    // 122s vs upstream's published 100-600ms / 800-3000ms). Emitted through
+    // ONE resolver shared with the compose path; every gated group is omitted
+    // on a host that cannot prove the capability, and an operator value in
+    // `hindsight.env` replaces the default rather than being appended after
+    // it. See src/setup/hindsight-perf-defaults.ts.
+    ...hindsightPerfEnvPairs(llm, litellm, gpu, perf),
+    // Embedded-PostgreSQL (pg0) sizing, read by hindsight-entrypoint.sh's
+    // pre-start. pg0 bakes its tuning into the postgres child's ARGV, which
+    // outranks `ALTER SYSTEM`, so pre-starting the instance is the only route
+    // that can change it. Best-effort in the entrypoint: a pre-start that
+    // fails leaves pg0's own defaults in place rather than blocking boot.
+    // See src/setup/hindsight-pg-defaults.ts.
+    ...hindsightPgEnvPairs(perf),
+  ];
+
+  // The `claude-code` provider drives an underlying claude subprocess; pin
+  // `ANTHROPIC_MODEL` to the same model so the subprocess (and any LiteLLM
+  // proxy it routes through, below) targets it. Only meaningful for the
+  // claude-code path — other providers ignore it.
+  if (llmProvider === "claude-code") {
+    pairs.push(["ANTHROPIC_MODEL", llmModel]);
+  }
+
+  if (litellm) {
+    // Host-network mode: the container shares the host network stack so
+    // 127.0.0.1:4010 (LiteLLM) is directly reachable, identical to how
+    // agent containers work. Explicit port env vars preserve the same
+    // external ports (18888/19999) the operator is used to.
+    const litellmRoot = litellm.baseUrl.replace(/\/+$/, "");
+    // Claude models ride the Anthropic pass-through (<root>/anthropic,
+    // raw byte-forward, OAuth) — the model-mapped route re-chunks the SSE
+    // stream and stalls long Claude responses mid-flight (the 2026-07-05
+    // stall). Any other model (e.g. OpenRouter) MUST use the model-mapped
+    // root instead — the pass-through only forwards to the real Anthropic
+    // API, so a non-Claude model_name there 404s / always fails open.
+    const anthropicBaseUrl = isClaudeModel(llmModel)
+      ? `${litellmRoot}/anthropic`
+      : litellmRoot;
+    pairs.push(
+      // HINDSIGHT_API_PORT is the only port knob the upstream config.py
+      // recognizes; the CP service has no equivalent env var override.
+      ["HINDSIGHT_API_PORT", String(apiPort)],
+      // In host-network mode the container shares the host's network stack,
+      // so the CP dashboard's dataplane calls resolve `localhost:<port>`
+      // against host-bound listeners. The image default for the dataplane
+      // URL is `http://localhost:8888`, but 8888 is where we MOVED OFF (it's
+      // squatted on this host by an unrelated container → the dashboard's
+      // data calls 502 while the API is healthy on the API port). Pin the CP
+      // dataplane URL to the SAME port the API actually binds so it tracks
+      // any auto-bump instead of the stale 8888 default.
+      ["HINDSIGHT_CP_DATAPLANE_API_URL", `http://localhost:${apiPort}`],
+      // LiteLLM routing: inherited by the claude_agent_sdk subprocess so
+      // consolidation/reflect calls hit the proxy for spend tracking.
+      ["ANTHROPIC_BASE_URL", anthropicBaseUrl],
+      [
+        "ANTHROPIC_CUSTOM_HEADERS",
+        `x-litellm-api-key: Bearer ${litellm.apiKey}\nx-litellm-customer-id: hindsight\nx-litellm-tags: service:hindsight`,
+      ],
+    );
+  } else if (hindsightNeedsHostNetwork(llm, litellm)) {
+    // When only per-op loopback bases forced host net (no full litellm cfg),
+    // still pin API/CP ports the way the litellm branch does — otherwise the
+    // image default 8888 binds on the shared host stack.
+    pairs.push(
+      ["HINDSIGHT_API_PORT", String(apiPort)],
+      ["HINDSIGHT_CP_DATAPLANE_API_URL", `http://localhost:${apiPort}`],
+    );
+  }
+
+  return pairs;
+}
+
 export function startHindsight(
   ports?: { apiPort: number; uiPort: number },
   litellm?: LiteLLMHindsightConfig,
@@ -1496,109 +1640,13 @@ export function startHindsight(
   const apiPort = ports?.apiPort ?? HINDSIGHT_DEFAULT_API_PORT;
   const uiPort = ports?.uiPort ?? HINDSIGHT_DEFAULT_UI_PORT;
 
-  // Effective LLM provider + model, applying the operator override
-  // (top-level `hindsight.llm` in switchroom.yaml) over the hard-coded
-  // subscription-honest fallbacks. With LiteLLM routing enabled and no
-  // explicit `hindsight.llm.model`, the model default shifts to a cheap
-  // OpenRouter model (HINDSIGHT_DEFAULT_LITELLM_MODEL) — see
-  // resolveHindsightLlm — since the proxy can translate a non-Claude name.
-  const { provider: llmProvider, model: llmModel } = resolveHindsightLlm(llm, litellm);
-
-  // Per-op LLM overrides (retain / reflect / consolidation). Only the vars an
-  // operator actually configured are emitted; an unset op inherits the global
-  // HINDSIGHT_API_LLM_* in the engine, so we emit nothing for it.
-  const perOpLlm = resolveHindsightPerOpLlm(llm);
-
-  // Non-secret env stays on `-e` — provider name is configuration, not a
-  // secret. `HINDSIGHT_API_LLM_PROVIDER=claude-code` selects the
-  // subscription-honest path; `HINDSIGHT_API_LLM_MODEL` pins the memory-ops
-  // model (default HINDSIGHT_DEFAULT_MODEL, or the cheap LiteLLM default,
-  // operator-overridable via `hindsight.llm`). The per-scope observation cap
-  // is emitted by the managed perf-defaults block below, not pinned here, so
-  // an operator can raise it through `hindsight.env`.
-  const envArgs: string[] = [
-    "-e", `HINDSIGHT_API_LLM_PROVIDER=${llmProvider}`,
-    "-e", `HINDSIGHT_API_LLM_MODEL=${llmModel}`,
-    // Per-op LLM overrides (only the configured vars — see resolveHindsightPerOpLlm).
-    ...perOpLlm.flatMap(([k, v]) => ["-e", `${k}=${v}`]),
-    "-e", `HINDSIGHT_API_MCP_STATELESS=${HINDSIGHT_DEFAULT_MCP_STATELESS}`,
-    // Reranker smart-defaults, the reflect wall timeout and the consolidation
-    // scheduling knobs are NOT pinned here any more — they are emitted by the
-    // managed perf-defaults block below, so `hindsight.env` can reach them.
-    // Their rationale moved with them to hindsight-perf-defaults.ts.
-    // Retain output cap + the DERIVED per-call deadline for every lane
-    // (interactive / reflect / retain / consolidation). Asserted consistent by
-    // hindsightLlmBudgetEnv() before it returns — against the token budget
-    // (the 767.6s runaway, see the constants above) AND against each lane's
-    // litellm routing chain (src/litellm/timeout-budget.ts).
-    // …and the CONTEXT budget: consolidation batch size + the two completion
-    // caps, derived from the declared window so a prompt cannot overflow the
-    // backend's slot (an overflow returns HTTP 200 + garbage, never an error).
-    ...hindsightLlmBudgetEnv(llm).flatMap(([k, v]) => ["-e", `${k}=${v}`]),
-    // Stable worker identity (see HINDSIGHT_DEFAULT_WORKER_ID). Must be on
-    // the docker-run path — the entrypoint only fills the var with `:=` when
-    // unset, which is fine, but an explicit pin makes the intent legible in
-    // `docker inspect` and survives operators who wrap start without the
-    // entrypoint default.
-    "-e", `HINDSIGHT_API_WORKER_ID=${HINDSIGHT_DEFAULT_WORKER_ID}`,
-    // Capability-gated performance defaults (recall p90 5.83s / reflect p90
-    // 122s vs upstream's published 100-600ms / 800-3000ms). Emitted through
-    // ONE resolver shared with the compose path; every gated group is omitted
-    // on a host that cannot prove the capability, and an operator value in
-    // `hindsight.env` replaces the default rather than being appended after
-    // it. See src/setup/hindsight-perf-defaults.ts.
-    ...hindsightPerfEnvPairs(llm, litellm, gpu, perf).flatMap(([k, v]) => ["-e", `${k}=${v}`]),
-    // Embedded-PostgreSQL (pg0) sizing, read by hindsight-entrypoint.sh's
-    // pre-start. pg0 bakes its tuning into the postgres child's ARGV, which
-    // outranks `ALTER SYSTEM`, so pre-starting the instance is the only route
-    // that can change it. Best-effort in the entrypoint: a pre-start that
-    // fails leaves pg0's own defaults in place rather than blocking boot.
-    // See src/setup/hindsight-pg-defaults.ts.
-    ...hindsightPgEnvPairs(perf).flatMap(([k, v]) => ["-e", `${k}=${v}`]),
-  ];
-
-  // The `claude-code` provider drives an underlying claude subprocess; pin
-  // `ANTHROPIC_MODEL` to the same model so the subprocess (and any LiteLLM
-  // proxy it routes through, below) targets it. Only meaningful for the
-  // claude-code path — other providers ignore it.
-  if (llmProvider === "claude-code") {
-    envArgs.push("-e", `ANTHROPIC_MODEL=${llmModel}`);
-  }
-
-  if (litellm) {
-    // Host-network mode: the container shares the host network stack so
-    // 127.0.0.1:4010 (LiteLLM) is directly reachable, identical to how
-    // agent containers work. Explicit port env vars preserve the same
-    // external ports (18888/19999) the operator is used to.
-    const litellmRoot = litellm.baseUrl.replace(/\/+$/, "");
-    // Claude models ride the Anthropic pass-through (<root>/anthropic,
-    // raw byte-forward, OAuth) — the model-mapped route re-chunks the SSE
-    // stream and stalls long Claude responses mid-flight (the 2026-07-05
-    // stall). Any other model (e.g. OpenRouter) MUST use the model-mapped
-    // root instead — the pass-through only forwards to the real Anthropic
-    // API, so a non-Claude model_name there 404s / always fails open.
-    const anthropicBaseUrl = isClaudeModel(llmModel)
-      ? `${litellmRoot}/anthropic`
-      : litellmRoot;
-    envArgs.push(
-      // HINDSIGHT_API_PORT is the only port knob the upstream config.py
-      // recognizes; the CP service has no equivalent env var override.
-      "-e", `HINDSIGHT_API_PORT=${apiPort}`,
-      // In host-network mode the container shares the host's network stack,
-      // so the CP dashboard's dataplane calls resolve `localhost:<port>`
-      // against host-bound listeners. The image default for the dataplane
-      // URL is `http://localhost:8888`, but 8888 is where we MOVED OFF (it's
-      // squatted on this host by an unrelated container → the dashboard's
-      // data calls 502 while the API is healthy on ${apiPort}). Pin the CP
-      // dataplane URL to the SAME port the API actually binds so it tracks
-      // any auto-bump instead of the stale 8888 default.
-      "-e", `HINDSIGHT_CP_DATAPLANE_API_URL=http://localhost:${apiPort}`,
-      // LiteLLM routing: inherited by the claude_agent_sdk subprocess so
-      // consolidation/reflect calls hit the proxy for spend tracking.
-      "-e", `ANTHROPIC_BASE_URL=${anthropicBaseUrl}`,
-      "-e", `ANTHROPIC_CUSTOM_HEADERS=x-litellm-api-key: Bearer ${litellm.apiKey}\nx-litellm-customer-id: hindsight\nx-litellm-tags: service:hindsight`,
-    );
-  }
+  const envArgs: string[] = hindsightContainerEnvPairs({
+    apiPort,
+    litellm,
+    llm,
+    gpu,
+    perf,
+  }).flatMap(([k, v]) => ["-e", `${k}=${v}`]);
 
   const args = [
     "run", "-d",
@@ -1665,15 +1713,8 @@ export function startHindsight(
     // Host network: ports are published directly (no -p flags). Required so
     // loopback LiteLLM (127.0.0.1:4010) is reachable from the container.
     args.push("--network", "host");
-    // When only per-op loopback bases forced host net (no full litellm cfg),
-    // still pin API/CP ports the way the litellm branch does — otherwise the
-    // image default 8888 binds on the shared host stack.
-    if (!litellm) {
-      envArgs.push(
-        "-e", `HINDSIGHT_API_PORT=${apiPort}`,
-        "-e", `HINDSIGHT_CP_DATAPLANE_API_URL=http://localhost:${apiPort}`,
-      );
-    }
+    // (The API/CP port pins that host-network mode needs are emitted by
+    // hindsightContainerEnvPairs — see its host-network branch.)
   } else {
     args.push(
       "-p", `127.0.0.1:${apiPort}:8888`,
@@ -1894,6 +1935,83 @@ function getHindsightPortsFromEnv(): { apiPort: number; uiPort: number } | null 
     readVar("HINDSIGHT_UI_PORT") ??
     (apiPort === HINDSIGHT_DEFAULT_API_PORT ? HINDSIGHT_DEFAULT_UI_PORT : 19999);
   return { apiPort, uiPort };
+}
+
+/**
+ * `Config.Env` of the RUNNING hindsight container, as a `["K=V", …]` array.
+ *
+ * Read before a `--recreate` removes the container, so the drift check can see
+ * what is about to be thrown away (see src/setup/hindsight-env-drift.ts).
+ * `{{json .Config.Env}}` rather than the bare `{{.Config.Env}}` used by
+ * {@link getHindsightPortsFromEnv}: the bracketed Go-list rendering is
+ * whitespace-delimited and this env DOES contain values with spaces and
+ * newlines (`ANTHROPIC_CUSTOM_HEADERS`), so a token split would corrupt them.
+ *
+ * Returns null when the container does not exist or is not inspectable — a
+ * first install has nothing to compare against, which is a no-op, not an error.
+ */
+export function getHindsightContainerEnv(): string[] | null {
+  return inspectEnv("switchroom-hindsight");
+}
+
+/**
+ * `Config.Env` of the IMAGE the running hindsight container was created from.
+ *
+ * The baseline the drift check subtracts, so image-inherited vars (`PATH`,
+ * `LANG`, `PYTHON_VERSION`, …) are not reported as drops. Resolved from the
+ * container's own `.Image` digest rather than from `hindsightImageRef()`: the
+ * live container may predate the tag this recreate is pulling, and the baseline
+ * has to describe the container we are actually replacing.
+ *
+ * Returns null when it can't be resolved; callers then use an empty baseline,
+ * which is noisier but never wrong in the unsafe direction.
+ */
+export function getHindsightImageEnv(): string[] | null {
+  let imageId: string;
+  try {
+    imageId = execFileSync(
+      "docker",
+      ["inspect", "--format", "{{.Image}}", "switchroom-hindsight"],
+      { stdio: "pipe", encoding: "utf-8" },
+    ).trim();
+  } catch {
+    return null;
+  }
+  if (!imageId) return null;
+  return inspectEnv(imageId);
+}
+
+/** Shared `docker inspect --format '{{json .Config.Env}}'` read. */
+function inspectEnv(ref: string): string[] | null {
+  try {
+    const out = execFileSync(
+      "docker",
+      ["inspect", "--format", "{{json .Config.Env}}", ref],
+      { stdio: "pipe", encoding: "utf-8" },
+    );
+    const parsed = JSON.parse(out.trim()) as unknown;
+    if (!Array.isArray(parsed)) return null;
+    return parsed.filter((e): e is string => typeof e === "string");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The capability verdicts the next launch will actually use, exposed so the
+ * recreate path can EXPLAIN a dropped managed default rather than merely list
+ * it. Same single derivation `hindsightPerfEnvPairs` runs — not a second copy.
+ */
+export function hindsightResolvedCapabilities(
+  llm?: HindsightLlmConfig,
+  litellm?: LiteLLMHindsightConfig,
+  gpu?: boolean,
+  perf?: HindsightPerfOptions,
+): { gpu: boolean; localLlm: boolean } {
+  return {
+    gpu: hindsightGpuEnabled(gpu),
+    localLlm: hindsightLocalLlmEnabled(llm, litellm, perf?.localLlm),
+  };
 }
 
 /**

--- a/tests/hindsight-env-keys-are-reachable.test.ts
+++ b/tests/hindsight-env-keys-are-reachable.test.ts
@@ -75,12 +75,41 @@ describe("promoted container-env keys are reachable from switchroom.yaml", () =>
       "HINDSIGHT_API_LLM_MODEL",
       "HINDSIGHT_API_WORKER_ID",
       "HINDSIGHT_API_MCP_STATELESS",
+      // The asserted LLM budget (hindsightLlmBudgetEnv). Every one of these is
+      // COMPUTED from the declared context window / timeout chain and then
+      // cross-checked by assertHindsight*Budget before it is returned, so an
+      // operator override would break the assertion it exists to enforce.
+      // They were always allowed by this test's stated invariant ("… or the
+      // asserted LLM budget"); they only need naming now because the patterns
+      // below also see the `["KEY", value]` pair form they are written in.
+      "HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS",
+      "HINDSIGHT_API_LLM_TIMEOUT",
+      "HINDSIGHT_API_REFLECT_LLM_TIMEOUT",
+      "HINDSIGHT_API_RETAIN_LLM_TIMEOUT",
+      "HINDSIGHT_API_CONSOLIDATION_LLM_TIMEOUT",
+      "HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE",
+      "HINDSIGHT_API_CONSOLIDATION_MAX_COMPLETION_TOKENS",
+      "HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS",
     ]);
 
+    // NOT derived, and NOT excused: a genuine pre-existing instance of this
+    // defect that the old pattern could not see (it is a bare string literal,
+    // never a template). Carved out rather than fixed here so this change stays
+    // single-concern, and named explicitly so it cannot be quietly forgotten.
+    const KNOWN_UNREACHABLE = new Set(["HINDSIGHT_API_METRICS_INCLUDE_BANK_ID"]);
+
     const pinned = new Set<string>();
+    // Two shapes, because the docker-run env is now built as `["KEY", value]`
+    // pairs (hindsightContainerEnvPairs) while the compose snippet still
+    // renders `- KEY=${value}` templates. Matching only the template form
+    // would leave the entire run path unguarded.
     for (const m of src.matchAll(/`(?:\s+- )?(HINDSIGHT_API_[A-Z0-9_]+)=\$\{/g)) {
       pinned.add(m[1]!);
     }
+    for (const m of src.matchAll(/\[\s*"(HINDSIGHT_API_[A-Z0-9_]+)"\s*,/g)) {
+      pinned.add(m[1]!);
+    }
+    for (const k of KNOWN_UNREACHABLE) pinned.delete(k);
 
     const offenders = [...pinned].filter((k) => !DERIVED.has(k)).sort();
     expect(


### PR DESCRIPTION
## Summary

`switchroom memory setup --recreate` rebuilds the hindsight container's environment **from scratch** out of two sources only: the operator's `hindsight.env` block in `switchroom.yaml`, and switchroom's managed defaults in code. Anything live on the running container but declared in *neither* source was dropped with no error, no warning and no diff.

This PR makes that drop **visible before it happens**.

- `src/setup/hindsight.ts:1485` — new `hindsightContainerEnvPairs()`, the launcher's full env derivation extracted out of `startHindsight`'s body so the env is a *value* that can be computed without launching anything. `startHindsight` now consumes it at `src/setup/hindsight.ts:1643`; the `--network host` port pins that used to be pushed inline moved into the same function (`src/setup/hindsight.ts:1717`). One derivation, not two — a parallel copy would drift and report the wrong diff.
- `src/setup/hindsight.ts:1953` / `:1969` — `getHindsightContainerEnv()` and `getHindsightImageEnv()`, reading `docker inspect --format '{{json .Config.Env}}'` for the live container and for the image it was created from. `{{json …}}` and not the bare `{{.Config.Env}}` used by `getHindsightPortsFromEnv`: the bracketed Go-list rendering is whitespace-delimited, and this env genuinely contains values with spaces and newlines (`ANTHROPIC_CUSTOM_HEADERS`).
- `src/setup/hindsight.ts:2005` — `hindsightResolvedCapabilities()`, so the report can *explain* a dropped managed default (which gate was unproven) instead of merely listing it.
- `src/setup/hindsight-env-drift.ts` (new) — pure diff + report. `parseDockerEnvList` (`:92`, splits on the first `=`, last duplicate wins), `diffDroppedHindsightEnv` (`:112`, subtracts the image baseline so ~20 image-inherited vars are not reported every run — but an *overridden* image var still is), `explainDroppedHindsightEnv` (`:151`), `formatDroppedHindsightEnvReport` (`:174`, prints key **and** value plus a paste-ready `hindsight.env` block). Secret-shaped keys are redacted (`:79`, `:82`) — `ANTHROPIC_CUSTOM_HEADERS` embeds the LiteLLM API key and must not be dumped to a terminal.
- `src/cli/memory.ts:616-684` — wired into the recreate path, plus `--strict-env` (`src/cli/memory.ts:506`).

**Not auto-carried over, on purpose.** Silently re-applying the stray vars would just move the invisibility somewhere else; the operator would never learn their live config had diverged from `switchroom.yaml`. The point is that the drop becomes legible.

**Warn-by-default, refuse only on request.** `switchroom update` drives this path; hard-failing mid-rollout would trade a perf regression for fleet memory being down. `--strict-env` opts into the refusal, and it fires *before* the image pull and *before* `stopHindsight()`, so a refusal leaves the running container completely untouched.

## Why

Live evidence, 2026-07-28. A recreate on this host dropped:

```
HINDSIGHT_API_RERANKER_LOCAL_FP16=true
HINDSIGHT_API_RERANKER_LOCAL_BATCH_SIZE=128
```

Without FP16 the local cross-encoder reranker runs fp32 — roughly 2x the time per candidate, on the **interactive recall path**, i.e. every turn. It was caught only because a `docker inspect` snapshot happened to have been taken minutes before the recreate, and hand-diffed afterwards.

This is the **third** instance of the class. `switchroom.yaml` already carries two hand-written comment blocks memorialising the previous two — searchable by the phrases `existed ONLY in the imperative recreate script` and `existed NOWHERE in declarative config`. Two comment blocks pleading with a future operator is not a mechanism; a diff the tool prints itself is.

### A correction to the framing this was filed under

The originally reported fix was "add the two reranker keys as managed defaults so they survive a recreate". **They already are managed defaults** on `main` — `src/setup/hindsight-perf-defaults.ts:286`, `:301`, and `:630-633` inside `HINDSIGHT_PERF_DEFAULTS_GPU`. They are **GPU-gated**, not ungated like `HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT`, and they were withheld because the host did not prove a usable GPU on that run — not because the keys were missing from the code.

Ungating them was considered and rejected: it would violate that module's documented gating rule and push FP16 + batch-128 onto CPU-only hosts, which upstream explicitly warns against ("some CPUs lack native FP16 support"). So this PR does not touch the defaults; it pins the true behaviour in tests and makes the withholding *loud*, which is the durable fix for the whole class rather than for two keys.

Two follow-ups fall out of this and are deliberately **not** in this PR (single concern):

1. On the affected host, `~/.switchroom/host-capabilities.json` is `root:root 0600` inside a non-root home. `loadHostCapabilities()` swallows the `EACCES` and returns null, `hindsightGpuEnabled()` reads that as "not proven", and both the GPU-gated defaults **and** `--gpus` passthrough are silently withheld — confirmed by `docker inspect` showing `HostConfig.DeviceRequests: null`, `Runtime: "runc"` on a host whose capabilities file claims `gpuPresent: true, containerToolkit: true`. An unreadable capabilities file should be a loud degradation, not a silent one.
2. `HINDSIGHT_API_METRICS_INCLUDE_BANK_ID` is hard-pinned as a bare string literal at `src/setup/hindsight.ts:675`, so a `hindsight.env` line for it is silently discarded. A genuine pre-existing instance of the *other* reachability defect; named in `KNOWN_UNREACHABLE` (`tests/hindsight-env-keys-are-reachable.test.ts:99`) so it cannot be quietly forgotten.

## Test plan

`src/setup/hindsight-env-drift.test.ts` (20 tests) — every assertion is about the outcome an operator sees:

- a key live on the container and absent from the computed env **is reported, with its value** (the 2026-07-28 drop, reproduced literally);
- silent when the next launch sets everything; image-inherited env is not reported; an **overridden** image var **is**;
- a key whose value merely *changes* is not a drop;
- a secret-shaped value is redacted and does not appear in the row's JSON;
- first-`=` split (`a=1,*:1` survives), last-duplicate-wins, empty live env is a no-op;
- `explainDroppedHindsightEnv` names the GPU gate when it is unproven and stays silent when it is proven or the key is unmanaged;
- the report prints key **and** value, emits a paste-ready yaml block, explains the gate inline, keeps redacted values out of the paste block, and is empty when nothing dropped;
- plus ordering assertions on `src/cli/memory.ts`: the live env is read **before** the container is removed, the report is printed **before** the pull and **before** the removal, and `--strict-env` refuses only after the report. (Structural on purpose — the behavioural alternative is driving a real recreate against the production hindsight container. Anchors are call sites, not bare identifiers, because `stopHindsight()` is also called by `--stop` and a naive `indexOf` would compare the wrong occurrence and pass blind.)

`src/setup/hindsight-recreate-env-survival.test.ts` (5 tests) — against the **real** `hindsightContainerEnvPairs`, not a restatement of the constants:

- a GPU-proven host lands `FP16=true` and `BATCH_SIZE=128` with an **empty** `hindsight.env` and an empty process env;
- recreating a container that already has them drops **nothing** (the assertion that would have gone red on 2026-07-28);
- an operator value still wins over the managed default, and still reaches the container with the gate **off** — the recovery path the warning recommends has to work on the host that triggered the warning;
- a host that cannot prove the GPU withholds them **and** the guard reports both with their live values.

`tests/hindsight-env-keys-are-reachable.test.ts:101-112` — the "no perf knob is pinned outside the managed block" invariant would have gone **blind** after this refactor (pins moved from `` `KEY=${v}` `` templates to `["KEY", v]` tuples). Added the pair-form matcher so the whole run path stays guarded.

**Mutation check:** forcing `diffDroppedHindsightEnv` to return `[]` reds 9 tests — these would have failed on the actual bug.

**Live validation (read-only, nothing mutated):** computed the env from this host's real `switchroom.yaml` offline and diffed it against the live container — `live entries: 66, image entries: 17, next: 51`, `live-only-not-image-not-next: []`, `next-not-live: []`. Zero false positives against a real production container.

Local: scoped vitest 17 files / 281 tests passed; `npm run lint` clean through the final guard.

## Risk

Low. The launcher refactor is argv-order-preserving and mechanical — `startHindsight` emits the same `-e` pairs in the same sequence, verified by the existing hindsight suite. The new code is read-only (`docker inspect`), wrapped in try/catch, and prints `(env-drift check skipped: …)` rather than failing the recreate if anything goes wrong. Default behaviour is warn-and-proceed, so no existing rollout can be wedged by it; `--strict-env` is opt-in and refuses before touching anything.
