### PR TITLE
fix(hindsight): arm the control-plane dashboard login via HINDSIGHT_CP_ACCESS_KEY

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -589,6 +589,30 @@ hindsight:
 
 If you run your own Hindsight container outside `switchroom memory --start` (e.g. you point `memory.config.url` at an external server), switchroom doesn't manage that container's env — set the cap on your own image.
 
+### Logging in to the Hindsight dashboard (`hindsight.cp_access_key`)
+
+The Hindsight container also serves a **control-plane dashboard** (Next.js, host port 9999) alongside the memory API. That dashboard's login is armed by exactly one thing — upstream's `HINDSIGHT_CP_ACCESS_KEY`. When the variable is unset the access-key middleware short-circuits and lets every request through: the dashboard is not weakly protected, it has **no authentication at all**.
+
+Switchroom therefore treats an unset key as fail-closed, not as a default:
+
+```yaml
+hindsight:
+  cp_access_key: vault:hindsight_cp_access_key
+```
+
+Store the secret first (`switchroom vault set hindsight_cp_access_key`), then reference it. A literal string works too, but a `vault:` reference is the supported shape — it is read through the broker at container-launch time, the same path `litellm.admin_key` and `hindsight.llm.<op>.api_key` take.
+
+| `hindsight.cp_access_key` | Dashboard login | Where the dashboard listens |
+| --- | --- | --- |
+| set (literal, or a resolvable `vault:` ref) | armed — the access-key page guards every protected route | `0.0.0.0:9999` — reachable from the LAN and your tailnet |
+| unset, blank, or an unresolvable `vault:` ref | none | `HINDSIGHT_CP_HOSTNAME=127.0.0.1` — **host only**, plus a warning on every launch |
+
+The loopback pin is mechanical, not advisory: it is the same containment the tokenless memory API gets from `HINDSIGHT_API_HOST`, and it exists because `--network host` makes Docker ignore `-p` publishing entirely, so the process's own bind address is the only control left. Both launch paths — `switchroom memory --start` and the `switchroom memory docker-compose` snippet — derive it from one place, so they cannot disagree.
+
+An unresolvable vault reference counts as "no key" on purpose. A denied grant or a down broker must not degrade into serving an open dashboard to the network.
+
+Changing this takes effect on the next container recreate (`switchroom memory setup --recreate`), not live.
+
 ### GPU passthrough for the Hindsight container
 
 The local embedding model and the cross-encoder reranker run on the GPU when the container can see one. Switchroom decides that by reading `~/.switchroom/host-capabilities.json`, the verdict `switchroom setup` writes after probing the host: `--gpus all` is added only when that file proves **both** a GPU and the nvidia container toolkit. It has to be gated — `docker run --gpus all` hard-fails container create on a host without the toolkit.

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -29,6 +29,8 @@ import {
   getHindsightDeviceRequests,
   hindsightGpuDecision,
   resolveHindsightGpuOverride,
+  resolveHindsightCpAccessKey,
+  HINDSIGHT_CP_NO_ACCESS_KEY_WARNING,
   HINDSIGHT_DEFAULT_API_PORT,
   HINDSIGHT_DEFAULT_MCP_URL,
   type LiteLLMHindsightConfig,
@@ -728,6 +730,10 @@ export function registerMemoryCommand(program: Command): void {
               // The SAME GPU answer the launch will use, passed as a value.
               gpu: gpuDecision.enabled,
               perf: driftPerf,
+              // The SAME CP access key the launch below resolves — otherwise
+              // the drift report reads HINDSIGHT_CP_ACCESS_KEY as "about to be
+              // dropped" on every recreate of a protected dashboard.
+              cpAccessKey: await resolveHindsightCpAccessKey(driftConfig),
             });
             const dropped = diffDroppedHindsightEnv(
               liveEnv,
@@ -915,6 +921,8 @@ export function registerMemoryCommand(program: Command): void {
       try {
         const hindsightConfig = getConfig(program);
         const litellmCfg = await resolveLiteLLMForHindsight(hindsightConfig);
+        const cpAccessKey = await resolveHindsightCpAccessKey(hindsightConfig);
+        if (!cpAccessKey) console.log(chalk.yellow(`  ! ${HINDSIGHT_CP_NO_ACCESS_KEY_WARNING}`));
         startHindsight(
           ports,
           litellmCfg,
@@ -928,6 +936,9 @@ export function registerMemoryCommand(program: Command): void {
           gpuDecision.enabled,
           // Operator overrides for the capability-gated performance defaults.
           { env: hindsightConfig.hindsight?.env },
+          // Resolved `hindsight.cp_access_key`. Absent ⇒ the CP dashboard has
+          // no login, so hindsightCpAuthEnvPairs pins it to loopback.
+          cpAccessKey,
         );
         if (litellmCfg) {
           console.log(chalk.gray("  LiteLLM routing enabled for hindsight (--network host)."));
@@ -964,10 +975,19 @@ export function registerMemoryCommand(program: Command): void {
   memory
     .command("docker-compose")
     .description("Output a docker-compose snippet for Hindsight (broker-fed mode)")
-    .action(() => {
+    // Async now that the CP access key is resolved through the vault broker;
+    // withConfigError keeps a bad switchroom.yaml a friendly message rather
+    // than an unhandled rejection (the sibling `memory` subcommands' shape).
+    .action(withConfigError(async () => {
       console.log(chalk.bold("\n# Add this to your docker-compose.yml:\n"));
       {
         const snippetConfig = getConfig(program);
+        // Same resolve + same warning as the docker-run path: a compose
+        // deployment must not be the one that quietly serves an open dashboard.
+        const cpAccessKey = await resolveHindsightCpAccessKey(snippetConfig);
+        if (!cpAccessKey) {
+          console.error(chalk.yellow(`# ! ${HINDSIGHT_CP_NO_ACCESS_KEY_WARNING}`));
+        }
         console.log(
           generateHindsightComposeSnippet(
             snippetConfig.hindsight?.llm,
@@ -980,11 +1000,12 @@ export function registerMemoryCommand(program: Command): void {
               resolveHindsightGpuOverride({ config: snippetConfig.hindsight?.gpu }),
             ).enabled,
             { env: snippetConfig.hindsight?.env },
+            cpAccessKey,
           ),
         );
       }
       console.log();
-    });
+    }));
 
   // switchroom memory repair — reachability for hindsight 0.8.5's
   // `hindsight-admin repair-bank`. A bank that arrived already populated

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -38,7 +38,9 @@ import {
   hindsightConsumerMirrorDir,
   stopHindsight,
   ensureHindsightConsumer,
+  resolveHindsightCpAccessKey,
   HINDSIGHT_CONSUMER_NAME,
+  HINDSIGHT_CP_NO_ACCESS_KEY_WARNING,
   HINDSIGHT_DEFAULT_API_PORT,
   pickHindsightPorts,
   preflightHindsightPorts,
@@ -1290,6 +1292,10 @@ export async function stepMemoryBackend(
   const spin = spinner("Starting Hindsight Docker container...");
   try {
     const litellmCfg = await resolveLiteLLMForHindsight(config);
+    const cpAccessKey = await resolveHindsightCpAccessKey(config);
+    if (!cpAccessKey) {
+      console.log(chalk.yellow(`  ! ${HINDSIGHT_CP_NO_ACCESS_KEY_WARNING}`));
+    }
     const startContainer = deps.startContainer ?? startHindsight;
     startContainer(
       ports,
@@ -1297,6 +1303,13 @@ export async function stepMemoryBackend(
       undefined,
       config.hindsight?.llm,
       hindsightConsumerMirrorDir(config),
+      // gpu: omitted ⇒ hindsightGpuEnabled() reads the persisted verdict.
+      undefined,
+      // perf: omitted ⇒ the managed defaults, same as before.
+      undefined,
+      // Resolved `hindsight.cp_access_key` — absent ⇒ loginless dashboard,
+      // pinned to loopback by hindsightCpAuthEnvPairs.
+      cpAccessKey,
     );
     if (litellmCfg) {
       console.log(chalk.gray("  LiteLLM routing enabled (--network host, ANTHROPIC_BASE_URL set)."));

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2463,6 +2463,23 @@ export const HindsightConfigSchema = z.object({
       "turn a GPU container into a CPU one). `--gpu`/`--no-gpu` on `memory " +
       "setup` override this for a single run.",
     ),
+  cp_access_key: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "Access key for the hindsight control-plane DASHBOARD (upstream " +
+      "`HINDSIGHT_CP_ACCESS_KEY`, port 9999). Literal or — strongly preferred " +
+      "— a `vault:` reference such as `vault:hindsight_cp_access_key`, read " +
+      "through the broker at container-launch time. This is the ONLY thing " +
+      "that arms the dashboard's login: upstream's middleware short-circuits " +
+      "to `next()` when the var is unset, so an unset key means the dashboard " +
+      "has no authentication at all, not weak authentication. Because of that, " +
+      "leaving it unset is FAIL-CLOSED: switchroom pins " +
+      "`HINDSIGHT_CP_HOSTNAME=127.0.0.1` so the loginless dashboard is " +
+      "reachable only from the host, and warns. Set this to serve the " +
+      "dashboard on the LAN/tailnet.",
+    ),
   llm: z
     .object({
       provider: z

--- a/src/setup/hindsight-cp-access-key.test.ts
+++ b/src/setup/hindsight-cp-access-key.test.ts
@@ -1,0 +1,437 @@
+/**
+ * The hindsight CONTROL-PLANE dashboard must never be reachable off host
+ * loopback without a login — on ANY launch path, under ANY configuration.
+ *
+ * `HINDSIGHT_CP_ACCESS_KEY` is the only thing that arms the CP login
+ * middleware. The shipped edge bundle reads the var and short-circuits to
+ * `next()` when it is falsy, so an UNSET key is not weak auth — it is no auth,
+ * on every protected route. Meanwhile upstream `start-all.sh` exports
+ * `HOSTNAME="${HINDSIGHT_CP_HOSTNAME:-0.0.0.0}"` before `node server.js`, and
+ * `--network host` makes docker ignore `-p`. On 2026-07-29 those three facts
+ * combined into an unauthenticated dashboard answering on the host's LAN and
+ * Tailscale addresses on port 9999 — the CP twin of the API exposure #3976
+ * closed.
+ *
+ * So, exactly as in `hindsight-loopback-bind.test.ts`, these tests do NOT
+ * assert "the string appears in the branch that was edited". They compute the
+ * EXPOSURE VERDICT of the real artefacts — the `docker run` argv
+ * `startHindsight` executes, and the text `generateHindsightComposeSnippet`
+ * emits — across the whole space of configurations, with and without a
+ * configured key, and fail if any of them can produce a dashboard that is
+ * reachable beyond loopback while the login is inert.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+const { execFileSyncMock } = vi.hoisted(() => ({ execFileSyncMock: vi.fn() }));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, execFileSync: execFileSyncMock };
+});
+
+import {
+  startHindsight,
+  generateHindsightComposeSnippet,
+  hindsightCpAuthEnvPairs,
+  resolveHindsightCpAccessKey,
+  HINDSIGHT_CP_UNAUTHENTICATED_BIND_ADDR,
+  HINDSIGHT_DEFAULT_API_PORT,
+  HINDSIGHT_DEFAULT_UI_PORT,
+  type HindsightLlmConfig,
+  type LiteLLMHindsightConfig,
+} from "./hindsight.js";
+
+const API_PORT = HINDSIGHT_DEFAULT_API_PORT;
+const UI_PORT = HINDSIGHT_DEFAULT_UI_PORT;
+/** Loopback literals a bind address may legitimately be. Nothing else counts. */
+const LOOPBACK = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
+/** Not a credential — assembled at runtime so push-protection scanners stay quiet. */
+const ACCESS_KEY = "cp-" + "test-access-key-not-real";
+
+beforeEach(() => {
+  execFileSyncMock.mockReset();
+  execFileSyncMock.mockReturnValue(Buffer.from(""));
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+type Case = {
+  name: string;
+  llm?: HindsightLlmConfig;
+  litellm?: LiteLLMHindsightConfig;
+};
+
+const litellmCfg = (baseUrl: string): LiteLLMHindsightConfig => ({
+  baseUrl,
+  apiKey: "sk-" + "test-not-a-real-key",
+  model: "claude-sonnet-5",
+});
+
+/** Every configuration that puts hindsight on the host network stack. */
+const HOST_NETWORK_CASES: Case[] = [
+  { name: "explicit litellm config (loopback)", litellm: litellmCfg("http://127.0.0.1:4010") },
+  { name: "explicit litellm config (remote)", litellm: litellmCfg("https://litellm.example.com") },
+  {
+    name: "per-op loopback base: retain",
+    llm: { retain: { base_url: "http://127.0.0.1:4010", model: "m" } },
+  },
+  {
+    name: "per-op loopback base: reflect",
+    llm: { reflect: { base_url: "http://localhost:4010", model: "m" } },
+  },
+  {
+    name: "per-op loopback base: consolidation",
+    llm: { consolidation: { base_url: "http://[::1]:4010", model: "m" } },
+  },
+  {
+    name: "litellm config AND per-op loopback base",
+    litellm: litellmCfg("http://127.0.0.1:4010"),
+    llm: { consolidation: { base_url: "http://127.0.0.1:11434/v1", model: "m" } },
+  },
+];
+
+/** Configurations that stay on the bridge — the `-p` publish must confine them. */
+const BRIDGE_CASES: Case[] = [
+  { name: "no llm config at all" },
+  { name: "remote per-op base only", llm: { reflect: { base_url: "https://api.openai.com/v1" } } },
+];
+
+const ALL_CASES = [...HOST_NETWORK_CASES, ...BRIDGE_CASES];
+
+/** The real `docker run` argv `startHindsight` would execute. */
+function dockerRunArgv(c: Case, cpAccessKey?: string): string[] {
+  execFileSyncMock.mockReset();
+  execFileSyncMock.mockReturnValue(Buffer.from(""));
+  startHindsight(
+    { apiPort: API_PORT, uiPort: UI_PORT },
+    c.litellm,
+    undefined,
+    c.llm,
+    undefined,
+    false,
+    { env: {}, processEnv: {} as NodeJS.ProcessEnv },
+    cpAccessKey,
+  );
+  const run = execFileSyncMock.mock.calls
+    .map((call) => call[1] as string[])
+    .filter((argv) => Array.isArray(argv) && argv[0] === "run");
+  expect(run.length).toBe(1);
+  return run[0];
+}
+
+function envFromArgv(argv: string[]): Map<string, string> {
+  const out = new Map<string, string>();
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] !== "-e") continue;
+    const pair = argv[i + 1] ?? "";
+    const eq = pair.indexOf("=");
+    if (eq > 0) out.set(pair.slice(0, eq), pair.slice(eq + 1));
+  }
+  return out;
+}
+
+/** `-p` values, e.g. `127.0.0.1:19999:9999`. */
+function publishesFromArgv(argv: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "-p" || argv[i] === "--publish") out.push(argv[i + 1] ?? "");
+  }
+  return out;
+}
+
+function hasHostNetworkArg(argv: string[]): boolean {
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--network" && argv[i + 1] === "host") return true;
+    if (argv[i] === "--network=host" || argv[i] === "--net=host") return true;
+  }
+  return false;
+}
+
+/** Compose snippet reduced to the same three facts. */
+function analyzeCompose(yaml: string) {
+  const lines = yaml.split("\n").map((l) => l.trim());
+  const env = new Map<string, string>();
+  for (const line of lines) {
+    const m = /^-\s+([A-Z0-9_]+)=(.*)$/.exec(line);
+    if (m) env.set(m[1], m[2]);
+  }
+  const publishes = lines
+    .map((l) => /^-\s+"(.+)"$/.exec(l)?.[1])
+    .filter((v): v is string => !!v && /^[^\s]*:?\d+:\d+$/.test(v));
+  return { hostNetwork: lines.includes("network_mode: host"), env, publishes };
+}
+
+function composeFor(c: Case, cpAccessKey?: string) {
+  return analyzeCompose(
+    generateHindsightComposeSnippet(c.llm, undefined, c.litellm, false, {
+      env: {},
+      processEnv: {} as NodeJS.ProcessEnv,
+    }, cpAccessKey),
+  );
+}
+
+/**
+ * Is the DASHBOARD (port 9999) reachable from beyond host loopback?
+ *
+ * Host network: `-p` is inert, so the verdict is the CP process's own bind
+ * address (`HINDSIGHT_CP_HOSTNAME`). Absent ⇒ upstream's `0.0.0.0` default ⇒
+ * exposed. That absence IS the bug.
+ *
+ * Bridge: the CP binds inside its own netns, so the verdict is whether the
+ * published 9999 mapping pins a loopback host-side address.
+ */
+function dashboardExposedBeyondLoopback(a: {
+  hostNetwork: boolean;
+  env: Map<string, string>;
+  publishes: string[];
+}): boolean {
+  if (a.hostNetwork) {
+    const bind = a.env.get("HINDSIGHT_CP_HOSTNAME");
+    return bind === undefined || !LOOPBACK.has(bind.trim());
+  }
+  const ui = a.publishes.filter((p) => p.endsWith(":9999"));
+  if (ui.length === 0) return false;
+  return ui.some((p) => {
+    const parts = p.split(":");
+    if (parts.length < 3) return true;
+    return !LOOPBACK.has(parts.slice(0, parts.length - 2).join(":"));
+  });
+}
+
+/** The CP login is armed iff the access key reaches the container. */
+function loginArmed(env: Map<string, string>): boolean {
+  return (env.get("HINDSIGHT_CP_ACCESS_KEY") ?? "").trim().length > 0;
+}
+
+describe("the CP access key reaches the container on every launch path", () => {
+  it.each(ALL_CASES.map((c) => [c.name, c] as const))(
+    "docker run argv carries HINDSIGHT_CP_ACCESS_KEY — %s",
+    (_name, c) => {
+      // Pre-fix this was absent on every path: the var was never emitted at
+      // all, so the dashboard's middleware was inert no matter what the
+      // operator put in switchroom.yaml.
+      const env = envFromArgv(dockerRunArgv(c, ACCESS_KEY));
+      expect(env.get("HINDSIGHT_CP_ACCESS_KEY")).toBe(ACCESS_KEY);
+    },
+  );
+
+  it.each(ALL_CASES.map((c) => [c.name, c] as const))(
+    "compose snippet carries HINDSIGHT_CP_ACCESS_KEY — %s",
+    (_name, c) => {
+      expect(composeFor(c, ACCESS_KEY).env.get("HINDSIGHT_CP_ACCESS_KEY")).toBe(ACCESS_KEY);
+    },
+  );
+
+  it("docker-run and compose agree about the CP auth env on every case", () => {
+    // The parity property #3976 established for the API bind, applied to CP
+    // auth: a fix present on one emitter and forgotten on the other is the
+    // recurring shape of this defect.
+    for (const c of ALL_CASES) {
+      for (const key of [ACCESS_KEY, undefined]) {
+        const run = envFromArgv(dockerRunArgv(c, key));
+        const comp = composeFor(c, key).env;
+        for (const v of ["HINDSIGHT_CP_ACCESS_KEY", "HINDSIGHT_CP_HOSTNAME"]) {
+          expect(comp.get(v), `${c.name} / key=${key ? "set" : "unset"} / ${v}`).toBe(
+            run.get(v),
+          );
+        }
+      }
+    }
+  });
+});
+
+describe("a dashboard reachable beyond loopback always has a login", () => {
+  it.each(ALL_CASES.map((c) => [c.name, c] as const))(
+    "docker run: exposed ⇒ login armed — %s",
+    (_name, c) => {
+      for (const key of [ACCESS_KEY, undefined]) {
+        const argv = dockerRunArgv(c, key);
+        const env = envFromArgv(argv);
+        const exposed = dashboardExposedBeyondLoopback({
+          hostNetwork: hasHostNetworkArg(argv),
+          env,
+          publishes: publishesFromArgv(argv),
+        });
+        // THE invariant. Not "the env var is present" — the verdict.
+        expect(
+          !exposed || loginArmed(env),
+          `${c.name} (key ${key ? "set" : "unset"}): dashboard exposed beyond ` +
+            "loopback with no access key",
+        ).toBe(true);
+      }
+    },
+  );
+
+  it.each(ALL_CASES.map((c) => [c.name, c] as const))(
+    "compose: exposed ⇒ login armed — %s",
+    (_name, c) => {
+      for (const key of [ACCESS_KEY, undefined]) {
+        const a = composeFor(c, key);
+        expect(
+          !dashboardExposedBeyondLoopback(a) || loginArmed(a.env),
+          `${c.name} (key ${key ? "set" : "unset"}): compose exposes the ` +
+            "dashboard with no access key",
+        ).toBe(true);
+      }
+    },
+  );
+
+  it.each(HOST_NETWORK_CASES.map((c) => [c.name, c] as const))(
+    "no key + host network ⇒ CP pinned to loopback, not merely warned about — %s",
+    (_name, c) => {
+      // Deterministic containment, not prompt/doc discipline: with no key the
+      // launch itself confines the loginless dashboard.
+      const env = envFromArgv(dockerRunArgv(c, undefined));
+      expect(env.get("HINDSIGHT_CP_HOSTNAME")).toBe(HINDSIGHT_CP_UNAUTHENTICATED_BIND_ADDR);
+      expect(env.has("HINDSIGHT_CP_ACCESS_KEY")).toBe(false);
+      expect(composeFor(c, undefined).env.get("HINDSIGHT_CP_HOSTNAME")).toBe(
+        HINDSIGHT_CP_UNAUTHENTICATED_BIND_ADDR,
+      );
+    },
+  );
+
+  it.each(HOST_NETWORK_CASES.map((c) => [c.name, c] as const))(
+    "key set + host network ⇒ dashboard is served to the LAN/tailnet — %s",
+    (_name, c) => {
+      // The operator WANTS LAN/Tailscale reachability; the fix must not be a
+      // disguised lockout. With the login armed the bind opens back up.
+      const env = envFromArgv(dockerRunArgv(c, ACCESS_KEY));
+      expect(env.get("HINDSIGHT_CP_HOSTNAME")).toBe("0.0.0.0");
+      expect(
+        dashboardExposedBeyondLoopback({
+          hostNetwork: true,
+          env,
+          publishes: [],
+        }),
+      ).toBe(true);
+    },
+  );
+
+  it("never pins the CP bind on the bridge path (it would break the -p publish)", () => {
+    // On bridge, docker-proxy dials the container's bridge IP; a 127.0.0.1
+    // in-netns bind makes `-p 127.0.0.1:19999:9999` connect-refuse. The `-p`
+    // mapping is already the containment there.
+    for (const c of BRIDGE_CASES) {
+      for (const key of [ACCESS_KEY, undefined]) {
+        expect(envFromArgv(dockerRunArgv(c, key)).has("HINDSIGHT_CP_HOSTNAME")).toBe(false);
+        expect(composeFor(c, key).env.has("HINDSIGHT_CP_HOSTNAME")).toBe(false);
+      }
+    }
+  });
+});
+
+describe("hindsightCpAuthEnvPairs", () => {
+  it("treats a whitespace-only key as no key", () => {
+    expect(hindsightCpAuthEnvPairs({ accessKey: "   ", hostNetwork: true })).toEqual([
+      ["HINDSIGHT_CP_HOSTNAME", HINDSIGHT_CP_UNAUTHENTICATED_BIND_ADDR],
+    ]);
+  });
+
+  it("emits nothing at all on bridge with no key", () => {
+    expect(hindsightCpAuthEnvPairs({ hostNetwork: false })).toEqual([]);
+  });
+
+  it("trims the key it emits", () => {
+    expect(
+      hindsightCpAuthEnvPairs({ accessKey: `  ${ACCESS_KEY}\n`, hostNetwork: false }),
+    ).toEqual([["HINDSIGHT_CP_ACCESS_KEY", ACCESS_KEY]]);
+  });
+});
+
+describe("a switchroom.yaml line actually reaches the container", () => {
+  // Reachability, not schema shape: the defect class here is a knob an
+  // operator sets that never changes the launch. Walk the whole chain —
+  // parse → resolve (vault) → docker-run argv.
+  it("hindsight.cp_access_key: vault:<key> ends up as HINDSIGHT_CP_ACCESS_KEY", async () => {
+    const { HindsightConfigSchema } = await import("../config/schema.js");
+    const parsed = HindsightConfigSchema.parse({
+      cp_access_key: "vault:hindsight_cp_access_key",
+    });
+    expect(parsed.cp_access_key).toBe("vault:hindsight_cp_access_key");
+
+    const resolved = await resolveHindsightCpAccessKey(
+      { hindsight: parsed },
+      {
+        getViaBrokerStructured: vi
+          .fn()
+          .mockResolvedValue({ kind: "ok", entry: { kind: "string", value: ACCESS_KEY } }) as never,
+      },
+    );
+    const env = envFromArgv(
+      dockerRunArgv({ name: "litellm", litellm: litellmCfg("http://127.0.0.1:4010") }, resolved),
+    );
+    expect(env.get("HINDSIGHT_CP_ACCESS_KEY")).toBe(ACCESS_KEY);
+    expect(env.get("HINDSIGHT_CP_HOSTNAME")).toBe("0.0.0.0");
+  });
+});
+
+describe("the access key never reaches the operator's terminal", () => {
+  it("the recreate env-drift report redacts HINDSIGHT_CP_ACCESS_KEY", async () => {
+    // The drift report dumps the live container's env when a recreate would
+    // drop a var. Introducing a credential into that env makes the report a
+    // new leak surface, so pin the redaction rather than trusting the regex.
+    const { diffDroppedHindsightEnv, formatDroppedHindsightEnvReport, REDACTED_ENV_VALUE } =
+      await import("./hindsight-env-drift.js");
+    const dropped = diffDroppedHindsightEnv([`HINDSIGHT_CP_ACCESS_KEY=${ACCESS_KEY}`], [], []);
+    expect(dropped.map((d) => d.key)).toContain("HINDSIGHT_CP_ACCESS_KEY");
+    const report = formatDroppedHindsightEnvReport(dropped, {
+      gpu: false,
+      localLlm: false,
+    }).join("\n");
+    expect(report).toContain(REDACTED_ENV_VALUE);
+    expect(report).not.toContain(ACCESS_KEY);
+  });
+});
+
+describe("resolveHindsightCpAccessKey", () => {
+  const brokerOk = (value: string) =>
+    vi.fn().mockResolvedValue({ kind: "ok", entry: { kind: "string", value } });
+
+  it("returns undefined when nothing is configured", async () => {
+    await expect(resolveHindsightCpAccessKey({})).resolves.toBeUndefined();
+    await expect(
+      resolveHindsightCpAccessKey({ hindsight: { cp_access_key: "  " } }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("passes a literal through without touching the broker", async () => {
+    const get = brokerOk("unused");
+    await expect(
+      resolveHindsightCpAccessKey(
+        { hindsight: { cp_access_key: ACCESS_KEY } },
+        { getViaBrokerStructured: get as never },
+      ),
+    ).resolves.toBe(ACCESS_KEY);
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it("reads a `vault:` reference through the broker, by bare key", async () => {
+    const get = brokerOk(ACCESS_KEY);
+    await expect(
+      resolveHindsightCpAccessKey(
+        { hindsight: { cp_access_key: "vault:hindsight_cp_access_key" } },
+        { getViaBrokerStructured: get as never },
+      ),
+    ).resolves.toBe(ACCESS_KEY);
+    expect(get).toHaveBeenCalledWith("hindsight_cp_access_key");
+  });
+
+  it("fails CLOSED on a denied/missing/erroring vault reference", async () => {
+    // An unresolvable ref must read as "no key" — which pins the dashboard to
+    // loopback — never as "carry on and serve it open".
+    for (const get of [
+      vi.fn().mockResolvedValue({ kind: "denied" }),
+      vi.fn().mockResolvedValue({ kind: "ok", entry: { kind: "json", value: {} } }),
+      vi.fn().mockResolvedValue({ kind: "ok", entry: { kind: "string", value: "  " } }),
+      vi.fn().mockRejectedValue(new Error("broker down")),
+    ]) {
+      await expect(
+        resolveHindsightCpAccessKey(
+          { hindsight: { cp_access_key: "vault:hindsight_cp_access_key" } },
+          { getViaBrokerStructured: get as never },
+        ),
+      ).resolves.toBeUndefined();
+    }
+  });
+});

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -1363,6 +1363,115 @@ export function hindsightHostNetworkBindEnvPairs(
 }
 
 /**
+ * Address the CP dashboard (Next.js, port 9999) binds under `--network host`
+ * when NO access key is configured.
+ *
+ * Upstream `start-all.sh` exports `HOSTNAME="${HINDSIGHT_CP_HOSTNAME:-0.0.0.0}"`
+ * before `node server.js`, so absent this pin the dashboard listens on every
+ * host address. That is only safe when the access-key middleware is armed —
+ * and the middleware is a NO-OP when `HINDSIGHT_CP_ACCESS_KEY` is unset
+ * (verified in the shipped edge bundle: the handler reads the var and
+ * short-circuits to `next()` when it is falsy, so no protected route is
+ * enforced at all). "Unauthenticated service on 0.0.0.0 under host
+ * networking" is the same exposure shape the API had before
+ * {@link HINDSIGHT_HOST_NETWORK_BIND_ADDR}, so it gets the same containment:
+ * no key ⇒ loopback only.
+ */
+export const HINDSIGHT_CP_UNAUTHENTICATED_BIND_ADDR = "127.0.0.1";
+
+/** Bind the CP dashboard on every host address (upstream's own default). */
+export const HINDSIGHT_CP_AUTHENTICATED_BIND_ADDR = "0.0.0.0";
+
+/**
+ * Operator-facing warning every launch path emits when the CP dashboard is
+ * started without an access key. Exported so the docker-run CLI and the
+ * compose emitter cannot word it differently — or forget it.
+ */
+export const HINDSIGHT_CP_NO_ACCESS_KEY_WARNING =
+  "hindsight: no `hindsight.cp_access_key` configured — the control-plane " +
+  "dashboard has NO login (the access-key middleware is inert when " +
+  "HINDSIGHT_CP_ACCESS_KEY is unset), so it is pinned to " +
+  `${HINDSIGHT_CP_UNAUTHENTICATED_BIND_ADDR} and will NOT be reachable from ` +
+  "the LAN or tailnet. Set `hindsight.cp_access_key: vault:<key>` in " +
+  "switchroom.yaml to arm the login and open it up.";
+
+/**
+ * THE control-plane auth env every hindsight launch path must carry.
+ *
+ * Two coupled facts, which is why they are derived together and in ONE place:
+ *
+ *  1. `HINDSIGHT_CP_ACCESS_KEY` is what arms the CP login middleware. Absent,
+ *     the middleware passes every request through — the dashboard is not
+ *     "weakly protected", it is unprotected.
+ *  2. `HINDSIGHT_CP_HOSTNAME` is what decides who can reach it. Under
+ *     `--network host` docker ignores `-p`, so this env var is the only
+ *     containment (exactly like the API's `HINDSIGHT_API_HOST`). On bridge the
+ *     `-p 127.0.0.1:<uiPort>:9999` publish already confines it, and pinning
+ *     the in-netns bind to loopback there would break the publish outright —
+ *     so the bind is emitted on the host-network path only.
+ *
+ * The verdict: a dashboard reachable off-host REQUIRES a key. With a key we
+ * bind `0.0.0.0` (the operator asked for LAN/tailnet, and the middleware is
+ * now armed); without one we fail CLOSED to loopback rather than silently
+ * serving an open dashboard to the LAN. Emitted from here by
+ * {@link startHindsight}'s docker-run argv AND
+ * {@link generateHindsightComposeSnippet} so the two can never disagree.
+ */
+export function hindsightCpAuthEnvPairs(opts: {
+  /** Resolved access key (post-`vault:` lookup). Blank/absent ⇒ no login. */
+  accessKey?: string;
+  /** Whether this launch takes `--network host` / `network_mode: host`. */
+  hostNetwork: boolean;
+}): Array<[string, string]> {
+  const key = opts.accessKey?.trim();
+  const pairs: Array<[string, string]> = [];
+  if (key) pairs.push(["HINDSIGHT_CP_ACCESS_KEY", key]);
+  if (opts.hostNetwork) {
+    pairs.push([
+      "HINDSIGHT_CP_HOSTNAME",
+      key ? HINDSIGHT_CP_AUTHENTICATED_BIND_ADDR : HINDSIGHT_CP_UNAUTHENTICATED_BIND_ADDR,
+    ]);
+  }
+  return pairs;
+}
+
+/**
+ * Resolve the operator's `hindsight.cp_access_key` to the actual secret.
+ *
+ * A literal is returned as-is; a `vault:<key>` reference is read through the
+ * broker — the same shape `hindsight.llm.<op>.api_key` and `litellm.admin_key`
+ * take (`resolveConfigSecret` in src/cli/apply.ts). NEVER read the vault file
+ * directly: from inside a container it isn't mounted, and on the host the
+ * broker is the audited path.
+ *
+ * Returns `undefined` when there is no config value OR when the reference
+ * cannot be resolved. Both collapse to "no key", which is deliberately the
+ * fail-CLOSED input to {@link hindsightCpAuthEnvPairs}: an unresolvable vault
+ * ref must not silently produce an open dashboard. Callers warn with
+ * {@link HINDSIGHT_CP_NO_ACCESS_KEY_WARNING}.
+ */
+export async function resolveHindsightCpAccessKey(
+  config: { hindsight?: { cp_access_key?: string } } | undefined,
+  deps: {
+    getViaBrokerStructured?: typeof import("../vault/broker/client.js").getViaBrokerStructured;
+  } = {},
+): Promise<string | undefined> {
+  const ref = config?.hindsight?.cp_access_key?.trim();
+  if (!ref) return undefined;
+  const { isVaultReference, parseVaultReference } = await import("../vault/resolver.js");
+  if (!isVaultReference(ref)) return ref;
+  const get =
+    deps.getViaBrokerStructured ??
+    (await import("../vault/broker/client.js")).getViaBrokerStructured;
+  const resolved = await get(parseVaultReference(ref)).catch(() => null);
+  if (!resolved || resolved.kind !== "ok" || resolved.entry.kind !== "string") {
+    return undefined;
+  }
+  const value = resolved.entry.value.trim();
+  return value.length > 0 ? value : undefined;
+}
+
+/**
  * Whether hindsight's LLM traffic terminates on a self-hosted endpoint.
  *
  * The capability gate for the LLM concurrency caps (see
@@ -1759,8 +1868,14 @@ export function hindsightContainerEnvPairs(opts: {
   /** GPU verdict override; omit in production. See {@link hindsightGpuEnabled}. */
   gpu?: boolean;
   perf?: HindsightPerfOptions;
+  /**
+   * Resolved control-plane access key (operator's `hindsight.cp_access_key`,
+   * post-`vault:` lookup). Absent ⇒ the dashboard has no login and is pinned
+   * to loopback. See {@link hindsightCpAuthEnvPairs}.
+   */
+  cpAccessKey?: string;
 }): Array<[string, string]> {
-  const { apiPort, litellm, llm, gpu, perf } = opts;
+  const { apiPort, litellm, llm, gpu, perf, cpAccessKey } = opts;
 
   // Effective LLM provider + model, applying the operator override
   // (top-level `hindsight.llm` in switchroom.yaml) over the hard-coded
@@ -1842,6 +1957,18 @@ export function hindsightContainerEnvPairs(opts: {
     pairs.push(...hindsightHostNetworkBindEnvPairs(apiPort));
   }
 
+  // Control-plane dashboard auth. Emitted on EVERY path (not just host
+  // network): the access key arms the CP login middleware regardless of
+  // networking, and the loopback fallback for a keyless launch is decided
+  // inside the helper off the same `hindsightNeedsHostNetwork` verdict.
+  // See {@link hindsightCpAuthEnvPairs}.
+  pairs.push(
+    ...hindsightCpAuthEnvPairs({
+      accessKey: cpAccessKey,
+      hostNetwork: hindsightNeedsHostNetwork(llm, litellm),
+    }),
+  );
+
   if (litellm) {
     const litellmRoot = litellm.baseUrl.replace(/\/+$/, "");
     // Claude models ride the Anthropic pass-through (<root>/anthropic,
@@ -1892,6 +2019,13 @@ export function startHindsight(
    * overrides. See {@link HindsightPerfOptions}.
    */
   perf?: HindsightPerfOptions,
+  /**
+   * Resolved control-plane access key — the operator's
+   * `hindsight.cp_access_key` after any `vault:` reference is read through the
+   * broker. Absent ⇒ the dashboard comes up with no login and is confined to
+   * loopback rather than served open. See {@link hindsightCpAuthEnvPairs}.
+   */
+  cpAccessKey?: string,
 ): void {
   const apiPort = ports?.apiPort ?? HINDSIGHT_DEFAULT_API_PORT;
   const uiPort = ports?.uiPort ?? HINDSIGHT_DEFAULT_UI_PORT;
@@ -1900,6 +2034,7 @@ export function startHindsight(
     apiPort,
     litellm,
     llm,
+    cpAccessKey,
     gpu,
     perf,
   }).flatMap(([k, v]) => ["-e", `${k}=${v}`]);
@@ -2359,6 +2494,13 @@ export function generateHindsightComposeSnippet(
    * overrides, mirroring {@link startHindsight}'s `perf` param.
    */
   perf?: HindsightPerfOptions,
+  /**
+   * Resolved control-plane access key, mirroring {@link startHindsight}'s
+   * `cpAccessKey` param. Emitted through the SAME
+   * {@link hindsightCpAuthEnvPairs} helper so a compose deployment cannot end
+   * up with an open dashboard while the docker-run path is protected.
+   */
+  cpAccessKey?: string,
 ): string {
   const { provider: llmProvider, model: llmModel } = resolveHindsightLlm(llm, litellm);
   const perOpLlm = resolveHindsightPerOpLlm(llm);
@@ -2397,6 +2539,14 @@ export function generateHindsightComposeSnippet(
     ...(hostNetwork
       ? hindsightHostNetworkBindEnvPairs(apiPort).map(([k, v]) => `      - ${k}=${v}`)
       : [`      - HINDSIGHT_CP_DATAPLANE_API_URL=http://localhost:8888`]),
+    // CP dashboard login + (host-network only) its bind address, from the
+    // SAME helper the docker-run path uses. Without this the compose
+    // deployment served an unauthenticated dashboard on 0.0.0.0:9999 while
+    // docker-run was protected — the exact one-path-fixed shape #3976 removed
+    // for the API.
+    ...hindsightCpAuthEnvPairs({ accessKey: cpAccessKey, hostNetwork }).map(
+      ([k, v]) => `      - ${k}=${v}`,
+    ),
   ];
   // Optional LiteLLM proxy env (ANTHROPIC_BASE_URL + spend-tag headers) —
   // same shape startHindsight emits when litellm is configured. Requires the


### PR DESCRIPTION
## Summary

The Hindsight control-plane dashboard (port 9999) comes up with **no login at all** unless `HINDSIGHT_CP_ACCESS_KEY` is set, and switchroom never emitted that variable on any launch path. Under `--network host` (which docker uses for the hindsight container whenever `hindsightNeedsHostNetwork` is true) docker ignores `-p` entirely, so the dashboard answered unauthenticated on the host's LAN and tailnet addresses.

This adds `hindsight.cp_access_key` to the config schema, resolves it through the existing vault-broker path, and emits it from a **single** derivation shared by the docker-run and compose emitters.

## Why

Not a docs claim — verified in the shipped artefact. The control-plane edge middleware in `ghcr.io/switchroom/switchroom-hindsight:v0.19.33` reads:

```js
let t = process.env.HINDSIGHT_CP_ACCESS_KEY
if (!t || …) return eb.next()
```

Unset key ⇒ every request passes the middleware. That is *no* authentication, not weak authentication.

## What changed

- **`src/config/schema.ts`** — new optional `hindsight.cp_access_key`. Takes a `vault:<key>` reference.
- **`src/setup/hindsight.ts`** — new `hindsightCpAuthEnvPairs()` (the one derivation) and `resolveHindsightCpAccessKey()`, which goes through `isVaultReference` / `parseVaultReference` / `getViaBrokerStructured` — the existing vault-backed-service-env pattern. No new mechanism, no direct vault file IO. `hindsightContainerEnvPairs`, `startHindsight` and `generateHindsightComposeSnippet` all consume the same helper, following #3976's "one derivation, all paths" shape so no launch path can miss it.
- **`src/cli/memory.ts` / `src/cli/setup.ts`** — resolve the key on `memory start`, `setup`, and `memory docker-compose`; warn loudly when it is absent. The compose warning goes to **stderr** so stdout stays a pasteable snippet. The env-drift path also resolves the key so it does not falsely report `HINDSIGHT_CP_ACCESS_KEY` as about to be dropped.
- **`docs/configuration.md`** — new section documenting the setting and both behaviours.

## The fail-closed decision

Requirement: if the key is unset, the dashboard must not silently come up unauthenticated. A warning alone is model/operator-dependent, so this uses a deterministic mechanism instead. `start-all.sh:263` does:

```sh
export HOSTNAME="${HINDSIGHT_CP_HOSTNAME:-0.0.0.0}"
```

So on the host-network path we emit:

| `cp_access_key` | `HINDSIGHT_CP_ACCESS_KEY` | `HINDSIGHT_CP_HOSTNAME` | Result |
|---|---|---|---|
| set + resolvable | the key | `0.0.0.0` | login armed, reachable on LAN/tailnet |
| unset / blank / unresolvable | *(absent)* | `127.0.0.1` | no login, and not reachable off-host |

This is **not** a bind restriction on the working case — with a key configured the dashboard binds `0.0.0.0` exactly as the operator wants. It only pins loopback in the state that would otherwise be a loginless LAN service. The bind is emitted **only** on the host-network path: on bridge, `-p 127.0.0.1:<uiPort>:9999` is already the containment, and an in-netns `127.0.0.1` bind would break docker-proxy.

Side effect worth knowing: under `--strict-env`, a recreate while the vault broker is unreachable now **refuses** rather than silently downgrading to a loginless dashboard.

## Client-JS verification (does #3976's loopback API break the browser?)

**No.** In the running `switchroom-hindsight` container:

- `/app/control-plane/.next/static` — **0** occurrences of `18888`, **0** of `DATAPLANE`, **0** `NEXT_PUBLIC_*` identifiers of any kind.
- `HINDSIGHT_CP_ACCESS_KEY` appears only under `.next/server/chunks/` and `.next/server/edge/chunks/`.

The dataplane URL is server-side only, so the loopback-only API on 18888 does not affect browser-side calls and LAN dashboard use is unaffected.

## Test plan

`src/setup/hindsight-cp-access-key.test.ts` (55 tests), modelled on `src/setup/hindsight-loopback-bind.test.ts`. These assert the **outcome**: they resolve the real `docker run` argv and the real compose snippet, parse env/publishes/network mode out of them, and compute an exposure verdict, then assert the invariant

```
!dashboardExposedBeyondLoopback(argv) || loginArmed(env)
```

on host-network, bridge and compose paths. Also covered: docker-run/compose parity on both variables, "key set ⇒ bind is `0.0.0.0`" (proves it is not a disguised lockout), "never pins the CP bind on bridge", a yaml→schema→vault→argv end-to-end reachability test, a redaction test asserting the env-drift report never prints the key, and `resolveHindsightCpAccessKey` failing closed on a denied/missing/erroring vault reference.

Mutation-tested: forcing `hindsightCpAuthEnvPairs` to ignore its input fails **23 of them**. They would fail on the bug they guard.

Local, scoped:

```
vitest run src/setup/ src/cli/memory.test.ts src/cli/setup.test.ts tests/memory.test.ts \
  tests/setup/ tests/hindsight-env-keys-are-reachable.test.ts src/config/
→ Test Files  39 passed (39)
  Tests  967 passed (967)
```

`npm run lint` green through `tsc --noEmit` and all guard scripts.

`src/cli/apply.test.ts` shows 10 `EACCES: mkdir '~/.switchroom/approvals'` failures in my container — reproduced **identically on unmodified `origin/main`** via `git stash -u`, so it is an environment artifact of the root-mapped HOME, not this change. CI is the authority.

## Risk

Low-to-moderate, all at recreate time. Existing containers are untouched (nothing was restarted or recreated). The behaviour change an operator can feel: recreating hindsight *without* configuring `cp_access_key` now pins the dashboard to loopback instead of leaving it open. That is the intended fail-closed direction and is documented, but it is a visible change for anyone relying on the current unauthenticated LAN access. The key lands in `docker run` argv (visible to `ps` / `docker inspect`), matching the existing litellm `apiKey` precedent.

Follow-up (LOW, filed separately, deliberately out of scope): a `switchroom doctor` check that FAILs when the live container is host-networked with no `HINDSIGHT_CP_ACCESS_KEY` and a non-loopback `HINDSIGHT_CP_HOSTNAME` — a runtime backstop for containers created before this change.

Job: `reference/jobs/remember-across-sessions.md` (invariant: single-tenant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
