### PR TITLE
fix(hindsight): serialise every drain path and park wedged entries

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -475,11 +475,25 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
   #    mechanism — it runs because the container is up, needs no LLM turn of
   #    its own, and cannot be prompted away.
   #
-  #    SERIALISED. `flock -n` on a per-agent lockfile makes overlapping runs
-  #    impossible: a run that overshoots the interval causes the next tick to
-  #    SKIP, never to stack. The lock path is deliberately the one the
-  #    out-of-band recovery tooling also takes, so a manual sweep and this
-  #    loop mutually exclude instead of double-processing an entry.
+  #    SERIALISED, BUT NOT BY THIS FILE. `drain_pending.py` takes an
+  #    exclusive `fcntl.flock` on `$HOME/.hindsight/drain-pending.lock` for
+  #    the whole of `drain()` and does nothing at all if another drain holds
+  #    it. That is where the guarantee has to live: the queue has three
+  #    independent drain paths — the SessionStart hook (which imports
+  #    `drain` in-process, and boots while this loop may be mid-run), this
+  #    sidecar, and the `docker exec … drain_pending.py --backlog` that
+  #    `switchroom doctor` documents for operators — and a lock wrapped
+  #    around only ONE of them serialises nothing. Two drains on one queue
+  #    means the same entry POSTed twice, i.e. ~168s of a 4-slot fleet-wide
+  #    lane spent twice on one memory.
+  #
+  #    DO NOT WRAP THE CALL BELOW IN `flock`. It would take the very lock
+  #    the python then asks for, and the drain would skip every tick,
+  #    silently, forever. (This is also why the lock file is NOT the
+  #    `drain.lock` the interim host cron wraps its `docker exec` in — with
+  #    distinct names that wrapper stays merely redundant instead of
+  #    starving the drain it launched.) `tests/hindsight-drain-sidecar.test.ts`
+  #    fails if a `flock` reappears here.
   #
   #    LANE-RESPECTING. Retain extraction is served by a small fixed pool of
   #    LLM lanes (4 on this fleet, 2 boxes x 2 slots) SHARED with live
@@ -516,6 +530,22 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
   #    already queued ABOVE the current bound are recovered by re-splitting
   #    them, not by waiting longer. An operator who still wants a longer
   #    deadline moves HINDSIGHT_RETAIN_CLIENT_DEADLINE_S, which moves both.
+  #    THE ROWS OUTLIVE THE STOPGAP THAT PRODUCED THEM; the serialisation in
+  #    it does not. That stopgap is the interim host cron named above, whose
+  #    outer `flock` on `drain.lock` serialised only that cron against
+  #    itself, while the SessionStart hook's in-process drain and a bare
+  #    `docker exec` walked straight past it — the widening to all three is
+  #    the whole point of moving the lock inside `drain_pending.py`. What
+  #    the rows measure is one drain completing (or not) inside a deadline,
+  #    which is a property of the drain and not of who serialised it, so
+  #    they still stand. They are not a licence to reinstate the wrapper.
+  #
+  #    UNATTENDED, SO BOUNDED PER ENTRY. `drain_pending` parks an entry past
+  #    its attempt ceiling (default 20) instead of retrying it forever —
+  #    without that, one permanently-failing entry on a 3600s backlog budget
+  #    would burn most of this agent's wall-clock, and a share of the 4
+  #    lanes, indefinitely and with nobody watching. Parked entries stay
+  #    queued and are still reconciled for free; `--force` replays them.
   #
   #    Failure is never terminal: the drain exits non-zero only when it
   #    promoted entries to `.dead`, and the loop below ignores the status
@@ -524,13 +554,24 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
   #    (those are exported later, in the inner pass) — only $HOME, to find
   #    the queue.
   #
+  #    DOCKER RUNTIME ONLY. This whole block is inside the
+  #    `[ "$SWITCHROOM_RUNTIME" = "docker" ]` branch that ends at the `exec
+  #    tmux` below, so an agent on the legacy systemd path gets NO drain
+  #    sidecar and keeps the boot-only SessionStart behaviour. The fleet is
+  #    entirely docker; if systemd ever comes back, this needs an equivalent
+  #    timer, and until then the honest statement is that it is unsupported
+  #    there rather than silently absent.
+  #
   #    Kill switch: SWITCHROOM_HINDSIGHT_DRAIN=0 at the container level.
-  #    Interval: SWITCHROOM_HINDSIGHT_DRAIN_INTERVAL_S (default 900s).
+  #    Interval: SWITCHROOM_HINDSIGHT_DRAIN_INTERVAL_S (default 900s). That
+  #    is a COOLDOWN BETWEEN RUNS, not a fixed period — the loop is strictly
+  #    sequential, so the true tick-to-tick spacing is one drain's duration
+  #    (up to the 3600s backlog budget) plus the interval. Deliberate: a
+  #    fixed period would give a long, lane-heavy drain no cooldown at all.
   _hs_drain_script="{{agentDir}}/.claude/plugins/hindsight-memory/scripts/drain_pending.py"
-  if [ "$SWITCHROOM_HINDSIGHT_DRAIN" != "0" ] \
+  if [ "${SWITCHROOM_HINDSIGHT_DRAIN:-1}" != "0" ] \
      && [ -f "$_hs_drain_script" ] \
-     && command -v python3 >/dev/null 2>&1 \
-     && command -v flock >/dev/null 2>&1; then
+     && command -v python3 >/dev/null 2>&1; then
     _switchroom_hindsight_drain_loop() {
       local _script="$1"
       local _interval="${SWITCHROOM_HINDSIGHT_DRAIN_INTERVAL_S:-900}"
@@ -538,24 +579,38 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
       # against the LLM lane. 60s is the floor.
       case "$_interval" in ''|*[!0-9]*) _interval=900 ;; esac
       [ "$_interval" -lt 60 ] && _interval=60
-      local _lock="$HOME/.hindsight/drain.lock"
-      mkdir -p "$HOME/.hindsight" 2>/dev/null || true
       # Deterministic per-agent phase offset (see the note above).
       local _offset=0
       if command -v cksum >/dev/null 2>&1; then
         _offset=$(( $(printf '%s' "{{name}}" | cksum | cut -d' ' -f1) % _interval ))
       fi
-      echo "[hindsight-drain] starting: interval=${_interval}s offset=${_offset}s lock=${_lock}"
+      echo "[hindsight-drain] starting: interval=${_interval}s (cooldown between runs, not a fixed period) offset=${_offset}s serialised-by=drain_pending.py"
       sleep "$_offset"
       while true; do
-        # -n: if a drain (ours or an operator sweep) already holds the
-        # lock, skip this tick entirely instead of queueing behind it.
-        flock -n "$_lock" python3 "$_script" --backlog || true
+        # No `flock` here, by design — drain_pending.py locks itself, and a
+        # wrapper here would hold the lock it needs. See the note above.
+        python3 "$_script" --backlog || true
         sleep "$_interval"
       done
     }
     _switchroom_supervise hindsight-drain /var/log/switchroom/hindsight-drain.log \
       _switchroom_hindsight_drain_loop "$_hs_drain_script" &
+  else
+    # NEVER FAIL SILENTLY. Without this branch a failed precondition left no
+    # log line and no logfile at all, so "is the drain running?" was
+    # unanswerable from the logs — indistinguishable from a drain that was
+    # running and finding nothing to do.
+    if [ "${SWITCHROOM_HINDSIGHT_DRAIN:-1}" = "0" ]; then
+      _hs_drain_why="disabled by SWITCHROOM_HINDSIGHT_DRAIN=0"
+    elif [ ! -f "$_hs_drain_script" ]; then
+      _hs_drain_why="no drain script at $_hs_drain_script (hindsight plugin not installed, or an interrupted \`switchroom apply\`)"
+    else
+      _hs_drain_why="python3 is not on PATH in this image"
+    fi
+    _hs_drain_msg="[hindsight-drain] NOT STARTED: ${_hs_drain_why}. The memory queue will only be drained at session boot, which cannot clear a backlog."
+    echo "$_hs_drain_msg"
+    mkdir -p /var/log/switchroom 2>/dev/null || true
+    echo "$_hs_drain_msg" >> /var/log/switchroom/hindsight-drain.log 2>/dev/null || true
   fi
 {{/if}}
 

--- a/src/cli/doctor-pending-retains.test.ts
+++ b/src/cli/doctor-pending-retains.test.ts
@@ -232,6 +232,91 @@ describe("checkPendingRetainsQueues (#1071/#1094)", () => {
     expect(fix).toMatch(/millisecond integer on stdout/);
   });
 
