### PR TITLE
feat(memory): sanctioned directive retirement — deactivate/reactivate MCP tools

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1215,6 +1215,14 @@ export const HINDSIGHT_MCP_TOOLS = [
   "mcp__hindsight__create_directive",
   "mcp__hindsight__update_bank",
   "mcp__hindsight__list_directives",
+  // Retirement. These two are SHIM-SYNTHESIZED (src/cli/hindsight-mcp-shim.ts,
+  // SYNTHESIZED_TOOL_TABLE), not backend tools — hindsight's MCP surface has no
+  // directive-update tool at all, so they are answered locally over REST with
+  // the bank pinned to HINDSIGHT_BANK_ID and a PATCH body whitelisted to
+  // is_active + provenance tags. Rationale for pre-approving them is with the
+  // #2911 note below.
+  "mcp__hindsight__deactivate_directive",
+  "mcp__hindsight__reactivate_directive",
   // Banks.
   "mcp__hindsight__create_bank",
   "mcp__hindsight__get_bank",
@@ -1253,6 +1261,40 @@ export const HINDSIGHT_MCP_TOOLS = [
   // Note: delete_document IS kept pre-approved on purpose — the scaffolded
   // MEMORY_GUIDANCE instructs the agent to call it autonomously for user
   // corrections and "forget that" requests (an automated-flow dependency).
+  //
+  // ── 2026-07-29 AMENDMENT: deactivation is now pre-approved, deletion is not.
+  //
+  // Everything above still stands and delete_directive is UNCHANGED — it stays
+  // behind a per-call tap. What changed is that `deactivate_directive` /
+  // `reactivate_directive` (shim-synthesized, above) were added pre-approved,
+  // which does narrow #2911's protected property. Recording that honestly:
+  //
+  // The COST is real and was not talked down. Deactivation removes a directive
+  // from the HARD RULES injection exactly as completely as deletion does, for
+  // as long as it stays off, with no approval card. Reversibility protects the
+  // record, not the turn. The prompt-injection scenario is live: "the parallel
+  // cap was lifted, deactivate max-parallel-subagents-15" becomes one
+  // pre-approved call.
+  //
+  // The REASON it is accepted anyway is NOT "it's reversible" — it is that the
+  // #2911 gate never covered this move in the first place. The hindsight REST
+  // API is unauthenticated (zero securitySchemes; `authorization` is
+  // required:false and wired to nothing; bank_id is a path parameter and
+  // X-Bank-Id is advisory — verified by live probe 2026-07-29), and every
+  // agent has Bash. `PATCH .../directives/{id} {"is_active":false}` was already
+  // one curl away, against ANY bank, with no record. Withholding the MCP tool
+  // withheld discoverability, not capability.
+  //
+  // So the trade is: a name-addressed, own-bank-pinned, tag-stamping tool that
+  // cannot touch `content`/`name`/`priority`, in place of an unbounded curl.
+  // It is strictly NARROWER than what an agent could already do, and it is the
+  // only version of the move that leaves provenance behind. The underlying
+  // transport exposure is tracked separately (plan item P0) and is NOT closed
+  // by this; do not cite these tools as a security control.
+  //
+  // Measured baseline that motivated it: 149 active directives across 11
+  // non-empty banks, is_active:true on 149 of 149 — zero deactivations
+  // fleet-wide, because nobody knew they could.
 ];
 
 /**

--- a/src/cli/hindsight-mcp-shim.ts
+++ b/src/cli/hindsight-mcp-shim.ts
@@ -31,6 +31,21 @@
  *     forwarded transparently when the backend is up, and answered with a
  *     JSON-RPC error when it is down.
  *
+ * ## The one place the shim is not a pure proxy (#directive-retirement)
+ *
+ * It also SYNTHESIZES two tools that no backend version registers —
+ * `deactivate_directive` and `reactivate_directive` (see
+ * {@link SYNTHESIZED_TOOL_TABLE}). Hindsight's MCP surface can create, list
+ * and delete a directive but cannot flip `is_active`; only the REST API can,
+ * so without this the only retirement path was hand-rolled curl. These two are
+ * answered locally by {@link DirectiveAdmin} against the REST base derived
+ * from `HINDSIGHT_MCP_URL`, with the bank pinned to `HINDSIGHT_BANK_ID`, and
+ * are never forwarded upstream.
+ *
+ * That pin is a usability and provenance boundary, NOT a security one — the
+ * REST API is unauthenticated and raw curl bypasses the shim entirely. See the
+ * header of `src/memory/hindsight-directive-admin.ts` for the full statement.
+ *
  * Escape hatch: `memory.config.mcp_transport: "http"` in switchroom.yaml
  * reverts the scaffolded entry to the old direct `type: "http"` form (see
  * generateHindsightMcpConfig in src/memory/hindsight.ts).
@@ -40,7 +55,9 @@
  * inputs are threaded via the entry's `env` block):
  *
  *   HINDSIGHT_MCP_URL         backend Streamable HTTP endpoint
- *   HINDSIGHT_BANK_ID         X-Bank-Id header value (agent's collection)
+ *   HINDSIGHT_BANK_ID         X-Bank-Id header value (agent's collection),
+ *                             and the PINNED bank for the synthesized
+ *                             directive tools
  *   HINDSIGHT_SHIM_CACHE_DIR  where the cached tools/list manifest lives
  */
 
@@ -51,6 +68,10 @@ import { createInterface } from "node:readline";
 
 import type { Command } from "commander";
 
+import {
+  DirectiveAdmin,
+  DirectivePairInconsistentError,
+} from "../memory/hindsight-directive-admin.js";
 import { HINDSIGHT_DEFAULT_MCP_URL } from "../setup/hindsight.js";
 
 // ─── Protocol constants ───────────────────────────────────────────────────
@@ -163,6 +184,122 @@ export const FALLBACK_TOOL_TABLE: Record<string, [string[], string[]]> = {
   update_mental_model: [["mental_model_id"], ["bank_id", "max_tokens", "mental_model_id", "name", "source_query", "tags", "trigger_refresh_after_consolidation"]],
 };
 
+// ─── Shim-synthesized tools (the documented carve-out) ────────────────────
+
+/**
+ * Tools the SHIM implements itself and never forwards upstream.
+ *
+ * ## Why this does not violate "OVER-REPORTING IS THE WORSE HALF"
+ *
+ * Read that rule above before adding anything here. It exists because
+ * hindsight drops an unknown ARGUMENT silently and answers `isError:false`, so
+ * advertising a prop the server does not accept makes an agent believe a
+ * filter applied when it did not. The harm is entirely a property of tools
+ * whose calls are FORWARDED to the backend.
+ *
+ * These two are not. `toolsCall()` intercepts them by name before any upstream
+ * request exists and answers them locally over REST, so there is no server to
+ * mis-describe and no argument that can be silently dropped: an unknown
+ * argument here is rejected loudly by {@link HindsightShim.synthesizedCall}.
+ * Advertising them is therefore accurate, not optimistic — the shim really
+ * does provide them, backend up or down.
+ *
+ * What the rule DOES still bind: `FALLBACK_TOOL_TABLE` must continue to
+ * describe the pinned image byte-for-byte. That is why these live in a
+ * separate table rather than being added to it, and why
+ * `tests/memory.hindsight-contract.fixture.test.ts` still asserts
+ * `FALLBACK_TOOL_TABLE` ≡ the snapshot, plus a new assertion that these names
+ * do NOT appear in the snapshot — so if a future image bump registers real
+ * `deactivate_directive` / `reactivate_directive` tools, the test reds and the
+ * synthesis gets retired rather than silently shadowing them.
+ *
+ * NOTE the deliberate absence of a `bank_id` property. The bank is pinned from
+ * `HINDSIGHT_BANK_ID`; a caller cannot name one. That is a usability and
+ * provenance boundary, not a security one — see
+ * `src/memory/hindsight-directive-admin.ts`.
+ */
+export const SYNTHESIZED_TOOL_TABLE: Record<
+  string,
+  { description: string; required: string[]; props: Record<string, unknown> }
+> = {
+  deactivate_directive: {
+    description:
+      "Retire one of YOUR OWN standing directives by setting is_active=false, " +
+      "so it stops being injected as a hard rule. Reversible with " +
+      "reactivate_directive; the directive and its text are preserved. Pass " +
+      "superseded_by when another directive replaces this one — both get " +
+      "provenance tags recording the supersession. Operates only on your own " +
+      "memory bank and changes nothing but the active flag and those tags.",
+    required: ["name"],
+    props: {
+      name: {
+        type: "string",
+        description: "Exact name of the directive to deactivate.",
+      },
+      superseded_by: {
+        type: "string",
+        description:
+          "Optional exact name of the directive that replaces this one. " +
+          "Records 'superseded-by:<winner>' on this directive and " +
+          "'supersedes:<this>' on the winner.",
+      },
+    },
+  },
+  reactivate_directive: {
+    description:
+      "Restore one of YOUR OWN previously deactivated directives by setting " +
+      "is_active=true, so it is injected as a hard rule again. Operates only " +
+      "on your own memory bank and changes nothing but the active flag.",
+    required: ["name"],
+    props: {
+      name: {
+        type: "string",
+        description: "Exact name of the directive to reactivate.",
+      },
+    },
+  },
+};
+
+/** Names of the shim-synthesized tools (never forwarded upstream). */
+export const SYNTHESIZED_TOOL_NAMES = Object.keys(SYNTHESIZED_TOOL_TABLE);
+
+/** Materialize the synthesized tools in MCP tools/list shape. */
+export function buildSynthesizedToolsList(): ToolDef[] {
+  return Object.entries(SYNTHESIZED_TOOL_TABLE).map(
+    ([name, { description, required, props }]) => ({
+      name,
+      description,
+      inputSchema: {
+        type: "object" as const,
+        properties: props,
+        required,
+      },
+    }),
+  );
+}
+
+/**
+ * Append the synthesized tools to a manifest, dropping any same-named backend
+ * tool first.
+ *
+ * The drop is the retirement seam: if hindsight ever registers a real
+ * `deactivate_directive`, the shim's bank-pinned version keeps winning at
+ * runtime (so behaviour never silently widens to accept a `bank_id`) while the
+ * contract test reds and forces a deliberate decision.
+ */
+export function withSynthesizedTools(result: { tools: ToolDef[] }): {
+  tools: ToolDef[];
+} {
+  const synthesized = new Set(SYNTHESIZED_TOOL_NAMES);
+  return {
+    ...result,
+    tools: [
+      ...result.tools.filter((t) => !synthesized.has(t.name)),
+      ...buildSynthesizedToolsList(),
+    ],
+  };
+}
+
 /** Materialize the static fallback manifest in MCP tools/list shape. */
 export function buildFallbackToolsList(): { tools: ToolDef[] } {
   const tools = Object.entries(FALLBACK_TOOL_TABLE).map(
@@ -179,7 +316,7 @@ export function buildFallbackToolsList(): { tools: ToolDef[] } {
       },
     }),
   );
