### PR TITLE
fix(telegram): class-aware edit-flood fuse — the activity feed can never again earn a flood ban

### DIFF
--- a/telegram-plugin/edit-flood-fuse.ts
+++ b/telegram-plugin/edit-flood-fuse.ts
@@ -56,11 +56,12 @@
  *   - send gate `editFloorMs` = 1500ms          ⇒ up to 40 edits/min/message
  *   - send gate cosmetic budget 150 / 300s      ⇒ 30 edits/min/message
  *   - worker feed's own floor 2500ms            ⇒ 24 edits/min/message
+ *   - gateway `FEED_HEARTBEAT_TICK_MS` = 6000ms ⇒ 10 repaints/min/turn
  *
- * The per-message ceiling here is 20/60s, i.e. BELOW all three. That is
- * deliberate — Telegram's own per-group limit is ~20 messages/minute and
- * edits count against it, so the *legitimate* cadences are themselves above
- * what Telegram tolerates; that is precisely how `overlord` got banned while
+ * The fuse's cosmetic ceilings sit BELOW all of these. That is deliberate —
+ * Telegram's own per-group limit is ~20 messages/minute and edits count
+ * against it, so the *legitimate* cadences are themselves above what
+ * Telegram tolerates; that is precisely how `overlord` got banned while
  * every in-repo pacer believed it was behaving. The fuse is therefore the
  * BINDING constraint on a hot card, not a never-reached backstop.
  *
@@ -74,12 +75,58 @@
  *     RELEASED late instead of dropped. Dropping it would freeze the card
  *     mid-run AND return `true` to the send gate, which would then record a
  *     never-painted payload as on-screen and no-op-skip every retry.