+  // ADJACENCY, not mere presence. The assertions above — and the two #3689
+  // ones below — are all substring checks, and a substring check cannot see
+  // a splice: when a block of serialisation prose was inserted INTO the
+  // middle of this sentence, the operator-facing text read "(must print a
+  // SAFE ALONGSIDE THE `hindsight-drain` SIDECAR …" and picked the sentence
+  // back up nine lines later with "…to replay them. millisecond integer on
+  // stdout; unset = no backoff)." Both fragments still existed, so every
+  // touching test stayed green while the remediation was incoherent at
+  // exactly the point it explains the backoff contract. Green tests
+  // asserting the wrong thing are worse than no test, so assert the sentence
+  // is CONTIGUOUS.
+  it("warn: the p95 backoff sentence is contiguous, not two fragments", () => {
+    const r = checkPendingRetainsQueues(cfg(["ziggy"]), {
+      probe: probeFrom({ ziggy: backlog(400) }),
+    });
+    const fix = r.fix ?? "";
+    expect(
+      fix,
+      "the backoff contract must read as one sentence, start to finish",
+    ).toContain("(must print a millisecond integer on stdout; unset = no backoff).");
+    // …and nothing may be wedged between its two halves. Asserted separately
+    // from the substring above so a failure names WHICH property broke.
+    const opener = fix.indexOf("(must print a");
+    const contract = fix.indexOf("millisecond integer on stdout");
+    expect(opener, "the sentence opener is missing entirely").toBeGreaterThan(-1);
+    expect(contract, "the contract clause is missing entirely").toBeGreaterThan(-1);
+    expect(
+      fix.slice(opener + "(must print a".length, contract),
+      "text was spliced into the middle of the p95 backoff sentence",
+    ).toBe(" ");
+  });
+
+  // The reciprocal: the block that was spliced IN must itself stay whole, so
+  // a future re-anchor of some other paragraph cannot cut this one in half
+  // the same way and still pass on substrings.
+  it("warn: the serialisation and circuit-breaker guidance is contiguous too", () => {
+    const r = checkPendingRetainsQueues(cfg(["ziggy"]), {
+      probe: probeFrom({ ziggy: backlog(400) }),
+    });
+    const fix = r.fix ?? "";
+    expect(fix).toContain(
+      "SAFE ALONGSIDE THE `hindsight-drain` SIDECAR and a session booting " +
+        "underneath you: drain_pending.py takes an exclusive lock on " +
+        "`$HOME/.hindsight/drain-pending.lock` for the whole run",
+    );
+    expect(fix).toContain(
+      "Entries past the attempt ceiling (HINDSIGHT_DRAIN_ATTEMPT_CEILING, " +
+        "default 20) are PARKED and reported rather than retried forever; add " +
+        "`--force` once the upstream is fixed to replay them.",
+    );
+  });
+
+  // #3689: this command is now one of THREE drain paths into the same queue
+  // (the others being the SessionStart hook and the `hindsight-drain`
+  // sidecar). An operator running it cannot know whether one of the others is
+  // mid-run, and two drains on one queue means one memory POSTed twice
+  // against a 4-lane fleet-wide pool. The serialisation lives inside
+  // drain_pending.py precisely so this documented command inherits it -- but
+  // the operator still has to be told, and told NOT to add an `flock` of
+  // their own on that path, which would hold the lock the script then asks
+  // for and turn the drain into a silent no-op.
+  it("warn: the remediation says the documented drain is serialised, and how not to break it", () => {
+    const r = checkPendingRetainsQueues(cfg(["ziggy"]), {
+      probe: probeFrom({ ziggy: backlog(400) }),
+    });
+    const fix = r.fix ?? "";
+    expect(fix).toContain("drain-pending.lock");
+    expect(fix).toMatch(/exclusive lock/i);
+    expect(fix, "the operator must be told not to wrap it").toMatch(
+      /Do NOT wrap this in `flock`/i,
+    );
+  });
+
+  // A parked entry is queue depth that will never go down on its own. An
+  // operator staring at that depth needs the escape hatch named, or the
+  // circuit breaker reads as the drain being broken.
+  it("warn: the remediation names the attempt ceiling and the --force replay", () => {
+    const r = checkPendingRetainsQueues(cfg(["ziggy"]), {
+      probe: probeFrom({ ziggy: backlog(400) }),
+    });
+    const fix = r.fix ?? "";
+    expect(fix).toContain("HINDSIGHT_DRAIN_ATTEMPT_CEILING");
+    expect(fix).toContain("--force");
+  });
+
   it("ok: zero drops and zero evictions never mention either", () => {
     const r = checkPendingRetainsQueues(cfg(["clerk"]), {
       probe: probeFrom({ clerk: ok() }),

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1942,7 +1942,36 @@ export function checkPendingRetainsQueues(
     `request_duration_ms)) from \\"LiteLLM_SpendLogs\\" where \\"startTime\\" > now() ` +
     `- interval '10 minutes' and metadata->>'user_api_key_alias' like 'hindsight-%' and ` +
     `status='success' and request_duration_ms is not null), -1)"\` (must print a ` +
-    `millisecond integer on stdout; unset = no backoff). Fix the upstream first (bank ` +
+    `millisecond integer on stdout; unset = no backoff). ` +
+    // ANCHOR — a SENTENCE BOUNDARY, and that is the whole requirement.
+    // This block belongs beside the documented `--backlog` command it
+    // qualifies, but the sentences immediately under that command were being
+    // rewritten in parallel by #3688, so sitting there guaranteed a conflict
+    // between two PRs meant to land in either order. Moving it was right;
+    // where it landed was not. It went into the MIDDLE of the p95 sentence,
+    // and the operator-facing text became "…-1)\"` (must print a SAFE
+    // ALONGSIDE THE `hindsight-drain` SIDECAR…", picking the sentence back
+    // up nine lines later at "…to replay them. millisecond integer on
+    // stdout; unset = no backoff)." — incoherent at exactly the point it
+    // explains the backoff contract. Every touching test stayed GREEN,
+    // because each asserted a substring that still existed somewhere in the
+    // string.
+    //
+    // So: the p95 sentence now ends at "no backoff)." above, the next one
+    // starts at "Fix the upstream first" below, and this block sits between
+    // two whole sentences. `warn: the p95 backoff sentence is contiguous,
+    // not two fragments` asserts adjacency rather than presence, so the next
+    // re-anchor that splices FAILS instead of passing.
+    `SAFE ALONGSIDE THE \`hindsight-drain\` SIDECAR and a session booting underneath ` +
+    `you: drain_pending.py takes an exclusive lock on ` +
+    `\`$HOME/.hindsight/drain-pending.lock\` for the whole run, so whichever drain ` +
+    `starts second prints "another drain holds ..." and exits without touching the ` +
+    `queue. Do NOT wrap this in \`flock\` on that path yourself — you would hold the ` +
+    `lock the script then asks for, and it would skip every time. Entries past the ` +
+    `attempt ceiling (HINDSIGHT_DRAIN_ATTEMPT_CEILING, default 20) are PARKED and ` +
+    `reported rather than retried forever; add \`--force\` once the upstream is fixed ` +
+    `to replay them. ` +
+    `Fix the upstream first (bank ` +
     `health rows above), or every retry just ages entries toward .dead. Entries the ` +
     `drain retires are MOVED to \`.hindsight/pending-reconciled/\` (bounded, so they ` +
     `expire), never deleted — every retire rests on an HTTP 200, which is an ack and ` +

--- a/tests/hindsight-drain-sidecar.test.ts
+++ b/tests/hindsight-drain-sidecar.test.ts
@@ -9,18 +9,36 @@
  * queue is a memory the agent cannot recall
  * (reference/jobs/remember-across-sessions.md).
  *
- * These tests execute the REAL shell function lifted out of the template
- * against real `flock`, and assert OUTCOMES: that a run cannot be
- * overlapped, that a failing run does not end the drain for the container's
- * life, and that the fleet does not wake in lockstep against a 4-slot LLM
- * lane.
+ * These tests execute the REAL shell — both the precondition guard and the
+ * loop — lifted out of the template, and assert OUTCOMES rather than log
+ * lines. Specifically, and deliberately:
+ *
+ * - the stagger is asserted as a WAIT that actually happens (wall clock, and
+ *   the argument handed to `sleep`), not as the `offset=Ns` it announces;
+ * - the interval clamp is asserted as the duration the loop actually waits
+ *   between ticks, with the announcement checked to MATCH it;
+ * - the kill switch and the other preconditions are asserted by running the
+ *   real guard and seeing whether a sidecar is supervised at all.
+ *
+ * Each of those three used to pass against a mutant with the mechanism
+ * deleted: the announcement was still printed, so the suite stayed green
+ * while the stagger, the switch and the cadence did nothing.
+ *
+ * Serialisation is NOT asserted here, because it is no longer this file's
+ * job: `drain_pending.py` locks itself for every caller (SessionStart, this
+ * sidecar, the operator's `docker exec`) and
+ * `vendor/hindsight-memory/scripts/tests/test_drain_serialisation.py` pins
+ * it. What IS asserted here is the corollary — that this loop does NOT hold
+ * that lock, because a wrapper here would starve the drain it launches.
  */
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
+  symlinkSync,
   readFileSync,
   readdirSync,
   rmSync,
@@ -62,6 +80,47 @@ function extractLoop(agentName: string): string {
   return fn.replaceAll("{{name}}", agentName);
 }
 
+/**
+ * Lift the whole precondition guard — `if ... then <define+supervise> else
+ * <explain> fi` — so the switch and the "why didn't it start" branch can be
+ * EXECUTED rather than pattern-matched.
+ */
+function extractGuard(agentDir: string, agentName: string, logDir: string): string {
+  const from = SRC.indexOf("  _hs_drain_script=");
+  const to = SRC.indexOf("{{/if}}", from);
+  expect(from, "the drain guard not found in start.sh.hbs").toBeGreaterThan(0);
+  expect(to, "the {{#if hindsightEnabled}} guard is not closed").toBeGreaterThan(from);
+  const block = SRC.slice(from, to)
+    .split("\n")
+    .map((l) => l.replace(/^ {2}/, ""))
+    .join("\n")
+    .replaceAll("{{agentDir}}", agentDir)
+    .replaceAll("{{name}}", agentName)
+    // The real log path is asserted separately (see the `_switchroom_supervise`
+    // structure test); rebinding it keeps the test out of the host's /var/log.
+    .replaceAll("/var/log/switchroom", logDir);
+  expect(block, "an unbound handlebars token would make this test lie").not.toContain(
+    "{{",
+  );
+  return block;
+}
+
+/**
+ * Absolute paths for the few real binaries these tests need, resolved ONCE
+ * off the ambient PATH. The guard tests below run the shell with a closed
+ * PATH (see runGuard), so nothing may be looked up by name at that point —
+ * not even `bash` itself.
+ */
+function whichOrThrow(name: string): string {
+  const p = execFileSync("sh", ["-c", `command -v ${name}`], {
+    encoding: "utf-8",
+  }).trim();
+  expect(p, `${name} must be on PATH to run these tests`).not.toBe("");
+  return p;
+}
+const BASH = whichOrThrow("bash");
+const MKDIR = whichOrThrow("mkdir");
+
 // Sandbox under the repo, NOT os.tmpdir(): these tests exec a stub `python3`
 // off PATH, and /tmp is mounted `noexec` in the agent container (and on some
 // CI images). A noexec sandbox silently falls through to the REAL python3,
@@ -84,34 +143,50 @@ interface Scenario {
   interval?: string;
   /** exit status of the stub drain */
   exitCode?: number;
-  /** hold the drain lock for the whole run, as a concurrent sweep would */
-  holdLock?: boolean;
   /** shell prologue injected after the loop is defined (e.g. a sleep stub) */
   prologue?: string;
-  /** how long the loop is allowed to run, in seconds */
+  /** how long the loop is allowed to run, in seconds (fractions allowed) */
   runFor?: number;
 }
 
+interface Result {
+  runs: number;
+  stdout: string;
+  argv: string[];
+  /** every duration the loop handed to `sleep`, in order (RECORD_SLEEPS only) */
+  sleeps: string[];
+  /** per run: whether the stub drain could take the drain lock itself */
+  lockTaken: boolean[];
+}
+
 /** Run the real loop in a sandbox and report what it did. */
-function run(s: Scenario): { runs: number; stdout: string; argv: string[] } {
+function run(s: Scenario): Result {
   const home = mkdtempSync(join(root, "home-"));
   mkdirSync(join(home, ".hindsight"), { recursive: true });
   const runsDir = join(home, "runs");
   mkdirSync(runsDir);
   writeFileSync(join(home, "drain_pending.py"), "# stub\n");
 
-  // Stand in for python3 on PATH: records every invocation, then exits.
+  // Stand in for python3 on PATH: records every invocation and, critically,
+  // whether IT could still take the drain lock — drain_pending.py takes that
+  // lock for real, so a `flock` wrapper in the loop would starve it.
   const py = join(home, "python3");
   writeFileSync(
     py,
-    `#!/usr/bin/env bash\nprintf '%s\\n' "$*" > "$RUNS_DIR/$(date +%s%N)"\nexit ${s.exitCode ?? 0}\n`,
+    `#!${BASH}
+_lock="$HOME/.hindsight/drain-pending.lock"
+if ( exec 9>"$_lock"; flock -n 9 ) 2>/dev/null; then _l=lock-free; else _l=lock-held; fi
+printf '%s\\n' "$_l $*" > "$RUNS_DIR/$(date +%s%N)"
+exit ${s.exitCode ?? 0}
+`,
   );
   chmodSync(py, 0o755);
 
-  const lockHold = s.holdLock
-    ? `exec 9>"$HOME/.hindsight/drain.lock"\nflock -n 9 || { echo "harness could not take the lock"; exit 99; }\n`
-    : "";
-
+  // `set -m` puts the loop in its own process group so the teardown below can
+  // kill the group. Without it, an un-stubbed `sleep` survives the loop as an
+  // orphan, keeps the harness's stdout pipe open, and every real-time test
+  // hangs until the runner's timeout instead of finishing in a second.
+  const out = join(home, "out");
   const harness = join(home, "harness.sh");
   writeFileSync(
     harness,
@@ -120,38 +195,60 @@ set -u
 export PATH="${home}:$PATH"
 ${extractLoop(s.agentName ?? "klanker")}
 ${s.prologue ?? ""}
-${lockHold}
-_switchroom_hindsight_drain_loop "${join(home, "drain_pending.py")}" &
+set -m
+_switchroom_hindsight_drain_loop "${join(home, "drain_pending.py")}" > "${out}" 2>&1 &
 _loop=$!
+set +m
 command sleep ${s.runFor ?? 1}
-kill -9 $_loop 2>/dev/null
+kill -9 -"$_loop" 2>/dev/null || kill -9 "$_loop" 2>/dev/null
 exit 0
 `,
   );
   chmodSync(harness, 0o755);
 
-  const stdout = execFileSync("bash", [harness], {
+  execFileSync(BASH, [harness], {
     encoding: "utf-8",
     env: {
       ...process.env,
       HOME: home,
       RUNS_DIR: runsDir,
+      SLEEPS_FILE: join(home, "sleeps"),
       SWITCHROOM_HINDSIGHT_DRAIN_INTERVAL_S: s.interval ?? "",
     },
-    timeout: 20_000,
+    timeout: 30_000,
   });
-  const names = readdirSync(runsDir);
+  const stdout = existsSync(out) ? readFileSync(out, "utf-8") : "";
+  const names = readdirSync(runsDir).sort();
+  const recorded = names.map((n) => readFileSync(join(runsDir, n), "utf-8").trim());
+  const sleepsPath = join(home, "sleeps");
   return {
     runs: names.length,
     stdout,
-    argv: names.map((n) => readFileSync(join(runsDir, n), "utf-8").trim()),
+    argv: recorded.map((l) => l.replace(/^lock-(free|held) /, "")),
+    lockTaken: recorded.map((l) => l.startsWith("lock-free ")),
+    sleeps: existsSync(sleepsPath)
+      ? readFileSync(sleepsPath, "utf-8").split("\n").filter(Boolean)
+      : [],
   };
 }
 
 /** Collapse the loop's own waits so a 15-minute cadence is testable in ~1s. */
 const FAST = "sleep() { command sleep 0.05; }";
-/** Stop the loop at its very first wait — enough to read the announced config. */
-const HALT_AT_FIRST_SLEEP = "sleep() { exit 0; }";
+/**
+ * Record every duration the loop asks to wait for, then return immediately.
+ * This is what makes the stagger and the clamp assertable as BEHAVIOUR: the
+ * value handed to `sleep` is the mechanism, the `offset=`/`interval=` line is
+ * only an announcement, and the two are independently mutable.
+ */
+const RECORD_SLEEPS = `sleep() { printf '%s\\n' "\${1:-}" >> "$SLEEPS_FILE"; command sleep 0.02; }`;
+
+/**
+ * An agent name chosen so the deterministic offset is exactly 1 second at the
+ * default 900s interval (`printf '%s' snooze-98 | cksum` → 3006612601, and
+ * 3006612601 % 900 == 1). That is what makes the stagger testable as a REAL
+ * wall-clock wait instead of a printed number.
+ */
+const ONE_SECOND_OFFSET_AGENT = "snooze-98";
 
 describe("hindsight drain sidecar — structure", () => {
   it("the whole block sits inside {{#if hindsightEnabled}}, so a memory-less agent's start.sh is unchanged", () => {
@@ -212,17 +309,158 @@ describe("hindsight drain sidecar — structure", () => {
     expect(block).not.toMatch(/HINDSIGHT_RETAIN_CLIENT_DEADLINE_S=/);
   });
 
+  // The stopgap the comment block above cites ran under an outer `flock` on
+  // `drain.lock`, so the rows are one `git revert` away from being read as a
+  // reason to put that wrapper back. The behavioural test below only goes red
+  // for a wrapper on the SAME path `drain_pending.py` takes; a wrapper on the
+  // historical `drain.lock` starves nothing and would slip through green while
+  // silently re-narrowing serialisation to this one caller — the SessionStart
+  // hook's in-process drain and a bare `docker exec` would walk past it again.
+  // So pin the wrapper's ABSENCE textually. Comments are stripped first: the
+  // block deliberately talks about `flock` at length.
+  it("wraps the drain in no `flock` at all — the outer lock was deleted, not renamed", () => {
+    const code = extractLoop("klanker")
+      .split("\n")
+      .filter((l) => !/^\s*#/.test(l))
+      .join("\n");
+    // Guards the negative below: if the invocation is ever renamed, this test
+    // must fail loudly rather than pass against a loop it no longer covers.
+    expect(code).toMatch(/python3 "\$_script" --backlog/);
+    expect(
+      code,
+      "an outer `flock` wrapper is back in the drain loop; drain_pending.py owns serialisation for ALL callers",
+    ).not.toMatch(/\bflock\b/);
+  });
+
   it("the sidecar region is valid bash", () => {
-    const from = SRC.indexOf("  _hs_drain_script=");
-    const to = SRC.indexOf("{{/if}}", from);
-    expect(from).toBeGreaterThan(0);
-    const block = SRC.slice(from, to)
-      .replaceAll("{{agentDir}}", "/state/agent")
-      .replaceAll("{{name}}", "klanker");
-    expect(block).not.toContain("{{");
+    const block = extractGuard("/state/agent", "klanker", join(root, "logs"));
     const f = join(root, "syntax.sh");
     writeFileSync(f, `#!/usr/bin/env bash\n_switchroom_supervise() { :; }\n${block}\n`);
     expect(() => execFileSync("bash", ["-n", f])).not.toThrow();
+  });
+
+  it("only the docker runtime gets a sidecar, and that is written down", () => {
+    // The block lives inside the `SWITCHROOM_RUNTIME = docker` branch that
+    // ends at `exec tmux`, so a systemd-path agent silently keeps the
+    // boot-only drain. Undocumented, that reads as a bug; documented, it is a
+    // scope statement. (The fleet is entirely docker.)
+    const runtimeGuard = SRC.indexOf(`[ "$SWITCHROOM_RUNTIME" = "docker" ]`);
+    const block = SRC.indexOf("5) hindsight backlog drain");
+    const execTmux = SRC.indexOf("exec tmux -L");
+    expect(runtimeGuard).toBeGreaterThan(0);
+    expect(block).toBeGreaterThan(runtimeGuard);
+    expect(execTmux).toBeGreaterThan(block);
+    expect(SRC.slice(block, execTmux)).toContain("DOCKER RUNTIME ONLY");
+  });
+});
+
+/**
+ * The precondition guard, EXECUTED. Previously nothing ran this: the kill
+ * switch could be deleted outright and all ten tests stayed green, while the
+ * Risk section leaned on it as the container-level off switch.
+ */
+describe("hindsight drain sidecar — preconditions", () => {
+  interface GuardResult {
+    supervised: string[];
+    stdout: string;
+    log: string;
+  }
+
+  function runGuard(env: Record<string, string>, opts?: { noScript?: boolean; noPython?: boolean }): GuardResult {
+    const home = mkdtempSync(join(root, "guard-"));
+    const agentDir = join(home, "agent");
+    const logDir = join(home, "log");
+    const scriptDir = join(agentDir, ".claude", "plugins", "hindsight-memory", "scripts");
+    if (!opts?.noScript) {
+      mkdirSync(scriptDir, { recursive: true });
+      writeFileSync(join(scriptDir, "drain_pending.py"), "# stub\n");
+    }
+    // A CLOSED PATH: the only interpreter on it is the one this test puts
+    // there, so "python3 is absent" is a real condition rather than a lie the
+    // ambient /usr/bin quietly contradicts. `mkdir` is the one external the
+    // guard actually runs (creating the log dir).
+    const binDir = join(home, "bin");
+    mkdirSync(binDir, { recursive: true });
+    symlinkSync(MKDIR, join(binDir, "mkdir"));
+    if (!opts?.noPython) {
+      writeFileSync(join(binDir, "python3"), "#!/usr/bin/env bash\nexit 0\n");
+      chmodSync(join(binDir, "python3"), 0o755);
+    }
+    const supervised = join(home, "supervised");
+    const harness = join(home, "guard.sh");
+    writeFileSync(
+      harness,
+      `#!/usr/bin/env bash
+# \`set -u\` on purpose: start.sh does not use it today, but a BARE
+# \$SWITCHROOM_HINDSIGHT_DRAIN is one \`set -u\` away from aborting boot for
+# every hindsight agent. The defaulted form must survive it.
+set -u
+# A CLOSED PATH — see runGuard: the ambient /usr/bin always has a python3.
+export PATH="${binDir}"
+_switchroom_supervise() { printf '%s\\n' "$*" >> "${supervised}"; }
+${extractGuard(agentDir, "klanker", logDir)}
+wait
+`,
+    );
+    chmodSync(harness, 0o755);
+    const stdout = execFileSync(BASH, [harness], {
+      encoding: "utf-8",
+      env: { ...process.env, HOME: home, PATH: binDir, ...env },
+      timeout: 20_000,
+    });
+    const logFile = join(logDir, "hindsight-drain.log");
+    return {
+      supervised: existsSync(supervised)
+        ? readFileSync(supervised, "utf-8").split("\n").filter(Boolean)
+        : [],
+      stdout,
+      log: existsSync(logFile) ? readFileSync(logFile, "utf-8") : "",
+    };
+  }
+
+  it("starts the sidecar when nothing objects, with SWITCHROOM_HINDSIGHT_DRAIN unset", () => {
+    const r = runGuard({});
+    expect(r.supervised.length, "the drain must be supervised by default").toBe(1);
+    expect(r.supervised[0]).toContain("hindsight-drain");
+    expect(r.supervised[0]).toContain("_switchroom_hindsight_drain_loop");
+  });
+
+  it("SWITCHROOM_HINDSIGHT_DRAIN=0 actually stops it — the Risk section's off switch", () => {
+    // Deleting the kill-switch condition left every other test green. This is
+    // the only thing that fails.
+    const r = runGuard({ SWITCHROOM_HINDSIGHT_DRAIN: "0" });
+    expect(r.supervised, "the kill switch did not kill anything").toEqual([]);
+    expect(r.log).toContain("NOT STARTED");
+    expect(r.log).toContain("SWITCHROOM_HINDSIGHT_DRAIN=0");
+  });
+
+  it("any other value leaves it running — the switch is =0, not truthiness", () => {
+    expect(runGuard({ SWITCHROOM_HINDSIGHT_DRAIN: "1" }).supervised.length).toBe(1);
+    expect(runGuard({ SWITCHROOM_HINDSIGHT_DRAIN: "" }).supervised.length).toBe(1);
+  });
+
+  it("says WHY it did not start, in the logfile, when the script is missing", () => {
+    // Silence was the bug: no line, no logfile, so "is the drain running?"
+    // was unanswerable and looked identical to "running, nothing to do".
+    const r = runGuard({}, { noScript: true });
+    expect(r.supervised).toEqual([]);
+    expect(r.log).toContain("NOT STARTED");
+    expect(r.log).toContain("no drain script at");
+    expect(r.stdout).toContain("NOT STARTED");
+  });
+
+  it("says WHY it did not start when python3 is absent", () => {
+    const r = runGuard({}, { noPython: true });
+    expect(r.supervised).toEqual([]);
+    expect(r.log).toContain("python3 is not on PATH");
+  });
+
+  it("names exactly one reason, and it is the true one", () => {
+    // A branch that reported "python3 missing" for a disabled switch would be
+    // worse than silence.
+    const r = runGuard({ SWITCHROOM_HINDSIGHT_DRAIN: "0" }, { noPython: true });
+    expect(r.log).toContain("SWITCHROOM_HINDSIGHT_DRAIN=0");
+    expect(r.log).not.toContain("python3 is not on PATH");
   });
 });
 
@@ -243,12 +481,19 @@ describe("hindsight drain sidecar — behaviour", () => {
     }
   });
 
-  it("CANNOT overlap a drain that is already running — the tick skips instead of stacking", () => {
-    // Same outcome as a long run overshooting the interval: the lock is
-    // held, so no second drain may start. Without `flock -n` in the loop
-    // this window would see a dozen concurrent drains.
-    const { runs } = run({ prologue: FAST, holdLock: true, runFor: 1 });
-    expect(runs, "no drain may start while the lock is held").toBe(0);
+  it("leaves the drain lock free for drain_pending.py, which takes it itself", () => {
+    // Serialisation moved INTO the script so every caller is covered (the
+    // SessionStart hook and the operator's `docker exec` never had a lock).
+    // The corollary is load-bearing: a `flock` wrapper HERE would hold the
+    // lock the script then asks for, and the drain would skip every tick,
+    // silently, for the container's life. The stub records whether it could
+    // still take the lock at the moment the loop invoked it.
+    const { runs, lockTaken } = run({ prologue: FAST, runFor: 1 });
+    expect(runs).toBeGreaterThan(2);
+    expect(
+      lockTaken.every(Boolean),
+      "the loop is holding the drain lock; drain_pending.py would skip every run",
+    ).toBe(true);
   });
 
   it("keeps draining after a non-zero exit — `dead` entries are an outcome, not a reason to stop", () => {
@@ -258,29 +503,67 @@ describe("hindsight drain sidecar — behaviour", () => {
     expect(runs).toBeGreaterThan(2);
   });
 
-  it("staggers the fleet with a deterministic per-agent offset", () => {
+  it("WAITS out the per-agent offset before the first drain — the stagger is a delay, not a log line", async () => {
+    // The offset exists so 11 agents do not wake together against 4 shared
+    // LLM lanes. Deleting `sleep "$_offset"` while keeping the computation
+    // and the echo left the suite fully green, because the old test read the
+    // announcement out of stdout. This one uses real time: the agent name is
+    // picked so the offset is exactly 1s (see ONE_SECOND_OFFSET_AGENT), the
+    // interval is the 900s default, so a drain inside the first second can
+    // only mean the wait was skipped.
+    const early = run({
+      agentName: ONE_SECOND_OFFSET_AGENT,
+      interval: "900",
+      runFor: 0.6,
+    });
+    expect(early.stdout).toContain("offset=1s");
+    expect(
+      early.runs,
+      "a drain fired before the offset elapsed — the fleet would stampede",
+    ).toBe(0);
+
+    const later = run({
+      agentName: ONE_SECOND_OFFSET_AGENT,
+      interval: "900",
+      runFor: 2.5,
+    });
+    expect(later.runs, "the drain never ran after the offset").toBe(1);
+  });
+
+  it("the offset it WAITS for is deterministic per agent and spreads the fleet", () => {
+    // Same mechanism, asserted on the value actually handed to `sleep` rather
+    // than the value printed — those are independently mutable, and only the
+    // first one staggers anything.
     const offsets = new Map<string, number>();
     for (const name of ["klanker", "reggie", "marko", "overlord", "fable"]) {
       const first = run({
         agentName: name,
         interval: "900",
-        prologue: HALT_AT_FIRST_SLEEP,
-        runFor: 1,
+        prologue: RECORD_SLEEPS,
+        runFor: 0.5,
       });
-      const m = first.stdout.match(/offset=(\d+)s/);
-      expect(m, `no offset announced for ${name}: ${first.stdout}`).not.toBeNull();
+      expect(first.sleeps.length, `${name}: the loop never slept`).toBeGreaterThan(0);
+      const offset = Number(first.sleeps[0]);
+      expect(
+        Number.isFinite(offset),
+        `${name}: first wait was not a number: ${first.sleeps[0]}`,
+      ).toBe(true);
+      expect(offset, `${name}: offset must be inside the interval`).toBeLessThan(900);
+
       const again = run({
         agentName: name,
         interval: "900",
-        prologue: HALT_AT_FIRST_SLEEP,
-        runFor: 1,
+        prologue: RECORD_SLEEPS,
+        runFor: 0.5,
       });
       expect(
-        again.stdout.match(/offset=(\d+)s/)![1],
-        "the same agent must get the same offset on every boot",
-      ).toBe(m![1]);
-      offsets.set(name, Number(m![1]));
-      expect(Number(m![1])).toBeLessThan(900);
+        Number(again.sleeps[0]),
+        "the same agent must wait the same offset on every boot",
+      ).toBe(offset);
+
+      // The announcement must describe the wait that actually happens.
+      expect(first.stdout).toContain(`offset=${offset}s`);
+      offsets.set(name, offset);
     }
     expect(
       new Set(offsets.values()).size,
@@ -288,7 +571,11 @@ describe("hindsight drain sidecar — behaviour", () => {
     ).toBeGreaterThan(3);
   });
 
-  it("clamps a bogus or too-eager interval instead of hammering the lane", () => {
+  it("waits the CLAMPED interval between ticks, and announces the same number", () => {
+    // The clamp used to be checked only as `interval=Ns` on stdout: replacing
+    // `sleep "$_interval"` with a hardcoded `sleep 900` kept all ten tests
+    // green. Here the assertion is on every wait the loop actually performs
+    // after the initial offset.
     const cases: Array<[string, number]> = [
       ["", 900],
       ["abc", 900],
@@ -297,12 +584,30 @@ describe("hindsight drain sidecar — behaviour", () => {
       ["1200", 1200],
     ];
     for (const [given, want] of cases) {
-      const { stdout } = run({
-        interval: given,
-        prologue: HALT_AT_FIRST_SLEEP,
-        runFor: 1,
-      });
-      expect(stdout, `interval ${JSON.stringify(given)}`).toContain(`interval=${want}s`);
+      const r = run({ interval: given, prologue: RECORD_SLEEPS, runFor: 0.5 });
+      expect(r.stdout, `interval ${JSON.stringify(given)}`).toContain(
+        `interval=${want}s`,
+      );
+      const betweenTicks = r.sleeps.slice(1);
+      expect(
+        betweenTicks.length,
+        `interval ${JSON.stringify(given)}: the loop never reached its cooldown`,
+      ).toBeGreaterThan(0);
+      for (const s of betweenTicks) {
+        expect(
+          Number(s),
+          `interval ${JSON.stringify(given)}: waited ${s}s between ticks, announced ${want}s`,
+        ).toBe(want);
+      }
     }
   });
-}, 60_000);
+
+  it("calls the interval a cooldown, because the loop is sequential", () => {
+    // Honesty fix: the loop is `drain; sleep $interval`, so the true period is
+    // a drain's duration (up to the 3600s backlog budget) PLUS the interval.
+    // Announcing 900s as if it were the period overstated the cadence by up
+    // to 5x on a backlogged agent.
+    const { stdout } = run({ prologue: RECORD_SLEEPS, runFor: 0.3 });
+    expect(stdout).toContain("cooldown between runs, not a fixed period");
+  });
+}, 90_000);

--- a/vendor/hindsight-memory/scripts/drain_pending.py
+++ b/vendor/hindsight-memory/scripts/drain_pending.py
@@ -23,6 +23,49 @@ memory" from degrading into "never drain anything" — the drain is
 sequential and oldest-first, so without the demotion three chronically
 failing entries sit at the head and end every run at zero progress.
 
+Serialisation
+-------------
+``drain()`` takes an EXCLUSIVE, non-blocking lock (``_exclusive_drain``,
+``_drain_lock_path``) for the whole run and returns a zero summary with
+``skipped_locked=True`` if another drain already holds it. That lives HERE,
+not in a caller, because the queue has several independent drain paths and a
+guarantee that depends on every caller remembering to wrap itself in
+``flock`` is not a guarantee:
+
+* the SessionStart hook (``session_start.py`` imports ``drain`` directly),
+* the ``hindsight-drain`` sidecar in ``profiles/_base/start.sh.hbs``,
+* the operator's out-of-band replay, which ``switchroom doctor`` documents
+  as a bare ``docker exec … drain_pending.py --backlog``.
+
+Two of those overlapping means two processes iterate the same queue and
+re-POST the same entry — ~168s of a 4-slot fleet-wide LLM lane, twice, for
+one memory. The lock is ``fcntl.flock``, so the kernel releases it if the
+process dies; there is no stale-lock recovery to get wrong.
+
+The lock file is ``drain-pending.lock``, deliberately NOT the ``drain.lock``
+that the interim host cron wraps its ``docker exec`` in. Same-path would
+mean that wrapper's outer ``flock`` starves the ``drain_pending.py`` it just
+launched — a silent no-op, i.e. the drain quietly stops. With a distinct
+name an external ``flock`` wrapper on the historical path is redundant but
+harmless, and this module's guarantee holds no matter who calls it.
+
+Circuit breaker
+---------------
+Demotion (above) bounds head-of-line blocking, but not TOTAL work: a
+chronically failing entry is retried on every run forever. That was
+tolerable when the only drains were a 4-second hook and a supervised manual
+sweep. It is not tolerable for the unattended sidecar, whose backlog budget
+is 3600s against a 900s cooldown — a wedged agent would spend ~80% of
+wall-clock re-POSTing the same unsaveable entries into a shared lane, for
+good. So an entry past ``_attempt_ceiling()`` (default ``MAX_ATTEMPTS`` x 4
+= 20 attempts, ``HINDSIGHT_DRAIN_ATTEMPT_CEILING``) is PARKED: skipped by
+the retain pass, counted in ``summary["parked"]``, still on disk, still
+swept for free by the reconcile pass, and still retried in full under
+``--force``. Parking destroys nothing; it stops paying for the same failure
+without end. HOW MUCH WALL-CLOCK 20 ATTEMPTS BUYS IS QUEUE-SIZE DEPENDENT,
+and is shorter than it looks — the measured table is at
+``ATTEMPT_CEILING_MULTIPLE``, and the trade it records is deliberate.
+
 Boundaries
 ----------
 * Per-entry HTTP timeout: ``HINDSIGHT_DRAIN_TIMEOUT`` (default 5s), but
@@ -118,6 +161,8 @@ Standalone usage::
 from __future__ import annotations
 
 import argparse
+import contextlib
+import fcntl
 import os
 import subprocess
 import sys
@@ -136,6 +181,7 @@ from lib.pending import (
     is_permanent_failure,
     iter_entries,
     mark_dead,
+    pending_dir,
     resplit_over_bound_entries,
     sweep_legacy_dead_markers,
     update_attempt,
@@ -144,6 +190,179 @@ from lib.retain_split import retain_client_deadline, retain_content_limit
 
 
 STALL_THRESHOLD = 3
+
+#: Attempt ceiling, as a multiple of ``MAX_ATTEMPTS`` — see ``_attempt_ceiling``
+#: and the "Circuit breaker" section of the module docstring. 4 x 5 = 20
+#: attempts.
+#:
+#: HOW LONG THAT BUYS IS QUEUE-SIZE DEPENDENT, which is the non-obvious part
+#: and the reason an earlier revision of this comment was wrong (it claimed 20
+#: attempts was "most of a day … far past any transient upstream outage"). A
+#: drain run attempts each live entry at most once, and ``pending.enqueue``
+#: already records attempt 1, so the FLOOR is 19 further runs — on the
+#: sidecar's 900s cooldown, **under 5 hours**, not most of a day. Above that
+#: floor the only thing that slows parking down is ``STALL_THRESHOLD`` (3),
+#: and it stops applying exactly when it would start to help: past
+#: ``MAX_ATTEMPTS`` an entry abstains from the stall guard (``_over_budget``),
+#: so once a queue is uniformly over budget EVERY entry is attempted on EVERY
+#: run.
+#:
+#: Measured against this module by ``CeilingArithmeticTest`` — total upstream
+#: outage, every attempt failing, counting drain runs until the whole queue is
+#: parked:
+#:
+#: ====  ====  ==============
+#: queue runs  at 900s
+#: ====  ====  ==============
+#: 1     20    5.0 h
+#: 4     24    6.0 h
+#: 13    36    9.0 h
+#: 30    56    14.0 h
+#: ====  ====  ==============
+#:
+#: So the guarantee runs BACKWARDS from the intuition: the SMALLER and
+#: healthier the queue, the SOONER a single overnight outage parks it whole.
+#: A 4-entry queue is gone in 6 hours. That is a real cost and it is accepted
+#: rather than papered over by a bigger number, because:
+#:
+#: * the ceiling is the ONLY bound on unattended lane waste, and it is a
+#:   per-run bound of ``len(queue)`` x ~168s once the stall guard abstains
+#:   (the n=30 run above retries all 30 entries every run for 14 hours).
+#:   Sizing the ceiling to survive a 24h outage means ~100 attempts, i.e.
+#:   5x that window — weakening the very mechanism this change adds;
+#: * parking destroys nothing. The entry stays on disk, the free reconcile
+#:   pass still sweeps it, ``--force`` replays it in full, and since the
+#:   summary-line fix below it is REPORTED on every drain path rather than
+#:   only the backlog one;
+#: * no attempt count can make a wall-clock promise anyway. Attempts convert
+#:   to hours only via the queue size, so a larger constant would restate the
+#:   same category error with a different number. Stating the conversion is
+#:   the durable fix.
+#:
+#: An operator who knows the upstream will be down longer than the table
+#: allows raises ``HINDSIGHT_DRAIN_ATTEMPT_CEILING`` for the duration, and
+#: replays with ``--force`` afterwards; ``switchroom doctor``'s backlog
+#: remediation names both.
+ATTEMPT_CEILING_MULTIPLE = 4
+
+#: Basename of the drain lock, inside the same directory that holds
+#: ``pending-retains/``. NOT ``drain.lock`` — see the module docstring:
+#: the interim host cron wraps its ``docker exec`` in ``flock -n
+#: $HOME/.hindsight/drain.lock``, and sharing that path would make that
+#: wrapper starve the very ``drain_pending.py`` it launches.
+DRAIN_LOCK_BASENAME = "drain-pending.lock"
+
+
+def _drain_lock_path() -> str:
+    """Absolute path of the per-agent drain lock.
+
+    Derived from ``pending_dir()`` rather than ``$HOME`` so it follows the
+    queue it protects: one lock per queue, including under
+    ``HINDSIGHT_PENDING_DIR``. In production that resolves to
+    ``$HOME/.hindsight/drain-pending.lock``.
+    """
+    override = os.environ.get("HINDSIGHT_DRAIN_LOCK")
+    if override:
+        return override
+    return os.path.join(
+        os.path.dirname(os.path.abspath(pending_dir())), DRAIN_LOCK_BASENAME
+    )
+
+
+@contextlib.contextmanager
+def _exclusive_drain():
+    """Hold the drain lock for the duration of a run.
+
+    Yields ``True`` if this process owns the drain, ``False`` if another
+    drain already holds the lock (caller must do nothing).
+
+    ``fcntl.flock`` and not a pidfile: the kernel releases it when the fd
+    closes OR the process dies, so a SIGKILLed drain cannot wedge the queue
+    and there is no stale-lock reaper to get wrong. ``LOCK_NB`` and not a
+    blocking wait, because every caller has somewhere better to be — the
+    SessionStart hook has a ~9s budget, and the sidecar has another tick in
+    900s.
+
+    FAILING TO OPEN the lock file is NOT contention and must not stop the
+    drain: an unwritable ``.hindsight/`` (read-only mount, ENOSPC) would
+    otherwise silently disable memory replay altogether, which is strictly
+    worse than an unserialised drain. That path warns and proceeds.
+    """
+    path = _drain_lock_path()
+    fd = None
+    try:
+        os.makedirs(os.path.dirname(path), mode=0o700, exist_ok=True)
+        fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+    except OSError as e:
+        if fd is not None:
+            os.close(fd)
+        print(
+            f"[Hindsight] drain_pending: cannot open drain lock {path} ({e}); "
+            f"draining WITHOUT serialisation",
+            file=sys.stderr,
+        )
+        yield True
+        return
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        os.close(fd)
+        yield False
+        return
+    try:
+        yield True
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
+def _attempt_ceiling() -> int:
+    """Attempts after which an entry is PARKED rather than retried again.
+
+    Floored at ``MAX_ATTEMPTS``: a ceiling below the attempt budget would
+    park entries the demotion logic is still trying to drain normally.
+    """
+    return _env_num(
+        "HINDSIGHT_DRAIN_ATTEMPT_CEILING",
+        MAX_ATTEMPTS * ATTEMPT_CEILING_MULTIPLE,
+        int,
+        lo=MAX_ATTEMPTS,
+    )
+
+
+def _circuit_broken(entry: dict) -> bool:
+    """Has this entry failed so many times that retrying it is just waste?"""
+    try:
+        return int(entry.get("attempt_count", 0)) >= _attempt_ceiling()
+    except (TypeError, ValueError):
+        # Same rule as ``_over_budget``: a corrupt counter must never decide
+        # policy and must never raise on the drain path. Treat it as live.
+        return False
+
+
+def _park_broken(
+    entries: list[tuple[str, dict]], summary: dict, force: bool
+) -> list[tuple[str, dict]]:
+    """Drop circuit-broken entries from a RETAIN pass, recording the count.
+
+    Applied to the POST paths only. The free reconcile pass
+    (``_reconcile_phase``) still sweeps every entry on disk, so a parked
+    entry whose document did land is still retired without a POST — parking
+    withholds the expensive retry, not the cheap proof.
+    """
+    if force:
+        return entries
+    live: list[tuple[str, dict]] = []
+    parked = 0
+    for path, entry in entries:
+        if _circuit_broken(entry):
+            parked += 1
+        else:
+            live.append((path, entry))
+    summary["parked"] = parked
+    return live
 
 
 def _clamp(timeout: int, budget: float, started: float) -> int:
@@ -552,6 +771,14 @@ def _new_summary() -> dict:
         "drained": 0,
         "retried": 0,
         "dead": 0,
+        # Entries past `_attempt_ceiling()` — skipped by the retain pass so an
+        # unattended sidecar cannot spend a shared LLM lane re-POSTing the same
+        # unsaveable entry forever. Still queued, still reconciled for free,
+        # still drained in full under `--force`. See the module docstring.
+        "parked": 0,
+        # True when another drain already held the lock, so THIS run did
+        # nothing at all. Distinguishes "no work" from "did not run".
+        "skipped_locked": False,
         "reconciled": 0,
         "unknown": 0,
         # Presence WAS established, but the entry could not be moved into
@@ -587,17 +814,28 @@ def drain(
     backlog: bool = False,
     phase: str = "both",
     dry_run: bool = False,
+    force: bool = False,
 ) -> dict:
     """Walk the pending-retains directory and retry each entry.
 
     ``backlog=False`` (default) is the bounded in-hook drain.
     ``backlog=True`` is the operator backlog replay — see ``drain_backlog()``.
+    ``force=True`` ignores the per-entry circuit breaker (module docstring).
+
+    THE SERIALISATION POINT for every drain path — the SessionStart hook, the
+    `hindsight-drain` sidecar and the operator's out-of-band replay all reach
+    the queue through this function, so the lock is taken here rather than in
+    any one caller. A run that finds the lock held does NOTHING and returns a
+    zero summary with ``skipped_locked=True``; it never queues behind the
+    holder, because every caller has a next tick and none has time to wait.
 
     Returns a summary dict::
 
         {"drained": int,   # successful retries (entries archived)
          "retried": int,   # failures kept for next session
          "dead":    int,   # entries promoted to .dead this run
+         "parked":  int,   # past the attempt ceiling: not retried this run
+         "skipped_locked": bool,  # another drain held the lock; did nothing
          "reconciled": int,# already durable, archived without a POST
          "unknown": int,   # presence unknown, left queued
          "archive_failed": int,  # durable, but the archive was unwritable
@@ -610,8 +848,26 @@ def drain(
          "budget_exceeded": bool}
     """
     config = config or load_config()
-    if backlog:
-        return _drain_backlog_impl(config, phase=phase, dry_run=dry_run)
+    with _exclusive_drain() as acquired:
+        if not acquired:
+            summary = _new_summary()
+            summary["skipped_locked"] = True
+            print(
+                f"[Hindsight] drain_pending: another drain holds "
+                f"{_drain_lock_path()} — skipping this run so the same entry "
+                f"is not retained twice.",
+                file=sys.stderr,
+            )
+            return summary
+        if backlog:
+            return _drain_backlog_impl(
+                config, phase=phase, dry_run=dry_run, force=force
+            )
+        return _drain_inhook_impl(config, force=force)
+
+
+def _drain_inhook_impl(config: dict, force: bool = False) -> dict:
+    """The bounded SessionStart drain. The caller holds the drain lock."""
     timeout = _per_entry_timeout()
     budget = _budget_seconds()
     started = time.monotonic()
@@ -622,9 +878,12 @@ def drain(
     # behind them — see ``_drain_order``. Matters even more here than in the
     # backlog drain: the in-hook budget is ~4s, so a single entry at the head
     # that always burns its clamped timeout consumes the entire run.
-    entries = _drain_order(iter_entries())
+    entries = _park_broken(_drain_order(iter_entries()), summary, force)
     if not entries:
-        debug_log(config, "drain_pending: queue empty")
+        debug_log(
+            config,
+            f"drain_pending: nothing to retry (parked={summary['parked']})",
+        )
         return summary
 
     debug_log(config, f"drain_pending: {len(entries)} entries to retry")
@@ -822,7 +1081,7 @@ def _wait_for_upstream(backoff_ms: int, started: float, budget: float) -> bool:
 
 
 def _drain_backlog_impl(
-    config: dict, phase: str = "both", dry_run: bool = False
+    config: dict, phase: str = "both", dry_run: bool = False, force: bool = False
 ) -> dict:
     """Concurrent-capable, long-budget, three-phase backlog replay."""
     summary = _new_summary()
@@ -897,8 +1156,18 @@ def _drain_backlog_impl(
 
     # See ``_drain_order``: without this, three budget-exhausted entries at the
     # head trip the stall guard on every run forever and the drain never makes
-    # progress again.
-    entries = _drain_order(iter_entries())
+    # progress again. Then the CIRCUIT BREAKER: demotion bounds head-of-line
+    # blocking but not total work, and this pass is the unattended one — a
+    # 3600s budget every 900s means a wedged agent would otherwise re-POST the
+    # same unsaveable entries into a 4-slot shared lane indefinitely.
+    entries = _park_broken(_drain_order(iter_entries()), summary, force)
+    if summary["parked"]:
+        _blog(
+            f"parked {summary['parked']} entries past the attempt ceiling "
+            f"({_attempt_ceiling()} attempts) — still queued and still "
+            f"reconciled for free, but not retained again. `--force` to retry "
+            f"them anyway."
+        )
     if not entries:
         _blog("phase 2: nothing left to retain")
         return summary
@@ -1045,6 +1314,13 @@ def _parse_args(argv: list[str] | None):
         action="store_true",
         help="with --backlog: report what would happen, issue no writes",
     )
+    ap.add_argument(
+        "--force",
+        action="store_true",
+        help="retry entries past the attempt ceiling too (they are skipped by "
+        "default so an unattended drain cannot spend the shared retain lane "
+        "on the same permanently-failing entry forever)",
+    )
     return ap.parse_args(argv)
 
 
@@ -1058,7 +1334,11 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     config = load_config()
     summary = drain(
-        config, backlog=args.backlog, phase=args.phase, dry_run=args.dry_run
+        config,
+        backlog=args.backlog,
+        phase=args.phase,
+        dry_run=args.dry_run,
+        force=args.force,
     )
     if any(
         summary[k]
@@ -1072,6 +1352,22 @@ def main(argv: list[str] | None = None) -> int:
             "reconciled",
             "unknown",
             "archive_failed",
+            # PARKED IS IN THE GATE, not only in the line below. A run whose
+            # entire queue is past the attempt ceiling parks everything and
+            # does nothing else, so every other counter is 0 — without this
+            # key the gate stays shut and the run is completely silent: rc=0,
+            # empty stdout, empty stderr, byte-identical to "queue empty".
+            #
+            # The backlog path narrates its own parking (`_drain_backlog_impl`
+            # logs "parked N entries past the attempt ceiling"). The IN-HOOK
+            # path only `debug_log`s it, so it says nothing unless debug is on
+            # — and that is the path that runs on every session boot. Nothing
+            # else can supply the signal either: `switchroom doctor` reads the
+            # queue DIRECTORY, where a parked entry and a backlogged entry are
+            # the same file. An operator watching a queue that will not shrink
+            # could not tell "parked by the circuit breaker, needs --force"
+            # from "ordinary backlog, will drain on its own".
+            "parked",
         )
     ):
         print(
@@ -1083,6 +1379,7 @@ def main(argv: list[str] | None = None) -> int:
             f"retried={summary['retried']} dead={summary['dead']} "
             f"unknown={summary['unknown']} "
             f"archive_failed={summary['archive_failed']} "
+            f"parked={summary['parked']} "
             f"stalled={summary['stalled']} budget_exceeded={summary['budget_exceeded']}",
             file=sys.stderr,
         )

--- a/vendor/hindsight-memory/scripts/tests/test_drain_circuit_breaker.py
+++ b/vendor/hindsight-memory/scripts/tests/test_drain_circuit_breaker.py
@@ -1,0 +1,401 @@
+"""A permanently-failing entry must stop costing LLM lane time.
+
+Lives under ``scripts/tests/`` because that is the only python test directory
+CI discovers (``ci-tests-python.yml`` runs ``python3 -m unittest discover
+tests/`` with ``working-directory: vendor/hindsight-memory/scripts``).
+
+BACKGROUND. The permanence gate (``pending.is_permanent_failure``) keeps an
+entry queued past ``MAX_ATTEMPTS`` on anything but a 4xx, and ``_over_budget``
+/ ``_drain_order`` then DEMOTE it so it cannot starve healthy entries behind
+it. Both are right, and together they bound head-of-line blocking — but not
+TOTAL work: the entry is still retried in full on every single run, forever.
+
+That was affordable when every drain was supervised: a 4-second in-hook pass,
+or an operator watching a manual sweep. The ``hindsight-drain`` sidecar makes
+it unaffordable. Its backlog budget is 3600s (``_backlog_budget_seconds``)
+against a 900s cooldown, so a wedged agent spends ~80% of wall-clock draining,
+unattended, against 4 lanes shared with live retains, reflect and
+consolidation — indefinitely. The interim host stopgap recorded exactly that
+shape while it ran: ``finn 280s drained=0 retried=3 STALLED``, ``carrie 564s
+drained=0 retried=2 (lane busy)``.
+
+So an entry past ``_attempt_ceiling()`` is PARKED. Parking is not retirement:
+the entry stays on disk, keeps being swept for free by the reconcile pass, and
+comes back in full under ``--force``. What it stops is paying ~168s of a
+shared lane, again, for a POST that has already failed 20 times.
+
+Every test here fails without the ``_park_broken`` call in the drain paths:
+the parked entry is retained again, which is the unbounded-retry behaviour.
+"""
+
+import io
+import json
+import os
+import re
+import sys
+import unittest
+import unittest.mock
+from contextlib import redirect_stderr
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import drain_pending  # noqa: E402
+import lib.pending as pending  # noqa: E402
+
+from tests.test_pending_drops import (  # noqa: E402
+    CONFIG,
+    _QueueTempDirMixin,
+    _cd_doc,
+    _payload,
+)
+
+
+class CircuitBreakerTest(_QueueTempDirMixin, unittest.TestCase):
+    ENV_KEYS = _QueueTempDirMixin.ENV_KEYS + ("HINDSIGHT_DRAIN_ATTEMPT_CEILING",)
+
+    def setUp(self):
+        super().setUp()
+        os.environ.pop("HINDSIGHT_DRAIN_ATTEMPT_CEILING", None)
+        self.posted = []
+
+    def _seed(self, attempts_by_content):
+        """Queue one entry per ``{content: attempt_count}`` pair."""
+        clock = iter(1000.0 + i for i in range(50))
+        with unittest.mock.patch.object(pending.time, "time", lambda: next(clock)):
+            for i, content in enumerate(attempts_by_content):
+                pending.enqueue(
+                    _payload(content=content, doc=_cd_doc(i)), RuntimeError("x")
+                )
+        for path, entry in pending.iter_entries():
+            entry["attempt_count"] = attempts_by_content[entry["content"]]
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(entry, f)
+
+    def _record_post(self, entry, timeout):
+        self.posted.append(entry["content"])
+
+    def _drain(self, present=False, **kw):
+        with unittest.mock.patch.object(
+            drain_pending, "_retry_one", self._record_post
+        ):
+            with unittest.mock.patch.object(
+                drain_pending, "_document_state", lambda e, timeout=30: present
+            ):
+                with redirect_stderr(io.StringIO()) as err:
+                    summary = drain_pending.drain(CONFIG, **kw)
+        return summary, err.getvalue()
+
+    # ── the breaker itself ────────────────────────────────────────────
+
+    def test_the_unattended_backlog_drain_stops_retrying_a_wedged_entry(self):
+        ceiling = drain_pending._attempt_ceiling()
+        self._seed({"wedged": ceiling, "healthy": 1})
+
+        summary, err = self._drain(backlog=True, phase="drain")
+
+        self.assertEqual(
+            self.posted,
+            ["healthy"],
+            "an entry past the attempt ceiling must not be retained again",
+        )
+        self.assertEqual(summary["parked"], 1)
+        self.assertIn("parked 1 entries past the attempt ceiling", err)
+
+    def test_parking_is_not_retirement_the_entry_is_still_on_disk(self):
+        """The whole permanence gate rests on never destroying a memory. A
+        breaker that deleted, or promoted to ``.dead``, would trade the
+        wedge for the data loss the gate exists to prevent."""
+        ceiling = drain_pending._attempt_ceiling()
+        self._seed({"wedged": ceiling})
+
+        self._drain(backlog=True, phase="drain")
+
+        self.assertEqual(pending.count(), 1)
+        self.assertEqual(
+            [e["content"] for _p, e in pending.iter_entries()], ["wedged"]
+        )
+        self.assertEqual(
+            [n for n in os.listdir(self._dir) if n.endswith(".dead")],
+            [],
+            "parking must not retire the entry",
+        )
+
+    def test_a_parked_entry_is_still_reconciled_for_free(self):
+        """Parking withholds the expensive retry, not the cheap proof: if the
+        document DID land, the free presence pass still retires the entry."""
+        ceiling = drain_pending._attempt_ceiling()
+        self._seed({"wedged": ceiling})
+
+        summary, _ = self._drain(backlog=True, present=True, phase="reconcile")
+
+        self.assertEqual(summary["reconciled"], 1)
+        self.assertEqual(self.posted, [], "no POST was needed")
+        self.assertEqual(pending.count(), 0)
+
+    def test_force_retries_the_parked_entries_anyway(self):
+        """The escape hatch. Without it the breaker would be a one-way door,
+        and an operator who fixed the upstream could never replay."""
+        ceiling = drain_pending._attempt_ceiling()
+        self._seed({"wedged": ceiling, "healthy": 1})
+
+        summary, _ = self._drain(backlog=True, phase="drain", force=True)
+
+        self.assertEqual(sorted(self.posted), ["healthy", "wedged"])
+        self.assertEqual(summary["parked"], 0)
+
+    def test_an_entry_one_attempt_below_the_ceiling_still_drains(self):
+        """The boundary. A breaker that fired early would park entries the
+        demotion logic is still successfully draining."""
+        ceiling = drain_pending._attempt_ceiling()
+        self._seed({"nearly": ceiling - 1})
+
+        summary, _ = self._drain(backlog=True, phase="drain")
+
+        self.assertEqual(self.posted, ["nearly"])
+        self.assertEqual(summary["parked"], 0)
+
+    def test_the_in_hook_drain_parks_too(self):
+        """Same policy on the SessionStart path: a 4s budget spent on an
+        entry that has failed 20 times is 4s not spent on the rest."""
+        ceiling = drain_pending._attempt_ceiling()
+        self._seed({"wedged": ceiling, "healthy": 1})
+
+        summary, _ = self._drain()
+
+        self.assertEqual(self.posted, ["healthy"])
+        self.assertEqual(summary["parked"], 1)
+
+    def test_repeated_unattended_runs_never_touch_the_wedged_entry_again(self):
+        """The actual failure mode: not one wasted run, but every run from
+        here to the heat death of the container."""
+        ceiling = drain_pending._attempt_ceiling()
+        self._seed({"wedged": ceiling})
+
+        for _ in range(5):
+            self._drain(backlog=True, phase="drain")
+
+        self.assertEqual(self.posted, [], "5 unattended ticks, zero lane time")
+        self.assertEqual(pending.count(), 1, "and the memory is still there")
+
+    # ── the ceiling ───────────────────────────────────────────────────
+
+    def test_the_default_ceiling_is_a_multiple_of_the_attempt_budget(self):
+        self.assertEqual(
+            drain_pending._attempt_ceiling(),
+            pending.MAX_ATTEMPTS * drain_pending.ATTEMPT_CEILING_MULTIPLE,
+        )
+        self.assertGreater(
+            drain_pending._attempt_ceiling(),
+            pending.MAX_ATTEMPTS,
+            "parking at the attempt budget would collide with demotion",
+        )
+
+    def test_the_ceiling_is_operator_tunable(self):
+        os.environ["HINDSIGHT_DRAIN_ATTEMPT_CEILING"] = "7"
+        self.assertEqual(drain_pending._attempt_ceiling(), 7)
+        self._seed({"wedged": 7, "healthy": 6})
+
+        summary, _ = self._drain(backlog=True, phase="drain")
+
+        self.assertEqual(self.posted, ["healthy"])
+        self.assertEqual(summary["parked"], 1)
+
+    def test_a_ceiling_below_the_attempt_budget_is_clamped_up(self):
+        """Below ``MAX_ATTEMPTS`` the breaker would park entries before the
+        ordinary retry policy has finished with them."""
+        os.environ["HINDSIGHT_DRAIN_ATTEMPT_CEILING"] = "1"
+        self.assertEqual(drain_pending._attempt_ceiling(), pending.MAX_ATTEMPTS)
+
+    def test_a_garbage_ceiling_falls_back_to_the_default(self):
+        os.environ["HINDSIGHT_DRAIN_ATTEMPT_CEILING"] = "not-a-number"
+        self.assertEqual(
+            drain_pending._attempt_ceiling(),
+            pending.MAX_ATTEMPTS * drain_pending.ATTEMPT_CEILING_MULTIPLE,
+        )
+
+    def test_a_corrupt_attempt_counter_never_parks_and_never_raises(self):
+        """Same rule as ``_over_budget``: a hand-edited counter must not
+        decide policy, and must not blow up the drain path."""
+        self.assertFalse(drain_pending._circuit_broken({"attempt_count": "many"}))
+        self.assertFalse(drain_pending._circuit_broken({"attempt_count": None}))
+        self.assertFalse(drain_pending._circuit_broken({}))
+
+    # ── reporting: parking must be VISIBLE, on every path ─────────────
+
+    def _main(self, argv, present=False):
+        """Run the CLI entrypoint, capturing what an operator would see."""
+        with unittest.mock.patch.object(drain_pending, "load_config", lambda: CONFIG):
+            with unittest.mock.patch.object(
+                drain_pending, "_retry_one", self._record_post
+            ):
+                with unittest.mock.patch.object(
+                    drain_pending, "_document_state", lambda e, timeout=30: present
+                ):
+                    with redirect_stderr(io.StringIO()) as err:
+                        rc = drain_pending.main(argv)
+        return rc, err.getvalue()
+
+    def test_an_in_hook_run_that_only_parks_still_says_so(self):
+        """THE OBSERVABILITY HOLE THE CIRCUIT BREAKER OPENS.
+
+        A run whose entire queue is past the ceiling parks everything and
+        does nothing else, so every other summary counter is 0. With
+        ``parked`` missing from ``main()``'s gate that run printed NOTHING —
+        rc=0, empty stdout, empty stderr — which is byte-identical to "the
+        queue was empty". The operator watching a queue that will not shrink
+        then has no way to tell "parked by the breaker, needs ``--force``"
+        from "ordinary backlog, drains on its own", because ``switchroom
+        doctor`` reads only the queue DIRECTORY and both look like a file.
+
+        The ``--backlog`` path narrates its own parking. This is the IN-HOOK
+        path, which is the one that runs on every session boot.
+        """
+        ceiling = drain_pending._attempt_ceiling()
+        self._seed({"a": ceiling, "b": ceiling, "c": ceiling})
+
+        rc, err = self._main([])
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.posted, [], "nothing was retried — all parked")
+        self.assertNotEqual(
+            err.strip(), "", "a run that parked the whole queue must not be silent"
+        )
+        self.assertIn("parked=3", err)
+
+    def test_the_summary_line_reports_parked_alongside_other_work(self):
+        """The gate is not the only half. With ``parked`` in the gate but
+        absent from the printed line, a mixed run opens the gate on its other
+        counters and still never names the parked entries."""
+        ceiling = drain_pending._attempt_ceiling()
+        self._seed({"wedged": ceiling, "healthy": 1})
+
+        rc, err = self._main([], present=True)
+
+        self.assertEqual(rc, 0)
+        self.assertIn("reconciled=1", err)
+        self.assertIn("parked=1", err)
+
+
+class CeilingArithmeticTest(_QueueTempDirMixin, unittest.TestCase):
+    """How long 20 attempts actually buys — measured, not asserted in prose.
+
+    ``ATTEMPT_CEILING_MULTIPLE``'s comment used to claim 20 attempts was
+    "most of a day … far past any transient upstream outage". It is not, and
+    the reason is the non-obvious part: attempts convert to wall-clock only
+    via the QUEUE SIZE. A drain run attempts each live entry at most once and
+    ``enqueue`` already records attempt 1, so the floor is 19 further runs —
+    under 5 hours at the sidecar's 900s cooldown. ``STALL_THRESHOLD`` only
+    rations attempts while entries are inside ``MAX_ATTEMPTS``; past it they
+    abstain from the stall guard, so a uniformly over-budget queue is
+    attempted in full on every run.
+
+    This measures the real figures and pins the comment's table to them, so
+    the prose cannot drift away from the code again: change the mechanism and
+    the measured column moves; delete the table and the parse fails.
+    """
+
+    ENV_KEYS = _QueueTempDirMixin.ENV_KEYS + ("HINDSIGHT_DRAIN_ATTEMPT_CEILING",)
+
+    #: Rows the module comment must carry: queue size → drain runs until the
+    #: WHOLE queue is parked, under a total upstream outage.
+    SIZES = (1, 4, 13, 30)
+
+    #: The sidecar's default cooldown (``profiles/_base/start.sh.hbs``); the
+    #: comment's hours column is runs x this.
+    COOLDOWN_S = 900
+
+    def setUp(self):
+        super().setUp()
+        os.environ.pop("HINDSIGHT_DRAIN_ATTEMPT_CEILING", None)
+        # No p95 backoff, no pacing: this test counts RUNS, not seconds.
+        os.environ.pop("HINDSIGHT_DRAIN_P95_CMD", None)
+
+    def _runs_until_wholly_parked(self, n: int) -> int:
+        # Own queue dir per call, so several sizes can be measured in one
+        # test without one size's entries contaminating the next. The mixin
+        # owns HINDSIGHT_PENDING_DIR and restores it in tearDown; the
+        # directory itself lives under the mixin's tmp root and goes with it.
+        os.environ["HINDSIGHT_PENDING_DIR"] = os.path.join(
+            self._tmp, f"pending-retains-{n}"
+        )
+        clock = iter(1000.0 + i for i in range(n + 10))
+        with unittest.mock.patch.object(pending.time, "time", lambda: next(clock)):
+            for i in range(n):
+                pending.enqueue(
+                    _payload(content=f"e{i}", doc=_cd_doc(i)),
+                    ConnectionError("upstream down"),
+                )
+
+        def always_fails(entry, timeout=30):
+            raise ConnectionError("upstream down")
+
+        runs = 0
+        # Generous ceiling on the loop itself: a mechanism change that made
+        # parking unreachable must fail loudly rather than hang CI.
+        while runs < 500:
+            runs += 1
+            with unittest.mock.patch.object(
+                drain_pending, "_retry_one", always_fails
+            ):
+                with unittest.mock.patch.object(
+                    drain_pending, "_document_state", lambda e, timeout=30: False
+                ):
+                    with redirect_stderr(io.StringIO()):
+                        summary = drain_pending.drain(
+                            CONFIG, backlog=True, phase="drain"
+                        )
+            if summary["parked"] == n:
+                return runs
+        self.fail(f"a {n}-entry queue never parked wholly within 500 runs")
+
+    def _documented_table(self) -> dict:
+        """Parse the table out of ``ATTEMPT_CEILING_MULTIPLE``'s comment."""
+        with open(drain_pending.__file__, encoding="utf-8") as f:
+            src = f.read()
+        rows = re.findall(r"^#: (\d+)\s+(\d+)\s+([\d.]+) h$", src, re.M)
+        return {int(q): (int(r), float(h)) for q, r, h in rows}
+
+    def test_the_documented_table_is_what_the_code_actually_does(self):
+        documented = self._documented_table()
+        self.assertEqual(
+            sorted(documented),
+            sorted(self.SIZES),
+            "ATTEMPT_CEILING_MULTIPLE's comment must document exactly these "
+            "queue sizes — the prose is the deliverable here",
+        )
+        for n in self.SIZES:
+            with self.subTest(queue=n):
+                measured = self._runs_until_wholly_parked(n)
+                runs, hours = documented[n]
+                self.assertEqual(
+                    measured,
+                    runs,
+                    f"a {n}-entry queue parks wholly in {measured} runs, but "
+                    f"the comment says {runs}",
+                )
+                self.assertAlmostEqual(
+                    hours, runs * self.COOLDOWN_S / 3600.0, places=1
+                )
+
+    def test_a_small_queue_parks_well_inside_one_overnight_outage(self):
+        """The claim the old comment made, stated as the outcome it is not.
+
+        4 entries — a healthy agent — park entirely in 6 hours. So a single
+        overnight upstream outage CAN park a small queue wholesale, which is
+        exactly what "far past any transient upstream outage" denied. Pinned
+        as an outcome so nobody re-asserts the denial.
+        """
+        measured = self._runs_until_wholly_parked(4)
+        hours = measured * self.COOLDOWN_S / 3600.0
+        self.assertLess(
+            hours,
+            12.0,
+            "a 4-entry queue parking in under 12h is the accepted trade — if "
+            "this ever became untrue the comment must be re-measured too",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/hindsight-memory/scripts/tests/test_drain_serialisation.py
+++ b/vendor/hindsight-memory/scripts/tests/test_drain_serialisation.py
@@ -1,0 +1,286 @@
+"""Two drains of one queue must never run at once — whoever the caller is.
+
+Lives under ``scripts/tests/`` because that is the only python test directory
+CI discovers (``ci-tests-python.yml`` runs ``python3 -m unittest discover
+tests/`` with ``working-directory: vendor/hindsight-memory/scripts``).
+
+WHY THIS IS LOAD-BEARING. Retain extraction on this fleet is served by 4
+shared LLM lanes and a single entry measured 85-280s, so two drains walking
+the same queue is not a tidiness problem: it is the same ~168s of a scarce
+fleet-wide resource, spent twice, for one memory. The queue has three
+independent drain paths and NONE of them is in a position to serialise the
+others:
+
+* ``session_start.py`` imports ``drain`` and calls it in-process at every
+  session boot, with no lock of its own;
+* the ``hindsight-drain`` sidecar (``profiles/_base/start.sh.hbs``) ticks on
+  a timer inside the same container;
+* ``switchroom doctor`` documents an out-of-band ``docker exec …
+  drain_pending.py --backlog`` for operators clearing a backlog.
+
+An agent booting a session while the sidecar is mid-backlog is the ordinary
+case, not a corner. So the lock is taken inside ``drain()`` — the one
+function all three go through — and these tests pin that it holds for the
+in-process caller AND for a genuinely separate process running the CLI.
+
+Every test here fails if ``_exclusive_drain`` is removed from ``drain()``:
+the work happens twice instead of being skipped.
+"""
+
+import fcntl
+import io
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+import unittest.mock
+from contextlib import contextmanager, redirect_stderr
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import drain_pending  # noqa: E402
+import lib.pending as pending  # noqa: E402
+
+from tests.test_pending_drops import (  # noqa: E402
+    CONFIG,
+    _QueueTempDirMixin,
+    _cd_doc,
+    _payload,
+)
+
+
+@contextmanager
+def _held_by_someone_else(path):
+    """Hold the drain lock on a SEPARATE open file description.
+
+    ``flock`` locks belong to the open file description, not to the process,
+    so a second ``open()`` of the same file contends with this one exactly as
+    another process would (flock(2): "these file descriptors are treated
+    independently"). That keeps the test deterministic — no sleeps, no race
+    with a child's startup — and the CLI case below covers a real process.
+    """
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        yield
+    finally:
+        os.close(fd)
+
+
+class DrainLockTest(_QueueTempDirMixin, unittest.TestCase):
+    ENV_KEYS = _QueueTempDirMixin.ENV_KEYS + ("HINDSIGHT_DRAIN_LOCK",)
+
+    def setUp(self):
+        super().setUp()
+        self.posted = []
+        self.presence_checks = []
+
+    def _seed(self, n=3):
+        for i in range(n):
+            pending.enqueue(_payload(content=f"c{i}", doc=_cd_doc(i)), RuntimeError("x"))
+
+    def _record_post(self, entry, timeout):
+        self.posted.append(entry["content"])
+
+    def _record_presence(self, entry, timeout=30):
+        self.presence_checks.append(entry["content"])
+        return True
+
+    def _drain(self, **kw):
+        with unittest.mock.patch.object(
+            drain_pending, "_retry_one", self._record_post
+        ):
+            with unittest.mock.patch.object(
+                drain_pending, "_document_state", self._record_presence
+            ):
+                with redirect_stderr(io.StringIO()) as err:
+                    summary = drain_pending.drain(CONFIG, **kw)
+        return summary, err.getvalue()
+
+    # ── the lock sits beside the queue it protects ────────────────────
+
+    def test_the_lock_lives_next_to_the_queue_it_protects(self):
+        """One lock per queue, so ``HINDSIGHT_PENDING_DIR`` moves both."""
+        self.assertEqual(
+            drain_pending._drain_lock_path(),
+            os.path.join(self._tmp, "drain-pending.lock"),
+        )
+
+    def test_the_production_path_is_the_agent_hindsight_dir(self):
+        """What the sidecar and the doctor recovery command actually share."""
+        os.environ.pop("HINDSIGHT_PENDING_DIR")
+        with unittest.mock.patch.dict(os.environ, {"HOME": "/state/agent/home"}):
+            self.assertEqual(
+                drain_pending._drain_lock_path(),
+                "/state/agent/home/.hindsight/drain-pending.lock",
+            )
+
+    def test_it_is_not_the_path_the_interim_host_cron_wraps(self):
+        """Deliberate: same path would make that wrapper starve this drain.
+
+        The interim host stopgap runs ``docker exec … flock -n
+        $HOME/.hindsight/drain.lock python3 drain_pending.py --backlog``. If
+        this module locked THAT path, the wrapper would already hold it and
+        the drain it just launched would skip every time — a silent no-op for
+        as long as both exist.
+        """
+        self.assertNotIn("/drain.lock", drain_pending._drain_lock_path())
+
+    # ── the in-process caller (SessionStart) ──────────────────────────
+
+    def test_the_in_hook_drain_does_nothing_while_another_drain_holds_it(self):
+        """``session_start.py`` calls this exact function, with no lock."""
+        self._seed(3)
+
+        with _held_by_someone_else(drain_pending._drain_lock_path()):
+            summary, err = self._drain()
+
+        self.assertEqual(self.posted, [], "no entry may be re-POSTed by a 2nd drain")
+        self.assertEqual(
+            self.presence_checks, [], "not even a free GET: the run did not happen"
+        )
+        self.assertTrue(summary["skipped_locked"])
+        self.assertEqual(summary["drained"], 0)
+        self.assertEqual(summary["reconciled"], 0)
+        self.assertEqual(pending.count(), 3, "the queue is untouched")
+        self.assertIn("another drain holds", err)
+
+    def test_the_backlog_drain_does_nothing_while_another_drain_holds_it(self):
+        """The sidecar's mode. Phase 1 is free, but it is not idempotent-free:
+        two reconcilers race on the same archive move."""
+        self._seed(3)
+
+        with _held_by_someone_else(drain_pending._drain_lock_path()):
+            summary, _ = self._drain(backlog=True)
+
+        self.assertEqual(self.posted, [])
+        self.assertEqual(self.presence_checks, [])
+        self.assertTrue(summary["skipped_locked"])
+        self.assertEqual(pending.count(), 3)
+
+    def test_the_skip_is_the_lock_and_not_an_unconditional_refusal(self):
+        """Guard rail: a drain that always skipped would pass the tests above
+        and drain nothing in production, which is the bug the whole PR is
+        about. Same queue, same call, lock free → the work happens."""
+        self._seed(3)
+
+        # `phase="drain"` so the free reconcile pass does not retire the
+        # entries before phase 2 can post them — the assertion here is that
+        # the EXPENSIVE work runs when the lock is free.
+        summary, _ = self._drain(backlog=True, phase="drain")
+
+        self.assertEqual(sorted(self.posted), ["c0", "c1", "c2"])
+        self.assertFalse(summary["skipped_locked"])
+        self.assertEqual(pending.count(), 0)
+
+    def test_the_lock_is_released_when_the_run_finishes(self):
+        """Not a one-shot: the next tick, 900s later, must still get in."""
+        self._seed(1)
+        self._drain(backlog=True)
+
+        # If the previous run leaked its fd, this acquisition raises.
+        with _held_by_someone_else(drain_pending._drain_lock_path()):
+            pass
+
+    def test_an_unopenable_lock_still_drains(self):
+        """A read-only ``.hindsight/`` must not silently disable memory replay.
+
+        Losing serialisation costs duplicated LLM work; losing the drain costs
+        the memory itself. The cheaper failure wins, loudly.
+        """
+        self._seed(1)
+        os.environ["HINDSIGHT_DRAIN_LOCK"] = os.path.join(
+            self._tmp, "no-such-dir", "x", "drain-pending.lock"
+        )
+        with unittest.mock.patch.object(
+            drain_pending.os, "makedirs", side_effect=PermissionError("read-only")
+        ):
+            summary, err = self._drain(backlog=True)
+
+        self.assertEqual(self.posted, ["c0"], "the drain must still run")
+        self.assertFalse(summary["skipped_locked"])
+        self.assertIn("WITHOUT serialisation", err)
+
+    # ── a genuinely separate process (the doctor recovery command) ────
+
+    def test_the_cli_a_separate_process_runs_also_skips(self):
+        """``switchroom doctor`` tells operators to run this by hand, with no
+        ``flock``. Before the lock moved into this module, doing that while
+        the sidecar ticked meant two processes on one queue."""
+        self._seed(2)
+        env = dict(os.environ)
+        env["HINDSIGHT_PENDING_DIR"] = self._dir
+        env["HOME"] = self._tmp
+
+        with _held_by_someone_else(drain_pending._drain_lock_path()):
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    os.path.join(SCRIPTS_DIR, "drain_pending.py"),
+                    "--backlog",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
+                env=env,
+            )
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("another drain holds", proc.stderr)
+        self.assertEqual(
+            pending.count(), 2, "a second process must not touch the queue"
+        )
+        # And nothing was posted: the entries point at 127.0.0.1:9, so a run
+        # that had NOT skipped would have recorded attempts against them.
+        for _path, entry in pending.iter_entries():
+            self.assertEqual(int(entry.get("attempt_count", 0)), 1)
+
+
+class SessionStartUsesTheLockedEntryPointTest(unittest.TestCase):
+    """The hook must not acquire a private, unlocked path into the queue.
+
+    ``session_start.py`` does ``from drain_pending import drain as
+    drain_pending_retains``. If it ever imported an impl helper instead (or a
+    future refactor moved the work out from under the lock) the serialisation
+    guarantee would silently regress for the one caller that runs on every
+    single session boot.
+    """
+
+    def test_session_start_imports_the_locked_public_drain(self):
+        with open(
+            os.path.join(SCRIPTS_DIR, "session_start.py"), encoding="utf-8"
+        ) as f:
+            src = f.read()
+        self.assertIn("from drain_pending import drain as drain_pending_retains", src)
+        self.assertNotIn("_drain_inhook_impl", src)
+        self.assertNotIn("_drain_backlog_impl", src)
+
+    def test_the_public_drain_is_what_takes_the_lock(self):
+        """Executable half of the check above: calling ``drain`` — the symbol
+        session_start binds — is what consults the lock."""
+        seen = []
+        real = drain_pending._exclusive_drain
+
+        def spy():
+            seen.append(True)
+            return real()
+
+        # A throwaway queue dir, so neither the empty queue nor the lock file
+        # this creates lands in the repo checkout.
+        with tempfile.TemporaryDirectory() as tmp:
+            env = {"HINDSIGHT_PENDING_DIR": os.path.join(tmp, "pending-retains")}
+            with unittest.mock.patch.dict(os.environ, env):
+                with unittest.mock.patch.object(
+                    drain_pending, "_exclusive_drain", spy
+                ):
+                    with redirect_stderr(io.StringIO()):
+                        drain_pending.drain(CONFIG)
+        self.assertEqual(seen, [True], "drain() must consult the lock every call")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -2259,8 +2259,10 @@ class CliTest(unittest.TestCase):
     def _run(self, argv):
         seen = {}
 
-        def fake_drain(config=None, backlog=False, phase="both", dry_run=False):
-            seen.update(backlog=backlog, phase=phase, dry_run=dry_run)
+        def fake_drain(
+            config=None, backlog=False, phase="both", dry_run=False, force=False
+        ):
+            seen.update(backlog=backlog, phase=phase, dry_run=dry_run, force=force)
             return drain_pending._new_summary()
 
         with unittest.mock.patch.object(drain_pending, "drain", fake_drain):
@@ -2284,6 +2286,16 @@ class CliTest(unittest.TestCase):
         _, seen = self._run(["--backlog", "--phase", "reconcile", "--dry-run"])
         self.assertEqual(seen["phase"], "reconcile")
         self.assertTrue(seen["dry_run"])
+
+    def test_force_is_plumbed_and_defaults_off(self):
+        # `--force` overrides the circuit breaker. Parsed-but-dropped would
+        # leave the operator's explicit "retry the parked entries" silently
+        # doing nothing, which is exactly the class of bug this file exists
+        # for (a flag accepted and ignored).
+        _, seen = self._run(["--backlog", "--force"])
+        self.assertTrue(seen["force"])
+        _, seen = self._run(["--backlog"])
+        self.assertFalse(seen["force"])
 
     def test_phase_without_backlog_is_refused(self):
         with redirect_stderr(io.StringIO()):


### PR DESCRIPTION
## Summary

`pending-retains` has **three** independent drain paths, and #3689 serialised exactly one of them. This puts the lock inside `drain_pending.drain()`, where every caller reaches it, and adds a circuit breaker so a permanently-wedged entry stops being retried forever.

Salvaged from abandoned post-#3689 follow-up work, rebased onto current `main`.

## Why

**Defect 1 — the lock guarded one of three callers.**

`profiles/_base/start.sh.hbs:553` (on `main`) wraps the sidecar's invocation in `flock -n "$HOME/.hindsight/drain.lock"`. The other two callers take no lock at all:

- `vendor/hindsight-memory/scripts/session_start.py:125-127` imports `drain_pending.drain` and calls it **in-process** on every session boot;
- `switchroom doctor`'s backlog remediation (`src/cli/doctor.ts`) documents a bare `docker exec … drain_pending.py --backlog` for operators.

A lock around one of three callers serialises nothing. And the collision is not hypothetical — `iter_entries()` (`lib/pending.py:1622`) has **no per-entry claim**, so two drains list the same directory and both POST every entry: ~168s of a 4-slot fleet-wide LLM lane, twice, for one memory.

Corroborating evidence, not merely inferred:
- `lib/pending.py:717-720` already documents the shape in `archive_duplicate`'s docstring — *"A concurrent drain that retired the same entry first lands here too"*.
- klanker's live `~/.switchroom/logs/klanker/hindsight-drain.log` carries a `could not archive … [Errno 2] No such file or directory: '…/pending-retains/…'` — an entry that vanished from the queue directory between one drain's listing and its archive. One occurrence fleet-wide; the logs are untimestamped so I can't correlate it to a specific SessionStart, so treat it as corroborating rather than proof.

**Defect 2 — nothing bounded total retry work.** Demotion (`_drain_order`) bounds head-of-line blocking but not total work; a permanently-failing entry was retried on every run, forever. Tolerable for a 4s boot hook, not for an unattended sidecar with a 3600s budget on a 900s cooldown.

## What changed

- **`_exclusive_drain()`** — exclusive non-blocking `fcntl.flock` held for the whole of `drain()`. A run that finds it held does nothing and returns a zero summary with `skipped_locked=True`. Kernel-released on process death, so there's no stale-lock reaper to get wrong. An **unopenable** lock file (read-only mount, ENOSPC) warns and drains anyway — silently disabling memory replay is worse than an unserialised drain.
- **The lock file is `drain-pending.lock`, deliberately NOT `drain.lock`.** Same path would mean the historical outer wrapper starves the python it just launched — a silent no-op. Distinct names make any leftover wrapper redundant instead of fatal.
- **The sidecar's `flock` wrapper is deleted**, along with its `command -v flock` precondition. The `else` branch that precondition previously fell through silently now logs why the drain did not start.
- **Parking.** An entry past `_attempt_ceiling()` (`MAX_ATTEMPTS` × 4 = 20, `HINDSIGHT_DRAIN_ATTEMPT_CEILING`) is skipped by the retain pass and counted in `summary["parked"]`. Still on disk, still swept by the free reconcile pass, still replayed in full under the new `--force`. Parking destroys nothing.
- **`parked` is in the summary-line gate, not just the line.** A run whose whole queue is parked would otherwise be rc=0 with empty output, byte-identical to "queue empty" — and `switchroom doctor` reads the queue *directory*, where a parked entry and a backlogged one are the same file.
- **`switchroom doctor`** remediation now says the documented drain is safe alongside the sidecar, that you must not re-wrap it in `flock` yourself, and names the ceiling and `--force`.

## Test plan

- `python3 -m unittest discover` in `vendor/hindsight-memory/scripts` — **845 pass**. Reverting `drain_pending.py` reds 26 errors + 1 failure.
- `vitest run tests/hindsight-drain-sidecar.test.ts src/cli/doctor-pending-retains.test.ts` — **75 pass**. Reverting `doctor.ts` reds 3.
- Mutation check on the guard test: re-adding `flock -n "$HOME/.hindsight/drain.lock"` to the sidecar loop reds **exactly one** test — `wraps the drain in no \`flock\` at all — the outer lock was deleted, not renamed`. The behavioural lock test stays green, because a wrapper on the *old* path starves nothing. That gap is precisely what the textual guard closes: without it, someone re-adds the wrapper and silently re-narrows serialisation to one caller.
- `npm run lint` — clean.

Local caveat: the behavioural sidecar tests exec a stub `python3`, so they need an exec-capable filesystem. Under a `noexec` worktree they fail for the wrong reason; the test file documents this and sandboxes under the repo's `.test-tmp/`.

## Risk

The lock is per-queue and non-blocking, so the worst case is a drain skipping a tick it would previously have raced.

The **ceiling is the real trade** and it runs backwards from intuition: the smaller and healthier the queue, the sooner one overnight outage parks it whole (4 entries → ~6h at the 900s cooldown). `CeilingArithmeticTest` pins that table against the code rather than the prose, and `--force` is the documented recovery. Rationale for accepting it rather than picking a bigger number is at `ATTEMPT_CEILING_MULTIPLE`.

## Conflict note

**Overlaps #3688's salvage**, which is in flight concurrently and touches `vendor/hindsight-memory/scripts/drain_pending.py` and `lib/pending.py`. This diff is scoped tightly to locking/parking: in `drain_pending.py` it adds `_exclusive_drain` / `_park_broken` / `_attempt_ceiling` and threads `force` through, and the only shared line is the `lib.pending` import list (one added name, `pending_dir`). The `doctor.ts` hunk is deliberately anchored at a **sentence boundary** between two whole sentences, away from the lines #3688 rewrites — the inline comment there explains why, and `warn: the p95 backoff sentence is contiguous, not two fragments` fails on a re-anchor that splices mid-sentence rather than passing on a substring.

## Verdict rule

Job spec: [`reference/jobs/remember-across-sessions.md`](reference/jobs/remember-across-sessions.md) — *"The agent brings back relevant facts … without the user reminding it."* A memory stuck in `pending-retains` is a memory the agent cannot recall; a drain that burns a shared lane retaining the same entry twice, or retries an unsaveable one forever, is a drain that isn't clearing the queue. Serves **standing-team**; crosses no invariant. Docs test: the operator-facing path is `switchroom doctor`'s remediation, updated here. Defaults test: the default is serialised and bounded, with `--force` as the explicit escape.
