### PR TITLE
docs(hindsight): correct observation-scope docs for curated default + untagged-sink growth watch

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -540,30 +540,56 @@ agents:
 
 **Cascade: override** (per-agent wins over profile/defaults). Omit the field to inherit the on-by-default. Operationally the knob threads the same way as the other recall tuning: the switchroom default is pinned in the plugin's `settings.json`, and `start.sh` exports `HINDSIGHT_DIRECTIVE_CAPTURE_NUDGE` only when you override it (the env value wins at plugin load). Serves the `remember-across-sessions` job.
 
-### Pooling observations across agents — `memory.observation_scopes`
+### Observation scopes — curated by default
 
-Hindsight stamps every retained row with an **observation scope**, which decides where consolidation files the observations it derives from that row. The engine default is **`combined`**: one consolidation pass using all the tags on the retain together, producing an observation tagged with that full set. Switchroom stamps exactly one tag per retain (`retainTags: ["{session_id}"]`), so that single pass is scoped to a single session. Because a session id never repeats, each session creates a fresh observation rather than growing an existing one. Several agents writing into one shared bank therefore end up in parallel per-session silos: each agent's observations consolidate on their own and never merge, so the shared bank never builds a shared picture.
+Hindsight stamps every retained row with an **observation scope**, which decides which other observations consolidation will dedup and merge this row against. Two things set that scope: switchroom's per-retain **strategy** (`observationScopeStrategy`, curated by default) and an optional **operator pin** (`memory.observation_scopes`, which overrides the strategy).
 
