### PR TITLE
fix(rollout): share ONE scope with `update --check`, and fail a roll that leaves a component behind (#3928)

### DIFF
--- a/src/cli/component-scope.test.ts
+++ b/src/cli/component-scope.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  classifyComponent,
+  gatedOwners,
+  imageRepoName,
+  partitionDrift,
+  remediationFor,
+} from "./component-scope.js";
+import type { ComponentVersion } from "./component-versions.js";
+
+/** Terse ComponentVersion builder — only the fields classification reads. */
+function comp(
+  name: string,
+  imageRef?: string,
+  version = "v0.19.26",
+): ComponentVersion {
+  return imageRef === undefined
+    ? { name, kind: "cli", version }
+    : { name, kind: "container", version, imageRef };
+}
+
+describe("imageRepoName", () => {
+  it("extracts the switchroom repo from tagged, digested and registry-port refs", () => {
+    expect(imageRepoName("ghcr.io/switchroom/switchroom-hostd:v0.19.30")).toBe(
+      "switchroom-hostd",
+    );
+    expect(
+      imageRepoName("ghcr.io/switchroom/switchroom-web@sha256:abc123"),
+    ).toBe("switchroom-web");
+    expect(imageRepoName("registry:5000/switchroom/switchroom-agent:v1.0.0")).toBe(
+      "switchroom-agent",
+    );
+  });
+
+  it("refuses non-switchroom and bare-name images", () => {
+    // `switchroom-hostd-docker-proxy` runs a THIRD-PARTY image under a
+    // switchroom-prefixed container name. Classifying it as a deploy unit
+    // would gate the roll on a component no switchroom command can move.
+    expect(imageRepoName("ghcr.io/tecnativa/docker-socket-proxy:0.3")).toBeNull();
+    expect(imageRepoName("alpine/socat:latest")).toBeNull();
+    expect(imageRepoName("switchroom-uat-runner:local")).toBeNull();
+    expect(imageRepoName(undefined)).toBeNull();
+  });
+});
+
+describe("classifyComponent", () => {
+  it("classifies the hindsight-autoheal sidecar as hostd-owned — the #3928 escapee", () => {
+    // THE regression. The sidecar's container name matches no allowlist
+    // any previous scope list carried, which is precisely how it stayed
+    // on v0.19.26 through a green roll to v0.19.30. Keyed on the IMAGE it
+    // lands on hostd automatically, because it runs the hostd image
+    // (src/cli/hostd.ts:406).
+    expect(
+      classifyComponent(
+        comp(
+          "switchroom-hindsight-autoheal",
+          "ghcr.io/switchroom/switchroom-hostd:v0.19.26",
+        ),
+      ),
+    ).toEqual({ kind: "hostd" });
+  });
+
+  it("maps each deploy unit onto its owning mechanism", () => {
+    expect(
+      classifyComponent(
+        comp("switchroom-web", "ghcr.io/switchroom/switchroom-web:v0.19.26"),
+      ),
+    ).toEqual({ kind: "web" });
+    expect(
+      classifyComponent(
+        comp("switchroom-hostd", "ghcr.io/switchroom/switchroom-hostd:v0.19.26"),
+      ),
+    ).toEqual({ kind: "hostd" });
+    expect(
+      classifyComponent(
+        comp(
+          "switchroom-hindsight",
+          "ghcr.io/switchroom/switchroom-hindsight:v0.19.26",
+        ),
+      ),
+    ).toEqual({ kind: "hindsight" });
+    expect(classifyComponent(comp("cli (host)"))).toEqual({ kind: "cli" });
+  });
+
+  it("carries the AGENT name for per-agent fleet containers", () => {
+    expect(
+      classifyComponent(
+        comp("switchroom-klanker", "ghcr.io/switchroom/switchroom-agent:v0.19.26"),
+      ),
+    ).toEqual({ kind: "fleet", agent: "klanker" });
+  });
+
+  it("classifies fleet singletons as fleet with NO agent name", () => {
+    // vault-broker / kernel / auth-broker / voice ride the agent compose
+    // project and self-heal on the first agent restart (#2170) — they are
+    // gated, but not attributable to any one agent.
+    for (const [name, repo] of [
+      ["switchroom-vault-broker", "switchroom-broker"],
+      ["switchroom-approval-kernel", "switchroom-kernel"],
+      ["switchroom-auth-broker", "switchroom-auth-broker"],
+      ["switchroom-voice-sidecar", "switchroom-voice"],
+    ] as const) {
+      expect(
+        classifyComponent(comp(name, `ghcr.io/switchroom/${repo}:v0.19.26`)),
+      ).toEqual({ kind: "fleet" });
+    }
+  });
+
+  it("defaults an UNKNOWN switchroom image to fleet, so a new component is gated the day it ships", () => {
+    expect(
+      classifyComponent(
+        comp(
+          "switchroom-something-new",
+          "ghcr.io/switchroom/switchroom-something-new:v0.19.26",
+        ),
+      ),
+    ).toEqual({ kind: "fleet" });
+  });
+});
+
+describe("remediationFor", () => {
+  it("names the per-owner command the operator (or an agent) can actually run", () => {
+    expect(remediationFor({ kind: "web" }, "v0.19.30")).toContain(
+      "switchroom webd install --tag v0.19.30",
+    );
+    expect(remediationFor({ kind: "hostd" }, "v0.19.30")).toContain(
+      "switchroom hostd install --tag v0.19.30",
+    );
+    expect(remediationFor({ kind: "hindsight" }, "v0.19.30")).toContain(
+      "switchroom memory setup",
+    );
+    expect(remediationFor({ kind: "cli" }, "v0.19.30")).toContain(
+      "switchroom update",
+    );
+    expect(remediationFor({ kind: "fleet", agent: "klanker" }, "v0.19.30")).toContain(
+      "--agents klanker",
+    );
+  });
+});
+
+describe("gatedOwners", () => {
+  it("gates web / hostd / hindsight exactly when the plan carries their refresh step", () => {
+    const full = gatedOwners(
+      ["apply", "refresh-web", "refresh-hostd", "refresh-hindsight"],
+      false,
+    );
+    expect([...full].sort()).toEqual(["fleet", "hindsight", "hostd", "web"]);
+
+    // `--skip-web` drops all three refresh steps on the host-shell path.
+    const skipped = gatedOwners(["apply", "restart-agent"], false);
+    expect([...skipped].sort()).toEqual(["fleet"]);
+  });
+
+  it("gates hostd on the hostd-driven path even though refresh-hostd is absent", () => {
+    // hostd deliberately does not recreate itself mid-roll (that would
+    // SIGKILL the in-flight child), but it DOES self-bump its compose
+    // project before spawning — so a hostd-project component left behind
+    // (exactly switchroom-hindsight-autoheal in #3928) is a real finding.
+    expect(gatedOwners(["apply", "restart-agent"], true).has("hostd")).toBe(true);
+  });
+
+  it("NEVER gates the host CLI", () => {
+    // No plan step converges `npm i -g switchroom` on the host. Gating it
+    // would fail every hostd-driven roll whenever the operator's host CLI
+    // lagged the tag — the normal state right after a release, and true
+    // on the #3928 host itself.
+    for (const hostd of [false, true]) {
+      expect(
+        gatedOwners(
+          ["apply", "refresh-web", "refresh-hostd", "refresh-hindsight"],
+          hostd,
+        ).has("cli"),
+      ).toBe(false);
+    }
+  });
+});
+
+describe("partitionDrift", () => {
+  const behind: ComponentVersion[] = [
+    comp("switchroom-web", "ghcr.io/switchroom/switchroom-web:v0.19.26"),
+    comp(
+      "switchroom-hindsight-autoheal",
+      "ghcr.io/switchroom/switchroom-hostd:v0.19.26",
+    ),
+    comp("switchroom-klanker", "ghcr.io/switchroom/switchroom-agent:v0.19.26"),
+    comp("switchroom-ghost", "ghcr.io/switchroom/switchroom-agent:v0.19.26"),
+    comp("cli (host)"),
+  ];
+
+  it("gates web + autoheal + the ROLLED agent, and exempts the rest (#3928)", () => {
+    const { gated, exempt } = partitionDrift(behind, {
+      owners: gatedOwners(
+        ["apply", "restart-agent", "refresh-web", "refresh-hostd"],
+        false,
+      ),
+      rolledAgents: new Set(["klanker"]),
+    });
+    expect(gated.map((c) => c.name)).toEqual([
+      "switchroom-web",
+      "switchroom-hindsight-autoheal",
+      "switchroom-klanker",
+    ]);
+    // `switchroom-ghost` was not in this roll's agent set; the host CLI is
+    // never gated. Both are still REPORTED, never silently dropped.
+    expect(exempt.map((c) => c.name)).toEqual(["switchroom-ghost", "cli (host)"]);
+  });
+
+  it("exempts web when the operator explicitly asked to skip it", () => {
+    const { gated, exempt } = partitionDrift(behind, {
+      owners: gatedOwners(["apply", "restart-agent"], false),
+      rolledAgents: new Set(["klanker", "ghost"]),
+    });
+    expect(gated.map((c) => c.name)).toEqual([
+      "switchroom-klanker",
+      "switchroom-ghost",
+    ]);
+    expect(exempt.map((c) => c.name)).toEqual([
+      "switchroom-web",
+      "switchroom-hindsight-autoheal",
+      "cli (host)",
+    ]);
+  });
+
+  it("returns nothing gated when nothing drifted", () => {
+    expect(
+      partitionDrift([], {
+        owners: gatedOwners(["apply", "refresh-web"], false),
+        rolledAgents: new Set(["klanker"]),
+      }),
+    ).toEqual({ gated: [], exempt: [] });
+  });
+});

