### PR TITLE
feat(hindsight): curated observation_scopes by default (opt-out)

### DIFF
--- a/vendor/hindsight-memory/scripts/lib/client.py
+++ b/vendor/hindsight-memory/scripts/lib/client.py
@@ -220,15 +220,18 @@ class HindsightClient:
         tags: Optional[list] = None,
         timeout: int = 15,
         async_processing: bool = True,
-        observation_scopes: Optional[str] = None,
+        observation_scopes: Optional[object] = None,
     ) -> dict:
         """Retain content into a bank's memory.
 
         ``observation_scopes`` is a per-row Hindsight field controlling which
         observation scope consolidation writes this item's observations into.
         ``"shared"`` puts them in ONE global untagged scope instead of a scope
-        per tag. ``None`` (the default) omits the field entirely, so the
-        engine's own default stands and the wire body is byte-identical to a
+        per tag; an explicit ``list[list[str]]`` (e.g. ``[["lesson"]]``, what
+        the ``curated`` strategy emits) declares the exact scope(s) to
+        consolidate into, JSON-serialised onto the wire as a nested array.
+        ``None`` (a falsy value) omits the field entirely, so the engine's own
+        default stands and the wire body is byte-identical to a
         pre-``observation_scopes`` client.
 
         By default posts with ``async=true`` so the server processes extraction
@@ -336,7 +339,7 @@ class HindsightClient:
         tags: Optional[list],
         timeout: int,
         async_processing: bool,
-        observation_scopes: Optional[str] = None,
+        observation_scopes: Optional[object] = None,
     ) -> dict:
         """POST exactly one retain item. Raises on any HTTP/transport error."""
         path = f"/v1/default/banks/{urllib.parse.quote(bank_id, safe='')}/memories"

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -6,7 +6,24 @@ variable overrides. Full config schema matching Openclaw's 30+ options.
 
 import json
 import os
+import re
 import sys
+
+#: Switchroom-local: strategies for the per-row curated observation scope.
+#: ``curated`` (default) strips volatile provenance tags from the consolidation
+#: scope, keeping stable semantic ones; ``shared`` pools every retain into one
+#: bank-wide untagged scope; ``combined`` / ``off`` emit no per-row scope (the
+#: pre-feature engine default). See ``compute_observation_scopes``.
+OBSERVATION_SCOPE_STRATEGIES = ("curated", "shared", "combined", "off")
+
+#: Tag patterns treated as VOLATILE per-session provenance by ``curated``:
+#: ``parent_session:<id>`` and a bare RFC-4122 UUID (what the ``{session_id}``
+#: retain tag resolves to). A tag matching ANY of these is dropped from the
+#: consolidation scope but LEFT on the source fact.
+DEFAULT_VOLATILE_SCOPE_PATTERNS = (
+    r"^parent_session:",
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+)
 
 DEFAULTS = {
     # Recall
@@ -181,6 +198,37 @@ DEFAULTS = {
     # through `defaults.memory.observation_scopes`) via
     # HINDSIGHT_OBSERVATION_SCOPES, exported ONLY when the operator opted in.
     "observationScopes": None,
+    # Switchroom hindsight-leverage — CURATED observation scopes (default ON).
+    # `combined` (the pre-feature engine default) makes consolidation dedup an
+    # observation only against others carrying the IDENTICAL tag set. Because
+    # switchroom stamps volatile per-session provenance on every retain
+    # (`{session_id}` → a bare UUID tag, and `parent_session:<uuid>` /
+    # `sidechain` / `agent_type:*` on sub-agent retains), that turns every
+    # session into its own dedup island — cross-session dedup never happens.
+    #
+    # `curated` (default) strips ONLY the volatile provenance tags
+    # (`observationScopeVolatilePatterns`) from the CONSOLIDATION scope, keeping
+    # the stable semantic ones (`lesson`, `anti-pattern`, `agent_type:*`,
+    # `sidechain`, entities). The stripped tags STAY on the source fact (still
+    # queryable / recall-filterable) — only the observation's dedup scope is
+    # narrowed. Non-empty stable set → the explicit scope `[[stable…]]`; empty
+    # stable set (e.g. a retain tagged only with a session id) → `"shared"`,
+    # one bank-wide untagged scope. This preserves recall tag-weighting on the
+    # observation layer (the kept tags still ride the observation) while giving
+    # cross-session dedup. Docs: https://hindsight.vectorize.io/developer/api/retain
+    # ("shared") and /developer/observations (scope isolation via all_strict).
+    #
+    # Opt-out: set `observationScopeStrategy` to `combined` (or `off`) — both
+    # emit no per-row scope, restoring the exact pre-feature engine default. A
+    # manually-pinned `observationScopes` (memory.observation_scopes) STILL wins
+    # over the strategy, so operators who set `per_tag` / `all_combinations` /
+    # `shared` keep that behaviour unchanged.
+    "observationScopeStrategy": "curated",
+    # Tag patterns treated as VOLATILE (stripped from the curated scope, kept on
+    # the source fact). Defaults: `parent_session:<id>` and a bare RFC-4122
+    # UUID (what `{session_id}` resolves to). Overridable via settings.json /
+    # ~/.hindsight/claude-code.json for a bank with an unusual provenance tag.
+    "observationScopeVolatilePatterns": list(DEFAULT_VOLATILE_SCOPE_PATTERNS),
     # Switchroom hindsight-leverage E2 / PR9 (#398) — lesson & anti-pattern
     # tagging at retain time. When on (default), build_retain_payload scans the
     # formatted transcript slice for explicit lesson / anti-pattern markers and
@@ -333,6 +381,11 @@ ENV_OVERRIDES = {
     # defaults.memory.observation_scopes) ONLY when the operator set it; unset
     # leaves `observationScopes` None and the field off the wire entirely.
     "HINDSIGHT_OBSERVATION_SCOPES": ("observationScopes", str),
+    # Opt-out / override the curated default. `combined` or `off` restore the
+    # pre-feature engine default; `curated` (the shipped default) / `shared`
+    # select the computed strategies. Off-list values fall back to `curated`
+    # (shouted, never raised) — see compute_observation_scopes.
+    "HINDSIGHT_OBSERVATION_SCOPE_STRATEGY": ("observationScopeStrategy", str),
     # Switchroom hindsight-leverage E2 / PR9 (#398) — lesson/anti-pattern tagging
     # + recall demotion toggles and overrides.
     "HINDSIGHT_LESSON_TAGGING": ("lessonTagging", bool),
@@ -511,6 +564,99 @@ def resolve_observation_scopes(config: dict):
     if error:
         raise ValueError(error)
     return value
+
+
+def _volatile_scope_matchers(config: dict):
+    """Compile ``observationScopeVolatilePatterns`` to regexes, skipping bad ones.
+
+    NEVER raises: a malformed pattern is dropped (and shouted about) rather than
+    allowed to kill a retain. Falls back to the built-in defaults when the
+    config value is absent or not a list.
+    """
+    raw = config.get("observationScopeVolatilePatterns")
+    if not isinstance(raw, (list, tuple)):
+        raw = DEFAULT_VOLATILE_SCOPE_PATTERNS
+    matchers = []
+    for pat in raw:
+        if not isinstance(pat, str):
+            continue
+        try:
+            matchers.append(re.compile(pat))
+        except re.error as e:
+            print(
+                f"[Hindsight] observationScopeVolatilePatterns entry {pat!r} is not "
+                f"a valid regex ({e}); ignoring it for scope curation.",
+                file=sys.stderr,
+            )
+    return matchers
+
+
+def _is_volatile_scope_tag(tag: str, matchers) -> bool:
+    return any(m.search(tag) for m in matchers)
+
+
+def compute_observation_scopes(tags, config: dict):
+    """Resolve the per-row ``observation_scopes`` value for one retain.
+
+    Returns ``(value, error)`` — exactly like :func:`classify_observation_scopes`
+    — and MUST NEVER RAISE (a bad config must degrade the SCOPE, never lose the
+    turn; see ``retain.build_retain_payload``). ``value`` is what goes on the
+    wire: ``None`` (omit the field entirely → engine default), a bare string
+    (``"shared"`` / an operator-pinned Hindsight scope), or an explicit
+    ``list[list[str]]`` tag matrix. The wire body is byte-identical to the
+    pre-feature client whenever ``value`` is ``None``.
+
+    Precedence:
+
+    1. A manually-pinned ``observationScopes`` (``memory.observation_scopes``)
+       WINS — its classified value (or its degrade-to-None-with-error on a typo)
+       is returned unchanged, so existing operator overrides keep working.
+    2. Otherwise ``observationScopeStrategy`` decides:
+
+       * ``combined`` / ``off`` → ``None`` (pre-feature engine default; opt-out).
+       * ``shared``             → ``"shared"`` uniformly.
+       * ``curated`` (default)  → strip volatile provenance tags from the scope
+         (keeping them on the source fact); non-empty stable set → ``[[stable…]]``
+         (deterministically sorted), empty stable set → ``"shared"``.
+       * anything else          → treated as ``curated`` and shouted about.
+
+    Docs: https://hindsight.vectorize.io/developer/api/retain (``shared`` == the
+    explicit ``[[]]`` scope; a custom ``list[list[str]]`` is consolidated with
+    ``all_strict`` matching so scopes stay isolated) and /developer/observations.
+    """
+    # 1. Operator-pinned scope wins (back-compat). Only fall through to the
+    #    strategy when observationScopes is genuinely UNSET — a typo'd pin
+    #    degrades to the engine default WITH its error, never silently curated.
+    manual, manual_error = classify_observation_scopes(config)
+    if manual is not None or manual_error is not None:
+        return manual, manual_error
+
+    strategy_raw = config.get("observationScopeStrategy")
+    strategy = strategy_raw.strip().lower() if isinstance(strategy_raw, str) else ""
+    if not strategy:
+        strategy = "curated"
+
+    error = None
+    if strategy not in OBSERVATION_SCOPE_STRATEGIES:
+        error = (
+            f"observationScopeStrategy={strategy_raw!r} is not one of "
+            f"{', '.join(OBSERVATION_SCOPE_STRATEGIES)}; using 'curated'."
+        )
+        strategy = "curated"
+
+    if strategy in ("combined", "off"):
+        return None, error
+    if strategy == "shared":
+        return "shared", error
+
+    # curated
+    matchers = _volatile_scope_matchers(config)
+    stable = sorted(
+        {t for t in (tags or []) if isinstance(t, str) and t and not _is_volatile_scope_tag(t, matchers)}
+    )
+    if stable:
+        return [stable], error
+    return "shared", error
 
 
 def _cast_env(value: str, typ):

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -18,11 +18,16 @@ OBSERVATION_SCOPE_STRATEGIES = ("curated", "shared", "combined", "off")
 
 #: Tag patterns treated as VOLATILE per-session provenance by ``curated``:
 #: ``parent_session:<id>`` and a bare RFC-4122 UUID (what the ``{session_id}``
-#: retain tag resolves to). A tag matching ANY of these is dropped from the
+#: retain tag resolves to on the parent path). The UUID pattern also matches
+#: the sidechain-derived ``<uuid>-sub-<agent_id>`` form, because
+#: ``subagent_retain.py`` sets ``sub_session_id = f"{session_id}-sub-{agent_id}"``
+#: and the ``{session_id}`` retain tag resolves to that — a per-invocation-unique
+#: value that, if left in scope, defeats cross-session dedup on the dominant
+#: (sidechain) observation path. A tag matching ANY of these is dropped from the
 #: consolidation scope but LEFT on the source fact.
 DEFAULT_VOLATILE_SCOPE_PATTERNS = (
     r"^parent_session:",
-    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(-sub-.+)?$",
 )
 
 DEFAULTS = {

--- a/vendor/hindsight-memory/scripts/retain.py
+++ b/vendor/hindsight-memory/scripts/retain.py
@@ -28,7 +28,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from lib import watermark
 from lib.bank import derive_bank_id, ensure_bank_mission
 from lib.client import HindsightClient
-from lib.config import classify_observation_scopes, debug_log, load_config
+from lib.config import compute_observation_scopes, debug_log, load_config
 from lib.content import (
     prepare_retention_transcript,
     slice_last_turns_by_user_boundary,
@@ -267,13 +267,13 @@ def build_retain_payload(
     Returns ``{payload, document_id, message_count, last_uuid, ordered_uuids,
     transcript}`` or ``None`` when the slice formats to nothing.
 
-    NEVER raises on a bad ``observationScopes``. Every retain producer builds
-    its payload here, so this seam sees the typo — but it is also the seam the
-    memory itself is made at, and a config typo must not be able to destroy
-    one. An off-list value is dropped from the payload (so the engine's own
-    default stands, exactly as before this feature existed) and shouted about
-    on stderr; the memory is still built, still POSTed, still queued on
-    failure. See ``lib.config.classify_observation_scopes``.
+    NEVER raises on a bad ``observationScopes`` / ``observationScopeStrategy``.
+    Every retain producer builds its payload here, so this seam sees the typo —
+    but it is also the seam the memory itself is made at, and a config typo must
+    not be able to destroy one. An off-list value degrades the SCOPE (the
+    engine's own default stands for a bad pin; ``curated`` stands for a bad
+    strategy) and is shouted about on stderr; the memory is still built, still
+    POSTed, still queued on failure. See ``lib.config.compute_observation_scopes``.
     """
     retain_roles = config.get("retainRoles", ["user", "assistant"])
     include_tool_calls = config.get("retainToolCalls", True)
