### PR TITLE
fix(gateway): loud out-of-credits — derive IPC operator-event allowlist from canonical taxonomy

### DIFF
--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -25,6 +25,7 @@ import type {
   ToolCallResult,
 } from "./ipc-protocol.js";
 import { RICH_MESSAGE_MAX_CHARS } from "../format.js";
+import { OPERATOR_EVENT_KINDS } from "../operator-events.js";
 
 export interface IpcServerOptions {
   socketPath: string;
@@ -196,21 +197,23 @@ type SocketData = { clientId: string; buffer: string };
  *  data without newline delimiters, which would cause unbounded memory growth. */
 const MAX_BUFFER_SIZE = 1024 * 1024;
 
-/** Allowlist of OperatorEventKind values that can arrive over IPC. Mirrors
- *  the union in `telegram-plugin/operator-events.ts` — kept as a literal Set
- *  here so the validator has zero cross-package type dependencies. If the
- *  taxonomy grows, update both places. */
-const VALID_OPERATOR_KINDS = new Set([
-  "credentials-expired",
-  "credentials-invalid",
-  "credit-exhausted",
-  "quota-exhausted",
-  "rate-limited",
-  "agent-crashed",
-  "agent-restarted-unexpectedly",
-  "unknown-4xx",
-  "unknown-5xx",
-]);
+/** Allowlist of OperatorEventKind values that can arrive over IPC. DERIVED
+ *  from the canonical `OPERATOR_EVENT_KINDS` array in
+ *  `telegram-plugin/operator-events.ts` — the single source of truth for the
+ *  taxonomy — so the validator can NEVER drift out of sync with it again.
+ *
+ *  History: this used to be a hand-maintained literal Set that missed the
+ *  `provider-credit-exhausted` / `mcp-dependency-blocked` / `proxy-misconfig`
+ *  kinds after they were added to the union. The bridge forwarded a
+ *  `provider-credit-exhausted` operator_event; this validator rejected it as an
+ *  "invalid IPC message shape" and dropped it, so an OpenRouter/LiteLLM 402
+ *  credit wall produced NO loud Telegram card (the 2026-07-30 incident).
+ *  Deriving from the canonical array closes that drift class structurally.
+ *
+ *  `operator-events.ts` is a pure module (its only imports are the pure
+ *  `format` / `raw-error-scrub` / `model-unavailable` / `provider-credit`
+ *  leaves), so importing it here introduces no cycle back into the gateway. */
+const VALID_OPERATOR_KINDS = new Set<string>(OPERATOR_EVENT_KINDS);
 
 /** Same regex as `assertSafeAgentName` and the op:* callback handler in
  *  gateway.ts — keeps every entry-point that touches an agent name on the

--- a/telegram-plugin/operator-events.ts
+++ b/telegram-plugin/operator-events.ts
@@ -23,11 +23,32 @@ import {
 
 // ─── Taxonomy ────────────────────────────────────────────────────────────────
 
-export type OperatorEventKind =
-  | 'credentials-expired'
-  | 'credentials-invalid'
-  | 'proxy-misconfig'
-  | 'credit-exhausted'
+/**
+ * The CANONICAL runtime list of every operator-event kind — the SINGLE source
+ * of truth for the taxonomy. The `OperatorEventKind` type is derived from it
+ * (below), and every other place that needs the set at RUNTIME (notably the
+ * gateway IPC validator's `VALID_OPERATOR_KINDS` in `gateway/ipc-server.ts`)
+ * imports THIS array rather than re-declaring a hand-maintained literal.
+ *
+ * WHY THIS IS AN ARRAY, NOT JUST A TYPE (the drift this closes)
+ * ------------------------------------------------------------
+ * A TypeScript union erases at compile time, so a runtime allowlist could only
+ * mirror it by hand — and it drifted: `ipc-server.ts` shipped a 9-entry Set
+ * that never gained `provider-credit-exhausted` / `mcp-dependency-blocked` /
+ * `proxy-misconfig` when those kinds were added here. The bridge forwarded a
+ * `provider-credit-exhausted` operator_event; the gateway validator rejected it
+ * as an "invalid IPC message shape" and DROPPED it — so a real OpenRouter/
+ * LiteLLM 402 credit wall produced NO loud Telegram card at all (the 2026-07-30
+ * incident). Deriving both the type and the runtime allowlist from this one
+ * array makes that class of silent drop structurally impossible.
+ *
+ * Order is not significant. Adding a kind is a one-line edit HERE.
+ */
+export const OPERATOR_EVENT_KINDS = [
+  'credentials-expired',
+  'credentials-invalid',
+  'proxy-misconfig',
+  'credit-exhausted',
   /**
    * A THIRD-PARTY model provider (OpenRouter / OpenAI / Perplexity) reports no
    * credit remaining — HTTP 402 `payment_required`, "insufficient credits",
@@ -37,7 +58,7 @@ export type OperatorEventKind =
    * must not share a card. Operator-actionable (top up in the vendor console),
    * never user-actionable — see {@link OPERATOR_ACTIONABLE_KINDS}.
    */
-  | 'provider-credit-exhausted'
+  'provider-credit-exhausted',
   /**
    * A paid MCP dependency (Perplexity, Eraser, Brevo, Postiz, Meta/Google Ads,
    * Cloudflare …) is refusing work because its KEY is the problem — out of
@@ -49,16 +70,19 @@ export type OperatorEventKind =
    * `mcp-credential-failure.ts`. Operator-actionable: only the operator can top
    * up or re-issue a key.
    */
-  | 'mcp-dependency-blocked'
-  | 'quota-exhausted'
-  | 'rate-limited'
-  | 'agent-crashed'
-  | 'agent-restarted-unexpectedly'
-  | 'unknown-4xx'
-  | 'unknown-5xx'
-  | 'config-warning'
-  | 'always-allow-persist-failed'
-  | 'mental-model-persist-failed'
+  'mcp-dependency-blocked',
+  'quota-exhausted',
+  'rate-limited',
+  'agent-crashed',
+  'agent-restarted-unexpectedly',
+  'unknown-4xx',
+  'unknown-5xx',
+  'config-warning',
+  'always-allow-persist-failed',
+  'mental-model-persist-failed',
+] as const
+
+export type OperatorEventKind = (typeof OPERATOR_EVENT_KINDS)[number]
 
 export interface OperatorEvent {
   kind: OperatorEventKind

--- a/telegram-plugin/tests/ipc-server-validate-operator.test.ts
+++ b/telegram-plugin/tests/ipc-server-validate-operator.test.ts
@@ -13,18 +13,13 @@
 
 import { describe, it, expect } from 'vitest'
 import { validateClientMessage } from '../gateway/ipc-server.js'
+import { OPERATOR_EVENT_KINDS } from '../operator-events.js'
 
-const VALID_KINDS = [
-  'credentials-expired',
-  'credentials-invalid',
-  'credit-exhausted',
-  'quota-exhausted',
-  'rate-limited',
-  'agent-crashed',
-  'agent-restarted-unexpectedly',
-  'unknown-4xx',
-  'unknown-5xx',
-]
+// Drift-proof: iterate the CANONICAL taxonomy the validator now derives its
+// allowlist from, not a hand-copied literal. A kind added to
+// OPERATOR_EVENT_KINDS is automatically covered here; a validator that fails
+// to accept any canonical kind fails this test.
+const VALID_KINDS = OPERATOR_EVENT_KINDS
 
 function base() {
   return {
@@ -40,6 +35,20 @@ describe('validateClientMessage — operator_event', () => {
   it('accepts every taxonomy kind', () => {
     for (const kind of VALID_KINDS) {
       expect(validateClientMessage({ ...base(), kind })).toBe(true)
+    }
+  })
+
+  // Regression for the 2026-07-30 silent-out-of-credits incident: these three
+  // kinds were added to the OperatorEventKind union but NOT to the gateway IPC
+  // validator's hand-maintained allowlist. The bridge forwarded a
+  // `provider-credit-exhausted` operator_event; the validator rejected it as an
+  // "invalid IPC message shape" and dropped it, so an OpenRouter/LiteLLM 402
+  // credit wall produced NO loud Telegram card. Named explicitly (not just via
+  // the canonical-list loop above) so the failure message points straight at
+  // the incident if the allowlist ever regresses to a hand-maintained literal.
+  it('accepts the operator-actionable kinds forwarded by the bridge over IPC', () => {
+    for (const kind of ['provider-credit-exhausted', 'mcp-dependency-blocked', 'proxy-misconfig']) {
+      expect(validateClientMessage({ ...base(), kind }), kind).toBe(true)
     }
   })
 


### PR DESCRIPTION
## What & why

During the 2026-07-30 incident, an OpenRouter/LiteLLM `402 Insufficient credits` wall killed a turn **silently** — no Telegram card, no user-visible message. Ken's standing rule: any provider/model credit exhaustion must fail **loudly and model-independently** to Telegram.

The classification + surfacing for this already landed (#3868 / #3880: `provider-credit.ts`, the `provider-credit-exhausted` kind, `OPERATOR_ACTIONABLE_KINDS`). The bug is one layer lower and is pure **kind-drift**:

- `telegram-plugin/gateway/ipc-server.ts` gated incoming `operator_event` IPC messages against a **hand-maintained** `VALID_OPERATOR_KINDS` literal Set.
- That Set was never updated when `provider-credit-exhausted`, `mcp-dependency-blocked`, and `proxy-misconfig` were added to the `OperatorEventKind` union.
- The agent-side bridge classifies the 402 as `provider-credit-exhausted` and forwards it, but `validateClientMessage` rejected it as an *"invalid IPC message shape"* and **dropped it** → the loud credit card never rendered → silence.

The stale comment on the Set even said *"If the taxonomy grows, update both places"* — and it wasn't.

## Fix (deterministic, drift-proof)

Promote the taxonomy to a single canonical runtime array `OPERATOR_EVENT_KINDS` in `operator-events.ts`, and derive **both** the `OperatorEventKind` type **and** the gateway's `VALID_OPERATOR_KINDS` from it. The IPC validator can no longer drift from the union — adding a kind is a one-line edit in one place and is automatically accepted over IPC. `operator-events.ts` is a pure module, so importing it into `ipc-server.ts` introduces no cycle.

All 15 union members are preserved byte-for-byte (verified).

## In user terms

An out-of-credits (or any provider billing/quota) wall now reliably reaches Telegram as the loud operator-actionable card instead of dying silently — and it can't silently regress the next time a new failure kind is added.

## Test — fails pre-fix

`tests/ipc-server-validate-operator.test.ts`:
- The "accepts every taxonomy kind" loop now iterates the **canonical** `OPERATOR_EVENT_KINDS` (was a hand-copied 9-entry literal that re-encoded the very drift).
- New explicit regression asserts `provider-credit-exhausted` / `mcp-dependency-blocked` / `proxy-misconfig` validate.

Proven pristine-fail against the pre-fix stale Set:
```
FAIL > accepts the operator-actionable kinds forwarded by the bridge over IPC
AssertionError: provider-credit-exhausted: expected false to be true
```
Green after the fix. Scoped suites (operator-events x3, ipc-validator, quota-wall, boot-card-silent, this file) = 175 tests pass; `tsc --noEmit` clean; full `npm run lint` clean.

## Note on the second requested fix (progress-card model)

The dispatch also asked for a "card shows the actually-served model, not the requested/started one" fix. I could **not** reproduce that on `origin/main`: the main-session progress card sources its model **exclusively** from served-truth (`turn.currentModel` = the transcript's `message.model`), seeded `undefined` per fresh turn (`stream-render.ts` turn literal), rendered at `narrative-lane.ts:132`, and updated only by the session-tail `model` event (`stream-render.ts:819`). There is no path that seeds it from a requested/config/prior value. Reported as a contradiction to the dispatcher rather than shipping a speculative change; happy to act on a specific reproducing surface if one is identified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)