### PR TITLE
perf(hindsight): raise container cap to 16g and resize the pg buffer pool with it

### DIFF
--- a/src/setup/hindsight-pg-defaults.ts
+++ b/src/setup/hindsight-pg-defaults.ts
@@ -82,7 +82,7 @@
  *
  * @see import("./hindsight.js").HINDSIGHT_DEFAULT_MEM_LIMIT
  */
-export const HINDSIGHT_PG_MEM_LIMIT_MIB_FOR_DERIVATION = 8 * 1024;
+export const HINDSIGHT_PG_MEM_LIMIT_MIB_FOR_DERIVATION = 16 * 1024;
 
 /**
  * Non-reclaimable anonymous working set of everything ELSE in the container,
@@ -112,7 +112,11 @@ export const HINDSIGHT_PG_PAGE_CACHE_FLOOR_MIB = 2048;
  *
  * Derived, not picked: whatever is left of the memory ceiling once the app's
  * anonymous working set and the page-cache floor are accounted for.
- * 8192 − 2560 − 2048 = 3584 MiB.
+ * 16384 − 2560 − 2048 = 11776 MiB.
+ *
+ * This is a CEILING, not a target. It is what the arithmetic permits; what
+ * {@link HINDSIGHT_PG_DEFAULT_SHARED_BUFFERS_MIB} actually takes is bounded
+ * far below it by the worst-case per-backend memory model, not by this number.
  */
 export const HINDSIGHT_PG_SHARED_BUFFERS_BUDGET_MIB =
   HINDSIGHT_PG_MEM_LIMIT_MIB_FOR_DERIVATION -
@@ -125,10 +129,25 @@ export const HINDSIGHT_PG_SHARED_BUFFERS_BUDGET_MIB =
  * 256MB against a 12 GB database is ~2% of the bank — every graph traversal
  * that misses is a kernel round-trip, which is exactly the bimodal
  * cold/hot distribution measured on `link_expansion` (p50 24ms, p90 1.412s).
- * 1536MB is 6x that, and 19% of the container's 8 GiB ceiling — under the
- * conventional "25% of available memory" guidance and comfortably inside
- * {@link HINDSIGHT_PG_SHARED_BUFFERS_BUDGET_MIB} (3584 MiB), which a test
- * pins.
+ * 1536MB was 6x that, and 19% of the container's original 8 GiB ceiling.
+ *
+ * 1536→3072 (2026-07-29), moved in the SAME commit that raised
+ * `HINDSIGHT_DEFAULT_MEM_LIMIT` 8g→16g, because these two are one decision:
+ * a bigger cap that leaves the buffer pool where it was just buys more page
+ * cache for data Postgres should have been holding itself. 3072 MiB is 19% of
+ * the new 16 GiB ceiling — the same fraction, deliberately, so the sizing
+ * stays inside the conventional "25% of available memory" guidance and well
+ * inside {@link HINDSIGHT_PG_SHARED_BUFFERS_BUDGET_MIB} (11776 MiB), which a
+ * test pins.
+ *
+ * **Why 3072 and not 4096**, which the budget ceiling would now permit: the
+ * budget arithmetic only accounts for the buffer pool itself. The per-backend
+ * side is not in it — `work_mem` is applied live per role,
+ * `hash_mem_multiplier=2` doubles it for hash nodes, and a parallel plan
+ * multiplies that again across workers. Stacking a 4 GiB pinned pool on top of
+ * that worst case does not fit under a 16 GiB cap alongside the ~2.5 GiB app
+ * anon set and the page-cache floor. 3072 leaves the pool a real 2x increase
+ * with the tail still covered.
  *
  * **This does NOT require an `shm_size` change**, contrary to the assumption
  * this work started from. That assumption is that `shared_buffers` is a POSIX
@@ -139,7 +158,7 @@ export const HINDSIGHT_PG_SHARED_BUFFERS_BUDGET_MIB =
  * `HINDSIGHT_DEFAULT_SHM_SIZE` was raised for (observed peak ~533MB), so 2g
  * stays correct and is deliberately left alone.
  */
