### PR TITLE
fix(telegram): align formatting guidance with the single GFM render path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## Unreleased — Telegram formatting guidance realigned to the single GFM render path
+
+Ships in v0.19.37. A focused cleanup that makes the agent-facing formatting
+docs match what the runtime actually does, and closes three small correctness
+gaps in the deterministic send-time normalizers.
+
+### Reply-tool `format` docs described deleted engines
+
+Since the Bot API 10.1 migration (#2669) there is exactly ONE render path —
+raw GFM markdown. But the `reply` / `edit_message` `format` param still claimed
+`'html'` "converts markdown to Telegram HTML" and `'markdownv2'` gave
+"MarkdownV2 with auto-escaping". Both are false: nothing converts to HTML,
+nothing auto-escapes, and the gateway routes everything non-`'text'` through the
+same rich path. The descriptions now tell the truth — default renders rich GFM
+markdown, `'text'` sends verbatim, and `'html'`/`'markdownv2'` are accepted
+legacy aliases onto the one rich path. The enum values are unchanged, so
+existing callers keep working. `ask_user`'s "Plain text or HTML" question hint
+was corrected the same way.
+
+### Dash normalization no longer rewrites quoted text
+
+`normalizePunctuation` rewrote ` — ` to `, ` everywhere, including inside `>`
+blockquotes, which are reserved for VERBATIM quoted text — silently corrupting
+an author's quotation. Blockquote lines (including the `**>` expandable-quote
+opener) are now exempt from the dash rewrite; code spans and link hrefs stay
+masked as before.
+
+### Footnote repair widened beyond digits
+
+The send-time footnote guard only matched `[^1]` (digits), so `[^note]` /
+`[^ref]` shipped as literal bracket noise. It now matches short alphanumeric
+ids (`\[\^[A-Za-z0-9]{1,10}\]`), keeping regex-literal negated char classes
+like `[^/]` / `[^a-z]` intact (they contain punctuation). Tradeoff: a
+pure-alphanumeric negated class in BARE prose (`array[^index]`) is now treated
+as a footnote — rare, since real regex/index literals live in masked code spans.
+
+### Guidance fixes (docs)
+
+- The house "make it scannable" example taught `• ` bullets, which the runtime
+  rewrites to `- ` at send time; the example now uses canonical `- `.
+- The floor card and depth reference now note the expandable-blockquote `**>`
+  opener must be at line start (column 0) — never indented — or it won't parse.
+
 ## v0.19.36 — credit exhaustion fails loudly, an honest model-switch card, memory redaction at intake, and Telegram keeps its headings
 
 Provider credit exhaustion can no longer die in silence, the boot-time

