### PR TITLE
fix(litellm): route claude-opus-4-8/4-7 to the real models, not Opus 5

### DIFF
--- a/docker/litellm-proxy/litellm-config.yaml
+++ b/docker/litellm-proxy/litellm-config.yaml
@@ -179,9 +179,12 @@ model_group_settings:
     forward_client_headers_to_llm_api: true
   claude-opus-4-8:
     forward_client_headers_to_llm_api: true
-  # Retired/older opus version ids alias to current opus so a client that
-  # still sends an old id (e.g. hindsight's claude CLI default) doesn't 400
-  # on version drift.
+  # 2026-07-30: these two are NO LONGER drift aliases. claude-opus-4-8 and
+  # claude-opus-4-7 now route to their OWN upstream models (see the model_list
+  # block for the evidence and the reason). Both are Active per Anthropic's
+  # model-status table, so they are ordinary Anthropic OAuth-passthrough groups
+  # and keep the forwarded Authorization header (invariant I1) — nothing about
+  # the I1 scoping changed here, only the upstream target.
   claude-opus-4-7:
     forward_client_headers_to_llm_api: true
   claude-sonnet-4-6:
@@ -234,16 +237,39 @@ model_list:
   - model_name: opus
     litellm_params:
       model: anthropic/claude-opus-5
-  # Version-drift aliases: clients still sending the retired claude-opus-4-8 /
-  # claude-opus-4-7 ids (e.g. hindsight's claude CLI default) are routed to
-  # current Opus 5 instead of pinning to a stale version — same pattern as the
-  # claude-sonnet-4-6 -> claude-sonnet-5 drift alias below.
+  # 2026-07-30 (per Ken, via klanker): claude-opus-4-8 now routes to the REAL
+  # Opus 4.8 instead of drift-aliasing to Opus 5. The previous comment here
+  # claimed 4.8 was "retired" — that was FALSE. Anthropic's model-status table
+  # (platform.claude.com/docs/en/about-claude/model-deprecations) lists
+  # `claude-opus-4-8` as Active with retirement "not sooner than May 28, 2027"
+  # (4-7: not sooner than April 16, 2027). The drift alias was therefore
+  # advertising a model name and silently serving a DIFFERENT model, which is
+  # worse than not offering it: `/model claude-opus-4-8` appeared to work while
+  # actually running Opus 5.
+  #
+  # Blast radius when this was changed: ZERO. 48h of proxy logs contained no
+  # request for either id — the only occurrences were the startup model-list
+  # printout. Nothing in the fleet pins these names (the sole fleet model
+  # setting is `defaults.model: opus` in switchroom.yaml, an alias to the
+  # CURRENT Opus flagship, deliberately unversioned; there are no per-agent
+  # model pins).
+  #
+  # Both keep their model_group_settings forward_client_headers_to_llm_api
+  # entries above (invariant I1) — they are Anthropic models on the OAuth
+  # passthrough, so the client's Authorization header must still be forwarded.
+  #
+  # NOTE the `opus` alias is UNAFFECTED and still tracks the latest Opus. Do
+  # NOT "fix" this back into a drift alias: pinning a bare codename is only
+  # dangerous when the codename is RETIRED (that is what 4xx'd the fleet on
+  # 2026-06-13 with claude-fable-5). These two are active for ~9 more months,
+  # and when they do retire the correct action is to delete these entries, not
+  # to silently redirect them.
   - model_name: claude-opus-4-8
     litellm_params:
-      model: anthropic/claude-opus-5
+      model: anthropic/claude-opus-4-8
   - model_name: claude-opus-4-7
     litellm_params:
-      model: anthropic/claude-opus-5
+      model: anthropic/claude-opus-4-7
   # Version-drift alias (2026-07-05, per Ken: "sonnet must be the latest"):
   # clients still sending claude-sonnet-4-6 (older switchroom sub-agent /
   # cron defaults) are routed to current Sonnet 5 — same pattern as the


### PR DESCRIPTION
## What

`docker/litellm-proxy/litellm-config.yaml` mapped both `claude-opus-4-8` and `claude-opus-4-7` to `model: anthropic/claude-opus-5` as "version-drift aliases". They now route to their real upstreams:

