### PR TITLE
feat(memory): opt-in relevance floor for auto-recall injection

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -157,6 +157,53 @@ The cap applies to the *combined* result list across the primary bank and any `r
 
 Operationally: the cap is set via the `HINDSIGHT_RECALL_MAX_MEMORIES` env var that `start.sh` exports. The vendored plugin's `recall.py` slices results client-side before formatting (plugin v0.4.0 has no `recallTopK` setting on the Claude Code integration — only Openclaw exposes it).
 
+### Filtering noise recall — `memory.recall.min_score` / `min_score_scope`
+
+`max_memories` bounds *how many* memories are injected; it cannot tell a
+relevant memory from a worthless one. When a bank misses its recall deadline the
+hook still returns a full slate of near-zero-scoring results and injects them
+under the "Relevant memories from past conversations" banner, which reads to the
+agent as ground truth. `min_score` is a client-side relevance floor applied
+after ranking and **before** the `max_memories` slice: any result whose
+`scores.final` falls below the floor is dropped.
+
+```yaml
+agents:
+  overlord:
+    memory:
+      recall:
+        min_score: 0.01          # default 0 = OFF (no filtering)
+        min_score_scope: degraded  # default: only filter on a degraded turn
+```
+
+- **`min_score`** (number, default `0`) — the floor. `0` disables filtering
+  entirely and leaves recall behaviour byte-identical to a fleet without this
+  setting. A result carrying no usable score is always kept, never dropped.
+- **`min_score_scope`** (`degraded` | `all`, default `degraded`) —
+  `degraded` applies the floor only on turns where the agent's own bank timed
+  out or errored (the same condition that raises the degraded-recall notice);
+  `all` applies it on every turn.
+
+**Why the default scope is `degraded`.** `scores.final` is not calibrated across
+queries — on a healthy fleet the score distribution is wide (p10 ≈ 0.0005, p90 ≈
+0.9259) and ~28% of healthy-turn results already sit below 0.01, so a
+fleet-wide floor would discard genuinely useful low-scoring hits. On a degraded
+turn the population is different in kind: ~98% of results fall below 0.01. The
+`degraded` scope binds the floor to the population the evidence supports.
+Set `all` only after inspecting your own recall-log distribution.
+
+If the floor empties the result set the hook injects **no** memory content —
+never an empty banner — and instead discloses that candidates were withheld, so
+the agent treats missing memory as *unknown* rather than *nothing was
+remembered*. The existing degraded-recall notice still fires independently.
+
+Observability: each `recall_log.jsonl` row carries `min_score_floor`,
+`min_score_scope`, `min_score_applied`, and `dropped_below_min_score` next to
+the existing `injected_score_*` fields — inspect with `switchroom memory
+recall-log`. Operationally the values reach the plugin via the
+`HINDSIGHT_RECALL_MIN_SCORE` / `HINDSIGHT_RECALL_MIN_SCORE_SCOPE` env vars that
+`start.sh` exports unconditionally.
+
 ### Tuning auto-retain cadence — `memory.retain.every_n_turns` / `overlap_turns`
 
 The plugin's Stop hook consolidates recent conversation into the bank on a

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -825,6 +825,23 @@ export HINDSIGHT_RECALL_REQUEST_TIMEOUT_SECONDS={{hindsightRecallRequestTimeoutS
 # Observe `injected_own_bank_count` via `switchroom memory recall-log <agent>`.
 export HINDSIGHT_RECALL_OWN_BANK_MIN_SLOTS={{hindsightRecallOwnBankMinSlots}}
 export HINDSIGHT_RECALL_ADDITIONAL_BANK_MIN_SLOTS={{hindsightRecallAdditionalBankMinSlots}}
+# Absolute relevance floor on an injected memory's engine score (#3837).
+# 0 = OFF, and 0 is what switchroom ships: at 0 recall.py drops nothing and the
+# injected set is exactly what it was before #3837.
+# It exists for the measured failure where the agent's own bank times out and
+# recall injects side-bank residue under the "relevant memories" banner —
+# 98.4% of degraded turns carry a best injected score below 0.01 against 28.4%
+# of healthy ones, and the agent cannot tell noise from recall. SCOPE decides
+# which turns a non-zero floor binds on: `degraded` (default) only when the own
+# bank timed out / was unreachable, `all` on every turn. `all` is NOT a
+# recommended fleet default — an unconditional 0.01 floor empties ~28% of
+# HEALTHY recalls (#3761), because `scores.final` is not calibrated across
+# queries. EXPORTED UNCONDITIONALLY for the #3774 reason above: a stale
+# hand-edited ~/.hindsight/claude-code.json must not be able to switch a recall
+# filter ON that switchroom ships OFF.
+# Observe `dropped_below_min_score` via `switchroom memory recall-log <agent>`.
+export HINDSIGHT_RECALL_MIN_SCORE={{hindsightRecallMinScore}}
+export HINDSIGHT_RECALL_MIN_SCORE_SCOPE={{hindsightRecallMinScoreScope}}
 # Recall fact types (memory.recall.types cascade). Switchroom default is
 # world,experience,observation (the synthesized `observation` tier is ON
 # by default, set in the plugin settings.json). Export only when the

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3288,6 +3288,25 @@ const HINDSIGHT_OWN_BANK_MIN_SLOTS_DEFAULT = 2;
 const HINDSIGHT_ADDITIONAL_BANK_MIN_SLOTS_DEFAULT = 1;
 
 /**
+ * Absolute relevance floor for injected memories (#3837), switchroom's shipped
+ * default: OFF.
+ *
+ * 0 disables the filter outright in recall.py (`_filter_by_min_score`
+ * short-circuits), so the fleet's injected sets are unchanged by #3837 until an
+ * operator opts in. That is deliberate and it is what the measurement supports:
+ * a below-floor `scores.final` predicts noise on a DEGRADED own-bank read
+ * (98.4% of those rows have a best injected score under 0.01) but not on a
+ * healthy one (28.4% do), and the score is not calibrated across queries, so
+ * there is no fleet-wide value safe to turn on unmeasured.
+ *
+ * The scope constant is the population a non-zero floor binds on and defaults
+ * to "degraded" for the same reason — it is inert while the floor is 0. Both
+ * are exported unconditionally for the #3774 reason above.
+ */
+const HINDSIGHT_RECALL_MIN_SCORE_DEFAULT = 0;
+const HINDSIGHT_RECALL_MIN_SCORE_SCOPE_DEFAULT = "degraded";
+
+/**
  * Merge switchroom-specific overrides into the vendored hindsight
  * plugin's `settings.json`. Idempotent — runs after every plugin
  * copy on every scaffold/reconcile/restart.
@@ -3654,6 +3673,10 @@ interface BuildWorkspaceContextArgs {
   // these unconditionally so a stale claude-code.json cannot shadow them.
   hindsightRecallOwnBankMinSlots: number;
   hindsightRecallAdditionalBankMinSlots: number;
+  // #3837 — absolute relevance floor + the population it binds on. Also always
+  // resolved and always exported (0 = off, the shipped default).
+  hindsightRecallMinScore: number;
+  hindsightRecallMinScoreScope: string;
   // Phase 1 / 6a opt-out cascade. Comma-joined types + stringified bool,
   // each undefined unless the operator overrode the switchroom default.
   hindsightRecallTypes?: string;
@@ -3704,6 +3727,8 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     hindsightRecallRequestTimeoutSeconds,
     hindsightRecallOwnBankMinSlots,
     hindsightRecallAdditionalBankMinSlots,
+    hindsightRecallMinScore,
+    hindsightRecallMinScoreScope,
     hindsightRecallTypes,
     hindsightRecallSkipTrivial,
     hindsightDirectiveCaptureNudge,
@@ -3793,6 +3818,8 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     hindsightRecallRequestTimeoutSeconds,
     hindsightRecallOwnBankMinSlots,
     hindsightRecallAdditionalBankMinSlots,
+    hindsightRecallMinScore,
+    hindsightRecallMinScoreScope,
     hindsightRecallTypes,
     hindsightRecallSkipTrivial,
     hindsightDirectiveCaptureNudge,
@@ -4742,6 +4769,15 @@ export function scaffoldAgent(
   const hindsightRecallAdditionalBankMinSlots =
     agentConfig.memory?.recall?.additional_bank_min_slots ??
     HINDSIGHT_ADDITIONAL_BANK_MIN_SLOTS_DEFAULT;
+  // #3837 score floor. Same unconditional-export treatment as the slot floors
+  // (#3774): a conditional export would let a stale hand-edited
+  // `~/.hindsight/claude-code.json` silently turn a filter ON that switchroom
+  // ships OFF. Resolving to 0 here makes "disabled" the authoritative state.
+  const hindsightRecallMinScore =
+    agentConfig.memory?.recall?.min_score ?? HINDSIGHT_RECALL_MIN_SCORE_DEFAULT;
+  const hindsightRecallMinScoreScope =
+    agentConfig.memory?.recall?.min_score_scope ??
+    HINDSIGHT_RECALL_MIN_SCORE_SCOPE_DEFAULT;
   // Phase 1 / 6a opt-out: undefined unless the operator overrode the
   // switchroom default (observations on, trivial-skip on). Exported only
   // when set (see start.sh.hbs), so an unset value leaves the on-by-default
@@ -4822,6 +4858,8 @@ export function scaffoldAgent(
     hindsightRecallRequestTimeoutSeconds,
     hindsightRecallOwnBankMinSlots,
     hindsightRecallAdditionalBankMinSlots,
+    hindsightRecallMinScore,
+    hindsightRecallMinScoreScope,
     hindsightRecallTypes,
     hindsightRecallSkipTrivial,
     hindsightDirectiveCaptureNudge,
@@ -7214,6 +7252,15 @@ function reconcileAgentInner(
   const hindsightRecallAdditionalBankMinSlots =
     agentConfig.memory?.recall?.additional_bank_min_slots ??
     HINDSIGHT_ADDITIONAL_BANK_MIN_SLOTS_DEFAULT;
+  // #3837 score floor. Same unconditional-export treatment as the slot floors
+  // (#3774): a conditional export would let a stale hand-edited
+  // `~/.hindsight/claude-code.json` silently turn a filter ON that switchroom
+  // ships OFF. Resolving to 0 here makes "disabled" the authoritative state.
+  const hindsightRecallMinScore =
+    agentConfig.memory?.recall?.min_score ?? HINDSIGHT_RECALL_MIN_SCORE_DEFAULT;
+  const hindsightRecallMinScoreScope =
+    agentConfig.memory?.recall?.min_score_scope ??
+    HINDSIGHT_RECALL_MIN_SCORE_SCOPE_DEFAULT;
   // Phase 1 / 6a opt-out: undefined unless the operator overrode the
   // switchroom default (observations on, trivial-skip on). Exported only
   // when set (see start.sh.hbs), so an unset value leaves the on-by-default
@@ -7318,6 +7365,8 @@ function reconcileAgentInner(
       hindsightRecallRequestTimeoutSeconds,
       hindsightRecallOwnBankMinSlots,
       hindsightRecallAdditionalBankMinSlots,
+      hindsightRecallMinScore,
+      hindsightRecallMinScoreScope,
       hindsightRecallTypes,
       hindsightRecallSkipTrivial,
       hindsightDirectiveCaptureNudge,
@@ -8106,6 +8155,8 @@ function reconcileAgentInner(
       hindsightRecallRequestTimeoutSeconds,
       hindsightRecallOwnBankMinSlots,
       hindsightRecallAdditionalBankMinSlots,
+      hindsightRecallMinScore,
+      hindsightRecallMinScoreScope,
       hindsightRecallTypes,
       hindsightRecallSkipTrivial,
       hindsightDirectiveCaptureNudge,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -656,6 +656,41 @@ export const AgentMemorySchema = z
             "`injected_additional_bank_count` via " +
             "`switchroom memory recall-log`.",
           ),
+        min_score: z
+          .number()
+          .min(0)
+          .optional()
+          .describe(
+            "Absolute floor on a memory's engine relevance score " +
+            "(`scores.final`) for it to be injected. 0 disables (default, " +
+            "and the shipped fleet behaviour). Exists for one measured " +
+            "failure: when the agent's own bank times out, recall still " +
+            "injects side-bank residue under the banner 'Relevant memories " +
+            "from past conversations' — 98.4% of degraded turns have a best " +
+            "injected score below 0.01, against 28.4% of healthy ones. Six " +
+            "noise memories are worse than none, because the agent cannot " +
+            "tell them apart. Below-floor results are dropped BEFORE " +
+            "rendering, and when the floor empties the set the turn says so " +
+            "rather than going silent. Do NOT read this as a general " +
+            "precision control: `scores.final` is not calibrated across " +
+            "queries, and #3761 measured that an unconditional 0.01 floor " +
+            "empties ~28% of HEALTHY recalls — which is why " +
+            "`min_score_scope` defaults to degraded turns only. Observe " +
+            "`dropped_below_min_score` via `switchroom memory recall-log`.",
+          ),
+        min_score_scope: z
+          .enum(["degraded", "all"])
+          .optional()
+          .describe(
+            "Which turns `min_score` binds on. \"degraded\" (default) — only " +
+            "turns where the agent's OWN bank timed out or was unreachable, " +
+            "the population where a below-floor score actually predicts " +
+            "noise and where the agent already receives the degraded-recall " +
+            "disclosure. \"all\" — every turn; only for an operator who has " +
+            "measured their own bank's score distribution, since it " +
+            "re-creates the empty-recall failure of #3541 at any floor " +
+            "calibrated on degraded data. No effect while `min_score` is 0.",
+          ),
         types: z
           .array(z.string())
           .optional()
@@ -2941,6 +2976,8 @@ const profileFields = {
           request_timeout_seconds: z.number().int().min(1).optional(),
           own_bank_min_slots: z.number().int().min(0).optional(),
           additional_bank_min_slots: z.number().int().min(0).optional(),
+          min_score: z.number().min(0).optional(),
+          min_score_scope: z.enum(["degraded", "all"]).optional(),
           additional_banks: z.array(z.string()).optional(),
           sender_banks: z.record(z.string(), z.string()).optional(),
         })

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2732,6 +2732,52 @@ describe("reconcileAgent", () => {
     expect(startSh).toContain("export HINDSIGHT_RECALL_ADDITIONAL_BANK_MIN_SLOTS=0");
   });
 
+  it("start.sh exports the #3837 score floor as OFF by default", () => {
+    // The floor must ship disabled: at 0 recall.py's `_filter_by_min_score`
+    // short-circuits and the injected set is unchanged fleet-wide. Exported
+    // unconditionally for the same #3774 reason as the slot floors above — a
+    // stale hand-edited `~/.hindsight/claude-code.json` loads AFTER
+    // settings.json, so without this line an operator's leftover
+    // `recallMinScore` would silently switch a recall FILTER on for an agent
+    // whose switchroom.yaml never asked for one.
+    const agentConfig = makeAgentConfig();
+    const withMemory = buildSwitchroomConfig(agentConfig, {
+      backend: "hindsight",
+      shared_collection: "shared",
+      config: { provider: "openai", docker_service: true, url: "http://127.0.0.1:18888/mcp/" },
+    });
+    scaffoldAgent("test-agent", agentConfig, tmpDir, telegramConfig, withMemory);
+
+    const startSh = readFileSync(join(tmpDir, "test-agent", "start.sh"), "utf-8");
+    // Whole-line match, deliberately: `toContain("...MIN_SCORE=0")` also
+    // matches a rendered `=0.01`, so a non-zero default would sail through it.
+    expect(startSh).toContain("export HINDSIGHT_RECALL_MIN_SCORE=0\n");
+    expect(startSh).toContain("export HINDSIGHT_RECALL_MIN_SCORE_SCOPE=degraded\n");
+    // Never an empty assignment: `_cast_env("", float)` returns None, the
+    // assignment is skipped, and claude-code.json wins again.
+    expect(startSh).not.toContain("export HINDSIGHT_RECALL_MIN_SCORE=\n");
+    expect(startSh).not.toContain("export HINDSIGHT_RECALL_MIN_SCORE_SCOPE=\n");
+  });
+
+  it("start.sh exports the #3837 score floor and scope when the operator opts in", () => {
+    const agentConfig = makeAgentConfig({
+      memory: {
+        collection: "test-agent",
+        recall: { min_score: 0.01, min_score_scope: "all" },
+      },
+    });
+    const withMemory = buildSwitchroomConfig(agentConfig, {
+      backend: "hindsight",
+      shared_collection: "shared",
+      config: { provider: "openai", docker_service: true, url: "http://127.0.0.1:18888/mcp/" },
+    });
+    scaffoldAgent("test-agent", agentConfig, tmpDir, telegramConfig, withMemory);
+
+    const startSh = readFileSync(join(tmpDir, "test-agent", "start.sh"), "utf-8");
+    expect(startSh).toContain("export HINDSIGHT_RECALL_MIN_SCORE=0.01");
+    expect(startSh).toContain("export HINDSIGHT_RECALL_MIN_SCORE_SCOPE=all");
+  });
+
   it("start.sh exports HINDSIGHT_RECALL_MAX_MEMORIES=0 when operator explicitly disables the cap", () => {
     // 0 is a meaningful sentinel ("uncapped"), not the same as unset.
     // The template uses an isNumber helper specifically so 0 still

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -46,6 +46,20 @@ DEFAULTS = {
     # cap of 6 its fleet actually deploys.
     "recallOwnBankMinSlots": 0,
     "recallAdditionalBankMinSlots": 0,
+    # Switchroom #3837: absolute floor on a result's engine relevance score
+    # (`scores.final`) for it to be injected. 0.0 (default) DISABLES the floor
+    # — nothing is dropped and the injected set is byte-identical to the
+    # pre-#3837 behaviour. `recallMinScoreScope` decides which turns a
+    # non-zero floor binds on: "degraded" (default) = only turns where the
+    # agent's OWN bank timed out or was unreachable, which is the population
+    # where a below-floor score actually predicts noise (98.4% of degraded
+    # rows have a best injected score under 0.01, against 28.4% of healthy
+    # ones); "all" = every turn, which #3761's replay says empties ~28% of
+    # HEALTHY recalls at 0.01 and is not recommended as a fleet default. See
+    # the design note above `_filter_by_min_score` in recall.py. Env:
+    # HINDSIGHT_RECALL_MIN_SCORE / HINDSIGHT_RECALL_MIN_SCORE_SCOPE.
+    "recallMinScore": 0.0,
+    "recallMinScoreScope": "degraded",
     "recallTypes": ["world", "experience"],
     # Switchroom-local: when True (default; Ken-approved ON) recall biases
     # toward synthesized `observation`-tier facts. Escape hatch: pin off via
@@ -324,6 +338,12 @@ ENV_OVERRIDES = {
     # .additional_bank_min_slots (cascading through defaults). 0 = off.
     "HINDSIGHT_RECALL_OWN_BANK_MIN_SLOTS": ("recallOwnBankMinSlots", int),
     "HINDSIGHT_RECALL_ADDITIONAL_BANK_MIN_SLOTS": ("recallAdditionalBankMinSlots", int),
+    # Switchroom #3837: absolute `scores.final` floor + the population it binds
+    # on. Set by start.sh from agents.<name>.memory.recall.min_score /
+    # .min_score_scope (cascading through defaults), exported only when the
+    # operator opted in. 0.0 = off (the default, and the shipped behaviour).
+    "HINDSIGHT_RECALL_MIN_SCORE": ("recallMinScore", float),
+    "HINDSIGHT_RECALL_MIN_SCORE_SCOPE": ("recallMinScoreScope", str),
     # Switchroom-local: recall fact types (comma-separated). Set by start.sh
     # from agents.<name>.memory.recall.types only when the operator overrode
     # the switchroom default (world,experience,observation) — i.e. the

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -580,6 +580,101 @@ def _injected_score_stats(results) -> dict:
         return empty
 
 
+# Switchroom #3837 — opt-in absolute score floor (`recallMinScore`).
+#
+# READ #3761 FIRST. It removed the lexical `recallMinOverlap` gate and stated
+# "no replacement floor", on a 330-query replay showing that for EVERY floor
+# value tested `top1lost% == zero%`: a floor at 0.001 took zero-result recalls
+# from 5.8% to 28.2%, at 0.05 to 40.6%. That measurement stands and this change
+# does not contradict it — which is why the floor ships DISABLED (0.0) and why
+# its default scope is not "every turn".
+#
+# What #3761 did not separate is the CONDITION of the bank read. Measured
+# fleet-wide from `recall_log.jsonl` on 2026-07-27 and recorded independently
+# in `src/hindsight-watch/thresholds.ts` (RECALL_SCORE_P50_PAGE):
+#
+#   own bank HEALTHY  (n=74)   p50 injected_score_max 0.0850   28.4% below 0.01
+#   own bank DEGRADED (n=247)  p50 injected_score_max 0.0006   98.4% below 0.01
+#
+# A ~140x separation in the p50, and the below-0.01 fraction separates
+# 28.4% vs 98.4%. Two conclusions follow, and only the second is actionable:
+#
+#   * On a HEALTHY turn a low `scores.final` does NOT imply noise. The healthy
+#     distribution is bimodal, p10 0.0005 to p90 0.9259 — the score is not
+#     calibrated across queries, so 28.4% of perfectly good turns would be
+#     emptied by a 0.01 floor. That is #3761's result, reproduced. A floor
+#     applied unconditionally re-creates #3541.
+#   * On a DEGRADED turn — the agent's own bank timed out or was unreachable,
+#     so what survives is side-bank residue — 98.4% of injected sets have a
+#     best score below 0.01, and the turn ALREADY carries
+#     `degraded_recall_notice`. Withholding that residue costs at most the
+#     1.6% tail and replaces "six memories presented as recall" with the
+#     honest "recall was DEGRADED, treat absence as UNKNOWN" the agent can
+#     act on. Injecting noise under the banner of recall is strictly worse
+#     than injecting nothing WITH a disclosure, because the agent cannot tell
+#     the two apart; injecting nothing WITHOUT a disclosure is the failure
+#     mode #3619 fixed and is not re-introduced here.
+#
+# Hence `recallMinScoreScope`, default "degraded": when the operator sets a
+# floor, it binds only on turns where the own-bank read was degraded, which is
+# the population the evidence supports. "all" widens it to every turn for an
+# operator who has measured their own bank and wants it — no fleet default
+# recommends that today.
+#
+# Nothing is dropped silently. When the floor empties a non-empty set the turn
+# emits `min_score_withheld_notice` (and the degraded notice too, when that
+# fired), so an empty recall is never mistaken for an empty memory. Per-turn
+# telemetry lands on `recall_log.jsonl` as `min_score_floor`,
+# `min_score_scope`, `min_score_applied` and `dropped_below_min_score`,
+# alongside the existing `injected_score_*` fields — the same instrument the
+# problem was measured with, so the effect is measurable the same way.
+def _filter_by_min_score(results, threshold: float):
+    """Drop results whose engine score (`scores.final`) is below `threshold`.
+
+    Returns ``(kept, dropped)``. ``threshold <= 0`` short-circuits to
+    passthrough with no iteration cost, so the disabled default cannot alter
+    the injected set.
+
+    A result carrying NO usable score is KEPT, never dropped. `-inf` is the
+    sentinel `_result_final_score` returns for a malformed or score-less
+    entry, and "the engine gave us no score" is not evidence of irrelevance —
+    dropping on it would turn a response-shape change upstream into silent
+    total recall loss. Same reasoning as the sort, which parks score-less
+    entries last rather than discarding them.
+    """
+    if threshold <= 0:
+        return results, 0
+    kept = []
+    dropped = 0
+    for m in results:
+        score = _result_final_score(m)
+        if score == float("-inf") or score >= threshold:
+            kept.append(m)
+        else:
+            dropped += 1
+    return kept, dropped
+
+
+def min_score_withheld_notice(dropped: int, threshold: float) -> str:
+    """One line telling the agent that recall HAD candidates and withheld them.
+
+    Only meaningful when the floor emptied the injected set. The distinction
+    it preserves is #3619's: "I could not retrieve anything worth trusting" is
+    not "there is nothing to remember", and an agent that cannot tell those
+    apart asserts the second. Kept to a single short line — this fires on an
+    already-thin turn.
+    """
+    if dropped <= 0:
+        return ""
+    return (
+        f"[Hindsight] Memory recall returned {dropped} candidate "
+        f"{'memory' if dropped == 1 else 'memories'}, all scoring below the "
+        f"configured relevance floor ({threshold:g}), so none were injected. "
+        f"Treat an absence of relevant memory as UNKNOWN, not as 'nothing was "
+        f"remembered'."
+    )
+
+
 def _sort_by_final_score(results):
     """Sort merged multi-bank results by `scores.final` descending, in place.
 
@@ -1676,6 +1771,15 @@ def main():
                 # No directives block is built on a cache hit.
                 "directives_omitted": None,
                 "demoted_count": 0,
+                # #3837 score-floor fields, present for a uniformly queryable
+                # schema. A cache hit replays a formatted context block, not a
+                # result set, so the floor cannot have run: None (not 0.0/False)
+                # so a cache-hit row is never counted as an observed
+                # floor-disabled turn.
+                "min_score_floor": None,
+                "min_score_scope": None,
+                "min_score_applied": None,
+                "dropped_below_min_score": None,
                 "capped": False,
                 # #3541 quality telemetry — present for a uniformly queryable
                 # schema. A cache hit replays a formatted context block, not a
@@ -2146,6 +2250,45 @@ def main():
     # regardless of source bank. Stable sort: ties keep own-bank-first order.
     _sort_by_final_score(results)
 
+    # Switchroom #3619 — DEGRADED-RECALL DISCLOSURE. Computed HERE rather than
+    # at emit time because the #3837 score floor is scoped by it: the same
+    # single source of truth for "the agent's own bank did not answer" decides
+    # both whether the floor binds and what the agent is told. See
+    # `degraded_recall_notice` for why only the agent's OWN bank counts.
+    degraded_block = degraded_recall_notice(bank_id, bank_timings)
+
+    # Switchroom #3837 — opt-in absolute score floor. Runs AFTER the tag
+    # weights and the relevance sort (so it judges the same effective
+    # `scores.final` the ranking used) and BEFORE the head-slice cap, so the
+    # cap sees only survivors. Disabled by default (`recallMinScore` 0.0);
+    # when set it binds on degraded turns only unless the operator widens
+    # `recallMinScoreScope` to "all". The design note above
+    # `_filter_by_min_score` carries the measurement, and why #3761's "no
+    # replacement floor" finding is not contradicted by this.
+    min_score_floor = config.get("recallMinScore", 0.0)
+    if isinstance(min_score_floor, bool) or not isinstance(min_score_floor, (int, float)):
+        min_score_floor = 0.0
+    min_score_floor = float(min_score_floor)
+    min_score_scope = config.get("recallMinScoreScope", "degraded")
+    if min_score_scope not in ("degraded", "all"):
+        min_score_scope = "degraded"
+    min_score_applied = min_score_floor > 0 and (
+        min_score_scope == "all" or bool(degraded_block)
+    )
+    dropped_below_min_score = 0
+    if min_score_applied:
+        pre_min_score_count = len(results)
+        results, dropped_below_min_score = _filter_by_min_score(
+            results, min_score_floor
+        )
+        if dropped_below_min_score > 0:
+            debug_log(
+                config,
+                f"Score floor dropped {dropped_below_min_score}/"
+                f"{pre_min_score_count} memories below scores.final "
+                f"{min_score_floor} (scope={min_score_scope})",
+            )
+
     # Switchroom-local: client-side count cap. Plugin v0.4.0 has no
     # `recallTopK` in the Claude Code integration (Openclaw-only), and a
     # token budget alone doesn't bound count — a single long memory can
@@ -2333,6 +2476,19 @@ def main():
         # doctor's directive-count check will be FAILing too.
         "directives_omitted": count_omitted_directives(directives),
         "demoted_count": demoted_count,
+        # Switchroom #3837 — score-floor telemetry, deliberately alongside the
+        # `injected_score_*` fields below: those are what the floor was derived
+        # from, and these are what says whether it bound and what it cost.
+        # `min_score_floor` is the configured value (0.0 = disabled),
+        # `min_score_scope` the population it may bind on, `min_score_applied`
+        # whether it actually ran this turn, and `dropped_below_min_score` how
+        # many results it removed. dropped > 0 with result_count 0 is the case
+        # the feature exists for: candidates existed, all were noise, none were
+        # injected, and the agent was told so.
+        "min_score_floor": min_score_floor,
+        "min_score_scope": min_score_scope,
+        "min_score_applied": min_score_applied,
+        "dropped_below_min_score": dropped_below_min_score,
         "capped": capped,
         "pre_cap_count": pre_cap_count,
         "memory_ids": [
@@ -2430,10 +2586,17 @@ def main():
         "error": recall_error_summary(bank_id, bank_timings, directives_timed_out),
     })
 
-    # Switchroom #3619 — DEGRADED-RECALL DISCLOSURE. See
-    # `degraded_recall_notice` for why this exists and why only the agent's
-    # OWN bank counts.
-    degraded_block = degraded_recall_notice(bank_id, bank_timings)
+    # (`degraded_block` — the #3619 disclosure — was computed before the score
+    # floor above, which is scoped by it.)
+    #
+    # Switchroom #3837 — when the floor emptied a non-empty set, say so. Not
+    # emitted when survivors remain: a partial drop still injects real
+    # memories and does not change how the turn should be read.
+    withheld_block = (
+        min_score_withheld_notice(dropped_below_min_score, min_score_floor)
+        if not results
+        else ""
+    )
 
     # If no block has content, there's nothing to inject — exit
     # silently to avoid emitting an empty hookSpecificOutput. #2848: unless
@@ -2441,10 +2604,13 @@ def main():
     # (a correction with no memories/directives still needs the reminder).
     # #3619: a degraded own-bank read is likewise worth emitting alone — that
     # is precisely the turn on which the agent must not assume it remembers.
+    # #3837: so is a set the score floor withheld entirely.
     if not directives_block and not memories_block and not transcript_fallback_block:
-        if degraded_block or nudge_block:
+        if degraded_block or withheld_block or nudge_block:
             _emit_cached_context(
-                "\n\n".join([b for b in (degraded_block, nudge_block) if b])
+                "\n\n".join(
+                    [b for b in (degraded_block, withheld_block, nudge_block) if b]
+                )
             )
         return
 
@@ -2500,7 +2666,10 @@ def main():
         "hookSpecificOutput": {
             "hookEventName": "UserPromptSubmit",
             "additionalContext": _combine_context(
-                _combine_context(degraded_block, context_message), nudge_block
+                _combine_context(
+                    _combine_context(degraded_block, withheld_block), context_message
+                ),
+                nudge_block,
             ),
         }
     }

--- a/vendor/hindsight-memory/scripts/tests/test_recall_min_score.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_min_score.py
@@ -1,0 +1,464 @@
+"""Switchroom #3837 — the opt-in absolute relevance floor (`recallMinScore`).
+
+The failure this exists for, measured from the fleet's own `recall_log.jsonl`
+(all agents, `injected_score_max` conditioned on `deadline_hit`):
+
+    deadline_hit TRUE   n=249   median best injected score 0.0006
+    deadline_hit FALSE  n=205   median best injected score 0.4663
+
+276 of 454 logged turns injected memories whose BEST score was below 0.01. A
+turn whose bank timed out does not inject nothing — it injects side-bank
+residue under the banner "Relevant memories from past conversations", and the
+agent cannot tell that from real recall. Silence with a disclosure is strictly
+better than noise without one.
+
+What the floor must NOT become is #3761's removed lexical gate. That gate was
+deleted after a 330-query replay showed every floor value had
+``top1lost% == zero%``, and the same fleet data says 28.4% of HEALTHY turns
+have a best injected score under 0.01 against 98.4% of degraded ones
+(`src/hindsight-watch/thresholds.ts`). So the floor ships OFF, and when it is
+switched on it binds on degraded turns only unless the operator widens the
+scope deliberately.
+
+These tests assert OUTCOMES — what reaches `additionalContext` and what lands
+on the log row — not that a branch was taken:
+
+  * an all-below-floor set injects NO memory content, and the turn still says
+    recall was degraded (the #3619 disclosure) rather than going silent;
+  * a mixed set injects the above-floor entries and only those;
+  * the log row's `dropped_below_min_score` matches what was actually dropped;
+  * the shipped default (floor 0) leaves the injected context byte-identical;
+  * the default scope does not touch a HEALTHY turn — the #3761 regression;
+  * a score-less result is never dropped (missing score != irrelevant);
+  * the withheld notice is per-turn state and never reaches the recall cache.
+
+Stdlib-only (unittest + mock); runs under ``python3 -m unittest discover
+tests/``. Harness mirrors ``test_recall_degraded_notice.py``.
+"""
+
+import io
+import json
+import os
+import shutil
+import socket
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import recall  # noqa: E402
+from recall import _filter_by_min_score, min_score_withheld_notice  # noqa: E402
+
+OWN = "test-bank"
+SIDE = "shared-bank"
+
+# The two regimes the fleet measurement separates: what a timed-out turn's
+# residue actually scores, and what a real hit scores.
+NOISE = 0.0006
+REAL = 0.9497
+
+
+def _memory(text, mem_id, score=None):
+    m = {"text": text, "type": "fact", "mentioned_at": "2026-01-01", "id": mem_id}
+    if score is not None:
+        m["scores"] = {"final": score}
+    return m
+
+
+def _directive(name, content, priority=5):
+    return {
+        "id": f"id-{name}",
+        "bank_id": OWN,
+        "name": name,
+        "content": content,
+        "priority": priority,
+        "is_active": True,
+        "tags": [],
+    }
+
+
+class _Client:
+    """Fake HindsightClient with per-bank results / exceptions."""
+
+    def __init__(self, bank_results=None, bank_errors=None, directives=None):
+        self._bank_results = bank_results or {}
+        self._bank_errors = bank_errors or {}
+        self._directives = directives or []
+
+    def list_directives(self, bank_id, active_only=True, timeout=2):
+        return {"items": list(self._directives)}
+
+    def recall(self, bank_id, query, **kwargs):
+        exc = self._bank_errors.get(bank_id)
+        if exc is not None:
+            raise exc
+        return {"results": [dict(m) for m in self._bank_results.get(bank_id, [])]}
+
+
+class FilterUnitTests(unittest.TestCase):
+    def test_threshold_zero_is_passthrough(self):
+        results = [_memory("a", "m1", NOISE), _memory("b", "m2", REAL)]
+        kept, dropped = _filter_by_min_score(results, 0.0)
+        self.assertEqual(kept, results)
+        self.assertEqual(dropped, 0)
+
+    def test_drops_only_below_threshold(self):
+        low = _memory("low", "m1", NOISE)
+        high = _memory("high", "m2", REAL)
+        kept, dropped = _filter_by_min_score([low, high, low], 0.01)
+        self.assertEqual(kept, [high])
+        self.assertEqual(dropped, 2)
+
+    def test_threshold_is_inclusive(self):
+        exact = _memory("exact", "m1", 0.01)
+        kept, dropped = _filter_by_min_score([exact], 0.01)
+        self.assertEqual(kept, [exact])
+        self.assertEqual(dropped, 0)
+
+    def test_all_below_yields_empty_set(self):
+        results = [_memory(f"n{i}", f"m{i}", NOISE) for i in range(6)]
+        kept, dropped = _filter_by_min_score(results, 0.01)
+        self.assertEqual(kept, [])
+        self.assertEqual(dropped, 6)
+
+    def test_scoreless_result_is_kept_not_dropped(self):
+        """`_result_final_score` returns -inf for a malformed / score-less
+        entry. Dropping on that sentinel would turn an upstream response-shape
+        change into total, silent recall loss — the failure mode is far worse
+        than admitting one unranked memory."""
+        unscored = _memory("no scores key", "m1")
+        broken = {"text": "malformed", "id": "m2", "scores": {"final": "NaN-ish"}}
+        kept, dropped = _filter_by_min_score([unscored, broken], 0.5)
+        self.assertEqual(kept, [unscored, broken])
+        self.assertEqual(dropped, 0)
+
+
+class WithheldNoticeUnitTests(unittest.TestCase):
+    def test_silent_when_nothing_was_dropped(self):
+        self.assertEqual(min_score_withheld_notice(0, 0.01), "")
+
+    def test_names_the_count_and_the_floor(self):
+        notice = min_score_withheld_notice(6, 0.01)
+        self.assertIn("6", notice)
+        self.assertIn("0.01", notice)
+
+    def test_tells_the_agent_to_treat_absence_as_unknown(self):
+        """The notice exists to change behaviour on a thin turn. If it stops
+        saying this it is decoration."""
+        self.assertIn("UNKNOWN", min_score_withheld_notice(3, 0.01))
+
+    def test_is_a_single_short_line(self):
+        notice = min_score_withheld_notice(3, 0.01)
+        self.assertNotIn("\n", notice)
+        self.assertLess(len(notice), 400)
+
+
+class _MainHarness(unittest.TestCase):
+    """Drives `recall.main()` end to end with an isolated recall log."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp(prefix="recall-min-score-test-")
+        self._prev = os.environ.get("CLAUDE_PLUGIN_DATA")
+        os.environ["CLAUDE_PLUGIN_DATA"] = self._tmpdir
+
+    def tearDown(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        if self._prev is None:
+            os.environ.pop("CLAUDE_PLUGIN_DATA", None)
+        else:
+            os.environ["CLAUDE_PLUGIN_DATA"] = self._prev
+
+    def _log_row(self):
+        path = os.path.join(self._tmpdir, "state", "recall_log.jsonl")
+        with open(path, encoding="utf-8") as fh:
+            rows = [json.loads(line) for line in fh if line.strip()]
+        self.assertTrue(rows, "no recall_log row was written")
+        return rows[-1]
+
+    def _run(self, client, config_extra=None):
+        hook_input = {
+            "prompt": "what did we decide about the auth flow",
+            "session_id": "test-session",
+            "transcript_path": "",
+            "cwd": "/tmp",
+        }
+        config = {
+            "autoRecall": True,
+            "bankId": OWN,
+            "recallMaxTokens": 1024,
+            "recallBudget": "mid",
+            "recallContextTurns": 1,
+            "recallMaxQueryChars": 800,
+            "recallPromptPreamble": "",
+            "recallParallelDeadlineSeconds": 5,
+            "directivesCacheTtlSeconds": 0,
+        }
+        if config_extra:
+            config.update(config_extra)
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        self._cached = []
+        with patch.object(recall, "load_config", return_value=config), patch.object(
+            recall, "get_api_url", return_value="http://localhost:18888"
+        ), patch.object(recall, "HindsightClient", return_value=client), patch.object(
+            recall, "ensure_bank_mission", return_value=None
+        ), patch.object(recall, "write_state", return_value=None), patch.object(
+            recall, "_cache_ttl_secs", return_value=300
+        ), patch.object(recall, "_cache_lookup", return_value=None), patch.object(
+            recall,
+            "_cache_store",
+            side_effect=lambda key, value: self._cached.append(value),
+        ), patch(
+            "sys.stdin", new=io.StringIO(json.dumps(hook_input))
+        ), patch("sys.stdout", new=stdout), patch("sys.stderr", new=stderr):
+            recall.main()
+        raw = stdout.getvalue()
+        if not raw.strip():
+            return None
+        return json.loads(raw)["hookSpecificOutput"]["additionalContext"]
+
+    def _degraded_noise_client(self, n=6, score=NOISE, directives=None):
+        """The measured shape: own bank times out, a side bank answers with
+        residue scoring in the noise band."""
+        return _Client(
+            bank_results={
+                SIDE: [_memory(f"noise fact {i}", f"m{i}", score) for i in range(n)]
+            },
+            bank_errors={OWN: socket.timeout("timed out")},
+            directives=directives,
+        )
+
+
+class AllBelowFloorInjectsNothingButStillDiscloses(_MainHarness):
+    def test_no_memory_content_is_injected(self):
+        ctx = self._run(
+            self._degraded_noise_client(),
+            {
+                "recallAdditionalBanks": [SIDE],
+                "recallMinScore": 0.01,
+            },
+        )
+        self.assertIsNotNone(ctx)
+        self.assertNotIn("<hindsight_memories>", ctx)
+        for i in range(6):
+            self.assertNotIn(f"noise fact {i}", ctx)
+
+    def test_the_turn_still_says_recall_was_degraded(self):
+        """Withholding must not re-create the #3619 ambiguity. An empty recall
+        that looks like an empty MEMORY is the bug; the agent has to be told
+        its own bank did not answer."""
+        ctx = self._run(
+            self._degraded_noise_client(),
+            {"recallAdditionalBanks": [SIDE], "recallMinScore": 0.01},
+        )
+        self.assertIsNotNone(ctx)
+        self.assertTrue(ctx.startswith("[Hindsight] Memory recall was DEGRADED"))
+        self.assertIn(OWN, ctx)
+
+    def test_the_turn_also_says_candidates_were_withheld(self):
+        ctx = self._run(
+            self._degraded_noise_client(),
+            {"recallAdditionalBanks": [SIDE], "recallMinScore": 0.01},
+        )
+        self.assertIn("below the configured relevance floor", ctx)
+        self.assertIn("UNKNOWN", ctx)
+
+    def test_log_row_reports_the_drop(self):
+        self._run(
+            self._degraded_noise_client(),
+            {"recallAdditionalBanks": [SIDE], "recallMinScore": 0.01},
+        )
+        row = self._log_row()
+        self.assertEqual(row["dropped_below_min_score"], 6)
+        self.assertEqual(row["min_score_floor"], 0.01)
+        self.assertEqual(row["min_score_scope"], "degraded")
+        self.assertTrue(row["min_score_applied"])
+        self.assertEqual(row["result_count"], 0)
+        # Nothing was injected, so the quality aggregates have nothing to
+        # summarise — the pairing an operator reads as "the floor bound here".
+        self.assertIsNone(row["injected_score_max"])
+
+
+class MixedSetInjectsOnlySurvivors(_MainHarness):
+    def _mixed_client(self):
+        return _Client(
+            bank_results={
+                SIDE: [
+                    _memory("real decision about auth", "m-real", REAL),
+                    _memory("noise fact 0", "m0", NOISE),
+                    _memory("noise fact 1", "m1", NOISE),
+                ]
+            },
+            bank_errors={OWN: socket.timeout("timed out")},
+        )
+
+    def test_above_floor_memory_is_injected_and_below_floor_ones_are_not(self):
+        ctx = self._run(
+            self._mixed_client(),
+            {"recallAdditionalBanks": [SIDE], "recallMinScore": 0.01},
+        )
+        self.assertIsNotNone(ctx)
+        self.assertIn("<hindsight_memories>", ctx)
+        self.assertIn("real decision about auth", ctx)
+        self.assertNotIn("noise fact 0", ctx)
+        self.assertNotIn("noise fact 1", ctx)
+
+    def test_no_withheld_notice_when_survivors_remain(self):
+        """A partial drop still injects real memories; the turn does not need
+        the extra line and a notice that fires on ordinary turns gets ignored
+        exactly when it matters."""
+        ctx = self._run(
+            self._mixed_client(),
+            {"recallAdditionalBanks": [SIDE], "recallMinScore": 0.01},
+        )
+        self.assertNotIn("below the configured relevance floor", ctx)
+
+    def test_log_row_counts_only_the_dropped(self):
+        self._run(
+            self._mixed_client(),
+            {"recallAdditionalBanks": [SIDE], "recallMinScore": 0.01},
+        )
+        row = self._log_row()
+        self.assertEqual(row["dropped_below_min_score"], 2)
+        self.assertEqual(row["result_count"], 1)
+        self.assertEqual(row["memory_ids"], ["m-real"])
+
+
+class DefaultOffChangesNothing(_MainHarness):
+    def test_noise_is_injected_exactly_as_before_when_the_floor_is_unset(self):
+        """The shipped default. Every one of the six sub-0.01 memories still
+        reaches the agent — this feature is inert until an operator opts in,
+        and a non-zero default sneaking in here fails this test."""
+        ctx = self._run(
+            self._degraded_noise_client(), {"recallAdditionalBanks": [SIDE]}
+        )
+        self.assertIsNotNone(ctx)
+        self.assertIn("<hindsight_memories>", ctx)
+        for i in range(6):
+            self.assertIn(f"noise fact {i}", ctx)
+        self.assertNotIn("below the configured relevance floor", ctx)
+        row = self._log_row()
+        self.assertEqual(row["dropped_below_min_score"], 0)
+        self.assertEqual(row["min_score_floor"], 0.0)
+        self.assertFalse(row["min_score_applied"])
+        self.assertEqual(row["result_count"], 6)
+
+    def test_explicit_zero_is_byte_identical_to_unset(self):
+        unset = self._run(
+            self._degraded_noise_client(), {"recallAdditionalBanks": [SIDE]}
+        )
+        explicit = self._run(
+            self._degraded_noise_client(),
+            {"recallAdditionalBanks": [SIDE], "recallMinScore": 0.0},
+        )
+        self.assertIsNotNone(unset)
+        self.assertEqual(unset, explicit)
+
+    def test_a_non_numeric_floor_is_treated_as_off(self):
+        """Config arrives from JSON and from the env cast; a garbage value must
+        degrade to disabled, never to "drop everything"."""
+        ctx = self._run(
+            self._degraded_noise_client(),
+            {"recallAdditionalBanks": [SIDE], "recallMinScore": "0.5"},
+        )
+        self.assertIsNotNone(ctx)
+        self.assertIn("noise fact 0", ctx)
+        self.assertEqual(self._log_row()["dropped_below_min_score"], 0)
+
+
+class ScopeDefaultsToDegradedTurnsOnly(_MainHarness):
+    """#3761's finding, honoured: a low `scores.final` does not imply noise on
+    a HEALTHY turn (28.4% of healthy rows sit under 0.01), so the default scope
+    must not touch one."""
+
+    def _healthy_noise_client(self):
+        return _Client(
+            bank_results={
+                OWN: [_memory(f"noise fact {i}", f"m{i}", NOISE) for i in range(6)]
+            }
+        )
+
+    def test_healthy_turn_is_untouched_at_the_default_scope(self):
+        ctx = self._run(self._healthy_noise_client(), {"recallMinScore": 0.5})
+        self.assertIsNotNone(ctx)
+        for i in range(6):
+            self.assertIn(f"noise fact {i}", ctx)
+        row = self._log_row()
+        self.assertEqual(row["dropped_below_min_score"], 0)
+        self.assertFalse(row["min_score_applied"])
+        self.assertEqual(row["min_score_scope"], "degraded")
+
+    def test_scope_all_binds_on_a_healthy_turn(self):
+        ctx = self._run(
+            self._healthy_noise_client(),
+            {"recallMinScore": 0.5, "recallMinScoreScope": "all"},
+        )
+        self.assertIsNotNone(ctx)
+        self.assertNotIn("<hindsight_memories>", ctx)
+        row = self._log_row()
+        self.assertEqual(row["dropped_below_min_score"], 6)
+        self.assertTrue(row["min_score_applied"])
+        self.assertEqual(row["min_score_scope"], "all")
+
+    def test_scope_all_emptying_a_healthy_turn_is_never_silent(self):
+        """No bank failed, so the #3619 degraded notice does NOT fire — this is
+        the case where the withheld notice is the only thing standing between
+        the agent and "I remember nothing"."""
+        ctx = self._run(
+            self._healthy_noise_client(),
+            {"recallMinScore": 0.5, "recallMinScoreScope": "all"},
+        )
+        self.assertIsNotNone(ctx)
+        self.assertNotIn("DEGRADED", ctx)
+        self.assertIn("below the configured relevance floor", ctx)
+
+    def test_an_unknown_scope_falls_back_to_degraded(self):
+        ctx = self._run(
+            self._healthy_noise_client(),
+            {"recallMinScore": 0.5, "recallMinScoreScope": "everything"},
+        )
+        self.assertIn("noise fact 0", ctx)
+        self.assertEqual(self._log_row()["min_score_scope"], "degraded")
+
+
+class ScorelessResultsSurviveTheFloor(_MainHarness):
+    def test_a_result_without_scores_is_injected_under_a_high_floor(self):
+        client = _Client(
+            bank_results={SIDE: [_memory("unranked but real", "m1")]},
+            bank_errors={OWN: socket.timeout("timed out")},
+        )
+        ctx = self._run(
+            client, {"recallAdditionalBanks": [SIDE], "recallMinScore": 0.9}
+        )
+        self.assertIsNotNone(ctx)
+        self.assertIn("unranked but real", ctx)
+        self.assertEqual(self._log_row()["dropped_below_min_score"], 0)
+
+
+class WithheldNoticeIsNotCached(_MainHarness):
+    def test_cache_write_carries_the_directives_without_the_notice(self):
+        """Same discipline as #3619's degraded notice: the withheld line is
+        per-turn state. If it reached `context_message` it would be cached and
+        replayed on a later healthy hit, telling the agent memories were
+        withheld on a turn where none were."""
+        client = self._degraded_noise_client(
+            directives=[_directive("trailer", "End every response with: [OK]", 10)]
+        )
+        ctx = self._run(
+            client,
+            {"recallAdditionalBanks": [SIDE], "recallMinScore": 0.01},
+        )
+        self.assertIn("below the configured relevance floor", ctx)
+        self.assertIn("End every response with: [OK]", ctx)
+        self.assertEqual(len(self._cached), 1)
+        self.assertNotIn("below the configured relevance floor", self._cached[0])
+        self.assertNotIn("DEGRADED", self._cached[0])
+        self.assertIn("End every response with: [OK]", self._cached[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #3837.

## Summary

Auto-recall had no relevance floor: whatever the engine returned went into the prompt under **"Relevant memories from past conversations"**, which the agent reads as ground truth. When a bank misses its deadline the engine still returns a full slate — just a worthless one.

This adds a client-side score floor in `recall.py`, applied **after** ranking and **before** the `recallMaxMemories` slice, plus a scope knob that decides which turns it binds on.

```yaml
agents:
  overlord:
    memory:
      recall:
        min_score: 0.01            # default 0 = OFF
        min_score_scope: degraded  # degraded (default) | all
