### PR TITLE
fix(telegram): class the terminal worker-card frame `useful`, not cosmetic (#3848)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -180,7 +180,7 @@ import {
 import { fmtLocalStamp, resolveEnvTimezone, renderLogTimestampsLocal } from '../shared/local-time.js'
 import { StatusReactionController } from '../status-reactions.js'
 import { DeferredDoneReactions } from '../reaction-defer.js'
-import { createWorkerActivityFeed, isWorkerActivityFeedEnabled } from '../worker-activity-feed.js'
+import { createWorkerActivityFeed, isWorkerActivityFeedEnabled, workerFeedEditPriorityClass } from '../worker-activity-feed.js'
 import {
   detectMemoryLegibilityEvent,
   isMemoryLegibilityEnabled,
@@ -23986,7 +23986,7 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                   )
                   return sent as { message_id: number }
                 },
-                editMessageText: (cid, mid, text, editOpts) =>
+                editMessageText: (cid, mid, text, editOpts, editMeta) =>
                   robustApiCall(
                     () =>
                       lockedBot.api.editMessageText(
@@ -23995,12 +23995,12 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                         richMessage(text),
                         editOpts as Parameters<typeof lockedBot.api.editMessageText>[3],
                       ),
-                    // Worker-feed EDITs are COSMETIC — pass messageId/editPayload
-                    // so the per-message floor + coalescing + no-op skip engage.
+                    // Repaints COSMETIC, terminal frame USEFUL (#3848); messageId/
+                    // editPayload engage the floor + coalescing + no-op skip.
                     {
                       chat_id: cid,
                       verb: 'worker-feed',
-                      priorityClass: 'cosmetic',
+                      priorityClass: workerFeedEditPriorityClass(editMeta),
                       messageId: mid,
                       editPayload: text,
                     },

--- a/telegram-plugin/tests/worker-feed-terminal-edit-class.test.ts
+++ b/telegram-plugin/tests/worker-feed-terminal-edit-class.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Regression suite for switchroom#3848 — the terminal worker-card frame must
+ * not be shed with the heartbeat repaints.
+ *
+ * #3847 made the edit-flood fuse class-aware and tagged EVERY worker-feed edit
+ * `cosmetic`. That is right for a liveness repaint (dropping one costs
+ * nothing — the next render carries full state) and wrong for the TERMINAL
+ * frame: it is the last frame the operator ever reads for that card, and
+ * nothing newer is coming to repaint it. Classed cosmetic, the single frame
+ * carrying the finished state competed in the same starved budget as a
+ * heartbeat, and under sustained cosmetic pressure it was the frame dropped —
+ * leaving the card frozen mid-run forever.
+ *
+ * Every test here asserts an OUTCOME (did the call reach the API / what class
+ * did it carry), under the exact pressure scenario that sheds it. Each one
+ * goes RED if the terminal frame is classed `cosmetic` again — at the feed
+ * (`{ terminal: … }` no longer passed), at the mapping
+ * (`workerFeedEditPriorityClass`), or at the fuse.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { createEditFloodFuse, EDIT_FLOOD_FUSE_DEFAULTS } from '../edit-flood-fuse.js'
+import { withOutboundClass } from '../outbound-class.js'
+import type { Clock, PriorityClass } from '../send-gate.js'
+import {
+  createWorkerActivityFeed,
+  workerFeedEditPriorityClass,
+  type BotApiForWorkerFeed,
+  type WorkerActivityView,
+  type WorkerFeedEditMeta,
+} from '../worker-activity-feed.js'
+
+const CHAT = '1001'
+
+class FakeClock implements Clock {
+  private cur = 0
+  private seq = 0
+  private timers: { at: number; id: number; resolve: () => void }[] = []
+
+  now(): number { return this.cur }
+
+  sleep(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.timers.push({ at: this.cur + ms, id: this.seq++, resolve })
+    })
+  }
+
+  async advance(ms: number): Promise<void> {
+    const target = this.cur + ms
+    for (;;) {
+      await flush()
+      const due = this.timers.filter((t) => t.at <= target).sort((a, b) => a.at - b.at || a.id - b.id)
+      if (due.length === 0) break
+      const t = due[0]!
+      this.timers = this.timers.filter((x) => x !== t)
+      this.cur = t.at
+      t.resolve()
+      await flush()
+    }
+    this.cur = target
+    await flush()
+  }
+}
+
+function flush(): Promise<void> {
+  return new Promise((r) => setImmediate(r))
+}
+
+async function drain(): Promise<void> {
+  for (let i = 0; i < 12; i++) await flush()
+}
+
+function view(step: string, elapsedMs: number, state: 'running' | 'done' = 'running'): WorkerActivityView {
+  return { description: 'ship the fix', lastTool: null, toolCount: 2, latestSummary: step, elapsedMs, state }
+}
+
+/**
+ * The gateway's worker-feed edit adapter, reproduced EXACTLY as
+ * `gateway.ts` wires it (see the `createWorkerActivityFeed({ bot: { … } })`
+ * block): map the feed's out-of-band `meta` to a priority class with
+ * `workerFeedEditPriorityClass`, publish it on the AsyncLocalStorage the fuse
+ * reads, then hand the call to the transformer.
+ *
+ * `withOutboundClass` is what the real send gate does with `priorityClass`;
+ * doing it here keeps this test on the production mapping rather than a
+ * hand-written class literal.
+ */
+function gatewayEditAdapter(
+  fuse: { apply: <R>(m: string, p: unknown, next: () => Promise<R>) => Promise<R> },
+  onLand: (messageId: number, cls: PriorityClass) => void,
+) {
+  return (chatId: string, messageId: number, text: string, meta?: WorkerFeedEditMeta): Promise<unknown> => {
+    const cls: PriorityClass = workerFeedEditPriorityClass(meta)
+    return withOutboundClass(cls, () =>
+      fuse.apply('editMessageText', { chat_id: chatId, message_id: messageId, text }, async () => {
+        onLand(messageId, cls)
+        return true
+      }),
+    )
+  }
+}
+
+const D = EDIT_FLOOD_FUSE_DEFAULTS
+
+/**
+ * Offset at which the frame under test is offered, relative to the pressure
+ * burst. Small and non-zero: the frame must arrive AFTER the chat's cosmetic
+ * allowance is spent (so it has to wait) but early enough that its own
+ * `maxDeferMs` deadline still falls inside the pressure window — which is
+ * precisely the "sustained cosmetic pressure" #3848 describes. Offering it at
+ * t=0 would race the burst's own late releases at the same instant.
+ */
+const OFFER_AT_MS = 1_000
+
+/**
+ * Saturate a chat's cosmetic allowance the way a busy agent does: N distinct
+ * worker cards all repainting at once. Both the per-chat cosmetic ceiling
+ * (`cosmeticPerChatMaxPerWindow`, 6/60s) and the bounded R1 late-release
+ * budget (`lateReleaseMaxPerWindow`, 2/60s) get spent — the latter matters
+ * because a LONE cosmetic frame is otherwise released late rather than
+ * dropped. That late-release budget is the partial mitigation #3848 records,
+ * and running it out is what turns the degradation into a guaranteed drop.
+ *
+ * Returns the still-pending burst; the caller advances the clock past
+ * `maxDeferMs` once, resolving the burst and the frame under test together.
+ */
+function startCosmeticPressure(
+  fuse: { apply: <R>(m: string, p: unknown, next: () => Promise<R>) => Promise<R> },
+  landed: number[],
+): Promise<unknown>[] {
+  const total = D.cosmeticPerChatMaxPerWindow + D.lateReleaseMaxPerWindow
+  const pending: Promise<unknown>[] = []
+  for (let i = 0; i < total; i++) {
+    pending.push(
+      withOutboundClass('cosmetic', () =>
+        fuse.apply('editMessageText', { chat_id: CHAT, message_id: 9000 + i, text: `card ${i}` }, async () => {
+          landed.push(9000 + i)
+          return true
+        }),
+      ),
+    )
+  }
+  return pending
+}
+
+/**
+ * Offer ONE lone edit to a fresh message id under an already-exhausted
+ * cosmetic budget, as `cls`, and report whether it reached the API.
+ */
+async function offerLoneEditUnderPressure(cls: PriorityClass): Promise<boolean> {
+  const clock = new FakeClock()
+  const fuse = createEditFloodFuse({ clock })
+  const landed: number[] = []
+  const pressure = startCosmeticPressure(fuse, landed)
+  await clock.advance(OFFER_AT_MS)
+
+  let reachedApi = false
+  const call = withOutboundClass(cls, () =>
+    fuse.apply(
+      'editMessageText',
+      { chat_id: CHAT, message_id: 4242, text: '✅ done · 12 tools' },
+      async () => { reachedApi = true; return true },
+    ),
+  )
+  await clock.advance(D.maxDeferMs + 1_000)
+  await Promise.all([...pressure, call])
+  // Sanity: the pressure really did consume the whole cosmetic allowance.
+  expect(landed).toHaveLength(D.cosmeticPerChatMaxPerWindow + D.lateReleaseMaxPerWindow)
+  return reachedApi
+}
+
+describe('#3848 — a terminal worker-card frame survives an exhausted cosmetic budget', () => {
+  it('drops the terminal frame when it is classed cosmetic, and lands it when classed useful', async () => {
+    // Both halves run the SAME fuse config under the SAME pressure, so the
+    // ONLY difference is the class the terminal frame carries. The classes
+    // come from the production mapping, so reverting the promotion turns the
+    // second assertion into the first.
+    const asCosmetic = await offerLoneEditUnderPressure(workerFeedEditPriorityClass({ terminal: false }))
+    const asUseful = await offerLoneEditUnderPressure(workerFeedEditPriorityClass({ terminal: true }))
+
+    // The defect (#3848): with the cosmetic budget spent, the frame carrying
+    // the finished state never reaches Telegram — the card freezes mid-run.
+    expect(asCosmetic).toBe(false)
+    // The fix: the same frame, promoted because it is terminal, gets through.
+    expect(asUseful).toBe(true)
+  })
+
+  it('still holds INTERMEDIATE repaints to the cosmetic ceiling after the fix', async () => {
+    // Guards the other direction: promoting the terminal frame must not
+    // promote the heartbeat stream, or #3847's whole flood defence is undone.
+    expect(workerFeedEditPriorityClass({ terminal: false })).toBe('cosmetic')
+    expect(await offerLoneEditUnderPressure('cosmetic')).toBe(false)
+  })
+})
+
+describe('#3848 — the REAL feed tags its terminal frame, through the REAL gateway mapping', () => {
+  /**
+   * End-to-end over the production pieces: `createWorkerActivityFeed` drives
+   * the gateway's own edit adapter into a real `createEditFloodFuse`. Nothing
+   * here hand-writes a class — the class comes from whatever the feed passes
+   * as `meta`. If the feed stops passing `{ terminal: … }`, or the adapter
+   * stops consulting it, the terminal recap is shed and this goes RED.
+   */
+  it('lands the finish recap at the API while the chat cosmetic budget is exhausted', async () => {
+    const clock = new FakeClock()
+    const fuse = createEditFloodFuse({ clock })
+    const preLanded: number[] = []
+    const pressure = startCosmeticPressure(fuse, preLanded)
+    await clock.advance(OFFER_AT_MS)
+
+    const CARD = 777
+    const landedEdits: { messageId: number; cls: PriorityClass }[] = []
+    const edit = gatewayEditAdapter(fuse, (messageId, cls) => landedEdits.push({ messageId, cls }))
+
+    const bot: BotApiForWorkerFeed = {
+      sendMessage: async () => ({ message_id: CARD }),
+      editMessageText: (chatId, messageId, text, _opts, meta) => edit(chatId, messageId, text, meta),
+    }
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock.now(),
+      minEditIntervalMs: 0,
+      elapsedRefreshMs: 0,
+      firstPaintMinMs: 0,
+      setInterval: () => 0,
+      clearInterval: () => {},
+    })
+
+    // First paint (a send — never dropped), then the worker finishes.
+    await feed.update('w1', CHAT, view('reading gateway.ts', 30_000))
+    await drain()
+
+    const finish = feed.finish('w1', view('opened the PR', 60_000, 'done'))
+    await clock.advance(D.maxDeferMs + 1_000)
+    await finish
+    await Promise.all(pressure)
+    await drain()
+
+    // The pressure really did spend the whole cosmetic allowance…
+    expect(preLanded).toHaveLength(D.cosmeticPerChatMaxPerWindow + D.lateReleaseMaxPerWindow)
+    // …and the terminal recap still reached Telegram, as `useful`.
+    expect(landedEdits.map((e) => e.messageId)).toContain(CARD)
+    expect(landedEdits.filter((e) => e.messageId === CARD).every((e) => e.cls === 'useful')).toBe(true)
+  })
+
+  it('classes the running repaints cosmetic and only the finish frame useful', async () => {
+    const clock = new FakeClock()
+    const CARD = 888
+    const seen: { text: string; meta?: WorkerFeedEditMeta }[] = []
+    const bot: BotApiForWorkerFeed = {
+      sendMessage: async () => ({ message_id: CARD }),
+      editMessageText: async (_c, _m, text, _opts, meta) => { seen.push({ text, meta }); return true },
+    }
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock.now(),
+      minEditIntervalMs: 0,
+      elapsedRefreshMs: 0,
+      firstPaintMinMs: 0,
+      setInterval: () => 0,
+      clearInterval: () => {},
+    })
+
+    await feed.update('w1', CHAT, view('first step', 10_000))
+    await drain()
+    await feed.update('w1', CHAT, view('second step', 20_000))
+    await drain()
+    await feed.update('w1', CHAT, view('third step', 30_000))
+    await drain()
+    const beforeFinish = seen.length
+    await feed.finish('w1', view('all done', 40_000, 'done'))
+    await drain()
+
+    // At least one intermediate repaint and exactly the finish frame after it.
+    expect(beforeFinish).toBeGreaterThan(0)
+    expect(seen.length).toBeGreaterThan(beforeFinish)
+    for (const e of seen.slice(0, beforeFinish)) {
+      expect(e.meta?.terminal).toBe(false)
+      expect(workerFeedEditPriorityClass(e.meta)).toBe('cosmetic')
+    }
+    for (const e of seen.slice(beforeFinish)) {
+      expect(e.meta?.terminal).toBe(true)
+      expect(workerFeedEditPriorityClass(e.meta)).toBe('useful')
+    }
+  })
+})
+
+describe('#3848 — gateway.ts actually wires the mapping', () => {
+  /**
+   * `gateway.ts` is not unit-importable (a single 24k-line module with a live
+   * bot at construction), so `gatewayEditAdapter` above can only MIRROR its
+   * adapter. That mirror would keep passing if someone hard-coded
+   * `priorityClass: 'cosmetic'` back into the real adapter, which is exactly
+   * the regression #3848 fixes. This asserts the real wiring at the source,
+   * deterministically, instead of trusting the mirror.
+   */
+  const GATEWAY = new URL('../gateway/gateway.ts', import.meta.url)
+
+  it('passes the feed edit meta through workerFeedEditPriorityClass', () => {
+    const src = readFileSync(GATEWAY, 'utf8')
+    // The adapter must actually RECEIVE the meta argument from the feed.
+    const ANCHOR = 'editMessageText: (cid, mid, text, editOpts, editMeta) =>'
+    const at = src.indexOf(ANCHOR)
+    expect(at, `gateway.ts no longer declares the worker-feed edit adapter as \`${ANCHOR}\``).toBeGreaterThan(-1)
+
+    // Bound the slice to this one adapter: it ends at the `verb: 'worker-feed'`
+    // options object it passes to robustApiCall.
+    const verbAt = src.indexOf("verb: 'worker-feed'", at)
+    expect(verbAt).toBeGreaterThan(at)
+    const feedAdapter = src.slice(at, verbAt + 500)
+
+    expect(feedAdapter).toContain('priorityClass: workerFeedEditPriorityClass(editMeta)')
+    // The hard-coded class #3848 removed must not come back.
+    expect(feedAdapter).not.toContain("priorityClass: 'cosmetic'")
+    // And the symbol must be imported, or the above is dead source text.
+    expect(src).toContain('workerFeedEditPriorityClass')
+  })
+})
+
+describe('#3848 — the class mapping itself', () => {
+  it('maps terminal → useful and everything else → cosmetic', () => {
+    expect(workerFeedEditPriorityClass({ terminal: true })).toBe('useful')
+    expect(workerFeedEditPriorityClass({ terminal: false })).toBe('cosmetic')
+    // An adapter that forgets to forward `meta` must degrade to the SAFE
+    // class, not silently promote every repaint.
+    expect(workerFeedEditPriorityClass(undefined)).toBe('cosmetic')
+  })
+
+  it('returns a value assignable to the send gate PriorityClass union', () => {
+    // Compile-time half: this line fails `tsc` if the mapping ever returns a
+    // class the gate does not know (#3847's OutboundClass/PriorityClass lock).
+    const cls: PriorityClass = workerFeedEditPriorityClass({ terminal: true })
+    expect(['critical', 'useful', 'cosmetic']).toContain(cls)
+  })
+})

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -126,6 +126,49 @@ export interface WorkerActivityView {
   model?: string
 }
 
