### PR TITLE
feat(doctor): surface Hindsight observation-scope saturation before the wall

### DIFF
--- a/src/cli/doctor-observation-scopes.test.ts
+++ b/src/cli/doctor-observation-scopes.test.ts
@@ -1,0 +1,494 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  OBSERVATION_SCOPE_CHECK_NAME,
+  OBSERVATION_SCOPE_WARN_RATIO,
+  checkObservationScopeSaturation,
+  classifyObservationScopeSaturation,
+  computeScopeSaturation,
+  inspectBankScopes,
+  type BankScopeReport,
+  type ObservationScope,
+} from "./doctor-observation-scopes.js";
+
+/**
+ * The defect these tests guard.
+ *
+ * On 2026-07-29 `docker logs switchroom-hindsight` was repeating, roughly every
+ * 40 seconds:
+ *
+ *   [CONSOLIDATION] bank=overlord scope=['0f3640d5-089f-4ea1-b5b0-165fe9ae81bf']
+ *     at observation limit (1009/1000), only updates/deletes allowed
+ *
+ * Consolidation kept running against that full scope — recall, a full
+ * extraction-model call, then a batch that could only update or delete
+ * (engine/consolidation/consolidator.py:1604-1613). It logs at INFO with no
+ * metric attached, so no switchroom surface could report it; a human found it
+ * by reading container logs. Meanwhile overlord carried ~43,700 memories
+ * pending consolidation.
+ *
+ * So the assertions below are about the OUTCOME an operator needs — does the
+ * row go RED, and does it name the bank, the scope and the real numbers — not
+ * about whether the new functions can be called.
+ */
+
+const scope = (tags: string[], count: number): ObservationScope => ({ tags, count });
+
+/** Overlord's live scope table on 2026-07-29, trimmed to the load-bearing rows. */
+const OVERLORD_SCOPES: ObservationScope[] = [
+  scope(["0f3640d5-089f-4ea1-b5b0-165fe9ae81bf"], 1009),
+  scope(["ca9b3dd6-4ff7-47f7-b185-b045bbc87ff7"], 1000),
+  scope(["7c62ce38-ee4b-45d0-8a4e-d407b064d3b5"], 963),
+  scope(["7c62ce38-ee4b-45d0-8a4e-d407b064d3b5", "anti-pattern"], 201),
+  scope(["c7905e1b-0db6-4862-86b6-6b7d3e457bc6"], 935),
+  scope(["d52ae253-2d26-42e5-a86b-9a354cc0ace5"], 641),
+  // The untagged/global scope. The engine never caps it.
+  scope([], 241),
+];
+
+const report = (over: Partial<BankScopeReport> & { bankId: string }): BankScopeReport => ({
+  ok: true,
+  cap: 1000,
+  observationsEnabled: true,
+  hasScopeLimitRules: false,
+  scopeCount: 0,
+  saturated: [],
+  pendingConsolidation: null,
+  ...over,
+});
+
+/** Build the report the probe would produce for a bank, from raw scope rows. */
+const reportFor = (
+  bankId: string,
+  scopes: ObservationScope[],
+  cap = 1000,
+  pendingConsolidation: number | null = null,
+): BankScopeReport =>
+  report({
+    bankId,
+    cap,
+    scopeCount: scopes.length,
+    saturated: computeScopeSaturation(scopes, cap).filter((s) => s.status !== "ok"),
+    pendingConsolidation,
+  });
+
+describe("the live overlord failure", () => {
+  it("FAILS, and names the bank, the scope and 1009/1000", () => {
+    // This is the whole point of the module. A scope at 1009 against a cap of
+    // 1000 with consolidation still running must be RED — the 2026-07 incident
+    // was already a warning-shaped signal (an INFO log) that nobody read.
+    const result = classifyObservationScopeSaturation([
+      reportFor("overlord", OVERLORD_SCOPES, 1000, 43_734),
+    ]);
+
+    expect(result.status).toBe("fail");
+    expect(result.name).toBe(OBSERVATION_SCOPE_CHECK_NAME);
+    expect(result.detail).toContain("overlord");
+    expect(result.detail).toContain("0f3640d5-089f-4ea1-b5b0-165fe9ae81bf");
+    expect(result.detail).toContain("1009/1000");
+  });
+
+  it("reports the pending-consolidation backlog alongside the scope id", () => {
+    // A bare uuid is cryptic. "overlord 43,734" is the symptom an operator
+    // recognises, and it is what made the incident legible in the first place.
+    const result = classifyObservationScopeSaturation([
+      reportFor("overlord", OVERLORD_SCOPES, 1000, 43_734),
+    ]);
+    expect(result.detail).toContain("43,734");
+    expect(result.detail).toContain("pending consolidation");
+  });
+
+  it("carries a fix that points at the cap and at the real counts", () => {
+    const result = classifyObservationScopeSaturation([
+      reportFor("overlord", OVERLORD_SCOPES, 1000, 43_734),
+    ]);
+    expect(result.fix).toContain("HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE");
+    expect(result.fix).toContain("observations/scopes");
+  });
+
+  it("never presents the bank-wide observations DELETE as a per-scope prune", () => {
+    // `DELETE /v1/default/banks/<bank>/observations` is "Clear all
+    // observations": it takes no scope parameter and wipes the bank's entire
+    // consolidated knowledge (verified against the live OpenAPI 2026-07-29).
+    // An earlier draft of this fix string told the operator to call it "for the
+    // scope you are retiring", which is a data-loss instruction dressed as
+    // remediation. This assertion is the guard so it cannot come back.
+    const fix = classifyObservationScopeSaturation([
+      reportFor("overlord", OVERLORD_SCOPES, 1000, 43_734),
+    ]).fix as string;
+    expect(fix).toContain("clears the WHOLE bank");
+    expect(fix).not.toMatch(/DELETE [^.]*observations for the scope/i);
+  });
+});
+
+describe("counting the way the engine counts", () => {
+  it("counts observations whose tags CONTAIN the scope, not just those that equal it", () => {
+    // engine/consolidation/consolidator.py:598-603 —
+    //   WHERE bank_id = $1 AND fact_type = 'observation' AND tags @> $2::varchar[]
+    // `GET /observations/scopes` reports EXACT tag sets instead, so a scope
+    // with tagged children reads far lower than the number the engine enforces.
+    // Live overlord: exact 963, engine-visible 1164 (963 + 201 under the
+    // `anti-pattern` child scope).
+    const sat = computeScopeSaturation(OVERLORD_SCOPES, 1000);
+    const parent = sat.find(
+      (s) => s.tags.length === 1 && s.tags[0] === "7c62ce38-ee4b-45d0-8a4e-d407b064d3b5",
+    );
+    expect(parent).toBeDefined();
+    expect(parent?.exact).toBe(963);
+    expect(parent?.effective).toBe(1164);
+    expect(parent?.status).toBe("fail");
+  });
+
+  it("would report the naive exact count as GREEN on the live klanker scope", () => {
+    // klanker `0291c461-…` on 2026-07-29: exact 792 — 79.2% of the cap, i.e.
+    // BELOW the 80% warn line, so an exact-count check reports it ok — against
+    // an engine-visible 1413, 41% past the cap. This assertion is the reason
+    // the containment fold exists at all.
+    const klanker: ObservationScope[] = [
+      scope(["0291c461-8640-4b6a-9f4e-2f0e5a5f1b7c"], 792),
+      scope(["0291c461-8640-4b6a-9f4e-2f0e5a5f1b7c", "sidechain"], 400),
+      scope(["0291c461-8640-4b6a-9f4e-2f0e5a5f1b7c", "worker"], 221),
+    ];
+    const exactRatio = 792 / 1000;
+    expect(exactRatio).toBeLessThan(OBSERVATION_SCOPE_WARN_RATIO);
+
+    const sat = computeScopeSaturation(klanker, 1000);
+    const worst = sat[0];
+    expect(worst?.effective).toBe(1413);
+    expect(worst?.status).toBe("fail");
+    expect(classifyObservationScopeSaturation([reportFor("klanker", klanker)]).status).toBe(
+      "fail",
+    );
+  });
+
+  it("gives a child scope its own smaller count rather than the parent's", () => {
+    // `[session, anti-pattern]` is a scope in its own right; only observations
+    // carrying BOTH tags count toward it. Folding the parent's 963 into it
+    // would fail a scope with 201 observations and 799 free slots.
+    const sat = computeScopeSaturation(OVERLORD_SCOPES, 1000);
+    const child = sat.find((s) => s.tags.includes("anti-pattern"));
+    expect(child?.effective).toBe(201);
+    expect(child?.status).toBe("ok");
+  });
+
+  it("never counts the untagged scope, which the engine does not cap", () => {
+    // consolidator.py:1605 guards with `if max_obs >= 0 and fact_tags:`, and
+    // _count_observations_for_scope documents "Observations with no tags are
+    // not counted". A bank whose global scope is huge is behaving as designed;
+    // reporting it would be a permanent false FAIL.
+    const sat = computeScopeSaturation([scope([], 50_000), scope(["a"], 10)], 1000);
+    expect(sat.some((s) => s.tags.length === 0)).toBe(false);
+    expect(classifyObservationScopeSaturation([
+      reportFor("bank", [scope([], 50_000), scope(["a"], 10)]),
+    ]).status).toBe("ok");
+  });
+
+  it("is order-insensitive across scopes that share tags", () => {
+    // Tag order is normalized server-side, but containment must not depend on
+    // the order rows arrive in.
+    const forward = computeScopeSaturation(
+      [scope(["a"], 600), scope(["a", "b"], 500)],
+      1000,
+    );
+    const reverse = computeScopeSaturation(
+      [scope(["a", "b"], 500), scope(["a"], 600)],
+      1000,
+    );
+    const pick = (rows: ReturnType<typeof computeScopeSaturation>) =>
+      rows.find((s) => s.tags.length === 1)?.effective;
+    expect(pick(forward)).toBe(1100);
+    expect(pick(reverse)).toBe(1100);
+  });
+});
+
+describe("thresholds", () => {
+  it("warns before the wall, while the scope is still writable", () => {
+    const sat = computeScopeSaturation([scope(["s"], 800)], 1000);
+    expect(sat[0]?.status).toBe("warn");
+    const result = classifyObservationScopeSaturation([
+      reportFor("carrie", [scope(["s"], 800)]),
+    ]);
+    expect(result.status).toBe("warn");
+    expect(result.detail).toContain("carrie/s (800/1000)");
+  });
+
+  it("stays quiet below the warn ratio", () => {
+    expect(computeScopeSaturation([scope(["s"], 799)], 1000)[0]?.status).toBe("ok");
+    expect(
+      classifyObservationScopeSaturation([reportFor("carrie", [scope(["s"], 799)])]).status,
+    ).toBe("ok");
+  });
+
+  it("fails AT the cap, not only past it", () => {
+    // The engine blocks creates when remaining slots hit zero — i.e. at
+    // count == cap, not count > cap (consolidator.py:1608). A `>` here would
+    // report the exact moment output starts being discarded as merely a warn.
+    expect(computeScopeSaturation([scope(["s"], 1000)], 1000)[0]?.status).toBe("fail");
+  });
+
+  it("puts the worst scope first so the top of the row is the real problem", () => {
+    const result = classifyObservationScopeSaturation([
+      reportFor("overlord", OVERLORD_SCOPES, 1000, 43_734),
+    ]);
+    const firstListed = result.detail?.indexOf("7c62ce38-ee4b-45d0-8a4e-d407b064d3b5");
+    const secondListed = result.detail?.indexOf("0f3640d5-089f-4ea1-b5b0-165fe9ae81bf");
+    // 1164 > 1009, so the containment-heavy scope leads.
+    expect(firstListed).toBeGreaterThanOrEqual(0);
+    expect(firstListed).toBeLessThan(secondListed as number);
+  });
+});
+
+describe("configurations this check must not judge", () => {
+  it("treats an unlimited cap (-1) as nothing to saturate", () => {
+    expect(computeScopeSaturation([scope(["s"], 999_999)], -1)).toEqual([]);
+    const result = classifyObservationScopeSaturation([
+      reportFor("big", [scope(["s"], 999_999)], -1),
+    ]);
+    expect(result.status).toBe("ok");
+    expect(result.detail).toContain("uncapped");
+  });
+
+  it("treats cap 0 as a deliberate close, not a failure", () => {
+    // 0 means "no new observations in this scope" — an operator choice. Every
+    // scope is trivially at it, so failing would make the row permanently red
+    // on a correctly-configured bank.
+    const result = classifyObservationScopeSaturation([
+      reportFor("closed", [scope(["s"], 5)], 0),
+    ]);
+    expect(result.status).toBe("ok");
+    expect(result.detail).toContain("closed");
+  });
+
+  it("refuses to judge a bank carrying observation_scope_limits rules", () => {
+    // Those rules resolve a DIFFERENT cap per scope via fnmatch exact-cover
+    // (consolidator.py:670-683). A rule that RAISES a scope's limit would make
+    // the bank-wide comparison invent a FAIL, so the bank is excluded and the
+    // gap is stated instead of guessed at.
+    const result = classifyObservationScopeSaturation([
+      report({
+        bankId: "ruled",
+        hasScopeLimitRules: true,
+        scopeCount: 1,
+        saturated: computeScopeSaturation([scope(["s"], 5000)], 1000),
+      }),
+    ]);
+    expect(result.status).toBe("skip");
+    expect(result.detail).toContain("observation_scope_limits");
+    expect(result.detail).toContain("ruled");
+  });
+
+  it("does not judge a bank with observations disabled", () => {
+    const result = classifyObservationScopeSaturation([
+      report({
+        bankId: "off",
+        observationsEnabled: false,
+        scopeCount: 1,
+        saturated: computeScopeSaturation([scope(["s"], 5000)], 1000),
+      }),
+    ]);
+    expect(result.status).toBe("skip");
+    expect(result.detail).toContain("observations disabled");
+  });
+});
+
+describe("partial visibility", () => {
+  it("does not turn an unreachable bank into a failure, but does say so", () => {
+    // "couldn't look" is not "saturated". A check that reddens when the server
+    // is down teaches operators to ignore the column.
+    const result = classifyObservationScopeSaturation([
+      report({ bankId: "healthy", scopeCount: 3 }),
+      { ...report({ bankId: "down" }), ok: false, reason: "Timeout" },
+    ]);
+    expect(result.status).toBe("ok");
+    expect(result.detail).toContain("down");
+    expect(result.detail).toContain("Timeout");
+  });
+
+  it("still FAILS on a saturated bank when a sibling bank is unreachable", () => {
+    const result = classifyObservationScopeSaturation([
+      { ...report({ bankId: "down" }), ok: false, reason: "Timeout" },
+      reportFor("overlord", OVERLORD_SCOPES, 1000, 43_734),
+    ]);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toContain("1009/1000");
+  });
+
+  it("skips when nothing at all could be read", () => {
+    const result = classifyObservationScopeSaturation([
+      { ...report({ bankId: "a" }), ok: false, reason: "HTTP 500" },
+    ]);
+    expect(result.status).toBe("skip");
+  });
+
+  it("skips when there are no banks", () => {
+    expect(classifyObservationScopeSaturation([]).status).toBe("skip");
+  });
+
+  it("elides a long saturated list rather than printing every scope", () => {
+    const many = Array.from({ length: 10 }, (_, i) => scope([`s${i}`], 1000 + i));
+    const result = classifyObservationScopeSaturation([reportFor("noisy", many)]);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toContain("more");
+    expect(result.detail).toContain("10 observation scope(s) at or over the cap");
+  });
+});
+
+/** Minimal `fetch` stand-in keyed by URL substring. */
+function stubFetch(routes: Record<string, unknown>, seen?: string[]): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    const url = String(input);
+    seen?.push(url);
+    for (const [needle, body] of Object.entries(routes)) {
+      if (url.includes(needle)) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => body,
+        } as unknown as Response;
+      }
+    }
+    return { ok: false, status: 404, json: async () => ({}) } as unknown as Response;
+  }) as unknown as typeof fetch;
+}
+
+describe("probing a bank over REST", () => {
+  const cfgBody = {
+    config: {
+      max_observations_per_scope: 1000,
+      observation_scope_limits: null,
+      enable_observations: true,
+    },
+  };
+
+  it("reads the cap the BANK carries, not switchroom's pushed default", () => {
+    // An operator override, or a bank created before the default moved, makes
+    // the two diverge exactly when the numbers matter. Assuming the constant
+    // would print a ratio no log line agrees with.
+    return inspectBankScopes(
+      "http://h:1/mcp",
+      "overlord",
+      {
+        fetchImpl: stubFetch({
+          "/config": {
+            config: { max_observations_per_scope: 4000, observation_scope_limits: null },
+          },
+          "/observations/scopes": { scopes: OVERLORD_SCOPES },
+        }),
+      },
+    ).then((r) => {
+      expect(r.ok).toBe(true);
+      expect(r.cap).toBe(4000);
+      // 1164 is 29% of 4000 — nothing is saturated at that cap.
+      expect(r.saturated).toEqual([]);
+    });
+  });
+
+  it("produces the saturated set for the live overlord shape", async () => {
+    const r = await inspectBankScopes("http://h:1/mcp", "overlord", {
+      fetchImpl: stubFetch({
+        "/config": cfgBody,
+        "/observations/scopes": { scopes: OVERLORD_SCOPES },
+        "/stats": { pending_consolidation: 43_734 },
+      }),
+    });
+    expect(r.ok).toBe(true);
+    expect(r.pendingConsolidation).toBe(43_734);
+    expect(r.saturated.map((s) => s.effective)).toEqual([1164, 1009, 1000, 935]);
+  });
+
+  it("does NOT pay for /stats when nothing is saturated", async () => {
+    // /stats measured at 1.4-2.1s against ~150ms for the scopes query, and
+    // doctor runs it across a whole fleet. A healthy bank must cost two cheap
+    // calls, not three.
+    const seen: string[] = [];
+    const r = await inspectBankScopes("http://h:1/mcp", "quiet", {
+      fetchImpl: stubFetch(
+        {
+          "/config": cfgBody,
+          "/observations/scopes": { scopes: [scope(["s"], 12)] },
+          "/stats": { pending_consolidation: 5 },
+        },
+        seen,
+      ),
+    });
+    expect(r.saturated).toEqual([]);
+    expect(seen.some((u) => u.includes("/stats"))).toBe(false);
+  });
+
+  it("refuses to guess a cap when the config shape is unrecognised", async () => {
+    // A defaulted cap yields a confident, wrong verdict on every scope.
+    const r = await inspectBankScopes("http://h:1/mcp", "weird", {
+      fetchImpl: stubFetch({
+        "/config": { config: { observation_scope_limits: null } },
+        "/observations/scopes": { scopes: OVERLORD_SCOPES },
+      }),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("Unexpected shape");
+  });
+
+  it("surfaces an HTTP error as unreadable rather than healthy", async () => {
+    const r = await inspectBankScopes("http://h:1/mcp", "gone", {
+      fetchImpl: stubFetch({}),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("HTTP 404");
+  });
+
+  it("drops malformed scope rows instead of throwing", async () => {
+    const r = await inspectBankScopes("http://h:1/mcp", "messy", {
+      fetchImpl: stubFetch({
+        "/config": cfgBody,
+        "/observations/scopes": {
+          scopes: [{ tags: ["ok"], count: 1200 }, { tags: "nope", count: 1 }, { count: 2 }, null],
+        },
+      }),
+    });
+    expect(r.ok).toBe(true);
+    expect(r.scopeCount).toBe(1);
+    expect(r.saturated[0]?.effective).toBe(1200);
+  });
+});
+
+describe("the fleet sweep", () => {
+  it("probes each agent's bank and the profile banks, deduped", async () => {
+    const seen: string[] = [];
+    const config = {
+      agents: {
+        overlord: {},
+        klanker: {},
+        // Two agents sharing one bank must be probed once.
+        alpha: { memory: { collection: "shared" } },
+        beta: { memory: { collection: "shared" } },
+      },
+      users: { ken: { profile_bank: "ken-profile" } },
+    } as never;
+
+    const result = await checkObservationScopeSaturation(config, "http://h:1/mcp", {
+      fetchImpl: stubFetch(
+        {
+          "/config": {
+            config: {
+              max_observations_per_scope: 1000,
+              observation_scope_limits: null,
+              enable_observations: true,
+            },
+          },
+          "banks/overlord/observations/scopes": { scopes: OVERLORD_SCOPES },
+          "/observations/scopes": { scopes: [scope(["quiet"], 3)] },
+          "/stats": { pending_consolidation: 43_734 },
+        },
+        seen,
+      ),
+    });
+
+    const scopeCalls = seen.filter((u) => u.includes("/observations/scopes"));
+    expect(scopeCalls).toHaveLength(4);
+    expect(scopeCalls.filter((u) => u.includes("/shared/"))).toHaveLength(1);
+    expect(seen.some((u) => u.includes("/ken-profile/"))).toBe(true);
+
+    // And the live overlord state still comes out red through the full path.
+    expect(result.status).toBe("fail");
+    expect(result.detail).toContain("overlord/0f3640d5-089f-4ea1-b5b0-165fe9ae81bf (1009/1000)");
+  });
+});

--- a/src/cli/doctor-observation-scopes.ts
+++ b/src/cli/doctor-observation-scopes.ts
@@ -1,0 +1,596 @@
+/**
+ * Doctor surface: Hindsight observation-scope saturation, per bank.
+ *
+ * ## The defect this detects
+ *
+ * Every consolidated observation lives under a *scope* — the exact tag set it
+ * was consolidated with. Hindsight caps observations per scope. When a scope is
+ * full the consolidator does NOT stop: it still recalls, still builds the
+ * batch, still spends an extraction-model call, and then tells the model it may
+ * only issue updates and deletes:
+ *
+ *     engine/consolidation/consolidator.py:1604-1613
+ *       max_obs = _effective_scope_limit(config, fact_tags)
+ *       if max_obs >= 0 and fact_tags:
+ *           current_count = await _count_observations_for_scope(...)
+ *           remaining_observation_slots = max(max_obs - current_count, 0)
+ *           if remaining_observation_slots == 0:
+ *               logger.info(f"[CONSOLIDATION] bank={bank_id} scope={fact_tags} "
+ *                           f"at observation limit ({current_count}/{max_obs}), "
+ *                           f"only updates/deletes allowed")
+ *
+ * That is the ONLY signal, and it is `logger.info` with no metric, no counter
+ * and no health surface attached. On this fleet it repeated roughly every 40
+ * seconds for an unknown length of time —
+ *
+ *     bank=overlord scope=['0f3640d5-089f-4ea1-b5b0-165fe9ae81bf']
+ *       at observation limit (1009/1000), only updates/deletes allowed
+ *
+ * — and was found only because a human ran `docker logs` for an unrelated
+ * reason. Nothing in switchroom could have told an operator. A cap that can be
+ * hit with no alarm gets hit again, so this module is the alarm.
+ *
+ * ## Why the obvious count is the WRONG count
+ *
+ * The engine does not count observations whose tags EQUAL the scope. It counts
+ * observations whose tags CONTAIN the scope — a superset match:
+ *
+ *     engine/consolidation/consolidator.py:598-603
+ *       SELECT COUNT(*) FROM memory_units
+ *        WHERE bank_id = $1 AND fact_type = 'observation' AND tags @> $2::varchar[]
+ *
+ * `GET /observations/scopes` reports the other thing: distinct EXACT tag sets
+ * with their own counts. Comparing those raw numbers to the cap silently
+ * under-reports every scope that has a tagged descendant, and the gap is not
+ * academic. Measured against the live fleet on 2026-07-29:
+ *
+ *   - klanker scope `0291c461-…` — exact 792 (79.2% of 1000, i.e. it would not
+ *     even have crossed an 80% WARN line) against an engine-visible **1413**.
+ *     41% past the cap, and the naive check reports it green.
+ *   - overlord scope `7c62ce38-…` — exact 963 against an engine-visible 1164.
+ *   - overlord scope `c7905e1b-…` — exact 935 against an engine-visible 1141.
+ *
+ * So {@link computeScopeSaturation} folds the endpoint's exact counts back into
+ * containment counts client-side, reproducing `tags @> …` from data that is
+ * already in hand. No extra query, no extra server work.
+ *
+ * ## Cost
+ *
+ * Per bank: `GET /config` (~9ms — one row) and `GET /observations/scopes`
+ * (~150ms on a 163k-node / 29k-observation bank; one GROUP BY over the
+ * `fact_type = 'observation'` slice, bounded by observation count, which the
+ * cap itself bounds). `GET /stats` is ~1.4-2.1s and is fetched ONLY for a bank
+ * that already has a saturated scope — on a healthy fleet this check makes zero
+ * `/stats` calls, and on the live fleet it makes four. Banks are probed
+ * concurrently, so wall time is one bank's latency, not the fleet's sum.
+ *
+ * ## Detection only
+ *
+ * Raising the cap, pruning a scope, or re-tagging sessions are operator
+ * decisions with real data consequences; `doctor` reports and hands over the
+ * numbers.
+ */
+
+import type { SwitchroomConfig } from "../config/schema.js";
+import { resolveAgentConfig } from "../config/merge.js";
+import { collectProfileBanks } from "../memory/hindsight.js";
+import { hindsightRestBase } from "../memory/bank-health.js";
+import type { CheckStatus } from "./doctor-status.js";
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+/** The doctor row's label. Single row for the whole fleet, like the HNSW check. */
+export const OBSERVATION_SCOPE_CHECK_NAME = "hindsight observation scopes";
+
+/**
+ * Fraction of the cap at which a scope is reported as `warn`.
+ *
+ * The point of the row is to arrive BEFORE the wall. At 80% a scope still has
+ * ~200 free slots at the fleet's cap of 1000 — days of headroom at observed
+ * rates, and enough for an operator to raise the cap or prune deliberately
+ * rather than discovering it from a log line after consolidation output has
+ * already been discarded. Below this the row says nothing: a check that fires
+ * on a half-full scope is one operators learn to scroll past.
+ */
+export const OBSERVATION_SCOPE_WARN_RATIO = 0.8;
+
+/** How many saturated scopes are named in the detail before it elides. */
+export const OBSERVATION_SCOPE_MAX_LISTED = 6;
+
+/** One `{tags, count}` entry as `GET /observations/scopes` returns it. */
+export interface ObservationScope {
+  tags: string[];
+  count: number;
+}
+
+/** One scope's saturation, counted the way the engine counts it. */
+export interface ScopeSaturation {
+  /** The scope's tag set, sorted (the endpoint already normalizes order). */
+  tags: string[];
+  /** Observations whose tags are EXACTLY this scope (what the endpoint reports). */
+  exact: number;
+  /**
+   * Observations whose tags CONTAIN this scope — the number
+   * `_count_observations_for_scope` returns, and the number the engine's log
+   * line prints. This is what the cap is compared against.
+   */
+  effective: number;
+  /** The cap in force for this scope. */
+  cap: number;
+  status: "ok" | "warn" | "fail";
+}
+
+/**
+ * Fold exact per-scope counts into the containment counts the engine enforces,
+ * and classify each scope against the cap.
+ *
+ * For a scope `S`, the engine's count is the sum of the counts of every scope
+ * `T` with `T ⊇ S` (which includes `S` itself). Computed here with a tag→scope
+ * postings index and driven from the rarest tag in `S`, so the work is bounded
+ * by how often a tag is shared rather than by the square of the scope count —
+ * a bank with 755 mostly-single-tag scopes does a few thousand comparisons, not
+ * half a million.
+ *
+ * Two exclusions, both mirroring the engine rather than taste:
+ *
+ *  - **The untagged scope (`tags: []`) is skipped.** The cap is guarded by
+ *    `if max_obs >= 0 and fact_tags:` (consolidator.py:1605) and the count
+ *    helper documents "Observations with no tags are not counted", so untagged
+ *    observations are never capped. Including them would manufacture a
+ *    permanent FAIL on a bank that is behaving exactly as designed.
+ *  - **`cap < 0` yields nothing at all.** -1 is upstream's "unlimited"; there
+ *    is no wall to approach.
+ *
+ * `cap === 0` ("no new observations in this scope") is a deliberate operator
+ * setting, not a fault, and is handled by the caller rather than here — see
+ * {@link classifyObservationScopeSaturation}.
+ *
+ * Scopes that have never held an observation are, by construction, at zero and
+ * cannot be saturated, so enumerating the scopes that exist is complete for the
+ * failure this detects. The one residual: a consolidation scope that is a
+ * strict SUBSET of an existing scope and has never itself written an
+ * observation is not enumerated. Reaching it would mean scoring every subset of
+ * every scope, which invents scope keys the bank has never consolidated under
+ * and would report, say, a bare `[sidechain]` as saturated when nothing ever
+ * consolidates under it alone. A false FAIL costs more than that gap.
+ */
+export function computeScopeSaturation(
+  scopes: ObservationScope[],
+  cap: number,
+  warnRatio: number = OBSERVATION_SCOPE_WARN_RATIO,
+): ScopeSaturation[] {
+  if (cap < 0) return [];
+
+  const sets = scopes.map((s) => ({ tags: s.tags, set: new Set(s.tags), count: s.count }));
+
+  // tag -> indices of every scope carrying that tag.
+  const postings = new Map<string, number[]>();
+  sets.forEach((entry, i) => {
+    for (const tag of entry.set) {
+      const list = postings.get(tag);
+      if (list) list.push(i);
+      else postings.set(tag, [i]);
+    }
+  });
+
+  const out: ScopeSaturation[] = [];
+  for (const entry of sets) {
+    // Untagged scope: never capped by the engine.
+    if (entry.set.size === 0) continue;
+
+    // Drive from the rarest tag — every superset of S carries every tag of S,
+    // so any one tag's postings list is a complete candidate set.
+    let candidates: number[] | undefined;
+    for (const tag of entry.set) {
+      const list = postings.get(tag);
+      if (list && (candidates === undefined || list.length < candidates.length)) {
+        candidates = list;
+      }
+    }
+
+    let effective = 0;
+    for (const idx of candidates ?? []) {
+      const other = sets[idx];
+      if (other === undefined) continue;
+      let contains = true;
+      for (const tag of entry.set) {
+        if (!other.set.has(tag)) {
+          contains = false;
+          break;
+        }
+      }
+      if (contains) effective += other.count;
+    }
+
+    // `cap === 0` is "closed on purpose": every scope would be at/over it, so
+    // ratio is undefined and the caller reports the bank, not each scope.
+    const status: ScopeSaturation["status"] =
+      cap > 0 && effective >= cap
+        ? "fail"
+        : cap > 0 && effective >= cap * warnRatio
+          ? "warn"
+          : "ok";
+
+    out.push({ tags: [...entry.tags], exact: entry.count, effective, cap, status });
+  }
+
+  // Worst first: the operator reads the top of the list, so it must be the
+  // scope that is furthest past the wall.
+  out.sort((a, b) => b.effective - a.effective);
+  return out;
+}
+
+/** Everything one bank contributes to the row. */
+export interface BankScopeReport {
+  bankId: string;
+  /** False when the bank could not be read at all (unreachable / bad shape). */
+  ok: boolean;
+  /** Populated when `ok` is false. */
+  reason?: string;
+  /** `max_observations_per_scope` as the bank actually carries it. */
+  cap: number;
+  /** `enable_observations` — false means consolidation writes none. */
+  observationsEnabled: boolean;
+  /**
+   * True when the bank carries `observation_scope_limits` rules. Those resolve
+   * a DIFFERENT cap per scope through fnmatch glob patterns
+   * (consolidator.py:670-683), which this check does not evaluate — see
+   * {@link classifyObservationScopeSaturation}.
+   */
+  hasScopeLimitRules: boolean;
+  /** Distinct scopes in the bank, including the untagged one. */
+  scopeCount: number;
+  /** Scopes at `warn` or `fail`, worst first. */
+  saturated: ScopeSaturation[];
+  /**
+   * `pending_consolidation` from `/stats`, fetched only for banks that already
+   * have a saturated scope. `null` when not fetched or unavailable.
+   */
+  pendingConsolidation: number | null;
+}
+
+/** `bank/scope-id (1164/1000)` — the shape the engine's own log line uses. */
+function describeScope(bankId: string, s: ScopeSaturation): string {
+  return `${bankId}/${s.tags.join(",")} (${s.effective}/${s.cap})`;
+}
+
+/**
+ * Turn per-bank reports into the single doctor row.
+ *
+ * - `fail` — at least one scope is AT or OVER its cap. The engine is discarding
+ *   the create half of every consolidation pass on that scope right now, at the
+ *   cost of a full extraction-model call each time. This is deliberately not a
+ *   warning: the 2026-07 incident was a warning-shaped log line nobody read.
+ * - `warn` — at least one scope is past {@link OBSERVATION_SCOPE_WARN_RATIO} of
+ *   its cap and still writable.
+ * - `skip` — nothing could be read, or every readable bank is one this check
+ *   cannot judge honestly (glob scope-limit rules, or observations disabled).
+ * - `ok`   — every scope on every reachable bank has room.
+ *
+ * Banks that could not be read do NOT fail the row on their own: "couldn't
+ * look" is not "saturated", and a check that reddens on an unreachable server
+ * teaches operators to ignore the column. They are named in the detail so the
+ * gap is visible rather than silent.
+ */
+export function classifyObservationScopeSaturation(
+  reports: BankScopeReport[],
+): CheckResult {
+  const name = OBSERVATION_SCOPE_CHECK_NAME;
+  if (reports.length === 0) {
+    return { name, status: "skip", detail: "no banks to inspect" };
+  }
+
+  const unreadable = reports.filter((r) => !r.ok);
+  const readable = reports.filter((r) => r.ok);
+
+  if (readable.length === 0) {
+    return {
+      name,
+      status: "skip",
+      detail:
+        `could not read observation scopes for ${unreadable.length} bank(s): ` +
+        unreadable.map((r) => `${r.bankId} (${r.reason ?? "unknown"})`).join(", "),
+    };
+  }
+
+  // Glob scope-limit rules resolve a per-scope cap this check does not
+  // evaluate, so judging those banks against the bank-wide cap could invent a
+  // FAIL on a scope whose rule RAISED its limit. Excluded, and said out loud.
+  const unjudged = readable.filter((r) => r.hasScopeLimitRules || !r.observationsEnabled);
+  const judged = readable.filter((r) => !r.hasScopeLimitRules && r.observationsEnabled);
+
+  const notes: string[] = [];
+  if (unreadable.length > 0) {
+    notes.push(
+      `${unreadable.length} bank(s) unreadable: ` +
+        unreadable.map((r) => `${r.bankId} (${r.reason ?? "unknown"})`).join(", "),
+    );
+  }
+  const withRules = unjudged.filter((r) => r.hasScopeLimitRules);
+  if (withRules.length > 0) {
+    notes.push(
+      `${withRules.length} bank(s) not judged — observation_scope_limits sets a ` +
+        `per-scope cap this check does not resolve: ${withRules.map((r) => r.bankId).join(", ")}`,
+    );
+  }
+  const disabled = unjudged.filter((r) => !r.hasScopeLimitRules && !r.observationsEnabled);
+  if (disabled.length > 0) {
+    notes.push(
+      `${disabled.length} bank(s) have observations disabled: ` +
+        disabled.map((r) => r.bankId).join(", "),
+    );
+  }
+  const suffix = notes.length > 0 ? ` · ${notes.join(" · ")}` : "";
+
+  if (judged.length === 0) {
+    return { name, status: "skip", detail: `no bank could be judged${suffix}` };
+  }
+
+  // `cap === 0` — the operator has closed the scope to new observations on
+  // purpose. Every scope is trivially "at" it, so it is reported as an
+  // intentional state, not as saturation.
+  const closed = judged.filter((r) => r.cap === 0);
+  const unlimited = judged.filter((r) => r.cap < 0);
+  const capped = judged.filter((r) => r.cap > 0);
+
+  const failing = capped.flatMap((r) =>
+    r.saturated.filter((s) => s.status === "fail").map((s) => ({ report: r, scope: s })),
+  );
+  const warning = capped.flatMap((r) =>
+    r.saturated.filter((s) => s.status === "warn").map((s) => ({ report: r, scope: s })),
+  );
+  failing.sort((a, b) => b.scope.effective - a.scope.effective);
+  warning.sort((a, b) => b.scope.effective - a.scope.effective);
+
+  const backlog = (rows: Array<{ report: BankScopeReport }>): string => {
+    const seen = new Map<string, number>();
+    for (const { report } of rows) {
+      if (report.pendingConsolidation != null && !seen.has(report.bankId)) {
+        seen.set(report.bankId, report.pendingConsolidation);
+      }
+    }
+    if (seen.size === 0) return "";
+    const parts = [...seen]
+      .sort((a, b) => b[1] - a[1])
+      .map(([bank, pending]) => `${bank} ${pending.toLocaleString()}`);
+    return ` · memories pending consolidation: ${parts.join(", ")}`;
+  };
+
+  const list = (rows: Array<{ report: BankScopeReport; scope: ScopeSaturation }>): string => {
+    const shown = rows
+      .slice(0, OBSERVATION_SCOPE_MAX_LISTED)
+      .map(({ report, scope }) => describeScope(report.bankId, scope))
+      .join("; ");
+    const rest = rows.length - Math.min(rows.length, OBSERVATION_SCOPE_MAX_LISTED);
+    return rest > 0 ? `${shown}; +${rest} more` : shown;
+  };
+
+  // WARNING to future editors: there is no per-scope observation delete on the
+  // REST surface. `DELETE /v1/default/banks/<bank>/observations` is "Clear all
+  // observations" — it takes no scope and wipes the bank's entire consolidated
+  // knowledge (verified against the live OpenAPI, 2026-07-29). Recommending it
+  // as a pruning step would turn this row into a data-loss instruction, so the
+  // fix names raising the cap as the actionable remedy and says plainly that
+  // scoped pruning is not a one-call operation.
+  const fix =
+    "Consolidation keeps running against a full scope — it recalls, spends an " +
+    "extraction-model call, and can only apply updates/deletes " +
+    "(engine/consolidation/consolidator.py:1604-1613), so every pass on that " +
+    "scope is paid for and its creates are discarded. Remedy: raise the cap, " +
+    "via `hindsight.env.HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE` in " +
+    "switchroom.yaml (fleet-wide) or `max_observations_per_scope` on the bank " +
+    "(PATCH /v1/default/banks/<bank>/config). Confirm the counts first with " +
+    "GET /v1/default/banks/<bank>/observations/scopes — but note they are EXACT " +
+    "tag sets, while the engine counts by CONTAINMENT (`tags @> scope`), so a " +
+    "scope's child scopes count toward it and its true number is higher than " +
+    "that endpoint shows. Retiring a scope instead is NOT a single call: " +
+    "DELETE /v1/default/banks/<bank>/observations clears the WHOLE bank's " +
+    "observations, so enumerate the scope first " +
+    "(GET /graph?type=observation&tags=<scope>&tags_match=exact) and delete " +
+    "per memory.";
+
+  if (failing.length > 0) {
+    return {
+      name,
+      status: "fail",
+      detail:
+        `${failing.length} observation scope(s) at or over the cap — consolidation ` +
+        `output is being discarded on them right now: ${list(failing)}` +
+        (warning.length > 0 ? ` · ${warning.length} more above ${Math.round(OBSERVATION_SCOPE_WARN_RATIO * 100)}%` : "") +
+        backlog([...failing, ...warning]) +
+        suffix,
+      fix,
+    };
+  }
+
+  if (warning.length > 0) {
+    return {
+      name,
+      status: "warn",
+      detail:
+        `${warning.length} observation scope(s) above ` +
+        `${Math.round(OBSERVATION_SCOPE_WARN_RATIO * 100)}% of the cap and still writable: ` +
+        `${list(warning)}` +
+        backlog(warning) +
+        suffix,
+      fix,
+    };
+  }
+
+  const totalScopes = capped.reduce((n, r) => n + r.scopeCount, 0);
+  const detailBase =
+    capped.length === 0
+      ? `no bank has a positive observation cap`
+      : `${totalScopes} scope(s) across ${capped.length} bank(s) below ` +
+        `${Math.round(OBSERVATION_SCOPE_WARN_RATIO * 100)}% of the cap`;
+  const extra: string[] = [];
+  if (unlimited.length > 0) {
+    extra.push(`${unlimited.length} bank(s) uncapped (-1)`);
+  }
+  if (closed.length > 0) {
+    extra.push(
+      `${closed.length} bank(s) deliberately closed to new observations (cap 0): ` +
+        closed.map((r) => r.bankId).join(", "),
+    );
+  }
+  return {
+    name,
+    status: "ok",
+    detail: detailBase + (extra.length > 0 ? ` · ${extra.join(" · ")}` : "") + suffix,
+  };
+}
+
+interface FetchOpts {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+async function getJson<T>(
+  url: string,
+  opts?: FetchOpts,
+): Promise<{ ok: true; data: T } | { ok: false; reason: string }> {
+  const fetchImpl = opts?.fetchImpl ?? fetch;
+  const timeoutMs = opts?.timeoutMs ?? 15_000;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const resp = await fetchImpl(url, { signal: controller.signal });
+    clearTimeout(timeout);
+    if (!resp.ok) return { ok: false, reason: `HTTP ${resp.status}` };
+    return { ok: true, data: (await resp.json()) as T };
+  } catch (err) {
+    clearTimeout(timeout);
+    if ((err as Error).name === "AbortError") return { ok: false, reason: "Timeout" };
+    return { ok: false, reason: String((err as Error).message ?? err) };
+  }
+}
+
+/**
+ * Inspect one bank: its cap, its scopes, and — only if something is already
+ * saturated — its consolidation backlog.
+ *
+ * The cap is read from the bank's own `/config` rather than from switchroom's
+ * `HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE` constant on purpose. The
+ * constant is what switchroom PUSHES; `/config` is what the bank actually
+ * carries, and the two diverge exactly when it matters (an operator override,
+ * a bank created before the default changed, a container running with a
+ * different env). Comparing live counts against an assumed cap is how a check
+ * reports numbers that no log line agrees with.
+ *
+ * A missing/wrong-typed `max_observations_per_scope` is `ok: false`, never
+ * defaulted: a guessed cap produces a confident, wrong verdict.
+ */
+export async function inspectBankScopes(
+  apiUrl: string,
+  bankId: string,
+  opts?: FetchOpts,
+): Promise<BankScopeReport> {
+  const base = hindsightRestBase(apiUrl);
+  const bank = encodeURIComponent(bankId);
+  const fail = (reason: string): BankScopeReport => ({
+    bankId,
+    ok: false,
+    reason,
+    cap: -1,
+    observationsEnabled: false,
+    hasScopeLimitRules: false,
+    scopeCount: 0,
+    saturated: [],
+    pendingConsolidation: null,
+  });
+
+  const cfg = await getJson<{ config?: Record<string, unknown> | null }>(
+    `${base}/v1/default/banks/${bank}/config`,
+    opts,
+  );
+  if (!cfg.ok) return fail(cfg.reason);
+  const config = cfg.data?.config;
+  if (config == null || typeof config !== "object") return fail("Unexpected shape");
+  const rawCap = config["max_observations_per_scope"];
+  if (typeof rawCap !== "number" || !Number.isFinite(rawCap)) {
+    return fail("Unexpected shape");
+  }
+  const rules = config["observation_scope_limits"];
+  const hasScopeLimitRules = Array.isArray(rules) && rules.length > 0;
+  // Absent means engine default (enabled); only an explicit `false` disables.
+  const observationsEnabled = config["enable_observations"] !== false;
+
+  const scopesResp = await getJson<{ scopes?: unknown }>(
+    `${base}/v1/default/banks/${bank}/observations/scopes`,
+    opts,
+  );
+  if (!scopesResp.ok) return fail(scopesResp.reason);
+  const rawScopes = scopesResp.data?.scopes;
+  if (!Array.isArray(rawScopes)) return fail("Unexpected shape");
+
+  const scopes: ObservationScope[] = [];
+  for (const entry of rawScopes) {
+    const tags = (entry as { tags?: unknown })?.tags;
+    const count = (entry as { count?: unknown })?.count;
+    if (!Array.isArray(tags) || typeof count !== "number") continue;
+    if (!tags.every((t) => typeof t === "string")) continue;
+    scopes.push({ tags: tags as string[], count });
+  }
+
+  const saturated = computeScopeSaturation(scopes, rawCap).filter((s) => s.status !== "ok");
+
+  // The backlog number is what makes the row legible ("overlord is sitting on
+  // 43,734 pending memories" beats a bare uuid), but /stats is the expensive
+  // call on this surface — ~1.4-2.1s against the ~150ms scopes query. Fetch it
+  // only when there is already something to explain, so a healthy fleet pays
+  // nothing for it.
+  let pendingConsolidation: number | null = null;
+  if (saturated.length > 0 && !hasScopeLimitRules && observationsEnabled) {
+    const stats = await getJson<{ pending_consolidation?: unknown }>(
+      `${base}/v1/default/banks/${bank}/stats`,
+      opts,
+    );
+    if (stats.ok && typeof stats.data?.pending_consolidation === "number") {
+      pendingConsolidation = stats.data.pending_consolidation;
+    }
+  }
+
+  return {
+    bankId,
+    ok: true,
+    cap: rawCap,
+    observationsEnabled,
+    hasScopeLimitRules,
+    scopeCount: scopes.length,
+    saturated,
+    pendingConsolidation,
+  };
+}
+
+/**
+ * The doctor entry point: sweep every bank switchroom knows about and return
+ * the single row.
+ *
+ * Bank set matches the ingest sweep — each agent's resolved
+ * `memory.collection` (deduped; several agents may share one) plus the profile
+ * banks recall routes to. Resolution goes through `resolveAgentConfig` so a
+ * `collection` inherited from `defaults:` or a profile lands on the same bank
+ * the runtime uses.
+ */
+export async function checkObservationScopeSaturation(
+  config: SwitchroomConfig,
+  apiUrl: string,
+  opts?: FetchOpts,
+): Promise<CheckResult> {
+  const banks = new Set<string>();
+  for (const [agentName, agentConfig] of Object.entries(config.agents ?? {})) {
+    const resolved = resolveAgentConfig(config.defaults, config.profiles, agentConfig);
+    banks.add(resolved.memory?.collection ?? agentName);
+  }
+  for (const bank of collectProfileBanks(config)) banks.add(bank);
+
+  const reports = await Promise.all(
+    [...banks].map((bankId) => inspectBankScopes(apiUrl, bankId, opts)),
+  );
+  return classifyObservationScopeSaturation(reports);
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -53,6 +53,7 @@ import { inspectBankHealth, staleMentalModels, corruptedMentalModels, recentUnex
 import { checkHindsightContainerHealth, classifyToolContract, checkHindsightHealthEndpoint, checkHindsightVersion, classifyConsolidationBacklog, classifyDirectiveCount } from "./doctor-memory.js";
 import { checkAgentRecallHealth } from "./doctor-recall-health.js";
 import { checkHnswPartialIndexes } from "./doctor-hnsw-index.js";
+import { checkObservationScopeSaturation } from "./doctor-observation-scopes.js";
 import { checkHindsightWatchArmed } from "./doctor-hindsight-watch.js";
 import { runLitellmModelChecks } from "../litellm/model-validation.js";
 import { runLitellmKeyAllowlistChecks } from "../litellm/key-allowlist-check.js";
@@ -1673,6 +1674,14 @@ async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> 
   // and invisible everywhere else, which is how the whole fleet ran the
   // engine's stock consolidation mission unnoticed (see the function's doc).
   results.push(...(await checkBankObservationsMissions(config, url)));
+
+  // …and whether those scopes still have room to consolidate INTO. Hindsight
+  // caps observations per scope; past the cap the consolidator keeps running,
+  // keeps spending an extraction-model call, and silently drops every create
+  // (consolidator.py:1604-1613). The only signal is an INFO log with no metric
+  // attached, which is why a scope on this fleet sat at 1009/1000 for an
+  // unknown length of time and was found by a human reading `docker logs`.
+  results.push(await checkObservationScopeSaturation(config, url));
 
   // Auto-recall health (#3619). Reachability, ingest, and /health all stayed
   // green through the 2026-07 regression while the busiest agents lost their


### PR DESCRIPTION
## The failure this ends

On this host, right now, `docker logs switchroom-hindsight` repeats roughly every 40 seconds:

```
[CONSOLIDATION] bank=overlord scope=['0f3640d5-089f-4ea1-b5b0-165fe9ae81bf'] at observation limit (1009/1000), only updates/deletes allowed
```

Consolidation does **not** stop at a full scope. It recalls, builds the batch, spends a full extraction-model call, and then tells the model it may only issue updates and deletes — every create is thrown away, and the tokens are already spent.

**Root cause, in real source at HEAD** (read inside the running `switchroom-hindsight` container, `hindsight_api` 0.8.5):

- `engine/consolidation/consolidator.py:1604-1613` — the cap is evaluated, `remaining_observation_slots` is clamped to 0, and the *only* signal is `logger.info(...)`. No metric, no counter, no health surface. This is the whole of the alarm today.
- `engine/consolidation/consolidator.py:598-603` — `_count_observations_for_scope` is `WHERE bank_id = $1 AND fact_type = 'observation' AND tags @> $2::varchar[]`. **Containment**, not equality.
- `engine/consolidation/consolidator.py:670-683` — `_effective_scope_limit` resolves the cap per scope: an `observation_scope_limits` glob rule wins over the bank-wide `max_observations_per_scope`.
- `engine/consolidation/consolidator.py:875-884` — worth stating because it is easy to misread: the `observation_scopes` trigger argument is a **row filter** (`tags @> $n::varchar[]` over which unconsolidated memories get processed), *not* a write-scope override. The scope an observation is written under comes from the memory's own tags (`consolidator.py:632-637`).

Nothing in switchroom could have told an operator any of this. It was found by a human reading container logs for an unrelated reason.

## What this adds

One doctor row, `hindsight observation scopes`, in its own module (`src/cli/doctor-observation-scopes.ts`) — deliberately isolated to keep conflict surface off `doctor.ts` beyond one import and one `results.push`.

- **FAIL** at or above the cap — creates are being discarded *right now*. Not a warning: the incident was already a warning-shaped signal nobody read.
- **WARN** above 80% of the cap, while the scope is still writable and the operator has room to act.
- Names bank, scope and real numbers in the engine's own format: `overlord/0f3640d5-089f-4ea1-b5b0-165fe9ae81bf (1007/1000)`.
- Carries `pending_consolidation` per affected bank, because a bare uuid is cryptic and `overlord 43,412` is the symptom an operator recognises.

## The part that is load-bearing: it counts the way the engine counts

`GET /observations/scopes` reports **exact** tag sets. The engine enforces by **containment**. Comparing the endpoint's numbers to the cap silently under-reports every scope that has a tagged child, and the gap decides verdicts. Measured against the live fleet, 2026-07-29:

| bank / scope | exact (endpoint) | engine-visible (`tags @>`) | naive verdict | this check |
|---|---|---|---|---|
| `klanker/0291c461-…` | 792 (**79.2%** — under the warn line) | **1413** | ok | **fail** |
| `overlord/7c62ce38-…` | 963 | **1164** | warn | **fail** |
| `overlord/c7905e1b-…` | 935 | **1141** | warn | **fail** |
| `overlord/0f3640d5-…` | 1007 | 1007 | fail | fail |

So a naive exact-count check would report klanker's worst scope — 41% past the cap — as **green**. `computeScopeSaturation` folds the exact counts into containment counts client-side, over data already in hand: no extra query, no extra server work.

Live output through the real code path against the real fleet:

```
FAIL | hindsight observation scopes
8 observation scope(s) at or over the cap — consolidation output is being discarded on them
right now: klanker/0291c461-… (1413/1000); overlord/7c62ce38-… (1164/1000);
overlord/c7905e1b-… (1141/1000); finn/328de942-… (1069/1000); overlord/0f3640d5-… (1007/1000);
overlord/ca9b3dd6-… (1000/1000); +2 more · 4 more above 80% ·
memories pending consolidation: overlord 43,412, finn 448, klanker 125, carrie 7
```

Two of those (`0f3640d5` 1007/1000, `ca9b3dd6` 1000/1000) match the live log lines exactly. The other six have **never** appeared in a log line, because a scope only logs when it happens to be receiving new memories.

## What it queries, and what it costs

Per bank, concurrently:

| call | cost | when |
|---|---|---|
| `GET /config` | ~9 ms | always — gives the cap the **bank actually carries**, not switchroom's pushed default |
| `GET /observations/scopes` | ~150 ms on a 163k-node / 29k-observation bank | always — one `GROUP BY` over the `fact_type='observation'` slice (`memory_engine.py:6547-6557`), bounded by observation count, which the cap itself bounds |
| `GET /stats` | ~1.4-2.1 s | **only** for a bank that already has a saturated scope |

Measured: **8 healthy banks in 75 ms total, zero `/stats` calls.** On the current (unhealthy) fleet, 6 banks in 1535 ms including 4 `/stats` calls. No unbounded scan anywhere; the containment fold is a tag→scope postings index driven from the rarest tag, so 755 mostly-single-tag scopes cost a few thousand comparisons rather than half a million.

The cap is read from the bank's live `/config`, not from `HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE`. The constant is what switchroom *pushes*; `/config` is what the bank *carries*, and they diverge exactly when it matters. An unrecognised config shape is `ok: false`, never a defaulted cap — a guessed cap yields a confident wrong verdict.

## What it deliberately refuses to judge

- **Banks carrying `observation_scope_limits`.** Those resolve a per-scope cap through fnmatch exact-cover globs this check does not evaluate; a rule that *raises* a scope's limit would make a bank-wide comparison invent a FAIL. Excluded and stated, not guessed. (Null across the entire fleet today; switchroom never writes it. Follow-up: #3950.)
- **The untagged global scope.** `if max_obs >= 0 and fact_tags:` (`consolidator.py:1605`) and "Observations with no tags are not counted" (`consolidator.py:596`) — never capped. Including it would be a permanent false FAIL on a correct bank.
- **`cap == 0`** — "no new observations", a deliberate operator setting, reported as intentional rather than as saturation. **`cap == -1`** — unlimited, nothing to saturate.
- **Unreachable banks** — named in the detail, never failed. "Couldn't look" is not "saturated"; a row that reddens when the server is down teaches operators to ignore the column.

Known residual, stated plainly: a consolidation scope that is a strict *subset* of an existing scope and has never itself written an observation is not enumerated. Closing it would mean scoring every subset of every scope, which invents scope keys the bank never consolidates under (a bare `[sidechain]`, say) and trades a real false-FAIL risk for a hypothetical miss.

## Tests

29 tests in `src/cli/doctor-observation-scopes.test.ts`, built on a fixture of overlord's live scope table (`0f3640d5` at 1009 against a cap of 1000, the `7c62ce38`/`anti-pattern` parent-child pair, the untagged scope, 43,734 pending).

They assert outcomes, not code paths. Verified by mutation — every one of these mutants is caught:

| mutant | tests killed |
|---|---|
| count exact tag sets instead of containment | 4 |
| `effective > cap` instead of `>=` | 3 |
| include the untagged global scope | 1 |
| fetch `/stats` unconditionally | 1 |
| judge `observation_scope_limits` banks anyway | 2 |
| let an unreachable bank fail the row | 2 |

The load-bearing one — *"FAILS, and names the bank, the scope and 1009/1000"* — fails on today's code because today's code has no such row at all: `switchroom doctor` emits nothing about observation scopes, which is precisely why 1009/1000 ran unseen.

## Adversarial review of my own diff

One **blocker, found and fixed before opening**: the first draft's `fix` string told the operator to `DELETE /v1/default/banks/<bank>/observations` "for the scope you are retiring". Checked against the live OpenAPI — that endpoint is *"Clear all observations"*, takes **no** scope parameter, and wipes the bank's entire consolidated knowledge. That is a data-loss instruction dressed as remediation. The fix string now names raising the cap as the remedy and says outright that scoped pruning is not a one-call operation; `never presents the bank-wide observations DELETE as a per-scope prune` is the regression guard.

Lower-severity, filed rather than fixed:

- **#3949** — the existing `hindsight consolidation backlog` row sums `pending_operations` (fleet total **5**, reported green) while the real memory-level backlog is `pending_consolidation` (fleet total **43,956**). Separate pre-existing bug, found while wiring the backlog number into this row; deliberately not fixed here because correcting the field also requires re-deriving its thresholds.
- **#3950** — `observation_scope_limits` fnmatch exact-cover support, so ruled banks are judged instead of skipped.
- **#3951** — upstream: the engine should log this at WARNING and expose a metric, so switchroom's poll is a backstop rather than the only alarm.

Nothing else in the diff reaches blocker or major.

## Operator note

This row goes **FAIL on the current fleet**, which sets a non-zero `switchroom doctor` exit until the cap is raised — that raise is being handled separately as triage. That is the row doing its job, not a regression, but worth knowing before it appears in a health job.

Detection only. Raising the cap and retiring a scope are operator decisions with real data consequences.