--- a/src/cli/component-scope.ts
+++ b/src/cli/component-scope.ts
@@ -1,0 +1,231 @@
+/**
+ * Component OWNERSHIP + remediation — the single source of truth for
+ * "which mechanism converges this component, and what command drives it"
+ * (#3928).
+ *
+ * WHY THIS EXISTS
+ *
+ * `component-versions.ts` (#3919) answers "is every component on the same
+ * version?" enumeratively, from `docker ps`. That gave `switchroom doctor`
+ * and `switchroom update --check` a standing, checkable answer — and on
+ * 2026-07-28 it correctly reported `switchroom-web` and
+ * `switchroom-hindsight-autoheal` still on v0.19.26 after a roll to
+ * v0.19.30 that had exited **0**.
+ *
+ * The reason the roll could exit green with that drift outstanding is that
+ * `rollout` carried its OWN, separate notion of scope: a hardcoded list of
+ * plan steps (`refresh-web`, `refresh-hostd`, `refresh-hindsight`) whose
+ * failures degraded to non-fatal warnings, and no check at all that the
+ * host had actually converged. Two derivations of "what is in scope", only
+ * one of which was enumerative — so they drifted, and the enumerative one
+ * was right.
+ *
+ * This module is the join. It maps a component from the SAME inventory
+ * `update --check` uses onto the mechanism that owns it, so:
+ *
+ *   - `rollout` can gate on exactly the components it was responsible for
+ *     converging, and fail loudly when any is left behind
+ *     (`src/cli/rollout.ts`, the `verify-components` step);
+ *   - `switchroom doctor` names the same remediation for the same
+ *     component (`src/cli/doctor-component-versions.ts`);
+ *
+ * and a component that ships tomorrow is classified by the same rules,
+ * without anyone editing a list.
+ *
+ * CLASSIFICATION IS KEYED ON THE IMAGE, NOT THE CONTAINER NAME.
+ *
+ * `switchroom-hindsight-autoheal` is the whole reason. It is a sidecar in
+ * the `switchroom-hostd` compose project that runs the **hostd image**
+ * (`src/cli/hostd.ts:406`) — a name allowlist put it nowhere, which is
+ * exactly how it escaped every previous scope list. Keyed on the image
+ * repo it lands on the hostd owner automatically, and so would a second
+ * hostd-project sidecar added next release.
+ */
+
+import type { ComponentVersion } from "./component-versions.js";
+
+/**
+ * The mechanism that converges a component onto the release target.
+ *
+ * One value per DEPLOY UNIT, not per container: `switchroom-hostd` and
+ * `switchroom-hindsight-autoheal` share `"hostd"` because one
+ * `hostd install` regenerates the compose project that holds both.
+ */
+export type ComponentOwnerKind =
+  /** The host CLI running this process. Converged by `switchroom update`. */
+  | "cli"
+  /** The agent-fleet compose project (`switchroom`): agents + the
+   *  vault-broker / approval-kernel / auth-broker / voice singletons,
+   *  which self-heal on the first `agent restart` (#2170). */
+  | "fleet"
+  /** The `switchroom-web` compose project. `switchroom webd install`. */
+  | "web"
+  /** The `switchroom-hostd` compose project — hostd, its docker-socket
+   *  proxy, and the hindsight-autoheal sidecar. `switchroom hostd install`. */
+  | "hostd"
+  /** The standalone `docker run` hindsight singleton. `memory setup`. */
+  | "hindsight";
+
+export interface ComponentOwner {
+  kind: ComponentOwnerKind;
+  /**
+   * Fleet AGENT name (container `switchroom-<agent>` on the
+   * `switchroom-agent` image), when this component is a per-agent
+   * container. Absent for fleet singletons.
+   *
+   * Load-bearing for the rollout gate: a `--agents <subset>` roll is only
+   * responsible for the agents it was asked to roll, so the gate must be
+   * able to tell "agent nobody asked us to touch" from "singleton that
+   * should have self-healed".
+   */
+  agent?: string;
+}
+
+/**
+ * The image REPOSITORY name (`switchroom-hostd`) from a full image ref
+ * (`ghcr.io/switchroom/switchroom-hostd:v0.19.30`).
+ *
+ * Returns null when the ref carries no `…/switchroom-<x>` repo path —
+ * the same shape `isSwitchroomReleaseImage` refuses, so a third-party
+ * image running under a switchroom-prefixed container name
+ * (`switchroom-hostd-docker-proxy` → `ghcr.io/tecnativa/…`) never
+ * classifies as a switchroom deploy unit.
+ */
+export function imageRepoName(imageRef: string | undefined): string | null {
+  if (!imageRef) return null;
+  const at = imageRef.indexOf("@");
+  const withoutDigest = at >= 0 ? imageRef.slice(0, at) : imageRef;
+  const slash = withoutDigest.lastIndexOf("/");
+  if (slash < 0) return null;
+  const afterSlash = withoutDigest.slice(slash + 1);
+  const colon = afterSlash.indexOf(":");
+  const repo = colon >= 0 ? afterSlash.slice(0, colon) : afterSlash;
+  return /^switchroom-[a-z0-9-]+$/.test(repo) ? repo : null;
+}
+
+/**
+ * Which mechanism owns this component.
+ *
+ * DEFAULTS TO `"fleet"` for an unrecognised switchroom image, and that
+ * default is deliberate and fail-LOUD rather than fail-silent: a new
+ * component is then gated by the rollout drift check from the day it
+ * ships. If it turns out to live in its own compose project, the roll
+ * says so by failing with the component named — which is strictly better
+ * than the historical behaviour (silently out of scope forever).
+ */
+export function classifyComponent(c: ComponentVersion): ComponentOwner {
+  if (c.kind === "cli") return { kind: "cli" };
+  const repo = imageRepoName(c.imageRef);
+  switch (repo) {
+    case "switchroom-web":
+      return { kind: "web" };
+    // hostd AND the hindsight-autoheal sidecar — same image, same compose
+    // project, one `hostd install` converges both.
+    case "switchroom-hostd":
+      return { kind: "hostd" };
+    case "switchroom-hindsight":
+      return { kind: "hindsight" };
+    case "switchroom-agent": {
+      const agent = c.name.startsWith("switchroom-")
+        ? c.name.slice("switchroom-".length)
+        : c.name;
+      return agent ? { kind: "fleet", agent } : { kind: "fleet" };
+    }
+    default:
+      return { kind: "fleet" };
+  }
+}
+
+/**
+ * The command that brings an owner's components onto `target`.
+ *
+ * Shared by the doctor row's `fix:` and the rollout drift gate's failure
+ * text so an operator is never given two different answers for the same
+ * drifted component.
+ */
+export function remediationFor(owner: ComponentOwner, target: string): string {
+  switch (owner.kind) {
+    case "cli":
+      return `switchroom update  (self-updates the host CLI to ${target} first, then everything else)`;
+    case "web":
+      return `switchroom webd install --tag ${target}  (separate compose project — regenerates + recreates switchroom-web)`;
+    case "hostd":
+      return `switchroom hostd install --tag ${target}  (regenerates the hostd compose project — both hostd and the autoheal sidecar)`;
+    case "hindsight":
+      return `switchroom memory setup --recreate --tag ${target}  (standalone container — not a compose service)`;
+    case "fleet":
+      return owner.agent
+        ? `switchroom rollout --pin ${target} --agents ${owner.agent}  (agent-fleet compose project)`
+        : `switchroom rollout --pin ${target}  (agent-fleet compose project — the singletons self-heal on the first agent restart)`;
+  }
+}
+
+/**
+ * Which owners a given rollout is ANSWERABLE for.
+ *
+ * Derived from the plan's own steps rather than from the CLI flags, so
+ * the gate can never claim responsibility for a step the plan does not
+ * contain (and can never quietly drop one it does).
+ *
+ * `"cli"` is DELIBERATELY NOT GATED. The host operator's CLI is installed
+ * with `npm i -g` on the host; no step of any rollout plan converges it,
+ * and on the hostd path the roll physically cannot (rollout.ts already
+ * names it as permanently deferred). Gating it would make every
+ * hostd-driven roll fail whenever the operator's host CLI lagged the
+ * release — which is the normal state immediately after a tag, and was
+ * true on the #3928 host itself. It is reported as an EXEMPT drift
+ * warning instead, and `shouldRefuseStaleCli` (rollout.ts) is what
+ * actually protects the roll from a stale driving CLI.
+ *
+ * @param stepKinds  the `kind` of every step in the executed plan.
+ * @param hostdContext  the agent-invoked path. `refresh-hostd` is
+ *   deliberately absent from that plan (recreating hostd would SIGKILL
+ *   the in-flight roll), but hostd is NOT unowned there: the daemon
+ *   self-bumps its own compose project onto the target before it spawns
+ *   the roll child (#2645), and `shouldRefuseStaleCli` refuses the roll
+ *   outright when the hostd-container CLI is older than the target. So on
+ *   that path hostd IS answered for — and a hostd-project component still
+ *   behind after the roll (exactly `switchroom-hindsight-autoheal` in
+ *   #3928) is a real finding, not an expected deferral.
+ */
+export function gatedOwners(
+  stepKinds: readonly string[],
+  hostdContext: boolean,
+): Set<ComponentOwnerKind> {
+  const kinds = new Set(stepKinds);
+  const owners = new Set<ComponentOwnerKind>(["fleet"]);
+  if (kinds.has("refresh-web")) owners.add("web");
+  if (kinds.has("refresh-hindsight")) owners.add("hindsight");
+  if (kinds.has("refresh-hostd") || hostdContext) owners.add("hostd");
+  return owners;
+}
+
+/**
+ * Split the drifted components into the ones this roll must answer for
+ * and the ones it deliberately did not touch.
+ *
+ * `--skip-web` (which on the host-shell path drops the web, hostd AND
+ * hindsight refresh steps) is an explicit operator opt-out, so those
+ * components are EXEMPT from the gate — but they are still returned as
+ * `exempt` and reported, because "you asked me to skip it and it is
+ * behind" is information, not silence.
+ */
+export function partitionDrift(
+  behind: readonly ComponentVersion[],
+  opts: { owners: ReadonlySet<ComponentOwnerKind>; rolledAgents: ReadonlySet<string> },
+): { gated: ComponentVersion[]; exempt: ComponentVersion[] } {
+  const gated: ComponentVersion[] = [];
+  const exempt: ComponentVersion[] = [];
+  for (const c of behind) {
+    const owner = classifyComponent(c);
+    const inScope =
+      owner.kind === "fleet" && owner.agent !== undefined
+        ? // A `--agents <subset>` roll is answerable only for the agents it
+          // was asked to roll. Ditto an agent container that is no longer in
+          // switchroom.yaml: nothing in this roll was going to move it.
+          opts.rolledAgents.has(owner.agent)
+        : opts.owners.has(owner.kind);
+    (inScope ? gated : exempt).push(c);
+  }
+  return { gated, exempt };
+}

--- a/src/cli/doctor-component-versions.ts
+++ b/src/cli/doctor-component-versions.ts
@@ -29,6 +29,7 @@ import {
   type ComponentVersion,
   type ExecFn,
 } from "./component-versions.js";
