### PR TITLE
fix(hindsight): make HINDSIGHT_API_WORKER_MAX_SLOTS an overridable key

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2522,7 +2522,10 @@ export const HindsightConfigSchema = z.object({
       "damping out entirely, unset means the patch's own derived gap; and " +
       "HINDSIGHT_API_RECENCY_DECAY_LINEAR_WINDOW_DAYS — only read when the " +
       "decay function is `linear`, so switchroom ships no default for it but " +
-      "still honours an operator who flips the function back), plus the " +
+      "still honours an operator who flips the function back; and " +
+      "HINDSIGHT_API_WORKER_MAX_SLOTS — the worker poller's TOTAL in-flight " +
+      "task budget, the pool WORKER_CONSOLIDATION_MAX_SLOTS reserves out of; " +
+      "unset means upstream's own default), plus the " +
       "embedded-PostgreSQL (pg0) sizing keys switchroom manages in " +
       "src/setup/hindsight-pg-defaults.ts (`HINDSIGHT_PG_ENV_KEYS`: " +
       "SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE, " +

--- a/src/setup/hindsight-perf-defaults.test.ts
+++ b/src/setup/hindsight-perf-defaults.test.ts
@@ -329,7 +329,7 @@ describe("operator override wins", () => {
     expect(got.size).toBe(0);
   });
 
-  it("is overridable on exactly these twenty-six keys, by name", () => {
+  it("is overridable on exactly these twenty-seven keys, by name", () => {
     // Spelled out, NOT derived from the three group arrays. HINDSIGHT_PERF_ENV_KEYS
     // is DEFINED as the union of those arrays, so asserting it equals that union
     // is a tautology — it passes no matter which keys are in the arrays. The
@@ -362,6 +362,7 @@ describe("operator override wins", () => {
       "HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY",
       "HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS",
       "HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT",
+      "HINDSIGHT_API_WORKER_MAX_SLOTS",
       // Not HINDSIGHT_API_* — a switchroom-patch knob (the CE-damping
       // rollback hatch), read by the patched reranking module, never by
       // upstream's config parser. Sorts last.
@@ -453,6 +454,75 @@ describe("HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY (override-only)", () 
     expect(runEnv(runArgs()).get("HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY")).toEqual([
       MAP,
     ]);
+  });
+});
+
+describe("HINDSIGHT_API_WORKER_MAX_SLOTS (override-only)", () => {
+  const KEY = "HINDSIGHT_API_WORKER_MAX_SLOTS";
+  const CAPS = [
+    { gpu: false, localLlm: false },
+    { gpu: true, localLlm: false },
+    { gpu: false, localLlm: true },
+    { gpu: true, localLlm: true },
+  ];
+
+  it("is in the managed set but in NO defaults group", () => {
+    expect(HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS.has(KEY)).toBe(true);
+    for (const group of [
+      HINDSIGHT_PERF_DEFAULTS_UNGATED,
+      HINDSIGHT_PERF_DEFAULTS_GPU,
+      HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM,
+    ]) {
+      expect(group.map(([k]) => k)).not.toContain(KEY);
+    }
+  });
+
+  it.each(CAPS)(
+    "is NOT emitted when unset (gpu=$gpu localLlm=$localLlm) — upstream's own default stands",
+    (caps) => {
+      expect(hindsightPerfEnv(caps).map(([k]) => k)).not.toContain(KEY);
+    },
+  );
+
+  it("reaches BOTH launch paths, with the operator's value, when set in hindsight.env", () => {
+    // The regression: this exact line sat in switchroom.yaml while the
+    // container booted `max_slots=10`, because the key was outside
+    // HINDSIGHT_PERF_ENV_KEYS and resolveHindsightPerfOverrides skipped it.
+    // Asserting only membership in the key set would not catch a gate-shaped
+    // regression on the emit side, so assert the launch argv itself.
+    const perf = { env: { [KEY]: "16" }, processEnv: {} };
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false, perf);
+    const fromRun = runEnv(runArgs());
+    const fromCompose = composeEnv(
+      generateHindsightComposeSnippet(undefined, undefined, LOOPBACK_LITELLM, false, perf),
+    );
+    expect(fromRun.get(KEY)).toEqual(["16"]);
+    expect(fromCompose.get(KEY)).toEqual(["16"]);
+  });
+
+  it("still reaches the container on a host with NO gated capability", () => {
+    const perf = { env: { [KEY]: "16" }, processEnv: {} };
+    startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, false, perf);
+    expect(runEnv(runArgs()).get(KEY)).toEqual(["16"]);
+  });
+
+  it("carries the slot policy's other two terms alongside it", () => {
+    // The point of managing this key at all: the reservation and the ceiling
+    // were already reachable, so an operator could set two of the three terms
+    // of one slot policy and silently lose the third. All three, or none.
+    const perf = {
+      env: {
+        [KEY]: "16",
+        HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS: "5",
+        HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT: "6",
+      },
+      processEnv: {},
+    };
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false, perf);
+    const fromRun = runEnv(runArgs());
+    expect(fromRun.get(KEY)).toEqual(["16"]);
+    expect(fromRun.get("HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS")).toEqual(["5"]);
+    expect(fromRun.get("HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT")).toEqual(["6"]);
   });
 });
 

--- a/src/setup/hindsight-perf-defaults.ts
+++ b/src/setup/hindsight-perf-defaults.ts
@@ -950,11 +950,45 @@ export const HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM: ReadonlyArray<readonly [string, 
  * Override-only rather than defaulted for the same reason as the two above:
  * emitting upstream's own 365 would add a hard-coded value to every host's
  * `docker inspect` for no behaviour change.
+ *
+ * ### `HINDSIGHT_API_WORKER_MAX_SLOTS`
+ *
+ * The total in-flight task budget for the worker poller — the pool that
+ * `HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS` reserves out of and that
+ * every other operation type shares. switchroom already manages the
+ * reservation and the ceiling (both are in {@link
+ * HINDSIGHT_PERF_DEFAULTS_UNGATED}) but not the total they are carved from,
+ * so an operator could set two of the three terms of one slot policy and not
+ * the third.
+ *
+ * That gap is not theoretical. On the reference fleet this line sat in
+ * `hindsight.env` from 2026-07-27 with a measured rationale attached:
+ *
+ * ```yaml
+ * hindsight:
+ *   env:
+ *     HINDSIGHT_API_WORKER_MAX_SLOTS: 16
+ * ```
+ *
+ * and the container ran `max_slots=10` — upstream's default — for the whole of
+ * the following day, because the key was outside this module's managed set and
+ * `resolveHindsightPerfOverrides` skipped it. The poller logs the value it
+ * actually booted with (`starting polling loop (max_slots=…)`), so the drop was
+ * observable, but nothing connected that line back to the yaml.
+ *
+ * Override-only rather than defaulted for the same reason as the three above:
+ * switchroom ships no opinion on the total slot budget, and emitting upstream's
+ * own 10 would add a hard-coded value to every host's `docker inspect` for no
+ * behaviour change. Note also that upstream validates the slot policy at boot
+ * (reservations must sum to <= this, and the consolidation ceiling must sit
+ * between the reservation and this), so an incoherent combination fails loudly
+ * in the container rather than silently here.
  */
 export const HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS: ReadonlySet<string> = new Set([
   "HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY",
   "HINDSIGHT_CE_DECISIVE_RELATIVE_GAP",
   "HINDSIGHT_API_RECENCY_DECAY_LINEAR_WINDOW_DAYS",
+  "HINDSIGHT_API_WORKER_MAX_SLOTS",
 ]);
 
 /**


### PR DESCRIPTION
## The bug

`hindsight.env` in `switchroom.yaml` is scoped to `HINDSIGHT_PERF_ENV_KEYS`. `resolveHindsightPerfOverrides` does `if (!HINDSIGHT_PERF_ENV_KEYS.has(key)) continue;` (`src/setup/hindsight-perf-defaults.ts`), so a key outside that set is discarded — no error, no warning. `HINDSIGHT_API_WORKER_MAX_SLOTS` was outside it.

Not hypothetical. On the reference fleet this line sat in `hindsight.env` from 2026-07-27 with a measured rationale attached:

```yaml
hindsight:
  env:
    # retain floods every free slot; at 10 slots consolidation completed
    # exactly 1 op in 90 minutes.
    HINDSIGHT_API_WORKER_MAX_SLOTS: 16
```

and the container booted `max_slots=10` — upstream's default — for the whole of the following day (`starting polling loop (max_slots=10, reservations=[consolidation=3], shared_pool=7, ceilings=[consolidation<=6])`). The consolidation backlog it was meant to relieve grew ~1,000 facts/hr through that window.

The gap is incoherent on its own terms: switchroom already manages `WORKER_CONSOLIDATION_MAX_SLOTS` (the reservation) and `WORKER_CONSOLIDATION_SLOT_LIMIT` (the ceiling), both carved out of `WORKER_MAX_SLOTS`. An operator could set two of the three terms of one slot policy and silently lose the third.

## The change

One line: add the key to `HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS`, plus its doc block and the schema description it is contracted against.

Override-only rather than defaulted, for the same reason as the three keys already there: switchroom ships no opinion on the total slot budget, so emitting upstream's own 10 would add a hard-coded value to every host's `docker inspect` for no behaviour change. Upstream validates the slot policy at boot (reservations sum <= this; consolidation ceiling between the reservation and this), so an incoherent combination fails loudly in the container rather than silently here.

## Tests

Outcome-asserting, not constant-asserting: the new cases check the value reaches the **`docker run` argv AND the compose snippet**, on a gated host and an ungated one. Set membership alone would stay green if the emit path regressed.

Mutation-verified — with the one-line set addition reverted:

```
× is in the managed set but in NO defaults group
× reaches BOTH launch paths, with the operator's value, when set in hindsight.env
× still reaches the container on a host with NO gated capability
× carries the slot policy's other two terms alongside it
  AssertionError: expected undefined to deeply equal [ '16' ]
Tests  4 failed | 4 passed
```

The exhaustive key-list contract test (`is overridable on exactly these twenty-seven keys, by name`) also fails, which is what forces the `src/config/schema.ts` doc update.

Scoped run green: `src/setup/`, `tests/setup/`, `tests/hindsight-env-keys-are-reachable.test.ts`, `src/config/` — 550 + 443 tests passing. `npm run lint` clean.

## Deliberately NOT changed

`HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE` is also unreachable from `hindsight.env`, and that is by design — it is derived from the declared context window by `resolveHindsightContextBudget()`, and this module's own header says a literal for it must not be added here (two emitters would race for one key and the `assertHindsightContextBudgetFits()` preflight would break). Batch size is a context-window decision; the knob is `hindsight.llm.context_window`. Left alone to keep this single-concern.

Hold retracted 2026-07-28 by klanker: the review this was flagged for has been completed — the resolver was executed against the live fleet config and confirmed this PR closes the one genuine gap (`HINDSIGHT_API_WORKER_MAX_SLOTS`). Cleared to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

