### PR TITLE
fix(vault): stop stripping decision_id from approval_consume_record replies (response-union order)

### DIFF
--- a/src/vault/broker/protocol.test.ts
+++ b/src/vault/broker/protocol.test.ts
@@ -85,6 +85,62 @@ describe("encodeResponse / decodeResponse roundtrip", () => {
   }
 });
 
+// ─── Response union ordering (#4069) ───────────────────────────────────────
+//
+// ResponseSchema is a plain z.union: first match wins and zod objects strip
+// unknown keys. OkApprovalConsumeResponse is a structural prefix of
+// OkApprovalConsumeRecordResponse, so if Consume is ordered before
+// ConsumeRecord, an approval_consume_record reply matches the Consume schema
+// and `decision_id` is silently stripped — the gateway then false-toasts
+// "kernel record failed" on every approval tap. These tests go through the
+// REAL decodeResponse (the kernel tests use raw JSON.parse and missed this).
+
+describe("response union ordering: approval_consume_record vs approval_consume (#4069)", () => {
+  it("preserves decision_id on a consume_record reply", () => {
+    const wire = JSON.stringify({
+      ok: true,
+      consumed: true,
+      decision_id: "dec-123",
+      agent_unit: "clerk",
+      scope: "ms365:calendar:write",
+      action: "update-calendar-event",
+      why: null,
+    });
+    const decoded = decodeResponse(wire) as Record<string, unknown>;
+    expect(decoded.ok).toBe(true);
+    expect(decoded.consumed).toBe(true);
+    // The load-bearing assertion: decision_id must survive the union.
+    expect(decoded.decision_id).toBe("dec-123");
+    expect(decoded.scope).toBe("ms365:calendar:write");
+  });
+
+  it("still decodes a plain consume reply (no decision_id) losslessly", () => {
+    const resp = {
+      ok: true,
+      consumed: true,
+      agent_unit: "clerk",
+      scope: "drive:file:read",
+      action: "read",
+      why: "user asked",
+    };
+    const decoded = decodeResponse(JSON.stringify(resp));
+    expect(decoded).toEqual(resp);
+  });
+
+  it("still decodes a consumed:false reply (burned/expired nonce)", () => {
+    const decoded = decodeResponse(JSON.stringify({ ok: true, consumed: false }));
+    expect(decoded).toEqual({ ok: true, consumed: false });
+  });
+
+  it("still routes a plain approval_record reply to its own schema", () => {
+    // {ok, decision_id} lacks `consumed`, so it must NOT be swallowed
+    // (or rejected) by the ConsumeRecord schema ordered ahead of it.
+    const resp = { ok: true, decision_id: "dec-456" };
+    const decoded = decodeResponse(JSON.stringify(resp));
+    expect(decoded).toEqual(resp);
+  });
+});
+
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
 describe("errorResponse helper", () => {

--- a/src/vault/broker/protocol.ts
+++ b/src/vault/broker/protocol.ts
@@ -643,11 +643,21 @@ export const ResponseSchema = z.union([
   OkRevokeGrantResponseSchema,
   OkApprovalRequestResponseSchema,
   OkApprovalLookupResponseSchema,
+  // ORDER MATTERS: ConsumeRecord MUST precede Consume. This is a plain
+  // z.union (first-match wins) and zod objects strip unknown keys, so if
+  // Consume came first it would match a consume_record reply (Consume's
+  // shape is a structural prefix) and silently strip `decision_id` —
+  // the gateway then false-toasts "kernel record failed" on every
+  // approval tap (#4069). The reverse order is safe: ConsumeRecord's
+  // only extra field (`decision_id`) is optional, so a plain consume
+  // reply still parses losslessly; and a plain approval_record reply
+  // ({ok, decision_id}) lacks the required `consumed`, so it falls
+  // through to OkApprovalRecordResponseSchema as before.
+  OkApprovalConsumeRecordResponseSchema,
   OkApprovalConsumeResponseSchema,
   OkApprovalRevokeResponseSchema,
   OkApprovalListResponseSchema,
   OkApprovalRecordResponseSchema,
-  OkApprovalConsumeRecordResponseSchema,
   ErrorResponseSchema,
 ]);
 

--- a/telegram-plugin/gateway/approval-callback-consume-record.test.ts
+++ b/telegram-plugin/gateway/approval-callback-consume-record.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Regression test for #4069 — the "kernel record failed" false toast.
+ *
+ * The kernel's approval_consume_record reply carries `decision_id`, but
+ * the client decodes every reply through ResponseSchema (a plain
+ * z.union, first-match wins, unknown keys stripped). With
+ * OkApprovalConsumeResponseSchema ordered before
+ * OkApprovalConsumeRecordResponseSchema, the consume_record reply
+ * matched the prefix schema and `decision_id` was silently stripped —
+ * so handleApprovalCallback hit its defensive `!result.decision_id`
+ * branch, toasted "kernel record failed", and returned before editing
+ * the card to its granted state. Deterministic on EVERY `apv:` approval
+ * tap. The audit row was never lost — the kernel committed it — this
+ * was purely the client's mangled view of the reply.
+ *
+ * This test drives handleApprovalCallback end-to-end against a fake
+ * kernel serving a REAL wire frame through the REAL
+ * rpcRaw/decodeResponse path (the kernel suites parse the wire with raw
+ * JSON.parse and bypass decodeResponse — which is exactly why they
+ * missed this). It asserts the tap lands: no "kernel record failed"
+ * toast, and the card advances to its granted body carrying the
+ * decision_id revoke hint.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import * as net from "node:net";
+import * as os from "node:os";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { Context } from "grammy";
+import { handleApprovalCallback } from "./approval-callback.js";
+
+const REQUEST_ID = "0123456789abcdef0123456789abcdef";
+const DECISION_ID = "dec-4069";
+
+/** One-shot fake kernel: replies to the first request line with `reply`. */
+function startFakeKernel(
+  socketPath: string,
+  reply: Record<string, unknown>,
+  seen: string[],
+): Promise<net.Server> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer((conn) => {
+      let buf = "";
+      conn.on("data", (chunk) => {
+        buf += chunk.toString("utf8");
+        const idx = buf.indexOf("\n");
+        if (idx === -1) return;
+        seen.push(buf.slice(0, idx));
+        conn.write(JSON.stringify(reply) + "\n");
+      });
+    });
+    server.on("error", reject);
+    server.listen(socketPath, () => resolve(server));
+  });
+}
+
+function makeFakeCtx(): {
+  ctx: Context;
+  toasts: string[];
+  edits: Array<{ markdown: string }>;
+} {
+  const toasts: string[] = [];
+  const edits: Array<{ markdown: string }> = [];
+  const ctx = {
+    from: { id: 42 },
+    answerCallbackQuery: async (args?: { text?: string }) => {
+      toasts.push(args?.text ?? "");
+      return true;
+    },
+    editMessageText: async (body: { markdown: string }) => {
+      edits.push(body);
+      return true;
+    },
+  } as unknown as Context;
+  return { ctx, toasts, edits };
+}
+
+describe("handleApprovalCallback × real decodeResponse (#4069)", () => {
+  let server: net.Server | undefined;
+  let tmpDir: string | undefined;
+  const savedEnv = process.env.SWITCHROOM_KERNEL_SOCKET;
+
+  afterEach(async () => {
+    if (server) await new Promise((r) => server!.close(r));
+    server = undefined;
+    if (savedEnv === undefined) delete process.env.SWITCHROOM_KERNEL_SOCKET;
+    else process.env.SWITCHROOM_KERNEL_SOCKET = savedEnv;
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = undefined;
+  });
+
+  it("approve tap records + advances the card — no false 'kernel record failed'", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sr4069-"));
+    const socketPath = path.join(tmpDir, "kernel.sock");
+    const seen: string[] = [];
+    server = await startFakeKernel(
+      socketPath,
+      {
+        ok: true,
+        consumed: true,
+        decision_id: DECISION_ID,
+        agent_unit: "clerk",
+        scope: "doc:gdrive:D1",
+        action: "write",
+        why: null,
+      },
+      seen,
+    );
+    process.env.SWITCHROOM_KERNEL_SOCKET = socketPath;
+
+    const { ctx, toasts, edits } = makeFakeCtx();
+    await handleApprovalCallback(ctx, `apv:${REQUEST_ID}:once`);
+
+    // The fake kernel really received the atomic consume+record op.
+    expect(seen.length).toBe(1);
+    expect(JSON.parse(seen[0]!)).toMatchObject({
+      op: "approval_consume_record",
+      request_id: REQUEST_ID,
+      decision: "allow_once",
+    });
+
+    // Outcome: the tap must land as Approved, never the false-failure
+    // toast, and the card must advance to its granted body carrying the
+    // decision_id revoke hint.
+    expect(toasts).not.toContain("kernel record failed");
+    expect(toasts).toContain("Approved");
+    expect(edits.length).toBe(1);
+    expect(edits[0]!.markdown).toContain(DECISION_ID);
+    expect(edits[0]!.markdown).toContain("granted once");
+  });
+});


