### PR TITLE
fix(gateway): deterministic recovery for orphaned handbacks; close #4027 delivered-window race

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -283,6 +283,7 @@ import { createTurnTypingLoop } from './turn-typing-loop.js'
 import {
   createHandbackPreturnSignal,
   type PreTurnCardRecord,
+  type HandbackOrphanEscalation,
 } from './handback-preturn-signal.js'
 import { deriveTurnId } from './derive-turn-id.js'
 import { createTypingEmitter, TYPING_REFRESH_MS } from '../typing-emitter.js'
@@ -13743,8 +13744,6 @@ if (isGatewayMain && !STATIC && FEED_HEARTBEAT_ENABLED) {
 // closes. Kill switch: SWITCHROOM_HANDBACK_PRETURN=0.
 const HANDBACK_PRETURN_ENABLED = !STATIC && process.env.SWITCHROOM_HANDBACK_PRETURN !== '0'
 const HANDBACK_PRETURN_HTML = '🤝 Reading the worker’s results…'
-const HANDBACK_PRETURN_ORPHAN_HTML =
-  '🤝 A background worker finished, but the handback never started — it may need a nudge.'
 
 async function openHandbackPreTurnCard(
   chatId: string,
@@ -13774,19 +13773,19 @@ async function openHandbackPreTurnCard(
   }
 }
 
-function finalizeHandbackPreTurnCard(record: PreTurnCardRecord): Promise<void> {
+// DELETE (not edit) a genuinely-orphaned pre-turn card. The old behaviour
+// rewrote the card to an operator-facing string asking the human to manually
+// recover a system that must recover itself. That string is removed; we now
+// delete the frozen card outright, and the orphan is re-injected through the
+// pending-inbound buffer (see the seam's reap) so the machine re-processes it,
+// with no stale message left behind.
+function deleteHandbackPreTurnCard(record: PreTurnCardRecord): Promise<void> {
   return robustApiCall(
-    () =>
-      bot.api.editMessageText(
-        record.chatId,
-        record.activityMessageId,
-        richMessage(HANDBACK_PRETURN_ORPHAN_HTML),
-        {},
-      ),
+    () => bot.api.deleteMessage(record.chatId, record.activityMessageId),
     {
       chat_id: record.chatId,
       ...(record.threadId != null ? { threadId: record.threadId } : {}),
-      verb: 'handback-preturn.orphan-finalize',
+      verb: 'handback-preturn.orphan-delete',
     },
   )
     .then(() => undefined)
@@ -13799,7 +13798,25 @@ const handbackPreturnSignal = createHandbackPreturnSignal({
   startTypingLoop: (chatId, threadId) => startTurnTypingLoop(chatId, threadId),
   stopTypingLoop: (chatId, threadId) => stopTurnTypingLoop(chatId, threadId),
   openCard: openHandbackPreTurnCard,
-  finalizeCard: finalizeHandbackPreTurnCard,
+  deleteCard: deleteHandbackPreTurnCard,
+  // Deterministic recovery on a genuine orphan: re-inject the handback through
+  // the same pending-inbound buffer the live synthesis + boot-replay use, so the
+  // idle-drain re-delivers it and the machine re-processes it itself (no operator
+  // nudge). `noteHandbackRelease` re-fires on the redelivery, re-arming the seam.
+  reinjectHandback: (inbound) => {
+    pendingInboundBuffer.push(process.env.SWITCHROOM_AGENT_NAME ?? '', inbound)
+  },
+  // Retries exhausted → fleet-health telemetry, NEVER an operator-facing card.
+  // A structured stderr line lands in the gateway log the nightly fleet-health
+  // sensor reads (src/fleet-health/scan.ts); the `handback orphan escalation`
+  // marker is greppable and carries the join key for correlation.
+  escalateOrphan: (esc: HandbackOrphanEscalation) => {
+    process.stderr.write(
+      `telegram gateway: handback orphan escalation key=${esc.statusKey} ` +
+        `turnId=${esc.adoptTurnId} reinjects=${esc.reinjectCount} ageMs=${esc.ageMs} ` +
+        `— deterministic recovery exhausted, no operator nudge issued\n`,
+    )
+  },
   writeCardRecord: (record) => {
     if (!activityCardPersistEnabled) return
     writeActivityCardRecord(ACTIVITY_CARD_STORE_PATH, activityCardStoreFs, record)

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -280,11 +280,8 @@ import { REPLY_TOOLS } from '../narrative-dedup.js'
 import { NarrativeFlushController, PENDING_NARRATIVE_FLUSH_MS } from '../narrative-flush.js'
 import { createTypingWrapper } from '../typing-wrap.js'
 import { createTurnTypingLoop } from './turn-typing-loop.js'
-import {
-  createHandbackPreturnSignal,
-  type PreTurnCardRecord,
-  type HandbackOrphanEscalation,
-} from './handback-preturn-signal.js'
+import { createHandbackPreturnSignal } from './handback-preturn-signal.js'
+import { createHandbackOrphanRecovery } from './handback-orphan-recovery.js'
 import { deriveTurnId } from './derive-turn-id.js'
 import { createTypingEmitter, TYPING_REFRESH_MS } from '../typing-emitter.js'
 import { type DraftStreamHandle } from '../draft-stream.js'
@@ -13773,24 +13770,20 @@ async function openHandbackPreTurnCard(
   }
 }
 
-// DELETE (not edit) a genuinely-orphaned pre-turn card. The old behaviour
-// rewrote the card to an operator-facing string asking the human to manually
-// recover a system that must recover itself. That string is removed; we now
-// delete the frozen card outright, and the orphan is re-injected through the
-// pending-inbound buffer (see the seam's reap) so the machine re-processes it,
-// with no stale message left behind.
-function deleteHandbackPreTurnCard(record: PreTurnCardRecord): Promise<void> {
-  return robustApiCall(
-    () => bot.api.deleteMessage(record.chatId, record.activityMessageId),
-    {
-      chat_id: record.chatId,
-      ...(record.threadId != null ? { threadId: record.threadId } : {}),
+// Deterministic recovery for a genuinely-orphaned handback: delete the frozen
+// pre-turn card, re-inject the handback through the pending-inbound buffer, and
+// past the retry cap emit fleet-health telemetry — never an operator-facing
+// "needs a nudge" card. See handback-orphan-recovery.ts.
+const handbackOrphanRecovery = createHandbackOrphanRecovery({
+  deleteMessage: (chatId, messageId, threadId) =>
+    robustApiCall(() => bot.api.deleteMessage(chatId, messageId), {
+      chat_id: chatId,
+      ...(threadId != null ? { threadId } : {}),
       verb: 'handback-preturn.orphan-delete',
-    },
-  )
-    .then(() => undefined)
-    .catch(() => undefined)
-}
+    }),
+  pushInbound: (inbound) =>
+    pendingInboundBuffer.push(process.env.SWITCHROOM_AGENT_NAME ?? '', inbound),
+})
 
 const handbackPreturnSignal = createHandbackPreturnSignal({
   chatKey: (chatId, threadId) => chatKey(chatId, threadId) as string,
@@ -13798,25 +13791,9 @@ const handbackPreturnSignal = createHandbackPreturnSignal({
   startTypingLoop: (chatId, threadId) => startTurnTypingLoop(chatId, threadId),
   stopTypingLoop: (chatId, threadId) => stopTurnTypingLoop(chatId, threadId),
   openCard: openHandbackPreTurnCard,
-  deleteCard: deleteHandbackPreTurnCard,
-  // Deterministic recovery on a genuine orphan: re-inject the handback through
-  // the same pending-inbound buffer the live synthesis + boot-replay use, so the
-  // idle-drain re-delivers it and the machine re-processes it itself (no operator
-  // nudge). `noteHandbackRelease` re-fires on the redelivery, re-arming the seam.
-  reinjectHandback: (inbound) => {
-    pendingInboundBuffer.push(process.env.SWITCHROOM_AGENT_NAME ?? '', inbound)
-  },
-  // Retries exhausted → fleet-health telemetry, NEVER an operator-facing card.
-  // A structured stderr line lands in the gateway log the nightly fleet-health
-  // sensor reads (src/fleet-health/scan.ts); the `handback orphan escalation`
-  // marker is greppable and carries the join key for correlation.
-  escalateOrphan: (esc: HandbackOrphanEscalation) => {
-    process.stderr.write(
-      `telegram gateway: handback orphan escalation key=${esc.statusKey} ` +
-        `turnId=${esc.adoptTurnId} reinjects=${esc.reinjectCount} ageMs=${esc.ageMs} ` +
-        `— deterministic recovery exhausted, no operator nudge issued\n`,
-    )
-  },
+  deleteCard: handbackOrphanRecovery.deleteCard,
+  reinjectHandback: handbackOrphanRecovery.reinjectHandback,
+  escalateOrphan: handbackOrphanRecovery.escalateOrphan,
   writeCardRecord: (record) => {
     if (!activityCardPersistEnabled) return
     writeActivityCardRecord(ACTIVITY_CARD_STORE_PATH, activityCardStoreFs, record)

--- a/telegram-plugin/gateway/handback-orphan-recovery.ts
+++ b/telegram-plugin/gateway/handback-orphan-recovery.ts
@@ -1,0 +1,69 @@
+/**
+ * handback-orphan-recovery.ts — the gateway-side EFFECTS for deterministic
+ * recovery of a genuinely-orphaned sub-agent handback.
+ *
+ * The decision ("is this an orphan, should it be re-injected, has it exhausted
+ * its retries") lives in `handback-preturn-signal.ts`. This module owns only the
+ * three side effects that decision drives, so they live in a module instead of
+ * inline in gateway.ts (switchroom#2996 anti-inflation ratchet — new logic goes
+ * into a seam, not into the 24k-line gateway):
+ *
+ *   1. `deleteCard`       — DELETE (never edit) the frozen pre-turn card. The
+ *      old behaviour rewrote it to an operator-facing string asking a human to
+ *      manually nudge a system that must recover itself. That string is gone
+ *      from the codebase; the card is removed outright.
+ *   2. `reinjectHandback` — push the handback back through the pending-inbound
+ *      buffer (the same path live synthesis + boot replay use) so the idle drain
+ *      re-delivers it and the machine re-processes it. The seam stamps the retry
+ *      counter on `inbound.meta` before calling this, so the cap survives the
+ *      round trip.
+ *   3. `escalateOrphan`   — retries exhausted → fleet-health TELEMETRY, never a
+ *      chat card. A structured line on the gateway log that the nightly
+ *      fleet-health sensor (`src/fleet-health/scan.ts`) reads; the
+ *      `handback orphan escalation` marker is greppable and carries the join key.
+ *
+ * Every effect is injected, so the contract is asserted by a unit test with spy
+ * transports (`tests/handback-orphan-recovery.test.ts`) rather than by reading
+ * gateway.ts.
+ */
+
+import type { InboundMessage } from './ipc-protocol.js'
+import type { HandbackOrphanEscalation, PreTurnCardRecord } from './handback-preturn-signal.js'
+
+export interface HandbackOrphanRecoveryDeps {
+  /** Delete a message. The gateway supplies its `robustApiCall`-wrapped
+   *  `bot.api.deleteMessage`; rejections are swallowed here (best-effort). */
+  deleteMessage: (chatId: string, messageId: number, threadId: number | null) => Promise<unknown>
+  /** The gateway's `pendingInboundBuffer.push`, pre-bound to this agent. */
+  pushInbound: (inbound: InboundMessage) => void
+  /** Telemetry sink. Defaults to the gateway log (stderr). */
+  writeLog?: (line: string) => void
+}
+
+/** Structured, greppable telemetry line for an exhausted-retry orphan. Exported
+ *  so the test asserts the exact marker + join keys the fleet-health sensor
+ *  greps for, not just that "something was logged". */
+export function formatOrphanEscalation(esc: HandbackOrphanEscalation): string {
+  return (
+    `telegram gateway: handback orphan escalation key=${esc.statusKey} ` +
+    `turnId=${esc.adoptTurnId} reinjects=${esc.reinjectCount} ageMs=${esc.ageMs} ` +
+    `— deterministic recovery exhausted, no operator nudge issued\n`
+  )
+}
+
+export function createHandbackOrphanRecovery(deps: HandbackOrphanRecoveryDeps): {
+  deleteCard: (record: PreTurnCardRecord) => Promise<void>
+  reinjectHandback: (inbound: InboundMessage) => void
+  escalateOrphan: (escalation: HandbackOrphanEscalation) => void
+} {
+  const writeLog = deps.writeLog ?? ((line: string) => void process.stderr.write(line))
+  return {
+    deleteCard: (record) =>
+      deps
+        .deleteMessage(record.chatId, record.activityMessageId, record.threadId)
+        .then(() => undefined)
+        .catch(() => undefined),
+    reinjectHandback: (inbound) => deps.pushInbound(inbound),
+    escalateOrphan: (esc) => writeLog(formatOrphanEscalation(esc)),
+  }
+}

--- a/telegram-plugin/gateway/handback-preturn-signal.ts
+++ b/telegram-plugin/gateway/handback-preturn-signal.ts
@@ -105,6 +105,29 @@ import type { InboundMessage } from './ipc-protocol.js'
  *  the seam's `handleReaped` hook (stop typing loop + drop map entry). */
 export const PRETURN_TURNKEY_PREFIX = 'preturn:'
 
+/** `meta` key carrying the deterministic-recovery re-injection counter across a
+ *  re-injected handback's round trip through the pending-inbound buffer. Stamped
+ *  on the inbound just before it is re-injected on a genuine orphan; read back
+ *  when that same inbound is released again, so the retry cap survives the
+ *  drop-and-recreate of the per-topic pre-turn entry. `meta` is
+ *  `Record<string,string>`, so the count is stored as a decimal string. */
+export const HANDBACK_REINJECT_COUNT_META_KEY = 'handbackReinjectCount'
+
+/** Emitted (NOT to chat) when a genuine orphan has exhausted its re-injection
+ *  retries — the deterministic-recovery escalation surface. The gateway routes
+ *  this to fleet-health telemetry (a structured log line the nightly sensor
+ *  reads), never to an operator-facing card: the system must recover itself, not
+ *  ask a human to nudge it. */
+export interface HandbackOrphanEscalation {
+  statusKey: string
+  chatId: string
+  threadId: number | null
+  adoptTurnId: string
+  reinjectCount: number
+  /** Age (ms) of the handback at escalation — release → escalation. */
+  ageMs: number
+}
+
 /** True IFF `source` is the load-bearing subagent-handback source string. Kept
  *  here next to the seam so a source-string regression is caught by this
  *  module's own test, not only the inbound-builder's. */
@@ -162,9 +185,21 @@ export interface HandbackPreturnSignalDeps {
    *  when the send failed / was suppressed (best-effort — a null just means no
    *  card was painted, so nothing to adopt or reap). */
   openCard: (chatId: string, threadId: number | null) => Promise<number | null>
-  /** Finalize (single honest edit) a frozen never-adopted pre-turn card on
-   *  orphan self-reap. Best-effort; failures swallowed by the caller. */
-  finalizeCard: (record: PreTurnCardRecord) => void | Promise<void>
+  /** DELETE (not edit) a never-adopted pre-turn card. Used on the genuine-orphan
+   *  reap so the frozen card is removed rather than rewritten to a stale
+   *  user-facing "needs a nudge" message, and on the rare emit-race teardown of a
+   *  card the adopting turn already owns. Best-effort; failures swallowed by the
+   *  caller. */
+  deleteCard: (record: PreTurnCardRecord) => void | Promise<void>
+  /** Re-inject a genuinely-orphaned handback back through the pending-inbound
+   *  buffer so the machine recovers itself — the deterministic alternative to
+   *  asking the operator to nudge. The gateway's `pendingInboundBuffer.push`. The
+   *  seam stamps `HANDBACK_REINJECT_COUNT_META_KEY` on `inbound.meta` first so the
+   *  retry cap survives the round trip. */
+  reinjectHandback: (inbound: InboundMessage) => void
+  /** Escalate a genuine orphan that has exhausted its re-injection retries to
+   *  fleet-health telemetry (NOT a chat card). */
+  escalateOrphan: (escalation: HandbackOrphanEscalation) => void
   /** Persist the durable card record (the gateway's `writeActivityCardRecord`,
    *  scoped by `turnKey`). */
   writeCardRecord: (record: PreTurnCardRecord) => void
@@ -190,16 +225,18 @@ export interface HandbackPreturnSignalDeps {
    *  handback is delivered into that single queue and only mints its adopting
    *  turn when claude next goes idle, so while claude is busy the handback is
    *  NOT orphaned — it is correctly enqueued BEHIND the in-flight turn (a long
-   *  parent turn can run many minutes). Finalizing it as an orphan in that
-   *  window posts a false "never started — needs a nudge" card. The reap
-   *  therefore DEFERS (re-arms) while this is true and finalizes only once
-   *  claude is idle and the handback still has not been adopted — the genuine
-   *  bridge-death / dropped-inbound degenerate case the reap exists for.
-   *  Distinct from `hasLiveTurn`, which is PER-KEY and only governs the
-   *  typing-loop stop; this is the GLOBAL busy signal because the handback
-   *  queues behind whatever turn is running, regardless of topic. Optional;
-   *  defaults to "not busy" (immediate reap — the pre-fix behaviour), so the
-   *  genuine-orphan path is unchanged. */
+   *  parent turn can run many minutes). Reaping it as an orphan in that window
+   *  used to post a false "never started — needs a nudge" card (the 3-cards-in-
+   *  4-min incident). The reap therefore DEFERS (re-arms) while this is true —
+   *  and, complementarily, while the handback was delivered but its turn has not
+   *  started streaming yet (`deliveredAwaitingTurnStart`, the #4027 coverage
+   *  gap) — recovering only once claude is idle AND the delivered window has
+   *  elapsed AND the handback still has not been adopted (the genuine bridge-
+   *  death / dropped-inbound case). Recovery is deterministic (delete the frozen
+   *  card + re-inject, then escalate), never an operator nudge. Distinct from
+   *  `hasLiveTurn`, which is PER-KEY and only governs the typing-loop stop; this
+   *  is the GLOBAL busy signal because the handback queues behind whatever turn
+   *  is running, regardless of topic. Optional; defaults to "not busy". */
   isClaudeBusy?: () => boolean
   now?: () => number
   /** Debounce before painting the pre-turn card (kills sub-second flicker). */
@@ -207,6 +244,17 @@ export interface HandbackPreturnSignalDeps {
   /** Age after emit at which a never-adopted card self-reaps. Independent of
    *  topic liveness. */
   adoptTimeoutMs?: number
+  /** TTL (ms) for the delivered-but-not-yet-streaming window. A released
+   *  handback has been DELIVERED into claude's queue but its adopting turn may
+   *  not have started streaming yet — the false-orphan window #4027 left open
+   *  (idle machine + un-adopted = looked like an orphan). While within this TTL
+   *  the reap DEFERS (`deliveredAwaitingTurnStart`); past it a truly-stuck
+   *  delivery finally reaps for deterministic recovery rather than hanging
+   *  forever. Defaults to 5 min. */
+  deliveredTtlMs?: number
+  /** Max deterministic re-injections of a genuine orphan before escalating to
+   *  fleet-health telemetry. Defaults to 2. */
+  maxReinjects?: number
   /** Injected scheduler (mirrors bridge-dead-watchdog.ts): defaults to
    *  setTimeout/clearTimeout. Injected so a runner-agnostic test can drive the
    *  debounce + self-reap deterministically WITHOUT any vitest-only fake-timer
@@ -224,6 +272,18 @@ interface PreTurnEntry {
   adoptTurnId: string
   syntheticTurnKey: string
   startedAt: number
+  /** When the handback was RELEASED/DELIVERED for delivery (stamped at
+   *  `noteHandbackRelease`). Drives `deliveredAwaitingTurnStart`: the reap must
+   *  not treat a delivered-but-not-yet-streaming handback as an orphan within
+   *  the delivered TTL. Equal to `startedAt` (release is the delivery point). */
+  deliveredAt: number
+  /** How many times this handback has already been deterministically re-injected
+   *  (carried across the buffer round trip via `HANDBACK_REINJECT_COUNT_META_KEY`
+   *  on the inbound). Governs the retry cap before fleet-health escalation. */
+  reinjectCount: number
+  /** The released handback inbound itself — retained so a genuine orphan can be
+   *  re-injected through the pending-inbound buffer (deterministic recovery). */
+  inbound: InboundMessage
   pinned: boolean
   debounceTimer: unknown | null
   reapTimer: unknown | null
@@ -273,6 +333,8 @@ export function createHandbackPreturnSignal(
   const now = deps.now ?? (() => Date.now())
   const debounceMs = deps.debounceMs ?? 700
   const adoptTimeoutMs = deps.adoptTimeoutMs ?? 30_000
+  const deliveredTtlMs = deps.deliveredTtlMs ?? 300_000
+  const maxReinjects = deps.maxReinjects ?? 2
   const setTimer =
     deps.setTimer ??
     ((fn: () => void, ms: number) => {
@@ -333,9 +395,9 @@ export function createHandbackPreturnSignal(
         if (messageId == null) return // no card painted; the reap timer cleans up
         if (entry.consumed) {
           // Adopted/reaped while the send was in flight: the card is now the
-          // turn's (adoption seeds a null id it can't use) — finalize+clear so
-          // it never dangles. Rare; the debounce makes it unlikely.
-          void deps.finalizeCard({
+          // turn's (adoption seeds a null id it can't use) — DELETE it so it
+          // never dangles. Rare; the debounce makes it unlikely.
+          void deps.deleteCard({
             turnKey: entry.syntheticTurnKey,
             chatId: entry.chatId,
             threadId: entry.threadId,
@@ -385,30 +447,52 @@ export function createHandbackPreturnSignal(
     deps.stopTypingLoop(entry.chatId, entry.threadId)
   }
 
+  /**
+   * The delivered-but-not-yet-streaming window (#4027 coverage gap). A released
+   * handback has been DELIVERED into claude's single input queue, but its
+   * adopting turn may not have started streaming yet — and in that stretch the
+   * machine reads as idle (`isClaudeBusy()` false) with the entry un-adopted,
+   * which looked exactly like a genuine orphan and produced the false "needs a
+   * nudge" card even after #4027 gated on `isMachineInTurn`. While the handback
+   * is within the delivered TTL and its turn has not started (we are in `reap`,
+   * so the entry is un-consumed = no adopting turn minted), it is NOT orphaned —
+   * defer. Past the TTL a truly-stuck delivery finally reaps rather than hanging
+   * forever, handing off to deterministic recovery.
+   */
+  function deliveredAwaitingTurnStart(entry: PreTurnEntry): boolean {
+    return now() - entry.deliveredAt < deliveredTtlMs
+  }
+
   function reap(entry: PreTurnEntry): void {
     entry.reapTimer = null
     if (entry.consumed) return
     // PRIMARY GATE (queue state, not a flat timeout): a released handback is
     // delivered into claude's SINGLE input queue and mints its adopting turn
-    // only when claude next goes idle. If claude is STILL in a turn, this
-    // handback is not orphaned — it is correctly enqueued behind the in-flight
-    // turn (a long parent turn can run many minutes). Finalizing now would post
-    // a false "never started — needs a nudge" card (the 3-cards-in-4-min
-    // incident). Defer: re-arm and re-check. We finalize only once claude is
-    // idle AND the handback still has not been adopted (the genuine bridge-
-    // death / dropped-inbound case). This cannot loop forever on a healthy
-    // agent: claude processes its queue FIFO, so the handback is either adopted
-    // (cancelling the reap) or claude eventually goes idle (letting it fire).
-    if (deps.isClaudeBusy?.() === true) {
+    // only when claude next goes idle. If claude is STILL in a turn, OR the
+    // handback was delivered and its turn has simply not started streaming yet
+    // (within the delivered TTL — the #4027 coverage gap), the handback is NOT
+    // orphaned. Reaping now would have posted a false "never started — needs a
+    // nudge" card (the 3-cards-in-4-min incident). Defer: re-arm and re-check.
+    // We proceed to recovery only once claude is idle AND the delivered window
+    // has elapsed AND the handback still has not been adopted (the genuine
+    // bridge-death / dropped-inbound case). This cannot loop forever: claude
+    // processes its queue FIFO (adoption cancels the reap), and the delivered
+    // TTL is bounded, so a stuck delivery eventually recovers deterministically.
+    if (deps.isClaudeBusy?.() === true || deliveredAwaitingTurnStart(entry)) {
       log(
         `handback-preturn-signal: reap deferred key=${entry.statusKey} ` +
-          `(claude busy — handback enqueued behind an in-flight turn, not orphaned)\n`,
+          `(${deps.isClaudeBusy?.() === true ? 'claude busy' : 'delivered, turn not yet streaming'}` +
+          ` — not orphaned)\n`,
       )
       entry.reapTimer = setTimer(() => reap(entry), adoptTimeoutMs)
       return
     }
     entry.consumed = true
-    // Stop the forever-running typing loop and finalize the frozen card.
+    // GENUINE ORPHAN. Recover DETERMINISTICALLY — never ask the operator to
+    // nudge. Stop the forever-running typing loop, DELETE the frozen card (do
+    // not leave a stale "needs a nudge" message), then re-inject the handback so
+    // the machine re-processes it itself. Cap the re-injections; past the cap
+    // escalate to fleet-health telemetry (NOT a chat card).
     stopTypingUnlessTurnLive(entry, 'orphan reap')
     if (entry.activityMessageId != null) {
       const record: PreTurnCardRecord = {
@@ -419,17 +503,61 @@ export function createHandbackPreturnSignal(
         startedAt: entry.startedAt,
         pinned: entry.pinned,
       }
-      // Clear the durable record BEFORE the finalizing edit (at-most-once
-      // idempotency guard, mirroring the activity-card-store reapers).
+      // Clear the durable record BEFORE the delete (at-most-once idempotency
+      // guard, mirroring the activity-card-store reapers).
       deps.clearCardRecord(entry.syntheticTurnKey, entry.activityMessageId)
-      void Promise.resolve(deps.finalizeCard(record)).catch((err) => {
+      void Promise.resolve(deps.deleteCard(record)).catch((err) => {
         log(
-          `handback-preturn-signal: orphan finalize failed key=${entry.statusKey}: ` +
+          `handback-preturn-signal: orphan card delete failed key=${entry.statusKey}: ` +
             `${err instanceof Error ? err.message : String(err)}\n`,
         )
       })
     }
+    // Drop the entry from the topic map BEFORE re-injecting so a redelivery that
+    // re-enters `noteHandbackRelease` (production: async buffer drain; possible
+    // synchronously) is not swallowed by the per-topic dedupe guard. The entry
+    // object stays valid for the captured re-inject below.
     dropEntry(entry)
+    if (entry.reinjectCount < maxReinjects) {
+      const nextCount = entry.reinjectCount + 1
+      // Stamp the counter on the inbound so it survives the buffer round trip
+      // (the re-injected inbound re-enters `noteHandbackRelease`, which reads it
+      // back — the retry cap outlives the drop-and-recreate of this entry).
+      entry.inbound.meta[HANDBACK_REINJECT_COUNT_META_KEY] = String(nextCount)
+      log(
+        `handback-preturn-signal: orphan reap key=${entry.statusKey} ` +
+          `turnId=${entry.adoptTurnId} — re-injecting handback (attempt ${nextCount}/${maxReinjects})\n`,
+      )
+      try {
+        deps.reinjectHandback(entry.inbound)
+      } catch (err) {
+        log(
+          `handback-preturn-signal: orphan re-inject failed key=${entry.statusKey}: ` +
+            `${err instanceof Error ? err.message : String(err)}\n`,
+        )
+      }
+    } else {
+      log(
+        `handback-preturn-signal: orphan reap key=${entry.statusKey} ` +
+          `turnId=${entry.adoptTurnId} — re-injection cap (${maxReinjects}) exhausted, ` +
+          `escalating to fleet-health telemetry\n`,
+      )
+      try {
+        deps.escalateOrphan({
+          statusKey: entry.statusKey,
+          chatId: entry.chatId,
+          threadId: entry.threadId,
+          adoptTurnId: entry.adoptTurnId,
+          reinjectCount: entry.reinjectCount,
+          ageMs: now() - entry.deliveredAt,
+        })
+      } catch (err) {
+        log(
+          `handback-preturn-signal: orphan escalation failed key=${entry.statusKey}: ` +
+            `${err instanceof Error ? err.message : String(err)}\n`,
+        )
+      }
+    }
   }
 
   return {
@@ -466,6 +594,12 @@ export function createHandbackPreturnSignal(
       )
       const startedAt = now()
       const syntheticTurnKey = `${PRETURN_TURNKEY_PREFIX}${statusKey}:${startedAt}`
+      // Carry the re-injection counter across the buffer round trip: a genuine
+      // orphan re-injects this inbound, which re-enters here with the counter
+      // stamped on `meta`, so the retry cap survives the entry's recreate.
+      const rawReinject = inbound.meta?.[HANDBACK_REINJECT_COUNT_META_KEY]
+      const parsedReinject = rawReinject != null ? Number.parseInt(rawReinject, 10) : 0
+      const reinjectCount = Number.isFinite(parsedReinject) && parsedReinject > 0 ? parsedReinject : 0
       const entry: PreTurnEntry = {
         statusKey,
         chatId,
@@ -473,6 +607,10 @@ export function createHandbackPreturnSignal(
         adoptTurnId,
         syntheticTurnKey,
         startedAt,
+        // Release IS the delivery point (this is the buffer-drain chokepoint).
+        deliveredAt: startedAt,
+        reinjectCount,
+        inbound,
         pinned: false,
         debounceTimer: null,
         reapTimer: null,

--- a/telegram-plugin/tests/handback-orphan-recovery.test.ts
+++ b/telegram-plugin/tests/handback-orphan-recovery.test.ts
@@ -1,0 +1,131 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createHandbackOrphanRecovery,
+  formatOrphanEscalation,
+} from '../gateway/handback-orphan-recovery.js'
+import type { HandbackOrphanEscalation, PreTurnCardRecord } from '../gateway/handback-preturn-signal.js'
+import type { InboundMessage } from '../gateway/ipc-protocol.js'
+
+/**
+ * Unit test for the gateway-side EFFECTS of deterministic handback-orphan
+ * recovery, extracted out of gateway.ts (switchroom#2996 ratchet). The seam's
+ * DECISION logic is covered by `handback-preturn-signal.test.ts`; this file
+ * asserts the three effects behave as the seam's contract requires:
+ *
+ *   - a genuine orphan's card is DELETED (never edited to a user-facing string)
+ *   - a delete failure is swallowed, so a reap is never wedged by a Telegram error
+ *   - the handback is re-injected through the pending-inbound buffer verbatim
+ *   - retry exhaustion emits greppable telemetry, NOT a chat message
+ *
+ * Uses injected spies + an injected `writeLog`, so it runs identically under
+ * vitest and bun (no fake timers, no module mocks).
+ */
+
+const record: PreTurnCardRecord = {
+  turnKey: 'preturn:chatA:_:1000',
+  chatId: 'chatA',
+  threadId: 7,
+  activityMessageId: 4242,
+  startedAt: 1000,
+  pinned: false,
+}
+
+const escalation: HandbackOrphanEscalation = {
+  statusKey: 'chatA:7',
+  chatId: 'chatA',
+  threadId: 7,
+  adoptTurnId: 'turn-abc',
+  reinjectCount: 2,
+  ageMs: 90_000,
+}
+
+function inbound(): InboundMessage {
+  return {
+    type: 'inbound',
+    chatId: 'chatA',
+    threadId: 7,
+    messageId: 900,
+    text: 'worker finished',
+    meta: { source: 'subagent_handback', handbackReinjectCount: '1' },
+  } as unknown as InboundMessage
+}
+
+describe('handback orphan recovery effects', () => {
+  it('deletes the frozen pre-turn card with its chat/message/thread identity', async () => {
+    const deleteMessage = vi.fn(async () => ({ ok: true }))
+    const r = createHandbackOrphanRecovery({
+      deleteMessage,
+      pushInbound: vi.fn(),
+      writeLog: vi.fn(),
+    })
+
+    await r.deleteCard(record)
+
+    expect(deleteMessage).toHaveBeenCalledTimes(1)
+    expect(deleteMessage).toHaveBeenCalledWith('chatA', 4242, 7)
+  })
+
+  it('swallows a delete failure so the reap is never wedged by a Telegram error', async () => {
+    const deleteMessage = vi.fn(async () => {
+      throw new Error('message to delete not found')
+    })
+    const r = createHandbackOrphanRecovery({
+      deleteMessage,
+      pushInbound: vi.fn(),
+      writeLog: vi.fn(),
+    })
+
+    await expect(r.deleteCard(record)).resolves.toBeUndefined()
+  })
+
+  it('re-injects the orphaned handback verbatim through the pending-inbound buffer', () => {
+    const pushInbound = vi.fn()
+    const r = createHandbackOrphanRecovery({
+      deleteMessage: vi.fn(async () => ({})),
+      pushInbound,
+      writeLog: vi.fn(),
+    })
+
+    const msg = inbound()
+    r.reinjectHandback(msg)
+
+    expect(pushInbound).toHaveBeenCalledTimes(1)
+    // Same object identity: the seam already stamped the retry counter on
+    // `meta`, and this effect must not rebuild or strip the inbound.
+    expect(pushInbound.mock.calls[0]?.[0]).toBe(msg)
+  })
+
+  it('escalates exhausted retries to telemetry with the fleet-health join keys, not to chat', () => {
+    const writeLog = vi.fn()
+    const pushInbound = vi.fn()
+    const deleteMessage = vi.fn(async () => ({}))
+    const r = createHandbackOrphanRecovery({ deleteMessage, pushInbound, writeLog })
+
+    r.escalateOrphan(escalation)
+
+    expect(writeLog).toHaveBeenCalledTimes(1)
+    const line = writeLog.mock.calls[0]?.[0] as string
+    expect(line).toContain('handback orphan escalation')
+    expect(line).toContain('key=chatA:7')
+    expect(line).toContain('turnId=turn-abc')
+    expect(line).toContain('reinjects=2')
+    expect(line).toContain('ageMs=90000')
+    expect(line.endsWith('\n')).toBe(true)
+    // Escalation is telemetry-only: it must not touch any chat transport.
+    expect(deleteMessage).not.toHaveBeenCalled()
+    expect(pushInbound).not.toHaveBeenCalled()
+  })
+
+  it('formatOrphanEscalation is a single line (one log record, not a multi-line blob)', () => {
+    const line = formatOrphanEscalation(escalation)
+    expect(line.trimEnd().split('\n')).toHaveLength(1)
+  })
+
+  it('the operator-facing "needs a nudge" string is gone from the recovery module', () => {
+    const src = readFileSync(new URL('../gateway/handback-orphan-recovery.ts', import.meta.url), 'utf8')
+    expect(src).not.toContain('it may need a nudge')
+  })
+})

--- a/telegram-plugin/tests/handback-preturn-signal.test.ts
+++ b/telegram-plugin/tests/handback-preturn-signal.test.ts
@@ -1,9 +1,13 @@
+import { readFileSync } from 'node:fs'
+
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   createHandbackPreturnSignal,
   isHandbackInbound,
+  HANDBACK_REINJECT_COUNT_META_KEY,
   PRETURN_TURNKEY_PREFIX,
+  type HandbackOrphanEscalation,
   type HandbackPreturnSignalDeps,
   type PreTurnCardRecord,
 } from '../gateway/handback-preturn-signal.js'
@@ -136,9 +140,13 @@ interface Harness {
   sched: ReturnType<typeof makeScheduler>
   sendChatAction: ReturnType<typeof vi.fn>
   openCard: ReturnType<typeof vi.fn>
-  finalizeCard: ReturnType<typeof vi.fn>
+  deleteCard: ReturnType<typeof vi.fn>
+  reinjectHandback: ReturnType<typeof vi.fn>
+  escalateOrphan: ReturnType<typeof vi.fn>
   records: Map<string, PreTurnCardRecord>
-  finalizedIds: number[]
+  deletedIds: number[]
+  reinjected: InboundMessage[]
+  escalations: HandbackOrphanEscalation[]
 }
 
 const harnesses: Harness[] = []
@@ -168,9 +176,19 @@ function makeHarness(overrides: Partial<HandbackPreturnSignalDeps> = {}): Harnes
     if (cur != null && cur.activityMessageId === activityMessageId) records.delete(turnKey)
   }
 
-  const finalizedIds: number[] = []
-  const finalizeCard = vi.fn<(r: PreTurnCardRecord) => void>((r) => {
-    finalizedIds.push(r.activityMessageId)
+  const deletedIds: number[] = []
+  const deleteCard = vi.fn<(r: PreTurnCardRecord) => void>((r) => {
+    deletedIds.push(r.activityMessageId)
+  })
+
+  const reinjected: InboundMessage[] = []
+  const reinjectHandback = vi.fn<(m: InboundMessage) => void>((m) => {
+    reinjected.push(m)
+  })
+
+  const escalations: HandbackOrphanEscalation[] = []
+  const escalateOrphan = vi.fn<(e: HandbackOrphanEscalation) => void>((e) => {
+    escalations.push(e)
   })
 
   const signal = createHandbackPreturnSignal({
@@ -179,7 +197,9 @@ function makeHarness(overrides: Partial<HandbackPreturnSignalDeps> = {}): Harnes
     startTypingLoop: (c, t) => typing.start(c, t),
     stopTypingLoop: (c, t) => typing.stop(c, t),
     openCard,
-    finalizeCard,
+    deleteCard,
+    reinjectHandback,
+    escalateOrphan,
     writeCardRecord,
     clearCardRecord,
     now: sched.now,
@@ -187,10 +207,28 @@ function makeHarness(overrides: Partial<HandbackPreturnSignalDeps> = {}): Harnes
     clearTimer: sched.clearTimer,
     debounceMs: 700,
     adoptTimeoutMs: 30_000,
+    // Default the delivered-window TTL to 0 so tests that exercise the reap
+    // MECHANICS (idle-orphan, #3544 typing, isClaudeBusy gate) see the reap fire
+    // at the adopt timeout exactly as before this fix. Tests that specifically
+    // assert the delivered-but-not-yet-streaming deferral opt into a real TTL.
+    deliveredTtlMs: 0,
     ...overrides,
   })
 
-  const h: Harness = { signal, typing, sched, sendChatAction, openCard, finalizeCard, records, finalizedIds }
+  const h: Harness = {
+    signal,
+    typing,
+    sched,
+    sendChatAction,
+    openCard,
+    deleteCard,
+    reinjectHandback,
+    escalateOrphan,
+    records,
+    deletedIds,
+    reinjected,
+    escalations,
+  }
   harnesses.push(h)
   return h
 }
@@ -283,7 +321,7 @@ describe('handback-preturn-signal — dead-air pre-turn emit→adopt→reap', ()
     expect(h.signal.pendingCount()).toBe(0)
   })
 
-  it('never-adopted handback self-reaps its frozen card past the TTL', async () => {
+  it('never-adopted handback self-reaps: DELETES the frozen card and re-injects (deterministic recovery, no nudge)', async () => {
     const h = makeHarness()
     h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatD', messageId: 77 }))
     await h.sched.advance(700)
@@ -291,10 +329,15 @@ describe('handback-preturn-signal — dead-air pre-turn emit→adopt→reap', ()
     expect(h.typing.activeCount()).toBe(1)
     expect(h.records.size).toBe(1)
 
-    // No enqueue ever arrives. Past the adopt TTL the orphan self-reaps.
+    // No enqueue ever arrives. Past the adopt TTL the orphan self-reaps into
+    // deterministic recovery: the frozen card is DELETED (never rewritten to a
+    // user-facing "needs a nudge" string) and the handback is re-injected.
     await h.sched.advance(30_000)
 
-    expect(h.finalizedIds).toEqual([resolvedId]) // finalized exactly THAT card
+    expect(h.deletedIds).toEqual([resolvedId]) // deleted exactly THAT card
+    expect(h.reinjected).toHaveLength(1) // re-injected for the machine to recover itself
+    expect(h.reinjected[0]!.meta[HANDBACK_REINJECT_COUNT_META_KEY]).toBe('1')
+    expect(h.escalations).toEqual([]) // first orphan → recover, do NOT escalate
     expect(h.typing.activeCount()).toBe(0) // typing stopped
     expect(h.records.size).toBe(0) // durable record cleared (at-most-once)
     expect(h.signal.pendingCount()).toBe(0) // map empty
@@ -326,18 +369,20 @@ describe('handback-preturn-signal — dead-air pre-turn emit→adopt→reap', ()
     // DEFER each time: no false orphan card, entry still live, typing still lit.
     await h.sched.advance(30_000)
     await h.sched.advance(30_000)
-    expect(h.finalizedIds).toEqual([]) // NEVER posted the "never started" nudge
+    expect(h.deletedIds).toEqual([]) // NEVER reaped: card intact
+    expect(h.reinjected).toEqual([]) // NEVER re-injected while enqueued
     expect(h.signal.pendingCount()).toBe(1) // still queued, not reaped
     expect(h.typing.activeCount()).toBe(1) // indicator kept while queued
 
     // The parent turn finally ends and the handback mints its own turn: it
-    // adopts the SAME card (an edit, not a second send / not an orphan finalize).
+    // adopts the SAME card (an edit, not a second send / not an orphan reap).
     busy = false
     const turnId = deriveTurnId('chatBusy', null, 700)!
     const adoption = h.signal.tryAdopt(turnId)
     expect(adoption).not.toBeNull()
     expect(adoption!.activityMessageId).toBe(resolvedId)
-    expect(h.finalizedIds).toEqual([]) // adopted, never finalized as orphan
+    expect(h.deletedIds).toEqual([]) // adopted, never reaped as orphan
+    expect(h.reinjected).toEqual([])
     expect(h.openCard).toHaveBeenCalledTimes(1) // no double-send
     expect(h.signal.pendingCount()).toBe(0)
   })
@@ -345,7 +390,7 @@ describe('handback-preturn-signal — dead-air pre-turn emit→adopt→reap', ()
   // The deferred reap is not a leak: once claude goes idle and the handback has
   // STILL not been adopted (genuine bridge-death / dropped inbound), the re-armed
   // reap finalizes honestly — the degenerate case the reap exists for.
-  it('finalizes a genuine orphan once claude goes idle, even after deferring while busy', async () => {
+  it('recovers a genuine orphan once claude goes idle, even after deferring while busy', async () => {
     let busy = true
     const h = makeHarness({ isClaudeBusy: () => busy })
     h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatIdleOrphan', messageId: 710 }))
@@ -354,17 +399,167 @@ describe('handback-preturn-signal — dead-air pre-turn emit→adopt→reap', ()
 
     // Busy: the first reap defers.
     await h.sched.advance(30_000)
-    expect(h.finalizedIds).toEqual([])
+    expect(h.deletedIds).toEqual([])
+    expect(h.reinjected).toEqual([])
     expect(h.signal.pendingCount()).toBe(1)
 
     // Claude goes idle but NO adopting turn ever mints (the inbound was dropped).
-    // The re-armed reap now finalizes the genuine orphan.
+    // The re-armed reap now recovers the genuine orphan: delete + re-inject.
     busy = false
     await h.sched.advance(30_000)
-    expect(h.finalizedIds).toEqual([resolvedId])
+    expect(h.deletedIds).toEqual([resolvedId])
+    expect(h.reinjected).toHaveLength(1)
     expect(h.typing.activeCount()).toBe(0)
     expect(h.records.size).toBe(0)
     expect(h.signal.pendingCount()).toBe(0)
+  })
+
+  // ── #4027 coverage gap: delivered-but-not-yet-streaming is NOT an orphan ──
+  // A handback that WAS delivered into claude's queue but whose adopting turn
+  // has not started streaming yet reads as idle (`isClaudeBusy()` false) + un-
+  // adopted — which #4027 still finalized as a false "needs a nudge" card. The
+  // `deliveredAwaitingTurnStart` gate DEFERS the reap for the whole delivered
+  // TTL. This test FAILS on revert of the gate: without it the reap fires at the
+  // 30 s adopt timeout (idle, un-adopted) and reaps a healthy delivery.
+  it('does NOT reap a delivered-but-not-yet-streaming handback within the delivered TTL', async () => {
+    // Real delivered TTL, no busy signal — the ONLY thing that can defer the
+    // reap here is the delivered-window gate.
+    const h = makeHarness({ deliveredTtlMs: 300_000 })
+    h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatDeliv', messageId: 800 }))
+    await h.sched.advance(700)
+    const resolvedId = await h.openCard.mock.results[0]!.value
+    expect(h.records.size).toBe(1)
+
+    // Well past the 30 s adopt timeout but comfortably within the 5 min TTL: the
+    // reap must DEFER every tick — no delete, no re-inject, entry still live,
+    // typing still lit. (Pre-fix this fired a false orphan at 30 s.)
+    await h.sched.advance(120_000)
+    expect(h.deletedIds).toEqual([])
+    expect(h.reinjected).toEqual([])
+    expect(h.escalations).toEqual([])
+    expect(h.signal.pendingCount()).toBe(1)
+    expect(h.typing.activeCount()).toBe(1)
+
+    // The turn finally starts streaming and adopts the SAME card — an edit, not
+    // an orphan reap, and no double-send.
+    const turnId = deriveTurnId('chatDeliv', null, 800)!
+    const adoption = h.signal.tryAdopt(turnId)
+    expect(adoption).not.toBeNull()
+    expect(adoption!.activityMessageId).toBe(resolvedId)
+    expect(h.deletedIds).toEqual([])
+    expect(h.reinjected).toEqual([])
+    expect(h.openCard).toHaveBeenCalledTimes(1)
+    expect(h.signal.pendingCount()).toBe(0)
+  })
+
+  it('reaps a delivered handback ONCE the delivered TTL elapses (deterministic recovery, still no nudge)', async () => {
+    const h = makeHarness({ deliveredTtlMs: 300_000 })
+    h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatStuck', messageId: 801 }))
+    await h.sched.advance(700)
+    const resolvedId = await h.openCard.mock.results[0]!.value
+
+    // Within the TTL: deferred.
+    await h.sched.advance(120_000)
+    expect(h.deletedIds).toEqual([])
+
+    // Past the TTL a truly-stuck delivery finally reaps into recovery rather than
+    // hanging forever — delete + re-inject, never a nudge card.
+    await h.sched.advance(210_000)
+    expect(h.deletedIds).toEqual([resolvedId])
+    expect(h.reinjected).toHaveLength(1)
+    expect(h.escalations).toEqual([])
+    expect(h.signal.pendingCount()).toBe(0)
+  })
+
+  // ── deterministic-recovery retry cap: re-inject up to 2×, THEN escalate ──
+  // A genuine orphan whose re-injections keep coming back orphaned must not loop
+  // forever, and must NEVER fall back to a chat nudge. After `maxReinjects` it
+  // escalates to fleet-health telemetry (the `escalateOrphan` sink). The retry
+  // counter rides `HANDBACK_REINJECT_COUNT_META_KEY` on the inbound across the
+  // buffer round trip, so the cap survives the drop-and-recreate of the entry.
+  it('re-injects a persistently-orphaned handback up to the cap, then escalates (never a nudge)', async () => {
+    const sched = makeScheduler()
+    const sendChatAction = vi.fn<(c: string, t: number | null) => void>()
+    const typing = createTurnTypingLoop({
+      sendChatAction,
+      chatKey: (c, t) => chatKey(c, t),
+      refreshMs: 4000,
+    })
+    let msgSeq = 5000
+    const deletedIds: number[] = []
+    const reinjectedCounts: (string | undefined)[] = []
+    const escalations: HandbackOrphanEscalation[] = []
+    const records = new Map<string, PreTurnCardRecord>()
+
+    // eslint-disable-next-line prefer-const
+    let signal: ReturnType<typeof createHandbackPreturnSignal>
+    signal = createHandbackPreturnSignal({
+      chatKey: (c, t) => chatKey(c, t),
+      deriveTurnId,
+      startTypingLoop: (c, t) => typing.start(c, t),
+      stopTypingLoop: (c, t) => typing.stop(c, t),
+      openCard: async () => ++msgSeq,
+      deleteCard: (r) => {
+        deletedIds.push(r.activityMessageId)
+      },
+      // Simulate the buffer round trip: a re-injected orphan comes straight back
+      // through the release chokepoint carrying its stamped retry counter.
+      reinjectHandback: (m) => {
+        reinjectedCounts.push(m.meta[HANDBACK_REINJECT_COUNT_META_KEY])
+        signal.noteHandbackRelease(m)
+      },
+      escalateOrphan: (e) => {
+        escalations.push(e)
+      },
+      writeCardRecord: (r) => {
+        records.set(r.turnKey, r)
+      },
+      clearCardRecord: (turnKey, id) => {
+        const cur = records.get(turnKey)
+        if (cur != null && cur.activityMessageId === id) records.delete(turnKey)
+      },
+      now: sched.now,
+      setTimer: sched.setTimer,
+      clearTimer: sched.clearTimer,
+      debounceMs: 700,
+      adoptTimeoutMs: 30_000,
+      deliveredTtlMs: 0, // no delivered-window deferral: exercise the retry cap directly
+      maxReinjects: 2,
+    })
+
+    try {
+      signal.noteHandbackRelease(handbackInbound({ chatId: 'chatCap', messageId: 802 }))
+      // Drive several reap cycles: each orphan deletes its card, re-injects (up
+      // to the cap), which re-arms the seam via the simulated round trip.
+      await sched.advance(200_000)
+
+      // Exactly 2 re-injections, stamped 1 then 2, then a single escalation.
+      expect(reinjectedCounts).toEqual(['1', '2'])
+      expect(escalations).toHaveLength(1)
+      expect(escalations[0]!.reinjectCount).toBe(2)
+      // One card deleted per orphan cycle (initial + 2 re-injected), never edited
+      // to a "needs a nudge" string.
+      expect(deletedIds).toHaveLength(3)
+      expect(signal.pendingCount()).toBe(0)
+    } finally {
+      typing.stopAll()
+    }
+  })
+
+  // ── the user-facing "needs a nudge" string is GONE from the gateway source ──
+  // Part A of the fix removed the operator-facing card text entirely; the orphan
+  // path now deletes + re-injects. This is a durable regression guard: it FAILS
+  // if the string is reintroduced anywhere in the gateway source.
+  it('the "may need a nudge" user-facing string is absent from the gateway source', () => {
+    const gatewaySrc = readFileSync(
+      new URL('../gateway/gateway.ts', import.meta.url),
+      'utf8',
+    )
+    // The literal user-facing phrase must not appear as a rendered string. (The
+    // only surviving mentions are historical CODE COMMENTS explaining the removal
+    // — assert the load-bearing card fragment is gone from any send/edit call.)
+    expect(gatewaySrc).not.toContain('it may need a nudge')
+    expect(gatewaySrc).not.toContain('HANDBACK_PRETURN_ORPHAN_HTML')
   })
 
   it('identity race: a user inbound on the same topic never mis-adopts the handback, no double-send', async () => {


### PR DESCRIPTION
## Problem

When a background workflow subagent finished, the gateway would sometimes edit its handback pre-turn card to:

> 🤝 A background worker finished, but the handback never started — it may need a nudge.

That card asks the operator to manually recover a system that should recover itself, and it fired as a **false orphan**: the handback *was* delivered, the adopting turn just hadn't started streaming yet inside the 30s reap window. A heavy workflow spinning up 9-11 workers blew past that window and produced 3 false nudge cards.

#4027 gated the reap on `isMachineInTurn()` but left the "delivered-but-not-yet-streaming" window open — idle machine + un-adopted still read as a genuine orphan.

## Fix

**A) Deterministic recovery on a genuine orphan (stop asking the human).**
The reap now deletes the frozen pre-turn card and re-injects the handback through the pending-inbound buffer so the machine re-processes it. Re-injections are capped (`maxReinjects`, default 2, carried across the buffer round trip via `HANDBACK_REINJECT_COUNT_META_KEY`); past the cap it escalates to fleet-health telemetry (a structured gateway-log line), never a chat card. The user-facing "needs a nudge" string is removed entirely.

**B) Close the delivered-window race so genuine orphans are rare.**
The reap gate extends from `isClaudeBusy()` to `isClaudeBusy() || deliveredAwaitingTurnStart()`. `deliveredAt` is stamped at the handback release site (`noteHandbackRelease`) and bounded by a ~5min TTL (`deliveredTtlMs`), so a delivered-but-not-yet-streaming handback defers instead of false-reaping, while a truly-stuck delivery still eventually reaps into deterministic recovery.

## Validation

- 17/17 tests passing, typecheck clean.
- Revert-check performed: reverting the fix makes the new tests fail, confirming they assert the bug rather than just the code path.

Closes #4027 (delivered-window race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
