### PR TITLE
fix(gateway): stop logging Telegram rejections as tg-post status=ok

### DIFF
--- a/telegram-plugin/retry-api-call.ts
+++ b/telegram-plugin/retry-api-call.ts
@@ -92,13 +92,49 @@ export interface RetryCallOpts {
   priorityClass?: 'critical' | 'useful' | 'cosmetic'
 }
 
+/**
+ * The three benign Telegram 400s this policy swallows (contract table above).
+ */
+export type BenignTelegram400Kind = 'not_modified' | 'message_not_found' | 'delete_not_found'
+
+/**
+ * Single source of truth for "is this Telegram 400 a benign no-op?".
+ *
+ * Benign here means exactly what the retry policy already treats as a
+ * non-event: the edit was a no-op because the content is identical, or the
+ * target message vanished before the edit/delete landed. Both are
+ * high-volume on a healthy agent (every coalesced card repaint can produce
+ * one) and neither means anything is wrong — so any surface that reports
+ * Telegram failures needs to tell them apart from a real rejection WITHOUT
+ * maintaining a second copy of the description list (#3927). The retry
+ * policy's own swallow branches call this, so there is one list.
+ *
+ * Returns the benign kind, or `null` for everything else — including 429,
+ * 403, and any 400 not on this deliberately narrow list. A new benign
+ * description belongs here, not in a caller.
+ */
+export function classifyBenignTelegram400(
+  errorCode: number | undefined,
+  description: string | undefined,
+): BenignTelegram400Kind | null {
+  if (errorCode !== 400) return null
+  const desc = (description ?? '').toLowerCase()
+  // "message is not modified" / "message was not modified" — Telegram's
+  // no-op-on-equal-text.
+  if (desc.includes('not modified')) return 'not_modified'
+  // "message to edit/delete not found" — the target vanished.
+  if (desc.includes('message to edit not found')) return 'message_not_found'
+  if (desc.includes('message to delete not found')) return 'delete_not_found'
+  return null
+}
+
 export interface RetryObserver {
   /** Fires just before sleeping for a retry. */
   onRetry?(info: { attempt: number; reason: 'flood_wait' | 'network'; delayMs: number }): void
   /** Fires when max retries is reached and the wrapper gives up. */
   onGiveUp?(info: { attempts: number; error: unknown }): void
   /** Fires for each benign error we swallowed (not-modified, not-found). */
-  onBenign?(info: { kind: 'not_modified' | 'message_not_found' | 'delete_not_found' }): void
+  onBenign?(info: { kind: BenignTelegram400Kind }): void
 }
 
 export interface RetryApiCallConfig {
@@ -399,26 +435,15 @@ export function createRetryApiCall(
           continue
         }
 
-        // Swallow "message is not modified" — Telegram's no-op-on-equal-text.
-        if (
-          isGrammyErr &&
-          (err as GrammyError).error_code === 400 &&
-          desc.includes('not modified')
-        ) {
-          observer?.onBenign?.({ kind: 'not_modified' })
-          return undefined as unknown as T
-        }
-
-        // Swallow "message to edit/delete not found" — target vanished.
-        if (
-          isGrammyErr &&
-          (err as GrammyError).error_code === 400 &&
-          (desc.includes('message to edit not found') ||
-            desc.includes('message to delete not found'))
-        ) {
-          observer?.onBenign?.({
-            kind: desc.includes('edit') ? 'message_not_found' : 'delete_not_found',
-          })
+        // Swallow the benign 400s — "message is not modified" (Telegram's
+        // no-op-on-equal-text) and "message to edit/delete not found" (the
+        // target vanished). Classification lives in `classifyBenignTelegram400`
+        // so the tg-post logger reports the same family identically (#3927).
+        const benignKind = isGrammyErr
+          ? classifyBenignTelegram400((err as GrammyError).error_code, desc)
+          : null
+        if (benignKind !== null) {
+          observer?.onBenign?.({ kind: benignKind })
           return undefined as unknown as T
         }
 

--- a/telegram-plugin/shared/bot-runtime.ts
+++ b/telegram-plugin/shared/bot-runtime.ts
@@ -28,10 +28,10 @@ import { execFileSync, spawnSync } from 'child_process'
 import { createHash } from 'crypto'
 import { AsyncLocalStorage } from 'async_hooks'
 import { clearStaleTelegramPollingState } from '../startup-reset.js'
-import { createRetryApiCall } from '../retry-api-call.js'
+import { createRetryApiCall, classifyBenignTelegram400 } from '../retry-api-call.js'
 import { makeFloodWaitRecorder, makeFloodWaitProbe } from '../flood-circuit-breaker.js'
 import { RICH_MESSAGE_MAX_CHARS } from '../format.js'
-import { shouldEmitTgPost } from './gw-trace-gate.js'
+import { shouldEmitTgPost, type TgPostStatus } from './gw-trace-gate.js'
 import { guardAccidentalFormatting } from '../rich-send.js'
 
 // ─── tg-post tag plumbing ─────────────────────────────────────────────────
@@ -81,6 +81,17 @@ function formatTgPostTags(tags: TgPostTags | undefined): string {
 // ─── tg-post observability transformer ────────────────────────────────────
 
 /**
+ * Sanitise a Telegram error description for single-line log output —
+ * collapse whitespace, strip newlines, cap at 80 chars, `-` when absent.
+ * PII-safe: Telegram error descriptions are server-generated and don't
+ * echo the request body.
+ */
+function shortDesc(raw: string | undefined): string {
+  if (!raw) return '-'
+  return raw.replace(/\s+/g, ' ').slice(0, 80).replace(/[\r\n]/g, ' ') || '-'
+}
+
+/**
  * Installs an API transformer on the bot that emits one stderr line per
  * outbound Telegram Bot API POST. This is the single catchment point for
  * correlating user-visible duplicate-message reports (switchroom #656,
@@ -91,7 +102,30 @@ function formatTgPostTags(tags: TgPostTags | undefined): string {
  *
  * Log shape (one line per POST, on both success and failure):
  *
- *   tg-post method=<m> chat=<id> thread=<id|-> parse_mode=<HTML|MarkdownV2|none> bytes=<n> hash=<sha1-12> status=<ok|err> err=<class-or--> code=<http-or--> desc=<short|-->
+ *   tg-post method=<m> chat=<id> thread=<id|-> parse_mode=<HTML|MarkdownV2|none> bytes=<n> hash=<sha1-12> status=<ok|benign|err> err=<class-or--> code=<http-or--> desc=<short|-->
+ *
+ * TRUTHFULNESS (#3927): grammY resolves the transformer chain with the raw
+ * `ApiResponse`, and only converts `{ok:false}` into a thrown `GrammyError`
+ * AFTER the chain returns — verified in the pinned grammy 1.44.0,
+ * `out/core/client.js:95-100`:
+ *
+ *     const data = await this.call(method, payload, signal)   // chain
+ *     if (data.ok) return data.result
+ *     else throw toGrammyError(data, method, payload)          // OUTSIDE
+ *
+ * So EVERY Telegram-level rejection (429 flood-wait, 400, 403) arrives here
+ * as a RESOLVED response, and the `catch` below only ever sees transport
+ * (`HttpError`) failures. Before this was fixed the logger reported every
+ * one of them as `status=ok err=- code=- desc=-` — a rate-limited
+ * `unpinAllChatMessages` logged as SUCCESS 3ms before the retry policy
+ * logged `429 rate limited, waiting 3s`. We therefore inspect the resolved
+ * body and report `status=err err=telegram_<code>` from it.
+ *
+ * The narrow set of benign 400s the retry policy already swallows
+ * ("message is not modified", "message to edit/delete not found" —
+ * classified by the shared `classifyBenignTelegram400`) gets `status=benign`
+ * instead, so promoting real rejections out of `status=ok` doesn't bury
+ * `grep status=err` under high-volume card-repaint no-ops.
  *
  * Body content is never logged — only its length and a 12-char sha1 prefix
  * so we can recognise repeated identical sends without leaking PII. The
@@ -115,16 +149,34 @@ export function installTgPostLogger(bot: Bot): void {
       ? createHash('sha1').update(text).digest('hex').slice(0, 12)
       : '-'
     const tagSuffix = formatTgPostTags(_getTgPostTags())
-    try {
-      const res = await prev(method, payload, signal)
+    const emit = (status: TgPostStatus, errClass: string, code: string, desc: string) => {
       // #3025: suppress zero-signal per-poll heartbeats (getUpdates/getMe
       // status=ok, one line per ~30s long-poll tick) unless the operator
       // set SWITCHROOM_GW_TRACE. Errors and all other methods still log.
-      if (shouldEmitTgPost(method, 'ok')) {
-        process.stderr.write(
-          `tg-post method=${method} chat=${chat} thread=${thread} parse_mode=${parseMode} bytes=${bytes} hash=${hash} status=ok err=- code=- desc=-${tagSuffix}\n`,
+      if (!shouldEmitTgPost(method, status)) return
+      process.stderr.write(
+        `tg-post method=${method} chat=${chat} thread=${thread} parse_mode=${parseMode} bytes=${bytes} hash=${hash} status=${status} err=${errClass} code=${code} desc=${desc}${tagSuffix}\n`,
+      )
+    }
+    try {
+      const res = await prev(method, payload, signal)
+      // A RESOLVED response can still be a Telegram-level rejection — grammy
+      // converts `{ok:false}` to a thrown GrammyError only after this chain
+      // returns (see the docblock). Same defensive shape as the edit fuse's
+      // `runObserved` (edit-flood-fuse.ts).
+      const r = res as unknown as { ok?: boolean; error_code?: number; description?: string }
+      if (r != null && typeof r === 'object' && r.ok === false) {
+        const code = r.error_code
+        const benign = classifyBenignTelegram400(code, r.description)
+        emit(
+          benign !== null ? 'benign' : 'err',
+          `telegram_${code ?? 'unknown'}`,
+          code != null ? String(code) : '-',
+          shortDesc(r.description),
         )
+        return res
       }
+      emit('ok', '-', '-', '-')
       return res
     } catch (err) {
       const errClass = err instanceof GrammyError
@@ -134,15 +186,7 @@ export function installTgPostLogger(bot: Bot): void {
       const rawDesc = err instanceof GrammyError
         ? (err as GrammyError).description
         : (err instanceof Error ? err.message : '')
-      // Sanitise the description for single-line log output — collapse
-      // whitespace, strip newlines, cap at 80 chars. PII-safe: Telegram
-      // error descriptions are server-generated and don't echo body.
-      const desc = rawDesc
-        ? rawDesc.replace(/\s+/g, ' ').slice(0, 80).replace(/[\r\n]/g, ' ') || '-'
-        : '-'
-      process.stderr.write(
-        `tg-post method=${method} chat=${chat} thread=${thread} parse_mode=${parseMode} bytes=${bytes} hash=${hash} status=err err=${errClass} code=${code} desc=${desc}${tagSuffix}\n`,
-      )
+      emit('err', errClass, code, shortDesc(rawDesc))
       throw err
     }
   })

--- a/telegram-plugin/shared/gw-trace-gate.ts
+++ b/telegram-plugin/shared/gw-trace-gate.ts
@@ -58,6 +58,20 @@ export const gwTraceVerbose: boolean = computeGwTraceVerbose(
 const ZERO_SIGNAL_POLL_METHODS = new Set(['getUpdates', 'getMe'])
 
 /**
+ * The status tiers a `tg-post` line can carry.
+ *
+ * `benign` (#3927) is a REJECTED call that is nonetheless a non-event —
+ * the narrow set of 400s the retry policy already swallows ("message is
+ * not modified", "message to edit/delete not found"), classified by
+ * `classifyBenignTelegram400`. It exists so that promoting resolved
+ * `ok:false` responses out of `status=ok` doesn't drown the newly-truthful
+ * `status=err` signal in high-volume card-repaint no-ops: `grep status=err`
+ * stays a list of real failures, and the benign lines are still there,
+ * honestly labelled, for anyone who wants them.
+ */
+export type TgPostStatus = 'ok' | 'benign' | 'err'
+
+/**
  * Decide whether a `tg-post` line should be written.
  *
  * Suppressed (unless `SWITCHROOM_GW_TRACE` is set):
@@ -66,11 +80,13 @@ const ZERO_SIGNAL_POLL_METHODS = new Set(['getUpdates', 'getMe'])
  * Always emitted:
  *   - any `status=err` (real failures — the whole point of the log),
  *   - every other method's `ok` line (sendMessage/editMessageText/... are
- *     genuine outbound observability, #656/#657).
+ *     genuine outbound observability, #656/#657),
+ *   - `status=benign` on any non-poll method — same volume as the
+ *     `status=ok` line it replaces, just no longer mislabelled as success.
  */
 export function shouldEmitTgPost(
   method: string,
-  status: 'ok' | 'err',
+  status: TgPostStatus,
   verbose: boolean = gwTraceVerbose,
 ): boolean {
   if (verbose) return true

--- a/telegram-plugin/tests/tg-post-logger-error-shape.test.ts
+++ b/telegram-plugin/tests/tg-post-logger-error-shape.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Wire-level outcome tests for the `tg-post` logger's error shape (#3927).
+ *
+ * The bug: grammY resolves its transformer chain with the raw `ApiResponse`
+ * and only converts `{ok:false}` into a thrown `GrammyError` AFTER the chain
+ * returns (grammy `out/core/client.js`, `callApi`). Every Telegram-level
+ * rejection — 429 flood-wait, 400, 403 — therefore reached
+ * `installTgPostLogger` as a RESOLVED value and was logged
+ * `status=ok err=- code=- desc=-`. Only transport `HttpError`s ever hit the
+ * `catch`. A rate-limited `unpinAllChatMessages` on clerk logged as SUCCESS
+ * 3ms before the retry policy logged `429 rate limited, waiting 3s`.
+ *
+ * These tests MUST go through a REAL grammy `Bot` with a stubbed transport
+ * (the same reason `rich-markdown-guard-transformer.test.ts` does): the
+ * mock-`api` harnesses sit ABOVE the transformer layer, so `api.config.use`
+ * transformers never run there and a test written through them would be a
+ * false guard. Stubbing `client.fetch` with an `ok:false` envelope is the
+ * only way to reproduce the exact resolved-rejection path.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { Bot } from 'grammy'
+import { installTgPostLogger } from '../shared/bot-runtime.js'
+
+/**
+ * A real Bot whose transport always answers with the given Telegram
+ * envelope. HTTP status stays 200 — a Bot API rejection is a 200 response
+ * carrying `ok:false`, which is precisely why it resolves the chain.
+ */
+function makeBot(envelope: Record<string, unknown>): Bot {
+  const fakeFetch = (async () =>
+    ({
+      ok: true,
+      status: 200,
+      json: async () => envelope,
+    }) as unknown as Response) as unknown as typeof fetch
+
+  const bot = new Bot('123456:TEST_TOKEN', {
+    botInfo: {
+      id: 123456,
+      is_bot: true,
+      first_name: 'Test',
+      username: 'test_bot',
+      can_join_groups: false,
+      can_read_all_group_messages: false,
+      supports_inline_queries: false,
+      can_connect_to_business: false,
+      has_main_web_app: false,
+    },
+    client: { fetch: fakeFetch },
+  })
+  installTgPostLogger(bot)
+  return bot
+}
+
+/** Run one API call against the stub and return every tg-post line emitted. */
+async function tgPostLinesFor(envelope: Record<string, unknown>): Promise<string[]> {
+  const written: string[] = []
+  const spy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation(((chunk: unknown) => {
+      written.push(String(chunk))
+      return true
+    }) as unknown as typeof process.stderr.write)
+  try {
+    const bot = makeBot(envelope)
+    // grammy converts the ok:false envelope into a thrown GrammyError once
+    // the transformer chain has returned — expected, and not what we assert.
+    await bot.api.sendMessage(4242, 'hello').catch(() => undefined)
+  } finally {
+    spy.mockRestore()
+  }
+  return written.filter(l => l.startsWith('tg-post '))
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('tg-post logger — resolved ok:false responses (#3927)', () => {
+  it('logs a 429 flood-wait as status=err code=429 (FAILS before the fix: logged status=ok)', async () => {
+    const lines = await tgPostLinesFor({
+      ok: false,
+      error_code: 429,
+      description: 'Too Many Requests: retry after 3',
+      parameters: { retry_after: 3 },
+    })
+
+    expect(lines).toHaveLength(1)
+    const line = lines[0]
+    expect(line).toContain('status=err')
+    expect(line).toContain('code=429')
+    expect(line).toContain('err=telegram_429')
+    expect(line).toContain('desc=Too Many Requests: retry after 3')
+    // The precise regression: it must NOT claim success.
+    expect(line).not.toContain('status=ok')
+  })
+
+  it('logs a non-benign 400 as status=err carrying the rejection reason', async () => {
+    const lines = await tgPostLinesFor({
+      ok: false,
+      error_code: 400,
+      description: "Bad Request: can't parse entities: unsupported start tag",
+    })
+
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain('status=err')
+    expect(lines[0]).toContain('code=400')
+    expect(lines[0]).toContain("desc=Bad Request: can't parse entities")
+  })
+
+  it('logs a 403 as status=err', async () => {
+    const lines = await tgPostLinesFor({
+      ok: false,
+      error_code: 403,
+      description: 'Forbidden: bot was blocked by the user',
+    })
+
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain('status=err')
+    expect(lines[0]).toContain('code=403')
+  })
+})
+
+describe('tg-post logger — benign 400s do not become error noise (#3927)', () => {
+  // Promoting every ok:false to status=err would flood the log with the
+  // high-volume no-ops the retry policy already swallows, burying the signal
+  // this change exists to create. They get their own `benign` tier instead:
+  // still logged (same volume as the status=ok line they replace), never
+  // matched by `grep status=err`.
+  const benign: Array<[string, string]> = [
+    ['not modified', 'Bad Request: message is not modified'],
+    ['edit target gone', 'Bad Request: message to edit not found'],
+    ['delete target gone', 'Bad Request: message to delete not found'],
+  ]
+
+  for (const [label, description] of benign) {
+    it(`logs "${label}" as status=benign, never status=err`, async () => {
+      const lines = await tgPostLinesFor({ ok: false, error_code: 400, description })
+
+      expect(lines).toHaveLength(1)
+      expect(lines[0]).toContain('status=benign')
+      expect(lines[0]).not.toContain('status=err')
+      // Still honest about what happened — the reason is on the line.
+      expect(lines[0]).toContain('code=400')
+      expect(lines[0]).toContain('desc=Bad Request: message')
+    })
+  }
+})
+
+describe('tg-post logger — success is unchanged', () => {
+  it('still logs a genuine ok:true response as status=ok with empty error fields', async () => {
+    const lines = await tgPostLinesFor({
+      ok: true,
+      result: { message_id: 7, date: 0, chat: { id: 4242, type: 'private' } },
+    })
+
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain('status=ok')
+    expect(lines[0]).toContain('err=- code=- desc=-')
+  })
+})


### PR DESCRIPTION
## Summary

`installTgPostLogger` logged **every Telegram-level rejection as a success**. grammY resolves its API transformer chain with the raw `ApiResponse` and only converts `{ok:false}` into a thrown `GrammyError` *after* the chain returns — pinned grammy 1.44.0, `out/core/client.js` `callApi`:

```js
const data = await this.call(method, payload, signal);   // ← transformer chain
if (data.ok) return data.result;
else throw toGrammyError(data, method, payload);          // ← OUTSIDE the chain
```

So a 429 / 400 / 403 arrived at the transformer as a resolved `{ok:false, error_code, description}` and fell into the success branch: `status=ok err=- code=- desc=-`. Only transport-level `HttpError`s ever produced `status=err`.

Wire proof from a live gateway log — same call, 3 ms apart:

```
[00:07:44.883Z] tg-post method=unpinAllChatMessages chat=… status=ok err=- code=- desc=-
[00:07:44.886Z] telegram gateway: 429 rate limited, waiting 3s
```

The fix inspects the resolved body before logging (`telegram-plugin/shared/bot-runtime.ts`), using the same defensive `ok:false` idiom already in `edit-flood-fuse.ts:1201-1206`'s `runObserved`. The `catch` block for transport errors is unchanged, and the transformer still returns/rethrows exactly as before.

## Why

This masked real failures across the **entire** Telegram surface — every send, edit, delete, pin and unpin. It is currently hiding a fleet-wide stale-pin bug, and it is the prerequisite for that follow-up work: you cannot diagnose a pin that didn't stick when the log says the unpin succeeded.

Job spec: `reference/jobs/fleet-stays-healthy.md` — "the fleet detects, ranks and tracks its own recurring failures … the operator never has to hand-audit turns to find what is quietly breaking." A liveness log that reports failure as success is the exact failure mode that spec exists to prevent.

## Guarantee delta

**Added:** a `tg-post` line's `status` field is now *truthful* for Telegram-level rejections. `grep 'status=err'` on a gateway log is, for the first time, a list of calls that actually failed — including 429 flood-waits, which are the highest-value signal here and previously invisible in this log entirely.

**Not changed:** no send/edit/retry/pin behaviour. The transformer remains pure observability — same return value, same rethrow, no swallowing. Line *volume* is also unchanged: an `ok:false` produced exactly one line before and produces exactly one line now, only correctly labelled.

**Downstream consequence, called out deliberately:** `src/fleet-health/detect.ts:136` matches `/tg-post method=sendRichMessage[^\n]*status=err/` and `gw_hits["reply-delivery-failure"] > 0` escalates. That detector has therefore **never fired on a Telegram-level reply rejection** — it could only ever see transport errors. After this PR it will. That is the intended repair, but note the logger records one line per POST *attempt*, so a 429 that `robustApiCall` retries and then delivers successfully will now also produce a `status=err` line and can escalate. Filed as a follow-up to decide whether that detector should require a terminal failure rather than any attempt (issue linked below).

## The noise question — why a `benign` tier and not suppression

Promoting every `ok:false` to `status=err` would flood the log with the high-volume-but-harmless 400s the retry policy already swallows (`message is not modified`, `message to edit not found`, `message to delete not found`) and bury the signal this PR exists to create.

Two options were on the table: suppress them via `shouldEmitTgPost`, or give them their own status tier. **Tier, because:**

1. **It preserves observability instead of trading one blind spot for another.** These lines are already emitted today (as `status=ok`). Suppressing them would *remove* existing coverage — the same class of mistake as the bug being fixed, just quieter.
2. **Volume is identical to today**, so there is no noise regression to trade off against. `grep status=err` is clean, `grep status=benign` shows the no-ops, both are honest.
3. `shouldEmitTgPost` already has a meaning — "is this line zero-signal poll noise?" — keyed on *method*, not on outcome. Overloading it with an outcome-based benign list would have put two unrelated policies in one predicate.

**One list, not two.** Rather than inventing a second copy of the benign descriptions, `classifyBenignTelegram400` is extracted into `telegram-plugin/retry-api-call.ts` (which already owned the canonical set — see its contract table at the top of the file) and the policy's *own* two swallow branches now call it. The logger and the retry policy classify identically by construction, and a future benign description has exactly one place to go.

## Test plan

New `telegram-plugin/tests/tg-post-logger-error-shape.test.ts` (7 cases). These drive a **real grammy `Bot` with a stubbed `client.fetch`** returning an `ok:false` envelope over HTTP 200 — the same reason `rich-markdown-guard-transformer.test.ts` does it that way: the mock-`api` harnesses in `tests/bot-api.harness.ts` sit *above* the transformer layer, so `api.config.use` transformers never run there and a test written through them would be a false guard.

**Confirmed failing before the fix.** The exact new file, copied onto a pristine `origin/main` worktree:

```
Test Files  1 failed (1)
     Tests  6 failed | 1 passed (7)

AssertionError: expected 'tg-post … status=ok err=- code=- desc=-' to contain 'status=err'
```

The one pass is the `ok:true` control case, which pins that success logging is unchanged. On this branch: **7 passed**.

Coverage:
- 429 flood-wait → `status=err code=429 err=telegram_429`, and explicitly *not* `status=ok`
- non-benign 400 (`can't parse entities`) → `status=err code=400` with the reason
- 403 (`bot was blocked by the user`) → `status=err code=403`
- all three benign 400s → `status=benign`, never `status=err`, reason still on the line
- `ok:true` → `status=ok err=- code=- desc=-`, byte-identical to before

Also run scoped, all green: `retry-api-call.test.ts` (55), `edit-flood-fuse.test.ts` (15), `flood-429-ledger.test.ts` (21), `gw-trace-gate.test.ts` (12), `bot-runtime.test.ts` (26), `rich-markdown-guard-transformer.test.ts` (6). Full `npm run lint` clean (tsc + all 21 guards).

## Risk

Low. The transformer's control flow is unchanged (same return, same rethrow); only the emitted string differs, and only for calls that were already failing. The one refactor outside the logger — routing the retry policy's two swallow branches through the shared classifier — is behaviour-preserving except that description matching is now case-insensitive, a strict widening over descriptions Telegram does not vary the case of; `retry-api-call.test.ts` passes unchanged. The real-world blast radius is the fleet-health detector described under Guarantee delta.

Ships alone and first: it unblocks the stale-pin investigation and two further follow-ups that all depend on being able to see which Telegram calls actually failed.