--- a/reference/telegram-formatting-guide.md
+++ b/reference/telegram-formatting-guide.md
@@ -51,7 +51,8 @@ You're writing for a phone screen in Telegram. Every reply renders as rich Markd
   fenced code blocks ALWAYS with a language
   hint (```diff, ```json, ```bash — bare fence only for non-code fixed-width output);
   and the flagship — the **expandable blockquote** `**> first line` + `> continuation`
-  for a long quote, stack trace, or detailed aside the reader can collapse. Use it
+  for a long quote, stack trace, or detailed aside the reader can collapse. The `**>`
+  opener must be at the line start (column 0) — never indented — or it won't parse. Use it
   whenever a bulky supporting block would otherwise dominate the message.
 
 Renders wrong on this path — never emit: underline (`__x__` renders as bold),
@@ -127,7 +128,8 @@ Bot API 10.1 rich messages.
   - Do **not** reach for a leading `· ` as a pseudo-indent: Telegram promotes it to a
     real list bullet, which is a block-structure line.
 - **Pull-quote / expandable blockquote** — `**> …`** (Bot API 10.1 expandable
-  blockquote). A long quote the reader can collapse/expand.
+  blockquote). A long quote the reader can collapse/expand. The `**>` opener must be at
+  the line start (column 0) — never indented — or it won't parse.
 - **Section heading** — `#` … `######`. Only in a genuinely long, multi-section answer.
 - **Preformatted block** — a code fence with no language, for fixed-width non-code
   (ASCII tables, aligned columns).

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -258,8 +258,8 @@ into your system prompt every session; this is the conversational summary.
   Kicking off a worker to crawl the changelog.
 
   **What it'll do**
-  • pull every entry since v0.14
-  • flag anything user-facing
+  - pull every entry since v0.14
+  - flag anything user-facing
 
   **Back in** ~2 min with a synthesized summary.
 - Use backtick-wrapped \`inline code\` for filenames, commands, and
@@ -534,7 +534,8 @@ You're writing for a phone screen in Telegram. Every reply renders as rich Markd
   fenced code blocks ALWAYS with a language
   hint (\`\`\`diff, \`\`\`json, \`\`\`bash — bare fence only for non-code fixed-width output);
   and the flagship — the **expandable blockquote** \`**> first line\` + \`> continuation\`
-  for a long quote, stack trace, or detailed aside the reader can collapse. Use it
+  for a long quote, stack trace, or detailed aside the reader can collapse. The \`**>\`
+  opener must be at the line start (column 0) — never indented — or it won't parse. Use it
   whenever a bulky supporting block would otherwise dominate the message.
 
 Renders wrong on this path — never emit: underline (\`__x__\` renders as bold),

--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -94,7 +94,7 @@ const TOOL_SCHEMAS = [
       // client and this detail was being silently truncated away.
       'FORUM TOPICS: a reply is auto-routed back to the topic the question came from, so do NOT pass message_thread_id on a normal reply — pass the inbound\'s origin_turn_id instead, so the answer lands in the right topic even if a message from another topic arrived while you were working. message_thread_id is only for deliberately posting into a topic that is not the one you were asked in. ' +
       // Format modes: likewise moved out of the truncated instructions string.
-      'FORMAT: the default format is "html" — write natural markdown and it is auto-converted to Telegram HTML (bold, italic, code, links, code blocks). Pass format: "markdownv2" for MarkdownV2 with auto-escaping, or "text" for plain text sent verbatim.',
+      'FORMAT: by default your text is rendered as rich GFM markdown (Bot API 10.1) — write natural markdown (bold, italic, code, links, code blocks, lists, tables) and it renders as-is. Pass format: "text" to send plain text verbatim with no rendering. "html" and "markdownv2" are accepted legacy aliases that route through the exact same single rich GFM path — there is no separate HTML engine and no auto-escaping.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -105,7 +105,7 @@ const TOOL_SCHEMAS = [
         message_thread_id: { type: 'string', description: 'Forum topic thread ID. Auto-applied from the last inbound message in the same chat if not specified.' },
         origin_turn_id: { type: 'string', description: 'In a forum supergroup, pass back the origin_turn_id attribute from the <channel> message you are answering. It pins the reply to that message\'s topic even if another topic\'s turn started meanwhile. Omit in DMs / single-topic chats.' },
         files: { type: 'array', items: { type: 'string' }, description: 'Absolute file paths to attach. Images send as photos; other types as documents. Max 50MB each. Telegram rejects photos with extreme dimensions (aspect ratio over ~10:1, width+height over 10000px, or over 10MB) — very tall images like full-page screenshots are auto-rerouted as documents; crop or split them first if the user should see them inline as photos.' },
-        format: { type: 'string', enum: ['html', 'markdownv2', 'text'], description: "Rendering mode. 'html' (default) converts markdown to Telegram HTML." },
+        format: { type: 'string', enum: ['html', 'markdownv2', 'text'], description: "Rendering mode. Default renders your text as rich GFM markdown (Bot API 10.1). 'text' sends plain text verbatim. 'html' and 'markdownv2' are legacy aliases that route through the same single rich GFM path — no separate HTML engine, no auto-escaping." },
         disable_web_page_preview: { type: 'boolean', description: 'Disable link preview thumbnails. Default: true.' },
         protect_content: { type: 'boolean', description: 'When true, Telegram prevents the message from being forwarded or saved.' },
         quote_text: { type: 'string', description: 'Surgical quote: specific text to highlight from the reply_to message. Requires reply_to.' },
@@ -180,7 +180,7 @@ const TOOL_SCHEMAS = [
         chat_id: { type: 'string' },
         message_id: { type: 'string' },
         text: { type: 'string' },
-        format: { type: 'string', enum: ['html', 'markdownv2', 'text'], description: "Rendering mode. 'html' (default) converts markdown to Telegram HTML." },
+        format: { type: 'string', enum: ['html', 'markdownv2', 'text'], description: "Rendering mode. Default renders your text as rich GFM markdown (Bot API 10.1). 'text' sends plain text verbatim. 'html' and 'markdownv2' are legacy aliases that route through the same single rich GFM path — no separate HTML engine, no auto-escaping." },
       },
       required: ['chat_id', 'message_id', 'text'],
     },
@@ -341,7 +341,7 @@ const TOOL_SCHEMAS = [
       type: 'object',
       properties: {
         chat_id: { type: 'string', description: 'Chat that should receive the question. Pass from inbound meta.' },
-        question: { type: 'string', description: 'The question text. Plain text or HTML. Keep it short — buttons render below.' },
+        question: { type: 'string', description: 'The question text. Plain text or GFM markdown (rendered through the same rich path as replies). Keep it short — buttons render below.' },
         options: {
           type: 'array',
           items: { type: 'string' },

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -718,21 +718,37 @@ export function normalizePunctuation(text: string): string {
   const restoreLinks = (s: string): string =>
     s.replace(linkRestoreRe, (_m, idx: string) => linkMasks[Number(idx)] ?? _m)
 
+  // The dash rewrite runs per line so blockquote lines can be exempted:
+  // `>` blockquotes are reserved for VERBATIM quoted text, and rewriting an
+  // author's ` — ` to `, ` inside a quotation would corrupt what they quoted.
+  // The expandable-blockquote opener `**>` is a blockquote line too even though
+  // isBlockquoteLine (which keys on a leading `>`) doesn't catch the `**`
+  // prefix, so exempt it explicitly. Code spans and link hrefs stay masked
+  // throughout, so their dashes are already protected on every line.
+  const rewriteDashes = (line: string): string =>
+    line
+      // 1. Space-flanked em/en dash. Numeric range keeps a hyphen. The right
+      //    flank is a LOOKAHEAD (captured, not consumed) so consecutive spaced
+      //    dashes ("a — b — c") all normalize in one pass — a consumed \S would
+      //    swallow the char that anchors the next match.
+      .replace(/(\S)[ \t][—–][ \t](?=(\S))/g, (_m, a: string, b: string) =>
+        /\d/.test(a) && /\d/.test(b) ? `${a}-` : `${a}, `,
+      )
+      // 2. Bare em-dash between word chars. Numeric range keeps a hyphen.
+      //    Right flank is a lookahead for the same consecutive-match reason.
+      .replace(/(\w)—(?=(\w))/g, (_m, a: string, b: string) =>
+        /\d/.test(a) && /\d/.test(b) ? `${a}-` : `${a}, `,
+      )
+      // 3. Bare en-dash between word chars → hyphen (ranges: 2019–2024).
+      .replace(/(\w)–(?=\w)/g, '$1-')
+
+  const isQuotedLine = (line: string): boolean =>
+    isBlockquoteLine(line) || line.trimStart().startsWith('**>')
+
   let out = maskedAutolinks
-    // 1. Space-flanked em/en dash. Numeric range keeps a hyphen. The right
-    //    flank is a LOOKAHEAD (captured, not consumed) so consecutive spaced
-    //    dashes ("a — b — c") all normalize in one pass — a consumed \S would
-    //    swallow the char that anchors the next match.
-    .replace(/(\S)[ \t][—–][ \t](?=(\S))/g, (_m, a: string, b: string) =>
-      /\d/.test(a) && /\d/.test(b) ? `${a}-` : `${a}, `,
-    )
-    // 2. Bare em-dash between word chars. Numeric range keeps a hyphen.
-    //    Right flank is a lookahead for the same consecutive-match reason.
-    .replace(/(\w)—(?=(\w))/g, (_m, a: string, b: string) =>
-      /\d/.test(a) && /\d/.test(b) ? `${a}-` : `${a}, `,
-    )
-    // 3. Bare en-dash between word chars → hyphen (ranges: 2019–2024).
-    .replace(/(\w)–(?=\w)/g, '$1-')
+    .split('\n')
+    .map((line) => (isQuotedLine(line) ? line : rewriteDashes(line)))
+    .join('\n')
 
   // Restore link hrefs now that the dash passes are done — before the bullet
   // pass and the code restore.

--- a/telegram-plugin/render/unsupported-token-guard.ts
+++ b/telegram-plugin/render/unsupported-token-guard.ts
@@ -59,12 +59,16 @@ import { splitProtectedSegments } from "./code-segments.js";
  *  `a^2+b^2=c^2`, `2^8`, and `x^n` all pass through untouched. */
 const CARET_PAIR = /\^([A-Za-z0-9]+)\^/g;
 
-/** Footnote reference marker `[^N]` (digits only) NOT immediately followed by
- *  `:` (which would make it a footnote DEFINITION line we leave intact). Removed
- *  entirely. Restricting the id to digits keeps this off in-prose bracket
- *  literals like `array[^index]` and regex-ish `[^/]`, which are NOT footnotes
- *  and would otherwise be silently eaten. */
-const FOOTNOTE_MARKER = /\[\^\d+\](?!:)/g;
+/** Footnote reference marker `[^id]` where the id is a short alphanumeric run
+ *  (`[^1]`, `[^note]`, `[^ref]`) NOT immediately followed by `:` (which would
+ *  make it a footnote DEFINITION line we leave intact). Removed entirely.
+ *  Requiring the id to be 1–10 ALPHANUMERIC chars keeps this off regex-ish
+ *  literals like `[^/]`, `[^\s]`, `[^-a-z]`, whose bodies contain punctuation
+ *  and so never match. In-prose subscript-ish `array[^i]` outside a code span
+ *  is a rare theoretical false positive (an `i` id matches); code spans are
+ *  masked upstream by splitProtectedSegments so real code is safe, and prose
+ *  that writes a literal `[^i]` reads as footnote noise anyway. */
+const FOOTNOTE_MARKER = /\[\^[A-Za-z0-9]{1,10}\](?!:)/g;
 
 /** `<details>…</details>` with an optional leading `<summary>…</summary>`.
  *  Dot-all via `[\s\S]`; non-greedy so adjacent blocks don't merge. */

--- a/telegram-plugin/tests/format-consistency.test.ts
+++ b/telegram-plugin/tests/format-consistency.test.ts
@@ -245,6 +245,24 @@ describe('normalizePunctuation', () => {
     expect(normalizePunctuation('<not—a—url>')).toBe('<not, a, url>')
   })
 
+  test('does NOT rewrite a dash inside a `>` blockquote (verbatim quote)', () => {
+    // `>` blockquotes hold quoted text the author is reproducing verbatim;
+    // rewriting their em-dash to `, ` corrupts the quotation.
+    expect(normalizePunctuation('> she said — plainly — no')).toBe(
+      '> she said — plainly — no',
+    )
+    // Indented blockquote line is still a blockquote.
+    expect(normalizePunctuation('  > quoted — text')).toBe('  > quoted — text')
+    // The expandable-blockquote opener `**>` is a blockquote line too.
+    expect(normalizePunctuation('**> first — line\n> continues — here')).toBe(
+      '**> first — line\n> continues — here',
+    )
+    // Prose OUTSIDE the quote still normalizes; only the quoted line is spared.
+    expect(normalizePunctuation('intro — here\n> quote — verbatim\nafter — end')).toBe(
+      'intro, here\n> quote — verbatim\nafter, end',
+    )
+  })
+
   test('idempotent', () => {
     const once = normalizePunctuation('a — b\n• c\nd—e\n1–2')
     expect(normalizePunctuation(once)).toBe(once)

--- a/telegram-plugin/tests/mcp-instructions-budget.test.ts
+++ b/telegram-plugin/tests/mcp-instructions-budget.test.ts
@@ -162,8 +162,15 @@ describe("moved instruction content landed in tool descriptions", () => {
 
   it("format modes landed in the reply description", () => {
     expect(bridgeCode).toContain("FORMAT:");
-    expect(bridgeCode).toMatch(/default format is "html"/);
+    // The description must describe the ONE real render path (rich GFM), and
+    // still name the legacy aliases so the enum values stay documented. It must
+    // NOT resurrect the deleted-engine claims (html→HTML conversion, MarkdownV2
+    // auto-escaping) — those are false at HEAD (single GFM path, no escaping).
+    expect(bridgeCode).toMatch(/rich GFM markdown/);
     expect(bridgeCode).toContain("markdownv2");
+    expect(bridgeCode).not.toMatch(/default format is "html"/);
+    expect(bridgeCode).not.toMatch(/auto-converted to Telegram HTML/);
+    expect(bridgeCode).not.toMatch(/MarkdownV2 with auto-escaping/);
   });
 
   it("history-buffer rationale landed in get_recent_messages", () => {

--- a/telegram-plugin/tests/render/unsupported-token-guard.test.ts
+++ b/telegram-plugin/tests/render/unsupported-token-guard.test.ts
@@ -71,15 +71,46 @@ describe("guardUnsupportedTokens — deterministic send-time repair", () => {
     expect(guardUnsupportedTokens("x^2^ metres")).toBe("x2 metres");
   });
 
-  it("leaves in-prose bracket literals intact, repairs real numeric footnotes", () => {
-    // `array[^index]` is a negated-char-class / index literal, not a footnote.
-    expect(guardUnsupportedTokens("array[^index] lookup")).toBe(
-      "array[^index] lookup",
+  it("repairs alphanumeric footnote markers, not just numeric", () => {
+    // POLISH-4: widened from digits-only so `[^note]`/`[^ref]` no longer ship
+    // as literal bracket noise. Each would survive UNTOUCHED on origin/main.
+    expect(guardUnsupportedTokens("see the note[^note] here")).toBe(
+      "see the note here",
     );
+    expect(guardUnsupportedTokens("as shown[^ref] above")).toBe(
+      "as shown above",
+    );
+    expect(guardUnsupportedTokens("point[^fn1] made")).toBe("point made");
+    // A single-letter id is a footnote too.
+    expect(guardUnsupportedTokens("claim[^a] holds")).toBe("claim holds");
+    // Definition lines with an alphanumeric id are still left intact (`(?!:)`).
+    expect(guardUnsupportedTokens("[^note]: the definition")).toBe(
+      "[^note]: the definition",
+    );
+  });
+
+  it("leaves regex-literal negated char classes intact", () => {
+    // Real negated char classes contain punctuation / ranges / escapes, so the
+    // alphanumeric-only id requirement excludes them — these stay verbatim.
     expect(guardUnsupportedTokens("use [^/] to match")).toBe(
       "use [^/] to match",
     );
-    // A real numeric footnote marker is still stripped.
+    expect(guardUnsupportedTokens("strip [^a-z] chars")).toBe(
+      "strip [^a-z] chars",
+    );
+    expect(guardUnsupportedTokens('match [^"] here')).toBe('match [^"] here');
+    // Accepted tradeoff (task POLISH-4): a PURE-alphanumeric negated class in
+    // BARE prose like `array[^index]` is now treated as a footnote and stripped.
+    // This is rare — regex/index literals in real prose live in code spans,
+    // which splitProtectedSegments masks (see code-span test below).
+    expect(guardUnsupportedTokens("array[^index] lookup")).toBe("array lookup");
+    // …but inside a code span the same literal is untouched.
+    expect(guardUnsupportedTokens("`array[^index]` lookup")).toBe(
+      "`array[^index]` lookup",
+    );
+  });
+
+  it("repairs a real numeric footnote marker", () => {
     expect(guardUnsupportedTokens("see the note[^1] here")).toBe(
       "see the note here",
     );


### PR DESCRIPTION
Since the Bot API 10.1 migration (#2669) there is exactly ONE outbound render path — raw GFM markdown (`telegram-plugin/format.ts:4-7`). This focused, low-risk PR realigns the agent-facing docs and a few send-time normalizers that still described (or behaved as if there were) the deleted HTML/MarkdownV2 engines, and closes three small correctness gaps. Docs + strings + three narrow runtime fixes; no enum changes, no refactors.

## What changed

**MUST-1 — reply-tool `format` docs described deleted engines** (`telegram-plugin/bridge/bridge.ts:97,108,183`)
The `format` param claimed `'html'` "converts markdown to Telegram HTML" and `'markdownv2'` gives "MarkdownV2 with auto-escaping". Both false at HEAD — nothing converts to HTML, nothing auto-escapes, and the gateway routes everything non-`'text'` through the one rich GFM path. Rewrote `reply` and `edit_message` descriptions to reality: default renders rich GFM markdown, `'text'` sends verbatim, `'html'`/`'markdownv2'` are accepted legacy aliases onto the same single path. **Enum values unchanged** (`html|markdownv2|text` stay valid) so existing callers don't break. Also corrected `ask_user`'s "Plain text or HTML" question hint (`bridge.ts:344`) — that text renders through the same `richMessage` path (`gateway.ts:12763`).
User-visible win: the model stops being told to reach for an HTML/escaping engine that doesn't exist, so it stops second-guessing plain markdown.

**POLISH-2 — house guide taught a rewritten bullet** (`src/agents/scaffold.ts:261-262`)
The "make it scannable" example used `• ` bullets, which `normalizePunctuation` (`format.ts:744`) rewrites to `- ` at send time. Changed the teaching example to canonical `- `. Edited the guidance example, not the floor-card constant.
Win: what the guide shows now matches what ships.

**POLISH-3 — dash normalization rewrote quoted text** (`telegram-plugin/format.ts` normalizePunctuation)
` — ` → `, ` was applied everywhere including inside `>` blockquotes, which are reserved for VERBATIM quoted text — silently corrupting an author's quotation. The dash pass now runs per line and exempts blockquote lines (via the existing `isBlockquoteLine` helper) plus the `**>` expandable-quote opener. Code-span and href masking is unchanged.
Win: quotations stay exactly as quoted.

**POLISH-4 — footnote repair was digits-only** (`telegram-plugin/render/unsupported-token-guard.ts:67`)
`FOOTNOTE_MARKER` matched only `[^1]`, so `[^note]`/`[^ref]` shipped as literal bracket noise. Widened to `\[\^[A-Za-z0-9]{1,10}\](?!:)`. Punctuation-bearing regex literals (`[^/]`, `[^a-z]`, `[^"]`) still stay intact. **Accepted tradeoff:** a pure-alphanumeric negated char class in BARE prose (`array[^index]`) is now treated as a footnote and stripped — rare, since real regex/index literals live in code spans, which `splitProtectedSegments` masks. Called out in a test comment and the CHANGELOG.
Win: alphanumeric footnote markers get cleaned instead of rendering as noise.

**POLISH-5 — expandable blockquote is column-0 only** (docs)
`render/parse.ts` parses `**>` only at column 0. Added a one-line note to both the floor card (`scaffold.ts:536`) and the depth reference (`reference/telegram-formatting-guide.md:53,130`) that the `**>` opener must be at line start, never indented. The two remain verbatim-synced.
Win: the model stops emitting indented `**>` that silently fails to parse.

## Deferred
- **NICE-6** (`PSEUDO_HEADING_MAX_CHARS = 48` flattening long bold labels) — filed as #4021. Deferred to keep this PR single-concern; it tunes the over-bold tripwire heuristic and wants its own test.

## Tests
Added assertions that pristine-FAIL on `origin/main` and pass here (verified by swapping in `origin/main` source and re-running — 3 failures on main, 0 here):
- `format-consistency.test.ts` — em-dash inside `>` / `**>` blockquotes stays verbatim; prose outside still normalizes.
- `unsupported-token-guard.test.ts` — `[^note]`/`[^ref]`/`[^fn1]`/`[^a]` repaired; regex literals intact; `array[^index]` tradeoff documented; code-span form untouched.

Scoped tests green (70 passed) and `npm run lint` clean.