### PR TITLE
feat(litellm): put a conservative spend cap on every per-agent virtual key

### DIFF
--- a/src/cli/apply-litellm-provision.test.ts
+++ b/src/cli/apply-litellm-provision.test.ts
@@ -36,12 +36,17 @@ const updateKeyModels = vi.fn((...a: unknown[]) => {
   void a;
   return Promise.resolve({ kind: "ok" as const });
 });
+const updateKeyBudget = vi.fn((...a: unknown[]) => {
+  void a;
+  return Promise.resolve({ kind: "ok" as const });
+});
 vi.mock("../litellm/provision.js", () => ({
   ensureTeam: (...a: unknown[]) => ensureTeam(...a),
   ensureKey: (...a: unknown[]) => ensureKey(...a),
   validateKey: (...a: unknown[]) => validateKey(...a),
   bindKeyToTeam: (...a: unknown[]) => bindKeyToTeam(...a),
   updateKeyModels: (...a: unknown[]) => updateKeyModels(...a),
+  updateKeyBudget: (...a: unknown[]) => updateKeyBudget(...a),
 }));
 
 function makeConfig(): SwitchroomConfig {

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -19,6 +19,7 @@ import { Option, type Command } from "commander";
 import chalk from "chalk";
 import { accessSync, chmodSync, chownSync, constants as fsConstants, copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, writeFileSync } from "node:fs";
 import { writeConfigFileSync } from "../util/atomic.js";
+import { describeKeyBudget, resolveKeyBudget } from "../litellm/budget.js";
 import { mkdir } from "node:fs/promises";
 import { spawnSync as childSpawnSync } from "node:child_process";
 import readline from "node:readline";
@@ -333,7 +334,7 @@ export async function provisionLiteLLMKeys(
   // Lazy imports — only paid for when at least one agent opts in or hindsight is wired.
   const [
     { getViaBrokerStructured, putViaBroker },
-    { ensureTeam, ensureKey, validateKey, bindKeyToTeam, updateKeyModels },
+    { ensureTeam, ensureKey, validateKey, bindKeyToTeam, updateKeyModels, updateKeyBudget },
     { addAgentSecret },
   ] =
     await Promise.all([
@@ -477,6 +478,9 @@ export async function provisionLiteLLMKeys(
     admin_key?: string;
     team?: string;
     small_fast_model?: string;
+    max_budget?: number;
+    soft_budget?: number;
+    budget_duration?: string;
   } }).litellm;
 
   // The fleet's active OAuth account (auth-broker single-active model) — used
@@ -510,6 +514,15 @@ export async function provisionLiteLLMKeys(
       const baseUrl = litellm.base_url ?? topLevel?.base_url;
       const team = litellm.team ?? topLevel?.team ?? "switchroom";
       const adminKeyRef = litellm.admin_key ?? topLevel?.admin_key;
+      // Spend cap for this agent's key. Per-agent overrides the top-level
+      // block; absent everywhere ⇒ the conservative default in budget.ts. An
+      // UNCAPPED virtual key is a bearer token for the whole upstream account
+      // balance, so the default is "capped", not "unlimited".
+      const budget = resolveKeyBudget({
+        max_budget: litellm.max_budget ?? topLevel?.max_budget,
+        soft_budget: litellm.soft_budget ?? topLevel?.soft_budget,
+        budget_duration: litellm.budget_duration ?? topLevel?.budget_duration,
+      });
       if (!baseUrl || !adminKeyRef) {
         failures.push({
           agent: name,
@@ -693,6 +706,37 @@ export async function provisionLiteLLMKeys(
           writeOut(chalk.gray(`  ~ litellm/${name}: key already provisioned (skipped)\n`));
         }
 
+        // Re-cap an EXISTING key. Keys provisioned before spend caps existed
+        // are never regenerated (the vault check above short-circuits), so
+        // without this heal every pre-existing agent would stay UNCAPPED
+        // forever and the feature would protect only new agents. Idempotent —
+        // LiteLLM accepts the same budget repeatedly.
+        //
+        // `soft_budget` is NOT healed: LiteLLM's UpdateKeyRequest does not
+        // carry it (see updateKeyBudget), so an existing key can only gain the
+        // advisory alert by being regenerated. Said plainly rather than
+        // silently pretended.
+        if (!driftReprovision && storedKey && masterKey && budget) {
+          const cap = await updateKeyBudget({ baseUrl, masterKey, key: storedKey, budget });
+          if (cap.kind === "ok") {
+            writeOut(
+              chalk.gray(
+                `  ~ litellm/${name}: spend ${describeKeyBudget(budget)}` +
+                `${budget.softBudget != null ? " (soft budget applies to newly generated keys only)" : ""}\n`,
+              ),
+            );
+          } else {
+            ctx.writeErr(
+              chalk.yellow(
+                `  ! litellm/${name}: could NOT apply the spend cap (${cap.detail}) — ` +
+                `this key remains UNCAPPED and can spend the whole upstream account ` +
+                `balance. Manual: POST ${baseUrl}/key/update ` +
+                `{"key":"<key>","max_budget":${budget.maxBudget},"budget_duration":"${budget.budgetDuration}"}.\n`,
+              ),
+            );
+          }
+        }
+
         if (!driftReprovision) {
           // Still ensure the read-ACL is granted (cheap, idempotent).
           if (configText !== null) {
@@ -741,6 +785,7 @@ export async function provisionLiteLLMKeys(
         alias,
         teamId,
         metadata,
+        ...(budget ? { budget } : {}),
         // Surface the orphaned-alias self-heal steps (delete + regenerate) so the
         // operator sees the recovery instead of a silent extra round-trip.
         log: (m) => ctx.writeErr(chalk.gray(`  ~ litellm/${name}: ${m}\n`)),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2287,6 +2287,44 @@ export const LiteLLMConfigSchema = z
         "Extra key/value metadata tags attached to the provisioned LiteLLM " +
         "virtual key. Merged per-key across cascade layers (agent wins).",
       ),
+    max_budget: z
+      .number()
+      .positive()
+      .optional()
+      .describe(
+        "HARD spend cap in USD for this agent's virtual key over one " +
+        "`budget_duration` window. LiteLLM refuses the request once the key's " +
+        "tracked spend exceeds it, so a runaway loop costs at most this much " +
+        "before it is stopped. Defaults to " +
+        "DEFAULT_KEY_MAX_BUDGET_USD (see src/litellm/budget.ts) — deliberately " +
+        "conservative; raise it per-agent rather than removing it. Set 0 or " +
+        "omit `budget_duration` at your own risk: an uncapped key is only as " +
+        "bounded as the upstream account balance.",
+      ),
+    soft_budget: z
+      .number()
+      .positive()
+      .optional()
+      .describe(
+        "ADVISORY spend threshold in USD. LiteLLM keeps serving past it and " +
+        "raises a budget alert instead. Must be < max_budget. NOTE: LiteLLM " +
+        "accepts soft_budget only on POST /key/generate (GenerateKeyRequest); " +
+        "UpdateKeyRequest does NOT carry it, so changing this value only takes " +
+        "effect on a key that is (re)generated, not on an existing one.",
+      ),
+    budget_duration: z
+      .string()
+      .regex(
+        /^\d+(s|m|h|d|mo)$/,
+        "budget_duration must be a LiteLLM duration like '30d', '24h', '1mo'",
+      )
+      .optional()
+      .describe(
+        "Rolling window the budget resets on, in LiteLLM duration syntax " +
+        "('30d', '24h', '1mo'). Defaults to DEFAULT_KEY_BUDGET_DURATION. " +
+        "WITHOUT a duration LiteLLM treats max_budget as a LIFETIME cap that " +
+        "never resets — the key silently dies for good once it is hit.",
+      ),
   })
   .optional()
   .describe(

--- a/src/litellm/budget.test.ts
+++ b/src/litellm/budget.test.ts
@@ -1,0 +1,238 @@
+/**
+ * budget.test.ts — outcome tests for the per-agent LiteLLM virtual-key spend
+ * caps.
+ *
+ * THE RISK. A per-agent virtual key without a budget is a bearer token for the
+ * whole upstream account balance. A runaway loop or a compromised agent can
+ * spend it all, and the first symptom is every OTHER agent failing — they share
+ * that balance. These assert the OBSERVABLE result: the exact JSON that reaches
+ * LiteLLM's `/key/generate` and `/key/update`, because that payload is the only
+ * thing that actually enforces anything.
+ *
+ * The LiteLLM contract asserted here was read from `litellm/proxy/_types.py`
+ * on 2026-07-28:
+ *   GenerateRequestBase.max_budget      → /key/generate ✅  /key/update ✅
+ *   GenerateRequestBase.budget_duration → /key/generate ✅  /key/update ✅
+ *   GenerateKeyRequest.soft_budget      → /key/generate ✅  /key/update ❌
+ * (`UpdateKeyRequest` extends `KeyRequestBase`, a SIBLING of
+ * `GenerateKeyRequest` — so `soft_budget` has no update path at all.)
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  DEFAULT_KEY_BUDGET_DURATION,
+  DEFAULT_KEY_MAX_BUDGET_USD,
+  DEFAULT_KEY_SOFT_BUDGET_USD,
+  describeKeyBudget,
+  resolveKeyBudget,
+} from "./budget.js";
+import { ensureKey, updateKeyBudget, type FetchFn } from "./provision.js";
+
+/** Capture the exact body posted to LiteLLM. */
+function recordingFetch(
+  respond: (url: string) => { status: number; body: unknown },
+): { fetchFn: FetchFn; calls: Array<{ url: string; body: Record<string, unknown> }> } {
+  const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+  const fetchFn = (async (url: string, init?: { body?: string }) => {
+    calls.push({ url, body: JSON.parse(init?.body ?? "{}") });
+    const r = respond(url);
+    return {
+      ok: r.status >= 200 && r.status < 300,
+      status: r.status,
+      json: async () => r.body,
+      text: async () => JSON.stringify(r.body),
+    } as unknown as Response;
+  }) as unknown as FetchFn;
+  return { fetchFn, calls };
+}
+
+const OK_KEY = { status: 200, body: { key: "sk-fake-virtual-key" } };
+
+describe("resolveKeyBudget — a misconfiguration degrades toward SAFER", () => {
+  it("caps by DEFAULT when config says nothing (opting out must be explicit)", () => {
+    const b = resolveKeyBudget(undefined);
+    expect(b).not.toBeNull();
+    expect(b!.maxBudget).toBe(DEFAULT_KEY_MAX_BUDGET_USD);
+    expect(b!.softBudget).toBe(DEFAULT_KEY_SOFT_BUDGET_USD);
+    expect(b!.budgetDuration).toBe(DEFAULT_KEY_BUDGET_DURATION);
+  });
+
+  it("ALWAYS pairs a window with a cap — a lifetime cap is a permanent kill-switch", () => {
+    // LiteLLM never resets a max_budget that has no budget_duration, so the key
+    // dies for good the first time it is reached. There must be no config path
+    // that produces one.
+    for (const cfg of [
+      undefined,
+      {},
+      { max_budget: 5 },
+      { max_budget: 5, soft_budget: 1 },
+      { budget_duration: "" },
+    ]) {
+      const b = resolveKeyBudget(cfg);
+      if (b == null) continue;
+      expect(b.budgetDuration.length, `no window for ${JSON.stringify(cfg)}`).toBeGreaterThan(0);
+    }
+  });
+
+  it("treats max_budget: 0 as 'uncapped' rather than 'zero dollars'", () => {
+    // A literal 0 sent to LiteLLM would block EVERY request instantly. The only
+    // safe reading of 0 is the explicit opt-out.
+    expect(resolveKeyBudget({ max_budget: 0 })).toBeNull();
+    expect(resolveKeyBudget({ max_budget: -5 })).toBeNull();
+  });
+
+  it("drops a soft budget that could never fire before the hard stop", () => {
+    expect(resolveKeyBudget({ max_budget: 10, soft_budget: 10 })?.softBudget).toBeUndefined();
+    expect(resolveKeyBudget({ max_budget: 10, soft_budget: 25 })?.softBudget).toBeUndefined();
+    expect(resolveKeyBudget({ max_budget: 10, soft_budget: 4 })?.softBudget).toBe(4);
+  });
+
+  it("keeps the default soft budget strictly under the default hard cap", () => {
+    expect(DEFAULT_KEY_SOFT_BUDGET_USD).toBeLessThan(DEFAULT_KEY_MAX_BUDGET_USD);
+  });
+
+  it("honours an explicit per-agent override", () => {
+    const b = resolveKeyBudget({ max_budget: 100, soft_budget: 80, budget_duration: "1mo" });
+    expect(b).toEqual({ maxBudget: 100, softBudget: 80, budgetDuration: "1mo" });
+  });
+
+  it("describes the cap for the apply transcript", () => {
+    expect(describeKeyBudget(resolveKeyBudget({ max_budget: 10, soft_budget: 4 }))).toBe(
+      "cap $10/30d, alert at $4",
+    );
+    expect(describeKeyBudget(null)).toContain("no spend cap");
+  });
+});
+
+describe("/key/generate carries the full cap", () => {
+  it("posts max_budget, budget_duration AND soft_budget", async () => {
+    const { fetchFn, calls } = recordingFetch(() => OK_KEY);
+    await ensureKey(
+      {
+        baseUrl: "http://proxy:4010",
+        masterKey: "sk-master",
+        alias: "agent:klanker",
+        budget: resolveKeyBudget(undefined)!,
+      },
+      fetchFn,
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("http://proxy:4010/key/generate");
+    expect(calls[0].body.max_budget).toBe(DEFAULT_KEY_MAX_BUDGET_USD);
+    expect(calls[0].body.budget_duration).toBe(DEFAULT_KEY_BUDGET_DURATION);
+    expect(calls[0].body.soft_budget).toBe(DEFAULT_KEY_SOFT_BUDGET_USD);
+  });
+
+  it("never posts a cap with no window", async () => {
+    const { fetchFn, calls } = recordingFetch(() => OK_KEY);
+    await ensureKey(
+      {
+        baseUrl: "http://proxy:4010",
+        masterKey: "sk-master",
+        alias: "agent:klanker",
+        budget: { maxBudget: 7, budgetDuration: "24h" },
+      },
+      fetchFn,
+    );
+    expect(calls[0].body.max_budget).toBe(7);
+    expect(calls[0].body.budget_duration).toBe("24h");
+    // No soft budget configured ⇒ the field is absent, not null/0.
+    expect("soft_budget" in calls[0].body).toBe(false);
+  });
+
+  it("sends NO budget fields at all for an explicitly uncapped key", async () => {
+    // Sending max_budget: 0 would block every request — an uncapped key must
+    // simply omit the fields.
+    const { fetchFn, calls } = recordingFetch(() => OK_KEY);
+    await ensureKey(
+      { baseUrl: "http://proxy:4010", masterKey: "sk-master", alias: "agent:klanker" },
+      fetchFn,
+    );
+    for (const field of ["max_budget", "soft_budget", "budget_duration"]) {
+      expect(field in calls[0].body, `${field} leaked onto an uncapped key`).toBe(false);
+    }
+  });
+});
+
+describe("/key/update heals an EXISTING key — the pre-existing-agent case", () => {
+  it("posts max_budget + budget_duration for a key already in the vault", async () => {
+    const { fetchFn, calls } = recordingFetch(() => ({ status: 200, body: {} }));
+    const res = await updateKeyBudget(
+      {
+        baseUrl: "http://proxy:4010",
+        masterKey: "sk-master",
+        key: "sk-existing",
+        budget: { maxBudget: 25, softBudget: 15, budgetDuration: "30d" },
+      },
+      fetchFn,
+    );
+    expect(res.kind).toBe("ok");
+    expect(calls[0].url).toBe("http://proxy:4010/key/update");
+    expect(calls[0].body).toMatchObject({
+      key: "sk-existing",
+      max_budget: 25,
+      budget_duration: "30d",
+    });
+  });
+
+  it("does NOT post soft_budget — UpdateKeyRequest has no such field", async () => {
+    // Verified against litellm/proxy/_types.py: UpdateKeyRequest extends
+    // KeyRequestBase, a SIBLING of GenerateKeyRequest. Sending soft_budget here
+    // would be silently ignored, leaving the operator believing an advisory
+    // alert was armed when none was.
+    const { fetchFn, calls } = recordingFetch(() => ({ status: 200, body: {} }));
+    await updateKeyBudget(
+      {
+        baseUrl: "http://proxy:4010",
+        masterKey: "sk-master",
+        key: "sk-existing",
+        budget: { maxBudget: 25, softBudget: 15, budgetDuration: "30d" },
+      },
+      fetchFn,
+    );
+    expect("soft_budget" in calls[0].body).toBe(false);
+  });
+
+  it("is LOUD, not fatal, when the proxy refuses the cap", async () => {
+    const { fetchFn } = recordingFetch(() => ({ status: 500, body: { error: "boom" } }));
+    const res = await updateKeyBudget(
+      {
+        baseUrl: "http://proxy:4010",
+        masterKey: "sk-master",
+        key: "sk-existing",
+        budget: { maxBudget: 25, budgetDuration: "30d" },
+      },
+      fetchFn,
+    );
+    expect(res.kind).toBe("error");
+    expect(res.kind === "error" && res.detail).toContain("500");
+  });
+
+  it("never throws on a transport failure (apply must not die on a cap)", async () => {
+    const fetchFn = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as FetchFn;
+    const res = await updateKeyBudget(
+      {
+        baseUrl: "http://proxy:4010",
+        masterKey: "sk-master",
+        key: "sk-existing",
+        budget: { maxBudget: 25, budgetDuration: "30d" },
+      },
+      fetchFn,
+    );
+    expect(res.kind).toBe("error");
+  });
+});
+
+describe("the default is conservative but usable", () => {
+  it("is a real number of dollars, not unlimited and not pennies", () => {
+    expect(DEFAULT_KEY_MAX_BUDGET_USD).toBeGreaterThan(0);
+    expect(DEFAULT_KEY_MAX_BUDGET_USD).toBeLessThanOrEqual(50);
+  });
+
+  it("resets on a window that matches how the upstream accounts are billed", () => {
+    expect(DEFAULT_KEY_BUDGET_DURATION).toMatch(/^\d+(s|m|h|d|mo)$/);
+  });
+});

--- a/src/litellm/budget.ts
+++ b/src/litellm/budget.ts
@@ -1,0 +1,132 @@
+/**
+ * budget.ts — the spend caps switchroom puts on every per-agent LiteLLM
+ * virtual key, and the one place their defaults are decided.
+ *
+ * WHY
+ * ---
+ * A per-agent virtual key is, without a budget, a bearer token for the whole
+ * upstream account balance. A runaway loop, a mis-tuned retry, or a
+ * compromised agent can spend the entire OpenRouter/OpenAI balance before
+ * anyone notices — and the first symptom is every OTHER agent failing, because
+ * they share that balance. A cap converts an unbounded fleet-wide outage into a
+ * bounded, single-agent one that names its own cause.
+ *
+ * VERIFIED AGAINST LITELLM SOURCE (`litellm/proxy/_types.py`, read 2026-07-28):
+ *   - `GenerateRequestBase.max_budget: Optional[float]`      → /key/generate ✅ /key/update ✅
+ *   - `GenerateRequestBase.budget_duration: Optional[str]`   → /key/generate ✅ /key/update ✅
+ *   - `GenerateKeyRequest.soft_budget: Optional[float]`      → /key/generate ✅ /key/update ❌
+ *
+ * That last row is a real constraint, not an oversight: `UpdateKeyRequest`
+ * extends `KeyRequestBase`, NOT `GenerateKeyRequest`, so `soft_budget` has no
+ * update path. Changing it takes effect only when a key is (re)generated. The
+ * hard cap and the window CAN be healed onto an existing key — which is why
+ * `updateKeyBudget` exists and only sends those two.
+ *
+ * WHY THESE DEFAULTS
+ * ------------------
+ * `max_budget` USD per `budget_duration`. The numbers are chosen to be
+ * CONSERVATIVE-BUT-NOT-ANNOYING: high enough that ordinary agent work never
+ * touches them, low enough that hitting one is unambiguous evidence of a
+ * runaway rather than a busy week.
+ *
+ *  - Anthropic traffic is subscription-funded through the OAuth passthrough and
+ *    is NOT metered by these keys, so the cap only governs the paid third-party
+ *    lane (OpenRouter et al.) — a lane whose normal fleet usage is small.
+ *  - A 30-day window matches how the underlying provider accounts are topped
+ *    up and billed, so "spent the month's allowance" and "hit the cap" line up.
+ *  - A LIFETIME cap (a `max_budget` with NO `budget_duration`) is the trap
+ *    here: LiteLLM never resets it, so the key permanently dies the first time
+ *    it is reached. Both are always sent together for exactly that reason.
+ *
+ * The default is a floor, not a ceiling: raise it per-agent in
+ * `switchroom.yaml` (`litellm.max_budget`) for an agent that genuinely needs
+ * more. Removing the cap entirely is possible but is a decision, not a default.
+ *
+ * NOT COVERED BY THIS FILE — the per-key credit limit in the OPENROUTER
+ * DASHBOARD is a separate, provider-side control that switchroom cannot set:
+ * OpenRouter exposes no API to create or limit provisioning keys. Setting it is
+ * a MANUAL OPERATOR ACTION at https://openrouter.ai/settings/keys. The LiteLLM
+ * cap here bounds what one AGENT can spend; the dashboard limit bounds what the
+ * whole PROXY can spend if its key ever leaks. They are complementary.
+ */
+
+/**
+ * Hard cap, USD, per window, for one agent's virtual key.
+ *
+ * 25 USD / 30 days. Sizing: fleet third-party (non-Anthropic) spend runs at
+ * cents-to-low-dollars per agent-month in normal operation, so this is roughly
+ * an order of magnitude of headroom — a busy month cannot trip it, while a
+ * runaway loop trips it in hours instead of draining the account.
+ */
+export const DEFAULT_KEY_MAX_BUDGET_USD = 25;
+
+/**
+ * Advisory threshold, USD. Crossing it raises a LiteLLM budget alert while the
+ * key keeps working — the warning shot before the hard stop. 60% of the hard
+ * cap leaves real time to react.
+ */
+export const DEFAULT_KEY_SOFT_BUDGET_USD = 15;
+
+/**
+ * Rolling reset window, LiteLLM duration syntax. NEVER leave this unset
+ * alongside a `max_budget`: LiteLLM then treats the cap as a lifetime budget
+ * that never resets, and the key dies permanently the first time it is hit.
+ */
+export const DEFAULT_KEY_BUDGET_DURATION = "30d";
+
+/** The resolved caps applied to one key. */
+export interface KeyBudget {
+  maxBudget: number;
+  softBudget?: number;
+  budgetDuration: string;
+}
+
+/** Config shape as it arrives from `switchroom.yaml`'s `litellm:` block. */
+export interface KeyBudgetConfig {
+  max_budget?: number;
+  soft_budget?: number;
+  budget_duration?: string;
+}
+
+/**
+ * Resolve the caps for one key from config + defaults.
+ *
+ * Rules, all of them chosen so a misconfiguration degrades toward SAFER rather
+ * than toward unbounded:
+ *  - an absent `max_budget` takes the conservative default (opting OUT is
+ *    explicit: `max_budget: 0`);
+ *  - `max_budget: 0` (or negative) means "no cap" and returns `null` — the
+ *    caller then sends no budget fields at all, so LiteLLM is not handed a
+ *    zero-dollar budget that would block every request;
+ *  - a `budget_duration` is ALWAYS emitted alongside a cap, so a cap can never
+ *    silently become a permanent lifetime kill-switch;
+ *  - a `soft_budget` at or above the hard cap is dropped rather than sent: it
+ *    could never fire before the hard stop, and shipping a dead alert is worse
+ *    than shipping none.
+ */
+export function resolveKeyBudget(config: KeyBudgetConfig | undefined): KeyBudget | null {
+  const raw = config?.max_budget;
+  const maxBudget = raw === undefined ? DEFAULT_KEY_MAX_BUDGET_USD : raw;
+  if (!Number.isFinite(maxBudget) || maxBudget <= 0) return null;
+
+  const budgetDuration =
+    config?.budget_duration && config.budget_duration.length > 0
+      ? config.budget_duration
+      : DEFAULT_KEY_BUDGET_DURATION;
+
+  const rawSoft = config?.soft_budget ?? DEFAULT_KEY_SOFT_BUDGET_USD;
+  const softBudget =
+    Number.isFinite(rawSoft) && rawSoft > 0 && rawSoft < maxBudget ? rawSoft : undefined;
+
+  return { maxBudget, softBudget, budgetDuration };
+}
+
+/**
+ * Human summary for the `switchroom apply` transcript. The operator should be
+ * able to read what cap landed without querying the proxy.
+ */
+export function describeKeyBudget(budget: KeyBudget | null): string {
+  if (budget == null) return "no spend cap (uncapped key)";
+  const soft = budget.softBudget != null ? `, alert at $${budget.softBudget}` : "";
+  return `cap $${budget.maxBudget}/${budget.budgetDuration}${soft}`;
+}

--- a/src/litellm/provision.ts
+++ b/src/litellm/provision.ts
@@ -49,6 +49,8 @@
  * `preconnect` that a test mock can't satisfy). Defaults to the global
  * `fetch`.
  */
+import type { KeyBudget } from "./budget.js";
+
 export type FetchFn = (
   url: string,
   init?: { method?: string; headers?: Record<string, string>; body?: string },
@@ -89,6 +91,14 @@ export interface EnsureKeyOpts {
   teamId?: string;
   /** Arbitrary metadata tags attached to the key. */
   metadata?: Record<string, string>;
+  /**
+   * Spend caps for this key (see `./budget.ts`). Omit ⇒ an UNCAPPED key, which
+   * is a bearer token for the whole upstream account balance. `soft_budget` is
+   * sent ONLY here: LiteLLM's `UpdateKeyRequest` does not carry it (verified
+   * against `litellm/proxy/_types.py`), so it can never be healed onto an
+   * existing key — only `max_budget` / `budget_duration` can (`updateKeyBudget`).
+   */
+  budget?: KeyBudget;
   /**
    * Optional structured logger for the orphaned-alias self-heal path (delete +
    * regenerate). Defaults to a no-op — the module stays quiet on the happy path.
@@ -320,6 +330,14 @@ async function generateKeyOnce(opts: EnsureKeyOpts, fetchFn: FetchFn): Promise<G
   if (opts.teamId) payload.team_id = opts.teamId;
   if (opts.metadata && Object.keys(opts.metadata).length > 0) {
     payload.metadata = opts.metadata;
+  }
+  // Spend caps. `budget_duration` is ALWAYS sent alongside `max_budget`:
+  // without it LiteLLM treats the cap as a LIFETIME budget that never resets,
+  // and the key dies permanently the first time it is hit.
+  if (opts.budget) {
+    payload.max_budget = opts.budget.maxBudget;
+    payload.budget_duration = opts.budget.budgetDuration;
+    if (opts.budget.softBudget != null) payload.soft_budget = opts.budget.softBudget;
   }
 
   let resp: Response;
@@ -731,4 +749,65 @@ async function safeText(resp: Response): Promise<string> {
   } catch {
     return "";
   }
+}
+
+export interface UpdateKeyBudgetOpts {
+  baseUrl: string;
+  masterKey: string;
+  /** The existing virtual key string to re-cap. */
+  key: string;
+  /** The caps to write. */
+  budget: KeyBudget;
+}
+
+/** Outcome of a budget-only /key/update. */
+export type UpdateKeyBudgetResult =
+  | { kind: "ok" }
+  | { kind: "error"; detail: string };
+
+/**
+ * Apply spend caps to an EXISTING virtual key in place via
+ * POST /key/update {key, max_budget, budget_duration}.
+ *
+ * Why this is needed: keys provisioned before spend caps existed are stored in
+ * the vault and are NOT regenerated on a later apply (the caller checks the
+ * vault first and short-circuits). Without this, every pre-existing key would
+ * stay uncapped forever and the feature would only protect new agents.
+ *
+ * Contract verified against LiteLLM `litellm/proxy/_types.py` (read 2026-07-28):
+ * `UpdateKeyRequest` extends `KeyRequestBase` → `GenerateRequestBase`, which
+ * carries `max_budget: Optional[float]` and `budget_duration: Optional[str]`.
+ *
+ * `soft_budget` is DELIBERATELY NOT SENT. It lives on `GenerateKeyRequest`, a
+ * SIBLING of `UpdateKeyRequest`, not an ancestor — so the update endpoint has
+ * no such field and would silently ignore it. Sending it would let the caller
+ * believe an advisory alert had been armed when none had. An existing key can
+ * only gain a soft budget by being regenerated.
+ *
+ * Best-effort + LOUD on failure: never throws, never deletes or regenerates the
+ * key — returns a structured error the caller surfaces as a warning.
+ */
+export async function updateKeyBudget(
+  opts: UpdateKeyBudgetOpts,
+  fetchFn: FetchFn = fetch,
+): Promise<UpdateKeyBudgetResult> {
+  const url = `${normalizeBase(opts.baseUrl)}/key/update`;
+  let resp: Response;
+  try {
+    resp = await fetchFn(url, {
+      method: "POST",
+      headers: authHeaders(opts.masterKey),
+      body: JSON.stringify({
+        key: opts.key,
+        max_budget: opts.budget.maxBudget,
+        // Always paired — a cap with no window is a permanent kill-switch.
+        budget_duration: opts.budget.budgetDuration,
+      }),
+    });
+  } catch (err) {
+    return { kind: "error", detail: (err as Error).message };
+  }
+  if (resp.ok) return { kind: "ok" };
+  const body = await safeText(resp);
+  return { kind: "error", detail: `HTTP ${resp.status}: ${body.slice(0, 200)}` };
 }


### PR DESCRIPTION
## What

Puts a **conservative spend cap on every per-agent LiteLLM virtual key**, configurable in `switchroom.yaml`, and heals the cap onto keys that already exist.

## Why

A per-agent virtual key with no budget is a bearer token for the **whole upstream account balance**. A runaway loop, a mis-tuned retry, or a compromised agent can spend it all — and the first symptom is *every other agent* failing, because they share that balance. A cap converts an unbounded fleet-wide outage into a bounded, single-agent one that names its own cause.

## LiteLLM contract — verified, not assumed

Read from `litellm/proxy/_types.py` on 2026-07-28:

| field | `/key/generate` | `/key/update` |
|---|---|---|
| `max_budget` (`GenerateRequestBase`) | ✅ | ✅ |
| `budget_duration` (`GenerateRequestBase`) | ✅ | ✅ |
| `soft_budget` (`GenerateKeyRequest`) | ✅ | ❌ |

That last row is a real constraint, not an oversight: `UpdateKeyRequest` extends `KeyRequestBase`, a **sibling** of `GenerateKeyRequest` — so `soft_budget` has no update path at all. `updateKeyBudget` therefore sends only the hard cap and the window, and `apply` says so out loud rather than pretending an advisory alert was armed.

## Defaults, and why

`src/litellm/budget.ts`: **$25 hard cap / 30d, $15 soft alert.**

Anthropic traffic is subscription-funded through the OAuth passthrough and is **not metered by these keys**, so the cap only governs the paid third-party lane (OpenRouter et al.), whose normal usage is cents-to-low-dollars per agent-month. That is roughly an order of magnitude of headroom: a busy month cannot trip it, while a runaway loop trips it in hours instead of draining the account. The 30-day window matches how the upstream accounts are topped up and billed.

Override per-agent: `litellm.max_budget` / `soft_budget` / `budget_duration`.

## Safe-by-default degradation (each asserted)

- absent config ⇒ the conservative default — **opting out is explicit**;
- `max_budget: 0` ⇒ **no budget fields sent at all**, because a literal zero cap would block every request instantly;
- a window is **always** paired with a cap — LiteLLM never resets a `max_budget` that has no `budget_duration`, so a bare cap is a permanent kill-switch the first time it is hit;
- a soft budget ≥ the hard cap is **dropped**, not sent — a dead alert is worse than none.

## Existing keys are healed

Keys already in the vault are never regenerated (apply short-circuits on the vault check), so without the `/key/update` heal every pre-existing agent would stay uncapped forever and this would protect only new agents. Best-effort and **loud**: a failed cap warns with the manual `curl` and never fails the apply.

## ⚠️ Manual operator action Ken must do himself

The **per-key credit limit in the OpenRouter dashboard** is a provider-side control with **no API** — OpenRouter exposes no way to create or limit keys programmatically, so switchroom cannot set it. That one is Ken's own action at <https://openrouter.ai/settings/keys>.

The two are complementary: the LiteLLM cap bounds what **one agent** can spend; the dashboard limit bounds what the **whole proxy** can spend if its key ever leaks.

## Tests

16 tests asserting the **exact JSON** that reaches `/key/generate` and `/key/update` — that payload is the only thing that actually enforces anything.

**Mutation results** — every one killed tests, baseline restored 16/16:

| mutation | result |
|---|---|
| M1 default becomes uncapped | 2 failed |
| M2 `max_budget: 0` sent as a literal zero cap | 1 failed |
| M3 drop `budget_duration` (lifetime kill-switch) | 2 failed |
| M4 send `soft_budget` on `/key/update` | 1 failed |
| M5 emit budget fields on an uncapped key | 1 failed |
| M6 allow `soft_budget` ≥ `max_budget` (dead alert) | 1 failed |

## Checks

- `npx vitest run src/litellm/ src/config/` — 580 passed (24 files)
- `npm run lint` (tsc + 19 guards) — green
- `src/cli/apply.test.ts` fails **identically on `origin/main`** in this sandbox (`EROFS: read-only file system, .../switchroom-invariants.md`) — environmental, not caused by this change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
