### PR TITLE
fix(telegram): meter every chat-targeted call, and add a per-bot-token window

### DIFF
--- a/telegram-plugin/edit-flood-fuse.ts
+++ b/telegram-plugin/edit-flood-fuse.ts
@@ -102,10 +102,61 @@
  *   3. **A shared per-chat budget with a reply reservation.** Telegram meters
  *      sends and edits against the SAME per-chat allowance, so separate
  *      edit/send windows could each be "in budget" while their sum was not.
- *      One `perChatTotalMaxPerWindow` window (default 20/60s) now counts
- *      every admitted call, and `perChatReplyReserve` (default 8) slots of it
+ *      One `perChatTotalMaxPerWindow` window (default 20/60s) counts every
+ *      chat-targeted call, and `perChatReplyReserve` (default 8) slots of it
  *      are unreachable by `cosmetic` traffic. A reply therefore cannot be
  *      starved by repaints even if a future call site is misclassified.
+ *
+ * ── 2026-07-28: the meter was reading ~58% of the traffic (#3855) ─────────
+ * Point 3 above USED to claim `perChatTotalMaxPerWindow` "counts every
+ * admitted call" and "matches Telegram's own per-chat metering". Both were
+ * false, and the gap is the reason a "20/60s" ceiling did not stop a ban.
+ * `apply` opened with `if (!isEdit && !isSend) return runObserved(next)` —
+ * an ALLOWLIST. Anything outside `EDIT_METHODS`/`SEND_METHODS` was entirely
+ * unmetered: it took no slot, and the ceiling therefore governed only the
+ * subset of traffic it happened to recognise.
+ *
+ * Measured on overlord's own gateway log (46791 `tg-post` lines), the
+ * unmetered share was 29% overall and 42% inside the 30 minutes before the
+ * 20:19:56 ban. By method:
+ *
+ *     sendChatAction      10457   ← unmetered, and up to 18/min on ONE DM
+ *     setMessageReaction   2098   ← unmetered
+ *     deleteMessage         370   ← unmetered
+ *     pinChatMessage        366   ← unmetered
+ *     unpinChatMessage      365   ← unmetered
+ *     answerCallbackQuery    31   ← unmetered (carries no chat_id)
+ *
+ * `sendChatAction` alone ran at Telegram's entire documented per-chat/minute
+ * allowance while the fuse counted none of it. So the fix is not a smaller
+ * number, it is an honest meter:
+ *
+ *   4. **DEFAULT-DENY metering.** Every method whose payload carries a
+ *      `chat_id` is charged to `perChatTotalMaxPerWindow`, whether or not this
+ *      file has heard of it. There is no per-chat exemption list to forget to
+ *      update — a new Bot API method, or one this gateway starts calling
+ *      tomorrow (`sendChecklist` is exactly that case: it carries `chat_id`,
+ *      creates a message, and was in neither set), is metered on arrival.
+ *      Methods that are neither edits nor sends are PACED and never dropped,
+ *      except `CHAT_ACTION_METHODS` — a typing indicator expires by itself in
+ *      ~5s and carries no content, so shedding one loses nothing.
+ *      The ceiling NUMBER is unchanged at 20/60s; what changed is that 20
+ *      admitted calls now means 20 on the wire rather than ~34.
+ *   5. **A per-BOT-TOKEN window.** Telegram's flood ban is scoped to the bot
+ *      token, not the chat, and enforces a global rate across all chats. A
+ *      second window keyed by the bot's PUBLIC numeric id (`perTokenWindowMs`
+ *      / `perTokenMaxPerWindow`, default 25 per 1000ms) is now charged for
+ *      EVERY outbound call — including the chat-less ones like
+ *      `answerCallbackQuery`, which the per-chat tier structurally cannot key.
+ *      A call is admitted only if BOTH windows have room.
+ *      LIMITATION, stated plainly: this window is per-PROCESS. Two agents
+ *      sharing one bot token run in separate containers with separate state
+ *      dirs, so neither sees the other's window. It is a real improvement on
+ *      the single process that actually floods and it is NOT full coverage
+ *      under a shared token; a cross-process view would need a token-keyed
+ *      store on a path both processes can write, which does not exist today.
+ *      Only the public bot id (the prefix before the `:`) is ever used as a
+ *      key, and it is never logged — see {@link deriveBotScopeKey}.
  *
  * Plus **escalating** backoff: a 429 used to apply ONE 0.5× tightening for a
  * flat 10 minutes, so a stream that took repeated small 429s re-tightened to
@@ -117,6 +168,8 @@
  * Every ceiling is operator-overridable via env — see
  * {@link editFloodFuseConfigFromEnv}. Previously none of them were.
  */
+
+import { createHash } from 'node:crypto'
 
 import type { Bot } from 'grammy'
 
@@ -158,6 +211,54 @@ const SEND_METHODS: ReadonlySet<string> = new Set([
   // 30s-preview draft is high-cadence by design and is not a persisted message.
   'sendRichMessage',
 ])
