### PR TITLE
feat(rollout): singleton/shared-service status on the progress card

### DIFF
--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -1380,6 +1380,91 @@ describe("executeRollout — phase emission", () => {
     expect(clerkDone.length).toBe(1);
   });
 
+  it("emits singleton phases: web-refresh → web-refresh-done, hindsight-refresh → -done", () => {
+    const steps = planRollout(["clerk"], { hostdContext: true });
+    const { deps, phases } = harness({
+      versions: { clerk: "0.15.18" },
+      hindsightExists: true,
+      webImageTag: "v0.15.18", // matches target → observed success
+    });
+    const r = executeRollout(steps, TARGET, deps, { hostdContext: true });
+    expect(r.ok).toBe(true);
+    const names = phases.map((p) => p.phase);
+    // The card's singleton section is fed by these — order matters.
+    expect(names.indexOf("web-refresh")).toBeGreaterThanOrEqual(0);
+    expect(names.indexOf("web-refresh-done")).toBeGreaterThan(names.indexOf("web-refresh"));
+    expect(names.indexOf("hindsight-refresh")).toBeGreaterThan(names.indexOf("web-refresh-done"));
+    expect(names.indexOf("hindsight-refresh-done")).toBeGreaterThan(
+      names.indexOf("hindsight-refresh"),
+    );
+    expect(names).not.toContain("hindsight-skipped");
+  });
+
+  it("emits hindsight-skipped (not -done) when no hindsight container exists", () => {
+    const steps = planRollout(["clerk"], { hostdContext: true });
+    const { deps, phases } = harness({
+      versions: { clerk: "0.15.18" },
+      hindsightExists: false,
+    });
+    executeRollout(steps, TARGET, deps, { hostdContext: true });
+    const names = phases.map((p) => p.phase);
+    expect(names).toContain("hindsight-skipped");
+    expect(names).not.toContain("hindsight-refresh");
+    expect(names).not.toContain("hindsight-refresh-done");
+  });
+
+  it("does NOT emit web-refresh-done when the skew probe disproves the target", () => {
+    const steps = planRollout(["clerk"], { hostdContext: true });
+    const { deps, phases } = harness({
+      versions: { clerk: "0.15.18" },
+      webImageTag: "v0.15.17", // downgrade-guard skip left web behind
+    });
+    executeRollout(steps, TARGET, deps, { hostdContext: true });
+    const names = phases.map((p) => p.phase);
+    expect(names).toContain("web-refresh");
+    expect(names).not.toContain("web-refresh-done"); // never a fabricated ✓
+  });
+
+  it("does NOT emit web-refresh-done when webd install fails", () => {
+    const steps = planRollout(["clerk"], { hostdContext: true });
+    const { deps, phases } = harness({
+      versions: { clerk: "0.15.18" },
+      runStatus: (args) => (args[0] === "webd" ? 1 : 0),
+    });
+    executeRollout(steps, TARGET, deps, { hostdContext: true });
+    expect(phases.map((p) => p.phase)).not.toContain("web-refresh-done");
+  });
+
+  it("does NOT emit web-refresh-done when the web tag probe reads nothing (exit 0 proves nothing)", () => {
+    // `webd install` exits 0 on a downgrade-guard skip, so a clean exit with
+    // an unreadable tag is NOT an observation of success — the terminal
+    // verify-components gate resolves it instead.
+    const steps = planRollout(["clerk"], { hostdContext: true });
+    const { deps, phases } = harness({
+      versions: { clerk: "0.15.18" },
+      webImageTag: null,
+    });
+    const r = executeRollout(steps, TARGET, deps, { hostdContext: true });
+    expect(r.ok).toBe(true);
+    const names = phases.map((p) => p.phase);
+    expect(names).toContain("web-refresh");
+    expect(names).not.toContain("web-refresh-done");
+  });
+
+  it("round-trips every singleton phase through the sentinel parser", () => {
+    for (const p of [
+      "web-refresh-done",
+      "hindsight-refresh",
+      "hindsight-refresh-done",
+      "hindsight-skipped",
+    ] as const) {
+      const parsed = parseRolloutPhaseLine(
+        encodeRolloutPhaseLine({ phase: p, target: "v1.2.3" }),
+      );
+      expect(parsed).toEqual({ phase: p, target: "v1.2.3" });
+    }
+  });
+
   it("emits a persist-pin phase on the hostd path", () => {
     const steps = planRollout(["test-harness", "clerk"], {
       hostdContext: true,

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -319,6 +319,19 @@ export type RolloutPhaseName =
   // In-plan web singleton refresh (webd install) — emitted just before the
   // spawn so a slow pull/recreate isn't a silent gap in the narration.
   | "web-refresh"
+  // Emitted only when `webd install` exited 0 AND the belt-and-braces image
+  // tag probe did not detect a version skew — i.e. the roll actually
+  // OBSERVED web on the target (or could not disprove it after a clean
+  // install). Absent on failure/skew so the narration surface never shows a
+  // fabricated ✓.
+  | "web-refresh-done"
+  // Hindsight singleton refresh (memory setup --recreate): start / observed
+  // success / no-container skip. A FAILED recreate emits no -done phase —
+  // the roll stops with failedStep=refresh-hindsight and the terminal row
+  // carries the truth.
+  | "hindsight-refresh"
+  | "hindsight-refresh-done"
+  | "hindsight-skipped"
   | "hostd-web-deferred"
   // #2645 — hostd self-bump. Emitted by the DAEMON directly (never via the
   // child's stdout sentinel): "self-bump" when the old hostd hands its own
@@ -392,6 +405,10 @@ export function parseRolloutPhaseLine(line: string): RolloutPhase | null {
     "agent-done",
     "persist-pin",
     "web-refresh",
+    "web-refresh-done",
+    "hindsight-refresh",
+    "hindsight-refresh-done",
+    "hindsight-skipped",
     "hostd-web-deferred",
     "self-bump",
     "self-bump-done",
@@ -1138,6 +1155,23 @@ export function executeRollout(
                 `skipped the install). Finish it host-side: \`switchroom webd ` +
                 `install --tag ${target} --allow-downgrade\`.`,
             );
+            // No web-refresh-done phase: the probe just DISPROVED "web is on
+            // the target", so the narration surface must not show a ✓.
+            break;
+          }
+          if (
+            webTag !== undefined &&
+            webTag !== null &&
+            isVersionAssertable(webTag) &&
+            normalizeVersion(webTag) === targetNorm
+          ) {
+            // OBSERVED success: install exited 0 AND the running container's
+            // image tag equals the target. Only this earns the ✓ phase —
+            // `webd install` exits 0 on a downgrade-guard skip, so exit
+            // status alone observes nothing; when the tag probe can't read a
+            // tag the card stays on ⏳ and the terminal verify-components
+            // gate resolves it.
+            emit({ phase: "web-refresh-done", target });
           }
           break;
         }
@@ -1180,6 +1214,7 @@ export function executeRollout(
           const hindsightExists = deps.hindsightExists ?? isHindsightContainerExists;
           if (!hindsightExists()) {
             deps.log(`ROLL_STEP refresh-hindsight — no hindsight container on this host; skipping`);
+            emit({ phase: "hindsight-skipped", target });
             break;
           }
           // Thread the pinned rollout target through as `--tag <target>` so the
@@ -1189,6 +1224,7 @@ export function executeRollout(
           deps.log(
             `ROLL_STEP refresh-hindsight — memory setup --recreate --tag ${target} (pull ${target} + recreate)`,
           );
+          emit({ phase: "hindsight-refresh", target });
           const r = deps.run(["memory", "setup", "--recreate", "--tag", target]);
           if (r.status !== 0) {
             // FATAL, not a soft warning (#2752 fix 2): `memory setup --recreate`
@@ -1208,6 +1244,7 @@ export function executeRollout(
               ...(r.timedOut ? { timedOut: true } : {}),
             });
           }
+          emit({ phase: "hindsight-refresh-done", target });
           break;
         }
         case "sweep": {

--- a/src/host-control/render-rollout-status.ts
+++ b/src/host-control/render-rollout-status.ts
@@ -40,6 +40,37 @@ export interface AgentRollProgress {
   startedAtMs?: number;
 }
 
+/**
+ * Truthful per-singleton state on the narration card. Every value maps to a
+ * REAL observation (or a real deferral) — the narrator never invents a ✓:
+ *   - "pending"   — this roll owns it but hasn't reached it yet;
+ *   - "updating"  — its refresh phase started and no outcome phase yet;
+ *   - "updated"   — an observed success (a `…-done` phase, or the terminal
+ *                   `verify-components` gate proving convergence);
+ *   - "deferred"  — deliberately left to a host-side run (hostd on the
+ *                   agent-invoked path);
+ *   - "skipped"   — not refreshed in this roll (no container / --skip-web /
+ *                   the roll never reached it);
+ *   - "failed"    — its refresh step failed (roll stopped there, or the
+ *                   terminal drift gate named it still behind).
+ */
+export type SingletonRollStatus =
+  | "pending"
+  | "updating"
+  | "updated"
+  | "deferred"
+  | "skipped"
+  | "failed";
+
+export interface SingletonRollProgress {
+  /** Display name (container-ish: `switchroom-web`, `hindsight`, `hostd`,
+   *  or the shared-services group row). */
+  name: string;
+  status: SingletonRollStatus;
+  /** Short truthful qualifier rendered after the name (e.g. "host-side"). */
+  detail?: string;
+}
+
 /** The rollout progress state a renderer needs — a projection of the latest
  *  durable rollout row / status payload. */
 export interface RolloutRenderState {
@@ -60,6 +91,13 @@ export interface RolloutRenderState {
   agent?: string;
   /** Per-agent checklist state, in roll order (accumulated by the narrator). */
   agents?: AgentRollProgress[];
+  /**
+   * Singleton / shared-service checklist (accumulated by the narrator from
+   * the singleton phases + the terminal row). Rendered as its own section so
+   * the card answers "what about web / hindsight / hostd / the shared
+   * services", not just the agents.
+   */
+  singletons?: SingletonRollProgress[];
   /** ms since epoch the roll started (for the elapsed line). */
   startedAtMs?: number;
   /** ms since epoch "now" at render time (clock seam — keeps the fn pure). */
@@ -107,6 +145,14 @@ function phaseLine(s: RolloutRenderState): string {
       return "persisting pin";
     case "web-refresh":
       return "refreshing web dashboard (webd install)";
+    case "web-refresh-done":
+      return "web dashboard refreshed";
+    case "hindsight-refresh":
+      return "refreshing hindsight (memory backend recreate)";
+    case "hindsight-refresh-done":
+      return "hindsight refreshed";
+    case "hindsight-skipped":
+      return "hindsight — no container on this host; skipped";
     case "hostd-web-deferred":
       // Legacy phase name: since the in-plan refresh-web step landed, only
       // the hostd self-refresh is actually deferred on the agent path.
@@ -190,6 +236,44 @@ function checklistLines(s: RolloutRenderState, compact: boolean): string[] {
   return lines;
 }
 
+/** Glyph per singleton state — consistent with the agent checklist glyphs
+ *  (✓ / ⏳ / ✗), plus ⧗ for a deliberate host-side deferral and ○ for a
+ *  skip. */
+function singletonGlyph(status: SingletonRollStatus): string {
+  switch (status) {
+    case "updated":
+      return "✓";
+    case "updating":
+      return "⏳";
+    case "deferred":
+      return "⧗";
+    case "skipped":
+      return "○";
+    case "failed":
+      return "✗";
+    default:
+      return "·";
+  }
+}
+
+/**
+ * The singleton / shared-service section: a header plus one checklist line
+ * per tracked singleton. Kept in BOTH full and compact renders — it is a
+ * fixed handful of rows, unlike the per-agent list, so it can't blow the
+ * size ceiling; folding it would drop exactly the information the section
+ * exists to add.
+ */
+function singletonLines(s: RolloutRenderState): string[] {
+  const singletons = s.singletons ?? [];
+  if (singletons.length === 0) return [];
+  const lines = ["**Singletons / shared:**"];
+  for (const g of singletons) {
+    const detail = g.detail ? ` — ${g.detail}` : "";
+    lines.push(`- ${singletonGlyph(g.status)} \`${g.name}\`${detail}`);
+  }
+  return lines;
+}
+
 /** Rough ETA from the mean per-agent duration so far. */
 function etaLine(s: RolloutRenderState): string | null {
   if (s.m === undefined) return null;
@@ -251,6 +335,7 @@ function renderWith(s: RolloutRenderState, compact: boolean): string {
   const rolled = s.rolled ?? [];
   const rolledCount = rolled.length;
   const checklist = checklistLines(s, compact);
+  const singletons = singletonLines(s);
   const elapsedMs =
     s.elapsedMs ??
     (s.startedAtMs !== undefined && s.nowMs !== undefined
@@ -264,6 +349,7 @@ function renderWith(s: RolloutRenderState, compact: boolean): string {
     summary += compact ? "." : `: ${rolledList(rolled, compact)}.`;
     parts.push(summary);
     if (checklist.length > 0) parts.push("", ...checklist);
+    if (singletons.length > 0) parts.push("", ...singletons);
     if (s.deferred !== false) parts.push("", ...deferredLines(s.target));
     return parts.join("\n");
   }
@@ -294,6 +380,7 @@ function renderWith(s: RolloutRenderState, compact: boolean): string {
         `target. Finish the stale component(s), then \`switchroom update --check\`.`,
     );
     if (checklist.length > 0) parts.push("", ...checklist);
+    if (singletons.length > 0) parts.push("", ...singletons);
     return parts.join("\n");
   }
 
@@ -307,12 +394,14 @@ function renderWith(s: RolloutRenderState, compact: boolean): string {
     summary += `. Rolled before stop: ${rolledList(rolled, compact)}.`;
     parts.push(summary);
     if (checklist.length > 0) parts.push("", ...checklist);
+    if (singletons.length > 0) parts.push("", ...singletons);
     return parts.join("\n");
   }
 
   // In-flight.
   const parts = [headerLine(s, "⏳"), `**Phase:** ${phaseLine(s)}`];
   if (checklist.length > 0) parts.push("", ...checklist);
+  if (singletons.length > 0) parts.push("", ...singletons);
   const footer: string[] = [];
   if (s.m !== undefined) footer.push(`${rolledCount}/${s.m} rolled`);
   else if (rolledCount > 0) footer.push(`${rolledCount} rolled`);

--- a/src/host-control/rollout-narrator.test.ts
+++ b/src/host-control/rollout-narrator.test.ts
@@ -322,6 +322,107 @@ describe("LogTailRolloutNarrator", () => {
     expect(t).toContain("Re-running the roll will NOT fix this");
   });
 
+  it("renders a truthful singleton/shared section that tracks the singleton phases", async () => {
+    const relay = makeRelay(100);
+    const n = new LogTailRolloutNarrator(relay, { debounceMs: 500 });
+    const entry = makeEntry();
+
+    // From the FIRST post the card must answer for the singletons, not just
+    // the agents: web/hindsight pending, hostd honestly deferred (the
+    // agent-invoked path cannot recreate its own hostd), shared services
+    // named with their self-heal mechanism.
+    n.onPhase(entry, phase("apply"));
+    await vi.runAllTimersAsync();
+    const first = relay.posts[0]!.text;
+    expect(first).toContain("**Singletons / shared:**");
+    expect(first).toContain("- · `switchroom-web`");
+    expect(first).toContain("- · `hindsight`");
+    expect(first).toContain("- ⧗ `hostd` — host-side");
+    expect(first).toContain("self-heal with the first agent restart");
+
+    // First agent done → the shared singletons' self-heal ran (⏳, verified
+    // at end — never a bare ✓ mid-roll).
+    n.onPhase(entry, phase("canary-start", { agent: "test-harness", n: 1, m: 2 }));
+    n.onPhase(entry, phase("canary-pass", { agent: "test-harness", n: 1, m: 2 }));
+    await vi.advanceTimersByTimeAsync(500);
+    expect(relay.edits.at(-1)!.text).toContain(
+      "recreated with the first agent restart — verified at roll end",
+    );
+
+    // web refresh: ⏳ on -start, ✓ only on the observed -done.
+    n.onPhase(entry, phase("web-refresh"));
+    await vi.advanceTimersByTimeAsync(500);
+    expect(relay.edits.at(-1)!.text).toContain("- ⏳ `switchroom-web` — webd install…");
+    n.onPhase(entry, phase("web-refresh-done"));
+    await vi.advanceTimersByTimeAsync(500);
+    expect(relay.edits.at(-1)!.text).toContain("- ✓ `switchroom-web`");
+
+    // hindsight skip renders as an honest ○, not a ✓.
+    n.onPhase(entry, phase("hindsight-skipped"));
+    await vi.advanceTimersByTimeAsync(500);
+    const t = relay.edits.at(-1)!.text;
+    expect(t).toContain("- ○ `hindsight` — no hindsight container on this host");
+  });
+
+  it("terminal ✅ reconciles the singleton rows from the verify-components outcome", async () => {
+    const relay = makeRelay(100);
+    const n = new LogTailRolloutNarrator(relay, { debounceMs: 500 });
+    const entry = makeEntry();
+    n.onPhase(entry, phase("canary-start", { agent: "a", n: 1, m: 1 }));
+    n.onPhase(entry, phase("canary-pass", { agent: "a", n: 1, m: 1 }));
+    await vi.runAllTimersAsync();
+    // NO web/hindsight phases arrived (e.g. --skip-web) — a completed roll
+    // must render them as skipped, never as a fabricated ✓.
+    n.onTerminal(makeEntry({ result: "completed", rolled: ["a"] }));
+    await vi.runAllTimersAsync();
+    const final = relay.edits.at(-1)!.text;
+    expect(final).toContain("- ○ `switchroom-web` — no refresh observed in this roll");
+    expect(final).toContain("- ○ `hindsight` — no refresh observed in this roll");
+    // Shared services: the end-of-roll component check passed with them in
+    // scope (gatedOwners always gates "fleet"), so ✓ is an observation.
+    expect(final).toContain(
+      "- ✓ `shared services (approval-kernel · auth-broker · vault-broker · voice)`",
+    );
+    expect(final).toContain("end-of-roll check passed");
+    // hostd stays the deferral truth.
+    expect(final).toContain("- ⧗ `hostd`");
+  });
+
+  it("terminal drift (#3928) marks the named singleton ✗ — even past a web-refresh-done", async () => {
+    const relay = makeRelay(100);
+    const n = new LogTailRolloutNarrator(relay, { debounceMs: 500 });
+    const entry = makeEntry();
+    n.onPhase(entry, phase("web-refresh"));
+    n.onPhase(entry, phase("web-refresh-done"));
+    await vi.runAllTimersAsync();
+    n.onTerminal(
+      makeEntry({
+        result: "error",
+        failed_step: "verify-components",
+        rolled: ["a"],
+        drifted: ["switchroom-web"],
+      }),
+    );
+    await vi.runAllTimersAsync();
+    const final = relay.edits.at(-1)!.text;
+    expect(final).toContain("- ✗ `switchroom-web` — still behind (switchroom-web)");
+  });
+
+  it("terminal refresh-hindsight failure marks hindsight ✗ with the recovery command", async () => {
+    const relay = makeRelay(100);
+    const n = new LogTailRolloutNarrator(relay, { debounceMs: 500 });
+    const entry = makeEntry();
+    n.onPhase(entry, phase("hindsight-refresh"));
+    await vi.runAllTimersAsync();
+    n.onTerminal(
+      makeEntry({ result: "error", failed_step: "refresh-hindsight", rolled: ["a"] }),
+    );
+    await vi.runAllTimersAsync();
+    const final = relay.edits.at(-1)!.text;
+    expect(final).toContain("- ✗ `hindsight`");
+    expect(final).toContain("switchroom memory setup");
+  });
+
   it("terminal before any phase still posts the final message", async () => {
     const relay = makeRelay(100);
     const n = new LogTailRolloutNarrator(relay, { debounceMs: 500 });

--- a/src/host-control/rollout-narrator.ts
+++ b/src/host-control/rollout-narrator.ts
@@ -48,7 +48,47 @@ import {
   renderRolloutStatus,
   type AgentRollProgress,
   type RolloutRenderState,
+  type SingletonRollProgress,
 } from "./render-rollout-status.js";
+
+/**
+ * Display names for the singleton / shared-service checklist rows. Stable
+ * strings — the narrator keys row updates on them.
+ */
+export const SINGLETON_WEB = "switchroom-web";
+export const SINGLETON_HINDSIGHT = "hindsight";
+export const SINGLETON_HOSTD = "hostd";
+export const SINGLETON_SHARED =
+  "shared services (approval-kernel · auth-broker · vault-broker · voice)";
+
+/**
+ * Initial singleton checklist for a narrated roll. The narrator only exists
+ * on the hostd/agent-invoked path (hostd tails its own child's phases), so
+ * the initial states encode that path's plan truthfully:
+ *   - web + hindsight are in-plan refresh steps → pending until their phase;
+ *   - hostd is ALWAYS deferred there (an agent-invoked roll cannot recreate
+ *     its own hostd mid-roll) — refined to "updated" only if a self-bump is
+ *     actually observed;
+ *   - the shared fleet singletons self-heal on the first `agent restart`
+ *     (#2170) and are only individually OBSERVED by the terminal
+ *     verify-components gate, so they start pending with that stated.
+ */
+function initialSingletons(): SingletonRollProgress[] {
+  return [
+    { name: SINGLETON_WEB, status: "pending" },
+    { name: SINGLETON_HINDSIGHT, status: "pending" },
+    {
+      name: SINGLETON_HOSTD,
+      status: "deferred",
+      detail: "host-side (agent-invoked roll cannot recreate its own hostd)",
+    },
+    {
+      name: SINGLETON_SHARED,
+      status: "pending",
+      detail: "self-heal with the first agent restart",
+    },
+  ];
+}
 
 /**
  * The transport the narrator drives — a live gateway relay that can POST the
@@ -123,6 +163,8 @@ interface NarrationState {
   render: RolloutRenderState;
   /** Per-agent checklist progress, in roll order (fed into render.agents). */
   agents: AgentRollProgress[];
+  /** Singleton / shared-service checklist (fed into render.singletons). */
+  singletons: SingletonRollProgress[];
   /** Frozen once the terminal row is applied — no later edit may un-finalize. */
   frozen: boolean;
   /** Pending debounce timer for a trailing-edge edit. */
@@ -197,6 +239,85 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
     }
   }
 
+  /** Patch one singleton row in place (rows are fixed at ensureState). */
+  private static patchSingleton(
+    st: NarrationState,
+    name: string,
+    patch: Partial<SingletonRollProgress>,
+  ): void {
+    const row = st.singletons.find((g) => g.name === name);
+    if (row) Object.assign(row, patch);
+  }
+
+  /**
+   * Fold a phase into the singleton / shared-service checklist. Every
+   * transition mirrors a REAL emitted phase (rollout.ts emits `…-done` only
+   * on an observed success), so no row ever shows a ✓ the roll didn't see.
+   */
+  private trackSingletonProgress(st: NarrationState, phase: RolloutPhase): void {
+    const patch = LogTailRolloutNarrator.patchSingleton;
+    switch (phase.phase) {
+      case "canary-pass":
+      case "agent-done": {
+        // #2170 — the fleet's shared singletons are recreated by the FIRST
+        // agent restart. Mark the mechanism as having run; "updated" waits
+        // for the terminal row (the verify-components gate is what actually
+        // observes them).
+        const shared = st.singletons.find((g) => g.name === SINGLETON_SHARED);
+        if (shared && shared.status === "pending") {
+          shared.status = "updating";
+          shared.detail =
+            "recreated with the first agent restart — verified at roll end";
+        }
+        break;
+      }
+      case "web-refresh":
+        patch(st, SINGLETON_WEB, { status: "updating", detail: "webd install…" });
+        break;
+      case "web-refresh-done":
+        patch(st, SINGLETON_WEB, { status: "updated", detail: undefined });
+        break;
+      case "hindsight-refresh":
+        patch(st, SINGLETON_HINDSIGHT, {
+          status: "updating",
+          detail: "memory setup --recreate…",
+        });
+        break;
+      case "hindsight-refresh-done":
+        patch(st, SINGLETON_HINDSIGHT, { status: "updated", detail: undefined });
+        break;
+      case "hindsight-skipped":
+        patch(st, SINGLETON_HINDSIGHT, {
+          status: "skipped",
+          detail: "no hindsight container on this host",
+        });
+        break;
+      case "self-bump":
+        patch(st, SINGLETON_HOSTD, {
+          status: "updating",
+          detail: "self-bump to the target…",
+        });
+        break;
+      case "self-bump-done":
+        patch(st, SINGLETON_HOSTD, {
+          status: "updated",
+          detail: "self-bump; template regen stays host-side",
+        });
+        break;
+      case "hostd-web-deferred": {
+        // Don't downgrade an observed self-bump back to "deferred".
+        const hostd = st.singletons.find((g) => g.name === SINGLETON_HOSTD);
+        if (hostd && hostd.status !== "updated") {
+          hostd.status = "deferred";
+          hostd.detail = "host-side";
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
   /**
    * Monotonic sequence for a phase, so out-of-order / duplicate phases drop.
    * hostd feeds phases in stdout order; this is defense-in-depth.
@@ -236,9 +357,17 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
       case "agent-done":
         return 2 * (phase.n ?? 1) + 1;
       case "web-refresh":
+      case "web-refresh-done":
         // In-plan web singleton refresh — after every agent restart, before
-        // the deferral note. Anchored just below hostd-web-deferred.
-        return Number.MAX_SAFE_INTEGER - 2;
+        // the hindsight refresh. Equal-seq: -done REFINES -start (the
+        // executor emits them strictly in order on one stdout).
+        return Number.MAX_SAFE_INTEGER - 4;
+      case "hindsight-refresh":
+      case "hindsight-refresh-done":
+      case "hindsight-skipped":
+        // After the web refresh, before the deferral note. Same equal-seq
+        // refine-only shape as web above.
+        return Number.MAX_SAFE_INTEGER - 3;
       case "hostd-web-deferred":
         return Number.MAX_SAFE_INTEGER - 1; // near the end, before terminal
       default:
@@ -266,8 +395,10 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
       if (seq < st.lastAppliedSeq) return; // stale — drop.
       st.lastAppliedSeq = seq;
 
-      // Fold the phase into the per-agent checklist (✓/⏳/·/✗ + durations).
+      // Fold the phase into the per-agent checklist (✓/⏳/·/✗ + durations)
+      // and the singleton / shared-service checklist.
       this.trackAgentProgress(st, phase);
+      this.trackSingletonProgress(st, phase);
 
       // #2726 fix — during the roll, `entry.rolled` is still empty: hostd only
       // parses the child's result sentinel into `entry.rolled` AFTER the whole
@@ -295,6 +426,7 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
         ...(phase.agent !== undefined ? { agent: phase.agent } : {}),
         rolled: rolledSoFar,
         agents: st.agents,
+        singletons: st.singletons,
         requestId: entry.request_id,
         ...(entry.prior_pin ? { fromVersion: entry.prior_pin } : {}),
         startedAtMs: entry.started_at,
@@ -321,6 +453,7 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
           a.status = "pending";
         }
       }
+      this.reconcileSingletonsAtTerminal(st, entry);
       // Terminal wins unconditionally and FREEZES the surface.
       st.render = {
         target: entry.pin ?? st.render.target,
@@ -336,6 +469,7 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
           ? { drifted: entry.drifted }
           : {}),
         ...(st.agents.length > 0 ? { agents: st.agents } : {}),
+        ...(st.singletons.length > 0 ? { singletons: st.singletons } : {}),
         ...(st.render.m !== undefined ? { m: st.render.m } : {}),
         requestId: entry.request_id,
         ...(entry.prior_pin ?? st.render.fromVersion
@@ -363,6 +497,94 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
     }
   }
 
+  /**
+   * Reconcile the singleton checklist against the TERMINAL row — the only
+   * point where the roll has actually OBSERVED the singletons as a set (the
+   * verify-components gate: a `completed` terminal means every in-scope
+   * component passed it; a drifted list names exactly what did not).
+   */
+  private reconcileSingletonsAtTerminal(
+    st: NarrationState,
+    entry: StatusEntry,
+  ): void {
+    const completed = entry.result === "completed";
+    const drifted = new Set(entry.drifted ?? []);
+    const driftedHits = (row: string): string[] => {
+      switch (row) {
+        case SINGLETON_WEB:
+          return [...drifted].filter((d) => d === "switchroom-web");
+        case SINGLETON_HINDSIGHT:
+          return [...drifted].filter((d) => d === "switchroom-hindsight");
+        case SINGLETON_HOSTD:
+          // The autoheal sidecar runs the hostd image in the hostd compose
+          // project (component-scope.ts) — its drift is hostd's to fix.
+          return [...drifted].filter(
+            (d) => d === "switchroom-hostd" || d === "switchroom-hindsight-autoheal",
+          );
+        case SINGLETON_SHARED:
+          return [...drifted].filter(
+            (d) =>
+              d.includes("broker") || d.includes("kernel") || d.includes("voice"),
+          );
+        default:
+          return [];
+      }
+    };
+    for (const g of st.singletons) {
+      const hits = driftedHits(g.name);
+      if (hits.length > 0) {
+        // The terminal drift gate NAMED it still behind — that observation
+        // outranks any in-flight phase (incl. a web-refresh-done whose
+        // install was later disproven).
+        g.status = "failed";
+        g.detail = `still behind (${hits.join(", ")}) — see the roll's warnings`;
+        continue;
+      }
+      if (entry.failed_step === "refresh-hindsight" && g.name === SINGLETON_HINDSIGHT) {
+        g.status = "failed";
+        g.detail =
+          "recreate FAILED — memory backend down; run `switchroom memory setup`";
+        continue;
+      }
+      if (!completed) {
+        // A stopped roll: leave each row's last honest state (pending rows
+        // simply never got reached; "updating" without an outcome phase is
+        // unproven, so say so rather than claim either way).
+        if (g.status === "updating" && g.name !== SINGLETON_SHARED) {
+          g.detail = "outcome unknown — the roll stopped; see warnings";
+        }
+        continue;
+      }
+      // Completed roll: the verify-components gate passed with this row's
+      // components in scope wherever their plan step ran.
+      switch (g.name) {
+        case SINGLETON_WEB:
+        case SINGLETON_HINDSIGHT:
+          if (g.status === "updated") break;
+          if (g.status === "updating") {
+            // Its -done phase never arrived (lost line / older CLI), but the
+            // terminal gate proved convergence.
+            g.status = "updated";
+            g.detail = "verified by the end-of-roll component check";
+          } else if (g.status === "pending") {
+            // The roll finished without this narrator seeing its refresh
+            // phase — --skip-web, a plan without the step, or a narration
+            // restart mid-roll. Not a failure; not a ✓ either.
+            g.status = "skipped";
+            g.detail = "no refresh observed in this roll — see warnings";
+          }
+          break;
+        case SINGLETON_SHARED:
+          g.status = "updated";
+          g.detail =
+            "self-healed with the first agent restart; end-of-roll check passed";
+          break;
+        default:
+          break; // hostd keeps its deferred / self-bump state — that IS the truth.
+      }
+    }
+  }
+
   private ensureState(entry: StatusEntry): NarrationState {
     let st = this.states.get(entry.request_id);
     if (!st) {
@@ -377,6 +599,7 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
         postFailed: false,
         render: { target: entry.pin ?? "" },
         agents: [],
+        singletons: initialSingletons(),
         frozen: false,
         timer: null,
         pendingEditAfterPost: false,


### PR DESCRIPTION
## Summary
The rollout narration card rendered only the per-agent checklist — nothing about `switchroom-web`, `hindsight`, `hostd`, or the shared fleet singletons (approval-kernel / auth-broker / vault-broker / voice) a roll also touches or defers. This adds a **Singletons / shared** section with a truthful per-row state: ✓ updated (observed) / ⏳ updating / ⧗ deferred host-side / · pending / ○ skipped / ✗ failed.

## How truthfulness is kept (no fabricated ✓)
- **New executor phases** `web-refresh-done`, `hindsight-refresh`, `hindsight-refresh-done`, `hindsight-skipped` (`src/cli/rollout.ts`). `web-refresh-done` fires ONLY when the running container's image tag is observed equal to the target — `webd install` exits 0 on a downgrade-guard skip, so exit status alone observes nothing. `hindsight-refresh-done` rides `memory setup --recreate` exit 0, which has no silent-skip path (its guards refuse non-zero before touching the container).
- **hostd** renders ⧗ deferred (host-side) — the honest state on the agent-invoked path, the only path with a narration card — refined to ✓ only when a self-bump phase is actually observed.
- **Shared fleet singletons** are only individually observed by the terminal `verify-components` gate (#3928): mid-roll they show "recreated with the first agent restart — verified at roll end" (#2170); ✓ lands only on a completed terminal, and a drifted terminal marks the named component ✗ even past an in-flight done phase.
- Unknown phase names parse to `null` in an older hostd (`parseRolloutPhaseLine` is defensive), so a version-skewed roll degrades to the old card, never a crash.

## Files
- `src/cli/rollout.ts` — phase names + PHASES set + emissions in refresh-web / refresh-hindsight.
- `src/host-control/render-rollout-status.ts` — `SingletonRollProgress` + section rendered in all four shapes (in-flight, ✅, ⚠️ drift, ❌), kept in compact mode (fixed 4 rows).
- `src/host-control/rollout-narrator.ts` — `trackSingletonProgress`, `seqFor` slots for the new phases (equal-seq refine-only, per the existing contract), terminal reconciliation.

## Test plan
- `src/cli/rollout.test.ts`: phase-order emission (web → web-done → hindsight → hindsight-done), `hindsight-skipped` on no container, NO `web-refresh-done` on install failure / tag mismatch / unreadable tag, sentinel round-trips. Fails on the old behavior (phases didn't exist).
- `src/host-control/rollout-narrator.test.ts`: the card's first post carries the singleton section; glyphs track phases; completed-terminal reconciliation (unseen refresh → ○, shared → ✓ via the end-of-roll check); drifted terminal → ✗; refresh-hindsight failure → ✗ with the recovery command. Fails on the old renderer (no section).
- Local: 196 passed across the 5 rollout/narrator suites; `npm run lint` (incl. full tsc) → clean.

## Risk
Medium-low. New phases are additive to the sentinel protocol and defensively dropped by older parsers; the section is bounded (4 rows) so the MAX_RENDER_CHARS fallback is unaffected.

Job spec: `reference/jobs/restart-and-know-what-im-running.md` (also `know-what-my-agent-is-doing.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)