### PR TITLE
feat(config): expose memory.observation_scope_strategy in switchroom.yaml (#4051)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -571,6 +571,33 @@ Be aware of the limit: past `apply`, a bad value on the **retain** path is visib
 
 **Cascade: override** (per-agent wins over profile/defaults). `start.sh` exports `HINDSIGHT_OBSERVATION_SCOPES` only when you set it. Serves the `remember-across-sessions` job.
 
+### Choosing the observation-scope strategy — `memory.observation_scope_strategy`
+
+The pin above forces one Hindsight scope on every retain. The **strategy** is the other lever: it decides how switchroom *computes* the scope when no pin is set. Since #4035 the strategy ships on-by-default as **`curated`**, and this is the first-class knob for it — before it existed, the only ways to change the strategy were a raw `HINDSIGHT_OBSERVATION_SCOPE_STRATEGY` env var in the agent's `env:` map or pinning `memory.observation_scopes`, neither discoverable from the schema.
+
+```yaml
+defaults:
+  memory:
+    observation_scope_strategy: combined   # opt the whole fleet out of curated
+
+agents:
+  clerk:
+    memory:
+      observation_scope_strategy: curated  # per-agent opt back in
+```
+
+Accepted values (`OBSERVATION_SCOPE_STRATEGIES` in the plugin's `lib/config.py`):
+
+| value | effect |
+|---|---|
+| `curated` | **default.** For each retain, strip the volatile per-session provenance tags (a bare session UUID, `parent_session:*`) from the *consolidation* scope while keeping them on the source fact — so observations dedup and merge across sessions instead of pocketing one-per-session. A non-empty stable tag set becomes an explicit `[[stable…]]` scope; an all-volatile retain goes to `shared`. |
+| `shared` | Send *every* retain to the one global untagged scope — the whole bank pools into a single belief set. |
+| `combined` / `off` | **Opt out.** Emit no per-row scope at all, restoring the pre-#4035 engine default (per-session islands). Byte-identical wire body to an unconfigured pre-feature client. |
+
+**Omitted by default.** Leave it unset and `start.sh` emits no `HINDSIGHT_OBSERVATION_SCOPE_STRATEGY` export, so the plugin's own `curated` default stands. A manual `memory.observation_scopes` pin **wins over the strategy** — set the pin only when you need to force a specific Hindsight scope regardless of tags; otherwise use the strategy. Off-list values are **rejected at `switchroom apply`**, the same cheap gate as the pin; a raw env / hand-edited `settings.json` value that slips past falls back to `curated` (shouted on stderr, never raised — a typo cannot lose a turn).
+
+**Cascade: override** (per-agent wins over profile/defaults). `start.sh` exports `HINDSIGHT_OBSERVATION_SCOPE_STRATEGY` only when you set it, and the resolver (`lib/config.compute_observation_scopes`) reads it. Serves the `remember-across-sessions` job.
+
 ### Server-side caps on the Hindsight container
 
 `switchroom memory --start` launches the bundled Hindsight container with `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=1000` already set. The same default is baked into the `--compose` snippet output.

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -1018,6 +1018,16 @@ export HINDSIGHT_DIRECTIVE_CAPTURE_NUDGE={{hindsightDirectiveCaptureNudge}}
 {{#if hindsightObservationScopesQ}}
 export HINDSIGHT_OBSERVATION_SCOPES={{{hindsightObservationScopesQ}}}
 {{/if}}
+# Per-retain observation-scope STRATEGY (memory.observation_scope_strategy
+# cascade). Selects curated-vs-not: "curated" (plugin default) strips volatile
+# per-session provenance tags so observations dedup across sessions; "shared"
+# forces the one global untagged scope; "combined"/"off" opt out (no per-row
+# scope on the wire, pre-feature engine default). Export ONLY when the operator
+# set it: unset leaves the plugin's on-by-default `curated` in force. A pinned
+# per-row scope (memory.observation_scopes) still wins over this in the resolver.
+{{#if hindsightObservationScopeStrategyQ}}
+export HINDSIGHT_OBSERVATION_SCOPE_STRATEGY={{{hindsightObservationScopeStrategyQ}}}
+{{/if}}
 # PR6 — supergroup-mode topic tagging. JSON map of {alias: thread_id}
 # parsed by retain.py + recall.py to (a) stamp chat_id/thread_id/topic_alias
 # into retained memory metadata and (b) emit a "Current topic: …" preamble

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3801,6 +3801,9 @@ interface BuildWorkspaceContextArgs {
   // Per-row observation scope. undefined unless the operator set
   // memory.observation_scopes; exported only when set.
   hindsightObservationScopes?: string;
+  // Per-retain observation-scope strategy selector. undefined unless the
+  // operator set memory.observation_scope_strategy; exported only when set.
+  hindsightObservationScopeStrategy?: string;
   // PR6 — supergroup-mode topic tagging. JSON map of {alias: thread_id}
   // injected as HINDSIGHT_TOPIC_ALIASES_JSON so retain.py can resolve
   // numeric thread_ids to human alias names in memory metadata.
@@ -3851,6 +3854,7 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     hindsightRecallSkipTrivial,
     hindsightDirectiveCaptureNudge,
     hindsightObservationScopes,
+    hindsightObservationScopeStrategy,
     hindsightTopicAliasesJson,
     hindsightSenderBanksJson,
     hindsightTopicFilterMode,
@@ -3957,6 +3961,9 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     hindsightDirectiveCaptureNudge,
     hindsightObservationScopesQ: hindsightObservationScopes
       ? shellSingleQuote(hindsightObservationScopes)
+      : undefined,
+    hindsightObservationScopeStrategyQ: hindsightObservationScopeStrategy
+      ? shellSingleQuote(hindsightObservationScopeStrategy)
       : undefined,
     // PR6 — only emit the env-export blocks when we actually have a
     // value, so `{{#if hindsightTopicAliasesJsonQ}}` and friends are
@@ -4947,6 +4954,12 @@ export function scaffoldAgent(
   // stands. Top-level memory.* knob: it stamps every retain path, not just the
   // Stop-hook cadence under memory.retain.
   const hindsightObservationScopes = agentConfig.memory?.observation_scopes;
+  // Per-retain observation-scope strategy (memory.observation_scope_strategy
+  // cascade). undefined unless the operator set it — exported only when set
+  // (see start.sh.hbs), so an unset value leaves the plugin's on-by-default
+  // `curated` strategy in force. Selects curated-vs-not; the pin above wins.
+  const hindsightObservationScopeStrategy =
+    agentConfig.memory?.observation_scope_strategy;
 
   // PR6 — supergroup-mode topic tagging. Build the {alias: thread_id}
   // JSON for retain.py + recall.py to resolve numeric thread_ids to
@@ -5014,6 +5027,7 @@ export function scaffoldAgent(
     hindsightRecallSkipTrivial,
     hindsightDirectiveCaptureNudge,
     hindsightObservationScopes,
+    hindsightObservationScopeStrategy,
     hindsightTopicAliasesJson,
     hindsightSenderBanksJson,
     hindsightTopicFilterMode,
@@ -7461,6 +7475,12 @@ function reconcileAgentInner(
   // stands. Top-level memory.* knob: it stamps every retain path, not just the
   // Stop-hook cadence under memory.retain.
   const hindsightObservationScopes = agentConfig.memory?.observation_scopes;
+  // Per-retain observation-scope strategy (memory.observation_scope_strategy
+  // cascade). undefined unless the operator set it — exported only when set
+  // (see start.sh.hbs), so an unset value leaves the plugin's on-by-default
+  // `curated` strategy in force. Selects curated-vs-not; the pin above wins.
+  const hindsightObservationScopeStrategy =
+    agentConfig.memory?.observation_scope_strategy;
   // PR6 — mirror scaffoldAgent's computation. Both paths feed
   // buildWorkspaceContext, so the template sees identical shape.
   const topicAliases = agentConfig.channels?.telegram?.topic_aliases;
@@ -7562,6 +7582,9 @@ function reconcileAgentInner(
       hindsightDirectiveCaptureNudge,
       hindsightObservationScopesQ: hindsightObservationScopes
         ? shellSingleQuote(hindsightObservationScopes)
+        : undefined,
+      hindsightObservationScopeStrategyQ: hindsightObservationScopeStrategy
+        ? shellSingleQuote(hindsightObservationScopeStrategy)
         : undefined,
       // PR6 — supergroup-mode topic tagging env vars. Same gate as
       // buildWorkspaceContext: only emit the shell-quoted JSON when
@@ -8355,6 +8378,7 @@ function reconcileAgentInner(
       hindsightRecallSkipTrivial,
       hindsightDirectiveCaptureNudge,
       hindsightObservationScopes,
+      hindsightObservationScopeStrategy,
       hindsightTopicAliasesJson,
       hindsightSenderBanksJson,
       hindsightTopicFilterMode,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { OBSERVATION_SCOPES } from "../memory/observation-scopes.js";
+import {
+  OBSERVATION_SCOPES,
+  OBSERVATION_SCOPE_STRATEGIES,
+} from "../memory/observation-scopes.js";
 
 /**
  * A single entry in an agent's code_repos list.
@@ -367,6 +370,43 @@ const ObservationScopesSchema = z
     "Cascade: override (per-agent wins over default)."
   );
 
+/**
+ * `memory.observation_scope_strategy` — the per-retain SELECTOR that decides
+ * how switchroom computes each row's `observation_scopes` when no pin is set.
+ * This is the first-class surface for the plugin's `observationScopeStrategy`
+ * knob (shipped on-by-default in #4035): `curated` (default) strips volatile
+ * per-session provenance tags so cross-session dedup happens; `shared` forces
+ * the one global untagged scope; `combined` / `off` opt out entirely,
+ * restoring the pre-feature engine default. A manual `observation_scopes` pin
+ * still wins over the strategy outright.
+ *
+ * Declared once and reused by BOTH `AgentMemorySchema` and the
+ * defaults/profile-tier mirror, so the two tiers cannot drift. Same enum
+ * rationale as the pin: a typo is invisible after the write, so rejecting it
+ * at `switchroom apply` is the cheap catch; the plugin re-validates
+ * (`lib/config.compute_observation_scopes`) for a raw env / settings.json
+ * value this schema cannot reach.
+ */
+const ObservationScopeStrategySchema = z
+  .enum(OBSERVATION_SCOPE_STRATEGIES)
+  .optional()
+  .describe(
+    "Per-retain strategy that decides how the observation scope is " +
+    "computed when no `observation_scopes` pin is set. \"curated\" " +
+    "(the default since #4035) strips volatile per-session provenance " +
+    "tags from each retain's consolidation scope — keeping the stable " +
+    "semantic ones on the source fact — so an agent's observations dedup " +
+    "and merge across sessions instead of pocketing one-per-session. " +
+    "\"shared\" sends every retain to the one global untagged scope. " +
+    "\"combined\" / \"off\" opt OUT: no per-row scope goes on the wire, " +
+    "restoring the pre-feature engine default (byte-identical to an " +
+    "unconfigured client). OMITTED BY DEFAULT: unset leaves the plugin's " +
+    "own default (`curated`) in force. A manual `observation_scopes` pin " +
+    "wins over this strategy. Accepted values: " +
+    `${OBSERVATION_SCOPE_STRATEGIES.join(", ")}. ` +
+    "Cascade: override (per-agent wins over default)."
+  );
+
 export const AgentMemorySchema = z
   .object({
     collection: z.string().describe("Hindsight collection name for this agent"),
@@ -542,6 +582,7 @@ export const AgentMemorySchema = z
         "Cascade: override (per-agent wins over default)."
       ),
     observation_scopes: ObservationScopesSchema,
+    observation_scope_strategy: ObservationScopeStrategySchema,
     recall: z
       .object({
         max_memories: z
@@ -3282,6 +3323,11 @@ const profileFields = {
       // defaults/profile tier too, so `defaults.memory.observation_scopes:
       // shared` pools a whole fleet's observations with per-agent opt-out.
       observation_scopes: ObservationScopesSchema,
+      // Mirror of AgentMemorySchema.observation_scope_strategy — accepted at
+      // the defaults/profile tier too, so `defaults.memory.
+      // observation_scope_strategy: combined` opts a whole fleet out of the
+      // curated default with per-agent opt-in.
+      observation_scope_strategy: ObservationScopeStrategySchema,
       recall: z
         .object({
           max_memories: z.number().int().min(0).optional(),

--- a/src/memory/observation-scopes.ts
+++ b/src/memory/observation-scopes.ts
@@ -32,6 +32,40 @@ export type ObservationScope = (typeof OBSERVATION_SCOPES)[number];
 /** Env var start.sh exports the scope through, when the operator set one. */
 export const OBSERVATION_SCOPES_ENV = "HINDSIGHT_OBSERVATION_SCOPES";
 
+/**
+ * The `observationScopeStrategy` values the plugin's per-retain resolver
+ * accepts — the selector that decides curated-vs-not, distinct from the pin
+ * above. `curated` (the shipped default since #4035) strips volatile
+ * provenance tags from each retain's consolidation scope; `shared` forces the
+ * one global untagged scope; `combined` / `off` opt out entirely (emit no
+ * per-row scope, restoring the pre-feature engine default). A manual
+ * `observation_scopes` pin still wins over the strategy.
+ *
+ * Paired copy of `OBSERVATION_SCOPE_STRATEGIES` in
+ * `vendor/hindsight-memory/scripts/lib/config.py` — that resolver runs in the
+ * agent container with no access to this module, so widening the set means
+ * widening BOTH. Same enum rationale as the pin: a typo is invisible after the
+ * write, so `switchroom apply` rejecting it is the cheap catch.
+ */
+export const OBSERVATION_SCOPE_STRATEGIES = [
+  "curated",
+  "shared",
+  "combined",
+  "off",
+] as const;
+
+export type ObservationScopeStrategy =
+  (typeof OBSERVATION_SCOPE_STRATEGIES)[number];
+
+/** Env var start.sh exports the strategy through, when the operator set one. */
+export const OBSERVATION_SCOPE_STRATEGY_ENV =
+  "HINDSIGHT_OBSERVATION_SCOPE_STRATEGY";
+
+/** Human-readable accepted set, for error messages. */
+export function observationScopeStrategiesHint(): string {
+  return OBSERVATION_SCOPE_STRATEGIES.join(", ");
+}
+
 export function isObservationScope(value: unknown): value is ObservationScope {
   return typeof value === "string" && (OBSERVATION_SCOPES as readonly string[]).includes(value);
 }

--- a/tests/scaffold.observation-scope-strategy.test.ts
+++ b/tests/scaffold.observation-scope-strategy.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent, reconcileAgent } from "../src/agents/scaffold.js";
+import { AgentMemorySchema, SwitchroomConfigSchema } from "../src/config/schema.js";
+import type { SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+import { OBSERVATION_SCOPE_STRATEGIES } from "../src/memory/observation-scopes.js";
+
+/**
+ * `memory.observation_scope_strategy` — the first-class switchroom.yaml surface
+ * for the plugin's `observationScopeStrategy` selector (shipped on-by-default
+ * in #4035, previously reachable only via a raw env var or by pinning
+ * `memory.observation_scopes`).
+ *
+ * The end-to-end chain is: yaml `memory.observation_scope_strategy: combined`
+ * → schema validation (rejects a typo at `apply`) → cascade → scaffold.ts →
+ * `start.sh` exports `HINDSIGHT_OBSERVATION_SCOPE_STRATEGY=combined`. The
+ * resolver half — that env value reaching `observationScopeStrategy` and
+ * producing the opt-out (no per-row scope on the wire) — is proven by
+ * `vendor/hindsight-memory/scripts/tests/test_observation_scopes.py`
+ * (`test_strategy_env_override_opts_out`, `test_payload_omits_scope_when_opted_out`).
+ * These tests pin the switchroom half and the init-vs-reconcile parity a second
+ * hand-built template context makes easy to drift.
+ */
+describe("memory.observation_scope_strategy plumbing", () => {
+  let tmpDir: string;
+  let telegram: TelegramConfig;
+
+  beforeEach(() => {
+    tmpDir = join(
+      tmpdir(),
+      `obs-strategy-${Date.now()}-${Math.floor(Math.random() * 1e6)}`,
+    );
+    mkdirSync(tmpDir, { recursive: true });
+    telegram = { bot_token: "t", forum_chat_id: "c" };
+  });
+  afterEach(() => {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function configFor(memory: Record<string, unknown> | undefined): SwitchroomConfig {
+    return {
+      agents: memory ? ({ probe: { memory } } as never) : {},
+      memory: { backend: "hindsight", config: { url: "http://localhost:18888/mcp/" } },
+      telegram,
+    } as SwitchroomConfig;
+  }
+
+  function startShFor(memory: Record<string, unknown> | undefined): string {
+    const config = configFor(memory);
+    const res = scaffoldAgent("probe", config.agents.probe ?? {}, tmpDir, telegram, config);
+    return readFileSync(join(res.agentDir, "start.sh"), "utf-8");
+  }
+
+  describe("schema", () => {
+    it("accepts every strategy the resolver accepts", () => {
+      for (const strategy of OBSERVATION_SCOPE_STRATEGIES) {
+        const ok = AgentMemorySchema.safeParse({
+          collection: "probe",
+          observation_scope_strategy: strategy,
+        });
+        expect(ok.success, strategy).toBe(true);
+        if (ok.success) expect(ok.data?.observation_scope_strategy).toBe(strategy);
+      }
+    });
+
+    it("rejects an empty string (an empty strategy is a typo, not an opt-out)", () => {
+      expect(
+        AgentMemorySchema.safeParse({
+          collection: "probe",
+          observation_scope_strategy: "",
+        }).success,
+      ).toBe(false);
+    });
+
+    it("REJECTS an off-list value instead of passing it through", () => {
+      // A free string would apply clean, reach the env, and the resolver would
+      // silently fall back to `curated` — the operator's opt-out never landing,
+      // discovered only by inspecting the bank. `apply` is the cheap gate.
+      for (const bad of ["curate", "Combined", "opt-out", "sharedd", "none"]) {
+        const res = AgentMemorySchema.safeParse({
+          collection: "probe",
+          observation_scope_strategy: bad,
+        });
+        expect(res.success, bad).toBe(false);
+      }
+    });
+
+    it("REJECTS an off-list value at the defaults tier too", () => {
+      expect(() =>
+        SwitchroomConfigSchema.parse({
+          switchroom: { version: 1, home: "/tmp/does-not-matter" },
+          telegram: { bot_token: "t", forum_chat_id: "c" },
+          defaults: { memory: { observation_scope_strategy: "curate" } },
+          agents: {},
+        }),
+      ).toThrow();
+    });
+
+    it("survives the defaults tier instead of being stripped by the parse", () => {
+      // The defaults/profile tier is a SEPARATE zod object; a key missing there
+      // is silently dropped, so a fleet-wide opt-out would vanish before the
+      // cascade ever saw it.
+      const parsed = SwitchroomConfigSchema.parse({
+        switchroom: { version: 1, home: "/tmp/does-not-matter" },
+        telegram: { bot_token: "t", forum_chat_id: "c" },
+        defaults: { memory: { observation_scope_strategy: "combined" } },
+        agents: {},
+      });
+      expect(parsed.defaults?.memory?.observation_scope_strategy).toBe("combined");
+    });
+  });
+
+  describe("start.sh", () => {
+    it("unset emits NO export — the plugin's on-by-default curated stands", () => {
+      expect(startShFor(undefined)).not.toMatch(
+        /HINDSIGHT_OBSERVATION_SCOPE_STRATEGY/,
+      );
+    });
+
+    it("an unrelated memory block still emits NO export", () => {
+      expect(startShFor({ collection: "probe" })).not.toMatch(
+        /HINDSIGHT_OBSERVATION_SCOPE_STRATEGY/,
+      );
+    });
+
+    it("the opt-out value reaches the resolver env verbatim", () => {
+      // The whole point of the feature: `combined` in yaml must land as the env
+      // the plugin's ENV_MAPPINGS reads (config.py). The resolver then omits the
+      // per-row scope (vendor test_payload_omits_scope_when_opted_out).
+      expect(startShFor({ observation_scope_strategy: "combined" })).toMatch(
+        /export HINDSIGHT_OBSERVATION_SCOPE_STRATEGY='combined'/,
+      );
+    });
+
+    it("shell-quotes the value so it cannot inject shell", () => {
+      const startSh = startShFor({ observation_scope_strategy: "a'b; rm -rf /" });
+      expect(startSh).toContain(
+        `export HINDSIGHT_OBSERVATION_SCOPE_STRATEGY='a'"'"'b; rm -rf /'`,
+      );
+      expect(startSh).not.toMatch(/^\s*rm -rf \//m);
+    });
+
+    it("reconcileAgent emits the same export as scaffoldAgent (no init/reconcile drift)", () => {
+      const memory = { observation_scope_strategy: "combined" };
+      const config = configFor(memory);
+      const agentConfig = config.agents.probe ?? {};
+      const res = scaffoldAgent("probe", agentConfig, tmpDir, telegram, config);
+      const scaffolded = readFileSync(join(res.agentDir, "start.sh"), "utf-8");
+      reconcileAgent("probe", agentConfig, tmpDir, telegram, config);
+      const reconciled = readFileSync(join(res.agentDir, "start.sh"), "utf-8");
+      expect(reconciled).toMatch(
+        /export HINDSIGHT_OBSERVATION_SCOPE_STRATEGY='combined'/,
+      );
+      expect(reconciled).toBe(scaffolded);
+    });
+
+    it("reconcileAgent also omits the export when unset", () => {
+      const config = configFor(undefined);
+      const res = scaffoldAgent("probe", {}, tmpDir, telegram, config);
+      reconcileAgent("probe", {}, tmpDir, telegram, config);
+      const reconciled = readFileSync(join(res.agentDir, "start.sh"), "utf-8");
+      expect(reconciled).not.toMatch(/HINDSIGHT_OBSERVATION_SCOPE_STRATEGY/);
+    });
+
+    it("the pin and the strategy export independently (both wire up)", () => {
+      // A pin still wins in the resolver, but the schema/scaffold surface both:
+      // setting both must emit both exports, not swallow one.
+      const startSh = startShFor({
+        observation_scopes: "shared",
+        observation_scope_strategy: "combined",
+      });
+      expect(startSh).toMatch(/export HINDSIGHT_OBSERVATION_SCOPES='shared'/);
+      expect(startSh).toMatch(
+        /export HINDSIGHT_OBSERVATION_SCOPE_STRATEGY='combined'/,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #4051. The curated observation-scope strategy shipped on-by-default in #4035 (v0.19.39) but had **no `switchroom.yaml` schema surface** — the only opt-out was a raw `HINDSIGHT_OBSERVATION_SCOPE_STRATEGY` env var or pinning `memory.observation_scopes: combined`, neither discoverable from the schema nor caught by `switchroom apply` validation.

This adds a first-class, validated, documented `memory.observation_scope_strategy` field (enum `curated | shared | combined | off`) and wires it end-to-end through the same path the `observation_scopes` pin already uses.

## Why

Advances the `remember-across-sessions` job: an operator can now opt a bank in/out of the curated strategy from `switchroom.yaml` with apply-time validation, instead of an undiscoverable raw env var.

## What changed

- `src/memory/observation-scopes.ts` — `OBSERVATION_SCOPE_STRATEGIES` (paired copy of the plugin resolver's tuple), `OBSERVATION_SCOPE_STRATEGY_ENV`, hint helper.
- `src/config/schema.ts` — `ObservationScopeStrategySchema` (zod enum, `.describe`) added at both the per-agent (`AgentMemorySchema`) and defaults/profile tiers, so a typo is rejected at `apply` and the two tiers cannot drift.
- `src/agents/scaffold.ts` — mirror the pin's plumbing: read `agentConfig.memory.observation_scope_strategy`, thread `hindsightObservationScopeStrategyQ` through both the init and reconcile template contexts.
- `profiles/_base/start.sh.hbs` — `export HINDSIGHT_OBSERVATION_SCOPE_STRATEGY` only when set (unset leaves the plugin's on-by-default `curated`).
- `docs/configuration.md` — new "Choosing the observation-scope strategy" subsection with the value table and pin-vs-strategy precedence.
- `tests/scaffold.observation-scope-strategy.test.ts` — new.

## End-to-end wiring trace

`yaml memory.observation_scope_strategy` → `ObservationScopeStrategySchema` (schema.ts, both tiers) → cascade → `scaffold.ts` reads `agentConfig.memory.observation_scope_strategy` → `start.sh` `export HINDSIGHT_OBSERVATION_SCOPE_STRATEGY=<value>` → `vendor/hindsight-memory/scripts/lib/config.py` ENV_MAPPINGS `"HINDSIGHT_OBSERVATION_SCOPE_STRATEGY": ("observationScopeStrategy", str)` → `compute_observation_scopes` reads `config.get("observationScopeStrategy")` (`combined`/`off` → `None`, opt-out).

## Test plan

- `tsc --noEmit` clean; `npm run lint` fully green (all guard scripts).
- New + existing scope tests green (`tests/scaffold.observation-scope-strategy.test.ts`, `tests/scaffold.observation-scopes.test.ts`): every accepted strategy validates, off-list rejected at both tiers, opt-out value reaches the exact resolver env export, init/reconcile parity, pin+strategy export independently.
- Resolver half (env value → opt-out payload) already covered by `vendor/.../tests/test_observation_scopes.py` (`test_strategy_env_override_opts_out`, `test_payload_omits_scope_when_opted_out`).

## Coordination with #4053

#4053 (`docs/hindsight-curated-scope-defaults`) also edits `src/config/schema.ts` and `docs/configuration.md`. A test-merge of #4053's branch into this one **auto-merged with zero git conflicts** — edits are in non-overlapping regions. This branch also rebases cleanly on current `origin/main`.

One **prose** (not git) follow-up: #4053's docs rewrite states "there is no dedicated `memory.observation_scope_strategy` knob in switchroom.yaml yet." Once both land, that sentence is stale — whoever merges second should reword it to point at the new field. Low severity, doc-consistency only.

Risk: low. Additive optional field; unset behaviour is byte-identical to today.

Job spec: `reference/jobs/remember-across-sessions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)