@@ -367,12 +367,16 @@ def build_retain_payload(
     except Exception:
         pass
 
-    # Per-row observation scope (switchroom). None unless the operator set
-    # memory.observation_scopes — and a None is dropped at the wire by
-    # HindsightClient._retain_one, so the default request body is unchanged.
-    # Carried ON THE PAYLOAD so it survives the pending-retains queue: a retain
-    # that fails and drains hours later must land in the SAME scope it would
-    # have landed in inline.
+    # Per-row observation scope (switchroom). Default `curated`: volatile
+    # per-session provenance tags are stripped from the CONSOLIDATION scope
+    # (kept on the source fact) so observations dedup across sessions instead of
+    # per-session — a non-empty stable tag set yields an explicit `[[stable…]]`
+    # scope, an all-volatile/empty set yields `"shared"`. A None (opt-out via
+    # observationScopeStrategy=combined/off, or a manual observationScopes typo)
+    # is dropped at the wire by HindsightClient._retain_one, so that request
+    # body is byte-identical to the pre-feature default. Carried ON THE PAYLOAD
+    # so it survives the pending-retains queue: a retain that fails and drains
+    # hours later must land in the SAME scope it would have landed in inline.
     #
     # CLASSIFIED, NOT VALIDATED. This is the one seam every retain producer
     # funnels through, which makes it the tempting place to reject a typo — and
@@ -388,7 +392,7 @@ def build_retain_payload(
     # So a bad value degrades to the PRE-FEATURE behaviour (field omitted, the
     # engine's own default scope stands) and is shouted about on stderr. Wrong
     # scope is recoverable; a lost turn is not.
-    scope, scope_error = classify_observation_scopes(config)
+    scope, scope_error = compute_observation_scopes(tags, config)
     if scope_error:
         print(
             f"[Hindsight] observation_scopes IGNORED for this retain: {scope_error} "

--- a/vendor/hindsight-memory/scripts/tests/test_backfill.py
+++ b/vendor/hindsight-memory/scripts/tests/test_backfill.py
@@ -172,11 +172,24 @@ class TestBackfill(BackfillTestBase):
         self.assertTrue(all(async_flag is False for _, async_flag in self.daemon.posts))
 
     # -- switchroom: per-row observation scope on the backfill path ---------
-    def test_backfill_omits_the_scope_when_unconfigured(self):
+    def test_backfill_omits_the_scope_when_opted_out(self):
+        # The curated default now emits a scope on every path; the opt-out
+        # (observationScopeStrategy=combined) must stay byte-identical to the
+        # pre-feature body — no scope on the wire, engine default in force.
+        os.environ["HINDSIGHT_OBSERVATION_SCOPE_STRATEGY"] = "combined"
+        self.addCleanup(os.environ.pop, "HINDSIGHT_OBSERVATION_SCOPE_STRATEGY", None)
         self._transcript("clerk", "sess-plain", 4)
         bf.Backfill(self._config(), commit=True, delay_ms=0).run()
         self.assertTrue(self.daemon.observation_scopes_seen)
         self.assertTrue(all(s is None for s in self.daemon.observation_scopes_seen))
+
+    def test_backfill_curates_the_scope_by_default(self):
+        # Default ON: every recovered slice carries a curated scope; a miss here
+        # would silently drop the backfill path back to the pre-feature default.
+        self._transcript("clerk", "sess-plain", 4)
+        bf.Backfill(self._config(), commit=True, delay_ms=0).run()
+        self.assertTrue(self.daemon.observation_scopes_seen)
+        self.assertTrue(all(s is not None for s in self.daemon.observation_scopes_seen))
 
     def test_backfill_posts_the_configured_scope(self):
         # The backfill enumerates its own retain kwargs; a miss here would

--- a/vendor/hindsight-memory/scripts/tests/test_observation_scopes.py
+++ b/vendor/hindsight-memory/scripts/tests/test_observation_scopes.py
@@ -393,6 +393,19 @@ class ComputeCuratedScopes(unittest.TestCase):
         self.assertIsNone(err)
         self.assertEqual(value, [["lesson"]])
 
+    def test_curated_strips_sidechain_sub_session_tag(self):
+        # The dominant observation path: subagent_retain sets
+        # `sub_session_id = f"{session_id}-sub-{agent_id}"`, and `retainTags:
+        # ["{session_id}"]` resolves to `<parent-uuid>-sub-<agent_id>`. That is
+        # per-invocation-unique, so if it survives into the scope every sidechain
+        # retain gets its own island and never dedups. It must be treated as
+        # volatile (like the bare UUID it derives from) and stripped, while the
+        # stable semantic tags stay in scope.
+        sub_tag = f"{self._UUID}-sub-af5fba739c0ee6b38"
+        value, err = self._compute([sub_tag, "sidechain", "agent_type:worker"])
+        self.assertIsNone(err)
+        self.assertEqual(value, [["agent_type:worker", "sidechain"]])
+
     def test_curated_all_volatile_falls_back_to_shared(self):
         # A retain tagged ONLY with volatile provenance has no stable scope, so
         # it pools into the one bank-wide untagged scope instead of an island.

--- a/vendor/hindsight-memory/scripts/tests/test_observation_scopes.py
+++ b/vendor/hindsight-memory/scripts/tests/test_observation_scopes.py
@@ -38,6 +38,8 @@ import retain  # noqa: E402
 from lib.client import HindsightClient  # noqa: E402
 from lib.config import (  # noqa: E402
     OBSERVATION_SCOPES_VALUES,
+    OBSERVATION_SCOPE_STRATEGIES,
+    compute_observation_scopes,
     load_config,
     resolve_observation_scopes,
 )
@@ -134,6 +136,18 @@ class ConfigResolution(unittest.TestCase):
                              clear=True):
             self.assertEqual(load_config().get("observationScopes"), "shared")
 
+    def test_strategy_default_is_curated(self):
+        # switchroom ships curated ON out of the box — a fresh install with no
+        # settings.json key and no env override still gets the curated scope.
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(load_config().get("observationScopeStrategy"), "curated")
+
+    def test_strategy_env_override_opts_out(self):
+        with mock.patch.dict(
+            os.environ, {"HINDSIGHT_OBSERVATION_SCOPE_STRATEGY": "combined"}, clear=True
+        ):
+            self.assertEqual(load_config().get("observationScopeStrategy"), "combined")
+
 
 class PayloadBuild(unittest.TestCase):
     """``build_retain_payload`` is the single producer for every retain path."""
@@ -147,10 +161,33 @@ class PayloadBuild(unittest.TestCase):
             bank_id="bank", api_url="http://fake", api_token=None,
         )["payload"]
 
-    def test_payload_carries_none_when_unconfigured(self):
-        self.assertIsNone(self._build({})["observation_scopes"])
+    def test_payload_omits_scope_when_opted_out(self):
+        # Opt-out (strategy=combined) is byte-identical to the pre-feature body:
+        # no scope on the payload, so the engine default stands.
+        self.assertIsNone(
+            self._build({"observationScopeStrategy": "combined"})["observation_scopes"]
+        )
 
-    def test_payload_carries_the_configured_scope(self):
+    def test_payload_curates_the_scope_by_default(self):
+        # No strategy key at all → the shipped default (curated) fires, so a
+        # scope IS carried. A retain carrying only volatile/no stable tags
+        # curates down to the bank-wide "shared" scope.
+        self.assertEqual(self._build({})["observation_scopes"], "shared")
+
+    def test_payload_curates_stable_tags_into_an_explicit_scope(self):
+        # A stable semantic tag survives onto the consolidation scope as an
+        # explicit list-of-lists, while a volatile session-id tag is stripped.
+        payload = self._build(
+            {"retainTags": ["team:acme", "{session_id}"]}
+        )
+        # {session_id} → "sess" (not a UUID / parent_session:*), so it is NOT
+        # volatile here and rides the scope alongside the stable tag.
+        self.assertEqual(
+            sorted(payload["observation_scopes"][0]), ["sess", "team:acme"]
+        )
+
+    def test_payload_carries_the_manually_pinned_scope(self):
+        # A hand-pinned observationScopes still wins over the strategy.
         self.assertEqual(
             self._build({"observationScopes": "shared"})["observation_scopes"],
             "shared",
@@ -204,6 +241,16 @@ class DrainOfQueuedEntries(unittest.TestCase):
         entry = json.loads(json.dumps(dict(self._LEGACY, observation_scopes="shared")))
         drain_pending._retry_one(entry, timeout=15)
         self.assertEqual(self.calls[0]["observation_scopes"], "shared")
+
+    def test_curated_list_scope_survives_the_queue_round_trip(self):
+        # The curated default emits a list[list[str]] scope. A retain that fails
+        # inline and drains hours later must land in the SAME curated scope, so
+        # the list value has to survive JSON on disk and reach client.retain
+        # intact — otherwise a retried turn shards away from its inline siblings.
+        scope = [["agent_type:worker", "sidechain"]]
+        entry = json.loads(json.dumps(dict(self._LEGACY, observation_scopes=scope)))
+        drain_pending._retry_one(entry, timeout=15)
+        self.assertEqual(self.calls[0]["observation_scopes"], scope)
 
 
 class ValueValidation(unittest.TestCase):
@@ -319,6 +366,135 @@ class ValueValidation(unittest.TestCase):
                              clear=True):
             with self.assertRaises(ValueError):
                 resolve_observation_scopes(load_config())
+
+
+class ComputeCuratedScopes(unittest.TestCase):
+    """``compute_observation_scopes`` — the curated-default resolver, asserted as
+    exact (input tags, config) → emitted ``observation_scopes`` value mappings.
+
+    This is the load-bearing new behaviour: which tags survive onto the
+    consolidation scope and which are stripped as volatile provenance. The
+    function NEVER raises — a bad config degrades the scope, never the turn.
+    """
+
+    _UUID = "0291c461-864d-4284-b2b3-3fba9bf3142c"
+
+    def _compute(self, tags, **config):
+        return compute_observation_scopes(tags, config)
+
+    # --- default (curated) ------------------------------------------------
+    def test_curated_strips_parent_session_keeps_stable(self):
+        value, err = self._compute(["parent_session:abc", "sidechain", "agent_type:worker"])
+        self.assertIsNone(err)
+        self.assertEqual(value, [["agent_type:worker", "sidechain"]])  # sorted, stripped
+
+    def test_curated_strips_bare_uuid_session_tag(self):
+        value, err = self._compute([self._UUID, "lesson"])
+        self.assertIsNone(err)
+        self.assertEqual(value, [["lesson"]])
+
+    def test_curated_all_volatile_falls_back_to_shared(self):
+        # A retain tagged ONLY with volatile provenance has no stable scope, so
+        # it pools into the one bank-wide untagged scope instead of an island.
+        value, err = self._compute([self._UUID, "parent_session:xyz"])
+        self.assertIsNone(err)
+        self.assertEqual(value, "shared")
+
+    def test_curated_no_tags_is_shared(self):
+        self.assertEqual(self._compute([])[0], "shared")
+        self.assertEqual(self._compute(None)[0], "shared")
+
+    def test_curated_scope_is_deterministically_sorted(self):
+        # Same tag set in any order → identical scope (so it dedups, not shards).
+        a, _ = self._compute(["z:1", "a:2", "m:3"])
+        b, _ = self._compute(["m:3", "z:1", "a:2"])
+        self.assertEqual(a, b)
+        self.assertEqual(a, [["a:2", "m:3", "z:1"]])
+
+    def test_curated_dedups_repeated_tags(self):
+        value, _ = self._compute(["lesson", "lesson", "sidechain"])
+        self.assertEqual(value, [["lesson", "sidechain"]])
+
+    # --- opt-out ----------------------------------------------------------
+    def test_combined_emits_no_scope(self):
+        self.assertEqual(
+            self._compute(["lesson"], observationScopeStrategy="combined"), (None, None)
+        )
+
+    def test_off_emits_no_scope(self):
+        self.assertEqual(
+            self._compute(["lesson"], observationScopeStrategy="off"), (None, None)
+        )
+
+    def test_shared_strategy_is_uniform(self):
+        value, err = self._compute(["lesson", "sidechain"], observationScopeStrategy="shared")
+        self.assertIsNone(err)
+        self.assertEqual(value, "shared")
+
+    # --- precedence / robustness -----------------------------------------
+    def test_manual_pin_wins_over_strategy(self):
+        # An operator who pinned per_tag keeps it even though curated is default.
+        value, err = self._compute(
+            ["lesson"], observationScopes="per_tag", observationScopeStrategy="curated"
+        )
+        self.assertIsNone(err)
+        self.assertEqual(value, "per_tag")
+
+    def test_manual_pin_typo_degrades_to_none_with_error_not_curated(self):
+        # A typo'd pin must NOT silently fall through to curated — it degrades to
+        # the engine default (None) and carries an error, exactly like the
+        # pre-strategy behaviour, so the misconfiguration stays visible.
+        value, err = self._compute(["lesson"], observationScopes="shred")
+        self.assertIsNone(value)
+        self.assertIsNotNone(err)
+        self.assertIn("shred", err)
+
+    def test_unknown_strategy_degrades_to_curated_with_error(self):
+        value, err = self._compute(["lesson"], observationScopeStrategy="curatd")
+        self.assertEqual(value, [["lesson"]])
+        self.assertIsNotNone(err)
+        self.assertIn("curatd", err)
+        for s in OBSERVATION_SCOPE_STRATEGIES:
+            self.assertIn(s, err)
+
+    def test_empty_strategy_string_is_curated(self):
+        # An empty export hands authority back to the default, same idiom as
+        # the bare-string scope path.
+        self.assertEqual(self._compute(["lesson"], observationScopeStrategy="")[0], [["lesson"]])
+        self.assertEqual(self._compute(["lesson"], observationScopeStrategy="   ")[0], [["lesson"]])
+
+    def test_strategy_is_case_insensitive(self):
+        self.assertEqual(
+            self._compute(["lesson"], observationScopeStrategy="COMBINED"), (None, None)
+        )
+
+    def test_custom_volatile_patterns_override_defaults(self):
+        # An operator can declare a bank-specific provenance tag volatile.
+        value, err = self._compute(
+            ["run:42", "lesson"],
+            observationScopeVolatilePatterns=[r"^run:"],
+        )
+        self.assertIsNone(err)
+        self.assertEqual(value, [["lesson"]])
+
+    def test_bad_volatile_pattern_is_skipped_not_fatal(self):
+        # A malformed regex must not kill the retain — it is dropped and the
+        # remaining (valid) matchers still curate.
+        err_out = io.StringIO()
+        with contextlib.redirect_stderr(err_out):
+            value, err = self._compute(
+                [self._UUID, "lesson"],
+                observationScopeVolatilePatterns=["(", r"^parent_session:",
+                                                   r"^[0-9a-fA-F-]{36}$"],
+            )
+        self.assertIsNone(err)
+        self.assertEqual(value, [["lesson"]])
+
+    def test_never_raises_on_junk_tags(self):
+        # Non-string tags in the list must be ignored, not explode.
+        value, err = self._compute(["lesson", None, 42, "", "sidechain"])
+        self.assertIsNone(err)
+        self.assertEqual(value, [["lesson", "sidechain"]])
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/vendor/hindsight-memory/scripts/tests/test_reconcile_durability.py
+++ b/vendor/hindsight-memory/scripts/tests/test_reconcile_durability.py
@@ -414,14 +414,30 @@ class TestObservationScopes(DurabilityTestBase):
         os.environ["HINDSIGHT_OBSERVATION_SCOPES"] = value
         self.addCleanup(os.environ.pop, "HINDSIGHT_OBSERVATION_SCOPES", None)
 
-    # -- default: nothing changes -------------------------------------------
-    def test_unconfigured_stop_retain_posts_no_scope(self):
+    def _set_strategy(self, value):
+        os.environ["HINDSIGHT_OBSERVATION_SCOPE_STRATEGY"] = value
+        self.addCleanup(os.environ.pop, "HINDSIGHT_OBSERVATION_SCOPE_STRATEGY", None)
+
+    # -- opt-out: byte-identical to pre-feature -----------------------------
+    def test_opted_out_stop_retain_posts_no_scope(self):
+        # observationScopeStrategy=combined restores the pre-feature body: no
+        # scope on the wire so the engine default stands.
+        self._set_strategy("combined")
         hook = self._hook("plainsess")
         with mock.patch("retain.increment_turn_count", return_value=3), \
              mock.patch("sys.stdin", _stdin(hook)):
             retain.main()
         self.assertTrue(self.daemon.observation_scopes_seen)
         self.assertTrue(all(s is None for s in self.daemon.observation_scopes_seen))
+
+    # -- default ON: a curated scope reaches the Stop-hook POST --------------
+    def test_default_stop_retain_posts_a_curated_scope(self):
+        hook = self._hook("plainsess")
+        with mock.patch("retain.increment_turn_count", return_value=3), \
+             mock.patch("sys.stdin", _stdin(hook)):
+            retain.main()
+        self.assertTrue(self.daemon.observation_scopes_seen)
+        self.assertTrue(all(s is not None for s in self.daemon.observation_scopes_seen))
 
     # -- Stop hook (retain.py) ----------------------------------------------
     def test_configured_stop_retain_posts_the_scope(self):

--- a/vendor/hindsight-memory/scripts/tests/test_subagent_retain.py
+++ b/vendor/hindsight-memory/scripts/tests/test_subagent_retain.py
@@ -339,9 +339,31 @@ class RunSubagentRetain(unittest.TestCase):
         self.assertEqual(captured["context"], "claude-code-sidechain")
         self.assertEqual(captured["metadata"]["parent_session_id"], "parentsess")
 
-    def test_sidechain_retain_omits_the_scope_when_unconfigured(self):
-        # switchroom — default behaviour must be byte-identical: the sidechain
-        # POST carries no scope, so the engine default stands.
+    def test_sidechain_retain_omits_the_scope_when_opted_out(self):
+        # switchroom — opt-out (observationScopeStrategy=combined) must be
+        # byte-identical to the pre-feature body: the sidechain POST carries no
+        # scope, so the engine default stands.
+        with tempfile.TemporaryDirectory() as d:
+            sc = os.path.join(d, "agent-af5.jsonl")
+            _write_sidechain(sc, 8, chars_per_msg=400)
+            hook_input = {
+                "session_id": "parentsess",
+                "agent_id": "af5",
+                "agent_transcript_path": sc,
+                "transcript_path": os.path.join(d, "parentsess.jsonl"),
+                "cwd": d,
+            }
+            result, captured = self._run(
+                hook_input, config_extra={"observationScopeStrategy": "combined"}
+            )
+        self.assertEqual(result["status"], "ok")
+        self.assertIsNone(captured["observation_scopes"])
+
+    def test_sidechain_retain_curates_the_scope_by_default(self):
+        # switchroom default ON: the volatile `parent_session:*` tag is STRIPPED
+        # from the consolidation scope so sidechain observations dedup across
+        # parent sessions, while the stable `sidechain` tag is KEPT on the scope
+        # (so recall's sidechain:0.8 demotion still fires on the observation).
         with tempfile.TemporaryDirectory() as d:
             sc = os.path.join(d, "agent-af5.jsonl")
             _write_sidechain(sc, 8, chars_per_msg=400)
@@ -354,7 +376,13 @@ class RunSubagentRetain(unittest.TestCase):
             }
             result, captured = self._run(hook_input)
         self.assertEqual(result["status"], "ok")
