### PR TITLE
fix(hostd): keep the rollout card live across a self-bump (persist narration message_id)

### DIFF
--- a/src/host-control/main.ts
+++ b/src/host-control/main.ts
@@ -198,7 +198,15 @@ async function main(): Promise<void> {
       resolveGatewaySocket,
       log: (m) => process.stderr.write(`hostd: rollout-narration — ${m}\n`),
     }),
-    { log: (m) => process.stderr.write(`hostd: rollout-narration — ${m}\n`) },
+    {
+      log: (m) => process.stderr.write(`hostd: rollout-narration — ${m}\n`),
+      // Late-bound: the narrator is built before `server` exists, but this
+      // sink only fires when a post lands (well after `server` is assigned).
+      // Persist the learned card id into the pending-rollout marker so a hostd
+      // self-bump can hand it back and the resumed roll edits the same card
+      // instead of stranding it and re-posting (#4062-adjacent).
+      onMessageId: (rid, mid) => server?.persistNarrationMessageId(rid, mid),
+    },
   );
 
   const server = new HostdServer({

--- a/src/host-control/rollout-narrator.test.ts
+++ b/src/host-control/rollout-narrator.test.ts
@@ -95,6 +95,57 @@ describe("LogTailRolloutNarrator", () => {
     expect(relay.edits.at(-1)!.text).toContain("canary");
   });
 
+  it("a seeded (post-self-bump) narrator EDITs the carried card and NEVER re-posts", async () => {
+    // Regression for the self-bump card bug: when hostd recreates itself onto
+    // the new CLI, the old process's in-memory message_id was lost, so the
+    // resumed narrator re-posted a fresh card and stranded the original frozen.
+    // Seeding the carried message_id must make the resumed roll take the EDIT
+    // branch on its very first phase — post() must never fire.
+    const relay = makeRelay(100);
+    const n = new LogTailRolloutNarrator(relay, { debounceMs: 1000 });
+    const entry = makeEntry();
+
+    // Old hostd had already posted card 4242; the new hostd carries the id.
+    n.seedPostedMessage("ro-1", "overlord", 4242);
+
+    // First phase after the self-bump.
+    n.onPhase(entry, phase("self-bump-done"));
+    await vi.advanceTimersByTimeAsync(1000);
+
+    // Subsequent agent phases through to a converged terminal.
+    n.onPhase(entry, phase("agent-start", { agent: "a", n: 1, m: 2 }));
+    n.onPhase(entry, phase("agent-done", { agent: "a", n: 1, m: 2 }));
+    await vi.advanceTimersByTimeAsync(1000);
+    n.onTerminal(makeEntry({ result: "completed", rolled: ["a", "b"] }));
+    await vi.runAllTimersAsync();
+
+    // The card was NEVER re-posted — the whole point of the fix.
+    expect(relay.posts).toHaveLength(0);
+    // Every edit landed on the carried card id, including the converged render.
+    expect(relay.edits.length).toBeGreaterThanOrEqual(1);
+    expect(relay.edits.every((e) => e.messageId === 4242)).toBe(true);
+    expect(relay.edits.at(-1)!.messageId).toBe(4242);
+    expect(relay.edits.at(-1)!.text).toContain("✅");
+  });
+
+  it("surfaces the learned message_id to the onMessageId sink exactly once on first post", async () => {
+    const relay = makeRelay(777);
+    const seen: { requestId: string; messageId: number }[] = [];
+    const n = new LogTailRolloutNarrator(relay, {
+      debounceMs: 1000,
+      onMessageId: (requestId, messageId) => seen.push({ requestId, messageId }),
+    });
+    const entry = makeEntry();
+
+    n.onPhase(entry, phase("apply"));
+    await vi.runAllTimersAsync();
+    n.onPhase(entry, phase("agent-start", { agent: "a", n: 1, m: 2 }));
+    await vi.advanceTimersByTimeAsync(1000);
+
+    // Fired once, on the post that learned the id — not on later edits.
+    expect(seen).toEqual([{ requestId: "ro-1", messageId: 777 }]);
+  });
+
   it("debounces multiple rapid phases into a single trailing-edge edit", async () => {
     const relay = makeRelay(100);
     const n = new LogTailRolloutNarrator(relay, { debounceMs: 1000 });

--- a/src/host-control/rollout-narrator.ts
+++ b/src/host-control/rollout-narrator.ts
@@ -188,6 +188,12 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
       log?: (m: string) => void;
       /** Clock seam for tests; defaults to Date.now. */
       now?: () => number;
+      /**
+       * Called once the first post lands with a real Telegram message_id, so a
+       * caller can durably persist it (into the pending-rollout marker) and let
+       * a post-self-bump resume EDIT the same card instead of re-posting.
+       */
+      onMessageId?: (requestId: string, messageId: number) => void;
     } = {},
   ) {}
 
@@ -585,28 +591,63 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
     }
   }
 
