### PR TITLE
feat(model): short /model spellings for pinned claude-opus-4-8

### DIFF
--- a/docs/model-routing.md
+++ b/docs/model-routing.md
@@ -182,9 +182,16 @@ File:line citations are against the v0.17.11 tree.
   not this repo; switchroom steers it only via env, and the spawned `claude`
   subprocess inherits `ANTHROPIC_BASE_URL` / `ANTHROPIC_CUSTOM_HEADERS`.
 
-`isClaudeModel` (`telegram-plugin/gateway/model-command.ts:79`) is a pure
-model-token test — a known alias or a `claude-` prefix — which is why the
-routing decision keys off the model string alone.
+`isClaudeModel` (`telegram-plugin/gateway/model-command.ts:113`) is a pure
+model-token test — it matches a `MODEL_ALIASES` family alias, a
+`CLAUDE_MODEL_ALIASES` switchroom-side short spelling of a pinned Anthropic id
+(e.g. `opus48` → `claude-opus-4-8`), or a `claude-` prefix — which is why the
+routing decision keys off the model string alone. All three name an Anthropic
+OAuth-passthrough target, so the credential-vs-proxy invariant is unchanged by
+the shortcut arm; it exists so a shortcut is never mistaken for an external
+(`sr-*`) route. The `/model` path additionally expands shortcuts to the
+canonical id (`expandModelAlias`) *before* any classifier sees the token, so a
+short spelling never reaches a routing consumer in the first place.
 
 ## Known Gaps / Follow-ups
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -564,7 +564,7 @@ import {
   MODEL_CALLBACK_PAGE_EXTERNAL,
   MODEL_CALLBACK_PAGE_MAIN,
   srFriendlyLabel,
-  expandSrAlias,
+  expandModelAlias,
   isSrModel,
   isBusyRefusalText,
   isOfflineTrustedModelToken,
@@ -17259,7 +17259,7 @@ function persistQueuedCommandForRestart(action: ShutdownResolutionAction): strin
         const configured =
           readConfiguredDefaultModel(agentDir) ?? resolveMainModel(undefined)
         // Consume-once carrier: applied by the next boot, then reverts.
-        writeSessionModelFile(agentDir, expandSrAlias(action.arg), configured)
+        writeSessionModelFile(agentDir, expandModelAlias(action.arg), configured)
         break
       }
       case 'clear-model':

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -16961,6 +16961,9 @@ function buildModelDeps(restartCtx?: ModelDepsRestartContext): ModelMenuDeps & M
       const data = switchroomExecJson<AgentListResp>(['agent', 'list'])
       return data?.agents?.find(a => a.name === getMyAgentName())?.model ?? null
     },
+    // Feeds the switch-time #1978 assessment (thinkingEffortCaveat); see the
+    // ModelCommandDeps.getConfiguredEffort doc for why doctor can't make it.
+    getConfiguredEffort: () => getConfiguredEffortForPersist(),
     escapeHtml: escapeHtmlForTg,
     preBlock,
     /**

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -33,6 +33,7 @@ import {
   type DiscoverResult,
   type ModelPickerOption,
 } from '../../src/agents/model-picker.js'
+import { assessThinkingEffortRisk } from '../../src/config/thinking-effort-risk.js'
 
 /**
  * Aliases the claude CLI resolves natively (`claude --help`: "an alias for
@@ -694,6 +695,24 @@ export interface ModelCommandDeps {
    * rendered as "default".
    */
   getConfiguredModel: () => string | null
+  /**
+   * The agent's cascade-resolved `thinking_effort` from `switchroom agent list`
+   * — the value start.sh bakes into `--effort` on the relaunch this command is
+   * about to schedule. Null when unset / unreadable (treated as the scaffold
+   * floor `low`, i.e. safe).
+   *
+   * Needed because a `/model` switch is SESSION-scoped and therefore invisible
+   * to `switchroom doctor`, whose `thinking_effort × adaptive model` check
+   * (`src/cli/doctor.ts:572`) reads the CONFIGURED `model:` out of
+   * switchroom.yaml. Switching the live session onto a pinned Opus 4.x id — by
+   * typing it, by a `CLAUDE_MODEL_ALIASES` shortcut, or by tapping the
+   * "Opus 4.8" button — lands the exact (pinned Opus 4.x, effort > low)
+   * combination doctor exists to warn about, with doctor none the wiser. So the
+   * assessment is re-run HERE, at switch time, against the effort the relaunch
+   * will actually use. A relaunch writes no `.session-effort` carrier, so any
+   * live `/effort` override is shed and the configured value is the right input.
+   */
+  getConfiguredEffort: () => string | null
   escapeHtml: (s: string) => string
   preBlock: (s: string) => string
   /**
@@ -880,17 +899,64 @@ function relaunchErrorReply(
  * TARGET is vouched by the same curation gate that makes it offline-trustable
  * (isOfflineTrustedModelToken), so it is exempt too; warning "can't be
  * validated" on a shortcut switchroom itself curates would contradict that.
- * The first-reply divergence tripwire still covers it either way.
+ *
+ * The exemption compares `canonicalModelToken(model)` — the SAME form
+ * `expandModelAlias` emits — so the token that reaches `claude --model` and the
+ * token this gate judges can never disagree. Comparing a lowercased form against
+ * a verbatim-emitted one is exactly how `/model CLAUDE-OPUS-4-8` used to launch
+ * an uncanonical id under a clean green ack.
+ *
+ * What the exemption costs, stated honestly: the ONLY remaining signal that an
+ * exempted target silently fell back is the first-reply divergence tripwire
+ * (`servedModelMatchesRequested`). The post-boot confirmation card is NOT a
+ * second signal for a pinned id whose FAMILY equals the configured default's:
+ * `modelFamilyToken('claude-opus-4-8')` is `'opus'`, so on an `opus`-default
+ * agent `classifyModelSwitchConfirmation` returns `default`, not `not-applied`
+ * (see #4001 — a pre-existing property of the family reduction, reachable
+ * before this map existed by typing the full id).
  * Exported for tests.
  */
 export function unvalidatedIdCaveat(
   deps: Pick<ModelCommandDeps, 'escapeHtml'>,
   model: string,
 ): string | null {
-  const lower = model.trim().toLowerCase()
+  const lower = canonicalModelToken(model).toLowerCase()
   if (!lower.startsWith('claude-')) return null
   if (Object.values(CLAUDE_MODEL_ALIASES).includes(lower)) return null
   return `_\`${deps.escapeHtml(model)}\` can't be validated before launch — if it isn't a real Claude model id, claude will silently serve the configured fallback model instead. I check the first reply and will warn if that happens._`
+}
+
+/**
+ * Switch-time surfacing of the #1978 adaptive-thinking risk (`thinking_effort`
+ * above `low` on a PINNED Opus 4.x id).
+ *
+ * `assessThinkingEffortRisk` had exactly ONE consumer — `switchroom doctor`
+ * (`src/cli/doctor.ts:572`) — which reads the CONFIGURED `model:` from
+ * switchroom.yaml. A `/model` switch is session-scoped and never touches that
+ * file, so every route onto a pinned Opus 4.x (typed full id, a
+ * `CLAUDE_MODEL_ALIASES` shortcut, or the one-tap "Opus 4.8" button) reached the
+ * risky combination with no warning anywhere. This is the second consumer, on
+ * the path that actually creates the combination.
+ *
+ * Advisory only — it never rewrites anyone's effort. Returns null when the combo
+ * is safe (effort unset/`low`, or any non-Opus-4.x model, including Opus 5 and
+ * the bare `opus` alias).
+ */
+export function thinkingEffortCaveat(
+  deps: Pick<ModelCommandDeps, 'escapeHtml' | 'getConfiguredEffort'>,
+  model: string,
+): string | null {
+  let effort: string | null
+  try {
+    effort = deps.getConfiguredEffort()
+  } catch {
+    // The effort probe shells out to `switchroom agent list`; a transient
+    // failure must never block or fail the switch it is only annotating.
+    return null
+  }
+  const risk = assessThinkingEffortRisk(model, effort ?? undefined)
+  if (!risk.risky || !risk.reason) return null
+  return `⚠️ _${deps.escapeHtml(risk.reason)}_`
 }
 
 /** Schedule a carrier relaunch onto `model`, returning the deterministic ack. */