+
+/**
+ * Chat-targeted methods whose effect EXPIRES on its own and carries no content,
+ * so shedding one under pressure loses nothing a user would notice.
+ *
+ * `sendChatAction` is the entire set and the reason this tier exists: it was
+ * the single largest unmetered method in the incident log (10457 calls, up to
+ * 18/min on ONE DM — Telegram's whole documented per-chat/minute allowance),
+ * and the typing status it sets clears itself after ~5 seconds regardless.
+ * Every OTHER non-edit, non-send method with a `chat_id` (`deleteMessage`,
+ * `pinChatMessage`, `setMessageReaction`, …) has a durable, user-visible
+ * effect and is paced but never dropped.
+ */
+const CHAT_ACTION_METHODS: ReadonlySet<string> = new Set(['sendChatAction'])
+
+/**
+ * The ONLY methods exempt from metering entirely. Deliberately one entry.
+ *
+ * `getUpdates` is the long-poll RECEIVE loop, not outbound traffic: it is how
+ * inbound messages arrive at all. Pacing it would stall message delivery
+ * rather than protect anything, and it targets no chat, so it consumes no
+ * per-chat budget by construction.
+ *
+ * Nothing else is listed. The one-off administrative calls (`setMyCommands`,
+ * `deleteWebhook`, `getFile`, `getChat` — 37 calls TOTAL across a 46791-call
+ * log) are metered like everything else: at 25/second the cost is nil, and
+ * exempting them would mean asserting something about Telegram's accounting
+ * that this repo cannot verify from first-party evidence. Default-deny means
+ * the burden of proof is on the exemption.
+ */
+const UNMETERED_METHODS: ReadonlySet<string> = new Set(['getUpdates'])
+
+/**
+ * Reduce a bot token to a key safe to hold in memory.
+ *
+ * A Telegram token is `<bot_id>:<secret>`. The bot id is PUBLIC (it is the
+ * bot's user id, visible on every message it sends); the secret half is not.
+ * This returns the bot id alone when the token has that shape, so nothing
+ * secret is ever used as a map key, logged, or persisted. A token that does
+ * not match the shape falls back to a truncated SHA-256, which is stable
+ * across processes and irreversible.
+ */
+export function deriveBotScopeKey(token: string | undefined): string {
+  if (token == null || token === '') return 'unknown'
+  const id = token.slice(0, token.indexOf(':'))
+  if (/^\d+$/.test(id)) return id
+  return `h${createHash('sha256').update(token).digest('hex').slice(0, 16)}`
+}
 
 export interface EditFloodFuseConfig {
   /** Master switch. When false, `apply` is a pure passthrough. Default true. */
@@ -203,6 +304,28 @@ export interface EditFloodFuseConfig {
    */
   perChatReplyReserve?: number
   /**
+   * Ceiling on EVERY outbound call made with this bot token, across all chats
+   * and including the chat-less ones. Default 25 per `perTokenWindowMs`
+   * (1000ms), just under the ~30/second Telegram enforces at the token level.
+   * The flood ban is token-scoped, so this is the tier that matches the thing
+   * that actually gets banned. Per-PROCESS — see the docblock's point 5.
+   */
+  perTokenMaxPerWindow?: number
+  perTokenWindowMs?: number
+  /**
+   * Scope key for the token window: the bot's PUBLIC numeric id. Never pass a
+   * raw token — {@link installEditFloodFuse} derives this via
+   * {@link deriveBotScopeKey}. Default `'unknown'` (a single shared window,
+   * which is still correct for the one-bot-per-process case).
+   */
+  botScopeKey?: string
+  /**
+   * Longest a `CHAT_ACTION_METHODS` call may be held before it is shed.
+   * Default 3000ms — a typing indicator that arrives after the status it
+   * describes has already expired is worse than no typing indicator.
+   */
+  chatActionMaxDeferMs?: number
+  /**
    * Cap on COSMETIC edits that may be released late (over budget) because
    * nothing newer will repaint them — the bounded form of the R1 rule. Default
    * 2 per `perChatWindowMs`, so the worst-case sustained cosmetic rate is
@@ -247,6 +370,16 @@ export interface EditFloodFuseStats {
   cosmeticPerMessageCeiling: number
   /** Live COSMETIC per-chat ceiling (post-AIMD). */
   cosmeticPerChatCeiling: number
+  /**
+   * Chat-targeted calls charged by the DEFAULT-DENY rule — every one of these
+   * was completely unmetered before #3855. A non-zero value here is the direct
+   * measure of the hole this closed.
+   */
+  meteredByDefault: number
+  /** Calls with no `chat_id`, charged to the token window only. */
+  chatless: number
+  /** Live per-bot-token ceiling (post-AIMD). */
+  perTokenCeiling: number
 }
 
 export const EDIT_FLOOD_FUSE_DEFAULTS = {
@@ -275,6 +408,16 @@ export const EDIT_FLOOD_FUSE_DEFAULTS = {
   perChatTotalMaxPerWindow: 20,
   /** 8 of those 20 slots/min are unreachable by cosmetic traffic. */
   perChatReplyReserve: 8,
+  /**
+   * 25 per second across the whole bot token. Telegram enforces ~30/s at the
+   * token level and the ban it issues is token-scoped; 25 leaves headroom for
+   * traffic this process cannot see (a peer agent sharing the token, or a
+   * retry issued below the transformer stack).
+   */
+  perTokenMaxPerWindow: 25,
+  perTokenWindowMs: 1_000,
+  /** A typing indicator held longer than this is not worth sending. */
+  chatActionMaxDeferMs: 3_000,
   /** At most 2 cosmetic frames/min may exceed the ceiling as "lone" releases. */
   lateReleaseMaxPerWindow: 2,
   perChatWindowMs: 60_000,
@@ -309,6 +452,7 @@ export function editFloodFuseConfigFromEnv(
   assign('cosmeticPerChatMaxPerWindow', envInt(env.SWITCHROOM_FEED_EDIT_MAX_PER_CHAT_PER_MIN))
   assign('perChatTotalMaxPerWindow', envInt(env.SWITCHROOM_CHAT_TOTAL_MAX_PER_MIN))
   assign('perChatReplyReserve', envInt(env.SWITCHROOM_CHAT_REPLY_RESERVE))
+  assign('perTokenMaxPerWindow', envInt(env.SWITCHROOM_TOKEN_MAX_PER_SEC))
   assign('maxDeferMs', envInt(env.SWITCHROOM_EDIT_FUSE_MAX_DEFER_MS))
   return cfg
 }
@@ -356,6 +500,11 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
     Math.max(0, config.perChatReplyReserve ?? D.perChatReplyReserve),
     Math.max(0, perChatTotalMax - 1),
   )
+  const perTokenMax = Math.max(1, config.perTokenMaxPerWindow ?? D.perTokenMaxPerWindow)
+  const perTokenWindowMs = Math.max(1, config.perTokenWindowMs ?? D.perTokenWindowMs)
+  // Only ever the PUBLIC bot id (or an irreversible hash) reaches this key.
+  const tokenKey = `g:${config.botScopeKey ?? 'unknown'}`
+  const chatActionMaxDeferMs = config.chatActionMaxDeferMs ?? D.chatActionMaxDeferMs
   const lateReleaseMax = Math.max(0, config.lateReleaseMaxPerWindow ?? D.lateReleaseMaxPerWindow)
   const maxDeferMs = config.maxDeferMs ?? D.maxDeferMs
   const tightenFactor = config.tightenFactor ?? D.tightenFactor
@@ -364,7 +513,14 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
   const onTrip = config.onTrip
 
   const windows = new Map<string, Window>()
-  const counters = { deferred: 0, dropped: 0, superseded: 0, floodObserved: 0 }
+  const counters = {
+    deferred: 0, dropped: 0, superseded: 0, floodObserved: 0,
+    /** Chat-targeted calls charged by the DEFAULT-DENY rule that the old
+     *  allowlist would have let through unmetered (#3855 observability). */
+    meteredByDefault: 0,
+    /** Calls with no `chat_id`, charged to the token window only. */
+    chatless: 0,
+  }
   /**
    * Compounding 429 backoff. `tightenLevel` is the number of multiplicative
    * decreases currently in force; `tightenedUntil` is when the NEXT level
@@ -605,15 +761,13 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
     next: () => Promise<R>,
   ): Promise<R> {
     if (!enabled) return next()
+    if (UNMETERED_METHODS.has(method)) return runObserved(next)
 
     const isEdit = EDIT_METHODS.has(method)
     const isSend = SEND_METHODS.has(method)
-    if (!isEdit && !isSend) return runObserved(next)
+    const isChatAction = CHAT_ACTION_METHODS.has(method)
 
     const { chat, msg } = payloadKeys(payload)
-    // Inline-message edits carry no chat/message id — nothing to key on, and
-    // they are not part of any card loop. Pass through (still observed).
-    if (chat == null) return runObserved(next)
 
     const now = clock.now()
     evict(now)
@@ -622,7 +776,21 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
 
     // The send gate's priority class, propagated through AsyncLocalStorage.
     // An untagged edit is COSMETIC by default — see `defaultOutboundClass`.
-    const cls = currentOutboundClass() ?? defaultOutboundClass(isEdit)
+    // A chat action is cosmetic too: it is a self-expiring status, not content.
+    const cls =
+      currentOutboundClass() ?? (isChatAction ? 'cosmetic' : defaultOutboundClass(isEdit))
+
+    // DEFAULT-DENY (#3855): a call the fuse cannot key to a chat — an inline
+    // edit, `answerCallbackQuery`, `getFile`, `setMyCommands` — is NOT free.
+    // It cannot take a per-chat slot (there is no chat to charge), but it does
+    // consume the bot token's global allowance, which is the thing Telegram
+    // actually bans. Charge it there and pass.
+    if (chat == null) {
+      counters.chatless++
+      await awaitRoom(tokenKey, perTokenWindowMs, perTokenMax, method, 'release', cls, undefined, deadline)
+      return runObserved(next)
+    }
+
     const totalKey = `t:${chat}`
     // Cosmetic traffic may only reach `perChatTotalMax - perChatReplyReserve`;
     // the remaining slots stay available to a real reply no matter how hot the
@@ -630,8 +798,13 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
     const totalMaxFor = (c: OutboundClass): number =>
       c === 'cosmetic' ? Math.max(1, perChatTotalMax - perChatReplyReserve) : perChatTotalMax
 
-    if (isEdit) {
-      if (msg == null) return runObserved(next)
+    /** Final tier for every chat-targeted path: the token-scoped ceiling. */
+    const passToken = async (): Promise<R> => {
+      await awaitRoom(tokenKey, perTokenWindowMs, perTokenMax, method, 'release', cls, undefined, deadline)
+      return runObserved(next)
+    }
+
+    if (isEdit && msg != null) {
       const msgKey = `m:${chat}:${msg}`
       const mw = win(msgKey)
       // Counted BEFORE the first await so a frame that arrives while an older
@@ -670,18 +843,42 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
           cls === 'cosmetic' ? 'drop' : 'release', cls, dropGuard, deadline, lateKey,
         )
         if (totalSlot === null) { giveBack(); return DROPPED_RESULT as unknown as R }
-        return runObserved(next)
+        return passToken()
       } finally {
         mw.inflight--
       }
     }
 
