### PR TITLE
feat(rollout): roll overlord, carrie, finn right after the canary

### DIFF
--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -25,7 +25,8 @@ import { Command } from "commander";
 import {
   normalizeVersion,
   isVersionAssertable,
-  orderAgentsCanaryFirst,
+  orderAgentsForRoll,
+  ROLLOUT_PRIORITY_AGENTS,
   planRollout,
   formatRolloutPlan,
   executeRollout,
@@ -85,16 +86,48 @@ describe("isVersionAssertable", () => {
   });
 });
 
-describe("orderAgentsCanaryFirst", () => {
+describe("orderAgentsForRoll", () => {
   it("puts test-harness first, preserving the rest's order", () => {
-    expect(orderAgentsCanaryFirst(["clerk", "test-harness", "marko"])).toEqual([
+    expect(orderAgentsForRoll(["clerk", "test-harness", "marko"])).toEqual([
       "test-harness",
       "clerk",
       "marko",
     ]);
   });
-  it("is a no-op when test-harness is absent", () => {
-    expect(orderAgentsCanaryFirst(["clerk", "marko"])).toEqual(["clerk", "marko"]);
+  it("is a no-op when test-harness is absent and no priority agents roll", () => {
+    expect(orderAgentsForRoll(["clerk", "marko"])).toEqual(["clerk", "marko"]);
+  });
+
+  it("orders canary, then overlord → carrie → finn, then the rest in config order", () => {
+    // Config order deliberately scrambles the priority agents so this test
+    // FAILS on the old canary-only ordering (which preserved config order
+    // for everything after test-harness).
+    expect(
+      orderAgentsForRoll([
+        "clerk",
+        "finn",
+        "test-harness",
+        "marko",
+        "overlord",
+        "carrie",
+      ]),
+    ).toEqual(["test-harness", "overlord", "carrie", "finn", "clerk", "marko"]);
+  });
+
+  it("applies the priority prefix even when the canary is absent", () => {
+    expect(orderAgentsForRoll(["clerk", "carrie", "overlord"])).toEqual([
+      "overlord",
+      "carrie",
+      "clerk",
+    ]);
+  });
+
+  it("skips priority agents not present in the roll (a --agents subset)", () => {
+    expect(orderAgentsForRoll(["marko", "finn"])).toEqual(["finn", "marko"]);
+  });
+
+  it("pins the priority list itself — overlord, then carrie, then finn", () => {
+    expect(ROLLOUT_PRIORITY_AGENTS).toEqual(["overlord", "carrie", "finn"]);
   });
 });
 
@@ -110,6 +143,26 @@ describe("planRollout", () => {
       "refresh-hindsight",
       "sweep",
       "verify-components",
+    ]);
+  });
+
+  it("restarts canary → overlord → carrie → finn → rest, in the step list", () => {
+    const steps = planRollout([
+      "clerk",
+      "finn",
+      "test-harness",
+      "overlord",
+      "carrie",
+    ]);
+    const restarts = steps.flatMap((s) =>
+      s.kind === "restart-agent" ? [s.agent] : [],
+    );
+    expect(restarts).toEqual([
+      "test-harness",
+      "overlord",
+      "carrie",
+      "finn",
+      "clerk",
     ]);
   });
 
@@ -296,9 +349,12 @@ describe("executeRollout", () => {
   });
 
   it("STOPS at the first agent that comes back on the wrong version", () => {
-    const steps = planRollout(["clerk", "marko", "finn"]);
+    // NOTE: neutral (non-priority) agent names — the roll order for
+    // priority agents (overlord/carrie/finn) is pinned by the
+    // orderAgentsForRoll tests above.
+    const steps = planRollout(["clerk", "marko", "quill"]);
     const { deps, runs } = harness({
-      versions: { clerk: "0.15.18", marko: "0.15.17" /* stale! */, finn: "0.15.18" },
+      versions: { clerk: "0.15.18", marko: "0.15.17" /* stale! */, quill: "0.15.18" },
     });
     const r = executeRollout(steps, TARGET, deps);
     expect(r.ok).toBe(false);
@@ -306,8 +362,8 @@ describe("executeRollout", () => {
     expect(r.failedAgent).toBe("marko");
     expect(r.got).toBe("0.15.17");
     expect(r.rolled).toEqual(["clerk"]); // only the one before the failure
-    // finn was never restarted; web/hostd never refreshed.
-    expect(runs).not.toContainEqual(["agent", "restart", "finn", "--wait", "--force"]);
+    // quill was never restarted; web/hostd never refreshed.
+    expect(runs).not.toContainEqual(["agent", "restart", "quill", "--wait", "--force"]);
     expect(runs).not.toContainEqual(["webd", "install", "--tag", TARGET]);
   });
 

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -158,14 +158,48 @@ export function isVersionAssertable(target: string): boolean {
 }
 
 /**
- * Order agents canary-first: `test-harness` (the sanctioned canary) goes
- * first if present, so a bad build fails on it before touching the rest
- * (stop-on-first-mismatch turns this into an automatic canary gate).
+ * Priority prefix for the agent roll order, AFTER the canary (operator
+ * request, 2026-07-31): the operator's primary agents get the new build
+ * as early as possible instead of waiting behind the rest of the fleet.
+ *
+ * Maintainable by edit: add/remove/reorder names here — `orderAgentsForRoll`
+ * applies whatever this list says, skipping names not present in the roll.
+ *
+ * Deliberately AFTER `test-harness`, not before it: the first restarted
+ * agent IS the canary gate (stop-on-first-mismatch, persist-pin-after-canary
+ * on the hostd path, the #3333 scoped-sweep staging, and hostd's
+ * canary-fail auto-rollback all key off restart position 1). Putting
+ * `overlord` literally first would make the operator's primary agent the
+ * agent that eats a bad build with no gate in front of it — the exact
+ * exposure the sanctioned canary exists to absorb.
  */
-export function orderAgentsCanaryFirst(agents: string[]): string[] {
+export const ROLLOUT_PRIORITY_AGENTS: readonly string[] = [
+  "overlord",
+  "carrie",
+  "finn",
+];
+
+/**
+ * Order agents for a roll: canary first, then the priority prefix, then
+ * everything else in its incoming (config) order.
+ *
+ *   1. `test-harness` (the sanctioned canary) goes first if present, so a
+ *      bad build fails on it before touching the rest
+ *      (stop-on-first-mismatch turns this into an automatic canary gate).
+ *   2. {@link ROLLOUT_PRIORITY_AGENTS}, in that list's order, for those
+ *      present in the roll.
+ *   3. All remaining agents, preserving their incoming order.
+ */
+export function orderAgentsForRoll(agents: string[]): string[] {
   const canary = agents.filter((a) => a === "test-harness");
-  const rest = agents.filter((a) => a !== "test-harness");
-  return [...canary, ...rest];
+  const priority = ROLLOUT_PRIORITY_AGENTS.filter(
+    (p) => p !== "test-harness" && agents.includes(p),
+  );
+  const prioritySet = new Set(priority);
+  const rest = agents.filter(
+    (a) => a !== "test-harness" && !prioritySet.has(a),
+  );
+  return [...canary, ...priority, ...rest];
 }
 
 /**
@@ -178,7 +212,7 @@ export function planRollout(
   opts: RolloutPlanOpts = {},
 ): RolloutStep[] {
   const steps: RolloutStep[] = [];
-  const ordered = orderAgentsCanaryFirst(agents);
+  const ordered = orderAgentsForRoll(agents);
 
   if (opts.hostdContext) {
     // hostd/MCP path (#2487): persist the pin AFTER the canary confirms,


### PR DESCRIPTION
## Summary
Adds `ROLLOUT_PRIORITY_AGENTS = ["overlord", "carrie", "finn"]` (a single editable priority list, `src/cli/rollout.ts`) and replaces `orderAgentsCanaryFirst` with `orderAgentsForRoll`: **test-harness (the sanctioned canary) still restarts first**, then `overlord` → `carrie` → `finn`, then the remaining agents in their config order. Priority names absent from a `--agents` subset are skipped.

## Why
Operator request: the primary agents should pick up a new build early instead of waiting behind the rest of the fleet.

**Deliberate deviation from the literal request ("overlord first"), flagged for review:** the priority prefix sits AFTER the canary, not before it, because the first-restarted agent IS the canary gate — stop-on-first-mismatch, persist-pin-after-canary on the hostd path, the #3333 scoped-sweep staging env, and hostd's canary-fail auto-rollback (`recoverFailedAutoRollout`) all key off restart position 1. Putting `overlord` literally first would make the operator's primary agent absorb every bad build (including unattended auto-update rolls) with no gate in front of it. If overlord-before-canary is truly wanted, it is a one-line list change — but it demotes the sanctioned canary.

## Roll-survives-overlord-recreation (verified)
- The roll executes as a **child of hostd** (`spawnRollout`, `src/host-control/server.ts:4213`), in the external `switchroom-hostd` compose project — recreating `switchroom-overlord` does not touch it.
- The narrator lives in hostd, explicitly NOT in overlord (`src/host-control/rollout-narrator.ts:27-28`).
- The narration relay (`src/host-control/rollout-narration-relay.ts`) connects per-call to the caller gateway socket; edits are fire-and-forget and post failures resolve null with back-off — overlord's own restart window can only drop a narration edit, never the roll.

## Test plan
- `src/cli/rollout.test.ts`: new `orderAgentsForRoll` suite asserting canary → overlord → carrie → finn → rest (fails on the old canary-only ordering), a priority-without-canary case, a `--agents`-subset case, a pin on the list itself, and a `planRollout`-level restart-order test. One pre-existing test's filler agent renamed `finn` → `quill` to keep its stop-on-mismatch intent.
- Local: `vitest run src/cli/rollout.test.ts` → 151 passed; `npm run lint` → clean.

## Risk
Low — pure ordering, no step semantics changed. The main semantic to review is the canary-position decision above.

Job spec: `reference/jobs/restart-and-know-what-im-running.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)