### PR TITLE
fix(telegram): gate handback orphan reap on queue state, not a flat 30s timeout

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8909,10 +8909,14 @@ async function runMidSessionCardReaper(): Promise<void> {
       const { finalized, vanished, total } = await runActivityCardMidSessionReaper({
         path: ACTIVITY_CARD_STORE_PATH,
         fs: activityCardStoreFs,
-        // A synthetic pre-turn record's key is never a live topic key, so it is
-        // correctly seen as ownerless here (the seam's own age-based self-reap is
-        // the fast path; this is the crash / long-lived backstop).
-        isLive: (record) => topicKeys.has(record.turnKey),
+        // A synthetic pre-turn key reads as ownerless here (self-reap is the fast
+        // path; this is the crash backstop). EXCEPTION: a pre-turn handback still
+        // enqueued behind an in-flight turn is NOT an orphan — keep it live while
+        // claude is busy, else this 15-min backstop re-posts the false nudge the
+        // self-reap gate removed. (Boot reaper stays ungated: boot is never mid-turn.)
+        isLive: (record) =>
+          topicKeys.has(record.turnKey) ||
+          (handbackPreturnSignal.isPreTurnRecord(record.turnKey) && isMachineInTurn()),
         ttlMs: MID_SESSION_CARD_REAPER_TTL_MS,
         now,
         finalizeCard: (record) => {
@@ -13827,6 +13831,10 @@ const handbackPreturnSignal = createHandbackPreturnSignal({
     // dark-indicator bug). Flag-ON is already per-key; the check is a no-op there.
     return statusKey(live.sessionChatId, live.sessionThreadId) === key
   },
+  // Queue-state gate for the orphan reap (see the signal's `isClaudeBusy` doc):
+  // while a turn is in flight the handback is enqueued behind it, not orphaned.
+  // False for both `bridge_alive_idle` and `bridge_dead` → genuine orphan reaps.
+  isClaudeBusy: () => isMachineInTurn(),
 })
 
 /**

--- a/telegram-plugin/gateway/handback-preturn-signal.ts
+++ b/telegram-plugin/gateway/handback-preturn-signal.ts
@@ -54,9 +54,23 @@
  *     On adoption the durable record is re-keyed from its synthetic pre-turn key
  *     to the real `statusKey` so that teardown matches.
  *
- *   • NEVER-ADOPTED ORPHAN REAP. A degenerate case (bridge death after release,
- *     no enqueue ever arrives) would leave a frozen card + a forever `typing…`
- *     loop. The pre-turn card is persisted as a COMPLETE `ActivityCardRecord`
+ *   • NEVER-ADOPTED ORPHAN REAP — GATED ON A GLOBAL-BUSY QUEUE CHECK. A
+ *     degenerate case (bridge death after release, no enqueue ever arrives)
+ *     would leave a frozen card + a forever `typing…` loop. But the reap must
+ *     fire ONLY for that genuine orphan, never for a handback that is correctly
+ *     enqueued and simply waiting behind a long in-flight turn: claude has ONE
+ *     bridge / ONE input queue, so a released handback mints its adopting turn
+ *     only when claude next goes idle. A flat age-based reap cannot tell the two
+ *     apart and (before this gate) posted a false "never started — needs a
+ *     nudge" card every time a parent turn out-ran the timeout (the 3-cards-in-
+ *     4-min incident). The reap therefore consults `isClaudeBusy()` — the
+ *     machine-level "a turn is in flight right now" signal — and DEFERS
+ *     (re-arms for another `adoptTimeoutMs`) while claude is busy, finalizing
+ *     only once claude is idle AND the handback still has not been adopted. That
+ *     idle-with-no-adoption state is the genuine bridge-death / dropped-inbound
+ *     degenerate case. Lengthening the flat timeout would merely move the false
+ *     positive; the queue-state gate removes it. The pre-turn card is persisted
+ *     as a COMPLETE `ActivityCardRecord`
  *     under a SYNTHETIC `turnKey` (`preturn:<statusKey>:<startedAt>`) — synthetic
  *     so a sibling REAL turn on the same topic key can neither upsert-clobber it
  *     nor keep it "live" (the mid-session reaper's `isLive` keys on live topic
@@ -171,6 +185,22 @@ export interface HandbackPreturnSignalDeps {
    *  canonical turn-end owns the stop. Optional; defaults to "no live turn"
    *  (the pre-#3544 behaviour). */
   hasLiveTurn?: (statusKey: string) => boolean
+  /** True IFF claude is CURRENTLY producing a turn (ANY topic — the machine has
+   *  ONE bridge / ONE input queue). Consulted by the orphan reap: a released
+   *  handback is delivered into that single queue and only mints its adopting
+   *  turn when claude next goes idle, so while claude is busy the handback is
+   *  NOT orphaned — it is correctly enqueued BEHIND the in-flight turn (a long
+   *  parent turn can run many minutes). Finalizing it as an orphan in that
+   *  window posts a false "never started — needs a nudge" card. The reap
+   *  therefore DEFERS (re-arms) while this is true and finalizes only once
+   *  claude is idle and the handback still has not been adopted — the genuine
+   *  bridge-death / dropped-inbound degenerate case the reap exists for.
+   *  Distinct from `hasLiveTurn`, which is PER-KEY and only governs the
+   *  typing-loop stop; this is the GLOBAL busy signal because the handback
+   *  queues behind whatever turn is running, regardless of topic. Optional;
+   *  defaults to "not busy" (immediate reap — the pre-fix behaviour), so the
+   *  genuine-orphan path is unchanged. */
+  isClaudeBusy?: () => boolean
   now?: () => number
   /** Debounce before painting the pre-turn card (kills sub-second flicker). */
   debounceMs?: number
@@ -349,6 +379,25 @@ export function createHandbackPreturnSignal(
   function reap(entry: PreTurnEntry): void {
     entry.reapTimer = null
     if (entry.consumed) return
+    // PRIMARY GATE (queue state, not a flat timeout): a released handback is
+    // delivered into claude's SINGLE input queue and mints its adopting turn
+    // only when claude next goes idle. If claude is STILL in a turn, this
+    // handback is not orphaned — it is correctly enqueued behind the in-flight
+    // turn (a long parent turn can run many minutes). Finalizing now would post
+    // a false "never started — needs a nudge" card (the 3-cards-in-4-min
+    // incident). Defer: re-arm and re-check. We finalize only once claude is
+    // idle AND the handback still has not been adopted (the genuine bridge-
+    // death / dropped-inbound case). This cannot loop forever on a healthy
+    // agent: claude processes its queue FIFO, so the handback is either adopted
+    // (cancelling the reap) or claude eventually goes idle (letting it fire).
+    if (deps.isClaudeBusy?.() === true) {
+      log(
+        `handback-preturn-signal: reap deferred key=${entry.statusKey} ` +
+          `(claude busy — handback enqueued behind an in-flight turn, not orphaned)\n`,
+      )
+      entry.reapTimer = setTimer(() => reap(entry), adoptTimeoutMs)
+      return
+    }
     entry.consumed = true
     // Stop the forever-running typing loop and finalize the frozen card.
     stopTypingUnlessTurnLive(entry, 'orphan reap')

--- a/telegram-plugin/tests/handback-preturn-signal.test.ts
+++ b/telegram-plugin/tests/handback-preturn-signal.test.ts
@@ -300,6 +300,73 @@ describe('handback-preturn-signal — dead-air pre-turn emit→adopt→reap', ()
     expect(h.signal.pendingCount()).toBe(0) // map empty
   })
 
+  // ── queued-behind-a-long-turn is NOT an orphan (the 3-cards-in-4-min bug) ──
+  // A handback released while the parent is mid-turn on a long task is delivered
+  // into claude's single input queue and mints its adopting turn only when the
+  // parent turn ends. The flat 30 s reap could not tell "enqueued and waiting"
+  // from "bridge died, never enqueued" and finalized a false "handback never
+  // started — needs a nudge" card. With the queue-state gate (`isClaudeBusy`)
+  // the reap DEFERS while claude is busy and the late adoption finalizes the
+  // card honestly. This test FAILS on the pre-fix flat-30 s behaviour: without
+  // the gate the reap fires at 30 s, finalizes the orphan text, and consumes the
+  // entry so the later adoption returns null.
+  it('does NOT finalize a handback whose turn adopts late because the parent was busy', async () => {
+    let busy = false
+    const h = makeHarness({ isClaudeBusy: () => busy })
+    h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatBusy', messageId: 700 }))
+    await h.sched.advance(700) // debounce: card painted, reap armed
+    const resolvedId = await h.openCard.mock.results[0]!.value
+    expect(h.records.size).toBe(1)
+
+    // The parent turn is now in flight (a long Wave-2 assembly). The handback is
+    // enqueued behind it.
+    busy = true
+
+    // Two full reap intervals elapse — well beyond the flat 30 s. The reap must
+    // DEFER each time: no false orphan card, entry still live, typing still lit.
+    await h.sched.advance(30_000)
+    await h.sched.advance(30_000)
+    expect(h.finalizedIds).toEqual([]) // NEVER posted the "never started" nudge
+    expect(h.signal.pendingCount()).toBe(1) // still queued, not reaped
+    expect(h.typing.activeCount()).toBe(1) // indicator kept while queued
+
+    // The parent turn finally ends and the handback mints its own turn: it
+    // adopts the SAME card (an edit, not a second send / not an orphan finalize).
+    busy = false
+    const turnId = deriveTurnId('chatBusy', null, 700)!
+    const adoption = h.signal.tryAdopt(turnId)
+    expect(adoption).not.toBeNull()
+    expect(adoption!.activityMessageId).toBe(resolvedId)
+    expect(h.finalizedIds).toEqual([]) // adopted, never finalized as orphan
+    expect(h.openCard).toHaveBeenCalledTimes(1) // no double-send
+    expect(h.signal.pendingCount()).toBe(0)
+  })
+
+  // The deferred reap is not a leak: once claude goes idle and the handback has
+  // STILL not been adopted (genuine bridge-death / dropped inbound), the re-armed
+  // reap finalizes honestly — the degenerate case the reap exists for.
+  it('finalizes a genuine orphan once claude goes idle, even after deferring while busy', async () => {
+    let busy = true
+    const h = makeHarness({ isClaudeBusy: () => busy })
+    h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatIdleOrphan', messageId: 710 }))
+    await h.sched.advance(700)
+    const resolvedId = await h.openCard.mock.results[0]!.value
+
+    // Busy: the first reap defers.
+    await h.sched.advance(30_000)
+    expect(h.finalizedIds).toEqual([])
+    expect(h.signal.pendingCount()).toBe(1)
+
+    // Claude goes idle but NO adopting turn ever mints (the inbound was dropped).
+    // The re-armed reap now finalizes the genuine orphan.
+    busy = false
+    await h.sched.advance(30_000)
+    expect(h.finalizedIds).toEqual([resolvedId])
+    expect(h.typing.activeCount()).toBe(0)
+    expect(h.records.size).toBe(0)
+    expect(h.signal.pendingCount()).toBe(0)
+  })
+
   it('identity race: a user inbound on the same topic never mis-adopts the handback, no double-send', async () => {
     const h = makeHarness()
     h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatE', messageId: 200 }))


### PR DESCRIPTION
## Summary

The sub-agent-handback pre-turn signal armed a flat **30s "orphan reap"** on release. If the parent turn didn't ADOPT the pre-turn card within 30s, the reap finalized it to:

> 🤝 A background worker finished, but the handback never started — it may need a nudge.

That flat timeout cannot distinguish a **genuine orphan** (bridge died / released but never enqueued — no turn will ever consume it) from a handback that is **correctly ENQUEUED and simply waiting behind a long in-flight parent turn**. claude has ONE bridge / ONE input queue, so a released handback mints its adopting turn only when claude next goes idle. A parent turn that ran many minutes tripped the reap on every queued handback → **three false "needs a nudge" cards in four minutes** in one chat (operator-flagged), training the operator to ignore the alert.

## Why (root cause)

- `telegram-plugin/gateway/handback-preturn-signal.ts` `reap()` fired at a flat `adoptTimeoutMs` (30s) and finalized to the orphan text regardless of whether the handback was still queued.
- `telegram-plugin/gateway/gateway.ts` `finalizeHandbackPreTurnCard` → `HANDBACK_PRETURN_ORPHAN_HTML` is the card in the screenshot.
- The reap's own design note says it exists only for the DEGENERATE "bridge death after release" case — but the flat timer also caught the healthy "queued behind a long turn" case.

## The fix — queue state is the primary gate, not a longer timeout

The reap now consults `isClaudeBusy()` — wired to the authoritative single-bridge `isMachineInTurn()` read — and **DEFERS** (re-arms) while a turn is in flight, finalizing only once claude is **idle AND** the handback still has not been adopted. That idle-with-no-adoption state is the genuine bridge-death / dropped-inbound case the reap exists for. `isMachineInTurn()` is false for both `bridge_alive_idle` and `bridge_dead`, so a genuine orphan still finalizes honestly — and across a restart via the persisted record + boot reaper, which stays **ungated** (a fresh session is never mid-turn, so a boot-time pre-turn record IS a real orphan).

Lengthening the flat timeout would merely move the false positive; the queue-state gate removes it. The defer is bounded — the single-tenant FIFO queue plus the machine's stale-turn TTL guarantee `isMachineInTurn()` eventually goes false, so a queued handback is always either adopted or reaped once idle.

The **15-min mid-session card reaper** is a second flat timeout over the same records, so it gets the same gate: a pre-turn handback record is kept "live" (not reaped) while claude is busy — otherwise the fix would just move the false positive from 30s to 15min.

## Test plan

`telegram-plugin/tests/handback-preturn-signal.test.ts` (scoped vitest, passes under bun too):
- **does NOT finalize a handback whose turn adopts late because the parent was busy** — two full reap intervals elapse while busy, no orphan card, entry stays live, then late adoption finalizes honestly. This test **fails on the pre-fix flat-30s behaviour** (verified by neutering the gate).
- **finalizes a genuine orphan once claude goes idle, even after deferring while busy** — the deferred reap is not a leak; the re-armed reap fires honestly when idle with no adoption.

`npm run lint` clean (incl. gateway line-ratchet at ceiling, bot-api-wrapping, attribution trailers); `tsc --noEmit` clean; `handback-preturn-signal` + `turn-mint` + `activity-card` + `status-pin-lifecycle` suites green.

## Risk

Low. New behaviour is behind an optional dep that defaults to the prior immediate-reap when absent, so the genuine-orphan path is byte-identical without wiring. No new Telegram API surface. Boot reaper deliberately unchanged.

Job: `reference/jobs/know-what-my-agent-is-doing.md` — a status surface must never lie about what the agent is doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)