### PR TITLE
fix(rollout): derive prior_pin from the running fleet, not the config pin

### DIFF
--- a/src/host-control/audit-reader.ts
+++ b/src/host-control/audit-reader.ts
@@ -77,6 +77,11 @@ export interface AuditEntry {
    *  `rollout --allow-downgrade` to default its target to the last good
    *  version without the operator having to recall the tag. */
   prior_pin?: string;
+  /** Every distinct version observed across the in-scope fleet when the
+   *  roll started, highest first. Present only when the fleet was mixed. */
+  prior_pin_observed?: string[];
+  /** How `prior_pin` was derived — see `PriorPinSource` in prior-pin.ts. */
+  prior_pin_source?: string;
 }
 
 export interface AuditFilters {
@@ -331,6 +336,15 @@ export function parseAuditLine(line: string): AuditEntry | null {
   if (typeof o.m === "number") entry.m = o.m;
   // Prior-pin capture (#2492) — present only on completed rollout terminal rows.
   if (typeof o.prior_pin === "string") entry.prior_pin = o.prior_pin;
+  if (
+    Array.isArray(o.prior_pin_observed) &&
+    o.prior_pin_observed.every((v) => typeof v === "string")
+  ) {
+    entry.prior_pin_observed = o.prior_pin_observed as string[];
+  }
+  if (typeof o.prior_pin_source === "string") {
+    entry.prior_pin_source = o.prior_pin_source;
+  }
   return entry;
 }
 

--- a/src/host-control/main.ts
+++ b/src/host-control/main.ts
@@ -32,6 +32,7 @@ import {
 } from "./config-degraded.js";
 import { allocateAgentUid } from "../agents/compose.js";
 import { HostdServer } from "./server.js";
+import { dockerFleetComponents } from "./prior-pin.js";
 import { SocketApprovalGateway } from "./approval-gateway.js";
 import { SocketRolloutRelay } from "./rollout-relay.js";
 import { SocketRolloutNarrationRelay } from "./rollout-narration-relay.js";
@@ -203,6 +204,11 @@ async function main(): Promise<void> {
   const server = new HostdServer({
     homeDir: homedir(),
     agentUids,
+    // The sole production wiring of the running-fleet inventory. `prior_pin`
+    // (the rollback target stamped on every completed roll) is derived from
+    // it; drop this and rollback degrades to "no target recorded". Asserted
+    // by tests/host-control/hostd-fleet-components-callsite.test.ts.
+    fleetComponents: () => dockerFleetComponents(),
     config: {
       agents: Object.fromEntries(
         // `root: true` (the root-tier debugging agent) is strictly above

--- a/src/host-control/prior-pin.test.ts
+++ b/src/host-control/prior-pin.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit coverage for the pure `prior_pin` resolver.
+ *
+ * The wiring-level regression (config pin already == target) lives in
+ * `tests/host-control/rollout-prior-pin-source.test.ts`. These pin the
+ * two invariants the module exists to hold, at the level where they are
+ * decided: the target is never the answer, and a mixed fleet is recorded
+ * honestly with a deterministic single pick.
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolvePriorPinFromFleet } from "./prior-pin.js";
+import type { ComponentVersion } from "../cli/component-versions.js";
+
+const AGENT_IMAGE = "ghcr.io/switchroom/switchroom-agent";
+
+function agent(name: string, version: string | null): ComponentVersion {
+  return {
+    name: `switchroom-${name}`,
+    kind: "container",
+    version,
+    imageRef: `${AGENT_IMAGE}:${version ?? "latest"}`,
+  };
+}
+
+function container(
+  name: string,
+  imageRef: string,
+  version: string | null,
+): ComponentVersion {
+  return { name, kind: "container", version, imageRef };
+}
+
+describe("resolvePriorPinFromFleet", () => {
+  it("returns the single version a uniform fleet is running", () => {
+    expect(
+      resolvePriorPinFromFleet(
+        [agent("clerk", "v1.9.0"), agent("marko", "v1.9.0")],
+        "v2.0.0",
+      ),
+    ).toEqual({ prior_pin: "v1.9.0", prior_pin_source: "running-fleet" });
+  });
+
+  it("INVARIANT 1: never returns the target", () => {
+    const r = resolvePriorPinFromFleet(
+      [agent("clerk", "v2.0.0"), agent("marko", "v2.0.0")],
+      "v2.0.0",
+    );
+    expect(r.prior_pin).toBeUndefined();
+    expect(r.prior_pin_source).toBe("all-on-target");
+    expect(r.prior_pin_observed).toEqual(["v2.0.0"]);
+  });
+
+  it("INVARIANT 1 holds when the target tag is written bare (no leading v)", () => {
+    const r = resolvePriorPinFromFleet([agent("clerk", "v2.0.0")], "2.0.0");
+    expect(r.prior_pin).toBeUndefined();
+    expect(r.prior_pin_source).toBe("all-on-target");
+  });
+
+  it("INVARIANT 2: a mixed fleet picks the LOWEST candidate and records the whole set", () => {
+    const r = resolvePriorPinFromFleet(
+      [
+        agent("clerk", "v1.9.0"),
+        agent("marko", "v1.7.2"),
+        agent("ghost", "v1.10.0"),
+      ],
+      "v2.0.0",
+    );
+    // Lowest: a rollback must never be an UPGRADE for any in-scope agent.
+    expect(r.prior_pin).toBe("v1.7.2");
+    expect(r.prior_pin_source).toBe("running-fleet-mixed");
+    // Semver ordering, not lexical: v1.10.0 > v1.9.0.
+    expect(r.prior_pin_observed).toEqual(["v1.10.0", "v1.9.0", "v1.7.2"]);
+  });
+
+  it("a mixed fleet that includes the target still excludes it from the pick", () => {
+    const r = resolvePriorPinFromFleet(
+      [agent("clerk", "v2.0.0"), agent("marko", "v1.9.0"), agent("ghost", "v1.8.0")],
+      "v2.0.0",
+    );
+    expect(r.prior_pin).toBe("v1.8.0");
+    expect(r.prior_pin_observed).toEqual(["v2.0.0", "v1.9.0", "v1.8.0"]);
+  });
+
+  it("one candidate beside the target is unambiguous but still discloses the set", () => {
+    const r = resolvePriorPinFromFleet(
+      [agent("clerk", "v2.0.0"), agent("marko", "v1.9.0")],
+      "v2.0.0",
+    );
+    expect(r.prior_pin).toBe("v1.9.0");
+    expect(r.prior_pin_source).toBe("running-fleet");
+    expect(r.prior_pin_observed).toEqual(["v2.0.0", "v1.9.0"]);
+  });
+
+  it("reports `unobserved` — not a guess — when nothing readable is running", () => {
+    expect(resolvePriorPinFromFleet([], "v2.0.0")).toEqual({
+      prior_pin_source: "unobserved",
+    });
+  });
+
+  it("ignores agents whose image tag carries no semver", () => {
+    const r = resolvePriorPinFromFleet(
+      [container("switchroom-clerk", `${AGENT_IMAGE}:latest`, null)],
+      "v2.0.0",
+    );
+    expect(r.prior_pin_source).toBe("unobserved");
+  });
+
+  it("ignores non-agent components — hostd/web/hindsight advance separately", () => {
+    const r = resolvePriorPinFromFleet(
+      [
+        container(
+          "switchroom-web",
+          "ghcr.io/switchroom/switchroom-web:v1.0.0",
+          "v1.0.0",
+        ),
+        container(
+          "switchroom-hostd",
+          "ghcr.io/switchroom/switchroom-hostd:v1.1.0",
+          "v1.1.0",
+        ),
+        container(
+          "switchroom-hindsight",
+          "ghcr.io/switchroom/switchroom-hindsight:v1.2.0",
+          "v1.2.0",
+        ),
+        agent("clerk", "v1.9.0"),
+      ],
+      "v2.0.0",
+    );
+    expect(r.prior_pin).toBe("v1.9.0");
+    expect(r.prior_pin_source).toBe("running-fleet");
+  });
+
+  it("ignores the CLI component", () => {
+    const r = resolvePriorPinFromFleet(
+      [
+        { name: "cli (host)", kind: "cli", version: "v1.0.0" },
+        agent("clerk", "v1.9.0"),
+      ],
+      "v2.0.0",
+    );
+    expect(r.prior_pin).toBe("v1.9.0");
+  });
+
+  it("restricts to the --agents subset when one was given", () => {
+    const r = resolvePriorPinFromFleet(
+      [agent("clerk", "v1.9.0"), agent("marko", "v1.0.0")],
+      "v2.0.0",
+      ["clerk"],
+    );
+    expect(r.prior_pin).toBe("v1.9.0");
+    expect(r.prior_pin_source).toBe("running-fleet");
+  });
+
+  it("an empty scope array means the whole fleet, not an empty fleet", () => {
+    const r = resolvePriorPinFromFleet(
+      [agent("clerk", "v1.9.0"), agent("marko", "v1.9.0")],
+      "v2.0.0",
+      [],
+    );
+    expect(r.prior_pin).toBe("v1.9.0");
+  });
+
+  it("with no target given, the highest-observed is still not assumed — the lowest rule holds", () => {
+    const r = resolvePriorPinFromFleet(
+      [agent("clerk", "v1.9.0"), agent("marko", "v1.7.0")],
+      undefined,
+    );
+    expect(r.prior_pin).toBe("v1.7.0");
+    expect(r.prior_pin_source).toBe("running-fleet-mixed");
+  });
+});

--- a/src/host-control/prior-pin.ts
+++ b/src/host-control/prior-pin.ts
@@ -1,0 +1,202 @@
+/**
+ * `prior_pin` derivation — the rollback target, read from the RUNNING
+ * fleet rather than from the config file the roll is about to rewrite.
+ *
+ * WHY THIS EXISTS
+ *
+ * `rollout` stamps `prior_pin` on its completed terminal audit row so a
+ * later `rollout --allow-downgrade` (no `--pin`) can default its target
+ * to "the last good version" without the operator having to recall the
+ * tag (#2492). The value therefore has exactly one job: name the version
+ * the fleet was on BEFORE this roll.
+ *
+ * The original derivation read `release.pin` out of `switchroom.yaml`.
+ * That is the wrong source, because the roll's own `persist-pin` step
+ * writes that same field — so the config pin is only "the prior version"
+ * when nothing else has already moved it. Anything that sets the pin
+ * ahead of the roll (an operator editing the yaml first, a re-run of a
+ * roll that already persisted, an `apply` that wrote the target) makes
+ * the config pin equal to the TARGET, and `prior_pin` is then recorded
+ * as the version being rolled TO. Rollback silently becomes a no-op:
+ * `--allow-downgrade` resolves a target identical to the current one and
+ * "rolls back" to where it already is.
+ *
+ * Observed on the operator host, 2026-07-29 (host-control-audit.log):
+ *
+ *   {"op":"rollout","result":"completed","pin":"v0.19.32",
+ *    "prior_pin":"v0.19.32"}
+ *
+ * while every agent had actually been running v0.19.30.
+ *
+ * THE FIX IS THE SOURCE, NOT A GUARD.
+ *
+ * `prior_pin` is derived from the versions the fleet's agent containers
+ * are ACTUALLY running at the moment the roll starts — the same
+ * enumerative `docker ps` inventory `switchroom update --check`, the
+ * doctor's component table, and the roll's own `verify-components` gate
+ * read from (`src/cli/component-versions.ts`, `src/cli/component-scope.ts`).
+ * A declared intent in a config file cannot disagree with the fleet;
+ * the fleet is the fact.
+ *
+ * TWO INVARIANTS THIS MODULE ENFORCES
+ *
+ *  1. `prior_pin` is NEVER the target. The target is filtered out of the
+ *     candidate set before a value is chosen, so the no-op-rollback
+ *     failure mode is structurally unreachable — not merely unlikely.
+ *     When every in-scope agent is already on the target there IS no
+ *     prior version to name, and we record none (`all-on-target`)
+ *     rather than inventing one.
+ *
+ *  2. A MIXED-version fleet is recorded honestly. Picking one version
+ *     out of several silently would make `prior_pin` a coin flip. We
+ *     record the full observed set in `prior_pin_observed` AND pick the
+ *     single value by one documented, deterministic rule: the LOWEST
+ *     observed version. Rolling back to the lowest is the only choice
+ *     that is not an UPGRADE for some in-scope agent — a rollback must
+ *     never move an agent forward.
+ *
+ * Pure: string-in / verdict-out, no I/O. The docker read is the caller's
+ * (`server.ts`), through the same `ExecFn` seam the rest of the
+ * inventory uses, so this unit-tests without docker.
+ */
+
+import { spawnSync } from "node:child_process";
+import {
+  collectContainerComponents,
+  normalizeSemverTag,
+  type ComponentVersion,
+} from "../cli/component-versions.js";
+import { classifyComponent } from "../cli/component-scope.js";
+import { compareReleaseTags } from "../config/release-resolve.js";
+
+/**
+ * The production fleet-inventory reader: one `docker ps` through the same
+ * collector `switchroom update --check`, `doctor`, and the roll's
+ * `verify-components` gate use — so hostd cannot disagree with them about
+ * what the fleet is running.
+ *
+ * Wired at the daemon's composition root (`main.ts`) rather than defaulted
+ * inside `HostdServer`, so a unit-test server never shells out to the
+ * host's docker. Fail-soft: a missing/failing `docker` yields `[]`, which
+ * the resolver reports as `unobserved`.
+ */
+export function dockerFleetComponents(dockerBin?: string): ComponentVersion[] {
+  const bin = dockerBin ?? "docker";
+  try {
+    return collectContainerComponents((cmd, args) => {
+      const r = spawnSync(cmd === "docker" ? bin : cmd, args, {
+        encoding: "utf-8",
+        timeout: 5000,
+      });
+      return { status: r.status ?? 1, stdout: r.stdout ?? "" };
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * How `prior_pin` was arrived at. Recorded on the audit row so a reader
+ * can tell "no prior version existed" from "we could not look".
+ */
+export type PriorPinSource =
+  /** One version observed across the in-scope fleet (target excluded). */
+  | "running-fleet"
+  /** Several versions observed; `prior_pin` is the lowest, set recorded. */
+  | "running-fleet-mixed"
+  /** Every in-scope agent already runs the target — no prior version. */
+  | "all-on-target"
+  /** No in-scope agent container reported a readable version. */
+  | "unobserved";
+
+export interface PriorPinResolution {
+  /** The rollback target. Absent when none could be named. */
+  prior_pin?: string;
+  /**
+   * Every distinct version observed across the in-scope fleet, highest
+   * first — INCLUDING the target when some agents already ran it.
+   * Present only when the fleet was not uniform, i.e. when the single
+   * `prior_pin` value does not tell the whole truth.
+   */
+  prior_pin_observed?: string[];
+  prior_pin_source: PriorPinSource;
+}
+
+/** Highest-first ordering; falls back to string compare so two tags that
+ *  `compareReleaseTags` cannot order still sort deterministically. */
+function byVersionDesc(a: string, b: string): number {
+  const cmp = compareReleaseTags(a, b);
+  if (cmp !== null && cmp !== 0) return -cmp;
+  return b.localeCompare(a);
+}
+
+/**
+ * Derive `prior_pin` from the running fleet.
+ *
+ * @param components  The `docker ps` component inventory (any mix of
+ *                    kinds — non-agent components are ignored, since
+ *                    hostd / web / hindsight advance by their own
+ *                    mechanisms and are not what a fleet rollback
+ *                    targets).
+ * @param target      The version this roll is moving TO. Excluded from
+ *                    the result by invariant 1.
+ * @param scope       Agent names this roll is responsible for (the
+ *                    `--agents` subset). Empty/undefined = whole fleet.
+ */
+export function resolvePriorPinFromFleet(
+  components: readonly ComponentVersion[],
+  target: string | undefined,
+  scope?: readonly string[],
+): PriorPinResolution {
+  const normalizedTarget = normalizeSemverTag(target);
+  const scoped = new Set(scope ?? []);
+
+  const seen = new Set<string>();
+  for (const c of components) {
+    if (c.kind !== "container") continue;
+    const owner = classifyComponent(c);
+    // Agent containers only. A fleet SINGLETON (vault-broker, approval
+    // kernel, …) classifies as `fleet` with no `agent` — it rides the
+    // same compose project but is not what "the version the fleet was
+    // running" means to an operator rolling back.
+    if (owner.kind !== "fleet" || !owner.agent) continue;
+    if (scoped.size > 0 && !scoped.has(owner.agent)) continue;
+    const v = normalizeSemverTag(c.version ?? undefined);
+    if (v) seen.add(v);
+  }
+
+  const observed = [...seen].sort(byVersionDesc);
+  if (observed.length === 0) return { prior_pin_source: "unobserved" };
+
+  // Invariant 1: the target can never be the answer.
+  const candidates = normalizedTarget
+    ? observed.filter((v) => v !== normalizedTarget)
+    : [...observed];
+
+  if (candidates.length === 0) {
+    return { prior_pin_source: "all-on-target", prior_pin_observed: observed };
+  }
+
+  if (candidates.length === 1 && observed.length === 1) {
+    return { prior_pin: candidates[0]!, prior_pin_source: "running-fleet" };
+  }
+
+  if (candidates.length === 1) {
+    // One candidate, but the fleet was not uniform (some agents already
+    // sat on the target). The answer is unambiguous; the set still gets
+    // recorded so the row does not imply uniformity it did not have.
+    return {
+      prior_pin: candidates[0]!,
+      prior_pin_source: "running-fleet",
+      prior_pin_observed: observed,
+    };
+  }
+
+  // Invariant 2: mixed. Lowest wins — a rollback must not be an upgrade
+  // for any in-scope agent — and the whole set is recorded.
+  return {
+    prior_pin: candidates[candidates.length - 1]!,
+    prior_pin_source: "running-fleet-mixed",
+    prior_pin_observed: observed,
+  };
+}

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -93,6 +93,11 @@ import {
   type PendingRolloutMarker,
 } from "./self-bump.js";
 import { parseUpdateResultLine } from "../cli/update.js";
+import type { ComponentVersion } from "../cli/component-versions.js";
+import {
+  resolvePriorPinFromFleet,
+  type PriorPinSource,
+} from "./prior-pin.js";
 import { parseAuditLine, latestRolloutRowForRequest } from "./audit-reader.js";
 import {
   validateConfigEdit,
@@ -231,6 +236,18 @@ export interface ServerOptions {
    * to enumerate refs from the operator's compose file.
    */
   imageRefsForDigests?: () => string[];
+  /**
+   * The running-container inventory the `prior_pin` derivation reads —
+   * REQUIRED in production, and injected rather than defaulted.
+   *
+   * `main.ts` wires `dockerFleetComponents`: one `docker ps` through the
+   * same collector `switchroom update --check` and `doctor` use, so the
+   * three cannot disagree about what the fleet is running. Left unset,
+   * the daemon sees an EMPTY fleet and records no `prior_pin` — which is
+   * exactly what keeps a unit-test server from reading the host's real
+   * containers.
+   */
+  fleetComponents?: () => ComponentVersion[];
   /**
    * Path to the live `switchroom.yaml` the config-edit validator (PR 1b)
    * reads when checking that a proposed unified diff applies cleanly
@@ -408,7 +425,19 @@ export interface StatusEntry {
   // intentionally absent on error rows. Enables `rollout --allow-downgrade`
   // to default its target to "the last good one" without the operator
   // having to remember the version string.
+  //
+  // DERIVED FROM THE RUNNING FLEET, not from `release.pin` — the roll
+  // rewrites that field, so the config pin is the TARGET whenever it was
+  // already set ahead of the roll, and rollback becomes a no-op. See
+  // `prior-pin.ts`.
   prior_pin?: string;
+  /** Every distinct version observed across the in-scope fleet, highest
+   *  first. Present only when the fleet was NOT uniform — a mixed fleet
+   *  is recorded honestly rather than collapsed to one silent pick. */
+  prior_pin_observed?: string[];
+  /** How `prior_pin` was arrived at — distinguishes "no prior version
+   *  existed" (`all-on-target`) from "we could not look" (`unobserved`). */
+  prior_pin_source?: PriorPinSource;
 }
 
 /**
@@ -2372,19 +2401,19 @@ export class HostdServer {
     // begins. Used to stamp `prior_pin` on the completed terminal row so
     // a subsequent `rollout --allow-downgrade` can default its target to
     // "the last good one" without the operator having to recall the tag.
-    // Best-effort: read the durable release.pin from config (the version
-    // last pinned by a prior completed rollout). If the config has no
-    // version-assertable pin we record nothing — `prior_pin` is optional.
-    let priorPin: string | undefined;
-    try {
-      const cfg = loadConfig(this.opts.configPath);
-      const cfgPin = (cfg as { release?: { pin?: string } }).release?.pin;
-      if (cfgPin && isVersionAssertable(cfgPin)) {
-        priorPin = cfgPin.startsWith("v") ? cfgPin : `v${cfgPin}`;
-      }
-    } catch {
-      // loadConfig throws on a malformed yaml; proceed without prior_pin.
-    }
+    //
+    // Read from the RUNNING FLEET, never from `release.pin` in the config
+    // file — this roll's own `persist-pin` step writes that field, so a
+    // config pin that was already set to the target makes `prior_pin` the
+    // target and turns rollback into a no-op. See `prior-pin.ts` for the
+    // full account and the two invariants. Fail-soft: an unreadable
+    // inventory yields no `prior_pin` (it is optional) rather than falling
+    // back to the config, which is the defect.
+    const priorPin = resolvePriorPinFromFleet(
+      this.fleetComponents(),
+      args.pin,
+      args.agents,
+    );
 
     const entry: StatusEntry = {
       request_id,
@@ -2401,7 +2430,11 @@ export class HostdServer {
         install_type: installCtx.install_type,
         detected_at: installCtx.detected_at,
       },
-      ...(priorPin ? { prior_pin: priorPin } : {}),
+      ...(priorPin.prior_pin ? { prior_pin: priorPin.prior_pin } : {}),
+      ...(priorPin.prior_pin_observed
+        ? { prior_pin_observed: priorPin.prior_pin_observed }
+        : {}),
+      prior_pin_source: priorPin.prior_pin_source,
     };
     this.recordStatus(entry);
     this.fleetMutationInFlight = {
@@ -4032,6 +4065,28 @@ export class HostdServer {
    * in-flight call.
    */
   /**
+   * The running switchroom containers and the version each is on — the
+   * source `prior_pin` is derived from.
+   *
+   * INJECTED, never self-serviced. The daemon does not reach for `docker`
+   * on its own: production wires {@link dockerFleetComponents} at the sole
+   * composition root (`main.ts`), and a server built without it sees an
+   * EMPTY fleet, which the resolver records as
+   * `prior_pin_source: "unobserved"` — an honest "could not look", never a
+   * fallback to the config pin.
+   *
+   * The asymmetry is deliberate. A self-servicing default would make every
+   * unit test's `prior_pin` depend on whichever containers the host running
+   * the suite happens to have — the same host-vs-container divergence
+   * `vitest.config.ts` scrubs env vars to prevent. The wiring is asserted
+   * by `tests/host-control/hostd-fleet-components-callsite.test.ts`, so
+   * dropping it fails CI instead of silently degrading rollback.
+   */
+  private fleetComponents(): ComponentVersion[] {
+    return this.opts.fleetComponents ? this.opts.fleetComponents() : [];
+  }
+
+  /**
    * Enumerate the docker image refs the digest resolver should look up.
    * In production, shells out to `docker compose config --images` so
    * the resolver targets exactly the images the running compose file
@@ -4214,9 +4269,13 @@ export class HostdServer {
         // prior_pin is only meaningful on COMPLETED rows (#2492): a failed
         // canary roll does NOT change the running pin, so recording a
         // prior_pin on an error row would mislead subsequent --allow-downgrade
-        // defaulting logic into thinking the roll succeeded. Strip it on failure.
+        // defaulting logic into thinking the roll succeeded. Strip it on
+        // failure — together with the corroborating fields, so an error row
+        // never carries a half-populated prior-pin story.
         if (entry.result !== "completed") {
           delete entry.prior_pin;
+          delete entry.prior_pin_observed;
+          delete entry.prior_pin_source;
         }
       })
       .catch((err) => {
@@ -4225,6 +4284,8 @@ export class HostdServer {
         entry.finished_at = Date.now();
         entry.error = (err as Error).message;
         delete entry.prior_pin;
+        delete entry.prior_pin_observed;
+        delete entry.prior_pin_source;
       })
       .finally(() => {
         // Crash net for the durable pin, GATED ON THE OUTCOME.
@@ -4430,9 +4491,10 @@ export class HostdServer {
     }
     if (!priorPin) {
       notes.push(
-        `No automatic rollback: no prior version-assertable release.pin was ` +
-          `recorded before this roll. Verify compose host-side ` +
-          `(\`switchroom apply\`).`,
+        `No automatic rollback: no prior version could be read off the running ` +
+          `fleet when this roll started (every agent was already on the target, ` +
+          `or no agent container reported a semver tag), so there is no restore ` +
+          `target to name. Verify compose host-side (\`switchroom apply\`).`,
       );
       return notes;
     }

--- a/tests/host-control/auto-rollout.test.ts
+++ b/tests/host-control/auto-rollout.test.ts
@@ -70,6 +70,19 @@ function makeServer(
     // High selfVersion so needsSelfBump never triggers in these tests.
     selfVersion: "v99.0.0",
     allowNonLinux: true,
+    // The fleet these rolls START from. `prior_pin` — which the
+    // unattended-failure recovery below uses as its compose-restore /
+    // canary-restart target — is derived from the RUNNING fleet, not from
+    // `release.pin`, so the fixture has to state what is actually running.
+    // Wiring the seam also keeps the suite hermetic: without it the daemon
+    // runs a real `docker ps` and reads whatever containers the host has.
+    fleetComponents: () =>
+      ["test-harness", "overlord", "clerk"].map((name) => ({
+        name: `switchroom-${name}`,
+        kind: "container" as const,
+        version: PRIOR_PIN,
+        imageRef: `ghcr.io/switchroom/switchroom-agent:${PRIOR_PIN}`,
+      })),
     rolloutRelay: {
       postTerminal: (n) => {
         posted.push(n);

--- a/tests/host-control/hostd-fleet-components-callsite.test.ts
+++ b/tests/host-control/hostd-fleet-components-callsite.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The `fleetComponents` wiring is load-bearing and silent when missing.
+ *
+ * `HostdServer` deliberately does NOT reach for `docker` on its own: a
+ * self-servicing default would make every unit test's `prior_pin` depend
+ * on whatever containers the host running the suite happens to have. The
+ * price of that choice is that the real inventory reader has to be
+ * injected at the composition root — and if someone drops that injection,
+ * NOTHING fails loudly. Rolls keep succeeding; they just stop recording a
+ * `prior_pin`, and `rollout --allow-downgrade` quietly loses its default
+ * target. The regression would only surface the day someone needed to
+ * roll back.
+ *
+ * A behavioural test cannot catch this: it would have to construct the
+ * daemon the way `main.ts` does, which is the very thing at issue. So
+ * this is a static callsite assertion — same shape as
+ * `singleton-cleanup-callsite.test.ts` — pinning the one wiring that
+ * exists to the one place it belongs.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const mainSrc = readFileSync(
+  join(repoRoot, "src", "host-control", "main.ts"),
+  "utf8",
+);
+const serverSrc = readFileSync(
+  join(repoRoot, "src", "host-control", "server.ts"),
+  "utf8",
+);
+
+describe("hostd wires the running-fleet inventory at its composition root", () => {
+  it("main.ts passes fleetComponents into HostdServer", () => {
+    expect(mainSrc).toMatch(/fleetComponents:\s*\(\)\s*=>\s*dockerFleetComponents\(/);
+  });
+
+  it("main.ts imports the real docker-backed collector", () => {
+    expect(mainSrc).toContain("dockerFleetComponents");
+    expect(mainSrc).toMatch(
+      /import\s*\{\s*dockerFleetComponents\s*\}\s*from\s*"\.\/prior-pin\.js"/,
+    );
+  });
+
+  it("server.ts does NOT shell out to docker for the inventory itself", () => {
+    // The whole point of the injection: a server built in a test must not
+    // read the host's containers. If a `docker ps` reappears in the
+    // daemon, unit-test `prior_pin` becomes host-dependent again.
+    //
+    // Matched as CALLS, so the `{@link dockerFleetComponents}` reference in
+    // the seam's own doc comment (which is documentation, not a call) does
+    // not trip the guard.
+    expect(serverSrc).not.toMatch(/\bcollectContainerComponents\s*\(/);
+    expect(serverSrc).not.toMatch(/\bdockerFleetComponents\s*\(/);
+  });
+});

--- a/tests/host-control/rollout-prior-pin-source.test.ts
+++ b/tests/host-control/rollout-prior-pin-source.test.ts
@@ -1,0 +1,186 @@
+/**
+ * `prior_pin` must name the version the FLEET was running, not the one
+ * the config file happened to say.
+ *
+ * THE BUG THESE GUARD
+ *
+ * `launchRollout` used to read `release.pin` out of `switchroom.yaml` to
+ * stamp `prior_pin`. The roll's own `persist-pin` step writes that same
+ * field, so whenever the pin was ALREADY set to the target before the
+ * roll ran, `prior_pin` came out equal to `pin` — and `rollout
+ * --allow-downgrade` (which defaults its target to the last completed
+ * row's `prior_pin`) resolved a rollback target identical to the version
+ * already deployed. Rollback silently became a no-op. Recorded live on
+ * the operator host on 2026-07-29:
+ *
+ *   {"op":"rollout","result":"completed","pin":"v0.19.32",
+ *    "prior_pin":"v0.19.32"}
+ *
+ * while every agent had actually been running v0.19.30.
+ *
+ * THESE TESTS FAIL ON THAT BUG. The first one puts the config pin at the
+ * TARGET before the roll starts — the exact precondition that produced
+ * the bad row — and asserts `prior_pin` is the RUNNING fleet version.
+ * Under the old config-derived code it read back `v2.0.0` (the target),
+ * which is the failure. It is an outcome assertion on the recorded audit
+ * entry, not a check that some function was called.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { HostdServer } from "../../src/host-control/server.js";
+import type { ServerOptions } from "../../src/host-control/server.js";
+import type { ComponentVersion } from "../../src/cli/component-versions.js";
+
+const TARGET = "v2.0.0";
+/** What the fleet is actually running — the true rollback target. */
+const RUNNING = "v1.9.0";
+
+const AGENT_IMAGE = "ghcr.io/switchroom/switchroom-agent";
+
+function agent(name: string, version: string): ComponentVersion {
+  return {
+    name: `switchroom-${name}`,
+    kind: "container",
+    version,
+    imageRef: `${AGENT_IMAGE}:${version}`,
+  };
+}
+
+/** Every server built here, stopped in afterEach. */
+const started: Array<{ stop(): Promise<void> }> = [];
+afterEach(async () => {
+  while (started.length > 0) await started.pop()!.stop();
+});
+
+interface Launched {
+  entry: Record<string, unknown>;
+}
+
+/**
+ * Launch a roll against a config whose `release.pin` is `configPin`, with
+ * `components` as the running-container inventory, and return the status
+ * entry hostd recorded.
+ *
+ * The child is stubbed out entirely: `prior_pin` is captured BEFORE the
+ * child spawns, so the roll's outcome is irrelevant to what these assert.
+ */
+function launch(
+  configPin: string,
+  components: ComponentVersion[],
+  agents?: string[],
+): Launched {
+  const dir = mkdtempSync(join(tmpdir(), "prior-pin-src-"));
+  const configPath = join(dir, "switchroom.yaml");
+  // A config that genuinely PARSES is load-bearing here, not incidental.
+  // The old derivation read `release.pin` through `loadConfig` inside a
+  // `try {} catch {}`; against an invalid fixture it would throw, swallow,
+  // and yield `undefined` — so these tests would red for the wrong reason
+  // and could not show the actual bug signature (`prior_pin === pin`).
+  writeFileSync(
+    configPath,
+    [
+      "switchroom:",
+      "  version: 1",
+      "telegram:",
+      '  bot_token: "vault:telegram-bot-token"',
+      '  forum_chat_id: "-1001234567890"',
+      "release:",
+      `  pin: ${configPin}`,
+      "agents:",
+      "  clerk:",
+      "    extends: default",
+      "    topic_name: Clerk",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  const server = new HostdServer({
+    homeDir: dir,
+    configPath,
+    agentUids: {},
+    config: { agents: { "test-harness": {}, overlord: { admin: true } } },
+    auditLogPath: join(dir, "audit.log"),
+    selfVersion: "v99.0.0",
+    allowNonLinux: true,
+    fleetComponents: () => components,
+  } as unknown as ServerOptions);
+  started.push(server);
+  const s = server as unknown as {
+    spawnRollout: (args: string[], entry: Record<string, unknown>) => void;
+    launchRollout: (
+      args: { pin: string; agents?: string[] },
+      request_id: string,
+      caller: unknown,
+      started_at: number,
+    ) => Record<string, unknown>;
+  };
+  // Neutralise the child spawn — we are asserting what was captured at
+  // launch, before any child could run.
+  s.spawnRollout = () => {};
+  const entry = s.launchRollout(
+    { pin: TARGET, ...(agents ? { agents } : {}) },
+    "req-prior-pin-src",
+    { kind: "agent", name: "overlord" },
+    Date.now(),
+  );
+  return { entry };
+}
+
+describe("prior_pin is derived from the running fleet, not release.pin", () => {
+  it("records the RUNNING version when the config pin was already the target (the #live-2026-07-29 bug)", () => {
+    // The precondition that produced the bad row: yaml already names the
+    // target, but every agent is still on the older build.
+    const { entry } = launch(TARGET, [agent("clerk", RUNNING), agent("marko", RUNNING)]);
+
+    expect(entry.pin).toBe(TARGET);
+    // The regression: the old derivation returned TARGET here.
+    expect(entry.prior_pin).toBe(RUNNING);
+    expect(entry.prior_pin).not.toBe(entry.pin);
+    expect(entry.prior_pin_source).toBe("running-fleet");
+    // Uniform fleet — nothing extra to disclose.
+    expect(entry.prior_pin_observed).toBeUndefined();
+  });
+
+  it("ignores a config pin that disagrees with the fleet in the other direction too", () => {
+    // Config says something no agent is running. The fleet is still the fact.
+    const { entry } = launch("v0.0.1", [agent("clerk", RUNNING)]);
+    expect(entry.prior_pin).toBe(RUNNING);
+  });
+
+  it("never records the target, even when SOME agents already sit on it", () => {
+    // Mid-roll shapes / a retried roll: the canary already advanced.
+    const { entry } = launch(TARGET, [agent("clerk", TARGET), agent("marko", RUNNING)]);
+    expect(entry.prior_pin).toBe(RUNNING);
+    expect(entry.prior_pin).not.toBe(TARGET);
+    // The fleet was NOT uniform — say so rather than implying it was.
+    expect(entry.prior_pin_observed).toEqual([TARGET, RUNNING]);
+  });
+
+  it("records NO prior_pin when every agent already runs the target", () => {
+    const { entry } = launch(TARGET, [agent("clerk", TARGET), agent("marko", TARGET)]);
+    expect(entry.prior_pin).toBeUndefined();
+    expect(entry.prior_pin_source).toBe("all-on-target");
+    expect(entry.prior_pin_observed).toEqual([TARGET]);
+  });
+
+  it("records NO prior_pin — and never falls back to the config — when the inventory is unreadable", () => {
+    // `docker ps` failed. The old code would have happily used the config
+    // pin here; that fallback IS the defect, so absence is the contract.
+    const { entry } = launch(TARGET, []);
+    expect(entry.prior_pin).toBeUndefined();
+    expect(entry.prior_pin_source).toBe("unobserved");
+  });
+
+  it("honours the --agents subset: an out-of-scope agent's version is not the prior pin", () => {
+    const { entry } = launch(
+      TARGET,
+      [agent("clerk", RUNNING), agent("marko", "v0.5.0")],
+      ["clerk"],
+    );
+    expect(entry.prior_pin).toBe(RUNNING);
+  });
+});


### PR DESCRIPTION
## The defect

`rollout` stamps `prior_pin` on its completed terminal audit row so a later `rollout --allow-downgrade` (with no `--pin`) can default its target to "the last good version" (#2492). The value has exactly one job: name the version the fleet was on **before** the roll.

It was derived from `release.pin` in `switchroom.yaml` — the field the roll's own `persist-pin` step overwrites (`src/host-control/server.ts:2378-2387` on `main`). So whenever the pin was already set to the target before the roll ran, `prior_pin` came out **equal to `pin`**, and rollback silently became a no-op: `--allow-downgrade` resolved a target identical to the version already deployed.

Observed on the operator host (`host-control-audit.log`, 2026-07-29):

```json
{"op":"rollout","result":"completed","pin":"v0.19.32","prior_pin":"v0.19.32"}
```

while every agent had actually been running `v0.19.30`.

## The fix

The defect is the **derivation**, so that is what changes — no journal edit, no operator flag to pass the prior pin by hand.

`prior_pin` now comes from the versions the fleet's agent containers are **actually running** when the roll starts, read through the same enumerative `docker ps` inventory `switchroom update --check`, `doctor`, and the roll's own `verify-components` gate use (`component-versions.ts` / `component-scope.ts`). A declared intent in a config file cannot disagree with the fleet; the fleet is the fact.

Two invariants, in the new `src/host-control/prior-pin.ts`:

1. **`prior_pin` is never the target.** The target is filtered out of the candidate set before a value is chosen, so the no-op-rollback shape is *structurally unreachable* rather than merely unlikely. When every in-scope agent already runs the target there is no prior version, and none is recorded (`prior_pin_source: "all-on-target"`).
2. **A mixed-version fleet is recorded honestly.** The full observed set goes to a new `prior_pin_observed`, and the single value is picked by one documented deterministic rule — the **lowest** observed version, the only choice that is not an *upgrade* for some in-scope agent.

An unreadable inventory records **no** `prior_pin` (`"unobserved"`) rather than falling back to the config, since that fallback is the defect.

## Why the collector is injected, not defaulted

The inventory reader is wired at the daemon's sole composition root (`main.ts`) instead of defaulted inside `HostdServer`. A self-servicing default would make every unit test's `prior_pin` depend on whichever containers the host running the suite happens to have — the same host-vs-container divergence `vitest.config.ts` scrubs env vars to prevent.

That choice has a cost: a dropped injection degrades **silently** (rolls still pass; rollback just quietly loses its target, surfacing only the day someone needs it). So `tests/host-control/hostd-fleet-components-callsite.test.ts` pins the wiring statically — same shape as `singleton-cleanup-callsite.test.ts`. Verified it fails when the `main.ts` line is removed.

## The tests fail on the bug

`tests/host-control/rollout-prior-pin-source.test.ts` sets the config pin to the **target** before the roll — the exact precondition that produced the bad row — and asserts `prior_pin` is the running fleet version. Reverting the derivation to the old config read reds all six with the live signature:

```
× records the RUNNING version when the config pin was already the target
  → expected 'v2.0.0' to be 'v1.9.0'
× records NO prior_pin when every agent already runs the target
  → expected 'v2.0.0' to be undefined
```

The fixture config is deliberately one that genuinely **parses** — against an invalid fixture the old code's `try {} catch {}` would swallow and yield `undefined`, so the test would red for the wrong reason and could not demonstrate the actual `prior_pin === pin` bug.

## Also in this PR

- `audit-reader.ts` parses the two new fields so downstream readers keep them.
- The error-row strip now clears the corroborating fields too, so a failed roll never carries a half-populated prior-pin story.
- The unattended-recovery operator note no longer tells the operator that `release.pin` was the missing source.
- `tests/host-control/auto-rollout.test.ts` now states what its fleet is running. That fixture's intent was always "the fleet is on `v1.0.0` before rolling to `v1.0.1`" — previously implied via `release.pin`; now stated directly. It also makes that suite hermetic.

## Verification

- `npm run lint` — clean (full guard suite, including `check-agent-attribution-trailers`).
- Scoped: `vitest run tests/host-control/ src/host-control/ src/cli/rollout.test.ts` — failing-test set is **identical to pristine `origin/main`** (3 pre-existing env-dependent files: the fake-binary harness `ENOENT`s). New suites: 19/19 + 3/3 green.
- Both new guards proven to fail on the defect they guard.

## Not in scope

The correct rollback target for the affected host is `v0.19.30`; the journal itself is hash-chained and untouched.