+/**
+ * Out-of-band metadata about ONE feed edit, handed to the transport adapter
+ * alongside the Bot API arguments (switchroom#3848).
+ *
+ * Deliberately a SEPARATE parameter rather than a field on `opts`: `opts` is
+ * forwarded verbatim to `editMessageText` and therefore onto the wire, and
+ * `outbound-class.ts` exists precisely so a priority signal never has to be
+ * smuggled into an outbound Bot API payload.
+ */
+export interface WorkerFeedEditMeta {
+  /**
+   * True when this edit paints the card's FINAL state — the last worker's
+   * terminal recap, or the "superseded" note on a rotated-out message. False
+   * for every intermediate / liveness repaint.
+   */
+  terminal: boolean
+}
+
+/**
+ * The send-gate priority class a worker-feed edit must carry.
+ *
+ * Intermediate repaints are `cosmetic`: dropping one costs nothing, because
+ * the next render carries full state, and holding them to the fuse's tight
+ * cosmetic ceilings (4/message/60s, 6/chat/60s) is what stops the feed
+ * earning a per-chat flood ban (#3847).
+ *
+ * A TERMINAL frame is `useful` (#3848). It is the last frame the operator
+ * ever reads for that card and nothing newer is coming to repaint it, so
+ * classing it cosmetic made the one frame carrying the finished state
+ * compete in — and get shed from — the same starved budget as a heartbeat.
+ * `useful` rather than `critical` matches the activity-summary finalize in
+ * `gateway/narrative-lane.ts`: it may be DEFERRED under pressure, but it is
+ * not shed, and it does not spend the per-chat reply reservation that keeps
+ * the operator's real answer unstarvable.
+ *
+ * Exported so the mapping is unit-testable; `gateway.ts` only calls it.
+ */
+export function workerFeedEditPriorityClass(
+  meta?: WorkerFeedEditMeta,
+): 'useful' | 'cosmetic' {
+  return meta?.terminal === true ? 'useful' : 'cosmetic'
+}
+
 export interface BotApiForWorkerFeed {
   sendMessage(
     chatId: string,
@@ -137,6 +180,12 @@ export interface BotApiForWorkerFeed {
     messageId: number,
     text: string,
     opts?: Record<string, unknown>,
+    /**
+     * Out-of-band edit metadata (NOT part of the Bot API payload). The
+     * gateway adapter maps `terminal` to the send-gate priority class via
+     * {@link workerFeedEditPriorityClass}.
+     */
+    meta?: WorkerFeedEditMeta,
   ): Promise<unknown>
 }
 
@@ -1194,7 +1243,11 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     }
 
     try {
-      const res = await opts.bot.editMessageText(g.chatId, g.messageId, body, sendOptsFor(g))
+      // #3848: tell the transport whether this is the card's LAST frame. A
+      // terminal recap must not be shed with the heartbeat repaints.
+      const res = await opts.bot.editMessageText(
+        g.chatId, g.messageId, body, sendOptsFor(g), { terminal: isTerminal },
+      )
       // Shed honesty (#3084): a cosmetic edit the gate shed resolves the
       // distinguishable SEND_GATE_SHED sentinel (NOT a bare `undefined`, which
       // the gate reserves for a benign no-op drop whose payload IS on screen).
@@ -1483,8 +1536,14 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
         // doesn't sit frozen showing live-styled rows (mistakable for a stuck
         // worker). ONE best-effort edit per rotation (≥ cap interval), fired
         // off-chain and swallowing errors — never per-tick, never a burst.
+        // #3848: terminal — this is the retired message's LAST frame, and it
+        // fires at most once per `groupMessageLifetimeCapMs`, so promoting it
+        // out of the cosmetic budget costs nothing and stops the retired card
+        // being left frozen showing live-styled rows.
         void opts.bot
-          .editMessageText(g.chatId, retiredId, WORKER_CARD_SUPERSEDED_BODY, sendOptsFor(g))
+          .editMessageText(
+            g.chatId, retiredId, WORKER_CARD_SUPERSEDED_BODY, sendOptsFor(g), { terminal: true },
+          )
           .catch(() => {})
       }
 


