### PR TITLE
fix(hindsight): let reflect see tagged directives, not just untagged

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -127,6 +127,7 @@ jobs:
               - 'tests/docker/hindsight-retry-perturbation-patches.test.ts'
               - 'tests/docker/hindsight-graph-seed-patch.test.ts'
               - 'tests/docker/hindsight-maxitems-grammar-patch.test.ts'
+              - 'tests/docker/hindsight-reflect-directives-patch.test.ts'
               - 'tests/docker/dockerfile-hindsight-bakes.test.ts'
               - '.github/workflows/docker-e2e.yml'
 
@@ -374,10 +375,24 @@ jobs:
           SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
         run: npx vitest run tests/docker/hindsight-maxitems-grammar-patch.test.ts
 
+      - name: Run the hindsight reflect-directives probe (RED/GREEN, must not skip)
+        # Same contract again, for the reflect-directive-isolation patch
+        # (switchroom #3967, upstream vectorize-io/hindsight#1269 / #3031).
+        # The bakes test cannot cover the failure that matters here: its
+        # assertions are unanchored substring matches, so reverting the spliced
+        # value to True — a single token — leaves them green while every tagged
+        # directive is again silently dropped from synthesis (45% of this
+        # fleet's active directives). Only loading real directives out of a real
+        # database with the kwargs reflect actually passes, and reading which
+        # ones reach directives_applied and the system prompt, catches it.
+        env:
+          SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
+        run: npx vitest run tests/docker/hindsight-reflect-directives-patch.test.ts
+
       - name: Label-scoped teardown
         if: always()
         run: |
-          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-graph-seed-patch hindsight-maxitems-grammar-patch; do
+          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-graph-seed-patch hindsight-maxitems-grammar-patch hindsight-reflect-directives-patch; do
             ids=$(docker ps -aq --filter "label=switchroom.test=$phase" 2>/dev/null || true)
             if [ -n "$ids" ]; then docker rm -f $ids 2>/dev/null || true; fi
           done

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -1936,6 +1936,145 @@ print(
 )
 PYEOF
 
