### PR TITLE
fix(hindsight): sidechain retains carry learnings, not raw transcripts and tools

### DIFF
--- a/vendor/hindsight-memory/scripts/subagent_retain.py
+++ b/vendor/hindsight-memory/scripts/subagent_retain.py
@@ -3,10 +3,23 @@
 
 Delegated (sub-agent / Task-tool) work is the biggest systematic memory hole:
 the main-session Stop retain only ever reads the parent ``transcript_path``, so
-a worker's hours of process work — the paths it touched, the commands that
-worked, the dead ends — reach memory only as the terse final report the parent
+a worker's hours of reasoning — the constraints it discovered, the structural
+dead ends it ruled out — reach memory only as the terse final report the parent
 transcript captures. This hook closes that hole by retaining a bounded window of
 the *sidechain* transcript when a sub-agent terminates.
+
+Scope (Ken, 2026-07-29): LEARNINGS, not raw transcripts and tools. The window is
+retained on the TEXT-ONLY formatting path (``run_subagent_retain`` forces
+``retainToolCalls = False`` on its config copy), so what reaches memory is the
+sub-agent's own prose — reasoning, findings, final report — and NOT tool_use
+inputs, tool_result bodies, file contents or diffs.
+
+The text-only path cannot format to nothing here: the volume gate already
+requires ``MIN_HUMAN_TURNS`` GENUINE human turns (tool_result-only user messages
+are explicitly not counted, ``count_human_turns``), and every such turn is a
+plain-string user message that ``_extract_text_content`` returns verbatim. So a
+window that clears the gate always carries at least its instruction turns, and
+``build_retain_payload`` never returns None on this path for volume reasons.
 
 Probe result (Claude Code 2.1.215, PR5 Task 0 — recorded in the PR body):
 the ``SubagentStop`` hook input carries BOTH the parent ``transcript_path`` AND
@@ -62,8 +75,11 @@ from lib.pacing import inflight_lock
 # stays byte-identical to the main path where it matters (dedup ids, formatting).
 from retain import build_retain_payload, read_transcript
 
-# Retain the last N human turns of the sidechain. Tool-result bodies inside the
-# window are truncated by _extract_message_blocks (content.py) already.
+# Retain the last N human turns of the sidechain. The window is formatted on the
+# TEXT-ONLY path (``retainToolCalls`` is forced False for the sidechain — see
+# ``run_subagent_retain``), so tool_use inputs and tool_result bodies are dropped
+# entirely rather than passed through / truncated. ``_extract_message_blocks`` is
+# still imported here, but only for the volume gate's char count.
 SIDECHAIN_WINDOW_TURNS = 40
 
 # Volume gate floors — SubagentStop fires for every Task, so skip trivial forks.
@@ -256,6 +272,14 @@ def non_tool_result_char_count(messages: list, stop_at: int | None = None) -> in
     the floor even if it emitted a large tool_result, while a real worker's
     commands and decisions count.
 
+    KNOWN MISMATCH (accepted, tracked as a follow-up): this counts ``tool_use``
+    inputs, but those are no longer RETAINED — the sidechain payload is built on
+    the text-only path. So the gate can clear on tool volume that contributes
+    nothing to the stored memory. It cannot produce an EMPTY retain (the
+    ``MIN_HUMAN_TURNS`` floor guarantees prose-bearing user turns — see the
+    module docstring), so this is a precision issue in the gate, not a
+    correctness bug. Tightening it to count only text is a separate change.
+
     ``stop_at`` (review finding 4 — early short-circuit): return as soon as the
     running total reaches this many chars. The gate only needs to know whether
     the floor is CLEARED, not the exact size — so on a large worker transcript
@@ -396,9 +420,32 @@ def run_subagent_retain(hook_input: dict) -> dict:
     # main-session retains: reuse retain.py's ``slice_document_id`` recipe via a
     # composite session key so (a) re-fires of the SAME sub-agent window upsert
     # server-side, and (b) it never collides with the parent's own
