### PR TITLE
fix(update): reconcile the hindsight-watch cron on every update

### DIFF
--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -36,7 +36,7 @@ function fakeRunner() {
 }
 
 describe("planUpdate", () => {
-  it("produces 10 steps in default mode (no --rebuild)", () => {
+  it("produces 11 steps in default mode (no --rebuild)", () => {
     const tmp = mkdtempSync(join(tmpdir(), "update-plan-"));
     try {
       const composePath = join(tmp, "docker-compose.yml");
@@ -54,6 +54,7 @@ describe("planUpdate", () => {
         "self-update-cli",
         "pull-images",
         "apply-config",
+        "reconcile-hindsight-watch-cron",
         "refresh-hostd",
         "refresh-web",
         "refresh-hindsight",
@@ -66,6 +67,70 @@ describe("planUpdate", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
+  });
+
+  describe("reconcile-hindsight-watch-cron step (#silent-cli-drift)", () => {
+    const OLD_ENV = { ...process.env };
+    function stepFor(opts: Parameters<typeof planUpdate>[0]) {
+      return planUpdate({ composePath: "unused", ...opts }).find(
+        (s) => s.name === "reconcile-hindsight-watch-cron",
+      )!;
+    }
+
+    it("REWRITES the cron when it differs, then is a NO-OP when identical", () => {
+      const tmp = mkdtempSync(join(tmpdir(), "update-cron-"));
+      try {
+        process.env.SWITCHROOM_BINARY = "/usr/local/bin/switchroom";
+        const cronPath = join(tmp, "hindsight-watch");
+        // Armed earlier as `ada` at a STALE binary path.
+        writeFileSync(
+          cronPath,
+          [
+            "# switchroom hindsight-watch — model-free memory watchdog.",
+            "# Managed by `switchroom hindsight-watch --install-cron`; edits are overwritten.",
+            "# Exit 0 = clean, 10 = a signal is firing (DM sent), 1 = the check could not complete.",
+            "SHELL=/bin/sh",
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "*/15 * * * * ada /usr/bin/flock -n /run/lock/hindsight-watch.lock /opt/old/switchroom hindsight-watch >> /var/log/hindsight-watch.log 2>&1",
+            "",
+          ].join("\n"),
+        );
+        const before = readFileSync(cronPath, "utf8");
+
+        // First run: the stale binary path is corrected → file changes.
+        stepFor({ watchCronPath: cronPath }).run();
+        const after = readFileSync(cronPath, "utf8");
+        expect(after).not.toBe(before);
+        expect(after).toContain("/usr/local/bin/switchroom hindsight-watch");
+        expect(after).not.toContain("/opt/old/switchroom");
+        // The operator's chosen user is preserved, not overwritten to root.
+        expect(after).toContain("*/15 * * * * ada ");
+
+        // Second run: definition already current → byte-identical no-op.
+        stepFor({ watchCronPath: cronPath }).run();
+        expect(readFileSync(cronPath, "utf8")).toBe(after);
+      } finally {
+        process.env = { ...OLD_ENV };
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it("is a NO-OP when the host was never armed (no fragment present)", () => {
+      const tmp = mkdtempSync(join(tmpdir(), "update-cron-absent-"));
+      try {
+        const cronPath = join(tmp, "hindsight-watch");
+        // Must not throw and must not create the file — arming stays opt-in.
+        expect(() => stepFor({ watchCronPath: cronPath }).run()).not.toThrow();
+        expect(existsSync(cronPath)).toBe(false);
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it("is deferred (skipReason) in hostd-context — /etc/cron.d is on the host", () => {
+      expect(stepFor({ hostdContext: true }).skipReason).toMatch(/hostd-context/);
+      expect(stepFor({ hostdContext: false }).skipReason).toBeUndefined();
+    });
   });
 
   it("refresh-hindsight runs when memory.backend is hindsight, skips otherwise / on --skip-images", () => {
@@ -271,6 +336,7 @@ describe("planUpdate", () => {
         "pull-images",
         "rebuild-source",
         "apply-config",
+        "reconcile-hindsight-watch-cron",
         "refresh-hostd",
         "refresh-web",
         "refresh-hindsight",

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -70,6 +70,7 @@ import {
   formatComponentDrift,
   type ExecFn,
 } from "./component-versions.js";
+import { reconcileCron } from "../hindsight-watch/install-cron.js";
 
 /**
  * Default durable-pin persister for `update --pin`: comment-preserving,
@@ -210,6 +211,10 @@ interface UpdateOptions {
   selfUpdateSink?: { replacedWith?: string; binaryPath?: string };
   /** Test seam — replace the re-exec of the freshly installed binary. */
   reexecFn?: (binaryPath: string, args: string[]) => { status: number };
+  /** Test seam — override the /etc/cron.d/hindsight-watch path the
+   *  `reconcile-hindsight-watch-cron` step reconciles (default: the real
+   *  `CRON_PATH`). Lets the step be exercised against a temp file. */
+  watchCronPath?: string;
 }
 
 interface UpdateStep {
@@ -648,6 +653,72 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
         ...releaseOverrideArgs,
       ));
       if (r.status !== 0) throw new Error("switchroom apply failed");
+    },
+  });
+
+  // reconcile-hindsight-watch-cron: re-assert the hindsight-watch cron
+  // definition on every update so an already-armed host can't drift.
+  //
+  // The watchdog cron (`/etc/cron.d/hindsight-watch`) pins the binary path,
+  // schedule, flags and PATH when it is armed, but nothing re-asserted it
+  // afterwards — so a definition change, or a binary that moved out from under
+  // the fragment, would persist silently until someone re-ran
+  // `--install-cron` by hand. This step folds that reconcile into `update`,
+  // right after apply-config where the rest of the host's generated surfaces
+  // are refreshed.
+  //
+  // It is REPAIR, not ARM: `reconcileCron` is a no-op when the fragment is
+  // absent (arming stays the explicit `hindsight-watch --install-cron` opt-in,
+  // and `switchroom doctor` FAILs while unarmed), and idempotent when present
+  // and already correct. The operator's chosen `--cron-user` is preserved.
+  //
+  // Deferred in hostd-context: `/etc/cron.d` lives on the host, not inside the
+  // hostd container, so writing it from there would land in the wrong
+  // filesystem. Never fatal — a failed reconcile warns and continues; the
+  // update itself succeeded.
+  steps.push({
+    name: "reconcile-hindsight-watch-cron",
+    description:
+      "Reconcile /etc/cron.d/hindsight-watch (binary path / schedule / flags) on already-armed hosts — idempotent; no-op when unarmed or already current",
+    skipReason: hostdContext
+      ? "deferred (hostd-context): /etc/cron.d is on the host, not in the hostd container — finish host-side with `switchroom hindsight-watch --install-cron`"
+      : undefined,
+    isHostdDeferred: hostdContext,
+    run: () => {
+      const say = opts.stdout ?? ((t: string) => process.stdout.write(t));
+      const binary = process.env.SWITCHROOM_BINARY ?? "/usr/local/bin/switchroom";
+      const fallbackUser =
+        process.env.SUDO_USER ?? process.env.USER ?? process.env.LOGNAME;
+      let res: ReturnType<typeof reconcileCron>;
+      try {
+        res = reconcileCron({
+          binary,
+          fallbackUser,
+          ...(opts.watchCronPath ? { path: opts.watchCronPath } : {}),
+        });
+      } catch (e) {
+        // Non-fatal: the update succeeded; a cron we couldn't reconcile is a
+        // diagnostic, not an update failure. `switchroom doctor` carries the
+        // standing signal.
+        say(
+          chalk.yellow(
+            `  hindsight-watch cron not reconciled: ${(e as Error).message}\n`,
+          ),
+        );
+        return;
+      }
+      if (res.status === "absent") {
+        say(
+          chalk.gray(
+            "  hindsight-watch cron not armed — skipping reconcile " +
+              "(arm with `switchroom hindsight-watch --install-cron`; doctor FAILs while unarmed)\n",
+          ),
+        );
+      } else if (res.status === "reconciled") {
+        say(chalk.green(`  hindsight-watch cron reconciled at ${res.path}\n`));
+      } else {
+        say(chalk.gray(`  hindsight-watch cron already current at ${res.path}\n`));
+      }
     },
   });
 

--- a/src/hindsight-watch/install-cron.test.ts
+++ b/src/hindsight-watch/install-cron.test.ts
@@ -6,8 +6,11 @@ import { join } from "node:path";
 import {
   CRON_LOCK_PATH,
   CRON_LOG_PATH,
+  CRON_PATH,
   CRON_SCHEDULE,
   installCron,
+  parseCronUser,
+  reconcileCron,
   renderCron,
 } from "./install-cron.js";
 
@@ -97,5 +100,66 @@ describe("installCron", () => {
     // branch got there.
     expect(installCron({ ...OPTS, path }).status).toBe("installed");
     expect(readFileSync(path, "utf8")).toBe(renderCron(OPTS));
+  });
+});
+
+describe("parseCronUser", () => {
+  it("returns the user field of the managed schedule line", () => {
+    expect(parseCronUser(renderCron(OPTS))).toBe("kenthompson");
+  });
+
+  it("ignores comment / SHELL= / PATH= lines and reads the hindsight-watch line", () => {
+    const other = renderCron({ user: "ada", binary: "/usr/local/bin/switchroom" });
+    expect(parseCronUser(other)).toBe("ada");
+  });
+
+  it("returns null for a fragment with no managed line", () => {
+    expect(parseCronUser("# just a comment\nPATH=/bin\n")).toBeNull();
+    expect(parseCronUser("")).toBeNull();
+  });
+});
+
+describe("reconcileCron — repair an already-armed cron, never arm", () => {
+  it("is a no-op (absent) when the fragment does not exist — never arms", () => {
+    const path = join(dir, "hindsight-watch");
+    const res = reconcileCron({ binary: OPTS.binary, path, fallbackUser: "ken" });
+    expect(res.status).toBe("absent");
+    // Crucially, nothing was written: an unarmed host STAYS unarmed.
+    expect(() => statSync(path)).toThrow();
+  });
+
+  it("REWRITES a drifted fragment (stale binary path) and preserves the user", () => {
+    const path = join(dir, "hindsight-watch");
+    // Armed earlier as `ada` pointing at an old binary location.
+    writeFileSync(path, renderCron({ user: "ada", binary: "/opt/old/switchroom" }));
+    const res = reconcileCron({
+      binary: "/usr/local/bin/switchroom",
+      path,
+      fallbackUser: "root", // must NOT be used — user is parsed from the file
+    });
+    expect(res.status).toBe("reconciled");
+    // The operator's chosen user is preserved; only the binary is corrected.
+    expect(readFileSync(path, "utf8")).toBe(
+      renderCron({ user: "ada", binary: "/usr/local/bin/switchroom" }),
+    );
+  });
+
+  it("is idempotent: a second reconcile of a current fragment is unchanged", () => {
+    const path = join(dir, "hindsight-watch");
+    writeFileSync(path, renderCron({ user: "ada", binary: "/usr/local/bin/switchroom" }));
+    expect(reconcileCron({ binary: "/usr/local/bin/switchroom", path }).status).toBe(
+      "unchanged",
+    );
+    expect(reconcileCron({ binary: "/usr/local/bin/switchroom", path }).status).toBe(
+      "unchanged",
+    );
+  });
+
+  it("defaults to the real CRON_PATH when none is given", () => {
+    // Not writable in tests, but the resolved path must be the production one.
+    const res = reconcileCron({ binary: OPTS.binary, path: undefined, fallbackUser: "ken" });
+    // On a dev host with no armed cron this is absent; the point under test is
+    // that it resolved CRON_PATH rather than throwing.
+    expect(res.path).toBe(CRON_PATH);
   });
 });

--- a/src/hindsight-watch/install-cron.ts
+++ b/src/hindsight-watch/install-cron.ts
@@ -114,3 +114,92 @@ export function installCron(
   renameSync(tmp, path);
   return { status: "installed", path, content };
 }
+
+/**
+ * Parse the unix user field out of an existing cron fragment.
+ *
+ * `/etc/cron.d` lines are `MIN HOUR DOM MON DOW USER COMMAND` — the sixth
+ * whitespace-delimited field. We match the managed line (the one that invokes
+ * `hindsight-watch`) rather than any comment/`SHELL=`/`PATH=` line, and return
+ * that user so a reconcile PRESERVES the operator's chosen `--cron-user`
+ * instead of guessing it from the reconciling process's environment (which,
+ * under `sudo switchroom update`, would be `root` — the exact value
+ * `--install-cron` refuses).
+ *
+ * Returns null when no managed schedule line is found (empty/foreign/malformed
+ * fragment), so the caller can fall back or decline to touch it.
+ */
+export function parseCronUser(content: string): string | null {
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    if (!trimmed.includes("hindsight-watch")) continue;
+    // MIN HOUR DOM MON DOW USER … — the user is the 6th field.
+    const fields = trimmed.split(/\s+/);
+    if (fields.length >= 7) return fields[5];
+  }
+  return null;
+}
+
+export interface ReconcileResult {
+  /**
+   * `absent`     — the fragment is not present; the host never armed the
+   *                watchdog, so reconcile does nothing (arming stays the
+   *                explicit opt-in, and `switchroom doctor` FAILs while
+   *                unarmed).
+   * `reconciled` — the fragment existed but drifted (stale binary path,
+   *                schedule, flags, or PATH) and was rewritten to match.
+   * `unchanged`  — the fragment existed and already matched — a true no-op.
+   */
+  status: "absent" | "reconciled" | "unchanged";
+  path: string;
+  content?: string;
+}
+
+/**
+ * Reconcile an ALREADY-ARMED hindsight-watch cron to the current definition.
+ *
+ * ## Why this is separate from {@link installCron}
+ *
+ * `installCron` ARMS — it writes the fragment whether or not one exists. That
+ * is the opt-in `--install-cron` verb's job. `reconcileCron` REPAIRS — it only
+ * touches a fragment that already exists, so `switchroom update` can keep every
+ * armed host's cron definition current (the binary path, schedule, flags and
+ * PATH) without silently arming a host that deliberately never opted in.
+ *
+ * This closes the drift that let a stale cron survive an update: the fragment's
+ * `binary` path is pinned when written, but nothing re-asserted it, so a
+ * definition change (or a moved binary) would persist until someone re-ran
+ * `--install-cron` by hand.
+ *
+ * Idempotent: re-running changes nothing once the fragment matches. The user
+ * field is preserved from the existing fragment (see {@link parseCronUser}),
+ * falling back to `fallbackUser` only when the existing line is unparseable.
+ */
+export function reconcileCron(opts: {
+  binary: string;
+  path?: string;
+  fallbackUser?: string;
+}): ReconcileResult {
+  const path = opts.path ?? CRON_PATH;
+  if (!existsSync(path)) return { status: "absent", path };
+  let user = opts.fallbackUser;
+  try {
+    user = parseCronUser(readFileSync(path, "utf8")) ?? opts.fallbackUser;
+  } catch {
+    // Unreadable — fall back to the provided user and let installCron rewrite.
+  }
+  if (!user) {
+    // No user to render with and none parseable: refuse to write a fragment
+    // with an empty/invalid user field rather than break the cron.
+    throw new Error(
+      `cannot reconcile ${path}: no cron-user parseable from the existing fragment and no fallback user available`,
+    );
+  }
+  const r = installCron({ user, binary: opts.binary, path });
+  return {
+    status: r.status === "installed" ? "reconciled" : "unchanged",
+    path,
+    content: r.content,
+  };
+}


### PR DESCRIPTION
## Problem

`switchroom update` refreshes every host-side surface **except** the hindsight-watch cron. The fragment at `/etc/cron.d/hindsight-watch` pins the binary path, schedule, flags and PATH *when it is armed*, but nothing re-asserted it afterwards — so a definition change, or a binary that moved out from under the fragment, would persist silently until someone re-ran `hindsight-watch --install-cron` by hand. That is the same class of silent host-side drift as the stale-CLI incident.

## Fix

A new `reconcile-hindsight-watch-cron` step in `update`'s **apply-config phase** (right after `apply-config`, where the other generated surfaces are refreshed). It is **repair, not arm**:

- **No-op when absent.** `reconcileCron` does nothing if the fragment does not exist — arming stays the explicit `hindsight-watch --install-cron` opt-in, and `switchroom doctor` already FAILs while unarmed. An unarmed host is **never silently armed** by an update.
- **Idempotent.** Re-running changes nothing once the fragment matches (tmp+rename compare inherited from `installCron`).
- **User preserved.** The operator's chosen `--cron-user` is parsed from the existing line and kept — not overwritten to `root`, which is what the reconciling process's env resolves to under `sudo switchroom update` (and the exact value `--install-cron` refuses).
- **Deferred in hostd-context.** `/etc/cron.d` is on the host, not in the hostd container. Never fatal — a failed reconcile warns and continues; the update itself succeeded.

## Tests (assert outcomes)

`reconcileCron` unit tests:
- rewrites a drifted fragment (stale binary path) **and preserves the user**
- **unchanged** on a second reconcile of a current fragment
- **absent** — writes nothing — when the host was never armed
- `parseCronUser` reads the 6th field of the managed line, ignoring comments/`SHELL=`/`PATH=`

Update-step test: writes a stale fragment, runs the step, asserts it was **rewritten** to the current binary with the user preserved, then runs again and asserts a **byte-identical no-op**; plus the unarmed-host no-write case and the hostd-context deferral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)