### PR TITLE
fix(wedge-watchdog): stop Esc-denying a permission prompt whose card is merely late

### DIFF
--- a/src/agents/flood-pressure-probe.ts
+++ b/src/agents/flood-pressure-probe.ts
@@ -1,0 +1,175 @@
+// Read-only "is Telegram currently throttling this agent?" probe, for the
+// wedge-watchdog's permission-prompt branch (issue: the Esc-before-the-card
+// race, 2026-07-28).
+//
+// ## Why this exists
+//
+// The watchdog runs in the `autoaccept-poll` sidecar — a DIFFERENT process to
+// the gateway, in the same container and sharing `TELEGRAM_STATE_DIR`. It
+// cannot see the gateway's in-memory send-gate or edit-flood-fuse state. What
+// it CAN see is the two on-disk artefacts the flood-ban work (#3084, #3847,
+// #3853) already writes there, and this module reads exactly those two:
+//
+//   * `flood-windows.json` — the send gate's SCOPED flood windows
+//     (`global` / `chat:<id>` / `group:<id>` / `msg-edit:<id>`), written
+//     through by `makeFloodWindowRecorder` on every 429 and re-read at boot
+//     (`flood-circuit-breaker.ts`).
+//   * `429-ledger.json` — the 429 pressure ledger, folded into EPISODES by
+//     `recordFlood429`, which every `onFloodWait` wiring goes through
+//     (`flood-429-ledger.ts`).
+//
+// Both readers are imported, not reimplemented. There is deliberately NO new
+// state file, no new recorder, and no writing of any kind here.
+//
+// ## Why the ledger and not just the open window
+//
+// An open window alone is too narrow to answer the question the watchdog is
+// really asking, which is "could a Telegram approval card be LATE right now?".
+// Measured against the live clerk incident (2026-07-28,
+// `~/.switchroom/agents/clerk/telegram/`):
+//
+//   429-ledger episode:  firstTs 1785197264885 → lastTs 1785197284509,
+//                        peakRetryAfterSec 3, count 3
+//   flood-windows.json:  [{ scopeKey: "chat:12345",
+//                           untilTs: 1785197287509, ... }]
+//
+// Each individual window is only ~3s wide (retry_after 3), while the gateway's
+// edit-flood-fuse kept DEFERRING critical sends into that same chat from
+// 00:11:16Z to past 00:12:03Z — 47s after the first 429. A watchdog polling
+// every 5s would usually sample BETWEEN the 3s windows and conclude "all
+// clear" while the card was still stuck behind the fuse. So an open window is
+// sufficient evidence of pressure but not necessary: a 429 observed within
+// `FLOOD_PRESSURE_GRACE_MS` counts too.
+
+import {
+  readFloodWindows,
+  floodWindowsPath,
+} from "../../telegram-plugin/flood-circuit-breaker.js";
+import {
+  flood429LedgerPath,
+  readFlood429LedgerResult,
+} from "../../telegram-plugin/flood-429-ledger.js";
+
+/**
+ * How long after the LAST observed 429 (or after a window's expiry) the
+ * outbound path is still treated as under flood pressure.
+ *
+ * Calibrated on the clerk incident above: the 429 burst spanned ~20s and the
+ * edit-flood-fuse went on deferring `class=critical` sends for that chat for
+ * at least another ~27s (00:11:37Z `sendRichMessage` … 00:12:03Z
+ * `editMessageText`), i.e. ~47s of card-delivery risk behind a peak
+ * `retry_after` of 3s. 120s is ~2.5x that observed tail — comfortably past it
+ * without being open-ended, and it is a floor on the suppression, not a
+ * ceiling: the caller bounds total patience separately.
+ */
+export const FLOOD_PRESSURE_GRACE_MS = 120_000;
+
+/**
+ * Scope keys that can delay a NEW card POST into a chat.
+ *
+ * `msg-edit:<id>` is deliberately excluded: it throttles edits of ONE
+ * already-sent message, which cannot be the reason an approval card has not
+ * appeared yet. Counting it would let an unrelated worker-feed card's edit
+ * ceiling suppress the watchdog.
+ */
+function scopeBlocksCardDelivery(scopeKey: string): boolean {
+  return !scopeKey.startsWith("msg-edit:");
+}
+
+/** Why the probe answered `true` — for the watchdog's log line. */
+export interface FloodPressure {
+  /** Telegram is (or was very recently) throttling this agent's outbound path. */
+  active: boolean;
+  /** Human-readable evidence, e.g. `open window chat:123 (4s left)`. */
+  reason: string;
+}
+
+const NO_PRESSURE: FloodPressure = { active: false, reason: "" };
+
+export interface FloodPressureProbeOptions {
+  /** Agent telegram state dir. Default: `TELEGRAM_STATE_DIR` or the container path. */
+  stateDir?: string;
+  /** Grace after the last 429. Default `FLOOD_PRESSURE_GRACE_MS`. */
+  graceMs?: number;
+}
+
+/** Resolve the agent's telegram state dir the same way the gateway does. */
+export function resolveTelegramStateDir(): string {
+  return process.env.TELEGRAM_STATE_DIR ?? "/state/agent/telegram";
+}
+
+/**
+ * Answer "is this agent's Telegram outbound path under flood pressure right
+ * now?" from the two existing on-disk flood artefacts. Pure read; never
+ * throws (the caller is a never-throw sidecar).
+ *
+ * Note `readFloodWindows` fails SAFE — a corrupt/unreadable
+ * `flood-windows.json` yields a synthesized conservative `global` window. That
+ * is the right answer here too: if we cannot tell whether a ban is open, we
+ * must not fire a permanent Esc-deny on the assumption that it is not. The
+ * caller's absolute patience ceiling keeps that bounded.
+ */
+export function readFloodPressure(
+  now: number,
+  opts: FloodPressureProbeOptions = {},
+): FloodPressure {
+  const stateDir = opts.stateDir ?? resolveTelegramStateDir();
+  const graceMs = opts.graceMs ?? FLOOD_PRESSURE_GRACE_MS;
+  try {
+    // (a) A scoped window that is open NOW, or expired less than `graceMs`
+    //     ago. `readFloodWindows` prunes anything already expired, so query it
+    //     with a clock rolled BACK by the grace to keep recently-closed
+    //     windows visible.
+    const windows = readFloodWindows(
+      floodWindowsPath(stateDir),
+      now - graceMs,
+      // The gateway logs corrupt-marker warnings loudly already; a 5s poll
+      // loop must not duplicate them into the sidecar log forever.
+      () => {},
+    );
+    for (const w of windows) {
+      if (!scopeBlocksCardDelivery(w.scopeKey)) continue;
+      const msLeft = w.untilTs - now;
+      return {
+        active: true,
+        reason:
+          msLeft > 0
+            ? `open flood window ${w.scopeKey} (${Math.ceil(msLeft / 1000)}s left, src=${w.retryAfterSrc})`
+            : `flood window ${w.scopeKey} closed ${Math.ceil(-msLeft / 1000)}s ago (within ${Math.round(graceMs / 1000)}s grace)`,
+      };
+    }
+    // (b) A 429 episode observed within the grace. Catches the common case the
+    //     windows miss: several short (retry_after ≤ 5s) windows whose gaps a
+    //     5s poll cadence samples straight through, while the edit-flood-fuse
+    //     is still deferring the card.
+    const ledger = readFlood429LedgerResult(flood429LedgerPath(stateDir));
+    if (ledger.status === "ok") {
+      for (const ep of ledger.episodes) {
+        const lastEvidenceTs = Math.max(ep.lastTs, ep.untilTs);
+        if (lastEvidenceTs >= now - graceMs) {
+          return {
+            active: true,
+            reason:
+              `429 episode ${ep.count}x peak=${ep.peakRetryAfterSec}s last seen ` +
+              `${Math.max(0, Math.round((now - ep.lastTs) / 1000))}s ago ` +
+              `(within ${Math.round(graceMs / 1000)}s grace)`,
+          };
+        }
+      }
+    }
+    return NO_PRESSURE;
+  } catch {
+    // Soft-fail. Unlike the window reader's deliberate fail-SAFE, an
+    // unexpected throw here means we learned nothing at all, and reporting
+    // "under flood pressure" forever on a coding error would be worse than
+    // falling back to the (bounded, longer) streak gate. Report no pressure.
+    return NO_PRESSURE;
+  }
+}
+
+/** Bind a probe to this agent's state dir. Used by the wedge-watchdog. */
+export function makeFloodPressureProbe(
+  opts: FloodPressureProbeOptions = {},
+): (now: number) => FloodPressure {
+  return (now: number) => readFloodPressure(now, opts);
+}