-        self.assertIsNone(captured["observation_scopes"])
+        scope = captured["observation_scopes"]
+        self.assertIsInstance(scope, list)
+        scope_tags = {t for group in scope for t in group}
+        self.assertIn("sidechain", scope_tags)
+        self.assertNotIn("parent_session:parentsess", scope_tags)
+        # The source-fact tags are untouched — the stripped tag stays queryable.
+        self.assertIn("parent_session:parentsess", captured["tags"])
 
     def test_sidechain_retain_posts_the_configured_scope(self):
         # switchroom — sidechain retains are their own hand-enumerated kwarg

--- a/vendor/hindsight-memory/scripts/tests/test_subagent_retain.py
+++ b/vendor/hindsight-memory/scripts/tests/test_subagent_retain.py
@@ -360,29 +360,54 @@ class RunSubagentRetain(unittest.TestCase):
         self.assertIsNone(captured["observation_scopes"])
 
     def test_sidechain_retain_curates_the_scope_by_default(self):
-        # switchroom default ON: the volatile `parent_session:*` tag is STRIPPED
-        # from the consolidation scope so sidechain observations dedup across
-        # parent sessions, while the stable `sidechain` tag is KEPT on the scope
-        # (so recall's sidechain:0.8 demotion still fires on the observation).
+        # switchroom default ON: every VOLATILE per-session provenance tag is
+        # STRIPPED from the consolidation scope so sidechain observations dedup
+        # across parent sessions, while the stable semantic tags (`sidechain`,
+        # `agent_type:*`) are KEPT on the scope (so recall's sidechain:0.8
+        # demotion still fires on the observation).
+        #
+        # Two volatile tags must be stripped, and the second is the one the
+        # Fable review caught leaking:
+        #   1. `parent_session:<uuid>` — the explicit parent link.
+        #   2. `<uuid>-sub-<agent_id>` — what `retainTags: ["{session_id}"]`
+        #      resolves to on the sidechain path, since subagent_retain sets
+        #      `sub_session_id = f"{session_id}-sub-{agent_id}"`. This is
+        #      per-invocation-unique; if it survives into the scope, sidechain
+        #      retains (the dominant observation volume) never dedup and the
+        #      feature silently fails on its primary path.
+        #
+        # The session_id is a real RFC-4122 UUID here (not a synthetic slug)
+        # precisely because the strip is anchored on the UUID shape — a slug
+        # would not exercise the volatile pattern and the test would pass on the
+        # pre-fix code. Assert EXACT scope equality so the test fails on the bug
+        # it guards, not merely on a membership check.
+        session_id = "a1b2c3d4-e5f6-4a8b-9c0d-1e2f3a4b5c6d"
         with tempfile.TemporaryDirectory() as d:
             sc = os.path.join(d, "agent-af5.jsonl")
             _write_sidechain(sc, 8, chars_per_msg=400)
             hook_input = {
-                "session_id": "parentsess",
+                "session_id": session_id,
                 "agent_id": "af5",
+                "agent_type": "worker",
                 "agent_transcript_path": sc,
-                "transcript_path": os.path.join(d, "parentsess.jsonl"),
+                "transcript_path": os.path.join(d, f"{session_id}.jsonl"),
                 "cwd": d,
             }
             result, captured = self._run(hook_input)
         self.assertEqual(result["status"], "ok")
         scope = captured["observation_scopes"]