- `claude-opus-4-8` → `anthropic/claude-opus-4-8`
- `claude-opus-4-7` → `anthropic/claude-opus-4-7`

Two hunks, both in this one file:

1. **`model_list`** — the routing change itself, plus a replacement comment recording the evidence and the reasoning.
2. **`model_group_settings`** — the stale comment above `claude-opus-4-7` (which still described the pair as drift aliases) is replaced. Fixing this is part of the change, not a follow-up: a comment that is now factually false is precisely the failure mode that produced this bug — the old "retired" claim was trusted as ground truth and repeated downstream. The repo and live copies had worded this comment *differently* (live carried an extra "Routes upstream to claude-opus-4-8." sentence), so both now receive the identical replacement and the hunk **converges** rather than diverging further.

## Why

**(a) The live config was already edited by hand — this PR brings the repo copy into line.** The repo copy is the declared source of truth (KEN-125), so leaving it stale means a config-driven redeploy silently reverts the live fix. Both hunks are **byte-for-byte identical** to what is running, verified by `md5sum` of each extracted block against `/data/coolify/services/<svc>/litellm-config.yaml`.

Note the repo and live files are *not* full mirrors and never have been: the repo copy is authoritative with intentional, inline-marked `REPO-ONLY` / `NOT VENDORED` deltas (see the file header), and live carries additional UI-managed models because `store_model_in_db: true`. **Block-level parity for the hunks touched here** is the goal and the thing verified — not whole-file equality.

**(b) Opus 4.8 and 4.7 are ACTIVE, not retired.** The old comment claimed these ids were "retired". Anthropic's model-status table (`platform.claude.com/docs/en/about-claude/model-deprecations`, fetched 2026-07-30) lists `claude-opus-4-8` as Active with retirement "not sooner than May 28, 2027", and `claude-opus-4-7` "not sooner than April 16, 2027" — the older model reaching end of support earlier, as expected. Roughly nine more months of life each.

**(c) The old behaviour advertised one model and served another.** `/model claude-opus-4-8` appeared to work while actually running Opus 5. That is worse than not offering the name at all: a silent substitution with no signal to the caller.

**(d) Blast radius was zero.** 48h of proxy logs contained no request for either id — the only occurrences were the startup model-list printout. Nothing in the fleet pins these names; the sole fleet model setting is `defaults.model: opus` in `switchroom.yaml`, a deliberately unversioned alias, and there are no per-agent model pins.

**(e) The `opus` alias and the fleet default are unchanged.** `opus` still maps to `anthropic/claude-opus-5` and continues to track the current Opus flagship. Nothing about the default model path moves.

## Invariants

Both entries keep their `model_group_settings` `forward_client_headers_to_llm_api: true` (invariant I1) — they are Anthropic models on the OAuth passthrough, so the client's `Authorization` header must still be forwarded. **Only the upstream target moved; the I1 scoping is untouched.** No OpenRouter or OpenAI group gained the flag.

## Verification

- `model_list` length unchanged (58 before, 58 after both hunks); YAML parses under `yaml.safe_load`.
- Resolved opus targets: `claude-opus-5`→`anthropic/claude-opus-5`, `opus`→`anthropic/claude-opus-5`, `claude-opus-4-8`→`anthropic/claude-opus-4-8`, `claude-opus-4-7`→`anthropic/claude-opus-4-7`.
- I1 flag present and `true` for `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-5`, `opus`; the flagged-group set is unchanged and contains zero non-Anthropic groups.
- `node scripts/check-litellm-config-guard.mjs` — OK for the repo copy, and OK for the **live** copy too when pointed at the real services dir.
- Scoped tests: `src/litellm/repo-config.test.ts`, `tests/check-litellm-config-guard.test.ts`, `src/litellm/header-passthrough-guard.test.ts`, `src/fleet-health/litellm-config-sensor.test.ts`, `tests/litellm.model-validation.test.ts` — 98 pass / 0 fail.
- `npm run lint` — clean end to end.
- `.github/path-filters.yml` already covers this file via the `ws9f1-security` anchor (`docker/**`), which feeds both `lint` and `core`. No filter change needed.

Switchroom-Agent: klanker
Switchroom-Model: opus