### PR TITLE
fix(telegram): keep section headings when stripping excess bold + log when it fires

### DIFF
--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -761,6 +761,35 @@ function isFullyBolded(fragment: string): boolean {
   return /^\*\*[^*]+\*\*[.,:;!?]?$/.test(fragment.trim())
 }
 
+/**
+ * Max length (markers included) of a standalone fully-bolded line that is
+ * treated as a legitimate pseudo-heading (`**Section**`) rather than an
+ * over-bolded paragraph. Single source of truth for BOTH the per-block rule
+ * and the global-ratio heading exemption.
+ */
+const PSEUDO_HEADING_MAX_CHARS = 48
+
+/**
+ * True when a blank-line-delimited block is a single-line pseudo-heading: one
+ * non-empty line that is a single fully-bolded span of ≤PSEUDO_HEADING_MAX_CHARS
+ * characters (`**Summary**`, `**Next steps:**`). Multi-line blocks are never
+ * headings, so this can never mislabel a bolded paragraph as exempt.
+ */
+function isPseudoHeadingBlock(block: string): boolean {
+  const lines = block.split('\n').filter((l) => l.trim() !== '')
+  if (lines.length !== 1) return false
+  const t = lines[0].trim()
+  return t.length <= PSEUDO_HEADING_MAX_CHARS && isFullyBolded(t)
+}
+
+/** Diagnostic emitted when the over-bold tripwire actually removes bold. */
+export interface ExcessBoldStripDiagnostic {
+  /** Which rule fired: the whole-message ratio, or per-block flattening. */
+  rule: 'global' | 'per-block'
+  /** Measured bold ratio: bold chars / visible (non-code) chars. */
+  ratio: number
+}
+
 /** Strip `**bold**` markers from a fragment, keeping the text. */
 function unbold(fragment: string): string {
   return fragment.replace(/\*\*([^*]+)\*\*/g, '$1')
@@ -778,16 +807,24 @@ function unbold(fragment: string): string {
  * Deliberately conservative:
  *   - Messages under 100 non-code characters are exempt (a short reply whose
  *     one key fact is bolded is exactly the house style).
- *   - A single-line fully-bolded paragraph of ≤48 chars is treated as a
- *     pseudo-heading (the "**Section**" label the fleet style encourages) and
- *     is NOT stripped by the per-block rule (it still counts toward the
- *     global ratio).
+ *   - A single-line fully-bolded paragraph of ≤PSEUDO_HEADING_MAX_CHARS chars
+ *     is treated as a pseudo-heading (the "**Section**" label the fleet style
+ *     encourages) and is NOT stripped — neither by the per-block rule NOR by
+ *     the global-ratio rule (it still counts toward the global ratio, so a
+ *     genuinely over-bolded message still trips, but its section headings
+ *     survive instead of the whole reply going plain).
  *   - A list with any non-fully-bolded item is left alone.
  *
  * Code spans/fences are masked (maskCodeRegions) and never counted or
  * modified. Idempotent: stripped output has no `**` spans left to trip on.
+ *
+ * `onStrip` is an optional diagnostic sink invoked exactly once, only when
+ * bold is actually removed, carrying which rule fired and the measured ratio.
  */
-export function stripExcessBold(text: string): string {
+export function stripExcessBold(
+  text: string,
+  onStrip?: (d: ExcessBoldStripDiagnostic) => void,
+): string {
   if (!text.includes('**')) return text
 
   const nonce = Math.random().toString(36).slice(2)
@@ -800,14 +837,24 @@ export function stripExcessBold(text: string): string {
 
   let boldChars = 0
   for (const m of visible.matchAll(/\*\*([^*]+)\*\*/g)) boldChars += m[1].length
+  const ratio = boldChars / visible.length
 
-  if (boldChars / visible.length > 0.3) {
-    // Clearly over-bolded — strip every bold span, keep the text.
-    return restore(unbold(masked))
+  // Blank-line-delimited blocks of the masked text (shared by both rules).
+  const blocks = masked.split(/\n{2,}/)
+
+  if (ratio > 0.3) {
+    // Clearly over-bolded — strip every bold span, keeping the text, EXCEPT
+    // standalone short pseudo-heading blocks (`**Section**`), which stay bold
+    // so a bold-dense digest keeps its section headings.
+    const rebuilt = blocks.map((block) =>
+      isPseudoHeadingBlock(block) ? block : unbold(block),
+    )
+    const out = rejoinBlocks(masked, rebuilt)
+    if (out !== masked) onStrip?.({ rule: 'global', ratio })
+    return restore(out)
   }
 
-  // Per-block check on blank-line-delimited blocks of the masked text.
-  const blocks = masked.split(/\n{2,}/)
+  // Per-block check on the same blocks.
   const rebuilt = blocks.map((block) => {
     const lines = block.split('\n').filter((l) => l.trim() !== '')
     if (lines.length === 0 || !block.includes('**')) return block
@@ -824,17 +871,25 @@ export function stripExcessBold(text: string): string {
     const isProseBlock = lines.every((l) => !isMarkerLine(l, placeholder))
     if (!isProseBlock) return block
     if (!lines.every((l) => isFullyBolded(l))) return block
-    if (lines.length === 1 && lines[0].trim().length <= 48) return block
+    if (isPseudoHeadingBlock(block)) return block
     return unbold(block)
   })
 
-  // Rejoin with the original gap shapes: split() lost them, so re-split the
-  // masked text capturing the separators and interleave.
+  const out = rejoinBlocks(masked, rebuilt)
+  if (out !== masked) onStrip?.({ rule: 'per-block', ratio })
+  return restore(out)
+}
+
+/**
+ * Rejoin blocks produced by `masked.split(/\n{2,}/)` after per-block mapping,
+ * restoring the ORIGINAL blank-gap shapes (split() drops the separators, so
+ * re-capture them from the masked source and interleave).
+ */
+function rejoinBlocks(masked: string, rebuilt: string[]): string {
   const seps = masked.match(/\n{2,}/g) ?? []
   let out = rebuilt[0] ?? ''
   for (let i = 1; i < rebuilt.length; i++) out += (seps[i - 1] ?? '\n\n') + rebuilt[i]
-
-  return restore(out)
+  return out
 }
 
 // ---------------------------------------------------------------------------

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -191,7 +191,18 @@ export function normalizeOutboundBody(
   if (!literalText) text = normalizeParagraphBreaks(text)
   text = redact(text, site)
   if (!literalText) {
-    let formatted = stripExcessBold(normalizePunctuation(text))
+    let formatted = stripExcessBold(normalizePunctuation(text), (d) => {
+      // Observability: the over-bold tripwire silently flattened formatting.
+      // Emit one diagnostic line naming the rule + measured ratio so a lost
+      // reply is traceable (it previously vanished with no signal).
+      try {
+        process.stderr.write(
+          `telegram gateway: strip-excess-bold: fired site=${site} rule=${d.rule} ratio=${d.ratio.toFixed(3)}\n`,
+        )
+      } catch {
+        // stderr write must never break the send path. Swallow.
+      }
+    })
     if (addSpacers) formatted = addParagraphSpacers(formatted)
     text = formatted
     // Temporal normalization (#3501): UTC/Zulu → local wall clock, then

--- a/telegram-plugin/tests/format-consistency.test.ts
+++ b/telegram-plugin/tests/format-consistency.test.ts
@@ -334,4 +334,97 @@ describe('stripExcessBold', () => {
     const once = stripExcessBold(input)
     expect(stripExcessBold(once)).toBe(once)
   })
+
+  // ── Heading exemption in the GLOBAL (>30%) rule ──────────────────────────
+  // A bold-dense digest tripped the global ratio and lost EVERY bold marker,
+  // including its section headings, with no signal. Short standalone
+  // pseudo-heading blocks must now survive the global strip.
+
+  const boldDenseBody =
+    '**alpha** **bravo** **charlie** **delta** **echo** **foxtrot** **golf** ' +
+    '**hotel** **india** **juliet** **kilo** **lima** plus a short plain tail here.'
+
+  test('global strip keeps a short standalone bold heading, strips the rest', () => {
+    const input = `**Section One**\n\n${boldDenseBody}`
+    const out = stripExcessBold(input)
+    // Heading survives.
+    expect(out).toContain('**Section One**')
+    // Non-heading inline bold is flattened.
+    expect(out).toContain('alpha')
+    expect(out).not.toContain('**alpha**')
+    expect(out).not.toContain('**golf**')
+  })
+
+  test('global strip preserves EVERY heading in a multi-section digest', () => {
+    const input =
+      `**Overview**\n\n${boldDenseBody}\n\n` +
+      `**Next steps:**\n\n**one** **two** **three** **four** **five** **six** ` +
+      'plus a plain closing clause long enough to matter here.'
+    const out = stripExcessBold(input)
+    expect(out).toContain('**Overview**')
+    expect(out).toContain('**Next steps:**')
+    expect(out).not.toContain('**one**')
+    expect(out).not.toContain('**six**')
+  })
+
+  test('regression: global strip with NO headings still fully strips', () => {
+    const input = `${boldDenseBody}`
+    const out = stripExcessBold(input)
+    expect(out).not.toContain('**')
+    expect(out).toContain('alpha')
+  })
+
+  test('regression: under-threshold message keeps all bold (incl. headings)', () => {
+    const input = `**Summary**\n\n${filler} The key fact is **42**.`
+    expect(stripExcessBold(input)).toBe(input)
+  })
+
+  test('48/49-char pseudo-heading boundary honoured under global strip', () => {
+    // Heading length is measured WITH the `**` markers. 44 inner chars → 48
+    // total (exempt); 45 inner chars → 49 total (stripped).
+    const heading48 = '**' + 'H'.repeat(44) + '**' // length 48
+    const heading49 = '**' + 'H'.repeat(45) + '**' // length 49
+    expect(heading48.length).toBe(48)
+    expect(heading49.length).toBe(49)
+
+    const out48 = stripExcessBold(`${heading48}\n\n${boldDenseBody}`)
+    expect(out48).toContain(heading48)
+
+    const out49 = stripExcessBold(`${heading49}\n\n${boldDenseBody}`)
+    expect(out49).not.toContain(heading49)
+    expect(out49).toContain('H'.repeat(45))
+  })
+
+  test('multi-line fully-bolded block is NOT mislabelled a heading (global)', () => {
+    // Two bolded lines in one block must be flattened, not exempted — the
+    // heading exemption is single-line only.
+    const input = `**First bold line here**\n**Second bold line here**\n\n${boldDenseBody}`
+    const out = stripExcessBold(input)
+    expect(out).not.toContain('**First bold line here**')
+    expect(out).toContain('First bold line here')
+  })
+
+  // ── Observability ────────────────────────────────────────────────────────
+  test('onStrip fires with rule=global + ratio when global rule strips', () => {
+    const calls: Array<{ rule: string; ratio: number }> = []
+    stripExcessBold(`**Section One**\n\n${boldDenseBody}`, (d) => calls.push(d))
+    expect(calls).toHaveLength(1)
+    expect(calls[0].rule).toBe('global')
+    expect(calls[0].ratio).toBeGreaterThan(0.3)
+  })
+
+  test('onStrip fires with rule=per-block when only a block is flattened', () => {
+    const calls: Array<{ rule: string; ratio: number }> = []
+    const input = `${filler}\n\n**This whole paragraph is bold.**\n**Every single line of it.**`
+    stripExcessBold(input, (d) => calls.push(d))
+    expect(calls).toHaveLength(1)
+    expect(calls[0].rule).toBe('per-block')
+    expect(calls[0].ratio).toBeLessThanOrEqual(0.3)
+  })
+
+  test('onStrip does NOT fire when nothing is stripped', () => {
+    const calls: Array<{ rule: string; ratio: number }> = []
+    stripExcessBold(`**Summary**\n\n${filler} The key fact is **42**.`, (d) => calls.push(d))
+    expect(calls).toHaveLength(0)
+  })
 })

--- a/telegram-plugin/tests/outbound-send-path.test.ts
+++ b/telegram-plugin/tests/outbound-send-path.test.ts
@@ -379,7 +379,7 @@ describe('outbound-send-path — temporal pass wiring (#3501)', () => {
   it('temporal runs AFTER punctuation/bold and BEFORE scrubVoice (structural pin)', () => {
     const src = readFileSync(new URL('../gateway/outbound-send-path.ts', import.meta.url), 'utf8')
     const start = src.indexOf('export function normalizeOutboundBody(')
-    const boldIdx = src.indexOf('stripExcessBold(normalizePunctuation(text))', start)
+    const boldIdx = src.indexOf('stripExcessBold(normalizePunctuation(text),', start)
     const temporalIdx = src.indexOf('normalizeTemporal(text, tz, nowMs)', start)
     const scrubIdx = src.indexOf('scrubVoice(text)', start)
     expect(boldIdx).toBeGreaterThan(start)

--- a/telegram-plugin/tests/turn-flush-safety.test.ts
+++ b/telegram-plugin/tests/turn-flush-safety.test.ts
@@ -294,7 +294,7 @@ describe('#2798 turn-flush punctuation/bold parity with reply', () => {
 
     const start = moduleSrc.indexOf('export function normalizeOutboundBody(')
     const redactIdx = moduleSrc.indexOf('redact(text, site)', start)
-    const normIdx = moduleSrc.indexOf('stripExcessBold(normalizePunctuation(text))', start)
+    const normIdx = moduleSrc.indexOf('stripExcessBold(normalizePunctuation(text),', start)
     const scrubIdx = moduleSrc.indexOf('scrubVoice(text)', start)
     expect(start).toBeGreaterThan(0)
     expect(redactIdx).toBeGreaterThan(start)
@@ -322,7 +322,7 @@ describe('#2798 turn-flush punctuation/bold parity with reply', () => {
     // Parity, structurally: after consolidation the reply and turn_flush sites
     // share ONE normalization implementation — the punctuation/bold wrapper
     // lives only inside normalizeOutboundBody, and both sites invoke it.
-    expect(replyModuleSrc).toContain('stripExcessBold(normalizePunctuation(text))')
+    expect(replyModuleSrc).toContain('stripExcessBold(normalizePunctuation(text),')
     expect(streamSrc).toContain('normalizeOutboundBody(')
     expect(streamSrc).toContain(`'turn_flush',`)
   })


### PR DESCRIPTION
## Summary

The outbound over-bold tripwire (`stripExcessBold` in `telegram-plugin/format.ts`, invoked from `gateway/outbound-send-path.ts`) silently flattened a structured reply. A bold-dense digest using ~15 short bold section headings tripped the **global >30% ratio rule**, which called `unbold()` on the *entire* message and stripped **every** bold marker, headings included, with no signal at all.

## Why

- **Root cause:** the global rule (`format.ts`) measured bold chars / visible non-code chars and, above 0.3, unbolded the whole message. Legitimate `**Section**` pseudo-headings were collateral. The per-block rule already exempted a single fully-bolded standalone line <=48 chars as a heading, but the global rule ignored that carve-out.
- **No observability:** when the tripwire fired, the flattened reply just went out plain. Nothing was logged, so the regression was invisible.

## Changes

1. **Heading exemption in the global rule.** Factored the existing heading definition into `isPseudoHeadingBlock` + `PSEUDO_HEADING_MAX_CHARS` (single source of truth, reused by the per-block rule). When the >0.3 ratio fires, standalone short pseudo-heading blocks keep their bold; everything else still flattens. The ratio maths and denominator (full visible/non-code text) are unchanged, so a genuinely over-bolded message still trips - it just keeps its section headings instead of going fully plain. Multi-line blocks are never treated as headings, so a bolded paragraph can't sneak through.

2. **Observability.** `stripExcessBold` now takes an optional `onStrip` diagnostic sink, invoked exactly once only when bold is actually removed, carrying the rule (`global` vs `per-block`) and the measured ratio. The call site emits one `telegram gateway: strip-excess-bold: ...` stderr line, matching the plugin's existing tagged-stderr logging convention. No message content is logged.

## Tests

Added to `telegram-plugin/tests/format-consistency.test.ts` (outcome assertions):
- bold-dense (>30%) message with a short <=48-char standalone bold heading: the heading's `**` survives, non-heading bold is stripped; multi-section digest keeps *every* heading.
- regression: no-heading >30% message still fully strips; under-threshold message keeps all bold.
- 48/49-char boundary (markers included) honoured.
- multi-line fully-bolded block is NOT mislabelled a heading.
- `onStrip` fires with the right rule/ratio for global and per-block, and does not fire when nothing is stripped.

Updated three structural source-pin tests (`outbound-send-path.test.ts`, `turn-flush-safety.test.ts`) whose pinned literal shifted with the new callback arg; their pipeline-ordering intent is preserved.

## Test plan

- `vitest run` on the four affected files: **209 passed**.
- `tsc --noEmit`: clean.
- Logic lint guards (bot-api-wrapping, no-pii-secrets, stale-tool-descriptions, gateway-line-ratchet, agent-attribution-trailers, etc.): pass. `check-plugin-references` fails only on missing `telegram-plugin/package.json` optional deps in the local symlinked node_modules (verified identical on clean `origin/main`) - an environment artifact CI resolves with a real install.

## Risk

Low. Behaviour change is narrow: over-bolded messages now retain standalone short bold headings instead of going fully plain, and a stripped message is now observable. Idempotency preserved.

Job spec: outbound Telegram formatting fidelity (`reference/telegram-formatting-guide.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)