### PR TITLE
fix(hindsight): stop a recreate silently dropping GPU passthrough

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -466,6 +466,32 @@ hindsight:
 
 If you run your own Hindsight container outside `switchroom memory --start` (e.g. you point `memory.config.url` at an external server), switchroom doesn't manage that container's env — set the cap on your own image.
 
+### GPU passthrough for the Hindsight container
+
+The local embedding model and the cross-encoder reranker run on the GPU when the container can see one. Switchroom decides that by reading `~/.switchroom/host-capabilities.json`, the verdict `switchroom setup` writes after probing the host: `--gpus all` is added only when that file proves **both** a GPU and the nvidia container toolkit. It has to be gated — `docker run --gpus all` hard-fails container create on a host without the toolkit.
+
+You can override the autodetection in both directions:
+
+```yaml
+hindsight:
+  gpu: true    # force GPU passthrough on
+  # gpu: false # force it off on a GPU host
+```
+
+`--gpu` / `--no-gpu` on `switchroom memory setup` override the yaml for a single run. Explicit always beats autodetect. Force it on when you know the host has a working toolkit but the verdict file is wrong or unreadable — switchroom cannot verify the toolkit for you, so a wrong `true` fails the container create loudly rather than silently.
+
+**A recreate will not silently take GPU away.** `switchroom memory setup --recreate` inspects the running container first. If it currently has GPU passthrough and the next launch would not, the recreate is **refused** before the image pull and before the container is removed, naming the reason. That drop is otherwise invisible: it moves the reranker to CPU on the interactive recall path and also withholds the GPU-only defaults `HINDSIGHT_API_RERANKER_LOCAL_FP16` and `HINDSIGHT_API_RERANKER_LOCAL_BATCH_SIZE`.
+
+Three ways past the refusal, in the order you probably want them:
+
+| You want | Use |
+| --- | --- |
+| GPU kept, because the verdict file is wrong | `--gpu`, or `hindsight.gpu: true` to make it stick |
+| CPU, deliberately, from now on | `hindsight.gpu: false` or `--no-gpu` (never refused — that is the declared opt-out) |
+| CPU, just this once | `--allow-gpu-drop` |
+
+`switchroom doctor` carries a `host capabilities verdict` row that FAILs when the file exists but cannot be read or parsed. That is the failure mode this guards: an unreadable verdict used to be indistinguishable from "this host has no GPU". The usual cause is `sudo switchroom setup` writing the file as root into a non-root home; the fix is printed in the row.
+
 Any server from `defaults.mcp_servers` also flows to all agents via the normal cascade.
 
 To suppress the built-in `playwright` server for a specific agent:

--- a/src/cli/doctor-host-capabilities.test.ts
+++ b/src/cli/doctor-host-capabilities.test.ts
@@ -1,0 +1,109 @@
+/**
+ * `switchroom doctor` — the host-capabilities verdict row.
+ *
+ * Nothing checked this file before, and its silent-failure mode cost the fleet
+ * GPU passthrough plus the GPU-gated reranker defaults on 2026-07-28: the
+ * verdict was `root:root 0600` under a uid-1000 home (`sudo switchroom setup`
+ * writes as root), so every later run read `EACCES`, swallowed it, and treated
+ * the host as GPU-less. `doctor` was green throughout.
+ */
+
+import { describe, it, expect } from "vitest";
+import { checkHostCapabilitiesReadable } from "./doctor.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+import type { HostCapabilitiesRead } from "../setup/host-capabilities.js";
+
+const CONFIG = { agents: {} } as unknown as SwitchroomConfig;
+const CONFIG_GPU_ON = { agents: {}, hindsight: { gpu: true } } as unknown as SwitchroomConfig;
+
+const PATH = "/home/someone/.switchroom/host-capabilities.json";
+
+const read = (over: Partial<HostCapabilitiesRead>): HostCapabilitiesRead => ({
+  status: "ok",
+  path: PATH,
+  caps: null,
+  detail: "",
+  ...over,
+});
+
+describe("checkHostCapabilitiesReadable", () => {
+  it("FAILS on an unreadable verdict and names the file, the consequence, and the fix", () => {
+    const r = checkHostCapabilitiesReadable(
+      CONFIG,
+      read({ status: "unreadable", code: "EACCES", detail: "EACCES: permission denied" }),
+    );
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain(PATH);
+    expect(r.detail).toContain("cannot tell");
+    // The consequence has to be in the row — "unreadable file" alone reads
+    // like a cosmetic problem, and that is why it was ignored for months.
+    expect(r.detail).toContain("--gpus all");
+    expect(r.detail).toContain("HINDSIGHT_API_RERANKER_LOCAL_FP16");
+    expect(r.fix).toContain("chown");
+    expect(r.fix).toContain("hindsight.gpu");
+  });
+
+  it("FAILS on a malformed verdict and tells the operator to re-probe", () => {
+    const r = checkHostCapabilitiesReadable(
+      CONFIG,
+      read({ status: "malformed", detail: "invalid JSON: Unexpected end of input" }),
+    );
+    expect(r.status).toBe("fail");
+    expect(r.fix).toContain("switchroom setup");
+  });
+
+  it("downgrades to WARN when `hindsight.gpu` already pins the answer", () => {
+    const r = checkHostCapabilitiesReadable(
+      CONFIG_GPU_ON,
+      read({ status: "unreadable", code: "EACCES", detail: "EACCES: permission denied" }),
+    );
+    // Hindsight no longer depends on the file, but voice/compose still do —
+    // so it is not silently green either.
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("hindsight.gpu: true");
+  });
+
+  it("stays OK for an absent verdict (a fresh install has never probed)", () => {
+    const r = checkHostCapabilitiesReadable(CONFIG, read({ status: "absent" }));
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("never probed");
+  });
+
+  it("is OK and reports the proven/not-proven verdict when the file reads fine", () => {
+    const proven = checkHostCapabilitiesReadable(
+      CONFIG,
+      read({
+        status: "ok",
+        caps: {
+          version: 1,
+          voice: {
+            gpuPresent: true,
+            containerToolkit: true,
+            engine: "local",
+            detectedAt: "2026-07-26T00:00:00.000Z",
+          },
+        },
+      }),
+    );
+    expect(proven.status).toBe("ok");
+    expect(proven.detail).toContain("GPU passthrough proven");
+
+    const notProven = checkHostCapabilitiesReadable(
+      CONFIG,
+      read({
+        status: "ok",
+        caps: {
+          version: 1,
+          voice: {
+            gpuPresent: false,
+            containerToolkit: false,
+            engine: "cloud",
+            detectedAt: "2026-07-26T00:00:00.000Z",
+          },
+        },
+      }),
+    );
+    expect(notProven.status).toBe("ok");
+    expect(notProven.detail).toContain("GPU passthrough not proven");
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -34,6 +34,10 @@ import type { AgentConfig, SwitchroomConfig } from "../config/schema.js";
 import { loadManifest, detectDrift, type DriftProbers } from "../manifest.js";
 import { probeHindsight, isHindsightEnabled, fetchHindsightToolsList, collectProfileBanks } from "../memory/hindsight.js";
 import { HINDSIGHT_DEFAULT_MCP_URL } from "../setup/hindsight.js";
+import {
+  readHostCapabilities,
+  type HostCapabilitiesRead,
+} from "../setup/host-capabilities.js";
 import { findUnmanagedHindsightEnvKeys } from "../setup/hindsight-perf-defaults.js";
 import { inspectBankHealth, staleMentalModels, corruptedMentalModels, recentUnextracted, ageDays } from "../memory/bank-health.js";
 import { checkHindsightContainerHealth, classifyToolContract, checkHindsightHealthEndpoint, checkHindsightVersion, classifyConsolidationBacklog, classifyDirectiveCount } from "./doctor-memory.js";
@@ -1066,6 +1070,87 @@ export function checkHindsightEnvKeysAreManaged(
   };
 }
 
+/**
+ * FAIL when the persisted host-capabilities verdict exists but cannot be read.
+ *
+ * Nothing checked this file before, and its silent-failure mode is expensive:
+ * every GPU gate in switchroom (`hindsightGpuEnabled`, the GPU-only hindsight
+ * perf defaults, the compose voice sidecar) reads it, and an unreadable file
+ * used to be indistinguishable from "this host has no GPU". On 2026-07-28 that
+ * cost the fleet `--gpus all` plus `RERANKER_LOCAL_FP16` on the interactive
+ * recall path, with no error anywhere — the file was `root:root 0600` under a
+ * uid-1000 home (`sudo switchroom setup` writes as root; every later run is
+ * uid 1000).
+ *
+ * FAIL, not WARN: a present-but-unreadable verdict has no benign reading.
+ * Absent is a different thing entirely — a fresh install has never probed —
+ * so it stays OK, with the consequence spelled out.
+ *
+ * An explicit `hindsight.gpu` downgrades the row to WARN: the operator has
+ * stated the answer, so the unreadable file no longer decides anything for
+ * hindsight, but the voice/compose gates still read it.
+ *
+ * @internal exported for testing
+ */
+export function checkHostCapabilitiesReadable(
+  config: SwitchroomConfig,
+  read: HostCapabilitiesRead = readHostCapabilities(),
+): CheckResult {
+  const name = "host capabilities verdict";
+  const gpuPinned = typeof config.hindsight?.gpu === "boolean";
+
+  if (read.status === "absent") {
+    return {
+      name,
+      status: "ok",
+      detail:
+        `no verdict at ${read.path} — host never probed, so GPU-gated features ` +
+        "(hindsight `--gpus all`, the GPU perf defaults, local voice) stay off",
+      fix: "Run `switchroom setup` to probe the host, or set `hindsight.gpu: true` to force it.",
+    };
+  }
+
+  if (read.status === "unreadable" || read.status === "malformed") {
+    return {
+      name,
+      status: gpuPinned ? "warn" : "fail",
+      detail:
+        `${read.path} is ${read.status} (${read.detail}) — switchroom cannot tell ` +
+        "whether this host has a GPU, so every GPU gate reads false" +
+        (gpuPinned
+          ? `; hindsight is unaffected (\`hindsight.gpu: ${config.hindsight?.gpu}\` pins it) but voice/compose gates still read this file`
+          : ", silently withholding `--gpus all` and HINDSIGHT_API_RERANKER_LOCAL_FP16"),
+      fix:
+        `sudo chown $(id -u):$(id -g) ${read.path} && chmod 600 ${read.path}` +
+        (read.status === "malformed" ? " — then re-run `switchroom setup` to rewrite it" : "") +
+        ". Or set `hindsight.gpu: true|false` in switchroom.yaml to state the answer explicitly.",
+    };
+  }
+
+  const voice = read.caps?.voice;
+  const proven = voice?.gpuPresent === true && voice?.containerToolkit === true;
+  let mode: number | undefined;
+  try {
+    mode = statSync(read.path).mode & 0o777;
+  } catch {
+    mode = undefined;
+  }
+  // The writer uses 0600; anything group/world-writable means something else
+  // has been editing it, which is worth saying out loud even though the read
+  // itself succeeded.
+  const looseWrite = mode !== undefined && (mode & 0o022) !== 0;
+  return {
+    name,
+    status: looseWrite ? "warn" : "ok",
+    detail:
+      `${read.path} readable (mode ${mode === undefined ? "?" : "0" + mode.toString(8)})` +
+      `; GPU passthrough ${proven ? "proven" : "not proven"} ` +
+      `(gpuPresent=${JSON.stringify(voice?.gpuPresent)}, containerToolkit=${JSON.stringify(voice?.containerToolkit)})` +
+      (looseWrite ? " — but the file is group/world-writable" : ""),
+    ...(looseWrite ? { fix: `chmod 600 ${read.path}` } : {}),
+  };
+}
+
 export function checkHindsightConsumer(
   config: SwitchroomConfig,
   opts?: { socketProbe?: (consumerName: string) => "present" | "missing" | "unreachable" },
@@ -1317,10 +1402,21 @@ async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> 
 
   const results: CheckResult[] = [];
 
+  // The persisted GPU/voice verdict gates `--gpus all` and the GPU-only perf
+  // defaults, and an unreadable copy of it used to read exactly like "no GPU".
+  // Nothing checked the file itself until this row.
+  //
+  // Pushed FIRST, before the URL parse and the reachability probe, because
+  // every one of those paths `return`s early. A container that is down (or on
+  // an unparseable URL) is exactly when an operator is reading doctor output,
+  // and the verdict file is a plausible reason the container came back wrong.
+  results.push(checkHostCapabilitiesReadable(config));
+
   // Parse host and port out of the URL
   const match = url.match(/^https?:\/\/([^:/]+):?(\d+)?/);
   if (!match) {
     return [
+      ...results,
       {
         name: "hindsight URL",
         status: "fail",
@@ -1334,6 +1430,7 @@ async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> 
 
   if (!(await checkTcp(host, port))) {
     return [
+      ...results,
       {
         name: "hindsight reachable",
         status: "fail",

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -26,10 +26,14 @@ import {
   hindsightContainerEnvPairs,
   hindsightResolvedCapabilities,
   preflightHindsightPorts,
+  getHindsightDeviceRequests,
+  hindsightGpuDecision,
+  resolveHindsightGpuOverride,
   HINDSIGHT_DEFAULT_API_PORT,
   HINDSIGHT_DEFAULT_MCP_URL,
   type LiteLLMHindsightConfig,
 } from "../setup/hindsight.js";
+import { assessHindsightGpuDrop } from "../setup/hindsight-gpu-guard.js";
 import {
   diffDroppedHindsightEnv,
   formatDroppedHindsightEnvReport,
@@ -509,7 +513,30 @@ export function registerMemoryCommand(program: Command): void {
         "nor switchroom's managed defaults. Default is to warn loudly and proceed, so a " +
         "rollout is never wedged half-way with memory down.",
     )
-    .action(async (opts: { stop?: boolean; status?: boolean; recreate?: boolean; tag?: string; provider?: string; strictEnv?: boolean }) => {
+    // `--gpu` MUST be declared before `--no-gpu`: commander only leaves the
+    // pair's default `undefined` (i.e. "operator said nothing") when the
+    // positive form is defined first. Declared alone, `--no-gpu` would default
+    // `opts.gpu` to `true` and silently force GPU on every host.
+    .option(
+      "--gpu",
+      "Force GPU passthrough on for this launch, overriding host autodetection. " +
+        "Use when `~/.switchroom/host-capabilities.json` is wrong or unreadable and " +
+        "you know the host has a working nvidia container toolkit (`docker run --gpus " +
+        "all` hard-fails container create without one). Beats `hindsight.gpu`.",
+    )
+    .option(
+      "--no-gpu",
+      "Force GPU passthrough off for this launch, overriding host autodetection. " +
+        "Also the explicit opt-out for the recreate GPU drop guard.",
+    )
+    .option(
+      "--allow-gpu-drop",
+      "Proceed with a --recreate that would take GPU passthrough away from the " +
+        "running container. Without this the recreate refuses, because that drop " +
+        "moves the embedding model and cross-encoder reranker to CPU on the " +
+        "interactive recall path with no other signal.",
+    )
+    .action(async (opts: { stop?: boolean; status?: boolean; recreate?: boolean; tag?: string; provider?: string; strictEnv?: boolean; gpu?: boolean; allowGpuDrop?: boolean }) => {
       if (opts.status) {
         if (!isDockerAvailable()) {
           console.log(chalk.red("  Docker is not available."));
@@ -613,6 +640,61 @@ export function registerMemoryCommand(program: Command): void {
         return;
       }
 
+      // ── GPU passthrough: decide, report, and guard the drop ──────────────
+      //
+      // FIRST, because the env-drift guard below needs the same answer: the
+      // GPU-gated perf defaults (HINDSIGHT_API_RERANKER_LOCAL_FP16, ..._BATCH_SIZE)
+      // are emitted only when this is true, so re-deriving it there would let
+      // the drift report disagree with the launch it is predicting.
+      //
+      // The 2026-07-28 regression: this decision silently evaluated false (the
+      // host-capabilities verdict file was root:root 0600 under a uid-1000
+      // home, the EACCES was swallowed, and an unreadable file was
+      // indistinguishable from "no GPU"). The container came back on CPU with
+      // no output at all. Every part of that is now visible here.
+      let gpuConfigured: boolean | undefined;
+      try {
+        gpuConfigured = getConfig(program).hindsight?.gpu;
+      } catch {
+        gpuConfigured = undefined;
+      }
+      const gpuDecision = hindsightGpuDecision(
+        resolveHindsightGpuOverride({ flag: opts.gpu, config: gpuConfigured }),
+      );
+      console.log(
+        (gpuDecision.enabled ? chalk.green : chalk.gray)(
+          `  GPU passthrough: ${gpuDecision.enabled ? "ON" : "off"} — ${gpuDecision.reason}`,
+        ),
+      );
+      if (gpuDecision.degraded) {
+        // Loud on the command's OWN output, not only on the library's stderr:
+        // this is the path whose behaviour the degraded read actually changes.
+        console.log(
+          chalk.yellow(
+            `\n  ⚠  Cannot read the host-capabilities verdict (${gpuDecision.capabilities.path}).\n` +
+            `     ${gpuDecision.capabilities.detail}\n` +
+            "     GPU is being treated as unproven because switchroom could not tell,\n" +
+            "     NOT because this host lacks one. Fix the file, or set `hindsight.gpu`\n" +
+            "     in switchroom.yaml / pass --gpu to state the answer explicitly.\n",
+          ),
+        );
+      }
+
+      // Does this recreate take GPU away from the container that is running?
+      // Positive evidence only: getHindsightDeviceRequests() returns null for
+      // "could not inspect", and the guard must never manufacture a refusal
+      // out of not knowing. Assessed here, REPORTED with the env-drift report
+      // below, and refused after both have been printed — an operator should
+      // see everything this recreate would change in one run, not one reason
+      // per invocation.
+      const gpuDrop = recreate
+        ? assessHindsightGpuDrop({
+            existing: getHindsightDeviceRequests(),
+            decision: gpuDecision,
+            allowDrop: opts.allowGpuDrop === true,
+          })
+        : { drops: false, blocks: false, message: "" };
+
       // ── Env-drift guard ────────────────────────────────────────────────
       // A recreate rebuilds the container env FROM SCRATCH out of
       // `hindsight.env` + switchroom's managed defaults, so anything set
@@ -643,6 +725,8 @@ export function registerMemoryCommand(program: Command): void {
               apiPort: reusePorts?.apiPort ?? HINDSIGHT_DEFAULT_API_PORT,
               litellm: driftLitellm,
               llm: driftConfig.hindsight?.llm,
+              // The SAME GPU answer the launch will use, passed as a value.
+              gpu: gpuDecision.enabled,
               perf: driftPerf,
             });
             const dropped = diffDroppedHindsightEnv(
@@ -655,7 +739,7 @@ export function registerMemoryCommand(program: Command): void {
               hindsightResolvedCapabilities(
                 driftConfig.hindsight?.llm,
                 driftLitellm,
-                undefined,
+                gpuDecision.enabled,
                 driftPerf,
               ),
             );
@@ -672,14 +756,27 @@ export function registerMemoryCommand(program: Command): void {
         console.log("");
         for (const line of envDriftLines) console.log(chalk.yellow(line));
         console.log("");
-        if (opts.strictEnv) {
-          console.error(
-            chalk.red(
-              "  Refusing to recreate (--strict-env). The running container was NOT touched.\n",
-            ),
-          );
-          process.exit(1);
-        }
+      }
+      if (gpuDrop.drops) {
+        console.log(chalk[gpuDrop.blocks ? "red" : "yellow"](`\n  ${gpuDrop.message}\n`));
+      }
+
+      // Both refusals fire here — after everything has been printed, and still
+      // before the image pull and before stopHindsight(), so a refusal leaves
+      // the running container completely untouched.
+      if (gpuDrop.blocks) {
+        console.error(
+          chalk.red("  Refusing to recreate. The running container was NOT touched.\n"),
+        );
+        process.exit(1);
+      }
+      if (envDriftLines.length > 0 && opts.strictEnv) {
+        console.error(
+          chalk.red(
+            "  Refusing to recreate (--strict-env). The running container was NOT touched.\n",
+          ),
+        );
+        process.exit(1);
       }
 
       if (recreate) {
@@ -824,8 +921,11 @@ export function registerMemoryCommand(program: Command): void {
           effectiveTag,
           hindsightConfig.hindsight?.llm,
           hindsightConsumerMirrorDir(hindsightConfig),
-          // gpu: omitted ⇒ hindsightGpuEnabled() reads the persisted verdict.
-          undefined,
+          // The SAME answer that was printed and drop-guarded above, passed as
+          // a value rather than re-derived. Re-deriving would let the launch
+          // disagree with the guard that just cleared it — the exact class of
+          // silent divergence this PR exists to close.
+          gpuDecision.enabled,
           // Operator overrides for the capability-gated performance defaults.
           { env: hindsightConfig.hindsight?.env },
         );
@@ -872,9 +972,13 @@ export function registerMemoryCommand(program: Command): void {
           generateHindsightComposeSnippet(
             snippetConfig.hindsight?.llm,
             hindsightConsumerMirrorDir(snippetConfig),
-            // litellm / gpu: omitted ⇒ same defaults the docker-run path uses.
+            // litellm: omitted ⇒ same default the docker-run path uses.
             undefined,
-            undefined,
+            // gpu: the `hindsight.gpu` override still applies here, so the
+            // emitted compose file agrees with what `memory setup` would launch.
+            hindsightGpuDecision(
+              resolveHindsightGpuOverride({ config: snippetConfig.hindsight?.gpu }),
+            ).enabled,
             { env: snippetConfig.hindsight?.env },
           ),
         );

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2178,6 +2178,24 @@ const HindsightPerOpLlmSchema = z
   );
 
 export const HindsightConfigSchema = z.object({
+  gpu: z
+    .boolean()
+    .optional()
+    .describe(
+      "Force GPU passthrough for the hindsight container on (`true`) or off " +
+      "(`false`), overriding host autodetection in BOTH directions. Absent " +
+      "(the default) → autodetect from the persisted host-capabilities " +
+      "verdict (`~/.switchroom/host-capabilities.json`), which enables " +
+      "`--gpus all` only when that file proves BOTH a GPU and the nvidia " +
+      "container toolkit. Set `true` when that verdict is wrong or unreadable " +
+      "and you know the host has a working toolkit — switchroom cannot verify " +
+      "it for you, and `docker run --gpus all` hard-fails container create on " +
+      "a host without one. Set `false` to pin the container to CPU on a GPU " +
+      "host. This is also the declarative opt-out for the recreate-time GPU " +
+      "drop guard (`switchroom memory setup --recreate` refuses to silently " +
+      "turn a GPU container into a CPU one). `--gpu`/`--no-gpu` on `memory " +
+      "setup` override this for a single run.",
+    ),
   llm: z
     .object({
       provider: z

--- a/src/setup/hindsight-gpu-guard.test.ts
+++ b/src/setup/hindsight-gpu-guard.test.ts
@@ -1,0 +1,368 @@
+/**
+ * The GPU passthrough decision + the recreate drop guard.
+ *
+ * Regression under test (2026-07-28, production): `switchroom memory setup
+ * --recreate` relaunched the hindsight container WITHOUT `--gpus all` on a
+ * host that has a GPU, because the persisted verdict file was `root:root 0600`
+ * under a uid-1000 home. `loadHostCapabilities()` swallowed the EACCES,
+ * `hindsightGpuEnabled()` read the resulting `null` as "no GPU", and the local
+ * embedding model plus the cross-encoder reranker moved to CPU on the
+ * interactive recall path. The GPU-gated perf defaults
+ * (`HINDSIGHT_API_RERANKER_LOCAL_FP16`, `..._BATCH_SIZE`) went with them.
+ * Nothing printed. It was found by hand-diffing a `docker inspect` snapshot.
+ *
+ * Three properties are pinned here, and each one alone would have caught it:
+ *
+ *   1. an unreadable verdict yields a `degraded` decision, not a quiet false;
+ *   2. an explicit operator answer beats autodetect in BOTH directions, so the
+ *      verdict file is never the only lever;
+ *   3. a recreate that would take GPU away from the running container is
+ *      REFUSED unless the operator said so.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { execFileSyncMock } = vi.hoisted(() => ({ execFileSyncMock: vi.fn() }));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, execFileSync: execFileSyncMock };
+});
+
+import {
+  deviceRequestsHaveGpu,
+  getHindsightDeviceRequests,
+  hindsightGpuDecision,
+  hindsightGpuEnabled,
+  resolveHindsightGpuOverride,
+  startHindsight,
+  type HindsightDeviceRequest,
+} from "./hindsight.js";
+import { assessHindsightGpuDrop } from "./hindsight-gpu-guard.js";
+import { resetHostCapabilitiesWarnings } from "./host-capabilities.js";
+
+let home: string;
+let prevHome: string | undefined;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "switchroom-gpuguard-"));
+  prevHome = process.env.HOME;
+  process.env.HOME = home;
+  resetHostCapabilitiesWarnings();
+  execFileSyncMock.mockReset();
+  execFileSyncMock.mockReturnValue(Buffer.from(""));
+  vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  if (prevHome === undefined) delete process.env.HOME;
+  else process.env.HOME = prevHome;
+  rmSync(home, { recursive: true, force: true });
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+/** Write a verdict file with the two probe booleans. */
+function writeVerdict(gpuPresent: boolean, containerToolkit: boolean): void {
+  mkdirSync(join(home, ".switchroom"), { recursive: true });
+  writeFileSync(
+    join(home, ".switchroom", "host-capabilities.json"),
+    JSON.stringify({
+      version: 1,
+      voice: {
+        gpuPresent,
+        containerToolkit,
+        engine: gpuPresent && containerToolkit ? "local" : "cloud",
+        detectedAt: "2026-07-26T00:00:00.000Z",
+      },
+    }) + "\n",
+  );
+}
+
+/**
+ * Make the verdict file present-but-unreadable in a way that holds for a root
+ * test runner too (root ignores mode bits, so `chmod 000` would be a no-op in
+ * some CI images and this suite would pass without testing anything).
+ */
+function makeVerdictUnreadable(): void {
+  mkdirSync(join(home, ".switchroom", "host-capabilities.json"), { recursive: true });
+}
+
+/** `--gpus all`, exactly as docker materialises it in HostConfig.DeviceRequests. */
+const GPUS_ALL: HindsightDeviceRequest[] = [
+  { Driver: "", Count: -1, DeviceIDs: null, Capabilities: [["gpu"]] },
+];
+
+describe("hindsightGpuDecision — a blind false is not a negative one", () => {
+  it("is enabled + not degraded when the verdict proves GPU and toolkit", () => {
+    writeVerdict(true, true);
+    const d = hindsightGpuDecision();
+    expect(d.enabled).toBe(true);
+    expect(d.source).toBe("autodetect");
+    expect(d.degraded).toBe(false);
+  });
+
+  it("is a NON-degraded false when the verdict genuinely says no GPU", () => {
+    writeVerdict(false, false);
+    const d = hindsightGpuDecision();
+    expect(d.enabled).toBe(false);
+    expect(d.degraded).toBe(false);
+    expect(d.reason).toContain("does not prove GPU passthrough");
+  });
+
+  it("is a DEGRADED false when the verdict exists but cannot be read", () => {
+    makeVerdictUnreadable();
+    const d = hindsightGpuDecision();
+    // Still false — emitting `--gpus all` blind would hard-fail container
+    // create on a toolkit-less host. But now it is a false that SAYS SO.
+    expect(d.enabled).toBe(false);
+    expect(d.degraded).toBe(true);
+    expect(d.capabilities.status).toBe("unreadable");
+    expect(d.reason).toContain("unreadable");
+    expect(d.reason).toContain(join(home, ".switchroom", "host-capabilities.json"));
+  });
+
+  it("is a DEGRADED false when the verdict is corrupt", () => {
+    mkdirSync(join(home, ".switchroom"), { recursive: true });
+    writeFileSync(join(home, ".switchroom", "host-capabilities.json"), "{ truncated");
+    const d = hindsightGpuDecision();
+    expect(d.enabled).toBe(false);
+    expect(d.degraded).toBe(true);
+    expect(d.capabilities.status).toBe("malformed");
+  });
+
+  it("is a NON-degraded false when no verdict was ever written", () => {
+    const d = hindsightGpuDecision();
+    expect(d.enabled).toBe(false);
+    expect(d.degraded).toBe(false);
+    expect(d.reason).toContain("host never probed");
+  });
+});
+
+describe("explicit operator override beats autodetect — in both directions", () => {
+  it("forces GPU ON over a verdict that says no GPU", () => {
+    writeVerdict(false, false);
+    expect(hindsightGpuDecision({ value: true, source: "config" }).enabled).toBe(true);
+    expect(hindsightGpuDecision({ value: true, source: "flag" }).enabled).toBe(true);
+  });
+
+  it("forces GPU ON over an UNREADABLE verdict — the production recovery path", () => {
+    makeVerdictUnreadable();
+    const d = hindsightGpuDecision({ value: true, source: "config" });
+    expect(d.enabled).toBe(true);
+    expect(d.source).toBe("config");
+    // The override is a real answer, so the decision is no longer "blind".
+    expect(d.degraded).toBe(false);
+    expect(d.reason).toContain("hindsight.gpu: true");
+  });
+
+  it("forces GPU OFF over a verdict that proves GPU", () => {
+    writeVerdict(true, true);
+    const d = hindsightGpuDecision({ value: false, source: "flag" });
+    expect(d.enabled).toBe(false);
+    expect(d.reason).toContain("--no-gpu");
+  });
+
+  it("resolves the flag ahead of the yaml key, and yaml ahead of nothing", () => {
+    expect(resolveHindsightGpuOverride({ flag: false, config: true })).toEqual({
+      value: false,
+      source: "flag",
+    });
+    expect(resolveHindsightGpuOverride({ config: true })).toEqual({
+      value: true,
+      source: "config",
+    });
+    // `false` is an answer, not an absence.
+    expect(resolveHindsightGpuOverride({ config: false })).toEqual({
+      value: false,
+      source: "config",
+    });
+    expect(resolveHindsightGpuOverride({})).toBeNull();
+  });
+
+  it("reaches the launched argv: a forced-on override emits `--gpus all` on a no-GPU verdict", () => {
+    writeVerdict(false, false);
+    startHindsight({ apiPort: 18888, uiPort: 19999 }, undefined, undefined, undefined, undefined, true);
+    const call = execFileSyncMock.mock.calls.find(
+      (c) =>
+        c[0] === "docker" &&
+        Array.isArray(c[1]) &&
+        (c[1] as string[])[0] === "run" &&
+        (c[1] as string[]).includes("switchroom-hindsight"),
+    );
+    const argv = call![1] as string[];
+    expect(argv[argv.indexOf("--gpus") + 1]).toBe("all");
+  });
+
+  it("hindsightGpuEnabled still answers the plain boolean for existing call sites", () => {
+    writeVerdict(true, true);
+    expect(hindsightGpuEnabled()).toBe(true);
+    writeVerdict(false, true);
+    expect(hindsightGpuEnabled()).toBe(false);
+    // explicit seam unchanged
+    expect(hindsightGpuEnabled(true)).toBe(true);
+    expect(hindsightGpuEnabled(false)).toBe(false);
+  });
+});
+
+describe("deviceRequestsHaveGpu / getHindsightDeviceRequests", () => {
+  it("recognises `--gpus all` and `--gpus device=0`", () => {
+    expect(deviceRequestsHaveGpu(GPUS_ALL)).toBe(true);
+    expect(
+      deviceRequestsHaveGpu([{ Driver: "nvidia", Count: 0, DeviceIDs: ["0"], Capabilities: null }]),
+    ).toBe(true);
+  });
+
+  it("is false for a CPU container and for `could not tell`", () => {
+    expect(deviceRequestsHaveGpu([])).toBe(false);
+    expect(deviceRequestsHaveGpu(null)).toBe(false);
+  });
+
+  it("parses docker's JSON DeviceRequests, and maps the `null` literal to []", () => {
+    execFileSyncMock.mockReturnValue(JSON.stringify(GPUS_ALL));
+    expect(deviceRequestsHaveGpu(getHindsightDeviceRequests())).toBe(true);
+
+    execFileSyncMock.mockReturnValue("null\n");
+    expect(getHindsightDeviceRequests()).toEqual([]);
+  });
+
+  it("returns null (not []) when docker inspect fails, so the guard cannot misfire", () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error("No such object: switchroom-hindsight");
+    });
+    expect(getHindsightDeviceRequests()).toBeNull();
+  });
+});
+
+describe("assessHindsightGpuDrop — the recreate cannot silently drop GPU", () => {
+  const degraded = () => {
+    makeVerdictUnreadable();
+    return hindsightGpuDecision();
+  };
+
+  it("BLOCKS a GPU→CPU recreate caused by an unreadable verdict", () => {
+    const a = assessHindsightGpuDrop({ existing: GPUS_ALL, decision: degraded() });
+    expect(a.drops).toBe(true);
+    expect(a.blocks).toBe(true);
+    // The message has to be actionable, not just alarming.
+    expect(a.message).toContain("Refusing to recreate");
+    expect(a.message).toContain("unreadable");
+    expect(a.message).toContain(join(home, ".switchroom", "host-capabilities.json"));
+    expect(a.message).toContain("--gpu");
+    expect(a.message).toContain("--allow-gpu-drop");
+    expect(a.message).toContain("HINDSIGHT_API_RERANKER_LOCAL_FP16");
+  });
+
+  it("BLOCKS a GPU→CPU recreate caused by an honest no-GPU verdict too", () => {
+    writeVerdict(false, false);
+    const a = assessHindsightGpuDrop({ existing: GPUS_ALL, decision: hindsightGpuDecision() });
+    expect(a.blocks).toBe(true);
+    expect(a.message).toContain("does not prove GPU passthrough");
+  });
+
+  it("allows the recreate when the next launch keeps GPU", () => {
+    writeVerdict(true, true);
+    const a = assessHindsightGpuDrop({ existing: GPUS_ALL, decision: hindsightGpuDecision() });
+    expect(a.drops).toBe(false);
+    expect(a.blocks).toBe(false);
+    expect(a.message).toBe("");
+  });
+
+  it("allows a CPU→CPU recreate (nothing is being lost)", () => {
+    const a = assessHindsightGpuDrop({ existing: [], decision: degraded() });
+    expect(a.drops).toBe(false);
+    expect(a.blocks).toBe(false);
+  });
+
+  it("does not manufacture a refusal when the container cannot be inspected", () => {
+    const a = assessHindsightGpuDrop({ existing: null, decision: degraded() });
+    expect(a.drops).toBe(false);
+    expect(a.blocks).toBe(false);
+  });
+
+  it("reports but does NOT block a drop the operator asked for (--no-gpu)", () => {
+    writeVerdict(true, true);
+    const a = assessHindsightGpuDrop({
+      existing: GPUS_ALL,
+      decision: hindsightGpuDecision({ value: false, source: "flag" }),
+    });
+    expect(a.drops).toBe(true);
+    expect(a.blocks).toBe(false);
+    expect(a.message).toContain("requested explicitly");
+  });
+
+  it("reports but does NOT block a drop the operator asked for (hindsight.gpu: false)", () => {
+    writeVerdict(true, true);
+    const a = assessHindsightGpuDrop({
+      existing: GPUS_ALL,
+      decision: hindsightGpuDecision({ value: false, source: "config" }),
+    });
+    expect(a.drops).toBe(true);
+    expect(a.blocks).toBe(false);
+  });
+
+  it("reports but does NOT block once --allow-gpu-drop is passed", () => {
+    const a = assessHindsightGpuDrop({
+      existing: GPUS_ALL,
+      decision: degraded(),
+      allowDrop: true,
+    });
+    expect(a.drops).toBe(true);
+    expect(a.blocks).toBe(false);
+    expect(a.message).toContain("--allow-gpu-drop was passed");
+  });
+});
+
+describe("the drop guard is wired into the recreate path, and refuses early enough", () => {
+  // Same rationale as the env-drift guard's ordering block (PR #3834): a guard
+  // that only refuses AFTER `docker rm` has already run has not guarded
+  // anything — the GPU-bearing container is gone by then and the operator is
+  // left with a stopped stack plus an error. Driving this behaviourally would
+  // mean recreating the production hindsight container against a live daemon,
+  // so the assertions are structural on purpose.
+  //
+  // Anchors are call sites, not identifiers: `stopHindsight()` is also reached
+  // via `--stop`, and the imports sit at the top of the file, so a bare
+  // indexOf would compare the wrong occurrence and pass blind.
+  const src = readFileSync(join(import.meta.dirname, "..", "cli", "memory.ts"), "utf-8");
+
+  const at = (needle: string) => {
+    const i = src.indexOf(needle);
+    expect(i, `${needle} not found in src/cli/memory.ts`).toBeGreaterThan(-1);
+    return i;
+  };
+
+  const INSPECTS = "existing: getHindsightDeviceRequests()";
+  const ASSESSES = "assessHindsightGpuDrop({";
+  const REPORTS = "gpuDrop.message";
+  const REFUSES = "if (gpuDrop.blocks)";
+  const PULLS = "pullHindsightImage(effectiveTag);";
+  const REMOVES = "Removing existing switchroom-hindsight container";
+
+  it("inspects the live container's device requests before removing it", () => {
+    expect(at(INSPECTS)).toBeLessThan(at(REMOVES));
+  });
+
+  it("assesses the drop before the pull and before the removal", () => {
+    // Before the pull too: a refusal should not have spent minutes pulling an
+    // image it is about to decline to run.
+    expect(at(ASSESSES)).toBeLessThan(at(PULLS));
+    expect(at(ASSESSES)).toBeLessThan(at(REMOVES));
+  });
+
+  it("prints the reason before it refuses, and refuses before anything is touched", () => {
+    expect(at(REPORTS)).toBeLessThan(at(REFUSES));
+    expect(at(REFUSES)).toBeLessThan(at(PULLS));
+    expect(at(REFUSES)).toBeLessThan(at(REMOVES));
+  });
+
+  it("threads the resolved GPU decision into the launch, not a hardcoded undefined", () => {
+    // The bug's blast radius included the GPU-gated perf defaults, which are
+    // selected from the same flag. If the drift report and the launcher
+    // disagree about GPU, the report is lying about what is coming.
+    expect(src).toContain("gpu: gpuDecision.enabled");
+    expect(at("gpuDecision.enabled")).toBeLessThan(at(REMOVES));
+  });
+});

--- a/src/setup/hindsight-gpu-guard.ts
+++ b/src/setup/hindsight-gpu-guard.ts
@@ -1,0 +1,113 @@
+/**
+ * The recreate-time GPU drop guard.
+ *
+ * `switchroom memory setup --recreate` tears the hindsight container down and
+ * rebuilds its argv from scratch. The `--gpus all` pair on that argv is gated
+ * on `hindsightGpuDecision()`, and on 2026-07-28 that gate evaluated false on a
+ * host that genuinely had a GPU — the persisted verdict file was
+ * `root:root 0600` under a uid-1000 home, so the read EACCES'd and was
+ * swallowed. The recreate succeeded, the container came back on `runc` with
+ * `HostConfig.DeviceRequests: null`, and the local embedding model plus the
+ * cross-encoder reranker moved to CPU on the interactive recall path. Nothing
+ * printed. Nothing failed. It was found by hand-diffing a `docker inspect`
+ * snapshot taken minutes earlier.
+ *
+ * The read is now loud (`readHostCapabilities`) and the answer is now
+ * overridable (`hindsight.gpu` / `--gpu` / `--no-gpu`), but neither of those is
+ * a backstop: both require the operator to already be looking. This module is
+ * the backstop. It compares what the RUNNING container has against what the
+ * NEXT launch plans to have, and refuses the recreate when GPU would be lost
+ * without anyone having asked for that.
+ *
+ * Deliberate asymmetry — an explicit `--no-gpu` / `hindsight.gpu: false` is NOT
+ * refused. That IS the opt-out: the operator stated the intent in the same
+ * breath as the recreate. `--allow-gpu-drop` exists for the remaining case, an
+ * autodetected drop the operator has looked at and accepted, so that accepting
+ * it never requires editing switchroom.yaml mid-incident.
+ */
+
+import type { HindsightDeviceRequest, HindsightGpuDecision } from "./hindsight.js";
+import { deviceRequestsHaveGpu } from "./hindsight.js";
+
+/** Verdict of {@link assessHindsightGpuDrop}. */
+export interface HindsightGpuDropAssessment {
+  /** True iff the running container has GPU and the next launch would not. */
+  drops: boolean;
+  /**
+   * True iff the drop must block the recreate. False for a drop the operator
+   * explicitly asked for (`--no-gpu` / `hindsight.gpu: false`) or explicitly
+   * accepted (`--allow-gpu-drop`) — those are reported, not refused.
+   */
+  blocks: boolean;
+  /** Operator-facing report. Empty string when `drops` is false. */
+  message: string;
+}
+
+/**
+ * Compare the live container's device requests against the planned GPU answer.
+ *
+ * @param existing Live `HostConfig.DeviceRequests`, or `null` for "could not
+ *   tell" (no container / docker unavailable). A `null` never blocks — the
+ *   guard refuses only on positive evidence that GPU is being taken away.
+ */
+export function assessHindsightGpuDrop(args: {
+  existing: HindsightDeviceRequest[] | null;
+  decision: HindsightGpuDecision;
+  /** `--allow-gpu-drop`: proceed past an autodetected drop. */
+  allowDrop?: boolean;
+}): HindsightGpuDropAssessment {
+  const { existing, decision, allowDrop = false } = args;
+
+  const hadGpu = deviceRequestsHaveGpu(existing);
+  if (!hadGpu || decision.enabled) {
+    return { drops: false, blocks: false, message: "" };
+  }
+
+  // An explicit operator answer is consent. Report it; do not refuse it.
+  const explicit = decision.source !== "autodetect";
+  const blocks = !explicit && !allowDrop;
+
+  return { drops: true, blocks, message: buildMessage(decision, blocks, explicit) };
+}
+
+function buildMessage(
+  decision: HindsightGpuDecision,
+  blocks: boolean,
+  explicit: boolean,
+): string {
+  const head = blocks
+    ? "Refusing to recreate switchroom-hindsight: it is running WITH GPU passthrough and this recreate would drop it."
+    : "switchroom-hindsight is running WITH GPU passthrough and this recreate drops it.";
+
+  const lines = [head, `  Reason: ${decision.reason}`];
+
+  if (decision.degraded) {
+    lines.push(
+      "  This is a BLIND false, not a negative one — switchroom could not read the",
+      "  host-capabilities verdict, so it cannot tell whether this host has a GPU.",
+      `  Fix the file: sudo chown $(id -u):$(id -g) ${decision.capabilities.path} && chmod 600 ${decision.capabilities.path}`,
+    );
+  }
+
+  lines.push(
+    "  Dropping GPU moves the local embedding model and the cross-encoder reranker",
+    "  to CPU on the interactive recall path, and also withholds the GPU-gated perf",
+    "  defaults (HINDSIGHT_API_RERANKER_LOCAL_FP16, ..._BATCH_SIZE).",
+  );
+
+  if (blocks) {
+    lines.push(
+      "  Choose one:",
+      "    --gpu                        keep GPU passthrough on this recreate",
+      "    hindsight.gpu: true          keep it on every recreate (switchroom.yaml)",
+      "    --allow-gpu-drop             proceed to CPU anyway, this once",
+      "    --no-gpu                     proceed to CPU and mean it",
+    );
+  } else if (explicit) {
+    lines.push("  Proceeding: the drop was requested explicitly.");
+  } else {
+    lines.push("  Proceeding: --allow-gpu-drop was passed.");
+  }
+
+  return lines.join("\n");
+}

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -7,7 +7,12 @@ import {
   assertClientBudget,
   clientBudgetSeconds,
 } from "../litellm/timeout-budget.js";
-import { loadHostCapabilities } from "./host-capabilities.js";
+import {
+  isDegradedHostCapabilitiesRead,
+  readHostCapabilities,
+  warnDegradedHostCapabilities,
+  type HostCapabilitiesRead,
+} from "./host-capabilities.js";
 import {
   hindsightPerfEnv,
   resolveHindsightPerfOverrides,
@@ -1383,25 +1388,218 @@ export function buildLiteLlmAwareHealthCmd(apiPort: number, litellmBaseUrl: stri
  * the schema first (`src/setup/host-capabilities.ts` v1) — they are host
  * hardware facts, not voice settings.
  *
- * Degrading to `false` on a GPU host is safe (CPU reranking, i.e. today);
- * degrading to CPU inside a GPU-enabled container is also safe
- * (cross_encoder.py's own `torch.cuda.is_available()` fallback). The only
- * genuinely bad outcome is emitting `--gpus` where Docker can't honour it,
- * which is precisely what this gate prevents.
+ * Degrading to `false` on a GPU host is NOT free, which is the 2026-07-28
+ * correction to this comment's original claim. It costs the local reranker its
+ * device AND — because they live in `HINDSIGHT_PERF_DEFAULTS_GPU` — the
+ * `RERANKER_LOCAL_FP16` / `RERANKER_LOCAL_BATCH_SIZE` defaults, on the
+ * interactive recall path. Safe to LAUNCH, expensive to run. So the gate's
+ * fail-safe direction is kept, and the silence around it is what changed:
+ * a blind `false` is now reported (see {@link hindsightGpuDecision}) and a
+ * recreate that would drop live GPU is refused (see `assessHindsightGpuDrop`).
  *
- * Both probes are compared with `=== true`, NOT coerced. `loadHostCapabilities`
+ * Both probes are compared with `=== true`, NOT coerced. `readHostCapabilities`
  * does a shape check but no per-field type check, so a hand-edited or corrupt
  * verdict holding the STRING `"false"` would satisfy a truthiness test and emit
  * `--gpus all` on a host that cannot honour it — the precise failure this gate
  * exists to prevent, arrived at through the gate. Anything that is not
  * literally `true` is treated as "not proven", which is the fail-safe reading.
  *
- * @param override Test/caller seam. When omitted the persisted verdict is read.
+ * Autodetect is NOT the only lever. An explicit operator answer — the
+ * `hindsight.gpu` key in switchroom.yaml, or `--gpu`/`--no-gpu` on
+ * `switchroom memory setup` — wins in BOTH directions, so a host whose verdict
+ * file is unreadable (or plain wrong) is never stuck. See
+ * {@link resolveHindsightGpuOverride} / {@link hindsightGpuDecision}.
+ *
+ * @param override Explicit operator answer (flag/yaml), or a test seam. When
+ *   omitted the persisted verdict is read.
  */
 export function hindsightGpuEnabled(override?: boolean): boolean {
   if (override !== undefined) return override;
-  const caps = loadHostCapabilities();
-  return caps?.voice?.gpuPresent === true && caps?.voice?.containerToolkit === true;
+  return hindsightGpuDecision().enabled;
+}
+
+/** Where the effective GPU answer came from. Explicit sources outrank autodetect. */
+export type HindsightGpuSource = "flag" | "config" | "autodetect";
+
+/** An explicit operator answer plus which lever supplied it. */
+export interface HindsightGpuOverride {
+  value: boolean;
+  source: "flag" | "config";
+}
+
+/**
+ * The full GPU answer: the boolean, where it came from, and — crucially —
+ * whether the autodetect that produced it was itself blind.
+ */
+export interface HindsightGpuDecision {
+  /** The effective answer: does this launch get `--gpus all`? */
+  enabled: boolean;
+  source: HindsightGpuSource;
+  /**
+   * True when the answer is `false` from autodetect and the verdict file was
+   * present-but-unusable. The distinguishing fact the old boolean-only gate
+   * threw away: "this host has no GPU" vs "switchroom could not tell".
+   */
+  degraded: boolean;
+  /** The raw verdict read, for messages that must name the actual file. */
+  capabilities: HostCapabilitiesRead;
+  /** One line, operator-facing, explaining WHY the answer is what it is. */
+  reason: string;
+}
+
+/**
+ * Resolve the explicit operator override, if any. Flag beats yaml; both beat
+ * autodetect. `null` means "nobody said", i.e. fall through to the verdict.
+ *
+ * Deliberately total in both directions — an operator who has to force GPU ON
+ * past a bad verdict also has to be able to force it OFF past a good one,
+ * otherwise the "explicit wins" rule is only half true and the drop guard
+ * below would have no legitimate opt-out.
+ */
+export function resolveHindsightGpuOverride(opts: {
+  /** `--gpu` / `--no-gpu` on the CLI. */
+  flag?: boolean;
+  /** `hindsight.gpu` in switchroom.yaml. */
+  config?: boolean;
+}): HindsightGpuOverride | null {
+  if (typeof opts.flag === "boolean") return { value: opts.flag, source: "flag" };
+  if (typeof opts.config === "boolean") return { value: opts.config, source: "config" };
+  return null;
+}
+
+/**
+ * Decide GPU passthrough and explain the decision.
+ *
+ * This is the function that must be used anywhere the answer changes what gets
+ * launched — {@link hindsightGpuEnabled} is the thin boolean view for call
+ * sites that only need the bit.
+ */
+export function hindsightGpuDecision(
+  override?: HindsightGpuOverride | null,
+): HindsightGpuDecision {
+  const capabilities = readHostCapabilities();
+
+  if (override) {
+    const lever = override.source === "flag"
+      ? (override.value ? "--gpu" : "--no-gpu")
+      : `hindsight.gpu: ${override.value}`;
+    return {
+      enabled: override.value,
+      source: override.source,
+      // An explicit answer is not degraded whatever the file says — the
+      // operator overrode the autodetect, which is the whole point.
+      degraded: false,
+      capabilities,
+      reason: `explicit operator override (${lever})`,
+    };
+  }
+
+  // Present-but-unusable verdict: the answer is still the fail-safe `false`
+  // (emitting `--gpus all` blind would hard-fail container create on a
+  // toolkit-less host) but it is now flagged as a BLIND false, not a
+  // negative one.
+  if (isDegradedHostCapabilitiesRead(capabilities)) {
+    warnDegradedHostCapabilities(capabilities);
+    return {
+      enabled: false,
+      source: "autodetect",
+      degraded: true,
+      capabilities,
+      reason:
+        `host-capabilities verdict is ${capabilities.status} ` +
+        `(${capabilities.path}): ${capabilities.detail} — GPU treated as unproven`,
+    };
+  }
+
+  if (capabilities.status === "absent") {
+    return {
+      enabled: false,
+      source: "autodetect",
+      degraded: false,
+      capabilities,
+      reason:
+        `no host-capabilities verdict at ${capabilities.path} ` +
+        "(host never probed — run `switchroom setup`)",
+    };
+  }
+
+  const voice = capabilities.caps?.voice;
+  const enabled = voice?.gpuPresent === true && voice?.containerToolkit === true;
+  return {
+    enabled,
+    source: "autodetect",
+    degraded: false,
+    capabilities,
+    reason: enabled
+      ? "host-capabilities verdict proves a GPU and the nvidia container toolkit"
+      : `host-capabilities verdict does not prove GPU passthrough ` +
+        `(gpuPresent=${JSON.stringify(voice?.gpuPresent)}, ` +
+        `containerToolkit=${JSON.stringify(voice?.containerToolkit)})`,
+  };
+}
+
+/**
+ * One entry of `docker inspect`'s `HostConfig.DeviceRequests` — what
+ * `docker run --gpus all` actually materialises on the container.
+ */
+export interface HindsightDeviceRequest {
+  Driver?: string;
+  Count?: number;
+  DeviceIDs?: string[] | null;
+  Capabilities?: string[][] | null;
+}
+
+/**
+ * Read the live hindsight container's device requests.
+ *
+ * `null` means "could not tell" — no container, docker unavailable, or an
+ * unparseable inspect. Distinct from `[]`, which means the container exists
+ * and requests no devices. The drop guard treats only a NON-EMPTY GPU-shaped
+ * list as "this container currently has GPU", so a `null` never manufactures a
+ * false refusal.
+ */
+export function getHindsightDeviceRequests(
+  container = "switchroom-hindsight",
+): HindsightDeviceRequest[] | null {
+  let out: string;
+  try {
+    out = execFileSync(
+      "docker",
+      ["inspect", "--format", "{{json .HostConfig.DeviceRequests}}", container],
+      { stdio: "pipe", encoding: "utf-8" },
+    );
+  } catch {
+    return null;
+  }
+  const trimmed = out.trim();
+  // Docker renders an unset DeviceRequests as the JSON literal `null`.
+  if (trimmed === "" || trimmed === "null" || trimmed === "<no value>") return [];
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (parsed === null) return [];
+    return Array.isArray(parsed) ? (parsed as HindsightDeviceRequest[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Does this device-request list represent live GPU passthrough?
+ *
+ * `--gpus all` materialises as a single entry with `Count: -1` and
+ * `Capabilities: [["gpu"]]`; `--gpus device=0` uses `DeviceIDs` instead. Match
+ * on any of the three shapes rather than on one, so a container launched by an
+ * operator's own `docker run` variant still counts.
+ */
+export function deviceRequestsHaveGpu(reqs: HindsightDeviceRequest[] | null): boolean {
+  if (!reqs || reqs.length === 0) return false;
+  return reqs.some((r) => {
+    const caps = (r.Capabilities ?? []).flat().map((c) => String(c).toLowerCase());
+    if (caps.includes("gpu")) return true;
+    if ((r.Driver ?? "").toLowerCase() === "nvidia") return true;
+    if ((r.DeviceIDs?.length ?? 0) > 0) return true;
+    return (r.Count ?? 0) !== 0;
+  });
 }
 
 /**

--- a/src/setup/host-capabilities.test.ts
+++ b/src/setup/host-capabilities.test.ts
@@ -7,17 +7,48 @@
  * so each test points HOME at a fresh tmpdir — NEVER the operator's real
  * `~/.switchroom/` (vault/shared-state test discipline).
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, existsSync, statSync, readFileSync, writeFileSync } from "node:fs";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  statSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  chmodSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   saveVoiceCapability,
   loadHostCapabilities,
+  readHostCapabilities,
+  isDegradedHostCapabilitiesRead,
+  resetHostCapabilitiesWarnings,
   hostCapabilitiesPath,
   HOST_CAPABILITIES_VERSION,
 } from "./host-capabilities.js";
 import type { GpuCapabilities } from "./gpu-detect.js";
+
+/**
+ * Capture `process.stderr.write` for the duration of a block.
+ *
+ * The point of these assertions is that the operator SEES something, so they
+ * are made against the real stream the library writes to rather than a
+ * refactor-friendly injected logger — a logger seam could be silently
+ * disconnected and every test would still pass.
+ */
+function captureStderr(): { text: () => string; restore: () => void } {
+  let buf = "";
+  const spy = vi
+    .spyOn(process.stderr, "write")
+    .mockImplementation((chunk: string | Uint8Array) => {
+      buf += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8");
+      return true;
+    });
+  return { text: () => buf, restore: () => spy.mockRestore() };
+}
 
 let home: string;
 let prevHome: string | undefined;
@@ -94,5 +125,143 @@ describe("saveVoiceCapability / loadHostCapabilities", () => {
     saveVoiceCapability(CLOUD_CAPS);
     writeFileSync(path, "{ not json");
     expect(loadHostCapabilities()).toBeNull();
+  });
+});
+
+/**
+ * The 2026-07-28 GPU regression, at its source.
+ *
+ * `loadHostCapabilities` used to answer `null` for four different situations —
+ * absent, denied, not-JSON, wrong-shape — and every GPU gate downstream read
+ * that `null` as "this host has no GPU". A verdict file the process could not
+ * READ therefore turned `--gpus all` and the GPU-gated reranker defaults off
+ * with no output on any stream.
+ *
+ * These assert the distinction itself, and that the failure is audible.
+ */
+describe("readHostCapabilities distinguishes cannot-read from no-GPU", () => {
+  beforeEach(() => resetHostCapabilitiesWarnings());
+
+  it("reports `absent` and stays SILENT when the file was never written", () => {
+    const warn = captureStderr();
+    try {
+      const read = readHostCapabilities();
+      expect(read.status).toBe("absent");
+      expect(read.caps).toBeNull();
+      expect(isDegradedHostCapabilitiesRead(read)).toBe(false);
+      // A fresh install has legitimately never probed. No noise for it.
+      expect(warn.text()).toBe("");
+    } finally {
+      warn.restore();
+    }
+  });
+
+  it("reports `unreadable` — NOT absent, NOT a no-GPU verdict — when the read fails", () => {
+    // EISDIR rather than EACCES so the assertion holds for a root runner too
+    // (root bypasses mode bits; the EACCES shape is pinned separately below).
+    mkdirSync(hostCapabilitiesPath(), { recursive: true });
+
+    const read = readHostCapabilities();
+    expect(read.status).toBe("unreadable");
+    expect(isDegradedHostCapabilitiesRead(read)).toBe(true);
+    expect(read.caps).toBeNull();
+    expect(read.code).toBe("EISDIR");
+    expect(read.path).toBe(hostCapabilitiesPath());
+    // The status must NOT be collapsible with the absent case — that
+    // collapse IS the bug.
+    expect(read.status).not.toBe("absent");
+  });
+
+  it("reports `unreadable` with EACCES when permissions deny the read", () => {
+    // The literal production trigger: `sudo switchroom setup` wrote the file
+    // root:root 0600 into a uid-1000 home. Root ignores mode bits, so this
+    // cannot be asserted as root — the EISDIR case above covers that runner.
+    if (process.getuid?.() === 0) return;
+    saveVoiceCapability(LOCAL_CAPS);
+    chmodSync(hostCapabilitiesPath(), 0o000);
+
+    const read = readHostCapabilities();
+    expect(read.status).toBe("unreadable");
+    expect(read.code).toBe("EACCES");
+    expect(isDegradedHostCapabilitiesRead(read)).toBe(true);
+  });
+
+  it("reports `malformed` for junk bytes and for a right-JSON/wrong-shape doc", () => {
+    saveVoiceCapability(CLOUD_CAPS);
+
+    writeFileSync(hostCapabilitiesPath(), "{ not json");
+    const junk = readHostCapabilities();
+    expect(junk.status).toBe("malformed");
+    expect(isDegradedHostCapabilitiesRead(junk)).toBe(true);
+
+    writeFileSync(hostCapabilitiesPath(), JSON.stringify({ version: 1 }) + "\n");
+    const shape = readHostCapabilities();
+    expect(shape.status).toBe("malformed");
+    expect(shape.detail).toContain("voice");
+  });
+
+  it("reports `ok` with the document when the file is readable", () => {
+    saveVoiceCapability(LOCAL_CAPS);
+    const read = readHostCapabilities();
+    expect(read.status).toBe("ok");
+    expect(read.caps?.voice.gpuPresent).toBe(true);
+    expect(isDegradedHostCapabilitiesRead(read)).toBe(false);
+  });
+});
+
+describe("a degraded verdict read is loud", () => {
+  beforeEach(() => resetHostCapabilitiesWarnings());
+
+  it("warns on stderr, names the file and the consequence, and does not stay quiet", () => {
+    mkdirSync(hostCapabilitiesPath(), { recursive: true });
+    const warn = captureStderr();
+    let text: string;
+    try {
+      expect(loadHostCapabilities()).toBeNull();
+      text = warn.text();
+    } finally {
+      warn.restore();
+    }
+    // The pre-fix behaviour was an empty string here. That is the regression.
+    expect(text).not.toBe("");
+    expect(text).toContain(hostCapabilitiesPath());
+    expect(text).toContain("unreadable");
+    // It must say WHY this matters, or an operator scrolling past learns nothing.
+    expect(text).toContain("--gpus all");
+    expect(text.toLowerCase()).toContain("not because this host lacks a gpu");
+    // And it must name a way out.
+    expect(text).toContain("hindsight.gpu: true");
+  });
+
+  it("warns once per process for the same problem, so it cannot spam a rollout", () => {
+    mkdirSync(hostCapabilitiesPath(), { recursive: true });
+    const warn = captureStderr();
+    try {
+      loadHostCapabilities();
+      loadHostCapabilities();
+      loadHostCapabilities();
+      expect(warn.text().match(/WARNING: host capabilities file/g)?.length).toBe(1);
+    } finally {
+      warn.restore();
+    }
+  });
+
+  it("emits nothing for an absent or healthy verdict", () => {
+    const absent = captureStderr();
+    try {
+      loadHostCapabilities();
+      expect(absent.text()).toBe("");
+    } finally {
+      absent.restore();
+    }
+
+    saveVoiceCapability(LOCAL_CAPS);
+    const healthy = captureStderr();
+    try {
+      expect(loadHostCapabilities()?.voice.engine).toBe("local");
+      expect(healthy.text()).toBe("");
+    } finally {
+      healthy.restore();
+    }
   });
 });

--- a/src/setup/host-capabilities.ts
+++ b/src/setup/host-capabilities.ts
@@ -31,7 +31,7 @@
  * (e.g. a GPU added after install) is visible.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { resolveStatePath } from "../config/paths.js";
 import type { GpuCapabilities, VoiceEngine } from "./gpu-detect.js";
@@ -90,26 +90,170 @@ export function saveVoiceCapability(
 }
 
 /**
+ * How the verdict file read went.
+ *
+ * `absent` and the three failure states used to be the SAME value (`null`) —
+ * that conflation is the 2026-07-28 GPU regression. A capabilities file the
+ * process cannot READ is indistinguishable from "this host has no GPU", so
+ * every capability gate downstream (`hindsightGpuEnabled`, the compose voice
+ * sidecar, the GPU-gated hindsight perf defaults) evaluated false and nothing
+ * anywhere said why. Two real triggers, both hit in production:
+ *
+ *   - the file was written `root:root 0600` into a uid-1000 home, so any
+ *     non-root run got `EACCES`;
+ *   - `resolveStatePath` derives from `process.env.HOME ?? "/root"`, so a
+ *     wrong/overridden HOME (sudo, a container) pointed at a path that does
+ *     not exist.
+ *
+ * The second one is genuinely indistinguishable from a fresh install at this
+ * layer, so it stays quiet. The FIRST one is not: the file is there and we
+ * were denied. That must be loud.
+ */
+export type HostCapabilitiesReadStatus =
+  /** Parsed and shape-checked. `caps` is non-null. */
+  | "ok"
+  /** `ENOENT` — never probed, or the wrong HOME. Legitimate; stay quiet. */
+  | "absent"
+  /** The file exists but could not be read (`EACCES`/`EPERM`/`EISDIR`/…). */
+  | "unreadable"
+  /** Read fine, but the bytes are not a valid capabilities document. */
+  | "malformed";
+
+/** The outcome of {@link readHostCapabilities} — never collapses to null. */
+export interface HostCapabilitiesRead {
+  status: HostCapabilitiesReadStatus;
+  /** The path that was attempted, for messages the operator can act on. */
+  path: string;
+  /** The document, iff `status === "ok"`. */
+  caps: HostCapabilities | null;
+  /** Node errno for `unreadable` (e.g. `EACCES`), when one was available. */
+  code?: string;
+  /** One-line human explanation. Empty string for `ok` / `absent`. */
+  detail: string;
+}
+
+/** True when the file is present but switchroom could not use it. */
+export function isDegradedHostCapabilitiesRead(read: HostCapabilitiesRead): boolean {
+  return read.status === "unreadable" || read.status === "malformed";
+}
+
+/**
+ * Read the persisted host-capabilities document, reporting HOW the read went.
+ *
+ * This is the honest primitive; {@link loadHostCapabilities} is the lossy
+ * back-compat wrapper over it. Callers that gate real behaviour on the verdict
+ * (GPU passthrough, the GPU-gated perf defaults) must use THIS one so they can
+ * tell "no GPU" from "could not tell".
+ */
+export function readHostCapabilities(): HostCapabilitiesRead {
+  const path = hostCapabilitiesPath();
+
+  // No `existsSync` pre-check: it cannot distinguish the cases we care about
+  // (an unreadable file still "exists") and it adds a TOCTOU window. Let the
+  // read itself report the errno.
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    // ENOENT ONLY. Every other errno — EACCES, EPERM, EISDIR, ENOTDIR — means
+    // something IS at (or in the way of) that path and the read was stopped,
+    // which is a different fact from "never probed" and must not be filed
+    // under it. Filing it under it is precisely the original bug.
+    if (code === "ENOENT") {
+      return { status: "absent", path, caps: null, code, detail: "" };
+    }
+    return {
+      status: "unreadable",
+      path,
+      caps: null,
+      code,
+      detail: `${code ?? "read failed"}: ${(err as Error).message}`,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch (err) {
+    return {
+      status: "malformed",
+      path,
+      caps: null,
+      detail: `invalid JSON: ${(err as Error).message}`,
+    };
+  }
+
+  if (
+    parsed &&
+    typeof parsed === "object" &&
+    "voice" in parsed &&
+    typeof (parsed as HostCapabilities).voice === "object" &&
+    (parsed as HostCapabilities).voice !== null
+  ) {
+    return { status: "ok", path, caps: parsed as HostCapabilities, detail: "" };
+  }
+  return {
+    status: "malformed",
+    path,
+    caps: null,
+    detail: "document has no `voice` object — not a host-capabilities file",
+  };
+}
+
+/**
+ * Keyed by `<path>|<status>` so the warning fires once per process per
+ * distinct problem (production: once), while a test that points HOME at a
+ * fresh tmpdir still gets its own warning. {@link resetHostCapabilitiesWarnings}
+ * exists for suites that assert the once-ness itself.
+ */
+const _warnedReads = new Set<string>();
+
+/** @internal test seam — clears the warn-once memo. */
+export function resetHostCapabilitiesWarnings(): void {
+  _warnedReads.clear();
+}
+
+/**
+ * Emit the one-time stderr WARN for a degraded read. Returns true if it wrote.
+ *
+ * stderr is the floor, not the ceiling: any command whose BEHAVIOUR changes
+ * because of the degraded read (`switchroom memory setup --recreate`) must
+ * also surface it on its own output — see `src/cli/memory.ts`. This exists so
+ * the quieter callers (compose generation, singleton reconcile, the voice
+ * sidecar token) are not silent either.
+ */
+export function warnDegradedHostCapabilities(read: HostCapabilitiesRead): boolean {
+  if (!isDegradedHostCapabilitiesRead(read)) return false;
+  const memo = `${read.path}|${read.status}`;
+  if (_warnedReads.has(memo)) return false;
+  _warnedReads.add(memo);
+  process.stderr.write(
+    `[switchroom] WARNING: host capabilities file is present but ${read.status} ` +
+      `(${read.path}) — ${read.detail}\n` +
+      "  GPU-gated features (hindsight `--gpus all`, the GPU perf defaults, the " +
+      "local voice engine) are being treated as UNAVAILABLE because switchroom " +
+      "cannot read the verdict, NOT because this host lacks a GPU.\n" +
+      `  Fix: chown/chmod the file so this user can read it ` +
+      `(\`sudo chown $(id -u):$(id -g) ${read.path} && chmod 600 ${read.path}\`), ` +
+      "re-run `switchroom setup` to re-probe, or force the answer with " +
+      "`hindsight.gpu: true` in switchroom.yaml.\n",
+  );
+  return true;
+}
+
+/**
  * Load the persisted host-capabilities document, or null if it doesn't
- * exist / is unreadable / is malformed. A missing or corrupt file is not
- * an error — callers (PR-B2 compose-gen, doctor) degrade by re-detecting
- * or skipping.
+ * exist / is unreadable / is malformed. A missing file is not an error —
+ * callers (compose-gen, doctor) degrade by re-detecting or skipping.
+ *
+ * Lossy by signature: prefer {@link readHostCapabilities} anywhere the null
+ * would silently become a behaviour change. A degraded read still emits the
+ * one-time stderr warning via {@link warnDegradedHostCapabilities}, so no
+ * caller of this function can fail silently either.
  */
 export function loadHostCapabilities(): HostCapabilities | null {
-  const path = hostCapabilitiesPath();
-  if (!existsSync(path)) return null;
-  try {
-    const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
-    if (
-      parsed &&
-      typeof parsed === "object" &&
-      "voice" in parsed &&
-      typeof (parsed as HostCapabilities).voice === "object"
-    ) {
-      return parsed as HostCapabilities;
-    }
-    return null;
-  } catch {
-    return null;
-  }
+  const read = readHostCapabilities();
+  warnDegradedHostCapabilities(read);
+  return read.caps;
 }


### PR DESCRIPTION
## The bug

`switchroom memory setup --recreate` relaunched `switchroom-hindsight` **without `--gpus all`** on a GPU host, and said nothing. The local embedding model and the cross-encoder reranker moved to CPU on the interactive recall path, and the GPU-gated perf defaults (`HINDSIGHT_API_RERANKER_LOCAL_FP16`, `HINDSIGHT_API_RERANKER_LOCAL_BATCH_SIZE`, `src/setup/hindsight-perf-defaults.ts:629-635`) went with them. It was found by hand-diffing a `docker inspect` snapshot.

Root cause is one swallowed errno:

- `src/setup/host-capabilities.ts:110` (pre-change) — `loadHostCapabilities()` ended in a bare `catch { return null; }`. **Every** read failure collapsed to the same `null` as "no file".
- `src/setup/hindsight.ts:1401-1404` — `hindsightGpuEnabled()` reads that `null` as `gpuPresent !== true` ⇒ **false**.
- `src/setup/hindsight.ts:1623` — `...(hindsightGpuEnabled(gpu) ? ["--gpus", "all"] : [])` ⇒ the flag is silently dropped.

Two real triggers, both hit in production: the verdict file written `root:root 0600` into a uid-1000 home (`EACCES` on every later non-root run), and `resolveStatePath` deriving from `process.env.HOME ?? "/root"` (`src/config/paths.ts:24-26,55-64`), so a wrong HOME lands on a path that does not exist. There was also **no** operator lever — no yaml key, no env var, no flag — to force the answer, so a host in this state had no recovery except fixing the file.

`doctor` was green throughout.

## What this changes

**1. The read reports how it went** (`src/setup/host-capabilities.ts:92-259`). New `readHostCapabilities()` returns a discriminated `HostCapabilitiesRead` — `ok` / `absent` / `unreadable` / `malformed` — with the path, errno, and a one-line detail. **`ENOENT` only** maps to `absent`; `EACCES`/`EPERM`/`EISDIR`/`ENOTDIR` all mean something is at (or in the way of) that path and the read was *stopped*, which is a different fact and must not be filed under "never probed" — filing it under it is precisely this bug. `warnDegradedHostCapabilities()` emits a one-time stderr WARN naming the path, the consequence (`--gpus all`, the perf defaults, the local voice engine), the explicit words "NOT because this host lacks a GPU", and the fix. `loadHostCapabilities()` is kept as a lossy wrapper that now warns, so no existing caller is silent either.

**2. An explicit operator override, winning in both directions** (`src/setup/hindsight.ts`, `src/config/schema.ts`, `src/cli/memory.ts`). New `hindsight.gpu: true|false` yaml key and `--gpu` / `--no-gpu` on `memory setup`, resolved by `resolveHindsightGpuOverride({flag, config})` (flag > yaml > autodetect) into a `HindsightGpuDecision { enabled, source, degraded, capabilities, reason }`. `memory setup` now prints `GPU passthrough: ON/off — <reason>` on every run, plus a loud yellow block when the decision is `degraded`. The decision is threaded into `startHindsight(...)` and into the perf-default selection instead of the previous hardcoded `undefined`.

**3. A drop guard on recreate** (`src/setup/hindsight-gpu-guard.ts`, new). Before anything is touched, `getHindsightDeviceRequests()` reads `HostConfig.DeviceRequests` off the live container; if it has GPU and the new plan does not, `assessHindsightGpuDrop()` **refuses by default** with a message naming why, the CPU/FP16 consequence, and the four escapes. An *explicit* `--no-gpu` / `hindsight.gpu: false` is treated as consent — reported, never refused; only an autodetected drop blocks, and `--allow-gpu-drop` is the one-shot opt-out. Positive evidence only: an inspect failure returns `null` and never blocks.

**4. A `doctor` row** (`src/cli/doctor.ts` — `checkHostCapabilitiesReadable`, name `host capabilities verdict`). `absent` → ok; `unreadable`/`malformed` → **fail**, downgraded to warn when `hindsight.gpu` already pins the answer; `ok` → ok, or warn if group/world-writable. It is pushed at the **top** of `checkHindsight()` and spread into both early returns, so the row still appears when hindsight is unreachable — exactly when an operator is reading doctor output.

## Relationship to #3834

#3834 (`622d37e27`) landed while this was in flight and touches the same block of `src/cli/memory.ts`. **Extended, not duplicated.** The rebase conflict was resolved by merging the two guard bodies into one ordered block: the GPU decision is computed **first** and threaded into `hindsightContainerEnvPairs({gpu: gpuDecision.enabled, …})` and `hindsightResolvedCapabilities(…, gpuDecision.enabled, …)` — both of which #3834 called with `undefined` — so the env-drift report now predicts the same launch the launcher actually performs. Order in the merged block: decide → report → assess drop → env-drift diff → print → refuse (`gpuDrop.blocks`, then `--strict-env`) → pull → stop. #3834's 20 structural + 5 survival tests still pass unchanged, and the new ordering tests mirror its anchor-on-call-site pattern rather than inventing a second one.

## Tests (55 new/changed assertions across 3 files)

Mutation-checked: reverting the `unreadable` branch to `absent` and forcing `hadGpu = false` in the guard turns ~9 assertions red. A test that would not have failed on this bug is not a test.

- `src/setup/hindsight-gpu-guard.test.ts` (new, 27) — degraded vs honest-false vs absent decisions; override both directions incl. over an unreadable verdict; that a forced-on override **reaches the launched argv** (`argv[argv.indexOf("--gpus")+1] === "all"`); device-request parsing incl. the `null` literal and inspect failure; the block/no-block matrix; and structural ordering proving the refusal fires before `pullHindsightImage` and before the `docker rm`.
- `src/setup/host-capabilities.test.ts` (13) — EACCES/EISDIR/corrupt-JSON do **not** yield a quiet `absent`, and the WARN actually reaches stderr. Uses `mkdirSync` at the file path for a root-proof unreadable case (`chmod 000` is a no-op for a root runner).
- `src/cli/doctor-host-capabilities.test.ts` (new, 5) — fail/warn/ok statuses, and that the detail names `--gpus all` + `HINDSIGHT_API_RERANKER_LOCAL_FP16` and the fix names `chown` + `hindsight.gpu`.

Local: `vitest run src/setup/ src/cli/doctor-host-capabilities.test.ts` → 18 files / 305 tests pass; `tsc --noEmit` clean; `npm run lint` clean (all 16 guards).

## Job spec

`reference/jobs/idempotent-update-and-restart.md` — "re-running setup converges on the same fleet, and anything it is about to take away is stated before it is taken." A recreate that silently downgrades the machine the memory system runs on is the exact failure that job forbids.

## Deliberately out of scope

- The compose voice sidecar and `gpu-detect.ts` re-probe path still consume `loadHostCapabilities()`; they now inherit the stderr WARN but get no override key of their own. `hindsight.gpu` is scoped to hindsight, as named.
- No auto-repair of a bad-mode verdict file. `doctor` names the `chown`/`chmod`; switchroom does not silently `sudo`.
- Pre-existing, unrelated: `src/cli/apply.test.ts` (10) and `tests/cli.memory.demote.test.ts` (5) fail identically on pristine `origin/main` in this environment — they write to the real `~/.switchroom`. Not touched here; follow-up issue to file.