@@ -905,8 +971,14 @@ async function scheduleRelaunchReply(
     return relaunchErrorReply(deps, model, err)
   }
   const caveat = unvalidatedIdCaveat(deps, model)
+  const effortRisk = thinkingEffortCaveat(deps, model)
   return {
-    text: [switchingLine(deps, model), ...(caveat ? [caveat] : []), PERSIST_NOTE].join('\n'),
+    text: [
+      switchingLine(deps, model),
+      ...(caveat ? [caveat] : []),
+      ...(effortRisk ? [effortRisk] : []),
+      PERSIST_NOTE,
+    ].join('\n'),
     html: true,
   }
 }
@@ -995,20 +1067,28 @@ export const MODEL_CALLBACK_PAGE_MAIN = 'mdl:page:main'
 export type ModelMenuPage = 'main' | 'external'
 
 /**
- * Static Claude aliases appended to the scraped Claude group. The claude CLI's
- * own `/model` picker (deps.discover) does NOT list `fable`, but the CLI
- * resolves the alias natively, so we render it as an extra button that switches
- * via the carrier relaunch (MODEL_CALLBACK_ALIAS → scheduleModelRelaunch, rev
- * 5). Extend this list to surface further CLI-resolvable aliases the picker
- * omits.
+ * Static Claude `--model` TOKENS appended to the scraped Claude group — extra
+ * keyboard rows for targets the claude CLI's own `/model` picker (deps.discover)
+ * does not list. Each renders as a button that switches via the carrier relaunch
+ * (MODEL_CALLBACK_ALIAS → scheduleModelRelaunch, rev 5).
+ *
+ * NB "token", not "alias": members are not required to be CLI-resolvable aliases
+ * and are treated opaquely by both call sites (they are only concatenated onto
+ * the `mdl:alias:` callback prefix, whose wire format predates this list). The
+ * two kinds present today:
+ *   - `fable` — a genuine alias the CLI resolves itself; the picker just omits
+ *     it. Boots via the LiteLLM router repoint in start.sh (see the fable case).
+ *   - `claude-opus-4-8` — a full PINNED id, not an alias. Rendered because the
+ *     picker doesn't offer it and typing it on a phone is hostile.
+ * Extend with either kind; a member only has to be a legal `claude --model` arg.
  */