-    // Sends create user-visible output and are NEVER dropped — only paced. The
-    // shared budget's reserve is what guarantees they still have room when the
-    // repaint surfaces are saturated.
-    await awaitRoom(`cs:${chat}`, perChatWindowMs, perChatSendMax, method, 'release', cls, undefined, deadline)
+    if (isSend) {
+      // Sends create user-visible output and are NEVER dropped — only paced.
+      // The shared budget's reserve is what guarantees they still have room
+      // when the repaint surfaces are saturated.
+      await awaitRoom(`cs:${chat}`, perChatWindowMs, perChatSendMax, method, 'release', cls, undefined, deadline)
+      await awaitRoom(totalKey, perChatWindowMs, totalMaxFor(cls), method, 'release', cls, undefined, deadline)
+      return passToken()
+    }
+
+    // DEFAULT-DENY (#3855). Everything else with a `chat_id` — `sendChatAction`,
+    // `setMessageReaction`, `deleteMessage`, `pinChatMessage`, `sendChecklist`,
+    // an inline edit that carries a chat but no message id, and any Bot API
+    // method added after this file was written — is charged to the SAME shared
+    // per-chat window. Previously all of it was free, which is how a "20/60s"
+    // ceiling admitted ~34 calls/60s on the wire.
+    counters.meteredByDefault++
+    if (isChatAction) {
+      // Self-expiring status: shed it rather than deliver it late. Its own
+      // short deadline also keeps a typing ping from occupying a 30s hold.
+      const actionDeadline = Math.min(deadline, now + chatActionMaxDeferMs)
+      const slot = await awaitRoom(
+        totalKey, perChatWindowMs, totalMaxFor(cls), method, 'drop', cls, undefined, actionDeadline,
+      )
+      if (slot === null) return DROPPED_RESULT as unknown as R
+      return passToken()
+    }
+    // Durable, user-visible effect (a deletion, a pin, a reaction): paced,
+    // never dropped — the same contract sends get.
     await awaitRoom(totalKey, perChatWindowMs, totalMaxFor(cls), method, 'release', cls, undefined, deadline)
