### PR TITLE
feat(alerts): hard operator warning when a paid MCP dependency's key is blocked

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -404,6 +404,7 @@ import {
   type OperatorEvent,
   type OperatorEventKind,
 } from '../operator-events.js'
+import { createMcpFailureHook } from './mcp-failure-hook.js'
 import { pendingUserNoticeGate } from '../pending-user-notice.js'
 import { recordOperatorEvent } from '../operator-events-history.js'
 import {
@@ -14007,7 +14008,13 @@ function surfaceConsolidationLegibility(
   })
 }
 
+/** Blocked-paid-dependency alerting — policy in `mcp-credential-failure.ts`,
+ *  seam in `gateway/mcp-failure-hook.ts`. Tees the SAME
+ *  `emitGatewayOperatorEvent` path so there is ONE operator-alert mechanism. */
+const noteMcpDependencyFailure = createMcpFailureHook({ agent: AGENT_NAME, emit: emitGatewayOperatorEvent })
+
 function handleSessionEvent(ev: SessionEvent): void {
+  noteMcpDependencyFailure(ev)
   handleSessionEventCore(gatewayStreamRenderDeps(), ev)
 }
 

--- a/telegram-plugin/gateway/mcp-failure-hook.ts
+++ b/telegram-plugin/gateway/mcp-failure-hook.ts
@@ -1,0 +1,74 @@
+/**
+ * mcp-failure-hook.ts — the gateway-side wiring that turns a blocked PAID MCP
+ * DEPENDENCY into an operator alert.
+ *
+ * Ken: "If perplexity fails for any agent we should have hard warning via
+ * message here per other failures."
+ *
+ * MCP providers (Perplexity, Eraser, Brevo, Postiz, Meta/Google Ads,
+ * Cloudflare) never touch LiteLLM, so the operator-event path that catches an
+ * OpenRouter 402 never sees them — an expired Perplexity key would otherwise
+ * die as a transient red step in the live feed and nobody would learn the fleet
+ * had lost a paid capability.
+ *
+ * This tees the SAME `emitGatewayOperatorEvent` path (redact → per-kind
+ * cooldown → operator-only audience via `OPERATOR_ACTIONABLE_KINDS` → brief
+ * user notice), so there is ONE operator-alert mechanism in switchroom, not
+ * two. All the policy — what counts as a key problem, what stays silent, the
+ * 6-hour re-notify cadence — lives in `../mcp-credential-failure.ts`; this file
+ * is only the seam.
+ *
+ * Extracted from `gateway.ts` rather than inlined there, per the
+ * switchroom#2996 anti-inflation ratchet (`scripts/check-gateway-line-ratchet.mjs`).
+ */
+
+import type { SessionEvent } from '../session-tail.js'
+import type { OperatorEvent } from '../operator-events.js'
+import { McpFailureWatcher, renderMcpFailureDetail } from '../mcp-credential-failure.js'
+
+export interface McpFailureHookDeps {
+  agent: string
+  emit: (event: OperatorEvent) => void
+  now?: () => number
+}
+
+/**
+ * Build the `handleSessionEvent` side-hook. One watcher per gateway process,
+ * captured in the closure.
+ *
+ * Silent by default: only a credit/credential/quota class raises anything, and
+ * only once per (server, class) per re-notify window. A bad query, a 404, a
+ * timeout, a transient 429 or a successful call all return without emitting.
+ *
+ * Never throws — alerting is a side channel and must not break the live feed.
+ */
+export function createMcpFailureHook(deps: McpFailureHookDeps): (ev: SessionEvent) => void {
+  const watcher = new McpFailureWatcher()
+  const clock = deps.now ?? (() => Date.now())
+  return function noteMcpDependencyFailure(ev: SessionEvent): void {
+    try {
+      if (ev.kind === 'tool_use') {
+        watcher.onToolUse(ev.toolUseId, ev.toolName)
+        return
+      }
+      if (ev.kind !== 'tool_result') return
+      const alert = watcher.onToolResult({
+        toolUseId: ev.toolUseId,
+        isError: ev.isError,
+        errorText: ev.errorText,
+        agent: deps.agent,
+        now: clock(),
+      })
+      if (alert == null) return
+      deps.emit({
+        kind: 'mcp-dependency-blocked',
+        agent: deps.agent,
+        detail: renderMcpFailureDetail(alert),
+        suggestedActions: [],
+        firstSeenAt: new Date(clock()),
+      })
+    } catch {
+      // Side channel — never let alerting break the live feed.
+    }
+  }
+}