--- a/src/agents/wedge-watchdog.ts
+++ b/src/agents/wedge-watchdog.ts
@@ -34,6 +34,7 @@ import {
   queryPendingPermission as defaultQueryPendingPermission,
   type PendingPermissionQueryResult,
 } from "./permission-pending-query.js";
+import { readFloodPressure, type FloodPressure } from "./flood-pressure-probe.js";
 
 /**
  * Blocking-modal footer signature. Deliberately strict: requires BOTH
@@ -355,6 +356,48 @@ const DEFAULT_MANIFEST_STALL_POLLS = 60;
 // @ 5s — a wedged permission prompt never clears on its own (no human),
 // so even a short streak is conclusive while staying clear of a transient.
 const DEFAULT_PERMISSION_PROMPT_POLLS = 3;
+// The card-LESS streak: how many consecutive polls a permission prompt must be
+// present before Esc when the gateway has affirmatively answered
+// `{ ok: true, pending: false }` ("no approval card exists for this agent").
+//
+// This is deliberately MUCH longer than DEFAULT_PERMISSION_PROMPT_POLLS,
+// because `pending: false` has two very different meanings that the answer
+// itself cannot distinguish:
+//
+//   1. genuinely card-less — the bridge is down, or the tool is
+//      `requiresUserInteraction`, so no card will EVER exist. Esc is correct.
+//   2. not card-less YET — Claude Code emitted the `permission_request`
+//      channel notification, but the gateway has not managed to POST the card
+//      to Telegram, because a 429 flood window / the edit-flood-fuse is
+//      holding it (`edit-flood-fuse deferred method=sendRichMessage
+//      key=t:<chat> class=critical`). A card IS coming. Esc is a permanent
+//      deny of a request the operator is about to approve.
+//
+// Before this split, both shared the 3-poll (~15s) gate and case 2 lost the
+// race routinely (clerk, 2026-07-28: three separate `dismissing stuck per-tool
+// permission prompt … gateway reports no pending permission` lines at 3, 3 and
+// 15 polls, interleaved with `has live card … deferring` lines for the same
+// agent minutes apart).
+//
+// 24 polls ≈ 120s @ 5s. Chosen to comfortably exceed a realistic flood-wait
+// plus card-post latency: the flood ledger's calibration data (16 days of live
+// gateway logs, `flood-429-ledger.ts`) puts EVERY benign `retry_after` at
+// ≤ 5s and classifies anything ≤ 60s as a rate nudge that `retryApiCall`
+// simply sleeps and retries — so 120s is 2x the top of the entire
+// sleep-and-succeed band, on top of which the observed edit-flood-fuse defer
+// tail for the clerk incident was ~47s. It is also still an order of magnitude
+// below the #2724 card TTL, so a genuinely wedged card-less prompt is denied
+// in ~2 minutes rather than hanging.
+const DEFAULT_PERMISSION_CARDLESS_POLLS = 24;
+// Absolute ceiling on flood-pressure suppression: once a permission prompt has
+// been present for this many consecutive polls, Esc fires even if Telegram is
+// still throttling. 120 polls ≈ 10 min @ 5s.
+//
+// Bounded patience is a hard requirement — a multi-hour flood ban (the
+// 2026-07-27 `retry_after=15908` incident) must not park a wedged turn
+// forever. At that point the card cannot realistically reach the operator in
+// time anyway, and Esc is the safe DENY.
+const DEFAULT_PERMISSION_FLOOD_MAX_POLLS = 120;
 
 function envInt(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -457,6 +500,37 @@ export interface WedgeWatchdogOptions {
    */
   permissionPromptPolls?: number;
   /**
+   * Consecutive polls a permission prompt must be PRESENT before Esc **when
+   * the gateway affirmatively reports no pending card** (`{ok:true,
+   * pending:false}`). Substantially longer than `permissionPromptPolls`
+   * because that answer cannot distinguish "no card will ever exist" from
+   * "the card has not been POSTED yet" — see
+   * `DEFAULT_PERMISSION_CARDLESS_POLLS`. Default
+   * `SWITCHROOM_WEDGE_PERMISSION_CARDLESS_POLLS` or 24 (~120s @ 5s). Clamped
+   * to at least `permissionPromptPolls`.
+   */
+  permissionCardlessPolls?: number;
+  /**
+   * Flood-pressure probe: "is Telegram currently throttling this agent's
+   * outbound path?". While it reports `active`, the permission branch does
+   * NOT send Esc — the approval card may simply be stuck behind a 429 window
+   * / the edit-flood-fuse rather than absent.
+   *
+   * Consumes the flood-ban work's existing on-disk state only
+   * (`flood-windows.json` + `429-ledger.json` via
+   * `src/agents/flood-pressure-probe.ts`); it never records anything.
+   * `undefined` (default) wires the real probe; `null` disables
+   * flood-awareness entirely (kill switch / rollback).
+   */
+  floodPressure?: ((now: number) => FloodPressure) | null;
+  /**
+   * Absolute ceiling (in consecutive present-polls) on flood-pressure
+   * suppression. Past this the prompt is Esc'd regardless of an open window,
+   * so a multi-hour ban can never park a wedged turn forever. Default
+   * `SWITCHROOM_WEDGE_PERMISSION_FLOOD_MAX_POLLS` or 120 (~10 min @ 5s).
+   */
+  permissionFloodMaxPolls?: number;
+  /**
    * Issue #2971 — card-aware gate for the permission-prompt branch. Once
    * `permissionPromptPolls` shape-persistence is reached, the watchdog calls
    * this BEFORE ever sending Esc, to ask the gateway whether a live Telegram
@@ -534,6 +608,15 @@ export interface WedgeWatchdogResult {
    *  LIVE pending-permission card, so the watchdog deferred (no Esc) rather
    *  than racing the card/TTL reaper. Disjoint from `permissionPromptFires`. */
   permissionPromptDeferrals: number;
