### PR TITLE
fix(hindsight-watch): relay operator alerts through overlord first

### DIFF
--- a/src/cli/hindsight-watch.test.ts
+++ b/src/cli/hindsight-watch.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  PREFERRED_RELAY_AGENT,
+  collectRelayCandidates,
+  orderRelayCandidates,
+} from "./hindsight-watch.js";
+
+/**
+ * The relay picks the FIRST candidate whose gateway socket accepts the write
+ * (`postOperatorNoticeViaGateways` is first-success-wins over candidate
+ * order). These tests pin the candidate ORDER — the one lever that decides
+ * which agent's bot the operator sees the alert come from — so an alert is
+ * attributed to the root debugging agent while never regressing delivery when
+ * that agent's gateway is down.
+ */
+describe("orderRelayCandidates", () => {
+  it("puts the preferred agent first while keeping the rest in place", () => {
+    const candidates = ["carrie", "dana", "overlord", "zed"].map((agent) => ({
+      agent,
+      sock: `/sock/${agent}`,
+    }));
+    const ordered = orderRelayCandidates(candidates);
+    expect(ordered.map((c) => c.agent)).toEqual(["overlord", "carrie", "dana", "zed"]);
+  });
+
+  it("leaves the alphabetical list untouched when the preferred agent is absent", () => {
+    const candidates = ["carrie", "dana", "zed"].map((agent) => ({
+      agent,
+      sock: `/sock/${agent}`,
+    }));
+    const ordered = orderRelayCandidates(candidates);
+    expect(ordered.map((c) => c.agent)).toEqual(["carrie", "dana", "zed"]);
+  });
+
+  it("defaults its preferred agent to the root debugging agent", () => {
+    expect(PREFERRED_RELAY_AGENT).toBe("overlord");
+  });
+});
+
+describe("collectRelayCandidates (live gateway sockets)", () => {
+  let dir: string;
+
+  const seedGatewaySocket = (agent: string): void => {
+    const sockDir = join(dir, agent, "telegram");
+    mkdirSync(sockDir, { recursive: true });
+    // A plain file is enough: collectRelayCandidates only checks existsSync.
+    writeFileSync(join(sockDir, "gateway.sock"), "");
+  };
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "hw-relay-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("orders overlord first when its gateway socket is live", () => {
+    // Alphabetically, carrie sorts first — the pre-fix behaviour delivered
+    // through carrie. With overlord's socket live it must now lead.
+    for (const agent of ["carrie", "dana", "overlord", "zed"]) seedGatewaySocket(agent);
+
+    const ordered = collectRelayCandidates(dir);
+    expect(ordered.map((c) => c.agent)).toEqual(["overlord", "carrie", "dana", "zed"]);
+  });
+
+  it("falls back to a non-overlord agent when overlord's socket is absent", () => {
+    // overlord has no live gateway socket — delivery must still be attempted,
+    // via the alphabetically-first live agent.
+    for (const agent of ["carrie", "dana", "zed"]) seedGatewaySocket(agent);
+
+    const ordered = collectRelayCandidates(dir);
+    expect(ordered.map((c) => c.agent)).toEqual(["carrie", "dana", "zed"]);
+    expect(ordered[0]?.agent).not.toBe("overlord");
+  });
+
+  it("ignores an agent dir that has no live gateway socket", () => {
+    seedGatewaySocket("overlord");
+    // dana exists as a dir but never opened a gateway socket.
+    mkdirSync(join(dir, "dana", "telegram"), { recursive: true });
+
+    const ordered = collectRelayCandidates(dir);
+    expect(ordered.map((c) => c.agent)).toEqual(["overlord"]);
+  });
+});