--- a/telegram-plugin/mcp-credential-failure.ts
+++ b/telegram-plugin/mcp-credential-failure.ts
@@ -1,0 +1,459 @@
+/**
+ * mcp-credential-failure.ts — "a paid MCP dependency is blocked" detection.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Ken: "If perplexity fails for any agent we should have hard warning via
+ * message here per other failures."
+ *
+ * Perplexity (and Eraser, Brevo, Meta Ads, Postiz, Google Ads …) reach
+ * switchroom over the MCP TOOL surface, not through LiteLLM. So the operator-
+ * event path that PR A fixed for an OpenRouter 402 never sees them: an expired
+ * Perplexity key surfaces as an ordinary `is_error` tool_result, gets rendered
+ * as a transient step in the live feed, and dies there. Nobody is told the
+ * fleet just lost a paid capability.
+ *
+ * This module is the classifier + ledger for that. It is deliberately GENERIC:
+ * Perplexity is one row in `PROVIDER_CREDIT_REGISTRY` / `MCP_SERVER_VAULT_KEYS`,
+ * not a special case, so every current and future MCP server gets the same
+ * treatment by adding DATA, never a new conditional at a call site.
+ *
+ * THE CLASSIFICATION RULE (stated explicitly, because it decides whether Ken's
+ * phone buzzes — and an alert he learns to ignore is worse than no alert):
+ *
+ *   ALERT — the key itself is the problem, and only Ken can fix it:
+ *     • credit    — out of money   (402, "insufficient credits", "payment_required")
+ *     • credential— key rejected   (401/403, "invalid api key", "unauthorized",
+ *                                   "key has been disabled/revoked/blocked")
+ *     • quota     — hard usage wall("quota exceeded", "usage limit reached",
+ *                                   "monthly limit", "plan limit", "over
+ *                                   quota") — i.e. spent for the period
+ *
+ *   SILENT — ordinary operational failure, retrying or rewording fixes it:
+ *     • a bare rate limit / 429 with a retry-after (throttle, not a wall)
+ *     • 404, 400, validation errors, a bad query, no results
+ *     • timeouts, ECONNRESET, 5xx, transport errors
+ *
+ * The 429 split is the subtle one and is intentional: a throttle self-heals in
+ * seconds and must NOT page the operator; a `quota exceeded`/`usage limit`
+ * wording on the same status means the period's allowance is gone and only a
+ * plan change or a top-up clears it. Status alone is never sufficient — see the
+ * OpenAI case in `provider-credit.ts` (a spent balance arrives as 429).
+ *
+ * DEDUPLICATION — and its HONEST LIMIT
+ * ------------------------------------
+ * The ledger coalesces per `(server, class)` and re-notifies on the house
+ * cadence (`RENOTIFY_MS`, 6 h — the same interval `src/hindsight-watch` uses,
+ * so operator alerts across switchroom share one rhythm). Repeated failures
+ * inside the window are ACCUMULATED, not dropped: the next alert names every
+ * agent seen since the last one.
+ *
+ * The limit: this ledger is IN-PROCESS and therefore AGENT-LOCAL. Each agent
+ * runs its own `switchroom-<agent>` container with its own gateway process and
+ * no shared writable mount (`~/.switchroom/fleet` is read-only; per-agent state
+ * dirs are 0700 under distinct UIDs). So if six agents hit a blocked Perplexity
+ * key in the same minute, Ken gets up to six alerts — one per agent, each
+ * naming its agent — not one coalesced alert, and not thirty-six. Honouring
+ * "one alert naming the affected agents" fleet-wide needs a shared ledger the
+ * gateway does not have; that is filed as a follow-up rather than faked here.
+ *
+ * Pure module: no IPC, no bot, no FS, no network, no ambient clock (`now` is a
+ * parameter). Trivially unit-testable.
+ */
+
+import {
+  PROVIDER_CREDIT_REGISTRY,
+  hasCreditExhaustionWording,
+  isProviderCreditStatus,
+  type ProviderCreditEntry,
+} from './provider-credit.js'
+
+// ─── Server identity ─────────────────────────────────────────────────────────
+
+/**
+ * Vault key names for paid MCP servers that are NOT in the credit registry
+ * (the registry only covers providers that also serve inference). A NAME only —
+ * this module never reads or renders a secret VALUE.
+ *
+ * Adding a paid dependency is a DATA edit here.
+ */
+export const MCP_SERVER_VAULT_KEYS: Readonly<Record<string, { label: string; vaultKey: string; consoleUrl: string }>> = {
+  eraser: { label: 'Eraser', vaultKey: 'eraser/api-key', consoleUrl: 'https://app.eraser.io/settings/api' },
+  brevo: { label: 'Brevo', vaultKey: 'brevo/api-key', consoleUrl: 'https://app.brevo.com/settings/keys/api' },
+  postiz: { label: 'Postiz', vaultKey: 'postiz/api-key', consoleUrl: 'https://platform.postiz.com/settings' },
+  'meta-ads': { label: 'Meta Ads', vaultKey: 'meta-ads/access-token', consoleUrl: 'https://business.facebook.com/settings' },
+  'google-ads': { label: 'Google Ads', vaultKey: 'google-ads/developer-token', consoleUrl: 'https://ads.google.com/aw/apicenter' },
+  cloudflare: { label: 'Cloudflare', vaultKey: 'cloudflare/api-token', consoleUrl: 'https://dash.cloudflare.com/profile/api-tokens' },
+  context7: { label: 'Context7', vaultKey: 'context7/api-key', consoleUrl: 'https://context7.com/dashboard' },
+}
+
+/**
+ * `mcp__perplexity__perplexity_search` → `perplexity`. Returns `null` for a
+ * non-MCP tool (Bash, Read, …) — those are never a credential problem, so the
+ * caller short-circuits on `null` and the hot path costs one `startsWith`.
+ */
+export function parseMcpServerFromToolName(toolName: unknown): string | null {
+  if (typeof toolName !== 'string') return null
+  if (!toolName.startsWith('mcp__')) return null
+  const rest = toolName.slice('mcp__'.length)
+  const end = rest.indexOf('__')
+  const server = end === -1 ? rest : rest.slice(0, end)
+  return server.length > 0 ? server : null
+}
+
+/** Remedy metadata for a server, from either data source. `null` when unknown. */
+export function describeMcpServer(
+  server: string,
+): { label: string; vaultKey: string; consoleUrl: string } | null {
+  const direct = MCP_SERVER_VAULT_KEYS[server]
+  if (direct != null) return direct
+  const entry: ProviderCreditEntry | undefined = PROVIDER_CREDIT_REGISTRY.find(e => e.id === server)
+  if (entry != null) {
+    return { label: entry.label, vaultKey: entry.vaultKey, consoleUrl: entry.consoleUrl }
+  }
+  return null
+}
+
+// ─── Classification ──────────────────────────────────────────────────────────
+
+/** `ordinary` is the SILENT class — everything else raises an operator alert. */
+export type McpFailureClass = 'credit' | 'credential' | 'quota' | 'ordinary'
+
+/** True for the classes that page the operator. */
+export function isAlertingClass(c: McpFailureClass): boolean {
+  return c !== 'ordinary'
+}
+
+interface ClassRule {
+  cls: Exclude<McpFailureClass, 'ordinary'>
+  /** Structured HTTP statuses that imply this class on their own. */
+  statuses: readonly number[]
+  /** Lowercase wordings that imply this class. */
+  signals: readonly string[]
+}
+
+/**
+ * Evaluated IN ORDER — first match wins. Credit precedes credential because a
+ * spent Perplexity balance answers 401 with "insufficient credits", and the
+ * remedy is "top up", not "re-issue the key".
+ */
+const CLASS_RULES: readonly ClassRule[] = [
+  // `credit` is handled ahead of this table via the shared registry predicates.
+  {
+    cls: 'credential',
+    statuses: [401, 403],
+    signals: [
+      'invalid api key',
+      'invalid_api_key',
+      'incorrect api key',
+      'invalid authentication',
+      'authentication_error',
+      'authentication failed',
+      'unauthorized',
+      'unauthorised',
+      'forbidden',
+      'api key not found',
+      'no api key provided',
+      'missing api key',
+      'api key expired',
+      'key has been disabled',
+      'key has been revoked',
+      'key is disabled',
+      'account has been blocked',
+      'account is blocked',
+      'account suspended',
+      'permission_denied',
+      'token expired',
+      'invalid token',
+    ],
+  },
+  {
+    cls: 'quota',
+    // NOTE: 429 is deliberately NOT listed. A bare 429 is a throttle and must
+    // stay silent; only the hard-wall WORDINGS below promote it to an alert.
+    statuses: [],
+    signals: [
+      'quota exceeded',
+      'quota_exceeded',
+      'over quota',
+      'usage limit reached',
+      'usage limit exceeded',
+      'monthly limit',
+      'monthly quota',
+      'plan limit',
+      'plan_limit',
+      'limit reached for your plan',
+      'upgrade your plan',
+      'spending limit',
+      // NOTE: "exceeded your current quota" is deliberately NOT here. It is
+      // OpenAI's BILLING wording and already lives in `CREDIT_EXHAUSTION_SIGNALS`,
+      // where it is matched first — duplicating it would be dead data that
+      // silently disagrees with the shared registry.
+    ],
+  },
+]
+
+/**
+ * Wordings that mean "transient throttle / operational hiccup" and must keep a
+ * failure SILENT even if a broader signal would otherwise match. Checked before
+ * the alerting rules so `429 rate limit, retry after 2s` never pages anyone.
+ */
+const TRANSIENT_SIGNALS: readonly string[] = [
+  'rate limit',
+  'rate_limit',
+  'too many requests',
+  'retry after',
+  'retry-after',
+  'slow down',
+  'timeout',
+  'timed out',
+  'etimedout',
+  'econnreset',
+  'econnrefused',
+  'socket hang up',
+  'network error',
+  'service unavailable',
+  'bad gateway',
+  'temporarily unavailable',
+]
+
+const MAX_SCAN_CHARS = 16_384
+
+function sample(text: unknown): string {
+  if (typeof text !== 'string' || text.length === 0) return ''
+  return (text.length > MAX_SCAN_CHARS ? text.slice(0, MAX_SCAN_CHARS) : text).toLowerCase()
+}
+
+/**
+ * Pull a structured HTTP status out of free-form error text. Conservative on
+ * purpose: only reads a 3-digit code that is LABELLED as a status/code, never a
+ * bare number (ids, token counts and durations are full of them).
+ */
+export function extractHttpStatus(text: unknown): number | null {
+  const lower = sample(text)
+  if (lower.length === 0) return null
+  const m =
+    /\b(?:http[ _-]?status|status[ _-]?code|statuscode|status|http|code|error)\b\D{0,4}\b([1-5]\d\d)\b/.exec(lower) ??
+    /\b([1-5]\d\d)\s+(?:unauthorized|unauthorised|forbidden|payment required|too many requests)\b/.exec(lower)
+  if (m == null) return null
+  const n = Number(m[1])
+  return Number.isFinite(n) ? n : null
+}
+
+/**
+ * Classify one failed MCP tool result. `status` may be supplied by a caller
+ * that has a structured one; otherwise it is recovered from the text.
+ *
+ * Returns `'ordinary'` — the SILENT class — for anything not proven to be a
+ * key/billing problem. That default is deliberate: a false alert costs Ken's
+ * trust in the channel, a missed one costs a retry.
+ */
+export function classifyMcpFailure(text: unknown, status?: unknown): McpFailureClass {
+  const lower = sample(text)
+  const httpStatus = typeof status === 'number' ? status : extractHttpStatus(text)
+
+  // 1. Credit wall — the shared registry decides, so the MCP path and the
+  //    LiteLLM path can never disagree about what "out of money" looks like.
+  if (isProviderCreditStatus(httpStatus) || hasCreditExhaustionWording(lower)) return 'credit'
+
+  // 2. An EXPLICIT alerting wording beats everything below it. Deliberately
+  //    ahead of the transient check: providers routinely wrap a hard wall in
+  //    throttle language ("Rate limit exceeded: monthly quota exhausted"), and
+  //    the wall is the real news.
+  for (const rule of CLASS_RULES) {
+    if (rule.signals.some(s => lower.includes(s))) return rule.cls
+  }
+
+  // 3. Transient beats a STATUS-ONLY inference: a throttle is not a wall, and
+  //    a bare status with retry/timeout language is an operational hiccup.
+  if (TRANSIENT_SIGNALS.some(s => lower.includes(s))) return 'ordinary'
+
+  // 4. Status-only inference, last and weakest.
+  for (const rule of CLASS_RULES) {
+    if (httpStatus != null && rule.statuses.includes(httpStatus)) return rule.cls
+  }
+
+  return 'ordinary'
+}
+
+// ─── Ledger ──────────────────────────────────────────────────────────────────
+
+/**
+ * House re-notify cadence, matched to `src/hindsight-watch/thresholds.ts`
+ * (`RENOTIFY_MS`) so every standing operator alert in switchroom repeats on the
+ * same 6-hour rhythm.
+ */
+export const RENOTIFY_MS = 6 * 60 * 60 * 1000
+
+export interface McpFailureAlert {
+  server: string
+  label: string
+  vaultKey: string
+  consoleUrl: string
+  cls: Exclude<McpFailureClass, 'ordinary'>
+  /** Every agent seen failing this way since the previous alert. */
+  agents: string[]
+  /** Total failures counted since the previous alert. */
+  occurrences: number
+  /** True when this is a 6-hourly repeat rather than a first firing. */
+  renotify: boolean
+}
+
+interface LedgerRow {
+  agents: Set<string>
+  occurrences: number
+  lastAlertAt: number
+}
+
+/**
+ * Coalescing ledger. One instance per gateway process; `now` is injected so
+ * tests are deterministic and no ambient clock leaks in.
+ */
+export class McpFailureLedger {
+  private readonly rows = new Map<string, LedgerRow>()
+
+  constructor(private readonly renotifyMs: number = RENOTIFY_MS) {}
+
+  /**
+   * Record one classified failure. Returns the alert to send, or `null` when
+   * this occurrence is inside an already-alerted window (deduplicated).
+   */
+  note(input: {
+    server: string
+    agent: string
+    cls: McpFailureClass
+    now: number
+  }): McpFailureAlert | null {
+    if (!isAlertingClass(input.cls)) return null
+    const cls = input.cls as Exclude<McpFailureClass, 'ordinary'>
+    const key = `${input.server}::${cls}`
+    const row = this.rows.get(key) ?? { agents: new Set<string>(), occurrences: 0, lastAlertAt: -Infinity }
+    row.agents.add(input.agent)
+    row.occurrences += 1
+    this.rows.set(key, row)
+
+    const due = input.now - row.lastAlertAt >= this.renotifyMs
+    if (!due) return null
+
+    const renotify = Number.isFinite(row.lastAlertAt)
+    const meta = describeMcpServer(input.server)
+    const alert: McpFailureAlert = {
+      server: input.server,
+      label: meta?.label ?? input.server,
+      vaultKey: meta?.vaultKey ?? `${input.server}/api-key`,
+      consoleUrl: meta?.consoleUrl ?? '',
+      cls,
+      agents: [...row.agents].sort(),
+      occurrences: row.occurrences,
+      renotify,
+    }
+    row.lastAlertAt = input.now
+    row.agents = new Set<string>()
+    row.occurrences = 0
+    return alert
+  }
+
+  /** Test/diagnostic helper — number of tracked (server, class) pairs. */
+  size(): number {
+    return this.rows.size
+  }
+}
+
+// ─── The seam watcher ────────────────────────────────────────────────────────
+
+/** Bound on the pending tool_use→name map so a leaked id can't grow it forever. */
+const PENDING_TOOL_NAMES_MAX = 512
+
+/**
+ * The whole seam in one object: pair `tool_use` → `tool_result` by
+ * `toolUseId` (the session stream reports `toolName: null` on results, so the
+ * name MUST be carried across), classify, coalesce, and hand back the alert to
+ * emit — or `null` for the overwhelmingly common case of "nothing to say".
+ *
+ * One instance per gateway process. `now` is injected; nothing here touches a
+ * clock, the network, or the FS.
+ */
+export class McpFailureWatcher {
+  private readonly pending = new Map<string, string>()
+  private readonly ledger: McpFailureLedger
+
+  constructor(renotifyMs: number = RENOTIFY_MS) {
+    this.ledger = new McpFailureLedger(renotifyMs)
+  }
+
+  /** Remember the tool name for a call in flight. Non-MCP tools are ignored. */
+  onToolUse(toolUseId: unknown, toolName: unknown): void {
+    if (typeof toolUseId !== 'string' || toolUseId.length === 0) return
+    if (parseMcpServerFromToolName(toolName) == null) return
+    if (this.pending.size >= PENDING_TOOL_NAMES_MAX) {
+      // Evict oldest — Map preserves insertion order.
+      const oldest = this.pending.keys().next()
+      if (!oldest.done) this.pending.delete(oldest.value)
+    }
+    this.pending.set(toolUseId, toolName as string)
+  }
+
+  /**
+   * Consume a tool result. Returns an alert only when the failure is proven to
+   * be a key/billing problem AND the (server, class) is outside its re-notify
+   * window. Everything else — a success, a non-MCP tool, an ordinary error, a
+   * deduplicated repeat — returns `null`.
+   */
+  onToolResult(input: {
+    toolUseId: unknown
+    isError?: boolean
+    errorText?: unknown
+    agent: string
+    now: number
+  }): McpFailureAlert | null {
+    const id = typeof input.toolUseId === 'string' ? input.toolUseId : ''
+    const toolName = id.length > 0 ? this.pending.get(id) : undefined
+    if (id.length > 0) this.pending.delete(id)
+    if (input.isError !== true) return null
+    if (toolName == null) return null
+    const server = parseMcpServerFromToolName(toolName)
+    if (server == null) return null
+    const cls = classifyMcpFailure(input.errorText)
+    return this.ledger.note({ server, agent: input.agent, cls, now: input.now })
+  }
+}
+
+// ─── Rendering ───────────────────────────────────────────────────────────────
+
+const CLASS_HEADLINE: Record<Exclude<McpFailureClass, 'ordinary'>, string> = {
+  credit: 'is out of credit',
+  credential: 'key is being rejected',
+  quota: 'has hit its usage quota',
+}
+
+const CLASS_ACTION: Record<Exclude<McpFailureClass, 'ordinary'>, string> = {
+  credit: 'Top up the balance',
+  credential: 'Re-issue the key and update the vault entry',
+  quota: 'Raise the plan limit or wait for the quota to reset',
+}
+
+/**
+ * The operator-card DETAIL for an MCP credential alert. Names the provider, the
+ * VAULT KEY NAME (never a value), the affected agents and the action.
+ *
+ * Never includes the raw provider error: the same standing rule as the
+ * OpenRouter 402 work — the end user sees nothing, and the operator sees a
+ * remedy, not a stack trace.
+ *
+ * The output is composed ENTIRELY of registry constants, counts and sanitised
+ * agent slugs — no provider text, no user text — which is why the card may
+ * render it as Markdown without escaping (see `renderOperatorEvent`).
+ */
+export function renderMcpFailureDetail(alert: McpFailureAlert): string {
+  const agents =
+    alert.agents.length > 0
+      ? alert.agents.map(a => a.replace(/[^A-Za-z0-9._-]/g, '')).filter(Boolean).join(', ')
+      : 'unknown agent'
+  const console_ = alert.consoleUrl.length > 0 ? ` → ${alert.consoleUrl}` : ''
+  const repeat = alert.renotify ? ' (still failing)' : ''
+  const times = alert.occurrences === 1 ? '1 failure' : `${alert.occurrences} failures`
+  return (
+    `${alert.label} ${CLASS_HEADLINE[alert.cls]}${repeat} — ${times}, affecting: ${agents}. ` +
+    `${CLASS_ACTION[alert.cls]}. Vault key: \`${alert.vaultKey}\`${console_}`
+  )
+}