-    # ``{session_id}-r...`` documents. Client-side diffing against the parent's
-    # final-report retain is deliberately NOT attempted — overlap is fine, and
-    # hindsight's consolidation dedups (design item 4).
+    # ``{session_id}-r...`` documents.
+    #
+    # Client-side diffing against the parent's final-report retain is still NOT
+    # attempted, but NOT because "hindsight's consolidation dedups" — the
+    # original claim here (design item 4) was FALSE and is the assumption that
+    # licensed the sidechain volume. Verified against the engine source
+    # (upstream image ``ghcr.io/vectorize-io/hindsight``):
+    #   * The only SEMANTIC dedup lives in
+    #     ``hindsight_api/engine/consolidation/consolidator.py`` and is a guard
+    #     on the consolidator's OWN OUTPUT: ``_dedup_adjudicate`` probes a newly
+    #     created/updated ``observation`` against existing ones, passing the
+    #     literal fact-type list ``["observation"]`` to
+    #     ``retrieve_semantic_bm25_combined``.
+    #   * ``world`` and ``experience`` are the raw extracted facts that FEED the
+    #     consolidator (it selects ``fact_type IN ('experience', 'world')`` for
+    #     unconsolidated rows) — they never traverse the observation dedup path.
+    #   * Grepping ``hindsight_api/engine/retain/*.py`` for dedup finds only
+    #     content-hash CHUNK dedup (``chunk_storage.compute_chunk_hash``), i.e.
+    #     byte-identical-chunk skipping. There is no semantic dedup on the
+    #     retain path at all.
+    # So overlap between a sidechain retain and the parent's own retain persists
+    # as extra ``world``/``experience`` rows forever. Volume control has to come
+    # from retaining LESS (see ``retainToolCalls`` below), not from a downstream
+    # dedup that does not exist. Diffing is still skipped here because the
+    # deterministic document_id already makes re-fires of the SAME window upsert,
+    # which is the duplicate class this path can actually create.
     sub_session_id = f"{session_id}-sub-{agent_id}"
 
     # Sidechain tags + a topic-friendly parent link. Reuse the config-driven tag
@@ -407,6 +454,55 @@ def run_subagent_retain(hook_input: dict) -> dict:
     # (recallTagWeights); ``parent_session:<id>`` lets a fresh session pull a
     # worker's process facts by parent.
     sub_config = dict(config)
