### PR TITLE
fix(schema): correct observation_scopes defaults-tier "opt-out" comment (#3912)

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -3328,7 +3328,12 @@ const profileFields = {
       directive_capture_nudge: z.boolean().optional(),
       // Mirror of AgentMemorySchema.observation_scopes — accepted at the
       // defaults/profile tier too, so `defaults.memory.observation_scopes:
-      // shared` pools a whole fleet's observations with per-agent opt-out.
+      // shared` pins a whole fleet's observations to one scope. A per-agent
+      // value OVERRIDES that pin with another enum member; because the schema
+      // is `z.enum().optional()` with no clear sentinel, `undefined` inherits
+      // the fleet pin (it cannot cancel it). To decline the pool, an agent
+      // sets `observation_scopes: combined` — the member that restores the
+      // pre-feature engine default (see ObservationScopesSchema above).
       observation_scopes: ObservationScopesSchema,
       // Mirror of AgentMemorySchema.observation_scope_strategy — accepted at
       // the defaults/profile tier too, so `defaults.memory.

--- a/tests/scaffold.observation-scopes-cascade.test.ts
+++ b/tests/scaffold.observation-scopes-cascade.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent } from "../src/agents/scaffold.js";
+import type { SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+/**
+ * #3912 — the defaults/profile-tier `memory.observation_scopes` comment used
+ * to promise a "per-agent opt-out". `ObservationScopesSchema` is
+ * `z.enum().optional()` with NO clear/null sentinel, and the cascade inherits
+ * on `undefined` — so a per-agent value can only OVERRIDE the fleet pin with
+ * another enum member; it cannot cancel it. The member that declines the pool
+ * is `combined` (restores the pre-feature engine default).
+ *
+ * These pin the OUTCOME the corrected comment describes, driving the FULL
+ * cascade through scaffoldAgent (defaults → agent) and reading the start.sh
+ * export the plugin actually loads. Each fails if the cascade stops inheriting
+ * the fleet pin, or if a per-agent override stops winning.
+ */
+describe("observation_scopes defaults-tier cascade + override (#3912)", () => {
+  let tmpDir: string;
+  let telegram: TelegramConfig;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `obs-cascade-${Date.now()}-${Math.floor(Math.random() * 1e6)}`);
+    mkdirSync(tmpDir, { recursive: true });
+    telegram = { bot_token: "t", forum_chat_id: "c" };
+  });
+  afterEach(() => {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function startShFor(config: SwitchroomConfig): string {
+    const res = scaffoldAgent("probe", config.agents.probe ?? {}, tmpDir, telegram, config);
+    return readFileSync(join(res.agentDir, "start.sh"), "utf-8");
+  }
+
+  function base(partial: Partial<SwitchroomConfig>): SwitchroomConfig {
+    return {
+      memory: { backend: "hindsight", config: { url: "http://localhost:18888/mcp/" } },
+      telegram,
+      agents: {},
+      ...partial,
+    } as SwitchroomConfig;
+  }
+
+  it("a defaults-tier pin is INHERITED by an agent that sets nothing", () => {
+    // The agent's own memory block is empty ⇒ undefined ⇒ inherits the fleet
+    // pin. This is the "cannot cancel by omission" half: silence adopts the
+    // fleet scope, it does not fall back to the engine default.
+    const startSh = startShFor(
+      base({
+        defaults: { memory: { observation_scopes: "shared" } },
+        agents: { probe: {} },
+      }),
+    );
+    expect(startSh).toMatch(/export HINDSIGHT_OBSERVATION_SCOPES='shared'/);
+  });
+
+  it("a per-agent value OVERRIDES the defaults-tier pin (not additive)", () => {
+    const startSh = startShFor(
+      base({
+        defaults: { memory: { observation_scopes: "shared" } },
+        agents: { probe: { memory: { observation_scopes: "per_tag" } } as never },
+      }),
+    );
+    expect(startSh).toMatch(/export HINDSIGHT_OBSERVATION_SCOPES='per_tag'/);
+    // The inherited pin must NOT also leak through — override, not merge.
+    expect(startSh).not.toMatch(/export HINDSIGHT_OBSERVATION_SCOPES='shared'/);
+  });
+
+  it("`combined` is the member an agent uses to decline a fleet pool", () => {
+    // The corrected comment's opt-out mechanism: not a null sentinel, but the
+    // `combined` enum member, which restores the pre-feature engine default.
+    const startSh = startShFor(
+      base({
+        defaults: { memory: { observation_scopes: "shared" } },
+        agents: { probe: { memory: { observation_scopes: "combined" } } as never },
+      }),
+    );
+    expect(startSh).toMatch(/export HINDSIGHT_OBSERVATION_SCOPES='combined'/);
+    expect(startSh).not.toMatch(/export HINDSIGHT_OBSERVATION_SCOPES='shared'/);
+  });
+
+  it("a profile-tier pin cascades the same way (defaults → profile → agent)", () => {
+    const startSh = startShFor(
+      base({
+        profiles: { pooled: { memory: { observation_scopes: "shared" } } } as never,
+        agents: { probe: { extends: "pooled" } } as never,
+      }),
+    );
+    expect(startSh).toMatch(/export HINDSIGHT_OBSERVATION_SCOPES='shared'/);
+  });
+});


### PR DESCRIPTION
## What

Closes #3912. Corrects the false "per-agent opt-out" promise in the
defaults/profile-tier mirror comment for `memory.observation_scopes`, and
locks the real cascade behaviour with a test so the comment and the code
cannot drift again.

## Why

The mirror comment at `src/config/schema.ts` read:

> `defaults.memory.observation_scopes: shared` pools a whole fleet's
> observations **with per-agent opt-out**.

There is no per-agent opt-out in the *clear/cancel* sense the phrase implies:

- `ObservationScopesSchema` is `z.enum(OBSERVATION_SCOPES).optional()` — no
  `null` / empty / clear sentinel. An empty string is explicitly rejected as
  a typo, not an opt-out (existing schema test).
- The config cascade (`resolveAgentConfig`) inherits on `undefined`. So a
  per-agent agent that sets nothing **adopts** the fleet pin; it cannot
  cancel it by omission.
- A per-agent value can only **override** the pin with *another enum member*.
  The member that actually declines a fleet pool is `combined`, which
  restores the pre-feature engine default — exactly as
  `ObservationScopesSchema`'s own doc-comment already states
  ("`combined` is the pin form of opting out").

So the mirror comment contradicted the schema it mirrors. This is the
lower-risk of the two options floated in #3912 (correct the comment vs. add a
general clear-sentinel to the cascade): a clear-sentinel would touch the
cascade merge semantics for every `optional()` enum knob and change runtime
behaviour fleet-wide, whereas the enum *already contains* an effective
opt-out member (`combined`). Documenting the real mechanism is the honest,
zero-behaviour-change fix.

## Change

- **`src/config/schema.ts`** — rewrite the `observation_scopes` mirror
  comment: fleet pin + per-agent **override** with another enum member +
  `undefined` inherits (cannot cancel) + `combined` is the decline-the-pool
  member. (The sibling `observation_scope_strategy` comment says "per-agent
  opt-in", which *is* expressible — set the `curated` member — so it is left
  as-is.)
- **`tests/scaffold.observation-scopes-cascade.test.ts`** (new) — drives the
  full cascade through `scaffoldAgent` (defaults → profile → agent) and
  asserts on the `start.sh` export the plugin actually loads:
  - a defaults-tier pin is **inherited** by an agent that sets nothing;
  - a per-agent value **overrides** (asserts the inherited `shared` does NOT
    also leak — override, not merge);
  - `combined` is the member an agent uses to decline the pool;
  - a profile-tier pin cascades identically.

These assert outcomes (the emitted env export), so each fails if the cascade
stops inheriting the pin or an override stops winning — not merely exercising
a code path.

## Validation

- `tsc --noEmit`: clean.
- `npm run lint`: clean (all guard scripts pass, attribution trailers OK).
- New test file: 4/4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)