### PR TITLE
fix(telegram): send_checklist degrades to text instead of raw Telegram 400

### DIFF
--- a/docs/telegram-plugin.md
+++ b/docs/telegram-plugin.md
@@ -21,8 +21,8 @@ The official Telegram plugin provides basic message send/receive. Switchroom's f
 | `send_typing` | Show typing indicator during long operations (5s auto-expire). |
 | `download_attachment` | Fetch files attached to inbound messages. |
 | `get_recent_messages` | Query the local SQLite history buffer with pagination and thread filtering. |
-| `send_checklist` | Native Telegram checklist message — fixed-order items with per-item state. Returns a checklist id usable with `update_checklist` (#272). |
-| `update_checklist` | Patch the state of items on a previously sent checklist (e.g. mark item 2 done) without re-sending the whole message. |
+| `send_checklist` | Checklist message — fixed-order items with per-item state. Native Telegram checklists are Business-account-only, so without a business connection (the normal case) it renders as a formatted ✅/⬜ text message and the result carries `degraded: "text"`. Returns a message id usable with `update_checklist` (#272). |
+| `update_checklist` | Patch the state of items on a previously sent checklist (e.g. mark item 2 done) without re-sending the whole message. Re-renders in the mode the checklist was sent in. |
 
 ### Status accent headers
 

--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -268,7 +268,7 @@ const TOOL_SCHEMAS = [
   {
     name: 'send_checklist',
     description:
-      'Send a native Telegram checklist (interactive task list) to a chat. Users can tick tasks directly in the Telegram app. Returns the message_id of the created checklist. The bot is notified when tasks are ticked — these arrive as channel events with kind="checklist_task_changed". Limit: 30 tasks per checklist.',
+      'Send a checklist (task list) to a chat. Native interactive Telegram checklists require a Business-account connection, which most deployments do not have — in that normal case the checklist is sent as a formatted TEXT message (bold title + ✅/⬜ task lines) and the result carries degraded:"text": tasks are NOT tappable, and you tick them yourself via update_checklist (task ids are 1..N in send order). With a Business connection configured, the checklist is sent natively and tick events arrive as channel events with kind="checklist_task_changed". Returns JSON with message_id and mode. Limit: 30 tasks.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -357,7 +357,7 @@ const TOOL_SCHEMAS = [
   {
     name: 'update_checklist',
     description:
-      'Patch an existing native Telegram checklist. Supports updating the title, adding new tasks, removing tasks, or marking tasks done/undone. Tasks with an id target existing items; tasks without an id are appended. Preserves existing task ids across edits.',
+      'Patch a checklist previously sent with send_checklist: update the title, append tasks, or mark tasks done/undone. Tasks with an id target existing items (ids are 1..N in send order for text-mode checklists); tasks without an id are appended. Removal is not supported. The edit re-renders in the mode the checklist was sent in (text for most deployments). Returns JSON { ok, ... }; after a gateway restart the stored task state may be gone — then it returns ok:false with reason "unknown_checklist" unless you pass a full replacement (title + every task\'s text).',
     inputSchema: {
       type: 'object',
       properties: {

--- a/telegram-plugin/gateway/checklist-fallback.ts
+++ b/telegram-plugin/gateway/checklist-fallback.ts
@@ -1,0 +1,370 @@
+/**
+ * Checklist send/update with graceful degradation.
+ *
+ * Telegram's native `sendChecklist` / `editMessageChecklist` (Bot API 9.1)
+ * are **Business-account-only**: both REQUIRE a `business_connection_id`,
+ * and the payload nests `title`/`tasks` inside a single `checklist` object
+ * (`InputChecklist`) whose tasks each carry a REQUIRED integer `id` and NO
+ * completion flag (`InputChecklistTask = { id, text }` — a native checklist
+ * cannot be pre-marked done). The original wrapper sent a FLAT
+ * `{ chat_id, title, tasks: [{ text, is_completed? }] }` payload, which
+ * Telegram rejected with `400: parameter "checklist" is required` — and even
+ * a well-formed payload fails for ordinary bot DMs/groups (no business
+ * connection), which is every chat this fleet uses.
+ *
+ * So the tool degrades gracefully instead of surfacing a raw 400:
+ *   1. If a business connection id is configured AND the Bot API supports
+ *      checklists → build the CORRECT native payload and send natively.
+ *   2. Otherwise (the normal case) → render the checklist as a formatted
+ *      text message (bold title + ✅/⬜ task lines — text CAN show the
+ *      `done` flag) and send via the normal message path. The tool result
+ *      carries `degraded: "text"` so the caller knows it is not interactive.
+ *   3. A failed native attempt falls back to text rather than erroring.
+ *
+ * Updates work against a per-message in-memory state store (the gateway has
+ * no other record of a text-rendered checklist's tasks): a patch is applied
+ * to the stored state and the message is edited (natively or as text to
+ * match how it was sent). State is process-local — after a gateway restart
+ * an update to a pre-restart checklist returns a graceful
+ * `unknown_checklist` result unless the patch itself carries a full
+ * replacement (title + all task texts), never a raw Telegram error.
+ *
+ * Pure/deps-injected so the orchestration is unit-testable without a bot
+ * (same pattern as checklist-message-handler.ts).
+ */
+
+export interface ChecklistTaskState {
+  /** 1-based sequential id assigned at send time (mirrors the native API's
+   *  required per-task integer id; doubles as the patch handle in text mode). */
+  id: number
+  text: string
+  done: boolean
+}
+
+export interface ChecklistState {
+  title: string
+  tasks: ChecklistTaskState[]
+  /** How the message was actually delivered — updates must match it. */
+  mode: 'native' | 'text'
+}
+
+export interface ChecklistPatchTask {
+  id?: string | number
+  text?: string
+  done?: boolean
+}
+
+export interface ChecklistPatch {
+  title?: string
+  tasks?: ChecklistPatchTask[]
+}
+
+export const CHECKLIST_MAX_TASKS = 30
+
+/** Assign sequential 1-based ids and normalize the `done` flag. */
+export function buildChecklistTasks(
+  tasks: ReadonlyArray<{ text: string; done?: boolean }>,
+): ChecklistTaskState[] {
+  if (tasks.length > CHECKLIST_MAX_TASKS) {
+    throw new Error(`checklist exceeds ${CHECKLIST_MAX_TASKS}-task limit (got ${tasks.length})`)
+  }
+  return tasks.map((t, i) => ({ id: i + 1, text: t.text, done: t.done === true }))
+}
+
+/**
+ * Render a checklist as a text message: title header + one ✅/⬜ line per
+ * task. Rich (default) output is GFM markdown for `richMessage()`; pass
+ * `literal: true` when the access config pins `parseMode: 'text'` (plain
+ * sends, no markdown parsing) so the title doesn't ship raw asterisks.
+ */
+export function renderChecklistText(
+  cl: { title: string; tasks: ReadonlyArray<{ text: string; done: boolean }> },
+  opts?: { literal?: boolean },
+): string {
+  const header = opts?.literal ? cl.title : `**${cl.title}**`
+  const lines = cl.tasks.map((t) => `${t.done ? '✅' : '⬜'} ${t.text}`)
+  return [header, ...lines].join('\n')
+}
+
+/**
+ * Apply an update_checklist patch: `title` replaces the title; a task with
+ * an `id` matching an existing task updates its text/done in place; a task
+ * without an `id` (or with an unknown id) is appended. Returns a NEW state
+ * (input untouched). Removal is not supported by the patch shape.
+ */
+export function applyChecklistPatch(
+  cl: { title: string; tasks: ReadonlyArray<ChecklistTaskState> },
+  patch: ChecklistPatch,
+): { title: string; tasks: ChecklistTaskState[] } {
+  const tasks = cl.tasks.map((t) => ({ ...t }))
+  for (const p of patch.tasks ?? []) {
+    const pid = p.id != null ? Number(p.id) : undefined
+    const existing = pid != null ? tasks.find((t) => t.id === pid) : undefined
+    if (existing) {
+      if (p.text != null) existing.text = p.text
+      if (p.done != null) existing.done = p.done
+    } else {
+      const nextId = pid != null && Number.isFinite(pid)
+        ? pid
+        : tasks.reduce((m, t) => Math.max(m, t.id), 0) + 1
+      tasks.push({ id: nextId, text: p.text ?? '', done: p.done === true })
+    }
+  }
+  if (tasks.length > CHECKLIST_MAX_TASKS) {
+    throw new Error(`checklist exceeds ${CHECKLIST_MAX_TASKS}-task limit (got ${tasks.length})`)
+  }
+  return { title: patch.title ?? cl.title, tasks }
+}
+
+/**
+ * Build a CORRECT native `sendChecklist` payload per Bot API 9.1:
+ * `business_connection_id` is required, `title`/`tasks` nest inside a single
+ * `checklist` object (`InputChecklist`), each task carries its integer `id`,
+ * and there is NO completion field (`InputChecklistTask` has none).
+ */
+export function buildNativeChecklistPayload(p: {
+  businessConnectionId: string
+  chatId: number
+  title: string
+  tasks: ReadonlyArray<ChecklistTaskState>
+  replyToMessageId?: number
+  protectContent?: boolean
+}): Record<string, unknown> {
+  return {
+    business_connection_id: p.businessConnectionId,
+    chat_id: p.chatId,
+    checklist: {
+      title: p.title,
+      tasks: p.tasks.map((t) => ({ id: t.id, text: t.text })),
+    },
+    ...(p.replyToMessageId != null ? { reply_parameters: { message_id: p.replyToMessageId } } : {}),
+    ...(p.protectContent === true ? { protect_content: true } : {}),
+  }
+}
+
+/**
+ * Build a native `editMessageChecklist` payload. The native edit REPLACES
+ * the whole checklist, so the FULL post-patch state is sent; reusing the
+ * stored task ids preserves user tick state for unchanged tasks.
+ */
+export function buildNativeEditChecklistPayload(p: {
+  businessConnectionId: string
+  chatId: number
+  messageId: number
+  title: string
+  tasks: ReadonlyArray<ChecklistTaskState>
+}): Record<string, unknown> {
+  return {
+    business_connection_id: p.businessConnectionId,
+    chat_id: p.chatId,
+    message_id: p.messageId,
+    checklist: {
+      title: p.title,
+      tasks: p.tasks.map((t) => ({ id: t.id, text: t.text })),
+    },
+  }
+}
+
+/** Bounded per-message checklist state store (insertion-order eviction). */
+export interface ChecklistStore {
+  get(key: string): ChecklistState | undefined
+  set(key: string, state: ChecklistState): void
+}
+
+export function createChecklistStore(cap = 500): ChecklistStore {
+  const map = new Map<string, ChecklistState>()
+  return {
+    get: (key) => map.get(key),
+    set: (key, state) => {
+      if (map.has(key)) map.delete(key) // refresh insertion order
+      map.set(key, state)
+      while (map.size > cap) {
+        const oldest = map.keys().next().value as string | undefined
+        if (oldest == null) break
+        map.delete(oldest)
+      }
+    },
+  }
+}
+
+export function checklistStoreKey(chatId: string, messageId: string | number): string {
+  return `${chatId}:${messageId}`
+}
+
+// ─── Orchestration (deps-injected, unit-testable) ─────────────────────────
+
+export interface SendChecklistDeps {
+  /** Business connection id, when the operator has one configured. Native
+   *  checklists are impossible without it (required API parameter). */
+  businessConnectionId: string | undefined
+  /** Boot-probe result: the connected grammY/Bot API exposes sendChecklist. */
+  nativeAvailable: boolean
+  sendNative: (payload: Record<string, unknown>) => Promise<{ message_id: number }>
+  sendText: (text: string) => Promise<{ message_id: number }>
+  /** access.parseMode === 'text' — render without markdown. */
+  literalText: boolean
+  log: (line: string) => void
+}
+
+export interface SendChecklistResult {
+  message_id: number
+  mode: 'native' | 'text'
+  state: ChecklistState
+}
+
+/**
+ * Send a checklist: natively when possible, degrading to a formatted text
+ * message otherwise. NEVER lets a native-send failure escape — the fallback
+ * is the text render. (A text-send failure still throws: there is nothing
+ * further to degrade to, and the caller's normal error path applies.)
+ */
+export async function performSendChecklist(
+  deps: SendChecklistDeps,
+  args: {
+    title: string
+    tasks: ReadonlyArray<{ text: string; done?: boolean }>
+    chatId: number
+    replyToMessageId?: number
+    protectContent?: boolean
+  },
+): Promise<SendChecklistResult> {
+  const tasks = buildChecklistTasks(args.tasks)
+  if (deps.nativeAvailable && deps.businessConnectionId) {
+    try {
+      const sent = await deps.sendNative(buildNativeChecklistPayload({
+        businessConnectionId: deps.businessConnectionId,
+        chatId: args.chatId,
+        title: args.title,
+        tasks,
+        replyToMessageId: args.replyToMessageId,
+        protectContent: args.protectContent,
+      }))
+      return {
+        message_id: sent.message_id,
+        mode: 'native',
+        state: { title: args.title, tasks, mode: 'native' },
+      }
+    } catch (err) {
+      deps.log(`native sendChecklist failed — falling back to text render: ${err}\n`)
+    }
+  }
+  const text = renderChecklistText({ title: args.title, tasks }, { literal: deps.literalText })
+  const sent = await deps.sendText(text)
+  return {
+    message_id: sent.message_id,
+    mode: 'text',
+    state: { title: args.title, tasks, mode: 'text' },
+  }
+}
+
+/** Tool-result text for send_checklist. The degraded shape carries
+ *  `degraded: "text"` + a note so the calling agent knows the checklist is a
+ *  formatted message, not a natively tickable one. */
+export function sendChecklistToolText(r: SendChecklistResult): string {
+  return JSON.stringify(
+    r.mode === 'native'
+      ? { ok: true, message_id: r.message_id, mode: 'native' }
+      : {
+          ok: true,
+          message_id: r.message_id,
+          mode: 'text',
+          degraded: 'text',
+          note: 'rendered as a formatted text message (native Telegram checklists require a Business connection) — tasks are not tappable; use update_checklist with task ids 1..N to tick them',
+        },
+  )
+}
+
+export interface UpdateChecklistDeps {
+  /** Stored state for this chat:message, if the gateway still has it. */
+  state: ChecklistState | undefined
+  businessConnectionId: string | undefined
+  nativeAvailable: boolean
+  editNative: (payload: Record<string, unknown>) => Promise<void>
+  editText: (text: string) => Promise<void>
+  literalText: boolean
+  log: (line: string) => void
+  chatId: number
+  messageId: number
+}
+
+export type UpdateChecklistResult =
+  | { ok: true; mode: 'native' | 'text'; state: ChecklistState }
+  | { ok: false; reason: 'unknown_checklist' | 'edit_failed'; hint: string }
+
+/**
+ * Update a checklist message. Applies the patch to the stored state and
+ * re-renders in the mode the message was originally sent in. Failures come
+ * back as structured `{ ok: false, reason, hint }` results — never a raw
+ * Telegram error thrown at the caller.
+ */
+export async function performUpdateChecklist(
+  deps: UpdateChecklistDeps,
+  patch: ChecklistPatch,
+): Promise<UpdateChecklistResult> {
+  let base = deps.state
+  if (!base) {
+    // State lost (gateway restart / evicted). If the patch is a full
+    // replacement — a title plus tasks that all carry text — we can rebuild
+    // and edit as text (the fleet-normal mode). Otherwise we cannot know
+    // the existing tasks; degrade gracefully.
+    const fullReplacement =
+      patch.title != null &&
+      (patch.tasks?.length ?? 0) > 0 &&
+      (patch.tasks ?? []).every((t) => t.text != null)
+    if (!fullReplacement) {
+      return {
+        ok: false,
+        reason: 'unknown_checklist',
+        hint: 'no stored state for this checklist (gateway restarted?). Re-send it with send_checklist, or pass a full replacement (title + every task\'s text) to update_checklist.',
+      }
+    }
+    base = { title: patch.title!, tasks: [], mode: 'text' }
+  }
+  let next: { title: string; tasks: ChecklistTaskState[] }
+  try {
+    next = applyChecklistPatch(base, patch)
+  } catch (err) {
+    return { ok: false, reason: 'edit_failed', hint: String(err) }
+  }
+  const state: ChecklistState = { title: next.title, tasks: next.tasks, mode: base.mode }
+  if (base.mode === 'native') {
+    // A native checklist message cannot be edited into plain text — there is
+    // no text fallback here; a failure surfaces as a structured result.
+    if (!deps.nativeAvailable || !deps.businessConnectionId) {
+      return {
+        ok: false,
+        reason: 'edit_failed',
+        hint: 'this checklist was sent natively but the business connection / checklist API is no longer available.',
+      }
+    }
+    try {
+      await deps.editNative(buildNativeEditChecklistPayload({
+        businessConnectionId: deps.businessConnectionId,
+        chatId: deps.chatId,
+        messageId: deps.messageId,
+        title: state.title,
+        tasks: state.tasks,
+      }))
+      return { ok: true, mode: 'native', state }
+    } catch (err) {
+      deps.log(`native editMessageChecklist failed: ${err}\n`)
+      return { ok: false, reason: 'edit_failed', hint: String(err) }
+    }
+  }
+  try {
+    await deps.editText(renderChecklistText(state, { literal: deps.literalText }))
+    return { ok: true, mode: 'text', state }
+  } catch (err) {
+    deps.log(`checklist text edit failed: ${err}\n`)
+    return { ok: false, reason: 'edit_failed', hint: String(err) }
+  }
+}
+
+/** Tool-result text for update_checklist — structured for both outcomes. */
+export function updateChecklistToolText(r: UpdateChecklistResult, messageId: number): string {
+  return JSON.stringify(
+    r.ok
+      ? { ok: true, message_id: messageId, mode: r.mode, ...(r.mode === 'text' ? { degraded: 'text' } : {}) }
+      : { ok: false, reason: r.reason, hint: r.hint },
+  )
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -35,6 +35,7 @@ import {
   type AskUserOutcome,
 } from '../ask-user.js'
 import { redactAskUserFields, redactChecklistFields } from '../outbound-field-redact.js'
+import { createChecklistStore, checklistStoreKey, performSendChecklist, performUpdateChecklist, sendChecklistToolText, updateChecklistToolText } from './checklist-fallback.js'
 import { parseInterruptMarker } from '../interrupt-marker.js'
 import {
   ToolFlightTracker,
@@ -1383,65 +1384,29 @@ let _rawEditMessageChecklist: unknown
 /** True when the connected Telegram Bot API supports native checklists. Set in initGatewayBot() (#2996 P0b). */
 let CHECKLIST_API_AVAILABLE = false
 
-/**
- * Send a native Telegram checklist message.
- * Wraps bot.api.raw.sendChecklist with string→number coercion (chat_id) and
- * a 30-task cap enforced before the API call.
- */
-async function rawSendChecklist(args: {
-  chat_id: string
-  title: string
-  tasks: Array<{ text: string; done?: boolean }>
-  message_thread_id?: number
-  reply_to_message_id?: number
-  protect_content?: boolean
-}): Promise<{ message_id: number }> {
-  if (!CHECKLIST_API_AVAILABLE) {
-    throw new Error('sendChecklist is not available in this grammY/Telegram Bot API version')
-  }
-  const MAX_TASKS = 30
-  if (args.tasks.length > MAX_TASKS) {
-    throw new Error(`checklist exceeds ${MAX_TASKS}-task limit (got ${args.tasks.length})`)
-  }
-  const result = await (_rawSendChecklist as (p: Record<string, unknown>) => Promise<{ message_id: number }>)({
-    chat_id: Number(args.chat_id),
-    title: args.title,
-    tasks: args.tasks.map(t => ({ text: t.text, ...(t.done != null ? { is_completed: t.done } : {}) })),
-    ...(args.message_thread_id != null ? { message_thread_id: args.message_thread_id } : {}),
-    ...(args.reply_to_message_id != null ? { reply_to_message_id: args.reply_to_message_id } : {}),
-    ...(args.protect_content === true ? { protect_content: true } : {}),
-  })
+/** bot.api.raw.sendChecklist with a payload pre-built by checklist-fallback.ts
+ *  (nested `checklist` object, per-task integer ids, business_connection_id —
+ *  the old flat shape got `400: parameter "checklist" is required`). */
+async function rawSendChecklist(payload: Record<string, unknown>): Promise<{ message_id: number }> {
+  if (!CHECKLIST_API_AVAILABLE) throw new Error('sendChecklist is not available in this grammY/Telegram Bot API version')
+  const result = await (_rawSendChecklist as (p: Record<string, unknown>) => Promise<{ message_id: number }>)(payload)
   return { message_id: result.message_id }
 }
 
-/**
- * Edit (patch) an existing Telegram checklist message.
- * Supports updating title, adding/removing tasks, and marking tasks done/undone.
- * Task objects with an `id` field target existing tasks; those without are added.
- */
-async function rawEditMessageChecklist(args: {
-  chat_id: string
-  message_id: string
-  title?: string
-  tasks?: Array<{ id?: string; text?: string; done?: boolean }>
-}): Promise<void> {
-  if (!CHECKLIST_API_AVAILABLE) {
-    throw new Error('editMessageChecklist is not available in this grammY/Telegram Bot API version')
-  }
-  await (_rawEditMessageChecklist as (p: Record<string, unknown>) => Promise<unknown>)({
-    chat_id: Number(args.chat_id),
-    message_id: Number(args.message_id),
-    ...(args.title != null ? { title: args.title } : {}),
-    ...(args.tasks != null
-      ? {
-          tasks: args.tasks.map(t => ({
-            ...(t.id != null ? { id: Number(t.id) } : {}),
-            ...(t.text != null ? { text: t.text } : {}),
-            ...(t.done != null ? { is_completed: t.done } : {}),
-          })),
-        }
-      : {}),
-  })
+/** bot.api.raw.editMessageChecklist with a pre-built payload (the native edit REPLACES the whole checklist, so checklist-fallback.ts sends full state). */
+async function rawEditMessageChecklist(payload: Record<string, unknown>): Promise<void> {
+  if (!CHECKLIST_API_AVAILABLE) throw new Error('editMessageChecklist is not available in this grammY/Telegram Bot API version')
+  await (_rawEditMessageChecklist as (p: Record<string, unknown>) => Promise<unknown>)(payload)
+}
+
+/** Per-message checklist state — update_checklist re-renders from it (process-local; post-restart updates degrade gracefully). */
+const checklistStore = createChecklistStore()
+
+/** Native checklists are Telegram-Business-only (sendChecklist REQUIRES a business_connection_id).
+ *  No fleet config plumbing exists yet; this env var is the opt-in — unset (the normal case) means text fallback. */
+function resolveBusinessConnectionId(): string | undefined {
+  const v = process.env.SWITCHROOM_TELEGRAM_BUSINESS_CONNECTION_ID?.trim()
+  return v ? v : undefined
 }
 
 const chatLock = createChatLock()
@@ -12083,17 +12048,35 @@ async function executeSendChecklist(args: Record<string, unknown>): Promise<{ co
     (t) => redactOutboundText(t, 'send_checklist'),
   )
 
-  const sent = await rawSendChecklist({
-    chat_id,
-    title: redactedTitle!,
-    tasks: redactedTasks!,
+  // Graceful degradation: native sendChecklist is Business-account-only, so
+  // ordinary chats (the fleet norm) get a formatted text render instead of a
+  // raw Telegram 400 (rationale + orchestration in checklist-fallback.ts).
+  const literal = (loadAccess().parseMode ?? 'html') === 'text'
+  const sendOpts = {
     ...(threadId != null ? { message_thread_id: threadId } : {}),
-    ...(replyTo != null ? { reply_to_message_id: replyTo } : {}),
+    ...(replyTo != null ? { reply_parameters: { message_id: replyTo } } : {}),
     ...(protectContent ? { protect_content: true } : {}),
-  })
+  }
+  const result = await performSendChecklist({
+    businessConnectionId: resolveBusinessConnectionId(),
+    nativeAvailable: CHECKLIST_API_AVAILABLE,
+    sendNative: rawSendChecklist,
+    sendText: (text) => robustApiCall(
+      (): Promise<{ message_id: number }> =>
+        literal
+          // allow-raw-bot-api: literal checklist text-fallback send routed through robustApiCall
+          ? lockedBot.api.sendMessage(chat_id, text, sendOpts as never)
+          // allow-raw-bot-api: checklist text-fallback send routed through robustApiCall
+          : lockedBot.api.sendRichMessage(chat_id, richMessage(text), sendOpts as never),
+      { verb: 'sendMessage', chat_id, threadId },
+    ),
+    literalText: literal,
+    log: (l) => process.stderr.write(`telegram gateway: ${l}`),
+  }, { title: redactedTitle!, tasks: redactedTasks!, chatId: Number(chat_id), replyToMessageId: replyTo, protectContent })
 
-  process.stderr.write(`telegram gateway: send_checklist: sent chatId=${chat_id} messageId=${sent.message_id} tasks=${tasks.length}\n`)
-  return { content: [{ type: 'text', text: `checklist sent (id: ${sent.message_id})` }] }
+  checklistStore.set(checklistStoreKey(chat_id, result.message_id), result.state)
+  process.stderr.write(`telegram gateway: send_checklist: sent chatId=${chat_id} messageId=${result.message_id} tasks=${tasks.length} mode=${result.mode}\n`)
+  return { content: [{ type: 'text', text: sendChecklistToolText(result) }] }
 }
 
 /**
@@ -12180,10 +12163,27 @@ async function executeUpdateChecklist(args: Record<string, unknown>): Promise<{ 
     (t) => redactOutboundText(t, 'update_checklist'),
   )
 
-  await rawEditMessageChecklist({ chat_id, message_id, title: redactedTitle, tasks: redactedTasks })
+  // Graceful degradation (checklist-fallback.ts): the patch is applied to the
+  // stored per-message state and the message re-rendered in the mode it was
+  // sent in. Failures come back structured, never as a raw Telegram 400.
+  const literal = (loadAccess().parseMode ?? 'html') === 'text'
+  const key = checklistStoreKey(chat_id, message_id)
+  const result = await performUpdateChecklist({
+    state: checklistStore.get(key),
+    businessConnectionId: resolveBusinessConnectionId(),
+    nativeAvailable: CHECKLIST_API_AVAILABLE,
+    editNative: rawEditMessageChecklist,
+    // allow-raw-bot-api: checklist text-fallback edit routed through robustApiCall
+    editText: async (text) => { await robustApiCall(() => lockedBot.api.editMessageText(chat_id, Number(message_id), literal ? text : richMessage(text))) },
+    literalText: literal,
+    log: (l) => process.stderr.write(`telegram gateway: ${l}`),
+    chatId: Number(chat_id),
+    messageId: Number(message_id),
+  }, { title: redactedTitle, tasks: redactedTasks })
 
-  process.stderr.write(`telegram gateway: update_checklist: updated chatId=${chat_id} messageId=${message_id}\n`)
-  return { content: [{ type: 'text', text: `checklist updated (id: ${message_id})` }] }
+  if (result.ok) checklistStore.set(key, result.state)
+  process.stderr.write(`telegram gateway: update_checklist: ${result.ok ? `updated mode=${result.mode}` : `failed reason=${result.reason}`} chatId=${chat_id} messageId=${message_id}\n`)
+  return { content: [{ type: 'text', text: updateChecklistToolText(result, Number(message_id)) }] }
 }
 
 /**

--- a/telegram-plugin/tests/checklist-fallback.test.ts
+++ b/telegram-plugin/tests/checklist-fallback.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Outcome pins for checklist graceful degradation
+ * (gateway/checklist-fallback.ts).
+ *
+ * The bug this guards: `send_checklist` built a FLAT
+ * `{ chat_id, title, tasks: [{ text, is_completed }] }` payload for
+ * Telegram's `sendChecklist`, which requires (a) `title`/`tasks` nested
+ * inside a single `checklist` object, (b) a REQUIRED integer `id` per task,
+ * (c) NO completion flag, and (d) a `business_connection_id` — native
+ * checklists are Business-account-only, so every ordinary bot chat got a raw
+ * `400: Bad Request: parameter "checklist" is required`.
+ *
+ * Pinned outcomes: the normal (no business connection) path sends a
+ * formatted ✅/⬜ text message and reports `degraded: "text"`; the native
+ * payload, when built, is CORRECT per Bot API 9.1; and no native failure
+ * escapes as a raw error — it falls back to text.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import {
+  buildChecklistTasks,
+  renderChecklistText,
+  applyChecklistPatch,
+  buildNativeChecklistPayload,
+  buildNativeEditChecklistPayload,
+  createChecklistStore,
+  checklistStoreKey,
+  performSendChecklist,
+  performUpdateChecklist,
+  sendChecklistToolText,
+  updateChecklistToolText,
+  CHECKLIST_MAX_TASKS,
+  type ChecklistState,
+  type SendChecklistDeps,
+  type UpdateChecklistDeps,
+} from '../gateway/checklist-fallback.js'
+
+function sendDeps(over: Partial<SendChecklistDeps> = {}) {
+  const sendNative = vi.fn(async () => ({ message_id: 100 }))
+  const sendText = vi.fn(async () => ({ message_id: 200 }))
+  const log = vi.fn()
+  const deps: SendChecklistDeps = {
+    businessConnectionId: undefined,
+    nativeAvailable: true,
+    sendNative,
+    sendText,
+    literalText: false,
+    log,
+    ...over,
+  }
+  return { deps, sendNative, sendText, log }
+}
+
+function updateDeps(over: Partial<UpdateChecklistDeps> = {}) {
+  const editNative = vi.fn(async () => {})
+  const editText = vi.fn(async () => {})
+  const log = vi.fn()
+  const deps: UpdateChecklistDeps = {
+    state: undefined,
+    businessConnectionId: undefined,
+    nativeAvailable: true,
+    editNative,
+    editText,
+    literalText: false,
+    log,
+    chatId: 42,
+    messageId: 7,
+    ...over,
+  }
+  return { deps, editNative, editText, log }
+}
+
+const textState = (over: Partial<ChecklistState> = {}): ChecklistState => ({
+  title: 'Trip prep',
+  tasks: [
+    { id: 1, text: 'book flights', done: false },
+    { id: 2, text: 'renew passport', done: true },
+  ],
+  mode: 'text',
+  ...over,
+})
+
+describe('buildChecklistTasks', () => {
+  it('assigns sequential 1-based ids and normalizes done', () => {
+    expect(buildChecklistTasks([{ text: 'a' }, { text: 'b', done: true }])).toEqual([
+      { id: 1, text: 'a', done: false },
+      { id: 2, text: 'b', done: true },
+    ])
+  })
+
+  it('rejects more than the 30-task API limit', () => {
+    const tasks = Array.from({ length: CHECKLIST_MAX_TASKS + 1 }, (_, i) => ({ text: `t${i}` }))
+    expect(() => buildChecklistTasks(tasks)).toThrow(/30-task limit/)
+  })
+})
+
+describe('renderChecklistText', () => {
+  it('renders bold title + ✅/⬜ lines honoring done', () => {
+    expect(renderChecklistText(textState())).toBe('**Trip prep**\n⬜ book flights\n✅ renew passport')
+  })
+
+  it('literal mode drops the markdown bold (parseMode: text sends are not parsed)', () => {
+    expect(renderChecklistText(textState(), { literal: true })).toBe('Trip prep\n⬜ book flights\n✅ renew passport')
+  })
+})
+
+describe('applyChecklistPatch', () => {
+  it('updates by id, appends without id, replaces title; input untouched', () => {
+    const base = textState()
+    const next = applyChecklistPatch(base, {
+      title: 'Trip prep v2',
+      tasks: [{ id: '1', done: true }, { text: 'pack bags' }],
+    })
+    expect(next).toEqual({
+      title: 'Trip prep v2',
+      tasks: [
+        { id: 1, text: 'book flights', done: true },
+        { id: 2, text: 'renew passport', done: true },
+        { id: 3, text: 'pack bags', done: false },
+      ],
+    })
+    expect(base.tasks[0].done).toBe(false) // pure — no mutation
+  })
+
+  it('appends a task with an unknown id, preserving that id', () => {
+    const next = applyChecklistPatch(textState(), { tasks: [{ id: 9, text: 'buy sim', done: false }] })
+    expect(next.tasks[2]).toEqual({ id: 9, text: 'buy sim', done: false })
+  })
+})
+
+describe('native payloads — correct Bot API 9.1 shape', () => {
+  it('sendChecklist nests title/tasks inside `checklist`, carries ids, has NO is_completed', () => {
+    const payload = buildNativeChecklistPayload({
+      businessConnectionId: 'bc1',
+      chatId: 42,
+      title: 'T',
+      tasks: buildChecklistTasks([{ text: 'a', done: true }, { text: 'b' }]),
+      replyToMessageId: 5,
+    })
+    expect(payload).toEqual({
+      business_connection_id: 'bc1',
+      chat_id: 42,
+      checklist: { title: 'T', tasks: [{ id: 1, text: 'a' }, { id: 2, text: 'b' }] },
+      reply_parameters: { message_id: 5 },
+    })
+    expect(JSON.stringify(payload)).not.toContain('is_completed')
+  })
+
+  it('editMessageChecklist sends the FULL checklist (native edits replace it)', () => {
+    const payload = buildNativeEditChecklistPayload({
+      businessConnectionId: 'bc1',
+      chatId: 42,
+      messageId: 7,
+      title: 'T',
+      tasks: [{ id: 3, text: 'kept', done: false }],
+    })
+    expect(payload).toEqual({
+      business_connection_id: 'bc1',
+      chat_id: 42,
+      message_id: 7,
+      checklist: { title: 'T', tasks: [{ id: 3, text: 'kept' }] },
+    })
+  })
+})
+
+describe('performSendChecklist — degradation outcomes', () => {
+  it('no business connection (the fleet norm) → sends the ✅/⬜ text render, never native', async () => {
+    const { deps, sendNative, sendText } = sendDeps()
+    const r = await performSendChecklist(deps, {
+      title: 'Trip prep',
+      tasks: [{ text: 'book flights' }, { text: 'renew passport', done: true }],
+      chatId: 42,
+    })
+    expect(sendNative).not.toHaveBeenCalled()
+    expect(sendText).toHaveBeenCalledWith('**Trip prep**\n⬜ book flights\n✅ renew passport')
+    expect(r).toMatchObject({ message_id: 200, mode: 'text' })
+    expect(r.state).toEqual({
+      title: 'Trip prep',
+      tasks: [
+        { id: 1, text: 'book flights', done: false },
+        { id: 2, text: 'renew passport', done: true },
+      ],
+      mode: 'text',
+    })
+  })
+
+  it('business connection configured → sends the correct nested native payload', async () => {
+    const { deps, sendNative, sendText } = sendDeps({ businessConnectionId: 'bc1' })
+    const r = await performSendChecklist(deps, { title: 'T', tasks: [{ text: 'a' }], chatId: 42 })
+    expect(sendText).not.toHaveBeenCalled()
+    expect(sendNative).toHaveBeenCalledWith({
+      business_connection_id: 'bc1',
+      chat_id: 42,
+      checklist: { title: 'T', tasks: [{ id: 1, text: 'a' }] },
+    })
+    expect(r).toMatchObject({ message_id: 100, mode: 'native' })
+  })
+
+  it('native failure does NOT escape — falls back to the text render', async () => {
+    const { deps, sendText, log } = sendDeps({
+      businessConnectionId: 'bc1',
+      sendNative: vi.fn(async () => { throw new Error('400: Bad Request: parameter "checklist" is required') }),
+    })
+    const r = await performSendChecklist(deps, { title: 'T', tasks: [{ text: 'a' }], chatId: 42 })
+    expect(r).toMatchObject({ message_id: 200, mode: 'text' })
+    expect(sendText).toHaveBeenCalledWith('**T**\n⬜ a')
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('falling back to text'))
+  })
+
+  it('checklist API not available in this grammY version → text render, no native attempt', async () => {
+    const { deps, sendNative } = sendDeps({ businessConnectionId: 'bc1', nativeAvailable: false })
+    const r = await performSendChecklist(deps, { title: 'T', tasks: [{ text: 'a' }], chatId: 42 })
+    expect(sendNative).not.toHaveBeenCalled()
+    expect(r.mode).toBe('text')
+  })
+})
+
+describe('performUpdateChecklist — degradation outcomes', () => {
+  it('text-mode: patch applies to stored state and re-renders the ✅/⬜ text', async () => {
+    const { deps, editText, editNative } = updateDeps({ state: textState() })
+    const r = await performUpdateChecklist(deps, { tasks: [{ id: 1, done: true }] })
+    expect(editNative).not.toHaveBeenCalled()
+    expect(editText).toHaveBeenCalledWith('**Trip prep**\n✅ book flights\n✅ renew passport')
+    expect(r).toMatchObject({ ok: true, mode: 'text' })
+  })
+
+  it('no stored state + partial patch → structured unknown_checklist, no edit attempted', async () => {
+    const { deps, editText, editNative } = updateDeps()
+    const r = await performUpdateChecklist(deps, { tasks: [{ id: 1, done: true }] })
+    expect(r).toMatchObject({ ok: false, reason: 'unknown_checklist' })
+    expect(editText).not.toHaveBeenCalled()
+    expect(editNative).not.toHaveBeenCalled()
+  })
+
+  it('no stored state + full replacement (title + all task texts) → rebuilds and edits as text', async () => {
+    const { deps, editText } = updateDeps()
+    const r = await performUpdateChecklist(deps, {
+      title: 'Rebuilt',
+      tasks: [{ text: 'a', done: true }, { text: 'b' }],
+    })
+    expect(r).toMatchObject({ ok: true, mode: 'text' })
+    expect(editText).toHaveBeenCalledWith('**Rebuilt**\n✅ a\n⬜ b')
+  })
+
+  it('native-mode: edits with the FULL post-patch checklist payload', async () => {
+    const { deps, editNative } = updateDeps({
+      state: textState({ mode: 'native' }),
+      businessConnectionId: 'bc1',
+    })
+    const r = await performUpdateChecklist(deps, { tasks: [{ text: 'new task' }] })
+    expect(r).toMatchObject({ ok: true, mode: 'native' })
+    expect(editNative).toHaveBeenCalledWith({
+      business_connection_id: 'bc1',
+      chat_id: 42,
+      message_id: 7,
+      checklist: {
+        title: 'Trip prep',
+        tasks: [
+          { id: 1, text: 'book flights' },
+          { id: 2, text: 'renew passport' },
+          { id: 3, text: 'new task' },
+        ],
+      },
+    })
+  })
+
+  it('a failed edit never throws a raw Telegram error — structured edit_failed instead', async () => {
+    const { deps } = updateDeps({
+      state: textState(),
+      editText: vi.fn(async () => { throw new Error('400: Bad Request: message to edit not found') }),
+    })
+    const r = await performUpdateChecklist(deps, { tasks: [{ id: 1, done: true }] })
+    expect(r).toMatchObject({ ok: false, reason: 'edit_failed' })
+    expect((r as { hint: string }).hint).toContain('message to edit not found')
+  })
+
+  it('native-mode checklist with the business connection gone → structured edit_failed', async () => {
+    const { deps, editNative } = updateDeps({ state: textState({ mode: 'native' }) })
+    const r = await performUpdateChecklist(deps, { tasks: [{ id: 1, done: true }] })
+    expect(r).toMatchObject({ ok: false, reason: 'edit_failed' })
+    expect(editNative).not.toHaveBeenCalled()
+  })
+})
+
+describe('tool-result text', () => {
+  it('send: degraded text result carries degraded:"text" so the agent knows', () => {
+    const parsed = JSON.parse(sendChecklistToolText({
+      message_id: 200, mode: 'text', state: textState(),
+    }))
+    expect(parsed).toMatchObject({ ok: true, message_id: 200, mode: 'text', degraded: 'text' })
+    expect(parsed.note).toContain('Business connection')
+  })
+
+  it('send: native result has no degraded marker', () => {
+    expect(JSON.parse(sendChecklistToolText({
+      message_id: 100, mode: 'native', state: textState({ mode: 'native' }),
+    }))).toEqual({ ok: true, message_id: 100, mode: 'native' })
+  })
+
+  it('update: structured failure round-trips reason + hint', () => {
+    expect(JSON.parse(updateChecklistToolText(
+      { ok: false, reason: 'unknown_checklist', hint: 'resend it' }, 7,
+    ))).toEqual({ ok: false, reason: 'unknown_checklist', hint: 'resend it' })
+  })
+})
+
+describe('createChecklistStore', () => {
+  it('evicts oldest entries past the cap', () => {
+    const store = createChecklistStore(2)
+    store.set(checklistStoreKey('1', 1), textState())
+    store.set(checklistStoreKey('1', 2), textState())
+    store.set(checklistStoreKey('1', 3), textState())
+    expect(store.get('1:1')).toBeUndefined()
+    expect(store.get('1:2')).toBeDefined()
+    expect(store.get('1:3')).toBeDefined()
+  })
+})

--- a/telegram-plugin/tests/gateway-outbound-redact.test.ts
+++ b/telegram-plugin/tests/gateway-outbound-redact.test.ts
@@ -114,21 +114,25 @@ describe('gateway outbound secret-scrub — structural wiring', () => {
     expect(sendIdx).toBeGreaterThan(redactIdx) // mask BEFORE the question is sent
   })
 
-  it('send_checklist: redacts title + task text BEFORE rawSendChecklist', () => {
-    // F2 — checklist title + task strings were sent unredacted.
+  it('send_checklist: redacts title + task text BEFORE the send orchestration', () => {
+    // F2 — checklist title + task strings were sent unredacted. The send now
+    // routes through performSendChecklist (native OR text fallback), so the
+    // scrub must land before that orchestration call — both paths receive
+    // only redacted strings.
     const start = src.indexOf('async function executeSendChecklist(')
     const redactIdx = src.indexOf('redactChecklistFields(', start)
-    const sendIdx = src.indexOf('rawSendChecklist({', start)
+    const sendIdx = src.indexOf('performSendChecklist({', start)
     expect(start).toBeGreaterThan(0)
     expect(redactIdx).toBeGreaterThan(start)
     expect(sendIdx).toBeGreaterThan(redactIdx) // mask BEFORE the send
   })
 
-  it('update_checklist: redacts title + task text BEFORE rawEditMessageChecklist', () => {
-    // F2 sibling — update_checklist shares the identical leak class.
+  it('update_checklist: redacts title + task text BEFORE the edit orchestration', () => {
+    // F2 sibling — update_checklist shares the identical leak class; the edit
+    // routes through performUpdateChecklist (native OR text fallback).
     const start = src.indexOf('async function executeUpdateChecklist(')
     const redactIdx = src.indexOf('redactChecklistFields(', start)
-    const editIdx = src.indexOf('rawEditMessageChecklist({', start)
+    const editIdx = src.indexOf('performUpdateChecklist({', start)
     expect(start).toBeGreaterThan(0)
     expect(redactIdx).toBeGreaterThan(start)
     expect(editIdx).toBeGreaterThan(redactIdx) // mask BEFORE the edit


### PR DESCRIPTION
## Summary

`send_checklist` failed fleet-wide with `400: Bad Request: parameter "checklist" is required`. Two compounding defects, verified against the [official Bot API docs](https://core.telegram.org/bots/api#sendchecklist):

1. **Wrong payload shape.** `rawSendChecklist` sent a FLAT `{ chat_id, title, tasks: [{ text, is_completed? }] }`. The API wants `title`/`tasks` nested inside a single `checklist` object (`InputChecklist`), each task carrying a REQUIRED integer `id`, and there is no completion field at all (`InputChecklistTask = { id, text }`). `rawEditMessageChecklist` had the same flat-payload bug.
2. **Business-only API.** `sendChecklist` / `editMessageChecklist` also REQUIRE a `business_connection_id` — native checklists are a Telegram Business feature and cannot be sent to an ordinary bot DM/group. So even a perfect payload can never work for the chats this fleet actually uses.

## The fix — graceful degradation, not just a payload fix

New deps-injected module `telegram-plugin/gateway/checklist-fallback.ts`:

- **Native path** (only when a business connection id is configured — `SWITCHROOM_TELEGRAM_BUSINESS_CONNECTION_ID`; no fleet config plumbing for business connections exists yet): builds the CORRECT nested payload with sequential integer task ids and no `is_completed`. Native `editMessageChecklist` sends the FULL post-patch checklist (the native edit replaces it), reusing stored ids so user ticks survive.
- **Normal path** (no business connection — every current deployment): renders the checklist as a formatted text message — bold title + `✅`/`⬜` task lines (text CAN honor `done`; literal render under `parseMode: text`) — sent via the standard `robustApiCall` path. The tool result carries `degraded: "text"` + a note so the agent knows tasks are not tappable.
- **No raw 400 escapes.** A failed native send falls back to the text render; a failed edit returns a structured `{ ok: false, reason, hint }`.
- **`update_checklist`** patches a bounded per-message state store and re-renders in the mode the checklist was sent in. Lost state (gateway restart / eviction) degrades to a structured `unknown_checklist` result unless the patch is a full replacement (title + every task's text), which rebuilds.
- Tool descriptions (`bridge.ts`) and `docs/telegram-plugin.md` updated so callers are not misled about native interactivity.

Job spec: `reference/jobs/talk-to-agents-from-anywhere.md` — the Telegram surface is the product; a tool that 400s on every use in its only real deployment mode breaks it.

## Test plan

- New `telegram-plugin/tests/checklist-fallback.test.ts` (22 tests, vitest): correct Bot API 9.1 native payload shape (nested `checklist`, ids, no `is_completed`), ✅/⬜ text render incl. literal mode, patch semantics, native-failure→text fallback (no throw), unknown-state and edit-failure structured results, store eviction, `degraded:"text"` tool-result marker.
- Updated the two structural pins in `gateway-outbound-redact.test.ts` (redaction still lands BEFORE the send/edit orchestration on both paths).
- Local: scoped vitest green (58 tests across the checklist/redact suites); plugin-source `tsc --noEmit` clean (uat excluded — its mtcute type errors reproduce on pristine `origin/main` in this env); guard scripts green incl. `check-bot-api-wrapping`, `check-gateway-line-ratchet` (gateway.ts net −1 line), `check-stale-tool-descriptions`.

## Risk

- Behavior change: checklists now arrive as text messages instead of erroring — strictly better than the current 100% failure. `checklist_task_changed` events never fired for these chats before (the send always 400'd), so nothing regresses there.
- `update_checklist` state is process-local; a post-restart update returns a structured hint instead of silently failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)