### PR TITLE
fix(cards): share the ✅ result footer between the 🤖 agent and 🛠 worker cards

### DIFF
--- a/telegram-plugin/gateway/narrative-lane.ts
+++ b/telegram-plugin/gateway/narrative-lane.ts
@@ -133,6 +133,15 @@ export function createNarrativeLane(deps: NarrativeLaneDeps) {
       // The parent's OWN running token total → `· N tok` on the metrics line.
       // 0 → tokenSegment omits it (clean, same as the worker feed).
       totalTokens: turn.totalTokens,
+      // Terminal `✅ <summary>` footer, rendered through the SAME
+      // `deriveCardResult` the 🛠 worker card uses. The agent's analogue of the
+      // worker's `latestSummary` is the answer it actually delivered this turn
+      // (`lastReplyText`, stamped on the reply/stream_reply tool_use just
+      // before the first-reply `clearActivitySummary` hand-off). Only supplied
+      // on a FINAL render; empty (a turn that finalised before any reply — the
+      // foreground handoff-clear path — or a genuinely silent turn) → the
+      // shared derivation omits the block, exactly as the worker card does.
+      resultText: final ? turn.lastReplyText : undefined,
     }
     return renderActivityFeedWithNested(turn.mirrorLines, childLines, final, liveSuffix, stepCount, header)
   }
@@ -892,6 +901,9 @@ export function createNarrativeLane(deps: NarrativeLaneDeps) {
         const livenessHeader: SessionActivityHeader = {
           label: 'Agent', elapsedMs: livenessElapsed, toolCount: turn.labeledToolCount, state: 'done',
           model: turn.currentModel,
+          // Same terminal `✅ <summary>` footer as the normal final render —
+          // this liveness-only card is still a FINAL agent card.
+          resultText: turn.lastReplyText,
         }
         finalHtml = renderActivityFeedWithNested(['Working…'], [], true, '', undefined, livenessHeader)
       }