-export const EXTRA_CLAUDE_ALIASES: ReadonlyArray<{ alias: string; label: string }> = [
-  { alias: 'fable', label: 'Fable' },
+export const EXTRA_CLAUDE_MENU_TOKENS: ReadonlyArray<{ token: string; label: string }> = [
+  { token: 'fable', label: 'Fable' },
   // Pinned Opus 4.8. The button carries the CANONICAL id (not the `opus48`
   // shortcut) so the tap needs no expansion to be recognized by an older
   // gateway, and so `canonicalClaudeToken` resolves it directly. Typed
   // `/model opus48` / `/model opus-4-8` land on the same target.
-  { alias: 'claude-opus-4-8', label: 'Opus 4.8' },
+  { token: 'claude-opus-4-8', label: 'Opus 4.8' },
 ]
 
 /**
@@ -1120,9 +1200,35 @@ export function expandSrAlias(arg: string): string {
   return SR_MODEL_ALIASES[arg.toLowerCase()] ?? arg
 }
 
+/**
+ * The ONE canonical form of a model token — what `claude --model` is handed and
+ * what every downstream gate compares against.
+ *
+ * Two normalizations, both narrow:
+ *   - **trim** — unconditional. `unvalidatedIdCaveat` already trimmed while
+ *     expansion did not, so the two disagreed on a padded token.
+ *   - **lowercase, `claude-*` ONLY.** Every real Anthropic model id is lowercase
+ *     and a phone autocapitalizes, so `/model Claude-Opus-4-8` used to be launched
+ *     VERBATIM as an unvalidated id while the caveat exemption (which lowercases)
+ *     suppressed the warning — a clean green ack for a token the caveat was
+ *     written for. Non-`claude-` tokens are left alone: `sr-*` ids are matched
+ *     case-insensitively by their own maps, and rewriting an arbitrary external
+ *     id's case is not ours to do.
+ *
+ * Applied by `expandModelAlias`, so canonicalization happens on every `/model`
+ * path (typed apply, mid-turn queue, menu tap, queued-across-restart persist)
+ * whether or not the token hit a shortcut map — one canonical form flows to
+ * `claude --model`, and `unvalidatedIdCaveat` sees exactly that form.
+ */
+export function canonicalModelToken(arg: string): string {
+  const trimmed = arg.trim()
+  const lower = trimmed.toLowerCase()
+  return lower.startsWith('claude-') ? lower : trimmed
+}
+
 /** Expand a short pinned-Claude spelling (case-insensitive) to its full `claude-*` id. */
 export function expandClaudeAlias(arg: string): string {
-  return CLAUDE_MODEL_ALIASES[arg.toLowerCase()] ?? arg
+  return CLAUDE_MODEL_ALIASES[arg.trim().toLowerCase()] ?? arg
 }
 
 /**
@@ -1131,13 +1237,15 @@ export function expandClaudeAlias(arg: string): string {
  * queued-across-restart persist). Claude shortcuts resolve first, then sr-*
  * shortcuts; the two key sets are disjoint by construction (a Claude shortcut
  * never expands to an `sr-*` id and vice versa), so order only documents intent.
+ * The result is `canonicalModelToken`-normalized, so a miss can no longer emit a
+ * verbatim mixed-case `claude-*` id that the caveat exemption then mis-matches.
  *
  * Expanding HERE — before `isClaudeModel` / `isSrModel` / `externalModelNames`
  * ever see the token — is what keeps a pinned-Claude shortcut on the Anthropic
  * OAuth passthrough instead of being misread as an external route.
  */
 export function expandModelAlias(arg: string): string {
-  return expandSrAlias(expandClaudeAlias(arg))
+  return canonicalModelToken(expandSrAlias(expandClaudeAlias(arg)))
 }
 
 export function srFriendlyLabel(srName: string): string {
@@ -1258,9 +1366,9 @@ function busyStaticMenu(
   // Same extra Claude rows the live keyboard renders (Fable, pinned Opus 4.8),
   // minus any already covered by a MODEL_ALIASES row above — otherwise a model
   // is selectable when idle but vanishes from the mid-turn quick list.
-  for (const { alias, label } of EXTRA_CLAUDE_ALIASES) {
-    if ((MODEL_ALIASES as readonly string[]).includes(alias.toLowerCase())) continue
-    rows.push([{ text: label, callback_data: `${MODEL_CALLBACK_ALIAS}${alias}` }])
+  for (const { token, label } of EXTRA_CLAUDE_MENU_TOKENS) {
+    if ((MODEL_ALIASES as readonly string[]).includes(token.toLowerCase())) continue
+    rows.push([{ text: label, callback_data: `${MODEL_CALLBACK_ALIAS}${token}` }])
   }
   rows.push([{ text: 'Default (configured)', callback_data: `${MODEL_CALLBACK_ALIAS}default` }])
   if (externalNames.length > 0) {
@@ -1331,16 +1439,16 @@ function mainPageKeyboard(
     }])
   }
 
-  // Static Claude aliases the CLI picker omits (e.g. Fable). Deduped: if the
-  // scraped Claude options already include a matching row, don't render the
-  // static one too.
-  for (const { alias, label } of EXTRA_CLAUDE_ALIASES) {
+  // Static Claude tokens the CLI picker omits (Fable, pinned Opus 4.8).
+  // Deduped: if the scraped Claude options already include a matching row,
+  // don't render the static one too.
+  for (const { token, label } of EXTRA_CLAUDE_MENU_TOKENS) {
     const already = claudeOptions.some(
       (o) => o.label.toLowerCase() === label.toLowerCase() ||
-        o.label.toLowerCase() === alias.toLowerCase(),
+        o.label.toLowerCase() === token.toLowerCase(),
     )
     if (already) continue
-    rows.push([{ text: label, callback_data: `${MODEL_CALLBACK_ALIAS}${alias}` }])
+    rows.push([{ text: label, callback_data: `${MODEL_CALLBACK_ALIAS}${token}` }])
   }
 
   if (hasExternal) {
@@ -1535,13 +1643,17 @@ export async function handleModelMenuCallback(
       token = data.slice(MODEL_CALLBACK_SELECT.length)
       label = token
     }
+    // Shape gate FIRST, on the RAW callback payload. `expandModelAlias` trims,
+    // so gating after it would let a whitespace-padded payload through a regex
+    // that exists precisely to guarantee one whitespace-free token reaches the
+    // tmux pane. Order: shape → expand → recognition.
+    if (!isValidModelArg(token)) {
+      return { answer: 'Invalid model name', reply: await buildModelMenu(deps) }
+    }
     // Same expansion the typed path applies, before the recognition gate: a
     // callback minted by an older gateway (or a hand-crafted `mdl:alias:opus48`)
     // must resolve to the canonical id rather than be rejected as unrecognized.
     token = expandModelAlias(token)
-    if (!isValidModelArg(token)) {
-      return { answer: 'Invalid model name', reply: await buildModelMenu(deps) }
-    }
     // N1: reject a token we don't recognize (a stale OLD-gateway `mdl:s:<hex>`
     // callback, an unmapped SELECT row, or garbage). Relaunching onto it would
     // write a carrier claude silently falls back from (--fallback-model). Re-render
@@ -1603,11 +1715,16 @@ async function menuRelaunchOutcome(
     }
   }
   const friendly = isDefault ? 'the configured default' : label
+  // Same #1978 switch-time guard the typed path carries — the one-tap
+  // "Opus 4.8" button is the EASIEST route into (pinned Opus 4.x, effort > low)
+  // and doctor cannot see a session-scoped switch. `/model default` reverts to
+  // the configured model, which doctor already covers, so it is not assessed.
+  const effortRisk = isDefault ? null : thinkingEffortCaveat(deps, token)
   return {
     answer: `Switching to ${isDefault ? 'default' : label} — relaunching (~30s)`,
     reply: await menuWithBannerStatic(
       deps,
-      `🔄 Switching session to **${deps.escapeHtml(friendly)}** — relaunching (~30s).\n${PERSIST_NOTE}`,
+      `🔄 Switching session to **${deps.escapeHtml(friendly)}** — relaunching (~30s).${effortRisk ? `\n${effortRisk}` : ''}\n${PERSIST_NOTE}`,
     ),
   }
 }

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -912,7 +912,7 @@ function relaunchErrorReply(
  * second signal for a pinned id whose FAMILY equals the configured default's:
  * `modelFamilyToken('claude-opus-4-8')` is `'opus'`, so on an `opus`-default
  * agent `classifyModelSwitchConfirmation` returns `default`, not `not-applied`
- * (see #4001 — a pre-existing property of the family reduction, reachable
+ * (see #4005 — a pre-existing property of the family reduction, reachable
  * before this map existed by typing the full id).
  * Exported for tests.
  */

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -51,6 +51,34 @@ import {
 export const MODEL_ALIASES = ['opus', 'sonnet', 'haiku', 'fable', 'default'] as const
 
 /**
+ * Short SWITCHROOM-side spellings for pinned **Anthropic** model ids. These are
+ * expanded to the full `claude-*` id on the `/model` path BEFORE any
+ * Claude-vs-external classification runs, so what reaches the `.session-model`
+ * carrier (and therefore `claude --model`) is always the canonical id — the CLI
+ * never sees the short spelling.
+ *
+ * Deliberately NOT `SR_MODEL_ALIASES`: that map means "external / OpenRouter /
+ * the Anthropic OAuth header is NOT forwarded". These targets are Anthropic
+ * OAuth-passthrough models, so putting them there would flip the
+ * header-forwarding + external-billing classification and surface them under the
+ * "🌐 External models" keyboard page with an `srFriendlyLabel`.
+ *
+ * Also NOT `MODEL_ALIASES`: that list is the aliases the claude CLI resolves
+ * *itself*, and its members double as FAMILY tokens in `modelFamilyToken` /
+ * `canonicalClaudeToken` / `servedModelMatchesRequested`. A pinned-id shortcut
+ * is neither.
+ *
+ * NB the repo prefers family aliases over pinned ids (an alias tracks the
+ * current flagship, a pinned id goes stale) — these exist because an operator
+ * sometimes wants a specific pinned Opus, and typing `claude-opus-4-8` on a
+ * phone is hostile. Keys are matched case-insensitively.
+ */
+export const CLAUDE_MODEL_ALIASES: Record<string, string> = {
+  opus48: 'claude-opus-4-8',
+  'opus-4-8': 'claude-opus-4-8',
+}
+
+/**
  * Shape gate for the model argument. This string is typed literally
  * into the agent's tmux pane, so the gate is strict by construction:
  * one token, alphanumeric start, then alphanumerics plus the chars
@@ -76,11 +104,15 @@ export function isSrModel(name: string): boolean {
  * True when `name` is a Claude model — either a well-known alias or a
  * full `claude-*` id (including `[1m]` variants). This is intentionally
  * broader than MODEL_ALIASES: any `claude-…` string from claude's own
- * picker (e.g. `claude-opus-4-8`) qualifies.
+ * picker (e.g. `claude-opus-4-8`) qualifies, as does a switchroom-side short
+ * spelling of a pinned Claude id (CLAUDE_MODEL_ALIASES, e.g. `opus48`) — those
+ * name an Anthropic OAuth-passthrough model, so a classification consumer must
+ * never mistake one for an external/OpenRouter route.
  */
 export function isClaudeModel(name: string): boolean {
   const lower = name.toLowerCase()
   if ((MODEL_ALIASES as readonly string[]).includes(lower)) return true
+  if (lower in CLAUDE_MODEL_ALIASES) return true
   return lower.startsWith('claude-')
 }
 
@@ -621,7 +653,7 @@ export function planModelCommand(
 ): ModelCommandDisposition {
   if (parsed.kind === 'show' && ctx.menuEnabled) return { kind: 'menu' }
   if (parsed.kind === 'set' && isModelCommandBusy(ctx)) {
-    return { kind: 'queue', target: expandSrAlias(parsed.model) }
+    return { kind: 'queue', target: expandModelAlias(parsed.model) }
   }
   return { kind: 'apply', parsed }
 }
@@ -721,14 +753,34 @@ export interface ModelCommandReply {
 const PERSIST_NOTE =
   '_A `/model` switch relaunches the session (~30s) on the chosen model. Session-only — reverts to the configured \`model:\` on the next restart. \`/model default\` reverts now. Live scrollback is replaced by a fresh session; memory and the handoff briefing carry the context. To change the default permanently, set \`model:\` in switchroom.yaml._'
 
+/**
+ * Discoverability line for CLAUDE_MODEL_ALIASES, grouped by target so several
+ * spellings of one id read as one entry (`opus48` · `opus-4-8` → `claude-opus-4-8`).
+ * Derived from the map, never hand-listed, so a new shortcut shows up in the
+ * help and dashboard text for free.
+ */
+function claudeAliasHints(prefix: string): string {
+  const byTarget = new Map<string, string[]>()
+  for (const [alias, target] of Object.entries(CLAUDE_MODEL_ALIASES)) {
+    const spellings = byTarget.get(target) ?? []
+    spellings.push(alias)
+    byTarget.set(target, spellings)
+  }
+  return [...byTarget]
+    .map(([target, spellings]) => `${spellings.map(a => `\`${prefix}${a}\``).join(' · ')} → \`${target}\``)
+    .join('; ')
+}
+
 function helpText(deps: ModelCommandDeps, reason?: string): ModelCommandReply {
   const srAliasExamples = Object.keys(SR_MODEL_ALIASES).map(a => `\`${a}\``).join(' · ')
+  const claudeAliasExamples = claudeAliasHints('')
   const lines: string[] = []
   if (reason) lines.push(`⚠️ ${deps.escapeHtml(reason)}`)
   lines.push(
     '**/model** — show or switch the Claude model',
     '\`/model\` — show the configured model',
     `\`/model <name>\` — switch the live session (${MODEL_ALIASES.map(a => `\`${a}\``).join(' · ')} or a full model id)`,
+    `_Pinned Claude shortcuts:_ ${claudeAliasExamples}`,
     `_OpenRouter shortcuts:_ ${srAliasExamples}`,
     '_Every switch relaunches the session (~30s) on the chosen model — Claude and OpenRouter (sr-\\*) alike._',
     PERSIST_NOTE,
@@ -751,6 +803,7 @@ export async function handleModelCommand(
         `**Model — ${deps.escapeHtml(deps.getAgentName())}**`,
         `Configured: \`${deps.escapeHtml(shown)}\``,
         `Switch the live session: ${MODEL_ALIASES.map(a => `\`/model ${a}\``).join(' · ')}`,
+        `Pinned Claude shortcuts: ${claudeAliasHints('/model ')}`,
         `OpenRouter shortcuts: ${srAliasExamples}`,
         'or \`/model <full-model-id>\`',
         PERSIST_NOTE,
@@ -765,8 +818,9 @@ export async function handleModelCommand(
     return helpText(deps, `not a valid model name: ${parsed.model}`)
   }
 
-  // Expand short aliases: `flash` → `sr-gemini-2.5-flash`, `codex` → `sr-codex-5.5`, etc.
-  const model = expandSrAlias(parsed.model)
+  // Expand short aliases BEFORE any Claude-vs-external decision below:
+  // `opus48`/`opus-4-8` → `claude-opus-4-8`, `flash` → `sr-gemini-2.5-flash`, etc.
+  const model = expandModelAlias(parsed.model)
 
   // Busy gate: a switch RELAUNCHES the session, which is unsafe mid-turn (it
   // would tear down the live turn). The gateway's mid-turn path ACKs + queues +
@@ -822,13 +876,20 @@ function relaunchErrorReply(
  * silently serves the fallback. Say so IMMEDIATELY in the switch ack, and
  * point at the first-reply tripwire that will catch it. Aliases and sr-* ids
  * are vouched by their own gates (MODEL_ALIASES / the LiteLLM route probe),
- * so only typed `claude-*` ids carry the caveat. Exported for tests.
+ * so only typed `claude-*` ids carry the caveat — and a CLAUDE_MODEL_ALIASES
+ * TARGET is vouched by the same curation gate that makes it offline-trustable
+ * (isOfflineTrustedModelToken), so it is exempt too; warning "can't be
+ * validated" on a shortcut switchroom itself curates would contradict that.
+ * The first-reply divergence tripwire still covers it either way.
+ * Exported for tests.
  */
 export function unvalidatedIdCaveat(
   deps: Pick<ModelCommandDeps, 'escapeHtml'>,
   model: string,
 ): string | null {
-  if (!model.trim().toLowerCase().startsWith('claude-')) return null
+  const lower = model.trim().toLowerCase()
+  if (!lower.startsWith('claude-')) return null
+  if (Object.values(CLAUDE_MODEL_ALIASES).includes(lower)) return null
   return `_\`${deps.escapeHtml(model)}\` can't be validated before launch — if it isn't a real Claude model id, claude will silently serve the configured fallback model instead. I check the first reply and will warn if that happens._`
 }
 
