### PR TITLE
feat(config): complete profileFields memory mirror + global hindsight.llm passthrough + parity class-killer

### DIFF
--- a/src/config/schema.mirror-parity.test.ts
+++ b/src/config/schema.mirror-parity.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import {
+  AgentSchema,
+  AgentMemorySchema,
+  AgentDefaultsSchema,
+  ProfileSchema,
+  HindsightConfigSchema,
+  HindsightPerOpLlmSchema,
+} from "./schema.js";
+import { mergeAgentConfig } from "./merge.js";
+
+/**
+ * ── The class-killer parity test (#3909 / #3779 / #3687) ────────────────────
+ *
+ * switchroom's cascade has a recurring, silent failure class: a per-agent
+ * schema field (AgentMemorySchema, HindsightPerOpLlmSchema) grows a new key,
+ * but the DEFAULTS/PROFILE-tier mirror inside `profileFields` — or the GLOBAL
+ * `hindsight.llm` object — is never updated to match. Because those mirror
+ * objects are plain `z.object`s, an unmirrored key is STRIPPED at parse (Zod
+ * drops unknown keys) AND the merge clause that would cascade it becomes a
+ * no-op. The knob looks accepted in yaml and silently does nothing. This is the
+ * #3773 class (resources.tmp_size), the #3909 class (memory.retain), the #3779
+ * class (recall.types/skip_trivial/topic_filter_mode), and the missing
+ * memory-level missions/disposition.
+ *
+ * A per-key parse test only guards the keys someone remembered to write. This
+ * test instead shape-DIFFS `Object.keys` of each canonical per-agent sub-object
+ * against its mirror and FAILS on ANY asymmetry — so a FUTURE key added to the
+ * per-agent schema without a matching mirror breaks CI immediately, with a
+ * message naming the drifted keys. It is anchored by object SHAPE, not by line.
+ */
+
+/** Peel ZodOptional / ZodDefault / ZodNullable / ZodEffects to the ZodObject. */
+function unwrapToObject(schema: z.ZodTypeAny): z.ZodObject<z.ZodRawShape> {
+  let cur: z.ZodTypeAny = schema;
+  // Bounded: the deepest wrapper stack in this schema is a couple levels.
+  for (let i = 0; i < 10; i++) {
+    if (cur instanceof z.ZodObject) return cur as z.ZodObject<z.ZodRawShape>;
+    const def = (cur as unknown as { _def: Record<string, unknown> })._def;
+    const next = (def.innerType ?? def.schema) as z.ZodTypeAny | undefined;
+    if (!next) break;
+    cur = next;
+  }
+  throw new Error("unwrapToObject: never reached a ZodObject");
+}
+
+function keysOf(schema: z.ZodTypeAny): string[] {
+  return Object.keys(unwrapToObject(schema).shape).sort();
+}
+
+/** Keys the mirror DELIBERATELY omits from the per-agent memory shape. */
+const INTENTIONAL_MEMORY_MIRROR_EXCLUSIONS = new Set<string>([
+  // Per-agent ONLY by design: a mental model must never be fleet-seeded from
+  // the defaults/profile tier (see AgentMemorySchema.mental_models). If this
+  // exclusion is ever removed, mirror the field AND drop it from this set.
+  "mental_models",
+]);
+
+describe("profileFields mirror ↔ per-agent schema parity (class-killer)", () => {
+  const perAgentMemory = unwrapToObject(AgentMemorySchema).shape;
+  const profileMemory = unwrapToObject(ProfileSchema.shape.memory).shape;
+  const defaultsMemory = unwrapToObject(
+    unwrapToObject(AgentDefaultsSchema).shape.memory,
+  ).shape;
+
+  it("memory top-level: mirror == per-agent minus intentional exclusions", () => {
+    const expected = Object.keys(perAgentMemory)
+      .filter((k) => !INTENTIONAL_MEMORY_MIRROR_EXCLUSIONS.has(k))
+      .sort();
+    const mirror = Object.keys(profileMemory).sort();
+    // Directional messages so a failure names exactly what drifted.
+    const missingFromMirror = expected.filter((k) => !mirror.includes(k));
+    const extraInMirror = mirror.filter((k) => !expected.includes(k));
+    expect(
+      { missingFromMirror, extraInMirror },
+      "profileFields.memory drifted from AgentMemorySchema — add the mirror " +
+        "(or, for a deliberate omission, add it to " +
+        "INTENTIONAL_MEMORY_MIRROR_EXCLUSIONS)",
+    ).toEqual({ missingFromMirror: [], extraInMirror: [] });
+  });
+
+  it("defaults tier mirror matches the profile tier mirror (same source)", () => {
+    // Both are built from `profileFields`, but assert it rather than assume it.
+    expect(Object.keys(defaultsMemory).sort()).toEqual(
+      Object.keys(profileMemory).sort(),
+    );
+  });
+
+  it("memory.recall: mirror keys == per-agent recall keys (strict)", () => {
+    const perAgent = keysOf((perAgentMemory as Record<string, z.ZodTypeAny>).recall);
+    const mirror = keysOf((profileMemory as Record<string, z.ZodTypeAny>).recall);
+    expect(mirror, "profileFields.memory.recall drifted from AgentMemorySchema.recall").toEqual(perAgent);
+  });
+
+  it("memory.retain: mirror keys == per-agent retain keys (strict)", () => {
+    const perAgent = keysOf((perAgentMemory as Record<string, z.ZodTypeAny>).retain);
+    const mirror = keysOf((profileMemory as Record<string, z.ZodTypeAny>).retain);
+    expect(mirror, "profileFields.memory.retain drifted from AgentMemorySchema.retain").toEqual(perAgent);
+  });
+
+  it("memory.disposition: mirror keys == per-agent disposition keys (strict)", () => {
+    const perAgent = keysOf((perAgentMemory as Record<string, z.ZodTypeAny>).disposition);
+    const mirror = keysOf((profileMemory as Record<string, z.ZodTypeAny>).disposition);
+    expect(mirror, "profileFields.memory.disposition drifted from AgentMemorySchema.disposition").toEqual(perAgent);
+  });
+
+  it("hindsight.llm (global): every per-op LLM field is mirrored on the global object (#3687)", () => {
+    const perOp = keysOf(HindsightPerOpLlmSchema);
+    const global = keysOf(HindsightConfigSchema.shape.llm);
+    const missing = perOp.filter((k) => !global.includes(k));
+    expect(
+      missing,
+      "global hindsight.llm is missing per-op passthrough field(s) — copy the " +
+        "field def from HindsightPerOpLlmSchema",
+    ).toEqual([]);
+    // Guard the two this PR added explicitly, so a future revert is loud.
+    expect(global).toContain("base_url");
+    expect(global).toContain("api_key");
+  });
+});
+
+/**
+ * Parse + merge survival: a value set at the DEFAULTS tier for every newly
+ * mirrored key must survive `parse` (not be stripped) AND survive
+ * `mergeAgentConfig` (cascade into an agent that omits it). A shape-diff proves
+ * the KEY exists; these prove the VALUE actually flows.
+ */
+describe("newly mirrored keys survive parse + merge cascade", () => {
+  const defaults = AgentDefaultsSchema.parse({
+    memory: {
+      recall: {
+        types: ["world", "experience"],
+        skip_trivial: false,
+        topic_filter_mode: "hard-filter",
+        max_memories: 9,
+      },
+      retain: { every_n_turns: 7, overlap_turns: 4 },
+      bank_mission: "bm",
+      reflect_mission: "rm",
+      retain_mission: "rtm",
+      observations_mission: "om",
+      disposition: { skepticism: 5, literalism: 2 },
+    },
+  });
+
+  it("defaults tier: every mirrored key survives parse (not stripped)", () => {
+    const m = defaults!.memory!;
+    expect(m.recall?.types).toEqual(["world", "experience"]);
+    expect(m.recall?.skip_trivial).toBe(false);
+    expect(m.recall?.topic_filter_mode).toBe("hard-filter");
+    expect(m.retain?.every_n_turns).toBe(7);
+    expect(m.retain?.overlap_turns).toBe(4);
+    expect(m.bank_mission).toBe("bm");
+    expect(m.reflect_mission).toBe("rm");
+    expect(m.retain_mission).toBe("rtm");
+    expect(m.observations_mission).toBe("om");
+    expect(m.disposition?.skepticism).toBe(5);
+    expect(m.disposition?.literalism).toBe(2);
+  });
+
+  it("profile tier: retain + missions survive parse", () => {
+    const p = ProfileSchema.parse({
+      memory: {
+        retain: { every_n_turns: 2 },
+        recall: { skip_trivial: true },
+        observations_mission: "pm",
+      },
+    });
+    expect(p.memory?.retain?.every_n_turns).toBe(2);
+    expect(p.memory?.recall?.skip_trivial).toBe(true);
+    expect(p.memory?.observations_mission).toBe("pm");
+  });
+
+  it("cascade: an agent that omits the keys inherits them from defaults", () => {
+    const agent = AgentSchema.parse({
+      topic_name: "ops",
+      memory: { collection: "ops-bank" },
+    });
+    const merged = mergeAgentConfig(defaults, agent);
+    const m = merged.memory!;
+    expect(m.recall?.types).toEqual(["world", "experience"]);
+    expect(m.recall?.topic_filter_mode).toBe("hard-filter");
+    expect(m.retain?.every_n_turns).toBe(7);
+    expect(m.retain?.overlap_turns).toBe(4);
+    expect(m.bank_mission).toBe("bm");
+    expect(m.reflect_mission).toBe("rm");
+    expect(m.retain_mission).toBe("rtm");
+    expect(m.observations_mission).toBe("om");
+    expect(m.disposition?.skepticism).toBe(5);
+  });
+
+  it("cascade: retain + disposition per-key merge (agent overrides one, inherits siblings)", () => {
+    const agent = AgentSchema.parse({
+      topic_name: "ops",
+      memory: {
+        collection: "ops-bank",
+        retain: { every_n_turns: 1 },
+        disposition: { empathy: 4 },
+      },
+    });
+    const merged = mergeAgentConfig(defaults, agent);
+    const m = merged.memory!;
+    // retain: agent wins on every_n_turns, inherits overlap_turns from defaults.
+    expect(m.retain?.every_n_turns).toBe(1);
+    expect(m.retain?.overlap_turns).toBe(4);
+    // disposition: agent wins on empathy, inherits skepticism/literalism.
+    expect(m.disposition?.empathy).toBe(4);
+    expect(m.disposition?.skepticism).toBe(5);
+    expect(m.disposition?.literalism).toBe(2);
+  });
+});
+
+/**
+ * Global hindsight.llm base_url / api_key survive parse (#3687). The env
+ * EMISSION is covered in src/setup — here we only prove the schema accepts and
+ * retains the two new global fields rather than stripping them.
+ */
+describe("hindsight.llm global base_url / api_key survive parse (#3687)", () => {
+  it("accepts and retains both fields on the global llm object", () => {
+    const cfg = HindsightConfigSchema.parse({
+      llm: {
+        provider: "litellm",
+        model: "openrouter/some/model",
+        base_url: "http://127.0.0.1:4010",
+        api_key: "vault:litellm/hindsight/api-key",
+      },
+    });
+    expect(cfg.llm?.base_url).toBe("http://127.0.0.1:4010");
+    expect(cfg.llm?.api_key).toBe("vault:litellm/hindsight/api-key");
+  });
+});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2432,7 +2432,7 @@ export const LiteLLMConfigSchema = z
  * container also inherits `ANTHROPIC_MODEL=<model>` so the underlying claude
  * subprocess (and any LiteLLM proxy it routes through) targets the same model.
  */
