### PR TITLE
feat(memory): expose the remaining auto-recall knobs through switchroom.yaml

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -204,6 +204,98 @@ recall-log`. Operationally the values reach the plugin via the
 `HINDSIGHT_RECALL_MIN_SCORE` / `HINDSIGHT_RECALL_MIN_SCORE_SCOPE` env vars that
 `start.sh` exports unconditionally.
 
+### The remaining recall knobs — full `memory.recall.*` reference
+
+Everything the vendored plugin's recall hook reads is reachable from
+`switchroom.yaml`. Omit a key and you get the plugin's own default — the values
+below are exported verbatim by `start.sh` on every boot, so an agent with no
+`memory.recall:` block behaves exactly as it did before these keys existed.
+
+**Why they are exported even when unset.** The plugin's config cascade is
+built-in defaults → plugin `settings.json` → `~/.hindsight/claude-code.json` →
+environment. That third file is user-owned, survives `switchroom apply`, and
+loads *after* switchroom's `settings.json` stamp — so a stale hand-edit there
+silently outranks your yaml. Exporting unconditionally (#3774) puts
+switchroom last in the cascade and makes `switchroom.yaml` the single source of
+truth. It also means a value you set here **wins over the same variable set in
+an agent's `env:` map**, since compose environment is in place before
+`start.sh` runs.
+
+Any illegal value is rejected at `switchroom apply` time with a
+`HINDSIGHT-RECALL-CONFIG` error naming the key. That is deliberate: the plugin's
+env casting is fail-open, so a bad value there would be *dropped*, the default
+would stand, and your yaml would read as if it were in force.
+
+#### What gets recalled
+
+| Key | Type | Default | What it does |
+| --- | --- | --- | --- |
+| `budget` | `low` \| `mid` \| `high` | `low` | Server-side retrieval effort per query. `mid`/`high` search harder (more candidates, more reranking) at the cost of recall latency on every single turn. Raise only for a bank large enough that `low` visibly misses things. |
+| `max_tokens` | integer ≥ 1 | `1024` | Token ceiling for the injected memory block. This bounds the *prompt cost* of recall; `max_memories` bounds the count. Raise for an agent that needs long-form recalled context, lower for a chatty agent you want to keep cheap. |
+| `prefer_observations` | boolean | `true` | Bias retrieval toward distilled observations over raw conversation chunks. Turn off when you want verbatim source text rather than the bank's summaries. |
+| `types` | list of strings | *(plugin default)* | Restrict recall to specific memory types. Documented here for completeness — this key predates the rest of the block. |
+| `skip_trivial` | boolean | *(plugin default)* | Skip recall on prompts the hook judges trivial (greetings, "thanks"). Also predates this block. |
+
+#### How the query is built
+
+| Key | Type | Default | What it does |
+| --- | --- | --- | --- |
+| `context_turns` | integer ≥ 1 | `2` | How many recent turns are folded into the recall query. `1` makes recall track the immediate message tightly; higher values keep a longer thread in view but blur a topic switch. |
+| `roles` | non-empty list of strings | `["user","assistant"]` | Which transcript roles contribute to the query text. Set `["user"]` to query purely on what the human said, ignoring your own prior output. An empty list is rejected — it would leave recall nothing to build a query from. |
+| `max_query_chars` | integer ≥ 1 | `800` | Hard cap on the assembled query string. Long queries dilute semantic search; raise only if your agents routinely send long, information-dense prompts. |
+| `transcript_fallback` | boolean | `true` | When the hook receives no usable prompt text, fall back to reading the tail of the session transcript. Disable to make recall strictly prompt-driven. |
+| `transcript_tail_bytes` | integer ≥ 0 | `262144` | How many bytes of transcript tail that fallback reads. |
+| `prompt_preamble` | non-empty string | *(see below)* | The banner text prefixed to the injected memory block. Rewrite it to change how the agent is told to weigh recalled memories. Free-form text — quoting and escaping are handled for you. Empty is rejected: it would leave recalled memories in the prompt with nothing marking them as memories. |
+
+The default preamble is:
+
+> Relevant memories from past conversations (prioritize recent when conflicting). Only use memories that are directly useful to continue this conversation; ignore the rest:
+
+#### Tag filtering and weighting
+
+These are **dormant by default** — `tags` is empty and `tag_groups` is unset, so
+no filtering happens unless you opt in. They exist for banks where memories are
+tagged with a taxonomy you maintain yourself; switchroom does not invent one.
+
+| Key | Type | Default | What it does |
+| --- | --- | --- | --- |
+| `tags` | list of strings | `[]` (no filtering) | Only recall memories carrying these tags. |
+| `tags_match` | `any` \| `all` \| `any_strict` \| `all_strict` | `any` | How `tags` combines. The `_strict` variants require the tag to be present rather than merely scoring for it. Irrelevant while `tags` is empty. |
+| `tag_groups` | list of tag-lists, **or** a map of name → tag-list | *(unset)* | OR-of-ANDs filtering: a memory matches if it satisfies any one group. More expressive than `tags` + `tags_match`. |
+| `tag_weights` | map of tag → number ≥ 0 | `{"sidechain": 0.8}` | Score multipliers, not filters — a weight below `1` demotes without excluding. **Your map is merged over the default**, so setting `{"lesson": 1.4}` keeps the `sidechain: 0.8` demotion of delegated sub-agent memories. Set `sidechain` explicitly (e.g. `1`) to neutralise it. |
+
+```yaml
+agents:
+  archivist:
+    memory:
+      recall:
+        budget: mid
+        max_tokens: 2048
+        context_turns: 4
+        tag_weights:
+          lesson: 1.4        # promote; sidechain: 0.8 still applies
+```
+
+#### Multi-bank recall
+
+| Key | Type | Default | What it does |
+| --- | --- | --- | --- |
+| `additional_banks` | list of strings | *(unset)* | Extra banks to query — see [Shared / profile recall banks](#shared--profile-recall-banks--memoryrecalladditional_banks) below. Also populated automatically from `knows` / `serves`. |
+| `additional_bank_filters` | map of bank name → `{tags, tags_match, tag_groups}` | `{}` | Per-bank tag filtering for those extra banks, using the same three fields as above. Use it when a shared bank is broad but this agent should only see one slice of it. |
+| `parallel` | boolean | `true` | Query additional banks concurrently. This is a **rollback lever**: set `false` to serialise if concurrent recall destabilises your Hindsight instance. Serial recall is slower on every turn. |
+
+```yaml
+agents:
+  clerk:
+    memory:
+      recall:
+        additional_banks: ["operator-profile"]
+        additional_bank_filters:
+          operator-profile:
+            tags: ["preferences", "projects"]
+            tags_match: any
+```
+
 ### Tuning auto-retain cadence — `memory.retain.every_n_turns` / `overlap_turns`
 
 The plugin's Stop hook consolidates recent conversation into the bank on a

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -842,6 +842,61 @@ export HINDSIGHT_RECALL_ADDITIONAL_BANK_MIN_SLOTS={{hindsightRecallAdditionalBan
 # Observe `dropped_below_min_score` via `switchroom memory recall-log <agent>`.
 export HINDSIGHT_RECALL_MIN_SCORE={{hindsightRecallMinScore}}
 export HINDSIGHT_RECALL_MIN_SCORE_SCOPE={{hindsightRecallMinScoreScope}}
+# ── The remaining recall knobs (#3841) ───────────────────────────────────────
+# Everything else `recall.py` reads out of the plugin config, resolved from
+# `memory.recall.*` in switchroom.yaml and exported UNCONDITIONALLY for the
+# #3774 reason spelled out above: `~/.hindsight/claude-code.json` loads AFTER
+# the plugin's settings.json and survives an apply, so a knob switchroom does
+# not export is a knob a stale hand-edit owns. Every default below is the value
+# the fleet already ran before this block existed — an operator who sets none of
+# these gets byte-identical recall — and each is pinned against the vendored
+# plugin by tests/scaffold.recall-passthrough.test.ts so the two cannot drift.
+# Structural values are single-quoted JSON; `_cast_env` parses them and, unlike
+# an empty export, actually ASSIGNS (an empty one is skipped and hands authority
+# straight back to claude-code.json).
+#
+# How hard Hindsight searches: low (vector only, ~1-2s) | mid (+LLM rerank,
+# ~5s measured) | high. Switchroom ships `low` — mid was the second-largest
+# contributor to perceived dead air after model TTFT.
+export HINDSIGHT_RECALL_BUDGET={{hindsightRecallPass.budget}}
+# Token budget for the injected block. The count cap (…MAX_MEMORIES) is the
+# other bound and the tighter of the two wins.
+export HINDSIGHT_RECALL_MAX_TOKENS={{hindsightRecallPass.maxTokens}}
+# Bias toward the synthesized `observation` tier, backfilling slots freed by
+# superseded raw facts. On by default (memory.recall.prefer_observations).
+export HINDSIGHT_RECALL_PREFER_OBSERVATIONS={{hindsightRecallPass.preferObservations}}
+# Recent human turns composed into the query, and the transcript roles they may
+# be drawn from. 2 turns so a bare follow-up ("and the port?") embeds with its
+# antecedent instead of recalling on the pronoun alone.
+export HINDSIGHT_RECALL_CONTEXT_TURNS={{hindsightRecallPass.contextTurns}}
+export HINDSIGHT_RECALL_ROLES={{{hindsightRecallPass.rolesQ}}}
+# Character bound on the composed query, applied BEFORE …QUERY_MAX_TOKENS
+# shapes it; truncation keeps the latest turn and drops oldest context first.
+export HINDSIGHT_RECALL_MAX_QUERY_CHARS={{hindsightRecallPass.maxQueryChars}}
+# Tail bytes read from the session transcript for that composition — the read
+# stays O(1) on a session log that can grow to many MB. 0 = whole file.
+export HINDSIGHT_RECALL_TRANSCRIPT_TAIL_BYTES={{hindsightRecallPass.transcriptTailBytes}}
+# The banner above injected memories. The agent reads this line as the
+# instruction for how to treat the block, so it is behaviour, not cosmetics.
+export HINDSIGHT_RECALL_PROMPT_PREAMBLE={{{hindsightRecallPass.promptPreambleQ}}}
+# Tag filters (upstream 962140eef port). Dormant by default and exported at
+# their no-op values — `[]` / `{}` fold to None in recall.py, so nothing is
+# filtered unless an operator sets memory.recall.tags / .tag_groups.
+export HINDSIGHT_RECALL_TAGS={{{hindsightRecallPass.tagsQ}}}
+export HINDSIGHT_RECALL_TAGS_MATCH={{hindsightRecallPass.tagsMatch}}
+export HINDSIGHT_RECALL_TAG_GROUPS={{{hindsightRecallPass.tagGroupsQ}}}
+export HINDSIGHT_RECALL_ADDITIONAL_BANK_FILTERS={{{hindsightRecallPass.additionalBankFiltersQ}}}
+# Per-tag score multipliers — a DOWN-RANK, never a drop. Carries switchroom's
+# `sidechain: 0.8` seed (delegated sub-agent memories rank just under
+# first-party ones), merged with memory.recall.tag_weights.
+export HINDSIGHT_RECALL_TAG_WEIGHTS={{{hindsightRecallPass.tagWeightsQ}}}
+# Bounded transcript-grep fallback: only when EVERY bank returned zero AND no
+# bank hit its deadline. Covers the window between an abrupt kill and the next
+# boot reconciliation, where the fact layer never heard about the lost turns.
+export HINDSIGHT_RECALL_TRANSCRIPT_FALLBACK={{hindsightRecallPass.transcriptFallback}}
+# Parallel multi-bank fan-out: total latency is the SLOWEST slot, not the SUM.
+# false is the serial rollback lever.
+export HINDSIGHT_RECALL_PARALLEL={{hindsightRecallPass.parallel}}
 # Recall fact types (memory.recall.types cascade). Switchroom default is
 # world,experience,observation (the synthesized `observation` tier is ON
 # by default, set in the plugin settings.json). Export only when the

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -796,6 +796,7 @@ import {
 } from "../setup/hindsight-recall-tunables.js";
 import {
   resolveHindsightRecallPassthrough,
+  recallPassthroughTemplateFields,
   HINDSIGHT_RECALL_TAG_WEIGHT_SEED,
   type HindsightRecallPassthrough,
   type RecallPassthroughInput,
@@ -3838,25 +3839,13 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     // preamble is free-form operator text and the JSON carries double quotes;
     // neither is safe bare). Never empty: an empty export is skipped by
     // `_cast_env` and hands authority back to ~/.hindsight/claude-code.json.
-    hindsightRecallPass: {
-      budget: hindsightRecallPassthrough.budget,
-      maxTokens: hindsightRecallPassthrough.maxTokens,
-      preferObservations: hindsightRecallPassthrough.preferObservations,
-      contextTurns: hindsightRecallPassthrough.contextTurns,
-      rolesQ: shellSingleQuote(hindsightRecallPassthrough.rolesJson),
-      promptPreambleQ: shellSingleQuote(hindsightRecallPassthrough.promptPreamble),
-      tagsQ: shellSingleQuote(hindsightRecallPassthrough.tagsJson),
-      tagsMatch: hindsightRecallPassthrough.tagsMatch,
-      tagGroupsQ: shellSingleQuote(hindsightRecallPassthrough.tagGroupsJson),
-      tagWeightsQ: shellSingleQuote(hindsightRecallPassthrough.tagWeightsJson),
-      additionalBankFiltersQ: shellSingleQuote(
-        hindsightRecallPassthrough.additionalBankFiltersJson,
-      ),
-      transcriptFallback: hindsightRecallPassthrough.transcriptFallback,
-      transcriptTailBytes: hindsightRecallPassthrough.transcriptTailBytes,
-      maxQueryChars: hindsightRecallPassthrough.maxQueryChars,
-      parallel: hindsightRecallPassthrough.parallel,
-    },
+    // Built by the shared helper, NOT inline: reconcileAgentInner hand-builds
+    // its own template context, and a second copy of this mapping is the
+    // init-vs-reconcile drift scaffold.memory-prompt.test.ts guards.
+    hindsightRecallPass: recallPassthroughTemplateFields(
+      hindsightRecallPassthrough,
+      shellSingleQuote,
+    ),
     hindsightRecallTypes,
     hindsightRecallSkipTrivial,
     hindsightDirectiveCaptureNudge,
@@ -7421,7 +7410,16 @@ function reconcileAgentInner(
       hindsightRecallAdditionalBankMinSlots,
       hindsightRecallMinScore,
       hindsightRecallMinScoreScope,
-      hindsightRecallPassthrough,
+      // #3841 — the SAME builder buildWorkspaceContext uses. This context is
+      // hand-built, so passing the resolver object straight through would leave
+      // every `{{hindsightRecallPass.*}}` path unknown, and handlebars renders
+      // an unknown path as "" rather than throwing: reconcile would silently
+      // emit `export HINDSIGHT_RECALL_BUDGET=` and hand the knob back to
+      // ~/.hindsight/claude-code.json.
+      hindsightRecallPass: recallPassthroughTemplateFields(
+        hindsightRecallPassthrough,
+        shellSingleQuote,
+      ),
       hindsightRecallTypes,
       hindsightRecallSkipTrivial,
       hindsightDirectiveCaptureNudge,

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -794,6 +794,12 @@ import {
   type HindsightRecallTunables,
   type RecallTunableInput,
 } from "../setup/hindsight-recall-tunables.js";
+import {
+  resolveHindsightRecallPassthrough,
+  HINDSIGHT_RECALL_TAG_WEIGHT_SEED,
+  type HindsightRecallPassthrough,
+  type RecallPassthroughInput,
+} from "../setup/hindsight-recall-passthrough.js";
 import { ensureBareClone } from "../repos/bare-clone.js";
 import {
   ensureAgentWorktree,
@@ -3494,12 +3500,17 @@ function renderHindsightSettingsOverrides(
   // tags delegated worker process-facts `sidechain`; this down-weights their
   // recall `scores.final` by 0.8 so first-party session memory ranks first,
   // while a sidechain fact still surfaces when it is the only relevant hit
-  // (a DOWN-RANK, not the hard demote-tag DROP filter). No first-class cascade
-  // knob yet (mirrors the intentionally-dormant recallTags port below);
-  // operators re-tune per-agent by setting HINDSIGHT_RECALL_TAG_WEIGHTS (a JSON
-  // object) via the agent's `env:` map in switchroom.yaml — the env value wins
-  // over this scaffold default (config.py ENV_OVERRIDES).
-  settings.recallTagWeights = { sidechain: 0.8 };
+  // (a DOWN-RANK, not the hard demote-tag DROP filter).
+  //
+  // #3841: the first-class knob is now `memory.recall.tag_weights`, which
+  // MERGES over this seed (an explicit `sidechain: 1.0` neutralises it) and is
+  // exported as HINDSIGHT_RECALL_TAG_WEIGHTS from start.sh unconditionally.
+  // The seed literal lives in hindsight-recall-passthrough.ts so this stamp and
+  // that export cannot drift. NOTE the migration: because the export is now
+  // unconditional, a raw `HINDSIGHT_RECALL_TAG_WEIGHTS` in an agent's `env:`
+  // map (the pre-#3841 escape hatch, set on the container BEFORE start.sh runs)
+  // no longer wins — use the yaml knob.
+  settings.recallTagWeights = { ...HINDSIGHT_RECALL_TAG_WEIGHT_SEED };
   // Static shared-bank recall (RFC reference/rfcs/per-speaker-memory-routing.md,
   // ship-B): recall these extra banks on every turn, merged into the agent's
   // own bank results. Sourced from memory.recall.additional_banks (cascaded);
@@ -3509,29 +3520,24 @@ function renderHindsightSettingsOverrides(
   if (additionalBanks.length > 0) {
     settings.recallAdditionalBanks = [...additionalBanks];
   }
-  // #2816 tag-filter port — INTENTIONALLY DORMANT (do not wire without an RFC).
+  // #2816 tag-filter port — still DORMANT BY DEFAULT, now operator-reachable.
   // The vendored recall.py reads `recallTags` / `recallTagsMatch` /
-  // `recallTagGroups` / `recallAdditionalBankFilters` (upstream 962140eef, and
-  // the env overrides HINDSIGHT_RECALL_TAGS / _TAGS_MATCH / _TAG_GROUPS exist in
-  // vendor/hindsight-memory/scripts/lib/config.py). But switchroom deliberately
-  // does NOT set any of them here, and there is no memory.recall.tags config
-  // surface in src/config/schema.ts — so the filters collapse to their no-op
-  // pass-through default (empty filter = match everything).
+  // `recallTagGroups` / `recallAdditionalBankFilters` (upstream 962140eef).
+  // Nothing is stamped here, deliberately: the settings.json side stays at the
+  // vendor no-op (empty filter = match everything), so an agent with no
+  // `memory.recall.tags*` config filters nothing, exactly as before.
   //
-  // This is a decision, not an oversight. reference/rfcs/hindsight-synthesis-
-  // layers.md frames the port as "a ready-made hook for future recall shaping
-  // (e.g. scoping additional-bank recall to specific tags), currently dormant" —
-  // explicitly future work, NOT part of the Phase 2 bank-specialization goals
-  // (which are mission/disposition-driven, already wired via updateBankMissions
-  // + resolveBankMissionExtras). Wiring a first-class tag surface now would mean
-  // inventing a per-bank tag taxonomy the RFC does not specify. The env-var
-  // escape hatch above remains available to advanced operators in the meantime.
-  //
-  // TODO(#2816): if/when an RFC calls for tag-scoped recall, add a
-  // `memory.recall.tags` (+ match/groups) cascade knob mirroring the
-  // `recallTypes` wiring above and export it through profiles/_base/start.sh.hbs
-  // (HINDSIGHT_RECALL_TAGS), letting the env value win over this scaffold
-  // default — then set settings.recallTags here from the resolved config.
+  // What #3841 changed is only the LEVER, not the default. The four keys now
+  // have a `memory.recall.{tags,tags_match,tag_groups,additional_bank_filters}`
+  // cascade surface, exported unconditionally from start.sh at their existing
+  // effective values ([] / "any" / {} / {}) — the passthrough shape #3774
+  // requires. That is the wiring the old TODO here described, minus the part it
+  // warned against: switchroom still does NOT invent a per-bank tag taxonomy.
+  // reference/rfcs/hindsight-synthesis-layers.md frames the port as "a
+  // ready-made hook for future recall shaping (e.g. scoping additional-bank
+  // recall to specific tags), currently dormant"; an operator who has such a
+  // taxonomy in their own bank can now express it in switchroom.yaml instead of
+  // hand-editing the installed plugin, and one who does not is unaffected.
   return JSON.stringify(settings, null, 2) + "\n";
 }
 
@@ -3677,6 +3683,11 @@ interface BuildWorkspaceContextArgs {
   // resolved and always exported (0 = off, the shipped default).
   hindsightRecallMinScore: number;
   hindsightRecallMinScoreScope: string;
+  // #3841 — the remaining recall knobs, resolved to their effective values and
+  // exported unconditionally for the same #3774 reason. Carried as one object
+  // rather than 15 flat fields; buildWorkspaceContext shell-quotes the
+  // JSON/string members into `hindsightRecallPass` for the template.
+  hindsightRecallPassthrough: HindsightRecallPassthrough;
   // Phase 1 / 6a opt-out cascade. Comma-joined types + stringified bool,
   // each undefined unless the operator overrode the switchroom default.
   hindsightRecallTypes?: string;
@@ -3729,6 +3740,7 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     hindsightRecallAdditionalBankMinSlots,
     hindsightRecallMinScore,
     hindsightRecallMinScoreScope,
+    hindsightRecallPassthrough,
     hindsightRecallTypes,
     hindsightRecallSkipTrivial,
     hindsightDirectiveCaptureNudge,
@@ -3820,6 +3832,31 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     hindsightRecallAdditionalBankMinSlots,
     hindsightRecallMinScore,
     hindsightRecallMinScoreScope,
+    // #3841 — one nested object, so start.sh.hbs reads
+    // `{{hindsightRecallPass.budget}}` etc. Structural values arrive
+    // pre-serialised from the resolver and are shell-single-quoted here (the
+    // preamble is free-form operator text and the JSON carries double quotes;
+    // neither is safe bare). Never empty: an empty export is skipped by
+    // `_cast_env` and hands authority back to ~/.hindsight/claude-code.json.
+    hindsightRecallPass: {
+      budget: hindsightRecallPassthrough.budget,
+      maxTokens: hindsightRecallPassthrough.maxTokens,
+      preferObservations: hindsightRecallPassthrough.preferObservations,
+      contextTurns: hindsightRecallPassthrough.contextTurns,
+      rolesQ: shellSingleQuote(hindsightRecallPassthrough.rolesJson),
+      promptPreambleQ: shellSingleQuote(hindsightRecallPassthrough.promptPreamble),
+      tagsQ: shellSingleQuote(hindsightRecallPassthrough.tagsJson),
+      tagsMatch: hindsightRecallPassthrough.tagsMatch,
+      tagGroupsQ: shellSingleQuote(hindsightRecallPassthrough.tagGroupsJson),
+      tagWeightsQ: shellSingleQuote(hindsightRecallPassthrough.tagWeightsJson),
+      additionalBankFiltersQ: shellSingleQuote(
+        hindsightRecallPassthrough.additionalBankFiltersJson,
+      ),
+      transcriptFallback: hindsightRecallPassthrough.transcriptFallback,
+      transcriptTailBytes: hindsightRecallPassthrough.transcriptTailBytes,
+      maxQueryChars: hindsightRecallPassthrough.maxQueryChars,
+      parallel: hindsightRecallPassthrough.parallel,
+    },
     hindsightRecallTypes,
     hindsightRecallSkipTrivial,
     hindsightDirectiveCaptureNudge,
@@ -4778,6 +4815,14 @@ export function scaffoldAgent(
   const hindsightRecallMinScoreScope =
     agentConfig.memory?.recall?.min_score_scope ??
     HINDSIGHT_RECALL_MIN_SCORE_SCOPE_DEFAULT;
+  // #3841 — everything else recall.py reads. Resolved from the same CASCADED
+  // agent config, always to a concrete value, and exported unconditionally.
+  // THROWS on an out-of-enum / wrong-typed value: a bad knob must red the
+  // apply, not sail through to a fail-open `_cast_env` that silently restores
+  // the plugin default while switchroom.yaml reads as though it were tuned.
+  const hindsightRecallPassthrough = resolveHindsightRecallPassthrough(
+    agentConfig.memory?.recall as RecallPassthroughInput | undefined,
+  );
   // Phase 1 / 6a opt-out: undefined unless the operator overrode the
   // switchroom default (observations on, trivial-skip on). Exported only
   // when set (see start.sh.hbs), so an unset value leaves the on-by-default
@@ -4860,6 +4905,7 @@ export function scaffoldAgent(
     hindsightRecallAdditionalBankMinSlots,
     hindsightRecallMinScore,
     hindsightRecallMinScoreScope,
+    hindsightRecallPassthrough,
     hindsightRecallTypes,
     hindsightRecallSkipTrivial,
     hindsightDirectiveCaptureNudge,
@@ -7261,6 +7307,14 @@ function reconcileAgentInner(
   const hindsightRecallMinScoreScope =
     agentConfig.memory?.recall?.min_score_scope ??
     HINDSIGHT_RECALL_MIN_SCORE_SCOPE_DEFAULT;
+  // #3841 — everything else recall.py reads. Resolved from the same CASCADED
+  // agent config, always to a concrete value, and exported unconditionally.
+  // THROWS on an out-of-enum / wrong-typed value: a bad knob must red the
+  // apply, not sail through to a fail-open `_cast_env` that silently restores
+  // the plugin default while switchroom.yaml reads as though it were tuned.
+  const hindsightRecallPassthrough = resolveHindsightRecallPassthrough(
+    agentConfig.memory?.recall as RecallPassthroughInput | undefined,
+  );
   // Phase 1 / 6a opt-out: undefined unless the operator overrode the
   // switchroom default (observations on, trivial-skip on). Exported only
   // when set (see start.sh.hbs), so an unset value leaves the on-by-default
@@ -7367,6 +7421,7 @@ function reconcileAgentInner(
       hindsightRecallAdditionalBankMinSlots,
       hindsightRecallMinScore,
       hindsightRecallMinScoreScope,
+      hindsightRecallPassthrough,
       hindsightRecallTypes,
       hindsightRecallSkipTrivial,
       hindsightDirectiveCaptureNudge,
@@ -8157,6 +8212,7 @@ function reconcileAgentInner(
       hindsightRecallAdditionalBankMinSlots,
       hindsightRecallMinScore,
       hindsightRecallMinScoreScope,
+      hindsightRecallPassthrough,
       hindsightRecallTypes,
       hindsightRecallSkipTrivial,
       hindsightDirectiveCaptureNudge,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -739,6 +739,199 @@ export const AgentMemorySchema = z
             "never skips a turn that references user/project/session state. " +
             "Set false to always run recall.",
           ),
+        // ── Passthrough knobs (#3841) ────────────────────────────────────
+        // Every one of these was previously reachable only by hand-editing
+        // the installed plugin (reverted by the next `switchroom apply`) or by
+        // smuggling a raw HINDSIGHT_RECALL_* into the agent's `env:` map. Each
+        // defaults to the value the fleet already runs, and start.sh exports
+        // all of them unconditionally (#3774) — see
+        // src/setup/hindsight-recall-passthrough.ts.
+        budget: z
+          .enum(["low", "mid", "high"])
+          .optional()
+          .describe(
+            "How hard Hindsight searches. \"low\" (switchroom default) = " +
+            "vector retrieval only, ~1-2s. \"mid\" adds the LLM rerank pass " +
+            "and measured ~5s of hook latency on real fleet turns — the " +
+            "second-largest contributor to perceived dead air after model " +
+            "TTFT. \"high\" is thorough and slower still. Raise it for an " +
+            "agent whose recall quality matters more than its reply latency " +
+            "(a research or audit role); leave it at low for chat.",
+          ),
+        max_tokens: z
+          .number()
+          .int()
+          .min(1)
+          .optional()
+          .describe(
+            "Token budget for the injected memory block. Default 1024. This " +
+            "is the TOKEN bound; `max_memories` is the separate COUNT bound " +
+            "and the tighter of the two wins. Raise it only alongside " +
+            "`max_memories` — on its own it buys nothing once the count cap " +
+            "binds.",
+          ),
+        prefer_observations: z
+          .boolean()
+          .optional()
+          .describe(
+            "Bias recall toward the synthesized `observation` tier, " +
+            "backfilling the slots freed by superseded raw facts for denser " +
+            "coverage inside the same budget. Default true. Set false to " +
+            "rank raw `world`/`experience` facts on equal footing — useful " +
+            "when auditing what the consolidation engine actually stored, or " +
+            "if a bank's observations are stale.",
+          ),
+        context_turns: z
+          .number()
+          .int()
+          .min(1)
+          .optional()
+          .describe(
+            "How many recent human turns are composed into the recall query. " +
+            "Default 2, so a bare follow-up (\"and the port?\") embeds with " +
+            "its antecedent instead of recalling on the pronoun alone. 1 = " +
+            "the latest turn only. Raising it costs BM25 terms, which is the " +
+            "real recall cost driver — `query_max_tokens` still bounds the " +
+            "result, so a large value mostly shifts which terms survive.",
+          ),
+        roles: z
+          .array(z.string().min(1))
+          .min(1)
+          .optional()
+          .describe(
+            "Transcript roles the multi-turn composition may draw from. " +
+            "Default [\"user\", \"assistant\"]. Set [\"user\"] to compose " +
+            "the query from the human's words only — worth trying when an " +
+            "agent's own verbose replies are dominating the query terms. No " +
+            "effect while `context_turns` is 1.",
+          ),
+        prompt_preamble: z
+          .string()
+          .min(1)
+          .optional()
+          .describe(
+            "The banner rendered above injected memories. The agent reads " +
+            "this line as the instruction for how to treat the block, so it " +
+            "is a behaviour knob, not cosmetics. Default tells the model to " +
+            "prioritise recent memories on conflict and ignore irrelevant " +
+            "ones. Override to tighten that framing for a specialised agent.",
+          ),
+        tags: z
+          .array(z.string().min(1))
+          .optional()
+          .describe(
+            "Restrict recall to memories carrying these tags. Default [] = " +
+            "no filter (match everything). This is a HARD filter applied " +
+            "server-side — a memory without the tags cannot surface at any " +
+            "score — so it is for a genuinely scoped agent, not for " +
+            "ranking. Use `tag_weights` when you want a preference rather " +
+            "than an exclusion.",
+          ),
+        tags_match: z
+          .enum(["any", "all", "any_strict", "all_strict"])
+          .optional()
+          .describe(
+            "How `tags` combine. \"any\" (default) = at least one; " +
+            "\"all\" = every tag. The `_strict` forms additionally require " +
+            "the memory to actually carry the tags rather than merely rank " +
+            "for them. No effect while `tags` and `tag_groups` are empty.",
+          ),
+        tag_groups: z
+          .union([
+            z.array(z.array(z.string().min(1))),
+            z.record(z.string(), z.array(z.string().min(1))),
+          ])
+          .optional()
+          .describe(
+            "Tag filtering with grouping — either an OR-of-ANDs list " +
+            "([[\"a\",\"b\"],[\"c\"]] = (a AND b) OR c) or a named " +
+            "{group: [tags]} map. Default unset (no grouping). Use when a " +
+            "flat `tags` + `tags_match` cannot express the scope you need.",
+          ),
+        tag_weights: z
+          .record(z.string(), z.number().min(0))
+          .optional()
+          .describe(
+            "Per-tag multipliers applied to `scores.final` just before the " +
+            "final sort — a DEMOTION/PROMOTION, never a drop, so a " +
+            "down-weighted memory still surfaces when it is the only " +
+            "relevant hit. MERGED over switchroom's seed " +
+            "({\"sidechain\": 0.8}, which ranks delegated sub-agent " +
+            "process-memories just under first-party ones), so setting one " +
+            "unrelated weight does not silently undo it; pass " +
+            "`sidechain: 1.0` to neutralise the seed. Reach for this when " +
+            "recall_log shows one class of memory crowding the block.",
+          ),
+        additional_bank_filters: z
+          .record(
+            z.string(),
+            z
+              .object({
+                tags: z.array(z.string().min(1)).optional(),
+                tags_match: z.enum(["any", "all", "any_strict", "all_strict"]).optional(),
+                tag_groups: z
+                  .union([
+                    z.array(z.array(z.string().min(1))),
+                    z.record(z.string(), z.array(z.string().min(1))),
+                  ])
+                  .optional(),
+              })
+              .strict(),
+          )
+          .optional()
+          .describe(
+            "Per-bank overrides of the tag filters above, keyed by bank id " +
+            "(applies to `additional_banks` AND to sender banks). Default " +
+            "{} = every extra bank inherits the global filters. Use it to " +
+            "scope a shared bank — e.g. recall only `profile`-tagged " +
+            "memories from the operator's profile bank while leaving the " +
+            "agent's own bank unfiltered.",
+          ),
+        transcript_fallback: z
+          .boolean()
+          .optional()
+          .describe(
+            "When every bank returns zero results AND no bank hit its " +
+            "deadline, grep the current session's transcript tail for turns " +
+            "matching the query and inject them as a clearly-labelled " +
+            "lower-confidence block. Default true — it covers the window " +
+            "between an abrupt kill and the next boot reconciliation, where " +
+            "the fact layer was never told about the lost turns. Set false " +
+            "if you never want un-consolidated transcript text in context.",
+          ),
+        transcript_tail_bytes: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            "Bytes of the session transcript read from the tail for the " +
+            "multi-turn query composition. Default 262144 (256 KiB), which " +
+            "keeps the per-turn read O(1) on a session log that can grow to " +
+            "many MB. 0 = read the whole file (the pre-bound behaviour, and " +
+            "the rollback lever if a composition ever needs older turns).",
+          ),
+        max_query_chars: z
+          .number()
+          .int()
+          .min(1)
+          .optional()
+          .describe(
+            "Character bound on the composed recall query, applied before " +
+            "`query_max_tokens` shapes it. Default 800. Truncation preserves " +
+            "the latest turn and drops the oldest context first. Lower it " +
+            "for an agent whose turns are long pasted payloads.",
+          ),
+        parallel: z
+          .boolean()
+          .optional()
+          .describe(
+            "Run the directives fetch and every bank recall concurrently " +
+            "under one shared deadline, so total latency is the SLOWEST slot " +
+            "rather than their SUM. Default true. false restores the serial " +
+            "path — the rollback lever if the parallel path ever misbehaves; " +
+            "expect multi-bank recall latency to add up.",
+          ),
         topic_filter_mode: z
           .enum(["soft-preamble", "hard-filter"])
           .optional()
@@ -2978,6 +3171,45 @@ const profileFields = {
           additional_bank_min_slots: z.number().int().min(0).optional(),
           min_score: z.number().min(0).optional(),
           min_score_scope: z.enum(["degraded", "all"]).optional(),
+          // #3841 passthrough knobs. Mirrored here so a fleet-wide
+          // `defaults.memory.recall.budget` (etc.) cascades like its siblings;
+          // the descriptions live on AgentMemorySchema.recall above.
+          budget: z.enum(["low", "mid", "high"]).optional(),
+          max_tokens: z.number().int().min(1).optional(),
+          prefer_observations: z.boolean().optional(),
+          context_turns: z.number().int().min(1).optional(),
+          roles: z.array(z.string().min(1)).min(1).optional(),
+          prompt_preamble: z.string().min(1).optional(),
+          tags: z.array(z.string().min(1)).optional(),
+          tags_match: z.enum(["any", "all", "any_strict", "all_strict"]).optional(),
+          tag_groups: z
+            .union([
+              z.array(z.array(z.string().min(1))),
+              z.record(z.string(), z.array(z.string().min(1))),
+            ])
+            .optional(),
+          tag_weights: z.record(z.string(), z.number().min(0)).optional(),
+          additional_bank_filters: z
+            .record(
+              z.string(),
+              z
+                .object({
+                  tags: z.array(z.string().min(1)).optional(),
+                  tags_match: z.enum(["any", "all", "any_strict", "all_strict"]).optional(),
+                  tag_groups: z
+                    .union([
+                      z.array(z.array(z.string().min(1))),
+                      z.record(z.string(), z.array(z.string().min(1))),
+                    ])
+                    .optional(),
+                })
+                .strict(),
+            )
+            .optional(),
+          transcript_fallback: z.boolean().optional(),
+          transcript_tail_bytes: z.number().int().min(0).optional(),
+          max_query_chars: z.number().int().min(1).optional(),
+          parallel: z.boolean().optional(),
           additional_banks: z.array(z.string()).optional(),
           sender_banks: z.record(z.string(), z.string()).optional(),
         })

--- a/src/setup/hindsight-recall-passthrough.ts
+++ b/src/setup/hindsight-recall-passthrough.ts
@@ -1,0 +1,421 @@
+/**
+ * Declarative passthrough for the remaining Hindsight auto-recall knobs.
+ *
+ * ## Why this module exists
+ *
+ * `vendor/hindsight-memory/scripts/recall.py` reads ~25 `recall*` settings out
+ * of the plugin config. Before this module, only eight of them had a
+ * `switchroom.yaml` surface (`max_memories`, `query_max_tokens`,
+ * `query_stop_terms`, `request_timeout_seconds`, `parallel_deadline_seconds`,
+ * `own_bank_min_slots`, `additional_bank_min_slots`, and — since #3838 —
+ * `min_score` / `min_score_scope`, plus the two opt-out knobs `types` and
+ * `skip_trivial`). Every other one was reachable ONLY by hand-editing plugin
+ * internals or by smuggling a raw `HINDSIGHT_RECALL_*` into the agent's
+ * `env:` map — and the first of those does not survive `switchroom apply`,
+ * which rm's and re-copies the whole plugin tree from `vendor/`.
+ *
+ * This module resolves the rest of them from the CASCADED agent config
+ * (defaults → profile → agent) into concrete, always-present values that
+ * `profiles/_base/start.sh.hbs` exports UNCONDITIONALLY.
+ *
+ * ## Unconditional export, and why (the #3774 defect class)
+ *
+ * The plugin resolves config in this order
+ * (`vendor/hindsight-memory/scripts/lib/config.py:457-490`):
+ *
+ *   built-in DEFAULTS → plugin settings.json → ~/.hindsight/claude-code.json → env
+ *
+ * `~/.hindsight/claude-code.json` sits ABOVE anything switchroom stamps into
+ * settings.json and SURVIVES an apply. So a knob that is exported only when the
+ * operator sets it leaves a stale hand-edited value in that file authoritative
+ * for every agent that did NOT set it — silently, and permanently. Exporting
+ * the resolved effective value on every boot is the only shape that makes
+ * `switchroom.yaml` the authority.
+ *
+ * The corollary is that every default here MUST equal the value the fleet is
+ * running today, or turning the passthrough on would itself change behaviour.
+ * They are pinned whole-value against the vendored plugin by
+ * `tests/scaffold.recall-passthrough.test.ts`, which reads
+ * `vendor/hindsight-memory/settings.json` and `scripts/lib/config.py` directly
+ * so the two cannot drift.
+ *
+ * An EMPTY export is not a no-op either: `_cast_env("", int)` returns `None`
+ * and `config.py` then skips the assignment, so an empty export is
+ * indistinguishable from no export at all. Everything below therefore resolves
+ * to a concrete, non-empty rendering — `[]` / `{}` for the collection-shaped
+ * knobs, `true` / `false` for the booleans.
+ *
+ * ## Validation
+ *
+ * `switchroom.yaml` is parsed by zod (`src/config/schema.ts`), which is the
+ * first gate. This module re-checks the same constraints so that a config that
+ * reaches the scaffolder by any other route (a profile merge, a programmatic
+ * caller, a hand-built `AgentConfig` in a test) still fails LOUDLY at scaffold
+ * time. The alternative is worse than a crash: `_cast_env` is fail-open, so a
+ * malformed JSON value silently reverts to the plugin default at recall time
+ * and the operator's `switchroom.yaml` reads as though it were in force.
+ */
+
+/**
+ * Recall-side score weight seed for `sidechain`-tagged (delegated sub-agent)
+ * memories. Lives here rather than in `scaffold.ts` because BOTH channels need
+ * exactly the same value: `applyHindsightSettingsOverrides` stamps it into the
+ * plugin's settings.json, and the env export below carries it (merged with any
+ * operator override) as the authoritative copy. Two literals would drift.
+ */
+export const HINDSIGHT_RECALL_TAG_WEIGHT_SEED: Readonly<Record<string, number>> =
+  Object.freeze({ sidechain: 0.8 });
+
+/**
+ * The banner the recall hook puts above injected memories. Must match
+ * `recallPromptPreamble` in `vendor/hindsight-memory/settings.json` exactly —
+ * pinned by test.
+ */
+export const HINDSIGHT_RECALL_PROMPT_PREAMBLE_DEFAULT =
+  "Relevant memories from past conversations (prioritize recent when " +
+  "conflicting). Only use memories that are directly useful to continue " +
+  "this conversation; ignore the rest:";
+
+/** Legal `recallBudget` values (vendor README table, `recallBudget` row). */
+export const RECALL_BUDGETS = ["low", "mid", "high"] as const;
+export type RecallBudget = (typeof RECALL_BUDGETS)[number];
+
+/**
+ * Legal `tags_match` values. `any` / `all` are the loose forms; the `_strict`
+ * forms require the memory to carry the tags rather than merely rank for them
+ * (see `src/memory/hindsight.ts:894-901` and
+ * `vendor/hindsight-memory/tests/test_client.py:251`).
+ */
+export const RECALL_TAGS_MATCH_MODES = ["any", "all", "any_strict", "all_strict"] as const;
+export type RecallTagsMatch = (typeof RECALL_TAGS_MATCH_MODES)[number];
+
+/**
+ * Tag groups: either an OR-of-AND list (`[["a","b"],["c"]]`) or a named map
+ * (`{group: ["a","b"]}`). `config.py`'s dict caster accepts both shapes
+ * explicitly ("tag_groups may be a list").
+ */
+export type RecallTagGroups = string[][] | Record<string, string[]>;
+
+/** Per-additional-bank filter override, in switchroom.yaml's snake_case. */
+export interface RecallBankFilter {
+  tags?: string[];
+  tags_match?: string;
+  tag_groups?: RecallTagGroups;
+}
+
+/**
+ * The `memory.recall.*` subset this module owns, as it appears in
+ * switchroom.yaml. Every field optional — the whole point is that an operator
+ * who sets none of them gets today's behaviour byte-for-byte.
+ */
+export interface RecallPassthroughInput {
+  budget?: string;
+  max_tokens?: number;
+  prefer_observations?: boolean;
+  context_turns?: number;
+  roles?: string[];
+  prompt_preamble?: string;
+  tags?: string[];
+  tags_match?: string;
+  tag_groups?: RecallTagGroups;
+  tag_weights?: Record<string, number>;
+  additional_bank_filters?: Record<string, RecallBankFilter>;
+  transcript_fallback?: boolean;
+  transcript_tail_bytes?: number;
+  max_query_chars?: number;
+  parallel?: boolean;
+}
+
+/**
+ * Resolved values, shaped for the handlebars context. Scalars stay scalars;
+ * everything structural is pre-serialised to JSON here (one serialiser, one
+ * shape) and shell-quoted by the caller.
+ */
+export interface HindsightRecallPassthrough {
+  budget: string;
+  maxTokens: number;
+  /** "true" | "false" — rendered bare, `_cast_env(..., bool)` reads it. */
+  preferObservations: string;
+  contextTurns: number;
+  /** JSON array. */
+  rolesJson: string;
+  /** Raw string; the caller shell-quotes it. */
+  promptPreamble: string;
+  /** JSON array. */
+  tagsJson: string;
+  tagsMatch: string;
+  /** JSON — `{}` when unset, which `recall.py` folds to `None` (`or None`). */
+  tagGroupsJson: string;
+  /** JSON object of {tag: multiplier}. */
+  tagWeightsJson: string;
+  /** JSON object keyed by bank id, values in the plugin's camelCase keys. */
+  additionalBankFiltersJson: string;
+  transcriptFallback: string;
+  transcriptTailBytes: number;
+  maxQueryChars: number;
+  parallel: string;
+}
+
+/**
+ * The effective values the fleet runs TODAY, i.e. what an agent with no
+ * `memory.recall.*` config resolves to through
+ * `DEFAULTS → settings.json → (no env)`. Pinned against the vendored plugin by
+ * test; do not "tidy" one of these without changing the vendor side too.
+ */
+export const RECALL_PASSTHROUGH_DEFAULTS = Object.freeze({
+  /** vendor/hindsight-memory/settings.json `recallBudget` */
+  budget: "low" as RecallBudget,
+  /** settings.json `recallMaxTokens` */
+  maxTokens: 1024,
+  /** config.py DEFAULTS `recallPreferObservations` (not in settings.json) */
+  preferObservations: true,
+  /** settings.json `recallContextTurns` */
+  contextTurns: 2,
+  /** settings.json `recallRoles` */
+  roles: ["user", "assistant"] as readonly string[],
+  /** settings.json `recallPromptPreamble` */
+  promptPreamble: HINDSIGHT_RECALL_PROMPT_PREAMBLE_DEFAULT,
+  /** settings.json `recallTags` */
+  tags: [] as readonly string[],
+  /** settings.json `recallTagsMatch` */
+  tagsMatch: "any" as RecallTagsMatch,
+  /**
+   * settings.json ships `null`; `_load_settings_file` drops null values, so the
+   * effective value is config.py's `None`. `{}` is the same thing to
+   * `recall.py` (`config.get("recallTagGroups") or None`) and, unlike `null`,
+   * it actually ASSIGNS through `_cast_env` — exporting `null` would cast to
+   * `None`, be skipped, and hand authority back to claude-code.json.
+   */
+  tagGroups: {} as RecallTagGroups,
+  /** scaffold's settings.json stamp (`applyHindsightSettingsOverrides`) */
+  tagWeights: HINDSIGHT_RECALL_TAG_WEIGHT_SEED,
+  /** settings.json `recallAdditionalBankFilters` */
+  additionalBankFilters: {} as Record<string, RecallBankFilter>,
+  /** config.py DEFAULTS `recallTranscriptFallback` (not in settings.json) */
+  transcriptFallback: true,
+  /** settings.json `recallTranscriptTailBytes` */
+  transcriptTailBytes: 262144,
+  /** settings.json `recallMaxQueryChars` */
+  maxQueryChars: 800,
+  /** config.py DEFAULTS `recallParallel` (not in settings.json) */
+  parallel: true,
+});
+
+/** Marker every validation failure carries, so operators can grep for it. */
+export const RECALL_PASSTHROUGH_ERROR_MARKER = "HINDSIGHT-RECALL-CONFIG";
+
+function fail(key: string, detail: string): never {
+  throw new Error(
+    `${RECALL_PASSTHROUGH_ERROR_MARKER}: memory.recall.${key} is invalid — ${detail}. ` +
+    "Fix switchroom.yaml; the value cannot be passed through to the recall hook, " +
+    "and shipping it would silently fall back to the plugin default at recall time.",
+  );
+}
+
+function requireInt(key: string, value: number, min: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    fail(key, `expected a number, got ${JSON.stringify(value)}`);
+  }
+  if (!Number.isInteger(value)) {
+    fail(key, `expected an integer, got ${value}`);
+  }
+  if (value < min) {
+    fail(key, `expected an integer >= ${min}, got ${value}`);
+  }
+  return value;
+}
+
+function requireBool(key: string, value: boolean): boolean {
+  if (typeof value !== "boolean") {
+    fail(key, `expected true or false, got ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function requireStringArray(key: string, value: string[], minLength = 0): string[] {
+  if (!Array.isArray(value) || value.some((v) => typeof v !== "string" || v.length === 0)) {
+    fail(key, `expected an array of non-empty strings, got ${JSON.stringify(value)}`);
+  }
+  if (value.length < minLength) {
+    fail(key, `expected at least ${minLength} entr${minLength === 1 ? "y" : "ies"}, got none`);
+  }
+  return [...value];
+}
+
+function requireEnum<T extends string>(key: string, value: string, legal: readonly T[]): T {
+  if (typeof value !== "string" || !legal.includes(value as T)) {
+    fail(key, `expected one of ${legal.map((v) => `"${v}"`).join(", ")}, got ${JSON.stringify(value)}`);
+  }
+  return value as T;
+}
+
+function requireTagGroups(key: string, value: RecallTagGroups): RecallTagGroups {
+  if (Array.isArray(value)) {
+    for (const group of value) {
+      if (!Array.isArray(group) || group.some((t) => typeof t !== "string" || t.length === 0)) {
+        fail(key, `expected an array of tag arrays, got ${JSON.stringify(value)}`);
+      }
+    }
+    return value.map((g) => [...g]);
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, string[]> = {};
+    for (const [name, group] of Object.entries(value)) {
+      if (!Array.isArray(group) || group.some((t) => typeof t !== "string" || t.length === 0)) {
+        fail(key, `group "${name}" must be an array of non-empty strings`);
+      }
+      out[name] = [...group];
+    }
+    return out;
+  }
+  return fail(key, `expected a list of tag groups or a {name: [tags]} map, got ${JSON.stringify(value)}`);
+}
+
+function requireTagWeights(key: string, value: Record<string, number>): Record<string, number> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail(key, `expected a {tag: multiplier} map, got ${JSON.stringify(value)}`);
+  }
+  for (const [tag, weight] of Object.entries(value)) {
+    if (typeof weight !== "number" || !Number.isFinite(weight) || weight < 0) {
+      fail(key, `weight for "${tag}" must be a finite number >= 0, got ${JSON.stringify(weight)}`);
+    }
+  }
+  return { ...value };
+}
+
+/**
+ * Translate the yaml-facing per-bank filter (snake_case) into the plugin keys
+ * `recall.py` actually reads off the map
+ * (`vendor/hindsight-memory/scripts/recall.py:2018-2023`).
+ */
+function resolveBankFilters(
+  raw: Record<string, RecallBankFilter>,
+): Record<string, Record<string, unknown>> {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    fail("additional_bank_filters", `expected a {bank_id: filter} map, got ${JSON.stringify(raw)}`);
+  }
+  const out: Record<string, Record<string, unknown>> = {};
+  for (const [bankId, filter] of Object.entries(raw)) {
+    if (!filter || typeof filter !== "object" || Array.isArray(filter)) {
+      fail("additional_bank_filters", `filter for bank "${bankId}" must be a map`);
+    }
+    const entry: Record<string, unknown> = {};
+    if (filter.tags !== undefined) {
+      entry.recallTags = requireStringArray(`additional_bank_filters.${bankId}.tags`, filter.tags);
+    }
+    if (filter.tags_match !== undefined) {
+      entry.recallTagsMatch = requireEnum(
+        `additional_bank_filters.${bankId}.tags_match`,
+        filter.tags_match,
+        RECALL_TAGS_MATCH_MODES,
+      );
+    }
+    if (filter.tag_groups !== undefined) {
+      entry.recallTagGroups = requireTagGroups(
+        `additional_bank_filters.${bankId}.tag_groups`,
+        filter.tag_groups,
+      );
+    }
+    out[bankId] = entry;
+  }
+  return out;
+}
+
+/**
+ * Resolve the passthrough knobs for one agent. Every field always resolves to a
+ * concrete value — `undefined` is never a legal output, because the template
+ * exports all of them unconditionally.
+ *
+ * @throws Error carrying {@link RECALL_PASSTHROUGH_ERROR_MARKER} when a value is
+ * out of range, the wrong type, or outside a known enum.
+ */
+export function resolveHindsightRecallPassthrough(
+  input: RecallPassthroughInput | undefined,
+): HindsightRecallPassthrough {
+  const cfg = input ?? {};
+  const d = RECALL_PASSTHROUGH_DEFAULTS;
+
+  const budget = cfg.budget === undefined
+    ? d.budget
+    : requireEnum("budget", cfg.budget, RECALL_BUDGETS);
+  const maxTokens = cfg.max_tokens === undefined
+    ? d.maxTokens
+    : requireInt("max_tokens", cfg.max_tokens, 1);
+  const preferObservations = cfg.prefer_observations === undefined
+    ? d.preferObservations
+    : requireBool("prefer_observations", cfg.prefer_observations);
+  const contextTurns = cfg.context_turns === undefined
+    ? d.contextTurns
+    : requireInt("context_turns", cfg.context_turns, 1);
+  // At least one role, because `recallRoles: []` casts and ASSIGNS cleanly (it
+  // is a list, so `_cast_env` keeps it) and then no transcript turn qualifies
+  // to build the query from — recall degrades to nothing with no error.
+  const roles = cfg.roles === undefined
+    ? [...d.roles]
+    : requireStringArray("roles", cfg.roles, 1);
+  const promptPreamble = cfg.prompt_preamble === undefined
+    ? d.promptPreamble
+    : (() => {
+      if (typeof cfg.prompt_preamble !== "string") {
+        fail("prompt_preamble", `expected a string, got ${JSON.stringify(cfg.prompt_preamble)}`);
+      }
+      // Non-empty required. `""` is the one string `_cast_env` still assigns,
+      // which would strip the banner and leave recalled memories in the prompt
+      // with no framing telling the agent what they are — read as instructions
+      // rather than as recalled context. Almost always a yaml slip, never worth
+      // shipping silently.
+      if (cfg.prompt_preamble.trim().length === 0) {
+        fail("prompt_preamble", "expected a non-empty string; omit the key to keep the default banner");
+      }
+      return cfg.prompt_preamble;
+    })();
+  const tags = cfg.tags === undefined ? [...d.tags] : requireStringArray("tags", cfg.tags);
+  const tagsMatch = cfg.tags_match === undefined
+    ? d.tagsMatch
+    : requireEnum("tags_match", cfg.tags_match, RECALL_TAGS_MATCH_MODES);
+  const tagGroups = cfg.tag_groups === undefined
+    ? d.tagGroups
+    : requireTagGroups("tag_groups", cfg.tag_groups);
+  // MERGED, not replaced: the `sidechain` seed is a switchroom-side ranking
+  // decision (delegated sub-agent process-memories rank just under first-party
+  // ones), not an operator default. A wholesale replace would silently undo it
+  // for anyone who set a single unrelated weight. Per-tag override still works
+  // — an explicit `sidechain: 1.0` neutralises the seed.
+  const tagWeights = {
+    ...d.tagWeights,
+    ...(cfg.tag_weights === undefined ? {} : requireTagWeights("tag_weights", cfg.tag_weights)),
+  };
+  const additionalBankFilters = cfg.additional_bank_filters === undefined
+    ? {}
+    : resolveBankFilters(cfg.additional_bank_filters);
+  const transcriptFallback = cfg.transcript_fallback === undefined
+    ? d.transcriptFallback
+    : requireBool("transcript_fallback", cfg.transcript_fallback);
+  const transcriptTailBytes = cfg.transcript_tail_bytes === undefined
+    ? d.transcriptTailBytes
+    : requireInt("transcript_tail_bytes", cfg.transcript_tail_bytes, 0);
+  const maxQueryChars = cfg.max_query_chars === undefined
+    ? d.maxQueryChars
+    : requireInt("max_query_chars", cfg.max_query_chars, 1);
+  const parallel = cfg.parallel === undefined
+    ? d.parallel
+    : requireBool("parallel", cfg.parallel);
+
+  return {
+    budget,
+    maxTokens,
+    preferObservations: String(preferObservations),
+    contextTurns,
+    rolesJson: JSON.stringify(roles),
+    promptPreamble,
+    tagsJson: JSON.stringify(tags),
+    tagsMatch,
+    tagGroupsJson: JSON.stringify(tagGroups),
+    tagWeightsJson: JSON.stringify(tagWeights),
+    additionalBankFiltersJson: JSON.stringify(additionalBankFilters),
+    transcriptFallback: String(transcriptFallback),
+    transcriptTailBytes,
+    maxQueryChars,
+    parallel: String(parallel),
+  };
+}

