### PR TITLE
fix(telegram): surface a card for genuinely-queued mid-turn messages

### DIFF
--- a/telegram-plugin/gateway/handback-preturn-signal.ts
+++ b/telegram-plugin/gateway/handback-preturn-signal.ts
@@ -246,6 +246,15 @@ export interface HandbackPreturnSignal {
    *  re-keyed to the real `statusKey` so the turn's end-of-turn
    *  `clearActivitySummary` finalizes it. Cancels the debounce/self-reap. */
   tryAdopt: (turnId: string) => HandbackAdoption | null
+  /** True IFF a live (un-consumed) pre-turn entry is armed whose adopting turn
+   *  is `turnId`. Consulted by the queued-card surface (stream-render Part B) at
+   *  PARK time: when a handback pre-turn signal already owns the surface for the
+   *  turn this parked message will mint, the queued card must NOT be posted —
+   *  otherwise the same message ends up with two cards (the handback card the
+   *  turn adopts, plus a queued card that then freezes). Turn-scoped, NOT
+   *  key-scoped, so an unrelated user message parked on the same topic (a
+   *  DIFFERENT adoptTurnId) is not wrongly suppressed. */
+  hasPendingForTurnId: (turnId: string) => boolean
   /** True IFF `turnKey` is a synthetic pre-turn record key. */
   isPreTurnRecord: (turnKey: string) => boolean
   /** Reap hook for the gateway's mid-session / boot card reapers: stop the
@@ -514,6 +523,13 @@ export function createHandbackPreturnSignal(
       }
       dropEntry(entry)
       return adoption
+    },
+
+    hasPendingForTurnId(turnId) {
+      for (const e of byKey.values()) {
+        if (e.adoptTurnId === turnId && !e.consumed) return true
+      }
+      return false
     },
 
     isPreTurnRecord(turnKey) {

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -586,6 +586,26 @@ function beginTurn(deps: StreamRenderDeps, ev: TurnStartEnvelope): void {
       process.stderr.write(
         `telegram gateway: queued card adopted turnId=${turnId} card=${ev.queuedCardMessageId}\n`,
       )
+    } else if (
+      QUEUED_CARD_ENABLED &&
+      ev.queuedCardMessageId != null &&
+      ev.chatId != null &&
+      next.activityMessageId != null &&
+      next.activityMessageId !== ev.queuedCardMessageId
+    ) {
+      // Part B safety net — the handback adoption above WON the surface (its card
+      // is now `activityMessageId`) yet this envelope ALSO carries a queued card:
+      // the park raced ahead of `noteHandbackRelease`, so the park-time
+      // suppression missed and a queued card got posted. It is now a pure
+      // duplicate that would otherwise FREEZE on "⏳ Queued" beneath the adopted
+      // handback card (the MAJOR). Delete it — the handback card is the one
+      // surface; a delete (not a "folded" edit) is right because there is no
+      // separate message to explain, just a stray duplicate to remove.
+      deleteQueuedCard(deps, ev.chatId, ev.queuedCardMessageId)
+      process.stderr.write(
+        `telegram gateway: queued card superseded by handback adoption turnId=${turnId} ` +
+          `queued=${ev.queuedCardMessageId} adopted=${next.activityMessageId}\n`,
+      )
     }
     // #3544 — arm the turn-long `typing…` loop for EVERY minted turn,
     // unconditionally. It used to hang off the handback ADOPTION above,
@@ -939,7 +959,29 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
       // Post the queued card, reply-anchored to the parked message, and store its
       // id back on the envelope so `beginTurn` can adopt+edit it on dequeue. One
       // card per envelope (multiple queued messages each get their own).
-      if (QUEUED_CARD_ENABLED) {
+      //
+      // SUPPRESS when a handback pre-turn signal already owns this turn's surface
+      // (the common worker-handoff-while-busy case): `noteHandbackRelease` fired
+      // at buffer drain BEFORE this injected handback inbound reached park, so an
+      // entry armed for THIS message's turnId is already live. That entry paints
+      // (and the dequeued turn adopts) its OWN card, so a queued card here would
+      // be a second card that then freezes on "⏳ Queued" (the MAJOR this fixes).
+      // Turn-scoped, not key-scoped: an unrelated user message parked on the same
+      // topic derives a different turnId and is NOT suppressed. beginTurn carries
+      // a belt-and-suspenders cleanup for the residual race where the queued card
+      // was already posted before the handback entry armed.
+      const parkTurnId = deriveTurnId(ev.chatId, enqThreadIdNum ?? null, ev.messageId)
+      const handbackOwnsSurface =
+        HANDBACK_PRETURN_ENABLED &&
+        parkTurnId != null &&
+        handbackPreturnSignal.hasPendingForTurnId(parkTurnId)
+      if (handbackOwnsSurface) {
+        process.stderr.write(
+          `telegram gateway: queued card suppressed (handback owns surface) ` +
+            `turnId=${parkTurnId} msg=${ev.messageId ?? '-'}\n`,
+        )
+      }
+      if (QUEUED_CARD_ENABLED && !handbackOwnsSurface) {
         const cardChatId = ev.chatId
         const replyToRaw = ev.messageId != null ? Number(ev.messageId) : null
         const replyTo = replyToRaw != null && Number.isFinite(replyToRaw) ? replyToRaw : null

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -133,6 +133,21 @@ import * as silencePoke from '../silence-poke.js'
 const PARKED_TURN_START_MAX = 16
 const PARKED_TURN_START_TTL_MS = 30 * 60_000
 
+// ─── Queued-turn card (#3927 follow-up) ──────────────────────────────────────
+// Since #3927 a genuinely-queued mid-turn message is parked with NO surface at
+// all until it dequeues — the user gets silence between sending and the turn
+// starting. We post an immediate, clearly-marked "queued" card at park time,
+// reply-anchored to the parked message, and store its id on the envelope. On
+// dequeue → `beginTurn` seeds it as the turn's `activityMessageId` (mirroring
+// the handback-card adoption) so the SAME card is EDITED IN PLACE into the live
+// progress card — one lifecycle, finalized by the normal turn end. A `remove`
+// (folded into the running turn) or a TTL expiry finalizes it so it never
+// freezes. Kill switch: SWITCHROOM_QUEUED_CARD=0.
+const QUEUED_CARD_ENABLED = process.env.SWITCHROOM_QUEUED_CARD !== '0'
+const QUEUED_CARD_HTML = '⏳ Queued — waiting for the current task to finish…'
+const QUEUED_CARD_FOLDED_HTML = '✅ Folded into the current task.'
+const QUEUED_CARD_EXPIRED_HTML = '⚠️ This queued message timed out before it could start.'
+
 /** The `enqueue` envelope fields `beginTurn` needs — the SessionEvent minus its
  *  discriminant. A parked entry additionally carries `parkedAt` for the TTL. */
 export interface TurnStartEnvelope {
@@ -140,6 +155,10 @@ export interface TurnStartEnvelope {
   messageId: string | null
   threadId: string | null
   rawContent: string
+  /** Message id of the "queued" card posted at park time (Part B). Seeded as the
+   *  turn's `activityMessageId` on dequeue so the card is edited in place into
+   *  the live progress card. Absent on the idle-mint path (no parking, no card). */
+  queuedCardMessageId?: number | null
 }
 interface ParkedTurnStart extends TurnStartEnvelope {
   parkedAt: number
@@ -149,7 +168,9 @@ interface ParkedTurnStart extends TurnStartEnvelope {
  *  claude CLI session's ONE queue, exactly like the `currentTurn` mirror. */
 const parkedTurnStarts: ParkedTurnStart[] = []
 
-function pruneParkedTurnStarts(now: number): void {
+/** `onDrop` (Part B) fires for every removed entry so the caller can finalize a
+ *  posted queued card. Best-effort — never throws into the prune loop. */
+function pruneParkedTurnStarts(now: number, onDrop?: (entry: ParkedTurnStart) => void): void {
   for (let i = parkedTurnStarts.length - 1; i >= 0; i--) {
     if (now - parkedTurnStarts[i].parkedAt > PARKED_TURN_START_TTL_MS) {
       const [dropped] = parkedTurnStarts.splice(i, 1)
@@ -157,19 +178,29 @@ function pruneParkedTurnStarts(now: number): void {
         `telegram gateway: parked-turn-start expired chat=${dropped.chatId ?? '-'} ` +
           `msg=${dropped.messageId ?? '-'} age_ms=${now - dropped.parkedAt}\n`,
       )
+      try { onDrop?.(dropped) } catch { /* never let card cleanup break the prune */ }
     }
   }
 }
 
-function parkTurnStart(env: TurnStartEnvelope, now: number): void {
-  parkedTurnStarts.push({ ...env, parkedAt: now })
+/** Returns the freshly-parked entry so the caller can attach a queued-card id to
+ *  it asynchronously. `onEvict` (Part B) fires for a cap-evicted entry. */
+function parkTurnStart(
+  env: TurnStartEnvelope,
+  now: number,
+  onEvict?: (entry: ParkedTurnStart) => void,
+): ParkedTurnStart {
+  const entry: ParkedTurnStart = { ...env, parkedAt: now }
+  parkedTurnStarts.push(entry)
   while (parkedTurnStarts.length > PARKED_TURN_START_MAX) {
     const [dropped] = parkedTurnStarts.splice(0, 1)
     process.stderr.write(
       `telegram gateway: parked-turn-start evicted (cap ${PARKED_TURN_START_MAX}) ` +
         `chat=${dropped.chatId ?? '-'} msg=${dropped.messageId ?? '-'}\n`,
     )
+    try { onEvict?.(dropped) } catch { /* never let card cleanup break parking */ }
   }
+  return entry
 }
 
 /** Pop the MOST RECENTLY parked envelope — the one a `dequeue` pairs with. */
@@ -181,14 +212,14 @@ function takeParkedTurnStart(): ParkedTurnStart | null {
  *  match first. A `remove` means "folded into the running turn" — that message
  *  will never get a turn of its own, so leaving it parked would let a LATER
  *  `dequeue` mint a spurious turn for an already-answered message. */
-function discardParkedTurnStart(rawContent: string): boolean {
+function discardParkedTurnStart(rawContent: string): ParkedTurnStart | null {
   for (let i = parkedTurnStarts.length - 1; i >= 0; i--) {
     if (parkedTurnStarts[i].rawContent === rawContent) {
-      parkedTurnStarts.splice(i, 1)
-      return true
+      const [dropped] = parkedTurnStarts.splice(i, 1)
+      return dropped
     }
   }
-  return false
+  return null
 }
 
 /** Test seam: the parked store is module-scope (one CLI session, one queue), so
@@ -199,6 +230,111 @@ export function __resetParkedTurnStartsForTest(): void {
 /** Test seam: parked-envelope count (bound / eviction assertions). */
 export function __parkedTurnStartCountForTest(): number {
   return parkedTurnStarts.length
+}
+
+// ─── Queued-turn card send / finalize (Part B) ───────────────────────────────
+// These use the ALREADY-injected `bot` + `robustApiCall` deps, so the whole
+// feature lives in stream-render.ts with zero new wiring in gateway.ts. No
+// streaming is structurally possible before dequeue (no CurrentTurn exists),
+// so this card is a single static line until the turn adopts + edits it.
+
+/** Minimal deps the queued-card helpers need. */
+type QueuedCardDeps = Pick<StreamRenderDeps, 'bot' | 'robustApiCall'>
+
+/** Post the "queued" card, reply-anchored to the parked message. Resolves to the
+ *  sent message id, or null when the send failed / was suppressed (best-effort —
+ *  a null just means no card, so nothing to adopt or finalize). Forum topics use
+ *  the envelope's OWN thread id. */
+async function openQueuedCard(
+  deps: QueuedCardDeps,
+  chatId: string,
+  threadId: number | null,
+  replyToMessageId: number | null,
+): Promise<number | null> {
+  try {
+    const sent = await deps.robustApiCall(
+      // allow-raw-bot-api: sendRichMessage routed through robustApiCall (not in the THREAD_NOT_FOUND blast pattern)
+      () =>
+        deps.bot.api.sendRichMessage(chatId, richMessage(QUEUED_CARD_HTML), {
+          ...(threadId != null ? { message_thread_id: threadId } : {}),
+          ...(replyToMessageId != null
+            ? { reply_parameters: { message_id: replyToMessageId, allow_sending_without_reply: true } }
+            : {}),
+          // Status surface, not the user's answer — never ping the device.
+          disable_notification: true,
+        }),
+      {
+        chat_id: chatId,
+        ...(threadId != null ? { threadId } : {}),
+        verb: 'queued-card.send',
+      },
+    )
+    return sent?.message_id ?? null
+  } catch (err) {
+    process.stderr.write(
+      `telegram gateway: queued card send failed: ${(err as Error).message}\n`,
+    )
+    return null
+  }
+}
+
+/** Finalize (single honest edit) a queued card that will NOT become a live turn:
+ *  folded into the running turn (`remove`) or timed out (TTL). Best-effort. */
+function finalizeQueuedCard(
+  deps: QueuedCardDeps,
+  chatId: string,
+  threadId: number | null,
+  messageId: number,
+  html: string,
+): void {
+  void deps
+    .robustApiCall(
+      // allow-raw-bot-api: editMessageText routed through robustApiCall
+      () => deps.bot.api.editMessageText(chatId, messageId, richMessage(html), {}),
+      {
+        chat_id: chatId,
+        ...(threadId != null ? { threadId } : {}),
+        verb: 'queued-card.finalize',
+      },
+    )
+    .catch(() => undefined)
+}
+
+/** Delete a queued card that lost its race (the entry left the store before its
+ *  card id was stored, so `beginTurn` couldn't adopt it — a fresh progress card
+ *  will open instead). Best-effort. */
+function deleteQueuedCard(
+  deps: QueuedCardDeps,
+  chatId: string,
+  messageId: number,
+): void {
+  void deps
+    .robustApiCall(
+      // allow-raw-bot-api: deleteMessage routed through robustApiCall
+      () => deps.bot.api.deleteMessage(chatId, messageId),
+      { chat_id: chatId, verb: 'queued-card.delete-orphan' },
+    )
+    .catch(() => undefined)
+}
+
+/** Numeric thread id from an envelope's string thread id (null/invalid → null). */
+function envThreadIdNum(threadId: string | null): number | null {
+  if (threadId == null) return null
+  const n = Number(threadId)
+  return Number.isFinite(n) ? n : null
+}
+
+/** Finalize a queued card carried by a parked entry that is being dropped
+ *  (folded via `remove`, cap-evicted, or TTL-expired). No-op when the entry
+ *  never got a card. */
+function finalizeParkedEntryCard(
+  deps: QueuedCardDeps,
+  entry: ParkedTurnStart,
+  html: string,
+): void {
+  if (!QUEUED_CARD_ENABLED) return
+  if (entry.queuedCardMessageId == null || entry.chatId == null) return
+  finalizeQueuedCard(deps, entry.chatId, envThreadIdNum(entry.threadId), entry.queuedCardMessageId, html)
 }
 
 /**
@@ -435,6 +571,21 @@ function beginTurn(deps: StreamRenderDeps, ev: TurnStartEnvelope): void {
             `key=${handbackAdoption.statusKey} card=${handbackAdoption.activityMessageId ?? 'none'}\n`,
         )
       }
+    }
+    // Part B — ADOPT the queued card. A parked envelope reaching `beginTurn`
+    // (via `dequeue`) carries the id of the "queued" card posted at park time.
+    // Seed it exactly as the handback adoption does so `renderActivityFeed`
+    // EDITS that same message into the live progress card instead of opening a
+    // second one, and the turn's own end-of-turn `clearActivitySummary`
+    // finalizes it — one continuous lifecycle. Guarded on `activityMessageId`
+    // still being null so a card-bearing handback adoption (mutually exclusive
+    // in practice) is never clobbered.
+    if (QUEUED_CARD_ENABLED && ev.queuedCardMessageId != null && next.activityMessageId == null) {
+      next.activityMessageId = ev.queuedCardMessageId
+      next.activityEverOpened = true
+      process.stderr.write(
+        `telegram gateway: queued card adopted turnId=${turnId} card=${ev.queuedCardMessageId}\n`,
+      )
     }
     // #3544 — arm the turn-long `typing…` loop for EVERY minted turn,
     // unconditionally. It used to hang off the handback ADOPTION above,
@@ -731,7 +882,7 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
           )
         }
       }
-      pruneParkedTurnStarts(now)
+      pruneParkedTurnStarts(now, (e) => finalizeParkedEntryCard(deps, e, QUEUED_CARD_EXPIRED_HTML))
       // `enqueue` with no chat can never mint a turn (the whole mint block is
       // `if (ev.chatId)`-gated); parking it would only pollute the store, so
       // run the pre-turn drain path verbatim and stop.
@@ -751,11 +902,13 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
         beginTurn(deps, ev)
         return
       }
-      // PARKED. Deliberately NO surface work here — no `promoteQueuedStatus`
-      // ("On it — replying now" is a lie until the turn actually starts), no
-      // `typingWrapper.drainAll()` (that drains the LIVE turn's wraps), no card.
-      // The queued placeholder Hook A already posted is the honest surface, and
-      // its lifecycle stays owned by the existing reap machinery.
+      // PARKED. No `promoteQueuedStatus` ("On it — replying now" is a lie until
+      // the turn actually starts) and no `typingWrapper.drainAll()` (that drains
+      // the LIVE turn's wraps). Part B DOES post one honest, clearly-marked
+      // "queued" card here: on the machine-authoritative path (the default) the
+      // legacy Hook A placeholder never fires — it lives in the buffer-until-idle
+      // branch that returns BEFORE the machine enqueues — so before Part B a
+      // parked envelope had no surface at all until it dequeued.
       //
       // UNIFORM ACROSS SOURCES — synthetic enqueues (cron fire, subagent
       // handback, obligation-represent, vault-grant resume, wake inbound) park
@@ -766,7 +919,7 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
       // attachment), never by a `dequeue`. Minting for it invented a turn the
       // CLI never started. FIX B covers the residual case where a mint DOES
       // land on top of a live atom.
-      parkTurnStart(
+      const parkedEntry = parkTurnStart(
         {
           chatId: ev.chatId,
           messageId: ev.messageId,
@@ -774,12 +927,35 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
           rawContent: ev.rawContent,
         },
         now,
+        // Cap-evicted (oldest lost its slot) → finalize its card as expired so
+        // it never freezes on "⏳ Queued".
+        (evicted) => finalizeParkedEntryCard(deps, evicted, QUEUED_CARD_EXPIRED_HTML),
       )
       process.stderr.write(
         `telegram gateway: turn-start parked (session busy) chat=${ev.chatId} ` +
           `thread=${enqThreadIdNum ?? '-'} msg=${ev.messageId ?? '-'} ` +
           `parked=${parkedTurnStarts.length}\n`,
       )
+      // Post the queued card, reply-anchored to the parked message, and store its
+      // id back on the envelope so `beginTurn` can adopt+edit it on dequeue. One
+      // card per envelope (multiple queued messages each get their own).
+      if (QUEUED_CARD_ENABLED) {
+        const cardChatId = ev.chatId
+        const replyToRaw = ev.messageId != null ? Number(ev.messageId) : null
+        const replyTo = replyToRaw != null && Number.isFinite(replyToRaw) ? replyToRaw : null
+        void openQueuedCard(deps, cardChatId, enqThreadIdNum ?? null, replyTo).then((cardId) => {
+          if (cardId == null) return
+          // Still parked → adopt on the next dequeue. Otherwise the entry already
+          // dequeued/removed/expired before the async send resolved (a sub-second
+          // race), so `beginTurn` ran without the id — delete the orphan card so
+          // no frozen duplicate lingers below the turn's own fresh card.
+          if (parkedTurnStarts.includes(parkedEntry)) {
+            parkedEntry.queuedCardMessageId = cardId
+          } else {
+            deleteQueuedCard(deps, cardChatId, cardId)
+          }
+        })
+      }
       return
     }
     case 'dequeue': {
@@ -789,7 +965,7 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
       // RECENT enqueue, not the oldest. An empty store is the normal idle path
       // (the enqueue ms earlier already minted) and a dequeue with no parked
       // start at all is a no-op, exactly as before.
-      pruneParkedTurnStarts(Date.now())
+      pruneParkedTurnStarts(Date.now(), (e) => finalizeParkedEntryCard(deps, e, QUEUED_CARD_EXPIRED_HTML))
       const parked = takeParkedTurnStart()
       if (parked == null) return
       beginTurn(deps, parked)
@@ -801,8 +977,11 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
       // its parked envelope so a later `dequeue` cannot mint a spurious turn
       // for it. Content-matched: `remove` replays its enqueue's `content`
       // byte-for-byte.
-      pruneParkedTurnStarts(Date.now())
-      discardParkedTurnStart(ev.rawContent)
+      pruneParkedTurnStarts(Date.now(), (e) => finalizeParkedEntryCard(deps, e, QUEUED_CARD_EXPIRED_HTML))
+      // Part B — finalize the removed envelope's queued card as "folded into the
+      // current task" so it never freezes on "⏳ Queued".
+      const removed = discardParkedTurnStart(ev.rawContent)
+      if (removed != null) finalizeParkedEntryCard(deps, removed, QUEUED_CARD_FOLDED_HTML)
       return
     }
     case 'model': {

--- a/telegram-plugin/tests/activity-ever-opened-sticky.test.ts
+++ b/telegram-plugin/tests/activity-ever-opened-sticky.test.ts
@@ -11,13 +11,17 @@
  *
  * Load-bearing constraints:
  *   1. `activityEverOpened = true` is set only at legitimate feed-OPEN signal
- *      sites in gateway.ts — the send-message success site in
- *      drainActivitySummary, AND the sub-agent-handback pre-turn ADOPTION site
- *      (#3268): an adopted turn inherits an already-open pre-turn card via a
- *      seeded `activityMessageId`, so it only ever EDITs the feed (never hits
- *      the open branch), and must stamp the flag itself so the turn-end
- *      DEGRADED check doesn't false-flag it as "feed never opened". Both are
- *      set-TRUE (never a reset), preserving the sticky-true invariant.
+ *      sites — the send-message success site in drainActivitySummary, the
+ *      sub-agent-handback pre-turn ADOPTION site (#3268), AND the queued-card
+ *      ADOPTION site (#3927 Part B). The two adoption sites are the same shape:
+ *      an adopted turn inherits an ALREADY-OPEN, user-visible card via a seeded
+ *      `activityMessageId`, so it only ever EDITs the feed (never hits the open
+ *      branch), and must stamp the flag itself so the turn-end DEGRADED check
+ *      doesn't false-flag it as "feed never opened". A parked message's "⏳
+ *      Queued" card is a real message the user already sees before the turn
+ *      mints, so adopting it on dequeue IS a feed-open — same rationale as the
+ *      handback adoption. All three are set-TRUE (never a reset), preserving the
+ *      sticky-true invariant.
  *   2. `turn.activityEverOpened = false` NEVER appears in gateway.ts (it is only
  *      initialised to `false` in the turn-initialiser object literal, never reset
  *      via a standalone assignment).
@@ -49,13 +53,16 @@ const laneSrc = readFileSync(
 const gatewayAndStreamSrc = gatewaySrc + '\n' + streamSrc + '\n' + laneSrc
 
 describe('M-2: activityEverOpened sticky-true invariant', () => {
-  it('activityEverOpened = true appears only at the two feed-OPEN signal sites', () => {
+  it('activityEverOpened = true appears only at the three feed-OPEN signal sites', () => {
     // Site 1: drainActivitySummary send-message success. Site 2: the #3268
-    // handback pre-turn ADOPTION seed (an adopted turn only edits, so it stamps
-    // the flag itself). Both are set-TRUE; the sticky invariant (no reset to
-    // false) is enforced by the next test.
+    // handback pre-turn ADOPTION seed. Site 3: the #3927 Part B queued-card
+    // ADOPTION seed (stream-render.ts) — a parked message's "⏳ Queued" card is
+    // an already-open, user-visible card the dequeued turn adopts and only
+    // EDITs, so it stamps the flag itself, exactly like the handback adoption.
+    // All three are set-TRUE; the sticky invariant (no reset to false) is
+    // enforced by the next test.
     const setTrueMatches = [...gatewayAndStreamSrc.matchAll(/activityEverOpened\s*=\s*true/g)]
-    expect(setTrueMatches).toHaveLength(2)
+    expect(setTrueMatches).toHaveLength(3)
   })
 
   it('turn.activityEverOpened = false never appears (no standalone reset)', () => {

--- a/telegram-plugin/tests/queued-card-surface.test.ts
+++ b/telegram-plugin/tests/queued-card-surface.test.ts
@@ -14,7 +14,7 @@
  *   • remove  → the card is finalized as "folded into the current task".
  *   • TTL     → the card is finalized as timed-out, never left frozen.
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import {
   handleSessionEvent,
   __resetParkedTurnStartsForTest,
@@ -131,33 +131,38 @@ describe('Part B — queued card is finalized, never frozen', () => {
   })
 
   it('finalizes the card as timed-out on TTL expiry (a dequeue that never arrives)', async () => {
-    vi.useFakeTimers()
+    // Runner-agnostic: the TTL prune reads wall-clock `Date.now()` (it is NOT a
+    // scheduled setTimeout), so we drive it by advancing `Date.now` around the
+    // dequeue rather than a vitest-only fake-timer API (`vi.runAllTimersAsync`
+    // is absent under bun — the same reason handback-preturn-signal.test.ts
+    // injects its own scheduler). `parkedAt` is stamped with the REAL clock at
+    // park; only the prune's `now` is advanced, so the entry ages past the TTL.
+    const h = makeHarness()
+    const rec = withRecordingBot(h)
+
+    handleSessionEvent(h.deps, enqueue('1201'))
+    const turnA = h.current()!
+    handleSessionEvent(h.deps, enqueue('1202'))
+    await settle() // real microtask/macrotask flush → the card id lands on the entry
+    expect(rec.sends).toHaveLength(1)
+    const cardId = rec.sends[0]!.id
+
+    // 31 minutes pass with neither dequeue nor remove; a stray dequeue prunes it.
+    const realNow = Date.now
+    Date.now = () => realNow() + 31 * 60_000
     try {
-      const h = makeHarness()
-      const rec = withRecordingBot(h)
-
-      handleSessionEvent(h.deps, enqueue('1201'))
-      const turnA = h.current()!
-      handleSessionEvent(h.deps, enqueue('1202'))
-      // Under fake timers the send still resolves on a real microtask flush.
-      await vi.runAllTimersAsync()
-      expect(rec.sends).toHaveLength(1)
-      const cardId = rec.sends[0]!.id
-
-      // 31 minutes pass with neither dequeue nor remove; a stray dequeue prunes it.
-      vi.advanceTimersByTime(31 * 60_000)
       turnA.endedAt = Date.now()
       handleSessionEvent(h.deps, { kind: 'dequeue' })
-      await vi.runAllTimersAsync()
-
-      expect(__parkedTurnStartCountForTest()).toBe(0)
-      expect(h.current()).toBe(turnA) // 1202 was NOT minted 31 min late
-      expect(rec.edits).toHaveLength(1)
-      expect(rec.edits[0]!.messageId).toBe(cardId)
-      expect(rec.edits[0]!.markdown).toContain('timed out')
     } finally {
-      vi.useRealTimers()
+      Date.now = realNow
     }
+    await settle()
+
+    expect(__parkedTurnStartCountForTest()).toBe(0)
+    expect(h.current()).toBe(turnA) // 1202 was NOT minted 31 min late
+    expect(rec.edits).toHaveLength(1)
+    expect(rec.edits[0]!.messageId).toBe(cardId)
+    expect(rec.edits[0]!.markdown).toContain('timed out')
   })
 })
 

--- a/telegram-plugin/tests/queued-card-surface.test.ts
+++ b/telegram-plugin/tests/queued-card-surface.test.ts
@@ -20,7 +20,8 @@ import {
   __resetParkedTurnStartsForTest,
   __parkedTurnStartCountForTest,
 } from '../gateway/stream-render.js'
-import { makeHarness, enqueue, type Harness } from './turn-mint-harness.js'
+import { makeHarness, enqueue, CHAT, type Harness } from './turn-mint-harness.js'
+import { deriveTurnId } from '../gateway/derive-turn-id.js'
 
 interface SendRec { chatId: string; markdown: string; opts: Record<string, unknown>; id: number }
 interface EditRec { chatId: string; messageId: number; markdown: string }
@@ -157,5 +158,100 @@ describe('Part B — queued card is finalized, never frozen', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+})
+
+/**
+ * Regression for the handback-while-busy MAJOR (adversarial review of #4040).
+ *
+ * The COMMON worker-handoff case: a worker hands back while the parent session
+ * is busy → the handback pre-turn signal arms a card for that turn → the same
+ * handback inbound parks → (before the fix) the park posted a SECOND "⏳ Queued"
+ * card unconditionally → on dequeue the handback `tryAdopt` won the surface, so
+ * the Part B `activityMessageId == null` guard was false and the queued card was
+ * neither adopted nor finalized → TWO cards for one message, the queued one
+ * FROZEN forever.
+ *
+ * The shared harness hardcodes `HANDBACK_PRETURN_ENABLED:false` +
+ * `tryAdopt:()=>null`, so it never exercised this; here we turn the signal ON
+ * with a card-bearing `tryAdopt`, matching prod. Both tests fail on the current
+ * HEAD (a queued card is posted and then frozen) and pass after the fix.
+ */
+const HANDBACK_CARD_ID = 7777
+
+/** Turn the handback pre-turn signal ON for message `msgId`'s turn. `pendingAtPark`
+ *  models whether `noteHandbackRelease` has already armed the entry by the time the
+ *  message parks (true = the common case; false = the sub-second race the beginTurn
+ *  safety net covers). `tryAdopt` always returns the handback card for that turn. */
+function withHandbackFor(h: Harness, msgId: string, pendingAtPark: boolean) {
+  const tid = deriveTurnId(CHAT, null, msgId)!
+  const d = h.deps as unknown as {
+    HANDBACK_PRETURN_ENABLED: boolean
+    handbackPreturnSignal: {
+      hasPendingForTurnId: (t: string) => boolean
+      tryAdopt: (t: string) => { activityMessageId: number | null; statusKey: string } | null
+    }
+  }
+  d.HANDBACK_PRETURN_ENABLED = true
+  d.handbackPreturnSignal = {
+    hasPendingForTurnId: (t: string) => pendingAtPark && t === tid,
+    tryAdopt: (t: string) =>
+      t === tid ? { activityMessageId: HANDBACK_CARD_ID, statusKey: `${CHAT}:main` } : null,
+  }
+  return tid
+}
+
+describe('Part B — handback-while-busy: exactly one card, never a frozen "Queued"', () => {
+  it('SUPPRESSES the queued card at park when a handback signal already owns the turn (common case)', async () => {
+    const h = makeHarness()
+    const rec = withRecordingBot(h)
+    withHandbackFor(h, '502', /* pendingAtPark */ true)
+
+    // Turn A mints on an idle session.
+    handleSessionEvent(h.deps, enqueue('501'))
+    const turnA = h.current()!
+
+    // The handback inbound (502) parks while A is busy. The handback signal
+    // already owns 502's surface → NO queued card is posted.
+    handleSessionEvent(h.deps, enqueue('502', 'handback: worker done'))
+    await settle()
+    expect(rec.sends).toHaveLength(0) // ← fails on HEAD (a 2nd card was posted)
+
+    // A ends → 502 dequeues → adopts the HANDBACK card as its one surface.
+    turnA.endedAt = Date.now()
+    handleSessionEvent(h.deps, { kind: 'dequeue' })
+    const turnB = h.current()!
+    expect(turnB.activityMessageId).toBe(HANDBACK_CARD_ID)
+    // No queued card was ever posted, edited, or left frozen.
+    expect(rec.sends).toHaveLength(0)
+    expect(rec.edits).toHaveLength(0)
+    expect(rec.deletes).toHaveLength(0)
+  })
+
+  it('DELETES the orphaned queued card at dequeue when the handback armed after park (the race)', async () => {
+    const h = makeHarness()
+    const rec = withRecordingBot(h)
+    withHandbackFor(h, '502', /* pendingAtPark */ false)
+
+    handleSessionEvent(h.deps, enqueue('501'))
+    const turnA = h.current()!
+
+    // 502 parks BEFORE the handback entry armed → the queued card is posted.
+    handleSessionEvent(h.deps, enqueue('502', 'handback: worker done'))
+    await settle()
+    expect(rec.sends).toHaveLength(1)
+    const queuedCardId = rec.sends[0]!.id
+
+    // A ends → 502 dequeues → the handback adoption WINS the surface, and the
+    // now-orphaned queued card is DELETED so it never freezes on "⏳ Queued".
+    turnA.endedAt = Date.now()
+    handleSessionEvent(h.deps, { kind: 'dequeue' })
+    const turnB = h.current()!
+    expect(turnB.activityMessageId).toBe(HANDBACK_CARD_ID) // handback card is the surface
+    expect(rec.deletes).toHaveLength(1) // ← fails on HEAD (no cleanup, card frozen)
+    expect(rec.deletes[0]!.messageId).toBe(queuedCardId)
+    // One live card total: the handback card. The queued card was removed, not
+    // left as a frozen "Queued" and not finalized as folded/timed-out.
+    expect(rec.edits).toHaveLength(0)
   })
 })

--- a/telegram-plugin/tests/queued-card-surface.test.ts
+++ b/telegram-plugin/tests/queued-card-surface.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Part B (#3927 follow-up) — the queued-turn card.
+ *
+ * Since #3927 a genuinely-queued mid-turn message is PARKED with no surface at
+ * all until it dequeues: on the machine-authoritative path the legacy Hook A
+ * placeholder never fires (it lives in the buffer-until-idle branch that returns
+ * before the machine enqueues). These tests assert the fix's lifecycle against
+ * the REAL `handleSessionEvent`:
+ *
+ *   • park    → a "⏳ Queued" card is posted ONCE, reply-anchored to the parked
+ *               message, in the envelope's own chat/thread.
+ *   • dequeue → the SAME card id is adopted as the turn's activityMessageId and
+ *               EDITED in place (not re-sent) — one continuous lifecycle.
+ *   • remove  → the card is finalized as "folded into the current task".
+ *   • TTL     → the card is finalized as timed-out, never left frozen.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  handleSessionEvent,
+  __resetParkedTurnStartsForTest,
+  __parkedTurnStartCountForTest,
+} from '../gateway/stream-render.js'
+import { makeHarness, enqueue, type Harness } from './turn-mint-harness.js'
+
+interface SendRec { chatId: string; markdown: string; opts: Record<string, unknown>; id: number }
+interface EditRec { chatId: string; messageId: number; markdown: string }
+interface DelRec { chatId: string; messageId: number }
+
+/** Attach a recording bot to a harness so the queued-card send/edit/delete calls
+ *  are observable. `sendRichMessage` returns an incrementing message id. */
+function withRecordingBot(h: Harness) {
+  const sends: SendRec[] = []
+  const edits: EditRec[] = []
+  const deletes: DelRec[] = []
+  let nextId = 9001
+  ;(h.deps as unknown as { bot: unknown }).bot = {
+    api: {
+      sendRichMessage: async (chatId: string, msg: { markdown: string }, opts: Record<string, unknown>) => {
+        const id = nextId++
+        sends.push({ chatId, markdown: msg.markdown, opts, id })
+        return { message_id: id }
+      },
+      editMessageText: async (chatId: string, messageId: number, msg: { markdown: string }) => {
+        edits.push({ chatId, messageId, markdown: msg.markdown })
+        return true
+      },
+      deleteMessage: async (chatId: string, messageId: number) => {
+        deletes.push({ chatId, messageId })
+        return true
+      },
+    },
+  }
+  return { sends, edits, deletes }
+}
+
+/** Flush the microtask + macrotask queue so the async card send's `.then` (which
+ *  stores the card id on the parked envelope) has run. */
+const settle = () => new Promise((r) => setTimeout(r, 0))
+
+beforeEach(() => {
+  __resetParkedTurnStartsForTest()
+})
+
+describe('Part B — queued card is posted at park and adopted on dequeue', () => {
+  it('parks with a reply-anchored "Queued" card, then EDITS that same card in place on dequeue', async () => {
+    const h = makeHarness()
+    const rec = withRecordingBot(h)
+
+    // Turn A mints on an idle session.
+    handleSessionEvent(h.deps, enqueue('501'))
+    const turnA = h.current()!
+    expect(rec.sends).toHaveLength(0) // idle mint posts no queued card
+
+    // Message B arrives mid-turn → parks → queued card is posted ONCE.
+    handleSessionEvent(h.deps, enqueue('502', 'also check the vault'))
+    await settle()
+    expect(__parkedTurnStartCountForTest()).toBe(1)
+    expect(rec.sends).toHaveLength(1)
+    const card = rec.sends[0]!
+    expect(card.markdown).toContain('Queued')
+    // Reply-anchored to B's own message id, in B's chat.
+    expect((card.opts.reply_parameters as { message_id: number }).message_id).toBe(502)
+    expect(card.chatId).toBe('1001')
+
+    // Turn A ends; the CLI drains the queue → B mints and ADOPTS the card.
+    turnA.endedAt = Date.now()
+    handleSessionEvent(h.deps, { kind: 'dequeue' })
+    const turnB = h.current()!
+    expect(turnB).not.toBe(turnA)
+    expect(turnB.sourceMessageId).toBe(502)
+    // The queued card became the live progress card — same id, adopted in place.
+    expect(turnB.activityMessageId).toBe(card.id)
+    expect(turnB.activityEverOpened).toBe(true)
+    // No SECOND card was ever sent (edited in place, not re-posted).
+    expect(rec.sends).toHaveLength(1)
+  })
+
+  it('posts one card PER envelope (multiple queued messages each get their own)', async () => {
+    const h = makeHarness()
+    const rec = withRecordingBot(h)
+
+    handleSessionEvent(h.deps, enqueue('601'))
+    handleSessionEvent(h.deps, enqueue('602'))
+    handleSessionEvent(h.deps, enqueue('603'))
+    await settle()
+    expect(__parkedTurnStartCountForTest()).toBe(2)
+    expect(rec.sends).toHaveLength(2)
+    expect(new Set(rec.sends.map((s) => s.id)).size).toBe(2)
+  })
+})
+
+describe('Part B — queued card is finalized, never frozen', () => {
+  it('finalizes the card as "folded" when the message is removed (folded into the running turn)', async () => {
+    const h = makeHarness()
+    const rec = withRecordingBot(h)
+
+    handleSessionEvent(h.deps, enqueue('701'))
+    const queued = enqueue('702', 'while you are in there…')
+    handleSessionEvent(h.deps, queued)
+    await settle()
+    expect(rec.sends).toHaveLength(1)
+    const cardId = rec.sends[0]!.id
+
+    handleSessionEvent(h.deps, { kind: 'queue_remove', rawContent: queued.rawContent })
+    expect(__parkedTurnStartCountForTest()).toBe(0)
+    // The card was edited (finalized) in place — folded, not left on "Queued".
+    expect(rec.edits).toHaveLength(1)
+    expect(rec.edits[0]!.messageId).toBe(cardId)
+    expect(rec.edits[0]!.markdown).toContain('Folded')
+  })
+
+  it('finalizes the card as timed-out on TTL expiry (a dequeue that never arrives)', async () => {
+    vi.useFakeTimers()
+    try {
+      const h = makeHarness()
+      const rec = withRecordingBot(h)
+
+      handleSessionEvent(h.deps, enqueue('1201'))
+      const turnA = h.current()!
+      handleSessionEvent(h.deps, enqueue('1202'))
+      // Under fake timers the send still resolves on a real microtask flush.
+      await vi.runAllTimersAsync()
+      expect(rec.sends).toHaveLength(1)
+      const cardId = rec.sends[0]!.id
+
+      // 31 minutes pass with neither dequeue nor remove; a stray dequeue prunes it.
+      vi.advanceTimersByTime(31 * 60_000)
+      turnA.endedAt = Date.now()
+      handleSessionEvent(h.deps, { kind: 'dequeue' })
+      await vi.runAllTimersAsync()
+
+      expect(__parkedTurnStartCountForTest()).toBe(0)
+      expect(h.current()).toBe(turnA) // 1202 was NOT minted 31 min late
+      expect(rec.edits).toHaveLength(1)
+      expect(rec.edits[0]!.messageId).toBe(cardId)
+      expect(rec.edits[0]!.markdown).toContain('timed out')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})


### PR DESCRIPTION
## Part B (#3927 follow-up) — the queued message had no surface

Since #3927, a mid-turn message that gets **parked** (session busy) had no surface at all until it dequeued. The legacy Hook A "queued" placeholder only fires on the *buffer-until-idle* branch (cross-topic forum / non-DM), which **returns before the machine-authoritative path enqueues** — so on the default path the user got dead silence between sending and the turn actually starting.

### The fix — one card, one lifecycle
- **At park** (`stream-render.ts` enqueue→PARKED branch): post one clearly-marked `⏳ Queued — waiting for the current task…` card, reply-anchored to the parked message, in its own chat/thread, `disable_notification` (status surface, never a device ping). Store its id back on the `TurnStartEnvelope`.
- **On dequeue** (`beginTurn`): seed the card id as the turn's `activityMessageId` + `activityEverOpened`, mirroring the handback-card adoption — **guarded on `activityMessageId` still being null** so a card-bearing handback adoption is never clobbered. The SAME card is then **edited in place** into the live progress card; the turn's own end finalizes it.
- **On queue_remove** (folded into the running turn): finalize the card as `✅ Folded into the current task.`
- **On TTL expiry / cap eviction**: finalize as `⚠️ … timed out …` — it never freezes on "Queued".
- **Async send race** (entry leaves the store before the id lands): delete the orphan card instead of adopting, so no frozen duplicate lingers.

### Scope discipline
Lives **entirely in `stream-render.ts`** using the already-injected `bot` + `robustApiCall` deps — **zero `gateway.ts` changes** (line ratchet untouched). Kill switch: `SWITCHROOM_QUEUED_CARD=0`.

### Tests (`tests/queued-card-surface.test.ts`, vitest, drives real `handleSessionEvent`)
- park → one reply-anchored "Queued" card posted; dequeue → **same** id adopted as `activityMessageId`, no second send.
- one card per envelope (multiple queued messages each get their own).
- queue_remove → card edited/finalized as "Folded".
- TTL expiry → card finalized as "timed out", the message is **not** minted 31 min late.

All 4 green + 8 existing turn-mint + 16 stream-render-golden + orphaned-reply-rearm green. Full `npm run lint` clean (tsc, bot-api-wrapping, test-runner-coverage, gateway-line-ratchet).

Independent of Part A (#4038, the sidechain-label filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)