### PR TITLE
fix(update): update EVERY switchroom component — self-update the host CLI first, fix the stranded autoheal sidecar, report drift deterministically

### DIFF
--- a/src/cli/component-versions.test.ts
+++ b/src/cli/component-versions.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  collectComponents,
+  collectContainerComponents,
+  detectComponentDrift,
+  formatComponentDrift,
+  isSwitchroomReleaseImage,
+  resolveDriftTarget,
+  versionFromImageRef,
+  type ExecFn,
+} from "./component-versions.js";
+
+/**
+ * The exact `docker ps` output from the operator host on 2026-07-29,
+ * trimmed to the switchroom containers. This is the state that motivated
+ * #3919: fleet + hostd on v0.19.28, web + the autoheal sidecar stranded
+ * on v0.19.26, and (separately) the host CLI on 0.19.23.
+ */
+const REFERENCE_HOST_PS = [
+  "switchroom-hindsight\tghcr.io/switchroom/switchroom-hindsight:v0.19.28",
+  "switchroom-klanker\tghcr.io/switchroom/switchroom-agent:v0.19.28",
+  "switchroom-test-harness\tghcr.io/switchroom/switchroom-agent:v0.19.28",
+  "switchroom-voice-sidecar\tghcr.io/switchroom/switchroom-voice:v0.19.28",
+  "switchroom-auth-broker\tghcr.io/switchroom/switchroom-auth-broker:v0.19.28",
+  "switchroom-approval-kernel\tghcr.io/switchroom/switchroom-kernel:v0.19.28",
+  "switchroom-vault-broker\tghcr.io/switchroom/switchroom-broker:v0.19.28",
+  "switchroom-hostd\tghcr.io/switchroom/switchroom-hostd:v0.19.28",
+  "switchroom-hindsight-autoheal\tghcr.io/switchroom/switchroom-hostd:v0.19.26",
+  "switchroom-web\tghcr.io/switchroom/switchroom-web:v0.19.26",
+  "switchroom-hostd-docker-proxy\tghcr.io/tecnativa/docker-socket-proxy:v0.4.2",
+  "switchroom-grafana-fwd\talpine/socat",
+  "switchroom-uat-runner\tswitchroom-uat-runner:local",
+].join("\n");
+
+const execOk = (stdout: string): ExecFn => () => ({ status: 0, stdout });
+
+describe("versionFromImageRef", () => {
+  it("reads a vX.Y.Z tag", () => {
+    expect(
+      versionFromImageRef("ghcr.io/switchroom/switchroom-web:v0.19.26").version,
+    ).toBe("v0.19.26");
+  });
+
+  it("reports a floating tag as uncomparable rather than dropping it", () => {
+    const r = versionFromImageRef("ghcr.io/switchroom/switchroom-hostd:latest");
+    expect(r.version).toBeNull();
+    expect(r.detail).toContain("latest");
+  });
+
+  it("does not mistake a registry port for a tag", () => {
+    expect(
+      versionFromImageRef("registry.example.com:5000/switchroom-web:v1.2.3")
+        .version,
+    ).toBe("v1.2.3");
+  });
+
+  it("ignores a digest suffix", () => {
+    expect(
+      versionFromImageRef(
+        "ghcr.io/switchroom/switchroom-web:v1.2.3@sha256:" + "a".repeat(64),
+      ).version,
+    ).toBe("v1.2.3");
+  });
+});
+
+describe("isSwitchroomReleaseImage", () => {
+  it("excludes the third-party docker-socket-proxy despite the switchroom- name", () => {
+    expect(
+      isSwitchroomReleaseImage(
+        "switchroom-hostd-docker-proxy",
+        "ghcr.io/tecnativa/docker-socket-proxy:v0.4.2",
+      ),
+    ).toBe(false);
+  });
+
+  it("includes a component that did not exist when this code was written", () => {
+    expect(
+      isSwitchroomReleaseImage(
+        "switchroom-brand-new-thing",
+        "ghcr.io/switchroom/switchroom-brand-new-thing:v9.9.9",
+      ),
+    ).toBe(true);
+  });
+
+  it("includes the hindsight singleton — it IS release-tagged", () => {
+    // Regression: an earlier draft excluded it by name on the assumption
+    // that hindsight was versioned upstream. The live host disagrees, and
+    // excluding it would hide exactly the drift this module exists to find.
+    expect(
+      isSwitchroomReleaseImage(
+        "switchroom-hindsight",
+        "ghcr.io/switchroom/switchroom-hindsight:v0.19.28",
+      ),
+    ).toBe(true);
+  });
+
+  it("excludes third-party and locally-built images under switchroom- names", () => {
+    expect(isSwitchroomReleaseImage("switchroom-grafana-fwd", "alpine/socat")).toBe(
+      false,
+    );
+    expect(
+      isSwitchroomReleaseImage("switchroom-uat-runner", "switchroom-uat-runner:local"),
+    ).toBe(false);
+  });
+});
+
+describe("detectComponentDrift — the reference-host regression", () => {
+  it("names EVERY stale component, including the autoheal sidecar and the host CLI", () => {
+    const components = collectComponents(
+      "0.19.23", // the host CLI at the time
+      execOk(REFERENCE_HOST_PS),
+    );
+    const report = detectComponentDrift(components, "v0.19.28");
+
+    const behind = report.behind.map((c) => c.name).sort();
+    expect(behind).toEqual([
+      "cli (host)",
+      "switchroom-hindsight-autoheal",
+      "switchroom-web",
+    ]);
+    expect(report.target).toBe("v0.19.28");
+    expect(report.targetSource).toBe("release.pin");
+    expect(report.ahead).toEqual([]);
+    // The proxy is excluded, not reported as unknown noise.
+    const all = [...report.unknown, ...report.current, ...report.behind].map(
+      (c) => c.name,
+    );
+    expect(all).not.toContain("switchroom-hostd-docker-proxy");
+    expect(all).not.toContain("switchroom-grafana-fwd");
+    expect(all).not.toContain("switchroom-uat-runner");
+    // …but the hindsight singleton IS a release-tagged component.
+    expect(report.current.map((c) => c.name)).toContain("switchroom-hindsight");
+    // And the converged components are accounted for, not silently dropped.
+    expect(report.current.map((c) => c.name)).toContain("switchroom-hostd");
+    expect(report.current.map((c) => c.name)).toContain("switchroom-klanker");
+  });
+
+  it("renders the stale components in the operator summary", () => {
+    const report = detectComponentDrift(
+      collectComponents("0.19.23", execOk(REFERENCE_HOST_PS)),
+      "v0.19.28",
+    );
+    const text = formatComponentDrift(report);
+    expect(text).toContain("BEHIND   switchroom-web — v0.19.26");
+    expect(text).toContain("BEHIND   switchroom-hindsight-autoheal — v0.19.26");
+    expect(text).toContain("BEHIND   cli (host) — v0.19.23");
+  });
+
+  it("reports NOTHING behind once every component is on the pin", () => {
+    const converged = REFERENCE_HOST_PS.replace(/v0\.19\.26/g, "v0.19.28");
+    const report = detectComponentDrift(
+      collectComponents("0.19.28", execOk(converged)),
+      "v0.19.28",
+    );
+    expect(report.behind).toEqual([]);
+    expect(report.current.length).toBeGreaterThan(5);
+  });
+});
+
+describe("resolveDriftTarget", () => {
+  it("prefers release.pin — the operator's declared intent", () => {
+    const r = resolveDriftTarget(
+      collectContainerComponents(execOk(REFERENCE_HOST_PS)),
+      "v0.20.0",
+    );
+    expect(r).toEqual({ target: "v0.20.0", targetSource: "release.pin" });
+  });
+
+  it("falls back to the highest deployed version when no pin is set", () => {
+    const r = resolveDriftTarget(
+      collectContainerComponents(execOk(REFERENCE_HOST_PS)),
+      undefined,
+    );
+    expect(r).toEqual({
+      target: "v0.19.28",
+      targetSource: "highest-deployed",
+    });
+  });
+
+  it("still catches the split fleet with no pin at all", () => {
+    const report = detectComponentDrift(
+      collectComponents("0.19.23", execOk(REFERENCE_HOST_PS)),
+      undefined,
+    );
+    expect(report.behind.map((c) => c.name).sort()).toEqual([
+      "cli (host)",
+      "switchroom-hindsight-autoheal",
+      "switchroom-web",
+    ]);
+  });
+
+  it("returns no target when nothing is comparable", () => {
+    expect(resolveDriftTarget([], undefined)).toEqual({
+      target: null,
+      targetSource: "none",
+    });
+  });
+});
+
+describe("collectContainerComponents", () => {
+  it("degrades to an empty inventory when docker is unreachable", () => {
+    expect(collectContainerComponents(() => ({ status: 1, stdout: "" }))).toEqual(
+      [],
+    );
+  });
+
+  it("passes a name-prefix filter rather than hardcoding a component list", () => {
+    let seen: string[] = [];
+    collectContainerComponents((_cmd, args) => {
+      seen = args;
+      return { status: 0, stdout: "" };
+    });
+    expect(seen).toContain("name=switchroom-");
+  });
+});

