### PR TITLE
feat(memory): seed a default observations_mission on every Hindsight bank

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -772,7 +772,7 @@ import { shouldEmitNotionMcp } from "../config/notion-workspace-acl.js";
 import { reconcileAgentDefaultSkills } from "./reconcile-default-skills.js";
 import { applyTelegramProgressGuidance, applySubAgentLocalTimeGuidance } from "./sub-agent-telegram-prompt.js";
 import type { McpServerConfig } from "../memory/hindsight.js";
-import { createBank, updateBankMissions, ensureDeclaredMentalModels, DEFAULT_RETAIN_MISSION, resolveBankMissionExtras, isHindsightEnabled, fetchBankRetainMission, decideRetainMissionUpgrade } from "../memory/hindsight.js";
+import { createBank, updateBankMissions, ensureDeclaredMentalModels, DEFAULT_RETAIN_MISSION, resolveBankMissionExtras, isHindsightEnabled, fetchBankRetainMission, decideRetainMissionUpgrade, PROFILE_MEMORY_DEFAULTS, fetchBankObservationsMission, decideObservationsMissionUpgrade } from "../memory/hindsight.js";
 import { loadTopicState } from "../telegram/state.js";
 import { resolveDualPath } from "../config/paths.js";
 import { resolvePath } from "../config/loader.js";
