### PR TITLE
fix(memory): pre-approve reversible Hindsight writes to stop card flood

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1231,6 +1231,20 @@ export const HINDSIGHT_MCP_TOOLS = [
   // Memories.
   "mcp__hindsight__get_memory",
   "mcp__hindsight__list_memories",
+  // Reversible memory writes — pre-approved. Both are SHIM-SYNTHESIZED
+  // (src/cli/hindsight-mcp-shim.ts) and REVERSIBLE, which is why they ride
+  // with the read/retain surface rather than behind a per-call card:
+  //   • invalidate_memory — soft-retire (is_active:false). It has a `restore`
+  //     path that reactivates the exact memory (shim SYNTHESIZED_TOOL_TABLE,
+  //     `restore` arg), so nothing is destroyed.
+  //   • update_memory — edits an existing memory's fields in place.
+  // The agent uses these autonomously for user corrections / "actually it's X"
+  // amendments (an automated-flow dependency, same shape as delete_document
+  // above), and every uncurated call otherwise raises a fresh Telegram
+  // permission card — a flood on high-frequency correction workloads. The
+  // PERMANENTLY-destructive memory tool, clear_memories, stays gated below.
+  "mcp__hindsight__invalidate_memory",
+  "mcp__hindsight__update_memory",
   // Documents.
   "mcp__hindsight__get_document",
   "mcp__hindsight__list_documents",

--- a/tests/hindsight-permission-surface.test.ts
+++ b/tests/hindsight-permission-surface.test.ts
@@ -47,6 +47,7 @@ describe("Hindsight pre-approved permission surface (Fix 1.2, #2903)", () => {
       "mcp__hindsight__get_memory",
       "mcp__hindsight__get_mental_model",
       "mcp__hindsight__get_operation",
+      "mcp__hindsight__invalidate_memory",
       "mcp__hindsight__list_banks",
       "mcp__hindsight__list_directives",
       "mcp__hindsight__list_documents",
@@ -60,6 +61,7 @@ describe("Hindsight pre-approved permission surface (Fix 1.2, #2903)", () => {
       "mcp__hindsight__retain",
       "mcp__hindsight__sync_retain",
       "mcp__hindsight__update_bank",
+      "mcp__hindsight__update_memory",
     ]);
   });
 
@@ -80,6 +82,16 @@ describe("Hindsight pre-approved permission surface (Fix 1.2, #2903)", () => {
     // delete_document STAYS pre-approved: MEMORY_GUIDANCE instructs the agent
     // to call it autonomously for corrections / "forget that" (automated flow).
     expect(HINDSIGHT_MCP_TOOLS).toContain("mcp__hindsight__delete_document");
+  });
+
+  it("pre-approves the REVERSIBLE memory writes but NOT the permanent memory wipe", () => {
+    // invalidate_memory (soft-retire with a `restore` path) and update_memory
+    // (in-place edit) are reversible, so they ride with the read/retain surface
+    // instead of raising a per-call Telegram card on every correction. The
+    // permanently-destructive clear_memories stays gated.
+    expect(HINDSIGHT_MCP_TOOLS).toContain("mcp__hindsight__invalidate_memory");
+    expect(HINDSIGHT_MCP_TOOLS).toContain("mcp__hindsight__update_memory");
+    expect(HINDSIGHT_MCP_TOOLS).not.toContain("mcp__hindsight__clear_memories");
   });
 
   it("NEVER pre-approves a mental-model write tool (they route through the propose card)", () => {


### PR DESCRIPTION
## Problem

Every call to `mcp__hindsight__invalidate_memory` or `mcp__hindsight__update_memory` raises a fresh Telegram permission card. On correction-heavy workloads this is a flood — e.g. 73 `invalidate_memory` calls produce 73 approval cards, each needing an operator tap.

## Root cause

The agent scaffold pre-approves a curated, deliberately-enumerated set of Hindsight MCP tools into every agent's `.claude/settings.json` `permissions.allow` (`HINDSIGHT_MCP_TOOLS` in `src/agents/scaffold.ts`). A wildcard is banned there on purpose so mental-model writes can't silently ride in ungated — which means each tool must be listed explicitly. Two **reversible** write tools were never added to that seed, so they fall through to a normal Claude Code permission prompt on every call.

Note this can't be fixed with a broad `all` grant: in Claude Code, `permissions.allow: all` does not cover `mcp__*` tools — each MCP tool must be named. The enumerated seed is the only mechanism.

## The fix

Add the two reversible tools to `HINDSIGHT_MCP_TOOLS`:

- `mcp__hindsight__invalidate_memory` — soft-retire (`is_active:false`) with a `restore` reactivation path (shim `SYNTHESIZED_TOOL_TABLE`, `src/cli/hindsight-mcp-shim.ts:169`). Nothing is destroyed.
- `mcp__hindsight__update_memory` — edits an existing memory's fields in place.

Both are used autonomously for user corrections / "actually it's X" amendments — the same automated-flow shape that already justifies pre-approving `delete_document`.

## Why destructive tools stay gated

This is scoped strictly to reversible writes. The permanently-destructive tools keep their per-call approval card and are asserted to stay gated by the test:

- `clear_memories` — wipes every memory in a bank
- `delete_bank` — destroys an entire bank
- `delete_directive` — removes a standing guardrail irrecoverably
- the mental-model write tools (`create`/`update`/`delete`/`refresh_mental_model`) — route through the agent-proposes / human-approves propose card

Both new tools are already present in the authoritative engine surface (`tests/fixtures/hindsight-tools-list.snapshot.json`), so no fixture change was needed.

## Test evidence

`tests/hindsight-permission-surface.test.ts`:
- added both tools to the exact enumerated allowed-set assertion
- new focused test asserting `invalidate_memory` + `update_memory` are pre-approved while `clear_memories` stays gated

```
npx vitest run tests/hindsight-permission-surface.test.ts
 ✓ tests/hindsight-permission-surface.test.ts (9 tests) 8ms
 Test Files  1 passed (1) | Tests  9 passed (9)

npx tsc --noEmit            # EXIT 0
node scripts/check-stale-tool-descriptions.mjs   # clean
node scripts/check-hindsight-write-redaction.mjs # OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)