### PR TITLE
feat(doctor): give the untracked-LiteLLM boot a standing signal

### DIFF
--- a/profiles/_base/cron-session.sh.hbs
+++ b/profiles/_base/cron-session.sh.hbs
@@ -127,7 +127,11 @@ if [ -n "${SWITCHROOM_LITELLM:-}" ] && command -v switchroom >/dev/null 2>&1; th
   sr_ll_ok=""
   sr_ll_unreachable=""
   if [ -z "$sr_ll_key" ]; then
-    echo "litellm(cron): no virtual key for '{{name}}' — falling back to direct OAuth (untracked, unguarded)" >&2
+    # Remediation, not just diagnosis. Unlike start.sh this block re-runs on
+    # EVERY fire, so no restart is needed — a provisioned key is picked up by
+    # the next fire on its own. Say that, so the operator does not bounce the
+    # agent chasing a cron-only problem.
+    echo "litellm(cron): no virtual key for '{{name}}' — falling back to direct OAuth (untracked, unguarded). FIX: re-run 'switchroom apply' to provision the key; the next fire picks it up (no restart needed)." >&2
   elif command -v curl >/dev/null 2>&1 && [ -n "$ANTHROPIC_BASE_URL" ]; then
     # Bounded retry probe — short budget for cron latency (3 attempts,
     # worst-case ~25s: 3×5s curl timeouts + 2×5s sleeps).

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -108,7 +108,13 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
     sr_ll_ok=""
     sr_ll_unreachable=""
     if [ -z "$sr_ll_key" ]; then
-      echo "litellm(outer): WARNING — no virtual key for agent '$SWITCHROOM_AGENT_NAME'; gateway falling back to direct Anthropic OAuth (untracked, unguarded)." >&2
+      # Say what to DO, not just what happened: the fail-open is a BOOT-TIME
+      # decision that is never re-evaluated, so provisioning the key later
+      # changes nothing until the agent is restarted. An operator who reads
+      # only "untracked" and provisions a key reasonably assumes it took
+      # effect; it did not. `switchroom doctor` carries the standing version
+      # of this signal (it reads .routing-mode) once the boot log has rotated.
+      echo "litellm(outer): WARNING — no virtual key for agent '$SWITCHROOM_AGENT_NAME'; gateway falling back to direct Anthropic OAuth (untracked, unguarded). FIX: re-run 'switchroom apply' to provision the key, then RESTART this agent — the fail-open is decided once at boot and is never re-evaluated for the life of the session." >&2
     elif command -v curl >/dev/null 2>&1 && [ -n "$ANTHROPIC_BASE_URL" ]; then
       # Bounded retry probe (co-boot race fix, 2026-07): when the whole stack
       # co-boots, the litellm proxy's heavy Python app is often not yet healthy
@@ -1563,6 +1569,14 @@ if [ -n "${SWITCHROOM_LITELLM:-}" ] && command -v switchroom >/dev/null 2>&1; th
     echo "WARNING: no litellm virtual key for agent '$SWITCHROOM_AGENT_NAME'." >&2
     echo "WARNING: falling back to direct Anthropic OAuth (untracked, unguarded)" >&2
     echo "WARNING: — cannot authenticate to the proxy without a key." >&2
+    # Remediation, not just diagnosis. The fail-open is decided ONCE here and
+    # never re-evaluated, so a key provisioned mid-session is inert — an
+    # operator who is not told that will provision one and believe the agent
+    # healed. `switchroom doctor` reads .routing-mode for the standing version
+    # of this signal, since this banner only lives in a rotating boot log.
+    echo "WARNING: FIX: re-run 'switchroom apply' to provision the key, then" >&2
+    echo "WARNING: RESTART this agent — the fail-open is decided once at boot" >&2
+    echo "WARNING: and is never re-evaluated for the life of this session." >&2
     echo "==========================================================" >&2
   elif command -v curl >/dev/null 2>&1 && [ -n "$ANTHROPIC_BASE_URL" ]; then
     # Bounded retry probe (co-boot race fix, 2026-07): when the whole stack

--- a/src/cli/doctor-routing-mode.test.ts
+++ b/src/cli/doctor-routing-mode.test.ts
@@ -3,11 +3,16 @@
  *
  * The behaviour under test is the one that matters to the operator: an agent
  * whose boot landed on untracked direct-OAuth while its declared routing says
- * it must ride the proxy produces a FAIL row that names the agent and the
+ * it must ride the proxy produces a WARN row that names the agent and the
  * remediation. The record shape asserted here is the one start.sh actually
  * writes — `tests/scaffold.routing-mode.test.ts` pins the writer.
+ *
+ * The severity is load-bearing, not cosmetic: `warn` is the operator's ruling
+ * (2026-07-29) and it is what keeps `switchroom doctor` from exiting non-zero
+ * over a deliberate fail-open. The "exit status" block at the bottom pins that
+ * against doctor's REAL counter, so a silent flip back to `fail` cannot pass.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import {
   classifyRoutingMode,
@@ -15,6 +20,7 @@ import {
   routingModePath,
   runRoutingModeChecks,
 } from "./doctor-routing-mode.js";
+import { printSection } from "./doctor.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 
 const AGENTS_DIR = "/nonexistent-test-agents";