@@ -943,6 +1004,11 @@ export type ModelMenuPage = 'main' | 'external'
  */
 export const EXTRA_CLAUDE_ALIASES: ReadonlyArray<{ alias: string; label: string }> = [
   { alias: 'fable', label: 'Fable' },
+  // Pinned Opus 4.8. The button carries the CANONICAL id (not the `opus48`
+  // shortcut) so the tap needs no expansion to be recognized by an older
+  // gateway, and so `canonicalClaudeToken` resolves it directly. Typed
+  // `/model opus48` / `/model opus-4-8` land on the same target.
+  { alias: 'claude-opus-4-8', label: 'Opus 4.8' },
 ]
 
 /**
@@ -1039,11 +1105,39 @@ export function isOfflineTrustedModelToken(token: string): boolean {
   const lower = token.toLowerCase()
   if ((MODEL_ALIASES as readonly string[]).includes(lower)) return true
   if (lower in SR_MODEL_ALIASES) return true
-  return Object.values(SR_MODEL_ALIASES).includes(lower)
+  if (Object.values(SR_MODEL_ALIASES).includes(lower)) return true
+  // Curated pinned-Claude shortcuts and their targets. Both spellings are
+  // trustable for the same reason the sr-* alias TARGETS are: the id is
+  // switchroom-curated, not a hand-typed guess. A queue that already expanded
+  // (planModelCommand) persists the VALUE, an alias tap persists the KEY — so
+  // both sides must be accepted or `/model opus48` would survive a boot only
+  // on one of the two paths.
+  if (lower in CLAUDE_MODEL_ALIASES) return true
+  return Object.values(CLAUDE_MODEL_ALIASES).includes(lower)
 }
 
 export function expandSrAlias(arg: string): string {
   return SR_MODEL_ALIASES[arg.toLowerCase()] ?? arg
+}
+
+/** Expand a short pinned-Claude spelling (case-insensitive) to its full `claude-*` id. */
+export function expandClaudeAlias(arg: string): string {
+  return CLAUDE_MODEL_ALIASES[arg.toLowerCase()] ?? arg
+}
+
+/**
+ * The ONE expansion every `/model` argument goes through, on every path that
+ * consumes a user-supplied token (typed apply, mid-turn queue, menu tap,
+ * queued-across-restart persist). Claude shortcuts resolve first, then sr-*
+ * shortcuts; the two key sets are disjoint by construction (a Claude shortcut
+ * never expands to an `sr-*` id and vice versa), so order only documents intent.
+ *
+ * Expanding HERE — before `isClaudeModel` / `isSrModel` / `externalModelNames`
+ * ever see the token — is what keeps a pinned-Claude shortcut on the Anthropic
+ * OAuth passthrough instead of being misread as an external route.
+ */
+export function expandModelAlias(arg: string): string {
+  return expandSrAlias(expandClaudeAlias(arg))
 }
 
 export function srFriendlyLabel(srName: string): string {
@@ -1160,6 +1254,13 @@ function busyStaticMenu(
       text: alias.charAt(0).toUpperCase() + alias.slice(1),
       callback_data: `${MODEL_CALLBACK_ALIAS}${alias}`,
     }])
