### PR TITLE
fix(pins): one meaning per sweep counter, and a store reader that degrades

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,37 @@ When the canonical `switchroom/switchroom:main` is ready to ship:
 
 npm publishes come from the canonical repo only.
 
+#### Rolling a release back — on-disk state the newer build already wrote
+
+Rolling back the code does not roll back the JSON state files a running fleet
+has already written. Before downgrading a fleet, check whether the version you
+are leaving bumped an on-disk envelope, because a reader that cannot make sense
+of a file **loses whatever that file was remembering**.
+
+The pair that bites is the Telegram gateway's pin state, under
+`~/.switchroom/agents/<name>/telegram/`:
+
+- `status-pins.json` — the only record of which messages the gateway pinned.
+  Lose it and every pin the newer build took becomes a permanent orphan that
+  boot cleanup can never see again (#3957).
+- `stale-pin-sweep.json` — the durable sweep obligation ledger. Same hazard.
+
+Rules:
+
+- **Envelope bumps stay additive.** Every field added after `v: 1` is optional,
+  so a build that does not know the version can still validate rows
+  structurally — and both readers are deliberately version-TOLERANT: an unknown
+  `v` is read row by row, never discarded. A change that ever needs to be
+  non-additive must change the **filename**, not just `v`.
+- **One known-lossy hop exists and cannot be fixed retroactively:**
+  **v0.19.31+ → v0.19.30 or older.** `v: 4` was added by #3953 (shipped in
+  v0.19.31) and readers up to v0.19.30 only know v1–v3, so they fail open to
+  `[]` and drop every pin row. Version tolerance landed after v0.19.32, so it
+  protects the NEXT bump, not that one. If you must make that hop, drain the
+  pins first — stop the fleet on the newer build, let boot cleanup run, confirm
+  the file reads `{"v":4,"pins":[]}` — or expect to clear a handful of stale
+  pins by hand afterwards.
+
 ### 3. Local deploy (optional)
 
 If you maintain your own fleet of switchroom-managed agents on a personal

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ operators jump to **Operating**; contributors and reviewers use
 | [operators/rollback-v0.7.12.md](operators/rollback-v0.7.12.md) | Rollback runbook: v0.7.12 → v0.7.11. |
 | [scheduling.md](scheduling.md) | Scheduled tasks via the in-container scheduler sibling. |
 | [crash-reports.md](crash-reports.md) | What the watchdog records when it kills an agent. |
+| [operators/stale-pin-cleanup.md](operators/stale-pin-cleanup.md) | Clearing orphaned bot pins the automatic sweep deliberately cannot touch. |
 | [status-ask-cause-classes.md](status-ask-cause-classes.md) | Cause-class catalog for driving the status-ask rate to zero. |
 | [session-optimization.md](session-optimization.md) | Managing context/tokens in long-running agents. |
 | [sub-agents.md](sub-agents.md) | Sub-agent delegation ("Opus plans, Sonnet implements"). |