@@ -95,7 +101,7 @@ describe("parseRoutingModeRecord", () => {
 });
 
 describe("classifyRoutingMode", () => {
-  it("FAILs when a passthrough-declared agent landed on direct-oauth", () => {
+  it("WARNs when a passthrough-declared agent landed on direct-oauth", () => {
     const v = classifyRoutingMode({
       mode: "direct-oauth",
       base: "direct",
@@ -104,11 +110,23 @@ describe("classifyRoutingMode", () => {
       declared: "passthrough",
       ts: "2026-07-28T18:59:32Z",
     });
-    expect(v?.status).toBe("fail");
+    expect(v?.status).toBe("warn");
     expect(v?.detail).toContain("UNTRACKED");
   });
 
-  it("FAILs for a router-root-declared agent too (fable / sr-* models)", () => {
+  it("never returns `fail` — the untracked landing is a warn, by ruling", () => {
+    const v = classifyRoutingMode({
+      mode: "direct-oauth",
+      base: "direct",
+      model: "opus",
+      litellmOk: "0",
+      declared: "passthrough",
+      ts: "2026-07-28T18:59:32Z",
+    });
+    expect(v?.status).not.toBe("fail");
+  });
+
+  it("WARNs for a router-root-declared agent too (fable / sr-* models)", () => {
     const v = classifyRoutingMode({
       mode: "direct-oauth",
       base: "direct",
@@ -117,7 +135,7 @@ describe("classifyRoutingMode", () => {
       declared: "router-root",
       ts: "",
     });
-    expect(v?.status).toBe("fail");
+    expect(v?.status).toBe("warn");
   });
 
   it("is silent when LiteLLM was never configured (declared=direct-oauth)", () => {
@@ -135,7 +153,7 @@ describe("classifyRoutingMode", () => {
 
   it("is silent for a non-untracked divergence — router-root declared, landed passthrough", () => {
     // Still on the proxy, still metered. That divergence is the
-    // .session-model-alert relay's business, not a standing doctor FAIL.
+    // .session-model-alert relay's business, not a standing doctor row.
     expect(
       classifyRoutingMode({
         mode: "passthrough",
@@ -187,7 +205,7 @@ describe("runRoutingModeChecks", () => {
     expect(results).toEqual([]);
   });
 
-  it("FAILs the stripped agent, names it, and leaves its healthy peers silent", () => {
+  it("WARNs the stripped agent, names it, and leaves its healthy peers silent", () => {
     const results = runRoutingModeChecks(config("alpha", "beta", "gamma"), {
       agentsDir: AGENTS_DIR,
       readFile: reader({
@@ -205,7 +223,7 @@ describe("runRoutingModeChecks", () => {
 
     expect(results).toHaveLength(1);
     const [row] = results;
-    expect(row.status).toBe("fail");
+    expect(row.status).toBe("warn");
     expect(row.name).toBe("litellm routing: beta");
     expect(row.detail).toContain("direct-oauth");
     expect(row.detail).toContain("UNTRACKED");
@@ -268,5 +286,58 @@ describe("runRoutingModeChecks", () => {
     } finally {
       if (saved !== undefined) process.env.SWITCHROOM_AGENTS_DIR = saved;
     }
+  });
+});
+
+describe("exit status — an untracked boot must NOT make doctor exit non-zero", () => {
+  /**
+   * `switchroom doctor` exits 1 iff the `fails` counted by `printSection`
+   * across every section sum to > 0 (src/cli/doctor.ts — `totalFail > 0` →
+   * `process.exit(1)`). So the only honest way to pin "this row does not turn
+   * the build red" is to push the real rows through doctor's real counter and
+   * assert the fail tally is zero. Asserting `status === "warn"` alone would
+   * be re-stating the implementation; this asserts the CONSEQUENCE the
+   * operator ruled on.
+   */
+  function count(results: Parameters<typeof printSection>[1]) {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      return printSection("LiteLLM boot routing", results);
+    } finally {
+      logSpy.mockRestore();
+    }
+  }
+
+  it("counts the stripped agent as a warn and contributes zero fails", () => {
+    const results = runRoutingModeChecks(config("beta"), {
+      agentsDir: AGENTS_DIR,
+      readFile: reader({
+        [path("beta")]: record({
+          mode: "direct-oauth",
+          base: "direct",
+          litellmOk: "0",
+          declared: "passthrough",
+        }),
+      }),
+    });
+
+    // Guard: if the row ever stops being emitted the tally below goes to zero
+    // for the wrong reason, and this test would pass while the check is dead.
+    expect(results).toHaveLength(1);
+    expect(count(results)).toEqual({ oks: 0, warns: 1, fails: 0, skips: 0 });
+  });
+
+  it("contributes zero fails even with a whole fleet stripped at once", () => {
+    const results = runRoutingModeChecks(config("beta", "delta", "epsilon"), {
+      agentsDir: AGENTS_DIR,
+      readFile: reader({
+        [path("beta")]: record({ mode: "direct-oauth", declared: "passthrough" }),
+        [path("delta")]: record({ mode: "direct-oauth", declared: "router-root" }),
+        [path("epsilon")]: record({ mode: "direct-oauth", declared: "passthrough" }),
+      }),
+    });
+
+    expect(results).toHaveLength(3);
+    expect(count(results)).toEqual({ oks: 0, warns: 3, fails: 0, skips: 0 });
   });
 });

--- a/src/cli/doctor-routing-mode.test.ts
+++ b/src/cli/doctor-routing-mode.test.ts
@@ -1,0 +1,272 @@
+/**
+ * `switchroom doctor` LiteLLM boot-routing section.
+ *
+ * The behaviour under test is the one that matters to the operator: an agent
+ * whose boot landed on untracked direct-OAuth while its declared routing says
+ * it must ride the proxy produces a FAIL row that names the agent and the
+ * remediation. The record shape asserted here is the one start.sh actually
+ * writes — `tests/scaffold.routing-mode.test.ts` pins the writer.
+ */
+import { describe, it, expect } from "vitest";
+
+import {
+  classifyRoutingMode,
+  parseRoutingModeRecord,
+  routingModePath,
+  runRoutingModeChecks,
+} from "./doctor-routing-mode.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+const AGENTS_DIR = "/nonexistent-test-agents";
+
+function config(...names: string[]): SwitchroomConfig {
+  const agents: Record<string, unknown> = {};
+  for (const n of names) agents[n] = {};
+  return { agents } as unknown as SwitchroomConfig;
+}
+
+/** Read seam that serves `files` and throws ENOENT for anything else. */
+function reader(files: Record<string, string>) {
+  return (p: string): string => {
+    if (p in files) return files[p];
+    const err = new Error(`ENOENT: no such file or directory, open '${p}'`);
+    (err as NodeJS.ErrnoException).code = "ENOENT";
+    throw err;
+  };
+}
+
+const path = (agent: string) => routingModePath(`${AGENTS_DIR}/${agent}`);
+
+/** Byte-for-byte the line start.sh writes (profiles/_base/start.sh.hbs). */
+function record(o: {
+  mode: string;
+  base?: string;
+  model?: string;
+  litellmOk?: string;
+  declared: string;
+  ts?: string;
+}): string {
+  return (
+    `mode=${o.mode} base=${o.base ?? "http://127.0.0.1:4010/anthropic"} ` +
+    `model=${o.model ?? "opus"} litellm_ok=${o.litellmOk ?? "1"} ` +
+    `declared=${o.declared} ts=${o.ts ?? "2026-07-28T18:59:32Z"}\n`
+  );
+}
+
+describe("parseRoutingModeRecord", () => {
+  it("parses a real healthy line", () => {
+    const rec = parseRoutingModeRecord(
+      "mode=passthrough base=http://127.0.0.1:4010/anthropic model=opus " +
+        "litellm_ok=1 declared=passthrough ts=2026-07-28T18:59:32Z\n",
+    );
+    expect(rec).toEqual({
+      mode: "passthrough",
+      base: "http://127.0.0.1:4010/anthropic",
+      model: "opus",
+      litellmOk: "1",
+      declared: "passthrough",
+      ts: "2026-07-28T18:59:32Z",
+    });
+  });
+
+  it("parses the stripped line start.sh writes with base=direct", () => {
+    const rec = parseRoutingModeRecord(
+      "mode=direct-oauth base=direct model=opus litellm_ok=0 " +
+        "declared=passthrough ts=2026-07-28T18:59:32Z",
+    );
+    expect(rec?.mode).toBe("direct-oauth");
+    expect(rec?.base).toBe("direct");
+    expect(rec?.declared).toBe("passthrough");
+  });
+
+  it("tolerates an unknown extra field the writer may grow later", () => {
+    const rec = parseRoutingModeRecord(
+      "mode=passthrough declared=passthrough future_field=x",
+    );
+    expect(rec?.mode).toBe("passthrough");
+  });
+
+  it("returns null for a truncated record missing the load-bearing fields", () => {
+    expect(parseRoutingModeRecord("mode=passthrough base=x")).toBeNull();
+    expect(parseRoutingModeRecord("")).toBeNull();
+    expect(parseRoutingModeRecord("\n\n")).toBeNull();
+    expect(parseRoutingModeRecord("garbage without equals")).toBeNull();
+  });
+});
+
+describe("classifyRoutingMode", () => {
+  it("FAILs when a passthrough-declared agent landed on direct-oauth", () => {
+    const v = classifyRoutingMode({
+      mode: "direct-oauth",
+      base: "direct",
+      model: "opus",
+      litellmOk: "0",
+      declared: "passthrough",
+      ts: "2026-07-28T18:59:32Z",
+    });
+    expect(v?.status).toBe("fail");
+    expect(v?.detail).toContain("UNTRACKED");
+  });
+
+  it("FAILs for a router-root-declared agent too (fable / sr-* models)", () => {
+    const v = classifyRoutingMode({
+      mode: "direct-oauth",
+      base: "direct",
+      model: "fable",
+      litellmOk: "0",
+      declared: "router-root",
+      ts: "",
+    });
+    expect(v?.status).toBe("fail");
+  });
+
+  it("is silent when LiteLLM was never configured (declared=direct-oauth)", () => {
+    expect(
+      classifyRoutingMode({
+        mode: "direct-oauth",
+        base: "direct",
+        model: "opus",
+        litellmOk: "0",
+        declared: "direct-oauth",
+        ts: "",
+      }),
+    ).toBeNull();
+  });
+
+  it("is silent for a non-untracked divergence — router-root declared, landed passthrough", () => {
+    // Still on the proxy, still metered. That divergence is the
+    // .session-model-alert relay's business, not a standing doctor FAIL.
+    expect(
+      classifyRoutingMode({
+        mode: "passthrough",
+        base: "http://127.0.0.1:4010/anthropic",
+        model: "opus",
+        litellmOk: "1",
+        declared: "router-root",
+        ts: "",
+      }),
+    ).toBeNull();
+  });
+
+  it("is silent for a healthy boot", () => {
+    expect(
+      classifyRoutingMode({
+        mode: "passthrough",
+        base: "http://127.0.0.1:4010/anthropic",
+        model: "opus",
+        litellmOk: "1",
+        declared: "passthrough",
+        ts: "",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("runRoutingModeChecks", () => {
+  it("is silent for a fleet of healthy agents", () => {
+    const results = runRoutingModeChecks(config("alpha", "beta"), {
+      agentsDir: AGENTS_DIR,
+      readFile: reader({
+        [path("alpha")]: record({ mode: "passthrough", declared: "passthrough" }),
+        [path("beta")]: record({
+          mode: "router-root",
+          base: "http://127.0.0.1:4010",
+          model: "fable",
+          declared: "router-root",
+        }),
+      }),
+    });
+    expect(results).toEqual([]);
+  });
+
+  it("is silent for an agent that has never written a record", () => {
+    const results = runRoutingModeChecks(config("alpha"), {
+      agentsDir: AGENTS_DIR,
+      readFile: reader({}),
+    });
+    expect(results).toEqual([]);
+  });
+
+  it("FAILs the stripped agent, names it, and leaves its healthy peers silent", () => {
+    const results = runRoutingModeChecks(config("alpha", "beta", "gamma"), {
+      agentsDir: AGENTS_DIR,
+      readFile: reader({
+        [path("alpha")]: record({ mode: "passthrough", declared: "passthrough" }),
+        [path("beta")]: record({
+          mode: "direct-oauth",
+          base: "direct",
+          litellmOk: "0",
+          declared: "passthrough",
+          ts: "2026-07-29T02:11:00Z",
+        }),
+        [path("gamma")]: record({ mode: "passthrough", declared: "passthrough" }),
+      }),
+    });
+
+    expect(results).toHaveLength(1);
+    const [row] = results;
+    expect(row.status).toBe("fail");
+    expect(row.name).toBe("litellm routing: beta");
+    expect(row.detail).toContain("direct-oauth");
+    expect(row.detail).toContain("UNTRACKED");
+    expect(row.detail).toContain("2026-07-29T02:11:00Z");
+    // The remediation must say the fix does not land until a RESTART — a key
+    // provisioned mid-session changes nothing, the strip is a boot decision.
+    expect(row.fix).toContain("switchroom apply");
+    expect(row.fix?.toUpperCase()).toContain("RESTART");
+  });
+
+  it("WARNs — never silently passes — when the record is unreadable", () => {
+    const results = runRoutingModeChecks(config("alpha"), {
+      agentsDir: AGENTS_DIR,
+      readFile: () => {
+        const err = new Error("EACCES: permission denied");
+        (err as NodeJS.ErrnoException).code = "EACCES";
+        throw err;
+      },
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe("warn");
+    expect(results[0].detail).toContain("EACCES");
+  });
+
+  it("WARNs — never silently passes — when the record is malformed", () => {
+    const results = runRoutingModeChecks(config("alpha"), {
+      agentsDir: AGENTS_DIR,
+      readFile: reader({ [path("alpha")]: "mode=passthrough\n" }),
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe("warn");
+    expect(results[0].detail).toContain("malformed");
+  });
+
+  it("returns nothing for a config with no agents", () => {
+    expect(
+      runRoutingModeChecks({ agents: {} } as unknown as SwitchroomConfig, {
+        agentsDir: AGENTS_DIR,
+        readFile: reader({}),
+      }),
+    ).toEqual([]);
+  });
+
+  it("WARNs once when the agents dir cannot be resolved", () => {
+    // resolveAgentsDir dereferences config.switchroom.agents_dir; a config
+    // with no switchroom block throws, and the check must degrade to a single
+    // visible warn row rather than crashing doctor or claiming health.
+    // The container-mode env override would short-circuit that throw, so
+    // clear it for the duration of this case.
+    const saved = process.env.SWITCHROOM_AGENTS_DIR;
+    delete process.env.SWITCHROOM_AGENTS_DIR;
+    try {
+      const results = runRoutingModeChecks(config("alpha"), {
+        agentsDir: undefined,
+        readFile: reader({}),
+      });
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe("warn");
+      expect(results[0].detail).toContain("agents directory");
+    } finally {
+      if (saved !== undefined) process.env.SWITCHROOM_AGENTS_DIR = saved;
+    }
+  });
+});

--- a/src/cli/doctor-routing-mode.ts
+++ b/src/cli/doctor-routing-mode.ts
@@ -50,7 +50,7 @@
  * `direct-oauth` — i.e. routing was stripped. Other divergences (declared
  * `router-root`, landed `passthrough`) still ride the proxy and are still
  * metered, so they are the `.session-model-alert` relay's business, not a
- * standing doctor FAIL. `declared=direct-oauth` means LiteLLM was never
+ * standing doctor row. `declared=direct-oauth` means LiteLLM was never
  * configured for that agent and there is no invariant to breach.
  */
 
@@ -129,9 +129,15 @@ export function parseRoutingModeRecord(text: string): RoutingModeRecord | null {
 /**
  * Verdict for one boot record, or null when there is nothing to report.
  *
- * FAILs (non-zero exit) rather than warns: an agent metering nothing while the
- * operator believes the fleet is fully metered is a breached invariant with a
- * concrete remediation, not a thing to glance at.
+ * WARNs rather than FAILs (operator ruling, 2026-07-29). The condition is a
+ * real breached invariant and earns a permanent, named row with a concrete
+ * remediation — but the thing it reports is a DELIBERATE availability trade:
+ * start.sh chose to boot rather than refuse, and the agent is degraded, not
+ * broken. `fail` sets `switchroom doctor`'s exit non-zero (doctor.ts sums
+ * `fails` across sections and exits 1 when the total is > 0), which would put
+ * a red build on a state the operator consciously accepted and teach them to
+ * ignore the exit code. `warn` keeps the row loud and standing without that.
+ * The exit-code contract is pinned by test, not by this comment.
  */
 export function classifyRoutingMode(
   rec: RoutingModeRecord,
@@ -141,7 +147,7 @@ export function classifyRoutingMode(
 
   const when = rec.ts ? ` at its last boot (${rec.ts})` : "";
   return {
-    status: "fail",
+    status: "warn",
     detail:
       `landed on direct-oauth${when} but its declared routing is ` +
       `\`${rec.declared}\` — start.sh's missing-key fail-open stripped the ` +

--- a/src/cli/doctor-routing-mode.ts
+++ b/src/cli/doctor-routing-mode.ts
@@ -1,0 +1,259 @@
+/**
+ * `switchroom doctor` probe for agents that booted OFF the LiteLLM proxy.
+ *
+ * ## Why this exists
+ *
+ * The operator invariant is that all agent traffic rides the LiteLLM proxy
+ * (Claude Code keeps its own OAuth passthrough; LiteLLM is the metering and
+ * guardrail layer). start.sh has exactly one path that breaks that invariant
+ * on purpose: the MISSING-KEY fail-open. When the per-agent virtual key cannot
+ * be fetched from the vault there is nothing to authenticate to the proxy
+ * with, so start.sh strips `ANTHROPIC_BASE_URL` / `SWITCHROOM_LITELLM*` and
+ * lets the session run direct against Anthropic — UNTRACKED — rather than
+ * refusing to boot. Availability wins; that trade is deliberate.
+ *
+ * The trade is only safe if the operator finds out. Today two signals exist
+ * and both are transient:
+ *
+ *   1. A `>&2` WARNING from start.sh (`profiles/_base/start.sh.hbs`, the
+ *      "litellm FAIL-OPEN" banner and its outer-pass one-liner). It goes to
+ *      the container log, which rotates, and nobody greps a healthy-looking
+ *      agent's boot log.
+ *   2. The `.session-model-alert` divergence line, which the gateway relays to
+ *      the operator ONCE per (landed, declared) pair — by design, so a
+ *      persistently degraded agent does not nag on every restart. The flip
+ *      side is that a persistently degraded agent goes quiet after the first
+ *      alert and stays quiet across every subsequent boot.
+ *
+ * So an agent can sit indefinitely on untracked direct OAuth with no standing
+ * signal anywhere. `switchroom doctor` is the standing-signal surface, and it
+ * had no check for this.
+ *
+ * ## Why `.routing-mode` and not the process environ
+ *
+ * start.sh writes `<agentDir>/.routing-mode` (0644, one line, overwritten)
+ * immediately before `exec claude`, from the same variables the session is
+ * about to launch on:
+ *
+ *   mode=<landed> base=<url|direct> model=<m> litellm_ok=<0|1> declared=<intent> ts=<iso>
+ *
+ * That is a deterministic, already-existing record of where the boot actually
+ * landed. Scraping `/proc/<pid>/environ` inside each container would need
+ * docker exec, would only work for RUNNING agents, and would re-derive by
+ * inference what start.sh already states as fact. Reading the file is the
+ * durable mechanism.
+ *
+ * ## Signal
+ *
+ * Narrow on purpose: only the untracked condition earns a row. `declared` is a
+ * LiteLLM mode (`passthrough` / `router-root`) but the boot LANDED on
+ * `direct-oauth` — i.e. routing was stripped. Other divergences (declared
+ * `router-root`, landed `passthrough`) still ride the proxy and are still
+ * metered, so they are the `.session-model-alert` relay's business, not a
+ * standing doctor FAIL. `declared=direct-oauth` means LiteLLM was never
+ * configured for that agent and there is no invariant to breach.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { resolveAgentsDir } from "../config/loader.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+import type { CheckStatus } from "./doctor-status.js";
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+/** Parsed `.routing-mode` line. Fields mirror start.sh's writer exactly. */
+export interface RoutingModeRecord {
+  /** Where the boot LANDED: direct-oauth | passthrough | router-root. */
+  mode: string;
+  /** ANTHROPIC_BASE_URL at exec, or the literal "direct" when unset. */
+  base: string;
+  /** The model the session launched on. */
+  model: string;
+  /** "1" when the boot-time liveliness probe succeeded, else "0". */
+  litellmOk: string;
+  /** Apply-time INTENT: direct-oauth | passthrough | router-root. */
+  declared: string;
+  /** ISO-8601 UTC stamp of the boot that wrote this record. */
+  ts: string;
+}
+
+/** The `declared` values that assert "this agent must ride the proxy". */
+const LITELLM_DECLARED_MODES = new Set(["passthrough", "router-root"]);
+
+/** The `mode` value that means routing was stripped — no proxy in the path. */
+const UNTRACKED_MODE = "direct-oauth";
+
+export const ROUTING_MODE_FILENAME = ".routing-mode";
+
+/** Absolute path to an agent's boot routing record. */
+export function routingModePath(agentDir: string): string {
+  return join(agentDir, ROUTING_MODE_FILENAME);
+}
+
+/**
+ * Parse the single-line `key=value key=value …` record start.sh writes.
+ *
+ * Returns null when the load-bearing fields (`mode`, `declared`) are absent —
+ * a truncated or foreign file must not be read as a healthy agent. Unknown
+ * extra keys are ignored so adding a field to the writer does not break this.
+ */
+export function parseRoutingModeRecord(text: string): RoutingModeRecord | null {
+  const line = text.split("\n").find((l) => l.trim().length > 0);
+  if (!line) return null;
+
+  const fields: Record<string, string> = {};
+  for (const tok of line.trim().split(/\s+/)) {
+    const eq = tok.indexOf("=");
+    if (eq <= 0) continue;
+    fields[tok.slice(0, eq)] = tok.slice(eq + 1);
+  }
+  if (!fields.mode || !fields.declared) return null;
+
+  return {
+    mode: fields.mode,
+    base: fields.base ?? "",
+    model: fields.model ?? "",
+    litellmOk: fields.litellm_ok ?? "",
+    declared: fields.declared,
+    ts: fields.ts ?? "",
+  };
+}
+
+/**
+ * Verdict for one boot record, or null when there is nothing to report.
+ *
+ * FAILs (non-zero exit) rather than warns: an agent metering nothing while the
+ * operator believes the fleet is fully metered is a breached invariant with a
+ * concrete remediation, not a thing to glance at.
+ */
+export function classifyRoutingMode(
+  rec: RoutingModeRecord,
+): { status: CheckStatus; detail: string } | null {
+  if (!LITELLM_DECLARED_MODES.has(rec.declared)) return null;
+  if (rec.mode !== UNTRACKED_MODE) return null;
+
+  const when = rec.ts ? ` at its last boot (${rec.ts})` : "";
+  return {
+    status: "fail",
+    detail:
+      `landed on direct-oauth${when} but its declared routing is ` +
+      `\`${rec.declared}\` — start.sh's missing-key fail-open stripped the ` +
+      `LiteLLM routing env, so this agent runs UNTRACKED on direct Anthropic ` +
+      `OAuth: no spend attribution, no guardrails` +
+      (rec.model ? ` (model \`${rec.model}\`)` : "") +
+      `.`,
+  };
+}
+
+export interface RoutingModeDeps {
+  /** Defaults to `resolveAgentsDir(config)`, resolved lazily + guarded. */
+  agentsDir?: string;
+  /** File read seam — injected in tests. Must throw on a missing file. */
+  readFile?: (p: string) => string;
+}
+
+const FIX =
+  "start.sh could not fetch this agent's `litellm/<agent>/api-key` from the " +
+  "vault-broker. Re-run `switchroom apply` (it provisions the per-agent " +
+  "virtual key idempotently and re-grants the agent's `secrets:` ACL), then " +
+  "RESTART the agent — the strip is decided once at boot and is never " +
+  "re-evaluated for the life of the session, so a fixed key does not take " +
+  "effect until the next boot. Confirm from the agent's `.routing-mode` line " +
+  "afterwards.";
+
+/**
+ * For each configured agent, report a boot that landed off the proxy.
+ *
+ * Silent for a healthy record, for an agent with no record (never booted since
+ * the writer shipped), and for an agent whose declared routing genuinely is
+ * direct-oauth. An unreadable or malformed record earns a WARN: "cannot see
+ * the evidence" must never render identically to "verified healthy", which is
+ * the exact failure mode this probe exists to end.
+ */
+export function runRoutingModeChecks(
+  config: SwitchroomConfig,
+  deps: RoutingModeDeps = {},
+): CheckResult[] {
+  const results: CheckResult[] = [];
+  const agents = Object.keys(config.agents ?? {});
+  if (agents.length === 0) return results;
+
+  const readFile = deps.readFile ?? ((p: string) => readFileSync(p, "utf-8"));
+
+  let agentsDir = deps.agentsDir;
+  if (agentsDir === undefined) {
+    try {
+      agentsDir = resolveAgentsDir(config);
+    } catch {
+      agentsDir = undefined;
+    }
+  }
+  if (agentsDir === undefined) {
+    return [
+      {
+        name: "litellm routing",
+        status: "warn",
+        detail:
+          "could not resolve the agents directory (no switchroom block) — " +
+          "skipped the boot routing-mode check",
+      },
+    ];
+  }
+
+  for (const name of agents) {
+    const path = routingModePath(join(agentsDir, name));
+
+    let text: string;
+    try {
+      text = readFile(path);
+    } catch (err) {
+      // ENOENT is the honest "this agent has not booted since the writer
+      // shipped" case and stays silent. Anything else (EACCES on a
+      // hardened agent dir, EISDIR, I/O error) is a blind spot worth a row.
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") continue;
+      results.push({
+        name: `litellm routing: ${name}`,
+        status: "warn",
+        detail:
+          `could not read the boot routing record at ${path} ` +
+          `(${code ?? (err as Error).message}) — an untracked boot would go ` +
+          `unreported here.`,
+        fix: `Check the file's ownership and mode (start.sh writes it 0644 before \`exec claude\`).`,
+      });
+      continue;
+    }
+
+    const rec = parseRoutingModeRecord(text);
+    if (!rec) {
+      results.push({
+        name: `litellm routing: ${name}`,
+        status: "warn",
+        detail:
+          `the boot routing record at ${path} is malformed (no \`mode=\`/` +
+          `\`declared=\` fields) — an untracked boot would go unreported here.`,
+        fix: `Delete it and restart the agent to have start.sh rewrite it: rm ${path}`,
+      });
+      continue;
+    }
+
+    const verdict = classifyRoutingMode(rec);
+    if (!verdict) continue;
+
+    results.push({
+      name: `litellm routing: ${name}`,
+      status: verdict.status,
+      detail: verdict.detail,
+      fix: FIX,
+    });
+  }
+
+  return results;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -57,6 +57,7 @@ import { checkObservationScopeSaturation } from "./doctor-observation-scopes.js"
 import { checkHindsightWatchArmed } from "./doctor-hindsight-watch.js";
 import { runLitellmModelChecks } from "../litellm/model-validation.js";
 import { runLitellmKeyAllowlistChecks } from "../litellm/key-allowlist-check.js";
+import { runRoutingModeChecks } from "./doctor-routing-mode.js";
 import { isVaultReference, parseVaultReference } from "../vault/resolver.js";
 import { isDockerMode, runDockerChecks } from "./doctor-docker.js";
 import { runAuthBrokerChecks } from "./doctor-auth-broker.js";
@@ -3868,6 +3869,18 @@ export function registerDoctorCommand(program: Command): void {
                 }
               },
             }),
+          },
+          {
+            // The half both LiteLLM sections above are blind to: they prove
+            // the PROXY is configured correctly, not that each agent's session
+            // actually rode it. start.sh's missing-key fail-open strips the
+            // routing env and boots UNTRACKED on direct Anthropic OAuth — loud
+            // in a rotating container log, and relayed to the operator only
+            // ONCE per (landed, declared) pair, so a persistently degraded
+            // agent goes quiet. This reads the per-boot `.routing-mode` record
+            // and gives that state a standing signal.
+            title: "LiteLLM boot routing",
+            results: runRoutingModeChecks(config),
           },
           { title: "Telegram", results: await checkTelegram(config) },
           {

--- a/tests/cheap-cron-session-render.test.ts
+++ b/tests/cheap-cron-session-render.test.ts
@@ -177,6 +177,14 @@ describe("cron-session.sh LiteLLM routing — mirrors start.sh boot block", () =
     expect(out).toContain("falling back to direct OAuth");
   });
 
+  it("MISSING KEY log tells the operator what to DO, and that cron needs no restart", () => {
+    // Diagnosis without remediation leaves the operator guessing. Cron re-runs
+    // this block on every fire, so — unlike start.sh — the fix lands without a
+    // restart; saying so stops an operator bouncing the agent for nothing.
+    expect(out).toContain("FIX: re-run 'switchroom apply'");
+    expect(out).toContain("no restart needed");
+  });
+
   it("PROXY UNREACHABLE with key does NOT fail open — keeps routing + self-heals (ported from start.sh)", () => {
     // The pre-#2940 cron logic unset routing on unreachable → untracked direct
     // OAuth for the fire. The new contract keeps routing in place, loud-warns,

--- a/tests/doctor-routing-mode-boot.test.ts
+++ b/tests/doctor-routing-mode-boot.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Producer ↔ consumer coupling for the untracked-LiteLLM-boot signal.
+ *
+ * `src/cli/doctor-routing-mode.ts` parses a one-line record that a SHELL
+ * `printf` in `profiles/_base/start.sh.hbs` writes. Nothing in the type system
+ * connects the two, so a reworded field in the template would silently turn
+ * the doctor check into a no-op — reporting a perfectly clean fleet while an
+ * agent burns untracked tokens. That is the exact class of failure this check
+ * exists to end, so it must not be possible to reintroduce it here.
+ *
+ * These tests therefore run the REAL rendered start.sh routing block under the
+ * REAL missing-key strip conditions, let it write a REAL `.routing-mode` file,
+ * and feed that file to the REAL doctor check off disk. No hand-written
+ * fixture strings.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { basename, dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { scaffoldAgent } from "../src/agents/scaffold.js";
+import { runRoutingModeChecks } from "../src/cli/doctor-routing-mode.js";
+import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+const BLOCK_HEADER = "# --- Session model resolution";
+const AGENT = "routing-doctor-agent";
+
+function makeSwitchroomConfig(name: string, agentConfig: AgentConfig): SwitchroomConfig {
+  return {
+    switchroom: {
+      version: 1,
+      agents_dir: "~/.switchroom/agents",
+      skills_dir: "~/.switchroom/skills",
+    },
+    telegram: telegramConfig,
+    agents: { [name]: agentConfig },
+  };
+}
+
+describe("untracked-boot signal: rendered start.sh → switchroom doctor", () => {
+  let tmpDir: string;
+  let agentDir: string;
+  let block: string;
+
+  /** Scaffold the agent and slice the resolver→routing-write block out of it. */
+  function scaffold(model: string): void {
+    const config = { extends: "default", topic_name: "T", schedule: [], model } as AgentConfig;
+    const res = scaffoldAgent(
+      AGENT,
+      config,
+      tmpDir,
+      telegramConfig,
+      makeSwitchroomConfig(AGENT, config),
+    );
+    agentDir = res.agentDir;
+    const startSh = readFileSync(join(agentDir, "start.sh"), "utf-8");
+    const start = startSh.indexOf(BLOCK_HEADER);
+    const end = startSh.indexOf('if [ -n "$APPEND_PROMPT" ]', start);
+    expect(start, "session-model resolver block not found in rendered start.sh").toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    block = startSh.slice(start, end);
+  }
+
+  /**
+   * Simulate the MISSING-KEY fail-open exactly as start.sh's litellm block
+   * leaves the environment: routing vars stripped, but SWITCHROOM_LITELLM_
+   * DECLARED still carrying the pre-strip intent, and neither _LITELLM_OK nor
+   * _LITELLM_UNREACHABLE set.
+   */
+  function bootStripped(): void {
+    execFileSync(
+      "bash",
+      [
+        "-c",
+        [
+          "set -e",
+          "unset SWITCHROOM_CONFIG ANTHROPIC_BASE_URL SWITCHROOM_LITELLM SWITCHROOM_LITELLM_BASE",
+          'export SWITCHROOM_LITELLM_DECLARED="1"',
+          '_LITELLM_OK=""',
+          '_LITELLM_UNREACHABLE=""',
+          block,
+        ].join("\n"),
+      ],
+      { encoding: "utf-8" },
+    );
+  }
+
+  /** A healthy boot: key present, proxy live, riding the /anthropic passthrough. */
+  function bootHealthy(): void {
+    execFileSync(
+      "bash",
+      [
+        "-c",
+        [
+          "set -e",
+          "unset SWITCHROOM_CONFIG",
+          'export ANTHROPIC_BASE_URL="http://litellm:4010/anthropic"',
+          'export SWITCHROOM_LITELLM_BASE="http://litellm:4010"',
+          'export SWITCHROOM_LITELLM_DECLARED="1"',
+          '_LITELLM_OK="1"',
+          '_LITELLM_UNREACHABLE=""',
+          block,
+        ].join("\n"),
+      ],
+      { encoding: "utf-8" },
+    );
+  }
+
+  /** Run the real doctor check against the real file on disk. */
+  function doctor() {
+    return runRoutingModeChecks(
+      { agents: { [basename(agentDir)]: {} } } as unknown as SwitchroomConfig,
+      { agentsDir: dirname(agentDir) },
+    );
+  }
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-doctor-routing-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("FAILs doctor after a real missing-key boot lands on untracked direct OAuth", () => {
+    scaffold("claude-sonnet-5"); // declares passthrough
+    bootStripped();
+
+    // Precondition: the shell really did record the untracked landing. If this
+    // ever stops holding, the assertion below is meaningless.
+    const record = readFileSync(join(agentDir, ".routing-mode"), "utf-8");
+    expect(record).toContain("mode=direct-oauth");
+    expect(record).toContain("declared=passthrough");
+
+    const results = doctor();
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe("fail");
+    expect(results[0].name).toContain(AGENT);
+    expect(results[0].detail).toContain("UNTRACKED");
+    expect(results[0].fix).toContain("switchroom apply");
+  });
+
+  it("FAILs doctor for a stripped router-root agent (fable) too", () => {
+    scaffold("fable"); // declares router-root
+    bootStripped();
+    expect(readFileSync(join(agentDir, ".routing-mode"), "utf-8")).toContain("declared=router-root");
+
+    const results = doctor();
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe("fail");
+  });
+
+  it("stays silent after a real healthy boot on the passthrough", () => {
+    scaffold("claude-sonnet-5");
+    bootHealthy();
+    expect(readFileSync(join(agentDir, ".routing-mode"), "utf-8")).toContain("mode=passthrough");
+    expect(doctor()).toEqual([]);
+  });
+
+  it("stays silent for an agent that has never booted (no record written)", () => {
+    scaffold("claude-sonnet-5");
+    expect(existsSync(join(agentDir, ".routing-mode"))).toBe(false);
+    expect(doctor()).toEqual([]);
+  });
+
+  it("stays silent when LiteLLM was never configured for the agent", () => {
+    // No SWITCHROOM_LITELLM_DECLARED at all → start.sh forces
+    // declared=direct-oauth, landed matches, no invariant to breach.
+    scaffold("claude-sonnet-5");
+    execFileSync(
+      "bash",
+      [
+        "-c",
+        [
+          "set -e",
+          "unset SWITCHROOM_CONFIG ANTHROPIC_BASE_URL SWITCHROOM_LITELLM SWITCHROOM_LITELLM_BASE SWITCHROOM_LITELLM_DECLARED",
+          '_LITELLM_OK=""',
+          '_LITELLM_UNREACHABLE=""',
+          block,
+        ].join("\n"),
+      ],
+      { encoding: "utf-8" },
+    );
+    expect(readFileSync(join(agentDir, ".routing-mode"), "utf-8")).toContain("declared=direct-oauth");
+    expect(doctor()).toEqual([]);
+  });
+});

--- a/tests/doctor-routing-mode-boot.test.ts
+++ b/tests/doctor-routing-mode-boot.test.ts
@@ -14,7 +14,7 @@
  * fixture strings.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { basename, dirname, join } from "node:path";
@@ -22,6 +22,7 @@ import { tmpdir } from "node:os";
 
 import { scaffoldAgent } from "../src/agents/scaffold.js";
 import { runRoutingModeChecks } from "../src/cli/doctor-routing-mode.js";
+import { printSection } from "../src/cli/doctor.js";
 import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
 
 const telegramConfig: TelegramConfig = {
@@ -121,6 +122,20 @@ describe("untracked-boot signal: rendered start.sh → switchroom doctor", () =>
     );
   }
 
+  /**
+   * Push rows through doctor's REAL section counter. `switchroom doctor` exits
+   * 1 iff the summed `fails` is > 0 (src/cli/doctor.ts), so a zero `fails`
+   * tally here is the actual "does not turn the build red" assertion.
+   */
+  function counts(results: ReturnType<typeof doctor>) {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      return printSection("LiteLLM boot routing", results);
+    } finally {
+      logSpy.mockRestore();
+    }
+  }
+
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "switchroom-doctor-routing-"));
   });
@@ -129,7 +144,7 @@ describe("untracked-boot signal: rendered start.sh → switchroom doctor", () =>
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("FAILs doctor after a real missing-key boot lands on untracked direct OAuth", () => {
+  it("WARNs doctor after a real missing-key boot lands on untracked direct OAuth", () => {
     scaffold("claude-sonnet-5"); // declares passthrough
     bootStripped();
 
@@ -141,20 +156,34 @@ describe("untracked-boot signal: rendered start.sh → switchroom doctor", () =>
 
     const results = doctor();
     expect(results).toHaveLength(1);
-    expect(results[0].status).toBe("fail");
+    expect(results[0].status).toBe("warn");
     expect(results[0].name).toContain(AGENT);
     expect(results[0].detail).toContain("UNTRACKED");
     expect(results[0].fix).toContain("switchroom apply");
   });
 
-  it("FAILs doctor for a stripped router-root agent (fable) too", () => {
+  it("does NOT make doctor exit non-zero — real shell boot → real fail tally", () => {
+    // The end-to-end version of the operator's 2026-07-29 ruling: a REAL
+    // rendered start.sh really stripping the routing env must leave a standing
+    // row, and that row must contribute ZERO to the counter doctor exits on.
+    scaffold("claude-sonnet-5");
+    bootStripped();
+    expect(readFileSync(join(agentDir, ".routing-mode"), "utf-8")).toContain("mode=direct-oauth");
+
+    const results = doctor();
+    expect(results).toHaveLength(1); // the row is really there…
+    expect(counts(results)).toEqual({ oks: 0, warns: 1, fails: 0, skips: 0 }); // …and costs 0 fails
+  });
+
+  it("WARNs doctor for a stripped router-root agent (fable) too", () => {
     scaffold("fable"); // declares router-root
     bootStripped();
     expect(readFileSync(join(agentDir, ".routing-mode"), "utf-8")).toContain("declared=router-root");
 
     const results = doctor();
     expect(results).toHaveLength(1);
-    expect(results[0].status).toBe("fail");
+    expect(results[0].status).toBe("warn");
+    expect(counts(results).fails).toBe(0);
   });
 
   it("stays silent after a real healthy boot on the passthrough", () => {

--- a/tests/scaffold.litellm-failopen.test.ts
+++ b/tests/scaffold.litellm-failopen.test.ts
@@ -135,6 +135,14 @@ describe("scaffoldAgent: LiteLLM fail-open boot contract (#litellm)", () => {
     // MISSING-KEY branch is still logged LOUDLY (not silent).
     expect(innerBlock).toContain("no litellm virtual key for agent");
 
+    // …and ACTIONABLY: the banner must carry the remediation AND the fact that
+    // the fail-open is a boot-time decision. Without the latter an operator
+    // provisions the key, sees nothing change, and concludes the key was not
+    // the cause — the session stays untracked until an unrelated restart.
+    expect(innerBlock).toContain("FIX: re-run 'switchroom apply'");
+    expect(innerBlock).toContain("RESTART this agent");
+    expect(innerBlock).toContain("never re-evaluated for the life of this session");
+
     // Per-AGENT attribution headers, keyed off the agent name (unchanged path).
     expect(startSh).toContain("x-litellm-api-key: Bearer $sr_ll_key");
     expect(startSh).toContain("x-litellm-customer-id: $SWITCHROOM_AGENT_NAME");

--- a/tests/scaffold.litellm-gateway-outer.test.ts
+++ b/tests/scaffold.litellm-gateway-outer.test.ts
@@ -129,6 +129,30 @@ describe("start.sh: LiteLLM ANTHROPIC_CUSTOM_HEADERS hoisted before gateway fork
     expect(outerSlice).toContain("no virtual key for agent");
   });
 
+  it("outer missing-key warning is ACTIONABLE: names the fix and the restart requirement", () => {
+    const startSh = renderStartSh();
+    const forkIdx = startSh.indexOf(GATEWAY_FORK);
+    const outerSlice = startSh.slice(startSh.indexOf(LITELLM_GATE), forkIdx);
+
+    // "untracked" alone is a diagnosis, not an instruction. The trap this
+    // closes: the strip is decided ONCE at boot, so an operator who
+    // provisions the key without restarting sees no change and reasonably
+    // concludes the key was not the problem.
+    expect(outerSlice).toContain("FIX: re-run 'switchroom apply'");
+    expect(outerSlice).toContain("RESTART this agent");
+    expect(outerSlice).toContain("never re-evaluated for the life of the session");
+
+    // The message is a DOUBLE-quoted shell string, so a backtick in it is
+    // command substitution executed at boot, not markup. Assert on the echo
+    // line itself (the surrounding block has backticks in comments, which are
+    // harmless).
+    const warnLine = outerSlice
+      .split("\n")
+      .find((l) => l.includes("no virtual key for agent"));
+    expect(warnLine, "outer missing-key warning line not found").toBeTruthy();
+    expect(warnLine).not.toContain("`");
+  });
+
   it("outer dispatch (executed): UNREACHABLE keeps routing env + HEADERS, MISSING KEY strips it", () => {
     const startSh = renderStartSh();
     // Extract JUST the outer dispatch (decision + scratch cleanup): from the


### PR DESCRIPTION
## Heads up: the premise this was dispatched on does not hold at HEAD

This work was requested as "the missing-virtual-key strip path is silent — add a `>&2` WARNING". **It is not silent.** All three emitters already warn, and have since #2940 (2026-07-08):

| Emitter | Source | Text |
|---|---|---|
| outer (gateway pass) | `profiles/_base/start.sh.hbs:111` | `litellm(outer): WARNING — no virtual key for agent '$SWITCHROOM_AGENT_NAME'; gateway falling back to direct Anthropic OAuth (untracked, unguarded).` |
| inner (claude pass) | `profiles/_base/start.sh.hbs:1562-1566` | 5-line `==== litellm FAIL-OPEN ====` banner |
| cron | `profiles/_base/cron-session.sh.hbs:130` | `litellm(cron): no virtual key for '<name>' — falling back to direct OAuth (untracked, unguarded)` |

They are already test-pinned (`tests/scaffold.litellm-gateway-outer.test.ts:129`, `tests/scaffold.litellm-failopen.test.ts:136`, `tests/cheap-cron-session-render.test.ts:176`). The reading that produced the premise looked at the strip `unset` line in the generated artifact and saw only a shell comment beside it; the warning is emitted earlier in the same branch, and the `unset` is reachable **only** from that branch.

So the required item was already done. Two gaps that ARE real are what this PR fixes.

## Gap 1 (the substance) — the signal has no standing form

Both existing signals expire:

- The `>&2` banner lands in a container log that rotates. Nobody greps the boot log of an agent that looks healthy.
- The `.routing-mode` divergence line is relayed to the operator **once per (landed, declared) pair**, deliberately (`start.sh.hbs:2096-2102`), so a persistently degraded agent goes quiet after its first alert and stays quiet across every later boot.

An agent can therefore sit indefinitely on untracked direct OAuth with nothing standing anywhere saying so. `switchroom doctor` is the standing-signal surface and had no check — nothing in `src/` reads `.routing-mode` at all today.

Adds a **`LiteLLM boot routing`** doctor section (`src/cli/doctor-routing-mode.ts`, wired at `src/cli/doctor.ts:3873`) that reads the per-boot `.routing-mode` record start.sh already writes (0644, one line, overwritten immediately before `exec claude`) and **WARNs** when `declared` is a LiteLLM mode but the boot LANDED on `direct-oauth`:

```
! litellm routing: beta
  landed on direct-oauth at its last boot (2026-07-29T02:11:00Z) but its declared
  routing is `passthrough` — start.sh's missing-key fail-open stripped the LiteLLM
  routing env, so this agent runs UNTRACKED on direct Anthropic OAuth: no spend
  attribution, no guardrails (model `opus`).
  → start.sh could not fetch this agent's `litellm/<agent>/api-key` from the
    vault-broker. Re-run `switchroom apply` …, then RESTART the agent — the strip
    is decided once at boot and is never re-evaluated …
```

**Why the file and not `/proc/<pid>/environ`.** The record is already a deterministic statement of where the boot landed, written from the same variables the session launches on. Environ scraping would need `docker exec`, would only cover RUNNING agents, and would re-derive by inference what start.sh states as fact. (Verified on the live fleet: `{{agentDir}}` renders to `<agents_dir>/<name>`, exactly what `resolveAgentsDir()` computes, and the files are 0644 so the operator UID can read them.)

**Scope is narrow on purpose.**
- A divergence that still rides the proxy (declared `router-root`, landed `passthrough`) is metered — that stays the `.session-model-alert` relay's business, not a standing row.
- `declared=direct-oauth` means LiteLLM was never configured. Compose injects **no** routing env when the key was unconfirmed at apply time (`tests/docker/compose-generator.test.ts:3589`), so an unprovisioned agent cannot false-alarm here.
- Which means a row can only mean *compose believed the key existed and boot could not fetch it* — a real anomaly.
- **Severity: `warn`, per Ken's ruling (2026-07-29).** This was the one open question and it is now settled: the row stays standing, named, and loud, but it does **not** set `switchroom doctor`'s exit non-zero. Rationale — the condition reports a *deliberate* availability trade (start.sh chose to boot rather than refuse), so the agent is degraded, not broken; a `fail` would red the exit code over a state the operator consciously accepted, which is how an exit code gets trained into noise. Nothing else moved: detection, detail text, remediation, and the shell-template banners are exactly as reviewed.
- Unreadable/malformed record → `warn`. "Cannot see the evidence" must never render identically to "verified healthy" — that is the exact failure mode being closed.

## Gap 2 — the warnings diagnose but don't instruct

The existing messages name the agent and say "untracked, unguarded", but none says what to do, and none says the decisive part: **the strip is a boot-time decision that is never re-evaluated.** An operator who provisions the key without restarting sees no change and reasonably concludes the key was not the cause. One appended sentence per emitter:

```
… FIX: re-run 'switchroom apply' to provision the key, then RESTART this agent
— the fail-open is decided once at boot and is never re-evaluated for the life
of the session.
```

Cron gets its own wording because its block re-runs on **every fire** and genuinely needs no restart — telling an operator to bounce the agent there would be wrong.

Single quotes, not backticks: these are double-quoted shell strings, so a backtick would be command substitution at boot. Pinned by an assertion on the echo line itself; the rendered lines were executed under `bash -eu` to confirm they emit literally.

## Explicitly NOT done

**No hard-fail on boot.** Considered and rejected upstream of this PR, and I agree: an agent that refuses to boot over a provisioning gap is worse than one that boots untracked and shouts. Availability wins; observability was the gap.

## Tests fail without the fix

Not "the code path exists" tests — both halves were proven by reverting:

- Neutering `classifyRoutingMode` to its pre-fix behaviour (return null on the untracked condition) → **5 failures** across `src/cli/doctor-routing-mode.test.ts` and `tests/doctor-routing-mode-boot.test.ts`.
- `git stash`-ing just the two template edits → **3 failures** across the three render tests.
- Flipping the severity back to `fail` → **9 of 25 failures** across those same two suites; restored to `warn`, **25/25 green**. (Mutation-verified both directions after the 2026-07-29 downgrade.)

The severity is pinned by **outcome**, not by a comment. Both suites carry an `exit status` case that pushes the real rows through doctor's real `printSection` counter — the very function whose summed `fails` decides `process.exit(1)` in `src/cli/doctor.ts` — and asserts the fail tally is **zero**, including end-to-end where a REAL rendered `start.sh` really strips the routing env and writes `.routing-mode` off disk. Each asserts the row still exists first (`toHaveLength(1)`), so the tally cannot reach zero because the check died.

`tests/doctor-routing-mode-boot.test.ts` closes the producer/consumer gap nothing in the type system covers: the doctor check parses a record a **shell `printf`** writes. It scaffolds a real agent, executes the REAL rendered start.sh routing block under the REAL missing-key strip conditions, lets it write a REAL `.routing-mode` file, and feeds that file to the REAL doctor check off disk. A reworded field in the template can no longer silently turn the check into a no-op that reports a clean fleet.

## Local verification

- `vitest run tests/scaffold tests/cheap-cron src/cli/doctor` → **966 passed**, 2 failures in `tests/scaffold.persistent-home.test.ts` that reproduce identically on pristine `origin/main` in the same worktree (container runs as root with a real `~/.switchroom`; env artifact, bucket 3).
- `tsc --noEmit` clean.
- Lint guards run: `check-bun-test-imports`, `check-test-runner-coverage`, `check-bun-module-mock-scope`, `check-no-pii-secrets`, `check-litellm-config-guard`, `check-stale-tool-descriptions`, `check-agent-attribution-trailers` — all OK. `check-plugin-references` fails on `Cannot find module '@mtcute/node'` in this worktree's borrowed `node_modules`; identical failure on pristine `origin/main`, so env-only. CI is the authority.

## Fleet state

Measured before writing anything: all 12 running agents have `SWITCHROOM_LITELLM=1` + `ANTHROPIC_BASE_URL` in their live environ, and every `.routing-mode` on disk reads `mode=passthrough … litellm_ok=1 declared=passthrough`. **Zero agents are in the stripped state.** This is insurance, not an incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