+# Let `reflect` see the TAGGED directives too (switchroom #3967, upstream
+# vectorize-io/hindsight#1269 / #3031).
+#
+# THE DEFECT, in the real shipping source. `reflect_async` loads its directives
+# with `isolation_mode=True` (engine/memory_engine.py ~:9390), and
+# `list_directives` turns that flag into a hard filter whenever the caller
+# supplied no tags (~:11655):
+#
+#     if not tags and not tag_groups and isolation_mode:
+#         # Isolation mode: only include directives with empty/null tags
+#         filters.append("(tags IS NULL OR tags = '{}')")
+#
+# So an untagged reflect — the common case, and the only one switchroom's
+# `reflect` tool issues — silently drops every directive that carries at least
+# one tag. It is absent from the system prompt's DIRECTIVES (MANDATORY) section
+# AND from `directives_applied` in the trace, and the engine's own
+# `[REFLECT …] Loaded N directives` line reports the post-filter count as though
+# it were the whole set.
+#
+# Measured on this fleet 2026-07-29: 172 active directives, 94 untagged. 45% of
+# the operator's standing rules never reached a reflect prompt. Per bank
+# (reaching reflect / active): reggie 3/20, test-harness 2/19, gymbro 4/11,
+# overlord 10/22, `default` 0/9.
+#
+# WHY THE FLAG IS WRONG HERE RATHER THAN THE FILTER. `isolation_mode` is a
+# MEMORY-scoping concept — don't let tag-scoped content leak into an untagged
+# operation. Directives have their own documented semantics, stated by upstream
+# in the branch immediately above the one quoted: "Untagged directives always
+# apply regardless of reflect tags; tagged directives only apply when the reflect
+# operation includes matching tags". Under that rule a no-tags reflect has no tag
+# context to leak ACROSS, so the isolation branch only ever subtracts. Fixing it
+# at the call site rather than in `list_directives` keeps the public
+# `GET /directives` behaviour and every other caller byte-for-byte upstream.
+#
+# BLAST RADIUS, by construction: the flag is consulted ONLY inside
+# `if not tags and not tag_groups and isolation_mode`. A tagged reflect never
+# reaches it — its directives are still scoped by the tags/tag_groups branches
+# (untagged OR matching), which this patch does not touch. Only the no-tags path
+# changes, and only by ceasing to subtract.
+#
+# The RECALL side of switchroom already worked around this client-side
+# (vendor/hindsight-memory/scripts/lib/directives.py, recall.py:1918-1949), which
+# is why the same bank's directives read complete on the recall hook and 45%
+# short in reflect. This closes that inconsistency at the source.
+#
+# Self-verifying (exact-once anchor, re-asserted after the splice, `ast.parse` on
+# the result); guarded structurally by
+# tests/docker/dockerfile-hindsight-bakes.test.ts and behaviourally (RED against
+# unpatched upstream / GREEN patched) by
+# tests/docker/hindsight-reflect-directives-patch.test.ts, which loads directives
+# from a REAL database with the kwargs reflect actually passes and asserts which
+# ones reach `directives_applied` and the system prompt.
+RUN python3 - <<'PYEOF'
+import ast
+import pathlib
+
+TAG = "switchroom hindsight reflect-directive-isolation patch"
+f = pathlib.Path("/app/api/hindsight_api/engine/memory_engine.py")
+s = f.read_text()
+
+
+def apply(source, anchor, repl):
+    n = source.count(anchor)
+    assert n == 1, (
+        f"{TAG}: anchor found {n}x (expected 1) in engine/memory_engine.py — upstream "
+        "reformatted reflect's directive fetch; re-author this patch in "
+        f"docker/Dockerfile.hindsight. Anchor head: {anchor.splitlines()[0]!r}"
+    )
+    return source.replace(anchor, repl, 1)
+
+
+# ---- 1. the comment that states the (now inverted) intent ----
+# Left alone it would sit directly above `isolation_mode=False` telling the next
+# maintainer the opposite of what the code does.
+s = apply(
+    s,
+    "        # Use isolation_mode=True to prevent tag-scoped directives from leaking into untagged operations\n",
+    "        # switchroom #3967 / upstream vectorize-io/hindsight#1269, #3031: NOT\n"
+    "        # isolation_mode. It filters this fetch down to `tags IS NULL OR tags = '{}'`\n"
+    "        # whenever the caller supplied no tags, which silently drops EVERY tagged\n"
+    "        # directive from synthesis — 45% of this fleet's active directives, measured\n"
+    "        # 2026-07-29. There is nothing to isolate on a no-tags reflect: directives\n"
+    "        # carry their own scoping rule one branch up in list_directives ('untagged\n"
+    "        # always apply; tagged apply only on a matching reflect'), so with no tag\n"
+    "        # context the isolation branch only ever subtracts.\n",
+)
+
+# ---- 2. the flag itself ----
+s = apply(
+    s,
+    "            active_only=True,\n"
+    "            request_context=request_context,\n"
+    "            isolation_mode=True,\n"
+    "        )\n",
+    "            active_only=True,\n"
+    "            request_context=request_context,\n"
+    "            # switchroom: scoped to THIS call site — every other list_directives\n"
+    "            # caller, including the public GET /directives, keeps upstream behaviour.\n"
+    "            isolation_mode=False,\n"
+    "        )\n",
+)
+
+f.write_text(s)
+ast.parse(s)
+
+t = f.read_text()
+# The premise this patch depends on: `isolation_mode` is only ever consulted on
+# the no-tags path. If upstream ever widens that condition, flipping the flag
+# would start changing TAGGED reflects too — fail the build instead.
+assert "if not tags and not tag_groups and isolation_mode:" in t, (
+    f"{TAG}: the isolation branch in list_directives is no longer gated on "
+    "`not tags and not tag_groups` — flipping the reflect call site would now also "
+    "change TAGGED reflects. Re-author this patch."
+)
+# The patch must have LANDED, not merely applied: no `isolation_mode=True` may
+# survive as an ARGUMENT anywhere in the engine, and the reflect fetch must read
+# False. (The prose in list_directives' own docstring still says
+# `isolation_mode=True`, correctly, and is deliberately not matched here.)
+assert "isolation_mode=True," not in t, (
+    f"{TAG}: an isolation_mode=True argument survived in engine/memory_engine.py — "
+    "the reflect directive fetch still drops tagged directives"
+)
+assert t.count("            isolation_mode=False,\n        )\n") == 1, (
+    f"{TAG}: reflect's directive fetch does not read isolation_mode=False exactly once"
+)
+# The scoping the flag replaces must still exist, or reflect would now load
+# directives that a TAGGED reflect is supposed to exclude.
+assert t.count("f\"((tags IS NULL OR tags = '{{}}') OR ({scoped_clause}))\"") == 2, (
+    f"{TAG}: the untagged-OR-matching tag scoping in list_directives is gone — a "
+    "tagged reflect would no longer be scoped at all. Re-author this patch."
+)
+
+print(
+    "switchroom hindsight reflect-directive-isolation patch: reflect now loads TAGGED "
+    "directives too (isolation_mode=False on its fetch only); a tagged reflect is "
+    "unchanged because the flag is consulted only when no tags are supplied"
+)
+PYEOF
+
 # Perturbed JSON retry: upstream's `except json.JSONDecodeError` handler in
 # `LiteLLMLLM.call()` (litellm_llm.py:50, :216) sleeps and then re-issues the
 # SAME `call_kwargs` — a byte-identical request. Behind a caching LiteLLM

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -993,6 +993,68 @@ describe("Dockerfile.hindsight shape", () => {
     );
   });
 