-const HindsightPerOpLlmSchema = z
+export const HindsightPerOpLlmSchema = z
   .object({
     model: z
       .string()
@@ -2569,6 +2569,28 @@ export const HindsightConfigSchema = z.object({
           "drops the system prompt and the model answers conversationally " +
           "with HTTP 200 — so this value is what makes the failure " +
           "detectable at setup time instead of never.",
+        ),
+      base_url: z
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+          "GLOBAL LLM base URL (upstream `HINDSIGHT_API_LLM_BASE_URL`). The " +
+          "default endpoint every op inherits absent a per-op " +
+          "`hindsight.llm.<op>.base_url`. Optional passthrough; unset → the " +
+          "engine's provider default. When this points at host loopback the " +
+          "hindsight container is forced onto host networking, same as a " +
+          "per-op base URL, so the endpoint stays reachable (#3687).",
+        ),
+      api_key: z
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+          "GLOBAL LLM API key (upstream `HINDSIGHT_API_LLM_API_KEY`). Literal " +
+          "or `vault:` reference. The default credential every op inherits " +
+          "absent a per-op `hindsight.llm.<op>.api_key`; the engine reads it as " +
+          "a plain env fallback. Optional passthrough (#3687).",
         ),
       retain: HindsightPerOpLlmSchema.optional().describe(
         "Per-op override for the `retain` LLM op (memory ingestion). Emits " +
@@ -3392,6 +3414,44 @@ const profileFields = {
           parallel: z.boolean().optional(),
           additional_banks: z.array(z.string()).optional(),
           sender_banks: z.record(z.string(), z.string()).optional(),
+          // Mirrors of AgentMemorySchema.recall.{types,skip_trivial,
+          // topic_filter_mode} (#3779) — accepted at the defaults/profile tier
+          // too so they cascade fleet-wide like their siblings. Without these
+          // the keys were stripped at parse (unknown key) — the #3773 silent
+          // no-op class. Descriptions live on AgentMemorySchema.recall above.
+          types: z.array(z.string()).optional(),
+          skip_trivial: z.boolean().optional(),
+          topic_filter_mode: z.enum(["soft-preamble", "hard-filter"]).optional(),
+        })
+        .optional(),
+      // Mirror of AgentMemorySchema.retain (#3909) — accepted at the
+      // defaults/profile tier too so the auto-retain cadence can be tuned
+      // fleet-wide with per-agent overrides. merge.ts one-level-deep merges
+      // this per-key exactly like `recall`; without the mirror the keys were
+      // stripped at parse AND the merge clause was a silent no-op. Descriptions
+      // live on AgentMemorySchema.retain.
+      retain: z
+        .object({
+          every_n_turns: z.number().int().min(1).optional(),
+          overlap_turns: z.number().int().min(0).optional(),
+        })
+        .optional(),
+      // Mirrors of AgentMemorySchema.{bank_mission,reflect_mission,
+      // retain_mission,observations_mission,disposition} — accepted at the
+      // defaults/profile tier too so a bank's mission framing and disposition
+      // cascade fleet-wide (per-key merge for `disposition`, override for the
+      // missions). mental_models is DELIBERATELY not mirrored: it is per-agent
+      // only by design (see AgentMemorySchema.mental_models) so a model can
+      // never be fleet-seeded. Descriptions live on AgentMemorySchema.
+      bank_mission: z.string().optional(),
+      reflect_mission: z.string().optional(),
+      retain_mission: z.string().optional(),
+      observations_mission: z.string().optional(),
+      disposition: z
+        .object({
+          skepticism: z.number().int().min(1).max(5).optional(),
+          literalism: z.number().int().min(1).max(5).optional(),
+          empathy: z.number().int().min(1).max(5).optional(),
         })
         .optional(),
     })

