### PR TITLE
fix(telegram): stop cross-turn card contamination — drop sidechain tool labels at the hook

### DIFF
--- a/telegram-plugin/hooks/tool-label-pretool.mjs
+++ b/telegram-plugin/hooks/tool-label-pretool.mjs
@@ -15,7 +15,9 @@
  * If $TELEGRAM_STATE_DIR is unset → silent skip (renderer just falls back
  * to its existing precedence ladder). If session_id or tool_use_id is
  * missing → skip (the row could never be joined anyway). If the rule
- * table doesn't produce a label for the tool → skip.
+ * table doesn't produce a label for the tool → skip. If the call is a
+ * SIDECHAIN (sub-agent) tool call → skip (see isSubagentToolCall / #cross-
+ * contamination below).
  *
  * Tools intentionally NOT labeled here (handled by existing description
  * / TodoWrite / sub-agent panels in the renderer):
@@ -364,6 +366,56 @@ export function computeLabel(toolName, input) {
   return 'Working…'
 }
 
+/**
+ * True IFF this PreToolUse payload is for a SIDECHAIN (sub-agent) tool call,
+ * i.e. one made inside a Task/worker/Explore/Plan sub-agent rather than the
+ * top-level thread.
+ *
+ * WHY THIS EXISTS — the cross-contamination bug. Claude Code fires PreToolUse
+ * hooks for sub-agent tool calls too, and (as of 2.1.x) passes the PARENT
+ * `session_id` in that payload. The sidecar JSONL is keyed by `session_id`
+ * (`tool-labels-<session_id>.jsonl`), so a still-running background worker's
+ * labels were being appended into the PARENT session's sidecar. The gateway's
+ * real-time draft-mirror tails that file and emits a main-tier `tool_label`
+ * event per line, which the renderer binds to whatever turn is live — so a
+ * worker dispatched by turn N streamed its Bash step labels into an unrelated
+ * turn N+1's progress card. The worker's OWN activity is already surfaced by
+ * the worker-feed (sub_agent_tool_use events tailed from the sub-agent's own
+ * transcript), so the correct fix is to never write sub-agent labels to the
+ * parent sidecar in the first place — the cheapest, at-source link.
+ *
+ * DISCRIMINATOR — the payload carries sidechain identity. The PreToolUse hook
+ * input is built by the CLI's base `Kf(...)` helper, which includes
+ * `agent_id` and `agent_type`. The CLI's own top-level predicate is
+ * `agentType === "main"` (its `hb()` seeds the main thread as
+ * `{ agentType: "main", agentId: <sessionId> }`), while every sub-agent
+ * carries a concrete non-"main" `agent_type` ("worker", "general-purpose",
+ * "Explore", "Plan", a custom agent name, …). So:
+ *   - a concrete `agent_type` other than "main" ⇒ sub-agent (drop), and
+ *   - as a corroborating signal, a sidechain's `agent_id` differs from the
+ *     (parent) `session_id`, whereas the main thread's `agent_id` equals its
+ *     session id.
+ * An ABSENT `agent_type` (or one equal to "main") is treated as main-tier and
+ * KEPT — the safe default. A genuine sub-agent always carries a concrete
+ * agent_type (the Task tool requires a subagent_type), so this never drops a
+ * real sub-agent while risking a main-tier drop.
+ */
+export function isSubagentToolCall(event) {
+  if (!event || typeof event !== 'object') return false
+  const at = event.agent_type
+  if (typeof at === 'string' && at.length > 0 && at !== 'main') return true
+  const aid = event.agent_id
+  const sid = event.session_id
+  if (
+    typeof aid === 'string' && aid.length > 0 &&
+    typeof sid === 'string' && sid.length > 0 &&
+    aid !== sid
+  ) {
+    return true
+  }
+  return false
+}
+
 function main() {
   const raw = readStdin().trim()
   if (!raw) process.exit(0)
@@ -382,6 +434,13 @@ function main() {
   const toolUseId = event.tool_use_id
   const toolName = event.tool_name
   if (!sessionId || !toolUseId || !toolName) process.exit(0)
+
+  // Sidechain (sub-agent) tool calls arrive here with the PARENT session_id,
+  // so writing their label to `tool-labels-<sessionId>.jsonl` pollutes the
+  // parent session's sidecar and cross-contaminates an unrelated turn's card.
+  // Drop them: the worker-feed already surfaces sub-agent activity. See
+  // isSubagentToolCall for the full rationale + discriminator.
+  if (isSubagentToolCall(event)) process.exit(0)
 
   let label
   try {

--- a/telegram-plugin/hooks/tool-label-pretool.mjs
+++ b/telegram-plugin/hooks/tool-label-pretool.mjs
@@ -385,35 +385,77 @@ export function computeLabel(toolName, input) {
  * parent sidecar in the first place — the cheapest, at-source link.
  *
  * DISCRIMINATOR — the payload carries sidechain identity. The PreToolUse hook
- * input is built by the CLI's base `Kf(...)` helper, which includes
- * `agent_id` and `agent_type`. The CLI's own top-level predicate is
- * `agentType === "main"` (its `hb()` seeds the main thread as
- * `{ agentType: "main", agentId: <sessionId> }`), while every sub-agent
- * carries a concrete non-"main" `agent_type` ("worker", "general-purpose",
- * "Explore", "Plan", a custom agent name, …). So:
- *   - a concrete `agent_type` other than "main" ⇒ sub-agent (drop), and
- *   - as a corroborating signal, a sidechain's `agent_id` differs from the
- *     (parent) `session_id`, whereas the main thread's `agent_id` equals its
- *     session id.
- * An ABSENT `agent_type` (or one equal to "main") is treated as main-tier and
- * KEPT — the safe default. A genuine sub-agent always carries a concrete
- * agent_type (the Task tool requires a subagent_type), so this never drops a
- * real sub-agent while risking a main-tier drop.
+ * input is built by the CLI's base `Kf(...)` helper, whose real 2.1.219 field
+ * shape (verified against the installed binary — see
+ * tests/fixtures/pretool-*.json) is:
+ *   { session_id, transcript_path, cwd, prompt_id?, permission_mode,
+ *     agent_id, agent_type, effort?, hook_event_name, tool_name, tool_input,
+ *     tool_use_id }
+ * The CLI's own top-level predicate is `agentType === "main"` (its `hb()`
+ * seeds the main thread as `{ agentType: "main", agentId: <sessionId> }`),
+ * while every sub-agent carries a concrete non-"main" `agent_type` ("worker",
+ * "general-purpose", "Explore", "Plan", a custom agent name, …).
+ *
+ * AUTHORITY ORDER (this matters for correctness, not just style):
+ *   1. `agent_type` is AUTHORITATIVE whenever it is a non-empty string:
+ *        - "main"        ⇒ top-level thread (KEEP), full stop, and
+ *        - anything else ⇒ concrete sub-agent (DROP).
+ *      Making "main" short-circuit is what prevents the SYMMETRIC false
+ *      positive: a (hypothetical future) main-tier payload whose `agent_id`
+ *      no longer equals `session_id` must STILL be kept — the identity
+ *      corroboration below must never override an explicit "main".
+ *   2. Only when `agent_type` is ABSENT/empty (unknown / a legacy CLI) do we
+ *      fall back to identity corroboration: a sidechain carries the PARENT
+ *      `session_id` but its OWN `agent_id`, so `agent_id !== session_id`
+ *      ⇒ sub-agent (DROP). Equal (or either missing) ⇒ main-tier (KEEP).
+ *
+ * A genuine sub-agent always carries a concrete agent_type (the Task tool
+ * requires a subagent_type), so this never drops a real sub-agent while
+ * risking a main-tier drop. See `hasAttributionSignal` for the fail-loud
+ * guard that fires if a FUTURE CLI drops BOTH identity fields (which would
+ * silently revert this whole fix — the drift the canary + warning defend).
  */
 export function isSubagentToolCall(event) {
   if (!event || typeof event !== 'object') return false
   const at = event.agent_type
-  if (typeof at === 'string' && at.length > 0 && at !== 'main') return true
+  // (1) agent_type is authoritative when present: "main" ⇒ keep, else ⇒ drop.
+  if (typeof at === 'string' && at.length > 0) return at !== 'main'
+  // (2) agent_type absent/empty — corroborate via identity. A sidechain carries
+  // the parent session_id but its own agent_id.
   const aid = event.agent_id
   const sid = event.session_id
-  if (
+  return (
     typeof aid === 'string' && aid.length > 0 &&
     typeof sid === 'string' && sid.length > 0 &&
     aid !== sid
-  ) {
-    return true
-  }
-  return false
+  )
+}
+
+/**
+ * True IFF the payload carries AT LEAST ONE sidechain-attribution field
+ * (`agent_type` or `agent_id`) that `isSubagentToolCall` can key on.
+ *
+ * DRIFT CANARY (runtime half). On CC 2.1.219 EVERY PreToolUse payload carries
+ * both `agent_id` and `agent_type` (the base `Kf` builder). If a future CLI
+ * renamed/dropped BOTH (e.g. `agent_type`→`agentType`), `isSubagentToolCall`
+ * would silently return false for real sub-agents and the cross-turn
+ * contamination bug would return with NO test catching it (a frozen fixture
+ * can't see the live CLI change). So `main()` emits a one-line stderr WARNING
+ * — captured by plugin-logger — when a real tool call arrives with neither
+ * field, making the drift LOUD instead of silent. We warn rather than drop:
+ * dropping every label on drift would dark-out the whole live feed (a worse,
+ * feed-wide regression), whereas a warning lets an operator re-point the
+ * predicate at the renamed field. The committed fixtures
+ * (tests/fixtures/pretool-*.json) are the compile-time half of the canary.
+ */
+export function hasAttributionSignal(event) {
+  if (!event || typeof event !== 'object') return false
+  const at = event.agent_type
+  const aid = event.agent_id
+  return (
+    (typeof at === 'string' && at.length > 0) ||
+    (typeof aid === 'string' && aid.length > 0)
+  )
 }
 
 function main() {
@@ -434,6 +476,23 @@ function main() {
   const toolUseId = event.tool_use_id
   const toolName = event.tool_name
   if (!sessionId || !toolUseId || !toolName) process.exit(0)
+
+  // DRIFT CANARY (runtime half). On 2.1.219 a real PreToolUse payload ALWAYS
+  // carries agent_type + agent_id. If a future CLI dropped/renamed BOTH, the
+  // sidechain discriminator below would silently fail open and the cross-turn
+  // contamination bug would return unnoticed. Warn LOUDLY (plugin-logger tails
+  // stderr) so the drift is visible; we do NOT drop here — dropping every label
+  // on drift would dark-out the whole live feed. See hasAttributionSignal.
+  if (!hasAttributionSignal(event)) {
+    try {
+      process.stderr.write(
+        `[tool-label-pretool] WARNING: PreToolUse payload carries neither ` +
+          `agent_type nor agent_id — the sidechain-attribution invariant may be ` +
+          `broken by a Claude Code schema change; sub-agent labels may be ` +
+          `mis-attributed to the parent session (tool_use_id=${toolUseId}).\n`,
+      )
+    } catch { /* never block */ }
+  }
 
   // Sidechain (sub-agent) tool calls arrive here with the PARENT session_id,
   // so writing their label to `tool-labels-<sessionId>.jsonl` pollutes the

--- a/telegram-plugin/tests/fixtures/pretool-main-2.1.219.json
+++ b/telegram-plugin/tests/fixtures/pretool-main-2.1.219.json
@@ -1,0 +1,15 @@
+{
+  "session_id": "e2c9a4f0-1b3d-4c8a-9f21-parent000000",
+  "transcript_path": "/home/agent/.claude/projects/-home-agent-work/e2c9a4f0-1b3d-4c8a-9f21-parent000000.jsonl",
+  "cwd": "/home/agent/work",
+  "permission_mode": "default",
+  "agent_id": "e2c9a4f0-1b3d-4c8a-9f21-parent000000",
+  "agent_type": "main",
+  "effort": "medium",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Read",
+  "tool_input": {
+    "file_path": "/home/agent/work/src/index.ts"
+  },
+  "tool_use_id": "toolu_01MainReadCall4z"
+}

--- a/telegram-plugin/tests/fixtures/pretool-subagent-2.1.219.json
+++ b/telegram-plugin/tests/fixtures/pretool-subagent-2.1.219.json
@@ -1,0 +1,16 @@
+{
+  "session_id": "e2c9a4f0-1b3d-4c8a-9f21-parent000000",
+  "transcript_path": "/home/agent/.claude/projects/-home-agent-work/e2c9a4f0-1b3d-4c8a-9f21-parent000000.jsonl",
+  "cwd": "/home/agent/work",
+  "permission_mode": "default",
+  "agent_id": "7a1b9c3d-4e5f-6071-8293-subagentownid0",
+  "agent_type": "general-purpose",
+  "effort": "medium",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "npm run build",
+    "description": "Build the worker output"
+  },
+  "tool_use_id": "toolu_01SubAgentBashCall9x"
+}

--- a/telegram-plugin/tests/sidechain-label-filter-pretool.test.ts
+++ b/telegram-plugin/tests/sidechain-label-filter-pretool.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Regression: the PreToolUse hook must NOT write labels for SIDECHAIN
+ * (sub-agent) tool calls into the parent session's sidecar.
+ *
+ * The bug (log-verified): Claude Code fires PreToolUse for sub-agent tool
+ * calls too, and passes the PARENT `session_id`. The hook wrote the worker's
+ * label into `tool-labels-<parentSession>.jsonl`; the gateway's real-time
+ * draft-mirror tails that file and emits a main-tier `tool_label` event per
+ * line, binding it to whatever turn is live — so a still-running background
+ * worker dispatched by the PREVIOUS turn streamed its Bash step labels into an
+ * unrelated new turn's progress card, and inflated that turn's
+ * `labeledToolCount` / re-armed its orphaned-reply fuse.
+ *
+ * The fix severs the chain at its cheapest, at-source link: the hook drops
+ * sidechain calls, so a sub-agent `toolUseId` never reaches the parent sidecar
+ * → never becomes a `tool_label` event → never touches an unrelated card.
+ * These tests assert that OUTCOME (no foreign sidecar line), plus the pure
+ * predicate that distinguishes main-tier from sub-agent payloads.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+// The hook exports isSubagentToolCall for unit testing (see the "Skip main()
+// when imported" guard at the bottom of the hook).
+import { isSubagentToolCall } from '../hooks/tool-label-pretool.mjs'
+
+const HOOK_PATH = resolve(__dirname, '..', 'hooks', 'tool-label-pretool.mjs')
+
+/** Run the hook once with a payload; return the sidecar file's lines (if any). */
+function runHook(payload: Record<string, unknown>): { stateDir: string; lines: string[]; sidecarPath: string } {
+  const stateDir = mkdtempSync(join(tmpdir(), 'sidechain-label-'))
+  const sessionId = String(payload.session_id ?? 'sess')
+  const sidecarPath = join(stateDir, `tool-labels-${sessionId}.jsonl`)
+  const res = spawnSync(process.execPath, [HOOK_PATH], {
+    input: JSON.stringify(payload),
+    env: { ...process.env, TELEGRAM_STATE_DIR: stateDir },
+    encoding: 'utf8',
+  })
+  // The hook must always exit 0 (exit 2 would BLOCK the tool call).
+  expect(res.status).toBe(0)
+  const lines = existsSync(sidecarPath)
+    ? readFileSync(sidecarPath, 'utf8').split('\n').filter(Boolean)
+    : []
+  return { stateDir, lines, sidecarPath }
+}
+
+describe('isSubagentToolCall — main-tier vs sidechain discrimination', () => {
+  it('treats agent_type "main" as main-tier (keep)', () => {
+    expect(isSubagentToolCall({ agent_type: 'main', agent_id: 's1', session_id: 's1' })).toBe(false)
+  })
+
+  it('treats an ABSENT agent_type as main-tier (safe default — keep)', () => {
+    expect(isSubagentToolCall({ session_id: 's1' })).toBe(false)
+    expect(isSubagentToolCall({ agent_id: 's1', session_id: 's1' })).toBe(false)
+  })
+
+  it('flags every concrete non-"main" agent_type as sidechain (drop)', () => {
+    for (const at of ['worker', 'general-purpose', 'Explore', 'Plan', 'researcher', 'my-custom-agent']) {
+      expect(isSubagentToolCall({ agent_type: at, session_id: 'parent' })).toBe(true)
+    }
+  })
+
+  it('flags a distinct agent_id (sub-agent id ≠ parent session) as sidechain', () => {
+    // Corroborating signal even if agent_type were somehow absent.
+    expect(isSubagentToolCall({ agent_id: 'sub-abc', session_id: 'parent-xyz' })).toBe(true)
+  })
+
+  it('does not flag main when agent_id equals session_id', () => {
+    expect(isSubagentToolCall({ agent_id: 'same', session_id: 'same' })).toBe(false)
+  })
+
+  it('is robust to a null/undefined event', () => {
+    expect(isSubagentToolCall(null)).toBe(false)
+    expect(isSubagentToolCall(undefined)).toBe(false)
+  })
+})
+
+describe('PreToolUse hook — sidechain calls never reach the parent sidecar', () => {
+  it('writes a sidecar line for a MAIN-tier Bash call', () => {
+    const { stateDir, lines } = runHook({
+      session_id: 'parent-sess',
+      tool_use_id: 'toolu_main_1',
+      tool_name: 'Bash',
+      tool_input: { command: 'git status', description: 'Check status' },
+      agent_type: 'main',
+      agent_id: 'parent-sess',
+    })
+    try {
+      expect(lines.length).toBe(1)
+      const row = JSON.parse(lines[0])
+      expect(row.tool_use_id).toBe('toolu_main_1')
+      expect(row.label).toBe('Check status')
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true })
+    }
+  })
+
+  it('DROPS a sub-agent Bash call (no line in the parent sidecar)', () => {
+    // The exact shape of the log-verified bug: a background worker's Bash call,
+    // carrying the PARENT session_id but a "worker" agent_type.
+    const { stateDir, lines, sidecarPath } = runHook({
+      session_id: 'parent-sess',
+      tool_use_id: 'toolu_worker_9',
+      tool_name: 'Bash',
+      tool_input: { command: 'npm run build', description: 'Build the worker output' },
+      agent_type: 'worker',
+      agent_id: 'sub-agent-42',
+    })
+    try {
+      // No sidecar row at all → the draft-mirror never emits a foreign
+      // tool_label → the live turn's card / labeledToolCount / fuse are
+      // untouched. This is the regression that would have caught the bug.
+      expect(lines.length).toBe(0)
+      expect(existsSync(sidecarPath)).toBe(false)
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true })
+    }
+  })
+
+  it('DROPS a sub-agent call flagged only by a distinct agent_id', () => {
+    const { stateDir, lines } = runHook({
+      session_id: 'parent-sess',
+      tool_use_id: 'toolu_worker_10',
+      tool_name: 'Read',
+      tool_input: { file_path: '/etc/hosts' },
+      agent_id: 'sub-agent-77',
+    })
+    try {
+      expect(lines.length).toBe(0)
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/telegram-plugin/tests/sidechain-label-filter-pretool.test.ts
+++ b/telegram-plugin/tests/sidechain-label-filter-pretool.test.ts
@@ -25,12 +25,23 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 // The hook exports isSubagentToolCall for unit testing (see the "Skip main()
 // when imported" guard at the bottom of the hook).
-import { isSubagentToolCall } from '../hooks/tool-label-pretool.mjs'
+import { isSubagentToolCall, hasAttributionSignal } from '../hooks/tool-label-pretool.mjs'
 
 const HOOK_PATH = resolve(__dirname, '..', 'hooks', 'tool-label-pretool.mjs')
+const FIXTURE_DIR = resolve(__dirname, 'fixtures')
+
+/** Load a committed real-shape PreToolUse fixture (see the drift-canary block). */
+function loadFixture(name: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(FIXTURE_DIR, name), 'utf8'))
+}
 
 /** Run the hook once with a payload; return the sidecar file's lines (if any). */
-function runHook(payload: Record<string, unknown>): { stateDir: string; lines: string[]; sidecarPath: string } {
+function runHook(payload: Record<string, unknown>): {
+  stateDir: string
+  lines: string[]
+  sidecarPath: string
+  stderr: string
+} {
   const stateDir = mkdtempSync(join(tmpdir(), 'sidechain-label-'))
   const sessionId = String(payload.session_id ?? 'sess')
   const sidecarPath = join(stateDir, `tool-labels-${sessionId}.jsonl`)
@@ -44,7 +55,7 @@ function runHook(payload: Record<string, unknown>): { stateDir: string; lines: s
   const lines = existsSync(sidecarPath)
     ? readFileSync(sidecarPath, 'utf8').split('\n').filter(Boolean)
     : []
-  return { stateDir, lines, sidecarPath }
+  return { stateDir, lines, sidecarPath, stderr: res.stderr ?? '' }
 }
 
 describe('isSubagentToolCall — main-tier vs sidechain discrimination', () => {
@@ -130,6 +141,130 @@ describe('PreToolUse hook — sidechain calls never reach the parent sidecar', (
     })
     try {
       expect(lines.length).toBe(0)
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true })
+    }
+  })
+})
+
+/**
+ * DRIFT CANARY — the compile-time half.
+ *
+ * The hand-built payloads above all use the field NAMES this reviewer round
+ * happened to expect (`agent_type`, `agent_id`). If a future Claude Code
+ * renamed BOTH (e.g. `agent_type`→`agentType`), those tests would stay green
+ * while the hook silently fails open and the cross-turn contamination bug
+ * returns. These two fixtures are the REAL 2.1.219 PreToolUse shape, verified
+ * field-by-field against the installed binary's base `Kf(...)` hook-input
+ * builder:
+ *   { session_id, transcript_path, cwd, prompt_id?, permission_mode,
+ *     agent_id, agent_type, effort?, hook_event_name, tool_name, tool_input,
+ *     tool_use_id }
+ * Piping the genuine object shape through the real hook proves the predicate
+ * works against what claude actually emits (not a mental model of it), and
+ * pins the field names so a rename that reaches these fixtures fails CI. The
+ * runtime WARNING below covers the residual case (a live CLI drift the frozen
+ * fixture can't see).
+ */
+describe('drift canary — real 2.1.219 PreToolUse payload shape', () => {
+  it('DROPS a genuine sub-agent payload (full Kf shape) — zero sidecar lines, no file', () => {
+    const fixture = loadFixture('pretool-subagent-2.1.219.json')
+    // Sanity: the fixture really is a sidechain shape (parent session_id, own
+    // agent_id, concrete agent_type) — if a maintainer refreshes it from a
+    // future CLI and the schema moved, this predicate assertion trips first.
+    expect(isSubagentToolCall(fixture)).toBe(true)
+    const { stateDir, lines, sidecarPath } = runHook(fixture)
+    try {
+      expect(lines.length).toBe(0)
+      expect(existsSync(sidecarPath)).toBe(false)
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true })
+    }
+  })
+
+  it('KEEPS a genuine main-tier payload (full Kf shape) — one sidecar line', () => {
+    const fixture = loadFixture('pretool-main-2.1.219.json')
+    expect(isSubagentToolCall(fixture)).toBe(false)
+    const { stateDir, lines } = runHook(fixture)
+    try {
+      expect(lines.length).toBe(1)
+      const row = JSON.parse(lines[0])
+      expect(row.tool_use_id).toBe('toolu_01MainReadCall4z')
+      expect(row.label).toBe('Reading index.ts')
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true })
+    }
+  })
+})
+
+/**
+ * SYMMETRIC FALSE-POSITIVE guard — an explicit "main" must win over identity.
+ *
+ * The predicate's identity fallback (`agent_id !== session_id` ⇒ sidechain)
+ * must never override an explicit `agent_type: "main"`. If a FUTURE main-tier
+ * payload stopped setting `agent_id === session_id`, the old ordering would
+ * have wrongly DROPPED legit main labels (the whole live feed for that turn).
+ */
+describe('agent_type "main" is authoritative — never a false-positive drop', () => {
+  it('KEEPS a "main" payload even when agent_id differs from session_id', () => {
+    expect(
+      isSubagentToolCall({ agent_type: 'main', agent_id: 'different-id', session_id: 's1' }),
+    ).toBe(false)
+    const { stateDir, lines } = runHook({
+      session_id: 's1',
+      tool_use_id: 'toolu_main_diverged',
+      tool_name: 'Read',
+      tool_input: { file_path: '/x/y.ts' },
+      agent_type: 'main',
+      agent_id: 'different-id',
+    })
+    try {
+      expect(lines.length).toBe(1)
+      expect(JSON.parse(lines[0]).tool_use_id).toBe('toolu_main_diverged')
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true })
+    }
+  })
+})
+
+/**
+ * FAIL-LOUD guard — a payload with NEITHER identity field is anomalous on
+ * 2.1.219 and means the schema may have drifted out from under the predicate.
+ * The hook must warn (so plugin-logger surfaces it) but NOT drop (dropping
+ * every label on drift would dark-out the whole feed).
+ */
+describe('hasAttributionSignal + the schema-drift warning', () => {
+  it('hasAttributionSignal is true with either field, false with neither', () => {
+    expect(hasAttributionSignal({ agent_type: 'main' })).toBe(true)
+    expect(hasAttributionSignal({ agent_id: 'x' })).toBe(true)
+    expect(hasAttributionSignal({ agent_type: '', agent_id: '' })).toBe(false)
+    expect(hasAttributionSignal({ session_id: 's1', tool_use_id: 't' })).toBe(false)
+    expect(hasAttributionSignal(null)).toBe(false)
+  })
+
+  it('WARNS but still writes when a real tool call carries neither agent_type nor agent_id', () => {
+    const { stateDir, lines, stderr } = runHook({
+      session_id: 's1',
+      tool_use_id: 'toolu_no_attribution',
+      tool_name: 'Read',
+      tool_input: { file_path: '/x/y.ts' },
+      // No agent_type, no agent_id — the both-fields-dropped drift scenario.
+    })
+    try {
+      // Loud: the drift warning fires (plugin-logger tails stderr)…
+      expect(stderr).toContain('sidechain-attribution invariant may be')
+      // …but NOT dropped — main-tier labels still flow so the feed isn't dark.
+      expect(lines.length).toBe(1)
+      expect(JSON.parse(lines[0]).tool_use_id).toBe('toolu_no_attribution')
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true })
+    }
+  })
+
+  it('does NOT warn on a normal 2.1.219 payload (both fields present)', () => {
+    const { stateDir, stderr } = runHook(loadFixture('pretool-main-2.1.219.json'))
+    try {
+      expect(stderr).not.toContain('sidechain-attribution invariant may be')
     } finally {
       rmSync(stateDir, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Problem

A new turn's progress card was showing step rows that belonged to a **still-running background worker dispatched by the PREVIOUS turn**. Verified from transcript: a worker's Bash `description` labels appeared in the main session's label sidecar under the parent's `agent_id`, then streamed into an unrelated new turn's card.

## Three-link cause (this PR fixes link 1, the cheapest at-source link)

1. `telegram-plugin/hooks/tool-label-pretool.mjs` — Claude Code fires PreToolUse hooks for sidechain (sub-agent) tool calls too, passing the **parent** `session_id`. The hook had no sidechain discrimination and appended the worker's label into `tool-labels-<parentSession>.jsonl`.
2. `telegram-plugin/session-tail.ts:1264` — the sidecar emits a main-tier `tool_label` event per appended line.
3. `telegram-plugin/gateway/stream-render.ts` (`case 'tool_label'`) — binds it to `getCurrentTurn()`, appends to `mirrorLines`, increments `labeledToolCount`, re-arms the orphaned-reply fuse.

## Fix — hook-level filter (the cheapest correct fix)

The installed Claude Code (2.1.219) PreToolUse payload **does** carry sidechain identity: the CLI's base `Kf()` helper includes `agent_id` and `agent_type`, and the CLI's own top-level predicate is `agentType === "main"` (its `hb()` seeds the main thread as `{ agentType: "main", agentId: <sessionId> }`; every sub-agent carries a concrete non-"main" type — `worker` / `general-purpose` / `Explore` / `Plan` / custom).

`isSubagentToolCall(event)` drops a call when `agent_type` is a concrete non-"main" value, corroborated by `agent_id !== session_id`. An **absent** `agent_type` is treated as main-tier and kept (safe default; a genuine sub-agent always carries a concrete type). A sub-agent's own activity is already surfaced by the worker-feed (`sub_agent_tool_use` events from its own transcript), so nothing is lost.

Because the label is never written to the parent sidecar, no foreign `tool_label` event is ever emitted — the `labeledToolCount` inflation and the foreign-fuse re-arming downstream are fixed by construction, no render-layer change needed.

## Test

`telegram-plugin/tests/sidechain-label-filter-pretool.test.ts` asserts the outcome: a sub-agent PreToolUse payload writes **no** line to the parent sidecar (a main-tier payload still does), plus the pure `isSubagentToolCall` predicate across main/absent/sub-agent shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)