### PR TITLE
fix(errors): stop OpenRouter/OpenAI credit 402s leaking to end users

### DIFF
--- a/telegram-plugin/llm-error-present.ts
+++ b/telegram-plugin/llm-error-present.ts
@@ -34,6 +34,12 @@ import {
   parseResetTime,
 } from './model-unavailable.js'
 import { classify429Detail } from './throttle-tier.js'
+import {
+  PROVIDER_CREDIT_REGISTRY,
+  attributeProvider,
+  describeProviderCreditRemedy,
+  type ProviderCreditEntry,
+} from './provider-credit.js'
 import { classifyClaudeError } from './operator-events.js'
 import { stripRawErrorBytes, extractRequestId } from './raw-error-scrub.js'
 import { fmtLocalClock, tzAbbrev } from './shared/local-time.js'
@@ -48,10 +54,24 @@ export type LlmErrorKind =
   | 'quota_wall'
   | 'auth'
   | 'infra_misconfig'
+  /**
+   * A THIRD-PARTY model provider (OpenRouter / OpenAI / Perplexity) is out of
+   * credit. OPERATOR-actionable, never user-actionable — its `coreText` is a
+   * deliberately diagnosis-free one-liner and its recommendation names the
+   * vendor console, never `/auth`. Kept distinct from `quota_wall` (the
+   * Anthropic subscription window, which resets on a clock and is addressed by
+   * switching account slots); a vendor balance resets only when someone pays.
+   */
+  | 'provider_credit'
   | 'transient'
   | 'unknown'
 