--- a/src/litellm/key-allowlist-check.test.ts
+++ b/src/litellm/key-allowlist-check.test.ts
@@ -25,11 +25,11 @@ const LIVE_ALLOWLIST_20260726 = [
  * Three litellm-routed lanes presenting one declared key — the shape a fleet
  * has to be in for reachability to be checkable at all.
  *
- * Each op names its `api_key`, because a lane that declares none presents a
- * credential switchroom cannot identify (no global `HINDSIGHT_API_LLM_API_KEY`
- * is ever emitted, and the global `hindsight.llm` block has no `api_key` field
- * in the schema). That case has its own describe block below and must WARN, not
- * report on some other key.
+ * Each op in this fixture names its own `api_key`, and no global
+ * `hindsight.llm.api_key` is set. A lane that declares none, when there is also
+ * no global key to inherit (#3687), presents a credential switchroom cannot
+ * identify — nothing emits a `HINDSIGHT_API_LLM_API_KEY` for it. That case has
+ * its own describe block below and must WARN, not report on some other key.
  */
 function cfg(over: Partial<SwitchroomConfig> = {}): SwitchroomConfig {
   return {

--- a/src/litellm/key-allowlist.test.ts
+++ b/src/litellm/key-allowlist.test.ts
@@ -298,9 +298,10 @@ describe("requiredKeyDemands — group by the key that must reach the lane", () 
       PROXY_MODELS,
     );
     expect(required.find((r) => r.group === "gpt-oss-20b-retain")?.apiKeyRef).toBe("sk-lane");
-    // The global block has no `api_key` field in the schema, so the global lane
-    // is always `null` — UNKNOWN, not "the provisioned service key". Callers
-    // must warn on it rather than reconciling or failing another key by proxy.
+    // This config sets no global `hindsight.llm.api_key`, so the global lane
+    // inherits nothing and its apiKeyRef is `null` — UNKNOWN, not "the
+    // provisioned service key". When the global key IS set it presents that
+    // key instead (#3687) — see the global-key fallback describe block below.
     expect(required.find((r) => r.group === "gpt-oss-20b")?.apiKeyRef).toBeNull();
   });
 
@@ -355,6 +356,59 @@ describe("requiredKeyDemands — group by the key that must reach the lane", () 
       PROXY_MODELS,
     );
     expect(required.find((r) => r.group === "gpt-oss-20b-retain")?.apiKeyRef).toBeNull();
+  });
+});
+
+/**
+ * The global-credential fallback added by #3687.
+ *
+ * The global `hindsight.llm.api_key` (upstream `HINDSIGHT_API_LLM_API_KEY`) is
+ * now a real, emitted credential: the global lane presents it, and a per-op
+ * lane that declares no `api_key` inherits it rather than presenting nothing.
+ * `apiKeyRef` is only `null` — UNKNOWN — when neither the per-op block nor the
+ * global `llm` block names a key. Without this coverage the whole fallback can
+ * be reverted with every other test still green, which is exactly the false-
+ * attribution class this module exists to prevent.
+ */
+describe("requiredKeyModels — global hindsight.llm.api_key fallback (#3687)", () => {
+  it("presents the global api_key on the global lane when it is set", () => {
+    const required = requiredKeyModels(liveConfig({ api_key: "sk-global" }), PROXY_MODELS);
+    expect(required.find((r) => r.group === "gpt-oss-20b")?.apiKeyRef).toBe("sk-global");
+  });
+
+  it("inherits the global api_key on a per-op lane that declares none", () => {
+    // `retain` in liveConfig() overrides only `model`, so it carries no key of
+    // its own and must inherit the global credential — not resolve to null.
+    const required = requiredKeyModels(liveConfig({ api_key: "sk-global" }), PROXY_MODELS);
+    expect(required.find((r) => r.group === "gpt-oss-20b-retain")?.apiKeyRef).toBe("sk-global");
+    expect(required.find((r) => r.group === "gpt-oss-20b-consolidation")?.apiKeyRef).toBe(
+      "sk-global",
+    );
+  });
+
+  it("lets a per-op api_key still override the global one, sibling still inherits", () => {
+    const required = requiredKeyModels(
+      liveConfig({
+        api_key: "sk-global",
+        retain: { model: "openai/gpt-oss-20b-retain", api_key: "sk-lane" },
+      }),
+      PROXY_MODELS,
+    );
+    // The op that names its own key presents it…
+    expect(required.find((r) => r.group === "gpt-oss-20b-retain")?.apiKeyRef).toBe("sk-lane");
+    // …while the keyless sibling still falls back to the global credential.
+    expect(required.find((r) => r.group === "gpt-oss-20b-consolidation")?.apiKeyRef).toBe(
+      "sk-global",
+    );
+  });
+
+  it("is null ONLY when neither the per-op block nor the global llm declares a key", () => {
+    // No global `api_key`, and `retain`/global/`consolidation` declare none, so
+    // there is genuinely no credential to name — the one case that stays null.
+    const required = requiredKeyModels(liveConfig(), PROXY_MODELS);
+    expect(required.find((r) => r.group === "gpt-oss-20b")?.apiKeyRef).toBeNull();
+    expect(required.find((r) => r.group === "gpt-oss-20b-retain")?.apiKeyRef).toBeNull();
+    expect(required.find((r) => r.group === "gpt-oss-20b-consolidation")?.apiKeyRef).toBeNull();
   });
 });
 

