### PR TITLE
fix(hindsight-maintenance): stop false wedge alerts; surface + recover dead-lettered retains (#3758 #3795)

### DIFF
--- a/docker/hindsight-maintenance.sh
+++ b/docker/hindsight-maintenance.sh
@@ -41,6 +41,18 @@
 #   SWITCHROOM_HINDSIGHT_STUCK_OP_WARN_S      alarm if any 'processing' op is
 #                                             claimed older than this (the reaper
 #                                             should have reset it). default 3600 (1h)
+#   SWITCHROOM_HINDSIGHT_DEAD_LETTER_WARN_S    warn if a failed 'retain' op with an
+#                                             intact payload (recoverable, stalled
+#                                             memory) is older than this. default
+#                                             21600 (6h). 0=off  (#3795)
+#   SWITCHROOM_HINDSIGHT_REQUEUE_DEAD_LETTERS  opt-in: POST FK-race dead letters to
+#                                             the engine retry endpoint (costs LLM
+#                                             spend). 1=on, default 0=off  (#3795)
+#   SWITCHROOM_HINDSIGHT_REQUEUE_MAX           max dead letters requeued per tick.
+#                                             default 100  (#3795)
+#   SWITCHROOM_HINDSIGHT_API_URL / _API_TOKEN  override the loopback engine API base
+#                                             URL / bearer token for the requeue POST
+#                                             (else http://127.0.0.1:${HINDSIGHT_API_PORT:-9077})
 set -u
 
 MAINT_ENABLED="${SWITCHROOM_HINDSIGHT_MAINTENANCE:-1}"
@@ -69,6 +81,19 @@ INDEX_HEALTH_CHECK="${SWITCHROOM_HINDSIGHT_INDEX_HEALTH_CHECK:-1}"
 # 'processing' op still claimed past this threshold means the heal isn't
 # landing (corrupt index / disabled reaper) and the deadlock is ACTIVE.
 STUCK_OP_WARN_S="${SWITCHROOM_HINDSIGHT_STUCK_OP_WARN_S:-3600}"
+# Dead-letter visibility + recovery (#3795). A ForeignKeyViolation race on
+# unit_entities (#3794) was misclassified by the engine as a DETERMINISTIC
+# failure, so the affected `retain` ops were dead-lettered with retry_count=0
+# / next_retry_at NULL — the worker's claim loop only revisits status='pending',
+# so nothing ever picks them up, yet their `task_payload` is intact. The memory
+# is STALLED, not lost. `DEAD_LETTER_WARN_S` surfaces the stalled backlog loudly
+# (nothing surfaced 770 such ops for 8 days); `REQUEUE_*` is an OFF-by-default,
+# operator-signed recovery that re-runs fact extraction (LLM spend) via the
+# engine's own retry endpoint. The classifier fix itself is an engine change
+# (out of scope here) tracked in #3794/#3795.
+DEAD_LETTER_WARN_S="${SWITCHROOM_HINDSIGHT_DEAD_LETTER_WARN_S:-21600}"
+REQUEUE_DEAD_LETTERS="${SWITCHROOM_HINDSIGHT_REQUEUE_DEAD_LETTERS:-0}"
+REQUEUE_MAX="${SWITCHROOM_HINDSIGHT_REQUEUE_MAX:-100}"
 
 log() { echo "switchroom-hindsight-maintenance: $*" >&2; }
 
@@ -118,8 +143,17 @@ fi
 # that previously hid for 26 days. Reports the oldest pending/processing
 # op's age; if it exceeds the threshold, something isn't draining. ---
 if [ "${QUEUE_LAG_WARN_S}" -gt 0 ] 2>/dev/null; then
-  # "count|oldest_age_seconds" for non-terminal ops (0 rows → "0|0").
-  _q="$(_sql "SELECT count(*)||'|'||coalesce(max(extract(epoch from (now()-created_at)))::bigint,0) FROM async_operations WHERE status IN ('pending','processing')")"
+  # "count|oldest_age_seconds" for CLAIMABLE non-terminal ops (0 rows → "0|0").
+  # #3758: `task_payload IS NOT NULL` mirrors the worker's PARTIAL claim index
+  # (`idx_async_operations_pending_claim ON (status, created_at) WHERE
+  # status='pending' AND task_payload IS NOT NULL`). A `batch_retain` PARENT is
+  # created with `task_payload=NULL` by design (memory_engine.py:12556) and is
+  # resolved by sibling aggregation, NEVER claimed by a worker — so its age can
+  # never indicate a stalled claimable pipeline. Counting payload-null parents
+  # produced recurring FALSE "queue may be wedged" alerts on perfectly healthy
+  # in-flight retains, whose suggested remediation (clearing the rows) would
+  # destroy live memory writes.
+  _q="$(_sql "SELECT count(*)||'|'||coalesce(max(extract(epoch from (now()-created_at)))::bigint,0) FROM async_operations WHERE status IN ('pending','processing') AND task_payload IS NOT NULL")"
   _qn="${_q%%|*}"
   _qage="${_q##*|}"
   if [ "${_qage:-0}" -gt "${QUEUE_LAG_WARN_S}" ] 2>/dev/null; then
@@ -155,6 +189,69 @@ if [ "${INDEX_HEALTH_CHECK}" = "1" ]; then
   _stuck="$(_sql "SELECT count(*) FROM async_operations WHERE status='processing' AND claimed_at < now() - make_interval(secs => ${STUCK_OP_WARN_S})")"
   if [ "${_stuck:-0}" -gt 0 ] 2>/dev/null; then
     log "ERROR: ${_stuck} async op(s) stuck in 'processing' older than $((STUCK_OP_WARN_S/60))m — the stale-claim reaper is not clearing them (corrupt pk_async_operations index or reaper disabled); per-bank consolidation is deadlocked. Inspect async_operations + 'docker logs switchroom-hindsight'."
+  fi
+fi
+
+# --- 6. Dead-letter visibility: WARN on recoverable-but-stalled failed
+# retains (#3795). A failed 'retain' op still carrying its task_payload is
+# recoverable via the retry endpoint — the memory is stalled, not lost — but
+# the worker's claim loop (status='pending') will never revisit it. Nothing
+# surfaced 770 such ops for 8 days; this makes the silent pile loud. ---
+if [ "${DEAD_LETTER_WARN_S}" -gt 0 ] 2>/dev/null; then
+  # "total|fk_signature|oldest_age_seconds". `total` = every failed retain with
+  # an intact payload (all recoverable). `fk_signature` = the subset the FK-race
+  # misclassifier stranded (retry_count=0 AND next_retry_at NULL) — these never
+  # entered the retry ladder and are the safe default to requeue. Read-only.
+  _dl="$(_sql "SELECT count(*)||'|'||count(*) FILTER (WHERE retry_count=0 AND next_retry_at IS NULL)||'|'||coalesce(max(extract(epoch from (now()-created_at)))::bigint,0) FROM async_operations WHERE operation_type='retain' AND status='failed' AND task_payload IS NOT NULL")"
+  _dltot="${_dl%%|*}"
+  _dlrest="${_dl#*|}"
+  _dlfk="${_dlrest%%|*}"
+  _dlage="${_dlrest##*|}"
+  if [ "${_dltot:-0}" -gt 0 ] 2>/dev/null && [ "${_dlage:-0}" -gt "${DEAD_LETTER_WARN_S}" ] 2>/dev/null; then
+    log "WARNING: ${_dltot} failed 'retain' op(s) with an intact payload are stalled (recoverable, oldest $((_dlage/3600))h old > $((DEAD_LETTER_WARN_S/3600))h); ${_dlfk} match the FK-race dead-letter signature (retry_count=0, never retried). STALLED memory, not lost — requeue via the retry endpoint (SWITCHROOM_HINDSIGHT_REQUEUE_DEAD_LETTERS=1; re-runs extraction, costs LLM spend). See #3795."
+  fi
+fi
+
+# --- 7. Dead-letter REQUEUE (opt-in, costs LLM spend). POST each FK-race dead
+# letter to the engine's own retry endpoint (failed→pending; clears
+# next_retry_at / worker_id; resets retry_count). The worker's claim index then
+# re-picks it up. OFF by default; operator sign-off required (#3795). ---
+if [ "${REQUEUE_DEAD_LETTERS}" = "1" ]; then
+  _api="${SWITCHROOM_HINDSIGHT_API_URL:-http://127.0.0.1:${HINDSIGHT_API_PORT:-9077}}"
+  _tok="${SWITCHROOM_HINDSIGHT_API_TOKEN:-${HINDSIGHT_API_TOKEN:-}}"
+  if ! command -v curl >/dev/null 2>&1; then
+    log "ERROR: dead-letter requeue requested but curl is absent — cannot reach ${_api}; skipping."
+  else
+    # bank|operation_id for the FK-race dead letters, oldest first, bounded.
+    _cands="$(_sql "SELECT bank_id||'|'||operation_id FROM async_operations WHERE operation_type='retain' AND status='failed' AND task_payload IS NOT NULL AND retry_count=0 AND next_retry_at IS NULL ORDER BY created_at LIMIT ${REQUEUE_MAX}")"
+    if [ -z "${_cands}" ]; then
+      log "dead-letter requeue: no FK-race dead letters to requeue."
+    else
+      # Read from a file (not a pipe) so the counters survive the loop.
+      _tmpf="$(mktemp 2>/dev/null || echo "/tmp/hs-requeue.$$")"
+      printf '%s\n' "${_cands}" > "${_tmpf}"
+      _ok=0; _fail=0; _aborted=0
+      while IFS='|' read -r _bank _op; do
+        [ -n "${_bank}" ] && [ -n "${_op}" ] || continue
+        _url="${_api}/v1/default/banks/${_bank}/operations/${_op}/retry"
+        if [ -n "${_tok}" ]; then
+          _code="$(curl -sS -o /dev/null -w '%{http_code}' -X POST -H "Authorization: Bearer ${_tok}" "${_url}" 2>/dev/null)"
+        else
+          _code="$(curl -sS -o /dev/null -w '%{http_code}' -X POST "${_url}" 2>/dev/null)"
+        fi
+        case "${_code}" in
+          2*) log "dead-letter requeue: ${_bank}/${_op} -> HTTP ${_code} (failed->pending)"; _ok=$((_ok + 1)) ;;
+          401|403) log "ERROR: dead-letter requeue: ${_bank}/${_op} -> HTTP ${_code} — the retry endpoint needs auth; set SWITCHROOM_HINDSIGHT_API_TOKEN. Aborting sweep."; _aborted=1; break ;;
+          *) log "WARNING: dead-letter requeue: ${_bank}/${_op} -> HTTP ${_code:-000} (not requeued)"; _fail=$((_fail + 1)) ;;
+        esac
+      done < "${_tmpf}"
+      rm -f "${_tmpf}" 2>/dev/null
+      if [ "${_aborted}" = 1 ]; then
+        log "dead-letter requeue: aborted after ${_ok} requeued (auth error) — supply SWITCHROOM_HINDSIGHT_API_TOKEN and re-run."
+      else
+        log "dead-letter requeue: ${_ok} requeued, ${_fail} failed (bounded at ${REQUEUE_MAX}/tick)."
+      fi
+    fi
   fi
 fi
 

