### PR TITLE
refactor(cards): one card layout core, plus golden + end-to-end lifecycle coverage (closes #3844, #3846)

### DIFF
--- a/scripts/card-previews.ts
+++ b/scripts/card-previews.ts
@@ -5,362 +5,12 @@
  *
  * Run: bun scripts/card-previews.ts > card-previews.md
  *
- * Not a test; not wired into CI. Kept in-repo so the previews can be regenerated
- * verbatim whenever a card renderer changes.
+ * Not a test; not wired into CI. The fixtures live in
+ * `telegram-plugin/tests/card-variants.ts` — the SAME catalogue the golden
+ * suite (`telegram-plugin/tests/card-golden.test.ts`) pins byte-for-byte, so
+ * this doc and the regression alarm can never drift apart.
  */
-import {
-  renderActivityFeed,
-  renderActivityFeedWithNested,
-  renderCombinedWorkerFeed,
-  type CombinedWorkerRow,
-  type SessionActivityHeader,
-} from '../telegram-plugin/tool-activity-summary.js'
-import {
-  renderWorkerActivity,
-  WORKER_CARD_SUPERSEDED_BODY,
-  type WorkerActivityView,
-} from '../telegram-plugin/worker-activity-feed.js'
-
-type Section = {
-  name: string
-  fn: string
-  when: string
-  out: string
-  /** Does this variant reach the shared `renderStatusCard` primitive? */
-  shared: 'shared' | 'mixed' | 'divergent'
-}
-const sections: Section[] = []
-const add = (
-  name: string,
-  fn: string,
-  when: string,
-  out: string | null,
-  shared: 'shared' | 'mixed' | 'divergent' = 'shared',
-): void => {
-  sections.push({ name, fn, when, out: out ?? '(null — renderer returned nothing)', shared })
-}
-
-// Visualise the invisible: U+2800 BRAILLE BLANK and U+00A0 would otherwise be
-// silent in a fenced block. Rendered as themselves PLUS a legend note.
-const agentHeader = (over: Partial<SessionActivityHeader> = {}): SessionActivityHeader => ({
-  label: 'Agent',
-  elapsedMs: 95_000,
-  toolCount: 12,
-  state: 'running',
-  model: 'claude-opus-4-8',
-  totalTokens: 41_200,
-  ...over,
-})
-
-const AGENT_STEPS = [
-  'Searching memory for card render paths',
-  'Reading telegram-plugin/tool-activity-summary.ts',
-  'Reading telegram-plugin/worker-activity-feed.ts',
-  'Grepping for renderStatusCard callers',
-  'Drafting the inventory table',
-]
-
-// ── 1. Agent card — running ────────────────────────────────────────────────
-add(
-  'Agent card — running',
-  'renderActivityFeed → renderStatusCard',
-  'Every turn that labels a tool. Pinned in the session chat, edited in place.',
-  renderActivityFeed(AGENT_STEPS, false, '', undefined, agentHeader()),
-)
-
-// ── 2. Agent card — final ──────────────────────────────────────────────────
-add(
-  'Agent card — final (turn complete)',
-  'renderActivityFeed → renderStatusCard',
-  'The terminal edit when the turn ends: every step struck, `✓ N steps` footer.',
-  renderActivityFeed(AGENT_STEPS, true, '', 17, agentHeader({ state: 'done', elapsedMs: 214_000 })),
-)
-
-// ── 3. Agent card — no header (steps only) ─────────────────────────────────
-add(
-  'Agent card — steps only (no header)',
-  'renderActivityFeed → renderStatusCard (header omitted)',
-  'Legacy/direct callers (`appendActivityLine`, `appendActivityLabel`) that pass no header.',
-  renderActivityFeed(AGENT_STEPS.slice(0, 3)),
-)
-
-// ── 4. Agent card — nested foreground sub-agent ────────────────────────────
-add(
-  'Agent card — with nested foreground sub-agent',
-  'renderActivityFeedWithNested → renderStatusCard (childSteps)',
-  'A foreground Task/Agent runs inside the turn: parent lines all struck, the live `→` sits in the `↳` child block.',
-  renderActivityFeedWithNested(
-    AGENT_STEPS.slice(0, 3),
-    ['Reading the repo conventions', 'Running the scoped test suite', 'Summarising findings'],
-    false,
-    ' · 24s',
-    undefined,
-    agentHeader(),
-  ),
-)
-
-// ── 5. Agent card — liveness early-open ────────────────────────────────────
-add(
-  'Agent card — liveness early-open (no tools yet)',
-  'narrative-lane.ts:572 → renderActivityFeedWithNested → renderStatusCard',
-  'A silent turn passes the liveness threshold before any tool is labelled — the card opens on `Working…`.',
-  renderActivityFeedWithNested(
-    ['Working…'],
-    [],
-    false,
-    ' · 32s',
-    undefined,
-    { label: 'Agent', elapsedMs: 32_000, toolCount: 0, state: 'running', model: 'claude-opus-4-8' },
-  ),
-)
-
-// ── 6. Agent card — liveness finalised ─────────────────────────────────────
-add(
-  'Agent card — liveness finalised',
-  'narrative-lane.ts:882 → renderActivityFeedWithNested → renderStatusCard',
-  'The liveness-only card at turn end: `→ Working…` becomes a done record instead of freezing live.',
-  renderActivityFeedWithNested(
-    ['Working…'],
-    [],
-    true,
-    '',
-    undefined,
-    { label: 'Agent', elapsedMs: 88_000, toolCount: 0, state: 'done', model: 'claude-opus-4-8' },
-  ),
-)
-
-// ── 7. Agent card — post-answer background sub-agent liveness ──────────────
-add(
-  'Agent card — post-answer background activity',
-  'narrative-lane.ts:699 → renderActivityFeedWithNested → renderStatusCard',
-  'The reply already went out and a background sub-agent is still running — the card surfaces below the reply.',
-  renderActivityFeedWithNested(
-    ['Working in background…'],
-    [],
-    false,
-    ' · 1m10s',
-    undefined,
-    { label: 'Agent', elapsedMs: 130_000, toolCount: 3, state: 'running', model: 'claude-opus-4-8' },
-  ),
-)
-
-// ── 8. Agent card — budget overflow ────────────────────────────────────────
-const LONG = 'A'.repeat(700)
-add(
-  'Agent card — char-budget overflow backstop',
-  'renderStatusCard → fitCardToBudget',
-  'The rendered card exceeds STATUS_CARD_CHAR_BUDGET: oldest bullets are dropped and a `+N earlier…` marker re-inserted.',
-  renderActivityFeed(
-    [LONG, LONG, LONG, 'Finally a short newest step'],
-    false,
-    '',
-    undefined,
-    agentHeader(),
-  ),
-)
-
-// ── Worker views ───────────────────────────────────────────────────────────
-const workerView = (over: Partial<WorkerActivityView> = {}): WorkerActivityView => ({
-  workerId: 'w1',
-  description: 'Audit every card render path and de-indent the worker card',
-  state: 'running',
-  elapsedMs: 143_000,
-  toolCount: 31,
-  latestSummary: '',
-  narrativeLines: [
-    'Fetching origin and branching off main',
-    'Reading telegram-plugin/status-no-truncate.ts',
-    'Mapping renderStatusCard callers',
-    'Writing the preview harness',
-  ],
-  model: 'claude-opus-4-8',
-  totalTokens: 88_400,
-  ...over,
-}) as WorkerActivityView
-
-// ── 9. Worker card — just dispatched ───────────────────────────────────────
-add(
-  'Worker card — just dispatched (no steps yet)',
-  'renderWorkerActivity → renderStatusCard, then a hand-rolled starting… tail appended outside the primitive',
-  'The first paint of a background worker, before it has produced a narrative line.',
-  renderWorkerActivity(workerView({ narrativeLines: [], latestSummary: '', elapsedMs: 1_200, toolCount: 0 })),
-  'mixed',
-)
-
-// ── 10. Worker card — running ──────────────────────────────────────────────
-add(
-  'Worker card — single worker running',
-  'renderWorkerActivity → renderStatusCard',
-  'Exactly one background worker live in the chat. Pinned; edited in place.',
-  renderWorkerActivity(workerView(), ' · 18s'),
-)
-
-// ── 11. Worker card — done ─────────────────────────────────────────────────
-add(
-  'Worker card — done (with result recap)',
-  'renderWorkerActivity → renderStatusCard (result block)',
-  'The worker finished successfully: feed all-struck, rule, then the ✅ result paragraph.',
-  renderWorkerActivity(
-    workerView({
-      state: 'done',
-      elapsedMs: 902_000,
-      latestSummary:
-        'Inventoried 14 card variants, found renderCombinedWorkerFeed forks the header + budget logic, and de-indented the worker card. PR #0000.',
-    }),
-  ),
-)
-
-// ── 12. Worker card — failed ───────────────────────────────────────────────
-add(
-  'Worker card — failed',
-  'renderWorkerActivity → renderStatusCard (result block, ⚠️)',
-  'The worker errored: header line 2 reads `failed`, result block carries the error recap.',
-  renderWorkerActivity(
-    workerView({
-      state: 'failed',
-      elapsedMs: 61_000,
-      latestSummary: 'Scoped test run failed: 3 assertions in card-type-distinguishability.test.ts.',
-    }),
-  ),
-)
-
-// ── 13. Worker card — incomplete ───────────────────────────────────────────
-add(
-  'Worker card — incomplete (killed / timed out)',
-  'renderWorkerActivity → renderStatusCard (result suppressed by invariant)',
-  'The worker was terminated before producing a result — the renderer refuses to fabricate a result block.',
-  renderWorkerActivity(
-    workerView({ state: 'incomplete', elapsedMs: 1_805_000, latestSummary: 'stray text that must not render' }),
-  ),
-)
-
-// ── Combined feed ──────────────────────────────────────────────────────────
-const row = (n: number, desc: string, hist: string[], over: Partial<CombinedWorkerRow> = {}): CombinedWorkerRow => ({
-  ordinal: n,
-  description: desc,
-  elapsedMs: 60_000 * n + 15_000,
-  toolCount: 7 * n,
-  totalTokens: 20_000 * n,
-  currentStep: hist[hist.length - 1] ?? 'starting…',
-  historyLines: hist,
-  model: 'claude-opus-4-8',
-  ...over,
-})
-
-const H = (k: number, tag: string): string[] =>
-  Array.from({ length: k }, (_, i) => `${tag} step ${i + 1}`)
-
-// ── 14. Combined — 2 workers ───────────────────────────────────────────────
-add(
-  'WORKERS card — 2 workers',
-  'renderCombinedWorkerFeed',
-  '2+ background workers live in the same chat/thread coalesce into ONE message. Depth = 5 each.',
-  renderCombinedWorkerFeed(
-    [
-      row(1, 'Audit every card render path', H(5, 'audit')),
-      row(2, 'Fix the hindsight recall floor', H(5, 'recall')),
-    ],
-    { maxRows: 6 },
-  ),
-  'divergent',
-)
-
-// ── 15. Combined — 4 workers ───────────────────────────────────────────────
-add(
-  'WORKERS card — 4 workers',
-  'renderCombinedWorkerFeed',
-  'Depth degrades to the floor of Ken\'s 6/5/4/3 curve.',
-  renderCombinedWorkerFeed(
-    [
-      row(1, 'Audit every card render path', H(4, 'audit')),
-      row(2, 'Fix the hindsight recall floor', H(4, 'recall')),
-      row(3, 'Release v0.19.24', H(4, 'release')),
-      row(4, 'Investigate the flaky UAT scenario', H(4, 'uat')),
-    ],
-    { maxRows: 6 },
-  ),
-  'divergent',
-)
-
-// ── 16. Combined — spill ───────────────────────────────────────────────────
-add(
-  'WORKERS card — 8 workers (spill)',
-  'renderCombinedWorkerFeed (row-count backstop)',
-  'Beyond the design fan-out the NEWEST rows collapse into a single `+M more working…` line.',
-  renderCombinedWorkerFeed(
-    Array.from({ length: 8 }, (_, i) => row(i + 1, `Background task number ${i + 1}`, H(3, `t${i + 1}`))),
-    { maxRows: 6 },
-  ),
-  'divergent',
-)
-
-// ── 17. Combined — survivors keep ordinals ─────────────────────────────────
-add(
-  'WORKERS card — survivors keep their ordinals',
-  'renderCombinedWorkerFeed',
-  'Worker 1 finished; 2 and 3 keep their numbers, so the card shows `2.`/`3.` with no `1.`',
-  renderCombinedWorkerFeed(
-    [
-      row(2, 'Fix the hindsight recall floor', H(4, 'recall')),
-      row(3, 'Release v0.19.24', H(4, 'release')),
-    ],
-    { maxRows: 6 },
-  ),
-  'divergent',
-)
-
-// ── 18. Combined — no history yet ──────────────────────────────────────────
-add(
-  'WORKERS card — a worker with no history yet',
-  'renderCombinedWorkerFeed (→ starting… fallback)',
-  'A freshly dispatched worker joins a group that already has a live card.',
-  renderCombinedWorkerFeed(
-    [
-      row(1, 'Audit every card render path', H(5, 'audit')),
-      row(2, 'Freshly dispatched worker', [], { currentStep: '', historyLines: undefined }),
-    ],
-    { maxRows: 6 },
-  ),
-  'divergent',
-)
-
-// ── 19. Rotated / superseded card ──────────────────────────────────────────
-add(
-  'Worker card — superseded (group message rotated)',
-  'worker-activity-feed.ts WORKER_CARD_SUPERSEDED_BODY (static literal, no renderer)',
-  'The shared worker message hit its lifetime cap and a fresh card was opened; the retired message is finalised to this static note so it does not read as a stuck worker.',
-  WORKER_CARD_SUPERSEDED_BODY,
-  'divergent',
-)
-
-// ── 20. Agent card — rolling overflow ──────────────────────────────────────
-add(
-  'Agent card — rolling-window overflow',
-  'renderActivityFeed → renderStatusCard → renderStepFeed',
-  'More steps than the rolling window: the oldest collapse to a `✓ +N earlier…` header.',
-  renderActivityFeed(
-    Array.from({ length: 14 }, (_, i) => `Doing thing number ${i + 1}`),
-    false,
-    '',
-    undefined,
-    agentHeader(),
-  ),
-)
-
-// ── 21. Agent card — nested child overflow ─────────────────────────────────
-add(
-  'Agent card — nested sub-agent with child overflow',
-  'renderActivityFeedWithNested → renderStatusCard',
-  'The foreground sub-agent has produced more steps than the window: a `↳ +N earlier…` header appears in the child block.',
-  renderActivityFeedWithNested(
-    AGENT_STEPS.slice(0, 2),
-    Array.from({ length: 11 }, (_, i) => `Child step ${i + 1}`),
-    false,
-    '',
-    undefined,
-    agentHeader(),
-  ),
-)
+import { CARD_VARIANTS } from '../telegram-plugin/tests/card-variants.js'
 
 // ── emit ───────────────────────────────────────────────────────────────────
 const vis = (s: string): string =>
@@ -390,35 +40,41 @@ Lines are joined with a GFM hard break (\`  \\n\`).
 
 ## Verdict on centralisation
 
-**Mostly, not entirely.** Every 🤖 agent-card variant and every SINGLE-worker
-🛠 card goes through the one shared primitive, \`renderStatusCard\`
-(\`telegram-plugin/tool-activity-summary.ts\`). Three surfaces do not:
+**Yes — one renderer.** Every variant below is composed by the single card
+layout core, \`telegram-plugin/card-layout.ts\`: \`renderCardTitleLine\` +
+\`metricsRun\` compose every header, \`emitSection\` draws every step block, and
+\`fitCardToBudget\` is the ONLY char-budget enforcement. The 🤖 agent card, the
+single-worker 🛠 card and the 2+ worker 🛠 WORKERS card are now three
+\`CardSpec\` *configurations* of that core, not three implementations.
 
-1. \`renderCombinedWorkerFeed\` — the 2+ worker WORKERS card. It shares the
-   per-line pipeline (\`escapeStepLine\`, \`renderStepFeed\`, \`stackCardLines\`)
-   but composes its own header (\`glanceLine\` + \`rowHeader\`, not
-   \`renderActivityHeader\`) and carries its own char-budget backstop
-   (a row-shrinking loop, not \`fitCardToBudget\`).
-2. The just-dispatched \`starting…\` tail — appended by string concatenation
-   AFTER \`renderStatusCard\` returns, in \`renderWorkerActivity\`.
-3. \`WORKER_CARD_SUPERSEDED_BODY\` — a static literal with no renderer at all.
+One deliberate exception: \`WORKER_CARD_SUPERSEDED_BODY\` stays a constant. It
+carries no live state — no steps, no metrics, no window and no budget to
+enforce — so there is nothing for a renderer to compute. Its title line is
+composed by the shared \`renderCardTitleLine\`, so its chrome cannot drift from
+the live cards.
+
+Regression alarm: \`telegram-plugin/tests/card-golden.test.ts\` pins every
+variant's exact bytes; \`telegram-plugin/tests/card-lifecycle-render.test.ts\`
+drives the real feed manager through the full worker lifecycle and asserts the
+text actually sent to Telegram.
 
 ---
 
 `
 
 md += '## Inventory\n\n'
-md += '| # | Variant | Renderer | Shared primitive? |\n|---|---|---|---|\n'
-sections.forEach((s, i) => {
-  md += `| ${i + 1} | ${s.name} | \`${s.fn}\` | ${s.shared === 'shared' ? 'shared (`renderStatusCard`)' : s.shared === 'mixed' ? 'shared **+ hand-rolled tail**' : '**divergent**'} |\n`
+md += '| # | Variant | Renderer | Shared layout core? |\n|---|---|---|---|\n'
+CARD_VARIANTS.forEach((v, i) => {
+  const shared = v.layout === 'constant' ? 'constant (title line shared)' : 'shared (`card-layout.ts`)'
+  md += `| ${i + 1} | ${v.name} | \`${v.fn}\` | ${shared} |\n`
 })
 md += '\n---\n\n'
 
-for (const s of sections) {
-  md += `## ${s.name}\n\n`
-  md += `**Renderer:** \`${s.fn}\`\n\n`
-  md += `**When:** ${s.when}\n\n`
-  md += '```\n' + vis(s.out) + '\n```\n\n---\n\n'
+for (const v of CARD_VARIANTS) {
+  md += `## ${v.name}\n\n`
+  md += `**Renderer:** \`${v.fn}\`\n\n`
+  md += `**When:** ${v.when}\n\n`
+  md += '```\n' + vis(v.render() ?? '(null — renderer returned nothing)') + '\n```\n\n---\n\n'
 }
 
 process.stdout.write(md)

--- a/telegram-plugin/card-layout.ts
+++ b/telegram-plugin/card-layout.ts
@@ -1,0 +1,328 @@
+/**
+ * Card layout core — the ONE place a status/progress card is composed.
+ *
+ * Every card the gateway paints (🤖 agent, 🛠 single worker, 🛠 WORKERS
+ * combined, and their overflow/terminal variants) is expressed as a
+ * {@link CardSpec}: fixed `chrome` lines, N `sections` (each an optional
+ * header plus a windowed `✓`/`→` step trail), and fixed `footer` lines. The
+ * renderers in `tool-activity-summary.ts` / `worker-activity-feed.ts` are
+ * CONFIGURATIONS of this module, not parallel implementations.
+ *
+ * Two things used to exist twice and agreed only by hand (#3844):
+ *
+ *   1. **Header composition.** The combined card built its own row header
+ *      instead of going through `renderActivityHeader`, so the metrics run
+ *      (`{elapsed} · {n} tools · {t} tok · {model}`) was written out in two
+ *      places. It is now composed exactly once, by {@link metricsRun}, which
+ *      the agent header, the worker header, the combined row header and the
+ *      combined glance line all read.
+ *   2. **Char-budget enforcement.** The combined card carried its own
+ *      row-shrinking loop instead of the status card's `fitCardToBudget`.
+ *      There is now exactly one budget enforcer — {@link fitCardToBudget} —
+ *      a generic "render at progressively deeper shrink levels, take the
+ *      first that fits" loop. Each card supplies what a shrink level MEANS
+ *      (drop the oldest bullet / drop the newest row); nothing else compares
+ *      a rendered card against `STATUS_CARD_CHAR_BUDGET`.
+ *
+ * Nothing in here knows about workers, turns, or Telegram transport — it is
+ * pure string composition, so a card variant can be rendered (and asserted)
+ * without any of the feed machinery.
+ */
+
+import { escapeMarkdown, stripMarkdown, truncate, stackCardLines } from './card-format.js'
+import { formatModelLabel } from './model-label.js'
+import { STATUS_CARD_CHAR_BUDGET, STATUS_LINE_MAX, STATUS_ROLLING_LINES } from './status-no-truncate.js'
+
+// ─── Metrics composition (the single header vocabulary) ─────────────────────
+
+/** Format elapsed milliseconds for display in the activity header (e.g. "12s", "2m05s"). */
+export function formatFeedElapsed(ms: number): string {
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  return `${m}m${(s % 60).toString().padStart(2, '0')}s`
+}
+
+/**
+ * Compact token-count formatter for the activity card's metrics line:
+ *   <1000        → raw          ("940")
+ *   ≥1000, <1e6  → one-decimal k ("12.4k", "1.0k")
+ *   ≥1e6         → one-decimal M ("1.2M")
+ * Negative / non-finite inputs clamp to "0". The caller appends " tok".
+ */
+export function formatTokenCount(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return '0'
+  if (n < 1000) return String(Math.floor(n))
+  if (n < 1_000_000) {
+    // Round to the displayed 1-decimal k FIRST: inputs in [999_950, 999_999]
+    // round to "1000.0k", which must promote into the M branch rather than
+    // render a nonsense "1000.0k". Fall through when the rounded k reaches 1000.
+    const k = Number((n / 1000).toFixed(1))
+    if (k < 1000) return `${k.toFixed(1)}k`
+  }
+  return `${(n / 1_000_000).toFixed(1)}M`
+}
+
+/**
+ * The ` · {N} tok` metrics segment, or '' when there are no tokens to show.
+ * A 0 / undefined total (a worker that emitted no usage — e.g. a non-Claude
+ * transcript) OMITS the segment entirely so the line stays clean; every card
+ * that shows tokens reads this one predicate so they never diverge.
+ */
+export function tokenSegment(totalTokens: number | undefined): string {
+  if (totalTokens == null || totalTokens <= 0) return ''
+  return ` · ${formatTokenCount(totalTokens)} tok`
+}
+
+/** `tool` / `tools`, pluralised once for every surface that prints a tool count. */
+export function toolWord(n: number): string {
+  return n === 1 ? 'tool' : 'tools'
+}
+
+/** Terminal/running state a card (or a row on it) can report. */
+export type CardState = 'running' | 'done' | 'failed' | 'incomplete'
+
+/**
+ * The metrics RUN — the dot-separated `{elapsed} · {n} tools · {t} tok · {model}`
+ * text that every card header carries, WITHOUT the italic wrapper (callers own
+ * the wrapper because they place the leading separator differently).
+ *
+ * This is the single composition point the audit (#3844) found forked: the
+ * combined card's row header spelled the same run out by hand, so a change to
+ * (say) token placement had to be made twice and agreed only by inspection.
+ *
+ * `running` puts elapsed FIRST (it is the live fact); a terminal state leads
+ * with the state word and moves elapsed to the tail, so a failed or reaped
+ * worker never reads as done.
+ */
+export function metricsRun(
+  elapsedMs: number,
+  toolCount: number,
+  state: CardState,
+  totalTokens?: number,
+  model?: string,
+): string {
+  const elapsed = formatFeedElapsed(elapsedMs)
+  const tokPart = tokenSegment(totalTokens)
+  const modelLabel = formatModelLabel(model)
+  const modelPart = modelLabel != null ? ` · ${escapeMarkdown(modelLabel)}` : ''
+  return state === 'running'
+    ? `${elapsed} · ${toolCount} ${toolWord(toolCount)}${tokPart}${modelPart}`
+    : `${state} · ${toolCount} ${toolWord(toolCount)}${tokPart} · ${elapsed}${modelPart}`
+}
+
+/**
+ * Line 1 of a card: `<emoji> <b>LABEL</b> · <i>description</i>` (description
+ * optional). Shared by the agent card, the worker card and the static
+ * superseded notice, so the card's type chrome is composed in one place.
+ */
+export function renderCardTitleLine(emoji: string, label: string, description: string): string {
+  const descPart = description.length > 0 ? ` · _${escapeMarkdown(description)}_` : ''
+  return `${emoji} **${escapeMarkdown(label)}**${descPart}`
+}
+
+/**
+ * Render a two-line header for an activity card.
+ *
+ * Line 1: `<emoji> <b>Label</b> · <i>description</i>`  (description optional)
+ * Line 2: the metrics run, italicised.
+ *
+ * Returns a two-element array of ready Telegram markdown lines (no trailing
+ * newline).
+ */
+export function renderActivityHeader(
+  emoji: string,
+  label: string,
+  description: string,
+  elapsedMs: number,
+  toolCount: number,
+  state: CardState,
+  model?: string,
+  totalTokens?: number,
+): [string, string] {
+  return [
+    renderCardTitleLine(emoji, label, description),
+    `_${metricsRun(elapsedMs, toolCount, state, totalTokens, model)}_`,
+  ]
+}
+
+// ─── Per-line truncation pipeline ───────────────────────────────────────────
+//
+// Per RAW line, in this EXACT order:
+//   1. stripMarkdown(raw)
+//   2. .replace(/\s+/g, ' ').trim()
+//   3. truncate(_, STATUS_LINE_MAX)
+//   4. escapeMarkdown(_)   ← escape is ALWAYS the last per-line op.
+// Escaping last is load-bearing: clipping an already-escaped string can split
+// a markdown escape (\* → \), which renders wrong.
+
+/** Clean + clip + escape a single raw step line. Returns ready-to-wrap markdown. */
+export function escapeStepLine(raw: string): string {
+  const cleaned = stripMarkdown(raw).replace(/\s+/g, ' ').trim()
+  return escapeMarkdown(truncate(cleaned, STATUS_LINE_MAX))
+}
+
+/** The cleaned (unescaped) form of a raw line — the input to `truncate`. */
+export function cleanStepLine(raw: string): string {
+  return stripMarkdown(raw).replace(/\s+/g, ' ').trim()
+}
+
+// ─── Card spec ──────────────────────────────────────────────────────────────
+
+/**
+ * How a FINISHED step bullet is drawn.
+ *   'struck' — `~~_✓ step_~~`, the normal card body.
+ *   'plain'  — `_step_`, used by the char-budget shrink levels where the
+ *              strike/✓ chrome is spent bytes on a card already over the wire
+ *              limit.
+ */
+export type DoneStyle = 'struck' | 'plain'
+
+/** One section of a card: an optional header plus a windowed step trail. */
+export interface CardSection {
+  /** Ready lines emitted above this section's steps (the combined row header). */
+  header?: string[]
+  /** ALREADY-ESCAPED step lines, oldest → newest. */
+  steps: string[]
+  /** Trailing steps shown; the remainder collapses to a `+N earlier…` marker. */
+  window: number
+  /** When true every step renders done — no live `→` bullet. */
+  allDone?: boolean
+  /** Heartbeat suffix rendered INSIDE the newest in-progress bullet. */
+  liveSuffix?: string
+  /**
+   * Literal prefix on EVERY line this section emits (marker, bullets,
+   * placeholder), OUTSIDE the markdown spans so it never lands inside an
+   * emphasis run.
+   */
+  indent?: string
+  /**
+   * Token before a done step and inside the overflow marker. `'✓ '` on a normal
+   * body; `''` for the `↳` nested-child block, whose `↳` glyph already marks it.
+   */
+  doneMark?: string
+  /** See {@link DoneStyle}. Default 'struck'. */
+  doneStyle?: DoneStyle
+  /** Emitted (with `indent`) when this section has no steps at all. */
+  placeholder?: string
+}
+
+/** A whole card, as fixed chrome + sections + fixed footer. */
+export interface CardSpec {
+  /** Lines above every section — the card header, or the combined glance line. */
+  chrome?: string[]
+  sections: CardSection[]
+  /** Lines below every section — `✓ N steps`, the result block, the spill line. */
+  footer?: string[]
+}
+
+/**
+ * Emit one section's lines into `out`. This is the single `✓`/`→` bullet
+ * emitter: every step line on every card comes through here.
+ */
+export function emitSection(out: string[], section: CardSection): void {
+  const indent = section.indent ?? ''
+  const doneMark = section.doneMark ?? '✓ '
+  const doneStyle = section.doneStyle ?? 'struck'
+  const allDone = section.allDone === true
+  const liveSuffix = section.liveSuffix ?? ''
+  if (section.header != null) out.push(...section.header)
+  if (section.steps.length === 0) {
+    if (section.placeholder != null) out.push(`${indent}${section.placeholder}`)
+    return
+  }
+  const shown = section.steps.slice(-Math.max(1, section.window))
+  const hidden = section.steps.length - shown.length
+  if (hidden > 0) out.push(`${indent}_${doneMark}+${hidden} earlier…_`)
+  const lastIdx = shown.length - 1
+  shown.forEach((s, i) => {
+    if (!allDone && i === lastIdx) {
+      out.push(`${indent}**→ ${s}${liveSuffix}**`)
+      return
+    }
+    out.push(doneStyle === 'plain' ? `${indent}_${s}_` : `${indent}~~_${doneMark}${s}_~~`)
+  })
+}
+
+/**
+ * Shared step-feed emitter (back-compat signature). Appends `✓`/`→` bullet
+ * lines to `out` for the given ALREADY-ESCAPED step strings. Thin wrapper over
+ * {@link emitSection}.
+ */
+export function renderStepFeed(
+  out: string[],
+  steps: string[],
+  allDone: boolean,
+  liveSuffix = '',
+  window: number = STATUS_ROLLING_LINES,
+  indent = '',
+): void {
+  emitSection(out, { steps, window, allDone, liveSuffix, indent })
+}
+
+/** Flatten a spec to its ordered card lines. */
+export function cardSpecLines(spec: CardSpec): string[] {
+  const out: string[] = [...(spec.chrome ?? [])]
+  for (const section of spec.sections) emitSection(out, section)
+  out.push(...(spec.footer ?? []))
+  return out
+}
+
+/**
+ * Join card lines with GFM hard breaks so the styled prose lines don't collapse
+ * onto one visual line in the rich-message renderer — see `stackCardLines`.
+ *
+ * `collapseSafe` is unconditional here: every card this module renders is a
+ * PINNED surface, and Telegram's pinned bar shows a pinned message collapsed to
+ * one line with the newlines dropped and nothing substituted (#3666).
+ */
+export function stackCard(lines: string[]): string {
+  return stackCardLines(lines, { collapseSafe: true })
+}
+
+/** Render a spec straight to wire text, with no budget enforcement. */
+export function renderCardSpec(spec: CardSpec): string {
+  return stackCard(cardSpecLines(spec))
+}
+
+// ─── The one char-budget enforcer ───────────────────────────────────────────
+
+/** One shrink level's rendered candidate. */
+export interface CardCandidate {
+  spec: CardSpec
+  /**
+   * An additional card-specific ceiling this candidate violates (the combined
+   * card's total body-line budget). A candidate that fits the char budget but
+   * sets this is still rejected, so both ceilings are enforced by one loop.
+   */
+  overflow?: boolean
+}
+
+/**
+ * THE char-budget backstop — the only place a rendered card is measured against
+ * `STATUS_CARD_CHAR_BUDGET`.
+ *
+ * `build(level)` renders the card at progressively deeper shrink levels
+ * (level 0 = the full card). The first level whose rendered text fits the
+ * budget and clears its own `overflow` flag wins; if even `maxLevel` does not
+ * fit, that deepest render is returned — a card is always emitted, never
+ * dropped.
+ *
+ * What a level MEANS is the caller's business and is genuinely card-specific:
+ * the status card drops its oldest bullet (and, at its deepest level, truncates
+ * an oversized newest bullet), while the combined card drops its newest worker
+ * row into `+M more working…`. The MECHANISM — render, measure, accept or go
+ * deeper — exists only here.
+ */
+export function fitCardToBudget(
+  build: (level: number) => CardCandidate,
+  maxLevel: number,
+): string {
+  let text = ''
+  for (let level = 0; level <= maxLevel; level++) {
+    const candidate = build(level)
+    text = renderCardSpec(candidate.spec)
+    if (candidate.overflow !== true && text.length <= STATUS_CARD_CHAR_BUDGET) return text
+  }
+  return text
+}

--- a/telegram-plugin/tests/card-golden.test.ts
+++ b/telegram-plugin/tests/card-golden.test.ts
@@ -1,0 +1,69 @@
+/**
+ * GOLDEN SUITE — every status/progress card variant, pinned byte-for-byte.
+ *
+ * Why this exists: card rendering now flows through ONE layout core
+ * (`card-layout.ts`). That is the point — but it also means a change made for
+ * one card silently reshapes the other twenty. This suite is the alarm: it
+ * renders all variants in `card-variants.ts` through the real renderers and
+ * compares the exact wire text against a checked-in golden file. Any diff, in
+ * any card, fails.
+ *
+ * Regenerate deliberately (and read the diff in the PR):
+ *   UPDATE_CARD_GOLDEN=1 npx vitest run telegram-plugin/tests/card-golden.test.ts
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+import { CARD_VARIANTS, GOLDEN_DELIMITER, renderGoldenDocument } from './card-variants.js'
+
+const GOLDEN_PATH = join(dirname(fileURLToPath(import.meta.url)), 'card-variants.golden.txt')
+
+describe('card golden suite', () => {
+  it('every card variant renders exactly its pinned golden text', () => {
+    const actual = renderGoldenDocument()
+    if (process.env.UPDATE_CARD_GOLDEN === '1') {
+      writeFileSync(GOLDEN_PATH, actual, 'utf8')
+    }
+    const expected = readFileSync(GOLDEN_PATH, 'utf8')
+    // Compare per-variant first: a one-card regression should name that card,
+    // not dump a 21-card diff.
+    const split = (doc: string): Map<string, string> => {
+      const out = new Map<string, string>()
+      for (const chunk of doc.split(GOLDEN_DELIMITER).slice(1)) {
+        const nl = chunk.indexOf('\n')
+        out.set(chunk.slice(0, nl).trim(), chunk.slice(nl + 1))
+      }
+      return out
+    }
+    const exp = split(expected)
+    const act = split(actual)
+    for (const [name, body] of act) {
+      expect(exp.has(name), `golden has no entry for "${name}" — regenerate it`).toBe(true)
+      expect(body, `card "${name}" no longer renders its golden text`).toBe(exp.get(name))
+    }
+    // And the whole document, so a REMOVED or reordered variant also fails.
+    expect(actual).toBe(expected)
+  })
+
+  it('the golden covers every variant in the catalogue and nothing else', () => {
+    const golden = readFileSync(GOLDEN_PATH, 'utf8')
+    const namesInGolden = golden
+      .split(GOLDEN_DELIMITER)
+      .slice(1)
+      .map((c) => c.slice(0, c.indexOf('\n')).trim())
+    expect(namesInGolden).toEqual(CARD_VARIANTS.map((v) => v.name))
+    // Guards against a fixture that silently stops rendering (e.g. a renderer
+    // starting to return null) and thus stops asserting anything real.
+    expect(namesInGolden.length).toBeGreaterThanOrEqual(21)
+  })
+
+  it('no variant renders empty or null', () => {
+    for (const v of CARD_VARIANTS) {
+      const text = v.render()
+      expect(text, `variant "${v.name}" rendered null`).not.toBeNull()
+      expect((text ?? '').trim().length, `variant "${v.name}" rendered empty`).toBeGreaterThan(0)
+    }
+  })
+})

--- a/telegram-plugin/tests/card-lifecycle-render.test.ts
+++ b/telegram-plugin/tests/card-lifecycle-render.test.ts
@@ -1,0 +1,362 @@
+/**
+ * END-TO-END card lifecycle — drives the REAL feed manager
+ * (`createWorkerActivityFeed`) with realistic worker cues and asserts the
+ * EXACT text that reaches Telegram at every stage of a worker's life:
+ *
+ *   dispatch → running → a second worker joins (coalesce) → spill/overflow
+ *   → one finishes (survivors keep ordinals) → failure recap → supersede.
+ *
+ * This is deliberately NOT `renderStatusCard(opts)` in isolation. The seam is
+ * the highest one drivable in-process: feed state in, `sendMessage` /
+ * `editMessageText` bodies out — the same bytes the user reads on their phone.
+ * The golden suite (`card-golden.test.ts`) pins each variant's shape; this
+ * suite proves the lifecycle actually PRODUCES those variants, in order.
+ *
+ * Every assertion here is one that fails if the shared card layout core
+ * (`card-layout.ts`) changes header composition, step-block drawing, the
+ * rolling window, the placeholder, the spill line or the budget backstop.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  createWorkerActivityFeed,
+  WORKER_CARD_SUPERSEDED_BODY,
+  type BotApiForWorkerFeed,
+  type WorkerActivityView,
+} from '../worker-activity-feed.js'
+import { WORKER_STEP_INDENT } from '../status-no-truncate.js'
+
+const CHAT = '4242'
+
+interface Painted {
+  kind: 'send' | 'edit'
+  messageId: number
+  text: string
+}
+
+function harness(opts: { maxRows?: number; groupMessageLifetimeCapMs?: number } = {}) {
+  let now = 1_000_000
+  const painted: Painted[] = []
+  let nextId = 500
+  const bot: BotApiForWorkerFeed = {
+    async sendMessage(_chatId, text) {
+      const message_id = ++nextId
+      painted.push({ kind: 'send', messageId: message_id, text })
+      return { message_id }
+    },
+    async editMessageText(_chatId, messageId, text) {
+      painted.push({ kind: 'edit', messageId, text })
+      return {}
+    },
+  }
+  const feed = createWorkerActivityFeed({
+    bot,
+    now: () => now,
+    // Zero the rate limiters so every cue paints — this suite is about the
+    // RENDERED BYTES, not the edit budget (that is worker-feed-coalesce's job).
+    minEditIntervalMs: 0,
+    elapsedRefreshMs: 0,
+    firstPaintMinMs: 0,
+    maxRows: opts.maxRows ?? 6,
+    groupMessageLifetimeCapMs: opts.groupMessageLifetimeCapMs,
+    // No real timers in the test process.
+    setInterval: () => null,
+    clearInterval: () => {},
+  })
+  return {
+    feed,
+    painted,
+    advance: (ms: number) => {
+      now += ms
+    },
+    nowMs: () => now,
+    /** The most recent body sent or edited — what the user is looking at. */
+    last: (): string => painted[painted.length - 1]?.text ?? '',
+    reset: () => {
+      painted.length = 0
+    },
+  }
+}
+
+const view = (over: Partial<WorkerActivityView> = {}): WorkerActivityView => ({
+  description: 'Audit every card render path',
+  state: 'running',
+  elapsedMs: 12_000,
+  toolCount: 3,
+  lastTool: null,
+  latestSummary: '',
+  narrativeLines: [],
+  model: 'claude-opus-4-8',
+  totalTokens: 10_000,
+  ...over,
+})
+
+/** Await the feed's internal promise chain. */
+const settle = async (): Promise<void> => {
+  for (let i = 0; i < 8; i++) await new Promise((r) => setImmediate(r))
+}
+
+describe('worker card lifecycle — the bytes the user actually sees', () => {
+  it('dispatch: the first paint is a real card with a starting… placeholder, not a bare header', async () => {
+    const h = harness()
+    await h.feed.update('w1', CHAT, view({ elapsedMs: 1_200, toolCount: 0, narrativeLines: [] }))
+    await settle()
+
+    expect(h.painted.length).toBeGreaterThan(0)
+    expect(h.painted[0].kind).toBe('send')
+    const card = h.painted[0].text
+    // Title line, metrics line, placeholder — three lines, all from the layout core.
+    expect(card).toContain('🛠 **WORKER**')
+    expect(card).toContain('Audit every card render path')
+    expect(card).toMatch(/_1s · 0 tools · 10\.0k tok · opus 4\.8_/)
+    expect(card).toContain('_starting…_')
+    // #3846: the placeholder is a SECTION of the card, so it carries the same
+    // collapse-safe line joining as every other line — a hand-appended tail did not.
+    const lines = card.split('\n')
+    expect(lines.length).toBe(3)
+    for (const l of lines.slice(0, -1)) expect(l.endsWith('  ')).toBe(true)
+    expect(card).not.toContain('starting…\n_starting…_')
+  })
+
+  it('running: narrative steps become a ✓/→ trail under one shared header', async () => {
+    const h = harness()
+    await h.feed.update('w1', CHAT, view({ latestSummary: 'Fetching origin' }))
+    await settle()
+    h.reset()
+    // The watcher emits ONE latest step per tick; the feed accumulates them.
+    await h.feed.update('w1', CHAT, view({ toolCount: 10, latestSummary: 'Reading the renderer' }))
+    await settle()
+    await h.feed.update(
+      'w1',
+      CHAT,
+      view({ elapsedMs: 143_000, toolCount: 31, totalTokens: 88_400, latestSummary: 'Mapping callers' }),
+    )
+    await settle()
+
+    const card = h.last()
+    expect(card).toContain('~~_✓ Fetching origin_~~')
+    expect(card).toContain('~~_✓ Reading the renderer_~~')
+    expect(card).toContain('**→ Mapping callers**')
+    expect(card).not.toContain('_starting…_')
+    // The metrics line is composed once, by metricsRun — running order is
+    // `{elapsed} · {tools} · {tok} · {model}`.
+    expect(card).toContain('_2m23s · 31 tools · 88.4k tok · opus 4.8_')
+    // Single-worker card carries NO indent (#3843 de-indent).
+    expect(card).not.toContain(WORKER_STEP_INDENT)
+  })
+
+  it('depth budget: a row deeper than its per-worker budget shows only its newest steps', async () => {
+    // The feed retains WORKER_HISTORY_MAX (6) steps; with 2 workers the shared
+    // layout gives each row a depth of 5, so the oldest step must drop out.
+    const h = harness()
+    for (let i = 1; i <= 6; i++) {
+      await h.feed.update('w1', CHAT, view({ toolCount: i, latestSummary: `s${i}` }))
+      await settle()
+    }
+    await h.feed.update('w2', CHAT, view({ description: 'Second worker', latestSummary: 'b1' }))
+    await settle()
+
+    const card = h.last()
+    expect(card).not.toContain('s1_')
+    expect(card).toContain(`${WORKER_STEP_INDENT}~~_✓ s2_~~`)
+    expect(card).toContain(`${WORKER_STEP_INDENT}**→ s6**`)
+    // Exactly depth-1 done steps plus the one live step.
+    expect(card.split('\n').filter((l) => /~~_✓ s\d_~~/.test(l)).length).toBe(4)
+    expect(card.split('\n').filter((l) => l.includes('**→ ')).length).toBe(2)
+  })
+
+  it('two workers coalesce into ONE message whose rows share the header composer', async () => {
+    const h = harness()
+    await h.feed.update('w1', CHAT, view({ latestSummary: 'audit 1' }))
+    await settle()
+    const firstId = h.painted[0].messageId
+    h.reset()
+    await h.feed.update(
+      'w2',
+      CHAT,
+      view({
+        description: 'Fix the hindsight recall floor',
+        elapsedMs: 60_000,
+        toolCount: 7,
+        totalTokens: 20_000,
+        latestSummary: 'recall 1',
+      }),
+    )
+    await settle()
+
+    // One message, edited — not a second send.
+    expect(h.painted.every((p) => p.messageId === firstId)).toBe(true)
+    expect(h.painted.some((p) => p.kind === 'send')).toBe(false)
+
+    const card = h.last()
+    expect(card).toContain('🛠 **WORKERS**')
+    expect(card).toContain('2 running')
+    expect(card).toContain('**1. Audit every card render path**')
+    expect(card).toContain('**2. Fix the hindsight recall floor**')
+    // Row headers use the SAME metricsRun as the single-worker card.
+    expect(card).toContain('_· 1m00s · 7 tools · 20.0k tok · opus 4.8_')
+    // Rows are indented with the braille blank so Telegram cannot left-trim.
+    expect(card).toContain(`${WORKER_STEP_INDENT}**→ recall 1**`)
+  })
+
+  it('a worker with no history yet renders the shared placeholder inside its row', async () => {
+    const h = harness()
+    await h.feed.update('w1', CHAT, view({ latestSummary: 'audit 1' }))
+    await settle()
+    h.reset()
+    await h.feed.update('w2', CHAT, view({ description: 'Freshly dispatched', latestSummary: '' }))
+    await settle()
+
+    const card = h.last()
+    expect(card).toContain('**2. Freshly dispatched**')
+    expect(card).toContain(`${WORKER_STEP_INDENT}→ _starting…_`)
+  })
+
+  it('spill: beyond maxRows the newest rows collapse into one +M more working… line', async () => {
+    const h = harness({ maxRows: 6 })
+    for (let i = 1; i <= 8; i++) {
+      await h.feed.update(`w${i}`, CHAT, view({ description: `Background task ${i}`, latestSummary: `t${i} a` }))
+      await settle()
+    }
+    const card = h.last()
+    expect(card).toContain('8 running')
+    expect(card).toContain('**6. Background task 6**')
+    expect(card).not.toContain('**7. Background task 7**')
+    expect(card).toContain('_+2 more working…_')
+    // The spill line is the LAST line of the card (a footer, not a stray row).
+    const lines = card.split('\n')
+    expect(lines[lines.length - 1]).toContain('+2 more working…')
+  })
+
+  it('spill honours the body-line budget: many deep rows still shrink to fit', async () => {
+    const h = harness({ maxRows: 6 })
+    for (let i = 1; i <= 6; i++) {
+      await h.feed.update(
+        `w${i}`,
+        CHAT,
+        view({
+          description: `Background task ${i}`,
+          latestSummary: `t${i} step`,
+        }),
+      )
+      await settle()
+      for (const step of ['b', 'c', 'd', 'e', 'f']) {
+        await h.feed.update(`w${i}`, CHAT, view({ description: `Background task ${i}`, latestSummary: `t${i} ${step}` }))
+        await settle()
+      }
+    }
+    const card = h.last()
+    // MAX_COMBINED_BODY_LINES = 6 rows × (1 header + 3 steps) = 24.
+    const body = card.split('\n').filter((l) => !l.includes('🛠 **WORKERS**') && !l.includes('more working…'))
+    expect(body.length).toBeLessThanOrEqual(24)
+    // Shrinking drops ROWS, never the glance chrome.
+    expect(card).toContain('🛠 **WORKERS**')
+    expect(card).toContain('6 running')
+  })
+
+  it('one worker finishing leaves the survivors numbered as they were dispatched', async () => {
+    const h = harness()
+    await h.feed.update('w1', CHAT, view({ latestSummary: 'audit 1' }))
+    await settle()
+    await h.feed.update('w2', CHAT, view({ description: 'Second worker', latestSummary: 'b1' }))
+    await settle()
+    await h.feed.update('w3', CHAT, view({ description: 'Third worker', latestSummary: 'c1' }))
+    await settle()
+    expect(h.last()).toContain('**1. Audit every card render path**')
+    h.reset()
+
+    await h.feed.finish('w1', view({ state: 'done', latestSummary: 'All done.' }))
+    await settle()
+
+    const card = h.last()
+    expect(card).toContain('2 running')
+    expect(card).toContain('**2. Second worker**')
+    expect(card).toContain('**3. Third worker**')
+    expect(card).not.toContain('**1. ')
+  })
+
+  it('completion: the last worker collapses to a struck feed plus the ✅ result recap', async () => {
+    const h = harness()
+    await h.feed.update('w1', CHAT, view({ latestSummary: 'Fetching origin' }))
+    await settle()
+    await h.feed.update('w1', CHAT, view({ toolCount: 20, latestSummary: 'Mapping callers' }))
+    await settle()
+    h.reset()
+    await h.feed.finish(
+      'w1',
+      view({
+        state: 'done',
+        elapsedMs: 902_000,
+        toolCount: 44,
+        latestSummary: 'Inventoried every card variant and unified the renderer. PR #0000.',
+      }),
+    )
+    await settle()
+
+    const card = h.last()
+    // Terminal metrics order flips: `{state} · {tools} · {tok} · {elapsed}`.
+    expect(card).toContain('_done · 44 tools · 10.0k tok · 15m02s · opus 4.8_')
+    // No live `→` marker survives on a finished card.
+    expect(card).not.toContain('**→ ')
+    expect(card).toContain('~~_✓ Mapping callers_~~')
+    // The result block: shared rule, then the ✅ recap paragraph.
+    expect(card).toContain('─────')
+    expect(card).toContain('✅ _Inventoried')
+    expect(card).toContain('Inventoried every card variant and unified the renderer.')
+  })
+
+  it('failure: the card reads failed and carries the error recap', async () => {
+    const h = harness()
+    await h.feed.update('w1', CHAT, view({ latestSummary: 'Running the scoped suite' }))
+    await settle()
+    h.reset()
+    await h.feed.finish(
+      'w1',
+      view({
+        state: 'failed',
+        elapsedMs: 61_000,
+        toolCount: 9,
+        latestSummary: 'Scoped test run failed: 3 assertions.',
+      }),
+    )
+    await settle()
+
+    const card = h.last()
+    expect(card).toContain('_failed · 9 tools · 10.0k tok · 1m01s · opus 4.8_')
+    expect(card).toContain('⚠️ _Scoped test run failed: 3 assertions._')
+    expect(card).not.toContain('**→ ')
+  })
+
+  it('supersede: the retired message is finalised to the shared-chrome notice, and a fresh card opens', async () => {
+    const h = harness({ groupMessageLifetimeCapMs: 60_000 })
+    await h.feed.update('w1', CHAT, view({ latestSummary: 'step one' }))
+    await settle()
+    const firstId = h.painted[0].messageId
+    h.reset()
+
+    // Push the group's shared message past its lifetime cap, then let the
+    // heartbeat (the real rotation trigger) run.
+    h.advance(120_000)
+    await h.feed.update('w1', CHAT, view({ elapsedMs: 132_000, toolCount: 9, latestSummary: 'step two' }))
+    await settle()
+    h.feed.heartbeatTick()
+    await settle()
+
+    const superseded = h.painted.find((p) => p.text === WORKER_CARD_SUPERSEDED_BODY)
+    expect(superseded, 'the retired message must be finalised to the superseded notice').toBeDefined()
+    expect(superseded?.kind).toBe('edit')
+    expect(superseded?.messageId).toBe(firstId)
+    // Shared chrome: same title composer as every live card.
+    expect(WORKER_CARD_SUPERSEDED_BODY.startsWith('🛠 **WORKER** · _continued_')).toBe(true)
+    // The retired notice carries no live-styled rows — it must not read as a
+    // stuck worker.
+    expect(WORKER_CARD_SUPERSEDED_BODY).not.toContain('**→ ')
+
+    // A fresh, live card was opened for the still-running worker.
+    const fresh = h.painted.filter((p) => p.kind === 'send')
+    expect(fresh.length).toBe(1)
+    expect(fresh[0].messageId).not.toBe(firstId)
+    expect(fresh[0].text).toContain('🛠 **WORKER**')
+    expect(fresh[0].text).toContain('step two')
+  })
+})

--- a/telegram-plugin/tests/card-variants.golden.txt
+++ b/telegram-plugin/tests/card-variants.golden.txt
@@ -1,0 +1,211 @@
+
+===== CARD ===== Agent card — running
+🤖 **Agent**   
+_1m35s · 12 tools · 41.2k tok · opus 4.8_   
+~~_✓ Searching memory for card render paths_~~   
+~~_✓ Reading telegram-plugin/tool-activity-summary.ts_~~   
+~~_✓ Reading telegram-plugin/worker-activity-feed.ts_~~   
+~~_✓ Grepping for renderStatusCard callers_~~   
+**→ Drafting the inventory table**
+
+===== CARD ===== Agent card — final (turn complete)
+🤖 **Agent**   
+_done · 12 tools · 41.2k tok · 3m34s · opus 4.8_   
+~~_✓ Searching memory for card render paths_~~   
+~~_✓ Reading telegram-plugin/tool-activity-summary.ts_~~   
+~~_✓ Reading telegram-plugin/worker-activity-feed.ts_~~   
+~~_✓ Grepping for renderStatusCard callers_~~   
+~~_✓ Drafting the inventory table_~~   
+_✓ 17 steps_
+
+===== CARD ===== Agent card — steps only (no header)
+~~_✓ Searching memory for card render paths_~~   
+~~_✓ Reading telegram-plugin/tool-activity-summary.ts_~~   
+**→ Reading telegram-plugin/worker-activity-feed.ts**
+
+===== CARD ===== Agent card — with nested foreground sub-agent
+🤖 **Agent**   
+_1m35s · 12 tools · 41.2k tok · opus 4.8_   
+~~_✓ Searching memory for card render paths_~~   
+~~_✓ Reading telegram-plugin/tool-activity-summary.ts_~~   
+~~_✓ Reading telegram-plugin/worker-activity-feed.ts_~~   
+   ↳ ~~_Reading the repo conventions_~~   
+   ↳ ~~_Running the scoped test suite_~~   
+   ↳ **→ Summarising findings · 24s**
+
+===== CARD ===== Agent card — liveness early-open (no tools yet)
+🤖 **Agent**   
+_32s · 0 tools · opus 4.8_   
+**→ Working… · 32s**
+
+===== CARD ===== Agent card — liveness finalised
+🤖 **Agent**   
+_done · 0 tools · 1m28s · opus 4.8_   
+~~_✓ Working…_~~
+
+===== CARD ===== Agent card — post-answer background activity
+🤖 **Agent**   
+_2m10s · 3 tools · opus 4.8_   
+**→ Working in background… · 1m10s**
+
+===== CARD ===== Agent card — over-long steps (per-line clip)
+🤖 **Agent**   
+_1m35s · 12 tools · 41.2k tok · opus 4.8_   
+~~_✓ AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA…_~~   
+~~_✓ AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA…_~~   
+~~_✓ AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA…_~~   
+**→ Finally a short newest step**
+
+===== CARD ===== Worker card — just dispatched (no steps yet)
+🛠 **WORKER** · _Audit every card render path and de-indent the worker card_   
+_1s · 0 tools · 88.4k tok · opus 4.8_   
+_starting…_
+
+===== CARD ===== Worker card — single worker running
+🛠 **WORKER** · _Audit every card render path and de-indent the worker card_   
+_2m23s · 31 tools · 88.4k tok · opus 4.8_   
+~~_✓ Fetching origin and branching off main_~~   
+~~_✓ Reading telegram-plugin/status-no-truncate.ts_~~   
+~~_✓ Mapping renderStatusCard callers_~~   
+**→ Writing the preview harness · 18s**
+
+===== CARD ===== Worker card — done (with result recap)
+🛠 **WORKER** · _Audit every card render path and de-indent the worker card_   
+_done · 31 tools · 88.4k tok · 15m02s · opus 4.8_   
+~~_✓ Fetching origin and branching off main_~~   
+~~_✓ Reading telegram-plugin/status-no-truncate.ts_~~   
+~~_✓ Mapping renderStatusCard callers_~~   
+~~_✓ Writing the preview harness_~~   
+─────   
+✅ _Inventoried 14 card variants, found renderCombinedWorkerFeed forks the header + budget logic, and de-indented the worker card. PR #0000._
+
+===== CARD ===== Worker card — failed
+🛠 **WORKER** · _Audit every card render path and de-indent the worker card_   
+_failed · 31 tools · 88.4k tok · 1m01s · opus 4.8_   
+~~_✓ Fetching origin and branching off main_~~   
+~~_✓ Reading telegram-plugin/status-no-truncate.ts_~~   
+~~_✓ Mapping renderStatusCard callers_~~   
+~~_✓ Writing the preview harness_~~   
+─────   
+⚠️ _Scoped test run failed: 3 assertions in card-type-distinguishability.test.ts._
+
+===== CARD ===== Worker card — incomplete (killed / timed out)
+🛠 **WORKER** · _Audit every card render path and de-indent the worker card_   
+_incomplete · 31 tools · 88.4k tok · 30m05s · opus 4.8_   
+~~_✓ Fetching origin and branching off main_~~   
+~~_✓ Reading telegram-plugin/status-no-truncate.ts_~~   
+~~_✓ Mapping renderStatusCard callers_~~   
+~~_✓ Writing the preview harness_~~
+
+===== CARD ===== WORKERS card — 2 workers
+🛠 **WORKERS** · _2 running · oldest 2m15s · 21 tools · 60.0k tok_   
+**1. Audit every card render path** _· 1m15s · 7 tools · 20.0k tok · opus 4.8_   
+⠀⠀⠀~~_✓ audit step 1_~~   
+⠀⠀⠀~~_✓ audit step 2_~~   
+⠀⠀⠀~~_✓ audit step 3_~~   
+⠀⠀⠀~~_✓ audit step 4_~~   
+⠀⠀⠀**→ audit step 5**   
+**2. Fix the hindsight recall floor** _· 2m15s · 14 tools · 40.0k tok · opus 4.8_   
+⠀⠀⠀~~_✓ recall step 1_~~   
+⠀⠀⠀~~_✓ recall step 2_~~   
+⠀⠀⠀~~_✓ recall step 3_~~   
+⠀⠀⠀~~_✓ recall step 4_~~   
+⠀⠀⠀**→ recall step 5**
+
+===== CARD ===== WORKERS card — 4 workers
+🛠 **WORKERS** · _4 running · oldest 4m15s · 70 tools · 200.0k tok_   
+**1. Audit every card render path** _· 1m15s · 7 tools · 20.0k tok · opus 4.8_   
+⠀⠀⠀~~_✓ audit step 2_~~   
+⠀⠀⠀~~_✓ audit step 3_~~   
+⠀⠀⠀**→ audit step 4**   
+**2. Fix the hindsight recall floor** _· 2m15s · 14 tools · 40.0k tok · opus 4.8_   
+⠀⠀⠀~~_✓ recall step 2_~~   
+⠀⠀⠀~~_✓ recall step 3_~~   
+⠀⠀⠀**→ recall step 4**   
+**3. Release v0.19.24** _· 3m15s · 21 tools · 60.0k tok · opus 4.8_   
+⠀⠀⠀~~_✓ release step 2_~~   
+⠀⠀⠀~~_✓ release step 3_~~   
+⠀⠀⠀**→ release step 4**   
+**4. Investigate the flaky UAT scenario** _· 4m15s · 28 tools · 80.0k tok · opus 4.8_   
+⠀⠀⠀~~_✓ uat step 2_~~   
+⠀⠀⠀~~_✓ uat step 3_~~   
+⠀⠀⠀**→ uat step 4**
+
+===== CARD ===== WORKERS card — 8 workers (spill)
+🛠 **WORKERS** · _8 running · oldest 8m15s · 252 tools · 720.0k tok_   
+**1. Background task number 1** _· 1m15s · 7 tools · 20.0k tok · opus 4.8_   
+⠀⠀⠀~~_✓ t1 step 1_~~   
+⠀⠀⠀~~_✓ t1 step 2_~~   
+⠀⠀⠀**→ t1 step 3**   
+**2. Background task number 2** _· 2m15s · 14 tools · 40.0k tok · opus 4.8_   
+⠀⠀⠀~~_✓ t2 step 1_~~   
+⠀⠀⠀~~_✓ t2 step 2_~~   
+⠀⠀⠀**→ t2 step 3**   
+**3. Background task number 3** _· 3m15s · 21 tools · 60.0k tok · opus 4.8_   
+⠀⠀⠀~~_✓ t3 step 1_~~   
+⠀⠀⠀~~_✓ t3 step 2_~~   
+⠀⠀⠀**→ t3 step 3**   
+**4. Background task number 4** _· 4m15s · 28 tools · 80.0k tok · opus 4.8_   
+⠀⠀⠀~~_✓ t4 step 1_~~   
+⠀⠀⠀~~_✓ t4 step 2_~~   
+⠀⠀⠀**→ t4 step 3**   
+**5. Background task number 5** _· 5m15s · 35 tools · 100.0k tok · opus 4.8_   
+⠀⠀⠀~~_✓ t5 step 1_~~   
+⠀⠀⠀~~_✓ t5 step 2_~~   
+⠀⠀⠀**→ t5 step 3**   
+**6. Background task number 6** _· 6m15s · 42 tools · 120.0k tok · opus 4.8_   
+⠀⠀⠀~~_✓ t6 step 1_~~   
+⠀⠀⠀~~_✓ t6 step 2_~~   
+⠀⠀⠀**→ t6 step 3**   
+_+2 more working…_
+
+===== CARD ===== WORKERS card — survivors keep their ordinals
+🛠 **WORKERS** · _2 running · oldest 3m15s · 35 tools · 100.0k tok_   
+**2. Fix the hindsight recall floor** _· 2m15s · 14 tools · 40.0k tok · opus 4.8_   
+⠀⠀⠀~~_✓ recall step 1_~~   
+⠀⠀⠀~~_✓ recall step 2_~~   
+⠀⠀⠀~~_✓ recall step 3_~~   
+⠀⠀⠀**→ recall step 4**   
+**3. Release v0.19.24** _· 3m15s · 21 tools · 60.0k tok · opus 4.8_   
+⠀⠀⠀~~_✓ release step 1_~~   
+⠀⠀⠀~~_✓ release step 2_~~   
+⠀⠀⠀~~_✓ release step 3_~~   
+⠀⠀⠀**→ release step 4**
+
+===== CARD ===== WORKERS card — a worker with no history yet
+🛠 **WORKERS** · _2 running · oldest 2m15s · 21 tools · 60.0k tok_   
+**1. Audit every card render path** _· 1m15s · 7 tools · 20.0k tok · opus 4.8_   
+⠀⠀⠀~~_✓ audit step 1_~~   
+⠀⠀⠀~~_✓ audit step 2_~~   
+⠀⠀⠀~~_✓ audit step 3_~~   
+⠀⠀⠀~~_✓ audit step 4_~~   
+⠀⠀⠀**→ audit step 5**   
+**2. Freshly dispatched worker** _· 2m15s · 14 tools · 40.0k tok · opus 4.8_   
+⠀⠀⠀→ _starting…_
+
+===== CARD ===== Worker card — superseded (group message rotated)
+🛠 **WORKER** · _continued_
+
+_Live progress moved to a fresh card to stay pinned._
+
+===== CARD ===== Agent card — rolling-window overflow
+🤖 **Agent**   
+_1m35s · 12 tools · 41.2k tok · opus 4.8_   
+_✓ +9 earlier…_   
+~~_✓ Doing thing number 10_~~   
+~~_✓ Doing thing number 11_~~   
+~~_✓ Doing thing number 12_~~   
+~~_✓ Doing thing number 13_~~   
+**→ Doing thing number 14**
+
+===== CARD ===== Agent card — nested sub-agent with child overflow
+🤖 **Agent**   
+_1m35s · 12 tools · 41.2k tok · opus 4.8_   
+~~_✓ Searching memory for card render paths_~~   
+~~_✓ Reading telegram-plugin/tool-activity-summary.ts_~~   
+   ↳ _+6 earlier…_   
+   ↳ ~~_Child step 7_~~   
+   ↳ ~~_Child step 8_~~   
+   ↳ ~~_Child step 9_~~   
+   ↳ ~~_Child step 10_~~   
+   ↳ **→ Child step 11**

--- a/telegram-plugin/tests/card-variants.ts
+++ b/telegram-plugin/tests/card-variants.ts
@@ -1,0 +1,366 @@
+/**
+ * The catalogue of EVERY status/progress card variant the gateway can paint,
+ * each rendered through the REAL renderer with realistic inputs.
+ *
+ * One catalogue, two consumers, so they can never disagree:
+ *   - `telegram-plugin/tests/card-golden.test.ts` — the golden suite. Every
+ *     variant's exact wire text is pinned in `card-variants.golden.txt`, so a
+ *     change to the shared card layout that alters ANY card fails loudly.
+ *   - `scripts/card-previews.ts` — the human-readable preview doc.
+ *
+ * Adding a card variant means adding it HERE (and regenerating the golden with
+ * `UPDATE_CARD_GOLDEN=1 npx vitest run telegram-plugin/tests/card-golden.test.ts`),
+ * which is what keeps the golden suite exhaustive rather than a sample.
+ *
+ * These are RENDERER-level fixtures. The lifecycle behaviour that decides WHICH
+ * variant gets painted (dispatch → running → 2 workers → spill → done → failed
+ * → superseded) is covered end-to-end from the feed manager in
+ * `card-lifecycle-render.test.ts`; the two suites are complementary, not
+ * duplicates.
+ */
+import {
+  renderActivityFeed,
+  renderActivityFeedWithNested,
+  renderCombinedWorkerFeed,
+  type CombinedWorkerRow,
+  type SessionActivityHeader,
+} from '../tool-activity-summary.js'
+import {
+  renderWorkerActivity,
+  WORKER_CARD_SUPERSEDED_BODY,
+  type WorkerActivityView,
+} from '../worker-activity-feed.js'
+
+/** Which renderer path a variant exercises, for the preview doc's inventory. */
+export interface CardVariant {
+  /** Stable identity — the golden file keys on this, so renaming rewrites it. */
+  name: string
+  /** The call path, for the preview doc. */
+  fn: string
+  /** When a user actually sees this card. */
+  when: string
+  /**
+   * How the variant reaches the wire:
+   *  - `shared`   — composed by the one card layout core (`card-layout.ts`).
+   *  - `constant` — a static notice with no live state to render (see the
+   *    superseded card); its title line still comes from the shared composer.
+   */
+  layout?: 'shared' | 'constant'
+  /** The real render. `null` means the renderer declined to emit anything. */
+  render: () => string | null
+}
+
+const agentHeader = (over: Partial<SessionActivityHeader> = {}): SessionActivityHeader => ({
+  label: 'Agent',
+  elapsedMs: 95_000,
+  toolCount: 12,
+  state: 'running',
+  model: 'claude-opus-4-8',
+  totalTokens: 41_200,
+  ...over,
+})
+
+const AGENT_STEPS = [
+  'Searching memory for card render paths',
+  'Reading telegram-plugin/tool-activity-summary.ts',
+  'Reading telegram-plugin/worker-activity-feed.ts',
+  'Grepping for renderStatusCard callers',
+  'Drafting the inventory table',
+]
+
+const workerView = (over: Partial<WorkerActivityView> = {}): WorkerActivityView => ({
+  description: 'Audit every card render path and de-indent the worker card',
+  state: 'running',
+  elapsedMs: 143_000,
+  toolCount: 31,
+  lastTool: null,
+  latestSummary: '',
+  narrativeLines: [
+    'Fetching origin and branching off main',
+    'Reading telegram-plugin/status-no-truncate.ts',
+    'Mapping renderStatusCard callers',
+    'Writing the preview harness',
+  ],
+  model: 'claude-opus-4-8',
+  totalTokens: 88_400,
+  ...over,
+})
+
+const row = (
+  n: number,
+  desc: string,
+  hist: string[],
+  over: Partial<CombinedWorkerRow> = {},
+): CombinedWorkerRow => ({
+  ordinal: n,
+  description: desc,
+  elapsedMs: 60_000 * n + 15_000,
+  toolCount: 7 * n,
+  totalTokens: 20_000 * n,
+  currentStep: hist[hist.length - 1] ?? 'starting…',
+  historyLines: hist,
+  model: 'claude-opus-4-8',
+  ...over,
+})
+
+const H = (k: number, tag: string): string[] =>
+  Array.from({ length: k }, (_, i) => `${tag} step ${i + 1}`)
+
+/** A 700-char step — long enough to blow the per-line clip and force the backstop. */
+const LONG = 'A'.repeat(700)
+
+export const CARD_VARIANTS: CardVariant[] = [
+  {
+    name: 'Agent card — running',
+    fn: 'renderActivityFeed → renderStatusCard',
+    when: 'Every turn that labels a tool. Pinned in the session chat, edited in place.',
+    render: () => renderActivityFeed(AGENT_STEPS, false, '', undefined, agentHeader()),
+  },
+  {
+    name: 'Agent card — final (turn complete)',
+    fn: 'renderActivityFeed → renderStatusCard',
+    when: 'The terminal edit when the turn ends: every step struck, `✓ N steps` footer.',
+    render: () =>
+      renderActivityFeed(AGENT_STEPS, true, '', 17, agentHeader({ state: 'done', elapsedMs: 214_000 })),
+  },
+  {
+    name: 'Agent card — steps only (no header)',
+    fn: 'renderActivityFeed → renderStatusCard (header omitted)',
+    when: 'Legacy/direct callers (`appendActivityLine`, `appendActivityLabel`) that pass no header.',
+    render: () => renderActivityFeed(AGENT_STEPS.slice(0, 3)),
+  },
+  {
+    name: 'Agent card — with nested foreground sub-agent',
+    fn: 'renderActivityFeedWithNested → renderStatusCard (childSteps)',
+    when: 'A foreground Task/Agent runs inside the turn: parent lines all struck, the live `→` sits in the `↳` child block.',
+    render: () =>
+      renderActivityFeedWithNested(
+        AGENT_STEPS.slice(0, 3),
+        ['Reading the repo conventions', 'Running the scoped test suite', 'Summarising findings'],
+        false,
+        ' · 24s',
+        undefined,
+        agentHeader(),
+      ),
+  },
+  {
+    name: 'Agent card — liveness early-open (no tools yet)',
+    fn: 'narrative-lane.ts → renderActivityFeedWithNested → renderStatusCard',
+    when: 'A silent turn passes the liveness threshold before any tool is labelled — the card opens on `Working…`.',
+    render: () =>
+      renderActivityFeedWithNested(['Working…'], [], false, ' · 32s', undefined, {
+        label: 'Agent',
+        elapsedMs: 32_000,
+        toolCount: 0,
+        state: 'running',
+        model: 'claude-opus-4-8',
+      }),
+  },
+  {
+    name: 'Agent card — liveness finalised',
+    fn: 'narrative-lane.ts → renderActivityFeedWithNested → renderStatusCard',
+    when: 'The liveness-only card at turn end: `→ Working…` becomes a done record instead of freezing live.',
+    render: () =>
+      renderActivityFeedWithNested(['Working…'], [], true, '', undefined, {
+        label: 'Agent',
+        elapsedMs: 88_000,
+        toolCount: 0,
+        state: 'done',
+        model: 'claude-opus-4-8',
+      }),
+  },
+  {
+    name: 'Agent card — post-answer background activity',
+    fn: 'narrative-lane.ts → renderActivityFeedWithNested → renderStatusCard',
+    when: 'The reply already went out and a background sub-agent is still running — the card surfaces below the reply.',
+    render: () =>
+      renderActivityFeedWithNested(['Working in background…'], [], false, ' · 1m10s', undefined, {
+        label: 'Agent',
+        elapsedMs: 130_000,
+        toolCount: 3,
+        state: 'running',
+        model: 'claude-opus-4-8',
+      }),
+  },
+  {
+    name: 'Agent card — over-long steps (per-line clip)',
+    fn: 'renderStatusCard → cleanStepLine (STATUS_LINE_MAX)',
+    when: 'A step line far exceeds STATUS_LINE_MAX: each is clipped to 200 chars + `…` before escaping. (This is also why the card-wide `fitCardToBudget` backstop is unreachable on the agent card — 5 clipped lines cannot approach 32768. The shrink levels are genuinely exercised by the WORKERS spill variant.)',
+    render: () =>
+      renderActivityFeed(
+        [LONG, LONG, LONG, 'Finally a short newest step'],
+        false,
+        '',
+        undefined,
+        agentHeader(),
+      ),
+  },
+  {
+    name: 'Worker card — just dispatched (no steps yet)',
+    fn: 'renderWorkerActivity → renderStatusCard (emptyPlaceholder)',
+    when: 'The first paint of a background worker, before it has produced a narrative line.',
+    render: () =>
+      renderWorkerActivity(
+        workerView({ narrativeLines: [], latestSummary: '', elapsedMs: 1_200, toolCount: 0 }),
+      ),
+  },
+  {
+    name: 'Worker card — single worker running',
+    fn: 'renderWorkerActivity → renderStatusCard',
+    when: 'Exactly one background worker live in the chat. Pinned; edited in place.',
+    render: () => renderWorkerActivity(workerView(), ' · 18s'),
+  },
+  {
+    name: 'Worker card — done (with result recap)',
+    fn: 'renderWorkerActivity → renderStatusCard (result block)',
+    when: 'The worker finished successfully: feed all-struck, rule, then the ✅ result paragraph.',
+    render: () =>
+      renderWorkerActivity(
+        workerView({
+          state: 'done',
+          elapsedMs: 902_000,
+          latestSummary:
+            'Inventoried 14 card variants, found renderCombinedWorkerFeed forks the header + budget logic, and de-indented the worker card. PR #0000.',
+        }),
+      ),
+  },
+  {
+    name: 'Worker card — failed',
+    fn: 'renderWorkerActivity → renderStatusCard (result block, ⚠️)',
+    when: 'The worker errored: header line 2 reads `failed`, result block carries the error recap.',
+    render: () =>
+      renderWorkerActivity(
+        workerView({
+          state: 'failed',
+          elapsedMs: 61_000,
+          latestSummary: 'Scoped test run failed: 3 assertions in card-type-distinguishability.test.ts.',
+        }),
+      ),
+  },
+  {
+    name: 'Worker card — incomplete (killed / timed out)',
+    fn: 'renderWorkerActivity → renderStatusCard (result suppressed by invariant)',
+    when: 'The worker was terminated before producing a result — the renderer refuses to fabricate a result block.',
+    render: () =>
+      renderWorkerActivity(
+        workerView({
+          state: 'incomplete',
+          elapsedMs: 1_805_000,
+          latestSummary: 'stray text that must not render',
+        }),
+      ),
+  },
+  {
+    name: 'WORKERS card — 2 workers',
+    fn: 'renderCombinedWorkerFeed → the shared card spec',
+    when: '2+ background workers live in the same chat/thread coalesce into ONE message. Depth = 5 each.',
+    render: () =>
+      renderCombinedWorkerFeed(
+        [
+          row(1, 'Audit every card render path', H(5, 'audit')),
+          row(2, 'Fix the hindsight recall floor', H(5, 'recall')),
+        ],
+        { maxRows: 6 },
+      ),
+  },
+  {
+    name: 'WORKERS card — 4 workers',
+    fn: 'renderCombinedWorkerFeed → the shared card spec',
+    when: "Depth degrades to the floor of Ken's 6/5/4/3 curve.",
+    render: () =>
+      renderCombinedWorkerFeed(
+        [
+          row(1, 'Audit every card render path', H(4, 'audit')),
+          row(2, 'Fix the hindsight recall floor', H(4, 'recall')),
+          row(3, 'Release v0.19.24', H(4, 'release')),
+          row(4, 'Investigate the flaky UAT scenario', H(4, 'uat')),
+        ],
+        { maxRows: 6 },
+      ),
+  },
+  {
+    name: 'WORKERS card — 8 workers (spill)',
+    fn: 'renderCombinedWorkerFeed → fitCardToBudget (row-count shrink levels)',
+    when: 'Beyond the design fan-out the NEWEST rows collapse into a single `+M more working…` line.',
+    render: () =>
+      renderCombinedWorkerFeed(
+        Array.from({ length: 8 }, (_, i) => row(i + 1, `Background task number ${i + 1}`, H(3, `t${i + 1}`))),
+        { maxRows: 6 },
+      ),
+  },
+  {
+    name: 'WORKERS card — survivors keep their ordinals',
+    fn: 'renderCombinedWorkerFeed → the shared card spec',
+    when: 'Worker 1 finished; 2 and 3 keep their numbers, so the card shows `2.`/`3.` with no `1.`',
+    render: () =>
+      renderCombinedWorkerFeed(
+        [
+          row(2, 'Fix the hindsight recall floor', H(4, 'recall')),
+          row(3, 'Release v0.19.24', H(4, 'release')),
+        ],
+        { maxRows: 6 },
+      ),
+  },
+  {
+    name: 'WORKERS card — a worker with no history yet',
+    fn: 'renderCombinedWorkerFeed → section placeholder',
+    when: 'A freshly dispatched worker joins a group that already has a live card.',
+    render: () =>
+      renderCombinedWorkerFeed(
+        [
+          row(1, 'Audit every card render path', H(5, 'audit')),
+          row(2, 'Freshly dispatched worker', [], { currentStep: '', historyLines: undefined }),
+        ],
+        { maxRows: 6 },
+      ),
+  },
+  {
+    name: 'Worker card — superseded (group message rotated)',
+    layout: 'constant',
+    fn: 'WORKER_CARD_SUPERSEDED_BODY (static notice; title line via renderCardTitleLine)',
+    when: 'The shared worker message hit its lifetime cap and a fresh card was opened; the retired message is finalised to this static note so it does not read as a stuck worker.',
+    render: () => WORKER_CARD_SUPERSEDED_BODY,
+  },
+  {
+    name: 'Agent card — rolling-window overflow',
+    fn: 'renderActivityFeed → renderStatusCard → emitSection',
+    when: 'More steps than the rolling window: the oldest collapse to a `✓ +N earlier…` header.',
+    render: () =>
+      renderActivityFeed(
+        Array.from({ length: 14 }, (_, i) => `Doing thing number ${i + 1}`),
+        false,
+        '',
+        undefined,
+        agentHeader(),
+      ),
+  },
+  {
+    name: 'Agent card — nested sub-agent with child overflow',
+    fn: 'renderActivityFeedWithNested → renderStatusCard',
+    when: 'The foreground sub-agent has produced more steps than the window: a `↳ +N earlier…` header appears in the child block.',
+    render: () =>
+      renderActivityFeedWithNested(
+        AGENT_STEPS.slice(0, 2),
+        Array.from({ length: 11 }, (_, i) => `Child step ${i + 1}`),
+        false,
+        '',
+        undefined,
+        agentHeader(),
+      ),
+  },
+]
+
+/** Section delimiter in the golden file. Chosen so no card body can contain it. */
+export const GOLDEN_DELIMITER = '\n===== CARD ====='
+
+/**
+ * The whole catalogue as ONE deterministic string — what the golden file holds.
+ * Every variant contributes its name and its exact rendered bytes.
+ */
+export function renderGoldenDocument(): string {
+  return (
+    CARD_VARIANTS.map(
+      (v) => `${GOLDEN_DELIMITER} ${v.name}\n${v.render() ?? '(null — renderer returned nothing)'}`,
+    ).join('\n') + '\n'
+  )
+}

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -91,9 +91,45 @@ import {
   NESTED_PREFIX,
   WORKER_STEP_INDENT,
 } from './status-no-truncate.js'
-import { escapeMarkdown, stripMarkdown, truncate, stackCardLines } from './card-format.js'
+import { escapeMarkdown, truncate } from './card-format.js'
 import { isTelegramSurfaceTool } from './tool-names.js'
-import { formatModelLabel } from './model-label.js'
+// The card layout core. Header composition (`metricsRun` /
+// `renderActivityHeader`), the per-line escape pipeline (`escapeStepLine`), the
+// bullet emitter (`emitSection`) and the char-budget backstop
+// (`fitCardToBudget`) each live there exactly once; the renderers below are
+// CONFIGURATIONS of it, never parallel implementations (#3844).
+import {
+  cardSpecLines,
+  cleanStepLine,
+  escapeStepLine,
+  emitSection,
+  fitCardToBudget,
+  formatFeedElapsed,
+  formatTokenCount,
+  metricsRun,
+  renderActivityHeader,
+  renderCardSpec,
+  renderCardTitleLine,
+  renderStepFeed,
+  tokenSegment,
+  toolWord,
+  type CardCandidate,
+  type CardSection,
+  type CardSpec,
+  type CardState,
+} from './card-layout.js'
+
+// Re-exported so every existing importer keeps its `tool-activity-summary.js`
+// entrypoint while the implementations live in the one layout core.
+export {
+  escapeStepLine,
+  formatFeedElapsed,
+  formatTokenCount,
+  renderActivityHeader,
+  renderCardTitleLine,
+  renderStepFeed,
+}
+export type { CardSection, CardSpec, CardState }
 
 /**
  * Optional header for the main-session activity card, matching the worker
@@ -166,92 +202,6 @@ export function clipNarrative(s: string): string {
 }
 
 /**
- * Render a two-line header for the activity card, matching the worker card's
- * style. Used by both the main-session card and the worker card.
- *
- * Line 1: `<emoji> <b>Label</b> · <i>description</i>`  (description optional)
- * Line 2: status + elapsed + tool count
- *
- * `emoji`       — leading emoji (e.g. "🤖", "🛠")
- * `label`       — bold name (e.g. "Agent", "Worker")
- * `description` — italicised task description (optional)
- * `elapsedMs`   — wall-clock elapsed, rendered via `formatFeedElapsed`
- * `toolCount`   — labeled tool calls this turn
- * `state`       — 'running' | 'done' | 'failed' | 'incomplete' (controls the
- *                 status line wording; 'failed'/'incomplete' render
- *                 `failed · …` / `incomplete · …` so a failed or reaped worker
- *                 never reads as done)
- *
- * Returns a two-element array of ready Telegram HTML lines (no trailing newline).
- */
-export function renderActivityHeader(
-  emoji: string,
-  label: string,
-  description: string,
-  elapsedMs: number,
-  toolCount: number,
-  state: 'running' | 'done' | 'failed' | 'incomplete',
-  model?: string,
-  totalTokens?: number,
-): [string, string] {
-  const toolWord = toolCount === 1 ? 'tool' : 'tools'
-  const elapsed = formatFeedElapsed(elapsedMs)
-  const descPart = description.length > 0 ? ` · _${escapeMarkdown(description)}_` : ''
-  const line1 = `${emoji} **${escapeMarkdown(label)}**${descPart}`
-  // Running total tokens: joins the dot-separated metrics between the tool
-  // count and the model tag. Omitted (empty) when the total is 0/unknown.
-  const tokPart = tokenSegment(totalTokens)
-  // Subtle live-model tag: joins the existing dot-separated metrics (never a new
-  // line). formatModelLabel returns null for absent/sentinel values → no suffix.
-  const modelLabel = formatModelLabel(model)
-  const modelPart = modelLabel != null ? ` · ${escapeMarkdown(modelLabel)}` : ''
-  const line2 = state === 'running'
-    ? `_${elapsed} · ${toolCount} ${toolWord}${tokPart}${modelPart}_`
-    : `_${state} · ${toolCount} ${toolWord}${tokPart} · ${elapsed}${modelPart}_`
-  return [line1, line2]
-}
-
-/**
- * Compact token-count formatter for the activity card's metrics line:
- *   <1000        → raw          ("940")
- *   ≥1000, <1e6  → one-decimal k ("12.4k", "1.0k")
- *   ≥1e6         → one-decimal M ("1.2M")
- * Negative / non-finite inputs clamp to "0". The caller appends " tok".
- */
-export function formatTokenCount(n: number): string {
-  if (!Number.isFinite(n) || n <= 0) return '0'
-  if (n < 1000) return String(Math.floor(n))
-  if (n < 1_000_000) {
-    // Round to the displayed 1-decimal k FIRST: inputs in [999_950, 999_999]
-    // round to "1000.0k", which must promote into the M branch rather than
-    // render a nonsense "1000.0k". Fall through when the rounded k reaches 1000.
-    const k = Number((n / 1000).toFixed(1))
-    if (k < 1000) return `${k.toFixed(1)}k`
-  }
-  return `${(n / 1_000_000).toFixed(1)}M`
-}
-
-/**
- * The ` · {N} tok` metrics segment, or '' when there are no tokens to show.
- * A 0 / undefined total (a worker that emitted no usage — e.g. a non-Claude
- * transcript) OMITS the segment entirely so the line stays clean; the same
- * predicate is used by BOTH render variants (single-worker header + combined
- * row) so they never diverge.
- */
-function tokenSegment(totalTokens: number | undefined): string {
-  if (totalTokens == null || totalTokens <= 0) return ''
-  return ` · ${formatTokenCount(totalTokens)} tok`
-}
-
-/** Format elapsed milliseconds for display in the activity header (e.g. "12s", "2m05s"). */
-export function formatFeedElapsed(ms: number): string {
-  const s = Math.floor(ms / 1000)
-  if (s < 60) return `${s}s`
-  const m = Math.floor(s / 60)
-  return `${m}m${(s % 60).toString().padStart(2, '0')}s`
-}
-
-/**
  * Minimum time the CURRENT step must have been running before its own
  * `· <elapsed>` suffix appears on the `→` line. Under this, no suffix — a
  * fresh step reads cleaner without a timer, and the header total already
@@ -268,62 +218,6 @@ export const STEP_TIMER_MIN_MS = 10_000
 export function formatStepSuffix(stepElapsedMs: number): string {
   if (stepElapsedMs < STEP_TIMER_MIN_MS) return ''
   return ` · ${formatFeedElapsed(stepElapsedMs)}`
-}
-
-// ─── Truncation pipeline (the single correctness-critical primitive) ────────
-//
-// Per RAW line, in this EXACT order:
-//   1. stripMarkdown(raw)
-//   2. .replace(/\s+/g, ' ').trim()
-//   3. truncate(_, STATUS_LINE_MAX)
-//   4. escapeMarkdown(_)   ← escape is ALWAYS the last per-line op.
-// Escaping last is load-bearing: clipping an already-escaped string can split
-// a markdown escape (\* → \), which renders wrong.
-
-/** Clean + clip + escape a single raw step line. Returns ready-to-wrap markdown. */
-function escapeStepLine(raw: string): string {
-  const cleaned = stripMarkdown(raw).replace(/\s+/g, ' ').trim()
-  return escapeMarkdown(truncate(cleaned, STATUS_LINE_MAX))
-}
-
-/**
- * Shared step-feed emitter. Appends `✓`/`→` bullet lines to `out` for the
- * given ALREADY-ESCAPED step strings, windowing to `window` (default
- * STATUS_ROLLING_LINES; the worker surfaces pass a deeper window) and
- * prepending a `+N earlier…` header when the feed overflows the window (on
- * BOTH surfaces now). The worker feed imports this directly.
- *
- * `out`        — accumulator mutated in place
- * `steps`      — pre-cleaned + pre-escaped HTML step strings
- * `allDone`    — when true ALL steps render done (✓ struck italic); when false the
- *                newest renders in-progress (→ bold)
- * `liveSuffix` — appended INSIDE the newest in-progress line (heartbeat tick)
- * `indent`     — literal prefix put on EVERY emitted line (incl. the
- *                `+N earlier…` header), OUTSIDE the markdown spans so it never
- *                lands inside an emphasis run. Default `''` — byte-identical
- *                output for callers that don't indent. The combined worker card
- *                passes `WORKER_STEP_INDENT` to nest steps under their worker.
- */
-export function renderStepFeed(
-  out: string[],
-  steps: string[],
-  allDone: boolean,
-  liveSuffix = '',
-  window: number = STATUS_ROLLING_LINES,
-  indent = '',
-): void {
-  if (steps.length === 0) return
-  const shown = steps.slice(-Math.max(1, window))
-  const hidden = steps.length - shown.length
-  if (hidden > 0) out.push(`${indent}_✓ +${hidden} earlier…_`)
-  const lastIdx = shown.length - 1
-  shown.forEach((s, i) => {
-    out.push(
-      !allDone && i === lastIdx
-        ? `${indent}**→ ${s}${liveSuffix}**`
-        : `${indent}~~_✓ ${s}_~~`,
-    )
-  })
 }
 
 // ─── Unified status-card primitive ──────────────────────────────────────────
@@ -372,6 +266,17 @@ export interface StatusCardOpts {
    * full recent trail — see WORKER_HISTORY_MAX.
    */
   historyWindow?: number
+  /**
+   * Body line rendered when the card has NO steps and NO children at all — the
+   * 🛠 worker card's `starting…` placeholder for a just-dispatched worker.
+   *
+   * This used to be string-concatenated onto the renderer's return value by
+   * `renderWorkerActivity` (#3846), which put one user-visible card line
+   * outside the primitive that owns line assembly, hard-break stacking and the
+   * char budget. It is a normal body line now, emitted by `emitSection` like
+   * every other one.
+   */
+  emptyPlaceholder?: string
 }
 
 /**
@@ -400,7 +305,7 @@ export function renderStatusCard(opts: StatusCardOpts): string | null {
   const steps = rawSteps.map(escapeStepLine)
   const children = rawChildren.map(escapeStepLine)
 
-  const headerLines = header != null
+  const chrome = header != null
     ? renderActivityHeader(
         header.emoji,
         header.label,
@@ -417,136 +322,138 @@ export function renderStatusCard(opts: StatusCardOpts): string | null {
       )
     : []
 
-  const out: string[] = [...headerLines]
-
-  if (hasChildren) {
-    // Parent lines all render done — the live → step lives in the nested block.
-    const shownParent = steps.slice(-window)
-    const hiddenParent = steps.length - shownParent.length
-    if (hiddenParent > 0) out.push(`_✓ +${hiddenParent} earlier…_`)
-    for (const s of shownParent) out.push(`~~_✓ ${s}_~~`)
-    // Child block.
-    const shownChild = children.slice(-window)
-    const hiddenChild = children.length - shownChild.length
-    if (hiddenChild > 0) out.push(`${NESTED_PREFIX}_+${hiddenChild} earlier…_`)
-    const lastChildIdx = shownChild.length - 1
-    shownChild.forEach((s, i) => {
-      out.push(
-        i === lastChildIdx && !final
-          ? `${NESTED_PREFIX}**→ ${s}${liveSuffix}**`
-          : `${NESTED_PREFIX}~~_${s}_~~`,
-      )
-    })
-  } else {
-    renderStepFeed(out, steps, final, liveSuffix, window)
-  }
-
-  if (final && stepCount != null && stepCount > 0) {
-    out.push(`_✓ ${stepCount} steps_`)
-  }
-
+  // Fixed footer/result lines — kept at every shrink level.
+  const footer: string[] = []
+  if (final && stepCount != null && stepCount > 0) footer.push(`_✓ ${stepCount} steps_`)
   if (result != null && result.text.length > 0) {
-    out.push(WORKER_RESULT_RULE)
-    out.push(`${result.emoji} _${escapeMarkdown(truncate(result.text, WORKER_RESULT_MAX))}_`)
+    footer.push(WORKER_RESULT_RULE)
+    footer.push(`${result.emoji} _${escapeMarkdown(truncate(result.text, WORKER_RESULT_MAX))}_`)
   }
 
-  // out always carries the two header lines, so it is never empty — but guard
-  // against a degenerate header-less future caller.
-  if (out.length === 0) return null
-  // Stack lines with GFM hard breaks (`  \n`) so the card's styled prose lines
-  // don't collapse onto one visual line in the rich-message renderer — see
-  // stackCardLines. This is what makes a card render identically to a reply.
-  // collapseSafe (#3666): the agent status card and the single-worker card are
-  // both PINNED, and Telegram's pinned bar shows them collapsed to one line
-  // with the newlines dropped — the separator keeps that preview legible.
-  const joined = stackCardLines(out, { collapseSafe: true })
-  if (joined.length <= STATUS_CARD_CHAR_BUDGET) return joined
-  return fitCardToBudget(opts, headerLines)
+  // The active "body" group the shrink levels erode: children when present
+  // (the parent trail collapses to a single `+N` marker), else parent steps.
+  const rawBody = hasChildren ? rawChildren : rawSteps
+  const escapedBody = hasChildren ? children : steps
+  const bodyIndent = hasChildren ? NESTED_PREFIX : ''
+  // The `↳` glyph already marks the nested block, so its bullets carry no ✓.
+  const bodyDoneMark = hasChildren ? '' : '✓ '
+
+  /** Level 0 — the full card, everything at its natural window. */
+  const fullSpec = (): CardSpec => ({
+    chrome,
+    sections: hasChildren
+      ? [
+          // Parent lines all render done — the live `→` lives in the nested block.
+          { steps, window, allDone: true },
+          {
+            steps: children,
+            window,
+            allDone: final,
+            liveSuffix,
+            indent: NESTED_PREFIX,
+            doneMark: '',
+          },
+        ]
+      : [{ steps, window, allDone: final, liveSuffix, placeholder: opts.emptyPlaceholder }],
+    footer,
+  })
+
+  const lines = cardSpecLines(fullSpec())
+  // `lines` always carries the two header lines, so it is never empty — but
+  // guard against a degenerate header-less future caller.
+  if (lines.length === 0) return null
+
+  // Parent-collapsed marker line used once the shrink levels start dropping
+  // children (the parent trail is spent bytes on an over-budget card).
+  const parentMarker =
+    hasChildren && rawSteps.length > 0 ? `_✓ +${rawSteps.length} earlier…_` : null
+
+  /**
+   * Shrink levels for the status card:
+   *   0                    — the full card.
+   *   1 … len(body)-1      — drop that many OLDEST body bullets, re-inserting a
+   *                          `+N earlier…` marker; done bullets lose their
+   *                          strike/✓ chrome (`doneStyle: 'plain'`).
+   *   len(body) (deepest)  — a single newest bullet that is ITSELF oversized:
+   *                          truncate the RAW text, THEN escape, THEN wrap, so
+   *                          an already-escaped markdown escape is never sliced.
+   */
+  const deepest = Math.max(1, escapedBody.length)
+  return fitCardToBudget((level) => {
+    if (level === 0) return { spec: fullSpec() }
+    const markerSection: CardSection = {
+      steps: [],
+      window: 1,
+      placeholder: parentMarker ?? undefined,
+    }
+    if (level < escapedBody.length) {
+      return {
+        spec: {
+          chrome,
+          sections: [
+            markerSection,
+            {
+              steps: escapedBody,
+              // Showing all but the `level` oldest — `emitSection` derives the
+              // `+level earlier…` marker from the hidden remainder.
+              window: escapedBody.length - level,
+              allDone: final,
+              liveSuffix,
+              indent: bodyIndent,
+              doneMark: bodyDoneMark,
+              doneStyle: 'plain',
+            },
+          ],
+          footer,
+        },
+      }
+    }
+    return {
+      spec: {
+        chrome,
+        sections: [markerSection, { steps: [], window: 1, placeholder: truncatedNewestLine() }],
+        footer,
+      },
+    }
+  }, deepest)
+
+  /**
+   * The deepest shrink level's single bullet. Charges the fixed header/footer
+   * (and the parent marker) against `STATUS_CARD_CHAR_BUDGET`, then clips the
+   * RAW newest text to what is left, re-checking after escaping because
+   * escaping can expand the string (`&` → `&amp;`).
+   */
+  function truncatedNewestLine(): string {
+    const fixedCost = [...chrome, ...footer].join('\n').length
+    const rawNewest = rawBody.length > 0 ? cleanStepLine(rawBody[rawBody.length - 1]) : ''
+    const wrapperOverhead = final
+      ? (bodyIndent + '_✓ _').length
+      : (bodyIndent + '**→ **').length + liveSuffix.length
+    const headerFooterCost =
+      fixedCost +
+      (fixedCost > 0 ? 1 : 0) +
+      (parentMarker != null ? parentMarker.length + 1 : 0)
+    const budget = STATUS_CARD_CHAR_BUDGET - headerFooterCost - wrapperOverhead
+    let raw = rawNewest.slice(0, Math.max(0, budget))
+    let newest = escapeMarkdown(raw)
+    while (
+      raw.length > 0 &&
+      wrapperOverhead + headerFooterCost + newest.length > STATUS_CARD_CHAR_BUDGET
+    ) {
+      const excess = wrapperOverhead + headerFooterCost + newest.length - STATUS_CARD_CHAR_BUDGET
+      raw = raw.slice(0, Math.max(0, raw.length - excess - 1))
+      newest = escapeMarkdown(raw)
+    }
+    return final
+      ? `${bodyIndent}_✓ ${newest}_`
+      : `${bodyIndent}**→ ${newest}${liveSuffix}**`
+  }
 }
 
 /** Subtle horizontal rule between the running feed and the finished result. */
 const WORKER_RESULT_RULE = '─────'
 /** Hard cap on the terminal result paragraph. */
 const WORKER_RESULT_MAX = 320
-
-/**
- * Char-budget backstop. Keeps the header / footer / result block fixed and
- * drops the oldest body bullets one at a time, re-inserting a `+N earlier…`
- * marker, until the card fits STATUS_CARD_CHAR_BUDGET. In the extreme case
- * (a single newest bullet that is itself oversized) it truncates the RAW
- * newest text, THEN escapes, THEN wraps — never slicing already-escaped markdown.
- */
-function fitCardToBudget(opts: StatusCardOpts, headerLines: string[]): string {
-  const { final = false, liveSuffix = '', stepCount, result } = opts
-  const rawSteps = opts.steps.filter((s) => s != null)
-  const rawChildren = (opts.childSteps ?? []).map((s) => s.trim()).filter((s) => s.length > 0)
-  const hasChildren = rawChildren.length > 0
-  // No per-line nesting cost since #3842 removed whole-card subordination:
-  // every line this function assembles is flush, so the arithmetic below
-  // charges only the line's own bytes.
-  const stack = (lines: string[]): string =>
-    stackCardLines(lines, { collapseSafe: true })
-
-  // Fixed footer/result lines (always kept).
-  const footerLines: string[] = []
-  if (final && stepCount != null && stepCount > 0) footerLines.push(`_✓ ${stepCount} steps_`)
-  if (result != null && result.text.length > 0) {
-    footerLines.push(WORKER_RESULT_RULE)
-    footerLines.push(`${result.emoji} _${escapeMarkdown(truncate(result.text, WORKER_RESULT_MAX))}_`)
-  }
-  const fixedCost = [...headerLines, ...footerLines].join('\n').length
-
-  // The active "body" group whose oldest bullets we drop: children when
-  // present (parent collapses to a single "+N" marker), else parent steps.
-  const body = hasChildren ? rawChildren : rawSteps
-  const escapedBody = body.map(escapeStepLine)
-  const prefix = hasChildren ? NESTED_PREFIX : ''
-
-  const buildBullet = (esc: string, isLast: boolean): string =>
-    !final && isLast ? `${prefix}**→ ${esc}${liveSuffix}**` : `${prefix}_${esc}_`
-
-  // Parent-collapsed marker line when we are dropping children but parent steps exist.
-  const parentMarker =
-    hasChildren && rawSteps.length > 0 ? `_✓ +${rawSteps.length} earlier…_` : null
-
-  for (let drop = 1; drop < escapedBody.length; drop++) {
-    const shown = escapedBody.slice(drop)
-    const lines: string[] = [...headerLines]
-    if (parentMarker != null) lines.push(parentMarker)
-    lines.push(hasChildren ? `${NESTED_PREFIX}_+${drop} earlier…_` : `_✓ +${drop} earlier…_`)
-    const lastIdx = shown.length - 1
-    shown.forEach((esc, i) => lines.push(buildBullet(esc, i === lastIdx)))
-    lines.push(...footerLines)
-    // collapseSafe: same pinned surface as renderStatusCard (#3666).
-    const candidate = stack(lines)
-    if (candidate.length <= STATUS_CARD_CHAR_BUDGET) return candidate
-  }
-
-  // Extreme: the single newest bullet is itself oversized. Truncate the RAW
-  // newest text, then escape, then wrap — re-checking post-escape because
-  // escaping can expand the string (& → &amp;).
-  const rawNewest = body.length > 0 ? stripMarkdown(body[body.length - 1]).replace(/\s+/g, ' ').trim() : ''
-  const wrapperOverhead =
-    final ? (prefix + '_✓ _').length : (prefix + '**→ **').length + liveSuffix.length
-  const headerFooterCost =
-    fixedCost +
-    (fixedCost > 0 ? 1 : 0) +
-    (parentMarker != null ? parentMarker.length + 1 : 0)
-  const budget = STATUS_CARD_CHAR_BUDGET - headerFooterCost - wrapperOverhead
-  let raw = rawNewest.slice(0, Math.max(0, budget))
-  let newest = escapeMarkdown(raw)
-  while (raw.length > 0 && wrapperOverhead + headerFooterCost + newest.length > STATUS_CARD_CHAR_BUDGET) {
-    const excess = wrapperOverhead + headerFooterCost + newest.length - STATUS_CARD_CHAR_BUDGET
-    raw = raw.slice(0, Math.max(0, raw.length - excess - 1))
-    newest = escapeMarkdown(raw)
-  }
-  const newestLine = final ? `${prefix}_✓ ${newest}_` : `${prefix}**→ ${newest}${liveSuffix}**`
-  const lines: string[] = [...headerLines]
-  if (parentMarker != null) lines.push(parentMarker)
-  lines.push(newestLine)
-  lines.push(...footerLines)
-  return stack(lines)
-}
 
 /**
  * Render the accumulated feed as ready Telegram HTML — one action per line,
@@ -779,10 +686,13 @@ function glanceLine(rows: CombinedWorkerRow[]): string {
   const oldestMs = rows.reduce((m, r) => Math.max(m, r.elapsedMs), 0)
   const tools = rows.reduce((n, r) => n + r.toolCount, 0)
   const tok = rows.reduce((n, r) => n + (r.totalTokens ?? 0), 0)
-  const toolWord = tools === 1 ? 'tool' : 'tools'
+  // Aggregate glance, so it is NOT a `metricsRun` (no per-entity state/model,
+  // and it leads with the swarm count rather than elapsed). It still reads the
+  // same elapsed / tool-word / token primitives, so the vocabulary that DOES
+  // repeat across cards cannot drift.
   return (
     `🛠 **WORKERS** · _${rows.length} running · oldest ${formatFeedElapsed(oldestMs)}` +
-    ` · ${tools} ${toolWord}${tokenSegment(tok)}_`
+    ` · ${tools} ${toolWord(tools)}${tokenSegment(tok)}_`
   )
 }
 
@@ -855,88 +765,69 @@ export function renderCombinedWorkerFeed(
 
   const rowHeader = (r: CombinedWorkerRow): string => {
     const desc = escapeMarkdown(
-      truncate(stripMarkdown(r.description).replace(/\s+/g, ' ').trim() || 'background task', COMBINED_ROW_DESC_MAX),
+      truncate(cleanStepLine(r.description) || 'background task', COMBINED_ROW_DESC_MAX),
     )
-    const toolWord = r.toolCount === 1 ? 'tool' : 'tools'
-    const tokPart = tokenSegment(r.totalTokens)
-    const modelLabel = formatModelLabel(r.model)
-    const modelPart = modelLabel != null ? ` · ${escapeMarkdown(modelLabel)}` : ''
     // Stable ordinal prefix INSIDE the bold span, before the already-escaped
     // description — no new escaping surface, and the gateway md→HTML conversion
     // has no ordered-list auto-formatting on bolded text.
     const num = numbered && r.ordinal != null ? `${r.ordinal}. ` : ''
-    return `**${num}${desc}** _· ${formatFeedElapsed(r.elapsedMs)} · ${r.toolCount} ${toolWord}${tokPart}${modelPart}_`
+    // The metrics run is composed by the SAME function as the 🤖 agent header
+    // and the 🛠 single-worker header (`metricsRun`, card-layout.ts). A combined
+    // row is always live, so it reports 'running'; before #3844 this line spelled
+    // the run out by hand and agreed with the other two only by inspection.
+    return `**${num}${desc}** _· ${metricsRun(r.elapsedMs, r.toolCount, 'running', r.totalTokens, r.model)}_`
   }
 
   // Raw (unescaped) history for a worker, oldest→newest, empty lines stripped.
   // Falls back to the single currentStep when no history was supplied.
   const rowHistory = (r: CombinedWorkerRow): string[] => {
     const src = r.historyLines != null && r.historyLines.length > 0 ? r.historyLines : [r.currentStep]
-    return src.filter((s) => s != null && stripMarkdown(s).replace(/\s+/g, ' ').trim().length > 0)
+    return src.filter((s) => s != null && cleanStepLine(s).length > 0)
   }
 
-  const compose = (visibleCount: number): { body: string; bodyLines: number } => {
+  const compose = (visibleCount: number): CardCandidate => {
     const shown = rows.slice(0, visibleCount)
     const hidden = rows.length - shown.length
     // Per-worker depth follows Ken's deterministic curve max(3, 7−w) (#3349):
     // the curve drives DEPTH; the total-line budget below drives ROW COUNT.
     const depth = combinedHistoryDepth(shown.length)
-    const chrome: string[] = [glanceLine(rows)]
-    const bodyOut: string[] = []
-    for (const r of shown) {
-      bodyOut.push(rowHeader(r))
-      const hist = rowHistory(r)
-      if (hist.length === 0) {
-        bodyOut.push(`${WORKER_STEP_INDENT}→ _starting…_`)
-        continue
-      }
-      // Paint the last-K history lines with the SAME `✓`/`→` idiom as the
-      // single-worker card: escape each raw line through the shared per-line
-      // pipeline (escapeStepLine), then renderStepFeed strikes the prior steps
-      // and bolds the newest in-progress step. The window equals the depth so a
-      // per-worker `+N earlier…` marker never appears inside the combined feed.
-      //
-      // WORKER_STEP_INDENT nests every step line one level under its worker
-      // header, so the boundary between two workers is visible at a glance on a
-      // phone (the header lines stay at the left margin, their steps sit in).
-      // It is a U+2800 run. NOT ASCII spaces and NOT U+00A0: Telegram's
-      // server-side parser left-trims a leading Unicode-whitespace run, so both
-      // render flat (#3662 shipped U+00A0 and was inert). U+2800 is category So,
-      // not Zs. See the constant's doc comment for the live evidence.
-      const esc = hist.slice(-depth).map(escapeStepLine)
-      renderStepFeed(bodyOut, esc, false, '', depth, WORKER_STEP_INDENT)
-    }
-    const out = [...chrome, ...bodyOut]
-    if (hidden > 0) out.push(`_+${hidden} more working…_`)
-    // collapseSafe (#3666): this card is PINNED, and Telegram's pinned bar
-    // renders it collapsed to one line with the newlines dropped and nothing
-    // substituted. Without the separator the glance line runs straight into
-    // row 1's ordinal and every step glyph mashes into the previous line.
+    // Each worker is ONE SECTION of the shared card spec: its row header, then
+    // its last-K history lines painted with the SAME `✓`/`→` idiom as every
+    // other card (emitSection). The window equals the depth, so a per-worker
+    // `+N earlier…` marker never appears inside the combined feed.
     //
-    // No whole-card nesting (#3842): `out` goes to the stacker as-is, so the
-    // glance / row-header / spill lines land flush and only the step lines
-    // carry their WORKER_STEP_INDENT — one level of hierarchy, not two.
-    return {
-      body: stackCardLines(out, { collapseSafe: true }),
-      bodyLines: bodyOut.length,
-    }
+    // WORKER_STEP_INDENT nests every step line one level under its worker
+    // header, so the boundary between two workers is visible at a glance on a
+    // phone (the header lines stay at the left margin, their steps sit in).
+    // It is a U+2800 run. NOT ASCII spaces and NOT U+00A0: Telegram's
+    // server-side parser left-trims a leading Unicode-whitespace run, so both
+    // render flat (#3662 shipped U+00A0 and was inert). U+2800 is category So,
+    // not Zs. See the constant's doc comment for the live evidence.
+    const sections: CardSection[] = shown.map((r) => ({
+      header: [rowHeader(r)],
+      steps: rowHistory(r).slice(-depth).map(escapeStepLine),
+      window: depth,
+      indent: WORKER_STEP_INDENT,
+      placeholder: '→ _starting…_',
+    }))
+    const footer = hidden > 0 ? [`_+${hidden} more working…_`] : []
+    // No whole-card nesting (#3842): the glance / row-header / spill lines land
+    // flush and only the step lines carry their WORKER_STEP_INDENT — one level
+    // of hierarchy, not two.
+    const spec: CardSpec = { chrome: [glanceLine(rows)], sections, footer }
+    // The per-worker BODY lines (row headers + their steps) — the glance line and
+    // the spill line are fixed chrome and sit outside this ceiling.
+    const bodyLines = cardSpecLines(spec).length - 1 - footer.length
+    return { spec, overflow: bodyLines > MAX_COMBINED_BODY_LINES }
   }
 
-  // Cap to maxRows first, then shrink the visible set while EITHER the total
-  // body-line budget (#3349: bounds a big swarm without stealing depth from the
-  // shown workers) OR the wire char budget is exceeded. Newest (trailing) rows
-  // collapse into the `+M more working…` spill (`rows.slice(0, visibleCount)`
-  // keeps the head of the list).
-  let visible = Math.min(rows.length, maxRows)
-  let { body, bodyLines } = compose(visible)
-  while (
-    (bodyLines > MAX_COMBINED_BODY_LINES || body.length > STATUS_CARD_CHAR_BUDGET) &&
-    visible > 1
-  ) {
-    visible -= 1
-    ;({ body, bodyLines } = compose(visible))
-  }
-  return body
+  // Cap to maxRows first, then let the ONE shared budget enforcer shrink the
+  // visible set while EITHER the total body-line budget (#3349: bounds a big
+  // swarm without stealing depth from the shown workers) OR the wire char budget
+  // is exceeded. Newest (trailing) rows collapse into the `+M more working…`
+  // spill (`rows.slice(0, visibleCount)` keeps the head of the list).
+  const visible = Math.min(rows.length, maxRows)
+  return fitCardToBudget((level) => compose(Math.max(1, visible - level)), visible - 1)
 }
 
 /**

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -53,9 +53,9 @@ import {
   cleanWorkerResultParagraph,
   stripMarkdown,
   truncate,
-  COLLAPSE_SAFE_SEPARATOR,
 } from './card-format.js'
 import { WORKER_HISTORY_MAX } from './status-no-truncate.js'
+import { renderCardTitleLine } from './card-layout.js'
 import {
   renderStatusCard,
   formatStepSuffix,
@@ -237,9 +237,6 @@ export function renderWorkerActivity(v: WorkerActivityView, liveSuffix = ''): st
     if (text.length > 0) result = { emoji: v.state === 'done' ? '✅' : '⚠️', text }
   }
 
-  // `renderStatusCard` always returns content when a header is supplied. When
-  // running with no steps it shows just the header — append a "starting…" line
-  // for parity with the prior behaviour.
   const card = renderStatusCard({
     header,
     steps,
@@ -249,21 +246,18 @@ export function renderWorkerActivity(v: WorkerActivityView, liveSuffix = ''): st
     // Lone-worker card: window to the w=1 point of Ken's curve (6) so it shows
     // the full recent trail, not the 5-line agent-card default (#3349).
     historyWindow: workerHistoryDepth(1),
+    // A just-dispatched worker has no narrative yet. The placeholder is a normal
+    // BODY line of the shared spec now (#3846): it used to be concatenated onto
+    // this function's return value, which put a user-visible card line outside
+    // the primitive that owns hard-break stacking, the collapse-safe separator
+    // and the char budget, and made the seam the one boundary that could mash in
+    // Telegram's pinned bar. Only while RUNNING — a finished worker with no
+    // steps must not read as "starting…".
+    emptyPlaceholder: finished ? undefined : '_starting…_',
   })
   if (card == null) {
     // Unreachable (header always present) — defensive.
-    return '🛠 **WORKER** · _starting…_'
-  }
-  if (!finished && steps.length === 0) {
-    // Header-only running render → append the starting placeholder with a GFM
-    // hard break (`  \n`) so it stacks under the header instead of collapsing
-    // onto the header line in the rich-message renderer (matches stackCardLines).
-    // The collapse separator is carried here too (#3666) — this card is pinned,
-    // and a hand-rolled seam would be the one boundary that still mashed in
-    // Telegram's pinned bar.
-    // Flush like every other body line of this card (#3842) — the single-worker
-    // card carries no indentation at all now.
-    return `${card}${COLLAPSE_SAFE_SEPARATOR}  \n_starting…_`
+    return renderCardTitleLine('🛠', 'WORKER', 'starting…')
   }
   return card
 }
@@ -613,9 +607,17 @@ const COOLDOWN_JITTER_MS = 500
  *
  * Exported so the card-preview harness (`scripts/card-previews.ts`) renders the
  * real string rather than a copy that can drift from it.
+ *
+ * DELIBERATELY still a constant, not a card render (#3846). It shows no live
+ * state — no elapsed, no tool count, no steps — so there is nothing for a
+ * renderer to compose and no rolling window or char budget to enforce; routing
+ * it through `renderStatusCard` would mean inventing a state to render. What it
+ * DOES share with every other card is its type chrome, so line 1 comes from the
+ * one title composer (`renderCardTitleLine`): if the 🛠 / **WORKER** convention
+ * ever changes, this notice moves with it instead of being the one stale card.
  */
 export const WORKER_CARD_SUPERSEDED_BODY =
-  '🛠 **WORKER** · _continued_\n\n' +
+  `${renderCardTitleLine('🛠', 'WORKER', 'continued')}\n\n` +
   '_Live progress moved to a fresh card to stay pinned._'
 
 function extractRetryAfterSecs(err: unknown): number | null {


### PR DESCRIPTION
## What

Card rendering forked three ways. `renderStatusCard` served the 🤖 agent card and the single-worker 🛠 card, but:

- **#3844** — `renderCombinedWorkerFeed` (the 2+ worker `🛠 WORKERS` card) built its own `glanceLine` + `rowHeader` instead of `renderActivityHeader`, and carried its own row-shrinking loop instead of `fitCardToBudget`. Header composition and char-budget enforcement each existed **twice** and agreed only by hand.
- **#3846** — the just-dispatched `starting…` line was string-concatenated onto the card *after* `renderStatusCard` returned, and `WORKER_CARD_SUPERSEDED_BODY` was a bare literal with no renderer.

This extracts **`telegram-plugin/card-layout.ts`** — one layout core — and expresses a card as sections/rows:

| Concern | Now lives in exactly one place |
|---|---|
| Title line | `renderCardTitleLine` |
| Metrics line | `metricsRun` |
| Step block (rolling window, `✓`/`→`, `+N earlier…`, placeholder) | `emitSection` |
| Char-budget enforcement | `fitCardToBudget` |
| Line stacking | `stackCard` → `stackCardLines` |

The `🛠 WORKERS` card is now a **`CardSpec` configuration** of that core, not a parallel implementation: each worker row is a `CardSection` with `indent: WORKER_STEP_INDENT` and `placeholder: '→ _starting…_'`. The nested `↳` foreground-sub-agent block is the same `emitSection` with `doneMark: ''`. The status card's drop-oldest shrink levels and the combined card's drop-newest-row shrink levels are both `build(level) -> CardCandidate` ladders fed to the one `fitCardToBudget`.

The `starting…` line became a normal section `placeholder`, so it picks up the same collapse-safe line joining as every other line instead of being appended outside the primitive (#3846).

### Deliberately NOT unified

`WORKER_CARD_SUPERSEDED_BODY` stays a **constant**. It renders no live state — no steps, no metrics, no window and no budget to enforce — so there is nothing for a renderer to compute; wrapping it in one would be ceremony, not centralisation. Its **title line now comes from the shared `renderCardTitleLine`**, so its chrome cannot drift from the live cards.

## Byte-identical output

All 21 variants were captured from `scripts/card-previews.ts` on `origin/main` and again on this branch, and diffed. **Every card body is unchanged to the byte.** The only diffs are the harness's own prose: the (now stale) "mostly, not entirely" centralisation verdict, and the renderer labels in the inventory table. One fixture was also renamed for accuracy — "char-budget overflow backstop" → "over-long steps (per-line clip)", because `STATUS_LINE_MAX` clipping makes the card-wide budget backstop unreachable on the agent card; the shrink ladder is genuinely exercised by the WORKERS spill variant instead.

## Tests — outcomes, not functions

Two new suites, neither a unit test of `renderStatusCard(opts)`:

1. **`telegram-plugin/tests/card-golden.test.ts`** — a golden suite over **all 21 variants**, rendered through the real renderers and compared byte-for-byte against `card-variants.golden.txt`. Now that every card flows through one core, a change made for one card can silently reshape the other twenty; this is the alarm. It also asserts the golden covers *exactly* the catalogue, so a variant cannot quietly stop being checked.

2. **`telegram-plugin/tests/card-lifecycle-render.test.ts`** — end-to-end at the highest in-process seam: the **real feed manager** (`createWorkerActivityFeed`) with a fake bot, asserting the exact `sendMessage` / `editMessageText` bodies across the real lifecycle — dispatch (placeholder) → running trail → depth budget → two workers coalescing into one message → spill past `maxRows` → body-line-budget shrink → a worker finishing (survivors keep their ordinals) → done recap → failure recap → group-message supersede.

The fixtures live in **one** catalogue (`telegram-plugin/tests/card-variants.ts`) imported by *both* the golden suite and `scripts/card-previews.ts`, so the preview doc and the regression alarm cannot drift apart.

### Teeth verified by mutation

Each of these turned the suites red; reverting turned them green:

| Mutation | Failures |
|---|---|
| `emitSection` live `→` marker → `>` | 4 |
| `metricsRun` separator `·` → `\|` | 4 |
| drop the `emptyPlaceholder` (regress #3846) | 2 |
| WORKERS rows lose `WORKER_STEP_INDENT` (regress the #3844 shape) | 4 |

## Verification

- `npm run lint` — **clean**, all 16 guards including `check-test-runner-coverage` (`OK — 1345 test file(s), every one has a runner`; both new files are plain vitest under `telegram-plugin/tests/`, auto-covered).
- Scoped: 8 card/worker-feed test files, **277 passed**.
- Full `vitest run telegram-plugin/`: **8408 passed**, 3 skipped, 1 failure — `approval-hold-record.test.ts > falls back to the agent's own state dir when the shared dir is not writable`, which fails only because this dev container runs as uid 0 and root ignores the `chmod` the test uses to simulate an unwritable dir. Unrelated to this change; CI runs non-root.

Closes #3844
Closes #3846