--- a/telegram-plugin/operator-events.ts
+++ b/telegram-plugin/operator-events.ts
@@ -38,6 +38,18 @@ export type OperatorEventKind =
    * never user-actionable — see {@link OPERATOR_ACTIONABLE_KINDS}.
    */
   | 'provider-credit-exhausted'
+  /**
+   * A paid MCP dependency (Perplexity, Eraser, Brevo, Postiz, Meta/Google Ads,
+   * Cloudflare …) is refusing work because its KEY is the problem — out of
+   * credit, rejected, or past a hard usage wall. Raised from the tool_result
+   * seam, not the LLM-error seam, because these providers never touch LiteLLM.
+   *
+   * Deliberately NOT raised for an ordinary tool failure (bad query, 404,
+   * timeout, transient 429) — see `classifyMcpFailure` in
+   * `mcp-credential-failure.ts`. Operator-actionable: only the operator can top
+   * up or re-issue a key.
+   */
+  | 'mcp-dependency-blocked'
   | 'quota-exhausted'
   | 'rate-limited'
   | 'agent-crashed'
@@ -378,6 +390,28 @@ export function renderOperatorEvent(ev: OperatorEvent): RenderResult {
       }
     }
 
+    // A paid MCP dependency's KEY is blocked. `ev.detail` for this kind is
+    // built by `renderMcpFailureDetail` from registry constants, counts and
+    // sanitised agent slugs ONLY — no provider text and no user text ever
+    // reaches it — so it is rendered as Markdown VERBATIM (escaping it would
+    // mangle the `vault key` code span and the console URL). It names the
+    // provider, the vault key NAME (never a value), the affected agents and
+    // the action. Dismiss-only: `/auth` cannot fix a third-party MCP key.
+    case 'mcp-dependency-blocked':
+      return {
+        text: [
+          `🔌 **Paid dependency blocked**`,
+          stripRawErrorBytes(ev.detail),
+        ]
+          .filter(Boolean)
+          .join('\n'),
+        keyboard: {
+          inline_keyboard: [
+            [{ text: '❌ Dismiss', callback_data: `op:dismiss:${encodeURIComponent(ev.agent)}` }],
+          ],
+        },
+      }
+
     case 'quota-exhausted':
       // Canonical quota-exhausted text (migrated from auto-fallback.ts).
       // auto-fallback.ts's buildSwitchedMessage / buildAllExhaustedMessage
