### PR TITLE
fix(doctor): fail on host-CLI drift so it can't silently trail the fleet

### DIFF
--- a/src/cli/doctor-component-versions.test.ts
+++ b/src/cli/doctor-component-versions.test.ts
@@ -20,14 +20,16 @@ const REFERENCE_HOST = [
 ];
 
 describe("doctor: component versions (#3919)", () => {
-  it("WARNs once per stale component and names a remediation for each", () => {
+  it("WARNs once per stale CONTAINER and names a remediation for each", () => {
     const rows = runComponentVersionChecks(config("v0.19.28"), {
       exec: ps(REFERENCE_HOST),
       cliVersion: "0.19.23",
     });
     const warns = rows.filter((r) => r.status === "warn");
+    // Containers that lag are warn-only (they can trail legitimately
+    // mid-roll). The host CLI is NOT in this set — it is a fail, asserted
+    // separately below.
     expect(warns.map((r) => r.name).sort()).toEqual([
-      "component behind: cli (host)",
       "component behind: switchroom-hindsight-autoheal",
       "component behind: switchroom-web",
     ]);
@@ -38,17 +40,32 @@ describe("doctor: component versions (#3919)", () => {
     expect(
       warns.find((r) => r.name.endsWith("switchroom-hindsight-autoheal"))?.fix,
     ).toContain("hostd install --tag v0.19.28");
-    expect(warns.find((r) => r.name.endsWith("cli (host)"))?.fix).toContain(
-      "switchroom update",
-    );
   });
 
-  it("never FAILs — version skew must not change doctor's exit code", () => {
+  it("FAILs when the host CLI binary trails the target — the silent-drift bug", () => {
+    // The regression: fleet on v0.19.28, host binary left on an older
+    // release running a retired cron. This is the case that must turn
+    // doctor RED (non-zero exit), not merely warn.
     const rows = runComponentVersionChecks(config("v0.19.28"), {
       exec: ps(REFERENCE_HOST),
       cliVersion: "0.19.23",
     });
+    const hostCli = rows.find((r) => r.name === "component behind: cli (host)");
+    expect(hostCli?.status).toBe("fail");
+    expect(hostCli?.fix).toContain("switchroom update");
+    expect(rows.some((r) => r.status === "fail")).toBe(true);
+  });
+
+  it("does NOT fail when the host CLI is on target even while CONTAINERS lag", () => {
+    // A current host binary with containers mid-roll must stay green
+    // (no fail): container skew alone never changes doctor's exit code.
+    const rows = runComponentVersionChecks(config("v0.19.28"), {
+      exec: ps(REFERENCE_HOST),
+      cliVersion: "0.19.28",
+    });
     expect(rows.some((r) => r.status === "fail")).toBe(false);
+    // The lagging containers are still surfaced, as warnings.
+    expect(rows.some((r) => r.status === "warn")).toBe(true);
   });
 
   it("reports a single ok row on a converged host", () => {
@@ -80,5 +97,17 @@ describe("doctor: component versions (#3919)", () => {
       "component ahead: switchroom-klanker",
     ]);
     expect(ahead.every((r) => r.status === "warn")).toBe(true);
+  });
+
+  it("does NOT fail when the host CLI is AHEAD of a stale pin", () => {
+    // An ahead host binary (operator bumped ahead of release.pin, or the
+    // pin is stale) is not the drift bug — only *behind* fails.
+    const rows = runComponentVersionChecks(config("v0.19.26"), {
+      exec: ps(REFERENCE_HOST.map((l) => l.replace(/v0\.19\.2[68]/g, "v0.19.26"))),
+      cliVersion: "0.19.28",
+    });
+    const hostCli = rows.find((r) => r.name.includes("cli (host)"));
+    expect(hostCli?.status).not.toBe("fail");
+    expect(rows.some((r) => r.status === "fail")).toBe(false);
   });
 });

--- a/src/cli/doctor-component-versions.ts
+++ b/src/cli/doctor-component-versions.ts
@@ -12,10 +12,22 @@
  * `component-versions.ts` for the inventory + comparison rules; this
  * module is only the doctor row mapping.
  *
- * Status contract: `warn` for a behind component, `ok` when converged,
- * `skip` when nothing is comparable. Never `fail` — version skew is a
- * real finding but it is not a broken install, and this section must not
- * change doctor's exit code for an otherwise-healthy host.
+ * Status contract: `warn` for a behind CONTAINER, `ok` when converged,
+ * `skip` when nothing is comparable. Container skew is a real finding but
+ * not a broken install — and containers legitimately sit behind `target`
+ * transiently mid-roll (release.pin is bumped before every container has
+ * advanced), so failing on any container-behind would turn doctor RED for
+ * a healthy host during a normal roll. Those stay `warn`.
+ *
+ * The ONE exception is the host CLI binary itself (`cli (host)`): it is a
+ * single artifact that `switchroom update` converges in-band, so a
+ * *behind* host binary is never a transient mid-roll state — it is the
+ * exact silent-drift bug this module exists to catch (v0.19.38 rolled to
+ * every container while `/usr/local/bin/switchroom` stayed on v0.19.33 and
+ * the hindsight-watch cron ran retired code for 12 h). That single case
+ * is `fail`, so doctor goes RED and the drift can no longer hide behind a
+ * warning. A current or ahead host CLI stays green. See
+ * `hostCliBehindStatus()` for the scoped rule.
  */
 
 import { spawnSync } from "node:child_process";
@@ -56,6 +68,18 @@ function fixFor(c: ComponentVersion, target: string): string {
   return remediationFor(classifyComponent(c), target);
 }
 
+/**
+ * The status for a *behind* component. Scoped-fail rule (see the module
+ * header): only the host CLI binary drifting behind `target` is a `fail`;
+ * every containerised component stays `warn` because it can legitimately
+ * lag mid-roll. Keyed on `kind === "cli"`, the field `collectComponents`
+ * stamps on the host entry — never on a container — so a container can
+ * never trip the fail path even if its name were to change.
+ */
+export function hostCliBehindStatus(c: ComponentVersion): "fail" | "warn" {
+  return c.kind === "cli" ? "fail" : "warn";
+}
+
 export function runComponentVersionChecks(
   config: SwitchroomConfig,
   opts: ComponentVersionCheckOpts = {},
@@ -89,10 +113,14 @@ export function runComponentVersionChecks(
     });
   }
   for (const c of report.behind) {
+    const status = hostCliBehindStatus(c);
     results.push({
       name: `component behind: ${c.name}`,
-      status: "warn",
-      detail: `on ${c.version}, expected ${report.target} (${src})`,
+      status,
+      detail:
+        status === "fail"
+          ? `on ${c.version}, expected ${report.target} (${src}) — the host CLI must never trail the fleet; it self-heals in-band via \`switchroom update\``
+          : `on ${c.version}, expected ${report.target} (${src})`,
       fix: fixFor(c, report.target),
     });
   }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -4005,7 +4005,11 @@ export function registerDoctorCommand(program: Command): void {
             // #3919: is every switchroom component — the host CLI included —
             // on the same release? Three components drifted across three
             // releases on the reference host because nothing held a standing
-            // answer to that question. warn-only; never changes exit code.
+            // answer to that question. Container skew is warn-only (it lags
+            // legitimately mid-roll); a *behind* host CLI binary is FAIL —
+            // that is the silent-drift bug (v0.19.38 fleet vs v0.19.33 host
+            // CLI running a retired cron for 12h), and it self-heals in-band
+            // so it is never a transient state. See doctor-component-versions.
             title: "Component versions (#3919)",
             results: ((): CheckResult[] => {
               try {


### PR DESCRIPTION
## Problem

After **v0.19.38** rolled to every container, the host binary at `/usr/local/bin/switchroom` stayed on **v0.19.33**. The `hindsight-watch` cron therefore ran retired code for **12h**. Nothing surfaced it: the component-version doctor section is *warn-only*, and a warning scrolls past during a roll.

## Fix — scoped to the actual failure mode

`switchroom doctor` now returns a **`fail`** row (non-zero exit) when the host CLI binary (`cli (host)`) is **behind** the drift target. Every containerised component stays **`warn`**.

Why not fail on any behind component? Containers legitimately trail `target` transiently mid-roll — `release.pin` is bumped before every container has advanced — so failing on any container-behind would turn doctor RED for a *healthy rolling host*. The host CLI is the one component `switchroom update` converges **in-band**, so a *behind* host binary is never a transient state — it is exactly this bug. Ahead/current host CLI stays green; only genuinely-behind fails.

## Blast radius (assessed)

doctor's exit code is consumed by:
- interactive operator runs
- `switchroom update`'s doctor step — which **explicitly ignores** the return status (`runner(self.command, selfArgv("doctor"))`, comment: *"the update succeeded; the diagnostics are informational"*), so a RED host-CLI-drift row does **not** break an update

Not consumers of the exit code: no `.github/` workflow runs `switchroom doctor`; `rollout` and `setup/verify` call the drift primitives / runtime-health functions directly, not the doctor exit code. A current host stays green.

## Tests (assert outcomes)

- **FAILs** when host binary < target (the regression) — a `fail` row named `component behind: cli (host)`
- **no fail** when host binary == target, even while containers lag (they stay `warn`)
- **no fail** when host binary is ahead of a stale pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)