### PR TITLE
fix(durability): fsync the crash-recovery state so it survives a power cut

### DIFF
--- a/src/agents/handoff-summarizer.ts
+++ b/src/agents/handoff-summarizer.ts
@@ -35,6 +35,7 @@
 
 import { readFileSync, writeFileSync, renameSync, mkdirSync, existsSync, statSync, readdirSync } from "node:fs";
 import { join } from "node:path";
+import { fsyncPathSync } from "../util/atomic.js";
 import {
   OBSERVATION_SCOPES_ENV,
   observationScopesHint,
@@ -238,8 +239,24 @@ export function writeSidecarsAtomic(
   const topicTmp = topicPath + ".tmp";
   writeFileSync(handoffTmp, briefing, "utf-8");
   writeFileSync(topicTmp, topic, "utf-8");
+  // Atomic ≠ durable. rename(2) guarantees a reader never sees a torn file,
+  // but it does not put the tmp file's BYTES on stable storage — so a host
+  // power cut can leave `.handoff.md` naming an inode that was never written,
+  // and the next boot reorients from an empty or stale briefing. fsync each
+  // tmp file BEFORE publishing it, then fsync the containing DIRECTORY after
+  // both renames so the directory entries themselves survive.
+  fsyncPathSync(handoffTmp);
+  fsyncPathSync(topicTmp);
   renameSync(handoffTmp, handoffPath);
   renameSync(topicTmp, topicPath);
+  // Best-effort: the renames have already landed, so a failure here only
+  // means we can't prove the entries survive a power cut. Never fail the
+  // handoff write over it.
+  try {
+    fsyncPathSync(agentDir);
+  } catch {
+    /* durability barrier only; the sidecars are written either way */
+  }
 }
 
 // ─── Pipeline ─────────────────────────────────────────────────────────────────

--- a/src/util/atomic.test.ts
+++ b/src/util/atomic.test.ts
@@ -24,7 +24,7 @@ vi.mock("node:fs", async () => {
   };
 });
 
-import { atomicWriteFileSync, atomicWriteJsonSync, writeConfigFileSync } from "./atomic.js";
+import { atomicWriteFileSync, atomicWriteJsonSync, fsyncPathSync, writeConfigFileSync } from "./atomic.js";
 
 describe("atomicWriteFileSync", () => {
   let dir: string;
@@ -241,5 +241,38 @@ describe("writeConfigFileSync (#2457 — EBUSY bind-mount fallback)", () => {
 
     fsyncSpy.mockRestore();
     closeSpy.mockRestore();
+  });
+});
+
+describe("fsyncPathSync", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(join(tmpdir(), "fsync-path-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("syncs a regular file without disturbing its contents", () => {
+    const p = join(dir, "spool.jsonl");
+    fs.writeFileSync(p, "line one\n");
+    expect(() => fsyncPathSync(p)).not.toThrow();
+    expect(fs.readFileSync(p, "utf-8")).toBe("line one\n");
+  });
+
+  it("syncs a DIRECTORY — the non-obvious half, and the one a rename needs", () => {
+    // A directory cannot be opened for writing, so a naive fsync helper that
+    // opens O_WRONLY throws EISDIR here and the rename-durability barrier is
+    // silently never taken.
+    fs.writeFileSync(join(dir, "obligations.json"), "{}");
+    expect(() => fsyncPathSync(dir)).not.toThrow();
+  });
+
+  it("throws on a missing path rather than silently skipping the barrier", () => {
+    // A swallowed fsync is exactly the bug this primitive exists to prevent;
+    // callers that want best-effort must wrap it themselves.
+    expect(() => fsyncPathSync(join(dir, "does-not-exist"))).toThrow(/ENOENT/);
   });
 });

--- a/src/util/atomic.ts
+++ b/src/util/atomic.ts
@@ -130,6 +130,45 @@ export function atomicWriteFileSync(
   }
 }
 