--- a/src/litellm/key-allowlist.ts
+++ b/src/litellm/key-allowlist.ts
@@ -108,22 +108,22 @@ export interface RequiredKeyModel {
    * it is the caller's job, because only the caller knows whether it holds a
    * broker handle or a passphrase).
    *
-   * `null` when the op declares none — and that means UNKNOWN, not "the
-   * provisioned service key". There is no fallback to fall back TO: switchroom
-   * emits `HINDSIGHT_API_<OP>_LLM_API_KEY` only for an op that declares one,
-   * never a global `HINDSIGHT_API_LLM_API_KEY` (`src/cli/setup.ts:1112` records
-   * that the global var is "no longer used"), and hindsight reads the global as
-   * a plain `os.getenv(ENV_LLM_API_KEY)` with no default. The provisioned vault
-   * key is NOT it either: `src/setup/hindsight.ts:1178` injects that key solely
-   * as the `ANTHROPIC_CUSTOM_HEADERS` bearer for the CLAUDE-CODE passthrough,
-   * which is a lane `can_key_call_model` never sees.
+   * `null` when the op declares none AND no global `hindsight.llm.api_key`
+   * exists to inherit — and that means UNKNOWN, not "the provisioned service
+   * key". Since #3687 the global `hindsight.llm` block DOES carry an optional
+   * `api_key`, emitted as `HINDSIGHT_API_LLM_API_KEY`; hindsight reads it as the
+   * `os.getenv(ENV_LLM_API_KEY)` fallback for any op that emits no per-op key.
+   * So `requiredKeyModels` resolves a per-op omission to `?? llm.api_key` — a
+   * lane is `null` only when neither the op nor the global declares a key. The
+   * provisioned vault key is NOT it either: `src/setup/hindsight.ts` injects
+   * that key solely as the `ANTHROPIC_CUSTOM_HEADERS` bearer for the CLAUDE-CODE
+   * passthrough, which is a lane `can_key_call_model` never sees.
    *
