### PR TITLE
fix(hindsight): guard drain phases 0b/0c and report a failed phase

### DIFF
--- a/vendor/hindsight-memory/scripts/drain_pending.py
+++ b/vendor/hindsight-memory/scripts/drain_pending.py
@@ -793,6 +793,14 @@ def _new_summary() -> dict:
         "dead_relocated": 0,
         "resplit": 0,
         "resplit_parts": 0,
+        # Labels of the pre-drain phases ("0"/"0b"/"0c") that raised and were
+        # stepped over this run — see `_phase_failed`. A LIST, not a count,
+        # because which phase broke is what an operator needs. IN THE GATE,
+        # not only in the summary line, for exactly the reason `parked` is
+        # (see `main()`): every pre-drain counter reads 0 both on a run whose
+        # phases all blew up and on a clean, empty, healthy queue, so without
+        # this key the two runs are byte-identical from outside.
+        "phase_failures": [],
         "stalled": False,
         "budget_exceeded": False,
     }
@@ -844,6 +852,8 @@ def drain(
          "dead_relocated": int,  # legacy .dead markers moved out of the queue dir
          "resplit":   int, # over-bound entries split into drainable parts
          "resplit_parts": int,  # parts those entries became
+         "phase_failures": list[str],  # pre-drain phases that raised and
+                                       # were stepped over (backlog only)
          "stalled": bool,  # stall guard tripped
          "budget_exceeded": bool}
     """
@@ -1001,6 +1011,47 @@ def _blog(msg: str) -> None:
     print(f"[Hindsight] drain_pending(backlog): {msg}", file=sys.stderr)
 
 
+def _phase_failed(summary: dict, phase: str, e: BaseException, cost: str) -> None:
+    """Record a pre-drain phase that raised, and let the drain continue.
+
+    ONE mechanism for phases 0, 0b and 0c (#3894 / #3895). They sit in the same
+    ``if not dry_run:`` block and run BEFORE the phases that actually
+    drain, so a raise out of any of them takes phases 1 and 2 with it and
+    the backlog becomes immortal — for every OTHER entry too, none of
+    which had anything to do with the failure. Phases 0 and 0c PARSE
+    queued entries, so a semantically-malformed-but-valid-JSON entry
+    reaches both — precisely the class ``iter_entries``' quarantine cannot
+    catch. Phase 0b parses nothing and its guard is defence-in-depth on
+    the caller contract; the comment at its call site says so plainly.
+    None of the three is loss-bearing to skip — a collapse, a sweep and a
+    re-split only MOVE or REWRITE bytes already on disk, and none of them
+    deletes — so all three are logged and stepped over, not fatal.
+
+    Reported in TWO places on purpose. The stderr line is for whoever is
+    watching the run; ``summary["phase_failures"]`` is what makes the
+    failure survive into the return value, into ``main()``'s summary line,
+    and into its "anything to report?" gate. Without the second, a run
+    where every pre-drain phase blew up prints exactly what an empty,
+    healthy queue prints — every pre-drain counter is 0 either way — and a
+    permanently broken phase is invisible to anything not tailing stderr.
+    Same argument, same shape, as ``parked`` (#3893).
+
+    ``cost`` states what skipping this phase actually costs, in the same
+    voice as the phase's own log lines: the point of the message is that
+    the operator can tell at a glance that no memory was lost.
+
+    The message format is deliberately the one #3894 wrote inline for its
+    phase-0 guard, so folding that guard onto this helper changed no
+    output at all. Three hand-rolled ``except`` blocks in one block is
+    exactly the shape that drifts.
+    """
+    summary["phase_failures"].append(phase)
+    _blog(
+        f"phase {phase} FAILED ({type(e).__name__}: {e}) — continuing to the "
+        f"phases that actually drain. Nothing was lost: {cost}"
+    )
+
+
 def _reconcile_phase(config: dict, summary: dict, dry_run: bool) -> None:
     """PHASE 1 — free pass: drop entries whose document already exists.
 
@@ -1115,11 +1166,13 @@ def _drain_backlog_impl(
         try:
             summary["collapsed"] = collapse_duplicates()
         except Exception as e:  # noqa: BLE001 — see comment above
-            _blog(
-                f"phase 0 FAILED ({type(e).__name__}: {e}) — continuing to the "
-                f"phases that actually drain. Nothing was lost: a collapse only "
-                f"ever MOVES a byte-identical copy into pending-duplicate/, so "
-                f"the cost of skipping it is duplicated work, not a memory."
+            _phase_failed(
+                summary,
+                "0",
+                e,
+                "a collapse only ever MOVES a byte-identical copy into "
+                "pending-duplicate/, so the cost of skipping it is duplicated "
+                "work, not a memory.",
             )
         if summary["collapsed"]:
             _blog(
@@ -1132,7 +1185,29 @@ def _drain_backlog_impl(
         # queue directory. Free, local, and an UPGRADE step: markers written
         # by an older build sit in the directory external janitors sweep, and
         # a marker is the only remaining copy of its memory.
-        moved = sweep_legacy_dead_markers()
+        #
+        # GUARDED (#3895) because it runs BEFORE the phases that drain, but
+        # be honest about WHY: unlike phase 0c this one parses no entry — it
+        # walks filenames — and it already catches `OSError` per marker,
+        # which covers `shutil.Error` too (an `OSError` subclass). No queue
+        # state reachable today makes it raise, and none was found looking.
+        # The guard is on the CALLER contract rather than a live defect:
+        # nothing running before the drain may be able to stop the drain,
+        # and any future line inside that loop re-opens the hole. Skipping
+        # the sweep is free — the markers stay exactly where every earlier
+        # build left them.
+        try:
+            moved = sweep_legacy_dead_markers()
+        except Exception as e:  # noqa: BLE001 — see `_phase_failed`
+            moved = 0
+            _phase_failed(
+                summary,
+                "0b",
+                e,
+                "a sweep only ever MOVES a `.dead` marker out of the live "
+                "queue directory, so the cost of skipping it is that the "
+                "markers stay where they already were, not a memory.",
+            )
         if moved:
             summary["dead_relocated"] = moved
             _blog(
@@ -1150,7 +1225,30 @@ def _drain_backlog_impl(
         # part drainable, which is the difference between a lost memory and a
         # slow one. Runs after the duplicate collapse so a duplicated
         # over-bound entry is split ONCE, not once per copy.
-        entries_split, parts_written = resplit_over_bound_entries()
+        #
+        # GUARDED (#3895), and this is the most exposed of the pre-drain
+        # phases: it PARSES every queued entry to measure it, so a
+        # semantically-malformed-but-valid-JSON entry — the exact class
+        # `iter_entries`' quarantine hands over rather than quarantines —
+        # reaches it. Measured: one entry whose `metadata` is a string
+        # instead of a mapping raises `ValueError` out of the payload
+        # rebuild. Unguarded, that ONE entry stops phases 1 and 2 for every
+        # other entry in the queue, on every run. Skipping the split costs
+        # the over-bound entries only: they stay exactly as undrainable as
+        # they were before phase 0c existed, and nothing is deleted.
+        try:
+            entries_split, parts_written = resplit_over_bound_entries()
+        except Exception as e:  # noqa: BLE001 — see `_phase_failed`
+            entries_split, parts_written = 0, 0
+            _phase_failed(
+                summary,
+                "0c",
+                e,
+                "a re-split only ever REWRITES an over-bound entry into "
+                "drainable parts and archives the original, so the cost of "
+                "skipping it is that those entries stay as undrainable as "
+                "they were before phase 0c existed. Nothing is deleted.",
+            )
         if entries_split:
             summary["resplit"] = entries_split
             summary["resplit_parts"] = parts_written
@@ -1388,6 +1486,12 @@ def main(argv: list[str] | None = None) -> int:
             # could not tell "parked by the circuit breaker, needs --force"
             # from "ordinary backlog, will drain on its own".
             "parked",
+            # Same argument as `parked` directly above, one stage earlier in
+            # the run (#3895). A run whose pre-drain phases all raised has
+            # every pre-drain counter at 0 — identical to a clean, empty
+            # queue — so without this key a permanently broken phase
+            # 0/0b/0c prints nothing at all from the CLI.
+            "phase_failures",
         )
     ):
         print(
@@ -1400,6 +1504,7 @@ def main(argv: list[str] | None = None) -> int:
             f"unknown={summary['unknown']} "
             f"archive_failed={summary['archive_failed']} "
             f"parked={summary['parked']} "
+            f"phase_failures={','.join(summary['phase_failures']) or 'none'} "
             f"stalled={summary['stalled']} budget_exceeded={summary['budget_exceeded']}",
             file=sys.stderr,
         )

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -2767,6 +2767,45 @@ class CliTest(unittest.TestCase):
             rc, _ = self._run(["--phase", "reconcile"])
         self.assertEqual(rc, 2)
 
+    # ---- #3895: a failed pre-drain phase must not be invisible ------------
+
+    def _run_with(self, summary, argv=("--backlog",)):
+        with unittest.mock.patch.object(
+            drain_pending, "drain", lambda *a, **kw: summary
+        ):
+            with unittest.mock.patch.object(drain_pending, "load_config", lambda: {}):
+                with redirect_stderr(io.StringIO()) as err:
+                    drain_pending.main(list(argv))
+        return err.getvalue()
+
+    def test_a_run_whose_phases_all_failed_does_not_look_like_a_clean_one(self):
+        """The whole reason the failure is in the SUMMARY, not only a log.
+
+        Every pre-drain counter reads 0 on a run where the phases blew up
+        and on a run over an empty, healthy queue — they are the same
+        numbers. `main()`'s report gate is `any(...)` over those counters,
+        so without `phase_failures` in it a permanently broken phase 0b/0c
+        prints, from the CLI, EXACTLY what a clean run prints: nothing.
+        Same failure shape `parked` was added to that gate for (#3893), one
+        stage earlier in the run. Pinned as a DIFFERENCE rather than a
+        substring, because "these two runs are indistinguishable" is the
+        defect.
+        """
+        clean = drain_pending._new_summary()
+        broken = drain_pending._new_summary()
+        broken["phase_failures"] = ["0b", "0c"]
+
+        self.assertEqual(self._run_with(clean), "", "a clean quiet run stays quiet")
+        out = self._run_with(broken)
+        self.assertNotEqual(out, "", "a run that lost both phases must report")
+        self.assertIn("phase_failures=0b,0c", out, "and it must name which")
+
+    def test_a_reported_run_with_no_phase_failure_says_so(self):
+        """The negative half: the field is present, not conditional noise."""
+        summary = drain_pending._new_summary()
+        summary["drained"] = 1
+        self.assertIn("phase_failures=none", self._run_with(summary))
+
 
 class StallGuardBoundaryTest(_QueueTempDirMixin, unittest.TestCase):
     """The stall guard counts CONSECUTIVE failures of the SAME class.
@@ -3327,6 +3366,61 @@ class DeadMarkersLeaveTheLiveQueueTest(_QueueTempDirMixin, unittest.TestCase):
 
         self.assertEqual(summary["dead_relocated"], 0)
         self.assertTrue(os.path.exists(legacy))
+
+    # ---- #3895: a broken phase 0b must not wedge the drain ----------------
+
+    def test_a_failing_phase_0b_never_blocks_the_phases_that_drain(self):
+        """Phase 0b's blast radius, pinned.
+
+        0b runs BEFORE the phases that actually drain, so an exception out
+        of it takes phases 1 and 2 with it and the whole backlog becomes
+        immortal — for every OTHER entry in the queue, none of which had
+        anything to do with the failure.
+
+        The raise is INJECTED here rather than provoked from queue data, and
+        that is an honest statement about this phase: unlike phase 0c,
+        `sweep_legacy_dead_markers` parses no entry — it walks filenames and
+        already catches `OSError` per marker (`shutil.Error` is an `OSError`
+        subclass, so a cross-device move is covered too). No queue state
+        reachable today makes it raise; several were tried. The guard is
+        therefore defence-in-depth on the CALLER contract, which is the part
+        that matters: nothing that runs before the drain may be able to stop
+        it, and any future line added inside that loop re-opens the hole
+        this pins shut.
+
+        A sweep only MOVES a marker out of the janitor's path, so skipping
+        it leaves the markers exactly where every earlier build left them.
+        """
+        path = pending.enqueue(_payload(content="a real memory"), RuntimeError("x"))
+        self.assertTrue(os.path.exists(path), "fixture")
+
+        def boom():
+            raise OSError(errno.EACCES, "Permission denied")
+
+        posted = []
+        with unittest.mock.patch.object(
+            drain_pending, "sweep_legacy_dead_markers", boom
+        ):
+            with unittest.mock.patch.object(
+                drain_pending, "_document_state", lambda e, timeout=30: bool(posted)
+            ):
+                with unittest.mock.patch.object(
+                    drain_pending,
+                    "_retry_one",
+                    lambda e, timeout: posted.append(e["document_id"]),
+                ):
+                    with redirect_stderr(io.StringIO()) as err:
+                        summary = drain_pending.drain_backlog(CONFIG)
+
+        self.assertEqual(len(posted), 1, "phase 2 still ran")
+        self.assertEqual(pending.count(), 0, "the entry drained anyway")
+        self.assertEqual(summary["dead_relocated"], 0, "nothing moved, honestly")
+        self.assertIn("phase 0b FAILED", err.getvalue(), "and it was not silent")
+        self.assertEqual(
+            summary["phase_failures"],
+            ["0b"],
+            "the failure must survive into the summary, not only into stderr",
+        )
 
 
 class ResplitOverBoundEntriesTest(_QueueTempDirMixin, unittest.TestCase):
@@ -4180,6 +4274,138 @@ class ResplitOverBoundEntriesTest(_QueueTempDirMixin, unittest.TestCase):
         )
         self.assertEqual(summary["resplit"], 0)
         self.assertTrue(os.path.exists(path))
+
+    # ---- #3895: a broken phase 0c must not wedge the drain ----------------
+
+    def test_a_non_dict_metadata_cannot_make_the_backlog_immortal(self):
+        """The concrete reproduction, end to end — measured, not imagined.
+
+        Phase 0c PARSES every queued entry, so a
+        semantically-malformed-but-valid-JSON entry reaches it.
+        `iter_entries()`' quarantine cannot help: the file is valid JSON, so
+        it is handed over rather than quarantined — that is the whole point
+        of the quarantine, and the whole reason this class of entry is the
+        dangerous one.
+
+        One entry with `"metadata": "nope"` (a string where a mapping
+        belongs) is enough: the payload rebuild inside `enqueue_parts`
+        raises `ValueError: dictionary update sequence element #0 has
+        length 1; 2 is required`. Unguarded, that ONE entry stops phases 1
+        and 2 for the WHOLE queue, on every run, forever.
+
+        The healthy entry is the assertion that matters: it has nothing to
+        do with the malformed one and must still reach the bank.
+        """
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        bad = pending.enqueue(
+            dict(_payload(content="m" * 40_000, doc=_cd_doc(1)), metadata="nope"),
+            RuntimeError("x"),
+        )
+        pending.enqueue(
+            _payload(content="a healthy memory", doc=_cd_doc(5)), RuntimeError("x")
+        )
+        self.assertEqual(pending.count(), 2, "fixture")
+        self.assertTrue(os.path.exists(bad), "fixture")
+        # The bound MOVES under the entry — exactly what a deadline change
+        # does — so phase 0c now has work to do and reaches the bad entry.
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+
+        posted = []
+        with unittest.mock.patch.object(
+            drain_pending, "_document_state", lambda e, timeout=30: bool(posted)
+        ):
+            with unittest.mock.patch.object(
+                drain_pending,
+                "_retry_one",
+                lambda e, timeout: posted.append(e["document_id"]),
+            ):
+                with redirect_stderr(io.StringIO()) as err:
+                    summary = drain_pending.drain_backlog(CONFIG)
+
+        self.assertIn("phase 0c FAILED", err.getvalue(), "and it was not silent")
+        self.assertEqual(summary["phase_failures"], ["0c"])
+        self.assertEqual(summary["resplit"], 0, "nothing was re-split, honestly")
+        self.assertEqual(summary["resplit_parts"], 0)
+        self.assertIn(_cd_doc(5), posted, "the healthy memory still reached the bank")
+        self.assertEqual(pending.count(), 0, "and the queue drained")
+
+    def test_a_failing_phase_0c_never_blocks_the_phases_that_drain(self):
+        """The guard itself, independent of which raise provokes it.
+
+        The reproduction above pins ONE measured raise. This pins the
+        contract that outlives it: whatever `resplit_over_bound_entries`
+        raises, phases 1 and 2 still run. Skipping a re-split costs the
+        over-bound entries only — they stay as undrainable as they were
+        before phase 0c existed — and costs the rest of the queue nothing.
+        """
+        pending.enqueue(_payload(content="a real memory"), RuntimeError("x"))
+
+        def boom():
+            raise ValueError("invalid literal for int() with base 10: 'many'")
+
+        posted = []
+        with unittest.mock.patch.object(
+            drain_pending, "resplit_over_bound_entries", boom
+        ):
+            with unittest.mock.patch.object(
+                drain_pending, "_document_state", lambda e, timeout=30: bool(posted)
+            ):
+                with unittest.mock.patch.object(
+                    drain_pending,
+                    "_retry_one",
+                    lambda e, timeout: posted.append(e["document_id"]),
+                ):
+                    with redirect_stderr(io.StringIO()) as err:
+                        summary = drain_pending.drain_backlog(CONFIG)
+
+        self.assertEqual(len(posted), 1, "phase 2 still ran")
+        self.assertEqual(pending.count(), 0, "the entry drained anyway")
+        self.assertEqual(summary["resplit"], 0)
+        self.assertEqual(summary["resplit_parts"], 0)
+        self.assertIn("phase 0c FAILED", err.getvalue())
+        self.assertEqual(summary["phase_failures"], ["0c"])
+
+    def test_every_pre_drain_phase_can_fail_and_the_drain_still_completes(self):
+        """All three at once, and the summary names all three, in run order.
+
+        Phases 0, 0b and 0c share a block and a failure mode, so the
+        interesting case is not one of them breaking but the state where the
+        whole pre-drain stage is unusable. The drain must still be the thing
+        that runs, and the queue must still empty.
+
+        Phase 0 is included because #3894's guard now routes through the same
+        `_phase_failed` helper: this is the test that keeps the three of them
+        on ONE mechanism, rather than three `except` blocks that drift.
+        """
+        pending.enqueue(_payload(content="a real memory"), RuntimeError("x"))
+
+        def boom(*a, **kw):
+            raise RuntimeError("the pre-drain stage is unusable")
+
+        posted = []
+        with unittest.mock.patch.object(drain_pending, "collapse_duplicates", boom):
+            with unittest.mock.patch.object(
+                drain_pending, "sweep_legacy_dead_markers", boom
+            ):
+                with unittest.mock.patch.object(
+                    drain_pending, "resplit_over_bound_entries", boom
+                ):
+                    with unittest.mock.patch.object(
+                        drain_pending,
+                        "_document_state",
+                        lambda e, timeout=30: bool(posted),
+                    ):
+                        with unittest.mock.patch.object(
+                            drain_pending,
+                            "_retry_one",
+                            lambda e, timeout: posted.append(e["document_id"]),
+                        ):
+                            with redirect_stderr(io.StringIO()):
+                                summary = drain_pending.drain_backlog(CONFIG)
+
+        self.assertEqual(len(posted), 1, "phase 2 still ran")
+        self.assertEqual(pending.count(), 0)
+        self.assertEqual(summary["phase_failures"], ["0", "0b", "0c"])
 
 
 class CorruptLedgerNeverStallsTheDrainTest(_QueueTempDirMixin, unittest.TestCase):


### PR DESCRIPTION
Closes #3895.

Phases 0b (`sweep_legacy_dead_markers`) and 0c (`resplit_over_bound_entries`) sit in the same `if not dry_run:` block as phase 0 and run **before** the phases that actually drain. An unguarded raise out of either aborts `_drain_backlog_impl` before phase 1 and phase 2 — so one bad entry makes the backlog immortal *for every other entry too*, fleet-wide. That is exactly the shape #3894 closed for phase 0.

## What this changes

Three parts, in `vendor/hindsight-memory/scripts/drain_pending.py`:

1. **One mechanism, not three `except` blocks.** New `_phase_failed(summary, phase, e, cost)` helper: appends the phase label to `summary["phase_failures"]` and emits the stderr line. Phases 0b and 0c are guarded through it, and **#3894's phase-0 guard is folded onto it too** — that fold is byte-identical in output, because this helper's message format was deliberately written to match the line #3894 inlined. Three hand-rolled `except` blocks in one block is the shape that drifts.

2. **The failure is visible in the summary, not just on stderr.** `_new_summary()` gains `"phase_failures": []` and `main()` adds it to the "anything to report?" gate as well as the printed `key=value` line. This matters because a run whose pre-drain phases *all* raised has every pre-drain counter at `0` — identical to a clean, empty, healthy queue. Without the gate entry, a permanently broken phase prints **nothing at all** from the CLI: rc=0, empty stdout, empty stderr, byte-identical to "queue empty". Precedent is directly in the file: #3893 added `"parked"` to the same gate for the same reason, with a comment saying so.

3. Tests, below.

## Correction to the issue's premise

The issue describes 0b and 0c as "the same five-line pattern". Half right, and the code comments say which half:

- **0c is a live, reproducible defect.** It parses every queued entry. An entry with `metadata` as a string (valid JSON, semantically malformed — precisely the class `iter_entries()`'s quarantine cannot catch) raises `ValueError: dictionary update sequence element #0 has length 1; 2 is required` out of the payload rebuild in `enqueue_parts`. There is an end-to-end regression test for exactly this (`test_a_non_dict_metadata_cannot_make_the_backlog_immortal`) — no mocks, real queue, real drain.
- **0b has no reachable raise that I could find.** It parses nothing, walks filenames, and already catches `OSError` per marker (and `shutil.Error` subclasses `OSError`). I probed surrogate-escaped names, a directory named `*.dead`, and pre-existing destinations — all return cleanly. Its guard is **defence-in-depth on the caller contract**, and the comment at its call site says that plainly rather than implying a bug that isn't there.

Also worth flagging for the reviewer reading these side by side: #3894 reported its phase-0 failure **only** to stderr — `summary["collapsed"]` stays `0`, so an all-failed run really was byte-identical to a clean one from the CLI. Part 2 above closes that for phase 0 as well as 0b/0c.

## Base

Branched off freshly-fetched `origin/main` at `2909a8139` — which **is** #3894's merge commit (#3894 merged 2026-07-28T01:48). No stacking, no deferred fold: the phase-0 retrofit described above is included here because its guard is now on main.

(For the record: this started stacked on `fix/hindsight-drain-resilience` while #3894 was open. That base runs **zero** CI — every workflow in `.github/workflows/` is `on: pull_request: branches: [main]` — and once #3893 landed, the stacked diff conflicted with main, leaving the PR `DIRTY` and skipping `pull_request` events entirely. Rebasing onto merged main resolved both.)

Job spec: `reference/jobs/remember-across-sessions.md` — a stalled drain is the failure mode where a memory is accepted by the hook and then never reaches the bank.

## Tests

Six new tests in `vendor/hindsight-memory/scripts/tests/test_pending_drops.py`:

| Test | Asserts |
|---|---|
| `test_a_non_dict_metadata_cannot_make_the_backlog_immortal` | real end-to-end: one over-bound entry with `metadata="nope"` + one healthy entry → 0c raises, healthy entry still POSTs, `pending.count()==0`, `phase_failures==["0c"]` |
| `test_a_failing_phase_0b_never_blocks_the_phases_that_drain` | injected `OSError(EACCES)` → drain completes, `phase_failures==["0b"]` |
| `test_a_failing_phase_0c_never_blocks_the_phases_that_drain` | injected `ValueError` → same |
| `test_every_pre_drain_phase_can_fail_and_the_drain_still_completes` | 0, 0b and 0c all raise → `phase_failures==["0","0b","0c"]`, queue still empties. This is the test that keeps all three on one mechanism. |
| `test_a_run_whose_phases_all_failed_does_not_look_like_a_clean_one` | pinned as a **difference**: clean run prints `""`, broken run prints non-empty containing `phase_failures=0b,0c` |
| `test_a_reported_run_with_no_phase_failure_says_so` | `phase_failures=none` on a reported clean-phase run |

**Local results**

- `python3 -m unittest discover -s tests` in `vendor/hindsight-memory/scripts`: **868 tests, OK**
- `npm run lint`: clean (tsc + all guard scripts)
- pytest `vendor/hindsight-memory/tests`: 257 passed, 1 pre-existing failure (`test_hooks.py::TestRecallHook::test_graceful_on_api_error`) — red on pristine `main`, unrelated to this change, not touched here.

**Mutation verification — 6/6**, each mutation reddening a distinct, relevant test:

| # | Mutation | Result |
|---|---|---|
| M1 | remove the 0b guard | ERROR ×2 — `..._phase_0b_never_blocks...`, `..._every_pre_drain_phase...` |
| M2 | remove the 0c guard | ERROR ×3 — incl. the real-repro `..._non_dict_metadata...` |
| M3 | drop `summary["phase_failures"].append(phase)` | FAIL ×4 |
| M4 | drop `"phase_failures"` from `main()`'s gate | FAIL ×1 — `..._does_not_look_like_a_clean_one` |
| M5 | drop `phase_failures=` from the printed line | FAIL ×2 |
| M6 | un-fold the phase-0 guard | ERROR ×2 — incl. #3894's own `..._phase_0_never_blocks...` |

M1/M2/M6 redden as **ERROR** rather than FAIL: the exception escapes `_drain_backlog_impl` — which *is* the stall being guarded against.

## Risk

Low. The guards only convert a raise into a logged skip; neither phase is loss-bearing to skip (a collapse MOVES a byte-identical copy, a sweep MOVES a marker, a re-split REWRITES and archives — none of the three deletes). The one behavioural change beyond that is that `main()` now reports a run it previously kept silent, which is the point.

## Please do not auto-merge

Opened for review only.
