### PR TITLE
feat(memory): decouple memory profile from `extends` via `memory.profile`

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -631,7 +631,7 @@ export function renderFleetInvariants(): string {
   ].join("\n");
 }
 
-import { DEFAULT_PROFILE } from "../config/schema.js";
+import { DEFAULT_PROFILE, resolveMemoryProfile } from "../config/schema.js";
 import { DEFAULT_CRON_MODEL, scheduleNeedsCronSession } from "../scheduler/cron-routing.js";
 import { applyDefaultTier } from "../scheduler/tier-selector.js";
 
@@ -6125,7 +6125,7 @@ export function scaffoldAgent(
       // wins; disposition merges per-key.
       const extras = resolveBankMissionExtras(
         agentConfig.memory,
-        agentConfig.extends ?? DEFAULT_PROFILE,
+        resolveMemoryProfile(agentConfig),
       );
 
       const missions: {
@@ -6147,7 +6147,7 @@ export function scaffoldAgent(
         apiUrl,
         hindsightBankId,
         agentConfig.memory?.observations_mission,
-        agentConfig.extends ?? DEFAULT_PROFILE,
+        resolveMemoryProfile(agentConfig),
         formatAgentBankLabel(name, hindsightBankId),
       );
       if (seededObservationsMission) {
@@ -8555,7 +8555,7 @@ function reconcileAgentInner(
       // wins over profile defaults; disposition merges per-key.
       const extras = resolveBankMissionExtras(
         agentConfig.memory,
-        agentConfig.extends ?? DEFAULT_PROFILE,
+        resolveMemoryProfile(agentConfig),
       );
 
       const missions: {
@@ -8592,7 +8592,7 @@ function reconcileAgentInner(
         apiUrl,
         hindsightBankId,
         agentConfig.memory?.observations_mission,
-        agentConfig.extends ?? DEFAULT_PROFILE,
+        resolveMemoryProfile(agentConfig),
         formatAgentBankLabel(name, hindsightBankId),
       );
       if (observationsMission) missions.observations_mission = observationsMission;

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -31,7 +31,7 @@ import { reconcileAgent } from "../agents/scaffold.js";
 import { getAllAuthStatuses } from "../auth/manager.js";
 import { getSlotInfos, type SlotInfo } from "../auth/accounts.js";
 import type { AgentConfig, SwitchroomConfig } from "../config/schema.js";
-import { DEFAULT_PROFILE } from "../config/schema.js";
+import { resolveMemoryProfile } from "../config/schema.js";
 import { loadManifest, detectDrift, type DriftProbers } from "../manifest.js";
 import {
   probeHindsight,
@@ -1344,8 +1344,13 @@ export async function checkBankObservationsMissions(
       };
     }
 
+    // Key the disposition/observations default off the resolved MEMORY profile
+    // (memory.profile → extends → default), not raw `extends` — otherwise an
+    // agent opted into a memory profile via `memory.profile` would be
+    // false-flagged as drifted against its persona profile's default here.
+    const memoryProfile = resolveMemoryProfile(entry.config);
     const profileDefault =
-      PROFILE_MEMORY_DEFAULTS[entry.config.extends ?? DEFAULT_PROFILE]?.observations_mission;
+      PROFILE_MEMORY_DEFAULTS[memoryProfile]?.observations_mission;
     const decision = decideObservationsMissionUpgrade(
       entry.config.memory?.observations_mission,
       profileDefault,
@@ -1384,7 +1389,7 @@ export async function checkBankObservationsMissions(
       status: "ok" as const,
       detail: isSwitchroomDefault
         ? profileDefault != null
-          ? `switchroom ${entry.config.extends ?? DEFAULT_PROFILE}-profile default`
+          ? `switchroom ${memoryProfile}-profile default`
           : "switchroom fleet default"
         : "operator-authored (left untouched by the never-clobber rule)",
     };

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -437,6 +437,18 @@ export const AgentMemorySchema = z
       .describe(
         "strict = never shared cross-agent, default = eligible for reflect"
       ),
+    profile: z
+      .string()
+      .optional()
+      .describe(
+        "Memory profile bank this agent's curated memory defaults key off — " +
+        "the built-in disposition + observations_mission in PROFILE_MEMORY_DEFAULTS. " +
+        "Decouples the memory profile from `extends` (the filesystem persona " +
+        "profile), so an agent on `extends: default` can opt into the `coding` " +
+        "memory bundle via `memory.profile: coding` without inheriting the coding " +
+        "persona. Resolution: memory.profile → extends → DEFAULT_PROFILE (see " +
+        "resolveMemoryProfile). Unset ⇒ byte-identical to keying off `extends`."
+      ),
     bank_mission: z
       .string()
       .optional()
@@ -3322,6 +3334,10 @@ const profileFields = {
       // agents) hindsight-native by default, with per-agent `file: true` opt-in.
       file: z.boolean().optional(),
       isolation: z.enum(["default", "strict"]).optional(),
+      // Mirror of AgentMemorySchema.profile — accepted at the defaults/profile
+      // tier too, so `defaults.memory.profile: coding` (or a profile setting it)
+      // cascades like every other memory field, with per-agent override.
+      profile: z.string().optional(),
       // Mirror of AgentMemorySchema.directive_capture_nudge — accepted at the
       // defaults/profile tier too, so `defaults.memory.directive_capture_nudge:
       // false` can disable the #2848 nudge fleet-wide (per-agent `true` opt-in).
@@ -3645,6 +3661,27 @@ export const AgentDefaultsSchema = z.object(defaultsFields).optional();
  * `profiles/default/` directory bundled with switchroom.
  */
 export const DEFAULT_PROFILE = "default";
+
+/**
+ * Resolve the **memory** profile an agent's curated memory defaults key off
+ * (disposition + observations_mission in `PROFILE_MEMORY_DEFAULTS`), decoupled
+ * from `extends` (the filesystem *persona* profile).
+ *
+ * Precedence: explicit `memory.profile` → `extends` → {@link DEFAULT_PROFILE}.
+ * When `memory.profile` is unset this is byte-identical to the historical
+ * `agentConfig.extends ?? DEFAULT_PROFILE`, so unopted agents see zero change.
+ *
+ * Structurally typed so it accepts a full `AgentConfig` or any `{ extends?,
+ * memory? }` shape (e.g. the doctor's bank-entry config). Takes the merged
+ * config — the cascade has already layered defaults/profile/agent memory.
+ */
+export function resolveMemoryProfile(
+  agentConfig:
+    | { extends?: string; memory?: { profile?: string } }
+    | undefined,
+): string {
+  return agentConfig?.memory?.profile ?? agentConfig?.extends ?? DEFAULT_PROFILE;
+}
 
 export const AgentSchema = z.object({
   extends: z

--- a/tests/memory.bank-health.test.ts
+++ b/tests/memory.bank-health.test.ts
@@ -672,6 +672,38 @@ describe("checkBankObservationsMissions (doctor)", () => {
     expect(generic[0].status).toBe("warn");
   });
 
+  // Option-B red-team: the drift row must key off the RESOLVED memory profile
+  // (memory.profile → extends → default), not raw `extends`. An agent on the
+  // `default` PERSONA profile that opts its bank into the `coding` MEMORY bundle
+  // via `memory.profile` carries the coding mission on its bank (scaffold seeds
+  // it). If doctor keyed off `extends` ("default"), the coding mission would be
+  // seen as a superseded switchroom default and the row would FALSE-FLAG the
+  // opted-in agent as drifted, sending the operator to a reconcile that would
+  // (correctly) re-push the same coding mission — a no-op churn loop.
+  //
+  // Verified to bite: reverting doctor's `resolveMemoryProfile(entry.config)`
+  // back to `entry.config.extends ?? DEFAULT_PROFILE` flips this row to `warn`.
+  it("keys the drift row off memory.profile, not extends (no false drift for opted-in agents)", async () => {
+    const config = {
+      memory: { backend: "hindsight", config: { url: "http://x/mcp/" } },
+      agents: { dev: { extends: "default", memory: { profile: "coding" } } },
+    } as unknown as SwitchroomConfig;
+    const coding = PROFILE_MEMORY_DEFAULTS.coding.observations_mission!;
+
+    // Bank correctly carries the coding mission → steady state, not drift.
+    const matching = await checkBankObservationsMissions(config, "http://x/mcp/", {
+      fetchImpl: fakeConfigFetch({ dev: { observations_mission: coding } }),
+    });
+    expect(matching[0].status).toBe("ok");
+    expect(matching[0].detail).toBe("switchroom coding-profile default");
+
+    // And the generic fleet default IS a real upgrade-pending for this bank.
+    const generic = await checkBankObservationsMissions(config, "http://x/mcp/", {
+      fetchImpl: fakeConfigFetch({ dev: { observations_mission: DEFAULT_OBSERVATIONS_MISSION } }),
+    });
+    expect(generic[0].status).toBe("warn");
+  });
+
   it("reports a failed read as unknown, never as unset", async () => {
     const results = await checkBankObservationsMissions(
       minimalConfig({ ziggy: {} }),

--- a/tests/memory.bank-missions.test.ts
+++ b/tests/memory.bank-missions.test.ts
@@ -1251,6 +1251,31 @@ describe("scaffoldAgent — observations_mission seed", () => {
     );
   }, 15_000);
 
+  // Option-B decoupling: an agent on the `default` PERSONA profile opts its
+  // bank into the `coding` MEMORY bundle via `memory.profile`. BOTH halves must
+  // key off the resolved memory profile — the observations_mission AND the
+  // disposition — or an opt-in gets a half-applied bundle. Verified to bite:
+  // reverting scaffold's `resolveMemoryProfile(agentConfig)` back to
+  // `agentConfig.extends ?? DEFAULT_PROFILE` resolves the profile to `default`,
+  // so the observations_mission falls back to the fleet default and the coding
+  // disposition disappears from the wire — both assertions below fail.
+  it("keys BOTH observations_mission and disposition off memory.profile, not extends", async () => {
+    const config = makeAgentConfig({
+      extends: "default",
+      memory: { profile: "coding" },
+    } as Partial<AgentConfig>);
+    const args = await runScaffold(null, config);
+    const updates = args.config_updates as Record<string, unknown>;
+    // Observations: the coding profile mission, not the generic fleet default.
+    expect(updates.observations_mission).toBe(
+      PROFILE_MEMORY_DEFAULTS.coding.observations_mission,
+    );
+    // Disposition: the coding profile's flattened traits, not the engine default.
+    expect(updates.disposition_skepticism).toBe(4);
+    expect(updates.disposition_literalism).toBe(5);
+    expect(updates.disposition_empathy).toBe(2);
+  }, 15_000);
+
   it("upgrades a profiled agent's bank off the generic fleet default", async () => {
     const config = makeAgentConfig({ extends: "executive-assistant" });
     const args = await runScaffold(DEFAULT_OBSERVATIONS_MISSION, config);

--- a/tests/schema.memory-profile.test.ts
+++ b/tests/schema.memory-profile.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveMemoryProfile,
+  DEFAULT_PROFILE,
+  AgentMemorySchema,
+  ProfileSchema,
+  AgentDefaultsSchema,
+} from "../src/config/schema.js";
+
+/**
+ * `memory.profile` decouples the MEMORY profile (which curated disposition +
+ * observations_mission bundle a bank keys off, in PROFILE_MEMORY_DEFAULTS) from
+ * `extends` (the filesystem PERSONA profile). An agent can run the `default`
+ * persona while opting its bank into the `coding` memory bundle.
+ *
+ * These are the pure-precedence unit tests. Each fails if `resolveMemoryProfile`
+ * is reverted to a bare `extends ?? DEFAULT_PROFILE` (the historical behaviour):
+ * the first case would then return `default` instead of `coding`.
+ */
+describe("resolveMemoryProfile", () => {
+  it("explicit memory.profile wins over extends", () => {
+    expect(
+      resolveMemoryProfile({ extends: "default", memory: { profile: "coding" } }),
+    ).toBe("coding");
+    // Even when extends names a different real profile.
+    expect(
+      resolveMemoryProfile({ extends: "health-coach", memory: { profile: "coding" } }),
+    ).toBe("coding");
+  });
+
+  it("falls back to extends when memory.profile is unset", () => {
+    expect(resolveMemoryProfile({ extends: "coding" })).toBe("coding");
+    expect(resolveMemoryProfile({ extends: "coding", memory: {} })).toBe("coding");
+    // A memory block present but without `profile` must not shadow extends.
+    expect(
+      resolveMemoryProfile({ extends: "health-coach", memory: { profile: undefined } }),
+    ).toBe("health-coach");
+  });
+
+  it("falls back to DEFAULT_PROFILE when neither is set", () => {
+    expect(resolveMemoryProfile({})).toBe(DEFAULT_PROFILE);
+    expect(resolveMemoryProfile(undefined)).toBe(DEFAULT_PROFILE);
+    expect(resolveMemoryProfile({ memory: {} })).toBe(DEFAULT_PROFILE);
+  });
+
+  // Back-compat: for every agent that does NOT set memory.profile, the resolved
+  // value is byte-identical to the historical `extends ?? DEFAULT_PROFILE`, so
+  // this change is a pure no-op for the entire existing fleet (zero migration).
+  it("is byte-identical to `extends ?? DEFAULT_PROFILE` whenever memory.profile is unset", () => {
+    for (const extendsVal of [undefined, "default", "coding", "health-coach", "executive-assistant"]) {
+      const legacy = extendsVal ?? DEFAULT_PROFILE;
+      expect(resolveMemoryProfile({ extends: extendsVal })).toBe(legacy);
+      expect(resolveMemoryProfile({ extends: extendsVal, memory: { collection: "b" } })).toBe(legacy);
+    }
+  });
+});
+
+describe("memory.profile schema acceptance", () => {
+  it("AgentMemorySchema accepts an optional profile string and defaults it undefined", () => {
+    expect(AgentMemorySchema.parse({ collection: "b" }).profile).toBeUndefined();
+    expect(AgentMemorySchema.parse({ collection: "b", profile: "coding" }).profile).toBe("coding");
+  });
+
+  it("cascades from the defaults/profile tier too (mirror), so `defaults.memory.profile` is not stripped", () => {
+    expect(AgentDefaultsSchema.parse({ memory: { profile: "coding" } })?.memory?.profile).toBe(
+      "coding",
+    );
+    expect(ProfileSchema.parse({ memory: { profile: "coding" } }).memory?.profile).toBe("coding");
+  });
+});


### PR DESCRIPTION
## What

Implements **Option B** profile-memory decoupling. Adds an optional `memory.profile` config field so an agent can opt its memory bank into a curated `PROFILE_MEMORY_DEFAULTS` bundle (disposition + `observations_mission`) **independently of `extends`** — its filesystem *persona* profile.

An agent on `extends: default` can now run the `coding` memory bundle via `memory.profile: coding` without inheriting the coding persona.

## How

- **Schema** (`src/config/schema.ts`): new optional `memory.profile` string on `AgentMemorySchema`, mirrored into the `profileFields` memory block so it cascades from the defaults/profile tier like every other memory field. New `resolveMemoryProfile(agentConfig)` helper: `memory.profile ?? extends ?? DEFAULT_PROFILE`.
- **Scaffold** (`src/agents/scaffold.ts`): threaded through all four bank-update call sites (the two `resolveBankMissionExtras` calls and the two `resolveObservationsMissionPush` calls) so the **disposition** lookup AND the **observations-mission** lookup key off the *same* resolved memory profile. An opt-in gets the full bundle, not a half.
- **Doctor** (`src/cli/doctor.ts`) — **red-team fix**: the observations-mission drift row keyed off raw `entry.config.extends`, so it would have **false-flagged an opted-in agent** (bank correctly carrying its profile mission) as drifted, sending the operator into a no-op reconcile loop. It now keys off the resolved memory profile too.

## Invariants honoured

- **Zero migration.** With `memory.profile` unset, resolution is byte-identical to the historical `extends ?? DEFAULT_PROFILE`. Proved by a dedicated back-compat test.
- No `default` key added to `PROFILE_MEMORY_DEFAULTS` (per the design comment at `hindsight.ts:1057-1060`).
- `resolveBankMissionExtras`' `profileName` signature is unchanged — the resolved value is simply passed in.

## Tests

Each new test is verified **RED when its production change is reverted**, GREEN with it:

| Test | Reverting… flips it |
|---|---|
| `resolveMemoryProfile` precedence (`tests/schema.memory-profile.test.ts`) | helper → `extends ?? DEFAULT_PROFILE` ⇒ returns `default` not `coding` |
| scaffold seeds BOTH coding `observations_mission` **and** disposition off `memory.profile` (`tests/memory.bank-missions.test.ts`) | call sites → `extends` ⇒ observations falls back to fleet default, disposition drops |
| doctor drift row reports `ok` (not `warn`) for an opted-in agent (`tests/memory.bank-health.test.ts`) | doctor → `extends` ⇒ `warn` false-drift (the exact red-team defect) |

Scoped run: `tests/schema.memory-profile.test.ts`, `tests/memory.bank-missions.test.ts`, `tests/memory.bank-health.test.ts` — **136 passed**. Adjacent regression sweep (`cli.doctor.memory`, `scaffold`, `schema.mental-models`) — **256 passed**. `tsc --noEmit` clean for all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)