### PR TITLE
fix(hindsight): turn fsync ON for the embedded PostgreSQL

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -120,8 +120,16 @@ jobs:
             # "No test files found". Without this entry the structural
             # anchor/negative guards would be skipped for exactly the change
             # they exist to police. The hindsight-probe job runs them.
+            #
+            # hindsight-pg-fsync-probe.test.ts boots the REAL entrypoint in the
+            # real image, so its inputs are the entrypoint and the module that
+            # supplies its env — both listed, or a PR that turned fsync back off
+            # would get no probe run until the merge queue.
             hindsight:
               - 'docker/Dockerfile.hindsight'
+              - 'docker/hindsight-entrypoint.sh'
+              - 'src/setup/hindsight-pg-defaults.ts'
+              - 'tests/docker/hindsight-pg-fsync-probe.test.ts'
               - 'tests/docker/hindsight-search-patches.test.ts'
               - 'tests/docker/hindsight-recall-isolation-patches.test.ts'
               - 'tests/docker/hindsight-retry-perturbation-patches.test.ts'
@@ -389,10 +397,26 @@ jobs:
           SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
         run: npx vitest run tests/docker/hindsight-reflect-directives-patch.test.ts
 
+      - name: Run the embedded-postgres fsync probe (RED/GREEN, must not skip)
+        # NOT a patch probe: this one boots the REAL docker/hindsight-entrypoint.sh
+        # inside the pinned image and reads `SHOW fsync` off the server it
+        # started. pg0 launches postgres with `-F` (fsync OFF), which is how an
+        # HNSW index on memory_units silently corrupted on 2026-07-29 after one
+        # of the container's 6-20 daily unclean shutdowns — data_checksums
+        # cannot see a lost write. The entrypoint overrides it with a trailing
+        # `-c fsync=on`, and whether postgres HONOURS that over pg0's earlier
+        # `-F` is a property of a pinned third-party binary, not of this repo:
+        # every unit-level test stays green if pg0 reorders its argv or starts
+        # writing postgresql.conf. Only this step sees it. Both arms run, so a
+        # probe that stopped observing the real server cannot pass.
+        env:
+          SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
+        run: npx vitest run tests/docker/hindsight-pg-fsync-probe.test.ts
+
       - name: Label-scoped teardown
         if: always()
         run: |
-          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-graph-seed-patch hindsight-maxitems-grammar-patch hindsight-reflect-directives-patch; do
+          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-graph-seed-patch hindsight-maxitems-grammar-patch hindsight-reflect-directives-patch hindsight-pg-fsync-probe; do
             ids=$(docker ps -aq --filter "label=switchroom.test=$phase" 2>/dev/null || true)
             if [ -n "$ids" ]; then docker rm -f $ids 2>/dev/null || true; fi
           done

--- a/docker/hindsight-entrypoint.sh
+++ b/docker/hindsight-entrypoint.sh
@@ -103,6 +103,16 @@ PG0_INSTANCE="${SWITCHROOM_HINDSIGHT_PG0_INSTANCE:-/home/hindsight/.pg0/instance
 # case) is the operator's per-knob opt-out.
 PG_EFFECTIVE_CACHE_SIZE="${SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE:-}"
 PG_SHARED_BUFFERS="${SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS:-}"
+# --- pg0 durability pre-start ------------------------------------------------
+# `on` (the default) makes the pre-start append `-c fsync=on`; `off` omits the
+# flag and leaves pg0's own `-F` (fsync OFF) standing.
+#
+# Unlike the two sizing knobs above this one defaults ON *here*, not only in
+# src/setup/hindsight-pg-defaults.ts, and deliberately: durability must not
+# depend on a new-enough switchroom CLI having emitted the env var. An operator
+# running an older `switchroom apply`, or `docker run`-ing the image by hand,
+# still gets a crash-safe database.
+PG_FSYNC="${SWITCHROOM_HINDSIGHT_PG_FSYNC:-on}"
 # pg0 CLI. The python wheel bundles it; the venv's python minor version is not
 # guaranteed stable, so glob rather than hard-code. Overridable for tests.
 PG0_BIN="${SWITCHROOM_HINDSIGHT_PG0_BIN:-}"
@@ -257,7 +267,7 @@ reap_stale_processing_when_ready() {
 }
 
 # ---------------------------------------------------------------------------
-# pg0 sizing pre-start (#3706)
+# pg0 sizing + durability pre-start (#3706)
 #
 # Hindsight's embedded PostgreSQL is pg0, and pg0 bakes its tuning into the
 # `postgres` child's ARGV:
@@ -278,6 +288,23 @@ reap_stale_processing_when_ready() {
 # `-c effective_cache_size=4GB -c shared_buffers=1536MB` kept pg0's work_mem,
 # maintenance_work_mem, max_parallel_maintenance_workers and logging flags).
 #
+# DURABILITY. Note the `-F` in that argv: pg0 starts PostgreSQL with fsync
+# DISABLED, which means a crash can leave a torn or stale page that
+# `data_checksums` still validates (a lost write, not a corrupt one). `-F` is a
+# positional flag pg0 always emits immediately after `-D`/`-p`, BEFORE the
+# merged `-c` block, and postgres applies command-line options in order — so a
+# later `-c fsync=on` wins. Verified on a throwaway pg0 instance from the same
+# image (2026-07-29):
+#
+#   pg0 start --name probeA … -c fsync=on
+#   argv:  postgres -D …/probeA/data -F -p 5432 … -c fsync=on …
+#   SELECT name, setting, source FROM pg_settings WHERE name='fsync'
+#     →  fsync | on | command line
+#
+# The order of the `-c` flags among themselves is NOT stable (pg0 iterates a
+# map), so this only holds because `-F` is positional and there is exactly one
+# fsync `-c`. Do not add a second one.
+#
 # BEST-EFFORT BY CONSTRUCTION. Every failure path returns 0 and leaves pg0
 # unstarted, so hindsight_api starts it exactly as it does today with pg0's own
 # defaults. A sizing change can never be why the container fails to boot.
@@ -295,8 +322,18 @@ prestart_pg0() {
   case "$(printf '%s' "${PG_SHARED_BUFFERS}" | tr '[:upper:]' '[:lower:]')" in
     off) PG_SHARED_BUFFERS="" ;;
   esac
+  # fsync is a tri-state collapsed to a boolean: only the literal `on` (any
+  # case) applies the flag. `off`, empty, and any typo all fall through to
+  # "omit it", which restores pg0's `-F` — the pre-change behaviour. A typo can
+  # therefore never hand postgres an unparseable `fsync=` value and turn a
+  # durability change into a boot failure.
+  case "$(printf '%s' "${PG_FSYNC}" | tr '[:upper:]' '[:lower:]')" in
+    on) PG_FSYNC="on" ;;
+    *) PG_FSYNC="" ;;
+  esac
   # Nothing to apply ⇒ do not touch pg0 at all (pre-#3706 behaviour).