--- a/telegram-plugin/tests/agent-card-result-footer.test.ts
+++ b/telegram-plugin/tests/agent-card-result-footer.test.ts
@@ -1,0 +1,193 @@
+/**
+ * The 🤖 agent card and the 🛠 worker card must end the SAME way: a `─────`
+ * rule then `✅ _<final summary sentence>_`.
+ *
+ * Before this suite the two surfaces had already been unified for the card
+ * BODY (#3844 — one `renderStatusCard`/`card-layout` core), but the terminal
+ * RESULT footer was still forked: the derivation (clean the raw summary, pick
+ * ✅/⚠️ from the state, omit on empty, never emit one for `incomplete`) lived
+ * inline in `renderWorkerActivity`, so the agent card had no result block at
+ * all and ended on `✓ N steps`. `deriveCardResult` is now the single shared
+ * derivation and both adapters call it.
+ *
+ * These assertions fail on the forked behaviour: (1) the agent card had no
+ * `✅` footer to end with, and (2) there was no shared symbol whose output
+ * both cards' footers could be compared against byte for byte.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  deriveCardResult,
+  renderActivityFeed,
+  renderActivityFeedWithNested,
+  type SessionActivityHeader,
+} from '../tool-activity-summary.js'
+import { renderWorkerActivity, type WorkerActivityView } from '../worker-activity-feed.js'
+
+/** A realistic multi-line, markdown-authored final summary. */
+const RAW_SUMMARY = '## Result\nStanding by for the **background merge waiter** to complete.'
+/** What the shared derivation cleans it down to. */
+const CLEAN_SUMMARY = 'Result Standing by for the background merge waiter to complete.'
+/** The exact two trailing card lines both surfaces must end with. */
+const EXPECTED_FOOTER_TAIL = `─────`
+
+function agentHeader(over: Partial<SessionActivityHeader> = {}): SessionActivityHeader {
+  return {
+    label: 'Agent',
+    elapsedMs: 64_000,
+    toolCount: 6,
+    state: 'done',
+    model: 'claude-opus-5',
+    totalTokens: 3000,
+    ...over,
+  }
+}
+
+function workerView(over: Partial<WorkerActivityView> = {}): WorkerActivityView {
+  return {
+    description: 'Merge 3922 and cut v0.19.30',
+    lastTool: null,
+    toolCount: 6,
+    totalTokens: 3000,
+    latestSummary: RAW_SUMMARY,
+    narrativeLines: ['Reading a.ts', 'Running tests'],
+    elapsedMs: 64_000,
+    state: 'done',
+    model: 'claude-opus-5',
+    ...over,
+  }
+}
+
+/** The card's trailing result block: the `─────` rule line and everything after. */
+function footerOf(card: string): string {
+  const idx = card.lastIndexOf(EXPECTED_FOOTER_TAIL)
+  return idx === -1 ? '' : card.slice(idx)
+}
+
+describe('deriveCardResult — the ONE terminal-footer derivation', () => {
+  it('done → ✅ + the cleaned single-paragraph summary', () => {
+    expect(deriveCardResult('done', RAW_SUMMARY)).toEqual({ emoji: '✅', text: CLEAN_SUMMARY })
+  })
+
+  it('failed → ⚠️ (never the green tick)', () => {
+    expect(deriveCardResult('failed', RAW_SUMMARY)).toEqual({ emoji: '⚠️', text: CLEAN_SUMMARY })
+  })
+
+  it('running → no block (the card is not finished)', () => {
+    expect(deriveCardResult('running', RAW_SUMMARY)).toBeUndefined()
+  })
+
+  it('incomplete → NEVER a block, even with summary text (truthful-no-result)', () => {
+    expect(deriveCardResult('incomplete', RAW_SUMMARY)).toBeUndefined()
+  })
+
+  it('empty / whitespace / markdown-only summary → no block, never a fabricated line', () => {
+    expect(deriveCardResult('done', '')).toBeUndefined()
+    expect(deriveCardResult('done', undefined)).toBeUndefined()
+    expect(deriveCardResult('done', '   \n---\n  ')).toBeUndefined()
+  })
+
+  it('redacts a secret in the summary — cards bypass the outbound redact chokepoint', () => {
+    // Status cards go out via sendRichMessage, which skips
+    // `normalizeOutboundBody → redact` (outbound-send-path.ts). The agent
+    // card's summary is the turn's PRE-redaction reply text, so the scrub has
+    // to happen in this derivation or a token reaches Telegram verbatim.
+    const token = 'sk-ant-' + 'api03-' + 'A'.repeat(48)
+    const out = deriveCardResult('done', `Deployed with ${token} and all is green.`)!
+    expect(out.text).not.toContain(token)
+    expect(out.text).toContain('[REDACTED:')
+    expect(out.text).toContain('Deployed with')
+    expect(out.text).toContain('and all is green.')
+  })
+})
+
+describe('🤖 agent card ends with the ✅ + final-summary footer', () => {
+  it('final render with resultText appends the rule + ✅ summary as the LAST line', () => {
+    const card = renderActivityFeed(
+      ['Reading a.ts', 'Running tests'],
+      true,
+      '',
+      6,
+      agentHeader({ resultText: RAW_SUMMARY }),
+    )!
+    expect(card).toContain('─────')
+    // The ✅ summary is the final line of the card, exactly like the worker card.
+    expect(card.endsWith(`✅ _${CLEAN_SUMMARY}_`)).toBe(true)
+  })
+
+  it('the nested (foreground sub-agent) render gets the identical footer', () => {
+    const flat = renderActivityFeed(
+      ['Delegating: x'],
+      true,
+      '',
+      6,
+      agentHeader({ resultText: RAW_SUMMARY }),
+    )!
+    const nested = renderActivityFeedWithNested(
+      ['Delegating: x'],
+      ['child step'],
+      true,
+      '',
+      6,
+      agentHeader({ resultText: RAW_SUMMARY }),
+    )!
+    expect(footerOf(nested)).toBe(footerOf(flat))
+    expect(nested.endsWith(`✅ _${CLEAN_SUMMARY}_`)).toBe(true)
+  })
+
+  it('no resultText → no footer block (worker fallback), card still ends on ✓ N steps', () => {
+    const card = renderActivityFeed(['Reading a.ts'], true, '', 6, agentHeader())!
+    expect(card).not.toContain('─────')
+    expect(card).not.toContain('✅')
+    expect(card.endsWith('_✓ 6 steps_')).toBe(true)
+  })
+
+  it('a LIVE (non-final) render never shows the footer, even if resultText is set', () => {
+    const card = renderActivityFeed(
+      ['Reading a.ts'],
+      false,
+      '',
+      undefined,
+      agentHeader({ state: 'running', resultText: RAW_SUMMARY }),
+    )!
+    expect(card).not.toContain('─────')
+    expect(card).not.toContain('✅')
+  })
+})
+
+describe('both cards render their footer through the SAME shared derivation', () => {
+  it('agent + worker footers are byte-identical for the same raw summary', () => {
+    const agent = renderActivityFeed(
+      ['Reading a.ts', 'Running tests'],
+      true,
+      '',
+      6,
+      agentHeader({ resultText: RAW_SUMMARY }),
+    )!
+    const worker = renderWorkerActivity(workerView())
+    const footer = footerOf(agent)
+    expect(footer).not.toBe('')
+    expect(footer).toBe(footerOf(worker))
+    // …and that shared footer is exactly what `deriveCardResult` produced.
+    const derived = deriveCardResult('done', RAW_SUMMARY)!
+    expect(footer.endsWith(`${derived.emoji} _${derived.text}_`)).toBe(true)
+  })
+
+  it('the shared body (stats line + struck step list) is identical too', () => {
+    // Line 2 (the `done · N tools · N tok · elapsed · model` stats run) and the
+    // struck-through step lines come from the one card core — the only
+    // legitimate difference is the title line (icon + label + task).
+    const agent = renderActivityFeed(
+      ['Reading a.ts', 'Running tests'],
+      true,
+      '',
+      undefined,
+      agentHeader({ resultText: RAW_SUMMARY }),
+    )!
+    const worker = renderWorkerActivity(workerView())
+    const dropTitle = (card: string) => card.split('  \n').slice(1).join('  \n')
+    expect(dropTitle(agent)).toBe(dropTitle(worker))
+    // The title lines DO differ — that is the one parameterised difference.
+    expect(agent.split('  \n')[0]).toContain('🤖')
+    expect(worker.split('  \n')[0]).toContain('🛠')
+  })
+})

