### PR TITLE
feat(memory): dry-run legacy observation-scope cleanup planner

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -8,6 +8,11 @@ import {
   DEMOTE_FROM_RECALL_TAG,
 } from "../memory/hindsight.js";
 import { searchMemory, getMemoryStats, reflectAcrossAgents } from "../memory/search.js";
+import {
+  planBankCleanup,
+  formatCleanupPlan,
+  type BankCleanupPlan,
+} from "../memory/observation-scope-cleanup.js";
 import { redactMemoryWriteBody } from "../memory/hindsight-write-redaction.js";
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
 import {
@@ -1294,6 +1299,108 @@ export function registerMemoryCommand(program: Command): void {
             ),
           );
           process.exit(1);
+        },
+      ),
+    );
+
+  // switchroom memory cleanup-scopes — AUDIT + DRY-RUN for legacy
+  // observation-scope fragmentation left by banks that retained before #4035
+  // (curated scopes by default). It only READS `/observations/scopes` and
+  // prints what a curated re-home WOULD change; it never writes. Live execution
+  // is not wired: Hindsight has no per-memory tag-write (#3772) and no per-scope
+  // delete, so healing is not mechanizable through the REST surface today —
+  // `--execute` refuses and explains, keeping this a diagnostic only.
+  memory
+    .command("cleanup-scopes [agent]")
+    .description(
+      "Dry-run audit of legacy pre-#4035 observation-scope fragmentation " +
+        "(per-session UUID islands, stale agent-<hex> scopes). Reads only; " +
+        "prints the blast radius of a curated re-home. Pass an agent, or --all.",
+    )
+    .option("--all", "Audit every agent bank and profile bank")
+    .option(
+      "--retire-stale",
+      "Also fold stale agent-<hex> producer scopes into shared (opt-in; not part of the #4035 heal)",
+    )
+    .option("--execute", "(refused) live mutation is not supported — see the printed reason")
+    .option("--json", "Emit the plans as JSON")
+    .action(
+      withConfigError(
+        async (
+          agent: string | undefined,
+          opts: { all?: boolean; retireStale?: boolean; execute?: boolean; json?: boolean },
+        ) => {
+          const config = getConfig(program);
+          const apiUrl =
+            (config.memory?.config?.url as string | undefined) ?? HINDSIGHT_DEFAULT_MCP_URL;
+
+          if (opts.execute) {
+            console.error(
+              chalk.red("✗ --execute is not supported: legacy-scope healing is not mechanizable"),
+            );
+            console.error(
+              chalk.gray(
+                "  Hindsight exposes no per-memory tag-write (update_memory / PATCH memories/{id}\n" +
+                  "  silently drop a `tags` argument, #3772) and no per-scope delete (DELETE\n" +
+                  "  .../observations clears the WHOLE bank). So an observation's scope cannot be\n" +
+                  "  edited in place, and this tool stays a read-only audit. A live heal needs an\n" +
+                  "  upstream tag-write path or a deliberate, operator-approved enumerate-and-\n" +
+                  "  invalidate pass — neither is run from here.",
+              ),
+            );
+            process.exit(1);
+          }
+
+          // Resolve the bank set. One agent, or the whole fleet + profile banks.
+          const banks = new Set<string>();
+          if (agent) {
+            if (!config.agents[agent]) {
+              console.error(chalk.red(`Agent "${agent}" is not defined in switchroom.yaml`));
+              process.exit(1);
+            }
+            banks.add(getCollectionForAgent(agent, config));
+          } else if (opts.all) {
+            for (const name of Object.keys(config.agents)) {
+              banks.add(getCollectionForAgent(name, config));
+            }
+            for (const bank of collectProfileBanks(config)) banks.add(bank);
+          } else {
+            console.error(chalk.red("Pass an agent name, or --all to audit every bank."));
+            process.exit(1);
+          }
+
+          const plans: BankCleanupPlan[] = await Promise.all(
+            [...banks].map((bankId) =>
+              planBankCleanup(apiUrl, bankId, { retireStale: opts.retireStale }),
+            ),
+          );
+          plans.sort((a, b) => b.affectedObservations - a.affectedObservations);
+
+          if (opts.json) {
+            console.log(JSON.stringify(plans, null, 2));
+            return;
+          }
+
+          console.log(chalk.bold("\nObservation-scope cleanup — DRY RUN (no writes)\n"));
+          console.log(chalk.gray(`  api=${apiUrl}  retireStale=${Boolean(opts.retireStale)}\n`));
+          for (const plan of plans) {
+            console.log(formatCleanupPlan(plan));
+            console.log();
+          }
+          const totalObs = plans.reduce((n, p) => n + p.affectedObservations, 0);
+          const totalScopes = plans.reduce((n, p) => n + p.scopeReduction, 0);
+          console.log(
+            chalk.cyan(
+              `Fleet total (would change): ${totalObs.toLocaleString()} observations re-homed, ` +
+                `${totalScopes.toLocaleString()} scopes removed.`,
+            ),
+          );
+          console.log(
+            chalk.gray(
+              "Nothing was written. Live execution is not supported from this tool " +
+                "(--execute prints why).",
+            ),
+          );
         },
       ),
     );

