### PR TITLE
docs: make the official docs site the authority for vendored deps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,8 @@ scripts/                build.mjs + the lint guard scripts
 tests/                  vitest suite for src/;  tests/docker/ = docker e2e
 evals/                  Python eval harness (dataset.yaml + run_*.py)
 commands/               bundled slash commands (setup/start/status/stop)
-vendor/                 vendored upstream (hindsight-memory) — don't edit
+vendor/                 vendored upstream (hindsight-memory) — a snapshot,
+                        not the spec; read vendor/hindsight-memory/CLAUDE.md
 reference/              THE DESIGN CONTRACT (see below)
 docs/                   user/operator docs only — design lives in reference/
 ```
@@ -439,6 +440,36 @@ fragment. It binds work on THIS repo too — the five parts, condensed:
    `cron-session.sh` export `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS=15`
    (below the CLI's own default of 20). Change that export and the
    dev-protocol prose together.
+
+## Third-party docs — the official site is the spec
+
+Authority order for any third-party dependency, highest first:
+
+1. **The vendor's official documentation site.** Search it first, before
+   concluding anything about what that dependency does or doesn't support.
+2. **context7 when the library is indexed** — `resolve-library-id` then
+   `query-docs`; wired for every agent by default (`docs/configuration.md`).
+3. **The OSS repo and our `vendor/` copy, last.** A vendored tree is an
+   implementation snapshot at one commit, not the specification.
+
+For Hindsight, which we vendor and run:
+
+- Docs root <https://hindsight.vectorize.io/>. Memory curation lives at
+  `/developer/api/memories`; see also `/developer/api/retain`,
+  `/developer/api/recall`, `/developer/observations`,
+  `/developer/configuration`, and the index at `/api-reference`. There is no
+  `/developer/` index page (it 404s) — enter from the root.
+- context7: prefer `/websites/hindsight_vectorize_io` (the docs site) over
+  `/vectorize-io/hindsight` (the OSS repo).
+
+**"No config path exists" / "not supported" / "not possible" are positive
+claims that need a check, not inferences from a failed local grep.** A worker
+tuning hindsight recall/consolidation told the operator no documented config
+path existed, because the running container ships no `/app/docs` and `vendor/`
+had no such knob — while the docs site documented the sanctioned answer the
+whole time: `PATCH /v1/default/banks/{bank}/memories/{id}` with
+`state: "invalidated"` soft-retires a duplicate, `state: "valid"` restores it.
+Absence of local documentation is not evidence that no documentation exists.
 
 ## Docker test discipline (HARD RULES)
 

--- a/vendor/hindsight-memory/CLAUDE.md
+++ b/vendor/hindsight-memory/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md — vendor/hindsight-memory
+
+**This directory is a VENDORED SNAPSHOT of the hindsight-memory plugin. It is
+not the specification, and it is not what runs.** Treat it as evidence about
+one commit of the implementation, nothing more.
+
+The load-bearing copy of this rule is the repo-root `CLAUDE.md`
+("Third-party docs — the official site is the spec"); nothing auto-loads a
+subdirectory `CLAUDE.md`, so this file only reaches an agent that opens it.
+
+## Where the truth is
+
+1. **Official docs site** — <https://hindsight.vectorize.io/>. Curation and
+   the memory-unit endpoints: `/developer/api/memories`. Also
+   `/developer/api/retain`, `/developer/api/recall`,
+   `/developer/observations`, `/developer/configuration`, index at
+   `/api-reference`. (`/developer/` itself has no index page — it 404s.)
+2. **context7** — prefer `/websites/hindsight_vectorize_io` (the docs site)
+   over `/vectorize-io/hindsight` (the OSS repo).
+3. **This tree** — last, and only for "what does the code here actually do".
+
+Not finding something here is not evidence it doesn't exist. Search the docs
+before you tell anyone a knob, endpoint or config path is unsupported.
+
+## Trap: `settings.json` here is NOT what switchroom installs
+
+`installHindsightPlugin` (`src/agents/scaffold.ts`) copies this tree into each
+agent's `.claude/plugins/hindsight-memory/` and then **stamps switchroom's own
+overrides over `settings.json`** — additional banks, the retain cadence knobs,
+and the recall types. Concretely, this file has
+`"recallTypes": ["world", "experience"]` while switchroom writes
+`["world", "experience", "observation"]` (`scaffold.ts:3449` as of writing;
+line anchors drift — grep `settings.recallTypes`).
+
+So reading the vendored `settings.json` to learn live behaviour is actively
+misleading. Read the override site in `scaffold.ts`, or the deployed
+`~/.switchroom/agents/<name>/.claude/plugins/hindsight-memory/settings.json`.
+
+## Editing
+
+Don't hand-edit vendored upstream files without a reason (repo-root
+`CLAUDE.md` § Secrets & safety rails). This file and switchroom's local
+patches are the exceptions; changes here ship to every agent on the next
+`apply`/reconcile, and the Python under `scripts/` is gated by the required
+`python-ok` check (`python3 -m unittest discover` in `scripts`).


### PR DESCRIPTION
## Summary

- **Root `CLAUDE.md`** gains a `## Third-party docs — the official site is the spec` section: authority order (official docs site → context7 → OSS/vendored source), the concrete Hindsight URLs and context7 library ids, and the corollary that "not supported" / "no config path exists" / "not possible" are positive claims needing a check, not inferences from a failed local grep.
- **New `vendor/hindsight-memory/CLAUDE.md`** warns the tree is a vendored snapshot, not the specification, points at the docs site + context7 id, and flags the practical trap that its `settings.json` is NOT what switchroom installs.
- Repo-layout line for `vendor/` updated to point down at the new file (reconciles with the existing "don't edit vendor/" rail rather than adding a competing rule).