-        self.assertIsInstance(scope, list)
+        # EXACT curated scope: only the stable semantic tags survive, sorted.
+        self.assertEqual(scope, [["agent_type:worker", "sidechain"]])
+
+        # And the specific volatile tags are provably gone from the scope.
         scope_tags = {t for group in scope for t in group}
-        self.assertIn("sidechain", scope_tags)
-        self.assertNotIn("parent_session:parentsess", scope_tags)
-        # The source-fact tags are untouched — the stripped tag stays queryable.
-        self.assertIn("parent_session:parentsess", captured["tags"])
+        sub_session_tag = f"{session_id}-sub-af5"
+        self.assertNotIn(f"parent_session:{session_id}", scope_tags)
+        self.assertNotIn(sub_session_tag, scope_tags)
+
+        # The source-fact tags are untouched — the stripped tags stay queryable.
+        self.assertIn(f"parent_session:{session_id}", captured["tags"])
+        self.assertIn(sub_session_tag, captured["tags"])
 
     def test_sidechain_retain_posts_the_configured_scope(self):
         # switchroom — sidechain retains are their own hand-enumerated kwarg


### PR DESCRIPTION
## Problem

switchroom stamps volatile per-session provenance on every retain — the `{session_id}` retain tag resolves to a **bare UUID**, and sub-agent retains add `parent_session:<uuid>`. With Hindsight's engine default (`combined`), consolidation only dedups an observation against others carrying the **identical tag set**, so those volatile tags make **every session its own dedup island** and cross-session dedup never happens.