-Set `memory.observation_scopes: shared` to send an agent's retains into **one global untagged scope** instead:
+**Why a strategy exists.** Switchroom stamps volatile per-session provenance on every retain: the `{session_id}` retain tag resolves to a bare UUID, and sub-agent (sidechain) retains add `parent_session:<uuid>` and a `<uuid>-sub-<agent>` id. Under Hindsight's engine default (`combined`) an observation only dedups against others carrying the *identical* tag set, so those volatile tags turn every session into its own dedup island and cross-session merging never happens — measured at 99.5% of observations pocketed one-per-session on the live overlord bank before this shipped (#4035).
+
+**What `curated` does (the default, since #4035).** For each retain it strips the volatile provenance tags from the *consolidation scope* while **leaving them on the source fact** (so they are still queryable and recall-filterable), then:
+
+- **non-empty stable tag set** → an explicit `[[stable…]]` scope. Stable semantic tags (`lesson`, `sidechain`, `agent_type:*`, entities) ride the scope, so recall tag-weighting still fires on the observation layer and observations that share real meaning consolidate together across sessions.
+- **all-volatile / empty** → `shared`, i.e. the one global untagged scope.
+
+The volatile patterns are `parent_session:*` and a bare RFC-4122 UUID (including the `<uuid>-sub-<agent>` sidechain form) — `DEFAULT_VOLATILE_SCOPE_PATTERNS` in the plugin's `lib/config.py`. A curated retain never raises: a bad strategy degrades to `curated`, a bad pin degrades to the engine default, both shouted on stderr — a config typo can never lose a turn.
+
+**Choosing the strategy — `observationScopeStrategy`.** Four values (`lib/config.py:OBSERVATION_SCOPE_STRATEGIES`):
+
+| value | effect |
+|---|---|
+| `curated` | **default.** Strip volatile provenance tags, keep stable ones (above). |
+| `shared` | Send *every* retain to the one global untagged scope — the whole bank pools into a single belief set. What agents deliberately sharing one bank want. |
+| `combined` / `off` | Opt out: emit no per-row scope at all, restoring the pre-#4035 engine default (`combined`, per-session islands). Byte-identical wire body to an unconfigured pre-feature client. |
+
+There is **no dedicated `memory.observation_scope_strategy` knob in `switchroom.yaml` yet.** Today you select a non-default strategy in one of two ways:
+
+1. **Raw env** on the agent — set `HINDSIGHT_OBSERVATION_SCOPE_STRATEGY` in the agent's `env:` map (it is propagated into the container and read by the plugin, `lib/config.py` `ENV_MAPPINGS`):
+
+   ```yaml
+   agents:
+     clerk:
+       env:
+         HINDSIGHT_OBSERVATION_SCOPE_STRATEGY: shared   # or combined / off
+   ```
+
+2. **Pin the scope** with `memory.observation_scopes` (below), which wins over the strategy outright.
+
+**Pinning a scope — `memory.observation_scopes`.** A pin is an operator override that takes precedence over the strategy for every retain. Use it to force one Hindsight scope regardless of tags:
 
 ```yaml
-defaults:
-  memory:
-    observation_scopes: shared    # pool the whole fleet's observations
-
 agents:
   clerk:
     memory:
-      observation_scopes: shared  # or just the agents sharing a bank
+      observation_scopes: shared     # force the global untagged scope
 ```
 
-**Omitted by default.** Leave it unset and the field never goes on the wire at all — the engine's own default stands and nothing about your retains changes. Only set it on agents that genuinely share a bank; on an agent with its own bank it buys nothing.
+Accepted pin values are `per_tag`, `combined`, `all_combinations` and `shared` — the set Hindsight accepts as a bare string. **`combined` is the pin form of opting out** (restores the pre-feature engine default). Anything off that list is **rejected at `switchroom apply`** — the only place a typo is stopped before it exists anywhere; a silently-ignored one would keep retaining at the wrong scope and surface months later as a bank whose observations never merged.
 
-It applies to *every* retain path — the Stop hook, sub-agent (sidechain) retains, the boot reconciler, the pending-queue drain and the historical backfill — and the value is carried on the queued payload, so a retain that fails now and drains hours later still lands in the scope it was written for. Changing the knob does **not** re-scope already-consolidated observations; it binds new retains only.
+A pin (or a raw strategy env) can still carry a bad value by a path `apply` cannot see — a raw `HINDSIGHT_OBSERVATION_SCOPES` export, or a hand-edited installed `settings.json`. There, **the retain always wins over the scope**: the plugin drops the bad field, retains the turn at the engine's own default scope (exactly what an unconfigured agent does) and prints the offending value to the hook's stderr. It deliberately does *not* fail the retain — that would delete the turn, and every producer would keep deleting turns for as long as the bad value sat in the config. A wrong scope you can fix and re-consolidate; a lost turn is gone.
 
-Accepted values are `per_tag`, `combined`, `all_combinations` and `shared` — the set Hindsight accepts. Anything else is **rejected at `switchroom apply`**. That is the gate that matters: it is the only place a typo is stopped before it exists anywhere, and a silently-ignored one would keep retaining at the engine default and only surface months later as a bank whose observations never merged.
+Both the strategy and the pin apply to *every* retain path — the Stop hook, sub-agent (sidechain) retains, the boot reconciler, the pending-queue drain and the historical backfill — and the resolved scope is carried on the queued payload, so a retain that fails now and drains hours later still lands in the scope it was written for. Changing either does **not** re-scope already-consolidated observations; it binds new retains only.
 
-A bad value can still reach the plugin by a path `apply` cannot see — a raw `HINDSIGHT_OBSERVATION_SCOPES` export, or a hand-edited installed `settings.json`. There, **the retain always wins over the scope**: the plugin drops the bad field, retains the turn at the engine's own default scope (exactly what an unconfigured agent does) and prints the offending value to the hook's stderr. It deliberately does *not* fail the retain — doing that would not "reject" the typo, it would delete the turn, and every producer would keep deleting turns for as long as the bad value sat in the config. A wrong scope you can fix and re-consolidate; a lost turn is gone.
+**The untagged global scope is now the uncapped default sink.** Under `curated`, every all-volatile retain lands in the `shared` (untagged) scope, and the engine deliberately does **not** cap the untagged scope (`max_observations_per_scope` only guards tagged scopes). So that one scope grows without a wall. `switchroom doctor` watches its size — the `hindsight observation scopes` row WARNs when a bank's untagged scope crosses 10,000 observations (`OBSERVATION_SCOPE_UNTAGGED_WARN_COUNT` in `src/cli/doctor-observation-scopes.ts`), well before the pool is large enough to drag consolidation. Nothing is discarded (unlike a saturated *tagged* scope, which is a FAIL) — it is a growth signal.
 
 The session-handoff mirror — the briefing switchroom writes into the agent's own bank on shutdown — is the one path that fails closed instead, because it is risking less: the on-disk handoff sidecars are already written, so the next session still reorients and only the recallable copy is skipped. `switchroom handoff` exits non-zero in that case, which makes `run-hook.sh` file a red `hook:handoff` issue carrying the reason — visible in `switchroom issues` and on the Telegram issues card, and self-clearing on the next clean shutdown once the value is fixed.
 
@@ -575,9 +601,9 @@ Be aware of the limit: past `apply`, a bad value on the **retain** path is visib
 
 `switchroom memory --start` launches the bundled Hindsight container with `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=1000` already set. The same default is baked into the `--compose` snippet output.
 
-What this actually caps: per-*tag scope* observation count. Switchroom's vendored plugin retains with `retainTags: ["{session_id}"]`, so each session becomes its own scope and the cap bounds a single very-long session at 1000 observations. Most sessions stay well below 1000 — this is a safety rail for the worst case (a Telegram session running uninterrupted for weeks), not an active limit on most agents. Tagless observations are unaffected.
+What this actually caps: per-*tag scope* observation count. Under the default `curated` strategy (above) retains consolidate into stable-tag scopes (`lesson`, `sidechain`, `agent_type:*`, entities) that persist across sessions, so this cap now bounds a *durable* scope's growth rather than a single session's — a busy stable scope on a shared bank is the one to watch, and `switchroom doctor`'s `hindsight observation scopes` row reports any scope past 80% of the cap (counting by containment, the way the engine does). **Tagless/untagged observations are not capped at all** — the engine skips them (`if max_obs >= 0 and fact_tags:`), which is exactly why the untagged `shared` sink needs its own growth watch (see "Observation scopes" above).
 
-This is **not** a fix for vectorize-io/hindsight#1284 (the upstream unbounded-growth bug for whole-bank consolidation) — that's their work to do. It's a companion guardrail.
+This is **not** a fix for vectorize-io/hindsight#1284 (the upstream unbounded-growth bug for whole-bank consolidation) — that's their work to do. It's a companion guardrail, and the untagged-scope growth watch in `switchroom doctor` is the visibility half.
 
 You don't need to do anything to opt in. To change it, set the key under `hindsight.env` — it's a managed key, so your value replaces switchroom's default on both the `docker run` and `--compose` paths and survives the next `switchroom apply`:
 

--- a/src/cli/doctor-observation-scopes.test.ts
+++ b/src/cli/doctor-observation-scopes.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   OBSERVATION_SCOPE_CHECK_NAME,
   OBSERVATION_SCOPE_WARN_RATIO,
+  OBSERVATION_SCOPE_UNTAGGED_WARN_COUNT,
   checkObservationScopeSaturation,
   classifyObservationScopeSaturation,
   computeScopeSaturation,
@@ -52,6 +53,7 @@ const report = (over: Partial<BankScopeReport> & { bankId: string }): BankScopeR
   observationsEnabled: true,
   hasScopeLimitRules: false,
   scopeCount: 0,
+  untaggedCount: 0,
   saturated: [],
   pendingConsolidation: null,
   ...over,
@@ -68,6 +70,8 @@ const reportFor = (
     bankId,
     cap,
     scopeCount: scopes.length,
+    // Mirror inspectBankScopes: the untagged scope is tracked, never saturated.
+    untaggedCount: scopes.filter((s) => s.tags.length === 0).reduce((n, s) => n + s.count, 0),
     saturated: computeScopeSaturation(scopes, cap).filter((s) => s.status !== "ok"),
     pendingConsolidation,
   });