--- a/src/cli/component-versions.ts
+++ b/src/cli/component-versions.ts
@@ -1,0 +1,310 @@
+/**
+ * Component version inventory + drift detection (#3919).
+ *
+ * WHY THIS EXISTS
+ *
+ * Switchroom is not one artifact. It is a host CLI plus N containerised
+ * components spread across THREE docker compose projects and one
+ * standalone `docker run` container:
+ *
+ *   - `switchroom`        — agent fleet + vault-broker + approval-kernel
+ *                           + auth-broker + voice sidecar
+ *   - `switchroom-hostd`  — hostd daemon, its docker-socket-proxy, and
+ *                           the `hindsight-autoheal` sidecar (#2910)
+ *   - `switchroom-web`    — dashboard / webhook receiver
+ *   - (standalone)        — the hindsight memory singleton
+ *   - (host)              — the operator CLI itself
+ *
+ * Every one of those advances by a DIFFERENT mechanism, and each
+ * mechanism has its own failure mode. In July 2026 the operator host
+ * ran the fleet on v0.19.28 while:
+ *
+ *   - the host CLI was on 0.19.23  (nothing ever updates it — `switchroom
+ *     update` updated everything except itself)
+ *   - `switchroom-web` was on v0.19.26  (`webd install` fails inside the
+ *     hostd container when the hostd compose predates the
+ *     SWITCHROOM_HOSTD_OPERATOR_UID env; the rollout logs it as a
+ *     NON-FATAL warning and carries on)
+ *   - `switchroom-hindsight-autoheal` was on v0.19.26  (the self-bump
+ *     rewrote only the first hostd image line — fixed in this same PR)
+ *
+ * Three unrelated bugs, all with the same signature: a component quietly
+ * left behind. The reason the drift survived three releases is not that
+ * the individual failures were invisible — two of them logged a warning
+ * at the time — it is that NOTHING held a standing, checkable answer to
+ * "is every component on the same version?". A warning scrolls past
+ * once; a deterministic check fires every time you look.
+ *
+ * This module is that check. It is deliberately:
+ *
+ *   - ENUMERATIVE, not hardcoded. The component list comes from `docker
+ *     ps`, so a component added tomorrow is covered without editing a
+ *     list here. (A hardcoded list is how the autoheal sidecar escaped
+ *     notice in the first place.)
+ *   - PURE at the analysis layer. `detectComponentDrift` is string-in /
+ *     verdict-out so it unit-tests without docker.
+ *   - NETWORK-FREE. The target version is resolved from local facts, so
+ *     `doctor` stays fast and offline-safe. Comparing against the latest
+ *     PUBLISHED release is the separate concern of the CLI self-update.
+ */
+
+import { compareReleaseTags } from "../config/release-resolve.js";
+
+/** One switchroom component and the version it is currently running. */
+export interface ComponentVersion {
+  /** Container name (`switchroom-web`) or the literal `"cli (host)"`. */
+  name: string;
+  kind: "cli" | "container";
+  /** `vX.Y.Z`, or null when the ref carries a non-semver tag
+   *  (`:latest`, `:sha-abc1234`, a digest pin) or could not be read. */
+  version: string | null;
+  /** Full image ref, for containers. */
+  imageRef?: string;
+  /** Non-semver tag or probe error, surfaced verbatim to the operator. */
+  detail?: string;
+}
+
+/** Verdict for the whole host. */
+export interface ComponentDriftReport {
+  /** Version everything is expected to be on — see {@link resolveDriftTarget}. */
+  target: string | null;
+  /** How `target` was chosen, for the operator-facing detail line. */
+  targetSource: "release.pin" | "highest-deployed" | "none";
+  /** Components strictly older than `target`. THE finding that matters. */
+  behind: ComponentVersion[];
+  /** Components strictly newer than `target` (mid-roll, or a manual bump). */
+  ahead: ComponentVersion[];
+  /** Components on `target`. */
+  current: ComponentVersion[];
+  /** Components whose version could not be compared (floating tag, probe
+   *  failure). Reported, never silently dropped. */
+  unknown: ComponentVersion[];
+}
+
+/** `vX.Y.Z` — the only tag shape the release comparison understands. */
+const SEMVER_TAG_RE = /^v\d+\.\d+\.\d+$/;
+
+/**
+ * Extract the version tag from an image ref.
+ *
+ * Returns `{ version }` for a `vX.Y.Z` tag and `{ detail }` for anything
+ * else (`:latest`, `:sha-…`, `@sha256:…`) so the caller can report WHY a
+ * component is uncomparable instead of dropping it.
+ */
+export function versionFromImageRef(
+  ref: string,
+): { version: string | null; detail?: string } {
+  const at = ref.indexOf("@");
+  const withoutDigest = at >= 0 ? ref.slice(0, at) : ref;
+  const slash = withoutDigest.lastIndexOf("/");
+  const colon = withoutDigest.indexOf(":", slash + 1);
+  if (colon < 0) {
+    return { version: null, detail: `image ref has no tag (${ref})` };
+  }
+  const tag = withoutDigest.slice(colon + 1);
+  if (SEMVER_TAG_RE.test(tag)) return { version: tag };
+  return { version: null, detail: `non-semver tag "${tag}"` };
+}
+
+/**
+ * True when an image ref identifies a switchroom component whose tag
+ * tracks the switchroom release.
+ *
+ * Keyed on the IMAGE, never on a name allowlist — a hardcoded list is how
+ * the `hindsight-autoheal` sidecar escaped notice for three releases, so
+ * a component added tomorrow must be covered the day it ships. Two rules,
+ * both verified against a live host's `docker ps`:
+ *
+ *   1. The repository path must end in `/switchroom-<something>`. That
+ *      admits every published component
+ *      (`ghcr.io/switchroom/switchroom-{agent,web,hostd,hindsight,voice,
+ *      auth-broker,kernel,broker}`) and excludes third-party images that
+ *      happen to run under a switchroom-prefixed CONTAINER name — e.g.
+ *      `switchroom-hostd-docker-proxy` → `ghcr.io/tecnativa/…`,
+ *      `switchroom-grafana-fwd` → `alpine/socat`.
+ *   2. Requiring the leading `/` also excludes locally-built bare-name
+ *      images (`switchroom-uat-runner:local`), which are dev artifacts
+ *      with no release tag and would otherwise be permanent `unknown`
+ *      noise in every report.
+ *
+ * `name` is accepted for call-site clarity and future name-based
+ * exclusions; the verdict deliberately depends only on the image.
+ */
+export function isSwitchroomReleaseImage(
+  _name: string,
+  imageRef: string,
+): boolean {
+  return /\/switchroom-[a-z0-9-]+(:|@|$)/.test(imageRef);
+}
+
+/** Minimal shell seam so the collector unit-tests without docker. */
+export type ExecFn = (
+  cmd: string,
+  args: string[],
+) => { status: number; stdout: string };
+
+/**
+ * Enumerate running switchroom containers and the version each is on.
+ *
+ * One `docker ps` — no per-container inspect — so this is cheap enough
+ * to run on every `doctor` and every `update --check`. `--filter
+ * name=switchroom-` is a prefix match on the container name, which is
+ * how every switchroom component is named (`container_name:` is set
+ * explicitly in all three compose projects and by `memory setup`).
+ *
+ * RUNNING containers only (no `-a`). A stopped component is a different
+ * finding that doctor's service checks already own, and `-a` would drag
+ * in exited one-shots (`switchroom-rollout-helper`) whose tags say
+ * nothing about the current release.
+ */
+export function collectContainerComponents(exec: ExecFn): ComponentVersion[] {
+  const r = exec("docker", [
+    "ps",
+    "--filter",
+    "name=switchroom-",
+    "--format",
+    "{{.Names}}\t{{.Image}}",
+  ]);
+  if (r.status !== 0) return [];
+  const out: ComponentVersion[] = [];
+  for (const line of r.stdout.split("\n")) {
+    const [name, imageRef] = line.trim().split("\t");
+    if (!name || !imageRef) continue;
+    if (!isSwitchroomReleaseImage(name, imageRef)) continue;
+    const { version, detail } = versionFromImageRef(imageRef);
+    out.push({
+      name,
+      kind: "container",
+      version,
+      imageRef,
+      ...(detail ? { detail } : {}),
+    });
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Normalize a bare `0.19.23` to the canonical `v0.19.23`. */
+export function normalizeSemverTag(v: string | undefined): string | null {
+  if (!v) return null;
+  const tag = `v${v.trim().replace(/^v/, "")}`;
+  return SEMVER_TAG_RE.test(tag) ? tag : null;
+}
+
+/**
+ * Choose the version every component is expected to be on.
+ *
+ * `release.pin` wins when present: it is the operator's declared intent
+ * and is what compose / `webd install` / `hostd install` all resolve
+ * their tags from, so a component off the pin is unambiguously drifted.
+ *
+ * With no pin (a floating `channel:` install) there is no declared
+ * target, so fall back to the HIGHEST version actually deployed on the
+ * host. That is still a real finding: if one component reached vX and
+ * another did not, something failed to advance it. It cannot detect
+ * "the whole host is behind the published release" — that is the CLI
+ * self-update's job, which does consult the network.
+ */
+export function resolveDriftTarget(
+  components: readonly ComponentVersion[],
+  releasePin: string | undefined,
+): { target: string | null; targetSource: ComponentDriftReport["targetSource"] } {
+  const pin = normalizeSemverTag(releasePin);
+  if (pin) return { target: pin, targetSource: "release.pin" };
+  let highest: string | null = null;
+  for (const c of components) {
+    if (!c.version) continue;
+    if (highest === null) {
+      highest = c.version;
+      continue;
+    }
+    const cmp = compareReleaseTags(c.version, highest);
+    if (cmp !== null && cmp > 0) highest = c.version;
+  }
+  return highest
+    ? { target: highest, targetSource: "highest-deployed" }
+    : { target: null, targetSource: "none" };
+}
+
+/**
+ * Bucket every component against the target. Pure — no I/O.
+ */
+export function detectComponentDrift(
+  components: readonly ComponentVersion[],
+  releasePin: string | undefined,
+): ComponentDriftReport {
+  const { target, targetSource } = resolveDriftTarget(components, releasePin);
+  const report: ComponentDriftReport = {
+    target,
+    targetSource,
+    behind: [],
+    ahead: [],
+    current: [],
+    unknown: [],
+  };
+  for (const c of components) {
+    if (!c.version || !target) {
+      report.unknown.push(c);
+      continue;
+    }
+    const cmp = compareReleaseTags(c.version, target);
+    if (cmp === null) report.unknown.push(c);
+    else if (cmp < 0) report.behind.push(c);
+    else if (cmp > 0) report.ahead.push(c);
+    else report.current.push(c);
+  }
+  return report;
+}
+
+/**
+ * Collect the full inventory: the host CLI plus every running container.
+ *
+ * `cliVersion` is the running CLI's own version (`SWITCHROOM_VERSION`).
+ * It is passed in rather than imported so the caller controls the seam
+ * and tests stay hermetic.
+ */
+export function collectComponents(
+  cliVersion: string,
+  exec: ExecFn,
+): ComponentVersion[] {
+  const cli: ComponentVersion = {
+    name: "cli (host)",
+    kind: "cli",
+    version: normalizeSemverTag(cliVersion),
+    ...(normalizeSemverTag(cliVersion)
+      ? {}
+      : { detail: `unparseable CLI version "${cliVersion}"` }),
+  };
+  return [cli, ...collectContainerComponents(exec)];
+}
+
+/**
+ * One-line-per-component operator summary. Shared by `doctor` and
+ * `update --check` so the two can never describe the host differently.
+ */
+export function formatComponentDrift(report: ComponentDriftReport): string {
+  const lines: string[] = [];
+  if (!report.target) {
+    lines.push(
+      "Component versions: no comparable version found (no release.pin and no semver-tagged component).",
+    );
+  } else {
+    const src =
+      report.targetSource === "release.pin"
+        ? "release.pin"
+        : "highest deployed version (no release.pin set)";
+    lines.push(`Component versions — target ${report.target} (from ${src}):`);
+  }
+  for (const c of report.behind) {
+    lines.push(`  BEHIND   ${c.name} — ${c.version} (target ${report.target})`);
+  }
+  for (const c of report.ahead) {
+    lines.push(`  ahead    ${c.name} — ${c.version}`);
+  }
+  for (const c of report.unknown) {
+    lines.push(`  unknown  ${c.name} — ${c.detail ?? "version not readable"}`);
+  }
+  for (const c of report.current) {
+    lines.push(`  ok       ${c.name} — ${c.version}`);
+  }
+  return lines.join("\n");
+}

--- a/src/cli/doctor-component-versions.test.ts
+++ b/src/cli/doctor-component-versions.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+
+import { runComponentVersionChecks } from "./doctor-component-versions.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+import type { ExecFn } from "./component-versions.js";
+
+const config = (pin?: string) =>
+  ({ agents: {}, ...(pin ? { release: { pin } } : {}) }) as unknown as SwitchroomConfig;
+
+const ps = (lines: string[]): ExecFn => () => ({
+  status: 0,
+  stdout: lines.join("\n"),
+});
+
+const REFERENCE_HOST = [
+  "switchroom-hostd\tghcr.io/switchroom/switchroom-hostd:v0.19.28",
+  "switchroom-hindsight-autoheal\tghcr.io/switchroom/switchroom-hostd:v0.19.26",
+  "switchroom-web\tghcr.io/switchroom/switchroom-web:v0.19.26",
+  "switchroom-klanker\tghcr.io/switchroom/switchroom-agent:v0.19.28",
+];
+
+describe("doctor: component versions (#3919)", () => {
+  it("WARNs once per stale component and names a remediation for each", () => {
+    const rows = runComponentVersionChecks(config("v0.19.28"), {
+      exec: ps(REFERENCE_HOST),
+      cliVersion: "0.19.23",
+    });
+    const warns = rows.filter((r) => r.status === "warn");
+    expect(warns.map((r) => r.name).sort()).toEqual([
+      "component behind: cli (host)",
+      "component behind: switchroom-hindsight-autoheal",
+      "component behind: switchroom-web",
+    ]);
+    expect(warns.every((r) => (r.fix ?? "").length > 0)).toBe(true);
+    expect(
+      warns.find((r) => r.name.endsWith("switchroom-web"))?.fix,
+    ).toContain("webd install --tag v0.19.28");
+    expect(
+      warns.find((r) => r.name.endsWith("switchroom-hindsight-autoheal"))?.fix,
+    ).toContain("hostd install --tag v0.19.28");
+    expect(warns.find((r) => r.name.endsWith("cli (host)"))?.fix).toContain(
+      "switchroom update",
+    );
+  });
+
+  it("never FAILs — version skew must not change doctor's exit code", () => {
+    const rows = runComponentVersionChecks(config("v0.19.28"), {
+      exec: ps(REFERENCE_HOST),
+      cliVersion: "0.19.23",
+    });
+    expect(rows.some((r) => r.status === "fail")).toBe(false);
+  });
+
+  it("reports a single ok row on a converged host", () => {
+    const rows = runComponentVersionChecks(config("v0.19.28"), {
+      exec: ps(REFERENCE_HOST.map((l) => l.replace("v0.19.26", "v0.19.28"))),
+      cliVersion: "0.19.28",
+    });
+    expect(rows.filter((r) => r.status === "warn")).toEqual([]);
+    expect(rows[0].status).toBe("ok");
+  });
+
+  it("skips cleanly when docker is unreachable and no pin is set", () => {
+    const rows = runComponentVersionChecks(config(), {
+      exec: () => ({ status: 1, stdout: "" }),
+      cliVersion: "not-a-version",
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("skip");
+  });
+
+  it("flags an AHEAD component (mid-roll / stale pin) without failing", () => {
+    const rows = runComponentVersionChecks(config("v0.19.26"), {
+      exec: ps(REFERENCE_HOST),
+      cliVersion: "0.19.26",
+    });
+    const ahead = rows.filter((r) => r.name.startsWith("component ahead:"));
+    expect(ahead.map((r) => r.name).sort()).toEqual([
+      "component ahead: switchroom-hostd",
+      "component ahead: switchroom-klanker",
+    ]);
+    expect(ahead.every((r) => r.status === "warn")).toBe(true);
+  });
+});

--- a/src/cli/doctor-component-versions.ts
+++ b/src/cli/doctor-component-versions.ts
@@ -1,0 +1,114 @@
+/**
+ * `switchroom doctor` section: component version drift (#3919).
+ *
+ * The bug this section exists to make impossible: a switchroom component
+ * silently left on an old release. It happened three times at once on the
+ * reference host (host CLI two-plus releases behind, `switchroom-web` and
+ * `switchroom-hindsight-autoheal` each two behind a v0.19.28 fleet) from
+ * three unrelated causes, and survived three releases because the only
+ * evidence was a warning that scrolled past during a roll.
+ *
+ * Deterministic check beats remembering to look. See
+ * `component-versions.ts` for the inventory + comparison rules; this
+ * module is only the doctor row mapping.
+ *
+ * Status contract: `warn` for a behind component, `ok` when converged,
+ * `skip` when nothing is comparable. Never `fail` — version skew is a
+ * real finding but it is not a broken install, and this section must not
+ * change doctor's exit code for an otherwise-healthy host.
+ */
+
+import { spawnSync } from "node:child_process";
+
+import type { SwitchroomConfig } from "../config/schema.js";
+import type { CheckResult } from "./doctor.js";
+import { SWITCHROOM_VERSION } from "./resolve-version.js";
+import {
+  collectComponents,
+  detectComponentDrift,
+  type ComponentVersion,
+  type ExecFn,
+} from "./component-versions.js";
+
+export interface ComponentVersionCheckOpts {
+  /** Test seam — replace the `docker ps` shellout. */
+  exec?: ExecFn;
+  /** Test seam — override the running CLI's version. */
+  cliVersion?: string;
+}
+
+const defaultExec: ExecFn = (cmd, args) => {
+  const r = spawnSync(cmd, args, { encoding: "utf-8", timeout: 10_000 });
+  return { status: r.status ?? 1, stdout: r.stdout ?? "" };
+};
+
+/** The remediation for a given drifted component. */
+function fixFor(c: ComponentVersion, target: string): string {
+  if (c.kind === "cli") {
+    return `switchroom update  (self-updates the host CLI to ${target} first, then everything else)`;
+  }
+  if (c.name === "switchroom-web") {
+    return `switchroom webd install --tag ${target}  (run host-side: webd install fails inside hostd when the hostd compose predates SWITCHROOM_HOSTD_OPERATOR_UID)`;
+  }
+  if (c.name === "switchroom-hindsight-autoheal" || c.name === "switchroom-hostd") {
+    return `switchroom hostd install --tag ${target}  (regenerates the hostd compose project — both hostd and the autoheal sidecar)`;
+  }
+  return `switchroom update`;
+}
+
+export function runComponentVersionChecks(
+  config: SwitchroomConfig,
+  opts: ComponentVersionCheckOpts = {},
+): CheckResult[] {
+  const exec = opts.exec ?? defaultExec;
+  const components = collectComponents(opts.cliVersion ?? SWITCHROOM_VERSION, exec);
+  const report = detectComponentDrift(components, config.release?.pin);
+
+  if (!report.target) {
+    return [
+      {
+        name: "component versions",
+        status: "skip",
+        detail:
+          "no release.pin set and no semver-tagged switchroom container running — nothing to compare.",
+      },
+    ];
+  }
+
+  const results: CheckResult[] = [];
+  const src =
+    report.targetSource === "release.pin"
+      ? `release.pin ${report.target}`
+      : `${report.target} (highest deployed — no release.pin set)`;
+
+  if (report.behind.length === 0) {
+    results.push({
+      name: "component versions",
+      status: "ok",
+      detail: `all ${report.current.length} comparable component(s) on ${src}`,
+    });
+  }
+  for (const c of report.behind) {
+    results.push({
+      name: `component behind: ${c.name}`,
+      status: "warn",
+      detail: `on ${c.version}, expected ${report.target} (${src})`,
+      fix: fixFor(c, report.target),
+    });
+  }
+  for (const c of report.ahead) {
+    results.push({
+      name: `component ahead: ${c.name}`,
+      status: "warn",
+      detail: `on ${c.version}, ahead of ${src} — a roll may be mid-flight, or release.pin is stale`,
+    });
+  }
+  for (const c of report.unknown) {
+    results.push({
+      name: `component version unknown: ${c.name}`,
+      status: "skip",
+      detail: c.detail ?? "version not readable",
+    });
+  }
+  return results;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -66,6 +66,7 @@ import { runOpenRouterCreditChecks, usesOpenRouter } from "./doctor-openrouter-c
 import { runCronSessionChecks } from "./doctor-cron-session.js";
 import { runFloodPressureChecks } from "./doctor-flood-pressure.js";
 import { runGeneratedSurfaceDriftChecks } from "./doctor-drift.js";
+import { runComponentVersionChecks } from "./doctor-component-versions.js";
 import { runMicrosoftChecks } from "./doctor-microsoft.js";
 import { runNotionChecks } from "./doctor-notion.js";
 import { runMcpSecretChecks } from "./doctor-mcp-secrets.js";
@@ -3978,6 +3979,26 @@ export function registerDoctorCommand(program: Command): void {
           // the fleet today — only agents the value-gate routes to a cron
           // session produce a line.
           { title: "Cron Session", results: runCronSessionChecks(config) },
+          {
+            // #3919: is every switchroom component — the host CLI included —
+            // on the same release? Three components drifted across three
+            // releases on the reference host because nothing held a standing
+            // answer to that question. warn-only; never changes exit code.
+            title: "Component versions (#3919)",
+            results: ((): CheckResult[] => {
+              try {
+                return runComponentVersionChecks(config);
+              } catch (err) {
+                return [
+                  {
+                    name: "component versions",
+                    status: "skip",
+                    detail: `not checkable: ${(err as Error)?.message ?? String(err)}`,
+                  },
+                ];
+              }
+            })(),
+          },
           {
             // KEN-130: every generated/synced surface (compose, hooks,
             // start.sh/CLAUDE.md/.mcp.json stamp, skills, image hook

--- a/src/cli/self-update-io.ts
+++ b/src/cli/self-update-io.ts
@@ -1,0 +1,112 @@
+/**
+ * Production wiring for the CLI self-update (#3919).
+ *
+ * Split out from `self-update.ts` so that module stays pure and its
+ * download → verify → prove → swap sequence is unit-testable against an
+ * in-memory filesystem with no network. Nothing here has logic worth
+ * testing in isolation; every decision lives in the pure module.
+ */
+
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  copyFileSync,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  renameSync,
+  rmSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { spawnSync } from "node:child_process";
+
+import type { SelfUpdateIO } from "./self-update.js";
+
+/** Bounded so a hung GitHub/CDN connection can't wedge an update. */
+const HTTP_TIMEOUT_MS = 60_000;
+
+export function defaultSelfUpdateIO(): SelfUpdateIO {
+  return {
+    async httpGetText(url) {
+      const res = await fetch(url, {
+        headers: { "user-agent": "switchroom-cli-self-update" },
+        signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+      return await res.text();
+    },
+    async httpDownload(url, dest) {
+      const res = await fetch(url, {
+        headers: { "user-agent": "switchroom-cli-self-update" },
+        redirect: "follow",
+        signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+      if (!res.body) throw new Error(`empty response body for ${url}`);
+      // Stream to disk — the binary is ~100MB and buffering it whole
+      // would spike RSS on a small host.
+      await pipeline(
+        Readable.fromWeb(
+          res.body as unknown as Parameters<typeof Readable.fromWeb>[0],
+        ),
+        createWriteStream(dest),
+      );
+    },
+    sha256File(path) {
+      // Chunked for the same reason httpDownload streams: the artifact is
+      // ~100MB and readFileSync would materialise all of it.
+      const hash = createHash("sha256");
+      const fd = openSync(path, "r");
+      try {
+        const buf = Buffer.allocUnsafe(1 << 20);
+        for (;;) {
+          const n = readSync(fd, buf, 0, buf.length, null);
+          if (n <= 0) break;
+          hash.update(buf.subarray(0, n));
+        }
+      } finally {
+        closeSync(fd);
+      }
+      return hash.digest("hex");
+    },
+    probeBinaryVersion(path) {
+      const r = spawnSync(path, ["version"], {
+        encoding: "utf-8",
+        timeout: 30_000,
+        // A candidate binary must not inherit the self-update sentinel or
+        // it could mask a loop guard in a future refactor.
+        env: { ...process.env, SWITCHROOM_SELF_UPDATED: "" },
+      });
+      if (r.status !== 0) return null;
+      const out = `${r.stdout ?? ""}`.trim();
+      const m = out.match(/\d+\.\d+\.\d+/);
+      return m ? m[0] : null;
+    },
+    mkdirp(dir) {
+      mkdirSync(dir, { recursive: true });
+    },
+    copyFile(src, dest) {
+      copyFileSync(src, dest);
+    },
+    chmodExec(path) {
+      chmodSync(path, 0o755);
+    },
+    rename(src, dest) {
+      renameSync(src, dest);
+    },
+    remove(path) {
+      rmSync(path, { force: true });
+    },
+    exists(path) {
+      return existsSync(path);
+    },
+    dirname(path) {
+      return dirname(path);
+    },
+  };
+}

--- a/src/cli/self-update.test.ts
+++ b/src/cli/self-update.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  alreadySelfUpdated,
+  detectInstallKind,
+  expectedChecksum,
+  parseLatestReleaseTag,
+  performSelfUpdate,
+  planSelfUpdate,
+  releaseAssetName,
+  rollbackHint,
+  versionStorePath,
+  type SelfUpdateAction,
+  type SelfUpdateIO,
+} from "./self-update.js";
+
+const STATIC_BINARY = {
+  bundleDir: "/$bunfs/root",
+  execPath: "/usr/local/bin/switchroom",
+  scriptPath: "/$bunfs/root/switchroom",
+  inContainer: false,
+};
+
+describe("detectInstallKind", () => {
+  it("identifies a published static binary and the file to replace", () => {
+    const d = detectInstallKind(STATIC_BINARY);
+    expect(d.kind).toBe("static-binary");
+    expect(d.binaryPath).toBe("/usr/local/bin/switchroom");
+  });
+
+  it("refuses to touch a source checkout", () => {
+    const d = detectInstallKind({
+      bundleDir: "/home/dev/switchroom/src/cli",
+      execPath: "/home/dev/.bun/bin/bun",
+      scriptPath: "/home/dev/switchroom/dist/cli/switchroom.js",
+      inContainer: false,
+    });
+    expect(d.kind).toBe("source-checkout");
+    expect(d.binaryPath).toBeUndefined();
+    expect(d.reason).toContain("npm run build");
+  });
+
+  it("refuses to touch an npm-global install and names the right command", () => {
+    const d = detectInstallKind({
+      bundleDir: "/usr/lib/node_modules/switchroom/dist/cli",
+      execPath: "/usr/bin/node",
+      scriptPath: "/usr/lib/node_modules/switchroom/dist/cli/switchroom.js",
+      inContainer: false,
+    });
+    expect(d.kind).toBe("npm-global");
+    expect(d.reason).toContain("npm i -g switchroom@latest");
+  });
+
+  it("never self-updates inside a container", () => {
+    const d = detectInstallKind({ ...STATIC_BINARY, inContainer: true });
+    expect(d.kind).toBe("container");
+    expect(d.binaryPath).toBeUndefined();
+  });
+
+  it("falls back to `unknown` rather than guessing", () => {
+    const d = detectInstallKind({
+      bundleDir: "/opt/weird/bundle",
+      execPath: "/opt/weird/bin/node",
+      scriptPath: "/opt/weird/switchroom-launcher",
+      inContainer: false,
+    });
+    expect(d.kind).toBe("unknown");
+    expect(d.binaryPath).toBeUndefined();
+  });
+});
+
+describe("planSelfUpdate", () => {
+  const detection = detectInstallKind(STATIC_BINARY);
+
+  it("updates when the local CLI is behind the published release", () => {
+    const p = planSelfUpdate({
+      detection,
+      currentVersion: "0.19.23",
+      latestTag: "v0.19.28",
+    });
+    expect(p).toEqual({
+      action: "update",
+      from: "v0.19.23",
+      to: "v0.19.28",
+      binaryPath: "/usr/local/bin/switchroom",
+    });
+  });
+
+  it("is a no-op when already current", () => {
+    expect(
+      planSelfUpdate({ detection, currentVersion: "0.19.28", latestTag: "v0.19.28" }),
+    ).toEqual({ action: "current", version: "v0.19.28" });
+  });
+
+  it("never DOWNGRADES a locally-newer CLI", () => {
+    const p = planSelfUpdate({
+      detection,
+      currentVersion: "0.20.0",
+      latestTag: "v0.19.28",
+    });
+    expect(p.action).toBe("current");
+  });
+
+  it("skips (does not fail) when GitHub could not be reached", () => {
+    const p = planSelfUpdate({
+      detection,
+      currentVersion: "0.19.23",
+      latestTag: null,
+    });
+    expect(p.action).toBe("skip");
+  });
+
+  it("skips a non-static install even when a newer release exists", () => {
+    const p = planSelfUpdate({
+      detection: detectInstallKind({ ...STATIC_BINARY, inContainer: true }),
+      currentVersion: "0.19.23",
+      latestTag: "v0.19.28",
+    });
+    expect(p.action).toBe("skip");
+  });
+});
+
+describe("release metadata parsing", () => {
+  it("reads tag_name from /releases/latest", () => {
+    expect(parseLatestReleaseTag('{"tag_name":"v0.19.28"}')).toBe("v0.19.28");
+  });
+
+  it("rejects a draft payload", () => {
+    expect(parseLatestReleaseTag('{"tag_name":"v0.19.29","draft":true}')).toBeNull();
+  });
+
+  it("rejects a non-semver tag rather than passing it to a download URL", () => {
+    expect(parseLatestReleaseTag('{"tag_name":"nightly"}')).toBeNull();
+    expect(parseLatestReleaseTag("not json")).toBeNull();
+  });
+
+  it("matches the checksum line exactly, not by prefix", () => {
+    const text = [
+      `${"a".repeat(64)}  switchroom-linux-amd64.sig`,
+      `${"b".repeat(64)}  switchroom-linux-amd64`,
+      `${"c".repeat(64)}  switchroom-macos-arm64`,
+    ].join("\n");
+    expect(expectedChecksum(text, "switchroom-linux-amd64")).toBe("b".repeat(64));
+    expect(expectedChecksum(text, "switchroom-linux-arm64")).toBeNull();
+  });
+
+  it("mirrors install.sh's asset naming", () => {
+    expect(releaseAssetName("linux", "x64")).toBe("switchroom-linux-amd64");
+    expect(releaseAssetName("darwin", "arm64")).toBe("switchroom-macos-arm64");
+    expect(releaseAssetName("win32", "x64")).toBeNull();
+    expect(releaseAssetName("linux", "ppc64")).toBeNull();
+  });
+});
+
+describe("rollback layout", () => {
+  it("archives inside the install dir so the final swap is a same-fs rename", () => {
+    expect(versionStorePath("/usr/local/bin", "v0.19.23")).toBe(
+      "/usr/local/bin/.switchroom-versions/switchroom-0.19.23",
+    );
+  });
+
+  it("prints a one-command rollback", () => {
+    expect(rollbackHint("/usr/local/bin", "v0.19.23")).toBe(
+      "Rollback: cp /usr/local/bin/.switchroom-versions/switchroom-0.19.23 /usr/local/bin/switchroom",
+    );
+  });
+});
+
+describe("alreadySelfUpdated", () => {
+  it("is the re-exec loop guard", () => {
+    expect(alreadySelfUpdated({ SWITCHROOM_SELF_UPDATED: "1" })).toBe(true);
+    expect(alreadySelfUpdated({})).toBe(false);
+  });
+});
+
+// ─── performSelfUpdate — an in-memory filesystem, no network ─────────────
+
+const GOOD_SHA = "d".repeat(64);
+
+function makeIO(overrides: Partial<SelfUpdateIO> = {}) {
+  const files = new Map<string, string>([
+    ["/usr/local/bin/switchroom", "OLD-BINARY"],
+  ]);
+  const dirs = new Set<string>(["/usr/local/bin"]);
+  const io: SelfUpdateIO = {
+    async httpGetText(url) {
+      if (url.endsWith("switchroom-checksums.txt")) {
+        return `${GOOD_SHA}  switchroom-linux-amd64\n`;
+      }
+      return '{"tag_name":"v0.19.28"}';
+    },
+    async httpDownload(_url, dest) {
+      files.set(dest, "NEW-BINARY");
+    },
+    sha256File: () => GOOD_SHA,
+    probeBinaryVersion: () => "0.19.28",
+    mkdirp: (d) => void dirs.add(d),
+    copyFile: (src, dest) => void files.set(dest, files.get(src) ?? ""),
+    chmodExec: () => {},
+    rename: (src, dest) => {
+      files.set(dest, files.get(src) ?? "");
+      files.delete(src);
+    },
+    remove: (p) => void files.delete(p),
+    exists: (p) => files.has(p),
+    dirname: (p) => p.slice(0, p.lastIndexOf("/")) || "/",
+    ...overrides,
+  };
+  return { io, files, dirs };
+}
+
+const PLAN: Extract<SelfUpdateAction, { action: "update" }> = {
+  action: "update",
+  from: "v0.19.23",
+  to: "v0.19.28",
+  binaryPath: "/usr/local/bin/switchroom",
+};
+
+async function run(io: SelfUpdateIO) {
+  return performSelfUpdate({ plan: PLAN, assetName: "switchroom-linux-amd64", io });
+}
+
+describe("performSelfUpdate", () => {
+  it("installs the new binary and archives the outgoing one for rollback", async () => {
+    const { io, files } = makeIO();
+    const r = await run(io);
+    expect(r.replaced).toBe(true);
+    expect(r.newVersion).toBe("v0.19.28");
+    // The binary on $PATH is the new one …
+    expect(files.get("/usr/local/bin/switchroom")).toBe("NEW-BINARY");
+    // … the OUTGOING one is recoverable …
+    expect(
+      files.get("/usr/local/bin/.switchroom-versions/switchroom-0.19.23"),
+    ).toBe("OLD-BINARY");
+    // … the new one is kept under its version too …
+    expect(
+      files.get("/usr/local/bin/.switchroom-versions/switchroom-0.19.28"),
+    ).toBe("NEW-BINARY");
+    // … and no temp file is left behind.
+    expect([...files.keys()].filter((k) => k.includes(".download"))).toEqual([]);
+    expect([...files.keys()].filter((k) => k.endsWith(".new"))).toEqual([]);
+    expect(r.message).toContain("Rollback: cp");
+  });
+
+  it("leaves the installed binary UNTOUCHED when the download fails", async () => {
+    const { io, files } = makeIO({
+      httpDownload: async () => {
+        throw new Error("connection reset");
+      },
+    });
+    await expect(run(io)).rejects.toThrow(/download of .* failed/);
+    expect(files.get("/usr/local/bin/switchroom")).toBe("OLD-BINARY");
+  });
+
+  it("refuses a checksum mismatch and leaves the binary UNTOUCHED", async () => {
+    const { io, files } = makeIO({ sha256File: () => "e".repeat(64) });
+    await expect(run(io)).rejects.toThrow(/SHA256 mismatch/);
+    expect(files.get("/usr/local/bin/switchroom")).toBe("OLD-BINARY");
+    expect([...files.keys()].filter((k) => k.includes(".download"))).toEqual([]);
+  });
+
+  it("refuses when the release has no checksum entry for this asset", async () => {
+    const { io, files } = makeIO({
+      httpGetText: async () => "",
+    });
+    await expect(run(io)).rejects.toThrow(/no checksum entry/);
+    expect(files.get("/usr/local/bin/switchroom")).toBe("OLD-BINARY");
+  });
+
+  it("refuses a binary that cannot run on this host, BEFORE the swap", async () => {
+    const { io, files } = makeIO({ probeBinaryVersion: () => null });
+    await expect(run(io)).rejects.toThrow(/did not run cleanly/);
+    // The whole point: a broken binary never reaches $PATH.
+    expect(files.get("/usr/local/bin/switchroom")).toBe("OLD-BINARY");
+  });
+
+  it("refuses to swap when the rollback copy cannot be made", async () => {
+    const { io, files } = makeIO({
+      copyFile: () => {
+        throw new Error("EACCES");
+      },
+    });
+    await expect(run(io)).rejects.toThrow(/refusing to swap without a rollback copy/);
+    expect(files.get("/usr/local/bin/switchroom")).toBe("OLD-BINARY");
+  });
+
+  it("does not clobber an existing archive of the outgoing version", async () => {
+    const { io, files } = makeIO();
+    files.set(
+      "/usr/local/bin/.switchroom-versions/switchroom-0.19.23",
+      "PRISTINE-0.19.23",
+    );
+    await run(io);
+    expect(
+      files.get("/usr/local/bin/.switchroom-versions/switchroom-0.19.23"),
+    ).toBe("PRISTINE-0.19.23");
+  });
+});

--- a/src/cli/self-update.ts
+++ b/src/cli/self-update.ts
@@ -1,0 +1,511 @@
+/**
+ * Host CLI self-update (#3919).
+ *
+ * THE GAP THIS CLOSES
+ *
+ * `switchroom update` updated every switchroom component except the one
+ * running the update. On the operator host in July 2026 that left the
+ * CLI on 0.19.23 while the fleet ran v0.19.28 — three releases of drift,
+ * with no command that would ever close it.
+ *
+ * That is not cosmetic. `switchroom apply` renders every per-agent
+ * scaffold from Handlebars templates that ship INSIDE the installed CLI
+ * (`profiles/_base/start.sh.hbs` et al.). A merged feature that adds a
+ * template variable is invisible on a host whose CLI is stale, no matter
+ * how current the container images are. The CLI is the compiler; the
+ * images are the output.
+ *
+ * ORDERING IS THE WHOLE POINT
+ *
+ * The self-update step runs FIRST, before `apply-config`. Updating the
+ * CLI after applying config would render this run's scaffolds from the
+ * OLD templates and then leave a new CLI sitting unused until the next
+ * update — precisely the drift, one release later.
+ *
+ * SELF-REPLACEMENT MECHANICS — why swap-then-re-exec, not swap-in-place
+ *
+ * A process cannot start executing new code by having its own file
+ * overwritten. On Linux the swap itself is safe (the running process
+ * holds the old inode open through an atomic `rename(2)`; the old bytes
+ * stay readable until exit), but the running process keeps running the
+ * OLD code. So after the swap we RE-EXEC the new binary with the rest of
+ * the update plan and hand it our exit status. Three consequences worth
+ * stating:
+ *
+ *   1. `rename(2)` within the same directory is atomic, so there is no
+ *      window where `switchroom` on $PATH is a truncated file. A crash
+ *      mid-download touches nothing: the download lands in a temp file
+ *      in the version store and is only renamed into place after its
+ *      checksum verifies AND it proves it can execute.
+ *   2. We do NOT need the detached-helper trick hostd uses for its own
+ *      container recreate (`deploy-v01546.sh`, `self-bump.ts`). That
+ *      hazard is specific to a process that is about to `docker compose
+ *      up` the container it lives in and get SIGKILLed. The host CLI is
+ *      an ordinary host process; nothing in the update kills it. A
+ *      detached helper here would only cost us the operator's terminal
+ *      (no streamed output, no exit code) for no safety gain.
+ *   3. The re-exec is guarded by `SWITCHROOM_SELF_UPDATED=1` in the
+ *      child's env plus an explicit `--skip-self-update`, so a binary
+ *      that mis-reports its own version cannot re-exec forever.
+ *
+ * FAILURE MODES, STATED
+ *
+ *   - Download fails / is truncated / registry 404s → the temp file is
+ *     removed and the step FAILS the update before anything else runs.
+ *     The installed CLI is byte-identical to before.
+ *   - Checksum mismatch → same: refuse, delete, fail. We never install
+ *     an unverified binary (this is the supply-chain boundary, and
+ *     install.sh already enforces it — we match it).
+ *   - The new binary is broken (wrong arch, corrupt, missing runtime) →
+ *     caught BEFORE the swap by running `<candidate> version` and
+ *     requiring exit 0 with a parseable version. A binary that cannot
+ *     print its own version never reaches $PATH.
+ *   - Interrupted between the swap and `apply-config` → the host is left
+ *     with a NEW CLI and un-applied config. That is a benign state: the
+ *     next `switchroom update` (or bare `switchroom apply`) converges,
+ *     and it is strictly better than the reverse order, which would
+ *     leave scaffolds rendered from templates the operator has already
+ *     replaced.
+ *   - The new CLI is broken in a way `version` does not catch → the
+ *     previous binary is still on disk in the version store. Rollback is
+ *     one `cp`, and the step prints the exact command.
+ *
+ * ROLLBACK
+ *
+ * Every binary this module installs is kept at
+ * `<installDir>/.switchroom-versions/switchroom-<version>`, including
+ * the OUTGOING one (copied there before the swap). The store lives
+ * inside the install dir so it is guaranteed to be on the same
+ * filesystem as the target — that is what makes the final `rename(2)`
+ * atomic rather than a copy with a torn-file window. Reverting is:
+ *
+ *     sudo cp <installDir>/.switchroom-versions/switchroom-<old> <installDir>/switchroom
+ *
+ * We keep the store rather than a symlink farm because `install.sh`
+ * installs a plain regular file at `<installDir>/switchroom`; making the
+ * target a symlink would diverge from the installer and be silently
+ * clobbered back to a regular file the next time anyone ran it.
+ *
+ * Everything analysable here is a pure function so it unit-tests without
+ * network, docker, or a writable /usr/local/bin.
+ */
+
+import { compareReleaseTags } from "../config/release-resolve.js";
+
+export const SELF_UPDATE_ENV_SENTINEL = "SWITCHROOM_SELF_UPDATED";
+export const VERSION_STORE_DIRNAME = ".switchroom-versions";
+export const GITHUB_LATEST_RELEASE_URL =
+  "https://api.github.com/repos/switchroom/switchroom/releases/latest";
+
+/**
+ * How this copy of switchroom was installed. Only `static-binary` is
+ * self-updatable — it is the artifact `install.sh` publishes and the
+ * only one where "replace one file" is the complete update.
+ */
+export type InstallKind =
+  | "static-binary"
+  | "npm-global"
+  | "source-checkout"
+  | "container"
+  | "unknown";
+
+export interface InstallProbe {
+  /** `import.meta.dirname` of the running bundle. `/$bunfs/root` inside
+   *  a `bun build --compile` binary. */
+  bundleDir: string;
+  /** `process.execPath` — the real on-disk binary for a compiled build. */
+  execPath: string;
+  /** `process.argv[1]`. */
+  scriptPath: string;
+  /** True when running inside a switchroom container (agent / hostd). */
+  inContainer: boolean;
+}
+
+export interface InstallDetection {
+  kind: InstallKind;
+  /** Path of the file to replace. Only set for `static-binary`. */
+  binaryPath?: string;
+  /** Operator-facing explanation — printed verbatim when we skip. */
+  reason: string;
+}
+
+/**
+ * Classify the running install.
+ *
+ * Deliberately conservative: anything we cannot positively identify as a
+ * published static binary is left ALONE with a message naming the right
+ * upgrade command. Clobbering a maintainer's dev checkout — or writing a
+ * host binary into a container layer that gets discarded on the next
+ * image pull — is far worse than skipping.
+ */
+export function detectInstallKind(p: InstallProbe): InstallDetection {
+  if (p.inContainer) {
+    return {
+      kind: "container",
+      reason:
+        "running inside a switchroom container — the CLI here comes from the " +
+        "container image and is updated by pulling a new image, not by " +
+        "replacing a file. Nothing to self-update.",
+    };
+  }
+  // A `bun build --compile` binary sees its own bundle at the bunfs
+  // virtual root; the real file is process.execPath.
+  if (p.bundleDir.startsWith("/$bunfs")) {
+    if (!p.execPath) {
+      return {
+        kind: "unknown",
+        reason:
+          "compiled binary but process.execPath is empty — cannot locate the " +
+          "file to replace. Re-run install.sh to upgrade.",
+      };
+    }
+    return {
+      kind: "static-binary",
+      binaryPath: p.execPath,
+      reason: `published static binary at ${p.execPath}`,
+    };
+  }
+  // node_modules FIRST: an npm install also runs `.../dist/cli/switchroom.js`,
+  // so the checkout heuristic below would claim it and hand the operator the
+  // wrong remediation command.
+  if (/[/\\]node_modules[/\\]switchroom[/\\]/.test(p.scriptPath)) {
+    return {
+      kind: "npm-global",
+      reason:
+        "installed via npm — self-update does not manage npm installs. " +
+        "Upgrade with `npm i -g switchroom@latest`.",
+    };
+  }
+  if (isSwitchroomSourceCheckoutPath(p.scriptPath)) {
+    return {
+      kind: "source-checkout",
+      reason:
+        "running from a switchroom source checkout — self-update would clobber " +
+        "your working tree. Upgrade with `git pull && bun install && npm run build`.",
+    };
+  }
+  return {
+    kind: "unknown",
+    reason:
+      `could not identify how switchroom was installed (running from ` +
+      `"${p.scriptPath}"). Not touching it. Upgrade with the method you used ` +
+      `to install, or re-run install.sh.`,
+  };
+}
+
+/**
+ * Path-only source-checkout test.
+ *
+ * The reliable signal is a `package.json` naming switchroom beside a
+ * `.git`, but this module stays pure (no fs) so it unit-tests without a
+ * fixture tree. A path heuristic is sufficient here because it is only
+ * ever used to DECLINE: a false positive skips a self-update that could
+ * have run (the operator gets a message and a command), while a false
+ * negative cannot clobber a checkout — the `/$bunfs` branch above has
+ * already claimed every compiled binary, and a checkout never runs one.
+ */
+function isSwitchroomSourceCheckoutPath(scriptPath: string): boolean {
+  return /[/\\](src|dist)[/\\]cli[/\\]switchroom(\.js|\.ts)?$/.test(scriptPath);
+}
+
+/**
+ * Release asset name for this platform — must match `install.sh`
+ * exactly, because it is the same GitHub release assets we fetch.
+ */
+export function releaseAssetName(
+  platform: NodeJS.Platform,
+  arch: string,
+): string | null {
+  const os =
+    platform === "linux" ? "linux" : platform === "darwin" ? "macos" : null;
+  const cpu = arch === "x64" ? "amd64" : arch === "arm64" ? "arm64" : null;
+  if (!os || !cpu) return null;
+  return `switchroom-${os}-${cpu}`;
+}
+
+/**
+ * Extract `tag_name` from the GitHub `/releases/latest` payload.
+ *
+ * `/releases/latest` excludes drafts and pre-releases by construction
+ * (documented in skills/switchroom-release/SKILL.md), which is exactly
+ * the semantics we want: a self-update must never pull a draft.
+ */
+export function parseLatestReleaseTag(body: string): string | null {
+  try {
+    const parsed = JSON.parse(body) as { tag_name?: unknown; draft?: unknown };
+    if (parsed?.draft === true) return null;
+    const tag = parsed?.tag_name;
+    if (typeof tag !== "string" || !/^v\d+\.\d+\.\d+$/.test(tag)) return null;
+    return tag;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Look up an asset's expected SHA256 in the release's
+ * `switchroom-checksums.txt` (canonical `<hash>  <file>` format).
+ * Fixed-string match on the two-space-prefixed asset name, mirroring the
+ * hardening install.sh already carries.
+ */
+export function expectedChecksum(
+  checksumsText: string,
+  asset: string,
+): string | null {
+  for (const line of checksumsText.split("\n")) {
+    const idx = line.indexOf(`  ${asset}`);
+    if (idx <= 0) continue;
+    // The asset name must terminate the line — otherwise
+    // `switchroom-linux-amd64` would match `switchroom-linux-amd64.sig`.
+    if (line.slice(idx + 2).trim() !== asset) continue;
+    const hash = line.slice(0, idx).trim();
+    if (/^[0-9a-f]{64}$/i.test(hash)) return hash.toLowerCase();
+  }
+  return null;
+}
+
+/** What the self-update step decided to do. */
+export type SelfUpdateAction =
+  | { action: "skip"; reason: string }
+  | { action: "current"; version: string }
+  | { action: "update"; from: string; to: string; binaryPath: string };
+
+/**
+ * Decide whether to replace the binary. Pure.
+ *
+ * A NEWER local CLI than the published release is left alone (an
+ * operator running an RC / a locally-built binary must not be silently
+ * downgraded by a routine update).
+ */
+export function planSelfUpdate(opts: {
+  detection: InstallDetection;
+  currentVersion: string;
+  latestTag: string | null;
+}): SelfUpdateAction {
+  const { detection, currentVersion, latestTag } = opts;
+  if (detection.kind !== "static-binary" || !detection.binaryPath) {
+    return { action: "skip", reason: detection.reason };
+  }
+  if (!latestTag) {
+    return {
+      action: "skip",
+      reason:
+        "could not resolve the latest published release from GitHub " +
+        "(offline, rate-limited, or the API changed shape) — leaving the CLI as-is.",
+    };
+  }
+  const current = `v${currentVersion.trim().replace(/^v/, "")}`;
+  const cmp = compareReleaseTags(current, latestTag);
+  if (cmp === null) {
+    return {
+      action: "skip",
+      reason:
+        `local CLI version "${currentVersion}" is not a comparable semver — ` +
+        `refusing to guess whether ${latestTag} is an upgrade.`,
+    };
+  }
+  if (cmp >= 0) return { action: "current", version: current };
+  return {
+    action: "update",
+    from: current,
+    to: latestTag,
+    binaryPath: detection.binaryPath,
+  };
+}
+
+/**
+ * Where a given version's binary is archived. Inside the install dir so
+ * the final install is a same-filesystem atomic rename.
+ */
+export function versionStorePath(
+  installDir: string,
+  version: string,
+  sep = "/",
+): string {
+  return `${installDir}${sep}${VERSION_STORE_DIRNAME}${sep}switchroom-${version.replace(/^v/, "")}`;
+}
+
+/** Operator-facing rollback instruction for a completed swap. */
+export function rollbackHint(installDir: string, previousVersion: string): string {
+  return (
+    `Rollback: cp ${versionStorePath(installDir, previousVersion)} ` +
+    `${installDir}/switchroom`
+  );
+}
+
+/**
+ * True when this process is itself the child of a self-update re-exec —
+ * the loop guard. Also honoured when the operator passes
+ * `--skip-self-update` explicitly.
+ */
+export function alreadySelfUpdated(env: NodeJS.ProcessEnv): boolean {
+  return env[SELF_UPDATE_ENV_SENTINEL] === "1";
+}
+
+// ─── execution ───────────────────────────────────────────────────────────
+//
+// Every side effect is behind this interface so the whole download →
+// verify → prove → swap sequence is exercisable in a unit test with an
+// in-memory filesystem and no network.
+
+export interface SelfUpdateIO {
+  /** GET a URL as text. Throws on non-2xx. */
+  httpGetText(url: string): Promise<string>;
+  /** GET a URL and write the body to `dest`. Throws on non-2xx. */
+  httpDownload(url: string, dest: string): Promise<void>;
+  /** Lowercase hex SHA256 of a file. */
+  sha256File(path: string): string;
+  /** Run `<path> version` and return the printed version, or null when
+   *  the binary does not exit 0 / prints nothing parseable. */
+  probeBinaryVersion(path: string): string | null;
+  mkdirp(dir: string): void;
+  copyFile(src: string, dest: string): void;
+  chmodExec(path: string): void;
+  /** Atomic same-filesystem rename. */
+  rename(src: string, dest: string): void;
+  remove(path: string): void;
+  exists(path: string): boolean;
+  dirname(path: string): string;
+}
+
+export interface SelfUpdateResult {
+  /** True when the on-disk binary was replaced (caller must re-exec). */
+  replaced: boolean;
+  /** Human line for the update log. */
+  message: string;
+  /** New version, when replaced. */
+  newVersion?: string;
+  /** Path of the (now new) binary, when replaced. */
+  binaryPath?: string;
+}
+
+/**
+ * Resolve the latest published release tag. Returns null on any failure
+ * — a self-update that cannot reach GitHub SKIPS, it does not fail the
+ * update (an offline host must still be able to run `switchroom update
+ * --skip-images` against local state).
+ */
+export async function fetchLatestReleaseTag(
+  io: Pick<SelfUpdateIO, "httpGetText">,
+): Promise<string | null> {
+  try {
+    return parseLatestReleaseTag(await io.httpGetText(GITHUB_LATEST_RELEASE_URL));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Download, verify, prove, and atomically install the target release's
+ * binary. THROWS on every failure after the decision to update — at that
+ * point the operator has been told an upgrade is happening, and silently
+ * continuing on a stale CLI is the bug this PR exists to kill.
+ *
+ * Invariant: `binaryPath` is either the untouched original or a fully
+ * verified new binary. There is no intermediate state.
+ */
+export async function performSelfUpdate(opts: {
+  plan: Extract<SelfUpdateAction, { action: "update" }>;
+  assetName: string;
+  io: SelfUpdateIO;
+  log?: (s: string) => void;
+}): Promise<SelfUpdateResult> {
+  const { plan, assetName, io } = opts;
+  const log = opts.log ?? (() => {});
+  const installDir = io.dirname(plan.binaryPath);
+  const store = `${installDir}/${VERSION_STORE_DIRNAME}`;
+  const base = `https://github.com/switchroom/switchroom/releases/download/${plan.to}`;
+  const staged = versionStorePath(installDir, plan.to);
+  const tmp = `${staged}.download`;
+
+  io.mkdirp(store);
+  io.remove(tmp);
+
+  log(`downloading ${assetName} ${plan.to}`);
+  try {
+    await io.httpDownload(`${base}/${assetName}`, tmp);
+  } catch (err) {
+    io.remove(tmp);
+    throw new Error(
+      `self-update: download of ${base}/${assetName} failed (${(err as Error).message}). ` +
+        `The installed CLI is unchanged.`,
+    );
+  }
+
+  // Supply-chain boundary: never install an unverified binary. Same
+  // check install.sh performs, for the same reason.
+  let checksums: string;
+  try {
+    checksums = await io.httpGetText(`${base}/switchroom-checksums.txt`);
+  } catch (err) {
+    io.remove(tmp);
+    throw new Error(
+      `self-update: could not fetch switchroom-checksums.txt for ${plan.to} ` +
+        `(${(err as Error).message}) — refusing to install an unverified binary. ` +
+        `The installed CLI is unchanged.`,
+    );
+  }
+  const expected = expectedChecksum(checksums, assetName);
+  if (!expected) {
+    io.remove(tmp);
+    throw new Error(
+      `self-update: release ${plan.to} has no checksum entry for ${assetName} — ` +
+        `refusing to install an unverified binary. The installed CLI is unchanged.`,
+    );
+  }
+  const actual = io.sha256File(tmp).toLowerCase();
+  if (actual !== expected) {
+    io.remove(tmp);
+    throw new Error(
+      `self-update: SHA256 mismatch for ${assetName} (expected ${expected}, got ${actual}) — ` +
+        `refusing to install. The installed CLI is unchanged.`,
+    );
+  }
+  io.chmodExec(tmp);
+
+  // Prove the candidate RUNS before it can become `switchroom` on
+  // $PATH. Catches an arch mismatch, a truncated-but-correctly-hashed
+  // artifact (impossible, but cheap to exclude), and a binary whose
+  // bundled runtime this host cannot load. A CLI that cannot print its
+  // own version must never reach the operator's PATH.
+  const proved = io.probeBinaryVersion(tmp);
+  if (!proved) {
+    io.remove(tmp);
+    throw new Error(
+      `self-update: the downloaded ${plan.to} binary did not run cleanly on this host ` +
+        `(\`switchroom version\` failed) — refusing to install it. The installed CLI is unchanged.`,
+    );
+  }
+
+  // Archive the OUTGOING binary before the swap so rollback is a copy.
+  const previousArchive = versionStorePath(installDir, plan.from);
+  try {
+    if (!io.exists(previousArchive)) io.copyFile(plan.binaryPath, previousArchive);
+  } catch (err) {
+    io.remove(tmp);
+    throw new Error(
+      `self-update: could not archive the current binary to ${previousArchive} ` +
+        `(${(err as Error).message}) — refusing to swap without a rollback copy. ` +
+        `The installed CLI is unchanged.`,
+    );
+  }
+
+  // Keep the verified artifact in the store under its version, then
+  // install it. Both renames are same-filesystem (the store is a
+  // subdirectory of the install dir), so each is atomic: `switchroom`
+  // on $PATH is never a partially-written file.
+  io.rename(tmp, staged);
+  io.copyFile(staged, `${plan.binaryPath}.new`);
+  io.chmodExec(`${plan.binaryPath}.new`);
+  io.rename(`${plan.binaryPath}.new`, plan.binaryPath);
+
+  log(rollbackHint(installDir, plan.from));
+  return {
+    replaced: true,
+    newVersion: plan.to,
+    binaryPath: plan.binaryPath,
+    message:
+      `host CLI ${plan.from} → ${plan.to} (verified sha256, ran clean). ` +
+      rollbackHint(installDir, plan.from),
+  };
+}

--- a/src/cli/update-self-update.test.ts
+++ b/src/cli/update-self-update.test.ts
@@ -1,0 +1,302 @@
+/**
+ * `switchroom update` × host-CLI self-update wiring (#3919).
+ *
+ * These assert the OUTCOMES that the pre-#3919 pipeline got wrong:
+ *
+ *   1. The host CLI is in scope at all — before this change nothing on a
+ *      host ever updated it, which is how the reference host's CLI reached
+ *      0.19.23 against a v0.19.28 fleet.
+ *   2. It is updated FIRST. `apply-config` renders per-agent scaffolds from
+ *      Handlebars templates that ship inside the installed CLI, so a
+ *      self-update ordered after apply renders the run from the OLD
+ *      templates — the drift, one release later.
+ *   3. Whole-host update is the DEFAULT; the scope control is an opt-out.
+ *   4. After a swap the process re-execs the NEW binary — a process cannot
+ *      begin executing a replacement of its own file — with loop guards.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { planUpdate, runUpdate, buildReexecArgs } from "./update.js";
+import type { SelfUpdateIO } from "./self-update.js";
+
+function withCompose<T>(fn: (composePath: string) => T): T {
+  const tmp = mkdtempSync(join(tmpdir(), "update-selfupd-"));
+  try {
+    const composePath = join(tmp, "docker-compose.yml");
+    writeFileSync(composePath, "services: {}\n");
+    return fn(composePath);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+const baseOpts = {
+  hostControlEnabled: false,
+  webServiceManaged: false,
+  memoryBackendHindsight: false,
+  syncBundledSkillsFn: () => {},
+  agentNamesFn: () => [] as string[],
+  writeMarkerFn: () => {},
+  componentExec: () => ({ status: 1, stdout: "" }),
+};
+
+/** A self-update IO that swaps successfully, with no network or disk. */
+function fakeIO(): SelfUpdateIO {
+  const files = new Map<string, string>([["/usr/local/bin/switchroom", "OLD"]]);
+  return {
+    httpGetText: async (url) =>
+      url.endsWith("switchroom-checksums.txt")
+        ? `${"a".repeat(64)}  switchroom-linux-amd64\n${"a".repeat(64)}  switchroom-linux-arm64\n${"a".repeat(64)}  switchroom-macos-amd64\n${"a".repeat(64)}  switchroom-macos-arm64\n`
+        : '{"tag_name":"v9.9.9"}',
+    httpDownload: async (_u, dest) => void files.set(dest, "NEW"),
+    sha256File: () => "a".repeat(64),
+    probeBinaryVersion: () => "9.9.9",
+    mkdirp: () => {},
+    copyFile: (s, d) => void files.set(d, files.get(s) ?? ""),
+    chmodExec: () => {},
+    rename: (s, d) => {
+      files.set(d, files.get(s) ?? "");
+      files.delete(s);
+    },
+    remove: (p) => void files.delete(p),
+    exists: (p) => files.has(p),
+    dirname: (p) => p.slice(0, p.lastIndexOf("/")) || "/",
+  };
+}
+
+const STATIC_PROBE = {
+  bundleDir: "/$bunfs/root",
+  execPath: "/usr/local/bin/switchroom",
+  scriptPath: "/$bunfs/root/switchroom",
+  inContainer: false,
+};
+
+describe("self-update-cli is in the plan, first, by default", () => {
+  it("is the FIRST step — ahead of apply-config, which renders from CLI templates", () => {
+    withCompose((composePath) => {
+      const names = planUpdate({ composePath, ...baseOpts }).map((s) => s.name);
+      expect(names[0]).toBe("self-update-cli");
+      expect(names.indexOf("self-update-cli")).toBeLessThan(
+        names.indexOf("apply-config"),
+      );
+    });
+  });
+
+  it("still precedes persist-release-pin and the compose regen under --pin", () => {
+    withCompose((composePath) => {
+      const names = planUpdate({
+        composePath,
+        ...baseOpts,
+        pin: "v1.2.3",
+        persistPinFn: () => {},
+      }).map((s) => s.name);
+      expect(names[0]).toBe("self-update-cli");
+      expect(names).toContain("persist-release-pin");
+      expect(names.indexOf("self-update-cli")).toBeLessThan(
+        names.indexOf("persist-release-pin"),
+      );
+    });
+  });
+
+  it("runs by DEFAULT — whole-host update is opt-out, not opt-in", () => {
+    withCompose((composePath) => {
+      const step = planUpdate({ composePath, ...baseOpts }).find(
+        (s) => s.name === "self-update-cli",
+      );
+      expect(step?.skipReason).toBeUndefined();
+    });
+  });
+
+  it("--skip-self-update opts out, and --check says so", async () => {
+    await withCompose(async (composePath) => {
+      const step = planUpdate({
+        composePath,
+        ...baseOpts,
+        skipSelfUpdate: true,
+      }).find((s) => s.name === "self-update-cli");
+      expect(step?.skipReason).toBe("--skip-self-update flag set");
+
+      let out = "";
+      const code = await runUpdate({
+        composePath,
+        ...baseOpts,
+        skipSelfUpdate: true,
+        check: true,
+        stdout: (s) => {
+          out += s;
+        },
+        stderr: () => {},
+      });
+      expect(code).toBe(0);
+      expect(out).toContain("self-update-cli");
+      expect(out).toContain("--skip-self-update flag set");
+    });
+  });
+
+  it("--check names the step as [run] when it is NOT opted out", async () => {
+    await withCompose(async (composePath) => {
+      let out = "";
+      await runUpdate({
+        composePath,
+        ...baseOpts,
+        check: true,
+        stdout: (s) => {
+          out += s;
+        },
+        stderr: () => {},
+      });
+      // The step is listed and not marked skipped.
+      const line = out
+        .split("\n")
+        .find((l) => l.includes("self-update-cli"));
+      expect(line).toBeDefined();
+      expect(line).not.toContain("[skip]");
+    });
+  });
+});
+
+describe("--check reports component drift", () => {
+  it("names every component behind the pin, including the CLI itself", async () => {
+    await withCompose(async (composePath) => {
+      let out = "";
+      await runUpdate({
+        composePath,
+        ...baseOpts,
+        check: true,
+        componentExec: () => ({
+          status: 0,
+          stdout: [
+            "switchroom-hostd\tghcr.io/switchroom/switchroom-hostd:v0.19.28",
+            "switchroom-hindsight-autoheal\tghcr.io/switchroom/switchroom-hostd:v0.19.26",
+            "switchroom-web\tghcr.io/switchroom/switchroom-web:v0.19.26",
+          ].join("\n"),
+        }),
+        stdout: (s) => {
+          out += s;
+        },
+        stderr: () => {},
+      });
+      expect(out).toContain("BEHIND   switchroom-web — v0.19.26");
+      expect(out).toContain("BEHIND   switchroom-hindsight-autoheal — v0.19.26");
+      expect(out).toContain("component(s) BEHIND");
+    });
+  });
+});
+
+describe("swap → re-exec", () => {
+  it("re-execs the NEW binary for the remaining steps and adopts its exit code", async () => {
+    await withCompose(async (composePath) => {
+      const reexec: Array<{ bin: string; args: string[] }> = [];
+      const ranAfter: string[] = [];
+      const code = await runUpdate({
+        composePath,
+        ...baseOpts,
+        installProbe: STATIC_PROBE,
+        selfUpdateIO: fakeIO(),
+        latestReleaseTagFn: async () => "v9.9.9",
+        runner: (cmd, args) => {
+          ranAfter.push(`${cmd} ${args[1] ?? args[0]}`);
+          return { status: 0 };
+        },
+        reexecFn: (bin, args) => {
+          reexec.push({ bin, args });
+          return { status: 0 };
+        },
+        stdout: () => {},
+        stderr: () => {},
+      });
+      expect(code).toBe(0);
+      expect(reexec).toHaveLength(1);
+      expect(reexec[0].bin).toBe("/usr/local/bin/switchroom");
+      expect(reexec[0].args).toEqual(["update", "--skip-self-update"]);
+      // The OLD process must NOT go on to run apply-config etc. — that is
+      // the whole reason to re-exec.
+      expect(ranAfter).toEqual([]);
+    });
+  });
+
+  it("propagates a non-zero exit from the re-exec'd binary", async () => {
+    await withCompose(async (composePath) => {
+      const code = await runUpdate({
+        composePath,
+        ...baseOpts,
+        installProbe: STATIC_PROBE,
+        selfUpdateIO: fakeIO(),
+        latestReleaseTagFn: async () => "v9.9.9",
+        reexecFn: () => ({ status: 3 }),
+        stdout: () => {},
+        stderr: () => {},
+      });
+      expect(code).toBe(3);
+    });
+  });
+
+  it("does NOT re-exec when the CLI was already current", async () => {
+    await withCompose(async (composePath) => {
+      let reexeced = false;
+      await runUpdate({
+        composePath,
+        ...baseOpts,
+        installProbe: STATIC_PROBE,
+        selfUpdateIO: fakeIO(),
+        // Older than the running CLI → nothing to do.
+        latestReleaseTagFn: async () => "v0.0.1",
+        runner: () => ({ status: 0 }),
+        reexecFn: () => {
+          reexeced = true;
+          return { status: 0 };
+        },
+        stdout: () => {},
+        stderr: () => {},
+      });
+      expect(reexeced).toBe(false);
+    });
+  });
+
+  it("fails the whole update when the swap fails — never silently continues stale", async () => {
+    await withCompose(async (composePath) => {
+      let err = "";
+      const code = await runUpdate({
+        composePath,
+        ...baseOpts,
+        installProbe: STATIC_PROBE,
+        selfUpdateIO: {
+          ...fakeIO(),
+          probeBinaryVersion: () => null, // downloaded binary won't run
+        },
+        latestReleaseTagFn: async () => "v9.9.9",
+        runner: () => ({ status: 0 }),
+        reexecFn: () => ({ status: 0 }),
+        stdout: () => {},
+        stderr: (s) => {
+          err += s;
+        },
+      });
+      expect(code).toBe(1);
+      expect(err).toContain("self-update-cli failed");
+      expect(err).toContain("did not run cleanly");
+    });
+  });
+});
+
+describe("buildReexecArgs", () => {
+  it("always carries the loop guard", () => {
+    expect(buildReexecArgs({})).toEqual(["update", "--skip-self-update"]);
+  });
+
+  it("forwards the flags that still matter after the swap", () => {
+    expect(
+      buildReexecArgs({ skipImages: true, pin: "v1.2.3" }),
+    ).toEqual(["update", "--skip-self-update", "--skip-images", "--pin", "v1.2.3"]);
+    expect(buildReexecArgs({ channel: "rc" })).toEqual([
+      "update",
+      "--skip-self-update",
+      "--channel",
+      "rc",
+    ]);
+  });
+});

--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -48,6 +48,10 @@ describe("planUpdate", () => {
         memoryBackendHindsight: false,
       });
       expect(steps.map((s) => s.name)).toEqual([
+        // self-update-cli is FIRST by design (#3919): apply-config renders
+        // scaffolds from templates shipped inside the CLI, so updating the
+        // CLI afterwards would render this run from the old templates.
+        "self-update-cli",
         "pull-images",
         "apply-config",
         "refresh-hostd",
@@ -263,6 +267,7 @@ describe("planUpdate", () => {
         memoryBackendHindsight: false,
       });
       expect(steps.map((s) => s.name)).toEqual([
+        "self-update-cli",
         "pull-images",
         "rebuild-source",
         "apply-config",

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -52,6 +52,23 @@ import { normalizeHindsightVersionTag } from "../setup/hindsight.js";
 import { getBuiltinDefaultSkillEntries } from "../memory/scaffold-integration.js";
 import { syncBundledSkills } from "./sync-bundled-skills.js";
 import { SWITCHROOM_VERSION } from "./resolve-version.js";
+import {
+  alreadySelfUpdated,
+  detectInstallKind,
+  fetchLatestReleaseTag,
+  performSelfUpdate,
+  planSelfUpdate,
+  releaseAssetName,
+  SELF_UPDATE_ENV_SENTINEL,
+  type SelfUpdateIO,
+} from "./self-update.js";
+import { defaultSelfUpdateIO } from "./self-update-io.js";
+import {
+  collectComponents,
+  detectComponentDrift,
+  formatComponentDrift,
+  type ExecFn,
+} from "./component-versions.js";
 
 /**
  * Default durable-pin persister for `update --pin`: comment-preserving,
@@ -156,6 +173,37 @@ interface UpdateOptions {
    * `true`/`false` explicitly to avoid touching the real process env.
    */
   hostdContext?: boolean;
+  /**
+   * Opt OUT of the host-CLI self-update step (#3919).
+   *
+   * DEFAULT IS ON, deliberately. `switchroom update`'s documented
+   * contract is "update switchroom on this host"; a version of it that
+   * silently leaves the CLI behind is the defect, not the feature. Making
+   * whole-host update opt-IN would preserve the current drift for every
+   * operator who never learns the flag — which is exactly how the CLI on
+   * the reference host reached three releases of skew. So the scope
+   * control is an opt-out, and `--check` names the step either way.
+   */
+  skipSelfUpdate?: boolean;
+  /** Test seam — replace the self-update side effects. */
+  selfUpdateIO?: SelfUpdateIO;
+  /** Test seam — override the resolved latest published release tag
+   *  (bypasses the GitHub round-trip). */
+  latestReleaseTagFn?: () => Promise<string | null>;
+  /** Test seam — override install-kind detection inputs. */
+  installProbe?: Parameters<typeof detectInstallKind>[0];
+  /** Test seam — exec used by the component-version inventory. */
+  componentExec?: ExecFn;
+  /**
+   * Mutable sink the self-update step writes to when it replaces the
+   * binary. `runUpdate` reads it and re-execs the NEW binary for the
+   * remaining steps. A shared holder (rather than a throw / process.exit
+   * inside the step) keeps `planUpdate` pure-ish and the re-exec
+   * decision in one place.
+   */
+  selfUpdateSink?: { replacedWith?: string; binaryPath?: string };
+  /** Test seam — replace the re-exec of the freshly installed binary. */
+  reexecFn?: (binaryPath: string, args: string[]) => { status: number };
 }
 
 interface UpdateStep {
@@ -171,7 +219,7 @@ interface UpdateStep {
    */
   isHostdDeferred?: boolean;
   /** Invoked when not in --check mode. Throws on failure. */
-  run: () => void;
+  run: () => void | Promise<void>;
 }
 
 const DEFAULT_COMPOSE_PATH = join(
@@ -393,6 +441,87 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
   // end of runUpdate tells the server which steps were deferred.
   const hostdContext =
     typeof opts.hostdContext === "boolean" ? opts.hostdContext : isHostdContext();
+
+  // ── self-update-cli — FIRST, ahead of everything (#3919) ──────────────
+  //
+  // Ordering is the whole point of this step. `apply-config` renders every
+  // per-agent scaffold from Handlebars templates that ship INSIDE the
+  // installed CLI, so a CLI updated AFTER apply renders this run from the
+  // OLD templates and the new one sits unused until the next update — the
+  // drift, one release later. It also precedes persist-release-pin and the
+  // compose regen so the whole rest of the plan runs under the new code.
+  //
+  // Skipped (never failed) when the install is not a published static
+  // binary, when GitHub is unreachable, or when the operator opted out.
+  // Skipping is loud: the reason is printed and, in --check, listed.
+  steps.push({
+    name: "self-update-cli",
+    description:
+      "Replace the host operator CLI binary with the latest published release (checksum-verified, run-proved, atomic swap + versioned rollback copy), then re-exec the new binary for the remaining steps",
+    skipReason: opts.skipSelfUpdate
+      ? "--skip-self-update flag set"
+      : alreadySelfUpdated(process.env)
+        ? "already re-exec'd from a freshly installed binary in this run"
+        : undefined,
+    run: async () => {
+      const say = opts.stdout ?? ((t: string) => process.stdout.write(t));
+      const io = opts.selfUpdateIO ?? defaultSelfUpdateIO();
+      const detection = detectInstallKind(
+        opts.installProbe ?? {
+          bundleDir: import.meta.dirname,
+          execPath: process.execPath,
+          scriptPath: scriptPath,
+          inContainer:
+            process.env.SWITCHROOM_HOSTD_CONTEXT === "1" ||
+            existsSync("/.dockerenv"),
+        },
+      );
+      // Classify BEFORE any network I/O: a container / checkout / npm
+      // install can never be self-updated, so asking GitHub about it is a
+      // pointless round-trip (and would make every unit test that walks
+      // this step reach the network).
+      if (detection.kind !== "static-binary") {
+        say(chalk.gray(`  host CLI not self-updated: ${detection.reason}\n`));
+        return;
+      }
+      const latestTag = opts.latestReleaseTagFn
+        ? await opts.latestReleaseTagFn()
+        : await fetchLatestReleaseTag(io);
+      const plan = planSelfUpdate({
+        detection,
+        currentVersion: SWITCHROOM_VERSION,
+        latestTag,
+      });
+      if (plan.action === "skip") {
+        say(chalk.gray(`  host CLI not self-updated: ${plan.reason}\n`));
+        return;
+      }
+      if (plan.action === "current") {
+        say(chalk.gray(`  host CLI already on ${plan.version}\n`));
+        return;
+      }
+      const asset = releaseAssetName(process.platform, process.arch);
+      if (!asset) {
+        say(
+          chalk.gray(
+            `  host CLI not self-updated: no published binary for ${process.platform}/${process.arch}\n`,
+          ),
+        );
+        return;
+      }
+      const result = await performSelfUpdate({
+        plan,
+        assetName: asset,
+        io,
+        log: (s) => say(chalk.gray(`  ${s}\n`)),
+      });
+      if (result.replaced && opts.selfUpdateSink) {
+        opts.selfUpdateSink.replacedWith = result.newVersion;
+        opts.selfUpdateSink.binaryPath = result.binaryPath;
+      }
+      say(chalk.green(`  ${result.message}\n`));
+    },
+  });
 
   // When --channel / --pin is set, the resolved image tag in compose
   // needs to change BEFORE pull-images runs (so `docker compose pull`
@@ -1195,6 +1324,66 @@ function formatStatusReport(rep: StatusReport): string {
   return lines.join("\n");
 }
 
+/**
+ * Reconstruct this run's flags for the re-exec'd (new) binary, plus the
+ * two loop guards. Only flags that are still meaningful after the CLI has
+ * already been replaced are forwarded — `--check` and `--status` never
+ * reach here (they return before any step runs).
+ */
+export function buildReexecArgs(opts: UpdateOptions): string[] {
+  const args = ["update", "--skip-self-update"];
+  if (opts.skipImages) args.push("--skip-images");
+  if (opts.channel) args.push("--channel", opts.channel);
+  // self-update-cli runs BEFORE persist-release-pin, so this run has not
+  // persisted --pin yet. Forward it; the new binary does the persist.
+  if (opts.pin) args.push("--pin", opts.pin);
+  // --rebuild is deliberately NOT forwarded: it is refused on any
+  // published install, and a static binary (the only self-updatable
+  // shape) is by definition published.
+  return args;
+}
+
+function defaultReexec(binaryPath: string, args: string[]): { status: number } {
+  const r = spawnSync(binaryPath, args, {
+    stdio: "inherit",
+    env: { ...process.env, [SELF_UPDATE_ENV_SENTINEL]: "1" },
+  });
+  return { status: r.status ?? 1 };
+}
+
+/**
+ * Local, network-free component-version drift summary for `--check`.
+ *
+ * Never throws: an advisory block must not be able to break the dry-run
+ * an operator uses to decide whether to update.
+ */
+export function renderDriftPreamble(opts: UpdateOptions): string {
+  try {
+    const exec: ExecFn =
+      opts.componentExec ??
+      ((cmd, args) => {
+        const r = spawnSync(cmd, args, { encoding: "utf-8", timeout: 10_000 });
+        return { status: r.status ?? 1, stdout: r.stdout ?? "" };
+      });
+    let pin: string | undefined;
+    try {
+      pin = loadConfig().release?.pin ?? undefined;
+    } catch {
+      pin = undefined;
+    }
+    const report = detectComponentDrift(
+      collectComponents(SWITCHROOM_VERSION, exec),
+      pin,
+    );
+    const body = formatComponentDrift(report);
+    return report.behind.length > 0
+      ? `${body}\n\n${report.behind.length} component(s) BEHIND ${report.target} — this update targets them.\n`
+      : `${body}\n`;
+  } catch (err) {
+    return `Component versions: not checkable (${(err as Error).message})\n`;
+  }
+}
+
 async function runUpdate(opts: UpdateOptions): Promise<number> {
   const stdout = opts.stdout ?? ((s) => process.stdout.write(s));
   const stderr = opts.stderr ?? ((s) => process.stderr.write(s));
@@ -1238,10 +1427,19 @@ async function runUpdate(opts: UpdateOptions): Promise<number> {
     }
   }
 
-  const steps = planUpdate(opts);
+  // Sink the self-update step writes to when it swaps the binary, so the
+  // loop below knows it must re-exec the NEW code for the remaining steps.
+  const selfUpdateSink: { replacedWith?: string; binaryPath?: string } =
+    opts.selfUpdateSink ?? {};
+  const steps = planUpdate({ ...opts, selfUpdateSink });
 
   if (opts.check) {
     stdout(chalk.bold("switchroom update --check (dry-run)\n\n"));
+    // Report component drift up front (#3919). Local-only and
+    // deterministic — this is the standing answer to "is anything on this
+    // host behind?" that nobody had, which is why three components drifted
+    // across three releases with only transient warnings to show for it.
+    stdout(renderDriftPreamble(opts) + "\n");
     for (const step of steps) {
       const status = step.skipReason
         ? chalk.gray(`[skip] ${step.skipReason}`)
@@ -1259,7 +1457,31 @@ async function runUpdate(opts: UpdateOptions): Promise<number> {
     }
     stdout(chalk.bold(`▸ ${step.name}\n`));
     try {
-      step.run();
+      await step.run();
+      if (step.name === "self-update-cli" && selfUpdateSink.binaryPath) {
+        // The binary on $PATH is now the new release, but THIS process is
+        // still running the old code — a process cannot start executing a
+        // replacement of its own file. Hand the rest of the plan to the new
+        // binary and adopt its exit status. `--skip-self-update` plus the
+        // env sentinel make a re-exec loop impossible even if the new
+        // binary mis-reports its own version.
+        //
+        // This can never fire in a hostd-driven run: inside a container
+        // detectInstallKind() returns `container` and the step skips, so
+        // the UPDATE_RESULT sentinel line the server parses is always
+        // emitted by this process, never swallowed by a child.
+        const reexec = opts.reexecFn ?? defaultReexec;
+        stdout(
+          chalk.bold(
+            `\n▸ re-exec ${selfUpdateSink.binaryPath} (${selfUpdateSink.replacedWith}) for the remaining steps\n`,
+          ),
+        );
+        const r = reexec(
+          selfUpdateSink.binaryPath,
+          buildReexecArgs(opts),
+        );
+        return r.status;
+      }
     } catch (err) {
       stderr(
         chalk.red(`✗ ${step.name} failed: ${(err as Error).message}\n`),
@@ -1291,10 +1513,14 @@ export function registerUpdateCommand(program: Command): void {
   program
     .command("update")
     .description(
-      "Update switchroom on this host: pull images, refresh scaffolds, recreate containers. Wraps the full `pull && apply && up -d` flow.",
+      "Update EVERY switchroom component on this host — the operator CLI itself (first), images, scaffolds, the hostd / web / hindsight singletons, and the agent fleet. Wraps the full `self-update && pull && apply && up -d` flow.",
     )
     .option("--check", "Dry-run: print the steps that would execute, exit 0.")
     .option("--skip-images", "Skip the docker image pull (offline mode).")
+    .option(
+      "--skip-self-update",
+      "Do NOT replace the host operator CLI binary. By default `update` updates every switchroom component INCLUDING itself (and does it first, because `apply` renders scaffolds from templates shipped inside the CLI).",
+    )
     .option(
       "--rebuild",
       "Source-checkout / maintainer only: git pull + bun install + npm run build before applying. REFUSED on a published install — use `npm i -g switchroom@latest && switchroom update` there.",

--- a/src/host-control/self-bump.test.ts
+++ b/src/host-control/self-bump.test.ts
@@ -77,6 +77,50 @@ describe("bumpHostdComposeImageTag", () => {
     expect(r!.yaml).toContain("switchroom-agent:v0.16.49");
     expect(r!.yaml).toContain("switchroom-hostd:v0.17.0");
   });
+
+  // #3919 regression: the hostd compose project has carried a SECOND
+  // service on the hostd image since #2910 (`hindsight-autoheal`). The
+  // original non-global regex rewrote only the first match, so every
+  // self-bump advanced `hostd` and left `hindsight-autoheal` on the prior
+  // tag — the exact split observed on the operator host (hostd v0.19.28,
+  // autoheal v0.19.26). Assert the OUTCOME: no stale tag survives anywhere.
+  it("bumps EVERY switchroom-hostd image line, including the hindsight-autoheal sidecar", () => {
+    const twoServices = [
+      "services:",
+      "  hostd:",
+      "    image: ghcr.io/switchroom/switchroom-hostd:v0.19.26",
+      "    volumes:",
+      "      - /var/run/docker.sock:/var/run/docker.sock",
+      "",
+      "  hindsight-autoheal:",
+      "    image: ghcr.io/switchroom/switchroom-hostd:v0.19.26",
+      "    container_name: switchroom-hindsight-autoheal",
+    ].join("\n");
+    const r = bumpHostdComposeImageTag(twoServices, "v0.19.28");
+    expect(r).not.toBeNull();
+    expect(r!.bumpedCount).toBe(2);
+    // No line anywhere is left on the prior tag.
+    expect(r!.yaml).not.toContain("v0.19.26");
+    expect(r!.yaml.match(/switchroom-hostd:v0\.19\.28/g)?.length).toBe(2);
+    // The blank line between the two services survives (a globalised
+    // `\s*$` tail would eat the trailing newlines).
+    expect(r!.yaml).toContain(
+      "      - /var/run/docker.sock:/var/run/docker.sock\n\n  hindsight-autoheal:",
+    );
+    expect(r!.yaml).toContain("container_name: switchroom-hindsight-autoheal");
+  });
+
+  it("preserves each line's own registry prefix when they differ", () => {
+    const mirrored = [
+      "  hostd:",
+      "    image: ghcr.io/switchroom/switchroom-hostd:v1.0.0",
+      "  hindsight-autoheal:",
+      "    image: registry.example.com/me/switchroom-hostd:v1.0.0",
+    ].join("\n");
+    const r = bumpHostdComposeImageTag(mirrored, "v1.1.0");
+    expect(r!.yaml).toContain("ghcr.io/switchroom/switchroom-hostd:v1.1.0");
+    expect(r!.yaml).toContain("registry.example.com/me/switchroom-hostd:v1.1.0");
+  });
 });
 
 describe("pending-rollout marker", () => {

--- a/src/host-control/self-bump.ts
+++ b/src/host-control/self-bump.ts
@@ -105,27 +105,51 @@ export function needsSelfBump(
 }
 
 /**
- * Tag-bump the hostd compose yaml: rewrite the `image:` line that
+ * Tag-bump the hostd compose yaml: rewrite EVERY `image:` line that
  * references a `switchroom-hostd` image to the target pin, preserving the
  * registry/owner prefix as-is (forks / GHCR mirrors keep working).
  *
+ * ALL matches, not just the first (#3919). The hostd compose project has
+ * carried a SECOND service on the hostd image since #2910 — the
+ * `hindsight-autoheal` sidecar. The original implementation used a
+ * non-global regex with `String.replace`, which rewrites only the first
+ * match, so every self-bump advanced the `hostd` service and silently left
+ * `hindsight-autoheal` on the prior tag. Observed on the operator host:
+ * `switchroom-hostd` on v0.19.28 while `switchroom-hindsight-autoheal` was
+ * still on v0.19.26, two releases after the sidecar last saw a host-side
+ * `hostd install`. Nothing surfaced the split because the self-bump reports
+ * only the (correctly bumped) hostd ref.
+ *
  * Returns the rewritten yaml plus the old and new image refs, or null when
  * no such image line is found (hand-mangled compose — caller refuses and
- * points at host-side `hostd install`).
+ * points at host-side `hostd install`). `oldImageRef` is the ref of the
+ * FIRST matched line (the `hostd` service in a generated compose) so the
+ * caller's audit line is unchanged; `bumpedCount` reports how many lines
+ * were actually rewritten.
  */
 export function bumpHostdComposeImageTag(
   yaml: string,
   pin: string,
-): { yaml: string; oldImageRef: string; newImageRef: string } | null {
-  const re = /^(\s*image:\s*)(\S*switchroom-hostd):(\S+)\s*$/m;
-  const m = yaml.match(re);
-  if (!m) return null;
-  const oldImageRef = `${m[2]}:${m[3]}`;
-  const newImageRef = `${m[2]}:${pin}`;
+): {
+  yaml: string;
+  oldImageRef: string;
+  newImageRef: string;
+  bumpedCount: number;
+} | null {
+  const re = /^(\s*image:\s*)(\S*switchroom-hostd):(\S+)[ \t]*$/gm;
+  const matches = [...yaml.matchAll(re)];
+  if (matches.length === 0) return null;
+  const first = matches[0];
+  const oldImageRef = `${first[2]}:${first[3]}`;
+  const newImageRef = `${first[2]}:${pin}`;
   return {
-    yaml: yaml.replace(re, `$1${newImageRef}`),
+    // Rewrite every match, preserving each line's own registry/owner
+    // prefix — a fork could legitimately mirror the two services from
+    // different registries and we must not collapse them onto one.
+    yaml: yaml.replace(re, (_m, indent: string, repo: string) => `${indent}${repo}:${pin}`),
     oldImageRef,
     newImageRef,
+    bumpedCount: matches.length,
   };
 }
 

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -2518,6 +2518,14 @@ export class HostdServer {
     };
     copyFileSync(composePath, bakPath);
     writeFileSync(composePath, bumped.yaml, "utf8");
+    // #3919: log HOW MANY hostd image lines were bumped. The compose has
+    // carried two since the hindsight-autoheal sidecar (#2910), and the bug
+    // that stranded that sidecar for three releases was invisible precisely
+    // because this step only ever reported the single hostd ref.
+    process.stderr.write(
+      `hostd: self-bump rewrote ${bumped.bumpedCount} switchroom-hostd ` +
+        `image line(s) → ${bumped.newImageRef}\n`,
+    );
     writeFileSync(markerPath, encodePendingRolloutMarker(marker), {
       mode: 0o600,
     });


### PR DESCRIPTION
Closes #3919.

## The problem

`switchroom update` updated every switchroom component **except the one running the update**, and nothing anywhere reported the resulting skew. The reference host carried three simultaneous drifts against a v0.19.28 fleet:

| component | version | cause |
|---|---|---|
| host CLI | 0.19.23 | nothing on a host ever updates it |
| `switchroom-hindsight-autoheal` | v0.19.26 | non-global regex in the hostd self-bump |
| `switchroom-web` | v0.19.26 | `webd install` fails non-fatally on operator-uid |

Three unrelated causes, one shared signature: a component quietly left behind. They survived three releases not because the individual failures were invisible — two logged a warning at the time — but because **nothing held a standing, checkable answer to "is every component on the same version?"**. A warning scrolls past once; a deterministic check fires every time you look.

## What this PR does

### 1. The host CLI self-updates, and it goes FIRST

`apply-config` renders every per-agent scaffold from Handlebars templates that ship **inside the installed CLI**. A merged feature that adds a template variable is invisible on a host whose CLI is stale, no matter how current the images are — the CLI is the compiler, the images are the output. So `self-update-cli` runs ahead of `persist-release-pin`, the compose regen, and `apply-config`.

**Mechanics** (`src/cli/self-update.ts`, decisions in the module header):

- Fetches the same GitHub release asset `install.sh` publishes, verifies SHA256 against `switchroom-checksums.txt`, and **proves the candidate runs** (`<candidate> version`, exit 0 + parseable version) *before* any swap.
- Archives the outgoing binary to `<installDir>/.switchroom-versions/switchroom-<old>`, then two same-filesystem atomic `rename(2)`s. The store lives inside the install dir specifically so the final rename is atomic rather than a copy with a torn-file window. Rollback is one printed `cp`.
- **Swap-then-re-exec**, not swap-in-place and not a detached helper. A process cannot begin executing a replacement of its own file, so after the swap we hand the remaining plan to the new binary and adopt its exit status. Loop-guarded by `--skip-self-update` plus `SWITCHROOM_SELF_UPDATED=1`. The detached-helper pattern hostd uses (`self-bump.ts`, `deploy-v01546.sh`) exists because *that* process is about to SIGKILL itself recreating its own container; the host CLI has no such hazard, and a helper would cost the operator streamed output and the exit code for no safety gain.
- **Non-static installs are detected and skipped, never clobbered** — source checkout, npm global, in-container each get the correct remediation printed. Classification happens *before* any network I/O.

**Default-on with `--skip-self-update` as the opt-out.** Opt-in would preserve the drift for every operator who never learns the flag — which is exactly how this host reached three releases of skew.

**Failure modes, all covered by tests:** download fails / truncated / 404 → temp removed, update fails, installed CLI byte-identical. Checksum mismatch → refuse. Candidate won't run → refuse *before* the swap. Rollback copy can't be made → refuse to swap. Interrupted between swap and apply-config → benign: new CLI + un-applied config, and the next `switchroom update` converges (strictly better than the reverse order, which renders scaffolds from templates the operator has already replaced).

### 2. Root cause of the stranded autoheal sidecar

`bumpHostdComposeImageTag` used a **non-global** regex with `String.replace`, which rewrites only the first match. The hostd compose has carried a *second* `switchroom-hostd` image line since the `hindsight-autoheal` sidecar (#2910), so every self-bump advanced `hostd` and silently left the sidecar behind. Now rewrites every line, preserving each line's own registry prefix (forks mirroring the two services from different registries must not collapse onto one), and logs `bumpedCount` so a future split is observable.

The regression tests were verified to **FAIL against the pre-fix implementation** (`expected undefined to be 2`, and the second line still on the old tag).

### 3. Deterministic drift reporting

New `src/cli/component-versions.ts` — enumerative, pure, network-free:

- Inventory comes from `docker ps`, **not a hardcoded list**. A hardcoded list is how the autoheal sidecar escaped notice; a component added tomorrow is covered the day it ships.
- Inclusion is keyed on the image repo path (`…/switchroom-<x>`), so third-party images running under switchroom-prefixed container names (`switchroom-hostd-docker-proxy` → `ghcr.io/tecnativa/…`, `switchroom-grafana-fwd` → `alpine/socat`) and locally-built dev images (`switchroom-uat-runner:local`) are excluded, while **every** published component is covered — including `switchroom-hindsight`, which an earlier draft wrongly excluded by name until a live `docker ps` proved it is release-tagged.
- Target is `release.pin` when set (the operator's declared intent, and what compose / `webd install` / `hostd install` all resolve from), else the highest deployed version. Network-free so `doctor` stays fast and offline-safe.

Surfaced two ways: a **warn-only** `switchroom doctor` section (never `fail` — skew is a real finding but not a broken install, and it must not change doctor's exit code) with a per-component remediation, and a drift preamble on `switchroom update --check` that names every component behind the target.

## Testing

`npm run lint` clean. Scoped suites green: `component-versions` (17), `self-update` (25), `update-self-update` (12), `doctor-component-versions` (5), `self-bump` (27), `update` (68), full `src/host-control/` (173).

Tests assert outcomes, not code paths:
- The self-bump regression tests were confirmed to fail against the old implementation (path-scoped stash, so the fix was removed but the tests were not).
- The drift tests run against a **verbatim capture of the reference host's `docker ps`** and assert the exact set of stale components — `[cli (host), switchroom-hindsight-autoheal, switchroom-web]`.
- The `performSelfUpdate` suite drives download / checksum / prove / archive failures against an in-memory filesystem and asserts in each case that the installed binary is still `OLD-BINARY`.

`src/cli/apply.test.ts` has 10 failures, **pre-existing on a clean `origin/main` tree** (verified by stashing) — unrelated to this change.

## Deliberately out of scope

- **#3920** — `switchroom-web` drift. `webd install` inside hostd exits non-zero ("Could not resolve the operator uid") against a hostd compose that predates `SWITCHROOM_HOSTD_OPERATOR_UID`, and the rollout treats that as non-fatal. Separate root cause (hostd compose template staleness / uid plumbing) needing its own design call. This PR makes the resulting drift permanently visible with the correct host-side fix string.
- **#3921** — `rebuildRefusalMessage` tells operators to `npm i -g switchroom@latest`, which is wrong for the static-binary shape `install.sh` publishes. Four existing assertions pin the string; fixing it belongs in its own PR.

## One contradiction worth flagging

The task premise said the install convention is versioned dirs `/opt/switchroom-cli-<version>` with a `switchroom-cli` symlink. The repo disagrees: `install.sh` installs a **single static binary** to `/usr/local/bin/switchroom`, and `grep -rn "opt/switchroom-cli"` returns nothing repo-wide. That layout is host-local (the wrapper there self-describes as "installed from the published npm release"). This PR implements against the real published artifact, while adopting the *spirit* of versioned dirs via the `.switchroom-versions/` store. A symlink target was rejected because `install.sh` would silently clobber it back to a regular file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)