+  }
+  // Same extra Claude rows the live keyboard renders (Fable, pinned Opus 4.8),
+  // minus any already covered by a MODEL_ALIASES row above — otherwise a model
+  // is selectable when idle but vanishes from the mid-turn quick list.
+  for (const { alias, label } of EXTRA_CLAUDE_ALIASES) {
+    if ((MODEL_ALIASES as readonly string[]).includes(alias.toLowerCase())) continue
+    rows.push([{ text: label, callback_data: `${MODEL_CALLBACK_ALIAS}${alias}` }])
   }
   rows.push([{ text: 'Default (configured)', callback_data: `${MODEL_CALLBACK_ALIAS}default` }])
   if (externalNames.length > 0) {
@@ -1434,6 +1535,10 @@ export async function handleModelMenuCallback(
       token = data.slice(MODEL_CALLBACK_SELECT.length)
       label = token
     }
+    // Same expansion the typed path applies, before the recognition gate: a
+    // callback minted by an older gateway (or a hand-crafted `mdl:alias:opus48`)
+    // must resolve to the canonical id rather than be rejected as unrecognized.
+    token = expandModelAlias(token)
     if (!isValidModelArg(token)) {
       return { answer: 'Invalid model name', reply: await buildModelMenu(deps) }
     }

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -911,3 +911,182 @@ describe("unvalidatedIdCaveat — immediate fail-fast warn on free-text claude-*
     expect(alias.text).not.toContain("can't be validated before launch");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Short `/model` spellings for pinned Claude ids (CLAUDE_MODEL_ALIASES).
+//
+// Every assertion here FAILS on the pre-change code: `opus48` / `opus-4-8` were
+// passed through verbatim to the carrier (claude would 4xx or silently serve the
+// fallback), were refused by the offline-trust gate, and were not reachable from
+// the picker. The negative block pins the design constraint that made this a
+// separate map from SR_MODEL_ALIASES: these are Anthropic OAuth-passthrough
+// models and must NEVER be classified as external/OpenRouter routes.
+// ---------------------------------------------------------------------------
+import {
+  CLAUDE_MODEL_ALIASES,
+  expandClaudeAlias,
+  expandModelAlias,
+  buildModelMenu as buildModelMenuForAliases,
+} from "../gateway/model-command.js";
+
+const OPUS_48 = "claude-opus-4-8";
+
+describe("CLAUDE_MODEL_ALIASES — short spellings for a pinned Claude id", () => {
+  it("both requested spellings expand to the canonical id", () => {
+    expect(expandModelAlias("opus48")).toBe(OPUS_48);
+    expect(expandModelAlias("opus-4-8")).toBe(OPUS_48);
+    expect(expandClaudeAlias("opus48")).toBe(OPUS_48);
+    expect(expandClaudeAlias("opus-4-8")).toBe(OPUS_48);
+  });
+
+  it("expansion is case-insensitive", () => {
+    for (const spelling of ["OPUS48", "Opus48", "OPUS-4-8", "Opus-4-8"]) {
+      expect(expandModelAlias(spelling)).toBe(OPUS_48);
+    }
+  });
+
+  it("leaves every other token alone (sr aliases still expand, ids pass through)", () => {
+    expect(expandModelAlias("opus")).toBe("opus");
+    expect(expandModelAlias("default")).toBe("default");
+    expect(expandModelAlias("flash")).toBe("sr-gemini-2.5-flash");
+    expect(expandModelAlias("sr-glm-5")).toBe("sr-glm-5");
+    expect(expandModelAlias(OPUS_48)).toBe(OPUS_48);
+    // The Claude map must not swallow an sr-* shortcut, nor vice versa.
+    expect(expandClaudeAlias("flash")).toBe("flash");
+    expect(expandSrAlias("opus48")).toBe("opus48");
+  });
+
+  it("every target is a full claude-* id and a legal model arg", () => {
+    for (const target of Object.values(CLAUDE_MODEL_ALIASES)) {
+      expect(target.startsWith("claude-")).toBe(true);
+      expect(isValidModelArg(target)).toBe(true);
+    }
+  });
+
+  it("typed `/model opus48` relaunches on the canonical id, not the shortcut", async () => {
+    const { deps, relaunchCalls } = makeDeps();
+    const reply = await handleModelCommand({ kind: "set", model: "opus48" }, deps);
+    expect(relaunchCalls).toEqual([
+      { model: OPUS_48, reason: `user: /model ${OPUS_48} (session-only relaunch)` },
+    ]);
+    expect(reply.text).toContain(OPUS_48);
+    // The raw shortcut must never reach the carrier / `claude --model`.
+    expect(relaunchCalls[0].model).not.toBe("opus48");
+  });
+
+  it("typed `/model opus-4-8` relaunches on the canonical id", async () => {
+    const { deps, relaunchCalls } = makeDeps();
+    await handleModelCommand({ kind: "set", model: "opus-4-8" }, deps);
+    expect(relaunchCalls).toEqual([
+      { model: OPUS_48, reason: `user: /model ${OPUS_48} (session-only relaunch)` },
+    ]);
+  });
+
+  it("typed `/model OPUS48` (mixed case) relaunches on the canonical id", async () => {
+    const { deps, relaunchCalls } = makeDeps();
+    await handleModelCommand({ kind: "set", model: "OPUS48" }, deps);
+    expect(relaunchCalls).toEqual([expect.objectContaining({ model: OPUS_48 })]);
+  });
+
+  it("a mid-turn `/model opus48` QUEUES the expanded id (start.sh never sees the shortcut)", () => {
+    const busy = { currentTurnActive: true, turnInFlight: false, menuEnabled: true };
+    expect(planModelCommand({ kind: "set", model: "opus48" }, busy)).toEqual({
+      kind: "queue",
+      target: OPUS_48,
+    });
+    expect(planModelCommand({ kind: "set", model: "opus-4-8" }, busy)).toEqual({
+      kind: "queue",
+      target: OPUS_48,
+    });
+  });
+
+  it("a queued shortcut survives a boot: both the KEY and the TARGET are offline-trusted", () => {
+    expect(isOfflineTrustedModelToken("opus48")).toBe(true);
+    expect(isOfflineTrustedModelToken("opus-4-8")).toBe(true);
+    expect(isOfflineTrustedModelToken("OPUS48")).toBe(true);
+    expect(isOfflineTrustedModelToken(OPUS_48)).toBe(true);
+    // Still refuses an arbitrary hand-typed pinned id.
+    expect(isOfflineTrustedModelToken("claude-opus-4-9")).toBe(false);
+  });
+
+  it("the parser accepts both spellings as a set", () => {
+    expect(parseModelCommand("/model opus48")).toEqual({ kind: "set", model: "opus48" });
+    expect(parseModelCommand("/model opus-4-8")).toEqual({ kind: "set", model: "opus-4-8" });
+  });
+
+  it("NEGATIVE: the shortcuts are Claude, never external / sr-*", () => {
+    for (const token of ["opus48", "opus-4-8", "OPUS48", OPUS_48]) {
+      expect(isSrModel(token)).toBe(false);
+      expect(isClaudeModel(token)).toBe(true);
+    }
+    // Not in the external map, in either direction.
+    for (const key of Object.keys(CLAUDE_MODEL_ALIASES)) {
+      expect(key in SR_MODEL_ALIASES).toBe(false);
+      expect(Object.values(SR_MODEL_ALIASES)).not.toContain(key);
+    }
+    for (const target of Object.values(CLAUDE_MODEL_ALIASES)) {
+      expect(Object.values(SR_MODEL_ALIASES)).not.toContain(target);
+      expect(SR_MODEL_LABELS[target]).toBeUndefined();
+    }
+    // And never rendered on the 🌐 External keyboard page.
+    const external = externalModelNames(["sr-gpt-oss-20b"]);
+    for (const token of [...Object.keys(CLAUDE_MODEL_ALIASES), ...Object.values(CLAUDE_MODEL_ALIASES)]) {
+      expect(external).not.toContain(token);
+    }
+  });
+
+  it("NEGATIVE: expansion happens before classification — no external ack copy", async () => {
+    const { deps } = makeDeps();
+    const reply = await handleModelCommand({ kind: "set", model: "opus48" }, deps);
+    expect(reply.text).not.toContain("sr-");
+    expect(reply.text).not.toContain("billed separately");
+  });
+
+  it("selectable: the pinned id is a main-page keyboard button", async () => {
+    const { deps } = makeMenuDeps();
+    const menu = await buildModelMenuForAliases(deps);
+    const buttons = (menu.keyboard ?? []).flat();
+    expect(buttons.some((b) => b.callback_data === `${MODEL_CALLBACK_ALIAS}${OPUS_48}`)).toBe(true);
+    expect(buttons.some((b) => b.text === "Opus 4.8")).toBe(true);
+  });
+
+  it("selectable mid-turn too: the static quick list carries the same button", async () => {
+    const { deps } = makeMenuDeps({ isBusy: () => true });
+    const menu = await buildModelMenuForAliases(deps);
+    const buttons = (menu.keyboard ?? []).flat();
+    expect(buttons.some((b) => b.callback_data === `${MODEL_CALLBACK_ALIAS}${OPUS_48}`)).toBe(true);
+  });
+
+  it("tapping the button relaunches on the canonical id", async () => {
+    const { deps, relaunchCalls } = makeMenuDeps();
+    await handleModelMenuCallback(`${MODEL_CALLBACK_ALIAS}${OPUS_48}`, deps);
+    expect(relaunchCalls).toEqual([expect.objectContaining({ model: OPUS_48 })]);
+  });
+
+  it("a shortcut arriving on a callback is expanded, not rejected as unrecognized", async () => {
+    const { deps, relaunchCalls } = makeMenuDeps();
+    await handleModelMenuCallback(`${MODEL_CALLBACK_ALIAS}opus48`, deps);
+    expect(relaunchCalls).toEqual([expect.objectContaining({ model: OPUS_48 })]);
+  });
+
+  it("discoverable: help and the dashboard both name every spelling", async () => {
+    const { deps } = makeDeps();
+    const help = await handleModelCommand({ kind: "help" }, deps);
+    const show = await handleModelCommand({ kind: "show" }, deps);
+    for (const spelling of Object.keys(CLAUDE_MODEL_ALIASES)) {
+      expect(help.text).toContain(spelling);
+      expect(show.text).toContain(`/model ${spelling}`);
+    }
+    expect(help.text).toContain(OPUS_48);
+    expect(show.text).toContain(OPUS_48);
+  });
+
+  it("a curated target carries no 'can't be validated' caveat (it is offline-trusted)", async () => {
+    const { deps } = makeDeps();
+    const reply = await handleModelCommand({ kind: "set", model: "opus48" }, deps);
+    expect(reply.text).not.toContain("can't be validated before launch");
+    // An UNcurated pinned id still does.
+    const other = await handleModelCommand({ kind: "set", model: "claude-opus-4-9" }, deps);
+    expect(other.text).toContain("can't be validated before launch");
+  });
+});

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -50,6 +50,7 @@ function makeDeps(overrides: Partial<ModelCommandDeps> = {}) {
   const deps: ModelCommandDeps = {
     getAgentName: () => "klanker",
     getConfiguredModel: () => "claude-sonnet-5",
+    getConfiguredEffort: () => "low",
     escapeHtml: (s) =>
       s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;"),
     preBlock: (s) => `<pre>${s}</pre>`,
@@ -241,7 +242,7 @@ import {
   MODEL_CALLBACK_PAGE_EXTERNAL,
   SR_MODEL_LABELS,
   SR_MODEL_ALIASES,
-  EXTRA_CLAUDE_ALIASES,
+  EXTRA_CLAUDE_MENU_TOKENS,
   expandSrAlias,
   externalModelNames,
   type ModelMenuDeps,
@@ -496,14 +497,14 @@ describe("classifyDiscoveredOptions", () => {
   });
 });
 
-describe("externalModelNames / SR_MODEL_LABELS / EXTRA_CLAUDE_ALIASES", () => {
+describe("externalModelNames / SR_MODEL_LABELS / EXTRA_CLAUDE_MENU_TOKENS", () => {
   it("seeds from the curated alias targets and merges discovered sr-*", () => {
     const names = externalModelNames(["sr-gpt-oss-20b"]);
     expect(names).toContain("sr-gemini-2.5-flash");
     expect(names).toContain("sr-gpt-oss-20b");
   });
-  it("Fable is offered as an extra Claude alias", () => {
-    expect(EXTRA_CLAUDE_ALIASES.some((a) => a.alias === "fable")).toBe(true);
+  it("Fable is offered as an extra Claude menu token", () => {
+    expect(EXTRA_CLAUDE_MENU_TOKENS.some((t) => t.token === "fable")).toBe(true);
   });
   it("labels are display-only strings", () => {
     expect(SR_MODEL_LABELS["sr-glm-5"]).toBeTypeOf("string");
@@ -922,10 +923,13 @@ describe("unvalidatedIdCaveat — immediate fail-fast warn on free-text claude-*
 // separate map from SR_MODEL_ALIASES: these are Anthropic OAuth-passthrough
 // models and must NEVER be classified as external/OpenRouter routes.
 // ---------------------------------------------------------------------------
+import { readFileSync } from "node:fs";
 import {
   CLAUDE_MODEL_ALIASES,
+  canonicalModelToken,
   expandClaudeAlias,
   expandModelAlias,
+  thinkingEffortCaveat,
   buildModelMenu as buildModelMenuForAliases,
 } from "../gateway/model-command.js";
 
@@ -1009,9 +1013,16 @@ describe("CLAUDE_MODEL_ALIASES — short spellings for a pinned Claude id", () =
     expect(isOfflineTrustedModelToken("claude-opus-4-9")).toBe(false);
   });
 
-  it("the parser accepts both spellings as a set", () => {
-    expect(parseModelCommand("/model opus48")).toEqual({ kind: "set", model: "opus48" });
-    expect(parseModelCommand("/model opus-4-8")).toEqual({ kind: "set", model: "opus-4-8" });
+  it("parser → expansion round-trip: both spellings reach the canonical id", () => {
+    // The parser alone is not the contract (it tokenizes anything shape-legal —
+    // `opus_4_8` parses too and expands to nothing, see the near-miss issue).
+    // What must hold is the PIPELINE: parse, then the one expansion every
+    // `/model` path applies, lands on the canonical id.
+    for (const text of ["/model opus48", "/model opus-4-8", "/model OPUS48"]) {
+      const parsed = parseModelCommand(text);
+      expect(parsed?.kind).toBe("set");
+      expect(expandModelAlias((parsed as { model: string }).model)).toBe(OPUS_48);
+    }
   });
 
   it("NEGATIVE: the shortcuts are Claude, never external / sr-*", () => {
@@ -1035,10 +1046,18 @@ describe("CLAUDE_MODEL_ALIASES — short spellings for a pinned Claude id", () =
     }
   });
 
-  it("NEGATIVE: expansion happens before classification — no external ack copy", async () => {
+  it("the ACK names the canonical id and never echoes the raw shortcut back", async () => {
+    // Renamed from a "NEGATIVE: … no external ack copy" assertion that was
+    // vacuous: `sr-` / `billed separately` are equally absent from the
+    // pre-change ack, so it could not fail on the bug it claimed to guard.
+    // (The real external-classification constraint is pinned by the
+    // "NEGATIVE: the shortcuts are Claude, never external / sr-*" case above,
+    // which DOES fail without the expansion.) What is genuinely discriminating
+    // here is that the operator is told the id they actually got.
     const { deps } = makeDeps();
     const reply = await handleModelCommand({ kind: "set", model: "opus48" }, deps);
-    expect(reply.text).not.toContain("sr-");
+    expect(reply.text).toContain(OPUS_48);
+    expect(reply.text).not.toMatch(/\bopus48\b/);
     expect(reply.text).not.toContain("billed separately");
   });
 
@@ -1057,9 +1076,16 @@ describe("CLAUDE_MODEL_ALIASES — short spellings for a pinned Claude id", () =
     expect(buttons.some((b) => b.callback_data === `${MODEL_CALLBACK_ALIAS}${OPUS_48}`)).toBe(true);
   });
 
-  it("tapping the button relaunches on the canonical id", async () => {
+  it("end-to-end: the RENDERED 'Opus 4.8' button's own payload relaunches on the canonical id", async () => {
+    // Drive the payload the keyboard actually mints rather than a hand-typed
+    // `mdl:alias:claude-opus-4-8` — the latter is recognized on the pre-change
+    // code too, so it could not fail on the bug it guards. Rendering first ties
+    // the button's existence and its payload together in one assertion.
     const { deps, relaunchCalls } = makeMenuDeps();
-    await handleModelMenuCallback(`${MODEL_CALLBACK_ALIAS}${OPUS_48}`, deps);
+    const menu = await buildModelMenuForAliases(deps);
+    const button = (menu.keyboard ?? []).flat().find((b) => b.text === "Opus 4.8");
+    expect(button).toBeDefined();
+    await handleModelMenuCallback(button!.callback_data, deps);
     expect(relaunchCalls).toEqual([expect.objectContaining({ model: OPUS_48 })]);
   });
 
@@ -1081,12 +1107,218 @@ describe("CLAUDE_MODEL_ALIASES — short spellings for a pinned Claude id", () =
     expect(show.text).toContain(OPUS_48);
   });
 
-  it("a curated target carries no 'can't be validated' caveat (it is offline-trusted)", async () => {
-    const { deps } = makeDeps();
-    const reply = await handleModelCommand({ kind: "set", model: "opus48" }, deps);
-    expect(reply.text).not.toContain("can't be validated before launch");
-    // An UNcurated pinned id still does.
-    const other = await handleModelCommand({ kind: "set", model: "claude-opus-4-9" }, deps);
+  it("the exemption itself: a curated TARGET carries no 'can't be validated' caveat", async () => {
+    // The riskiest line in the change is the
+    // `Object.values(CLAUDE_MODEL_ALIASES).includes(lower)` early return in
+    // `unvalidatedIdCaveat`. Driving `/model opus48` does NOT exercise it: on
+    // the pre-change code `opus48` doesn't start with `claude-`, so the caveat
+    // is null for an unrelated reason. Test the full canonical id directly.
+    const deps = { escapeHtml: (s: string) => s, getConfiguredEffort: () => "low" };
+    for (const target of Object.values(CLAUDE_MODEL_ALIASES)) {
+      expect(unvalidatedIdCaveat(deps, target)).toBeNull();
+    }
+    // …and via the ack, on the full-id spelling as well as the shortcut.
+    const { deps: cmdDeps } = makeDeps();
+    for (const spelling of ["opus48", "opus-4-8", OPUS_48]) {
+      const reply = await handleModelCommand({ kind: "set", model: spelling }, cmdDeps);
+      expect(reply.text).not.toContain("can't be validated before launch");
+    }
+    // An UNcurated pinned id still warns — the exemption is not a blanket
+    // silencing of the caveat.
+    const other = await handleModelCommand({ kind: "set", model: "claude-opus-4-9" }, cmdDeps);
     expect(other.text).toContain("can't be validated before launch");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MAJOR-1: expansion and the caveat exemption must agree on ONE canonical form.
+//
+// Pre-fix, `expandModelAlias` emitted its argument VERBATIM on a map miss (no
+// lowercase, no trim) while `unvalidatedIdCaveat` lowercased before comparing.
+// So `/model CLAUDE-OPUS-4-8` (phone autocapitalize) was launched as the
+// uncanonical token `CLAUDE-OPUS-4-8` — an id claude cannot resolve, hence a
+// silent `--fallback-model` serve — under a clean green ack, because the
+// exemption matched the lowercased form. Both halves are asserted here.
+// ---------------------------------------------------------------------------
+describe("canonicalization — one form reaches `claude --model` and the caveat gate", () => {
+  it("canonicalModelToken lowercases claude-* ids, trims everything, touches nothing else", () => {
+    expect(canonicalModelToken("CLAUDE-OPUS-4-8")).toBe(OPUS_48);
+    expect(canonicalModelToken("Claude-Opus-4-8")).toBe(OPUS_48);
+    expect(canonicalModelToken(`  ${OPUS_48}  `)).toBe(OPUS_48);
+    expect(canonicalModelToken("Claude-Opus-4-9")).toBe("claude-opus-4-9");
+    // Non-claude tokens keep their case — sr-* ids are not ours to rewrite.
+    expect(canonicalModelToken("sr-GLM-5")).toBe("sr-GLM-5");
+    expect(canonicalModelToken(" sr-glm-5 ")).toBe("sr-glm-5");
+    expect(canonicalModelToken("opus")).toBe("opus");
+  });
+
+  it("expandModelAlias emits the canonical form on a MISS, not the raw argument", () => {
+    expect(expandModelAlias("CLAUDE-OPUS-4-8")).toBe(OPUS_48);
+    expect(expandModelAlias("Claude-Opus-4-8")).toBe(OPUS_48);
+    expect(expandModelAlias("Claude-Opus-4-9")).toBe("claude-opus-4-9");
+    // …and trims, matching what `unvalidatedIdCaveat` has always done.
+    expect(expandModelAlias(" opus48 ")).toBe(OPUS_48);
+    expect(expandModelAlias(` ${OPUS_48} `)).toBe(OPUS_48);
+  });
+
+  it("a mixed-case pinned id is LAUNCHED canonical, not verbatim", async () => {
+    for (const spelling of ["CLAUDE-OPUS-4-8", "Claude-Opus-4-8"]) {
+      const { deps, relaunchCalls } = makeDeps();
+      const reply = await handleModelCommand({ kind: "set", model: spelling }, deps);
+      expect(relaunchCalls).toEqual([
+        { model: OPUS_48, reason: `user: /model ${OPUS_48} (session-only relaunch)` },
+      ]);
+      // The uncanonical token must not survive anywhere the operator can see
+      // it either — the ack names what actually boots.
+      expect(reply.text).not.toContain(spelling);
+      expect(reply.text).toContain(OPUS_48);
+    }
+  });
+
+  it("an UNCURATED mixed-case pinned id is canonicalized AND still warned about", async () => {
+    const { deps, relaunchCalls } = makeDeps();
+    const reply = await handleModelCommand({ kind: "set", model: "CLAUDE-OPUS-4-9" }, deps);
+    expect(relaunchCalls[0].model).toBe("claude-opus-4-9");
+    expect(reply.text).toContain("can't be validated before launch");
+  });
+
+  it("the caveat exemption agrees with expansion across the whole casing matrix", () => {
+    const deps = { escapeHtml: (s: string) => s, getConfiguredEffort: () => "low" };
+    for (const spelling of [
+      OPUS_48,
+      "CLAUDE-OPUS-4-8",
+      "Claude-Opus-4-8",
+      `  ${OPUS_48}  `,
+      " CLAUDE-OPUS-4-8 ",
+    ]) {
+      // Exempt (curated target) …
+      expect(unvalidatedIdCaveat(deps, spelling)).toBeNull();
+      // … and that is only sound because expansion emits the SAME form.
+      expect(expandModelAlias(spelling)).toBe(OPUS_48);
+    }
+    for (const spelling of ["claude-opus-4-9", "CLAUDE-OPUS-4-9", "Claude-Sonnet-9"]) {
+      expect(unvalidatedIdCaveat(deps, spelling)).not.toBeNull();
+    }
+  });
+
+  it("the callback shape gate still runs on the RAW payload (trim must not widen it)", async () => {
+    const { deps, relaunchCalls } = makeMenuDeps();
+    // `expandModelAlias` trims; the shape gate exists to guarantee a single
+    // whitespace-free token reaches the tmux pane, so a padded payload must
+    // still be refused rather than trimmed into legality.
+    const out = await handleModelMenuCallback(`${MODEL_CALLBACK_ALIAS} ${OPUS_48} `, deps);
+    expect(out.answer).toBe("Invalid model name");
+    expect(relaunchCalls).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MAJOR-2: the #1978 adaptive-thinking risk must surface at SWITCH time.
+//
+// `assessThinkingEffortRisk` had exactly one consumer — `switchroom doctor`,
+// which reads the CONFIGURED `model:` out of switchroom.yaml. A `/model` switch
+// is session-scoped, so every route onto a pinned Opus 4.x id (typed, shortcut,
+// or the one-tap "Opus 4.8" button this change adds) reached the exact
+// (pinned Opus 4.x, effort > low) combination doctor exists to warn about with
+// no warning anywhere. These fail on BOTH the pre-change code and the
+// pre-fix PR head.
+// ---------------------------------------------------------------------------
+const MERGE_400_MARKER = "issue #1978";
+
+describe("thinking_effort × pinned Opus 4.x — surfaced when the switch is made", () => {
+  it("typed switch onto a pinned Opus 4.x at medium effort warns in the ack", async () => {
+    const { deps } = makeDeps({ getConfiguredEffort: () => "medium" });
+    const reply = await handleModelCommand({ kind: "set", model: OPUS_48 }, deps);
+    expect(reply.text).toContain(MERGE_400_MARKER);
+    expect(reply.text).toContain("medium");
+  });
+
+  it("the SHORTCUT spelling warns too — the risk follows the expanded target", async () => {
+    const { deps } = makeDeps({ getConfiguredEffort: () => "high" });
+    const reply = await handleModelCommand({ kind: "set", model: "opus48" }, deps);
+    expect(reply.text).toContain(MERGE_400_MARKER);
+  });
+
+  it("the one-tap 'Opus 4.8' BUTTON warns too — the easiest route into the combo", async () => {
+    const { deps } = makeMenuDeps({ getConfiguredEffort: () => "medium" });
+    const menu = await buildModelMenuForAliases(deps);
+    const button = (menu.keyboard ?? []).flat().find((b) => b.text === "Opus 4.8");
+    const out = await handleModelMenuCallback(button!.callback_data, deps);
+    expect(out.reply.text).toContain(MERGE_400_MARKER);
+  });
+
+  it("NEGATIVE: safe combos stay quiet — low effort, Opus 5, the bare alias, sonnet", async () => {
+    const atLow = makeDeps({ getConfiguredEffort: () => "low" });
+    expect(
+      (await handleModelCommand({ kind: "set", model: OPUS_48 }, atLow.deps)).text,
+    ).not.toContain(MERGE_400_MARKER);
+
+    const atMedium = makeDeps({ getConfiguredEffort: () => "medium" });
+    for (const safe of ["opus", "claude-opus-5-20260601", "sonnet", "sr-glm-5"]) {
+      const reply = await handleModelCommand({ kind: "set", model: safe }, atMedium.deps);
+      expect(reply.text).not.toContain(MERGE_400_MARKER);
+    }
+  });
+
+  it("NEGATIVE: an unreadable effort never blocks or fails the switch", async () => {
+    const { deps, relaunchCalls } = makeDeps({
+      getConfiguredEffort: () => { throw new Error("agent list unavailable"); },
+    });
+    const reply = await handleModelCommand({ kind: "set", model: OPUS_48 }, deps);
+    expect(relaunchCalls).toEqual([expect.objectContaining({ model: OPUS_48 })]);
+    expect(reply.text).not.toContain(MERGE_400_MARKER);
+
+    const unset = makeDeps({ getConfiguredEffort: () => null });
+    expect(
+      (await handleModelCommand({ kind: "set", model: OPUS_48 }, unset.deps)).text,
+    ).not.toContain(MERGE_400_MARKER);
+  });
+
+  it("thinkingEffortCaveat is advisory only — it never rewrites the effort", () => {
+    const escapeHtml = (s: string) => s;
+    expect(thinkingEffortCaveat({ escapeHtml, getConfiguredEffort: () => "max" }, OPUS_48))
+      .toContain(MERGE_400_MARKER);
+    expect(thinkingEffortCaveat({ escapeHtml, getConfiguredEffort: () => "low" }, OPUS_48))
+      .toBeNull();
+    expect(thinkingEffortCaveat({ escapeHtml, getConfiguredEffort: () => "max" }, "opus"))
+      .toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The queued-across-restart persist path (gateway.ts). `persistQueuedCommandForRestart`
+// is module-local in a ~25k-line file that cannot be imported into a unit test,
+// so this is a source ratchet in the style of
+// `tests/scaffold.session-model.test.ts`: it pins the ONE line that decides
+// which token survives a restart. Pre-change that call used `expandSrAlias`, so
+// a queued `/model opus48` was persisted as the raw shortcut and start.sh
+// launched a token claude cannot resolve.
+// ---------------------------------------------------------------------------
+describe("gateway persist path uses the shared expansion, not the sr-only one", () => {
+  const gatewaySrc = readFileSync(
+    new URL("../gateway/gateway.ts", import.meta.url),
+    "utf-8",
+  );
+
+  it("the `.session-model` carrier write expands through expandModelAlias", () => {
+    expect(gatewaySrc).toContain(
+      "writeSessionModelFile(agentDir, expandModelAlias(action.arg), configured)",
+    );
+    expect(gatewaySrc).not.toContain("writeSessionModelFile(agentDir, expandSrAlias(");
+    // …and the symbol is actually imported, so the above is live code.
+    expect(gatewaySrc).toMatch(/^\s*expandModelAlias,$/m);
+  });
+
+  it("the MODEL deps wire the configured effort for the switch-time guard", () => {
+    // Anchored on the model deps' own `getConfiguredModel` reader — the effort
+    // reader already existed on the EFFORT deps (`buildEffortDeps`), so a bare
+    // substring match would pass without the model side being wired at all.
+    const lines = gatewaySrc.split("\n");
+    const anchor = lines.findIndex((l) =>
+      l.includes("return data?.agents?.find(a => a.name === getMyAgentName())?.model ?? null"),
+    );
+    expect(anchor).toBeGreaterThan(-1);
+    const window = lines.slice(anchor, anchor + 15).join("\n");
+    expect(window).toContain("getConfiguredEffort: () => getConfiguredEffortForPersist(),");
   });
 });


### PR DESCRIPTION
Summary
`/model opus48` and `/model opus-4-8` now both resolve to `claude-opus-4-8`,
and the pinned id is tappable from the model picker (both the live keyboard
and the mid-turn quick list) instead of only typeable.

Why
Typing `claude-opus-4-8` on a phone is hostile, and the id was reachable only
as free text. `isClaudeModel()` already accepted any `claude-*` string, so the
full id worked; this adds the short spellings.

The shortcuts live in a NEW `CLAUDE_MODEL_ALIASES` map, deliberately NOT in
`SR_MODEL_ALIASES`. That map means "external / OpenRouter / the Anthropic OAuth
header is not forwarded"; `claude-opus-4-8` is an OAuth-passthrough model, so
misfiling it there would flip the header-forwarding and external-billing
classification and surface it on the "External models" keyboard page. It is
also not added to `MODEL_ALIASES`, whose members double as FAMILY tokens in
`modelFamilyToken` / `canonicalClaudeToken` / `servedModelMatchesRequested`.

`expandModelAlias()` (Claude shortcuts then sr-* shortcuts, then
`canonicalModelToken`) is now the single expansion every `/model` argument goes
through, applied BEFORE any Claude-vs-external classification, so the
`.session-model` carrier and `claude --model` only ever see the canonical id —
start.sh never learns the shortcut. Both the alias KEYS and their TARGETS are
offline-trusted, so a queued `/model opus48` survives a boot exactly like
`/model opus`.

Review fixes (rev 2, commits f27d50d9 + 3e383342)
Three MAJOR findings, all fixed in-branch:

- **Canonicalization split.** `expandClaudeAlias` emitted its argument VERBATIM
  on a map miss (no lowercase, no trim) while `unvalidatedIdCaveat` lowercased
  and trimmed before checking the exemption. So `/model CLAUDE-OPUS-4-8` (phone
  autocapitalize) launched the uncanonical token — an id `claude` cannot
  resolve, hence a silent `--fallback-model` serve — under a clean green ack.
  Fixed by canonicalizing what expansion EMITS (`canonicalModelToken`: trim
  always, lowercase `claude-*` only), so one form flows to `claude --model` and
  the caveat gate judges exactly that form. The menu callback now runs the
  `MODEL_ARG_RE` shape gate on the RAW payload before expanding, so the new
  trim cannot widen it.
- **#1978 adaptive-thinking risk at switch time.** `assessThinkingEffortRisk`
  had exactly one consumer, `switchroom doctor`, which reads the CONFIGURED
  `model:` from switchroom.yaml — invisible to a session-scoped `/model`
  switch. Tapping the new "Opus 4.8" button on an agent at `thinking_effort`
  above `low` landed the exact (pinned Opus 4.x, effort > low) combination
  doctor exists to warn about, silently. `thinkingEffortCaveat()` is a second
  consumer on the path that creates the combination; its `.reason` is appended
  to both the typed ack and the menu-tap banner. Advisory only — no effort is
  changed. Fed by a new required `ModelCommandDeps.getConfiguredEffort`, wired
  to the same reader the `.session-effort` persist uses.
- **Weak tests.** 4 of the 18 tests originally added here passed on pristine
  source, including the only one nominally guarding the
  `Object.values(CLAUDE_MODEL_ALIASES).includes(lower)` exemption — it drove
  `/model opus48`, which on pristine does not start with `claude-`, so the
  caveat was null for an unrelated reason. All four rewritten to be
  discriminating, the exemption is now tested directly across the whole casing
  matrix, and the `gateway.ts` carrier-persist swap (previously untested) has a
  source ratchet.

Also corrected: `docs/model-routing.md` (the `isClaudeModel` description became
false with this change, and its line ref was stale), and
`EXTRA_CLAUDE_ALIASES` -> `EXTRA_CLAUDE_MENU_TOKENS` (the new member is a full
pinned id, not an alias "the CLI resolves natively").

Deferred, filed not fixed: #4003 (near-miss spellings `opus_4_8` / `opus4.8`
fail silently), #4004 (hermes-adapter is a second `/model <token>` entry
point), #4005 (`modelFamilyToken` collapses `claude-opus-4-8` to `opus`, so a
silently-reverted pinned switch renders a green "default" card — pre-existing,
and the `unvalidatedIdCaveat` doc now states that the first-reply tripwire is
the only remaining signal rather than implying two).

Test plan
- telegram-plugin/tests/model-command.test.ts: **+30** tests net of the
  rewrites (the first revision added 18, not the 14 this description previously
  claimed). Proven discriminating by reverting the two source files and
  re-running:
  - vs `origin/main` (6f432a94): **30 failed | 96 passed** (126 total)
  - vs the pre-review-fix head (82d83f5b): **11 failed | 115 passed**
  - with the fix: **126 passed**
  Two negative guards and the callback shape-gate guard pass on both baselines
  by design — they pin properties the fix must not break, not bugs it fixes.
- Scoped: model-command, bot-commands-model-effort, effort-command,
  scaffold.session-model, thinking-effort-risk, doctor-claude-cli — 256 passed.
- Full telegram-plugin vitest: 8724 passed, 1 pre-existing env failure
  (approval-hold-record "not writable" fallback — the container runs as uid 0,
  so the mode-0500 dir is writable and the fallback never triggers; fails
  identically with the diff stashed).
- npm run lint: clean. gateway.ts grew by 3 lines (24913 -> 24916) for the deps
  wiring, still inside the ratchet ceiling (24867 + 50 = 24917), and the
  bot-api allowlist is unaffected.

Risk
Low and confined to the `/model` surface. `isClaudeModel()` widens to accept
the shortcut keys so no consumer can misread one as an external route; the
first-reply served-model divergence tripwire still covers a bogus id, and the
switch-time effort warning closes the one path that had lost its pre-launch
signal.

Job spec: reference/jobs/restart-and-know-what-im-running.md (hold-the-leash —
the operator picks the model from the phone and the boot confirmation reports
what actually launched).

Switchroom-Agent: klanker
Switchroom-Model: opus
Co-authored-by: Claude Opus 5 <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)