+
+    # Learnings, not raw transcripts and tools (Ken, 2026-07-29): "I don't want
+    # sub-agents' transcripts but definitely their learnings should be captured
+    # but not raw transcripts and tools."
+    #
+    # With ``retainToolCalls`` on, ``build_retain_payload`` formats the window
+    # via ``_prepare_json_transcript`` → ``_extract_message_blocks``, which emits
+    # every ``tool_use.input`` verbatim (an entire ``Write.content``, a full
+    # ``Edit`` diff, a full ``Bash.command``) plus every ``tool_result`` at up to
+    # 2,000 chars per block.
+    #
+    # The cost mechanism is DOCUMENT FAN-OUT, not one oversized payload: a large
+    # payload is not truncated, it is CAPPED and SPLIT by
+    # ``lib.retain_split.split_retain_content`` at ``retain_content_limit()``
+    # (33,000 chars on the shipped inputs) into ``{base}-p{i}of{n}`` parts
+    # (``client.py`` ~:235). Real sidechain retains have been observed splitting
+    # into 38 parts / 1,022 messages, and every part is separately chunked and
+    # LLM-extracted into ``world``/``experience`` rows. Shrinking the content is
+    # therefore the lever that reduces rows.
+    #
+    # Forcing it OFF for the sidechain path routes the window through
+    # ``_prepare_text_transcript`` → ``_extract_text_content``, keeping assistant
+    # ``text`` blocks and channel-message tool_use text. Measured on real fleet
+    # sidechains: 5.5x smaller over 30 sampled transcripts (2,012,376 → 367,796
+    # chars), and independently 6.4x over the 84 most recent GATE-PASSING ones
+    # (26,278,261 → 4,085,678 chars) — of which 0 formatted to empty and 0 came
+    # out under 500 chars.
+    #
+    # ACCEPTED LOSS — this is not a clean "tool noise only" filter.
+    # ``_extract_text_content`` also drops image blocks, ALL ``tool_result``
+    # content, and sub-agent Task report bodies. So a fact that existed ONLY in
+    # tool output is unrecoverable: if a query returned ``43442`` and the agent
+    # merely replied "checked, it's the backlog", the number is gone. That trade
+    # is deliberate and is what Ken asked for; sub-agent prose was separately
+    # measured to carry durable learnings at essentially the main-session rate
+    # (5.24% vs 6.87%), so the learnings themselves survive.
+    #
+    # Mid-session safety: ``slice_document_id`` derives the BASE id from the
+    # slice's first/last uuids, not from the formatted text, so a re-fire of the
+    # same window still targets the same base id. Note the part SUFFIX embeds the
+    # part total, so a document that used to split into n parts and now splits
+    # into m < n leaves parts m+1..n in place — they are not overwritten and not
+    # duplicated. Historical sidechain rows are untouched by this change; this
+    # fixes INTAKE going forward only.
+    #
+    # Deliberately set on the COPY, not on ``config``: the parent session's own
+    # Stop retain keeps whatever the operator configured.
+    sub_config["retainToolCalls"] = False
+
     base_tags = list(config.get("retainTags") or [])
     extra_tags = ["sidechain", f"parent_session:{session_id}"]
     if agent_type:

