### PR TITLE
fix(scaffold): expand model aliases from one shared table (#3998)

### DIFF
--- a/src/agents/model-aliases.ts
+++ b/src/agents/model-aliases.ts
@@ -1,0 +1,128 @@
+/**
+ * Shared model-alias tables and the ONE expansion every switchroom-side model
+ * token flows through.
+ *
+ * This is the single source of truth consumed by BOTH sites that turn a
+ * user/operator-supplied model token into a canonical `claude --model` value:
+ *
+ *   - the gateway `/model` command (`telegram-plugin/gateway/model-command.ts`,
+ *     which re-exports these for its existing public API), and
+ *   - config-default resolution at scaffold time
+ *     (`resolveMainModel` / `normalizeModelAlias` in `scaffold.ts`).
+ *
+ * Before this module existed the two sites carried DIVERGENT alias tables:
+ * scaffold expanded only `claude-fable-5 → fable`, so a config
+ * `model: opus48` (a shortcut the gateway `/model` path happily expands to
+ * `claude-opus-4-8`) was launched VERBATIM as `opus48` — a token the claude CLI
+ * cannot resolve. Sharing one table kills that divergence class: every alias
+ * the gateway accepts now resolves identically in scaffold.
+ */
+
+/**
+ * Short SWITCHROOM-side spellings for pinned **Anthropic** model ids. These are
+ * expanded to the full `claude-*` id on the `/model` path BEFORE any
+ * Claude-vs-external classification runs, so what reaches the `.session-model`
+ * carrier (and therefore `claude --model`) is always the canonical id — the CLI
+ * never sees the short spelling.
+ *
+ * Deliberately NOT `SR_MODEL_ALIASES`: that map means "external / OpenRouter /
+ * the Anthropic OAuth header is NOT forwarded". These targets are Anthropic
+ * OAuth-passthrough models, so putting them there would flip the
+ * header-forwarding + external-billing classification and surface them under the
+ * "🌐 External models" keyboard page with an `srFriendlyLabel`.
+ *
+ * Also NOT `MODEL_ALIASES`: that list is the aliases the claude CLI resolves
+ * *itself*, and its members double as FAMILY tokens in `modelFamilyToken` /
+ * `canonicalClaudeToken` / `servedModelMatchesRequested`. A pinned-id shortcut
+ * is neither.
+ *
+ * NB the repo prefers family aliases over pinned ids (an alias tracks the
+ * current flagship, a pinned id goes stale) — these exist because an operator
+ * sometimes wants a specific pinned Opus, and typing `claude-opus-4-8` on a
+ * phone is hostile. Keys are matched case-insensitively.
+ */
+export const CLAUDE_MODEL_ALIASES: Record<string, string> = {
+  opus48: 'claude-opus-4-8',
+  'opus-4-8': 'claude-opus-4-8',
+}
+
+/**
+ * Short text-command aliases for sr-* models. These let the operator type
+ * `/model flash`, `/model codex`, etc. instead of the full `sr-*` id.
+ * Expanded in handleModelCommand before injection; the full sr-* id is what
+ * reaches the agent session and LiteLLM.
+ */
+export const SR_MODEL_ALIASES: Record<string, string> = {
+  flash: 'sr-gemini-2.5-flash',
+  gemini: 'sr-gemini-2.5-pro',
+  deepseek: 'sr-deepseek-v3',
+  r1: 'sr-deepseek-r1',
+  glm: 'sr-glm-5',
+  codex: 'sr-codex-5.5',
+  // Flagship keyboard buttons for the three providers added 2026-07-19. Each
+  // points at that provider's top tier; the cheaper tiers (grok-4.3,
+  // kimi-k2.7-code, gpt-5.6-terra/luna) stay typeable via `/model sr-<id>` and
+  // keep a friendly label above, matching the "labels are a superset of buttons"
+  // design (SR_MODEL_LABELS doc comment).
+  grok: 'sr-grok-4.5',
+  kimi: 'sr-kimi-k3',
+  gpt: 'sr-gpt-5.6-sol',
+  // Per-tier buttons for the GPT-5.6 line so each is a one-word shortcut
+  // (`gpt` stays the flagship-Sol default). Added 2026-07-19.
+  sol: 'sr-gpt-5.6-sol',
+  terra: 'sr-gpt-5.6-terra',
+  luna: 'sr-gpt-5.6-luna',
+}
+
+/** Expand a short alias (case-insensitive) to its full sr-* id, or return the original. */
+export function expandSrAlias(arg: string): string {
+  return SR_MODEL_ALIASES[arg.toLowerCase()] ?? arg
+}
+
+/** Expand a short pinned-Claude spelling (case-insensitive) to its full `claude-*` id. */
+export function expandClaudeAlias(arg: string): string {
+  return CLAUDE_MODEL_ALIASES[arg.trim().toLowerCase()] ?? arg
+}
+
+/**
+ * The ONE canonical form of a model token — what `claude --model` is handed and
+ * what every downstream gate compares against.
+ *
+ * Two normalizations, both narrow:
+ *   - **trim** — unconditional. `unvalidatedIdCaveat` already trimmed while
+ *     expansion did not, so the two disagreed on a padded token.
+ *   - **lowercase, `claude-*` ONLY.** Every real Anthropic model id is lowercase
+ *     and a phone autocapitalizes, so `/model Claude-Opus-4-8` used to be launched
+ *     VERBATIM as an unvalidated id while the caveat exemption (which lowercases)
+ *     suppressed the warning — a clean green ack for a token the caveat was
+ *     written for. Non-`claude-` tokens are left alone: `sr-*` ids are matched
+ *     case-insensitively by their own maps, and rewriting an arbitrary external
+ *     id's case is not ours to do.
+ *
+ * Applied by `expandModelAlias`, so canonicalization happens on every `/model`
+ * path (typed apply, mid-turn queue, menu tap, queued-across-restart persist)
+ * whether or not the token hit a shortcut map — one canonical form flows to
+ * `claude --model`, and `unvalidatedIdCaveat` sees exactly that form.
+ */
+export function canonicalModelToken(arg: string): string {
+  const trimmed = arg.trim()
+  const lower = trimmed.toLowerCase()
+  return lower.startsWith('claude-') ? lower : trimmed
+}
+
+/**
+ * The ONE expansion every `/model` argument goes through, on every path that
+ * consumes a user-supplied token (typed apply, mid-turn queue, menu tap,
+ * queued-across-restart persist). Claude shortcuts resolve first, then sr-*
+ * shortcuts; the two key sets are disjoint by construction (a Claude shortcut
+ * never expands to an `sr-*` id and vice versa), so order only documents intent.
+ * The result is `canonicalModelToken`-normalized, so a miss can no longer emit a
+ * verbatim mixed-case `claude-*` id that the caveat exemption then mis-matches.
+ *
+ * Expanding HERE — before `isClaudeModel` / `isSrModel` / `externalModelNames`
+ * ever see the token — is what keeps a pinned-Claude shortcut on the Anthropic
+ * OAuth passthrough instead of being misread as an external route.
+ */
+export function expandModelAlias(arg: string): string {
+  return canonicalModelToken(expandSrAlias(expandClaudeAlias(arg)))
+}

--- a/src/agents/scaffold.model.test.ts
+++ b/src/agents/scaffold.model.test.ts
@@ -1,5 +1,18 @@
 import { describe, it, expect } from "vitest";
 import { resolveMainModel, normalizeModelAlias, SWITCHROOM_DEFAULT_MAIN_MODEL } from "./scaffold.js";
+// The gateway `/model` entrypoint — the OTHER site that turns an operator alias
+// into a `claude --model` token. These are re-exported by model-command from
+// the shared `model-aliases.ts` module; scaffold consumes the same module, so
+// the two sites can no longer carry divergent alias tables (#3998).
+import {
+  CLAUDE_MODEL_ALIASES,
+  SR_MODEL_ALIASES,
+  expandModelAlias,
+} from "../../telegram-plugin/gateway/model-command.js";
+import {
+  CLAUDE_MODEL_ALIASES as SHARED_CLAUDE_ALIASES,
+  SR_MODEL_ALIASES as SHARED_SR_ALIASES,
+} from "./model-aliases.js";
 
 // The ONE model resolver — shared by the scaffold bake, `agent list --json`,
 // and the launcher's boot-time `agent effective-model` read. These pin the
@@ -24,5 +37,47 @@ describe("resolveMainModel / normalizeModelAlias", () => {
     expect(normalizeModelAlias("claude-fable-5")).toBe("fable");
     expect(normalizeModelAlias("fable")).toBe("fable");
     expect(normalizeModelAlias("claude-sonnet-5")).toBe("claude-sonnet-5");
+  });
+
+  // #3998: the class this kills is "two divergent alias tables". Before the
+  // shared module, scaffold expanded ONLY the fable codename, so a config
+  // `model: opus48` (a shortcut the gateway `/model` path expands to
+  // `claude-opus-4-8`) reached `claude --model` VERBATIM and 4xx'd.
+  describe("shares ONE alias table with the gateway /model path (#3998)", () => {
+    it("resolves the opus48-class pinned-Claude shortcuts to their full ids", () => {
+      // These are exactly the shortcuts the gateway accepts; each must now
+      // resolve identically when it arrives as a config `model:` default.
+      expect(resolveMainModel("opus48")).toBe("claude-opus-4-8");
+      expect(resolveMainModel("opus-4-8")).toBe("claude-opus-4-8");
+      expect(normalizeModelAlias("opus48")).toBe("claude-opus-4-8");
+      // Case-insensitive, matching the gateway's expansion.
+      expect(resolveMainModel("OPUS48")).toBe("claude-opus-4-8");
+    });
+
+    it("resolves every alias the gateway accepts to the same launch token", () => {
+      // Guards against a shortcut being added to the gateway table but not
+      // resolving in scaffold — the exact drift that produced the original bug.
+      const aliases = [
+        ...Object.keys(CLAUDE_MODEL_ALIASES),
+        ...Object.keys(SR_MODEL_ALIASES),
+      ];
+      // Non-empty so the loop can't vacuously pass.
+      expect(aliases.length).toBeGreaterThan(0);
+      for (const alias of aliases) {
+        // resolveMainModel diverges from expandModelAlias ONLY on the
+        // `default`/unset footgun remap; no alias-table key is `default`, so
+        // the two must agree on every one of them.
+        expect(resolveMainModel(alias)).toBe(expandModelAlias(alias));
+        // And the resolved value is the full id, never the bare shortcut.
+        expect(resolveMainModel(alias)).not.toBe(alias);
+      }
+    });
+
+    it("uses the SAME table object as the gateway (single source of truth)", () => {
+      // Re-export identity: model-command re-exports the shared module's tables
+      // rather than declaring its own, so there is exactly one table to drift.
+      expect(CLAUDE_MODEL_ALIASES).toBe(SHARED_CLAUDE_ALIASES);
+      expect(SR_MODEL_ALIASES).toBe(SHARED_SR_ALIASES);
+    });
   });
 });

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -22,6 +22,7 @@ import { createHash } from "node:crypto";
 import chalk from "chalk";
 import type { AgentConfig, QuotaConfig, SwitchroomConfig, TelegramConfig } from "../config/schema.js";
 import { CRON_SCRIPT_BASENAME_RE, LEGACY_CRON_SCRIPT_BASENAME_RE } from "./cron-unit-name.js";
