### PR TITLE
feat(update): install the self-heal systemd timer so a release converges the host

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ operators jump to **Operating**; contributors and reviewers use
 | [scheduling.md](scheduling.md) | Scheduled tasks via the in-container scheduler sibling. |
 | [crash-reports.md](crash-reports.md) | What the watchdog records when it kills an agent. |
 | [operators/stale-pin-cleanup.md](operators/stale-pin-cleanup.md) | Clearing orphaned bot pins the automatic sweep deliberately cannot touch. |
-| [operators/host-cli-self-heal.md](operators/host-cli-self-heal.md) | systemd timer that self-heals the host CLI binary so it can't silently trail the fleet. |
+| [operators/host-cli-self-heal.md](operators/host-cli-self-heal.md) | systemd timer that self-heals the host CLI binary so it can't silently trail the fleet — installed automatically by `switchroom update` on systemd hosts. |
 | [status-ask-cause-classes.md](status-ask-cause-classes.md) | Cause-class catalog for driving the status-ask rate to zero. |
 | [session-optimization.md](session-optimization.md) | Managing context/tokens in long-running agents. |
 | [sub-agents.md](sub-agents.md) | Sub-agent delegation ("Opus plans, Sonnet implements"). |

--- a/docs/operators/host-cli-self-heal.md
+++ b/docs/operators/host-cli-self-heal.md
@@ -13,6 +13,17 @@ every update — but "loud" still needs a human to look. This timer makes the ho
 binary **self-heal** without one: it re-runs `switchroom update --skip-images` on
 a cadence, so a behind host CLI is corrected within one interval.
 
+> **Installed automatically.** As of the change that shipped this doc's timer,
+> `switchroom update` **installs and enables this timer for you** whenever it
+> runs on a **systemd-booted host with root privilege and a resolvable non-root
+> operator user** (the `install-self-heal-timer` step). So one host-context
+> `switchroom update` is enough to arm perpetual self-heal — you do not need to
+> run the manual steps below. They are kept as the **fallback** for a host
+> *without* systemd, without root, or where no operator user resolves: on such a
+> host the step writes nothing, never fails the update, and prints these exact
+> unit files plus the two `systemctl` commands so you can install it by hand.
+> Re-running `switchroom update` once the timer exists is a byte-identical no-op.
+
 ## What the tick does (and does not do)
 
 `ExecStart` runs `switchroom update --skip-images`:
@@ -102,7 +113,11 @@ WantedBy=timers.target
 > is a fine, lighter alternative; anything much longer re-opens the multi-hour
 > drift window this unit exists to close.
 
-## Install and enable
+## Install and enable (manual fallback)
+
+> You only need this on a host where `switchroom update` **could not** install
+> the timer itself (no systemd, no root, or no resolvable operator user). On a
+> normal systemd host the `install-self-heal-timer` step already did all of this.
 
 ```bash
 # 1. Drop the two unit files in place (edit OPERATOR / the binary path first).
@@ -135,10 +150,18 @@ sudo rm /etc/systemd/system/switchroom-self-heal.{service,timer}
 sudo systemctl daemon-reload
 ```
 
-## Why this is not wired into `install.sh`
+## Where the auto-install lives (and why not `install.sh`)
+
+The auto-install is a step in **`switchroom update`** (`install-self-heal-timer`,
+right after the `hindsight-watch` cron reconcile), **not** in `install.sh`.
 
 `install.sh` is a `curl | sh` one-shot that must work on hosts **without**
-systemd or root (it falls back to `~/.local/bin`). Auto-installing and enabling a
-system-wide timer from it would fail or surprise those hosts, and it cannot know
-the operator username or the intended cadence. So this stays an explicit,
-operator-installed artifact rather than an installer side effect.
+systemd or root (it falls back to `~/.local/bin`), and it cannot know the
+operator username — so arming a system-wide timer from it would fail or surprise
+those hosts. `switchroom update` is the right seam: it already self-elevates,
+already resolves the operator, and is the host-context path that converges the
+rest of the host. The step is guarded (systemd-booted **and** root **and** a
+non-root operator user) and degrades to the manual fallback above on any host
+that fails a guard, so it is safe to run unconditionally. It is deferred in
+hostd-context because `/etc/systemd/system` lives on the host, not inside the
+hostd container.