-export type LlmErrorSource = 'anthropic' | 'litellm-local' | 'network'
+export type LlmErrorSource =
+  | 'anthropic'
+  | 'litellm-local'
+  /** A paid third-party model provider reached THROUGH the proxy (OpenRouter, OpenAI). */
+  | 'external-provider'
+  | 'network'
 
 export interface ParsedLlmError {
   kind: LlmErrorKind
@@ -65,6 +85,14 @@ export interface ParsedLlmError {
   model?: string
   /** Anthropic `request_id`, when present — the strongest dedup key. */
   requestId?: string
+  /**
+   * Registry id of the third-party provider the error was attributed to
+   * (`openrouter` / `openai` / `perplexity`), when `kind === 'provider_credit'`
+   * and the raw text named one. An ID only — never raw error text, never a
+   * credential — so the recommendation line can point at the right console
+   * without this struct ever carrying the raw string it was parsed from.
+   */
+  providerId?: string
   source: LlmErrorSource
   /** True when the harness is still retrying this error internally (mid-retry). */
   autoRetrying: boolean
@@ -96,7 +124,10 @@ const TRANSIENT_KINDS: ReadonlySet<LlmErrorKind> = new Set<LlmErrorKind>([
 
 /** The always-actionable kinds — NEVER silenced, even inside a collapse window. */
 export function isActionableKind(kind: LlmErrorKind): boolean {
-  return kind === 'auth' || kind === 'quota_wall'
+  // `provider_credit` joins the never-silenced set: an unpaid vendor balance
+  // does not clear on its own, so collapsing it inside a dedup window would
+  // hide the one signal that needs a human.
+  return kind === 'auth' || kind === 'quota_wall' || kind === 'provider_credit'
 }
 
 /**
@@ -118,6 +149,8 @@ export function parseLlmError(
     resetAt != null ? Math.max(0, resetAt.getTime() - Date.now()) : undefined
 
   const { kind, source } = classifyKindAndSource(text)
+  const providerId =
+    kind === 'provider_credit' ? (attributeProvider(text)?.id ?? undefined) : undefined
 
   // Retry / terminal semantics. Only the transient family can be mid-retry;
   // auth / quota_wall / model_unavailable are terminal by construction.
@@ -143,6 +176,7 @@ export function parseLlmError(
     ...(retryAfterMs != null ? { retryAfterMs } : {}),
     ...(model != null ? { model } : {}),
     ...(requestId != null ? { requestId } : {}),
+    ...(providerId != null ? { providerId } : {}),
     source,
     autoRetrying,
     terminal,
@@ -165,6 +199,15 @@ function classifyKindAndSource(text: string): { kind: LlmErrorKind; source: LlmE
 
   // 1. Auth — always terminal, always actionable.
   const claudeKind = classifyClaudeError({ message: text, type: text })
+  // 1b. THIRD-PARTY provider credit wall. Placed immediately after the auth
+  //     resolution and BEFORE isLitellmProxyLocal429 / detectModelUnavailable:
+  //     OpenAI reports an exhausted balance as HTTP 429 `insufficient_quota`,
+  //     and the 429 matchers below would otherwise swallow it as a transient
+  //     "retrying automatically" — the single most misleading thing to tell
+  //     someone whose provider has no money left.
+  if (claudeKind === 'provider-credit-exhausted') {
+    return { kind: 'provider_credit', source: 'external-provider' }
+  }
   if (claudeKind === 'proxy-misconfig') {
     return { kind: 'infra_misconfig', source: 'litellm-local' }
   }
@@ -216,6 +259,12 @@ function classifyKindAndSource(text: string): { kind: LlmErrorKind; source: LlmE
   return { kind: 'unknown', source: 'anthropic' }
 }
 
+/** Resolve a registry entry from a persisted `providerId`, or null. */
+function providerById(id: string | undefined): ProviderCreditEntry | null {
+  if (id == null) return null
+  return PROVIDER_CREDIT_REGISTRY.find(p => p.id === id) ?? null
+}
+
 function buildCoreText(kind: LlmErrorKind, source: LlmErrorSource): string {
   switch (kind) {
     case 'rate_limit':
@@ -230,6 +279,10 @@ function buildCoreText(kind: LlmErrorKind, source: LlmErrorSource): string {
       return 'Claude login needs re-authentication.'
     case 'infra_misconfig':
       return 'Local model-gateway auth misconfig (proxy fallback dropped the OAuth header).'
+    case 'provider_credit':
+      // Diagnosis-free by design — this string is the ceiling on what a
+      // non-operator may ever be told about a vendor billing wall.
+      return 'An upstream model provider is out of credit — the operator has been notified.'
     case 'transient':
       return source === 'network'
         ? "Couldn't reach Anthropic (network) — retrying automatically."
@@ -302,6 +355,10 @@ function buildRecommendation(parsed: ParsedLlmError, tz: string): string | undef
       // Operator-facing — NO re-auth wording (the login is fine). Points at the
       // real remedy: the local LiteLLM proxy fallback config.
       return '→ Fix the LiteLLM proxy fallback config (deployment missing OAuth passthrough).'
+    case 'provider_credit':
+      // Operator-facing. NO `/auth` wording: the credential is valid, the
+      // balance is empty, and rotating an Anthropic slot changes nothing.
+      return `→ ${describeProviderCreditRemedy(providerById(parsed.providerId))}`
     case 'quota_wall': {
       const reset = formatResetClock(parsed.resetAt, tz)
       return reset
@@ -377,6 +434,8 @@ function kindEmoji(kind: LlmErrorKind): string {
       return '🔑'
     case 'infra_misconfig':
       return '🛠️'
+    case 'provider_credit':
+      return '💳'
     case 'transient':
       return '🌐'
     case 'unknown':

--- a/telegram-plugin/model-unavailable.ts
+++ b/telegram-plugin/model-unavailable.ts
@@ -790,6 +790,14 @@ export function resolveModelUnavailableFromOperatorEvent(
   ev: OperatorEventLike,
 ): ModelUnavailableDetection | null {
   const detail = typeof ev.detail === 'string' ? ev.detail : ''
+  // A THIRD-PARTY provider credit wall is never "model unavailable" in the
+  // Anthropic sense. Returning a detection here would route the event into the
+  // `modelUnavailable` branch of emitGatewayOperatorEvent, which renders the
+  // "⚠️ Model unavailable" card AND — for a `quota_exhausted` detection —
+  // fires `fireFleetAutoFallback`, benching a perfectly healthy Anthropic
+  // account slot because OpenRouter ran out of money. Return null so the event
+  // takes the plain `renderOperatorEvent` path with its provider-specific card.
+  if (ev.kind === 'provider-credit-exhausted') return null
   if (ev.kind === 'quota-exhausted') {
     return detectModelUnavailable(detail) ?? { kind: 'quota_exhausted', raw: detail }
   }

--- a/telegram-plugin/operator-events.ts
+++ b/telegram-plugin/operator-events.ts
@@ -15,6 +15,11 @@
 import { escapeMarkdown } from './format.js'
 import { stripRawErrorBytes } from './raw-error-scrub.js'
 import { isLitellmProxyAuthMisconfig } from './model-unavailable.js'
+import {
+  attributeProvider,
+  describeProviderCreditRemedy,
+  detectProviderCreditExhaustion,
+} from './provider-credit.js'
 
 // ─── Taxonomy ────────────────────────────────────────────────────────────────
 
@@ -23,6 +28,16 @@ export type OperatorEventKind =
   | 'credentials-invalid'
   | 'proxy-misconfig'
   | 'credit-exhausted'
+  /**
+   * A THIRD-PARTY model provider (OpenRouter / OpenAI / Perplexity) reports no
+   * credit remaining — HTTP 402 `payment_required`, "insufficient credits",
+   * OpenAI's `insufficient_quota`, etc. Distinct from `credit-exhausted`,
+   * which is the ANTHROPIC balance and whose remedy is `/auth use <slot>`:
+   * rotating an Anthropic account slot buys zero OpenRouter tokens, so the two
+   * must not share a card. Operator-actionable (top up in the vendor console),
+   * never user-actionable — see {@link OPERATOR_ACTIONABLE_KINDS}.
+   */
+  | 'provider-credit-exhausted'
   | 'quota-exhausted'
   | 'rate-limited'
   | 'agent-crashed'
@@ -134,14 +149,36 @@ function classifyInner(raw: unknown): OperatorEventKind {
     return 'credentials-invalid'
   }
 
+  // The full scan surface for the provider-credit decision — same
+  // type/code/message union isLitellmProxyAuthMisconfig uses, because LiteLLM
+  // stamps the upstream vendor's wording in whichever field it has room for.
+  const creditScanText = `${errorType}\n${errorCode}\n${sdkCode}\n${message}`
+
+  // ANTHROPIC credit wall. Guarded with `attributeProvider(...) == null` so an
+  // OpenRouter/OpenAI/Perplexity error that happens to say "credit balance"
+  // does NOT get the Anthropic card, whose remedy (`/auth use <slot>`) is
+  // useless against a third-party balance. Unattributed credit-balance wording
+  // keeps its historical Anthropic reading — that is where it has always come
+  // from, and the alternative (guessing a vendor) sends the operator to the
+  // wrong console.
   if (
-    errorType === 'credit_balance_too_low' ||
-    errorCode === 'credit_balance_too_low' ||
-    sdkCode === 'credit_balance_too_low' ||
-    message.toLowerCase().includes('credit_balance_too_low') ||
-    message.toLowerCase().includes('credit balance')
+    (errorType === 'credit_balance_too_low' ||
+      errorCode === 'credit_balance_too_low' ||
+      sdkCode === 'credit_balance_too_low' ||
+      message.toLowerCase().includes('credit_balance_too_low') ||
+      message.toLowerCase().includes('credit balance')) &&
+    attributeProvider(creditScanText) == null
   ) {
     return 'credit-exhausted'
+  }
+
+  // THIRD-PARTY provider credit wall — the OpenRouter 402 leak (#external-credit).
+  // Runs BEFORE the rate-limit branch on purpose: OpenAI signals an exhausted
+  // balance as HTTP *429* `insufficient_quota`, so a rate-limit-first ordering
+  // would classify a billing wall as a transient throttle and tell the operator
+  // to wait for a reset that will never come.
+  if (detectProviderCreditExhaustion(creditScanText, status) != null) {
+    return 'provider-credit-exhausted'
   }
 
   if (
@@ -315,6 +352,31 @@ export function renderOperatorEvent(ev: OperatorEvent): RenderResult {
           ],
         },
       }
+
+    // A third-party provider's balance, NOT Anthropic's. Deliberately carries
+    // NO `/auth use` / `/auth add` language (those rotate Anthropic account
+    // slots and buy zero OpenRouter tokens) and NO "🔐 Reauth" button (the key
+    // is valid; it is out of money). The remedy names the provider, the VAULT
+    // KEY NAME — never a value — and the console to act in. Dismiss-only.
+    case 'provider-credit-exhausted': {
+      const provider = attributeProvider(ev.detail)
+      const who = provider != null ? escapeMarkdown(provider.label) : 'An upstream model provider'
+      return {
+        text: [
+          `💳 **${provider != null ? `${who} credit exhausted` : 'Upstream provider credit exhausted'}** — hit by **${agent}**.`,
+          detail ? `_${detail}_` : '',
+          describeProviderCreditRemedy(provider),
+          `Anthropic account slots are unaffected — \`/auth use\` will NOT fix this.`,
+        ]
+          .filter(Boolean)
+          .join('\n'),
+        keyboard: {
+          inline_keyboard: [
+            [{ text: '❌ Dismiss', callback_data: `op:dismiss:${encodeURIComponent(ev.agent)}` }],
+          ],
+        },
+      }
+    }
 
     case 'quota-exhausted':
       // Canonical quota-exhausted text (migrated from auto-fallback.ts).
@@ -544,6 +606,11 @@ export const OPERATOR_ACTIONABLE_KINDS: ReadonlySet<OperatorEventKind> = new Set
   'credentials-expired',
   'credentials-invalid',
   'credit-exhausted',
+  // The OpenRouter/OpenAI/Perplexity 402 class. Only the operator can top up a
+  // vendor balance; an end user shown "insufficient credits" can do nothing but
+  // lose confidence. This membership is what routes it to the operator card and
+  // hands the user the brief plain-language notice instead.
+  'provider-credit-exhausted',
   'proxy-misconfig',
 ])
 

--- a/telegram-plugin/provider-credit.ts
+++ b/telegram-plugin/provider-credit.ts
@@ -1,0 +1,237 @@
+/**
+ * provider-credit.ts — the ONE registry of "this paid third-party provider is
+ * out of credit / its billing is blocked" signals, plus the pure classifier
+ * both surfaces consult.
+ *
+ * WHY THIS EXISTS (the leak it closes)
+ * ------------------------------------
+ * Every quota/credit wording switchroom recognised was an ANTHROPIC wording
+ * (`model-unavailable.ts`'s `quotaSignals`, `operator-events.ts`'s
+ * `credit_balance_too_low` branch). OpenRouter — which serves the whole
+ * `gpt-oss-20b` group and every `openrouter/*` model in
+ * `docker/litellm-proxy/litellm-config.yaml` — answers an exhausted balance
+ * with HTTP 402 `payment_required` / "insufficient credits", which matched
+ * NONE of them. It fell through `classifyClaudeError` to `unknown-4xx`, and
+ * `unknown-4xx` is NOT in `OPERATOR_ACTIONABLE_KINDS`, so the card (with the
+ * raw provider error in a code span, and a "🔐 Reauth" button nobody can act
+ * on) was BROADCAST to every allowlist chat — an end user included.
+ *
+ * Ken's standing product rule: a raw API/auth error that is OPERATOR-actionable
+ * rather than USER-actionable must never reach an end user. So a provider
+ * credit wall must classify to an operator-only kind.
+ *
+ * WHAT THIS MODULE IS AND IS NOT
+ * ------------------------------
+ * It is DATA (`PROVIDER_CREDIT_REGISTRY` + `CREDIT_EXHAUSTION_SIGNALS`) plus
+ * two pure predicates over that data. It is deliberately NOT wired to the
+ * Anthropic quota path: `detectModelUnavailable`'s `quota_exhausted` kind is
+ * what fires `fireFleetAutoFallback` (swap the Anthropic ACCOUNT SLOT). An
+ * OpenRouter balance of $0 says nothing about any Anthropic account, and
+ * rotating Anthropic slots would not buy a single OpenRouter token — so
+ * teaching the Anthropic detector these wordings would fire a bogus fleet
+ * failover on every OpenRouter 402. See the explicit early-return for
+ * `provider-credit-exhausted` in `resolveModelUnavailableFromOperatorEvent`.
+ *
+ * PROVENANCE of each wording (verified against live vendor docs 2026-07-28):
+ *  - OpenRouter — https://openrouter.ai/docs/api-reference/errors:
+ *    "402: Your account or API key has insufficient credits. Add more credits
+ *    and retry the request." Typed error code `payment_required`. The limits
+ *    page (https://openrouter.ai/docs/api-reference/limits) documents the same
+ *    402 for both an exhausted ACCOUNT balance and an exhausted PER-KEY
+ *    `limit_remaining`.
+ *  - OpenAI — https://platform.openai.com/docs/guides/error-codes: 429 with
+ *    `code: "insufficient_quota"`, message "You exceeded your current quota,
+ *    please check your plan and billing details"; hard billing stop surfaces as
+ *    `billing_hard_limit_reached`. NOTE the status is 429, NOT 402 — which is
+ *    exactly why status alone is not a sufficient signal and the wording list
+ *    carries its own weight.
+ *  - Perplexity — https://docs.perplexity.ai/guides/usage-tiers: an exhausted
+ *    balance answers 401/403 with "insufficient credits"/"credit balance"; the
+ *    account is otherwise valid. Perplexity reaches switchroom through the MCP
+ *    tool surface, not through LiteLLM, so this registry is consumed there too
+ *    (`mcp-credential-failure.ts`) — one registry, both paths.
+ *
+ * Pure module: no IPC, no bot, no FS, no network. Trivially unit-testable.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface ProviderCreditEntry {
+  /** Stable id — also the `mcp_servers.<name>` key where one exists. */
+  id: string
+  /** Human display name for the operator card. */
+  label: string
+  /**
+   * The VAULT KEY NAME the operator must top up / re-issue. A NAME only —
+   * this module never sees, reads, or renders a secret VALUE.
+   */
+  vaultKey: string
+  /** Where the operator actually fixes it. */
+  consoleUrl: string
+  /** The one-line remedy sentence rendered on the operator card. */
+  action: string
+  /**
+   * Lowercase substrings that ATTRIBUTE an error to this provider. Matched
+   * against the raw error text. Deliberately specific (hostnames, route
+   * prefixes, SDK exception names) so a passing mention can't misattribute.
+   */
+  markers: string[]
+}
+
+/**
+ * The providers whose credit exhaustion switchroom can recognise. Adding a
+ * provider is a DATA edit here — never a new conditional at a call site.
+ */
+export const PROVIDER_CREDIT_REGISTRY: readonly ProviderCreditEntry[] = [
+  {
+    id: 'openrouter',
+    label: 'OpenRouter',
+    vaultKey: 'openrouter/api-key',
+    consoleUrl: 'https://openrouter.ai/credits',
+    action: 'Top up the OpenRouter balance (or raise the key’s credit limit) in the OpenRouter console.',
+    markers: ['openrouter', 'openrouter.ai'],
+  },
+  {
+    id: 'openai',
+    label: 'OpenAI',
+    vaultKey: 'openai/api-key',
+    consoleUrl: 'https://platform.openai.com/settings/organization/billing',
+    action: 'Add credit / raise the billing limit in the OpenAI console.',
+    markers: ['api.openai.com', 'openai.', 'openaiexception', 'openai_api'],
+  },
+  {
+    id: 'perplexity',
+    label: 'Perplexity',
+    vaultKey: 'perplexity/api-key',
+    consoleUrl: 'https://www.perplexity.ai/settings/api',
+    action: 'Top up the Perplexity API balance (or re-issue the key) in the Perplexity console.',
+    markers: ['perplexity', 'api.perplexity.ai', 'pplx'],
+  },
+]
+
+// ─── Credit-exhaustion wording ───────────────────────────────────────────────
+
+/**
+ * Provider-agnostic markers of a CREDIT/BILLING wall — "there is no money
+ * left", as distinct from "you are going too fast" (rate limit) or "your key
+ * is wrong" (auth).
+ *
+ * Every entry is a multi-word phrase or an explicit vendor error CODE. A bare
+ * `'402'` is deliberately ABSENT: a three-digit substring appears in model ids,
+ * token counts, request ids and timestamps, and matching it would misclassify
+ * unrelated errors as a billing wall. HTTP 402 is honoured only as a STRUCTURED
+ * status field — see {@link isProviderCreditStatus}.
+ */
+export const CREDIT_EXHAUSTION_SIGNALS: readonly string[] = [
+  // OpenRouter (402)
+  'payment_required',
+  'payment required',
+  'insufficient credits',
+  'insufficient_credits',
+  'more credits are required',
+  'requires more credits',
+  'add more credits',
+  'out of credits',
+  // OpenAI (429 insufficient_quota / hard billing stop)
+  'insufficient_quota',
+  'exceeded your current quota',
+  'billing_hard_limit_reached',
+  'billing hard limit',
+  // Cross-vendor balance wordings (Perplexity, Brevo, and the generic shape)
+  'insufficient balance',
+  'insufficient_balance',
+  'credit balance is too low',
+  'credit balance too low',
+  'credit_balance_too_low',
+  'no credits remaining',
+  'quota exceeded for credits',
+]
+
+/** HTTP statuses that, on their own, mean "billing". Only 402 qualifies. */
+export const CREDIT_EXHAUSTION_STATUSES: readonly number[] = [402]
+
+const MAX_SCAN_CHARS = 16_384
+
+function sample(text: unknown): string {
+  if (typeof text !== 'string' || text.length === 0) return ''
+  return (text.length > MAX_SCAN_CHARS ? text.slice(0, MAX_SCAN_CHARS) : text).toLowerCase()
+}
+
+/**
+ * True when `status` is a structured HTTP status that means "out of credit".
+ * Structured only — never inferred from a substring (see the note on
+ * {@link CREDIT_EXHAUSTION_SIGNALS}).
+ */
+export function isProviderCreditStatus(status: unknown): boolean {
+  return typeof status === 'number' && CREDIT_EXHAUSTION_STATUSES.includes(status)
+}
+
+/** True when `text` carries an explicit credit/billing-exhaustion wording. */
+export function hasCreditExhaustionWording(text: unknown): boolean {
+  const lower = sample(text)
+  if (lower.length === 0) return false
+  return CREDIT_EXHAUSTION_SIGNALS.some(s => lower.includes(s))
+}
+
+/**
+ * Attribute an error string to a registered provider, or `null` when nothing
+ * in the text names one. `null` is a legitimate, honest outcome: the card then
+ * says "an upstream model provider" rather than guessing a vendor (and a wrong
+ * vendor name would send the operator to the wrong console).
+ */
+export function attributeProvider(text: unknown): ProviderCreditEntry | null {
+  const lower = sample(text)
+  if (lower.length === 0) return null
+  for (const entry of PROVIDER_CREDIT_REGISTRY) {
+    if (entry.markers.some(m => lower.includes(m))) return entry
+  }
+  return null
+}
+
+export interface ProviderCreditDetection {
+  /** The registry entry, when the text named a known provider. */
+  provider: ProviderCreditEntry | null
+  /** Which evidence fired — useful in logs and in the test assertions. */
+  via: 'status' | 'wording'
+}
+
+/**
+ * The single decision: is this error a THIRD-PARTY PROVIDER credit/billing
+ * wall? Returns `null` when it is not — callers then fall through to their
+ * existing classification unchanged.
+ *
+ * `status` is the structured HTTP status when the caller has one (an SDK throw,
+ * a LiteLLM error body with `"status": 402`). Omit it and the decision rests on
+ * wording alone.
+ *
+ * ANTHROPIC IS DELIBERATELY EXCLUDED. `credit_balance_too_low` is in the
+ * wording list because it is a genuine cross-vendor balance phrase, but an
+ * Anthropic-attributed credit wall already has its own `credit-exhausted` kind
+ * with slot-switch advice (`/auth use`). Callers keep that branch FIRST; this
+ * one only catches what that branch does not. See `classifyClaudeError`.
+ */
+export function detectProviderCreditExhaustion(
+  text: unknown,
+  status?: unknown,
+): ProviderCreditDetection | null {
+  if (isProviderCreditStatus(status)) {
+    return { provider: attributeProvider(text), via: 'status' }
+  }
+  if (hasCreditExhaustionWording(text)) {
+    return { provider: attributeProvider(text), via: 'wording' }
+  }
+  return null
+}
+
+/**
+ * The operator-facing remedy line for a detection. Names the provider, the
+ * VAULT KEY NAME (never a value) and the console to act in. Used by both the
+ * operator-event card and the MCP credential alert so the two speak with one
+ * voice.
+ */
+export function describeProviderCreditRemedy(provider: ProviderCreditEntry | null): string {
+  if (provider == null) {
+    return 'An upstream model provider reports no credit remaining. Check the provider console for the key the LiteLLM proxy uses.'
+  }
+  return `${provider.action} Vault key: \`${provider.vaultKey}\` → ${provider.consoleUrl}`
+}

--- a/telegram-plugin/tests/provider-credit-402.test.ts
+++ b/telegram-plugin/tests/provider-credit-402.test.ts
@@ -1,0 +1,243 @@
+/**
+ * provider-credit-402.test.ts — outcome tests for the OpenRouter/OpenAI/
+ * Perplexity credit-error leak.
+ *
+ * THE BUG (audited 2026-07-28). OpenRouter answers an exhausted balance with
+ * HTTP 402 `payment_required` / "insufficient credits". None of switchroom's
+ * quota/credit wordings matched it — every one of them was an ANTHROPIC
+ * wording — so `classifyClaudeError` fell through to `unknown-4xx`.
+ * `unknown-4xx` is NOT in `OPERATOR_ACTIONABLE_KINDS`, so
+ * `decideOperatorEventAudience` broadcast it to EVERY allowlist chat: an end
+ * user got a card carrying the raw vendor error in a code span and a "🔐
+ * Reauth" button they cannot act on. That violates Ken's standing rule that an
+ * operator-actionable error must never reach an end user.
+ *
+ * These assert the OBSERVABLE RESULT, composing the SAME production functions
+ * in the SAME order `emitGatewayOperatorEvent` (gateway.ts ~:8134-8290) calls
+ * them — classify → resolveModelUnavailableFromOperatorEvent → render →
+ * decideOperatorEventAudience → renderUserFacingFailureNotice — so a
+ * regression anywhere along that chain fails here:
+ *
+ *   1. a real OpenRouter 402 body produces an OPERATOR card, and
+ *   2. the text a non-operator user sees is the brief plain-language notice,
+ *      carrying NO raw error text, NO vendor name, NO status code.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  classifyClaudeError,
+  renderOperatorEvent,
+  decideOperatorEventAudience,
+  isOperatorActionableKind,
+  renderUserFacingFailureNotice,
+  type OperatorEvent,
+} from '../operator-events.js'
+import { resolveModelUnavailableFromOperatorEvent } from '../model-unavailable.js'
+import { parseLlmError, isActionableKind } from '../llm-error-present.js'
+import { attributeProvider, detectProviderCreditExhaustion } from '../provider-credit.js'
+
+// ── Verbatim vendor shapes (docs verified 2026-07-28) ───────────────────────
+
+/**
+ * OpenRouter through LiteLLM. Wording per
+ * https://openrouter.ai/docs/api-reference/errors — 402, typed code
+ * `payment_required`, "insufficient credits. Add more credits and retry".
+ */
+const OPENROUTER_402 =
+  'litellm.APIError: OpenrouterException - {"error":{"code":402,"message":"Your account or API key has insufficient credits. Add more credits and retry the request.","metadata":{"provider_name":"openrouter"}}}'
+
+/** The per-key variant: the ACCOUNT has money, the key's `limit_remaining` is spent. */
+const OPENROUTER_402_PER_KEY =
+  'openrouter.ai returned 402: This request requires more credits, or fewer max_tokens.'
+
+/**
+ * OpenAI's exhausted balance. NOTE the status is 429, not 402
+ * (https://platform.openai.com/docs/guides/error-codes) — the case that makes
+ * "just match 402" insufficient.
+ */
+const OPENAI_INSUFFICIENT_QUOTA =
+  'litellm.RateLimitError: OpenAIException - {"error":{"message":"You exceeded your current quota, please check your plan and billing details.","type":"insufficient_quota","code":"insufficient_quota"}} (api.openai.com)'
+
+/** A genuine ANTHROPIC credit wall — must keep its own kind and its own card. */
+const ANTHROPIC_CREDIT =
+  '{"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Claude API."}}'
+
+/** An ordinary transient 429 — must NOT be dragged into the credit class. */
+const PLAIN_RATE_LIMIT =
+  '{"type":"error","error":{"type":"rate_limit_error","message":"Number of requests has exceeded your rate limit"}}'
+
+const ALLOW = ['5000000001' /* operator */, '5000000002' /* end user */, '5000000003']
+
+function makeEvent(detail: string): OperatorEvent {
+  const kind = classifyClaudeError({ message: detail, type: detail })
+  return {
+    kind,
+    agent: 'klanker',
+    detail,
+    suggestedActions: [],
+    firstSeenAt: new Date('2026-07-28T10:00:00Z'),
+  }
+}
+
+/**
+ * The gateway's observable outcome for one error string: what the OPERATOR
+ * sees and what a NON-OPERATOR user sees. Composed from the same production
+ * functions, in the gateway's order (gateway.ts ~:8134-8290).
+ */
+function route(detail: string): {
+  kind: string
+  firedFleetFailover: boolean
+  operatorText: string | null
+  operatorChats: string[]
+  userText: string | null
+  userChats: string[]
+} {
+  const ev = makeEvent(detail)
+  // The gateway renders the "⚠️ Model unavailable" card AND fires
+  // fireFleetAutoFallback iff this resolves to a quota_exhausted detection.
+  const mu = resolveModelUnavailableFromOperatorEvent(ev)
+  const firedFleetFailover = mu?.kind === 'quota_exhausted'
+  const { operatorChats, userNoticeChats } = decideOperatorEventAudience(
+    ev.kind,
+    ALLOW,
+    ALLOW[0],
+  )
+  return {
+    kind: ev.kind,
+    firedFleetFailover,
+    operatorText: operatorChats.length > 0 ? renderOperatorEvent(ev).text : null,
+    operatorChats,
+    userText: userNoticeChats.length > 0 ? renderUserFacingFailureNotice() : null,
+    userChats: userNoticeChats,
+  }
+}
+
+describe('OpenRouter 402 — the end-user leak is closed', () => {
+  it('produces an OPERATOR card and gives the user only the brief notice', () => {
+    const r = route(OPENROUTER_402)
+
+    // 1. Classified as the operator-only provider-credit kind.
+    expect(r.kind).toBe('provider-credit-exhausted')
+    expect(isOperatorActionableKind('provider-credit-exhausted')).toBe(true)
+
+    // 2. The full card goes to the OPERATOR ONLY.
+    expect(r.operatorChats).toEqual(['5000000001'])
+    expect(r.userChats).toEqual(['5000000002', '5000000003'])
+
+    // 3. The operator card is actionable and provider-correct.
+    expect(r.operatorText).toContain('OpenRouter')
+    expect(r.operatorText).toContain('openrouter/api-key') // vault key NAME
+    expect(r.operatorText).toContain('https://openrouter.ai/credits')
+
+    // 4. THE LEAK ASSERTION: nothing an end user receives carries the raw
+    //    vendor error, the vendor name, or the status code.
+    expect(r.userText).toBe(renderUserFacingFailureNotice())
+    for (const fragment of [
+      'insufficient credits',
+      'OpenRouter',
+      'openrouter',
+      '402',
+      'payment_required',
+      'litellm',
+      'api key',
+    ]) {
+      expect(r.userText!.toLowerCase()).not.toContain(fragment.toLowerCase())
+    }
+  })
+
+  it('never advertises an Anthropic remedy — /auth cannot buy OpenRouter credit', () => {
+    const { operatorText } = route(OPENROUTER_402)
+    // The `credit-exhausted` (Anthropic) card's recommendation sentence must
+    // not appear — the card may only NAME `/auth use` to rule it OUT.
+    expect(operatorText).not.toContain('Use `/auth use <label>`')
+    expect(operatorText).not.toContain('/auth add')
+    expect(operatorText).toContain('`/auth use` will NOT fix this')
+    // and no re-auth button: the key is valid, it is out of money
+    const rendered = renderOperatorEvent(makeEvent(OPENROUTER_402))
+    const buttons = rendered.keyboard.inline_keyboard.flat().map(b => b.text)
+    expect(buttons).toEqual(['❌ Dismiss'])
+    expect(JSON.stringify(rendered.keyboard)).not.toContain('reauth')
+  })
+
+  it('does NOT fire an Anthropic fleet failover (nothing about Anthropic is exhausted)', () => {
+    expect(route(OPENROUTER_402).firedFleetFailover).toBe(false)
+    expect(route(OPENROUTER_402_PER_KEY).firedFleetFailover).toBe(false)
+  })
+
+  it('covers the per-key credit-limit variant, not just a zero account balance', () => {
+    const r = route(OPENROUTER_402_PER_KEY)
+    expect(r.kind).toBe('provider-credit-exhausted')
+    expect(r.userChats.length).toBe(2)
+    expect(r.userText).toBe(renderUserFacingFailureNotice())
+  })
+})
+
+describe('OpenAI + Perplexity have the same gap and are covered', () => {
+  it('OpenAI insufficient_quota (HTTP 429!) is a credit wall, not a transient throttle', () => {
+    const r = route(OPENAI_INSUFFICIENT_QUOTA)
+    expect(r.kind).toBe('provider-credit-exhausted')
+    expect(r.operatorText).toContain('OpenAI')
+    expect(r.operatorText).toContain('openai/api-key')
+    // The bug this guards: 429 wording routing to "Rate limited … will retry
+    // automatically", which is false — nothing retries a spent balance.
+    expect(r.operatorText).not.toContain('Will retry automatically')
+    expect(r.userChats.length).toBe(2)
+  })
+
+  it('attributes a Perplexity balance error to the Perplexity console + key name', () => {
+    const entry = attributeProvider('api.perplexity.ai responded 401: insufficient credits')
+    expect(entry?.id).toBe('perplexity')
+    expect(entry?.vaultKey).toBe('perplexity/api-key')
+    expect(detectProviderCreditExhaustion('api.perplexity.ai: insufficient credits')).not.toBeNull()
+  })
+})
+
+describe('no collateral damage to the Anthropic paths', () => {
+  it('an Anthropic credit-balance wall keeps its own kind and its slot-switch remedy', () => {
+    const r = route(ANTHROPIC_CREDIT)
+    expect(r.kind).toBe('credit-exhausted')
+    expect(r.operatorText).toContain('/auth use')
+  })
+
+  it('an ordinary rate limit is untouched — still broadcast, still transient', () => {
+    const r = route(PLAIN_RATE_LIMIT)
+    expect(r.kind).toBe('rate-limited')
+    expect(r.operatorChats).toEqual(ALLOW)
+    expect(r.userChats).toEqual([])
+  })
+
+  it('a bare "402" substring in unrelated text is NOT a credit wall', () => {
+    // model ids, token counts and request ids routinely contain "402".
+    expect(detectProviderCreditExhaustion('model=gpt-402-turbo request_id=req_402x')).toBeNull()
+    expect(classifyClaudeError({ message: 'timeout after 402 ms', type: '' })).not.toBe(
+      'provider-credit-exhausted',
+    )
+  })
+
+  it('a structured HTTP 402 status is honoured even with no recognisable wording', () => {
+    expect(classifyClaudeError({ message: 'upstream refused', status: 402 })).toBe(
+      'provider-credit-exhausted',
+    )
+  })
+})
+
+describe('the user-facing LLM error surface', () => {
+  it('renders a diagnosis-free one-liner, never the raw 402 body', () => {
+    const parsed = parseLlmError(OPENROUTER_402)
+    expect(parsed.kind).toBe('provider_credit')
+    expect(parsed.providerId).toBe('openrouter')
+    expect(parsed.coreText).toBe(
+      'An upstream model provider is out of credit — the operator has been notified.',
+    )
+    expect(parsed.coreText).not.toContain('402')
+    expect(parsed.coreText).not.toContain('insufficient credits')
+    // Never claim a retry will fix it — a spent balance does not self-heal.
+    expect(parsed.coreText).not.toContain('retrying automatically')
+    expect(parsed.terminal).toBe(true)
+    expect(parsed.autoRetrying).toBe(false)
+  })
+
+  it('is always-actionable, so a dedup window can never silence it', () => {
+    expect(isActionableKind('provider_credit')).toBe(true)
+  })
+})


### PR DESCRIPTION
## The bug

OpenRouter answers an exhausted balance with **HTTP 402 `payment_required` / "insufficient credits"** (verified against [openrouter.ai/docs/api-reference/errors](https://openrouter.ai/docs/api-reference/errors), 2026-07-28). Every quota/credit wording switchroom recognised was an **Anthropic** wording (`model-unavailable.ts` `quotaSignals`, `operator-events.ts` `credit_balance_too_low`), so `classifyClaudeError` fell through to `unknown-4xx`.

`unknown-4xx` is **not** in `OPERATOR_ACTIONABLE_KINDS`, so `decideOperatorEventAudience` broadcast the card to *every* allowlist chat. An end user got:

> ⚠️ **API error (4xx)** for **klanker**
> `litellm.APIError: OpenrouterException - {"error":{"code":402,"message":"Your account or API key has insufficient credits…`
> [🔐 Reauth] [❌ Dismiss]

Raw vendor error, and a button they cannot act on. This breaks Ken's standing rule: an operator-actionable error must never reach an end user.

## What changes

- **New pure module `telegram-plugin/provider-credit.ts`** — the one data registry of paid third-party providers (OpenRouter / OpenAI / Perplexity: id, label, **vault key NAME**, console URL, remedy, attribution markers), the provider-agnostic credit-wording list, and `detectProviderCreditExhaustion`. Adding a provider is a data edit, not a new conditional.
- **New operator-event kind `provider-credit-exhausted`**, added to `OPERATOR_ACTIONABLE_KINDS`, with its own card: names the provider, the vault key **name** (never a value), the console. No `/auth` recommendation, no Reauth button — rotating an Anthropic slot buys zero OpenRouter tokens.
- **OpenAI covered too.** It reports an exhausted balance as HTTP **429** `insufficient_quota`, so the new branch runs *before* the rate-limit branch; otherwise a billing wall reads as "will retry automatically", which is false.
- **Perplexity** is in the registry. It reaches switchroom via MCP, not LiteLLM — the MCP consumer lands in a follow-up PR that builds on this registry.
- `resolveModelUnavailableFromOperatorEvent` returns `null` for the new kind, so a 402 can never fire `fireFleetAutoFallback` and bench a healthy Anthropic slot.
- `llm-error-present.ts` gains `provider_credit`: a diagnosis-free user-facing one-liner, always-actionable (never dedup-silenced).

## Deliberately not done

The new wordings are kept **out** of `detectModelUnavailable`'s `quotaSignals`. That list is what triggers Anthropic account-slot failover — teaching it OpenRouter wording would fire a bogus fleet failover on every 402.

A bare `'402'` substring is **not** a signal (model ids, token counts, request ids contain it). HTTP 402 is honoured only as a structured status field.

## Tests

`telegram-plugin/tests/provider-credit-402.test.ts` composes the same production functions in the same order `emitGatewayOperatorEvent` (gateway.ts ~:8134-8290) calls them, and asserts the **observable outcome**: an operator card is produced, and the text a non-operator receives is the brief plain-language notice — no vendor name, no status code, no raw error.

**Mutation results** — 6 deliberate breaks, each turned the suite red, all reverted:

| mutation | tests failed |
|---|---|
| drop `provider-credit-exhausted` from `OPERATOR_ACTIONABLE_KINDS` | 3 |
| disable the classifier branch (pre-fix `unknown-4xx`) | 6 |
| let it re-fire the Anthropic fleet failover | 1 |
| leak the raw detail into the user notice | 1 |
| re-add the bare `'402'` signal (false-positive guard) | 1 |
| relay raw text as `coreText` | 1 |

Scoped tests + full `npm run lint` green locally; `check-test-runner-coverage` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)