### PR TITLE
fix(gateway): defer 300s silence-fallback during mid-turn auto-compaction

### DIFF
--- a/telegram-plugin/gateway/compaction-marker.ts
+++ b/telegram-plugin/gateway/compaction-marker.ts
@@ -1,0 +1,84 @@
+/**
+ * Compaction-in-flight marker (#4058 — spurious 300s silence-fallback fire
+ * during mid-turn auto-compaction).
+ *
+ * The blind spot this closes: when Claude Code hits mid-turn auto-compaction
+ * (the session ran out of context and spends minutes summarizing), the model
+ * emits ZERO output and runs ZERO tools — the gateway sees pure silence, so
+ * the silence-poke 300s framework fallback fired on a perfectly healthy turn:
+ * a spurious "⚠️ no output for 5 min — the framework ended that stalled turn"
+ * card plus an obligation re-present, right before the turn completed
+ * normally. Observed live: ~1m50s of tools then ~3m25s compacting = 304s of
+ * "silence" → false fire.
+ *
+ * The signal problem: the transcript JSONL carries a compaction record ONLY
+ * at the END (`{"type":"system","subtype":"compact_boundary",...}` — it
+ * embeds the compaction's own durationMs, so it cannot exist before the
+ * compaction finishes). Nothing observable lands at the START from the
+ * stream. The START therefore comes from Claude Code's PreCompact hook
+ * (`hooks/compaction-marker-precompact.mjs`), which writes
+ * `<STATE_DIR>/compaction-in-flight.json` the moment compaction begins —
+ * the same sidecar-file pattern as `turn-active-marker.ts` and the
+ * tool-label sidecar (#783).
+ *
+ * Consumers:
+ *   - `liveness-wiring.ts` wires `isCompactionInFlight` into the silence-poke
+ *     deps: marker present AND younger than the fallback hard ceiling ⇒ the
+ *     300s fallback is DEFERRED via the exact same `underCeiling` mechanism
+ *     as the #1292/#3519 in-flight-tool defers — a genuinely-wedged
+ *     compaction still unwedges once silence crosses `fallbackHardCeiling`.
+ *   - `silence-poke-session-event.ts` removes the marker on the
+ *     `compact_boundary` session event (the deterministic END) and counts
+ *     the boundary as production, so the resumed turn gets a fresh 300s
+ *     window instead of firing on the very next tick.
+ *
+ * Staleness is double-bounded: the reader treats an old marker as absent
+ * (age bound supplied by the caller — the hard ceiling), so a marker leaked
+ * by a crash between compaction start and boundary can never defer a future
+ * genuine wedge for more than one ceiling window.
+ *
+ * Pure file I/O; clock injectable for tests; never throws.
+ */
+
+import { statSync, unlinkSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export const COMPACTION_MARKER_FILE = 'compaction-in-flight.json'
+
+/**
+ * The gateway's state dir — same resolution as gateway.ts (`STATE_DIR`).
+ * Exported so `silence-poke-session-event.ts` (which is handed no stateDir)
+ * can clear the marker without widening its call signature.
+ */
+export function resolveTelegramStateDir(): string {
+  return process.env.TELEGRAM_STATE_DIR ?? join(homedir(), '.claude', 'channels', 'telegram')
+}
+
+/**
+ * Age (ms) of the compaction marker's mtime, or null when absent/unstattable.
+ * The PreCompact hook (re)writes the file at compaction start, so a small age
+ * means a compaction began recently and may still be running. Never throws.
+ */
+export function readCompactionMarkerAgeMs(stateDir: string, now?: number): number | null {
+  try {
+    const st = statSync(join(stateDir, COMPACTION_MARKER_FILE))
+    return (now ?? Date.now()) - st.mtimeMs
+  } catch {
+    return null // ENOENT / unstattable → no compaction in flight
+  }
+}
+
+/**
+ * Remove the marker — called on the `compact_boundary` session event (the
+ * compaction's deterministic END record in the transcript). Idempotent;
+ * ENOENT and any other unlink failure are swallowed (the age bound in the
+ * reader is the correctness backstop, removal is the fast path).
+ */
+export function removeCompactionMarker(stateDir: string): void {
+  try {
+    unlinkSync(join(stateDir, COMPACTION_MARKER_FILE))
+  } catch {
+    // best-effort — staleness bound in readCompactionMarkerAgeMs self-heals
+  }
+}

--- a/telegram-plugin/gateway/liveness-wiring.ts
+++ b/telegram-plugin/gateway/liveness-wiring.ts
@@ -25,6 +25,7 @@ import { logStreamingEvent } from '../streaming-metrics.js'
 import { clearSilentEndState } from '../silent-end.js'
 import { purgeStaleTurnsForChat } from './turn-state-purge.js'
 import { removeTurnActiveMarker, readTurnActiveMarkerAgeMs } from './turn-active-marker.js'
+import { readCompactionMarkerAgeMs } from './compaction-marker.js'
 import { decideHangRestart } from './hang-restart-decision.js'
 import { recordTurnEnd } from '../registry/turns-schema.js'
 import { hostdGetStatusOnce } from './hostd-dispatch.js'
@@ -70,6 +71,20 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
   thresholdsMs: { fallback: SILENCE_FALLBACK_MS, fallbackHardCeiling: SILENCE_FALLBACK_HARD_MS, floor: SILENCE_FLOOR_MS },
   deferFallbackWhileToolInFlight: SILENCE_DEFER_INFLIGHT_TOOLS,
   isLegitimatelyWorking: (key) => isLegitimatelyWorking(key),
+  // #4058 — mid-turn auto-compaction defer. The PreCompact hook writes the
+  // compaction marker at compaction START (the transcript only records the
+  // END, via `compact_boundary`); while the marker is present AND younger
+  // than the fallback hard ceiling, silence-poke defers the 300s fallback the
+  // same way it does for an in-flight tool. The age bound makes a marker
+  // leaked by a crash (boundary never observed) self-heal: it can never hold
+  // a future genuine wedge past one ceiling window. The marker is process-
+  // wide, not keyed — the gateway runs ONE Claude session, so a compaction
+  // belongs to whichever turn is live (same accepted trade-off as
+  // `toolFlightTracker` in gateway.ts `isLegitimatelyWorking`).
+  isCompactionInFlight: () => {
+    const ageMs = readCompactionMarkerAgeMs(STATE_DIR)
+    return ageMs != null && ageMs >= 0 && ageMs < SILENCE_FALLBACK_HARD_MS
+  },
   // #3552 — orphan-state reaper predicate. Deliberately the SAME condition the
   // `onFrameworkFallback` late-fire guard below uses: no `activeTurnStartedAt`
   // entry AND no current turn ⇒ the turn this state belongs to is over. Note

--- a/telegram-plugin/gateway/silence-poke-session-event.ts
+++ b/telegram-plugin/gateway/silence-poke-session-event.ts
@@ -12,6 +12,7 @@ import type { SessionEvent } from '../session-tail.js'
 import { isTelegramSurfaceTool } from '../tool-names.js'
 import { toolLabel } from '../tool-labels.js'
 import { applyBackgroundShellLiveness } from './background-shell-liveness.js'
+import { removeCompactionMarker, resolveTelegramStateDir } from './compaction-marker.js'
 
 /** The silence-poke module namespace (kept as `typeof` so no surface drift). */
 type SilencePoke = typeof import('../silence-poke.js')
@@ -83,6 +84,18 @@ export function applySilencePokeSessionEvent(
     if (ev.toolUseId != null && ev.toolUseId.length > 0) {
       silencePoke.noteToolEnd(key, ev.toolUseId, Date.now())
     }
+  } else if (ev.kind === 'compact_boundary') {
+    // #4058 — mid-turn compaction ENDED (the transcript's compact_boundary
+    // record only exists once compaction is done). Two effects:
+    //   1. Clear the PreCompact marker so the compaction defer stops holding
+    //      the 300s fallback (a post-compaction wedge fires on schedule).
+    //   2. Count the boundary as PRODUCTION: the silence clock ran the whole
+    //      compaction, so without a reset the fallback would fire on the very
+    //      next tick — before the resumed model's first output can land. The
+    //      transcript resuming IS observable progress; a turn that stays
+    //      silent AFTER compaction still fires one full window later.
+    removeCompactionMarker(resolveTelegramStateDir())
+    silencePoke.noteProduction(key, Date.now())
   }
   // #3519 sharpen: feed background-shell liveness (ALIVE/DEAD) to silence-poke — see background-shell-liveness.ts.
   applyBackgroundShellLiveness(silencePoke, key, ev)

--- a/telegram-plugin/hooks/compaction-marker-precompact.mjs
+++ b/telegram-plugin/hooks/compaction-marker-precompact.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * PreCompact hook — marks "compaction in flight" for the gateway (#4058).
+ *
+ * Claude Code PreCompact protocol:
+ *   Input:  JSON on stdin — { session_id, transcript_path, cwd,
+ *           hook_event_name: "PreCompact", trigger: "auto"|"manual",
+ *           custom_instructions }
+ *   Output: exit 0 + empty stdout → proceed. We NEVER block compaction and
+ *           NEVER exit non-zero.
+ *
+ * Side effect: writes (overwrites) ONE small JSON file
+ *   $TELEGRAM_STATE_DIR/compaction-in-flight.json
+ * with shape { ts, session_id, trigger }.
+ *
+ * Why: during mid-turn auto-compaction the model emits zero output and runs
+ * zero tools for minutes, so the gateway's silence-poke saw pure silence and
+ * fired its 300s "stalled turn" fallback on a healthy turn. The transcript
+ * only records compaction at its END (`system/compact_boundary` carries the
+ * compaction's own durationMs), so this hook is the one observable START
+ * signal. The gateway reads the marker's mtime (compaction-marker.ts) to
+ * DEFER the fallback — bounded by the same hard ceiling as the in-flight-tool
+ * defer — and removes it when the compact_boundary lands.
+ *
+ * If $TELEGRAM_STATE_DIR is unset → silent skip (dev / one-shot contexts;
+ * the fallback just keeps its pre-#4058 behaviour).
+ */
+
+import { readFileSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+function readStdin() {
+  try {
+    return readFileSync(0, 'utf8')
+  } catch {
+    return ''
+  }
+}
+
+function main() {
+  const stateDir = process.env.TELEGRAM_STATE_DIR
+  if (!stateDir) return
+
+  let payload = {}
+  try {
+    payload = JSON.parse(readStdin() || '{}')
+  } catch {
+    // Unparseable stdin — still write the marker: the mtime alone carries
+    // the load-bearing signal; the body fields are diagnostics.
+  }
+
+  try {
+    mkdirSync(stateDir, { recursive: true })
+    writeFileSync(
+      join(stateDir, 'compaction-in-flight.json'),
+      JSON.stringify({
+        ts: Date.now(),
+        session_id: typeof payload.session_id === 'string' ? payload.session_id : null,
+        trigger: typeof payload.trigger === 'string' ? payload.trigger : null,
+      }) + '\n',
+      { mode: 0o600 },
+    )
+  } catch {
+    // Best-effort: a missed marker just reverts one fallback decision to
+    // the pre-#4058 behaviour. Never fail the hook (never block compaction).
+  }
+}
+
+main()
+process.exit(0)

--- a/telegram-plugin/hooks/hooks.json
+++ b/telegram-plugin/hooks/hooks.json
@@ -71,6 +71,17 @@
         ]
       }
     ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" node \"${CLAUDE_PLUGIN_ROOT}/hooks/compaction-marker-precompact.mjs\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -158,6 +158,12 @@ export type SessionEvent =
    * ~300s wedge recovery once the launching bash is no longer running.
    */
   | { kind: 'task_notification'; taskId: string; status: string }
+  // #4058 — system compact_boundary: the CLI finished compacting the session
+  // mid-turn (the record is written at compaction END — it embeds the
+  // compaction's own durationMs). Consumed by silence-poke wiring to clear
+  // the PreCompact "compaction in flight" marker and count the boundary as
+  // production so the resumed turn gets a fresh silence window.
+  | { kind: 'compact_boundary'; trigger: string | null; compactDurationMs: number | null }
   // `reason` is set ONLY by an internal gateway-synthesized turn_end (never by
   // the JSONL projection). `answer-ready-quiescence` (PR A) marks the positive
   // deterministic quiescence-flush signal, which — unlike the orphaned-reply
@@ -700,6 +706,20 @@ export function projectTranscriptLine(line: string): SessionEvent[] {
     return [
       { kind: 'turn_end', durationMs: (obj.durationMs as number | undefined) ?? 0 },
     ]
+  }
+
+  // #4058 — system compact_boundary: written when a mid-turn (auto or manual)
+  // compaction FINISHES. Real shape observed in live transcripts:
+  //   { type:"system", subtype:"compact_boundary", content:"Conversation
+  //     compacted", compactMetadata:{ trigger:"auto", preTokens, postTokens,
+  //     durationMs, ... } }
+  if (type === 'system' && obj.subtype === 'compact_boundary') {
+    const meta = obj.compactMetadata as { trigger?: unknown; durationMs?: unknown } | undefined
+    return [{
+      kind: 'compact_boundary',
+      trigger: typeof meta?.trigger === 'string' ? meta.trigger : null,
+      compactDurationMs: typeof meta?.durationMs === 'number' ? meta.durationMs : null,
+    }]
   }
 
   return []

--- a/telegram-plugin/silence-poke.ts
+++ b/telegram-plugin/silence-poke.ts
@@ -265,6 +265,25 @@ export interface SilencePokeDeps {
    * exactly as before.
    */
   isTurnLive?: (key: string) => boolean
+  /**
+   * #4058 — mid-turn auto-compaction defer predicate. Returns true while the
+   * Claude CLI is compacting the session for `key`'s turn (the PreCompact hook
+   * wrote the compaction marker and the `compact_boundary` transcript record
+   * hasn't landed / the marker isn't stale — see gateway/compaction-marker.ts).
+   *
+   * Why: during compaction the model emits ZERO output and runs ZERO tools
+   * for minutes, so every other work signal (`isLegitimatelyWorking`,
+   * in-flight tools, alive shells) is false and the 300s fallback fired on a
+   * healthy turn — a spurious "framework ended that stalled turn" card + a
+   * harmless re-ask, recurring on any session near the context ceiling.
+   *
+   * Semantics mirror the #1292/#3519 defers exactly: the silence CLOCK is
+   * never reset here; the terminal unwedge is DEFERRED (`continue` without
+   * setting fallbackFired) and remains bounded by `fallbackHardCeiling`, so
+   * a genuinely-wedged compaction still unwedges at the ceiling. Optional:
+   * absent (legacy fixtures) ⇒ behaviour unchanged.
+   */
+  isCompactionInFlight?: (key: string) => boolean
 }
 
 const state = new Map<string, SilencePokeState>()
@@ -773,6 +792,15 @@ function tick(now: number): void {
       const ceiling = thresholds.fallbackHardCeiling ?? Number.POSITIVE_INFINITY
       const underCeiling = silence < ceiling
       if (underCeiling) {
+        // #4058 — mid-turn auto-compaction: the CLI is summarizing the
+        // session, so the model provably CANNOT produce output or tool
+        // events; the silence is healthy, not a wedge. Defer exactly like
+        // the in-flight-tool paths below (clock untouched, fallbackFired
+        // unset, re-checked next tick) and stay bounded by the same hard
+        // ceiling via the enclosing `underCeiling` guard. Deliberately NOT
+        // gated by SWITCHROOM_SILENCE_DEFER_INFLIGHT_TOOLS=0 — that flag
+        // scopes the TOOL defers; compaction has no tool in flight.
+        if (activeDeps.isCompactionInFlight?.(key) === true) continue
         const forceDisable = process.env.SWITCHROOM_SILENCE_DEFER_INFLIGHT_TOOLS === '0'
         if (!forceDisable && activeDeps.isLegitimatelyWorking != null) {
           if (activeDeps.isLegitimatelyWorking(key)) continue

--- a/telegram-plugin/tests/silence-poke-compaction.test.ts
+++ b/telegram-plugin/tests/silence-poke-compaction.test.ts
@@ -1,0 +1,222 @@
+/**
+ * #4058 — mid-turn auto-compaction must not trip the 300s silence fallback.
+ *
+ * The bug: during compaction the model emits zero output and runs zero tools,
+ * so the gateway saw pure silence and fired the framework fallback ("⚠️ no
+ * output for 5 min — the framework ended that stalled turn") on a healthy
+ * turn that completed correctly right after compaction. Observed live:
+ * ~1m50s of tools + ~3m25s compacting = 304s silence → false fire.
+ *
+ * The fix: the PreCompact hook writes a compaction marker; silence-poke gets
+ * an `isCompactionInFlight` dep consulted in the SAME `underCeiling` defer
+ * branch as the #1292/#3519 in-flight-tool defers; the transcript's
+ * `compact_boundary` record (compaction END) clears the marker and counts as
+ * production. These tests drive the REAL tick loop and assert outcomes:
+ *   - a compaction gap past 300s but under the hard ceiling → NO fire;
+ *   - a genuinely-wedged turn (no compaction) → STILL fires at 300s;
+ *   - a compaction stuck past the hard ceiling → STILL fires (bounded defer).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, existsSync, utimesSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { projectTranscriptLine } from '../session-tail.js'
+import { applySilencePokeSessionEvent } from '../gateway/silence-poke-session-event.js'
+import {
+  COMPACTION_MARKER_FILE,
+  readCompactionMarkerAgeMs,
+  removeCompactionMarker,
+} from '../gateway/compaction-marker.js'
+import * as silencePoke from '../silence-poke.js'
+import * as pendingProgress from '../pending-work-progress.js'
+import {
+  startTurn,
+  __tickForTests,
+  __setDepsForTests,
+  __getStateForTests,
+  __resetAllForTests,
+  DEFAULT_THRESHOLDS,
+  type SilencePokeMetric,
+  type FrameworkFallbackContext,
+} from '../silence-poke.js'
+
+const HARD_CEILING = 900_000 // SILENCE_FALLBACK_HARD_MS default
+
+interface TestFixtures {
+  emitted: SilencePokeMetric[]
+  fallbacks: FrameworkFallbackContext[]
+}
+
+function setupDeps(opts?: {
+  isCompactionInFlight?: (key: string) => boolean
+  isLegitimatelyWorking?: (key: string) => boolean
+}): TestFixtures {
+  const fixtures: TestFixtures = { emitted: [], fallbacks: [] }
+  __setDepsForTests({
+    emitMetric: (e) => fixtures.emitted.push(e),
+    onFrameworkFallback: (ctx) => { fixtures.fallbacks.push(ctx) },
+    thresholdsMs: { ...DEFAULT_THRESHOLDS, fallbackHardCeiling: HARD_CEILING },
+    // Mirror production wiring: the callback path is active (liveness-wiring
+    // always wires isLegitimatelyWorking), returning false = "no tool work".
+    isLegitimatelyWorking: opts?.isLegitimatelyWorking ?? (() => false),
+    ...(opts?.isCompactionInFlight != null
+      ? { isCompactionInFlight: opts.isCompactionInFlight }
+      : {}),
+  })
+  return fixtures
+}
+
+beforeEach(() => {
+  __resetAllForTests()
+  delete process.env.SWITCHROOM_DISABLE_SILENCE_POKE
+})
+
+afterEach(() => {
+  __resetAllForTests()
+})
+
+describe('silence-poke — #4058 compaction defer (outcome)', () => {
+  it('a compaction gap longer than 300s but under the hard ceiling does NOT fire the fallback', () => {
+    // Real observed shape: tools until t=110s, compaction t=110s..415s (305s
+    // of pure silence — past the 300s window), turn completes after.
+    let compacting = false
+    const fx = setupDeps({ isCompactionInFlight: () => compacting })
+    startTurn('chat:1', 0)
+    // Tools produced feed renders until 110s → production reset at 110s.
+    silencePoke.noteProduction('chat:1', 110_000)
+    compacting = true // PreCompact hook fired
+    __tickForTests(300_000) // 190s silent — under threshold anyway
+    __tickForTests(415_000) // 305s silent — WOULD fire without the fix
+    __tickForTests(500_000) // 390s silent — still compacting
+    expect(fx.fallbacks).toHaveLength(0)
+    expect(fx.emitted).toHaveLength(0)
+    // Compaction ends: the compact_boundary handler clears the marker AND
+    // counts the boundary as production (fresh window for the resumed turn).
+    compacting = false
+    silencePoke.noteProduction('chat:1', 505_000)
+    __tickForTests(510_000)
+    expect(fx.fallbacks).toHaveLength(0) // healthy turn: never fired
+  })
+
+  it('a genuinely-wedged turn with no compaction STILL fires at 300s', () => {
+    const fx = setupDeps({ isCompactionInFlight: () => false })
+    startTurn('chat:2', 0)
+    __tickForTests(300_000)
+    expect(fx.fallbacks).toHaveLength(1)
+    expect(fx.emitted.at(-1)).toMatchObject({ kind: 'silence_fallback_sent' })
+  })
+
+  it('a turn that goes silent AFTER compaction ends still fires one window later', () => {
+    let compacting = true
+    const fx = setupDeps({ isCompactionInFlight: () => compacting })
+    startTurn('chat:3', 0)
+    __tickForTests(310_000)
+    expect(fx.fallbacks).toHaveLength(0) // deferred while compacting
+    compacting = false
+    silencePoke.noteProduction('chat:3', 320_000) // compact_boundary landed
+    __tickForTests(325_000)
+    expect(fx.fallbacks).toHaveLength(0)
+    // …but the model never resumes → real wedge → fires 300s after boundary.
+    __tickForTests(620_000)
+    expect(fx.fallbacks).toHaveLength(1)
+  })
+
+  it('a compaction stuck past the hard ceiling STILL fires (bounded defer)', () => {
+    const fx = setupDeps({ isCompactionInFlight: () => true })
+    startTurn('chat:4', 0)
+    __tickForTests(899_000)
+    expect(fx.fallbacks).toHaveLength(0) // deferred under the ceiling
+    __tickForTests(900_000) // silence ≥ fallbackHardCeiling → defer expires
+    expect(fx.fallbacks).toHaveLength(1)
+  })
+
+  it('absent dep (legacy fixtures) leaves behaviour unchanged — fires at 300s', () => {
+    const fx = setupDeps()
+    startTurn('chat:5', 0)
+    __tickForTests(300_000)
+    expect(fx.fallbacks).toHaveLength(1)
+  })
+})
+
+describe('session-tail — compact_boundary projection', () => {
+  it('projects a real transcript compact_boundary line', () => {
+    // Verbatim shape from a live agent transcript (trimmed to the fields the
+    // projection reads).
+    const line = JSON.stringify({
+      parentUuid: null,
+      isSidechain: false,
+      type: 'system',
+      subtype: 'compact_boundary',
+      content: 'Conversation compacted',
+      level: 'info',
+      compactMetadata: { trigger: 'auto', preTokens: 283797, postTokens: 224551, durationMs: 111959 },
+    })
+    expect(projectTranscriptLine(line)).toEqual([
+      { kind: 'compact_boundary', trigger: 'auto', compactDurationMs: 111959 },
+    ])
+  })
+
+  it('tolerates missing compactMetadata', () => {
+    const line = JSON.stringify({ type: 'system', subtype: 'compact_boundary', content: 'Conversation compacted' })
+    expect(projectTranscriptLine(line)).toEqual([
+      { kind: 'compact_boundary', trigger: null, compactDurationMs: null },
+    ])
+  })
+})
+
+describe('compaction-marker + session-event wiring', () => {
+  let dir: string
+  const envBefore = process.env.TELEGRAM_STATE_DIR
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'sp-compact-'))
+    process.env.TELEGRAM_STATE_DIR = dir
+  })
+
+  afterEach(() => {
+    if (envBefore != null) process.env.TELEGRAM_STATE_DIR = envBefore
+    else delete process.env.TELEGRAM_STATE_DIR
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('readCompactionMarkerAgeMs: absent → null; present → mtime age', () => {
+    expect(readCompactionMarkerAgeMs(dir, 1_000)).toBeNull()
+    const p = join(dir, COMPACTION_MARKER_FILE)
+    writeFileSync(p, '{"ts":1}\n')
+    const at = new Date(Date.now() - 10_000)
+    utimesSync(p, at, at)
+    const age = readCompactionMarkerAgeMs(dir)
+    expect(age).not.toBeNull()
+    expect(age!).toBeGreaterThanOrEqual(9_000)
+    expect(age!).toBeLessThan(60_000)
+    removeCompactionMarker(dir)
+    expect(readCompactionMarkerAgeMs(dir)).toBeNull()
+    removeCompactionMarker(dir) // idempotent
+  })
+
+  it('compact_boundary session event clears the marker and resets the silence clock', () => {
+    writeFileSync(join(dir, COMPACTION_MARKER_FILE), '{"ts":1}\n')
+    startTurn('c:9', 0)
+    setupDeps()
+    applySilencePokeSessionEvent(silencePoke, pendingProgress, 'c:9', {
+      kind: 'compact_boundary',
+      trigger: 'auto',
+      compactDurationMs: 111_959,
+    })
+    expect(existsSync(join(dir, COMPACTION_MARKER_FILE))).toBe(false)
+    // Clock reset: lastOutboundAt stamped by noteProduction.
+    expect(__getStateForTests('c:9')?.lastOutboundAt).not.toBeNull()
+  })
+
+  it('PreCompact hook writes the marker from its stdin payload', () => {
+    const hook = join(__dirname, '..', 'hooks', 'compaction-marker-precompact.mjs')
+    execFileSync('node', [hook], {
+      env: { ...process.env, TELEGRAM_STATE_DIR: dir },
+      input: JSON.stringify({ session_id: 's-1', trigger: 'auto', hook_event_name: 'PreCompact' }),
+    })
+    const age = readCompactionMarkerAgeMs(dir)
+    expect(age).not.toBeNull()
+    expect(age!).toBeLessThan(30_000)
+  })
+})


### PR DESCRIPTION
## Root cause

The silence-poke framework fallback (`telegram-plugin/silence-poke.ts`, `fallback: 300_000`) resets its clock only on model output/production events. During **mid-turn auto-compaction** the model emits zero output and runs zero tools for minutes, so every existing work signal — `isLegitimatelyWorking`, in-flight tools (#1292), alive background shells (#3519) — is false. The gateway saw pure silence and fired the 300s teardown on a healthy turn: a spurious "⚠️ no output for 5 min — the framework ended that stalled turn" card + an obligation re-present, right before the turn completed normally. Observed live: ~1m50s of tools then ~3m25s compacting = 304s silence → false fire. Recurs on any session near the context ceiling.

**Signal survey (verified against live transcripts):** the transcript JSONL records compaction only at its END — `{"type":"system","subtype":"compact_boundary","compactMetadata":{...,"durationMs":…}}` (it embeds the compaction's own duration, so it cannot exist earlier). Nothing observable lands at compaction START from the stream. The START signal therefore comes from Claude Code's **PreCompact hook**.

## The fix (composes with the existing defer machinery — no new timer)

- `hooks/compaction-marker-precompact.mjs` (+ `hooks.json` PreCompact entry): writes `$TELEGRAM_STATE_DIR/compaction-in-flight.json` at compaction start — same sidecar pattern as `turn-active-marker.ts` / the tool-label hook (#783). Never blocks compaction, never exits non-zero.
- `silence-poke.ts`: new **optional** dep `isCompactionInFlight?(key)`, consulted inside the exact same `underCeiling` defer branch as the #1292/#3519 tool defers — clock untouched, `fallbackFired` unset, re-checked each tick, **bounded by `fallbackHardCeiling`** (900s default), so a genuinely-wedged compaction still unwedges at the ceiling. Absent dep ⇒ behaviour unchanged.
- `liveness-wiring.ts`: wires the predicate as "marker present AND younger than `SILENCE_FALLBACK_HARD_MS`" — the age bound makes a crash-leaked marker self-heal (can never hold a future genuine wedge past one ceiling window). **`gateway.ts` untouched** (line ratchet clean).
- `session-tail.ts`: projects the `compact_boundary` record → new `{kind:'compact_boundary'}` SessionEvent (real observed shape pinned in a test).
- `silence-poke-session-event.ts`: on `compact_boundary`, clears the marker (defer ends deterministically) and counts the boundary as production — without that reset the fallback would fire on the very next tick after compaction, before the resumed model's first output lands. A turn that stays silent AFTER compaction still fires one full window later.

## Tests — RED-verified

`telegram-plugin/tests/silence-poke-compaction.test.ts` drives the **real tick loop** and asserts outcomes. Verified RED first against origin/main's `silence-poke.ts` (3 failed: the fallback fired during the compaction gap, after only 310s, and at 899s):

- compaction gap past 300s but under the hard ceiling → **no fire**, and no fire after the turn resumes healthily;
- genuinely-wedged turn with no compaction → **still fires at 300s**;
- turn that goes silent after compaction ends → fires one window after the boundary;
- compaction stuck past the hard ceiling → **still fires at the ceiling** (bounded defer);
- absent dep (legacy fixtures) → unchanged;
- plus: projection of a verbatim live `compact_boundary` transcript line, marker read/remove/staleness, boundary-event clears marker + resets clock, and the PreCompact hook executed for real against a tmp state dir.

## Validation

- `vitest run` scoped: new file 10/10 green; regression: `silence-poke`, `silence-poke-orphan-reap`, `silence-poke-teardown-notice`, `silence-liveness-wiring`, `session-tail`(+first-attach,+capped) — 187/187 green.
- `tsc --noEmit` clean; `check-gateway-line-ratchet` clean (gateway.ts unchanged, 24917 = main); `check-bot-api-wrapping` clean; `check-bun-test-imports` / `check-test-runner-coverage` / `check-agent-state-dir-hermeticity` / `check-retry-flood-hooks` / `check-callback-ctx-wrapping` clean.
- `check-plugin-references` fails on `@mtcute/node` **identically on pristine origin/main** in this sandbox (node_modules artifact, not a regression).

## Deployment note

The PreCompact hook ships in `telegram-plugin/hooks/` (baked into the agent image via `DOCKER_HOOKS_PATH`), so the start-signal half lands with the next image rebuild; the gateway half is safe to roll first (absent marker ⇒ pre-fix behaviour). **Flagging for the pending v0.19.40 release.**

Do not merge / do not enroll in the merge queue — handed back for independent review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)