Measured on the live `overlord` bank: **194,179** observations pocketed across **4,308** per-session scopes — **99.5%** one-per-session, i.e. no dedup.

## Change — curated per-row `observation_scopes`, ON by default for any install

- **`compute_observation_scopes(tags, config)`** (`lib/config.py`) strips volatile provenance tags (`parent_session:*` and bare RFC-4122 UUIDs, configurable via `observationScopeVolatilePatterns`) from the **consolidation scope** while leaving them **on the source fact** (still queryable / recall-filterable). Non-empty stable set → explicit `[[stable…]]`; all-volatile/empty → `"shared"`. Stable semantic tags (`lesson`, `sidechain`, `agent_type:*`, entities) ride the scope, so recall tag-weighting (e.g. `sidechain:0.8`) still fires on the observation layer.
- **`observationScopeStrategy`** config: `curated` (default), `shared`, `combined`/`off` (opt-out → pre-feature engine default, field omitted from the wire). Env `HINDSIGHT_OBSERVATION_SCOPE_STRATEGY`. Default lives in the plugin `DEFAULTS`, so **every fresh install gets `curated`** with no settings.json/scaffold change.
- **Precedence:** a manually pinned `observationScopes` (`memory.observation_scopes`) still **wins**, so existing operator overrides are unchanged.
- **Never raises:** a bad strategy degrades to `curated`, a bad pin degrades to the engine default — both shouted on stderr. A config typo can never lose a turn (the #3244 data-loss shape).

## Durability

The scope is carried on the **payload** and threaded through every retain producer (Stop, sub-agent, reconcile, backfill) and the **pending-retry drain**, so a retain that fails inline and drains hours later lands in the same scope — including the new `list[list[str]]` value across the queue's JSON round-trip.

## Tests

Assert **outcomes**, not code paths: exact `(input tags, config)` → emitted `observation_scopes` value; default-ON; opt-out omission; manual-pin precedence; unknown-strategy/typo degradation; custom & malformed volatile patterns; and list-scope retry-replay threading through the drain queue.

- `python3 -m unittest discover tests/` → **968 passed**
- `python3 -m pytest tests/ -q` → **968 passed, 566 subtests**

## Rollout / opt-out

Default `curated` (forward-fix only; the ~30h historical backfill is deferred by decision). Opt out per-agent via `HINDSIGHT_OBSERVATION_SCOPE_STRATEGY=combined` (or a `memory.observation_scopes` pin).

**Follow-up (not in this PR):** a native `memory.observation_scope_strategy` key in `switchroom.yaml` → env wiring in `start.sh`/`handoff.ts`, so operators can opt out via yaml without the raw env var. Today the yaml opt-out path is the existing `memory.observation_scopes: combined` pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)