-export const HINDSIGHT_PG_DEFAULT_SHARED_BUFFERS_MIB = 1536;
+export const HINDSIGHT_PG_DEFAULT_SHARED_BUFFERS_MIB = 3072;
 
 /**
  * `effective_cache_size` (pg0 default `1GB`).
@@ -151,16 +170,23 @@ export const HINDSIGHT_PG_DEFAULT_SHARED_BUFFERS_MIB = 1536;
  *
  * 1GB is a ~5x under-declaration of what this container measurably holds: the
  * live cgroup was carrying 5212 MiB of page cache on top of the 256MB buffer
- * pool. 4096 MiB is the conservative reading of that — `shared_buffers`
- * (1536) plus a page-cache assumption (2560) well below the 5212 measured —
- * so the planner is told the truth without being told to expect cache the
- * container cannot hold under pressure.
+ * pool. 4096 MiB was the conservative reading of that under the 8 GiB cap.
+ *
+ * 4096→7168 (2026-07-29), moved with the cap and the buffer pool. Sized to
+ * what the container can actually hold AFTER this change, not to the size of
+ * the database: `shared_buffers` (3072) plus a page-cache assumption of 4096,
+ * against a 16 GiB ceiling that still has to carry the ~2.5 GiB app anon set.
+ * The temptation is to declare something near the 12 GB bank size so the
+ * planner "knows" the data is cacheable — don't. `effective_cache_size` is
+ * the term that prices index scans against sequential ones, so over-declaring
+ * it does not make the container hold more, it flips plan shapes on the
+ * strength of cache that does not exist under pressure.
  *
  * Honest scope: see the module header. On the link-expansion query this moved
  * total cost ~12% at 300 seeds and changed no plan shape. It is the cheap,
  * zero-memory half of the change, not the whole fix.
  */