@@ -1953,6 +1953,51 @@ async function resolveRetainMissionPush(
   if (decision.action === "upgrade") {
     console.log(
       `  ${chalk.green("✓")} Upgrading superseded default retain_mission for ${label}`,
+    );
+  }
+  return decision.mission;
+}
+
+/**
+ * `observations_mission` counterpart of {@link resolveRetainMissionPush}, and
+ * deliberately the same shape: read the bank's current value, and push only
+ * when it is unset or byte-equals a mission switchroom itself shipped. Returns
+ * `undefined` for "push nothing".
+ *
+ * Before this existed, `observations_mission` reached `updateBankMissions`
+ * straight out of `resolveBankMissionExtras` and was therefore pushed
+ * UNCONDITIONALLY on every `switchroom apply` — the same clobber hazard the
+ * retain path was fixed for (2026-07-25 re-review H1). It never bit only
+ * because the sole value that could be produced came from a profile no live
+ * agent uses. Now that a fleet default makes this path hot, it goes through the
+ * read-first decision.
+ *
+ * A FAILED read pushes nothing: "unknown" must never be treated as
+ * "upgradable", or a Hindsight hiccup would overwrite an operator's mission.
+ */
+async function resolveObservationsMissionPush(
+  apiUrl: string,
+  bankId: string,
+  configured: string | undefined,
+  profileName: string,
+  label: string,
+): Promise<string | undefined> {
+  // Config wins outright and needs no read — push it regardless.
+  if (configured) return configured;
+
+  const profileDefault = PROFILE_MEMORY_DEFAULTS[profileName]?.observations_mission;
+  const current = await fetchBankObservationsMission(apiUrl, bankId, { timeoutMs: 5000 });
+  if (!current.ok) {
+    console.warn(
+      `  ${chalk.yellow("⚠")} Could not read current observations_mission for ${label} (${current.reason}) — leaving it untouched`,
+    );
+    return undefined;
+  }
+
+  const decision = decideObservationsMissionUpgrade(configured, profileDefault, current.mission);
+  if (decision.action === "upgrade") {
+    console.log(
+      `  ${chalk.green("✓")} Seeding default observations_mission for ${label}`,
     );
   }
   return decision.mission;
@@ -5996,6 +6041,21 @@ export function scaffoldAgent(
       if (seededRetainMission) {
         missions.retain_mission = seededRetainMission;
       }
+
+      // observations_mission does NOT ride `extras` straight through: like
+      // retain_mission it is a switchroom-managed default, so it goes through a
+      // read-first decision that never clobbers an operator's hand-edit.
+      delete missions.observations_mission;
+      const seededObservationsMission = await resolveObservationsMissionPush(
+        apiUrl,
+        hindsightBankId,
+        agentConfig.memory?.observations_mission,
+        agentConfig.extends ?? DEFAULT_PROFILE,
+        formatAgentBankLabel(name, hindsightBankId),
+      );
+      if (seededObservationsMission) {
+        missions.observations_mission = seededObservationsMission;
+      }
       if (userBankMission) {
         missions.bank_mission = userBankMission;
       }
@@ -8407,6 +8467,18 @@ function reconcileAgentInner(
         formatAgentBankLabel(name, hindsightBankId),
       );
       if (retainMission) missions.retain_mission = retainMission;
+
+      // Same read-first treatment for observations_mission — see
+      // `resolveObservationsMissionPush`.
+      delete missions.observations_mission;
+      const observationsMission = await resolveObservationsMissionPush(
+        apiUrl,
+        hindsightBankId,
+        agentConfig.memory?.observations_mission,
+        agentConfig.extends ?? DEFAULT_PROFILE,
+        formatAgentBankLabel(name, hindsightBankId),
+      );
+      if (observationsMission) missions.observations_mission = observationsMission;
 
       if (Object.keys(missions).length > 0) {
         await updateBankMissions(apiUrl, hindsightBankId, missions, { timeoutMs: 5000 })

--- a/src/memory/hindsight.ts
+++ b/src/memory/hindsight.ts
@@ -476,12 +476,174 @@ export function decideRetainMissionUpgrade(
   configured: string | undefined | null,
   current: string | null,
 ): { action: "config" | "upgrade" | "none"; mission?: string } {
+  return decideMissionUpgrade(
+    configured,
+    current,
+    DEFAULT_RETAIN_MISSION,
+    SUPERSEDED_RETAIN_MISSIONS,
+  );
+}
+
+/**
+ * Field-agnostic form of {@link decideRetainMissionUpgrade}.
+ *
+ * The never-clobber rule is the whole point, and it is identical for every
+ * mission-shaped bank config field: switchroom may seed and upgrade its OWN
+ * defaults, and must never overwrite text a human wrote. Encoding it once means
+ * a second managed mission field (`observations_mission`, below) cannot drift
+ * into a weaker rule by being implemented separately.
+ *
+ * @param configured Operator yaml value, if any. Wins outright, needs no read.
+ * @param current    The bank's live value; null ONLY when the read SUCCEEDED
+ *                   and the field is genuinely unset. A FAILED read must not be
+ *                   passed here at all — see `decideRetainMissionUpgrade`'s doc.
+ * @param desired    The default switchroom wants the bank to carry.
+ * @param shipped    Every OTHER value switchroom has ever shipped as a default
+ *                   for this field. Membership is byte-equality, so any
+ *                   hand-edit (even whitespace) matches nothing and is left
+ *                   alone.
+ */
+export function decideMissionUpgrade(
+  configured: string | undefined | null,
+  current: string | null,
+  desired: string,
+  shipped: readonly string[],
+): { action: "config" | "upgrade" | "none"; mission?: string } {
   if (configured) return { action: "config", mission: configured };
-  if (current === DEFAULT_RETAIN_MISSION) return { action: "none" };
-  if (isUpgradableRetainMission(current)) {
-    return { action: "upgrade", mission: DEFAULT_RETAIN_MISSION };
+  if (current === desired) return { action: "none" };
+  if (current == null || current.trim() === "" || shipped.includes(current)) {
+    return { action: "upgrade", mission: desired };
   }
   return { action: "none" };
+}
+
+/**
+ * Recommended default `observations_mission` for every switchroom-managed bank
+ * — the consolidation-side counterpart to {@link DEFAULT_RETAIN_MISSION}.
+ *
+ * ## The divergence this closes
+ *
+ * `observations_mission` is a documented Hindsight bank config field: "Defines
+ * what this bank should synthesise into durable observations"
+ * (<https://hindsight.vectorize.io/> bank configuration reference). Switchroom
+ * already had every piece of plumbing for it — `BankMissionExtras`,
+ * `resolveBankMissionExtras`, the `config_updates` write path — but the only
+ * value that ever reached a bank was
+ * `PROFILE_MEMORY_DEFAULTS["health-coach"].observations_mission`, keyed on
+ * `agents.<name>.extends`. Verified live 2026-07-28 against
+ * switchroom-hindsight (`GET /v1/default/banks/<id>/config` for every bank):
+ * all 27 banks carried `observations_mission: null`, including the
+ * health-coach agent's, because every live agent runs `extends: default`. The
+ * whole fleet therefore ran the engine's stock mission and the profile knob was
+ * dead code in practice.
+ *
+ * The stock mission is `_DEFAULT_MISSION` in
+ * `hindsight_api/engine/consolidation/prompts.py:10` — "Track anything notable
+ * in the new facts — names, numbers, dates, places, events, decisions, claims,
+ * relationships, and recurring patterns." It is deliberately maximal, and it is
+ * the wrong shape for a switchroom bank for two reasons that are checkable
+ * rather than aesthetic:
+ *
+ *  - **The observation tier is PREFERRED at recall.** `memory.recall.types`
+ *    defaults to `["world","experience","observation"]` and
+ *    `prefer_observations` defaults to true (`src/config/schema.ts`). So
+ *    switchroom biases the injected block toward observations while telling the
+ *    consolidator to synthesise "anything notable".
+ *  - **The raw fact layer leaks exactly what "anything notable" preserves.**
+ *    `DEFAULT_RETAIN_MISSION` above records the measured tool-exhaust leak (A/B
+ *    over 52 real retain chunks; 20.3% residual exhaust in the shipped arm),
+ *    and consolidation reads those leaked facts. Scoping the consolidation step
+ *    is the second line of defence on the SAME failure, at the tier recall
+ *    prefers.
+ *
+ * ## Blast radius — narrower than the docs claim
+ *
+ * The bank-config doc page says `observations_mission` "replaces the built-in
+ * consolidation rules entirely". That overstates it, and the difference is why
+ * this change is low-risk. In the deployed engine
+ * (`ghcr.io/switchroom/switchroom-hindsight:v0.19.26`, read 2026-07-28)
+ * `build_batch_consolidation_prompt` (`prompts.py:159`) substitutes this text
+ * for the `## MISSION` block ONLY; `_PROCESSING_RULES` (prefer-update-over-
+ * create, one-facet-per-observation, match-by-entity, state-change cascade),
+ * `_DECISION_GUIDE` and `_OUTPUT_SECTION` are concatenated unconditionally on
+ * every call. So this text scopes WHAT is synthesised and cannot disable
+ * merge/dedup behaviour.
+ *
+ * The engine does state its own precedence — "If anything in this MISSION
+ * conflicts with the PROCESSING RULES ... the MISSION takes priority"
+ * (`prompts.py:15`). The text below is therefore written purely in scope terms
+ * (what to keep, what to drop) and says nothing about merge-vs-create, so it
+ * never contradicts the rules it outranks.
+ *
+ * ## Why this text
+ *
+ * It keeps the stock mission's positive coverage — the consolidator must still
+ * be told it may record decisions, relationships and patterns. An
+ * exclusion-only mission produced degenerate empty output against this same
+ * small local extraction model in the retain-mission work above, which is why
+ * the positive clause leads and the exclusions follow.
+ */
+export const DEFAULT_OBSERVATIONS_MISSION =
+  "Synthesise durable, standing knowledge about the people, projects, and systems this agent works with: preferences and standing rules, roles and relationships, skills and recurring patterns, technical and operational decisions with their rationale, and the state of long-running work once it lands.\n" +
+  "\n" +
+  "The test is durability, not notability: an observation must still be worth reading weeks from now. A single dated event belongs in an observation only when it establishes or changes a standing fact.\n" +
+  "\n" +
+  "Do NOT synthesise observations from:\n" +
+  "- Transcript exhaust — tool calls and their results, file paths, temp or scratchpad directories, where some output was written, or narration of what an assistant did.\n" +
+  "- Identifiers with no standing meaning: session, agent, request, batch or command IDs, UUIDs, hashes, error codes.\n" +
+  "- In-flight process narration — a task started, paused, or still running. Record the outcome once it lands, not the running state.\n" +
+  "- The memory system's own errors, retries, backlogs, or internal state.\n" +
+  "- Transient state (what is running right now, unread counts, build status) unless the fact is explicitly dated, in which case record it as dated.\n" +
+  "\n" +
+  "If the new facts contain nothing durable, record nothing rather than synthesising a weak observation.";
+
+/**
+ * Ordered registry of every `observations_mission` switchroom has shipped as a
+ * DEFAULT, oldest first — the `observations_mission` analogue of
+ * {@link SUPERSEDED_RETAIN_MISSIONS}, consumed the same way by
+ * {@link decideMissionUpgrade}. Append the OUTGOING text when
+ * {@link DEFAULT_OBSERVATIONS_MISSION} changes; never edit an entry.
+ *
+ * Seeded with the `health-coach` profile default, which is the only
+ * observations mission switchroom has ever pushed. Listing it here is what lets
+ * an existing health-coach bank carrying it be recognised as switchroom-authored
+ * and upgradable, rather than mistaken for an operator hand-edit and frozen.
+ */
+export const SUPERSEDED_OBSERVATIONS_MISSIONS: readonly string[] = [
+  // PROFILE_MEMORY_DEFAULTS["health-coach"].observations_mission, shipped since
+  // the Phase 2 bank-specialisation work.
+  "Synthesise the person's wellbeing patterns, motivations, and emotional " +
+    "context — how habits, setbacks, and encouragement connect over time.",
+];
+
+/**
+ * Reconcile-time `observations_mission` decision (pure).
+ *
+ * Precedence: operator yaml > built-in profile default > the fleet default. The
+ * profile default is the DESIRED value for a profiled agent rather than a mere
+ * fallback, so a health-coach bank keeps its wellbeing mission instead of being
+ * flattened to the generic one.
+ *
+ * @param configured     `agents.<name>.memory.observations_mission` from yaml.
+ * @param profileDefault `PROFILE_MEMORY_DEFAULTS[<profile>].observations_mission`.
+ * @param current        The bank's live value; null ONLY on a SUCCESSFUL read of
+ *                       an unset field (see {@link decideMissionUpgrade}).
+ */
+export function decideObservationsMissionUpgrade(
+  configured: string | undefined | null,
+  profileDefault: string | undefined,
+  current: string | null,
+): { action: "config" | "upgrade" | "none"; mission?: string } {
+  const desired = profileDefault ?? DEFAULT_OBSERVATIONS_MISSION;
+  // Every text switchroom has ever shipped as a default for this field is
+  // upgradable, INCLUDING the current fleet default — otherwise a profiled
+  // agent whose bank was seeded generically could never reach its profile
+  // mission. `desired` itself is excluded so the "already current" short-circuit
+  // in decideMissionUpgrade stays the one that fires.
+  const shipped = [...SUPERSEDED_OBSERVATIONS_MISSIONS, DEFAULT_OBSERVATIONS_MISSION].filter(
+    (m) => m !== desired,
+  );
+  return decideMissionUpgrade(configured, current, desired, shipped);
 }
 
 /**
@@ -509,6 +671,39 @@ export async function fetchBankRetainMission(
   bankId: string,
   opts?: { fetchImpl?: typeof fetch; timeoutMs?: number },
 ): Promise<{ ok: true; mission: string | null } | { ok: false; reason: string }> {
+  return fetchBankMissionField(apiUrl, bankId, "retain_mission", opts);
+}
+
+/**
+ * Read a bank's current `observations_mission` from Hindsight. Same contract,
+ * timeouts and unrecognised-shape posture as {@link fetchBankRetainMission} —
+ * see that doc comment; only the config key differs.
+ */
+export async function fetchBankObservationsMission(
+  apiUrl: string,
+  bankId: string,
+  opts?: { fetchImpl?: typeof fetch; timeoutMs?: number },
+): Promise<{ ok: true; mission: string | null } | { ok: false; reason: string }> {
+  return fetchBankMissionField(apiUrl, bankId, "observations_mission", opts);
+}
+
+/**
+ * Shared reader behind {@link fetchBankRetainMission} and
+ * {@link fetchBankObservationsMission}.
+ *
+ * The unrecognised-shape posture is the load-bearing part and is why this is
+ * one function rather than two: a 200 whose body lacks `config`, or whose
+ * `config` lacks the requested KEY, is `{ ok: false }` and NOT "unset". The
+ * upgrade decision treats null as upgradable, so mapping an unrecognised shape
+ * to null would push a default over every customized mission fleet-wide the day
+ * Hindsight renests or renames a field (2026-07-25 re-review M1).
+ */
+async function fetchBankMissionField(
+  apiUrl: string,
+  bankId: string,
+  field: "retain_mission" | "observations_mission",
+  opts?: { fetchImpl?: typeof fetch; timeoutMs?: number },
+): Promise<{ ok: true; mission: string | null } | { ok: false; reason: string }> {
   const fetchImpl = opts?.fetchImpl ?? fetch;
   const timeoutMs = opts?.timeoutMs ?? 5000;
   const base = apiUrl.replace(/\/mcp\/?$/, "").replace(/\/$/, "");
@@ -520,20 +715,20 @@ export async function fetchBankRetainMission(
     clearTimeout(timeout);
     if (!resp.ok) return { ok: false, reason: `HTTP ${resp.status}` };
     const body = (await resp.json()) as {
-      config?: { retain_mission?: string | null } | null;
+      config?: Record<string, unknown> | null;
     };
     const config = body?.config;
     if (config == null || typeof config !== "object") {
       return { ok: false, reason: "Unexpected shape" };
     }
-    if (!("retain_mission" in config)) {
+    if (!(field in config)) {
       return { ok: false, reason: "Unexpected shape" };
     }
-    const mission = config.retain_mission;
+    const mission = config[field];
     if (mission != null && typeof mission !== "string") {
       return { ok: false, reason: "Unexpected shape" };
     }
-    return { ok: true, mission: mission ?? null };
+    return { ok: true, mission: (mission as string | undefined) ?? null };
   } catch (err) {
     clearTimeout(timeout);
     if ((err as Error).name === "AbortError") return { ok: false, reason: "Timeout" };

--- a/tests/memory.bank-missions.test.ts
+++ b/tests/memory.bank-missions.test.ts
@@ -8,6 +8,10 @@ import {
   fetchBankRetainMission,
   resolveBankMissionExtras,
   PROFILE_MEMORY_DEFAULTS,
+  DEFAULT_OBSERVATIONS_MISSION,
+  SUPERSEDED_OBSERVATIONS_MISSIONS,
+  decideObservationsMissionUpgrade,
+  fetchBankObservationsMission,
 } from "../src/memory/hindsight.js";
 import {
   reconcileAgent,
@@ -344,6 +348,135 @@ describe("fetchBankRetainMission", () => {
   });
 });
 
+describe("decideObservationsMissionUpgrade", () => {
+  it("seeds the fleet default onto an unset bank (the live fleet-wide state)", () => {
+    // Verified live 2026-07-28: all 27 banks on switchroom-hindsight carried
+    // observations_mission: null, so this is the case that actually fires.
+    expect(decideObservationsMissionUpgrade(undefined, undefined, null)).toEqual({
+      action: "upgrade",
+      mission: DEFAULT_OBSERVATIONS_MISSION,
+    });
+  });
+
+  it("treats a whitespace-only mission as unset", () => {
+    expect(decideObservationsMissionUpgrade(undefined, undefined, "   ")).toEqual({
+      action: "upgrade",
+      mission: DEFAULT_OBSERVATIONS_MISSION,
+    });
+  });
+
+  it("never clobbers an operator hand-edit", () => {
+    expect(
+      decideObservationsMissionUpgrade(undefined, undefined, "only track cricket scores"),
+    ).toEqual({ action: "none" });
+  });
+
+  it("is a no-op once the bank already carries the current default", () => {
+    expect(
+      decideObservationsMissionUpgrade(undefined, undefined, DEFAULT_OBSERVATIONS_MISSION),
+    ).toEqual({ action: "none" });
+  });
+
+  it("operator yaml wins outright, even over a hand-edited bank value", () => {
+    expect(
+      decideObservationsMissionUpgrade("from yaml", "profile text", "hand-written"),
+    ).toEqual({ action: "config", mission: "from yaml" });
+  });
+
+  it("a profiled agent gets its PROFILE mission, not the generic fleet default", () => {
+    const profile = PROFILE_MEMORY_DEFAULTS["health-coach"].observations_mission!;
+    expect(decideObservationsMissionUpgrade(undefined, profile, null)).toEqual({
+      action: "upgrade",
+      mission: profile,
+    });
+  });
+
+  it("upgrades a bank already holding the generic default to its profile mission", () => {
+    // Ordering hazard: an agent scaffolded before its profile was assigned
+    // carries the generic default. That is switchroom-authored text, so it must
+    // stay upgradable rather than being frozen as if a human wrote it.
+    const profile = PROFILE_MEMORY_DEFAULTS["health-coach"].observations_mission!;
+    expect(
+      decideObservationsMissionUpgrade(undefined, profile, DEFAULT_OBSERVATIONS_MISSION),
+    ).toEqual({ action: "upgrade", mission: profile });
+  });
+
+  it("upgrades every superseded default to the current one", () => {
+    for (const old of SUPERSEDED_OBSERVATIONS_MISSIONS) {
+      expect(decideObservationsMissionUpgrade(undefined, undefined, old)).toEqual({
+        action: "upgrade",
+        mission: DEFAULT_OBSERVATIONS_MISSION,
+      });
+    }
+  });
+});
+
+describe("SUPERSEDED_OBSERVATIONS_MISSIONS registry", () => {
+  it("never contains the current default (that would make the no-op case an upgrade)", () => {
+    expect(SUPERSEDED_OBSERVATIONS_MISSIONS).not.toContain(DEFAULT_OBSERVATIONS_MISSION);
+  });
+
+  it("carries the health-coach profile default, so those banks stay upgradable", () => {
+    expect(SUPERSEDED_OBSERVATIONS_MISSIONS).toContain(
+      PROFILE_MEMORY_DEFAULTS["health-coach"].observations_mission,
+    );
+  });
+});
+
+describe("fetchBankObservationsMission", () => {
+  it("reads config.observations_mission off the same REST config surface", async () => {
+    let seen = "";
+    const fetchImpl = vi.fn(async (url: string) => {
+      seen = url;
+      return {
+        ok: true,
+        json: async () => ({ config: { observations_mission: "current text" } }),
+      } as any;
+    });
+    const r = await fetchBankObservationsMission("http://h:18888/mcp/", "a b", {
+      fetchImpl: fetchImpl as any,
+    });
+    expect(seen).toBe("http://h:18888/v1/default/banks/a%20b/config");
+    expect(r).toEqual({ ok: true, mission: "current text" });
+  });
+
+  it("reports failure — not 'unset' — on an unrecognised body", async () => {
+    // Same M1 posture as retain: null reads as upgradable, so an unrecognised
+    // shape must never be flattened to null or a rename upstream would push the
+    // default over every customized mission fleet-wide.
+    const shapes = [
+      {},
+      { config: null },
+      { config: { retain_mission: "x" } }, // observations_mission key absent
+      { config: { observations_mission: 42 } },
+    ];
+    for (const body of shapes) {
+      const fetchImpl = vi.fn(async () => ({ ok: true, json: async () => body }) as any);
+      expect(
+        await fetchBankObservationsMission("http://h/mcp/", "b", { fetchImpl: fetchImpl as any }),
+      ).toEqual({ ok: false, reason: "Unexpected shape" });
+    }
+  });
+
+  it("does not confuse the two fields — a null retain_mission is not a null observations_mission", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          json: async () => ({
+            config: { retain_mission: null, observations_mission: "obs text" },
+          }),
+        }) as any,
+    );
+    expect(
+      await fetchBankObservationsMission("http://h/mcp/", "b", { fetchImpl: fetchImpl as any }),
+    ).toEqual({ ok: true, mission: "obs text" });
+    expect(
+      await fetchBankRetainMission("http://h/mcp/", "b", { fetchImpl: fetchImpl as any }),
+    ).toEqual({ ok: true, mission: null });
+  });
+});
+
 /**
  * End-to-end outcome test for review finding 1.
  *
@@ -466,6 +599,130 @@ describe("reconcileAgent — retain_mission upgrade on existing banks", () => {
     runReconcile(config);
     const args = await seen;
     expect((args.config_updates as Record<string, unknown>).retain_mission).toBe("operator text");
+  }, 15_000);
+});
+
+/**
+ * End-to-end outcome tests for the observations_mission seed.
+ *
+ * `switchroom apply` calls `scaffoldAgent` for every agent on every run, so
+ * scaffold — not reconcile — is the path that actually reaches live banks.
+ * These drive the real `scaffoldAgent` against a stubbed Hindsight and assert
+ * what goes out on the wire.
+ *
+ * Verified to bite: with the `resolveObservationsMissionPush` call removed from
+ * scaffold (i.e. the pre-change code, where observations_mission rode
+ * `resolveBankMissionExtras` and resolved to nothing for `extends: default`),
+ * "seeds the fleet default onto a bank with none" fails with the received value
+ * `undefined` — which is exactly the live fleet state measured on 2026-07-28.
+ */
+describe("scaffoldAgent — observations_mission seed", () => {
+  const telegramConfig: TelegramConfig = {
+    bot_token: "123456:ABC-DEF",
+    forum_chat_id: "-1001234567890",
+  };
+  const switchroomConfig: SwitchroomConfig = {
+    agents: {},
+    telegram: telegramConfig,
+    defaults: {},
+    memory: { backend: "hindsight", config: { url: "http://hindsight.test/mcp/" } },
+  } as unknown as SwitchroomConfig;
+
+  const realFetch = globalThis.fetch;
+  let tmpDir = "";
+
+  beforeEach(() => {
+    __resetPendingBankOpsForTests();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = "";
+  });
+
+  /**
+   * Stub Hindsight with a config surface that carries BOTH mission keys, so the
+   * observations reader sees a recognised shape. Resolves with the update_bank
+   * arguments once the fire-and-forget push lands.
+   */
+  function runScaffold(
+    currentObservations: string | null,
+    config: AgentConfig,
+    updateBankCalls: Record<string, unknown>[] = [],
+  ): Promise<Record<string, unknown>> {
+    tmpDir = mkdtempSync(resolve(tmpdir(), "switchroom-obs-mission-"));
+    let resolveArgs: (a: Record<string, unknown>) => void;
+    const seen = new Promise<Record<string, unknown>>((r) => (resolveArgs = r));
+    globalThis.fetch = (async (url: any, init?: any) => {
+      const u = String(url);
+      if (u.endsWith("/config")) {
+        return {
+          ok: true,
+          json: async () => ({
+            config: {
+              // Already current, so the retain half is a no-op and cannot be
+              // confused with the observations push under test.
+              retain_mission: DEFAULT_RETAIN_MISSION,
+              observations_mission: currentObservations,
+            },
+          }),
+        } as any;
+      }
+      const body = init?.body ? JSON.parse(init.body) : {};
+      if (body?.params?.name === "update_bank") {
+        updateBankCalls.push(body.params.arguments as Record<string, unknown>);
+        resolveArgs(body.params.arguments as Record<string, unknown>);
+      }
+      return {
+        ok: true,
+        headers: new Map(),
+        text: async () => JSON.stringify({ result: { isError: false, content: [] } }),
+      } as any;
+    }) as any;
+    scaffoldAgent("test-agent", config, tmpDir, telegramConfig, switchroomConfig);
+    return seen;
+  }
+
+  function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+    return {
+      extends: "default",
+      topic_name: "Test Topic",
+      schedule: [],
+      ...overrides,
+    } as AgentConfig;
+  }
+
+  it("seeds the fleet default onto a bank with none", async () => {
+    const config = makeAgentConfig();
+    const seen = runScaffold(null, config);
+    const args = await seen;
+    expect((args.config_updates as Record<string, unknown>).observations_mission).toBe(
+      DEFAULT_OBSERVATIONS_MISSION,
+    );
+  }, 15_000);
+
+  it("does NOT clobber an operator hand-edited observations_mission", async () => {
+    // Both managed missions are left alone here (retain is already current,
+    // observations is hand-edited), so `missions` is empty and the emptiness
+    // guard suppresses update_bank entirely. Asserting "no update_bank call"
+    // is therefore the strongest available statement of "nothing was clobbered".
+    const config = makeAgentConfig();
+    const calls: Record<string, unknown>[] = [];
+    runScaffold("only track cricket scores", config, calls);
+    await flushPendingBankOps(10_000);
+    expect(calls).toEqual([]);
+  }, 15_000);
+
+  it("pushes the operator's yaml observations_mission verbatim when set", async () => {
+    const config = makeAgentConfig({
+      memory: { observations_mission: "operator obs text" },
+    } as Partial<AgentConfig>);
+    const seen = runScaffold(null, config);
+    const args = await seen;
+    expect((args.config_updates as Record<string, unknown>).observations_mission).toBe(
+      "operator obs text",
+    );
   }, 15_000);
 });
 


### PR DESCRIPTION
## Summary

Seeds a switchroom-managed default `observations_mission` onto every Hindsight bank, through the same read-first, never-clobber push `retain_mission` already uses.

## Why

`observations_mission` is a **documented Hindsight bank config field** — "Defines what this bank should synthesise into durable observations". Switchroom already had every piece of plumbing for it (`BankMissionExtras.observations_mission`, `resolveBankMissionExtras`, the `config_updates` write path), but the only value that could ever reach a bank came from `PROFILE_MEMORY_DEFAULTS["health-coach"]`, keyed on `agents.<name>.extends`.

Every live agent runs `extends: default`. Verified live 2026-07-28 by reading `GET /v1/default/banks/<id>/config` for **all 27 banks** on `switchroom-hindsight`: every one carried `observations_mission: null`. The knob was effectively dead code and the whole fleet ran the engine's stock mission.

That stock mission (`hindsight_api/engine/consolidation/prompts.py:10`) is:

> Track anything notable in the new facts — names, numbers, dates, places, events, decisions, claims, relationships, and recurring patterns.

Deliberately maximal, and the wrong shape here for two checkable reasons:

- **The observation tier is PREFERRED at recall.** `memory.recall.types` defaults to `["world","experience","observation"]` and `prefer_observations` defaults to true (`src/config/schema.ts`). We bias the injected block toward observations while telling the consolidator to synthesise "anything notable".
- **The raw fact layer leaks exactly what "anything notable" preserves.** `DEFAULT_RETAIN_MISSION` documents the measured tool-exhaust leak (A/B over 52 real retain chunks; 20.3% residual in the shipped arm). Consolidation reads those leaked facts, so scoping the consolidation step is a second line of defence on the same failure, at the tier recall prefers.

This is the **config-first** fix: a documented bank config field, not new switchroom behaviour.

## Blast radius is narrower than the docs claim

The bank-config doc page says `observations_mission` "replaces the built-in consolidation rules entirely". That overstates the running implementation, and the difference is why this is low-risk. In the deployed engine (`ghcr.io/switchroom/switchroom-hindsight:v0.19.26`, read 2026-07-28) `build_batch_consolidation_prompt` (`prompts.py:159`) substitutes this text for the `## MISSION` block **only** — `_PROCESSING_RULES` (prefer-update-over-create, one-facet-per-observation, match-by-entity, state-change cascade), `_DECISION_GUIDE` and `_OUTPUT_SECTION` are concatenated unconditionally on every call. The text scopes *what* is synthesised and cannot disable merge/dedup behaviour.

The engine states its own precedence ("If anything in this MISSION conflicts with the PROCESSING RULES ... the MISSION takes priority", `prompts.py:15`), so the new text is written purely in scope terms and says nothing about merge-vs-create.

## What changed

- `src/memory/hindsight.ts`
  - `DEFAULT_OBSERVATIONS_MISSION`, `SUPERSEDED_OBSERVATIONS_MISSIONS`, `decideObservationsMissionUpgrade`.
  - `decideMissionUpgrade` — the never-clobber rule, extracted field-agnostic. `decideRetainMissionUpgrade` now delegates to it (behaviour byte-identical) so the two managed fields cannot drift into different safety rules.
  - `fetchBankObservationsMission`, over a shared `fetchBankMissionField`. The unrecognised-shape posture is preserved: a 200 whose `config` lacks the key is `{ok:false}`, never "unset" (M1, 2026-07-25 re-review).
- `src/agents/scaffold.ts` — `resolveObservationsMissionPush`, wired into **both** bank-op sites. `observations_mission` no longer rides `resolveBankMissionExtras` straight to the wire, where it was pushed unconditionally on every `switchroom apply` (the H1 clobber hazard retain was fixed for; it never bit only because no live agent used the profile that produced a value).

Precedence: operator yaml > profile default > fleet default. A health-coach bank keeps its wellbeing mission rather than being flattened.

## Test plan

`tests/memory.bank-missions.test.ts` — 72 pass locally (was 61). New coverage asserts outcomes, and both mutations were verified to bite:

- Removing the scaffold wiring (pre-change behaviour) fails *"seeds the fleet default onto a bank with none"* and *"pushes the operator's yaml observations_mission verbatim"* — reproducing the measured live fleet state.
- Replacing the decision with a naive unconditional push fails *"never clobbers an operator hand-edit"*, *"is a no-op once the bank already carries the current default"*, and the scaffold-level *"does NOT clobber…"*.

Also green: `tests/memory.create-bank.test.ts`, `memory.hindsight-contract.fixture.test.ts`, `memory.bank-health.test.ts`, `src/memory` (167 pass total). `npm run lint` clean.

## Risk

Low, and bounded by the read-first guard.

- The push fires only when the bank's value is unset/whitespace or byte-equals a mission switchroom itself shipped. Any hand-edit — even a whitespace difference — is left alone, and a **failed read pushes nothing** (never treats "unknown" as "upgradable").
- Consolidation is prospective: this changes what future consolidation rounds synthesise. Existing observations are untouched.
- Quality claim is deliberately narrow. Unlike the retain-mission revision, this text was **not** A/B'd against live extraction — it is a scoping mission over an engine prompt whose processing rules are unchanged, and the counterfactual is a mission that says "track anything notable". If it under-extracts, `agents.<name>.memory.observations_mission` overrides it per-agent with no code change.
- Existing retain-focused tests whose stub config omits `observations_mission` now log a benign `⚠ Could not read current observations_mission … leaving it untouched`. That is the fail-safe path working, and is also the real behaviour against a Hindsight build predating the field.

## Verdict rule

- **(a) Vision outcome:** standing-team — memory that compounds instead of accumulating exhaust.
- **(b) Job spec:** `reference/jobs/remember-across-sessions.md` — "brings back relevant facts, preferences, decisions, and open threads … in the right moment". This raises the signal of the tier recall already prefers.
- **(c) Principles:** docs test — one documented vendor field, exposed and defaulted, overridable in yaml. Defaults test — works on a fresh `switchroom setup` with zero yaml. Consistency test — identical shape and safety rule as the existing `retain_mission` path, now literally shared code.
- **(d) Invariants:** none crossed. Single-tenant preserved; no new egress, no `claude -p`, no API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)