### PR TITLE
fix(memory): stop the sidechain retain header from soliciting ephemera

### DIFF
--- a/vendor/hindsight-memory/scripts/subagent_retain.py
+++ b/vendor/hindsight-memory/scripts/subagent_retain.py
@@ -90,14 +90,37 @@ SIDECHAIN_MAX_READ_BYTES = 8 * 1024 * 1024
 SIDECHAIN_SCAN_FRESH_WINDOW_S = 300
 
 # Extraction-framing header prepended to the retained content. The retain API
-# has no per-call mission (mission is bank-level), so we bias the consolidation
-# engine toward PROCESS facts with a short in-content note. Deterministic text —
-# it does not change the document_id (that is computed from the raw slice before
-# this is prepended).
+# has no per-call mission (mission is bank-level), so the only lever available
+# here is a short in-content note. Deterministic text — it does not change the
+# document_id (that is computed from the raw slice before this is prepended).
+#
+# 2026-07-29 rewrite. The original text asked the extractor for "PROCESS facts:
+# files/paths touched, commands that worked, ..." — i.e. it explicitly SOLICITED
+# the exact classes the bank-level mission (`DEFAULT_RETAIN_MISSION` in
+# src/memory/hindsight.ts) enumerates as NEVER-extract: file paths, tool-result
+# exhaust, narration of what the assistant did, volatile state. Because this
+# header sits inside the content the extractor reads, it read as a local
+# override and countermanded the bank mission on the sidechain path. The header
+# now REINFORCES the bank mission instead of fighting it: it keeps the genuinely
+# durable half of the old wording (decisions with their rationale, non-obvious
+# technique, structural dead ends) and names the ephemera to drop.
+# Governing test: would this still be worth knowing in a month?
 SIDECHAIN_MISSION_HEADER = (
-    "[sidechain sub-agent work log — extract PROCESS facts: files/paths touched, "
-    "commands that worked, decisions made, dead ends hit and why. Ignore the "
-    "restated mission prose and routine tool chatter.]"
+    "[sidechain sub-agent work log. Apply the bank's retain mission unchanged; "
+    "this is raw work exhaust and most of it is NOT memorable. Extract only "
+    "durable knowledge — something that would still be worth knowing in a month: "
+    "decisions made and the reasoning behind them; a non-obvious technique or "
+    "constraint that would save the next agent real time; a STRUCTURAL dead end "
+    "(\"X cannot work because Y\") as opposed to an incidental one (\"the command "
+    "failed so I retried\"). "
+    "Do NOT extract: the status of in-flight or unfinished work; PR, issue, "
+    "branch, review or CI state; counts, metrics, versions, sizes or any other "
+    "value that changes; container, process or runtime snapshots; narration of "
+    "what the agent did, including lists of the files, paths or commands it "
+    "touched; paths under /tmp or a scratchpad directory; session, agent, "
+    "request or operation IDs; the restated mission prose; routine tool chatter. "
+    "Anything whose truth expires when this session does is not a memory. "
+    "If nothing durable remains, extract nothing.]"
 )
 
 

--- a/vendor/hindsight-memory/scripts/tests/test_subagent_retain.py
+++ b/vendor/hindsight-memory/scripts/tests/test_subagent_retain.py
@@ -331,8 +331,10 @@ class RunSubagentRetain(unittest.TestCase):
         self.assertIn("agent_type:worker", captured["tags"])
         # Deterministic id in a DISTINCT namespace from parent retains.
         self.assertTrue(captured["document_id"].startswith("parentsess-sub-af5-r"))
-        # Process-fact framing header is prepended.
-        self.assertIn("extract PROCESS facts", captured["content"])
+        # Durable-knowledge framing header is prepended, verbatim and first.
+        self.assertTrue(
+            captured["content"].startswith(subagent_retain.SIDECHAIN_MISSION_HEADER)
+        )
         # Distinct provenance context.
         self.assertEqual(captured["context"], "claude-code-sidechain")
         self.assertEqual(captured["metadata"]["parent_session_id"], "parentsess")