-export const HINDSIGHT_PG_DEFAULT_EFFECTIVE_CACHE_SIZE_MIB = 4096;
+export const HINDSIGHT_PG_DEFAULT_EFFECTIVE_CACHE_SIZE_MIB = 7168;
 
 /** Format a MiB integer the way Postgres wants it on the command line. */
 export function pgMib(mib: number): string {

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -829,7 +829,30 @@ export { HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM } from "./hindsight-per
 // ~600m of headroom under the old 4g cap, and the consolidation-throughput
 // bump above (LLM_PARALLELISM 4→6 = more in-flight synthesis) pushes it
 // higher. 8g gives comfortable headroom on the 60g host. Reservation 2g→4g.
-export const HINDSIGHT_DEFAULT_MEM_LIMIT = "8g";
+//
+// 8g→16g (2026-07-29): the 8g cap stopped being headroom and became a
+// treadmill. Live cgroup on `switchroom-hindsight`: `memory.current` pinned
+// at 99.5% of the 8 GiB ceiling with ~2.2 GiB of that anon (the API process,
+// the embedder, the cross-encoder, next-server) — leaving the working set of
+// a ~12 GB bank to fight over the remainder as reclaimable page cache. The
+// symptom is not an OOM kill, it is churn: ~24.5 GB/hour re-read from disk
+// and 7,400+ reclaim events, i.e. the container is paying disk latency to
+// hold a set it very nearly fits. 16g on the 60g host buys the page cache
+// room to stop thrashing, and `shared_buffers` moves WITH it in the same
+// commit (hindsight-pg-defaults.ts) so the cap and the buffer pool can never
+// drift — `hindsight-pg-defaults.test.ts` pins them equal.
+//
+// **`--memory-swap` is deliberately NOT emitted, on either launch path.**
+// When it is omitted Docker sets MemorySwap = 2 × Memory, so the container
+// keeps a swap cushion equal to its RAM cap (live: Memory=8g/MemorySwap=16g,
+// with ~900 MiB actually in swap — which is why 7,400 reclaim events have
+// produced zero OOM kills). Setting `--memory-swap` EQUAL to `--memory`
+// disables swap entirely; doing that in the same change that pins ~1.5 GiB
+// more unreclaimable shared memory converts graceful degradation into a hard
+// OOM kill that takes memory down for the whole fleet. Never emit a
+// memory-swap equal to the memory limit — `tests/setup/hindsight.test.ts`
+// asserts the invariant on BOTH the run-args and compose paths.
+export const HINDSIGHT_DEFAULT_MEM_LIMIT = "16g";
 export const HINDSIGHT_DEFAULT_MEM_RESERVATION = "4g";
 export const HINDSIGHT_DEFAULT_PIDS_LIMIT = 1000;
 
@@ -843,7 +866,7 @@ export const HINDSIGHT_DEFAULT_PIDS_LIMIT = 1000;
  * segment ... No space left on device` and ALL memory writes/queries die
  * (2026-06-06 fleet outage). 2g gives comfortable headroom over the
  * observed peak while staying well under `HINDSIGHT_DEFAULT_MEM_LIMIT`
- * (8g) so shm can't starve the app. Applies to BOTH the standalone
+ * (16g) so shm can't starve the app. Applies to BOTH the standalone
  * `docker run` path and the compose snippet below — keep them in sync.
  */
 export const HINDSIGHT_DEFAULT_SHM_SIZE = "2g";

--- a/tests/setup/hindsight.test.ts
+++ b/tests/setup/hindsight.test.ts
@@ -676,18 +676,106 @@ describe("hindsight broker-fed mode (#1245)", () => {
     expect(h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND).toBeLessThanOrEqual(1000);
   });
 
-  it("raises the memory limit to give the throughput bump headroom (8g, was 4g)", async () => {
+  it("raises the memory limit to give the throughput bump headroom (16g, was 8g)", async () => {
     const h = await import("../../src/setup/hindsight.js");
     // Baseline RSS ~3.4g; 4g was tight, and more in-flight consolidation
-    // raises it. Both emit paths must carry the bumped limit.
+    // raises it. 8g then went to 16g when the live cgroup sat at 99.5% of the
+    // ceiling re-reading ~24.5 GB/hour of evicted page cache. Both emit paths
+    // must carry the bumped limit.
     const m = /^(\d+)g$/.exec(h.HINDSIGHT_DEFAULT_MEM_LIMIT);
     expect(m, "mem limit should be N gigabytes").not.toBeNull();
-    expect(Number(m![1])).toBeGreaterThanOrEqual(8);
+    expect(Number(m![1])).toBeGreaterThanOrEqual(16);
     startHindsight({ apiPort: 8888, uiPort: 9999 });
     expect(findRunArgs()).toContain(`--memory=${h.HINDSIGHT_DEFAULT_MEM_LIMIT}`);
     expect(h.generateHindsightComposeSnippet()).toMatch(
       new RegExp(`mem_limit:\\s*${h.HINDSIGHT_DEFAULT_MEM_LIMIT}\\b`),
     );
+  });
+
+  // ── the swap cushion ───────────────────────────────────────────────────
+  //
+  // Docker's rule: when `--memory-swap` is OMITTED it defaults to 2 × memory,
+  // so the container gets a swap cushion the size of its RAM cap. Setting it
+  // EQUAL to `--memory` means "no swap at all". Those two look like the same
+  // kind of tidying edit and are opposites.
+  //
+  // On the live container that cushion is load-bearing, not theoretical:
+  // Memory=8g / MemorySwap=16g with ~900 MiB actually resident in swap, and
+  // 7,400+ reclaim events with ZERO OOM kills. Zeroing it in the same change
+  // that pins ~1.5 GiB more unreclaimable shared memory turns a slow
+  // degradation into a hard kill of the memory backend for the whole fleet.
+  //
+  // So the invariant is: emit no swap flag at all (inherit 2x), or emit one
+  // that is STRICTLY GREATER than the memory limit. Never equal, never less.
+  // Asserted on BOTH launch paths, because compose is what actually creates
+  // the container on a fleet host.
+  it("never emits a memory-swap equal to (or below) the memory limit — the OOM cushion", async () => {
+    const h = await import("../../src/setup/hindsight.js");
+
+    /** Docker size string (`16g`, `512m`, `2G`, `1024`) → MiB. */
+    const toMib = (size: string): number => {
+      const m = /^(\d+(?:\.\d+)?)\s*([kmgKMG])?[bB]?$/.exec(size.trim());
+      expect(m, `unparseable docker size: ${size}`).not.toBeNull();
+      const n = Number(m![1]);
+      switch ((m![2] ?? "m").toLowerCase()) {
+        case "k":
+          return n / 1024;
+        case "g":
+          return n * 1024;
+        default:
+          return n;
+      }
+    };
+
+    /**
+     * Pull `--memory` / `--memory-swap` out of a docker-run argv, accepting
+     * both the single-token (`--memory=16g`) and split (`--memory 16g`) forms
+     * so the assertion cannot be dodged by a formatting change.
+     */
+    const runFlag = (args: string[], flag: string): string | null => {
+      for (let i = 0; i < args.length; i++) {
+        const a = args[i];
+        if (a === flag) return (args[i + 1] as string) ?? null;
+        if (a.startsWith(`${flag}=`)) return a.slice(flag.length + 1);
+      }
+      return null;
+    };
+
+    startHindsight({ apiPort: 8888, uiPort: 9999 });
+    const args = findRunArgs();
+
+    const runMemory = runFlag(args, "--memory");
+    expect(runMemory, "docker run must cap memory").not.toBeNull();
+    const runSwap = runFlag(args, "--memory-swap");
+    if (runSwap !== null) {
+      expect(
+        toMib(runSwap),
+        `--memory-swap=${runSwap} must be STRICTLY greater than --memory=${runMemory}; ` +
+          "equal disables swap and removes the cushion that has kept this " +
+          "container OOM-free through 7,400+ reclaim events",
+      ).toBeGreaterThan(toMib(runMemory!));
+    }
+
+    // Compose twin. `memswap_limit` is compose's spelling of --memory-swap;
+    // omitted, the daemon applies the same 2x default.
+    const snippet = h.generateHindsightComposeSnippet();
+    const memLine = /^\s*mem_limit:\s*(\S+)\s*$/m.exec(snippet);
+    expect(memLine, "compose snippet must carry mem_limit").not.toBeNull();
+    const swapLine = /^\s*memswap_limit:\s*(\S+)\s*$/m.exec(snippet);
+    if (swapLine) {
+      expect(
+        toMib(swapLine[1]),
+        `memswap_limit: ${swapLine[1]} must be STRICTLY greater than ` +
+          `mem_limit: ${memLine![1]} — equal disables swap entirely`,
+      ).toBeGreaterThan(toMib(memLine![1]));
+    }
+
+    // Guard the guard: if BOTH paths silently stopped emitting a memory cap,
+    // every branch above would be vacuous. Pin that the caps are still there
+    // and that the two paths agree, so this test can never pass by emitting
+    // nothing at all.
+    expect(runMemory).toBe(h.HINDSIGHT_DEFAULT_MEM_LIMIT);
+    expect(memLine![1]).toBe(h.HINDSIGHT_DEFAULT_MEM_LIMIT);
   });
 
   it("enables stateless MCP (HINDSIGHT_API_MCP_STATELESS=true) so a hindsight bounce doesn't strand agent-side MCP sessions", () => {


### PR DESCRIPTION
## Summary

Raises the `switchroom-hindsight` container memory ceiling **8 GiB → 16 GiB** and resizes the embedded-Postgres buffer pool **in the same commit**, so the cap and the pool can never drift apart.

| constant | file | was | now |
|---|---|---|---|
| `HINDSIGHT_DEFAULT_MEM_LIMIT` | `src/setup/hindsight.ts` | `"8g"` | `"16g"` |
| `HINDSIGHT_PG_MEM_LIMIT_MIB_FOR_DERIVATION` | `src/setup/hindsight-pg-defaults.ts` | `8 * 1024` | `16 * 1024` |
| `HINDSIGHT_PG_DEFAULT_SHARED_BUFFERS_MIB` | `src/setup/hindsight-pg-defaults.ts` | `1536` | `3072` |
| `HINDSIGHT_PG_DEFAULT_EFFECTIVE_CACHE_SIZE_MIB` | `src/setup/hindsight-pg-defaults.ts` | `4096` | `7168` |

The mem limit reaches the container on both launch paths from that one constant — `--memory=` in the run argv (`hindsight.ts:1857`) and `mem_limit:` in the compose snippet (`:2421`).

## Why

The live container is at **99.5% of its 8 GiB cap**, with ~2.2 GiB of the cgroup taken by non-reclaimable anon (API process, embedder, cross-encoder, next-server). It is *not* OOM-killing — it is thrashing: **~24.5 GB/hour re-read from disk** across **7,400+ reclaim events**. That is a container paying disk latency to hold a working set it very nearly fits, which is exactly the bimodal cold/hot `link_expansion` distribution (p50 24ms / p90 1.4s) the pg-defaults module was written for.

Raising the cap alone would just buy more page cache for data Postgres should be holding itself, so the buffer pool moves with it.

### Why `shared_buffers = 3072` and not 4096

The widened budget ceiling (`16384 − 2560 app-anon − 2048 page-cache-floor = 11776 MiB`) would permit 4096, but that ceiling only accounts for the **pinned pool**. The per-backend side is not in it: `work_mem` is applied live per role, `hash_mem_multiplier=2` doubles it for hash nodes, and a parallel plan multiplies that again across workers. A 4 GiB pinned pool on top of that worst case does not fit under a 16 GiB cap alongside the app anon set and the page-cache floor. 3072 is a real 2x on the pool, holds the same 19% of the ceiling the previous value held, and leaves the tail covered.

### Why `effective_cache_size = 7168`

Sized to what the container can hold **after** this change (3072 pool + a 4096 page-cache assumption), not to the ~12 GB bank. It allocates nothing, but it is the term that prices index scans against sequential ones — over-declaring it does not make the container hold more, it flips plan shapes on the strength of cache that does not exist under pressure.

## The swap cushion (new test)

Neither launch path emits `--memory-swap` / `memswap_limit` today, so Docker applies its `MemorySwap = 2 × Memory` default. That is why the live container shows `Memory=8g / MemorySwap=16g` with **~900 MiB actually resident in swap** — and why 7,400 reclaim events have produced **zero OOM kills**.

Setting `memory-swap` *equal* to `memory` disables swap entirely. It looks like the same kind of tidying edit as omitting it; it is the opposite. Doing it in the change that pins ~1.5 GiB more unreclaimable shared memory would convert graceful degradation into a hard OOM kill of the memory backend for all 12 agents.

So this PR adds a durable guard rather than relying on nobody ever adding the flag: `tests/setup/hindsight.test.ts` asserts that **both** the run-args path and the compose path either omit the swap flag or emit a value **strictly greater** than the memory limit, and pins that a memory cap is emitted at all so the check can't go vacuous.

**Mutation-verified, both branches independently:**

```
# --memory-swap=${HINDSIGHT_DEFAULT_MEM_LIMIT} added to the run argv:
AssertionError: --memory-swap=16g must be STRICTLY greater than --memory=16g;
  equal disables swap and removes the cushion ... expected 16384 to be greater than 16384

# memswap_limit: ${HINDSIGHT_DEFAULT_MEM_LIMIT} added to the compose snippet only:
AssertionError: memswap_limit: 16g must be STRICTLY greater than mem_limit: 16g
  — equal disables swap entirely: expected 16384 to be greater than 16384
```

## The interlock still holds

`src/setup/hindsight-pg-defaults.test.ts:122-146` pins `HINDSIGHT_PG_MEM_LIMIT_MIB_FOR_DERIVATION === dockerSizeToMib(HINDSIGHT_DEFAULT_MEM_LIMIT)` and `shared_buffers <= budget`. It passes **unchanged** with the new numbers — no assertion was weakened or relaxed. That test is what prevents a future cap/buffer drift and it stays load-bearing.

## Test plan

Scoped, on this branch:

```
vitest run src/setup tests/setup tests/hindsight-env-keys-are-reachable.test.ts
  → 24 files, 635 tests passed
vitest run tests/docker/hindsight-entrypoint.test.ts   → 26 passed
vitest run tests/cli.doctor.memory-health.test.ts      → 63 passed
npm run lint                                           → clean (tsc + all 21 guards)
```

No pre-existing failures in any of the scoped paths on this worktree; nothing needed to be distinguished from a baseline. Full suite is CI's call.

## Rollout cost — read before merging

This lands as **code only**. Nothing here restarts, recreates, or `docker update`s anything; the new values reach the live container on the next hindsight rollout.

When that rollout happens:

- **No fleet quiesce is needed.** Agents do not have to be stopped or drained.
- Agents see **up to ~12s of added latency** on a turn that lands during the bounce, and one turn may run **without recall context**.
- **No memory is lost.** Retains are queued and drained automatically.

## Deliberately NOT in this PR

- `random_page_cost` — the riskiest knob, and its premise (planner choosing seq scans on `memory_links`) does not currently reproduce. Deferred.
- `work_mem` / `track_io_timing` — **already applied live** via `ALTER ROLE` / `ALTER SYSTEM`. No code here touches them.
- autovacuum tuning, index changes, `REINDEX` — out of scope.
- `SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS` is **not** set anywhere, and `switchroom.yaml` is untouched. Doing this via the env-override path would bypass the interlock test above and leave a latent OOM configuration armed after the next rollout — the whole point of moving the constants instead.

## Follow-up, same window

**`max_wal_size` 1GB → 4GB.** At the current write rate a 1 GB WAL forces frequent checkpoints, which is a separate I/O amplifier from the one this PR addresses. Deliberately not bundled — it is a different mechanism and deserves its own diff.

## Risk

Low. Both values are compile-time constants on both launch paths, guarded by the existing budget interlock plus the new swap invariant. The cap change is a *widening* on a 60 GB host; the buffer-pool change is bounded well under the derived budget. Worst realistic case is that the buffer pool is larger than needed, which costs page cache the container now has spare.

**Job:** `reference/jobs/remember-across-sessions.md` — a memory backend re-reading 24.5 GB/hour is a recall-latency tax on every turn.