+ *
+ * ── 2026-07-27: the fuse existed and the ban happened anyway ──────────────
+ * The ceilings above were sized against the in-repo pacers, not against what
+ * Telegram actually tolerates. Agent `overlord` then sustained ~17
+ * `editMessageText`/min on ONE DM chat for hours (326 edits against 6 real
+ * replies in the final 20 minutes) and took a **15908-second** flood ban that
+ * severed every outbound reply. Both original ceilings — 20 edits/60s per
+ * message, 30 edits/60s per chat — sat ABOVE that observed rate, so the fuse
+ * never bound once. Three structural changes follow, and each is a separate,
+ * independently-sufficient reason the same incident cannot recur:
+ *
+ *   1. **Class awareness.** The fuse now reads the send gate's priority class
+ *      off `outbound-class.ts` (AsyncLocalStorage). `cosmetic` traffic — every
+ *      activity/worker/liveness repaint — is governed by its own, much tighter
+ *      ceilings; `useful` / `critical` edits (approval cards, answers) are not
+ *      throttled by them. Previously the fuse was class-blind and had to pick
+ *      one number for both, which is why the number was too high.
+ *   2. **A hard cosmetic rate ceiling.** 4 edits/60s per message (one per 15s,
+ *      matching the worker feed's own `elapsedRefreshMs`) and 6 edits/60s per
+ *      chat across ALL cosmetic surfaces. 6/min is below the ~4-6/min band the
+ *      live chat survived for hours and far below the 15-17/min that earned
+ *      the ban. Coalescing (supersede) means the card still shows CURRENT
+ *      state at every permitted edit — the operator loses refresh frequency,
+ *      never accuracy.
+ *   3. **A shared per-chat budget with a reply reservation.** Telegram meters
+ *      sends and edits against the SAME per-chat allowance, so separate
+ *      edit/send windows could each be "in budget" while their sum was not.
+ *      One `perChatTotalMaxPerWindow` window (default 20/60s) now counts
+ *      every admitted call, and `perChatReplyReserve` (default 8) slots of it
+ *      are unreachable by `cosmetic` traffic. A reply therefore cannot be
+ *      starved by repaints even if a future call site is misclassified.
+ *
+ * Plus **escalating** backoff: a 429 used to apply ONE 0.5× tightening for a
+ * flat 10 minutes, so a stream that took repeated small 429s re-tightened to
+ * the same level forever and walked into the big ban. Tightening is now
+ * multiplicative PER 429 (`tightenFactor ^ level`, level capped by
+ * `maxTightenLevel`) and decays one level at a time, so sustained pressure
+ * ratchets the cosmetic rate down towards the floor of 1/window.
+ *
+ * Every ceiling is operator-overridable via env — see
+ * {@link editFloodFuseConfigFromEnv}. Previously none of them were.
  */
 
 import type { Bot } from 'grammy'
 
 import type { Clock } from './send-gate.js'
 import { systemClock } from './send-gate.js'
+import {
+  currentOutboundClass,
+  defaultOutboundClass,
+  type OutboundClass,
+} from './outbound-class.js'
 
 /** Methods that mutate an EXISTING message — droppable, coalescible. */
 const EDIT_METHODS: ReadonlySet<string> = new Set([
@@ -116,22 +163,68 @@ export interface EditFloodFuseConfig {
   /** Master switch. When false, `apply` is a pure passthrough. Default true. */
   enabled?: boolean
   clock?: Clock
-  /** Hard ceiling on edits to ONE message id. Default 20 per 60s. */
+  /**
+   * Hard ceiling on NON-cosmetic (`useful` / `critical`) edits to ONE message
+   * id. Default 20 per 60s. Approval cards and answer finalisations live here;
+   * they are low-cadence by nature, so this stays a backstop, not a pacer.
+   */
   perMessageMaxPerWindow?: number
   perMessageWindowMs?: number
-  /** Hard ceiling on edits to ONE chat across all messages. Default 30 per 60s. */
+  /** Hard ceiling on ALL edits to ONE chat across all messages. Default 30 per 60s. */
   perChatEditMaxPerWindow?: number
   /** Pacing ceiling on non-edit sends to ONE chat. Default 25 per 60s. */
   perChatSendMaxPerWindow?: number
+  /**
+   * ADDITIONAL ceiling applied to COSMETIC edits of ONE message id, on top of
+   * `perMessageMaxPerWindow` (the effective ceiling is the lower of the two).
+   * Default 4 per 60s — one per 15s, matching the worker feed's
+   * `elapsedRefreshMs`. This is the number that bounds a hot progress card.
+   */
+  cosmeticPerMessageMaxPerWindow?: number
+  /**
+   * ADDITIONAL ceiling applied to COSMETIC edits in ONE chat, summed across
+   * every cosmetic surface in it (lower of this and `perChatEditMaxPerWindow`
+   * binds). Default 6 per 60s. Without it, N concurrent cards each inside their
+   * own per-message ceiling still add up to a flood.
+   */
+  cosmeticPerChatMaxPerWindow?: number
+  /**
+   * Shared per-chat allowance counting EVERY admitted call — edits and sends,
+   * every class. Default 20 per 60s, matching Telegram's own per-chat/group
+   * metering (which does not separate the two). Sends and non-cosmetic edits
+   * are paced against it and never dropped.
+   */
+  perChatTotalMaxPerWindow?: number
+  /**
+   * Slots of `perChatTotalMaxPerWindow` that `cosmetic` traffic may NEVER
+   * consume. Default 8. This is the reply-starvation guarantee: whatever the
+   * repaint surfaces do, at least this many calls per window remain available
+   * to an actual answer.
+   */
+  perChatReplyReserve?: number
+  /**
+   * Cap on COSMETIC edits that may be released late (over budget) because
+   * nothing newer will repaint them — the bounded form of the R1 rule. Default
+   * 2 per `perChatWindowMs`, so the worst-case sustained cosmetic rate is
+   * `cosmeticPerChatMaxPerWindow + lateReleaseMaxPerWindow`.
+   */
+  lateReleaseMaxPerWindow?: number
   perChatWindowMs?: number
   /** Longest a call may be held before it is dropped (edit) / released (send). Default 30s. */
   maxDeferMs?: number
-  /** Multiplicative decrease applied to every ceiling after a 429. Default 0.5. */
+  /** Multiplicative decrease applied per observed 429. Default 0.5. */
   tightenFactor?: number
-  /** How long a tightened ceiling stays in force. Default 10 minutes. */
+  /** How long ONE level of tightening stays in force before decaying. Default 10 minutes. */
   tightenMs?: number
+  /** Cap on compounding 429 tightening levels. Default 4 (⇒ 0.5^4 = 1/16). */
+  maxTightenLevel?: number
   /** Observability hook; fired whenever the fuse binds. */
-  onTrip?: (info: { method: string; key: string; action: 'deferred' | 'dropped' | 'superseded' }) => void
+  onTrip?: (info: {
+    method: string
+    key: string
+    action: 'deferred' | 'dropped' | 'superseded'
+    cls: OutboundClass
+  }) => void
 }
 
 export interface EditFloodFuseStats {
@@ -146,8 +239,14 @@ export interface EditFloodFuseStats {
   floodObserved: number
   /** Whether a tightened ceiling is in force right now. */
   tightened: boolean
-  /** Live per-message ceiling (post-AIMD). */
+  /** Compounding 429 tightening level currently in force (0 = untightened). */
+  tightenLevel: number
+  /** Live NON-cosmetic per-message ceiling (post-AIMD). */
   perMessageCeiling: number
+  /** Live COSMETIC per-message ceiling (post-AIMD) — the incident-relevant one. */
+  cosmeticPerMessageCeiling: number
+  /** Live COSMETIC per-chat ceiling (post-AIMD). */
+  cosmeticPerChatCeiling: number
 }
 
 export const EDIT_FLOOD_FUSE_DEFAULTS = {
@@ -155,11 +254,64 @@ export const EDIT_FLOOD_FUSE_DEFAULTS = {
   perMessageWindowMs: 60_000,
   perChatEditMaxPerWindow: 30,
   perChatSendMaxPerWindow: 25,
+  /**
+   * 4/60s. One cosmetic repaint per 15s per card. Chosen to equal the worker
+   * feed's `elapsedRefreshMs` (15000) — the slowest cadence at which the feed
+   * itself considers a repaint worth making — so the fuse binds the runaway
+   * case without ever throttling the feed's own intended pace.
+   */
+  cosmeticPerMessageMaxPerWindow: 4,
+  /**
+   * 6/60s across every cosmetic surface in a chat. The incident's own timeline
+   * is the evidence: 10-minute buckets of 58/53/41 edits (≈4-6/min) ran for
+   * hours without a ban; 115/78/73 then 152/174 (≈8-17/min) earned one. 6/min
+   * sits at the top of the survived band and less than half the banned rate.
+   */
+  cosmeticPerChatMaxPerWindow: 6,
+  /**
+   * 20/60s. Telegram's documented per-group ceiling, and it meters sends and
+   * edits together — so this is the only window that reflects the real budget.
+   */
+  perChatTotalMaxPerWindow: 20,
+  /** 8 of those 20 slots/min are unreachable by cosmetic traffic. */
+  perChatReplyReserve: 8,
+  /** At most 2 cosmetic frames/min may exceed the ceiling as "lone" releases. */
+  lateReleaseMaxPerWindow: 2,
   perChatWindowMs: 60_000,
   maxDeferMs: 30_000,
   tightenFactor: 0.5,
   tightenMs: 600_000,
+  maxTightenLevel: 4,
 } as const
+
+/** Parse a positive integer from env, or undefined when unset/invalid. */
+function envInt(raw: string | undefined): number | undefined {
+  if (raw == null || raw.trim() === '') return undefined
+  const n = Number(raw)
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : undefined
+}
+
+/**
+ * Operator config surface. Before the 2026-07-27 incident the fuse had exactly
+ * one knob — `SWITCHROOM_EDIT_FUSE=0`, which turns the whole failsafe OFF —
+ * so an operator whose chat was being flooded had no way to tighten it and no
+ * way to loosen it for a chat that could take more. Every ceiling is now
+ * overridable; unset values keep the defaults above.
+ */
+export function editFloodFuseConfigFromEnv(
+  env: Record<string, string | undefined>,
+): EditFloodFuseConfig {
+  const cfg: EditFloodFuseConfig = { enabled: env.SWITCHROOM_EDIT_FUSE !== '0' }
+  const assign = <K extends keyof EditFloodFuseConfig>(k: K, v: number | undefined): void => {
+    if (v !== undefined) (cfg[k] as number) = v
+  }
+  assign('cosmeticPerMessageMaxPerWindow', envInt(env.SWITCHROOM_FEED_EDIT_MAX_PER_MSG_PER_MIN))
+  assign('cosmeticPerChatMaxPerWindow', envInt(env.SWITCHROOM_FEED_EDIT_MAX_PER_CHAT_PER_MIN))
+  assign('perChatTotalMaxPerWindow', envInt(env.SWITCHROOM_CHAT_TOTAL_MAX_PER_MIN))
+  assign('perChatReplyReserve', envInt(env.SWITCHROOM_CHAT_REPLY_RESERVE))
+  assign('maxDeferMs', envInt(env.SWITCHROOM_EDIT_FUSE_MAX_DEFER_MS))
+  return cfg
+}
 
 /** grammY resolves an edit with `true` when there is nothing to return. */
 const DROPPED_RESULT = true
@@ -189,28 +341,63 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
   const perMessageWindowMs = config.perMessageWindowMs ?? D.perMessageWindowMs
   const perChatEditMax = config.perChatEditMaxPerWindow ?? D.perChatEditMaxPerWindow
   const perChatSendMax = config.perChatSendMaxPerWindow ?? D.perChatSendMaxPerWindow
+  // Cosmetic tiers are an ADDITIONAL constraint on the same window keys, so the
+  // effective ceiling is the lower of the two. Folding them in here (rather
+  // than as extra tiers) keeps the admission path at the same number of awaits.
+  const cosmeticPerMessageMax = Math.min(
+    perMessageMax, config.cosmeticPerMessageMaxPerWindow ?? D.cosmeticPerMessageMaxPerWindow)
+  const cosmeticPerChatMax = Math.min(
+    perChatEditMax, config.cosmeticPerChatMaxPerWindow ?? D.cosmeticPerChatMaxPerWindow)
+  const perChatTotalMax = config.perChatTotalMaxPerWindow ?? D.perChatTotalMaxPerWindow
   const perChatWindowMs = config.perChatWindowMs ?? D.perChatWindowMs
+  // Clamped so a misconfigured reserve can never make the cosmetic allowance
+  // negative (deadlocking every card) or eat the whole budget.
+  const perChatReplyReserve = Math.min(
+    Math.max(0, config.perChatReplyReserve ?? D.perChatReplyReserve),
+    Math.max(0, perChatTotalMax - 1),
+  )
+  const lateReleaseMax = Math.max(0, config.lateReleaseMaxPerWindow ?? D.lateReleaseMaxPerWindow)
   const maxDeferMs = config.maxDeferMs ?? D.maxDeferMs
   const tightenFactor = config.tightenFactor ?? D.tightenFactor
   const tightenMs = config.tightenMs ?? D.tightenMs
+  const maxTightenLevel = Math.max(0, config.maxTightenLevel ?? D.maxTightenLevel)
   const onTrip = config.onTrip
 
   const windows = new Map<string, Window>()
   const counters = { deferred: 0, dropped: 0, superseded: 0, floodObserved: 0 }
-  /** Timestamp until which the AIMD tightening is in force (0 = untightened). */
+  /**
+   * Compounding 429 backoff. `tightenLevel` is the number of multiplicative
+   * decreases currently in force; `tightenedUntil` is when the NEXT level
+   * decays. A single flat tightening (the pre-2026-07-27 behaviour) let a
+   * stream that kept taking small 429s sit at 0.5× indefinitely and walk into
+   * a long ban; escalating means repeated 429s ratchet the rate down.
+   */
+  let tightenLevel = 0
   let tightenedUntil = 0
 
+  /** Decay one level per `tightenMs` of quiet, rather than a single cliff. */
+  function levelAt(now: number): number {
+    if (tightenLevel === 0) return 0
+    while (tightenLevel > 0 && tightenedUntil <= now) {
+      tightenLevel--
+      tightenedUntil = tightenLevel > 0 ? tightenedUntil + tightenMs : 0
+    }
+    return tightenLevel
+  }
+
   function isTightened(now: number): boolean {
-    return tightenedUntil > now
+    return levelAt(now) > 0
   }
 
   /**
-   * AIMD multiplicative decrease. Applied to every ceiling while tightened;
-   * floored at 1 so the fuse never deadlocks a surface completely.
+   * AIMD multiplicative decrease, compounding per observed 429. Applied to
+   * every ceiling while tightened; floored at 1 so the fuse never deadlocks a
+   * surface completely.
    */
   function ceiling(base: number, now: number): number {
-    if (!isTightened(now)) return base
-    return Math.max(1, Math.floor(base * tightenFactor))
+    const level = levelAt(now)
+    if (level === 0) return base
+    return Math.max(1, Math.floor(base * Math.pow(tightenFactor, level)))
   }
 
   function win(key: string): Window {
@@ -266,9 +453,13 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
     return { chat, msg }
   }
 
-  /** Record a 429 (whatever shape it arrives in) and tighten. */
+  /** Record a 429 (whatever shape it arrives in) and tighten one more level. */
   function noteFlood(now: number): void {
     counters.floodObserved++
+    levelAt(now)
+    tightenLevel = Math.min(maxTightenLevel, tightenLevel + 1)
+    // Every level currently in force is re-armed for a full `tightenMs`; the
+    // decay clock restarts from the newest 429, not from the first.
     tightenedUntil = now + tightenMs
   }
 
@@ -311,7 +502,7 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
    * Returns the reserved timestamp, or null when the call must be dropped.
    */
   async function awaitRoom(
-    key: string, windowMs: number, max: number, method: string, mode: WaitMode,
+    key: string, windowMs: number, max: number, method: string, mode: WaitMode, cls: OutboundClass,
     /**
      * Consulted ONLY at the defer deadline for `mode: 'drop'`. Returning false
      * converts the drop into a late release: this call is the last thing that
@@ -319,10 +510,30 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
      * frame", it is freezing a card. Absent ⇒ drop unconditionally (the
      * pre-review behaviour).
      */
-    dropGuard?: () => boolean,
+    dropGuard: (() => boolean) | undefined,
+    /**
+     * Absolute deadline SHARED by every tier of one `apply` call. Each tier
+     * used to start its own `maxDeferMs`, so a call crossing three tiers could
+     * be held 3×`maxDeferMs` — an unbounded-in-practice hold that a caller's
+     * own timeout, not this fuse, would have to end. One deadline per call
+     * makes `maxDeferMs` mean what it says.
+     */
+    deadline: number,
+    /**
+     * Bounded overshoot budget for the R1 late-release path (cosmetic edits
+     * only). R1 says an over-budget edit that nothing newer will repaint must
+     * be RELEASED late rather than dropped, so a card cannot freeze mid-run.
+     * Taken literally that rule has no ceiling: a stream of cosmetic edits to
+     * DISTINCT message ids is a stream of "lone" frames, every one of which
+     * releases over budget — which is how 6 concurrent worker cards can sail
+     * past a 6/min chat ceiling. Charging each late release to a small extra
+     * window keeps R1's guarantee for the rare genuinely-lone frame (a
+     * worker's terminal recap) while capping the leak at `lateReleaseMax` per
+     * window. Absent ⇒ unbounded late release (sends, non-cosmetic edits).
+     */
+    lateReleaseKey?: string,
   ): Promise<number | null> {
     const w = win(key)
-    const deadline = clock.now() + maxDeferMs
     let counted = false
     for (;;) {
       const now = clock.now()
@@ -337,19 +548,32 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
         // worse than a late one).
         if (mode !== 'release' && (dropGuard === undefined || dropGuard())) {
           counters.dropped++
-          onTrip?.({ method, key, action: 'dropped' })
+          onTrip?.({ method, key, action: 'dropped', cls })
           return null
         }
         // A send — or an edit that nothing newer will repaint — is released
         // rather than dropped, and still takes a slot so the window reflects
-        // what actually went out.
+        // what actually went out. Cosmetic late releases are additionally
+        // charged to the bounded overshoot budget; when that is exhausted the
+        // frame is dropped after all, so the ceiling cannot be walked past one
+        // "lone" frame at a time.
+        if (lateReleaseKey !== undefined) {
+          const lw = win(lateReleaseKey)
+          prune(lw, now, perChatWindowMs)
+          if (lw.ts.length >= ceiling(lateReleaseMax, now)) {
+            counters.dropped++
+            onTrip?.({ method, key, action: 'dropped', cls })
+            return null
+          }
+          lw.ts.push(now)
+        }
         w.ts.push(now)
         return now
       }
       if (!counted) {
         counters.deferred++
         counted = true
-        onTrip?.({ method, key, action: 'deferred' })
+        onTrip?.({ method, key, action: 'deferred', cls })
       }
       // Last-write-wins: a newer edit to the same message kills this one. Only
       // valid on the per-MESSAGE tier — on a per-chat key the "newer" edit is
@@ -364,7 +588,7 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
         await Promise.race([clock.sleep(Math.min(wait, deadline - now)), superseded])
         if (killed) {
           counters.superseded++
-          onTrip?.({ method, key, action: 'superseded' })
+          onTrip?.({ method, key, action: 'superseded', cls })
           return null
         }
         w.waiter = null
@@ -393,6 +617,18 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
 
     const now = clock.now()
     evict(now)
+    // ONE deadline for the whole call, shared by every tier it crosses.
+    const deadline = now + maxDeferMs
+
+    // The send gate's priority class, propagated through AsyncLocalStorage.
+    // An untagged edit is COSMETIC by default — see `defaultOutboundClass`.
+    const cls = currentOutboundClass() ?? defaultOutboundClass(isEdit)
+    const totalKey = `t:${chat}`
+    // Cosmetic traffic may only reach `perChatTotalMax - perChatReplyReserve`;
+    // the remaining slots stay available to a real reply no matter how hot the
+    // repaint surfaces are. This reservation is the reply-starvation guarantee.
+    const totalMaxFor = (c: OutboundClass): number =>
+      c === 'cosmetic' ? Math.max(1, perChatTotalMax - perChatReplyReserve) : perChatTotalMax
 
     if (isEdit) {
       if (msg == null) return runObserved(next)
@@ -402,29 +638,49 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
       // one is waiting is visible to that older one's `dropGuard`.
       mw.inflight++
       try {
-        const msgSlot = await awaitRoom(msgKey, perMessageWindowMs, perMessageMax, method, 'supersede')
+        const msgSlot = await awaitRoom(
+          msgKey, perMessageWindowMs,
+          cls === 'cosmetic' ? cosmeticPerMessageMax : perMessageMax,
+          method, 'supersede', cls, undefined, deadline,
+        )
         if (msgSlot === null) return DROPPED_RESULT as unknown as R
+        // R1: only drop while something newer for THIS message is still in
+        // flight to repaint it. `> 1` = this frame plus at least one newer.
+        const dropGuard = (): boolean => mw.inflight > 1
+        // Cosmetic frames share ONE overshoot budget per chat across both
+        // per-chat tiers, so a frame cannot late-release twice on its way out.
+        const lateKey = cls === 'cosmetic' ? `lr:${chat}` : undefined
+        const reserved: Array<[string, number]> = [[msgKey, msgSlot]]
+        const giveBack = (): void => { for (const [k, at] of reserved) unreserve(k, at) }
+
         const chatKey = `ce:${chat}`
         const chatSlot = await awaitRoom(
-          chatKey, perChatWindowMs, perChatEditMax, method, 'drop',
-          // R1: only drop while something newer for THIS message is still in
-          // flight to repaint it. `> 1` = this frame plus at least one newer.
-          () => mw.inflight > 1,
+          chatKey, perChatWindowMs,
+          cls === 'cosmetic' ? cosmeticPerChatMax : perChatEditMax,
+          method, 'drop', cls, dropGuard, deadline, lateKey,
         )
-        if (chatSlot === null) {
-          // Denied by the second tier — hand the first tier's slot back so a
-          // dropped edit never consumes budget it did not use.
-          unreserve(msgKey, msgSlot)
-          return DROPPED_RESULT as unknown as R
-        }
+        if (chatSlot === null) { giveBack(); return DROPPED_RESULT as unknown as R }
+        reserved.push([chatKey, chatSlot])
+
+        // Shared per-chat budget — the one that mirrors Telegram's real
+        // metering. A non-cosmetic edit is RELEASED late rather than dropped:
+        // an approval card or answer finalisation has no newer frame coming.
+        const totalSlot = await awaitRoom(
+          totalKey, perChatWindowMs, totalMaxFor(cls), method,
+          cls === 'cosmetic' ? 'drop' : 'release', cls, dropGuard, deadline, lateKey,
+        )
+        if (totalSlot === null) { giveBack(); return DROPPED_RESULT as unknown as R }
         return runObserved(next)
       } finally {
         mw.inflight--
       }
     }
 
-    const chatKey = `cs:${chat}`
-    await awaitRoom(chatKey, perChatWindowMs, perChatSendMax, method, 'release')
+    // Sends create user-visible output and are NEVER dropped — only paced. The
+    // shared budget's reserve is what guarantees they still have room when the
+    // repaint surfaces are saturated.
+    await awaitRoom(`cs:${chat}`, perChatWindowMs, perChatSendMax, method, 'release', cls, undefined, deadline)
+    await awaitRoom(totalKey, perChatWindowMs, totalMaxFor(cls), method, 'release', cls, undefined, deadline)
     return runObserved(next)
   }
 
@@ -454,7 +710,10 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
       superseded: counters.superseded,
       floodObserved: counters.floodObserved,
       tightened: isTightened(now),
+      tightenLevel: levelAt(now),
       perMessageCeiling: ceiling(perMessageMax, now),
+      cosmeticPerMessageCeiling: ceiling(cosmeticPerMessageMax, now),
+      cosmeticPerChatCeiling: ceiling(cosmeticPerChatMax, now),
     }
   }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -294,7 +294,7 @@ import {
   retryWithThreadFallback,
   isFloodWaitActiveError,
 } from '../retry-api-call.js'
-import { installEditFloodFuse } from '../edit-flood-fuse.js'
+import { installEditFloodFuse, editFloodFuseConfigFromEnv } from '../edit-flood-fuse.js'
 import { createSendGate, sendGateConfigFromEnv, isSendGateShed } from '../send-gate.js'
 import { createStatsLogger, createFloodWindowObserver } from '../send-gate-observability.js'
 import { installTgPostLogger, installRichMarkdownGuard, withTgPostTags } from '../shared/bot-runtime.js'
@@ -22965,8 +22965,8 @@ async function initGatewayBot(): Promise<void> {
   // outbound call can bypass (grammY has no route to the network that skips the
   // transformer stack). Kill-switch SWITCHROOM_EDIT_FUSE=0; see edit-flood-fuse.ts.
   installEditFloodFuse(bot, {
-    enabled: process.env.SWITCHROOM_EDIT_FUSE !== '0',
-    onTrip: (i) => process.stderr.write(`edit-flood-fuse ${i.action} method=${i.method} key=${i.key}\n`),
+    ...editFloodFuseConfigFromEnv(process.env),
+    onTrip: (i) => process.stderr.write(`edit-flood-fuse ${i.action} method=${i.method} key=${i.key} class=${i.cls}\n`),
   })
 
   // Diagnostic update tap (#3300): one compact line per received update, logged

--- a/telegram-plugin/outbound-class.ts
+++ b/telegram-plugin/outbound-class.ts
@@ -1,0 +1,81 @@
+/**
+ * Outbound priority class, propagated to the grammY transformer stack.
+ *
+ * ── Why this module exists ────────────────────────────────────────────────
+ * The send gate (`send-gate.ts`) knows every outbound call's `priorityClass`
+ * — `cosmetic` (a repaint of a progress card), `useful`, or `critical` (the
+ * operator's actual answer). The edit-flood fuse (`edit-flood-fuse.ts`) is a
+ * grammY API transformer, and a transformer sees only `(method, payload)`.
+ * It therefore could NOT tell a liveness repaint apart from a reply, and had
+ * to treat every edit identically.
+ *
+ * That blindness is the core defect behind the 2026-07-27 incident: agent
+ * `overlord` sustained ~17 activity-card edits/min for hours, earned a
+ * 15908-second (4.4h) per-chat flood ban, and the ban took out ALL replies.
+ * The fuse's per-chat edit ceiling at the time was 30/60s, so it never bound
+ * — a purely cosmetic surface was allowed to consume the whole chat's real
+ * Telegram budget, and the answer path paid for it.
+ *
+ * A class-aware fuse can do the two things a class-blind one cannot:
+ *   1. hold COSMETIC traffic to a rate far below Telegram's per-chat ceiling,
+ *      without throttling approval cards or answers; and
+ *   2. RESERVE part of the per-chat budget so a reply is never starved by
+ *      repaints.
+ *
+ * ── Why AsyncLocalStorage ─────────────────────────────────────────────────
+ * The class must travel from the send gate (well above grammY) down to the
+ * transformer, through an arbitrary async chain, WITHOUT smuggling a
+ * non-Bot-API field into the outbound payload. `AsyncLocalStorage` is the
+ * Node-native mechanism for exactly that, and the plugin already uses the
+ * same pattern for `tg-post` log tags (`shared/bot-runtime.ts`).
+ *
+ * This module deliberately has NO imports beyond `async_hooks`: both
+ * `send-gate.ts` (the writer) and `edit-flood-fuse.ts` (the reader) import
+ * it, so anything heavier would create an import cycle.
+ */
+
+import { AsyncLocalStorage } from 'async_hooks'
+
+/**
+ * Mirrors `send-gate.ts`'s `PriorityClass`. Declared here rather than
+ * imported so this module stays dependency-free (see the docblock); the
+ * send gate's `PriorityClass` is assignable to it and a compile-time
+ * assertion in `send-gate.ts` keeps the two in lockstep.
+ */
+export type OutboundClass = 'critical' | 'useful' | 'cosmetic'
+
+const store = new AsyncLocalStorage<OutboundClass>()
+
+/**
+ * Run `fn` with `cls` visible to every Telegram API call it makes, including
+ * across awaits. The send gate wraps each admitted call in this.
+ */
+export function withOutboundClass<T>(cls: OutboundClass, fn: () => T): T {
+  return store.run(cls, fn)
+}
+
+/** The class of the call currently in flight, or undefined when untagged. */
+export function currentOutboundClass(): OutboundClass | undefined {
+  return store.getStore()
+}
+
+/**
+ * The class the fuse assigns to a call that arrived with no tag.
+ *
+ * Asymmetric ON PURPOSE:
+ *
+ *   - an untagged EDIT is treated as `cosmetic`. An edit that never went
+ *     through the send gate is, by construction, exactly the shape of the
+ *     incident (the activity card edited one message id with no key and no
+ *     class). Defaulting it to cosmetic means a NEW unkeyed edit call site
+ *     is rate-limited by default instead of being invisible until it earns
+ *     a ban. Dropping a repaint is free — the next render carries full
+ *     state.
+ *   - an untagged SEND is treated as `critical`, matching the send gate's
+ *     own `UNTAGGED_SEND_CLASS`. Sends create user-visible output and are
+ *     never dropped by the fuse; the conservative default here is the one
+ *     that cannot lose an answer.
+ */
+export function defaultOutboundClass(isEdit: boolean): OutboundClass {
+  return isEdit ? 'cosmetic' : 'critical'
+}

--- a/telegram-plugin/send-gate.ts
+++ b/telegram-plugin/send-gate.ts
@@ -73,6 +73,7 @@ import {
   makeFloodWaitActiveError,
   isFloodWaitActiveError,
 } from './retry-api-call.js'
+import { withOutboundClass, type OutboundClass } from './outbound-class.js'
 
 /** Injectable time source. Default binds to real wall clock + setTimeout. */
 export interface Clock {
@@ -111,6 +112,20 @@ export type ChatType = 'private' | 'group' | 'supergroup' | 'channel'
  * dropped — so their default is non-droppable already.)
  */
 export type PriorityClass = 'critical' | 'useful' | 'cosmetic'
+
+/**
+ * Compile-time lock: `PriorityClass` and `outbound-class.ts`'s `OutboundClass`
+ * must stay identical, because the gate publishes the former into the latter's
+ * AsyncLocalStorage so the edit-flood fuse (a grammY transformer, which sees
+ * only `(method, payload)`) can tell a repaint from a reply. Adding a class to
+ * one and not the other fails `tsc`, not review.
+ */
+type _ClassesMatch =
+  OutboundClass extends PriorityClass
+    ? PriorityClass extends OutboundClass ? true : never
+    : never
+const _classesMatch: _ClassesMatch = true
+void _classesMatch
 
 /**
  * Priority class an UNTAGGED non-edit send is admitted as. `critical` =
@@ -1130,7 +1145,13 @@ export function createSendGate(config: SendGateConfig): SendGate {
           // the fact that the only production caller is `robustApiCall`, whose
           // own request/retry timeouts bound every send — so `p.fn()` is
           // guaranteed to settle. No separate watchdog is needed here.
-          const res = await p.fn()
+          // Publish the class for the edit-flood fuse (a grammY transformer
+          // downstream of here, which otherwise cannot tell a cosmetic repaint
+          // from an approval-card edit). `p.priorityClass` is the COALESCED
+          // class — a cosmetic edit that a `useful` one superseded is sent as
+          // `useful`, which is exactly what should happen: the frame going out
+          // carries the higher-priority payload.
+          const res = await withOutboundClass(p.priorityClass, () => p.fn())
           // M1: only record the payload as on-screen AFTER a successful send,
           // so a FAILED edit can be retried with the same payload (not dropped
           // as a phantom no-op).
@@ -1363,7 +1384,8 @@ export function createSendGate(config: SendGateConfig): SendGate {
 
     try {
       // N4: count `sent` only AFTER a successful send, mirroring the edit path.
-      const res = await fn()
+      // Class published for the fuse — see the edit path's call above.
+      const res = await withOutboundClass(priority, () => fn())
       counters.sent++
       return res
     } catch (err) {

--- a/telegram-plugin/tests/feed-edit-rate-ceiling.test.ts
+++ b/telegram-plugin/tests/feed-edit-rate-ceiling.test.ts
@@ -1,0 +1,457 @@
+/**
+ * Regression suite for the 2026-07-27 activity-feed flood ban.
+ *
+ * What happened: agent `overlord`'s live activity/worker feed edited its card
+ * at a sustained 4-17 `editMessageText`/min on ONE DM chat for hours (326
+ * edits against 6 real replies in the final 20 minutes). Telegram answered
+ * with a **15908-second** per-chat flood ban, which severed every outbound
+ * reply — a cosmetic progress indicator took out the agent's entire ability
+ * to communicate.
+ *
+ * The edit-flood fuse was already installed. It did not bind ONCE, because
+ * its ceilings (20 edits/60s per message, 30 edits/60s per chat) sat ABOVE
+ * the rate that earned the ban, and because it was class-blind: it could not
+ * tell a repaint from a reply, so it could not hold repaints to a low rate
+ * without also throttling answers.
+ *
+ * Every test here asserts an OUTCOME at the transformer seam — how many calls
+ * actually reached the API — under a scenario drawn from the incident. Each
+ * one fails if the cosmetic ceiling, the reply reservation, the class
+ * propagation, or the escalating 429 backoff is removed.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  createEditFloodFuse,
+  editFloodFuseConfigFromEnv,
+  EDIT_FLOOD_FUSE_DEFAULTS,
+} from '../edit-flood-fuse.js'
+import { withOutboundClass, currentOutboundClass } from '../outbound-class.js'
+import { createSendGate, type Clock } from '../send-gate.js'
+
+const CHAT = '1001'
+const CARD = 4242
+
+class FakeClock implements Clock {
+  private cur = 0
+  private seq = 0
+  private timers: { at: number; id: number; resolve: () => void }[] = []
+
+  now(): number { return this.cur }
+
+  sleep(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.timers.push({ at: this.cur + ms, id: this.seq++, resolve })
+    })
+  }
+
+  async advance(ms: number): Promise<void> {
+    const target = this.cur + ms
+    for (;;) {
+      await flush()
+      const due = this.timers.filter((t) => t.at <= target).sort((a, b) => a.at - b.at || a.id - b.id)
+      if (due.length === 0) break
+      const t = due[0]!
+      this.timers = this.timers.filter((x) => x !== t)
+      this.cur = t.at
+      t.resolve()
+      await flush()
+    }
+    this.cur = target
+    await flush()
+  }
+}
+
+function flush(): Promise<void> {
+  return new Promise((r) => setImmediate(r))
+}
+
+describe('feed flood ban — a cosmetic edit stream is held below the banned rate', () => {
+  it('replays the incident cadence: ~17 feed edits/min offered for 10 min admit ≤ the cosmetic ceiling', async () => {
+    const clock = new FakeClock()
+    const landed: number[] = []
+    const fuse = createEditFloodFuse({ clock })
+
+    // The incident's peak 10-minute bucket: 174 editMessageText calls against
+    // one card in one chat. Offered at a steady ~3.4s spacing, exactly as the
+    // feed heartbeat + worker ticks produced them.
+    const OFFERED = 174
+    const SPAN_MS = 600_000
+    const inflight: Promise<unknown>[] = []
+    for (let i = 0; i < OFFERED; i++) {
+      inflight.push(
+        withOutboundClass('cosmetic', () => fuse.apply(
+          'editMessageText',
+          { chat_id: CHAT, message_id: CARD, text: `frame ${i}` },
+          async () => { landed.push(i); return true },
+        )),
+      )
+      await clock.advance(Math.floor(SPAN_MS / OFFERED))
+    }
+    await clock.advance(EDIT_FLOOD_FUSE_DEFAULTS.maxDeferMs + 1_000)
+    await Promise.all(inflight)
+
+    const perMinuteAdmitted = landed.length / (SPAN_MS / 60_000)
+    // The ceiling that must hold. 4/min per card is the cosmetic per-message
+    // default; a little slack covers window-boundary effects.
+    expect(perMinuteAdmitted).toBeLessThanOrEqual(
+      EDIT_FLOOD_FUSE_DEFAULTS.cosmeticPerMessageMaxPerWindow + 1)
+    // …and it must be a REDUCTION, not a no-op: the offered rate is the rate
+    // that earned the ban.
+    expect(landed.length).toBeLessThan(OFFERED / 3)
+    // The card is still live — throttled, never silenced.
+    expect(landed.length).toBeGreaterThan(0)
+
+    // The pre-fix ceilings would not have bound at all. This is the assertion
+    // that makes the whole suite non-vacuous: 174/10min = 17.4/min, which is
+    // under BOTH old ceilings, which is precisely why the ban happened.
+    const offeredPerMin = OFFERED / (SPAN_MS / 60_000)
+    expect(offeredPerMin).toBeLessThan(EDIT_FLOOD_FUSE_DEFAULTS.perMessageMaxPerWindow)
+    expect(offeredPerMin).toBeLessThan(EDIT_FLOOD_FUSE_DEFAULTS.perChatEditMaxPerWindow)
+  })
+
+  it('coalesces rather than loses state: the LAST frame offered is the last frame painted', async () => {
+    const clock = new FakeClock()
+    const landed: string[] = []
+    const fuse = createEditFloodFuse({ clock })
+
+    const inflight: Promise<unknown>[] = []
+    for (let i = 1; i <= 60; i++) {
+      inflight.push(
+        withOutboundClass('cosmetic', () => fuse.apply(
+          'editMessageText', { chat_id: CHAT, message_id: CARD, text: `v${i}` },
+          async () => { landed.push(`v${i}`); return true },
+        )),
+      )
+      await clock.advance(1_000)
+    }
+    await clock.advance(120_000)
+    await Promise.all(inflight)
+
+    // Backpressure, not dropping-on-the-floor: the operator sees CURRENT state
+    // at every permitted edit, just less often. If the newest frame could be
+    // shed the card would go stale, which is the failure mode a plain rate
+    // limiter would introduce.
+    expect(landed[landed.length - 1]).toBe('v60')
+  })
+
+  it('N concurrent worker cards in one chat share the cosmetic allowance', async () => {
+    const clock = new FakeClock()
+    const landed: string[] = []
+    const fuse = createEditFloodFuse({ clock })
+
+    // 6 background workers, each with its own card, each individually inside
+    // the per-message ceiling. Only a per-CHAT cosmetic ceiling stops their sum.
+    const inflight: Promise<unknown>[] = []
+    // 9 rounds ⇒ every offer lands inside ONE 60s window, so the snapshot below
+    // measures the ceiling and not a window-boundary refill.
+    for (let round = 0; round < 9; round++) {
+      for (let w = 0; w < 6; w++) {
+        inflight.push(
+          withOutboundClass('cosmetic', () => fuse.apply(
+            'editMessageText', { chat_id: CHAT, message_id: 500 + w, text: `w${w} r${round}` },
+            async () => { landed.push(`w${w} r${round}`); return true },
+          )),
+        )
+      }
+      await clock.advance(6_000) // the gateway's FEED_HEARTBEAT_TICK_MS
+    }
+    const inWindow = landed.length
+    await clock.advance(EDIT_FLOOD_FUSE_DEFAULTS.maxDeferMs + 1_000)
+    await Promise.all(inflight)
+
+    // 54 offers across one 60s window; the chat's cosmetic allowance binds.
+    expect(inWindow).toBeLessThanOrEqual(
+      EDIT_FLOOD_FUSE_DEFAULTS.cosmeticPerChatMaxPerWindow
+      + EDIT_FLOOD_FUSE_DEFAULTS.lateReleaseMaxPerWindow + 1)
+  })
+})
+
+describe('feed flood ban — a real reply is never starved by feed edits', () => {
+  it('delivers a reply while the cosmetic budget is fully exhausted', async () => {
+    const clock = new FakeClock()
+    const replies: string[] = []
+    const fuse = createEditFloodFuse({ clock })
+
+    // Saturate: 200 cosmetic edits offered as fast as the feed can produce
+    // them, spread across several cards so every cosmetic tier is pinned.
+    const noise: Promise<unknown>[] = []
+    for (let i = 0; i < 200; i++) {
+      noise.push(
+        withOutboundClass('cosmetic', () => fuse.apply(
+          'editMessageText', { chat_id: CHAT, message_id: 700 + (i % 5), text: `n${i}` },
+          async () => true,
+        )),
+      )
+    }
+    await clock.advance(500)
+
+    // The operator's actual answer, issued mid-flood.
+    const reply = withOutboundClass('critical', () => fuse.apply(
+      'sendMessage', { chat_id: CHAT, text: 'the answer' },
+      async () => { replies.push('the answer'); return { message_id: 1 } },
+    ))
+    // It must land, and land PROMPTLY — inside the reserve, not after the
+    // cosmetic window slides. This is the property the incident violated: the
+    // feed consumed the chat's budget and the reply could not go out at all.
+    await clock.advance(2_000)
+    await reply
+    expect(replies).toEqual(['the answer'])
+
+    await clock.advance(300_000)
+    await Promise.all(noise)
+    // Not one reply was dropped by the fuse.
+    expect(fuse.stats().dropped).toBeGreaterThan(0) // cosmetic edits were shed…
+    expect(replies).toHaveLength(1)                 // …the answer was not.
+  })
+
+  it('does not throttle a non-cosmetic edit with the cosmetic ceiling', async () => {
+    const clock = new FakeClock()
+    const landed: number[] = []
+    const fuse = createEditFloodFuse({ clock })
+
+    // An approval card being re-rendered by operator taps: `useful`, low
+    // volume, but above the 4/min cosmetic ceiling. Throttling it would be a
+    // regression — the fix must separate classes, not just lower one number.
+    const inflight: Promise<unknown>[] = []
+    for (let i = 0; i < 10; i++) {
+      inflight.push(
+        withOutboundClass('useful', () => fuse.apply(
+          'editMessageText', { chat_id: CHAT, message_id: 900, text: `tap ${i}` },
+          async () => { landed.push(i); return true },
+        )),
+      )
+      await clock.advance(2_000)
+    }
+    await clock.advance(60_000)
+    await Promise.all(inflight)
+
+    expect(landed).toHaveLength(10)
+    expect(landed[landed.length - 1]).toBe(9)
+  })
+
+  it('treats an UNTAGGED edit as cosmetic — a new unkeyed call site is limited by default', async () => {
+    const clock = new FakeClock()
+    const landed: number[] = []
+    const fuse = createEditFloodFuse({ clock })
+
+    // No `withOutboundClass` wrapper at all: the shape of a future call site
+    // that never heard of the send gate. That is exactly how both the
+    // 2026-07-25 and 2026-07-27 floods started.
+    const inflight: Promise<unknown>[] = []
+    for (let i = 0; i < 60; i++) {
+      inflight.push(fuse.apply(
+        'editMessageText', { chat_id: CHAT, message_id: 950, text: `u${i}` },
+        async () => { landed.push(i); return true },
+      ))
+      await clock.advance(1_000)
+    }
+    const inWindow = landed.length
+    await clock.advance(EDIT_FLOOD_FUSE_DEFAULTS.maxDeferMs + 1_000)
+    await Promise.all(inflight)
+
+    expect(inWindow).toBeLessThanOrEqual(
+      EDIT_FLOOD_FUSE_DEFAULTS.cosmeticPerMessageMaxPerWindow + 1)
+  })
+
+  it('treats an UNTAGGED send as critical — never dropped', async () => {
+    const clock = new FakeClock()
+    const landed: number[] = []
+    const fuse = createEditFloodFuse({ clock })
+    const inflight: Promise<unknown>[] = []
+    for (let i = 0; i < 40; i++) {
+      inflight.push(fuse.apply('sendMessage', { chat_id: CHAT, text: `s${i}` },
+        async () => { landed.push(i); return { message_id: i } }))
+    }
+    await clock.advance(600_000)
+    await Promise.all(inflight)
+    expect(landed).toHaveLength(40)
+  })
+})
+
+describe('feed flood ban — a 429 reduces the subsequent feed edit rate', () => {
+  it('escalates: each 429 compounds the tightening rather than re-applying one step', async () => {
+    const clock = new FakeClock()
+    const fuse = createEditFloodFuse({ clock })
+    const base = EDIT_FLOOD_FUSE_DEFAULTS.cosmeticPerChatMaxPerWindow
+
+    expect(fuse.stats().tightenLevel).toBe(0)
+    expect(fuse.stats().cosmeticPerChatCeiling).toBe(base)
+
+    const flood = (): unknown => Object.assign(
+      new Error('Too Many Requests: retry after 3'),
+      { error_code: 429, parameters: { retry_after: 3 } },
+    )
+    const takeOne429 = async (): Promise<void> => {
+      await expect(fuse.apply('sendMessage', { chat_id: CHAT, text: 'x' },
+        async () => { throw flood() })).rejects.toThrow(/Too Many Requests/)
+    }
+
+    await takeOne429()
+    const after1 = fuse.stats().cosmeticPerChatCeiling
+    await clock.advance(1_000)
+    await takeOne429()
+    const after2 = fuse.stats().cosmeticPerChatCeiling
+
+    // Pre-fix a second 429 changed nothing: the tightening was a single flat
+    // 0.5× re-armed for another 10 minutes, so a stream taking repeated small
+    // 429s held the SAME rate and walked into the long ban.
+    expect(after1).toBeLessThan(base)
+    expect(after2).toBeLessThan(after1)
+    expect(fuse.stats().tightenLevel).toBe(2)
+  })
+
+  it('a 429 actually reduces how many feed edits get through afterwards', async () => {
+    const clock = new FakeClock()
+    const fuse = createEditFloodFuse({ clock })
+
+    const offerBurst = async (tag: string): Promise<number> => {
+      const landed: number[] = []
+      const inflight: Promise<unknown>[] = []
+      for (let i = 0; i < 40; i++) {
+        inflight.push(
+          withOutboundClass('cosmetic', () => fuse.apply(
+            'editMessageText', { chat_id: CHAT, message_id: 1234, text: `${tag}${i}` },
+            async () => { landed.push(i); return true },
+          )),
+        )
+        await clock.advance(500)
+      }
+      const n = landed.length
+      await clock.advance(EDIT_FLOOD_FUSE_DEFAULTS.maxDeferMs + 1_000)
+      await Promise.all(inflight)
+      return n
+    }
+
+    const before = await offerBurst('a')
+    // Let every window fully drain so the comparison isolates the tightening.
+    await clock.advance(120_000)
+
+    await expect(fuse.apply('sendMessage', { chat_id: CHAT, text: 'x' }, async () => {
+      throw Object.assign(new Error('Too Many Requests: retry after 3'),
+        { error_code: 429, parameters: { retry_after: 3 } })
+    })).rejects.toThrow(/Too Many Requests/)
+    await clock.advance(120_000)
+
+    const after = await offerBurst('b')
+
+    expect(before).toBeGreaterThan(0)
+    expect(after).toBeLessThan(before)
+  })
+
+  it('decays one level at a time rather than restoring full rate in one step', async () => {
+    const clock = new FakeClock()
+    const fuse = createEditFloodFuse({ clock, tightenMs: 60_000 })
+    const base = EDIT_FLOOD_FUSE_DEFAULTS.cosmeticPerMessageMaxPerWindow
+
+    for (let i = 0; i < 3; i++) {
+      await expect(fuse.apply('sendMessage', { chat_id: CHAT, text: 'x' }, async () => {
+        throw Object.assign(new Error('Too Many Requests: retry after 3'),
+          { error_code: 429, parameters: { retry_after: 3 } })
+      })).rejects.toThrow(/Too Many Requests/)
+    }
+    expect(fuse.stats().tightenLevel).toBe(3)
+
+    await clock.advance(60_001)
+    expect(fuse.stats().tightenLevel).toBe(2)
+    await clock.advance(60_001)
+    expect(fuse.stats().tightenLevel).toBe(1)
+    await clock.advance(60_001)
+    expect(fuse.stats().tightenLevel).toBe(0)
+    expect(fuse.stats().cosmeticPerMessageCeiling).toBe(base)
+  })
+})
+
+describe('feed flood ban — the send gate publishes the class the fuse depends on', () => {
+  it('a cosmetic gated EDIT is visible as cosmetic at the transformer seam', async () => {
+    const gate = createSendGate({ enabled: true })
+    let seen: string | undefined
+    await gate.gate(
+      async () => { seen = currentOutboundClass(); return true },
+      { chat_id: CHAT, messageId: CARD, editPayload: 'body', priorityClass: 'cosmetic' },
+    )
+    // Without this propagation the fuse's class awareness is decorative: every
+    // edit would fall back to the untagged default and the classes would never
+    // actually separate.
+    expect(seen).toBe('cosmetic')
+  })
+
+  it('a critical gated SEND is visible as critical at the transformer seam', async () => {
+    const gate = createSendGate({ enabled: true })
+    let seen: string | undefined
+    await gate.gate(
+      async () => { seen = currentOutboundClass(); return true },
+      { chat_id: CHAT, priorityClass: 'critical' },
+    )
+    expect(seen).toBe('critical')
+  })
+
+  it('an untagged gated send reports the gate\'s own UNTAGGED_SEND_CLASS', async () => {
+    const gate = createSendGate({ enabled: true })
+    let seen: string | undefined
+    await gate.gate(async () => { seen = currentOutboundClass(); return true }, { chat_id: CHAT })
+    expect(seen).toBe('critical')
+  })
+})
+
+describe('feed flood ban — the ceilings are operator-configurable', () => {
+  it('reads every ceiling from env, and keeps defaults when unset', () => {
+    // Pre-fix the ONLY knob was SWITCHROOM_EDIT_FUSE=0, which turns the whole
+    // failsafe off — an operator being flooded had no way to tighten it.
+    const cfg = editFloodFuseConfigFromEnv({
+      SWITCHROOM_FEED_EDIT_MAX_PER_MSG_PER_MIN: '2',
+      SWITCHROOM_FEED_EDIT_MAX_PER_CHAT_PER_MIN: '3',
+      SWITCHROOM_CHAT_TOTAL_MAX_PER_MIN: '15',
+      SWITCHROOM_CHAT_REPLY_RESERVE: '9',
+    })
+    expect(cfg).toMatchObject({
+      enabled: true,
+      cosmeticPerMessageMaxPerWindow: 2,
+      cosmeticPerChatMaxPerWindow: 3,
+      perChatTotalMaxPerWindow: 15,
+      perChatReplyReserve: 9,
+    })
+
+    const bare = editFloodFuseConfigFromEnv({})
+    expect(bare.cosmeticPerMessageMaxPerWindow).toBeUndefined()
+    expect(bare.enabled).toBe(true)
+    expect(editFloodFuseConfigFromEnv({ SWITCHROOM_EDIT_FUSE: '0' }).enabled).toBe(false)
+    // Garbage must not silently become 0 (which would deadlock every card).
+    expect(editFloodFuseConfigFromEnv({ SWITCHROOM_FEED_EDIT_MAX_PER_MSG_PER_MIN: 'lots' })
+      .cosmeticPerMessageMaxPerWindow).toBeUndefined()
+  })
+
+  it('an env-tightened ceiling actually binds', async () => {
+    const clock = new FakeClock()
+    const fuse = createEditFloodFuse({
+      clock, ...editFloodFuseConfigFromEnv({ SWITCHROOM_FEED_EDIT_MAX_PER_MSG_PER_MIN: '1' }),
+    })
+    const landed: number[] = []
+    const inflight: Promise<unknown>[] = []
+    for (let i = 0; i < 30; i++) {
+      inflight.push(
+        withOutboundClass('cosmetic', () => fuse.apply(
+          'editMessageText', { chat_id: CHAT, message_id: 4321, text: `e${i}` },
+          async () => { landed.push(i); return true },
+        )),
+      )
+      await clock.advance(1_000)
+    }
+    const inWindow = landed.length
+    await clock.advance(EDIT_FLOOD_FUSE_DEFAULTS.maxDeferMs + 1_000)
+    await Promise.all(inflight)
+    expect(inWindow).toBeLessThanOrEqual(2)
+  })
+
+  it('a reserve larger than the total budget cannot deadlock cosmetic traffic', async () => {
+    const clock = new FakeClock()
+    const fuse = createEditFloodFuse({
+      clock, perChatTotalMaxPerWindow: 5, perChatReplyReserve: 99,
+    })
+    const landed: number[] = []
+    await withOutboundClass('cosmetic', () => fuse.apply(
+      'editMessageText', { chat_id: CHAT, message_id: 8888, text: 'x' },
+      async () => { landed.push(1); return true },
+    ))
+    expect(landed).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Incident

`2026-07-27T20:19:56.704Z` — Telegram issued a **15908-second (4.4h) flood ban** on `scope=chat:8248703757`. It cut off ALL agent replies, not just the feed. In the final 20 minutes the worker-activity narrator issued **326 `editMessageText` against 6 real replies** (~54x more API traffic than answers). 10-minute `editMessageText` buckets leading in: 58, 53, 41, 115, 78, 73, 17, 25, **152, 174** — sustained 4-17 edits/min for hours, peaking ~17/min.

## Post-mortem: why the existing fuse did not trip

Both `edit-flood-fuse.ts` and `flood-circuit-breaker.ts` existed as preventive machinery. Neither was disabled and neither was unwired.

1. **The fuse WAS enabled and WAS structurally wired.** It installs as a grammY API transformer on the single `new Bot(TOKEN)` (`gateway/gateway.ts:22967`), so every `editMessageText` in the process — including the feed's — passes through it. `SWITCHROOM_EDIT_FUSE` was not set to `0`.
2. **It was NOT only per-message-id.** It already had a per-chat edit tier keyed `ce:${chat}`, so the aggregate chat rate was visible to it.
3. **Both ceilings sat ABOVE the banned rate by construction.** Pre-fix defaults were `perMessageMaxPerWindow: 20` and `perChatEditMaxPerWindow: 30` per 60s. The observed ~17.4 edits/min is under both. Nothing bound because nothing was configured to bind at the rate Telegram actually punishes.
4. **Those numbers were sized against in-repo pacers, not against Telegram.** `send-gate.ts`'s `editFloorMs = 1500` permits 40 edits/min/message; the worker feed's own `minEditInterval = 2500` (`worker-activity-feed.ts:758`) permits 24/min; `FEED_HEARTBEAT_TICK_MS = 6000` drives 10 repaints/min/turn. A fuse at 20-30/min is a ceiling above the floor its own producers set — i.e. decorative.
5. **The ~1.5s debounce is indeed a ~40/min floor**, and lowering it alone would not have fixed this: a debounce collapses bursts but does not bound sustained rate, and the incident was sustained.
6. **The real reason it could not simply be tightened is class-blindness.** A transformer sees only `(method, payload)`; the fuse could not tell a liveness repaint from a streamed answer or an approval card. Any ceiling low enough to stop the feed would equally have throttled the answer path.
7. **`flood-circuit-breaker.ts` is reactive, not preventive** — it opens on an observed 429. By the time it had evidence, the 4.4h ban was already issued. It is the wrong layer to have caught this.

## The fix

Priority separation, not a smaller debounce.

- **`telegram-plugin/outbound-class.ts` (new)** — carries the send gate's `priorityClass` down to the transformer via `AsyncLocalStorage` (the plugin already uses this pattern in `shared/bot-runtime.ts` for `tg-post` tags), without smuggling a non-Bot-API field into the outbound payload. Untagged EDIT defaults to `cosmetic` (a new unkeyed edit call site is rate-limited by default instead of invisible until it earns a ban); untagged SEND defaults to `critical`.
- **`telegram-plugin/send-gate.ts`** — wraps both execution sites in `withOutboundClass(...)`. A compile-time assertion locks `PriorityClass` and `OutboundClass` together, so adding a class to one and not the other fails `tsc`, not review.
- **`telegram-plugin/edit-flood-fuse.ts`** — cosmetic-only ceilings **4/msg/60s** and **6/chat/60s**. Chosen from the incident's own timeline: the 58/53/41 buckets (~4-6/min) ran for hours without a ban; 115/78/73 and then 152/174 (~8-17/min) earned one. 4/msg/60s equals the feed's own `elapsedRefreshMs` (15000), so the fuse never throttles the feed's intended pace — only its overrun.
- **A shared `t:${chat}` window at 20/60s** — Telegram's documented per-group ceiling, which meters sends and edits *together*, so it is the only window that reflects the real budget. **8 of those 20 slots are reserved from cosmetic traffic**: a reply is structurally unstarvable by repaints even if a future call site is misclassified.
- **Escalating 429 backoff** — AIMD replacing the flat single-step tighten. Up to 4 compounding levels, decaying one level per quiet `tightenMs` instead of a single cliff.
- **One defer deadline per `apply()` call**, shared across tiers. Previously each tier started its own `maxDeferMs`, so a call crossing three tiers could be held 3x that.
- **Bounded R1 late-release** — R1 says an over-budget edit nothing newer will repaint must be released late, not dropped (else the card freezes AND the send gate records a never-painted payload as on-screen). Taken literally that has no ceiling: cosmetic edits to *distinct* message ids are all "lone" frames, which is how N concurrent worker cards walked past a per-chat ceiling one frame at a time. Late releases are now charged to a 2/min window, preserving R1 for the genuinely-lone terminal recap.
- **Operator knobs.** The only prior control was `SWITCHROOM_EDIT_FUSE=0`, which turns the entire failsafe OFF. Adds `SWITCHROOM_FEED_EDIT_MAX_PER_MSG_PER_MIN`, `SWITCHROOM_FEED_EDIT_MAX_PER_CHAT_PER_MIN`, `SWITCHROOM_CHAT_TOTAL_MAX_PER_MIN`, `SWITCHROOM_CHAT_REPLY_RESERVE`, `SWITCHROOM_EDIT_FUSE_MAX_DEFER_MS`.

## Tests

`telegram-plugin/tests/feed-edit-rate-ceiling.test.ts` — 16 tests asserting outcomes:

- **Incident replay**: the peak 174-edits-in-10-min bucket driven through the fuse is held under the banned rate; coalescing preserves the newest frame; N concurrent worker cards share one chat allowance. The suite is explicitly non-vacuous — it asserts the *offered* rate is below **both** pre-fix ceilings, which is precisely why the ban happened, so these tests cannot pass with the limiter removed.
- **Reply is never starved**: a reply is delivered while the cosmetic budget is exhausted; `useful` edits are not caught by the cosmetic ceiling; untagged send is `critical` and never dropped.
- **429 reduces subsequent rate**: escalation compounds and measurably reduces later admissions; decay is one level at a time.
- **The seam is real**: an actual `createSendGate` is observed publishing the class at the transformer.
- **Knobs bind**: env parsing, an env-tightened ceiling actually binding, and an oversized reserve unable to deadlock the chat.

## Checked and deliberately left alone

- The `feedHeartbeatTick` post-answer branch is already correctly bounded: `POST_ANSWER_LIVENESS_STALE_MS` defaults ON at 30s (`gateway.ts:3006`, `turn-liveness-floor.ts:182`), consumed at `narrative-lane.ts:679`. Not the defect.
- Worker-feed TERMINAL/finalize edits are classed `cosmetic` alongside ordinary repaints (`gateway.ts:24003`). Ideally the terminal recap would be `useful`, but threading that requires adding lines to `gateway.ts`, which `check-gateway-line-ratchet` forbids (24917 lines against ratchet 24867 + slack 50 — zero room). The bounded late-release budget is the mitigation. Worth a follow-up when the ratchet moves.
- `gateway.ts` edits here are strictly line-neutral for that reason.

## Local verification

- `vitest run edit-flood-fuse.test.ts feed-edit-rate-ceiling.test.ts` → **31 passed**
- send-gate + flood suites (8 files) → **121 passed, 3 skipped**
- feed/narrative/liveness suites (7 files) → **170 passed**
- `npm run lint` → clean, including `check-bot-api-wrapping`, `check-gateway-line-ratchet`, `check-test-runner-coverage`, `tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)