--- a/src/memory/observation-scope-cleanup.test.ts
+++ b/src/memory/observation-scope-cleanup.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  planScopeCleanup,
+  planBankCleanup,
+  formatCleanupPlan,
+  type ObservationScope,
+} from "./observation-scope-cleanup.js";
+
+const scope = (tags: string[], count: number): ObservationScope => ({ tags, count });
+
+// Shapes taken from the live klanker bank on 2026-07-31 (read-only).
+const UUID_A = "516929ee-1666-4d5b-9db1-85b5d7a03b30";
+const UUID_B = "6ec44942-e9cb-4be5-9bbd-cc653ecc93e7";
+const UUID_C = "b11cbaca-fc44-4409-825c-10783f9e1e0f";
+const SUB_A = "34c4bbeb-f805-4dd3-b085-46ac2eb57ae9-sub-a5df90f21bb098e8f";
+const SUB_B = "68b17a48-f224-4223-964f-925301de960f-sub-a34b4856e57e91924";
+
+describe("all-volatile scopes collapse into the shared scope", () => {
+  it("folds N single-UUID per-session scopes into one shared target", () => {
+    // The pre-#4035 per-session island: each session got its own bare-UUID
+    // scope, so its observations never merged with any other session's.
+    const plan = planScopeCleanup("klanker", [
+      scope([UUID_A], 50),
+      scope([UUID_B], 30),
+      scope([UUID_C], 20),
+    ]);
+
+    expect(plan.affectedScopes).toBe(3);
+    expect(plan.affectedObservations).toBe(100);
+    // Three scopes → one `shared` scope.
+    expect(plan.resultingScopeCount).toBe(1);
+    expect(plan.scopeReduction).toBe(2);
+    expect(plan.merges).toEqual([{ target: "shared", sourceScopes: 3, observations: 100 }]);
+    expect(plan.breakdown.allVolatileScopes).toBe(3);
+    expect(plan.breakdown.allVolatileObservations).toBe(100);
+  });
+
+  it("treats a parent_session-tagged scope as volatile too", () => {
+    const plan = planScopeCleanup("k", [scope([`parent_session:${UUID_A}`], 7)]);
+    expect(plan.reclassified[0]?.to).toBe("shared");
+    expect(plan.reclassified[0]?.strippedVolatile).toEqual([`parent_session:${UUID_A}`]);
+  });
+});
+
+describe("mixed scopes keep their stable tags and merge on them", () => {
+  it("strips the volatile provenance and collapses onto the stable-tag scope", () => {
+    // Two different sessions, same stable meaning: under curated both land on
+    // `[agent_type:worker, sidechain]` and finally merge.
+    const plan = planScopeCleanup("klanker", [
+      scope([SUB_A, `parent_session:${UUID_A}`, "agent_type:worker", "sidechain"], 12),
+      scope([SUB_B, `parent_session:${UUID_B}`, "agent_type:worker", "sidechain"], 9),
+    ]);
+
+    expect(plan.affectedScopes).toBe(2);
+    expect(plan.resultingScopeCount).toBe(1);
+    const target = plan.reclassified[0]?.to;
+    expect(target).toBe("agent_type:worker,sidechain");
+    expect(plan.merges).toEqual([
+      { target: "agent_type:worker,sidechain", sourceScopes: 2, observations: 21 },
+    ]);
+    expect(plan.breakdown.mixedScopes).toBe(2);
+  });
+
+  it("leaves an already-clean stable scope untouched", () => {
+    const plan = planScopeCleanup("k", [scope(["lesson"], 100)]);
+    expect(plan.affectedScopes).toBe(0);
+    expect(plan.scopeReduction).toBe(0);
+    expect(plan.merges).toEqual([]);
+  });
+
+  it("leaves the untagged shared scope untouched", () => {
+    const plan = planScopeCleanup("k", [scope([], 188)]);
+    expect(plan.affectedScopes).toBe(0);
+  });
+});
+
+describe("stale agent-<hex> producer tags", () => {
+  const stale = scope(["agent-a0114e4b60521433b"], 40);
+
+  it("counts them but does NOT retire them by default (not part of the #4035 heal)", () => {
+    const plan = planScopeCleanup("klanker", [stale]);
+    expect(plan.breakdown.staleScopes).toBe(1);
+    expect(plan.breakdown.staleObservations).toBe(40);
+    // agent-<hex> is not volatile, so with retireStale off nothing changes.
+    expect(plan.affectedScopes).toBe(0);
+  });
+
+  it("retires them into shared when explicitly asked", () => {
+    const plan = planScopeCleanup("klanker", [stale], { retireStale: true });
+    expect(plan.affectedScopes).toBe(1);
+    expect(plan.reclassified[0]?.to).toBe("shared");
+    expect(plan.reclassified[0]?.strippedStale).toEqual(["agent-a0114e4b60521433b"]);
+  });
+
+  it("keeps a stable tag when retiring the stale one from a scope that has both", () => {
+    const plan = planScopeCleanup("klanker", [scope(["agent-a039d22e5cc4d8fc0", "lesson"], 5)], {
+      retireStale: true,
+    });
+    expect(plan.reclassified[0]?.to).toBe("lesson");
+  });
+});
+
+describe("blast radius summary", () => {
+  it("reports the total scope reduction across a mixed bank", () => {
+    const plan = planScopeCleanup("klanker", [
+      scope([UUID_A], 10),
+      scope([UUID_B], 10),
+      scope([SUB_A, "lesson"], 5),
+      scope([SUB_B, "lesson"], 5),
+      scope(["lesson"], 100), // already clean — the merge TARGET for the two above
+      scope([], 188), // shared, untouched
+    ]);
+
+    // The two bare-UUID scopes → shared (new). The two sub-lesson scopes →
+    // `lesson` (existing). Resulting distinct scopes: shared, lesson = 2.
+    expect(plan.resultingScopeCount).toBe(2);
+    expect(plan.totalScopes).toBe(6);
+    expect(plan.scopeReduction).toBe(4);
+    expect(plan.affectedScopes).toBe(4);
+    expect(plan.affectedObservations).toBe(30);
+    // `lesson` gains the two sub-scopes → a merge of 3 sources (2 changed + the
+    // clean one), all folding into `lesson`.
+    const lessonMerge = plan.merges.find((m) => m.target === "lesson");
+    expect(lessonMerge?.sourceScopes).toBe(3);
+    expect(lessonMerge?.observations).toBe(110);
+  });
+
+  it("orders reclassified scopes worst (largest) first", () => {
+    const plan = planScopeCleanup("k", [scope([UUID_A], 5), scope([UUID_B], 500)]);
+    expect(plan.reclassified[0]?.count).toBe(500);
+  });
+});
+
+describe("formatting", () => {
+  it("renders the blast radius and top merges for an operator", () => {
+    const plan = planScopeCleanup("klanker", [
+      scope([UUID_A], 10),
+      scope([UUID_B], 20),
+    ]);
+    const out = formatCleanupPlan(plan);
+    expect(out).toContain("bank klanker");
+    expect(out).toContain("2 → 1 scopes");
+    expect(out).toContain("2 scopes → shared");
+  });
+
+  it("renders an unreadable bank plainly", () => {
+    const out = formatCleanupPlan({
+      bankId: "down",
+      ok: false,
+      reason: "Timeout",
+      totalScopes: 0,
+      totalObservations: 0,
+      reclassified: [],
+      merges: [],
+      affectedScopes: 0,
+      affectedObservations: 0,
+      resultingScopeCount: 0,
+      scopeReduction: 0,
+      breakdown: {
+        allVolatileScopes: 0,
+        allVolatileObservations: 0,
+        mixedScopes: 0,
+        mixedObservations: 0,
+        staleScopes: 0,
+        staleObservations: 0,
+      },
+    });
+    expect(out).toContain("down");
+    expect(out).toContain("UNREADABLE");
+  });
+});
+
+describe("planBankCleanup over REST (read-only)", () => {
+  const stubFetch = (routes: Record<string, unknown>): typeof fetch =>
+    (async (input: string | URL | Request) => {
+      const url = String(input);
+      for (const [needle, body] of Object.entries(routes)) {
+        if (url.includes(needle)) {
+          return { ok: true, status: 200, json: async () => body } as unknown as Response;
+        }
+      }
+      return { ok: false, status: 404, json: async () => ({}) } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+  it("fetches the scope table and plans from it", async () => {
+    const plan = await planBankCleanup(
+      "http://h:1/mcp",
+      "klanker",
+      {},
+      {
+        fetchImpl: stubFetch({
+          "/observations/scopes": { scopes: [scope([UUID_A], 3), scope([UUID_B], 4)] },
+        }),
+      },
+    );
+    expect(plan.ok).toBe(true);
+    expect(plan.affectedScopes).toBe(2);
+    expect(plan.merges[0]?.target).toBe("shared");
+  });
+
+  it("surfaces an unreadable bank without throwing", async () => {
+    const plan = await planBankCleanup(
+      "http://h:1/mcp",
+      "gone",
+      {},
+      { fetchImpl: stubFetch({}) },
+    );
+    expect(plan.ok).toBe(false);
+    expect(plan.reason).toContain("404");
+  });
+});

--- a/src/memory/observation-scope-cleanup.ts
+++ b/src/memory/observation-scope-cleanup.ts
@@ -1,0 +1,364 @@
+/**
+ * One-time audit + dry-run planner for LEGACY observation-scope fragmentation
+ * left behind by banks that retained before #4035 (curated scopes by default).
+ *
+ * ## What it is for
+ *
+ * Before #4035 every retain carried its volatile per-session provenance
+ * (`{session_id}` → a bare UUID; sub-agent retains add `parent_session:<uuid>`
+ * and a `<uuid>-sub-<agent>` id) INTO the consolidation scope. Because
+ * Hindsight only dedups an observation against others carrying the identical
+ * tag set, each session became its own dedup island and cross-session merging
+ * never happened. The result on a long-lived bank is thousands of
+ * single-session scopes that #4035 would now fold together:
+ *
+ *   - **all-volatile scopes** — the tag set is ONLY volatile provenance. Under
+ *     curated these collapse to the one `shared` (untagged) scope.
+ *   - **mixed scopes** — volatile provenance PLUS stable semantic tags
+ *     (`lesson`, `sidechain`, `agent_type:*`, entities). Under curated the
+ *     volatile part is stripped and they collapse onto their stable-tag scope.
+ *   - **stale producer tags** — `agent-<hex>` scopes from a retired tag
+ *     producer that no live code path writes any more. Dead weight; a cleanup
+ *     that retires them is the operator's call, so they are flagged separately
+ *     and only folded when explicitly asked ({@link CleanupOptions.retireStale}).
+ *
+ * ## Why it is DRY-RUN ONLY — the write path is not mechanizable today
+ *
+ * This module deliberately ships without a live-mutation path, and not merely
+ * for caution:
+ *
+ *  - **There is no per-memory tag-write on the Hindsight REST surface.**
+ *    `update_memory` / `PATCH /v1/default/banks/<bank>/memories/{id}` accept
+ *    only text / context / occurred_* / fact_type / entities; an unknown
+ *    argument (`tags`, `add_tags`) is SILENTLY DROPPED (verified in
+ *    `switchroom memory demote`, upstream #3772). So an observation's scope
+ *    cannot be edited in place to strip its volatile tags.
+ *  - **There is no per-scope delete.** `DELETE /v1/default/banks/<bank>/
+ *    observations` clears the WHOLE bank's observations (no scope parameter,
+ *    verified against the live OpenAPI). Retiring one scope means enumerating
+ *    it (`GET /graph?type=observation&tags=<scope>&tags_match=exact`) and
+ *    deleting per memory — a destructive, operator-approved operation.
+ *
+ * So the deliverable is an AUDIT: it quantifies the fragmentation and the exact
+ * blast radius of a heal (scopes merged, observations affected, resulting scope
+ * count) so an operator can decide, and so a future write path (an upstream
+ * tag-write, or a deliberate enumerate-and-invalidate) has a costed target. The
+ * planner is a pure function; nothing here issues a write.
+ */
+
+import { hindsightRestBase } from "./bank-health.js";
+
+/** One `{tags, count}` entry as `GET /observations/scopes` returns it. */
+export interface ObservationScope {
+  tags: string[];
+  count: number;
+}
+
+/**
+ * VOLATILE per-session provenance patterns — a paired copy of the plugin's
+ * `DEFAULT_VOLATILE_SCOPE_PATTERNS` (`vendor/hindsight-memory/scripts/lib/
+ * config.py`). Kept in sync by hand because this runs in the switchroom CLI
+ * (Node), not the agent container (Python). A tag matching any of these is what
+ * the `curated` strategy strips from the consolidation scope.
+ */
+export const CLEANUP_VOLATILE_PATTERNS: readonly RegExp[] = [
+  /^parent_session:/,
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(-sub-.+)?$/,
+];
+
+/**
+ * STALE producer tags — `agent-<hex>` scopes from a retired tag producer. These
+ * are NOT in the volatile set (curated leaves them alone), so retiring them is a
+ * separate, opt-in cleanup decision, not part of the #4035 heal.
+ */
+export const CLEANUP_STALE_PATTERNS: readonly RegExp[] = [/^agent-[0-9a-f]{8,}$/];
+
+function matchesAny(tag: string, patterns: readonly RegExp[]): boolean {
+  return patterns.some((p) => p.test(tag));
+}
+
+/** A scope key for grouping — the target scope printed as a stable string. */
+function scopeKey(tags: string[]): string {
+  return tags.length === 0 ? "shared" : [...tags].sort().join(",");
+}
+
+export interface CleanupOptions {
+  /**
+   * Also strip `agent-<hex>` stale-producer tags (retire those scopes). Off by
+   * default: the #4035 heal only touches volatile provenance; retiring the
+   * stale producer is a separate operator decision.
+   */
+  retireStale?: boolean;
+  volatilePatterns?: readonly RegExp[];
+  stalePatterns?: readonly RegExp[];
+}
+
+/** How one existing scope is reclassified under a cleanup. */
+export interface ScopeReclass {
+  /** The scope as it exists today. */
+  from: string[];
+  /** The curated target scope key it would collapse into (`"shared"` = untagged). */
+  to: string;
+  /** Observations in the source scope. */
+  count: number;
+  /** Volatile tags that would be stripped. */
+  strippedVolatile: string[];
+  /** Stale `agent-<hex>` tags that would be stripped (only when retireStale). */
+  strippedStale: string[];
+}
+
+/** One target scope several source scopes collapse into. */
+export interface ScopeMerge {
+  target: string;
+  /** How many DISTINCT existing scopes fold into this target. */
+  sourceScopes: number;
+  /** Total observations across those source scopes. */
+  observations: number;
+}
+
+/** The full cleanup plan for one bank. Pure data; no writes implied. */
+export interface BankCleanupPlan {
+  bankId: string;
+  ok: boolean;
+  reason?: string;
+  /** Distinct scopes in the bank today (including untagged). */
+  totalScopes: number;
+  /** Total observations across all scopes. */
+  totalObservations: number;
+  /** Scopes whose tag set changes under the cleanup, worst (largest) first. */
+  reclassified: ScopeReclass[];
+  /** Targets that ≥2 source scopes collapse into, or that a changed scope joins. */
+  merges: ScopeMerge[];
+  /** Count of scopes that change (== reclassified.length). */
+  affectedScopes: number;
+  /** Observations in changed scopes — the blast radius. */
+  affectedObservations: number;
+  /** Distinct scopes AFTER the cleanup. */
+  resultingScopeCount: number;
+  /** How many distinct scopes the cleanup removes. */
+  scopeReduction: number;
+  /** Class breakdown, for the summary line. */
+  breakdown: {
+    allVolatileScopes: number;
+    allVolatileObservations: number;
+    mixedScopes: number;
+    mixedObservations: number;
+    staleScopes: number;
+    staleObservations: number;
+  };
+}
+
+/**
+ * Pure planner: given a bank's scope table, compute what a curated re-home would
+ * do. No I/O, no writes — the same input always yields the same plan, which is
+ * what the tests assert against.
+ */
+export function planScopeCleanup(
+  bankId: string,
+  scopes: ObservationScope[],
+  options: CleanupOptions = {},
+): BankCleanupPlan {
+  const volatilePatterns = options.volatilePatterns ?? CLEANUP_VOLATILE_PATTERNS;
+  const stalePatterns = options.stalePatterns ?? CLEANUP_STALE_PATTERNS;
+  const retireStale = options.retireStale ?? false;
+
+  const totalScopes = scopes.length;
+  const totalObservations = scopes.reduce((n, s) => n + s.count, 0);
+
+  const reclassified: ScopeReclass[] = [];
+  const breakdown = {
+    allVolatileScopes: 0,
+    allVolatileObservations: 0,
+    mixedScopes: 0,
+    mixedObservations: 0,
+    staleScopes: 0,
+    staleObservations: 0,
+  };
+
+  // target key -> {distinct source scopes, observations, anyChanged}
+  const targets = new Map<string, { sources: number; observations: number; changed: boolean }>();
+
+  for (const s of scopes) {
+    const volatileTags = s.tags.filter((t) => matchesAny(t, volatilePatterns));
+    const staleTags = s.tags.filter((t) => matchesAny(t, stalePatterns));
+
+    const stripped = s.tags.filter((t) => {
+      if (matchesAny(t, volatilePatterns)) return false;
+      if (retireStale && matchesAny(t, stalePatterns)) return false;
+      return true;
+    });
+    const toKey = scopeKey(stripped);
+    const changed = scopeKey(s.tags) !== toKey;
+
+    // Class breakdown (independent of retireStale — describes the bank as it is).
+    const hasStable = s.tags.some(
+      (t) => !matchesAny(t, volatilePatterns) && !matchesAny(t, stalePatterns),
+    );
+    if (staleTags.length > 0) {
+      breakdown.staleScopes += 1;
+      breakdown.staleObservations += s.count;
+    }
+    if (volatileTags.length > 0 && !hasStable && staleTags.length === 0) {
+      breakdown.allVolatileScopes += 1;
+      breakdown.allVolatileObservations += s.count;
+    } else if (volatileTags.length > 0 && hasStable) {
+      breakdown.mixedScopes += 1;
+      breakdown.mixedObservations += s.count;
+    }
+
+    const entry = targets.get(toKey) ?? { sources: 0, observations: 0, changed: false };
+    entry.sources += 1;
+    entry.observations += s.count;
+    entry.changed = entry.changed || changed;
+    targets.set(toKey, entry);
+
+    if (changed) {
+      reclassified.push({
+        from: s.tags,
+        to: toKey,
+        count: s.count,
+        strippedVolatile: volatileTags,
+        strippedStale: retireStale ? staleTags : [],
+      });
+    }
+  }
+
+  reclassified.sort((a, b) => b.count - a.count);
+
+  const merges: ScopeMerge[] = [...targets.entries()]
+    .filter(([, v]) => v.sources > 1 && v.changed)
+    .map(([target, v]) => ({ target, sourceScopes: v.sources, observations: v.observations }))
+    .sort((a, b) => b.observations - a.observations);
+
+  const affectedObservations = reclassified.reduce((n, r) => n + r.count, 0);
+  const resultingScopeCount = targets.size;
+
+  return {
+    bankId,
+    ok: true,
+    totalScopes,
+    totalObservations,
+    reclassified,
+    merges,
+    affectedScopes: reclassified.length,
+    affectedObservations,
+    resultingScopeCount,
+    scopeReduction: totalScopes - resultingScopeCount,
+    breakdown,
+  };
+}
+
+interface FetchOpts {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+async function getJson<T>(
+  url: string,
+  opts?: FetchOpts,
+): Promise<{ ok: true; data: T } | { ok: false; reason: string }> {
+  const fetchImpl = opts?.fetchImpl ?? fetch;
+  const timeoutMs = opts?.timeoutMs ?? 15_000;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const resp = await fetchImpl(url, { signal: controller.signal });
+    clearTimeout(timeout);
+    if (!resp.ok) return { ok: false, reason: `HTTP ${resp.status}` };
+    return { ok: true, data: (await resp.json()) as T };
+  } catch (err) {
+    clearTimeout(timeout);
+    if ((err as Error).name === "AbortError") return { ok: false, reason: "Timeout" };
+    return { ok: false, reason: String((err as Error).message ?? err) };
+  }
+}
+
+/**
+ * Fetch one bank's scope table (read-only) and plan the cleanup. `GET
+ * /observations/scopes` only — no /config, no writes.
+ */
+export async function planBankCleanup(
+  apiUrl: string,
+  bankId: string,
+  options: CleanupOptions = {},
+  fetchOpts?: FetchOpts,
+): Promise<BankCleanupPlan> {
+  const base = hindsightRestBase(apiUrl);
+  const bank = encodeURIComponent(bankId);
+  const resp = await getJson<{ scopes?: unknown }>(
+    `${base}/v1/default/banks/${bank}/observations/scopes`,
+    fetchOpts,
+  );
+  if (!resp.ok) {
+    return {
+      bankId,
+      ok: false,
+      reason: resp.reason,
+      totalScopes: 0,
+      totalObservations: 0,
+      reclassified: [],
+      merges: [],
+      affectedScopes: 0,
+      affectedObservations: 0,
+      resultingScopeCount: 0,
+      scopeReduction: 0,
+      breakdown: {
+        allVolatileScopes: 0,
+        allVolatileObservations: 0,
+        mixedScopes: 0,
+        mixedObservations: 0,
+        staleScopes: 0,
+        staleObservations: 0,
+      },
+    };
+  }
+  const raw = resp.data?.scopes;
+  const scopes: ObservationScope[] = [];
+  if (Array.isArray(raw)) {
+    for (const entry of raw) {
+      const tags = (entry as { tags?: unknown })?.tags;
+      const count = (entry as { count?: unknown })?.count;
+      if (!Array.isArray(tags) || typeof count !== "number") continue;
+      if (!tags.every((t) => typeof t === "string")) continue;
+      scopes.push({ tags: tags as string[], count });
+    }
+  }
+  return planScopeCleanup(bankId, scopes, options);
+}
+
+/** Render one bank's plan as a human-readable dry-run report. */
+export function formatCleanupPlan(plan: BankCleanupPlan, maxMerges = 10): string {
+  if (!plan.ok) {
+    return `bank ${plan.bankId}: UNREADABLE (${plan.reason ?? "unknown"})`;
+  }
+  const b = plan.breakdown;
+  const lines: string[] = [];
+  lines.push(`bank ${plan.bankId}`);
+  lines.push(
+    `  today: ${plan.totalScopes} scopes, ${plan.totalObservations.toLocaleString()} observations`,
+  );
+  lines.push(
+    `  legacy fragmentation:` +
+      ` all-volatile ${b.allVolatileScopes} scopes / ${b.allVolatileObservations.toLocaleString()} obs;` +
+      ` mixed ${b.mixedScopes} scopes / ${b.mixedObservations.toLocaleString()} obs;` +
+      ` stale agent-<hex> ${b.staleScopes} scopes / ${b.staleObservations.toLocaleString()} obs`,
+  );
+  lines.push(
+    `  WOULD change: ${plan.affectedScopes} scopes` +
+      ` (${plan.affectedObservations.toLocaleString()} obs re-homed),` +
+      ` ${plan.totalScopes} → ${plan.resultingScopeCount} scopes` +
+      ` (−${plan.scopeReduction})`,
+  );
+  if (plan.merges.length > 0) {
+    lines.push(`  top merges:`);
+    for (const m of plan.merges.slice(0, maxMerges)) {
+      lines.push(
+        `    ${m.sourceScopes} scopes → ${m.target}  (${m.observations.toLocaleString()} obs)`,
+      );
+    }
+    if (plan.merges.length > maxMerges) {
+      lines.push(`    +${plan.merges.length - maxMerges} more merge targets`);
+    }
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
## What & why

Follow-up to review of #4035. Curated scopes fixed *new* consolidation, but
banks that consolidated before it shipped carry hundreds of legacy per-session
scopes plus stale `agent-<hex>` scopes that will never merge further (klanker:
~779 distinct observation scopes). This adds an **audit / dry-run planner** that
reports what a re-consolidation would re-home per bank, without writing.

Second half of #4052.

## Why dry-run only (a real constraint, not caution)

Hindsight exposes **no per-memory tag-write** and **no per-scope delete** —
`DELETE …/observations` clears the *whole* bank (verified against the live
OpenAPI). So there is no REST primitive to re-home an observation from a legacy
scope to its curated target. A live heal is not mechanizable through the API
today; it needs an upstream write primitive. The tool therefore ships dry-run
only, and `--execute` refuses with that explanation. Reported as a contradiction
to the "build the cleanup" ask rather than force-fitting a bank-wiping DELETE.

## Changes

- **`src/memory/observation-scope-cleanup.ts`** (new) — pure
  `planScopeCleanup()` folds legacy volatile/stale scopes into their curated
  target and returns the reclass + merge plan; `planBankCleanup()` fetches a
  bank's live scope table **read-only** (`GET …/observations/scopes`);
  `formatCleanupPlan()` renders it. `CLEANUP_VOLATILE_PATTERNS` mirrors the
  plugin's `DEFAULT_VOLATILE_SCOPE_PATTERNS`; `CLEANUP_STALE_PATTERNS` covers
  `agent-<hex>`.
- **`src/cli/memory.ts`** — `switchroom memory cleanup-scopes [agent]`.
  Defaults to dry-run; `--all`, `--retire-stale`, `--json`, and an `--execute`
  that refuses (see above).

## Dry-run against klanker (read-only, live)

- Default (fold volatile only): 431 scopes change, ~49,436 observations
  re-homed, 779 → 357 scopes (−422).
- `--retire-stale` (also retire `agent-<hex>`): 729 scopes, ~61,916 obs,
  779 → 59 (−720).

## Blast radius / rollback

Zero, by construction — the tool performs only `GET` requests and prints. There
is nothing to roll back. Any future live execution stays operator-gated and
blocked on an upstream write primitive.

## Tests / lint

- `vitest run src/memory/observation-scope-cleanup.test.ts` — 14 tests green,
  planned against real klanker tag shapes.
- `npm run lint` — EXIT 0. `tsc --noEmit` — EXIT 0.

Not enrolled in the merge queue by request — independent adversarial review
runs before merge.
