### PR TITLE
fix(cli): honor reconcile --no-restart (close #3903)

### DIFF
--- a/src/cli/agent.test.ts
+++ b/src/cli/agent.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, it, expect } from "vitest";
 import { Command } from "commander";
-import { summarizeReconcileBatch, resolveLogsTail, registerAgentCommand } from "./agent.js";
+import { summarizeReconcileBatch, resolveLogsTail, registerAgentCommand, shouldAutoRestartAfterReconcile } from "./agent.js";
 import { buildAgentLogsArgs } from "../agents/lifecycle.js";
 
 describe("resolveLogsTail (agent logs --lines clamp contract)", () => {
@@ -184,5 +184,49 @@ describe("agent effective-model command", () => {
     const cmd = findCommand();
     expect(cmd).toBeDefined();
     expect(cmd!.registeredArguments.map((a) => `${a.name()}:${a.required}`)).toEqual(["name:true"]);
+  });
+});
+
+describe("shouldAutoRestartAfterReconcile (--no-restart opt-out, switchroom#3903)", () => {
+  // Regression: reconcile declared `--no-restart` but read the flag via
+  // `opts.noRestart`, which Commander never sets (it exposes the negated
+  // flag as `opts.restart === false`). So `--no-restart` was silently
+  // ignored and the agent auto-restarted anyway whenever a
+  // restart-required change was present. This pins the corrected
+  // `opts.restart !== false` decision.
+
+  it("--no-restart (opts.restart === false) suppresses the auto-restart", () => {
+    // restart-required changes present, but user opted out → no restart.
+    expect(shouldAutoRestartAfterReconcile({ restart: false }, 3)).toBe(false);
+  });
+
+  it("default (flag absent) auto-restarts when restart-required changes exist", () => {
+    expect(shouldAutoRestartAfterReconcile({}, 3)).toBe(true);
+    expect(shouldAutoRestartAfterReconcile({ restart: undefined }, 3)).toBe(true);
+  });
+
+  it("--restart (opts.restart === true) auto-restarts when changes exist", () => {
+    expect(shouldAutoRestartAfterReconcile({ restart: true }, 3)).toBe(true);
+  });
+
+  it("no restart-required changes → never auto-restarts, regardless of flag", () => {
+    expect(shouldAutoRestartAfterReconcile({}, 0)).toBe(false);
+    expect(shouldAutoRestartAfterReconcile({ restart: false }, 0)).toBe(false);
+    expect(shouldAutoRestartAfterReconcile({ restart: true }, 0)).toBe(false);
+  });
+
+  it("Commander parses --no-restart into opts.restart === false (not opts.noRestart)", () => {
+    // Pins the root-cause fact: the camelCase-negation read the fix removes
+    // (`opts.noRestart`) never exists — only `opts.restart` does.
+    const cmd = new Command();
+    cmd
+      .command("reconcile <name>")
+      .option("--restart", "restart")
+      .option("--no-restart", "skip restart")
+      .action(() => {});
+    cmd.parse(["node", "test", "reconcile", "agentx", "--no-restart"]);
+    const opts = cmd.commands.find((c) => c.name() === "reconcile")!.opts();
+    expect(opts.restart).toBe(false);
+    expect(opts.noRestart).toBeUndefined();
   });
 });

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -91,6 +91,26 @@ export function summarizeReconcileBatch(
 }
 
 /**
+ * Decide whether `agent reconcile` should auto-restart the agent.
+ *
+ * Restart-required changes (soul/MCP/settings/start.sh) only take
+ * effect on a fresh container, so reconcile auto-restarts when any are
+ * present — UNLESS the user passed `--no-restart` to defer the bounce.
+ *
+ * Commander exposes `--no-restart` as `opts.restart === false` (NOT
+ * `opts.noRestart`, which is always `undefined`). This helper reads the
+ * flag through the correct `opts.restart !== false` shape so the pure
+ * decision is unit-testable and the `--no-restart` opt-out actually
+ * takes effect (switchroom#3903).
+ */
+export function shouldAutoRestartAfterReconcile(
+  opts: { restart?: boolean },
+  restartRequiredCount: number,
+): boolean {
+  return opts.restart !== false && restartRequiredCount > 0;
+}
+
+/**
  * Resolve the `agent logs --lines` value to a docker `--tail` count.
  * Pure so the clamp contract is unit-testable: default 50 when omitted,
  * floor 1, cap 1000; a non-numeric or out-of-range (< 1) value falls
@@ -1757,7 +1777,7 @@ export function registerAgentCommand(program: Command): void {
     )
     .option("--check", "Report drift between yaml and settings.json without writing")
     .action(
-      withConfigError(async (name: string, opts: { restart?: boolean; noRestart?: boolean; gracefulRestart?: boolean; preserveClaudeMd?: boolean; check?: boolean }) => {
+      withConfigError(async (name: string, opts: { restart?: boolean; gracefulRestart?: boolean; preserveClaudeMd?: boolean; check?: boolean }) => {
         const config = getConfig(program);
         const agentsDir = resolveAgentsDir(config);
         const configPath = getConfigPath(program);
@@ -1875,7 +1895,7 @@ export function registerAgentCommand(program: Command): void {
                 const needsRestart = restartRequired.length > 0 || staleTillRestart.length > 0;
                 // Auto-restart when restart-required changes present (e.g. soul fields),
                 // unless the user explicitly opted out with --no-restart.
-                const autoRestart = restartRequired.length > 0 && !opts.noRestart;
+                const autoRestart = shouldAutoRestartAfterReconcile(opts, restartRequired.length);
                 if (!needsRestart && hot.length > 0) {
                   console.log(chalk.green("\n  (no restart needed, changes active next turn)"));
                 } else if (needsRestart && !opts.restart && !opts.gracefulRestart && !autoRestart) {
@@ -1899,9 +1919,8 @@ export function registerAgentCommand(program: Command): void {
             // running claude process loaded them at boot.
             const changesBySemantics = result.changesBySemantics;
             const autoRestartNeeded =
-              !opts.noRestart &&
               changesBySemantics !== undefined &&
-              changesBySemantics.restartRequired.length > 0;
+              shouldAutoRestartAfterReconcile(opts, changesBySemantics.restartRequired.length);
             const shouldRestart = (opts.restart || opts.gracefulRestart || autoRestartNeeded) && allChanges.length > 0;
 
             if (shouldRestart) {


### PR DESCRIPTION
## What changed

`switchroom agent reconcile` declared `--no-restart` but read the flag via `opts.noRestart` (~`src/cli/agent.ts` reconcile action). Commander exposes a `--no-restart` negated flag as `opts.restart === false`, never as `opts.noRestart` — so `opts.noRestart` was always `undefined`, `!opts.noRestart` always `true`, and the auto-restart fired regardless. The documented opt-out was silently ignored: `reconcile --no-restart` still bounced the container whenever a restart-required change (soul/MCP/settings/start.sh) was present.

- Extracted the decision into a pure, exported `shouldAutoRestartAfterReconcile(opts, restartRequiredCount)` that reads the flag through the correct `opts.restart !== false` shape.
- Used it at both reconcile call sites (the display branch and the `autoRestartNeeded` gate) and dropped the dead `noRestart` field from the opts type.

## Class-killer: CLI-wide `--no-*` audit

Grepped every `.option("--no-..."` declaration across `src/`:
- `src/cli/skill-search.ts` `--no-json` → reads `opts.json !== false` ✅ correct
- `src/cli/vault.ts` `--no-broker` → reads `opts.broker !== false` ✅ correct
- `src/cli/update.ts` `--no-restart` → documented legacy v0.6 no-op, never read ✅ n/a
- `src/cli/agent.ts` `--no-restart` (grant ~2035, another ~2111) → already read `opts.restart !== false` ✅ correct

Only the reconcile action had the camelCase-negation bug. No sibling instances remain.

## Issues
Closes #3903.

## Revert-check
Confirmed the new tests FAIL on revert: temporarily restored the buggy `!opts.noRestart` read inside the helper → `--no-restart (opts.restart === false) suppresses the auto-restart` went red (1 failed / 25 passed); restored the fix → 26 passed.

## Scoped-test result
- `npx vitest run src/cli/agent.test.ts` → 26 passed.
- `npx tsc --noEmit` → clean (exit 0).
- Full suite not run (per contribution guidance; CI is the authority).

## Caveats
The reconcile `.action` closure imports `restartAgent` at module scope and isn't argv-driven in tests, so rather than an integration harness the fix is pinned via a pure exported helper plus a Commander parse-shape assertion (`--no-restart` → `opts.restart === false`, `opts.noRestart` undefined). The helper is the single decision point both reconcile call sites now use, so the outcome (`--no-restart` ⇒ no auto-restart) is fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)