### PR TITLE
fix(hindsight): stop the consolidation schema emitting an uncompilable maxItems

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -126,6 +126,7 @@ jobs:
               - 'tests/docker/hindsight-recall-isolation-patches.test.ts'
               - 'tests/docker/hindsight-retry-perturbation-patches.test.ts'
               - 'tests/docker/hindsight-graph-seed-patch.test.ts'
+              - 'tests/docker/hindsight-maxitems-grammar-patch.test.ts'
               - 'tests/docker/dockerfile-hindsight-bakes.test.ts'
               - '.github/workflows/docker-e2e.yml'
 
@@ -359,10 +360,24 @@ jobs:
           SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
         run: npx vitest run tests/docker/hindsight-graph-seed-patch.test.ts
 
+      - name: Run the hindsight maxItems-grammar probe (RED/GREEN, must not skip)
+        # Same contract again, for the consolidation-maxItems-grammar patch.
+        # The bakes test cannot cover the failure that matters here: its
+        # assertions are unanchored substring matches, so raising the ceiling
+        # (or reinstating a clamp that still emits a four-digit maxItems) keeps
+        # every grepped literal green while the schema is once again
+        # uncompilable by a local GBNF backend — and every consolidation call on
+        # a large bank silently falls over to the metered provider, carrying
+        # private corpus text off-host. Only serialising the model and reading
+        # the emitted maxItems catches that.
+        env:
+          SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
+        run: npx vitest run tests/docker/hindsight-maxitems-grammar-patch.test.ts
+
       - name: Label-scoped teardown
         if: always()
         run: |
-          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-graph-seed-patch; do
+          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-graph-seed-patch hindsight-maxitems-grammar-patch; do
             ids=$(docker ps -aq --filter "label=switchroom.test=$phase" 2>/dev/null || true)
             if [ -n "$ids" ]; then docker rm -f $ids 2>/dev/null || true; fi
           done

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -2581,6 +2581,148 @@ print(
 )
 PYEOF
 
