### PR TITLE
fix(telegram): replies and reactions survive rate-limit pressure (#3885)

### DIFF
--- a/telegram-plugin/edit-flood-fuse.ts
+++ b/telegram-plugin/edit-flood-fuse.ts
@@ -165,8 +165,46 @@
  * `maxTightenLevel`) and decays one level at a time, so sustained pressure
  * ratchets the cosmetic rate down towards the floor of 1/window.
  *
+ * ── 2026-07-28: the reserve could not fire, and the reply paid (#3885) ────
+ * Points 3 and 5 above, and the escalating backoff, combined into a defect
+ * that hit the operator directly: during a 12-agent staggered restart that drew
+ * **three** genuine 429s, one chat logged 792 fuse events in an hour against a
+ * 35-50/hr baseline, shed 221 typing indicators, deferred 18 reactions, and
+ * deferred real replies long enough that the MCP `reply` tool's 60s timeout
+ * fired — so the agent retried and the operator got the same answer twice. One
+ * ~1900-character reply was lost outright.
+ *
+ * Three 3-second 429s ratchet `tightenLevel` to 3, and each one also writes
+ * `flood-wait.json`, which pinned `levelAt` at `maxTightenLevel` outright. At
+ * level 4 the shared per-chat budget is `max(1, floor(20 * 0.5^4))` = **1 call
+ * per minute for the entire chat**. The reserve that exists for precisely this
+ * case could not help, because it was a fixed count subtracted from the BASE:
+ * `max(1, 20 - 8)` = 12, tightened to 1 — the same 1 the reply had. Reply and
+ * repaint ended up with an identical budget, which is the opposite of a
+ * reservation. Three changes:
+ *
+ *   6. **The reserve is a PROPORTION, re-derived per window.** `cosmeticTotalMax`
+ *      computes it against the EFFECTIVE ceiling, so "8 of 20" means "40% of
+ *      whatever the budget currently is", and at least one slot is always
+ *      reserved. When the effective budget shrinks to the reserve, cosmetic
+ *      traffic gets 0 and every remaining slot belongs to a reply.
+ *   7. **A hard floor under `critical`.** `perChatCriticalMinPerWindow`
+ *      (default 3) is a rate no tightening may cross, on every per-chat tier.
+ *      Shedding a typing indicator under pressure is correct; holding the
+ *      answer past the caller's own timeout is not — it does not save a call,
+ *      it doubles it.
+ *   8. **A persisted flood window tightens IN PROPORTION to what remains**,
+ *      through the same severity ladder `noteFlood` uses, instead of jumping
+ *      straight to `maxTightenLevel`. `makeFloodWaitRecorder` writes the marker
+ *      for every 429 including a 3-second nudge, so the flat jump reintroduced
+ *      on the persisted path exactly the "a nudge and a 4.4h ban are the same
+ *      signal" defect that #3856 had just fixed on the in-memory path.
+ *
  * Every ceiling is operator-overridable via env — see
- * {@link editFloodFuseConfigFromEnv}. Previously none of them were.
+ * {@link editFloodFuseConfigFromEnv}. Previously none of them were, and until
+ * #3885 the tightening CURVE (`maxTightenLevel`, `tightenFactor`) still was
+ * not, which is why the only available workaround for the above was to inflate
+ * the base ceiling fleet-wide.
  */
 
 import { createHash } from 'node:crypto'
@@ -302,8 +340,29 @@ export interface EditFloodFuseConfig {
    * consume. Default 8. This is the reply-starvation guarantee: whatever the
    * repaint surfaces do, at least this many calls per window remain available
    * to an actual answer.
+   *
+   * Read as a PROPORTION of the base, not an absolute count (#3885). The
+   * reserve used to be a fixed number subtracted from the base ceiling, which
+   * made it arithmetically dead under tightening: at `maxTightenLevel` the base
+   * 20 collapses to an effective 1, and `1 - 8` clamps to the same floor of 1
+   * that cosmetic traffic already had — so reply and repaint ended up with an
+   * identical budget in exactly the situation the reserve exists for. It is now
+   * re-derived against the EFFECTIVE ceiling every window, and always leaves at
+   * least one slot reserved.
    */
   perChatReplyReserve?: number
+  /**
+   * Absolute floor, per `perChatWindowMs`, on `critical`-class traffic in one
+   * chat — the operator's actual answer, an approval card, a reaction. Default
+   * 3. No amount of tightening may take a chat below this: a reply held past
+   * the caller's own timeout is not "shedding under pressure", it is a lost
+   * answer plus a retry that sends it twice (#3885). Cosmetic traffic has no
+   * floor and is still shed to zero, which is the correct trade.
+   *
+   * Capped by the tier's own base ceiling, so an operator who deliberately
+   * configures a base below this floor still gets what they configured.
+   */
+  perChatCriticalMinPerWindow?: number
   /**
    * Ceiling on EVERY outbound call made with this bot token, across all chats
    * and including the chat-less ones. Default 25 per `perTokenWindowMs`
@@ -340,7 +399,11 @@ export interface EditFloodFuseConfig {
   tightenFactor?: number
   /** How long ONE level of tightening stays in force before decaying. Default 10 minutes. */
   tightenMs?: number
-  /** Cap on compounding 429 tightening levels. Default 4 (⇒ 0.5^4 = 1/16). */
+  /**
+   * Cap on compounding 429 tightening levels. Default 4 (⇒ 0.5^4 = 1/16).
+   * Operator-overridable via `SWITCHROOM_EDIT_FUSE_MAX_TIGHTEN_LEVEL` (#3885);
+   * `0` disables tightening entirely.
+   */
   maxTightenLevel?: number
   /**
    * Remaining ms of a KNOWN-OPEN Telegram flood window, or 0 when none — the
@@ -390,6 +453,18 @@ export interface EditFloodFuseStats {
   /** Live COSMETIC per-chat ceiling (post-AIMD). */
   cosmeticPerChatCeiling: number
   /**
+   * Live shared per-chat budget available to COSMETIC traffic (post-AIMD, after
+   * the reply reserve). Goes to 0 under heavy tightening — that is the reserve
+   * working, not a fault.
+   */
+  cosmeticPerChatTotalCeiling: number
+  /**
+   * Live shared per-chat budget available to CRITICAL traffic (post-AIMD, after
+   * the critical floor). The direct measure of #3885: this must never drop
+   * below `perChatCriticalMinPerWindow`, at any tighten level.
+   */
+  criticalPerChatTotalCeiling: number
+  /**
    * Chat-targeted calls charged by the DEFAULT-DENY rule — every one of these
    * was completely unmetered before #3855. A non-zero value here is the direct
    * measure of the hole this closed.
@@ -430,8 +505,18 @@ export const EDIT_FLOOD_FUSE_DEFAULTS = {
    * edits together — so this is the only window that reflects the real budget.
    */
   perChatTotalMaxPerWindow: 20,
-  /** 8 of those 20 slots/min are unreachable by cosmetic traffic. */
+  /**
+   * 8 of those 20 slots/min are unreachable by cosmetic traffic — i.e. 40% of
+   * whatever the EFFECTIVE ceiling is, re-derived per window (#3885).
+   */
   perChatReplyReserve: 8,
+  /**
+   * 3/60s. The hard floor on `critical` traffic in a chat. Sized against the
+   * thing that broke: the MCP `reply` tool times out at 60s, so a chat that can
+   * pass fewer than a couple of criticals a minute turns one answer into a
+   * timeout, a retry, and a duplicate message.
+   */
+  perChatCriticalMinPerWindow: 3,
   /**
    * 25 per second across the whole bot token. Telegram enforces ~30/s at the
    * token level and the ban it issues is token-scoped; 25 leaves headroom for
@@ -461,6 +546,20 @@ function envInt(raw: string | undefined): number | undefined {
 }
 
 /**
+ * Parse a multiplicative-decrease factor from env: a real in (0, 1].
+ *
+ * Rejects 0 and negatives (which would zero every ceiling) and anything above
+ * 1 (which would make a 429 LOOSEN the fuse). An out-of-range value is treated
+ * as unset rather than clamped — silently reinterpreting an operator's number
+ * is how a fuse ends up at a rate nobody chose.
+ */
+function envFactor(raw: string | undefined): number | undefined {
+  if (raw == null || raw.trim() === '') return undefined
+  const n = Number(raw)
+  return Number.isFinite(n) && n > 0 && n <= 1 ? n : undefined
+}
+
+/**
  * Operator config surface. Before the 2026-07-27 incident the fuse had exactly
  * one knob — `SWITCHROOM_EDIT_FUSE=0`, which turns the whole failsafe OFF —
  * so an operator whose chat was being flooded had no way to tighten it and no
@@ -478,8 +577,16 @@ export function editFloodFuseConfigFromEnv(
   assign('cosmeticPerChatMaxPerWindow', envInt(env.SWITCHROOM_FEED_EDIT_MAX_PER_CHAT_PER_MIN))
   assign('perChatTotalMaxPerWindow', envInt(env.SWITCHROOM_CHAT_TOTAL_MAX_PER_MIN))
   assign('perChatReplyReserve', envInt(env.SWITCHROOM_CHAT_REPLY_RESERVE))
+  assign('perChatCriticalMinPerWindow', envInt(env.SWITCHROOM_CHAT_CRITICAL_MIN_PER_MIN))
   assign('perTokenMaxPerWindow', envInt(env.SWITCHROOM_TOKEN_MAX_PER_SEC))
   assign('maxDeferMs', envInt(env.SWITCHROOM_EDIT_FUSE_MAX_DEFER_MS))
+  // #3885 — the tightening curve itself is now operator-tunable. Before this,
+  // `SWITCHROOM_CHAT_TOTAL_MAX_PER_MIN` was the ONLY lever on it, so an
+  // operator whose chats were collapsing under `factor^maxLevel` had to inflate
+  // the BASE ceiling fleet-wide to compensate — raising the untightened rate
+  // (the one that earns bans) to fix the tightened one.
+  assign('maxTightenLevel', envInt(env.SWITCHROOM_EDIT_FUSE_MAX_TIGHTEN_LEVEL))
+  assign('tightenFactor', envFactor(env.SWITCHROOM_EDIT_FUSE_TIGHTEN_FACTOR))
   // #3856 — durable ban awareness. The fuse reads the SAME persisted marker
   // (`flood-wait.json`) that `robustApiCall` and the outbox sweep consult, so a
   // restart mid-ban comes back tightened instead of at full rate. Wired here
@@ -529,12 +636,21 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
     perChatEditMax, config.cosmeticPerChatMaxPerWindow ?? D.cosmeticPerChatMaxPerWindow)
   const perChatTotalMax = config.perChatTotalMaxPerWindow ?? D.perChatTotalMaxPerWindow
   const perChatWindowMs = config.perChatWindowMs ?? D.perChatWindowMs
-  // Clamped so a misconfigured reserve can never make the cosmetic allowance
-  // negative (deadlocking every card) or eat the whole budget.
+  // Clamped so a misconfigured reserve can never eat more than the whole
+  // budget. Note this clamp is on the BASE only — the reserve that actually
+  // binds is re-derived per window by `cosmeticTotalMax` (#3885).
   const perChatReplyReserve = Math.min(
     Math.max(0, config.perChatReplyReserve ?? D.perChatReplyReserve),
     Math.max(0, perChatTotalMax - 1),
   )
+  /**
+   * The reserve as a FRACTION of the base. This is the whole #3885 fix: the
+   * reserve has to mean "40% of the chat's budget belongs to replies", not "8
+   * calls", because 8 is meaningless once the effective budget is 1.
+   */
+  const replyReserveFraction = perChatTotalMax > 0 ? perChatReplyReserve / perChatTotalMax : 0
+  const perChatCriticalMin = Math.max(
+    0, config.perChatCriticalMinPerWindow ?? D.perChatCriticalMinPerWindow)
   const perTokenMax = Math.max(1, config.perTokenMaxPerWindow ?? D.perTokenMaxPerWindow)
   const perTokenWindowMs = Math.max(1, config.perTokenWindowMs ?? D.perTokenWindowMs)
   // Only ever the PUBLIC bot id (or an irreversible hash) reaches this key.
@@ -602,12 +718,29 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
       tightenLevel--
       tightenedUntil = tightenLevel > 0 ? tightenedUntil + tightenMs : 0
     }
-    // #3856 — a KNOWN-OPEN persisted window pins the fuse at its tightest
-    // regardless of in-memory state. This is what survives a restart: the
-    // process forgets, the marker on disk does not. It does not MUTATE
-    // `tightenLevel`, so when the window closes the fuse returns to whatever
-    // this process actually earned rather than staying pinned.
-    if (persistedFloodRemainingMs(now) > 0) return maxTightenLevel
+    // #3856 — a KNOWN-OPEN persisted window pins the fuse regardless of
+    // in-memory state. This is what survives a restart: the process forgets,
+    // the marker on disk does not. It does not MUTATE `tightenLevel`, so when
+    // the window closes the fuse returns to whatever this process actually
+    // earned rather than staying pinned.
+    //
+    // #3885 — but pinned at a level PROPORTIONAL to the window still open, not
+    // unconditionally at `maxTightenLevel`. `flood-wait.json` is written for
+    // EVERY 429 including a routine 3-second nudge (`makeFloodWaitRecorder` →
+    // `computeFloodWait`), so the flat jump meant a 3s burst nudge and a 4.4h
+    // ban produced the identical maximal response — the exact asymmetry #3856
+    // fixed for the in-memory path and left in place here. The remaining window
+    // is graded through the SAME severity ladder `noteFlood` uses, so a big ban
+    // still pins at maximum and a nudge costs one level.
+    //
+    // Clamped by `maxTightenLevel` like every other path: `tightenStepFor`
+    // returns a fixed 1..3 for the smaller bands, so an operator who sets
+    // `SWITCHROOM_EDIT_FUSE_MAX_TIGHTEN_LEVEL=0` to disable tightening entirely
+    // must not find the fuse tightening anyway the moment a marker exists.
+    const remainingMs = persistedFloodRemainingMs(now)
+    if (remainingMs > 0) {
+      return Math.max(tightenLevel, Math.min(maxTightenLevel, tightenStepFor(remainingMs / 1000)))
+    }
     return tightenLevel
   }
 
@@ -624,6 +757,45 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
     const level = levelAt(now)
     if (level === 0) return base
     return Math.max(1, Math.floor(base * Math.pow(tightenFactor, level)))
+  }
+
+  /**
+   * The ceiling a given CLASS sees on a tier whose base is `base` (#3885).
+   *
+   * `critical` traffic — the operator's answer, an approval card, a reaction —
+   * gets an absolute floor that tightening cannot cross. Everything else takes
+   * the tightened ceiling as-is, so shedding still happens; it just happens to
+   * the traffic that can afford it.
+   *
+   * The floor is capped by `base` so it can only ever RAISE a tightened ceiling
+   * back towards what the operator configured, never above it.
+   */
+  function classCeiling(base: number, cls: OutboundClass, now: number): number {
+    const eff = ceiling(base, now)
+    if (cls !== 'critical') return eff
+    return Math.max(eff, Math.min(base, perChatCriticalMin))
+  }
+
+  /**
+   * The shared per-chat budget COSMETIC traffic may reach, re-derived against
+   * the EFFECTIVE ceiling (#3885).
+   *
+   * Returns 0 when the effective budget has shrunk to the reserve — at that
+   * point every remaining slot belongs to replies, and a repaint waits for the
+   * window or is shed. That is the intended behaviour under real flood
+   * pressure: the operator loses refresh frequency, never the answer.
+   */
+  function cosmeticTotalMax(now: number): number {
+    const eff = ceiling(perChatTotalMax, now)
+    if (replyReserveFraction <= 0) return eff
+    const reserve = Math.min(eff, Math.max(1, Math.round(eff * replyReserveFraction)))
+    return Math.max(0, eff - reserve)
+  }
+
+  /** Shared per-chat budget resolver, per class, evaluated at admission time. */
+  function totalMaxFor(cls: OutboundClass): (now: number) => number {
+    if (cls === 'cosmetic') return cosmeticTotalMax
+    return (now: number) => classCeiling(perChatTotalMax, cls, now)
   }
 
   function win(key: string): Window {
@@ -668,6 +840,14 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
   /** ms until `w` has room, or 0 if it has room now. */
   function waitFor(w: Window, now: number, windowMs: number, max: number): number {
     prune(w, now, windowMs)
+    // A ceiling of 0 is reachable now that the reply reserve is derived against
+    // the EFFECTIVE budget (#3885): under heavy tightening the whole remaining
+    // budget belongs to replies, so cosmetic traffic has none. There is no
+    // "oldest slot" to wait behind in that case, so wait out the window rather
+    // than indexing an empty array (which would produce NaN and admit).
+    if (max <= 0) {
+      return w.ts.length > 0 ? Math.max(1, w.ts[0]! + windowMs - now) : Math.max(1, windowMs)
+    }
     if (w.ts.length < max) return 0
     return Math.max(1, w.ts[0]! + windowMs - now)
   }
@@ -770,7 +950,16 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
    * Returns the reserved timestamp, or null when the call must be dropped.
    */
   async function awaitRoom(
-    key: string, windowMs: number, max: number, method: string, mode: WaitMode, cls: OutboundClass,
+    key: string, windowMs: number,
+    /**
+     * The ceiling, resolved at EVERY loop iteration rather than once at entry.
+     * It has to be a function: the effective ceiling depends on the tighten
+     * level, the tighten level decays with time, and a call can sit in this
+     * loop for `maxDeferMs`. Passing a number would pin a waiter to the ceiling
+     * that was in force when it arrived.
+     */
+    maxFor: (now: number) => number,
+    method: string, mode: WaitMode, cls: OutboundClass,
     /**
      * Consulted ONLY at the defer deadline for `mode: 'drop'`. Returning false
      * converts the drop into a late release: this call is the last thing that
@@ -805,7 +994,7 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
     let counted = false
     for (;;) {
       const now = clock.now()
-      const wait = waitFor(w, now, windowMs, ceiling(max, now))
+      const wait = waitFor(w, now, windowMs, maxFor(now))
       if (wait === 0) {
         w.ts.push(now)
         return now
@@ -897,22 +1086,29 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
     // It cannot take a per-chat slot (there is no chat to charge), but it does
     // consume the bot token's global allowance, which is the thing Telegram
     // actually bans. Charge it there and pass.
+    // The token tier is per-SECOND and global; a class floor there would be
+    // meaningless (even at maximum tightening it admits 60/min), so it takes
+    // the plain tightened ceiling.
+    const tokenMaxFor = (t: number): number => ceiling(perTokenMax, t)
+
     if (chat == null) {
       counters.chatless++
-      await awaitRoom(tokenKey, perTokenWindowMs, perTokenMax, method, 'release', cls, undefined, deadline)
+      await awaitRoom(tokenKey, perTokenWindowMs, tokenMaxFor, method, 'release', cls, undefined, deadline)
       return runObserved(next)
     }
 
     const totalKey = `t:${chat}`
-    // Cosmetic traffic may only reach `perChatTotalMax - perChatReplyReserve`;
-    // the remaining slots stay available to a real reply no matter how hot the
-    // repaint surfaces are. This reservation is the reply-starvation guarantee.
-    const totalMaxFor = (c: OutboundClass): number =>
-      c === 'cosmetic' ? Math.max(1, perChatTotalMax - perChatReplyReserve) : perChatTotalMax
+    // Cosmetic traffic may only reach the effective ceiling MINUS the reply
+    // reserve; the remaining slots stay available to a real reply no matter how
+    // hot the repaint surfaces are, and `critical` additionally cannot be
+    // tightened below `perChatCriticalMinPerWindow`. Together these are the
+    // reply-starvation guarantee, and unlike the pre-#3885 shape they hold at
+    // every tighten level rather than only at level 0.
+    const chatTotalMax = totalMaxFor(cls)
 
     /** Final tier for every chat-targeted path: the token-scoped ceiling. */
     const passToken = async (): Promise<R> => {
-      await awaitRoom(tokenKey, perTokenWindowMs, perTokenMax, method, 'release', cls, undefined, deadline)
+      await awaitRoom(tokenKey, perTokenWindowMs, tokenMaxFor, method, 'release', cls, undefined, deadline)
       return runObserved(next)
     }
 
@@ -925,7 +1121,9 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
       try {
         const msgSlot = await awaitRoom(
           msgKey, perMessageWindowMs,
-          cls === 'cosmetic' ? cosmeticPerMessageMax : perMessageMax,
+          cls === 'cosmetic'
+            ? (t) => ceiling(cosmeticPerMessageMax, t)
+            : (t) => classCeiling(perMessageMax, cls, t),
           method, 'supersede', cls, undefined, deadline,
         )
         if (msgSlot === null) return DROPPED_RESULT as unknown as R
@@ -941,7 +1139,9 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
         const chatKey = `ce:${chat}`
         const chatSlot = await awaitRoom(
           chatKey, perChatWindowMs,
-          cls === 'cosmetic' ? cosmeticPerChatMax : perChatEditMax,
+          cls === 'cosmetic'
+            ? (t) => ceiling(cosmeticPerChatMax, t)
+            : (t) => classCeiling(perChatEditMax, cls, t),
           method, 'drop', cls, dropGuard, deadline, lateKey,
         )
         if (chatSlot === null) { giveBack(); return DROPPED_RESULT as unknown as R }
@@ -951,7 +1151,7 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
         // metering. A non-cosmetic edit is RELEASED late rather than dropped:
         // an approval card or answer finalisation has no newer frame coming.
         const totalSlot = await awaitRoom(
-          totalKey, perChatWindowMs, totalMaxFor(cls), method,
+          totalKey, perChatWindowMs, chatTotalMax, method,
           cls === 'cosmetic' ? 'drop' : 'release', cls, dropGuard, deadline, lateKey,
         )
         if (totalSlot === null) { giveBack(); return DROPPED_RESULT as unknown as R }
@@ -965,8 +1165,9 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
       // Sends create user-visible output and are NEVER dropped — only paced.
       // The shared budget's reserve is what guarantees they still have room
       // when the repaint surfaces are saturated.
-      await awaitRoom(`cs:${chat}`, perChatWindowMs, perChatSendMax, method, 'release', cls, undefined, deadline)
-      await awaitRoom(totalKey, perChatWindowMs, totalMaxFor(cls), method, 'release', cls, undefined, deadline)
+      await awaitRoom(`cs:${chat}`, perChatWindowMs,
+        (t) => classCeiling(perChatSendMax, cls, t), method, 'release', cls, undefined, deadline)
+      await awaitRoom(totalKey, perChatWindowMs, chatTotalMax, method, 'release', cls, undefined, deadline)
       return passToken()
     }
 
@@ -982,14 +1183,14 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
       // short deadline also keeps a typing ping from occupying a 30s hold.
       const actionDeadline = Math.min(deadline, now + chatActionMaxDeferMs)
       const slot = await awaitRoom(
-        totalKey, perChatWindowMs, totalMaxFor(cls), method, 'drop', cls, undefined, actionDeadline,
+        totalKey, perChatWindowMs, chatTotalMax, method, 'drop', cls, undefined, actionDeadline,
       )
       if (slot === null) return DROPPED_RESULT as unknown as R
       return passToken()
     }
     // Durable, user-visible effect (a deletion, a pin, a reaction): paced,
     // never dropped — the same contract sends get.
-    await awaitRoom(totalKey, perChatWindowMs, totalMaxFor(cls), method, 'release', cls, undefined, deadline)
+    await awaitRoom(totalKey, perChatWindowMs, chatTotalMax, method, 'release', cls, undefined, deadline)
     return passToken()
   }
 