+  private freshState(agentName: string, target: string): NarrationState {
+    return {
+      agentName,
+      lastAppliedSeq: -1,
+      messageId: null,
+      posting: false,
+      postAttempts: 0,
+      postFailed: false,
+      render: { target },
+      agents: [],
+      singletons: initialSingletons(),
+      frozen: false,
+      timer: null,
+      pendingEditAfterPost: false,
+    };
+  }
+
   private ensureState(entry: StatusEntry): NarrationState {
     let st = this.states.get(entry.request_id);
     if (!st) {
       const agentName =
         entry.caller.kind === "agent" ? entry.caller.name : "";
-      st = {
-        agentName,
-        lastAppliedSeq: -1,
-        messageId: null,
-        posting: false,
-        postAttempts: 0,
-        postFailed: false,
-        render: { target: entry.pin ?? "" },
-        agents: [],
-        singletons: initialSingletons(),
-        frozen: false,
-        timer: null,
-        pendingEditAfterPost: false,
-      };
+      st = this.freshState(agentName, entry.pin ?? "");
       this.states.set(entry.request_id, st);
     }
     return st;
+  }
+
+  /**
+   * Seed a narration state that already has a posted message_id — used after a
+   * hostd self-bump so the RESUMED narrator adopts the card the OLD hostd
+   * posted (message_id carried across the recreate via the pending-rollout
+   * marker) and its first `onPhase` takes the EDIT branch instead of posting a
+   * fresh card and stranding the original. Idempotent: if a state already
+   * exists for this request (e.g. onPhase raced ahead), only backfill a still-
+   * null messageId rather than clobbering live progress.
+   */
+  seedPostedMessage(
+    requestId: string,
+    agentName: string,
+    messageId: number,
+  ): void {
+    const existing = this.states.get(requestId);
+    if (existing) {
+      if (existing.messageId === null) {
+        existing.messageId = messageId;
+        existing.posting = false;
+        existing.postFailed = false;
+        if (existing.postAttempts < 1) existing.postAttempts = 1;
+        existing.pendingEditAfterPost = false;
+      }
+      return;
+    }
+    const st = this.freshState(agentName, "");
+    st.messageId = messageId;
+    st.postAttempts = 1;
+    this.states.set(requestId, st);
   }
 
   /** Post the first message (once), then debounce edits for subsequent phases. */
@@ -671,6 +712,15 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
         }
         st.messageId = mid;
         st.postFailed = false;
+        // Surface the learned id so it can be persisted for a post-self-bump
+        // resume (best-effort; a throwing sink must not break narration).
+        try {
+          this.opts.onMessageId?.(requestId, mid);
+        } catch (e) {
+          this.opts.log?.(
+            `onMessageId sink threw (non-fatal): ${(e as Error).message}`,
+          );
+        }
         // If phases arrived while we were posting, apply the latest now.
         if (st.pendingEditAfterPost) {
           st.pendingEditAfterPost = false;

--- a/src/host-control/self-bump.test.ts
+++ b/src/host-control/self-bump.test.ts
@@ -141,6 +141,36 @@ describe("pending-rollout marker", () => {
     );
   });
 