--- a/src/setup/hindsight-recall-passthrough.ts
+++ b/src/setup/hindsight-recall-passthrough.ts
@@ -204,6 +204,68 @@ export const RECALL_PASSTHROUGH_DEFAULTS = Object.freeze({
 /** Marker every validation failure carries, so operators can grep for it. */
 export const RECALL_PASSTHROUGH_ERROR_MARKER = "HINDSIGHT-RECALL-CONFIG";
 
+/**
+ * The `hindsightRecallPass.*` object `profiles/_base/start.sh.hbs` reads. Every
+ * structural value is already shell-quoted, so the template renders it with a
+ * triple-stash.
+ */
+export interface RecallPassthroughTemplateFields {
+  budget: string;
+  maxTokens: number;
+  preferObservations: string;
+  contextTurns: number;
+  rolesQ: string;
+  promptPreambleQ: string;
+  tagsQ: string;
+  tagsMatch: string;
+  tagGroupsQ: string;
+  tagWeightsQ: string;
+  additionalBankFiltersQ: string;
+  transcriptFallback: string;
+  transcriptTailBytes: number;
+  maxQueryChars: number;
+  parallel: string;
+}
+
+/**
+ * Build the template object, in ONE place.
+ *
+ * `scaffoldAgent` renders through `buildWorkspaceContext`; `reconcileAgentInner`
+ * hand-builds its own template context. Two hand-written copies of this mapping
+ * is precisely the init-vs-reconcile drift `tests/scaffold.memory-prompt.test.ts`
+ * exists to catch — and the failure is silent in the worst way, because
+ * handlebars renders an unknown path as the EMPTY STRING rather than throwing.
+ * An empty `export HINDSIGHT_RECALL_X=` then casts to `None`, `load_config()`
+ * skips the assignment, and a stale `~/.hindsight/claude-code.json` takes the
+ * knob back — the exact defect class (#3774) the unconditional export exists to
+ * close. So both callers go through this function.
+ *
+ * @param quote the shell single-quoter (passed in so this module stays free of
+ * scaffold.ts imports).
+ */
+export function recallPassthroughTemplateFields(
+  resolved: HindsightRecallPassthrough,
+  quote: (value: string) => string,
+): RecallPassthroughTemplateFields {
+  return {
+    budget: resolved.budget,
+    maxTokens: resolved.maxTokens,
+    preferObservations: resolved.preferObservations,
+    contextTurns: resolved.contextTurns,
+    rolesQ: quote(resolved.rolesJson),
+    promptPreambleQ: quote(resolved.promptPreamble),
+    tagsQ: quote(resolved.tagsJson),
+    tagsMatch: resolved.tagsMatch,
+    tagGroupsQ: quote(resolved.tagGroupsJson),
+    tagWeightsQ: quote(resolved.tagWeightsJson),
+    additionalBankFiltersQ: quote(resolved.additionalBankFiltersJson),
+    transcriptFallback: resolved.transcriptFallback,
+    transcriptTailBytes: resolved.transcriptTailBytes,
+    maxQueryChars: resolved.maxQueryChars,
+    parallel: resolved.parallel,
+  };
+}
+
 function fail(key: string, detail: string): never {
   throw new Error(
     `${RECALL_PASSTHROUGH_ERROR_MARKER}: memory.recall.${key} is invalid — ${detail}. ` +

--- a/tests/scaffold.recall-passthrough.test.ts
+++ b/tests/scaffold.recall-passthrough.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent } from "../src/agents/scaffold.js";
+import {
+  resolveHindsightRecallPassthrough,
+  RECALL_PASSTHROUGH_DEFAULTS,
+  RECALL_PASSTHROUGH_ERROR_MARKER,
+  HINDSIGHT_RECALL_TAG_WEIGHT_SEED,
+  HINDSIGHT_RECALL_PROMPT_PREAMBLE_DEFAULT,
+} from "../src/setup/hindsight-recall-passthrough.js";
+import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+/**
+ * #3841 — `memory.recall.*` passthrough for the recall knobs that previously
+ * had no switchroom.yaml surface.
+ *
+ * Two properties are load-bearing and both are asserted on OUTCOMES (the
+ * rendered `start.sh`, the scaffolded `settings.json`, a real `sh` evaluating
+ * the exported line), never on "the code ran":
+ *
+ *  1. **Zero behaviour change when unset.** Each default must equal the value
+ *     the fleet already resolved through DEFAULTS -> settings.json -> (no env).
+ *     Pinned whole-line, and cross-checked against the vendored plugin itself so
+ *     a vendor bump that moves a default reds here instead of silently
+ *     re-tuning every agent.
+ *  2. **The value that reaches the plugin is the value the operator wrote.**
+ *     A knob that renders empty, renders unquoted, or renders under a name
+ *     `config.py` does not read fails SILENTLY at runtime — `_cast_env` is
+ *     fail-open, so the plugin default stands while switchroom.yaml reads as
+ *     though it were in force.
+ */
+
+const VENDOR_SETTINGS = JSON.parse(
+  readFileSync(join(__dirname, "..", "vendor", "hindsight-memory", "settings.json"), "utf-8"),
+) as Record<string, unknown>;
+
+const VENDOR_CONFIG_PY = readFileSync(
+  join(__dirname, "..", "vendor", "hindsight-memory", "scripts", "lib", "config.py"),
+  "utf-8",
+);
+
+/** Pull a `"key": True/False,` literal out of config.py's DEFAULTS block. */
+function vendorDefaultBool(key: string): boolean {
+  const m = VENDOR_CONFIG_PY.match(new RegExp(`^\\s*"${key}":\\s*(True|False),`, "m"));
+  if (!m) throw new Error(`config.py has no DEFAULTS entry for ${key}`);
+  return m[1] === "True";
+}
+
+function exportedLine(startSh: string, name: string): string {
+  const m = startSh.match(new RegExp(`^export ${name}=(.*)$`, "m"));
+  if (!m) throw new Error(`start.sh does not export ${name}`);
+  return m[1];
+}
+
+/** Evaluate one exported line with a real shell and read the value back. */
+function shellValueOf(startSh: string, name: string): string {
+  const line = `export ${name}=${exportedLine(startSh, name)}`;
+  return execFileSync("sh", ["-c", `${line}; printf '%s' "$${name}"`], {
+    encoding: "utf-8",
+  });
+}
+
+describe("recall passthrough (#3841)", () => {
+  let tmpDir: string;
+  let telegram: TelegramConfig;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `recall-passthrough-${Date.now()}-${Math.floor(Math.random() * 1e6)}`);
+    mkdirSync(tmpDir, { recursive: true });
+    telegram = { bot_token: "t", forum_chat_id: "c" };
+  });
+  afterEach(() => {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function scaffold(agentConfig: AgentConfig): { startSh: string; agentDir: string } {
+    const config = {
+      agents: { probe: agentConfig },
+      memory: { backend: "hindsight", config: { url: "http://localhost:18888/mcp/" } },
+      telegram,
+    } as unknown as SwitchroomConfig;
+    const res = scaffoldAgent("probe", agentConfig, tmpDir, telegram, config);
+    return {
+      startSh: readFileSync(join(res.agentDir, "start.sh"), "utf-8"),
+      agentDir: res.agentDir,
+    };
+  }
+
+  function withRecall(recall: Record<string, unknown>): AgentConfig {
+    return { memory: { collection: "probe", recall } } as unknown as AgentConfig;
+  }
+
+  describe("defaults are the values the fleet already runs", () => {
+    it("matches the vendored plugin's settings.json for every key it ships", () => {
+      // A vendor bump that changes one of these must red HERE, loudly, rather
+      // than silently re-tuning every agent through switchroom's export (which
+      // outranks settings.json).
+      expect(RECALL_PASSTHROUGH_DEFAULTS.budget).toBe(VENDOR_SETTINGS.recallBudget);
+      expect(RECALL_PASSTHROUGH_DEFAULTS.maxTokens).toBe(VENDOR_SETTINGS.recallMaxTokens);
+      expect(RECALL_PASSTHROUGH_DEFAULTS.contextTurns).toBe(VENDOR_SETTINGS.recallContextTurns);
+      expect(RECALL_PASSTHROUGH_DEFAULTS.roles).toEqual(VENDOR_SETTINGS.recallRoles);
+      expect(RECALL_PASSTHROUGH_DEFAULTS.maxQueryChars).toBe(VENDOR_SETTINGS.recallMaxQueryChars);
+      expect(RECALL_PASSTHROUGH_DEFAULTS.transcriptTailBytes).toBe(
+        VENDOR_SETTINGS.recallTranscriptTailBytes,
+      );
+      expect(RECALL_PASSTHROUGH_DEFAULTS.tags).toEqual(VENDOR_SETTINGS.recallTags);
+      expect(RECALL_PASSTHROUGH_DEFAULTS.tagsMatch).toBe(VENDOR_SETTINGS.recallTagsMatch);
+      expect(RECALL_PASSTHROUGH_DEFAULTS.additionalBankFilters).toEqual(
+        VENDOR_SETTINGS.recallAdditionalBankFilters,
+      );
+      expect(HINDSIGHT_RECALL_PROMPT_PREAMBLE_DEFAULT).toBe(VENDOR_SETTINGS.recallPromptPreamble);
+      // settings.json ships `recallTagGroups: null`; `_load_settings_file`
+      // drops nulls, so the effective value is config.py's None. `{}` is the
+      // same thing to recall.py (`or None`) and, unlike `null`, assigns.
+      expect(VENDOR_SETTINGS.recallTagGroups).toBeNull();
+      expect(RECALL_PASSTHROUGH_DEFAULTS.tagGroups).toEqual({});
+    });
+
+    it("matches config.py DEFAULTS for the keys settings.json does not ship", () => {
+      expect(VENDOR_SETTINGS.recallPreferObservations).toBeUndefined();
+      expect(VENDOR_SETTINGS.recallTranscriptFallback).toBeUndefined();
+      expect(VENDOR_SETTINGS.recallParallel).toBeUndefined();
+      expect(RECALL_PASSTHROUGH_DEFAULTS.preferObservations).toBe(
+        vendorDefaultBool("recallPreferObservations"),
+      );
+      expect(RECALL_PASSTHROUGH_DEFAULTS.transcriptFallback).toBe(
+        vendorDefaultBool("recallTranscriptFallback"),
+      );
+      expect(RECALL_PASSTHROUGH_DEFAULTS.parallel).toBe(vendorDefaultBool("recallParallel"));
+    });
+
+    it("carries the same sidechain tag-weight seed the settings.json stamp writes", () => {
+      // One literal, two channels. If they drift, the env export (which wins)
+      // silently overrides the stamp.
+      const { agentDir } = scaffold({ memory: { collection: "probe" } } as unknown as AgentConfig);
+      const settings = JSON.parse(
+        readFileSync(
+          join(agentDir, ".claude", "plugins", "hindsight-memory", "settings.json"),
+          "utf-8",
+        ),
+      ) as Record<string, unknown>;
+      expect(settings.recallTagWeights).toEqual({ ...HINDSIGHT_RECALL_TAG_WEIGHT_SEED });
+      expect(RECALL_PASSTHROUGH_DEFAULTS.tagWeights).toEqual({ ...HINDSIGHT_RECALL_TAG_WEIGHT_SEED });
+    });
+  });
+
+  describe("an agent with no memory.recall config", () => {
+    it("exports every knob at exactly today's effective value", () => {
+      const { startSh } = scaffold({} as AgentConfig);
+      // Whole-line matches including the trailing newline: `toContain("=1")`
+      // would also be satisfied by a rendered `=1024`, so a changed default
+      // could sail through a substring assertion.
+      expect(startSh).toContain("export HINDSIGHT_RECALL_BUDGET=low\n");
+      expect(startSh).toContain("export HINDSIGHT_RECALL_MAX_TOKENS=1024\n");
+      expect(startSh).toContain("export HINDSIGHT_RECALL_PREFER_OBSERVATIONS=true\n");
+      expect(startSh).toContain("export HINDSIGHT_RECALL_CONTEXT_TURNS=2\n");
+      expect(startSh).toContain(`export HINDSIGHT_RECALL_ROLES='["user","assistant"]'\n`);
+      expect(startSh).toContain("export HINDSIGHT_RECALL_MAX_QUERY_CHARS=800\n");
+      expect(startSh).toContain("export HINDSIGHT_RECALL_TRANSCRIPT_TAIL_BYTES=262144\n");
+      expect(startSh).toContain(`export HINDSIGHT_RECALL_TAGS='[]'\n`);
+      expect(startSh).toContain("export HINDSIGHT_RECALL_TAGS_MATCH=any\n");
+      expect(startSh).toContain(`export HINDSIGHT_RECALL_TAG_GROUPS='{}'\n`);
+      expect(startSh).toContain(`export HINDSIGHT_RECALL_TAG_WEIGHTS='{"sidechain":0.8}'\n`);
+      expect(startSh).toContain(`export HINDSIGHT_RECALL_ADDITIONAL_BANK_FILTERS='{}'\n`);
+      expect(startSh).toContain("export HINDSIGHT_RECALL_TRANSCRIPT_FALLBACK=true\n");
+      expect(startSh).toContain("export HINDSIGHT_RECALL_PARALLEL=true\n");
+      expect(shellValueOf(startSh, "HINDSIGHT_RECALL_PROMPT_PREAMBLE")).toBe(
+        HINDSIGHT_RECALL_PROMPT_PREAMBLE_DEFAULT,
+      );
+    });
+
+    it("never renders an empty assignment", () => {
+      // `_cast_env("", int)` returns None and config.py SKIPS the assignment,
+      // so an empty export is indistinguishable from no export — and a stale
+      // ~/.hindsight/claude-code.json wins again with every other test green.
+      // A typo'd handlebars path renders empty rather than throwing, which is
+      // exactly how this regression arrives.
+      const { startSh } = scaffold({} as AgentConfig);
+      const empties = startSh
+        .split("\n")
+        .filter((l) => /^export HINDSIGHT_RECALL_[A-Z_]+=$/.test(l));
+      expect(empties).toEqual([]);
+    });
+  });
+
+  describe("an operator-set value reaches the plugin", () => {
+    it("exports each scalar knob as configured", () => {
+      const { startSh } = scaffold(
+        withRecall({
+          budget: "high",
+          max_tokens: 2048,
+          prefer_observations: false,
+          context_turns: 1,
+          max_query_chars: 400,
+          transcript_tail_bytes: 0,
+          transcript_fallback: false,
+          parallel: false,
+          tags_match: "all_strict",
+        }),
+      );
+      expect(startSh).toContain("export HINDSIGHT_RECALL_BUDGET=high\n");
+      expect(startSh).toContain("export HINDSIGHT_RECALL_MAX_TOKENS=2048\n");
+      expect(startSh).toContain("export HINDSIGHT_RECALL_PREFER_OBSERVATIONS=false\n");
+      expect(startSh).toContain("export HINDSIGHT_RECALL_CONTEXT_TURNS=1\n");
+      expect(startSh).toContain("export HINDSIGHT_RECALL_MAX_QUERY_CHARS=400\n");
+      expect(startSh).toContain("export HINDSIGHT_RECALL_TRANSCRIPT_TAIL_BYTES=0\n");
+      expect(startSh).toContain("export HINDSIGHT_RECALL_TRANSCRIPT_FALLBACK=false\n");
+      expect(startSh).toContain("export HINDSIGHT_RECALL_PARALLEL=false\n");
+      expect(startSh).toContain("export HINDSIGHT_RECALL_TAGS_MATCH=all_strict\n");
+    });
+
+    it("serialises lists as JSON, not as a bare shell word", () => {
+      const { startSh } = scaffold(withRecall({ roles: ["user"], tags: ["profile", "ken"] }));
+      expect(shellValueOf(startSh, "HINDSIGHT_RECALL_ROLES")).toBe('["user"]');
+      expect(shellValueOf(startSh, "HINDSIGHT_RECALL_TAGS")).toBe('["profile","ken"]');
+    });
+
+    it("serialises the structured knobs as JSON the plugin can parse", () => {
+      const { startSh } = scaffold(
+        withRecall({
+          tag_groups: [["a", "b"], ["c"]],
+          tag_weights: { lesson: 0.5 },
+          additional_bank_filters: {
+            "ken-profile": { tags: ["profile"], tags_match: "all" },
+          },
+        }),
+      );
+      expect(JSON.parse(shellValueOf(startSh, "HINDSIGHT_RECALL_TAG_GROUPS"))).toEqual([
+        ["a", "b"],
+        ["c"],
+      ]);
+      // Merged over the seed, not replacing it: a single unrelated weight must
+      // not silently un-demote delegated sub-agent memories.
+      expect(JSON.parse(shellValueOf(startSh, "HINDSIGHT_RECALL_TAG_WEIGHTS"))).toEqual({
+        sidechain: 0.8,
+        lesson: 0.5,
+      });
+      // Translated into the camelCase keys recall.py reads off the map
+      // (recall.py:2018-2023) — the yaml surface is snake_case.
+      expect(
+        JSON.parse(shellValueOf(startSh, "HINDSIGHT_RECALL_ADDITIONAL_BANK_FILTERS")),
+      ).toEqual({ "ken-profile": { recallTags: ["profile"], recallTagsMatch: "all" } });
+    });
+
+    it("lets an explicit sidechain weight neutralise the seed", () => {
+      const { startSh } = scaffold(withRecall({ tag_weights: { sidechain: 1 } }));
+      expect(JSON.parse(shellValueOf(startSh, "HINDSIGHT_RECALL_TAG_WEIGHTS"))).toEqual({
+        sidechain: 1,
+      });
+    });
+
+    it("survives a preamble containing shell metacharacters", () => {
+      // Free-form operator text on an `export` line. Unquoted, a single quote
+      // or a `$(...)` would either break the boot or execute.
+      const nasty = `It's $(rm -rf /) \`backtick\` "quoted" $HOME`;
+      const { startSh } = scaffold(withRecall({ prompt_preamble: nasty }));
+      expect(shellValueOf(startSh, "HINDSIGHT_RECALL_PROMPT_PREAMBLE")).toBe(nasty);
+    });
+  });
+
+  describe("invalid config fails loudly at scaffold time", () => {
+    // `_cast_env` is fail-open: a value it cannot cast is DROPPED and the
+    // plugin default silently stands. So a bad knob has to red the apply.
+    const cases: Array<[string, Record<string, unknown>]> = [
+      ["budget outside the enum", { budget: "medium" }],
+      ["tags_match outside the enum", { tags_match: "either" }],
+      ["non-integer context_turns", { context_turns: 1.5 }],
+      ["zero max_tokens", { max_tokens: 0 }],
+      ["negative transcript_tail_bytes", { transcript_tail_bytes: -1 }],
+      ["a non-numeric tag weight", { tag_weights: { lesson: "heavy" } }],
+      ["a negative tag weight", { tag_weights: { lesson: -1 } }],
+      ["tag_groups that are not tag arrays", { tag_groups: ["a", "b"] }],
+      ["a non-string role", { roles: [42] }],
+      // These two CAST cleanly and assign, so the plugin default does not save
+      // you: empty roles means no transcript turn qualifies to build the query
+      // from, and an empty banner puts recalled memories in the prompt with
+      // nothing framing them as memories.
+      ["an empty roles list", { roles: [] }],
+      ["an empty prompt_preamble", { prompt_preamble: "" }],
+      ["a whitespace-only prompt_preamble", { prompt_preamble: "   " }],
+      ["a bank filter that is not a map", { additional_bank_filters: { bank: "profile" } }],
+      [
+        "a bank filter with an illegal tags_match",
+        { additional_bank_filters: { bank: { tags_match: "either" } } },
+      ],
+    ];
+    for (const [label, recall] of cases) {
+      it(`rejects ${label}`, () => {
+        expect(() => scaffold(withRecall(recall))).toThrow(RECALL_PASSTHROUGH_ERROR_MARKER);
+      });
+    }
+
+    it("names the offending key in the message", () => {
+      expect(() => resolveHindsightRecallPassthrough({ budget: "medium" })).toThrow(
+        /memory\.recall\.budget/,
+      );
+      expect(() =>
+        resolveHindsightRecallPassthrough({
+          additional_bank_filters: { "ken-profile": { tags: [""] } },
+        } as never),
+      ).toThrow(/additional_bank_filters\.ken-profile\.tags/);
+    });
+  });
+});

--- a/tests/scaffold.recall-passthrough.test.ts
+++ b/tests/scaffold.recall-passthrough.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { scaffoldAgent } from "../src/agents/scaffold.js";
+import { scaffoldAgent, reconcileAgent } from "../src/agents/scaffold.js";
 import {
   resolveHindsightRecallPassthrough,
   RECALL_PASSTHROUGH_DEFAULTS,
@@ -258,6 +258,74 @@ describe("recall passthrough (#3841)", () => {
       const nasty = `It's $(rm -rf /) \`backtick\` "quoted" $HOME`;
       const { startSh } = scaffold(withRecall({ prompt_preamble: nasty }));
       expect(shellValueOf(startSh, "HINDSIGHT_RECALL_PROMPT_PREAMBLE")).toBe(nasty);
+    });
+  });
+
+  describe("reconcile emits the same knobs as scaffold", () => {
+    // `reconcileAgentInner` hand-builds its own template context instead of
+    // going through buildWorkspaceContext. A knob wired into only one of them
+    // renders EMPTY on the other path — handlebars resolves an unknown path to
+    // "" rather than throwing — and an empty export is skipped by `_cast_env`,
+    // handing the knob back to ~/.hindsight/claude-code.json. Caught in CI on
+    // the first push of this feature, so it is not hypothetical.
+    it("renders byte-identical recall exports on both paths", () => {
+      const agentConfig = withRecall({
+        budget: "mid",
+        max_tokens: 2048,
+        prefer_observations: false,
+        context_turns: 3,
+        roles: ["user"],
+        prompt_preamble: "Past context — it's yours:",
+        tags: ["profile"],
+        tags_match: "all_strict",
+        tag_groups: { core: ["profile"] },
+        tag_weights: { lesson: 1.4 },
+        additional_bank_filters: { "ken-profile": { tags: ["profile"] } },
+        transcript_fallback: false,
+        transcript_tail_bytes: 4096,
+        max_query_chars: 400,
+        parallel: false,
+      });
+      const config = {
+        agents: { probe: agentConfig },
+        memory: { backend: "hindsight", config: { url: "http://localhost:18888/mcp/" } },
+        telegram,
+      } as unknown as SwitchroomConfig;
+
+      const res = scaffoldAgent("probe", agentConfig, tmpDir, telegram, config);
+      const startShPath = join(res.agentDir, "start.sh");
+      const scaffolded = readFileSync(startShPath, "utf-8");
+      reconcileAgent("probe", agentConfig, tmpDir, telegram, config);
+      const reconciled = readFileSync(startShPath, "utf-8");
+
+      const recallLines = (sh: string) =>
+        sh.split("\n").filter((l) => l.startsWith("export HINDSIGHT_RECALL_"));
+      // Named explicitly, so a knob that silently drops off BOTH paths still
+      // reds — an equality check alone would call two identical gaps a pass.
+      const names = (sh: string) =>
+        recallLines(sh).map((l) => l.slice("export ".length).split("=")[0]);
+      for (const name of [
+        "HINDSIGHT_RECALL_BUDGET",
+        "HINDSIGHT_RECALL_MAX_TOKENS",
+        "HINDSIGHT_RECALL_PREFER_OBSERVATIONS",
+        "HINDSIGHT_RECALL_CONTEXT_TURNS",
+        "HINDSIGHT_RECALL_ROLES",
+        "HINDSIGHT_RECALL_PROMPT_PREAMBLE",
+        "HINDSIGHT_RECALL_MAX_QUERY_CHARS",
+        "HINDSIGHT_RECALL_TRANSCRIPT_TAIL_BYTES",
+        "HINDSIGHT_RECALL_TRANSCRIPT_FALLBACK",
+        "HINDSIGHT_RECALL_TAGS",
+        "HINDSIGHT_RECALL_TAGS_MATCH",
+        "HINDSIGHT_RECALL_TAG_GROUPS",
+        "HINDSIGHT_RECALL_TAG_WEIGHTS",
+        "HINDSIGHT_RECALL_ADDITIONAL_BANK_FILTERS",
+        "HINDSIGHT_RECALL_PARALLEL",
+      ]) {
+        expect(names(scaffolded)).toContain(name);
+        expect(names(reconciled)).toContain(name);
+      }
+      expect(recallLines(reconciled)).toEqual(recallLines(scaffolded));
+      expect(recallLines(reconciled).some((l) => /=$/.test(l))).toBe(false);
     });
   });
 

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -353,6 +353,19 @@ ENV_OVERRIDES = {
     # from agents.<name>.memory.recall.skip_trivial only on override; the
     # switchroom default is on (recall.py falls back to True).
     "HINDSIGHT_RECALL_SKIP_TRIVIAL": ("recallSkipTrivial", bool),
+    # Switchroom #3841: the last three recall settings that had a config key but
+    # no env channel at all, so switchroom.yaml could not reach them and a
+    # hand-edit of the installed plugin did not survive `switchroom apply`. Set
+    # by start.sh from agents.<name>.memory.recall.prefer_observations / .roles /
+    # .prompt_preamble (cascading through defaults), always exported at their
+    # existing effective values, so an operator who sets none of them sees no
+    # change. The other #3841 knobs (budget, max_tokens, context_turns,
+    # max_query_chars, transcript_tail_bytes, tags, tags_match, tag_groups,
+    # tag_weights, additional_bank_filters, transcript_fallback, parallel)
+    # already had entries in this table and only needed the yaml surface.
+    "HINDSIGHT_RECALL_PREFER_OBSERVATIONS": ("recallPreferObservations", bool),
+    "HINDSIGHT_RECALL_ROLES": ("recallRoles", list),
+    "HINDSIGHT_RECALL_PROMPT_PREAMBLE": ("recallPromptPreamble", str),
     # Switchroom #2848 Stage B: directive-capture nudge on/off. Set by
     # start.sh from agents.<name>.memory.directive_capture_nudge only when
     # the operator overrode it; the switchroom default is on (settings.json

--- a/vendor/hindsight-memory/scripts/tests/test_config_recall_passthrough_env.py
+++ b/vendor/hindsight-memory/scripts/tests/test_config_recall_passthrough_env.py
@@ -1,0 +1,170 @@
+"""Switchroom #3841 — the recall knobs switchroom.yaml exports must actually
+land in the loaded config.
+
+Three of them (`recallPreferObservations`, `recallRoles`,
+`recallPromptPreamble`) had a config key and a `recall.py` read but NO entry in
+`ENV_OVERRIDES`, so there was no channel from switchroom.yaml at all: the only
+way to change them was to hand-edit the installed plugin, which
+`switchroom apply` reverts by re-copying this tree.
+
+The rest already had entries and only needed the yaml surface — they are
+asserted here too, because the failure they guard against is silent in exactly
+the same way. `start.sh` exports a NAME; if that name is not a key of
+`ENV_OVERRIDES`, `load_config()` ignores it, the plugin default stands, and the
+operator's switchroom.yaml reads as though it were in force. Nothing errors.
+
+Stdlib-only.
+"""
+
+import json
+import os
+import sys
+import unittest
+from unittest import mock
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from lib.config import DEFAULTS, ENV_OVERRIDES, load_config  # noqa: E402
+
+
+# Every env var `profiles/_base/start.sh.hbs` exports for the #3841
+# passthrough, with the config key it must reach.
+PASSTHROUGH_ENV = {
+    "HINDSIGHT_RECALL_BUDGET": "recallBudget",
+    "HINDSIGHT_RECALL_MAX_TOKENS": "recallMaxTokens",
+    "HINDSIGHT_RECALL_PREFER_OBSERVATIONS": "recallPreferObservations",
+    "HINDSIGHT_RECALL_CONTEXT_TURNS": "recallContextTurns",
+    "HINDSIGHT_RECALL_ROLES": "recallRoles",
+    "HINDSIGHT_RECALL_PROMPT_PREAMBLE": "recallPromptPreamble",
+    "HINDSIGHT_RECALL_MAX_QUERY_CHARS": "recallMaxQueryChars",
+    "HINDSIGHT_RECALL_TRANSCRIPT_TAIL_BYTES": "recallTranscriptTailBytes",
+    "HINDSIGHT_RECALL_TAGS": "recallTags",
+    "HINDSIGHT_RECALL_TAGS_MATCH": "recallTagsMatch",
+    "HINDSIGHT_RECALL_TAG_GROUPS": "recallTagGroups",
+    "HINDSIGHT_RECALL_TAG_WEIGHTS": "recallTagWeights",
+    "HINDSIGHT_RECALL_ADDITIONAL_BANK_FILTERS": "recallAdditionalBankFilters",
+    "HINDSIGHT_RECALL_TRANSCRIPT_FALLBACK": "recallTranscriptFallback",
+    "HINDSIGHT_RECALL_PARALLEL": "recallParallel",
+}
+
+
+def _load_with(env):
+    """load_config() with a hermetic environment (no plugin/user settings)."""
+    with mock.patch.dict(os.environ, env, clear=True):
+        # Point CLAUDE_PLUGIN_ROOT at a directory with no settings.json so the
+        # result is DEFAULTS + env only, and no developer's real
+        # ~/.hindsight/claude-code.json can leak in.
+        os.environ["CLAUDE_PLUGIN_ROOT"] = os.path.join(SCRIPTS_DIR, "does-not-exist")
+        os.environ["HOME"] = os.path.join(SCRIPTS_DIR, "does-not-exist")
+        return load_config()
+
+
+class EveryExportedNameHasAChannel(unittest.TestCase):
+    def test_all_passthrough_env_names_are_wired(self):
+        missing = [name for name in PASSTHROUGH_ENV if name not in ENV_OVERRIDES]
+        self.assertEqual(missing, [], f"exported but never read: {missing}")
+
+    def test_each_name_maps_to_the_expected_config_key(self):
+        for name, key in PASSTHROUGH_ENV.items():
+            with self.subTest(name=name):
+                self.assertEqual(ENV_OVERRIDES[name][0], key)
+
+    def test_every_target_key_exists_in_defaults(self):
+        for name, key in PASSTHROUGH_ENV.items():
+            with self.subTest(name=name):
+                self.assertIn(key, DEFAULTS)
+
+
+class ValuesActuallyLand(unittest.TestCase):
+    """The outcome that matters: the loaded config carries the exported value."""
+
+    def test_prefer_observations_can_be_turned_off(self):
+        self.assertTrue(DEFAULTS["recallPreferObservations"])
+        cfg = _load_with({"HINDSIGHT_RECALL_PREFER_OBSERVATIONS": "false"})
+        self.assertIs(cfg["recallPreferObservations"], False)
+
+    def test_roles_accepts_the_exported_json_array(self):
+        cfg = _load_with({"HINDSIGHT_RECALL_ROLES": '["user"]'})
+        self.assertEqual(cfg["recallRoles"], ["user"])
+
+    def test_prompt_preamble_replaces_the_banner(self):
+        cfg = _load_with({"HINDSIGHT_RECALL_PROMPT_PREAMBLE": "Past context:"})
+        self.assertEqual(cfg["recallPromptPreamble"], "Past context:")
+
+    def test_tag_weights_accepts_the_exported_json_object(self):
+        cfg = _load_with({"HINDSIGHT_RECALL_TAG_WEIGHTS": '{"sidechain": 0.8}'})
+        self.assertEqual(cfg["recallTagWeights"], {"sidechain": 0.8})
+
+    def test_tag_groups_accepts_both_shapes(self):
+        as_list = _load_with({"HINDSIGHT_RECALL_TAG_GROUPS": '[["a","b"],["c"]]'})
+        self.assertEqual(as_list["recallTagGroups"], [["a", "b"], ["c"]])
+        as_map = _load_with({"HINDSIGHT_RECALL_TAG_GROUPS": '{"g": ["a"]}'})
+        self.assertEqual(as_map["recallTagGroups"], {"g": ["a"]})
+
+    def test_empty_collection_exports_assign_rather_than_being_skipped(self):
+        # `[]` / `{}` are what switchroom exports when the operator configured
+        # nothing. They must ASSIGN (making env authoritative over a stale
+        # ~/.hindsight/claude-code.json), not be dropped like an empty string.
+        cfg = _load_with(
+            {
+                "HINDSIGHT_RECALL_TAGS": "[]",
+                "HINDSIGHT_RECALL_TAG_GROUPS": "{}",
+                "HINDSIGHT_RECALL_ADDITIONAL_BANK_FILTERS": "{}",
+            }
+        )
+        self.assertEqual(cfg["recallTags"], [])
+        self.assertEqual(cfg["recallTagGroups"], {})
+        self.assertEqual(cfg["recallAdditionalBankFilters"], {})
+
+    def test_exported_defaults_reproduce_the_shipped_config(self):
+        """The no-config path: exporting today's effective values changes nothing.
+
+        This is the whole contract of the passthrough — an operator who sets no
+        `memory.recall.*` key must get the same loaded config as an agent
+        running before the exports existed.
+        """
+        baseline = _load_with({})
+        exported = _load_with(
+            {
+                "HINDSIGHT_RECALL_BUDGET": baseline["recallBudget"],
+                "HINDSIGHT_RECALL_MAX_TOKENS": str(baseline["recallMaxTokens"]),
+                "HINDSIGHT_RECALL_PREFER_OBSERVATIONS": str(
+                    baseline["recallPreferObservations"]
+                ).lower(),
+                "HINDSIGHT_RECALL_CONTEXT_TURNS": str(baseline["recallContextTurns"]),
+                "HINDSIGHT_RECALL_ROLES": json.dumps(baseline["recallRoles"]),
+                "HINDSIGHT_RECALL_PROMPT_PREAMBLE": baseline["recallPromptPreamble"],
+                "HINDSIGHT_RECALL_MAX_QUERY_CHARS": str(baseline["recallMaxQueryChars"]),
+                "HINDSIGHT_RECALL_TRANSCRIPT_TAIL_BYTES": str(
+                    baseline["recallTranscriptTailBytes"]
+                ),
+                "HINDSIGHT_RECALL_TAGS": json.dumps(baseline["recallTags"]),
+                "HINDSIGHT_RECALL_TAGS_MATCH": baseline["recallTagsMatch"],
+                # settings.json ships null / DEFAULTS carries None; `{}` is the
+                # same thing to recall.py (`config.get(...) or None`) and unlike
+                # `null` it actually assigns.
+                "HINDSIGHT_RECALL_TAG_GROUPS": "{}",
+                "HINDSIGHT_RECALL_TAG_WEIGHTS": json.dumps(baseline["recallTagWeights"]),
+                "HINDSIGHT_RECALL_ADDITIONAL_BANK_FILTERS": json.dumps(
+                    baseline["recallAdditionalBankFilters"]
+                ),
+                "HINDSIGHT_RECALL_TRANSCRIPT_FALLBACK": str(
+                    baseline["recallTranscriptFallback"]
+                ).lower(),
+                "HINDSIGHT_RECALL_PARALLEL": str(baseline["recallParallel"]).lower(),
+            }
+        )
+        for key in PASSTHROUGH_ENV.values():
+            with self.subTest(key=key):
+                if key == "recallTagGroups":
+                    # None vs {} — equivalent at every read site (`or None`).
+                    self.assertFalse(baseline[key])
+                    self.assertFalse(exported[key])
+                    continue
+                self.assertEqual(exported[key], baseline[key])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`vendor/hindsight-memory/scripts/recall.py` reads ~25 `recall*` settings out of the plugin config. Ten had a `switchroom.yaml` surface (the eight pre-existing ones plus `min_score` / `min_score_scope` from #3838). This adds the remaining fifteen, following the #3838 shape exactly: `memory.recall.<key>` → `HINDSIGHT_RECALL_<KEY>` → plugin key, exported unconditionally from `start.sh`.

| `memory.recall.*` | env | default (= today's effective value) |
| --- | --- | --- |
| `budget` | `HINDSIGHT_RECALL_BUDGET` | `low` |
| `max_tokens` | `..._MAX_TOKENS` | `1024` |
| `prefer_observations` | `..._PREFER_OBSERVATIONS` | `true` |
| `context_turns` | `..._CONTEXT_TURNS` | `2` |
| `roles` | `..._ROLES` | `["user","assistant"]` |
| `prompt_preamble` | `..._PROMPT_PREAMBLE` | the shipped banner |
| `max_query_chars` | `..._MAX_QUERY_CHARS` | `800` |
| `transcript_fallback` | `..._TRANSCRIPT_FALLBACK` | `true` |
| `transcript_tail_bytes` | `..._TRANSCRIPT_TAIL_BYTES` | `262144` |
| `tags` | `..._TAGS` | `[]` (filtering off) |
| `tags_match` | `..._TAGS_MATCH` | `any` |
| `tag_groups` | `..._TAG_GROUPS` | `{}` (filtering off) |
| `tag_weights` | `..._TAG_WEIGHTS` | `{"sidechain":0.8}` — **merged**, not replaced |
| `additional_bank_filters` | `..._ADDITIONAL_BANK_FILTERS` | `{}` |
| `parallel` | `..._PARALLEL` | `true` |

## Why

Tuning any of these meant hand-editing the installed plugin — which `switchroom apply` reverts, because it rm's and re-copies the whole tree from `vendor/`. That is the same defect class #3838 and the release-note entry above it describe: the operator's change disappears with no error and no log line while `switchroom.yaml` reads as though the host were tuned.

Three keys (`recallPreferObservations`, `recallRoles`, `recallPromptPreamble`) had a config key and a `recall.py` read but **no `ENV_OVERRIDES` entry at all** — there was no channel from `switchroom.yaml` even in principle. The other twelve had the env entry and needed only the yaml surface.

**Unconditional export, per #3774.** `~/.hindsight/claude-code.json` loads *after* switchroom's `settings.json` stamp and survives an apply, so a knob switchroom does not export is a knob a stale hand-edit owns. Collection knobs export `[]`/`{}` rather than an empty string, because `_cast_env("", T)` returns `None` and `load_config()` then *skips* the assignment (`config.py:502-504`) — an empty export is indistinguishable from no export and hands authority straight back. `[]`/`{}` fold to `None` at recall.py's read sites (`or None`), so they assign without filtering.

**Zero behaviour change when unset,** and it is enforced rather than asserted once: `RECALL_PASSTHROUGH_DEFAULTS` is pinned by test against `vendor/hindsight-memory/settings.json` and the `DEFAULTS` block in `config.py`, so a vendor bump that moves a default reds here instead of silently re-tuning every agent through an export that outranks `settings.json`.

**Validation is loud, at scaffold time.** `_cast_env` is fail-open: a value it cannot cast is dropped and the plugin default stands. So a bad knob has to fail the apply, not the recall. Rejected with a `HINDSIGHT-RECALL-CONFIG` error naming the key: an out-of-enum `budget`/`tags_match`, a non-integer or out-of-range count, a negative tag weight, malformed `tag_groups`, a bank filter that is not a map — plus an empty `roles` list and an empty `prompt_preamble`, which *do* cast cleanly and assign, and then respectively leave recall nothing to build a query from and strip the framing off injected memories.

Resolution lives in one module (`src/setup/hindsight-recall-passthrough.ts`) consumed by both `scaffoldAgent` and `reconcileAgentInner`, so scaffold and reconcile cannot drift.

The #2816 tag-filter port stays **dormant by default** — only the lever changed, not the value. No per-bank tag taxonomy is invented; that is what the old `TODO(#2816)` warned against, and the comment now says so rather than being deleted.

## Deliberately out of scope

- **`recallAdditionalBanks` gets no env export.** It already has `memory.recall.additional_banks`, but its *effective* value is composed inside `installHindsightPlugin` from the cascaded config **union** the `knows`/`serves`-assigned profile banks from `resolveUsers()`. An export derived from `memory.recall.additional_banks` alone would outrank `settings.json` and silently drop those user banks — a real behaviour change, which is the one thing this PR promises not to do.
- **`recallTypes` / `recallSkipTrivial` already had surfaces** (`memory.recall.types` / `.skip_trivial`) and are untouched; they are documented in the new reference table for completeness.
- **`recallParallel` already had the `HINDSIGHT_RECALL_PARALLEL` entry in `ENV_OVERRIDES`** but no yaml path — the yaml path is added, the env entry was left alone.
- The eight pre-existing passthroughs are untouched.

## Test plan

`tests/scaffold.recall-passthrough.test.ts` (25 tests) asserts outcomes on the rendered `start.sh`, the scaffolded plugin `settings.json`, and a real `sh` evaluating the exported line:

- defaults match `vendor/.../settings.json` and `config.py` `DEFAULTS` key by key, and the `sidechain: 0.8` seed matches the settings.json stamp (one literal, two channels);
- unset → every knob exported at today's value, pinned **whole-line** (`toContain("=1")` would also match a rendered `=1024`), plus an assertion that no `HINDSIGHT_RECALL_*` line renders empty — a typo'd handlebars path renders empty rather than throwing, which is exactly how this regression arrives;
- each key set in yaml → the right env var, JSON for lists/objects, bare `true`/`false` for booleans, `tag_weights` merged over the seed, `additional_bank_filters` translated to the camelCase keys `recall.py` reads;
- a `prompt_preamble` containing `'`, `` ` ``, `$(...)` and `$HOME` round-trips byte-for-byte through `sh`;
- 14 invalid configs each throw `HINDSIGHT-RECALL-CONFIG`, with the message naming the offending key path.

`vendor/hindsight-memory/scripts/tests/test_config_recall_passthrough_env.py` (10 tests, stdlib-only) closes the other half: every env name `start.sh` exports is a key of `ENV_OVERRIDES`, maps to the expected config key, and that key exists in `DEFAULTS` — an exported name the plugin does not read is silent. Plus: exporting all fifteen defaults reproduces the baseline `load_config()` key by key.

**Mutation-checked, not just green.** Typo'ing one handlebars path in `start.sh.hbs` (renders empty, throws nothing) reds 3 tests.

```
vitest tests/scaffold.test.ts tests/scaffold.recall-envelope-carrier.test.ts \
       tests/scaffold.recall-passthrough.test.ts tests/config.test.ts tests/merge.test.ts
  Test Files  5 passed (5)       Tests  377 passed (377)

python3 -m unittest discover -s tests   (vendor/hindsight-memory/scripts)
  Ran 817 tests in 34.136s   OK

npm run lint   clean
```

## Risk

Low, and the failure mode is loud rather than silent. Every default is pinned to the value the fleet already ran, so an agent with no `memory.recall:` block resolves identically; the python suite proves that at the `load_config()` level and the vitest suite proves it at the rendered-`start.sh` level. The one live behaviour change for an existing host is that a raw `HINDSIGHT_RECALL_*` in an agent's `env:` map no longer wins (compose environment is set before `start.sh` runs) — `grep HINDSIGHT_RECALL` over the live fleet's `switchroom.yaml` shows no agent using that escape hatch, and it is now documented as superseded.

Job spec: [`reference/jobs/remember-across-sessions.md`](reference/jobs/remember-across-sessions.md) — "what comes back is relevant, not a grab-bag" is precisely what these knobs tune, and until now tuning it required editing plugin internals that the next apply reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)