--- a/src/cli/hindsight-watch.ts
+++ b/src/cli/hindsight-watch.ts
@@ -206,6 +206,57 @@ function runInstallCron(cronUser?: string): number {
 }
 
 /**
+ * The fleet's root/admin debugging agent. hindsight-watch is a host process
+ * with no chat of its own, so it relays its single operator DM through
+ * whichever live agent gateway socket answers first (see
+ * `postOperatorNoticeViaGateways`, which is first-success-wins over the
+ * candidate order). Left in raw alphabetical order the relay always came out
+ * of the alphabetically-first live gateway, so every watch alert appeared to
+ * be sent by an unrelated agent's bot. The operator wants these host-monitor
+ * alerts attributed to the root debugging agent instead.
+ *
+ * This is a COSMETIC delivery preference only: if this agent's gateway is
+ * down, delivery falls back to the remaining agents in alphabetical order
+ * (see `orderRelayCandidates`), so an alert is never dropped for attribution.
+ *
+ * A bare constant — rather than reading the full config cascade to discover
+ * which agent is admin/root — is deliberate: hindsight-watch is a zero-model
+ * host cron that must stay cheap and dependency-light, and walking config per
+ * tick to answer a purely cosmetic question isn't worth it.
+ */
+export const PREFERRED_RELAY_AGENT = "overlord";
+
+/**
+ * Reorder relay candidates so `preferred` is tried first when present,
+ * preserving the relative order (alphabetical, as built by the caller) of the
+ * rest as fallback. Pure; no IO. A candidate is only present here when its
+ * gateway socket is live, so a missing/down preferred agent simply leaves the
+ * alphabetical fallback list untouched.
+ */
+export function orderRelayCandidates(
+  candidates: GatewayCandidate[],
+  preferred: string = PREFERRED_RELAY_AGENT,
+): GatewayCandidate[] {
+  const first = candidates.filter((c) => c.agent === preferred);
+  const rest = candidates.filter((c) => c.agent !== preferred);
+  return [...first, ...rest];
+}
+
+/**
+ * Walk the agents dir, collect every agent whose Telegram gateway socket is
+ * live, and return them ordered with {@link PREFERRED_RELAY_AGENT} first. May
+ * throw if the dir is unreadable — callers wrap this in try/catch.
+ */
+export function collectRelayCandidates(agentsDir: string): GatewayCandidate[] {
+  const candidates: GatewayCandidate[] = [];
+  for (const name of readdirSync(agentsDir).sort()) {
+    const sock = resolve(agentsDir, name, "telegram", "gateway.sock");
+    if (existsSync(sock)) candidates.push({ agent: name, sock });
+  }
+  return orderRelayCandidates(candidates);
+}
+
+/**
  * Deliver one plain operator DM through the first agent gateway socket that
  * accepts it. Identical transport to hostd's degraded-boot notice; the
  * gateway fences delivery to its own operator chat, so this cannot address a
@@ -216,12 +267,9 @@ async function notifyOperator(
   text: string,
   log: (msg: string) => void,
 ): Promise<boolean> {
-  const candidates: GatewayCandidate[] = [];
+  let candidates: GatewayCandidate[] = [];
   try {
-    for (const name of readdirSync(agentsDir).sort()) {
-      const sock = resolve(agentsDir, name, "telegram", "gateway.sock");
-      if (existsSync(sock)) candidates.push({ agent: name, sock });
-    }
+    candidates = collectRelayCandidates(agentsDir);
   } catch (e) {
     log(`hindsight-watch: agents dir unreadable (${(e as Error).message})`);
   }


### PR DESCRIPTION
## Summary
`switchroom hindsight-watch` is a host process with no chat of its own. It relays its single operator DM through whichever live agent gateway socket answers first (`postOperatorNoticeViaGateways` is first-success-wins over the candidate order). Candidates were built in raw alphabetical order (`readdirSync(agentsDir).sort()`), so every watch alert came out of the alphabetically-first live gateway's bot — an unrelated agent — instead of the root/admin debugging agent.

This adds `PREFERRED_RELAY_AGENT` + a pure `orderRelayCandidates` helper so the root debugging agent (`overlord`) is tried first **when its gateway socket is live**, with all other agents preserved in alphabetical order as fallback. `postOperatorNoticeViaGateways` is untouched — the fix is candidate ordering only.

## Why
Cosmetic attribution: host-monitor alerts should visibly come from the root debugging agent, not from whoever happens to sort first alphabetically. Delivery must never regress for cosmetics, so if `overlord`'s gateway is down it simply isn't in the candidate list and the alphabetical fallback delivers the alert as before.

A bare well-named constant is used rather than walking the full config cascade to discover the admin/root agent: hindsight-watch is a zero-model host cron that must stay cheap and dependency-light, and loading config per tick to answer a purely cosmetic question isn't worth it. The rationale is documented at the constant.

## Test plan
`src/cli/hindsight-watch.test.ts` (new) drives the extracted pure helpers, including a real-socket path via a temp agents dir:
- `orderRelayCandidates` puts `overlord` first while keeping the rest in place.
- `collectRelayCandidates` orders `overlord` first when its gateway socket is live.
- Fallback: a non-`overlord` agent leads when `overlord`'s socket is absent (delivery does not regress).
- Agent dirs with no live socket are ignored.

Verified the two "overlord first" assertions **fail** under the pre-fix alphabetical-only behavior (temporarily neutralized the reorder → 2 failures), so the test guards the actual bug. Scoped `vitest` green; `npm run lint` clean; `tsc --noEmit` clean.

## Risk
Low. Pure reordering of an already-filtered candidate list; no transport, IO, or delivery-fallback semantics change. `postOperatorNoticeViaGateways` unchanged.

## Follow-up (out of scope)
`src/cli/openrouter-watch.ts` carries the byte-identical relay pattern and the same cosmetic attribution issue — filed separately to keep this PR single-concern.

Job spec: `reference/jobs/fleet-stays-healthy.md` (the fleet watches itself and puts the failure in front of the operator — now attributed to the root debugging agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)