### PR TITLE
chore(litellm): delete the no-op gpt-oss-20b fallback and guard against re-adding one

### DIFF
--- a/docker/litellm-proxy/litellm-config.yaml
+++ b/docker/litellm-proxy/litellm-config.yaml
@@ -94,26 +94,34 @@ router_settings:
   # 2026-07-09 (per Ken) because require_parameters made ~5% of steady
   # structured retains 404 on OpenRouter even while local was healthy.
   routing_strategy: simple-shuffle
-  # Down-fallback chain. HISTORICAL intent (per Ken 2026-07-14) was local Ollama
-  # FIRST, then OpenRouter, then Claude Sonnet as last resort, tried in list
-  # order. Neither of the other two tiers survives: claude-sonnet-5 was removed
-  # 2026-07-17 (see inline note) and the local tier is out of the group, so what
-  # remains below is a SINGLE hop.
-  # ⚠ NO-OP AS WRITTEN (audited 2026-07-25): gpt-oss-20b and gpt-oss-20b-openrouter
-  # now have functionally identical litellm_params — same model
-  # (openrouter/openai/gpt-oss-20b), same max_tokens (8192), same
-  # extra_body.provider.order (fireworks/together/deepinfra/novita). Failing over
-  # from OpenRouter to the same OpenRouter route with the same provider order
-  # buys no additional availability. Left in place deliberately (routing changes
-  # are Ken's call, not an audit's) — but if a genuine second tier is wanted,
-  # the fallback target needs to differ from the primary. See the note on the
-  # gpt-oss-20b-openrouter entry in model_list.
-  fallbacks:
-    # claude-sonnet-5 removed 2026-07-17: internal fallback re-dispatch cannot
-    # carry the client OAuth header (gpt-oss callers auth with a virtual key),
-    # so this hop always 401'd ("x-api-key header is required") and leaked bogus
-    # re-auth errors to users.
-    - gpt-oss-20b: ["gpt-oss-20b-openrouter"]
+  # NO FALLBACK CHAIN — deliberately empty. Do not re-add one without a
+  # genuinely DIFFERENT second tier.
+  #
+  # HISTORICAL intent (Ken 2026-07-14) was local Ollama first, then OpenRouter,
+  # then Claude Sonnet as a last resort. Neither of the other two tiers
+  # survives:
+  #   - claude-sonnet-5 was removed 2026-07-17: internal fallback re-dispatch
+  #     cannot carry the client OAuth header (gpt-oss callers auth with a
+  #     virtual key), so this hop always 401'd ("x-api-key header is required")
+  #     and leaked bogus re-auth errors to users.
+  #   - the local Ollama tier is no longer in the group.
+  #
+  # What remained — `gpt-oss-20b: ["gpt-oss-20b-openrouter"]` — was audited as a
+  # NO-OP on 2026-07-25 and REMOVED 2026-07-28. Both entries resolve to the same
+  # model (openrouter/openai/gpt-oss-20b), the same max_tokens (8192) and the
+  # same extra_body.provider.order (fireworks/together/deepinfra/novita), so
+  # failing over from OpenRouter to the identical OpenRouter route bought no
+  # availability whatsoever. It was deleted rather than left in place because a
+  # `fallbacks:` block in the config ADVERTISES resilience: an operator reading
+  # this file, or an incident responder reasoning about why a request failed,
+  # would reasonably assume a second tier existed. An empty section that tells
+  # the truth is better than a populated one that lies.
+  #
+  # Consequence, stated plainly: an OpenRouter outage or a spent OpenRouter
+  # balance takes the whole gpt-oss-20b group down with no automatic recovery.
+  # That was ALREADY the behaviour — this change only stops the config implying
+  # otherwise. Restoring real resilience is a routing decision (a different
+  # provider, a different account, or a local tier), and routing is Ken's call.
 
 litellm_settings:
   # Do NOT set forward_client_headers_to_llm_api here — it is a Boolean in

--- a/src/litellm/repo-config.test.ts
+++ b/src/litellm/repo-config.test.ts
@@ -211,6 +211,56 @@ describe("repo-managed litellm-config.yaml (KEN-125)", () => {
     }
   });
 