@@ -457,6 +459,102 @@ class RunSubagentRetain(unittest.TestCase):
         # Payload is enqueue-shaped (matches lib.pending expectations).
         for k in ("bank_id", "content", "document_id", "context", "metadata", "tags"):
             self.assertIn(k, result["payload"])
+
+
+class SidechainMissionHeader(unittest.TestCase):
+    """The header must REINFORCE the bank-level retain mission, not countermand it.
+
+    The header is prepended into the retained content, where the extractor reads
+    it as a local instruction — so anything it solicits is written to memory even
+    when `DEFAULT_RETAIN_MISSION` (src/memory/hindsight.ts) lists that same class
+    under NEVER extract. The pre-2026-07-29 text asked for "PROCESS facts:
+    files/paths touched, commands that worked, ...", which is that exact
+    contradiction. These tests pin the fix: the solicit half asks only for
+    durable knowledge, and the ephemeral classes appear ONLY as exclusions.
+    """
+
+    SPLIT = "Do NOT extract"
+
+    def _halves(self):
+        header = subagent_retain.SIDECHAIN_MISSION_HEADER
+        self.assertIn(
+            self.SPLIT,
+            header,
+            "header must carry an explicit exclusion clause",
+        )
+        solicit, _, exclude = header.partition(self.SPLIT)
+        return header, solicit, exclude
+
+    def test_header_does_not_solicit_ephemeral_classes(self):
+        """Ephemera may be named as exclusions, never in the 'extract X' half."""
+        header = subagent_retain.SIDECHAIN_MISSION_HEADER
+        # The pre-fix solicitations, banned anywhere in the header — there is no
+        # phrasing of these that is a request for durable knowledge.
+        for gone in ("PROCESS facts", "files/paths touched", "commands that worked"):
+            self.assertNotIn(
+                gone,
+                header,
+                f"header still asks for {gone!r}, which the bank mission forbids",
+            )
+        _, solicit, _ = self._halves()
+        lowered = solicit.lower()
+        for banned in (
+            "process fact",
+            "files/paths",
+            "paths touched",
+            "commands that worked",
+            "/tmp",
+            "status",
+            "session id",
+            "container",
+            "metric",
+        ):
+            self.assertNotIn(
+                banned,
+                lowered,
+                f"header solicits ephemeral class {banned!r}: {solicit!r}",
+            )
+
+    def test_header_excludes_every_expiring_class(self):
+        _, _, exclude = self._halves()
+        lowered = exclude.lower()
+        for required in (
+            "in-flight",
+            "pr,",  # PR / issue / branch / CI state
+            "ci state",
+            "counts",
+            "versions",
+            "container",
+            "narration",
+            "/tmp",
+            "scratchpad",
+            "session, agent, request or operation ids",
+        ):
+            self.assertIn(
+                required,
+                lowered,
+                f"header fails to exclude {required!r}",
+            )
+
+    def test_header_still_solicits_decisions_with_rationale(self):
+        """The single most valuable sub-agent output must survive the rewrite."""
+        _, solicit, _ = self._halves()
+        lowered = solicit.lower()
+        self.assertIn("decisions made", lowered)
+        self.assertTrue(
+            any(w in lowered for w in ("reasoning", "rationale", "why")),
+            f"decisions are solicited without their rationale: {solicit!r}",
+        )
+        # And the other two durable classes the old wording earned.
+        self.assertIn("dead end", lowered)
+        self.assertIn("structural", lowered)
+
+    def test_header_states_the_durability_bar(self):
+        header, solicit, _ = self._halves()
+        self.assertIn("durable", solicit.lower())
+        self.assertIn("worth knowing in a month", solicit.lower())
+        # Bounded: this is prepended to every sidechain retain payload.
+        self.assertLess(len(header), 1500)
 
 
 class HookRegistration(unittest.TestCase):


### PR DESCRIPTION
## What

Rewrites `SIDECHAIN_MISSION_HEADER` in `vendor/hindsight-memory/scripts/subagent_retain.py` so the sub-agent retain path asks for **durable knowledge** and explicitly rejects ephemeral work detail. Text change plus tests — nothing else.