```

- `memory.recall.min_score` → `HINDSIGHT_RECALL_MIN_SCORE` → `recallMinScore`
- `memory.recall.min_score_scope` → `HINDSIGHT_RECALL_MIN_SCORE_SCOPE` → `recallMinScoreScope`

Both exported unconditionally from `start.sh` (per #3774, so a stale `~/.hindsight/claude-code.json` can't shadow switchroom).

**No timeout, deadline, or candidate-cap value is touched.** This PR only filters what gets injected.

## Why

Live fleet `recall_log.jsonl`, `injected_score_max` split by `deadline_hit`:

| population | n | median best injected score | p90 | median `result_count` |
|---|---|---|---|---|
| `deadline_hit=true` | 249 | 0.0006 | 0.0038 | 6 |
| `deadline_hit=false` | 205 | 0.4663 | 0.9834 | 6 |

276 of 454 turns (60.8%) injected six memories whose *best* score was under 0.01.

`reference/jobs/remember-across-sessions.md`: "what comes back is relevant, not a grab-bag; most of what's recalled is useful." Six sub-0.001 hits is the grab-bag. That same spec names **silent forgetting** as never-ship, which shapes the disclosure below.

## The two defaults, and why

**`min_score: 0` (OFF).** Behaviour is byte-identical on every host that does not set it — `_filter_by_min_score` returns its input unchanged for `threshold <= 0`, and `min_score_applied` short-circuits before the filter runs. `tests/scaffold.test.ts` pins the exported line as `=0`, whole-line.

**`min_score_scope: degraded`.** `scores.final` is **not calibrated across queries**, so a single number is not universally safe. `src/hindsight-watch/thresholds.ts:470-540` already records the two populations this repo measured:

- healthy: p50 0.0850, **28.4%** of results below 0.01, p10 0.0005 → p90 0.9259
- degraded: p50 0.0006, **98.4%** below 0.01

A fleet-wide 0.01 floor would discard roughly a quarter of healthy-turn results, some of them real. On a degraded turn it discards essentially only noise. `degraded` binds the floor to the population the evidence supports; `all` is available but is not the recommended fleet default.

> A note on the probe that motivated this work: a controlled run on one bank found 17/17 ground-truth targets at 0.9497–1.0043 and 95/95 controls at 0.0000–0.0019, i.e. any floor in 0.01..0.9 was free. That result is real but **does not generalise** — it is one query family on one bank, and the healthy fleet-wide distribution above is far wider. The scope default exists precisely because that separation cannot be assumed.

## Disclosure, not silent emptying

If the floor empties a non-empty result set, the hook injects **no memory content** — never an empty banner — and emits:

> `[Hindsight] Memory recall returned N candidate memories, all scoring below the configured relevance floor (X), so none were injected. Treat an absence of relevant memory as UNKNOWN, not as 'nothing was remembered'.`

That notice follows the #3619 degraded-notice discipline exactly: it is kept **out** of `context_message` (which is cached and written to `LAST_RECALL_STATE`) and prepended at emit time via `_combine_context`, so a cache hit can never replay it. The #3619 degraded notice itself is unchanged and still fires independently on its own `bank_id` match — the two compose rather than duplicate.

A result carrying **no usable score** (`_result_final_score` → `-inf`) is always kept, never dropped.

## Observability

Every `recall_log.jsonl` row gains `min_score_floor`, `min_score_scope`, `min_score_applied`, `dropped_below_min_score`, next to the existing `injected_score_*` fields (cache-hit rows carry them as `null` for a uniform schema). Inspect with `switchroom memory recall-log`.

## Relationship to #3761 — the contradiction, stated

#3761 (merged 2026-07-27, one day before this work) removed `recallMinOverlap` and left a note in `recall.py` that "no score floor replaced it … `min_scores` is deliberately left unset". This PR does not pretend that decision away, and two things about it are worth naming:

1. Its headline `top1lost% == zero%` is **tautological** — if the gate empties the result set, top-1 is lost by definition. It measures *displacement*, not the *relevance* of what was lost.
2. It never conditioned on bank health, so the degraded population (98.4% sub-0.01) was averaged in with the healthy one.

The replacement here is therefore deliberately a different shape: a **score** floor rather than a **lexical** gate, **off by default** rather than always-on, and **scoped by default** to exactly the population #3761 did not measure. `recall.py`'s note has been updated to say this rather than removed.

## Test plan

New `vendor/hindsight-memory/scripts/tests/test_recall_min_score.py` — 25 tests, stdlib-only, harness mirroring `test_recall_degraded_notice.py` (isolated `CLAUDE_PLUGIN_DATA` tmpdir, `_log_row()` reader, patched `_cache_store`). Classes: `AllBelowFloorInjectsNothingButStillDiscloses`, `MixedSetInjectsOnlySurvivors`, `DefaultOffChangesNothing`, `ScopeDefaultsToDegradedTurnsOnly`, `ScorelessResultsSurviveTheFloor`, `WithheldNoticeIsNotCached`, plus filter/notice unit classes.

They assert **outcomes** — the emitted `additionalContext` string and the `recall_log.jsonl` row — not that a code path ran.

Local runs:

- `test_recall_min_score.py` — **25/25 OK**
- full vendored python suite — **807 tests OK**
- `tests/scaffold.test.ts` — **240 passed**
- `tsc --noEmit` — clean
- `npm run lint` — clean

### Mutation check (the filter is load-bearing)

Every mutation below was applied, the suite run, then reverted and re-verified green (`diff -q` against a saved copy of `recall.py`, 25/25 restored):

| mutation | failures |
|---|---|
| `_filter_by_min_score` made a no-op | 10 |
| `min_score_applied` forced `False` | 8 |
| comparison inverted (`<=` for `>=`) | 10 |
| withheld notice suppressed | 6 |
| score-less results dropped instead of kept | 2 |
| default flipped `0` → `0.01` | 2 |
| scope gate ignored (floor applied on healthy turns) | 2 |

Two `tests/scaffold.test.ts` mutations (default flipped, scope default flipped) also go red and restore green. The first version of those scaffold assertions used `toContain("...MIN_SCORE=0")`, which a `0.01` default still satisfied — that weakness was found by the mutation run and fixed by asserting whole lines including the trailing newline.

## Risk

Low. Off by default and short-circuited before any filtering when off, so the no-config path is unchanged. The main residual risk is an operator setting `min_score_scope: all` with too high a floor and starving recall on healthy turns; `docs/configuration.md` says so explicitly and points at the recall-log distribution as the thing to check first.

## Verdict rule

- **Advances:** standing-team (the fleet's memory stops being a grab-bag).
- **Job spec:** `reference/jobs/remember-across-sessions.md` — "what comes back is relevant, not a grab-bag"; silent forgetting is prevented by the withheld notice.
- **Principle checks:** docs test (`docs/configuration.md` section added); defaults test (off, byte-identical); consistency test (same env → JSON → default cascade, same unconditional-export treatment, same emit-time-not-cached notice discipline as #3619).
- **Invariants:** none crossed — no egress, no self-escalation, claude-native, client-side only.