@@ -611,6 +645,10 @@ export const OPERATOR_ACTIONABLE_KINDS: ReadonlySet<OperatorEventKind> = new Set
   // lose confidence. This membership is what routes it to the operator card and
   // hands the user the brief plain-language notice instead.
   'provider-credit-exhausted',
+  // A paid MCP dependency's key is blocked (Perplexity out of credit, a revoked
+  // Eraser key, …). Only the operator holds the vendor console and the vault —
+  // an end user shown "401 invalid api key" can do nothing with it.
+  'mcp-dependency-blocked',
   'proxy-misconfig',
 ])
 

--- a/telegram-plugin/tests/mcp-credential-failure.test.ts
+++ b/telegram-plugin/tests/mcp-credential-failure.test.ts
@@ -1,0 +1,310 @@
+/**
+ * mcp-credential-failure.test.ts — outcome tests for "a paid MCP dependency's
+ * key is blocked → Ken gets ONE hard warning".
+ *
+ * THE GAP. Perplexity (and Eraser, Brevo, Postiz, Meta/Google Ads, Cloudflare)
+ * reach switchroom over the MCP TOOL surface, never through LiteLLM. So the
+ * operator-event path that PR A fixed for an OpenRouter 402 never sees them: an
+ * expired Perplexity key surfaced as an ordinary red step in the live feed and
+ * died there. Nobody was told the fleet had lost a paid capability.
+ *
+ * These assert the OBSERVABLE RESULT at the gateway seam, composing the SAME
+ * production functions in the SAME order `handleSessionEvent` →
+ * `noteMcpDependencyFailure` → `emitGatewayOperatorEvent` calls them:
+ * McpFailureWatcher.onToolUse/onToolResult → renderMcpFailureDetail →
+ * renderOperatorEvent → decideOperatorEventAudience →
+ * renderUserFacingFailureNotice.
+ *
+ * The three guarantees the brief names, each asserted end-to-end:
+ *   1. a credential-class MCP failure produces EXACTLY ONE operator alert with
+ *      the provider, the vault key NAME, the agents and the action;
+ *   2. a second agent failing the same way inside the window produces NO
+ *      second alert;
+ *   3. an ordinary tool error (bad query, 404, timeout, transient 429)
+ *      produces NONE.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  McpFailureWatcher,
+  McpFailureLedger,
+  classifyMcpFailure,
+  parseMcpServerFromToolName,
+  renderMcpFailureDetail,
+  RENOTIFY_MS,
+  type McpFailureAlert,
+} from '../mcp-credential-failure.js'
+import {
+  renderOperatorEvent,
+  decideOperatorEventAudience,
+  isOperatorActionableKind,
+  renderUserFacingFailureNotice,
+  type OperatorEvent,
+} from '../operator-events.js'
+
+// ── Verbatim vendor failure bodies ──────────────────────────────────────────
+
+/** Perplexity, key revoked / rejected. */
+const PPLX_401 =
+  '{"error":{"message":"Invalid API key provided.","type":"authentication_error","code":401}}'
+
+/** Perplexity, balance spent — 401 status, but the remedy is "top up". */
+const PPLX_NO_CREDIT =
+  'api.perplexity.ai responded with status 401: {"detail":"insufficient credits — please add funds to your account"}'
+
+/**
+ * Perplexity, hard monthly wall. Note the status is 429 — the SAME status as a
+ * transient throttle — so only the wording can tell the two apart, which is
+ * exactly why 429 is not in the quota rule's status list.
+ */
+const PPLX_QUOTA =
+  '{"error":{"message":"Monthly quota exceeded for your plan. Upgrade your plan to continue.","code":429}}'
+
+// ── Ordinary failures that must stay SILENT ─────────────────────────────────
+
+const ORDINARY_FAILURES: ReadonlyArray<[string, string]> = [
+  ['a bad query', 'Error: search query must not be empty'],
+  ['a 404', 'Request failed with status code 404: not found'],
+  ['a timeout', 'Error: ETIMEDOUT — request to api.perplexity.ai timed out after 30000ms'],
+  ['a transient throttle', '{"error":{"message":"Rate limit exceeded, retry after 2s","code":429}}'],
+  ['a transport reset', 'Error: socket hang up (ECONNRESET)'],
+  ['an upstream 5xx', 'Request failed with status code 503: service unavailable'],
+  ['no results', 'The search returned no results for that query.'],
+]
+
+const ALLOW = ['7000000001' /* operator */, '7000000002' /* end user */]
+const T0 = Date.UTC(2026, 6, 28, 10, 0, 0)
+
+/**
+ * One agent's gateway, driven exactly as `handleSessionEvent` drives it. The
+ * `alerts` array is what `emitGatewayOperatorEvent` would have been called with.
+ */
+function makeAgent(agent: string, watcher: McpFailureWatcher) {
+  const alerts: McpFailureAlert[] = []
+  let seq = 0
+  return {
+    alerts,
+    /** Drive one full MCP tool call that fails with `errorText`. */
+    fail(toolName: string, errorText: string, now: number): void {
+      const toolUseId = `toolu_${agent}_${seq++}`
+      watcher.onToolUse(toolUseId, toolName)
+      const alert = watcher.onToolResult({ toolUseId, isError: true, errorText, agent, now })
+      if (alert != null) alerts.push(alert)
+    },
+    /** A successful call — must never alert. */
+    succeed(toolName: string, now: number): void {
+      const toolUseId = `toolu_${agent}_${seq++}`
+      watcher.onToolUse(toolUseId, toolName)
+      const alert = watcher.onToolResult({ toolUseId, isError: false, agent, now })
+      if (alert != null) alerts.push(alert)
+    },
+  }
+}
+
+/** What the operator and a non-operator user actually receive for one alert. */
+function route(alert: McpFailureAlert): {
+  operatorText: string | null
+  operatorChats: string[]
+  userText: string | null
+  userChats: string[]
+  buttons: string[]
+} {
+  const ev: OperatorEvent = {
+    kind: 'mcp-dependency-blocked',
+    agent: alert.agents[0] ?? 'agent',
+    detail: renderMcpFailureDetail(alert),
+    suggestedActions: [],
+    firstSeenAt: new Date(T0),
+  }
+  const rendered = renderOperatorEvent(ev)
+  const { operatorChats, userNoticeChats } = decideOperatorEventAudience(ev.kind, ALLOW, ALLOW[0])
+  return {
+    operatorText: operatorChats.length > 0 ? rendered.text : null,
+    operatorChats,
+    userText: userNoticeChats.length > 0 ? renderUserFacingFailureNotice() : null,
+    userChats: userNoticeChats,
+    buttons: rendered.keyboard.inline_keyboard.flat().map(b => b.text),
+  }
+}
+
+describe('a blocked Perplexity key raises exactly one operator alert', () => {
+  it('produces ONE alert naming provider, vault key NAME, agent and action', () => {
+    const w = new McpFailureWatcher()
+    const klanker = makeAgent('klanker', w)
+
+    klanker.fail('mcp__perplexity__perplexity_search', PPLX_401, T0)
+
+    expect(klanker.alerts).toHaveLength(1)
+    const alert = klanker.alerts[0]
+    expect(alert.server).toBe('perplexity')
+    expect(alert.cls).toBe('credential')
+    expect(alert.agents).toEqual(['klanker'])
+    expect(alert.renotify).toBe(false)
+
+    const r = route(alert)
+
+    // Operator-only: the kind is actionable, so the user gets the brief notice.
+    expect(isOperatorActionableKind('mcp-dependency-blocked')).toBe(true)
+    expect(r.operatorChats).toEqual(['7000000001'])
+    expect(r.userChats).toEqual(['7000000002'])
+
+    // The card says what Ken can actually DO.
+    expect(r.operatorText).toContain('Perplexity')
+    expect(r.operatorText).toContain('perplexity/api-key') // vault key NAME
+    expect(r.operatorText).toContain('https://www.perplexity.ai/settings/api')
+    expect(r.operatorText).toContain('klanker')
+    expect(r.operatorText).toContain('Re-issue the key')
+    expect(r.buttons).toEqual(['❌ Dismiss'])
+
+    // NEVER a secret value, and never the raw provider error.
+    expect(r.operatorText).not.toContain('Invalid API key provided')
+    expect(r.operatorText).not.toMatch(/pplx-[A-Za-z0-9]/)
+
+    // The end user still sees only the diagnosis-free notice.
+    expect(r.userText).toBe(renderUserFacingFailureNotice())
+    for (const fragment of ['perplexity', '401', 'api key', 'authentication_error', 'vault']) {
+      expect(r.userText!.toLowerCase()).not.toContain(fragment)
+    }
+  })
+
+  it('routes a spent BALANCE to "top up", not to "re-issue the key"', () => {
+    const w = new McpFailureWatcher()
+    const a = makeAgent('klanker', w)
+    a.fail('mcp__perplexity__perplexity_ask', PPLX_NO_CREDIT, T0)
+    expect(a.alerts).toHaveLength(1)
+    // 401 status, but the credit wording must win — the key is fine, the
+    // account is empty, and re-issuing it would waste the operator's time.
+    expect(a.alerts[0].cls).toBe('credit')
+    expect(route(a.alerts[0]).operatorText).toContain('Top up the balance')
+  })
+
+  it('sees a hard wall wrapped in throttle language (429 + "rate limit")', () => {
+    // Providers routinely dress a monthly wall up as a rate limit. The wall is
+    // the real news; silencing it as a throttle would lose the capability
+    // quietly, which is the exact failure this whole feature exists to stop.
+    const w = new McpFailureWatcher()
+    const a = makeAgent('klanker', w)
+    a.fail(
+      'mcp__perplexity__perplexity_search',
+      'Rate limit exceeded — monthly quota exceeded for your plan (429)',
+      T0,
+    )
+    expect(a.alerts).toHaveLength(1)
+    expect(a.alerts[0].cls).toBe('quota')
+  })
+
+  it('routes a hard usage wall to the quota remedy', () => {
+    const w = new McpFailureWatcher()
+    const a = makeAgent('klanker', w)
+    a.fail('mcp__perplexity__perplexity_research', PPLX_QUOTA, T0)
+    expect(a.alerts).toHaveLength(1)
+    expect(a.alerts[0].cls).toBe('quota')
+    expect(route(a.alerts[0]).operatorText).toContain('Raise the plan limit')
+  })
+})
+
+describe('deduplication — a storm of failures is one alert, not a storm of alerts', () => {
+  it('a second agent failing the same way in the window produces NO second alert', () => {
+    // One shared watcher stands in for one gateway process seeing several
+    // agents/sub-agents; the cross-CONTAINER limit is documented in the module.
+    const w = new McpFailureWatcher()
+    const klanker = makeAgent('klanker', w)
+    const scribe = makeAgent('scribe', w)
+
+    klanker.fail('mcp__perplexity__perplexity_search', PPLX_401, T0)
+    scribe.fail('mcp__perplexity__perplexity_ask', PPLX_401, T0 + 1_000)
+    klanker.fail('mcp__perplexity__perplexity_search', PPLX_401, T0 + 30_000)
+
+    expect(klanker.alerts).toHaveLength(1)
+    expect(scribe.alerts).toHaveLength(0)
+  })
+
+  it('re-notifies after the 6h house cadence, and NAMES everyone seen since', () => {
+    const w = new McpFailureWatcher()
+    const klanker = makeAgent('klanker', w)
+    const scribe = makeAgent('scribe', w)
+
+    klanker.fail('mcp__perplexity__perplexity_search', PPLX_401, T0)
+    expect(klanker.alerts).toHaveLength(1)
+
+    // Silent for the whole window, however many failures land.
+    scribe.fail('mcp__perplexity__perplexity_ask', PPLX_401, T0 + RENOTIFY_MS - 1)
+    expect(scribe.alerts).toHaveLength(0)
+
+    // At the boundary it fires again, accumulating everyone seen meanwhile.
+    scribe.fail('mcp__perplexity__perplexity_ask', PPLX_401, T0 + RENOTIFY_MS)
+    expect(scribe.alerts).toHaveLength(1)
+    const repeat = scribe.alerts[0]
+    expect(repeat.renotify).toBe(true)
+    expect(repeat.agents).toEqual(['scribe'])
+    expect(repeat.occurrences).toBe(2)
+    expect(route(repeat).operatorText).toContain('still failing')
+  })
+
+  it('matches the house re-notify cadence used by the hindsight watcher', () => {
+    expect(RENOTIFY_MS).toBe(6 * 60 * 60 * 1000)
+  })
+
+  it('tracks credit and credential walls on the same server independently', () => {
+    const led = new McpFailureLedger()
+    expect(led.note({ server: 'perplexity', agent: 'a', cls: 'credential', now: T0 })).not.toBeNull()
+    // A different failure CLASS is a different problem with a different remedy,
+    // so it must not be silenced by the first one's window.
+    expect(led.note({ server: 'perplexity', agent: 'a', cls: 'credit', now: T0 })).not.toBeNull()
+  })
+})
+
+describe('ordinary tool failures never page the operator', () => {
+  for (const [label, body] of ORDINARY_FAILURES) {
+    it(`stays silent for ${label}`, () => {
+      const w = new McpFailureWatcher()
+      const a = makeAgent('klanker', w)
+      a.fail('mcp__perplexity__perplexity_search', body, T0)
+      expect(a.alerts).toEqual([])
+      expect(classifyMcpFailure(body)).toBe('ordinary')
+    })
+  }
+
+  it('stays silent for a SUCCESSFUL MCP call', () => {
+    const w = new McpFailureWatcher()
+    const a = makeAgent('klanker', w)
+    a.succeed('mcp__perplexity__perplexity_search', T0)
+    expect(a.alerts).toEqual([])
+  })
+
+  it('stays silent for a non-MCP tool that fails with auth-shaped text', () => {
+    // A Bash step printing "401 unauthorized" from some unrelated curl is NOT
+    // a fleet capability loss and must not page anyone.
+    const w = new McpFailureWatcher()
+    const a = makeAgent('klanker', w)
+    a.fail('Bash', 'curl: server returned status 401 unauthorized', T0)
+    expect(a.alerts).toEqual([])
+  })
+})
+
+describe('the rule is data, and it generalises past Perplexity', () => {
+  it('derives the server from any mcp__<server>__<tool> name', () => {
+    expect(parseMcpServerFromToolName('mcp__perplexity__perplexity_search')).toBe('perplexity')
+    expect(parseMcpServerFromToolName('mcp__meta-ads__list_campaigns')).toBe('meta-ads')
+    expect(parseMcpServerFromToolName('Read')).toBeNull()
+    expect(parseMcpServerFromToolName(undefined)).toBeNull()
+  })
+
+  it('covers other paid dependencies with no new code — Eraser, Brevo', () => {
+    const w = new McpFailureWatcher()
+    const a = makeAgent('klanker', w)
+    a.fail('mcp__eraser__create_diagram', '403 Forbidden: api key has been revoked', T0)
+    a.fail('mcp__brevo__send_email', '{"code":"unauthorized","message":"Key not found"}', T0)
+    expect(a.alerts.map(x => x.server)).toEqual(['eraser', 'brevo'])
+    expect(route(a.alerts[0]).operatorText).toContain('eraser/api-key')
+    expect(route(a.alerts[1]).operatorText).toContain('brevo/api-key')
+  })
+
+  it('an unregistered MCP server still alerts, with a conventional key name', () => {
+    const w = new McpFailureWatcher()
+    const a = makeAgent('klanker', w)
+    a.fail('mcp__somenewthing__do_it', '401 unauthorized: invalid api key', T0)
+    expect(a.alerts).toHaveLength(1)
+    expect(a.alerts[0].vaultKey).toBe('somenewthing/api-key')
+  })
+})