--- a/docs/operators/stale-pin-cleanup.md
+++ b/docs/operators/stale-pin-cleanup.md
@@ -1,0 +1,82 @@
+# Clearing orphaned bot pins
+
+The gateway pins things: the foreground activity card, worker feeds, the slot
+banner, `pin_message` tool pins. A crash mid-turn can leave one of those pinned
+forever — an **orphan**. The boot sweep
+(`telegram-plugin/gateway/stale-pin-sweep.ts`) exists to drain them, and on a
+current build it does so automatically. This page is for the residue it
+deliberately cannot touch.
+
+## What the automatic sweep will and will not do
+
+A Telegram chat holds a **stack** of pinned messages. A bot cannot enumerate
+it: `getChat().pinned_message` exposes only the top, and there is no list-pins
+method. So the sweep is not a stack walk — in a group it unpins **exactly the
+message ids the gateway is on record as having pinned**, from
+`status-pins.json` plus the pinned activity cards.
+
+That restriction is a correctness requirement, not caution.
+`unpinAllChatMessages` clears a group's whole stack in one silent call, and
+"whole stack" includes **other people's pins** — measured, it destroyed a
+pre-existing pin that predated the test. In a real team chat that is
+unrecoverable. A pin the gateway did not place is not the gateway's to remove.
+
+The cost is a blind spot. An orphan the gateway has no record of — one left by
+a build that predates durable pin records, or one whose store row was lost — is
+invisible to the sweep and will never be cleared automatically. In the gateway
+log it shows up as:
+
+```
+telegram gateway: stale-pin-sweep: chat=-100… thread=… kind=supergroup status=skipped-nothing-recorded …
+```
+
+`skipped-nothing-recorded` means "there is nothing here this gateway may
+legitimately remove", not "the chat is clean". If you can still see a stale
+pin in the chat after that line, it is an unrecorded orphan and one of the two
+remedies below applies.
+
+## Remedy 1 — unpin it by hand (default)
+
+Fastest and safest, because you can see exactly what you are removing: in the
+Telegram client, open the pinned-message bar, find the stale card, and unpin
+it. Long-press → **Unpin** on mobile; the pin bar's context menu on desktop.
+
+You need `can_pin_messages` in that chat, same as the bot. Nothing in
+switchroom needs to be restarted — the sweep only ever removed pins it
+recorded, so removing an unrecorded one behind its back cannot desynchronise
+anything.
+
+## Remedy 2 — the wholesale topic drain (opt-in, forum supergroups only)
+
+For a forum topic with more orphans than you want to click through, a
+deployment can opt into `unpinAllForumTopicMessages`:
+
+```
+SWITCHROOM_PIN_SWEEP_UNPIN_ALL_TOPIC=1
+```
+
+Set it in the agent's environment and restart the agent; the next boot sweep
+uses it for `forum-topic` targets.
+
+**Read this before you set it.** The verb is genuinely topic-scoped — it is
+the only pin verb a bot has that takes a `message_thread_id` — but *within*
+that topic it is indiscriminate: it removes every pin in the topic, including
+ones the gateway never placed and ones a human deliberately pinned. That is why
+it is off by default and why it is a remedy rather than a policy. Turn it on,
+let one boot sweep run, turn it back off.
+
+It also runs **once** per sweep, never in a loop: on a deep stack the unpin-all
+family can peg at `429 retry_after: 3` with zero progress, because TDLib
+services it through `run_affected_history_query_until_complete`, which re-issues
+the identical query while the result is not final. Retrying that is not slow,
+it is non-terminating. A 429 there is reported as `deferred-flood` and the
+sweep yields to the next boot.
+
+## What is deliberately not offered
+
+There is no "unpin everything in this chat" switch and no automatic fallback
+that clears an unrecorded orphan, because both would mean the gateway removing
+pins it did not place. See
+[#3960](https://github.com/switchroom/switchroom/issues/3960) for the full
+reasoning, and `telegram-plugin/gateway/stale-pin-sweep.ts` for where it is
+enforced.

--- a/telegram-plugin/gateway/stale-pin-sweep-store.ts
+++ b/telegram-plugin/gateway/stale-pin-sweep-store.ts
@@ -102,12 +102,20 @@ export interface SweepStoreFsSeam {
   existsSync: (path: string) => boolean
 }
 
+/**
+ * Envelope. Same bump rule as `status-pin-store.ts` (#3957): every field added
+ * after v1 is OPTIONAL, and the reader is version-TOLERANT so a row written by
+ * a newer build survives a downgrade rather than being discarded. Discarding is
+ * not "do nothing" for an obligation ledger — it forgets an obligation, which
+ * is precisely the orphaned-pin failure this module exists to close.
+ */
 interface SweepEnvelope {
-  v: 1
+  v: number
   cursors: SweepCursor[]
 }
 
-const SWEEP_ENVELOPE_VERSIONS = new Set([1])
+/** The version THIS build writes. Only the writer is pinned; see above. */
+const SWEEP_ENVELOPE_VERSION = 1
 
 /** Stable identity of a sweep target: chat plus topic (topic-less = `-`). */
 export function sweepTargetKey(chatId: string, threadId?: number): string {
@@ -153,11 +161,9 @@ export function loadSweepCursors(path: string, fs: SweepStoreFsSeam): SweepCurso
   }
   if (parsed == null || typeof parsed !== 'object') return []
   const env = parsed as Record<string, unknown>
-  if (
-    typeof env.v !== 'number' ||
-    !SWEEP_ENVELOPE_VERSIONS.has(env.v) ||
-    !Array.isArray(env.cursors)
-  ) {
+  // Version-TOLERANT, structurally strict — see {@link SweepEnvelope}. An
+  // unknown `v` still yields the cursor rows that validate.
+  if (!Number.isInteger(env.v) || (env.v as number) < 1 || !Array.isArray(env.cursors)) {
     return []
   }
   return env.cursors.filter(isCursorRow)
@@ -174,7 +180,7 @@ export function persistSweepCursors(
   cursors: readonly SweepCursor[],
   log: (line: string) => void = (l) => process.stderr.write(l),
 ): void {
-  const env: SweepEnvelope = { v: 1, cursors: [...cursors] }
+  const env: SweepEnvelope = { v: SWEEP_ENVELOPE_VERSION, cursors: [...cursors] }
   try {
     fs.writeFileSync(path, JSON.stringify(env))
   } catch (err) {

--- a/telegram-plugin/gateway/stale-pin-sweep.test.ts
+++ b/telegram-plugin/gateway/stale-pin-sweep.test.ts
@@ -73,6 +73,15 @@ interface FakeOpts {
   pinErrors?: (unknown | null)[]
   /** Errors to throw from `unpinAllForumTopicMessages`, consumed in order. */
   unpinAllErrors?: (unknown | null)[]
+  /**
+   * Ids `unpinAllForumTopicMessages` removes. Undefined = the whole stack.
+   *
+   * The verb is TOPIC-scoped while `getChat` exposes the CHAT-wide top, so a
+   * successful topic drain routinely leaves pins belonging to other topics —
+   * including the one on top — untouched. That is exactly the case where a
+   * call-counted `popped` and an observation-counted `popped` disagree.
+   */
+  unpinAllTopicRemoves?: number[]
   canPin?: boolean
   /** Throws from `getChat`, consumed in order (null = normal read). */
   getChatErrors?: (unknown | null)[]
@@ -114,7 +123,14 @@ function fakeChat(o: FakeOpts) {
       calls.push(`unpinAllTopic:${threadId}`)
       const err = unpinAllErrors.shift()
       if (err != null) throw err
-      stack.length = 0
+      if (o.unpinAllTopicRemoves == null) {
+        stack.length = 0
+      } else {
+        for (const id of o.unpinAllTopicRemoves) {
+          const at = stack.indexOf(id)
+          if (at >= 0) stack.splice(at, 1)
+        }
+      }
       return { ok: true }
     },
     canPinInChat: async () => {
@@ -268,6 +284,32 @@ describe('stale-pin sweep — draining a stacked chat', () => {
     const res = await createStalePinSweeper(h.deps).sweepTarget({ chatId: DM })
     expect(res.status).toBe('incomplete')
     expect(h.fake.stack).toEqual([41])
+  })
+
+  it('does not lose an unpin that landed after the verifying read went dark (#3956)', async () => {
+    // Sequence: read/read agree on 61 → repin 61 → unpin 61 (it really pops) →
+    // the read that WOULD have verified it throws, so the sweep exits early.
+    //
+    // `popped` must stay 0 — the module never credits an unobserved pop — but
+    // the removal must not vanish from the accounting either: it is reported as
+    // one `issued`, which is what makes the ledger's "went out, unverified"
+    // figure honest instead of silently short by one.
+    const h = harness({ stack: [61, 62], getChatErrors: [null, null, new Error('ETIMEDOUT')] })
+    const res = await createStalePinSweeper(h.deps).sweepTarget({ chatId: DM })
+
+    expect(res.status).toBe('incomplete')
+    // The pop DID happen in the chat — this is not a hypothetical loss.
+    expect(h.fake.stack).toEqual([62])
+    expect(res.popped).toBe(0)
+    expect(res.issued).toBe(1)
+  })
+
+  it('reports issued alongside popped on a clean DM drain', async () => {
+    const h = harness({ stack: [71, 72] })
+    const res = await createStalePinSweeper(h.deps).sweepTarget({ chatId: DM })
+    expect(res.status).toBe('drained')
+    expect(res.popped).toBe(2)
+    expect(res.issued).toBe(2)
   })
 
   it('accepts Telegram\'s honest empty-stack signal from unpin', async () => {
@@ -446,6 +488,38 @@ describe('stale-pin sweep — forum topics', () => {
     expect(res.status).toBe('deferred-flood')
     expect(h.fake.calls.filter((c) => c === 'unpinAllTopic:77')).toHaveLength(1)
     expect(h.sleeps).not.toContain(3000) // it did not even back off — it gave up
+  })
+
+  it('credits the wholesale drain a POP only when the observed top moved (#3955)', async () => {
+    // A real, ordinary shape: the topic drain clears THIS topic's pins (202)
+    // while the chat-wide top (201) belongs to another topic and survives. The
+    // obligation IS discharged, but nothing observable moved — so this is one
+    // `issued`, zero `popped`. Counting the call as a pop would give the forum
+    // branch a different meaning for `popped` than every other branch has.
+    const h = harness({
+      stack: [201, 202],
+      allowUnpinAllForumTopic: true,
+      unpinAllTopicRemoves: [202],
+    })
+    const res = await createStalePinSweeper(h.deps).sweepTarget(topic)
+
+    expect(h.fake.calls.filter((c) => c === 'unpinAllTopic:77')).toHaveLength(1)
+    expect(res.status).toBe('drained')
+    expect(res.issued).toBe(1)
+    expect(res.popped).toBe(0)
+    // …and the durable counter did not inherit the call count either.
+    expect(h.cursors()[0].popped).toBe(0)
+  })
+
+  it('credits the wholesale drain a pop when the top DID move', async () => {
+    const h = harness({ stack: [211, 212], allowUnpinAllForumTopic: true })
+    const res = await createStalePinSweeper(h.deps).sweepTarget(topic)
+
+    expect(h.fake.stack).toEqual([])
+    expect(res.status).toBe('drained')
+    expect(res.issued).toBe(1)
+    expect(res.popped).toBe(1)
+    expect(h.cursors()[0].popped).toBe(1)
   })
 
   it('routes the wholesale-drain policy through ONE predicate', () => {
@@ -702,6 +776,37 @@ describe('stale-pin sweep — eligibility and durable resume', () => {
     h.fs.files.set(h.path, '{ not json')
     const res = await createStalePinSweeper(h.deps).sweepTarget({ chatId: DM })
     expect(res.status).toBe('drained')
+  })
+
+  it('still honours an obligation written by a NEWER build (#3957)', async () => {
+    // Downgrade case. A ledger the running build does not recognise must not be
+    // silently thrown away: for an obligation ledger, "discard" means "forget
+    // an obligation", which re-creates the orphan the sweep exists to clear.
+    // Here the newer build already discharged this target — a version-
+    // intolerant reader would re-drain a chat it had no business touching.
+    const h = harness({ stack: [241] })
+    h.fs.files.set(
+      h.path,
+      JSON.stringify({
+        v: 99,
+        cursors: [
+          {
+            chatId: DM,
+            kind: 'dm',
+            popped: 3,
+            done: true,
+            attempts: 1,
+            updatedAt: 1,
+            futureFieldFromV99: 'x',
+          },
+        ],
+      }),
+    )
+    const res = await createStalePinSweeper(h.deps).sweepTarget({ chatId: DM })
+
+    expect(res.status).toBe('already-drained')
+    expect(h.fake.calls.filter((c) => c.startsWith('unpin:'))).toHaveLength(0)
+    expect(h.fake.stack).toEqual([241])
   })
 
   it('never lets a failing ledger write break the sweep', async () => {

--- a/telegram-plugin/gateway/stale-pin-sweep.ts
+++ b/telegram-plugin/gateway/stale-pin-sweep.ts
@@ -20,6 +20,22 @@
  *     Drain progress is only ever concluded from OBSERVED STATE, never from an
  *     API result.
  *
+ * ── Two counters, one meaning each, on EVERY branch ──────────────────────────
+ *
+ * That invariant is only enforceable if the accounting keeps the two apart, so
+ * `SweepResult` carries both and every drain primitive populates both:
+ *
+ *   • `issued` — removal calls that went out unrejected. A claim. Credited
+ *     immediately, before any observation.
+ *   • `popped` — a `getChat` top that DEMONSTRABLY MOVED. Evidence. A LOWER
+ *     BOUND, credited only from an observation, never from a call.
+ *
+ * Neither branch is allowed its own dialect: a call-counted `popped` on one
+ * path and an observation-counted `popped` on another is how the next reader
+ * ends up trusting a number that was never evidence (#3955, #3956). `issued -
+ * popped` is the honest "went out, could not be verified" figure everywhere,
+ * and undercounting `popped` can only make the sweeper do less work.
+ *
  * ── The drain primitives, per chat class ─────────────────────────────────────
  *
  * ONE sweep path (`sweepTarget`) that owns eligibility, the rights precheck,
@@ -497,15 +513,38 @@ export type SweepStatus =
 
 export interface SweepResult {
   status: SweepStatus
-  /** Pops OBSERVED to have landed in THIS sweep (never counted from an API
-   *  result — see the module docblock). */
+  /**
+   * Pops OBSERVED to have landed in THIS sweep — never counted from an API
+   * result (see the module docblock).
+   *
+   * It is a LOWER BOUND, deliberately, and it means the same thing on EVERY
+   * drain branch: "a `getChat` top that demonstrably moved". Two structural
+   * reasons it can undercount, both safe:
+   *
+   *   • a removal aimed at a MID-STACK id changes nothing a bot can read, so it
+   *     is never creditable however well it worked (#3959);
+   *   • a sweep that exits between a removal and the read that would have
+   *     verified it (an unverifiable `getChat`) leaves that removal uncredited
+   *     rather than guessing (#3956).
+   *
+   * Undercounting can only make the sweeper do LESS work — `popped` drives the
+   * per-chat pop cap and telemetry, nothing else — whereas overcounting would
+   * launder the `ok:true` silent no-op into a success. Use {@link issued} for
+   * "how many removals went out"; the two are never the same number by design.
+   */
   popped: number
   /**
-   * Targeted unpins ISSUED in this sweep. Deliberately separate from `popped`:
-   * an unpin aimed at a mid-stack id has no observable effect on the only thing
-   * a bot can read (`getChat().pinned_message`, the top), so issuing one is not
-   * evidence it landed. Keeping the two apart is what stops the `ok:true`
-   * silent no-op from being laundered back into a success count.
+   * Pin-removal calls that WENT OUT and were not rejected — the DM repin+unpin
+   * loop's unpins, the group drain's targeted unpins, and the opt-in wholesale
+   * topic drain's single call. (Telegram's honest `message to unpin not found`
+   * counts too: it settles the id, it just does not move the top.)
+   * Deliberately separate from `popped`: a resolved call is a claim, not
+   * evidence — `unpinChatMessage` answers `ok:true` on a silent no-op, and a
+   * mid-stack removal has no read-back at all.
+   *
+   * Every branch populates it, so `issued - popped` is the honest "removals we
+   * could not verify" figure on any branch, and the two counters can never be
+   * conflated by a future reader.
    */
   issued?: number
   /** Detail for the log line. */
@@ -693,7 +732,10 @@ export function createStalePinSweeper(deps: StalePinSweepDeps): StalePinSweeper 
   /**
    * The DM / opted-in-supergroup drain: RE-PIN the top then UNPIN it, which is
    * the only sequence that actually pops an entry, and re-read the observed top
-   * to decide whether anything moved. A resolved unpin is never counted.
+   * to decide whether anything moved. A resolved unpin is never counted as a
+   * pop — but it IS counted as `issued` the instant it resolves, so an exit
+   * taken before the verifying read reports "one removal, none verified"
+   * instead of silently reporting nothing at all (#3956).
    */
   const repinUnpinLoop = async (
     target: SweepTarget,
@@ -702,6 +744,7 @@ export function createStalePinSweeper(deps: StalePinSweepDeps): StalePinSweeper 
   ): Promise<SweepResult> => {
     const gate = gateFor(kind)
     let popped = 0
+    let issued = 0
     let consecutiveFloods = 0
     let lastRetryAfter: number | null = null
     let noProgressAtSameRetryAfter = 0
@@ -710,6 +753,16 @@ export function createStalePinSweeper(deps: StalePinSweepDeps): StalePinSweeper 
     // decided whether it actually did anything". A resolved unpin is a CLAIM,
     // never a pop.
     let unverifiedPop = false
+
+    /**
+     * EVERY exit from this loop goes through here, so the issued-vs-observed
+     * accounting cannot be dropped on any of its many early-return paths (#3956).
+     * A resolved unpin is credited to `issued` the moment it resolves; whether
+     * it also becomes a `popped` depends on a later observation that an
+     * interrupted sweep may never get to make. Reporting both is what keeps the
+     * unverified one visible instead of vanishing.
+     */
+    const out = (r: Omit<SweepResult, 'issued'>): SweepResult => ({ ...r, issued })
 
     /** Count a pop ONLY once the observed top has moved. */
     const creditPop = (): void => {
@@ -721,35 +774,35 @@ export function createStalePinSweeper(deps: StalePinSweepDeps): StalePinSweeper 
 
     for (let i = 0; i < gate.maxPopsPerChatPerSweep; i++) {
       if (circuitOpen) {
-        return { status: 'aborted-circuit-breaker', popped, detail: 'breaker open' }
+        return out({ status: 'aborted-circuit-breaker', popped, detail: 'breaker open' })
       }
       const observed = await readTopVerified(target.chatId)
       if (observed == null) {
         // Ambiguous read (disagreeing reads or a throw). Not a drain, and NOT
         // an empty stack. Defer rather than assert either way.
-        return { status: 'incomplete', popped, detail: 'pin-stack read unverifiable' }
+        return out({ status: 'incomplete', popped, detail: 'pin-stack read unverifiable' })
       }
       if (unverifiedPop) {
         // THE bug this module exists for: `unpinChatMessage` resolves ok:true on
         // a stale entry and pops NOTHING. The same id still on top after a full
         // repin+unpin is proof the pop did not land, whatever the API answered.
         if (observed.top != null && observed.top === lastObservedTop) {
-          return {
+          return out({
             status: 'incomplete',
             popped,
             detail: `no progress: message ${observed.top} still on top after a repin+unpin`,
-          }
+          })
         }
         creditPop()
         unverifiedPop = false
       }
       if (observed.top == null) {
-        return { status: 'drained', popped }
+        return out({ status: 'drained', popped })
       }
       lastObservedTop = observed.top
 
       if (!(await awaitWriteSlot(kind))) {
-        return { status: 'deferred-budget', popped, detail: 'per-minute pin-op budget spent' }
+        return out({ status: 'deferred-budget', popped, detail: 'per-minute pin-op budget spent' })
       }
       try {
         await deps.pinSilent(target.chatId, observed.top)
@@ -757,9 +810,9 @@ export function createStalePinSweeper(deps: StalePinSweepDeps): StalePinSweeper 
         const d = classify(err)
         if (d.kind === 'breaker') {
           circuitOpen = true
-          return { status: 'aborted-circuit-breaker', popped, detail: d.detail }
+          return out({ status: 'aborted-circuit-breaker', popped, detail: d.detail })
         }
-        if (d.kind === 'rights') return { status: 'skipped-no-rights', popped }
+        if (d.kind === 'rights') return out({ status: 'skipped-no-rights', popped })
         if (d.kind === 'flood') {
           consecutiveFloods++
           if (lastRetryAfter === d.seconds) noProgressAtSameRetryAfter++
@@ -769,22 +822,22 @@ export function createStalePinSweeper(deps: StalePinSweepDeps): StalePinSweeper 
             consecutiveFloods >= MAX_CONSECUTIVE_FLOOD_WAITS ||
             noProgressAtSameRetryAfter >= MAX_IDENTICAL_RETRY_AFTER_NO_PROGRESS
           ) {
-            return {
+            return out({
               status: 'deferred-flood',
               popped,
               detail: `flood: ${consecutiveFloods} consecutive 429s, retry_after=${d.seconds}s`,
-            }
+            })
           }
           // Honour retry_after, then double it for the next one (3→6→12→24).
           await deps.sleep(d.seconds * 1000 * Math.pow(FLOOD_BACKOFF_FACTOR, consecutiveFloods - 1))
           continue
         }
-        return { status: 'error', popped, detail: d.detail }
+        return out({ status: 'error', popped, detail: d.detail })
       }
       // The unpin's RESULT is deliberately ignored — it resolves ok:true on a
       // silent no-op. Only the next observed top decides whether this popped.
       if (!(await awaitWriteSlot(kind))) {
-        return { status: 'deferred-budget', popped, detail: 'per-minute pin-op budget spent' }
+        return out({ status: 'deferred-budget', popped, detail: 'per-minute pin-op budget spent' })
       }
       try {
         await deps.unpin(target.chatId, observed.top)
@@ -792,10 +845,10 @@ export function createStalePinSweeper(deps: StalePinSweepDeps): StalePinSweeper 
         const d = classify(err)
         if (d.kind === 'breaker') {
           circuitOpen = true
-          return { status: 'aborted-circuit-breaker', popped, detail: d.detail }
+          return out({ status: 'aborted-circuit-breaker', popped, detail: d.detail })
         }
-        if (d.kind === 'rights') return { status: 'skipped-no-rights', popped }
-        if (isNothingToUnpinError(err)) return { status: 'drained', popped }
+        if (d.kind === 'rights') return out({ status: 'skipped-no-rights', popped })
+        if (isNothingToUnpinError(err)) return out({ status: 'drained', popped })
         if (d.kind === 'flood') {
           consecutiveFloods++
           if (lastRetryAfter === d.seconds) noProgressAtSameRetryAfter++
@@ -805,18 +858,23 @@ export function createStalePinSweeper(deps: StalePinSweepDeps): StalePinSweeper 
             consecutiveFloods >= MAX_CONSECUTIVE_FLOOD_WAITS ||
             noProgressAtSameRetryAfter >= MAX_IDENTICAL_RETRY_AFTER_NO_PROGRESS
           ) {
-            return {
+            return out({
               status: 'deferred-flood',
               popped,
               detail: `flood: ${consecutiveFloods} consecutive 429s, retry_after=${d.seconds}s`,
-            }
+            })
           }
           await deps.sleep(d.seconds * 1000 * Math.pow(FLOOD_BACKOFF_FACTOR, consecutiveFloods - 1))
           continue
         }
-        return { status: 'error', popped, detail: d.detail }
+        return out({ status: 'error', popped, detail: d.detail })
       }
       consecutiveFloods = 0
+      // The removal went out. It is `issued` NOW — unconditionally, before the
+      // observation that may or may not turn it into a `popped`. That ordering
+      // is the fix for #3956: an exit taken before the next verified read can
+      // no longer make this call disappear from the accounting.
+      issued++
       unverifiedPop = true
     }
 
@@ -824,12 +882,12 @@ export function createStalePinSweeper(deps: StalePinSweepDeps): StalePinSweeper 
     // is the ONLY thing allowed to report `drained`.
     const finalRead = await readTopVerified(target.chatId)
     if (unverifiedPop && finalRead != null && finalRead.top !== lastObservedTop) creditPop()
-    if (finalRead != null && finalRead.top == null) return { status: 'drained', popped }
-    return {
+    if (finalRead != null && finalRead.top == null) return out({ status: 'drained', popped })
+    return out({
       status: 'deferred-budget',
       popped,
       detail: `hit the ${gate.maxPopsPerChatPerSweep}-pop cap for this chat; yielding to next boot`,
-    }
+    })
   }
 
   /**
@@ -962,6 +1020,16 @@ export function createStalePinSweeper(deps: StalePinSweepDeps): StalePinSweeper 
    * place, which is why it is gated on {@link mayUnpinAllForumTopic}. A 429 here
    * is the pegged TDLib re-issue loop, so it is a give-up, not a backoff — see
    * the module docblock.
+   *
+   * Counting is the SAME contract as every other branch (#3955): the resolved
+   * call is one `issued`, and `popped` is credited only from a `getChat` top
+   * that demonstrably moved between the before- and after-reads. It is not a
+   * distinction without a difference here — the verb is topic-scoped while the
+   * only readable state is the CHAT-wide top, so a drained topic in a chat whose
+   * top belongs to another topic legitimately moves nothing. That is still a
+   * discharged obligation (`drained`), it is just not an observed pop, and
+   * crediting one would make this branch's `popped` a call counter wearing a
+   * pop counter's name.
    */
   const forumTopicDrain = async (
     target: SweepTarget,
@@ -969,10 +1037,22 @@ export function createStalePinSweeper(deps: StalePinSweepDeps): StalePinSweeper 
   ): Promise<SweepResult> => {
     const threadId = target.threadId
     if (threadId == null) {
-      return { status: 'skipped-nothing-recorded', popped: 0, detail: 'no message_thread_id' }
+      return {
+        status: 'skipped-nothing-recorded',
+        popped: 0,
+        issued: 0,
+        detail: 'no message_thread_id',
+      }
     }
+    // Read BEFORE the write, so "did the top move?" is answerable afterwards.
+    const before = await readTopVerified(target.chatId)
     if (!(await awaitWriteSlot('forum-topic'))) {
-      return { status: 'deferred-budget', popped: 0, detail: 'per-minute pin-op budget spent' }
+      return {
+        status: 'deferred-budget',
+        popped: 0,
+        issued: 0,
+        detail: 'per-minute pin-op budget spent',
+      }
     }
     try {
       await deps.unpinAllForumTopicMessages(target.chatId, threadId)
@@ -980,9 +1060,9 @@ export function createStalePinSweeper(deps: StalePinSweepDeps): StalePinSweeper 
       const d = classify(err)
       if (d.kind === 'breaker') {
         circuitOpen = true
-        return { status: 'aborted-circuit-breaker', popped: 0, detail: d.detail }
+        return { status: 'aborted-circuit-breaker', popped: 0, issued: 0, detail: d.detail }
       }
-      if (d.kind === 'rights') return { status: 'skipped-no-rights', popped: 0 }
+      if (d.kind === 'rights') return { status: 'skipped-no-rights', popped: 0, issued: 0 }
       if (d.kind === 'flood') {
         // DO NOT retry. `run_affected_history_query_until_complete` re-issues
         // the identical query while `!is_final_`, re-tripping the same server
@@ -990,35 +1070,60 @@ export function createStalePinSweeper(deps: StalePinSweepDeps): StalePinSweeper 
         return {
           status: 'deferred-flood',
           popped: 0,
+          issued: 0,
           detail: `unpinAllForumTopicMessages pegged at retry_after=${d.seconds}s; not looping`,
         }
       }
-      return { status: 'error', popped: 0, detail: d.detail }
+      return { status: 'error', popped: 0, issued: 0, detail: d.detail }
     }
-    cursor.popped++
-    cursor.updatedAt = deps.now()
-    commit(cursor)
+    // The call resolved: that is exactly ONE issued removal, and — per the
+    // module invariant — no evidence of anything at all. Only the read below
+    // may credit a pop, and only the durable counter it credits is `popped`.
     const observed = await readTopVerified(target.chatId)
-    if (observed != null && observed.top == null) return { status: 'drained', popped: 1 }
+    const topMoved =
+      before != null && observed != null && observed.top !== before.top ? 1 : 0
+    if (topMoved > 0) {
+      cursor.popped += topMoved
+      cursor.updatedAt = deps.now()
+      commit(cursor)
+    }
+    if (observed != null && observed.top == null) {
+      return { status: 'drained', popped: topMoved, issued: 1 }
+    }
     // The chat-wide stack may legitimately still hold pins belonging to OTHER
     // topics — the topic-scoped verb only drains this one. That is a success
     // for this obligation, not an incomplete drain.
-    return { status: 'drained', popped: 1, detail: 'topic drained; chat-wide stack may hold other topics' }
+    return {
+      status: 'drained',
+      popped: topMoved,
+      issued: 1,
+      detail: 'topic drained; chat-wide stack may hold other topics',
+    }
   }
 
   const sweepOnce = async (target: SweepTarget): Promise<SweepResult> => {
-    if (!deps.eligible()) return { status: 'skipped-not-eligible', popped: 0 }
+    if (!deps.eligible()) return { status: 'skipped-not-eligible', popped: 0, issued: 0 }
     if (circuitOpen) {
-      return { status: 'aborted-circuit-breaker', popped: 0, detail: 'breaker already open' }
+      return {
+        status: 'aborted-circuit-breaker',
+        popped: 0,
+        issued: 0,
+        detail: 'breaker already open',
+      }
     }
     const kind = classifyChatForSweep(target)
     const cursor = loadCursor(target, kind)
-    if (cursor.done) return { status: 'already-drained', popped: 0 }
+    if (cursor.done) return { status: 'already-drained', popped: 0, issued: 0 }
     // Attempt budget exhausted: a permanently-undrainable chat (bot kicked,
     // rights revoked, a chat that flood-waits forever) must not re-burn the pop
     // budget on every boot for the rest of time.
     if (cursor.attempts >= SWEEP_MAX_ATTEMPTS) {
-      return { status: 'forfeited', popped: 0, detail: `${cursor.attempts} attempts exhausted` }
+      return {
+        status: 'forfeited',
+        popped: 0,
+        issued: 0,
+        detail: `${cursor.attempts} attempts exhausted`,
+      }
     }
 
     // RIGHTS PRECHECK, before ANY write, in every group. A bot without
@@ -1037,7 +1142,7 @@ export function createStalePinSweeper(deps: StalePinSweepDeps): StalePinSweeper 
         cursor.lastStatus = 'skipped-no-rights'
         cursor.updatedAt = deps.now()
         commit(cursor)
-        return { status: 'skipped-no-rights', popped: 0 }
+        return { status: 'skipped-no-rights', popped: 0, issued: 0 }
       }
     }
 
@@ -1078,7 +1183,7 @@ export function createStalePinSweeper(deps: StalePinSweepDeps): StalePinSweeper 
             : await targetedUnpinDrain(target, kind, cursor, ids)
       }
     } catch (err) {
-      result = { status: 'error', popped: 0, detail: (err as Error).message }
+      result = { status: 'error', popped: 0, issued: 0, detail: (err as Error).message }
     }
 
     // `skipped-nothing-recorded` discharges the obligation too: there is no id
@@ -1134,8 +1239,12 @@ export function createStalePinSweeper(deps: StalePinSweepDeps): StalePinSweeper 
     // Not eligible yet ⇒ nothing was attempted, so do NOT consume the one
     // allowed attempt: the boot sweep must still get its turn once the mutex
     // is won.
-    if (!deps.eligible()) return Promise.resolve({ status: 'skipped-not-eligible', popped: 0 })
-    if (attempted.has(key)) return Promise.resolve({ status: 'already-attempted', popped: 0 })
+    if (!deps.eligible()) {
+      return Promise.resolve({ status: 'skipped-not-eligible', popped: 0, issued: 0 })
+    }
+    if (attempted.has(key)) {
+      return Promise.resolve({ status: 'already-attempted', popped: 0, issued: 0 })
+    }
     attempted.add(key)
     const p = sweepOnce(target).finally(() => inFlight.delete(key))
     inFlight.set(key, p)

--- a/telegram-plugin/gateway/status-pin-store.ts
+++ b/telegram-plugin/gateway/status-pin-store.ts
@@ -117,19 +117,43 @@ export interface PersistedStatusPin {
  *  re-fail on every boot forever. */
 export const BOOT_UNPIN_MAX_ATTEMPTS = 5
 
-/** Envelope version. v1 had no `pending` field; a v1 row loads as a confirmed
- *  pin (pending undefined). v2 adds the optional `pending` flag. v3 adds the
- *  optional `pinnedAt` claim timestamp (#3810). v4 adds the optional `threadId`
- *  so the claim is keyed by (chat, thread) and a forum topic can be drained
- *  after a crash. All load fail-open — an unknown/newer version yields [].
- *  Every field added since v1 is optional, so the versions are mutually
- *  readable and a downgrade degrades rather than breaks. */
+/**
+ * Envelope version. v1 had no `pending` field; a v1 row loads as a confirmed
+ * pin (pending undefined). v2 adds the optional `pending` flag. v3 adds the
+ * optional `pinnedAt` claim timestamp (#3810). v4 adds the optional `threadId`
+ * so the claim is keyed by (chat, thread) and a forum topic can be drained
+ * after a crash.
+ *
+ * ── The bump rule, which the reader depends on (#3957) ───────────────────────
+ *
+ * EVERY field added since v1 is OPTIONAL, and every future bump must keep that
+ * property. That is what makes the versions mutually readable in both
+ * directions, and {@link loadStatusPins} now cashes it in: an envelope whose
+ * version this build does not know is still READ, row by row, through the same
+ * structural validator. Rows it cannot validate are dropped; rows it can are
+ * kept.
+ *
+ * Why that matters more than it looks: this file is the boot cleanup's only
+ * record of which messages the gateway pinned. A reader that discarded the
+ * whole file on an unfamiliar version turned every pin taken by the newer build
+ * into a permanent orphan the moment an operator rolled back — manufacturing
+ * exactly the bug this subsystem exists to prevent. Degrading (keep what
+ * validates) is strictly safer than failing open to `[]` here, because the
+ * fail-open outcome is not "do nothing", it is "forget an obligation".
+ *
+ * A bump that ever needs to be NON-additive — a field whose absence changes the
+ * meaning of a row — must therefore change the FILENAME, not just `v`, so old
+ * readers see "no file" rather than misreading rows. Do not quietly break the
+ * additive rule and leave `v` to carry it.
+ */
 interface SnapshotEnvelope {
-  v: 1 | 2 | 3 | 4
+  v: number
   pins: PersistedStatusPin[]
 }
 
-const SNAPSHOT_VERSIONS = new Set([1, 2, 3, 4])
+/** The version THIS build writes. Reading is deliberately version-tolerant
+ *  (see above); only the writer is pinned. */
+const SNAPSHOT_VERSION = 4
 
 function isPinRow(x: unknown): x is PersistedStatusPin {
   if (x == null || typeof x !== 'object') return false
@@ -153,6 +177,13 @@ function isPinRow(x: unknown): x is PersistedStatusPin {
  * file (fail-open to empty: a corrupt snapshot must never crash boot — worst
  * case an orphaned pin isn't cleaned up this boot, strictly no worse than the
  * pre-persistence behaviour).
+ *
+ * An UNRECOGNISED envelope version is NOT malformed and does not fail open
+ * (#3957). Any positive-integer `v` with an array of `pins` is read, and each
+ * row is kept iff {@link isPinRow} can structurally validate it. A row written
+ * by a newer build therefore survives a downgrade instead of being discarded
+ * into a permanent orphan — see the {@link SnapshotEnvelope} bump rule for the
+ * additive-fields property this relies on.
  */
 export function loadStatusPins(
   path: string,
@@ -173,7 +204,9 @@ export function loadStatusPins(
   }
   if (parsed == null || typeof parsed !== 'object') return []
   const env = parsed as Record<string, unknown>
-  if (typeof env.v !== 'number' || !SNAPSHOT_VERSIONS.has(env.v) || !Array.isArray(env.pins)) return []
+  // Version-TOLERANT, structurally strict: an unknown `v` still yields the rows
+  // that validate. Only a shape that is not an envelope at all fails open.
+  if (!Number.isInteger(env.v) || (env.v as number) < 1 || !Array.isArray(env.pins)) return []
   return env.pins.filter(isPinRow)
 }
 
@@ -189,7 +222,7 @@ export function persistStatusPins(
   snapshot: readonly PersistedStatusPin[],
   log: (line: string) => void = (l) => process.stderr.write(l),
 ): void {
-  const env: SnapshotEnvelope = { v: 4, pins: [...snapshot] }
+  const env: SnapshotEnvelope = { v: SNAPSHOT_VERSION, pins: [...snapshot] }
   const tmp = path + '.tmp'
   try {
     fs.writeFileSync(tmp, JSON.stringify(env))

--- a/telegram-plugin/tests/status-pin-store.test.ts
+++ b/telegram-plugin/tests/status-pin-store.test.ts
@@ -116,12 +116,15 @@ describe("status-pin-store", () => {
     expect(idOnly(loadStatusPins(PATH, fs))).toEqual([]);
   });
 
-  it("fail-open: wrong envelope version / shape loads as []", () => {
-    // v5 is an unknown FUTURE version (v1–v4 are the supported set).
-    const { fs: f1 } = memFs({ [PATH]: JSON.stringify({ v: 5, pins: [pin()] }) });
+  it("fail-open: a shape that is not an envelope at all loads as []", () => {
+    const { fs: f1 } = memFs({ [PATH]: JSON.stringify({ v: 1, pins: "nope" }) });
     expect(loadStatusPins(PATH, f1)).toEqual([]);
-    const { fs: f2 } = memFs({ [PATH]: JSON.stringify({ v: 1, pins: "nope" }) });
+    const { fs: f2 } = memFs({ [PATH]: JSON.stringify({ pins: [pin()] }) });
     expect(loadStatusPins(PATH, f2)).toEqual([]);
+    const { fs: f3 } = memFs({ [PATH]: JSON.stringify({ v: "4", pins: [pin()] }) });
+    expect(loadStatusPins(PATH, f3)).toEqual([]);
+    const { fs: f4 } = memFs({ [PATH]: JSON.stringify({ v: 0, pins: [pin()] }) });
+    expect(loadStatusPins(PATH, f4)).toEqual([]);
   });
 
   it("drops malformed rows but keeps valid ones", () => {
@@ -604,8 +607,61 @@ describe("status-pin-store — envelope version compat", () => {
     expect(loadStatusPins(PATH, fs)).toHaveLength(1);
   });
 
-  it("rejects an unknown future envelope version (fail-open [])", () => {
-    const { fs } = memFs({ [PATH]: JSON.stringify({ v: 5, pins: [pin()] }) });
+  /**
+   * #3957 — a DOWNGRADE must degrade, not discard.
+   *
+   * The pre-#3953 reader has already shipped, so the v3→v4 case can never be
+   * retroactively fixed; this pins the forward-looking half so the NEXT bump
+   * behaves. A build that does not know the envelope version still reads every
+   * row it can structurally validate — because for THIS file "discard" is not
+   * "do nothing", it is "forget which messages we pinned", which turns every
+   * pin the newer build took into a permanent orphan.
+   */
+  it("reads an unknown FUTURE envelope version, keeping every row it can validate", () => {
+    const { fs } = memFs({
+      [PATH]: JSON.stringify({
+        v: 99,
+        pins: [
+          // A future row: known fields valid, plus a field this build has never
+          // heard of. Kept — unknown fields are additive by the bump rule.
+          { ...pin({ messageId: 715 }), someFutureField: "v99" },
+          { pinKey: "k", chatId: "c", messageId: "not-a-number" }, // still dropped
+        ],
+      }),
+    });
+    const loaded = loadStatusPins(PATH, fs);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].messageId).toBe(715);
+  });
+
+  it("a rolled-back build still UNPINS the orphans a newer build recorded (#3957)", async () => {
+    // The outcome that matters: not "the rows parse" but "the boot cleanup can
+    // still reach them". Against the fail-open reader this unpins nothing.
+    const { fs } = memFs({
+      [PATH]: JSON.stringify({
+        v: 99,
+        pins: [
+          { pinKey: "fg:c:3", chatId: "-100123", messageId: 715, unknownV99: 1 },
+          { pinKey: "wk:agent-x", chatId: "-100999", messageId: 42 },
+        ],
+      }),
+    });
+
+    const unpinned: Array<[string, number]> = [];
+    const res = await runStatusPinBootCleanup({
+      path: PATH,
+      fs,
+      unpin: async (chatId, messageId) => {
+        unpinned.push([chatId, messageId]);
+      },
+      log: () => {},
+    });
+
+    expect(unpinned).toEqual([
+      ["-100123", 715],
+      ["-100999", 42],
+    ]);
+    expect(res.cleared).toBe(2);
     expect(idOnly(loadStatusPins(PATH, fs))).toEqual([]);
   });
 


### PR DESCRIPTION
Triage of three low-severity follow-ups filed from the #3953 review. All three
live in the pin subsystem, so they ship as one focused change.

Fixes #3955
Fixes #3956
Fixes #3957

## Summary

**#3955 — the forum drain credited a pop per API call.** `forumTopicDrain` did
`cursor.popped++` immediately after `unpinAllForumTopicMessages` resolved, with
no read-back. That gave `popped` a different meaning on that branch than on
every other one, where it is credited only from a `getChat` top that
demonstrably moved. It now takes a verified read before and after the call and
credits a pop only on observed change. `drained` is still reported either way —
a topic-scoped drain legitimately moves nothing when the chat-wide top belongs
to another topic — but that is a discharged obligation, not an observed pop.

**#3956 — an early return dropped one unverified pop.** In `repinUnpinLoop` a
resolved unpin becomes a `popped` only on the *next* verified read; when that
read went dark the sweep exited and the removal vanished from the accounting.
The issue offered "do a final verified read on the early-return paths" as one
option — that one does not survive contact with the code. The only reachable
drop path is precisely the one where `readTopVerified` already returned
`null` after exhausting `VERIFY_READ_MAX_PAIRS`, so re-reading buys nothing,
and crediting anyway would break the module's founding invariant (never
conclude drain progress from an API result). Taken the second option instead,
made structural rather than a comment: **every branch now populates both
counters** — `issued` the instant a removal goes out, `popped` only from an
observation — and every exit in the loop routes through one `out()` helper so
no path can forget. `issued - popped` is the honest "went out, could not be
verified" figure, on all three drain primitives.

**#3957 — v4 failed open to `[]` on a downgrade.** `loadStatusPins` discarded
the whole file on an unrecognised envelope version. For *this* file, discarding
is not "do nothing" — it is "forget which messages we pinned", which turns
every pin the newer build took into a permanent orphan the boot cleanup can
never see again: the exact bug the subsystem exists to prevent. The pre-#3953
reader has already shipped, so the v0.19.31 → v0.19.30 hop cannot be fixed
retroactively; the durable fix is forward-looking. Both pin stores
(`status-pins.json` and the sweep obligation ledger) are now version-TOLERANT
and structurally strict: any positive-integer `v` is read row by row through
the same validator, so the NEXT envelope bump degrades instead of discarding.
The known-lossy hop is documented in the release/rollback section of
`CONTRIBUTING.md`, together with the bump rule the tolerance depends on
(additive-optional fields; a non-additive change must change the filename, not
just `v`).

The sweep-ledger half of #3957 was not in the issue text. It is the same defect
in the same subsystem — same fail-open on unknown `v`, same "forget an
obligation" consequence — and fixing only one of the pair would leave the
identical trap armed next door.

## Why

`reference/jobs/fleet-stays-healthy.md`: an agent's own housekeeping must not
manufacture the mess it exists to clean. Two of these are about a counter that
could be trusted for something it never measured; the third is about state that
a rollback silently forgets.

## Test plan

Every regression test was run against pristine `origin/main` first and
confirmed to FAIL there:

- `stale-pin sweep — forum topics > credits the wholesale drain a POP only when
  the observed top moved (#3955)` — topic drain clears its topic's pin while the
  chat-wide top (another topic's) survives: `issued: 1`, `popped: 0`,
  `cursor.popped: 0`. Fails on main (`popped: 1`).
- `stale-pin sweep — draining a stacked chat > does not lose an unpin that
  landed after the verifying read went dark (#3956)` — the unpin really pops
  (`stack` goes `[61,62]` → `[62]`) and the verifying read then throws:
  `popped: 0`, `issued: 1`. Fails on main (`issued: undefined`).
- `status-pin-store > a rolled-back build still UNPINS the orphans a newer build
  recorded (#3957)` — drives the real `runStatusPinBootCleanup` over a `v: 99`
  snapshot and asserts both orphans are actually unpinned. Fails on main
  (unpins nothing).
- `stale-pin sweep > still honours an obligation written by a NEWER build
  (#3957)` — a `v: 99` ledger row marked `done` is respected, so the downgraded
  build does not re-drain a chat the newer one already discharged.

Scoped locally: `vitest run` over the seven pin/sweep suites — 148 tests, all
green (`stale-pin-sweep`, `status-pin-store`, `status-pin-lifecycle`,
`status-pin-boot-recovery`, `status-pin-retarget`, `boot-pin-sweep-wiring`,
`worker-pin-reaper`). `tsc --noEmit` clean; `check-status-pin-single-path`,
`check-bot-api-wrapping`, `check-no-pii-secrets`, `check-gateway-line-ratchet`,
`check-callback-ctx-wrapping` and the rest of the guards pass. (Local
`check-plugin-references` fails on missing `telegram-plugin/node_modules` in
this sandbox — unrelated files, `render/parse.ts` and `uat/driver.ts`; CI
installs deps and is the authority.)

## Risk

Low, and behavioural surface is narrow:

- No change to any pin/unpin decision, rate gate, breaker, or `drained`/
  `incomplete` verdict. `popped` is telemetry plus the per-chat DM pop cap; the
  forum branch has no pop cap (`Infinity`), so the corrected count cannot change
  what the sweeper does — only what it reports.
- The forum drain now spends one extra `getChat` read pair before the call. It
  is an opt-in, last-resort path (`SWITCHROOM_PIN_SWEEP_UNPIN_ALL_TOPIC=1`) and
  reads are not rate-gated here.
- Store reads get MORE permissive, never less: every version that loaded before
  still loads identically, and a non-envelope shape still fails open to `[]`
  (covered by an expanded test — missing `v`, string `v`, `v: 0`, non-array
  `pins`). The two tests that pinned the old fail-open-on-unknown-version
  behaviour were deliberately inverted; that inversion IS the fix.

## Also: the operator doc backing the #3960 close

`docs/operators/stale-pin-cleanup.md` (indexed from `docs/README.md`) is new
here. It is not part of the three fixes — it is the "manual remedies
documented" half of closing #3960 as not-planned. The sweep was documented
nowhere under `docs/` or `reference/`, so the page covers what the sweep will
and will not clear, how an unrecorded orphan reads in the log
(`skipped-nothing-recorded`), and the two working remedies: hand-unpin in the
Telegram client, and the opt-in
`SWITCHROOM_PIN_SWEEP_UNPIN_ALL_TOPIC=1` topic drain with its
"turn it on, one boot sweep, turn it back off" caveat. Docs-only, no code.