@@ -171,16 +175,22 @@ describe("counting the way the engine counts", () => {
     expect(child?.status).toBe("ok");
   });
 
-  it("never counts the untagged scope, which the engine does not cap", () => {
+  it("never counts the untagged scope toward the per-scope cap saturation", () => {
     // consolidator.py:1605 guards with `if max_obs >= 0 and fact_tags:`, and
     // _count_observations_for_scope documents "Observations with no tags are
-    // not counted". A bank whose global scope is huge is behaving as designed;
-    // reporting it would be a permanent false FAIL.
+    // not counted". The untagged scope must never appear as a cap FAIL —
+    // reporting it as saturated would be a permanent false FAIL on a bank
+    // behaving exactly as designed. (Its uncapped GROWTH is watched separately;
+    // see the "untagged global scope growth watch" block below.)
     const sat = computeScopeSaturation([scope([], 50_000), scope(["a"], 10)], 1000);
     expect(sat.some((s) => s.tags.length === 0)).toBe(false);
-    expect(classifyObservationScopeSaturation([
+    // No tagged scope is over its cap, so the cap dimension is clean — the only
+    // reason this bank is not `ok` is the growth watch, never a saturation fail.
+    const result = classifyObservationScopeSaturation([
       reportFor("bank", [scope([], 50_000), scope(["a"], 10)]),
-    ]).status).toBe("ok");
+    ]);
+    expect(result.detail).not.toContain("at or over the cap");
+    expect(result.detail).not.toContain("50,000/");
   });
 
   it("is order-insensitive across scopes that share tags", () => {
@@ -235,6 +245,64 @@ describe("thresholds", () => {
     // 1164 > 1009, so the containment-heavy scope leads.
     expect(firstListed).toBeGreaterThanOrEqual(0);
     expect(firstListed).toBeLessThan(secondListed as number);
+  });
+});
+
+describe("untagged global scope growth watch", () => {
+  // Since #4035 the `curated` strategy sends every all-volatile retain (a bare
+  // session UUID, `parent_session:*`) to the UNTAGGED scope, which the engine
+  // never caps. It is the one scope that grows without a wall, so the row must
+  // WARN on it before the pool is a drag — a fresh dimension from cap saturation.
+  const bigUntagged = OBSERVATION_SCOPE_UNTAGGED_WARN_COUNT + 1;
+
+  it("WARNS when a bank's untagged scope crosses the watch line, and names it", () => {
+    const result = classifyObservationScopeSaturation([
+      reportFor("klanker", [scope([], bigUntagged), scope(["s"], 10)]),
+    ]);
+    expect(result.status).toBe("warn");
+    expect(result.detail).toContain("klanker");
+    expect(result.detail).toContain(bigUntagged.toLocaleString());
+    expect(result.detail).toContain("growth watch");
+  });
+
+  it("stays ok one observation below the watch line", () => {
+    const result = classifyObservationScopeSaturation([
+      reportFor("klanker", [scope([], OBSERVATION_SCOPE_UNTAGGED_WARN_COUNT - 1), scope(["s"], 10)]),
+    ]);
+    expect(result.status).toBe("ok");
+    expect(result.detail).not.toContain("growth watch");
+  });
+
+  it("keeps a cap FAIL as fail but still reports the growing untagged scope", () => {
+    // A saturated tagged scope is the more urgent problem (output is being
+    // discarded), so it wins the status — but the growth note must still ride
+    // along so the operator sees both.
+    const result = classifyObservationScopeSaturation([
+      reportFor("busy", [scope(["s"], 1000), scope([], bigUntagged)], 1000, 5_000),
+    ]);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toContain("at or over the cap");
+    expect(result.detail).toContain("growth watch");
+    expect(result.detail).toContain("busy " + bigUntagged.toLocaleString());
+  });
+
+  it("does not watch the untagged scope of a bank with observations disabled", () => {
+    const result = classifyObservationScopeSaturation([
+      report({ bankId: "off", observationsEnabled: false, untaggedCount: bigUntagged, scopeCount: 1 }),
+    ]);
+    expect(result.status).toBe("skip");
+    expect(result.detail).not.toContain("growth watch");
+  });
+
+  it("warns on a growing sink even when no bank can be cap-judged", () => {
+    // observation_scope_limits makes the bank uncap-judgeable, but the untagged
+    // growth watch is independent of the cap, so it must not be swallowed.
+    const result = classifyObservationScopeSaturation([
+      report({ bankId: "ruled", hasScopeLimitRules: true, untaggedCount: bigUntagged, scopeCount: 1 }),
+    ]);
+    expect(result.status).toBe("warn");
+    expect(result.detail).toContain("growth watch");
+    expect(result.detail).toContain("ruled");
   });
 });
 

--- a/src/cli/doctor-observation-scopes.ts
+++ b/src/cli/doctor-observation-scopes.ts
@@ -102,6 +102,29 @@ export const OBSERVATION_SCOPE_WARN_RATIO = 0.8;
 /** How many saturated scopes are named in the detail before it elides. */
 export const OBSERVATION_SCOPE_MAX_LISTED = 6;
 
+/**
+ * Observation count at which the UNTAGGED global scope is reported as `warn`.
+ *
+ * The tagged-scope machinery above deliberately never judges the untagged
+ * scope: the engine skips it (`if max_obs >= 0 and fact_tags:`,
+ * consolidator.py:1605) so it has no cap to breach. Since #4035 that same scope
+ * is the *default consolidation sink* — the `curated` strategy sends every
+ * all-volatile retain (a bare session UUID, `parent_session:*`) to `shared`,
+ * which is the untagged scope. It therefore grows without a cap while every
+ * other scope is bounded, and upstream vectorize-io/hindsight#1284 (whole-bank
+ * unbounded consolidation growth) is acknowledged unfixed. A pool that only
+ * grows eventually makes every consolidation pass recall a larger set for the
+ * same output, so it needs a watch even though it has no wall to hit.
+ *
+ * 10k is ten times the historical per-scope cap of 1000: far past any single
+ * tagged scope's ceiling, quiet on a healthy bank (the live klanker global
+ * scope carried 188 observations on 2026-07-31), and early enough that an
+ * operator can act — raise consolidation cadence, prune, or split the bank —
+ * long before the pool is a drag. This is a WARN, never a FAIL: nothing is
+ * being discarded, unlike a saturated tagged scope; it is a growth signal.
+ */
+export const OBSERVATION_SCOPE_UNTAGGED_WARN_COUNT = 10_000;
+
 /** One `{tags, count}` entry as `GET /observations/scopes` returns it. */
 export interface ObservationScope {
   tags: string[];
@@ -245,6 +268,14 @@ export interface BankScopeReport {
   hasScopeLimitRules: boolean;
   /** Distinct scopes in the bank, including the untagged one. */
   scopeCount: number;
+  /**
+   * Observations in the UNTAGGED global scope (`tags: []`). This scope is the
+   * `curated`-strategy default sink and is never capped by the engine, so it is
+   * tracked separately from {@link saturated} and watched by
+   * {@link OBSERVATION_SCOPE_UNTAGGED_WARN_COUNT} rather than by the per-scope
+   * cap. 0 when the bank has no untagged observations.
+   */
+  untaggedCount: number;
   /** Scopes at `warn` or `fail`, worst first. */
   saturated: ScopeSaturation[];
   /**
@@ -267,7 +298,9 @@ function describeScope(bankId: string, s: ScopeSaturation): string {
  *   cost of a full extraction-model call each time. This is deliberately not a
  *   warning: the 2026-07 incident was a warning-shaped log line nobody read.
  * - `warn` — at least one scope is past {@link OBSERVATION_SCOPE_WARN_RATIO} of
- *   its cap and still writable.
+ *   its cap and still writable, OR a bank's untagged global scope has grown past
+ *   {@link OBSERVATION_SCOPE_UNTAGGED_WARN_COUNT} (the uncapped `curated` sink —
+ *   nothing is discarded, but the pool only grows, so it is watched).
  * - `skip` — nothing could be read, or every readable bank is one this check
  *   cannot judge honestly (glob scope-limit rules, or observations disabled).
  * - `ok`   — every scope on every reachable bank has room.
@@ -287,6 +320,27 @@ export function classifyObservationScopeSaturation(
 
   const unreadable = reports.filter((r) => !r.ok);
   const readable = reports.filter((r) => r.ok);
+
+  // The untagged global scope grows uncapped and is the `curated` default sink
+  // (see OBSERVATION_SCOPE_UNTAGGED_WARN_COUNT). It is independent of the
+  // per-scope cap and the glob rules, so it is judged for every readable bank
+  // that still writes observations, not only the cap-judged ones. Worst first.
+  const growing = readable
+    .filter((r) => r.observationsEnabled && r.untaggedCount >= OBSERVATION_SCOPE_UNTAGGED_WARN_COUNT)
+    .sort((a, b) => b.untaggedCount - a.untaggedCount);
+  const growthNote =
+    growing.length > 0
+      ? `${growing.length} bank(s) with an untagged global scope over ` +
+        `${OBSERVATION_SCOPE_UNTAGGED_WARN_COUNT.toLocaleString()} observations ` +
+        `(uncapped curated sink, growth watch): ` +
+        growing
+          .slice(0, OBSERVATION_SCOPE_MAX_LISTED)
+          .map((r) => `${r.bankId} ${r.untaggedCount.toLocaleString()}`)
+          .join(", ") +
+        (growing.length > OBSERVATION_SCOPE_MAX_LISTED
+          ? `; +${growing.length - OBSERVATION_SCOPE_MAX_LISTED} more`
+          : "")
+      : "";
 
   if (readable.length === 0) {
     return {
@@ -326,8 +380,15 @@ export function classifyObservationScopeSaturation(
     );
   }
   const suffix = notes.length > 0 ? ` · ${notes.join(" · ")}` : "";
+  const growthSuffix = growthNote ? ` · ${growthNote}` : "";
 
   if (judged.length === 0) {
+    // Nothing can be judged against the per-scope cap, but the untagged growth
+    // watch is independent of it — surface a growing sink as a warn rather than
+    // swallowing it in a skip.
+    if (growing.length > 0) {
+      return { name, status: "warn", detail: `${growthNote}${suffix}` };
+    }
     return { name, status: "skip", detail: `no bank could be judged${suffix}` };
   }
 
@@ -403,23 +464,27 @@ export function classifyObservationScopeSaturation(
         `output is being discarded on them right now: ${list(failing)}` +
         (warning.length > 0 ? ` · ${warning.length} more above ${Math.round(OBSERVATION_SCOPE_WARN_RATIO * 100)}%` : "") +
         backlog([...failing, ...warning]) +
+        growthSuffix +
         suffix,
       fix,
     };
   }
 
-  if (warning.length > 0) {
-    return {
-      name,
-      status: "warn",
-      detail:
-        `${warning.length} observation scope(s) above ` +
-        `${Math.round(OBSERVATION_SCOPE_WARN_RATIO * 100)}% of the cap and still writable: ` +
-        `${list(warning)}` +
-        backlog(warning) +
-        suffix,
-      fix,
-    };
+  if (warning.length > 0 || growing.length > 0) {
+    // Either a tagged scope is past its warn ratio, or the untagged sink has
+    // grown past its watch line (or both). Both are writable-but-worth-seeing.
+    const scopeClause =
+      warning.length > 0
+        ? `${warning.length} observation scope(s) above ` +
+          `${Math.round(OBSERVATION_SCOPE_WARN_RATIO * 100)}% of the cap and still writable: ` +
+          `${list(warning)}` +
+          backlog(warning)
+        : "";
+    const detail =
+      warning.length > 0
+        ? scopeClause + growthSuffix + suffix
+        : `${growthNote}${suffix}`;
+    return { name, status: "warn", detail, ...(warning.length > 0 ? { fix } : {}) };
   }
 
   const totalScopes = capped.reduce((n, r) => n + r.scopeCount, 0);
@@ -500,6 +565,7 @@ export async function inspectBankScopes(
     observationsEnabled: false,
     hasScopeLimitRules: false,
     scopeCount: 0,
+    untaggedCount: 0,
     saturated: [],
     pendingConsolidation: null,
   });
@@ -538,6 +604,12 @@ export async function inspectBankScopes(
   }
 
   const saturated = computeScopeSaturation(scopes, rawCap).filter((s) => s.status !== "ok");
+  // The untagged global scope: never in `saturated` (the engine skips it), but
+  // it is the `curated` default sink and grows uncapped, so its size is tracked
+  // and watched separately (OBSERVATION_SCOPE_UNTAGGED_WARN_COUNT).
+  const untaggedCount = scopes
+    .filter((s) => s.tags.length === 0)
+    .reduce((n, s) => n + s.count, 0);
 
   // The backlog number is what makes the row legible ("overlord is sitting on
   // 43,734 pending memories" beats a bare uuid), but /stats is the expensive
@@ -562,6 +634,7 @@ export async function inspectBankScopes(
     observationsEnabled,
     hasScopeLimitRules,
     scopeCount: scopes.length,
+    untaggedCount,
     saturated,
     pendingConsolidation,
   };

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -334,8 +334,14 @@ export const AgentToolsSchema = z
   .optional();
 
 /**
- * `memory.observation_scopes` — the per-row `observation_scopes` switchroom
- * stamps on every retained Hindsight MemoryItem.
+ * `memory.observation_scopes` — an operator PIN for the per-row
+ * `observation_scopes` switchroom stamps on every retained Hindsight MemoryItem.
+ *
+ * This is an override, not the default path. Since #4035 the default is the
+ * plugin's `curated` strategy (`observationScopeStrategy`), which computes a
+ * scope per retain; a pin here wins over that strategy outright. `combined` is
+ * the pin form of opting out (restores the pre-feature engine default). See
+ * `docs/configuration.md` § "Observation scopes".
  *
  * Declared once and reused by BOTH `AgentMemorySchema` and the
  * defaults/profile-tier mirror, so the two tiers cannot drift into accepting
@@ -352,14 +358,15 @@ const ObservationScopesSchema = z
   .enum(OBSERVATION_SCOPES)
   .optional()
   .describe(
-    "Per-row observation scope stamped on every memory this agent " +
-    "retains. \"shared\" makes Hindsight's consolidation write the " +
-    "resulting observations into ONE global untagged scope instead of a " +
-    "scope per tag — what several agents pooling one bank need so their " +
-    "observations actually merge rather than sitting in parallel " +
-    "per-tag silos. OMITTED BY DEFAULT: unset means the field never goes " +
-    "on the wire and the engine's own default stands, which is the " +
-    "shipped behaviour. Applies to every retain path (Stop hook, " +
+    "Operator PIN for the per-row observation scope, overriding the " +
+    "default `curated` strategy (see docs/configuration.md). \"shared\" " +
+    "forces Hindsight's consolidation to write EVERY observation into ONE " +
+    "global untagged scope — what several agents pooling one bank want so " +
+    "their observations merge rather than sitting in parallel silos. " +
+    "\"combined\" is the pin form of opting out (restores the pre-#4035 " +
+    "engine default). UNSET does NOT mean 'nothing on the wire': the " +
+    "`curated` strategy still computes a scope per retain. Applies to " +
+    "every retain path (Stop hook, " +
     "sidechain, boot reconcile, queue drain, backfill, session-handoff " +
     "mirror) and is carried on the queued payload, so a retain that fails " +
     "now and drains later still lands in this scope. Accepted values: " +

--- a/src/memory/observation-scopes.ts
+++ b/src/memory/observation-scopes.ts
@@ -3,9 +3,14 @@
  *
  * Server-side `MemoryItem.observation_scopes` is typed
  * `Literal["per_tag","combined","all_combinations","shared"] | list[list[str]]
- * | None`. The explicit list-of-lists tag matrix is deliberately NOT exposed
- * through switchroom config: it is an unbounded per-memory matrix with no safe
- * fleet-wide default and no caller here needs it.
+ * | None`. The explicit list-of-lists tag matrix is deliberately NOT exposed as
+ * a `switchroom.yaml` *pin* value: it is an unbounded per-memory matrix with no
+ * safe fleet-wide default. It IS emitted on the wire — but computed per retain
+ * by the plugin's `curated` strategy (`compute_observation_scopes`,
+ * `vendor/hindsight-memory/scripts/lib/config.py`), which strips volatile
+ * provenance tags and produces a `[[stable…]]` scope from the retain's own
+ * tags. This enum is only the operator PIN surface, whose values override the
+ * strategy; the matrix has no place there.
  *
  * This is the single TS source of truth, consumed by the zod enum in
  * `src/config/schema.ts` (both the per-agent and defaults/profile tiers) and by


### PR DESCRIPTION
## What & why

Follow-up to review of #4035 (curated observation scopes, v0.19.39). Two
things that shipped stale with that feature:

1. The docs describe the **pre-#4035** world — scopes "omitted / off by
   default", engine default stands — when curated is now default-ON. The
   `observationScopeStrategy` knob / `HINDSIGHT_OBSERVATION_SCOPE_STRATEGY` env
   (the only opt-out) were documented nowhere.
2. Curated makes the **untagged global scope** the default consolidation sink,
   and the engine never caps it (`if max_obs >= 0 and fact_tags:`,
   `consolidator.py:1605`). Nothing watched its growth.

Closes #4050. First half of #4052 (untagged-sink growth watch).

## Changes

- **`docs/configuration.md`** — rewrite the observation-scopes section for
  curated default-ON: what curated does (strips volatile provenance tags, keeps
  them on the source fact), the strategy table (curated / shared / combined /
  off), both opt-out paths (`HINDSIGHT_OBSERVATION_SCOPE_STRATEGY` in the agent
  `env:` map, or pinning `memory.observation_scopes: combined`), pin precedence,
  and the untagged-sink growth watch. Fix the stale per-scope-cap paragraph.
- **`src/cli/doctor-observation-scopes.ts`** — add a WARN growth watch on the
  untagged global scope (`OBSERVATION_SCOPE_UNTAGGED_WARN_COUNT`, 10k — 10× the
  historical cap; klanker's global scope was 188 at authoring). Doctor now goes
  yellow before the uncapped sink becomes a problem.
- **`src/config/schema.ts`** — correct the `ObservationScopesSchema` docstring
  and `.describe()` (the pin is an override of the curated strategy; `combined`
  is the pin-level opt-out; unset means curated computes a scope, not "omitted").
- **`src/memory/observation-scopes.ts`** — fix the stale NIT comment (the
  list-of-lists matrix IS emitted, computed plugin-side by curated).

## Tests / lint

- `vitest run src/cli/doctor-observation-scopes.test.ts` — green, incl. a new
  `untagged global scope growth watch` describe block asserting the metric
  fires at the threshold and stays quiet below it. Tests assert the OUTCOME
  (row goes yellow, names the bank + count), not just that the code runs.
- `npm run lint` — EXIT 0. `tsc --noEmit` — EXIT 0.

Not enrolled in the merge queue by request — independent adversarial review
runs before merge.