### PR DESCRIPTION
Ken: "If perplexity fails for any agent we should have hard warning via
message here per other failures."

THE GAP. Perplexity — and Eraser, Brevo, Postiz, Meta/Google Ads,
Cloudflare — reach switchroom over the MCP TOOL surface, never through
LiteLLM. So the operator-event path that PR #3868 fixed for an OpenRouter
402 never saw them: an expired Perplexity key surfaced as an ordinary
`is_error` tool_result, rendered as a transient red step in the live
feed, and died there. Nobody was told the fleet had lost a paid
capability, and the only person who could fix it (the operator, who holds
the vault and the vendor console) was the one person not told.

WHAT THIS DOES. `telegram-plugin/mcp-credential-failure.ts` is a pure
classifier + coalescing ledger. `gateway/mcp-failure-hook.ts` is the
seam, teeing into the SAME `emitGatewayOperatorEvent` path the OpenRouter
402 work uses — redact → per-kind cooldown → operator-only audience via
`OPERATOR_ACTIONABLE_KINDS` → brief user notice. One operator-alert
mechanism, not two.

THE CLASSIFICATION RULE — data, not scattered conditionals. Only three
classes page the operator, and all three mean "the KEY is the problem":

  credit     — 402 / "insufficient credits" / "payment_required"
               (decided by the SHARED registry from #3868, so the MCP
               path and the LiteLLM path can never disagree)
  credential — 401/403 / "invalid api key" / "revoked" / "disabled"
  quota      — "quota exceeded" / "usage limit reached" / "plan limit"

