### PR TITLE
chore: release v0.19.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.19.29 — a shared bank can actually be shared, and the retain lane can hold a floor
 
 ### Agents sharing a bank can pool their observations, instead of siloing them per tag
 
@@ -73,6 +73,21 @@ stop a retain, does not reach `switchroom doctor`, and on the retain path is
 visible only as hook stderr. The design point is that it cannot destroy
 anything — `apply` is where a typo is meant to die.
 
+### The `retain` lane can be given a reserved worker-slot floor
+
+- **`HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS` is now settable (#3907).** The same
+  silent drop as `HINDSIGHT_API_WORKER_MAX_SLOTS` (#3901), on the other side of
+  the same slot policy: the key sat outside the managed key set, so a
+  `hindsight.env` line for it was discarded with no error and no warning and an
+  operator could not reserve any worker slots for memory writes. Upstream
+  defaults that floor to `0`, and switchroom is the reason that matters —
+  consolidation is the one lane switchroom widens (ceiling raised to 6) and the
+  one that holds a slot longest, while retain, the write path, holds no floor at
+  all. The reference fleet's poller boots
+  `reservations=[consolidation=5], shared_pool=11` with `retain` absent
+  entirely. Now settable; still unset by default, so nothing moves for anyone
+  who does not ask for it.
+
 ## v0.19.28 — private memories can no longer be shipped to a paid outside provider by accident
 
 **The headline, in plain language.** Every agent's memories are meant to be
@@ -141,17 +156,6 @@ on this fleet rather than from theory.
   — no error, no warning. This one was outside it, so an operator's measured
   `16` sat in `switchroom.yaml` for a full day while the container booted
   upstream's default `10`.
-- **The `retain` lane can be given a reserved floor (#3907).** Same silent drop,
-  the other side of the same slot policy:
-  `HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS` was outside the managed key set, so an
-  operator could not reserve any worker slots for memory writes. Upstream
-  defaults that floor to `0`, and switchroom is the reason that matters —
-  consolidation is the one lane switchroom widens (ceiling raised to 6) and the
-  one that holds a slot longest, while retain, the write path, holds no floor at
-  all. The reference fleet's poller boots
-  `reservations=[consolidation=5], shared_pool=11` with `retain` absent
-  entirely. Now settable; still unset by default, so nothing moves for anyone
-  who does not ask for it.
 - **One malformed queue entry no longer kills the whole drain (#3894).** Phase 0
   of the pending-retain drain raised on a non-numeric `attempt_count` and took
   phases 1 and 2 down with it, making the *entire* backlog immortal — fleet-wide


### PR DESCRIPTION
Release commit for **v0.19.29**. CHANGELOG.md only — no `package.json` bump (placeholder discipline).

- Consolidates the `## Unreleased` section (from #3908) under `## v0.19.29`.
- Moves the #3907 entry out of the already-shipped `## v0.19.28` section, where the PR misfiled it, into this release's notes. That section's own "Five fixes" intro is correct again.

In range `v0.19.28..main`:
- #3908 feat(memory): plumb per-row observation_scopes through every retain path
- #3907 feat(hindsight): make the retain lane's reserved slot floor settable

🤖 Generated with [Claude Code](https://claude.com/claude-code)