-  [ -n "${PG_EFFECTIVE_CACHE_SIZE}" ] || [ -n "${PG_SHARED_BUFFERS}" ] || return 0
+  [ -n "${PG_EFFECTIVE_CACHE_SIZE}" ] || [ -n "${PG_SHARED_BUFFERS}" ] ||
+    [ -n "${PG_FSYNC}" ] || return 0
 
   # Only the embedded-pg0 database is ours to pre-start. An operator pointing
   # hindsight at an external postgres (or a differently-named/ported pg0
@@ -345,9 +382,12 @@ EOF
   if [ -n "${PG_SHARED_BUFFERS}" ]; then
     set -- "$@" -c "shared_buffers=${PG_SHARED_BUFFERS}"
   fi
+  if [ -n "${PG_FSYNC}" ]; then
+    set -- "$@" -c "fsync=${PG_FSYNC}"
+  fi
 
   if _out="$("${_pg0}" "$@" 2>&1)"; then
-    log "pg0 pre-start ok: name=${PG0_NAME} effective_cache_size=${PG_EFFECTIVE_CACHE_SIZE:-<pg0-default>} shared_buffers=${PG_SHARED_BUFFERS:-<pg0-default>}"
+    log "pg0 pre-start ok: name=${PG0_NAME} effective_cache_size=${PG_EFFECTIVE_CACHE_SIZE:-<pg0-default>} shared_buffers=${PG_SHARED_BUFFERS:-<pg0-default>} fsync=${PG_FSYNC:-<pg0-default:off>}"
     return 0
   fi
 