+/**
+ * fsync whatever inode lives at `path` — a file OR a directory.
+ *
+ * Two distinct durability jobs need this, and both are real:
+ *
+ *   - **File**: `writeFileSync`/`appendFileSync` return once the bytes are in
+ *     the page cache. They are NOT on stable storage, so a host power cut
+ *     loses them even though every syscall succeeded. fsync is the barrier.
+ *   - **Directory**: `rename(2)` is atomic — a crash leaves either the old or
+ *     the new file, never a torn one — but atomicity is an *ordering*
+ *     guarantee, not a durability one. The new directory entry itself lives
+ *     in the parent directory's own (also cached) metadata, so after a power
+ *     cut the rename can be missing entirely. fsync'ing the parent directory
+ *     is what makes the rename survive.
+ *
+ * Hence the standard tmp+rename durability sequence, which callers must
+ * follow in this order: write tmp → fsync(tmp) → rename(tmp, dest) →
+ * fsync(dirname(dest)). Syncing the directory before the rename, or skipping
+ * the tmp fsync, publishes a name that may point at unwritten data.
+ *
+ * Implementation note: `fsync(2)` on an O_RDONLY fd is valid on Linux (and
+ * macOS) and flushes the inode's dirty pages regardless of the fd's access
+ * mode; a directory can only be opened O_RDONLY, so one code path serves
+ * both. On macOS full device-level durability would additionally need
+ * `F_FULLFSYNC`; the fleet runs Linux containers, where fsync is sufficient.
+ *
+ * Throws on failure (ENOENT, EIO). Callers that treat durability as
+ * best-effort must wrap it — this primitive never swallows an error, because
+ * a silently-skipped fsync is the exact bug it exists to prevent.
+ */
+export function fsyncPathSync(path: string): void {
+  const fd = openSync(path, constants.O_RDONLY);
+  try {
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+
 export function atomicWriteJsonSync(
   destPath: string,
   value: unknown,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -19,6 +19,7 @@ import {
   statSync, renameSync, realpathSync, chmodSync, openSync, closeSync,
   existsSync, unlinkSync, appendFileSync,
 } from 'fs'
+import { fsyncPathSync } from '../../src/util/atomic.js'
 import { homedir } from 'os'
 import { join, sep, basename } from 'path'
 
@@ -2838,6 +2839,7 @@ const obligationStoreFs = {
   writeFileSync: (p: string, d: string) => writeFileSync(p, d),
   renameSync: (a: string, b: string) => renameSync(a, b),
   existsSync: (p: string) => existsSync(p),
+  fsyncFileSync: fsyncPathSync, fsyncDirSync: fsyncPathSync,
 }
 const obligationLedger = new ObligationLedger(OBLIGATION_REPRESENT_MAX, {
   onChange:
@@ -9926,6 +9928,7 @@ if (isGatewayMain) inboundSpool = STATIC
         renameSync: (a, b) => renameSync(a, b),
         existsSync: (p) => existsSync(p),
         statSizeSync: (p) => statSync(p).size,
+        fsyncFileSync: fsyncPathSync, fsyncDirSync: fsyncPathSync,
       },
       // #2789 B: durability degradation must be visible, not silent. When
       // spool appends start failing we're back to in-memory-only — a

--- a/telegram-plugin/gateway/inbound-spool.ts
+++ b/telegram-plugin/gateway/inbound-spool.ts
@@ -41,6 +41,7 @@
  * gateway (mirrors the #1544/#1546/#1549 pure-seam idiom).
  */
 
+import { dirname } from 'node:path'
 import type { InboundMessage } from './ipc-protocol.js'
 
 /** Stable dedup id for an inbound. Real Telegram messages have a
@@ -161,6 +162,17 @@ export interface InboundSpoolFsSeam {
   renameSync: (from: string, to: string) => void
   existsSync: (path: string) => boolean
   statSizeSync: (path: string) => number
+  /** fsync the FILE at `path` — flush its bytes to stable storage.
+   *  `appendFileSync` returning only means the page cache took the write;
+   *  without this a host power cut loses the record even though every
+   *  syscall succeeded. */
+  fsyncFileSync: (path: string) => void
+  /** fsync the DIRECTORY at `path` — makes a completed `renameSync`
+   *  durable. rename(2) is atomic (never a torn file) but that is an
+   *  ordering guarantee, not a durability one: the new directory entry
+   *  lives in the parent's own cached metadata and can vanish in a power
+   *  cut. Call AFTER the rename. */
+  fsyncDirSync: (path: string) => void
 }
 
 export interface InboundSpoolOptions {
@@ -345,6 +357,13 @@ export function createInboundSpool(opts: InboundSpoolOptions): InboundSpool {
   function appendRecord(rec: SpoolRecord): void {
     try {
       fs.appendFileSync(path, JSON.stringify(rec) + '\n')
+      // Durability barrier. The whole point of this file is that the
+      // record survives the process dying, and `appendFileSync` alone
+      // only guarantees the page cache holds it — enough for a SIGKILL,
+      // not for a host power cut. fsync before we report success, so a
+      // failure here is treated as the durability loss it is (latched
+      // `degraded`) rather than a silent downgrade to in-memory.
+      fs.fsyncFileSync(path)
       // #2789 B: a successful append after a failure run means the spool
       // is durable again — un-latch degraded state and surface recovery
       // so the health signal clears.
@@ -435,7 +454,15 @@ export function createInboundSpool(opts: InboundSpoolOptions): InboundSpool {
     const tmp = path + '.compact.tmp'
     try {
       fs.writeFileSync(tmp, lines.length ? lines.join('\n') + '\n' : '')
+      // fsync the tmp file BEFORE publishing it: rename orders the
+      // metadata, it does not put the DATA on the platter. Renaming an
+      // unsynced tmp over the log can leave the spool naming a file whose
+      // contents were never written — worse than not compacting at all.
+      fs.fsyncFileSync(tmp)
       fs.renameSync(tmp, path)
+      // ...then fsync the containing DIRECTORY, which is what makes the
+      // rename itself survive a power cut.
+      fs.fsyncDirSync(dirname(path))
       log(`inbound-spool: compacted path=${path} live=${live.size}\n`)
     } catch (err) {
       // Compaction is opportunistic — a failure keeps the (larger but

--- a/telegram-plugin/gateway/inbound-spool.ts
+++ b/telegram-plugin/gateway/inbound-spool.ts
@@ -460,14 +460,26 @@ export function createInboundSpool(opts: InboundSpoolOptions): InboundSpool {
       // contents were never written — worse than not compacting at all.
       fs.fsyncFileSync(tmp)
       fs.renameSync(tmp, path)
-      // ...then fsync the containing DIRECTORY, which is what makes the
-      // rename itself survive a power cut.
-      fs.fsyncDirSync(dirname(path))
       log(`inbound-spool: compacted path=${path} live=${live.size}\n`)
     } catch (err) {
       // Compaction is opportunistic — a failure keeps the (larger but
       // correct) append-only log; never lose data trying to shrink it.
       log(`inbound-spool: compact FAILED path=${path}: ${(err as Error).message}\n`)
+      return
+    }
+    // ...then fsync the containing DIRECTORY, which is what makes the rename
+    // itself survive a power cut. Separate try: the rename has already
+    // landed, so this failing is a weaker durability claim, NOT a failed
+    // compaction — logging it as one would send an operator hunting a
+    // rewrite that actually worked.
+    try {
+      fs.fsyncDirSync(dirname(path))
+    } catch (err) {
+      log(
+        `inbound-spool: compact directory fsync FAILED path=${path}: ` +
+        `${(err as Error).message} — compacted log written but the rename ` +
+        `may not survive a power cut\n`,
+      )
     }
   }
 

--- a/telegram-plugin/gateway/obligation-store.ts
+++ b/telegram-plugin/gateway/obligation-store.ts
@@ -25,6 +25,7 @@
  * unbounded. PURE w.r.t. the injected fs seam ⇒ unit-testable.
  */
 
+import { dirname } from 'node:path'
 import type { Obligation } from './obligation-ledger.js'
 
 export interface ObligationStoreFsSeam {
@@ -34,6 +35,14 @@ export interface ObligationStoreFsSeam {
    *  the snapshot. */
   renameSync: (from: string, to: string) => void
   existsSync: (path: string) => boolean
+  /** fsync the FILE at `path`. Atomicity ≠ durability: rename orders the
+   *  metadata, it does not put the tmp file's DATA on stable storage. Call
+   *  on the tmp file BEFORE the rename. */
+  fsyncFileSync: (path: string) => void
+  /** fsync the DIRECTORY at `path`, AFTER the rename — the new directory
+   *  entry lives in the parent's own cached metadata and is otherwise lost
+   *  in a power cut. */
+  fsyncDirSync: (path: string) => void
 }
 
 interface SnapshotEnvelope {
@@ -133,11 +142,30 @@ export function persistObligations(
   const tmp = path + '.tmp'
   try {
     fs.writeFileSync(tmp, JSON.stringify(env))
+    // Order matters: fsync the tmp file's DATA, THEN publish it by rename.
+    // Renaming first would let a power cut leave the snapshot path pointing
+    // at an inode whose bytes never reached the platter — a zero-length or
+    // stale snapshot that reads as "no open obligations", which is exactly
+    // the silent-drop this store exists to prevent.
+    fs.fsyncFileSync(tmp)
     fs.renameSync(tmp, path)
   } catch (err) {
     log(
       `obligation-store: persist FAILED path=${path}: ${(err as Error).message} — ` +
         `durability degraded to in-memory\n`,
+    )
+    return
+  }
+  // The rename landed, so the snapshot is already correct for a process
+  // crash; this last barrier only upgrades it to survive a power cut. Kept
+  // in its own try so a directory-fsync failure isn't mislabelled as a
+  // failed persist — the data IS written, just not provably on the platter.
+  try {
+    fs.fsyncDirSync(dirname(path))
+  } catch (err) {
+    log(
+      `obligation-store: directory fsync FAILED path=${path}: ${(err as Error).message} — ` +
+        `snapshot written but the rename may not survive a power cut\n`,
     )
   }
 }

--- a/telegram-plugin/registry/turns-schema.ts
+++ b/telegram-plugin/registry/turns-schema.ts
@@ -240,7 +240,27 @@ const PHASE4_MIGRATIONS = [
 
 function applySchema(db: SqliteDatabase): void {
   db.exec('PRAGMA journal_mode = WAL')
-  db.exec('PRAGMA synchronous = NORMAL')
+  // FULL, not NORMAL. This registry is the crash-recovery ledger: the turn row
+  // is what tells the boot-time resume protocol that a turn was in flight when
+  // the process died. Under WAL, `synchronous = NORMAL` deliberately does NOT
+  // fsync the WAL on commit — it syncs only at checkpoint — so a container kill
+  // is survived but a HOST POWER CUT can lose the last commits, including the
+  // whole turn row. The interrupted turn then becomes invisible to resume:
+  // silently unrecoverable, which is exactly the case this ledger exists for.
+  //
+  // Cost is bounded and measured, not assumed: on this fleet's ext4/NVMe volume
+  // a FULL commit costs ~0.87ms mean (p99 1.7ms) vs ~0.011ms at NORMAL, i.e. a
+  // ~1150 commits/s ceiling. Steady state is ~330 commits/day, and the hot path
+  // is `bumpSubagentActivity` (subagents-schema.ts) at ~1Hz per running worker
+  // — ~4 commits/s during fan-out, a ~0.35% duty cycle.
+  //
+  // `synchronous` is per-connection and NOT persisted in the DB file (unlike
+  // `journal_mode`), so it binds only connections that set it. The PreToolUse
+  // subagent tracker (`hooks/subagent-tracker-pretool.mjs`) opens this same
+  // registry.db without the pragma and has therefore been running at SQLite's
+  // default FULL on the tool-call hot path since it shipped; the gateway's
+  // NORMAL was the outlier.
+  db.exec('PRAGMA synchronous = FULL')
   // Concurrency: multiple writers contend on this registry (the PreToolUse
   // subagent-tracker hook, the gateway's subagent-watcher backfill, the turns
   // writer) — especially when several sub-agents dispatch at once. Without a

--- a/telegram-plugin/tests/inbound-delivery-machine-dispatch.test.ts
+++ b/telegram-plugin/tests/inbound-delivery-machine-dispatch.test.ts
@@ -245,6 +245,8 @@ describe('dispatchEffects — inbound-routing effects (PR3c wiring)', () => {
       },
       existsSync: (p: string) => files.has(p),
       statSizeSync: (p: string) => Buffer.byteLength(files.get(p) ?? ''),
+      fsyncFileSync: () => {},
+      fsyncDirSync: () => {},
     }
     const spool = createInboundSpool({ path: spoolPath, fs, log: () => {} })
     const buffer = createPendingInboundBuffer({ spool, log: () => {} })

--- a/telegram-plugin/tests/inbound-spool-progress.test.ts
+++ b/telegram-plugin/tests/inbound-spool-progress.test.ts
@@ -60,6 +60,8 @@ function fakeFs(): InboundSpoolFsSeam {
     },
     existsSync: (p) => files.has(p),
     statSizeSync: (p) => Buffer.byteLength(files.get(p) ?? ''),
+    fsyncFileSync: () => {},
+    fsyncDirSync: () => {},
   }
 }
 

--- a/telegram-plugin/tests/inbound-spool.test.ts
+++ b/telegram-plugin/tests/inbound-spool.test.ts
@@ -33,20 +33,33 @@ function msg(over: Partial<InboundMessage> = {}): InboundMessage {
 }
 
 /** In-memory fake fs keyed by path. Models append, full rewrite, and
- *  atomic rename (so the tmp→rename compaction path is exercised). */
-function fakeFs(): InboundSpoolFsSeam & { dump(p?: string): string } {
+ *  atomic rename (so the tmp→rename compaction path is exercised).
+ *  `ops` records the mutating/durability calls in order, so tests can pin
+ *  the fsync ORDERING the crash-durability guarantee depends on. */
+function fakeFs(): InboundSpoolFsSeam & { dump(p?: string): string; ops: string[] } {
   const files = new Map<string, string>()
+  const ops: string[] = []
   return {
-    appendFileSync: (p, d) => files.set(p, (files.get(p) ?? '') + d),
+    appendFileSync: (p, d) => {
+      ops.push(`append:${p}`)
+      files.set(p, (files.get(p) ?? '') + d)
+    },
     readFileSync: (p) => files.get(p) ?? '',
-    writeFileSync: (p, d) => files.set(p, d),
+    writeFileSync: (p, d) => {
+      ops.push(`write:${p}`)
+      files.set(p, d)
+    },
     renameSync: (from, to) => {
+      ops.push(`rename:${from}->${to}`)
       files.set(to, files.get(from) ?? '')
       files.delete(from)
     },
     existsSync: (p) => files.has(p),
     statSizeSync: (p) => Buffer.byteLength(files.get(p) ?? ''),
+    fsyncFileSync: (p) => ops.push(`fsyncFile:${p}`),
+    fsyncDirSync: (p) => ops.push(`fsyncDir:${p}`),
     dump: (p = PATH) => files.get(p) ?? '',
+    ops,
   }
 }
 
@@ -478,6 +491,74 @@ describe('inbound-spool — robustness', () => {
   })
 })
 
+describe('inbound-spool — power-cut durability (fsync)', () => {
+  it('fsyncs the spool file on every appended record', () => {
+    const fs = fakeFs()
+    const s = createInboundSpool({ path: PATH, fs, log: () => {} })
+    s.put('a', msg({ messageId: 1 }))
+    s.ack(msg({ messageId: 1 }))
+    // Both the put record and the ack tombstone are durability-critical:
+    // an un-synced ack replays an already-answered message after a power
+    // cut, an un-synced put loses it entirely.
+    expect(fs.ops).toEqual([
+      `append:${PATH}`,
+      `fsyncFile:${PATH}`,
+      `append:${PATH}`,
+      `fsyncFile:${PATH}`,
+    ])
+  })
+
+  it('compaction fsyncs the tmp file BEFORE the rename and the directory AFTER', () => {
+    const fs = fakeFs()
+    const s = createInboundSpool({ path: PATH, fs, compactAtBytes: 200, log: () => {} })
+    for (let i = 1; i <= 10; i++) s.put('a', msg({ messageId: i, text: 'y'.repeat(50) }))
+    // The bound triggers several compactions across the 10 puts; each one
+    // must follow the same four-step sequence, so pin the last.
+    expect(fs.ops.slice(-4)).toEqual([
+      `write:${PATH}.compact.tmp`,
+      `fsyncFile:${PATH}.compact.tmp`,
+      `rename:${PATH}.compact.tmp->${PATH}`,
+      'fsyncDir:/state/agent/telegram',
+    ])
+  })
+
+  it('an un-acked entry survives a POWER CUT, not just a process kill', () => {
+    // Models the distinction the fsync exists for: `appendFileSync` returning
+    // puts the bytes in the page cache (enough to survive SIGKILL — the
+    // process dies, the kernel still holds them), but only fsync puts them on
+    // stable storage. `powerCut()` discards everything not fsync'd, which is
+    // what a host power loss actually does.
+    const cache = new Map<string, string>()
+    const platter = new Map<string, string>()
+    const fs: InboundSpoolFsSeam = {
+      appendFileSync: (p, d) => cache.set(p, (cache.get(p) ?? '') + d),
+      readFileSync: (p) => cache.get(p) ?? '',
+      writeFileSync: (p, d) => cache.set(p, d),
+      renameSync: (from, to) => {
+        cache.set(to, cache.get(from) ?? '')
+        cache.delete(from)
+      },
+      existsSync: (p) => cache.has(p),
+      statSizeSync: (p) => Buffer.byteLength(cache.get(p) ?? ''),
+      fsyncFileSync: (p) => {
+        if (cache.has(p)) platter.set(p, cache.get(p)!)
+      },
+      fsyncDirSync: () => {},
+    }
+    const powerCut = (): void => {
+      cache.clear()
+      for (const [p, d] of platter) cache.set(p, d)
+    }
+
+    const s = createInboundSpool({ path: PATH, fs, log: () => {} })
+    s.put('a', msg({ messageId: 7, text: 'answer me' }))
+    powerCut()
+
+    const rebooted = createInboundSpool({ path: PATH, fs, log: () => {} })
+    expect(rebooted.liveEntries().map((e) => e.msg.messageId)).toEqual([7])
+  })
+})
+
 describe('inbound-spool — #2789 C: multi-message drop notice reports the real count', () => {
   it('passes the true per-chat dropped count to the coalesced notice', () => {
     const fs = fakeFs()
@@ -549,10 +630,14 @@ describe('inbound-spool — #2789 B: spool write failure surfaces a health signa
   // An fs whose appendFileSync can be toggled to fail, modelling a full /
   // unwritable persistent volume. The append swallows the error (delivery
   // must not break) but the degradation must be SURFACED, not silent.
-  function toggleableFs(): InboundSpoolFsSeam & { fail: boolean } {
+  function toggleableFs(): InboundSpoolFsSeam & { fail: boolean; failFsync: boolean } {
     const files = new Map<string, string>()
     const seam = {
       fail: false,
+      // A failing fsync is its own degradation mode: the bytes reached the
+      // page cache but NOT stable storage, so the durable promise is gone
+      // even though appendFileSync returned cleanly.
+      failFsync: false,
       appendFileSync(p: string, d: string) {
         if (seam.fail) throw new Error('ENOSPC: no space left on device')
         files.set(p, (files.get(p) ?? '') + d)
@@ -565,6 +650,10 @@ describe('inbound-spool — #2789 B: spool write failure surfaces a health signa
       },
       existsSync: (p: string) => files.has(p),
       statSizeSync: (p: string) => Buffer.byteLength(files.get(p) ?? ''),
+      fsyncFileSync: (_p: string) => {
+        if (seam.failFsync) throw new Error('EIO: i/o error, fsync')
+      },
+      fsyncDirSync: (_p: string) => {},
     }
     return seam
   }
@@ -586,6 +675,28 @@ describe('inbound-spool — #2789 B: spool write failure surfaces a health signa
     expect(s.appendFailureCount()).toBe(1)
     // Latched: exactly one transition event on entering degraded.
     expect(events).toEqual([{ degraded: true, consecutiveFailures: 1 }])
+  })
+
+  it('a failing fsync degrades too — a cached-but-unsynced append is NOT durable', () => {
+    // The subtle one: appendFileSync succeeds, so the old code would have
+    // reported a healthy spool while the record was one power cut from gone.
+    const fs = toggleableFs()
+    const events: { degraded: boolean }[] = []
+    const logs: string[] = []
+    const s = createInboundSpool({
+      path: PATH,
+      fs,
+      log: (l) => logs.push(l),
+      onDegraded: (info) => events.push({ degraded: info.degraded }),
+    })
+    fs.failFsync = true
+    expect(() => s.put('a', msg({ messageId: 1, ts: 1 }))).not.toThrow()
+    expect(s.isDegraded()).toBe(true)
+    expect(events).toEqual([{ degraded: true }])
+    expect(logs.join('')).toContain('durability degraded')
+    // Live delivery is unaffected — degradation is a durability claim, not a
+    // delivery failure.
+    expect(s.liveCount()).toBe(1)
   })
 
   it('does not re-fire the degraded signal on every failing append (latched)', () => {

--- a/telegram-plugin/tests/inbound-spool.test.ts
+++ b/telegram-plugin/tests/inbound-spool.test.ts
@@ -522,6 +522,24 @@ describe('inbound-spool — power-cut durability (fsync)', () => {
     ])
   })
 
+  it('a failed compaction directory fsync is not reported as a failed compaction', () => {
+    // The rename already landed, so the compacted log IS on disk; only the
+    // power-cut upgrade is missing. Calling it "compact FAILED" would send an
+    // operator hunting a rewrite that actually worked.
+    const fs = fakeFs()
+    const logs: string[] = []
+    fs.fsyncDirSync = () => {
+      throw new Error('EIO: i/o error, fsync dir')
+    }
+    const s = createInboundSpool({ path: PATH, fs, compactAtBytes: 200, log: (l) => logs.push(l) })
+    for (let i = 1; i <= 10; i++) s.put('a', msg({ messageId: i, text: 'y'.repeat(50) }))
+    expect(logs.join('')).toContain('compact directory fsync FAILED')
+    expect(logs.join('')).toContain('compacted path=')
+    // And the compacted log is intact and readable — nothing was rolled back.
+    const s2 = createInboundSpool({ path: PATH, fs, log: () => {} })
+    expect(s2.liveCount()).toBe(10)
+  })
+
   it('an un-acked entry survives a POWER CUT, not just a process kill', () => {
     // Models the distinction the fsync exists for: `appendFileSync` returning
     // puts the bytes in the page cache (enough to survive SIGKILL — the

--- a/telegram-plugin/tests/obligation-determinism.test.ts
+++ b/telegram-plugin/tests/obligation-determinism.test.ts
@@ -64,6 +64,8 @@ function memStore(): { fs: ObligationStoreFsSeam } {
         files.delete(a);
       },
       existsSync: (p) => files.has(p),
+      fsyncFileSync: () => {},
+      fsyncDirSync: () => {},
     },
   };
 }

--- a/telegram-plugin/tests/obligation-store.test.ts
+++ b/telegram-plugin/tests/obligation-store.test.ts
@@ -27,6 +27,12 @@ function memFs(seed: Record<string, string> = {}) {
       files.delete(a);
     },
     existsSync: (p) => files.has(p),
+    fsyncFileSync: (p) => {
+      calls.push(`fsyncFile:${p}`);
+    },
+    fsyncDirSync: (p) => {
+      calls.push(`fsyncDir:${p}`);
+    },
   };
   return { fs, files, calls };
 }
@@ -63,7 +69,12 @@ describe("obligation-store", () => {
   it("persists atomically: writes a sibling .tmp then renames over the path", () => {
     const { fs, calls, files } = memFs();
     persistObligations(PATH, fs, [ob("c:3#1")]);
-    expect(calls).toEqual([`write:${PATH}.tmp`, `rename:${PATH}.tmp->${PATH}`]);
+    expect(calls).toEqual([
+      `write:${PATH}.tmp`,
+      `fsyncFile:${PATH}.tmp`,
+      `rename:${PATH}.tmp->${PATH}`,
+      "fsyncDir:/state/agent/telegram",
+    ]);
     // The tmp is gone (renamed); only the real path remains.
     expect(files.has(PATH)).toBe(true);
     expect(files.has(`${PATH}.tmp`)).toBe(false);
@@ -170,8 +181,63 @@ describe("obligation-store", () => {
       },
       renameSync: () => {},
       existsSync: () => false,
+      fsyncFileSync: () => {},
+      fsyncDirSync: () => {},
     };
     expect(() => persistObligations(PATH, fs, [ob("c:3#1")], (l) => logs.push(l))).not.toThrow();
     expect(logs.join("")).toContain("persist FAILED");
+  });
+});
+
+describe("obligation-store — power-cut durability (fsync ordering)", () => {
+  it("fsyncs the tmp file BEFORE the rename and the directory AFTER it", () => {
+    const { fs, calls } = memFs();
+    persistObligations(PATH, fs, [ob("c:3#1")]);
+    // The exact sequence IS the guarantee: syncing the directory before the
+    // rename, or renaming before the tmp file's data is on stable storage,
+    // publishes a name that can point at bytes that were never written.
+    expect(calls).toEqual([
+      `write:${PATH}.tmp`,
+      `fsyncFile:${PATH}.tmp`,
+      `rename:${PATH}.tmp->${PATH}`,
+      "fsyncDir:/state/agent/telegram",
+    ]);
+  });
+
+  it("a failed tmp fsync aborts BEFORE the rename — the previous snapshot is left intact", () => {
+    // Publishing an unsynced tmp over a good snapshot would be strictly worse
+    // than not writing at all, so the rename must not happen.
+    const prior = JSON.stringify({ v: 1, obligations: [ob("c:3#1")] });
+    const { fs, files } = memFs({ [PATH]: prior });
+    const logs: string[] = [];
+    const failing: ObligationStoreFsSeam = {
+      ...fs,
+      fsyncFileSync: () => {
+        throw new Error("EIO: i/o error, fsync");
+      },
+    };
+    expect(() => persistObligations(PATH, failing, [ob("c:3#2")], (l) => logs.push(l))).not.toThrow();
+    expect(logs.join("")).toContain("persist FAILED");
+    expect(files.get(PATH)).toBe(prior);
+    expect(loadObligations(PATH, fs)[0]!.originTurnId).toBe("c:3#1");
+  });
+
+  it("a failed DIRECTORY fsync keeps the written snapshot and is not reported as a failed persist", () => {
+    // The rename already landed, so the snapshot is correct for a process
+    // crash; only the power-cut upgrade is missing. Mislabelling it
+    // "persist FAILED" would send an operator hunting a write that worked.
+    const { fs, files } = memFs();
+    const logs: string[] = [];
+    const failing: ObligationStoreFsSeam = {
+      ...fs,
+      fsyncDirSync: () => {
+        throw new Error("EIO: i/o error, fsync dir");
+      },
+    };
+    expect(() => persistObligations(PATH, failing, [ob("c:3#1")], (l) => logs.push(l))).not.toThrow();
+    expect(logs.join("")).toContain("directory fsync FAILED");
+    expect(logs.join("")).not.toContain("persist FAILED");
+    expect(files.has(PATH)).toBe(true);
+    expect(loadObligations(PATH, fs)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

Four write sites that persist crash-recovery state are **atomic but not durable**. They all survive a container death — SIGTERM, rollout recreate, OOM, SIGKILL — because the process dies but the kernel still holds the page cache. None of them reliably survives the host losing power, which is precisely the case they exist for.

| Site | Before | After |
|---|---|---|
| `telegram-plugin/registry/turns-schema.ts:242` | WAL + `synchronous = NORMAL` | `synchronous = FULL` |
| `telegram-plugin/gateway/inbound-spool.ts` (append) | `appendFileSync`, no fsync | append → `fsync(file)` |
| `telegram-plugin/gateway/inbound-spool.ts` (compact) | write tmp → rename | write tmp → `fsync(tmp)` → rename → `fsync(dir)` |
| `telegram-plugin/gateway/obligation-store.ts:135` | write tmp → rename | write tmp → `fsync(tmp)` → rename → `fsync(dir)` |
| `src/agents/handoff-summarizer.ts:239` | write tmps → renames | write tmps → `fsync(tmp)` each → renames → `fsync(dir)` |

**No behaviour change.** This is the foundation the resume-path work builds on: later PRs add the logic that reads this state on boot, and that logic is only as trustworthy as the record underneath it.

## Guarantee delta — what now survives a power cut that did not before

Everything below already survived a process/container kill. The change is the **host power cut** column.

- **An interrupted turn stays visible to resume.** Under WAL, `synchronous = NORMAL` deliberately does *not* fsync the WAL on commit — it syncs at checkpoint. A power cut could therefore drop the last commits, including a whole `turns` row. The turn that was in flight would simply never have existed as far as the boot-time resume protocol is concerned: silently unrecoverable, and exactly the case the ledger exists for. Now the commit is on stable storage before it is acknowledged.
- **A spooled inbound is not lost.** `appendFileSync` returning means the page cache took the bytes, not that they are on the platter. The "your message is queued and will be processed" promise now holds across a power cut, not just a restart.
- **A spool compaction cannot publish unwritten data.** `rename(2)` orders the metadata; it does not put the tmp file's DATA on the platter. Renaming an unsynced tmp over the log could leave the spool naming a file whose contents were never written — strictly worse than not compacting.
- **An open obligation is not silently dropped.** Same tmp+rename gap: a snapshot that reads back as "no open obligations" after a power cut loses the answer-obligation entirely.
- **The handoff sidecars are real.** `.handoff.md` / `.handoff-topic` can no longer name an inode that was never written, so a post-power-cut boot doesn't reorient from an empty or stale briefing.
- **A failing fsync is now visible.** The spool's existing `onDegraded` health signal latches on an fsync failure too — previously `appendFileSync` succeeding was reported as a healthy spool while the record was one power cut from gone.

Nothing is removed. No delivery path gains a new failure mode: every new barrier is inside the existing best-effort `try` (spool, obligation store) or explicitly swallowed after the rename has already landed (handoff sidecars, obligation dir-fsync).

## Why FULL is safe on the gateway connection

Measured on this fleet's storage (`/dev/nvme0n1p2`, ext4, non-rotational), `bun:sqlite`, 3000 autocommitted single-row inserts per run, two runs each, warm:

| journal_mode | synchronous | commits/s | mean | p50 | p95 | p99 |
|---|---|---|---|---|---|---|
| WAL | NORMAL | 88,979 | 0.011ms | 0.006ms | 0.011ms | 0.016ms |
| WAL | **FULL** | **1,179** | **0.848ms** | 0.859ms | 0.997ms | 1.668ms |
| WAL | NORMAL | 94,059 | 0.011ms | 0.005ms | 0.009ms | 0.012ms |
| WAL | **FULL** | **1,116** | **0.896ms** | 0.871ms | 1.036ms | 1.697ms |

Against the real write rate:

- **Steady state:** 723 turn rows over 13.84 days on the live `overlord` registry = 52 turns/day, ~330 commits/day. FULL costs ~0.29 **seconds per day** in aggregate.
- **Peak:** the hot path is `bumpSubagentActivity` (`telegram-plugin/registry/subagents-schema.ts:609`) at ~1Hz per running worker, so ~4 commits/s during worker fan-out. Against a ~1150 commits/s ceiling that is a **~0.35% duty cycle**.

Corroborating evidence that FULL is already proven on this exact DB: `PRAGMA synchronous` is **per-connection and not persisted in the DB file** (unlike `journal_mode`). The PreToolUse subagent tracker (`telegram-plugin/hooks/subagent-tracker-pretool.mjs:196`) opens the same `registry.db` setting only `busy_timeout`, so it has been running at SQLite's default `synchronous = FULL` **on the tool-call hot path** since it shipped, with no reported latency issue. The gateway's NORMAL was the outlier, not the norm.

The two remaining `synchronous = NORMAL` lines in `subagents-schema.ts` are `:memory:` test helpers, where durability is meaningless. Left alone deliberately.

## Implementation note — one primitive, two orderings

`fsyncPathSync` (new, `src/util/atomic.ts`) opens `O_RDONLY` and `fsync`s. `fsync(2)` on a read-only fd flushes the inode's dirty pages regardless of access mode, and a directory can *only* be opened `O_RDONLY`, so one primitive serves both jobs. The seams expose it under two names (`fsyncFileSync` / `fsyncDirSync`) because the two calls sit on opposite sides of the rename, and that ordering **is** the guarantee: fsync the tmp file *before* the rename, fsync the containing directory *after* it.

`atomicWriteFileSync` in the same file already fsyncs its tmp file but not the parent directory — same residual gap, different subsystem (vault / auth-broker secrets). Deliberately out of scope here; filed as a follow-up.

## Test plan

- [x] `telegram-plugin/tests/inbound-spool.test.ts` — new `power-cut durability` block: every appended record (put *and* ack tombstone) is fsync'd; compaction pins the exact four-step `write tmp → fsyncFile tmp → rename → fsyncDir` sequence; and a **power-cut model** (an fs where unsynced bytes are discarded, which a SIGKILL model would not do) asserts an un-acked entry is still live after reboot. That last one fails on `main`.
- [x] `telegram-plugin/tests/inbound-spool.test.ts` — a failing fsync degrades the spool: `isDegraded()`, a latched `onDegraded`, and the log all fire even though `appendFileSync` succeeded. Live delivery is unaffected.
- [x] `telegram-plugin/tests/obligation-store.test.ts` — exact call ordering; a failed tmp fsync aborts **before** the rename and leaves the previous snapshot loadable; a failed directory fsync keeps the written snapshot and is *not* mislabelled `persist FAILED`.
- [x] `src/util/atomic.test.ts` — `fsyncPathSync` on a real file, on a real **directory** (the half a naive `O_WRONLY` helper gets wrong with EISDIR), and throwing on a missing path rather than silently skipping the barrier.
- [x] Existing assertions updated for the new sequence, none weakened.
- [x] `bun test` registry suites (191 pass) — the FULL pragma path.
- [x] `npm run lint` clean, including the gateway line ratchet.

Known local env artifact: `tests/handoff-summarizer.test.ts > skips the Hindsight mirror when no URL is configured` fails inside an agent container because `HINDSIGHT_API_URL` is exported into the environment; passes with it unset, and fails identically on `main`. Filed as a follow-up (test hermeticity), unrelated to this diff.

## Risk

Low. Write-path latency only, bounded by the measurement above; the storage-dependent worst case is a rotational or networked volume where an fsync costs ~5-10ms — still ~4% duty cycle at the 4/s peak, and the correctness argument dominates. No API, schema, or wire-format change.

## Job spec

`reference/jobs/survive-reboots-and-real-life.md` — *"Agents come back cleanly after crashes, power loss, context exhaustion, and transient failures. Work resumes."* The word in that outcome doing the work here is **power loss**: the state the resume path reads was previously only crash-durable, not power-durable.
