### PR TITLE
fix(telegram): make the fuse ban-aware across restarts and scale it to the penalty

### DIFF
--- a/telegram-plugin/edit-flood-fuse.ts
+++ b/telegram-plugin/edit-flood-fuse.ts
@@ -175,6 +175,7 @@ import type { Bot } from 'grammy'
 
 import type { Clock } from './send-gate.js'
 import { systemClock } from './send-gate.js'
+import { floodStatePath, makeFloodWaitProbe } from './flood-circuit-breaker.js'
 import {
   currentOutboundClass,
   defaultOutboundClass,
@@ -341,6 +342,24 @@ export interface EditFloodFuseConfig {
   tightenMs?: number
   /** Cap on compounding 429 tightening levels. Default 4 (⇒ 0.5^4 = 1/16). */
   maxTightenLevel?: number
+  /**
+   * Remaining ms of a KNOWN-OPEN Telegram flood window, or 0 when none — the
+   * persisted breaker state (`flood-circuit-breaker.ts`) that every other
+   * outbound path already consults. Wired by {@link editFloodFuseConfigFromEnv}.
+   *
+   * The fuse's tightening lived only in process memory, so before #3856 a
+   * gateway restart during a ban came back FULLY UNTIGHTENED and resumed at
+   * the rate that earned the ban — and a restart is the single most likely
+   * thing to happen during a multi-hour outage. Consulting the persisted
+   * window makes the response durable: while it is open the fuse holds
+   * `maxTightenLevel` regardless of what this process remembers.
+   *
+   * FAILS OPEN (throwing or absent probe ⇒ untightened): a breaker that cannot
+   * read its own state must never gag the bot.
+   */
+  floodWaitRemainingMs?: () => number
+  /** How often the persisted window may be re-read. Default 1000ms. */
+  floodProbeIntervalMs?: number
   /** Observability hook; fired whenever the fuse binds. */
   onTrip?: (info: {
     method: string
@@ -380,6 +399,11 @@ export interface EditFloodFuseStats {
   chatless: number
   /** Live per-bot-token ceiling (post-AIMD). */
   perTokenCeiling: number
+  /**
+   * True when a PERSISTED flood window is open right now — i.e. the tightening
+   * in force is durable rather than remembered, and survives a restart (#3856).
+   */
+  persistedFloodOpen: boolean
 }
 
 export const EDIT_FLOOD_FUSE_DEFAULTS = {
@@ -425,6 +449,8 @@ export const EDIT_FLOOD_FUSE_DEFAULTS = {
   tightenFactor: 0.5,
   tightenMs: 600_000,
   maxTightenLevel: 4,
+  /** The persisted flood window is re-read at most once a second (#3856). */
+  floodProbeIntervalMs: 1_000,
 } as const
 
 /** Parse a positive integer from env, or undefined when unset/invalid. */
@@ -454,6 +480,15 @@ export function editFloodFuseConfigFromEnv(
   assign('perChatReplyReserve', envInt(env.SWITCHROOM_CHAT_REPLY_RESERVE))
   assign('perTokenMaxPerWindow', envInt(env.SWITCHROOM_TOKEN_MAX_PER_SEC))
   assign('maxDeferMs', envInt(env.SWITCHROOM_EDIT_FUSE_MAX_DEFER_MS))
+  // #3856 — durable ban awareness. The fuse reads the SAME persisted marker
+  // (`flood-wait.json`) that `robustApiCall` and the outbox sweep consult, so a
+  // restart mid-ban comes back tightened instead of at full rate. Wired here
+  // rather than at the call site so no caller can forget it, and because
+  // `gateway.ts` is under a zero-slack line ratchet.
+  const stateDir = env.TELEGRAM_STATE_DIR
+  if (stateDir != null && stateDir !== '') {
+    cfg.floodWaitRemainingMs = makeFloodWaitProbe(floodStatePath(stateDir))
+  }
   return cfg
 }
 
@@ -510,6 +545,8 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
   const tightenFactor = config.tightenFactor ?? D.tightenFactor
   const tightenMs = config.tightenMs ?? D.tightenMs
   const maxTightenLevel = Math.max(0, config.maxTightenLevel ?? D.maxTightenLevel)
+  const floodProbe = config.floodWaitRemainingMs
+  const floodProbeIntervalMs = Math.max(0, config.floodProbeIntervalMs ?? D.floodProbeIntervalMs)
   const onTrip = config.onTrip
 
   const windows = new Map<string, Window>()
@@ -531,13 +568,46 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
   let tightenLevel = 0
   let tightenedUntil = 0
 
+  /**
+   * Cached read of the PERSISTED flood window (#3856). Throttled to
+   * `floodProbeIntervalMs` because `levelAt` runs on every admission and the
+   * probe is a file read — an unthrottled read would make the fuse the latency
+   * problem it exists to prevent. Between reads the cached remaining time is
+   * decayed by elapsed wall time, so a window never appears to last longer
+   * than it does.
+   *
+   * FAILS OPEN: any throw is treated as "no window". `makeFloodWaitProbe`
+   * already fails open on an unreadable marker and warns loudly (#3106); this
+   * catch covers the rest.
+   */
+  let probedAt = Number.NEGATIVE_INFINITY
+  let probedRemainingMs = 0
+  function persistedFloodRemainingMs(now: number): number {
+    if (floodProbe === undefined) return 0
+    const since = now - probedAt
+    if (since < floodProbeIntervalMs) return Math.max(0, probedRemainingMs - since)
+    probedAt = now
+    try {
+      const ms = floodProbe()
+      probedRemainingMs = Number.isFinite(ms) && ms > 0 ? ms : 0
+    } catch {
+      probedRemainingMs = 0
+    }
+    return probedRemainingMs
+  }
+
   /** Decay one level per `tightenMs` of quiet, rather than a single cliff. */
   function levelAt(now: number): number {
-    if (tightenLevel === 0) return 0
     while (tightenLevel > 0 && tightenedUntil <= now) {
       tightenLevel--
       tightenedUntil = tightenLevel > 0 ? tightenedUntil + tightenMs : 0
     }
+    // #3856 — a KNOWN-OPEN persisted window pins the fuse at its tightest
+    // regardless of in-memory state. This is what survives a restart: the
+    // process forgets, the marker on disk does not. It does not MUTATE
+    // `tightenLevel`, so when the window closes the fuse returns to whatever
+    // this process actually earned rather than staying pinned.
+    if (persistedFloodRemainingMs(now) > 0) return maxTightenLevel
     return tightenLevel
   }
 
@@ -609,27 +679,69 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
     return { chat, msg }
   }
 
-  /** Record a 429 (whatever shape it arrives in) and tighten one more level. */
-  function noteFlood(now: number): void {
+  /**
+   * Record a 429 and tighten IN PROPORTION TO THE PENALTY (#3856).
+   *
+   * Before this, every 429 was worth exactly one level: a 3-second "slow down
+   * a touch" nudge and a **15908-second** ban produced the identical response.
+   * The whole point of AIMD is that the decrease matches the signal, and a
+   * four-hour ban is not one nudge's worth of signal. `retryAfterSec` is the
+   * severity Telegram itself states, so it is what the step is scaled by.
+   *
+   * The tightening is also held for at least the ban's own duration. A flat
+   * 10-minute `tightenMs` expired ~25× over during the 2026-07-27 ban, so the
+   * fuse would have been back at full rate long before the window closed.
+   */
+  function noteFlood(now: number, retryAfterSec: number): void {
     counters.floodObserved++
     levelAt(now)
-    tightenLevel = Math.min(maxTightenLevel, tightenLevel + 1)
-    // Every level currently in force is re-armed for a full `tightenMs`; the
-    // decay clock restarts from the newest 429, not from the first.
-    tightenedUntil = now + tightenMs
+    tightenLevel = Math.min(maxTightenLevel, tightenLevel + tightenStepFor(retryAfterSec))
+    // Every level currently in force is re-armed; the decay clock restarts
+    // from the newest 429, and never expires before the penalty itself does.
+    tightenedUntil = now + Math.max(tightenMs, retryAfterSec * 1000 + tightenMs)
   }
 
-  function looksLikeFlood(err: unknown): boolean {
+  /**
+   * Levels of multiplicative decrease one 429 is worth, by stated penalty:
+   *
+   *   ≤ 5s     1   a routine burst nudge
+   *   ≤ 60s    2   sustained overrate
+   *   ≤ 600s   3   a real ban
+   *   > 600s   ALL the way to `maxTightenLevel` — at this magnitude the rate
+   *               that produced it is categorically wrong, and stepping down
+   *               one level at a time would spend the next window earning the
+   *               next ban. The 2026-07-25 (3713s) and 2026-07-27 (15908s)
+   *               bans are both in this band.
+   */
+  function tightenStepFor(retryAfterSec: number): number {
+    if (!Number.isFinite(retryAfterSec) || retryAfterSec <= 5) return 1
+    if (retryAfterSec <= 60) return 2
+    if (retryAfterSec <= 600) return 3
+    return maxTightenLevel
+  }
+
+  /**
+   * The stated `retry_after` in seconds when `err` is a flood rejection, else
+   * null. Returns 0 for a flood whose magnitude is not stated (the text-match
+   * path), which `tightenStepFor` treats as the mildest case — an unquantified
+   * signal must not be inflated into a maximal response.
+   */
+  function floodRetryAfterSec(err: unknown): number | null {
     const e = err as { error_code?: number; parameters?: { retry_after?: number } } | null
     if (e != null && typeof e === 'object') {
-      if (e.error_code === 429) return true
-      if (e.parameters != null && typeof e.parameters.retry_after === 'number') return true
+      const stated = e.parameters?.retry_after
+      if (typeof stated === 'number') return stated
+      if (e.error_code === 429) return 0
     }
     // Match on the SEMANTIC markers only. A bare "429" substring
     // false-positives on ordinary server text (e.g. "message 429 not found"),
     // and a false positive here halves every ceiling for ten minutes.
     const msg = err instanceof Error ? err.message : String(err ?? '')
-    return /too many requests/i.test(msg) || /retry[ _-]?after/i.test(msg)
+    if (!/too many requests/i.test(msg) && !/retry[ _-]?after/i.test(msg)) return null
+    // grammY and the Bot API both surface the magnitude in the text; use it
+    // when it is there rather than throwing the severity away.
+    const m = /retry[ _-]?after[^0-9]{0,4}(\d+)/i.exec(msg)
+    return m != null ? Number(m[1]) : 0
   }
 
 /**
@@ -887,13 +999,16 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
       const res = await next()
       // grammY throws on ok:false, but a transformer installed BELOW another
       // one can still observe a raw ApiResponse — handle both shapes.
-      const r = res as unknown as { ok?: boolean; error_code?: number }
+      const r = res as unknown as {
+        ok?: boolean; error_code?: number; parameters?: { retry_after?: number }
+      }
       if (r != null && typeof r === 'object' && r.ok === false && r.error_code === 429) {
-        noteFlood(clock.now())
+        noteFlood(clock.now(), r.parameters?.retry_after ?? 0)
       }
       return res
     } catch (err) {
-      if (looksLikeFlood(err)) noteFlood(clock.now())
+      const retryAfterSec = floodRetryAfterSec(err)
+      if (retryAfterSec !== null) noteFlood(clock.now(), retryAfterSec)
       throw err
     }
   }
@@ -914,6 +1029,7 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
       meteredByDefault: counters.meteredByDefault,
       chatless: counters.chatless,
       perTokenCeiling: ceiling(perTokenMax, now),
+      persistedFloodOpen: persistedFloodRemainingMs(now) > 0,
     }
   }
 

--- a/telegram-plugin/tests/edit-flood-fuse-ban-awareness.test.ts
+++ b/telegram-plugin/tests/edit-flood-fuse-ban-awareness.test.ts
@@ -1,0 +1,316 @@
+/**
+ * The fuse must survive a restart and must react in PROPORTION to the ban
+ * (#3856).
+ *
+ * ── The two bugs these tests guard ───────────────────────────────────────
+ *
+ * 1. **All state was in process memory.** `tightenLevel` / `tightenedUntil`
+ *    were module-local variables. The gateway restarting during a flood ban —
+ *    the single most likely thing to happen during a multi-hour outage —
+ *    brought the fuse back FULLY UNTIGHTENED, at exactly the rate that earned
+ *    the ban, while the window was still open. Every other outbound path in
+ *    the tree already consults `flood-wait.json`; the fuse did not.
+ *
+ * 2. **`noteFlood()` ignored the magnitude.** Every 429 was worth exactly one
+ *    level of multiplicative decrease, so a 3-second burst nudge and the
+ *    15908-second (4.4h) ban of 2026-07-27 produced an identical response.
+ *    The tightening also expired after a flat 10 minutes — ~25× shorter than
+ *    that ban, so the fuse would have been back at full rate for hours while
+ *    still banned.
+ *
+ * Every test asserts an OUTCOME (the live ceiling, or how many calls reached
+ * the wire), never that a branch ran.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  createEditFloodFuse,
+  editFloodFuseConfigFromEnv,
+  EDIT_FLOOD_FUSE_DEFAULTS,
+} from '../edit-flood-fuse.js'
+import { floodStatePath, makeFloodWaitProbe } from '../flood-circuit-breaker.js'
+import type { Clock } from '../send-gate.js'
+
+const CHAT = '1001'
+
+class FakeClock implements Clock {
+  private cur = 0
+  private seq = 0
+  private timers: { at: number; id: number; resolve: () => void }[] = []
+  now(): number { return this.cur }
+  sleep(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.timers.push({ at: this.cur + ms, id: this.seq++, resolve })
+    })
+  }
+  async advance(ms: number): Promise<void> {
+    const target = this.cur + ms
+    for (;;) {
+      await flush()
+      const due = this.timers.filter((t) => t.at <= target).sort((a, b) => a.at - b.at || a.id - b.id)
+      if (due.length === 0) break
+      const t = due[0]!
+      this.timers = this.timers.filter((x) => x !== t)
+      this.cur = t.at
+      t.resolve()
+      await flush()
+    }
+    this.cur = target
+    await flush()
+  }
+}
+const flush = (): Promise<void> => new Promise((r) => setImmediate(r))
+
+/** A 429 in the shape grammY throws it. */
+function flood(retryAfterSec: number): Error & Record<string, unknown> {
+  const e = new Error('Too Many Requests: retry after ' + retryAfterSec) as Error &
+    Record<string, unknown>
+  e.error_code = 429
+  e.parameters = { retry_after: retryAfterSec }
+  return e
+}
+
+describe('restart durability — the persisted window outranks process memory', () => {
+  it('a FRESH fuse is already at its tightest when a ban is open on disk', async () => {
+    const clock = new FakeClock()
+    // Simulate the restart: brand-new fuse, zero in-memory history, but the
+    // marker on disk still says 12247s of ban to go.
+    const fuse = createEditFloodFuse({
+      clock, floodWaitRemainingMs: () => 12_247_000,
+      perMessageMaxPerWindow: 20, cosmeticPerMessageMaxPerWindow: 16,
+      maxTightenLevel: 4, tightenFactor: 0.5,
+    })
+
+    const s = fuse.stats()
+    expect(s.persistedFloodOpen).toBe(true)
+    expect(s.tightenLevel).toBe(4)
+    // 0.5^4 = 1/16 of the base ceiling — the fuse did NOT come back at full rate.
+    expect(s.cosmeticPerMessageCeiling).toBe(1)
+    expect(s.perMessageCeiling).toBe(1)
+    // And it BINDS: 30 cosmetic edits offered, at most the tightened ceiling
+    // reaches the wire. Without the persisted read this is 16.
+    let landed = 0
+    const calls = Array.from({ length: 30 }, () =>
+      fuse.apply('editMessageText', { chat_id: CHAT, message_id: 7 }, async () => {
+        landed++
+        return true
+      }))
+    await clock.advance(31_000)
+    await Promise.all(calls)
+    expect(landed).toBeLessThanOrEqual(2)
+  })
+
+  it('untightens once the window on disk closes — it is a floor, not a latch', async () => {
+    const clock = new FakeClock()
+    let remaining = 60_000
+    const fuse = createEditFloodFuse({
+      clock, floodWaitRemainingMs: () => remaining,
+      floodProbeIntervalMs: 0, // re-read every call, for determinism here
+      perMessageMaxPerWindow: 20, maxTightenLevel: 4, tightenFactor: 0.5,
+    })
+    expect(fuse.stats().tightenLevel).toBe(4)
+    remaining = 0
+    // The fuse earned nothing itself, so it returns all the way to base — the
+    // persisted window pins the level while open and never mutates it.
+    expect(fuse.stats().tightenLevel).toBe(0)
+    expect(fuse.stats().perMessageCeiling).toBe(20)
+  })
+
+  it('FAILS OPEN: an unreadable marker must never gag the bot', async () => {
+    const clock = new FakeClock()
+    const fuse = createEditFloodFuse({
+      clock,
+      floodWaitRemainingMs: () => {
+        throw new Error('EACCES: flood-wait.json owned by another uid')
+      },
+      perChatSendMaxPerWindow: 25,
+    })
+    expect(fuse.stats().persistedFloodOpen).toBe(false)
+    expect(fuse.stats().tightenLevel).toBe(0)
+    let landed = 0
+    await fuse.apply('sendMessage', { chat_id: CHAT, text: 'the answer' }, async () => {
+      landed++
+      return true
+    })
+    expect(landed).toBe(1)
+  })
+
+  it('re-reads the marker at most once per floodProbeIntervalMs', async () => {
+    const clock = new FakeClock()
+    let reads = 0
+    const fuse = createEditFloodFuse({
+      clock, floodProbeIntervalMs: 1_000,
+      floodWaitRemainingMs: () => { reads++; return 0 },
+      perChatTotalMaxPerWindow: 1_000, perChatSendMaxPerWindow: 1_000,
+      perTokenMaxPerWindow: 1_000,
+    })
+    for (let i = 0; i < 50; i++) {
+      await fuse.apply('sendMessage', { chat_id: CHAT, text: 'x' }, async () => true)
+    }
+    // A file read on every admission would make the fuse the latency problem
+    // it exists to prevent.
+    expect(reads).toBeLessThanOrEqual(2)
+  })
+
+  it('reads the REAL breaker file that robustApiCall and the sweep use', async () => {
+    // Not a mock: write the actual on-disk marker and let the production probe
+    // read it, so the two halves cannot drift apart.
+    const dir = mkdtempSync(join(tmpdir(), 'fuse-flood-'))
+    try {
+      writeFileSync(
+        floodStatePath(dir),
+        JSON.stringify({ untilTs: Date.now() + 12_247_000, retryAfterSec: 12247, recordedTs: Date.now() }),
+        'utf-8',
+      )
+      const fuse = createEditFloodFuse({
+        floodWaitRemainingMs: makeFloodWaitProbe(floodStatePath(dir)),
+        maxTightenLevel: 4, tightenFactor: 0.5, perMessageMaxPerWindow: 20,
+      })
+      expect(fuse.stats().persistedFloodOpen).toBe(true)
+      expect(fuse.stats().perMessageCeiling).toBe(1)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('editFloodFuseConfigFromEnv wires the probe from TELEGRAM_STATE_DIR', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fuse-env-'))
+    try {
+      writeFileSync(
+        floodStatePath(dir),
+        JSON.stringify({ untilTs: Date.now() + 600_000, retryAfterSec: 600, recordedTs: Date.now() }),
+        'utf-8',
+      )
+      const cfg = editFloodFuseConfigFromEnv({ TELEGRAM_STATE_DIR: dir })
+      expect(cfg.floodWaitRemainingMs).toBeTypeOf('function')
+      expect(cfg.floodWaitRemainingMs!()).toBeGreaterThan(0)
+      // The wiring is what makes it durable in production — a fuse built from
+      // this config is tightened without anyone remembering to pass a probe.
+      expect(createEditFloodFuse(cfg).stats().persistedFloodOpen).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('is a no-op when TELEGRAM_STATE_DIR is unset (dev / one-shot contexts)', () => {
+    const cfg = editFloodFuseConfigFromEnv({})
+    expect(cfg.floodWaitRemainingMs).toBeUndefined()
+    expect(createEditFloodFuse(cfg).stats().persistedFloodOpen).toBe(false)
+  })
+})
+
+describe('severity scaling — a 4.4h ban is not one nudge\'s worth of signal', () => {
+  const mk = (clock: FakeClock) =>
+    createEditFloodFuse({
+      clock, maxTightenLevel: 4, tightenFactor: 0.5, tightenMs: 600_000,
+      perMessageMaxPerWindow: 32,
+    })
+
+  async function observe(fuse: ReturnType<typeof mk>, retryAfterSec: number): Promise<void> {
+    await expect(
+      fuse.apply('editMessageText', { chat_id: CHAT, message_id: 1 }, async () => {
+        throw flood(retryAfterSec)
+      }),
+    ).rejects.toThrow()
+  }
+
+  it.each([
+    [3, 1],      // routine burst nudge
+    [30, 2],     // sustained overrate
+    [120, 3],    // a real ban
+    [3713, 4],   // the 2026-07-25 incident — straight to maximum
+    [15908, 4],  // the 2026-07-27 incident
+  ])('retry_after=%is tightens by %i level(s)', async (retryAfterSec, expected) => {
+    const clock = new FakeClock()
+    const fuse = mk(clock)
+    await observe(fuse, retryAfterSec)
+    expect(fuse.stats().tightenLevel).toBe(expected)
+  })
+
+  it('the ban-magnitude case reaches the floor in ONE 429, not four', async () => {
+    // This is the assertion that fails on the pre-fix code: there, a single
+    // 15908s ban moved the ceiling from 32 to 16 and the stream carried on at
+    // half rate into a four-hour outage.
+    const clock = new FakeClock()
+    const fuse = mk(clock)
+    expect(fuse.stats().perMessageCeiling).toBe(32)
+    await observe(fuse, 15_908)
+    expect(fuse.stats().perMessageCeiling).toBe(2) // 32 * 0.5^4
+  })
+
+  it('holds the tightening for AT LEAST the ban\'s own duration', async () => {
+    // A flat 10-minute tightenMs expired ~25× over during the 4.4h ban.
+    const clock = new FakeClock()
+    const fuse = mk(clock)
+    await observe(fuse, 15_908)
+    await clock.advance(15_907_000) // one second before the ban lifts
+    expect(fuse.stats().tightenLevel).toBeGreaterThan(0)
+    expect(fuse.stats().perMessageCeiling).toBeLessThan(32)
+  })
+
+  it('a 3s nudge still decays on the normal 10-minute schedule', async () => {
+    const clock = new FakeClock()
+    const fuse = mk(clock)
+    await observe(fuse, 3)
+    expect(fuse.stats().tightenLevel).toBe(1)
+    // Held for tightenMs PLUS the stated penalty (3s) — still ~10 minutes.
+    await clock.advance(600_001)
+    expect(fuse.stats().tightenLevel).toBe(1)
+    await clock.advance(3_001)
+    expect(fuse.stats().tightenLevel).toBe(0)
+    expect(fuse.stats().perMessageCeiling).toBe(32)
+  })
+
+  it('recovers the magnitude from a 429 that arrives as a raw ApiResponse', async () => {
+    const clock = new FakeClock()
+    const fuse = mk(clock)
+    await fuse.apply('editMessageText', { chat_id: CHAT, message_id: 1 }, async () =>
+      ({ ok: false, error_code: 429, parameters: { retry_after: 15_908 } }))
+    expect(fuse.stats().tightenLevel).toBe(4)
+  })
+
+  it('recovers the magnitude from the message text when there is no parameters block', async () => {
+    const clock = new FakeClock()
+    const fuse = mk(clock)
+    await expect(
+      fuse.apply('editMessageText', { chat_id: CHAT, message_id: 1 }, async () => {
+        throw new Error('Too Many Requests: retry after 15908')
+      }),
+    ).rejects.toThrow()
+    expect(fuse.stats().tightenLevel).toBe(4)
+  })
+
+  it('an UNQUANTIFIED flood is treated as the mildest case, not the worst', async () => {
+    // Inflating an unmeasured signal into a maximal response would let one
+    // ambiguous error message throttle the bot to 1/window.
+    const clock = new FakeClock()
+    const fuse = mk(clock)
+    await expect(
+      fuse.apply('editMessageText', { chat_id: CHAT, message_id: 1 }, async () => {
+        throw new Error('Too Many Requests')
+      }),
+    ).rejects.toThrow()
+    expect(fuse.stats().tightenLevel).toBe(1)
+  })
+
+  it('still does NOT tighten on an ordinary error that merely contains "429"', async () => {
+    const clock = new FakeClock()
+    const fuse = mk(clock)
+    await expect(
+      fuse.apply('editMessageText', { chat_id: CHAT, message_id: 1 }, async () => {
+        throw new Error('Bad Request: message 429 not found')
+      }),
+    ).rejects.toThrow()
+    expect(fuse.stats().tightenLevel).toBe(0)
+    expect(fuse.stats().floodObserved).toBe(0)
+  })
+
+  it('the default probe interval is bounded', () => {
+    expect(EDIT_FLOOD_FUSE_DEFAULTS.floodProbeIntervalMs).toBeGreaterThan(0)
+    expect(EDIT_FLOOD_FUSE_DEFAULTS.floodProbeIntervalMs).toBeLessThanOrEqual(5_000)
+  })
+})

--- a/telegram-plugin/tests/feed-edit-rate-ceiling.test.ts
+++ b/telegram-plugin/tests/feed-edit-rate-ceiling.test.ts
@@ -351,7 +351,12 @@ describe('feed flood ban — a 429 reduces the subsequent feed edit rate', () =>
     }
     expect(fuse.stats().tightenLevel).toBe(3)
 
-    await clock.advance(60_001)
+    // #3856: the hold is now `max(tightenMs, retry_after * 1000 + tightenMs)`,
+    // so a stated `retry_after: 3` holds for 63s — the fuse must not begin
+    // decaying while Telegram's own stated cooldown is still running. The
+    // one-level-at-a-time decay this test guards is unchanged; only the FIRST
+    // hold is longer, by the stated 3s.
+    await clock.advance(63_001)
     expect(fuse.stats().tightenLevel).toBe(2)
     await clock.advance(60_001)
     expect(fuse.stats().tightenLevel).toBe(1)


### PR DESCRIPTION
Stacked on #3855 (same file). Closes the two remaining holes in the fuse's response to a 429.

## 1. The fuse's ban response did not survive a restart

`tightenLevel` and `tightenedUntil` were plain local variables inside `createEditFloodFuse`. So a gateway restart during a flood ban — the single most likely thing to happen during a multi-hour outage, and exactly what happened on 2026-07-27 — brought the fuse back **fully untightened**, at precisely the rate that earned the ban, while the window was still open on disk.

Every other outbound path in the tree already consults `flood-wait.json`. The fuse was the one that did not.

**Fix.** `levelAt(now)` consults the persisted window. While it is open the fuse reports `maxTightenLevel` regardless of what this process remembers.

Three properties that matter:

- **It is a floor, not a latch.** The persisted read does not mutate `tightenLevel`. When the window closes the fuse drops back to whatever this process actually earned, rather than staying pinned at maximum until a decay timer it never set expires.
- **It is throttled.** `levelAt` runs on every admission and the probe is a file read; unthrottled that would make the fuse the latency problem it exists to prevent. Re-read at most once per `floodProbeIntervalMs` (1000ms), with the cached value decayed by elapsed wall time so a window never *appears* to outlast itself.
- **It fails OPEN.** A throwing probe means untightened. `makeFloodWaitProbe` already fails open and warns loudly on an unreadable marker (#3106); the catch covers the rest. A breaker that cannot read its own state must never gag the bot.

**Wiring.** In `editFloodFuseConfigFromEnv` from `TELEGRAM_STATE_DIR`, not at the call site. Two reasons: no caller can forget it, and `gateway.ts` is under a zero-slack line ratchet — this PR does not touch that file at all.

## 2. `noteFlood()` threw away the severity

```ts
function noteFlood(now: number): void {
  tightenLevel = Math.min(maxTightenLevel, tightenLevel + 1)   // always ONE
  tightenedUntil = now + tightenMs                             // always 10 min
}
```

A 3-second "ease off" nudge and a **15908-second** ban produced the identical response. That defeats the point of AIMD, whose whole premise is that the decrease matches the signal.

Worse, the *hold* was flat: 10 minutes against a 4.4-hour ban means the tightening expired roughly **25 times over** while the ban was still in force. The fuse would have been back at full rate for hours.

**Fix.** The step scales with the `retry_after` Telegram itself states:

| stated `retry_after` | levels | rationale |
|---|---:|---|
| ≤ 5s | 1 | routine burst nudge |
| ≤ 60s | 2 | sustained overrate |
| ≤ 600s | 3 | a real ban |
| > 600s | **all the way to `maxTightenLevel`** | both real incidents (3713s on 07-25, 15908s on 07-27) are in this band. At this magnitude the rate that produced it is categorically wrong, and stepping down one level at a time spends the next window earning the next ban. |

The hold is now `tightenMs` **plus** the stated penalty, so it can never expire before the ban does.

`looksLikeFlood(): boolean` became `floodRetryAfterSec(): number | null`, which also recovers the magnitude from the message text (`retry after 15908`) when there is no `parameters` block. Deliberately conservative in both directions: an **unquantified** flood returns 0 and is treated as the *mildest* case (inflating an unmeasured signal into a maximal response would let one ambiguous error throttle the bot to 1/window), and the semantic-marker matching is unchanged, so `Bad Request: message 429 not found` still does not tighten anything.

## What the tests prove

`telegram-plugin/tests/edit-flood-fuse-ban-awareness.test.ts` — 20 tests, **12 of which fail against the pre-fix code** (verified by reverting just the two mechanisms and re-running):

**Restart durability**
- A brand-new fuse with zero in-memory history but a 12247s window on disk reports `tightenLevel: 4` and a `perMessageCeiling` of **1** instead of 20 — and then *binds*: 30 cosmetic edits offered, ≤2 reach the wire. Without the persisted read, 16 do.
- Closing the window returns the ceiling to base (floor, not latch).
- A throwing probe still lets a `sendMessage` through (fail-open).
- 50 admissions cause ≤2 file reads (throttle).
- **Not a mock**: one test writes a real `flood-wait.json` and reads it through the production `makeFloodWaitProbe`, so the two halves cannot drift apart.
- `editFloodFuseConfigFromEnv({ TELEGRAM_STATE_DIR })` produces a fuse that is tightened without anyone passing a probe; with the env unset it is a clean no-op.

**Severity scaling**
- Parameterised over 3s→1, 30s→2, 120s→3, **3713s→4**, **15908s→4**.
- One 15908s ban takes the ceiling 32 → **2** in a single 429. On pre-fix code it went 32 → 16 and the stream carried on at half rate into a four-hour outage.
- After a 15908s ban, the fuse is still tightened at t+15907s.
- A 3s nudge still decays on the normal ~10-minute schedule.
- Magnitude recovered from a raw `ApiResponse` and from message text.
- An unquantified flood tightens by 1, not 4.

54 tests pass across the three fuse suites. `tsc --noEmit` clean. `check-gateway-line-ratchet` clean at 24917 (untouched).

## Adversarial notes

- `levelAt` is called by `stats()`, which is now not quite free — it performs at most one throttled file read per second. No hot-path caller.
- `floodProbeIntervalMs: 0` is legal and means "read every time"; used by one test for determinism. In production the default is 1000ms.
- The persisted window pins the *level*, not the counters, so `stats().tightenLevel` can read 4 while `floodObserved` is 0. That is honest: this process observed no 429, it inherited a ban.
- Importing `flood-circuit-breaker.js` into `edit-flood-fuse.ts` introduces no cycle (the breaker does not import the fuse).
- The env wiring is skipped entirely when `TELEGRAM_STATE_DIR` is unset, so dev/one-shot contexts are unchanged rather than reading a path under `$HOME`.