@@ -1026,6 +1227,8 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
       perMessageCeiling: ceiling(perMessageMax, now),
       cosmeticPerMessageCeiling: ceiling(cosmeticPerMessageMax, now),
       cosmeticPerChatCeiling: ceiling(cosmeticPerChatMax, now),
+      cosmeticPerChatTotalCeiling: cosmeticTotalMax(now),
+      criticalPerChatTotalCeiling: classCeiling(perChatTotalMax, 'critical', now),
       meteredByDefault: counters.meteredByDefault,
       chatless: counters.chatless,
       perTokenCeiling: ceiling(perTokenMax, now),

--- a/telegram-plugin/tests/edit-flood-fuse-ban-awareness.test.ts
+++ b/telegram-plugin/tests/edit-flood-fuse-ban-awareness.test.ts
@@ -106,7 +106,7 @@ describe('restart durability — the persisted window outranks process memory', 
 
   it('untightens once the window on disk closes — it is a floor, not a latch', async () => {
     const clock = new FakeClock()
-    let remaining = 60_000
+    let remaining = 12_247_000
     const fuse = createEditFloodFuse({
       clock, floodWaitRemainingMs: () => remaining,
       floodProbeIntervalMs: 0, // re-read every call, for determinism here
@@ -118,6 +118,63 @@ describe('restart durability — the persisted window outranks process memory', 
     // persisted window pins the level while open and never mutates it.
     expect(fuse.stats().tightenLevel).toBe(0)
     expect(fuse.stats().perMessageCeiling).toBe(20)
+  })
+
+  it('grades the persisted window by what REMAINS, not straight to maximum (#3885)', () => {
+    // `makeFloodWaitRecorder` writes `flood-wait.json` for EVERY 429, including
+    // a routine 3-second nudge. Pinning at `maxTightenLevel` for any open
+    // window therefore reintroduced on the persisted path the exact defect
+    // #3856 fixed on the in-memory one: a nudge and a 4.4h ban produced the
+    // same maximal response, collapsing a whole chat to 1 call/min over a
+    // transient blip. The severity ladder is the same one `noteFlood` uses.
+    const cases: [number, number][] = [
+      [3_000, 1],        // routine burst nudge
+      [45_000, 2],       // sustained overrate
+      [300_000, 3],      // a real ban
+      [12_247_000, 4],   // the 2026-07-27 magnitude — still straight to maximum
+    ]
+    for (const [remainingMs, expected] of cases) {
+      const fuse = createEditFloodFuse({
+        clock: new FakeClock(), floodWaitRemainingMs: () => remainingMs,
+        floodProbeIntervalMs: 0, maxTightenLevel: 4, tightenFactor: 0.5,
+      })
+      expect(fuse.stats().persistedFloodOpen).toBe(true)
+      expect(fuse.stats().tightenLevel).toBe(expected)
+    }
+  })
+
+  it('a single 3s 429 does not collapse the chat to 1 call/min (#3885)', async () => {
+    // The production regression, end to end: one transient 429 during a fleet
+    // restart both bumped the in-memory level AND wrote a 3-second marker that
+    // pinned the fuse at maximum, taking `perChatTotalMaxPerWindow: 20` down to
+    // an effective 1 for the whole chat.
+    const clock = new FakeClock()
+    const fuse = createEditFloodFuse({
+      clock, floodProbeIntervalMs: 0,
+      // The marker as the real recorder would write it for a 3s penalty.
+      floodWaitRemainingMs: () => Math.max(0, 3_000 - clock.now()),
+      perChatTotalMaxPerWindow: 20, perChatReplyReserve: 8, perChatSendMaxPerWindow: 25,
+      perTokenMaxPerWindow: 1_000, maxTightenLevel: 4, tightenFactor: 0.5,
+    })
+    await expect(
+      fuse.apply('sendMessage', { chat_id: CHAT, text: 'x' }, async () => { throw flood(3) }),
+    ).rejects.toThrow()
+
+    // One nudge is worth one level, on both paths — so the chat keeps half its
+    // budget, not one-twentieth of it.
+    expect(fuse.stats().tightenLevel).toBe(1)
+    expect(fuse.stats().criticalPerChatTotalCeiling).toBe(10)
+
+    // And it BINDS at that rate: 20 replies offered inside one window, ~half
+    // land promptly rather than one. 9 rather than 10 because the 429'd call
+    // above took a slot of the same window before it failed.
+    let landed = 0
+    const calls = Array.from({ length: 20 }, () =>
+      fuse.apply('sendMessage', { chat_id: CHAT, text: 'answer' }, async () => { landed++; return true }))
+    await clock.advance(1_000)
+    expect(landed).toBe(9)
+    await clock.advance(60_000)
+    await Promise.all(calls)
   })
 
   it('FAILS OPEN: an unreadable marker must never gag the bot', async () => {

--- a/telegram-plugin/tests/edit-flood-fuse-reply-reserve.test.ts
+++ b/telegram-plugin/tests/edit-flood-fuse-reply-reserve.test.ts
@@ -1,0 +1,340 @@
+/**
+ * The reply reserve must actually reserve — at EVERY tighten level (#3885).
+ *
+ * ── What broke in production ─────────────────────────────────────────────
+ * A 12-agent staggered restart drew three genuine 429s. The chat logged 792
+ * fuse events in an hour against a 35-50/hr baseline, shed 221 typing
+ * indicators, deferred 18 reactions (the operator noticed his reactions had
+ * stopped working), and held real replies long enough that the MCP `reply`
+ * tool's 60s timeout fired — so the agent retried and the operator received
+ * the same answer twice. One ~1900-character reply was lost entirely.
+ *
+ * The arithmetic: at `maxTightenLevel: 4` with `tightenFactor: 0.5`, the shared
+ * per-chat budget `max(1, floor(20 * 0.5^4))` is **1 call per minute for the
+ * whole chat**. `perChatReplyReserve: 8` was a fixed count subtracted from the
+ * BASE — `max(1, 20 - 8) = 12`, itself tightened to 1 — so a reply and a
+ * progress repaint ended up with the identical budget of 1. The reservation
+ * was arithmetically dead in exactly the situation it exists for.
+ *
+ * ── What these tests pin ─────────────────────────────────────────────────
+ * Outcomes on the wire, not code paths. Every case here counts how many calls
+ * a fake downstream actually received.
+ *
+ *   1. A `critical` message gets through at maximum tightening, inside the
+ *      window. (This is the case that fails on pre-#3885 code.)
+ *   2. Critical strictly out-ranks cosmetic on the shared budget at EVERY
+ *      tighten level — the reserve is proportional, not absolute.
+ *   3. Cosmetic traffic is still shed under pressure. #3847 built this feature
+ *      to stop a repaint surface earning a flood ban; the reserve fix must not
+ *      hand that budget back.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import { createEditFloodFuse, EDIT_FLOOD_FUSE_DEFAULTS } from '../edit-flood-fuse.js'
+import { withOutboundClass } from '../outbound-class.js'
+import type { Clock } from '../send-gate.js'
+
+const CHAT = '1001'
+
+class FakeClock implements Clock {
+  private cur = 0
+  private seq = 0
+  private timers: { at: number; id: number; resolve: () => void }[] = []
+  now(): number { return this.cur }
+  sleep(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.timers.push({ at: this.cur + ms, id: this.seq++, resolve })
+    })
+  }
+  async advance(ms: number): Promise<void> {
+    const target = this.cur + ms
+    for (;;) {
+      await flush()
+      const due = this.timers.filter((t) => t.at <= target).sort((a, b) => a.at - b.at || a.id - b.id)
+      if (due.length === 0) break
+      const t = due[0]!
+      this.timers = this.timers.filter((x) => x !== t)
+      this.cur = t.at
+      t.resolve()
+      await flush()
+    }
+    this.cur = target
+    await flush()
+  }
+}
+const flush = (): Promise<void> => new Promise((r) => setImmediate(r))
+
+/**
+ * A fuse pinned at `maxTightenLevel` via a large persisted ban window — the
+ * production shape, and the one where `0.5^4` bites.
+ */
+function tightestFuse(clock: FakeClock, over: Record<string, number> = {}) {
+  return createEditFloodFuse({
+    clock,
+    floodWaitRemainingMs: () => 12_247_000, // a 3.4h ban: maximum tightening
+    floodProbeIntervalMs: 0,
+    perChatTotalMaxPerWindow: 20,
+    perChatReplyReserve: 8,
+    perChatSendMaxPerWindow: 25,
+    perChatEditMaxPerWindow: 30,
+    perMessageMaxPerWindow: 20,
+    perChatWindowMs: 60_000,
+    perTokenMaxPerWindow: 1_000, // take the per-second tier out of the picture
+    maxTightenLevel: 4,
+    tightenFactor: 0.5,
+    ...over,
+  })
+}
+
+describe('a reply gets through at maximum tightening (#3885)', () => {
+  it('delivers a critical send inside the window when the chat is at its tightest', async () => {
+    // THE regression test. On pre-#3885 code the whole chat had an effective
+    // budget of 1/min and the reserve could not raise it, so the second and
+    // subsequent replies sat until `maxDeferMs` — past the MCP reply tool's
+    // own 60s timeout, which is what produced duplicates and one lost answer.
+    const clock = new FakeClock()
+    const fuse = tightestFuse(clock)
+    expect(fuse.stats().tightenLevel).toBe(4)
+
+    let landed = 0
+    const replies = Array.from({ length: 3 }, (_, i) =>
+      withOutboundClass('critical', () =>
+        fuse.apply('sendMessage', { chat_id: CHAT, text: `answer ${i}` }, async () => {
+          landed++
+          return true
+        })))
+    // No clock advance at all: the floor must be available immediately, not
+    // "eventually, after the window slides".
+    await flush()
+    expect(landed).toBe(EDIT_FLOOD_FUSE_DEFAULTS.perChatCriticalMinPerWindow)
+
+    await clock.advance(60_000)
+    await Promise.all(replies)
+  })
+
+  it('delivers a critical EDIT (an approval card, an answer finalisation) too', async () => {
+    const clock = new FakeClock()
+    const fuse = tightestFuse(clock)
+    let landed = 0
+    const edits = Array.from({ length: 3 }, (_, i) =>
+      withOutboundClass('critical', () =>
+        fuse.apply('editMessageText', { chat_id: CHAT, message_id: 100 + i }, async () => {
+          landed++
+          return true
+        })))
+    await flush()
+    expect(landed).toBe(3)
+    await clock.advance(60_000)
+    await Promise.all(edits)
+  })
+
+  it('delivers a critical reaction — the surface the operator noticed had died', async () => {
+    // `setMessageReaction` is neither an edit nor a send: it takes the
+    // default-deny path (#3855) straight to the shared per-chat budget, which
+    // is where it was being deferred 30s at a time.
+    const clock = new FakeClock()
+    const fuse = tightestFuse(clock)
+    let landed = 0
+    const calls = Array.from({ length: 3 }, () =>
+      withOutboundClass('critical', () =>
+        fuse.apply('setMessageReaction', { chat_id: CHAT, message_id: 7 }, async () => {
+          landed++
+          return true
+        })))
+    await flush()
+    expect(landed).toBe(3)
+    await clock.advance(60_000)
+    await Promise.all(calls)
+  })
+
+  it('the critical floor is capped by the operator\'s own base ceiling', async () => {
+    // A floor that could RAISE a ceiling above what the operator configured
+    // would be a second, hidden rate policy. Base 2 means 2, tightened or not.
+    const clock = new FakeClock()
+    const fuse = tightestFuse(clock, { perChatTotalMaxPerWindow: 2, perChatReplyReserve: 0 })
+    expect(fuse.stats().criticalPerChatTotalCeiling).toBe(2)
+    let landed = 0
+    const calls = Array.from({ length: 5 }, () =>
+      withOutboundClass('critical', () =>
+        fuse.apply('sendMessage', { chat_id: CHAT, text: 'x' }, async () => { landed++; return true })))
+    await flush()
+    expect(landed).toBe(2)
+    await clock.advance(60_000)
+    await Promise.all(calls)
+  })
+})
+
+describe('the reserve is honoured against the EFFECTIVE ceiling, at every level', () => {
+  it('critical strictly out-ranks cosmetic on the shared budget at levels 0..4', () => {
+    for (let level = 0; level <= 4; level++) {
+      const clock = new FakeClock()
+      // `tightenFactor^level` with a per-level persisted window is fiddly to
+      // stage; drive the level directly by tightening with graded 429s is
+      // equally so. Configure `maxTightenLevel: level` and hold a large
+      // persisted window: `levelAt` then reports exactly `level`.
+      const fuse = createEditFloodFuse({
+        clock,
+        floodWaitRemainingMs: () => 12_247_000,
+        floodProbeIntervalMs: 0,
+        perChatTotalMaxPerWindow: 20,
+        perChatReplyReserve: 8,
+        maxTightenLevel: level,
+        tightenFactor: 0.5,
+      })
+      const s = fuse.stats()
+      expect(s.tightenLevel).toBe(level)
+      // The property that failed in production: whatever the effective budget
+      // is, a reply always has strictly more of it than a repaint, and never
+      // less than the floor.
+      expect(s.criticalPerChatTotalCeiling).toBeGreaterThan(s.cosmeticPerChatTotalCeiling)
+      expect(s.criticalPerChatTotalCeiling)
+        .toBeGreaterThanOrEqual(EDIT_FLOOD_FUSE_DEFAULTS.perChatCriticalMinPerWindow)
+    }
+  })
+
+  it('level 0 behaviour is unchanged — 8 of 20 reserved, exactly as before', () => {
+    const fuse = createEditFloodFuse({
+      clock: new FakeClock(),
+      perChatTotalMaxPerWindow: 20,
+      perChatReplyReserve: 8,
+    })
+    expect(fuse.stats().tightenLevel).toBe(0)
+    expect(fuse.stats().criticalPerChatTotalCeiling).toBe(20)
+    expect(fuse.stats().cosmeticPerChatTotalCeiling).toBe(12)
+  })
+
+  it('a zero reserve still means zero — the fix does not invent a reservation', () => {
+    const fuse = createEditFloodFuse({
+      clock: new FakeClock(),
+      floodWaitRemainingMs: () => 12_247_000,
+      floodProbeIntervalMs: 0,
+      perChatTotalMaxPerWindow: 20,
+      perChatReplyReserve: 0,
+      maxTightenLevel: 4,
+      tightenFactor: 0.5,
+    })
+    expect(fuse.stats().cosmeticPerChatTotalCeiling).toBe(1)
+  })
+
+  it('cosmetic reaches 0 at the tightest — every remaining slot is the reply\'s', () => {
+    const fuse = createEditFloodFuse({
+      clock: new FakeClock(),
+      floodWaitRemainingMs: () => 12_247_000,
+      floodProbeIntervalMs: 0,
+      perChatTotalMaxPerWindow: 20,
+      perChatReplyReserve: 8,
+      maxTightenLevel: 4,
+      tightenFactor: 0.5,
+    })
+    expect(fuse.stats().cosmeticPerChatTotalCeiling).toBe(0)
+  })
+})
+
+describe('cosmetic traffic is still shed under pressure (#3847 must not regress)', () => {
+  it('sheds typing indicators while the chat is at maximum tightening', async () => {
+    const clock = new FakeClock()
+    const fuse = tightestFuse(clock)
+    let landed = 0
+    const actions = Array.from({ length: 12 }, () =>
+      withOutboundClass('cosmetic', () =>
+        fuse.apply('sendChatAction', { chat_id: CHAT, action: 'typing' }, async () => {
+          landed++
+          return true
+        })))
+    await clock.advance(31_000)
+    await Promise.all(actions)
+    // A typing bubble expires by itself in ~5s; delivering it late is worse
+    // than not delivering it. Under maximum tightening none should reach the
+    // wire — the budget belongs to the answer.
+    expect(landed).toBe(0)
+    expect(fuse.stats().dropped).toBeGreaterThan(0)
+  })
+
+  it('holds a hot cosmetic card far below the cosmetic ceiling when tightened', async () => {
+    const clock = new FakeClock()
+    const fuse = tightestFuse(clock, { cosmeticPerMessageMaxPerWindow: 4, cosmeticPerChatMaxPerWindow: 6 })
+    let landed = 0
+    const frames = Array.from({ length: 40 }, () =>
+      withOutboundClass('cosmetic', () =>
+        fuse.apply('editMessageText', { chat_id: CHAT, message_id: 7 }, async () => {
+          landed++
+          return true
+        })))
+    await clock.advance(31_000)
+    await Promise.all(frames)
+    // 0.5^4 of 4 floors at 1 repaint per window; the late-release budget can
+    // add at most `lateReleaseMaxPerWindow` tightened to 1 on top.
+    expect(landed).toBeLessThanOrEqual(2)
+  })
+
+  it('a saturated cosmetic surface cannot starve a reply', async () => {
+    // The starvation guarantee stated as an outcome: repaints run flat out for
+    // a whole window, and the answer still lands.
+    const clock = new FakeClock()
+    const fuse = tightestFuse(clock)
+    const frames = Array.from({ length: 60 }, (_, i) =>
+      withOutboundClass('cosmetic', () =>
+        fuse.apply('editMessageText', { chat_id: CHAT, message_id: 200 + (i % 6) }, async () => true)))
+    await flush()
+
+    let replied = 0
+    const reply = withOutboundClass('critical', () =>
+      fuse.apply('sendMessage', { chat_id: CHAT, text: 'the answer' }, async () => {
+        replied++
+        return true
+      }))
+    await flush()
+    expect(replied).toBe(1)
+
+    await clock.advance(61_000)
+    await Promise.all([...frames, reply])
+  })
+})
+
+describe('operator knobs for the tightening curve (#3885)', () => {
+  it('SWITCHROOM_EDIT_FUSE_MAX_TIGHTEN_LEVEL and _TIGHTEN_FACTOR reach the fuse', async () => {
+    const { editFloodFuseConfigFromEnv } = await import('../edit-flood-fuse.js')
+    const cfg = editFloodFuseConfigFromEnv({
+      SWITCHROOM_EDIT_FUSE_MAX_TIGHTEN_LEVEL: '2',
+      SWITCHROOM_EDIT_FUSE_TIGHTEN_FACTOR: '0.75',
+      SWITCHROOM_CHAT_CRITICAL_MIN_PER_MIN: '5',
+    })
+    expect(cfg.maxTightenLevel).toBe(2)
+    expect(cfg.tightenFactor).toBe(0.75)
+    expect(cfg.perChatCriticalMinPerWindow).toBe(5)
+
+    // And they BIND: 0.75^2 of 20 is 11, not 0.5^4's 1.
+    const fuse = createEditFloodFuse({
+      ...cfg, clock: new FakeClock(), floodProbeIntervalMs: 0,
+      floodWaitRemainingMs: () => 12_247_000, perChatTotalMaxPerWindow: 20,
+    })
+    expect(fuse.stats().criticalPerChatTotalCeiling).toBe(11)
+  })
+
+  it('maxTightenLevel=0 disables tightening even with a ban marker on disk', async () => {
+    // `tightenStepFor` returns a fixed 1..3 for the smaller severity bands, so
+    // the persisted path had to be clamped by `maxTightenLevel` too — otherwise
+    // an operator who turned tightening OFF would find the fuse tightening
+    // anyway the moment a marker existed.
+    const fuse = createEditFloodFuse({
+      clock: new FakeClock(),
+      floodWaitRemainingMs: () => 12_247_000,
+      floodProbeIntervalMs: 0,
+      maxTightenLevel: 0,
+      perChatTotalMaxPerWindow: 20,
+    })
+    expect(fuse.stats().persistedFloodOpen).toBe(true)
+    expect(fuse.stats().tightenLevel).toBe(0)
+    expect(fuse.stats().criticalPerChatTotalCeiling).toBe(20)
+  })
+
+  it('rejects an out-of-range tighten factor rather than silently clamping it', async () => {
+    const { editFloodFuseConfigFromEnv } = await import('../edit-flood-fuse.js')
+    for (const bad of ['0', '-1', '1.5', 'half', '']) {
+      expect(editFloodFuseConfigFromEnv({ SWITCHROOM_EDIT_FUSE_TIGHTEN_FACTOR: bad }).tightenFactor)
+        .toBeUndefined()
+    }
+    expect(editFloodFuseConfigFromEnv({ SWITCHROOM_EDIT_FUSE_TIGHTEN_FACTOR: '1' }).tightenFactor).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

**Under Telegram rate-limit pressure, the operator's replies and reactions now keep working instead of silently vanishing or arriving twice.** Typing indicators are still shed — that is the correct thing to drop — but the answer itself is not.

Fixes #3885, a v0.19.27 regression. On this host, a 12-agent staggered restart that drew **three genuine 429s** produced 792 fuse events in one hour (baseline 35-50/hr), 221 dropped `sendChatAction`, 18 deferred `setMessageReaction` (the operator noticed his reactions had stopped working), replies deferred past the MCP `reply` tool's 60s timeout — so the agent retried and sent duplicates — and one ~1900-character reply lost entirely.

## Why

v0.19.27 added `perChatTotalMaxPerWindow: 20` and `maxTightenLevel: 4`. `perChatReplyReserve` was supposed to protect replies in exactly this case, and could not:

```ts
// the reserve, computed once against the BASE ceiling
const perChatReplyReserve = Math.min(reserve, Math.max(0, perChatTotalMax - 1))   // 8
const totalMaxFor = (c) => c === 'cosmetic' ? Math.max(1, 20 - 8) : 20            // 12 / 20
// …then both are tightened at admission time
ceiling(12) = Math.max(1, Math.floor(12 * 0.5**4)) = 1
ceiling(20) = Math.max(1, Math.floor(20 * 0.5**4)) = 1
```

At maximum tightening the whole chat gets **1 API call per minute**, and reply and repaint get *the same* 1. The reservation is arithmetically dead precisely when it is needed. `levelAt` compounded it by returning `maxTightenLevel` for any open persisted `flood-wait.json` window — and `makeFloodWaitRecorder` writes that marker for **every** 429 including a routine 3-second nudge, so the flat jump reintroduced on the persisted path the exact "a 3s nudge and a 4.4h ban are the same signal" defect that #3856 had just fixed on the in-memory path.

## What changed

`telegram-plugin/edit-flood-fuse.ts` only.

1. **The reserve is a proportion, re-derived per window** (`cosmeticTotalMax`). "8 of 20" now means "40% of whatever the effective budget currently is", with at least one slot always reserved. When the effective budget shrinks to the reserve, cosmetic gets 0 and every remaining slot belongs to a reply. Level-0 behaviour is byte-identical to before (20 / 12).
2. **`perChatCriticalMinPerWindow` (default 3)** — an absolute floor on `critical` traffic that no tightening may cross, applied on every per-chat tier via `classCeiling`. Capped by the tier's own base, so it can only ever raise a *tightened* ceiling back toward what the operator configured, never above it.
3. **A persisted FLOOD_WAIT window tightens in proportion to what remains**, graded through the same `tightenStepFor` ladder `noteFlood` uses (≤5s → 1, ≤60s → 2, ≤600s → 3, beyond → max), clamped by `maxTightenLevel`. A restart mid-4.4h-ban still pins at maximum; a 3s blip costs one level.
4. **`maxTightenLevel` and `tightenFactor` are env knobs** — `SWITCHROOM_EDIT_FUSE_MAX_TIGHTEN_LEVEL`, `SWITCHROOM_EDIT_FUSE_TIGHTEN_FACTOR` (a real in (0, 1]; an out-of-range value is treated as unset rather than silently clamped), plus `SWITCHROOM_CHAT_CRITICAL_MIN_PER_MIN`.
5. `awaitRoom` takes a ceiling **resolver** instead of a number, so a waiter re-derives its budget on each loop iteration rather than being pinned to the level in force when it arrived.

With defaults at maximum tightening, per chat per minute: critical **3** (was 1), useful 1, cosmetic **0** (was 1).

## Can the `SWITCHROOM_CHAT_TOTAL_MAX_PER_MIN=96` workaround be reverted?

**Yes — and it should be, once this lands and the fleet is rolled.** It was only ever a way to reach the tightened ceiling by inflating the base, and it does that at a real cost: it raises the *untightened* per-chat rate from 20/min to 96/min, i.e. it loosens the ceiling that exists to stop a repaint surface earning a flood ban (#3847, #3855) in order to fix a reserve bug under tightening. 96/min is roughly 5x Telegram's documented per-group allowance. With this PR the tightened floor is guaranteed directly, so the base can go back to the default 20. If an operator still wants a lever on the curve itself, `SWITCHROOM_EDIT_FUSE_MAX_TIGHTEN_LEVEL` / `_TIGHTEN_FACTOR` are the right ones now.

Reverting is a `switchroom.yaml` + compose change on the host and is deliberately **not** in this PR.

## Test plan

New `telegram-plugin/tests/edit-flood-fuse-reply-reserve.test.ts` (14 tests) plus 2 in the ban-awareness suite. Every assertion is an outcome — how many calls a fake downstream actually received — not a code path.

**14 of them fail on `origin/main` source with the new tests applied** (verified by stashing only the source file):

- a critical send / edit / reaction lands at maximum tightening, with **no clock advance at all** (the floor must be available immediately, not after the window slides)
- critical strictly out-ranks cosmetic on the shared budget at tighten levels 0..4
- a saturated cosmetic surface (60 frames in flight) cannot starve a reply
- a single 3s 429 leaves the chat 10 calls/min, not 1
- the persisted window grades 3s → 1, 45s → 2, 300s → 3, 12247s → 4
- the operator knobs bind (`0.75^2` of 20 = 11, not `0.5^4`'s 1)

No-regression coverage that the feature still does its original job: typing indicators are shed to **zero** under maximum tightening, a hot cosmetic card stays at ≤2 frames/window, level-0 ceilings are unchanged, a zero reserve still means zero, and the critical floor cannot exceed a configured base.

```
$ ./node_modules/.bin/vitest run telegram-plugin/tests/edit-flood-fuse*.ts \
    telegram-plugin/tests/feed-edit-rate-ceiling.test.ts \
    telegram-plugin/tests/flood-circuit-breaker.test.ts \
    telegram-plugin/tests/worker-feed-terminal-edit-class.test.ts
 Test Files  7 passed (7)
      Tests  99 passed (99)

$ npm run lint
 ... check-agent-attribution-trailers: OK
```

One existing assertion changed: `edit-flood-fuse-ban-awareness.test.ts` "untightens once the window on disk closes" used a 60s persisted window and asserted level 4. That was asserting the jump-to-max, i.e. the bug. Its actual intent — "a floor, not a latch" — is preserved by giving it a ban-magnitude window (12247s, which still pins at 4), and the graduation it used to encode is now covered explicitly by its own test.

## Risk

Low and one-directional for user-facing traffic: every change either raises a ceiling for `critical` or lowers one for `cosmetic`. Nothing raises an untightened ceiling, so the flood-ban posture from #3847 / #3855 / #3856 is not loosened — the rate that earns a ban is unchanged at every tighten level. `waitFor` gained an explicit `max <= 0` branch because a zero cosmetic budget is now reachable; without it, an empty window would have indexed `ts[0]` and produced `NaN`, which compares false and would have *admitted* the call.

## Job spec

`reference/jobs/` — always available: the agent's answer reaches the operator. A rate-limit backstop that drops typing indicators is doing its job; one that holds the answer past the caller's own timeout is not shedding load, it is losing work and then doubling it on the retry.