### PR TITLE
fix(skill): chmod 0755 staging dirs so mirrored/pooled skills stay traversable (#1862)

### DIFF
--- a/src/cli/skill-personal.test.ts
+++ b/src/cli/skill-personal.test.ts
@@ -157,6 +157,18 @@ describe("initPersonalAction", () => {
     expect(statSync(join(skillDir, "scripts/run.sh")).mode & 0o100).toBe(0o100);
   });
 
+  it("live personal-skill dir is 0755, not the 0700 mkdtemp default (#1862)", () => {
+    const skillFile = join(root, "input.md");
+    writeFileSync(skillFile, validSkillMd("perms"));
+    captureStdout(() => {
+      initPersonalAction("perms", { agent: AGENT, from: skillFile, root });
+    });
+    const skillDir = join(root, AGENT, ".claude/skills/personal-perms");
+    const mode = statSync(skillDir).mode & 0o777;
+    expect(mode & 0o055).toBe(0o055);
+    expect(mode).toBe(0o755);
+  });
+
   it("refuses a duplicate name (init twice)", () => {
     const skillFile = join(root, "input.md");
     writeFileSync(skillFile, validSkillMd("dup"));
@@ -691,6 +703,21 @@ describe("config-repo mirror (versioned personal skills)", () => {
 
     // Live copy also exists (mirror is additive, not redirect).
     expect(existsSync(join(agentsRoot, AGENT, ".claude/skills/personal-mirrored/SKILL.md"))).toBe(true);
+  });
+
+  it("mirrored skill dir is operator-traversable (0755, not the 0700 mkdtemp default) (#1862)", () => {
+    const skillFile = join(agentsRoot, "input.md");
+    writeFileSync(skillFile, validSkillMd("traversable"));
+    captureStdout(() => {
+      initPersonalAction("traversable", { agent: AGENT, from: skillFile, root: agentsRoot });
+    });
+
+    const mirror = join(configDir, "agents", AGENT, "personal-skills", "traversable");
+    const mode = statSync(mirror).mode & 0o777;
+    // Must carry o+rx (and g+rx) — mkdtempSync would leave it 0700, which
+    // the operator can't `cd`/`git status` into. Assert the full 0755.
+    expect(mode & 0o055).toBe(0o055);
+    expect(mode).toBe(0o755);
   });
 
   it("edit re-mirrors with updated content", () => {

--- a/src/cli/skill-personal.ts
+++ b/src/cli/skill-personal.ts
@@ -40,6 +40,7 @@
 
 import { Command, Option } from "commander";
 import {
+  chmodSync,
   closeSync,
   existsSync,
   lstatSync,
@@ -215,6 +216,13 @@ function mirrorToConfigRepo(
       }
     };
     walk(liveSkillDir, staging);
+
+    // mkdtempSync creates the staging root at 0700 (untraversable by the
+    // operator), and walk()'s recursive mkdirSync is a mode no-op on the
+    // already-existing root — so without this the mirrored skill dir lands
+    // 0700 and the operator can't `cd`/`git status` into it (#1862). Match
+    // the 0755 the live personal-skill dir uses.
+    chmodSync(staging, 0o755);
 
     if (existsSync(dest)) {
       const prior = join(configSkillsRoot, `.${name}-prior-${Date.now()}`);
@@ -502,6 +510,11 @@ function writePersonalSkill(
   const staging = mkdtempSync(
     join(dirname(targetDir), `.skill-personal-stage-`),
   );
+  // mkdtempSync creates staging at 0700; the personal-skill dir is
+  // documented as mode 0755 (see file header). The nested mkdirSync calls
+  // below only set the mode of directories they create, not this
+  // already-existing root, so chmod it explicitly (#1862).
+  chmodSync(staging, 0o755);
   let oldRename: string | null = null;
   try {
     for (const [path, content] of Object.entries(files)) {

--- a/src/cli/skill.test.ts
+++ b/src/cli/skill.test.ts
@@ -212,6 +212,15 @@ describe("writePayload", () => {
     expect(readFileSync(target, "utf-8")).toContain("name: foo");
   });
 
+  it("pool skill dir is 0755, not the 0700 mkdtemp staging default (#1862)", () => {
+    writePayload(poolDir, "foo", { "SKILL.md": validSkillMd("foo") });
+    const mode = statSync(join(poolDir, "foo")).mode & 0o777;
+    // Staging is created via mkdtempSync (0700); without an explicit chmod
+    // the renamed pool dir is untraversable by the operator / other agents.
+    expect(mode & 0o055).toBe(0o055);
+    expect(mode).toBe(0o755);
+  });
+
   it("writes multi-file payload with scripts marked +x", () => {
     writePayload(poolDir, "foo", {
       "SKILL.md": validSkillMd("foo"),

--- a/src/cli/skill.ts
+++ b/src/cli/skill.ts
@@ -42,6 +42,7 @@
 
 import { Command } from "commander";
 import {
+  chmodSync,
   closeSync,
   existsSync,
   lstatSync,
@@ -493,6 +494,12 @@ export function writePayload(poolDir: string, name: string, files: FileMap): voi
   }
 
   const staging = mkdtempSync(join(poolDir, `.skill-apply-stage-${name}-`));
+  // mkdtempSync creates staging at 0700 (untraversable by anyone but the
+  // owner), and the nested mkdirSync calls below only set the mode of dirs
+  // they create, not this already-existing root. Without this chmod the
+  // pool skill dir lands 0700 after the rename and can't be traversed by
+  // the operator or other agents sharing the pool (#1862).
+  chmodSync(staging, 0o755);
   let oldRename: string | null = null;
   try {
     // Write files into staging with O_CREAT|O_EXCL ('wx') so any


### PR DESCRIPTION
## What changed

Personal-skill and shared-pool skill writes stage content into a `mkdtempSync` dir (created **0700**), then atomic-rename it into place. The nested `mkdirSync({recursive:true, mode:0o755})` calls only set the mode of directories they *create* — never the already-existing staging **root** — so the destination skill dir landed **0700**, untraversable by the operator (`cd` / `git status`) and by other agents sharing the pool.

Fix: add an explicit `chmodSync(staging, 0o755)` between the walk/write and the rename at all three same-shaped `mkdtempSync -> renameSync` staging sites:

- `mirrorToConfigRepo` in `src/cli/skill-personal.ts` — the config-repo mirror the brief flagged.
- `writePersonalSkill` in `src/cli/skill-personal.ts` — the live personal-skill dir (2nd staging site named in the brief).
- `writePayload` in `src/cli/skill.ts` — the shared skills pool (found by the repo-wide grep for the same pattern; identical hole).

The `mkdtempSync` sites in `behavioralValidate` / `loadFromTarball` are temp dirs that are `rmSync`'d, never renamed to a destination, so they carry no traversability concern and were left alone.

## Issues

Closes #1862.

## Revert-check

Reverted the three `chmodSync(staging, 0o755)` lines and confirmed all three new tests go **red** (assert dir mode `0755` / `o+rx`); restored and confirmed green. The tests fail on the exact bug they guard.

## Scoped-test result

`npx vitest run src/cli/skill-personal.test.ts src/cli/skill.test.ts` → **83 passed**. `npx tsc --noEmit` → clean.

## Caveats

- Mode assertions are POSIX-mode-bit checks; on a filesystem/OS without Unix perms they'd be meaningless, but this codebase already asserts mode bits elsewhere (script `+x` tests), so this matches existing convention.
- `writePayload` (`skill.ts`) fix is slightly beyond the primary file but is the identical bug the brief's repo-wide grep asked to audit; kept in-scope as one focused concern (staging-dir traversability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)