+  it("has no SELF-REFERENTIAL fallback edge (a hop that buys no availability)", () => {
+    // 2026-07-25 audit / 2026-07-28 removal: `gpt-oss-20b` fell back to
+    // `gpt-oss-20b-openrouter`, and the two deployments had functionally
+    // IDENTICAL litellm_params — same model, same max_tokens, same
+    // extra_body.provider.order. Failing over from OpenRouter to the same
+    // OpenRouter route with the same provider order recovers nothing, while a
+    // populated `fallbacks:` block advertises resilience to anyone reading the
+    // config or debugging an incident. This asserts the OUTCOME: every fallback
+    // edge that exists must reach a MATERIALLY DIFFERENT deployment.
+    const deployments = parsed.model_list as Array<{
+      model_name: string;
+      litellm_params?: Record<string, unknown>;
+    }>;
+    // Only AVAILABILITY-relevant fields count. Two deployments that differ
+    // solely by `timeout` or `num_retries` are still the same upstream reached
+    // with the same credential over the same provider order — a shorter
+    // deadline is not a second tier. (That is precisely the shape the removed
+    // gpt-oss-20b edge had: identical model/key/provider order, timeout 90→60.)
+    const availabilityKeyFor = (group: string): string =>
+      JSON.stringify(
+        deployments
+          .filter((d) => d.model_name === group)
+          .map((d) => {
+            const p = (d.litellm_params ?? {}) as Record<string, unknown>;
+            const extra = (p.extra_body ?? {}) as Record<string, unknown>;
+            const provider = (extra.provider ?? {}) as Record<string, unknown>;
+            return JSON.stringify({
+              model: p.model ?? null,
+              api_base: p.api_base ?? null,
+              api_key: p.api_key ?? null,
+              provider_order: provider.order ?? null,
+            });
+          })
+          .sort(),
+      );
+
+    const fallbacks = (parsed.router_settings as Record<string, unknown> | undefined)
+      ?.fallbacks;
+    for (const edge of Array.isArray(fallbacks) ? fallbacks : []) {
+      for (const [src, targets] of Object.entries(edge as Record<string, string[]>)) {
+        for (const target of targets ?? []) {
+          expect(
+            availabilityKeyFor(src),
+            `fallback ${src} → ${target} is a NO-OP: both deployments reach the same model with the same credential over the same provider order, so the hop buys no availability. Point it at a genuinely different provider/account/tier, or delete the edge.`,
+          ).not.toBe(availabilityKeyFor(target));
+        }
+      }
+    }
+  });
+
   it("does NOT capture the Anthropic /anthropic pass-through (no pass_through_endpoints, no wildcard model)", () => {
     // 2026-07-05 incident: agent Claude traffic must stay on the URL-based
     // raw-byte pass-through, never the model-mapped route. The config must not


### PR DESCRIPTION
## What

Deletes the `gpt-oss-20b → gpt-oss-20b-openrouter` fallback edge from `docker/litellm-proxy/litellm-config.yaml`, replaces it with a comment saying what happened and what the consequence is, and adds a guard test so an equivalent no-op edge cannot be re-added silently.

## Why — the audit was right, and I verified it

The inline `⚠ NO-OP AS WRITTEN (audited 2026-07-25)` comment claimed the two deployments were functionally identical. Verified against the parsed YAML:

| field | `gpt-oss-20b` | `gpt-oss-20b-openrouter` |
|---|---|---|
| `model` | `openrouter/openai/gpt-oss-20b` | `openrouter/openai/gpt-oss-20b` |
| `api_key` | `os.environ/OPENROUTER_API_KEY` | `os.environ/OPENROUTER_API_KEY` |
| `extra_body.provider.order` | fireworks, together, deepinfra, novita | fireworks, together, deepinfra, novita |
| `max_tokens` | 8192 | 8192 |
| `timeout` | **90** | **60** |

The audit's "functionally identical" is very slightly overstated — they differ by `timeout` (90 → 60). That difference buys **no availability**: it is the same model, reached with the same credential, over the same provider order, just with a shorter deadline. If OpenRouter is down, or the OpenRouter balance is spent (see #3868), the fallback hop fails for exactly the same reason the primary did.

## Why delete rather than leave it and file an issue

A populated `fallbacks:` block **advertises resilience**. An operator reading this file, or an incident responder reasoning about why a `gpt-oss-20b` request failed outright, would reasonably assume a second tier existed. The config was lying about the system's behaviour. Deleting it changes **no runtime behaviour at all** — it only stops the config implying something untrue.

Stated plainly in the new comment: an OpenRouter outage or a spent OpenRouter balance takes the whole `gpt-oss-20b` group down with no automatic recovery. That was *already* true.

## The routing decision is NOT made here

Restoring real resilience is Ken's call, not an audit's. Options, for the record:

1. **Leave it with no fallback** (what this PR does). Honest; a spent OpenRouter balance is now *visible* via #3868's operator alert rather than silently mis-routed.
2. **A different OpenRouter provider order** as the second tier (e.g. drop `fireworks` from the fallback so a fireworks-specific outage recovers). Cheapest real improvement; still dies with the account balance.
3. **A second account/key** as the second tier. Survives a spent balance; needs a second OpenRouter account and a second vault key.
4. **A local Ollama tier** back in the group — the original 2026-07-14 intent. Survives an OpenRouter outage entirely; costs local capacity and quality.
5. **Claude Sonnet as last resort** — do NOT re-add as-is. Removed 2026-07-17 because internal fallback re-dispatch cannot carry the client OAuth header, so the hop always 401'd and leaked bogus re-auth errors to users.

## The guard

New test in `src/litellm/repo-config.test.ts`: every fallback edge that exists must reach a **materially different** deployment, comparing only the availability-relevant fields (`model`, `api_base`, `api_key`, `extra_body.provider.order`) — a differing `timeout`/`num_retries` explicitly does not count as a second tier.

**Mutation-checked:** re-adding `- gpt-oss-20b: ["gpt-oss-20b-openrouter"]` fails the guard with the actionable message; removed → 20/20 pass. An earlier version of the guard that compared whole `litellm_params` did **not** fire (because of the timeout difference) — that near-miss is why it compares the availability fields specifically.

## Checks

- `npx vitest run src/litellm/repo-config.test.ts` — 20 passed
- `npm run lint` (tsc + 19 guards, incl. `check-litellm-config-guard`) — green

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