+# ── consolidation maxItems grammar patch ──────────────────────────────────────
+# Stop the consolidation response schema emitting a `maxItems` so large that a
+# local grammar-constrained backend cannot compile it — which is what silently
+# routes private corpus content to a METERED third party.
+#
+# THE DEFECT, in the real shipping source.
+# `_build_response_model()` (engine/consolidation/consolidator.py) constrains the
+# `creates` field with `PydanticField(default=[], max_length=clamped)`, which
+# pydantic serialises into the request's JSON schema as `"maxItems": <clamped>`.
+# Its only caller passes `max_creates=remaining_observation_slots` — the bank's
+# REMAINING OBSERVATION-SLOT COUNT (`remaining_observation_slots = max(max_obs -
+# current_count, 0)`), not a modelling constraint. On this fleet that number is
+# ~4,230 for a cohort of banks.
+#
+# llama.cpp/Ollama compile a JSON schema down to a GBNF grammar, and a
+# repetition count that large fails to build. Measured on this host
+# (2026-07-28), the consolidation deployment returns:
+#
+#   HTTP 400 {"error":{"code":400,"message":"Failed to initialize samplers:
+#            failed to parse grammar","type":"invalid_request_error"}}
+#
+# LiteLLM's router-level fallback then re-sends the SAME call — batch prompt and
+# all, up to `CONSOLIDATION_LLM_BATCH_SIZE` memories of verbatim private corpus
+# text — to the metered OpenRouter deployment. 56 such fallbacks are visible in
+# the proxy's log for `Received Model Group=gpt-oss-20b-consolidation`. It is
+# deterministic per bank: a bank with ~4,230 remaining slots fails EVERY time,
+# a bank with ~670 compiles fine (threshold measured between 672 and 4,223).
+# The fallback rule itself is deliberately NOT touched here — removing it before
+# this fix lands would convert a leak into hard consolidation failures.
+#
+# WHY OMIT RATHER THAN CLAMP. Clamping to a smaller number would move the
+# threshold and keep the class of bug; it would also assert a bound that is not
+# true. The cap is a RESOURCE GUARD, not something the model needs to see:
+#   * `CONSOLIDATION_LLM_BATCH_SIZE=6`, so one batch sees 6 memories and can
+#     never approach 4,230 — above a small ceiling the constraint cannot bind.
+#   * The slot cap is ALREADY enforced in Python after validation, regardless of
+#     the schema — consolidator.py's "Defensive truncation: some LLM providers
+#     may not enforce JSON schema max_length" trims `creates` to
+#     `remaining_observation_slots`. Nothing is lost by dropping the hint.
+#   * When the cap is genuinely tight the model is ALSO told in prose: the
+#     `observation_capacity_note` branch fires whenever
+#     `remaining_observation_slots <= len(memories)`.
+# So the constraint is kept exactly where it is real and compiles trivially
+# (<= 64, ~10x below the measured failure threshold) and omitted where it is
+# pure resource accounting. `maxItems` is then either a binding truth or absent.
+#
+# Self-verifying (exact-once anchors, re-asserted after the splice, `ast.parse`
+# on the result); guarded structurally by
+# tests/docker/dockerfile-hindsight-bakes.test.ts and behaviourally (RED against
+# unpatched upstream / GREEN patched) by
+# tests/docker/hindsight-maxitems-grammar-patch.test.ts, which builds the schema
+# at the production-like 4,230 and asserts the emitted `maxItems`.
+RUN python3 - <<'PYEOF'
+import ast
+import pathlib
+
+BASE = pathlib.Path("/app/api/hindsight_api")
+TAG = "switchroom hindsight consolidation-maxItems-grammar patch"
+
+
+def apply(rel, edits):
+    f = BASE / rel
+    s = f.read_text()
+    for anchor, repl in edits:
+        n = s.count(anchor)
+        assert n == 1, (
+            f"{TAG}: anchor found {n}x (expected 1) in {rel} — upstream "
+            "reformatted _build_response_model; re-author this patch in "
+            f"docker/Dockerfile.hindsight. Anchor head: {anchor.splitlines()[0]!r}"
+        )
+        s = s.replace(anchor, repl, 1)
+    f.write_text(s)
+    ast.parse(s)
+    return s
+
+
+new = apply("engine/consolidation/consolidator.py", [
+    (
+        "def _build_response_model(max_creates: int | None = None) -> type[_ConsolidationBatchResponse]:\n"
+        '    """Build a response model, optionally constraining max creates via JSON schema."""\n'
+        "    if max_creates is None or max_creates < 0:\n"
+        "        return _ConsolidationBatchResponse\n"
+        "\n"
+        "    from pydantic import Field as PydanticField\n",
+
+        "# switchroom: the largest `maxItems` this schema may emit. A local\n"
+        "# grammar-constrained backend (llama.cpp/Ollama) compiles the response schema\n"
+        "# into GBNF, and a repetition count in the thousands fails to build:\n"
+        '# HTTP 400 "Failed to initialize samplers: failed to parse grammar". LiteLLM\n'
+        "# then falls the call over to a METERED deployment, sending the batch's\n"
+        "# verbatim private corpus text off-host. 64 is ~10x below the measured\n"
+        "# failure threshold (672 compiles, 4,223 does not) and still an order of\n"
+        "# magnitude above anything one batch could emit\n"
+        "# (CONSOLIDATION_LLM_BATCH_SIZE=6).\n"
+        "SWITCHROOM_MAX_CREATES_SCHEMA_CEILING = 64\n"
+        "\n"
+        "\n"
+        "def _build_response_model(max_creates: int | None = None) -> type[_ConsolidationBatchResponse]:\n"
+        '    """Build a response model, optionally constraining max creates via JSON schema."""\n'
+        "    if max_creates is None or max_creates < 0:\n"
+        "        return _ConsolidationBatchResponse\n"
+        "\n"
+        "    # switchroom: omit the constraint entirely when it cannot bind. The caller\n"
+        "    # passes the bank's REMAINING OBSERVATION-SLOT COUNT, a resource guard\n"
+        "    # rather than a modelling constraint — above the ceiling it only breaks\n"
+        "    # grammar compilation. The cap is still enforced: the caller truncates\n"
+        "    # `creates` to remaining_observation_slots after validation regardless of\n"
+        "    # the schema, and a genuinely tight cap is also stated in prose via\n"
+        "    # observation_capacity_note.\n"
+        "    if max_creates > SWITCHROOM_MAX_CREATES_SCHEMA_CEILING:\n"
+        "        return _ConsolidationBatchResponse\n"
+        "\n"
+        "    from pydantic import Field as PydanticField\n",
+    ),
+])
+
+# The Python-side enforcement this patch relies on must still be there: without
+# it, omitting `maxItems` really would drop the cap.
+assert "creates = creates[:remaining_observation_slots]" in new, (
+    f"{TAG}: the post-validation truncation to remaining_observation_slots is gone "
+    "from consolidator.py — omitting maxItems would now DROP the observation cap. "
+    "Re-author this patch."
+)
+assert new.count("_build_response_model(max_creates=remaining_observation_slots)") == 1, (
+    f"{TAG}: _build_response_model is no longer called with "
+    "remaining_observation_slots — re-author this patch."
+)
+assert new.count("SWITCHROOM_MAX_CREATES_SCHEMA_CEILING") == 2, (
+    f"{TAG}: ceiling constant not spliced exactly once plus its use"
+)
+assert new.count("max_length=clamped") == 1, (
+    f"{TAG}: the constrained field vanished — the ceiling now guards nothing"
+)
+
+print(
+    "switchroom hindsight consolidation-maxItems-grammar patch: the consolidation "
+    "response schema now omits maxItems above 64 instead of emitting the bank's "
+    "remaining-slot count, so a local grammar backend can compile it and the call "
+    "no longer falls over to a metered provider"
+)
+PYEOF
+
 # Pin the upstream `hindsight` user to UID 11000 to match
 # `HINDSIGHT_DEFAULT_UID` in src/setup/hindsight.ts (and the
 # `auth.consumers[hindsight].uid` value the operator writes in

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -937,6 +937,62 @@ describe("Dockerfile.hindsight shape", () => {
     expect(dockerfile).toMatch(/^    ast\.parse\(s\)$/m);
   });
 