--- a/telegram-plugin/tests/narrative-lane-golden.test.ts
+++ b/telegram-plugin/tests/narrative-lane-golden.test.ts
@@ -211,6 +211,34 @@ describe('narrative-lane golden — SHOW path opens then edits ONE feed card', (
     expect(final!).toMatch(/3 steps/)
     expect(live!).not.toMatch(/3 steps/)
   })
+
+  it('composeTurnActivity: the FINAL render ends with the ✅ + delivered-answer footer', () => {
+    // Parity with the 🛠 worker card, which has always closed on `✅ <summary>`.
+    // The agent card's analogue of the worker's `latestSummary` is the answer
+    // the turn actually delivered (`turn.lastReplyText`); the lane threads it
+    // into the header as `resultText` and the SHARED `deriveCardResult` renders
+    // it. Fails on the pre-fix lane, which passed no result text at all.
+    const { lane } = makeLane()
+    const turn = makeLaneTurn(lane, { labeledToolCount: 2 })
+    turn.mirrorLines.push('Read the file', 'Ran the tests')
+    turn.lastReplyText = 'Standing by for the background merge waiter to complete.'
+    const live = lane.composeTurnActivity(turn)
+    const final = lane.composeTurnActivity(turn, true)
+    expect(final!).toContain('─────')
+    expect(final!.endsWith('✅ _Standing by for the background merge waiter to complete._')).toBe(true)
+    // The LIVE render must not leak the footer — the turn is not finished.
+    expect(live!).not.toContain('✅')
+  })
+
+  it('composeTurnActivity: a turn that delivered no answer renders NO footer (no fabrication)', () => {
+    const { lane } = makeLane()
+    const turn = makeLaneTurn(lane, { labeledToolCount: 2 })
+    turn.mirrorLines.push('Read the file', 'Ran the tests')
+    turn.lastReplyText = ''
+    const final = lane.composeTurnActivity(turn, true)
+    expect(final!).not.toContain('─────')
+    expect(final!).not.toContain('✅')
+  })
 })
 
 describe('narrative-lane golden — the narrative-dedup gate at turn end', () => {

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -91,7 +91,8 @@ import {
   NESTED_PREFIX,
   WORKER_STEP_INDENT,
 } from './status-no-truncate.js'
-import { escapeMarkdown, truncate } from './card-format.js'
+import { cleanWorkerResultParagraph, escapeMarkdown, truncate } from './card-format.js'
+import { redact } from './secret-detect/redact.js'
 import { isTelegramSurfaceTool } from './tool-names.js'
 // The card layout core. Header composition (`metricsRun` /
 // `renderActivityHeader`), the per-line escape pipeline (`escapeStepLine`), the
@@ -158,6 +159,15 @@ export interface SessionActivityHeader {
    *  line via `tokenSegment`. Omitted (0/undefined) → no token segment, same
    *  clean-omit behavior as the worker feed. */
   totalTokens?: number
+  /**
+   * RAW final-summary text for the terminal `✅ <summary>` footer — the agent
+   * card's analogue of the worker card's `latestSummary` (the gateway passes
+   * the turn's delivered answer, `turn.lastReplyText`). Rendered ONLY on a
+   * final render, through the SHARED `deriveCardResult` the worker card uses,
+   * so both surfaces clean/cap/emoji it identically. Absent or empty → no
+   * footer block (the worker card's own fallback), never a fabricated line.
+   */
+  resultText?: string
 }
 
 /**
@@ -456,32 +466,71 @@ const WORKER_RESULT_RULE = '─────'
 const WORKER_RESULT_MAX = 320
 
 /**
- * Render the accumulated feed as ready Telegram HTML — one action per line,
- * newest last. The current (newest) step is bold with a `→`; finished steps
- * are italic with a `✓`. Capped to the last STATUS_ROLLING_LINES with a dim
- * `✓ +N earlier…` header when the turn ran longer. Returns null when empty.
- * Callers send the result verbatim — do NOT re-escape or re-wrap it.
+ * The ONE derivation of a card's terminal `✅/⚠️ <summary>` footer block, shared
+ * by the 🤖 agent card and the 🛠 worker card (#3844 unified the card BODY; the
+ * footer stayed forked until this landed — the agent card silently had no
+ * result block at all, so it ended on `✓ N steps` while the worker card ended
+ * on the green tick + summary sentence).
  *
- * Thin adapter over `renderStatusCard` (emoji 🤖, label 'Agent').
+ * Contract (the worker card's long-standing behaviour, now the spec for both):
+ *   - `running`     → no block. The card is not finished.
+ *   - `incomplete`  → NEVER a block, whatever `summary` carries. Truthful-no-
+ *                     result invariant: a reaped/abandoned unit produced no
+ *                     result, so it must not render a `⚠️`-prefixed paragraph
+ *                     out of stray summary text. Enforced HERE (deterministic
+ *                     mechanism) rather than left to caller discipline.
+ *   - `done`        → `✅` + the cleaned paragraph.
+ *   - `failed`      → `⚠️` + the cleaned paragraph.
+ *   - empty/absent summary, or one that cleans to nothing → no block. Omitting
+ *     is the fallback; the card never fabricates a sentence.
  *
- * `stepCount` (optional): when `final=true` and `stepCount > 0`, appends a
- * `✓ N steps` footer line.
+ * `summary` is RAW model-authored text (markdown, multi-line). It is scrubbed
+ * with `redact()` and cleaned with `cleanWorkerResultParagraph`;
+ * `renderStatusCard` does the final truncate + escape when it emits the block.
  *
- * `header` (optional): when provided, the two-line activity header carries
- * elapsed + tool count.
+ * The `redact()` is load-bearing, not belt-and-braces: status cards are sent
+ * via `sendRichMessage` and BYPASS the outbound redact chokepoint
+ * (`normalizeOutboundBody` → `redact`, outbound-send-path.ts:192) that scrubs
+ * every ordinary reply — the same gap `emitGatewayOperatorEvent` closes in
+ * gateway.ts. The agent card's summary is the turn's delivered answer text
+ * taken PRE-redaction, so scrubbing here is what keeps a token smuggled into a
+ * summary from reaching Telegram verbatim. It runs BEFORE markdown stripping /
+ * escaping, which is the order the outbound pipeline requires (redacting
+ * already-escaped text lets url-query-param secrets slip past url-redact).
  */
-export function renderActivityFeed(
+export function deriveCardResult(
+  state: CardState,
+  summary: string | undefined,
+): { emoji: string; text: string } | undefined {
+  if (state !== 'done' && state !== 'failed') return undefined
+  const text = cleanWorkerResultParagraph(redact(summary ?? ''))
+  if (text.length === 0) return undefined
+  return { emoji: state === 'done' ? '✅' : '⚠️', text }
+}
+
+/** Leading emoji for the main-session (🤖 Agent) card. */
+const AGENT_CARD_EMOJI = '🤖'
+
+/**
+ * The single 🤖-agent-card configuration of `renderStatusCard`. Both public
+ * agent-card entrypoints (`renderActivityFeed`, `renderActivityFeedWithNested`)
+ * funnel through this so the header mapping, the empty-guard, and the terminal
+ * result footer cannot drift between the flat and nested renders — they used
+ * to be two byte-copies of the same object literal.
+ */
+function renderAgentCard(
   lines: string[],
-  final = false,
-  liveSuffix = "",
-  stepCount?: number,
-  header?: SessionActivityHeader,
+  children: string[],
+  final: boolean,
+  liveSuffix: string,
+  stepCount: number | undefined,
+  header: SessionActivityHeader | undefined,
 ): string | null {
-  if (lines.length === 0 && header == null) return null;
+  if (lines.length === 0 && children.length === 0 && header == null) return null
   return renderStatusCard({
     header: header != null
       ? {
-          emoji: '🤖',
+          emoji: AGENT_CARD_EMOJI,
           label: header.label,
           elapsedMs: header.elapsedMs,
           toolCount: header.toolCount,
@@ -491,10 +540,44 @@ export function renderActivityFeed(
         }
       : undefined,
     steps: lines,
+    ...(children.length > 0 ? { childSteps: children } : {}),
     final,
     liveSuffix,
     stepCount,
+    // Same footer derivation the 🛠 worker card uses — one code path, so the
+    // two surfaces cannot drift apart again. Only a FINAL render can carry a
+    // result; a live render passes 'running' through and gets undefined.
+    result: final && header != null
+      ? deriveCardResult(header.state, header.resultText)
+      : undefined,
   })
+}
+
+/**
+ * Render the accumulated feed as ready Telegram HTML — one action per line,
+ * newest last. The current (newest) step is bold with a `→`; finished steps
+ * are italic with a `✓`. Capped to the last STATUS_ROLLING_LINES with a dim
+ * `✓ +N earlier…` header when the turn ran longer. Returns null when empty.
+ * Callers send the result verbatim — do NOT re-escape or re-wrap it.
+ *
+ * Thin adapter over `renderStatusCard` (emoji 🤖, label 'Agent') via the shared
+ * `renderAgentCard` configuration.
+ *
+ * `stepCount` (optional): when `final=true` and `stepCount > 0`, appends a
+ * `✓ N steps` footer line.
+ *
+ * `header` (optional): when provided, the two-line activity header carries
+ * elapsed + tool count — and, on a final render, `header.resultText` supplies
+ * the terminal `✅ <summary>` footer (identical derivation to the worker card).
+ */
+export function renderActivityFeed(
+  lines: string[],
+  final = false,
+  liveSuffix = "",
+  stepCount?: number,
+  header?: SessionActivityHeader,
+): string | null {
+  return renderAgentCard(lines, [], final, liveSuffix, stepCount, header)
 }
 
 // ─── Foreground sub-agent nesting (Model A) ─────────────────────────────────
@@ -519,7 +602,8 @@ export const NESTED_MAX_LINES = 4;
  * a `↳ +N earlier…` header when it overflows. Returns ready Telegram HTML
  * (callers must NOT re-escape) or null when there is nothing to show.
  *
- * Thin adapter over `renderStatusCard` (emoji 🤖, label 'Agent', childSteps).
+ * Thin adapter over `renderStatusCard` (emoji 🤖, label 'Agent', childSteps) via
+ * the shared `renderAgentCard` configuration.
  */
 export function renderActivityFeedWithNested(
   lines: string[],
@@ -530,25 +614,7 @@ export function renderActivityFeedWithNested(
   header?: SessionActivityHeader,
 ): string | null {
   const children = childLines.map((s) => s.trim()).filter((s) => s.length > 0);
-  if (children.length === 0) return renderActivityFeed(lines, final, liveSuffix, stepCount, header);
-  return renderStatusCard({
-    header: header != null
-      ? {
-          emoji: '🤖',
-          label: header.label,
-          elapsedMs: header.elapsedMs,
-          toolCount: header.toolCount,
-          state: header.state,
-          model: header.model,
-          totalTokens: header.totalTokens,
-        }
-      : undefined,
-    steps: lines,
-    childSteps: children,
-    final,
-    liveSuffix,
-    stepCount,
-  })
+  return renderAgentCard(lines, children, final, liveSuffix, stepCount, header)
 }
 
 // ─── Combined multi-worker feed (coalesced one-message-per-chat) ────────────

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -50,13 +50,13 @@
  */
 
 import {
-  cleanWorkerResultParagraph,
   stripMarkdown,
   truncate,
 } from './card-format.js'
 import { WORKER_HISTORY_MAX } from './status-no-truncate.js'
 import { renderCardTitleLine } from './card-layout.js'
 import {
+  deriveCardResult,
   renderStatusCard,
   formatStepSuffix,
   renderCombinedWorkerFeed,
@@ -274,17 +274,12 @@ export function renderWorkerActivity(v: WorkerActivityView, liveSuffix = ''): st
   // Terminal: latestSummary carries the worker's final result text (gateway
   // onFinish), distinct from the running narrative steps. Pass it as `result`.
   //
-  // Truthful-no-result invariant (deterministic control, not caller-discipline):
-  // an `incomplete` worker produced NO result, so it must NEVER render a result
-  // block regardless of whatever `latestSummary` happens to carry. The current
-  // call site (terminateWorker) always sets latestSummary:'' for incomplete, but
-  // enforce the invariant HERE so any future/direct caller can't fabricate a
-  // `⚠️`-prefixed result paragraph out of stray summary text.
-  let result: { emoji: string; text: string } | undefined
-  if (finished && v.state !== 'incomplete') {
-    const text = cleanWorkerResultParagraph(v.latestSummary)
-    if (text.length > 0) result = { emoji: v.state === 'done' ? '✅' : '⚠️', text }
-  }
+  // The whole derivation — state gating, the truthful-no-result invariant for
+  // `incomplete`, ✅/⚠️ selection, and omission on an empty summary — lives ONCE
+  // in `deriveCardResult` and is SHARED with the 🤖 agent card. It used to be
+  // inline here, which is precisely why the agent card had no result footer at
+  // all: the logic was unreachable from the other surface.
+  const result = deriveCardResult(v.state, v.latestSummary)
 
   const card = renderStatusCard({
     header,


### PR DESCRIPTION
## The bug

The 🛠 worker card ends with a `─────` rule then `✅ _<final summary sentence>_`.
The 🤖 agent card ended on `✓ N steps` — no result block at all.

## The actual fork

#3844 already unified the card **body** — one `renderStatusCard` / `card-layout`
core, both surfaces are configurations of it. What was still forked is the
terminal **result footer**, and it was forked by *location*, not by duplication:

- `telegram-plugin/worker-activity-feed.ts:283-287` (pre-diff) held the whole
  derivation inline — clean the raw summary, pick `✅` vs `⚠️` from the state,
  omit on an empty summary, never emit a block for `incomplete`. Nothing else
  could reach it, so the agent adapters simply never passed `result` to
  `renderStatusCard`.
- `telegram-plugin/tool-activity-summary.ts:482-492` and `:535-545` (pre-diff)
  carried two byte-identical copies of the agent header object literal — the
  other, smaller half of the fork.

## The fix

- **`deriveCardResult(state, summary)`** (`tool-activity-summary.ts`) is now the
  single derivation. `renderWorkerActivity` calls it in place of its inline
  copy; worker behaviour is byte-unchanged.
- **`renderAgentCard`** — one private configuration of `renderStatusCard` that
  both `renderActivityFeed` and `renderActivityFeedWithNested` funnel through.
  Header mapping, empty-guard and footer now exist once.
- **`SessionActivityHeader.resultText`** carries the agent card's summary. The
  gateway's narrative lane (`gateway/narrative-lane.ts`) supplies
  `turn.lastReplyText` — the answer the turn actually delivered, the agent's
  analogue of the worker's `latestSummary` — on **final** renders only.
- **No summary → no block.** That is the worker card's own fallback and it is
  now the spec for both. The card never fabricates a sentence.
- **`redact()` on the raw summary.** Status cards are sent via
  `sendRichMessage` and bypass the outbound redact chokepoint
  (`outbound-send-path.ts:192`), the same gap `emitGatewayOperatorEvent` closes
  in `gateway.ts`. The agent card's summary is *pre-redaction* reply text, so
  without this the change would open a new leak surface. It also closes the
  same (pre-existing, previously unexercised) gap on the worker summary.

## Tests

New `telegram-plugin/tests/agent-card-result-footer.test.ts`:

- `deriveCardResult` unit contract: done → ✅, failed → ⚠️, running → none,
  **incomplete → never a block even with summary text**, empty/markdown-only →
  none, secret → redacted.
- The agent card *ends with* `✅ _<summary>_`, flat and nested; a live render
  never shows the footer; no `resultText` → no footer and the card still ends
  on `✓ N steps`.
- **Shared-path assertions:** the agent and worker footers are byte-identical
  for the same raw summary and equal `deriveCardResult`'s output; and each
  card's body minus its title line is byte-identical (the icon/label title is
  the one legitimate parameterised difference).

Plus two lane-wiring cases in `narrative-lane-golden.test.ts` driving the real
`createNarrativeLane`.

Six of these assertions fail on the pre-diff behaviour (verified by neutering
the shared `result` wiring and re-running).

## Deliberately not done

- The `✓ N steps` line is **kept** on the agent card, with the `✅` footer
  appended after it. It is an existing, tested surface (#2461); removing it is a
  separate opinion call.
- The agent footer repeats up to 320 chars of an answer that is also sent as its
  own Telegram message. That duplication is inherent to the requested parity —
  flagging it, not hiding it.
- No new UAT scenario.

## Checks

`tsc --noEmit` + all 22 lint guards clean. `vitest run telegram-plugin/tests/`
→ 8181 passed, 1 failed: `approval-hold-record.test.ts` "falls back to the
agent's own state dir when the shared dir is not writable" — reproduced on
pristine `origin/main` with the diff stashed; it is a uid-0-container artifact
(root can write the "unwritable" dir), untouched by this change.