### PR TITLE
feat(hindsight-watch): see consolidation failures, not just a queue

### DIFF
--- a/docs/hindsight-watch.md
+++ b/docs/hindsight-watch.md
@@ -37,6 +37,9 @@ workers issue thousands.
 | `recall-injected-score` | p50 of `injected_score_max` ≤0.02 (warn) / ≤0.01 (page) | level |
 | `recall-zero-memory` | >25 % (warn) / >40 % (page) of recalls injected nothing | level |
 | `consolidation-queue-age` | oldest pending `async_operations` row ≥2 h (warn) / ≥12 h (page) | level |
+| `consolidation-failure-streak` | ≥3 (warn) / ≥10 (page) consecutive **failed** `async_operations` for one `(bank, operation_type)` pair, newest within 2 h | edge |
+| `pending-consolidation-depth` | one bank's unconsolidated memories ≥500 **and** grew by ≥max(500, 50 %) across the window (≥5 000 pages) | level |
+| `vector-index-corruption` | a nearest-neighbour probe against an HNSW index raises | edge |
 | `llm-fallback-ineffective` | ≥2 % (warn) / ≥10 % (page) of hindsight LLM calls failed outright | level |
 
 The five recall signals read `recall_log.jsonl` — the hook's own telemetry —
@@ -61,6 +64,38 @@ A threshold checked only against the outage proves it can see the outage,
 which is the easy half; the hard half is not firing once the outage is over.
 Two drafted lines failed that second check and were re-derived (injected-score
 warn, 0.05 → 0.02) or deleted (recall latency) before shipping.
+
+**The three consolidation signals exist because `consolidation-queue-age` is
+inverted.** Its probe selects `FROM async_operations WHERE status IN
+('pending','processing')`, so an operation that has FAILED is no longer in the
+set being measured — and `evaluateConsolidationQueueAge` reports
+`"consolidation queue empty"` when that count is zero. The more reliably a
+bank's consolidator fails, the healthier it reads. On 2026-07-29 the `overlord`
+bank's consolidation failed on ~every run from 04:28 to 07:09 UTC and the API
+reported `pending_operations: 0, failed_operations: 96, pending_consolidation:
+37 711` **simultaneously**, for 2.5 h, with every watchdog signal green. It was
+found because an operator happened to ask.
+
+`consolidation-failure-streak` is the one that closes that. It counts
+consecutive `failed` rows *since the last `completed` one*, keyed on the
+`(bank, operation_type)` **pair** — not the bank, because during the incident
+`overlord` completed 3 753 retains while its consolidation failed 112 times,
+and a bank-wide streak would have been broken by every successful retain and
+never reached 3. It is deliberately error-string-agnostic: it catches any
+deterministic non-retryable consolidation failure, not one incident's message.
+
+`pending-consolidation-depth` scores **growth**, not absolute depth, because
+some banks legitimately run deep (the fleet holds 676 720 memory units; one
+bank carries 202 549) and an absolute line would be either noise or useless.
+
+`vector-index-corruption` exists because `amcheck` has no HNSW support — a
+nearest-neighbour probe is the only available verifier for these indexes. Note
+the shape in `probe.ts`: the aggregate must be over the correlated subquery's
+**result** (`count(nn)`, not `count(*)`), or the planner elides the SubPlan and
+the probe silently passes without touching the index. The partial-index
+predicate is likewise spliced verbatim from `pg_get_expr(indpred, indrelid)` —
+a correlated column reference cannot prove a partial predicate, so the planner
+falls back to the single global index and leaves all 88 partial ones unprobed.
 
 Breaches now carry a **severity**: `warn` renders 🟠 "… degraded", `page`
 renders 🔴. Every pre-existing signal sets no severity and stays 🔴.
@@ -173,6 +208,40 @@ Notes on the reduction, all of which are fail-CLOSED by design:
   `success="false"` therefore means the local deployment failed **and** the
   OpenRouter hop did not rescue it — which is the question worth alerting on.
   A fallback that never fires can no longer read as clean.
+
+### Consolidation thresholds
+
+Measured read-only against the live fleet on 2026-07-29, shortly after the
+incident was repaired (baseline block **B9** in `thresholds.ts`):
+
+| Constant | Value | Measurement that set it |
+|---|---|---|
+| `CONSOLIDATION_FAILURE_STREAK_WARN` | 3 | The streak query returned exactly one row across all 20 banks — `overlord \| consolidation \| 103 \| 668`. Every other `(bank, op)` pair read 0. A healthy fleet's floor is 0, so 3 is three consecutive terminal failures above a population with none, and fires ~15 min into an incident. |
+| `CONSOLIDATION_FAILURE_STREAK_PAGE` | 10 | ~2.5 consecutive 15-min ticks of total failure. The incident reached 103. |
+| `CONSOLIDATION_STREAK_RECENCY_S` | 2 h | A streak is defined *relative to the last completed op*, so a bank that is fixed but then goes idle keeps its streak for ever. Without this the signal would never resolve. |
+| `PENDING_CONSOLIDATION_FLOOR` | 500 | Healthy per-bank depth: `overlord` 38 130 (sick) · `carrie` 45 · `switchroom-dev` 12 · every other bank 0, over 676 720 memory units. |
+| `PENDING_CONSOLIDATION_GROWTH_FRACTION` / `_WARN_ABS` / `_PAGE_ABS` | 50 % / 500 / 5 000 | Same "deep **and** rising" conjunction as `retain-queue-growth`, so a draining backlog stays silent. The incident's window growth was ~38 000. |
+| `VECTOR_INDEX_SAMPLE_ROWS` | 3 | 89 HNSW indexes swept in **0.45 s** at this sample size. |
+
+Two honest caveats on the canary:
+
+- **The corruption was already repaired when this was built** (last failed row
+  07:08:55 UTC, probe run 07:18), so the live sweep returned `VECIDX|89|0|` and
+  the raise could not be reproduced end-to-end. What *is* proven is the
+  mechanism: `EXPLAIN` over `count(nn)` shows `Index Scan using
+  idx_mu_emb_obsv_81cef5f6a42e4b4d` with `SubPlan 1` (9.6 ms), while the same
+  query as `count(*)` shows a bare `Aggregate` with no `SubPlan` and no index
+  scan (0.8 ms). `probeVectorIndexes` refuses to run — returning `no-data`, not
+  `ok` — if the generated SQL ever stops containing `count(nn)`.
+- The damage is **inside the index, not the data**: the column is `vector(384)`
+  and a full scan found zero off-dimension rows, which is why a nearest-
+  neighbour probe (and not a column check) is the detector.
+
+`pending_consolidation` is read in the same psql round trip as the streak
+rather than through the `/stats` HTTP endpoint. Same predicate
+(`consolidated_at IS NULL AND fact_type IN ('experience','world')`, per
+`doctor-observation-scopes.ts`), 0.284 s for the whole fleet against the
+1.4–2.1 s **per bank** that endpoint costs.
 
 ## Exit codes
 