+  it("keeps the consolidation-maxItems-grammar fix (assert-guarded, fail-loud)", () => {
+    // `_build_response_model()` constrained `creates` with
+    // `PydanticField(max_length=clamped)` where `clamped` is the bank's
+    // REMAINING OBSERVATION-SLOT COUNT, so the request schema carried
+    // `"maxItems": 4230` on this fleet. llama.cpp/Ollama compile that to GBNF
+    // and a repetition count that large fails to build — HTTP 400 "Failed to
+    // initialize samplers: failed to parse grammar" — after which LiteLLM's
+    // router fallback re-sent the whole batch, verbatim private corpus text
+    // included, to the METERED OpenRouter deployment (56 such fallbacks logged
+    // for `Received Model Group=gpt-oss-20b-consolidation`, 2026-07-28).
+    //
+    // SCOPE: this test is structural, not behavioural. Every assertion below is
+    // an unanchored substring match, so it proves the patch is PRESENT, never
+    // that the number it emits is compilable — raising the ceiling to 100_000
+    // keeps all of them green. The behavioural gate is
+    // tests/docker/hindsight-maxitems-grammar-patch.test.ts, which applies this
+    // block to the pinned image and reads the `maxItems` pydantic actually
+    // serialises at a production-like 4,230. Do not treat this file as
+    // sufficient.
+
+    // The exact-once anchor guard (fail-loud on upstream drift).
+    expect(dockerfile).toMatch(
+      /switchroom hindsight consolidation-maxItems-grammar patch/,
+    );
+    expect(dockerfile).toMatch(
+      /f"\{TAG\}: anchor found \{n\}x \(expected 1\) in \{rel\} — upstream "/,
+    );
+    // The ceiling, and the branch that omits the constraint above it. Omitting
+    // beats clamping: a clamp moves the threshold and asserts a bound that is
+    // not true, so `maxItems` would still be a number nobody can compile at
+    // some other bank size.
+    expect(dockerfile).toMatch(/SWITCHROOM_MAX_CREATES_SCHEMA_CEILING = 64\\n/);
+    expect(dockerfile).toMatch(
+      /if max_creates > SWITCHROOM_MAX_CREATES_SCHEMA_CEILING:\\n/,
+    );
+    // The premise that makes omission safe: the cap is still enforced in
+    // Python after validation. If upstream ever drops that truncation, this
+    // patch must fail the build rather than silently uncap observations.
+    expect(dockerfile).toMatch(
+      /assert "creates = creates\[:remaining_observation_slots\]" in new,/,
+    );
+    // The caller contract the whole defect hangs on.
+    expect(dockerfile).toMatch(
+      /assert new\.count\("_build_response_model\(max_creates=remaining_observation_slots\)"\) == 1,/,
+    );
+    // Post-replace re-assertions (verification-on-build): a patch that applied
+    // but landed inert must fail the build.
+    expect(dockerfile).toMatch(
+      /assert new\.count\("SWITCHROOM_MAX_CREATES_SCHEMA_CEILING"\) == 2,/,
+    );
+    expect(dockerfile).toMatch(/assert new\.count\("max_length=clamped"\) == 1,/);
+    expect(dockerfile).toMatch(
+      /switchroom hindsight consolidation-maxItems-grammar patch: the consolidation /,
+    );
+  });
+
   it("preserves upstream's start-all.sh as the post-shim CMD", () => {
     // The shim does broker auth, then `exec "$@"` which is whatever
     // CMD docker passes — must be upstream's start-all.sh so the

--- a/tests/docker/hindsight-maxitems-grammar-patch.test.ts
+++ b/tests/docker/hindsight-maxitems-grammar-patch.test.ts
@@ -1,0 +1,411 @@
+/**
+ * Behavioural proof for the consolidation-maxItems-grammar patch that
+ * `docker/Dockerfile.hindsight` bakes into the pinned upstream Hindsight image.
+ *
+ * `dockerfile-hindsight-bakes.test.ts` pins the *shape* of that patch block
+ * (grep-on-file, runs everywhere). This file proves the *outcome*: it builds
+ * the real consolidation response model at a production-like remaining-slot
+ * count and reads the `maxItems` pydantic actually emits into the request
+ * schema — RED against unpatched upstream, GREEN with the patch applied.
+ *
+ * THE DEFECT, in the real shipping source.
+ * `_build_response_model()` (`engine/consolidation/consolidator.py`) constrains
+ * `creates` with `PydanticField(default=[], max_length=clamped)`, which pydantic
+ * serialises as `"maxItems": <clamped>`. Its one caller passes
+ * `max_creates=remaining_observation_slots` — the bank's remaining
+ * observation-slot count, not a modelling constraint. Measured on this host
+ * 2026-07-28 against the running `switchroom-hindsight` container:
+ * `_build_response_model(max_creates=4230).model_json_schema()` yields
+ * `{"maxItems": 4230, ...}` for `creates`.
+ *
+ * Local llama.cpp/Ollama compile that schema into a GBNF grammar and a
+ * repetition count that large fails to build, so the deployment answers
+ * `HTTP 400 {"error":{"code":400,"message":"Failed to initialize samplers:
+ * failed to parse grammar",...}}`. LiteLLM's router fallback then re-sends the
+ * identical call — batch prompt and all, carrying verbatim private corpus text
+ * — to the metered OpenRouter deployment (56 such fallbacks logged for
+ * `Received Model Group=gpt-oss-20b-consolidation`). Deterministic per bank:
+ * ~4,230 remaining slots fails every time, ~670 compiles (threshold measured
+ * between 672 and 4,223).
+ *
+ * WHY THIS PROBE AND NOT A GREP. The bakes test's assertions are unanchored
+ * substring matches: raising the ceiling to 100_000, or reintroducing a clamp
+ * that still emits a four-digit `maxItems`, keeps every literal it greps for in
+ * place while the schema is once again uncompilable. Only serialising the model
+ * and reading the emitted number catches that, which is what this file does.
+ *
+ * It drives the REAL `_build_response_model` from the image and asserts on
+ * `model_json_schema()` — the same call path pydantic takes when the schema is
+ * handed to the provider — rather than re-implementing the model here. It
+ * applies the patch by `docker exec` (not `docker build`) so it runs on daemons
+ * without buildx, and it never touches the production `switchroom-hindsight`
+ * container.
+ *
+ * SKIP DISCIPLINE: identical to `hindsight-retry-perturbation-patches.test.ts`.
+ * Locally, with no docker or no cached image, this skips (never pull a 6.4GB
+ * third-party image onto a dev box). In CI the `hindsight-probe` job pulls the
+ * pinned digest and sets SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1, under which an
+ * unavailable docker/image is a HARD FAILURE, never a green skip. Both runs
+ * assert a `PROBE_EXECUTED` sentinel so a probe that dies early can never be
+ * mistaken for a pass.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { execFileSync, execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const dockerfile = readFileSync(
+  resolve(root, "docker/Dockerfile.hindsight"),
+  "utf8",
+);
+
+const RUN_ID = randomUUID();
+const TEST_PHASE = "hindsight-maxitems-grammar-patch";
+
+/** The pinned upstream image, read from the Dockerfile so it can never drift. */
+const UPSTREAM_IMAGE = (() => {
+  const m = dockerfile.match(/^FROM\s+(\S+)/m);
+  if (!m) throw new Error("Dockerfile.hindsight has no FROM line");
+  return m[1];
+})();
+
+/** The patch this file proves, named by its unique in-block marker. */
+const PATCH_NAME = "consolidation-maxItems-grammar patch";
+
+/**
+ * The patch block under test, pulled out of the Dockerfile's
+ * `RUN python3 - <<'PYEOF' ... PYEOF` heredocs by its unique patch name.
+ */
+function patchBlocks(): string[] {
+  const blocks = [
+    ...dockerfile.matchAll(/^RUN python3 - <<'PYEOF'\n([\s\S]*?)^PYEOF$/gm),
+  ].map((m) => m[1]);
+  const hits = blocks.filter((b) => b.includes(PATCH_NAME));
+  if (hits.length !== 1) {
+    throw new Error(
+      `Dockerfile.hindsight contains ${hits.length} "${PATCH_NAME}" RUN blocks ` +
+        `(expected exactly 1) — if the patch was deliberately removed, delete ` +
+        `this test with it.`,
+    );
+  }
+  return hits;
+}
+
+/**
+ * Python probe. Exits 0 only when the emitted schema is compilable at every
+ * slot count that matters; prints the offending assertions otherwise.
+ *
+ * Deliberately asserts the OUTCOME — the `maxItems` value pydantic actually
+ * serialises — not that a code path ran. Nothing here greps the patched source.
+ */
+const PROBE = String.raw`
+import json
+import sys
+
+failures = []
+
+
+def fail(msg):
+    failures.append(msg)
+
+
+from hindsight_api.engine.consolidation.consolidator import _build_response_model
+
+# The measured grammar-compilation threshold on this fleet: 672 compiles,
+# 4,223 does not. 4230 is a real production remaining-slot count.
+PRODUCTION_SLOTS = 4230
+# The largest maxItems a local GBNF backend is known to compile here.
+COMPILABLE_CEILING = 64
+
+
+def creates_schema(max_creates):
+    model = _build_response_model(max_creates=max_creates)
+    return model.model_json_schema()["properties"]["creates"]
+
+
+def max_items(max_creates):
+    return creates_schema(max_creates).get("maxItems")
+
+
+# ── 1. the defect itself: a production-like slot count ────────────────────
+prod = max_items(PRODUCTION_SLOTS)
+print("MAXITEMS_PRODUCTION", json.dumps(prod))
+if prod is not None:
+    fail(
+        "schema for remaining_observation_slots="
+        + str(PRODUCTION_SLOTS)
+        + " emitted maxItems="
+        + repr(prod)
+        + " — a local GBNF backend cannot compile this and the call falls over "
+        "to the metered provider"
+    )
+
+# ── 2. the whole uncompilable band, not just one lucky number ─────────────
+band = {n: max_items(n) for n in (673, 1000, 4223, PRODUCTION_SLOTS, 100000)}
+print("MAXITEMS_BAND", json.dumps({str(k): v for k, v in sorted(band.items())}))
+for n, v in sorted(band.items()):
+    if v is not None and v > COMPILABLE_CEILING:
+        fail(
+            "slots="
+            + str(n)
+            + " emitted an uncompilable maxItems="
+            + repr(v)
+            + " (ceiling "
+            + str(COMPILABLE_CEILING)
+            + ")"
+        )
+
+# ── 3. a genuinely tight cap is still expressed to the model ──────────────
+# The constraint is real there (2 slots left really does mean at most 2
+# creates), it compiles trivially, and dropping it would make the model emit
+# creates the caller then silently truncates.
+tight = {n: max_items(n) for n in (0, 1, 2, 6, 64)}
+print("MAXITEMS_TIGHT", json.dumps({str(k): v for k, v in sorted(tight.items())}))
+for n, v in sorted(tight.items()):
+    if v != n:
+        fail("slots=" + str(n) + " should still emit maxItems=" + str(n) + ", got " + repr(v))
+
+# ── 4. upstream's own no-constraint contract is untouched ─────────────────
+for sentinel in (None, -1):
+    v = max_items(sentinel)
+    if v is not None:
+        fail("max_creates=" + repr(sentinel) + " must stay unconstrained, got maxItems=" + repr(v))
+print("MAXITEMS_UNCONSTRAINED", json.dumps([max_items(None), max_items(-1)]))
+
+# ── 5. omitting maxItems must not change anything else about the field ────
+# Same shape as the unconstrained model, so the only delta is the cap.
+base = _build_response_model(max_creates=None).model_json_schema()["properties"]["creates"]
+prod_schema = creates_schema(PRODUCTION_SLOTS)
+print("SCHEMA_PRODUCTION", json.dumps(prod_schema, sort_keys=True))
+if {k: v for k, v in prod_schema.items() if k != "title"} != {
+    k: v for k, v in base.items() if k != "title"
+}:
+    fail(
+        "the unconstrained-above-ceiling schema differs from the unconstrained one "
+        "by more than maxItems: " + json.dumps(prod_schema, sort_keys=True)
+    )
+
+# ── 6. the cap is still ENFORCED in Python, which is why omitting is safe ─
+import inspect
+import hindsight_api.engine.consolidation.consolidator as _c
+
+src = inspect.getsource(_c)
+enforced = "creates = creates[:remaining_observation_slots]" in src
+print("PYTHON_TRUNCATION_PRESENT", enforced)
+if not enforced:
+    fail(
+        "consolidator.py no longer truncates creates to remaining_observation_slots — "
+        "without it, omitting maxItems would DROP the observation cap"
+    )
+
+print("FAILURES", failures)
+print("PROBE_EXECUTED")
+sys.exit(1 if failures else 0)
+`;
+
+function hasDocker(): boolean {
+  try {
+    execSync("docker version --format '{{.Server.Version}}'", {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasImage(ref: string): boolean {
+  try {
+    execSync(`docker image inspect ${ref}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * CI marker. When set, this suite MUST really execute — an absent docker or
+ * an absent upstream image becomes a hard failure instead of a green skip.
+ * `.github/workflows/docker-e2e.yml` sets it after pulling the pinned digest.
+ */
+const REQUIRED = process.env.SWITCHROOM_REQUIRE_HINDSIGHT_PROBE === "1";
+
+const dockerOk = hasDocker();
+const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
+
+type ProbeResult = { status: number; stdout: string };
+
+/** Run the probe in a throwaway container, optionally patching first. */
+function runProbe(patched: boolean): ProbeResult {
+  const name = `sr-hs-maxitems-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
+    0,
+    8,
+  )}`;
+  try {
+    execFileSync(
+      "docker",
+      [
+        "run",
+        "-d",
+        "--name",
+        name,
+        "--label",
+        `switchroom.test=${TEST_PHASE}`,
+        "--label",
+        `switchroom.test.run=${RUN_ID}`,
+        "--user",
+        "root",
+        "--network",
+        "none",
+        UPSTREAM_IMAGE,
+        "sleep",
+        "300",
+      ],
+      { stdio: ["ignore", "ignore", "pipe"] },
+    );
+
+    if (patched) {
+      for (const block of patchBlocks()) {
+        // The block is self-verifying: it asserts its upstream anchor exists
+        // exactly once and re-asserts the result, so a non-zero exit here means
+        // upstream drifted and the patch must be re-authored.
+        execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
+          input: block,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      }
+    }
+
+    const res = execFileSync(
+      "docker",
+      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
+      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
+    );
+    return { status: 0, stdout: res };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: Buffer | string };
+    return {
+      status: err.status ?? -1,
+      stdout: (err.stdout ?? "").toString(),
+    };
+  } finally {
+    try {
+      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+describe("Dockerfile.hindsight maxItems-grammar probe is real, not a silent skip", () => {
+  it("pins the upstream image by digest so the probe tests the exact shipping bytes", () => {
+    expect(UPSTREAM_IMAGE).toMatch(/@sha256:[0-9a-f]{64}$/);
+  });
+
+  it("extracts exactly the one patch block it claims to prove", () => {
+    expect(patchBlocks()).toHaveLength(1);
+  });
+
+  it("hard-fails rather than skipping when CI demands a real run", () => {
+    if (!REQUIRED) {
+      // Local/dev path: skipping is legitimate (never pull a 6.4GB image onto
+      // a dev box), but it must be visible rather than silent.
+      expect(
+        REQUIRED,
+        "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE is unset — the behavioural probe " +
+          "is advisory here. CI's hindsight-probe job sets it after pulling " +
+          `${UPSTREAM_IMAGE}.`,
+      ).toBe(false);
+      return;
+    }
+    expect(
+      dockerOk,
+      "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but the docker daemon is unreachable",
+    ).toBe(true);
+    expect(
+      imageOk,
+      `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but ${UPSTREAM_IMAGE} is not present ` +
+        "locally — the workflow must pull the pinned digest before running this suite",
+    ).toBe(true);
+  });
+});
+
+describe.skipIf(!dockerOk || !imageOk)(
+  "Dockerfile.hindsight consolidation-maxItems-grammar patch changes real behaviour",
+  () => {
+    afterAll(() => {
+      // Label-scoped teardown belt (never an unlabelled bulk removal).
+      try {
+        const ids = execSync(
+          `docker ps -aq --filter label=switchroom.test.run=${RUN_ID}`,
+          { encoding: "utf8" },
+        )
+          .split("\n")
+          .filter(Boolean);
+        if (ids.length) {
+          execFileSync("docker", ["rm", "-f", ...ids], { stdio: "ignore" });
+        }
+      } catch {
+        /* nothing to clean */
+      }
+    });
+
+    it("unpatched upstream is RED — the schema carries the bank's raw slot count", () => {
+      const { status, stdout } = runProbe(false);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED",
+      );
+      expect(status, `probe unexpectedly passed:\n${stdout}`).not.toBe(0);
+
+      // The defect, driven: the emitted schema states maxItems: 4230, which is
+      // exactly what a local GBNF backend refuses to compile.
+      expect(stdout).toContain("MAXITEMS_PRODUCTION 4230");
+      expect(stdout).toContain(
+        'MAXITEMS_BAND {"673": 673, "1000": 1000, "4223": 4223, "4230": 4230, "100000": 100000}',
+      );
+      // Upstream is already correct on the tight and unconstrained cases, so
+      // those are NOT what makes this run red — the large band is.
+      expect(stdout).toContain(
+        'MAXITEMS_TIGHT {"0": 0, "1": 1, "2": 2, "6": 6, "64": 64}',
+      );
+      expect(stdout).toContain("MAXITEMS_UNCONSTRAINED [null, null]");
+      // And upstream already enforces the cap in Python, which is the premise
+      // that makes dropping the schema hint safe.
+      expect(stdout).toContain("PYTHON_TRUNCATION_PRESENT True");
+    }, 240_000);
+
+    it("upstream + the baked patch block is GREEN — maxItems is absent above the ceiling", () => {
+      const { status, stdout } = runProbe(true);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED",
+      );
+      expect(status, `probe failed:\n${stdout}`).toBe(0);
+      expect(stdout).toContain("FAILURES []");
+
+      // 1./2. no uncompilable repetition count survives, anywhere in the band.
+      expect(stdout).toContain("MAXITEMS_PRODUCTION null");
+      expect(stdout).toContain(
+        'MAXITEMS_BAND {"673": null, "1000": null, "4223": null, "4230": null, "100000": null}',
+      );
+      // 3. a cap that is genuinely tight is still stated to the model, so this
+      // is an omission of a non-binding guard rather than a blanket removal.
+      expect(stdout).toContain(
+        'MAXITEMS_TIGHT {"0": 0, "1": 1, "2": 2, "6": 6, "64": 64}',
+      );
+      // 4. upstream's None/-1 contract is untouched.
+      expect(stdout).toContain("MAXITEMS_UNCONSTRAINED [null, null]");
+      // 5. the field is otherwise byte-identical to the unconstrained one — the
+      // patch drops a cap, it does not reshape the schema.
+      expect(stdout).toContain(
+        'SCHEMA_PRODUCTION {"default": [], "items": {"$ref": "#/$defs/_CreateAction"}, "title": "Creates", "type": "array"}',
+      );
+      expect(stdout).not.toContain('"maxItems"');
+      // 6. and the cap is still really enforced, after validation, in Python.
+      expect(stdout).toContain("PYTHON_TRUNCATION_PRESENT True");
+    }, 240_000);
+  },
+);


### PR DESCRIPTION
## What's wrong

`_build_response_model()` (`engine/consolidation/consolidator.py`) constrains the `creates` field with `PydanticField(default=[], max_length=clamped)`, which pydantic serialises into the request's JSON schema as `"maxItems": <clamped>`. Its one caller passes `max_creates=remaining_observation_slots` — the bank's **remaining observation-slot count**, not a modelling constraint.

Measured against the running `switchroom-hindsight` container (2026-07-28):

```
$ _build_response_model(max_creates=4230).model_json_schema()["properties"]["creates"]
{"default": [], "items": {"$ref": "#/$defs/_CreateAction"}, "maxItems": 4230, "title": "Creates", "type": "array"}
```

llama.cpp/Ollama compile that schema into a GBNF grammar, and a repetition count that large fails to build. The local consolidation deployment answers:

```
HTTP 400 {"error":{"code":400,"message":"Failed to initialize samplers: failed to parse grammar","type":"invalid_request_error"}}
```

LiteLLM's router-level fallback then re-sends the **identical call** — batch prompt and all, carrying verbatim private corpus text — to the metered OpenRouter deployment. 56 such fallbacks are visible in the proxy log for `Received Model Group=gpt-oss-20b-consolidation`. It is deterministic per bank: a bank with ~4,230 remaining slots fails every time; a bank with ~670 compiles fine (threshold measured between 672 and 4,223).

## The approach, and why this one

**Omit `maxItems` above a small ceiling (64) rather than clamp to it.**

Clamping was the other candidate. It was rejected because it only *moves* the threshold — it keeps the class of bug alive for whatever repetition count the next backend chokes on — and because it asserts a bound that is not true.

Omitting costs nothing, and that is verified rather than assumed:

- The cap is a **resource guard, not a modelling constraint**. `CONSOLIDATION_LLM_BATCH_SIZE=6`, so one batch sees 6 memories and can never approach 4,230. Above a small ceiling the constraint cannot bind.
- **The cap is already enforced in Python after validation, independent of the schema.** consolidator.py's own "Defensive truncation: some LLM providers may not enforce JSON schema max_length" trims `creates` to `remaining_observation_slots`. The patch block asserts that truncation is still present at build time — if upstream ever removes it, the build fails loudly rather than silently uncapping observations.
- **When the cap is genuinely tight the model is also told in prose**, via the `observation_capacity_note` branch that fires whenever `remaining_observation_slots <= len(memories)`.

So `maxItems` is now either a binding truth (`<= 64`, which compiles trivially — ~10x below the measured failure threshold) or absent. Upstream's `None` / negative no-constraint contract is untouched.

**Out of scope, deliberately:** the LiteLLM fallback rule is not touched. Removing it before this fix lands would convert a leak into hard consolidation failures.

## The diff

- `docker/Dockerfile.hindsight` — a new self-verifying `RUN python3` patch block (exact-once anchors, post-splice re-assertions, `ast.parse` on the result) that introduces `SWITCHROOM_MAX_CREATES_SCHEMA_CEILING = 64` and an early return above it.
- `tests/docker/hindsight-maxitems-grammar-patch.test.ts` — the behavioural RED/GREEN probe (new).
- `tests/docker/dockerfile-hindsight-bakes.test.ts` — structural guard for the new block.
- `.github/workflows/docker-e2e.yml` — the new probe added to the `hindsight` path filter, a `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1` step, and the label-scoped teardown loop.

## The test, and what it would have caught

`tests/docker/hindsight-maxitems-grammar-patch.test.ts` applies this Dockerfile block to the digest-pinned upstream image and **serialises the real model**, asserting the `maxItems` pydantic actually emits — not that a code path ran.

It is RED against unpatched upstream and GREEN patched, both verified locally:

```
✓ unpatched upstream is RED — the schema carries the bank's raw slot count  3358ms
✓ upstream + the baked patch block is GREEN — maxItems is absent above the ceiling  2476ms
```

RED run output (the defect, driven):

```
MAXITEMS_PRODUCTION 4230
MAXITEMS_BAND {"673": 673, "1000": 1000, "4223": 4223, "4230": 4230, "100000": 100000}
```

GREEN run: `MAXITEMS_PRODUCTION null`, every band entry `null`, and `SCHEMA_PRODUCTION` byte-identical to the unconstrained schema so the patch is proven to drop a cap rather than reshape the field.

It also pins the properties that make the fix *safe*, so a future "simplification" cannot quietly break them:

- a tight cap is **still** emitted — `MAXITEMS_TIGHT {"0": 0, "1": 1, "2": 2, "6": 6, "64": 64}`
- upstream's `None` / `-1` contract is unchanged
- `PYTHON_TRUNCATION_PRESENT True` — the post-validation truncation that makes omission safe still exists

The grep-based bakes test could not have caught this class of regression: its assertions are unanchored substring matches, so raising the ceiling to `100_000` or reinstating a four-digit clamp keeps every literal green while the schema is uncompilable again. Only reading the emitted number catches it.

## Test plan

- [x] `npx vitest run tests/docker/dockerfile-hindsight-bakes.test.ts tests/docker/hindsight-maxitems-grammar-patch.test.ts` — 35/35 pass, including both RED and GREEN probe legs against the pinned digest.
- [x] All **10** `RUN python3` patch blocks applied sequentially to the pinned image in Dockerfile order — every one succeeds, mine last; resulting module emits `None / -1 / 65 / 673 / 4230 → no maxItems`, `0 / 2 / 6 / 64 → 0 / 2 / 6 / 64`.
- [x] `npx vitest run tests/ci-merge-queue-triggers.test.ts tests/ci-buildx-warm-pull.test.ts tests/ci-python-path-filter.test.ts` — 66/66 pass.
- [x] `bun run lint` — clean (exit 0).

No deploy/restart performed; rollout is a separate decision.