### PR TITLE
perf(hindsight): derive the consolidation LLM concurrency cap so it can keep up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,75 @@ of any warning that the escalation was coming, and — the last one — the
 interactive reply path silently destroying the agent's composed answer instead
 of queueing it.
 
+### Consolidation keeps up with what agents write, instead of falling permanently behind
+
+Agents' recent work becomes searchable in hours instead of never. The
+consolidated memory layer — the observations recall actually returns, and the
+mental models built on top of them — only reflects what consolidation has
+processed, and on the busiest banks it had stopped keeping up: 43,155 memories
+pending on one bank and rising ~719 every 3 hours, 5,997 on the next. Nothing
+was erroring (`failed_consolidation` was 0 on every bank); it was purely
+throughput.
+
+The binding constraint was `HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT`,
+shipped as a hard literal `1`. It is a process-wide semaphore that every
+consolidation LLM call must acquire, and the engine composes it with the global
+cap rather than replacing it (`llm_wrapper._semaphores_for_scope`: "Per-op
+acquired first so contention queues on the narrower cap"). So at 1 the process
+makes at most ONE consolidation LLM call at a time no matter how many worker
+slots, banks or tag groups are in flight — and every other consolidation knob
+only pipelines the non-LLM stages behind it. Measured over one hour on the live
+fleet: 168 consolidation LLM calls averaging 29.4s consumed 4,936s of LLM wall
+time — **1.37 effective concurrency against 6 worker slots**, with the worker
+reporting `consolidation=6/3(avail=0,cap=6)` and per-batch logs showing
+`llm=160.9s` for calls the backend serves in ~30s. That whole gap was queueing
+on this semaphore.
+
+The default is now **derived** rather than a literal:
+
+```
+consolidation = clamp(global − retain − 1, 1, global − 1)
+```
+
+Two reasons it could not simply be a bigger number. A literal at or above the
+global cap is **inert and misleading** — the semaphores compose, so a
+consolidation cap of 6 against a global cap of 4 permits 4, not 6, and would
+advertise a ceiling the engine cannot honour. And a literal **cannot scale with
+the operator's endpoint**: the global cap is deliberately left at upstream's
+worked-example 4 because only the operator knows their slot count, so under a
+fixed literal an operator who measures their pool and raises the global cap gets
+zero extra consolidation throughput. That is exactly the trap this fleet fell
+into.
+
+The `− 1` is upstream's own stated purpose for per-op caps, quoted verbatim in
+`llm_wrapper._build_per_op_semaphores`: they exist so operators can "reserve
+headroom in the global pool by capping individual operations". Reflect and
+recall have no per-op cap, so subtracting the retain cap and one further slot
+guarantees an interactive reflect always has at least one global permit even
+with retain AND consolidation fully saturated. Background consolidation still
+cannot crowd the interactive lane off a shared local endpoint — the property the
+old literal `1` was protecting — it just stops being pinned to a single
+in-flight call. On switchroom's own defaults this lands on 2, double the
+previous ceiling, and it now tracks the global cap instead of needing a second
+yaml line.
+
+An explicit `hindsight.env` value still wins outright and is **not** clamped by
+the derivation; a test asserts an operator value above the headroom reserve
+survives verbatim, and another proves the derived default never exceeds the
+global cap across a 54-case matrix.
+
+Two things deliberately NOT changed. `CONSOLIDATION_LLM_PARALLELISM` stays at 2:
+it is a semaphore over *tag groups within one op*, built only under
+`if llm_parallelism > 1 and len(numbered_groups) > 1:`, and switchroom's
+`retainTags: ["{session_id}"]` means a bank resolves to one group — every batch
+on this fleet logs `1 llm calls` at any value. Pinning it to 1 would disable a
+real fan-out for deployments that do tag across scopes, so the value stays and
+the misleading doc comment is corrected instead. And
+`CONSOLIDATION_LLM_BATCH_SIZE` is not touched here at all: it is derived from
+the declared context window by `hindsight-context-budget.ts`, so a literal in
+the perf-defaults module would make two emitters race for one key and break the
+preflight that proves prompt + completion fit the window.
+
 ### A flood-blocked reply is queued, not destroyed (#3861)
 
 The durable-outbox work-loss guarantee held for the outbox-delivered paths and

--- a/src/setup/hindsight-perf-defaults.test.ts
+++ b/src/setup/hindsight-perf-defaults.test.ts
@@ -242,7 +242,9 @@ describe("hindsightPerfEnv — capability gating", () => {
     const got = new Map(hindsightPerfEnv({ gpu: false, localLlm: true }));
     expect(got.get("HINDSIGHT_API_LLM_MAX_CONCURRENT")).toBe("4");
     expect(got.get("HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT")).toBe("1");
-    expect(got.get("HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT")).toBe("1");
+    // Derived from global 4 / retain 1, reserving one global permit for the
+    // uncapped interactive lane: 4 - 1 - 1 = 2.
+    expect(got.get("HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT")).toBe("2");
   });
 
   it("treats a non-boolean-true capability as NOT proven", () => {
@@ -503,6 +505,134 @@ describe("HINDSIGHT_CE_DECISIVE_RELATIVE_GAP (override-only, patch rollback hatc
     const perf = { env: { [KEY]: "0.7" }, processEnv: {} };
     startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, false, perf);
     expect(runEnv(runArgs()).get(KEY)).toEqual(["0.7"]);
+  });
+});
+
+// ── the consolidation LLM concurrency ceiling ─────────────────────────────
+describe("HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT (derived, was a literal 1)", () => {
+  const KEY = "HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT";
+  const GLOBAL = "HINDSIGHT_API_LLM_MAX_CONCURRENT";
+  const RETAIN = "HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT";
+  const LOCAL = { gpu: false, localLlm: true };
+
+  it("no longer pins a fresh install to a single in-flight consolidation call", () => {
+    // The regression this guards is the measured one: at 1 the process makes at
+    // most ONE consolidation LLM call at a time regardless of worker slots, so
+    // the backlog can only grow. Assert the OUTCOME (the emitted ceiling), and
+    // assert it is strictly greater than the old hard throttle.
+    const emitted = Number(new Map(hindsightPerfEnv(LOCAL)).get(KEY));
+    expect(emitted).toBe(2);
+    expect(emitted).toBeGreaterThan(1);
+  });
+
+  it("widens when the operator raises the global cap, without a second yaml line", () => {
+    // The trap the old literal created: an operator measures their slot pool,
+    // raises the global cap, and gets ZERO extra consolidation throughput.
+    const wide = new Map(hindsightPerfEnv(LOCAL, new Map([[GLOBAL, "10"]])));
+    // global 10, retain default 1 => 10 - 1 - 1 = 8.
+    expect(wide.get(KEY)).toBe("8");
+    expect(Number(wide.get(KEY))).toBeGreaterThan(
+      Number(new Map(hindsightPerfEnv(LOCAL)).get(KEY)),
+    );
+  });
+
+  it("yields to a raised retain cap so both lanes cannot oversubscribe the pool", () => {
+    // The live fleet's shape: global 10, retain 6. The derived consolidation cap
+    // must leave retain's reservation AND one interactive permit intact.
+    const got = new Map(
+      hindsightPerfEnv(
+        LOCAL,
+        new Map([
+          [GLOBAL, "10"],
+          [RETAIN, "6"],
+        ]),
+      ),
+    );
+    expect(got.get(KEY)).toBe("3");
+    expect(Number(got.get(KEY)) + 6).toBeLessThan(10);
+  });
+
+  it("NEVER derives a default above the global cap, across the whole matrix", () => {
+    // The load-bearing invariant. The engine composes the two semaphores
+    // (llm_wrapper._semaphores_for_scope: per-op acquired first, THEN global),
+    // so a consolidation cap at or above the global cap is inert and
+    // advertises a ceiling the engine cannot honour — and leaves the uncapped
+    // reflect/recall lane with no guaranteed permit at all.
+    for (const global of [1, 2, 3, 4, 6, 8, 10, 16, 32]) {
+      for (const retain of [0, 1, 2, 6, 9, 32]) {
+        const got = new Map(
+          hindsightPerfEnv(
+            LOCAL,
+            new Map([
+              [GLOBAL, String(global)],
+              [RETAIN, String(retain)],
+            ]),
+          ),
+        );
+        const cap = Number(got.get(KEY));
+        const emittedGlobal = Number(got.get(GLOBAL));
+        expect(cap, `global=${global} retain=${retain}`).toBeLessThanOrEqual(emittedGlobal);
+        // Positive: the engine raises ValueError on a per-op cap <= 0
+        // ("must be a positive integer"), which would refuse to boot.
+        expect(cap, `global=${global} retain=${retain}`).toBeGreaterThanOrEqual(1);
+        // Headroom: only a global cap of 1 can leave the interactive lane
+        // sharing consolidation's single permit.
+        if (emittedGlobal > 1) {
+          expect(cap, `global=${global} retain=${retain}`).toBeLessThan(emittedGlobal);
+        }
+      }
+    }
+  });
+
+  it("falls back to the shipped caps rather than deriving from junk", () => {
+    for (const junk of ["", "banana", "0", "-4", "3.9.1"]) {
+      const got = new Map(hindsightPerfEnv(LOCAL, new Map([[GLOBAL, junk]])));
+      expect(Number(got.get(KEY)), `global=${JSON.stringify(junk)}`).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("an explicit operator value survives and is NOT clamped by the derivation", () => {
+    // Overridability is the hard requirement: these are defaults. An operator
+    // who has measured their endpoint may deliberately exceed our headroom
+    // reserve, and we must not quietly rewrite their number.
+    const got = new Map(
+      hindsightPerfEnv(
+        LOCAL,
+        new Map([
+          [GLOBAL, "10"],
+          [KEY, "9"],
+        ]),
+      ),
+    );
+    expect(got.get(KEY)).toBe("9");
+  });
+
+  it("the operator's value REPLACES the default on BOTH launch paths", () => {
+    const perf = { env: { [KEY]: "5" }, processEnv: {} };
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false, perf);
+    // Exactly one value per path — a duplicate emission would be last-wins by
+    // luck on docker-run and ambiguous in compose.
+    expect(runEnv(runArgs()).get(KEY)).toEqual(["5"]);
+    expect(
+      composeEnv(
+        generateHindsightComposeSnippet(undefined, undefined, LOOPBACK_LITELLM, false, perf),
+      ).get(KEY),
+    ).toEqual(["5"]);
+  });
+
+  it("emits the derived default exactly once per path when NOT overridden", () => {
+    const perf = { env: {}, processEnv: {} };
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false, perf);
+    expect(runEnv(runArgs()).get(KEY)).toEqual(["2"]);
+    expect(
+      composeEnv(
+        generateHindsightComposeSnippet(undefined, undefined, LOOPBACK_LITELLM, false, perf),
+      ).get(KEY),
+    ).toEqual(["2"]);
+  });
+
+  it("stays absent on a cloud endpoint — it is a local-slot-pool knob", () => {
+    expect(new Map(hindsightPerfEnv({ gpu: true, localLlm: false })).has(KEY)).toBe(false);
   });
 });
 
@@ -813,7 +943,8 @@ describe("startHindsight — performance defaults reach the container", () => {
     const fromRun = runEnv(runArgs());
     expect(fromRun.get("HINDSIGHT_API_LLM_MAX_CONCURRENT")).toEqual(["4"]);
     expect(fromRun.get("HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT")).toEqual(["1"]);
-    expect(fromRun.get("HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT")).toEqual(["1"]);
+    // Derived from global 4 / retain 1 — see the consolidation-cap block below.
+    expect(fromRun.get("HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT")).toEqual(["2"]);
     // ...and the compose twin reads the same argument the same way.
     const fromCompose = composeEnv(
       generateHindsightComposeSnippet(llm, undefined, undefined, false),

--- a/src/setup/hindsight-perf-defaults.ts
+++ b/src/setup/hindsight-perf-defaults.ts
@@ -57,6 +57,17 @@
  * `HINDSIGHT_API_RERANKER_MAX_CANDIDATES` is deliberately untouched (150).
  * The rejection rationale is recorded at
  * src/setup/hindsight-reranker-budget.test.ts:111-118.
+ *
+ * `HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE` is NOT a default here and must
+ * not become one. It is *derived* from the declared context window by
+ * `resolveHindsightContextBudget()` (`hindsight-context-budget.ts`, the
+ * `batchSize = clamp(⌊(promptBudget − OVERHEAD) / PER_FACT⌋, 1, 12)` line) and
+ * emitted from that derivation by `hindsightLlmBudgetEnv()`
+ * (`hindsight.ts`). Adding a literal for it to any group in this module would
+ * make two emitters race for one key, and would break the preflight in
+ * `assertHindsightContextBudgetFits()` that proves prompt + completion fit the
+ * window. Batch size is a context-window decision; change the derivation, not
+ * this file.
  */
 
 import { HINDSIGHT_PG_ENV_KEYS } from "./hindsight-pg-defaults.js";
@@ -257,19 +268,100 @@ export const HINDSIGHT_DEFAULT_RETAIN_LLM_MAX_CONCURRENT = 1;
  * global cap pipelines the non-LLM stages and improves fairness, but only THIS
  * value multiplies concurrent consolidation inference.
  *
- * Kept at 1 by default: it is the guarantee that background consolidation
- * cannot crowd interactive recall/reflect off a shared local endpoint, which
- * is upstream's stated reason for the worked example. Raising it is a real
- * latency trade on the interactive lanes, so it is an operator decision made
- * declaratively against a measured slot pool, not a shipped default:
+ * ## Why this is DERIVED and not a literal any more
+ *
+ * A fixed 1 made the shipped default a hard throttle that no other knob could
+ * lift. Measured on the live fleet (2026-07-28, 60 minutes of logs): 168
+ * consolidation LLM calls averaging 29.4s consumed 4,936s of LLM wall time in
+ * one hour — **1.37 effective concurrency against 6 worker slots**, with the
+ * worker reporting `consolidation=6/3(avail=0,cap=6)` and per-batch logs
+ * showing `llm=160.9s` for calls the backend serves in ~30s. That gap is
+ * queueing on this semaphore and nothing else; `failed_consolidation` was 0 on
+ * every bank. The result was a backlog that only grows — 43,155 pending on the
+ * busiest bank, rising ~719 every 3 hours.
+ *
+ * Two failure modes rule out simply picking a bigger literal:
+ *
+ *  1. **A literal at or above the global cap is inert AND misleading.** The
+ *     semaphores compose, so a consolidation cap of 6 against a global cap of 4
+ *     permits 4, not 6. Shipping 6 would advertise a ceiling the engine cannot
+ *     honour — the same "knob set to a value that does nothing" defect this
+ *     module exists to remove.
+ *  2. **A literal cannot scale with the operator's endpoint.** The global cap
+ *     is deliberately left at upstream's worked-example 4 because only the
+ *     operator knows their slot count. Under a fixed consolidation literal, an
+ *     operator who measures their pool and raises the global cap gets *zero*
+ *     extra consolidation throughput — which is exactly the trap the fleet fell
+ *     into.
+ *
+ * So the default is a function of the caps around it:
+ *
+ * ```
+ *   consolidation = clamp(global − retain − 1, 1, global − 1)
+ * ```
+ *
+ * The `− 1` is upstream's own stated purpose for per-op caps, quoted in
+ * `llm_wrapper._build_per_op_semaphores`: "This lets operators reserve headroom
+ * in the global pool by capping individual operations (e.g. cap retain at 2 of
+ * 4 global slots so the live chat path always has 2 slots available)." Reflect
+ * and recall have no per-op cap, so their headroom is whatever the capped lanes
+ * leave. Subtracting the retain cap and one further slot guarantees that even
+ * with retain AND consolidation both fully saturated, an interactive reflect
+ * always has at least one global permit. Background consolidation therefore
+ * still cannot crowd the interactive lane off a shared local endpoint — the
+ * property the old literal 1 was protecting — while it stops being pinned to a
+ * single in-flight call.
+ *
+ * On switchroom's own defaults (global 4, retain 1) this lands on **2**, double
+ * the previous ceiling. On an operator who has raised the global cap to 10 with
+ * retain at 6 it lands on 3, and it keeps tracking further changes instead of
+ * needing a second yaml line.
+ *
+ * An explicit operator value still wins outright and is NOT clamped — the
+ * derivation only supplies the default:
  *
  * ```yaml
  * hindsight:
  *   env:
- *     HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT: 2
+ *     HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT: 4
  * ```
+ *
+ * RESTORE CONDITION (unchanged, inherited from the 2026-07-06 quota incident):
+ * if consolidation ever returns to `provider: claude-code`, every concurrent op
+ * is a live subprocess spending the subscription's quota and this must go back
+ * to a hard 1.
  */
-export const HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_MAX_CONCURRENT = 1;
+export function hindsightConsolidationLlmMaxConcurrentDefault(
+  globalMaxConcurrent: number = HINDSIGHT_DEFAULT_LLM_MAX_CONCURRENT,
+  retainMaxConcurrent: number = HINDSIGHT_DEFAULT_RETAIN_LLM_MAX_CONCURRENT,
+): number {
+  // Defensive: an operator override arrives as a string and may be junk. A
+  // non-finite or non-positive cap falls back to the shipped literal rather
+  // than deriving nonsense from it.
+  const globalCap =
+    Number.isFinite(globalMaxConcurrent) && globalMaxConcurrent >= 1
+      ? Math.floor(globalMaxConcurrent)
+      : HINDSIGHT_DEFAULT_LLM_MAX_CONCURRENT;
+  const retainCap =
+    Number.isFinite(retainMaxConcurrent) && retainMaxConcurrent >= 0
+      ? Math.floor(retainMaxConcurrent)
+      : HINDSIGHT_DEFAULT_RETAIN_LLM_MAX_CONCURRENT;
+
+  // Never exceed `globalCap - 1` (the reflect/recall reserve) and never fall
+  // below 1 (0 would be rejected by the engine: "must be a positive integer").
+  const headroomBound = Math.max(1, globalCap - 1);
+  return Math.min(headroomBound, Math.max(1, globalCap - retainCap - 1));
+}
+
+/**
+ * The derived consolidation cap on switchroom's own shipped caps — i.e. what a
+ * fresh install with no `hindsight.env` gets. Exported as the readable anchor
+ * for docs and tests; the emitted value is always
+ * {@link hindsightConsolidationLlmMaxConcurrentDefault} applied to the
+ * EFFECTIVE caps, so an operator who raises the global cap moves this too.
+ */
+export const HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_MAX_CONCURRENT =
+  hindsightConsolidationLlmMaxConcurrentDefault();
 
 /**
  * Half-precision local reranking. Upstream default `false`, and upstream is
@@ -337,6 +429,27 @@ export const HINDSIGHT_DEFAULT_LLM_MAX_RETRIES = 2;
  * i.e. the value is not absolute, it is pegged to how much LLM concurrency the
  * deployment has granted. switchroom holds 2, chosen when a consolidation call
  * was the heaviest thing on a single local backend.
+ *
+ * ## READ THIS BEFORE TUNING IT: on most switchroom banks it does NOTHING
+ *
+ * This is a semaphore over *tag groups within one consolidation op*, not over
+ * LLM calls. `consolidator.py` only builds it at all under
+ * `if llm_parallelism > 1 and len(numbered_groups) > 1:` — with a single tag
+ * group there is one group, the `else` branch runs the groups serially, and the
+ * semaphore is never constructed. switchroom retains with
+ * `retainTags: ["{session_id}"]`, so a bank overwhelmingly resolves to ONE tag
+ * set and therefore one group. Confirmed live (2026-07-28): every consolidation
+ * batch on this fleet logs `1 llm calls`, at every value of this knob. Upstream
+ * tracks the general shape of this as vectorize-io/hindsight#1604.
+ *
+ * So it is not a throughput knob here and must not be reached for as one.
+ * {@link hindsightConsolidationLlmMaxConcurrentDefault} is the knob that
+ * actually multiplies concurrent consolidation inference.
+ *
+ * Left at 2 rather than dropped to 1: on a deployment that DOES tag across
+ * several scopes the fan-out is real, and pinning 1 would disable it for those
+ * installs to make one fleet's log line tidier. The misleading thing was this
+ * comment, not the value.
  *
  * Moved here from a bare constant in `hindsight.ts` (2026-07-27). The value is
  * unchanged; what changes is that it is now a MANAGED key, so an operator can
@@ -794,13 +907,36 @@ export function hindsightPerfEnv(
   if (caps.gpu === true) groups.push(HINDSIGHT_PERF_DEFAULTS_GPU);
   if (caps.localLlm === true) groups.push(HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM);
 
+  // The consolidation cap's default is derived from the EFFECTIVE global and
+  // retain caps, so an operator who raises the global cap widens consolidation
+  // with it instead of staying pinned to a literal the engine may not even be
+  // able to honour. See hindsightConsolidationLlmMaxConcurrentDefault. An
+  // explicit consolidation override still wins below, unclamped.
+  const effectiveCap = (key: string, fallback: number): number => {
+    const raw = overrides.get(key);
+    if (raw === undefined) return fallback;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed >= 1 ? parsed : fallback;
+  };
+  const derivedConsolidationCap = String(
+    hindsightConsolidationLlmMaxConcurrentDefault(
+      effectiveCap("HINDSIGHT_API_LLM_MAX_CONCURRENT", HINDSIGHT_DEFAULT_LLM_MAX_CONCURRENT),
+      effectiveCap(
+        "HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT",
+        HINDSIGHT_DEFAULT_RETAIN_LLM_MAX_CONCURRENT,
+      ),
+    ),
+  );
+
   const out: Array<[string, string]> = [];
   const emitted = new Set<string>();
   for (const group of groups) {
     for (const [key, value] of group) {
       if (emitted.has(key)) continue;
       emitted.add(key);
-      out.push([key, overrides.get(key) ?? value]);
+      const shipped =
+        key === "HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT" ? derivedConsolidationCap : value;
+      out.push([key, overrides.get(key) ?? shipped]);
     }
   }
 

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -706,7 +706,8 @@ export function hindsightLlmBudgetEnv(llm?: HindsightLlmConfig): Array<[string, 
  *
  * Interactive-lane protection therefore lives elsewhere, and this is the knob
  * to reach for first: `HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT`
- * (src/setup/hindsight-perf-defaults.ts, default 1) is a process-wide
+ * (src/setup/hindsight-perf-defaults.ts — DERIVED from the effective global and
+ * retain caps, landing on 2 with switchroom's own defaults) is a process-wide
  * semaphore on consolidation LLM calls — see the engine's
  * `llm_wrapper._build_per_op_semaphores`, where a consolidation call must
  * acquire the per-op semaphore AND the global one. Every knob in THIS block


### PR DESCRIPTION
## Summary

**Agents' recent work becomes searchable in hours instead of never**, because the consolidated memory layer keeps up with what they write.

Recall returns consolidated observations, and mental models are built on top of them. Neither reflects anything consolidation has not processed yet — so a bank whose backlog only grows has a memory layer that is permanently stale about the last N days of that agent's work. That is where the fleet was.

Measured 2026-07-28 on the live fleet:

- **43,155 memories pending** on the busiest bank, rising **~719 every 3 hours**. 5,997 on the next.
- `failed_consolidation` **0 on every bank** — nothing was erroring. Purely throughput.
- Over one hour: **168 consolidation LLM calls averaging 29.4s consumed 4,936s of LLM wall time** = **1.37 effective concurrency against 6 worker slots**.
- The worker reported `consolidation=6/3(avail=0,cap=6)` — six ops in flight, zero available.
- Per-batch logs showed `llm=160.9s` for calls the backend serves in ~30s.

That entire gap is queueing on one semaphore.

## Why

`HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT` was shipped as a hard literal `1`. Verified in the running engine rather than inferred — `llm_wrapper._build_per_op_semaphores` builds a process-wide `asyncio.Semaphore` per operation, and `_semaphores_for_scope` returns `[per_op, _global_llm_semaphore]` with the comment *"Per-op acquired first so contention queues on the narrower cap"*. **The caps compose; they do not replace.** So at 1 the process makes at most ONE consolidation LLM call at a time regardless of worker slots, banks or tag groups, and every other consolidation knob only pipelines the non-LLM stages behind it.

The default is now derived from the caps around it:

```
consolidation = clamp(global - retain - 1, 1, global - 1)
```

**Two independent reasons a bigger literal was not an option.**

1. **A literal at or above the global cap is inert AND misleading.** Because the semaphores compose, a consolidation cap of 6 against a global cap of 4 permits 4, not 6 — it would advertise a ceiling the engine cannot honour. That is precisely the "knob set to a value that does nothing" defect this module exists to remove.
2. **A literal cannot scale with the operator's endpoint.** The global cap is deliberately left at upstream's worked-example 4 because only the operator knows their slot count. Under a fixed literal, an operator who measures their pool and raises the global cap gets **zero** extra consolidation throughput. That is exactly the trap this fleet fell into.

The `- 1` is upstream's own stated purpose for per-op caps, quoted verbatim in `_build_per_op_semaphores`: they exist so operators can *"reserve headroom in the global pool by capping individual operations"*. Reflect and recall have no per-op cap, so subtracting the retain cap and one further slot guarantees an interactive reflect at least one global permit **even with retain AND consolidation both fully saturated**. Background consolidation therefore still cannot crowd the interactive lane off a shared local endpoint — the property the old literal `1` was protecting — it just stops being pinned to a single in-flight call.

On switchroom's own defaults (global 4, retain 1) this lands on **2**, double the previous ceiling, and it now tracks the global cap instead of needing a second yaml line.

### Why the concurrency cap existed at all

`git log -S CONSOLIDATION_LLM_MAX_CONCURRENT` traces it to #3700 / #3728. The original rationale was **not** protecting the LiteLLM proxy — it was protecting the **Anthropic subscription quota**, back when consolidation ran on `provider: claude-code` and every concurrent op was a live `claude` subprocess. A 2026-07-06 18-way fan-out hit a 429 wall and starved live agent turns. #3728 already recorded that the premise died when the lane moved to local inference, and wrote an explicit **RESTORE CONDITION**: back down to a hard 1 if consolidation ever returns to `claude-code`. That condition is carried forward verbatim in the new doc block.

So the cap was never proxy protection. Global protection is `HINDSIGHT_API_LLM_MAX_CONCURRENT`, and the derivation is now structurally bounded by it.

## Overridability

Hard requirement, and it uses the module's **existing** precedence mechanism — `resolveHindsightPerfOverrides` (yaml > process env) feeding `overrides.get(key) ?? shipped`. No new mechanism. An explicit operator value **wins outright and is NOT clamped** by the derivation: an operator who has measured their endpoint may deliberately exceed our headroom reserve, and we must not quietly rewrite their number. Asserted by test.

## Deliberately NOT changed

- **`CONSOLIDATION_LLM_PARALLELISM` stays at 2.** It is a semaphore over *tag groups within one op*, constructed only under `if llm_parallelism > 1 and len(numbered_groups) > 1:` (`consolidator.py`). switchroom's `retainTags: ["{session_id}"]` resolves a bank to one tag group, so every consolidation batch on this fleet logs `1 llm calls` at any value — upstream tracks this as vectorize-io/hindsight#1604. Pinning it to 1 would **disable a real fan-out** for deployments that do tag across scopes, to make one fleet's log line tidier. The misleading thing was the doc comment, so that is what is corrected.
- **`CONSOLIDATION_LLM_BATCH_SIZE` is not touched.** It is not a static default: `resolveHindsightContextBudget()` derives it from the declared context window (`batchSize = clamp(floor((promptBudget - OVERHEAD) / PER_FACT), 1, 12)`) and `hindsightLlmBudgetEnv()` emits it from that derivation. A literal in this module would make **two emitters race for one key** and would break `assertHindsightContextBudgetFits()`. The 32,768-token window derives batch 6 / completion 8,192 exactly as the container runs. The observed truncation is **completion-side** (`finish_reason == "length"` against the derived 8,192 cap, `litellm_llm.py:276`), and prompt and completion are coupled by the same budget — raising the completion cap shrinks the prompt budget and lowers batch size automatically. That is a change to the derivation constants, i.e. a separate single-concern PR. Filed as follow-up.
- The consolidation model and `reasoning_effort` — out of scope, and `low` is the documented recommendation for this lane.

## Test plan

Outcomes, not code paths, and mutation-checked:

- Fresh install emits a ceiling **> 1** (the exact regression: at 1 the backlog can only grow).
- Raising the global cap to 10 **widens** consolidation without a second yaml line.
- Fleet shape (global 10, retain 6) derives 3, and `3 + 6 < 10` — the two capped lanes cannot oversubscribe the pool.
- **Guard:** across a 54-case matrix of global x retain, the derived default is never greater than the emitted global cap, never below 1 (the engine raises `ValueError` on a non-positive per-op cap), and strictly below global whenever global > 1.
- Junk override values fall back to the shipped caps rather than deriving nonsense.
- An explicit operator value survives verbatim, unclamped, on **both** launch paths (`docker run` argv and compose), emitted exactly once each.
- Absent entirely on a cloud endpoint.

```
✓ src/setup/hindsight-perf-defaults.test.ts (110 tests)
✓ tests/setup/hindsight.test.ts (75) · tests/hindsight-env-keys-are-reachable.test.ts (16)
✓ src/setup/hindsight-env-drift.test.ts (20) · tests/setup/hindsight-context-budget.test.ts (35)
✓ src/setup/hindsight-recreate-env-survival.test.ts (5)
  261 passed
npm run lint — clean (tsc --noEmit + all 20 guard scripts)
```

Mutation checks (each restored afterwards):

| Mutation | Tests failed |
|---|---|
| Unwire the derivation from `hindsightPerfEnv` | 3 |
| Revert the formula to a hard `1` | 6 |
| Drop the headroom reserve (`cap == global`) | 7, incl. the matrix guard |

## Risk

Low, and bounded by the invariant. The only behaviour change is a shipped default moving 1 to 2 on a local-LLM host, with a structural proof that it can never exceed the global cap or starve the interactive lane of its reserved permit. Operator overrides are unaffected. No new managed keys, so `HINDSIGHT_PERF_ENV_KEYS` and its pinned literal list are unchanged.

**This does not by itself change the live fleet.** `switchroom.yaml` carries an explicit `HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT: 2`, and an operator value correctly wins over the default — that is the required behaviour, not a bug. Draining the measured backlog needs that yaml line raised, which is an operator decision with a real latency trade (at global 10 / retain 6, a consolidation cap above 3 lets the two capped lanes oversubscribe the pool and contend with reflect). Flagged rather than done here.

## Design contract

`reference/jobs/` — the memory job: an agent's own recent work must be recallable. The three principle checks: **docs test** (the knob's doc block now states what it actually does and why the value is what it is), **defaults test** (a fresh install stops shipping a hard throttle, and the default scales with the operator's declared capacity), **consistency test** (uses the module's one existing override mechanism and its one gating shape; adds no second emitter). No invariant crossed — no model work, no subscription path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
