### PR TITLE
fix(memory): single-source config resolution + observation-scope settings.json mirror (#3914, #3915)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3147,7 +3147,16 @@ export function installHindsightPlugin(
   if (!memory) return null;
 
   const agentMemory = switchroomConfig.agents[agentName]?.memory;
-  if (agentMemory?.auto_recall === false) return null;
+  // auto_recall from the CASCADED config (defaults → profile → agent), NOT the
+  // raw per-agent map entry: a fleet-wide `defaults.memory.auto_recall: false`
+  // or a profile-tier opt-out must disable the plugin too. Reading the raw
+  // `agents[name].memory.auto_recall` here silently dropped both tiers (#3914),
+  // installing the plugin for an agent the operator had turned recall off for.
+  // resolveHindsightRecallConfig documents why re-deriving from the raw entry is
+  // not equivalent to the caller's already-cascaded config.
+  if (resolveHindsightAutoRecall(switchroomConfig, agentName, resolvedAgentConfig) === false) {
+    return null;
+  }
 
   const sourcePath = resolveHindsightVendorPath();
   if (!existsSync(sourcePath)) {
@@ -3181,7 +3190,25 @@ export function installHindsightPlugin(
   // in the env-export path (see resolveHindsightRetainConfig). These drive
   // the stamped settings.json values below, so a switchroom.yaml
   // `memory.retain.*` override is authoritative and survives reconcile.
-  const retainConfig = resolveHindsightRetainConfig(switchroomConfig, agentName);
+  const retainConfig = resolveHindsightRetainConfig(
+    switchroomConfig,
+    agentName,
+    resolvedAgentConfig,
+  );
+  // Per-row observation scope + per-retain strategy, from the CASCADED config.
+  // These MUST be mirrored into the deployed settings.json (below), not left to
+  // the start.sh env export alone: start.sh only exports HINDSIGHT_OBSERVATION_*
+  // into the supervised claude session, so a docker-exec'd backfill/drain that
+  // does NOT inherit that env falls back to the vendor settings.json default
+  // (scope None / strategy "curated") and silently retains under the WRONG scope
+  // (#3915). Stamping settings.json makes the supervised and exec'd processes
+  // resolve identically — config.py reads settings.json first, env overrides it
+  // with the same value in the supervised case.
+  const observationScopeSettings = resolveHindsightObservationScopeSettings(
+    switchroomConfig,
+    agentName,
+    resolvedAgentConfig,
+  );
   // Recall latency envelope (hook ceiling / parallel deadline / per-bank
   // timeout) from the CASCADED config. Stamped onto the deployed plugin below
   // so `switchroom apply` RE-ASSERTS these values instead of reverting them —
@@ -3198,6 +3225,7 @@ export function installHindsightPlugin(
         additionalBanks,
         retainConfig,
         recallTunables,
+        observationScopeSettings,
       );
       if (expectedSettings != null) contentOverrides["settings.json"] = expectedSettings;
     }
@@ -3255,7 +3283,13 @@ export function installHindsightPlugin(
   // per-agent value. Now also folds in the `knows`-assigned user/bank profiles
   // (user concept, RFC reference/rfcs/user-concept.md); resolveUsers() handles
   // the cascade + union (defaults ∪ agent, generated ∪ explicit) itself.
-  applyHindsightSettingsOverrides(destPath, additionalBanks, retainConfig, recallTunables);
+  applyHindsightSettingsOverrides(
+    destPath,
+    additionalBanks,
+    retainConfig,
+    recallTunables,
+    observationScopeSettings,
+  );
   // Stamp the UserPromptSubmit recall-hook ceiling into the deployed
   // hooks/hooks.json. Claude Code reads this file directly and does NOT expand
   // env vars in the `timeout` field, so unlike the settings.json knobs there is
@@ -3300,21 +3334,90 @@ interface HindsightRetainConfig {
 function resolveHindsightRetainConfig(
   switchroomConfig: SwitchroomConfig | undefined,
   agentName: string,
+  /**
+   * The caller's already-cascaded agent config, when it has one. Preferred over
+   * re-deriving for the SAME reason as resolveHindsightRecallConfig: the fallback
+   * below resolves the `defaults:` tier ONLY (an empty stand-in carries no
+   * `extends:`), so re-deriving there silently drops any
+   * `profiles.<name>.memory.retain.*`. Both production callers thread it (#3914).
+   */
+  resolvedAgentConfig?: AgentConfig,
 ): HindsightRetainConfig {
-  const resolved = switchroomConfig
-    ? resolveAgentConfig(
-        switchroomConfig.defaults,
-        switchroomConfig.profiles,
-        // Some scaffold paths install the plugin for an agent that isn't in
-        // the `agents` map yet (fresh scaffold); resolve against an empty
-        // agent so the defaults/profile tiers still apply.
-        switchroomConfig.agents[agentName] ?? ({} as AgentConfig),
-      )
-    : undefined;
-  const retain = resolved?.memory?.retain;
+  const retain = resolvedAgentConfig
+    ? resolvedAgentConfig.memory?.retain
+    : switchroomConfig
+      ? resolveAgentConfig(
+          switchroomConfig.defaults,
+          switchroomConfig.profiles,
+          // Some scaffold paths install the plugin for an agent that isn't in
+          // the `agents` map yet (fresh scaffold); resolve against an empty
+          // agent so the defaults tier still applies.
+          switchroomConfig.agents[agentName] ?? ({} as AgentConfig),
+        )?.memory?.retain
+      : undefined;
   return {
     everyNTurns: retain?.every_n_turns ?? HINDSIGHT_DEFAULT_RETAIN_EVERY_N_TURNS,
     overlapTurns: retain?.overlap_turns ?? HINDSIGHT_DEFAULT_RETAIN_OVERLAP_TURNS,
+  };
+}
+
+/**
+ * Resolve the effective `memory.auto_recall` for an agent, honouring the full
+ * cascade (defaults → profile → agent). Mirrors resolveHindsightRecallConfig:
+ * prefer the caller's already-cascaded config; fall back to re-deriving for
+ * config-free callers (whose fallback resolves the `defaults:` tier only — an
+ * empty stand-in carries no `extends:`).
+ */
+function resolveHindsightAutoRecall(
+  switchroomConfig: SwitchroomConfig | undefined,
+  agentName: string,
+  resolvedAgentConfig?: AgentConfig,
+): boolean | undefined {
+  if (resolvedAgentConfig) return resolvedAgentConfig.memory?.auto_recall;
+  if (!switchroomConfig) return undefined;
+  return resolveAgentConfig(
+    switchroomConfig.defaults,
+    switchroomConfig.profiles,
+    switchroomConfig.agents[agentName] ?? ({} as AgentConfig),
+  )?.memory?.auto_recall;
+}
+
+/**
+ * The per-row observation scope pin (`memory.observation_scopes`) and the
+ * per-retain strategy (`memory.observation_scope_strategy`), resolved from the
+ * CASCADED config. `undefined` for a field means "operator set nothing" — the
+ * stamp leaves the vendor default in place, exactly as start.sh emits no env
+ * export in that case.
+ */
+interface HindsightObservationScopeSettings {
+  observationScopes?: string;
+  observationScopeStrategy?: string;
+}
+
+/**
+ * Resolve the observation-scope settings for an agent, honouring the cascade
+ * (defaults → profile → agent). Same prefer-cascaded / fallback-re-derive shape
+ * as resolveHindsightRetainConfig; feeds the settings.json mirror so a
+ * docker-exec'd retain resolves the same scope the supervised session does
+ * (#3915).
+ */
+function resolveHindsightObservationScopeSettings(
+  switchroomConfig: SwitchroomConfig | undefined,
+  agentName: string,
+  resolvedAgentConfig?: AgentConfig,
+): HindsightObservationScopeSettings {
+  const memory = resolvedAgentConfig
+    ? resolvedAgentConfig.memory
+    : switchroomConfig
+      ? resolveAgentConfig(
+          switchroomConfig.defaults,
+          switchroomConfig.profiles,
+          switchroomConfig.agents[agentName] ?? ({} as AgentConfig),
+        )?.memory
+      : undefined;
+  return {
+    observationScopes: memory?.observation_scopes,
+    observationScopeStrategy: memory?.observation_scope_strategy,
   };
 }
 
@@ -3440,6 +3543,7 @@ function applyHindsightSettingsOverrides(
   additionalBanks: readonly string[],
   retainConfig: HindsightRetainConfig,
   recallTunables: HindsightRecallTunables,
+  observationScopeSettings: HindsightObservationScopeSettings,
 ): void {
   const settingsPath = join(pluginDestPath, "settings.json");
   if (!existsSync(settingsPath)) return; // vendor structure changed; bail safely
@@ -3454,6 +3558,7 @@ function applyHindsightSettingsOverrides(
     additionalBanks,
     retainConfig,
     recallTunables,
+    observationScopeSettings,
   );
   if (next == null) return; // malformed settings; don't make it worse
   writeFileSyncIfChanged(settingsPath, next);
@@ -3472,6 +3577,7 @@ function renderHindsightSettingsOverrides(
   additionalBanks: readonly string[],
   retainConfig: HindsightRetainConfig,
   recallTunables: HindsightRecallTunables,
+  observationScopeSettings: HindsightObservationScopeSettings,
 ): string | null {
   let settings: Record<string, unknown>;
   try {
@@ -3641,6 +3747,31 @@ function renderHindsightSettingsOverrides(
   // recall to specific tags), currently dormant"; an operator who has such a
   // taxonomy in their own bank can now express it in switchroom.yaml instead of
   // hand-editing the installed plugin, and one who does not is unaffected.
+  // Per-row observation scope pin + per-retain strategy (#3915). Mirror the
+  // CASCADED config into the deployed settings.json so a docker-exec'd retain —
+  // a `backfill_transcripts.py` / consolidation drain that does NOT inherit the
+  // supervised session's start.sh env exports — resolves the SAME scope the
+  // supervised session does. config.py loads settings.json first and lets the
+  // HINDSIGHT_OBSERVATION_* env override it, so in the supervised case the two
+  // channels carry the identical value; in the exec'd case settings.json is the
+  // only channel, and before this it silently fell back to the vendor default
+  // (scope None / strategy "curated") — retaining under the wrong scope.
+  //
+  // Stamp ONLY when the operator set the value, byte-for-byte matching start.sh's
+  // "export only when set" semantics: an unset field leaves the vendor default
+  // (config.py: observationScopes None, observationScopeStrategy "curated"), so
+  // an agent that configured neither is unchanged and the field never reaches
+  // the wire. No re-validation here — the schema already rejects off-list values
+  // at parse time, and matching start.sh's raw passthrough is what keeps the two
+  // channels provably identical.
+  const observationScopes = observationScopeSettings.observationScopes;
+  if (typeof observationScopes === "string" && observationScopes.length > 0) {
+    settings.observationScopes = observationScopes;
+  }
+  const observationScopeStrategy = observationScopeSettings.observationScopeStrategy;
+  if (typeof observationScopeStrategy === "string" && observationScopeStrategy.length > 0) {
+    settings.observationScopeStrategy = observationScopeStrategy;
+  }
   return JSON.stringify(settings, null, 2) + "\n";
 }
 
@@ -5278,9 +5409,12 @@ export function scaffoldAgent(
       // get dueling instructions (write to local .md files vs use
       // Hindsight). The settings flag gates the memory system-prompt
       // block at the source.
-      const hindsightOn = isHindsightEnabled(switchroomConfig)
-        && switchroomConfig.agents[name]?.memory?.auto_recall !== false;
-      if (hindsightOn) {
+      // Use the CASCADED gate computed above, not a re-read of the raw
+      // `agents[name].memory.auto_recall`: this and installHindsightPlugin must
+      // agree, or an agent with a defaults/profile-tier `auto_recall: false`
+      // would get the plugin skipped (correct) yet keep Claude Code's built-in
+      // auto-memory disabled here (wrong) — the exact split #3914 is about.
+      if (hindsightAutoRecallEnabled) {
         settings.autoMemoryEnabled = false;
       }
 

--- a/tests/scaffold.memory-cascade.test.ts
+++ b/tests/scaffold.memory-cascade.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent, installHindsightPlugin } from "../src/agents/scaffold.js";
+import { resolveAgentConfig } from "../src/config/merge.js";
+import type { SwitchroomConfig, AgentConfig, TelegramConfig } from "../src/config/schema.js";
+
+/**
+ * #3914 — memory config resolution must go through the SAME cascade
+ * (defaults → profile → agent) the rest of switchroom uses, not a raw read of
+ * the per-agent `agents[name].memory` map entry.
+ *
+ * Two reads inside installHindsightPlugin bypassed it:
+ *   - `auto_recall` was read RAW, so a fleet-wide `defaults.memory.auto_recall:
+ *     false` or a profile-tier opt-out did NOT disable the plugin — it installed
+ *     anyway, against the operator's fleet-wide intent.
+ *   - the retain cadence resolver ignored the caller's already-cascaded config
+ *     and re-derived, so it read a DIFFERENT object whenever the raw config the
+ *     caller resolved was not literally the map entry (the divergence
+ *     resolveHindsightRecallConfig's doc-comment describes).
+ *
+ * These assert the OUTCOME (plugin installed-or-not; the stamped cadence), so
+ * each one fails on the pre-fix raw read rather than merely exercising it.
+ */
+const PLUGIN_REL = [".claude", "plugins", "hindsight-memory"] as const;
+
+function baseConfig(partial: Partial<SwitchroomConfig>): SwitchroomConfig {
+  return {
+    memory: { backend: "hindsight", config: { url: "http://localhost:18888/mcp/" } },
+    telegram: { bot_token: "t", forum_chat_id: "c" },
+    agents: {},
+    ...partial,
+  } as SwitchroomConfig;
+}
+
+/** The fully-cascaded config a production caller threads as resolvedAgentConfig. */
+function cascade(config: SwitchroomConfig, name: string): AgentConfig {
+  return resolveAgentConfig(config.defaults, config.profiles, config.agents[name] ?? {});
+}
+
+describe("auto_recall honours the full cascade (#3914)", () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `mem-cascade-ar-${Date.now()}-${Math.floor(Math.random() * 1e6)}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+  afterEach(() => {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("a defaults-tier auto_recall:false disables the plugin (null install)", () => {
+    // Raw read of agents.probe.memory.auto_recall was undefined here, so the
+    // pre-fix code installed the plugin against a fleet-wide opt-out.
+    const config = baseConfig({
+      defaults: { memory: { auto_recall: false } },
+      agents: { probe: {} },
+    });
+    expect(installHindsightPlugin("probe", tmpDir, config, cascade(config, "probe"))).toBeNull();
+  });
+
+  it("a profile-tier auto_recall:false disables the plugin (null install)", () => {
+    const config = baseConfig({
+      profiles: { silent: { memory: { auto_recall: false } } } as never,
+      agents: { probe: { extends: "silent" } } as never,
+    });
+    expect(installHindsightPlugin("probe", tmpDir, config, cascade(config, "probe"))).toBeNull();
+  });
+
+  it("still installs when no tier opts out (control)", () => {
+    const config = baseConfig({ agents: { probe: {} } });
+    expect(installHindsightPlugin("probe", tmpDir, config, cascade(config, "probe"))).not.toBeNull();
+  });
+
+  it("a per-agent auto_recall:false still disables it (existing behaviour preserved)", () => {
+    const config = baseConfig({
+      agents: { probe: { memory: { auto_recall: false } } } as never,
+    });
+    expect(installHindsightPlugin("probe", tmpDir, config, cascade(config, "probe"))).toBeNull();
+  });
+
+  it("end-to-end: a defaults-tier opt-out installs no plugin AND leaves built-in memory on", () => {
+    // The scaffoldAgent-side gate (settings.autoMemoryEnabled) must agree with
+    // installHindsightPlugin: recall off ⇒ no plugin ⇒ do NOT disable Claude
+    // Code's own auto-memory. Before the fix the plugin gate was cascaded but
+    // the autoMemory gate re-read the raw map, so they split.
+    const config = baseConfig({
+      defaults: { memory: { auto_recall: false } },
+      agents: { probe: {} },
+    });
+    const res = scaffoldAgent("probe", config.agents.probe ?? {}, tmpDir, config.telegram, config);
+    expect(existsSync(join(res.agentDir, ...PLUGIN_REL, "settings.json"))).toBe(false);
+    const agentSettings = JSON.parse(
+      readFileSync(join(res.agentDir, ".claude", "settings.json"), "utf-8"),
+    ) as Record<string, unknown>;
+    expect(agentSettings.autoMemoryEnabled).not.toBe(false);
+  });
+});
+
+describe("retain cadence honours the threaded cascaded config (#3914)", () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `mem-cascade-rt-${Date.now()}-${Math.floor(Math.random() * 1e6)}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+  afterEach(() => {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const settingsPath = () => join(tmpDir, ...PLUGIN_REL, "settings.json");
+  const readSettings = () =>
+    JSON.parse(readFileSync(settingsPath(), "utf-8")) as Record<string, unknown>;
+
+  it("the threaded cascaded config WINS over the raw agents[name] map entry", () => {
+    // The map entry says every-2; the cascaded config the caller resolved says
+    // every-9. The pre-fix resolver re-derived from the map and stamped 2,
+    // ignoring the value the env-export path was built from — the two channels
+    // diverge. Threading the cascaded config is what keeps them one source.
+    const config = baseConfig({
+      agents: { probe: { memory: { retain: { every_n_turns: 2, overlap_turns: 1 } } } } as never,
+    });
+    const resolved = {
+      memory: { retain: { every_n_turns: 9, overlap_turns: 3 } },
+    } as unknown as AgentConfig;
+    installHindsightPlugin("probe", tmpDir, config, resolved);
+    const s = readSettings();
+    expect(s.retainEveryNTurns).toBe(9);
+    expect(s.retainOverlapTurns).toBe(3);
+  });
+
+  it("end-to-end: a profile-tier retain cadence lands in the deployed settings.json", () => {
+    const config = baseConfig({
+      profiles: { chatty: { memory: { retain: { every_n_turns: 7, overlap_turns: 4 } } } } as never,
+      agents: { probe: { extends: "chatty" } } as never,
+    });
+    const res = scaffoldAgent("probe", config.agents.probe ?? {}, tmpDir, config.telegram, config);
+    const s = JSON.parse(
+      readFileSync(join(res.agentDir, ...PLUGIN_REL, "settings.json"), "utf-8"),
+    ) as Record<string, unknown>;
+    expect(s.retainEveryNTurns).toBe(7);
+    expect(s.retainOverlapTurns).toBe(4);
+  });
+});

--- a/tests/scaffold.observation-scopes.test.ts
+++ b/tests/scaffold.observation-scopes.test.ts
@@ -158,6 +158,112 @@ describe("memory.observation_scopes plumbing", () => {
       expect(reconciled).not.toMatch(/HINDSIGHT_OBSERVATION_SCOPES/);
     });
   });
+
+  /**
+   * #3915 — the settings.json mirror, the OTHER channel.
+   *
+   * start.sh exports HINDSIGHT_OBSERVATION_SCOPES / _STRATEGY into the
+   * SUPERVISED claude session only. A docker-exec'd retain — a
+   * `backfill_transcripts.py` slice, a consolidation drain, `hostd agent_exec` —
+   * does NOT inherit that env, so `lib/config.load_config` falls back to the
+   * plugin's settings.json. Left unmirrored, settings.json carried the vendor
+   * default (scope None / strategy "curated") and the exec'd process retained
+   * under the WRONG scope — silent bank corruption during a reconsolidation.
+   *
+   * So the load-bearing assertion is not "the value reaches start.sh" (the
+   * describe above) but "the value is ALSO in the deployed settings.json, so the
+   * two channels resolve identically". These read the deployed plugin file that
+   * the env-less exec path actually consults.
+   */
+  describe("settings.json mirror for docker-exec'd retains (#3915)", () => {
+    const PLUGIN_REL = [".claude", "plugins", "hindsight-memory", "settings.json"] as const;
+
+    function deployedSettings(
+      memory: Record<string, unknown> | undefined,
+    ): Record<string, unknown> {
+      const config = configFor(memory);
+      const res = scaffoldAgent("probe", config.agents.probe ?? {}, tmpDir, telegram, config);
+      return JSON.parse(
+        readFileSync(join(res.agentDir, ...PLUGIN_REL), "utf-8"),
+      ) as Record<string, unknown>;
+    }
+
+    it("stamps the configured scope + strategy into the file the env-less path reads", () => {
+      // The bug: before the mirror these keys were absent, so an exec'd retain
+      // resolved the vendor default instead of the operator's scope.
+      const s = deployedSettings({
+        observation_scopes: "shared",
+        observation_scope_strategy: "shared",
+      });
+      expect(s.observationScopes).toBe("shared");
+      expect(s.observationScopeStrategy).toBe("shared");
+    });
+
+    it("stamps a strategy-only config (no manual pin) too", () => {
+      const s = deployedSettings({ observation_scope_strategy: "combined" });
+      expect(s.observationScopeStrategy).toBe("combined");
+      // No pin set → no scope key, so the strategy is what decides the scope.
+      expect("observationScopes" in s).toBe(false);
+    });
+
+    it("unset leaves NO observation keys — the vendor default (None/curated) stands", () => {
+      // Over-stamping would change the wire for every agent that configured
+      // nothing; the field must stay absent so config.py keeps its own default.
+      const s = deployedSettings(undefined);
+      expect("observationScopes" in s).toBe(false);
+      expect("observationScopeStrategy" in s).toBe(false);
+    });
+
+    it("an unrelated memory block still stamps NO observation keys", () => {
+      const s = deployedSettings({ collection: "probe" });
+      expect("observationScopes" in s).toBe(false);
+      expect("observationScopeStrategy" in s).toBe(false);
+    });
+
+    it("the settings.json value is BYTE-IDENTICAL to what start.sh exports", () => {
+      // The whole point of the mirror is that the supervised env channel and the
+      // exec'd settings.json channel carry the SAME value. Assert both at once so
+      // a future edit to one cannot silently diverge from the other.
+      const memory = { observation_scopes: "shared", observation_scope_strategy: "shared" };
+      const config = configFor(memory);
+      const res = scaffoldAgent("probe", config.agents.probe ?? {}, tmpDir, telegram, config);
+      const startSh = readFileSync(join(res.agentDir, "start.sh"), "utf-8");
+      const s = JSON.parse(
+        readFileSync(join(res.agentDir, ...PLUGIN_REL), "utf-8"),
+      ) as Record<string, unknown>;
+      expect(startSh).toMatch(/export HINDSIGHT_OBSERVATION_SCOPES='shared'/);
+      expect(startSh).toMatch(/export HINDSIGHT_OBSERVATION_SCOPE_STRATEGY='shared'/);
+      expect(s.observationScopes).toBe("shared");
+      expect(s.observationScopeStrategy).toBe("shared");
+    });
+
+    it("re-asserts the stamp after a reinstall clobbers it (survives apply)", () => {
+      // installHindsightPlugin rm+re-copies the vendor tree on every reconcile;
+      // a mirror that only stamped on first install would be reverted by the
+      // next `switchroom apply` — the exact failure mode the recall-tunables
+      // regression test guards. Reproduce it: install, clobber, reinstall.
+      const memory = { observation_scopes: "shared", observation_scope_strategy: "shared" };
+      const config = configFor(memory);
+      const agentConfig = config.agents.probe ?? {};
+      const res = scaffoldAgent("probe", agentConfig, tmpDir, telegram, config);
+      const settingsPath = join(res.agentDir, ...PLUGIN_REL);
+
+      const clobbered = JSON.parse(readFileSync(settingsPath, "utf-8"));
+      delete clobbered.observationScopes;
+      delete clobbered.observationScopeStrategy;
+      writeFileSync(settingsPath, JSON.stringify(clobbered, null, 2) + "\n");
+      // Sanity: the clobber took, so a green result below means the re-stamp ran.
+      expect(
+        "observationScopes" in
+          (JSON.parse(readFileSync(settingsPath, "utf-8")) as Record<string, unknown>),
+      ).toBe(false);
+
+      reconcileAgent("probe", agentConfig, tmpDir, telegram, config);
+      const s = JSON.parse(readFileSync(settingsPath, "utf-8")) as Record<string, unknown>;
+      expect(s.observationScopes).toBe("shared");
+      expect(s.observationScopeStrategy).toBe("shared");
+    });
+  });
 });
 
 /**


### PR DESCRIPTION
## Summary

Makes hindsight memory config single-source: what `switchroom.yaml` says is what the retaining processes actually see. Closes the live mis-scoping during the running reconsolidation drain (#3915) and the dropped-tier reads (#3914).

`installHindsightPlugin` (`src/agents/scaffold.ts`) bypassed its own cascade in three ways:

1. **`auto_recall` read RAW** (`agents[name].memory.auto_recall`) — a fleet-wide `defaults.memory.auto_recall: false` or a profile-tier opt-out did **not** disable the plugin. Now resolved through the cascade. The `scaffoldAgent` `autoMemoryEnabled` gate re-read the *same* raw value and had drifted from the already-cascaded plugin gate; it now uses the cascaded `hindsightAutoRecallEnabled`.
2. **Retain cadence re-derived**, ignoring the caller's already-cascaded `resolvedAgentConfig` — reading a different object whenever the raw config the caller resolved was not literally the `agents[name]` map entry. Now prefers the threaded config, exactly like `resolveHindsightRecallConfig` already does.
3. **`observation_scopes` / `observation_scope_strategy` travelled ONLY via `start.sh` env export** — which reaches the supervised claude session but **not** a `docker exec`'d backfill/consolidation drain. Those env-less processes fell back to the vendored `settings.json` default (scope `None` / strategy `curated`) and retained under the **wrong scope** — silent bank corruption mid-reconsolidation. Both values are now mirrored into the deployed plugin `settings.json` via `renderHindsightSettingsOverrides`, stamped **only when the operator set them** (byte-for-byte matching `start.sh`'s export-only-when-set semantics). `lib/config.load_config` loads `settings.json` first and lets the env override it, so the supervised and exec'd processes now resolve **identically**.

No `vendor/**` changes.

## Why

Advances the remember-across-sessions job by making memory config authoritative through one cascade. Vision outcome: on-the-leash — operator config is the source of truth. Job spec: `reference/jobs/remember-across-sessions.md`.

## Test plan

- `tests/scaffold.memory-cascade.test.ts` (new) — `auto_recall` cascade (defaults + profile tiers ⇒ null install; end-to-end gate agreement) and retain cadence (threaded-config-wins divergence + profile-tier end-to-end). Each asserts an outcome that **goes red on `origin/main`'s scaffold.ts** (verified by stash-and-run).
- `tests/scaffold.observation-scopes.test.ts` (extended) — new `settings.json mirror` describe: stamp present for scope+strategy, strategy-only, absent when unset, **byte-identical to the `start.sh` export**, and **survives a reinstall/apply** (clobber + reconcile re-asserts). The four mirror assertions fail pre-fix.
- Scoped `vitest` green (275 in the broader scaffold/drift/reconcile sweep + the two new/extended files); `tsc --noEmit` clean.

## Risk

Low. Stamping is additive and gated on the operator having set the value — an agent that configured neither observation knob gets a byte-identical `settings.json`, so the idempotent skip-recopy path is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)