+  /** Count of polls where Esc was withheld because Telegram was throttling
+   *  this agent's outbound path (an approval card may be en route but stuck
+   *  behind a 429 window / the edit-flood-fuse). Disjoint from
+   *  `permissionPromptFires`. */
+  permissionPromptFloodHolds: number;
+  /** Count of polls where Esc was withheld because a card-LESS gateway answer
+   *  had not yet reached the longer `permissionCardlessPolls` streak.
+   *  Disjoint from `permissionPromptFires`. */
+  permissionPromptCardlessHolds: number;
   /** #2471 — count of manifest-stall escalations (kill + handoff restart). */
   restartEscalations: number;
   /** Total polls executed (bounded only in tests via maxPolls). */
@@ -595,6 +678,25 @@ export async function runWedgeWatchdog(
   const permissionPromptPolls =
     opts.permissionPromptPolls ??
     envInt("SWITCHROOM_WEDGE_PERMISSION_POLLS", DEFAULT_PERMISSION_PROMPT_POLLS);
+  // The card-LESS branch gets its OWN, longer streak. Clamped so a
+  // mis-set env can never make the card-less path FASTER than the
+  // wedged/unreachable path it is supposed to be more patient than.
+  const permissionCardlessPolls = Math.max(
+    permissionPromptPolls,
+    opts.permissionCardlessPolls ??
+      envInt("SWITCHROOM_WEDGE_PERMISSION_CARDLESS_POLLS", DEFAULT_PERMISSION_CARDLESS_POLLS),
+  );
+  // Flood-awareness. `null` disables; `undefined` → the real on-disk probe.
+  const floodPressure =
+    opts.floodPressure === null
+      ? null
+      : (opts.floodPressure ?? ((n: number) => readFloodPressure(n)));
+  // Absolute ceiling on flood suppression — bounded patience, never infinite.
+  const permissionFloodMaxPolls = Math.max(
+    permissionCardlessPolls,
+    opts.permissionFloodMaxPolls ??
+      envInt("SWITCHROOM_WEDGE_PERMISSION_FLOOD_MAX_POLLS", DEFAULT_PERMISSION_FLOOD_MAX_POLLS),
+  );
   const manifestStallSignature =
     opts.manifestStallSignature === null
       ? null
@@ -621,6 +723,8 @@ export async function runWedgeWatchdog(
   let confirmModalFires = 0;
   let permissionPromptFires = 0;
   let permissionPromptDeferrals = 0;
+  let permissionPromptFloodHolds = 0;
+  let permissionPromptCardlessHolds = 0;
   let restartEscalations = 0;
   let polls = 0;
   // #2471 — shape-persistence counters (independent of the byte-stable
@@ -635,6 +739,10 @@ export async function runWedgeWatchdog(
   let lastManifestKey: string | null = null;
   let confirmCooldownUntil = 0;
   let permissionCooldownUntil = 0;
+  // Log throttle for the two new "holding off on Esc" paths. They are
+  // evaluated EVERY poll (deliberately — that is how we notice the moment the
+  // card lands), so their log lines must not be.
+  let lastPermissionHoldLogAt = Number.NEGATIVE_INFINITY;
 
   while (polls < maxPolls) {
     polls++;
@@ -905,33 +1013,89 @@ export async function runWedgeWatchdog(
           permissionPromptDeferrals++;
           permissionCooldownUntil = now() + cooldownMs;
         } else {
-          const reason =
-            queryPendingPermission == null
-              ? "card-aware check disabled"
-              : status && status.ok
-                ? "gateway reports no pending permission (card-less prompt)"
-                : `gateway unreachable/no answer within budget${status && !status.ok ? ` (${status.reason})` : ""}`;
-          console.error(
-            `[wedge-watchdog] ${opts.agentName}: dismissing stuck per-tool ` +
-              `permission prompt (Esc == decline == safe DENY) after ` +
-              `${permissionPromptPresent} polls present ` +
-              `(~${Math.round((permissionPromptPresent * pollIntervalMs) / 1000)}s) — ${reason}`,
-          );
-          // Esc ONLY — Claude Code treats Esc as "user declined", which is the
-          // safe DENY for a non-pre-approved verb. It can NEVER land on option
-          // 1/2 ("Yes" / "Yes, and don't ask again"), so the human-in-the-loop
-          // boundary for the hostd verbs is preserved. Never send Enter/numeric.
-          try {
-            send(opts.agentName, ["Escape"]);
-          } catch (err) {
-            console.error(
-              `[wedge-watchdog] ${opts.agentName}: send threw: ${(err as Error).message}`,
+          // ── Two independent gates now sit between "no live card" and Esc. ──
+          //
+          // Esc is a PERMANENT deny. Before this, the single
+          // `permissionPromptPolls` streak fed both the live-card defer path
+          // above and this one, so a card that was merely LATE (Telegram 429
+          // → the gateway's edit-flood-fuse deferring `sendRichMessage`) got
+          // the exact same ~15s of patience as a genuinely wedged card-less
+          // prompt, and lost the race. The operator then tapped Approve on a
+          // card whose prompt was already Esc-denied.
+          const held = now();
+          const pressure = floodPressure ? floodPressure(held) : null;
+          const logHold = (line: string) => {
+            if (held - lastPermissionHoldLogAt < cooldownMs) return;
+            lastPermissionHoldLogAt = held;
+            console.error(line);
+          };
+
+          // Gate 1 — Telegram is throttling this agent RIGHT NOW. Whatever the
+          // gateway just said about pending cards, a card may be queued behind
+          // the flood window / fuse, so no keystroke. Bounded by
+          // `permissionFloodMaxPolls` so a multi-hour ban cannot park a
+          // genuinely wedged turn forever.
+          const floodHold =
+            pressure?.active === true &&
+            permissionPromptPresent < permissionFloodMaxPolls;
+          // Gate 2 — the gateway affirmatively said "no card" but we have not
+          // yet waited the longer card-LESS streak. `pending: false` cannot
+          // distinguish "never will have a card" from "not posted yet".
+          const cardless = status != null && status.ok && !status.pending;
+          const cardlessHold =
+            !floodHold && cardless && permissionPromptPresent < permissionCardlessPolls;
+          if (floodHold) {
+            permissionPromptFloodHolds++;
+            logHold(
+              `[wedge-watchdog] ${opts.agentName}: permission prompt present ` +
+                `${permissionPromptPresent} polls ` +
+                `(~${Math.round((permissionPromptPresent * pollIntervalMs) / 1000)}s) but ` +
+                `Telegram is flood-throttling this agent (${pressure.reason}) — ` +
+                `an approval card may be deferred, NOT sending Esc ` +
+                `(ceiling ${permissionFloodMaxPolls} polls)`,
             );
+          } else if (cardlessHold) {
+            permissionPromptCardlessHolds++;
+            logHold(
+              `[wedge-watchdog] ${opts.agentName}: gateway reports no pending ` +
+                `permission after ${permissionPromptPresent} polls ` +
+                `(~${Math.round((permissionPromptPresent * pollIntervalMs) / 1000)}s) — ` +
+                `holding Esc until the card-less streak of ${permissionCardlessPolls} polls ` +
+                `(~${Math.round((permissionCardlessPolls * pollIntervalMs) / 1000)}s), ` +
+                `in case the card is merely late`,
+            );
+          } else {
+            const reason =
+              queryPendingPermission == null
+                ? "card-aware check disabled"
+                : status && status.ok
+                  ? `gateway reports no pending permission (card-less prompt) for ${permissionCardlessPolls}+ polls`
+                  : `gateway unreachable/no answer within budget${status && !status.ok ? ` (${status.reason})` : ""}`;
+            const floodNote = pressure?.active
+              ? ` [flood ceiling ${permissionFloodMaxPolls} polls reached while ${pressure.reason}]`
+              : "";
+            console.error(
+              `[wedge-watchdog] ${opts.agentName}: dismissing stuck per-tool ` +
+                `permission prompt (Esc == decline == safe DENY) after ` +
+                `${permissionPromptPresent} polls present ` +
+                `(~${Math.round((permissionPromptPresent * pollIntervalMs) / 1000)}s) — ${reason}${floodNote}`,
+            );
+            // Esc ONLY — Claude Code treats Esc as "user declined", which is the
+            // safe DENY for a non-pre-approved verb. It can NEVER land on option
+            // 1/2 ("Yes" / "Yes, and don't ask again"), so the human-in-the-loop
+            // boundary for the hostd verbs is preserved. Never send Enter/numeric.
+            try {
+              send(opts.agentName, ["Escape"]);
+            } catch (err) {
+              console.error(
+                `[wedge-watchdog] ${opts.agentName}: send threw: ${(err as Error).message}`,
+              );
+            }
+            fires++;
+            permissionPromptFires++;
+            permissionCooldownUntil = now() + cooldownMs;
+            permissionPromptPresent = 0;
           }
-          fires++;
-          permissionPromptFires++;
-          permissionCooldownUntil = now() + cooldownMs;
-          permissionPromptPresent = 0;
         }
       }
     } else if (isConfirmModal) {
@@ -1017,6 +1181,8 @@ export async function runWedgeWatchdog(
     confirmModalFires,
     permissionPromptFires,
     permissionPromptDeferrals,
+    permissionPromptFloodHolds,
+    permissionPromptCardlessHolds,
     restartEscalations,
     polls,
     reason: "max-polls",

--- a/src/cli/autoaccept-poll.ts
+++ b/src/cli/autoaccept-poll.ts
@@ -114,12 +114,22 @@ async function main(): Promise<void> {
   // SWITCHROOM_PERMISSION_CARD_AWARE=0 restores the old unconditional-Esc
   // behaviour (useful if this ever needs a fast rollback).
   const permissionCardAware = process.env.SWITCHROOM_PERMISSION_CARD_AWARE !== "0";
+  // Flood-aware permission gate: default ON. While Telegram is 429-throttling
+  // this agent's outbound path, an approval card the gateway has ALREADY
+  // decided to post may still be sitting behind the flood window / the
+  // edit-flood-fuse — so `{ok:true, pending:false}` does not mean "no card is
+  // coming". The watchdog reads the flood-ban work's own on-disk state
+  // (`flood-windows.json` + `429-ledger.json`) and withholds Esc while that
+  // state says the channel is throttled, up to a bounded ceiling. Kill switch
+  // SWITCHROOM_WEDGE_FLOOD_AWARE=0 restores the flood-blind behaviour.
+  const permissionFloodAware = process.env.SWITCHROOM_WEDGE_FLOOD_AWARE !== "0";
   try {
     console.error(
       `[autoaccept-poll] ${agentName}: entering wedge-watchdog (continuous)` +
         (rateLimitDetect ? " +rate-limit-detect" : " (rate-limit-detect OFF)") +
         (overageSelect ? " +overage-carveout" : "") +
-        (permissionCardAware ? " +permission-card-aware" : " (permission-card-aware OFF)"),
+        (permissionCardAware ? " +permission-card-aware" : " (permission-card-aware OFF)") +
+        (permissionFloodAware ? " +permission-flood-aware" : " (permission-flood-aware OFF)"),
     );
     // Runs until the container stops (maxPolls defaults to Infinity).
     const res = await runWedgeWatchdog({
@@ -140,9 +150,11 @@ async function main(): Promise<void> {
       // #2971 — `undefined` wires the real gateway query (default export's
       // own default); `null` disables the card-aware check entirely.
       queryPendingPermission: permissionCardAware ? undefined : null,
+      // `undefined` wires the real on-disk flood probe; `null` disables it.
+      floodPressure: permissionFloodAware ? undefined : null,
     });
     console.error(
-      `[autoaccept-poll] ${agentName}: wedge-watchdog returned reason=${res.reason} fires=${res.fires} rateLimitFires=${res.rateLimitFires} overageCreditSelections=${res.overageCreditSelections} confirmModalFires=${res.confirmModalFires} permissionPromptFires=${res.permissionPromptFires} permissionPromptDeferrals=${res.permissionPromptDeferrals} restartEscalations=${res.restartEscalations}`,
+      `[autoaccept-poll] ${agentName}: wedge-watchdog returned reason=${res.reason} fires=${res.fires} rateLimitFires=${res.rateLimitFires} overageCreditSelections=${res.overageCreditSelections} confirmModalFires=${res.confirmModalFires} permissionPromptFires=${res.permissionPromptFires} permissionPromptDeferrals=${res.permissionPromptDeferrals} permissionPromptFloodHolds=${res.permissionPromptFloodHolds} permissionPromptCardlessHolds=${res.permissionPromptCardlessHolds} restartEscalations=${res.restartEscalations}`,
     );
   } catch (err) {
     console.error(

--- a/tests/flood-pressure-probe.test.ts
+++ b/tests/flood-pressure-probe.test.ts
@@ -1,0 +1,117 @@
+// Unit tests for the wedge-watchdog's read-only flood-pressure probe.
+//
+// Hermetic by construction: every case points `stateDir` at a fresh tmpdir, so
+// the probe never reads a live agent's `~/.switchroom/agents/<name>/telegram/`.
+// The fixtures are the REAL bytes from the clerk incident (2026-07-28) that
+// motivated the fix.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  readFloodPressure,
+  FLOOD_PRESSURE_GRACE_MS,
+} from "../src/agents/flood-pressure-probe.js";
+
+// Verbatim from ~/.switchroom/agents/clerk/telegram/ on 2026-07-28.
+const CLERK_WINDOWS = [
+  {
+    scopeKey: "chat:12345",
+    untilTs: 1785197287509,
+    retryAfterSrc: "429",
+    observedAt: 1785197284509,
+  },
+];
+const CLERK_LEDGER = [
+  { firstTs: 1785196413517, lastTs: 1785196413517, peakRetryAfterSec: 3, untilTs: 1785196416517, count: 1 },
+  { firstTs: 1785197264885, lastTs: 1785197284509, peakRetryAfterSec: 3, untilTs: 1785197287509, count: 3 },
+];
+/** Epoch ms the clerk `chat:12345` window expired. */
+const WINDOW_CLOSE = 1785197287509;
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "flood-pressure-probe-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function writeWindows(v: unknown) {
+  writeFileSync(join(dir, "flood-windows.json"), JSON.stringify(v));
+}
+function writeLedger(v: unknown) {
+  writeFileSync(join(dir, "429-ledger.json"), JSON.stringify(v));
+}
+
+describe("readFloodPressure", () => {
+  it("reports no pressure when neither artefact exists", () => {
+    expect(readFloodPressure(WINDOW_CLOSE, { stateDir: dir }).active).toBe(false);
+  });
+
+  it("reports pressure from an OPEN scoped window", () => {
+    writeWindows(CLERK_WINDOWS);
+    const p = readFloodPressure(WINDOW_CLOSE - 1_000, { stateDir: dir });
+    expect(p.active).toBe(true);
+    expect(p.reason).toContain("chat:12345");
+  });
+
+  it("still reports pressure just AFTER the window closes (within the grace)", () => {
+    // The load-bearing case. Each clerk window was only ~3s wide (retry_after
+    // 3) while the edit-flood-fuse kept deferring the card for ~47s, so a 5s
+    // poll cadence samples between windows and would otherwise see "all clear".
+    writeWindows(CLERK_WINDOWS);
+    expect(readFloodPressure(WINDOW_CLOSE + 30_000, { stateDir: dir }).active).toBe(true);
+  });
+
+  it("reports no pressure once the window is older than the grace", () => {
+    writeWindows(CLERK_WINDOWS);
+    expect(
+      readFloodPressure(WINDOW_CLOSE + FLOOD_PRESSURE_GRACE_MS + 1_000, { stateDir: dir }).active,
+    ).toBe(false);
+  });
+
+  it("reports pressure from a recent 429 EPISODE even with no window file", () => {
+    writeLedger(CLERK_LEDGER);
+    const p = readFloodPressure(WINDOW_CLOSE + 10_000, { stateDir: dir });
+    expect(p.active).toBe(true);
+    expect(p.reason).toContain("429 episode");
+  });
+
+  it("ignores a 429 episode older than the grace", () => {
+    writeLedger(CLERK_LEDGER);
+    expect(
+      readFloodPressure(WINDOW_CLOSE + FLOOD_PRESSURE_GRACE_MS + 60_000, { stateDir: dir }).active,
+    ).toBe(false);
+  });
+
+  it("ignores a msg-edit: window — it cannot delay a NEW card post", () => {
+    writeWindows([
+      { scopeKey: "msg-edit:123", untilTs: WINDOW_CLOSE, retryAfterSrc: "429", observedAt: 0 },
+    ]);
+    expect(readFloodPressure(WINDOW_CLOSE - 1_000, { stateDir: dir }).active).toBe(false);
+  });
+
+  it("counts a global window", () => {
+    writeWindows([
+      { scopeKey: "global", untilTs: WINDOW_CLOSE, retryAfterSrc: "429", observedAt: 0 },
+    ]);
+    expect(readFloodPressure(WINDOW_CLOSE - 1_000, { stateDir: dir }).active).toBe(true);
+  });
+
+  it("fails SAFE (pressure active) on a corrupt windows file", () => {
+    writeFileSync(join(dir, "flood-windows.json"), "{not json");
+    // Matches `readFloodWindows`'s deliberate fail-safe posture: if we cannot
+    // tell whether a ban is open, we must not fire a permanent Esc-deny on the
+    // assumption that it is not. Bounded by the caller's poll ceiling.
+    expect(readFloodPressure(WINDOW_CLOSE, { stateDir: dir }).active).toBe(true);
+  });
+
+  it("reports no pressure on a corrupt LEDGER (the window file is the safety-critical one)", () => {
+    writeFileSync(join(dir, "429-ledger.json"), "{not json");
+    expect(readFloodPressure(WINDOW_CLOSE, { stateDir: dir }).active).toBe(false);
+  });
+});

--- a/tests/wedge-watchdog.test.ts
+++ b/tests/wedge-watchdog.test.ts
@@ -523,6 +523,9 @@ describe("runWedgeWatchdog — permission-prompt freeze", () => {
     const res = await runWedgeWatchdog({
       agentName: "carrie",
       permissionPromptPolls: 3,
+      // Flood-awareness off: these cases assert the non-flood behaviour and
+      // must never read the real on-disk flood state.
+      floodPressure: null,
       // isolate the permission-prompt branch.
       rateLimitSignature: null,
       confirmModalSignature: null,
@@ -553,6 +556,9 @@ describe("runWedgeWatchdog — permission-prompt freeze", () => {
     const res = await runWedgeWatchdog({
       agentName: "carrie",
       permissionPromptPolls: 3,
+      // Flood-awareness off: these cases assert the non-flood behaviour and
+      // must never read the real on-disk flood state.
+      floodPressure: null,
       rateLimitSignature: null,
       confirmModalSignature: null,
       manifestStallSignature: null,
@@ -574,6 +580,9 @@ describe("runWedgeWatchdog — permission-prompt freeze", () => {
     const res = await runWedgeWatchdog({
       agentName: "carrie",
       permissionPromptPolls: 3,
+      // Flood-awareness off: these cases assert the non-flood behaviour and
+      // must never read the real on-disk flood state.
+      floodPressure: null,
       rateLimitSignature: null,
       confirmModalSignature: null,
       manifestStallSignature: null,
@@ -612,6 +621,9 @@ describe("runWedgeWatchdog — permission-prompt card-aware gate (#2971)", () =>
     const res = await runWedgeWatchdog({
       agentName: "carrie",
       permissionPromptPolls: 3,
+      // Flood-awareness off: these cases assert the non-flood behaviour and
+      // must never read the real on-disk flood state.
+      floodPressure: null,
       rateLimitSignature: null,
       confirmModalSignature: null,
       manifestStallSignature: null,
@@ -641,6 +653,9 @@ describe("runWedgeWatchdog — permission-prompt card-aware gate (#2971)", () =>
     const res = await runWedgeWatchdog({
       agentName: "carrie",
       permissionPromptPolls: 3,
+      // Flood-awareness off: these cases assert the non-flood behaviour and
+      // must never read the real on-disk flood state.
+      floodPressure: null,
       rateLimitSignature: null,
       confirmModalSignature: null,
       manifestStallSignature: null,
@@ -662,13 +677,17 @@ describe("runWedgeWatchdog — permission-prompt card-aware gate (#2971)", () =>
     expect(res.permissionPromptDeferrals).toBe(0);
   });
 
-  it("Escs on gateway reporting no pending permission (card-less prompt)", async () => {
+  it("Escs on gateway reporting no pending permission (card-less prompt), but only after the LONGER card-less streak", async () => {
     const { send, calls } = recordSend();
     const queryPendingPermission = async () =>
       ({ ok: true, pending: false }) as const;
-    const res = await runWedgeWatchdog({
+    const base = {
       agentName: "carrie",
       permissionPromptPolls: 3,
+      permissionCardlessPolls: 6,
+      // Flood-awareness off: these cases assert the non-flood behaviour and
+      // must never read the real on-disk flood state.
+      floodPressure: null as null,
       rateLimitSignature: null,
       confirmModalSignature: null,
       manifestStallSignature: null,
@@ -676,18 +695,20 @@ describe("runWedgeWatchdog — permission-prompt card-aware gate (#2971)", () =>
       pollIntervalMs: 0,
       now: () => 0,
       sleep: () => {},
-      maxPolls: 3,
-      capture: captureFlicker([
-        PERMISSION_PROMPT_A,
-        PERMISSION_PROMPT_B,
-        PERMISSION_PROMPT_A,
-      ]),
-      send,
-    });
+      capture: captureFlicker([PERMISSION_PROMPT_A, PERMISSION_PROMPT_B]),
+    };
+    // At the OLD threshold (3 polls) the card-less prompt is now held, not Esc'd.
+    const early = await runWedgeWatchdog({ ...base, maxPolls: 5, send });
+    expect(calls).toEqual([]);
+    expect(early.permissionPromptFires).toBe(0);
+    expect(early.permissionPromptCardlessHolds).toBe(3); // polls 3,4,5
+    // Past the card-less streak it still fires — a genuinely wedged prompt is
+    // never left to hang.
+    const late = await runWedgeWatchdog({ ...base, maxPolls: 6, send });
     expect(calls).toEqual([["Escape"]]);
-    expect(res.fires).toBe(1);
-    expect(res.permissionPromptFires).toBe(1);
-    expect(res.permissionPromptDeferrals).toBe(0);
+    expect(late.fires).toBe(1);
+    expect(late.permissionPromptFires).toBe(1);
+    expect(late.permissionPromptDeferrals).toBe(0);
   });
 
   it("Escs when queryPendingPermission THROWS (soft-fail, defence-in-depth)", async () => {
@@ -698,6 +719,9 @@ describe("runWedgeWatchdog — permission-prompt card-aware gate (#2971)", () =>
     const res = await runWedgeWatchdog({
       agentName: "carrie",
       permissionPromptPolls: 3,
+      // Flood-awareness off: these cases assert the non-flood behaviour and
+      // must never read the real on-disk flood state.
+      floodPressure: null,
       rateLimitSignature: null,
       confirmModalSignature: null,
       manifestStallSignature: null,
@@ -728,6 +752,11 @@ describe("runWedgeWatchdog — permission-prompt card-aware gate (#2971)", () =>
       await runWedgeWatchdog({
         agentName: "carrie",
         permissionPromptPolls: 3,
+        permissionCardlessPolls: 3,
+        floodPressure: null,
+      // Flood-awareness off: these cases assert the non-flood behaviour and
+      // must never read the real on-disk flood state.
+      floodPressure: null,
         rateLimitSignature: null,
         confirmModalSignature: null,
         manifestStallSignature: null,
@@ -747,6 +776,171 @@ describe("runWedgeWatchdog — permission-prompt card-aware gate (#2971)", () =>
         expect(keys).toEqual(["Escape"]);
       }
     }
+  });
+});
+
+// ─── Flood-aware permission gate (the Esc-before-the-card race) ───────────────
+//
+// clerk, 2026-07-28. Telegram 429'd chat 12345; the gateway's
+// edit-flood-fuse deferred the approval card
+// (`edit-flood-fuse deferred method=sendRichMessage key=t:12345
+// class=critical`); the watchdog asked the gateway, was told
+// `{ok:true, pending:false}` because the card did not exist YET, and Esc'd —
+// a permanent deny — ~15s in. The card then landed still looking tappable and
+// the operator tapped Approve into a dead prompt.
+//
+// Outcome contract asserted here: while the flood state says Telegram is
+// throttling this agent, a card-less permission prompt gets NO keystroke; with
+// no flood pressure, a genuinely wedged one is still denied.
+
+describe("runWedgeWatchdog — flood-aware permission gate", () => {
+  const cardless = async () => ({ ok: true, pending: false }) as const;
+
+  it("does NOT Esc a card-less prompt while a flood window is open", async () => {
+    const { send, calls } = recordSend();
+    const res = await runWedgeWatchdog({
+      agentName: "clerk",
+      permissionPromptPolls: 3,
+      permissionCardlessPolls: 6,
+      permissionFloodMaxPolls: 100,
+      // The flood-ban state says chat:12345 is throttled.
+      floodPressure: () => ({
+        active: true,
+        reason: "open flood window chat:12345 (3s left, src=429)",
+      }),
+      rateLimitSignature: null,
+      confirmModalSignature: null,
+      manifestStallSignature: null,
+      queryPendingPermission: cardless,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 40,
+      capture: captureFlicker([PERMISSION_PROMPT_A, PERMISSION_PROMPT_B]),
+      send,
+    });
+    // The whole point: no keystroke of any kind reached the TUI.
+    expect(calls).toEqual([]);
+    expect(res.fires).toBe(0);
+    expect(res.permissionPromptFires).toBe(0);
+    expect(res.permissionPromptFloodHolds).toBe(38); // polls 3..40
+  });
+
+  it("still Escs a genuinely wedged card-less prompt when there is NO flood window", async () => {
+    const { send, calls } = recordSend();
+    const res = await runWedgeWatchdog({
+      agentName: "clerk",
+      permissionPromptPolls: 3,
+      permissionCardlessPolls: 6,
+      permissionFloodMaxPolls: 100,
+      floodPressure: () => ({ active: false, reason: "" }),
+      rateLimitSignature: null,
+      confirmModalSignature: null,
+      manifestStallSignature: null,
+      queryPendingPermission: cardless,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 6,
+      capture: captureFlicker([PERMISSION_PROMPT_A, PERMISSION_PROMPT_B]),
+      send,
+    });
+    expect(calls).toEqual([["Escape"]]);
+    expect(res.permissionPromptFires).toBe(1);
+    expect(res.permissionPromptFloodHolds).toBe(0);
+  });
+
+  it("Escs once the flood ceiling is reached — patience is bounded, never infinite", async () => {
+    const { send, calls } = recordSend();
+    const res = await runWedgeWatchdog({
+      agentName: "clerk",
+      permissionPromptPolls: 3,
+      permissionCardlessPolls: 6,
+      // A 4.4h ban would otherwise hold forever; the ceiling ends it.
+      permissionFloodMaxPolls: 10,
+      floodPressure: () => ({ active: true, reason: "429 episode 3x peak=15908s" }),
+      rateLimitSignature: null,
+      confirmModalSignature: null,
+      manifestStallSignature: null,
+      queryPendingPermission: cardless,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 10,
+      capture: captureFlicker([PERMISSION_PROMPT_A, PERMISSION_PROMPT_B]),
+      send,
+    });
+    expect(calls).toEqual([["Escape"]]);
+    expect(res.permissionPromptFires).toBe(1);
+    expect(res.permissionPromptFloodHolds).toBe(7); // polls 3..9, then poll 10 fires
+  });
+
+  it("withholds Esc under flood pressure even when the gateway is UNREACHABLE", async () => {
+    const { send, calls } = recordSend();
+    const res = await runWedgeWatchdog({
+      agentName: "clerk",
+      permissionPromptPolls: 3,
+      permissionFloodMaxPolls: 100,
+      floodPressure: () => ({ active: true, reason: "open flood window global" }),
+      rateLimitSignature: null,
+      confirmModalSignature: null,
+      manifestStallSignature: null,
+      queryPendingPermission: async () => ({ ok: false, reason: "timeout" }) as const,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 8,
+      capture: captureFlicker([PERMISSION_PROMPT_A, PERMISSION_PROMPT_B]),
+      send,
+    });
+    expect(calls).toEqual([]);
+    expect(res.permissionPromptFires).toBe(0);
+  });
+
+  it("never sends anything but Escape under flood pressure (safety boundary)", async () => {
+    for (const active of [true, false]) {
+      const { send, calls } = recordSend();
+      await runWedgeWatchdog({
+        agentName: "clerk",
+        permissionPromptPolls: 3,
+        permissionCardlessPolls: 4,
+        permissionFloodMaxPolls: 6,
+        floodPressure: () => ({ active, reason: "r" }),
+        rateLimitSignature: null,
+        confirmModalSignature: null,
+        manifestStallSignature: null,
+        queryPendingPermission: cardless,
+        pollIntervalMs: 0,
+        now: () => 0,
+        sleep: () => {},
+        maxPolls: 8,
+        capture: captureFlicker([PERMISSION_PROMPT_A, PERMISSION_PROMPT_B]),
+        send,
+      });
+      for (const keys of calls) expect(keys).toEqual(["Escape"]);
+    }
+  });
+
+  it("clamps a mis-set card-less streak so it can never be SHORTER than the base streak", async () => {
+    const { send, calls } = recordSend();
+    const res = await runWedgeWatchdog({
+      agentName: "clerk",
+      permissionPromptPolls: 5,
+      permissionCardlessPolls: 1, // nonsense — must clamp up to 5
+      floodPressure: null,
+      rateLimitSignature: null,
+      confirmModalSignature: null,
+      manifestStallSignature: null,
+      queryPendingPermission: cardless,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 4,
+      capture: captureFlicker([PERMISSION_PROMPT_A, PERMISSION_PROMPT_B]),
+      send,
+    });
+    expect(calls).toEqual([]);
+    expect(res.permissionPromptFires).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

The operator taps **Approve** on a Telegram permission card and the tool comes back `The user doesn't want to proceed with this tool use`. The tap is not the problem: `wedge-watchdog` had already sent Escape — a permanent deny — to the TUI *before the card ever reached Telegram*.

## The race, with evidence

1. **Telegram 429'd the chat.** `~/.switchroom/agents/clerk/telegram/429-ledger.json` (chat id redacted below to the repo's synthetic `12345`):

   ```json
   {"firstTs":1785197264885,"lastTs":1785197284509,"peakRetryAfterSec":3,"untilTs":1785197287509,"count":3}
   ```
   and `flood-windows.json`:
   ```json
   [{"scopeKey":"chat:12345","untilTs":1785197287509,"retryAfterSrc":"429","observedAt":1785197284509}]
   ```

2. **The gateway deferred the card post.** `logs/clerk/gateway-supervisor.log`, 2026-07-28:
   ```
   00:11:28.489Z edit-flood-fuse deferred method=sendRichMessage key=t:12345 class=critical
   00:11:37.541Z edit-flood-fuse deferred method=sendRichMessage key=t:12345 class=critical
   00:12:03.401Z edit-flood-fuse deferred method=editMessageText  key=ce:12345 class=cosmetic
   ```

3. **The watchdog asked the gateway and was told "no card".** `queryPendingPermission` answers `{ok: true, pending: false}` — truthfully, because the card did not exist *yet*. The `else` branch fired Escape.

4. **The card then landed still looking tappable.** Same log: `finalizeCallback: editMessageText failed: Call to 'editMessageText' failed!` — the repaint that should have stripped `reply_markup` never happened, so the operator tapped into a corpse.

`logs/clerk/autoaccept.log` shows the nondeterminism directly — same agent, minutes apart:

```
[wedge-watchdog] clerk: permission prompt has live card ycjue, deferring to card/TTL after 3 polls present (~15s) — NOT sending Esc
[wedge-watchdog] clerk: dismissing stuck per-tool permission prompt (Esc == decline == safe DENY) after 3 polls present (~15s) — gateway reports no pending permission (card-less prompt)
[wedge-watchdog] clerk: dismissing stuck per-tool permission prompt (Esc == decline == safe DENY) after 15 polls present (~75s) — gateway reports no pending permission (card-less prompt)
```

Some of the operator's directive deletes landed, some were denied, one went through "delayed". Classic race.

## The defect

`src/agents/wedge-watchdog.ts` — one streak gate fed **both** downstream branches:

```ts
if (permissionPromptPresent >= permissionPromptPolls && now() >= permissionCooldownUntil) {
```

So a genuinely-wedged card-less prompt and a card that is merely *late* behind a flood-wait got the identical ~15s of patience. (`/opt/switchroom/autoaccept-poll.js` on the host is the built artifact of this same logic; the fix is in `src/`.)

## What changed

**1. Separate thresholds.** New `permissionCardlessPolls` gates only the `{ok:true, pending:false}` path. `permissionPromptPolls` (3) still governs the gateway-unreachable / card-aware-disabled path, so mixed-version fleet behaviour is untouched.

*Why 24 polls ≈ 120s @ 5s:* `flood-429-ledger.ts`'s calibration against 16 days of live gateway logs (170 observations) puts **every benign `retry_after` at ≤ 5s** and classifies anything ≤ `TRIVIAL_RETRY_AFTER_SEC` (60s) as a rate nudge that `retryApiCall` simply sleeps and retries. 120s is 2x the top of that entire sleep-and-succeed band, on top of which the measured edit-flood-fuse defer tail in this incident was ~47s. It is still an order of magnitude under the #2724 card TTL, so a genuinely wedged card-less prompt is denied in ~2 minutes rather than left hanging. Clamped to never be shorter than `permissionPromptPolls`.

**2. Esc suppressed while a flood window is open**, bounded by `permissionFloodMaxPolls` (120 polls ≈ 10 min). Bounded patience is deliberate: the 2026-07-27 `retry_after=15908` ban must not park a wedged turn for 4.4 hours, and past the ceiling the card cannot reach the operator in time anyway, so Esc is the safe DENY.

**3. Which flood state, and why not just the window.** New `src/agents/flood-pressure-probe.ts` **consumes** the existing flood-ban machinery — `readFloodWindows` from `telegram-plugin/flood-circuit-breaker.ts` (#3084) and `readFlood429LedgerResult` from `telegram-plugin/flood-429-ledger.ts` (#3853). No new state file, no new recorder, no writes. The watchdog runs in the `autoaccept-poll` sidecar, a different process from the gateway sharing `TELEGRAM_STATE_DIR`, so these two files are the only handle on flood state it can have; the cross-import follows the existing `src/cli/doctor-flood-pressure.ts` precedent.

The **ledger arm is load-bearing, not belt-and-braces**: each window in this incident was only ~3s wide (`peakRetryAfterSec: 3`) while the fuse deferred the card for ~47s, so a 5s poll cadence would usually sample *between* windows and conclude "all clear". Hence a 120s grace after the last observed 429 counts as pressure too. `msg-edit:` scopes are excluded — they throttle edits of one already-sent message and cannot be why a new card has not appeared.

Kill switch `SWITCHROOM_WEDGE_FLOOD_AWARE=0`; tuning via `SWITCHROOM_WEDGE_PERMISSION_CARDLESS_POLLS` / `SWITCHROOM_WEDGE_PERMISSION_FLOOD_MAX_POLLS`.

## Safety boundary — unchanged

Escape remains the only key ever sent for a permission prompt; the watchdog still cannot select "Yes" or "Yes, and don't ask again", so human-in-the-loop for the hostd verbs is intact. Both new gates only ever *withhold* a keystroke, and both are bounded — nothing here can make a prompt hang forever.

## Items 3 and 4 — filed, not bundled

**Item 3 (do the 429s count?).** Verified structurally clean for the paths that matter: `check-bot-api-wrapping.sh` proves no raw `bot.api.*` escapes the retry policy, and `check-retry-flood-hooks.mjs` proves all 4 `createRetryApiCall` wirings carry both `floodWaitRemainingMs` and `onFloodWait` — so card posts, card repaints and activity/progress edits all record. **One real gap found:** `finalizeCallback` uses grammy's *context* methods (`ctx.answerCallbackQuery`, `ctx.editMessageText`), which are a third surface neither guard sees, so tap-path 429s never reach the ledger.

**Item 4 (the dead-looking card).** Same function, same root cause: no retry on `ctx.editMessageText`, so a transient failure leaves `reply_markup` in place.

Both are one concern and nine call sites away from this diff, so they are filed together as **#3891** rather than bloating this PR.

## Test plan

`tests/wedge-watchdog.test.ts` (+6 cases) and new `tests/flood-pressure-probe.test.ts` (10 cases, hermetic — every case points `stateDir` at a `mkdtempSync` tmpdir, incident fixtures verbatim with the chat id redacted).

Outcome assertions, not code paths — **5 of them fail on `origin/main`'s behaviour** (verified by stashing only `wedge-watchdog.ts` and re-running):

```
× ... > Escs on gateway reporting no pending permission (card-less prompt), but only after the LONGER card-less streak
× flood-aware permission gate > does NOT Esc a card-less prompt while a flood window is open
× flood-aware permission gate > still Escs a genuinely wedged card-less prompt when there is NO flood window
× flood-aware permission gate > Escs once the flood ceiling is reached — patience is bounded, never infinite
× flood-aware permission gate > withholds Esc under flood pressure even when the gateway is UNREACHABLE
  Tests  5 failed | 41 passed (46)
```

With the fix: `Tests 64 passed (64)` across `wedge-watchdog` + `flood-pressure-probe` + `doctor-flood-pressure`.

- [x] `tsc --noEmit` clean
- [x] every `npm run lint` guard clean (`check-plugin-references` needs a full `node_modules`, unavailable in this worktree — CI is the authority for it)
- [x] scoped vitest green
- [x] `tests/autoaccept-poll-bundled.test.ts` fails locally only because a fresh worktree has no `dist/` (`npm test`'s pretest builds first) — environment artifact, not a regression

## Job spec

`reference/jobs/` — on-the-leash: the operator's approval decision must be the one that lands. A framework keystroke that pre-empts a card the framework itself is still trying to deliver breaks that, and it broke it nondeterministically, which is worse.

## Risk

Low and one-directional. The only behavioural delta is *withholding* Escape for longer in two narrow, bounded cases; no new keystroke, no new send, no new persisted state. Worst case under a chronically-429'd chat is a wedged card-less prompt denied at ~10 min instead of ~15s, logged with its reason. Full rollback is `SWITCHROOM_WEDGE_FLOOD_AWARE=0` plus `SWITCHROOM_WEDGE_PERMISSION_CARDLESS_POLLS=3`.