-   * So a `provider: litellm` lane with no `api_key` presents no credential this
-   * module can name, and no allowlist grant can fix it. Callers must degrade to
-   * a warning rather than reconciling or failing some other key on its behalf —
-   * blaming a key the lane does not present is the same false-attribution bug
-   * this module exists to remove. The global `hindsight.llm` block carries no
-   * `api_key` field in the schema at all, so the global lane is always `null`.
+   * So a `provider: litellm` lane with no per-op AND no global `api_key`
+   * presents no credential this module can name, and no allowlist grant can fix
+   * it. Callers must degrade to a warning rather than reconciling or failing
+   * some other key on its behalf — blaming a key the lane does not present is
+   * the same false-attribution bug this module exists to remove.
    */
   apiKeyRef: string | null;
 }
@@ -219,23 +219,28 @@ export function requiredKeyModels(
   // group demanded by two consumers is a finding that has to name both, so
   // there was never a duplicate to collapse here — `unreachableModels` does the
   // collapsing, by group, at report time.
-  consider(llm.model, llm.provider, undefined, "hindsight.llm.model (global)");
+  // The global op presents the global `hindsight.llm.api_key` (#3687). A per-op
+  // op with no `api_key` inherits the same global credential — the engine reads
+  // `HINDSIGHT_API_LLM_API_KEY` as the fallback — so we resolve `?? llm.api_key`
+  // rather than treating a per-op omission as "presents nothing".
+  const globalKey = llm.api_key;
+  consider(llm.model, llm.provider, globalKey, "hindsight.llm.model (global)");
   consider(
     llm.retain?.model,
     llm.retain?.provider,
-    llm.retain?.api_key,
+    llm.retain?.api_key ?? globalKey,
     "hindsight.llm.retain",
   );
   consider(
     llm.reflect?.model,
     llm.reflect?.provider,
-    llm.reflect?.api_key,
+    llm.reflect?.api_key ?? globalKey,
     "hindsight.llm.reflect",
   );
   consider(
     llm.consolidation?.model,
     llm.consolidation?.provider,
-    llm.consolidation?.api_key,
+    llm.consolidation?.api_key ?? globalKey,
     "hindsight.llm.consolidation",
   );
 

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -1148,6 +1148,17 @@ export interface HindsightLlmConfig {
   /** `HINDSIGHT_API_LLM_MODEL`. Default {@link HINDSIGHT_DEFAULT_MODEL}. */
   model?: string;
   /**
+   * Global `HINDSIGHT_API_LLM_BASE_URL`. Default endpoint every op inherits
+   * absent a per-op `base_url`. Emitted only when set (#3687). A loopback value
+   * forces host networking via {@link collectHindsightLlmBaseUrls}.
+   */
+  base_url?: string;
+  /**
+   * Global `HINDSIGHT_API_LLM_API_KEY`. Default credential every op inherits
+   * absent a per-op `api_key`. Emitted only when set (#3687).
+   */
+  api_key?: string;
+  /**
    * Declared context window (tokens) of the backend. NOT an upstream env var
    * — switchroom derives the token budget from it (see
    * `hindsight-context-budget.ts`). Absent → a per-provider default.
@@ -1218,6 +1229,26 @@ export function resolveHindsightPerOpLlm(
     if (baseUrl) out.push([`${prefix}_BASE_URL`, baseUrl]);
     if (apiKey) out.push([`${prefix}_API_KEY`, apiKey]);
   }
+  return out;
+}
+
+/**
+ * Resolve the GLOBAL LLM passthrough env vars (`HINDSIGHT_API_LLM_BASE_URL` /
+ * `HINDSIGHT_API_LLM_API_KEY`) from an optional operator override. Returns ONLY
+ * the vars actually set — an unset field emits nothing and the engine uses its
+ * provider default (#3687). Symmetric with {@link resolveHindsightPerOpLlm} and
+ * shared by both launch paths so docker-run and compose never drift. Never
+ * emits empty values.
+ */
+export function resolveHindsightGlobalLlmExtras(
+  llm?: HindsightLlmConfig,
+): Array<[string, string]> {
+  const out: Array<[string, string]> = [];
+  if (!llm) return out;
+  const baseUrl = llm.base_url?.trim();
+  const apiKey = llm.api_key?.trim();
+  if (baseUrl) out.push(["HINDSIGHT_API_LLM_BASE_URL", baseUrl]);
+  if (apiKey) out.push(["HINDSIGHT_API_LLM_API_KEY", apiKey]);
   return out;
 }
 
@@ -1293,6 +1324,11 @@ export function collectHindsightLlmBaseUrls(
     out.push(v);
   };
   push(litellm?.baseUrl);
+  // Global base URL (#3687) forces host networking on a loopback value exactly
+  // like a per-op one — otherwise compose stays on bridge and the emitted
+  // http://127.0.0.1:… is unreachable (the same silent outage the per-op path
+  // fixed). Ordered before per-op so the global endpoint reports first.
+  push(llm?.base_url);
   for (const [k, v] of resolveHindsightPerOpLlm(llm)) {
     if (k.endsWith("_BASE_URL")) push(v);
   }
@@ -1900,6 +1936,9 @@ export function hindsightContainerEnvPairs(opts: {
   const pairs: Array<[string, string]> = [
     ["HINDSIGHT_API_LLM_PROVIDER", llmProvider],
     ["HINDSIGHT_API_LLM_MODEL", llmModel],
+    // Global LLM passthrough (base_url / api_key) — only the configured vars
+    // (#3687, see resolveHindsightGlobalLlmExtras).
+    ...resolveHindsightGlobalLlmExtras(llm),
     // Per-op LLM overrides (only the configured vars — see resolveHindsightPerOpLlm).
     ...perOpLlm,
     ["HINDSIGHT_API_MCP_STATELESS", String(HINDSIGHT_DEFAULT_MCP_STATELESS)],
@@ -2524,6 +2563,10 @@ export function generateHindsightComposeSnippet(
     // the docker-run/compose twin property still holds for it.
     `      - HINDSIGHT_API_LLM_PROVIDER=${llmProvider}`,
     `      - HINDSIGHT_API_LLM_MODEL=${llmModel}`,
+    // Global LLM passthrough (base_url / api_key) — only the configured vars
+    // (#3687), from the SAME resolver the docker-run path uses so the twin
+    // property holds.
+    ...resolveHindsightGlobalLlmExtras(llm).map(([k, v]) => `      - ${k}=${v}`),
     // Per-op LLM overrides (only the configured vars — see resolveHindsightPerOpLlm).
     ...perOpLlm.map(([k, v]) => `      - ${k}=${v}`),
     // Mirror of the docker-run path: with the claude-code provider, pin

--- a/tests/hindsight-env-keys-are-reachable.test.ts
+++ b/tests/hindsight-env-keys-are-reachable.test.ts
@@ -80,6 +80,19 @@ describe("promoted container-env keys are reachable from switchroom.yaml", () =>
       "HINDSIGHT_API_HOST",
       "HINDSIGHT_API_LLM_PROVIDER",
       "HINDSIGHT_API_LLM_MODEL",
+      // The global LLM passthrough (#3687, resolveHindsightGlobalLlmExtras) —
+      // siblings of PROVIDER / MODEL above, emitted from the same structured
+      // `hindsight.llm.{base_url,api_key}` config and ONLY when set. They ARE
+      // operator-overridable, but through that typed config field, which is
+      // their channel: they are endpoint/credential config, not a free-form
+      // `hindsight.env` perf knob, so they are deliberately not routed through
+      // the perf resolvers. A perf-defaults entry carries a default value and
+      // would emit an unconditional empty (breaking the loopback host-network
+      // derivation in collectHindsightLlmBaseUrls) and would double-source the
+      // same var against the typed field. Derived config passthrough, excused
+      // exactly like PROVIDER / MODEL.
+      "HINDSIGHT_API_LLM_BASE_URL",
+      "HINDSIGHT_API_LLM_API_KEY",
       "HINDSIGHT_API_WORKER_ID",
       "HINDSIGHT_API_MCP_STATELESS",
       // The asserted LLM budget (hindsightLlmBudgetEnv). Every one of these is

--- a/tests/setup/hindsight.test.ts
+++ b/tests/setup/hindsight.test.ts
@@ -262,6 +262,51 @@ describe("hindsight broker-fed mode (#1245)", () => {
     expect(env).toContain("HINDSIGHT_API_CONSOLIDATION_LLM_API_KEY=sk-consol");
   });
 
+  it("emits GLOBAL base_url / api_key passthrough only for the fields set (#3687)", () => {
+    startHindsight({ apiPort: 8888, uiPort: 9999 }, undefined, undefined, {
+      provider: "litellm",
+      model: "openrouter/z-ai/glm-5.2",
+      base_url: "http://127.0.0.1:4010",
+      api_key: "sk-global",
+    });
+    const env = envPairsFromArgs(findRunArgs());
+    expect(env).toContain("HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:4010");
+    expect(env).toContain("HINDSIGHT_API_LLM_API_KEY=sk-global");
+  });
+
+  it("emits NO global base_url / api_key when unset (default broker-fed mode) (#3687)", () => {
+    startHindsight({ apiPort: 8888, uiPort: 9999 }, undefined, undefined, {
+      provider: "claude-code",
+      model: "openrouter/z-ai/glm-5.2",
+    });
+    const env = envPairsFromArgs(findRunArgs());
+    expect(env.some((e) => e.startsWith("HINDSIGHT_API_LLM_BASE_URL="))).toBe(false);
+    expect(env.some((e) => e.startsWith("HINDSIGHT_API_LLM_API_KEY="))).toBe(false);
+  });
+
+  it("compose snippet emits the GLOBAL base_url / api_key passthrough too (#3687)", async () => {
+    const { generateHindsightComposeSnippet } = await import("../../src/setup/hindsight.js");
+    const snippet = generateHindsightComposeSnippet({
+      provider: "litellm",
+      model: "glm-5.2",
+      base_url: "http://127.0.0.1:4010",
+      api_key: "sk-global",
+    });
+    expect(snippet).toContain("HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:4010");
+    expect(snippet).toContain("HINDSIGHT_API_LLM_API_KEY=sk-global");
+  });
+
+  it("a loopback GLOBAL base_url forces host networking (#3687, no silent bridge outage)", () => {
+    startHindsight({ apiPort: 8888, uiPort: 9999 }, undefined, undefined, {
+      provider: "litellm",
+      model: "glm-5.2",
+      base_url: "http://127.0.0.1:4010",
+    });
+    const args = findRunArgs();
+    expect(args).toContain("--network");
+    expect(args).toContain("host");
+  });
+
   it("does NOT emit a per-op var for an op with no override (engine falls back to global)", () => {
     startHindsight({ apiPort: 8888, uiPort: 9999 }, undefined, undefined, {
       model: "glm-5.2",


### PR DESCRIPTION
## Summary

Closes the silent-cascade-drift class: a per-agent schema field (`AgentMemorySchema`, `HindsightPerOpLlmSchema`) grows a key, but the defaults/profile-tier mirror inside `profileFields` — or the GLOBAL `hindsight.llm` object — is never updated. Because those mirrors are plain `z.object`s, an unmirrored key is stripped at parse **and** its merge clause becomes a no-op. The knob looks accepted in yaml and silently does nothing (the #3773 class).

- **#3909** — mirror `memory.retain` (`every_n_turns`/`overlap_turns`) into `profileFields`. `merge.ts:416` already one-level-deep merges it per-key; the mirror was the only gap.
- **#3779** — mirror `memory.recall.{types,skip_trivial,topic_filter_mode}`.
- Mirror the memory-level `bank_mission` / `reflect_mission` / `retain_mission` / `observations_mission` / `disposition` (a prior review flagged these absent). `mental_models` is **deliberately** left per-agent-only (it must never be fleet-seeded — see `AgentMemorySchema.mental_models`); the parity test records that as an explicit exclusion.
- **#3687** — add `base_url` / `api_key` to the GLOBAL `hindsight.llm` object, copied from `HindsightPerOpLlmSchema`. Emit `HINDSIGHT_API_LLM_{BASE_URL,API_KEY}` on both launch paths (docker-run + compose) from one shared resolver so the twin property holds; a loopback global `base_url` now forces host networking exactly like a per-op one (no silent bridge outage). `key-allowlist` resolves a per-op omission to `?? llm.api_key` and its stale "global carries no api_key" comment is corrected.
- **The class-killer** — `src/config/schema.mirror-parity.test.ts` shape-diffs `Object.keys` of each per-agent sub-object (memory top-level, `recall`, `retain`, `disposition`, and the global `hindsight.llm` vs per-op schema) against its mirror and FAILS on any asymmetry, anchored by object shape not line. Plus parse+merge survival for every newly mirrored key. A future unmirrored key breaks CI immediately with a message naming the drifted keys.

## Why

Docs test + consistency test (`reference/principles.md`): a documented cascade knob must actually cascade. Job spec: `reference/jobs/configure-the-fleet.md` — config-cascade integrity.

## Test plan

- `vitest run src/config tests/setup/hindsight.test.ts src/litellm` — green (parity 11, hindsight 80, config 469, merge/key-allowlist green).
- `tsc --noEmit` — clean.
- Verified the class-killer **fails** (8 cases) when the mirror is reverted and **passes** after — it is strict enough that a missing future mirror key reds CI.

## Risk

Low — additive optional schema fields; env vars emitted only when the operator sets them; default broker-fed mode unchanged (asserted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)