### PR TITLE
fix(cards): de-indent the worker card back to flush, keep only the step indent (#3842)

### DIFF
--- a/scripts/card-previews.ts
+++ b/scripts/card-previews.ts
@@ -3,7 +3,7 @@
  * Card preview harness — renders EVERY status/progress card variant through the
  * REAL renderers (no mockups) and writes `card-previews.md`.
  *
- * Run: bun scripts/card-previews.ts > /host/home/kenthompson/code/card-previews.md
+ * Run: bun scripts/card-previews.ts > card-previews.md
  *
  * Not a test; not wired into CI. Kept in-repo so the previews can be regenerated
  * verbatim whenever a card renderer changes.

--- a/scripts/card-previews.ts
+++ b/scripts/card-previews.ts
@@ -1,0 +1,424 @@
+#!/usr/bin/env bun
+/**
+ * Card preview harness — renders EVERY status/progress card variant through the
+ * REAL renderers (no mockups) and writes `card-previews.md`.
+ *
+ * Run: bun scripts/card-previews.ts > /host/home/kenthompson/code/card-previews.md
+ *
+ * Not a test; not wired into CI. Kept in-repo so the previews can be regenerated
+ * verbatim whenever a card renderer changes.
+ */
+import {
+  renderActivityFeed,
+  renderActivityFeedWithNested,
+  renderCombinedWorkerFeed,
+  type CombinedWorkerRow,
+  type SessionActivityHeader,
+} from '../telegram-plugin/tool-activity-summary.js'
+import {
+  renderWorkerActivity,
+  WORKER_CARD_SUPERSEDED_BODY,
+  type WorkerActivityView,
+} from '../telegram-plugin/worker-activity-feed.js'
+
+type Section = {
+  name: string
+  fn: string
+  when: string
+  out: string
+  /** Does this variant reach the shared `renderStatusCard` primitive? */
+  shared: 'shared' | 'mixed' | 'divergent'
+}
+const sections: Section[] = []
+const add = (
+  name: string,
+  fn: string,
+  when: string,
+  out: string | null,
+  shared: 'shared' | 'mixed' | 'divergent' = 'shared',
+): void => {
+  sections.push({ name, fn, when, out: out ?? '(null — renderer returned nothing)', shared })
+}
+
+// Visualise the invisible: U+2800 BRAILLE BLANK and U+00A0 would otherwise be
+// silent in a fenced block. Rendered as themselves PLUS a legend note.
+const agentHeader = (over: Partial<SessionActivityHeader> = {}): SessionActivityHeader => ({
+  label: 'Agent',
+  elapsedMs: 95_000,
+  toolCount: 12,
+  state: 'running',
+  model: 'claude-opus-4-8',
+  totalTokens: 41_200,
+  ...over,
+})
+
+const AGENT_STEPS = [
+  'Searching memory for card render paths',
+  'Reading telegram-plugin/tool-activity-summary.ts',
+  'Reading telegram-plugin/worker-activity-feed.ts',
+  'Grepping for renderStatusCard callers',
+  'Drafting the inventory table',
+]
+
+// ── 1. Agent card — running ────────────────────────────────────────────────
+add(
+  'Agent card — running',
+  'renderActivityFeed → renderStatusCard',
+  'Every turn that labels a tool. Pinned in the session chat, edited in place.',
+  renderActivityFeed(AGENT_STEPS, false, '', undefined, agentHeader()),
+)
+
+// ── 2. Agent card — final ──────────────────────────────────────────────────
+add(
+  'Agent card — final (turn complete)',
+  'renderActivityFeed → renderStatusCard',
+  'The terminal edit when the turn ends: every step struck, `✓ N steps` footer.',
+  renderActivityFeed(AGENT_STEPS, true, '', 17, agentHeader({ state: 'done', elapsedMs: 214_000 })),
+)
+
+// ── 3. Agent card — no header (steps only) ─────────────────────────────────
+add(
+  'Agent card — steps only (no header)',
+  'renderActivityFeed → renderStatusCard (header omitted)',
+  'Legacy/direct callers (`appendActivityLine`, `appendActivityLabel`) that pass no header.',
+  renderActivityFeed(AGENT_STEPS.slice(0, 3)),
+)
+
+// ── 4. Agent card — nested foreground sub-agent ────────────────────────────
+add(
+  'Agent card — with nested foreground sub-agent',
+  'renderActivityFeedWithNested → renderStatusCard (childSteps)',
+  'A foreground Task/Agent runs inside the turn: parent lines all struck, the live `→` sits in the `↳` child block.',
+  renderActivityFeedWithNested(
+    AGENT_STEPS.slice(0, 3),
+    ['Reading the repo conventions', 'Running the scoped test suite', 'Summarising findings'],
+    false,
+    ' · 24s',
+    undefined,
+    agentHeader(),
+  ),
+)
+
+// ── 5. Agent card — liveness early-open ────────────────────────────────────
+add(
+  'Agent card — liveness early-open (no tools yet)',
+  'narrative-lane.ts:572 → renderActivityFeedWithNested → renderStatusCard',
+  'A silent turn passes the liveness threshold before any tool is labelled — the card opens on `Working…`.',
+  renderActivityFeedWithNested(
+    ['Working…'],
+    [],
+    false,
+    ' · 32s',
+    undefined,
+    { label: 'Agent', elapsedMs: 32_000, toolCount: 0, state: 'running', model: 'claude-opus-4-8' },
+  ),
+)
+
+// ── 6. Agent card — liveness finalised ─────────────────────────────────────
+add(
+  'Agent card — liveness finalised',
+  'narrative-lane.ts:882 → renderActivityFeedWithNested → renderStatusCard',
+  'The liveness-only card at turn end: `→ Working…` becomes a done record instead of freezing live.',
+  renderActivityFeedWithNested(
+    ['Working…'],
+    [],
+    true,
+    '',
+    undefined,
+    { label: 'Agent', elapsedMs: 88_000, toolCount: 0, state: 'done', model: 'claude-opus-4-8' },
+  ),
+)
+
+// ── 7. Agent card — post-answer background sub-agent liveness ──────────────
+add(
+  'Agent card — post-answer background activity',
+  'narrative-lane.ts:699 → renderActivityFeedWithNested → renderStatusCard',
+  'The reply already went out and a background sub-agent is still running — the card surfaces below the reply.',
+  renderActivityFeedWithNested(
+    ['Working in background…'],
+    [],
+    false,
+    ' · 1m10s',
+    undefined,
+    { label: 'Agent', elapsedMs: 130_000, toolCount: 3, state: 'running', model: 'claude-opus-4-8' },
+  ),
+)
+
+// ── 8. Agent card — budget overflow ────────────────────────────────────────
+const LONG = 'A'.repeat(700)
+add(
+  'Agent card — char-budget overflow backstop',
+  'renderStatusCard → fitCardToBudget',
+  'The rendered card exceeds STATUS_CARD_CHAR_BUDGET: oldest bullets are dropped and a `+N earlier…` marker re-inserted.',
+  renderActivityFeed(
+    [LONG, LONG, LONG, 'Finally a short newest step'],
+    false,
+    '',
+    undefined,
+    agentHeader(),
+  ),
+)
+
+// ── Worker views ───────────────────────────────────────────────────────────
+const workerView = (over: Partial<WorkerActivityView> = {}): WorkerActivityView => ({
+  workerId: 'w1',
+  description: 'Audit every card render path and de-indent the worker card',
+  state: 'running',
+  elapsedMs: 143_000,
+  toolCount: 31,
+  latestSummary: '',
+  narrativeLines: [
+    'Fetching origin and branching off main',
+    'Reading telegram-plugin/status-no-truncate.ts',
+    'Mapping renderStatusCard callers',
+    'Writing the preview harness',
+  ],
+  model: 'claude-opus-4-8',
+  totalTokens: 88_400,
+  ...over,
+}) as WorkerActivityView
+
+// ── 9. Worker card — just dispatched ───────────────────────────────────────
+add(
+  'Worker card — just dispatched (no steps yet)',
+  'renderWorkerActivity → renderStatusCard, then a hand-rolled starting… tail appended outside the primitive',
+  'The first paint of a background worker, before it has produced a narrative line.',
+  renderWorkerActivity(workerView({ narrativeLines: [], latestSummary: '', elapsedMs: 1_200, toolCount: 0 })),
+  'mixed',
+)
+
+// ── 10. Worker card — running ──────────────────────────────────────────────
+add(
+  'Worker card — single worker running',
+  'renderWorkerActivity → renderStatusCard',
+  'Exactly one background worker live in the chat. Pinned; edited in place.',
+  renderWorkerActivity(workerView(), ' · 18s'),
+)
+
+// ── 11. Worker card — done ─────────────────────────────────────────────────
+add(
+  'Worker card — done (with result recap)',
+  'renderWorkerActivity → renderStatusCard (result block)',
+  'The worker finished successfully: feed all-struck, rule, then the ✅ result paragraph.',
+  renderWorkerActivity(
+    workerView({
+      state: 'done',
+      elapsedMs: 902_000,
+      latestSummary:
+        'Inventoried 14 card variants, found renderCombinedWorkerFeed forks the header + budget logic, and de-indented the worker card. PR #0000.',
+    }),
+  ),
+)
+
+// ── 12. Worker card — failed ───────────────────────────────────────────────
+add(
+  'Worker card — failed',
+  'renderWorkerActivity → renderStatusCard (result block, ⚠️)',
+  'The worker errored: header line 2 reads `failed`, result block carries the error recap.',
+  renderWorkerActivity(
+    workerView({
+      state: 'failed',
+      elapsedMs: 61_000,
+      latestSummary: 'Scoped test run failed: 3 assertions in card-type-distinguishability.test.ts.',
+    }),
+  ),
+)
+
+// ── 13. Worker card — incomplete ───────────────────────────────────────────
+add(
+  'Worker card — incomplete (killed / timed out)',
+  'renderWorkerActivity → renderStatusCard (result suppressed by invariant)',
+  'The worker was terminated before producing a result — the renderer refuses to fabricate a result block.',
+  renderWorkerActivity(
+    workerView({ state: 'incomplete', elapsedMs: 1_805_000, latestSummary: 'stray text that must not render' }),
+  ),
+)
+
+// ── Combined feed ──────────────────────────────────────────────────────────
+const row = (n: number, desc: string, hist: string[], over: Partial<CombinedWorkerRow> = {}): CombinedWorkerRow => ({
+  ordinal: n,
+  description: desc,
+  elapsedMs: 60_000 * n + 15_000,
+  toolCount: 7 * n,
+  totalTokens: 20_000 * n,
+  currentStep: hist[hist.length - 1] ?? 'starting…',
+  historyLines: hist,
+  model: 'claude-opus-4-8',
+  ...over,
+})
+
+const H = (k: number, tag: string): string[] =>
+  Array.from({ length: k }, (_, i) => `${tag} step ${i + 1}`)
+
+// ── 14. Combined — 2 workers ───────────────────────────────────────────────
+add(
+  'WORKERS card — 2 workers',
+  'renderCombinedWorkerFeed',
+  '2+ background workers live in the same chat/thread coalesce into ONE message. Depth = 5 each.',
+  renderCombinedWorkerFeed(
+    [
+      row(1, 'Audit every card render path', H(5, 'audit')),
+      row(2, 'Fix the hindsight recall floor', H(5, 'recall')),
+    ],
+    { maxRows: 6 },
+  ),
+  'divergent',
+)
+
+// ── 15. Combined — 4 workers ───────────────────────────────────────────────
+add(
+  'WORKERS card — 4 workers',
+  'renderCombinedWorkerFeed',
+  'Depth degrades to the floor of Ken\'s 6/5/4/3 curve.',
+  renderCombinedWorkerFeed(
+    [
+      row(1, 'Audit every card render path', H(4, 'audit')),
+      row(2, 'Fix the hindsight recall floor', H(4, 'recall')),
+      row(3, 'Release v0.19.24', H(4, 'release')),
+      row(4, 'Investigate the flaky UAT scenario', H(4, 'uat')),
+    ],
+    { maxRows: 6 },
+  ),
+  'divergent',
+)
+
+// ── 16. Combined — spill ───────────────────────────────────────────────────
+add(
+  'WORKERS card — 8 workers (spill)',
+  'renderCombinedWorkerFeed (row-count backstop)',
+  'Beyond the design fan-out the NEWEST rows collapse into a single `+M more working…` line.',
+  renderCombinedWorkerFeed(
+    Array.from({ length: 8 }, (_, i) => row(i + 1, `Background task number ${i + 1}`, H(3, `t${i + 1}`))),
+    { maxRows: 6 },
+  ),
+  'divergent',
+)
+
+// ── 17. Combined — survivors keep ordinals ─────────────────────────────────
+add(
+  'WORKERS card — survivors keep their ordinals',
+  'renderCombinedWorkerFeed',
+  'Worker 1 finished; 2 and 3 keep their numbers, so the card shows `2.`/`3.` with no `1.`',
+  renderCombinedWorkerFeed(
+    [
+      row(2, 'Fix the hindsight recall floor', H(4, 'recall')),
+      row(3, 'Release v0.19.24', H(4, 'release')),
+    ],
+    { maxRows: 6 },
+  ),
+  'divergent',
+)
+
+// ── 18. Combined — no history yet ──────────────────────────────────────────
+add(
+  'WORKERS card — a worker with no history yet',
+  'renderCombinedWorkerFeed (→ starting… fallback)',
+  'A freshly dispatched worker joins a group that already has a live card.',
+  renderCombinedWorkerFeed(
+    [
+      row(1, 'Audit every card render path', H(5, 'audit')),
+      row(2, 'Freshly dispatched worker', [], { currentStep: '', historyLines: undefined }),
+    ],
+    { maxRows: 6 },
+  ),
+  'divergent',
+)
+
+// ── 19. Rotated / superseded card ──────────────────────────────────────────
+add(
+  'Worker card — superseded (group message rotated)',
+  'worker-activity-feed.ts WORKER_CARD_SUPERSEDED_BODY (static literal, no renderer)',
+  'The shared worker message hit its lifetime cap and a fresh card was opened; the retired message is finalised to this static note so it does not read as a stuck worker.',
+  WORKER_CARD_SUPERSEDED_BODY,
+  'divergent',
+)
+
+// ── 20. Agent card — rolling overflow ──────────────────────────────────────
+add(
+  'Agent card — rolling-window overflow',
+  'renderActivityFeed → renderStatusCard → renderStepFeed',
+  'More steps than the rolling window: the oldest collapse to a `✓ +N earlier…` header.',
+  renderActivityFeed(
+    Array.from({ length: 14 }, (_, i) => `Doing thing number ${i + 1}`),
+    false,
+    '',
+    undefined,
+    agentHeader(),
+  ),
+)
+
+// ── 21. Agent card — nested child overflow ─────────────────────────────────
+add(
+  'Agent card — nested sub-agent with child overflow',
+  'renderActivityFeedWithNested → renderStatusCard',
+  'The foreground sub-agent has produced more steps than the window: a `↳ +N earlier…` header appears in the child block.',
+  renderActivityFeedWithNested(
+    AGENT_STEPS.slice(0, 2),
+    Array.from({ length: 11 }, (_, i) => `Child step ${i + 1}`),
+    false,
+    '',
+    undefined,
+    agentHeader(),
+  ),
+)
+
+// ── emit ───────────────────────────────────────────────────────────────────
+const vis = (s: string): string =>
+  s.replace(/\u2800/g, '\u2800').replace(/\u00A0/g, '\u00A0')
+
+const now = new Date().toISOString()
+let md = `# Switchroom status/progress card previews
+
+Generated **verbatim** from the real renderers by \`scripts/card-previews.ts\`
+(\`bun scripts/card-previews.ts\`). Nothing here is a mockup.
+
+Generated: \`${now}\`
+Branch: \`${process.env.PREVIEW_BRANCH ?? 'fix/3839-deindent-worker-card'}\`
+
+## Reading these
+
+Card bodies are **Telegram markdown**, sent verbatim by the gateway. Two
+characters are invisible in the fenced blocks below:
+
+- \`U+2800\` BRAILLE PATTERN BLANK — the indent glyph. It renders blank-width on
+  a phone but is category **So**, not whitespace, so Telegram's parser cannot
+  left-trim it. Three of them = one indent level.
+- \`U+00A0\` NO-BREAK SPACE — the \`collapseSafe\` separator appended to every line
+  so the card stays legible when Telegram's pinned bar collapses it to one line.
+
+Lines are joined with a GFM hard break (\`  \\n\`).
+
+## Verdict on centralisation
+
+**Mostly, not entirely.** Every 🤖 agent-card variant and every SINGLE-worker
+🛠 card goes through the one shared primitive, \`renderStatusCard\`
+(\`telegram-plugin/tool-activity-summary.ts\`). Three surfaces do not:
+
+1. \`renderCombinedWorkerFeed\` — the 2+ worker WORKERS card. It shares the
+   per-line pipeline (\`escapeStepLine\`, \`renderStepFeed\`, \`stackCardLines\`)
+   but composes its own header (\`glanceLine\` + \`rowHeader\`, not
+   \`renderActivityHeader\`) and carries its own char-budget backstop
+   (a row-shrinking loop, not \`fitCardToBudget\`).
+2. The just-dispatched \`starting…\` tail — appended by string concatenation
+   AFTER \`renderStatusCard\` returns, in \`renderWorkerActivity\`.
+3. \`WORKER_CARD_SUPERSEDED_BODY\` — a static literal with no renderer at all.
+
+---
+
+`
+
+md += '## Inventory\n\n'
+md += '| # | Variant | Renderer | Shared primitive? |\n|---|---|---|---|\n'
+sections.forEach((s, i) => {
+  md += `| ${i + 1} | ${s.name} | \`${s.fn}\` | ${s.shared === 'shared' ? 'shared (`renderStatusCard`)' : s.shared === 'mixed' ? 'shared **+ hand-rolled tail**' : '**divergent**'} |\n`
+})
+md += '\n---\n\n'
+
+for (const s of sections) {
+  md += `## ${s.name}\n\n`
+  md += `**Renderer:** \`${s.fn}\`\n\n`
+  md += `**When:** ${s.when}\n\n`
+  md += '```\n' + vis(s.out) + '\n```\n\n---\n\n'
+}
+
+process.stdout.write(md)

--- a/telegram-plugin/status-no-truncate.ts
+++ b/telegram-plugin/status-no-truncate.ts
@@ -83,6 +83,16 @@ export const NESTED_PREFIX = '   ↳ '
  * (2+ worker) card — three U+2800 BRAILLE PATTERN BLANK, written as escapes so
  * the bytes are visible in source.
  *
+ * This is now the ONLY indent any card carries (#3839). #3820/#3821 also
+ * indented the whole worker card by one level and prefixed line 1 with `└─ `,
+ * which cost a level of horizontal space on a phone and asserted a
+ * parent/child relationship that is not always true (the worker card does not
+ * always sit below the agent card). That whole-card subordination is gone:
+ * every card is flush at the left margin, and this indent survives for the one
+ * job that genuinely needs it — telling one worker's step lines apart from the
+ * next worker's on the combined card, where the numbered row headers stay
+ * flush and their steps sit one level in.
+ *
  * ── Why not ASCII, and why not U+00A0 ────────────────────────────────
  * Card bodies reach Telegram as raw GFM markdown (`richMessage` →
  * `sendRichMessage` / `editMessageText({ markdown })`, #2669) and are parsed
@@ -125,51 +135,3 @@ export const NESTED_PREFIX = '   ↳ '
  */
 export const WORKER_STEP_INDENT = '\u2800\u2800\u2800'
 
-/**
- * Line-1 prefix that marks a card as structurally SUBORDINATE to the \ud83e\udd16 agent
- * card (#3820). Worker cards carry it; the agent card never does.
- *
- * `\u2514\u2500` (U+2514 BOX DRAWINGS LIGHT UP AND RIGHT + U+2500 BOX DRAWINGS LIGHT
- * HORIZONTAL) is ordinary ink to Telegram's server-side GFM parser: it is not
- * a line-start block trigger (`#`, `>`, `-`/`+`/`*`, `N.` \u2014 see
- * render/line-start-guard.ts for the full trigger set), so it can neither be
- * promoted to a list/quote/heading nor left-trimmed the way a leading
- * whitespace run is (the #3662 failure documented on WORKER_STEP_INDENT).
- *
- * LENGTH INVARIANT: exactly the same length as `SUBORDINATE_LINE_INDENT`, so
- * the char-budget arithmetic in `fitCardToBudget` charges one flat per-line
- * cost instead of special-casing line 1. `status-accent.test.ts` asserts it.
- */
-export const SUBORDINATE_HEADER_PREFIX = '\u2514\u2500 '
-
-/**
- * Left indent applied to EVERY line of a subordinate (worker) card after
- * line 1 \u2014 the whole card block sits one level in from the agent card's left
- * margin, so "parent vs child" is readable from the block's SHAPE at a glance
- * on a phone, not from reading its label (#3820).
- *
- * Same U+2800 run as `WORKER_STEP_INDENT` and for the same live-verified
- * reason (category So, not Zs \u2192 survives Telegram's inline left-trim; ASCII
- * spaces and U+00A0 both render flat). Aliased rather than re-declared so the
- * two indents can never drift to different glyphs.
- *
- * On the combined (2+ worker) card this composes with `WORKER_STEP_INDENT`:
- * chrome / row headers land at one level, their steps at two.
- */
-export const SUBORDINATE_LINE_INDENT = WORKER_STEP_INDENT
-
-/**
- * Apply subordinate-card nesting to a card's pre-rendered lines: line 1 gets
- * `SUBORDINATE_HEADER_PREFIX`, every later line gets `SUBORDINATE_LINE_INDENT`.
- *
- * Prefixes go OUTSIDE the markdown spans (lines arrive already wrapped in
- * `**` / `_` / `~~`), exactly like `renderStepFeed`'s `indent` parameter, so a
- * prefix can never land inside an emphasis run and break it.
- *
- * Pure; returns a new array. Empty in \u2192 empty out.
- */
-export function nestSubordinateCardLines(lines: string[]): string[] {
-  return lines.map((line, i) =>
-    i === 0 ? `${SUBORDINATE_HEADER_PREFIX}${line}` : `${SUBORDINATE_LINE_INDENT}${line}`,
-  )
-}

--- a/telegram-plugin/status-no-truncate.ts
+++ b/telegram-plugin/status-no-truncate.ts
@@ -83,7 +83,7 @@ export const NESTED_PREFIX = '   ↳ '
  * (2+ worker) card — three U+2800 BRAILLE PATTERN BLANK, written as escapes so
  * the bytes are visible in source.
  *
- * This is now the ONLY indent any card carries (#3839). #3820/#3821 also
+ * This is now the ONLY indent any card carries (#3842). #3820/#3821 also
  * indented the whole worker card by one level and prefixed line 1 with `└─ `,
  * which cost a level of horizontal space on a phone and asserted a
  * parent/child relationship that is not always true (the worker card does not

--- a/telegram-plugin/tests/card-type-distinguishability.test.ts
+++ b/telegram-plugin/tests/card-type-distinguishability.test.ts
@@ -1,5 +1,5 @@
 /**
- * #3839 — every status card is FLUSH at the left margin, and the only
+ * #3842 — every status card is FLUSH at the left margin, and the only
  * indentation any card carries is the step indent that separates one worker's
  * steps from the next worker's on the combined (2+ worker) card.
  *
@@ -13,7 +13,7 @@
  * plus the numbered row headers.
  *
  * These tests assert the RENDERED OUTPUT of the real renderers, and they fail
- * on the pre-#3839 shape (which put `└─ ` on line 1 and U+2800 on every other
+ * on the pre-#3842 shape (which put `└─ ` on line 1 and U+2800 on every other
  * line of both worker surfaces).
  *
  * What is NOT asserted here any more, deliberately: that no rendered line is
@@ -40,7 +40,7 @@ function lines(card: string): string[] {
 /** The exact scenario from #3820: parent narrating the task it delegated. */
 const STEPS = ['PR 2502 details', 'Commits since v0.8.5']
 
-/** The card-level chrome #3839 removed. Asserted absent, never re-emitted. */
+/** The card-level chrome #3842 removed. Asserted absent, never re-emitted. */
 const REMOVED_HEADER_PREFIX = '└─ '
 
 function agentCard(): string {
@@ -124,7 +124,7 @@ function everyWorkerSurface(): Array<{ name: string; card: string }> {
   ]
 }
 
-describe('#3839 every card is flush at the left margin', () => {
+describe('#3842 every card is flush at the left margin', () => {
   it('emits no `└─ ` header prefix on any surface', () => {
     for (const { name, card } of [{ name: 'agent', card: agentCard() }, ...everyWorkerSurface()]) {
       expect(card.includes(REMOVED_HEADER_PREFIX), `${name} card carries └─`).toBe(false)
@@ -132,7 +132,7 @@ describe('#3839 every card is flush at the left margin', () => {
   })
 
   it('leaves every line of the SINGLE-worker card unindented', () => {
-    // Pre-#3839 line 1 started `└─ ` and lines 2..n started with a U+2800 run.
+    // Pre-#3842 line 1 started `└─ ` and lines 2..n started with a U+2800 run.
     const surfaces = everyWorkerSurface()
     for (const name of [
       'running',
@@ -169,7 +169,7 @@ describe('#3839 every card is flush at the left margin', () => {
   })
 })
 
-describe('#3839 the combined card keeps exactly ONE level of indent', () => {
+describe('#3842 the combined card keeps exactly ONE level of indent', () => {
   it('puts the glance line and row headers flush', () => {
     const l = lines(combinedCard())
     expect(l[0]).toBe('🛠 **WORKERS** · _2 running · oldest 55s · 13 tools_')
@@ -184,7 +184,7 @@ describe('#3839 the combined card keeps exactly ONE level of indent', () => {
     expect(stepLines.length).toBeGreaterThan(0)
     for (const s of stepLines) {
       expect(s.startsWith(WORKER_STEP_INDENT)).toBe(true)
-      // The pre-#3839 double indent (SUBORDINATE_LINE_INDENT + WORKER_STEP_INDENT).
+      // The pre-#3842 double indent (SUBORDINATE_LINE_INDENT + WORKER_STEP_INDENT).
       expect(s.startsWith(WORKER_STEP_INDENT + WORKER_STEP_INDENT)).toBe(false)
     }
   })
@@ -204,7 +204,7 @@ describe('#3839 the combined card keeps exactly ONE level of indent', () => {
   })
 })
 
-describe('#3839 char-budget accounting matches the flush shape', () => {
+describe('#3842 char-budget accounting matches the flush shape', () => {
   it('keeps an oversized worker card under the wire budget', () => {
     // fitCardToBudget has its own line assembly + arithmetic. With the per-line
     // nest cost removed it must still land under the cap, and must not emit any
@@ -243,7 +243,7 @@ describe('#3839 char-budget accounting matches the flush shape', () => {
   })
 })
 
-describe('#3839 the surviving type cues', () => {
+describe('#3842 the surviving type cues', () => {
   it('uses a high-contrast caps type label on the worker card only', () => {
     const agent = agentCard()
     const worker = renderWorkerActivity(workerView())
@@ -261,14 +261,14 @@ describe('#3839 the surviving type cues', () => {
     expect(agent[0]).not.toBe(worker[0])
     expect(agent[0].startsWith('🤖 ')).toBe(true)
     expect(worker[0].startsWith('🛠 ')).toBe(true)
-    // The documented cost of #3839, pinned so a future change to it is visible:
+    // The documented cost of #3842, pinned so a future change to it is visible:
     // every line BELOW line 1 is now shared between the two cards.
     const overlap = agent.filter((a) => worker.includes(a))
     expect(overlap).toEqual(agent.slice(1))
   })
 })
 
-describe('#3839 the surviving step indent survives Telegram reality', () => {
+describe('#3842 the surviving step indent survives Telegram reality', () => {
   it('passes every card through the real outbound markdown guard byte-identical', () => {
     // richMessage() is the ONE adapter every `{ markdown }` wire send funnels
     // through (rich-send.ts) — it runs the line-start / heading / dollar-math

--- a/telegram-plugin/tests/card-type-distinguishability.test.ts
+++ b/telegram-plugin/tests/card-type-distinguishability.test.ts
@@ -1,26 +1,26 @@
 /**
- * #3820 — the 🤖 agent card and the 🛠 worker card must not be visually
- * interchangeable when both are live in one chat.
+ * #3839 — every status card is FLUSH at the left margin, and the only
+ * indentation any card carries is the step indent that separates one worker's
+ * steps from the next worker's on the combined (2+ worker) card.
  *
- * Both surfaces render through the SAME primitive (`renderStatusCard`,
- * tool-activity-summary.ts), so before this fix they were byte-for-byte the
- * same layout — two header lines, the identical `Ns · N tools · Nk tok · model`
- * stat row, the identical `✓`/`→` step trail — differing only by an emoji and
- * one word. When a parent narrates the task it delegated, the two cards' step
- * lines are literally identical strings and the pair reads as a duplicate
- * rather than as parent + child.
+ * #3820/#3821 had made the worker card structurally subordinate to the 🤖 agent
+ * card: line 1 prefixed with `└─ ` and every later line indented by a U+2800
+ * run. Ken rejected that shape — it burns a level of horizontal space on a
+ * phone, and the worker card does not always sit below the agent card, so a
+ * card-LEVEL subordination marker asserts a relationship that is not always
+ * true. Net effect of this file's expectations: everything shifted left by one
+ * level; worker-vs-worker separation is carried by the surviving step indent
+ * plus the numbered row headers.
  *
- * These tests assert the RENDERED OUTPUT differs structurally, using the same
- * inputs on both surfaces so a shared-layout regression cannot pass:
- *   - the worker card's line 1 carries `└─ ` and the agent card's never does;
- *   - every later worker line carries the subordinate indent;
- *   - with identical step text and identical stats, NO line of one card equals
- *     any line of the other.
+ * These tests assert the RENDERED OUTPUT of the real renderers, and they fail
+ * on the pre-#3839 shape (which put `└─ ` on line 1 and U+2800 on every other
+ * line of both worker surfaces).
  *
- * Plus the Telegram-reality guards: the prefixes survive the real outbound
- * markdown guard (`richMessage`) byte-identical, the indent is not whitespace
- * under any trimming rule (the #3662 lesson), and `└─` is not a line-start
- * block-construct trigger.
+ * What is NOT asserted here any more, deliberately: that no rendered line is
+ * shared between the agent card and the worker card. With whole-card nesting
+ * gone and identical step text, the two cards' BODY lines coincide byte for
+ * byte — see the explicit characterization test at the end. Line 1 (🤖 `Agent`
+ * vs 🛠 `WORKER`) is now the only type cue, which is the accepted trade.
  */
 import { describe, it, expect } from 'vitest'
 import {
@@ -29,22 +29,19 @@ import {
   renderCombinedWorkerFeed,
 } from '../tool-activity-summary.js'
 import { renderWorkerActivity, type WorkerActivityView } from '../worker-activity-feed.js'
-import {
-  SUBORDINATE_HEADER_PREFIX,
-  SUBORDINATE_LINE_INDENT,
-  WORKER_STEP_INDENT,
-  STATUS_CARD_CHAR_BUDGET,
-  nestSubordinateCardLines,
-} from '../status-no-truncate.js'
+import { WORKER_STEP_INDENT, STATUS_CARD_CHAR_BUDGET } from '../status-no-truncate.js'
 import { richMessage } from '../rich-send.js'
 
 /** Split a rendered card into display lines, dropping the hard-break padding. */
 function lines(card: string): string[] {
-  return card.split('\n').map((l) => l.replace(/[\u00A0 \t\r]+$/, ''))
+  return card.split('\n').map((l) => l.replace(/[  \t\r]+$/, ''))
 }
 
-/** The exact scenario from the issue: parent narrating the task it delegated. */
+/** The exact scenario from #3820: parent narrating the task it delegated. */
 const STEPS = ['PR 2502 details', 'Commits since v0.8.5']
+
+/** The card-level chrome #3839 removed. Asserted absent, never re-emitted. */
+const REMOVED_HEADER_PREFIX = '└─ '
 
 function agentCard(): string {
   const out = renderActivityFeed(STEPS, false, '', undefined, {
@@ -73,116 +70,145 @@ function workerView(over: Partial<WorkerActivityView> = {}): WorkerActivityView 
   } as WorkerActivityView
 }
 
-describe('#3820 agent vs worker card distinguishability', () => {
-  it('marks the worker card subordinate on line 1 and never the agent card', () => {
-    const agent = lines(agentCard())
-    const worker = lines(renderWorkerActivity(workerView()))
+function combinedCard(): string {
+  const card = renderCombinedWorkerFeed(
+    [
+      {
+        description: 'Check upstream hindsight changes',
+        elapsedMs: 55_000,
+        toolCount: 9,
+        currentStep: 'Commits since v0.8.5',
+        historyLines: STEPS,
+        ordinal: 1,
+      },
+      {
+        description: 'Fix the card renderer',
+        elapsedMs: 30_000,
+        toolCount: 4,
+        currentStep: 'Reading render.ts',
+        historyLines: ['Reading render.ts'],
+        ordinal: 2,
+      },
+    ],
+    { maxRows: 4 },
+  )
+  expect(card).not.toBeNull()
+  return card as string
+}
 
-    expect(worker[0].startsWith(SUBORDINATE_HEADER_PREFIX)).toBe(true)
-    expect(agent[0].startsWith(SUBORDINATE_HEADER_PREFIX)).toBe(false)
-    // The agent card stays flush at the left margin on EVERY line — it is the
-    // parent, so nothing about it may read as nested.
-    for (const l of agent) {
-      expect(l.startsWith(SUBORDINATE_HEADER_PREFIX)).toBe(false)
-      expect(l.startsWith(SUBORDINATE_LINE_INDENT)).toBe(false)
+/** Every worker surface, in each of its render states, as rendered strings. */
+function everyWorkerSurface(): Array<{ name: string; card: string }> {
+  return [
+    { name: 'running', card: renderWorkerActivity(workerView()) },
+    {
+      name: 'just dispatched',
+      card: renderWorkerActivity(workerView({ narrativeLines: [], latestSummary: '' })),
+    },
+    {
+      name: 'done + result block',
+      card: renderWorkerActivity(
+        workerView({ state: 'done', latestSummary: 'Rebased and opened the PR.' }),
+      ),
+    },
+    {
+      name: 'failed + result block',
+      card: renderWorkerActivity(
+        workerView({ state: 'failed', latestSummary: 'Scoped tests went red.' }),
+      ),
+    },
+    {
+      name: 'incomplete',
+      card: renderWorkerActivity(workerView({ state: 'incomplete', latestSummary: '' })),
+    },
+    { name: 'combined (2 workers)', card: combinedCard() },
+  ]
+}
+
+describe('#3839 every card is flush at the left margin', () => {
+  it('emits no `└─ ` header prefix on any surface', () => {
+    for (const { name, card } of [{ name: 'agent', card: agentCard() }, ...everyWorkerSurface()]) {
+      expect(card.includes(REMOVED_HEADER_PREFIX), `${name} card carries └─`).toBe(false)
     }
   })
 
-  it('indents every worker card line after line 1', () => {
-    const worker = lines(renderWorkerActivity(workerView()))
-    expect(worker.length).toBeGreaterThan(2)
-    for (const l of worker.slice(1)) {
-      expect(l.startsWith(SUBORDINATE_LINE_INDENT)).toBe(true)
+  it('leaves every line of the SINGLE-worker card unindented', () => {
+    // Pre-#3839 line 1 started `└─ ` and lines 2..n started with a U+2800 run.
+    const surfaces = everyWorkerSurface()
+    for (const name of [
+      'running',
+      'just dispatched',
+      'done + result block',
+      'failed + result block',
+      'incomplete',
+    ]) {
+      const card = surfaces.find((s) => s.name === name)?.card as string
+      const l = lines(card)
+      expect(l.length).toBeGreaterThan(1)
+      for (const line of l) {
+        expect(line.startsWith(WORKER_STEP_INDENT), `${name}: "${line}"`).toBe(false)
+      }
     }
   })
 
-  it('shares no rendered line between the two cards even with identical steps and stats', () => {
-    // This is the issue's actual symptom: the parent narrates the task it
-    // delegated, so the step text overlaps. On the pre-#3820 renderer the
-    // stat row AND both step lines were byte-identical across the two cards.
-    const agent = lines(agentCard())
-    const worker = lines(renderWorkerActivity(workerView()))
-    const overlap = agent.filter((a) => worker.includes(a))
-    expect(overlap).toEqual([])
+  it('keeps the just-dispatched `starting…` tail flush too', () => {
+    // The one render state a user always sees first takes a hand-rolled append
+    // path outside renderStatusCard — the place a shape change silently misses.
+    const l = lines(renderWorkerActivity(workerView({ narrativeLines: [], latestSummary: '' })))
+    expect(l[0].startsWith('🛠 **WORKER**')).toBe(true)
+    expect(l[l.length - 1]).toBe('_starting…_')
   })
 
-  it('uses a high-contrast caps type label on the worker card only', () => {
-    const agent = agentCard()
-    const worker = renderWorkerActivity(workerView())
-    expect(worker).toContain('🛠 **WORKER**')
-    expect(agent).toContain('🤖 **Agent**')
-    expect(agent).not.toContain('WORKER')
-  })
-
-  it('keeps the terminal (result-block) worker render subordinate too', () => {
-    const worker = lines(
+  it('keeps the terminal result block flush', () => {
+    const l = lines(
       renderWorkerActivity(
         workerView({ state: 'done', latestSummary: 'Rebased and opened the PR.' }),
       ),
     )
-    expect(worker[0].startsWith(SUBORDINATE_HEADER_PREFIX)).toBe(true)
-    for (const l of worker.slice(1)) {
-      expect(l.startsWith(SUBORDINATE_LINE_INDENT)).toBe(true)
-    }
-    // The result block is present and nested, not floated back to the margin.
-    expect(worker.some((l) => l.startsWith(`${SUBORDINATE_LINE_INDENT}✅ `))).toBe(true)
+    expect(l.some((x) => x.startsWith('✅ '))).toBe(true)
+    expect(l.some((x) => x.startsWith(`${WORKER_STEP_INDENT}✅ `))).toBe(false)
   })
+})
 
-  it('keeps the just-dispatched (starting…) worker render subordinate', () => {
-    // The first state a user ever sees for a worker takes a hand-rolled append
-    // path outside renderStatusCard — the one place a nesting fix can silently
-    // miss.
-    const worker = lines(
-      renderWorkerActivity(workerView({ narrativeLines: [], latestSummary: '' })),
-    )
-    expect(worker[0].startsWith(SUBORDINATE_HEADER_PREFIX)).toBe(true)
-    expect(worker[worker.length - 1]).toBe(`${SUBORDINATE_LINE_INDENT}_starting…_`)
-  })
-
-  it('nests the combined (2+ worker) card and keeps its internal hierarchy', () => {
-    const card = renderCombinedWorkerFeed(
-      [
-        {
-          description: 'Check upstream hindsight changes',
-          elapsedMs: 55_000,
-          toolCount: 9,
-          currentStep: 'Commits since v0.8.5',
-          historyLines: STEPS,
-          ordinal: 1,
-        },
-        {
-          description: 'Fix the card renderer',
-          elapsedMs: 30_000,
-          toolCount: 4,
-          currentStep: 'Reading render.ts',
-          historyLines: ['Reading render.ts'],
-          ordinal: 2,
-        },
-      ],
-      { maxRows: 4 },
-    )
-    expect(card).not.toBeNull()
-    const l = lines(card as string)
-    expect(l[0]).toBe(`${SUBORDINATE_HEADER_PREFIX}🛠 **WORKERS** · _2 running · oldest 55s · 13 tools_`)
-    // Row headers sit at one level; their steps stay one level deeper, so the
-    // card's own parent/child structure survives the shift right.
+describe('#3839 the combined card keeps exactly ONE level of indent', () => {
+  it('puts the glance line and row headers flush', () => {
+    const l = lines(combinedCard())
+    expect(l[0]).toBe('🛠 **WORKERS** · _2 running · oldest 55s · 13 tools_')
     const rowHeaders = l.filter((x) => x.includes('**1. ') || x.includes('**2. '))
     expect(rowHeaders.length).toBe(2)
-    for (const h of rowHeaders) {
-      expect(h.startsWith(SUBORDINATE_LINE_INDENT)).toBe(true)
-      expect(h.startsWith(SUBORDINATE_LINE_INDENT + WORKER_STEP_INDENT)).toBe(false)
-    }
+    for (const h of rowHeaders) expect(h.startsWith(WORKER_STEP_INDENT)).toBe(false)
+  })
+
+  it('indents step lines exactly one level — never two', () => {
+    const l = lines(combinedCard())
     const stepLines = l.filter((x) => x.includes('→ ') || x.includes('✓ '))
     expect(stepLines.length).toBeGreaterThan(0)
     for (const s of stepLines) {
-      expect(s.startsWith(SUBORDINATE_LINE_INDENT + WORKER_STEP_INDENT)).toBe(true)
+      expect(s.startsWith(WORKER_STEP_INDENT)).toBe(true)
+      // The pre-#3839 double indent (SUBORDINATE_LINE_INDENT + WORKER_STEP_INDENT).
+      expect(s.startsWith(WORKER_STEP_INDENT + WORKER_STEP_INDENT)).toBe(false)
     }
   })
 
-  it('stays under the wire char budget on the subordinate over-budget path', () => {
-    // fitCardToBudget has its own line assembly + its own arithmetic; the
-    // per-line nesting cost must be charged there or an oversized worker card
-    // can overflow the wire cap.
+  it('puts the `+M more working…` spill line flush', () => {
+    const rows = Array.from({ length: 5 }, (_, i) => ({
+      description: `task ${i + 1}`,
+      elapsedMs: 10_000,
+      toolCount: 1,
+      currentStep: 'working',
+      historyLines: ['working'],
+      ordinal: i + 1,
+    }))
+    const card = renderCombinedWorkerFeed(rows, { maxRows: 2 }) as string
+    const spill = lines(card).find((x) => x.includes('more working…'))
+    expect(spill).toBe('_+3 more working…_')
+  })
+})
+
+describe('#3839 char-budget accounting matches the flush shape', () => {
+  it('keeps an oversized worker card under the wire budget', () => {
+    // fitCardToBudget has its own line assembly + arithmetic. With the per-line
+    // nest cost removed it must still land under the cap, and must not emit any
+    // chrome the card no longer carries.
     const huge = Array.from({ length: 500 }, (_, i) => `${i} `.repeat(100))
     const card = renderStatusCard({
       header: {
@@ -194,41 +220,60 @@ describe('#3820 agent vs worker card distinguishability', () => {
         state: 'running',
       },
       steps: huge,
-      subordinate: true,
+      historyWindow: 6,
     })
     expect(card).not.toBeNull()
-    expect((card as string).length).toBeLessThanOrEqual(STATUS_CARD_CHAR_BUDGET)
-    expect((card as string).startsWith(SUBORDINATE_HEADER_PREFIX)).toBe(true)
+    const s = card as string
+    expect(s.length).toBeLessThanOrEqual(STATUS_CARD_CHAR_BUDGET)
+    expect(s.includes(REMOVED_HEADER_PREFIX)).toBe(false)
+    for (const l of lines(s)) expect(l.startsWith(WORKER_STEP_INDENT)).toBe(false)
   })
 
-  it('leaves a non-subordinate card byte-identical to the un-nested render', () => {
-    const opts = {
-      header: {
-        emoji: '🤖',
-        label: 'Agent',
-        elapsedMs: 1000,
-        toolCount: 2,
-        state: 'running' as const,
-      },
-      steps: STEPS,
-    }
-    expect(renderStatusCard({ ...opts, subordinate: false })).toBe(renderStatusCard(opts))
+  it('keeps an oversized combined card under the wire budget', () => {
+    const rows = Array.from({ length: 6 }, (_, i) => ({
+      description: 'D'.repeat(72),
+      elapsedMs: 10_000,
+      toolCount: 3,
+      currentStep: 'x',
+      historyLines: Array.from({ length: 6 }, (_, k) => `${'s'.repeat(180)}-${i}-${k}`),
+      ordinal: i + 1,
+    }))
+    const card = renderCombinedWorkerFeed(rows, { maxRows: 6 }) as string
+    expect(card.length).toBeLessThanOrEqual(STATUS_CARD_CHAR_BUDGET)
   })
 })
 
-describe('#3820 subordinate prefixes survive Telegram reality', () => {
-  it('passes through the real outbound markdown guard byte-identical', () => {
+describe('#3839 the surviving type cues', () => {
+  it('uses a high-contrast caps type label on the worker card only', () => {
+    const agent = agentCard()
+    const worker = renderWorkerActivity(workerView())
+    expect(worker).toContain('🛠 **WORKER**')
+    expect(agent).toContain('🤖 **Agent**')
+    expect(agent).not.toContain('WORKER')
+  })
+
+  it('distinguishes the two cards on LINE 1 — the only remaining cue', () => {
+    // Characterization, not aspiration: with whole-card nesting gone and
+    // identical step text + stats, the two cards' BODY lines coincide byte for
+    // byte. Line 1 is doing all of the work, so it must never converge.
+    const agent = lines(agentCard())
+    const worker = lines(renderWorkerActivity(workerView()))
+    expect(agent[0]).not.toBe(worker[0])
+    expect(agent[0].startsWith('🤖 ')).toBe(true)
+    expect(worker[0].startsWith('🛠 ')).toBe(true)
+    // The documented cost of #3839, pinned so a future change to it is visible:
+    // every line BELOW line 1 is now shared between the two cards.
+    const overlap = agent.filter((a) => worker.includes(a))
+    expect(overlap).toEqual(agent.slice(1))
+  })
+})
+
+describe('#3839 the surviving step indent survives Telegram reality', () => {
+  it('passes every card through the real outbound markdown guard byte-identical', () => {
     // richMessage() is the ONE adapter every `{ markdown }` wire send funnels
     // through (rich-send.ts) — it runs the line-start / heading / dollar-math
-    // guards. A prefix that gets escaped there would render as literal markup.
-    for (const card of [
-      agentCard(),
-      renderWorkerActivity(workerView()),
-      renderCombinedWorkerFeed(
-        [{ description: 'a', elapsedMs: 1, toolCount: 1, currentStep: 'b', ordinal: 1 }],
-        { maxRows: 4 },
-      ) as string,
-    ]) {
+    // guards. Chrome that got escaped there would render as literal markup.
+    for (const { card } of [{ card: agentCard() }, ...everyWorkerSurface()]) {
       expect(richMessage(card).markdown).toBe(card)
     }
   })
@@ -237,32 +282,10 @@ describe('#3820 subordinate prefixes survive Telegram reality', () => {
     // U+00A0 shipped in #3662 and was INERT: Telegram left-trims a leading
     // Unicode-whitespace run, and U+00A0 is category Zs. Assert the PROPERTY,
     // not the bytes — a byte-only assertion is what let #3662 ship green.
-    for (const ch of Array.from(SUBORDINATE_LINE_INDENT)) {
+    for (const ch of Array.from(WORKER_STEP_INDENT)) {
       expect(/\s/.test(ch)).toBe(false)
       expect(/\p{White_Space}/u.test(ch)).toBe(false)
       expect(/\p{Zs}/u.test(ch)).toBe(false)
     }
-  })
-
-  it('uses a header prefix that is ink, not a line-start block trigger', () => {
-    const first = SUBORDINATE_HEADER_PREFIX[0]
-    // Not whitespace (would be trimmed), and not one of the GFM line-start
-    // block-construct triggers guarded in render/line-start-guard.ts.
-    expect(/\s/.test(first)).toBe(false)
-    expect('#>-+*'.includes(first)).toBe(false)
-    expect(/^\d+[.)]/.test(SUBORDINATE_HEADER_PREFIX)).toBe(false)
-  })
-
-  it('charges one flat per-line cost: header prefix and indent are equal length', () => {
-    // fitCardToBudget's arithmetic depends on this invariant.
-    expect(SUBORDINATE_HEADER_PREFIX.length).toBe(SUBORDINATE_LINE_INDENT.length)
-  })
-
-  it('nestSubordinateCardLines is pure and handles the empty case', () => {
-    expect(nestSubordinateCardLines([])).toEqual([])
-    expect(nestSubordinateCardLines(['a', 'b'])).toEqual([
-      `${SUBORDINATE_HEADER_PREFIX}a`,
-      `${SUBORDINATE_LINE_INDENT}b`,
-    ])
   })
 })

--- a/telegram-plugin/tests/pinned-card-collapse.test.ts
+++ b/telegram-plugin/tests/pinned-card-collapse.test.ts
@@ -33,7 +33,6 @@ import {
   STATUS_CARD_CHAR_BUDGET,
   STATUS_LINE_MAX,
   WORKER_STEP_INDENT,
-  SUBORDINATE_LINE_INDENT,
 } from '../status-no-truncate.js'
 
 /**
@@ -135,31 +134,28 @@ describe('combined worker card survives the pinned-bar collapse (#3666)', () => 
 
   it('kills the exact artifacts from the report', () => {
     const collapsed = collapsePreview(body)
-    // 1. the count/ordinal collision — glance line into row 1's ordinal.
-    //    Since #3820 a worker header also carries the card-level
-    //    SUBORDINATE_LINE_INDENT (the whole worker card nests under the 🤖
-    //    agent card), so this seam is separator + card indent.
+    // 1. the count/ordinal collision — glance line into row 1's ordinal. Since
+    //    #3839 the row header is FLUSH (the #3820 card-level indent is gone),
+    //    so the separator is the ONLY thing holding this seam apart.
     //    (The reported spelling was `3 running1.`; with the packed glance line
     //    the same seam now reads `… 512.3k tok` -> `1. Fix issue`, so assert on
     //    the CURRENT last token of line 1 — an assertion on the old spelling
     //    alone would be vacuously green.)
     expect(collapsed).not.toContain('running1.')
     expect(collapsed).not.toContain('tok1.')
-    expect(collapsed).toContain(`tok${NB}${SUBORDINATE_LINE_INDENT}1. Fix issue`)
-    // 2. the mid-word ✓ (model tag running into the step trail). Here the
-    //    separator and WORKER_STEP_INDENT (three U+2800 leading a step line)
-    //    stack, so the seam is separator + indent, asserted against both
-    //    constants rather than a hardcoded run of spaces.
+    expect(collapsed).toContain(`tok${NB}1. Fix issue`)
+    // 2. the mid-word ✓ (model tag running into the step trail). A step line
+    //    still leads with WORKER_STEP_INDENT (three U+2800), so this seam is
+    //    separator + step indent — asserted against the constant rather than a
+    //    hardcoded run.
     expect(collapsed).not.toContain('opus 5✓')
-    expect(collapsed).toContain(`opus 5${NB}${SUBORDINATE_LINE_INDENT}${WORKER_STEP_INDENT}✓`)
+    expect(collapsed).toContain(`opus 5${NB}${WORKER_STEP_INDENT}✓`)
     // 3. the step trail running into the next step, and into the next row's
-    //    header (post-#3820 that last seam is separator + card indent).
+    //    header (post-#3839 that last seam is the separator alone).
     expect(collapsed).not.toContain('gateway.ts→')
-    expect(collapsed).toContain(
-      `gateway.ts${NB}${SUBORDINATE_LINE_INDENT}${WORKER_STEP_INDENT}→`,
-    )
+    expect(collapsed).toContain(`gateway.ts${NB}${WORKER_STEP_INDENT}→`)
     expect(collapsed).not.toContain('search2.')
-    expect(collapsed).toContain(`search${NB}${SUBORDINATE_LINE_INDENT}2.`)
+    expect(collapsed).toContain(`search${NB}2.`)
   })
 
   it('leads with a self-contained glance that ends in a unit word, not a bare number', () => {
@@ -178,13 +174,10 @@ describe('combined worker card survives the pinned-bar collapse (#3666)', () => 
     // show the collapsed preview mashes again. Without this, the assertions
     // above could all be passing for reasons unrelated to the fix.
     //
-    // The control runs on the 🤖 AGENT card, not the worker card: since #3820
-    // every line of a worker card after line 1 carries a leading
-    // SUBORDINATE_LINE_INDENT, which separates its seams independently of the
-    // collapse separator — so a worker-card control would no longer isolate the
-    // separator's contribution. The agent card is the surface where the
-    // separator is still the ONLY thing holding the seams apart, which is
-    // exactly what this control must measure.
+    // The control runs on the 🤖 AGENT card. Post-#3839 the single-worker card
+    // is flush too, so either would isolate the separator's contribution; the
+    // agent card is kept because it has no step indent on ANY line, so no
+    // future indent change can quietly make this control vacuous.
     const agent = renderActivityFeed([
       'Reading gateway.ts',
       'Searching memory',
@@ -228,7 +221,9 @@ describe('single-worker / agent status card survives the collapse too (#3666)', 
     expectNoMashedSeams(body)
     const collapsed = collapsePreview(body)
     expect(collapsed).not.toContain('toolsstarting')
-    expect(collapsed).toContain(`0 tools${NB}${SUBORDINATE_LINE_INDENT}starting`)
+    // #3839: the single-worker card is flush, so the separator alone holds the
+    // hand-rolled `starting…` seam apart — nothing else masks a regression.
+    expect(collapsed).toContain(`0 tools${NB}starting`)
   })
 
   it('the nested child block stays separated even though its indent is ASCII (#3668)', () => {

--- a/telegram-plugin/tests/pinned-card-collapse.test.ts
+++ b/telegram-plugin/tests/pinned-card-collapse.test.ts
@@ -135,7 +135,7 @@ describe('combined worker card survives the pinned-bar collapse (#3666)', () => 
   it('kills the exact artifacts from the report', () => {
     const collapsed = collapsePreview(body)
     // 1. the count/ordinal collision — glance line into row 1's ordinal. Since
-    //    #3839 the row header is FLUSH (the #3820 card-level indent is gone),
+    //    #3842 the row header is FLUSH (the #3820 card-level indent is gone),
     //    so the separator is the ONLY thing holding this seam apart.
     //    (The reported spelling was `3 running1.`; with the packed glance line
     //    the same seam now reads `… 512.3k tok` -> `1. Fix issue`, so assert on
@@ -151,7 +151,7 @@ describe('combined worker card survives the pinned-bar collapse (#3666)', () => 
     expect(collapsed).not.toContain('opus 5✓')
     expect(collapsed).toContain(`opus 5${NB}${WORKER_STEP_INDENT}✓`)
     // 3. the step trail running into the next step, and into the next row's
-    //    header (post-#3839 that last seam is the separator alone).
+    //    header (post-#3842 that last seam is the separator alone).
     expect(collapsed).not.toContain('gateway.ts→')
     expect(collapsed).toContain(`gateway.ts${NB}${WORKER_STEP_INDENT}→`)
     expect(collapsed).not.toContain('search2.')
@@ -174,7 +174,7 @@ describe('combined worker card survives the pinned-bar collapse (#3666)', () => 
     // show the collapsed preview mashes again. Without this, the assertions
     // above could all be passing for reasons unrelated to the fix.
     //
-    // The control runs on the 🤖 AGENT card. Post-#3839 the single-worker card
+    // The control runs on the 🤖 AGENT card. Post-#3842 the single-worker card
     // is flush too, so either would isolate the separator's contribution; the
     // agent card is kept because it has no step indent on ANY line, so no
     // future indent change can quietly make this control vacuous.
@@ -221,7 +221,7 @@ describe('single-worker / agent status card survives the collapse too (#3666)', 
     expectNoMashedSeams(body)
     const collapsed = collapsePreview(body)
     expect(collapsed).not.toContain('toolsstarting')
-    // #3839: the single-worker card is flush, so the separator alone holds the
+    // #3842: the single-worker card is flush, so the separator alone holds the
     // hand-rolled `starting…` seam apart — nothing else masks a regression.
     expect(collapsed).toContain(`0 tools${NB}starting`)
   })

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -76,7 +76,7 @@ describe('renderWorkerActivity', () => {
 
   it('renders the native header + running status + step feed', () => {
     const out = renderWorkerActivity(view())
-    // #3839: flush at the left margin — no `└─ ` card-level prefix.
+    // #3842: flush at the left margin — no `└─ ` card-level prefix.
     expect(out.startsWith('🛠 **WORKER** · _research competitors_')).toBe(true)
     // Unified header: running shows "<elapsed> · N tools" (no "running ·" word).
     expect(out).toContain('_10s · 3 tools_')
@@ -101,7 +101,7 @@ describe('renderWorkerActivity', () => {
 
   it('shows a "starting…" line when no step has run yet', () => {
     const out = renderWorkerActivity(view({ lastTool: null, latestSummary: '' }))
-    // #3839: flush at the left margin — no `└─ ` card-level prefix.
+    // #3842: flush at the left margin — no `└─ ` card-level prefix.
     expect(out.startsWith('🛠 **WORKER**')).toBe(true)
     expect(out).toContain('starting…')
     expect(out).not.toContain('→')

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -76,7 +76,8 @@ describe('renderWorkerActivity', () => {
 
   it('renders the native header + running status + step feed', () => {
     const out = renderWorkerActivity(view())
-    expect(out).toContain('└─ 🛠 **WORKER** · _research competitors_')
+    // #3839: flush at the left margin — no `└─ ` card-level prefix.
+    expect(out.startsWith('🛠 **WORKER** · _research competitors_')).toBe(true)
     // Unified header: running shows "<elapsed> · N tools" (no "running ·" word).
     expect(out).toContain('_10s · 3 tools_')
     expect(out).toContain('3 tools')
@@ -100,7 +101,8 @@ describe('renderWorkerActivity', () => {
 
   it('shows a "starting…" line when no step has run yet', () => {
     const out = renderWorkerActivity(view({ lastTool: null, latestSummary: '' }))
-    expect(out).toContain('└─ 🛠 **WORKER**')
+    // #3839: flush at the left margin — no `└─ ` card-level prefix.
+    expect(out.startsWith('🛠 **WORKER**')).toBe(true)
     expect(out).toContain('starting…')
     expect(out).not.toContain('→')
   })
@@ -121,7 +123,7 @@ describe('renderWorkerActivity', () => {
     const out = renderWorkerActivity(
       view({ state: 'done', toolCount: 5, latestSummary: 'PR #21 opened' }),
     )
-    expect(out).toContain('└─ 🛠 **WORKER** · _research competitors_')
+    expect(out).toContain('🛠 **WORKER** · _research competitors_')
     // Unified done header: "done · N tools · <elapsed>".
     expect(out).toContain('_done · 5 tools · ')
     expect(out).toContain('─────')
@@ -227,7 +229,7 @@ describe('renderWorkerActivity', () => {
         narrativeLines: ['- ran the **full** suite', '`git push`'],
       }),
     )
-    expect(running).toContain('└─ 🛠 **WORKER** · _Build the sync_')
+    expect(running).toContain('🛠 **WORKER** · _Build the sync_')
     expect(running).toContain('ran the full suite')
     expect(running).toContain('git push')
     // The CONTENT bold/code markers were stripped — no `**full**`, no backticks.
@@ -298,7 +300,7 @@ describe('createWorkerActivityFeed', () => {
     // #2669: the worker feed body is raw GFM markdown sent through the rich
     // path (the gateway wires sendMessage → sendRichMessage). No parse_mode.
     expect(bot.sent[0].opts?.parse_mode).toBeUndefined()
-    expect(bot.sent[0].text).toContain('└─ 🛠 **WORKER**')
+    expect(bot.sent[0].text).toContain('🛠 **WORKER**')
     expect(feed.has('w1')).toBe(true)
   })
 
@@ -932,7 +934,7 @@ describe('createWorkerActivityFeed — heartbeat', () => {
     await drain()
     expect(bot.sent).toHaveLength(1)
     expect(feed.messageIdOf('w1')).toBe(1000)
-    expect(bot.sent[0].text).toContain('└─ 🛠 **WORKER**')
+    expect(bot.sent[0].text).toContain('🛠 **WORKER**')
 
     // And it keeps updating: a later heartbeat edits the message with a
     // climbing `· Ns` suffix so the still-alive worker visibly advances.
@@ -1328,7 +1330,7 @@ describe('header row + rolling overflow survive in the unified worker render', (
     )
     const out = renderWorkerActivity(view({ narrativeLines, toolCount: 7 }))
 
-    expect(out).toContain('└─ 🛠 **WORKER**')
+    expect(out).toContain('🛠 **WORKER**')
     // Unified running status line.
     expect(out).toContain('_10s · 7 tools_')
     expect(out).toContain('7 tools')
@@ -1344,7 +1346,7 @@ describe('header row + rolling overflow survive in the unified worker render', (
 
     expect(out.length).toBeLessThanOrEqual(4096)
     expect(out).toContain('earlier…')
-    expect(out).toContain('└─ 🛠 **WORKER**')
+    expect(out).toContain('🛠 **WORKER**')
     expect(out).toContain('_10s · ')
   })
 
@@ -1359,7 +1361,7 @@ describe('header row + rolling overflow survive in the unified worker render', (
     expect(out.length).toBeLessThanOrEqual(4096)
     const hasBullet = out.includes('→') || out.includes('✓')
     expect(hasBullet).toBe(true)
-    expect(out).toContain('└─ 🛠 **WORKER**')
+    expect(out).toContain('🛠 **WORKER**')
     expect(out).toContain('_10s · ')
     expect(isValidWorkerMarkdown(out)).toBe(true)
   })
@@ -1525,7 +1527,7 @@ describe('worker-feed send-gate shed contract', () => {
     await feed.update('w1', 'chat', view({ elapsedMs: clock }))
     expect(bot.sendCalls).toBe(1)
     expect(bot.sent).toHaveLength(1)
-    expect(bot.sent[0].text).toContain('└─ 🛠 **WORKER**')
+    expect(bot.sent[0].text).toContain('🛠 **WORKER**')
     expect(feed.has('w1')).toBe(true)
   })
 

--- a/telegram-plugin/tests/worker-feed-coalesce.test.ts
+++ b/telegram-plugin/tests/worker-feed-coalesce.test.ts
@@ -6,12 +6,7 @@ import {
   type WorkerActivityView,
 } from '../worker-activity-feed.js'
 import { renderCombinedWorkerFeed, combinedHistoryDepth } from '../tool-activity-summary.js'
-import {
-  STATUS_CARD_CHAR_BUDGET,
-  WORKER_STEP_INDENT,
-  SUBORDINATE_HEADER_PREFIX,
-  SUBORDINATE_LINE_INDENT,
-} from '../status-no-truncate.js'
+import { STATUS_CARD_CHAR_BUDGET, WORKER_STEP_INDENT } from '../status-no-truncate.js'
 import { COLLAPSE_SAFE_SEPARATOR } from '../card-format.js'
 import { richMessage } from '../rich-send.js'
 import { parseRichEntities, validateRichMarkdown } from './rich-markdown-oracle.js'
@@ -1292,22 +1287,22 @@ describe('combined worker card — steps indent under their worker (U+2800)', ()
     // Load-bearing: the exact indent bytes. `WORKER_STEP_INDENT` is U+2800 ×3;
     // a plain-ASCII `'   '` indent fails this assertion, so does the U+00A0 run
     // #3662 shipped, and so does flat output with no prefix at all.
-    // Since #3820 the whole card is nested one level under the 🤖 agent card,
-    // so a step sits at SUBORDINATE_LINE_INDENT + WORKER_STEP_INDENT while its
-    // worker header sits at SUBORDINATE_LINE_INDENT alone — the RELATIVE
-    // one-level nesting this test guards is unchanged, just shifted right.
+    // #3839 removed the whole-card nesting #3820 added, so a step sits at
+    // EXACTLY one WORKER_STEP_INDENT — not two — and its worker header sits
+    // flush at the left margin. The RELATIVE one-level nesting this test guards
+    // is unchanged; the whole block shifted back left.
     for (const l of stepLines) {
-      expect(l.startsWith(SUBORDINATE_LINE_INDENT + WORKER_STEP_INDENT)).toBe(true)
+      expect(l.startsWith(WORKER_STEP_INDENT)).toBe(true)
+      expect(l.startsWith(WORKER_STEP_INDENT + WORKER_STEP_INDENT)).toBe(false)
       expect(l.startsWith(BLANK)).toBe(true)
       expect(l.startsWith(' ')).toBe(false)
       expect(l.startsWith(NBSP)).toBe(false)
     }
     // Workers stay one level ABOVE their steps so the nesting reads as nesting.
     for (const l of headerLines) {
-      expect(l.startsWith(SUBORDINATE_LINE_INDENT)).toBe(true)
-      expect(l.startsWith(SUBORDINATE_LINE_INDENT + WORKER_STEP_INDENT)).toBe(false)
+      expect(l.startsWith(WORKER_STEP_INDENT)).toBe(false)
     }
-    expect(lines[0].startsWith(`${SUBORDINATE_HEADER_PREFIX}🛠`)).toBe(true)
+    expect(lines[0].startsWith('🛠')).toBe(true)
   })
 
   it('golden body — each worker header is immediately followed by ITS indented steps', () => {
@@ -1317,8 +1312,8 @@ describe('combined worker card — steps indent under their worker (U+2800)', ()
     // would still pass every one of them. This pins the full line ORDER, which
     // is the actual thing the fix is for: a step must sit under its own worker.
     const body = renderCombinedWorkerFeed(rowsFor(3), { maxRows: 8 })!
-    const I = SUBORDINATE_LINE_INDENT + WORKER_STEP_INDENT
-    const N = SUBORDINATE_LINE_INDENT
+    const I = WORKER_STEP_INDENT
+    const N = ''
     // `S` is the pinned-bar collapse separator (#3666): every line that is
     // followed by a hard break carries one trailing U+00A0 so the pinned-message
     // bar (which drops the newline and substitutes nothing) does not mash the
@@ -1327,7 +1322,7 @@ describe('combined worker card — steps indent under their worker (U+2800)', ()
     // `WORKER_STEP_INDENT`, which is what this golden is really pinning.
     const S = COLLAPSE_SAFE_SEPARATOR
     expect(linesOf(body)).toEqual([
-      `${SUBORDINATE_HEADER_PREFIX}🛠 **WORKERS** · _3 running · oldest 3m00s · 9 tools_${S}`,
+      `🛠 **WORKERS** · _3 running · oldest 3m00s · 9 tools_${S}`,
       `${N}**1. worker task 1** _· 1m00s · 3 tools_${S}`,
       `${I}~~_✓ w1 step a_~~${S}`,
       `${I}**→ w1 step b**${S}`,
@@ -1455,7 +1450,7 @@ describe('combined worker card — steps indent under their worker (U+2800)', ()
     expect(ents.every((e) => !e.text.includes(NBSP))).toBe(true)
   })
 
-  it('the SINGLE-worker 🛠 card nests ONE level (card-level only, no per-worker indent)', () => {
+  it('the SINGLE-worker 🛠 card is entirely FLUSH — no card indent, no step indent (#3839)', () => {
     const single = renderWorkerActivity({
       workerId: 'w1',
       description: 'lone worker',
@@ -1467,18 +1462,17 @@ describe('combined worker card — steps indent under their worker (U+2800)', ()
     })
     expect(single).toContain('~~_✓ step a_~~')
     expect(single).toContain('**→ step b**')
-    // The lone-worker card has no worker HEADER to nest steps under, so it must
-    // never carry the per-worker indent — but since #3820 the whole card nests
-    // ONE level under the 🤖 agent card, so its body lines sit at exactly
-    // SUBORDINATE_LINE_INDENT and never at two levels. Asserted per line on the
-    // leading edge rather than as "no U+00A0 anywhere in the card", because
-    // #3666 puts one TRAILING U+00A0 on every hard-broken line of every pinned
-    // card (this one included) as the collapse separator.
+    // The lone-worker card has no worker HEADER to nest steps under, so there is
+    // nothing for an indent to distinguish — and #3839 removed the whole-card
+    // nesting #3820 added, so EVERY line sits at the left margin. Asserted per
+    // line on the leading edge rather than as "no U+2800 anywhere in the card",
+    // because #3666 puts one TRAILING U+00A0 on every hard-broken line of every
+    // pinned card (this one included) as the collapse separator.
     const ls = single.split('\n')
-    expect(ls[0].startsWith(SUBORDINATE_HEADER_PREFIX)).toBe(true)
-    for (const l of ls.slice(1)) {
-      expect(l.startsWith(SUBORDINATE_LINE_INDENT)).toBe(true)
-      expect(l.startsWith(SUBORDINATE_LINE_INDENT + WORKER_STEP_INDENT)).toBe(false)
+    expect(ls[0].startsWith('🛠 **WORKER**')).toBe(true)
+    for (const l of ls) {
+      expect(l.startsWith(WORKER_STEP_INDENT)).toBe(false)
+      expect(l.startsWith('└─')).toBe(false)
       expect(l.startsWith(NBSP)).toBe(false)
     }
   })

--- a/telegram-plugin/tests/worker-feed-coalesce.test.ts
+++ b/telegram-plugin/tests/worker-feed-coalesce.test.ts
@@ -1287,7 +1287,7 @@ describe('combined worker card — steps indent under their worker (U+2800)', ()
     // Load-bearing: the exact indent bytes. `WORKER_STEP_INDENT` is U+2800 ×3;
     // a plain-ASCII `'   '` indent fails this assertion, so does the U+00A0 run
     // #3662 shipped, and so does flat output with no prefix at all.
-    // #3839 removed the whole-card nesting #3820 added, so a step sits at
+    // #3842 removed the whole-card nesting #3820 added, so a step sits at
     // EXACTLY one WORKER_STEP_INDENT — not two — and its worker header sits
     // flush at the left margin. The RELATIVE one-level nesting this test guards
     // is unchanged; the whole block shifted back left.
@@ -1450,7 +1450,7 @@ describe('combined worker card — steps indent under their worker (U+2800)', ()
     expect(ents.every((e) => !e.text.includes(NBSP))).toBe(true)
   })
 
-  it('the SINGLE-worker 🛠 card is entirely FLUSH — no card indent, no step indent (#3839)', () => {
+  it('the SINGLE-worker 🛠 card is entirely FLUSH — no card indent, no step indent (#3842)', () => {
     const single = renderWorkerActivity({
       workerId: 'w1',
       description: 'lone worker',
@@ -1463,7 +1463,7 @@ describe('combined worker card — steps indent under their worker (U+2800)', ()
     expect(single).toContain('~~_✓ step a_~~')
     expect(single).toContain('**→ step b**')
     // The lone-worker card has no worker HEADER to nest steps under, so there is
-    // nothing for an indent to distinguish — and #3839 removed the whole-card
+    // nothing for an indent to distinguish — and #3842 removed the whole-card
     // nesting #3820 added, so EVERY line sits at the left margin. Asserted per
     // line on the leading edge rather than as "no U+2800 anywhere in the card",
     // because #3666 puts one TRAILING U+00A0 on every hard-broken line of every

--- a/telegram-plugin/tests/worker-visibility-prose-silent-harness.test.ts
+++ b/telegram-plugin/tests/worker-visibility-prose-silent-harness.test.ts
@@ -253,7 +253,7 @@ describe('prose-silent background worker — end-to-end visibility harness (PR 2
     expect(h.bot.sent).toHaveLength(1)
     expect(h.feed.messageIdOf(h.agentId)).not.toBeNull()
     expect(h.bot.sent[0].chatId).toBe('chat-42')
-    expect(h.bot.sent[0].text).toContain('└─ 🛠 **WORKER**')
+    expect(h.bot.sent[0].text.startsWith('🛠 **WORKER**')).toBe(true)
 
     // (b) KEEPS UPDATING: later heartbeats edit the message with a climbing
     // `· Ns` suffix so the still-alive worker visibly advances.

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -90,8 +90,6 @@ import {
   STATUS_LINE_MAX,
   NESTED_PREFIX,
   WORKER_STEP_INDENT,
-  SUBORDINATE_LINE_INDENT,
-  nestSubordinateCardLines,
 } from './status-no-truncate.js'
 import { escapeMarkdown, stripMarkdown, truncate, stackCardLines } from './card-format.js'
 import { isTelegramSurfaceTool } from './tool-names.js'
@@ -374,18 +372,6 @@ export interface StatusCardOpts {
    * full recent trail — see WORKER_HISTORY_MAX.
    */
   historyWindow?: number
-  /**
-   * Render this card as structurally SUBORDINATE to the 🤖 agent card (#3820):
-   * line 1 is prefixed with `└─ ` and every later line with
-   * `SUBORDINATE_LINE_INDENT`, so the whole block sits one level in from the
-   * agent card's left margin.
-   *
-   * This is what makes "my agent" vs "a background worker" answerable from the
-   * card's SHAPE without reading its label — the two cards were otherwise
-   * byte-for-byte the same layout, differing only by an emoji + one word.
-   * Worker surfaces pass `true`; the agent card never does.
-   */
-  subordinate?: boolean
 }
 
 /**
@@ -395,8 +381,13 @@ export interface StatusCardOpts {
  * Pipeline: header → escape+clip every raw step/child → rolling-window each
  * group with `+N earlier…` → wrap (parent done-styled when children present;
  * newest-in-progress `→` bold else `✓` italic; NESTED_PREFIX for children) →
- * optional `✓ N steps` footer → optional result block → subordinate nesting
- * (#3820, when `opts.subordinate`) → fitCardToBudget.
+ * optional `✓ N steps` footer → optional result block → fitCardToBudget.
+ *
+ * Every card this primitive emits is FLUSH at the left margin (#3839). The
+ * whole-card `└─ ` + one-level indent that #3820/#3821 put on the worker card
+ * is gone: it cost horizontal space on a phone and claimed a parent/child
+ * relationship that does not always hold. Intra-card nesting (the `↳` child
+ * block here, `WORKER_STEP_INDENT` on the combined card) is unaffected.
  */
 export function renderStatusCard(opts: StatusCardOpts): string | null {
   const { header, final = false, liveSuffix = '', stepCount, result } = opts
@@ -468,9 +459,7 @@ export function renderStatusCard(opts: StatusCardOpts): string | null {
   // collapseSafe (#3666): the agent status card and the single-worker card are
   // both PINNED, and Telegram's pinned bar shows them collapsed to one line
   // with the newlines dropped — the separator keeps that preview legible.
-  const joined = stackCardLines(opts.subordinate === true ? nestSubordinateCardLines(out) : out, {
-    collapseSafe: true,
-  })
+  const joined = stackCardLines(out, { collapseSafe: true })
   if (joined.length <= STATUS_CARD_CHAR_BUDGET) return joined
   return fitCardToBudget(opts, headerLines)
 }
@@ -492,15 +481,11 @@ function fitCardToBudget(opts: StatusCardOpts, headerLines: string[]): string {
   const rawSteps = opts.steps.filter((s) => s != null)
   const rawChildren = (opts.childSteps ?? []).map((s) => s.trim()).filter((s) => s.length > 0)
   const hasChildren = rawChildren.length > 0
-  const subordinate = opts.subordinate === true
-  // Subordinate nesting (#3820) costs a fixed prefix on EVERY line — the header
-  // prefix and the body indent are the same length by invariant (see
-  // SUBORDINATE_HEADER_PREFIX), so it is one flat per-line charge rather than a
-  // line-1 special case. Charged into the arithmetic below so the extreme
-  // single-oversized-bullet branch still lands under the wire cap.
-  const nestCost = subordinate ? SUBORDINATE_LINE_INDENT.length : 0
+  // No per-line nesting cost since #3839 removed whole-card subordination:
+  // every line this function assembles is flush, so the arithmetic below
+  // charges only the line's own bytes.
   const stack = (lines: string[]): string =>
-    stackCardLines(subordinate ? nestSubordinateCardLines(lines) : lines, { collapseSafe: true })
+    stackCardLines(lines, { collapseSafe: true })
 
   // Fixed footer/result lines (always kept).
   const footerLines: string[] = []
@@ -509,9 +494,7 @@ function fitCardToBudget(opts: StatusCardOpts, headerLines: string[]): string {
     footerLines.push(WORKER_RESULT_RULE)
     footerLines.push(`${result.emoji} _${escapeMarkdown(truncate(result.text, WORKER_RESULT_MAX))}_`)
   }
-  const fixedCost =
-    [...headerLines, ...footerLines].join('\n').length +
-    (headerLines.length + footerLines.length) * nestCost
+  const fixedCost = [...headerLines, ...footerLines].join('\n').length
 
   // The active "body" group whose oldest bullets we drop: children when
   // present (parent collapses to a single "+N" marker), else parent steps.
@@ -544,11 +527,11 @@ function fitCardToBudget(opts: StatusCardOpts, headerLines: string[]): string {
   // escaping can expand the string (& → &amp;).
   const rawNewest = body.length > 0 ? stripMarkdown(body[body.length - 1]).replace(/\s+/g, ' ').trim() : ''
   const wrapperOverhead =
-    (final ? (prefix + '_✓ _').length : (prefix + '**→ **').length + liveSuffix.length) + nestCost
+    final ? (prefix + '_✓ _').length : (prefix + '**→ **').length + liveSuffix.length
   const headerFooterCost =
     fixedCost +
     (fixedCost > 0 ? 1 : 0) +
-    (parentMarker != null ? parentMarker.length + nestCost + 1 : 0)
+    (parentMarker != null ? parentMarker.length + 1 : 0)
   const budget = STATUS_CARD_CHAR_BUDGET - headerFooterCost - wrapperOverhead
   let raw = rawNewest.slice(0, Math.max(0, budget))
   let newest = escapeMarkdown(raw)
@@ -807,23 +790,26 @@ function glanceLine(rows: CombinedWorkerRow[]): string {
  * Render N≥1 live workers into ONE combined feed body (ready Telegram
  * markdown; callers send verbatim — do NOT re-escape). Layout:
  *
- *   └─ 🛠 **WORKERS** · _N running · oldest {elapsed} · {n} tools · {t} tok_
- *      **1. {desc1}** _· {elapsed} · {n} tools_
- *         ~~_✓ {earlier step}_~~
- *         **→ {newest step}**
- *      **2. {desc2}** _· {elapsed} · {n} tools_
- *         **→ {newest step}**
- *      _+M more working…_
+ *   🛠 **WORKERS** · _N running · oldest {elapsed} · {n} tools · {t} tok_
+ *   **1. {desc1}** _· {elapsed} · {n} tools_
+ *      ~~_✓ {earlier step}_~~
+ *      **→ {newest step}**
+ *   **2. {desc2}** _· {elapsed} · {n} tools_
+ *      **→ {newest step}**
+ *   _+M more working…_
  *
- * SUBORDINATION (#3820): line 1 carries `└─ ` and every later line carries
- * `SUBORDINATE_LINE_INDENT`, so the whole card reads as a child block of the
- * 🤖 agent card rather than a second top-level card with the same silhouette.
+ * FLUSH (#3839): the card sits at the left margin like every other card. The
+ * whole-card `└─ ` + one-level indent from #3820/#3821 is gone — it burned a
+ * level of horizontal phone width to assert a parent/child relationship with
+ * the 🤖 agent card that does not always hold (this card is not always below
+ * it).
  *
- * INDENT: every step line carries a leading `WORKER_STEP_INDENT` (a U+2800 run
- * — neither ASCII spaces nor U+00A0; Telegram left-trims BOTH, see the
- * constant's doc comment) so the steps nest under their worker header and the
- * per-worker blocks are scannable. Header and chrome lines stay at the left
- * margin.
+ * INDENT: exactly ONE level of indentation survives, and it is the level that
+ * earns its keep — every step line carries a leading `WORKER_STEP_INDENT` (a
+ * U+2800 run — neither ASCII spaces nor U+00A0; Telegram left-trims BOTH, see
+ * the constant's doc comment) so one worker's steps are visibly separated from
+ * the next worker's. The glance line, the numbered row headers and the spill
+ * line stay flush.
  *
  * NUMBERING (#3298): when the card tracks 2+ rows AND a row carries `ordinal`,
  * its header gets a stable `{ordinal}. ` prefix. Ordinals are assigned by the
@@ -927,14 +913,11 @@ export function renderCombinedWorkerFeed(
     // substituted. Without the separator the glance line runs straight into
     // row 1's ordinal and every step glyph mashes into the previous line.
     //
-    // Subordinate nesting (#3820) is applied LAST, over the finished line list:
-    // the glance line takes `└─ ` and every row header / step / spill line takes
-    // one `SUBORDINATE_LINE_INDENT`, so this card reads as a child block of the
-    // 🤖 agent card the same way the single-worker card does. Step lines already
-    // carry WORKER_STEP_INDENT, so they end up one level deeper than their row
-    // header — the intra-card hierarchy is preserved, just shifted right.
+    // No whole-card nesting (#3839): `out` goes to the stacker as-is, so the
+    // glance / row-header / spill lines land flush and only the step lines
+    // carry their WORKER_STEP_INDENT — one level of hierarchy, not two.
     return {
-      body: stackCardLines(nestSubordinateCardLines(out), { collapseSafe: true }),
+      body: stackCardLines(out, { collapseSafe: true }),
       bodyLines: bodyOut.length,
     }
   }

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -383,7 +383,7 @@ export interface StatusCardOpts {
  * newest-in-progress `→` bold else `✓` italic; NESTED_PREFIX for children) →
  * optional `✓ N steps` footer → optional result block → fitCardToBudget.
  *
- * Every card this primitive emits is FLUSH at the left margin (#3839). The
+ * Every card this primitive emits is FLUSH at the left margin (#3842). The
  * whole-card `└─ ` + one-level indent that #3820/#3821 put on the worker card
  * is gone: it cost horizontal space on a phone and claimed a parent/child
  * relationship that does not always hold. Intra-card nesting (the `↳` child
@@ -481,7 +481,7 @@ function fitCardToBudget(opts: StatusCardOpts, headerLines: string[]): string {
   const rawSteps = opts.steps.filter((s) => s != null)
   const rawChildren = (opts.childSteps ?? []).map((s) => s.trim()).filter((s) => s.length > 0)
   const hasChildren = rawChildren.length > 0
-  // No per-line nesting cost since #3839 removed whole-card subordination:
+  // No per-line nesting cost since #3842 removed whole-card subordination:
   // every line this function assembles is flush, so the arithmetic below
   // charges only the line's own bytes.
   const stack = (lines: string[]): string =>
@@ -798,7 +798,7 @@ function glanceLine(rows: CombinedWorkerRow[]): string {
  *      **→ {newest step}**
  *   _+M more working…_
  *
- * FLUSH (#3839): the card sits at the left margin like every other card. The
+ * FLUSH (#3842): the card sits at the left margin like every other card. The
  * whole-card `└─ ` + one-level indent from #3820/#3821 is gone — it burned a
  * level of horizontal phone width to assert a parent/child relationship with
  * the 🤖 agent card that does not always hold (this card is not always below
@@ -913,7 +913,7 @@ export function renderCombinedWorkerFeed(
     // substituted. Without the separator the glance line runs straight into
     // row 1's ordinal and every step glyph mashes into the previous line.
     //
-    // No whole-card nesting (#3839): `out` goes to the stacker as-is, so the
+    // No whole-card nesting (#3842): `out` goes to the stacker as-is, so the
     // glance / row-header / spill lines land flush and only the step lines
     // carry their WORKER_STEP_INDENT — one level of hierarchy, not two.
     return {

--- a/telegram-plugin/uat/assertions.ts
+++ b/telegram-plugin/uat/assertions.ts
@@ -29,7 +29,7 @@ import type { Driver, ObservedMessage, ObservedReaction } from "./driver.js";
  * inside `WORKERS` (no word boundary between `r` and `S`). Without the optional
  * `s` the whole 2+ worker surface was invisible to this predicate, so a
  * recall/reply scenario running with two live workers could latch onto the
- * combined card as the agent's answer. Found during the #3839 card audit.
+ * combined card as the agent's answer. Found during the #3842 card audit.
  */
 export const WORKER_FEED_RE = /🛠[️]?\s*Workers?\b|finished\s*·\s*(?:completed|failed)/i;
 
@@ -92,7 +92,7 @@ const LIVENESS_HEADER_L1_RE = /^(?:🤖|🛠[️]?|⚙[️]?)\s+\S/u;
  * Telegram's own left-trim; see WORKER_STEP_INDENT). Without this, a worker
  * card's body lines stop matching `ACTIVITY_BODY_LINE_RE`.
  *
- * #3839 removed the whole-card `└─ ` header prefix and the whole-card indent
+ * #3842 removed the whole-card `└─ ` header prefix and the whole-card indent
  * that #3820/#3821 put on worker cards, so this no longer has to strip a `└─ `.
  * The step indent is the only nesting a card emits now.
  */

--- a/telegram-plugin/uat/assertions.ts
+++ b/telegram-plugin/uat/assertions.ts
@@ -23,8 +23,15 @@ import type { Driver, ObservedMessage, ObservedReaction } from "./driver.js";
  *
  * Single source of truth; the worker-feed scenario asserts against this,
  * and recall/reply scenarios exclude it via {@link isWorkerFeedMessage}.
+ *
+ * `Workers?` is load-bearing, not cosmetic: the COMBINED (2+ worker) card's
+ * glance line reads `🛠 WORKERS · N running · …`, and `Worker\b` cannot match
+ * inside `WORKERS` (no word boundary between `r` and `S`). Without the optional
+ * `s` the whole 2+ worker surface was invisible to this predicate, so a
+ * recall/reply scenario running with two live workers could latch onto the
+ * combined card as the agent's answer. Found during the #3839 card audit.
  */
-export const WORKER_FEED_RE = /🛠[️]?\s*Worker\b|finished\s*·\s*(?:completed|failed)/i;
+export const WORKER_FEED_RE = /🛠[️]?\s*Workers?\b|finished\s*·\s*(?:completed|failed)/i;
 
 /**
  * True when `m` is a worker-activity-feed message rather than the agent's
@@ -74,22 +81,26 @@ const ACTIVITY_BODY_LINE_RE = /^[→✓↳]/u;
 const LIVENESS_HEADER_L1_RE = /^(?:🤖|🛠[️]?|⚙[️]?)\s+\S/u;
 
 /**
- * Leading chrome a SUBORDINATE (worker) card carries since #3820: the `└─ `
- * header prefix on line 1 and a `U+2800` indent run on every later line, which
- * together make the worker card readable as a child of the 🤖 agent card.
+ * Leading indent chrome a card line can carry: a `U+2800` run, applied by
+ * `WORKER_STEP_INDENT` to the step lines under each worker header on the
+ * combined (2+ worker) card so one worker's steps are visibly separated from
+ * the next worker's.
  *
  * Every line-shape matcher below must normalise it away first: Telegram
- * delivers both verbatim, and NEITHER is stripped by `String.trim()` — U+2800
- * is category So, not whitespace (that property is exactly why it survives
+ * delivers it verbatim and `String.trim()` does NOT remove it — U+2800 is
+ * category So, not whitespace (that property is exactly why it survives
  * Telegram's own left-trim; see WORKER_STEP_INDENT). Without this, a worker
- * card's header stops matching `LIVENESS_HEADER_L1_RE` and its body lines stop
- * matching `ACTIVITY_BODY_LINE_RE`.
+ * card's body lines stop matching `ACTIVITY_BODY_LINE_RE`.
+ *
+ * #3839 removed the whole-card `└─ ` header prefix and the whole-card indent
+ * that #3820/#3821 put on worker cards, so this no longer has to strip a `└─ `.
+ * The step indent is the only nesting a card emits now.
  */
-const SUBORDINATE_CARD_PREFIX_RE = /^(?:└─\s*|\u2800+)+/u;
+const CARD_INDENT_PREFIX_RE = /^\u2800+/u;
 
-/** A card line with its subordinate-card nesting chrome removed, trimmed. */
+/** A card line with its leading step-indent chrome removed, trimmed. */
 export function stripCardNesting(line: string): string {
-  return line.replace(SUBORDINATE_CARD_PREFIX_RE, "").trim();
+  return line.replace(CARD_INDENT_PREFIX_RE, "").trim();
 }
 const LIVENESS_ELAPSED = String.raw`(?:\d+m)?\d+s`;
 const LIVENESS_HEADER_L2_RE = new RegExp(

--- a/telegram-plugin/uat/feed-matcher.test.ts
+++ b/telegram-plugin/uat/feed-matcher.test.ts
@@ -52,15 +52,15 @@ describe("isWorkerFeedMessage", () => {
     expect(WORKER_FEED_RE.test("🛠 Worker · x")).toBe(true);
   });
 
-  it("matches the FLUSH worker card as Telegram delivers it (#3839)", () => {
-    // #3839 removed the whole-card `└─ ` prefix and whole-card indent that
+  it("matches the FLUSH worker card as Telegram delivers it (#3842)", () => {
+    // #3842 removed the whole-card `└─ ` prefix and whole-card indent that
     // #3820/#3821 put on worker cards, so the single-worker card arrives flush.
     const flush = "🛠 WORKER · crawling changelog\n55s · 9 tools · opus 5";
     expect(isWorkerFeedMessage(feed(flush))).toBe(true);
   });
 });
 
-describe("#3839 the surviving step indent is transparent to the matchers", () => {
+describe("#3842 the surviving step indent is transparent to the matchers", () => {
   it("classifies a flush agent-shaped worker card as the liveness card, not an answer", () => {
     const flush =
       "🛠 WORKER · crawl\n12s · 3 tools\n✓ Reading CLAUDE.md\n→ Searching memory";
@@ -69,7 +69,7 @@ describe("#3839 the surviving step indent is transparent to the matchers", () =>
   });
 
   it("classifies a combined card whose step lines carry WORKER_STEP_INDENT", () => {
-    // The one indent that survives #3839: step lines under a worker row header
+    // The one indent that survives #3842: step lines under a worker row header
     // on the 2+ worker card. `String.trim()` does NOT remove U+2800 (category
     // So, not whitespace), so the matchers must normalise it explicitly or a
     // recall/reply scenario latches onto the combined card as an answer.

--- a/telegram-plugin/uat/feed-matcher.test.ts
+++ b/telegram-plugin/uat/feed-matcher.test.ts
@@ -52,29 +52,36 @@ describe("isWorkerFeedMessage", () => {
     expect(WORKER_FEED_RE.test("🛠 Worker · x")).toBe(true);
   });
 
-  it("still matches the #3820 SUBORDINATE worker card as Telegram delivers it", () => {
-    // Since #3820 the worker card leads with `└─ ` and indents every later line
-    // with a U+2800 run so it reads as a child of the 🤖 agent card. Telegram
-    // strips the bold/italic entities but delivers that chrome verbatim, and
-    // `String.trim()` removes neither (U+2800 is category So, not whitespace) —
-    // so every matcher here has to survive it or recall/reply scenarios start
-    // latching onto worker cards as answers.
-    const nested = "└─ 🛠 WORKER · crawling changelog\n⠀⠀⠀55s · 9 tools · opus 5";
-    expect(isWorkerFeedMessage(feed(nested))).toBe(true);
+  it("matches the FLUSH worker card as Telegram delivers it (#3839)", () => {
+    // #3839 removed the whole-card `└─ ` prefix and whole-card indent that
+    // #3820/#3821 put on worker cards, so the single-worker card arrives flush.
+    const flush = "🛠 WORKER · crawling changelog\n55s · 9 tools · opus 5";
+    expect(isWorkerFeedMessage(feed(flush))).toBe(true);
   });
 });
 
-describe("#3820 subordinate-card nesting is transparent to the matchers", () => {
-  it("classifies a nested agent-shaped card as the liveness card, not an answer", () => {
-    const nested =
-      "└─ 🛠 WORKER · crawl\n⠀⠀⠀12s · 3 tools\n⠀⠀⠀✓ Reading CLAUDE.md\n⠀⠀⠀→ Searching memory";
-    expect(isLivenessCardMessage(feed(nested))).toBe(true);
-    expect(isActivityFeedMessage(feed(nested))).toBe(true);
+describe("#3839 the surviving step indent is transparent to the matchers", () => {
+  it("classifies a flush agent-shaped worker card as the liveness card, not an answer", () => {
+    const flush =
+      "🛠 WORKER · crawl\n12s · 3 tools\n✓ Reading CLAUDE.md\n→ Searching memory";
+    expect(isLivenessCardMessage(feed(flush))).toBe(true);
+    expect(isActivityFeedMessage(feed(flush))).toBe(true);
   });
 
-  it("strips the header prefix and the indent, and leaves ordinary prose alone", () => {
-    expect(stripCardNesting("└─ 🛠 WORKER · crawl")).toBe("🛠 WORKER · crawl");
+  it("classifies a combined card whose step lines carry WORKER_STEP_INDENT", () => {
+    // The one indent that survives #3839: step lines under a worker row header
+    // on the 2+ worker card. `String.trim()` does NOT remove U+2800 (category
+    // So, not whitespace), so the matchers must normalise it explicitly or a
+    // recall/reply scenario latches onto the combined card as an answer.
+    const combined =
+      "🛠 WORKERS · 2 running · oldest 55s · 13 tools\n" +
+      "1. crawl · 55s · 9 tools\n⠀⠀⠀✓ Reading CLAUDE.md\n⠀⠀⠀→ Searching memory";
+    expect(isWorkerFeedMessage(feed(combined))).toBe(true);
+  });
+
+  it("strips the step indent and leaves ordinary prose alone", () => {
     expect(stripCardNesting("⠀⠀⠀→ Searching memory")).toBe("→ Searching memory");
+    expect(stripCardNesting("🛠 WORKER · crawl")).toBe("🛠 WORKER · crawl");
     expect(stripCardNesting("on it, pulling the logs now")).toBe(
       "on it, pulling the logs now",
     );

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -55,11 +55,7 @@ import {
   truncate,
   COLLAPSE_SAFE_SEPARATOR,
 } from './card-format.js'
-import {
-  WORKER_HISTORY_MAX,
-  SUBORDINATE_HEADER_PREFIX,
-  SUBORDINATE_LINE_INDENT,
-} from './status-no-truncate.js'
+import { WORKER_HISTORY_MAX } from './status-no-truncate.js'
 import {
   renderStatusCard,
   formatStepSuffix,
@@ -168,30 +164,32 @@ export function repeatCountOf(line: string): number {
 
 /**
  * Thin adapter over the unified `renderStatusCard` primitive (emoji 🛠, label
- * 'WORKER', `subordinate: true`): builds the header, passes raw narrative steps
+ * 'WORKER'): builds the header, passes raw narrative steps
  * (the primitive runs stripMarkdown → collapse ws → clip → escape per line),
  * and on finish passes the cleaned result paragraph as the `result` block.
  *
  * Layout (running):
- *   └─ 🛠 **WORKER** · _{description}_
- *      _{elapsed} · {n} tools_
- *      ~~_✓ {earlier step}_~~
- *      **→ {newest step}**
+ *   🛠 **WORKER** · _{description}_
+ *   _{elapsed} · {n} tools_
+ *   ~~_✓ {earlier step}_~~
+ *   **→ {newest step}**
  *
  * Layout (finished): the feed renders all-done, then a rule + cleaned result:
- *   └─ 🛠 **WORKER** · _{description}_
- *      _done · {n} tools · {elapsed}_
- *      ~~_✓ {step}_~~
- *      ─────
- *      ✅ _{cleaned result paragraph}_
+ *   🛠 **WORKER** · _{description}_
+ *   _done · {n} tools · {elapsed}_
+ *   ~~_✓ {step}_~~
+ *   ─────
+ *   ✅ _{cleaned result paragraph}_
  *
- * SUBORDINATION (#3820): the `└─ ` prefix, the whole-block indent, and the
- * caps `WORKER` label exist so this card cannot be mistaken for the 🤖 agent
- * card at a glance on a phone. Before #3820 the two cards differed only by
- * their emoji and one capitalised word while sharing the identical two-line
- * header, stat row, and step trail. Do NOT "tidy" any of the three away
- * individually: each is a separate one-glance cue, and the pair is frequently
- * live in the same chat at the same time with overlapping step text.
+ * FLUSH (#3839): this card sits at the left margin. #3820/#3821 indented the
+ * whole block and prefixed line 1 with `└─ ` to mark it subordinate to the 🤖
+ * agent card; that was reverted because it burned a level of horizontal phone
+ * width and because this card does not always sit below the agent card, so a
+ * card-level subordination marker asserts a relationship that is not always
+ * true. The remaining type cue is line 1: the 🛠 emoji plus the caps `WORKER`
+ * label against the agent card's 🤖 `Agent`. Keep that pair — with identical
+ * step text and stats the two cards' BODY lines can now coincide byte for
+ * byte, so line 1 is doing all of the distinguishing work.
  */
 export function renderWorkerActivity(v: WorkerActivityView, liveSuffix = ''): string {
   const desc = truncate(stripMarkdown(v.description).trim() || 'background task', DESC_MAX)
@@ -251,12 +249,10 @@ export function renderWorkerActivity(v: WorkerActivityView, liveSuffix = ''): st
     // Lone-worker card: window to the w=1 point of Ken's curve (6) so it shows
     // the full recent trail, not the 5-line agent-card default (#3349).
     historyWindow: workerHistoryDepth(1),
-    // Structurally subordinate to the 🤖 agent card (#3820).
-    subordinate: true,
   })
   if (card == null) {
     // Unreachable (header always present) — defensive.
-    return `${SUBORDINATE_HEADER_PREFIX}🛠 **WORKER** · _starting…_`
+    return '🛠 **WORKER** · _starting…_'
   }
   if (!finished && steps.length === 0) {
     // Header-only running render → append the starting placeholder with a GFM
@@ -265,11 +261,9 @@ export function renderWorkerActivity(v: WorkerActivityView, liveSuffix = ''): st
     // The collapse separator is carried here too (#3666) — this card is pinned,
     // and a hand-rolled seam would be the one boundary that still mashed in
     // Telegram's pinned bar.
-    // The placeholder is a card BODY line, so it carries the subordinate indent
-    // like every other non-header line (#3820) — otherwise the one render state
-    // a user sees first (a just-dispatched worker) would be the one that isn't
-    // visibly nested.
-    return `${card}${COLLAPSE_SAFE_SEPARATOR}  \n${SUBORDINATE_LINE_INDENT}_starting…_`
+    // Flush like every other body line of this card (#3839) — the single-worker
+    // card carries no indentation at all now.
+    return `${card}${COLLAPSE_SAFE_SEPARATOR}  \n_starting…_`
   }
   return card
 }
@@ -616,10 +610,13 @@ const COOLDOWN_JITTER_MS = 500
  * rows and reads like a stuck worker. A single best-effort edit collapses it to
  * an honest "moved" note — issued once per rotation (≥ cap interval), never per
  * tick, so it adds no edit churn / pin storm. Plain voice, no em dash.
+ *
+ * Exported so the card-preview harness (`scripts/card-previews.ts`) renders the
+ * real string rather than a copy that can drift from it.
  */
-const WORKER_CARD_SUPERSEDED_BODY =
-  `${SUBORDINATE_HEADER_PREFIX}🛠 **WORKER** · _continued_\n\n` +
-  `${SUBORDINATE_LINE_INDENT}_Live progress moved to a fresh card to stay pinned._`
+export const WORKER_CARD_SUPERSEDED_BODY =
+  '🛠 **WORKER** · _continued_\n\n' +
+  '_Live progress moved to a fresh card to stay pinned._'
 
 function extractRetryAfterSecs(err: unknown): number | null {
   if (err == null || typeof err !== 'object') return null

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -181,7 +181,7 @@ export function repeatCountOf(line: string): number {
  *   ─────
  *   ✅ _{cleaned result paragraph}_
  *
- * FLUSH (#3839): this card sits at the left margin. #3820/#3821 indented the
+ * FLUSH (#3842): this card sits at the left margin. #3820/#3821 indented the
  * whole block and prefixed line 1 with `└─ ` to mark it subordinate to the 🤖
  * agent card; that was reverted because it burned a level of horizontal phone
  * width and because this card does not always sit below the agent card, so a
@@ -261,7 +261,7 @@ export function renderWorkerActivity(v: WorkerActivityView, liveSuffix = ''): st
     // The collapse separator is carried here too (#3666) — this card is pinned,
     // and a hand-rolled seam would be the one boundary that still mashed in
     // Telegram's pinned bar.
-    // Flush like every other body line of this card (#3839) — the single-worker
+    // Flush like every other body line of this card (#3842) — the single-worker
     // card carries no indentation at all now.
     return `${card}${COLLAPSE_SAFE_SEPARATOR}  \n_starting…_`
   }


### PR DESCRIPTION
Closes #3842. Closes #3832.

**Do not merge or enable auto-merge** — Ken wants to review the rendered previews and approve the new shape first.

## Why

#3820 / #3821 made the 🛠 worker card structurally subordinate to the 🤖 agent card: line 1 prefixed `└─ ` and every later line indented with a U+2800 run. Ken's objection, both parts correct:

- the whole-card indent **burns a level of horizontal space** on a phone;
- the worker card **does not always sit below the agent card**, so a card-LEVEL subordination marker asserts a relationship that is not always true.

## What changed

Everything shifts left by one level.

| Surface | Before | After |
|---|---|---|
| 🤖 agent card | flush | flush (unchanged) |
| 🛠 single-worker card | `└─ ` + 1 indent level on every later line | **flush on every line** |
| 🛠 WORKERS card — glance / row headers / spill | 1 indent level | **flush** |
| 🛠 WORKERS card — step lines | **2** indent levels | **1** indent level |

Worker-vs-worker separation is now carried by the surviving `WORKER_STEP_INDENT` on step lines plus the numbered row titles — the only place indentation was earning its keep.

### Before / after, real renderer output

Before (`origin/main`):

```
└─ 🛠 **WORKERS** · _2 running · oldest 2m15s · 21 tools · 60.0k tok_
⠀⠀⠀**1. Audit every card render path** _· 1m15s · 7 tools · 20.0k tok · opus 4.8_
⠀⠀⠀⠀⠀⠀~~_✓ audit step 1_~~
⠀⠀⠀⠀⠀⠀**→ audit step 2**
⠀⠀⠀**2. Fix the hindsight recall floor** _· 2m15s · 14 tools · 40.0k tok · opus 4.8_
⠀⠀⠀⠀⠀⠀**→ recall step 1**
```

After (this branch):

```
🛠 **WORKERS** · _2 running · oldest 2m15s · 21 tools · 60.0k tok_
**1. Audit every card render path** _· 1m15s · 7 tools · 20.0k tok · opus 4.8_
⠀⠀⠀~~_✓ audit step 1_~~
⠀⠀⠀**→ audit step 2**
**2. Fix the hindsight recall floor** _· 2m15s · 14 tools · 40.0k tok · opus 4.8_
⠀⠀⠀**→ recall step 1**
```

Single-worker card, before → after:

```
└─ 🛠 **WORKER** · _Audit every card render path…_        🛠 **WORKER** · _Audit every card render path…_
⠀⠀⠀_2m23s · 31 tools · 88.4k tok · opus 4.8_        →    _2m23s · 31 tools · 88.4k tok · opus 4.8_
⠀⠀⠀~~_✓ Fetching origin_~~                               ~~_✓ Fetching origin_~~
⠀⠀⠀**→ Writing the preview harness · 18s**                **→ Writing the preview harness · 18s**
```

### Cost model, not just the output

`fitCardToBudget`'s `nestCost` per-line charge is removed along with the prefix it was paying for, so the char-budget arithmetic still matches the bytes actually emitted. Both over-budget paths (`renderStatusCard` → `fitCardToBudget`, and `renderCombinedWorkerFeed`'s row-shrinking backstop) have tests asserting the rendered card stays under `STATUS_CARD_CHAR_BUDGET`.

Removed as dead: `SUBORDINATE_HEADER_PREFIX`, `SUBORDINATE_LINE_INDENT`, `nestSubordinateCardLines`, `StatusCardOpts.subordinate`.

### UAT matcher layer

- `stripCardNesting` retargeted to the surviving step indent — it no longer has a `└─ ` to strip. It still makes sense and is still needed: combined-card step lines carry U+2800, which `String.trim()` does not remove.
- **Pre-existing bug found during the audit and fixed here:** `WORKER_FEED_RE` was `/🛠\s*Worker\b/i`. The combined card's glance line reads `🛠 WORKERS`, and `Worker\b` cannot match inside `WORKERS` (no word boundary between `r` and `S`) — so the *entire* 2+ worker surface was invisible to `isWorkerFeedMessage`, and a recall/reply scenario running with two live workers could latch onto the combined card as the agent's answer. Now `Workers?\b`, with a combined-card regression case in `feed-matcher.test.ts`.

### #3832 is moot

`nestSubordinateCardLines` no longer exists, so nothing can prefix U+2800 onto a blank line and defeat `stackCardLines`' paragraph-gap detection. The `cur === '' || next === ''` test in `card-format.ts:151` now always sees un-prefixed lines. Closing it.

## Tests

Rewritten to assert the NEW shape; each fails on the old one.

- `card-type-distinguishability.test.ts` — rebuilt around flush-ness and the one-level step indent, covering all six worker render states (running / just-dispatched / done / failed / incomplete / combined), the hand-rolled `starting…` tail, the spill line, and both over-budget paths.
- `worker-feed-coalesce.test.ts` — the golden combined body is re-pinned flush with a single step indent; the single-worker test now asserts the card is *entirely* flush.
- `pinned-card-collapse.test.ts` — the #3666 collapse seams are re-asserted for the flush shape, where the separator is now the only thing holding several of them apart.
- `feed-matcher.test.ts` — flush worker card + a new combined-card case.

Scoped run: 164 tests green across the five affected vitest files; `bun test telegram-plugin/uat/feed-matcher.test.ts` 27/27. `npm run lint` clean.

## Known cost, pinned rather than left implicit

Removing the whole-card marker removes the *shape* cue #3820 added. With identical step text and stats, the agent card and the worker card now share every body line byte for byte; line 1 (🤖 `Agent` vs 🛠 `WORKER`) is the only remaining type cue. `card-type-distinguishability.test.ts` has an explicit characterization test asserting exactly that, so any future change to it is visible rather than silent. Follow-up filed for a lighter-weight cue.

## Also

`scripts/card-previews.ts` — a harness that renders all 21 card variants through the real renderers so the shape can be reviewed verbatim rather than mocked. Not wired into CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)