+import { expandModelAlias } from "./model-aliases.js";
 import { atomicWriteFileSync } from "../util/atomic.js";
 import {
   alignAgentTreeOwnershipIfRoot,
@@ -1644,10 +1645,21 @@ export function declaredRoutingMode(resolvedModel: string): "passthrough" | "rou
  * only resolves via the LiteLLM router; the alias resolves everywhere the
  * model is reachable at all (the claude CLI maps it via
  * ANTHROPIC_DEFAULT_FABLE_MODEL), so it is the only safe spelling to write.
- * Everything else passes through unchanged.
+ *
+ * Beyond the fable codename we then run the config-default token through the
+ * SAME `expandModelAlias` the gateway `/model` path uses (#3998): a switchroom
+ * shortcut like `opus48` / `opus-4-8` expands to its pinned `claude-*` id, an
+ * sr-* shortcut (`flash`, `codex`, …) to its full `sr-*` id, and any `claude-*`
+ * id is case-canonicalized — so an operator-configured `model:` resolves to the
+ * exact same launch token as typing that alias into `/model`. Before this both
+ * sites carried divergent tables: scaffold expanded ONLY the fable codename, so
+ * a config `model: opus48` reached `claude --model` verbatim and 4xx'd. Family
+ * aliases the CLI resolves itself (`opus`/`sonnet`/`haiku`/`fable`/`default`)
+ * are in neither shortcut table and pass through unchanged, as before.
  */
 export function normalizeModelAlias(model: string): string {
-  return model === "claude-fable-5" ? "fable" : model;
+  if (model === "claude-fable-5") return "fable";
+  return expandModelAlias(model);
 }
 
 /**

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -34,6 +34,27 @@ import {
   type ModelPickerOption,
 } from '../../src/agents/model-picker.js'
 import { assessThinkingEffortRisk } from '../../src/config/thinking-effort-risk.js'
+// The model-alias tables + expansion helpers live in the shared
+// `src/agents/model-aliases.ts` module so the gateway `/model` path and
+// scaffold-time config-default resolution expand from ONE table (#3998).
+// Imported for this module's internal use and re-exported below to preserve the
+// existing `model-command.js` public API (every importer keeps its entrypoint).
+import {
+  CLAUDE_MODEL_ALIASES,
+  SR_MODEL_ALIASES,
+  expandClaudeAlias,
+  expandSrAlias,
+  canonicalModelToken,
+  expandModelAlias,
+} from '../../src/agents/model-aliases.js'
+export {
+  CLAUDE_MODEL_ALIASES,
+  SR_MODEL_ALIASES,
+  expandClaudeAlias,
+  expandSrAlias,
+  canonicalModelToken,
+  expandModelAlias,
+}
 
 /**
  * Aliases the claude CLI resolves natively (`claude --help`: "an alias for
@@ -50,34 +71,6 @@ import { assessThinkingEffortRisk } from '../../src/config/thinking-effort-risk.
  * regression tests.
  */
 export const MODEL_ALIASES = ['opus', 'sonnet', 'haiku', 'fable', 'default'] as const
-
-/**
- * Short SWITCHROOM-side spellings for pinned **Anthropic** model ids. These are
- * expanded to the full `claude-*` id on the `/model` path BEFORE any
- * Claude-vs-external classification runs, so what reaches the `.session-model`
- * carrier (and therefore `claude --model`) is always the canonical id — the CLI
- * never sees the short spelling.
- *
- * Deliberately NOT `SR_MODEL_ALIASES`: that map means "external / OpenRouter /
- * the Anthropic OAuth header is NOT forwarded". These targets are Anthropic
- * OAuth-passthrough models, so putting them there would flip the
- * header-forwarding + external-billing classification and surface them under the
- * "🌐 External models" keyboard page with an `srFriendlyLabel`.
- *
- * Also NOT `MODEL_ALIASES`: that list is the aliases the claude CLI resolves
- * *itself*, and its members double as FAMILY tokens in `modelFamilyToken` /
- * `canonicalClaudeToken` / `servedModelMatchesRequested`. A pinned-id shortcut
- * is neither.
- *
- * NB the repo prefers family aliases over pinned ids (an alias tracks the
- * current flagship, a pinned id goes stale) — these exist because an operator
- * sometimes wants a specific pinned Opus, and typing `claude-opus-4-8` on a
- * phone is hostile. Keys are matched case-insensitively.
- */
-export const CLAUDE_MODEL_ALIASES: Record<string, string> = {
-  opus48: 'claude-opus-4-8',
-  'opus-4-8': 'claude-opus-4-8',
-}
 
 /**
  * Shape gate for the model argument. This string is typed literally
@@ -1167,35 +1160,6 @@ export const SR_MODEL_LABELS: Record<string, string> = {
 }
 
 /**
- * Short text-command aliases for sr-* models. These let the operator type
- * `/model flash`, `/model codex`, etc. instead of the full `sr-*` id.
- * Expanded in handleModelCommand before injection; the full sr-* id is what
- * reaches the agent session and LiteLLM.
- */
-export const SR_MODEL_ALIASES: Record<string, string> = {
-  flash: 'sr-gemini-2.5-flash',
-  gemini: 'sr-gemini-2.5-pro',
-  deepseek: 'sr-deepseek-v3',
-  r1: 'sr-deepseek-r1',
-  glm: 'sr-glm-5',
-  codex: 'sr-codex-5.5',
-  // Flagship keyboard buttons for the three providers added 2026-07-19. Each
-  // points at that provider's top tier; the cheaper tiers (grok-4.3,
-  // kimi-k2.7-code, gpt-5.6-terra/luna) stay typeable via `/model sr-<id>` and
-  // keep a friendly label above, matching the "labels are a superset of buttons"
-  // design (SR_MODEL_LABELS doc comment).
-  grok: 'sr-grok-4.5',
-  kimi: 'sr-kimi-k3',
-  gpt: 'sr-gpt-5.6-sol',
-  // Per-tier buttons for the GPT-5.6 line so each is a one-word shortcut
-  // (`gpt` stays the flagship-Sol default). Added 2026-07-19.
-  sol: 'sr-gpt-5.6-sol',
-  terra: 'sr-gpt-5.6-terra',
-  luna: 'sr-gpt-5.6-luna',
-}
-
-/** Expand a short alias (case-insensitive) to its full sr-* id, or return the original. */
-/**
  * #3042 review blocker 2a: can `token` be trusted for a boot-applied
  * `.session-model` carrier persist WITHOUT a live confirmation from claude?
  *
@@ -1228,58 +1192,6 @@ export function isOfflineTrustedModelToken(token: string): boolean {
   // on one of the two paths.
   if (lower in CLAUDE_MODEL_ALIASES) return true
   return Object.values(CLAUDE_MODEL_ALIASES).includes(lower)
-}
-
-export function expandSrAlias(arg: string): string {
-  return SR_MODEL_ALIASES[arg.toLowerCase()] ?? arg
-}
-
-/**
- * The ONE canonical form of a model token — what `claude --model` is handed and
- * what every downstream gate compares against.
- *
- * Two normalizations, both narrow:
- *   - **trim** — unconditional. `unvalidatedIdCaveat` already trimmed while
- *     expansion did not, so the two disagreed on a padded token.
- *   - **lowercase, `claude-*` ONLY.** Every real Anthropic model id is lowercase
- *     and a phone autocapitalizes, so `/model Claude-Opus-4-8` used to be launched
- *     VERBATIM as an unvalidated id while the caveat exemption (which lowercases)
- *     suppressed the warning — a clean green ack for a token the caveat was
- *     written for. Non-`claude-` tokens are left alone: `sr-*` ids are matched
- *     case-insensitively by their own maps, and rewriting an arbitrary external
- *     id's case is not ours to do.
- *
- * Applied by `expandModelAlias`, so canonicalization happens on every `/model`
- * path (typed apply, mid-turn queue, menu tap, queued-across-restart persist)
- * whether or not the token hit a shortcut map — one canonical form flows to
- * `claude --model`, and `unvalidatedIdCaveat` sees exactly that form.
- */
-export function canonicalModelToken(arg: string): string {
-  const trimmed = arg.trim()
-  const lower = trimmed.toLowerCase()
-  return lower.startsWith('claude-') ? lower : trimmed
-}
-
-/** Expand a short pinned-Claude spelling (case-insensitive) to its full `claude-*` id. */
-export function expandClaudeAlias(arg: string): string {
-  return CLAUDE_MODEL_ALIASES[arg.trim().toLowerCase()] ?? arg
-}
-
-/**
- * The ONE expansion every `/model` argument goes through, on every path that
- * consumes a user-supplied token (typed apply, mid-turn queue, menu tap,
- * queued-across-restart persist). Claude shortcuts resolve first, then sr-*
- * shortcuts; the two key sets are disjoint by construction (a Claude shortcut
- * never expands to an `sr-*` id and vice versa), so order only documents intent.
- * The result is `canonicalModelToken`-normalized, so a miss can no longer emit a
- * verbatim mixed-case `claude-*` id that the caveat exemption then mis-matches.
- *
- * Expanding HERE — before `isClaudeModel` / `isSrModel` / `externalModelNames`
- * ever see the token — is what keeps a pinned-Claude shortcut on the Anthropic
- * OAuth passthrough instead of being misread as an external route.
- */
-export function expandModelAlias(arg: string): string {
-  return canonicalModelToken(expandSrAlias(expandClaudeAlias(arg)))
 }
 
 export function srFriendlyLabel(srName: string): string {


### PR DESCRIPTION
## What

Scaffold-time config-default resolution and the gateway `/model` command now expand model aliases from **one shared table** (`src/agents/model-aliases.ts`).

## Why

`resolveMainModel` / `normalizeModelAlias` in `src/agents/scaffold.ts` mapped only `claude-fable-5 → fable`. The gateway `/model` path (`telegram-plugin/gateway/model-command.ts`) carried its own richer alias tables — the opus48-class pinned-Claude shortcuts (`opus48`, `opus-4-8` → `claude-opus-4-8`) plus the sr-* shortcuts (`flash`, `codex`, …). Two divergent tables meant a config `model: opus48` reached `claude --model` **verbatim** and 4xx'd, even though typing `/model opus48` into Telegram resolved it correctly.

## Change

- Extract `CLAUDE_MODEL_ALIASES`, `SR_MODEL_ALIASES`, and the expansion helpers (`expandClaudeAlias`, `expandSrAlias`, `canonicalModelToken`, `expandModelAlias`) into a shared `src/agents/model-aliases.ts` module.
- `model-command.ts` imports + re-exports them, so its public API is unchanged (every existing importer/test keeps its `model-command.js` entrypoint).
- `scaffold.ts` `normalizeModelAlias` keeps the fable-codename special-case, then delegates to the shared `expandModelAlias`. Single source of truth — the class (two divergent alias tables) is dead.

Family aliases the CLI resolves itself (`opus`/`sonnet`/`haiku`/`fable`/`default`) are in neither shortcut table and still pass through unchanged; `resolveMainModel`'s `default`/unset footgun remap is untouched.

Fixes #3998

## Test evidence

`src/agents/scaffold.model.test.ts` (class-killer):
- opus48-class shortcuts resolve to their full pinned ids (case-insensitively) via `resolveMainModel`/`normalizeModelAlias`.
- **Every** alias the gateway accepts resolves to the same launch token in scaffold (`resolveMainModel(alias) === expandModelAlias(alias)`), guarding against future drift.
- Both sites reference the same table object (re-export identity).

The old fable-only code fails all three. Local: scoped vitest `scaffold.model` + `model-command` suites green (132 tests), plus session-model/reconcile suites green; `tsc --noEmit` clean; gateway line-ratchet + plugin-reference + test-runner-coverage checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)