### PR TITLE
fix(hindsight-watch): report the live 10s recall deadline, not the retired 8000ms budget

### DIFF
--- a/src/hindsight-watch/evaluate.test.ts
+++ b/src/hindsight-watch/evaluate.test.ts
@@ -6,14 +6,16 @@ import {
   evaluateFailureRate,
   evaluateLlmFallback,
   evaluateQueueGrowth,
+  evaluateRecallOwnBankTimeout,
   evaluateRetainLoss,
 } from "./evaluate.js";
 import {
   PARTS_PER_MEMORY,
   QUEUE_FLOOR,
   QUEUE_GROWTH_MIN_ABS,
+  RECALL_WALL_MS,
 } from "./thresholds.js";
-import type { Sample } from "./types.js";
+import type { RecallSample, Sample } from "./types.js";
 
 const T0 = Date.parse("2026-07-25T09:00:00Z");
 const INTERVAL = 15 * 60_000;
@@ -296,6 +298,45 @@ describe("evaluateAll", () => {
   it("reports no-data everywhere on a single sample — never a false all-clear", () => {
     const verdicts = evaluateAll([sample(0)]);
     expect(verdicts.filter((v) => v.signal !== "container").every((v) => v.state === "no-data")).toBe(true);
+  });
+});
+
+describe("evaluateRecallOwnBankTimeout — the diagnostic latency suffix", () => {
+  function recallSample(over: Partial<RecallSample> = {}): RecallSample {
+    return {
+      rows: 100,
+      agents: 1,
+      timeoutConsidered: 100,
+      ownBankDegraded: 0,
+      zeroConsidered: 100,
+      zeroResult: 0,
+      poolConsidered: 100,
+      poolMedian: 40,
+      scoreConsidered: 100,
+      scoreP50: 0.5,
+      elapsedConsidered: 100,
+      elapsedP95Ms: 7000,
+      ...over,
+    };
+  }
+
+  function ringWith(r: RecallSample): Sample[] {
+    return [sample(0, { recall: r }), sample(1, { recall: r })];
+  }
+
+  // The alert text used to hardcode "the 8000ms per-bank budget"; #3759 raised
+  // the live recall deadline to a 10 s declarative envelope. The operator-facing
+  // wall MUST report the live envelope, not the retired 8 s number.
+  it("reports the live 10 s recall deadline, never the retired 8000ms budget", () => {
+    const v = evaluateRecallOwnBankTimeout(ringWith(recallSample()));
+    expect(RECALL_WALL_MS).toBe(10_000);
+    expect(v.detail).toContain(`${RECALL_WALL_MS}ms recall deadline`);
+    expect(v.detail).not.toContain("8000ms per-bank budget");
+  });
+
+  it("renders the measured p95 alongside the wall it is read against", () => {
+    const v = evaluateRecallOwnBankTimeout(ringWith(recallSample({ elapsedP95Ms: 7421 })));
+    expect(v.detail).toContain("recall wall time p95 7421ms");
   });
 });
 