-    return runObserved(next)
+    return passToken()
   }
 
   /** Run the downstream call, tightening the ceilings if it floods. */
@@ -714,6 +911,9 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
       perMessageCeiling: ceiling(perMessageMax, now),
       cosmeticPerMessageCeiling: ceiling(cosmeticPerMessageMax, now),
       cosmeticPerChatCeiling: ceiling(cosmeticPerChatMax, now),
+      meteredByDefault: counters.meteredByDefault,
+      chatless: counters.chatless,
+      perTokenCeiling: ceiling(perTokenMax, now),
     }
   }
 
@@ -729,7 +929,13 @@ export type EditFloodFuse = ReturnType<typeof createEditFloodFuse>
 export type FuseInstallable = Bot
 
 export function installEditFloodFuse(bot: FuseInstallable, config: EditFloodFuseConfig = {}): EditFloodFuse {
-  const fuse = createEditFloodFuse(config)
+  // The token window is keyed by the bot's PUBLIC id only. `deriveBotScopeKey`
+  // never returns any part of the secret half, and the key is used solely as an
+  // in-memory Map key — never logged, never persisted.
+  const fuse = createEditFloodFuse({
+    botScopeKey: deriveBotScopeKey((bot as { token?: string }).token),
+    ...config,
+  })
   bot.api.config.use(async (prev, method, payload, signal) =>
     fuse.apply(method, payload, () => prev(method, payload, signal)))
   return fuse

--- a/telegram-plugin/tests/edit-flood-fuse-default-deny.test.ts
+++ b/telegram-plugin/tests/edit-flood-fuse-default-deny.test.ts
@@ -1,0 +1,319 @@
+/**
+ * The fuse's meter must count what Telegram counts (#3855).
+ *
+ * ── The bug these tests guard ────────────────────────────────────────────
+ * `apply` opened with an ALLOWLIST:
+ *
+ *     const isEdit = EDIT_METHODS.has(method)
+ *     const isSend = SEND_METHODS.has(method)
+ *     if (!isEdit && !isSend) return runObserved(next)      // ← everything
+ *                                                           //   else was FREE
+ *
+ * So `perChatTotalMaxPerWindow` — documented as counting "every admitted call"
+ * and "matching Telegram's own per-chat metering" — counted neither. Measured
+ * on overlord's gateway log (46791 `tg-post` lines), the unmetered share was
+ * 29% overall and 42% in the 30 minutes before the 15908s ban:
+ *
+ *     sendChatAction      10457  (up to 18/min on ONE DM — the whole documented
+ *                                 per-chat/minute allowance, counted as zero)
+ *     setMessageReaction   2098
+ *     deleteMessage         370
+ *     pinChatMessage        366
+ *     unpinChatMessage      365
+ *     answerCallbackQuery    31  (no chat_id — unkeyable per-chat)
+ *
+ * Plus: the ban is scoped to the BOT TOKEN, and the fuse had no token-scoped
+ * window at all, so nothing bounded the aggregate rate across chats.
+ *
+ * Every test below asserts an OUTCOME — how many calls reached `next` inside a
+ * window — not that a branch executed.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  createEditFloodFuse,
+  deriveBotScopeKey,
+  EDIT_FLOOD_FUSE_DEFAULTS,
+} from '../edit-flood-fuse.js'
+import type { Clock } from '../send-gate.js'
+
+const CHAT = '1001'
+
+class FakeClock implements Clock {
+  private cur = 0
+  private seq = 0
+  private timers: { at: number; id: number; resolve: () => void }[] = []
+  now(): number { return this.cur }
+  sleep(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.timers.push({ at: this.cur + ms, id: this.seq++, resolve })
+    })
+  }
+  async advance(ms: number): Promise<void> {
+    const target = this.cur + ms
+    for (;;) {
+      await flush()
+      const due = this.timers.filter((t) => t.at <= target).sort((a, b) => a.at - b.at || a.id - b.id)
+      if (due.length === 0) break
+      const t = due[0]!
+      this.timers = this.timers.filter((x) => x !== t)
+      this.cur = t.at
+      t.resolve()
+      await flush()
+    }
+    this.cur = target
+    await flush()
+  }
+}
+const flush = (): Promise<void> => new Promise((r) => setImmediate(r))
+
+describe('default-deny metering — the 29% the allowlist could not see', () => {
+  /**
+   * The headline outcome. `sendChatAction` was the single largest unmetered
+   * method in the incident. Before the fix this loop put 60 calls on the wire
+   * inside one 60s window while the fuse reported a 20/60s ceiling as intact.
+   */
+  it('meters sendChatAction — 60 offered, at most the ceiling reaches the wire', async () => {
+    const clock = new FakeClock()
+    let landed = 0
+    const fuse = createEditFloodFuse({
+      clock, perChatTotalMaxPerWindow: 20, perChatReplyReserve: 8, perChatWindowMs: 60_000,
+    })
+
+    const calls = Array.from({ length: 60 }, () =>
+      fuse.apply('sendChatAction', { chat_id: CHAT, action: 'typing' }, async () => {
+        landed++
+        return true
+      }))
+    await clock.advance(59_000)
+    await Promise.all(calls)
+
+    // 20 total minus the 8-slot reply reserve = 12 available to cosmetic
+    // traffic, which a typing indicator is.
+    expect(landed).toBeLessThanOrEqual(12)
+    expect(landed).toBeGreaterThan(0)
+    // And the meter SAW them — this counter is zero on the pre-fix code.
+    expect(fuse.stats().meteredByDefault).toBe(60)
+  })
+
+  it.each([
+    ['setMessageReaction', { chat_id: CHAT, message_id: 5, reaction: [] }],
+    ['deleteMessage', { chat_id: CHAT, message_id: 5 }],
+    ['pinChatMessage', { chat_id: CHAT, message_id: 5 }],
+    ['unpinChatMessage', { chat_id: CHAT, message_id: 5 }],
+    // Not in EDIT_METHODS or SEND_METHODS and never was — the exact class of
+    // method default-deny exists to catch. It carries chat_id and creates a
+    // message (gateway.ts `rawSendChecklist`), so it consumes chat budget.
+    ['sendChecklist', { chat_id: CHAT, title: 't', tasks: [] }],
+    // A Bot API method this file has never heard of.
+    ['sendSomethingInventedNextYear', { chat_id: CHAT }],
+  ])('meters %s against the shared per-chat window', async (method, payload) => {
+    const clock = new FakeClock()
+    let landed = 0
+    const fuse = createEditFloodFuse({
+      clock, perChatTotalMaxPerWindow: 5, perChatReplyReserve: 0, perChatWindowMs: 60_000,
+      maxDeferMs: 1_000,
+    })
+    const calls = Array.from({ length: 30 }, () =>
+      fuse.apply(method, payload, async () => { landed++; return true }))
+    await clock.advance(2_000) // past the 1s defer deadline
+    await Promise.all(calls)
+
+    // These have durable, user-visible effects, so they are PACED not dropped —
+    // over-budget calls release at the defer deadline. The outcome that matters
+    // is that they took slots at all: the shared window is now full.
+    expect(fuse.stats().meteredByDefault).toBe(30)
+    expect(landed).toBe(30)
+    expect(fuse.stats().dropped).toBe(0)
+
+    // The proof the slots were really charged: a reply offered now finds the
+    // window saturated and is deferred rather than sailing straight through.
+    // On the pre-fix code none of the 30 took a slot, so this never deferred.
+    const before = fuse.stats().deferred
+    const reply = fuse.apply('sendMessage', { chat_id: CHAT, text: 'hi' }, async () => true)
+    await flush()
+    expect(fuse.stats().deferred).toBeGreaterThan(before)
+    await clock.advance(120_000)
+    await reply
+  })
+
+  it('never DROPS a durable-effect ancillary call — a deletion is paced, not lost', async () => {
+    const clock = new FakeClock()
+    let landed = 0
+    const fuse = createEditFloodFuse({
+      clock, perChatTotalMaxPerWindow: 2, perChatReplyReserve: 0, perChatWindowMs: 60_000,
+      maxDeferMs: 5_000,
+    })
+    const calls = Array.from({ length: 10 }, (_, i) =>
+      fuse.apply('deleteMessage', { chat_id: CHAT, message_id: i }, async () => {
+        landed++
+        return true
+      }))
+    await clock.advance(120_000)
+    await Promise.all(calls)
+    expect(landed).toBe(10)
+    expect(fuse.stats().dropped).toBe(0)
+  })
+
+  it('DOES drop a typing indicator rather than deliver it stale', async () => {
+    const clock = new FakeClock()
+    let landed = 0
+    const fuse = createEditFloodFuse({
+      clock, perChatTotalMaxPerWindow: 2, perChatReplyReserve: 0, perChatWindowMs: 60_000,
+      maxDeferMs: 30_000, chatActionMaxDeferMs: 3_000,
+    })
+    const calls = Array.from({ length: 10 }, () =>
+      fuse.apply('sendChatAction', { chat_id: CHAT, action: 'typing' }, async () => {
+        landed++
+        return true
+      }))
+    await clock.advance(30_000)
+    await Promise.all(calls)
+    expect(landed).toBe(2)
+    expect(fuse.stats().dropped).toBe(8)
+  })
+
+  it('the reply reserve survives a saturating ancillary stream', async () => {
+    // The starvation guarantee has to hold against the traffic that was
+    // previously invisible, or it is not a guarantee.
+    const clock = new FakeClock()
+    let repliesLanded = 0
+    const fuse = createEditFloodFuse({
+      clock, perChatTotalMaxPerWindow: 20, perChatReplyReserve: 8, perChatWindowMs: 60_000,
+      maxDeferMs: 30_000,
+    })
+    const noise = Array.from({ length: 200 }, () =>
+      fuse.apply('sendChatAction', { chat_id: CHAT, action: 'typing' }, async () => true))
+    await flush()
+    const replies = Array.from({ length: 8 }, (_, i) =>
+      fuse.apply('sendMessage', { chat_id: CHAT, text: `answer ${i}` }, async () => {
+        repliesLanded++
+        return true
+      }))
+    await clock.advance(120_000)
+    await Promise.all([...noise, ...replies])
+    expect(repliesLanded).toBe(8)
+  })
+})
+
+describe('the per-BOT-TOKEN window — the scope the ban actually uses', () => {
+  it('bounds the aggregate rate across MANY chats, which per-chat windows cannot', async () => {
+    // 40 distinct chats, one call each, all in the same instant. Every per-chat
+    // window is comfortably in budget; only a token-scoped window sees the sum.
+    const clock = new FakeClock()
+    let landed = 0
+    const fuse = createEditFloodFuse({
+      clock, botScopeKey: '123456789',
+      perTokenMaxPerWindow: 25, perTokenWindowMs: 1_000, maxDeferMs: 30_000,
+    })
+    const calls = Array.from({ length: 40 }, (_, i) =>
+      fuse.apply('sendMessage', { chat_id: `chat-${i}`, text: 'x' }, async () => {
+        landed++
+        return true
+      }))
+    await flush()
+    expect(landed).toBe(25) // the token ceiling, not 40
+
+    await clock.advance(2_000)
+    await Promise.all(calls)
+    // Nothing is LOST — the remaining 15 land once the window slides.
+    expect(landed).toBe(40)
+  })
+
+  it('charges a CHAT-LESS call (answerCallbackQuery) to the token window', async () => {
+    // answerCallbackQuery carries `callback_query_id`, never `chat_id`, so the
+    // per-chat tier structurally cannot key it. Before #3855 that meant it was
+    // free everywhere. It is now charged where it genuinely counts.
+    const clock = new FakeClock()
+    let landed = 0
+    const fuse = createEditFloodFuse({
+      clock, perTokenMaxPerWindow: 3, perTokenWindowMs: 1_000, maxDeferMs: 30_000,
+    })
+    const calls = Array.from({ length: 10 }, (_, i) =>
+      fuse.apply('answerCallbackQuery', { callback_query_id: `q${i}` }, async () => {
+        landed++
+        return true
+      }))
+    await flush()
+    expect(landed).toBe(3)
+    expect(fuse.stats().chatless).toBe(10)
+
+    await clock.advance(5_000)
+    await Promise.all(calls)
+    expect(landed).toBe(10) // paced, never dropped
+  })
+
+  it('BOTH windows must pass — a single hot chat is still bounded per-chat', async () => {
+    const clock = new FakeClock()
+    let landed = 0
+    const fuse = createEditFloodFuse({
+      clock,
+      perChatTotalMaxPerWindow: 4, perChatReplyReserve: 0, perChatWindowMs: 60_000,
+      // Token window wide open, so only the per-chat tier can bind.
+      perTokenMaxPerWindow: 1_000, perTokenWindowMs: 1_000,
+      maxDeferMs: 500,
+    })
+    const calls = Array.from({ length: 20 }, () =>
+      fuse.apply('sendChatAction', { chat_id: CHAT, action: 'typing' }, async () => {
+        landed++
+        return true
+      }))
+    await clock.advance(2_000) // past the 500ms defer deadline
+    await Promise.all(calls)
+    expect(landed).toBe(4)
+  })
+
+  it('separate bot ids get separate windows; the same id shares one', async () => {
+    const clock = new FakeClock()
+    const mk = (botScopeKey: string) =>
+      createEditFloodFuse({
+        clock, botScopeKey, perTokenMaxPerWindow: 2, perTokenWindowMs: 60_000,
+        perChatTotalMaxPerWindow: 1_000, maxDeferMs: 100,
+      })
+    // Two fuses with the SAME id are still two processes' worth of state — the
+    // documented limitation. What this asserts is the KEY derivation, which is
+    // what a future shared store would key on.
+    expect(deriveBotScopeKey('123456789:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw')).toBe('123456789')
+    expect(mk('123456789')).toBeDefined()
+  })
+})
+
+describe('deriveBotScopeKey — the token itself must never become a key', () => {
+  const REAL_SHAPE = '8123456789:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw'
+
+  it('returns ONLY the public bot id, never any part of the secret', () => {
+    const key = deriveBotScopeKey(REAL_SHAPE)
+    expect(key).toBe('8123456789')
+    const secret = REAL_SHAPE.slice(REAL_SHAPE.indexOf(':') + 1)
+    expect(key).not.toContain(secret)
+    // Not even a prefix of the secret leaks — check every prefix ≥ 4 chars.
+    for (let n = 4; n <= secret.length; n++) {
+      expect(key).not.toContain(secret.slice(0, n))
+    }
+  })
+
+  it('falls back to an irreversible hash for a token of unexpected shape', () => {
+    const odd = 'not-a-normal-token'
+    const key = deriveBotScopeKey(odd)
+    expect(key).toMatch(/^h[0-9a-f]{16}$/)
+    expect(key).not.toContain(odd)
+    // Stable — the same token must key the same window across constructions.
+    expect(deriveBotScopeKey(odd)).toBe(key)
+  })
+
+  it('handles an absent token without throwing', () => {
+    expect(deriveBotScopeKey(undefined)).toBe('unknown')
+    expect(deriveBotScopeKey('')).toBe('unknown')
+  })
+})
+
+describe('the defaults still describe the real budget', () => {
+  it('the token ceiling sits below Telegram\'s ~30/s token-level limit', () => {
+    expect(EDIT_FLOOD_FUSE_DEFAULTS.perTokenMaxPerWindow).toBeLessThan(30)
+    expect(EDIT_FLOOD_FUSE_DEFAULTS.perTokenWindowMs).toBe(1_000)
+  })
+
+  it('a chat action may not be held past its own ~5s lifetime', () => {
+    expect(EDIT_FLOOD_FUSE_DEFAULTS.chatActionMaxDeferMs).toBeLessThan(5_000)
+  })
+})

