### PR TITLE
fix(hindsight): bind the tokenless API to loopback under --network host

### DIFF
--- a/src/setup/hindsight-loopback-bind.test.ts
+++ b/src/setup/hindsight-loopback-bind.test.ts
@@ -1,0 +1,361 @@
+/**
+ * The hindsight API must never be reachable off host loopback — on ANY launch
+ * path, under ANY configuration.
+ *
+ * The API is TOKENLESS: no securitySchemes, no bearer check, `GET
+ * /v1/default/banks` enumerates every agent's bank and PATCH mutates them. The
+ * ONLY thing keeping the fleet's memory off the LAN and the tailnet is where
+ * the listener binds.
+ *
+ * On 2026-07-29 it was answering unauthenticated on `0.0.0.0:18888` across the
+ * host's LAN and Tailscale addresses. The containment was written as
+ * `-p 127.0.0.1:<port>:8888`, which docker IGNORES under `--network host`, and
+ * the host-network branches pinned `HINDSIGHT_API_PORT` without ever pinning
+ * `HINDSIGHT_API_HOST` — so the image default `0.0.0.0` won. The bridge path
+ * was safe; the host path silently was not.
+ *
+ * These tests therefore do NOT assert "the string appears in the branch that
+ * was edited" — that passes while a sibling branch stays wide open, which is
+ * exactly how this shipped. They compute the EXPOSURE VERDICT of the real
+ * artefacts (`docker run` argv from `startHindsight`, and the compose snippet)
+ * across the whole space of configurations that select host networking, and
+ * fail if any of them can be produced without a loopback bind.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+const { execFileSyncMock } = vi.hoisted(() => ({ execFileSyncMock: vi.fn() }));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, execFileSync: execFileSyncMock };
+});
+
+import {
+  startHindsight,
+  generateHindsightComposeSnippet,
+  hindsightNeedsHostNetwork,
+  hindsightContainerEnvPairs,
+  HINDSIGHT_DEFAULT_API_PORT,
+  HINDSIGHT_DEFAULT_UI_PORT,
+  type HindsightLlmConfig,
+  type LiteLLMHindsightConfig,
+} from "./hindsight.js";
+
+const API_PORT = HINDSIGHT_DEFAULT_API_PORT;
+const UI_PORT = HINDSIGHT_DEFAULT_UI_PORT;
+/** Loopback literals a bind address may legitimately be. Nothing else counts. */
+const LOOPBACK = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
+
+beforeEach(() => {
+  execFileSyncMock.mockReset();
+  execFileSyncMock.mockReturnValue(Buffer.from(""));
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+type Case = {
+  name: string;
+  llm?: HindsightLlmConfig;
+  litellm?: LiteLLMHindsightConfig;
+};
+
+const litellmCfg = (baseUrl: string): LiteLLMHindsightConfig => ({
+  baseUrl,
+  apiKey: "sk-" + "test-not-a-real-key",
+  model: "claude-sonnet-5",
+});
+
+/**
+ * Every configuration that puts hindsight on the host network stack — the two
+ * originally-separate code paths (explicit LiteLLM config; per-op loopback
+ * base URL with no LiteLLM config) and each per-op lane, so a fix applied to
+ * one branch and forgotten in another goes red here.
+ */
+const HOST_NETWORK_CASES: Case[] = [
+  { name: "explicit litellm config (loopback)", litellm: litellmCfg("http://127.0.0.1:4010") },
+  { name: "explicit litellm config (remote)", litellm: litellmCfg("https://litellm.example.com") },
+  {
+    name: "per-op loopback base: retain",
+    llm: { retain: { base_url: "http://127.0.0.1:4010", model: "m" } },
+  },
+  {
+    name: "per-op loopback base: reflect",
+    llm: { reflect: { base_url: "http://localhost:4010", model: "m" } },
+  },
+  {
+    name: "per-op loopback base: consolidation",
+    llm: { consolidation: { base_url: "http://[::1]:4010", model: "m" } },
+  },
+  {
+    name: "per-op loopback base + non-claude provider",
+    llm: {
+      provider: "openai",
+      model: "gpt-4o",
+      reflect: { base_url: "http://127.0.0.1:11434/v1", model: "gpt-4o" },
+    },
+  },
+  {
+    name: "litellm config AND per-op loopback base",
+    litellm: litellmCfg("http://127.0.0.1:4010"),
+    llm: { consolidation: { base_url: "http://127.0.0.1:11434/v1", model: "m" } },
+  },
+];
+
+/** Configurations that stay on the bridge — the `-p` publish must confine them. */
+const BRIDGE_CASES: Case[] = [
+  { name: "no llm config at all" },
+  { name: "remote per-op base only", llm: { reflect: { base_url: "https://api.openai.com/v1" } } },
+];
+
+/** The real `docker run` argv `startHindsight` would execute. */
+function dockerRunArgv(c: Case): string[] {
+  execFileSyncMock.mockReset();
+  execFileSyncMock.mockReturnValue(Buffer.from(""));
+  startHindsight(
+    { apiPort: API_PORT, uiPort: UI_PORT },
+    c.litellm,
+    undefined,
+    c.llm,
+    undefined,
+    false,
+    { env: {}, processEnv: {} as NodeJS.ProcessEnv },
+  );
+  const run = execFileSyncMock.mock.calls
+    .map((call) => call[1] as string[])
+    .filter((argv) => Array.isArray(argv) && argv[0] === "run");
+  expect(run.length).toBe(1);
+  return run[0];
+}
+
+function envFromArgv(argv: string[]): Map<string, string> {
+  const out = new Map<string, string>();
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] !== "-e") continue;
+    const pair = argv[i + 1] ?? "";
+    const eq = pair.indexOf("=");
+    if (eq > 0) out.set(pair.slice(0, eq), pair.slice(eq + 1));
+  }
+  return out;
+}
+
+/** `-p` values, e.g. `127.0.0.1:18888:8888`. */
+function publishesFromArgv(argv: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "-p" || argv[i] === "--publish") out.push(argv[i + 1] ?? "");
+  }
+  return out;
+}
+
+function hasHostNetworkArg(argv: string[]): boolean {
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--network" && argv[i + 1] === "host") return true;
+    if (argv[i] === "--network=host" || argv[i] === "--net=host") return true;
+  }
+  return false;
+}
+
+/**
+ * Does this launch expose the tokenless API beyond host loopback?
+ *
+ * Host network: `-p` is inert, so the verdict is the application's own bind
+ * address. Absent ⇒ the image default `0.0.0.0` ⇒ exposed. That absence IS the
+ * bug this file exists for.
+ *
+ * Bridge: the container binds inside its own netns, so the verdict is whether
+ * every published mapping pins a loopback host-side address.
+ */
+function exposesBeyondLoopback(a: {
+  hostNetwork: boolean;
+  env: Map<string, string>;
+  publishes: string[];
+}): boolean {
+  if (a.hostNetwork) {
+    const bind = a.env.get("HINDSIGHT_API_HOST");
+    return bind === undefined || !LOOPBACK.has(bind.trim());
+  }
+  if (a.publishes.length === 0) return false;
+  return a.publishes.some((p) => {
+    const parts = p.split(":");
+    // `host:hostPort:containerPort` is confined; anything shorter publishes on
+    // every interface.
+    if (parts.length < 3) return true;
+    return !LOOPBACK.has(parts.slice(0, parts.length - 2).join(":"));
+  });
+}
+
+/** Compose snippet reduced to the same three facts. */
+function analyzeCompose(yaml: string) {
+  const lines = yaml.split("\n").map((l) => l.trim());
+  const env = new Map<string, string>();
+  for (const line of lines) {
+    const m = /^-\s+([A-Z0-9_]+)=(.*)$/.exec(line);
+    if (m) env.set(m[1], m[2]);
+  }
+  const publishes = lines
+    .map((l) => /^-\s+"(.+)"$/.exec(l)?.[1])
+    .filter((v): v is string => !!v && /^[^\s]*:?\d+:\d+$/.test(v));
+  return {
+    hostNetwork: lines.includes("network_mode: host"),
+    env,
+    publishes,
+  };
+}
+
+describe("hindsight API bind — host-network launches", () => {
+  it.each(HOST_NETWORK_CASES.map((c) => [c.name, c] as const))(
+    "%s: docker run cannot be produced without a loopback bind",
+    (_name, c) => {
+      // Precondition: this case really does select host networking, so the
+      // assertion below cannot pass by accidentally testing the bridge path.
+      expect(hindsightNeedsHostNetwork(c.llm, c.litellm)).toBe(true);
+      const argv = dockerRunArgv(c);
+      expect(hasHostNetworkArg(argv)).toBe(true);
+      const env = envFromArgv(argv);
+      expect(
+        exposesBeyondLoopback({ hostNetwork: true, env, publishes: publishesFromArgv(argv) }),
+      ).toBe(false);
+      // Spelled out, so the verdict helper itself can't be gutted silently.
+      expect(env.get("HINDSIGHT_API_HOST")).toBe("127.0.0.1");
+      // ...and the port pin still rides along, or the API binds 8888 on the
+      // shared host stack and every agent's memory.config.url points at a dead
+      // port (the 2026-07 outage).
+      expect(env.get("HINDSIGHT_API_PORT")).toBe(String(API_PORT));
+    },
+  );
+
+  it.each(HOST_NETWORK_CASES.map((c) => [c.name, c] as const))(
+    "%s: the compose snippet cannot be produced without a loopback bind",
+    (_name, c) => {
+      const snippet = generateHindsightComposeSnippet(c.llm, undefined, c.litellm, false, {
+        env: {},
+        processEnv: {} as NodeJS.ProcessEnv,
+      });
+      const a = analyzeCompose(snippet);
+      expect(a.hostNetwork).toBe(true);
+      expect(exposesBeyondLoopback(a)).toBe(false);
+      expect(a.env.get("HINDSIGHT_API_HOST")).toBe("127.0.0.1");
+      expect(a.env.get("HINDSIGHT_API_PORT")).toBe(String(API_PORT));
+    },
+  );
+
+  it("docker-run and compose agree on the bind for every host-network config", () => {
+    // The twin property: the two generators may not disagree about where the
+    // tokenless API listens. A fix applied to one is not a fix.
+    for (const c of HOST_NETWORK_CASES) {
+      const runEnv = envFromArgv(dockerRunArgv(c));
+      const composeEnv = analyzeCompose(
+        generateHindsightComposeSnippet(c.llm, undefined, c.litellm, false, {
+          env: {},
+          processEnv: {} as NodeJS.ProcessEnv,
+        }),
+      ).env;
+      expect([c.name, composeEnv.get("HINDSIGHT_API_HOST")]).toEqual([
+        c.name,
+        runEnv.get("HINDSIGHT_API_HOST"),
+      ]);
+      expect([c.name, composeEnv.get("HINDSIGHT_API_PORT")]).toEqual([
+        c.name,
+        runEnv.get("HINDSIGHT_API_PORT"),
+      ]);
+    }
+  });
+
+  it("the pure env derivation carries the bind for every host-network config", () => {
+    // `hindsightContainerEnvPairs` is what `switchroom memory setup --recreate`
+    // diffs against the live container, so a bind missing HERE means a
+    // recreate silently drops the containment off a running container.
+    for (const c of HOST_NETWORK_CASES) {
+      const env = new Map(
+        hindsightContainerEnvPairs({
+          apiPort: API_PORT,
+          litellm: c.litellm,
+          llm: c.llm,
+          gpu: false,
+          perf: { env: {}, processEnv: {} as NodeJS.ProcessEnv },
+        }),
+      );
+      expect([c.name, env.get("HINDSIGHT_API_HOST")]).toEqual([c.name, "127.0.0.1"]);
+    }
+  });
+});
+
+describe("hindsight API bind — bridge launches", () => {
+  it.each(BRIDGE_CASES.map((c) => [c.name, c] as const))(
+    "%s: publishes only on host loopback",
+    (_name, c) => {
+      expect(hindsightNeedsHostNetwork(c.llm, c.litellm)).toBe(false);
+      const argv = dockerRunArgv(c);
+      expect(hasHostNetworkArg(argv)).toBe(false);
+      const publishes = publishesFromArgv(argv);
+      expect(publishes).toContain(`127.0.0.1:${API_PORT}:8888`);
+      expect(
+        exposesBeyondLoopback({ hostNetwork: false, env: envFromArgv(argv), publishes }),
+      ).toBe(false);
+
+      const a = analyzeCompose(
+        generateHindsightComposeSnippet(c.llm, undefined, c.litellm, false, {
+          env: {},
+          processEnv: {} as NodeJS.ProcessEnv,
+        }),
+      );
+      expect(a.hostNetwork).toBe(false);
+      expect(a.publishes).toContain(`127.0.0.1:${API_PORT}:8888`);
+      expect(exposesBeyondLoopback(a)).toBe(false);
+    },
+  );
+});
+
+describe("the exposure verdict itself", () => {
+  // Without these, the helper above could be mutated to `return false` and the
+  // whole file would stay green.
+  it("calls an absent bind exposed under host networking", () => {
+    expect(
+      exposesBeyondLoopback({
+        hostNetwork: true,
+        env: new Map([["HINDSIGHT_API_PORT", String(API_PORT)]]),
+        publishes: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("calls a 0.0.0.0 bind exposed under host networking", () => {
+    expect(
+      exposesBeyondLoopback({
+        hostNetwork: true,
+        env: new Map([["HINDSIGHT_API_HOST", "0.0.0.0"]]),
+        publishes: [`127.0.0.1:${API_PORT}:8888`],
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores -p under host networking, the way docker does", () => {
+    // The exact false-confidence that shipped the bug: loopback `-p` flags on
+    // a `--network host` container mean nothing.
+    expect(
+      exposesBeyondLoopback({
+        hostNetwork: true,
+        env: new Map(),
+        publishes: [`127.0.0.1:${API_PORT}:8888`, `127.0.0.1:${UI_PORT}:9999`],
+      }),
+    ).toBe(true);
+  });
+
+  it("calls an unqualified bridge publish exposed", () => {
+    expect(
+      exposesBeyondLoopback({
+        hostNetwork: false,
+        env: new Map(),
+        publishes: [`${API_PORT}:8888`],
+      }),
+    ).toBe(true);
+    expect(
+      exposesBeyondLoopback({
+        hostNetwork: false,
+        env: new Map(),
+        publishes: [`0.0.0.0:${API_PORT}:8888`],
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -1316,6 +1316,53 @@ export function hindsightNeedsHostNetwork(
 }
 
 /**
+ * Address the hindsight API binds under `--network host`.
+ *
+ * The hindsight API is **TOKENLESS** — no auth, no securitySchemes, every
+ * bank readable and writable by anyone who can open the socket. On the bridge
+ * path that is contained by publishing `127.0.0.1:<port>:8888`, but
+ * `--network host` makes docker ignore `-p` entirely, so the `-p` flags are
+ * not a control there: the only thing standing between the fleet's memory and
+ * the LAN/tailnet is the address the application itself binds. The image
+ * defaults to `0.0.0.0`.
+ */
+export const HINDSIGHT_HOST_NETWORK_BIND_ADDR = "127.0.0.1";
+
+/**
+ * THE bind pins every `--network host` hindsight launch must carry.
+ *
+ * Under host networking the container has no netns of its own, so the
+ * listener's address and port are host-visible facts rather than
+ * container-internal ones, and `-p` publishing (the bridge path's loopback
+ * containment) is silently ignored by docker. Every host-network path —
+ * `startHindsight`'s docker-run argv and the compose snippet alike — takes
+ * its bind from here so the containment cannot be present on one and
+ * forgotten on the other. Emitting it from the branches themselves is exactly
+ * how the API ended up answering unauthenticated on `0.0.0.0:18888`.
+ */
+export function hindsightHostNetworkBindEnvPairs(
+  apiPort: number,
+): Array<[string, string]> {
+  return [
+    // Bind loopback only. See HINDSIGHT_HOST_NETWORK_BIND_ADDR: the API has no
+    // auth, so a 0.0.0.0 bind on the host stack publishes every agent's memory
+    // bank to the LAN and the tailnet.
+    ["HINDSIGHT_API_HOST", HINDSIGHT_HOST_NETWORK_BIND_ADDR],
+    // HINDSIGHT_API_PORT is the only port knob the upstream config.py
+    // recognizes; the CP service has no equivalent env var override. Without
+    // it the image default 8888 binds on the shared host stack.
+    ["HINDSIGHT_API_PORT", String(apiPort)],
+    // The CP dashboard's dataplane calls resolve `localhost:<port>` against
+    // host-bound listeners. The image default is `http://localhost:8888`, but
+    // 8888 is where we MOVED OFF (squatted by an unrelated container → the
+    // dashboard's data calls 502 while the API is healthy on the API port).
+    // Pin it to the SAME port the API actually binds so it tracks any
+    // auto-bump instead of the stale 8888 default.
+    ["HINDSIGHT_CP_DATAPLANE_API_URL", `http://localhost:${apiPort}`],
+  ];
+}
+
+/**
  * Whether hindsight's LLM traffic terminates on a self-hosted endpoint.
  *
  * The capability gate for the LLM concurrency caps (see
@@ -1784,11 +1831,18 @@ export function hindsightContainerEnvPairs(opts: {
     pairs.push(["ANTHROPIC_MODEL", llmModel]);
   }
 
+  // Host-network mode: the container shares the host network stack so
+  // 127.0.0.1:4010 (LiteLLM) is directly reachable, identical to how agent
+  // containers work — and, because `--network host` makes docker IGNORE `-p`,
+  // the listener's address and port become the container's own business. Both
+  // come from ONE helper, emitted from the single `hindsightNeedsHostNetwork`
+  // test, so no launch path can pick up host networking without also picking
+  // up the loopback bind. See {@link hindsightHostNetworkBindEnvPairs}.
+  if (hindsightNeedsHostNetwork(llm, litellm)) {
+    pairs.push(...hindsightHostNetworkBindEnvPairs(apiPort));
+  }
+
   if (litellm) {
-    // Host-network mode: the container shares the host network stack so
-    // 127.0.0.1:4010 (LiteLLM) is directly reachable, identical to how
-    // agent containers work. Explicit port env vars preserve the same
-    // external ports (18888/19999) the operator is used to.
     const litellmRoot = litellm.baseUrl.replace(/\/+$/, "");
     // Claude models ride the Anthropic pass-through (<root>/anthropic,
     // raw byte-forward, OAuth) — the model-mapped route re-chunks the SSE
@@ -1800,18 +1854,6 @@ export function hindsightContainerEnvPairs(opts: {
       ? `${litellmRoot}/anthropic`
       : litellmRoot;
     pairs.push(
-      // HINDSIGHT_API_PORT is the only port knob the upstream config.py
-      // recognizes; the CP service has no equivalent env var override.
-      ["HINDSIGHT_API_PORT", String(apiPort)],
-      // In host-network mode the container shares the host's network stack,
-      // so the CP dashboard's dataplane calls resolve `localhost:<port>`
-      // against host-bound listeners. The image default for the dataplane
-      // URL is `http://localhost:8888`, but 8888 is where we MOVED OFF (it's
-      // squatted on this host by an unrelated container → the dashboard's
-      // data calls 502 while the API is healthy on the API port). Pin the CP
-      // dataplane URL to the SAME port the API actually binds so it tracks
-      // any auto-bump instead of the stale 8888 default.
-      ["HINDSIGHT_CP_DATAPLANE_API_URL", `http://localhost:${apiPort}`],
       // LiteLLM routing: inherited by the claude_agent_sdk subprocess so
       // consolidation/reflect calls hit the proxy for spend tracking.
       ["ANTHROPIC_BASE_URL", anthropicBaseUrl],
@@ -1819,14 +1861,6 @@ export function hindsightContainerEnvPairs(opts: {
         "ANTHROPIC_CUSTOM_HEADERS",
         `x-litellm-api-key: Bearer ${litellm.apiKey}\nx-litellm-customer-id: hindsight\nx-litellm-tags: service:hindsight`,
       ],
-    );
-  } else if (hindsightNeedsHostNetwork(llm, litellm)) {
-    // When only per-op loopback bases forced host net (no full litellm cfg),
-    // still pin API/CP ports the way the litellm branch does — otherwise the
-    // image default 8888 binds on the shared host stack.
-    pairs.push(
-      ["HINDSIGHT_API_PORT", String(apiPort)],
-      ["HINDSIGHT_CP_DATAPLANE_API_URL", `http://localhost:${apiPort}`],
     );
   }
 
@@ -1932,12 +1966,20 @@ export function startHindsight(
   ];
 
   if (hindsightNeedsHostNetwork(llm, litellm)) {
-    // Host network: ports are published directly (no -p flags). Required so
-    // loopback LiteLLM (127.0.0.1:4010) is reachable from the container.
+    // Host network: ports are published directly (no -p flags — docker ignores
+    // them under `--network host`). Required so loopback LiteLLM
+    // (127.0.0.1:4010) is reachable from the container.
     args.push("--network", "host");
-    // (The API/CP port pins that host-network mode needs are emitted by
-    // hindsightContainerEnvPairs — see its host-network branch.)
+    // Because `-p` is inert here, the loopback containment the bridge branch
+    // below gets from `-p 127.0.0.1:...` has to come from the application's
+    // own bind address instead: HINDSIGHT_API_HOST=127.0.0.1, emitted with the
+    // API/CP port pins by hindsightContainerEnvPairs →
+    // hindsightHostNetworkBindEnvPairs. Without it the TOKENLESS API answers
+    // on 0.0.0.0 across the LAN and tailnet.
   } else {
+    // Bridge: bind to 127.0.0.1 on the host side only — the hindsight API is
+    // TOKENLESS, so publishing on 0.0.0.0 would expose the unauthenticated
+    // MCP/REST surface to the network.
     args.push(
       "-p", `127.0.0.1:${apiPort}:8888`,
       "-p", `127.0.0.1:${uiPort}:9999`,
@@ -2345,14 +2387,15 @@ export function generateHindsightComposeSnippet(
     // Mirror of the docker-run path: with the claude-code provider, pin
     // ANTHROPIC_MODEL to the same model for the underlying claude subprocess.
     ...(llmProvider === "claude-code" ? [`      - ANTHROPIC_MODEL=${llmModel}`] : []),
-    // Host-network: API binds HINDSIGHT_API_PORT on the shared host stack
-    // (and CP dataplane must track it so it doesn't hit squatted 8888).
-    // Bridge: API binds image-default 8888 inside the container netns.
+    // Host-network: the API binds HINDSIGHT_API_HOST:HINDSIGHT_API_PORT on the
+    // shared host stack (and CP dataplane must track the port so it doesn't hit
+    // squatted 8888). Taken from the SAME helper the docker-run path uses so
+    // the tokenless API cannot end up loopback-bound on one launch path and
+    // 0.0.0.0-bound on the other.
+    // Bridge: the API binds image-default 8888 inside the container netns, and
+    // the `ports:` mapping below is what confines it to host loopback.
     ...(hostNetwork
-      ? [
-          `      - HINDSIGHT_API_PORT=${apiPort}`,
-          `      - HINDSIGHT_CP_DATAPLANE_API_URL=http://localhost:${apiPort}`,
-        ]
+      ? hindsightHostNetworkBindEnvPairs(apiPort).map(([k, v]) => `      - ${k}=${v}`)
       : [`      - HINDSIGHT_CP_DATAPLANE_API_URL=http://localhost:8888`]),
   ];
   // Optional LiteLLM proxy env (ANTHROPIC_BASE_URL + spend-tag headers) —

--- a/tests/hindsight-env-keys-are-reachable.test.ts
+++ b/tests/hindsight-env-keys-are-reachable.test.ts
@@ -71,6 +71,13 @@ describe("promoted container-env keys are reachable from switchroom.yaml", () =>
     // stated reason the resolvers are scoped rather than a blanket passthrough.
     const DERIVED = new Set([
       "HINDSIGHT_API_PORT",
+      // The `--network host` bind address (hindsightHostNetworkBindEnvPairs).
+      // Deliberately NOT an operator knob: the hindsight API is tokenless, so
+      // this loopback pin is the only thing keeping every agent's memory bank
+      // off the LAN and the tailnet under host networking, where `-p` is inert.
+      // A `hindsight.env` line that could set it to 0.0.0.0 would be a
+      // footgun with no legitimate use on a single-host fleet.
+      "HINDSIGHT_API_HOST",
       "HINDSIGHT_API_LLM_PROVIDER",
       "HINDSIGHT_API_LLM_MODEL",
       "HINDSIGHT_API_WORKER_ID",


### PR DESCRIPTION
## Summary

`switchroom-hindsight` runs `--network host` on any fleet with LiteLLM (or any
per-op loopback base URL) configured, and in that mode the **tokenless**
hindsight API was binding `0.0.0.0`. Verified live before this change: HTTP 200
on the host's LAN address and its Tailscale address, `GET /v1/default/banks`
enumerating 29 banks, `Authorization: Bearer <garbage>` still 200, and a PATCH
into another agent's bank reaching resource resolution (404, not 401/403). `ufw`
is disabled on the host. The live OpenAPI spec has 0 `securitySchemes` and 0/57
paths carrying `security`.

This pins `HINDSIGHT_API_HOST=127.0.0.1` on every host-network launch path.

## Why

The loopback containment was expressed **only** as `-p 127.0.0.1:<port>:8888`,
and docker ignores `-p` entirely under `--network host`. Nothing replaced it:

- `src/setup/hindsight.ts` bridge branch published `-p 127.0.0.1:...` (safe),
  and the compose emitter's bridge branch says the intent out loud — *"the
  hindsight API is TOKENLESS, so publishing on 0.0.0.0 would expose the
  unauthenticated MCP/REST surface to the network."*
- The host-network branch pushed `--network host` and deliberately emitted no
  `-p` flags, because they would be inert.
- `hindsightContainerEnvPairs` pinned `HINDSIGHT_API_PORT` and
  `HINDSIGHT_CP_DATAPLANE_API_URL` in **both** host-network branches (the
  `if (litellm)` branch and the `else if (hindsightNeedsHostNetwork(...))`
  branch) and **never** `HINDSIGHT_API_HOST` — so the image default `0.0.0.0`
  won. `generateHindsightComposeSnippet` carried a **third**, independently
  written copy of the same host-network env block with the same omission.

So the bridge path was safe and the host path silently was not.

## What changed

- New `hindsightHostNetworkBindEnvPairs(apiPort)` — the one place the
  host-network bind pins (`HINDSIGHT_API_HOST`, `HINDSIGHT_API_PORT`,
  `HINDSIGHT_CP_DATAPLANE_API_URL`) are written.
- `hindsightContainerEnvPairs`: the two host-network branches collapse into a
  single `if (hindsightNeedsHostNetwork(llm, litellm))` that pushes those pairs;
  the `if (litellm)` branch keeps only the LiteLLM-specific `ANTHROPIC_*` vars.
  Structural, not disciplinary: a launch path cannot pick up host networking
  without picking up the bind, because both come off the same predicate.
- `generateHindsightComposeSnippet` renders its host-network env from the same
  helper, so the docker-run and compose twins cannot disagree about where the
  tokenless API listens.

Verified live that the image honours the var (Ken's manual recreate, below):
`/proc/net/tcp` inside the container shows `0100007F:49C8` — 127.0.0.1:18888 —
where it previously showed `00000000:49C8`.

## Scope — what this does NOT fix

- **Agent-to-agent access is unchanged and still open.** Every agent container
  is `network_mode: host`, so any agent can still curl every bank on
  `127.0.0.1:18888`. This closes the LAN/tailnet exposure only. Tracked
  separately; please don't read this PR as closing it.
- **The CP dashboard/UI (9999) is out of scope.** Under host networking it
  still binds `0.0.0.0` (`00000000:270F` on the live host). Filed as a
  follow-up rather than widened into this PR.

## Config drift to converge

Ken already applied this by hand on the live host, recreating the container with
`HINDSIGHT_API_HOST=127.0.0.1`. That is drift: **the next
`switchroom memory setup --recreate` reverts it until this PR ships.** Merging
here is what makes the manual change and the code agree.

## Strict network isolation — explicitly checked, not hidden

`networkIsolation: strict` (`src/agents/compose.ts:2089-2098`) puts an agent on
its own bridge network and reaches host services via
`host.docker.internal:host-gateway`, which resolves to the host's **bridge** IP,
not loopback. A loopback-bound hindsight is therefore unreachable from a
strict-mode agent.

That limitation is **pre-existing and unchanged by this PR**, in both directions:

- On the bridge hindsight path, `-p 127.0.0.1:18888:8888` already binds host
  loopback only, so a strict agent could not reach it there either. The same
  reasoning is already pinned for the auth-broker in
  `src/agents/compose-auth-broker-litellm.test.ts:79` ("a `host.docker.internal`
  address that cannot reach a loopback-bound port").
- Nothing rewrites a strict agent's `memory.config.url` away from
  `127.0.0.1:18888` — which in its own netns is its *own* loopback — so strict
  mode has never had a working hindsight path. `NetworkIsolationSchema` says as
  much: *"OPT-IN: validate hindsight / operator-LAN / cron / boot-self-test
  paths for your deployment before adopting fleet-wide."*
- `networkIsolation` appears zero times in this fleet's `switchroom.yaml`, so no
  live agent is affected.

Making strict mode reach hindsight needs a deliberate design (a host-gateway
listener with auth, or a per-agent proxy) — not a `0.0.0.0` bind on a tokenless
API.

## Behaviour change worth naming

A `litellm` config object whose `baseUrl` is empty/whitespace no longer receives
the host-network port pins on the docker-run path. `hindsightNeedsHostNetwork`
returns false for it, so that container runs on the **bridge**, where the pins
were actively wrong: they made the container bind 18888 while `-p` mapped the
host port onto 8888 and the healthcheck probed 8888. The compose emitter already
gated on `hindsightNeedsHostNetwork`, so this aligns docker-run to compose.
Unreachable in production — `resolveLiteLLMForHindsight`
(`src/cli/memory.ts:157`) returns `undefined` unless `base_url` is truthy.

## Test plan

New `src/setup/hindsight-loopback-bind.test.ts` asserts the **outcome** — "the
tokenless API is not reachable off host loopback" — not the presence of a string
in the branch that was edited (that form passes while a sibling branch stays
open, which is exactly how this shipped).

It computes an exposure verdict from the real artefacts (the `docker run` argv
`startHindsight` executes, captured through the `execFileSync` mock, plus the
generated compose snippet) across **every** configuration that selects host
networking — explicit LiteLLM config (loopback and remote), each per-op lane
(`retain` / `reflect` / `consolidation`), IPv4/`localhost`/IPv6 loopback
literals, non-Claude provider, and LiteLLM + per-op together — and fails if any
of them can be produced without a loopback bind. Under host networking the
verdict deliberately **ignores `-p`, the way docker does**. Bridge cases assert
the publish stays `127.0.0.1:...`. A twin test pins docker-run against compose,
and the verdict function has its own mutation tests so it cannot be gutted to
`return false` with the file staying green.

Proof it would have caught the bug: on the unfixed source, with only the test
added, **15 of 22 fail**; with the fix, 22/22 pass.

```
# unfixed src/setup/hindsight.ts + new test
Tests  15 failed | 7 passed (22)

# with the fix
./node_modules/.bin/vitest run src/setup/ tests/hindsight-env-keys-are-reachable.test.ts tests/docker/compose-generator.test.ts
Test Files  20 passed (20)
     Tests  603 passed (603)

./node_modules/.bin/tsc --noEmit        # clean
node scripts/check-no-pii-secrets.mjs   # clean
node scripts/check-agent-attribution-trailers.mjs  # OK
```

`tests/hindsight-env-keys-are-reachable.test.ts` needed `HINDSIGHT_API_HOST`
added to its `DERIVED` set: it is switchroom wiring, not an operator tuning
knob. `HINDSIGHT_PERF_ENV_KEYS` ignores keys outside the managed set, so
`hindsight.env` cannot override it — deliberately, since the only thing an
override could do is re-open this hole.

Pre-existing local failure, unrelated and untouched: 5 cases in
`tests/hindsight-drain-sidecar.test.ts` (a shell-harness suite for
`start.sh.hbs`) fail identically on pristine `origin/main` in this container,
including with an exec-capable `TMPDIR`. Filed as a follow-up; CI is the
authority for that suite.

## Risk

Low, and the failure mode is fail-closed. Every agent container on this fleet is
`network_mode: host`, so `127.0.0.1:18888` is reached unchanged; the web
dashboard is `network_mode: host` too. The live host has already been running
this exact bind since 2026-07-29 with no agent impact. A container is only
affected once it is recreated (`switchroom memory setup --recreate` /
`switchroom memory --restart`) — code is not runtime.

## Verdict rule

- **Advances**: `standing-team` — memory the fleet can trust is memory only the
  fleet can reach.
- **Job spec**: `reference/jobs/remember-across-sessions.md`, whose declared
  invariant is `single-tenant` — "the deployment is the trust boundary". An
  unauthenticated bank API on the LAN and the tailnet puts that boundary outside
  the deployment.
- **Principles**: docs test — the compose emitter already documented this exact
  intent, the host path just didn't implement it; defaults test — the safe bind
  is now the only bind; consistency test — one derivation for both launch paths
  instead of three.
- **Invariants**: crosses none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)