### PR TITLE
fix(doctor): measure the real consolidation backlog, not the op queue (#3949, #3954, #3950, #3538)

### DIFF
--- a/src/cli/doctor-memory.ts
+++ b/src/cli/doctor-memory.ts
@@ -143,20 +143,21 @@ export function classifyShmSize(bytes: number): CheckResult {
 }
 
 /**
- * Backlog thresholds for the consolidation queue. With the #2894 throttle
- * (MAX_SLOTS=1, ~7 consolidation ops/hour drained against a fleet retaining
- * every turn) the queue can build silently — the only prior signal was a 2h
- * queue-lag WARNING written to `docker logs` by `hindsight-maintenance.sh`.
- * A deep queue means retains are landing but not yet consolidated into recall.
- * WARN ≈ several hours of backlog; FAIL ≈ ~a day+, likely wedged.
+ * Depth thresholds for the async OPERATION queue (`/stats.pending_operations`
+ * — `async_operations` rows in `pending`/`processing`). This is the TASK queue:
+ * retains, refreshes and consolidation ops waiting to be claimed. It is NOT the
+ * memory-consolidation backlog — during the 2026-07 reconsolidation drain it
+ * read ~5 while 44k memory units sat unconsolidated (#3949). Use it to catch a
+ * stuck reaper / claim stall, where non-terminal ops pile up instead of
+ * draining. WARN ≈ a claim backlog building; FAIL ≈ the queue is wedged.
  */
-export const CONSOLIDATION_BACKLOG_WARN = 25;
-export const CONSOLIDATION_BACKLOG_FAIL = 200;
+export const OP_QUEUE_WARN = 25;
+export const OP_QUEUE_FAIL = 200;
 
 /**
- * Pure: classify the consolidation-queue backlog into a doctor result so
- * `switchroom doctor` surfaces queue depth (and, when available, the oldest
- * pending op's age) instead of it hiding in docker logs.
+ * Pure: classify the async OPERATION queue depth into a doctor result so
+ * `switchroom doctor` surfaces a claim/reaper stall (and, when available, the
+ * oldest pending op's age) instead of it hiding in docker logs.
  *
  * `queueDepth` is the count of pending/processing async operations across all
  * banks (summed from each bank's `/stats.pending_operations`). `oldestAgeSecs`
@@ -164,8 +165,12 @@ export const CONSOLIDATION_BACKLOG_FAIL = 200;
  * `/stats` surface exposes depth but not per-op age, so precise age
  * measurement is deferred to the #2847 follow-up (the maintenance loop already
  * logs it). Never throws.
+ *
+ * NOTE: this does NOT measure whether retained memory is reaching recall —
+ * that is {@link classifyConsolidationBacklog}, which reads the actual
+ * `memory_units` backlog (`pending_consolidation`).
  */
-export function classifyConsolidationBacklog(
+export function classifyAsyncOpQueue(
   queueDepth: number,
   oldestAgeSecs: number | null = null,
 ): CheckResult {
@@ -173,33 +178,160 @@ export function classifyConsolidationBacklog(
     oldestAgeSecs !== null && oldestAgeSecs > 0
       ? `, oldest ${Math.round(oldestAgeSecs / 60)}m old`
       : "";
-  const base = `${queueDepth} pending consolidation op(s)${ageStr}`;
-  if (queueDepth >= CONSOLIDATION_BACKLOG_FAIL) {
+  const base = `${queueDepth} pending async op(s)${ageStr}`;
+  if (queueDepth >= OP_QUEUE_FAIL) {
+    return {
+      name: "hindsight async op queue",
+      status: "fail",
+      detail:
+        `${base} — the operation queue is deep enough to be wedged; ops are ` +
+        `enqueued but not draining (a stuck reaper / claim stall)`,
+      fix:
+        "Check `docker logs switchroom-hindsight` for claim/reaper errors " +
+        "(quota/429/shm, stuck 'processing' ops); restart with `switchroom " +
+        "memory --restart` if the worker is stuck.",
+    };
+  }
+  if (queueDepth >= OP_QUEUE_WARN) {
+    return {
+      name: "hindsight async op queue",
+      status: "warn",
+      detail:
+        `${base} — non-terminal ops are building faster than they drain; ` +
+        `claims may be lagging (check the reaper before it wedges)`,
+    };
+  }
+  return {
+    name: "hindsight async op queue",
+    status: "ok",
+    detail: queueDepth > 0 ? base : "queue drained (0 pending)",
+  };
+}
+
+/**
+ * Backlog thresholds for the memory-consolidation queue — the count of
+ * `memory_units` with `consolidated_at IS NULL` (`/stats.pending_consolidation`).
+ * This is the number that actually gauges whether retained memory is reaching
+ * recall, and it is MEMORY-SCALE, not op-scale: the healthy fleet's largest
+ * per-bank reading was 45 (B9c in hindsight-watch/thresholds.ts) while the
+ * 2026-07 stall ran to ~44k. Absolute depth is a blunt gauge — a bank
+ * mid-ingest legitimately runs deep — so the thresholds sit far above the
+ * healthy floor and the fix text names the benign case. WARN ≈ growth worth a
+ * look; FAIL ≈ a stall that is starving recall.
+ */
+export const CONSOLIDATION_BACKLOG_WARN = 1000;
+export const CONSOLIDATION_BACKLOG_FAIL = 10000;
+
+/**
+ * Pure: classify the REAL memory-consolidation backlog into a doctor result.
+ *
+ * `pendingConsolidation` is the count of unconsolidated `memory_units` summed
+ * across every reachable bank (each bank's `/stats.pending_consolidation`).
+ * Unlike {@link classifyAsyncOpQueue} this reads the memory backlog directly,
+ * so it stays honest when the op queue is shallow but consolidation has stalled
+ * (the #3949 blind spot). Never throws.
+ */
+export function classifyConsolidationBacklog(
+  pendingConsolidation: number,
+): CheckResult {
+  const base = `${pendingConsolidation} memory unit(s) pending consolidation`;
+  if (pendingConsolidation >= CONSOLIDATION_BACKLOG_FAIL) {
     return {
       name: "hindsight consolidation backlog",
       status: "fail",
       detail:
-        `${base} — queue is deep enough to be wedged; retains are landing but ` +
-        `not consolidating into recall (drains ~7 ops/hr under the #2894 throttle)`,
+        `${base} — consolidation has stalled far behind ingest; retained ` +
+        `memory is landing but not reaching recall (drains ~7 ops/hr under ` +
+        `the #2894 throttle)`,
       fix:
-        "Check `docker logs switchroom-hindsight` for the queue-lag WARNING and " +
-        "consolidation errors (quota/429/shm); restart with `switchroom memory " +
-        "--restart` if the worker is stuck.",
+        "Check `docker logs switchroom-hindsight` for consolidation errors " +
+        "(quota/429/shm, HNSW index faults) and the consolidation-failure-" +
+        "streak signal; a bank legitimately mid-ingest can read deep, so " +
+        "confirm the number is not draining before restarting.",
     };
   }
-  if (queueDepth >= CONSOLIDATION_BACKLOG_WARN) {
+  if (pendingConsolidation >= CONSOLIDATION_BACKLOG_WARN) {
     return {
       name: "hindsight consolidation backlog",
       status: "warn",
       detail:
         `${base} — building faster than it drains (~7 ops/hr under the #2894 ` +
-        `throttle); recall may lag recent turns until it catches up`,
+        `throttle); recall may lag recent turns until it catches up (a bank ` +
+        `mid-ingest can read deep — confirm it is draining)`,
     };
   }
   return {
     name: "hindsight consolidation backlog",
     status: "ok",
-    detail: queueDepth > 0 ? base : "queue drained (0 pending)",
+    detail: pendingConsolidation > 0 ? base : "consolidation drained (0 pending)",
+  };
+}
+
+/** Doctor row label for the bank-config reachability probe (#3538). */
+export const BANK_CONFIG_API_CHECK_NAME = "hindsight bank-config API";
+
+/**
+ * Pure: classify a probe of the bank-config API's `retain_mission` readability.
+ *
+ * Since #3529 retain-mission seeding is FAIL-CLOSED: `resolveRetainMissionPush`
+ * reads the bank's current mission via `GET /v1/default/banks/<bank>/config`
+ * and, on a failed read, deliberately pushes NOTHING (so a transient 5xx can't
+ * be misread as "mission unset" and clobber an operator's customization). The
+ * cost of that safety: if the config API is turned off
+ * (`HINDSIGHT_API_ENABLE_BANK_CONFIG_API=false`, config.py default True) or
+ * Hindsight renames/renests `config.retain_mission`, EVERY read fails, apply
+ * seeds no agent — including brand-new ones — and still exits 0. The old
+ * fail-open code always seeded and masked this; the new code converts a loud
+ * problem into a silent one. This row makes it loud again (#3538).
+ *
+ * `result` is the outcome of {@link fetchBankRetainMission} for one bank:
+ *  - `ok` → the key is readable; the seed path works.
+ *  - `reason: "Unexpected shape"` → a 200 whose body carried no `retain_mission`
+ *    key: the API is disabled or the field moved. FAIL — this is exactly the
+ *    silent-skip trigger, and it is deterministic, not a transient.
+ *  - any other reason (HTTP error / timeout) → the surface could not be probed
+ *    at all; that is a server-reachability problem the container-health checks
+ *    own, so WARN here rather than FAIL (don't double-red a down server).
+ */
+export function classifyBankConfigReachability(
+  result: { ok: true } | { ok: false; reason: string },
+  bankId: string,
+): CheckResult {
+  const name = BANK_CONFIG_API_CHECK_NAME;
+  if (result.ok) {
+    return {
+      name,
+      status: "ok",
+      detail: `retain_mission readable on bank ${bankId} — the fail-closed seed path (#3529) can read the field`,
+    };
+  }
+  if (result.reason === "Unexpected shape") {
+    return {
+      name,
+      status: "fail",
+      detail:
+        `GET /v1/default/banks/${bankId}/config returned no retain_mission key — ` +
+        `the bank-config API is disabled or the field was renamed/renested. ` +
+        `Retain-mission seeding is fail-closed (#3529): with this read failing, ` +
+        `apply seeds retain_mission for NO agent (including new ones) and still ` +
+        `exits 0, so the fleet silently runs with unset retain missions.`,
+      fix:
+        "Confirm `HINDSIGHT_API_ENABLE_BANK_CONFIG_API` is true on the Hindsight " +
+        "deployment (config.py default True) and that GET .../config still nests " +
+        "`retain_mission` under `config`. If Hindsight renamed/renested the field, " +
+        "update `fetchBankMissionField` in src/memory/hindsight.ts to match.",
+    };
+  }
+  return {
+    name,
+    status: "warn",
+    detail:
+      `could not probe the bank-config API on ${bankId}: ${result.reason} — ` +
+      `retain-mission seeding is fail-closed (#3529) and can't be confirmed. If ` +
+      `this persists it silently skips seeding for every agent.`,
+    fix:
+      "Check the hindsight container is up and `HINDSIGHT_API_ENABLE_BANK_CONFIG_API` " +
+      "is enabled; re-run once it is reachable.",
   };
 }
 

--- a/src/cli/doctor-observation-scopes.test.ts
+++ b/src/cli/doctor-observation-scopes.test.ts
@@ -8,6 +8,10 @@ import {
   classifyObservationScopeSaturation,
   computeScopeSaturation,
   inspectBankScopes,
+  fnmatchcase,
+  scopeMatchesGlobs,
+  parseScopeLimitRules,
+  effectiveScopeLimit,
   type BankScopeReport,
   type ObservationScope,
 } from "./doctor-observation-scopes.js";
@@ -53,6 +57,7 @@ const report = (over: Partial<BankScopeReport> & { bankId: string }): BankScopeR
   observationsEnabled: true,
   hasScopeLimitRules: false,
   scopeCount: 0,
+  judgedScopeCount: 0,
   untaggedCount: 0,
   saturated: [],
   pendingConsolidation: null,
@@ -65,16 +70,20 @@ const reportFor = (
   scopes: ObservationScope[],
   cap = 1000,
   pendingConsolidation: number | null = null,
-): BankScopeReport =>
-  report({
+): BankScopeReport => {
+  // Mirror inspectBankScopes: the full judged list, then the saturated subset.
+  const allJudged = computeScopeSaturation(scopes, cap);
+  return report({
     bankId,
     cap,
     scopeCount: scopes.length,
+    judgedScopeCount: allJudged.length,
     // Mirror inspectBankScopes: the untagged scope is tracked, never saturated.
     untaggedCount: scopes.filter((s) => s.tags.length === 0).reduce((n, s) => n + s.count, 0),
-    saturated: computeScopeSaturation(scopes, cap).filter((s) => s.status !== "ok"),
+    saturated: allJudged.filter((s) => s.status !== "ok"),
     pendingConsolidation,
   });
+};
 
 describe("the live overlord failure", () => {
   it("FAILS, and names the bank, the scope and 1009/1000", () => {
@@ -327,24 +336,6 @@ describe("configurations this check must not judge", () => {
     expect(result.detail).toContain("closed");
   });
 
-  it("refuses to judge a bank carrying observation_scope_limits rules", () => {
-    // Those rules resolve a DIFFERENT cap per scope via fnmatch exact-cover
-    // (consolidator.py:670-683). A rule that RAISES a scope's limit would make
-    // the bank-wide comparison invent a FAIL, so the bank is excluded and the
-    // gap is stated instead of guessed at.
-    const result = classifyObservationScopeSaturation([
-      report({
-        bankId: "ruled",
-        hasScopeLimitRules: true,
-        scopeCount: 1,
-        saturated: computeScopeSaturation([scope(["s"], 5000)], 1000),
-      }),
-    ]);
-    expect(result.status).toBe("skip");
-    expect(result.detail).toContain("observation_scope_limits");
-    expect(result.detail).toContain("ruled");
-  });
-
   it("does not judge a bank with observations disabled", () => {
     const result = classifyObservationScopeSaturation([
       report({
@@ -356,6 +347,136 @@ describe("configurations this check must not judge", () => {
     ]);
     expect(result.status).toBe("skip");
     expect(result.detail).toContain("observations disabled");
+  });
+});
+
+// #3950 — the fnmatch scope-limit mirror. Divergence from the engine here
+// produces silently wrong verdicts, so these pin the semantics against the
+// docstrings of `_scope_matches_globs` / `_parse_scope_limit_rules`
+// (consolidator.py:606-683), not just the code path.
+describe("observation_scope_limits glob mirror (#3950)", () => {
+  describe("fnmatchcase — case-sensitive fnmatch semantics", () => {
+    it("* matches any run including empty", () => {
+      expect(fnmatchcase("run_1", "run_*")).toBe(true);
+      expect(fnmatchcase("run_", "run_*")).toBe(true);
+      expect(fnmatchcase("nope", "run_*")).toBe(false);
+    });
+    it("? matches exactly one char", () => {
+      expect(fnmatchcase("ab", "a?")).toBe(true);
+      expect(fnmatchcase("a", "a?")).toBe(false);
+      expect(fnmatchcase("abc", "a?")).toBe(false);
+    });
+    it("[seq] and [!seq] classes", () => {
+      expect(fnmatchcase("a", "[abc]")).toBe(true);
+      expect(fnmatchcase("d", "[abc]")).toBe(false);
+      expect(fnmatchcase("d", "[!abc]")).toBe(true);
+      expect(fnmatchcase("a", "[!abc]")).toBe(false);
+    });
+    it("is case-SENSITIVE (fnmatchcase, not fnmatch)", () => {
+      expect(fnmatchcase("Shared", "shared")).toBe(false);
+      expect(fnmatchcase("shared", "shared")).toBe(true);
+    });
+    it("escapes regex metacharacters in literals", () => {
+      expect(fnmatchcase("a.b", "a.b")).toBe(true);
+      expect(fnmatchcase("axb", "a.b")).toBe(false);
+    });
+  });
+
+  describe("scopeMatchesGlobs — exact cover both directions (the docstring examples)", () => {
+    it('["shared"] matches {shared} but NOT {run_1, shared}', () => {
+      expect(scopeMatchesGlobs(["shared"], ["shared"])).toBe(true);
+      expect(scopeMatchesGlobs(["shared"], ["run_1", "shared"])).toBe(false);
+    });
+    it('["run_*", "shared"] matches {run_1, shared} but NOT {shared}', () => {
+      expect(scopeMatchesGlobs(["run_*", "shared"], ["run_1", "shared"])).toBe(true);
+      expect(scopeMatchesGlobs(["run_*", "shared"], ["shared"])).toBe(false);
+    });
+    it("the empty tag set never matches (untagged is never rule-capped)", () => {
+      expect(scopeMatchesGlobs(["*"], [])).toBe(false);
+    });
+    it("rejects an uncovered tag", () => {
+      expect(scopeMatchesGlobs(["run_*"], ["run_1", "other"])).toBe(false);
+    });
+    it("rejects a vacuous glob that covers no tag", () => {
+      expect(scopeMatchesGlobs(["run_*", "nomatch_*"], ["run_1"])).toBe(false);
+    });
+  });
+
+  describe("parseScopeLimitRules — defensive parse, order preserved", () => {
+    it("keeps well-formed rules in order", () => {
+      const rules = parseScopeLimitRules([
+        { scope: ["run_*"], limit: 50 },
+        { scope: ["shared"], limit: 200 },
+      ]);
+      expect(rules).toEqual([
+        { globs: ["run_*"], limit: 50 },
+        { globs: ["shared"], limit: 200 },
+      ]);
+    });
+    it("skips malformed entries rather than throwing", () => {
+      expect(parseScopeLimitRules("nope")).toEqual([]);
+      expect(parseScopeLimitRules([{ scope: [], limit: 5 }])).toEqual([]);
+      expect(parseScopeLimitRules([{ scope: ["a"], limit: 1.5 }])).toEqual([]);
+      expect(parseScopeLimitRules([{ scope: ["a"], limit: true }])).toEqual([]);
+      expect(parseScopeLimitRules([{ scope: ["a", ""], limit: 5 }])).toEqual([]);
+      expect(parseScopeLimitRules([{ scope: ["a"] }])).toEqual([]);
+    });
+  });
+
+  describe("effectiveScopeLimit — first match wins, else bank cap", () => {
+    const rules = [
+      { globs: ["run_*", "shared"], limit: 50 },
+      { globs: ["shared"], limit: 5000 },
+    ];
+    it("returns the first matching rule's limit", () => {
+      expect(effectiveScopeLimit(rules, ["run_1", "shared"], 1000)).toBe(50);
+      expect(effectiveScopeLimit(rules, ["shared"], 1000)).toBe(5000);
+    });
+    it("falls back to the bank-wide cap when no rule covers the scope", () => {
+      expect(effectiveScopeLimit(rules, ["lonely"], 1000)).toBe(1000);
+    });
+  });
+
+  describe("computeScopeSaturation honours per-scope glob caps", () => {
+    it("a rule that RAISES a scope's cap stops it failing the bank-wide cap", () => {
+      // Bank-wide cap 1000, but a rule raises {shared} to 5000. 3000 exact
+      // observations are FINE under the rule though they'd fail the bank cap.
+      const rules = [{ globs: ["shared"], limit: 5000 }];
+      const sat = computeScopeSaturation([scope(["shared"], 3000)], 1000, OBSERVATION_SCOPE_WARN_RATIO, rules);
+      expect(sat[0]?.status).toBe("ok");
+      expect(sat[0]?.cap).toBe(5000);
+    });
+    it("a rule that LOWERS a scope's cap can fail a scope the bank cap would pass", () => {
+      const rules = [{ globs: ["run_*"], limit: 100 }];
+      const sat = computeScopeSaturation([scope(["run_1"], 150)], 1000, OBSERVATION_SCOPE_WARN_RATIO, rules);
+      expect(sat[0]?.status).toBe("fail");
+      expect(sat[0]?.cap).toBe(100);
+    });
+    it("a rule can cap a scope even when the bank-wide cap is unlimited (-1)", () => {
+      const rules = [{ globs: ["run_*"], limit: 100 }];
+      const sat = computeScopeSaturation([scope(["run_1"], 150)], -1, OBSERVATION_SCOPE_WARN_RATIO, rules);
+      expect(sat[0]?.status).toBe("fail");
+    });
+  });
+
+  it("a glob-rule bank is now JUDGED end-to-end, not skipped", () => {
+    // The former behaviour skipped any bank carrying observation_scope_limits.
+    // Now the per-scope cap is resolved, so a scope a rule LOWERED can fail the
+    // row — and the bank is named in the detail as judged with glob caps.
+    const rules = [{ globs: ["run_*"], limit: 100 }];
+    const sat = computeScopeSaturation([scope(["run_1"], 250)], 1000, OBSERVATION_SCOPE_WARN_RATIO, rules);
+    const result = classifyObservationScopeSaturation([
+      report({
+        bankId: "ruled",
+        hasScopeLimitRules: true,
+        scopeCount: 1,
+        judgedScopeCount: sat.length,
+        saturated: sat.filter((s) => s.status !== "ok"),
+      }),
+    ]);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toContain("ruled");
+    expect(result.detail).toContain("250/100");
   });
 });
 

--- a/src/cli/doctor-observation-scopes.ts
+++ b/src/cli/doctor-observation-scopes.ts
@@ -74,7 +74,7 @@
 import type { SwitchroomConfig } from "../config/schema.js";
 import { resolveAgentConfig } from "../config/merge.js";
 import { collectProfileBanks } from "../memory/hindsight.js";
-import { hindsightRestBase } from "../memory/bank-health.js";
+import { hindsightRestBase, getJson, type FetchOpts } from "../memory/bank-health.js";
 import type { CheckStatus } from "./doctor-status.js";
 
 export interface CheckResult {
@@ -149,6 +149,116 @@ export interface ScopeSaturation {
 }
 
 /**
+ * One `observation_scope_limits` rule as the engine parses it
+ * (`_ScopeLimitRule`, consolidator.py:606-623): a set of fnmatch tag-globs and
+ * the observation cap applied to a scope those globs exact-cover.
+ */
+export interface ScopeLimitRule {
+  globs: string[];
+  limit: number;
+}
+
+/**
+ * Translate a single fnmatch pattern into a RegExp — a faithful port of
+ * CPython's `fnmatch.translate` (the implementation behind `fnmatchcase`):
+ * `*` → any run (incl. empty, DOTALL), `?` → one char, `[seq]`/`[!seq]` →
+ * character class, everything else literal. Anchored to the whole string.
+ * Case-SENSITIVE, matching the engine's `fnmatchcase`.
+ */
+function fnmatchTranslate(pat: string): RegExp {
+  // `[\s\S]` (not `.`) so `*`/`?` span newlines too — Python compiles with the
+  // DOTALL flag (`(?s:...)`).
+  const ANY = "[\\s\\S]";
+  let res = "";
+  let i = 0;
+  const n = pat.length;
+  while (i < n) {
+    const c = pat[i];
+    i += 1;
+    if (c === "*") {
+      res += ANY + "*";
+    } else if (c === "?") {
+      res += ANY;
+    } else if (c === "[") {
+      let j = i;
+      if (j < n && pat[j] === "!") j += 1;
+      if (j < n && pat[j] === "]") j += 1;
+      while (j < n && pat[j] !== "]") j += 1;
+      if (j >= n) {
+        res += "\\[";
+      } else {
+        let stuff = pat.slice(i, j).replace(/\\/g, "\\\\");
+        i = j + 1;
+        if (stuff.startsWith("!")) stuff = "^" + stuff.slice(1);
+        else if (stuff.startsWith("^") || stuff.startsWith("[")) stuff = "\\" + stuff;
+        res += "[" + stuff + "]";
+      }
+    } else {
+      res += (c as string).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    }
+  }
+  return new RegExp("^(?:" + res + ")$");
+}
+
+/** Case-sensitive fnmatch — mirror of Python's `fnmatchcase(name, pat)`. */
+export function fnmatchcase(name: string, pat: string): boolean {
+  return fnmatchTranslate(pat).test(name);
+}
+
+/**
+ * Parse raw `observation_scope_limits` config into ordered rules, mirroring the
+ * engine's `_parse_scope_limit_rules` (consolidator.py:626-648): each entry is a
+ * `{ scope: string[], limit: int }` object; malformed entries are skipped (not
+ * raised), and list order is preserved (first match wins). Booleans are rejected
+ * as limits (the engine guards against `True`/`False` — JS has no int/bool
+ * ambiguity but a non-integer or boolean `limit` is still dropped).
+ */
+export function parseScopeLimitRules(raw: unknown): ScopeLimitRule[] {
+  if (!Array.isArray(raw)) return [];
+  const rules: ScopeLimitRule[] = [];
+  for (const entry of raw) {
+    if (entry == null || typeof entry !== "object") continue;
+    const scope = (entry as { scope?: unknown }).scope;
+    const limit = (entry as { limit?: unknown }).limit;
+    if (!Array.isArray(scope) || scope.length === 0) continue;
+    if (!scope.every((g) => typeof g === "string" && g.length > 0)) continue;
+    if (typeof limit !== "number" || !Number.isInteger(limit)) continue;
+    rules.push({ globs: scope as string[], limit });
+  }
+  return rules;
+}
+
+/**
+ * Exact-cover match between a scope pattern and a concrete tag set — a mirror of
+ * the engine's `_scope_matches_globs` (consolidator.py:651-668). True iff every
+ * tag is covered by at least one glob AND every glob covers at least one tag (no
+ * uncovered tags, no vacuous globs). The empty tag set never matches, so a rule
+ * never applies to untagged observations. Case-sensitive.
+ */
+export function scopeMatchesGlobs(globs: string[], tags: string[]): boolean {
+  if (tags.length === 0) return false;
+  if (!tags.every((t) => globs.some((g) => fnmatchcase(t, g)))) return false;
+  if (!globs.every((g) => tags.some((t) => fnmatchcase(t, g)))) return false;
+  return true;
+}
+
+/**
+ * Resolve the observation cap for one concrete scope — a mirror of the engine's
+ * `_effective_scope_limit` (consolidator.py:670-683). The first rule whose
+ * globs exact-cover `tags` wins; otherwise the bank-wide cap applies.
+ */
+export function effectiveScopeLimit(
+  rules: ScopeLimitRule[],
+  tags: string[],
+  bankCap: number,
+): number {
+  for (const rule of rules) {
+    if (scopeMatchesGlobs(rule.globs, tags)) return rule.limit;
+  }
+  return bankCap;
+}
+
+/**
  * Fold exact per-scope counts into the containment counts the engine enforces,
  * and classify each scope against the cap.
  *
@@ -186,8 +296,12 @@ export function computeScopeSaturation(
   scopes: ObservationScope[],
   cap: number,
   warnRatio: number = OBSERVATION_SCOPE_WARN_RATIO,
+  scopeLimitRules: ScopeLimitRule[] = [],
 ): ScopeSaturation[] {
-  if (cap < 0) return [];
+  // No glob rules + an unlimited bank-wide cap ⇒ nothing to judge. WITH rules a
+  // rule may impose a finite cap on a specific scope even when the bank-wide cap
+  // is unlimited (#3950), so the effective cap must be resolved per scope below.
+  if (cap < 0 && scopeLimitRules.length === 0) return [];
 
   const sets = scopes.map((s) => ({ tags: s.tags, set: new Set(s.tags), count: s.count }));
 
@@ -230,16 +344,23 @@ export function computeScopeSaturation(
       if (contains) effective += other.count;
     }
 
-    // `cap === 0` is "closed on purpose": every scope would be at/over it, so
-    // ratio is undefined and the caller reports the bank, not each scope.
+    // Resolve THIS scope's cap: a matching observation_scope_limits glob rule
+    // overrides the bank-wide cap (#3950). A scope whose effective cap is
+    // unlimited (-1, whether bank-wide or via a rule) has no wall to approach
+    // and is dropped from the output.
+    const scopeCap = effectiveScopeLimit(scopeLimitRules, entry.tags, cap);
+    if (scopeCap < 0) continue;
+
+    // `scopeCap === 0` is "closed on purpose": every scope would be at/over it,
+    // so ratio is undefined and the caller reports the bank, not each scope.
     const status: ScopeSaturation["status"] =
-      cap > 0 && effective >= cap
+      scopeCap > 0 && effective >= scopeCap
         ? "fail"
-        : cap > 0 && effective >= cap * warnRatio
+        : scopeCap > 0 && effective >= scopeCap * warnRatio
           ? "warn"
           : "ok";
 
-    out.push({ tags: [...entry.tags], exact: entry.count, effective, cap, status });
+    out.push({ tags: [...entry.tags], exact: entry.count, effective, cap: scopeCap, status });
   }
 
   // Worst first: the operator reads the top of the list, so it must be the
@@ -266,8 +387,16 @@ export interface BankScopeReport {
    * {@link classifyObservationScopeSaturation}.
    */
   hasScopeLimitRules: boolean;
-  /** Distinct scopes in the bank, including the untagged one. */
+  /** Distinct scopes in the bank, including the untagged one (raw endpoint total). */
   scopeCount: number;
+  /**
+   * How many scopes this check actually JUDGED against a cap — the length of
+   * {@link computeScopeSaturation}'s output (tagged, capped scopes), which
+   * excludes the untagged scope the engine never caps. The OK row reports THIS,
+   * not {@link scopeCount}, so the printed number reconciles with what was
+   * evaluated rather than overstating it by the untagged scope (#3954 item 1).
+   */
+  judgedScopeCount: number;
   /**
    * Observations in the UNTAGGED global scope (`tags: []`). This scope is the
    * `curated`-strategy default sink and is never capped by the engine, so it is
@@ -352,11 +481,12 @@ export function classifyObservationScopeSaturation(
     };
   }
 
-  // Glob scope-limit rules resolve a per-scope cap this check does not
-  // evaluate, so judging those banks against the bank-wide cap could invent a
-  // FAIL on a scope whose rule RAISED its limit. Excluded, and said out loud.
-  const unjudged = readable.filter((r) => r.hasScopeLimitRules || !r.observationsEnabled);
-  const judged = readable.filter((r) => !r.hasScopeLimitRules && r.observationsEnabled);
+  // Banks carrying observation_scope_limits glob rules ARE now judged: the
+  // per-scope cap those rules resolve is mirrored client-side (#3950), so their
+  // saturated scopes were computed against the SAME effective cap the engine
+  // enforces. Only observations-disabled banks are excluded from judgement.
+  const unjudged = readable.filter((r) => !r.observationsEnabled);
+  const judged = readable.filter((r) => r.observationsEnabled);
 
   const notes: string[] = [];
   if (unreadable.length > 0) {
@@ -365,14 +495,14 @@ export function classifyObservationScopeSaturation(
         unreadable.map((r) => `${r.bankId} (${r.reason ?? "unknown"})`).join(", "),
     );
   }
-  const withRules = unjudged.filter((r) => r.hasScopeLimitRules);
+  const withRules = judged.filter((r) => r.hasScopeLimitRules);
   if (withRules.length > 0) {
     notes.push(
-      `${withRules.length} bank(s) not judged — observation_scope_limits sets a ` +
-        `per-scope cap this check does not resolve: ${withRules.map((r) => r.bankId).join(", ")}`,
+      `${withRules.length} bank(s) judged with per-scope observation_scope_limits ` +
+        `glob caps: ${withRules.map((r) => r.bankId).join(", ")}`,
     );
   }
-  const disabled = unjudged.filter((r) => !r.hasScopeLimitRules && !r.observationsEnabled);
+  const disabled = unjudged.filter((r) => !r.observationsEnabled);
   if (disabled.length > 0) {
     notes.push(
       `${disabled.length} bank(s) have observations disabled: ` +
@@ -399,10 +529,14 @@ export function classifyObservationScopeSaturation(
   const unlimited = judged.filter((r) => r.cap < 0);
   const capped = judged.filter((r) => r.cap > 0);
 
-  const failing = capped.flatMap((r) =>
+  // Derive the saturated scopes from EVERY judged bank, not just the ones whose
+  // bank-wide cap is positive: a glob-rule bank can carry a bank-wide cap of -1
+  // or 0 yet still have a scope capped (and saturated) by a rule (#3950). Each
+  // bank's `saturated` was already computed against the correct per-scope cap.
+  const failing = judged.flatMap((r) =>
     r.saturated.filter((s) => s.status === "fail").map((s) => ({ report: r, scope: s })),
   );
-  const warning = capped.flatMap((r) =>
+  const warning = judged.flatMap((r) =>
     r.saturated.filter((s) => s.status === "warn").map((s) => ({ report: r, scope: s })),
   );
   failing.sort((a, b) => b.scope.effective - a.scope.effective);
@@ -487,7 +621,7 @@ export function classifyObservationScopeSaturation(
     return { name, status: "warn", detail, ...(warning.length > 0 ? { fix } : {}) };
   }
 
-  const totalScopes = capped.reduce((n, r) => n + r.scopeCount, 0);
+  const totalScopes = capped.reduce((n, r) => n + r.judgedScopeCount, 0);
   const detailBase =
     capped.length === 0
       ? `no bank has a positive observation cap`
@@ -508,31 +642,6 @@ export function classifyObservationScopeSaturation(
     status: "ok",
     detail: detailBase + (extra.length > 0 ? ` · ${extra.join(" · ")}` : "") + suffix,
   };
-}
-
-interface FetchOpts {
-  fetchImpl?: typeof fetch;
-  timeoutMs?: number;
-}
-
-async function getJson<T>(
-  url: string,
-  opts?: FetchOpts,
-): Promise<{ ok: true; data: T } | { ok: false; reason: string }> {
-  const fetchImpl = opts?.fetchImpl ?? fetch;
-  const timeoutMs = opts?.timeoutMs ?? 15_000;
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const resp = await fetchImpl(url, { signal: controller.signal });
-    clearTimeout(timeout);
-    if (!resp.ok) return { ok: false, reason: `HTTP ${resp.status}` };
-    return { ok: true, data: (await resp.json()) as T };
-  } catch (err) {
-    clearTimeout(timeout);
-    if ((err as Error).name === "AbortError") return { ok: false, reason: "Timeout" };
-    return { ok: false, reason: String((err as Error).message ?? err) };
-  }
 }
 
 /**
@@ -565,6 +674,7 @@ export async function inspectBankScopes(
     observationsEnabled: false,
     hasScopeLimitRules: false,
     scopeCount: 0,
+    judgedScopeCount: 0,
     untaggedCount: 0,
     saturated: [],
     pendingConsolidation: null,
@@ -581,8 +691,8 @@ export async function inspectBankScopes(
   if (typeof rawCap !== "number" || !Number.isFinite(rawCap)) {
     return fail("Unexpected shape");
   }
-  const rules = config["observation_scope_limits"];
-  const hasScopeLimitRules = Array.isArray(rules) && rules.length > 0;
+  const scopeLimitRules = parseScopeLimitRules(config["observation_scope_limits"]);
+  const hasScopeLimitRules = scopeLimitRules.length > 0;
   // Absent means engine default (enabled); only an explicit `false` disables.
   const observationsEnabled = config["enable_observations"] !== false;
 
@@ -603,7 +713,13 @@ export async function inspectBankScopes(
     scopes.push({ tags: tags as string[], count });
   }
 
-  const saturated = computeScopeSaturation(scopes, rawCap).filter((s) => s.status !== "ok");
+  const allJudged = computeScopeSaturation(
+    scopes,
+    rawCap,
+    OBSERVATION_SCOPE_WARN_RATIO,
+    scopeLimitRules,
+  );
+  const saturated = allJudged.filter((s) => s.status !== "ok");
   // The untagged global scope: never in `saturated` (the engine skips it), but
   // it is the `curated` default sink and grows uncapped, so its size is tracked
   // and watched separately (OBSERVATION_SCOPE_UNTAGGED_WARN_COUNT).
@@ -617,7 +733,7 @@ export async function inspectBankScopes(
   // only when there is already something to explain, so a healthy fleet pays
   // nothing for it.
   let pendingConsolidation: number | null = null;
-  if (saturated.length > 0 && !hasScopeLimitRules && observationsEnabled) {
+  if (saturated.length > 0 && observationsEnabled) {
     const stats = await getJson<{ pending_consolidation?: unknown }>(
       `${base}/v1/default/banks/${bank}/stats`,
       opts,
@@ -634,6 +750,7 @@ export async function inspectBankScopes(
     observationsEnabled,
     hasScopeLimitRules,
     scopeCount: scopes.length,
+    judgedScopeCount: allJudged.length,
     untaggedCount,
     saturated,
     pendingConsolidation,

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -39,6 +39,7 @@ import {
   fetchHindsightToolsList,
   collectProfileBanks,
   fetchBankObservationsMission,
+  fetchBankRetainMission,
   decideObservationsMissionUpgrade,
   DEFAULT_OBSERVATIONS_MISSION,
   PROFILE_MEMORY_DEFAULTS,
@@ -50,7 +51,7 @@ import {
 } from "../setup/host-capabilities.js";
 import { findUnmanagedHindsightEnvKeys } from "../setup/hindsight-perf-defaults.js";
 import { inspectBankHealth, staleMentalModels, corruptedMentalModels, recentUnextracted, ageDays } from "../memory/bank-health.js";
-import { checkHindsightContainerHealth, classifyToolContract, checkHindsightHealthEndpoint, checkHindsightVersion, classifyConsolidationBacklog, classifyDirectiveCount } from "./doctor-memory.js";
+import { checkHindsightContainerHealth, classifyToolContract, checkHindsightHealthEndpoint, checkHindsightVersion, classifyConsolidationBacklog, classifyAsyncOpQueue, classifyDirectiveCount, classifyBankConfigReachability } from "./doctor-memory.js";
 import { checkAgentRecallHealth } from "./doctor-recall-health.js";
 import { checkHnswPartialIndexes } from "./doctor-hnsw-index.js";
 import { checkObservationScopeSaturation } from "./doctor-observation-scopes.js";
@@ -1392,6 +1393,35 @@ export async function checkBankObservationsMissions(
 }
 
 /**
+ * Bank-config API reachability (#3538). Retain-mission seeding went fail-closed
+ * in #3529: it reads the bank's mission via `GET .../config` and seeds nothing
+ * on a failed read (so a transient 5xx can't clobber an operator's mission).
+ * The exposure: if that API is disabled
+ * (`HINDSIGHT_API_ENABLE_BANK_CONFIG_API=false`) or the field is renamed, every
+ * read fails, apply seeds NO agent, and still exits 0 — a silent regression the
+ * old fail-open code would have masked. One probe of one representative bank
+ * turns that into a doctor row. Returns `[]` when there is no bank to probe.
+ */
+export async function checkBankConfigApiReachable(
+  config: SwitchroomConfig,
+  url: string,
+  opts?: { fetchImpl?: typeof fetch },
+): Promise<CheckResult[]> {
+  // One representative agent bank is enough: the flag / field-shape is a
+  // deployment-wide property of the Hindsight server, not per-bank. Resolve
+  // through defaults+profiles exactly as the seed path does.
+  let bankId: string | undefined;
+  for (const [agentName, agentConfig] of Object.entries(config.agents)) {
+    const resolved = resolveAgentConfig(config.defaults, config.profiles, agentConfig);
+    bankId = resolved.memory?.collection ?? agentName;
+    break;
+  }
+  if (bankId === undefined) return [];
+  const read = await fetchBankRetainMission(url, bankId, { fetchImpl: opts?.fetchImpl });
+  return [classifyBankConfigReachability(read, bankId)];
+}
+
+/**
  * Per-agent bank ingest health. One CheckResult per agent bank:
  *
  * - fail: recent documents (≤30d) stored with ZERO extracted facts — the
@@ -1431,23 +1461,38 @@ export async function checkBankIngestHealth(
     ),
   );
 
-  // Fleet-wide consolidation backlog (#2903 fix 5.3): sum the pending-op
-  // count across every reachable bank so `switchroom doctor` shows the queue
-  // depth the #2894 throttle can silently build. Oldest-pending age isn't on
-  // the REST /stats surface (measurement follow-up: #2847), so age is unknown.
-  // Gated off by default so the per-bank ingest contract stays clean for
-  // callers/tests that only want bank rows; the CLI doctor opts in below.
-  let backlogRow: CheckResult | undefined;
+  // Fleet-wide queue health (#2903 fix 5.3, corrected in #3949): two SEPARATE
+  // gauges, summed across every reachable bank, because they measure different
+  // things and drift apart under a stall —
+  //   * async op queue    → `/stats.pending_operations` (the TASK queue: catches
+  //                          a stuck reaper / claim stall).
+  //   * consolidation      → `/stats.pending_consolidation` (unconsolidated
+  //     backlog              `memory_units`: the REAL "is memory reaching
+  //                          recall" gauge). During the 2026-07 drain the op
+  //                          queue read ~5 while this ran to ~44k, so summing
+  //                          the op queue and CALLING it the consolidation
+  //                          backlog (the old code) showed green through the
+  //                          stall.
+  // Oldest-pending age isn't on the REST /stats surface (measurement follow-up:
+  // #2847), so age is unknown. Gated off by default so the per-bank ingest
+  // contract stays clean for callers/tests that only want bank rows; the CLI
+  // doctor opts in below.
+  const backlogRows: CheckResult[] = [];
   if (opts?.includeConsolidationBacklog) {
-    let totalPending = 0;
+    let totalPendingOps = 0;
+    let totalPendingConsolidation = 0;
     let anyBankReachable = false;
     for (const [, , h] of inspected) {
       if (h.ok) {
         anyBankReachable = true;
-        totalPending += h.pendingOperations;
+        totalPendingOps += h.pendingOperations;
+        totalPendingConsolidation += h.pendingConsolidation;
       }
     }
-    if (anyBankReachable) backlogRow = classifyConsolidationBacklog(totalPending);
+    if (anyBankReachable) {
+      backlogRows.push(classifyAsyncOpQueue(totalPendingOps));
+      backlogRows.push(classifyConsolidationBacklog(totalPendingConsolidation));
+    }
   }
 
   for (const [bankId, agents, h] of inspected) {
@@ -1534,7 +1579,7 @@ export async function checkBankIngestHealth(
     }
     results.push({ name: label, status: "ok", detail: summary });
   }
-  if (backlogRow) results.push(backlogRow);
+  results.push(...backlogRows);
   return results;
 }
 
@@ -1675,6 +1720,12 @@ async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> 
   // and invisible everywhere else, which is how the whole fleet ran the
   // engine's stock consolidation mission unnoticed (see the function's doc).
   results.push(...(await checkBankObservationsMissions(config, url)));
+
+  // The bank-config API those missions are seeded through must actually be
+  // reachable: since #3529 retain-mission seeding is fail-closed, so a disabled
+  // HINDSIGHT_API_ENABLE_BANK_CONFIG_API or a renamed field silently skips
+  // seeding for every agent and still exits 0 (#3538).
+  results.push(...(await checkBankConfigApiReachable(config, url)));
 
   // …and whether those scopes still have room to consolidate INTO. Hindsight
   // caps observations per scope; past the cap the consolidator keeps running,

--- a/src/memory/bank-health.ts
+++ b/src/memory/bank-health.ts
@@ -101,7 +101,25 @@ export interface BankHealth {
   /** From /stats */
   totalDocuments: number;
   totalFacts: number;
+  /**
+   * Depth of the async operation queue — `/stats.pending_operations`, the
+   * count of `async_operations` rows in `pending`/`processing`. This is the
+   * TASK queue (retains, refreshes, consolidations waiting to be claimed), not
+   * the memory-consolidation backlog: during the 2026-07 reconsolidation drain
+   * it read ~5 while 44k memory units sat unconsolidated. Use it for stuck-op
+   * detection, NOT as a proxy for consolidation progress (that's
+   * {@link pendingConsolidation}).
+   */
   pendingOperations: number;
+  /**
+   * The REAL memory-consolidation backlog — `/stats.pending_consolidation`,
+   * the count of `memory_units` with `consolidated_at IS NULL AND fact_type IN
+   * ('experience','world')`. This is what actually gauges whether retained
+   * memory is making it into recall; it grows to tens of thousands during a
+   * consolidation stall while {@link pendingOperations} stays near zero. `0`
+   * when the field is absent (older engine) or the bank is drained.
+   */
+  pendingConsolidation: number;
   /** From /documents */
   newestDocumentAt: string | null;
   /** Documents stored but with zero extracted facts (the extraction-gap fingerprint). */
@@ -126,12 +144,23 @@ export function hindsightRestBase(mcpUrl: string): string {
 
 const DOCUMENTS_PAGE_LIMIT = 500;
 
-interface FetchOpts {
+export interface FetchOpts {
   fetchImpl?: typeof fetch;
   timeoutMs?: number;
 }
 
-async function getJson<T>(
+/**
+ * Best-effort JSON GET with a whole-request timeout. Shared by every Hindsight
+ * REST probe (bank-health here and the observation-scope check) so the timeout
+ * behaviour lives in one place. Never throws — an unreachable/erroring/slow
+ * server yields `{ ok: false, reason }`.
+ *
+ * The `clearTimeout` is in a `finally` AFTER the body read on purpose: a slow
+ * or hanging response BODY must be bounded by `timeoutMs` too, not just the
+ * headers (the earlier copies cleared the timer before `resp.json()`, leaving
+ * a hung body uncovered — #3954 item 2).
+ */
+export async function getJson<T>(
   url: string,
   opts?: FetchOpts,
 ): Promise<{ ok: true; data: T } | { ok: false; reason: string }> {
@@ -144,13 +173,13 @@ async function getJson<T>(
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const resp = await fetchImpl(url, { signal: controller.signal });
-    clearTimeout(timeout);
     if (!resp.ok) return { ok: false, reason: `HTTP ${resp.status}` };
     return { ok: true, data: (await resp.json()) as T };
   } catch (err) {
-    clearTimeout(timeout);
     if ((err as Error).name === "AbortError") return { ok: false, reason: "Timeout" };
     return { ok: false, reason: String((err as Error).message ?? err) };
+  } finally {
+    clearTimeout(timeout);
   }
 }
 
@@ -206,6 +235,7 @@ export async function inspectBankHealth(
     totalDocuments: 0,
     totalFacts: 0,
     pendingOperations: 0,
+    pendingConsolidation: 0,
     newestDocumentAt: null,
     unextractedDocuments: [],
     mentalModels: [],
@@ -216,6 +246,7 @@ export async function inspectBankHealth(
     total_documents?: number;
     total_nodes?: number;
     pending_operations?: number;
+    pending_consolidation?: number;
   }>(`${base}/v1/default/banks/${bank}/stats`, opts);
   if (!stats.ok) return { ...empty, reason: stats.reason };
 
@@ -285,6 +316,7 @@ export async function inspectBankHealth(
     totalDocuments: stats.data.total_documents ?? docItems.length,
     totalFacts: stats.data.total_nodes ?? 0,
     pendingOperations: stats.data.pending_operations ?? 0,
+    pendingConsolidation: stats.data.pending_consolidation ?? 0,
     newestDocumentAt,
     unextractedDocuments: unextracted,
     activeDirectiveCount,

--- a/tests/cli.doctor.memory-health.test.ts
+++ b/tests/cli.doctor.memory-health.test.ts
@@ -9,6 +9,8 @@ import {
   classifyHindsightHealthProbe,
   checkHindsightHealthEndpoint,
   classifyConsolidationBacklog,
+  classifyAsyncOpQueue,
+  classifyBankConfigReachability,
   classifyDirectiveCount,
   MAX_DIRECTIVES,
   DIRECTIVE_WARN_THRESHOLD,
@@ -19,6 +21,8 @@ import {
   classifyLiteLlmReachability,
   CONSOLIDATION_BACKLOG_WARN,
   CONSOLIDATION_BACKLOG_FAIL,
+  OP_QUEUE_WARN,
+  OP_QUEUE_FAIL,
   type AdvertisedTool,
   MIN_HINDSIGHT_SHM_BYTES,
   classifyHindsightVersionSkew,
@@ -75,38 +79,114 @@ describe("classifyToolContract — live contract-drift detector", () => {
   });
 });
 
-describe("classifyConsolidationBacklog (#2903 fix 5.3)", () => {
+// The async OPERATION queue (pending_operations) — the TASK queue. Formerly
+// this classifier was (mis)named the "consolidation backlog"; #3949 split it
+// from the real memory backlog below.
+describe("classifyAsyncOpQueue (#2903 fix 5.3, renamed #3949)", () => {
   it("ok when the queue is drained", () => {
-    const r = classifyConsolidationBacklog(0);
+    const r = classifyAsyncOpQueue(0);
     expect(r.status).toBe("ok");
+    expect(r.name).toBe("hindsight async op queue");
     expect(r.detail).toMatch(/drained/);
   });
 
   it("ok (not warn) just below the warn threshold", () => {
-    const r = classifyConsolidationBacklog(CONSOLIDATION_BACKLOG_WARN - 1);
+    const r = classifyAsyncOpQueue(OP_QUEUE_WARN - 1);
     expect(r.status).toBe("ok");
   });
 
   it("warns once the queue crosses the warn threshold", () => {
-    const r = classifyConsolidationBacklog(CONSOLIDATION_BACKLOG_WARN);
+    const r = classifyAsyncOpQueue(OP_QUEUE_WARN);
     expect(r.status).toBe("warn");
-    expect(r.detail).toContain(`${CONSOLIDATION_BACKLOG_WARN} pending`);
+    expect(r.detail).toContain(`${OP_QUEUE_WARN} pending`);
   });
 
   it("fails when the queue is deep enough to be wedged", () => {
-    const r = classifyConsolidationBacklog(CONSOLIDATION_BACKLOG_FAIL);
+    const r = classifyAsyncOpQueue(OP_QUEUE_FAIL);
     expect(r.status).toBe("fail");
     expect(r.fix).toBeDefined();
   });
 
   it("includes the oldest-op age when it is known", () => {
-    const r = classifyConsolidationBacklog(CONSOLIDATION_BACKLOG_WARN, 7200);
+    const r = classifyAsyncOpQueue(OP_QUEUE_WARN, 7200);
     expect(r.detail).toMatch(/oldest 120m old/);
   });
 
   it("omits the age clause when age is unknown (REST /stats has no per-op age — #2847)", () => {
-    const r = classifyConsolidationBacklog(CONSOLIDATION_BACKLOG_WARN, null);
+    const r = classifyAsyncOpQueue(OP_QUEUE_WARN, null);
     expect(r.detail).not.toMatch(/oldest/);
+  });
+
+  it("describes async ops, NOT consolidation (the #3949 mislabel is gone)", () => {
+    const r = classifyAsyncOpQueue(OP_QUEUE_FAIL);
+    expect(r.detail).toMatch(/async op/i);
+    expect(r.detail).not.toMatch(/consolidat/i);
+  });
+});
+
+// The REAL memory-consolidation backlog (pending_consolidation — unconsolidated
+// memory_units). Memory-scale thresholds: the incident ran to ~44k while the
+// healthy fleet floor is <50 (#3949).
+describe("classifyConsolidationBacklog (#3949 — reads pending_consolidation)", () => {
+  it("ok when consolidation is drained", () => {
+    const r = classifyConsolidationBacklog(0);
+    expect(r.status).toBe("ok");
+    expect(r.name).toBe("hindsight consolidation backlog");
+    expect(r.detail).toMatch(/drained/);
+  });
+
+  it("ok at a healthy memory-scale reading (well below memory-scale warn)", () => {
+    // 45 was the largest HEALTHY per-bank reading (B9c) — must NOT warn.
+    const r = classifyConsolidationBacklog(45);
+    expect(r.status).toBe("ok");
+    expect(r.detail).toMatch(/45 memory unit/);
+  });
+
+  it("warns once the backlog crosses the memory-scale warn threshold", () => {
+    const r = classifyConsolidationBacklog(CONSOLIDATION_BACKLOG_WARN);
+    expect(r.status).toBe("warn");
+    expect(r.detail).toMatch(/memory unit/);
+  });
+
+  it("fails at a stall (44k — the 2026-07 incident depth)", () => {
+    const r = classifyConsolidationBacklog(44_000);
+    expect(r.status).toBe("fail");
+    expect(r.fix).toBeDefined();
+    expect(CONSOLIDATION_BACKLOG_FAIL).toBeLessThanOrEqual(44_000);
+  });
+
+  it("counts MEMORY UNITS, not async ops (the #3949 truth swap)", () => {
+    const r = classifyConsolidationBacklog(CONSOLIDATION_BACKLOG_FAIL);
+    expect(r.detail).toMatch(/memory unit/);
+    expect(r.detail).not.toMatch(/async op/i);
+  });
+});
+
+describe("classifyBankConfigReachability (#3538 — fail-closed seed path visibility)", () => {
+  it("OK when retain_mission is readable", () => {
+    const r = classifyBankConfigReachability({ ok: true }, "overlord");
+    expect(r.status).toBe("ok");
+    expect(r.name).toBe("hindsight bank-config API");
+    expect(r.detail).toMatch(/overlord/);
+  });
+
+  it("FAILS when a 200 carries no retain_mission key (API disabled / field renamed)", () => {
+    const r = classifyBankConfigReachability({ ok: false, reason: "Unexpected shape" }, "overlord");
+    expect(r.status).toBe("fail");
+    // The failure must name the flag and the silent-skip consequence so an
+    // operator can act — this is the whole point of the row.
+    expect(r.fix).toMatch(/HINDSIGHT_API_ENABLE_BANK_CONFIG_API/);
+    expect(r.detail).toMatch(/retain_mission/);
+    expect(r.detail).toMatch(/silently|exits 0/);
+  });
+
+  it("WARNs (not FAIL) when the surface can't be probed at all (server down)", () => {
+    // A down server is the container-health check's job to redden; here it is a
+    // WARN so a transient outage doesn't double-red as a config-API defect.
+    const http = classifyBankConfigReachability({ ok: false, reason: "HTTP 502" }, "overlord");
+    expect(http.status).toBe("warn");
+    const timeout = classifyBankConfigReachability({ ok: false, reason: "Timeout" }, "overlord");
+    expect(timeout.status).toBe("warn");
   });
 });
 

--- a/tests/memory.bank-health.test.ts
+++ b/tests/memory.bank-health.test.ts
@@ -8,7 +8,11 @@ import {
   recentUnextracted,
   ageDays,
 } from "../src/memory/bank-health.js";
-import { checkBankIngestHealth, checkBankObservationsMissions } from "../src/cli/doctor.js";
+import {
+  checkBankIngestHealth,
+  checkBankObservationsMissions,
+  checkBankConfigApiReachable,
+} from "../src/cli/doctor.js";
 import {
   DEFAULT_OBSERVATIONS_MISSION,
   SUPERSEDED_OBSERVATIONS_MISSIONS,
@@ -329,6 +333,49 @@ function minimalConfig(agents: Record<string, { memory?: { collection?: string }
   } as unknown as SwitchroomConfig;
 }
 
+describe("checkBankConfigApiReachable (#3538)", () => {
+  /** Serve one bank's /config with a chosen body. */
+  const configFetch = (body: unknown, status = 200): typeof fetch =>
+    (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (/\/config$/.test(url)) {
+        return new Response(status === 200 ? JSON.stringify(body) : "err", { status });
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+
+  it("OK when the bank's /config carries a retain_mission key", async () => {
+    const results = await checkBankConfigApiReachable(minimalConfig({ marko: {} }), "http://x/mcp/", {
+      fetchImpl: configFetch({ config: { retain_mission: "Extract durable facts." } }),
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe("ok");
+    expect(results[0].name).toBe("hindsight bank-config API");
+  });
+
+  it("FAILS when /config returns 200 without a retain_mission key (API disabled / renamed)", async () => {
+    const results = await checkBankConfigApiReachable(minimalConfig({ marko: {} }), "http://x/mcp/", {
+      fetchImpl: configFetch({ config: { some_other_field: 1 } }),
+    });
+    expect(results[0].status).toBe("fail");
+    expect(results[0].fix).toMatch(/HINDSIGHT_API_ENABLE_BANK_CONFIG_API/);
+  });
+
+  it("WARNs (not FAIL) when the config surface is unreachable", async () => {
+    const results = await checkBankConfigApiReachable(minimalConfig({ marko: {} }), "http://x/mcp/", {
+      fetchImpl: configFetch(null, 503),
+    });
+    expect(results[0].status).toBe("warn");
+  });
+
+  it("emits no row when there is no agent bank to probe", async () => {
+    const results = await checkBankConfigApiReachable(minimalConfig({}), "http://x/mcp/", {
+      fetchImpl: configFetch({ config: {} }),
+    });
+    expect(results).toHaveLength(0);
+  });
+});
+
 describe("checkBankIngestHealth (doctor)", () => {
   it("fails the bank with recent unextracted documents and carries the reprocess fix", async () => {
     const results = await checkBankIngestHealth(
@@ -440,7 +487,7 @@ describe("checkBankIngestHealth (doctor)", () => {
     expect(ok.some((r) => r.name === "bank marko directives")).toBe(false);
   });
 
-  it("omits the fleet consolidation-backlog row unless opted in (#2903 fix 5.3)", async () => {
+  it("omits the fleet queue rows unless opted in (#2903 fix 5.3)", async () => {
     const BACKLOGGED = {
       stats: { total_documents: 5, total_nodes: 50, pending_operations: 250 },
       documents: { items: [{ id: "d1", created_at: "2026-06-09T00:00:00Z", text_length: 100, memory_unit_count: 2 }] },
@@ -449,19 +496,74 @@ describe("checkBankIngestHealth (doctor)", () => {
     const cfg = minimalConfig({ marko: {} });
     const fetchImpl = fakeFetchFor({ marko: BACKLOGGED });
 
-    // Default: per-bank rows only, no backlog aggregate (protects the contract
+    // Default: per-bank rows only, no aggregate rows (protects the contract
     // the other tests in this file assert exact lengths against).
     const bare = await checkBankIngestHealth(cfg, "http://x/mcp/", { fetchImpl, now: NOW });
-    expect(bare.some((r) => /backlog/i.test(r.name))).toBe(false);
+    expect(bare.some((r) => /backlog|op queue/i.test(r.name))).toBe(false);
 
-    // Opted in (as the CLI doctor does): the aggregate row is appended last.
+    // Opted in (as the CLI doctor does): BOTH aggregate rows are appended.
     const withBacklog = await checkBankIngestHealth(cfg, "http://x/mcp/", {
       fetchImpl,
       now: NOW,
       includeConsolidationBacklog: true,
     });
-    expect(withBacklog.length).toBe(bare.length + 1);
-    expect(/backlog/i.test(withBacklog[withBacklog.length - 1].name)).toBe(true);
+    expect(withBacklog.length).toBe(bare.length + 2);
+    expect(withBacklog.some((r) => r.name === "hindsight async op queue")).toBe(true);
+    expect(withBacklog.some((r) => r.name === "hindsight consolidation backlog")).toBe(true);
+  });
+
+  it("#3949: a deep async op queue does NOT masquerade as a consolidation backlog", async () => {
+    // The 2026-07 blind spot: pending_operations reads shallow while
+    // pending_consolidation runs to tens of thousands. Here the OPPOSITE input —
+    // a deep op queue (250) with a SHALLOW consolidation backlog (5) — must
+    // FAIL the op-queue row and leave the consolidation row OK. The old code
+    // summed pending_operations and CALLED it the consolidation backlog, which
+    // would have (a) failed the wrong row and (b) shown green through the real
+    // stall. Both rows now read their own /stats field.
+    const cfg = minimalConfig({ marko: {} });
+    const fetchImpl = fakeFetchFor({
+      marko: {
+        stats: {
+          total_documents: 5,
+          total_nodes: 50,
+          pending_operations: 250,
+          pending_consolidation: 5,
+        },
+        documents: { items: [{ id: "d1", created_at: "2026-06-09T00:00:00Z", text_length: 100, memory_unit_count: 2 }] },
+        models: { items: [] },
+      },
+    });
+    const results = await checkBankIngestHealth(cfg, "http://x/mcp/", {
+      fetchImpl,
+      now: NOW,
+      includeConsolidationBacklog: true,
+    });
+    const opQueue = results.find((r) => r.name === "hindsight async op queue");
+    const consolidation = results.find((r) => r.name === "hindsight consolidation backlog");
+    expect(opQueue?.status).toBe("fail");
+    expect(consolidation?.status).toBe("ok");
+
+    // ...and the inverse: a shallow op queue with a 44k consolidation backlog
+    // (the actual incident shape) fails the CONSOLIDATION row, not the op queue.
+    const stallFetch = fakeFetchFor({
+      marko: {
+        stats: {
+          total_documents: 5,
+          total_nodes: 50,
+          pending_operations: 5,
+          pending_consolidation: 44_000,
+        },
+        documents: { items: [{ id: "d1", created_at: "2026-06-09T00:00:00Z", text_length: 100, memory_unit_count: 2 }] },
+        models: { items: [] },
+      },
+    });
+    const stall = await checkBankIngestHealth(cfg, "http://x/mcp/", {
+      fetchImpl: stallFetch,
+      now: NOW,
+      includeConsolidationBacklog: true,
+    });
+    expect(stall.find((r) => r.name === "hindsight async op queue")?.status).toBe("ok");
+    expect(stall.find((r) => r.name === "hindsight consolidation backlog")?.status).toBe("fail");
   });
 });
 


### PR DESCRIPTION
## Cluster 3 — "the instruments lie" (doctor truth rows)

The doctor/health layer measured proxies and mislabelled reasons, so gauges stayed green through the exact stalls they were meant to catch. This PR makes each row read the field it claims to.

### #3949 — the consolidation backlog was the op queue
`checkBankIngestHealth` summed each bank's `/stats.pending_operations` (the async **task** queue) and called it the "consolidation backlog". During the 2026-07 reconsolidation drain that read ~5 while **44k** memory units sat unconsolidated — green through the stall.

Now two truth rows, each reading its own `/stats` field:
- **`hindsight async op queue`** (`pending_operations`) — the task queue; catches a stuck reaper / claim stall. (Formerly `classifyConsolidationBacklog` → `classifyAsyncOpQueue`, `OP_QUEUE_WARN/FAIL` = 25/200.)
- **`hindsight consolidation backlog`** (`pending_consolidation`) — the **real** memory backlog, memory-scale thresholds (WARN 1000 / FAIL 10000; healthy fleet floor <50, incident ~44k).

### #3954 — OK row counted a scope it never judged
The observation-scope OK detail printed `scopes.length` (includes the untagged scope the engine never caps). Now reports `judgedScopeCount` (scopes actually evaluated). Also exports/shares `getJson` from `bank-health.ts` (dedupes a byte-identical copy) and moves its `clearTimeout` into `finally` so a slow response **body** is bounded by the timeout too, not just the headers.

### #3950 — glob scope-limit banks were skipped
Mirrors the engine's `observation_scope_limits` resolution (`fnmatchcase` / `_scope_matches_globs` / `_effective_scope_limit`, `consolidator.py:606-683`) in TS, exact-cover in both directions, first-match-wins. Banks carrying per-scope glob caps are now judged against the same effective cap the engine enforces instead of reported as skip.

### #3538 — fail-closed retain-mission seeding was invisible
Since #3529 seeding reads `GET .../config` and pushes nothing on a failed read. If `HINDSIGHT_API_ENABLE_BANK_CONFIG_API` is disabled or the field is renamed, every read fails, apply seeds no agent, and still exits 0. New `hindsight bank-config API` row FAILs on a 200-without-key and WARNs on an unreachable surface, naming the flag.

## Tests (assert outcomes)
- A shallow op queue with a 44k consolidation backlog fails the **consolidation** row, not the op queue — and the inverse.
- The glob mirror is pinned against the engine docstring examples (`["shared"]` matches `{shared}` not `{run_1, shared}`; `["run_*","shared"]` matches `{run_1, shared}` not `{shared}`).
- `#3538` classifier + wiring: FAIL on 200-without-key, WARN on unreachable, no row when there's no bank.

Scoped `vitest` (162 tests across the three files) + `tsc --noEmit` green locally.

Job: `reference/jobs/fleet-stays-healthy.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)