### PR TITLE
fix(docs): correct memory CLI + observation-scope docs, pin template skill refs

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -141,6 +141,10 @@ switchroom workspace status <agent>               # git status on the workspace
 switchroom debug turn <agent>                     # Dump the exact prompt layering from the last turn
 switchroom memory setup|search|stats|reflect      # Hindsight memory
 switchroom memory repair --all [--dry-run]        # Rebuild per-bank vector index coverage
+switchroom memory recall-log [agent] [-n <N>]     # Tail the per-turn auto-recall log
+switchroom memory demote <agent> <memory-id>      # Drop one memory out of auto-recall
+switchroom memory profile add|list <bank> ...     # Author + inspect operator profile banks
+switchroom memory docker-compose                  # Print a Hindsight compose snippet
 ```
 
 `memory repair` is the fix for a bank whose recall silently under-returns —
@@ -148,6 +152,19 @@ one that arrived already populated (restore, cross-version upgrade,
 vector-extension switch) and so never got its per-`(bank, fact_type)` vector
 indexes. Idempotent, `CREATE INDEX CONCURRENTLY`, safe on a live fleet;
 requires hindsight ≥ 0.8.5. See `docs/operators/hindsight-memory.md`.
+
+`memory profile` is the authoring path for the shared / per-user profile
+banks you point `memory.recall.additional_banks` at: `add` writes an
+operator-authored fact (creating the bank on first write), `list` shows what
+is in one. See
+[configuration.md § Shared / profile recall banks](configuration.md#shared--profile-recall-banks--memoryrecalladditional_banks).
+
+`memory recall-log` tails what auto-recall actually injected per turn, and
+`memory demote` tags a single memory out of auto-recall while leaving it
+queryable via `recall` / `reflect`. See
+[configuration.md § Inspecting auto-recall in production](configuration.md#inspecting-auto-recall-in-production--switchroom-memory-recall-log)
+and
+[§ Demoting individual memories from auto-recall](configuration.md#demoting-individual-memories-from-auto-recall).
 
 
 The progress-card driver also writes a per-agent `card-events.jsonl`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -542,7 +542,7 @@ agents:
 
 ### Pooling observations across agents — `memory.observation_scopes`
 
-Hindsight stamps every retained row with an **observation scope**, which decides where consolidation files the observations it derives from that row. The engine default is a scope **per tag**. Since switchroom tags retains per session, several agents writing into one shared bank end up in parallel per-tag silos: each agent's observations consolidate on their own and never merge, so the shared bank never builds a shared picture.
+Hindsight stamps every retained row with an **observation scope**, which decides where consolidation files the observations it derives from that row. The engine default is **`combined`**: one consolidation pass using all the tags on the retain together, producing an observation tagged with that full set. Switchroom stamps exactly one tag per retain (`retainTags: ["{session_id}"]`), so that single pass is scoped to a single session. Because a session id never repeats, each session creates a fresh observation rather than growing an existing one. Several agents writing into one shared bank therefore end up in parallel per-session silos: each agent's observations consolidate on their own and never merge, so the shared bank never builds a shared picture.
 
 Set `memory.observation_scopes: shared` to send an agent's retains into **one global untagged scope** instead:
 

--- a/tests/profile-template-skill-references.test.ts
+++ b/tests/profile-template-skill-references.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Guard: every skill a PROFILE TEMPLATE names must actually be runnable by the
+ * agent that renders it (switchroom #3929).
+ *
+ * `profiles/**\/*.hbs` renders into each agent's `CLAUDE.md` / `start.sh`, so a
+ * skill named there is an instruction the agent will act on autonomously. For
+ * that instruction to be executable, two things must hold:
+ *
+ *   1. The skill SHIPS — `skills/<name>/SKILL.md` exists in the package
+ *      (`package.json` "files" includes `skills`, and `switchroom update`
+ *      syncs that payload into `~/.switchroom/skills/_bundled/`).
+ *   2. The skill is INSTALLED for every agent — it is a declared builtin
+ *      default (`getBuiltinDefaultSkillEntries()`), which is what symlinks it
+ *      into `<agent>/.claude/skills/`. A profile template renders for every
+ *      agent using that profile, so naming a skill that is only available
+ *      on-demand or foreman-only leaves most agents with a dead instruction.
+ *
+ * A reference that satisfies neither is a "ghost skill": referenced everywhere,
+ * runnable nowhere. The agent then either fails to find it or improvises, and
+ * both are worse than the guidance naming a path that exists.
+ *
+ * The sibling packaging guard in `src/agents/reconcile-default-skills.test.ts`
+ * pins the other direction (declared defaults ⊆ shipped `skills/`). Neither one
+ * subsumes the other: that one cannot see a template naming a skill that was
+ * never declared, and this one cannot see a declared default that stopped
+ * shipping.
+ */
+
+import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { getBuiltinDefaultSkillEntries } from "../src/memory/scaffold-integration.js";
+
+// tests/<thisfile> → repo root is one level up.
+const repoRoot = join(fileURLToPath(import.meta.url), "..", "..");
+const profilesDir = join(repoRoot, "profiles");
+const skillsDir = join(repoRoot, "skills");
+
+/** Skill directory names are kebab-case with at least two segments. Requiring
+ *  a hyphen is what keeps prose words (`retain`, `reflect`) out of the match. */
+const SKILL_NAME = "[a-z][a-z0-9]*(?:-[a-z0-9]+)+";
+const BACKTICKED = /`([^`\n]+)`/g;
+const SKILLS_PATH = new RegExp(String.raw`(?<![\w/-])skills\/(${SKILL_NAME})(?![\w-])`, "g");
+const IS_SKILL_NAME = new RegExp(`^${SKILL_NAME}$`);
+
+/**
+ * Names the extractor MUST still find. This is the anti-vacuity ratchet: an
+ * extractor that silently stops matching (a reworded sentence that drops the
+ * word "skill", a regex tightened too far) would otherwise pass on an empty
+ * set and this whole guard would go quiet without anyone noticing.
+ *
+ * Removing an entry is a deliberate, reviewable edit — do it in the same PR
+ * that removes the reference from the template.
+ */
+const EXPECTED_TEMPLATE_SKILL_REFERENCES = [
+  "mental-model-curator",
+  "switchroom-runtime",
+] as const;
+
+interface SkillReference {
+  name: string;
+  where: string;
+}
+
+function handlebarsTemplates(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...handlebarsTemplates(p));
+    else if (entry.name.endsWith(".hbs")) out.push(p);
+  }
+  return out.sort();
+}
+
+/**
+ * Collect skill references from one template. Two deterministic shapes, both
+ * of which the current templates use:
+ *
+ *   - a backticked kebab-case token on a line that also says "skill"
+ *     (`(or run the \`mental-model-curator\` skill)`), and
+ *   - a `skills/<name>` path (`skills/switchroom-runtime/SKILL.md`), which is
+ *     unambiguous on its own and needs no nearby keyword.
+ */
+function extractSkillReferences(file: string, body: string): SkillReference[] {
+  const refs: SkillReference[] = [];
+  body.split("\n").forEach((line, idx) => {
+    const where = `${file}:${idx + 1}`;
+    if (/skill/i.test(line)) {
+      for (const m of line.matchAll(BACKTICKED)) {
+        const token = m[1].trim();
+        if (IS_SKILL_NAME.test(token)) refs.push({ name: token, where });
+      }
+    }
+    for (const m of line.matchAll(SKILLS_PATH)) {
+      refs.push({ name: m[1], where });
+    }
+  });
+  return refs;
+}
+
+function collectAllReferences(): SkillReference[] {
+  const templates = handlebarsTemplates(profilesDir);
+  // Sanity: if profiles/ ever stops yielding templates, every assertion below
+  // becomes vacuous.
+  expect(templates.length).toBeGreaterThan(0);
+  return templates.flatMap((file) =>
+    extractSkillReferences(file.slice(repoRoot.length + 1), readFileSync(file, "utf8")),
+  );
+}
+
+describe("profile templates only name skills agents can actually run", () => {
+  it("finds the known skill references (extractor has not gone silent)", () => {
+    const found = new Set(collectAllReferences().map((r) => r.name));
+    for (const name of EXPECTED_TEMPLATE_SKILL_REFERENCES) {
+      expect(
+        found.has(name),
+        `profiles/ no longer yields a detectable reference to the "${name}" skill. ` +
+          `Either the reference was removed (drop it from ` +
+          `EXPECTED_TEMPLATE_SKILL_REFERENCES in the same PR) or it was reworded ` +
+          `into a shape the extractor cannot see (restore a \`${name}\` backtick on ` +
+          `a line mentioning "skill", or a skills/${name} path) — otherwise this ` +
+          `guard silently stops covering it.`,
+      ).toBe(true);
+    }
+  });
+
+  it("every skill named in profiles/**/*.hbs ships in the package skills/ dir", () => {
+    // Sanity: skills/ must exist, or the check is vacuous.
+    expect(existsSync(skillsDir)).toBe(true);
+
+    const unshipped = collectAllReferences().filter(
+      (r) => !existsSync(join(skillsDir, r.name, "SKILL.md")),
+    );
+    expect(
+      unshipped.map((r) => `${r.name} (${r.where})`),
+      "profile template(s) name a skill with no skills/<name>/SKILL.md. Ship the " +
+        "skill or stop naming it — an agent told to run a skill that does not " +
+        "exist either fails to find it or improvises.",
+    ).toEqual([]);
+  });
+
+  it("every skill named in profiles/**/*.hbs is a builtin default (so it is installed)", () => {
+    const defaults = new Set(getBuiltinDefaultSkillEntries().map((e) => e.key));
+    // Sanity: the defaults list must be non-empty, or the check is vacuous.
+    expect(defaults.size).toBeGreaterThan(0);
+
+    const notInstalled = collectAllReferences().filter((r) => !defaults.has(r.name));
+    expect(
+      notInstalled.map((r) => `${r.name} (${r.where})`),
+      "profile template(s) name a skill that is not in " +
+        "getBuiltinDefaultSkillEntries(), so it is never symlinked into an " +
+        "agent's .claude/skills/. Add it to the builtin defaults or stop naming " +
+        "it in a template that renders for every agent.",
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Three memory-guidance defects raised in #3929. Two are real doc errors and are
fixed here. The **headline defect is a misdiagnosis**, and I did not apply
either fix the issue proposed — details below, because the difference matters.

## Why defect 1 got a different fix than either option in the issue

The issue reports that `profiles/default/CLAUDE.md.hbs:78-79` names a
`mental-model-curator` skill that "does not exist in any tier", and offers
(a) author the skill or (b) delete the two mentions.

**Neither is correct — the skill already exists and already ships:**

| Claim | Reality at `origin/main` |
|---|---|
| Skill does not exist | `skills/mental-model-curator/SKILL.md` — shipped by #2883, last touched by #3529 |
| Not installed for agents | Declared builtin default: `src/memory/scaffold-integration.ts:411` (`switchroomCore`) |
| Not packaged | `package.json` `files` includes `skills`; `switchroom update` syncs it (`src/cli/update.ts:811-870`) |
| Reference is dead | Pinned live by `src/agents/reconcile-default-skills.test.ts:643,662` |

Option (a) is a no-op. Option (b) would have been an **active regression**: it
deletes correct guidance pointing at a real, default-installed skill, and it
removes the only documented remedy for the `MAX_DIRECTIVES=30` truncation
failure mode. `switchroom doctor` names that same remedy in its own `fix:`
string (`src/cli/doctor-memory.ts:105`), and `docs/operators/hindsight-memory.md:496`
plus `reference/rfcs/hindsight-synthesis-layers.md:381` document it too — so
(b) would have left four surfaces pointing at a skill the template no longer
mentions. **The template is unchanged.**

### What the reporter actually observed

The symptom is real, it is just not a repo defect. The reporting host's pool
(`~/.switchroom/skills/_bundled/`, a symlink into `~/.switchroom-config/skills/`)
last synced **2026-07-05**. `mental-model-curator` landed **2026-07-06** and
`dev-protocol` **2026-07-11**, so both are genuinely absent *there* — and the
pool has no `.switchroom-manifest.json`, meaning the manifest-owned sync from
#3487 has never completed on it. That is a stale deployment needing
`switchroom update`, not a source change. Filed as #3935.

### The durable fix instead

`tests/profile-template-skill-references.test.ts` closes the class rather than
today's instance. Every skill named in `profiles/**/*.hbs` must:

1. **ship** — `skills/<name>/SKILL.md` exists in the package, and
2. **be installed** — be in `getBuiltinDefaultSkillEntries()`, which is what
   symlinks it into `<agent>/.claude/skills/`. A profile template renders for
   every agent using that profile, so naming an on-demand or foreman-only skill
   leaves most agents with an unrunnable instruction.

This complements the existing packaging guard, which pins the *other* direction
(declared defaults ⊆ shipped `skills/`) and structurally cannot see a template
naming a skill that was never declared.

Extraction is deterministic (backticked kebab token on a line saying "skill";
`skills/<name>` paths) and finds exactly `mental-model-curator` and
`switchroom-runtime` with zero false positives. A baseline pin makes a silently
degrading extractor fail loudly instead of passing on an empty set.

## Defect 2 — `docs/cli-reference.md` listed 5 of 9 `memory` subcommands

Verified against `src/cli/memory.ts`: `search`:348, `stats`:386, `reflect`:456,
`setup`:493, `docker-compose`:965, `repair`:998, `recall-log`:1119,
`demote`:1178, `profile`:1292 (`add`:1298, `list`:1372). Adds the four missing.

`memory profile` matters most: `docs/configuration.md:362-367` already
documents it as *the* authoring path for the profile banks behind
`memory.recall.additional_banks`, so its absence from the CLI reference was a
real discoverability gap. Both new cross-reference anchors were derived with
github-slugger's algorithm and validated by reproducing two known-good anchors
already in the repo (`configuration.md:283`, `cli-reference.md:125`).

## Defect 3 — `docs/configuration.md:545` stated the wrong engine default

It said `per_tag`. The shipped engine says `combined`:

- Running image: `/app/api/hindsight_api/engine/retain/types.py:28-31` —
  `"per_tag" runs one pass per individual tag; "combined" (default) runs a
  single pass with all tags`
- Vendor docs (the spec, per CLAUDE.md's authority order):
  `hindsight.vectorize.io/developer/api/retain` — "**combined (default)** — One
  consolidation pass using all tags together."

Note the cite in the issue (`vendor/hindsight-memory/.../engine/retain/types.py`)
does not exist — `vendor/hindsight-memory/` is the *plugin* snapshot, not the
engine. The engine is only in the image, hence the two sources above.

The paragraph's **conclusion** was right and its **mechanism** was wrong, so
the rewrite keeps the former and fixes the latter: switchroom stamps one tag
per retain (`retainTags: ["{session_id}"]`,
`vendor/hindsight-memory/settings.json:27`), so the single combined pass is
scoped to one session, and because a session id never repeats each session
creates a fresh observation. Hence the per-session silos in a shared bank. This
now agrees with the already-correct text at `docs/configuration.md:578`, which
described the one-tag reality all along.

## Test plan

- New guard **mutation-tested against all three failure modes it claims to
  catch**, each failing in the right test with an actionable message:
  - `skills/mental-model-curator/` removed → ships-check fails
  - removed from `getBuiltinDefaultSkillEntries()` → installed-check fails
  - reference reworded so the extractor misses it → anti-vacuity check fails
- `vitest run tests/profile-template-skill-references.test.ts src/agents/reconcile-default-skills.test.ts`
  → 35 passed
- `npm run lint` → fully green (all 21 guards)

## Risk

Low. Two docs paragraphs and one new test; no runtime code, no template change.
The new guard is satisfied by `main` as-is, so it cannot red an unrelated PR
unless that PR genuinely introduces an unrunnable template skill reference.

## Verdict rule

Job spec: [`reference/jobs/remember-across-sessions.md`](reference/jobs/remember-across-sessions.md).
Memory-hygiene guidance is the part agents act on **autonomously**; when it
names a path that does not resolve the agent improvises, and the recall this
job promises degrades quietly. Advances **standing-team**; crosses no invariant.

## Follow-ups filed

- #3935 — stale `_bundled` pool on the reporting host (the real cause of the
  observed symptom; ops, not source)
- #3936 — `src/config/schema.ts:358` describes `shared` as replacing "a scope
  per tag", which is only accurate because switchroom sends one tag; imprecise
  in the general case. Out of scope here (agent-facing description string).

Fixes #3929