-  return { tools };
+  return withSynthesizedTools({ tools });
 }
 
 // ─── Types ────────────────────────────────────────────────────────────────
@@ -207,6 +344,13 @@ export interface ShimOptions {
   bankId: string;
   /** Directory for the persisted tools/list cache. Created on demand. */
   cacheDir: string;
+  /**
+   * REST base for the synthesized directive tools (no trailing slash).
+   * Defaults to `url` with the trailing `/mcp/` stripped — the same
+   * derivation `HINDSIGHT_DEFAULT_API_BASE_URL` uses, so the port lives in
+   * exactly one place.
+   */
+  apiBaseUrl?: string;
   /** Test seams — timeouts in ms. */
   toolsListTimeoutMs?: number;
   toolsCallTimeoutMs?: number;
@@ -592,11 +736,14 @@ export class HindsightShim {
       if (res.error) throw new Error(res.error.message);
       const result = res.result as { tools?: ToolDef[] };
       if (Array.isArray(result?.tools)) {
+        // Cache the BACKEND's manifest verbatim — the cache is a record of
+        // upstream truth, so the synthesized tools are layered on at serve
+        // time (below and in the catch) rather than baked into the file.
         this.writeCache(result);
         // The client is receiving the LIVE manifest right now — its view
         // is fresh, no recovery notification needed.
         this.staleManifestServed = false;
-        return result;
+        return withSynthesizedTools(result as { tools: ToolDef[] });
       }
       throw new Error("upstream tools/list returned no tools array");
     } catch (err) {
@@ -605,12 +752,112 @@ export class HindsightShim {
           "cached/fallback manifest",
       );
       this.staleManifestServed = true;
-      return this.readCache() ?? buildFallbackToolsList();
+      const cached = this.readCache();
+      // The synthesized directive tools do not depend on the backend at all,
+      // so they are advertised identically on every path — cold boot, cached,
+      // or live. An agent must never lose the retirement path just because
+      // memory is briefly down.
+      return cached ? withSynthesizedTools(cached) : buildFallbackToolsList();
+    }
+  }
+
+  /** Lazily built REST client for the synthesized directive tools. */
+  private directiveAdminCache: DirectiveAdmin | null = null;
+
+  private get directiveAdmin(): DirectiveAdmin {
+    if (!this.directiveAdminCache) {
+      this.directiveAdminCache = new DirectiveAdmin({
+        apiBaseUrl:
+          this.opts.apiBaseUrl ?? this.opts.url.replace(/\/mcp\/?$/, ""),
+        // PINNED. There is no parameter path from a tool call to this value.
+        bankId: this.opts.bankId,
+        ...(this.opts.fetchImpl ? { fetchImpl: this.opts.fetchImpl } : {}),
+      });
+    }
+    return this.directiveAdminCache;
+  }
+
+  /**
+   * Answer a shim-synthesized tool locally. Never touches the upstream MCP
+   * session.
+   *
+   * Argument handling is deliberately strict: an argument the tool does not
+   * declare is REJECTED rather than ignored. Silently ignoring `bank_id`
+   * would leave a caller believing it had targeted another bank when it had
+   * in fact edited its own — exactly the silent-drop failure mode the
+   * fallback-manifest rules above exist to prevent.
+   */
+  private async synthesizedCall(
+    name: string,
+    rawArgs: unknown,
+  ): Promise<unknown> {
+    const fail = (text: string) => ({
+      content: [{ type: "text", text }],
+      isError: true,
+    });
+    const spec = SYNTHESIZED_TOOL_TABLE[name];
+    const args = (rawArgs ?? {}) as Record<string, unknown>;
+    const allowed = new Set(Object.keys(spec.props));
+    const unknown = Object.keys(args).filter((k) => !allowed.has(k));
+    if (unknown.length > 0) {
+      return fail(
+        `${name} does not accept ${unknown.map((u) => `'${u}'`).join(", ")}. ` +
+          `Accepted arguments: ${[...allowed].join(", ")}. ` +
+          (unknown.includes("bank_id")
+            ? "This tool always operates on your own memory bank; there is no " +
+              "way to target another agent's bank through it."
+            : ""),
+      );
+    }
+    // Every declared arg is a string; an empty one is rejected rather than
+    // coerced away — silently treating `superseded_by: ""` as "no
+    // supersession" would drop the provenance the caller asked for without
+    // saying so.
+    for (const key of Object.keys(args)) {
+      if (typeof args[key] !== "string" || (args[key] as string).length === 0) {
+        return fail(`${name}: '${key}' must be a non-empty string.`);
+      }
+    }
+    for (const req of spec.required) {
+      if (args[req] === undefined) {
+        return fail(`${name} requires '${req}'.`);
+      }
+    }
+    if (!this.opts.bankId) {
+      return fail(
+        `${name} is unavailable: this agent has no HINDSIGHT_BANK_ID, so ` +
+          "there is no bank to pin the change to.",
+      );
+    }
+    try {
+      const text =
+        name === "deactivate_directive"
+          ? await this.directiveAdmin.deactivate({
+              name: args.name as string,
+              ...(typeof args.superseded_by === "string"
+                ? { supersededBy: args.superseded_by }
+                : {}),
+            })
+          : await this.directiveAdmin.reactivate({
+              name: args.name as string,
+            });
+      return { content: [{ type: "text", text }], isError: false };
+    } catch (err) {
+      if (err instanceof DirectivePairInconsistentError) {
+        this.log(`[hindsight-shim] ${err.message}`);
+      }
+      return fail(`${name} failed: ${String(err)}`);
     }
   }
 
   /** tools/call: lazy connect + bounded timeout + one retry; isError on down. */
   private async toolsCall(params: unknown): Promise<unknown> {
+    const called = (params as { name?: string; arguments?: unknown } | undefined);
+    // Synthesized tools are answered here and NEVER forwarded — the upstream
+    // MCP surface has no directive-update tool to forward them to.
+    if (called?.name && SYNTHESIZED_TOOL_NAMES.includes(called.name)) {
+      return this.synthesizedCall(called.name, called.arguments);
+    }
     try {
       const res = await this.upstream.request(
         "tools/call",

--- a/src/memory/hindsight-directive-admin.ts
+++ b/src/memory/hindsight-directive-admin.ts
@@ -1,0 +1,364 @@
+/**
+ * Directive retirement over the Hindsight REST API — the implementation
+ * behind the shim-synthesized `deactivate_directive` / `reactivate_directive`
+ * MCP tools.
+ *
+ * ## Why REST and not MCP
+ *
+ * The pinned hindsight image registers exactly three directive tools —
+ * `create_directive`, `list_directives`, `delete_directive` (see
+ * tests/fixtures/hindsight-tools-list.snapshot.json). There is NO
+ * `update_directive` on the MCP surface, so flipping `is_active` is simply
+ * not expressible as a backend tool call. The REST API does expose it:
+ * `PATCH /v1/default/banks/{bank_id}/directives/{directive_id}` accepts
+ * `UpdateDirectiveRequest{name, content, priority, is_active, tags}`.
+ *
+ * Consequence: retirement was previously reachable ONLY by hand-rolled curl
+ * from an agent's Bash — undiscoverable, unaudited, and unbounded (that curl
+ * can equally rewrite `content` or target a peer's bank). This module is the
+ * narrow, named, provenance-stamping alternative.
+ *
+ * ## The bank pin is a USABILITY AND PROVENANCE boundary, NOT A SECURITY ONE
+ *
+ * Read this before you cite it as a control. `bankId` is pinned here from the
+ * agent's own `HINDSIGHT_BANK_ID` and the tool schemas expose no `bank_id`
+ * property, so a *tool call* physically cannot address another agent's bank.
+ * That is the entire extent of the guarantee.
+ *
+ * It is NOT a security boundary, because the transport underneath it is
+ * unauthenticated (established by live probe, 2026-07-29): the Hindsight REST
+ * server declares zero `securitySchemes`, `authorization` is `required:false`
+ * and wired to nothing, `X-Bank-Id` is advisory and ignored by the REST layer,
+ * and `bank_id` is a path parameter — a PATCH aimed at a foreign bank reaches
+ * resource resolution and answers 404, not 401/403. Any agent with Bash can
+ * still curl any bank directly, bypassing this module entirely. Closing that
+ * is a separate, larger workstream (plan item P0: loopback bind, tenant API
+ * key, per-agent UDS proxy) and nothing here should be read as having done it.
+ *
+ * So: this module makes the SANCTIONED path safe and self-documenting. It does
+ * not make the unsanctioned path unavailable.
+ *
+ * ## Scope discipline
+ *
+ * The PATCH body is built by {@link buildDirectivePatchBody}, which admits
+ * `is_active` and `tags` and nothing else. `name`, `content` and `priority`
+ * are never sent, so no code path here can rewrite a directive's text —
+ * deliberately, because a directive body is the guardrail itself and a PATCH
+ * to `content` is destructive with no history table to recover from.
+ *
+ * ## Known limit, stated rather than papered over
+ *
+ * Tag updates are read-modify-write against an API with no compare-and-swap
+ * and no per-directive ETag, so two supersessions racing on the SAME winner
+ * can lose one of the two `supersedes:` tags. `deactivate` is the atomic unit
+ * from the caller's perspective (its own pair is all-or-nothing), not a
+ * serializable transaction against concurrent writers. In practice retirement
+ * is an interactive, one-at-a-time operation, and there is no upstream
+ * primitive that would let this module do better — so it is documented, not
+ * silently assumed away.
+ */
+
+/** Directive as returned by `GET .../directives`. */
+export interface HindsightDirective {
+  id: string;
+  bank_id?: string;
+  name: string;
+  content?: string;
+  priority?: number;
+  is_active?: boolean;
+  tags?: string[];
+}
+
+/**
+ * The ONLY fields this module will ever PATCH.
+ *
+ * `UpdateDirectiveRequest` upstream also accepts `name`, `content` and
+ * `priority`. Their absence from this type is the mechanism, not a comment:
+ * there is no call path that can populate them.
+ */
+export interface DirectivePatchBody {
+  is_active?: boolean;
+  tags?: string[];
+}
+
+/**
+ * Build a PATCH body from an explicit whitelist.
+ *
+ * Exported so a test can assert the key set directly rather than inferring it
+ * from behaviour — a regression that reintroduced `content` here would be a
+ * silent guardrail-rewrite primitive.
+ */
+export function buildDirectivePatchBody(fields: {
+  isActive?: boolean;
+  tags?: string[];
+}): DirectivePatchBody {
+  const body: DirectivePatchBody = {};
+  if (fields.isActive !== undefined) body.is_active = fields.isActive;
+  if (fields.tags !== undefined) body.tags = [...fields.tags];
+  return body;
+}
+
+/** Provenance tag written on the directive being retired. */
+export function supersededByTag(winnerName: string): string {
+  return `superseded-by:${winnerName}`;
+}
+
+/** Provenance tag written on the directive that replaces it. */
+export function supersedesTag(retiredName: string): string {
+  return `supersedes:${retiredName}`;
+}
+
+export interface DirectiveAdminOptions {
+  /** REST base, e.g. `http://127.0.0.1:18888` (no trailing slash). */
+  apiBaseUrl: string;
+  /**
+   * The agent's OWN bank. Pinned: every request path this module builds
+   * embeds this value, and no caller-supplied input can reach it.
+   */
+  bankId: string;
+  /** Injectable fetch (tests). Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Per-request timeout. */
+  timeoutMs?: number;
+}
+
+export const DIRECTIVE_ADMIN_TIMEOUT_MS = 15_000;
+
+/**
+ * Thrown when a supersession pair could not be left consistent: the winner's
+ * tag was written, the loser's write failed, AND the rollback of the winner
+ * also failed. The message names both directives and the exact repair, because
+ * this is the one state the caller cannot infer from a generic failure.
+ */
+export class DirectivePairInconsistentError extends Error {
+  constructor(
+    readonly retiredName: string,
+    readonly winnerName: string,
+    readonly cause1: unknown,
+    readonly cause2: unknown,
+  ) {
+    super(
+      `INCONSISTENT STATE — the supersession pair is half-written. ` +
+        `'${winnerName}' now carries the tag ${supersedesTag(retiredName)} but ` +
+        `'${retiredName}' was NOT deactivated (${String(cause1)}), and the ` +
+        `rollback of '${winnerName}' also failed (${String(cause2)}). ` +
+        `Repair manually: remove ${supersedesTag(retiredName)} from ` +
+        `'${winnerName}', or complete the retirement of '${retiredName}'. ` +
+        `Do not assume either directive is in the state you asked for.`,
+    );
+    this.name = "DirectivePairInconsistentError";
+  }
+}
+
+export class DirectiveAdmin {
+  constructor(private readonly opts: DirectiveAdminOptions) {}
+
+  private get fetchImpl(): typeof fetch {
+    return this.opts.fetchImpl ?? fetch;
+  }
+
+  /**
+   * Base path for THIS agent's directives. The bank segment comes from
+   * `opts.bankId` only — there is no parameter, so no caller can redirect it.
+   */
+  private directivesPath(): string {
+    const base = this.opts.apiBaseUrl.replace(/\/+$/, "");
+    return `${base}/v1/default/banks/${encodeURIComponent(this.opts.bankId)}/directives`;
+  }
+
+  private async send(
+    url: string,
+    init: { method: string; body?: string },
+  ): Promise<Response> {
+    const ctl = new AbortController();
+    const timer = setTimeout(
+      () => ctl.abort(),
+      this.opts.timeoutMs ?? DIRECTIVE_ADMIN_TIMEOUT_MS,
+    );
+    try {
+      return await this.fetchImpl(url, {
+        method: init.method,
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json",
+          // Advisory only — the REST layer ignores it. Sent for parity with
+          // the shim's MCP path and so request logs carry the intent.
+          ...(this.opts.bankId ? { "X-Bank-Id": this.opts.bankId } : {}),
+        },
+        ...(init.body === undefined ? {} : { body: init.body }),
+        signal: ctl.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * All directives in the pinned bank, ACTIVE AND INACTIVE.
+   *
+   * Both query params are load-bearing, not defensive:
+   *   • `active_only` defaults to **true** upstream, so a bare GET returns
+   *     only active directives — `reactivate_directive` would then never be
+   *     able to find the very directives it exists to restore.
+   *   • `limit` defaults to 100. `MAX_DIRECTIVES` is 30 today, but the cap is
+   *     on ACTIVE directives, and retirement is exactly the thing that grows
+   *     the inactive pile — so the paged default would start silently hiding
+   *     retired directives from reactivation once a bank accumulated 100.
+   *     1000 is the schema maximum.
+   */
+  async list(): Promise<HindsightDirective[]> {
+    const res = await this.send(
+      `${this.directivesPath()}?active_only=false&limit=1000`,
+      { method: "GET" },
+    );
+    if (!res.ok) {
+      throw new Error(
+        `listing directives in bank '${this.opts.bankId}' failed: HTTP ${res.status}`,
+      );
+    }
+    const parsed = (await res.json()) as
+      | { items?: HindsightDirective[] }
+      | HindsightDirective[];
+    const items = Array.isArray(parsed) ? parsed : (parsed.items ?? []);
+    return items;
+  }
+
+  /**
+   * PATCH one directive. Body is whitelist-built; `directiveId` always comes
+   * from a prior `list()` of the pinned bank, never from caller input.
+   */
+  private async patch(
+    directiveId: string,
+    fields: { isActive?: boolean; tags?: string[] },
+  ): Promise<void> {
+    const body = buildDirectivePatchBody(fields);
+    const res = await this.send(
+      `${this.directivesPath()}/${encodeURIComponent(directiveId)}`,
+      { method: "PATCH", body: JSON.stringify(body) },
+    );
+    if (!res.ok) {
+      throw new Error(
+        `updating directive ${directiveId} failed: HTTP ${res.status}`,
+      );
+    }
+  }
+
+  /** Exact-name resolution within the pinned bank. Ambiguity is an error. */
+  private resolve(
+    all: HindsightDirective[],
+    name: string,
+    label: string,
+  ): HindsightDirective {
+    const hits = all.filter((d) => d.name === name);
+    if (hits.length === 0) {
+      const known = all
+        .map((d) => d.name)
+        .sort()
+        .join(", ");
+      throw new Error(
+        `no directive named '${name}' in bank '${this.opts.bankId}' (${label}). ` +
+          `Known directives: ${known || "(none)"}`,
+      );
+    }
+    if (hits.length > 1) {
+      throw new Error(
+        `'${name}' is ambiguous — ${hits.length} directives in bank ` +
+          `'${this.opts.bankId}' share that name (${label}). Resolve the ` +
+          `duplicate before retiring either.`,
+      );
+    }
+    return hits[0];
+  }
+
+  /** Union that preserves existing order and never duplicates. */
+  private withTag(existing: string[] | undefined, tag: string): string[] {
+    const tags = [...(existing ?? [])];
+    if (!tags.includes(tag)) tags.push(tag);
+    return tags;
+  }
+
+  /**
+   * Set `is_active: false` on `name`, optionally recording that
+   * `supersededBy` replaces it.
+   *
+   * Ordering is the atomicity mechanism. The winner (B) is tagged FIRST
+   * because that write is non-destructive and leaves the retiring directive
+   * (A) fully intact if it fails — so a failure there is a clean no-op. Only
+   * once B is stamped is A deactivated; if THAT fails, B's tags are restored
+   * to their exact prior value. If the restore fails too we throw
+   * {@link DirectivePairInconsistentError}, which states the residue
+   * explicitly. There is no path that returns success on a half-written pair.
+   */
+  async deactivate(args: {
+    name: string;
+    supersededBy?: string;
+  }): Promise<string> {
+    const all = await this.list();
+    const target = this.resolve(all, args.name, "the directive to deactivate");
+
+    if (!args.supersededBy) {
+      await this.patch(target.id, { isActive: false });
+      return (
+        `Deactivated directive '${target.name}' in bank '${this.opts.bankId}'. ` +
+        `It is no longer injected as a hard rule. Reverse with ` +
+        `reactivate_directive.`
+      );
+    }
+
+    const winner = this.resolve(all, args.supersededBy, "the superseding directive");
+    if (winner.id === target.id) {
+      throw new Error(
+        `'${args.name}' cannot supersede itself — pass the name of the ` +
+          `directive that REPLACES it as superseded_by.`,
+      );
+    }
+
+    const winnerTagsBefore = [...(winner.tags ?? [])];
+    // Step 1 — stamp the winner. Non-destructive; A untouched if this throws.
+    await this.patch(winner.id, {
+      tags: this.withTag(winnerTagsBefore, supersedesTag(target.name)),
+    });
+    // Step 2 — retire the loser.
+    try {
+      await this.patch(target.id, {
+        isActive: false,
+        tags: this.withTag(target.tags, supersededByTag(winner.name)),
+      });
+    } catch (err) {
+      try {
+        await this.patch(winner.id, { tags: winnerTagsBefore });
+      } catch (rollbackErr) {
+        throw new DirectivePairInconsistentError(
+          target.name,
+          winner.name,
+          err,
+          rollbackErr,
+        );
+      }
+      throw new Error(
+        `Deactivating '${target.name}' failed (${String(err)}). The ` +
+          `supersession tag on '${winner.name}' was rolled back, so both ` +
+          `directives are unchanged — nothing was half-written. Retry once ` +
+          `the cause is cleared.`,
+      );
+    }
+    return (
+      `Deactivated directive '${target.name}' in bank '${this.opts.bankId}', ` +
+      `superseded by '${winner.name}'. Provenance recorded: ` +
+      `'${target.name}' tagged ${supersededByTag(winner.name)}, ` +
+      `'${winner.name}' tagged ${supersedesTag(target.name)}.`
+    );
+  }
+
+  /** Set `is_active: true` on `name`. Nothing else changes. */
+  async reactivate(args: { name: string }): Promise<string> {
+    const all = await this.list();
+    const target = this.resolve(all, args.name, "the directive to reactivate");
+    await this.patch(target.id, { isActive: true });
+    return (
+      `Reactivated directive '${target.name}' in bank '${this.opts.bankId}'. ` +
+      `It is injected as a hard rule again. Any superseded-by tag was left ` +
+      `in place as a record — clear it manually if the supersession is off.`
+    );
+  }
+}

--- a/tests/hindsight-directive-admin.test.ts
+++ b/tests/hindsight-directive-admin.test.ts
@@ -1,0 +1,526 @@
+/**
+ * Outcome tests for directive retirement — `DirectiveAdmin`
+ * (src/memory/hindsight-directive-admin.ts) and the two shim-synthesized MCP
+ * tools that wrap it (src/cli/hindsight-mcp-shim.ts).
+ *
+ * These drive the real modules against a stateful mock of the hindsight REST
+ * API, and assert the STATE THE SERVER ENDS UP IN plus the requests it
+ * actually received — not that a code path ran. Each guard below is written so
+ * it fails on the specific defect it exists for:
+ *
+ *   • bank pinning     — remove the pin and the request lands on a peer bank
+ *   • field whitelist  — widen the PATCH body and a directive's text changes
+ *   • pair atomicity   — drop the rollback and the winner keeps a dangling tag
+ *   • loud failure     — swallow the rollback failure and a half-written pair
+ *                        reports success
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServer, type Server } from "node:http";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  DirectiveAdmin,
+  DirectivePairInconsistentError,
+  buildDirectivePatchBody,
+  type HindsightDirective,
+} from "../src/memory/hindsight-directive-admin.js";
+import {
+  HindsightShim,
+  SYNTHESIZED_TOOL_NAMES,
+} from "../src/cli/hindsight-mcp-shim.js";
+
+// ─── stateful mock of the hindsight REST directive API ────────────────────
+
+interface SeenRequest {
+  method: string;
+  path: string;
+  body: unknown;
+}
+
+interface MockApi {
+  baseUrl: string;
+  server: Server;
+  /** bank id → directives, mutated by PATCH exactly as the real API would. */
+  banks: Record<string, HindsightDirective[]>;
+  seen: SeenRequest[];
+  /** Return an HTTP status to fail a PATCH with, or null to let it through. */
+  failPatch: (directiveId: string, patchIndex: number) => number | null;
+  close: () => Promise<void>;
+}
+
+async function startMockApi(
+  banks: Record<string, HindsightDirective[]>,
+): Promise<MockApi> {
+  const state: MockApi = {
+    baseUrl: "",
+    server: undefined as unknown as Server,
+    banks,
+    seen: [],
+    failPatch: () => null,
+    close: async () => undefined,
+  };
+  let patchCount = 0;
+
+  const server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (c) => (raw += c));
+    req.on("end", () => {
+      const path = req.url ?? "";
+      const body = raw ? JSON.parse(raw) : undefined;
+      state.seen.push({ method: req.method ?? "", path, body });
+      const send = (status: number, payload: unknown) => {
+        res.writeHead(status, { "content-type": "application/json" });
+        res.end(JSON.stringify(payload));
+      };
+      const [rawPath, rawQuery] = path.split("?");
+      const query = new URLSearchParams(rawQuery ?? "");
+      const m = /^\/v1\/default\/banks\/([^/]+)\/directives(?:\/([^/]+))?$/.exec(
+        rawPath,
+      );
+      if (!m) return send(404, { detail: "not found" });
+      const bank = decodeURIComponent(m[1]);
+      const directiveId = m[2] ? decodeURIComponent(m[2]) : undefined;
+      const items = state.banks[bank];
+      if (!items) return send(404, { detail: "no such bank" });
+
+      if (req.method === "GET" && !directiveId) {
+        // Mirror the REAL upstream defaults, which are the trap here:
+        // `active_only` defaults to TRUE and `limit` to 100, so a caller that
+        // omits them cannot see (and therefore cannot reactivate) a
+        // deactivated directive. A permissive mock would hide that bug.
+        const activeOnly = (query.get("active_only") ?? "true") !== "false";
+        const limit = Number(query.get("limit") ?? "100");
+        const offset = Number(query.get("offset") ?? "0");
+        const visible = (activeOnly ? items.filter((d) => d.is_active) : items)
+          .slice(offset, offset + limit);
+        return send(200, { items: visible });
+      }
+      if (req.method === "PATCH" && directiveId) {
+        const failStatus = state.failPatch(directiveId, patchCount++);
+        if (failStatus !== null) return send(failStatus, { detail: "injected" });
+        const target = items.find((d) => d.id === directiveId);
+        if (!target) return send(404, { detail: "no such directive" });
+        // Mirror the real UpdateDirectiveRequest semantics: any field present
+        // in the body is applied; tags REPLACE wholesale.
+        for (const key of Object.keys(body as Record<string, unknown>)) {
+          (target as Record<string, unknown>)[key] = (
+            body as Record<string, unknown>
+          )[key];
+        }
+        return send(200, target);
+      }
+      return send(405, { detail: "method not allowed" });
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const port = (server.address() as { port: number }).port;
+  state.baseUrl = `http://127.0.0.1:${port}`;
+  state.server = server;
+  state.close = () => new Promise((r) => server.close(() => r()));
+  return state;
+}
+
+const OWN_BANK = "agent-own-bank";
+const PEER_BANK = "peer-bank";
+
+function fixtureBanks(): Record<string, HindsightDirective[]> {
+  return {
+    [OWN_BANK]: [
+      {
+        id: "d-old",
+        name: "old-rule",
+        content: "The original guardrail text.",
+        priority: 7,
+        is_active: true,
+        tags: ["style"],
+      },
+      {
+        id: "d-new",
+        name: "new-rule",
+        content: "The replacement guardrail text.",
+        priority: 3,
+        is_active: true,
+        tags: ["style", "keep"],
+      },
+      {
+        id: "d-off",
+        name: "retired-rule",
+        content: "Already off.",
+        priority: 0,
+        is_active: false,
+        tags: [],
+      },
+    ],
+    [PEER_BANK]: [
+      {
+        id: "p-1",
+        name: "peer-guardrail",
+        content: "A peer agent's standing rule.",
+        priority: 9,
+        is_active: true,
+        tags: [],
+      },
+    ],
+  };
+}
+
+let api: MockApi;
+beforeEach(async () => {
+  api = await startMockApi(fixtureBanks());
+});
+afterEach(async () => {
+  await api.close();
+});
+
+const admin = (overrides: Partial<{ bankId: string }> = {}) =>
+  new DirectiveAdmin({
+    apiBaseUrl: api.baseUrl,
+    bankId: overrides.bankId ?? OWN_BANK,
+    timeoutMs: 2000,
+  });
+
+const byId = (bank: string, id: string) =>
+  api.banks[bank].find((d) => d.id === id)!;
+
+// ─── 1. bank pinning ──────────────────────────────────────────────────────
+
+describe("bank pinning", () => {
+  it("every request targets the pinned bank and only the pinned bank", async () => {
+    await admin().deactivate({ name: "old-rule" });
+    expect(api.seen.length).toBeGreaterThan(0);
+    for (const r of api.seen) {
+      expect(
+        r.path.startsWith(`/v1/default/banks/${OWN_BANK}/`),
+        `request ${r.method} ${r.path} escaped the pinned bank`,
+      ).toBe(true);
+    }
+    expect(byId(PEER_BANK, "p-1").is_active).toBe(true);
+  });
+
+  it("a directive NAME cannot be used to path-traverse into a peer bank", async () => {
+    // Names are resolved against a listing of the pinned bank, never
+    // interpolated into a URL. A traversal-shaped name must therefore fail as
+    // "not found" WITHOUT any request reaching the peer bank.
+    await expect(
+      admin().deactivate({
+        name: `../../${PEER_BANK}/directives/p-1`,
+      }),
+    ).rejects.toThrow(/no directive named/);
+    for (const r of api.seen) {
+      expect(r.path).not.toContain(PEER_BANK);
+    }
+    expect(byId(PEER_BANK, "p-1").is_active).toBe(true);
+  });
+
+  it("a name that exists ONLY in a peer bank is not reachable", async () => {
+    await expect(
+      admin().deactivate({ name: "peer-guardrail" }),
+    ).rejects.toThrow(/no directive named 'peer-guardrail'/);
+    expect(byId(PEER_BANK, "p-1").is_active).toBe(true);
+    expect(api.seen.some((r) => r.method === "PATCH")).toBe(false);
+  });
+
+  it("the tool schemas expose no bank_id, and a bank_id argument is REJECTED", async () => {
+    const cacheDir = mkdtempSync(join(tmpdir(), "shim-directive-test-"));
+    try {
+      const shim = new HindsightShim({
+        url: `${api.baseUrl}/mcp/`,
+        bankId: OWN_BANK,
+        cacheDir,
+        logger: () => undefined,
+      });
+      const list = (await shim.handle({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+      })) as { result: { tools: { name: string; inputSchema: unknown }[] } };
+      const tool = list.result.tools.find(
+        (t) => t.name === "deactivate_directive",
+      )!;
+      const props = Object.keys(
+        (tool.inputSchema as { properties: Record<string, unknown> }).properties,
+      );
+      expect(props).not.toContain("bank_id");
+
+      // ...and passing one anyway must fail loudly rather than be ignored.
+      const res = (await shim.handle({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: {
+          name: "deactivate_directive",
+          arguments: { name: "old-rule", bank_id: PEER_BANK },
+        },
+      })) as { result: { isError: boolean; content: { text: string }[] } };
+      expect(res.result.isError).toBe(true);
+      expect(res.result.content[0].text).toContain("bank_id");
+      // Nothing was written anywhere — not the peer bank, not our own.
+      expect(byId(PEER_BANK, "p-1").is_active).toBe(true);
+      expect(byId(OWN_BANK, "d-old").is_active).toBe(true);
+      expect(api.seen.some((r) => r.method === "PATCH")).toBe(false);
+    } finally {
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── 2. the PATCH body whitelist ──────────────────────────────────────────
+
+describe("field whitelist — only is_active and tags are ever written", () => {
+  it("buildDirectivePatchBody cannot emit name/content/priority", () => {
+    const body = buildDirectivePatchBody({ isActive: false, tags: ["x"] }) as Record<
+      string,
+      unknown
+    >;
+    expect(Object.keys(body).sort()).toEqual(["is_active", "tags"]);
+    for (const forbidden of ["name", "content", "priority"]) {
+      expect(Object.keys(body)).not.toContain(forbidden);
+    }
+    expect(Object.keys(buildDirectivePatchBody({ isActive: true }))).toEqual([
+      "is_active",
+    ]);
+  });
+
+  it("deactivate sends is_active only, and leaves content/name/priority byte-identical", async () => {
+    const before = { ...byId(OWN_BANK, "d-old") };
+    await admin().deactivate({ name: "old-rule" });
+    const patches = api.seen.filter((r) => r.method === "PATCH");
+    expect(patches).toHaveLength(1);
+    expect(Object.keys(patches[0].body as object)).toEqual(["is_active"]);
+
+    const after = byId(OWN_BANK, "d-old");
+    expect(after.is_active).toBe(false);
+    expect(after.content).toBe(before.content);
+    expect(after.name).toBe(before.name);
+    expect(after.priority).toBe(before.priority);
+    expect(after.tags).toEqual(before.tags);
+  });
+
+  it("can see — and therefore restore — an ALREADY-INACTIVE directive", async () => {
+    // Regression guard: upstream's `active_only` defaults to true, so a
+    // listing that omits `active_only=false` cannot see 'retired-rule' at all
+    // and reactivate_directive becomes permanently unable to do its one job.
+    expect(byId(OWN_BANK, "d-off").is_active).toBe(false);
+    await admin().reactivate({ name: "retired-rule" });
+    expect(byId(OWN_BANK, "d-off").is_active).toBe(true);
+  });
+
+  it("reactivate sends is_active only, and leaves content/name/priority byte-identical", async () => {
+    const before = { ...byId(OWN_BANK, "d-off") };
+    await admin().reactivate({ name: "retired-rule" });
+    const patches = api.seen.filter((r) => r.method === "PATCH");
+    expect(patches).toHaveLength(1);
+    expect(patches[0].body).toEqual({ is_active: true });
+
+    const after = byId(OWN_BANK, "d-off");
+    expect(after.is_active).toBe(true);
+    expect(after.content).toBe(before.content);
+    expect(after.name).toBe(before.name);
+    expect(after.priority).toBe(before.priority);
+  });
+
+  it("the supersession path also never writes content/name/priority", async () => {
+    const oldBefore = { ...byId(OWN_BANK, "d-old") };
+    const newBefore = { ...byId(OWN_BANK, "d-new") };
+    await admin().deactivate({ name: "old-rule", supersededBy: "new-rule" });
+    for (const p of api.seen.filter((r) => r.method === "PATCH")) {
+      for (const forbidden of ["name", "content", "priority"]) {
+        expect(
+          Object.keys(p.body as object),
+          `PATCH ${p.path} carried '${forbidden}' — this tool must never ` +
+            `rewrite a guardrail's text`,
+        ).not.toContain(forbidden);
+      }
+    }
+    expect(byId(OWN_BANK, "d-old").content).toBe(oldBefore.content);
+    expect(byId(OWN_BANK, "d-new").content).toBe(newBefore.content);
+    expect(byId(OWN_BANK, "d-new").priority).toBe(newBefore.priority);
+  });
+});
+
+// ─── 3. supersession provenance + atomicity ───────────────────────────────
+
+describe("supersession provenance", () => {
+  it("writes both tags and deactivates only the superseded directive", async () => {
+    const msg = await admin().deactivate({
+      name: "old-rule",
+      supersededBy: "new-rule",
+    });
+    const retired = byId(OWN_BANK, "d-old");
+    const winner = byId(OWN_BANK, "d-new");
+
+    expect(retired.is_active).toBe(false);
+    expect(retired.tags).toContain("superseded-by:new-rule");
+    expect(retired.tags).toContain("style"); // pre-existing tag preserved
+
+    expect(winner.is_active).toBe(true); // the winner is NOT touched otherwise
+    expect(winner.tags).toContain("supersedes:old-rule");
+    expect(winner.tags).toEqual(
+      expect.arrayContaining(["style", "keep"]), // pre-existing tags preserved
+    );
+    expect(msg).toContain("superseded by 'new-rule'");
+  });
+
+  it("refuses self-supersession", async () => {
+    await expect(
+      admin().deactivate({ name: "old-rule", supersededBy: "old-rule" }),
+    ).rejects.toThrow(/cannot supersede itself/);
+    expect(byId(OWN_BANK, "d-old").is_active).toBe(true);
+    expect(api.seen.some((r) => r.method === "PATCH")).toBe(false);
+  });
+
+  it("an unknown superseded_by aborts BEFORE any write", async () => {
+    await expect(
+      admin().deactivate({ name: "old-rule", supersededBy: "no-such-rule" }),
+    ).rejects.toThrow(/no directive named 'no-such-rule'/);
+    expect(byId(OWN_BANK, "d-old").is_active).toBe(true);
+    expect(api.seen.some((r) => r.method === "PATCH")).toBe(false);
+  });
+
+  it("NEVER leaves a half-written pair: a failed second write rolls the first back", async () => {
+    const winnerTagsBefore = [...byId(OWN_BANK, "d-new").tags!];
+    // Fail the PATCH that retires the loser; the winner's tag write already
+    // landed, so the ONLY thing standing between this and a dangling
+    // `supersedes:` tag is the rollback.
+    api.failPatch = (id) => (id === "d-old" ? 500 : null);
+
+    await expect(
+      admin().deactivate({ name: "old-rule", supersededBy: "new-rule" }),
+    ).rejects.toThrow(/rolled back/);
+
+    const retired = byId(OWN_BANK, "d-old");
+    const winner = byId(OWN_BANK, "d-new");
+    expect(retired.is_active).toBe(true); // not retired
+    expect(retired.tags).not.toContain("superseded-by:new-rule");
+    expect(
+      winner.tags,
+      "the winner kept a supersedes: tag for a supersession that never " +
+        "happened — that is exactly the half-written pair this forbids",
+    ).not.toContain("supersedes:old-rule");
+    expect(winner.tags).toEqual(winnerTagsBefore); // restored EXACTLY
+  });
+
+  it("when the rollback ALSO fails it throws loudly and names the residue", async () => {
+    // Every PATCH after the winner's initial tag write fails: the retire
+    // fails, and so does the rollback.
+    api.failPatch = (_id, index) => (index === 0 ? null : 500);
+
+    let caught: unknown;
+    try {
+      await admin().deactivate({ name: "old-rule", supersededBy: "new-rule" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(DirectivePairInconsistentError);
+    const msg = (caught as Error).message;
+    expect(msg).toContain("INCONSISTENT STATE");
+    expect(msg).toContain("old-rule");
+    expect(msg).toContain("new-rule");
+    // The residue the message describes is the residue that exists.
+    expect(byId(OWN_BANK, "d-new").tags).toContain("supersedes:old-rule");
+    expect(byId(OWN_BANK, "d-old").is_active).toBe(true);
+  });
+
+  it("the failed-pair result surfaces as an MCP tool error, never as success", async () => {
+    const cacheDir = mkdtempSync(join(tmpdir(), "shim-directive-test-"));
+    try {
+      const shim = new HindsightShim({
+        url: `${api.baseUrl}/mcp/`,
+        bankId: OWN_BANK,
+        cacheDir,
+        logger: () => undefined,
+      });
+      api.failPatch = (_id, index) => (index === 0 ? null : 500);
+      const res = (await shim.handle({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "deactivate_directive",
+          arguments: { name: "old-rule", superseded_by: "new-rule" },
+        },
+      })) as { result: { isError: boolean; content: { text: string }[] } };
+      expect(res.result.isError).toBe(true);
+      expect(res.result.content[0].text).toContain("INCONSISTENT STATE");
+      expect(byId(OWN_BANK, "d-old").is_active).toBe(true);
+    } finally {
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── 4. the synthesized tools are never forwarded upstream ────────────────
+
+describe("shim wiring", () => {
+  it("advertises both synthesized tools and answers them without an MCP session", async () => {
+    const cacheDir = mkdtempSync(join(tmpdir(), "shim-directive-test-"));
+    try {
+      const shim = new HindsightShim({
+        // /mcp/ on the mock answers 404 — proving the synthesized call never
+        // touches the MCP transport, only the REST endpoints.
+        url: `${api.baseUrl}/mcp/`,
+        bankId: OWN_BANK,
+        cacheDir,
+        toolsListTimeoutMs: 500,
+        logger: () => undefined,
+      });
+      const list = (await shim.handle({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+      })) as { result: { tools: { name: string }[] } };
+      const names = list.result.tools.map((t) => t.name);
+      for (const n of SYNTHESIZED_TOOL_NAMES) expect(names).toContain(n);
+
+      // From here on, ANY /mcp request would mean the call was forwarded.
+      const mark = api.seen.length;
+      const res = (await shim.handle({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: {
+          name: "deactivate_directive",
+          arguments: { name: "old-rule" },
+        },
+      })) as { result: { isError: boolean } };
+      expect(res.result.isError).toBe(false);
+      expect(byId(OWN_BANK, "d-old").is_active).toBe(false);
+      expect(
+        api.seen.slice(mark).some((r) => r.path.startsWith("/mcp")),
+        "the synthesized call was forwarded to the MCP transport — upstream " +
+          "has no directive-update tool, so a forward is a silent no-op",
+      ).toBe(false);
+      expect(api.seen.slice(mark).some((r) => r.method === "PATCH")).toBe(true);
+    } finally {
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to act when the agent has no pinned bank", async () => {
+    const cacheDir = mkdtempSync(join(tmpdir(), "shim-directive-test-"));
+    try {
+      const shim = new HindsightShim({
+        url: `${api.baseUrl}/mcp/`,
+        bankId: "",
+        cacheDir,
+        logger: () => undefined,
+      });
+      const res = (await shim.handle({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "reactivate_directive",
+          arguments: { name: "retired-rule" },
+        },
+      })) as { result: { isError: boolean; content: { text: string }[] } };
+      expect(res.result.isError).toBe(true);
+      expect(res.result.content[0].text).toContain("HINDSIGHT_BANK_ID");
+      expect(api.seen).toHaveLength(0);
+    } finally {
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/hindsight-mcp-shim.test.ts
+++ b/tests/hindsight-mcp-shim.test.ts
@@ -24,6 +24,7 @@ import {
   FALLBACK_TOOL_TABLE,
   TOOLS_CACHE_FILENAME,
   SHIM_SUPPORTED_PROTOCOL_VERSIONS,
+  SYNTHESIZED_TOOL_NAMES,
   type ShimOptions,
 } from "../src/cli/hindsight-mcp-shim.js";
 
@@ -205,7 +206,15 @@ describe("tools/list with backend down", () => {
 
     const res = await shim.handle(rpc(3, "tools/list") as never);
     expect(res?.error).toBeUndefined();
-    expect(res?.result).toEqual(cached);
+    // The cached BACKEND manifest is served verbatim; the shim-synthesized
+    // directive tools ride on top. They don't depend on the backend at all, so
+    // an agent must not lose the retirement path just because memory is down.
+    const { tools } = res?.result as { tools: { name: string }[] };
+    expect(tools.map((t) => t.name)).toEqual([
+      "recall",
+      ...SYNTHESIZED_TOOL_NAMES,
+    ]);
+    expect(tools[0]).toEqual(cached.tools[0]);
   });
 
   it("serves the static fallback manifest on first boot (no cache)", async () => {
@@ -218,7 +227,12 @@ describe("tools/list with backend down", () => {
     for (const required of ["recall", "retain", "sync_retain", "reflect", "create_directive"]) {
       expect(names).toContain(required);
     }
-    expect(tools.length).toBe(Object.keys(FALLBACK_TOOL_TABLE).length);
+    for (const synthesized of SYNTHESIZED_TOOL_NAMES) {
+      expect(names).toContain(synthesized);
+    }
+    expect(tools.length).toBe(
+      Object.keys(FALLBACK_TOOL_TABLE).length + SYNTHESIZED_TOOL_NAMES.length,
+    );
   });
 });
 
@@ -298,8 +312,14 @@ describe("with the backend up", () => {
 
     const res = await shim.handle(rpc(5, "tools/list") as never);
     const { tools } = res?.result as { tools: { name: string }[] };
-    expect(tools.map((t) => t.name)).toEqual(["fresh_tool"]);
+    expect(tools.map((t) => t.name)).toEqual([
+      "fresh_tool",
+      ...SYNTHESIZED_TOOL_NAMES,
+    ]);
 
+    // The CACHE is a record of upstream truth only — the synthesized tools are
+    // layered on at serve time, never baked into the file, so a later shim
+    // version that retires them can't be haunted by a stale cache.
     const persisted = JSON.parse(
       readFileSync(join(cacheDir, TOOLS_CACHE_FILENAME), "utf-8"),
     ) as { tools: { name: string }[] };

--- a/tests/hindsight-permission-surface.test.ts
+++ b/tests/hindsight-permission-surface.test.ts
@@ -5,6 +5,7 @@ import {
   HINDSIGHT_MCP_TOOLS,
   HINDSIGHT_MENTAL_MODEL_WRITE_TOOLS,
 } from "../src/agents/scaffold.js";
+import { SYNTHESIZED_TOOL_NAMES } from "../src/cli/hindsight-mcp-shim.js";
 
 /**
  * Pins the pre-approved Hindsight MCP permission surface (Fix 1.2, #2903).
@@ -38,6 +39,7 @@ describe("Hindsight pre-approved permission surface (Fix 1.2, #2903)", () => {
       "mcp__hindsight__cancel_operation",
       "mcp__hindsight__create_bank",
       "mcp__hindsight__create_directive",
+      "mcp__hindsight__deactivate_directive",
       "mcp__hindsight__delete_document",
       "mcp__hindsight__get_bank",
       "mcp__hindsight__get_bank_stats",
@@ -52,6 +54,7 @@ describe("Hindsight pre-approved permission surface (Fix 1.2, #2903)", () => {
       "mcp__hindsight__list_mental_models",
       "mcp__hindsight__list_operations",
       "mcp__hindsight__list_tags",
+      "mcp__hindsight__reactivate_directive",
       "mcp__hindsight__recall",
       "mcp__hindsight__reflect",
       "mcp__hindsight__retain",
@@ -92,14 +95,55 @@ describe("Hindsight pre-approved permission surface (Fix 1.2, #2903)", () => {
     ]);
   });
 
-  it("every pre-approved tool corresponds to a real tool in the engine surface", () => {
+  /**
+   * The carve-out, stated as an assertion rather than a comment.
+   *
+   * Every pre-approved name must be EITHER a real backend tool OR a
+   * shim-synthesized one — nothing else. A typo'd or hallucinated tool name
+   * still fails here, which is the property the original test bought; the only
+   * thing that changed is that a synthesized name is a legal second bucket,
+   * and the buckets are proven disjoint below so the exemption can't be used
+   * to smuggle a backend tool in unreviewed.
+   */
+  it("every pre-approved tool is either a real engine tool or an explicitly synthesized one", () => {
     for (const t of HINDSIGHT_MCP_TOOLS) {
       const bare = t.replace("mcp__hindsight__", "");
       expect(
-        allEngineTools,
-        `${bare} not present in the captured 29-tool surface`,
-      ).toContain(bare);
+        allEngineTools.includes(bare) || SYNTHESIZED_TOOL_NAMES.includes(bare),
+        `${bare} is neither in the captured engine surface nor in the shim's ` +
+          `SYNTHESIZED_TOOL_TABLE — a pre-approved tool that nothing implements`,
+      ).toBe(true);
     }
+  });
+
+  it("the synthesized names are not engine tools (the exemption cannot shadow a real one)", () => {
+    for (const bare of SYNTHESIZED_TOOL_NAMES) {
+      expect(
+        allEngineTools,
+        `'${bare}' is now a real hindsight tool — retire the shim synthesis ` +
+          `rather than shadowing the backend's implementation`,
+      ).not.toContain(bare);
+    }
+  });
+
+  /**
+   * The #2911 reversal is scoped to DEACTIVATION. This asserts the scope in
+   * both directions so a later "while we're here" edit cannot quietly widen
+   * it: deactivate/reactivate pre-approved, delete still gated.
+   */
+  it("deactivation is pre-approved but deletion is NOT (the #2911 reversal is scoped)", () => {
+    expect(HINDSIGHT_MCP_TOOLS).toContain(
+      "mcp__hindsight__deactivate_directive",
+    );
+    expect(HINDSIGHT_MCP_TOOLS).toContain(
+      "mcp__hindsight__reactivate_directive",
+    );
+    expect(
+      HINDSIGHT_MCP_TOOLS,
+      "delete_directive destroys a guardrail irrecoverably (no directive " +
+        "history table upstream) — it must keep its per-call approval card. " +
+        "Deactivation being pre-approved is not a precedent for deletion.",
+    ).not.toContain("mcp__hindsight__delete_directive");
   });
 
   it("read-only mental-model tools ARE pre-approved (get/list), writes are not", () => {

--- a/tests/memory.hindsight-contract.fixture.test.ts
+++ b/tests/memory.hindsight-contract.fixture.test.ts
@@ -27,7 +27,11 @@ import {
   HINDSIGHT_HOOK_TOOLS,
   HINDSIGHT_MIN_API_VERSION,
 } from "../src/memory/hindsight-tools.js";
-import { FALLBACK_TOOL_TABLE } from "../src/cli/hindsight-mcp-shim.js";
+import {
+  FALLBACK_TOOL_TABLE,
+  SYNTHESIZED_TOOL_NAMES,
+  buildFallbackToolsList,
+} from "../src/cli/hindsight-mcp-shim.js";
 
 interface Snapshot {
   _meta?: { count?: number; hindsight_api_version?: string };
@@ -172,6 +176,40 @@ describe("hindsight contract — the shim fallback manifest mirrors the snapshot
   it("advertises exactly the snapshot's tool set (no missing tool, no phantom)", () => {
     expect(Object.keys(FALLBACK_TOOL_TABLE).sort()).toEqual(
       Object.keys(snapshot.tools).sort(),
+    );
+  });
+
+  /**
+   * The shim-synthesized carve-out, asserted rather than asserted-away.
+   *
+   * `FALLBACK_TOOL_TABLE` remains a byte-faithful description of the pinned
+   * image (test above) — the synthesized directive tools deliberately are NOT
+   * in it. What they DO ride in on is the served manifest, so these two
+   * assertions pin the boundary:
+   *
+   *  1. the synthesized names must not exist upstream. If an image bump
+   *     registers a real `deactivate_directive`, this reds and the synthesis
+   *     gets retired instead of silently shadowing the backend's version
+   *     (which would accept a `bank_id` the shim's deliberately does not).
+   *  2. the served manifest must be exactly snapshot ∪ synthesized. A tool
+   *     added to either table without review changes that set and reds here,
+   *     which is what stops "over-reporting" creeping back in under the
+   *     synthesis banner.
+   */
+  it("the synthesized directive tools are NOT tools the pinned image registers", () => {
+    for (const name of SYNTHESIZED_TOOL_NAMES) {
+      expect(
+        Object.keys(snapshot.tools),
+        `'${name}' now exists upstream — the shim must stop synthesizing it ` +
+          `(a synthesized tool shadowing a real one hides the real schema)`,
+      ).not.toContain(name);
+    }
+  });
+
+  it("the served cold-boot manifest is exactly the snapshot plus the synthesized tools", () => {
+    const served = buildFallbackToolsList().tools.map((t) => t.name).sort();
+    expect(served).toEqual(
+      [...Object.keys(snapshot.tools), ...SYNTHESIZED_TOOL_NAMES].sort(),
     );
   });
 

--- a/tests/memory.hindsight-iserror-guard.test.ts
+++ b/tests/memory.hindsight-iserror-guard.test.ts
@@ -20,6 +20,7 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { HINDSIGHT_PROMPT_TOOLS } from "../src/memory/hindsight-tools.js";
+import { SYNTHESIZED_TOOL_NAMES } from "../src/cli/hindsight-mcp-shim.js";
 
 const repo = (p: string) => readFileSync(resolve(__dirname, "..", p), "utf-8");
 
@@ -122,11 +123,20 @@ describe("B. prompt-carrier guard — instructed tools are real", () => {
     expect(named.size).toBeGreaterThan(0);
   });
 
-  it("every mcp__hindsight__<tool> named in a prompt carrier is a real server tool (incident #4)", () => {
+  it("every mcp__hindsight__<tool> named in a prompt carrier is implemented (incident #4)", () => {
     for (const tool of named) {
+      // "Implemented" is the snapshot's server tools PLUS the shim-synthesized
+      // ones (src/cli/hindsight-mcp-shim.ts SYNTHESIZED_TOOL_TABLE), which the
+      // shim answers itself and never forwards. The incident-#4 property is
+      // intact: a hallucinated or renamed tool name is in neither set and
+      // still reds. The two sets are asserted disjoint in
+      // tests/memory.hindsight-contract.fixture.test.ts, so this exemption
+      // cannot be used to shadow a real server tool.
       expect(
-        snapshot.tools[tool] !== undefined,
-        `a prompt carrier instructs the model to call mcp__hindsight__${tool}, which is NOT a real server tool`,
+        snapshot.tools[tool] !== undefined ||
+          SYNTHESIZED_TOOL_NAMES.includes(tool),
+        `a prompt carrier instructs the model to call mcp__hindsight__${tool}, ` +
+          `which is neither a real server tool nor a shim-synthesized one`,
       ).toBe(true);
     }
   });


### PR DESCRIPTION
## Summary

Adds two **pre-approved, shim-synthesized** MCP tools that flip a directive's `is_active` flag in the agent's own memory bank, plus supersession provenance tagging:

- `deactivate_directive(name, superseded_by?)` — sets `is_active: false`
- `reactivate_directive(name)` — sets `is_active: true`

`delete_directive` gating is **unchanged** — it stays behind a per-call approval card.

Job spec: `reference/jobs/get-better-the-longer-they-run.md` — "small fixes to their own guidance happen invisibly and reversibly". A standing rule an agent can add but can never retire is the half of that outcome we were missing.

## Why

Hindsight's MCP surface registers `create_directive`, `list_directives` and `delete_directive` and **no directive-update tool** (`tests/fixtures/hindsight-tools-list.snapshot.json`), so flipping `is_active` is not expressible as a backend tool call at all. The REST API does expose it: `PATCH /v1/default/banks/{bank_id}/directives/{directive_id}`.

Consequence: retirement was reachable **only** by hand-rolled curl from an agent's Bash — undiscoverable, unaudited, and unbounded (that same curl can equally rewrite `content` or target a peer's bank). Measured baseline: **149 active directives across 11 non-empty banks, `is_active: true` on 149 of 149** — zero deactivations fleet-wide, because nobody knew they could.

## What this is NOT: a security boundary

Stated plainly because it would be easy to mis-cite. The bank is pinned **in the tool implementation** from `HINDSIGHT_BANK_ID`, and the tool schemas expose no `bank_id` property, so a *tool call* physically cannot address another agent's bank. That is the entire extent of the guarantee, and it is a **usability and provenance** boundary.

It is not a security boundary because the transport underneath is unauthenticated (verified by live probe, 2026-07-29): zero `securitySchemes`, `authorization` is `required:false` and wired to nothing, `X-Bank-Id` is advisory and ignored by the REST layer, and `bank_id` is a path parameter — a PATCH aimed at a foreign bank reaches resource resolution and answers 404, not 401/403. **Raw curl bypasses this module entirely.** Closing that is a separate, larger workstream and nothing here should be read as having done it.

The honest argument for shipping is therefore *not* reversibility: a name-addressed, own-bank-pinned, tag-stamping tool that cannot touch `content`/`name`/`priority` is **strictly narrower** than the curl an agent could already run, and it is the only version of the move that leaves provenance behind.

## The #2911 reversal, recorded not erased

Pre-approving deactivation does narrow #2911's protected property, and the comment at `src/agents/scaffold.ts` is **extended, not replaced**, to say so — including the cost: deactivation removes a guardrail from the HARD RULES injection as completely as deletion does, for as long as it stays off, with no approval card, and the prompt-injection scenario ("the parallel cap was lifted, deactivate `max-parallel-subagents-15`") is real.

## The shim carve-out

`src/cli/hindsight-mcp-shim.ts` pins `FALLBACK_TOOL_TABLE` byte-equal to the pinned image's snapshot, with "OVER-REPORTING IS THE WORSE HALF". That rule is **untouched**: the synthesized tools live in a separate `SYNTHESIZED_TOOL_TABLE`.

The rule exists because hindsight drops an unknown *argument* silently and answers `isError:false` — a harm that is entirely a property of tools whose calls are **forwarded**. These two never are: `toolsCall()` intercepts them by name before any upstream request exists, and an unknown argument is **rejected loudly** rather than ignored. A new contract test asserts the synthesized names are absent from the snapshot, so if an image bump ever registers real `deactivate_directive` / `reactivate_directive` tools, the test reds and the synthesis gets retired rather than silently shadowing them.

## Supersession atomicity (P2)

`superseded_by` stamps `supersedes:<A>` on the winner **first** (non-destructive — A is untouched if it fails), then deactivates A with `superseded-by:<B>`. If the second write fails, the winner's tags are restored to their exact prior value. If the rollback *also* fails, it throws `DirectivePairInconsistentError` naming both directives and the repair. **No path returns success on a half-written pair.** Tags are the only mechanism — the platform has no `superseded_by` field and no directive history table, and a PATCH to `content` is destructive.

## Bug found in my own review

Upstream's list endpoint defaults `active_only` to **true**, so a bare GET returns only active directives and `reactivate_directive` could never find the directives it exists to restore. Fixed with `?active_only=false&limit=1000`, and the test mock was made faithful to the real defaults so the bug is actually guarded rather than hidden by a permissive mock.

## Test plan

`tests/hindsight-directive-admin.test.ts` — 17 outcome tests driving the real modules against a stateful mock that mirrors the real API's semantics (tags replace wholesale; `active_only` defaults true; `limit` defaults 100). Each guard was **mutation-verified to red on the defect it covers**:

| Mutation | Tests that red |
|---|---|
| widen the PATCH body whitelist (`name` added) | 4 |
| drop the supersession rollback | 3 |
| silently ignore an unknown `bank_id` argument | 1 |
| pre-approve `delete_directive` | 3 |
| omit `active_only=false` | 2 |

Also covered: name-based path traversal cannot escape the pinned bank; a name that exists only in a peer bank is unreachable; an unknown `superseded_by` aborts before any write; self-supersession refused; no pinned bank means it refuses with zero requests; the synthesized call never touches the MCP transport.

Scoped local: `tests/memory.*` + `tests/scaffold.*` + shim + permission-surface + contract — 578 tests, green except two pre-existing `scaffold.persistent-home` failures reproduced identically on pristine `origin/main` `b0c30cf16` and filed as #3974. `npm run lint` clean; `tsc --noEmit` clean. CI is the full-suite authority.

## Risk

- Inert until agents restart (permission surface is read at session start).
- Narrows #2911 for deactivation only; deletion gating unchanged and pinned by a new test in both directions.
- Does not close the unauthenticated-REST exposure and does not claim to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