--- a/src/setup/hindsight-pg-defaults.test.ts
+++ b/src/setup/hindsight-pg-defaults.test.ts
@@ -34,8 +34,10 @@ import {
   HINDSIGHT_PG_APP_ANON_MIB,
   HINDSIGHT_PG_DEFAULTS,
   HINDSIGHT_PG_DEFAULT_EFFECTIVE_CACHE_SIZE_MIB,
+  HINDSIGHT_PG_DEFAULT_FSYNC,
   HINDSIGHT_PG_DEFAULT_SHARED_BUFFERS_MIB,
   HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE_ENV,
+  HINDSIGHT_PG_FSYNC_ENV,
   HINDSIGHT_PG_ENV_KEYS,
   HINDSIGHT_PG_MEM_LIMIT_MIB_FOR_DERIVATION,
   HINDSIGHT_PG_PAGE_CACHE_FLOOR_MIB,
@@ -250,13 +252,14 @@ describe("resolveHindsightPgOverrides", () => {
 
 // ── the emitted pairs ─────────────────────────────────────────────────────
 describe("hindsightPgEnv", () => {
-  it("emits both knobs, in MB form, with switchroom's defaults", () => {
+  it("emits every knob, in MB form, with switchroom's defaults", () => {
     expect(hindsightPgEnv()).toEqual([
       [
         HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE_ENV,
         pgMib(HINDSIGHT_PG_DEFAULT_EFFECTIVE_CACHE_SIZE_MIB),
       ],
       [HINDSIGHT_PG_SHARED_BUFFERS_ENV, pgMib(HINDSIGHT_PG_DEFAULT_SHARED_BUFFERS_MIB)],
+      [HINDSIGHT_PG_FSYNC_ENV, HINDSIGHT_PG_DEFAULT_FSYNC],
     ]);
   });
 
@@ -367,11 +370,45 @@ describe("pg0 sizing reaches the container on both launch paths", () => {
     // rename on either side is a silent no-op tuning change, which is the
     // worst failure mode available here — everything still boots, nothing is
     // tuned. Assert the contract on the real script text.
+    //
+    // `:-` with ANY word is accepted because the entrypoint carries its own
+    // default for fsync (`${…:-on}`) — see the fsync test below, which pins
+    // that default rather than leaving it to this pattern.
     const script = readFileSync(ENTRYPOINT, "utf-8");
     for (const key of HINDSIGHT_PG_ENV_KEYS) {
-      expect(script, `${key} is emitted but never read by the entrypoint`).toContain(
-        `\${${key}:-}`,
+      expect(script, `${key} is emitted but never read by the entrypoint`).toMatch(
+        new RegExp(`\\$\\{${key}:-[a-z]*\\}`),
       );
     }
+  });
+
+  // ── fsync: a correctness property, not a tuning knob ────────────────────
+  //
+  // pg0 starts postgres with `-F` (fsync OFF). Under that setting an unclean
+  // stop can lose a write that `data_checksums` still validates, which is how
+  // an HNSW index on `memory_units` silently corrupted on 2026-07-29 (see the
+  // HINDSIGHT_PG_DEFAULT_FSYNC docblock). The effective-outcome guard is
+  // tests/docker/hindsight-pg-fsync-probe.test.ts, which boots the real image
+  // and reads `SHOW fsync`; these two pin the halves that feed it.
+
+  it("ships fsync=on by default on BOTH launch paths", () => {
+    startHindsight();
+    expect(runEnv(runArgs()).get(HINDSIGHT_PG_FSYNC_ENV)).toEqual(["on"]);
+    expect(composeEnv(generateHindsightComposeSnippet()).get(HINDSIGHT_PG_FSYNC_ENV)).toEqual([
+      "on",
+    ]);
+    // Pinned literally as well as by reference: the entrypoint only applies
+    // the flag for the exact token `on`, so renaming the constant's value to
+    // anything else silently reverts to pg0's `-F`.
+    expect(HINDSIGHT_PG_DEFAULT_FSYNC).toBe("on");
+  });
+
+  it("the entrypoint defaults fsync ON even when switchroom emits nothing", () => {
+    // Durability must not depend on a new-enough switchroom CLI: an operator
+    // on an older `switchroom apply`, or running the image by hand, still has
+    // to get a crash-safe database. That is why the entrypoint carries its
+    // own `:-on`, unlike the two sizing knobs which default to empty.
+    const script = readFileSync(ENTRYPOINT, "utf-8");
+    expect(script).toContain(`PG_FSYNC="\${${HINDSIGHT_PG_FSYNC_ENV}:-on}"`);
   });
 });

--- a/src/setup/hindsight-pg-defaults.ts
+++ b/src/setup/hindsight-pg-defaults.ts
@@ -1,5 +1,6 @@
 /**
- * Embedded-PostgreSQL (pg0) sizing defaults for the hindsight container.
+ * Embedded-PostgreSQL (pg0) sizing and durability defaults for the hindsight
+ * container.
  *
  * ## Why this file exists
  *
@@ -32,6 +33,14 @@
  * before `exec`ing the upstream CMD, and hindsight_api adopts the running,
  * tuned instance. This module is the single, testable source of the values
  * that entrypoint receives.
+ *
+ * Note the `-F` in that argv — pg0 runs PostgreSQL with **fsync disabled**.
+ * That is a durability defect rather than a tuning choice, and it is fixed
+ * through the same mechanism; see {@link HINDSIGHT_PG_DEFAULT_FSYNC}. `-F` is
+ * positional and always precedes the merged `-c` block, and postgres applies
+ * command-line options in order, so a later `-c fsync=on` wins — verified on a
+ * throwaway pg0 instance from the same image (2026-07-29):
+ * `pg_settings` reported `fsync | on | command line`.
  *
  * Verified live that pg0 **merges** operator `-c` flags over its own defaults
  * rather than replacing them: a probe instance started with
@@ -204,14 +213,69 @@ export const HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE_ENV =
 export const HINDSIGHT_PG_SHARED_BUFFERS_ENV = "SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS";
 
 /**
- * The pg0 sizing defaults, in the order the entrypoint receives them.
+ * Env var carrying `fsync`. Only the literal `on` (any case) applies the flag;
+ * anything else — including `off` — leaves pg0's `-F` standing.
+ */
+export const HINDSIGHT_PG_FSYNC_ENV = "SWITCHROOM_HINDSIGHT_PG_FSYNC";
+
+/**
+ * `fsync` — pg0's default is **off**, via the positional `-F` it bakes into
+ * the `postgres` argv.
+ *
+ * ## Why this is not a tuning knob
+ *
+ * The other two values in this module are performance trade-offs. This one is
+ * a correctness property that pg0's default silently gives away.
+ *
+ * With `fsync=off` PostgreSQL never forces WAL or data pages to stable
+ * storage, so an unclean stop can leave a page that was never actually
+ * written while the WAL believes it was. `data_checksums` does not catch
+ * that: the stale page checksums *correctly*. It is a lost write, not a
+ * corrupt one. Recovery completes, the server reports healthy, and the damage
+ * is silent.
+ *
+ * ## The observed failure
+ *
+ * The live `switchroom-hindsight` container logs 6–20 "database system was not
+ * properly shut down; automatic recovery in progress" events per day
+ * (`postgresql-2026-07-2[6789].log`: 8 / 20 / 6 / 6). On 2026-07-29 one of
+ * them — `04:14:29 performing immediate shutdown because data directory lock
+ * file is invalid` — preceded, by ~13 minutes, silent corruption of an HNSW
+ * vector index on `memory_units` in the `overlord` bank. Consolidation for
+ * that bank wedged for ~2.5 hours behind ~38,000 queued memories, and
+ * `data_checksums` (which is on) reported nothing — exactly as the mechanism
+ * above predicts. `REINDEX INDEX CONCURRENTLY` repaired it.
+ *
+ * **This addresses the loss, not the restarts.** What is stopping PostgreSQL
+ * that often is a separate question, tracked separately; `fsync=on` only makes
+ * those stops survivable.
+ *
+ * ## Cost
+ *
+ * Measured on a throwaway pg0 instance from the same image against a
+ * `memory_units`-shaped table (220k rows, 384-dim vectors, 88 partial HNSW
+ * indexes) under a retain+consolidate pgbench workload: 30–55% fewer
+ * transactions per second depending on concurrency. Real, and paid against a
+ * workload whose measured demand is single-digit writes per second, which the
+ * fsync=on arm clears by more than an order of magnitude.
+ */
+export const HINDSIGHT_PG_DEFAULT_FSYNC = "on";
+
+/**
+ * The pg0 pre-start defaults, in the order the entrypoint receives them.
  *
  * Deliberately NOT capability-gated. Unlike the GPU / local-LLM knobs in
- * hindsight-perf-defaults.ts, these two are sized against
+ * hindsight-perf-defaults.ts, the two sizing values are derived from
  * `HINDSIGHT_DEFAULT_MEM_LIMIT` — a value switchroom itself sets on every
- * host — so the "capability" is already proven by construction. The runtime
- * safety property is the entrypoint's fallback instead: a pre-start that
- * cannot apply the values leaves the container running pg0's own defaults.
+ * host — so the "capability" is already proven by construction, and `fsync`
+ * has no capability to gate on at all. The runtime safety property is the
+ * entrypoint's fallback instead: a pre-start that cannot apply the values
+ * leaves the container running pg0's own defaults.
+ *
+ * `fsync` also carries a hard-coded `on` default *inside the entrypoint*, so
+ * durability does not depend on this array having been emitted by a new-enough
+ * switchroom. The entry here exists so an operator has a documented,
+ * overridable key, and so the compose file states the property explicitly.
  */
 export const HINDSIGHT_PG_DEFAULTS: ReadonlyArray<readonly [string, string]> = [
   [
@@ -219,6 +283,7 @@ export const HINDSIGHT_PG_DEFAULTS: ReadonlyArray<readonly [string, string]> = [
     pgMib(HINDSIGHT_PG_DEFAULT_EFFECTIVE_CACHE_SIZE_MIB),
   ],
   [HINDSIGHT_PG_SHARED_BUFFERS_ENV, pgMib(HINDSIGHT_PG_DEFAULT_SHARED_BUFFERS_MIB)],
+  [HINDSIGHT_PG_FSYNC_ENV, HINDSIGHT_PG_DEFAULT_FSYNC],
 ];
 
 /**

--- a/tests/docker/hindsight-entrypoint.test.ts
+++ b/tests/docker/hindsight-entrypoint.test.ts
@@ -506,8 +506,17 @@ describe("hindsight-entrypoint.sh (#1245)", () => {
       expect(stderr).toMatch(/credential refresh loop started/);
       // The reaper fired (REFRESH_S=1) but found no pg → silent no-op:
       // no reset log, and crucially no leaked psql/python crash.
+      //
+      // The pg0 pre-start's own "skipped: pg0 binary not found" line is
+      // expected on a host with no pg0 (fsync defaults ON, so the pre-start
+      // always runs now) and is stripped before the crash-signature check —
+      // otherwise a deliberate log would satisfy the `not found` guard.
+      const reaperNoise = stderr.replace(
+        /^switchroom-hindsight-entrypoint: pg0 pre-start .*$/gm,
+        "",
+      );
       expect(stderr).not.toMatch(/stale-claim reaper reset/);
-      expect(stderr).not.toMatch(/Traceback|psql:|not found/);
+      expect(reaperNoise).not.toMatch(/Traceback|psql:|not found/);
     } finally {
       try { child.kill("SIGKILL"); } catch { /* ignore */ }
     }
@@ -805,8 +814,10 @@ exit ${code}
     // The flags themselves — the whole point of the change.
     expect(argv).toContain("effective_cache_size=4096MB");
     expect(argv).toContain("shared_buffers=1536MB");
+    // ...plus the durability flag, which defaults ON inside the entrypoint.
+    expect(argv).toContain("fsync=on");
     // ...each introduced by its own `-c`, which is pg0's flag syntax.
-    expect(argv.filter((a) => a === "-c").length).toBe(2);
+    expect(argv.filter((a) => a === "-c").length).toBe(3);
     // The instance identity hindsight_api will look for, or it won't adopt ours.
     expect(argv[argv.indexOf("--name") + 1]).toBe("hindsight");
     // Ordering matters: pre-start must happen BEFORE the exec, otherwise
@@ -815,9 +826,10 @@ exit ${code}
     expect(existsSync(marker)).toBe(true);
   }, 20_000);
 
-  it("does NOT touch pg0 at all when neither knob is set (pre-#3706 behaviour)", async () => {
-    // An older switchroom, or an operator who cleared both, must get exactly
-    // today's boot: hindsight_api starts pg0 itself.
+  it("still pre-starts for fsync alone when BOTH sizing knobs are cleared", async () => {
+    // An older switchroom that emits neither sizing var must STILL get a
+    // crash-safe database — durability cannot be contingent on a CLI version.
+    // Pre-#3706 this case skipped the pre-start entirely; it no longer can.
     stopBroker = await startFakeBroker(socketPath);
     const log = join(dir, "pg0-argv-none.log");
     const r = await runWithEnv({
@@ -826,8 +838,59 @@ exit ${code}
       SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS: "",
     });
     expect(r.status).toBe(0);
+    const argv = argvOf(log);
+    expect(argv).toContain("fsync=on");
+    // ...and nothing else: clearing a sizing knob must still clear it.
+    expect(argv.filter((a) => a === "-c")).toEqual(["-c"]);
+    expect(argv.some((a) => a.startsWith("shared_buffers="))).toBe(false);
+    expect(argv.some((a) => a.startsWith("effective_cache_size="))).toBe(false);
+    expect(r.stderr).toMatch(/pg0 pre-start ok/);
+  }, 20_000);
+
+  it("does NOT touch pg0 at all when every knob is opted out", async () => {
+    // The full pre-#3706 escape hatch: an operator who explicitly turns all
+    // three off gets exactly hindsight_api starting pg0 itself.
+    stopBroker = await startFakeBroker(socketPath);
+    const log = join(dir, "pg0-argv-alloff.log");
+    const r = await runWithEnv({
+      SWITCHROOM_HINDSIGHT_PG0_BIN: installFakePg0(log),
+      SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE: "",
+      SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS: "",
+      SWITCHROOM_HINDSIGHT_PG_FSYNC: "off",
+    });
+    expect(r.status).toBe(0);
     expect(argvOf(log)).toEqual([]);
     expect(r.stderr).not.toMatch(/pg0 pre-start ok/);
+  }, 20_000);
+
+  it("never hands postgres a non-boolean fsync value", async () => {
+    // `fsync` is applied only for the exact token `on`. A typo must degrade to
+    // pg0's own `-F` rather than becoming `-c fsync=oon`, which would make the
+    // server refuse to start and turn a durability change into a boot failure.
+    stopBroker = await startFakeBroker(socketPath);
+    const log = join(dir, "pg0-argv-fsync-typo.log");
+    const r = await runWithEnv({
+      SWITCHROOM_HINDSIGHT_PG0_BIN: installFakePg0(log),
+      SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE: "4096MB",
+      SWITCHROOM_HINDSIGHT_PG_FSYNC: "oon",
+    });
+    expect(r.status).toBe(0);
+    const argv = argvOf(log);
+    expect(argv).toContain("effective_cache_size=4096MB");
+    expect(argv.some((a) => a.startsWith("fsync="))).toBe(false);
+  }, 20_000);
+
+  it("accepts an upper-case ON, like the other knobs' sentinels", async () => {
+    stopBroker = await startFakeBroker(socketPath);
+    const log = join(dir, "pg0-argv-fsync-upper.log");
+    const r = await runWithEnv({
+      SWITCHROOM_HINDSIGHT_PG0_BIN: installFakePg0(log),
+      SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE: "",
+      SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS: "",
+      SWITCHROOM_HINDSIGHT_PG_FSYNC: "ON",
+    });
+    expect(r.status).toBe(0);
+    expect(argvOf(log)).toContain("fsync=on");
   }, 20_000);
 
   it("`off` opts out ONE knob and leaves the other applied", async () => {

--- a/tests/docker/hindsight-pg-fsync-probe.test.ts
+++ b/tests/docker/hindsight-pg-fsync-probe.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Effective-outcome guard for embedded-PostgreSQL durability.
+ *
+ * WHAT THIS PINS. `docker/hindsight-entrypoint.sh` pre-starts pg0 with
+ * `-c fsync=on`, because pg0's own default is `-F` — PostgreSQL with fsync
+ * DISABLED. Under `-F` an unclean stop can lose a write that `data_checksums`
+ * still validates (the stale page checksums correctly; it is a lost write, not
+ * a corrupt one), so the database comes back "healthy" with silent damage.
+ * That is not hypothetical here: the live `switchroom-hindsight` container
+ * logs 6–20 unclean shutdowns per day, and on 2026-07-29 one of them preceded
+ * silent corruption of an HNSW index on `memory_units` by ~13 minutes, wedging
+ * one bank's consolidation for ~2.5 hours behind ~38,000 queued memories. See
+ * `HINDSIGHT_PG_DEFAULT_FSYNC` in `src/setup/hindsight-pg-defaults.ts`.
+ *
+ * WHY THE OTHER TESTS ARE NOT ENOUGH. Two cheaper layers already exist:
+ * `src/setup/hindsight-pg-defaults.test.ts` pins the env switchroom emits, and
+ * `tests/docker/hindsight-entrypoint.test.ts` drives the real entrypoint with a
+ * FAKE pg0 and asserts `fsync=on` reaches its argv. Neither can see the thing
+ * that actually decides the outcome, which is external to this repo: whether
+ * PostgreSQL honours a trailing `-c fsync=on` over the `-F` pg0 emits earlier
+ * in the same argv. It does — postgres applies command-line options in order,
+ * and `-F` is positional and always precedes pg0's merged `-c` block — but that
+ * is an upstream property of a pinned third-party binary, not of our code. If a
+ * future pg0 appends its own `-c fsync=off`, reorders the argv, or switches to
+ * writing `postgresql.conf`, every cheaper test in this repo stays green while
+ * the database silently goes back to losing writes. Only reading `SHOW fsync`
+ * out of a real server started by the real entrypoint catches that.
+ *
+ * HOW IT RUNS. The pinned upstream image, a throwaway container, the REAL
+ * `docker/hindsight-entrypoint.sh` (copied in, not reimplemented), a fake
+ * auth-broker UDS and a fake credential fetcher so the entrypoint's pre-flight
+ * passes, and `true` as the CMD so it reaches the pre-start and exits. Then
+ * `SHOW fsync` on the instance the entrypoint actually started.
+ *
+ * `--network none`, like the other probes in this directory: pg0 ships the
+ * PostgreSQL distribution inside its own binary and unpacks it locally, so a
+ * cold `pg0 start` needs no network (verified — 2s, offline).
+ *
+ * BOTH ARMS RUN. The GREEN arm is the default configuration and must report
+ * `on`. The RED arm sets `SWITCHROOM_HINDSIGHT_PG_FSYNC=off` and must report
+ * `off` — without it, a probe that read `fsync` from somewhere other than the
+ * server we started, or that silently no-op'd, would pass forever.
+ *
+ * SKIP DISCIPLINE: identical to the sibling probes. Locally, with no docker or
+ * no cached image, this skips (never pull a 6.4GB third-party image onto a dev
+ * box). CI's `hindsight-probe` job pulls the pinned digest and sets
+ * SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1, under which an unavailable
+ * docker/image is a HARD FAILURE rather than a green skip.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { execFileSync, execSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const ENTRYPOINT = resolve(root, "docker/hindsight-entrypoint.sh");
+const dockerfile = readFileSync(resolve(root, "docker/Dockerfile.hindsight"), "utf8");
+
+const RUN_ID = randomUUID();
+const TEST_PHASE = "hindsight-pg-fsync-probe";
+
+/** The pinned upstream image, read from the Dockerfile so it can never drift. */
+const UPSTREAM_IMAGE = (() => {
+  const m = dockerfile.match(/^FROM\s+(\S+)/m);
+  if (!m) throw new Error("Dockerfile.hindsight has no FROM line");
+  return m[1];
+})();
+
+/** Stands in for the auth-broker: the entrypoint only waits for the socket. */
+const FAKE_BROKER = `const net = require("node:net");
+net.createServer(() => {}).listen(process.argv[2]);
+setTimeout(() => process.exit(0), 300000);
+`;
+
+/** Stands in for hindsight-fetch-creds.cjs: write the dotfile, exit 0. */
+const FAKE_FETCHER = `require("node:fs").writeFileSync(
+  process.env.CRED_FILE,
+  JSON.stringify({ probe: true }) + "\\n",
+);
+`;
+
+/**
+ * Read `fsync` back out of the instance the entrypoint started, through pg0's
+ * own psql so we resolve the port/credentials the same way hindsight_api does.
+ * `pg_settings.source` comes with it: `command line` is the proof the value
+ * arrived on the argv rather than from a conf file we did not write.
+ */
+const READBACK = `set -e
+PG0=$(ls /app/api/.venv/lib/python3.*/site-packages/pg0/bin/pg0)
+echo "ARGV=$(ps -eo args= | grep '[i]nstances/hindsight/data' | head -1)"
+echo "FSYNC=$("$PG0" psql --name hindsight -tAc \\
+  "SELECT setting || ':' || source FROM pg_settings WHERE name = 'fsync'" \\
+  | tr -d '[:cntrl:]')"
+`;
+
+function hasDocker(): boolean {
+  try {
+    execSync("docker version --format '{{.Server.Version}}'", {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasImage(ref: string): boolean {
+  try {
+    execSync(`docker image inspect ${ref}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * CI marker. When set, this suite MUST really execute — an absent docker or an
+ * absent upstream image becomes a hard failure instead of a green skip.
+ * `.github/workflows/docker-e2e.yml` sets it after pulling the pinned digest.
+ */
+const REQUIRED = process.env.SWITCHROOM_REQUIRE_HINDSIGHT_PROBE === "1";
+
+const dockerOk = hasDocker();
+const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
+
+type ProbeResult = { fsync: string; source: string; argv: string; log: string };
+
+/**
+ * Boot the real entrypoint in a throwaway container and read `fsync` back.
+ *
+ * `extraEnv` is layered over the configuration switchroom actually ships, so
+ * the GREEN arm exercises the production values and the RED arm differs from
+ * it by exactly one variable.
+ */
+function probe(label: string, extraEnv: Record<string, string>): ProbeResult {
+  const name = `sr-hs-fsync-${label}-${RUN_ID.slice(0, 8)}`;
+  const stage = mkdtempSync(join(tmpdir(), "sr-fsync-probe-"));
+  try {
+    writeFileSync(join(stage, "fake-broker.cjs"), FAKE_BROKER);
+    writeFileSync(join(stage, "fake-fetch.cjs"), FAKE_FETCHER);
+
+    execFileSync(
+      "docker",
+      [
+        "run",
+        "-d",
+        "--name",
+        name,
+        "--label",
+        `switchroom.test=${TEST_PHASE}`,
+        "--label",
+        `switchroom.test.run=${RUN_ID}`,
+        // NOT --user root: postgres refuses to run as uid 0, and the image's
+        // own `hindsight` user is who runs it in production anyway.
+        "--network",
+        "none",
+        // shared_buffers is mmap here, but parallel-query DSM segments are not
+        // — the default 64MB /dev/shm is too small for pg0's own worker flags.
+        "--shm-size=1g",
+        "--entrypoint",
+        "sleep",
+        UPSTREAM_IMAGE,
+        "300",
+      ],
+      { stdio: ["ignore", "ignore", "pipe"] },
+    );
+
+    for (const f of ["fake-broker.cjs", "fake-fetch.cjs"]) {
+      execFileSync("docker", ["cp", join(stage, f), `${name}:/tmp/${f}`], {
+        stdio: "ignore",
+      });
+    }
+    // The REAL entrypoint, byte for byte — never a reimplementation.
+    execFileSync("docker", ["cp", ENTRYPOINT, `${name}:/tmp/entrypoint.sh`], {
+      stdio: "ignore",
+    });
+
+    execFileSync("docker", ["exec", "-d", name, "node", "/tmp/fake-broker.cjs", "/tmp/fake.sock"], {
+      stdio: "ignore",
+    });
+
+    const env: Record<string, string> = {
+      SWITCHROOM_AUTH_BROKER_SOCKET: "/tmp/fake.sock",
+      SWITCHROOM_HINDSIGHT_CRED_DIR: "/tmp/creds",
+      SWITCHROOM_HINDSIGHT_WAIT_S: "30",
+      // No refresh loop and no reaper: both hold the stdio pipes open, and
+      // neither is what this probe is about.
+      SWITCHROOM_HINDSIGHT_REFRESH_S: "0",
+      SWITCHROOM_HINDSIGHT_REAP_STALE_S: "0",
+      SWITCHROOM_HINDSIGHT_FETCHER: "/tmp/fake-fetch.cjs",
+      // Production sizing, scaled down to what a CI runner can allocate. The
+      // values are irrelevant to fsync; passing them keeps the argv shaped
+      // like the real one so a pg0 flag-merge regression shows up here too.
+      SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE: "1024MB",
+      SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS: "256MB",
+      ...extraEnv,
+    };
+    const envArgs = Object.entries(env).flatMap(([k, v]) => ["-e", `${k}=${v}`]);
+
+    // The entrypoint logs to stderr; fold it into stdout so the pre-start line
+    // is available for assertions and for the failure message.
+    const log = execFileSync(
+      "docker",
+      ["exec", ...envArgs, name, "sh", "-c", "sh /tmp/entrypoint.sh true 2>&1"],
+      { stdio: ["ignore", "pipe", "pipe"], encoding: "utf8" },
+    );
+
+    const out = execFileSync("docker", ["exec", "-i", name, "sh", "-s"], {
+      input: READBACK,
+      stdio: ["pipe", "pipe", "pipe"],
+      encoding: "utf8",
+    });
+    const [setting = "", source = ""] = (out.match(/^FSYNC=(.*)$/m)?.[1] ?? "").split(":");
+    return {
+      fsync: setting,
+      source,
+      argv: out.match(/^ARGV=(.*)$/m)?.[1] ?? "",
+      log,
+    };
+  } finally {
+    try {
+      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+    } catch {
+      /* already gone */
+    }
+    rmSync(stage, { recursive: true, force: true });
+  }
+}
+
+describe("the hindsight fsync probe is real, not a silent skip", () => {
+  it("pins the upstream image by digest so the probe tests the exact shipping bytes", () => {
+    expect(UPSTREAM_IMAGE).toMatch(/@sha256:[0-9a-f]{64}$/);
+  });
+
+  it("hard-fails rather than skipping when CI demands a real run", () => {
+    if (!REQUIRED) {
+      expect(
+        REQUIRED,
+        "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE is unset — the fsync probe is " +
+          "advisory here. CI's hindsight-probe job sets it after pulling " +
+          `${UPSTREAM_IMAGE}.`,
+      ).toBe(false);
+      return;
+    }
+    expect(
+      dockerOk,
+      "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but the docker daemon is unreachable",
+    ).toBe(true);
+    expect(
+      imageOk,
+      `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but ${UPSTREAM_IMAGE} is not present ` +
+        "locally — the workflow must pull the pinned digest before running this suite",
+    ).toBe(true);
+  });
+});
+
+describe.skipIf(!dockerOk || !imageOk)(
+  "embedded PostgreSQL comes up with fsync ON",
+  () => {
+    afterAll(() => {
+      // Label-scoped teardown belt (never an unlabelled bulk removal).
+      try {
+        const ids = execSync(`docker ps -aq --filter label=switchroom.test.run=${RUN_ID}`, {
+          encoding: "utf8",
+        })
+          .split("\n")
+          .filter(Boolean);
+        if (ids.length) {
+          execFileSync("docker", ["rm", "-f", ...ids], { stdio: "ignore" });
+        }
+      } catch {
+        /* nothing to clean */
+      }
+    });
+
+    it("the shipping configuration yields fsync=on, sourced from the command line", () => {
+      const r = probe("green", {});
+      // THE assertion. Everything else in this file exists to make this one
+      // mean something.
+      expect(r.fsync, `pre-start log:\n${r.log}\nargv: ${r.argv}`).toBe("on");
+      // `command line` proves it came from the argv the entrypoint composed.
+      // A `default`/`configuration file` source reading `on` would mean pg0
+      // changed mechanism underneath us and our flag is no longer what is
+      // holding the property.
+      expect(r.source).toBe("command line");
+      // pg0 still emits its `-F`; we are overriding it, not removing it. If
+      // this stops being true the ordering argument in the entrypoint header
+      // needs re-verifying rather than silently inheriting a pass.
+      expect(r.argv).toContain(" -F ");
+      expect(r.argv).toContain("-c fsync=on");
+      expect(r.log).toMatch(/pg0 pre-start ok: .*fsync=on/);
+    }, 180_000);
+
+    it("the RED arm really reads off, so the GREEN arm is not a tautology", () => {
+      const r = probe("red", { SWITCHROOM_HINDSIGHT_PG_FSYNC: "off" });
+      expect(r.fsync, `pre-start log:\n${r.log}\nargv: ${r.argv}`).toBe("off");
+      // With the flag omitted, pg0's `-F` is unopposed and postgres reports
+      // the value as a command-line one too — which is exactly why a source
+      // check alone could not substitute for reading the setting.
+      expect(r.argv).not.toContain("-c fsync=");
+    }, 180_000);
+  },
+);


### PR DESCRIPTION
## What

Turn `fsync` **on** for the embedded PostgreSQL (pg0) inside the hindsight container, and add a real-container guard so it cannot silently regress.

## Why

pg0 launches PostgreSQL with `-F` — fsync **disabled**. Confirmed live:

```
postgres -D /home/hindsight/.pg0/instances/hindsight/data -F -p 5432 -c work_mem=64MB …
SHOW fsync  →  off
```

This is an upstream pg0 default; switchroom never set it (`grep -r fsync src/ docker/` → no hits before this PR).

With `fsync=off` PostgreSQL never forces WAL or data pages to stable storage, so an unclean stop can leave a page that was never written while the WAL believes it was. **`data_checksums` cannot see this** — the stale page checksums *correctly*. It is a lost write, not a corrupt one, so recovery completes and the server reports healthy.

That is not hypothetical here. The live container logs **6–20 unclean shutdowns per day** (`postgresql-2026-07-2[6789].log`, "database system was not properly shut down; automatic recovery in progress" — Jul 26: 8, Jul 27: 20, Jul 28: 6, Jul 29: 6). On 2026-07-29, `04:14:29 performing immediate shutdown because data directory lock file is invalid` preceded, by ~13 minutes, silent corruption of an HNSW vector index on `memory_units` in the `overlord` bank. Consolidation for that bank wedged for **~2.5 hours** behind **~38,000** queued memories; `data_checksums` (which is on) reported nothing, exactly as the mechanism predicts. `REINDEX INDEX CONCURRENTLY` repaired it — a band-aid. This is the change that addresses the cause of the *loss*.

## How

The #3706 pre-start already sets pg0 server parameters via `-c` flags, so this rides the same mechanism: `docker/hindsight-entrypoint.sh` appends `-c fsync=on`.

**Verified, not assumed, that this actually wins over `-F`.** `-F` is positional and pg0 always emits it immediately after `-D`/`-p`, before the merged `-c` block; postgres applies command-line options in order. On a throwaway pg0 instance from the same image:

```
$ pg0 start --name probeA … -c fsync=on
$ ps -ef
postgres -D …/probeA/data -F -p 5432 -c maintenance_work_mem=512MB … -c fsync=on … 

$ SELECT name, setting, source FROM pg_settings WHERE name='fsync';
 fsync | on | command line
```

Note the ordering **among** the `-c` flags is not stable (pg0 iterates a map). This only holds because `-F` is positional and there is exactly one fsync `-c`; that constraint is written into the entrypoint header.

Two deliberate design points:

1. **fsync defaults ON inside the entrypoint**, not only in `src/setup/hindsight-pg-defaults.ts`. Durability must not depend on a new-enough switchroom CLI having emitted the env var — an operator on an older `switchroom apply`, or running the image by hand, still gets a crash-safe database. Consequence: the pre-start now runs even when both sizing knobs are cleared. `SWITCHROOM_HINDSIGHT_PG_FSYNC=off` alongside them restores the full pre-#3706 escape hatch.
2. **A typo degrades, it does not break the boot.** Only the exact token `on` (any case) applies the flag; `off`, empty and anything unrecognised fall through to "omit it", restoring pg0's `-F`. Postgres can therefore never be handed an unparseable `fsync=` value. The pre-start's existing best-effort contract is untouched: every failure path still returns 0 and lets `hindsight_api` start pg0 itself.

## The guard

**`tests/docker/hindsight-pg-fsync-probe.test.ts`** — an effective-outcome probe, not a string grep. It boots the **real** `docker/hindsight-entrypoint.sh` inside the pinned upstream image (fake auth-broker UDS + fake credential fetcher so the pre-flight passes, `true` as the CMD) and reads `SHOW fsync` off the server the entrypoint actually started. It asserts the setting is `on`, that `pg_settings.source` is `command line` (proving it came from our argv), that pg0's `-F` is still present and being overridden rather than removed, and that the pre-start log line agrees.

A **RED arm** runs too: with `SWITCHROOM_HINDSIGHT_PG_FSYNC=off` the same probe must read `off`. Without it, a probe that stopped observing the real server would pass forever.

**Verified it would have caught the bug:** run against `origin/main`'s entrypoint it goes red with `expected 'off' to be 'on'`.

This layer exists because the thing that decides the outcome is external to this repo. If a future pg0 reorders its argv, appends its own `-c fsync=off`, or starts writing `postgresql.conf`, every unit-level test in this repo stays green while the database silently goes back to losing writes. Only reading the running server catches that.

It runs `--network none` like the sibling probes (pg0 ships the PostgreSQL distribution inside its own binary and unpacks it locally — verified: 2s cold start, offline) and takes ~9s wall for both arms. Wired into `docker-e2e.yml`'s `hindsight-probe` job with `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1`, so it is a hard failure rather than a green skip in CI; `docker/hindsight-entrypoint.sh` and `src/setup/hindsight-pg-defaults.ts` were added to that job's path filter so a PR turning fsync back off gets the probe on the PR, not only at the merge queue.

Two cheaper layers back it up: `src/setup/hindsight-pg-defaults.test.ts` pins that both launch paths emit `fsync=on` and that the entrypoint carries its own `:-on` default; `tests/docker/hindsight-entrypoint.test.ts` drives the real entrypoint with a fake pg0 and asserts the flag reaches its argv, including the typo-degrades and all-knobs-off cases.

## Benchmark

**MEASURED.** On a throwaway pg0 instance from the same image, in a separate container with a separate volume — never against the live hindsight database.

Workload shaped to the real one: a `memory_units` table with 220,000 rows, `vector(384)` embeddings, and **88 partial HNSW indexes** partitioned by `(fact_type, bank_id)` — matching the live table's 88/107 index split and 384-dim vectors. 831 MB total relation size. pgbench transaction = one INSERT (retain) + one UPDATE of `access_count`/`updated_at`/`consolidated_at` (consolidation), which is the dominant write pattern. Both arms tuned identically (`shared_buffers=3072MB`, `effective_cache_size=7168MB`, `work_mem=64MB`), run sequentially, `CHECKPOINT` before each, 60s per run, two reps.

| clients | fsync=off (tps) | fsync=on (tps) | cost | lat avg off → on |
|---|---|---|---|---|
| 1 | 507 / 324 | 232 / 218 | ~46% | 2.0–3.1ms → 4.3–4.6ms |
| 4 | 808 / 557 | 531 / 422 | ~30% | 5.0–7.2ms → 7.5–9.5ms |
| 8 | 1473 / 1422 | 595 / 741 | ~54% | 5.4–5.6ms → 10.8–13.4ms |

Device floor for context — `pg_test_fsync -s 3` on the same storage: `fdatasync` 437 ops/sec (2.29ms/op), `fsync` 219 ops/sec (4.57ms/op). That is the term being paid.

**Read this as headroom, not as a percentage.** The cost is real and up to ~2x. What it is paid against is a workload whose measured demand is single digits per second — the incident itself was a *backlog* of 38,000 memories over ~2.5 hours, i.e. ~4 writes/sec. The worst fsync=on arm measured here sustains 218 tps single-client, ~50x that. There is no configuration in this table where fsync is the binding constraint on hindsight's write path.

Honest caveats: the benchmark's probe data directory sits on the container's writable layer rather than the `switchroom-hindsight-data` named volume (same host filesystem, but not byte-identical conditions); its partial indexes average 2,500 rows against the live table's ~7,700, which makes each transaction's WAL volume smaller and therefore makes the *relative* fsync penalty here pessimistic rather than optimistic; and the fsync=off arm was noticeably more variable run to run (507 vs 324 tps at 1 client), which is what an unsynced write path looks like when the checkpointer lands.

## Deploy

**This does not take effect until the hindsight container is restarted.** The entrypoint's pre-start only runs at container start, and `EmbeddedPostgres.ensure_running()` adopts an already-running instance without re-applying config — that short-circuit is the entire reason the `-c` mechanism works. Nothing here changes a running database.

Deliberately **not** deployed in this PR: the live `switchroom-hindsight` container is currently draining a consolidation backlog and was left untouched throughout.

## Out of scope

**What is stopping PostgreSQL 6–20 times a day is a separate question and is tracked separately.** `fsync=on` does not reduce that count; it makes those stops survivable. One lead surfaced while benchmarking and is worth recording for that investigation: `pg0 stop` waits 60s and then **SIGKILLs** the postgres process (observed verbatim: `PostgreSQL did not shut down within 60s, sending SIGKILL...`). A SIGKILL'd postgres is by definition an unclean shutdown, and with fsync off that is precisely the corruption vector. Not investigated further here.

## Test plan

- [x] `npm run lint` — clean (tsc + all 19 guard scripts)
- [x] `vitest run src/setup/ tests/docker/hindsight-entrypoint.test.ts` — 500 passed
- [x] `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 vitest run tests/docker/hindsight-pg-fsync-probe.test.ts` — 4 passed, 9.5s
- [x] Same probe against `origin/main`'s entrypoint — RED (`expected 'off' to be 'on'`)
- [x] Wider `vitest run tests/` — the only failures are the documented environment-dependent set (missing `dist/` build, git-hook harness, socket/root constraints, install/static-binary); none touch hindsight or pg paths, and `tests/docker/hindsight-entrypoint.test.ts` was verified green on pristine `origin/main` before and after. CI is the authority for those.
- [ ] CI `e2e-ok` → `hindsight-probe` (the new step runs there with the pinned digest)