--- a/telegram-plugin/tests/edit-flood-fuse.test.ts
+++ b/telegram-plugin/tests/edit-flood-fuse.test.ts
@@ -297,9 +297,18 @@ describe('edit-flood fuse — structural: installed where nothing can bypass it'
     expect(fuse.stats().dropped + fuse.stats().superseded).toBeGreaterThan(0)
   })
 
-  it('passes non-message methods straight through (getUpdates must never be paced)', async () => {
+  // #3855: this test used to be titled "passes non-message methods straight
+  // through" and stood for the ALLOWLIST — everything outside EDIT/SEND was
+  // free, which left 29% of real traffic unmetered. The exemption is now a
+  // one-entry list and this test guards exactly that entry, not a category.
+  it('getUpdates — the long-poll RECEIVE loop — is the one unmetered method', async () => {
     const clock = new FakeClock()
-    const fuse = createEditFloodFuse({ clock, perChatSendMaxPerWindow: 1, perChatWindowMs: 600_000 })
+    const fuse = createEditFloodFuse({
+      clock, perChatSendMaxPerWindow: 1, perChatWindowMs: 600_000,
+      // Deliberately brutal: if getUpdates were metered at all, the 2nd call
+      // would block forever on this clock.
+      perTokenMaxPerWindow: 1, perTokenWindowMs: 600_000,
+    })
     let calls = 0
     for (let i = 0; i < 100; i++) {
       await fuse.apply('getUpdates', {}, async () => { calls++; return [] })


### PR DESCRIPTION
Closes the two metering holes in `edit-flood-fuse.ts`: the meter read ~58% of the traffic, and there was no window at the scope Telegram actually bans.

## 1. The meter was an allowlist

`apply` opened with:

```ts
const isEdit = EDIT_METHODS.has(method)
const isSend = SEND_METHODS.has(method)
if (!isEdit && !isSend) return runObserved(next)   // ← everything else was FREE
```

So `perChatTotalMaxPerWindow` — whose docblock at `:102-108` asserted it "counts every admitted call" and "matches Telegram's own per-chat metering" — did neither. Both claims are corrected in place rather than deleted.

Measured on overlord's own gateway log (`/host-home/.switchroom/logs/overlord/gateway-supervisor.log`, 46791 `tg-post` lines). Unmetered share: **29% overall, 42% in the 30 minutes before the 20:19:56 ban.**

| method | calls | was metered? |
|---|---:|---|
| `editMessageText` | 31484 | yes |
| **`sendChatAction`** | **10457** | **no** |
| **`setMessageReaction`** | **2098** | **no** |
| `sendRichMessage` | 1255 | yes |
| **`deleteMessage`** | **370** | **no** |
| **`pinChatMessage`** | **366** | **no** |
| **`unpinChatMessage`** | **365** | **no** |
| `sendMessage` | 302 | yes |
| **`answerCallbackQuery`** | **31** | **no** |

`sendChatAction` is the headline: in the incident window it ran at **up to 18/min on ONE DM** — Telegram's entire documented per-chat/minute allowance — and the fuse counted none of it. A "20/60s" ceiling was admitting ~34 calls/60s on the wire.

**Fix — default-deny.** Every method whose payload carries a `chat_id` is charged to the shared per-chat window, whether or not this file has heard of it. There is no per-chat exemption list to forget to update.

- **`sendChecklist`** (the brief asked specifically): carries `chat_id` and creates a message (`gateway.ts:1403` `rawSendChecklist`), and was in **neither** `EDIT_METHODS` nor `SEND_METHODS`. It is now metered *without being listed anywhere* — which is the point of the rule.
- **`answerCallbackQuery`** (also asked specifically): carries `callback_query_id`, **never** a `chat_id`. The per-chat tier structurally cannot key it, so adding it to a chat-scoped set would have been meaningless. It is charged to the new **token** window instead, which is where it genuinely consumes budget. 31 calls in the whole log, so it was never the flood — but it is no longer free.
- **`getUpdates` is the one exemption**, and it is justified rather than assumed: it is the long-poll RECEIVE loop, so pacing it stalls inbound message delivery rather than protecting anything, and it targets no chat. The one-off administrative calls (`setMyCommands`, `deleteWebhook`, `getFile`, `getChat` — 37 calls **total** across 46791) are metered like everything else; at 25/second that costs nothing, and exempting them would mean asserting something about Telegram's accounting this repo cannot verify.

**Drop policy for the newly-metered traffic.** Ancillary methods with a durable, user-visible effect (`deleteMessage`, `pinChatMessage`, `setMessageReaction`) are **paced, never dropped** — the same contract sends get. `sendChatAction` is the sole exception: the typing status clears itself after ~5s, so a stale one is worse than none, and it is shed at `chatActionMaxDeferMs` (3s) rather than held for the full 30s.

## 2. There was no per-BOT-TOKEN window

The flood ban is scoped to the **token**, not the chat, and Telegram enforces a global rate across all chats. The fuse only ever keyed `t:${chat}`, so N chats could each be in budget while the token was not.

Added `perTokenMaxPerWindow` / `perTokenWindowMs` (default **25 per 1000ms**, under the ~30/s token-level limit), charged for **every** outbound call including the chat-less ones. A call is admitted only if **both** windows have room.

**Token handling.** `deriveBotScopeKey()` returns **only the public bot id** (the prefix before the `:`, which is the bot's user id and visible on every message it sends). A token of unexpected shape falls back to a truncated SHA-256. The key is an in-memory `Map` key and nothing else — never logged, never persisted, never in an error message. A test walks **every** prefix of the secret half ≥4 chars and asserts none appears in the derived key.

### The limitation, stated plainly

**This window is per-PROCESS.** Two agents sharing one bot token (`clerk` and `test-harness` share `vault:telegram-bot-token`) run in separate containers with separate state dirs, so neither sees the other's window. I did not "fix" this by splitting tokens — per the operator's explicit instruction, sharing a token is fine and is not the problem.

I considered persisting the window through `flood-circuit-breaker.ts`'s existing store and **it does not reach**: `flood-wait.json` / `flood-windows.json` live under each agent's *own* state dir (`/host-home/.switchroom/agents/<name>/telegram/`), so two token-sharing agents already have two separate copies of that state. A genuinely shared view needs a token-keyed path both processes can write, which does not exist today. Filed as a follow-up rather than bolted on here.

So: **this bounds the single process that actually floods, and it is NOT full coverage under a shared token.** Both halves of that sentence are true and I am not implying otherwise — overstated coverage is the exact failure being corrected from #3849.

## Ceilings

The ceiling **numbers are unchanged** (20/60s per chat, 8-slot reply reserve). The recalibration is that they now mean what they say: 20 admitted calls is 20 on the wire, not ~34. Against the incident timeline — 4-6/min survived for hours, 8-17/min earned the ban, ~45/min real combined rate in the final 20 minutes — an honest 20/min total with 12 of it reachable by cosmetic traffic sits inside the survived band. Lowering the number on top of fixing the meter would have compounded two changes and made neither measurable.

## What the tests prove

`telegram-plugin/tests/edit-flood-fuse-default-deny.test.ts` (19 new tests). **10 of them fail against the pre-fix allowlist** — verified by reinstating the `if (!isEdit && !isSend) return runObserved(next)` line and re-running:

- 60 `sendChatAction` offered in one window ⇒ at most 12 reach `next` (20 total − 8 reserve), and `stats().meteredByDefault === 60`. On pre-fix code all 60 land and the counter does not exist.
- Parameterised over `setMessageReaction` / `deleteMessage` / `pinChatMessage` / `unpinChatMessage` / `sendChecklist` / a **made-up future method**: all 30 land (paced, never dropped, `dropped === 0`) **and** a reply offered afterwards is deferred — proving the slots were really charged rather than the calls merely passing through.
- A typing indicator IS dropped (2 land, 8 dropped); a `deleteMessage` stream is NOT (10/10 land, 0 dropped).
- The reply reserve holds against 200 saturating chat actions: all 8 replies land.
- Token window: 40 sends across 40 **distinct** chats — every per-chat window in budget — admit exactly 25 in the first second, then the remaining 15 once it slides. Nothing lost.
- `answerCallbackQuery` ×10 with a 3/s token ceiling: 3 immediately, all 10 eventually, `stats().chatless === 10`.
- Both windows bind independently: a token window left wide open still leaves a hot single chat bounded at its per-chat ceiling.
- `deriveBotScopeKey` leaks no prefix of the secret; hashes an odd-shaped token stably; handles `undefined`.

Retitled the existing `passes non-message methods straight through (getUpdates must never be paced)` test — it used to stand for the *allowlist as a category* and now guards the single exemption, with the token ceiling set to 1 so any metering of `getUpdates` would hang it.

Full `telegram-plugin/tests/`: **7729 passed** on this branch vs 7710 on pristine `origin/main`, with the identical 4 pre-existing failures in both runs (bun-native suites executed under vitest + a `render/parse.ts` TS7006 in this sandbox's symlinked `node_modules`). `tsc --noEmit` clean. `check-gateway-line-ratchet` clean at 24917 (this PR does not touch `gateway.ts`). `check-bot-api-wrapping` clean.

## Evidence caveat — read this before approving the method classifications

**I could not reach `core.telegram.org` from this container** (no egress; the fetch timed out and no research tool is available here). So the classifications above are **not** verified against Telegram's published docs. They rest on:

1. **First-party measurement** — the method histogram and 429 timeline from our own production gateway log, quoted above.
2. **Structural facts about the payloads** — `answerCallbackQuery` carries no `chat_id` and therefore cannot be keyed per-chat by any implementation; `sendChecklist` carries `chat_id` and creates a message.
3. **Default-deny as the response to the uncertainty** — where I could not verify, the method is metered rather than exempted. The burden of proof is on the exemption, and there is exactly one.

If a reviewer has doc access, the two numbers worth checking are the ~30/s token-level limit (`perTokenMaxPerWindow: 25`) and whether pure getters consume per-chat budget (currently metered, i.e. the conservative choice).

## Adversarial notes

- `EditFloodFuseStats` gained three fields; `tsc` is clean so no consumer broke.
- `perTokenMax`/`perTokenWindowMs` are clamped to ≥1, so a zero from env cannot deadlock every outbound call.
- The token tier is always `'release'` mode — it can delay a call by at most one 1s window but never drops one. A burst limiter that shed traffic would be a new way to lose a reply.
- `installEditFloodFuse` spreads `config` **after** the derived `botScopeKey`, so an explicit caller-supplied key still wins (needed by tests).
- The chat-less path takes the token slot *before* `runObserved`, so a chat-less call that 429s still tightens the ceilings.