--- a/tests/docker/hindsight-maintenance.test.ts
+++ b/tests/docker/hindsight-maintenance.test.ts
@@ -67,12 +67,37 @@ case "$sql" in
     exit 0 ;;
   *"count(*)"*"status='processing'"*)
     if [ "$mode" = corrupt ]; then echo 4; else echo 0; fi; exit 0 ;;
+  *FILTER*"status='failed'"*)
+    # Dead-letter count probe (#3795): "total|fk_signature|oldest_age_s".
+    # (FILTER appears in the SELECT list, before the status='failed' WHERE.)
+    [ -n "\${FAKE_DL_COUNT:-}" ] && echo "\$FAKE_DL_COUNT"; exit 0 ;;
+  *"status='failed'"*"ORDER BY created_at"*)
+    # Requeue candidate select (#3795): "bank|operation_id" lines.
+    [ -n "\${FAKE_DL_CANDS:-}" ] && printf '%s\\n' "\$FAKE_DL_CANDS"; exit 0 ;;
   *) exit 0 ;;
 esac
 `,
     { mode: 0o755 },
   );
   return binDir;
+}
+
+/**
+ * Write a fake `curl` beside the fake `psql` (same bin dir). It logs the URL
+ * it was POSTed to and echoes `$FAKE_CURL_CODE` (default 200) — matching how
+ * the requeue calls curl with `-o /dev/null -w '%{http_code}'`.
+ */
+function installFakeCurl(binDir: string): void {
+  writeFileSync(
+    join(binDir, "curl"),
+    `#!/bin/sh
+url=""
+for a in "$@"; do url="$a"; done
+[ -n "\${FAKE_CURL_LOG:-}" ] && printf '%s\\n' "$url" >> "$FAKE_CURL_LOG"
+printf '%s' "\${FAKE_CURL_CODE:-200}"
+`,
+    { mode: 0o755 },
+  );
 }
 
 function writePgInstance(path: string): void {
@@ -223,5 +248,203 @@ describe("hindsight-maintenance.sh", () => {
     expect(raw).toMatch(/log "WARNING: queue may be wedged/);
     // The probe must not DELETE/UPDATE — it's visibility only.
     expect(raw).not.toMatch(/(DELETE|UPDATE).*status IN \('pending','processing'\)/);
+  });
+
+  // ── #3758: the wedge probe must EXCLUDE never-claimable batch_retain
+  // parents (task_payload IS NULL). Static guard so it cannot silently
+  // regress back to counting healthy in-flight parents as a wedge.
+  it("job #4 wedge probe excludes payload-null parents (mirrors the partial claim index)", () => {
+    const raw = readFileSync(SCRIPT, "utf-8");
+    // The oldest-age SELECT must be scoped to claimable rows only.
+    expect(raw).toMatch(
+      /FROM async_operations WHERE status IN \('pending','processing'\) AND task_payload IS NOT NULL/,
+    );
+    // ...and there must be NO remaining unclaimable-inclusive wedge SELECT.
+    expect(raw).not.toMatch(
+      /max\(extract\(epoch[^\n]*status IN \('pending','processing'\)"\)/,
+    );
+  });
+
+  // ── #3795 dead-letter visibility (job #6): a failed retain with an intact
+  // payload older than the threshold WARNs LOUDLY. Driven with a fake psql
+  // returning a stale count; asserts the OUTCOME, not just the code path.
+  it("job #6 WARNs on stalled, recoverable failed retains (intact payload)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "swr-hsi-maint-"));
+    const binDir = installFakePsql();
+    try {
+      const pgInstance = join(dir, "instance.json");
+      writePgInstance(pgInstance);
+      const r = spawnSync("sh", [SCRIPT], {
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH}`,
+          SWITCHROOM_HINDSIGHT_PG0_INSTANCE: pgInstance,
+          // total=5, fk-signature=3, oldest 999999s (~11.5d) > 6h default.
+          FAKE_DL_COUNT: "5|3|999999",
+        },
+        encoding: "utf-8",
+        timeout: 15_000,
+      });
+      expect(r.status).toBe(0);
+      expect(r.stderr).toMatch(
+        /WARNING: 5 failed 'retain' op\(s\) with an intact payload are stalled/,
+      );
+      // Names the FK-race subset that is safe to requeue.
+      expect(r.stderr).toMatch(/3 match the FK-race dead-letter signature/);
+      expect(r.stderr).toMatch(/costs LLM spend/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+
+  it("job #6 stays SILENT when there are no stalled dead letters", () => {
+    const dir = mkdtempSync(join(tmpdir(), "swr-hsi-maint-"));
+    const binDir = installFakePsql();
+    try {
+      const pgInstance = join(dir, "instance.json");
+      writePgInstance(pgInstance);
+      // No FAKE_DL_COUNT → the count probe returns empty → no WARN.
+      const r = spawnSync("sh", [SCRIPT], {
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH}`,
+          SWITCHROOM_HINDSIGHT_PG0_INSTANCE: pgInstance,
+        },
+        encoding: "utf-8",
+        timeout: 15_000,
+      });
+      expect(r.status).toBe(0);
+      expect(r.stderr).not.toMatch(/failed 'retain' op\(s\) with an intact payload/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+
+  it("job #6 dead-letter probe is read-only and correctly scoped (static guard)", () => {
+    const raw = readFileSync(SCRIPT, "utf-8");
+    // Scoped to failed retains with an INTACT payload (recoverable).
+    expect(raw).toMatch(
+      /operation_type='retain' AND status='failed' AND task_payload IS NOT NULL/,
+    );
+    // Breaks out the FK-race signature (never entered the retry ladder).
+    expect(raw).toMatch(/FILTER \(WHERE retry_count=0 AND next_retry_at IS NULL\)/);
+    // Visibility only — never mutates the failed set.
+    expect(raw).not.toMatch(/(UPDATE|DELETE)[^\n]*status='failed'/);
+  });
+
+  // ── #3795 requeue (job #7): OFF by default, and when enabled POSTs each
+  // FK-race dead letter to the engine retry endpoint via curl.
+  it("job #7 requeue is OFF by default — no curl, no POST", () => {
+    const dir = mkdtempSync(join(tmpdir(), "swr-hsi-maint-"));
+    const binDir = installFakePsql();
+    installFakeCurl(binDir);
+    try {
+      const pgInstance = join(dir, "instance.json");
+      const curlLog = join(dir, "curl.log");
+      writePgInstance(pgInstance);
+      const r = spawnSync("sh", [SCRIPT], {
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH}`,
+          SWITCHROOM_HINDSIGHT_PG0_INSTANCE: pgInstance,
+          FAKE_DL_CANDS: "overlord|11111111-1111-1111-1111-111111111111",
+          FAKE_CURL_LOG: curlLog,
+        },
+        encoding: "utf-8",
+        timeout: 15_000,
+      });
+      expect(r.status).toBe(0);
+      expect(r.stderr).not.toMatch(/dead-letter requeue/);
+      // curl was never invoked (no requeue log file written).
+      expect(() => readFileSync(curlLog, "utf-8")).toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+
+  it("job #7 requeue POSTs each FK-race dead letter to the engine retry endpoint when enabled", () => {
+    const dir = mkdtempSync(join(tmpdir(), "swr-hsi-maint-"));
+    const binDir = installFakePsql();
+    installFakeCurl(binDir);
+    try {
+      const pgInstance = join(dir, "instance.json");
+      const curlLog = join(dir, "curl.log");
+      writePgInstance(pgInstance);
+      const op = "11111111-1111-1111-1111-111111111111";
+      const r = spawnSync("sh", [SCRIPT], {
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH}`,
+          SWITCHROOM_HINDSIGHT_PG0_INSTANCE: pgInstance,
+          SWITCHROOM_HINDSIGHT_REQUEUE_DEAD_LETTERS: "1",
+          SWITCHROOM_HINDSIGHT_API_URL: "http://127.0.0.1:9077",
+          FAKE_DL_CANDS: `overlord|${op}`,
+          FAKE_CURL_LOG: curlLog,
+          FAKE_CURL_CODE: "200",
+        },
+        encoding: "utf-8",
+        timeout: 15_000,
+      });
+      expect(r.status).toBe(0);
+      // The POST targeted the documented retry endpoint for that bank+op.
+      const urls = readFileSync(curlLog, "utf-8");
+      expect(urls).toContain(
+        `http://127.0.0.1:9077/v1/default/banks/overlord/operations/${op}/retry`,
+      );
+      // The requeue logged success + a summary.
+      expect(r.stderr).toMatch(new RegExp(`dead-letter requeue: overlord/${op} -> HTTP 200`));
+      expect(r.stderr).toMatch(/dead-letter requeue: 1 requeued, 0 failed/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+
+  it("job #7 requeue aborts with a clear hint when the retry endpoint returns 401", () => {
+    const dir = mkdtempSync(join(tmpdir(), "swr-hsi-maint-"));
+    const binDir = installFakePsql();
+    installFakeCurl(binDir);
+    try {
+      const pgInstance = join(dir, "instance.json");
+      writePgInstance(pgInstance);
+      const r = spawnSync("sh", [SCRIPT], {
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH}`,
+          SWITCHROOM_HINDSIGHT_PG0_INSTANCE: pgInstance,
+          SWITCHROOM_HINDSIGHT_REQUEUE_DEAD_LETTERS: "1",
+          FAKE_DL_CANDS: "overlord|11111111-1111-1111-1111-111111111111",
+          FAKE_CURL_CODE: "401",
+        },
+        encoding: "utf-8",
+        timeout: 15_000,
+      });
+      expect(r.status).toBe(0);
+      expect(r.stderr).toMatch(/the retry endpoint needs auth; set SWITCHROOM_HINDSIGHT_API_TOKEN/);
+      expect(r.stderr).toMatch(/aborted after 0 requeued/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+
+  it("job #7 requeue targets the FK signature, is bounded, and hits the retry endpoint (static guard)", () => {
+    const raw = readFileSync(SCRIPT, "utf-8");
+    // OFF by default.
+    expect(raw).toMatch(/REQUEUE_DEAD_LETTERS="\$\{SWITCHROOM_HINDSIGHT_REQUEUE_DEAD_LETTERS:-0\}"/);
+    // Candidate query = the FK-race dead-letter signature, bounded by REQUEUE_MAX.
+    expect(raw).toMatch(
+      /operation_type='retain' AND status='failed' AND task_payload IS NOT NULL AND retry_count=0 AND next_retry_at IS NULL ORDER BY created_at LIMIT \$\{REQUEUE_MAX\}/,
+    );
+    // Uses the engine's own retry endpoint (not a raw SQL status flip).
+    expect(raw).toMatch(/\/v1\/default\/banks\/\$\{_bank\}\/operations\/\$\{_op\}\/retry/);
+    // POST, with an optional bearer token.
+    expect(raw).toMatch(/-X POST/);
+    expect(raw).toMatch(/Authorization: Bearer \$\{_tok\}/);
+    // The requeue must NOT reach into the queue table with a raw UPDATE.
+    expect(raw).not.toMatch(/UPDATE async_operations SET status='pending'/);
   });
 });


### PR DESCRIPTION
Two defects in `docker/hindsight-maintenance.sh`, both grounded in the engine's own partial claim index visible at `docker/Dockerfile.hindsight:1432-1444` (`idx_async_operations_pending_claim ON (status, created_at) WHERE status='pending' AND task_payload IS NOT NULL`).

## #3758 — false "queue may be wedged" alerts on healthy in-flight retains

Job #4's wedge probe took `max(age)` over **all** `pending`/`processing` rows. But a `batch_retain` **parent** is created with `task_payload=NULL` by design (`memory_engine.py:12556`) and is resolved by sibling aggregation — it is **never claimable** by a worker (the claim index requires `task_payload IS NOT NULL`). So a healthy live parent inflated the "oldest op" age and fired recurring false wedge alerts (the issue observed counts of 8 and 32 with nothing wrong; the quoted "oldest 235m" row was a `consolidation` op, not even the parent). The dangerous part is the implied remediation — clearing those rows would destroy in-flight memory writes for every agent mid-retain.

Fix: scope the wedge probe to `task_payload IS NOT NULL`, so the "is the claimable pipeline draining?" measurement covers exactly the rows a worker can claim.

## #3795 — 770 dead-lettered retains, silent for 8 days, recoverable

A `ForeignKeyViolation` race on `unit_entities` (#3794) was misclassified by the engine as a **deterministic** failure, so the affected `retain` ops were dead-lettered with `retry_count=0` / `next_retry_at=NULL`. The worker's claim loop only revisits `status='pending'`, so nothing recovers them — yet their `task_payload` is intact (10.4 MB of un-ingested content across 7 banks). **Stalled memory, not lost.** Nothing surfaced them for 8 days.

The classifier fix is an engine change (`memory_engine.py`), out of scope here and tracked in #3794/#3795. The two **switchroom-side** deliverables:

- **Job #6 — visibility (always-on, read-only).** WARNs when failed retains with an intact payload are older than `SWITCHROOM_HINDSIGHT_DEAD_LETTER_WARN_S` (default 6h; 0 disables), breaking out the FK-race subset (`retry_count=0 AND next_retry_at IS NULL`) that is safe to requeue. This is issue recommendation #3 ("alarm on it").
- **Job #7 — recovery (OFF by default, operator sign-off).** When `SWITCHROOM_HINDSIGHT_REQUEUE_DEAD_LETTERS=1`, POSTs each FK-race dead letter to the engine's **own** retry endpoint (`POST /v1/default/banks/{bank}/operations/{id}/retry`, verified in the issue: `api/http.py:5514` — flips `failed→pending`, clears `next_retry_at`/`worker_id`, resets `retry_count`). Bounded per tick by `REQUEUE_MAX` (default 100); aborts with a clear hint if the endpoint returns 401/403 (set `SWITCHROOM_HINDSIGHT_API_TOKEN`). This is issue recommendation #2 — it re-runs fact extraction and **costs LLM spend**, hence opt-in. **No raw SQL status flip and no engine code** — it uses the engine's retry semantics, per the constraint.

## Constraints honoured
- Switchroom-side only — no `vendor/hindsight-memory/**` and no engine (`memory_engine.py`) edits. The classifier narrowing (root cause) is left to the engine PR.
- The requeue uses the engine's REST retry endpoint, not a hand-rolled DB mutation.

## Operator note
The requeue endpoint route/auth is engine-internal (the `hindsight_api` package is pip-installed at image build, not vendored in this repo), so **confirm one op requeues correctly** (`SWITCHROOM_HINDSIGHT_REQUEUE_MAX=1`, watch the log) before running the flag fleet-wide. Loopback base URL defaults to `http://127.0.0.1:${HINDSIGHT_API_PORT:-9077}`; override with `SWITCHROOM_HINDSIGHT_API_URL`.

## Tests (assert outcomes, against a fake psql/curl)
- Job #4 wedge probe excludes payload-null parents (static + intent).
- Job #6 WARNs on a stale dead-letter count and stays silent when there are none; the probe is read-only and correctly scoped.
- Job #7 is OFF by default (no curl); when enabled it POSTs the exact retry-endpoint URL for the bank+op and logs a summary; on 401 it aborts with the token hint.

`tsc --noEmit` clean; 17 maintenance tests pass; `sh -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)