### PR TITLE
fix(cli): self-invoke the compiled binary directly, not via its /$bunfs path

### DIFF
--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -76,6 +76,7 @@ import { renderFleetDefaultsClaudeMd } from "../agents/fleet-defaults.js";
 import { refreshAgentConnectionHealth } from "../agents/connection-health.js";
 import type { VaultAclResult } from "./doctor-mcp-secrets.js";
 import { installUpdatePromptHook } from "./update-prompt-hook.js";
+import { resolveSelfInvocation, type SelfInvokeProbe } from "./self-invoke.js";
 import { allocateAgentUid } from "../agents/compose.js";
 import { LITELLM_MASTER_KEY_STATE_BASENAME } from "../litellm/external-spend.js";
 import { writeComposeFile, computeComposeContent, resolveHostSwitchroomConfigPath, resolveHostHomeForCompose } from "./write-compose.js";
@@ -2686,14 +2687,21 @@ export const SELF_ELEVATE_PRESERVED_ENV = [
  *   - process.execPath is the absolute path to bun/node, so sudo's
  *     secure PATH doesn't matter for the interpreter.
  *   - process.argv[1] is the absolute path to dist/cli/switchroom.js
- *     under both `bun run dev` and a global install.
+ *     under both `bun run dev` and a global install — but NOT under a
+ *     `bun build --compile` static binary, where it is the virtual
+ *     `/$bunfs/root/...` bundle path and process.execPath is the binary
+ *     itself. Forwarding the bunfs path there makes sudo run
+ *     `switchroom /$bunfs/root/switchroom-linux-amd64 apply` and
+ *     commander rejects it as an unknown command (#3963). The split is
+ *     resolved by {@link resolveSelfInvocation}.
  */
-export function buildSelfElevateArgv(): string[] {
+export function buildSelfElevateArgv(probe: SelfInvokeProbe = {}): string[] {
   const passthrough = process.argv.slice(2);
+  const self = resolveSelfInvocation(probe);
   return [
     `--preserve-env=${SELF_ELEVATE_PRESERVED_ENV.join(",")}`,
-    process.execPath,
-    process.argv[1] ?? "",
+    self.command,
+    ...self.prefixArgs,
     ...passthrough,
     "--skip-self-elevate",
   ];

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -55,6 +55,7 @@ import {
   recoverPinJournal,
 } from "./rollout-pin-journal.js";
 import { resolveOperatorUid } from "./operator-uid.js";
+import { resolveSelfInvocation } from "./self-invoke.js";
 import { writeConfigFileSync } from "../util/atomic.js";
 import { compareReleaseTags } from "../config/release-resolve.js";
 import { SWITCHROOM_VERSION } from "./resolve-version.js";
@@ -1602,6 +1603,9 @@ export function createRolloutDeps(params: {
   configPath: string;
   scriptPath: string;
   hostdCtx: boolean;
+  /** `process.execPath`. Injected in tests so the compiled-binary
+   *  self-invocation shape (#3963) is assertable without a real binary. */
+  execPath?: string;
   /** Injected in tests; defaults to node's `spawnSync`. */
   spawn?: RolloutSpawnSync;
   /** Injected in tests; defaults to process.stderr. */
@@ -1610,6 +1614,14 @@ export function createRolloutDeps(params: {
   const { configPath, scriptPath, hostdCtx } = params;
   const spawn = (params.spawn ?? (spawnSync as unknown as RolloutSpawnSync));
   const warn = params.warn ?? ((line: string) => process.stderr.write(line));
+  // #3963: a `bun build --compile` binary is its OWN entrypoint — passing
+  // its bunfs bundle path as argv[1] makes commander read it as the
+  // subcommand and every step of the roll dies with `unknown command
+  // '/$bunfs/root/switchroom-linux-amd64'`. See ./self-invoke.ts.
+  const self = resolveSelfInvocation({
+    execPath: params.execPath ?? process.execPath,
+    scriptPath,
+  });
 
   /**
    * One-shot `docker …` bounded by {@link ROLLOUT_PROBE_TIMEOUT_MS}.
@@ -1708,7 +1720,7 @@ export function createRolloutDeps(params: {
 
   return {
     run: (args, opts) => {
-      const r = spawn(process.execPath, [scriptPath, ...args], {
+      const r = spawn(self.command, [...self.prefixArgs, ...args], {
         stdio: "inherit",
         // #3333 amendment C: layer the per-invocation env (the scoped-sweep
         // flag on the canary spawn) onto the inherited environment.
@@ -2025,7 +2037,11 @@ export function registerRolloutCommand(program: Command): void {
       }
 
       const configPath = getConfigPath(program);
-      const scriptPath = process.argv[1] ?? "switchroom";
+      // Empty (not "switchroom") on the degenerate no-argv[1] path:
+      // resolveSelfInvocation then falls back to a bare `switchroom` on
+      // $PATH instead of passing the literal string as argv[1] to the
+      // interpreter, which could never have worked.
+      const scriptPath = process.argv[1] ?? "";
       const deps = createRolloutDeps({ configPath, scriptPath, hostdCtx });
 
       process.stdout.write(

--- a/src/cli/self-invoke.test.ts
+++ b/src/cli/self-invoke.test.ts
@@ -1,0 +1,324 @@
+/**
+ * #3963 — switchroom must be able to re-invoke ITSELF from the published
+ * static binary.
+ *
+ * The shipped artifact is a `bun build --compile` single-file executable.
+ * Inside it, `process.execPath` is the binary and `process.argv[1]` is the
+ * VIRTUAL bundle path `/$bunfs/root/switchroom-linux-amd64`. Every
+ * self-spawning command used to build its child argv as
+ * `[process.execPath, process.argv[1], ...args]`, which produced
+ *
+ *     switchroom /$bunfs/root/switchroom-linux-amd64 apply …
+ *
+ * and commander answered `error: unknown command
+ * '/$bunfs/root/switchroom-linux-amd64'`. `switchroom rollout` therefore
+ * died on step 1 with zero agents rolled on every binary install.
+ *
+ * These assertions are on the ARGV that reaches `spawn`, for BOTH modes,
+ * so they fail on the bug rather than merely walking the code path. A
+ * bunfs path appearing anywhere in a child's argv is the regression.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync, readdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  isCompiledBinaryPath,
+  resolveSelfInvocation,
+  selfInvokeArgv,
+} from "./self-invoke.js";
+import { createRolloutDeps, type RolloutSpawnSync } from "./rollout.js";
+import { planUpdate } from "./update.js";
+import { buildSelfElevateArgv } from "./apply.js";
+
+/** What a compiled binary actually reports for these two values. */
+const COMPILED = {
+  execPath: "/usr/local/bin/switchroom",
+  scriptPath: "/$bunfs/root/switchroom-linux-amd64",
+};
+/** What a JS install (npm global, `bun dist/cli/switchroom.js`) reports. */
+const JS_INSTALL = {
+  execPath: "/usr/local/bin/bun",
+  scriptPath: "/opt/switchroom/dist/cli/switchroom.js",
+};
+
+/** The tell: no child argv may ever contain a bunfs path. */
+function expectNoBunfs(argv: readonly string[]): void {
+  for (const a of argv) {
+    expect(a).not.toMatch(/\$bunfs/);
+    expect(a).not.toMatch(/~BUN/);
+  }
+}
+
+describe("isCompiledBinaryPath", () => {
+  it("recognises the POSIX bunfs virtual root", () => {
+    expect(isCompiledBinaryPath("/$bunfs/root/switchroom-linux-amd64")).toBe(true);
+    expect(isCompiledBinaryPath("/$bunfs/root/switchroom-macos-arm64")).toBe(true);
+  });
+
+  it("recognises the Windows bunfs virtual root", () => {
+    expect(isCompiledBinaryPath("B:\\~BUN\\root\\switchroom.exe")).toBe(true);
+  });
+
+  it("does not claim a real script path", () => {
+    expect(isCompiledBinaryPath("/opt/switchroom/dist/cli/switchroom.js")).toBe(false);
+    expect(isCompiledBinaryPath("/home/op/src/switchroom/src/cli/switchroom.ts")).toBe(false);
+  });
+
+  it("does not claim an absent path", () => {
+    expect(isCompiledBinaryPath(undefined)).toBe(false);
+    expect(isCompiledBinaryPath("")).toBe(false);
+  });
+});
+
+describe("resolveSelfInvocation", () => {
+  it("compiled binary: spawns the binary with NO script argument", () => {
+    const inv = resolveSelfInvocation(COMPILED);
+    expect(inv.compiled).toBe(true);
+    expect(inv.command).toBe(COMPILED.execPath);
+    // The whole bug: this must be empty, not [scriptPath].
+    expect(inv.prefixArgs).toEqual([]);
+  });
+
+  it("JS install: spawns the interpreter with the script path in front", () => {
+    const inv = resolveSelfInvocation(JS_INSTALL);
+    expect(inv.compiled).toBe(false);
+    expect(inv.command).toBe(JS_INSTALL.execPath);
+    expect(inv.prefixArgs).toEqual([JS_INSTALL.scriptPath]);
+  });
+
+  it("falls back to $PATH resolution rather than spawning an empty string", () => {
+    expect(resolveSelfInvocation({ execPath: "", scriptPath: "" })).toEqual({
+      command: "switchroom",
+      prefixArgs: [],
+      compiled: false,
+    });
+    expect(resolveSelfInvocation({ execPath: "", ...{ scriptPath: COMPILED.scriptPath } }))
+      .toEqual({ command: "switchroom", prefixArgs: [], compiled: true });
+  });
+
+  it("selfInvokeArgv puts the subcommand FIRST for a compiled binary", () => {
+    const { command, argv } = selfInvokeArgv(["apply", "--non-interactive"], COMPILED);
+    expect(command).toBe(COMPILED.execPath);
+    expect(argv).toEqual(["apply", "--non-interactive"]);
+    expectNoBunfs(argv);
+  });
+
+  it("selfInvokeArgv keeps the script path for a JS install", () => {
+    const { command, argv } = selfInvokeArgv(["apply", "--non-interactive"], JS_INSTALL);
+    expect(command).toBe(JS_INSTALL.execPath);
+    expect(argv).toEqual([JS_INSTALL.scriptPath, "apply", "--non-interactive"]);
+  });
+});
+
+// ─── call sites ──────────────────────────────────────────────────────────
+//
+// The helper being right is necessary but not sufficient: the bug was in
+// the call sites. Each block below asserts the argv that actually reaches
+// spawn, under BOTH execution modes.
+
+describe("rollout self-spawn (#3963 — the reproduced failure)", () => {
+  function spy(): {
+    calls: Array<{ cmd: string; args: string[] }>;
+    spawn: RolloutSpawnSync;
+  } {
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const spawn: RolloutSpawnSync = (cmd, args) => {
+      calls.push({ cmd, args });
+      return { status: 0, stdout: "" };
+    };
+    return { calls, spawn };
+  }
+
+  it("compiled binary: `apply` is the subcommand, not the bunfs path", () => {
+    const { calls, spawn } = spy();
+    const deps = createRolloutDeps({
+      configPath: "/nope/switchroom.yaml",
+      scriptPath: COMPILED.scriptPath,
+      execPath: COMPILED.execPath,
+      hostdCtx: false,
+      spawn,
+      warn: () => undefined,
+    });
+    deps.run(["apply", "--pin", "v0.19.32", "--non-interactive"]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.cmd).toBe(COMPILED.execPath);
+    // Pre-fix this was ["/$bunfs/root/switchroom-linux-amd64", "apply", …]
+    // and the child exited with `unknown command '/$bunfs/root/…'`.
+    expect(calls[0]!.args[0]).toBe("apply");
+    expect(calls[0]!.args).toEqual(["apply", "--pin", "v0.19.32", "--non-interactive"]);
+    expectNoBunfs(calls[0]!.args);
+  });
+
+  it("compiled binary: the per-agent restart step is intact too", () => {
+    const { calls, spawn } = spy();
+    const deps = createRolloutDeps({
+      configPath: "/nope/switchroom.yaml",
+      scriptPath: COMPILED.scriptPath,
+      execPath: COMPILED.execPath,
+      hostdCtx: false,
+      spawn,
+      warn: () => undefined,
+    });
+    deps.run(["agent", "restart", "clerk", "--wait", "--force"]);
+    expect(calls[0]!.args).toEqual(["agent", "restart", "clerk", "--wait", "--force"]);
+  });
+
+  it("JS install: unchanged — interpreter + script path + subcommand", () => {
+    const { calls, spawn } = spy();
+    const deps = createRolloutDeps({
+      configPath: "/nope/switchroom.yaml",
+      scriptPath: JS_INSTALL.scriptPath,
+      execPath: JS_INSTALL.execPath,
+      hostdCtx: false,
+      spawn,
+      warn: () => undefined,
+    });
+    deps.run(["apply"]);
+    expect(calls[0]!.cmd).toBe(JS_INSTALL.execPath);
+    expect(calls[0]!.args).toEqual([JS_INSTALL.scriptPath, "apply"]);
+  });
+});
+
+describe("update self-spawn steps (#3963)", () => {
+  function planWith(mode: { execPath: string; scriptPath: string }) {
+    const tmp = mkdtempSync(join(tmpdir(), "self-invoke-update-"));
+    const composePath = join(tmp, "docker-compose.yml");
+    writeFileSync(composePath, "services: {}\n");
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const steps = planUpdate({
+      composePath,
+      execPath: mode.execPath,
+      scriptPath: mode.scriptPath,
+      skipSelfUpdate: true,
+      hostControlEnabled: true,
+      webServiceManaged: true,
+      memoryBackendHindsight: true,
+      hostdContext: false,
+      runner: (cmd, args) => {
+        calls.push({ cmd, args });
+        return { status: 0 };
+      },
+    });
+    rmSync(tmp, { recursive: true, force: true });
+    return { steps, calls };
+  }
+
+  const selfInvoking = [
+    ["apply-config", ["apply", "--non-interactive", "--no-doctor"]],
+    ["refresh-hostd", ["hostd", "install"]],
+    ["refresh-web", ["webd", "install"]],
+  ] as const;
+
+  for (const [stepName, expectedArgs] of selfInvoking) {
+    it(`compiled binary: ${stepName} passes "${expectedArgs[0]}" as the subcommand`, async () => {
+      const { steps, calls } = planWith(COMPILED);
+      const step = steps.find((s) => s.name === stepName)!;
+      expect(step).toBeDefined();
+      await step.run();
+      const self = calls.find((c) => c.cmd === COMPILED.execPath);
+      expect(self, `${stepName} did not spawn the binary`).toBeDefined();
+      expect(self!.args).toEqual([...expectedArgs]);
+      expectNoBunfs(self!.args);
+    });
+
+    it(`JS install: ${stepName} keeps the interpreter + script path`, async () => {
+      const { steps, calls } = planWith(JS_INSTALL);
+      const step = steps.find((s) => s.name === stepName)!;
+      await step.run();
+      const self = calls.find((c) => c.cmd === JS_INSTALL.execPath);
+      expect(self).toBeDefined();
+      expect(self!.args).toEqual([JS_INSTALL.scriptPath, ...expectedArgs]);
+    });
+  }
+
+  it("compiled binary: refresh-hindsight passes `memory setup --recreate`", async () => {
+    const { steps, calls } = planWith(COMPILED);
+    const step = steps.find((s) => s.name === "refresh-hindsight")!;
+    await step.run();
+    const self = calls.find((c) => c.cmd === COMPILED.execPath)!;
+    expect(self.args.slice(0, 3)).toEqual(["memory", "setup", "--recreate"]);
+    expectNoBunfs(self.args);
+  });
+
+  it("compiled binary: no update step can ever hand a child a bunfs path", async () => {
+    const { steps, calls } = planWith(COMPILED);
+    for (const step of steps) {
+      if (step.skipReason) continue;
+      try {
+        await step.run();
+      } catch {
+        // Steps that shell out to docker/fs fail in a unit environment;
+        // we only care about the argv they built before failing.
+      }
+    }
+    expect(calls.length).toBeGreaterThan(0);
+    for (const c of calls) expectNoBunfs(c.args);
+  });
+});
+
+/**
+ * Structural guard. The five broken call sites all shared ONE spelling:
+ * `spawn(process.execPath, [<argv[1]-derived path>, …])`. Nothing stops a
+ * sixth from being written the same way, and no behavioural test can see a
+ * call site that does not exist yet — so pin the spelling itself. Every
+ * self-invocation must route through `self-invoke.ts`.
+ */
+describe("no source file re-invokes switchroom by hand (#3963)", () => {
+  const FORBIDDEN = [
+    /\bspawn(?:Sync)?\s*\(\s*process\.execPath\b/,
+    /\bspawn(?:Sync)?\s*\(\s*process\.argv0\b/,
+    /\bexecFile(?:Sync)?\s*\(\s*process\.execPath\b/,
+  ];
+
+  it("routes every self-spawn through resolveSelfInvocation", () => {
+    const srcRoot = join(import.meta.dirname, "..");
+    const offenders: string[] = [];
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const p = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(p);
+          continue;
+        }
+        if (!entry.name.endsWith(".ts")) continue;
+        if (entry.name.endsWith(".test.ts")) continue;
+        const text = readFileSync(p, "utf-8");
+        text.split("\n").forEach((line, i) => {
+          // Comments may quote the broken shape to explain it.
+          const t = line.trim();
+          if (t.startsWith("*") || t.startsWith("//") || t.startsWith("/*")) return;
+          if (FORBIDDEN.some((re) => re.test(line))) {
+            offenders.push(`${p}:${i + 1}: ${line.trim()}`);
+          }
+        });
+      }
+    };
+    walk(srcRoot);
+    expect(
+      offenders,
+      "spawn the result of resolveSelfInvocation()/selfInvokeArgv() instead — " +
+        "process.argv[1] is a virtual /$bunfs path in the published binary (#3963)",
+    ).toEqual([]);
+  });
+});
+
+describe("apply --self-elevate sudo argv (#3963)", () => {
+  it("compiled binary: sudo runs the binary with the subcommand directly", () => {
+    const argv = buildSelfElevateArgv(COMPILED);
+    const execIdx = argv.indexOf(COMPILED.execPath);
+    expect(execIdx).toBeGreaterThanOrEqual(0);
+    // Immediately after the binary comes the passthrough argv, never a
+    // bunfs bundle path.
+    expectNoBunfs(argv);
+    expect(argv[argv.length - 1]).toBe("--skip-self-elevate");
+  });
+
+  it("JS install: sudo runs interpreter + script path (unchanged)", () => {
+    const argv = buildSelfElevateArgv(JS_INSTALL);
+    const execIdx = argv.indexOf(JS_INSTALL.execPath);
+    expect(execIdx).toBeGreaterThanOrEqual(0);
+    expect(argv[execIdx + 1]).toBe(JS_INSTALL.scriptPath);
+  });
+});

--- a/src/cli/self-invoke.ts
+++ b/src/cli/self-invoke.ts
@@ -1,0 +1,145 @@
+/**
+ * How switchroom re-invokes ITSELF as a subprocess (#3963).
+ *
+ * THE BUG THIS CLOSES
+ *
+ * Half a dozen commands shell out to another switchroom subcommand
+ * rather than calling into it in-process (`rollout` runs `apply` then
+ * `agent restart …`; `update` runs `apply` / `hostd install` / `webd
+ * install` / `memory setup` / `doctor`; `apply` re-execs itself under
+ * sudo; `skill push` runs `apply`; `vault broker start` daemonises
+ * itself). Every one of them was written the same way:
+ *
+ *     spawn(process.execPath, [process.argv[1], ...args])
+ *
+ * That is correct for a JS install — `process.execPath` is the bun/node
+ * interpreter and `argv[1]` is a real `dist/cli/switchroom.js` on disk.
+ * It is WRONG for the artifact `install.sh` actually publishes. Inside a
+ * `bun build --compile` single-file executable, `process.execPath` is
+ * the switchroom binary itself and `process.argv[1]` is the VIRTUAL
+ * bundle path `/$bunfs/root/switchroom-linux-amd64` — not a file, and
+ * not something the binary will accept as an argument. The spawn became
+ *
+ *     /usr/local/bin/switchroom  /$bunfs/root/switchroom-linux-amd64  apply …
+ *
+ * and commander parsed the bunfs path as the subcommand:
+ *
+ *     error: unknown command '/$bunfs/root/switchroom-linux-amd64'
+ *
+ * `switchroom rollout` was therefore dead on arrival in every published
+ * binary — it stopped at step 1 with zero agents rolled (reproduced on
+ * v0.19.32).
+ *
+ * THE RULE
+ *
+ * A compiled binary is its own entrypoint: spawn `process.execPath` with
+ * the subcommand args and NOTHING in front of them. A JS install needs
+ * the interpreter plus the script path. {@link resolveSelfInvocation}
+ * returns exactly that split so no call site has to remember it, and
+ * {@link isCompiledBinaryPath} is the single definition of the tell.
+ *
+ * WHY A PATH PREFIX AND NOT A FILESYSTEM PROBE
+ *
+ * The bunfs root is virtual — `existsSync(argv[1])` is not a reliable
+ * discriminator across bun versions, and probing the filesystem on every
+ * self-spawn is both slower and less predictable than a string test. The
+ * repo already discriminates the compiled case exactly this way in
+ * `self-update.ts` (`detectInstallKind`, `p.bundleDir.startsWith("/$bunfs")`)
+ * and in `apply.ts`'s embedded-template comments. This module keeps that
+ * one convention.
+ *
+ * Pure and dependency-free on purpose: every call site can inject the
+ * probe, so the compiled-binary behaviour is unit-assertable on a host
+ * that has no compiled binary (CI included).
+ */
+
+/**
+ * Virtual root of a `bun build --compile` single-file executable's
+ * embedded filesystem on POSIX. Same literal `self-update.ts` matches.
+ */
+export const BUNFS_POSIX_PREFIX = "/$bunfs";
+
+/**
+ * Windows flavour of the same virtual root. Bun mounts the embedded
+ * filesystem at `B:\~BUN\root\…` there. Matched case-insensitively and
+ * on either slash so a normalised path still trips it.
+ */
+const BUNFS_WINDOWS_RE = /^[a-z]:[/\\]~BUN[/\\]/i;
+
+/**
+ * True when `scriptPath` is a compiled binary's virtual bundle path
+ * rather than a real file on disk.
+ *
+ * This is the ONLY place the tell is defined. Anything that needs to
+ * know "am I a published static binary?" for self-invocation purposes
+ * asks here.
+ */
+export function isCompiledBinaryPath(scriptPath: string | undefined | null): boolean {
+  if (!scriptPath) return false;
+  return (
+    scriptPath.startsWith(BUNFS_POSIX_PREFIX) || BUNFS_WINDOWS_RE.test(scriptPath)
+  );
+}
+
+/** What to pass to `spawn`/`spawnSync` to re-invoke switchroom. */
+export interface SelfInvocation {
+  /** Executable to spawn. */
+  command: string;
+  /**
+   * Arguments that must come BEFORE the subcommand args. `[scriptPath]`
+   * for a JS install; EMPTY for a compiled binary, which is its own
+   * entrypoint.
+   */
+  prefixArgs: string[];
+  /** True when {@link command} is the compiled switchroom binary itself. */
+  compiled: boolean;
+}
+
+/** Inputs to {@link resolveSelfInvocation}. Injectable for tests. */
+export interface SelfInvokeProbe {
+  /** `process.execPath` — the interpreter, or the binary when compiled. */
+  execPath?: string;
+  /** `process.argv[1]` — the script path, or the bunfs path when compiled. */
+  scriptPath?: string;
+}
+
+/**
+ * Resolve how to re-invoke this switchroom.
+ *
+ * Compiled binary  → `{ command: <the binary>, prefixArgs: [] }`
+ * JS install       → `{ command: <bun|node>,   prefixArgs: [<script>] }`
+ *
+ * Degenerate inputs fall back to the bare `switchroom` name and let
+ * $PATH resolve it — the same fallback the call sites used before, and
+ * strictly better than spawning an empty string.
+ */
+export function resolveSelfInvocation(probe: SelfInvokeProbe = {}): SelfInvocation {
+  const execPath = probe.execPath ?? process.execPath;
+  const scriptPath = probe.scriptPath ?? process.argv[1] ?? "";
+
+  if (isCompiledBinaryPath(scriptPath)) {
+    // The binary is its own entrypoint. Passing the bunfs path along is
+    // exactly the #3963 bug.
+    if (execPath) return { command: execPath, prefixArgs: [], compiled: true };
+    // A compiled binary with no execPath should not be reachable, but
+    // spawning "" certainly fails; let $PATH answer instead.
+    return { command: "switchroom", prefixArgs: [], compiled: true };
+  }
+
+  if (!execPath || !scriptPath) {
+    return { command: "switchroom", prefixArgs: [], compiled: false };
+  }
+  return { command: execPath, prefixArgs: [scriptPath], compiled: false };
+}
+
+/**
+ * Convenience wrapper: the complete `[command, argv]` pair for running
+ * `switchroom <args…>` as a subprocess of this one.
+ */
+export function selfInvokeArgv(
+  args: readonly string[],
+  probe: SelfInvokeProbe = {},
+): { command: string; argv: string[] } {
+  const inv = resolveSelfInvocation(probe);
+  return { command: inv.command, argv: [...inv.prefixArgs, ...args] };
+}

--- a/src/cli/skill.ts
+++ b/src/cli/skill.ts
@@ -68,6 +68,7 @@ import {
 } from "./skill-common.js";
 import { loadConfig } from "../config/loader.js";
 import { withConfigError } from "./helpers.js";
+import { selfInvokeArgv } from "./self-invoke.js";
 import chalk from "chalk";
 
 // ─── Constants ───────────────────────────────────────────────────────
@@ -654,13 +655,12 @@ export function registerSkillCommand(program: Command): void {
         // Run switchroom apply to materialise symlinks for opt-in agents.
         // Best-effort: failure here doesn't roll back the write (the file
         // is in the pool; the operator can re-run apply manually).
-        const applyBin = process.argv[1] ?? "switchroom";
+        // #3963: a compiled static binary is its own entrypoint — argv[1]
+        // is a virtual `/$bunfs/root/...` path there, and process.argv0 is
+        // not a reliable interpreter path either. See ./self-invoke.ts.
+        const self = selfInvokeArgv(["apply", "--non-interactive"]);
         console.log(chalk.gray(`Running \`switchroom apply --non-interactive\`...`));
-        const r = spawnSync(
-          process.argv0,
-          [applyBin, "apply", "--non-interactive"],
-          { stdio: "inherit" },
-        );
+        const r = spawnSync(self.command, self.argv, { stdio: "inherit" });
         if (r.status !== 0) {
           console.error(
             chalk.yellow(

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -63,6 +63,7 @@ import {
   type SelfUpdateIO,
 } from "./self-update.js";
 import { defaultSelfUpdateIO } from "./self-update-io.js";
+import { resolveSelfInvocation } from "./self-invoke.js";
 import {
   collectComponents,
   detectComponentDrift,
@@ -113,8 +114,13 @@ interface UpdateOptions {
   /** Compose-file override for tests. */
   composePath?: string;
   /** Test seam — override the running-script path used by the
-   *  `--rebuild` source-checkout guard (default: process.argv[1]). */
+   *  `--rebuild` source-checkout guard and by the self-invocation
+   *  resolver (default: process.argv[1]). */
   scriptPath?: string;
+  /** Test seam — override `process.execPath` for the self-invocation
+   *  resolver, so the compiled-binary spawn shape (#3963) is assertable
+   *  without a real static binary. */
+  execPath?: string;
   /** stdout/stderr writers for tests. */
   stdout?: (s: string) => void;
   stderr?: (s: string) => void;
@@ -434,6 +440,15 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
   const composePath = opts.composePath ?? DEFAULT_COMPOSE_PATH;
   const runner = opts.runner ?? defaultRunner;
   const scriptPath = opts.scriptPath ?? process.argv[1] ?? "";
+  // #3963: every self-invoking step below must NOT pass a compiled
+  // binary's bunfs bundle path as argv[1] — the binary is its own
+  // entrypoint and commander would parse the path as the subcommand.
+  // See ./self-invoke.ts.
+  const self = resolveSelfInvocation({
+    execPath: opts.execPath ?? process.execPath,
+    scriptPath,
+  });
+  const selfArgv = (...args: string[]): string[] => [...self.prefixArgs, ...args];
   const steps: UpdateStep[] = [];
   // Resolve whether we are running inside the hostd container. When true,
   // refresh-hostd and refresh-web are deferred (cannot recreate the very
@@ -555,13 +570,12 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
       description:
         "Regenerate compose with the --channel/--pin override so pull-images grabs the right tag",
       run: () => {
-        const r = runner(process.execPath, [
-          scriptPath,
+        const r = runner(self.command, selfArgv(
           "apply",
           "--compose-only",
           "--non-interactive",
           ...releaseOverrideArgs,
-        ]);
+        ));
         if (r.status !== 0) {
           throw new Error("regen-compose-for-release-override failed");
         }
@@ -627,13 +641,12 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
       // update has its own doctor step at position 5; running it
       // twice would produce identical output ~3s apart and read as
       // a broken pipeline.
-      const r = runner(process.execPath, [
-        scriptPath,
+      const r = runner(self.command, selfArgv(
         "apply",
         "--non-interactive",
         "--no-doctor",
         ...releaseOverrideArgs,
-      ]);
+      ));
       if (r.status !== 0) throw new Error("switchroom apply failed");
     },
   });
@@ -680,7 +693,7 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
           : undefined,
     isHostdDeferred: hostControlEnabled && !opts.skipImages && hostdContext,
     run: () => {
-      const r = runner(process.execPath, [scriptPath, "hostd", "install"]);
+      const r = runner(self.command, selfArgv("hostd", "install"));
       if (r.status !== 0) throw new Error("switchroom hostd install failed");
     },
   });
@@ -724,7 +737,7 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
           : undefined,
     isHostdDeferred: webServiceManaged && !opts.skipImages && hostdContext,
     run: () => {
-      const r = runner(process.execPath, [scriptPath, "webd", "install"]);
+      const r = runner(self.command, selfArgv("webd", "install"));
       if (r.status !== 0) throw new Error("switchroom webd install failed");
     },
   });
@@ -780,7 +793,7 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
       const pinTag = resolveHindsightPinTag(opts);
       const setupArgs = ["memory", "setup", "--recreate"];
       if (pinTag) setupArgs.push("--tag", pinTag);
-      const r = runner(process.execPath, [scriptPath, ...setupArgs]);
+      const r = runner(self.command, selfArgv(...setupArgs));
       if (r.status !== 0) throw new Error("switchroom memory setup --recreate failed");
     },
   });
@@ -992,7 +1005,7 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
       // Doctor returns non-zero on findings; don't propagate that as
       // an update failure (the update succeeded; the diagnostics are
       // informational). Just print and continue.
-      runner(process.execPath, [scriptPath, "doctor"]);
+      runner(self.command, selfArgv("doctor"));
     },
   });
 

--- a/src/cli/vault-broker.ts
+++ b/src/cli/vault-broker.ts
@@ -21,6 +21,7 @@ import { homedir } from "node:os";
 import { spawn } from "node:child_process";
 import { loadConfig } from "../config/loader.js";
 import { resolvePath } from "../config/loader.js";
+import { resolveSelfInvocation } from "./self-invoke.js";
 import {
   statusViaBroker,
   lockViaBroker,
@@ -242,11 +243,14 @@ export function registerVaultBrokerCommand(vaultCmd: Command, program: Command):
       } else {
         // Detached mode (v0.6 host/systemd): spawn a background
         // process and exit.
-        const self = process.argv[1];
         const args = ["vault", "broker", "start", "--foreground"];
         if (parentOpts.config) args.unshift("--config", parentOpts.config);
 
-        const child = spawn(process.execPath, [self, ...args], {
+        // #3963: under a compiled static binary the entrypoint is the
+        // binary itself — argv[1] is a virtual bunfs path that commander
+        // would read as the subcommand. See ./self-invoke.ts.
+        const self = resolveSelfInvocation();
+        const child = spawn(self.command, [...self.prefixArgs, ...args], {
           detached: true,
           stdio: "ignore",
         });


### PR DESCRIPTION
Fixes #3963.

## Summary

`switchroom rollout` is dead on arrival in the published static binary — the exact artifact `install.sh` puts on every operator's host. Reproduced here on a locally built `switchroom-linux-amd64` from `origin/main` (5ccce0a7), against a throwaway config:

```
Rolling 1 agent(s) to v0.19.32…
ROLL_STEP apply — regenerating compose for v0.19.32
error: unknown command '/$bunfs/root/switchroom-linux-amd64'
✗ Rollout STOPPED at apply.
  Rolled before stop: none.
```

## Why

Six call sites re-invoke switchroom as a subprocess, all spelled the same way:

```ts
spawn(process.execPath, [process.argv[1], ...args])
```

Correct for a JS install (interpreter + a real `dist/cli/switchroom.js`). Wrong for a `bun build --compile` executable, where `process.execPath` is the binary itself and `process.argv[1]` is the **virtual** bundle path `/$bunfs/root/switchroom-linux-amd64`. The bunfs path became the binary's first argument, and commander parsed it as the subcommand.

| site | what broke |
|---|---|
| `src/cli/rollout.ts` | every rollout step — the reported failure |
| `src/cli/update.ts` ×6 | `apply`, `hostd install`, `webd install`, `memory setup --recreate`, `doctor` |
| `src/cli/apply.ts` | the sudo self-elevate argv |
| `src/cli/skill.ts` | `skill push` → `apply` (also used `process.argv0`) |
| `src/cli/vault-broker.ts` | the detached broker daemon spawn |

The hostd container ships `dist/cli/switchroom.js` (`docker/Dockerfile.hostd:78`), which is why the same roll works through hostd and why this never showed up in the fleet's own tooling.

All six share one root cause and one mechanism, so they are fixed together rather than left as five known-broken siblings of a fixed one.

## What changed

New `src/cli/self-invoke.ts` owns the single rule: a compiled binary is its own entrypoint — spawn `process.execPath` with the subcommand and **no** script argument; a JS install keeps interpreter + script path. Detection is the `/$bunfs` prefix on `argv[1]` (plus the Windows `B:\~BUN\` flavour), the same discriminator `self-update.ts:153` already uses. Deliberately not a filesystem probe: the bunfs root is virtual, so `existsSync` is not a reliable discriminator.

Every call site routes through `resolveSelfInvocation()` / `selfInvokeArgv()`. Each grew an injectable probe so the compiled-binary shape is assertable without a compiled binary.

## Test plan

`src/cli/self-invoke.test.ts` (23 tests) asserts the argv that actually reaches `spawn`, in **both** execution modes, at the helper and at each call site:

- compiled: `cmd === <binary>`, `args[0] === "apply"`, and no argument anywhere matches `/\$bunfs/`
- JS install: `cmd === <interpreter>`, `args[0] === <script path>` — i.e. unchanged

**Confirmed it fails on the bug:** reverting only the argv construction (keeping the new test seams) fails 8 of the compiled-binary assertions, with the JS-install ones still green — the exact regression shape. A test that only exercised the JS path would have stayed green, which is how this shipped.

A structural guard in the same file fails the build if any `src/` file spells `spawn(process.execPath, …)` / `spawn(process.argv0, …)` again, so a seventh call site cannot reintroduce this by hand. Verified by planting a probe file — the guard reds.

End-to-end on real binaries built from this branch vs `origin/main` (`npm run build:cli`, read-only `apply --print-sudo-cmd`, throwaway `$HOME`):

```
# origin/main
sudo --preserve-env=… /…/switchroom-linux-amd64 /$bunfs/root/switchroom-linux-amd64 apply --print-sudo-cmd --skip-self-elevate
# this branch
sudo --preserve-env=… /…/switchroom-linux-amd64 apply --print-sudo-cmd --skip-self-elevate
```

Local: `vitest run src/cli/{self-invoke,rollout,update,skill,self-update,update-self-update}.test.ts` → 298 passed. `npm run lint` → clean. `src/cli/apply.test.ts` has 10 failures in this sandbox (`EROFS` writing `~/.switchroom/fleet`), identical on pristine `origin/main` — environment, not this diff.

## Risk

Low. Behaviour on a JS install is byte-identical (`prefixArgs === [scriptPath]`), which is what every existing test and the whole hostd path exercise. The changed branch is the one that could not work at all before. Degenerate inputs (no `argv[1]`) now fall back to a bare `switchroom` on `$PATH` instead of passing an empty string or a literal `"switchroom"` as `argv[1]`.

## Deliberately NOT in this PR

The issue flags four other `argv[1]` sites. Audited at HEAD:

- `src/vault/approvals/kernel-server.ts:839` and `src/vault/broker/server.ts:3524` — entry guards, not self-spawns. Both additionally require `argv[1]`'s basename to match `kernel-server.(js|ts)` / `server.(js|ts)`; `/$bunfs/root/switchroom-linux-amd64` matches neither, so they fail **closed** under the SEA. Correct as written; no change. (`src/auth/broker/index.ts:135` and `src/agent-scheduler/index.ts:1024` have the same shape and the same verdict.)
- `src/cli/update.ts` `defaultStatusProbe` (the `package.json` walk) and `src/vault/flock.ts:431` (lock-holder metadata) — real `argv[1]` residue, but a different mechanism (version *resolution* / diagnostics, not spawn argv) and non-blocking: `--status` degrades to `CLI: unknown` with a warning. Filed as a follow-up rather than widened into this diff.

Job spec: `reference/jobs/idempotent-update-and-restart.md` — the stack has to actually land the declared version; a rollout that cannot start is the sharpest failure of that outcome. Also `reference/jobs/operate-the-fleet-from-telegram.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)