### PR TITLE
fix(hindsight-shim): clamp recall/reflect budget + reject unknown args loudly

### DIFF
--- a/src/cli/hindsight-mcp-shim.ts
+++ b/src/cli/hindsight-mcp-shim.ts
@@ -141,6 +141,16 @@ export const TOOLS_CACHE_FILENAME = "hindsight-tools-list.json";
  * capture of the PINNED image with no forward-patch, and re-capturing it is
  * part of an image bump, not a follow-up to one.
  *
+ * The silent-drop hazard is not tools/LIST-only: on tools/CALL the engine
+ * likewise declares `additionalProperties:false` but does NOT enforce it, so a
+ * bogus arg (agents keep guessing recall `limit`) is dropped SILENTLY with
+ * isError:false and the agent believes it capped results when it did not. This
+ * table is now ALSO the ground truth for the tools/CALL guard: {@link
+ * guardAndClampToolCall} validates every forwarded call's argument keys
+ * against this union and rejects unknowns loudly, so drift here reds a test in
+ * both directions AND flows straight into call-time validation — do not
+ * hand-write a second accepted-prop list anywhere.
+ *
  * This table now describes 0.8.5, which the image pins: 0.8.5 registers the
  * same 32 tools as 0.8.4 plus exactly three props — `list_memories.tags`,
  * `list_memories.tags_match` and `create_mental_model.tags_match` (derived by
@@ -362,6 +372,127 @@ export function redactToolCallParams(params: unknown): unknown {
     return params;
   }
   return { ...called, arguments: redactToolArguments(called.arguments) };
+}
+
+// ─── Recall/reflect budget clamp + loud unknown-arg rejection ──────────────
+
+/**
+ * Injected token budget for a bare `recall` / `reflect` when the caller
+ * names none. The engine's MCP defaults are budget:"high" + max_tokens:4096,
+ * which returns ~53 facts / ~80KB of JSON — over Claude Code's MCP output
+ * token cap, so the payload silently NEVER lands in the agent's context.
+ * 1024 matches the auto-recall hook (`vendor/.../lib/client.py` uses
+ * max_tokens=1024). Explicit caller values always win — see
+ * {@link guardAndClampToolCall}. Tunable via
+ * `HINDSIGHT_SHIM_RECALL_MAX_TOKENS` / `HINDSIGHT_SHIM_REFLECT_MAX_TOKENS`.
+ */
+export const DEFAULT_RECALL_MAX_TOKENS = 1024;
+export const DEFAULT_REFLECT_MAX_TOKENS = 1024;
+
+/** Parse a positive-int env override, falling back on absent/garbage input. */
+function resolveClampMaxTokens(
+  envVal: string | undefined,
+  fallback: number,
+): number {
+  if (envVal === undefined || envVal === "") return fallback;
+  const n = Number.parseInt(envVal, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/** The accepted-argument union (required ∪ optional) for a table tool. */
+function acceptedArgs(name: string): Set<string> | undefined {
+  const spec = FALLBACK_TOOL_TABLE[name];
+  if (!spec) return undefined;
+  return new Set<string>([...spec[0], ...spec[1]]);
+}
+
+function unknownArgMessage(
+  name: string,
+  unknownKeys: string[],
+  allowed: Set<string>,
+): string {
+  const keys = unknownKeys.map((k) => `'${k}'`).join(", ");
+  const plural = unknownKeys.length > 1 ? "parameters" : "parameter";
+  const base =
+    `${name} has no ${keys} ${plural}. ` +
+    `Accepted arguments: ${[...allowed].sort().join(", ")}.`;
+  if (name === "recall" || name === "reflect") {
+    // The 0.6.2 changelog renamed max_results→max_tokens; agents keep
+    // guessing `limit`. Recall is capped by TOKEN BUDGET, not count.
+    return (
+      `${base} There is no 'limit'/'top_k' — cap results with max_tokens ` +
+      `(a token budget over each fact's text, in relevance order) or ` +
+      `budget: low|mid|high.`
+    );
+  }
+  return base;
+}
+
+/**
+ * Guard + clamp a `tools/call` params object before it is forwarded upstream.
+ *
+ * Two jobs, both closing holes the engine leaves open (it declares
+ * `additionalProperties:false` but does NOT enforce it — an unknown arg is
+ * dropped SILENTLY with isError:false, so the agent believes a cap/filter
+ * applied when it did not):
+ *
+ *  1. LOUD UNKNOWN-ARG REJECTION — validate argument keys against the
+ *     required∪optional union derived from {@link FALLBACK_TOOL_TABLE} (the
+ *     single pinned source; the contract fixture keeps it ≡ the image). An
+ *     unknown key returns a loud, self-correcting error instead of a silent
+ *     drop. Tools not in the table are passed through unvalidated (no ground
+ *     truth to validate against).
+ *  2. DEFAULT BUDGET CLAMP — for `recall`/`reflect` only, inject
+ *     max_tokens (env-tunable) + budget:"low" when the caller OMITS them.
+ *     Explicit caller values ALWAYS win (a deliberate max_tokens:4096 passes
+ *     untouched).
+ *
+ * Returns the (possibly rewritten) params to forward, or a loud error text.
+ */
+export function guardAndClampToolCall(
+  params: unknown,
+  env: NodeJS.ProcessEnv,
+): { ok: true; params: unknown } | { ok: false; text: string } {
+  const called = params as
+    | { name?: string; arguments?: unknown }
+    | undefined
+    | null;
+  const name = called?.name;
+  if (typeof name !== "string") return { ok: true, params };
+  const allowed = acceptedArgs(name);
+  // No pinned ground truth for this tool → nothing to validate/clamp against.
+  if (!allowed) return { ok: true, params };
+
+  const rawArgs = called?.arguments;
+  const args =
+    rawArgs && typeof rawArgs === "object" && !Array.isArray(rawArgs)
+      ? (rawArgs as Record<string, unknown>)
+      : {};
+
+  const unknownKeys = Object.keys(args).filter((k) => !allowed.has(k));
+  if (unknownKeys.length > 0) {
+    return { ok: false, text: unknownArgMessage(name, unknownKeys, allowed) };
+  }
+
+  if (name === "recall" || name === "reflect") {
+    const injected: Record<string, unknown> = { ...args };
+    if (injected.max_tokens === undefined) {
+      injected.max_tokens =
+        name === "recall"
+          ? resolveClampMaxTokens(
+              env.HINDSIGHT_SHIM_RECALL_MAX_TOKENS,
+              DEFAULT_RECALL_MAX_TOKENS,
+            )
+          : resolveClampMaxTokens(
+              env.HINDSIGHT_SHIM_REFLECT_MAX_TOKENS,
+              DEFAULT_REFLECT_MAX_TOKENS,
+            );
+    }
+    if (injected.budget === undefined) injected.budget = "low";
+    return { ok: true, params: { ...called, arguments: injected } };
+  }
+
+  return { ok: true, params };
 }
 
 /** Materialize the static fallback manifest in MCP tools/list shape. */
@@ -922,13 +1053,22 @@ export class HindsightShim {
     if (called?.name && SYNTHESIZED_TOOL_NAMES.includes(called.name)) {
       return this.synthesizedCall(called.name, called.arguments);
     }
+    // Guard + clamp BEFORE forwarding: turn the engine's silent unknown-arg
+    // drop into a loud, self-correcting error, and inject the recall/reflect
+    // budget defaults the engine otherwise leaves fat (see
+    // guardAndClampToolCall). Runs before redaction so the injected budget is
+    // covered by the same forward path.
+    const guarded = guardAndClampToolCall(params, process.env);
+    if (!guarded.ok) {
+      return { content: [{ type: "text", text: guarded.text }], isError: true };
+    }
     // Secret redaction chokepoint for the MCP write path. Every
     // `mcp__hindsight__*` call an agent makes is forwarded from HERE, so
     // masking the arguments here covers retain / update_memory /
     // create_directive / mental-model writes with one seam, and covers any
     // tool the backend adds later without a code change (see
     // READ_ONLY_TOOL_NAMES — the allowlist is the reads, not the writes).
-    const forwarded = redactToolCallParams(params);
+    const forwarded = redactToolCallParams(guarded.params);
     try {
       const res = await this.upstream.request(
         "tools/call",

--- a/tests/hindsight-mcp-shim.test.ts
+++ b/tests/hindsight-mcp-shim.test.ts
@@ -25,6 +25,8 @@ import {
   TOOLS_CACHE_FILENAME,
   SHIM_SUPPORTED_PROTOCOL_VERSIONS,
   SYNTHESIZED_TOOL_NAMES,
+  guardAndClampToolCall,
+  DEFAULT_RECALL_MAX_TOKENS,
   type ShimOptions,
 } from "../src/cli/hindsight-mcp-shim.js";
 
@@ -43,7 +45,11 @@ interface MockBackend {
   url: string;
   server: Server;
   /** Every JSON-RPC request body received, in order. */
-  requests: { method?: string; headers: Record<string, unknown> }[];
+  requests: {
+    method?: string;
+    headers: Record<string, unknown>;
+    params?: { name?: string; arguments?: unknown };
+  }[];
   close: () => Promise<void>;
 }
 
@@ -73,7 +79,11 @@ async function startMockBackend(
         method?: string;
         params?: { name?: string; arguments?: unknown };
       };
-      requests.push({ method: msg.method, headers: { ...req.headers } });
+      requests.push({
+        method: msg.method,
+        headers: { ...req.headers },
+        params: msg.params,
+      });
       const reply = (result: unknown) => {
         const payload = JSON.stringify({ jsonrpc: "2.0", id: msg.id, result });
         if (opts.sse) {
@@ -548,5 +558,183 @@ describe("static fallback manifest", () => {
         expect(Object.keys(schema.properties)).toContain(req);
       }
     }
+  });
+});
+
+// ─── recall/reflect budget clamp + loud unknown-arg rejection ──────────────
+//
+// Two engine holes the shim closes (both live-reproduced): the engine's fat
+// MCP defaults (budget:high + max_tokens:4096 → ~53 facts / ~80KB, over the
+// MCP output cap so it never lands) and its NON-enforcement of
+// additionalProperties:false (an unknown arg like `limit` is dropped silently
+// with isError:false, so the agent thinks it capped results when it did not).
+
+describe("guardAndClampToolCall (unit)", () => {
+  it("rejects recall's nonexistent 'limit' loudly, naming limit AND max_tokens", () => {
+    // On origin/main there is no guard: the arg is forwarded and the engine
+    // silently drops it. This asserts the loud, self-correcting replacement.
+    const res = guardAndClampToolCall(
+      { name: "recall", arguments: { query: "x", limit: 6 } },
+      {},
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected rejection");
+    expect(res.text).toContain("limit");
+    expect(res.text).toContain("max_tokens");
+    expect(res.text.toLowerCase()).toContain("budget");
+  });
+
+  it("injects max_tokens + budget:low into a bare recall (caller omitted both)", () => {
+    const res = guardAndClampToolCall(
+      { name: "recall", arguments: { query: "x" } },
+      {},
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error("unexpected rejection");
+    const args = (res.params as { arguments: Record<string, unknown> }).arguments;
+    expect(args.max_tokens).toBe(DEFAULT_RECALL_MAX_TOKENS);
+    expect(args.max_tokens).toBe(1024);
+    expect(args.budget).toBe("low");
+    expect(args.query).toBe("x"); // caller arg preserved
+  });
+
+  it("leaves an explicit max_tokens:4096 UNTOUCHED (caller always wins)", () => {
+    const res = guardAndClampToolCall(
+      { name: "recall", arguments: { query: "x", max_tokens: 4096 } },
+      {},
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error("unexpected rejection");
+    const args = (res.params as { arguments: Record<string, unknown> }).arguments;
+    expect(args.max_tokens).toBe(4096);
+  });
+
+  it("leaves an explicit budget UNTOUCHED (caller always wins)", () => {
+    const res = guardAndClampToolCall(
+      { name: "recall", arguments: { query: "x", budget: "high" } },
+      {},
+    );
+    if (!res.ok) throw new Error("unexpected rejection");
+    const args = (res.params as { arguments: Record<string, unknown> }).arguments;
+    expect(args.budget).toBe("high");
+    expect(args.max_tokens).toBe(1024); // the omitted one is still clamped
+  });
+
+  it("clamps reflect the same way", () => {
+    const res = guardAndClampToolCall(
+      { name: "reflect", arguments: { query: "x" } },
+      {},
+    );
+    if (!res.ok) throw new Error("unexpected rejection");
+    const args = (res.params as { arguments: Record<string, unknown> }).arguments;
+    expect(args.max_tokens).toBe(1024);
+    expect(args.budget).toBe("low");
+  });
+
+  it("honors the env override for the injected budget", () => {
+    const res = guardAndClampToolCall(
+      { name: "recall", arguments: { query: "x" } },
+      { HINDSIGHT_SHIM_RECALL_MAX_TOKENS: "600" },
+    );
+    if (!res.ok) throw new Error("unexpected rejection");
+    const args = (res.params as { arguments: Record<string, unknown> }).arguments;
+    expect(args.max_tokens).toBe(600);
+  });
+
+  it("does NOT clamp non-recall/reflect tools (retain passes through)", () => {
+    const res = guardAndClampToolCall(
+      { name: "retain", arguments: { content: "hi" } },
+      {},
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error("unexpected rejection");
+    const args = (res.params as { arguments: Record<string, unknown> }).arguments;
+    expect(args.max_tokens).toBeUndefined();
+    expect(args.budget).toBeUndefined();
+  });
+
+  it("passes through tools with no pinned table entry unvalidated", () => {
+    const res = guardAndClampToolCall(
+      { name: "search", arguments: { anything: 1 } },
+      {},
+    );
+    expect(res.ok).toBe(true); // 'search' is not in FALLBACK_TOOL_TABLE
+  });
+
+  // Constraint (d): the accepted-prop list is DERIVED from FALLBACK_TOOL_TABLE
+  // (the single pinned source), not a parallel hand-written list. Proven by
+  // driving the guard off the table entry itself — so the existing contract
+  // fixture pin (FALLBACK_TOOL_TABLE ≡ snapshot) already guards call-time
+  // validation against drift, in both directions.
+  it("accepts EVERY prop the table declares for recall, and only those", () => {
+    const [required, optional] = FALLBACK_TOOL_TABLE.recall;
+    for (const prop of [...required, ...optional]) {
+      const res = guardAndClampToolCall(
+        { name: "recall", arguments: { query: "x", [prop]: "v" } },
+        {},
+      );
+      expect(res.ok, `recall.${prop} should be accepted`).toBe(true);
+    }
+    // A prop NOT in the table is rejected.
+    const bogus = guardAndClampToolCall(
+      { name: "recall", arguments: { query: "x", not_a_real_prop: 1 } },
+      {},
+    );
+    expect(bogus.ok).toBe(false);
+  });
+});
+
+describe("tools/call clamp + rejection through the live shim", () => {
+  let backend: MockBackend;
+  afterEach(async () => {
+    await backend.close();
+  });
+
+  it("a bare recall forwards max_tokens:1024 + budget:low to the backend", async () => {
+    backend = await startMockBackend();
+    const shim = makeShim({ url: backend.url, cacheDir });
+    await shim.handle(rpc(1, "initialize", { protocolVersion: "2025-06-18" }) as never);
+
+    await shim.handle(
+      rpc(2, "tools/call", { name: "recall", arguments: { query: "x" } }) as never,
+    );
+    const call = backend.requests.find((r) => r.method === "tools/call");
+    expect(call).toBeDefined();
+    const args = call?.params?.arguments as Record<string, unknown>;
+    expect(args.max_tokens).toBe(1024);
+    expect(args.budget).toBe("low");
+    expect(args.query).toBe("x");
+  });
+
+  it("an explicit max_tokens:4096 reaches the backend untouched", async () => {
+    backend = await startMockBackend();
+    const shim = makeShim({ url: backend.url, cacheDir });
+    await shim.handle(rpc(1, "initialize", { protocolVersion: "2025-06-18" }) as never);
+
+    await shim.handle(
+      rpc(2, "tools/call", {
+        name: "recall",
+        arguments: { query: "x", max_tokens: 4096 },
+      }) as never,
+    );
+    const call = backend.requests.find((r) => r.method === "tools/call");
+    const args = call?.params?.arguments as Record<string, unknown>;
+    expect(args.max_tokens).toBe(4096);
+  });
+
+  it("recall {limit:6} is rejected loudly and NEVER reaches the backend", async () => {
+    backend = await startMockBackend();
+    const shim = makeShim({ url: backend.url, cacheDir });
+    await shim.handle(rpc(1, "initialize", { protocolVersion: "2025-06-18" }) as never);
+
+    const res = await shim.handle(
+      rpc(2, "tools/call", { name: "recall", arguments: { limit: 6 } }) as never,
+    );
+    const result = res?.result as { isError: boolean; content: { text: string }[] };
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("limit");
+    expect(result.content[0].text).toContain("max_tokens");
+    // The silent-drop is prevented: no tools/call was forwarded at all.
+    expect(backend.requests.some((r) => r.method === "tools/call")).toBe(false);
   });
 });


### PR DESCRIPTION
## The bug (live-reproduced)

Agent-invoked `mcp__hindsight__recall` returns ~53 facts / ~80KB of JSON on a bare call, blowing Claude Code's MCP output token cap — so the payload **never lands in the agent's context**, every turn, for every agent. Two root causes, both in the switchroom MCP shim's `tools/call` path (`src/cli/hindsight-mcp-shim.ts`), **not** the engine:

1. **Fat defaults forwarded verbatim.** The shim forwarded recall args untouched, so the engine's MCP defaults (`budget:"high"` + `max_tokens:4096`) applied on a bare call. Confirmed live: bare recall → 53 results / 82,042 bytes; `budget:"low"` + `max_tokens:600` → 11 results / 18,955 bytes.
2. **Silent unknown-arg drop.** Agents pass a nonexistent `limit` (guessing after the 0.6.2 `max_results`→`max_tokens` rename). The engine declares `additionalProperties:false` but does **not** enforce it — it drops the arg silently and answers `isError:false`, so the agent believes it capped results when it didn't. Confirmed: `{"limit":6}` → 53 results / 81,791 bytes, silently ignored.

Recall is capped by **token budget**, not count — there is no `limit`/`top_k`.

## The fix (in `toolsCall()`, no engine changes)

A pure, exported `guardAndClampToolCall(params, env)` runs before redaction/forwarding:

1. **Default budget clamp** — for `recall`/`reflect` only, inject `max_tokens:1024` (matches the auto-recall hook's `client.py`) + `budget:"low"` when the caller **omits** them. Explicit caller values always win (a deliberate `max_tokens:4096` passes through untouched). Tunable via `HINDSIGHT_SHIM_RECALL_MAX_TOKENS` / `HINDSIGHT_SHIM_REFLECT_MAX_TOKENS`.
2. **Loud unknown-arg rejection** — validate every forwarded tool's argument keys against the required∪optional union **derived from `FALLBACK_TOOL_TABLE`** (the single pinned source; the existing contract fixture keeps it ≡ the pinned image, so call-time validation is guarded against drift in both directions — no parallel hand-written list). An unknown key returns `isError:true` with self-correcting text, e.g. *"recall has no 'limit' parameter … cap results with max_tokens … or budget: low|mid|high."*

Switchroom-side only: touches `src/cli/hindsight-mcp-shim.ts` + its tests. No `vendor/**` or engine changes.

## Tests (assert outcomes; verified RED against pre-fix behavior)

- `recall {limit:6}` → `isError:true` naming both `limit` and `max_tokens`, and **never forwarded** to the backend.
- bare recall → forwarded args contain `max_tokens:1024` + `budget:"low"`.
- explicit `max_tokens:4096` → reaches the backend untouched; explicit `budget` likewise wins.
- env override honored; non-recall tools not clamped; the accepted-prop list is driven off `FALLBACK_TOOL_TABLE` entries.

`tsc --noEmit`, full `npm run lint`, and the scoped shim + contract-fixture suites all green (29 + 52 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)