### PR TITLE
fix(hindsight): stop one malformed queue entry from killing the whole drain

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -144,6 +144,14 @@ jobs:
       - name: Run unittest discover (hindsight scripts)
         working-directory: vendor/hindsight-memory/scripts
         run: python3 -m unittest discover tests/
+      # Mirrors ci-tests-python.yml (#3688) — the SIBLING plugin suite, which
+      # no check ran before. Kept in step with the twin deliberately; the
+      # pacer comment below is the standing record of what drift here costs.
+      - name: Install pytest (the sibling suite is pytest-only)
+        run: pip install -q pytest
+      - name: Run vendored plugin tests (pytest)
+        working-directory: vendor/hindsight-memory
+        run: python3 -m pytest tests/ -q
       - name: Run voice-sidecar unittests
         working-directory: docker/voice-sidecar
         run: python3 -m unittest discover -s . -p 'test_*.py'

--- a/.github/workflows/ci-tests-python.yml
+++ b/.github/workflows/ci-tests-python.yml
@@ -59,6 +59,18 @@ jobs:
           filters: |
             relevant:
               - 'vendor/hindsight-memory/scripts/**'
+              # The sibling plugin suite. Ran nowhere until #3688, so a PR
+              # touching only it started no check at all — see the pytest
+              # step in `unittest` below.
+              - 'vendor/hindsight-memory/tests/**'
+              # The hooks manifest is INPUT to that suite, not just shipped
+              # config: `tests/test_manifest.py` reads
+              # `<integration root>/hooks/hooks.json` and asserts it parses
+              # strictly. Without this line a PR editing only `hooks/`
+              # (adding a hook, renaming a matcher) matched no filter, the
+              # sentinel skipped `unittest`, and a manifest that no longer
+              # matches the shipped hooks could merge green.
+              - 'vendor/hindsight-memory/hooks/**'
               - 'docker/voice-sidecar/**'
               - 'docker/litellm-pacer/**'
               - '.github/workflows/ci-tests-python.yml'
@@ -76,6 +88,28 @@ jobs:
       - name: Run unittest discover
         working-directory: vendor/hindsight-memory/scripts
         run: python3 -m unittest discover tests/
+
+      # The SIBLING plugin suite (`vendor/hindsight-memory/tests/`). Added by
+      # switchroom #3688: until then NO check ran it — the `unittest discover`
+      # step above runs `vendor/hindsight-memory/scripts/tests/`, a different
+      # directory — and an unrun suite rots into a liability rather than a
+      # gate. Proof, found by turning it on:
+      # `test_hooks.py::TestRecallHook::test_graceful_on_api_error` had been
+      # asserting the pre-#3619 silent-degradation behaviour and was red on
+      # `main` (fixed in the same PR).
+      #
+      # pytest, not `unittest discover`: `tests/conftest.py` is what puts
+      # `scripts/` on `sys.path`, the suite uses `monkeypatch`/`tmp_path`
+      # fixtures, and `tests/` has no `__init__.py` (discovery refuses it).
+      # pytest is the ONLY extra dependency — the suite is otherwise stdlib
+      # and needs no network. Same unpinned `pip install -q` shape as
+      # ci-evals.yml's `pyyaml`.
+      - name: Install pytest (the sibling suite is pytest-only)
+        run: pip install -q pytest
+
+      - name: Run vendored plugin tests (pytest)
+        working-directory: vendor/hindsight-memory
+        run: python3 -m pytest tests/ -q
 
       # Voice sidecar's stdlib-only tests (TTS speed clamp). server.py imports
       # kokoro lazily, so no ONNX runtime / model is needed here.

--- a/tests/ci-python-path-filter.test.ts
+++ b/tests/ci-python-path-filter.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Guard: `ci-tests-python.yml`'s path filter must cover every input the
+ * python jobs actually read.
+ *
+ * `ci-tests-python.yml` gates its `unittest` job behind a
+ * dorny/paths-filter `relevant` output. That filter is a hand-maintained
+ * list, and every path a python step reads but the list omits is a silent
+ * hole: the sentinel reports `success` without running the suite, so a PR
+ * touching only that path merges green having been tested by nothing.
+ *
+ * Two holes this file was written for, both live on `main` until #3688:
+ *
+ *  1. `vendor/hindsight-memory/tests/**` was in NO filter and run by NO
+ *     job — the `unittest discover` step runs
+ *     `vendor/hindsight-memory/scripts/tests/`, a different directory.
+ *     258 assertions gated nothing, and one of them had rotted red.
+ *  2. `vendor/hindsight-memory/tests/test_manifest.py` reads
+ *     `<integration root>/hooks/hooks.json` and asserts it is strict-valid
+ *     JSON with a `hooks` mapping. `vendor/hindsight-memory/hooks/**` was
+ *     NOT in the filter, so a PR editing only `hooks/hooks.json` — adding
+ *     a hook, renaming a matcher — matched nothing, skipped `unittest`,
+ *     and could land a manifest that no longer matched the shipped hooks.
+ *
+ * This is deliberately a coverage assertion over the SUITE ROOTS the jobs
+ * run, not a hard-coded copy of the filter list: a new python suite added
+ * to the workflow without a matching filter entry fails here too, which is
+ * the general shape of the bug rather than the one instance of it.
+ *
+ * `ci-full.yml`'s twin `python-full` job is deliberately NOT checked for a
+ * filter — it is the nightly UNFILTERED sweep and has no `changes` job at
+ * all (see its header comment). Its exposure to this class of bug is nil;
+ * the PR-facing workflow is the only one that can skip.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { parse } from 'yaml'
+
+const REPO = resolve(import.meta.dirname, '..')
+const WORKFLOW = '.github/workflows/ci-tests-python.yml'
+
+interface Step {
+  name?: string
+  uses?: string
+  run?: string
+  'working-directory'?: string
+  with?: Record<string, unknown>
+}
+interface Job {
+  steps?: Step[]
+  outputs?: Record<string, string>
+}
+interface Workflow {
+  jobs?: Record<string, Job>
+}
+
+function loadWorkflow(): Workflow {
+  return parse(readFileSync(join(REPO, WORKFLOW), 'utf8')) as Workflow
+}
+
+/** The `relevant:` glob list out of the `changes` job's paths-filter step. */
+function relevantFilters(wf: Workflow): string[] {
+  const step = (wf.jobs?.changes?.steps ?? []).find((s) =>
+    (s.uses ?? '').includes('dorny/paths-filter'),
+  )
+  expect(
+    step,
+    `${WORKFLOW}: no dorny/paths-filter step in the \`changes\` job`,
+  ).toBeTruthy()
+  const filters = parse(String(step!.with?.filters ?? '')) as Record<string, string[]>
+  return filters.relevant ?? []
+}
+
+/** True when `path` is matched by at least one `dir/**`-style filter glob. */
+function covered(path: string, globs: string[]): boolean {
+  return globs.some((g) => {
+    if (g === path) return true
+    if (!g.endsWith('/**')) return false
+    return path === g.slice(0, -3) || path.startsWith(g.slice(0, -2))
+  })
+}
+
+/**
+ * The repo-relative suite root each python step actually runs, i.e. its
+ * `working-directory` joined with the target it hands the runner.
+ *
+ * Deliberately the TARGET, not the working directory: the pytest step runs
+ * from `vendor/hindsight-memory` but only collects `tests/`, and widening
+ * the filter to the whole vendor root would re-run the suite on every
+ * README edit. The filter is narrow on purpose; this asserts it is not
+ * narrower than what runs.
+ */
+function suiteRoots(wf: Workflow): string[] {
+  const roots: string[] = []
+  for (const step of wf.jobs?.unittest?.steps ?? []) {
+    const wd = step['working-directory']
+    const run = step.run ?? ''
+    if (!wd || !/\b(unittest|pytest)\b/.test(run)) continue
+    // `unittest discover -s <dir>` / `unittest discover <dir>` / `pytest <dir>`
+    const m = /discover\s+(?:-s\s+)?(\S+)/.exec(run) ?? /pytest\s+(?!-)(\S+)/.exec(run)
+    const target = (m?.[1] ?? '.').replace(/\/+$/, '')
+    roots.push(target === '.' ? wd : `${wd}/${target}`)
+  }
+  return roots
+}
+
+describe('ci-tests-python path filter — no test input can slip past the sentinel', () => {
+  it('every suite the job runs sits inside a filtered path', () => {
+    const wf = loadWorkflow()
+    const globs = relevantFilters(wf)
+    const roots = suiteRoots(wf)
+    expect(roots.length, 'fixture: the unittest job runs python suites').toBeGreaterThan(0)
+    const uncovered = roots.filter((d) => !covered(d, globs))
+    expect(
+      uncovered,
+      `${WORKFLOW}: these suites run but no \`relevant\` filter path matches them, so a PR ` +
+        `touching only them skips the job: ${uncovered.join(', ')}`,
+    ).toEqual([])
+  })
+
+  it('the sibling vendored plugin suite is actually RUN by the job', () => {
+    // The hole that made this file necessary: the suite existed, was
+    // filtered by nothing and executed by nothing. A filter entry with no
+    // step behind it would satisfy the coverage test above vacuously.
+    const roots = suiteRoots(loadWorkflow())
+    expect(
+      roots,
+      `${WORKFLOW}: no step runs vendor/hindsight-memory/tests — the suite would gate nothing`,
+    ).toContain('vendor/hindsight-memory/tests')
+  })
+
+  it('the hooks manifest read by test_manifest.py is filtered', () => {
+    // `tests/test_manifest.py` resolves INTEGRATION_ROOT / "hooks" /
+    // "hooks.json" — an input to the suite that lives outside every
+    // suite directory, which is exactly why it was missed.
+    const manifest = 'vendor/hindsight-memory/hooks/hooks.json'
+    const src = readFileSync(
+      join(REPO, 'vendor/hindsight-memory/tests/test_manifest.py'),
+      'utf8',
+    )
+    expect(src, 'fixture: the suite still reads the hooks manifest').toMatch(
+      /INTEGRATION_ROOT\s*\/\s*"hooks"\s*\/\s*"hooks\.json"/,
+    )
+    expect(
+      covered(manifest, relevantFilters(loadWorkflow())),
+      `${WORKFLOW}: \`${manifest}\` is asserted on by test_manifest.py but matches no ` +
+        `\`relevant\` filter path — a PR editing only the manifest would skip the suite`,
+    ).toBe(true)
+  })
+
+  it('the workflow file itself is filtered, so edits to the gate re-run it', () => {
+    expect(covered(WORKFLOW, relevantFilters(loadWorkflow()))).toBe(true)
+  })
+})