+  it("keeps the reflect-directive-isolation fix (assert-guarded, fail-loud)", () => {
+    // `reflect_async` loaded its directives with `isolation_mode=True`, and
+    // `list_directives` turns that flag into a hard
+    // `tags IS NULL OR tags = '{}'` filter whenever the caller supplied no
+    // tags — so an untagged reflect (the common case) silently dropped every
+    // directive carrying at least one tag, from the system prompt AND from
+    // `directives_applied` in the trace. Measured on this fleet 2026-07-29:
+    // 172 active directives, 94 untagged; 45% of the operator's standing rules
+    // never reached a reflect prompt. switchroom #3967, upstream
+    // vectorize-io/hindsight#1269 / #3031.
+    //
+    // SCOPE: structural, not behavioural. Every assertion below is an
+    // unanchored substring match, so it proves the patch is PRESENT, never that
+    // it LANDED. The behavioural gate is
+    // tests/docker/hindsight-reflect-directives-patch.test.ts, which loads real
+    // directives out of a real database with the kwargs reflect actually passes
+    // and reads which ones reach the trace and the prompt. Do not treat this
+    // file as sufficient.
+
+    // The exact-once anchor guard (fail-loud on upstream drift), and the
+    // instruction a future maintainer needs when it fires.
+    expect(dockerfile).toMatch(
+      /switchroom hindsight reflect-directive-isolation patch/,
+    );
+    expect(dockerfile).toMatch(
+      /f"\{TAG\}: anchor found \{n\}x \(expected 1\) in engine\/memory_engine\.py — upstream "/,
+    );
+    expect(dockerfile).toMatch(
+      /"reformatted reflect's directive fetch; re-author this patch in "/,
+    );
+    // The splice itself: the flag reflect passes, and the now-inverted upstream
+    // comment that would otherwise sit directly above it.
+    expect(dockerfile).toMatch(/"            isolation_mode=True,\\n"/);
+    expect(dockerfile).toMatch(/"            isolation_mode=False,\\n"/);
+    expect(dockerfile).toMatch(
+      /# Use isolation_mode=True to prevent tag-scoped directives from leaking into untagged operations\\n/,
+    );
+    // The premise that makes the flip NARROW: the flag is consulted only on the
+    // no-tags path. If upstream widens that condition, flipping it would start
+    // changing TAGGED reflects too, and the build must fail rather than ship it.
+    expect(dockerfile).toMatch(
+      /assert "if not tags and not tag_groups and isolation_mode:" in t,/,
+    );
+    // Post-replace re-assertions (verification-on-build): a patch that applied
+    // but landed inert must fail the build.
+    expect(dockerfile).toMatch(/assert "isolation_mode=True," not in t,/);
+    expect(dockerfile).toMatch(
+      /assert t\.count\("            isolation_mode=False,\\n        \)\\n"\) == 1,/,
+    );
+    // The scoping the flag is NOT replacing: a tagged reflect must still be
+    // scoped by the untagged-OR-matching clauses.
+    expect(dockerfile).toMatch(
+      /assert t\.count\("f\\"\(\(tags IS NULL OR tags = '\{\{\}\}'\) OR \(\{scoped_clause\}\)\)\\""\) == 2,/,
+    );
+    // The patched file is re-parsed, so a bad splice fails the build rather
+    // than the container.
+    expect(dockerfile).toMatch(/^ast\.parse\(s\)$/m);
+    expect(dockerfile).toMatch(
+      /switchroom hindsight reflect-directive-isolation patch: reflect now loads TAGGED /,
+    );
+  });
+
   it("preserves upstream's start-all.sh as the post-shim CMD", () => {
     // The shim does broker auth, then `exec "$@"` which is whatever
     // CMD docker passes — must be upstream's start-all.sh so the

--- a/tests/docker/hindsight-reflect-directives-patch.test.ts
+++ b/tests/docker/hindsight-reflect-directives-patch.test.ts
@@ -1,0 +1,540 @@
+/**
+ * Behavioural proof for the reflect-directive-isolation patch
+ * `docker/Dockerfile.hindsight` bakes into the pinned upstream Hindsight image
+ * (switchroom #3967, upstream vectorize-io/hindsight#1269 / #3031).
+ * `dockerfile-hindsight-bakes.test.ts` pins the *shape* of that block
+ * (grep-on-file, runs everywhere). This file proves the *outcome*: it runs the
+ * same probe against unpatched upstream (must be RED) and against upstream +
+ * the patch block applied (must be GREEN).
+ *
+ * THE DEFECT. `reflect_async` loads its directives with `isolation_mode=True`,
+ * and `list_directives` turns that flag into a hard
+ * `tags IS NULL OR tags = '{}'` filter whenever the caller supplied no tags. So
+ * an untagged reflect — the common case, and the only shape switchroom's
+ * `reflect` tool issues — silently drops every directive carrying at least one
+ * tag. Measured on this fleet 2026-07-29: 172 active directives, 94 untagged.
+ * 45% of the operator's standing rules never reached a reflect prompt (reggie
+ * 3 of 20, test-harness 2 of 19, gymbro 4 of 11, overlord 10 of 22, `default`
+ * 0 of 9). Switchroom's RECALL path already worked around this client-side
+ * (`vendor/hindsight-memory/scripts/lib/directives.py`); reflect never got the
+ * equivalent.
+ *
+ * WHY THIS FILE EXISTS SEPARATELY FROM THE BAKES TEST. The bakes assertions are
+ * unanchored substring matches, so a patch that applies and lands INERT keeps
+ * every one of them green. The failure that matters here is a single token:
+ * `isolation_mode=False` reverting to `True`, or upstream widening the
+ * `if not tags and not tag_groups and isolation_mode` condition so the flag
+ * starts binding on tagged reflects too. Only loading real directives out of a
+ * real database and reading which ones come back catches that.
+ *
+ * WHAT IT DRIVES, and what it deliberately does not. The probe runs the REAL
+ * `MemoryEngine.list_directives` against a REAL PostgreSQL (pg0, bundled in the
+ * image, started offline) whose schema comes from the REAL alembic migrations,
+ * with the directives inserted by the REAL `create_directive`. The kwargs it
+ * passes are not hard-coded: they are read out of `reflect_async`'s own AST, so
+ * the probe asks exactly what reflect asks, which is what makes it flip RED/GREEN
+ * with the patch. The rows that come back are then fed to the REAL
+ * `_build_directives_applied()` (the trace field) and the REAL
+ * `build_directives_section()` (the system-prompt block), and the assertions are
+ * on those two outputs — i.e. on which directives actually reach the trace and
+ * the prompt.
+ *
+ * It stops short of an end-to-end `reflect()` call for one reason: that would
+ * need a live LLM, and the probe container runs `--network none`. Everything
+ * between the database and the prompt is real; only the model call is absent,
+ * and no assertion here depends on what a model would have said.
+ *
+ * The patch block is extracted from the Dockerfile itself rather than duplicated
+ * here, so this test cannot drift from what actually ships. It applies it by
+ * `docker exec` (not `docker build`) so it runs on daemons without buildx, and
+ * it never touches the production `switchroom-hindsight` container.
+ *
+ * SKIP DISCIPLINE: identical to `hindsight-recall-isolation-patches.test.ts`.
+ * Locally, with no docker or no cached image, this skips (never pull a 6.4GB
+ * third-party image onto a dev box). In CI the `hindsight-probe` job pulls the
+ * pinned digest and sets SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1, under which an
+ * unavailable docker/image is a HARD FAILURE, never a green skip. Both runs
+ * assert a `PROBE_EXECUTED` sentinel so a probe that dies early can never be
+ * mistaken for a pass.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { execFileSync, execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const dockerfile = readFileSync(
+  resolve(root, "docker/Dockerfile.hindsight"),
+  "utf8"
+);
+
+const RUN_ID = randomUUID();
+const TEST_PHASE = "hindsight-reflect-directives-patch";
+
+/** The pinned upstream image, read from the Dockerfile so it can never drift. */
+const UPSTREAM_IMAGE = (() => {
+  const m = dockerfile.match(/^FROM\s+(\S+)/m);
+  if (!m) throw new Error("Dockerfile.hindsight has no FROM line");
+  return m[1];
+})();
+
+const PATCH_NAME = "reflect-directive-isolation patch";
+
+/**
+ * The patch block under test, pulled out of the Dockerfile's
+ * `RUN python3 - <<'PYEOF' ... PYEOF` heredocs by its unique patch name.
+ */
+function patchBlock(): string {
+  const blocks = [
+    ...dockerfile.matchAll(/^RUN python3 - <<'PYEOF'\n([\s\S]*?)^PYEOF$/gm),
+  ].map((m) => m[1]);
+  const matches = blocks.filter((b) => b.includes(PATCH_NAME));
+  if (matches.length !== 1) {
+    throw new Error(
+      `Dockerfile.hindsight contains ${matches.length} RUN blocks mentioning ` +
+        `"${PATCH_NAME}" (expected exactly 1) — if it was deliberately removed, ` +
+        `delete this test with it.`
+    );
+  }
+  return matches[0];
+}
+
+/**
+ * Python probe. Exits 0 only when a no-tags reflect loads BOTH directives and
+ * both reach the trace and the system prompt, AND tag scoping is untouched;
+ * prints the offending assertions otherwise.
+ */
+const PROBE = String.raw`
+import ast
+import asyncio
+import inspect
+import os
+import textwrap
+import uuid
+
+failures = []
+
+
+def fail(msg):
+    failures.append(msg)
+
+
+DB_URL = "postgresql://postgres:postgres@127.0.0.1:5432/postgres"
+os.environ["HINDSIGHT_API_DATABASE_URL"] = DB_URL
+# No LLM is ever called: the probe stops at the prompt, not at synthesis. These
+# exist only so MemoryEngine can be constructed with --network none.
+os.environ.setdefault("HINDSIGHT_API_LLM_PROVIDER", "openai")
+os.environ.setdefault("HINDSIGHT_API_LLM_API_KEY", "unused-no-llm-call-in-this-probe")
+os.environ.setdefault("HINDSIGHT_API_LLM_MODEL", "unused-no-llm-call-in-this-probe")
+
+from hindsight_api.engine.embeddings import Embeddings
+from hindsight_api.engine.memory_engine import MemoryEngine
+from hindsight_api.engine.reflect.agent import _build_directives_applied
+from hindsight_api.engine.reflect.prompts import build_directives_section
+from hindsight_api.models import RequestContext
+
+# =====================================================================
+# What reflect ACTUALLY passes to list_directives, read out of the shipping
+# source. Nothing below hard-codes the flag: the probe drives the real query
+# with whatever reflect_async really asks for, which is what makes it RED on
+# unpatched upstream and GREEN once patched.
+# =====================================================================
+tree = ast.parse(textwrap.dedent(inspect.getsource(MemoryEngine.reflect_async)))
+calls = [
+    n
+    for n in ast.walk(tree)
+    if isinstance(n, ast.Call)
+    and isinstance(n.func, ast.Attribute)
+    and n.func.attr == "list_directives"
+]
+if len(calls) != 1:
+    fail(
+        f"expected exactly 1 list_directives call in reflect_async, found {len(calls)} "
+        "- re-author the patch and this probe together"
+    )
+    print("PROBE_EXECUTED")
+    print("FAILURES", failures)
+    raise SystemExit(1)
+
+call = calls[0]
+kwarg_names = [kw.arg for kw in call.keywords]
+print("REFLECT_DIRECTIVE_KWARGS", kwarg_names)
+
+iso = [kw.value for kw in call.keywords if kw.arg == "isolation_mode"]
+if len(iso) != 1 or not isinstance(iso[0], ast.Constant) or not isinstance(iso[0].value, bool):
+    fail("reflect_async no longer passes a literal bool isolation_mode to list_directives")
+    print("PROBE_EXECUTED")
+    print("FAILURES", failures)
+    raise SystemExit(1)
+REFLECT_ISOLATION_MODE = iso[0].value
+print("REFLECT_ISOLATION_MODE", REFLECT_ISOLATION_MODE)
+
+# reflect forwards its own tag scoping through. If that stops being true, the
+# blast-radius assertions below stop meaning what they say.
+for expected in ("tags", "tags_match", "tag_groups", "active_only"):
+    if expected not in kwarg_names:
+        fail(f"reflect_async no longer forwards {expected} to list_directives")
+
+
+class ProbeEmbeddings(Embeddings):
+    """Deterministic stand-in. Directive loading never embeds anything; this
+    exists only so MemoryEngine can be constructed offline."""
+
+    @property
+    def provider_name(self):
+        return "switchroom-probe"
+
+    @property
+    def dimension(self):
+        return 8
+
+    async def initialize(self):
+        return None
+
+    def encode(self, texts):
+        return [[0.0] * 8 for _ in texts]
+
+
+UNTAGGED = ("switchroom-probe-untagged", "Always answer in English.")
+TAGGED = ("switchroom-probe-tagged", "End every response with [VERIFIED].")
+BOTH = sorted([UNTAGGED[0], TAGGED[0]])
+
+
+async def main():
+    from hindsight_api.migrations import run_migrations
+
+    # Real schema, from the image's own alembic revisions.
+    run_migrations(DB_URL, "/app/api/hindsight_api/alembic")
+
+    engine = MemoryEngine(
+        embeddings=ProbeEmbeddings(),
+        cross_encoder=None,
+        run_migrations=False,
+        skip_llm_verification=True,
+    )
+    await engine.initialize()
+    rc = RequestContext()
+    bank = "switchroom-reflect-directives-" + uuid.uuid4().hex[:8]
+    await engine._ensure_bank_exists(bank, request_context=rc)
+
+    # One untagged and one tagged directive, both ACTIVE. Inserted through the
+    # real write path so their stored shape is whatever upstream stores.
+    await engine.create_directive(bank, UNTAGGED[0], UNTAGGED[1], request_context=rc)
+    await engine.create_directive(bank, TAGGED[0], TAGGED[1], tags=["scoped"], request_context=rc)
+
+    async def load(tags):
+        """reflect's directive fetch, verbatim: the same kwargs reflect_async
+        passes, including the isolation_mode it actually ships with."""
+        return await engine.list_directives(
+            bank,
+            tags=tags,
+            tags_match="any",
+            tag_groups=None,
+            active_only=True,
+            request_context=rc,
+            isolation_mode=REFLECT_ISOLATION_MODE,
+        )
+
+    # ---- the defect: an UNTAGGED reflect (the common case) ----
+    loaded = await load(None)
+    names = sorted(d["name"] for d in loaded)
+    print("UNTAGGED_REFLECT_LOADED", names)
+    if names != BOTH:
+        fail(
+            f"an untagged reflect loaded {len(loaded)} of 2 active directives {names} "
+            "- a directive with any tag is silently dropped from synthesis "
+            "(vectorize-io/hindsight#1269)"
+        )
+
+    # ---- the outcome that matters: the trace field and the system prompt ----
+    applied = _build_directives_applied(loaded)
+    applied_names = sorted(d.name for d in applied)
+    print("DIRECTIVES_APPLIED", applied_names)
+    if applied_names != BOTH:
+        fail(
+            f"reflect's directives_applied trace carries {len(applied)} directive(s) "
+            f"{applied_names}; '{TAGGED[0]}' never reached it"
+        )
+
+    section = build_directives_section(loaded)
+    in_prompt = sorted(n for n, c in (UNTAGGED, TAGGED) if c in section)
+    print("PROMPT_DIRECTIVE_TEXTS", in_prompt)
+    if in_prompt != BOTH:
+        fail(
+            "the reflect system prompt's DIRECTIVES (MANDATORY) section carries "
+            f"{in_prompt} - the model is never shown the dropped rule"
+        )
+
+    # ---- blast radius: a TAGGED reflect must be unchanged either way ----
+    # The flag is only consulted inside "if not tags and not tag_groups and
+    # isolation_mode", so these two lines read identically patched and unpatched.
+    # They are what proves the patch narrow rather than merely effective.
+    matching = sorted(d["name"] for d in await load(["scoped"]))
+    print("MATCHING_TAG_REFLECT_LOADED", matching)
+    if matching != BOTH:
+        fail(
+            f"a reflect tagged ['scoped'] loaded {matching}, expected both the untagged "
+            "directive and the matching tagged one"
+        )
+
+    other = sorted(d["name"] for d in await load(["unrelated"]))
+    print("OTHER_TAG_REFLECT_LOADED", other)
+    if other != [UNTAGGED[0]]:
+        fail(
+            f"a reflect tagged ['unrelated'] loaded {other} - tag scoping must be "
+            "untouched by this patch; only the NO-tags path changes"
+        )
+
+    await engine.close()
+
+
+asyncio.run(main())
+print("PROBE_EXECUTED")
+print("FAILURES", failures)
+raise SystemExit(1 if failures else 0)
+`;
+
+function hasDocker(): boolean {
+  try {
+    execSync("docker version --format '{{.Server.Version}}'", {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasImage(ref: string): boolean {
+  try {
+    execSync(`docker image inspect ${ref}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * CI marker. When set, this suite MUST really execute — an absent docker or
+ * an absent upstream image becomes a hard failure instead of a green skip.
+ * `.github/workflows/docker-e2e.yml` sets it after pulling the pinned digest.
+ */
+const REQUIRED = process.env.SWITCHROOM_REQUIRE_HINDSIGHT_PROBE === "1";
+
+const dockerOk = hasDocker();
+const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
+
+/** Path to the bundled embedded-postgres binary inside the image. */
+const PG0 =
+  "/app/api/.venv/lib/python3.11/site-packages/pg0/bin/pg0";
+
+type ProbeResult = { status: number; stdout: string };
+
+/** Run the probe in a throwaway container, optionally patching first. */
+function runProbe(patched: boolean): ProbeResult {
+  const name = `sr-hs-refdir-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
+    0,
+    8
+  )}`;
+  try {
+    execFileSync(
+      "docker",
+      [
+        "run",
+        "-d",
+        "--name",
+        name,
+        "--label",
+        `switchroom.test=${TEST_PHASE}`,
+        "--label",
+        `switchroom.test.run=${RUN_ID}`,
+        "--user",
+        "root",
+        "--network",
+        "none",
+        UPSTREAM_IMAGE,
+        "sleep",
+        "600",
+      ],
+      { stdio: ["ignore", "ignore", "pipe"] }
+    );
+
+    if (patched) {
+      // The block is self-verifying: it asserts its upstream anchors exist
+      // exactly once and re-asserts the result, so a non-zero exit here means
+      // upstream drifted and the patch must be re-authored.
+      execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
+        input: patchBlock(),
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    }
+
+    // A real database, bundled in the image and started offline. postgres
+    // refuses to run as root, so this and the probe run as `hindsight`.
+    execFileSync(
+      "docker",
+      ["exec", "-u", "hindsight", "-e", "HOME=/home/hindsight", name, PG0, "start"],
+      { stdio: ["ignore", "pipe", "pipe"] }
+    );
+
+    const res = execFileSync(
+      "docker",
+      [
+        "exec",
+        "-i",
+        "-u",
+        "hindsight",
+        "-e",
+        "HOME=/home/hindsight",
+        "-w",
+        "/app/api",
+        name,
+        "/app/api/.venv/bin/python",
+        "-",
+      ],
+      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" }
+    );
+    return { status: 0, stdout: res };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: Buffer | string };
+    return {
+      status: err.status ?? -1,
+      stdout: (err.stdout ?? "").toString(),
+    };
+  } finally {
+    try {
+      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+describe("Dockerfile.hindsight reflect-directives probe is real, not a silent skip", () => {
+  it("pins the upstream image by digest so the probe tests the exact shipping bytes", () => {
+    expect(UPSTREAM_IMAGE).toMatch(/@sha256:[0-9a-f]{64}$/);
+  });
+
+  it("extracts exactly the one patch block it claims to prove", () => {
+    expect(patchBlock()).toContain(PATCH_NAME);
+  });
+
+  it("hard-fails rather than skipping when CI demands a real run", () => {
+    if (!REQUIRED) {
+      // Local/dev path: skipping is legitimate (never pull a 6.4GB image onto
+      // a dev box), but it must be visible rather than silent.
+      expect(
+        REQUIRED,
+        "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE is unset — the behavioural probe " +
+          "is advisory here. CI's hindsight-probe job sets it after pulling " +
+          `${UPSTREAM_IMAGE}.`
+      ).toBe(false);
+      return;
+    }
+    expect(
+      dockerOk,
+      "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but the docker daemon is unreachable"
+    ).toBe(true);
+    expect(
+      imageOk,
+      `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but ${UPSTREAM_IMAGE} is not present ` +
+        "locally — the workflow must pull the pinned digest before running this suite"
+    ).toBe(true);
+  });
+});
+
+describe.skipIf(!dockerOk || !imageOk)(
+  "Dockerfile.hindsight reflect-directive-isolation patch changes real behaviour",
+  () => {
+    afterAll(() => {
+      // Label-scoped teardown belt (never an unlabelled bulk removal).
+      try {
+        const ids = execSync(
+          `docker ps -aq --filter label=switchroom.test.run=${RUN_ID}`,
+          { encoding: "utf8" }
+        )
+          .split("\n")
+          .filter(Boolean);
+        if (ids.length) {
+          execFileSync("docker", ["rm", "-f", ...ids], { stdio: "ignore" });
+        }
+      } catch {
+        /* nothing to clean */
+      }
+    });
+
+    it("unpatched upstream is RED: a tagged directive never reaches reflect", () => {
+      const { status, stdout } = runProbe(false);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED"
+      );
+      expect(status, `probe unexpectedly passed:\n${stdout}`).not.toBe(0);
+
+      // The call site, as it ships.
+      expect(stdout).toContain("REFLECT_ISOLATION_MODE True");
+      // The defect, driven against a real database: 1 of 2 active directives.
+      expect(stdout).toContain(
+        "UNTAGGED_REFLECT_LOADED ['switchroom-probe-untagged']"
+      );
+      // …and therefore absent from BOTH observable surfaces.
+      expect(stdout).toContain(
+        "DIRECTIVES_APPLIED ['switchroom-probe-untagged']"
+      );
+      expect(stdout).toContain(
+        "PROMPT_DIRECTIVE_TEXTS ['switchroom-probe-untagged']"
+      );
+      expect(stdout).toContain(
+        "a directive with any tag is silently dropped from synthesis"
+      );
+      // The tagged paths already behave correctly upstream — the patch must not
+      // be credited with fixing them, and must not break them.
+      expect(stdout).toContain(
+        "MATCHING_TAG_REFLECT_LOADED ['switchroom-probe-tagged', 'switchroom-probe-untagged']"
+      );
+      expect(stdout).toContain(
+        "OTHER_TAG_REFLECT_LOADED ['switchroom-probe-untagged']"
+      );
+    }, 300_000);
+
+    it("upstream + the baked patch block is GREEN, and tag scoping is untouched", () => {
+      const { status, stdout } = runProbe(true);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED"
+      );
+      expect(status, `probe failed:\n${stdout}`).toBe(0);
+      expect(stdout).toContain("FAILURES []");
+
+      // The flag reflect actually passes, after the patch.
+      expect(stdout).toContain("REFLECT_ISOLATION_MODE False");
+      // The fix: an untagged reflect now loads BOTH active directives …
+      expect(stdout).toContain(
+        "UNTAGGED_REFLECT_LOADED ['switchroom-probe-tagged', 'switchroom-probe-untagged']"
+      );
+      // … and both reach the trace field and the system prompt, which is the
+      // outcome the whole patch exists for.
+      expect(stdout).toContain(
+        "DIRECTIVES_APPLIED ['switchroom-probe-tagged', 'switchroom-probe-untagged']"
+      );
+      expect(stdout).toContain(
+        "PROMPT_DIRECTIVE_TEXTS ['switchroom-probe-tagged', 'switchroom-probe-untagged']"
+      );
+      // Blast radius: byte-identical to the unpatched run on both tagged paths.
+      // A patch that also widened tagged reflect would go red here.
+      expect(stdout).toContain(
+        "MATCHING_TAG_REFLECT_LOADED ['switchroom-probe-tagged', 'switchroom-probe-untagged']"
+      );
+      expect(stdout).toContain(
+        "OTHER_TAG_REFLECT_LOADED ['switchroom-probe-untagged']"
+      );
+      // reflect still forwards its own scoping — the patch changes the flag and
+      // nothing else about the call.
+      expect(stdout).toContain(
+        "REFLECT_DIRECTIVE_KWARGS ['bank_id', 'tags', 'tags_match', 'tag_groups', " +
+          "'active_only', 'request_context', 'isolation_mode']"
+      );
+    }, 300_000);
+  }
+);


### PR DESCRIPTION
## Summary

`reflect_async` loads its directives with `isolation_mode=True`, and `list_directives` turns that flag into a hard `tags IS NULL OR tags = '{}'` filter whenever the caller supplied no tags. So an untagged reflect — the common case, and the only shape switchroom's `reflect` tool issues — silently drops every directive carrying at least one tag, both from the system prompt and from `directives_applied` in the trace.

This adds one more self-verifying patch block to `docker/Dockerfile.hindsight` that flips the flag to `False` **on reflect's directive fetch only**.

## Why

Measured on the fleet 2026-07-29: 172 active directives, 94 untagged. 45% of the operator's standing rules never reached a reflect prompt (reggie 3 of 20, test-harness 2 of 19, gymbro 4 of 11, overlord 10 of 22, `default` 0 of 9), confirmed from the engine's own `[REFLECT …] Loaded N directives` line.

The recall path already works around this client-side (`vendor/hindsight-memory/scripts/lib/directives.py`, `recall.py:1918-1949`), citing upstream vectorize-io/hindsight#1269. Reflect never got the equivalent, so the same bank's directives read complete on the recall hook and 45% short in reflect. This PR closes that inconsistency at the source.

Blast radius is narrow by construction: the flag is consulted only inside `if not tags and not tag_groups and isolation_mode`, so a tagged reflect is unchanged and every other `list_directives` caller — including the public `GET /directives` — stays byte-for-byte upstream. The patch re-asserts that premise after the splice and fails the image build if upstream ever widens the condition.

Refs #3967, vectorize-io/hindsight#3031 (refiling the withdrawn #1269).

Job spec: `reference/jobs/remember-across-sessions.md` — a standing rule the operator set has to actually reach the model that answers.

## Test plan

- **`tests/docker/hindsight-reflect-directives-patch.test.ts`** (new, behavioural RED/GREEN): boots the bundled pg0 postgres inside the digest-pinned upstream image under `--network none`, runs the real alembic migrations, inserts one untagged + one tagged active directive through the real `create_directive`, then loads them with the kwargs **read out of `reflect_async`'s own AST** (nothing hard-codes the flag) and feeds the result to the real `_build_directives_applied()` (= the `directives_applied` trace field) and `build_directives_section()` (= the prompt block). Asserts which directives actually reach the trace and the prompt.
  - Unpatched upstream: **RED** — `UNTAGGED_REFLECT_LOADED ['switchroom-probe-untagged']`, exit 1.
  - Upstream + the baked block: **GREEN** — both, exit 0.
  - Both tagged-reflect assertions are identical across the two runs, which is what proves the change narrow rather than merely effective.
  - Only the LLM call itself is absent (the container is offline by design); no assertion depends on it. Documented in the file header.
- **`tests/docker/dockerfile-hindsight-bakes.test.ts`**: pins the new block's shape, its anchors, its assert text and its receipt (structural; explicitly noted as not sufficient on its own).
- **`.github/workflows/docker-e2e.yml`**: probe wired into `hindsight-probe` — path filter, its own step with `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1` (an unreachable docker is a hard failure, not a skip), and the phase added to the label-scoped teardown.

Local: `vitest` 5 passed / 31 passed / 55 passed on the touched suites, `npm run lint` clean.

## Risk

Low. Behaviour changes for exactly one call site, and only on the no-tags path. The failure mode if upstream reformats is a **loud image build failure** with re-authoring instructions, not a silent no-op.

## Notes for the reviewer (two contradictions with the filed plan)

1. The plan's line coordinates were stale. The reflect call site is `api/hindsight_api/engine/memory_engine.py:9386-9396` in `reflect_async` (12-space indent), not `memory_engine.py:9456-9466`; the filter is at ~11655, not 11725-11728. The patch anchors on text, not lines.
2. Upstream #1269 is **closed as completed** — withdrawn by us ("Closing — withdrawing on our side. Please disregard."), never actually fixed; the defect is still present in v0.8.5. Refiled with fresh evidence as vectorize-io/hindsight#3031.
