### PR TITLE
fix(memory): surface bank-composition telemetry in the human recall-log view (#3775)

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -210,6 +210,25 @@ interface RecallLogEntry {
   injected_score_min?: number | null;
   injected_score_median?: number | null;
   injected_score_max?: number | null;
+  /**
+   * Bank-composition telemetry (#3775): how the injected result set split
+   * between the agent's OWN bank and any additional (shared/peer) banks.
+   * `injected_own_bank_count + injected_additional_bank_count` sums to
+   * `result_count`; an unstamped memory counts as ADDITIONAL, so `own` is
+   * never optimistic (`_injected_bank_composition`, recall.py). The
+   * `reserved_*_slots` pair is the reservation FLOOR each side was granted
+   * before the head-slice cap applied (recall.py). These are the regression
+   * detectors the scaffold/schema docs tell operators to watch: when own-bank
+   * recall collapses to 0 while additional stays high, the agent has quietly
+   * stopped seeing its own memory even though `result_count` still looks full.
+   * Before this they were reachable only under `--json`, so the documented
+   * remedy ("observe `injected_own_bank_count` via `memory recall-log`") did
+   * not actually work.
+   */
+  injected_own_bank_count?: number | null;
+  injected_additional_bank_count?: number | null;
+  reserved_own_slots?: number | null;
+  reserved_additional_slots?: number | null;
   cache_hit?: boolean;
 }
 
@@ -298,13 +317,28 @@ export function formatRecallLogView(
     medians.length > 0
       ? Math.round((medians.reduce((s, n) => s + n, 0) / medians.length) * 100) / 100
       : null;
+  // #3775 — own-bank collapse detector. Count the turns where the agent got a
+  // non-empty result set but NONE of it came from its own bank (own=0 while
+  // additional>0). That is the exact regression the composition telemetry
+  // exists to catch: `result_count` still looks full, so every volume stat
+  // above reads healthy, while the agent has silently stopped seeing its own
+  // memory. A turn with no composition stamp (own/additional both absent) is
+  // not counted — absence of data is not a collapse.
+  const collapseTurns = entries.filter(
+    (e) =>
+      typeof e.injected_own_bank_count === "number" &&
+      e.injected_own_bank_count === 0 &&
+      typeof e.injected_additional_bank_count === "number" &&
+      e.injected_additional_bank_count > 0,
+  ).length;
   lines.push(
     chalk.gray(
       `  last ${total} turn${total === 1 ? "" : "s"}: ` +
       `avg=${avg ?? "—"} max=${max ?? "—"} ` +
       `avg_score=${avgScore ?? "—"} ` +
       `cache_hits=${hits} capped=${cappedTurns}` +
-      (omittedTurns > 0 ? ` directives_omitted_turns=${omittedTurns}` : ""),
+      (omittedTurns > 0 ? ` directives_omitted_turns=${omittedTurns}` : "") +
+      (collapseTurns > 0 ? chalk.red(` own_bank_collapse_turns=${collapseTurns}`) : ""),
     ),
   );
 
@@ -324,6 +358,20 @@ export function formatRecallLogView(
     const ids = e.memory_ids && e.memory_ids.length > 0
       ? chalk.dim(` ids=${e.memory_ids.slice(0, 3).join(",")}${e.memory_ids.length > 3 ? `…+${e.memory_ids.length - 3}` : ""}`)
       : "";
+    // #3775 — the own/additional split. Shown whenever either side carries a
+    // count. `own=0` while additional>0 is the collapse the summary flags, so
+    // paint that row's split red; otherwise it's dim like the other detail.
+    const own = e.injected_own_bank_count;
+    const additional = e.injected_additional_bank_count;
+    const composition =
+      typeof own === "number" || typeof additional === "number"
+        ? (() => {
+            const text = ` own/add=${own ?? "—"}/${additional ?? "—"}`;
+            return own === 0 && typeof additional === "number" && additional > 0
+              ? chalk.red(text)
+              : chalk.dim(text);
+          })()
+        : "";
     // #3541 — the quality half of the row. Volume without score range reads
     // as success whether the injected memories are relevant or not.
     const score =
@@ -339,7 +387,7 @@ export function formatRecallLogView(
     lines.push(
       `  ${chalk.gray(e.ts)} ${flag} ` +
       `n=${e.result_count ?? "—"}${e.pre_cap_count != null && e.pre_cap_count !== e.result_count ? `/${e.pre_cap_count}` : ""}` +
-      `${dem}${omitted}${score}${ids}`,
+      `${dem}${omitted}${score}${composition}${ids}`,
     );
   }
 

--- a/tests/cli.memory.recall-log.test.ts
+++ b/tests/cli.memory.recall-log.test.ts
@@ -200,3 +200,116 @@ describe("formatRecallLogView — injected relevance scores", () => {
     expect(out.join("\n")).not.toContain("score=0.00");
   });
 });
+
+// Switchroom #3775 — bank-composition telemetry was invisible in the default
+// (non-`--json`) `memory recall-log` view. recall.py stamps every row with
+// `injected_own_bank_count` / `injected_additional_bank_count` (and the
+// `reserved_*_slots` floors), and the scaffold/schema docs tell operators to
+// watch `injected_own_bank_count` via `switchroom memory recall-log <agent>`.
+// But `formatRecallLogView` rendered only volume/score/omitted fields, so the
+// documented remedy required `--json`. The regression these catch is own-bank
+// COLLAPSE: `result_count` stays full while none of it comes from the agent's
+// own bank. These assert the split reaches the operator on the human path.
+describe("formatRecallLogView — bank composition (#3775)", () => {
+  const ANSI = new RegExp(String.fromCharCode(27) + "\\[[0-9;]*m", "g");
+  const strip = (s: string) => s.replace(ANSI, "");
+
+  it("reads the four composition fields off the log through the typed interface", () => {
+    const dir = mkdtempSync(join(tmpdir(), "recall-log-comp-"));
+    const stateDir = join(
+      dir, ".claude", "plugins", "data", "hindsight-memory-inline", "state",
+    );
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, "recall_log.jsonl"),
+      JSON.stringify({
+        ts: "2026-07-31T10:00:00Z",
+        result_count: 6,
+        injected_own_bank_count: 2,
+        injected_additional_bank_count: 4,
+        reserved_own_slots: 2,
+        reserved_additional_slots: 1,
+      }) + "\n",
+    );
+    try {
+      const e = readRecallLog(dir, 10)[0];
+      expect(e.injected_own_bank_count).toBe(2);
+      expect(e.injected_additional_bank_count).toBe(4);
+      expect(e.reserved_own_slots).toBe(2);
+      expect(e.reserved_additional_slots).toBe(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("prints the own/additional split per row", () => {
+    const out = formatRecallLogView("clerk", [
+      {
+        ts: "2026-07-31T10:00:00Z",
+        result_count: 6,
+        injected_own_bank_count: 2,
+        injected_additional_bank_count: 4,
+      },
+    ]).map(strip);
+    expect(out[2]).toContain("own/add=2/4");
+  });
+
+  it("flags an own-bank collapse turn in the summary (full result, zero own)", () => {
+    const out = formatRecallLogView("clerk", [
+      // Collapse: full set, but none of it is the agent's own bank.
+      {
+        ts: "2026-07-31T10:00:00Z",
+        result_count: 6,
+        injected_own_bank_count: 0,
+        injected_additional_bank_count: 6,
+      },
+      // Healthy row — own bank contributes.
+      {
+        ts: "2026-07-31T10:01:00Z",
+        result_count: 6,
+        injected_own_bank_count: 3,
+        injected_additional_bank_count: 3,
+      },
+    ]).map(strip);
+
+    // Only the collapse turn counts.
+    expect(out[1]).toContain("own_bank_collapse_turns=1");
+    // The collapse row surfaces its 0/N split; the healthy row shows its own.
+    expect(out[2]).toContain("own/add=0/6");
+    expect(out[3]).toContain("own/add=3/3");
+  });
+
+  it("distinguishes a full-but-own-starved turn from a full-and-own-fed one", () => {
+    // Both turns are volume-identical: result_count 8, no cap, no demotion.
+    const starved = formatRecallLogView("clerk", [
+      { ts: "t", result_count: 8, injected_own_bank_count: 0, injected_additional_bank_count: 8 },
+    ]).map(strip);
+    const fed = formatRecallLogView("clerk", [
+      { ts: "t", result_count: 8, injected_own_bank_count: 8, injected_additional_bank_count: 0 },
+    ]).map(strip);
+
+    // The volume summary cannot tell them apart.
+    expect(starved[1]).toContain("avg=8 max=8");
+    expect(fed[1]).toContain("avg=8 max=8");
+    // The composition detector can: only the starved turn is a collapse.
+    expect(starved[1]).toContain("own_bank_collapse_turns=1");
+    expect(fed[1]).not.toContain("own_bank_collapse");
+  });
+
+  it("stays silent about composition when no row carries the stamp (no noise)", () => {
+    const out = formatRecallLogView("clerk", [
+      { ts: "2026-07-31T10:00:00Z", result_count: 5 },
+      { ts: "2026-07-31T10:01:00Z", cache_hit: true },
+    ]).map(strip);
+    expect(out.join("\n")).not.toContain("own/add");
+    expect(out.join("\n")).not.toContain("own_bank_collapse");
+  });
+
+  it("does not count an unstamped (no-composition) turn as a collapse", () => {
+    // own is absent, not 0 — absence of data must not read as a regression.
+    const out = formatRecallLogView("clerk", [
+      { ts: "2026-07-31T10:00:00Z", result_count: 6 },
+    ]).map(strip);
+    expect(out.join("\n")).not.toContain("own_bank_collapse");
+  });
+});


### PR DESCRIPTION
## Problem

`recall.py` stamps every `recall_log.jsonl` row with `injected_own_bank_count` / `injected_additional_bank_count` (summing to `result_count`; an unstamped memory counts as *additional*, so `own` is never optimistic) plus the `reserved_own_slots` / `reserved_additional_slots` reservation floors. The scaffold/schema docs tell operators to watch `injected_own_bank_count` via `switchroom memory recall-log <agent>` — but `formatRecallLogView` (the default, non-`--json` view) rendered only volume/score/omitted fields. The documented remedy only worked under `--json`.

The regression this blinds is **own-bank collapse**: `result_count` stays full while none of the injected set comes from the agent's own bank. Every volume stat reads healthy while the agent has silently stopped seeing its own memory.

## Change

- Add the four composition fields to `RecallLogEntry` (typed, nullable).
- Per-row ` own/add=X/Y` split, painted red when `own=0 && additional>0` (the collapse), dim otherwise. Absent when no side is stamped.
- Summary counter `own_bank_collapse_turns=N`, counting only turns with a non-empty additional set and zero own contribution. An **unstamped** turn (composition absent, not 0) is never counted — absence of data is not a collapse.

## Tests

`tests/cli.memory.recall-log.test.ts` (+6): fields read through the typed interface; the split reaches the human path; two volume-identical full turns (`avg=8 max=8`) are distinguished only by the collapse detector; unstamped turns stay silent.

`tsc --noEmit` clean; 18/18 in the suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)