### PR TITLE
fix(gateway): a queue event is not a turn start — park mid-turn enqueues and finalize superseded cards (#3927)

### DIFF
--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -94,6 +94,487 @@ import * as pendingProgress from '../pending-work-progress.js'
 import * as signalTracker from '../turn-signal-tracker.js'
 import * as silencePoke from '../silence-poke.js'
 
+
+// ─── #3927: parked turn starts (FIX A) ────────────────────────────────────
+//
+// An `enqueue` transcript record is a QUEUE event, NOT a turn-start event. The
+// claude CLI writes it the moment a message lands on the queue, whether or not
+// a turn is already running. Ground truth from real transcripts (60 agent
+// sessions, 372 enqueues): every enqueue is terminated by exactly ONE of
+//
+//   • `dequeue` — the queue was drained into a NEW user turn. Always the
+//     immediately-preceding enqueue's terminal (199/200 dequeues are directly
+//     preceded by an enqueue); median gap 6 ms when the session was idle, but
+//     2–14 s when the message sat behind a running turn. THIS is turn start.
+//   • `remove`  — the queued item was folded into the ALREADY-RUNNING turn as a
+//     `queued_command` attachment. No new turn exists, and none ever will for
+//     that message. 161/372, and its `content` is byte-identical to its
+//     enqueue's (13/13 exact matches in the carrie session, 160/161 fleet-wide).
+//
+// Treating `enqueue` as turn start therefore minted a brand-new `CurrentTurn`
+// on top of a live one, which (a) froze the running turn's card and opened a
+// fresh one with reset stats, and (b) quoted the just-queued message on a card
+// that then streamed the STILL-RUNNING previous work into it.
+//
+// So: park the envelope while a turn is live and mint on the CLI's own
+// turn-start signal instead. Ordering is LIFO by evidence, not FIFO —
+// `dequeue` pairs with the MOST RECENT enqueue (max observed gap to the newest
+// parked envelope: 14.2 s; the gap to the oldest ran to hours). Popping the
+// oldest would mint a stale, long-since-folded message.
+//
+// BOUNDS (a parked envelope must never live forever — a `dequeue` that never
+// arrives, e.g. because the CLI died mid-turn, must not wedge the lane):
+//   • PARKED_TURN_START_MAX caps the store; the OLDEST is evicted on overflow
+//     (the newest message is the one the user is waiting on). An evicted
+//     envelope still reaches the model — the CLI owns the real queue — it just
+//     loses its own progress card.
+//   • PARKED_TURN_START_TTL_MS prunes on every touch, so a stale envelope can
+//     never be minted as a spurious turn later.
+const PARKED_TURN_START_MAX = 16
+const PARKED_TURN_START_TTL_MS = 30 * 60_000
+
+/** The `enqueue` envelope fields `beginTurn` needs — the SessionEvent minus its
+ *  discriminant. A parked entry additionally carries `parkedAt` for the TTL. */
+export interface TurnStartEnvelope {
+  chatId: string | null
+  messageId: string | null
+  threadId: string | null
+  rawContent: string
+}
+interface ParkedTurnStart extends TurnStartEnvelope {
+  parkedAt: number
+}
+
+/** Arrival-ordered (oldest first). Module-scope by design: it mirrors the ONE
+ *  claude CLI session's ONE queue, exactly like the `currentTurn` mirror. */
+const parkedTurnStarts: ParkedTurnStart[] = []
+
+function pruneParkedTurnStarts(now: number): void {
+  for (let i = parkedTurnStarts.length - 1; i >= 0; i--) {
+    if (now - parkedTurnStarts[i].parkedAt > PARKED_TURN_START_TTL_MS) {
+      const [dropped] = parkedTurnStarts.splice(i, 1)
+      process.stderr.write(
+        `telegram gateway: parked-turn-start expired chat=${dropped.chatId ?? '-'} ` +
+          `msg=${dropped.messageId ?? '-'} age_ms=${now - dropped.parkedAt}\n`,
+      )
+    }
+  }
+}
+
+function parkTurnStart(env: TurnStartEnvelope, now: number): void {
+  parkedTurnStarts.push({ ...env, parkedAt: now })
+  while (parkedTurnStarts.length > PARKED_TURN_START_MAX) {
+    const [dropped] = parkedTurnStarts.splice(0, 1)
+    process.stderr.write(
+      `telegram gateway: parked-turn-start evicted (cap ${PARKED_TURN_START_MAX}) ` +
+        `chat=${dropped.chatId ?? '-'} msg=${dropped.messageId ?? '-'}\n`,
+    )
+  }
+}
+
+/** Pop the MOST RECENTLY parked envelope — the one a `dequeue` pairs with. */
+function takeParkedTurnStart(): ParkedTurnStart | null {
+  return parkedTurnStarts.pop() ?? null
+}
+
+/** Drop the parked envelope a `remove` names (byte-identical `content`), newest
+ *  match first. A `remove` means "folded into the running turn" — that message
+ *  will never get a turn of its own, so leaving it parked would let a LATER
+ *  `dequeue` mint a spurious turn for an already-answered message. */
+function discardParkedTurnStart(rawContent: string): boolean {
+  for (let i = parkedTurnStarts.length - 1; i >= 0; i--) {
+    if (parkedTurnStarts[i].rawContent === rawContent) {
+      parkedTurnStarts.splice(i, 1)
+      return true
+    }
+  }
+  return false
+}
+
+/** Test seam: the parked store is module-scope (one CLI session, one queue), so
+ *  suites that drive `handleSessionEvent` need a deterministic reset. */
+export function __resetParkedTurnStartsForTest(): void {
+  parkedTurnStarts.length = 0
+}
+/** Test seam: parked-envelope count (bound / eviction assertions). */
+export function __parkedTurnStartCountForTest(): number {
+  return parkedTurnStarts.length
+}
+
+/**
+ * Mint the turn atom and open its surfaces. This is the ENTIRE pre-#3927
+ * `case 'enqueue'` body, relocated verbatim except for (a) the hoisted
+ * `ackDelivery` call (which acks RECEIPT and therefore stayed on the enqueue
+ * event) and (b) the FIX B supersession finalizer. Called from `enqueue` only
+ * when the session is idle, and otherwise from `dequeue`.
+ */
+function beginTurn(deps: StreamRenderDeps, ev: TurnStartEnvelope): void {
+  const {
+    HANDBACK_PRETURN_ENABLED,
+    STATE_DIR,
+    clearActivitySummary,
+    extractUserPromptPreview,
+    getCurrentTurn,
+    getPendingPtyPartial,
+    handbackPreturnSignal,
+    handlePtyPartial,
+    isDmChatId,
+    makeNarrativeGate,
+    pendingCrossTurnGate,
+    preambleSuppressor,
+    promoteQueuedStatus,
+    rememberRecentTurn,
+    scheduleEarlyLivenessOpen,
+    setCurrentTurn,
+    setPendingPtyPartial,
+    startTurnTypingLoop,
+    statusKey,
+    turnsDb,
+    typingWrapper,
+  } = deps
+  // Drain any orphaned typing-wrap entries left over from a crashed
+  // prior turn before resetting focus.
+  typingWrapper.drainAll()
+  if (ev.chatId) {
+    // #1445 cross-turn pending-async ambient — backstop for the
+    // `handleInbound` path's `clearPending('inbound')`. The
+    // inbound path covers real user messages, but synthesised
+    // wakes (subagent-handback channel turn, cron fires, vault
+    // grant resumes, restart markers) push directly to
+    // `pendingInboundBuffer` and bypass `handleInbound`. The
+    // `enqueue` session-event fires for EVERY fresh turn atom
+    // regardless of source — clearing here drops any prior turn's
+    // ambient before the new turn's `noteOutbound` lands. The
+    // call is idempotent so it's safe to fire in addition to the
+    // inbound-path clear (for the real-inbound case, this is a
+    // no-op because state was already deleted by then).
+    const enqThreadId = ev.threadId != null ? Number(ev.threadId) : undefined
+    pendingProgress.clearPending(
+      statusKey(ev.chatId, enqThreadId),
+      'handback',
+    )
+  }
+  if (ev.chatId) {
+    // Issue #195: if a previous turn left an answer-lane stream open
+    // (rapid steer/queue), force it to a new generation so its in-flight
+    // edits don't mutate the new turn's message. Materialize is best-effort
+    // — we don't await here because turn_end on the prior turn should
+    // have already done it; this is a defensive supersession guard.
+    const prior = getCurrentTurn()
+    if (prior?.answerStream != null) {
+      prior.answerStream.forceNewMessage()
+      prior.answerStream.stop()
+      prior.answerStream = null
+    }
+    // Bounded-leak hardening (A5): clear the prior turn's orphaned-reply
+    // fuse before it is superseded. The fire callback re-reads currentTurn
+    // and no-ops on a stale turn, but proactively clearing the timer avoids
+    // a bounded pile-up of dangling timers across rapid steer/queue turns.
+    if (prior?.orphanedReplyTimeoutId != null) {
+      clearTimeout(prior.orphanedReplyTimeoutId)
+      prior.orphanedReplyTimeoutId = null
+    }
+    // Same bounded-leak class (early-paint 250ms setTimeout): the prior
+    // turn may have armed its narrative gate's early-paint timer before
+    // being superseded. Left untorn, ~250ms later it fires showNarrativeStep
+    // on the dead turn and can paint a stale narration card below the new
+    // turn's surface. Teardown is guard-safe and idempotent (no-op when never
+    // armed / already fired / already disarmed by the prior turn's turn_end).
+    prior?.narrativeGate?.teardown()
+    // FIX B (#3927) — NEVER ORPHAN A SUPERSEDED CARD. Reaching here means a
+    // fresh turn is being minted while `prior` is still the live turn atom.
+    // After FIX A that is rare (a real inbound now parks instead of
+    // preempting), but it is still reachable: a turn whose `turn_end` was
+    // never observed (bridge death, transcript gap, an unclean restart)
+    // leaves a live-looking atom in the slot, and the next genuine
+    // dequeue-driven turn start must not inherit its surfaces. Pre-fix, the
+    // teardown above dropped the answer stream, the orphaned-reply fuse and
+    // the narrative gate but NEVER touched the activity card — so the card
+    // froze on its last landed edit, kept the `fg:<statusKey>` status pin
+    // forever, and left NO `turn-lifecycle clear` line to explain it (carrie
+    // 2026-07-28, turn `-1004223464247:_#1078`). `clearActivitySummary`
+    // finalizes/deletes the card AND releases the pin; it is idempotent and
+    // no-ops when the turn never opened a card.
+    // `endedAt == null` narrows this to a turn that never ended: a turn that
+    // ended normally already ran its own `clearActivitySummary` + `clear`
+    // log, and `endCurrentTurnAtomic` nulls the mirror, so this is a
+    // belt-and-braces guard against double-finalizing / double-logging.
+    if (prior != null && prior.endedAt == null) {
+      clearActivitySummary(prior)
+      // The missing breadcrumb: a clobber must never again be invisible.
+      // Same field format as every other `turn-lifecycle clear`.
+      process.stderr.write(
+        `telegram gateway: ${formatTurnLifecycle('clear', 'superseded', prior, Date.now())}\n`,
+      )
+    }
+    // #1067: swap the entire turn atom in one assignment. Every
+    // handler captures `const turn = currentTurn` at entry, so a
+    // captured-then-awaited read can't reattribute to the new turn.
+    const startedAt = Date.now()
+    // Component 3 — stable per-turn identity. For a real inbound this
+    // matches the `origin_turn_id` stamped into the inbound meta at
+    // build time (same chat/thread/messageId). Synthetic turns (cron /
+    // handback — no messageId) get a unique startedAt-based fallback id
+    // that no reply will ever echo, so they correctly fall through to
+    // the live-turn routing in resolveAnswerThreadId.
+    const enqThreadIdNum = ev.threadId != null ? Number(ev.threadId) : undefined
+    const turnId =
+      deriveTurnId(ev.chatId, enqThreadIdNum ?? null, ev.messageId)
+      ?? `${chatKey(ev.chatId, enqThreadIdNum ?? null)}#synthetic-${startedAt}`
+    // PR1 (cross-turn stale-card guard, §9 lever 4 / race C/D). Consume any
+    // pending cross-turn gate `obligationSweep` armed for THIS exact turn
+    // when it pushed an `obligation_represent` inbound. The gate is keyed on
+    // the obligation's `originTurnId`, and the represent inbound reuses the
+    // original chat/thread/messageId, so this turn's `turnId` (derived just
+    // above) equals that key iff this turn IS the represent surface armed for.
+    // An unrelated foreground turn on the same chat/thread derives a
+    // different `turnId` → finds no entry → no gate → its card opens normally
+    // (correct). Consume-once: delete on read so the matched gate can't leak
+    // forward, and a never-matched stale gate can never suppress another turn.
+    const xTurnGateKey = turnId
+    const consumedCrossTurnGate = pendingCrossTurnGate.get(xTurnGateKey)
+    if (consumedCrossTurnGate != null) pendingCrossTurnGate.delete(xTurnGateKey)
+    const next: CurrentTurn = {
+      sessionChatId: ev.chatId,
+      sessionThreadId: enqThreadIdNum,
+      // Accept the inbound id as a reply anchor only when it is a plausible
+      // Telegram message id. Synthetic boot-resume inbounds fabricate a
+      // 13-digit Date.now() message_id (for ack-tracking); if that reached
+      // the activity-feed reply anchor it 400'd every feed send and darkened
+      // the live feed for the whole resume turn (2026-06-05). The ack-queue
+      // still keys on ev.messageId independently — only the anchor is gated.
+      sourceMessageId: parseSourceMessageId(ev.messageId),
+      startedAt,
+      gatewayReceiveAt: startedAt,
+      // #2527 — stamp the loop role once, from the enqueue envelope.
+      role: deriveTurnRole(ev.rawContent),
+      // PR1 (cross-turn stale-card guard, §9 lever 4 / race C/D). Only a
+      // synthetic represent/owed-reply turn carries this; a foreground turn
+      // leaves it undefined and the cross-turn card-OPEN gate is inert.
+      ...(consumedCrossTurnGate != null ? { crossTurnGate: consumedCrossTurnGate } : {}),
+      replyCalled: false,
+      finalAnswerDelivered: false,
+      finalAnswerSubstantive: false,
+      // Sticky latch — reset ONLY here (turn start), never by reopen.
+      finalAnswerEverDelivered: false,
+      // 2026-07 double-reply-on-DM fix (Part 2) — answer-delivered race
+      // latch, reset at turn start alongside the other answer flags.
+      answerDelivered: false,
+      // #3429 — flushed-answer text for the content-vs-flush latch
+      // discrimination; stamped at flush arm, reset at turn start.
+      flushedAnswerText: null,
+      // 2026-07 double-reply-on-DM fix (F2) — stamped at turn end.
+      endedAt: null,
+      firstPingAt: null,
+      // Notification ownership (R8 / PR-2): no slot claimed yet, so the
+      // "claimer was substantive" flag starts false. Set atomically with
+      // firstPingAt at the over-ping decision site.
+      firstPingWasSubstantive: false,
+      silentAnchorMessageId: null,
+      silentAnchorText: '',
+      capturedText: [],
+      capturedBlockMeta: [],
+      orphanedReplyTimeoutId: null,
+      answerReadyFlushTimeoutId: null,
+      // Fresh liveness tracker: lastStreamEventAt seeded to the turn start
+      // so a turn that never streams still trips the fuse after windowMs.
+      liveness: new LivenessTracker(startedAt),
+      turnId,
+      registryKey: null,
+      noReplyDrainTimer: null,
+      lastAssistantMsgId: null,
+      lastAssistantDone: false,
+      toolCallCount: 0,
+      labeledToolCount: 0,
+      totalTokens: 0,
+      seenUsageMessageIds: new Set<string>(),
+      activityMessageId: null,
+      activityInFlight: null,
+      activityPendingRender: null,
+      activityLastSentRender: null,
+      activityEverOpened: false,
+      activityDrainFailures: 0,
+      mirrorLines: [],
+      // Assigned immediately after this literal via makeNarrativeGate(next) —
+      // the controller's SHOW/RETRACT effects close over the turn object, which
+      // can't reference itself inside its own initializer.
+      narrativeGate: undefined as unknown as NarrativeFlushController,
+      lastReplyText: '',
+      foregroundSubAgents: new Map(),
+      answerStream: null,
+      isDm: isDmChatId(ev.chatId),
+      // PR-4a — construct ONE emission-authority façade per turn, passing
+      // the chat/thread key in EXPLICITLY (the PR-4e seam; today equal to
+      // the singleton-sourced key). Per-turn: born with this turn literal,
+      // discarded with it — never persists across turns.
+      emissionAuthority: new EmissionAuthority(
+        statusKey(ev.chatId, enqThreadIdNum),
+      ),
+    }
+    // Wire the per-turn narrative gate now that `next` exists (its SHOW/RETRACT
+    // effects close over the turn). Born with this turn, torn down at turn end.
+    next.narrativeGate = makeNarrativeGate(next)
+    // Dead-air pre-turn signal — ADOPT by inbound identity (design lever 2).
+    // If a subagent-handback pre-turn signal was emitted for THIS exact turn
+    // (matched on `turnId`, not the bare topic key, so a racing user inbound
+    // can't mis-adopt), consume it. A card-bearing adoption seeds
+    // `activityMessageId` + `activityEverOpened` so `renderActivityFeed`
+    // EDITS the existing card instead of opening a second one, and so the
+    // turn's own end-of-turn `clearActivitySummary` finalizes it (lever 3).
+    if (HANDBACK_PRETURN_ENABLED) {
+      const handbackAdoption = handbackPreturnSignal.tryAdopt(turnId)
+      if (handbackAdoption != null) {
+        if (handbackAdoption.activityMessageId != null) {
+          next.activityMessageId = handbackAdoption.activityMessageId
+          next.activityEverOpened = true
+        }
+        // Observability (#3544): adoption is the rare, previously-silent
+        // branch — one line per adopted handback turn, not per turn.
+        process.stderr.write(
+          `telegram gateway: handback pre-turn adopted turnId=${turnId} ` +
+            `key=${handbackAdoption.statusKey} card=${handbackAdoption.activityMessageId ?? 'none'}\n`,
+        )
+      }
+    }
+    // #3544 — arm the turn-long `typing…` loop for EVERY minted turn,
+    // unconditionally. It used to hang off the handback ADOPTION above,
+    // which misses whenever the pre-turn entry was deduped (parallel
+    // workers on one topic), had no derivable turn id, or was already
+    // reaped — and the whole compose window went dark. Only the real-inbound
+    // path (`turn-start-surfaces.ts`) armed a loop, so a synthetic turn
+    // (handback / cron / wake) could have none at all. Unconditional is safe
+    // and costs nothing extra on the wire:
+    //   - `turnTypingLoop.start` is restart-safe (stops any prior loop on
+    //     the key first, so a real inbound's loop is replaced, not doubled);
+    //   - every send goes through the SHARED per-chat-key emitter floor
+    //     (`typing-emitter.ts`, TYPING_FLOOR_MS) so N arms on one chat still
+    //     cost at most one chat action per floor window — the 2026-07-11
+    //     flood-ban guard is what makes arming more loops free;
+    //   - `turn-end.ts` (`purgeReactionTracking → stopTurnTypingLoop`) is
+    //     already the single stop-owner for ALL turns, and a start is
+    //     self-healing anyway, so this cannot leak an interval.
+    startTurnTypingLoop(ev.chatId, enqThreadIdNum ?? null)
+    // PR-4e — route the turn-SET through the keyed accessor: flag-OFF assigns
+    // the singleton (byte-identical to `currentTurn = next`); flag-ON sets the
+    // per-topic `byKey[statusKey]` entry AND the most-recent mirror. The key is
+    // the SAME statusKey the ctor's façade was constructed with just above.
+    setCurrentTurn(next, statusKey(ev.chatId, enqThreadIdNum))
+    // (turn start already stamped the idle clock at the top of
+    // handleSessionEvent, along with every other session event — see the
+    // idle-clear block there.)
+    // Early-open the "Working…" liveness card at turn start so narration /
+    // thinking emitted BEFORE the first tool surfaces within ~a second
+    // instead of after the old 12 s threshold (the dead-air gap). Fires the
+    // SAME `openLivenessFeedIfDue` the 6 s heartbeat uses — a no-op if a
+    // tool/narrative already opened the card, and gated by `mayOpenActivityCard`
+    // (lever 1/4) so it never opens below a delivered answer. Scoped to real
+    // turns by construction: only the `enqueue` lifecycle event reaches here,
+    // and anonymous one-shot hook clients (recall.py) never emit it.
+    scheduleEarlyLivenessOpen(next)
+    // Status-surface observability: one line at every turn SET so a later
+    // dark card is traceable to which turn/topic key it belonged to.
+    process.stderr.write(
+      `telegram gateway: ${formatTurnLifecycle('set', 'enqueue', next, startedAt)}\n`,
+    )
+    // Component 3 — retain in the bounded recently-ended registry so a
+    // LATE reply (landing after currentTurn flips to a successor) can
+    // still resolve THIS turn's origin thread by its turnId.
+    rememberRecentTurn(next)
+    // Component 5 (Hook B) — this turn's topic had a queued placeholder
+    // from Hook A; promote it to "On it — replying now." (deleted later
+    // when the answer lands). No-op when there's no placeholder / DM.
+    promoteQueuedStatus(ev.chatId, enqThreadIdNum)
+    // PR3b-cutover: feed the authoritative turn-start to the delivery
+    // machine. `enqueue` fires for EVERY turn atom regardless of
+    // source — inbound, cron, subagent-handback, vault-resume,
+    // restart-marker — so it is the single chokepoint that captures
+    // the non-inbound turns the machine's own `inbound` event never
+    // sees (those bypass handleInbound). Without it the machine reads
+    // idle during a cron/handback turn and the gate would mis-deliver
+    // a concurrent inbound mid-turn (the #1556 composer wedge).
+    // Idempotent when already in_turn (turnStart only sets perKey).
+    shadowEmit({
+      kind: 'turnStart',
+      key: statusKey(ev.chatId, ev.threadId != null ? Number(ev.threadId) : undefined) as _ChatKey,
+      at: startedAt,
+    })
+    // #549 fix — fresh turn, reset preamble-suppression state.
+    preambleSuppressor.reset()
+    // Reset the silent-end retry budget for this chat. The stored
+    // turnKey is `chat:thread` shape (no per-instance suffix), so
+    // without an explicit per-turn clear, `writeSilentEndState`
+    // (silent-end.ts:114) inherits `retryCount` across turns
+    // whenever a prior turn for the same chat hit retryCount=1.
+    // The Stop hook then sees `retryCount >= MAX_RETRIES=1` on the
+    // very first silent-end of every subsequent turn and bails
+    // without re-prompting. finn hit this on 2026-05-25 with a
+    // stuck retryCount=1 file. A new turn invalidates any prior
+    // turn's retry budget by definition; clear it eagerly here.
+    // ev.threadId is `string | null` (Telegram's wire shape);
+    // statusKey wants `number | null` — same conversion as the
+    // registry-key branch a few lines down.
+    clearSilentEndState(statusKey(
+      ev.chatId,
+      ev.threadId != null ? Number(ev.threadId) : null,
+    ))
+    // Stage 3b: stamp turn-start in the registry. turn_key is
+    // chat:thread:startTs — unique per turn, distinct from the
+    // progress-card-driver's per-chat sequence number (these are two
+    // independent identifier schemes and don't need to align).
+    if (turnsDb != null) {
+      // ev.threadId is `string | null` (Telegram emits as string); convert
+      // to number for chatKeyWithSuffix. Number(null) = 0 which canonicalizes
+      // to '_' — same as the explicit `null` branch below.
+      const evThreadIdNum = ev.threadId != null ? Number(ev.threadId) : null
+      const turnKey = chatKeyWithSuffix(ev.chatId, evThreadIdNum, String(startedAt))
+      next.registryKey = turnKey
+      // Phase 1 of #332: capture first ~200 chars of the user's message.
+      const userPromptPreview = extractUserPromptPreview(ev.rawContent)
+      // Closes #472 finding #11. Pre-fix: this write was scheduled
+      // via setImmediate to "avoid stalling the turn handler" — but
+      // SQLite local writes are sub-millisecond, and the deferral
+      // opened a SIGTERM race window: a kill landing in the gap
+      // between scheduling and firing left a turn with no start
+      // row, invisible to the resume protocol (the user sent a
+      // message, the gateway lost it, no SWITCHROOM_PENDING_TURN
+      // env on next boot). Sibling writeTurnActiveMarker has always
+      // been synchronous here; this matches it.
+      try {
+        recordTurnStart(turnsDb, {
+          turnKey,
+          chatId: String(ev.chatId),
+          threadId: ev.threadId != null ? String(ev.threadId) : null,
+          lastUserMsgId: ev.messageId != null ? String(ev.messageId) : null,
+          userPromptPreview,
+        })
+      } catch (err) {
+        process.stderr.write(`telegram gateway: recordTurnStart failed turnKey=${turnKey}: ${(err as Error).message}\n`)
+      }
+      // #412: turn-active marker for the bridge-watchdog. File exists
+      // for the duration of the in-flight turn; mtime advances on
+      // every tool_use; deleted on turn_complete. The watchdog
+      // distinguishes wedged-mid-turn from healthy-idle by checking
+      // for this file's presence + mtime staleness.
+      writeTurnActiveMarker(STATE_DIR, {
+        turnKey,
+        chatId: String(ev.chatId),
+        threadId: ev.threadId != null ? String(ev.threadId) : null,
+        startedAt,
+      })
+    }
+    // (accessor-narrowing spelling: the pre-move body guarded the
+    // `pendingPtyPartial` variable then re-read it into `pending`; the
+    // injected accessor is a call expression TS can't narrow across, so
+    // capture once then guard the local — equivalent, no await between.)
+    const pending = getPendingPtyPartial()
+    if (pending != null) {
+      setPendingPtyPartial(null)
+      handlePtyPartial(pending)
+    }
+  }
+}
+
+
 export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): void {
   const {
     ANSWER_LANE,
@@ -209,241 +690,33 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
   }
   switch (ev.kind) {
     case 'enqueue': {
-      // Drain any orphaned typing-wrap entries left over from a crashed
-      // prior turn before resetting focus.
-      typingWrapper.drainAll()
+      // #3927 FIX A — an `enqueue` is a QUEUE event, not a turn START event
+      // (see the parked-turn-start block at the top of this module for the
+      // transcript evidence). Mint ONLY when the session is genuinely idle;
+      // otherwise park the envelope and let the CLI's own `dequeue` start the
+      // turn, or its `remove` discard it (the message was folded into the
+      // running turn and will never own a turn).
+      const enqThreadIdNum = ev.threadId != null ? Number(ev.threadId) : undefined
+      const now = Date.now()
       if (ev.chatId) {
-        // #1445 cross-turn pending-async ambient — backstop for the
-        // `handleInbound` path's `clearPending('inbound')`. The
-        // inbound path covers real user messages, but synthesised
-        // wakes (subagent-handback channel turn, cron fires, vault
-        // grant resumes, restart markers) push directly to
-        // `pendingInboundBuffer` and bypass `handleInbound`. The
-        // `enqueue` session-event fires for EVERY fresh turn atom
-        // regardless of source — clearing here drops any prior turn's
-        // ambient before the new turn's `noteOutbound` lands. The
-        // call is idempotent so it's safe to fire in addition to the
-        // inbound-path clear (for the real-inbound case, this is a
-        // no-op because state was already deleted by then).
-        const enqThreadId = ev.threadId != null ? Number(ev.threadId) : undefined
-        pendingProgress.clearPending(
-          statusKey(ev.chatId, enqThreadId),
-          'handback',
-        )
-      }
-      if (ev.chatId) {
-        // Issue #195: if a previous turn left an answer-lane stream open
-        // (rapid steer/queue), force it to a new generation so its in-flight
-        // edits don't mutate the new turn's message. Materialize is best-effort
-        // — we don't await here because turn_end on the prior turn should
-        // have already done it; this is a defensive supersession guard.
-        const prior = getCurrentTurn()
-        if (prior?.answerStream != null) {
-          prior.answerStream.forceNewMessage()
-          prior.answerStream.stop()
-          prior.answerStream = null
-        }
-        // Bounded-leak hardening (A5): clear the prior turn's orphaned-reply
-        // fuse before it is superseded. The fire callback re-reads currentTurn
-        // and no-ops on a stale turn, but proactively clearing the timer avoids
-        // a bounded pile-up of dangling timers across rapid steer/queue turns.
-        if (prior?.orphanedReplyTimeoutId != null) {
-          clearTimeout(prior.orphanedReplyTimeoutId)
-          prior.orphanedReplyTimeoutId = null
-        }
-        // Same bounded-leak class (early-paint 250ms setTimeout): the prior
-        // turn may have armed its narrative gate's early-paint timer before
-        // being superseded. Left untorn, ~250ms later it fires showNarrativeStep
-        // on the dead turn and can paint a stale narration card below the new
-        // turn's surface. Teardown is guard-safe and idempotent (no-op when never
-        // armed / already fired / already disarmed by the prior turn's turn_end).
-        prior?.narrativeGate?.teardown()
-        // #1067: swap the entire turn atom in one assignment. Every
-        // handler captures `const turn = currentTurn` at entry, so a
-        // captured-then-awaited read can't reattribute to the new turn.
-        const startedAt = Date.now()
-        // Component 3 — stable per-turn identity. For a real inbound this
-        // matches the `origin_turn_id` stamped into the inbound meta at
-        // build time (same chat/thread/messageId). Synthetic turns (cron /
-        // handback — no messageId) get a unique startedAt-based fallback id
-        // that no reply will ever echo, so they correctly fall through to
-        // the live-turn routing in resolveAnswerThreadId.
-        const enqThreadIdNum = ev.threadId != null ? Number(ev.threadId) : undefined
-        const turnId =
-          deriveTurnId(ev.chatId, enqThreadIdNum ?? null, ev.messageId)
-          ?? `${chatKey(ev.chatId, enqThreadIdNum ?? null)}#synthetic-${startedAt}`
-        // PR1 (cross-turn stale-card guard, §9 lever 4 / race C/D). Consume any
-        // pending cross-turn gate `obligationSweep` armed for THIS exact turn
-        // when it pushed an `obligation_represent` inbound. The gate is keyed on
-        // the obligation's `originTurnId`, and the represent inbound reuses the
-        // original chat/thread/messageId, so this turn's `turnId` (derived just
-        // above) equals that key iff this turn IS the represent surface armed for.
-        // An unrelated foreground turn on the same chat/thread derives a
-        // different `turnId` → finds no entry → no gate → its card opens normally
-        // (correct). Consume-once: delete on read so the matched gate can't leak
-        // forward, and a never-matched stale gate can never suppress another turn.
-        const xTurnGateKey = turnId
-        const consumedCrossTurnGate = pendingCrossTurnGate.get(xTurnGateKey)
-        if (consumedCrossTurnGate != null) pendingCrossTurnGate.delete(xTurnGateKey)
-        const next: CurrentTurn = {
-          sessionChatId: ev.chatId,
-          sessionThreadId: enqThreadIdNum,
-          // Accept the inbound id as a reply anchor only when it is a plausible
-          // Telegram message id. Synthetic boot-resume inbounds fabricate a
-          // 13-digit Date.now() message_id (for ack-tracking); if that reached
-          // the activity-feed reply anchor it 400'd every feed send and darkened
-          // the live feed for the whole resume turn (2026-06-05). The ack-queue
-          // still keys on ev.messageId independently — only the anchor is gated.
-          sourceMessageId: parseSourceMessageId(ev.messageId),
-          startedAt,
-          gatewayReceiveAt: startedAt,
-          // #2527 — stamp the loop role once, from the enqueue envelope.
-          role: deriveTurnRole(ev.rawContent),
-          // PR1 (cross-turn stale-card guard, §9 lever 4 / race C/D). Only a
-          // synthetic represent/owed-reply turn carries this; a foreground turn
-          // leaves it undefined and the cross-turn card-OPEN gate is inert.
-          ...(consumedCrossTurnGate != null ? { crossTurnGate: consumedCrossTurnGate } : {}),
-          replyCalled: false,
-          finalAnswerDelivered: false,
-          finalAnswerSubstantive: false,
-          // Sticky latch — reset ONLY here (turn start), never by reopen.
-          finalAnswerEverDelivered: false,
-          // 2026-07 double-reply-on-DM fix (Part 2) — answer-delivered race
-          // latch, reset at turn start alongside the other answer flags.
-          answerDelivered: false,
-          // #3429 — flushed-answer text for the content-vs-flush latch
-          // discrimination; stamped at flush arm, reset at turn start.
-          flushedAnswerText: null,
-          // 2026-07 double-reply-on-DM fix (F2) — stamped at turn end.
-          endedAt: null,
-          firstPingAt: null,
-          // Notification ownership (R8 / PR-2): no slot claimed yet, so the
-          // "claimer was substantive" flag starts false. Set atomically with
-          // firstPingAt at the over-ping decision site.
-          firstPingWasSubstantive: false,
-          silentAnchorMessageId: null,
-          silentAnchorText: '',
-          capturedText: [],
-          capturedBlockMeta: [],
-          orphanedReplyTimeoutId: null,
-          answerReadyFlushTimeoutId: null,
-          // Fresh liveness tracker: lastStreamEventAt seeded to the turn start
-          // so a turn that never streams still trips the fuse after windowMs.
-          liveness: new LivenessTracker(startedAt),
-          turnId,
-          registryKey: null,
-          noReplyDrainTimer: null,
-          lastAssistantMsgId: null,
-          lastAssistantDone: false,
-          toolCallCount: 0,
-          labeledToolCount: 0,
-          totalTokens: 0,
-          seenUsageMessageIds: new Set<string>(),
-          activityMessageId: null,
-          activityInFlight: null,
-          activityPendingRender: null,
-          activityLastSentRender: null,
-          activityEverOpened: false,
-          activityDrainFailures: 0,
-          mirrorLines: [],
-          // Assigned immediately after this literal via makeNarrativeGate(next) —
-          // the controller's SHOW/RETRACT effects close over the turn object, which
-          // can't reference itself inside its own initializer.
-          narrativeGate: undefined as unknown as NarrativeFlushController,
-          lastReplyText: '',
-          foregroundSubAgents: new Map(),
-          answerStream: null,
-          isDm: isDmChatId(ev.chatId),
-          // PR-4a — construct ONE emission-authority façade per turn, passing
-          // the chat/thread key in EXPLICITLY (the PR-4e seam; today equal to
-          // the singleton-sourced key). Per-turn: born with this turn literal,
-          // discarded with it — never persists across turns.
-          emissionAuthority: new EmissionAuthority(
-            statusKey(ev.chatId, enqThreadIdNum),
-          ),
-        }
-        // Wire the per-turn narrative gate now that `next` exists (its SHOW/RETRACT
-        // effects close over the turn). Born with this turn, torn down at turn end.
-        next.narrativeGate = makeNarrativeGate(next)
-        // Dead-air pre-turn signal — ADOPT by inbound identity (design lever 2).
-        // If a subagent-handback pre-turn signal was emitted for THIS exact turn
-        // (matched on `turnId`, not the bare topic key, so a racing user inbound
-        // can't mis-adopt), consume it. A card-bearing adoption seeds
-        // `activityMessageId` + `activityEverOpened` so `renderActivityFeed`
-        // EDITS the existing card instead of opening a second one, and so the
-        // turn's own end-of-turn `clearActivitySummary` finalizes it (lever 3).
-        if (HANDBACK_PRETURN_ENABLED) {
-          const handbackAdoption = handbackPreturnSignal.tryAdopt(turnId)
-          if (handbackAdoption != null) {
-            if (handbackAdoption.activityMessageId != null) {
-              next.activityMessageId = handbackAdoption.activityMessageId
-              next.activityEverOpened = true
-            }
-            // Observability (#3544): adoption is the rare, previously-silent
-            // branch — one line per adopted handback turn, not per turn.
-            process.stderr.write(
-              `telegram gateway: handback pre-turn adopted turnId=${turnId} ` +
-                `key=${handbackAdoption.statusKey} card=${handbackAdoption.activityMessageId ?? 'none'}\n`,
-            )
-          }
-        }
-        // #3544 — arm the turn-long `typing…` loop for EVERY minted turn,
-        // unconditionally. It used to hang off the handback ADOPTION above,
-        // which misses whenever the pre-turn entry was deduped (parallel
-        // workers on one topic), had no derivable turn id, or was already
-        // reaped — and the whole compose window went dark. Only the real-inbound
-        // path (`turn-start-surfaces.ts`) armed a loop, so a synthetic turn
-        // (handback / cron / wake) could have none at all. Unconditional is safe
-        // and costs nothing extra on the wire:
-        //   - `turnTypingLoop.start` is restart-safe (stops any prior loop on
-        //     the key first, so a real inbound's loop is replaced, not doubled);
-        //   - every send goes through the SHARED per-chat-key emitter floor
-        //     (`typing-emitter.ts`, TYPING_FLOOR_MS) so N arms on one chat still
-        //     cost at most one chat action per floor window — the 2026-07-11
-        //     flood-ban guard is what makes arming more loops free;
-        //   - `turn-end.ts` (`purgeReactionTracking → stopTurnTypingLoop`) is
-        //     already the single stop-owner for ALL turns, and a start is
-        //     self-healing anyway, so this cannot leak an interval.
-        startTurnTypingLoop(ev.chatId, enqThreadIdNum ?? null)
-        // PR-4e — route the turn-SET through the keyed accessor: flag-OFF assigns
-        // the singleton (byte-identical to `currentTurn = next`); flag-ON sets the
-        // per-topic `byKey[statusKey]` entry AND the most-recent mirror. The key is
-        // the SAME statusKey the ctor's façade was constructed with just above.
-        setCurrentTurn(next, statusKey(ev.chatId, enqThreadIdNum))
-        // (turn start already stamped the idle clock at the top of
-        // handleSessionEvent, along with every other session event — see the
-        // idle-clear block there.)
-        // Early-open the "Working…" liveness card at turn start so narration /
-        // thinking emitted BEFORE the first tool surfaces within ~a second
-        // instead of after the old 12 s threshold (the dead-air gap). Fires the
-        // SAME `openLivenessFeedIfDue` the 6 s heartbeat uses — a no-op if a
-        // tool/narrative already opened the card, and gated by `mayOpenActivityCard`
-        // (lever 1/4) so it never opens below a delivered answer. Scoped to real
-        // turns by construction: only the `enqueue` lifecycle event reaches here,
-        // and anonymous one-shot hook clients (recall.py) never emit it.
-        scheduleEarlyLivenessOpen(next)
-        // Status-surface observability: one line at every turn SET so a later
-        // dark card is traceable to which turn/topic key it belonged to.
-        process.stderr.write(
-          `telegram gateway: ${formatTurnLifecycle('set', 'enqueue', next, startedAt)}\n`,
-        )
-        // Component 3 — retain in the bounded recently-ended registry so a
-        // LATE reply (landing after currentTurn flips to a successor) can
-        // still resolve THIS turn's origin thread by its turnId.
-        rememberRecentTurn(next)
-        // Component 5 (Hook B) — this turn's topic had a queued placeholder
-        // from Hook A; promote it to "On it — replying now." (deleted later
-        // when the answer lands). No-op when there's no placeholder / DM.
-        promoteQueuedStatus(ev.chatId, enqThreadIdNum)
-        // Ack inbound delivery (the marko drop-wedge): claude actually started
-        // this turn, so its delivered inbound landed — stop tracking it for
-        // re-delivery. `enqueue` carries the same chat/thread the inbound was
-        // keyed on, so the key matches.
+        // Ack inbound delivery (the marko drop-wedge): the message reached
+        // claude's queue, so its delivered inbound landed — stop tracking it
+        // for re-delivery. `enqueue` carries the same chat/thread the inbound
+        // was keyed on, so the key matches.
+        //
+        // #3927: this ack stays on the ENQUEUE event and did NOT move into
+        // `beginTurn` with the rest of the old body. It asserts RECEIPT, not
+        // turn start — and receipt is exactly what an enqueue proves. A parked
+        // envelope whose terminal turns out to be `remove` (folded into the
+        // running turn) never reaches `beginTurn` at all, so acking there would
+        // leave that message tracked forever and the delivery machine would
+        // re-deliver it: a duplicate inbound.
         if (DELIVERY_CONFIRM_ENABLED) {
-          // Match on the source message id: `enqueue` fires for EVERY turn
-          // start (cron / subagent-handback / vault-resume / restart-marker
-          // too — see comment below), so a key-only ack would let a synthetic
-          // turn clear a real user message still waiting under the same key.
+          // Match on the source message id: `enqueue` fires for EVERY queued
+          // message regardless of source (cron / subagent-handback /
+          // vault-resume / restart-marker too), so a key-only ack would let a
+          // synthetic turn clear a real user message still waiting under the
+          // same key.
           ackDelivery(
             deliveryQueue,
             chatKey(ev.chatId, ev.threadId != null ? Number(ev.threadId) : null),
@@ -457,97 +730,81 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
             ev.rawContent,
           )
         }
-        // PR3b-cutover: feed the authoritative turn-start to the delivery
-        // machine. `enqueue` fires for EVERY turn atom regardless of
-        // source — inbound, cron, subagent-handback, vault-resume,
-        // restart-marker — so it is the single chokepoint that captures
-        // the non-inbound turns the machine's own `inbound` event never
-        // sees (those bypass handleInbound). Without it the machine reads
-        // idle during a cron/handback turn and the gate would mis-deliver
-        // a concurrent inbound mid-turn (the #1556 composer wedge).
-        // Idempotent when already in_turn (turnStart only sets perKey).
-        shadowEmit({
-          kind: 'turnStart',
-          key: statusKey(ev.chatId, ev.threadId != null ? Number(ev.threadId) : undefined) as _ChatKey,
-          at: startedAt,
-        })
-        // #549 fix — fresh turn, reset preamble-suppression state.
-        preambleSuppressor.reset()
-        // Reset the silent-end retry budget for this chat. The stored
-        // turnKey is `chat:thread` shape (no per-instance suffix), so
-        // without an explicit per-turn clear, `writeSilentEndState`
-        // (silent-end.ts:114) inherits `retryCount` across turns
-        // whenever a prior turn for the same chat hit retryCount=1.
-        // The Stop hook then sees `retryCount >= MAX_RETRIES=1` on the
-        // very first silent-end of every subsequent turn and bails
-        // without re-prompting. finn hit this on 2026-05-25 with a
-        // stuck retryCount=1 file. A new turn invalidates any prior
-        // turn's retry budget by definition; clear it eagerly here.
-        // ev.threadId is `string | null` (Telegram's wire shape);
-        // statusKey wants `number | null` — same conversion as the
-        // registry-key branch a few lines down.
-        clearSilentEndState(statusKey(
-          ev.chatId,
-          ev.threadId != null ? Number(ev.threadId) : null,
-        ))
-        // Stage 3b: stamp turn-start in the registry. turn_key is
-        // chat:thread:startTs — unique per turn, distinct from the
-        // progress-card-driver's per-chat sequence number (these are two
-        // independent identifier schemes and don't need to align).
-        if (turnsDb != null) {
-          // ev.threadId is `string | null` (Telegram emits as string); convert
-          // to number for chatKeyWithSuffix. Number(null) = 0 which canonicalizes
-          // to '_' — same as the explicit `null` branch below.
-          const evThreadIdNum = ev.threadId != null ? Number(ev.threadId) : null
-          const turnKey = chatKeyWithSuffix(ev.chatId, evThreadIdNum, String(startedAt))
-          next.registryKey = turnKey
-          // Phase 1 of #332: capture first ~200 chars of the user's message.
-          const userPromptPreview = extractUserPromptPreview(ev.rawContent)
-          // Closes #472 finding #11. Pre-fix: this write was scheduled
-          // via setImmediate to "avoid stalling the turn handler" — but
-          // SQLite local writes are sub-millisecond, and the deferral
-          // opened a SIGTERM race window: a kill landing in the gap
-          // between scheduling and firing left a turn with no start
-          // row, invisible to the resume protocol (the user sent a
-          // message, the gateway lost it, no SWITCHROOM_PENDING_TURN
-          // env on next boot). Sibling writeTurnActiveMarker has always
-          // been synchronous here; this matches it.
-          try {
-            recordTurnStart(turnsDb, {
-              turnKey,
-              chatId: String(ev.chatId),
-              threadId: ev.threadId != null ? String(ev.threadId) : null,
-              lastUserMsgId: ev.messageId != null ? String(ev.messageId) : null,
-              userPromptPreview,
-            })
-          } catch (err) {
-            process.stderr.write(`telegram gateway: recordTurnStart failed turnKey=${turnKey}: ${(err as Error).message}\n`)
-          }
-          // #412: turn-active marker for the bridge-watchdog. File exists
-          // for the duration of the in-flight turn; mtime advances on
-          // every tool_use; deleted on turn_complete. The watchdog
-          // distinguishes wedged-mid-turn from healthy-idle by checking
-          // for this file's presence + mtime staleness.
-          writeTurnActiveMarker(STATE_DIR, {
-            turnKey,
-            chatId: String(ev.chatId),
-            threadId: ev.threadId != null ? String(ev.threadId) : null,
-            startedAt,
-          })
-        }
-        // (accessor-narrowing spelling: the pre-move body guarded the
-        // `pendingPtyPartial` variable then re-read it into `pending`; the
-        // injected accessor is a call expression TS can't narrow across, so
-        // capture once then guard the local — equivalent, no await between.)
-        const pending = getPendingPtyPartial()
-        if (pending != null) {
-          setPendingPtyPartial(null)
-          handlePtyPartial(pending)
-        }
       }
+      pruneParkedTurnStarts(now)
+      // `enqueue` with no chat can never mint a turn (the whole mint block is
+      // `if (ev.chatId)`-gated); parking it would only pollute the store, so
+      // run the pre-turn drain path verbatim and stop.
+      if (!ev.chatId) {
+        beginTurn(deps, ev)
+        return
+      }
+      // The live-turn probe is the module's ONLY turn accessor: the
+      // most-recently-set turn mirror. Under the sequential-CLI invariant that
+      // IS the live turn, and `endedAt` (stamped in turn-end.ts) is the second
+      // guard for a mirror that outlived its turn. A non-empty parked store is
+      // equally disqualifying: the CLI's queue is not drained, so this message
+      // is queued BEHIND those and minting now would reorder them.
+      const live = getCurrentTurn()
+      const sessionBusy = live != null && live.endedAt == null
+      if (!sessionBusy && parkedTurnStarts.length === 0) {
+        beginTurn(deps, ev)
+        return
+      }
+      // PARKED. Deliberately NO surface work here — no `promoteQueuedStatus`
+      // ("On it — replying now" is a lie until the turn actually starts), no
+      // `typingWrapper.drainAll()` (that drains the LIVE turn's wraps), no card.
+      // The queued placeholder Hook A already posted is the honest surface, and
+      // its lifecycle stays owned by the existing reap machinery.
+      //
+      // UNIFORM ACROSS SOURCES — synthetic enqueues (cron fire, subagent
+      // handback, obligation-represent, vault-grant resume, wake inbound) park
+      // exactly like a real inbound and do NOT preempt. That is not a policy
+      // choice, it is what the CLI does: carrie's `obligation_represent`
+      // enqueue at 2026-07-28T18:19:07.032Z was terminated by a `remove` at
+      // 18:19:59.794Z (folded into the running turn as a `queued_command`
+      // attachment), never by a `dequeue`. Minting for it invented a turn the
+      // CLI never started. FIX B covers the residual case where a mint DOES
+      // land on top of a live atom.
+      parkTurnStart(
+        {
+          chatId: ev.chatId,
+          messageId: ev.messageId,
+          threadId: ev.threadId,
+          rawContent: ev.rawContent,
+        },
+        now,
+      )
+      process.stderr.write(
+        `telegram gateway: turn-start parked (session busy) chat=${ev.chatId} ` +
+          `thread=${enqThreadIdNum ?? '-'} msg=${ev.messageId ?? '-'} ` +
+          `parked=${parkedTurnStarts.length}\n`,
+      )
       return
     }
-    case 'dequeue': return
+    case 'dequeue': {
+      // #3927 FIX A — the CLI's authoritative TURN-START signal: the queue was
+      // drained into a new user turn. Carries no ids (session-tail.ts), so the
+      // pairing is positional — and the evidence says it pairs with the MOST
+      // RECENT enqueue, not the oldest. An empty store is the normal idle path
+      // (the enqueue ms earlier already minted) and a dequeue with no parked
+      // start at all is a no-op, exactly as before.
+      pruneParkedTurnStarts(Date.now())
+      const parked = takeParkedTurnStart()
+      if (parked == null) return
+      beginTurn(deps, parked)
+      return
+    }
+    case 'queue_remove': {
+      // #3927 FIX A — the queued message was folded into the ALREADY-RUNNING
+      // turn (a `queued_command` attachment); it will never own a turn. Drop
+      // its parked envelope so a later `dequeue` cannot mint a spurious turn
+      // for it. Content-matched: `remove` replays its enqueue's `content`
+      // byte-for-byte.
+      pruneParkedTurnStarts(Date.now())
+      discardParkedTurnStart(ev.rawContent)
+      return
+    }
     case 'model': {
       // Live model capture for the main turn. The session-tail projection
       // already filtered sentinels (`<synthetic>` compaction lines), so any

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -93,6 +93,13 @@ export function findActiveSessionFile(projectsDir: string): string | null {
 export type SessionEvent =
   | { kind: 'enqueue'; chatId: string | null; messageId: string | null; threadId: string | null; rawContent: string; isSync?: boolean }
   | { kind: 'dequeue' }
+  // #3927 — `queue-operation` op `remove`: the queued item was folded into the
+  // ALREADY-RUNNING turn as a `queued_command` attachment rather than drained
+  // into a new turn. It is the OTHER terminal of an `enqueue` (the CLI writes
+  // exactly one of `dequeue` / `remove` per enqueue), and unlike `dequeue` it
+  // REPLAYS the enqueue's `content` byte-for-byte — which is what lets the
+  // gateway discard the right parked turn-start by identity.
+  | { kind: 'queue_remove'; rawContent: string }
   | { kind: 'thinking' }
   // Live model in use for the MAIN session, extracted from `message.model` on
   // each `type:"assistant"` transcript line (the exact model that served that
@@ -565,6 +572,12 @@ export function projectTranscriptLine(line: string): SessionEvent[] {
     }
     if (op === 'dequeue') {
       return [{ kind: 'dequeue' }]
+    }
+    // #3927 — the enqueue's OTHER terminal. Previously dropped, which left the
+    // gateway unable to tell "queued message folded into the running turn"
+    // (`remove`) from "queue drained into a new turn" (`dequeue`).
+    if (op === 'remove') {
+      return [{ kind: 'queue_remove', rawContent: (obj.content as string | undefined) ?? '' }]
     }
     return []
   }

--- a/telegram-plugin/tests/stream-render-golden.test.ts
+++ b/telegram-plugin/tests/stream-render-golden.test.ts
@@ -19,10 +19,14 @@
  * the duplicate. This is the exact duplicate-reply class the shared-singleton
  * injection (never a re-`new`) exists to kill.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { handleSessionEvent, type StreamRenderDeps } from '../gateway/stream-render.js'
+import {
+  handleSessionEvent,
+  __resetParkedTurnStartsForTest,
+  type StreamRenderDeps,
+} from '../gateway/stream-render.js'
 import {
   sendReply,
   type SendReplyGatewayDeps,
@@ -612,6 +616,9 @@ describe('structural — the singleton lives once in gateway, never in the modul
 // the assertion is the OUTCOME the user sees — chat actions on the wire — not
 // the call.
 describe('#3544 — turn-start typing is unconditional at the enqueue seam', () => {
+  // #3927's parked turn-start store is module-scope (one CLI session, one
+  // queue), so reset it between cases for determinism.
+  beforeEach(() => { __resetParkedTurnStartsForTest() })
   interface TypingRig {
     h: StreamHarness
     sent: Array<{ chatId: string; threadId: number | null }>
@@ -669,15 +676,23 @@ describe('#3544 — turn-start typing is unconditional at the enqueue seam', () 
 
   it('FLOOD GUARD: N turns arming on ONE chat inside the floor cost at most ONE chat action', () => {
     const rig = makeTypingRig({ adopts: false })
+    // #3927: a repeated bare `enqueue` no longer mints a turn — while one is
+    // live it PARKS, and the CLI's `dequeue` is what starts the next turn. This
+    // guard is about N turn STARTS coalescing, so drive real starts: the first
+    // enqueue mints (idle) and each later enqueue+dequeue pair mints one more.
+    const startTurn = () => {
+      handleSessionEvent(rig.h.deps, enqueue())
+      handleSessionEvent(rig.h.deps, { kind: 'dequeue' })
+    }
     // 12 arms on one chat inside a single floor window: a real-inbound arm
-    // (turn-start-surfaces) plus repeated enqueue seams / restarts.
+    // (turn-start-surfaces) plus repeated turn-start seams / restarts.
     rig.loop.start(CHAT, null) // stand-in for the real-inbound path's arm
-    for (let i = 0; i < 11; i++) handleSessionEvent(rig.h.deps, enqueue())
+    for (let i = 0; i < 11; i++) startTurn()
     expect(rig.sent).toHaveLength(1) // the floor coalesced all 12
     expect(rig.loop.activeCount()).toBe(1) // restart-safe: no interval pile-up
     // Crossing the floor lets exactly one more through, then the floor holds again.
     rig.clock.t += TYPING_FLOOR_MS
-    for (let i = 0; i < 5; i++) handleSessionEvent(rig.h.deps, enqueue())
+    for (let i = 0; i < 5; i++) startTurn()
     expect(rig.sent).toHaveLength(2)
     rig.loop.stopAll()
     rig.emitter.reset()

--- a/telegram-plugin/tests/turn-mint-defers-until-dequeue.test.ts
+++ b/telegram-plugin/tests/turn-mint-defers-until-dequeue.test.ts
@@ -131,9 +131,17 @@ describe('#3927 FIX A — a mid-turn enqueue parks; the turn mints on dequeue', 
 
   it('a parked start expires after its TTL, so a dequeue that never arrives can ' +
     'never mint a stale turn later', () => {
+    // RUNNER-AGNOSTIC CLOCK. This file dual-runs (vitest + `bun test`), and
+    // bun's vitest shim does NOT implement `vi.setSystemTime` — calling it
+    // threw `TypeError: vi.setSystemTime is not a function` and made bun-test
+    // deterministically red. The TTL is a pure elapsed-time comparison
+    // (`now - parkedAt > PARKED_TURN_START_TTL_MS`), so the absolute wall
+    // clock is irrelevant; only the 31-minute JUMP matters. `useFakeTimers()`
+    // + `advanceTimersByTime()` moves `Date.now()` by exactly that delta on
+    // BOTH runners (same insight as races.test.ts:275-281), so the assertion
+    // below really executes under bun instead of being guarded away.
     vi.useFakeTimers()
     try {
-      vi.setSystemTime(new Date('2026-07-28T18:00:00Z'))
       const h = makeHarness()
       handleSessionEvent(h.deps, enqueue('1201'))
       const turnA = h.current()!
@@ -141,7 +149,7 @@ describe('#3927 FIX A — a mid-turn enqueue parks; the turn mints on dequeue', 
       expect(__parkedTurnStartCountForTest()).toBe(1)
 
       // The CLI died mid-turn: neither `dequeue` nor `remove` ever arrives.
-      vi.setSystemTime(new Date('2026-07-28T18:31:00Z')) // TTL is 30 min
+      vi.advanceTimersByTime(31 * 60_000) // TTL is 30 min
       turnA.endedAt = Date.now()
       handleSessionEvent(h.deps, { kind: 'dequeue' })
 

--- a/telegram-plugin/tests/turn-mint-defers-until-dequeue.test.ts
+++ b/telegram-plugin/tests/turn-mint-defers-until-dequeue.test.ts
@@ -1,0 +1,188 @@
+/**
+ * #3927 FIX A — a QUEUE event is not a TURN-START event.
+ *
+ * Pre-fix, `case 'enqueue'` in stream-render.ts unconditionally minted a fresh
+ * `CurrentTurn` and swapped it into the per-topic slot, even with a turn
+ * already live. The claude CLI writes `{"type":"queue-operation","operation":
+ * "enqueue"}` at QUEUE time, so a message the operator sent mid-turn produced
+ * a brand-new card (reset `startedAt` / `toolCallCount` / `mirrorLines`) that
+ * then streamed the STILL-RUNNING previous turn's tool labels into it, while
+ * the real turn's card froze on its last edit.
+ *
+ * Ground truth (60 real agent transcripts, 372 enqueues): every enqueue is
+ * terminated by exactly one of
+ *   • `dequeue` — queue drained into a NEW turn (199/200 dequeues are directly
+ *     preceded by their enqueue; median gap 6 ms idle, 2–14 s when queued
+ *     behind a running turn), or
+ *   • `remove`  — folded into the ALREADY-RUNNING turn as a `queued_command`
+ *     attachment, replaying the enqueue's `content` byte-for-byte.
+ *
+ * These drive the REAL `handleSessionEvent` (extracted-module golden-harness
+ * oracle, same standard as `stream-render-golden.test.ts`).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  handleSessionEvent,
+  __resetParkedTurnStartsForTest,
+  __parkedTurnStartCountForTest,
+} from '../gateway/stream-render.js'
+import { projectTranscriptLine } from '../session-tail.js'
+import { CHAT, enqueue, inbound, makeHarness } from './turn-mint-harness.js'
+
+beforeEach(() => {
+  __resetParkedTurnStartsForTest()
+})
+
+describe('#3927 FIX A — a mid-turn enqueue parks; the turn mints on dequeue', () => {
+  it('a second enqueue while turn A is live opens NO card, does not steal the slot, ' +
+    'and later tool labels still land on A — then dequeue mints B', () => {
+    const h = makeHarness()
+
+    // ── message A arrives on an idle session: mints immediately (unchanged) ──
+    handleSessionEvent(h.deps, enqueue('501'))
+    handleSessionEvent(h.deps, { kind: 'dequeue' }) // the CLI's ms-later pair
+    const turnA = h.current()!
+    expect(turnA).not.toBeNull()
+    expect(turnA.sourceMessageId).toBe(501)
+    expect(h.cardsOpened).toHaveLength(1)
+    // The idle enqueue already minted, so the paired dequeue found nothing
+    // parked and was a no-op — NOT a second turn.
+    expect(h.cardsOpened[0]!.sourceMessageId).toBe(501)
+
+    // ── A does tool work ────────────────────────────────────────────────────
+    handleSessionEvent(h.deps, { kind: 'tool_label', toolName: 'Read', label: 'Reading config.ts' })
+    expect(turnA.labeledToolCount).toBe(1)
+
+    // ── the operator sends message B MID-TURN (no turn_end for A) ───────────
+    handleSessionEvent(h.deps, enqueue('502', 'also check the vault'))
+
+    // No second card. This is BUG 1: pre-fix a fresh card appeared here with
+    // reset stats while A's froze.
+    expect(h.cardsOpened).toHaveLength(1)
+    // The topic slot still points at A — object identity, not just shape.
+    expect(h.current()).toBe(turnA)
+    // This is BUG 2: pre-fix the slot pointed at B, whose card quoted B's
+    // message id while streaming A's still-running work.
+    expect(h.current()!.sourceMessageId).toBe(501)
+    expect(__parkedTurnStartCountForTest()).toBe(1)
+
+    // ── labels emitted AFTER B still belong to A's card ─────────────────────
+    handleSessionEvent(h.deps, { kind: 'tool_label', toolName: 'Bash', label: 'Running tests' })
+    expect(turnA.labeledToolCount).toBe(2)
+    expect(turnA.mirrorLines.join('\n')).toContain('Running tests')
+    expect(h.drains.every((d) => d.turnId === turnA.turnId)).toBe(true)
+
+    // ── A ends, the CLI drains the queue → B's turn mints NOW ───────────────
+    turnA.endedAt = Date.now()
+    handleSessionEvent(h.deps, { kind: 'dequeue' })
+    const turnB = h.current()!
+    expect(turnB).not.toBe(turnA)
+    expect(turnB.sourceMessageId).toBe(502)
+    expect(h.cardsOpened).toHaveLength(2)
+    expect(h.cardsOpened[1]!.sourceMessageId).toBe(502)
+    // Fresh stats belong to B and only B.
+    expect(turnB.labeledToolCount).toBe(0)
+    expect(turnB.mirrorLines).toEqual([])
+    expect(__parkedTurnStartCountForTest()).toBe(0)
+  })
+
+  it('a `remove` terminal discards the parked start, so a LATER dequeue cannot ' +
+    'mint a spurious turn for an already-folded message', () => {
+    const h = makeHarness()
+    handleSessionEvent(h.deps, enqueue('601'))
+    const turnA = h.current()!
+
+    // Queued mid-turn, then folded into A as a `queued_command` attachment.
+    const queued = enqueue('602', 'while you are in there…')
+    handleSessionEvent(h.deps, queued)
+    expect(__parkedTurnStartCountForTest()).toBe(1)
+    handleSessionEvent(h.deps, { kind: 'queue_remove', rawContent: queued.rawContent })
+    expect(__parkedTurnStartCountForTest()).toBe(0)
+
+    // A stray dequeue now must NOT resurrect 602 as its own turn.
+    handleSessionEvent(h.deps, { kind: 'dequeue' })
+    expect(h.current()).toBe(turnA)
+    expect(h.cardsOpened).toHaveLength(1)
+  })
+
+  it('dequeue pairs with the MOST RECENT parked start (evidence: max observed ' +
+    'gap to the newest enqueue is 14.2 s; to the oldest, hours)', () => {
+    const h = makeHarness()
+    handleSessionEvent(h.deps, enqueue('701'))
+    const turnA = h.current()!
+
+    handleSessionEvent(h.deps, enqueue('702'))
+    handleSessionEvent(h.deps, enqueue('703'))
+    expect(__parkedTurnStartCountForTest()).toBe(2)
+
+    turnA.endedAt = Date.now()
+    handleSessionEvent(h.deps, { kind: 'dequeue' })
+    expect(h.current()!.sourceMessageId).toBe(703)
+    expect(__parkedTurnStartCountForTest()).toBe(1)
+  })
+
+  it('a chat-less enqueue never parks (it can never mint a turn)', () => {
+    const h = makeHarness()
+    handleSessionEvent(h.deps, { kind: 'enqueue', chatId: null, messageId: null, threadId: null, rawContent: 'x' })
+    expect(__parkedTurnStartCountForTest()).toBe(0)
+    expect(h.current()).toBeNull()
+    expect(h.cardsOpened).toHaveLength(0)
+  })
+
+  it('a parked start expires after its TTL, so a dequeue that never arrives can ' +
+    'never mint a stale turn later', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-07-28T18:00:00Z'))
+      const h = makeHarness()
+      handleSessionEvent(h.deps, enqueue('1201'))
+      const turnA = h.current()!
+      handleSessionEvent(h.deps, enqueue('1202'))
+      expect(__parkedTurnStartCountForTest()).toBe(1)
+
+      // The CLI died mid-turn: neither `dequeue` nor `remove` ever arrives.
+      vi.setSystemTime(new Date('2026-07-28T18:31:00Z')) // TTL is 30 min
+      turnA.endedAt = Date.now()
+      handleSessionEvent(h.deps, { kind: 'dequeue' })
+
+      // 1202 was pruned, not minted 31 minutes late.
+      expect(__parkedTurnStartCountForTest()).toBe(0)
+      expect(h.current()).toBe(turnA)
+      expect(h.cardsOpened).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('the parked store is bounded — the 17th mid-turn enqueue evicts the oldest, ' +
+    'so a dequeue that never arrives cannot grow it without limit', () => {
+    const h = makeHarness()
+    handleSessionEvent(h.deps, enqueue('801'))
+    for (let i = 0; i < 40; i++) handleSessionEvent(h.deps, enqueue(String(900 + i)))
+    expect(__parkedTurnStartCountForTest()).toBe(16)
+    // The newest message — the one the user is actually waiting on — survived.
+    h.current()!.endedAt = Date.now()
+    handleSessionEvent(h.deps, { kind: 'dequeue' })
+    expect(h.current()!.sourceMessageId).toBe(939)
+  })
+})
+
+describe('#3927 — session-tail projects the `remove` queue operation', () => {
+  it('projects op=remove as queue_remove carrying the enqueue content verbatim', () => {
+    const content = inbound('901', 'queued while busy')
+    const evs = projectTranscriptLine(
+      JSON.stringify({ type: 'queue-operation', operation: 'remove', content }),
+    )
+    expect(evs).toEqual([{ kind: 'queue_remove', rawContent: content }])
+  })
+
+  it('still projects enqueue and dequeue unchanged', () => {
+    const content = inbound('902', 'hello')
+    expect(projectTranscriptLine(
+      JSON.stringify({ type: 'queue-operation', operation: 'enqueue', content }),
+    )).toEqual([{ kind: 'enqueue', chatId: CHAT, messageId: '902', threadId: null, rawContent: content }])
+    expect(projectTranscriptLine(
+      JSON.stringify({ type: 'queue-operation', operation: 'dequeue' }),
+    )).toEqual([{ kind: 'dequeue' }])
+  })
+})

--- a/telegram-plugin/tests/turn-mint-harness.ts
+++ b/telegram-plugin/tests/turn-mint-harness.ts
@@ -1,0 +1,155 @@
+/**
+ * Shared harness for the #3927 turn-mint tests (FIX A / FIX B). NOT a test file
+ * — it drives the REAL `handleSessionEvent` against fake gateway closures, the
+ * extracted-module golden-harness oracle used by `stream-render-golden.test.ts`.
+ */
+import { tmpdir } from 'node:os'
+import type { CurrentTurn, StreamRenderDeps } from '../gateway/gateway.js'
+
+export const CHAT = '1001'
+
+/** `<channel …>` envelope shaped like the real inbound wrapper the CLI queues. */
+export function inbound(messageId: string, text: string): string {
+  return (
+    `<channel source="switchroom-telegram" chat_id="${CHAT}" ` +
+    `message_id="${messageId}" user="tester">${text}</channel>`
+  )
+}
+
+export interface Harness {
+  deps: StreamRenderDeps
+  /** Every card the early-liveness open posted, in order (one per minted turn). */
+  cardsOpened: Array<{ turnId: string; sourceMessageId: number | null }>
+  /** Turns handed to `clearActivitySummary`, in order (FIX B's observable). */
+  finalized: CurrentTurn[]
+  /** `drainActivitySummary` calls: which turn's feed was drained, and its text. */
+  drains: Array<{ turnId: string; render: string | null }>
+  /** Ordered trace of surface effects: `finalize:<turnId>` / `open:<turnId>`. */
+  seq: string[]
+  current: () => CurrentTurn | null
+}
+
+export function makeHarness(): Harness {
+  let curTurn: CurrentTurn | null = null
+  const cardsOpened: Harness['cardsOpened'] = []
+  const finalized: CurrentTurn[] = []
+  const drains: Harness['drains'] = []
+  const seq: string[] = []
+  const noop = () => {}
+  const key = (c: string, t?: number | null) => `${c}:${t ?? 'main'}`
+
+  const deps = {
+    // config
+    ANSWER_LANE: { visibleEnabled: false },
+    CAPTURED_PROSE_DELIVERY_ENABLED: false,
+    CONTEXT_EXHAUSTION_COOLDOWN_MS: 600000,
+    DELIVERY_CONFIRM_ENABLED: false,
+    FEED_REOPEN_AFTER_ACK_ENABLED: false,
+    HANDBACK_PRETURN_ENABLED: false,
+    HISTORY_ENABLED: false,
+    LIVENESS_TERMINAL_HONESTY: true,
+    OBLIGATION_LEDGER_ENABLED: false,
+    ORPHANED_REPLY_STREAM_WINDOW_MS: 120000,
+    SILENCE_LIVENESS_PRODUCTION: false,
+    STATE_DIR: tmpdir(),
+    TURN_FLUSH_SAFETY_ENABLED: true,
+    TURN_PREVIEW_MAX: 200,
+    // state
+    activeDraftStreams: new Map(),
+    activeStatusReactions: new Map(),
+    activeTurnStartedAt: new Map(),
+    backstopDeliveryLedger: { has: () => false, record: noop },
+    bot: { api: {} },
+    deliveryQueue: {},
+    flushedTurnSupersede: { record: noop },
+    handbackPreturnSignal: { tryAdopt: () => null },
+    idleTracker: { noteEvent: noop },
+    lastPtyPreviewByChat: new Map(),
+    obligationLedger: { close: noop, noteTurnEnded: noop },
+    outboundDedup: { check: () => null, record: noop },
+    pendingCrossTurnGate: new Map(),
+    preambleSuppressor: { dropNow: noop, flushNow: noop, onText: noop, onTool: noop, reset: noop },
+    progressDriver: null,
+    reactionTransitionCounts: new Map(),
+    sessionModelSource: { noteTranscriptModel: noop },
+    suppressPtyPreview: new Set(),
+    toolFlightTracker: { inFlightCount: () => 0 },
+    typingWrapper: { drainAll: noop, onToolResult: noop, onToolUse: noop },
+    robustApiCall: (fn: () => Promise<unknown>) => fn(),
+    swallowingApiCall: async (fn: () => Promise<unknown>) => { try { return await fn() } catch { return undefined } },
+    // accessors
+    getCurrentTurn: () => curTurn,
+    setCurrentTurn: (t: CurrentTurn) => { curTurn = t },
+    getLastContextExhaustionWarningAt: () => 0,
+    setLastContextExhaustionWarningAt: noop,
+    getPendingPtyPartial: () => null,
+    setPendingPtyPartial: noop,
+    // closures we observe
+    clearActivitySummary: (t: CurrentTurn) => { finalized.push(t); seq.push(`finalize:${t.turnId}`) },
+    scheduleEarlyLivenessOpen: (t: CurrentTurn) => {
+      // Models the real early-open: ONE card per minted turn. Pre-fix this ran
+      // for every enqueue, which is exactly how the duplicate card appeared.
+      cardsOpened.push({ turnId: t.turnId, sourceMessageId: t.sourceMessageId })
+      seq.push(`open:${t.turnId}`)
+    },
+    drainActivitySummary: (t: CurrentTurn) => {
+      drains.push({ turnId: t.turnId, render: t.activityPendingRender })
+      return Promise.resolve()
+    },
+    // rest of the closure surface
+    cardDrainGate: (_t: unknown, _ea: unknown, run: () => void) => run(),
+    clearAnswerReadyFlushTimeout: noop,
+    closeActivityLane: noop,
+    closeProgressLane: noop,
+    completeProgressCardTurn: null,
+    composeTurnActivity: () => null,
+    confirmMemoryLegibility: noop,
+    deliverAnswer: async () => ({ sentIds: [], chunkCount: 0, delivered: false, exhausted: false }),
+    deliverCapturedProse: async () => {},
+    emissionAuthorityFor: () => ({
+      mayDrain: () => true,
+      openOrEditCard: (_p: string, run: () => void) => run(),
+      claimOrDowngradePing: (_i: unknown, _s: unknown, _a: unknown, disabled: () => void) => disabled(),
+      markSubstantiveFinalDelivered: (fn: () => void) => fn(),
+      finalizeCard: (fn: () => void) => fn(),
+    }),
+    emitTurnRecord: noop,
+    endCurrentTurnAtomic: () => null,
+    extractUserPromptPreview: () => null,
+    finalizeStatusReaction: noop,
+    flushPendingNarrativeAtTurnEnd: noop,
+    getPinnedProgressCardMessageId: null,
+    handlePtyPartial: noop,
+    isDmChatId: () => true,
+    isLegitimatelyWorking: () => false,
+    makeNarrativeGate: () => ({ show: noop, stage: noop, resolveOnTool: noop, flushAtTurnEnd: noop, teardown: noop }),
+    promoteQueuedStatus: noop,
+    purgeReactionTracking: noop,
+    redactOutboundText: (t: string) => t,
+    rememberRecentTurn: noop,
+    resetAnswerReadyFlushTimeout: noop,
+    resetOrphanedReplyTimeout: noop,
+    resolvePendingNarrativeOnTool: noop,
+    stagePendingNarrative: noop,
+    startTurnTypingLoop: noop,
+    statusKey: key,
+    streamKey: key,
+    surfaceMemoryLegibility: noop,
+    turnLiveForItsTopic: () => true,
+    turnsDb: null,
+    unpinProgressCardForChat: null,
+  } as unknown as StreamRenderDeps
+
+  return { deps, cardsOpened, finalized, drains, seq, current: () => curTurn }
+}
+
+export function enqueue(messageId: string | null, text = 'hi', threadId: string | null = null) {
+  return {
+    kind: 'enqueue' as const,
+    chatId: CHAT,
+    messageId,
+    threadId,
+    rawContent: messageId == null ? text : inbound(messageId, text),
+  }
+}
+

--- a/telegram-plugin/tests/turn-supersede-finalizes-prior-card.test.ts
+++ b/telegram-plugin/tests/turn-supersede-finalizes-prior-card.test.ts
@@ -1,0 +1,124 @@
+/**
+ * #3927 FIX B — a superseded turn must never be left holding an orphaned card.
+ *
+ * The turn-supersession teardown in `stream-render.ts` tore down the prior
+ * turn's `answerStream`, its orphaned-reply fuse and its `narrativeGate`, but
+ * NEVER called `clearActivitySummary(prior)`. So a clobbered turn's activity
+ * card was never finalized, never unpinned (`fg:<statusKey>` stayed claimed
+ * forever), froze on its last landed edit, and left NO `turn-lifecycle clear`
+ * line to explain it. Proof from the field: carrie's turn
+ * `-1004223464247:_#1078` has a `turn-lifecycle set reason=enqueue` at
+ * 2026-07-28T18:13:37.554Z and no `clear` anywhere in the log; its stale pinned
+ * card was still on screen in the operator's screenshot.
+ *
+ * ── Which path still supersedes, after FIX A ──────────────────────────────
+ * FIX A parks EVERY mid-turn enqueue, synthetic ones included — that is not a
+ * policy choice, it is what the claude CLI does (carrie's `obligation_represent`
+ * enqueue at 18:19:07.032Z was terminated by a `remove` at 18:19:59.794Z, i.e.
+ * folded into the running turn as a `queued_command` attachment, never by a
+ * `dequeue`). So an enqueue no longer preempts, and the case below asserts that
+ * explicitly.
+ *
+ * Supersession is still REACHABLE, though: a turn whose `turn_end` the gateway
+ * never observed (bridge death, transcript gap, unclean restart) leaves a
+ * live-looking atom in the slot, and the next genuine dequeue-driven turn start
+ * mints straight on top of it. That is the exact orphan carrie hit, and it is
+ * what FIX B finalizes.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  handleSessionEvent,
+  __resetParkedTurnStartsForTest,
+  __parkedTurnStartCountForTest,
+} from '../gateway/stream-render.js'
+import { enqueue, makeHarness } from './turn-mint-harness.js'
+
+/** A cron / handback / wake enqueue: no `message_id`, so `deriveTurnId` falls
+ *  back to `…#synthetic-<startedAt>`. */
+function syntheticEnqueue(chatId: string, text: string) {
+  return {
+    kind: 'enqueue' as const,
+    chatId,
+    messageId: null,
+    threadId: null,
+    rawContent: `<channel source="switchroom-telegram" source="cron">${text}</channel>`,
+  }
+}
+
+beforeEach(() => {
+  __resetParkedTurnStartsForTest()
+})
+
+describe('#3927 FIX B — superseding a live turn finalizes its card', () => {
+  it('a dequeue-driven mint on top of a never-ended turn calls clearActivitySummary ' +
+    'for the PRIOR turn, and does so BEFORE the successor opens its card', () => {
+    const h = makeHarness()
+
+    // Turn A starts and opens a card with real work on it.
+    handleSessionEvent(h.deps, enqueue('1078'))
+    const turnA = h.current()!
+    handleSessionEvent(h.deps, { kind: 'tool_label', toolName: 'Read', label: 'Reading the log' })
+    expect(turnA.labeledToolCount).toBe(1)
+    expect(h.finalized).toHaveLength(0)
+
+    // A's `turn_end` is NEVER observed — `endedAt` stays null and the atom
+    // stays in the slot (exactly carrie's `#1078`).
+    expect(turnA.endedAt).toBeNull()
+
+    // A later message is queued and the CLI drains it into a new turn.
+    handleSessionEvent(h.deps, enqueue('1086'))
+    expect(__parkedTurnStartCountForTest()).toBe(1)
+    handleSessionEvent(h.deps, { kind: 'dequeue' })
+
+    const turnB = h.current()!
+    expect(turnB).not.toBe(turnA)
+
+    // FIX B: the orphan was finalized — pre-fix there was NO call at all.
+    expect(h.finalized).toHaveLength(1)
+    expect(h.finalized[0]).toBe(turnA)
+
+    // …and it happened BEFORE the successor's card opened, so the old card is
+    // finalized/unpinned rather than left frozen above a fresh one.
+    expect(h.seq).toEqual([
+      `open:${turnA.turnId}`,
+      `finalize:${turnA.turnId}`,
+      `open:${turnB.turnId}`,
+    ])
+  })
+
+  it('a turn that ENDED normally is not re-finalized when its successor mints', () => {
+    const h = makeHarness()
+    handleSessionEvent(h.deps, enqueue('1090'))
+    const turnA = h.current()!
+    // turn-end.ts stamps `endedAt` and runs its own clearActivitySummary.
+    turnA.endedAt = Date.now()
+
+    handleSessionEvent(h.deps, enqueue('1091'))
+    // Idle by `endedAt`, so this mints straight away — and must NOT double-
+    // finalize A's already-closed card.
+    expect(h.current()).not.toBe(turnA)
+    expect(h.finalized).toHaveLength(0)
+  })
+
+  it('FIX A is uniform across sources: a SYNTHETIC (cron/handback) enqueue parks ' +
+    'behind a live turn instead of preempting it', () => {
+    const h = makeHarness()
+    handleSessionEvent(h.deps, enqueue('1100'))
+    const turnA = h.current()!
+
+    handleSessionEvent(h.deps, syntheticEnqueue('1001', 'time for the daily digest'))
+
+    // No preemption: no new card, no slot steal, no orphaned finalize.
+    expect(h.current()).toBe(turnA)
+    expect(h.cardsOpened).toHaveLength(1)
+    expect(h.finalized).toHaveLength(0)
+    expect(__parkedTurnStartCountForTest()).toBe(1)
+
+    // It mints on the CLI's own turn-start signal, like every other source.
+    turnA.endedAt = Date.now()
+    handleSessionEvent(h.deps, { kind: 'dequeue' })
+    expect(h.current()).not.toBe(turnA)
+    expect(h.current()!.turnId).toContain('#synthetic-')
+    expect(h.cardsOpened).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## The bug

`case 'enqueue'` in `telegram-plugin/gateway/stream-render.ts` treated the claude CLI's
`{"type":"queue-operation","operation":"enqueue"}` transcript record as a **turn-start** event.
The CLI writes it at **queue** time, whether or not a turn is already running, so a message the
operator sent mid-turn unconditionally minted a fresh `CurrentTurn` and swapped it into the
per-topic slot.

Two operator-visible bugs fell out of that:

1. **Frozen card + reset stats.** The live progress card froze on its last edit and a brand-new
   card appeared with `startedAt`, `toolCallCount`/`labeledToolCount`, `mirrorLines: []` and
   `activityMessageId: null` all reset.
2. **Card quotes the wrong message.** The new card's `reply_parameters` quoted the just-queued
   message and then streamed the **still-running previous turn's** `tool_label`s into it.

Field proof (carrie, 2026-07-28): turn `-1004223464247:_#1078` got
`turn-lifecycle set reason=enqueue` at `18:13:37.554Z`, was clobbered 5m30s later by a synthetic
enqueue at `18:19:07.134Z`, and has **no** `turn-lifecycle clear` anywhere in the log — the stale
pinned card in the operator's screenshot is that orphan still holding the status pin.

## Fix A — mint on the CLI's own turn-start signal

The entire mint block is extracted verbatim into `beginTurn()` (`stream-render.ts:211`).
`case 'enqueue'` (`:692`) now calls it only when the session is genuinely idle; otherwise it parks
the envelope, and `case 'dequeue'` (`:785`) — previously literally `case 'dequeue': return` — mints
from the park.

### Transcript evidence corrected two points of the original plan

I validated against 60 real agent transcripts on the host (372 enqueues) before writing code, and
it contradicted the brief in two ways:

**1. A third op exists and was unparsed: `remove`.** Every enqueue is terminated by exactly one of
`dequeue` (200) or `remove` (161, 1 unmatched). A `remove` means the queued item was folded into
the **already-running** turn as a `"type": "queued_command"` attachment — no new turn exists for it
and none ever will (carrie lines 452→473→474: `obligation_represent` enqueued 18:19:07.032Z,
removed 18:19:59.794Z). Parking without handling `remove` would have been a *new* bug: a dead
envelope sitting forever, then minted by a later `dequeue` as a spurious turn for an
already-answered message. So `session-tail.ts` now projects it as
`{ kind: 'queue_remove', rawContent }` and `case 'queue_remove'` (`:798`) discards the
content-matching parked envelope. `remove` replays its enqueue's `content` byte-for-byte
(13/13 sha1 matches in carrie), so identity matching is reliable.

**2. Pairing is LIFO, not FIFO.** 199/200 dequeues are directly preceded by their enqueue. The gap
to the **newest** pending enqueue has median 6 ms and max 14.2 s; the gap to the **oldest** runs to
hours. Popping the oldest (as the brief specified) would mint stale envelopes. We pop the most
recent — and we also park when the store is non-empty even if idle, so ordering can never invert.

### Synthetic enqueues park too — deliberately, and it is not a policy choice

Cron fires, subagent handbacks, obligation-represents, vault-grant resumes and wake inbounds park
exactly like a real inbound and do **not** preempt. The CLI treats them identically: carrie's
`obligation_represent` enqueue was terminated by a `remove`, never a `dequeue`. Minting for it
invented a turn the CLI never started. Stated in a code comment at `:760` and covered by a test.

### `ackDelivery` stays on `enqueue`

It asserts **receipt**, not turn start, and receipt is exactly what an enqueue proves. A parked
envelope whose terminal turns out to be `remove` never reaches `beginTurn`, so acking there would
leave that message tracked forever and the delivery machine would re-deliver it as a duplicate
inbound. Hoisted and commented at `:702`.

### Bounds

`PARKED_TURN_START_MAX = 16` (evict **oldest** — the newest message is the one the user is waiting
on, and an evicted envelope still reaches the model via the CLI's own queue; it only loses its
progress card) and `PARKED_TURN_START_TTL_MS = 30 min`, pruned on every touch. So a `dequeue` that
never arrives (bridge death, unclean restart) can neither mint a stale turn 31 minutes late nor
grow the store without limit. Both bounds have tests.

## Fix B — never orphan a card on supersession

The supersession teardown tore down `answerStream`, the orphaned-reply fuse and
`narrativeGate.teardown()`, but **never** called `clearActivitySummary(prior)`. So a clobbered
turn's card was never finalized, kept the `fg:<statusKey>` status pin forever, froze on its last
landed edit, and left no log line to explain it.

`beginTurn` now finalizes a prior turn whose `endedAt` is still `null`
(`stream-render.ts:302-309`) and emits `turn-lifecycle clear reason=superseded` in the existing
field format, so a clobber can never again be invisible in the logs. `narrative-lane.ts` is only
**called**, never edited (another PR owns that file).

After Fix A this path is rare but still reachable: a turn whose `turn_end` was never observed
leaves a live-looking atom in the slot, and the next genuine dequeue-driven start mints on top of
it. That is exactly the orphan carrie hit.

## Tests

Both new files drive the **real** `handleSessionEvent` through the extracted-module
golden-harness oracle, same standard as `stream-render-golden.test.ts`.

- `telegram-plugin/tests/turn-mint-defers-until-dequeue.test.ts` (8) — the required main case
  (mid-turn enqueue opens no card, slot identity still `turnA`, `sourceMessageId === 501`, later
  tool labels still land on A, then `dequeue` mints B with fresh stats), plus `remove` discard,
  LIFO pairing, chat-less enqueue, TTL expiry (fake timers, 31 min), cap-16 eviction, and the
  session-tail `remove` projection.
- `telegram-plugin/tests/turn-supersede-finalizes-prior-card.test.ts` (3) — `clearActivitySummary`
  runs for the prior turn and does so **before** the successor's card opens
  (`seq === [open:A, finalize:A, open:B]`); a normally-ended turn is not re-finalized; synthetic
  enqueues park rather than preempt.
- `telegram-plugin/tests/turn-mint-harness.ts` — shared non-test harness.

**Red on pre-fix:** with Fix A and Fix B reverted in place, 6 of 10 fail, including both required
target tests.

`stream-render-golden.test.ts`'s "#3544 FLOOD GUARD" case is updated to drive enqueue+dequeue pairs
via a `startTurn()` helper, because a repeated bare `enqueue` legitimately no longer mints. That was
my regression, caught locally and fixed rather than papered over.

## Verification

- `tsc --noEmit -p tsconfig.json` — clean.
- `npm run lint` — clean across all 22 guard scripts (`check-gateway-line-ratchet`,
  `check-bot-api-wrapping`, `check-no-pii-secrets` included).
- Scoped: `turn-mint-defers-until-dequeue` + `turn-supersede-finalizes-prior-card` +
  `stream-render-golden` + `session-tail` → **93 passed**.
- Full `vitest run telegram-plugin/tests` → 500/501 files, 8177 passed. The single failure,
  `approval-hold-record.test.ts > falls back to the agent's own state dir when the shared dir is
  not writable`, is **pre-existing and environment-only** — verified failing on pristine
  `origin/main` in a temporary detached worktree. We run as uid 0, so the test's "not writable"
  `chmod` has no effect. CI is the authority.

## Adversarial review notes

- **Forum topics / concurrent turns.** The park store is module-global rather than per-`statusKey`,
  which is correct: the CLI has exactly ONE queue for the session, and turns are sequential across
  all topics. A per-key store would let a topic-B dequeue mint while topic-A's envelope is the one
  the CLI actually drained.
- **Boot replay.** `computeFirstAttachCursor` seeks to the last `enqueue` with no following
  `turn_duration`. At boot there is no live turn and the park store is empty, so the replayed
  enqueue mints exactly as before. No regression.
- **Rapid-fire race.** A second enqueue landing inside the ~6 ms idle enqueue→dequeue window parks
  and is minted by the next dequeue. No worse than pre-fix, which minted twice.
- **Stray dequeue with nothing parked** — no-op, as before. **Dequeue that never arrives** — TTL
  prune. **Unbounded queue** — cap 16.

## Deliberately left out

- No `promoteQueuedStatus` on park and none on `remove`. "On it — replying now" is a lie until the
  turn actually starts; the queued placeholder Hook A already posted is the honest surface and its
  lifecycle stays owned by the existing reap machinery.
- `gateway/queued-card-store.ts` untouched — it is a pure durable snapshot store for orphan reaping
  and the fix needed nothing from it.
- `gateway/narrative-lane.ts` untouched per scope discipline (only `clearActivitySummary` is
  called). Follow-up fixes B-and-C in that file are a separate PR.

Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
