### PR TITLE
Make the hindsight retain lane's reserved slot floor settable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,17 @@ on this fleet rather than from theory.
   — no error, no warning. This one was outside it, so an operator's measured
   `16` sat in `switchroom.yaml` for a full day while the container booted
   upstream's default `10`.
+- **The `retain` lane can be given a reserved floor (#3907).** Same silent drop,
+  the other side of the same slot policy:
+  `HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS` was outside the managed key set, so an
+  operator could not reserve any worker slots for memory writes. Upstream
+  defaults that floor to `0`, and switchroom is the reason that matters —
+  consolidation is the one lane switchroom widens (ceiling raised to 6) and the
+  one that holds a slot longest, while retain, the write path, holds no floor at
+  all. The reference fleet's poller boots
+  `reservations=[consolidation=5], shared_pool=11` with `retain` absent
+  entirely. Now settable; still unset by default, so nothing moves for anyone
+  who does not ask for it.
 - **One malformed queue entry no longer kills the whole drain (#3894).** Phase 0
   of the pending-retain drain raised on a non-numeric `attempt_count` and took
   phases 1 and 2 down with it, making the *entire* backlog immortal — fleet-wide

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2525,7 +2525,11 @@ export const HindsightConfigSchema = z.object({
       "still honours an operator who flips the function back; and " +
       "HINDSIGHT_API_WORKER_MAX_SLOTS — the worker poller's TOTAL in-flight " +
       "task budget, the pool WORKER_CONSOLIDATION_MAX_SLOTS reserves out of; " +
-      "unset means upstream's own default), plus the " +
+      "unset means upstream's own default; and " +
+      "HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS — the reserved slot FLOOR for the " +
+      "retain (memory write) lane, carved from that same total; unset means " +
+      "upstream's own 0, i.e. no floor and retain competes for the shared " +
+      "pool), plus the " +
       "embedded-PostgreSQL (pg0) sizing keys switchroom manages in " +
       "src/setup/hindsight-pg-defaults.ts (`HINDSIGHT_PG_ENV_KEYS`: " +
       "SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE, " +

--- a/src/setup/hindsight-perf-defaults.test.ts
+++ b/src/setup/hindsight-perf-defaults.test.ts
@@ -329,7 +329,7 @@ describe("operator override wins", () => {
     expect(got.size).toBe(0);
   });
 
-  it("is overridable on exactly these twenty-seven keys, by name", () => {
+  it("is overridable on exactly these twenty-eight keys, by name", () => {
     // Spelled out, NOT derived from the three group arrays. HINDSIGHT_PERF_ENV_KEYS
     // is DEFINED as the union of those arrays, so asserting it equals that union
     // is a tautology — it passes no matter which keys are in the arrays. The
@@ -363,6 +363,7 @@ describe("operator override wins", () => {
       "HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS",
       "HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT",
       "HINDSIGHT_API_WORKER_MAX_SLOTS",
+      "HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS",
       // Not HINDSIGHT_API_* — a switchroom-patch knob (the CE-damping
       // rollback hatch), read by the patched reranking module, never by
       // upstream's config parser. Sorts last.
@@ -521,6 +522,91 @@ describe("HINDSIGHT_API_WORKER_MAX_SLOTS (override-only)", () => {
     startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false, perf);
     const fromRun = runEnv(runArgs());
     expect(fromRun.get(KEY)).toEqual(["16"]);
+    expect(fromRun.get("HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS")).toEqual(["5"]);
+    expect(fromRun.get("HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT")).toEqual(["6"]);
+  });
+});
+
+describe("HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS (override-only)", () => {
+  const KEY = "HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS";
+  const CAPS = [
+    { gpu: false, localLlm: false },
+    { gpu: true, localLlm: false },
+    { gpu: false, localLlm: true },
+    { gpu: true, localLlm: true },
+  ];
+
+  it("is in the managed set but in NO defaults group", () => {
+    expect(HINDSIGHT_PERF_ENV_KEYS.has(KEY)).toBe(true);
+    expect(HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS.has(KEY)).toBe(true);
+    for (const group of [
+      HINDSIGHT_PERF_DEFAULTS_UNGATED,
+      HINDSIGHT_PERF_DEFAULTS_GPU,
+      HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM,
+    ]) {
+      expect(group.map(([k]) => k)).not.toContain(KEY);
+    }
+  });
+
+  it("survives resolveHindsightPerfOverrides from BOTH sources", () => {
+    expect(resolveHindsightPerfOverrides({ [KEY]: "2" }).get(KEY)).toBe("2");
+    expect(resolveHindsightPerfOverrides(undefined, { [KEY]: "2" }).get(KEY)).toBe("2");
+  });
+
+  it.each(CAPS)(
+    "is NOT emitted when unset (gpu=$gpu localLlm=$localLlm) — upstream's own 0 stands",
+    (caps) => {
+      // No floor is upstream's default and switchroom ships no opinion on the
+      // slot budget a floor would be carved from. Emitting anything here would
+      // move every install off `retain: 0` for no measured reason.
+      expect(hindsightPerfEnv(caps).map(([k]) => k)).not.toContain(KEY);
+    },
+  );
+
+  it("reaches BOTH launch paths, with the operator's value, when set in hindsight.env", () => {
+    // The outcome that matters. Without the key in the managed set both of
+    // these are undefined — `resolveHindsightPerfOverrides` drops an unmanaged
+    // key silently, so the operator's line reads as durable config in yaml and
+    // never reaches the container. Membership alone would not catch a
+    // gate-shaped regression on the emit side, so assert the launch argv.
+    const perf = { env: { [KEY]: "2" }, processEnv: {} };
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false, perf);
+    const fromRun = runEnv(runArgs());
+    const fromCompose = composeEnv(
+      generateHindsightComposeSnippet(undefined, undefined, LOOPBACK_LITELLM, false, perf),
+    );
+    expect(fromRun.get(KEY)).toEqual(["2"]);
+    expect(fromCompose.get(KEY)).toEqual(["2"]);
+  });
+
+  it("still reaches the container on a host with NO gated capability", () => {
+    // It belongs to no capability group, so a gate-shaped regression that only
+    // emits grouped keys would drop it. Cloud endpoint + no GPU is the harshest
+    // gating case.
+    const perf = { env: { [KEY]: "2" }, processEnv: {} };
+    startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, false, perf);
+    expect(runEnv(runArgs()).get(KEY)).toEqual(["2"]);
+  });
+
+  it("carries the whole slot policy — total, both reservations, and the ceiling", () => {
+    // The retain floor is only meaningful against the total it is carved from
+    // and the consolidation terms it competes with. All four reach the
+    // container together, or an operator sets a coherent policy and loses part
+    // of it silently. Upstream validates the combination at boot; it can only
+    // do that for the terms it is actually handed.
+    const perf = {
+      env: {
+        [KEY]: "2",
+        HINDSIGHT_API_WORKER_MAX_SLOTS: "16",
+        HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS: "5",
+        HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT: "6",
+      },
+      processEnv: {},
+    };
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false, perf);
+    const fromRun = runEnv(runArgs());
+    expect(fromRun.get(KEY)).toEqual(["2"]);
+    expect(fromRun.get("HINDSIGHT_API_WORKER_MAX_SLOTS")).toEqual(["16"]);
     expect(fromRun.get("HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS")).toEqual(["5"]);
     expect(fromRun.get("HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT")).toEqual(["6"]);
   });

--- a/src/setup/hindsight-perf-defaults.ts
+++ b/src/setup/hindsight-perf-defaults.ts
@@ -983,12 +983,61 @@ export const HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM: ReadonlyArray<readonly [string, 
  * (reservations must sum to <= this, and the consolidation ceiling must sit
  * between the reservation and this), so an incoherent combination fails loudly
  * in the container rather than silently here.
+ *
+ * ### `HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS`
+ *
+ * The reserved slot FLOOR for the `retain` lane — the same slot policy as the
+ * key above, from the other side. Upstream's `WORKER_SLOT_RESERVATION_TYPES`
+ * (`config.py`) gives `retain` a default of **0**, i.e. no floor at all: every
+ * retain competes for the shared pool that is left after the reservations are
+ * carved out.
+ *
+ * That asymmetry is switchroom's own doing. Consolidation is the one lane
+ * switchroom deliberately widens — {@link
+ * HINDSIGHT_DEFAULT_CONSOLIDATION_SLOT_LIMIT} raises its ceiling to 6 — and it
+ * is the lane that holds a slot longest, because a round runs up to {@link
+ * HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND} memories through an
+ * LLM. Retain is the lane that must not wait: it is the write path, and the
+ * agent-side queue in front of it (`pending-retains`) is bounded and evicts
+ * under pressure. Widening the slowest lane's ceiling while the write lane
+ * holds no floor is the wrong shape, and the reference fleet is running exactly
+ * that — the poller's own boot line on 2026-07-28 reads:
+ *
+ * ```
+ * starting polling loop (max_slots=16, reservations=[consolidation=5],
+ *   shared_pool=11, ceilings=[consolidation<=6])
+ * ```
+ *
+ * `retain` does not appear in `reservations` because its floor is 0. An
+ * operator who wants one has no way to say so: the key is outside {@link
+ * HINDSIGHT_PERF_ENV_KEYS}, so a `hindsight.env` line for it is discarded by
+ * `resolveHindsightPerfOverrides` with no error and no warning — the same
+ * silent drop that cost `HINDSIGHT_API_WORKER_MAX_SLOTS` a full day above.
+ *
+ * ```yaml
+ * hindsight:
+ *   env:
+ *     HINDSIGHT_API_WORKER_MAX_SLOTS: 16
+ *     HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS: 2
+ * ```
+ *
+ * Override-only rather than defaulted for the same reason as the four above:
+ * only the operator knows their slot budget, and a floor is only meaningful
+ * against a total switchroom deliberately ships no opinion on — emitting a
+ * number here would move every install off upstream's 0 for no measured
+ * reason. Unset ⇒ upstream's 0 ⇒ no behaviour change. And as with
+ * `WORKER_MAX_SLOTS`, upstream validates the whole slot policy at boot
+ * (reservations must sum to <= `WORKER_MAX_SLOTS`, and a type's ceiling — where
+ * one is set at all — must sit between that type's own reservation and
+ * `WORKER_MAX_SLOTS`), so an incoherent combination fails loudly in the
+ * container rather than silently here.
  */
 export const HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS: ReadonlySet<string> = new Set([
   "HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY",
   "HINDSIGHT_CE_DECISIVE_RELATIVE_GAP",
   "HINDSIGHT_API_RECENCY_DECAY_LINEAR_WINDOW_DAYS",
   "HINDSIGHT_API_WORKER_MAX_SLOTS",
+  "HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS",
 ]);
 
 /**


### PR DESCRIPTION
## Summary

Adds `HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS` to `HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS`, so an operator can reserve a floor of worker slots for the `retain` lane from `hindsight.env`. Override-only, following `HINDSIGHT_API_WORKER_MAX_SLOTS` (#3901) exactly: no shipped default, so unset means upstream's own `0` and nothing changes for anyone who does not set it.

## Why

Verified in the running engine, not inferred. `WORKER_SLOT_RESERVATION_TYPES` in the container's own `/app/api/hindsight_api/config.py:644` reads:

```python
"retain": ("HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS", 0),
```

and the poller's boot line on this fleet (2026-07-28) confirms the effect:

```
starting polling loop (max_slots=16, reservations=[consolidation=5],
  shared_pool=11, ceilings=[consolidation<=6])
```

`retain` is absent from `reservations` because its floor is `0` — every memory write competes for the shared pool.

An operator could not change that. The key was outside `HINDSIGHT_PERF_ENV_KEYS`, and `resolveHindsightPerfOverrides` does `if (!HINDSIGHT_PERF_ENV_KEYS.has(key)) continue;` (`src/setup/hindsight-perf-defaults.ts:1037`) — a `hindsight.env` line for it is discarded with no error and no warning. That is the same silent-drop defect documented in that file around L520 and, for `HINDSIGHT_API_WORKER_MAX_SLOTS`, at L954-991.

It matters here specifically because of switchroom's own choices: consolidation is the one lane switchroom deliberately widens (`HINDSIGHT_DEFAULT_CONSOLIDATION_SLOT_LIMIT` = 6 against upstream's 4) and the one that holds a slot longest, since a round runs up to 500 memories through an LLM. Retain is the write path, with a bounded, evicting agent-side queue (`pending-retains`) in front of it. Widening the slowest lane's ceiling while the write lane holds no floor is the wrong shape.

Upstream validates the whole slot policy at boot (`config.py:2486-2517`): reservations must sum to `<= worker_max_slots`, and a per-type ceiling, where one is set, must sit between that type's own reservation and `worker_max_slots`. So an incoherent combination raises in the container rather than mis-scheduling silently.

## Scope note on the motivation

The task that prompted this cited discarded memories on the live fleet. I could not corroborate that specific claim and have not written it into the code or the CHANGELOG. On this host the eviction ledger (`pending-evictions.log`) contains only `reason=archive-count archive=pending-reconciled` lines — trims of archived copies of *already-reconciled* retains, which is not memory loss — and the residual-drop ledger (`record_drop` in `vendor/hindsight-memory/scripts/lib/pending.py`) does not exist, i.e. zero permanently-dropped retains. The motivation as written is the one the evidence supports: the retain lane has no floor and no way for an operator to give it one.

## Test plan

`src/setup/hindsight-perf-defaults.test.ts`, following the existing `HINDSIGHT_API_WORKER_MAX_SLOTS` block:

- the operator's value reaches the emitted container env on **both** launch paths — the `docker run` argv (`startHindsight`) and the compose snippet (`generateHindsightComposeSnippet`)
- it still reaches the argv on a host with no gated capability (cloud endpoint, no GPU), since the key belongs to no defaults group
- **nothing is emitted when unset**, on all four capability combinations, so upstream's `0` stands
- the key is in the managed set and in no defaults group; it survives `resolveHindsightPerfOverrides` from both `hindsight.env` and the process env
- the whole slot policy (total, both reservations, the consolidation ceiling) reaches the container together

Mutation-checked: deleting the key from `HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS` fails 6 tests, including the by-name key-list contract and both launch-path assertions.

Local: `vitest run src/setup/hindsight-perf-defaults.test.ts tests/hindsight-env-keys-are-reachable.test.ts tests/docker/` → 583 passed, 33 skipped. `npm run lint` clean.

## Risk

Low. No shipped default, so the emitted container env is byte-identical for any install that does not set the key. The only behaviour change is that a key an operator writes is now honoured instead of dropped. `src/config/schema.ts`'s `hindsight.env` description is updated because it is the documented override contract and is pinned by the by-name key-list test.

## Job spec

`reference/jobs/remember-across-sessions.md` — the outcome depends on retains actually landing; this makes the write lane's slot floor an operator-reachable knob instead of an unchangeable upstream `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)