+import { classifyComponent, remediationFor } from "./component-scope.js";
 
 export interface ComponentVersionCheckOpts {
   /** Test seam — replace the `docker ps` shellout. */
@@ -42,18 +43,17 @@ const defaultExec: ExecFn = (cmd, args) => {
   return { status: r.status ?? 1, stdout: r.stdout ?? "" };
 };
 
-/** The remediation for a given drifted component. */
+/**
+ * The remediation for a given drifted component.
+ *
+ * Delegates to the SHARED owner→command mapping (#3928). It used to be a
+ * private name-keyed `if` ladder here, which meant doctor and `rollout`
+ * each carried their own idea of which mechanism owns which component —
+ * the duplication that let `switchroom-hindsight-autoheal` sit outside
+ * the roll's scope while doctor knew perfectly well how to fix it.
+ */
 function fixFor(c: ComponentVersion, target: string): string {
-  if (c.kind === "cli") {
-    return `switchroom update  (self-updates the host CLI to ${target} first, then everything else)`;
-  }
-  if (c.name === "switchroom-web") {
-    return `switchroom webd install --tag ${target}  (run host-side: webd install fails inside hostd when the hostd compose predates SWITCHROOM_HOSTD_OPERATOR_UID)`;
-  }
-  if (c.name === "switchroom-hindsight-autoheal" || c.name === "switchroom-hostd") {
-    return `switchroom hostd install --tag ${target}  (regenerates the hostd compose project — both hostd and the autoheal sidecar)`;
-  }
-  return `switchroom update`;
+  return remediationFor(classifyComponent(c), target);
 }
 
 export function runComponentVersionChecks(

--- a/src/cli/operator-uid.ts
+++ b/src/cli/operator-uid.ts
@@ -24,14 +24,129 @@ import {
   realpathSync,
   statSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
+
+/**
+ * The canonical in-container mount point of the operator's home.
+ *
+ * hostd pins `HOME=/host-home` and bind-mounts `~/.switchroom` there
+ * (src/cli/hostd.ts:302); the root-tier agent container mounts the same
+ * host home at the same path. It is deliberately NOT a valid bind SOURCE
+ * (see `assertPlausibleHostHome`) — but it IS a valid place to READ the
+ * operator's ownership from, because a bind mount preserves the host
+ * inode's uid.
+ */
+const CONTAINER_OPERATOR_HOME = "/host-home";
+
+/**
+ * Marker that a directory really is a switchroom home, so we never adopt
+ * the uid of some unrelated `.switchroom` directory.
+ */
+const SWITCHROOM_HOME_MARKER = "switchroom.yaml";
+
+export interface OperatorUidOwnershipDeps {
+  env?: NodeJS.ProcessEnv;
+  /** The process home. Defaults to `os.homedir()` at the call site. */
+  home?: string;
+  /** True when `path` exists (follows symlinks). */
+  exists?: (path: string) => boolean;
+  /** Owning uid of `path`, or undefined when unreadable. */
+  statUid?: (path: string) => number | undefined;
+}
+
+/**
+ * The switchroom-home directories to read operator ownership from, in
+ * precedence order. Deduped, `.switchroom` appended to each.
+ *
+ * `SWITCHROOM_HOST_HOME` first (authoritative when the host path is also
+ * visible here — the host shell), then the process home (correct inside
+ * hostd, whose HOME is pinned to `/host-home`), then `/host-home`
+ * explicitly (an agent container's HOME is its own state dir, so only the
+ * literal mount point finds the operator home there).
+ */
+export function operatorHomeCandidates(
+  env: NodeJS.ProcessEnv,
+  home: string | undefined,
+): string[] {
+  const roots = [env.SWITCHROOM_HOST_HOME?.trim(), home, CONTAINER_OPERATOR_HOME];
+  const out: string[] = [];
+  for (const r of roots) {
+    if (!r || r.length === 0) continue;
+    const dir = join(r, ".switchroom");
+    if (!out.includes(dir)) out.push(dir);
+  }
+  return out;
+}
+
+/**
+ * Last-resort operator identity: the OWNER of the switchroom home itself.
+ *
+ * WHY (#3928 amendment). Switchroom's contract is that an operator drives
+ * the fleet from Telegram, never a host shell. But `webd install` refused
+ * outright when it could not resolve an operator uid, and root-with-no-
+ * SUDO_UID is exactly what an agent/hostd container is — so the only
+ * remediation the CLI could offer for a stale `switchroom-web` was "open
+ * a shell as the operator". That is the design failure, not the peercred
+ * invariant it protects: the uid is right there on disk.
+ *
+ * It also closes the recursive hole that produced #3928's live evidence.
+ * `hostd install` run as root omits `SWITCHROOM_HOSTD_OPERATOR_UID` from
+ * the compose it generates (src/cli/hostd.ts:638 passes
+ * `resolveOperatorUid()`, and the env line is emitted only when it is
+ * defined) — so the hostd container it creates ALSO cannot resolve the
+ * uid, and the rollout's in-plan `refresh-web` step inside that container
+ * fails for the same reason. One fix at this layer closes both.
+ *
+ * Deliberately reads the DIRECTORY, not a file inside it: on the
+ * reference host `~/.switchroom/switchroom.yaml` is root-owned (written
+ * by a root-mode apply) while `~/.switchroom` itself is `1000:1000`. The
+ * directory is the operator-owned artifact (`operatorOwnedPaths`, and
+ * `restoreOperatorOwnership` keeps it that way); the file contents are
+ * not a reliable identity signal.
+ *
+ * Fail-closed: uid 0 is REJECTED (root is never "the operator" — adopting
+ * it would write `user: "0:0"` into the web compose and 503 every webhook
+ * forward, the exact silent breakage the refusal existed to prevent), as
+ * is a directory with no `switchroom.yaml` in it.
+ */
+export function resolveOperatorUidFromOwnership(
+  deps: OperatorUidOwnershipDeps = {},
+): number | undefined {
+  const env = deps.env ?? process.env;
+  const home = deps.home ?? homedir();
+  const exists = deps.exists ?? ((p) => existsSync(p));
+  const statUid =
+    deps.statUid ??
+    ((p) => {
+      try {
+        return statSync(p).uid;
+      } catch {
+        return undefined;
+      }
+    });
+
+  for (const dir of operatorHomeCandidates(env, home)) {
+    if (!exists(join(dir, SWITCHROOM_HOME_MARKER))) continue;
+    const uid = statUid(dir);
+    if (uid !== undefined && Number.isFinite(uid) && uid > 0) return uid;
+  }
+  return undefined;
+}
 
 /**
  * Resolve the real invoking operator's uid even under sudo. `sudo`
  * exports the underlying user's uid as `SUDO_UID` (process.getuid()
  * would return 0). Falls back to getuid() when >0, then to the
- * hostd-injected `SWITCHROOM_HOSTD_OPERATOR_UID`, else undefined
- * (non-POSIX where getuid is unavailable, or root with neither hint).
+ * hostd-injected `SWITCHROOM_HOSTD_OPERATOR_UID`, then to the OWNER of
+ * the switchroom home on disk, else undefined.
+ *
+ * The ownership tier is strictly additive: it is reached only where the
+ * three env/syscall tiers already returned `undefined` — i.e. exactly
+ * today's degraded outcomes (compose generated without the broker
+ * operator socket, a skipped chown-back, `webd install` refusing). No
+ * call that resolves today changes answer. See
+ * `resolveOperatorUidFromOwnership` for why it exists (#3928).
  *
  * The hostd fallback is load-bearing: `switchroom apply` shelled out by
  * hostd runs as root WITHOUT sudo, so `SUDO_UID` is unset and getuid()
@@ -45,7 +160,10 @@ import { join } from "node:path";
  * hostd-driven rollout emits the operator socket just like a host-shell
  * `sudo apply` does.
  */
-export function resolveOperatorUid(): number | undefined {
+export function resolveOperatorUid(
+  /** Test seam for the ownership tier only — production passes nothing. */
+  ownershipDeps: OperatorUidOwnershipDeps = {},
+): number | undefined {
   const sudoUid = process.env.SUDO_UID;
   if (sudoUid !== undefined) {
     const parsed = parseInt(sudoUid, 10);
@@ -60,7 +178,7 @@ export function resolveOperatorUid(): number | undefined {
     const parsed = parseInt(hostdUid, 10);
     if (Number.isFinite(parsed) && parsed > 0) return parsed;
   }
-  return undefined;
+  return resolveOperatorUidFromOwnership(ownershipDeps);
 }
 
 export interface OwnershipRestoreDeps {

--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -43,6 +43,8 @@ import {
   type RolloutPhase,
   type RolloutResult,
   type RolloutStep,
+  VERIFY_COMPONENTS_STEP,
+  evaluateRolloutDrift,
   createRolloutDeps,
   isSpawnTimeout,
   ROLLOUT_RUN_TIMEOUT_MS,
@@ -58,6 +60,7 @@ import {
   recoverPinJournal,
   PIN_JOURNAL_MAX_AGE_MS,
 } from "./rollout-pin-journal.js";
+import type { ComponentVersion } from "./component-versions.js";
 import { getReleasePinFromConfig } from "./release-yaml.js";
 import { SCOPED_SWEEP_ENV } from "../agents/agent-owned-tree.js";
 
@@ -96,7 +99,7 @@ describe("orderAgentsCanaryFirst", () => {
 });
 
 describe("planRollout", () => {
-  it("orders apply → restarts (canary-first) → web → hostd → hindsight → sweep", () => {
+  it("orders apply → restarts (canary-first) → web → hostd → hindsight → sweep → verify", () => {
     const steps = planRollout(["clerk", "test-harness"]);
     expect(steps.map((s) => (s.kind === "restart-agent" ? `r:${s.agent}` : s.kind))).toEqual([
       "apply",
@@ -106,6 +109,7 @@ describe("planRollout", () => {
       "refresh-hostd",
       "refresh-hindsight",
       "sweep",
+      "verify-components",
     ]);
   });
 
@@ -117,8 +121,26 @@ describe("planRollout", () => {
 
   it("drops web + hostd + hindsight when skipWeb is set", () => {
     const kinds = planRollout(["clerk"], { skipWeb: true }).map((s) => s.kind);
-    expect(kinds).toEqual(["apply", "restart-agent", "sweep"]);
+    expect(kinds).toEqual(["apply", "restart-agent", "sweep", "verify-components"]);
     expect(kinds).not.toContain("refresh-hindsight");
+  });
+
+  it("ALWAYS ends with verify-components — including under --skip-web (#3928)", () => {
+    // The convergence gate derives its scope FROM the steps present, so it
+    // must run even on a reduced plan: with --skip-web it still proves the
+    // agents converged, and demotes the skipped singletons to named
+    // warnings rather than dropping them silently.
+    for (const opts of [
+      undefined,
+      { skipWeb: true },
+      { hostdContext: true },
+      { hostdContext: true, skipWeb: true },
+      { pinToPersist: "v9.9.9" },
+    ]) {
+      const kinds = planRollout(["clerk"], opts).map((s) => s.kind);
+      expect(kinds[kinds.length - 1]).toBe("verify-components");
+      expect(kinds.filter((k) => k === "verify-components")).toHaveLength(1);
+    }
   });
 
   it("does NOT emit a singleton step (first restart self-heals them, #2170)", () => {
@@ -154,6 +176,13 @@ function harness(opts: {
    *  Defaults to the roll target shape being unknown (null → probe skipped
    *  by the isVersionAssertable gate never fires a warning). */
   webImageTag?: string | null;
+  /**
+   * Component inventory the terminal `verify-components` gate reads
+   * (#3928). Defaults to an EMPTY host — nothing behind, so the gate
+   * passes and every pre-existing test keeps its meaning. Tests that
+   * exercise the gate inject a real inventory.
+   */
+  components?: ComponentVersion[];
 }): {
   deps: RolloutDeps;
   runs: string[][];
@@ -182,6 +211,7 @@ function harness(opts: {
     },
     hindsightExists: () => opts.hindsightExists ?? false,
     webImageTag: () => opts.webImageTag ?? null,
+    collectComponents: () => opts.components ?? [],
   };
   return { deps, runs, runEnvs, logs, persisted, phases };
 }
@@ -395,7 +425,7 @@ describe("planRollout — hostd context (#2487)", () => {
       s.kind === "restart-agent" ? `r:${s.agent}` : s.kind,
     );
     // apply → canary (test-harness) → persist-pin → rest → refresh-web →
-    // refresh-hindsight → sweep.
+    // refresh-hindsight → sweep → verify-components.
     expect(kinds).toEqual([
       "apply",
       "r:test-harness",
@@ -404,6 +434,7 @@ describe("planRollout — hostd context (#2487)", () => {
       "refresh-web",
       "refresh-hindsight",
       "sweep",
+      "verify-components",
     ]);
     // persist-pin comes strictly AFTER the canary restart.
     const persistIdx = kinds.indexOf("persist-pin");
@@ -751,6 +782,258 @@ describe("rollout structured-result sentinel (#2487)", () => {
 
   it("returns null when no sentinel line is present (child died early)", () => {
     expect(parseRolloutResultLine("Rolling 3 agents…\napply\n")).toBeNull();
+  });
+
+  it("round-trips `drifted` so hostd can name the stranded components (#3928)", () => {
+    // hostd learns the roll's outcome ONLY from this line. If `drifted`
+    // does not survive the round-trip, the Telegram card can say "failed"
+    // but never say WHAT is still behind — which is the whole point.
+    const parsed = parseRolloutResultLine(
+      encodeRolloutResultLine({
+        ok: false,
+        rolled: ["test-harness", "klanker"],
+        failedStep: VERIFY_COMPONENTS_STEP,
+        warnings: ["switchroom webd install --tag v0.19.30"],
+        drifted: ["switchroom-web", "switchroom-hindsight-autoheal"],
+      }),
+    );
+    expect(parsed).toMatchObject({
+      ok: false,
+      failedStep: "verify-components",
+      drifted: ["switchroom-web", "switchroom-hindsight-autoheal"],
+    });
+  });
+});
+
+// ── #3928: a roll that leaves a component behind must NOT exit green ──────
+
+/**
+ * The #3928 regression suite.
+ *
+ * On 2026-07-28 `switchroom rollout` rolled the fleet to v0.19.30 and
+ * exited **0** while `switchroom-web` and `switchroom-hindsight-autoheal`
+ * stayed on v0.19.26 — and `switchroom update --check`, reading the same
+ * host, correctly named both as targets. Every test below is written
+ * against that exact inventory, and every one of them FAILS on the
+ * pre-fix executor (which had no terminal convergence check at all, so
+ * `r.ok` was `true`).
+ */
+describe("executeRollout — terminal component-drift gate (#3928)", () => {
+  const TARGET = "v0.19.30";
+
+  /** The reference host's inventory, mid-#3928. */
+  function referenceHost(opts: { webBehind?: boolean } = {}): ComponentVersion[] {
+    const at = (v: string, repo: string) =>
+      `ghcr.io/switchroom/switchroom-${repo}:${v}`;
+    return [
+      {
+        name: "switchroom-klanker",
+        kind: "container",
+        version: "v0.19.30",
+        imageRef: at("v0.19.30", "agent"),
+      },
+      {
+        name: "switchroom-test-harness",
+        kind: "container",
+        version: "v0.19.30",
+        imageRef: at("v0.19.30", "agent"),
+      },
+      {
+        name: "switchroom-hostd",
+        kind: "container",
+        version: "v0.19.30",
+        imageRef: at("v0.19.30", "hostd"),
+      },
+      {
+        // The escapee: hostd's compose project, hostd's IMAGE, a name no
+        // scope allowlist ever carried.
+        name: "switchroom-hindsight-autoheal",
+        kind: "container",
+        version: "v0.19.26",
+        imageRef: at("v0.19.26", "hostd"),
+      },
+      {
+        name: "switchroom-web",
+        kind: "container",
+        version: opts.webBehind === false ? "v0.19.30" : "v0.19.26",
+        imageRef: at(opts.webBehind === false ? "v0.19.30" : "v0.19.26", "web"),
+      },
+    ];
+  }
+
+  it("FAILS the roll and names both stranded components — the exact #3928 host", () => {
+    const steps = planRollout(["test-harness", "klanker"]);
+    const { deps, logs } = harness({
+      versions: { "test-harness": "0.19.30", klanker: "0.19.30" },
+      components: referenceHost(),
+    });
+
+    const r = executeRollout(steps, TARGET, deps);
+
+    // THE assertion #3928 is about: this roll exited 0 before the fix.
+    expect(r.ok).toBe(false);
+    expect(r.failedStep).toBe(VERIFY_COMPONENTS_STEP);
+    expect(r.drifted?.sort()).toEqual([
+      "switchroom-hindsight-autoheal",
+      "switchroom-web",
+    ]);
+
+    // Every agent it DID roll is still reported — the operator must be able
+    // to tell "nothing happened" from "the fleet moved, two components did
+    // not".
+    expect(r.rolled).toEqual(["test-harness", "klanker"]);
+
+    // And the failure carries the command that actually fixes each one,
+    // identical to the string `switchroom doctor` prints.
+    const warned = r.warnings.join("\n");
+    expect(warned).toContain(`switchroom webd install --tag ${TARGET}`);
+    expect(warned).toContain(`switchroom hostd install --tag ${TARGET}`);
+    expect(logs.join("\n")).toContain("verify-components");
+  });
+
+  it("exits green when the same host has actually converged", () => {
+    const steps = planRollout(["test-harness", "klanker"]);
+    const { deps } = harness({
+      versions: { "test-harness": "0.19.30", klanker: "0.19.30" },
+      components: referenceHost().map((c) =>
+        c.version === "v0.19.26"
+          ? {
+              ...c,
+              version: "v0.19.30",
+              imageRef: c.imageRef?.replace("v0.19.26", "v0.19.30"),
+            }
+          : c,
+      ),
+    });
+    const r = executeRollout(steps, TARGET, deps);
+    expect(r.ok).toBe(true);
+    expect(r.drifted).toBeUndefined();
+  });
+
+  it("gates the autoheal sidecar on the HOSTD-DRIVEN path too, where refresh-hostd is absent", () => {
+    // The #3928 roll was driven from hostd. Its plan deliberately omits
+    // `refresh-hostd` (recreating hostd would SIGKILL the in-flight roll),
+    // so a scope derived from "steps present" alone would exempt the
+    // sidecar and reproduce the bug on the very path that hit it.
+    const steps = planRollout(["test-harness", "klanker"], {
+      hostdContext: true,
+    });
+    expect(steps.some((s) => s.kind === "refresh-hostd")).toBe(false);
+
+    const { deps } = harness({
+      versions: { "test-harness": "0.19.30", klanker: "0.19.30" },
+      components: referenceHost({ webBehind: false }),
+    });
+    const r = executeRollout(steps, TARGET, deps, { hostdContext: true });
+    expect(r.ok).toBe(false);
+    expect(r.drifted).toEqual(["switchroom-hindsight-autoheal"]);
+  });
+
+  it("does NOT revert the durable pin when only the drift gate failed", () => {
+    // The fleet DID reach the target. Reverting the pin here would drag
+    // every later `agent restart` / reconcile back onto the old build —
+    // strictly worse than the bug being fixed. The gate therefore sits
+    // AFTER commitPin and returns a plain failure instead of calling
+    // `fail()`.
+    const steps = planRollout(["test-harness"], { pinToPersist: TARGET });
+    const { deps, persisted } = harness({
+      versions: { "test-harness": "0.19.30" },
+      components: referenceHost(),
+    });
+    const r = executeRollout(steps, TARGET, deps);
+    expect(r.ok).toBe(false);
+    expect(r.failedStep).toBe(VERIFY_COMPONENTS_STEP);
+    expect(persisted).toEqual([TARGET]);
+  });
+
+  it("reports an out-of-scope component as a WARNING, not a failure", () => {
+    // `--skip-web` is an explicit opt-out, so web must not fail the roll —
+    // but "you skipped it and it is behind" is information the operator
+    // still needs, so it is a named warning carrying the fix command.
+    const steps = planRollout(["klanker"], { skipWeb: true });
+    const { deps } = harness({
+      versions: { klanker: "0.19.30" },
+      components: referenceHost().filter(
+        (c) => c.name !== "switchroom-hindsight-autoheal",
+      ),
+    });
+    const r = executeRollout(steps, TARGET, deps);
+    expect(r.ok).toBe(true);
+    expect(r.warnings.join("\n")).toContain("switchroom-web");
+    expect(r.warnings.join("\n")).toContain(
+      `switchroom webd install --tag ${TARGET}`,
+    );
+  });
+
+  it("does not blame a roll for an agent it was never asked to touch", () => {
+    const steps = planRollout(["klanker"]);
+    const { deps } = harness({
+      versions: { klanker: "0.19.30" },
+      components: [
+        {
+          name: "switchroom-klanker",
+          kind: "container",
+          version: "v0.19.30",
+          imageRef: "ghcr.io/switchroom/switchroom-agent:v0.19.30",
+        },
+        {
+          name: "switchroom-somebody-else",
+          kind: "container",
+          version: "v0.19.26",
+          imageRef: "ghcr.io/switchroom/switchroom-agent:v0.19.26",
+        },
+      ],
+    });
+    const r = executeRollout(steps, TARGET, deps);
+    expect(r.ok).toBe(true);
+    expect(r.warnings.join("\n")).toContain("switchroom-somebody-else");
+  });
+
+  it("WARNS LOUDLY rather than passing silently when no collector is wired", () => {
+    // A missing inventory must never read as "converged". This is the
+    // fail-open hole that would quietly restore #3928.
+    const steps = planRollout(["klanker"]);
+    const { deps } = harness({ versions: { klanker: "0.19.30" } });
+    delete (deps as { collectComponents?: unknown }).collectComponents;
+    const r = executeRollout(steps, TARGET, deps);
+    expect(r.ok).toBe(true);
+    // A WARNING, not just a log line: warnings ride the result sentinel to
+    // hostd and onto the Telegram card, so the operator learns the roll was
+    // unproven even when nobody reads the child's stdout.
+    const warned = r.warnings.join("\n");
+    expect(warned).toContain("did not prove the host converged");
+    expect(warned).toContain("switchroom update --check");
+  });
+
+  it("survives a docker-less host: a THROWING collector warns, never crashes the roll", () => {
+    const steps = planRollout(["klanker"]);
+    const { deps } = harness({ versions: { klanker: "0.19.30" } });
+    deps.collectComponents = () => {
+      throw new Error("docker: command not found");
+    };
+    const r = executeRollout(steps, TARGET, deps);
+    expect(r.ok).toBe(true);
+    expect(r.warnings.join("\n")).toContain("docker: command not found");
+  });
+});
+
+describe("evaluateRolloutDrift (#3928, pure)", () => {
+  it("normalizes a bare target so a `0.19.30` roll is not read as drift", () => {
+    const verdict = evaluateRolloutDrift(
+      [
+        {
+          name: "switchroom-web",
+          kind: "container",
+          version: "v0.19.30",
+          imageRef: "ghcr.io/switchroom/switchroom-web:v0.19.30",
+        },
+      ],
+      "0.19.30",
+      planRollout(["klanker"]),
+      false,
+    );
+    expect(verdict.gated).toEqual([]);
+    expect(verdict.exempt).toEqual([]);
   });
 });
 

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -67,6 +67,18 @@ import {
 import { isHindsightContainerExists } from "../setup/hindsight.js";
 import { deployedImageTag, type DockerRunner } from "./deploy-version-guard.js";
 import { SCOPED_SWEEP_ENV } from "../agents/agent-owned-tree.js";
+import {
+  collectComponents as collectHostComponents,
+  detectComponentDrift,
+  type ComponentVersion,
+  type ExecFn,
+} from "./component-versions.js";
+import {
+  classifyComponent,
+  gatedOwners,
+  partitionDrift,
+  remediationFor,
+} from "./component-scope.js";
 
 /** One ordered step of a rollout plan. Pure data so it unit-tests. */
 export type RolloutStep =
@@ -76,7 +88,16 @@ export type RolloutStep =
   | { kind: "refresh-web" }
   | { kind: "refresh-hostd" }
   | { kind: "refresh-hindsight" }
-  | { kind: "sweep" };
+  | { kind: "sweep" }
+  | { kind: "verify-components" };
+
+/**
+ * `failedStep` label for a roll that converged its agents but left an
+ * in-scope component behind the target (#3928). Distinct from every
+ * other failure label because the recovery is different: nothing needs
+ * rolling BACK — a named component needs finishing forward.
+ */
+export const VERIFY_COMPONENTS_STEP = "verify-components";
 
 export interface RolloutPlanOpts {
   /** Skip the web + hostd + hindsight refresh (step 3). */
@@ -199,6 +220,9 @@ export function planRollout(
     // self-guards via hindsightExists().
     steps.push({ kind: "refresh-hindsight" });
     steps.push({ kind: "sweep" });
+    // Terminal drift gate (#3928) — read-only, and LAST so it sees the
+    // host every preceding step has finished mutating.
+    steps.push({ kind: "verify-components" });
     return steps;
   }
 
@@ -215,6 +239,11 @@ export function planRollout(
     steps.push({ kind: "refresh-hindsight" });
   }
   steps.push({ kind: "sweep" });
+  // Terminal drift gate (#3928). Emitted even under --skip-web: the gate's
+  // SCOPE is derived from the steps present (see gatedOwners), so skipping
+  // the refresh steps exempts those components rather than dropping the
+  // check for everything else.
+  steps.push({ kind: "verify-components" });
   return steps;
 }
 
@@ -248,6 +277,12 @@ export function formatRolloutPlan(
         break;
       case "sweep":
         lines.push(`  ${n}. sweep — print per-agent version table`);
+        break;
+      case "verify-components":
+        lines.push(
+          `  ${n}. verify-components — assert EVERY in-scope component is on ${target} ` +
+            `(same inventory \`switchroom update --check\` uses); non-zero exit if any is behind`,
+        );
         break;
     }
   }
@@ -472,6 +507,18 @@ export interface RolloutDeps {
    * when absent the skew check is skipped.
    */
   webImageTag?(): string | null;
+  /**
+   * Enumerate every switchroom component on this host and the version it
+   * is running — the SAME inventory `switchroom update --check` and
+   * `switchroom doctor` consume (`component-versions.ts`). Drives the
+   * terminal `verify-components` gate (#3928).
+   *
+   * Optional ONLY as a test seam. Production always wires it in
+   * `createRolloutDeps`, and the executor treats an unwired collector as a
+   * loud warning rather than a silent pass — an un-gated roll must never
+   * look like a converged one.
+   */
+  collectComponents?(): ComponentVersion[];
 }
 
 export interface RolloutResult {
@@ -493,6 +540,16 @@ export interface RolloutResult {
    * the PRIOR (working) version.
    */
   pinReverted?: boolean;
+  /**
+   * Components still BEHIND the target when the roll finished, and in
+   * this roll's scope (#3928). Non-empty ⇒ `ok` is false.
+   *
+   * Structured (not just prose in `warnings`) because the operator reads
+   * this outcome through Telegram — hostd lifts it onto the status entry
+   * so `get_status` names the stranded components without anyone grepping
+   * a truncated stderr tail.
+   */
+  drifted?: string[];
   /** Non-fatal warnings (e.g. web/hostd refresh failures). */
   warnings: string[];
 }
@@ -599,6 +656,9 @@ export function encodeRolloutResultLine(result: RolloutResult): string {
       ...(result.got !== undefined ? { got: result.got } : {}),
       ...(result.timedOut ? { timedOut: true } : {}),
       ...(result.pinReverted ? { pinReverted: true } : {}),
+      ...(result.drifted && result.drifted.length > 0
+        ? { drifted: result.drifted }
+        : {}),
       warnings: result.warnings,
     })
   );
@@ -617,6 +677,7 @@ export function parseRolloutResultLine(
   got?: string | null;
   timedOut?: boolean;
   pinReverted?: boolean;
+  drifted?: string[];
   warnings: string[];
 } | null {
   const lines = stdout.split("\n");
@@ -659,6 +720,55 @@ export interface RolloutExecOpts {
   allowDowngrade?: boolean;
 }
 
+/** Outcome of the terminal drift gate (#3928). Pure data. */
+export interface RolloutDriftVerdict {
+  /** Behind the target AND in this roll's scope. Non-empty ⇒ roll fails. */
+  gated: ComponentVersion[];
+  /**
+   * Behind the target but NOT this roll's responsibility — an agent the
+   * operator didn't ask to roll, or a singleton whose refresh step
+   * `--skip-web` removed. Reported, never silently dropped.
+   */
+  exempt: ComponentVersion[];
+  /** Version the inventory was compared against (normalized `vX.Y.Z`). */
+  target: string | null;
+}
+
+/**
+ * Compare the live component inventory against the roll target, and split
+ * the drift into what this roll must answer for and what it must not.
+ *
+ * Pure: inventory in, verdict out. THE point of this function is that its
+ * inputs are the same inventory `switchroom update --check` reads
+ * (`collectComponents`) and the same bucketing it applies
+ * (`detectComponentDrift`) — so `rollout` and `update --check` cannot
+ * disagree about what is in scope, which is exactly what they did in
+ * #3928 (`update --check` named `switchroom-web` and
+ * `switchroom-hindsight-autoheal` as targets; the roll that had just
+ * "succeeded" had never considered them).
+ *
+ * Scope is derived from the PLAN, not from flags — see `gatedOwners`.
+ */
+export function evaluateRolloutDrift(
+  components: readonly ComponentVersion[],
+  target: string,
+  steps: readonly RolloutStep[],
+  hostdContext: boolean,
+): RolloutDriftVerdict {
+  // `detectComponentDrift` resolves its target from a release-pin-shaped
+  // string, so normalize the roll target to the canonical `vX.Y.Z` first.
+  const report = detectComponentDrift(components, `v${normalizeVersion(target)}`);
+  const owners = gatedOwners(
+    steps.map((s) => s.kind),
+    hostdContext,
+  );
+  const rolledAgents = new Set(
+    steps.flatMap((s) => (s.kind === "restart-agent" ? [s.agent] : [])),
+  );
+  const { gated, exempt } = partitionDrift(report.behind, { owners, rolledAgents });
+  return { gated, exempt, target: report.target };
+}
+
 export function executeRollout(
   steps: RolloutStep[],
   target: string,
@@ -682,6 +792,13 @@ export function executeRollout(
   // just failed to boot, because every later restart/reconcile/`compose up`
   // reads that pin and converges the rest of the fleet onto it.
   let pinPersisted = false;
+
+  /**
+   * Verdict of the terminal `verify-components` gate (#3928). Computed
+   * inside the step loop (it is read-only), ACTED ON after the loop —
+   * see the gate below the pin commit for why the ordering matters.
+   */
+  let driftVerdict: RolloutDriftVerdict | null = null;
 
   /**
    * Single exit point for every stop-the-roll failure. Reverting the pin
@@ -1100,6 +1217,62 @@ export function executeRollout(
           }
           break;
         }
+        case "verify-components": {
+          // #3928 — the roll's own convergence proof. Read-only: one
+          // `docker ps` through the same collector `switchroom update
+          // --check` uses, so the two commands cannot disagree about what
+          // was in scope. Everything this step finds is decided AFTER the
+          // loop (see the gate below the pin commit).
+          deps.log(
+            `ROLL_STEP verify-components — asserting every in-scope component is on ${target}`,
+          );
+          if (!deps.collectComponents) {
+            // Never a silent pass: an un-gated roll must not be
+            // indistinguishable from a proven one.
+            warnings.push(
+              `verify-components ran with NO component collector wired, so this ` +
+                `roll did not prove the host converged. Confirm with ` +
+                `\`switchroom update --check\` — anything still BEHIND ${target} ` +
+                `was NOT caught here.`,
+            );
+            break;
+          }
+          let inventory: ComponentVersion[];
+          try {
+            inventory = deps.collectComponents();
+          } catch (e) {
+            // Deliberately caught HERE rather than left to the step loop's
+            // catch: that path routes through `fail()`, which reverts the
+            // provisional `release.pin`. A read-only inventory probe that
+            // could not run is not evidence the build is bad, and reverting
+            // the pin of an otherwise-proven roll would drag the whole fleet
+            // back on the next reconcile.
+            warnings.push(
+              `verify-components could not read the component inventory ` +
+                `(${(e as Error).message}), so this roll did not prove the host ` +
+                `converged. Confirm with \`switchroom update --check\`.`,
+            );
+            break;
+          }
+          driftVerdict = evaluateRolloutDrift(
+            inventory,
+            target,
+            steps,
+            execOpts.hostdContext === true,
+          );
+          for (const c of driftVerdict.exempt) {
+            // Behind, but this plan never owned it (a `--agents` subset, or
+            // a refresh step `--skip-web` removed). Say so — an explicit
+            // opt-out earns a named warning, not silence.
+            warnings.push(
+              `${c.name} is on ${c.version ?? "an unreadable version"}, behind ` +
+                `${target}, but was OUTSIDE this roll's scope (no step in this ` +
+                `plan owns it). Finish it: ` +
+                `${remediationFor(classifyComponent(c), `v${normalizeVersion(target)}`)}`,
+            );
+          }
+          break;
+        }
       }
     }
   } catch (e) {
@@ -1156,6 +1329,52 @@ export function executeRollout(
           `journal may cause a later boot to revert it — verify host-side.`,
       );
     }
+  }
+  // #3928 — the convergence gate. A roll that leaves an IN-SCOPE component
+  // behind the target does not exit 0. Before this, `switchroom rollout`
+  // rolled the fleet to v0.19.30 and exited green while `switchroom update
+  // --check` on the same host still reported `switchroom-web` and
+  // `switchroom-hindsight-autoheal` on v0.19.26 — the refresh steps had
+  // degraded their failures to warnings and nobody checked afterwards.
+  // Silent partial success is the deeper defect: it is what let the drift
+  // survive three releases.
+  //
+  // TWO deliberate differences from every other failure in this function:
+  //
+  //   1. It runs AFTER `commitPin`, and does NOT go through `fail()`. Every
+  //      agent came back on the target and the durable pin is CORRECT;
+  //      reverting it would drag the converged fleet back to the prior
+  //      version on the next reconcile — turning a "one singleton is stale"
+  //      finding into a fleet-wide downgrade. Nothing here needs rolling
+  //      BACK; a named component needs finishing FORWARD.
+  //   2. `rolled` is reported in full, so hostd's unattended-failure path
+  //      (`recoverFailedAutoRollout`) sees a past-canary failure and
+  //      correctly declines to auto-roll-back, alerting the operator with
+  //      the component names instead.
+  if (driftVerdict && driftVerdict.gated.length > 0) {
+    const normalizedTarget = `v${normalizeVersion(target)}`;
+    for (const c of driftVerdict.gated) {
+      deps.log(
+        `  ✗ ${c.name} → ${c.version ?? "<unreadable>"} (expected ${target}) — STILL BEHIND`,
+      );
+      warnings.push(
+        `${c.name} is STILL on ${c.version ?? "an unreadable version"} after ` +
+          `the roll to ${target} — it was in this roll's scope and did not ` +
+          `converge. Finish it: ` +
+          `${remediationFor(classifyComponent(c), normalizedTarget)}`,
+      );
+    }
+    deps.log(
+      `  ✗ verify-components FAILED — ${driftVerdict.gated.length} component(s) ` +
+        `still behind ${target}: ${driftVerdict.gated.map((c) => c.name).join(", ")}`,
+    );
+    return {
+      ok: false,
+      rolled,
+      warnings,
+      failedStep: VERIFY_COMPONENTS_STEP,
+      drifted: driftVerdict.gated.map((c) => c.name),
+    };
   }
   return { ok: true, rolled, warnings };
 }
@@ -1565,6 +1784,20 @@ export function createRolloutDeps(params: {
         const r = dockerRun(args);
         return r.ok ? r.stdout : null;
       }),
+    // #3928 — the terminal drift gate's inventory. Threaded through the
+    // SAME bounded `dockerRun` as the other in-process docker calls: this
+    // runs inside `executeRollout`, and an unbounded `docker ps` against an
+    // unresponsive daemon would strand hostd's fleet-mutation latch exactly
+    // like the probes above.
+    collectComponents: () =>
+      collectHostComponents(SWITCHROOM_VERSION, ((cmd, args) => {
+        // `collectContainerComponents` only ever calls `docker`; asserting
+        // it keeps a future caller from silently shelling out to something
+        // else through this seam.
+        if (cmd !== "docker") return { status: 1, stdout: "" };
+        const r = dockerRun(args);
+        return { status: r.ok ? 0 : 1, stdout: r.stdout };
+      }) satisfies ExecFn),
     persistPin: (pin) => {
       const before = readFileSync(configPath, "utf8");
       const after = setReleasePinInConfig(before, pin);
@@ -1851,6 +2084,27 @@ export function registerRolloutCommand(program: Command): void {
       // (rolled[]/failedStep/failedAgent) instead of a flattened tail.
       if (hostdCtx) {
         process.stdout.write(encodeRolloutResultLine(result) + "\n");
+      }
+
+      // #3928 — a residual-drift failure is NOT a "stopped partway" failure
+      // and must not be narrated as one. The agents ARE on the target and
+      // the pin IS committed; what failed is convergence of a component the
+      // roll was answerable for. Saying "Rolled before stop" here would send
+      // the operator to re-run the agent roll, which is already done and
+      // would not touch the component that is actually behind. Name the
+      // components and the per-component remediation instead — the warnings
+      // printed above carry the exact command for each.
+      if (!result.ok && result.failedStep === VERIFY_COMPONENTS_STEP) {
+        process.stderr.write(
+          `\n✗ Rollout INCOMPLETE — ${(result.drifted ?? []).length} component(s) ` +
+            `still behind ${target}: ${(result.drifted ?? []).join(", ") || "unknown"}.\n` +
+            `  ${result.rolled.length} agent(s) DID reach ${target} and the pin is ` +
+            `committed — re-running the agent roll will not fix this.\n` +
+            `  Run the per-component command named in the warning(s) above, then ` +
+            `\`switchroom update --check\` to confirm the host is converged.\n`,
+        );
+        process.exitCode = 1;
+        return;
       }
 
       if (!result.ok) {

--- a/src/cli/webd.test.ts
+++ b/src/cli/webd.test.ts
@@ -194,4 +194,28 @@ describe("resolveWebHostHome (SWITCHROOM_HOST_HOME preference + /host-home poiso
     ).toThrow(/SWITCHROOM_HOST_HOME/);
     expect(() => resolveWebHostHome({}, "/host-home/sub")).toThrow(/host bind source/);
   });
+
+  it("REFUSES every in-container prefix, not just /host-home (#3928)", () => {
+    // #3928 made the operator uid resolvable under root, which is what
+    // lets an agent/hostd container run `webd install` at all — and that
+    // newly reaches call sites whose homedir() is an AGENT state dir
+    // (`/state/agent/home`), not `/host-home`. Before, a two-prefix check
+    // would have waved those through and generated a compose file binding
+    // a path that does not exist on the host. The refusal now delegates to
+    // the SHARED list (`CONTAINER_ROOT_PREFIXES`, src/agents/compose.ts),
+    // so a prefix added there is covered here for free.
+    for (const poison of [
+      "/state/agent/home",
+      "/state",
+      "/run/whatever",
+      "/host-home",
+    ]) {
+      expect(() => resolveWebHostHome({}, poison)).toThrow(/refusing to generate/);
+      expect(() =>
+        resolveWebHostHome({ SWITCHROOM_HOST_HOME: poison }, "/home/operator"),
+      ).toThrow(/refusing to generate/);
+    }
+    // …and a real host home still passes.
+    expect(resolveWebHostHome({}, "/home/operator")).toBe("/home/operator");
+  });
 });

--- a/src/cli/webd.ts
+++ b/src/cli/webd.ts
@@ -45,6 +45,7 @@ import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { getConfig, withConfigError } from "./helpers.js";
 import { resolveOperatorUid } from "./operator-uid.js";
+import { assertPlausibleHostHome } from "../agents/compose.js";
 import { resolveImageTag, resolveRelease, type ReleaseBlockShape } from "../config/release-resolve.js";
 import { checkDowngrade } from "./deploy-version-guard.js";
 import { removeStaleContainerIfNeeded } from "./singleton-stale-cleanup.js";
@@ -86,7 +87,17 @@ export function resolveWebImageTag(
  * as a bind SOURCE would make Docker auto-create empty `/host-home/...` dirs
  * on the host: the receiver would see no webhook secrets, no web-token, no
  * per-agent webhook.sock — silent total breakage. The backstop refuses to
- * ever emit a `/host-home` source — fail loud with the recovery path.
+ * ever emit an in-container source — fail loud with the recovery path.
+ *
+ * #3928 — the refusal set is now the SHARED one. This used to hardcode a
+ * single `/host-home` literal, which was enough while `webd install` was
+ * only reachable from the host shell or from hostd (whose HOME *is*
+ * `/host-home`). Making the operator uid resolvable under root (see
+ * `resolveOperatorUidFromOwnership`) makes this command reachable from an
+ * agent container too, whose HOME is `/state/agent/home` — a path the old
+ * literal check waved straight through. `assertPlausibleHostHome` owns the
+ * full in-container prefix list (`/host-home`, `/state`, `/run`) for the
+ * agent-fleet generator; deferring to it means webd cannot drift from it.
  */
 export function resolveWebHostHome(
   env: NodeJS.ProcessEnv = process.env,
@@ -94,14 +105,16 @@ export function resolveWebHostHome(
 ): string {
   const fromEnv = env.SWITCHROOM_HOST_HOME?.trim();
   const resolved = fromEnv && fromEnv.length > 0 ? fromEnv : home;
-  if (resolved === "/host-home" || resolved.startsWith("/host-home/")) {
+  try {
+    assertPlausibleHostHome(resolved);
+  } catch {
     throw new Error(
       `switchroom webd install: refusing to generate — the host home resolved to ` +
-        `"${resolved}", the in-container mount point of the operator home (never a ` +
-        `valid host bind source). Emitting it would make Docker create empty ` +
-        `/host-home dirs on the host and break every webhook forward + secret read.\n\n` +
-        `Recovery: run \`switchroom webd install\` from the HOST shell, or set ` +
-        `SWITCHROOM_HOST_HOME to the real host home first.`,
+        `"${resolved}", an in-container path (never a valid host bind source). ` +
+        `Emitting it would make Docker create empty dirs on the host and break ` +
+        `every webhook forward + secret read.\n\n` +
+        `Recovery: set SWITCHROOM_HOST_HOME to the real host home, or drive the ` +
+        `install from hostd / the host shell (both set it).`,
     );
   }
   return resolved;
@@ -288,14 +301,32 @@ async function doInstall(opts: InstallOptions, program: Command): Promise<void> 
   // or with an unknown uid — a root-mode forward is silently 503'd by
   // every agent gateway, which is the exact silent-breakage class this
   // migration exists to kill.
+  //
+  // #3928 amendment — this used to tell the operator to "open a shell as
+  // the operator user", which is the one thing switchroom's design says
+  // they should never have to do: the fleet is driven from Telegram, and
+  // an agent/hostd container is root with no SUDO_UID by construction, so
+  // the refusal made `switchroom-web` UNUPDATEABLE from the managed path.
+  // `resolveOperatorUid` now derives the uid from the owner of the
+  // switchroom home when the env/syscall tiers come up empty, so this
+  // branch is reached only when the uid genuinely cannot be determined —
+  // and the recovery it names is a CONFIG fix, not a shell.
   const operatorUid = resolveOperatorUid();
   if (operatorUid === undefined) {
     console.error(
       chalk.red(
-        "Could not resolve the operator uid (no SUDO_UID and getuid() is 0 or unavailable).\n" +
+        "Could not resolve the operator uid.\n" +
           "The web container must run as the operator uid so its webhook forwards pass\n" +
-          "each agent gateway's peercred ACL. Run `switchroom webd install` as the\n" +
-          "operator user (not root), or under `sudo` from the operator's shell.",
+          "each agent gateway's peercred ACL; running as root would be silently 503'd.\n" +
+          "\n" +
+          "Tried, in order: SUDO_UID, this process's own uid (non-root only),\n" +
+          "SWITCHROOM_HOSTD_OPERATOR_UID, and the owner of ~/.switchroom.\n" +
+          "\n" +
+          "Recovery (no shell required): re-run `switchroom hostd install` so the\n" +
+          "hostd container carries SWITCHROOM_HOSTD_OPERATOR_UID, or make\n" +
+          "~/.switchroom owned by the operator account (`chown -R <operator>:<operator>\n" +
+          "~/.switchroom`) so it can be derived. If neither is possible, set\n" +
+          "SWITCHROOM_HOSTD_OPERATOR_UID to the operator's numeric uid.",
       ),
     );
     process.exit(1);

--- a/src/host-control/audit-reader.ts
+++ b/src/host-control/audit-reader.ts
@@ -61,6 +61,9 @@ export interface AuditEntry {
   failed_step?: string;
   /** Agent that failed the version assert (rollout rows). */
   failed_agent?: string;
+  /** Components still behind the target after the roll (#3928). Present on
+   *  rollout terminal rows with `failed_step === "verify-components"`. */
+  drifted?: string[];
   // ─── Rollout phase rows (#2726) ────────────────────────────────────
   /** Agent named in a per-phase rollout row (agent-start/-done, canary-*). */
   agent?: string;
@@ -317,6 +320,11 @@ export function parseAuditLine(line: string): AuditEntry | null {
   }
   if (typeof o.failed_step === "string") entry.failed_step = o.failed_step;
   if (typeof o.failed_agent === "string") entry.failed_agent = o.failed_agent;
+  // #3928 — components the roll left behind, so a `get_status` served from
+  // the durable log (in-memory entry evicted) still names them.
+  if (Array.isArray(o.drifted) && o.drifted.every((x) => typeof x === "string")) {
+    entry.drifted = o.drifted as string[];
+  }
   // Rollout phase rows (#2726) — per-phase agent/n/m context.
   if (typeof o.agent === "string") entry.agent = o.agent;
   if (typeof o.n === "number") entry.n = o.n;

--- a/src/host-control/render-rollout-status.ts
+++ b/src/host-control/render-rollout-status.ts
@@ -19,6 +19,13 @@
  * summary incl. elapsed total and the deferred host-side components.
  */
 
+// Imported, not re-declared: the renderer branches on this exact step
+// label, and a local copy would be one more place for "what does rollout
+// call this" to drift — the class of bug this whole change exists to kill
+// (#3928). cli/rollout.js does not import host-control, so no cycle; both
+// runtime consumers of this renderer already load it.
+import { VERIFY_COMPONENTS_STEP as VERIFY_COMPONENTS_FAILED_STEP } from "../cli/rollout.js";
+
 /** Per-agent progress an accumulator (the narrator) feeds the renderer. */
 export type AgentRollStatus = "pending" | "running" | "done" | "failed";
 
@@ -69,6 +76,16 @@ export interface RolloutRenderState {
   failedAgent?: string;
   /** Version detected on the failed agent (null = unreachable). */
   got?: string | null;
+  /**
+   * Components still BEHIND the target after the roll (#3928), set with
+   * `failedStep === "verify-components"`. Rendered as its own terminal
+   * shape: the agents DID roll, so "STOPPED — rolled before stop" would
+   * misdescribe it and send the operator to re-run a roll that cannot fix
+   * the stale component. This is the Telegram-side answer to "what is
+   * still behind?", which is the only place the operator is supposed to
+   * need to look.
+   */
+  drifted?: string[];
 }
 
 /** Human-readable one-liner for the current phase. */
@@ -186,13 +203,28 @@ function etaLine(s: RolloutRenderState): string | null {
   return `~${formatDurationMs(meanMs * remaining)} left (rough est.)`;
 }
 
-/** What stays on the prior version after an agent-invoked (hostd) roll, and
- *  the host-side commands that update each. */
+/**
+ * What genuinely stays behind after a COMPLETED roll, and the host-side
+ * command for each.
+ *
+ * #3928 — this used to list `switchroom-web` as "still on the prior
+ * version — run host-side". That claim is now provably false on a
+ * completed roll: `refresh-web` is in the plan on BOTH paths, and the
+ * terminal `verify-components` gate FAILS the roll if web is still
+ * behind — so a ✅ card means web converged. Leaving the line in would
+ * send an operator who has no host shell (the entire premise of the
+ * managed path) to run a command that is already done.
+ *
+ * What remains is only what no roll can converge: the operator's own
+ * host CLI (`npm i -g`, nothing in the plan touches it), and a hostd
+ * TEMPLATE regen, which matters only when a release changes hostd's
+ * mounts/env — the image tag itself is advanced by the self-bump.
+ */
 function deferredLines(target: string): string[] {
   const bare = target.trim().replace(/^v/, "");
   return [
-    `**Deferred (still on the prior version — run host-side):**`,
-    `- \`switchroom-web\` — \`switchroom webd install --tag ${target}\``,
+    `**Verified on ${target}** — every component this roll owned passed \`verify-components\`, so this is host convergence, not just the agents. Anything the roll was told to skip is named in its warnings.`,
+    `**Still host-side (nothing in a roll can do these):**`,
     `- host operator CLI — \`sudo npm i -g switchroom@${bare}\``,
     `- hostd template regen (only if the release changed hostd mounts/env) — \`switchroom hostd install --tag ${target}\``,
   ];
@@ -233,6 +265,35 @@ function renderWith(s: RolloutRenderState, compact: boolean): string {
     parts.push(summary);
     if (checklist.length > 0) parts.push("", ...checklist);
     if (s.deferred !== false) parts.push("", ...deferredLines(s.target));
+    return parts.join("\n");
+  }
+
+  // #3928 — residual component drift. Distinct from "STOPPED": every agent
+  // reached the target and the pin is committed; a component the roll owned
+  // did not converge. Name it, and name the fact that re-rolling is not the
+  // remedy — the operator reads this in Telegram and has no host shell.
+  if (s.terminal === "error" && s.failedStep === VERIFY_COMPONENTS_FAILED_STEP) {
+    const drifted = s.drifted ?? [];
+    const parts = [headerLine(s, "⚠️")];
+    let summary =
+      `**INCOMPLETE** — ${rolledCount}${s.m !== undefined ? `/${s.m}` : ""} ` +
+      `agent(s) reached ${s.target}`;
+    if (elapsedMs !== undefined) summary += ` in ${formatDurationMs(elapsedMs)}`;
+    summary += `, but the host did NOT fully converge.`;
+    parts.push(summary);
+    parts.push(
+      "",
+      `**Still behind ${s.target}:** ` +
+        (drifted.length > 0
+          ? drifted.map((d) => `\`${d}\``).join(", ")
+          : "one or more components (see the roll's warnings)"),
+    );
+    parts.push(
+      "",
+      `Re-running the roll will NOT fix this — the agents are already on ` +
+        `target. Finish the stale component(s), then \`switchroom update --check\`.`,
+    );
+    if (checklist.length > 0) parts.push("", ...checklist);
     return parts.join("\n");
   }
 

--- a/src/host-control/rollout-narrator.test.ts
+++ b/src/host-control/rollout-narrator.test.ts
@@ -296,6 +296,32 @@ describe("LogTailRolloutNarrator", () => {
     expect(t).toContain("test-harness");
   });
 
+  it("carries the drifted component names onto the Telegram card (#3928)", async () => {
+    // End-to-end for the operator-facing half of #3928: the roll's
+    // `drifted[]` must survive sentinel → StatusEntry → narrator → render,
+    // because Telegram is the only surface the operator has.
+    const relay = makeRelay(100);
+    const n = new LogTailRolloutNarrator(relay, { debounceMs: 500 });
+    const entry = makeEntry();
+    n.onPhase(entry, phase("canary-start", { agent: "test-harness", n: 1, m: 2 }));
+    await vi.runAllTimersAsync();
+
+    n.onTerminal(
+      makeEntry({
+        result: "error",
+        rolled: ["test-harness", "klanker"],
+        failed_step: "verify-components",
+        drifted: ["switchroom-web", "switchroom-hindsight-autoheal"],
+      }),
+    );
+    await vi.runAllTimersAsync();
+    const t = relay.edits.at(-1)!.text;
+    expect(t).toContain("INCOMPLETE");
+    expect(t).toContain("switchroom-web");
+    expect(t).toContain("switchroom-hindsight-autoheal");
+    expect(t).toContain("Re-running the roll will NOT fix this");
+  });
+
   it("terminal before any phase still posts the final message", async () => {
     const relay = makeRelay(100);
     const n = new LogTailRolloutNarrator(relay, { debounceMs: 500 });

--- a/src/host-control/rollout-narrator.ts
+++ b/src/host-control/rollout-narrator.ts
@@ -329,6 +329,12 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
         ...(entry.failed_step ? { failedStep: entry.failed_step } : {}),
         ...(entry.failed_agent ? { failedAgent: entry.failed_agent } : {}),
         ...(entry.got !== undefined ? { got: entry.got } : {}),
+        // #3928 — the narration card is the operator's live view of the roll;
+        // without this it would freeze on a bare "STOPPED at
+        // verify-components" and never name what is actually stale.
+        ...(entry.drifted && entry.drifted.length > 0
+          ? { drifted: entry.drifted }
+          : {}),
         ...(st.agents.length > 0 ? { agents: st.agents } : {}),
         ...(st.render.m !== undefined ? { m: st.render.m } : {}),
         requestId: entry.request_id,

--- a/src/host-control/rollout-observability.test.ts
+++ b/src/host-control/rollout-observability.test.ts
@@ -208,11 +208,27 @@ describe("renderRolloutStatus", () => {
     expect(out).toContain("Done");
     expect(out).toContain("rolled 2/2 agent(s) in 8m 12s");
     expect(out).toContain("`test-harness`, `clerk`");
-    // Deferred host-side components with their exact update commands.
-    expect(out).toContain("Deferred");
-    expect(out).toContain("switchroom webd install --tag v1.2.3");
+    // What is genuinely still host-side, with its exact command.
+    expect(out).toContain("Still host-side");
     expect(out).toContain("sudo npm i -g switchroom@1.2.3");
     expect(out).toContain("switchroom hostd install --tag v1.2.3");
+  });
+
+  it("a ✅ card no longer claims switchroom-web is stale (#3928)", () => {
+    // `refresh-web` is in the plan on both paths and `verify-components`
+    // FAILS the roll when web is behind — so a completed card telling the
+    // operator to go run `webd install` host-side is both false and the
+    // exact "go open a shell" instruction the managed path exists to
+    // eliminate.
+    const out = renderRolloutStatus({
+      target: "v1.2.3",
+      terminal: "completed",
+      rolled: ["test-harness", "clerk"],
+      m: 2,
+    });
+    expect(out).not.toContain("switchroom webd install");
+    expect(out).not.toContain("still on the prior version");
+    expect(out).toContain("Verified on v1.2.3");
   });
 
   it("renders the ❌ terminal-error summary with the failed step + agent", () => {
@@ -234,6 +250,42 @@ describe("renderRolloutStatus", () => {
     expect(out).toContain("after 1m 5s");
     // A failed roll must NOT advertise the deferred-update commands.
     expect(out).not.toContain("Deferred");
+  });
+
+  it("renders residual component drift as INCOMPLETE, naming what is behind (#3928)", () => {
+    // The operator reads THIS in Telegram and has no host shell, so the
+    // card must distinguish "the roll stopped, agents may be split" from
+    // "every agent is on target, two components are not" — and must not
+    // suggest re-rolling, which cannot fix it.
+    const out = renderRolloutStatus({
+      target: "v0.19.30",
+      terminal: "error",
+      failedStep: "verify-components",
+      drifted: ["switchroom-web", "switchroom-hindsight-autoheal"],
+      rolled: ["test-harness", "klanker"],
+      m: 2,
+      elapsedMs: 492_000,
+    });
+    expect(out.startsWith("⚠️")).toBe(true);
+    expect(out).toContain("INCOMPLETE");
+    expect(out).toContain("2/2 agent(s) reached v0.19.30");
+    expect(out).toContain("`switchroom-web`");
+    expect(out).toContain("`switchroom-hindsight-autoheal`");
+    expect(out).toContain("Re-running the roll will NOT fix this");
+    // Not the generic STOPPED wording, and no "everything is done" claim.
+    expect(out).not.toContain("STOPPED");
+    expect(out).not.toContain("Deferred");
+  });
+
+  it("still renders an INCOMPLETE card when the drift list did not survive", () => {
+    const out = renderRolloutStatus({
+      target: "v0.19.30",
+      terminal: "error",
+      failedStep: "verify-components",
+      rolled: ["klanker"],
+    });
+    expect(out).toContain("INCOMPLETE");
+    expect(out).toContain("see the roll's warnings");
   });
 
   it("code-spans agent names everywhere (underscores must not italicize in GFM)", () => {

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -370,6 +370,19 @@ export interface StatusEntry {
   failed_step?: string;
   /** Agent that failed the version assert (when failed_step is restart). */
   failed_agent?: string;
+  /**
+   * Components still BEHIND the target after the roll (#3928). Set only
+   * when `failed_step === "verify-components"` — the roll's own terminal
+   * convergence proof failed, i.e. every agent reached the target but a
+   * component the roll was answerable for (`switchroom-web`,
+   * `switchroom-hindsight-autoheal`, …) did not.
+   *
+   * Carried as structured data rather than left in the stderr tail so an
+   * operator reading `get_status` from TELEGRAM is told exactly which
+   * components are stranded — the whole point of the managed path is that
+   * they never have to open a host shell to find out.
+   */
+  drifted?: string[];
   /** Actual version detected on failed_agent (null = unreachable). BONUS #2458 got-field gap. */
   got?: string | null;
   /**
@@ -4175,6 +4188,11 @@ export class HostdServer {
           entry.rolled = parsed.rolled;
           if (parsed.failedStep) entry.failed_step = parsed.failedStep;
           if (parsed.failedAgent) entry.failed_agent = parsed.failedAgent;
+          // #3928 — the components the roll left behind. Lifted out of the
+          // sentinel so the Telegram-side `get_status` names them.
+          if (parsed.drifted && parsed.drifted.length > 0) {
+            entry.drifted = parsed.drifted;
+          }
           // BONUS (#2458 got-field gap): the sentinel carries `got` (the
           // actual version detected on the failed agent, or null when
           // unreachable). Preserve it so get_status readers can surface the
@@ -4307,13 +4325,29 @@ export class HostdServer {
     entry: StatusEntry,
     priorPin: string | undefined,
   ): Promise<void> {
-    const notes: string[] = [
-      `Unattended auto-update roll to ${entry.pin ?? "?"} FAILED at ` +
-        `${entry.failed_step ?? "unknown step"}` +
-        `${entry.failed_agent ? ` (agent ${entry.failed_agent})` : ""}. ` +
-        `Unattended retries of this version are disabled; fix the cause, ` +
-        `then roll manually (\`switchroom rollout --pin ${entry.pin ?? "vX.Y.Z"}\`).`,
-    ];
+    // #3928 — a residual-drift failure is a DIFFERENT operator instruction
+    // from a stopped-partway failure. The agents reached the target; what
+    // did not converge is a named component. Telling the operator to
+    // "re-run the roll" here would be wrong (it would not touch the stale
+    // component), so name the components instead.
+    const drifted = entry.drifted ?? [];
+    const notes: string[] =
+      entry.failed_step === "verify-components"
+        ? [
+            `Unattended auto-update roll to ${entry.pin ?? "?"} rolled ` +
+              `${(entry.rolled ?? []).length} agent(s) but did NOT converge the ` +
+              `whole host: ${drifted.join(", ") || "one or more components"} ` +
+              `still behind. Re-running the roll will not fix this — run the ` +
+              `per-component install named in the rollout warnings, then ` +
+              `\`switchroom update --check\` to confirm.`,
+          ]
+        : [
+            `Unattended auto-update roll to ${entry.pin ?? "?"} FAILED at ` +
+              `${entry.failed_step ?? "unknown step"}` +
+              `${entry.failed_agent ? ` (agent ${entry.failed_agent})` : ""}. ` +
+              `Unattended retries of this version are disabled; fix the cause, ` +
+              `then roll manually (\`switchroom rollout --pin ${entry.pin ?? "vX.Y.Z"}\`).`,
+          ];
     try {
       notes.push(...(await this.recoverFailedAutoRollout(entry, priorPin)));
     } catch (e) {
@@ -4360,6 +4394,21 @@ export class HostdServer {
   ): Promise<string[]> {
     const notes: string[] = [];
     const rolledCount = (entry.rolled ?? []).length;
+    // #3928 — residual component drift is NOT a partially-applied roll, and
+    // both generic branches below would misdescribe it: the agent fleet is
+    // uniformly on the target (not "mixed"), and the change DID land (not
+    // "nothing to revert"). Rolling back here would be actively wrong — it
+    // would drag a converged fleet backwards to fix a stale singleton.
+    if (entry.failed_step === "verify-components") {
+      notes.push(
+        `No automatic rollback: the agent fleet reached ` +
+          `${entry.pin ?? "the target"} and the pin is committed — the gap is ` +
+          `${(entry.drifted ?? []).join(", ") || "a component"}, not the fleet. ` +
+          `Rolling back would move working agents backwards; converge the ` +
+          `named component(s) forward instead.`,
+      );
+      return notes;
+    }
     const beforeAnyAgent =
       entry.failed_step === "apply" ||
       (entry.failed_step === "restart-agent" && rolledCount === 0);
@@ -4481,6 +4530,9 @@ export class HostdServer {
         ...(entry.failed_step ? { failedStep: entry.failed_step } : {}),
         ...(entry.failed_agent ? { failedAgent: entry.failed_agent } : {}),
         ...(entry.got !== undefined ? { got: entry.got } : {}),
+        ...(entry.drifted && entry.drifted.length > 0
+          ? { drifted: entry.drifted }
+          : {}),
       });
       this.opts.rolloutRelay.postTerminal({
         requestId: entry.request_id,
@@ -4597,6 +4649,9 @@ export class HostdServer {
       ...(row.agent ? { agent: row.agent } : {}),
       ...(row.failed_step ? { failedStep: row.failed_step } : {}),
       ...(row.failed_agent ? { failedAgent: row.failed_agent } : {}),
+      // #3928 — same field the live path emits, so a reader gets the
+      // stranded component names whether the entry is live or replayed.
+      ...(row.drifted && row.drifted.length > 0 ? { drifted: row.drifted } : {}),
       ...(row.pin ? { pin: row.pin } : {}),
       ...(row.prior_pin ? { prior_pin: row.prior_pin } : {}),
     });
@@ -4641,6 +4696,11 @@ export class HostdServer {
             ...(entry.failed_agent ? { failedAgent: entry.failed_agent } : {}),
             // BONUS (#2458 got-field gap): include `got` when present.
             ...(entry.got !== undefined ? { got: entry.got } : {}),
+            // #3928 — components left behind by the roll. Structured so a
+            // Telegram `get_status` can name them without a host shell.
+            ...(entry.drifted && entry.drifted.length > 0
+              ? { drifted: entry.drifted }
+              : {}),
             ...(entry.pin ? { pin: entry.pin } : {}),
             // Prior-pin (#2492) surfaced structurally too, so a rollback-aware
             // reader gets it from get_status, not only the durable terminal row.
@@ -4843,6 +4903,9 @@ export class HostdServer {
       ...(entry.rolled ? { rolled: entry.rolled } : {}),
       ...(entry.failed_step ? { failed_step: entry.failed_step } : {}),
       ...(entry.failed_agent ? { failed_agent: entry.failed_agent } : {}),
+      // #3928 — components left behind. Durable so `rolloutStatusFromLog`
+      // can still name them after the in-memory entry is evicted.
+      ...(entry.drifted && entry.drifted.length > 0 ? { drifted: entry.drifted } : {}),
       // BONUS (#2458 got-field gap): version detected on failed agent.
       ...(entry.got !== undefined ? { got: entry.got } : {}),
       // Update-apply deferral result (#2458) — only on update_apply rows.

--- a/src/mcp/hostd/server.ts
+++ b/src/mcp/hostd/server.ts
@@ -405,7 +405,12 @@ export const TOOLS = [
       "The web + hindsight singletons are refreshed in-plan on this path " +
       "(only the hostd template regen + host operator CLI stay host-side; " +
       "the terminal warnings name exactly what is still on the prior " +
-      "version and the commands to finish). By default downgrade pins " +
+      "version and the commands to finish). The roll ENDS by re-reading " +
+      "the same component inventory `update --check` uses and FAILS if " +
+      "any in-scope component is still behind the target (#3928), so a " +
+      "`completed` result means the host actually converged — never just " +
+      "the agents. On that failure get_status returns " +
+      "`failedStep: \"verify-components\"` plus `drifted[]`. By default downgrade pins " +
       "are rejected — pass `allow_downgrade: true` for the operator-approved " +
       "rollback path to a known-good earlier tag; all other safety rails " +
       "(canary order, version-assert, stop-on-mismatch) apply unchanged. " +
@@ -539,6 +544,11 @@ export const TOOLS = [
       "carries the current phase, n/m counters, rolled[] agents, " +
       "failedStep/failedAgent and pin, and it keeps working across a " +
       "hostd self-bump/restart via the durable audit-log fallback. " +
+      "When `failedStep` is `verify-components` the payload also " +
+      "carries `drifted[]` — the components that are STILL behind the " +
+      "target after the roll. Report those names verbatim: re-running " +
+      "the roll will not fix them, the named component's own install " +
+      "must be run. " +
       "This is the tool the `rollout` description tells you to poll " +
       "with the returned request_id. Without `request_id`, falls back " +
       "to reading the most recent terminal `update_apply` audit row " +

--- a/tests/host-control/audit-reader.test.ts
+++ b/tests/host-control/audit-reader.test.ts
@@ -411,3 +411,43 @@ describe("parseAuditLine — prior_pin capture (#2492)", () => {
     expect(e!.prior_pin).toBeUndefined();
   });
 });
+
+describe("parseAuditLine — drifted components (#3928)", () => {
+  const base = {
+    ts: "2026-07-29T00:00:00.000Z",
+    op: "rollout",
+    phase: "terminal",
+    caller: { kind: "operator" },
+    request_id: "roll-3928",
+    result: "error",
+    exit_code: 1,
+    duration_ms: 492_000,
+    failed_step: "verify-components",
+  };
+
+  it("round-trips drifted so a get_status served from the LOG still names them", () => {
+    // The in-memory status entry is evicted after a while; the durable log
+    // is then the only place the component names exist. Dropping them here
+    // would leave the operator with "the roll failed" and nothing to fix.
+    const e = parseAuditLine(
+      JSON.stringify({
+        ...base,
+        drifted: ["switchroom-web", "switchroom-hindsight-autoheal"],
+      }),
+    );
+    expect(e!.failed_step).toBe("verify-components");
+    expect(e!.drifted).toEqual([
+      "switchroom-web",
+      "switchroom-hindsight-autoheal",
+    ]);
+  });
+
+  it("drops a malformed drifted field instead of trusting it", () => {
+    expect(parseAuditLine(JSON.stringify({ ...base, drifted: "web" }))!.drifted)
+      .toBeUndefined();
+    expect(
+      parseAuditLine(JSON.stringify({ ...base, drifted: ["web", 7] }))!.drifted,
+    ).toBeUndefined();
+    expect(parseAuditLine(JSON.stringify(base))!.drifted).toBeUndefined();
+  });
+});

--- a/tests/operator-uid.test.ts
+++ b/tests/operator-uid.test.ts
@@ -2,10 +2,26 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 
 import {
   resolveOperatorUid,
+  resolveOperatorUidFromOwnership,
+  operatorHomeCandidates,
   restoreOperatorOwnership,
   operatorOwnedPaths,
+  type OperatorUidOwnershipDeps,
   type OwnershipRestoreDeps,
 } from "../src/cli/operator-uid.js";
+
+/**
+ * Ownership tier stubbed to "nothing on disk" — the pre-#3928 behaviour.
+ * Passed explicitly wherever a test asserts the env/syscall tiers in
+ * isolation, so the assertion never depends on whether the machine
+ * running the suite happens to have a real `~/.switchroom`.
+ */
+const NO_OWNERSHIP: OperatorUidOwnershipDeps = {
+  env: {},
+  home: "/nonexistent",
+  exists: () => false,
+  statUid: () => undefined,
+};
 
 const savedSudoUid = process.env.SUDO_UID;
 const savedHostdUid = process.env.SWITCHROOM_HOSTD_OPERATOR_UID;
@@ -31,11 +47,11 @@ describe("resolveOperatorUid", () => {
     expect(resolveOperatorUid()).toBe(1000);
   });
 
-  it("returns undefined when running as real root with no SUDO_UID and no hostd uid", () => {
+  it("returns undefined when running as real root with no SUDO_UID, no hostd uid, and no readable switchroom home", () => {
     delete process.env.SUDO_UID;
     delete process.env.SWITCHROOM_HOSTD_OPERATOR_UID;
     vi.spyOn(process, "getuid").mockReturnValue(0);
-    expect(resolveOperatorUid()).toBeUndefined();
+    expect(resolveOperatorUid(NO_OWNERSHIP)).toBeUndefined();
   });
 
   it("falls back to SWITCHROOM_HOSTD_OPERATOR_UID under root with no SUDO_UID (hostd-spawned apply)", () => {
@@ -58,9 +74,117 @@ describe("resolveOperatorUid", () => {
     delete process.env.SUDO_UID;
     vi.spyOn(process, "getuid").mockReturnValue(0);
     process.env.SWITCHROOM_HOSTD_OPERATOR_UID = "0";
-    expect(resolveOperatorUid()).toBeUndefined();
+    expect(resolveOperatorUid(NO_OWNERSHIP)).toBeUndefined();
     process.env.SWITCHROOM_HOSTD_OPERATOR_UID = "notanumber";
-    expect(resolveOperatorUid()).toBeUndefined();
+    expect(resolveOperatorUid(NO_OWNERSHIP)).toBeUndefined();
+  });
+
+  // #3928 amendment — the whole point of switchroom is that the operator
+  // drives the fleet from Telegram. An agent / hostd container is root
+  // with no SUDO_UID by construction, so before this tier the CLI simply
+  // refused (`webd install`) or silently degraded (`hostd install`
+  // omitting SWITCHROOM_HOSTD_OPERATOR_UID from the compose it writes,
+  // which propagates the same failure into the container it creates).
+  it("derives the operator uid from the owner of ~/.switchroom under root with no env hints", () => {
+    delete process.env.SUDO_UID;
+    delete process.env.SWITCHROOM_HOSTD_OPERATOR_UID;
+    vi.spyOn(process, "getuid").mockReturnValue(0);
+    expect(
+      resolveOperatorUid({
+        env: {},
+        home: "/host-home",
+        exists: (p) => p === "/host-home/.switchroom/switchroom.yaml",
+        statUid: (p) => (p === "/host-home/.switchroom" ? 1000 : undefined),
+      }),
+    ).toBe(1000);
+  });
+
+  it("never lets the ownership tier override a real SUDO_UID / getuid()", () => {
+    const ownedBySomeoneElse: OperatorUidOwnershipDeps = {
+      env: {},
+      home: "/host-home",
+      exists: () => true,
+      statUid: () => 4242,
+    };
+    process.env.SUDO_UID = "1234";
+    expect(resolveOperatorUid(ownedBySomeoneElse)).toBe(1234);
+    delete process.env.SUDO_UID;
+    vi.spyOn(process, "getuid").mockReturnValue(1001);
+    expect(resolveOperatorUid(ownedBySomeoneElse)).toBe(1001);
+  });
+});
+
+describe("resolveOperatorUidFromOwnership (#3928)", () => {
+  it("reads the DIRECTORY's owner, not the config file's", () => {
+    // Load-bearing: on the reference host `~/.switchroom/switchroom.yaml`
+    // is root-owned (a root-mode `apply` rewrote it) while `~/.switchroom`
+    // itself is still 1000:1000. Statting the file would resolve uid 0 and
+    // be rejected, stranding the operator exactly as before.
+    const statted: string[] = [];
+    const uid = resolveOperatorUidFromOwnership({
+      env: {},
+      home: "/host-home",
+      exists: () => true,
+      statUid: (p) => {
+        statted.push(p);
+        return p.endsWith(".yaml") ? 0 : 1000;
+      },
+    });
+    expect(uid).toBe(1000);
+    expect(statted).toEqual(["/host-home/.switchroom"]);
+  });
+
+  it("REJECTS a root-owned switchroom home rather than adopting uid 0", () => {
+    // Adopting 0 would write `user: "0:0"` into the web compose, and every
+    // agent gateway's peercred ACL would silently 503 the webhook forward —
+    // the exact breakage the original refusal existed to prevent.
+    expect(
+      resolveOperatorUidFromOwnership({
+        env: {},
+        home: "/root",
+        exists: () => true,
+        statUid: () => 0,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("ignores a .switchroom dir with no switchroom.yaml in it", () => {
+    expect(
+      resolveOperatorUidFromOwnership({
+        env: {},
+        home: "/somewhere",
+        exists: () => false,
+        statUid: () => 1000,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("falls through a candidate that is not visible here to one that is", () => {
+    // Inside hostd / an agent container SWITCHROOM_HOST_HOME is the HOST
+    // path (`/home/op`), which does not exist in that mount namespace; the
+    // operator home is visible at the bind mount instead.
+    const uid = resolveOperatorUidFromOwnership({
+      env: { SWITCHROOM_HOST_HOME: "/home/op" },
+      home: "/state/agent/home",
+      exists: (p) => p === "/host-home/.switchroom/switchroom.yaml",
+      statUid: (p) => (p === "/host-home/.switchroom" ? 1000 : undefined),
+    });
+    expect(uid).toBe(1000);
+  });
+});
+
+describe("operatorHomeCandidates", () => {
+  it("orders SWITCHROOM_HOST_HOME → process home → /host-home, deduped", () => {
+    expect(
+      operatorHomeCandidates({ SWITCHROOM_HOST_HOME: "/home/op" }, "/host-home"),
+    ).toEqual(["/home/op/.switchroom", "/host-home/.switchroom"]);
+    expect(operatorHomeCandidates({}, "/host-home")).toEqual([
+      "/host-home/.switchroom",
+    ]);
+    expect(operatorHomeCandidates({}, "/root")).toEqual([
+      "/root/.switchroom",
+      "/host-home/.switchroom",
+    ]);
   });
 });
 


### PR DESCRIPTION
Fixes #3928
Fixes #3920


## The bug, and the sharper version of it

`switchroom rollout` rolled the fleet to v0.19.30 and **exited 0** while `switchroom-web` and `switchroom-hindsight-autoheal` stayed on v0.19.26 — and `switchroom update --check`, reading the same host, correctly named both as targets.

Ken's reframing widened it, and the wider version is the one this PR fixes:

> Those host-side commands need to be run by switchroom admin or root agents. The whole point of switchroom is that operators manage from Telegram, no host access.

So "rollout should also cover these two components" was too narrow. The real defect is that **the Telegram-managed path could not update them at all**, and the remediation the tooling offered was "open a host shell" — which is the bug, not the fix.

## Root cause (real source, pre-fix HEAD)

| | derives "in scope" from | on failure |
|---|---|---|
| `update --check` / `doctor` | **enumeratively**, `docker ps` → `src/cli/component-versions.ts` (#3919) | reports |
| `rollout` | a **hardcoded plan-step list** in `planRollout` — `src/cli/rollout.ts:199-220` (`refresh-web` / `refresh-hostd` / `refresh-hindsight`) | `warnings.push(...)`, roll still returns `ok: true` |
| `doctor` (a **third** copy) | a private name-keyed remediation ladder — `src/cli/doctor-component-versions.ts:45-57` | — |

Three derivations of the same fact. Two of them already knew `switchroom-web` → `webd install` and `switchroom-hindsight-autoheal` → `hostd install`; the one that runs the roll couldn't see either. And with no post-roll convergence check anywhere, a refresh step that failed printed one line and the roll still exited green.

**Silent partial success is the deeper defect** — a warning scrolls past once, which is how this survived three releases.

### The Telegram half — verified live, `--dry-run`, nothing mutated

- `switchroom hostd install --tag v0.19.30 --dry-run` as root → **exit 0**
- `switchroom webd install --tag v0.19.30 --dry-run` as root → **hard refusal**: *"Could not resolve the operator uid (no SUDO_UID and getuid() is 0 or unavailable) … Run `switchroom webd install` as the operator user (not root), or under `sudo` from the operator's shell."*
- same command with `SUDO_UID=1000` → **exit 0**

An agent/hostd container is root with no `SUDO_UID` **by construction**. So `switchroom-web` was unupdateable from the managed path — and the roll's own in-plan `refresh-web` step hit the identical wall from inside hostd, degraded it to a warning, and exited green. The peercred invariant it protects is legitimate; the refusal-to-resolve is not, because the uid is sitting on disk.

This is #3920's half of the problem, and #3920 proposed exactly this remedy ("have `webd install` resolve the operator uid from a source that survives a stale compose (e.g. the owner of `~/.switchroom/switchroom.yaml` as seen through the mount)"). One deliberate divergence: this stats the **directory**, not the yaml. On the reference host `~/.switchroom/switchroom.yaml` is `0:0` — a root-mode apply rewrote it — while `~/.switchroom` itself is still `1000:1000`, so statting the file resolves uid 0, gets rejected, and strands the operator exactly as before. #3920's second ask ("stop calling it non-fatal") is the `verify-components` gate above.

There is a recursive version of the same hole: `hostd install` run as root omits `SWITCHROOM_HOSTD_OPERATOR_UID` from the compose it generates (`src/cli/hostd.ts:638` → `hostd.ts:184`), so the hostd container it *creates* can't resolve the uid either. One fix at the `resolveOperatorUid` layer closes both.

## What lands

**1. `src/cli/component-scope.ts` (new) — one source of truth for scope + remediation.**
Maps a component from the *same inventory `update --check` reads* onto the mechanism that owns it. Classification is keyed on the **image repo, never a container-name allowlist** — `switchroom-hindsight-autoheal` runs the **hostd image** (`src/cli/hostd.ts:405-407`), which is exactly how a name list put it nowhere and let it escape every prior scope check. A component that ships tomorrow is classified by the same rules with nobody editing a list; an unrecognised switchroom image defaults to `fleet`, i.e. **gated**, so a new component fails loud rather than being silently out of scope forever. `doctor` now calls `remediationFor()` (`doctor-component-versions.ts`), deleting the third copy.

**2. A terminal `verify-components` step on every rollout plan** — host-shell path, hostd path, and under `--skip-web` (`rollout.ts` `planRollout`). It re-reads the same inventory and, when any component this roll was answerable for is still behind, returns `ok: false`, `failedStep: "verify-components"`, `drifted[]`, and each component's exact fix command. The CLI exits non-zero.

Two deliberate differences from every other failure in `executeRollout`:

- **It runs AFTER `commitPin` and does NOT go through `fail()`.** Every agent came back on the target and the durable pin is *correct*; `fail()` reverts the provisional pin, which would drag the converged fleet backwards on the next reconcile — turning "one singleton is stale" into a fleet-wide downgrade. Nothing here needs rolling **back**; a named component needs finishing **forward**. `recoverFailedAutoRollout` gets the matching branch for the unattended path (it already declined to auto-roll-back past a green canary; now it says the *right* thing rather than "the fleet is mixed").
- **Scope comes from the plan's own steps, not the CLI flags** (`gatedOwners`), so it can never claim responsibility for a step the plan doesn't contain. `--agents <subset>` isn't blamed for agents nobody asked it to roll; `--skip-web` **exempts but still reports** what it skipped. The host operator CLI is never gated — no plan step converges `npm i -g`, and gating it would fail every hostd-driven roll whenever the host CLI lagged the tag (true on the #3928 host itself); `shouldRefuseStaleCli` is the real protection there.

Also fail-loud on the unhappy edges: an unwired collector and a throwing `docker ps` each produce a named warning saying the roll **did not prove** convergence, never a silent pass — and the throw is caught locally precisely so it can't reach `fail()` and revert a good pin.

**3. `webd install` resolves the operator uid without a shell or a hand-set `SUDO_UID`.**
`resolveOperatorUid()` gains a 4th tier: the **owner of `~/.switchroom`** (`src/cli/operator-uid.ts`). Strictly additive — reached only where the three env/syscall tiers already returned `undefined`, so no call that resolves today changes answer. It stats the **directory**, not the yaml inside it (on the reference host the yaml is root-owned after a root-mode apply while the dir is still `1000:1000`), requires a `switchroom.yaml` marker, and **rejects uid 0** — adopting root would write `user: "0:0"` into the web compose and silently 503 every webhook forward, the exact breakage the original refusal existed to prevent. The remaining refusal message now lists the four tiers tried and names **config** recoveries; it no longer tells anyone to open a shell.

New hazard that opens with it, closed in the same commit: making the uid resolvable under root newly reaches call sites whose HOME is `/state/agent/home`, which `resolveWebHostHome`'s old `/host-home`-only literal waved straight through into a compose bind source. It now delegates to the **shared** `assertPlausibleHostHome` (`src/agents/compose.ts:46-53`), so webd cannot drift from the fleet generator's refusal list.

**4. The whole thing is drivable from Telegram.** `rollout` was already a gated MCP verb (`src/mcp/hostd/server.ts:387`) — the unification lands *inside* it, so an operator gets full-coverage convergence from one approval tap. `drifted[]` is carried as structured data the whole way: result sentinel → `StatusEntry` → `get_status` payload → durable audit row → the narration card, which renders a new **⚠️ INCOMPLETE** terminal state naming the stranded components and stating that re-running the roll will not fix them. Both tool descriptions document the new failure shape.

And the ✅ card no longer claims `switchroom-web` is *"still on the prior version — run host-side"* (`render-rollout-status.ts` `deferredLines`). `refresh-web` is in the plan on both paths and `verify-components` now fails the roll if web is behind, so on a completed roll that line was provably false — and it was the exact "go open a shell" instruction the managed path exists to eliminate. What's left is only what no roll can converge: the operator's host CLI, and a hostd *template* regen.

## Tests

`src/cli/rollout.test.ts` gains a suite built on the **literal #3928 host inventory** (fleet + hostd on v0.19.30, `switchroom-web` and `switchroom-hindsight-autoheal` on v0.19.26).

**Proof it would have caught today's bug** — with the terminal gate disabled to simulate pre-fix behaviour:

```
× FAILS the roll and names both stranded components — the exact #3928 host
× gates the autoheal sidecar on the HOSTD-DRIVEN path too, where refresh-hostd is absent
× does NOT revert the durable pin when only the drift gate failed
Tests  3 failed | 8 passed
```

The first one is #3928 verbatim: pre-fix, `executeRollout` returns `ok: true` for that inventory, exactly as production did. Restored, all 139 pass.

These assert **outcomes** — `ok`, `failedStep`, `drifted[]`, the remediation strings the operator is handed, and that the pin is *not* reverted — not code paths. Also new: `component-scope.test.ts` (autoheal-on-the-hostd-image, a third-party image under a switchroom-prefixed container name, the never-gate-the-CLI invariant, `--agents`/`--skip-web` partitioning), ownership-tier cases in `tests/operator-uid.test.ts` (directory-not-file, uid-0-rejected, marker required, container fall-through), the INCOMPLETE render, the narrator's end-to-end carry onto the card, and the audit-row round-trip incl. malformed-input rejection.

Local: 379 scoped tests green, `npm run lint` clean. (38 failures in `tests/host-control/server.test.ts` + the two `config-propose-edit` suites are **pre-existing** in this sandbox — identical 38 on a stashed tree at the same commit; they need process-spawn/bind-mount capabilities this container lacks. CI is the authority.)

## Follow-ups filed, not fixed here

Deliberately out of scope to keep this single-concern; each is filed as its own issue:

- `switchroom update`'s hostd-context `refresh-web` deferral, whose stated reason is wrong (web is its own compose project, not hostd's) and whose real cause was the operator-uid refusal this PR fixes.
- `switchroom update` itself does not gate on residual drift the way `rollout` now does (extends #3922).
- hostd never carries the rollout's `warnings[]` onto the Telegram card, so an *exempt*-component notice (e.g. after `--skip-web`) is invisible there.
- `cli (host)` is a misleading label when the CLI is the hostd container's, not the host operator's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
