### PR TITLE
feat(memory): per-profile observations missions + a doctor row that sees them

### DIFF
--- a/docs/operators/hindsight-memory.md
+++ b/docs/operators/hindsight-memory.md
@@ -461,6 +461,25 @@ the shipped profiles (health-coach leans empathy-high; coding /
 executive-assistant lean skeptical + literal). Operator config overrides per
 key.
 
+`observations_mission` is the one switchroom seeds and keeps current itself.
+Precedence is **operator yaml > profile default > fleet default**:
+
+- `coding`, `executive-assistant` and `health-coach` each ship their own
+  consolidation mission. The two work profiles deliberately tell the
+  consolidator that operational state (versions, open work, outstanding
+  obligations) is durable knowledge and must be recorded with the date inline —
+  it would otherwise be dropped by the engine's "purely ephemeral facts → omit"
+  rule. `health-coach` deliberately does not, because a single day's reading
+  genuinely is ephemeral there.
+- Any other profile, including `default`, gets `DEFAULT_OBSERVATIONS_MISSION`.
+
+Seeding is read-first and never clobbers: switchroom pushes only when the bank's
+value is unset or byte-equals a text switchroom itself shipped, so a mission you
+wrote through the Hindsight API is left alone forever. `switchroom doctor` shows
+each bank's live value as a `bank <id> observations_mission` row, and warns when
+one is unset (that bank is consolidating under Hindsight's stock mission) or is
+waiting on a `switchroom agent reconcile <agent>`.
+
 ### Curated mental models + the curator skill (Phase 5)
 
 Mental models are pinned, named, self-refreshing reflections over a bank. Two

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -31,8 +31,18 @@ import { reconcileAgent } from "../agents/scaffold.js";
 import { getAllAuthStatuses } from "../auth/manager.js";
 import { getSlotInfos, type SlotInfo } from "../auth/accounts.js";
 import type { AgentConfig, SwitchroomConfig } from "../config/schema.js";
+import { DEFAULT_PROFILE } from "../config/schema.js";
 import { loadManifest, detectDrift, type DriftProbers } from "../manifest.js";
-import { probeHindsight, isHindsightEnabled, fetchHindsightToolsList, collectProfileBanks } from "../memory/hindsight.js";
+import {
+  probeHindsight,
+  isHindsightEnabled,
+  fetchHindsightToolsList,
+  collectProfileBanks,
+  fetchBankObservationsMission,
+  decideObservationsMissionUpgrade,
+  DEFAULT_OBSERVATIONS_MISSION,
+  PROFILE_MEMORY_DEFAULTS,
+} from "../memory/hindsight.js";
 import { HINDSIGHT_DEFAULT_MCP_URL } from "../setup/hindsight.js";
 import {
   readHostCapabilities,
@@ -1264,6 +1274,121 @@ function probeAuthBrokerSocket(
 }
 
 /**
+ * Per-agent bank `observations_mission` health. One CheckResult per agent bank.
+ *
+ * Why this row exists: `observations_mission` is pushed by scaffold/reconcile,
+ * never by the operator's yaml on a default setup, and nothing rendered its
+ * live value. That is how a bank could sit for months on the engine's stock
+ * consolidation mission ("Track anything notable in the new facts…") with every
+ * other memory row green — the exact fleet state measured on 2026-07-28, when
+ * all 27 live banks read `observations_mission: null`. A yaml-only check cannot
+ * see this: the value lives in the bank, so this reads the bank.
+ *
+ * - warn: unset (running the engine's stock mission), or a switchroom-shipped
+ *         default that reconcile has not pushed the current text over yet.
+ *         Both are fixed by `switchroom agent reconcile <agent>`.
+ * - warn: the read itself failed — reported as unknown, never as "unset"
+ *         (same posture as the push path, which refuses to treat a failed read
+ *         as upgradable).
+ * - ok:   carrying the mission switchroom intends, or an operator-authored text
+ *         that the never-clobber rule deliberately leaves alone.
+ *
+ * Exported for tests.
+ */
+export async function checkBankObservationsMissions(
+  config: SwitchroomConfig,
+  url: string,
+  opts?: { fetchImpl?: typeof fetch },
+): Promise<CheckResult[]> {
+  // Dedupe by bank the same way checkBankIngestHealth does — several agents may
+  // share one `memory.collection`. Profile banks are deliberately NOT swept:
+  // switchroom's push path only manages agent banks, so a warn row on one would
+  // point at a remediation that does not apply.
+  const banks = new Map<string, { agents: string[]; config: AgentConfig }>();
+  for (const [agentName, agentConfig] of Object.entries(config.agents)) {
+    // Resolve through defaults + profiles, exactly as the push path does — an
+    // `extends` or `memory.observations_mission` inherited from `defaults:`
+    // must produce the same verdict here as it produces on the wire.
+    const resolved = resolveAgentConfig(config.defaults, config.profiles, agentConfig);
+    const bankId = resolved.memory?.collection ?? agentName;
+    const existing = banks.get(bankId);
+    if (existing) existing.agents.push(agentName);
+    else banks.set(bankId, { agents: [agentName], config: resolved });
+  }
+
+  const inspected = await Promise.all(
+    [...banks].map(
+      async ([bankId, entry]) =>
+        [
+          bankId,
+          entry,
+          await fetchBankObservationsMission(url, bankId, { fetchImpl: opts?.fetchImpl }),
+        ] as const,
+    ),
+  );
+
+  return inspected.map(([bankId, entry, read]) => {
+    const label =
+      `bank ${bankId} observations_mission` +
+      (entry.agents[0] !== bankId ? ` (${entry.agents.join(", ")})` : "");
+    const firstAgent = entry.agents[0];
+
+    if (!read.ok) {
+      return {
+        name: label,
+        status: "warn" as const,
+        detail: `could not read observations_mission: ${read.reason}`,
+      };
+    }
+
+    const profileDefault =
+      PROFILE_MEMORY_DEFAULTS[entry.config.extends ?? DEFAULT_PROFILE]?.observations_mission;
+    const decision = decideObservationsMissionUpgrade(
+      entry.config.memory?.observations_mission,
+      profileDefault,
+      read.mission,
+    );
+
+    if (decision.action === "upgrade") {
+      return {
+        name: label,
+        status: "warn" as const,
+        detail:
+          read.mission == null || read.mission.trim() === ""
+            ? "unset — this bank consolidates under Hindsight's stock mission, not switchroom's"
+            : "carrying a superseded switchroom default",
+        fix: `Run: switchroom agent reconcile ${firstAgent}`,
+      };
+    }
+
+    if (decision.action === "config") {
+      // Operator yaml wins outright and needs no read, so the push is
+      // unconditional — a live value that differs is simply not pushed yet.
+      return read.mission === decision.mission
+        ? { name: label, status: "ok" as const, detail: "set from switchroom.yaml" }
+        : {
+            name: label,
+            status: "warn" as const,
+            detail: "switchroom.yaml sets a different observations_mission than the bank carries",
+            fix: `Run: switchroom agent reconcile ${firstAgent}`,
+          };
+    }
+
+    const isSwitchroomDefault =
+      read.mission === (profileDefault ?? DEFAULT_OBSERVATIONS_MISSION);
+    return {
+      name: label,
+      status: "ok" as const,
+      detail: isSwitchroomDefault
+        ? profileDefault != null
+          ? `switchroom ${entry.config.extends ?? DEFAULT_PROFILE}-profile default`
+          : "switchroom fleet default"
+        : "operator-authored (left untouched by the never-clobber rule)",
+    };
+  });
+}
+
+/**
  * Per-agent bank ingest health. One CheckResult per agent bank:
  *
  * - fail: recent documents (≤30d) stored with ZERO extracted facts — the
@@ -1542,6 +1667,11 @@ async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> 
   // keeps "remembering" nothing and no surface goes red. Inspect each bank's
   // REST surface for unextracted documents and stale mental models.
   results.push(...(await checkBankIngestHealth(config, url, { includeConsolidationBacklog: true })));
+
+  // What each bank actually consolidates under. Pushed by scaffold/reconcile
+  // and invisible everywhere else, which is how the whole fleet ran the
+  // engine's stock consolidation mission unnoticed (see the function's doc).
+  results.push(...(await checkBankObservationsMissions(config, url)));
 
   // Auto-recall health (#3619). Reachability, ingest, and /health all stayed
   // green through the 2026-07 regression while the busiest agents lost their

--- a/src/memory/hindsight.ts
+++ b/src/memory/hindsight.ts
@@ -691,14 +691,20 @@ export const DEFAULT_OBSERVATIONS_MISSION =
  * {@link decideMissionUpgrade}. Append the OUTGOING text when
  * {@link DEFAULT_OBSERVATIONS_MISSION} changes; never edit an entry.
  *
- * Seeded with the `health-coach` profile default, which is the only
- * observations mission switchroom has ever pushed. Listing it here is what lets
- * an existing health-coach bank carrying it be recognised as switchroom-authored
- * and upgradable, rather than mistaken for an operator hand-edit and frozen.
+ * PROFILE defaults belong here too when they are retired: an outgoing
+ * `PROFILE_MEMORY_DEFAULTS[<profile>].observations_mission` is a text
+ * switchroom shipped, and listing it is what lets a bank still carrying it be
+ * recognised as switchroom-authored and upgradable rather than mistaken for an
+ * operator hand-edit and frozen forever. (The CURRENT profile defaults do not
+ * need an entry — {@link decideObservationsMissionUpgrade} reads them straight
+ * off `PROFILE_MEMORY_DEFAULTS`.)
  */
 export const SUPERSEDED_OBSERVATIONS_MISSIONS: readonly string[] = [
-  // PROFILE_MEMORY_DEFAULTS["health-coach"].observations_mission, shipped since
-  // the Phase 2 bank-specialisation work.
+  // The original PROFILE_MEMORY_DEFAULTS["health-coach"].observations_mission,
+  // shipped from the Phase 2 bank-specialisation work until it was rewritten in
+  // consolidation voice. A one-line scoping sentence with no exclusions and no
+  // granularity guidance; superseded, not retired — health-coach still has a
+  // profile default, it is just different text now.
   "Synthesise the person's wellbeing patterns, motivations, and emotional " +
     "context — how habits, setbacks, and encouragement connect over time.",
 ];
@@ -723,13 +729,20 @@ export function decideObservationsMissionUpgrade(
 ): { action: "config" | "upgrade" | "none"; mission?: string } {
   const desired = profileDefault ?? DEFAULT_OBSERVATIONS_MISSION;
   // Every text switchroom has ever shipped as a default for this field is
-  // upgradable, INCLUDING the current fleet default — otherwise a profiled
-  // agent whose bank was seeded generically could never reach its profile
-  // mission. `desired` itself is excluded so the "already current" short-circuit
-  // in decideMissionUpgrade stays the one that fires.
-  const shipped = [...SUPERSEDED_OBSERVATIONS_MISSIONS, DEFAULT_OBSERVATIONS_MISSION].filter(
-    (m) => m !== desired,
-  );
+  // upgradable, INCLUDING the current fleet default and the CURRENT profile
+  // defaults — otherwise a profiled agent whose bank was seeded generically
+  // could never reach its profile mission, and (symmetrically) an agent moved
+  // OFF a profile would have its stale profile mission mistaken for an operator
+  // hand-edit and frozen there forever. `desired` itself is excluded so the
+  // "already current" short-circuit in decideMissionUpgrade stays the one that
+  // fires.
+  const shipped = [
+    ...SUPERSEDED_OBSERVATIONS_MISSIONS,
+    DEFAULT_OBSERVATIONS_MISSION,
+    ...Object.values(PROFILE_MEMORY_DEFAULTS)
+      .map((d) => d.observations_mission)
+      .filter((m): m is string => m != null),
+  ].filter((m) => m !== desired);
   return decideMissionUpgrade(configured, current, desired, shipped);
 }
 
@@ -859,21 +872,98 @@ export interface BankMissionExtras {
  *
  * Only `disposition` + `observations_mission` are defaulted here; the
  * persona statement (`reflect_mission` / `bank_mission`) stays operator-driven
- * so there is no code-vs-yaml persona conflict. Profiles not listed inherit
- * the engine default (all traits 3, no observations mission).
+ * so there is no code-vs-yaml persona conflict. Profiles not listed (notably
+ * `default`) inherit the engine disposition (all traits 3) and
+ * {@link DEFAULT_OBSERVATIONS_MISSION} — a `default` entry here would only
+ * duplicate the fleet default.
+ *
+ * ## Why the observations missions below are written the way they are
+ *
+ * Each one is a CONSOLIDATION mission, not an extraction mission: it addresses
+ * the two things `build_batch_consolidation_prompt` actually delegates to the
+ * `## MISSION` block — WHAT is worth an observation, and how much to aggregate
+ * into one ("how many observations to create and how much to aggregate is
+ * driven by the MISSION"; verified 2026-07-28 against `prompts.py` in
+ * `ghcr.io/switchroom/switchroom-hindsight:v0.19.26`). None of them says
+ * anything about merge-vs-create mechanics, which `_PROCESSING_RULES` owns and
+ * which the MISSION outranks — so none can contradict a rule it beats.
+ *
+ * The `coding` and `executive-assistant` missions **explicitly override the
+ * engine's ephemeral-omit rule** ("Purely ephemeral facts → omit them unless
+ * the MISSION explicitly targets such data", `_DECISION_GUIDE`,
+ * `prompts.py:90`). For an engineering or assistant bank the operational state
+ * IS the durable knowledge — a version, a failing gate, an outstanding
+ * obligation — so each instructs that the date be embedded in the observation
+ * text, because a consolidated observation is otherwise a timeless assertion
+ * with no way for a later reader to judge staleness.
+ *
+ * `health-coach` deliberately does NOT carry that override: for a coaching bank
+ * a single day's weight reading or skipped session genuinely is ephemeral, and
+ * the durable unit is the pattern it belongs to. One string for all three
+ * profiles is exactly the failure this avoids.
+ *
+ * Cost: this rides in the per-request user message of every consolidation
+ * batch (batch size 8) and is not prompt-cached, so each is kept under ~1700
+ * characters — roughly 400 tokens per batch, the same order as the
+ * unconditional `_PROCESSING_RULES` block it sits beside.
  */
 export const PROFILE_MEMORY_DEFAULTS: Record<string, BankMissionExtras> = {
   "health-coach": {
     disposition: { skepticism: 2, literalism: 2, empathy: 5 },
     observations_mission:
-      "Synthesise the person's wellbeing patterns, motivations, and emotional " +
-      "context — how habits, setbacks, and encouragement connect over time.",
+      "You consolidate the memory of a health and fitness coach working with one person. This bank records how that person actually lives and trains.\n" +
+      "\n" +
+      "Synthesise into durable observations:\n" +
+      "- Goals, targets, and the plan currently in force, with the reasoning behind each.\n" +
+      "- Training, nutrition, sleep, and alcohol patterns as they hold over weeks — what the person reliably does, not what they did once.\n" +
+      "- Constraints that shape the plan: injuries, medical guidance, schedule, equipment, foods and sessions they refuse.\n" +
+      "- Motivations, and what actually helps or backfires when they slip.\n" +
+      "- Trends in the numbers: direction and range over time, not any single reading.\n" +
+      "- Corrections to earlier beliefs, recorded explicitly as corrections.\n" +
+      "\n" +
+      "A single day's log, weight reading, or session is evidence, not an observation. Record one only when it establishes or changes a standing pattern, target, or constraint — then fold it into the observation for that pattern and say what changed and roughly when.\n" +
+      "\n" +
+      "Granularity: one observation per habit, target, constraint, or trend. Aggregate repeated daily evidence into the observation for that pattern rather than creating one per day, and keep training, nutrition, and sleep as separate observations.\n" +
+      "\n" +
+      "Word observations as the person's own pattern and framing, never as a verdict on them.",
   },
   "executive-assistant": {
     disposition: { skepticism: 4, literalism: 4, empathy: 3 },
+    observations_mission:
+      "You consolidate the memory of an executive assistant working for one person. This bank records that person's commitments, people, and standing arrangements.\n" +
+      "\n" +
+      "Synthesise into durable observations:\n" +
+      "- Standing rules and preferences: how they want things scheduled, written, and filed, and when they want to be interrupted.\n" +
+      "- People and organisations, and the relationship: who they are, what they are involved in, how to reach them.\n" +
+      "- Recurring commitments and routines, and the constraints around them.\n" +
+      "- Obligations and their state: what was promised to whom, the deadline, and what is still outstanding.\n" +
+      "- Decisions made and decisions deferred, with the reasoning and the trade accepted.\n" +
+      "- Corrections to earlier beliefs, recorded explicitly as corrections.\n" +
+      "\n" +
+      "Live commitment state IS durable knowledge here, not ephemeral chatter. An outstanding obligation, a travel window, an unanswered request, a \"currently X\" arrangement — these are precisely what this agent must recall later. Keep them, and embed the date inside the observation text so a later reader can judge staleness. Do not drop them as ephemeral.\n" +
+      "\n" +
+      "Granularity: one observation per person, arrangement, or obligation. Aggregate repeated mentions into that observation rather than creating siblings; never merge two different people or two different commitments into one.\n" +
+      "\n" +
+      "Do not synthesise from transcript exhaust: tool calls and their results, message or event identifiers, or narration of what the assistant did.",
   },
   coding: {
     disposition: { skepticism: 4, literalism: 5, empathy: 2 },
+    observations_mission:
+      "You consolidate the memory of a software-engineering agent. This bank records real work on real codebases.\n" +
+      "\n" +
+      "Synthesise into durable observations:\n" +
+      "- Architecture and design decisions, each with its rationale and the trade accepted.\n" +
+      "- Root causes, with the evidence chain, and negative results — what was ruled out matters as much as what was found.\n" +
+      "- How the repository works: build, test, and lint commands, conventions, CI gates, and where things live.\n" +
+      "- Outcomes of code work: issue and PR numbers, what changed, whether it merged, what review found.\n" +
+      "- The user's standing rules, preferences, and corrections to this agent's behaviour.\n" +
+      "- Corrections to earlier beliefs, recorded explicitly as corrections.\n" +
+      "\n" +
+      "Repository and service state IS durable knowledge here, not ephemeral chatter. Versions, a failing gate, an open PR, a measured number, a \"currently X\" claim — these are precisely what this agent must recall later. Keep them, and embed the date inside the observation text so a later reader can judge staleness. Do not drop them as ephemeral.\n" +
+      "\n" +
+      "Granularity: one observation per distinct decision, cause, convention, or work item. Aggregate repeated evidence about the same one into that observation rather than creating siblings; never merge two separate decisions into a single summary.\n" +
+      "\n" +
+      "Do not synthesise from transcript exhaust: tool calls and their results, scratch paths, session or request identifiers, or narration of what the agent did. Prefer specific and falsifiable — naming the file, the number, the commit, or the decision beats summarising the topic.",
   },
 };
 

--- a/tests/memory.bank-health.test.ts
+++ b/tests/memory.bank-health.test.ts
@@ -8,7 +8,12 @@ import {
   recentUnextracted,
   ageDays,
 } from "../src/memory/bank-health.js";
-import { checkBankIngestHealth } from "../src/cli/doctor.js";
+import { checkBankIngestHealth, checkBankObservationsMissions } from "../src/cli/doctor.js";
+import {
+  DEFAULT_OBSERVATIONS_MISSION,
+  SUPERSEDED_OBSERVATIONS_MISSIONS,
+  PROFILE_MEMORY_DEFAULTS,
+} from "../src/memory/hindsight.js";
 import { handleGetMemoryHealth } from "../src/web/api.js";
 import type { SwitchroomConfig } from "../src/config/schema.js";
 
@@ -557,5 +562,140 @@ describe("handleGetMemoryHealth (dashboard)", () => {
     });
     expect(health.reachable).toBe(false);
     expect(health.banks).toEqual([]);
+  });
+});
+
+/**
+ * `observations_mission` doctor row.
+ *
+ * Why a LIVE-read check rather than a yaml one: `observations_mission` is
+ * pushed by scaffold/reconcile and is never set in yaml on a default setup, so
+ * a yaml-shaped check is structurally incapable of seeing the failure. The
+ * failure it must see was measured on 2026-07-28 — all 27 live banks read
+ * `observations_mission: null`, i.e. the whole fleet consolidating under
+ * Hindsight's stock mission, with every other memory row green.
+ */
+describe("checkBankObservationsMissions (doctor)", () => {
+  /** Serves GET /v1/default/banks/<id>/config from a per-bank fixture. */
+  function fakeConfigFetch(
+    banks: Record<string, { observations_mission?: string | null; failWith?: number }>,
+  ): typeof fetch {
+    return (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const m = url.match(/\/v1\/default\/banks\/([^/?]+)\/config/);
+      if (!m) return new Response("not found", { status: 404 });
+      const fixture = banks[decodeURIComponent(m[1])];
+      if (!fixture) return new Response("no bank", { status: 404 });
+      if (fixture.failWith) return new Response("err", { status: fixture.failWith });
+      return new Response(
+        JSON.stringify({
+          config: { retain_mission: null, observations_mission: fixture.observations_mission ?? null },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+  }
+
+  it("WARNS on the measured fleet state — an unset mission means the engine's stock mission", async () => {
+    const results = await checkBankObservationsMissions(
+      minimalConfig({ ziggy: {} }),
+      "http://x/mcp/",
+      { fetchImpl: fakeConfigFetch({ ziggy: { observations_mission: null } }) },
+    );
+    expect(results).toHaveLength(1);
+    expect(results[0].name).toBe("bank ziggy observations_mission");
+    expect(results[0].status).toBe("warn");
+    expect(results[0].detail).toContain("unset");
+    expect(results[0].fix).toBe("Run: switchroom agent reconcile ziggy");
+  });
+
+  it("passes a bank carrying the current fleet default", async () => {
+    const results = await checkBankObservationsMissions(
+      minimalConfig({ ziggy: {} }),
+      "http://x/mcp/",
+      {
+        fetchImpl: fakeConfigFetch({
+          ziggy: { observations_mission: DEFAULT_OBSERVATIONS_MISSION },
+        }),
+      },
+    );
+    expect(results[0].status).toBe("ok");
+    expect(results[0].detail).toBe("switchroom fleet default");
+  });
+
+  it("passes an operator hand-authored mission — the never-clobber rule is not a defect", async () => {
+    const results = await checkBankObservationsMissions(
+      minimalConfig({ overlord: {} }),
+      "http://x/mcp/",
+      {
+        fetchImpl: fakeConfigFetch({
+          overlord: { observations_mission: "You consolidate the memory of overlord…" },
+        }),
+      },
+    );
+    expect(results[0].status).toBe("ok");
+    expect(results[0].detail).toContain("operator-authored");
+  });
+
+  it("warns that a superseded switchroom default is waiting on reconcile", async () => {
+    const results = await checkBankObservationsMissions(
+      minimalConfig({ gymbro: {} }),
+      "http://x/mcp/",
+      {
+        fetchImpl: fakeConfigFetch({
+          gymbro: { observations_mission: SUPERSEDED_OBSERVATIONS_MISSIONS[0] },
+        }),
+      },
+    );
+    expect(results[0].status).toBe("warn");
+    expect(results[0].detail).toContain("superseded");
+    expect(results[0].fix).toContain("reconcile gymbro");
+  });
+
+  it("reads the profile default for a profiled agent, and passes when the bank matches", async () => {
+    const config = {
+      memory: { backend: "hindsight", config: { url: "http://x/mcp/" } },
+      agents: { dev: { extends: "coding" } },
+    } as unknown as SwitchroomConfig;
+    const coding = PROFILE_MEMORY_DEFAULTS.coding.observations_mission!;
+
+    const matching = await checkBankObservationsMissions(config, "http://x/mcp/", {
+      fetchImpl: fakeConfigFetch({ dev: { observations_mission: coding } }),
+    });
+    expect(matching[0].status).toBe("ok");
+    expect(matching[0].detail).toBe("switchroom coding-profile default");
+
+    // The generic fleet default on a coding bank is an UPGRADE pending, not ok.
+    const generic = await checkBankObservationsMissions(config, "http://x/mcp/", {
+      fetchImpl: fakeConfigFetch({ dev: { observations_mission: DEFAULT_OBSERVATIONS_MISSION } }),
+    });
+    expect(generic[0].status).toBe("warn");
+  });
+
+  it("reports a failed read as unknown, never as unset", async () => {
+    const results = await checkBankObservationsMissions(
+      minimalConfig({ ziggy: {} }),
+      "http://x/mcp/",
+      { fetchImpl: fakeConfigFetch({ ziggy: { failWith: 503 } }) },
+    );
+    expect(results[0].status).toBe("warn");
+    expect(results[0].detail).toContain("could not read");
+    expect(results[0].detail).not.toContain("unset");
+    // No remediation: reconciling does not fix an unreachable backend, and the
+    // push path refuses to treat a failed read as upgradable either.
+    expect(results[0].fix).toBeUndefined();
+  });
+
+  it("dedupes agents sharing one bank and labels them", async () => {
+    const results = await checkBankObservationsMissions(
+      minimalConfig({
+        clerk: { memory: { collection: "assistant" } },
+        helper: { memory: { collection: "assistant" } },
+      }),
+      "http://x/mcp/",
+      { fetchImpl: fakeConfigFetch({ assistant: { observations_mission: null } }) },
+    );
+    expect(results).toHaveLength(1);
+    expect(results[0].name).toBe("bank assistant observations_mission (clerk, helper)");
   });
 });

--- a/tests/memory.bank-missions.test.ts
+++ b/tests/memory.bank-missions.test.ts
@@ -12,6 +12,7 @@ import {
   SUPERSEDED_OBSERVATIONS_MISSIONS,
   decideObservationsMissionUpgrade,
   fetchBankObservationsMission,
+  type BankMissionExtras,
 } from "../src/memory/hindsight.js";
 import {
   reconcileAgent,
@@ -22,7 +23,7 @@ import {
 } from "../src/agents/scaffold.js";
 import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
 import { AgentMemorySchema } from "../src/config/schema.js";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 
@@ -523,10 +524,174 @@ describe("SUPERSEDED_OBSERVATIONS_MISSIONS registry", () => {
     expect(SUPERSEDED_OBSERVATIONS_MISSIONS).not.toContain(DEFAULT_OBSERVATIONS_MISSION);
   });
 
-  it("carries the health-coach profile default, so those banks stay upgradable", () => {
+  it("carries the RETIRED health-coach profile default, so those banks stay upgradable", () => {
+    // The original one-line health-coach mission. It is no longer the profile
+    // default (rewritten in consolidation voice), so it must be listed here or
+    // a bank still carrying it would be mistaken for an operator hand-edit.
     expect(SUPERSEDED_OBSERVATIONS_MISSIONS).toContain(
+      "Synthesise the person's wellbeing patterns, motivations, and emotional " +
+        "context — how habits, setbacks, and encouragement connect over time.",
+    );
+    expect(SUPERSEDED_OBSERVATIONS_MISSIONS).not.toContain(
       PROFILE_MEMORY_DEFAULTS["health-coach"].observations_mission,
     );
+  });
+});
+
+/**
+ * Per-profile `observations_mission` defaults.
+ *
+ * These assert the properties that make a consolidation mission correct for its
+ * profile — not merely that some string is present. The ephemeral-override
+ * assertions are the load-bearing ones: the engine's `_DECISION_GUIDE` says
+ * "Purely ephemeral facts → omit them unless the MISSION explicitly targets
+ * such data" (`prompts.py:90`, verified 2026-07-28 against
+ * `ghcr.io/switchroom/switchroom-hindsight:v0.19.26`). For an engineering or
+ * assistant bank the operational state IS the durable knowledge, so the mission
+ * must override that rule AND ask for the date inline, since a consolidated
+ * observation is otherwise a timeless assertion. For a coaching bank the same
+ * override would be wrong, and its absence is asserted rather than assumed.
+ */
+describe("PROFILE_MEMORY_DEFAULTS observations missions", () => {
+  const profilesDir = resolve(import.meta.dirname, "../profiles");
+  const builtInProfiles = readdirSync(profilesDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && !d.name.startsWith("_"))
+    .map((d) => d.name);
+
+  it("covers every built-in profile except `default` (which takes the fleet default)", () => {
+    expect(builtInProfiles.length).toBeGreaterThan(1);
+    for (const profile of builtInProfiles) {
+      if (profile === "default") {
+        // A `default` entry would only duplicate DEFAULT_OBSERVATIONS_MISSION.
+        expect(PROFILE_MEMORY_DEFAULTS[profile]?.observations_mission).toBeUndefined();
+        continue;
+      }
+      expect(
+        PROFILE_MEMORY_DEFAULTS[profile]?.observations_mission,
+        `profile "${profile}" has no observations_mission default`,
+      ).toBeTruthy();
+    }
+  });
+
+  it("keeps every mission inside the per-batch prompt budget", () => {
+    // Rides the per-request user message of every consolidation batch,
+    // uncached. ~1700 chars ≈ 400 tokens, the order of the unconditional
+    // _PROCESSING_RULES block it sits beside.
+    for (const [profile, defaults] of Object.entries(PROFILE_MEMORY_DEFAULTS)) {
+      const mission = defaults.observations_mission;
+      if (!mission) continue;
+      expect(mission.length, `${profile} mission is ${mission.length} chars`).toBeLessThanOrEqual(
+        1700,
+      );
+    }
+  });
+
+  it("writes in consolidation terms: every mission steers observation granularity", () => {
+    // The engine delegates aggregation to the mission, so a mission that only
+    // lists topics leaves the most consequential knob unset.
+    for (const [profile, defaults] of Object.entries(PROFILE_MEMORY_DEFAULTS)) {
+      const mission = defaults.observations_mission;
+      if (!mission) continue;
+      expect(mission, `${profile} mission says nothing about granularity`).toMatch(
+        /Granularity: one observation per/,
+      );
+      expect(mission, `${profile} mission says nothing about aggregating`).toMatch(/[Aa]ggregate/);
+    }
+  });
+
+  it("overrides the engine's ephemeral-omit rule ONLY where operational state is the knowledge", () => {
+    for (const profile of ["coding", "executive-assistant"]) {
+      const mission = PROFILE_MEMORY_DEFAULTS[profile].observations_mission!;
+      expect(mission, `${profile} must override the ephemeral-omit rule`).toMatch(
+        /IS durable knowledge here, not ephemeral chatter/,
+      );
+      expect(mission, `${profile} must say not to drop it as ephemeral`).toMatch(
+        /[Dd]o not drop (them|it) as ephemeral/,
+      );
+      // Consolidated observations are timeless assertions; without an inline
+      // date a later reader cannot judge staleness.
+      expect(mission, `${profile} must ask for the date inline`).toMatch(
+        /embed the date inside the observation text/,
+      );
+    }
+
+    // A single day's reading genuinely IS ephemeral for a coaching bank — the
+    // durable unit is the pattern. Carrying the ops override here would be the
+    // one-size-fits-all failure this per-profile split exists to avoid.
+    const coach = PROFILE_MEMORY_DEFAULTS["health-coach"].observations_mission!;
+    expect(coach).not.toMatch(/not ephemeral chatter/);
+    expect(coach).not.toMatch(/[Dd]o not drop (them|it) as ephemeral/);
+    expect(coach).toMatch(/is evidence, not an observation/);
+  });
+
+  it("never contradicts the PROCESSING RULES it outranks (says nothing about merge-vs-create)", () => {
+    // The MISSION takes priority over the PROCESSING RULES, so a mission that
+    // opined on UPDATE-vs-CREATE could silently disable the engine's dedup.
+    for (const [profile, defaults] of Object.entries(PROFILE_MEMORY_DEFAULTS)) {
+      const mission = defaults.observations_mission;
+      if (!mission) continue;
+      expect(mission, `${profile} mission touches merge mechanics`).not.toMatch(
+        /\bUPDATE\b|\bCREATE\b|\bDELETE\b/,
+      );
+    }
+  });
+});
+
+/**
+ * Never-clobber, across profiles.
+ *
+ * The four live banks carrying hand-authored observations missions (verified
+ * 2026-07-28 via `GET /v1/default/banks/<id>/config`: 1691, 1667, 1594 and
+ * 1565 chars) are why this matters — shipping profile defaults must not put a
+ * single one of them at risk. The fixture reproduces their shape.
+ */
+describe("observations_mission never-clobber under profile defaults", () => {
+  const HAND_AUTHORED =
+    "You consolidate the memory of an agent working directly with the operator.\n\n" +
+    "Retain durably:\n- Fleet and infrastructure state, and WHY each is set as it is.\n" +
+    "- Investigations and their findings, including negative results.\n";
+
+  it("leaves an operator hand-authored mission alone under EVERY profile default", () => {
+    for (const defaults of [...Object.values(PROFILE_MEMORY_DEFAULTS), {} as BankMissionExtras]) {
+      expect(
+        decideObservationsMissionUpgrade(undefined, defaults.observations_mission, HAND_AUTHORED),
+      ).toEqual({ action: "none" });
+    }
+  });
+
+  it("upgrades an UNSET bank to its profile mission, not the fleet default", () => {
+    for (const [profile, defaults] of Object.entries(PROFILE_MEMORY_DEFAULTS)) {
+      const mission = defaults.observations_mission;
+      if (!mission) continue;
+      expect(decideObservationsMissionUpgrade(undefined, mission, null), profile).toEqual({
+        action: "upgrade",
+        mission,
+      });
+    }
+  });
+
+  it("frees a bank left holding another profile's mission after an `extends` change", () => {
+    // Ordering hazard, mirrored from the generic-default case: an agent moved
+    // OFF `extends: coding` still carries the coding mission. That is
+    // switchroom-authored text, so it must stay upgradable rather than freezing
+    // there forever as if a human had written it.
+    const coding = PROFILE_MEMORY_DEFAULTS.coding.observations_mission!;
+    expect(decideObservationsMissionUpgrade(undefined, undefined, coding)).toEqual({
+      action: "upgrade",
+      mission: DEFAULT_OBSERVATIONS_MISSION,
+    });
+    const coach = PROFILE_MEMORY_DEFAULTS["health-coach"].observations_mission!;
+    expect(decideObservationsMissionUpgrade(undefined, coach, coding)).toEqual({
+      action: "upgrade",
+      mission: coach,
+    });
+  });
+
+  it("is a no-op once a profiled bank already carries its own profile mission", () => {
+    const coding = PROFILE_MEMORY_DEFAULTS.coding.observations_mission!;
+    expect(decideObservationsMissionUpgrade(undefined, coding, coding)).toEqual({
+      action: "none",
+    });
   });
 });
 
@@ -830,6 +995,39 @@ describe("scaffoldAgent — observations_mission seed", () => {
     expect((args.config_updates as Record<string, unknown>).observations_mission).toBe(
       "operator obs text",
     );
+  }, 15_000);
+
+  // The outcome the per-profile defaults exist for: a bank on a profile that
+  // HAS an observations default must end up carrying that profile's mission on
+  // the wire, not the generic fleet default. Verified to bite by deleting
+  // `observations_mission` from PROFILE_MEMORY_DEFAULTS.coding — the received
+  // value falls back to DEFAULT_OBSERVATIONS_MISSION and this fails.
+  it("seeds the PROFILE mission onto a profiled agent's bank", async () => {
+    const config = makeAgentConfig({ extends: "coding" });
+    const args = await runScaffold(null, config);
+    expect((args.config_updates as Record<string, unknown>).observations_mission).toBe(
+      PROFILE_MEMORY_DEFAULTS.coding.observations_mission,
+    );
+  }, 15_000);
+
+  it("upgrades a profiled agent's bank off the generic fleet default", async () => {
+    const config = makeAgentConfig({ extends: "executive-assistant" });
+    const args = await runScaffold(DEFAULT_OBSERVATIONS_MISSION, config);
+    expect((args.config_updates as Record<string, unknown>).observations_mission).toBe(
+      PROFILE_MEMORY_DEFAULTS["executive-assistant"].observations_mission,
+    );
+  }, 15_000);
+
+  it("still leaves a hand-authored mission alone on a PROFILED agent", async () => {
+    const config = makeAgentConfig({ extends: "health-coach" });
+    const calls: Record<string, unknown>[] = [];
+    runScaffold("You consolidate the memory of a coach. Retain durably: …", config, calls);
+    await flushPendingBankOps(10_000);
+    expect(
+      calls.some(
+        (c) => (c.config_updates as Record<string, unknown> | undefined)?.observations_mission,
+      ),
+    ).toBe(false);
   }, 15_000);
 });
 


### PR DESCRIPTION
feat(memory): per-profile observations missions + a doctor row that sees them

Job spec: reference/jobs/remember-across-sessions.md — "brings back relevant
facts, preferences, decisions, and open threads … in the right moment".

Follow-on to #3881, which seeded a single fleet-wide DEFAULT_OBSERVATIONS_MISSION
onto every bank. Two gaps it left, both closed here.

1. THE GAP WAS INVISIBLE. `observations_mission` is pushed by scaffold/reconcile
   and is never set in yaml on a default setup, and nothing rendered its live
   value. That is how all 27 live banks could sit on Hindsight's stock
   consolidation mission for months with every other memory row green. The
   pre-existing `<agent> missions` doctor row reads yaml, so it is structurally
   incapable of seeing this. `checkBankObservationsMissions` reads the bank:
   one row per bank, warn on unset ("consolidating under Hindsight's stock
   mission") or on a superseded switchroom default waiting on reconcile, ok on
   the intended default or an operator-authored text, and a failed read is
   reported as unknown — never as unset, matching the push path's refusal to
   treat a failed read as upgradable.

2. ONE STRING FOR EVERY SPECIALIST IS THE WRONG SHAPE. The engine's
   _DECISION_GUIDE says "Purely ephemeral facts → omit them unless the MISSION
   explicitly targets such data" (prompts.py:90, verified 2026-07-28 against
   ghcr.io/switchroom/switchroom-hindsight:v0.19.26). For an engineering or
   assistant bank the operational state IS the durable knowledge, so `coding`
   and `executive-assistant` explicitly override that rule and require the date
   inline — a consolidated observation is otherwise a timeless assertion with no
   way to judge staleness. `health-coach` deliberately does NOT carry that
   override: a single day's weight reading genuinely is ephemeral there, and the
   durable unit is the pattern it belongs to. Its one-line Phase 2 mission is
   rewritten in the same consolidation voice; the outgoing text was already in
   SUPERSEDED_OBSERVATIONS_MISSIONS, so those banks upgrade in place.

   All three address observation GRANULARITY, which the engine delegates to the
   mission, and none mentions UPDATE/CREATE/DELETE, so none contradicts the
   PROCESSING RULES it outranks. 1327 / 1479 / 1578 chars, pinned under 1700 by
   a test: this rides the per-request user message of every consolidation batch
   (batch size 8) uncached, ~400 tokens, the order of the _PROCESSING_RULES
   block beside it.

3. ORDERING HAZARD, symmetric to the one #3881 fixed. decideObservationsMission-
   Upgrade's "shipped" set now includes the CURRENT profile defaults, not just
   the fleet default and retired texts. Without it, an agent moved off
   `extends: coding` keeps the coding mission forever — switchroom-authored text
   mistaken for an operator hand-edit and frozen.

Never-clobber is unchanged and re-pinned: the four live banks carrying
hand-authored missions (1691 / 1667 / 1594 / 1565 chars, read 2026-07-28) are
covered by a test asserting action "none" under EVERY profile default.

Test plan: tests/memory.bank-missions.test.ts 89 pass (was 72),
tests/memory.bank-health.test.ts 32 pass (was 25). Both new mechanisms verified
to bite by mutation — deleting PROFILE_MEMORY_DEFAULTS.coding.observations_mission
fails 4 tests including the end-to-end scaffold-to-wire one; reverting the
shipped-set widening fails the extends-change test. Also green: doctor.test.ts,
cli.doctor.memory*.test.ts, memory.create-bank.test.ts, src/memory (223 pass).
`npm run lint` clean.

Risk: low. No change to when a push fires, only to what text it carries and for
which profile. Every live agent runs `extends: default`, so the profile missions
change nothing on this fleet until an agent is moved onto a profile; the doctor
row is read-only. When Hindsight is unreachable the new row warns once per bank,
same as the existing ingest row.

Verdict rule: (a) standing-team — memory that compounds instead of accumulating
exhaust; (b) job spec above, at the tier recall already prefers
(prefer_observations defaults true); (c) docs test — the operator doc now states
the precedence and the doctor row; defaults test — works on a fresh setup with
zero yaml; consistency test — same read-first never-clobber rule as
retain_mission, literally shared code; (d) no invariant crossed.

Switchroom-Agent: klanker
Switchroom-Model: claude-opus-5