### PR DESCRIPTION
Closes #3848. The last known gap in the class-aware edit-flood fuse from #3847.

## The gap

#3847 made the fuse class-aware and tagged **every** worker-feed edit `cosmetic` (`gateway.ts:24003`). That is right for a liveness repaint — dropping one costs nothing, the next render carries full state — and wrong for the **terminal** frame. A terminal frame is the last frame the operator ever reads for that card, and nothing newer is coming to repaint it, so classing it cosmetic made the single frame carrying the finished state compete in the same starved budget as a heartbeat. Under sustained cosmetic pressure it was the frame shed, leaving the card frozen mid-run permanently.

## The distinction was already there

`worker-activity-feed.ts` has a clean `isTerminal` at the exact edit call site — `doRender`'s `terminalRecap != null`, supplied only when the finishing worker is the **last live one** in its group (`finalize`, latched by `markFinalized`). It simply had no way to tell the transport.

It now hands the adapter an out-of-band `WorkerFeedEditMeta { terminal }`. That is a **separate parameter, not a field on `opts`**: `opts` is forwarded verbatim to `editMessageText` and therefore onto the wire, and `outbound-class.ts` exists precisely so a priority signal never has to be smuggled into an outbound Bot API payload. `workerFeedEditPriorityClass` maps it; `gateway.ts` calls that instead of a hard-coded literal.

