### PR TITLE
fix(hostd): mount /tmp tmpfs on docker-socket-proxy so it can render haproxy.cfg

### DIFF
--- a/src/cli/hostd.test.ts
+++ b/src/cli/hostd.test.ts
@@ -250,6 +250,24 @@ describe("renderHostdComposeFile — docker-socket-proxy sidecar (#1842 / #1400 
     expect(proxyBlock).toContain("tmpfs:");
   });
 
+  it("mounts BOTH /run and /tmp as tmpfs so the read_only proxy can render haproxy.cfg on boot (#3932)", () => {
+    const out = render();
+    const proxyBlock = out.slice(
+      out.indexOf("docker-socket-proxy:"),
+      out.indexOf("  hostd:"),
+    );
+    // Collect the actual tmpfs list entries in the proxy block — not prose
+    // mentions in comments. The tecnativa entrypoint writes /tmp/haproxy.cfg
+    // at startup; with read_only rootfs, a missing /tmp tmpfs crash-loops the
+    // proxy before HAProxy starts (the regression this guards).
+    const tmpfsMounts = proxyBlock
+      .split("\n")
+      .filter((l) => /^\s*- \/(run|tmp)\s*$/.test(l))
+      .map((l) => l.trim());
+    expect(tmpfsMounts).toContain("- /run");
+    expect(tmpfsMounts).toContain("- /tmp");
+  });
+
   it("sets the endpoint allowlist to EXACTLY the flags hostd's call set needs", () => {
     const out = render();
     const proxyBlock = out.slice(

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -211,6 +211,10 @@ services:
       # HAProxy writes its runtime state/pidfile under /run; read_only rootfs
       # otherwise makes it crash-loop on boot.
       - /run
+      # The tecnativa/docker-socket-proxy entrypoint renders /tmp/haproxy.cfg
+      # on boot; with a read_only rootfs and no /tmp tmpfs it can't write the
+      # generated config and crash-loops before HAProxy ever starts.
+      - /tmp
     cap_drop:
       - ALL
     cap_add:


### PR DESCRIPTION
## What

Add `- /tmp` to the `docker-socket-proxy` service's `tmpfs` list in the generated hostd compose (`src/cli/hostd.ts`, `renderHostdComposeFile`).

## Why

The proxy runs with a `read_only: true` rootfs but the generator only mounted `/run` as tmpfs. The `tecnativa/docker-socket-proxy` entrypoint renders `/tmp/haproxy.cfg` at boot; with no writable `/tmp`, it can't write the generated config and crash-loops before HAProxy ever starts. That takes down the sole container fronting the raw docker socket, and with it every hostd fleet operation.

`read_only` hardening is kept — we add exactly one tmpfs entry.

## Test

Added a regression test in `src/cli/hostd.test.ts` that generates the hostd compose and asserts the proxy service's `tmpfs` list contains BOTH `/run` and `/tmp` (parsing actual list entries, not comment prose). Verified class-killer: the test fails on `origin/main` and passes with the fix.

- `vitest run src/cli/hostd.test.ts` -> 42 passed
- `tsc --noEmit` -> clean

Fixes #3932

🤖 Generated with [Claude Code](https://claude.com/claude-code)