--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -55,6 +55,7 @@ describe("planUpdate", () => {
         "pull-images",
         "apply-config",
         "reconcile-hindsight-watch-cron",
+        "install-self-heal-timer",
         "refresh-hostd",
         "refresh-web",
         "refresh-hindsight",
@@ -128,6 +129,88 @@ describe("planUpdate", () => {
     });
 
     it("is deferred (skipReason) in hostd-context — /etc/cron.d is on the host", () => {
+      expect(stepFor({ hostdContext: true }).skipReason).toMatch(/hostd-context/);
+      expect(stepFor({ hostdContext: false }).skipReason).toBeUndefined();
+    });
+  });
+
+  describe("install-self-heal-timer step (#host-cli-converge)", () => {
+    function stepFor(opts: Parameters<typeof planUpdate>[0]) {
+      return planUpdate({ composePath: "unused", ...opts }).find(
+        (s) => s.name === "install-self-heal-timer",
+      )!;
+    }
+
+    it("systemd present + privileged: writes both units (non-root User=) and enables the timer", () => {
+      const tmp = mkdtempSync(join(tmpdir(), "update-selfheal-"));
+      try {
+        const servicePath = join(tmp, "switchroom-self-heal.service");
+        const timerPath = join(tmp, "switchroom-self-heal.timer");
+        const calls: string[][] = [];
+        const step = stepFor({
+          selfHealTimerDeps: {
+            env: { SUDO_USER: "alice", SWITCHROOM_BINARY: "/usr/local/bin/switchroom" },
+            systemdBooted: () => true,
+            geteuid: () => 0,
+            homeForUser: () => "/home/alice",
+            runner: (cmd, args) => {
+              calls.push([cmd, ...args]);
+              return { status: 0 };
+            },
+            servicePath,
+            timerPath,
+          },
+        });
+        step.run();
+
+        const svc = readFileSync(servicePath, "utf8");
+        expect(svc).toContain("User=alice");
+        expect(svc).not.toContain("User=root");
+        expect(svc).toContain("ExecStart=/usr/local/bin/switchroom update --skip-images");
+        expect(readFileSync(timerPath, "utf8")).toContain("OnUnitActiveSec=30min");
+        expect(calls).toEqual([
+          ["systemctl", "daemon-reload"],
+          ["systemctl", "enable", "--now", "switchroom-self-heal.timer"],
+        ]);
+
+        // Second run: byte-identical no-op — units unchanged, still idempotently enabled.
+        const before = readFileSync(servicePath, "utf8");
+        step.run();
+        expect(readFileSync(servicePath, "utf8")).toBe(before);
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it("no systemd: writes NOTHING and does not throw (manual fallback emitted)", () => {
+      const tmp = mkdtempSync(join(tmpdir(), "update-selfheal-nosd-"));
+      try {
+        const servicePath = join(tmp, "switchroom-self-heal.service");
+        const timerPath = join(tmp, "switchroom-self-heal.timer");
+        const calls: string[][] = [];
+        const step = stepFor({
+          selfHealTimerDeps: {
+            env: { SUDO_USER: "alice", SWITCHROOM_BINARY: "/usr/local/bin/switchroom" },
+            systemdBooted: () => false,
+            geteuid: () => 0,
+            runner: (cmd, args) => {
+              calls.push([cmd, ...args]);
+              return { status: 0 };
+            },
+            servicePath,
+            timerPath,
+          },
+        });
+        expect(() => step.run()).not.toThrow();
+        expect(existsSync(servicePath)).toBe(false);
+        expect(existsSync(timerPath)).toBe(false);
+        expect(calls).toEqual([]);
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it("is deferred (skipReason) in hostd-context — /etc/systemd/system is on the host", () => {
       expect(stepFor({ hostdContext: true }).skipReason).toMatch(/hostd-context/);
       expect(stepFor({ hostdContext: false }).skipReason).toBeUndefined();
     });
@@ -337,6 +420,7 @@ describe("planUpdate", () => {
         "rebuild-source",
         "apply-config",
         "reconcile-hindsight-watch-cron",
+        "install-self-heal-timer",
         "refresh-hostd",
         "refresh-web",
         "refresh-hindsight",

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -71,6 +71,10 @@ import {
   type ExecFn,
 } from "./component-versions.js";
 import { reconcileCron } from "../hindsight-watch/install-cron.js";
+import {
+  installSelfHealTimer,
+  type InstallTimerDeps,
+} from "../host-cli-self-heal/install-timer.js";
 
 /**
  * Default durable-pin persister for `update --pin`: comment-preserving,
@@ -215,6 +219,10 @@ interface UpdateOptions {
    *  `reconcile-hindsight-watch-cron` step reconciles (default: the real
    *  `CRON_PATH`). Lets the step be exercised against a temp file. */
   watchCronPath?: string;
+  /** Test seam — override the self-heal timer install for the
+   *  `install-self-heal-timer` step (systemd/privilege/user/path shims).
+   *  Default: the real host detection + `/etc/systemd/system` writes. */
+  selfHealTimerDeps?: InstallTimerDeps;
 }
 
 interface UpdateStep {
@@ -718,6 +726,80 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
         say(chalk.green(`  hindsight-watch cron reconciled at ${res.path}\n`));
       } else {
         say(chalk.gray(`  hindsight-watch cron already current at ${res.path}\n`));
+      }
+    },
+  });
+
+  // install-self-heal-timer: arm the systemd timer that makes a shipped release
+  // converge the HOST binary automatically — the last convergence gap.
+  //
+  // A release auto-converges every container image, but the host operator binary
+  // (`/usr/local/bin/switchroom`) and the hindsight-watch cron converge only when
+  // a human runs `switchroom update` on the host, because self-update-cli and the
+  // cron reconcile are host-context work that skips inside the hostd/agent
+  // container a rollout runs from. This timer re-runs `switchroom update
+  // --skip-images` on the host every ~30 min, so a behind host CLI self-heals
+  // within one interval with no human in the loop (the v0.19.38 12h drift could
+  // not recur). `--skip-images` still runs self-update-cli (only --skip-self-update
+  // skips that, see the self-update-cli step above) — it just doesn't pull images
+  // on a healthy tick.
+  //
+  // ARM, not just repair: unlike the cron (opt-in, doctor FAILs while unarmed),
+  // this timer IS the mechanism the PR ships, so the host update path installs it
+  // whenever it safely can. It writes nothing and never fails when the host is
+  // not systemd-booted, the process is unprivileged, or no non-root operator user
+  // resolves — it prints the unit contents + the two systemctl commands as the
+  // manual fallback instead. Idempotent: a re-run once installed is a no-op.
+  //
+  // Deferred in hostd-context: /etc/systemd/system lives on the host, not inside
+  // the hostd container, so writing it from there would land in the wrong
+  // filesystem. Never fatal — a failed install warns and continues.
+  steps.push({
+    name: "install-self-heal-timer",
+    description:
+      "Install + enable the switchroom-self-heal systemd timer so a shipped release converges the host binary automatically — graceful no-op without systemd/privilege",
+    skipReason: hostdContext
+      ? "deferred (hostd-context): /etc/systemd/system is on the host, not in the hostd container — finish host-side by re-running `switchroom update` on the host"
+      : undefined,
+    isHostdDeferred: hostdContext,
+    run: () => {
+      const say = opts.stdout ?? ((t: string) => process.stdout.write(t));
+      let res: ReturnType<typeof installSelfHealTimer>;
+      try {
+        res = installSelfHealTimer(opts.selfHealTimerDeps ?? {});
+      } catch (e) {
+        // Non-fatal: the update succeeded; a timer we couldn't enable is a
+        // diagnostic, not an update failure. `switchroom doctor` carries the
+        // standing host-CLI-drift signal.
+        say(
+          chalk.yellow(
+            `  self-heal timer not installed: ${(e as Error).message}\n`,
+          ),
+        );
+        return;
+      }
+      if (res.status === "installed") {
+        say(
+          chalk.green(
+            `  self-heal timer installed + enabled (${res.servicePath}, ${res.timerPath})\n`,
+          ),
+        );
+      } else if (res.status === "unchanged") {
+        say(chalk.gray(`  self-heal timer already current + enabled at ${res.timerPath}\n`));
+      } else {
+        // Graceful skip — print the exact units + the two systemctl commands so
+        // the operator can install it by hand on a non-systemd / unprivileged host.
+        say(
+          chalk.gray(
+            `  self-heal timer not installed automatically: ${res.reason}\n`,
+          ) +
+            chalk.gray("  Install it by hand:\n") +
+            chalk.gray(`    # ${res.servicePath}\n`) +
+            res.serviceContent!.replace(/^/gm, chalk.gray("    ")) +
+            chalk.gray(`    # ${res.timerPath}\n`) +
+            res.timerContent!.replace(/^/gm, chalk.gray("    ")) +
+            res.manualCommands.map((c) => chalk.gray(`    ${c}\n`)).join(""),
+        );
       }
     },
   });

--- a/src/host-cli-self-heal/install-timer.test.ts
+++ b/src/host-cli-self-heal/install-timer.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  TIMER_UNIT,
+  installSelfHealTimer,
+  renderService,
+  renderTimer,
+  resolveOperatorUser,
+  type InstallTimerDeps,
+} from "./install-timer.js";
+
+/**
+ * The self-heal timer IS the mechanism that makes a shipped release converge the
+ * host binary automatically, so these tests assert OUTCOMES: which bytes land in
+ * /etc/systemd/system, that the timer is enabled, and that the unsafe hosts write
+ * NOTHING and instead emit a manual fallback. Every property is one of the ways
+ * this could silently install a timer that never heals (root user, wrong flag,
+ * disabled).
+ */
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "sh-timer-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const BIN = "/usr/local/bin/switchroom";
+
+describe("renderService", () => {
+  const out = renderService({ binary: BIN, user: "alice", home: "/home/alice" });
+
+  it("is a oneshot that runs `update --skip-images` — self-heal still self-updates the binary", () => {
+    expect(out).toContain("Type=oneshot");
+    // --skip-images keeps the tick cheap but DOES run self-update-cli; only
+    // --skip-self-update would skip the host-binary swap (update.ts).
+    expect(out).toContain(`ExecStart=${BIN} update --skip-images`);
+    expect(out).not.toContain("--skip-self-update");
+  });
+
+  it("runs as the resolved operator, never root", () => {
+    expect(out).toContain("User=alice");
+    expect(out).not.toContain("User=root");
+  });
+
+  it("pins HOME when resolvable, omits it otherwise", () => {
+    expect(out).toContain("Environment=HOME=/home/alice");
+    expect(renderService({ binary: BIN, user: "ada" })).not.toContain("Environment=HOME=");
+  });
+
+  it("ends with a newline", () => {
+    expect(out.endsWith("\n")).toBe(true);
+  });
+});
+
+describe("renderTimer", () => {
+  const out = renderTimer();
+  it("fires 5min after boot then every 30min, jittered, persistent, in timers.target", () => {
+    expect(out).toContain("OnBootSec=5min");
+    expect(out).toContain("OnUnitActiveSec=30min");
+    expect(out).toContain("RandomizedDelaySec=2min");
+    expect(out).toContain("Persistent=true");
+    expect(out).toContain("WantedBy=timers.target");
+  });
+});
+
+describe("resolveOperatorUser — mirrors the cron --cron-user resolution", () => {
+  it("prefers SUDO_USER (the real user under `sudo switchroom update`)", () => {
+    expect(resolveOperatorUser({ SUDO_USER: "ken", USER: "root" })).toBe("ken");
+  });
+  it("falls back to USER then LOGNAME", () => {
+    expect(resolveOperatorUser({ USER: "ada" })).toBe("ada");
+    expect(resolveOperatorUser({ LOGNAME: "grace" })).toBe("grace");
+  });
+  it("refuses root and empty — the exact value that would no-op forever", () => {
+    expect(resolveOperatorUser({ SUDO_USER: "root" })).toBeNull();
+    expect(resolveOperatorUser({})).toBeNull();
+  });
+});
+
+/** A deps bundle for the happy path with injectable IO. */
+function happyDeps(overrides: Partial<InstallTimerDeps> = {}): {
+  deps: InstallTimerDeps;
+  calls: string[][];
+} {
+  const calls: string[][] = [];
+  return {
+    calls,
+    deps: {
+      env: { SUDO_USER: "alice", SWITCHROOM_BINARY: BIN },
+      systemdBooted: () => true,
+      geteuid: () => 0,
+      homeForUser: () => "/home/alice",
+      runner: (cmd, args) => {
+        calls.push([cmd, ...args]);
+        return { status: 0 };
+      },
+      servicePath: join(dir, "switchroom-self-heal.service"),
+      timerPath: join(dir, "switchroom-self-heal.timer"),
+      ...overrides,
+    },
+  };
+}
+
+describe("installSelfHealTimer — systemd present + privileged", () => {
+  it("writes both units with the resolved non-root User= and enables the timer", () => {
+    const { deps, calls } = happyDeps();
+    const res = installSelfHealTimer(deps);
+
+    expect(res.status).toBe("installed");
+    // Both units landed on disk.
+    const svc = readFileSync(deps.servicePath!, "utf8");
+    const tim = readFileSync(deps.timerPath!, "utf8");
+    expect(svc).toContain("User=alice");
+    expect(svc).not.toContain("User=root");
+    expect(svc).toContain(`ExecStart=${BIN} update --skip-images`);
+    expect(tim).toContain("OnUnitActiveSec=30min");
+    expect(statSync(deps.servicePath!).mode & 0o777).toBe(0o644);
+
+    // The timer was reloaded and enabled --now.
+    expect(calls).toEqual([
+      ["systemctl", "daemon-reload"],
+      ["systemctl", "enable", "--now", TIMER_UNIT],
+    ]);
+  });
+
+  it("is idempotent: a re-run rewrites nothing and reports unchanged", () => {
+    const { deps } = happyDeps();
+    expect(installSelfHealTimer(deps).status).toBe("installed");
+    const res2 = installSelfHealTimer(deps);
+    expect(res2.status).toBe("unchanged");
+  });
+
+  it("throws (non-fatal to the caller) when systemctl enable fails", () => {
+    const { deps } = happyDeps({
+      runner: (cmd, args) =>
+        args.includes("enable") ? { status: 1 } : { status: 0 },
+    });
+    expect(() => installSelfHealTimer(deps)).toThrow(/enable --now/);
+  });
+});
+
+describe("installSelfHealTimer — graceful skip writes NOTHING + emits a fallback", () => {
+  it("skips when the host is not systemd-booted", () => {
+    const { deps, calls } = happyDeps({ systemdBooted: () => false });
+    const res = installSelfHealTimer(deps);
+    expect(res.status).toBe("skipped");
+    expect(res.reason).toMatch(/systemd/i);
+    // Nothing written, nothing run.
+    expect(() => statSync(deps.servicePath!)).toThrow();
+    expect(() => statSync(deps.timerPath!)).toThrow();
+    expect(calls).toEqual([]);
+    // The manual fallback is fully populated so the operator can install by hand.
+    expect(res.serviceContent).toContain("ExecStart=");
+    expect(res.timerContent).toContain("OnUnitActiveSec=30min");
+    expect(res.manualCommands).toEqual([
+      "sudo systemctl daemon-reload",
+      `sudo systemctl enable --now ${TIMER_UNIT}`,
+    ]);
+  });
+
+  it("skips (writes nothing) when unprivileged", () => {
+    const { deps, calls } = happyDeps({ geteuid: () => 1000 });
+    const res = installSelfHealTimer(deps);
+    expect(res.status).toBe("skipped");
+    expect(res.reason).toMatch(/privileged/i);
+    expect(() => statSync(deps.servicePath!)).toThrow();
+    expect(calls).toEqual([]);
+  });
+
+  it("skips (never installs a root timer) when no non-root operator resolves", () => {
+    const { deps } = happyDeps({ env: { SUDO_USER: "root", SWITCHROOM_BINARY: BIN } });
+    const res = installSelfHealTimer(deps);
+    expect(res.status).toBe("skipped");
+    expect(res.reason).toMatch(/operator user/i);
+    // Even the fallback message renders a placeholder, never root.
+    expect(res.serviceContent).not.toContain("User=root");
+    expect(() => statSync(deps.servicePath!)).toThrow();
+  });
+
+  it("skips when the binary path is not absolute", () => {
+    const { deps } = happyDeps({ env: { SUDO_USER: "ken", SWITCHROOM_BINARY: "switchroom" } });
+    const res = installSelfHealTimer(deps);
+    expect(res.status).toBe("skipped");
+    expect(res.reason).toMatch(/absolute/i);
+  });
+});

--- a/src/host-cli-self-heal/install-timer.ts
+++ b/src/host-cli-self-heal/install-timer.ts
@@ -1,0 +1,309 @@
+/**
+ * Arming the host-CLI self-heal — the step that closes the last convergence gap.
+ *
+ * ## Why this file exists
+ *
+ * A shipped release auto-converges every *container* image, but the host
+ * operator binary (`/usr/local/bin/switchroom`) and the `hindsight-watch` cron
+ * only converge when a human runs `switchroom update` on the host — because
+ * `self-update-cli` and the cron reconcile step are host-context work that skips
+ * inside the hostd/agent container a rollout runs from. So a release can roll to
+ * every container while the host binary silently trails the fleet (the v0.19.38
+ * incident: `/usr/local/bin/switchroom` stuck on v0.19.33 for 12 hours running
+ * retired `hindsight-watch` code).
+ *
+ * `switchroom doctor` now FAILs on that drift and `switchroom update` reconciles
+ * the cron — but "loud" still needs a human to look. This unit makes the host
+ * binary **self-heal** without one: a systemd timer re-runs
+ * `switchroom update --skip-images` on a cadence, so a behind host CLI is
+ * corrected within one interval, entirely on the host, no container involved.
+ *
+ * `--skip-images` is deliberate and load-bearing: it still runs `self-update-cli`
+ * (the atomic host-binary swap — only `--skip-self-update` skips that,
+ * update.ts:476) and reconciles the cron, but does not pull GHCR images or touch
+ * running containers on a healthy tick, so each run is cheap and offline-safe.
+ *
+ * ## Why a system timer and not the operator's crontab
+ *
+ * A `/etc/systemd/system` unit is declarative, idempotent, greppable, survives a
+ * user switch, gives `User=`/`OnBootSec`/`Persistent=` first-class homes, and
+ * `Persistent=true` fires a missed run on next boot. This mirrors the
+ * `/etc/cron.d/hindsight-watch` idioms (tmp+rename, mode 0644, idempotent
+ * compare, absolute-binary guard, refuse-root operator resolution) rather than
+ * inventing a new install mechanism — see `hindsight-watch/install-cron.ts`.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+/** Where the oneshot service unit lands. */
+export const SERVICE_PATH = "/etc/systemd/system/switchroom-self-heal.service";
+
+/** Where the timer unit lands. */
+export const TIMER_PATH = "/etc/systemd/system/switchroom-self-heal.timer";
+
+/** The unit name systemd enables/schedules. */
+export const TIMER_UNIT = "switchroom-self-heal.timer";
+
+/**
+ * The canonical marker that the host is systemd-booted. `sd_booted(3)` is
+ * defined as "the `/run/systemd/system/` directory exists"; presence of the
+ * `systemctl` binary is not sufficient (it exists on non-systemd containers).
+ */
+export const SYSTEMD_MARKER = "/run/systemd/system";
+
+const DOC_URL =
+  "https://github.com/switchroom/switchroom/blob/main/docs/operators/host-cli-self-heal.md";
+
+export interface UnitRenderOptions {
+  /** Absolute path to the `switchroom` binary the tick runs. */
+  binary: string;
+  /** Unix user the tick runs as — the operator, never root. */
+  user: string;
+  /**
+   * The operator's home dir, if resolvable. When present it is pinned as
+   * `Environment=HOME=` (belt-and-braces — systemd already sets `$HOME` from
+   * the account database for `User=`, but pinning it makes the unit legible and
+   * robust to a passwd without a home field). Omitted when unresolved.
+   */
+  home?: string;
+}
+
+/**
+ * Render the oneshot `.service` unit.
+ *
+ * Pure, so the exact bytes that land in `/etc/systemd/system` are asserted in a
+ * unit test rather than discovered in production. Pins:
+ *  - **`Type=oneshot`** — a run-to-completion tick, not a daemon.
+ *  - **`User=<operator>`** — `switchroom update` reads `$HOME/.switchroom`;
+ *    running it as root would read root's empty home and no-op forever.
+ *  - **`ExecStart=<binary> update --skip-images`** — self-heals the host binary
+ *    (self-update-cli still runs) without pulling images on a healthy tick.
+ *  - **`TimeoutStartSec` / `Nice`** — self-heal must never wedge the host.
+ */
+export function renderService(opts: UnitRenderOptions): string {
+  const homeLine = opts.home ? `Environment=HOME=${opts.home}\n` : "";
+  return (
+    `# switchroom host CLI self-heal — keeps /usr/local/bin/switchroom from silently\n` +
+    `# trailing the fleet. Managed by \`switchroom update\`; edits are overwritten.\n` +
+    `[Unit]\n` +
+    `Description=Switchroom host CLI self-heal (re-run \`switchroom update\` so the host binary can't silently trail the fleet)\n` +
+    `Documentation=${DOC_URL}\n` +
+    `After=network-online.target docker.service\n` +
+    `Wants=network-online.target\n` +
+    `\n` +
+    `[Service]\n` +
+    `Type=oneshot\n` +
+    `# Run as the operator whose ~/.switchroom holds the fleet config — NOT root.\n` +
+    `User=${opts.user}\n` +
+    homeLine +
+    `# --skip-images keeps each tick cheap: self-update-cli (the host binary swap)\n` +
+    `# still runs; GHCR pulls and container recreation do not.\n` +
+    `ExecStart=${opts.binary} update --skip-images\n` +
+    `# Self-heal must never wedge the host: bound the run and run at low priority.\n` +
+    `TimeoutStartSec=600\n` +
+    `Nice=10\n`
+  );
+}
+
+/**
+ * Render the `.timer` unit. Pure. Pins the cadence the doc and the incident
+ * arithmetic were derived against: first run 5 min after boot, then every 30
+ * min, jittered so a fleet of hosts does not hit the GitHub release API in
+ * lockstep, and `Persistent=true` so a missed run (host off) fires on next boot.
+ */
+export function renderTimer(): string {
+  return (
+    `# switchroom host CLI self-heal timer. Managed by \`switchroom update\`.\n` +
+    `[Unit]\n` +
+    `Description=Run the Switchroom host CLI self-heal every 30 minutes\n` +
+    `Documentation=${DOC_URL}\n` +
+    `\n` +
+    `[Timer]\n` +
+    `OnBootSec=5min\n` +
+    `OnUnitActiveSec=30min\n` +
+    `RandomizedDelaySec=2min\n` +
+    `Persistent=true\n` +
+    `\n` +
+    `[Install]\n` +
+    `WantedBy=timers.target\n`
+  );
+}
+
+/** Write `content` to `path` idempotently (tmp+rename, mode 0644). */
+function writeUnitIdempotent(path: string, content: string): "written" | "unchanged" {
+  if (existsSync(path)) {
+    try {
+      if (readFileSync(path, "utf8") === content) return "unchanged";
+    } catch {
+      // Unreadable but present — fall through and rewrite it.
+    }
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, content, { mode: 0o644 });
+  renameSync(tmp, path);
+  return "written";
+}
+
+export interface InstallTimerDeps {
+  env?: NodeJS.ProcessEnv;
+  /** True when the host is systemd-booted. Default: `/run/systemd/system` exists. */
+  systemdBooted?: () => boolean;
+  /** Effective uid of the process. Default: `process.geteuid()` (undefined off-Linux). */
+  geteuid?: () => number | undefined;
+  /**
+   * Resolve the operator's home dir for a username, or undefined. Default reads
+   * `/etc/passwd`. Only used to pin `Environment=HOME=`.
+   */
+  homeForUser?: (user: string) => string | undefined;
+  /**
+   * Run a command (systemctl). Returns its exit status. Default: `spawnSync`.
+   * Mirrors update.ts's injectable `runner` so the step is testable.
+   */
+  runner?: (cmd: string, args: string[]) => { status: number };
+  /** Test seams for the unit paths. */
+  servicePath?: string;
+  timerPath?: string;
+}
+
+export type InstallTimerStatus = "installed" | "unchanged" | "skipped";
+
+export interface InstallTimerResult {
+  status: InstallTimerStatus;
+  /** Present on `skipped` — why, for the operator message. */
+  reason?: string;
+  /** The resolved values (present when we got far enough to render). */
+  servicePath: string;
+  timerPath: string;
+  serviceContent?: string;
+  timerContent?: string;
+  /** The two manual `systemctl` commands, always populated for the fallback. */
+  manualCommands: string[];
+}
+
+/**
+ * Best-effort resolve the operator's home from `/etc/passwd` (field 6). Returns
+ * undefined on any read/parse failure — the caller then omits the HOME pin and
+ * lets systemd fill `$HOME` from the account database.
+ */
+function homeFromPasswd(user: string): string | undefined {
+  try {
+    for (const line of readFileSync("/etc/passwd", "utf8").split("\n")) {
+      const f = line.split(":");
+      if (f[0] === user && f[5]) return f[5];
+    }
+  } catch {
+    /* no passwd / unreadable — omit HOME */
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the operator username the SAME way the `hindsight-watch --install-cron`
+ * / `--cron-user` logic does (install-cron callsite in hindsight-watch.ts:165):
+ * `SUDO_USER` (the real user under `sudo switchroom update`) → `USER` → `LOGNAME`.
+ * Root is refused — `switchroom update` as root reads root's empty `~/.switchroom`
+ * and the tick would no-op forever, the exact failure this unit exists to close.
+ */
+export function resolveOperatorUser(env: NodeJS.ProcessEnv): string | null {
+  const user = env.SUDO_USER ?? env.USER ?? env.LOGNAME;
+  if (!user || user === "root") return null;
+  return user;
+}
+
+/**
+ * Arm the host-CLI self-heal timer.
+ *
+ * Idempotent and safe to call unconditionally from the host `switchroom update`
+ * path: it writes both units, `daemon-reload`s, and `enable --now`s the timer
+ * only when the host is **systemd-booted AND the process is privileged (euid 0)
+ * AND a non-root operator user resolves**. Otherwise it writes NOTHING, does not
+ * fail, and returns `skipped` with the exact unit contents + the two `systemctl`
+ * commands so the operator can install it by hand (the non-systemd fallback the
+ * doc describes). A re-run once installed is a byte-identical no-op.
+ */
+export function installSelfHealTimer(deps: InstallTimerDeps = {}): InstallTimerResult {
+  const env = deps.env ?? process.env;
+  const systemdBooted = deps.systemdBooted ?? (() => existsSync(SYSTEMD_MARKER));
+  const geteuid =
+    deps.geteuid ??
+    (() => (typeof process.geteuid === "function" ? process.geteuid() : undefined));
+  const homeForUser = deps.homeForUser ?? homeFromPasswd;
+  const servicePath = deps.servicePath ?? SERVICE_PATH;
+  const timerPath = deps.timerPath ?? TIMER_PATH;
+
+  const binary = env.SWITCHROOM_BINARY ?? "/usr/local/bin/switchroom";
+  const user = resolveOperatorUser(env);
+  // Render with a best-effort user for the fallback message even when we skip.
+  const renderUser = user ?? "OPERATOR";
+  const home = user ? homeForUser(user) : undefined;
+  const serviceContent = renderService({ binary, user: renderUser, ...(home ? { home } : {}) });
+  const timerContent = renderTimer();
+  const manualCommands = [
+    "sudo systemctl daemon-reload",
+    `sudo systemctl enable --now ${TIMER_UNIT}`,
+  ];
+  const base = { servicePath, timerPath, serviceContent, timerContent, manualCommands };
+
+  // Guard 1: absolute binary. A relative/dev argv would produce an ExecStart
+  // that fails on every fire with a message only in the journal.
+  if (!binary.startsWith("/")) {
+    return {
+      status: "skipped",
+      reason: `SWITCHROOM_BINARY must be an absolute path (got ${binary})`,
+      ...base,
+    };
+  }
+
+  // Guard 2: systemd must actually be the init system.
+  if (!systemdBooted()) {
+    return {
+      status: "skipped",
+      reason: "host is not systemd-booted (/run/systemd/system absent)",
+      ...base,
+    };
+  }
+
+  // Guard 3: writing /etc/systemd/system + systemctl need root.
+  if (geteuid() !== 0) {
+    return { status: "skipped", reason: "not privileged (euid != 0)", ...base };
+  }
+
+  // Guard 4: a resolvable non-root operator user — the same refusal the cron
+  // install makes. Never blindly root.
+  if (!user) {
+    return {
+      status: "skipped",
+      reason:
+        "no non-root operator user resolvable (SUDO_USER / USER / LOGNAME all unset or root)",
+      ...base,
+    };
+  }
+
+  const svc = writeUnitIdempotent(servicePath, serviceContent);
+  const tim = writeUnitIdempotent(timerPath, timerContent);
+  const changed = svc === "written" || tim === "written";
+
+  const runner =
+    deps.runner ??
+    ((cmd: string, args: string[]) => {
+      const r = spawnSync(cmd, args, { stdio: "inherit" });
+      return { status: r.status ?? 1 };
+    });
+
+  // daemon-reload picks up written/changed unit bytes; enable --now is
+  // idempotent (systemd no-ops an already-enabled+active timer) so we always
+  // run it — it's how a previously-disabled timer gets re-armed on re-run.
+  const reload = runner("systemctl", ["daemon-reload"]);
+  if (reload.status !== 0) {
+    throw new Error(`systemctl daemon-reload failed (exit ${reload.status})`);
+  }
+  const enable = runner("systemctl", ["enable", "--now", TIMER_UNIT]);
+  if (enable.status !== 0) {
+    throw new Error(`systemctl enable --now ${TIMER_UNIT} failed (exit ${enable.status})`);
+  }
+
+  return { status: changed ? "installed" : "unchanged", ...base };
+}


### PR DESCRIPTION
## What & why

A shipped release auto-converges every **container** image, but the host operator binary (`/usr/local/bin/switchroom`) and the `hindsight-watch` cron converge only when a human runs `switchroom update` **on the host** — `self-update-cli` and the cron reconcile are host-context work that skips inside the hostd/agent container a rollout runs from. #4032 (doctor FAILs on host-CLI drift) and #4033 (reconcile cron on update) made the drift loud; #4034 **documented** a `switchroom-self-heal` systemd timer that closes it by re-running `switchroom update --skip-images` every ~30 min — but installed nothing. This PR wires the install: the residual gap in #4034.

## The change

New **`install-self-heal-timer`** step in `switchroom update`, right after the `reconcile-hindsight-watch-cron` step (`src/cli/update.ts`). Logic lives in `src/host-cli-self-heal/install-timer.ts`.

- **systemd-booted AND privileged (euid 0) AND non-root operator user resolves** → writes `/etc/systemd/system/switchroom-self-heal.service` (`Type=oneshot`, `ExecStart=<binary> update --skip-images`, `User=<operator>`) + `.timer` (`OnBootSec=5min`, `OnUnitActiveSec=30min`, `RandomizedDelaySec=2min`, `Persistent=true`), then `systemctl daemon-reload` + `enable --now switchroom-self-heal.timer`.
- **Operator resolution mirrors the cron `--cron-user` path** (`SUDO_USER` → `USER` → `LOGNAME`, root refused) — same idiom as `hindsight-watch --install-cron`. Never blindly root.
- **Mirrors `install-cron.ts`**: tmp+rename mode 0644, idempotent byte-compare, absolute-binary guard.
- **Graceful skip**: no systemd / unprivileged / no operator user → writes nothing, never fails the update, prints the exact unit contents + the two `systemctl` commands as the manual fallback.
- **Deferred in hostd-context** (`/etc/systemd/system` is on the host, not the container), like the cron step.
- **Idempotent**: a re-run once installed is a byte-identical no-op.

## Trace — does the tick actually heal the binary?

Timer fires `switchroom update --skip-images` in a **host-shell** systemd oneshot as the operator → the `self-update-cli` step is skipped **only** by `--skip-self-update` (`src/cli/update.ts:489`), **not** by `--skip-images` → checksum-verified atomic binary swap runs → `apply-config` + `reconcile-hindsight-watch-cron` follow. `--skip-images` only suppresses the image pull / hostd / web / hindsight refreshes, keeping each tick cheap. Not a no-op timer.

## Docs

`docs/operators/host-cli-self-heal.md` (#4034) + `docs/README.md` updated: the timer is now installed automatically by `switchroom update` on a systemd host; the manual steps are kept as the **non-systemd fallback**.

## Tests (outcomes, not code paths)

`src/host-cli-self-heal/install-timer.test.ts` + `src/cli/update.test.ts`:
- systemd-present + privileged → both units written with resolved **non-root** `User=` and the timer enabled (`daemon-reload` + `enable --now`); idempotent re-run no-op.
- no-systemd / unprivileged / root-only-operator → **nothing written**, manual fallback populated.
- update step deferred in hostd-context.

Scoped `vitest` green (89 tests) and `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)