### PR DESCRIPTION
Fixes #4069

## The bug

`ResponseSchema` in `src/vault/broker/protocol.ts` is a **plain `z.union`**: zod v3 returns the FIRST matching member, and zod objects **strip unknown keys**. `OkApprovalConsumeResponseSchema` (no `decision_id`) is a structural prefix of `OkApprovalConsumeRecordResponseSchema` (has optional `decision_id`) and was ordered before it.

So on every operator Approve tap, the kernel's `approval_consume_record` reply — `{ok, consumed:true, decision_id, scope, …}` — matched the earlier consume schema at `decodeResponse`, and `decision_id` was **silently stripped**. The gateway's defensive `!result.decision_id` branch (`telegram-plugin/gateway/approval-callback.ts`) then toasted the false failure `kernel record failed` and returned early, before editing the card to its granted state.

This fired **deterministically on every `apv:` approval tap** (Drive + MS-365) since PR #1545 (`d02520da`) introduced the atomic consume+record op.

**Correcting the issue's premise:** the approval decision + audit rows were never lost. The kernel commits them in one SQLite transaction and they are durable — only the *client's decoded view* of the reply was mangled, so the failure toast was false and the card never advanced.

## The fix

Reorder the union so `OkApprovalConsumeRecordResponseSchema` precedes `OkApprovalConsumeResponseSchema`, with a load-bearing ORDER MATTERS comment. The reorder is safe in both directions because `ConsumeRecord`'s only extra field (`decision_id`) is **optional**:

- a plain `approval_consume` reply (no `decision_id`) still parses losslessly through `ConsumeRecord` (identical field set);
- a plain `approval_record` reply (`{ok, decision_id}`) lacks the required `consumed`, fails `ConsumeRecord`, and still falls through to `OkApprovalRecordResponseSchema` — the deferred-secret / `/vault-grant` dual-dispatch and `/folders` paths are unaffected (covered by a test).

## Regression tests (red on the pre-fix order, green after)

Existing kernel suites parse the wire with raw `JSON.parse` and bypass `decodeResponse` — which is exactly why they missed this. The new tests go through the REAL decode path:

- `src/vault/broker/protocol.test.ts` — decode-level: `decision_id` survives a consume_record reply (**fails on main**: `expected undefined to be 'dec-123'`); plain consume, `consumed:false`, and plain `approval_record` replies stay lossless.
- `telegram-plugin/gateway/approval-callback-consume-record.test.ts` — gateway-level: drives `handleApprovalCallback` end-to-end against a fake kernel unix socket serving a real wire frame through the real `rpcRaw`/`decodeResponse`; asserts no `kernel record failed` toast, an `Approved` toast, and the card edit carries the `decision_id` revoke hint (**fails on main** with the false toast).

## Adversarial review of other union consumers

Checked every op whose reply schema is a structural prefix/superset of another member: `approval_record` vs `consume_record` (covered above + test), `revoke_grant` vs `approval_revoke` (identical `{ok, revoked}` shapes — lossless either way), `approval_request` vs `approval_lookup` (discriminated by `kind`/`state` values). `src/auth/broker` and `src/host-control` have their own separate protocol modules — untouched. Only `src/vault/broker/client.ts` decodes through this union.

Scoped runs: vitest on `src/vault/broker/`, `src/vault/approvals/`, gateway approval tests (263 pass); `bun test` on the bun:sqlite kernel suites (55 pass); `tsc --noEmit` clean; gateway line-ratchet, test-runner coverage, bun-test-imports, attribution-trailer checks clean.

## Follow-up

The durable kill-the-bug-class fix is per-op response validation / a discriminated union with an echoed `op` field — filed as a follow-up issue (wire-affecting, out of scope for this hotfix). Post-fix, the defensive `!result.decision_id` branch in `approval-callback.ts` is dead-in-practice but kept as cheap defense in depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)