### PR TITLE
feat(openrouter): see the credit shortfall coming, and say so honestly

### DIFF
--- a/src/cli/doctor-openrouter-credit.ts
+++ b/src/cli/doctor-openrouter-credit.ts
@@ -1,0 +1,118 @@
+/**
+ * OpenRouter credit doctor check.
+ *
+ * PR #3868 made a spent OpenRouter balance visible AFTER it breaks a request
+ * (raw 402 → operator card, never to an end user). This is the proactive half:
+ * see the shortfall coming.
+ *
+ * The interesting outcome is the one that will actually apply to the fleet
+ * today — a key with NO per-key credit limit. `GET /api/v1/key` reports
+ * `limit`/`limit_remaining` as `null` for an uncapped key and carries no
+ * account-balance field at all, so there is genuinely nothing to threshold.
+ * This check says exactly that, as a WARN with the console action, rather than
+ * a green tick that means nothing. See `src/openrouter/credit.ts` for the
+ * verified endpoint contract.
+ *
+ * The API key is read through the NORMAL vault path at runtime (injected here
+ * as `readSecret`, so tests drive every branch with a fake and no live
+ * credential is ever needed). The key VALUE is never logged, never returned,
+ * and never placed in a check `detail` — only the vault key NAME appears.
+ */
+
+import type { CheckStatus } from "./doctor-status.js";
+import {
+  OPENROUTER_VAULT_KEY,
+  assessFetchFailure,
+  evaluateCredit,
+  fetchKeySnapshot,
+  type CreditFetchFn,
+} from "../openrouter/credit.js";
+
+/** Mirror of `CheckResult` in doctor.ts (imported there, not from there — the
+ *  doctor modules avoid a circular import by re-declaring the shape). */
+export interface OpenRouterCheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+export interface OpenRouterCreditDeps {
+  /**
+   * Read a secret by vault key NAME. Returns `null` when no grant/entry
+   * exists. Injected so this module never touches the vault directly and tests
+   * need no credential.
+   */
+  readSecret: (key: string) => Promise<string | null>;
+  fetchFn: CreditFetchFn;
+  /** True when the fleet actually routes through OpenRouter. */
+  enabled: boolean;
+}
+
+const CHECK_NAME = "OpenRouter credit";
+
+/**
+ * Returns exactly one result. Never throws — doctor sections must not be able
+ * to abort the run.
+ */
+export async function runOpenRouterCreditChecks(
+  deps: OpenRouterCreditDeps,
+): Promise<OpenRouterCheckResult[]> {
+  if (!deps.enabled) {
+    return [
+      {
+        name: CHECK_NAME,
+        status: "skip",
+        detail: "No OpenRouter-backed model is configured in the LiteLLM proxy config.",
+      },
+    ];
+  }
+
+  let apiKey: string | null;
+  try {
+    apiKey = await deps.readSecret(OPENROUTER_VAULT_KEY);
+  } catch (err) {
+    return [
+      {
+        name: CHECK_NAME,
+        status: "skip",
+        detail: `Could not read vault key \`${OPENROUTER_VAULT_KEY}\` (${(err as Error).message}).`,
+      },
+    ];
+  }
+
+  if (!apiKey) {
+    return [
+      {
+        name: CHECK_NAME,
+        status: "warn",
+        detail:
+          `The proxy routes through OpenRouter but vault key \`${OPENROUTER_VAULT_KEY}\` is not ` +
+          `readable here, so credit cannot be monitored.`,
+        fix: `Grant read access to \`${OPENROUTER_VAULT_KEY}\`, or store it if it is missing.`,
+      },
+    ];
+  }
+
+  const fetched = await fetchKeySnapshot(apiKey, deps.fetchFn);
+  const assessment =
+    fetched.kind === "ok" ? evaluateCredit(fetched.snapshot) : assessFetchFailure(fetched);
+
+  return [
+    {
+      name: CHECK_NAME,
+      status: assessment.status,
+      detail: assessment.detail,
+      ...(assessment.fix ? { fix: assessment.fix } : {}),
+    },
+  ];
+}
+
+/**
+ * Does the LiteLLM proxy config route anything through OpenRouter? Reads the
+ * config TEXT rather than parsing, so it works on a partially-valid file.
+ */
+export function usesOpenRouter(litellmConfigText: string | null): boolean {
+  if (!litellmConfigText) return false;
+  return litellmConfigText.includes("openrouter/") || litellmConfigText.includes("OPENROUTER_API_KEY");
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -52,6 +52,7 @@ import { runAuthBrokerChecks } from "./doctor-auth-broker.js";
 import { runHostdChecks } from "./doctor-hostd.js";
 import { runDriveChecks, runDriveBrokerReachabilityChecks } from "./doctor-drive.js";
 import { runWebkiteChecks } from "./doctor-webkite.js";
+import { runOpenRouterCreditChecks, usesOpenRouter } from "./doctor-openrouter-credit.js";
 import { runCronSessionChecks } from "./doctor-cron-session.js";
 import { runFloodPressureChecks } from "./doctor-flood-pressure.js";
 import { runGeneratedSurfaceDriftChecks } from "./doctor-drift.js";
@@ -79,6 +80,27 @@ import { runClaudeCliVersionChecks } from "./doctor-claude-cli.js";
  * `CheckStatus` + `statusGlyph` live in ./doctor-status.ts (imported
  * above) so the 9 doctor modules share one definition.
  */
+/**
+ * Read the repo/host LiteLLM proxy config text, or null when there is none.
+ * Text, not YAML — the caller only substring-matches, so a partially-valid
+ * file still answers the question.
+ */
+function readLitellmConfigText(): string | null {
+  const candidates = [
+    process.env.LITELLM_CONFIG_PATH,
+    "/data/coolify/services/litellm/litellm-config.yaml",
+    join(process.cwd(), "docker", "litellm-proxy", "litellm-config.yaml"),
+  ].filter((p): p is string => typeof p === "string" && p.length > 0);
+  for (const p of candidates) {
+    try {
+      if (existsSync(p)) return readFileSync(p, "utf-8");
+    } catch {
+      // unreadable — try the next candidate
+    }
+  }
+  return null;
+}
+
 export interface CheckResult {
   name: string;
   status: CheckStatus;
@@ -3767,6 +3789,32 @@ export function registerDoctorCommand(program: Command): void {
           },
           { title: "MFF Skill", results: await checkMff(passphrase, vaultPath, config) },
           { title: "Webkite", results: runWebkiteChecks(config) },
+          {
+            // Proactive half of the OpenRouter credit work (#3868 is the
+            // reactive half). NOTE: this reports WARN — not a green tick —
+            // when the key has no per-key credit limit, because GET
+            // /api/v1/key then returns nulls and carries no account-balance
+            // field, so there is genuinely nothing to threshold. A monitor
+            // that passes when it cannot see manufactures confidence.
+            title: "OpenRouter Credit",
+            results: await runOpenRouterCreditChecks({
+              enabled: usesOpenRouter(readLitellmConfigText()),
+              readSecret: async (key) => {
+                try {
+                  const { getViaBrokerStructured } = await import("../vault/broker/client.js");
+                  const result = await getViaBrokerStructured(key);
+                  if (result.kind === "ok" && result.entry.kind === "string") {
+                    return result.entry.value;
+                  }
+                  return null;
+                } catch {
+                  return null;
+                }
+              },
+              fetchFn: (url, init) =>
+                fetch(url, { headers: init?.headers, signal: init?.signal ?? AbortSignal.timeout(10_000) }),
+            }),
+          },
           // #2307 Tier-1: cron-session bridge liveness. Empty (no results) for
           // the fleet today — only agents the value-gate routes to a cron
           // session produce a line.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -47,6 +47,7 @@ import { registerWebdCommand } from "./webd.js";
 import { registerHostCommand } from "./host-repair.js";
 import { registerFleetHealthCommand } from "./fleet-health.js";
 import { registerHindsightWatchCommand } from "./hindsight-watch.js";
+import { registerOpenRouterWatchCommand } from "./openrouter-watch.js";
 import { captureEvent, installGlobalErrorHandlers } from "../analytics/posthog.js";
 
 installGlobalErrorHandlers();
@@ -121,3 +122,4 @@ registerWebdCommand(program);
 registerHostCommand(program);
 registerFleetHealthCommand(program);
 registerHindsightWatchCommand(program);
+registerOpenRouterWatchCommand(program);

--- a/src/cli/openrouter-watch.ts
+++ b/src/cli/openrouter-watch.ts
@@ -1,0 +1,241 @@
+import { existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import type { Command } from "commander";
+import chalk from "chalk";
+
+import {
+  postOperatorNoticeViaGateways,
+  type GatewayCandidate,
+} from "../host-control/config-degraded.js";
+import { CRON_PATH, CRON_SCHEDULE, installCron } from "../openrouter/install-cron.js";
+import { tick } from "../openrouter/run.js";
+import { defaultStatePath } from "../openrouter/state.js";
+import {
+  FAIL_REMAINING_FRACTION,
+  FAIL_REMAINING_USD,
+  OPENROUTER_VAULT_KEY,
+  WARN_REMAINING_FRACTION,
+  WARN_REMAINING_USD,
+} from "../openrouter/credit.js";
+import { RENOTIFY_MS } from "../openrouter/watch.js";
+
+/**
+ * `switchroom openrouter-watch` — the model-free OpenRouter credit watchdog.
+ *
+ * `switchroom doctor` answers "is credit low right now, when someone asks".
+ * This is the half that answers before anyone asks. Same evaluator
+ * (`src/openrouter/credit.ts`), so a green doctor and a silent watchdog can
+ * never mean different things.
+ *
+ * WHY a host CLI verb on a host cron rather than an agent cron: the check
+ * needs the vault broker and must not depend on a model choosing to speak. An
+ * alert that a model can decline to send is not a monitor. Zero model tokens
+ * per tick — the only outputs are stdout and, at most one per 6 h, a plain
+ * operator DM through an agent's gateway socket (the same relay hostd's
+ * degraded-boot notice uses).
+ *
+ * THE HONEST LIMIT, stated here because it is the case that will actually
+ * apply today: with NO per-key credit limit set on the OpenRouter key,
+ * `GET /api/v1/key` returns `limit`/`limit_remaining` as null and carries no
+ * account-balance field, so there is nothing to threshold. This watchdog then
+ * cannot warn about the account running dry, `switchroom doctor` says so as a
+ * WARN, and this tick deliberately stays silent — a standing configuration
+ * gap is not an incident, and paging about it hourly is how a channel gets
+ * muted. Setting the per-key limit at https://openrouter.ai/settings/keys is
+ * a manual console action; it is what makes proactive monitoring possible at
+ * all.
+ *
+ * Exit codes (cron-meaningful):
+ *   0  — ran, nothing firing
+ *  10  — ran, a credit signal is firing (DM sent, subject to the re-notify window)
+ *   1  — could NOT complete (vault key unreadable, OpenRouter unreachable,
+ *        state unwritable, or an alert that reached no gateway)
+ */
+export function registerOpenRouterWatchCommand(program: Command): void {
+  program
+    .command("openrouter-watch")
+    .description(
+      "Model-free OpenRouter credit watchdog: warns before the key's credit runs out. " +
+        "Alerts at most once per 6h, and escalates immediately.",
+    )
+    .option(
+      "--install-cron",
+      `arm the watchdog: write ${CRON_PATH} (${CRON_SCHEDULE}, flock-guarded) and exit`,
+      false,
+    )
+    .option("--cron-user <user>", "unix user the cron tick runs as (default: current user)")
+    .option("--dry-run", "evaluate and print; send no DM and write no state", false)
+    .option("--json", "emit machine-readable JSON", false)
+    .option("--state <path>", "state file path (default ~/.switchroom/openrouter-watch/state.json)")
+    .option("--agents-dir <path>", "agents scaffold dir (default ~/.switchroom/agents)")
+    .action(async (opts) => {
+      if (opts.installCron) {
+        process.exitCode = runInstallCron(opts.cronUser);
+        return;
+      }
+      const agentsDir: string =
+        opts.agentsDir ??
+        process.env.SWITCHROOM_AGENTS_DIR ??
+        join(process.env.SWITCHROOM_HOME ?? process.env.HOME ?? homedir(), ".switchroom", "agents");
+      const statePath: string = opts.state ?? defaultStatePath();
+      const log = (m: string): void => {
+        process.stderr.write(`${m}\n`);
+      };
+
+      const result = await tick({
+        statePath,
+        dryRun: Boolean(opts.dryRun),
+        log,
+        // The key is read through the NORMAL vault broker path at runtime and
+        // used only as an Authorization header. It is never logged or printed.
+        readSecret: async (key) => {
+          const { getViaBrokerStructured } = await import("../vault/broker/client.js");
+          const res = await getViaBrokerStructured(key);
+          if (res.kind === "ok" && res.entry.kind === "string") return res.entry.value;
+          return null;
+        },
+        fetchFn: (url, init) =>
+          fetch(url, {
+            headers: init?.headers,
+            signal: init?.signal ?? AbortSignal.timeout(10_000),
+          }),
+        notify: (text) => notifyOperator(agentsDir, text, log),
+      });
+
+      if (opts.json) {
+        process.stdout.write(
+          JSON.stringify(
+            {
+              status: result.assessment.status,
+              detail: result.assessment.detail,
+              fix: result.assessment.fix ?? null,
+              actionable: result.assessment.actionable,
+              firing: result.firing,
+              notified: result.notice,
+              delivered: result.delivered,
+              exitCode: result.exitCode,
+              vaultKey: OPENROUTER_VAULT_KEY,
+              thresholds: {
+                warnRemainingFraction: WARN_REMAINING_FRACTION,
+                warnRemainingUsd: WARN_REMAINING_USD,
+                failRemainingFraction: FAIL_REMAINING_FRACTION,
+                failRemainingUsd: FAIL_REMAINING_USD,
+                renotifyMs: RENOTIFY_MS,
+              },
+            },
+            null,
+            2,
+          ) + "\n",
+        );
+      } else {
+        const mark =
+          result.assessment.status === "fail"
+            ? chalk.red("FAIL")
+            : result.assessment.status === "warn"
+              ? chalk.yellow("WARN")
+              : result.assessment.status === "skip"
+                ? chalk.gray("skip")
+                : chalk.green("ok  ");
+        process.stdout.write(`${mark}  ${result.assessment.detail}\n`);
+        if (result.assessment.fix) process.stdout.write(`      → ${result.assessment.fix}\n`);
+        if (result.notice) {
+          const header = opts.dryRun ? "would send" : result.delivered ? "sent" : "UNDELIVERED";
+          process.stdout.write(`\n${chalk.bold(`operator DM ${header}:`)}\n`);
+          process.stdout.write(
+            result.notice.split("\n").map((l) => `  | ${l}`).join("\n") + "\n",
+          );
+        } else if (result.firing) {
+          process.stdout.write(
+            chalk.gray(`      (firing, but already reported within the ${RENOTIFY_MS / 3_600_000}h window)\n`),
+          );
+        }
+      }
+      process.exitCode = result.exitCode;
+    });
+}
+
+/**
+ * `--install-cron`: arm the watchdog.
+ *
+ * Refuses rather than guessing in the two cases where a guess installs a cron
+ * that silently never works — identical reasoning to `hindsight-watch`:
+ * a root tick reads the wrong `$HOME` (so the re-notify ledger lives
+ * somewhere the operator's tooling never looks), and a relative argv[1] under
+ * dev mode produces a cron line that fails on every tick into syslog.
+ */
+function runInstallCron(cronUser?: string): number {
+  const user = cronUser ?? process.env.SUDO_USER ?? process.env.USER ?? process.env.LOGNAME;
+  if (!user || user === "root") {
+    process.stderr.write(
+      chalk.red("openrouter-watch: refusing to install a cron for `root`.\n") +
+        "  The state file and the agents scaffold live under the OPERATOR's " +
+        "~/.switchroom, so a root tick would keep its re-notify ledger somewhere " +
+        "nothing else reads.\n" +
+        "  Re-run with `--cron-user <operator>`.\n",
+    );
+    return 1;
+  }
+
+  const binary = process.env.SWITCHROOM_BINARY ?? "/usr/local/bin/switchroom";
+  if (!binary.startsWith("/")) {
+    process.stderr.write(
+      chalk.red(`openrouter-watch: SWITCHROOM_BINARY must be an absolute path (got ${binary})\n`),
+    );
+    return 1;
+  }
+
+  let res: ReturnType<typeof installCron>;
+  try {
+    res = installCron({ user, binary });
+  } catch (e) {
+    process.stderr.write(
+      chalk.red(`openrouter-watch: could not write ${CRON_PATH}: ${(e as Error).message}\n`) +
+        "  This path needs root; re-run under sudo with `--cron-user <operator>`.\n",
+    );
+    return 1;
+  }
+
+  const verb = res.status === "installed" ? "installed" : "already up to date";
+  process.stdout.write(
+    `${chalk.green("✓")} openrouter-watch cron ${verb} at ${res.path} ` +
+      `(${CRON_SCHEDULE}, as ${user})\n` +
+      `  Verify with: switchroom openrouter-watch --dry-run\n`,
+  );
+  return 0;
+}
+
+/**
+ * Deliver one plain operator DM through the first agent gateway socket that
+ * accepts it. Identical transport to hostd's degraded-boot notice; the gateway
+ * fences delivery to its own operator chat, so this cannot address a foreign
+ * chat.
+ */
+async function notifyOperator(
+  agentsDir: string,
+  text: string,
+  log: (msg: string) => void,
+): Promise<boolean> {
+  const candidates: GatewayCandidate[] = [];
+  try {
+    for (const name of readdirSync(agentsDir).sort()) {
+      const sock = resolve(agentsDir, name, "telegram", "gateway.sock");
+      if (existsSync(sock)) candidates.push({ agent: name, sock });
+    }
+  } catch (e) {
+    log(`openrouter-watch: agents dir unreadable (${(e as Error).message})`);
+  }
+  if (candidates.length === 0) {
+    log("openrouter-watch: no gateway socket found — alert undelivered, will retry next tick");
+    return false;
+  }
+  const agent = await postOperatorNoticeViaGateways(
+    candidates,
+    text,
+    log,
+    5_000,
+    "openrouter-watch",
+    "",
+  );
+  return agent !== null;
+}

--- a/src/openrouter/credit-watch.test.ts
+++ b/src/openrouter/credit-watch.test.ts
@@ -1,0 +1,462 @@
+/**
+ * credit-watch.test.ts — outcome tests for proactive OpenRouter credit
+ * monitoring.
+ *
+ * THE RISK. #3868 made a spent OpenRouter balance visible AFTER it breaks a
+ * request. This is the proactive half, and it has two ways to be worse than
+ * useless:
+ *
+ *   1. It reports GREEN when it cannot actually see anything — the uncapped-key
+ *      case, which is the fleet's default state. That manufactures confidence.
+ *   2. It pages the operator about the same standing fact every hour, which
+ *      trains them to mute the channel.
+ *
+ * So these tests assert the OBSERVABLE result an operator would experience:
+ * the exact `switchroom doctor` line, and the exact operator DM (or the
+ * deliberate absence of one), driven end-to-end through the real state file on
+ * disk. Fakes exist only at the two edges that touch the world — the vault
+ * read and the HTTP GET — so no live credential is ever needed.
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  OPENROUTER_KEY_ENDPOINT,
+  OPENROUTER_VAULT_KEY,
+  evaluateCredit,
+  parseKeySnapshot,
+  type CreditFetchFn,
+} from "./credit.js";
+import { renderCron, installCron, CRON_SCHEDULE } from "./install-cron.js";
+import { tick } from "./run.js";
+import { loadState, saveState } from "./state.js";
+import { RENOTIFY_MS } from "./watch.js";
+import { runOpenRouterCreditChecks, usesOpenRouter } from "../cli/doctor-openrouter-credit.js";
+
+/**
+ * A stand-in for the real API key. Every test asserts this string never
+ * escapes into a doctor line, an operator DM, or a log line.
+ */
+const FAKE_KEY = "sk-or-v1-FAKEKEYVALUE-must-never-be-printed";
+
+const HOUR = 3_600_000;
+
+/** Build a `GET /api/v1/key` body in the documented shape. */
+function keyBody(over: Record<string, unknown> = {}): unknown {
+  return {
+    data: {
+      label: "switchroom-proxy",
+      limit: null,
+      limit_reset: null,
+      limit_remaining: null,
+      include_byok_in_limit: false,
+      usage: 12.34,
+      usage_daily: 1,
+      usage_weekly: 5,
+      usage_monthly: 12,
+      byok_usage: 0,
+      is_free_tier: false,
+      ...over,
+    },
+  };
+}
+
+/** A fetch fake that records the calls it saw. */
+function fakeFetch(
+  respond: (url: string) => { ok?: boolean; status: number; body?: unknown; throws?: Error },
+): { fetchFn: CreditFetchFn; calls: Array<{ url: string; headers?: Record<string, string> }> } {
+  const calls: Array<{ url: string; headers?: Record<string, string> }> = [];
+  const fetchFn: CreditFetchFn = async (url, init) => {
+    calls.push({ url, headers: init?.headers });
+    const r = respond(url);
+    if (r.throws) throw r.throws;
+    return {
+      ok: r.ok ?? (r.status >= 200 && r.status < 300),
+      status: r.status,
+      json: async () => r.body,
+    };
+  };
+  return { fetchFn, calls };
+}
+
+let dir: string;
+let statePath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "openrouter-watch-"));
+  statePath = join(dir, "state.json");
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** Drive one tick with fakes, capturing every DM and log line. */
+async function runTick(opts: {
+  respond: (url: string) => { ok?: boolean; status: number; body?: unknown; throws?: Error };
+  now: number;
+  secret?: string | null;
+  deliver?: boolean;
+  dryRun?: boolean;
+}) {
+  const dms: string[] = [];
+  const logs: string[] = [];
+  const { fetchFn, calls } = fakeFetch(opts.respond);
+  const result = await tick({
+    statePath,
+    readSecret: async (k) => {
+      const secret = opts.secret === undefined ? FAKE_KEY : opts.secret;
+      return k === OPENROUTER_VAULT_KEY ? secret : null;
+    },
+    fetchFn,
+    notify: async (text) => {
+      dms.push(text);
+      return opts.deliver ?? true;
+    },
+    now: () => opts.now,
+    dryRun: opts.dryRun,
+    log: (m) => logs.push(m),
+  });
+  return { result, dms, logs, calls };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("the uncapped key — the case that actually applies today", () => {
+  const uncapped = () => ({ status: 200, body: keyBody() });
+
+  it("doctor reports WARN and says WHY it cannot measure — never a green tick", async () => {
+    const [res] = await runOpenRouterCreditChecks({
+      enabled: true,
+      readSecret: async () => FAKE_KEY,
+      fetchFn: fakeFetch(uncapped).fetchFn,
+    });
+    // The whole point: a monitor that passes when it cannot see is worse than
+    // no monitor, because it manufactures confidence.
+    expect(res.status).toBe("warn");
+    expect(res.status).not.toBe("ok");
+    expect(res.detail).toMatch(/no per-key credit limit/i);
+    expect(res.detail).toMatch(/no account-balance field/i);
+    expect(res.fix).toContain("https://openrouter.ai/settings/keys");
+    expect(res.fix).toMatch(/manual console action/i);
+  });
+
+  it("the scheduled watch stays SILENT about it — a config gap is not an incident", async () => {
+    const { result, dms } = await runTick({ respond: uncapped, now: 1_000_000 });
+    expect(result.assessment.status).toBe("warn");
+    expect(result.assessment.actionable).toBe(false);
+    // Paging hourly, forever, about a fact that will be equally true in six
+    // weeks is exactly how an alert channel gets muted.
+    expect(dms).toEqual([]);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("stays silent across a whole week of hourly ticks", async () => {
+    const dms: string[] = [];
+    for (let h = 0; h < 24 * 7; h++) {
+      const r = await runTick({ respond: uncapped, now: h * HOUR });
+      dms.push(...r.dms);
+    }
+    expect(dms).toEqual([]);
+  });
+});
+
+describe("a quantified shortfall reaches the operator", () => {
+  const low = () => ({
+    status: 200,
+    body: keyBody({ limit: 50, limit_remaining: 6, limit_reset: "monthly", usage: 44 }),
+  });
+  const critical = () => ({
+    status: 200,
+    body: keyBody({ limit: 50, limit_remaining: 2, limit_reset: "monthly", usage: 48 }),
+  });
+  const healthy = () => ({
+    status: 200,
+    body: keyBody({ limit: 50, limit_remaining: 40, limit_reset: "monthly", usage: 10 }),
+  });
+
+  it("DMs once when credit runs low, naming the numbers and the action", async () => {
+    const { result, dms } = await runTick({ respond: low, now: 0 });
+    expect(result.assessment.status).toBe("warn");
+    expect(result.exitCode).toBe(10);
+    expect(dms).toHaveLength(1);
+    expect(dms[0]).toContain("OpenRouter credit");
+    expect(dms[0]).toContain("$6.00 of $50.00 remaining");
+    expect(dms[0]).toContain("https://openrouter.ai/credits");
+  });
+
+  it("escalates to FAIL when a single session could exhaust it", async () => {
+    const { result, dms } = await runTick({ respond: critical, now: 0 });
+    expect(result.assessment.status).toBe("fail");
+    expect(dms[0]).toMatch(/CRITICALLY low/);
+    expect(dms[0]).toMatch(/^🚨/);
+  });
+
+  it("says EXHAUSTED, not merely low, at zero", () => {
+    const a = evaluateCredit(parseKeySnapshot(keyBody({ limit: 50, limit_remaining: 0 }))!);
+    expect(a.status).toBe("fail");
+    expect(a.detail).toMatch(/EXHAUSTED/);
+    expect(a.detail).toMatch(/402/);
+    expect(a.actionable).toBe(true);
+  });
+
+  it("says nothing at all while there is real headroom", async () => {
+    const { result, dms } = await runTick({ respond: healthy, now: 0 });
+    expect(result.assessment.status).toBe("ok");
+    expect(dms).toEqual([]);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("warns on the ABSOLUTE floor even when the percentage looks fine", () => {
+    // $8 of a $20 limit is 40% — a percentage-only rule calls that healthy,
+    // and on a small limit $8 is about a day. The dollar floor is what makes
+    // the warning arrive before the outage rather than after it.
+    const a = evaluateCredit(parseKeySnapshot(keyBody({ limit: 20, limit_remaining: 8 }))!);
+    expect(a.status).toBe("warn");
+    expect(a.actionable).toBe(true);
+    // …and the same shape at the critical floor: 25% of $10 is not "fine".
+    const b = evaluateCredit(parseKeySnapshot(keyBody({ limit: 10, limit_remaining: 2.5 }))!);
+    expect(b.status).toBe("fail");
+  });
+
+  it("warns on the PERCENTAGE even when the dollar figure looks large", () => {
+    // $60 sounds fine until you know the limit is $500 and it is 12% left.
+    const a = evaluateCredit(parseKeySnapshot(keyBody({ limit: 500, limit_remaining: 60 }))!);
+    expect(a.status).toBe("warn");
+    expect(a.actionable).toBe(true);
+  });
+});
+
+describe("the operator is told once, not every hour", () => {
+  const low = () => ({
+    status: 200,
+    body: keyBody({ limit: 50, limit_remaining: 6, usage: 44 }),
+  });
+
+  it("suppresses a repeat of the same severity inside the 6h window", async () => {
+    const first = await runTick({ respond: low, now: 0 });
+    expect(first.dms).toHaveLength(1);
+    // Five more hourly ticks with the shortfall unchanged.
+    const later: string[] = [];
+    for (let h = 1; h <= 5; h++) {
+      later.push(...(await runTick({ respond: low, now: h * HOUR })).dms);
+    }
+    expect(later).toEqual([]);
+    // Still firing — the cron exit code says so even while the DM is silent.
+    const quiet = await runTick({ respond: low, now: 2 * HOUR });
+    expect(quiet.result.firing).toBe(true);
+    expect(quiet.result.exitCode).toBe(10);
+  });
+
+  it("re-notifies once the window has elapsed, flagged as unresolved", async () => {
+    await runTick({ respond: low, now: 0 });
+    const again = await runTick({ respond: low, now: RENOTIFY_MS + 1 });
+    expect(again.dms).toHaveLength(1);
+    expect(again.dms[0]).toMatch(/still unresolved/i);
+  });
+
+  it("ESCALATES immediately — a warn that becomes critical beats the cooldown", async () => {
+    await runTick({ respond: low, now: 0 });
+    const worse = await runTick({
+      respond: () => ({ status: 200, body: keyBody({ limit: 50, limit_remaining: 1 }) }),
+      now: 30 * 60_000, // half an hour later, deep inside the quiet window
+    });
+    expect(worse.dms).toHaveLength(1);
+    expect(worse.dms[0]).toMatch(/ESCALATED/);
+  });
+
+  it("clears the ledger on recovery so the NEXT incident is not swallowed", async () => {
+    await runTick({ respond: low, now: 0 });
+    await runTick({
+      respond: () => ({ status: 200, body: keyBody({ limit: 50, limit_remaining: 45 }) }),
+      now: HOUR,
+    });
+    // A brand-new shortfall an hour later must notify at once, even though
+    // that is well inside 6h of the FIRST alert.
+    const fresh = await runTick({ respond: low, now: 2 * HOUR });
+    expect(fresh.dms).toHaveLength(1);
+  });
+
+  it("does NOT start a 6h silence about an alert that reached nobody", async () => {
+    const undelivered = await runTick({ respond: low, now: 0, deliver: false });
+    expect(undelivered.dms).toHaveLength(1);
+    expect(undelivered.result.delivered).toBe(false);
+    // Loud: a watchdog that cannot speak is an incident.
+    expect(undelivered.result.exitCode).toBe(1);
+    // And the very next tick tries again rather than assuming it landed.
+    const retry = await runTick({ respond: low, now: 60_000, deliver: true });
+    expect(retry.dms).toHaveLength(1);
+    expect(retry.result.delivered).toBe(true);
+  });
+
+  it("--dry-run neither sends nor records", async () => {
+    const dry = await runTick({ respond: low, now: 0, dryRun: true });
+    expect(dry.dms).toEqual([]);
+    expect(dry.result.notice).not.toBeNull();
+    expect(loadState(statePath)).toEqual({});
+  });
+});
+
+describe("a broken key is an incident; an unreachable API is not", () => {
+  it("FAILs and DMs when OpenRouter rejects the key outright", async () => {
+    const { result, dms } = await runTick({
+      respond: () => ({ status: 401, ok: false, body: {} }),
+      now: 0,
+    });
+    expect(result.assessment.status).toBe("fail");
+    expect(dms).toHaveLength(1);
+    expect(dms[0]).toMatch(/invalid, revoked or disabled/);
+    // Names the vault key so the operator knows what to replace.
+    expect(dms[0]).toContain(OPENROUTER_VAULT_KEY);
+  });
+
+  it("exits 1 and stays silent when the API cannot be reached", async () => {
+    const { result, dms } = await runTick({
+      respond: () => ({ status: 0, throws: new Error("ENOTFOUND openrouter.ai") }),
+      now: 0,
+    });
+    expect(result.exitCode).toBe(1);
+    expect(dms).toEqual([]);
+    expect(result.assessment.status).toBe("skip");
+  });
+
+  it("treats an unrecognised body as UNKNOWN, never as healthy", async () => {
+    const { result, dms } = await runTick({
+      respond: () => ({ status: 200, body: { data: { something_else: 1 } } }),
+      now: 0,
+    });
+    expect(result.assessment.status).toBe("warn");
+    expect(result.assessment.status).not.toBe("ok");
+    expect(dms).toEqual([]); // an API-shape change is not a credit incident
+  });
+
+  it("exits 1 without DMing when the vault key is not readable", async () => {
+    const { result, dms, calls } = await runTick({
+      respond: () => ({ status: 200, body: keyBody() }),
+      now: 0,
+      secret: null,
+    });
+    expect(result.exitCode).toBe(1);
+    expect(dms).toEqual([]);
+    expect(calls).toEqual([]); // never attempts an unauthenticated call
+  });
+
+  it("doctor SKIPs cleanly when nothing routes through OpenRouter", async () => {
+    const [res] = await runOpenRouterCreditChecks({
+      enabled: false,
+      readSecret: async () => {
+        throw new Error("must not be called");
+      },
+      fetchFn: async () => {
+        throw new Error("must not be called");
+      },
+    });
+    expect(res.status).toBe("skip");
+  });
+});
+
+describe("the key VALUE never escapes", () => {
+  it("appears in no DM, no doctor line and no log, on every outcome", async () => {
+    const responses: Array<() => { ok?: boolean; status: number; body?: unknown; throws?: Error }> = [
+      () => ({ status: 200, body: keyBody() }),
+      () => ({ status: 200, body: keyBody({ limit: 50, limit_remaining: 1 }) }),
+      () => ({ status: 401, ok: false, body: {} }),
+      () => ({ status: 500, ok: false, body: {} }),
+      () => ({ status: 0, throws: new Error("ECONNRESET") }),
+      () => ({ status: 200, body: { nope: true } }),
+    ];
+    for (const respond of responses) {
+      rmSync(statePath, { force: true });
+      const { result, dms, logs, calls } = await runTick({ respond, now: 0 });
+      const surface = [
+        result.assessment.detail,
+        result.assessment.fix ?? "",
+        result.notice ?? "",
+        ...dms,
+        ...logs,
+      ].join("\n");
+      expect(surface).not.toContain(FAKE_KEY);
+      // …while the key WAS used, as an Authorization header and nowhere else.
+      if (calls.length > 0) {
+        expect(calls[0].url).toBe(OPENROUTER_KEY_ENDPOINT);
+        expect(calls[0].headers?.authorization).toBe(`Bearer ${FAKE_KEY}`);
+      }
+    }
+  });
+
+  it("names the vault KEY, never a value, in the doctor fix line", async () => {
+    const [res] = await runOpenRouterCreditChecks({
+      enabled: true,
+      readSecret: async () => null,
+      fetchFn: async () => {
+        throw new Error("must not be called");
+      },
+    });
+    expect(res.status).toBe("warn");
+    expect(res.fix).toContain(OPENROUTER_VAULT_KEY);
+  });
+});
+
+describe("the state file degrades safely", () => {
+  it("round-trips the ledger", () => {
+    saveState(statePath, { lastNotifiedAt: 42, lastNotifiedStatus: "warn" });
+    expect(loadState(statePath)).toEqual({ lastNotifiedAt: 42, lastNotifiedStatus: "warn" });
+  });
+
+  it("treats an absent or torn file as an empty ledger, never a throw", () => {
+    expect(loadState(join(dir, "nope.json"))).toEqual({});
+    writeFileSync(statePath, "{not json");
+    expect(loadState(statePath)).toEqual({});
+    writeFileSync(statePath, JSON.stringify({ v: 99, lastNotifiedAt: 1 }));
+    expect(loadState(statePath)).toEqual({});
+  });
+
+  it("a torn ledger costs at most ONE extra DM, never a missed one", async () => {
+    const low = () => ({ status: 200, body: keyBody({ limit: 50, limit_remaining: 6 }) });
+    await runTick({ respond: low, now: 0 });
+    writeFileSync(statePath, "garbage");
+    const after = await runTick({ respond: low, now: HOUR });
+    expect(after.dms).toHaveLength(1); // fails toward telling, not toward silence
+  });
+});
+
+describe("arming the watchdog is a mechanism, not a doc", () => {
+  it("renders a cron line that cron will actually run", () => {
+    const line = renderCron({ user: "kenthompson", binary: "/usr/local/bin/switchroom" });
+    // flock -n: two overlapping ticks would race on the re-notify ledger.
+    expect(line).toContain("/usr/bin/flock -n /run/lock/openrouter-watch.lock");
+    // cron silently ignores a fragment whose last line has no newline.
+    expect(line.endsWith("\n")).toBe(true);
+    // cron's default PATH is /usr/bin:/bin.
+    expect(line).toMatch(/^PATH=.*\/usr\/local\/bin/m);
+    expect(line).toContain(`${CRON_SCHEDULE} kenthompson `);
+    expect(line).toContain("switchroom openrouter-watch");
+  });
+
+  it("is idempotent", () => {
+    const path = join(dir, "cron.d-fragment");
+    const opts = { user: "kenthompson", binary: "/usr/local/bin/switchroom", path };
+    expect(installCron(opts).status).toBe("installed");
+    expect(installCron(opts).status).toBe("unchanged");
+    expect(readFileSync(path, "utf8")).toBe(renderCron(opts));
+  });
+
+  it("ticks at most hourly — one third-party GET per hour, not per minute", () => {
+    const [minute] = CRON_SCHEDULE.split(" ");
+    expect(minute).toMatch(/^\d+$/); // a fixed minute, not a */N sub-hour step
+  });
+});
+
+describe("enablement is read from the real proxy config shape", () => {
+  it("detects an OpenRouter-backed model group", () => {
+    expect(usesOpenRouter("  - model_name: gpt-5\n    litellm_params:\n      model: openrouter/openai/gpt-5\n")).toBe(true);
+    expect(usesOpenRouter("      api_key: os.environ/OPENROUTER_API_KEY\n")).toBe(true);
+  });
+
+  it("does not claim OpenRouter for a config that has none", () => {
+    expect(usesOpenRouter("  - model_name: sonnet\n    litellm_params:\n      model: anthropic/claude\n")).toBe(false);
+    expect(usesOpenRouter(null)).toBe(false);
+  });
+});

--- a/src/openrouter/credit.ts
+++ b/src/openrouter/credit.ts
@@ -1,0 +1,291 @@
+/**
+ * credit.ts — proactive OpenRouter credit monitoring.
+ *
+ * WHY
+ * ---
+ * PR #3868 stops a spent OpenRouter balance from leaking a raw 402 to an end
+ * user, and routes it to an operator card. That is REACTIVE: by the time it
+ * fires, the fleet has already failed a request. This is the proactive half —
+ * see the shortfall coming and say so before anything breaks.
+ *
+ * THE ENDPOINT — VERIFIED AGAINST LIVE DOCS 2026-07-28
+ * ----------------------------------------------------
+ * `GET https://openrouter.ai/api/v1/key`, authenticated with the ORDINARY
+ * inference key (no separate provisioning key needed), returns
+ * (https://openrouter.ai/docs/api-reference/limits):
+ *
+ *   type Key = { data: {
+ *     label: string
+ *     limit: number | null            // credit limit for the KEY, or null if unlimited
+ *     limit_reset: string | null      // reset cadence, or null if it never resets
+ *     limit_remaining: number | null  // remaining credits for the KEY, or null if unlimited
+ *     include_byok_in_limit: boolean
+ *     usage: number                   // credits used, all time
+ *     usage_daily / usage_weekly / usage_monthly: number
+ *     byok_usage{,_daily,_weekly,_monthly}: number
+ *     is_free_tier: boolean
+ *   } }
+ *
+ * THE CASE THAT BITES — and this is the important one:
+ *
+ *   `limit` and `limit_remaining` are `null` when the key has NO per-key
+ *   credit cap configured, and **the response carries no account-balance
+ *   field at all**.
+ *
+ * OpenRouter's own docs are explicit that credit limits come from TWO places —
+ * "Account balance — your available credits across the account" and "Per-key
+ * credit limits — an optional spending cap configured on an individual API
+ * key" — but `GET /api/v1/key` only ever describes the SECOND one.
+ *
+ * So with no per-key limit set (the default, and almost certainly the fleet's
+ * current state), this endpoint CANNOT warn about the account balance running
+ * out. There is no honest number to threshold. The check therefore reports
+ * `warn` with "monitoring is not possible until a per-key limit is set" rather
+ * than a green tick that means nothing — a monitor that silently passes when
+ * it cannot see is worse than no monitor, because it manufactures confidence.
+ *
+ * The fix is the same manual OpenRouter-console action the spend-cap work
+ * names: set a per-key credit limit at https://openrouter.ai/settings/keys.
+ * Doing that is what makes proactive monitoring possible AT ALL, and it also
+ * bounds the blast radius if the proxy key ever leaks.
+ *
+ * Pure module: no network, no FS, no clock. The caller injects the fetch.
+ */
+
+// ─── Thresholds ──────────────────────────────────────────────────────────────
+
+/**
+ * WARN when remaining credit falls below EITHER 25% of the key's limit OR
+ * this many dollars — whichever fires first.
+ *
+ * Two thresholds because one alone is wrong at one end of the range. A pure
+ * percentage on a $500 limit warns with $125 left (far too early, and the
+ * operator learns to ignore it); a pure absolute on a $10 limit warns at 50%
+ * (too late to be a warning). The pair warns at "you have a couple of days of
+ * headroom" across plausible limits.
+ */
+export const WARN_REMAINING_FRACTION = 0.25;
+export const WARN_REMAINING_USD = 10;
+
+/**
+ * FAIL when remaining credit falls below EITHER 10% of the limit OR this many
+ * dollars. At this point a single busy session can exhaust it, so it is a
+ * "top up now" condition rather than a heads-up.
+ */
+export const FAIL_REMAINING_FRACTION = 0.1;
+export const FAIL_REMAINING_USD = 3;
+
+/** Vault key NAME the check reads. A NAME only — never a value. */
+export const OPENROUTER_VAULT_KEY = "openrouter/api-key";
+
+/** Where the operator acts. */
+export const OPENROUTER_KEYS_URL = "https://openrouter.ai/settings/keys";
+export const OPENROUTER_CREDITS_URL = "https://openrouter.ai/credits";
+
+export const OPENROUTER_KEY_ENDPOINT = "https://openrouter.ai/api/v1/key";
+
+// ─── Parsing ─────────────────────────────────────────────────────────────────
+
+/** The subset of `GET /api/v1/key` this module reasons about. */
+export interface OpenRouterKeySnapshot {
+  label: string | null;
+  /** Per-key credit cap, or `null` when the key is uncapped. */
+  limit: number | null;
+  /** Remaining credit against `limit`, or `null` when the key is uncapped. */
+  limitRemaining: number | null;
+  limitReset: string | null;
+  usage: number | null;
+  isFreeTier: boolean | null;
+}
+
+function num(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+/**
+ * Parse a `GET /api/v1/key` body. Returns `null` for anything that is not the
+ * documented shape — a caller must not confuse "the API changed" with "there
+ * is no limit", because those have opposite meanings.
+ */
+export function parseKeySnapshot(body: unknown): OpenRouterKeySnapshot | null {
+  if (body == null || typeof body !== "object") return null;
+  const data = (body as { data?: unknown }).data;
+  if (data == null || typeof data !== "object") return null;
+  const d = data as Record<string, unknown>;
+  // `usage` is the one field documented as always present and non-nullable; if
+  // it is missing the payload is not the documented shape.
+  if (num(d.usage) == null) return null;
+  return {
+    label: typeof d.label === "string" ? d.label : null,
+    limit: num(d.limit),
+    limitRemaining: num(d.limit_remaining),
+    limitReset: typeof d.limit_reset === "string" ? d.limit_reset : null,
+    usage: num(d.usage),
+    isFreeTier: typeof d.is_free_tier === "boolean" ? d.is_free_tier : null,
+  };
+}
+
+// ─── Evaluation ──────────────────────────────────────────────────────────────
+
+export type CreditVerdict = "ok" | "warn" | "fail" | "skip";
+
+export interface CreditAssessment {
+  status: CreditVerdict;
+  /** One-line summary safe to render anywhere. Never contains a key VALUE. */
+  detail: string;
+  /** What the operator should do, or `undefined` when nothing is needed. */
+  fix?: string;
+  /**
+   * `true` when the shortfall is real and quantified — the only case a
+   * scheduled poll should DM the operator about. A "cannot monitor" verdict is
+   * a standing configuration gap, not an incident, and must not page anyone
+   * every six hours forever.
+   */
+  actionable: boolean;
+}
+
+/**
+ * Turn a snapshot into a verdict.
+ *
+ * The three genuinely different outcomes, kept genuinely different:
+ *  - a quantified shortfall (`warn`/`fail`, actionable);
+ *  - enough headroom (`ok`);
+ *  - NOT MONITORABLE — the key has no per-key limit, so the endpoint reports
+ *    `null` and there is no account-balance field to fall back on. Reported as
+ *    `warn` with an explicit explanation, NOT as `ok`.
+ */
+export function evaluateCredit(snapshot: OpenRouterKeySnapshot): CreditAssessment {
+  const usage = snapshot.usage ?? 0;
+
+  if (snapshot.limit == null || snapshot.limitRemaining == null) {
+    return {
+      status: "warn",
+      detail:
+        `OpenRouter key has NO per-key credit limit set, so its remaining credit cannot be measured. ` +
+        `GET /api/v1/key reports limit/limit_remaining as null when a key is uncapped, and the response ` +
+        `carries no account-balance field — so there is nothing to threshold and this check CANNOT warn ` +
+        `you before the account runs dry. (Key has spent $${usage.toFixed(2)} all-time.)`,
+      fix:
+        `Set a per-key credit limit at ${OPENROUTER_KEYS_URL} (vault key: \`${OPENROUTER_VAULT_KEY}\`). ` +
+        `That is what makes proactive monitoring possible at all, and it bounds the damage if the proxy ` +
+        `key ever leaks. This is a manual console action — OpenRouter exposes no API to set it.`,
+      // A standing config gap, not an incident: never DM about it on a timer.
+      actionable: false,
+    };
+  }
+
+  const { limit, limitRemaining } = snapshot;
+  const fraction = limit > 0 ? limitRemaining / limit : 0;
+  const reset = snapshot.limitReset ? ` (resets: ${snapshot.limitReset})` : " (never resets)";
+  const where = `$${limitRemaining.toFixed(2)} of $${limit.toFixed(2)} remaining${reset}`;
+
+  if (limitRemaining <= 0) {
+    return {
+      status: "fail",
+      detail: `OpenRouter key credit is EXHAUSTED — ${where}. Every request through it is answering HTTP 402.`,
+      fix: `Top up at ${OPENROUTER_CREDITS_URL} or raise the key's limit at ${OPENROUTER_KEYS_URL} (vault key: \`${OPENROUTER_VAULT_KEY}\`).`,
+      actionable: true,
+    };
+  }
+
+  if (fraction < FAIL_REMAINING_FRACTION || limitRemaining < FAIL_REMAINING_USD) {
+    return {
+      status: "fail",
+      detail: `OpenRouter key credit is CRITICALLY low — ${where}. A single busy session can exhaust it.`,
+      fix: `Top up at ${OPENROUTER_CREDITS_URL} or raise the key's limit at ${OPENROUTER_KEYS_URL} (vault key: \`${OPENROUTER_VAULT_KEY}\`).`,
+      actionable: true,
+    };
+  }
+
+  if (fraction < WARN_REMAINING_FRACTION || limitRemaining < WARN_REMAINING_USD) {
+    return {
+      status: "warn",
+      detail: `OpenRouter key credit is running low — ${where}.`,
+      fix: `Top up at ${OPENROUTER_CREDITS_URL} before it reaches zero (vault key: \`${OPENROUTER_VAULT_KEY}\`).`,
+      actionable: true,
+    };
+  }
+
+  return {
+    status: "ok",
+    detail: `OpenRouter key credit healthy — ${where}.`,
+    actionable: false,
+  };
+}
+
+// ─── Fetch ───────────────────────────────────────────────────────────────────
+
+export type CreditFetchFn = (
+  url: string,
+  init?: { headers?: Record<string, string>; signal?: AbortSignal },
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
+
+export type FetchCreditResult =
+  | { kind: "ok"; snapshot: OpenRouterKeySnapshot }
+  | { kind: "unauthorized"; status: number }
+  | { kind: "unreachable"; detail: string }
+  | { kind: "unexpected-shape" };
+
+/**
+ * Read the live snapshot. The API key is passed in by the caller (which got it
+ * from the vault broker) and is used ONLY as the Authorization header — it is
+ * never logged, never returned, and never placed in an error string.
+ */
+export async function fetchKeySnapshot(
+  apiKey: string,
+  fetchFn: CreditFetchFn,
+  signal?: AbortSignal,
+): Promise<FetchCreditResult> {
+  let resp: Awaited<ReturnType<CreditFetchFn>>;
+  try {
+    resp = await fetchFn(OPENROUTER_KEY_ENDPOINT, {
+      headers: { authorization: `Bearer ${apiKey}` },
+      signal,
+    });
+  } catch (err) {
+    // The message is from the transport, never from the credential.
+    return { kind: "unreachable", detail: (err as Error).message };
+  }
+  if (resp.status === 401 || resp.status === 403) {
+    return { kind: "unauthorized", status: resp.status };
+  }
+  if (!resp.ok) return { kind: "unreachable", detail: `HTTP ${resp.status}` };
+  let body: unknown;
+  try {
+    body = await resp.json();
+  } catch {
+    return { kind: "unexpected-shape" };
+  }
+  const snapshot = parseKeySnapshot(body);
+  if (snapshot == null) return { kind: "unexpected-shape" };
+  return { kind: "ok", snapshot };
+}
+
+/** Turn a non-`ok` fetch outcome into an assessment, without leaking anything. */
+export function assessFetchFailure(result: Exclude<FetchCreditResult, { kind: "ok" }>): CreditAssessment {
+  switch (result.kind) {
+    case "unauthorized":
+      return {
+        status: "fail",
+        detail: `OpenRouter rejected the credit query with HTTP ${result.status} — the key is invalid, revoked or disabled.`,
+        fix: `Re-issue the key at ${OPENROUTER_KEYS_URL} and update the vault entry \`${OPENROUTER_VAULT_KEY}\`.`,
+        actionable: true,
+      };
+    case "unexpected-shape":
+      return {
+        status: "warn",
+        detail:
+          `OpenRouter's GET /api/v1/key returned an unrecognised body, so credit could not be read. ` +
+          `Treated as UNKNOWN, not as healthy — the API shape may have changed.`,
+        fix: `Re-check https://openrouter.ai/docs/api-reference/limits against src/openrouter/credit.ts.`,
+        // Not a credit incident — do not page the operator on a timer for it.
+        actionable: false,
+      };
+    case "unreachable":
+      return {
+        status: "skip",
+        detail: `Could not reach OpenRouter to check credit (${result.detail}).`,
+        actionable: false,
+      };
+  }
+}

--- a/src/openrouter/install-cron.ts
+++ b/src/openrouter/install-cron.ts
@@ -1,0 +1,94 @@
+/**
+ * Arming the OpenRouter credit watch.
+ *
+ * Deliberately the same mechanism as `src/hindsight-watch/install-cron.ts`,
+ * for the reason that file spells out: a monitoring step that lives in a doc
+ * is not a mechanism, and switchroom already shipped one watchdog that never
+ * ran because arming it was four manual steps nobody performed. So this is a
+ * verb (`switchroom openrouter-watch --install-cron`) that writes a
+ * declarative, idempotent `/etc/cron.d` fragment.
+ *
+ * CADENCE — why hourly and not every 15 minutes.
+ * Credit is a slowly-moving quantity measured in dollars, and the alert it
+ * feeds re-notifies at most once per 6 h (`RENOTIFY_MS` in `./watch.ts`).
+ * Hourly gives six independent observations inside one re-notify window —
+ * ample to catch an escalation promptly — while costing one HTTP GET an hour
+ * and zero model tokens. A 15-minute tick would quadruple the request rate
+ * against a third-party API to buy latency the alert cadence throws away.
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+/** Where the cron fragment lands. */
+export const CRON_PATH = "/etc/cron.d/openrouter-watch";
+
+/** Cadence — see the module header for why hourly. */
+export const CRON_SCHEDULE = "17 * * * *";
+
+/** Log the cron appends to. */
+export const CRON_LOG_PATH = "/var/log/openrouter-watch.log";
+
+/** Lock file — `flock -n` so a slow tick cannot be overlapped by the next. */
+export const CRON_LOCK_PATH = "/run/lock/openrouter-watch.lock";
+
+export interface CronRenderOptions {
+  /** Unix user the tick runs as. */
+  user: string;
+  /** Absolute path to the `switchroom` binary. */
+  binary: string;
+}
+
+/**
+ * Render the cron fragment. Pure, so the exact bytes are asserted in a test.
+ *
+ * Three properties the test pins, each a real cron failure mode:
+ *  - **`flock -n`** — two overlapping ticks would race on the state file that
+ *    holds the re-notify ledger, which is what stops the operator being paged
+ *    every hour about the same shortfall.
+ *  - **a trailing newline** — cron silently ignores a fragment whose last
+ *    line has none.
+ *  - **an explicit `PATH`** — cron's default is `/usr/bin:/bin`, which on most
+ *    installs does not contain the `switchroom` binary's own dependencies.
+ */
+export function renderCron(opts: CronRenderOptions): string {
+  return (
+    `# switchroom openrouter-watch — model-free OpenRouter credit watchdog.\n` +
+    `# Managed by \`switchroom openrouter-watch --install-cron\`; edits are overwritten.\n` +
+    `# Exit 0 = clean, 10 = credit signal firing (DM sent), 1 = the check could not complete.\n` +
+    `SHELL=/bin/sh\n` +
+    `PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n` +
+    `${CRON_SCHEDULE} ${opts.user} /usr/bin/flock -n ${CRON_LOCK_PATH} ` +
+    `${opts.binary} openrouter-watch >> ${CRON_LOG_PATH} 2>&1\n`
+  );
+}
+
+export interface InstallResult {
+  status: "installed" | "unchanged";
+  path: string;
+  content: string;
+}
+
+/**
+ * Write the cron fragment idempotently (tmp+rename, mode 0644 — cron refuses
+ * a group- or world-writable fragment, and a half-written file would be
+ * parsed by whatever cron scan lands mid-write).
+ */
+export function installCron(opts: CronRenderOptions & { path?: string }): InstallResult {
+  const path = opts.path ?? CRON_PATH;
+  const content = renderCron(opts);
+  if (existsSync(path)) {
+    try {
+      if (readFileSync(path, "utf8") === content) {
+        return { status: "unchanged", path, content };
+      }
+    } catch {
+      // Unreadable but present — fall through and rewrite it.
+    }
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, content, { mode: 0o644 });
+  renameSync(tmp, path);
+  return { status: "installed", path, content };
+}

--- a/src/openrouter/run.ts
+++ b/src/openrouter/run.ts
@@ -1,0 +1,120 @@
+/**
+ * run.ts — one tick of the OpenRouter credit watch.
+ *
+ * Orchestration only: read the key (vault), read the snapshot (HTTP), evaluate
+ * (`./credit.ts` — the SAME evaluator `switchroom doctor` uses, so the two can
+ * never disagree about what "low" means), decide (`./watch.ts`), deliver, and
+ * persist the re-notify ledger.
+ *
+ * Everything that touches the world is injected, so the tests drive every
+ * outcome — including "the key is out of credit" — with fakes and no live
+ * credential. The API key VALUE never appears in a log line, a notice, or the
+ * returned result; only the vault key NAME does.
+ *
+ * EXIT CODES (cron-meaningful, matching `switchroom hindsight-watch`):
+ *   0  — ran, nothing firing
+ *  10  — ran, a credit signal is firing (DM sent unless suppressed by the
+ *        6 h re-notify window)
+ *   1  — could NOT complete: OpenRouter unreachable, the vault key
+ *        unreadable, the state file unwritable, or an alert that reached no
+ *        gateway. Loud by design — a watchdog that cannot see, or cannot
+ *        speak, is an incident, not a no-op.
+ */
+
+import {
+  OPENROUTER_VAULT_KEY,
+  assessFetchFailure,
+  evaluateCredit,
+  fetchKeySnapshot,
+  type CreditAssessment,
+  type CreditFetchFn,
+} from "./credit.js";
+import { loadState, saveState } from "./state.js";
+import { decideNotification, type CreditWatchState } from "./watch.js";
+
+export interface TickDeps {
+  statePath: string;
+  /** Reads the vault by key NAME. Returns null when absent or ungranted. */
+  readSecret: (key: string) => Promise<string | null>;
+  fetchFn: CreditFetchFn;
+  /** Deliver one operator DM. Resolves false when no gateway accepted it. */
+  notify: (text: string) => Promise<boolean>;
+  now?: () => number;
+  dryRun?: boolean;
+  log: (msg: string) => void;
+}
+
+export interface TickResult {
+  assessment: CreditAssessment;
+  /** The DM that was sent (or, under --dry-run, would have been). */
+  notice: string | null;
+  /** True when a signal is firing, whether or not it DM'd this tick. */
+  firing: boolean;
+  /** True when a DM was actually delivered. */
+  delivered: boolean;
+  exitCode: 0 | 1 | 10;
+}
+
+export async function tick(deps: TickDeps): Promise<TickResult> {
+  const now = deps.now?.() ?? Date.now();
+
+  let apiKey: string | null = null;
+  try {
+    apiKey = await deps.readSecret(OPENROUTER_VAULT_KEY);
+  } catch (err) {
+    deps.log(`openrouter-watch: vault read failed for \`${OPENROUTER_VAULT_KEY}\`: ${(err as Error).message}`);
+  }
+  if (!apiKey) {
+    // Cannot see. Loud in the cron log; NOT a DM — an ungranted vault key is a
+    // host-side configuration problem the operator meets in `switchroom
+    // doctor`, and DMing about it hourly would be paging about a static fact.
+    deps.log(
+      `openrouter-watch: vault key \`${OPENROUTER_VAULT_KEY}\` is not readable — credit cannot be checked.`,
+    );
+    return {
+      assessment: {
+        status: "skip",
+        detail: `Vault key \`${OPENROUTER_VAULT_KEY}\` unreadable.`,
+        actionable: false,
+      },
+      notice: null,
+      firing: false,
+      delivered: false,
+      exitCode: 1,
+    };
+  }
+
+  const fetched = await fetchKeySnapshot(apiKey, deps.fetchFn);
+  const assessment =
+    fetched.kind === "ok" ? evaluateCredit(fetched.snapshot) : assessFetchFailure(fetched);
+
+  const prior: CreditWatchState = loadState(deps.statePath);
+  const decision = decideNotification(assessment, prior, now);
+
+  let delivered = false;
+  if (decision.notice && !deps.dryRun) {
+    delivered = await deps.notify(decision.notice);
+  }
+
+  // Persist ONLY when the DM actually landed (or there was none to send).
+  // Recording a notification that never reached anyone would start a 6 h
+  // silence about a live incident nobody has heard about — the single worst
+  // failure this watchdog can have.
+  if (!deps.dryRun && (decision.notice === null || delivered)) {
+    try {
+      saveState(deps.statePath, decision.nextState);
+    } catch (err) {
+      deps.log(`openrouter-watch: could not persist state: ${(err as Error).message}`);
+      return { assessment, notice: decision.notice, firing: decision.firing, delivered, exitCode: 1 };
+    }
+  }
+
+  if (decision.notice && !deps.dryRun && !delivered) {
+    deps.log("openrouter-watch: alert reached no gateway — undelivered, will retry next tick");
+    return { assessment, notice: decision.notice, firing: decision.firing, delivered, exitCode: 1 };
+  }
+
+  const cannotComplete = fetched.kind === "unreachable";
+  const exitCode: 0 | 1 | 10 = cannotComplete ? 1 : decision.firing ? 10 : 0;
+  return { assessment, notice: decision.notice, firing: decision.firing, delivered, exitCode };
+}

--- a/src/openrouter/state.ts
+++ b/src/openrouter/state.ts
@@ -1,0 +1,63 @@
+/**
+ * Durable state for the OpenRouter credit watch: the re-notify ledger.
+ *
+ * Lives at `~/.switchroom/openrouter-watch/state.json` (tmp+rename, 0600),
+ * matching `src/hindsight-watch/state.ts`. Two properties, both deliberate:
+ *
+ *  - A torn / absent / garbage file degrades to an EMPTY ledger, never a
+ *    throw. The worst consequence of an empty ledger is ONE extra operator
+ *    DM about a shortfall that is genuinely still firing — strictly better
+ *    than a crashed cron, and it fails toward telling the operator rather
+ *    than toward silence.
+ *  - A write failure is NOT swallowed: `saveState` throws and the caller
+ *    exits 1. A watchdog that cannot persist its ledger would re-fire the
+ *    same alert every single hour, which trains the operator to mute it.
+ */
+
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, resolve } from "node:path";
+import type { CreditWatchState } from "./watch.js";
+
+interface Persisted extends CreditWatchState {
+  v: 1;
+}
+
+/** Default state-file path, honouring `SWITCHROOM_HOME` like the rest of the CLI. */
+export function defaultStatePath(
+  home: string = process.env.SWITCHROOM_HOME ?? process.env.HOME ?? homedir(),
+): string {
+  return resolve(home, ".switchroom", "openrouter-watch", "state.json");
+}
+
+/** Read the ledger, degrading to empty on absent/torn/foreign-version files. */
+export function loadState(path: string): CreditWatchState {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return {};
+  }
+  if (typeof parsed !== "object" || parsed === null) return {};
+  const s = parsed as Partial<Persisted>;
+  if (s.v !== 1) return {};
+  const out: CreditWatchState = {};
+  if (typeof s.lastNotifiedAt === "number" && Number.isFinite(s.lastNotifiedAt)) {
+    out.lastNotifiedAt = s.lastNotifiedAt;
+  }
+  if (typeof s.lastNotifiedStatus === "string") out.lastNotifiedStatus = s.lastNotifiedStatus;
+  // A ledger with a status but no timestamp cannot express a cooldown, and
+  // `decideNotification` would treat it as "never notified" anyway. Normalise
+  // it away rather than persisting a shape that means nothing.
+  if (out.lastNotifiedAt === undefined) delete out.lastNotifiedStatus;
+  return out;
+}
+
+/** Atomic write. Throws on failure — the caller must exit loudly. */
+export function saveState(path: string, state: CreditWatchState): void {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  const payload: Persisted = { v: 1, ...state };
+  writeFileSync(tmp, JSON.stringify(payload, null, 2) + "\n", { mode: 0o600 });
+  renameSync(tmp, path);
+}

--- a/src/openrouter/watch.ts
+++ b/src/openrouter/watch.ts
@@ -1,0 +1,119 @@
+/**
+ * watch.ts — the scheduled half of OpenRouter credit monitoring.
+ *
+ * `switchroom doctor` answers "is credit low RIGHT NOW, when someone asks".
+ * This answers "tell me before I have to ask". Same evaluator (`./credit.ts`),
+ * so the two can never disagree about what "low" means.
+ *
+ * HOUSE PATTERN, deliberately copied rather than reinvented
+ * --------------------------------------------------------
+ * `src/hindsight-watch/` is switchroom's existing model-free watchdog: a host
+ * CLI verb on a host cron, zero model tokens per tick, durable state under
+ * `~/.switchroom/`, and delivery through `postOperatorNoticeViaGateways`. This
+ * reuses that shape and, critically, its `RENOTIFY_MS` (6 h) so every standing
+ * operator alert in switchroom repeats on ONE rhythm rather than each watchdog
+ * inventing its own.
+ *
+ * WHAT IT WILL AND WILL NOT WAKE THE OPERATOR FOR
+ * ----------------------------------------------
+ * Only an `actionable` assessment DMs (see `CreditAssessment.actionable`):
+ * a quantified shortfall, or a key the API rejects outright.
+ *
+ * It deliberately does NOT DM for the "no per-key limit set, so credit cannot
+ * be measured" case, even though `doctor` reports that as a WARN. That is a
+ * standing CONFIGURATION GAP, not an incident — it will be equally true in six
+ * hours and in six weeks, and paging someone about it on a timer is exactly how
+ * an alert channel gets muted. It belongs in `doctor`, where the operator went
+ * looking; not in their DMs, where it arrived uninvited.
+ *
+ * Pure module: no network, no FS, no clock, no bot. The CLI verb injects them.
+ */
+
+import type { CreditAssessment } from "./credit.js";
+
+/**
+ * Re-notify cadence, matched to `src/hindsight-watch/thresholds.ts`
+ * (`RENOTIFY_MS`) — one rhythm for every standing operator alert.
+ */
+export const RENOTIFY_MS = 6 * 60 * 60 * 1000;
+
+/** Durable state. Small on purpose — it survives a torn write by degrading. */
+export interface CreditWatchState {
+  /** Epoch ms of the last DM, per severity. */
+  lastNotifiedAt?: number;
+  /** The status that was last notified, so an escalation re-fires immediately. */
+  lastNotifiedStatus?: string;
+}
+
+export interface WatchDecision {
+  /** The DM to send, or `null` to stay silent this tick. */
+  notice: string | null;
+  /** State to persist. */
+  nextState: CreditWatchState;
+  /** Cron-meaningful: true when a signal is firing (whether or not it DM'd). */
+  firing: boolean;
+}
+
+/**
+ * Decide what this tick does.
+ *
+ * Escalation beats the cooldown: if the previous DM said "running low" and it
+ * is now "critically low", the operator hears about it immediately rather than
+ * up to six hours later. A REPEAT of the same severity waits out the window.
+ * De-escalation and recovery are silent — nobody needs a DM saying a problem
+ * they were told about got smaller.
+ */
+export function decideNotification(
+  assessment: CreditAssessment,
+  state: CreditWatchState,
+  now: number,
+): WatchDecision {
+  if (!assessment.actionable) {
+    // Nothing firing → clear the ledger so a NEW incident notifies at once
+    // rather than being swallowed by a stale cooldown from a resolved one.
+    return { notice: null, nextState: {}, firing: false };
+  }
+
+  const escalated =
+    state.lastNotifiedStatus != null &&
+    state.lastNotifiedStatus !== "fail" &&
+    assessment.status === "fail";
+  const cooled =
+    state.lastNotifiedAt == null || now - state.lastNotifiedAt >= RENOTIFY_MS;
+
+  if (!escalated && !cooled) {
+    // Firing, but already reported and not worse. Keep the state as-is.
+    return { notice: null, nextState: state, firing: true };
+  }
+
+  const repeat = state.lastNotifiedAt != null && !escalated;
+  return {
+    notice: renderNotice(assessment, { repeat, escalated }),
+    nextState: { lastNotifiedAt: now, lastNotifiedStatus: assessment.status },
+    firing: true,
+  };
+}
+
+/**
+ * The operator DM. Names the provider, the VAULT KEY NAME (never a value) and
+ * the action — the same contract as every other operator alert in switchroom.
+ */
+export function renderNotice(
+  assessment: CreditAssessment,
+  opts: { repeat: boolean; escalated: boolean },
+): string {
+  const head =
+    assessment.status === "fail"
+      ? opts.escalated
+        ? "🚨 OpenRouter credit — ESCALATED"
+        : "🚨 OpenRouter credit"
+      : "⚠️ OpenRouter credit";
+  const suffix = opts.repeat && !opts.escalated ? " (still unresolved)" : "";
+  return [
+    `${head}${suffix}`,
+    assessment.detail,
+    assessment.fix ? `→ ${assessment.fix}` : "",
+  ]
+    .filter((l) => l.length > 0)
+    .join("\n");
+}


### PR DESCRIPTION
feat(openrouter): see the credit shortfall coming, and say so honestly

#3868 stopped a spent OpenRouter balance leaking a raw 402 to an end user. That
is REACTIVE: by the time it fires, the fleet has already failed a request. This
is the proactive half.

VERIFIED CONTRACT (openrouter.ai/docs/api-reference/limits, read 2026-07-28).
`GET https://openrouter.ai/api/v1/key`, authenticated with the ORDINARY
inference key, returns `{data: {label, limit, limit_reset, limit_remaining,
include_byok_in_limit, usage, usage_daily/weekly/monthly, byok_usage*,
is_free_tier}}`.

THE CASE THAT BITES, and it is the fleet's state today: `limit` and
`limit_remaining` are **null** when the key has no per-key credit cap, and the
response carries **no account-balance field at all**. OpenRouter's docs are
explicit that credit comes from two places — account balance and per-key limits
— but this endpoint only ever describes the second. So with no per-key limit
set, nothing here can warn about the account running dry.

Rather than let that pass as a green tick, `switchroom doctor` reports it as a
WARN that says exactly why measurement is impossible and names the manual
console action that makes it possible. A monitor that silently passes when it
cannot see is worse than no monitor: it manufactures confidence.

What lands:

- `src/openrouter/credit.ts` — pure: the verified parse, the thresholds, and
  the verdict. WARN below 25% OR $10 remaining; FAIL below 10% OR $3, or at
  zero. Two thresholds because either alone is wrong at one end: a pure
  percentage warns at $125 left on a $500 limit (ignorable), a pure dollar
  floor warns at 50% on a $10 limit (too late). `actionable` distinguishes a
  quantified shortfall from a standing configuration gap.
- `src/cli/doctor-openrouter-credit.ts` + a doctor section — one line, skipped
  when no OpenRouter-backed model is configured in the proxy config.
- `src/openrouter/watch.ts` + `run.ts` + `state.ts` + `install-cron.ts` and
  `switchroom openrouter-watch` — the scheduled poll, modelled directly on
  `src/hindsight-watch/`: host CLI verb, host cron, zero model tokens, durable
  ledger under `~/.switchroom/`, delivery via `postOperatorNoticeViaGateways`,
  exit codes 0 / 10 firing / 1 could-not-complete. It reuses hindsight-watch's
  `RENOTIFY_MS` (6 h) so every standing operator alert in switchroom repeats on
  ONE rhythm. Hourly cadence: six observations inside one re-notify window, one
  third-party GET per hour.
- The poll deliberately does NOT DM about the uncapped-key case. That is a
  standing config gap, equally true in six weeks; paging about it hourly is how
  an alert channel gets muted. It belongs in `doctor`, where the operator went
  looking.

The API key is read through the normal vault broker path at runtime and used
only as an Authorization header. It is never logged, never returned, and never
placed in a detail, a notice, or an error string — one test asserts exactly
that across all six outcomes.

30 outcome tests. Mutation-checked — 7 deliberate breaks (report the uncapped
key as `ok`; make it actionable so it pages hourly; remove the 6 h cooldown;
remove the escalation override; persist the ledger for an UNDELIVERED alert so
a live incident goes quiet for 6 h; leak the key value into an error detail;
drop `flock -n` from the cron) each turned the suite red; all reverted.

MANUAL OPERATOR ACTION, unavoidable: setting a per-key credit limit at
https://openrouter.ai/settings/keys. OpenRouter exposes no API for it, and it
is what makes proactive monitoring possible at all.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