--- a/vendor/hindsight-memory/scripts/drain_pending.py
+++ b/vendor/hindsight-memory/scripts/drain_pending.py
@@ -840,8 +840,28 @@ def _drain_backlog_impl(
     # the SessionStart drain's whole contract is a hard wall-clock ceiling
     # on hook latency. New duplicates cannot accumulate there anyway:
     # `pending.enqueue`'s filename-keyed guard stops those at the producer.
+    #
+    # GUARDED, because phase 0 runs BEFORE the phases that actually drain
+    # (#3688 review R1-M1). `iter_entries()` quarantines an unparsable entry
+    # precisely so no single corrupt file can make the whole queue immortal;
+    # an unguarded collapse re-creates that failure one level up, where a
+    # semantically-malformed-but-valid-JSON entry raises and takes phases 1
+    # and 2 with it — a strict regression against the pre-#3688 drain, where
+    # the same entry drains. A collapse failure costs duplicated work, never
+    # a memory, so it is logged and stepped over, exactly as every other
+    # phase treats a per-entry failure. `_attempt_count` closes the one
+    # measured raise; this guard is what keeps the NEXT one from being a
+    # fleet-wide drain stall.
     if not dry_run:
-        summary["collapsed"] = collapse_duplicates()
+        try:
+            summary["collapsed"] = collapse_duplicates()
+        except Exception as e:  # noqa: BLE001 — see comment above
+            _blog(
+                f"phase 0 FAILED ({type(e).__name__}: {e}) — continuing to the "
+                f"phases that actually drain. Nothing was lost: a collapse only "
+                f"ever MOVES a byte-identical copy into pending-duplicate/, so "
+                f"the cost of skipping it is duplicated work, not a memory."
+            )
         if summary["collapsed"]:
             _blog(
                 f"phase 0: collapsed {summary['collapsed']} duplicate entries "

--- a/vendor/hindsight-memory/scripts/lib/pending.py
+++ b/vendor/hindsight-memory/scripts/lib/pending.py
@@ -556,6 +556,112 @@ def _dir_bytes(d: str, names) -> int:
     return total
 
 
+def _append_ledger(line: str) -> None:
+    """Append one line to ``pending-evictions.log``, rotating at its cap.
+
+    Split out of ``_log_eviction`` (#3688 review R1-M2) so the OTHER way a
+    payload leaves this module for good — ``_trim_dir`` shedding an archived
+    copy — can be ledgered on exactly the same terms instead of leaving no
+    durable trace at all. Best-effort: a ledger that cannot be written *or
+    read back* must never take the caller down with it — hence the guard
+    catches ``ValueError`` as well as ``OSError`` (see there).
+
+    ROTATION PRIORITISES ``evicted=`` INSIDE THE SAME BUDGET, and that is a
+    direct consequence of sharing the file. Before #3688 every line here
+    was an eviction, so "keep the newest ``EVICTIONS_LOG_KEEP_LINES``
+    lines" and "keep the newest 2,000 evictions" were the same sentence.
+    They are not any more: a single ``collapse_duplicates`` run over the
+    measured 1,060-file backlog writes ~192 ``trimmed=`` lines, and a plain
+    tail-rotate would let that noise push real ``evicted=`` lines out of
+    the 7-day window ``switchroom doctor`` reads — i.e. adding
+    observability for the BENIGN channel would have removed it for the one
+    channel that means memory is actually gone.
+
+    So the keep window is filled evictions-first and only then topped up
+    with the newest remaining lines. The budget is unchanged at
+    ``EVICTIONS_LOG_KEEP_LINES`` lines TOTAL — a ledger of nothing but
+    evictions rotates exactly as it did before #3688 — and chronological
+    order is preserved because the selection is by index over the original
+    lines, which ``switchroom doctor``'s ``$1 >= cutoff`` awk depends on.
+    """
+    log = evictions_log_path()
+    try:
+        with open(log, "a", encoding="utf-8") as f:
+            print(line, file=f)
+        # Bounded, not append-forever. `switchroom doctor` windows this by
+        # timestamp so a single legitimate eviction can't turn the row red
+        # permanently, but the FILE still needs a ceiling of its own.
+        if os.path.getsize(log) > EVICTIONS_LOG_MAX_BYTES:
+            with open(log, encoding="utf-8") as f:
+                lines = f.readlines()
+            evictions = [i for i, ln in enumerate(lines) if "evicted=" in ln]
+            others = [i for i, ln in enumerate(lines) if "evicted=" not in ln]
+            keep_idx = set(evictions[-EVICTIONS_LOG_KEEP_LINES:])
+            room = EVICTIONS_LOG_KEEP_LINES - len(keep_idx)
+            if room > 0:
+                keep_idx.update(others[-room:])
+            kept = [ln for i, ln in enumerate(lines) if i in keep_idx]
+            tmp = log + ".tmp"
+            with open(tmp, "w", encoding="utf-8") as f:
+                f.writelines(kept)
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, log)
+    except (OSError, ValueError):
+        # ValueError, not just OSError, because BOTH codec errors are
+        # ValueError subclasses and neither is an OSError (#3688 re-review
+        # B1). The rotate READS the ledger back (``readlines()`` above) —
+        # something no revision before #3688 did — so a ledger holding one
+        # non-UTF-8 byte raises ``UnicodeDecodeError`` here, and a name
+        # carrying a surrogate raises ``UnicodeEncodeError`` at the
+        # ``print`` above. Under a bare ``except OSError`` both escape this
+        # "best-effort" guard: ``_trim_dir`` → ``_log_archive_trim`` → here
+        # runs inside ``archive_reconciled``/``enqueue``, so one corrupt
+        # ledger byte would take down every drain — on the sidecar,
+        # identically, every 900s forever. A ledger that cannot be written
+        # must never take the caller down with it, and that has to include
+        # the codec.
+        pass
+
+
+def _log_archive_trim(
+    name: str, size: int, reason: str, archive: str, depth: int, nbytes: int
+) -> None:
+    """Ledger ONE archived copy shed by ``_trim_dir``.
+
+    Until #3688 review R1-M2 a trim was stderr-only: an entry could enter
+    ``pending-duplicate/`` (or ``pending-evicted/``, or
+    ``pending-reconciled/``) and then be deleted from it with no durable
+    record anywhere, while an *eviction* — the other end of the same
+    payload's life — has had ``pending-evictions.log`` since #3599. stderr
+    is gone with the process; the ledger is what an operator can still read
+    a week later. Same file, because it answers one question ("what left
+    this agent's queue, and when").
+
+    THE FIRST TOKEN IS DELIBERATELY ``trimmed=``, NOT ``evicted=``.
+    ``switchroom doctor``'s probe counts eviction ledger lines with
+    ``awk '$1 >= cutoff && /evicted=/'`` (src/cli/doctor.ts, see
+    ``buildPendingRetainsProbeScript``), and that count FAILS the
+    pending-retains row. A trim is not an eviction — nothing was shed from
+    the live queue and, for ``pending-duplicate/``, a byte-identical copy is
+    still queued — so a trim must not be able to turn that row red. No field
+    on this line may ever be formatted such that ``evicted=`` appears in it;
+    ``ArchiveTrimLedgerTest`` pins that.
+    """
+    _append_ledger(
+        "%s trimmed=%s bytes=%d archive=%s reason=archive-%s "
+        "archive_depth=%d archive_bytes=%d"
+        % (
+            time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            name,
+            size,
+            archive,
+            reason,
+            depth,
+            nbytes,
+        )
+    )
+
+
 def _trim_dir(a: str, max_entries: int, max_bytes: int) -> int:
     """Keep ``a`` under its count/byte caps, deleting OLDEST first.
 
@@ -610,6 +716,21 @@ def _trim_dir(a: str, max_entries: int, max_bytes: int) -> int:
     ``pending-evicted/`` is a different story again — see ``_evict_to_fit``:
     an entry only reaches it through the ledgered eviction path, and under
     sustained ENOSPC it may not reach it at all.
+
+    EVERY DROP IS LEDGERED, AND ONLY A DROP (#3688 review R1-M2, tightened
+    by re-review B2). One ``trimmed=… archive=…`` line per shed copy goes
+    to ``pending-evictions.log`` via ``_log_archive_trim``, so the trim
+    horizon above is observable after the fact and not only in a stderr
+    stream nobody kept. That line is deliberately NOT counted as an
+    eviction by doctor — see ``_log_archive_trim``.
+
+    A victim whose ``os.remove`` FAILS (EACCES, read-only mount) is neither
+    ledgered nor counted nor named on stderr: it is still on disk, so a
+    ``trimmed=`` line for it would be a false claim of deletion in exactly
+    the record an operator consults after suspected loss, and the returned
+    count is what callers report as "copies shed". ``TrimDirBoundaryTest``
+    pins that a failed remove yields ``0``, no ledger line, and every file
+    still present.
     """
     # `.json` ONLY, and that is load-bearing beyond "skip stray files": a
     # `.dead` marker is named `<entry>.json.dead`, so it can never be
@@ -622,14 +743,35 @@ def _trim_dir(a: str, max_entries: int, max_bytes: int) -> int:
     except OSError:
         return 0
     dropped = []
-    while names and (
-        len(names) > max_entries or _dir_bytes(a, names) > max_bytes
-    ):
+    label = os.path.basename(a.rstrip("/"))
+    nbytes = _dir_bytes(a, names)
+    while names and (len(names) > max_entries or nbytes > max_bytes):
+        reason = "count" if len(names) > max_entries else "bytes"
+        victim = names.pop(0)
+        vpath = os.path.join(a, victim)
         try:
-            os.remove(os.path.join(a, names[0]))
+            vsize = os.path.getsize(vpath)
         except OSError:
-            pass
-        dropped.append(names.pop(0))
+            vsize = 0
+        try:
+            os.remove(vpath)
+        except OSError:
+            # The copy is still on disk, so the running total would drift.
+            # Re-measure rather than assume — this preserves the original
+            # recompute-every-iteration semantics on the one path where a
+            # decrement would be wrong (EACCES / read-only mount).
+            nbytes = _dir_bytes(a, names)
+            # NOT counted and NOT ledgered (#3688 re-review B2). The ledger
+            # is the forensic record an operator reads AFTER suspected data
+            # loss; a `trimmed=` line for a copy still sitting on disk sends
+            # them hunting a payload that never left, and the returned count
+            # (and the stderr line below) would name files that were not
+            # dropped. A ledger that claims deletions which never happened
+            # is worse than no ledger.
+            continue
+        nbytes -= vsize
+        dropped.append(victim)
+        _log_archive_trim(victim, vsize, reason, label, len(names), nbytes)
     if dropped:
         shown = ", ".join(dropped[:10])
         if len(dropped) > 10:
@@ -736,6 +878,47 @@ def archive_duplicate(path: str) -> Optional[str]:
     return dest
 
 
+def _attempt_count(entry: dict) -> int:
+    """How many retries this copy has BURNED, for survivor selection.
+
+    Not ``int(entry.get("attempt_count", 1) or 1)`` (#3688 review R1-L3).
+    That expression had two defects, both latent rather than reachable
+    today — ``_build_entry`` seeds ``1`` and ``update_attempt`` only ever
+    increments — which is exactly why they need pinning rather than
+    ignoring: nothing would have caught them turning real.
+
+    * ``0 or 1`` is ``1``, so a NEVER-ATTEMPTED copy scored the same as one
+      that had already burned an attempt, and lost the tie-break to it if
+      it happened to be the newer file. That is backwards from the rule
+      ``collapse_duplicates`` documents ("the copy with the most retries
+      left before ``MAX_ATTEMPTS`` wins") — a 0 must beat a 1.
+    * ``int("many")`` RAISES. A single semantically-malformed entry — valid
+      JSON, so ``iter_entries`` hands it over rather than quarantining it —
+      took the whole collapse pass down with it, and with it (before the
+      guard in ``drain_pending._drain_backlog_impl``) the whole drain.
+      Unparseable now scores ``MAX_ATTEMPTS``: we cannot tell how many
+      attempts it has left, so it is never PREFERRED as the survivor, but
+      it is never the reason a collapse fails either. Losing it costs
+      nothing anyway — every copy in a group is byte-identical, and the
+      loser is archived, not deleted.
+
+    A missing or ``None`` count reads as ``1``, matching what
+    ``_build_entry`` writes, so an entry from an older build that predates
+    the field is treated as freshly queued rather than exhausted.
+    """
+    raw = entry.get("attempt_count", 1)
+    if raw is None:
+        return 1
+    # bool is an int subclass; True would silently score 1. Neither True nor
+    # False is an attempt count, so both take the unparseable branch.
+    if isinstance(raw, bool):
+        return MAX_ATTEMPTS
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return MAX_ATTEMPTS
+
+
 def collapse_duplicates() -> int:
     """Collapse entries sharing ``(bank_id, part_position, sha256(content))``.
 
@@ -754,7 +937,8 @@ def collapse_duplicates() -> int:
     memory; the one with the most attempts left is the one most likely to
     get there before ``MAX_ATTEMPTS`` promotes it to ``.dead``. Picking the
     oldest outright would systematically keep the most-attempted copy —
-    exactly backwards.
+    exactly backwards. ``_attempt_count`` defines "lowest", including what
+    a ``0`` and what a malformed count are worth.
 
     An entry whose key is ``None`` (no ``content``) is never grouped: its
     identity cannot be established, so it is always kept.
@@ -773,10 +957,7 @@ def collapse_duplicates() -> int:
     for key, members in groups.items():
         if len(members) < 2:
             continue
-        survivor = min(
-            members,
-            key=lambda m: (int(m[2].get("attempt_count", 1) or 1), m[0]),
-        )
+        survivor = min(members, key=lambda m: (_attempt_count(m[2]), m[0]))
         for member in members:
             if member is survivor:
                 continue
@@ -1047,23 +1228,7 @@ def _log_eviction(name: str, size: int, reason: str, depth: int, nbytes: int) ->
         depth,
         nbytes,
     )
-    log = evictions_log_path()
-    try:
-        with open(log, "a", encoding="utf-8") as f:
-            print(line, file=f)
-        # Bounded, not append-forever. `switchroom doctor` windows this by
-        # timestamp so a single legitimate eviction can't turn the row red
-        # permanently, but the FILE still needs a ceiling of its own.
-        if os.path.getsize(log) > EVICTIONS_LOG_MAX_BYTES:
-            with open(log, encoding="utf-8") as f:
-                kept = f.readlines()[-(EVICTIONS_LOG_KEEP_LINES):]
-            tmp = log + ".tmp"
-            with open(tmp, "w", encoding="utf-8") as f:
-                f.writelines(kept)
-            os.chmod(tmp, 0o600)
-            os.replace(tmp, log)
-    except OSError:
-        pass
+    _append_ledger(line)
     print(
         "[Hindsight] pending-retains FULL - evicted OLDEST entry to keep the "
         "newest memory: %s (%d bytes, %s; queue now %d entries / %d bytes). "

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -1,11 +1,19 @@
 """Queue eviction/dedupe + two-phase backlog drain (switchroom #3596).
 
-These live under ``scripts/tests/`` deliberately: that is the ONLY python
-test directory CI discovers (``ci-tests-python.yml:63`` and
-``ci-full.yml:140`` both run ``python3 -m unittest discover tests/`` with
-``working-directory: vendor/hindsight-memory/scripts``). The sibling suite
-at ``vendor/hindsight-memory/tests/`` is never executed by CI, so a
-regression test placed there would gate nothing.
+These live under ``scripts/tests/`` deliberately: it is the stdlib-only
+suite, discovered by ``python3 -m unittest discover tests/`` with
+``working-directory: vendor/hindsight-memory/scripts`` in both
+``ci-tests-python.yml`` and ``ci-full.yml``, and it needs no third-party
+package to gate a merge.
+
+Until switchroom #3688 it was also the ONLY python test directory CI ran at
+all: the sibling suite at ``vendor/hindsight-memory/tests/`` started no
+check, so a regression test placed there gated nothing. #3688 turned that
+suite on too (a ``pip install -q pytest`` step in the same two workflows --
+it is pytest-only because its ``conftest.py`` is what puts ``scripts/`` on
+``sys.path``), and turning it on immediately surfaced one test that had
+rotted red on ``main``. Both directories are now gates; prefer this one for
+anything that can be written against the stdlib.
 
 The behaviours pinned here are the ones a well-meaning refactor would
 otherwise undo:
@@ -816,6 +824,202 @@ class CollapseDuplicatesTest(_QueueTempDirMixin, unittest.TestCase):
             summary = drain_pending.drain_backlog(CONFIG, dry_run=True)
         self.assertEqual(summary["collapsed"], 0)
         self.assertEqual(pending.count(), 3)
+
+    # ---- #3688 review R1-M1: a broken phase 0 must not wedge the drain -----
+
+    def test_a_failing_phase_0_never_blocks_the_phases_that_drain(self):
+        """The module's own invariant, one level up.
+
+        ``iter_entries`` quarantines an unparsable entry precisely so that no
+        single corrupt file can make the whole queue immortal. Phase 0 runs
+        BEFORE the phases that drain, so an unguarded exception in it
+        re-creates that failure with a bigger blast radius: nothing drains,
+        ever, until a human intervenes — strictly worse than the pre-#3688
+        drain, where the same queue drains fine.
+
+        A collapse failure can only ever cost duplicated work (the pass just
+        MOVES byte-identical copies), so it is logged and stepped over.
+        """
+        self._write_legacy("0000000001000-aaaaaaaaaaa0.json", "one-memory")
+
+        def boom():
+            raise ValueError("invalid literal for int() with base 10: 'many'")
+
+        posted = []
+        with unittest.mock.patch.object(drain_pending, "collapse_duplicates", boom):
+            with unittest.mock.patch.object(
+                drain_pending, "_document_state", lambda e, timeout=30: bool(posted)
+            ):
+                with unittest.mock.patch.object(
+                    drain_pending,
+                    "_retry_one",
+                    lambda e, timeout: posted.append(e["document_id"]),
+                ):
+                    with redirect_stderr(io.StringIO()) as err:
+                        summary = drain_pending.drain_backlog(CONFIG)
+
+        self.assertEqual(summary["collapsed"], 0, "nothing was collapsed, honestly")
+        self.assertEqual(len(posted), 1, "phase 2 still ran")
+        self.assertEqual(pending.count(), 0, "the entry drained anyway")
+        self.assertIn("phase 0 FAILED", err.getvalue(), "and it was not silent")
+
+    def test_a_malformed_attempt_count_cannot_make_the_backlog_immortal(self):
+        """The concrete reproduction, end to end.
+
+        Two byte-identical entries, one carrying ``"attempt_count": "many"``
+        — valid JSON, so ``iter_entries`` hands it over rather than
+        quarantining it. Before #3688 review R1-M1/R1-L3 the ``int()`` in
+        survivor selection raised, phase 0 died and phases 1 and 2 never ran.
+        Both halves are fixed (``_attempt_count`` no longer raises, and the
+        phase is guarded regardless); this asserts the OUTCOME either way.
+        """
+        self._write_legacy("0000000001000-aaaaaaaaaaa0.json", "same", attempts=1)
+        self._write_legacy("0000000002000-aaaaaaaaaaa1.json", "same", attempts="many")
+
+        posted = []
+        with unittest.mock.patch.object(
+            drain_pending, "_document_state", lambda e, timeout=30: bool(posted)
+        ):
+            with unittest.mock.patch.object(
+                drain_pending,
+                "_retry_one",
+                lambda e, timeout: posted.append(e["document_id"]),
+            ):
+                with redirect_stderr(io.StringIO()):
+                    summary = drain_pending.drain_backlog(CONFIG)
+
+        self.assertEqual(summary["collapsed"], 1)
+        self.assertEqual(len(posted), 1, "the memory still reached the bank")
+        self.assertEqual(pending.count(), 0)
+
+    # ---- #3688 review R1-L3: what "lowest attempt_count" actually means ----
+
+    def test_a_never_attempted_copy_beats_a_once_attempted_older_one(self):
+        """``attempt_count: 0`` must WIN, not tie.
+
+        The rule is "the copy with the most retries left before
+        MAX_ATTEMPTS". ``int(x or 1)`` scored a 0 as a 1, so a
+        never-attempted copy tied with a once-attempted one and lost the
+        tie-break to it for being newer — backwards from the documented rule.
+        Latent today (``_build_entry`` seeds 1) and therefore exactly the
+        kind of thing nothing else would catch turning real.
+        """
+        self._write_legacy("0000000001000-aaaaaaaaaaa0.json", "same", attempts=1)
+        keep = self._write_legacy("0000000002000-aaaaaaaaaaa1.json", "same", attempts=0)
+
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(pending.collapse_duplicates(), 1)
+
+        self.assertEqual(
+            [p for p, _ in pending.iter_entries()],
+            [keep],
+            "the copy with 5 retries left survives, not the one with 4",
+        )
+
+    def test_an_unparseable_attempt_count_is_never_preferred_as_survivor(self):
+        """Unknown burn count ⇒ scored as exhausted, never as fresh.
+
+        Costs nothing: every copy in a group is byte-identical and the loser
+        is archived, not deleted. The point is that it can neither win the
+        survivor slot on a lie nor raise.
+        """
+        keep = self._write_legacy("0000000001000-aaaaaaaaaaa0.json", "same", attempts=2)
+        self._write_legacy("0000000002000-aaaaaaaaaaa1.json", "same", attempts="many")
+
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(pending.collapse_duplicates(), 1)
+
+        self.assertEqual([p for p, _ in pending.iter_entries()], [keep])
+
+    # ---- #3688 re-review B3: the two unpinned `_attempt_count` branches ----
+    #
+    # Both mutations SURVIVED the suite: deleting the `isinstance(raw, bool)`
+    # branch (M6) and turning `raw is None: return 1` into
+    # `return MAX_ATTEMPTS` (M7). The logic is right; it was simply ungated,
+    # so a refactor could undo it with CI green.
+
+    def test_a_boolean_attempt_count_is_scored_as_UNPARSEABLE_not_as_one(self):
+        """``bool`` must be rejected BEFORE ``int()`` sees it.
+
+        #3688 re-review B3 / mutation M6. ``bool`` is an ``int`` subclass,
+        so ``int(True)`` is ``1`` — the score of a FRESH, never-retried
+        copy. Delete the ``isinstance(raw, bool)`` guard (it reads as
+        redundant next to the ``try``/``except``, which is exactly why a
+        future "simplification" would take it) and an entry carrying
+        ``"attempt_count": true`` becomes the most PREFERRED survivor in
+        its group: it wins the election, and every well-formed
+        byte-identical sibling is archived instead. Silent, and invisible
+        to the rest of the suite.
+
+        Scoring it ``MAX_ATTEMPTS`` makes it the LEAST preferred, which is
+        the honest reading — a garbage count tells us nothing about how
+        many retries are left, so it must never be trusted over a real one.
+        A raise would be wrong here for a different reason: this runs
+        inside ``collapse_duplicates``'s sort key over the whole queue, so
+        one malformed file would abort the collapse for every other entry.
+        """
+        self.assertEqual(
+            pending._attempt_count({"attempt_count": True}),
+            pending.MAX_ATTEMPTS,
+            "True is not one attempt — bool must take the unparseable branch",
+        )
+        self.assertEqual(
+            pending._attempt_count({"attempt_count": False}),
+            pending.MAX_ATTEMPTS,
+            "False is not zero attempts either",
+        )
+
+        # …and the consequence that actually costs a memory: the malformed
+        # copy must LOSE the survivor election to a well-formed sibling.
+        self._write_legacy("0000000001000-aaaaaaaaaaa0.json", "same", attempts=True)
+        keep = self._write_legacy("0000000002000-aaaaaaaaaaa1.json", "same", attempts=2)
+
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(pending.collapse_duplicates(), 1)
+
+        self.assertEqual(
+            [p for p, _ in pending.iter_entries()],
+            [keep],
+            "the well-formed copy survives; the boolean one is archived",
+        )
+        self.assertEqual(
+            self._duplicate_names(), ["0000000001000-aaaaaaaaaaa0.json"]
+        )
+
+    def test_a_missing_or_null_attempt_count_reads_as_FRESH_not_exhausted(self):
+        """Absent/``None`` scores ``1``, matching what ``_build_entry`` writes.
+
+        #3688 re-review B3 / mutation M7 (``return 1`` → ``return
+        MAX_ATTEMPTS`` survived). An entry from an older build that predates
+        the field has burned no *recorded* attempts; scoring it as exhausted
+        would systematically archive it in favour of a copy with a real,
+        HIGHER burn count — i.e. deliberately keep the copy closer to
+        ``.dead``, which is backwards from the durability-first rule
+        ``collapse_duplicates`` documents. This is the one malformed-ish
+        shape that is genuinely benign, and it must not be lumped in with
+        the garbage above.
+        """
+        self.assertEqual(pending._attempt_count({"attempt_count": None}), 1)
+        self.assertEqual(pending._attempt_count({}), 1, "absent reads the same")
+        self.assertLess(
+            pending._attempt_count({"attempt_count": None}),
+            pending._attempt_count({"attempt_count": 2}),
+            "a null count must be PREFERRED over a copy with 2 attempts burned",
+        )
+
+        self._write_legacy("0000000001000-aaaaaaaaaaa0.json", "same", attempts=2)
+        keep = self._write_legacy(
+            "0000000002000-aaaaaaaaaaa1.json", "same", attempts=None
+        )
+
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(pending.collapse_duplicates(), 1)
+
+        self.assertEqual(
+            [p for p, _ in pending.iter_entries()],
+            [keep],
+            "the null-count copy has 5 retries left; the other has 3",
+        )
 
 
 class DropLedgerTest(_QueueTempDirMixin, unittest.TestCase):
@@ -2075,6 +2279,267 @@ class TrimDirBoundaryTest(_QueueTempDirMixin, unittest.TestCase):
         self.assertIn("trimmed 18 archived copies", msg)
         self.assertIn("+8 more", msg)
         self.assertLessEqual(msg.count("-x.json"), 10)
+
+    def test_a_copy_that_could_NOT_be_removed_is_never_reported_as_dropped(self):
+        """A failed ``os.remove`` must not produce a ``trimmed=`` line.
+
+        #3688 re-review B2. ``dropped.append`` and ``_log_archive_trim``
+        ran UNCONDITIONALLY after the ``try``, so a read-only mount or an
+        EACCES made ``_trim_dir`` return a drop count for files that were
+        all still on disk and write one durable ``trimmed=`` line per
+        phantom deletion. ``pending-evictions.log`` is the forensic record
+        an operator reads AFTER suspected loss; one that claims deletions
+        that never happened sends them hunting a payload that never left,
+        and is worse than no ledger at all.
+
+        Measured on the unfixed tree with three files and a cap of one:
+        ``dropped=2``, three files still present, two false ledger lines.
+        """
+        d = self._archive([10, 10, 10])
+        real_remove = os.remove
+
+        def denied(path, *a, **kw):
+            if os.path.dirname(os.path.abspath(path)) == os.path.abspath(d):
+                raise PermissionError(13, "Permission denied")
+            return real_remove(path, *a, **kw)
+
+        with unittest.mock.patch.object(os, "remove", denied):
+            with redirect_stderr(io.StringIO()) as err:
+                dropped = pending._trim_dir(d, max_entries=1, max_bytes=10**9)
+
+        self.assertEqual(dropped, 0, "nothing was deleted, so nothing was dropped")
+        self.assertEqual(
+            len(self._names_in(d)), 3, "fixture: every copy is still on disk"
+        )
+        self.assertEqual(
+            err.getvalue(), "", "no stderr line may name a file still present"
+        )
+        ledger = pending.evictions_log_path()
+        trimmed = 0
+        if os.path.exists(ledger):
+            with open(ledger, encoding="utf-8") as f:
+                trimmed = f.read().count("trimmed=")
+        self.assertEqual(
+            trimmed, 0, "the ledger must never claim a deletion that did not happen"
+        )
+
+    def test_a_partial_failure_ledgers_only_the_copies_actually_shed(self):
+        """The mixed case: one victim deletes, the next does not.
+
+        Pins that the guard is per-victim rather than an all-or-nothing
+        bail — the ledger and the returned count must both describe
+        exactly the copies that really left.
+        """
+        d = self._archive([10, 10, 10, 10])
+        victims = [f"{1000 + i:013d}-x.json" for i in range(4)]
+        real_remove = os.remove
+        allowed = {os.path.abspath(os.path.join(d, victims[0]))}
+
+        def selective(path, *a, **kw):
+            if os.path.dirname(os.path.abspath(path)) == os.path.abspath(d):
+                if os.path.abspath(path) not in allowed:
+                    raise PermissionError(13, "Permission denied")
+            return real_remove(path, *a, **kw)
+
+        with unittest.mock.patch.object(os, "remove", selective):
+            with redirect_stderr(io.StringIO()) as err:
+                dropped = pending._trim_dir(d, max_entries=1, max_bytes=10**9)
+
+        self.assertEqual(dropped, 1, "only the one that really went is counted")
+        self.assertEqual(
+            self._names_in(d), victims[1:], "the undeletable copies are still here"
+        )
+        with open(pending.evictions_log_path(), encoding="utf-8") as f:
+            lines = [ln for ln in f.read().splitlines() if "trimmed=" in ln]
+        self.assertEqual(len(lines), 1, "exactly one real deletion, one ledger line")
+        self.assertIn(victims[0], lines[0])
+        for name in victims[1:]:
+            self.assertNotIn(name, err.getvalue())
+
+
+class ArchiveTrimLedgerTest(_QueueTempDirMixin, unittest.TestCase):
+    """A payload must not leave an ARCHIVE without a durable trace either.
+
+    ``_evict_to_fit`` has had ``pending-evictions.log`` since #3599, so the
+    moment a memory leaves the live queue is on the record. The other end of
+    the same payload's life — ``_trim_dir`` deleting it out of
+    ``pending-evicted/``, ``pending-reconciled/`` or (since #3688)
+    ``pending-duplicate/`` — was stderr-only, and stderr is gone with the
+    process. #3688 review R1-M2.
+
+    Two properties, and the second is the one with teeth: the line must NOT
+    be countable as an eviction. ``switchroom doctor``'s in-container probe
+    counts ledger lines matching ``/evicted=/`` inside a 7-day window and
+    FAILS the pending-retains row on any hit (src/cli/doctor.ts,
+    ``buildPendingRetainsProbeScript``). A duplicate archive rolling over is
+    not memory loss — a byte-identical copy is still queued — so it must not
+    be able to turn that row red.
+    """
+
+    def _archive(self, name, n=4):
+        d = os.path.join(self._tmp, name)
+        os.makedirs(d, exist_ok=True)
+        for i in range(n):
+            with open(os.path.join(d, f"{1000 + i:013d}-x.json"), "w") as f:
+                f.write("x")
+        return d
+
+    def _ledger(self):
+        try:
+            with open(pending.evictions_log_path(), encoding="utf-8") as f:
+                return [ln.strip() for ln in f if ln.strip()]
+        except OSError:
+            return []
+
+    def test_every_bounded_archive_ledgers_the_copies_it_sheds(self):
+        for name in ("pending-evicted", "pending-reconciled", "pending-duplicate"):
+            d = self._archive(name)
+            with redirect_stderr(io.StringIO()):
+                pending._trim_dir(d, max_entries=1, max_bytes=10**9)
+
+        lines = self._ledger()
+        self.assertEqual(len(lines), 9, "3 archives x 3 shed copies, all ledgered")
+        for name in ("pending-evicted", "pending-reconciled", "pending-duplicate"):
+            got = [ln for ln in lines if f"archive={name}" in ln]
+            self.assertEqual(len(got), 3, f"{name} trims are on the record")
+            self.assertIn("trimmed=0000000001000-x.json", got[0], "oldest first")
+            self.assertIn("bytes=1", got[0], "and how much went with it")
+
+    def test_a_trim_can_never_be_counted_as_an_eviction_by_doctor(self):
+        """``trimmed=``, never ``evicted=`` — see ``buildPendingRetainsProbeScript``.
+
+        Renaming the token to ``evicted=`` would make every duplicate-archive
+        rollover fail the operator's pending-retains row, which is the check
+        that means "memory was actually shed".
+        """
+        d = self._archive("pending-duplicate", n=3)
+        with redirect_stderr(io.StringIO()):
+            pending._trim_dir(d, max_entries=1, max_bytes=10**9)
+
+        lines = self._ledger()
+        self.assertTrue(lines, "the trim was ledgered at all")
+        for ln in lines:
+            self.assertNotIn(
+                "evicted=", ln, "doctor counts /evicted=/ and FAILS the row on it"
+            )
+            self.assertIn("trimmed=", ln)
+            # doctor windows the ledger with `awk '$1 >= cutoff'`, so the
+            # first field has to stay a lexicographically-sortable UTC stamp.
+            self.assertRegex(ln.split()[0], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+    def test_a_collapsed_duplicate_that_rolls_out_of_the_archive_is_traceable(self):
+        """End to end: collapse → archive full → the copy is gone, on record.
+
+        This is the honest reading of "reversible": reversible until the
+        archive rolls, and when it rolls the operator can still see WHAT
+        rolled and WHEN.
+        """
+        prev = pending.DUPLICATE_MAX_ENTRIES
+        pending.DUPLICATE_MAX_ENTRIES = 1
+        try:
+            os.makedirs(self._dir, mode=0o700, exist_ok=True)
+            for i in range(4):
+                entry = dict(_payload(content="same"))
+                entry["attempt_count"] = 1
+                with open(
+                    os.path.join(self._dir, f"{1000 + i:013d}-aaaaaaaaaaa{i}.json"),
+                    "w",
+                    encoding="utf-8",
+                ) as f:
+                    json.dump(entry, f)
+            with redirect_stderr(io.StringIO()):
+                self.assertEqual(pending.collapse_duplicates(), 3)
+        finally:
+            pending.DUPLICATE_MAX_ENTRIES = prev
+
+        self.assertEqual(
+            len(os.listdir(pending.duplicate_dir())), 1, "the archive stayed bounded"
+        )
+        trims = [ln for ln in self._ledger() if "archive=pending-duplicate" in ln]
+        self.assertEqual(len(trims), 2, "the two shed copies are on the record")
+
+    def test_trim_noise_can_never_push_a_real_eviction_out_of_the_ledger(self):
+        """The cost of SHARING ``pending-evictions.log`` with ``_trim_dir``.
+
+        Before #3688 every line in this file was an eviction, so "keep the
+        newest ``EVICTIONS_LOG_KEEP_LINES`` lines" and "keep the newest 2,000
+        evictions" meant the same thing. Ledgering trims broke that
+        equivalence: one ``collapse_duplicates`` run over the measured
+        1,060-file backlog writes ~192 ``trimmed=`` lines, and a plain
+        tail-rotate would let that noise evict real ``evicted=`` lines from
+        the 7-day window ``switchroom doctor`` reads.
+
+        That failure mode is worth spelling out because it INVERTS the fix:
+        adding observability for the benign channel (a collapse) would have
+        removed it for the only channel that means memory is actually gone.
+        Rotation therefore fills its window evictions-first — inside the SAME
+        budget, so the file is no less bounded than it was before #3688.
+        """
+        keep = pending.EVICTIONS_LOG_KEEP_LINES
+        log = pending.evictions_log_path()
+        os.makedirs(os.path.dirname(log), exist_ok=True)
+        # The oldest lines are the real evictions; everything after them is
+        # trim noise, deep enough to bury them past the tail window.
+        with open(log, "w", encoding="utf-8") as f:
+            for i in range(5):
+                f.write(
+                    "2026-07-20T00:00:%02dZ evicted=old-%d.json bytes=1 "
+                    "reason=count queue_depth=1 queue_bytes=1\n" % (i, i)
+                )
+            for i in range(keep + 50):
+                f.write(
+                    "2026-07-26T00:00:00Z trimmed=n-%d.json bytes=1 "
+                    "archive=pending-duplicate reason=archive-count "
+                    "archive_depth=0 archive_bytes=0\n" % i
+                )
+
+        # Force the rotate on the next append.
+        original = pending.EVICTIONS_LOG_MAX_BYTES
+        pending.EVICTIONS_LOG_MAX_BYTES = 1
+        try:
+            pending._append_ledger("2026-07-26T00:00:01Z trimmed=last.json bytes=1")
+        finally:
+            pending.EVICTIONS_LOG_MAX_BYTES = original
+
+        lines = self._ledger()
+        evictions = [ln for ln in lines if "evicted=" in ln]
+        self.assertEqual(len(evictions), 5, "every real eviction survived the rotate")
+        # …and the file is still BOUNDED, on the SAME budget as before
+        # #3688. Prioritising evictions must not raise the ceiling, or it
+        # trades a monitoring bug for the unbounded log #3599 bounded.
+        self.assertLessEqual(len(lines), keep)
+        # Chronological order is what doctor's `$1 >= cutoff` awk depends on.
+        self.assertEqual(
+            [ln.split()[0] for ln in lines],
+            sorted(ln.split()[0] for ln in lines),
+            "the rotate preserved timestamp order",
+        )
+
+    def test_the_rotate_still_sheds_trim_lines(self):
+        """The eviction rescue is a floor, not an excuse to keep everything.
+
+        Without this the previous test is satisfied by simply never
+        rotating, which would restore the unbounded ledger #3599 bounded.
+        """
+        keep = pending.EVICTIONS_LOG_KEEP_LINES
+        log = pending.evictions_log_path()
+        os.makedirs(os.path.dirname(log), exist_ok=True)
+        with open(log, "w", encoding="utf-8") as f:
+            for i in range(keep + 500):
+                f.write(
+                    "2026-07-26T00:00:00Z trimmed=n-%d.json bytes=1 "
+                    "archive=pending-duplicate reason=archive-count "
+                    "archive_depth=0 archive_bytes=0\n" % i
+                )
+        original = pending.EVICTIONS_LOG_MAX_BYTES
+        pending.EVICTIONS_LOG_MAX_BYTES = 1
+        try:
+            pending._append_ledger("2026-07-26T00:00:01Z trimmed=last.json bytes=1")
+        finally:
+            pending.EVICTIONS_LOG_MAX_BYTES = original
+        lines = self._ledger()
+        self.assertEqual(len(lines), keep, "a pure-trim ledger tail-rotates")
+        self.assertIn("trimmed=last.json", lines[-1])
 
 
 class ClampAndEnvKnobBoundaryTest(_QueueTempDirMixin, unittest.TestCase):
@@ -3703,6 +4168,112 @@ class ResplitOverBoundEntriesTest(_QueueTempDirMixin, unittest.TestCase):
         )
         self.assertEqual(summary["resplit"], 0)
         self.assertTrue(os.path.exists(path))
+
+
+class CorruptLedgerNeverStallsTheDrainTest(_QueueTempDirMixin, unittest.TestCase):
+    """A corrupt ``pending-evictions.log`` must not take the caller down.
+
+    #3688 re-review B1, and the reason it is a blocker rather than a nit:
+    the rotation now READS the ledger back (``open(log,
+    encoding="utf-8")`` + ``readlines()``) and ``UnicodeDecodeError`` is a
+    ``ValueError`` subclass, NOT an ``OSError``. Under a bare
+    ``except OSError`` guard the codec error escapes the "best-effort"
+    ledger entirely and propagates back out through every caller:
+
+      * ``archive_reconciled`` → ``_trim_dir`` → ``_log_archive_trim`` →
+        ``_append_ledger`` — and ``archive_reconciled`` is called from the
+        drain OUTSIDE the phase guard, so it reaches ``__main__`` and
+        exits 2;
+      * ``enqueue`` → ``_evict_to_fit`` → ``_log_eviction`` → the same —
+        i.e. a failed retain could no longer even be queued.
+
+    On the drain sidecar that is a SILENT permanent stall: the wrapper's
+    ``|| true`` swallows the exit code and the loop aborts identically on
+    every cycle, forever, which is precisely what these queue-hardening
+    changes exist to prevent. The trigger needs no exotic state — one
+    non-UTF-8 byte in a >1 MB ledger plus any archive over its cap. The
+    read-side surface is NOT new to the rotation, either: the pre-#3688
+    tail-rotate already called ``readlines()`` under ``except OSError``
+    (``lib/pending.py`` at 63182ce5), so this is a live latent bug on
+    ``main``, not one this change introduces.
+
+    The write side is the same bug through the other door: a filename
+    carrying a surrogate makes the ``print`` raise ``UnicodeEncodeError``,
+    also a ``ValueError``. ``except (OSError, ValueError)`` closes both.
+    """
+
+    def _corrupt_ledger(self):
+        """A >``EVICTIONS_LOG_MAX_BYTES`` ledger that is not valid UTF-8."""
+        log = pending.evictions_log_path()
+        os.makedirs(os.path.dirname(log), exist_ok=True)
+        with open(log, "wb") as f:
+            f.write(b"\xff" * (pending.EVICTIONS_LOG_MAX_BYTES + 4096))
+        return log
+
+    def _fill_archive_over_cap(self, d, n):
+        os.makedirs(d, mode=0o700, exist_ok=True)
+        for i in range(n):
+            with open(os.path.join(d, f"{1000 + i:013d}-k-x.json"), "w") as f:
+                f.write("{}")
+
+    def test_archive_reconciled_survives_a_non_utf8_ledger(self):
+        """The drain path. Measured raising ``UnicodeDecodeError`` unfixed."""
+        os.makedirs(self._dir, mode=0o700, exist_ok=True)
+        self._fill_archive_over_cap(
+            pending.reconciled_dir(), pending.RECONCILED_MAX_ENTRIES + 2
+        )
+        self._corrupt_ledger()
+        entry = os.path.join(self._dir, "9999999999999-k-v.json")
+        with open(entry, "w", encoding="utf-8") as f:
+            json.dump(_payload(content="a real turn"), f)
+
+        with redirect_stderr(io.StringIO()):
+            dest = pending.archive_reconciled(entry)
+
+        self.assertIsNotNone(dest, "the retire itself must still succeed")
+        self.assertFalse(os.path.exists(entry), "entry moved out of the queue")
+        with open(dest, encoding="utf-8") as f:
+            self.assertEqual(json.load(f)["content"], "a real turn")
+
+    def test_enqueue_survives_a_non_utf8_ledger(self):
+        """The eviction path. A corrupt ledger must not block QUEUEING."""
+        pending.MAX_ENTRIES = 1
+        first = pending.enqueue(_payload(content="m0", doc="d0"), RuntimeError("x"))
+        self.assertIsNotNone(first, "fixture")
+        self._corrupt_ledger()
+
+        with redirect_stderr(io.StringIO()):
+            second = pending.enqueue(_payload(content="m1", doc="d1"), RuntimeError("x"))
+
+        self.assertIsNotNone(second, "a corrupt ledger must not refuse a memory")
+        with open(second, encoding="utf-8") as f:
+            self.assertEqual(json.load(f)["content"], "m1")
+
+    def test_a_surrogate_in_a_trimmed_name_does_not_raise(self):
+        """The WRITE-side twin: ``UnicodeEncodeError`` is a ``ValueError`` too."""
+        os.makedirs(self._dir, mode=0o700, exist_ok=True)
+        # A name straight off `os.listdir` on a filesystem holding
+        # undecodable bytes carries surrogate escapes (PEP 383).
+        pending._log_archive_trim(
+            "0000000001000-k-\udcff.json", 10, "count", "pending-duplicate", 1, 10
+        )
+
+    def test_a_corrupt_ledger_is_still_repaired_on_the_next_clean_write(self):
+        """Swallowing the codec error must not wedge the ledger forever.
+
+        The rotate is attempted again on every append, so once the file is
+        replaced (or truncated) by anything the ledger resumes recording —
+        the guard degrades observability for the corrupt file only, it does
+        not permanently disable the eviction record.
+        """
+        self._corrupt_ledger()
+        with redirect_stderr(io.StringIO()):
+            pending._log_eviction("aaaa.json", 10, "count", 1, 10)
+        # Corrupt bytes are still there (we never destroy an operator's
+        # file) but the new line was appended regardless.
+        with open(pending.evictions_log_path(), "rb") as f:
+            raw = f.read()
+        self.assertIn(b"evicted=aaaa.json", raw)
 
 
 if __name__ == "__main__":

--- a/vendor/hindsight-memory/tests/test_hooks.py
+++ b/vendor/hindsight-memory/tests/test_hooks.py
@@ -104,9 +104,18 @@ class TestRecallHook:
             raise OSError("connection refused")
 
         hook_input = make_hook_input(prompt="What is my project about?")
-        # Should not raise — graceful degradation
+        # Should not raise — graceful degradation. Since switchroom #3619 that
+        # degradation is no longer SILENT: an unreachable OWN bank emits the
+        # degraded-recall disclosure, so the agent says "I could not check"
+        # rather than asserting there is no prior context. This case asserted
+        # the pre-#3619 silence and had been RED on main ever since. Nothing
+        # noticed because no CI job ran this file; #3688 wired the suite into
+        # ci-tests-python.yml, which is what surfaced it. The behaviour itself
+        # is pinned CI-side by scripts/tests/test_recall_degraded_notice.py.
         output = _run_hook("recall", hook_input, monkeypatch, tmp_path, urlopen_side_effect=raise_error)
-        assert output.strip() == ""
+        data = json.loads(output)
+        assert data["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+        assert "DEGRADED" in data["hookSpecificOutput"]["additionalContext"]
 
     def test_output_format_matches_claude_code_spec(self, monkeypatch, tmp_path):
         memory = make_memory("User prefers Python")


### PR DESCRIPTION
## Summary

Three independent defects in the vendored Hindsight pending-retain queue and its CI gate, salvaged from an abandoned branch and re-verified against `origin/main` before any code was written. We are about to run a very large backlog drain; the first of these can stop it dead.

**1. One malformed queue entry kills the entire drain run.** `drain_pending.py`'s phase 0 called `collapse_duplicates()` unguarded, and survivor selection did `int(m[2].get("attempt_count", 1) or 1)` — which *raises* `ValueError` on a non-numeric value. `iter_entries()` quarantines unparsable files precisely so no single bad entry can make the queue immortal; a semantically-malformed-but-valid-JSON entry sailed past that and took phases 1 and 2 down with it. Fixed at both levels: `_attempt_count()` removes the raise at source (a bad entry now costs only itself and scores `MAX_ATTEMPTS`, so it is never *preferred* as survivor), and phase 0 is wrapped so the *next* such raise is a logged skip rather than a fleet-wide stall. A collapse only ever MOVES a byte-identical copy into `pending-duplicate/`, so skipping it costs duplicated work, never a memory.

The same expression also had `0 or 1 == 1`, so a never-attempted copy scored identically to one that had already burned an attempt — backwards from the documented rule that the copy with the most retries left wins. And `bool` is an `int` subclass, so `True` would have silently scored `1`. Both pinned.

**2. `_trim_dir` reported drops that never happened.** `except OSError: pass` was followed by an unconditional `dropped.append(names.pop(0))`, so a failed `os.remove` (EACCES, read-only mount) still counted toward the "trimmed N copies" line. Now only a successful remove is counted, named, or ledgered.

While there: a trim was previously stderr-only, so a payload could enter `pending-duplicate/` and be deleted from it with no durable trace, while an *eviction* — the other end of the same payload's life — has had `pending-evictions.log` since #3599. Trims are now ledgered on the same terms via a `_append_ledger` extraction, keyed **`trimmed=`, never `evicted=`**, because `switchroom doctor`'s probe counts `/evicted=/` lines and FAILS the pending-retains row on any hit. Rotation is evictions-first inside the *same* line budget: one collapse over the measured 1,060-file backlog writes ~192 trim lines, and a plain tail-rotate would let that noise push real `evicted=` lines out of doctor's 7-day window — adding observability for the benign channel would have removed it for the channel that means memory is actually gone.

**3. `vendor/hindsight-memory/tests/` was run by no CI job at all.** The `unittest` job runs `vendor/hindsight-memory/scripts/tests/` — a different directory. The sibling suite (258 assertions over hooks, client, config, pending, manifest, recall exit codes) matched no `relevant` path filter *and* had no step behind it, so widening the filter alone would have fixed nothing. Both halves are fixed, and `tests/ci-python-path-filter.test.ts` pins them as a coverage assertion over the suite roots the job actually runs — so a *future* python suite added without a filter entry fails here too.

An unrun suite rots, and this one had: turning it on immediately red `test_hooks.py::TestRecallHook::test_graceful_on_api_error`, which still asserted the pre-#3619 *silent* degradation while recall has emitted the disclosure JSON since #3619. Red on main ever since; nothing noticed. Updated to the current contract (the behaviour itself stays pinned by `scripts/tests/test_recall_degraded_notice.py`).

Also closed a second filter hole: `test_manifest.py` reads `<integration root>/hooks/hooks.json`, an *input* living outside every suite directory, so a PR editing only `hooks/` skipped the gate and could land a manifest that no longer described the shipped hooks.

## Why

Defect 1 is the one with a deadline: the imminent large drain is exactly the workload most likely to contain one malformed entry, and one is enough. Defects 2 and 3 are the two places the system *lies about its own state* — a status line claiming deletions that did not occur, and a green check standing for a suite nobody ran.

One correction to the salvage brief, confirmed live: the `except (OSError, ValueError)` on the ledger guard is **not** new surface introduced here. `63182ce51:pending.py:550` already called `readlines()` under a bare `except OSError`, and codec errors are `ValueError` subclasses, not `OSError` — so a single non-UTF-8 byte in the ledger has been a latent drain-stall on main all along. Widening the catch fixes a pre-existing bug rather than covering for a new one.

## Test plan

- `vendor/hindsight-memory/scripts`: **834 unittest tests OK** (+583 lines of new assertions — 6 in `CollapseDuplicatesTest`, 2 in `TrimDirBoundaryTest`, new `ArchiveTrimLedgerTest` (5) and `CorruptLedgerNeverStallsTheDrainTest` (4)).
- `vendor/hindsight-memory` pytest: **258 passed** — the suite this PR turns on.
- `tests/ci-python-path-filter.test.ts`: 4 passed.
- `npm run lint`: clean (tsc + all 20 guard scripts).
- **Mutation-verified, 8/8.** Each fix's guard tests were re-run with only that fix reverted, and each reddened: unguarded phase 0, the `int(...)` survivor expression, the `0 or 1` tie-break, the bool branch, unconditional `dropped.append`, `evicted=` in the trim line, tail-rotate instead of evictions-first, bare `except OSError` on the ledger. The CI guard was mutated three ways (drop the `tests/**` entry / drop `hooks/**` / delete the pytest step) and each reddens a *distinct* assertion — the "is actually RUN" test exists so a filter entry with no step behind it cannot satisfy the coverage test vacuously.

## Risk

Low, and the shapes are named. Phase 0's `except Exception` is deliberately broad and deliberately non-fatal — `_new_summary` seeds `"collapsed": 0`, so the except path cannot `KeyError`. `_trim_dir` cannot loop forever on a failing remove: the victim is popped before the `continue`. The ledger stays inside its existing byte cap and its existing chronological order (doctor's `awk '$1 >= cutoff'` depends on both), and a ledger of nothing but evictions rotates exactly as it did before.

Deliberately **not** in this PR, to keep it single-concern: the `doctor.ts` / `hindsight-watch` observability surface for collapsed-duplicate counts (needs conflict resolution against substantial drift and fixes no live defect), and the sibling `sweep_legacy_dead_markers` / `resplit_over_bound_entries` phases which are unguarded in the same block and can stall the drain the same way. Both filed as follow-ups.

Do not auto-merge — a separate reviewer approves first.