--- a/src/hindsight-watch/evaluate.test.ts
+++ b/src/hindsight-watch/evaluate.test.ts
@@ -259,9 +259,11 @@ describe("evaluateAll", () => {
   it("returns one verdict per level/edge signal", () => {
     const verdicts = evaluateAll([sample(0), sample(1)]);
     expect(verdicts.map((v) => v.signal).sort()).toEqual([
+      "consolidation-failure-streak",
       "consolidation-queue-age",
       "container",
       "llm-fallback-ineffective",
+      "pending-consolidation-depth",
       "recall-candidate-floor",
       "recall-injected-score",
       "recall-own-bank-timeout",
@@ -269,6 +271,7 @@ describe("evaluateAll", () => {
       "retain-failure-rate",
       "retain-loss",
       "retain-queue-growth",
+      "vector-index-corruption",
     ]);
   });
 
@@ -383,5 +386,166 @@ describe("evaluateLlmFallback", () => {
 
   it("reports no-data when the exposition carries no LLM counter at all", () => {
     expect(evaluateLlmFallback([sample(0), sample(1)]).state).toBe("no-data");
+  });
+});
+
+// ── the three signals added for the 2026-07-29 consolidation outage ──────
+
+import {
+  evaluateConsolidationFailureStreak,
+  evaluatePendingConsolidationDepth,
+  evaluateVectorIndexCorruption,
+} from "./evaluate.js";
+import {
+  CONSOLIDATION_FAILURE_STREAK_PAGE,
+  CONSOLIDATION_FAILURE_STREAK_WARN,
+  CONSOLIDATION_STREAK_RECENCY_S,
+  PENDING_CONSOLIDATION_FLOOR,
+} from "./thresholds.js";
+import type { BankSample } from "./types.js";
+
+function banks(over: Partial<BankSample> = {}): BankSample {
+  return { streaks: [], pending: [], ...over };
+}
+
+describe("evaluateConsolidationFailureStreak — the signal that was missing", () => {
+  it("FIRES on the live incident shape: 103 consecutive failures, EMPTY pending queue", () => {
+    // The exact row read off production during the incident:
+    //   overlord | consolidation | 103 | 668
+    // …while `consolidation` (pending/processing) was 0.
+    const ring = [
+      sample(0, {
+        consolidation: { pending: 0, oldestAgeS: 0 },
+        banks: banks({ streaks: [{ bank: "overlord", operationType: "consolidation", streak: 103, newestFailureAgeS: 668 }] }),
+      }),
+    ];
+    const v = evaluateConsolidationFailureStreak(ring);
+    expect(v.state).toBe("breach");
+    expect(v.severity).toBe("page");
+    expect(v.measured?.bank).toBe("overlord");
+    expect(v.measured?.streak).toBe(103);
+
+    // …and the pre-existing signal, on the SAME window, reports health. If
+    // this ever stops being true the blind spot was fixed elsewhere and this
+    // test should be re-derived, not deleted.
+    const old = evaluateConsolidationQueueAge(ring);
+    expect(old.state).toBe("ok");
+    expect(old.detail).toContain("consolidation queue empty");
+  });
+
+  it("warns at the threshold and pages at the page line", () => {
+    const at = (streak: number) =>
+      evaluateConsolidationFailureStreak([
+        sample(0, {
+          banks: banks({ streaks: [{ bank: "b", operationType: "consolidation", streak, newestFailureAgeS: 60 }] }),
+        }),
+      ]);
+    expect(at(CONSOLIDATION_FAILURE_STREAK_WARN - 1).state).toBe("ok");
+    expect(at(CONSOLIDATION_FAILURE_STREAK_WARN).state).toBe("breach");
+    expect(at(CONSOLIDATION_FAILURE_STREAK_WARN).severity).toBe("warn");
+    expect(at(CONSOLIDATION_FAILURE_STREAK_PAGE).severity).toBe("page");
+  });
+
+  it("scores the PAIR, not the bank — successful retains must not mask a wedged consolidator", () => {
+    // During the incident `overlord` completed 3,753 retains while its
+    // consolidation failed 112 times. A bank-wide streak would read 0.
+    const v = evaluateConsolidationFailureStreak([
+      sample(0, {
+        banks: banks({
+          streaks: [
+            { bank: "overlord", operationType: "consolidation", streak: 112, newestFailureAgeS: 90 },
+            // `retain` has no streak at all — it keeps completing.
+          ],
+        }),
+      }),
+    ]);
+    expect(v.state).toBe("breach");
+    expect(v.measured?.operationType).toBe("consolidation");
+  });
+
+  it("ignores a STALE streak — a fixed-but-idle bank must not alert for ever", () => {
+    const v = evaluateConsolidationFailureStreak([
+      sample(0, {
+        banks: banks({
+          streaks: [
+            {
+              bank: "overlord",
+              operationType: "consolidation",
+              streak: 500,
+              newestFailureAgeS: CONSOLIDATION_STREAK_RECENCY_S + 1,
+            },
+          ],
+        }),
+      }),
+    ]);
+    expect(v.state).toBe("ok");
+  });
+
+  it("reports no-data — never a pass — when the per-bank block is missing", () => {
+    expect(evaluateConsolidationFailureStreak([sample(0)]).state).toBe("no-data");
+    expect(evaluateConsolidationFailureStreak([sample(0, { banks: null })]).state).toBe("no-data");
+  });
+});
+
+describe("evaluatePendingConsolidationDepth — growth, not absolute depth", () => {
+  const window = (from: Array<[string, number]>, to: Array<[string, number]>) => [
+    sample(0, { banks: banks({ pending: from.map(([b, n]) => ({ bank: b, pending: n })) }) }),
+    sample(8, { banks: banks({ pending: to.map(([b, n]) => ({ bank: b, pending: n })) }) }),
+  ];
+
+  it("FIRES and PAGES on the incident's growth (0 → 38,130 in one window)", () => {
+    const v = evaluatePendingConsolidationDepth(window([["overlord", 0]], [["overlord", 38130]]));
+    expect(v.state).toBe("breach");
+    expect(v.severity).toBe("page");
+    expect(v.measured?.bank).toBe("overlord");
+    expect(v.measured?.growth).toBe(38130);
+  });
+
+  it("stays quiet on a bank that legitimately runs DEEP but is not growing", () => {
+    // The reason this signal is a growth rate: klanker holds 202,549 units.
+    // A flat — or draining — deep bank is healthy, and an absolute threshold
+    // would have paged on it every tick.
+    expect(evaluatePendingConsolidationDepth(window([["klanker", 40000]], [["klanker", 40000]])).state).toBe("ok");
+    expect(evaluatePendingConsolidationDepth(window([["klanker", 40000]], [["klanker", 1000]])).state).toBe("ok");
+  });
+
+  it("stays quiet below the depth floor however fast it grew", () => {
+    const to = PENDING_CONSOLIDATION_FLOOR - 1;
+    expect(evaluatePendingConsolidationDepth(window([["b", 0]], [["b", to]])).state).toBe("ok");
+  });
+
+  it("ignores a bank that did not exist at the window start — ingest is not a stall", () => {
+    expect(evaluatePendingConsolidationDepth(window([["old", 0]], [["brand-new", 9000]])).state).toBe("ok");
+  });
+
+  it("reports no-data with fewer than two ticks carrying a per-bank block", () => {
+    expect(evaluatePendingConsolidationDepth([sample(0), sample(1)]).state).toBe("no-data");
+  });
+});
+
+describe("evaluateVectorIndexCorruption — the HNSW canary", () => {
+  it("FIRES, pages, and names the index on the incident's error", () => {
+    const v = evaluateVectorIndexCorruption([
+      sample(0, {
+        vectorIndex: {
+          probed: 88,
+          corrupt: ["idx_mu_emb_obsv_81cef5f6a42e4b4d=different vector dimensions 384 and 0"],
+        },
+      }),
+    ]);
+    expect(v.state).toBe("breach");
+    expect(v.severity).toBe("page");
+    expect(v.detail).toContain("idx_mu_emb_obsv_81cef5f6a42e4b4d");
+    expect(v.detail).toContain("REINDEX");
+  });
+
+  it("passes on the measured healthy sweep (89 indexes, 0 corrupt)", () => {
+    const v = evaluateVectorIndexCorruption([sample(0, { vectorIndex: { probed: 89, corrupt: [] } })]);
+    expect(v.state).toBe("ok");
+    expect(v.measured?.probed).toBe(89);
+  });
+
+  it("reports no-data — never a pass — when the canary did not run", () => {
+    expect(evaluateVectorIndexCorruption([sample(0)]).state).toBe("no-data");
   });
 });

--- a/src/hindsight-watch/evaluate.ts
+++ b/src/hindsight-watch/evaluate.ts
@@ -10,10 +10,17 @@ import { counterDelta } from "./metrics.js";
 import {
   CONSOLIDATION_AGE_PAGE_S,
   CONSOLIDATION_AGE_WARN_S,
+  CONSOLIDATION_FAILURE_STREAK_PAGE,
+  CONSOLIDATION_FAILURE_STREAK_WARN,
+  CONSOLIDATION_STREAK_RECENCY_S,
   LLM_FAILURE_RATE_PAGE,
   LLM_FAILURE_RATE_WARN,
   LLM_MIN_SAMPLES,
   MIN_RETAIN_SAMPLES,
+  PENDING_CONSOLIDATION_FLOOR,
+  PENDING_CONSOLIDATION_GROWTH_FRACTION,
+  PENDING_CONSOLIDATION_GROWTH_PAGE_ABS,
+  PENDING_CONSOLIDATION_GROWTH_WARN_ABS,
   QUEUE_FLOOR,
   QUEUE_GROWTH_FRACTION,
   QUEUE_GROWTH_MIN_ABS,
@@ -28,7 +35,13 @@ import {
   RECALL_ZERO_MEMORY_WARN,
   RETAIN_FAILURE_RATE,
 } from "./thresholds.js";
-import type { RecallSample, Sample, SignalId, Verdict } from "./types.js";
+import type {
+  BankFailureStreak,
+  RecallSample,
+  Sample,
+  SignalId,
+  Verdict,
+} from "./types.js";
 
 function pct(x: number): string {
   return `${(x * 100).toFixed(1)}%`;
@@ -571,6 +584,224 @@ export function evaluateConsolidationQueueAge(ring: Sample[]): Verdict {
 }
 
 /**
+ * R6 — CONSECUTIVE terminal consolidation failures for one bank.
+ *
+ * The signal above, `consolidation-queue-age`, structurally cannot raise on
+ * this. Its only SQL is `... WHERE status IN ('pending','processing')` and the
+ * failing path calls `_mark_operation_failed` within milliseconds, so a
+ * deterministically failing bank empties that set and reads as
+ * `"consolidation queue empty"`. On 2026-07-29 the API reported
+ * `pending_operations: 0, failed_operations: 96, pending_consolidation: 37711`
+ * at the same instant, for 2.5 h, with every watchdog signal green.
+ *
+ * This reads the set nothing else in this module reads — `status='failed'` —
+ * and scores its CONSECUTIVENESS rather than its rate. Consecutiveness is what
+ * separates "a flake" from "this will fail again the same way", and it covers
+ * the whole class of deterministic non-retryable consolidation faults rather
+ * than one error string.
+ *
+ * `no-data` when the block is missing, never a pass — the same rule the recall
+ * signals live by.
+ */
+export function evaluateConsolidationFailureStreak(ring: Sample[]): Verdict {
+  const signal = "consolidation-failure-streak" as const;
+  if (ring.length === 0) return { signal, state: "no-data", detail: "no samples" };
+  const banks = ring[ring.length - 1].banks ?? null;
+  if (banks === null) {
+    return {
+      signal,
+      state: "no-data",
+      detail:
+        "per-bank consolidation not probed this tick (no psql client, no pg descriptor, " +
+        "or the container is down) — the `container` signal covers the last of those",
+    };
+  }
+  // A streak whose newest failure is old is not evidence of an ONGOING fault:
+  // a streak is defined relative to the last COMPLETED op, so a fixed-but-idle
+  // bank would otherwise hold its historical streak — and alert on it — for
+  // ever.
+  const live = banks.streaks.filter((s) => s.newestFailureAgeS <= CONSOLIDATION_STREAK_RECENCY_S);
+  let worst: BankFailureStreak | null = null;
+  for (const s of live) if (worst === null || s.streak > worst.streak) worst = s;
+  if (worst === null || worst.streak < CONSOLIDATION_FAILURE_STREAK_WARN) {
+    const observed = worst?.streak ?? 0;
+    return {
+      signal,
+      state: "ok",
+      detail:
+        `longest live consolidation-failure streak ${observed} across ` +
+        `${banks.streaks.length} bank/op pair(s) — warn ≥${CONSOLIDATION_FAILURE_STREAK_WARN}, ` +
+        `page ≥${CONSOLIDATION_FAILURE_STREAK_PAGE}`,
+      measured: { streak: observed, pairs: banks.streaks.length },
+    };
+  }
+  const { state, severity } = scoreHigherIsWorse(
+    worst.streak,
+    CONSOLIDATION_FAILURE_STREAK_WARN,
+    CONSOLIDATION_FAILURE_STREAK_PAGE,
+  );
+  const breaching = live.filter((s) => s.streak >= CONSOLIDATION_FAILURE_STREAK_WARN);
+  const others = breaching
+    .filter((s) => s !== worst)
+    .map((s) => `${s.bank}/${s.operationType}×${s.streak}`);
+  return {
+    signal,
+    state,
+    severity,
+    detail:
+      `bank "${worst.bank}": ${worst.streak} consecutive FAILED ${worst.operationType} ` +
+      `operation(s) with no completion in between, newest ` +
+      `${Math.round(worst.newestFailureAgeS / 60)}m ago — ` +
+      `warn ≥${CONSOLIDATION_FAILURE_STREAK_WARN}, page ≥${CONSOLIDATION_FAILURE_STREAK_PAGE}. ` +
+      "The pending/processing queue reads EMPTY while this holds, so " +
+      "`consolidation-queue-age` cannot see it." +
+      (others.length > 0 ? `\n  also breaching: ${others.join(", ")}` : ""),
+    measured: {
+      streak: worst.streak,
+      bank: worst.bank,
+      operationType: worst.operationType,
+      newestFailureAgeS: worst.newestFailureAgeS,
+      breachingPairs: breaching.length,
+    },
+  };
+}
+
+/**
+ * R7 — per-bank unconsolidated depth RISING.
+ *
+ * The corroborating signal, and the one that catches the failure mode R6
+ * cannot: a consolidator that never ENQUEUES anything produces no failed
+ * operations at all, so there is no streak to count — but the memories still
+ * pile up unconsolidated and recall against that bank degrades identically.
+ *
+ * Growth, not absolute depth, for the same reason `retain-queue-growth` is
+ * growth: some banks legitimately run deep (`klanker` holds 202,549 units), so
+ * an absolute line is either noise or useless. Deliberately the same
+ * "deep AND rising" conjunction as `evaluateQueueGrowth`, applied per bank.
+ *
+ * The window ends are the oldest and newest samples that CARRY a bank block,
+ * not the ends of the ring: a tick whose psql probe was unavailable must not
+ * silently shorten the comparison to two samples minutes apart, which would
+ * read almost any real growth as flat.
+ */
+export function evaluatePendingConsolidationDepth(ring: Sample[]): Verdict {
+  const signal = "pending-consolidation-depth" as const;
+  const withBanks = ring.filter((s) => (s.banks ?? null) !== null);
+  if (withBanks.length < 2) {
+    return {
+      signal,
+      state: "no-data",
+      detail: `only ${withBanks.length} tick(s) carried a per-bank block — need two to see a trend`,
+      measured: { samples: withBanks.length },
+    };
+  }
+  const first = new Map(withBanks[0].banks!.pending.map((p) => [p.bank, p.pending]));
+  const last = withBanks[withBanks.length - 1].banks!.pending;
+  const mins = windowMinutes(withBanks);
+  let worst: { bank: string; from: number; to: number; growth: number; need: number } | null = null;
+  for (const p of last) {
+    const from = first.get(p.bank);
+    // A bank absent at the window start has no trend — a brand-new bank's
+    // first thousand memories are ingest, not a stall.
+    if (from === undefined) continue;
+    const growth = p.pending - from;
+    const need = Math.max(
+      PENDING_CONSOLIDATION_GROWTH_WARN_ABS,
+      Math.ceil(PENDING_CONSOLIDATION_GROWTH_FRACTION * from),
+    );
+    if (p.pending < PENDING_CONSOLIDATION_FLOOR || growth < need) continue;
+    if (worst === null || growth > worst.growth) {
+      worst = { bank: p.bank, from, to: p.pending, growth, need };
+    }
+  }
+  if (worst === null) {
+    return {
+      signal,
+      state: "ok",
+      detail:
+        `no bank's unconsolidated depth is both ≥${PENDING_CONSOLIDATION_FLOOR} and rising ` +
+        `over ${mins}m (${last.length} bank(s))`,
+      measured: { banks: last.length, windowMinutes: mins },
+    };
+  }
+  const { state, severity } = scoreHigherIsWorse(
+    worst.growth,
+    PENDING_CONSOLIDATION_GROWTH_WARN_ABS,
+    PENDING_CONSOLIDATION_GROWTH_PAGE_ABS,
+  );
+  const perHour = mins > 0 ? Math.round((worst.growth * 60) / mins) : worst.growth;
+  return {
+    signal,
+    state,
+    severity,
+    detail:
+      `bank "${worst.bank}": unconsolidated memories ${worst.from} → ${worst.to} ` +
+      `(+${worst.growth}, ≈${perHour}/h) over ${mins}m — fires at ` +
+      `≥${PENDING_CONSOLIDATION_FLOOR} deep AND +${worst.need} growth, pages at ` +
+      `+${PENDING_CONSOLIDATION_GROWTH_PAGE_ABS}. Rising depth with no failed operations ` +
+      `means consolidation is not being attempted at all.`,
+    measured: {
+      bank: worst.bank,
+      pending: worst.to,
+      growth: worst.growth,
+      growthPerHour: perHour,
+      growthNeeded: worst.need,
+      windowMinutes: mins,
+    },
+  };
+}
+
+/**
+ * R8 — an HNSW index raises on a nearest-neighbour probe.
+ *
+ * The root-cause canary under R6/R7: on 2026-07-29 every failed consolidation
+ * carried `different vector dimensions 384 and 0`, raised out of an index
+ * scan. `amcheck` has no HNSW support, so scanning one IS the verifier — there
+ * is no cheaper check and no data-level check at all (the column is
+ * `vector(384)` and the table held zero off-dimension rows throughout).
+ *
+ * Always `page`, and edge-triggered in `run.ts`. Index corruption does not
+ * flap, does not resolve itself, and fails every write path that touches the
+ * index — there is no "degraded" reading of it.
+ */
+export function evaluateVectorIndexCorruption(ring: Sample[]): Verdict {
+  const signal = "vector-index-corruption" as const;
+  if (ring.length === 0) return { signal, state: "no-data", detail: "no samples" };
+  const v = ring[ring.length - 1].vectorIndex ?? null;
+  if (v === null) {
+    return {
+      signal,
+      state: "no-data",
+      detail:
+        "vector-index canary did not run this tick (no psql client, no pg descriptor, " +
+        "or the container is down) — the `container` signal covers the last of those",
+    };
+  }
+  if (v.corrupt.length === 0) {
+    return {
+      signal,
+      state: "ok",
+      detail: `${v.probed} HNSW index(es) answered a nearest-neighbour probe cleanly`,
+      measured: { probed: v.probed, corrupt: 0 },
+    };
+  }
+  const shown = v.corrupt.slice(0, 5).join("\n  ");
+  const more = v.corrupt.length > 5 ? `\n  …and ${v.corrupt.length - 5} more` : "";
+  return {
+    signal,
+    state: "breach",
+    severity: "page",
+    detail:
+      `${v.corrupt.length} of ${v.probed + v.corrupt.length} HNSW index(es) RAISED on a ` +
+      `nearest-neighbour probe — the index is corrupt, and every consolidation or recall ` +
+      `that touches it fails:\n  ${shown}${more}\n` +
+      `Fix: REINDEX the named index(es). amcheck cannot verify HNSW, so this probe is the ` +
+      `only detector.`,
+    measured: { probed: v.probed, corrupt: v.corrupt.length, first: v.corrupt[0] },
+  };
+}
+
+/**
  * F1 — the LLM lane's fallback is not absorbing local failures.
  *
  * Stated positively on purpose. LiteLLM's fallback runs INSIDE the client
@@ -633,6 +864,9 @@ export function evaluateAll(ring: Sample[]): Verdict[] {
     evaluateRecallInjectedScore(ring),
     evaluateRecallZeroMemory(ring),
     evaluateConsolidationQueueAge(ring),
+    evaluateConsolidationFailureStreak(ring),
+    evaluatePendingConsolidationDepth(ring),
+    evaluateVectorIndexCorruption(ring),
     evaluateLlmFallback(ring),
   ];
 }

--- a/src/hindsight-watch/probe.test.ts
+++ b/src/hindsight-watch/probe.test.ts
@@ -207,3 +207,118 @@ describe("evaluateFailureRate with missing retain counters", () => {
     expect((v.measured as { rate: number }).rate).toBeCloseTo(0.5, 6);
   });
 });
+
+// ── the per-bank consolidation and HNSW probes ──────────────────────────
+
+import { probeBankConsolidation, probeVectorIndexes } from "./probe.js";
+import type { Runner } from "./probe.js";
+
+/** A runner that answers every `docker exec` with one canned stdout. */
+function psql(stdout: string, status = 0): Runner {
+  return () => ({ status, stdout, stderr: "" });
+}
+
+describe("probeBankConsolidation", () => {
+  it("parses the live incident output into streaks and per-bank depth", () => {
+    const out = probeBankConsolidation(
+      "c",
+      psql("S|overlord|consolidation|103|668\nP|overlord|38130\nP|carrie|45\nP|klanker|0\n"),
+    );
+    expect(out).toEqual({
+      streaks: [{ bank: "overlord", operationType: "consolidation", streak: 103, newestFailureAgeS: 668 }],
+      pending: [
+        { bank: "overlord", pending: 38130 },
+        { bank: "carrie", pending: 45 },
+        { bank: "klanker", pending: 0 },
+      ],
+    });
+  });
+
+  it("returns null — not an empty, healthy-looking block — when psql fails", () => {
+    expect(probeBankConsolidation("c", psql("", 1))).toBeNull();
+  });
+
+  it("returns null when NOTHING parsed: a live fleet always has ≥1 bank", () => {
+    // The dangerous shape: the query changed shape / the container answered
+    // with a banner. `{streaks: [], pending: []}` would evaluate as a clean
+    // pass on both signals for ever.
+    expect(probeBankConsolidation("c", psql("psql: could not connect\n"))).toBeNull();
+  });
+
+  it("skips a malformed row but keeps the rows it understood", () => {
+    const out = probeBankConsolidation(
+      "c",
+      psql("S|weird|bank|with|pipes|x|9\nS|overlord|consolidation|7|30\nP|overlord|12\n"),
+    );
+    expect(out?.streaks).toEqual([
+      { bank: "overlord", operationType: "consolidation", streak: 7, newestFailureAgeS: 30 },
+    ]);
+    expect(out?.pending).toEqual([{ bank: "overlord", pending: 12 }]);
+  });
+
+  it("rejects a negative or non-numeric count rather than trusting it", () => {
+    expect(probeBankConsolidation("c", psql("S|b|consolidation|-1|30\nP|b|4\n"))?.streaks).toEqual([]);
+    expect(probeBankConsolidation("c", psql("S|b|consolidation|NaN|30\nP|b|4\n"))?.streaks).toEqual([]);
+  });
+});
+
+describe("probeVectorIndexes", () => {
+  const notice = (probed: number, bad: string[]) =>
+    `NOTICE:  VECIDX|${probed}|${bad.length}|${bad.map((b) => b + ";").join("")}\n`;
+
+  it("parses the measured healthy sweep", () => {
+    expect(probeVectorIndexes("c", psql(notice(89, [])))).toEqual({ probed: 89, corrupt: [] });
+  });
+
+  it("parses a corrupt index, preserving the name and the error", () => {
+    const out = probeVectorIndexes(
+      "c",
+      psql(notice(88, ["idx_mu_emb_obsv_81cef5f6a42e4b4d=different vector dimensions 384 and 0"])),
+    );
+    expect(out?.probed).toBe(88);
+    expect(out?.corrupt).toEqual(["idx_mu_emb_obsv_81cef5f6a42e4b4d=different vector dimensions 384 and 0"]);
+  });
+
+  it("keeps an error that contains a pipe — the tail is re-joined, not truncated", () => {
+    const out = probeVectorIndexes("c", psql(notice(88, ["idx_a=bad tuple a|b"])));
+    expect(out?.corrupt).toEqual(["idx_a=bad tuple a|b"]);
+  });
+
+  it("returns null — never `ok` — when the count and the parsed list disagree", () => {
+    // Fail-closed: if we cannot read the answer we say so. `{probed, corrupt: []}`
+    // here would report a corrupt fleet as clean.
+    expect(probeVectorIndexes("c", psql("NOTICE:  VECIDX|88|2|idx_a=boom;\n"))).toBeNull();
+  });
+
+  it("returns null when the NOTICE never arrived", () => {
+    expect(probeVectorIndexes("c", psql("\n"))).toBeNull();
+    expect(probeVectorIndexes("c", psql(notice(89, []), 1))).toBeNull();
+  });
+
+  it("actually asks the database — the generated SQL carries the count(nn) shape", () => {
+    // The elision guard from probe.ts: aggregate over `*` and the planner
+    // drops the correlated subquery, so the sweep touches no index and passes
+    // on a corrupt one. Assert the shipped statement over the wire.
+    let sql = "";
+    probeVectorIndexes("c", (_cmd, args) => {
+      sql = args[args.length - 1] ?? "";
+      return { status: 0, stdout: notice(1, []), stderr: "" };
+    });
+    expect(sql).toContain("count(nn)");
+    expect(sql).not.toContain("count(*)");
+    expect(sql).toContain("pg_get_expr(i.indpred, i.indrelid)");
+    expect(sql).toContain("amname = 'hnsw'");
+  });
+
+  it("clamps the sample size to a positive integer before splicing it", () => {
+    let sql = "";
+    const cap: Runner = (_c, args) => {
+      sql = args[args.length - 1] ?? "";
+      return { status: 0, stdout: notice(1, []), stderr: "" };
+    };
+    probeVectorIndexes("c", cap, 3.9);
+    expect(sql).toContain("r.tbl, r.pred, 3)");
+    probeVectorIndexes("c", cap, -5);
+    expect(sql).toContain("r.tbl, r.pred, 1)");
+  });
+});

--- a/src/hindsight-watch/probe.ts
+++ b/src/hindsight-watch/probe.ts
@@ -9,6 +9,11 @@
  * whole transcripts, p50 ~98 KB. At the recommended 15-minute cadence that
  * is 4 requests an hour against a backend whose own workers issue thousands
  * — the watchdog cannot itself become the load.
+ *
+ * Plus three read-only `docker exec` psql calls (measured live 2026-07-29):
+ * the consolidation queue depth, the per-bank consolidation block (0.284 s for
+ * a grouped aggregate over 676,720 memory units), and the HNSW canary (0.45 s
+ * across all 89 indexes). None of the three writes anything.
  */
 
 import { spawnSync } from "node:child_process";
@@ -28,8 +33,16 @@ import {
   DEFAULT_METRICS_URL,
   METRICS_MAX_BYTES,
   METRICS_TIMEOUT_MS,
+  VECTOR_INDEX_SAMPLE_ROWS,
 } from "./thresholds.js";
-import type { ConsolidationSample, Sample } from "./types.js";
+import type {
+  BankFailureStreak,
+  BankPendingConsolidation,
+  BankSample,
+  ConsolidationSample,
+  Sample,
+  VectorIndexSample,
+} from "./types.js";
 
 /**
  * A probe failed in a way that means the watchdog CANNOT SEE hindsight. It
@@ -325,7 +338,7 @@ export interface ProbeOptions {
  * container's own environment and never crosses back out — the only thing
  * this returns is two integers.
  */
-const CONSOLIDATION_QUEUE_SH = `
+const PSQL_BOOTSTRAP_SH = `
 set -e
 B="$(ls -d /home/hindsight/.pg0/installation/*/bin 2>/dev/null | head -1)"
 PSQL="$(command -v psql 2>/dev/null || echo "\${B:-/nonexistent}/psql")"
@@ -342,9 +355,150 @@ d=json.load(open(sys.argv[1]))
 q=lambda k,dflt: shlex.quote(str(d.get(k) or dflt))
 print("U=%s DB=%s P=%s PW=%s"%(q("username","hindsight"),q("database","hindsight"),q("port",5432),q("password","")))' "$D")"
 [ -n "$PW" ] || exit 0
+`;
+
+const CONSOLIDATION_QUEUE_SH = `${PSQL_BOOTSTRAP_SH}
 PGPASSWORD="$PW" "$PSQL" -U "$U" -h /tmp -p "$P" -d "$DB" -tAc \\
   "SELECT count(*)||'|'||coalesce(max(extract(epoch from (now()-created_at)))::bigint,0) FROM async_operations WHERE status IN ('pending','processing')"
 `;
+
+/**
+ * Per-bank consolidation facts: terminal-failure STREAKS and unconsolidated
+ * DEPTH, in one psql pass.
+ *
+ * Two tagged sections on stdout, so one round trip answers both signals:
+ *
+ *   `S|<bank>|<operation_type>|<streak>|<newest_failure_age_seconds>`
+ *   `P|<bank>|<pending_consolidation>`
+ *
+ * ### The streak query
+ *
+ * A streak is the `status='failed'` rows NEWER than that
+ * `(bank_id, operation_type)` pair's most recent `status='completed'` row.
+ * Three properties, each load-bearing:
+ *
+ *  - **`completed` breaks a streak; `pending`/`processing` do not.** A row
+ *    that has not reached a terminal state is not evidence the fault is over,
+ *    and letting an in-flight attempt clear the streak would blind the signal
+ *    for exactly as long as the next attempt takes to fail.
+ *  - **Grouped by the PAIR, not the bank.** During the incident `overlord`
+ *    completed 3,753 retains while its consolidation failed 112 times; a
+ *    bank-wide streak would have been reset by every one of them.
+ *  - **`-infinity` for a pair that has never completed.** `coalesce` to a
+ *    finite date would silently window the count; a pair whose very first
+ *    op failed must still register a streak.
+ *
+ * ### The depth query
+ *
+ * `count(*) FILTER (WHERE consolidated_at IS NULL AND fact_type IN
+ * ('experience','world'))` per bank — the same predicate the API's
+ * `get_bank_freshness` uses for the `pending_consolidation` field it
+ * publishes on `/v1/default/banks/{bank}/stats`. Computed here rather than
+ * fetched over N HTTP calls: measured 0.284 s for the whole fleet, against
+ * ~1.4-2.1 s PER BANK for the `/stats` endpoint.
+ */
+const BANK_CONSOLIDATION_SH = `${PSQL_BOOTSTRAP_SH}
+PGPASSWORD="$PW" "$PSQL" -U "$U" -h /tmp -p "$P" -d "$DB" -tAc \\
+  "SELECT 'S|'||a.bank_id||'|'||a.operation_type||'|'||count(*)||'|'||extract(epoch from (now()-max(a.created_at)))::bigint
+     FROM async_operations a
+    WHERE a.status = 'failed'
+      AND a.created_at > coalesce((SELECT max(b.created_at) FROM async_operations b
+                                    WHERE b.bank_id = a.bank_id
+                                      AND b.operation_type = a.operation_type
+                                      AND b.status = 'completed'), '-infinity'::timestamptz)
+    GROUP BY a.bank_id, a.operation_type
+    UNION ALL
+   SELECT 'P|'||m.bank_id||'|'||count(*) FILTER (WHERE m.consolidated_at IS NULL AND m.fact_type IN ('experience','world'))
+     FROM memory_units m
+    GROUP BY m.bank_id"
+`;
+
+/**
+ * The HNSW nearest-neighbour canary.
+ *
+ * ### Why a NN probe is the only option
+ *
+ * `amcheck` has no HNSW support, so there is no verifier for these indexes
+ * short of scanning one. A corrupt index raises `different vector dimensions
+ * 384 and 0` when the scan reaches the damaged node — and nothing else in the
+ * system notices, because `memory_units.embedding` is `vector(384)` and the
+ * table itself is clean (0 rows with `vector_dims(embedding) <> 384`).
+ *
+ * ### THE GOTCHA — `count(nn)`, never `count(*)`
+ *
+ * The probe aggregates over the correlated subquery's RESULT. Aggregate over
+ * `*` instead and the planner elides the subquery entirely: the probe then
+ * costs nothing, touches no index, raises nothing, and PASSES. Verified live
+ * on the production database, same statement both ways:
+ *
+ *   count(nn) → `Index Scan using idx_mu_emb_obsv_81cef5f6a42e4b4d`,
+ *               `SubPlan 1`, 9.6 ms
+ *   count(*)  → bare `Aggregate`, no `SubPlan`, no index scan, 0.8 ms
+ *
+ * `probeVectorIndexes` re-asserts this on the SQL text before running it, so
+ * the elision cannot be reintroduced by an edit that still type-checks.
+ *
+ * ### Why the predicate is spliced verbatim
+ *
+ * The per-bank partial indexes are `WHERE fact_type = '…' AND bank_id = '…'`.
+ * The planner will only choose a partial index when it can prove the
+ * predicate, which it cannot do against a correlated column reference — the
+ * first draft of this probe correlated `m2.bank_id = s.bank_id` and the
+ * planner silently fell back to the single global index, leaving all 88
+ * partial ones unprobed. Splicing `pg_get_expr(indpred, indrelid)` — the
+ * predicate Postgres itself stores — is what makes the probe hit the index it
+ * names. It is not user input: it comes out of the catalog.
+ *
+ * ### Why a DO block
+ *
+ * One subtransaction per index, each with its own `EXCEPTION` handler, so a
+ * corrupt index is REPORTED BY NAME and the sweep continues to the next one
+ * instead of aborting at the first fault. The result comes back as a single
+ * `RAISE NOTICE` (psql writes notices to stderr, so the call redirects
+ * `2>&1`) because a `DO` block cannot return rows.
+ *
+ * Prints one `VECIDX|<probed>|<corrupt_count>|<name=err;…>` line.
+ */
+function vectorIndexSh(sampleRows: number): string {
+  // The only caller-controlled value that reaches the SQL text. Clamped to a
+  // positive integer so it can only ever be a `LIMIT` operand — the index
+  // names and predicates around it come from the catalog, not from input.
+  const limit = Math.max(1, Math.floor(Number.isFinite(sampleRows) ? sampleRows : 1));
+  return `${PSQL_BOOTSTRAP_SH}
+PGPASSWORD="$PW" PGOPTIONS='-c client_min_messages=notice' \\
+  "$PSQL" -U "$U" -h /tmp -p "$P" -d "$DB" -tAc "
+DO \\$\\$
+DECLARE r record; bad text := ''; n int := 0; probed int := 0;
+BEGIN
+  FOR r IN
+    SELECT c.relname AS idx,
+           i.indrelid::regclass::text AS tbl,
+           coalesce(pg_get_expr(i.indpred, i.indrelid), 'true') AS pred
+      FROM pg_index i
+      JOIN pg_class c ON c.oid = i.indexrelid
+      JOIN pg_am am ON am.oid = c.relam
+     WHERE am.amname = 'hnsw'
+     ORDER BY c.relname
+  LOOP
+    BEGIN
+      EXECUTE format(
+        'SELECT count(nn) FROM (SELECT (SELECT m2.ctid FROM %1\\$s m2 WHERE %2\\$s ORDER BY m2.embedding <=> s.embedding LIMIT 1) AS nn FROM (SELECT embedding FROM %1\\$s s0 WHERE %2\\$s AND embedding IS NOT NULL LIMIT %3\\$s) s) t',
+        r.tbl, r.pred, ${limit});
+      probed := probed + 1;
+    EXCEPTION WHEN others THEN
+      n := n + 1;
+      -- Both delimiters are stripped from the message BEFORE it is appended.
+      -- ';' separates entries and a newline would split the NOTICE line, so an
+      -- SQLERRM containing either would desynchronise the parsed list from n,
+      -- and probeVectorIndexes rejects a mismatched block as unreadable —
+      -- turning a real corruption into a silent no-data.
+      bad := bad || r.idx || '=' || translate(SQLERRM, ';' || chr(10) || chr(13), ',  ') || ';';
+    END;
+  END LOOP;
+  RAISE NOTICE 'VECIDX|%|%|%', probed, n, bad;
+END \\$\\$;" 2>&1
+`;
+}
 
 /**
  * Read the `async_operations` backlog, or null when it cannot be read.
@@ -369,6 +523,93 @@ export function probeConsolidationQueue(
   if (!Number.isFinite(pending) || !Number.isFinite(oldestAgeS)) return null;
   if (pending < 0 || oldestAgeS < 0) return null;
   return { pending, oldestAgeS };
+}
+
+/**
+ * Read the per-bank consolidation block, or null when it cannot be read.
+ *
+ * Soft-fails for the same reason `probeConsolidationQueue` does: psql and the
+ * pg descriptor legitimately do not exist off-host, and throwing would make
+ * the whole watchdog unrunnable in CI or on a laptop. Null degrades exactly
+ * the two per-bank signals to `no-data` — inert, visible, never a pass.
+ *
+ * A single unparseable LINE is skipped rather than nulling the block: a
+ * bank id containing a `|` would otherwise take the whole signal down. A
+ * block with NO parseable line at all is null, because "the query returned
+ * nothing we understood" is not the same as "the fleet is clean".
+ */
+export function probeBankConsolidation(
+  container: string = DEFAULT_CONTAINER,
+  run: Runner = defaultRunner,
+): BankSample | null {
+  const r = run("docker", ["exec", container, "sh", "-c", BANK_CONSOLIDATION_SH]);
+  if (r.status !== 0) return null;
+  const streaks: BankFailureStreak[] = [];
+  const pending: BankPendingConsolidation[] = [];
+  let parsedAny = false;
+  for (const line of r.stdout.split("\n")) {
+    const t = line.trim();
+    if (t === "") continue;
+    const f = t.split("|");
+    if (f[0] === "S" && f.length === 5) {
+      const streak = Number(f[3]);
+      const age = Number(f[4]);
+      if (!Number.isFinite(streak) || !Number.isFinite(age) || streak < 0 || age < 0) continue;
+      streaks.push({ bank: f[1], operationType: f[2], streak, newestFailureAgeS: age });
+      parsedAny = true;
+    } else if (f[0] === "P" && f.length === 3) {
+      const n = Number(f[2]);
+      if (!Number.isFinite(n) || n < 0) continue;
+      pending.push({ bank: f[1], pending: n });
+      parsedAny = true;
+    }
+  }
+  // A live fleet always has at least one bank, so zero parseable rows means
+  // the query did not run the way we think it did — report blindness, not
+  // health.
+  if (!parsedAny) return null;
+  return { streaks, pending };
+}
+
+/**
+ * Scan every HNSW index with a nearest-neighbour probe. Null when it could
+ * not run — soft-fail, exactly like the two probes above.
+ *
+ * The `count(nn)` assertion below is a DETERMINISTIC guard, not a comment: an
+ * edit that switches the aggregate back to `count(*)` makes the planner elide
+ * the correlated subquery, and the probe would then pass on a corrupt index
+ * forever with no observable difference. Refusing to run at all is loud;
+ * running and silently checking nothing is the failure mode this whole PR
+ * exists to remove.
+ */
+export function probeVectorIndexes(
+  container: string = DEFAULT_CONTAINER,
+  run: Runner = defaultRunner,
+  sampleRows: number = VECTOR_INDEX_SAMPLE_ROWS,
+): VectorIndexSample | null {
+  const sh = vectorIndexSh(sampleRows);
+  if (!sh.includes("count(nn)")) return null;
+  const r = run("docker", ["exec", container, "sh", "-c", sh]);
+  if (r.status !== 0) return null;
+  const line = r.stdout.split("\n").find((l) => l.includes("VECIDX|"));
+  if (line === undefined) return null;
+  const f = line.slice(line.indexOf("VECIDX|")).trim().split("|");
+  if (f.length < 4) return null;
+  const probed = Number(f[1]);
+  const count = Number(f[2]);
+  if (!Number.isFinite(probed) || !Number.isFinite(count) || probed < 0 || count < 0) return null;
+  // Re-join the tail: an SQLERRM can itself contain `|`.
+  const corrupt = f
+    .slice(3)
+    .join("|")
+    .split(";")
+    .map((s) => s.trim())
+    .filter((s) => s !== "");
+  // The reported count and the parsed list must agree, or we do not know what
+  // we are looking at. Trust the COUNT — it is what the database said — and
+  // treat a mismatch as unreadable rather than under-reporting corruption.
+  if (corrupt.length !== count) return null;
+  return { probed, corrupt };
 }
 
 /** Run every probe into one sample. A core-probe failure throws a ProbeError. */
@@ -400,6 +641,8 @@ export async function probeOnce(
     throw new ProbeError(`reading recall logs: ${(e as Error).message}`, "spool");
   }
   const consolidation = probeConsolidationQueue(opts.container, opts.run);
+  const banks = probeBankConsolidation(opts.container, opts.run);
+  const vectorIndex = probeVectorIndexes(opts.container, opts.run);
   return {
     sample: {
       ts,
@@ -418,6 +661,8 @@ export async function probeOnce(
       health: container.health,
       recall,
       consolidation,
+      banks,
+      vectorIndex,
     },
     spool,
     recall,

--- a/src/hindsight-watch/run.test.ts
+++ b/src/hindsight-watch/run.test.ts
@@ -538,3 +538,145 @@ describe("formatFiring — severity in the notification shade", () => {
     expect(out.startsWith("🔴 hindsight: retain-failure-rate\n")).toBe(true);
   });
 });
+
+// ── the 2026-07-29 consolidation outage, end to end ─────────────────────
+//
+// The regression this whole file section exists to pin: on 2026-07-29 the
+// `overlord` bank's consolidation failed on ~every run for 2.5 h while the
+// watchdog's `consolidation-queue-age` signal read "consolidation queue
+// empty" — because the failing path marks the row `failed` in milliseconds,
+// so it never appears in the `pending`/`processing` set that signal reads.
+//
+// These tests construct that EXACT condition — N consecutive failed ops with
+// an empty pending queue — and assert an operator DM is actually sent. They
+// fail against the pre-#3982 build for the right reason: nothing there reads
+// `status='failed'`, so nothing fires.
+
+/**
+ * A docker runner that answers each of the four calls a tick makes, keyed on
+ * the shell text so it cannot silently answer the wrong probe.
+ */
+function dockerIncident(opts: {
+  /** `(bank, op_type, streak, newest_failure_age_s)` rows */
+  streaks?: Array<[string, string, number, number]>;
+  /** `(bank, pending_consolidation)` rows */
+  pending?: Array<[string, number]>;
+  /** async_operations rows in `pending`/`processing` — the OLD signal's input */
+  queueDepth?: number;
+  queueOldestAgeS?: number;
+  /** HNSW indexes that raised, as `name=error` */
+  corruptIndexes?: string[];
+  probedIndexes?: number;
+}): (cmd: string, args: string[]) => { status: number | null; stdout: string; stderr: string } {
+  const ok = (stdout: string) => ({ status: 0, stdout, stderr: "" });
+  return (_cmd, args) => {
+    if (args[0] === "inspect") return ok("0\t2026-07-29T04:00:00Z\thealthy\n");
+    const sh = args[args.length - 1] ?? "";
+    if (sh.includes("VECIDX")) {
+      const bad = opts.corruptIndexes ?? [];
+      const probed = opts.probedIndexes ?? 89;
+      return ok(`NOTICE:  VECIDX|${probed}|${bad.length}|${bad.map((b) => `${b};`).join("")}\n`);
+    }
+    if (sh.includes("'S|'||")) {
+      const lines = [
+        ...(opts.streaks ?? []).map(([b, t, n, age]) => `S|${b}|${t}|${n}|${age}`),
+        ...(opts.pending ?? [["overlord", 0]] as Array<[string, number]>).map(
+          ([b, n]) => `P|${b}|${n}`,
+        ),
+      ];
+      return ok(lines.join("\n") + "\n");
+    }
+    if (sh.includes("status IN ('pending','processing')")) {
+      return ok(`${opts.queueDepth ?? 0}|${opts.queueOldestAgeS ?? 0}\n`);
+    }
+    return { status: 1, stdout: "", stderr: "unexpected docker call" };
+  };
+}
+
+describe("tick — the 2026-07-29 silent consolidation outage", () => {
+  it("DMs the operator while consolidation-queue-age still reads EMPTY", async () => {
+    const sent: Sent = { texts: [] };
+    spool(0);
+    const t0 = Date.parse("2026-07-29T05:00:00Z");
+    const run = dockerIncident({
+      // The live shape, read off the production database during the incident:
+      // `overlord | consolidation | 103 | 668`. Nothing else in the fleet.
+      streaks: [["overlord", "consolidation", 103, 668]],
+      pending: [["overlord", 38130], ["carrie", 45]],
+      // …and the pending/processing queue is EMPTY at the same instant. This
+      // is the whole bug: the old signal's input says the fleet is healthy.
+      queueDepth: 0,
+    });
+    const base = { statePath, agentsDir, notify: makeNotify(sent), run };
+
+    const r = await tick({
+      ...base,
+      fetchImpl: fakeFetch(metricsBody(1000, 10)),
+      nowFn: () => t0,
+    });
+
+    // The blind signal, in the same tick, on the same data: still "ok".
+    const age = r.outcomes.find((o) => o.verdict.signal === "consolidation-queue-age")!;
+    expect(age.verdict.state).toBe("ok");
+    expect(age.verdict.detail).toContain("consolidation queue empty");
+
+    // The new one fires on the FIRST tick — it is an edge signal, because a
+    // streak of 3+ is already its own debounce.
+    const streak = r.outcomes.find((o) => o.verdict.signal === "consolidation-failure-streak")!;
+    expect(streak.verdict.state).toBe("breach");
+    expect(streak.verdict.severity).toBe("page");
+    expect(streak.transition).toBe("fired");
+    expect(r.exitCode).toBe(10);
+
+    // The outcome that matters: a human was told, and told WHICH bank.
+    const dm = sent.texts.find((t) => t.includes("consolidation-failure-streak"));
+    expect(dm).toBeDefined();
+    expect(dm).toContain("overlord");
+    expect(dm).toContain("103 consecutive FAILED consolidation");
+  });
+
+  it("stays silent on a fleet with no failure streak at all — the live healthy shape", async () => {
+    const sent: Sent = { texts: [] };
+    spool(0);
+    const t0 = Date.parse("2026-07-29T05:00:00Z");
+    // Measured live 2026-07-29: 0 streak rows, largest healthy per-bank
+    // unconsolidated depth 45, 89 HNSW indexes clean.
+    const run = dockerIncident({
+      streaks: [],
+      pending: [["carrie", 45], ["switchroom-dev", 12], ["klanker", 0]],
+    });
+    const base = { statePath, agentsDir, notify: makeNotify(sent), run };
+    for (let i = 0; i <= 4; i++) {
+      const r = await tick({
+        ...base,
+        fetchImpl: fakeFetch(metricsBody(1000 + i * 40, 10)),
+        nowFn: () => t0 + i * 900_000,
+      });
+      expect(r.exitCode).toBe(0);
+    }
+    expect(sent.texts).toEqual([]);
+  });
+
+  it("DMs on a corrupt HNSW index, naming the index and the fix", async () => {
+    const sent: Sent = { texts: [] };
+    spool(0);
+    const t0 = Date.parse("2026-07-29T05:00:00Z");
+    const run = dockerIncident({
+      probedIndexes: 88,
+      corruptIndexes: ["idx_mu_emb_obsv_81cef5f6a42e4b4d=different vector dimensions 384 and 0"],
+    });
+    const r = await tick({
+      statePath,
+      agentsDir,
+      notify: makeNotify(sent),
+      run,
+      fetchImpl: fakeFetch(metricsBody(1000, 10)),
+      nowFn: () => t0,
+    });
+    expect(r.exitCode).toBe(10);
+    const dm = sent.texts.find((t) => t.includes("vector-index-corruption"));
+    expect(dm).toBeDefined();
+    expect(dm).toContain("idx_mu_emb_obsv_81cef5f6a42e4b4d");
+    expect(dm).toContain("REINDEX");
+  });
+});

--- a/src/hindsight-watch/run.ts
+++ b/src/hindsight-watch/run.ts
@@ -31,7 +31,21 @@ import {
  * happened — waiting for a second observation would just delay the news, and
  * they cannot flap the way a rate can.
  */
-const EDGE_SIGNALS = new Set<SignalId>(["retain-loss", "container"]);
+const EDGE_SIGNALS = new Set<SignalId>([
+  "retain-loss",
+  "container",
+  // Both of these carry their own debounce INSIDE the measurement, so the
+  // two-tick level debounce would only delay the news by one cadence:
+  //
+  //  - `consolidation-failure-streak` fires at ≥3 CONSECUTIVE terminal
+  //    failures with no completion in between. Three of those is not a flake;
+  //    requiring a second tick would put detection of the 2026-07-29 incident
+  //    at ~30 min instead of ~15.
+  //  - `vector-index-corruption` is an error RAISED by an index scan. A
+  //    corrupt HNSW index does not intermittently become valid.
+  "consolidation-failure-streak",
+  "vector-index-corruption",
+]);
 
 function breachesToFire(signal: SignalId): number {
   return EDGE_SIGNALS.has(signal) ? BREACHES_TO_FIRE_EDGE : BREACHES_TO_FIRE_LEVEL;

--- a/src/hindsight-watch/state.test.ts
+++ b/src/hindsight-watch/state.test.ts
@@ -70,7 +70,13 @@ describe("loadState", () => {
     // compute a NaN comparison that silently passes.
     expect(loadState(p)).toEqual({
       ...s,
-      ring: s.ring.map((r) => ({ ...r, recall: null, consolidation: null })),
+      ring: s.ring.map((r) => ({
+        ...r,
+        recall: null,
+        consolidation: null,
+        banks: null,
+        vectorIndex: null,
+      })),
     });
   });
 });

--- a/src/hindsight-watch/state.ts
+++ b/src/hindsight-watch/state.ts
@@ -18,7 +18,13 @@ import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { MAX_SAMPLE_AGE_MS, RING_MAX } from "./thresholds.js";
-import { emptyState, type Sample, type WatchState } from "./types.js";
+import {
+  emptyState,
+  type BankFailureStreak,
+  type BankPendingConsolidation,
+  type Sample,
+  type WatchState,
+} from "./types.js";
 
 /** Default state-file path, honouring `SWITCHROOM_HOME` like the rest of the CLI. */
 export function defaultStatePath(
@@ -44,6 +50,8 @@ export function loadState(path: string): WatchState {
       ...sample,
       recall: normalizeRecallSample(sample.recall),
       consolidation: normalizeConsolidationSample(sample.consolidation),
+      banks: normalizeBankSample(sample.banks),
+      vectorIndex: normalizeVectorIndexSample(sample.vectorIndex),
     }))
     .slice(-RING_MAX);
   const signals = typeof s.signals === "object" && s.signals !== null ? s.signals : {};
@@ -106,6 +114,47 @@ export function normalizeConsolidationSample(x: unknown): Sample["consolidation"
   const c = x as Record<string, unknown>;
   if (!isCount(c.pending) || !isCount(c.oldestAgeS)) return null;
   return x as Sample["consolidation"];
+}
+
+/**
+ * Validate a persisted per-bank consolidation block, or drop it to `null`.
+ *
+ * All-or-nothing per ROW, wholesale for the block: a row missing a field is
+ * dropped, but only after the block's two arrays are confirmed to be arrays.
+ * A partially-parsed block is still honest — every row it keeps was fully
+ * validated — and dropping the whole block because one row was malformed
+ * would turn a cosmetic defect into blindness on the signal that exists to
+ * end blindness.
+ */
+export function normalizeBankSample(x: unknown): Sample["banks"] {
+  if (x === null || typeof x !== "object") return null;
+  const b = x as Record<string, unknown>;
+  if (!Array.isArray(b.streaks) || !Array.isArray(b.pending)) return null;
+  const streaks = b.streaks.filter((r): r is BankFailureStreak => {
+    if (typeof r !== "object" || r === null) return false;
+    const s = r as Record<string, unknown>;
+    return (
+      typeof s.bank === "string" &&
+      typeof s.operationType === "string" &&
+      isCount(s.streak) &&
+      isCount(s.newestFailureAgeS)
+    );
+  });
+  const pending = b.pending.filter((r): r is BankPendingConsolidation => {
+    if (typeof r !== "object" || r === null) return false;
+    const p = r as Record<string, unknown>;
+    return typeof p.bank === "string" && isCount(p.pending);
+  });
+  return { streaks, pending };
+}
+
+/** Validate a persisted HNSW canary block, or drop it to `null`. */
+export function normalizeVectorIndexSample(x: unknown): Sample["vectorIndex"] {
+  if (x === null || typeof x !== "object") return null;
+  const v = x as Record<string, unknown>;
+  if (!isCount(v.probed)) return null;
+  if (!Array.isArray(v.corrupt) || !v.corrupt.every((s) => typeof s === "string")) return null;
+  return { probed: v.probed, corrupt: v.corrupt as string[] };
 }
 
 function isSample(x: unknown): x is Sample {

--- a/src/hindsight-watch/thresholds.ts
+++ b/src/hindsight-watch/thresholds.ts
@@ -606,6 +606,123 @@ export const CONSOLIDATION_AGE_WARN_S = 2 * 60 * 60;
 export const CONSOLIDATION_AGE_PAGE_S = 12 * 60 * 60;
 
 /**
+ * ── B9. The 2026-07-29 consolidation outage, and why the signal above could
+ *        not see it ──────────────────────────────────────────────────────
+ *
+ * The `overlord` bank's consolidation job failed on ~every attempt from 04:28
+ * to 07:09 UTC on 2026-07-29, backing up 38,000 unconsolidated memories. No
+ * signal fired. It was found because the operator happened to ask.
+ *
+ * `CONSOLIDATION_AGE_*` above is measured against `status IN ('pending',
+ * 'processing')` (`probeConsolidationQueue`), and the failing path calls
+ * `_mark_operation_failed` immediately — so a failed row leaves that set
+ * within milliseconds. `evaluateConsolidationQueueAge` then reads `pending
+ * === 0` and returns `state: "ok"`, detail `"consolidation queue empty"`.
+ * The measurement is INVERTED: the more reliably a bank fails, the healthier
+ * it reads. That is not a threshold set too high; it is a set the evidence
+ * cannot enter.
+ *
+ * Live measurements taken on the production host, read-only, 2026-07-29
+ * 07:1x UTC (the incident's tail, ~10 min after the corrupt index was
+ * rebuilt), and used to set every constant below:
+ *
+ *  B9a  Streak query — `failed` rows newer than the pair's last `completed`
+ *       row, grouped by `(bank_id, operation_type)`:
+ *         overlord | consolidation | 103 | 668 s
+ *       and NOTHING else across 20 banks. One row, one bank, one op type:
+ *       the healthy floor for this measurement is literally zero.
+ *  B9b  Same window, `(bank, op_type, status)` census: `overlord` held 3,753
+ *       COMPLETED retains and 3,753 completed batch_retains against those
+ *       112 failed consolidations. A bank-wide streak is therefore useless —
+ *       every successful retain would reset it.
+ *  B9c  Per-bank `pending_consolidation` across the fleet:
+ *         overlord 38,130 · carrie 45 · switchroom-dev 12 · every other
+ *         bank 0 (n = 20 banks, 676,720 memory units).
+ *       The largest HEALTHY reading is 45. Absolute depth is still the wrong
+ *       threshold — a bank mid-ingest legitimately runs deep and the number
+ *       is unbounded — but it bounds the floor below which growth is not
+ *       worth looking at.
+ *  B9d  Every `failed` row carried `different vector dimensions 384 and 0`,
+ *       raised out of an HNSW index scan. `memory_units.embedding` is
+ *       `vector(384)` and 0 rows have `vector_dims(embedding) <> 384`, so the
+ *       damage is inside the index structure, not in the data.
+ *  B9e  Canary cost: 89 HNSW indexes probed in 0.45 s wall (one `docker
+ *       exec`), 0 corrupt at the time of measurement.
+ */
+
+/**
+ * Consecutive terminal consolidation failures for one `(bank, operation_type)`
+ * pair: warn / page.
+ *
+ * **3** to warn because the healthy fleet's streak is 0 (B9a) — there is no
+ * band of "a few failures are normal" to sit above. Three consecutive
+ * failures with no completion in between is already the signature of a
+ * deterministic, non-retryable fault rather than a flake, and at the
+ * 15-minute cron cadence the incident's failure rate (112 failures over
+ * 2.7 h ≈ one per 87 s) clears 3 inside the FIRST tick after onset.
+ *
+ * **10** to page: a fault that has survived ten attempts is not going to
+ * retry its way out, and the bank has been unconsolidated long enough that
+ * recall against it is already degraded.
+ *
+ * Deliberately NOT keyed on the incident's error string. Any deterministic
+ * non-retryable consolidation failure — a corrupt index, a poisoned row, a
+ * schema drift, an LLM contract change — produces the same shape, and the
+ * shape is what is thresholded.
+ */
+export const CONSOLIDATION_FAILURE_STREAK_WARN = 3;
+export const CONSOLIDATION_FAILURE_STREAK_PAGE = 10;
+
+/**
+ * How fresh the newest failure in a streak must be for the streak to count.
+ *
+ * Without this the signal never resolves: a streak is defined relative to the
+ * last COMPLETED op, so a bank that is fixed but idle (no new consolidation
+ * demand) keeps its historical streak forever and alerts forever. Two hours
+ * bounds the post-fix tail while still being several times the observed
+ * inter-failure gap during the incident (87 s), so an ongoing fault cannot
+ * age itself out mid-incident.
+ */
+export const CONSOLIDATION_STREAK_RECENCY_S = 2 * 60 * 60;
+
+/**
+ * Per-bank unconsolidated depth: the floor below which GROWTH is not worth
+ * scoring, and the growth thresholds themselves.
+ *
+ * Growth, not absolute depth, because absolute depth has no defensible line:
+ * `klanker` holds 202,549 memory units and a bank mid-ingest legitimately
+ * carries thousands of unconsolidated ones, so any absolute threshold is
+ * either noise or useless (B9c). What is NOT legitimate is a depth that only
+ * ever goes up.
+ *
+ * The shape deliberately mirrors {@link QUEUE_FLOOR} /
+ * {@link QUEUE_GROWTH_FRACTION} / {@link QUEUE_GROWTH_MIN_ABS} — the same
+ * "deep AND rising" conjunction, applied per bank instead of to one fleet
+ * series — so there is one growth idiom in this file, not two.
+ *
+ *  - **500 floor**: an order of magnitude above the largest healthy reading
+ *    (45, B9c), so an ordinary ingest burst never reaches the conjunction.
+ *  - **50 % fraction / +500 absolute** to warn over the ~2 h window
+ *    (`RING_MAX` × 15 min).
+ *  - **+5000 absolute** to page. The incident grew ~38,000 in 2.7 h ≈
+ *    14,000/h ≈ 28,000 per window: it pages on the first full window.
+ */
+export const PENDING_CONSOLIDATION_FLOOR = 500;
+export const PENDING_CONSOLIDATION_GROWTH_FRACTION = 0.5;
+export const PENDING_CONSOLIDATION_GROWTH_WARN_ABS = 500;
+export const PENDING_CONSOLIDATION_GROWTH_PAGE_ABS = 5000;
+
+/**
+ * Rows the HNSW canary samples per index.
+ *
+ * Each sampled row costs one nearest-neighbour search. 3 is enough that the
+ * probe walks the graph rather than getting lucky on an entry point, and the
+ * whole sweep — 89 indexes — measured 0.45 s (B9e). Raising it multiplies the
+ * only cost this probe has.
+ */
+export const VECTOR_INDEX_SAMPLE_ROWS = 3;
+
+/**
  * Minimum scored rows before a recall SLI is trusted.
  *
  * Below this a single bad recall dominates the rate and the signal would flap

--- a/src/hindsight-watch/types.ts
+++ b/src/hindsight-watch/types.ts
@@ -35,6 +35,18 @@ export type SignalId =
   | "recall-candidate-floor" // the candidate pool itself is empty
   | "recall-injected-score" // what we DID inject scores like noise
   | "consolidation-queue-age" // the async queue is not draining
+  // ── consolidation: the half `consolidation-queue-age` cannot see ─────
+  // `consolidation-queue-age` reads ONLY `status IN ('pending','processing')`,
+  // and the failing path calls `_mark_operation_failed` within milliseconds —
+  // so a bank whose consolidation fails on every attempt leaves that set
+  // instantly and the signal reports "consolidation queue empty". The metric
+  // is inverted: the more RELIABLY a bank fails, the healthier it reads.
+  // Observed live 2026-07-29, `overlord` bank: the API reported
+  // `pending_operations: 0, failed_operations: 96, pending_consolidation:
+  // 37711` simultaneously, for 2.5 h, with every watchdog signal green.
+  | "consolidation-failure-streak" // consecutive terminal failures for one bank
+  | "pending-consolidation-depth" // unconsolidated memories piling up per bank
+  | "vector-index-corruption" // an HNSW index raises on a nearest-neighbour probe
   // ── the fallback that never fires ────────────────────────────────────
   | "llm-fallback-ineffective";
 
@@ -49,6 +61,9 @@ export const ALL_SIGNALS: SignalId[] = [
   "recall-candidate-floor",
   "recall-injected-score",
   "consolidation-queue-age",
+  "consolidation-failure-streak",
+  "pending-consolidation-depth",
+  "vector-index-corruption",
   "llm-fallback-ineffective",
 ];
 
@@ -116,6 +131,20 @@ export interface Sample {
    * legitimate off-host).
    */
   consolidation?: ConsolidationSample | null;
+  /**
+   * Per-bank consolidation facts — terminal-failure streaks and
+   * unconsolidated depth — or `null` when the psql probe was unavailable.
+   *
+   * Optional on the wire for the same reason `recall` is: a state file written
+   * by an older build must still load rather than being discarded wholesale,
+   * which would re-baseline every signal on upgrade.
+   */
+  banks?: BankSample | null;
+  /**
+   * Result of the HNSW nearest-neighbour canary, or `null` when the psql
+   * probe was unavailable.
+   */
+  vectorIndex?: VectorIndexSample | null;
   /** cumulative successful hindsight LLM calls across every lane */
   llmOk?: number;
   /** cumulative failed hindsight LLM calls across every lane */
@@ -158,6 +187,68 @@ export interface ConsolidationSample {
   pending: number;
   /** age of the oldest such row, in seconds */
   oldestAgeS: number;
+}
+
+/**
+ * One `(bank_id, operation_type)` pair's CONSECUTIVE terminal-failure streak:
+ * the `status='failed'` rows newer than that pair's most recent
+ * `status='completed'` row.
+ *
+ * Keyed on the pair, not on the bank, because a bank whose consolidation is
+ * wedged goes on completing `retain` and `batch_retain` ops the whole time —
+ * observed live during the 2026-07-29 incident, where `overlord` held 3,753
+ * completed retains against 112 failed consolidations. A bank-wide streak
+ * would have been broken by every successful retain and never reached 3.
+ */
+export interface BankFailureStreak {
+  bank: string;
+  operationType: string;
+  /** consecutive `failed` rows since the last `completed` one for this pair */
+  streak: number;
+  /** seconds since the NEWEST failure in the streak — the staleness guard */
+  newestFailureAgeS: number;
+}
+
+/** One bank's unconsolidated-memory depth. */
+export interface BankPendingConsolidation {
+  bank: string;
+  /**
+   * `memory_units` rows with `consolidated_at IS NULL AND fact_type IN
+   * ('experience','world')` — byte-for-byte the definition the API's
+   * `get_bank_freshness` uses for the `pending_consolidation` field it
+   * publishes on `/v1/default/banks/{bank}/stats`
+   * (`engine/memory_engine.py`, verified live 2026-07-29). Computed in the
+   * same psql pass rather than over N HTTP calls: one grouped aggregate over
+   * 676,720 rows measured 0.284 s, against the ~1.4-2.1 s per bank that
+   * `doctor-observation-scopes.ts` pays for the `/stats` endpoint.
+   */
+  pending: number;
+}
+
+/** The per-bank consolidation block one tick reads. */
+export interface BankSample {
+  /** every pair with at least one live failure streak; empty is healthy */
+  streaks: BankFailureStreak[];
+  /** every bank with at least one memory unit */
+  pending: BankPendingConsolidation[];
+}
+
+/**
+ * The HNSW canary's result for one tick.
+ *
+ * `amcheck` has no HNSW support, so a nearest-neighbour probe is the only
+ * available verifier for these indexes: a corrupt one raises
+ * `different vector dimensions 384 and 0` when the scan walks the damaged
+ * node. The damage is INSIDE the index, not in the data — `memory_units.
+ * embedding` is `vector(384)`, so a zero-dimension row cannot exist in the
+ * table (verified live: 0 rows with `vector_dims(embedding) <> 384`), which
+ * is why no data-level check can see it either.
+ */
+export interface VectorIndexSample {
+  /** HNSW indexes the probe successfully scanned */
+  probed: number;
+  /** `<indexname>=<sqlerrm>` for every index whose probe raised */
+  corrupt: string[];
 }
 
 /** Per-signal hysteresis state. */


### PR DESCRIPTION
## Summary

Adds three model-free signals to `hindsight-watch` that see the half of the consolidation path the existing signal cannot:

| Signal | Asserts | Kind |
|---|---|---|
| `consolidation-failure-streak` | ≥3 (warn) / ≥10 (page) consecutive `status='failed'` `async_operations` for one `(bank, operation_type)` pair, newest within 2 h | edge |
| `pending-consolidation-depth` | one bank's unconsolidated memories ≥500 **and** grew ≥max(500, 50 %) across the window (≥5 000 pages) | level |
| `vector-index-corruption` | a nearest-neighbour probe against any HNSW index raises | edge, always page |

## Why

**`consolidation-queue-age` is inverted.** Its only SQL is `... FROM async_operations WHERE status IN ('pending','processing')` (`src/hindsight-watch/probe.ts`), and `evaluateConsolidationQueueAge` returns `state:"ok"` / `"consolidation queue empty"` when that count is zero. A FAILED operation has left the set being measured — so the more reliably a bank's consolidator fails, the healthier it reads. No signal anywhere in `src/hindsight-watch/` read `status='failed'` before this PR.

On **2026-07-29** the `overlord` bank's consolidation failed on ~every run from 04:28 to 07:09 UTC. The API reported `pending_operations: 0, failed_operations: 96, pending_consolidation: 37711` **simultaneously**, for 2.5 h, with every watchdog signal green. It was found because an operator happened to ask. `consolidation-failure-streak` would have DM'd within ~15 minutes.

Design decisions that are load-bearing, each from a live read-only measurement (recorded as baseline **B9** in `thresholds.ts`):

- **The streak is keyed on the `(bank, operation_type)` PAIR, not the bank.** During the incident `overlord` completed 3,753 retains while its consolidation failed 112 times. A bank-wide streak would have been broken by every successful retain and never reached 3.
- **It is error-string-agnostic.** It catches any deterministic non-retryable consolidation failure, not this incident's message.
- **`CONSOLIDATION_STREAK_RECENCY_S = 2 h`** exists because a streak is defined *relative to the last completed op* — without a recency guard a bank that is fixed and then goes idle would alert forever.
- **Depth scores growth, not absolute depth.** The fleet holds 676,720 memory units and one bank carries 202,549; an absolute line would be either noise or useless. Same "deep AND rising" conjunction as `retain-queue-growth`, so a draining backlog stays silent.
- **`amcheck` has no HNSW support**, so a nearest-neighbour scan is the only available verifier. The column is `vector(384)` with zero off-dimension rows, so the damage is inside the index, not the data.

### The canary's one non-obvious requirement

The probe must aggregate over the correlated subquery's **result**. Verified by `EXPLAIN` on the production database, same statement both ways:

- `count(nn)` → `Index Scan using idx_mu_emb_obsv_81cef5f6a42e4b4d`, `SubPlan 1`, 9.6 ms
- `count(*)` → bare `Aggregate`, **no `SubPlan`, no index scan**, 0.8 ms

i.e. with `count(*)` the probe touches no index, raises nothing, and passes. `probeVectorIndexes` re-asserts `count(nn)` on the generated SQL and returns `null` (→ `no-data`) if it is ever absent, so the elision cannot be reintroduced by an edit that still type-checks. The partial-index predicate is likewise spliced verbatim from `pg_get_expr(indpred, indrelid)`: a correlated column reference cannot prove a partial predicate, and the first draft silently probed the one global index and left all 88 partial ones unprobed.

All three fail **closed** — an unreadable probe is `no-data`, never `ok`, per this module's existing rule. Both new `Sample` fields are optional on the wire and normalized on load, so an existing `state.json` upgrades without a re-baseline.

`pending_consolidation` is read in the same psql round trip as the streak rather than via the `/stats` endpoint: identical predicate (`consolidated_at IS NULL AND fact_type IN ('experience','world')`, per `doctor-observation-scopes.ts`), 0.284 s for the whole fleet vs 1.4–2.1 s **per bank**.

## Test plan

`vitest run src/hindsight-watch/` — 178 passed (8 files), up from 153.

The load-bearing test is `run.test.ts` → *"DMs the operator while consolidation-queue-age still reads EMPTY"*. It drives a full tick over the **measured live incident shape** (`overlord/consolidation` streak 103, `pending_operations` 0, `pending_consolidation` 38 130) and asserts, in one tick, that:

1. `consolidation-queue-age` returns `ok` / `"consolidation queue empty"` — the blind spot, still present;
2. `consolidation-failure-streak` returns `breach` / `page` / `transition: "fired"`;
3. `exitCode === 10`;
4. a DM was actually sent, containing `overlord` and `103 consecutive FAILED consolidation`.

**This test cannot pass against `main`** — the signal does not exist there, and the first assertion pins the fact that the pre-existing signal reads healthy on the same data.

Also covered: the pair-vs-bank property (a bank with completing retains and failing consolidations still fires); streak staleness resolving; a deep-but-flat and a deep-but-draining bank staying silent; a brand-new bank being ignored; the corrupt-index DM naming the index and `REINDEX`; and the probe parsers, including that a count/list mismatch returns `null` rather than an empty (clean-looking) corrupt list, and that the shipped SQL really does carry `count(nn)`.

`tsc --noEmit` clean; guard scripts pass. (`check-plugin-references` cannot run in this container — `telegram-plugin`'s own deps are absent from the shared store; this diff touches zero plugin files.)

## Risk

Low, and bounded by fail-closed design.

- **New cost:** two extra read-only `docker exec` psql calls per 15-min tick — 0.284 s for the per-bank aggregate and 0.45 s for the 89-index sweep, measured live. Both soft-fail to `null` when psql or the pg descriptor is absent (CI, a laptop), exactly like the existing `probeConsolidationQueue`.
- **Nothing is written.** Every statement is a `SELECT`, and the `DO` block runs one `EXCEPTION`-guarded subtransaction per index so a fault is reported by name rather than aborting the sweep.
- **False-positive surface:** the two edge-triggered signals fire on the first breaching tick. `consolidation-failure-streak` carries its own debounce inside the measurement (3 consecutive terminal failures with no completion between), and index corruption does not flap.
- **Known gap, stated plainly:** the corruption was already repaired (~07:09 UTC) before the canary was built, so the live sweep returned `VECIDX|89|0|` and the raise could not be reproduced end-to-end. What is proven is the *mechanism* (the EXPLAIN above) plus the evaluator against a synthesized corrupt block. Live corrupt-index detection is unproven in-suite.
- **Arming is unchanged and remains an operator step** — see below.

## Not in this PR: arming the watchdog

`/etc/cron.d/hindsight-watch` does not exist on the current host, so none of these signals — new or existing — will fire until someone arms it. A PR cannot write the host's `/etc/cron.d`. The operator command is:

```bash
sudo switchroom hindsight-watch --install-cron --cron-user "$USER"
```

`installCron()` (`src/hindsight-watch/install-cron.ts`) is idempotent, writes `*/15 * * * *` under `flock -n`, and requires `SWITCHROOM_BINARY` to be an absolute path to an installed binary. Verify with `switchroom hindsight-watch --dry-run`.

## Job spec

`reference/jobs/fleet-stays-healthy.md` — *"The fleet detects, ranks, and tracks its own recurring failures … the operator sees the worst-affecting issues first"*, in service of `reference/jobs/remember-across-sessions.md`. This incident is the stated failure mode verbatim: a silent, always-on failure that the operator learned about only by asking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)