--- a/src/hindsight-watch/evaluate.ts
+++ b/src/hindsight-watch/evaluate.ts
@@ -31,6 +31,7 @@ import {
   RECALL_POOL_MEDIAN_WARN,
   RECALL_SCORE_P50_PAGE,
   RECALL_SCORE_P50_WARN,
+  RECALL_WALL_MS,
   RECALL_ZERO_MEMORY_PAGE,
   RECALL_ZERO_MEMORY_WARN,
   RETAIN_FAILURE_RATE,
@@ -354,9 +355,11 @@ function errorSuffix(r: { topError?: string | null }): string {
  * Render recall wall time as DM context, or "" when unavailable.
  *
  * There is deliberately no `recall-latency` SIGNAL — see the deletion note in
- * `thresholds.ts`, where the healthy fleet's own p95 of 8037 ms is shown to
- * leave no thresholdable band below the 8 s per-bank budget. The measurement
- * is still worth SHOWING: it is what distinguishes "own-bank recall failed"
+ * `thresholds.ts`, where the 8037 ms healthy p95 (right-censored at the retired
+ * 8 s wall) is shown to leave no thresholdable band below the 10 s recall
+ * deadline the #3759 declarative envelope resolves to ({@link RECALL_WALL_MS}).
+ * The measurement is still worth SHOWING: it is what distinguishes "own-bank
+ * recall failed"
  * meaning *timed out at the wall* from meaning *errored immediately*, which
  * is the first question the operator asks and the cheapest one to pre-answer.
  *
@@ -367,7 +370,7 @@ function latencySuffix(r: { elapsedP95Ms?: number | null; elapsedConsidered?: nu
   const p95 = r.elapsedP95Ms;
   if (typeof p95 !== "number" || !Number.isFinite(p95)) return "";
   const n = typeof r.elapsedConsidered === "number" ? r.elapsedConsidered : 0;
-  return `\n  recall wall time p95 ${Math.round(p95)}ms over ${n} fire(s) (not thresholded — the 8000ms per-bank budget leaves no healthy band below it)`;
+  return `\n  recall wall time p95 ${Math.round(p95)}ms over ${n} fire(s) (not thresholded — the ${RECALL_WALL_MS}ms recall deadline leaves no healthy band below it)`;
 }
 
 /**
@@ -531,11 +534,13 @@ export function evaluateRecallInjectedScore(ring: Sample[]): Verdict {
 /*
  * There is no `evaluateRecallLatency`. `total_elapsed_ms` IS summarised (into
  * `RecallSample.elapsedP95Ms`) and IS shown, via `latencySuffix` on R1 — it
- * just carries no threshold, because the healthy fleet's own p95 is 8037 ms
- * against an 8000 ms per-bank budget and there is no band left underneath it.
- * The full derivation, including the bootstrap that breaches a 6000 ms line
- * in 100 % of healthy draws, is in `thresholds.ts` where the constants would
- * otherwise have lived.
+ * just carries no threshold, because the only healthy p95 ever measured
+ * (8037 ms) is right-censored at the retired 8 s wall, and against the 10 s
+ * recall deadline the #3759 declarative envelope resolves to ({@link
+ * RECALL_WALL_MS}) there is still no band left underneath it. The full
+ * derivation, including the bootstrap that breaches a 6000 ms line in 100 % of
+ * healthy draws, is in `thresholds.ts` where the constants would otherwise have
+ * lived.
  */
 
 /**

--- a/src/hindsight-watch/healthy-fleet.fixture.ts
+++ b/src/hindsight-watch/healthy-fleet.fixture.ts
@@ -25,9 +25,12 @@
  *   pool         p10 10      p50 41      min 3
  *   zero-memory  28/183 = 15.3 %
  *
- * The latency figures are why `recall-latency` is not a signal: a healthy
- * fleet's p95 sits at the 8 s per-bank budget. The score p10 is why the
- * injected-score warn moved from 0.05 to 0.02.
+ * The latency figures are why `recall-latency` is not a signal: this p95 sits
+ * at the 8 s per-bank wall it was captured under, RIGHT-CENSORED there. #3759
+ * later moved the wall to a 10 s declarative envelope, but a censored 8 s
+ * sample cannot describe the 8-10 s band, so the band is still not
+ * thresholdable — see the deletion note in `thresholds.ts` (RECALL_WALL_MS).
+ * The score p10 is why the injected-score warn moved from 0.05 to 0.02.
  *
  * Content: numeric telemetry only. Bank ids are remapped to `agent-NN` /
  * `side-NN` — no query text, no memory content, and no agent identity is

--- a/src/hindsight-watch/thresholds.test.ts
+++ b/src/hindsight-watch/thresholds.test.ts
@@ -5,7 +5,9 @@ import {
   QUEUE_FLOOR_MEMORIES,
   QUEUE_GROWTH_MIN_ABS,
   QUEUE_GROWTH_MIN_ABS_MEMORIES,
+  RECALL_WALL_MS,
 } from "./thresholds.js";
+import { resolveHindsightRecallTunables } from "../setup/hindsight-recall-tunables.js";
 
 describe("the #3610 memories → parts conversion", () => {
   // These two numbers are what the operator sees in `--json` and in every
@@ -44,5 +46,25 @@ describe("the #3610 memories → parts conversion", () => {
     // worst single entry in the live 2026-07-26 backlog re-split at the
     // post-#3693 33,000 bound (it was 17 at 45,000, B6).
     expect(5 * 23).toBeLessThan(QUEUE_GROWTH_MIN_ABS);
+  });
+});
+
+describe("RECALL_WALL_MS — the recall latency wall the diagnostic p95 reads against", () => {
+  // The wall the watchdog reports MUST track the live #3759 declarative
+  // envelope, not the retired hardcoded 8 s per-bank timeout. Every assertion
+  // here fails on the stale 8000 the alert used to state.
+  it("is sourced from the declarative recall envelope, not a literal", () => {
+    // The same resolver scaffold/reconcile stamp onto the deployed plugin,
+    // called with no operator overrides = the stock fleet envelope.
+    const stock = resolveHindsightRecallTunables(undefined);
+    expect(RECALL_WALL_MS).toBe(stock.parallelDeadlineSeconds * 1000);
+  });
+
+  it("resolves to the post-#3759 10 s envelope (12 s hook − 2 s headroom)", () => {
+    expect(RECALL_WALL_MS).toBe(10_000);
+  });
+
+  it("is the raised wall, not the retired 8000 ms per-bank budget", () => {
+    expect(RECALL_WALL_MS).toBeGreaterThan(8000);
   });
 });

--- a/src/hindsight-watch/thresholds.ts
+++ b/src/hindsight-watch/thresholds.ts
@@ -116,6 +116,8 @@
  *      and the largest finite `le` is still 120.0 (B4 holds).
  */
 
+import { resolveHindsightRecallTunables } from "../setup/hindsight-recall-tunables.js";
+
 /** How many samples the rolling window keeps (8 × 15 min = 2 h). */
 export const RING_MAX = 8;
 
@@ -386,7 +388,8 @@ export const METRICS_TIMEOUT_MS = 10_000;
 //   zero-memory        46.6 %  (983/2109 rows carrying result_count)
 //   candidate pool     median 18   (per-agent: 0 for finn/klanker/overlord)
 //   injected score     p50 0.0011  (n=284; gymbro 0.22, reggie 0.61 healthy)
-//   recall p95         8053 ms     (p50 8023 ms — pinned at the 8 s budget)
+//   recall p95         8053 ms     (p50 8023 ms — pinned at the then-8 s wall,
+//                                    retired by #3759; see RECALL_WALL_MS)
 //   consolidation      77 pending, oldest 3.98 h
 //
 // Each constant records BOTH the sick reading and the healthy one, because a
@@ -539,46 +542,71 @@ export const RECALL_POOL_MEDIAN_PAGE = 3;
 export const RECALL_SCORE_P50_WARN = 0.02;
 export const RECALL_SCORE_P50_PAGE = 0.01;
 
+/**
+ * The recall wall-time wall the diagnostic p95 is read against, in ms.
+ *
+ * NOT a fresh literal. #3759 made the recall deadline a DECLARATIVE envelope
+ * (`src/setup/hindsight-recall-tunables.ts`), exported fleet-wide via
+ * `HINDSIGHT_RECALL_*` (`src/agents/scaffold.ts`) — the highest-precedence
+ * layer of hindsight's config load order. The shared parallel fan-out deadline
+ * that bounds `total_elapsed_ms` is resolved there; taking it from the resolver
+ * (no operator overrides = the stock envelope) means this number tracks the
+ * envelope automatically instead of going stale the way the retired hardcoded
+ * `8000` did. The stock resolution is 12 s hook ceiling − 2 s headroom = 10 s
+ * (10000 ms), and the per-bank request timeout derives to the same 10 s — so
+ * whichever way you read "the wall", it is this one number now, not 8 s.
+ */
+export const RECALL_WALL_MS =
+  resolveHindsightRecallTunables(undefined).parallelDeadlineSeconds * 1000;
+
 /*
  * THERE IS NO `RECALL_P95_WARN_MS` / `RECALL_P95_PAGE_MS`. A recall latency
- * SLI was drafted at 4 s / 6 s and deleted before it shipped. Recording why,
- * because the number looked reasonable and the reasoning is the point.
+ * SLI was drafted at 4 s / 6 s, deleted before it shipped, and is STILL not
+ * re-derivable after #3759 moved the wall — recording why against the CURRENT
+ * envelope, because the number looked reasonable and the reasoning is the point.
  *
- * The draft justified 4 s / 6 s as sitting "above the 0.6-4.3 s an unloaded
- * server answers in and below the 8 s wall". That band does not reproduce.
- * Measured over the healthy-conditioned population — rows where no bank timed
- * out, errored, or hit the shared deadline, n=183 across 9 agents:
+ * The wall is no longer 8 s. #3759 made the recall deadline the declarative
+ * envelope above ({@link RECALL_WALL_MS}, 10 s by default = 12 s hook ceiling
+ * − 2 s headroom), and the per-bank request timeout now derives to the same
+ * 10 s rather than the old hardcoded 8 s. The healthy readings below cannot set
+ * a line against that 10 s wall, for two reasons that COMPOUND:
  *
- *   FLEET      p50 6420 ms   p75 7566   p90 7935   p95 8037   p99 11426
- *   per-agent healthy p95: 7816 (ziggy) … 11859 (overlord), every one of the
- *   nine above 6000 ms; fastest healthy p50 is finn at 4321 ms, itself
- *   already past the drafted WARN.
+ *   1. They are CENSORED at the retired 8 s wall. Every p95 here was measured
+ *      while the per-bank timeout was 8 s, so the distribution is right-clipped
+ *      at ~8 s ("pinned at the 8 s budget", baseline block above). The true
+ *      healthy p95 under a 10 s wall is unknown and can only be HIGHER, because
+ *      recalls that were cut off at 8 s now run on — so 8037 ms is a FLOOR on
+ *      healthy p95, not an estimate of it. Measured over the healthy-conditioned
+ *      population (rows where no bank timed out, errored, or hit the shared
+ *      deadline), n=183 across 9 agents, all under the 8 s wall:
  *
- * So the PAGE line sat BELOW the healthy median. A 2000-draw bootstrap over
- * healthy rows breaches 6000 ms in 100.0 % of draws. The failure mode is the
- * one that matters most for a watchdog: the recall fixes land, timeouts go to
- * 0 %, pool and scores recover — and this signal pages every 15 minutes
- * forever on a fleet that is working, training the operator to ignore it.
+ *        FLEET  p50 6420 ms  p75 7566  p90 7935  p95 8037  p99 11426
  *
- * Raising it does not save it either. The per-bank budget is 8 s, so healthy
- * traffic already reaches 8037 ms at p95; any line clear of that noise
- * (≥12 s bootstraps to 0.0 %) can only ever mean "pinned at the deadline",
- * which is exactly what `RECALL_OWN_BANK_TIMEOUT` already reports, from a
- * cleaner instrument. The usable band between the healthy median and the
- * budget wall is 6420-8000 ms — 1.25× — and no threshold separates healthy
- * from degraded inside it before the timeout rate does.
+ *      The p99 already sat at 11426 ms — PAST the new 10 s wall — so the healthy
+ *      tail extends beyond the wall and any warn line below it fires on healthy
+ *      traffic. Per-agent healthy p95 ran 7816 (ziggy) … 11859 (overlord).
+ *   2. Even taking 8037 ms at face value, the band between it and the 10 s wall
+ *      is 8037-10000 ms ≈ 1.24× — indistinguishable in width from the
+ *      6420-8000 ms (1.25×) band this signal was already rejected over — and
+ *      the degraded case inside it is already reported by `RECALL_OWN_BANK_
+ *      TIMEOUT` from a cleaner instrument (a bank that misses its deadline),
+ *      not from a percentile of a censored wall-time. A 2000-draw bootstrap
+ *      over healthy rows still breaches the drafted 6000 ms line in 100.0 % of
+ *      draws; the PAGE sat below the healthy median then and does now.
  *
- * This is the same defect this file already articulates when deleting
- * `RETAIN_P95_SECONDS` above: the healthy population sits past the threshold
- * and the instrument saturates at a budget just beyond it. It was caught in
- * review here rather than after six weeks of alert fatigue, which is the
- * system working.
+ * So moving the wall 8 s → 10 s did not open a thresholdable band; it widened
+ * the region of IGNORANCE (8-10 s) that the old, censored measurement cannot
+ * describe. This is the same defect this file articulates when deleting
+ * `RETAIN_P95_SECONDS` above: the healthy population sits at/past the threshold
+ * and the instrument saturates at a deadline just beyond it.
  *
  * `total_elapsed_ms` is still summarised into `RecallSample.elapsedP95Ms` and
- * rendered as DIAGNOSTIC context on the own-bank-timeout DM — the datum is
- * useful, it just cannot carry a threshold today. Restoring the signal needs
- * a re-baseline against a fleet whose recall is actually fixed, gated on that
- * measurement rather than on this one; filed as follow-up #3792.
+ * rendered as DIAGNOSTIC context on the own-bank-timeout DM (against
+ * {@link RECALL_WALL_MS}) — the datum is useful, it just cannot carry a
+ * threshold today. Restoring the signal needs a re-baseline against a fleet
+ * whose recall is BOTH fixed AND running the 10 s envelope, gated on that
+ * measurement rather than on this one; filed as follow-up #3792. Until then a
+ * latency line here would be calibrated against a wall that no longer exists.
  */
 
 /**

--- a/src/hindsight-watch/types.ts
+++ b/src/hindsight-watch/types.ts
@@ -14,10 +14,14 @@
  * `thresholds.ts`, where the constant used to be.
  *
  * `recall-latency` was removed for the SAME reason and caught the same way,
- * one signal-set later: the healthy fleet's recall p95 is 8037 ms against an
- * 8000 ms per-bank budget, so the drafted 6000 ms page line sat below the
- * healthy MEDIAN. Twice now the trap has been a latency threshold measured
- * against an outage instead of against a working fleet.
+ * one signal-set later: the drafted 6000 ms page line sat below the healthy
+ * MEDIAN (p50 6420 ms), and the only healthy p95 ever measured (8037 ms) was
+ * right-censored at the then-8 s per-bank wall — retired by #3759, which made
+ * the recall deadline a 10 s declarative envelope. Against that 10 s wall the
+ * band is STILL not thresholdable, and re-deriving it needs a re-baseline on a
+ * fixed fleet (follow-up #3792); the full argument lives in `thresholds.ts`.
+ * Twice now the trap has been a latency threshold measured against an outage
+ * instead of against a working fleet.
  */
 export type SignalId =
   | "probe" // the watchdog itself could not see hindsight


### PR DESCRIPTION
## Summary

`switchroom hindsight-watch`'s `recall-own-bank-timeout` alert hardcoded an **8000ms per-bank budget** in the operator-facing diagnostic latency suffix and in the deleted `recall-latency` SLI's threshold rationale. That wall was retired by **#3759** (`352a5aed`, merged 2026-07-27), which made the recall deadline a **declarative envelope** (`src/setup/hindsight-recall-tunables.ts`) exported fleet-wide via `HINDSIGHT_RECALL_*` (`src/agents/scaffold.ts`). The stock resolution is a **10s** shared parallel fan-out deadline (12s hook ceiling − 2s headroom), live-verified at ~9994ms. The watchdog was reporting a budget retired three days earlier, and its "no thresholdable band below the 8s wall" rationale was calibrated against a wall that no longer exists.

## What changed

- **Source the wall from the declarative tunable.** New `RECALL_WALL_MS` constant in `thresholds.ts`, derived from `resolveHindsightRecallTunables(undefined).parallelDeadlineSeconds * 1000` — the same resolver scaffold/reconcile stamp onto the deployed plugin. It tracks the envelope automatically instead of going stale the way the literal `8000` did.
- **Correct every operator-facing surface** from 8000ms → the sourced 10s wall: the runtime latency suffix in `evaluate.ts`, and the rationale comments in `thresholds.ts`, `evaluate.ts`, `types.ts`, and `healthy-fleet.fixture.ts`.

## SLI band decision — re-derived, still no band, defensibly

Determined against the **10s** wall (not the retired 8s one) whether a thresholdable latency band now exists. Conclusion: **still no clean band**, for a reason stated against the current wall:

1. The only healthy p95 we have (**8037ms**) was **right-censored at the retired 8s per-bank timeout** ("pinned at the 8s budget", `thresholds.ts` baseline). It is a *floor* on healthy p95, not an estimate under a 10s wall — recalls clipped at 8s now run on, so the true value can only be **higher**.
2. The healthy **p99 was already 11426ms** — past the new 10s wall — so the healthy tail crosses the wall; a warn line below it fires on healthy traffic.
3. Even taking 8037ms at face value, the **8037→10000ms band (1.24×)** is indistinguishable in width from the **6420→8000ms (1.25×)** band this signal was already rejected over, and the degraded case inside it is already reported by `RECALL_OWN_BANK_TIMEOUT` from a cleaner instrument.

Moving the wall 8s→10s did not open a band; it widened the region of ignorance (8–10s) the censored measurement cannot describe. Restoring the signal needs a re-baseline on a fleet that is both fixed and running the 10s envelope — already tracked as follow-up **#3792**.

## Test plan

- `thresholds.test.ts`: pins `RECALL_WALL_MS` to the resolver output, asserts it equals `10_000` and is `> 8000` — fails on the stale value.
- `evaluate.test.ts`: asserts the own-bank-timeout detail reports `"10000ms recall deadline"` and **not** `"8000ms per-bank budget"`.
- Scoped: `vitest run src/hindsight-watch/ src/setup/hindsight-reranker-budget.test.ts` → 190 passed.
- `tsc --noEmit` clean; `npm run lint` clean (all 22 guards).

## Risk

Low. No behaviour change to any firing threshold — the latency measurement is diagnostic-only and reads no threshold, so verdicts are unchanged. The change is the reported wall number (now sourced) and the rationale text.

Job: `reference/jobs/fleet-stays-healthy.md` — an alert that misstates its own threshold erodes operator trust in the watchdog it exists to build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)