## Why

The header is prepended into the content the extractor reads on every `SubagentStop` retain (`subagent_retain.py:411`). The retain API has no per-call mission — mission is bank-level — so this in-content note is the only lever on that path (documented at `subagent_retain.py:92-94`).

Its text was:

> `[sidechain sub-agent work log — extract PROCESS facts: files/paths touched, commands that worked, decisions made, dead ends hit and why. Ignore the restated mission prose and routine tool chatter.]`

Three of those four requests are classes the bank-level mission (`DEFAULT_RETAIN_MISSION`, `src/memory/hindsight.ts:377-418`) enumerates under **NEVER extract**:

- "files/paths touched" → *"is the subject of this candidate a file path … If yes, drop it — it is transcript exhaust, not memory."*
- "commands that worked" → *"Tool results verbatim or paraphrased"*, *"Agent tool-use traces or narration of what the assistant did"*
- the work-log framing generally → *"In-flight workflow/process narration"*, *"Volatile state written as a timeless assertion"*

Because the header sits *inside* the content rather than in the mission slot, it reads as a local override and countermands the bank mission. We were explicitly requesting the junk the bank mission exists to filter out — on the path that governs roughly a third of fleet memory writes.

A prior design proposed catching this downstream with a lexical filter; that was reviewed NO-GO. This is the deterministic fix: stop asking for it.

## What survives

The genuinely durable half of the old wording is kept and sharpened:

- **decisions made and the reasoning behind them** — the single most valuable thing a sub-agent produces;
- a **non-obvious technique or constraint** that would save the next agent real time;
- a **structural** dead end (`"X cannot work because Y"`) as opposed to an incidental one (`"the command failed so I retried"`).

## What is now excluded

Status of in-flight or unfinished work; PR / issue / branch / review / CI state; counts, metrics, versions, sizes; container, process and runtime snapshots; narration of what the agent did including the files, paths and commands it touched; `/tmp` and scratchpad paths; session / agent / request / operation IDs; restated mission prose and routine tool chatter. Plus the governing bar: *anything whose truth expires when the session does is not a memory* — would this still be worth knowing in a month?

## Consistency with the bank mission

This PR does **not** change `DEFAULT_RETAIN_MISSION` (that is separate work). It was read for consistency: the new header's exclusion list is a subset-and-restatement of the bank mission's NEVER-extract list, so the two now agree instead of contradicting.

## Impact

- **Expected to cut roughly a third of memory write volume** — that is the fraction of units written through the sidechain path — by no longer soliciting the ephemeral classes that dominate it.
- **Text change only. No data migration**, no schema change, no stored memory touched or invalidated.
- No behavioural change to transcript resolution, the volume gate, the window slice, or the `document_id` (computed from the raw slice *before* the header is prepended, so dedup ids are byte-identical).
- **Reversible by revert** — a `git revert` of this commit restores the previous string exactly.

## Tests

New `SidechainMissionHeader` test class in `vendor/hindsight-memory/scripts/tests/test_subagent_retain.py`. It splits the header at `"Do NOT extract"` and asserts the *solicit* half contains no ephemeral class while the *exclude* half names each one, that decisions-with-rationale and structural dead ends survive, and that the old solicitations (`PROCESS facts`, `files/paths touched`, `commands that worked`) appear nowhere.

Verified to actually red against the pre-change string — all four fail on `origin/main`'s text, e.g.:

```
AssertionError: 'PROCESS facts' unexpectedly found in '[sidechain sub-agent work log
— extract PROCESS facts: files/paths touched, ...' : header still asks for
'PROCESS facts', which the bank mission forbids
```

Local runs on this branch:

- `vendor/hindsight-memory/scripts` → `python3 -m unittest discover tests -q` — **904 tests, OK**
- `vendor/hindsight-memory` → `python3 -m pytest tests/ -q` — **258 passed**
- `npm run lint` — clean

No pre-existing failures observed; both suites were green on a pristine `origin/main` worktree before the edit as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