+  it("round-trips the narration_message_id (the card carried across a self-bump)", () => {
+    const withId: PendingRolloutMarker = {
+      ...marker,
+      narration_message_id: 4242,
+    };
+    const parsed = parsePendingRolloutMarker(encodePendingRolloutMarker(withId));
+    expect(parsed).toEqual(withId);
+    expect(parsed!.narration_message_id).toBe(4242);
+  });
+
+  it.each([
+    ["non-integer", 4242.5],
+    ["zero", 0],
+    ["negative", -1],
+    ["string", "4242"],
+    ["NaN", Number.NaN],
+    ["null", null],
+  ])(
+    "drops a malformed narration_message_id (%s) WITHOUT nulling the marker — must not block resume",
+    (_label, badId) => {
+      const raw = JSON.stringify({ ...marker, narration_message_id: badId });
+      const parsed = parsePendingRolloutMarker(raw);
+      // The marker still parses — a bad id can never strand the resume.
+      expect(parsed).not.toBeNull();
+      // ...but the bad field is dropped rather than carried forward.
+      expect(parsed).toEqual(marker);
+      expect(parsed!.narration_message_id).toBeUndefined();
+    },
+  );
+
   it("round-trips the minimal (no-optionals, operator) shape", () => {
     const min: PendingRolloutMarker = {
       v: 1,

--- a/src/host-control/self-bump.ts
+++ b/src/host-control/self-bump.ts
@@ -80,6 +80,14 @@ export interface PendingRolloutMarker {
   created_at: string;
   /** The OLD hostd's own CLI version, for the audit trail. */
   prior_hostd_version: string;
+  /**
+   * Telegram message_id of the rollout progress ("narration") card the OLD
+   * hostd already posted, so the resumed narrator EDITS the same card instead
+   * of stranding it and re-posting. Optional / best-effort: if the OLD hostd
+   * was SIGKILLed before it learned the posted id, this is absent and the
+   * resume degrades to a fresh post (today's behaviour — strictly no worse).
+   */
+  narration_message_id?: number;
 }
 
 const SEMVER_PIN_RE = /^v\d+\.\d+\.\d+$/;
@@ -202,6 +210,12 @@ export function parsePendingRolloutMarker(
   if (o.allow_downgrade !== undefined && typeof o.allow_downgrade !== "boolean") {
     return null;
   }
+  // Best-effort field: a malformed narration id must NEVER null the whole
+  // marker (that would block the resume). Drop only this field and keep going.
+  const narrationIdValid =
+    typeof o.narration_message_id === "number" &&
+    Number.isInteger(o.narration_message_id) &&
+    o.narration_message_id > 0;
   return {
     v: 1,
     request_id: o.request_id,
@@ -210,6 +224,9 @@ export function parsePendingRolloutMarker(
     ...(o.skip_web !== undefined ? { skip_web: o.skip_web as boolean } : {}),
     ...(o.allow_downgrade !== undefined
       ? { allow_downgrade: o.allow_downgrade as boolean }
+      : {}),
+    ...(narrationIdValid
+      ? { narration_message_id: o.narration_message_id as number }
       : {}),
     caller:
       caller.kind === "agent"

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -329,6 +329,14 @@ export interface RolloutNarrator {
    * final entry. Freezes the surface: no later edit may un-finalize it.
    */
   onTerminal(entry: StatusEntry): void;
+  /**
+   * Seed a resumed narrator with the message_id of the card the PRE-self-bump
+   * hostd already posted (carried across the recreate in the pending-rollout
+   * marker), so the resumed roll EDITS that card rather than posting a new one
+   * and stranding the original. Optional — a narrator without it degrades to
+   * the pre-fix re-post behaviour.
+   */
+  seedPostedMessage?(requestId: string, agentName: string, messageId: number): void;
 }
 
 /**
@@ -2723,6 +2731,40 @@ export class HostdServer {
    * Runs BEFORE the sockets bind (no request can race the lock) and
    * BEFORE the orphan sweep (a resumable roll isn't an orphan).
    */
+  /**
+   * Persist the rollout narration card's Telegram message_id into the pending-
+   * rollout marker, so a hostd self-bump can hand it to the resumed narrator
+   * (which then EDITs the same card instead of re-posting a fresh one and
+   * stranding the frozen original). Wired from main.ts as the narrator's
+   * `onMessageId` sink.
+   *
+   * No-op when the marker is gone (the common case: most rolls never self-bump,
+   * so no marker exists). Atomic (`.tmp` + rename) so a SIGKILL mid-write can
+   * never leave a torn marker that would block the resume — the worst case is
+   * the id simply isn't persisted and the resume degrades to a re-post.
+   * Best-effort throughout: every failure is swallowed.
+   */
+  persistNarrationMessageId(requestId: string, messageId: number): void {
+    try {
+      if (!Number.isInteger(messageId) || messageId <= 0) return;
+      const markerPath = join(this.hostdDirPath(), SELF_BUMP_MARKER_FILENAME);
+      if (!existsSync(markerPath)) return; // no self-bump in flight — nothing to carry.
+      const marker = parsePendingRolloutMarker(readFileSync(markerPath, "utf8"));
+      if (!marker) return; // torn/foreign marker — leave it for the resume path to judge.
+      if (marker.request_id !== requestId) return; // marker is for a different roll.
+      const updated: PendingRolloutMarker = {
+        ...marker,
+        narration_message_id: messageId,
+      };
+      const tmp = `${markerPath}.tmp`;
+      writeFileSync(tmp, encodePendingRolloutMarker(updated), { mode: 0o600 });
+      renameSync(tmp, markerPath);
+    } catch {
+      // Best-effort: a failure here only means the card may re-post after a
+      // self-bump (pre-fix behaviour), never a broken roll.
+    }
+  }
+
   private async resumePendingSelfBumpRollout(): Promise<void> {
     const markerPath = join(this.hostdDirPath(), SELF_BUMP_MARKER_FILENAME);
     if (!existsSync(markerPath)) return;
@@ -2822,6 +2864,21 @@ export class HostdServer {
       caller,
       Date.now(),
     );
+    // Adopt the card the PRE-self-bump hostd posted, if we carried its id, so
+    // the resumed roll EDITS that card instead of stranding it and posting a
+    // fresh one. MUST seed BEFORE feeding the first phase below, or that phase
+    // would see a null message_id and re-post. Best-effort: absent id (helper
+    // was SIGKILLed before the reply landed) degrades to the pre-fix re-post.
+    if (
+      marker.narration_message_id !== undefined &&
+      caller.kind === "agent"
+    ) {
+      this.rolloutNarrator?.seedPostedMessage?.(
+        marker.request_id,
+        caller.name,
+        marker.narration_message_id,
+      );
+    }
     this.onRolloutPhase(entry, { phase: "self-bump-done", target: marker.pin });
   }
 


### PR DESCRIPTION
## Symptom

During a fleet rollout, when hostd **self-bumps** (recreates itself onto the new CLI to satisfy the stale-CLI preflight), the Telegram rollout progress card **stops updating**. The operator watches a frozen card while the roll actually continues — and a *second*, fresh card appears further down the chat. Two cards, one stale, for a single roll.

## Root cause

The narration card's Telegram `message_id` lived **only in the old hostd process's memory** (`LogTailRolloutNarrator`'s per-request `NarrationState.messageId`). The self-bump replaces that process. When the new hostd resumes the roll from the on-disk `pending-rollout` marker, its narrator has no `message_id`, so its first phase takes the **post** branch and creates a new card — stranding the original, which is now frozen because no process will ever edit it again.

## Fix

Persist the card's `message_id` across the self-bump through the same durable channel that already carries the roll — the `pending-rollout` marker — so the resumed narrator **adopts** the card and **edits** it.

- **`src/host-control/self-bump.ts`** — `PendingRolloutMarker` gains an optional `narration_message_id`. `parsePendingRolloutMarker` validates and round-trips it, and — critically — **drops only that field** (never nulls the whole marker) when it's malformed, so a bad id can never block the resume.
- **`src/host-control/rollout-narrator.ts`** — an `onMessageId` sink surfaces the learned id the moment the first post lands; a new public `seedPostedMessage(requestId, agentName, messageId)` installs a `NarrationState` with `messageId` pre-set so the resumed narrator's first `onPhase` takes the **edit** branch instead of re-posting.
- **`src/host-control/server.ts`** — `persistNarrationMessageId()` writes the learned id into the marker **atomically** (`.tmp` + `rename`); `resumePendingSelfBumpRollout()` seeds the narrator with the carried id **before** feeding the first phase, so the first edit reuses the card.
- **`src/host-control/main.ts`** — wires `onMessageId → server.persistNarrationMessageId` (late-bound, since the narrator is constructed before the server object).

## Known race — strictly no worse than today

The post is fire-and-forget: if the `SIGKILL` from the self-bump recreate lands **before** the post-reply `message_id` is learned, the id isn't persisted and the resume degrades to **today's** behaviour (a fresh post). That is the pre-existing floor, never a regression. And because the marker rewrite is atomic (`.tmp` + `rename`), a kill mid-write can never leave a torn marker that would block the resume — the worst case is simply that the id isn't carried.

## Tests (assert outcomes; both fail on the pre-fix bug)

- `rollout-narrator.test.ts`: a **seeded** (post-self-bump) narrator EDITs the carried card (`message_id: 4242`) through to the converged terminal and **never** calls `post()`. Plus: the `onMessageId` sink fires exactly once, on the post that learns the id.
- `self-bump.test.ts`: the marker **round-trips** `narration_message_id`; and a marker with a **malformed** `narration_message_id` (non-integer / zero / negative / string / NaN / null) still parses OK with the field dropped — proving the don't-block-resume guard.

Verified failing on a pre-fix simulation (un-seeded narrator re-posts; parse drops the round-tripped id), then green after the fix. `tsc --noEmit` clean; all 203 `src/host-control` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)