`useful`, not `critical` — matching the activity-summary finalize already at `gateway/narrative-lane.ts:899`, with the same rationale in its comment. It may be **deferred** under pressure but is not shed, and it does not spend the per-chat reply reservation that keeps the operator's real answer unstarvable. Intermediate repaints stay `cosmetic`, so #3847's flood defence is untouched.

The two feed edits promoted: the terminal recap, and the `WORKER_CARD_SUPERSEDED_BODY` note on a rotated-out message (also that message's last frame, ≤1 per `groupMessageLifetimeCapMs`).

**Added traffic is negligible** — a terminal recap fires once per group emptying, latched per agent id; both promoted edits sit far under the non-cosmetic 20/60s per-message ceiling, and a failing re-drive backs off on `g.cooldownUntil` / `parkIfFloodWindowOpen`.

## The line ratchet — option 1, strictly line-neutral

`gateway.ts` is **24917 lines before and after**, against ratchet 24867 + slack 50 — i.e. zero headroom, which is exactly why #3847 filed the issue instead of fixing it. Re-measured on this branch; both numbers were unchanged from the issue.

Achieved without any restructuring, because the class was already a one-line value:

- `priorityClass: 'cosmetic',` → `priorityClass: workerFeedEditPriorityClass(editMeta),` (1 line → 1 line)
- the adapter's param list gains `editMeta` on its existing line
- the two-line comment above it was rewritten in two lines
- the helper is imported on the **existing** `../worker-activity-feed.js` import line, so no new import line

`check-gateway-line-ratchet`: clean, ratchet file untouched.

Raising the ratchet was never actually on the table, contrary to the issue's framing: rule 3 (NEVER-RAISE, `check-gateway-line-ratchet.mjs`) fails CI on any PR whose ratchet exceeds `origin/main`'s.

## Tests — `telegram-plugin/tests/worker-feed-terminal-edit-class.test.ts` (7)

Every test asserts an outcome at the transformer seam under the pressure that actually sheds the frame. Reaching that state required exhausting **both** the per-chat cosmetic ceiling (`cosmeticPerChatMaxPerWindow`, 6/60s) **and** the bounded R1 late-release budget (`lateReleaseMaxPerWindow`, 2/60s) — the latter is the partial mitigation #3848 records, and running it out is what turns the degradation into a guaranteed drop. The frame under test is offered 1s into the burst so its own `maxDeferMs` deadline falls inside the pressure window; a single burst whose window slides within `maxDeferMs` does *not* reproduce the defect.

Headline test offers the **same lone frame under the same pressure**, as cosmetic and as useful, with the classes coming from the production mapping:

```
expect(asCosmetic).toBe(false)   // the defect: never reaches Telegram
expect(asUseful).toBe(true)      // the fix: deferred, but delivered
```

Also covered: intermediate repaints are still held to the cosmetic ceiling (the promotion must not undo #3847); the **real** `createWorkerActivityFeed` driving the gateway's own adapter into a **real** `createEditFloodFuse` lands the finish recap while the chat's cosmetic budget is exhausted; running repaints carry `terminal: false` and only the finish frame `terminal: true`.

**Mutation-verified against all three revert points** (a test that wouldn't fail on the bug it guards is not a test):

| revert | tests red |
|---|---|
| `workerFeedEditPriorityClass` → always `'cosmetic'` | 4 |
| feed stops passing `{ terminal: isTerminal }` | 2 |
| `gateway.ts` adapter reverted | 1 (source guard) |

`gateway.ts` is not unit-importable, so the adapter in the e2e test can only *mirror* it — the mirror would keep passing if someone hard-coded `priorityClass: 'cosmetic'` back into the real file. The source guard closes that deterministically rather than trusting the mirror.

`PriorityClass` / `OutboundClass` compile-time lock (`send-gate.ts:123`): satisfied — the mapping returns `'useful' | 'cosmetic'`, and one test pins the return type to `PriorityClass` so a divergence fails `tsc`.

## Local verification

- `tsc --noEmit` clean
- `check-gateway-line-ratchet`, `check-bot-api-wrapping` (file:line-keyed — clean, no range widening needed), `check-plugin-references`, `check-no-pii-secrets`, `check-bun-test-imports`, `check-stale-tool-descriptions`: all clean
- scoped: 9 worker-feed / fuse suites, **182 passed** — including #3847's `feed-edit-rate-ceiling.test.ts` (16) and the N=15-workers coalesce load test
- full `telegram-plugin/tests`: **7990 passed**, 1 failed

The one failure is `approval-hold-record.test.ts > falls back to the agent's own state dir when the shared dir is not writable`. Verified failing identically on pristine `origin/main` (stashed diff, same worktree) and it is an environment artifact, not a pre-existing bug: this container runs as uid 0, so the test's `chmod 0o555` does not make the dir unwritable. Unrelated to this diff. CI is the authority.

## Adversarial review

No blockers, no majors. One low filed as mandated: **#3850** — a `useful` terminal edit can occupy the per-group `g.chain` up to `usefulTtlMs` (120s) under bucket pressure, where `settleForCaller` released a `cosmetic` one immediately. Bounded, gated behind `parkIfFloodWindowOpen`, nothing user-visible waits on it (the row and pin are released before the edit, per #3207), and it is the same trade-off `narrative-lane.ts` already accepts.

Do **not** auto-merge — leaving open for the operator to queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)