### PR TITLE
feat(backfill): operator-visible convergence for total-loss self-heal

### DIFF
--- a/vendor/hindsight-memory/scripts/backfill_transcripts.py
+++ b/vendor/hindsight-memory/scripts/backfill_transcripts.py
@@ -706,6 +706,11 @@ class Backfill:
             "sessions_gap_incomplete": 0,
             "slices_gap_filled": 0,
             "slices_gap_present": 0,
+            # Convergence visibility (#3291 self-heal): sessions that STILL are
+            # not fully recovered after this run (a restore or gap-completion
+            # POST failed). Non-zero ⇒ another run is needed; surfaced so a
+            # non-converging session can never be a SILENT permanent trap.
+            "sessions_incomplete": 0,
             "turns_recovered": 0,
             "posts_ok": 0,
             "posts_failed": 0,
@@ -949,8 +954,26 @@ class Backfill:
                 self.progress.record(agent, session, "done", slices=total, turns=n_turns)
             else:
                 session_entry["action"] = "restore_failed"
+                ar["sessions_incomplete"] += 1
                 self.progress.record(agent, session, "failed")
             ar["sessions"].append(session_entry)
+
+        # Convergence visibility: if any session is still short after this run,
+        # tell the operator plainly (and how to converge it) so a session that
+        # keeps failing can never be a silent permanent trap. The mechanism
+        # guarantees forward progress — each re-run posts only what is still
+        # missing — but a persistently-unpostable session needs a human.
+        if self.commit and ar["sessions_incomplete"] > 0:
+            stuck = [s.get("session") for s in ar["sessions"]
+                     if s.get("action") in ("restore_failed", "gap_incomplete")]
+            print(
+                f"[Hindsight] backfill(from-logs): {agent} — "
+                f"{ar['sessions_incomplete']} session(s) still INCOMPLETE after this "
+                f"run (POST failures): {', '.join(str(s) for s in stuck)}. Re-run "
+                f"`--from-logs --commit --agent {agent}` to fill the remaining "
+                f"slices (gap-completion posts ONLY what is still missing).",
+                file=sys.stderr,
+            )
 
     def _gap_complete_session(self, agent, session, bank_id, path, info, ar) -> None:
         """Fill the missing slices of a backfill-sole-writer session left
@@ -1042,6 +1065,7 @@ class Backfill:
             # gap-completion path (never the membership skip) and fills whatever
             # remains. Convergent: each run strictly reduces the missing set.
             ar["sessions_gap_incomplete"] += 1
+            ar["sessions_incomplete"] += 1
             session_entry["action"] = "gap_incomplete"
             self.progress.record(agent, session, "failed")
         ar["sessions"].append(session_entry)
@@ -1062,6 +1086,11 @@ class Backfill:
             "sessions_already_done": 0,
             "sessions_restored": 0,
             "slices_restored": 0,
+            "sessions_gap_completed": 0,
+            "sessions_gap_incomplete": 0,
+            "slices_gap_filled": 0,
+            "slices_gap_present": 0,
+            "sessions_incomplete": 0,
             "turns_recovered": 0,
             "posts_ok": 0,
             "posts_failed": 0,
@@ -1076,6 +1105,8 @@ class Backfill:
                 "unmatched_turns", "sessions_has_documents", "sessions_total_loss",
                 "sessions_membership_error", "sessions_active_skipped",
                 "sessions_already_done", "sessions_restored", "slices_restored",
+                "sessions_gap_completed", "sessions_gap_incomplete",
+                "slices_gap_filled", "slices_gap_present", "sessions_incomplete",
                 "turns_recovered", "posts_ok", "posts_failed",
             ):
                 roll[k] += ar.get(k, 0)
@@ -1132,11 +1163,15 @@ def format_report_from_logs(report: dict) -> str:
             f"already_done={ar['sessions_already_done']} "
             f"restored={ar['sessions_restored']} "
             f"slices_restored={ar['slices_restored']} "
+            f"gap_completed={ar.get('sessions_gap_completed', 0)} "
+            f"gap_filled={ar.get('slices_gap_filled', 0)} "
+            f"incomplete={ar.get('sessions_incomplete', 0)} "
             f"turns={ar['turns_recovered']} "
             f"posts_ok={ar['posts_ok']} posts_failed={ar['posts_failed']}"
         )
         for s in ar.get("sessions", []):
-            if s.get("class") in ("total_loss", "membership_error", "ambiguous"):
+            if s.get("class") in ("total_loss", "gap_completion",
+                                  "membership_error", "ambiguous"):
                 lines.append(
                     f"      - {s.get('session', s.get('turn_key'))} [{s.get('class')}] "
                     f"join={s.get('join', '-')} "
@@ -1154,9 +1189,21 @@ def format_report_from_logs(report: dict) -> str:
         f"membership_err={roll.get('sessions_membership_error', 0)} "
         f"restored={roll.get('sessions_restored', 0)} "
         f"slices_restored={roll.get('slices_restored', 0)} "
+        f"gap_completed={roll.get('sessions_gap_completed', 0)} "
+        f"gap_filled={roll.get('slices_gap_filled', 0)} "
+        f"incomplete={roll.get('sessions_incomplete', 0)} "
         f"turns_would_recover={roll.get('turns_recovered', 0)} "
         f"posts_ok={roll.get('posts_ok', 0)} posts_failed={roll.get('posts_failed', 0)}"
     )
+    incomplete = roll.get("sessions_incomplete", 0)
+    if incomplete:
+        lines.append(
+            f"  ⚠ CONVERGENCE: {incomplete} session(s) still INCOMPLETE (a POST "
+            f"failed). Re-run `--from-logs --commit` — gap-completion posts ONLY "
+            f"the still-missing slices, so each run strictly reduces the gap. A "
+            f"count that never reaches 0 across runs means a persistently-"
+            f"unpostable session that needs a human."
+        )
     lines.append("  NOTE: recovers only ZERO-document (total-loss) sessions. "
                  "Partial-tail recovery within a populated session is OUT OF SCOPE "
                  "on legacy epoch-ms banks (needs the -r{uuid} id scheme deployed).")

--- a/vendor/hindsight-memory/scripts/tests/test_backfill_from_logs.py
+++ b/vendor/hindsight-memory/scripts/tests/test_backfill_from_logs.py
@@ -530,6 +530,33 @@ class TestFromLogs(FromLogsTestBase):
         # Watermark advanced to the true tail slice on completion.
         self.assertIsNotNone(watermark.load("sess-partial"))
 
+    # --- #3291 self-heal: a persistently-failing slice must surface as an
+    #     operator-visible INCOMPLETE metric + convergence WARN, never a silent
+    #     trap. -----------------------------------------------------------------
+    def test_incomplete_session_surfaces_convergence_metric(self):
+        self._write_yaml({"clerk": None})
+        self._write_settings("clerk", "clerk")
+        base = 1_700_000_000_000
+        path, (first, last) = self._transcript("clerk", "sess-stuck", 2, base)
+        self._registry("clerk", [{
+            "turn_key": "123:_:t", "chat_id": "123", "started_at": str(first + 100),
+            "ended_at": str(last), "ended_via": "sigterm",
+        }])
+        # The first slice fails every attempt → session left INCOMPLETE.
+        self.daemon.fail_distinct_indices = {0}
+
+        report = self._run("clerk")
+        ar = report["agents"]["clerk"]
+        # Metric: one session did not fully recover.
+        self.assertEqual(ar["sessions_incomplete"], 1)
+        self.assertEqual(ar["sessions_restored"], 0)
+        self.assertEqual(report["rollup"]["sessions_incomplete"], 1)
+        # Operator-visible: the formatted report carries the count + a WARN that
+        # tells them to re-run (so a non-converging session is never silent).
+        text = bf.format_report_from_logs(report)
+        self.assertIn("incomplete=1", text)
+        self.assertIn("CONVERGENCE", text)
+
     # --- direct session_id join (migrated registry) -------------------------
     def test_direct_sessionid_join(self):
         self._write_yaml({"clerk": None})


### PR DESCRIPTION
**Stacked on #4074** (base is `fix/backfill-3291-gap-completion`; review/merge that first). This is the self-heal feature built on top of the gap-completion mechanism.

## What

The #3291 gap-completion path already guarantees each re-run posts only the still-missing slices (strictly reducing the gap), so a total-loss session can never be silently trapped by the session-membership skip. This PR adds the operator-visible convergence layer so a *persistently* non-converging session (a slice that keeps failing to POST) is impossible to miss:

- **`sessions_incomplete`** metric — per-agent and rolled up — counts sessions still short after the run (a restore or gap-completion POST failed).
- **`sessions_gap_completed` / `slices_gap_filled`** rolled up and shown in the per-agent line and rollup.
- A **⚠ CONVERGENCE** line in `format_report_from_logs` and a **per-agent stderr line** naming the stuck sessions and the exact `--from-logs --commit --agent <name>` re-run command. A count that never reaches 0 across runs flags a session that needs a human — instead of being an invisible permanent trap.

Note: the `maintenance.sh` dead-letter requeue and the `doctor` dead-letter metric are owned by another worker and are deliberately **not** touched here — this is backfill-side only.

## Test

`test_incomplete_session_surfaces_convergence_metric` — a persistently-failing slice must set `sessions_incomplete` (per-agent + rollup) and put `incomplete=1` + a `CONVERGENCE` warning into the operator-facing report. Verified non-vacuous (fails with the increment removed).

## Test plan

`cd vendor/hindsight-memory/scripts && python3 -m unittest discover tests/` — 971 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)