Everything else is `ordinary` and SILENT: a bad query, a 404, a timeout,
ECONNRESET, a 5xx, and — the subtle one — a bare 429 throttle with a
retry-after. A throttle self-heals in seconds; alerting on it would train
the operator to ignore the channel, which is worse than no alert at all.
An explicit hard-wall wording still wins over co-occurring throttle
language ("Rate limit exceeded — monthly quota exceeded"), because the
wall is the real news.

DEDUPLICATION. Coalesced per (server, class), re-notifying on the house
6-hour cadence — the same `RENOTIFY_MS` `src/hindsight-watch` uses, so
every standing operator alert in switchroom shares one rhythm. Failures
inside the window are ACCUMULATED, not dropped: the next alert names
every agent seen since the last one.

HONEST LIMIT (documented in the module, follow-up issue to file): the
ledger is in-process and therefore AGENT-LOCAL. Each agent runs its own
container with its own gateway and no shared writable mount, so six
agents hitting a blocked Perplexity key produce up to six alerts — one
per agent, each naming its agent — not one coalesced alert. Fleet-wide
coalescing needs a shared ledger the gateway does not have; faking it
here would be worse than stating it.

THE ALERT names the provider, the vault key NAME (never a value), the
affected agents and the action, with a Dismiss-only keyboard (`/auth`
cannot fix a third-party MCP key). The end user still sees only the
diagnosis-free notice — same standing rule as #3868.

TESTS (20, outcome-focused, driven through the real seam). The three
guarantees asserted end-to-end: exactly ONE operator alert with the right
content; a second agent failing the same way in the window produces NO
second alert; an ordinary tool error produces NONE (7 fixtures).

Mutation results — every one killed tests, baseline restored 20/20:
  M1 drop the kind from OPERATOR_ACTIONABLE_KINDS  → 1 failed (user leak)
  M2 ledger never dedups                            → 2 failed
  M3 classify every error as alerting               → 7 failed
  M4 drop the vault key NAME from the card          → 2 failed
  M5 fire on non-MCP tools                          → 1 failed
  M6 credit loses to credential (wrong remedy)      → 1 failed
  M7 relay the raw provider error into the card     → 1 failed

Wiring lives in `gateway/mcp-failure-hook.ts` rather than inline, per the
switchroom#2996 gateway line ratchet.

Stacked on #3868 (feat/external-credit-watch) — consumes its provider
registry.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)