## Why

A worker investigating hindsight recall/consolidation tuning concluded "no documented config path exists" — because the running container ships no `/app/docs` tree and the vendored source had no such knob — and relayed that to the operator as fact. The official docs site documented the sanctioned answer for that exact problem the whole time: `PATCH /v1/default/banks/{bank}/memories/{id}` with `state: "invalidated"` soft-retires a duplicate, `state: "valid"` restores it. Absence of local documentation is not evidence that no documentation exists.

There was no existing docs-authority guidance to duplicate: `hindsight.vectorize.io` appeared in zero markdown files, and `context7` appeared only in `docs/configuration.md` (the MCP wiring description, not an authority rule).

## Test plan

- Every URL fetched before it was written: `/`, `/developer/api/memories`, `/developer/api/retain`, `/developer/api/recall`, `/developer/observations`, `/developer/configuration`, `/api-reference` all 200. `/developer/` itself **404s** — the section index does not exist, so the doc says to enter from the site root.
- The `PATCH … state: "invalidated"` claim read out of the fetched `/developer/api/memories` page, not from memory.
- context7 ids confirmed via `context7.com/api/v1/search?query=hindsight`: `/websites/hindsight_vectorize_io` (9495 snippets, trust 9.4) and `/vectorize-io/hindsight` (8697, 7.6).
- `settings.json` drift claim verified on `origin/main`: `vendor/hindsight-memory/settings.json:12` has `["world","experience"]`; `src/agents/scaffold.ts:3449` writes `["world","experience","observation"]`.
- Scoped `vitest run tests/setup/hindsight.test.ts tests/reconcile.skip-profile-templates.test.ts tests/memory.bank-missions.test.ts tests/cli.doctor.memory-health.test.ts` → **196 passed**.
- `npm run lint` → exit 0.

## Risk

Docs-only. The new vendor file is copied into each agent's `.claude/plugins/hindsight-memory/` by `installHindsightPlugin` like any other vendored file; `dirContentEquals` compares by content, so idempotent apply is unaffected. Deliberately **no `AGENTS.md` symlink** in `vendor/` — `copyDirRecursive` `statSync`s entries, so a symlink that ever shipped broken (npm pack / image COPY) would throw inside the scaffold path; the root's symlink convention is kept where it is safe (repo root only).

Job spec: `reference/jobs/` — agent development protocol, grounding clause ("never assert an unchecked fact").