--- a/vendor/hindsight-memory/scripts/tests/test_subagent_retain_learnings.py
+++ b/vendor/hindsight-memory/scripts/tests/test_subagent_retain_learnings.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Sidechain retains carry LEARNINGS, not raw transcripts and tools.
+
+Ken, 2026-07-29: "I don't want sub-agents' transcripts but definitely their
+learnings should be captured but not raw transcripts and tools."
+
+``run_subagent_retain`` forces ``retainToolCalls = False`` on its config COPY,
+which routes the window through ``_prepare_text_transcript`` /
+``_extract_text_content`` instead of ``_prepare_json_transcript`` /
+``_extract_message_blocks``. These tests pin the observable consequences:
+
+  1. Structural exclusion — a ``Write`` body, a ``Bash`` command and a
+     ``tool_result`` marker are all absent from the POSTed content, while an
+     assistant prose finding survives; and the content is NOT JSON (proving the
+     text path, not the JSON path, produced it).
+  2. Nothing goes silently empty — the text-only formatter still yields a
+     substantive transcript for a representative sidechain fixture.
+
+Stdlib-only, hermetic (no network, no live container); runs under
+``python3 -m unittest discover tests/``.
+"""
+
+import contextlib
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import subagent_retain  # noqa: E402
+from lib.content import prepare_retention_transcript  # noqa: E402
+
+# Mirrors tests/test_subagent_retain.py CONFIG, including its
+# ``retainToolCalls: True`` — the point is that the sidechain path must override
+# it regardless of what the operator configured.
+CONFIG = {
+    "autoRetain": True,
+    "retainMode": "chunked",
+    "retainRoles": ["user", "assistant"],
+    "retainToolCalls": True,
+    "retainTags": ["{session_id}"],
+    "retainMetadata": {},
+    "retainContext": "claude-code",
+    "hindsightApiToken": None,
+    "debug": False,
+}
+
+# Distinctive markers. Each must be absent from the retained content.
+WRITE_BODY_MARKER = "MARKER_WRITE_FILE_BODY_9f3a"
+BASH_COMMAND_MARKER = "MARKER_BASH_COMMAND_c71d"
+TOOL_RESULT_MARKER = "MARKER_TOOL_RESULT_PAYLOAD_4e82"
+
+# The one thing that MUST survive: the sub-agent's own prose finding.
+FINDING = (
+    "Durable finding: the recall hook's stderr warning is swallowed by the CLI, "
+    "so directives_omitted on the recall_log row is the only visible signal."
+)
+
+
+def _entry(role: str, content, uuid: str) -> str:
+    """One nested Claude Code sidechain jsonl entry."""
+    return json.dumps(
+        {
+            "type": role,
+            "isSidechain": True,
+            "agentId": "af5fba739c0ee6b38",
+            "sessionId": "parentsess",
+            "uuid": uuid,
+            "message": {"role": role, "content": content},
+        }
+    )
+
+
+def _tool_heavy_sidechain(path: str, *, human_turns: int = 8) -> None:
+    """A sidechain transcript that is mostly tool traffic plus one prose finding.
+
+    Shaped to clear the volume gate (>= MIN_HUMAN_TURNS human turns and
+    >= MIN_NON_TOOL_RESULT_CHARS of non-tool-result chars) so the retain
+    actually happens — the gate counts tool_use inputs, which this has in bulk.
+    """
+    lines = []
+    for i in range(human_turns):
+        lines.append(_entry("user", f"instruction {i}: keep going with the audit task", f"u{i}"))
+        lines.append(
+            _entry(
+                "assistant",
+                [
+                    {
+                        "type": "thinking",
+                        "thinking": "internal reasoning that must never be retained",
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": f"tu_w{i}",
+                        "name": "Write",
+                        # ~50 KB body — the class of payload this change exists to drop.
+                        "input": {
+                            "file_path": f"/tmp/scratch/out{i}.txt",
+                            "content": WRITE_BODY_MARKER + ("Z" * 50_000),
+                        },
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": f"tu_b{i}",
+                        "name": "Bash",
+                        "input": {"command": f"{BASH_COMMAND_MARKER} --iteration {i}"},
+                    },
+                ],
+                f"a{i}",
+            )
+        )
+        lines.append(
+            _entry(
+                "user",
+                [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": f"tu_b{i}",
+                        "content": TOOL_RESULT_MARKER + " " + ("q" * 4000),
+                    }
+                ],
+                f"tr{i}",
+            )
+        )
+
+    # The sub-agent's own prose, last — the learning that must survive.
+    lines.append(_entry("user", "wrap up and report what you learned", "ufinal"))
+    lines.append(_entry("assistant", [{"type": "text", "text": FINDING}], "afinal"))
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+@contextlib.contextmanager
+def _lock_acquired(blocking=False):
+    yield True
+
+
+def _run_sidechain_retain(sidechain_path: str, tmpdir: str, config_extra=None):
+    """Drive run_subagent_retain with a stub client, returning (result, kwargs)."""
+    captured = {}
+
+    class _Client:
+        def __init__(self, *a, **k):
+            pass
+
+        def retain(self, **kwargs):
+            captured.update(kwargs)
+            return {"ok": True}
+
+    config = dict(CONFIG, **(config_extra or {}))
+    hook_input = {
+        "session_id": "parentsess",
+        "agent_id": "af5",
+        "agent_type": "worker",
+        "agent_transcript_path": sidechain_path,
+        "transcript_path": os.path.join(tmpdir, "parentsess.jsonl"),
+        "cwd": tmpdir,
+    }
+    with mock.patch("subagent_retain.load_config", return_value=config), \
+            mock.patch("subagent_retain.get_api_url", return_value="http://x"), \
+            mock.patch("subagent_retain.ensure_bank_mission"), \
+            mock.patch("subagent_retain.derive_bank_id", return_value="agentbank"), \
+            mock.patch("subagent_retain.HindsightClient", _Client), \
+            mock.patch("subagent_retain.inflight_lock", _lock_acquired):
+        result = subagent_retain.run_subagent_retain(hook_input)
+    return result, captured
+
+
+class SidechainRetainsLearningsNotTools(unittest.TestCase):
+    """The retained content is the sub-agent's prose, not its tool traffic."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.sidechain = os.path.join(self._tmp.name, "agent-af5.jsonl")
+        _tool_heavy_sidechain(self.sidechain)
+        self.result, self.captured = _run_sidechain_retain(self.sidechain, self._tmp.name)
+        self.assertEqual(self.result["status"], "ok", self.result)
+        self.content = self.captured["content"]
+
+    def test_sub_agent_prose_finding_survives(self):
+        self.assertIn(FINDING, self.content)
+
+    def test_write_tool_body_is_excluded(self):
+        self.assertNotIn(WRITE_BODY_MARKER, self.content)
+        # And the 50 KB body itself is nowhere in the payload.
+        self.assertNotIn("Z" * 200, self.content)
+
+    def test_bash_command_is_excluded(self):
+        self.assertNotIn(BASH_COMMAND_MARKER, self.content)
+
+    def test_tool_result_body_is_excluded(self):
+        self.assertNotIn(TOOL_RESULT_MARKER, self.content)
+
+    def test_thinking_blocks_are_excluded(self):
+        self.assertNotIn("internal reasoning that must never be retained", self.content)
+
+    def test_content_is_not_the_json_transcript_form(self):
+        """Proves we are on the text path, not _prepare_json_transcript.
+
+        The JSON path emits a ``json.dumps`` list of ``{role, content: [blocks]}``;
+        the text path emits ``[role: x]...[x:end]`` markers, which is not JSON.
+        The mission header is prepended to both, so strip it first — otherwise
+        this would pass for the wrong reason.
+        """
+        body = self.content[len(subagent_retain.SIDECHAIN_MISSION_HEADER):].strip()
+        self.assertTrue(body, "no transcript body after the mission header")
+        with self.assertRaises(json.JSONDecodeError):
+            json.loads(body)
+        # Positive check on the text-path shape.
+        self.assertIn("[role: assistant]", body)
+
+    def test_payload_is_far_smaller_than_the_raw_transcript(self):
+        """Volume, not just shape: the whole point is fewer chars to extract."""
+        raw_bytes = os.path.getsize(self.sidechain)
+        self.assertLess(
+            len(self.content),
+            raw_bytes / 5,
+            f"retained {len(self.content)} chars from a {raw_bytes}-byte transcript "
+            "— expected a large reduction on the text-only path",
+        )
+
+    def test_operator_config_is_not_mutated(self):
+        """The override lands on the sidechain COPY, not the parent's config."""
+        self.assertIs(CONFIG["retainToolCalls"], True)
+
+
+class ProseFreeSidechainDegradesGracefully(unittest.TestCase):
+    """The degenerate case — a worker with NO assistant prose at all.
+
+    Worth pinning because the volume gate counts ``tool_use`` inputs
+    (``non_tool_result_char_count``) while the retained content no longer
+    includes them, so gate and payload now measure different things. The
+    reassuring outcome, verified here rather than assumed: it still retains
+    cleanly, because the gate requires ``MIN_HUMAN_TURNS`` GENUINE human turns
+    and each one is a plain-string user message that survives the text path. So
+    ``build_retain_payload`` does not return None and nothing goes silently
+    empty — while the tool traffic is still excluded.
+    """
+
+    def _prose_free_sidechain(self, path: str, human_turns: int = 8) -> None:
+        lines = []
+        for i in range(human_turns):
+            # tool_result-only user messages don't count as human turns, so the
+            # instruction turns are plain strings — but they are the USER's
+            # words. Keep them short so the retained text is dominated by
+            # nothing at all once tools are stripped.
+            lines.append(_entry("user", "go", f"u{i}"))
+            lines.append(
+                _entry(
+                    "assistant",
+                    [
+                        {
+                            "type": "tool_use",
+                            "id": f"tu{i}",
+                            "name": "Bash",
+                            "input": {"command": "true " + ("x" * 4000)},
+                        }
+                    ],
+                    f"a{i}",
+                )
+            )
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+
+    def test_retains_the_human_turns_and_still_drops_the_tool_traffic(self):
+        with tempfile.TemporaryDirectory() as d:
+            sc = os.path.join(d, "agent-af5.jsonl")
+            self._prose_free_sidechain(sc)
+
+            # Precondition: the gate genuinely PASSES on tool_use chars alone,
+            # so this is the "cleared the gate with no prose" case and not just
+            # a trivial-fork skip.
+            msgs = subagent_retain.read_transcript(sc)
+            passed, turns, chars = subagent_retain.passes_volume_gate(msgs, CONFIG)
+            self.assertTrue(passed, f"gate did not pass: turns={turns} chars={chars}")
+
+            result, captured = _run_sidechain_retain(sc, d)
+
+        # Retains, does not crash and does not enqueue a doomed pending retain.
+        self.assertEqual(result["status"], "ok", result)
+        body = captured["content"][len(subagent_retain.SIDECHAIN_MISSION_HEADER):].strip()
+        # The human instruction turns survive — nothing went silently empty.
+        self.assertIn("[role: user]", body)
+        self.assertIn("go", body)
+        # The 4 KB Bash command bodies did NOT.
+        self.assertNotIn("x" * 200, body)
+        self.assertNotIn("true ", body)
+
+
+class TextOnlyPathIsNotEmpty(unittest.TestCase):
+    """A representative sidechain still yields a substantive transcript.
+
+    Prior measurement over 200 real klanker sidechain transcripts found 0 empty
+    and 0 under 500 chars (p10 5,035 / p50 10,058 / p90 26,040 chars). A floor
+    assertion, deliberately not an exact size.
+    """
+
+    # Well under the measured p10 (5,035) — this guards "silently empty",
+    # not the exact reduction ratio.
+    MIN_TRANSCRIPT_CHARS = 500
+
+    def _representative_messages(self):
+        """Prose-bearing assistant turns interleaved with tool traffic."""
+        msgs = []
+        for i in range(10):
+            msgs.append({"role": "user", "content": f"step {i}: continue the investigation"})
+            msgs.append(
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "internal " * 50},
+                        {
+                            "type": "text",
+                            "text": (
+                                f"Step {i}: confirmed the guard only probes observation rows, "
+                                "so world/experience facts never traverse the semantic dedup "
+                                "path. That is why overlap persists as extra rows."
+                            ),
+                        },
+                        {
+                            "type": "tool_use",
+                            "id": f"tu{i}",
+                            "name": "Bash",
+                            "input": {"command": "grep -rn dedup " + ("x" * 3000)},
+                        },
+                    ],
+                }
+            )
+            msgs.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": f"tu{i}", "content": "y" * 5000}
+                    ],
+                }
+            )
+        return msgs
+
+    def test_text_only_transcript_is_non_empty_and_non_trivial(self):
+        transcript, count = prepare_retention_transcript(
+            self._representative_messages(),
+            ["user", "assistant"],
+            True,
+            include_tool_calls=False,
+        )
+        self.assertIsNotNone(transcript, "text-only path formatted to nothing")
+        self.assertGreaterEqual(
+            len(transcript),
+            self.MIN_TRANSCRIPT_CHARS,
+            f"text-only transcript is only {len(transcript)} chars — below the "
+            f"{self.MIN_TRANSCRIPT_CHARS}-char floor",
+        )
+        self.assertGreater(count, 0)
+        # The prose is what carries; the tool traffic is what went.
+        self.assertIn("never traverse the semantic dedup", transcript)
+        self.assertNotIn("grep -rn dedup", transcript)
+
+    def test_text_only_is_materially_smaller_than_json_form(self):
+        msgs = self._representative_messages()
+        text_form, _ = prepare_retention_transcript(
+            msgs, ["user", "assistant"], True, include_tool_calls=False
+        )
+        json_form, _ = prepare_retention_transcript(
+            msgs, ["user", "assistant"], True, include_tool_calls=True
+        )
+        self.assertLess(len(text_form), len(json_form) / 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ken's requirement, verbatim: *"I don't want sub-agents' transcripts but definitely their learnings should be captured but not raw transcripts and tools."*

## What changes

Two edits in `vendor/hindsight-memory/scripts/subagent_retain.py`, plus a new test file.

**1. `sub_config["retainToolCalls"] = False`.** Set on the config COPY the sidechain path already makes, so the parent session's own Stop retain keeps whatever the operator configured. `build_retain_payload` reads `retainToolCalls` (`retain.py:279`), so this routes the retained window through `_prepare_text_transcript` → `_extract_text_content` instead of `_prepare_json_transcript` → `_extract_message_blocks`.

**2. A false comment is corrected** — see below.

## Why the text path is the correct seam

The seam already exists and is already documented. `_extract_text_content` (`lib/content.py` ~:1000-1043) states its contract: it excludes `thinking`, `tool_use` for operational tools, and `tool_result` entirely, while keeping assistant `text` blocks and structurally-detected channel-message text. That is exactly the learnings/exhaust line Ken drew, so this is a config flip onto a maintained path rather than a new filter to keep in sync.

The JSON path is what produced the volume: `_extract_message_blocks` emits every `tool_use.input` verbatim (~:826) and every `tool_result` at up to 2,000 chars (~:845).

**The cost mechanism is document fan-out, not one oversized payload.** A large payload is not truncated — `lib/retain_split.py` caps at `retain_content_limit()` (33,000 chars on the shipped inputs: `3000 * int((310 * 0.7) // 18.4)`, verified by calling it) and SPLITS into `{base}-p{i}of{n}` parts (`lib/client.py:235`). One live document was observed split into 38 parts / 1,022 messages. Every part is separately chunked and LLM-extracted into rows, so shrinking the content is the lever that reduces rows.

## Measured reduction

- **5.5x** over 30 sampled transcripts (2,012,376 → 367,796 chars).
- **6.4x**, measured independently in this PR over the 84 most recent *gate-passing* fleet sidechains: 26,278,261 → 4,085,678 chars.

Nothing goes silently empty: 0 of those 84 formatted to empty and 0 came out under 500 chars (p10 18,621 / p50 42,138 / p90 84,418). A prior 200-transcript sample agreed (0 empty, 0 under 500).

There is also a structural guarantee, verified rather than assumed: the volume gate requires `MIN_HUMAN_TURNS` GENUINE human turns (`count_human_turns` excludes tool_result-only user messages), and each is a plain-string user message that `_extract_text_content` returns verbatim. So a window that clears the gate always carries at least its instruction turns.

## Why the false comment mattered

The removed comment claimed *"Client-side diffing against the parent's final-report retain is deliberately NOT attempted — overlap is fine, and hindsight's consolidation dedups (design item 4)."* **That is false, and it is the assumption that licensed the volume.** Verified against the engine source in the running upstream image (`ghcr.io/vectorize-io/hindsight`), read-only:

- The only **semantic** dedup lives in `hindsight_api/engine/consolidation/consolidator.py` and is a guard on the consolidator's **own output**: `_dedup_adjudicate` probes a newly created/updated `observation` and passes the literal fact-type list `["observation"]` to `retrieve_semantic_bm25_combined` (:210).
- `world` and `experience` are the raw extracted facts that **feed** the consolidator — it selects `fact_type IN ('experience', 'world')` for unconsolidated rows (:895, :931, :998). They never traverse the observation dedup path.
- Grepping `hindsight_api/engine/retain/*.py` for dedup finds only content-hash **chunk** dedup (`chunk_storage.compute_chunk_hash`), i.e. byte-identical-chunk skipping.

So there is no semantic dedup on the retain path at all, and overlap persists as extra `world`/`experience` rows forever. Volume control has to come from retaining less. The comment is replaced with the verified mechanics and the real reason diffing is still skipped (the deterministic `document_id` already makes re-fires of the same window upsert).

## Accepted loss — stated plainly

The text path is **not** a clean tool-only filter. `_extract_text_content` also drops image blocks, ALL `tool_result` content, and sub-agent Task report bodies. So a fact that existed only in tool output is unrecoverable: if a query returned `43442` and the agent merely replied "checked, it's the backlog", the number is gone.

That trade is deliberate and is what was asked for. Sub-agent prose was separately measured to carry durable learnings at essentially the main-session rate (5.24% vs 6.87%), so the learnings themselves survive.

## Historical rows are untouched

**This changes intake going forward only. It deletes nothing.** `slice_document_id` (`retain.py:174-204`) derives the document id from the slice's first/last **uuids**, not from the formatted text (verified), so re-fires still target the same base id and the switch is safe mid-session. One nuance now documented in the source: the part suffix embeds the part total, so a document that used to split into n parts and now splits into m < n leaves parts m+1..n in place — not overwritten, not duplicated.

Explicitly **not** a justification for pruning the existing rows. A review of the high-volume exhaust clusters found the worst offenders (525 rows of "async agent launched", 200 of "cwd reset") have **zero** rows tagged `sidechain` — the historical sidechain rows are not that junk. A separate bulk-prune proposal was rejected as unsafe and this PR does not revive it.

## Tests

New: `vendor/hindsight-memory/scripts/tests/test_subagent_retain_learnings.py` (stdlib-only, hermetic — no network, no live container), matching the conventions of the existing `test_subagent_retain.py` and deliberately reusing its `retainToolCalls: True` config so the override is proven to win regardless of operator config.

**Verified failing on the pre-change code** — 5 of 11 fail when only the source edit is reverted:

```
FAIL: test_bash_command_is_excluded
FAIL: test_content_is_not_the_json_transcript_form
FAIL: test_payload_is_far_smaller_than_the_raw_transcript
FAIL: test_tool_result_body_is_excluded
FAIL: test_write_tool_body_is_excluded
Ran 10 tests / FAILED (failures=5)
```

Coverage: a 50 KB `Write` body, a distinctive `Bash` command and a `tool_result` marker are all absent while the assistant prose finding survives; `json.loads` on the payload body RAISES (proving the text path, with the mission header stripped first so it cannot pass for the wrong reason); a size-reduction floor; a non-empty/non-trivial floor for a representative fixture; and the degenerate prose-free worker, which is verified to still retain its human turns cleanly rather than going empty.

## Deliberately unchanged

`SIDECHAIN_WINDOW_TURNS` (40), `MIN_HUMAN_TURNS` (6), `MIN_NON_TOOL_RESULT_CHARS` (2000), and the mission header text. The header was rewritten on 2026-07-29; changing two things at once makes the effect unmeasurable. One concern per PR.

## Follow-up filed, not fixed here

The volume gate counts `tool_use` inputs (`non_tool_result_char_count`) but those are no longer retained, so the gate can clear on tool volume that contributes nothing to the stored memory. It cannot produce an empty retain (the `MIN_HUMAN_TURNS` floor guarantees prose-bearing turns), so this is a precision issue in the gate, not a correctness bug. Documented in the source docstring; tightening it is a separate change.

## Local verification

- `python3 -m unittest discover tests/` in `vendor/hindsight-memory/scripts` — **915 tests, OK**
- `python3 -m pytest tests/ -q` in `vendor/hindsight-memory` — **258 passed**
- `npm run lint` (tsc + 21 guard scripts) — **clean**

🤖 Generated with [Claude Code](https://claude.com/claude-code)