### PR TITLE
feat(doctor): prompt-cascade drift probes for all lanes (#1858)

### DIFF
--- a/src/cli/doctor-cascade.ts
+++ b/src/cli/doctor-cascade.ts
@@ -1,0 +1,562 @@
+/**
+ * Prompt-cascade doctor probes (epic #1850 / issue #1858).
+ *
+ * The redesigned system-prompt cascade has three release/operator lanes
+ * plus a per-turn plane and a per-repo hook. Each lane is a separate file
+ * on a separate durability contract, and every one of them fails SILENTLY
+ * when it drifts: a checksummed L1 file that got hand-edited, an L2
+ * fleet-default that never seeded, a per-agent CLAUDE.md whose operator
+ * marker got deleted, a settings.json missing the hook that reasserts
+ * pacing every turn. None of those throw — the agent just quietly reads a
+ * subtly wrong prompt. These probes convert each drift class into one
+ * upfront, operator-visible `switchroom doctor` line.
+ *
+ * The lanes (see `src/agents/scaffold.ts` + `src/agents/fleet-defaults.ts`):
+ *
+ *   L1  `~/.switchroom/fleet/switchroom-invariants.md` — release-pinned,
+ *       rendered by `renderFleetInvariants()`, checksum-restored by
+ *       `switchroom apply` on drift.
+ *   L2  `~/.switchroom/fleet/CLAUDE.md` — `writeIfMissing` operator-owned
+ *       defaults, rendered by `renderFleetDefaultsClaudeMd()`. Carries a
+ *       machine-readable `<!-- switchroom-fleet-defaults-version: X -->`
+ *       tag in its header so we can tell a stale default from a
+ *       personalised one.
+ *   L3  `<agentDir>/CLAUDE.md` — per-agent. Split by the
+ *       `# --- Yours (preserved across apply) ---` marker: scaffold owns
+ *       everything above, the operator owns everything below.
+ *   L4  the `repo-context-pretool` PreToolUse hook that injects a foreign
+ *       repo's own CLAUDE.md/AGENTS.md mid-turn.
+ *   per-turn  the `turn-pacing` UserPromptSubmit hook (#1646) that
+ *       reasserts the Telegram 5-beats adjacent to each user message.
+ *   cross-lane  `--add-dir ~/.switchroom/fleet` in the agent's boot
+ *       invocation (start.sh) — without it none of L1/L2 is discovered.
+ *   cross-lane  a regression grep: the Telegram 5-beats live in L1 now;
+ *       finding them re-inlined in a per-agent CLAUDE.md means the
+ *       deduplicated partial crept back (double-load).
+ *
+ * Filesystem access is dependency-injected (mirrors `doctor-webkite.ts`)
+ * so unit tests drive every branch without a real fleet tree. The
+ * EACCES/EPERM split is load-bearing: scaffold artifacts are agent-UID
+ * owned 0600 and the host operator running `doctor` (no sudo) cannot read
+ * them — that must read as `skip`, never `fail`.
+ */
+
+import {
+  existsSync as realExistsSync,
+  readFileSync as realReadFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+import { resolveAgentsDir } from "../config/loader.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+import { SWITCHROOM_VERSION } from "./resolve-version.js";
+import { renderFleetInvariants, CLAUDE_MD_YOURS_MARKER } from "../agents/scaffold.js";
+import { renderFleetDefaultsClaudeMd } from "../agents/fleet-defaults.js";
+import {
+  GENERATION_STAMP_FILE,
+  hashManagedClaudeMd,
+  sha256Text,
+} from "../agents/generation-stamp.js";
+import type { CheckStatus } from "./doctor-status.js";
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+/** Distinctive signature of the Telegram 5-beats pacing block. It lives in
+ * L1 (`TELEGRAM_GUIDANCE`) now; finding it in a per-agent CLAUDE.md means the
+ * deduplicated partial was re-inlined (the double-load regression #1858 guards). */
+export const TELEGRAM_PACING_SIGNATURE = "## Talking to a human on Telegram";
+
+/** Substring identifying the repo-context PreToolUse hook command. */
+const REPO_CONTEXT_HOOK_MARKER = "repo-context-pretool";
+/** Substring identifying the turn-pacing UserPromptSubmit hook command. */
+const TURN_PACING_HOOK_MARKER = "turn-pacing";
+/** Regex for the machine-readable L2 version tag in the fleet CLAUDE.md header. */
+const FLEET_DEFAULTS_VERSION_TAG = /<!--\s*switchroom-fleet-defaults-version:\s*(\S+)\s*-->/;
+
+export interface CascadeProbeDeps {
+  /** Home dir override (tests). Defaults to os.homedir(). */
+  homeDir?: string;
+  /** Defaults to `resolveAgentsDir(config)`, resolved lazily + guarded. */
+  agentsDir?: string;
+  /** The switchroom version the L2 tag is checked against. Defaults to SWITCHROOM_VERSION. */
+  currentVersion?: string;
+  existsSync?: (p: string) => boolean;
+  /** Read a file as utf-8. Throws (with `.code`) on EACCES/EPERM so the
+   * probe can classify agent-private 0600 files as `skip`. */
+  readFileSync?: (p: string) => string;
+  /**
+   * The below-marker (operator-owned) baseline hash recorded at the last
+   * `switchroom apply`, per agent. Production reads it from the generation
+   * stamp; it is `null` until the apply path is wired to persist it, in
+   * which case the L3-below probe honestly reports `skip` ("no baseline
+   * yet") rather than fabricating a pass. Injected in tests.
+   */
+  belowMarkerBaseline?: (agentDir: string) => string | null;
+}
+
+interface ResolvedDeps {
+  homeDir: string;
+  agentsDir: string | undefined;
+  currentVersion: string;
+  existsSync: (p: string) => boolean;
+  readFileSync: (p: string) => string;
+  belowMarkerBaseline: (agentDir: string) => string | null;
+}
+
+/** Read + parse the agent's generation stamp; null if absent/unreadable. */
+function readStamp(
+  d: Pick<ResolvedDeps, "existsSync" | "readFileSync">,
+  agentDir: string,
+): Record<string, unknown> | null {
+  const p = join(agentDir, GENERATION_STAMP_FILE);
+  if (!d.existsSync(p)) return null;
+  try {
+    return JSON.parse(d.readFileSync(p)) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function defaultBelowMarkerBaseline(
+  d: Pick<ResolvedDeps, "existsSync" | "readFileSync">,
+  agentDir: string,
+): string | null {
+  const stamp = readStamp(d, agentDir);
+  // The apply path does not yet persist a below-marker hash into the stamp;
+  // until it does, there is no baseline to compare against (honest skip).
+  const v = stamp?.["claudeMdBelowMarker"];
+  return typeof v === "string" ? v : null;
+}
+
+function resolveDeps(
+  config: SwitchroomConfig,
+  deps: CascadeProbeDeps,
+): ResolvedDeps {
+  let agentsDir = deps.agentsDir;
+  if (agentsDir === undefined) {
+    try {
+      agentsDir = resolveAgentsDir(config);
+    } catch {
+      agentsDir = undefined;
+    }
+  }
+  const existsSync = deps.existsSync ?? ((p) => realExistsSync(p));
+  const readFileSync = deps.readFileSync ?? ((p) => realReadFileSync(p, "utf-8"));
+  return {
+    homeDir: deps.homeDir ?? homedir(),
+    agentsDir,
+    currentVersion: deps.currentVersion ?? SWITCHROOM_VERSION,
+    existsSync,
+    readFileSync,
+    belowMarkerBaseline:
+      deps.belowMarkerBaseline ??
+      ((agentDir) => defaultBelowMarkerBaseline({ existsSync, readFileSync }, agentDir)),
+  };
+}
+
+/** Was this read failure an operator-can't-read-0600 case (→ skip)? */
+function isUnreadable(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException)?.code;
+  return code === "EACCES" || code === "EPERM";
+}
+
+/** Split a CLAUDE.md at the FIRST marker occurrence. Returns null if the
+ * marker is absent (the caller reports that as its own failure). */
+function belowMarkerSection(content: string): string | null {
+  const idx = content.indexOf(CLAUDE_MD_YOURS_MARKER);
+  if (idx === -1) return null;
+  return content.slice(idx + CLAUDE_MD_YOURS_MARKER.length);
+}
+
+/**
+ * Run all prompt-cascade checks. Always emits (the cascade is universal —
+ * every fleet has L1/L2 and at least one agent).
+ */
+export function runCascadeChecks(
+  config: SwitchroomConfig,
+  deps: CascadeProbeDeps = {},
+): CheckResult[] {
+  const d = resolveDeps(config, deps);
+  const results: CheckResult[] = [];
+  const fleetDir = join(d.homeDir, ".switchroom", "fleet");
+
+  // ── L1: invariants present ────────────────────────────────────────
+  const invariantsPath = join(fleetDir, "switchroom-invariants.md");
+  const invariantsPresent = d.existsSync(invariantsPath);
+  if (!invariantsPresent) {
+    results.push({
+      name: "cascade L1: invariants present",
+      status: "fail",
+      detail: `missing ${invariantsPath} — no agent can load the release-pinned fleet invariants`,
+      fix: "Run `switchroom apply` to re-seed the fleet directory.",
+    });
+  } else {
+    results.push({
+      name: "cascade L1: invariants present",
+      status: "ok",
+      detail: `present at ${invariantsPath}`,
+    });
+  }
+
+  // ── L1: invariants checksum matches release ───────────────────────
+  if (!invariantsPresent) {
+    results.push({
+      name: "cascade L1: invariants checksum",
+      status: "skip",
+      detail: "invariants file absent — nothing to checksum (see L1 present)",
+    });
+  } else {
+    let onDisk: string | null = null;
+    let unreadable = false;
+    try {
+      onDisk = d.readFileSync(invariantsPath);
+    } catch (err) {
+      unreadable = isUnreadable(err);
+    }
+    if (unreadable) {
+      results.push({
+        name: "cascade L1: invariants checksum",
+        status: "skip",
+        detail: "invariants file unreadable by the operator — re-run doctor without sudo",
+      });
+    } else if (onDisk === null) {
+      results.push({
+        name: "cascade L1: invariants checksum",
+        status: "fail",
+        detail: `could not read ${invariantsPath}`,
+      });
+    } else {
+      const canonical = renderFleetInvariants();
+      if (sha256Text(onDisk) === sha256Text(canonical)) {
+        results.push({
+          name: "cascade L1: invariants checksum",
+          status: "ok",
+          detail: "matches the release canonical",
+        });
+      } else {
+        results.push({
+          name: "cascade L1: invariants checksum",
+          status: "fail",
+          detail: `${invariantsPath} has drifted from the release canonical (it is release-controlled, not operator-editable)`,
+          fix: "Run `switchroom apply` — it restores the canonical invariants on drift.",
+        });
+      }
+    }
+  }
+
+  // ── L2: fleet CLAUDE.md present + version tag ─────────────────────
+  const fleetClaudePath = join(fleetDir, "CLAUDE.md");
+  if (!d.existsSync(fleetClaudePath)) {
+    results.push({
+      name: "cascade L2: fleet defaults",
+      status: "fail",
+      detail: `missing ${fleetClaudePath} — the operator-owned fleet brain never seeded`,
+      fix: "Run `switchroom apply` to seed the fleet defaults CLAUDE.md.",
+    });
+  } else {
+    let onDisk: string | null = null;
+    let unreadable = false;
+    try {
+      onDisk = d.readFileSync(fleetClaudePath);
+    } catch (err) {
+      unreadable = isUnreadable(err);
+    }
+    if (unreadable) {
+      results.push({
+        name: "cascade L2: fleet defaults",
+        status: "skip",
+        detail: "fleet CLAUDE.md unreadable by the operator — re-run doctor without sudo",
+      });
+    } else if (onDisk === null || onDisk.trim() === "") {
+      results.push({
+        name: "cascade L2: fleet defaults",
+        status: "fail",
+        detail: `${fleetClaudePath} is present but empty`,
+        fix: "Remove the empty file and run `switchroom apply` to re-seed it.",
+      });
+    } else if (onDisk === renderFleetDefaultsClaudeMd()) {
+      results.push({
+        name: "cascade L2: fleet defaults",
+        status: "warn",
+        detail:
+          "identical to the shipped default — the operator has not personalised the fleet brain yet (add household facts / fleet conventions here)",
+      });
+    } else {
+      const tag = onDisk.match(FLEET_DEFAULTS_VERSION_TAG)?.[1];
+      if (!tag) {
+        results.push({
+          name: "cascade L2: fleet defaults",
+          status: "warn",
+          detail: "personalised, but the machine-readable version tag is missing from the header",
+        });
+      } else if (tag !== d.currentVersion) {
+        results.push({
+          name: "cascade L2: fleet defaults",
+          status: "warn",
+          detail: `personalised, but the header version tag (${tag}) is older than the current release (${d.currentVersion}) — a newer default is available`,
+          fix: "Once `switchroom apply --refresh-fleet-defaults` (#1859) ships, opt in to fold newer defaults into your file.",
+        });
+      } else {
+        results.push({
+          name: "cascade L2: fleet defaults",
+          status: "ok",
+          detail: `personalised, header version tag current (${tag})`,
+        });
+      }
+    }
+  }
+
+  // ── Per-agent probes (L3, L4, per-turn, cross-lane) ───────────────
+  const agents = Object.keys(config.agents ?? {});
+  if (d.agentsDir === undefined) {
+    results.push({
+      name: "cascade: per-agent probes",
+      status: "warn",
+      detail: "agents_dir unresolved (no switchroom.agents_dir) — cannot verify per-agent lanes (L3/L4/pacing/--add-dir)",
+    });
+    return results;
+  }
+
+  for (const agent of agents) {
+    const agentDir = join(d.agentsDir, agent);
+    const claudeMdPath = join(agentDir, "CLAUDE.md");
+    const settingsPath = join(agentDir, ".claude", "settings.json");
+    const startShPath = join(agentDir, "start.sh");
+
+    const claudeScaffolded = d.existsSync(claudeMdPath);
+    const settingsScaffolded = d.existsSync(settingsPath);
+    const startScaffolded = d.existsSync(startShPath);
+    // Nothing scaffolded yet → apply will do it; stay silent for this agent.
+    if (!claudeScaffolded && !settingsScaffolded && !startScaffolded) continue;
+
+    // ---- L3: read the agent CLAUDE.md once ----
+    let claudeMd: string | null = null;
+    let claudeUnreadable = false;
+    if (claudeScaffolded) {
+      try {
+        claudeMd = d.readFileSync(claudeMdPath);
+      } catch (err) {
+        claudeUnreadable = isUnreadable(err);
+      }
+    }
+
+    // L3: marker presence
+    if (!claudeScaffolded) {
+      // handled by other lanes; skip marker probe
+    } else if (claudeUnreadable) {
+      results.push({
+        name: `cascade L3 ${agent}: Yours marker`,
+        status: "skip",
+        detail: "CLAUDE.md is agent-UID-owned (0600) — re-run doctor without sudo",
+      });
+    } else if (claudeMd === null) {
+      results.push({
+        name: `cascade L3 ${agent}: Yours marker`,
+        status: "fail",
+        detail: `could not read ${claudeMdPath}`,
+      });
+    } else if (!claudeMd.includes(CLAUDE_MD_YOURS_MARKER)) {
+      results.push({
+        name: `cascade L3 ${agent}: Yours marker`,
+        status: "fail",
+        detail: `${claudeMdPath} is missing the "${CLAUDE_MD_YOURS_MARKER}" marker — the operator deleted it or the scaffold broke; the below-marker operator section is no longer protected across apply`,
+        fix: "Run `switchroom agent restart <agent>` (or `switchroom apply`) to re-scaffold the marker.",
+      });
+    } else {
+      results.push({
+        name: `cascade L3 ${agent}: Yours marker`,
+        status: "ok",
+        detail: "marker present",
+      });
+
+      // L3: above-marker matches scaffold canonical — INFO only (drift is
+      // fine; scaffold rewrites the managed section on next apply).
+      const stamp = readStamp(d, agentDir);
+      const stampedManaged = (stamp?.["files"] as Record<string, unknown> | undefined)?.["CLAUDE.md"];
+      if (typeof stampedManaged === "string") {
+        const liveManaged = hashManagedClaudeMd(claudeMd);
+        if (liveManaged === stampedManaged) {
+          results.push({
+            name: `cascade L3 ${agent}: above-marker canonical`,
+            status: "ok",
+            detail: "managed (above-marker) section matches the last scaffold render",
+          });
+        } else {
+          results.push({
+            name: `cascade L3 ${agent}: above-marker canonical`,
+            status: "skip",
+            detail: "above-marker drift from the last scaffold render — informational only; the next `switchroom apply` rewrites this section",
+          });
+        }
+      }
+
+      // L3: below-marker preserved across last apply. FAIL if the
+      // operator-owned section changed since the baseline recorded at apply.
+      const baseline = d.belowMarkerBaseline(agentDir);
+      if (baseline === null) {
+        results.push({
+          name: `cascade L3 ${agent}: below-marker preserved`,
+          status: "skip",
+          detail: "no below-marker baseline recorded yet — will track from the next apply that persists it",
+        });
+      } else {
+        const below = belowMarkerSection(claudeMd) ?? "";
+        if (sha256Text(below) === baseline) {
+          results.push({
+            name: `cascade L3 ${agent}: below-marker preserved`,
+            status: "ok",
+            detail: "operator-owned below-marker section unchanged since last apply",
+          });
+        } else {
+          results.push({
+            name: `cascade L3 ${agent}: below-marker preserved`,
+            status: "fail",
+            detail: `the operator-owned below-marker section of ${claudeMdPath} changed since the last apply — scaffold must NEVER touch below-marker content; this signals a scaffold bug or an out-of-band edit`,
+            fix: "Diff against the last apply; if scaffold rewrote it that is a bug (#1858).",
+          });
+        }
+      }
+
+      // Cross-lane: Telegram 5-beats must NOT be re-inlined here.
+      if (claudeMd.includes(TELEGRAM_PACING_SIGNATURE)) {
+        results.push({
+          name: `cascade ${agent}: no pacing duplication`,
+          status: "fail",
+          detail: `${claudeMdPath} contains the Telegram 5-beats pacing block ("${TELEGRAM_PACING_SIGNATURE}") — that lives in L1 fleet invariants now; re-inlining it double-loads the pacing partial`,
+          fix: "Remove the pacing block from the per-agent CLAUDE.md; it is delivered once via ~/.switchroom/fleet/switchroom-invariants.md.",
+        });
+      } else {
+        results.push({
+          name: `cascade ${agent}: no pacing duplication`,
+          status: "ok",
+          detail: "Telegram pacing not re-inlined (delivered once via L1)",
+        });
+      }
+    }
+
+    // ---- L4 + per-turn: settings.json hooks ----
+    if (settingsScaffolded) {
+      let settings: { hooks?: Record<string, unknown> } | null = null;
+      let settingsUnreadable = false;
+      try {
+        settings = JSON.parse(d.readFileSync(settingsPath));
+      } catch (err) {
+        settingsUnreadable = isUnreadable(err);
+      }
+      if (settingsUnreadable) {
+        results.push({
+          name: `cascade L4 ${agent}: repo-context hook`,
+          status: "skip",
+          detail: "settings.json is agent-UID-owned (0600) — re-run doctor without sudo",
+        });
+      } else if (settings === null) {
+        results.push({
+          name: `cascade L4 ${agent}: repo-context hook`,
+          status: "fail",
+          detail: `could not parse ${settingsPath}`,
+        });
+      } else {
+        const hookCommands = collectHookCommands(settings.hooks, "PreToolUse");
+        const promptCommands = collectHookCommands(settings.hooks, "UserPromptSubmit");
+
+        if (hookCommands.some((c) => c.includes(REPO_CONTEXT_HOOK_MARKER))) {
+          results.push({
+            name: `cascade L4 ${agent}: repo-context hook`,
+            status: "ok",
+            detail: "repo-context-pretool PreToolUse hook wired",
+          });
+        } else {
+          results.push({
+            name: `cascade L4 ${agent}: repo-context hook`,
+            status: "fail",
+            detail: `${settingsPath} PreToolUse hooks are missing the repo-context-pretool hook — foreign-repo CLAUDE.md/AGENTS.md will not be injected mid-turn`,
+            fix: "Run `switchroom apply` to re-scaffold settings.json hooks.",
+          });
+        }
+
+        if (promptCommands.some((c) => c.includes(TURN_PACING_HOOK_MARKER))) {
+          results.push({
+            name: `cascade per-turn ${agent}: pacing hook`,
+            status: "ok",
+            detail: "turn-pacing UserPromptSubmit hook wired",
+          });
+        } else {
+          results.push({
+            name: `cascade per-turn ${agent}: pacing hook`,
+            status: "fail",
+            detail: `${settingsPath} UserPromptSubmit hooks are missing the turn-pacing hook — the per-turn pacing directive (#1646) will not reassert adjacent to each message`,
+            fix: "Run `switchroom apply` to re-scaffold settings.json hooks.",
+          });
+        }
+      }
+    }
+
+    // ---- Cross-lane: --add-dir fleet in the boot invocation ----
+    if (startScaffolded) {
+      let startSh: string | null = null;
+      let startUnreadable = false;
+      try {
+        startSh = d.readFileSync(startShPath);
+      } catch (err) {
+        startUnreadable = isUnreadable(err);
+      }
+      if (startUnreadable) {
+        results.push({
+          name: `cascade ${agent}: --add-dir fleet`,
+          status: "skip",
+          detail: "start.sh is agent-UID-owned (0600) — re-run doctor without sudo",
+        });
+      } else if (startSh === null) {
+        results.push({
+          name: `cascade ${agent}: --add-dir fleet`,
+          status: "fail",
+          detail: `could not read ${startShPath}`,
+        });
+      } else if (startSh.includes("--add-dir")) {
+        results.push({
+          name: `cascade ${agent}: --add-dir fleet`,
+          status: "ok",
+          detail: "start.sh extends CLAUDE.md discovery to the fleet dir",
+        });
+      } else {
+        results.push({
+          name: `cascade ${agent}: --add-dir fleet`,
+          status: "fail",
+          detail: `${startShPath} has no --add-dir for the fleet directory — the agent will not discover L1/L2 (~/.switchroom/fleet/*.md)`,
+          fix: "Run `switchroom apply` to re-render start.sh with the fleet --add-dir.",
+        });
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Flatten every `command` string under `hooks[event][].hooks[]`. Claude
+ * Code's settings.json shape is
+ * `{ hooks: { <Event>: [ { matcher?, hooks: [ { command } ] } ] } }`.
+ */
+function collectHookCommands(
+  hooks: Record<string, unknown> | undefined,
+  event: string,
+): string[] {
+  const out: string[] = [];
+  const groups = hooks?.[event];
+  if (!Array.isArray(groups)) return out;
+  for (const group of groups) {
+    const inner = (group as { hooks?: unknown })?.hooks;
+    if (!Array.isArray(inner)) continue;
+    for (const h of inner) {
+      const cmd = (h as { command?: unknown })?.command;
+      if (typeof cmd === "string") out.push(cmd);
+    }
+  }
+  return out;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -67,6 +67,7 @@ import { runAuthBrokerChecks } from "./doctor-auth-broker.js";
 import { runHostdChecks } from "./doctor-hostd.js";
 import { runDriveChecks, runDriveBrokerReachabilityChecks } from "./doctor-drive.js";
 import { runWebkiteChecks } from "./doctor-webkite.js";
+import { runCascadeChecks } from "./doctor-cascade.js";
 import { runOpenRouterCreditChecks, usesOpenRouter } from "./doctor-openrouter-credit.js";
 import { runCronSessionChecks } from "./doctor-cron-session.js";
 import { runFloodPressureChecks } from "./doctor-flood-pressure.js";
@@ -4188,6 +4189,7 @@ export function registerDoctorCommand(program: Command): void {
           },
           { title: "MFF Skill", results: await checkMff(passphrase, vaultPath, config) },
           { title: "Webkite", results: runWebkiteChecks(config) },
+          { title: "Prompt cascade", results: runCascadeChecks(config) },
           {
             // Proactive half of the OpenRouter credit work (#3868 is the
             // reactive half). NOTE: this reports WARN — not a green tick —

--- a/tests/doctor.prompt-redesign-probes.test.ts
+++ b/tests/doctor.prompt-redesign-probes.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Prompt-cascade doctor probes (#1858).
+ *
+ * Each case pins one drift class the redesigned cascade fails silently on:
+ *   - L1 invariants missing / checksum drift
+ *   - L2 fleet defaults missing / empty / unpersonalised / stale version tag
+ *   - L3 per-agent Yours-marker deletion
+ *   - L3 below-marker section changed since apply (scaffold bug guard)
+ *   - L4 repo-context-pretool hook missing from settings.json
+ *   - per-turn turn-pacing UserPromptSubmit hook missing
+ *   - cross-lane --add-dir fleet missing from start.sh
+ *   - cross-lane Telegram 5-beats re-inlined in a per-agent CLAUDE.md
+ *   - operator-can't-read-0600 → skip, never fail
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  runCascadeChecks,
+  TELEGRAM_PACING_SIGNATURE,
+  type CascadeProbeDeps,
+  type CheckResult,
+} from "../src/cli/doctor-cascade.js";
+import { renderFleetInvariants, CLAUDE_MD_YOURS_MARKER } from "../src/agents/scaffold.js";
+import { renderFleetDefaultsClaudeMd } from "../src/agents/fleet-defaults.js";
+import { sha256Text, hashManagedClaudeMd } from "../src/agents/generation-stamp.js";
+import { SWITCHROOM_VERSION } from "../src/cli/resolve-version.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
+
+const HOME = "/home/op";
+const FLEET = `${HOME}/.switchroom/fleet`;
+const AGENTS = "/agents";
+const VERSION = "9.9.9";
+
+function cfg(agents: string[]): SwitchroomConfig {
+  return { agents: Object.fromEntries(agents.map((a) => [a, {}])) } as unknown as SwitchroomConfig;
+}
+
+interface Vfs {
+  files: Record<string, string>;
+  unreadable?: Set<string>;
+}
+
+function deps(vfs: Vfs, extra: Partial<CascadeProbeDeps> = {}): CascadeProbeDeps {
+  return {
+    homeDir: HOME,
+    agentsDir: AGENTS,
+    currentVersion: VERSION,
+    existsSync: (p) => p in vfs.files || !!vfs.unreadable?.has(p),
+    readFileSync: (p) => {
+      if (vfs.unreadable?.has(p)) {
+        const e = new Error("EACCES") as NodeJS.ErrnoException;
+        e.code = "EACCES";
+        throw e;
+      }
+      if (!(p in vfs.files)) {
+        const e = new Error("ENOENT") as NodeJS.ErrnoException;
+        e.code = "ENOENT";
+        throw e;
+      }
+      return vfs.files[p]!;
+    },
+    ...extra,
+  };
+}
+
+function byName(rs: CheckResult[], name: string): CheckResult | undefined {
+  return rs.find((r) => r.name === name);
+}
+
+/** A healthy fleet fixture: L1/L2 good + one fully-wired agent. */
+function healthy(agent = "alice"): Vfs {
+  const claudeMd = `# Agent: ${agent}\n\nsome managed stuff\n\n${CLAUDE_MD_YOURS_MARKER}\n\noperator notes\n`;
+  const belowHash = sha256Text(claudeMd.slice(claudeMd.indexOf(CLAUDE_MD_YOURS_MARKER) + CLAUDE_MD_YOURS_MARKER.length));
+  const settings = JSON.stringify({
+    hooks: {
+      PreToolUse: [
+        { matcher: "^(Read|Edit)$", hooks: [{ type: "command", command: "bash run-hook.sh 'hook:repo-context-pretool' node repo-context-pretool.mjs" }] },
+      ],
+      UserPromptSubmit: [
+        { hooks: [{ type: "command", command: "bash run-hook.sh 'hook:turn-pacing' bash turn-pacing-hook.sh" }] },
+      ],
+    },
+  });
+  const stamp = JSON.stringify({
+    version: 1,
+    files: { "CLAUDE.md": hashManagedClaudeMd(claudeMd) },
+    claudeMdBelowMarker: belowHash,
+  });
+  return {
+    files: {
+      [`${FLEET}/switchroom-invariants.md`]: renderFleetInvariants(),
+      [`${FLEET}/CLAUDE.md`]: renderFleetDefaultsClaudeMd().replace("# Fleet defaults", "# Fleet defaults\n\nOperator household facts here.").replace(
+        /switchroom-fleet-defaults-version: \S+/,
+        `switchroom-fleet-defaults-version: ${VERSION}`,
+      ),
+      [`${AGENTS}/${agent}/CLAUDE.md`]: claudeMd,
+      [`${AGENTS}/${agent}/.claude/settings.json`]: settings,
+      [`${AGENTS}/${agent}/start.sh`]: 'exec claude --add-dir "$HOME/.switchroom/fleet"\n',
+      [`${AGENTS}/${agent}/.switchroom-generated.json`]: stamp,
+    },
+  };
+}
+
+describe("cascade doctor probes — clean fleet", () => {
+  it("all probes pass on a healthy install", () => {
+    const rs = runCascadeChecks(cfg(["alice"]), deps(healthy()));
+    // No fails anywhere.
+    expect(rs.filter((r) => r.status === "fail")).toEqual([]);
+    expect(byName(rs, "cascade L1: invariants present")?.status).toBe("ok");
+    expect(byName(rs, "cascade L1: invariants checksum")?.status).toBe("ok");
+    expect(byName(rs, "cascade L2: fleet defaults")?.status).toBe("ok");
+    expect(byName(rs, "cascade L3 alice: Yours marker")?.status).toBe("ok");
+    expect(byName(rs, "cascade L3 alice: below-marker preserved")?.status).toBe("ok");
+    expect(byName(rs, "cascade L4 alice: repo-context hook")?.status).toBe("ok");
+    expect(byName(rs, "cascade per-turn alice: pacing hook")?.status).toBe("ok");
+    expect(byName(rs, "cascade alice: --add-dir fleet")?.status).toBe("ok");
+    expect(byName(rs, "cascade alice: no pacing duplication")?.status).toBe("ok");
+  });
+});
+
+describe("cascade doctor probes — L1 invariants", () => {
+  it("FAILs when the invariants file is missing", () => {
+    const vfs = healthy();
+    delete vfs.files[`${FLEET}/switchroom-invariants.md`];
+    const rs = runCascadeChecks(cfg(["alice"]), deps(vfs));
+    expect(byName(rs, "cascade L1: invariants present")?.status).toBe("fail");
+    expect(byName(rs, "cascade L1: invariants checksum")?.status).toBe("skip");
+  });
+
+  it("FAILs on checksum drift from the release canonical", () => {
+    const vfs = healthy();
+    vfs.files[`${FLEET}/switchroom-invariants.md`] = renderFleetInvariants() + "\nhand-edit\n";
+    const rs = runCascadeChecks(cfg(["alice"]), deps(vfs));
+    const c = byName(rs, "cascade L1: invariants checksum");
+    expect(c?.status).toBe("fail");
+    expect(c?.fix).toMatch(/switchroom apply/);
+  });
+
+  it("SKIPs the checksum when the file is unreadable (no sudo)", () => {
+    const vfs = healthy();
+    delete vfs.files[`${FLEET}/switchroom-invariants.md`];
+    vfs.unreadable = new Set([`${FLEET}/switchroom-invariants.md`]);
+    const rs = runCascadeChecks(cfg(["alice"]), deps(vfs));
+    expect(byName(rs, "cascade L1: invariants checksum")?.status).toBe("skip");
+  });
+});
+
+describe("cascade doctor probes — L2 fleet defaults", () => {
+  it("FAILs when the fleet CLAUDE.md is missing", () => {
+    const vfs = healthy();
+    delete vfs.files[`${FLEET}/CLAUDE.md`];
+    const rs = runCascadeChecks(cfg(["alice"]), deps(vfs));
+    expect(byName(rs, "cascade L2: fleet defaults")?.status).toBe("fail");
+  });
+
+  it("FAILs when the fleet CLAUDE.md is empty", () => {
+    const vfs = healthy();
+    vfs.files[`${FLEET}/CLAUDE.md`] = "   \n";
+    const rs = runCascadeChecks(cfg(["alice"]), deps(vfs));
+    expect(byName(rs, "cascade L2: fleet defaults")?.status).toBe("fail");
+  });
+
+  it("WARNs (not fail) when identical to the shipped default — not personalised", () => {
+    const vfs = healthy();
+    vfs.files[`${FLEET}/CLAUDE.md`] = renderFleetDefaultsClaudeMd();
+    const rs = runCascadeChecks(cfg(["alice"]), deps(vfs, { currentVersion: SWITCHROOM_VERSION }));
+    const c = byName(rs, "cascade L2: fleet defaults");
+    expect(c?.status).toBe("warn");
+    expect(c?.detail).toMatch(/not personalised/);
+  });
+
+  it("WARNs when personalised but the header version tag is stale", () => {
+    const vfs = healthy();
+    vfs.files[`${FLEET}/CLAUDE.md`] = renderFleetDefaultsClaudeMd()
+      .replace("# Fleet defaults", "# Fleet defaults\n\nmy facts")
+      .replace(/switchroom-fleet-defaults-version: \S+/, "switchroom-fleet-defaults-version: 0.0.1");
+    const rs = runCascadeChecks(cfg(["alice"]), deps(vfs));
+    const c = byName(rs, "cascade L2: fleet defaults");
+    expect(c?.status).toBe("warn");
+    expect(c?.detail).toMatch(/newer default is available/);
+  });
+});
+
+describe("cascade doctor probes — L3 per-agent", () => {
+  it("FAILs when the Yours marker is missing", () => {
+    const vfs = healthy();
+    vfs.files[`${AGENTS}/alice/CLAUDE.md`] = "# Agent: alice\n\nno marker here\n";
+    const rs = runCascadeChecks(cfg(["alice"]), deps(vfs));
+    expect(byName(rs, "cascade L3 alice: Yours marker")?.status).toBe("fail");
+  });
+
+  it("FAILs when the below-marker section changed since last apply", () => {
+    const vfs = healthy();
+    // Baseline stamp records the ORIGINAL below-marker hash; the on-disk
+    // file now has a DIFFERENT below-marker section.
+    const tampered = `# Agent: alice\n\nsome managed stuff\n\n${CLAUDE_MD_YOURS_MARKER}\n\nSCAFFOLD CLOBBERED THIS\n`;
+    vfs.files[`${AGENTS}/alice/CLAUDE.md`] = tampered;
+    const rs = runCascadeChecks(cfg(["alice"]), deps(vfs));
+    const c = byName(rs, "cascade L3 alice: below-marker preserved");
+    expect(c?.status).toBe("fail");
+    expect(c?.detail).toMatch(/below-marker/);
+  });
+
+  it("OKs when the below-marker section is unchanged", () => {
+    const rs = runCascadeChecks(cfg(["alice"]), deps(healthy()));
+    expect(byName(rs, "cascade L3 alice: below-marker preserved")?.status).toBe("ok");
+  });
+
+  it("SKIPs below-marker when no baseline is recorded", () => {
+    const vfs = healthy();
+    const rs = runCascadeChecks(
+      cfg(["alice"]),
+      deps(vfs, { belowMarkerBaseline: () => null }),
+    );
+    expect(byName(rs, "cascade L3 alice: below-marker preserved")?.status).toBe("skip");
+  });
+
+  it("SKIPs (never fails) when the agent CLAUDE.md is unreadable", () => {
+    const vfs = healthy();
+    vfs.unreadable = new Set([`${AGENTS}/alice/CLAUDE.md`]);
+    delete vfs.files[`${AGENTS}/alice/CLAUDE.md`];
+    const rs = runCascadeChecks(cfg(["alice"]), deps(vfs));
+    expect(byName(rs, "cascade L3 alice: Yours marker")?.status).toBe("skip");
+  });
+
+  it("FAILs the pacing-dedup guard when the 5-beats are re-inlined", () => {
+    const vfs = healthy();
+    vfs.files[`${AGENTS}/alice/CLAUDE.md`] =
+      `# Agent: alice\n\n${TELEGRAM_PACING_SIGNATURE}\n\nblah\n\n${CLAUDE_MD_YOURS_MARKER}\n\noperator notes\n`;
+    const rs = runCascadeChecks(cfg(["alice"]), deps(vfs));
+    expect(byName(rs, "cascade alice: no pacing duplication")?.status).toBe("fail");
+  });
+});
+
+describe("cascade doctor probes — L4 + per-turn hooks", () => {
+  it("FAILs when the repo-context PreToolUse hook is missing", () => {
+    const vfs = healthy();
+    vfs.files[`${AGENTS}/alice/.claude/settings.json`] = JSON.stringify({
+      hooks: {
+        PreToolUse: [{ hooks: [{ command: "bash run-hook.sh 'hook:tool-label' node other.mjs" }] }],
+        UserPromptSubmit: [{ hooks: [{ command: "bash run-hook.sh 'hook:turn-pacing' bash turn-pacing-hook.sh" }] }],
+      },
+    });
+    const rs = runCascadeChecks(cfg(["alice"]), deps(vfs));
+    expect(byName(rs, "cascade L4 alice: repo-context hook")?.status).toBe("fail");
+  });
+
+  it("FAILs when the turn-pacing UserPromptSubmit hook is missing", () => {
+    const vfs = healthy();
+    vfs.files[`${AGENTS}/alice/.claude/settings.json`] = JSON.stringify({
+      hooks: {
+        PreToolUse: [{ hooks: [{ command: "bash run-hook.sh 'hook:repo-context-pretool' node repo-context-pretool.mjs" }] }],
+        UserPromptSubmit: [{ hooks: [{ command: "bash run-hook.sh 'hook:workspace-stable' node ws.mjs" }] }],
+      },
+    });
+    const rs = runCascadeChecks(cfg(["alice"]), deps(vfs));
+    expect(byName(rs, "cascade per-turn alice: pacing hook")?.status).toBe("fail");
+  });
+
+  it("SKIPs hooks when settings.json is unreadable", () => {
+    const vfs = healthy();
+    vfs.unreadable = new Set([`${AGENTS}/alice/.claude/settings.json`]);
+    delete vfs.files[`${AGENTS}/alice/.claude/settings.json`];
+    const rs = runCascadeChecks(cfg(["alice"]), deps(vfs));
+    expect(byName(rs, "cascade L4 alice: repo-context hook")?.status).toBe("skip");
+  });
+});
+
+describe("cascade doctor probes — cross-lane --add-dir", () => {
+  it("FAILs when start.sh has no --add-dir for the fleet", () => {
+    const vfs = healthy();
+    vfs.files[`${AGENTS}/alice/start.sh`] = "exec claude\n";
+    const rs = runCascadeChecks(cfg(["alice"]), deps(vfs));
+    expect(byName(rs, "cascade alice: --add-dir fleet")?.status).toBe("fail");
+  });
+});
+
+describe("cascade doctor probes — scaffolding edges", () => {
+  it("stays silent for an agent that is not scaffolded yet", () => {
+    const vfs = healthy("alice");
+    // bob declared in config but has no files on disk.
+    const rs = runCascadeChecks(cfg(["alice", "bob"]), deps(vfs));
+    expect(rs.some((r) => r.name.includes("bob"))).toBe(false);
+  });
+
+  it("WARNs when agents_dir cannot be resolved", () => {
+    const vfs = healthy();
+    const rs = runCascadeChecks(cfg(["alice"]), deps(vfs, { agentsDir: undefined }));
+    // With agentsDir undefined and no config.agents_dir, resolveAgentsDir may
+    // still succeed; assert only that L1/L2 emitted and no crash.
+    expect(byName(rs, "cascade L1: invariants present")).toBeDefined();
+  });
+});


### PR DESCRIPTION
## What

Adds a **Prompt cascade** section to `switchroom doctor` — ~10 probes that convert silent drift across the redesigned system-prompt cascade (epic #1850) into upfront, operator-visible lines. New module `src/cli/doctor-cascade.ts` follows the existing `doctor-webkite.ts` dependency-injected pattern and is wired into the doctor section list next to Webkite.

Probes (per issue #1858's table):

| Lane | Probe | Behaviour |
|---|---|---|
| L1 | invariants present | FAIL if `~/.switchroom/fleet/switchroom-invariants.md` missing |
| L1 | invariants checksum | FAIL on drift from `renderFleetInvariants()` canonical (with `switchroom apply` repair hint) |
| L2 | fleet defaults | FAIL if missing/empty; WARN if identical to shipped default ("not personalised"); WARN if header version-tag stale; OK if personalised + current |
| L3 | Yours marker | FAIL if the `# --- Yours ---` marker is gone |
| L3 | above-marker canonical | INFO/skip only — drift is fine, scaffold rewrites next apply |
| L3 | below-marker preserved | FAIL if the operator-owned below-marker section changed since the apply baseline |
| L4 | repo-context hook | FAIL if `repo-context-pretool` PreToolUse hook missing from an agent's settings.json |
| per-turn | pacing hook | FAIL if `turn-pacing` UserPromptSubmit hook missing |
| cross-lane | --add-dir fleet | FAIL if start.sh has no `--add-dir` for the fleet dir |
| cross-lane | no pacing duplication | FAIL if the Telegram 5-beats are re-inlined in a per-agent CLAUDE.md (double-load regression guard) |

Uses the machine-readable `<!-- switchroom-fleet-defaults-version: X -->` tag rendered by `src/agents/fleet-defaults.ts` (verified present at HEAD). Agent-UID-owned 0600 files read as `skip`, never `fail` (the no-sudo doctor discipline, mirroring `doctor-webkite.ts`).

## Issues

Closes #1858. Part of epic #1850; prerequisites #1852/#1855/#1856/#1857 are closed/live at HEAD.

## Revert-check

Reverted each probe's decision individually → **7 tests went red** (below-marker, marker, L1 checksum, repo-context hook, turn-pacing hook, --add-dir, pacing-dedup), then restored → all green. Tests assert outcomes, not code paths.

## Scoped tests

- `npx vitest run tests/doctor.prompt-redesign-probes.test.ts` → **20 passed**.
- `npx tsc --noEmit` → clean (exit 0).
- Full suite not run (scoped per task).

## Honest caveats

- **L3 below-marker baseline is DI-seamed and degrades to `skip` in production today.** The probe compares the live below-marker hash against a baseline recorded at the last `switchroom apply`. The apply/generation-stamp path does not yet persist that hash (an optional `claudeMdBelowMarker` stamp field), so in production this probe reports an honest `skip` ("no baseline recorded yet") rather than fabricating a pass. Tests drive the pass/fail branches via the injected baseline. Wiring apply to persist the below-marker hash is a small follow-up outside this PR's stated scope (doctor.ts + doctor-cascade module only); I did not touch the apply reconcile path to avoid the diff-abort risk.
- The pacing-dedup guard keys on the distinctive L1 header `## Talking to a human on Telegram`; if that heading text ever changes, update `TELEGRAM_PACING_SIGNATURE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)