### PR TITLE
feat(agents): resolve thinking_effort live from switchroom.yaml at boot

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -2033,6 +2033,10 @@ esac
 _BAKED_EFFORT={{#if thinkingEffort}}'{{thinkingEffort}}'{{else}}''{{/if}}
 _LKG_EFFORT="$(cat "{{agentDir}}/.configured-default-effort" 2>/dev/null | tr -d '[:space:]' || true)"
 _EFFECTIVE_EFFORT=""
+# Set only when step 1 actually produced a live value — it gates the
+# `.configured-default-effort` write below so the last-known-good file can
+# never record a value that was never live truth.
+_LE_LIVE_OK=""
 if [ -n "$SWITCHROOM_CONFIG" ] && [ -f "$SWITCHROOM_CONFIG" ] && command -v switchroom >/dev/null 2>&1; then
   _le_live=""
   for _le_try in 1 2; do
@@ -2048,6 +2052,7 @@ if [ -n "$SWITCHROOM_CONFIG" ] && [ -f "$SWITCHROOM_CONFIG" ] && command -v swit
   done
   if [ -n "$_le_live" ]; then
     _EFFECTIVE_EFFORT="$_le_live"
+    _LE_LIVE_OK=1
     if [ "$_le_live" != "$_BAKED_EFFORT" ]; then
       echo "session-effort: live configured thinking_effort '$_le_live' differs from apply-time bake '${_BAKED_EFFORT:-<unset>}' — using the live value (switchroom.yaml is the source of truth)" >&2
     fi
@@ -2056,22 +2061,29 @@ if [ -n "$SWITCHROOM_CONFIG" ] && [ -f "$SWITCHROOM_CONFIG" ] && command -v swit
     # Last-known-good beats the bake: it was live truth on a prior boot, while
     # the bake can predate any number of yaml edits. Loud either way.
     _EFFECTIVE_EFFORT="$_LKG_EFFORT"
-    echo "session-effort: live config read FAILED — using last-known-good configured thinking_effort '$_LKG_EFFORT' (apply-time bake: '${_BAKED_EFFORT:-<unset>}')" >&2
-    printf 'switchroom.yaml could not be read at boot, so the agent booted on the last-known-good configured effort `%s`. If you just changed `thinking_effort:`, check the yaml for errors and restart the agent.\n' "$_LKG_EFFORT" >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+    echo "session-effort: live effort read FAILED or returned an unrecognised level — using last-known-good configured thinking_effort '$_LKG_EFFORT' (apply-time bake: '${_BAKED_EFFORT:-<unset>}')" >&2
+    printf 'The live `thinking_effort:` could not be resolved at boot — switchroom.yaml could not be read, or it held a value this launcher does not recognise. The agent booted on the last-known-good configured effort `%s`. Check `thinking_effort:` in the yaml (low/medium/high/xhigh/max) and restart the agent.\n' "$_LKG_EFFORT" >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
   else
     _EFFECTIVE_EFFORT="$_BAKED_EFFORT"
-    echo "session-effort: live config read FAILED and no last-known-good value — using apply-time baked thinking_effort '${_BAKED_EFFORT:-<unset>}'" >&2
-    printf 'switchroom.yaml could not be read at boot and no prior boot recorded an effort, so the agent booted on the apply-time default `%s`. If you just changed `thinking_effort:`, check the yaml for errors and restart the agent.\n' "${_BAKED_EFFORT:-<unset>}" >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+    echo "session-effort: live effort read FAILED or returned an unrecognised level, and no last-known-good value — using apply-time baked thinking_effort '${_BAKED_EFFORT:-<unset>}'" >&2
+    printf 'The live `thinking_effort:` could not be resolved at boot — switchroom.yaml could not be read, or it held a value this launcher does not recognise — and no prior boot recorded an effort. The agent booted on the apply-time default `%s`. Check `thinking_effort:` in the yaml (low/medium/high/xhigh/max) and restart the agent.\n' "${_BAKED_EFFORT:-<unset>}" >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
   fi
   unset _le_live _le_try
 else
   _EFFECTIVE_EFFORT="$_BAKED_EFFORT"
 fi
 unset _BAKED_EFFORT _LKG_EFFORT
-# Record the RESOLVED configured default every boot, BEFORE the carrier below
-# can override it — this is the last-known-good the fallback chain reads on the
+# Record the LIVE-RESOLVED configured default, BEFORE the carrier below can
+# override it — this is the last-known-good the fallback chain reads on the
 # NEXT boot, and it must be the configured value, not a session override.
-printf '%s\n' "$_EFFECTIVE_EFFORT" > "{{agentDir}}/.configured-default-effort" 2>/dev/null || true
+# Written ONLY when step 1 genuinely produced a live value: a bake/LKG-fallback
+# boot (or a boot with no config mount at all) has no live truth to record, and
+# writing the bake here would let a LATER failed read cite a "last-known-good"
+# that was never read from switchroom.yaml.
+if [ -n "$_LE_LIVE_OK" ]; then
+  printf '%s\n' "$_EFFECTIVE_EFFORT" > "{{agentDir}}/.configured-default-effort" 2>/dev/null || true
+fi
+unset _LE_LIVE_OK
 if [ -f "{{agentDir}}/.session-effort" ]; then
   _sef="$(cat "{{agentDir}}/.session-effort" 2>/dev/null || true)"
   _se_level="$(printf '%s' "$_sef" | sed -n 's/.*"level"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -2002,10 +2002,76 @@ esac
 # changed) appends to `.session-model-alert` so the gateway's boot relay
 # tells the operator once.
 #
-# NB: the CONFIGURED default resolution is untouched (#3186 constraint) —
-# the configured `thinking_effort` (see #1978 /
-# src/config/thinking-effort-risk.ts) resolves exactly as before.
-_EFFECTIVE_EFFORT={{#if thinkingEffort}}'{{thinkingEffort}}'{{else}}''{{/if}}
+# --- Live configured-default resolution (effort sibling of the model block) ---
+#
+# The apply-time bake is only the LAST-DITCH fallback: editing
+# `thinking_effort:` in switchroom.yaml and restarting must take effect
+# WITHOUT a full `switchroom apply`, exactly as `model:` already does. Before
+# this, model was live-read and effort was bake-only, so a yaml effort change
+# needed an apply to re-render every start.sh — and the gateway's /effort menu
+# (which derives its configured default from `agent list --json`, i.e. the LIVE
+# yaml) disagreed with what the launcher actually passed to `--effort`.
+#
+# Same resolver as the gateway, asked as a verb (`switchroom agent
+# effective-effort`), never re-implemented in shell. Fallback chain, never
+# silent past step 1:
+#   1. live read of $SWITCHROOM_CONFIG (one bounded retry — a host-side
+#      in-place rewrite can present a torn file for a moment);
+#   2. `.configured-default-effort` — the last-known-good live value this
+#      launcher recorded on every prior boot (read BEFORE it is overwritten);
+#   3. the apply-time bake.
+# Steps 2/3 append to `.session-model-alert` so the gateway tells the operator
+# once at boot. No SWITCHROOM_CONFIG mount at all means there is nothing to
+# read live — the bake IS the truth there (stderr note only).
+#
+# Unlike the model sibling there is no routing class to flip: effort is a pure
+# CLI flag, so a live change is always safe to apply on a bare restart.
+#
+# NB {{thinkingEffort}} renders inside single quotes here (the scaffold does
+# not pre-quote it, unlike modelQ), and an unset value renders as '' — which
+# means "no --effort flag", handled by the $_EFFORT_ARG guard below.
+_BAKED_EFFORT={{#if thinkingEffort}}'{{thinkingEffort}}'{{else}}''{{/if}}
+_LKG_EFFORT="$(cat "{{agentDir}}/.configured-default-effort" 2>/dev/null | tr -d '[:space:]' || true)"
+_EFFECTIVE_EFFORT=""
+if [ -n "$SWITCHROOM_CONFIG" ] && [ -f "$SWITCHROOM_CONFIG" ] && command -v switchroom >/dev/null 2>&1; then
+  _le_live=""
+  for _le_try in 1 2; do
+    _le_live="$(timeout 20 switchroom --config "$SWITCHROOM_CONFIG" agent effective-effort "{{name}}" 2>/dev/null | tail -n 1 | tr -d '[:space:]')" || _le_live=""
+    # Allowlist gate — kept in sync with EFFORT_LEVELS in
+    # telegram-plugin/gateway/effort-command.ts, byte-identical to the carrier
+    # gate below. Anything else is treated as a failed read, not a value.
+    if [ -n "$_le_live" ] && printf '%s' "$_le_live" | grep -Eq '^(low|medium|high|xhigh|max)$'; then
+      break
+    fi
+    _le_live=""
+    if [ "$_le_try" -eq 1 ]; then sleep 1; fi
+  done
+  if [ -n "$_le_live" ]; then
+    _EFFECTIVE_EFFORT="$_le_live"
+    if [ "$_le_live" != "$_BAKED_EFFORT" ]; then
+      echo "session-effort: live configured thinking_effort '$_le_live' differs from apply-time bake '${_BAKED_EFFORT:-<unset>}' — using the live value (switchroom.yaml is the source of truth)" >&2
+    fi
+  elif [ -n "$_LKG_EFFORT" ] && printf '%s' "$_LKG_EFFORT" | grep -Eq '^(low|medium|high|xhigh|max)$'; then
+    # Live read failed (torn write mid-read, yaml schema error, CLI wedge).
+    # Last-known-good beats the bake: it was live truth on a prior boot, while
+    # the bake can predate any number of yaml edits. Loud either way.
+    _EFFECTIVE_EFFORT="$_LKG_EFFORT"
+    echo "session-effort: live config read FAILED — using last-known-good configured thinking_effort '$_LKG_EFFORT' (apply-time bake: '${_BAKED_EFFORT:-<unset>}')" >&2
+    printf 'switchroom.yaml could not be read at boot, so the agent booted on the last-known-good configured effort `%s`. If you just changed `thinking_effort:`, check the yaml for errors and restart the agent.\n' "$_LKG_EFFORT" >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+  else
+    _EFFECTIVE_EFFORT="$_BAKED_EFFORT"
+    echo "session-effort: live config read FAILED and no last-known-good value — using apply-time baked thinking_effort '${_BAKED_EFFORT:-<unset>}'" >&2
+    printf 'switchroom.yaml could not be read at boot and no prior boot recorded an effort, so the agent booted on the apply-time default `%s`. If you just changed `thinking_effort:`, check the yaml for errors and restart the agent.\n' "${_BAKED_EFFORT:-<unset>}" >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+  fi
+  unset _le_live _le_try
+else
+  _EFFECTIVE_EFFORT="$_BAKED_EFFORT"
+fi
+unset _BAKED_EFFORT _LKG_EFFORT
+# Record the RESOLVED configured default every boot, BEFORE the carrier below
+# can override it — this is the last-known-good the fallback chain reads on the
+# NEXT boot, and it must be the configured value, not a session override.
+printf '%s\n' "$_EFFECTIVE_EFFORT" > "{{agentDir}}/.configured-default-effort" 2>/dev/null || true
 if [ -f "{{agentDir}}/.session-effort" ]; then
   _sef="$(cat "{{agentDir}}/.session-effort" 2>/dev/null || true)"
   _se_level="$(printf '%s' "$_sef" | sed -n 's/.*"level"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"

--- a/src/cli/agent.test.ts
+++ b/src/cli/agent.test.ts
@@ -187,6 +187,24 @@ describe("agent effective-model command", () => {
   });
 });
 
+describe("agent effective-effort command", () => {
+  // Same contract as effective-model: start.sh shells this at every boot to
+  // resolve `thinking_effort` live from switchroom.yaml, so an unregistered
+  // verb would drop the whole fleet back to apply-time baked effort silently.
+  function findCommand(): Command | undefined {
+    const program = new Command();
+    registerAgentCommand(program);
+    const agent = program.commands.find((c) => c.name() === "agent")!;
+    return agent.commands.find((c) => c.name() === "effective-effort");
+  }
+
+  it("is registered with a required <name> argument", () => {
+    const cmd = findCommand();
+    expect(cmd).toBeDefined();
+    expect(cmd!.registeredArguments.map((a) => `${a.name()}:${a.required}`)).toEqual(["name:true"]);
+  });
+});
+
 describe("shouldAutoRestartAfterReconcile (--no-restart opt-out, switchroom#3903)", () => {
   // Regression: reconcile declared `--no-restart` but read the flag via
   // `opts.noRestart`, which Commander never sets (it exposes the negated

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -955,6 +955,31 @@ export function registerAgentCommand(program: Command): void {
       })
     );
 
+  // switchroom agent effective-effort <name>
+  //
+  // The effort sibling of `effective-model`, and for the same reason: start.sh
+  // calls it at boot against the live mounted switchroom.yaml so a
+  // `thinking_effort:` edit + restart takes effect WITHOUT a full apply. Same
+  // cascade resolver and same unset→SWITCHROOM_DEFAULT_THINKING_EFFORT fallback
+  // `agent list --json` uses for the gateway's /effort menu, so the launcher and
+  // the menu can never disagree about what the configured default is. Plain
+  // single-line stdout: the shell consumer wants a bare token.
+  agent
+    .command("effective-effort <name>")
+    .description("Print the cascade-resolved thinking effort the agent's launcher boots with")
+    .action(
+      withConfigError(async (name: string) => {
+        const config = getConfig(program);
+        const agentConfig = config.agents[name];
+        if (!agentConfig) {
+          console.error(chalk.red(`Agent "${name}" is not defined in switchroom.yaml`));
+          process.exit(1);
+        }
+        const resolved = resolveAgentConfig(config.defaults, config.profiles, agentConfig);
+        console.log(resolved.thinking_effort ?? SWITCHROOM_DEFAULT_THINKING_EFFORT);
+      })
+    );
+
   // switchroom agent status <name>
   //
   // Single-command answer to "is my agent alive and healthy?" — rolls up

--- a/tests/scaffold.session-model.test.ts
+++ b/tests/scaffold.session-model.test.ts
@@ -52,6 +52,9 @@ function makeSwitchroomConfig(name: string, agentConfig: AgentConfig): Switchroo
 }
 
 const DEFAULT_MODEL = "claude-sonnet-5";
+// SWITCHROOM_DEFAULT_THINKING_EFFORT — what an agent with no `thinking_effort:`
+// gets baked into start.sh, and what the CLI resolver returns for it.
+const DEFAULT_EFFORT = "low";
 const BLOCK_HEADER = "# --- Session model resolution";
 
 function extractBlock(startSh: string): string {
@@ -704,9 +707,32 @@ describe("scaffoldAgent: live configured-default resolution (start.sh)", () => {
     block = extractBlock(readFileSync(join(agentDir, "start.sh"), "utf-8"));
   }
 
-  /** Install a fake `switchroom` CLI; its stdout/exit code drive the live read. */
-  function fakeSwitchroom(body: string): void {
-    writeFileSync(join(fakeBin, "switchroom"), `#!/bin/bash\necho "$@" >> ${JSON.stringify(join(fakeBin, "args.log"))}\n${body}\n`);
+  /**
+   * Install a fake `switchroom` CLI; its stdout/exit code drive the live read.
+   *
+   * Dispatches PER VERB. The launcher now makes two live reads per boot
+   * (`agent effective-model` and `agent effective-effort`), so a single body
+   * that answers every verb with a model name makes the effort read see
+   * `fable`, fail its level allowlist, and spuriously append a
+   * `.session-model-alert` line — which is exactly how this PR first broke
+   * three model-side tests. `effortBody` defaults to the level the scaffold
+   * bakes, i.e. "the yaml agrees with the bake": no drift, no alert.
+   */
+  function fakeSwitchroom(body: string, effortBody = `echo ${DEFAULT_EFFORT}`): void {
+    const script = [
+      "#!/bin/bash",
+      `echo "$@" >> ${JSON.stringify(join(fakeBin, "args.log"))}`,
+      'case "$*" in',
+      "  *effective-effort*)",
+      effortBody,
+      "    ;;",
+      "  *)",
+      body,
+      "    ;;",
+      "esac",
+      "",
+    ].join("\n");
+    writeFileSync(join(fakeBin, "switchroom"), script);
     chmodSync(join(fakeBin, "switchroom"), 0o755);
   }
 
@@ -715,7 +741,8 @@ describe("scaffoldAgent: live configured-default resolution (start.sh)", () => {
     return existsSync(p) ? readFileSync(p, "utf-8") : "";
   }
 
-  function runLive(litellmOk = "1"): string {
+  /** Run the rendered block; report BOTH resolved values plus the `--effort` argv. */
+  function runLiveResolved(litellmOk = "1"): { model: string; effort: string; effortArg: string } {
     const script = [
       "set -e",
       `export PATH=${JSON.stringify(fakeBin)}:"$PATH"`,
@@ -727,10 +754,19 @@ describe("scaffoldAgent: live configured-default resolution (start.sh)", () => {
       `_LITELLM_OK=${JSON.stringify(litellmOk)}`,
       block,
       'echo "EFFECTIVE=$_EFFECTIVE_MODEL"',
+      'echo "EFFORT=$_EFFECTIVE_EFFORT"',
+      'echo "EFFORTARG=$_EFFORT_ARG"',
     ].join("\n");
     const out = execFileSync("bash", ["-c", script], { encoding: "utf-8" });
-    const m = out.match(/EFFECTIVE=(.*)/);
-    return m ? m[1].trim() : "";
+    const pick = (label: string): string => {
+      const m = out.match(new RegExp(`^${label}=(.*)$`, "m"));
+      return m ? m[1].trim() : "";
+    };
+    return { model: pick("EFFECTIVE"), effort: pick("EFFORT"), effortArg: pick("EFFORTARG") };
+  }
+
+  function runLive(litellmOk = "1"): string {
+    return runLiveResolved(litellmOk).model;
   }
 
   function alertText(): string {
@@ -896,6 +932,202 @@ if [ -f "$marker" ]; then echo claude-opus-4-8; else touch "$marker"; echo "mang
     const idxLkg = startSh.indexOf('_LKG_MODEL="$(cat');
     expect(idxLkg).toBeGreaterThan(-1);
     expect(idxLkg).toBeLessThan(idxRecord);
+  });
+});
+
+// ── Live configured-default EFFORT resolution (effort sibling of the above) ──
+//
+// `thinking_effort:` is resolved live at boot from the mounted switchroom.yaml
+// via `switchroom agent effective-effort`, exactly as `model:` is — editing the
+// yaml and restarting must take effect WITHOUT a full `switchroom apply`.
+// These are EXECUTED tests against the rendered block with a fake CLI on PATH:
+// string-containment on the template cannot tell a wired feature from an inert
+// one (inverting the live-branch guard leaves every asserted string present),
+// and green-CI-over-inert-feature is this repo's dominant failure mode.
+describe("scaffoldAgent: live configured-default effort resolution (start.sh)", () => {
+  let tmpDir: string;
+  let agentDir: string;
+  let block: string;
+  let fakeBin: string;
+  let cfgPath: string;
+
+  /** Scaffold with an explicit apply-time bake so live≠bake is unambiguous. */
+  function scaffold(bakedEffort?: string): void {
+    const name = "live-effort-agent";
+    const config = makeAgentConfig(
+      bakedEffort ? ({ thinking_effort: bakedEffort } as Partial<AgentConfig>) : {},
+    );
+    const res = scaffoldAgent(name, config, tmpDir, telegramConfig, makeSwitchroomConfig(name, config));
+    agentDir = res.agentDir;
+    block = extractBlock(readFileSync(join(agentDir, "start.sh"), "utf-8"));
+  }
+
+  /** Fake CLI: `effortBody` answers `agent effective-effort`, model is sane. */
+  function fakeSwitchroom(effortBody: string): void {
+    const script = [
+      "#!/bin/bash",
+      `echo "$@" >> ${JSON.stringify(join(fakeBin, "args.log"))}`,
+      'case "$*" in',
+      "  *effective-effort*)",
+      effortBody,
+      "    ;;",
+      "  *)",
+      `    echo ${DEFAULT_MODEL}`,
+      "    ;;",
+      "esac",
+      "",
+    ].join("\n");
+    writeFileSync(join(fakeBin, "switchroom"), script);
+    chmodSync(join(fakeBin, "switchroom"), 0o755);
+  }
+
+  function fakeArgs(): string {
+    const p = join(fakeBin, "args.log");
+    return existsSync(p) ? readFileSync(p, "utf-8") : "";
+  }
+
+  function runLive(): { effort: string; effortArg: string } {
+    const script = [
+      "set -e",
+      `export PATH=${JSON.stringify(fakeBin)}:"$PATH"`,
+      `export SWITCHROOM_CONFIG=${JSON.stringify(cfgPath)}`,
+      "unset ANTHROPIC_BASE_URL SWITCHROOM_LITELLM_DECLARED",
+      '_LITELLM_OK="1"',
+      block,
+      'echo "EFFORT=$_EFFECTIVE_EFFORT"',
+      'echo "EFFORTARG=$_EFFORT_ARG"',
+    ].join("\n");
+    const out = execFileSync("bash", ["-c", script], { encoding: "utf-8" });
+    const pick = (label: string): string => {
+      const m = out.match(new RegExp(`^${label}=(.*)$`, "m"));
+      return m ? m[1].trim() : "";
+    };
+    return { effort: pick("EFFORT"), effortArg: pick("EFFORTARG") };
+  }
+
+  function alertText(): string {
+    const p = join(agentDir, ".session-model-alert");
+    return existsSync(p) ? readFileSync(p, "utf-8") : "";
+  }
+
+  const lkgPath = (): string => join(agentDir, ".configured-default-effort");
+  function lkg(): string {
+    return existsSync(lkgPath()) ? readFileSync(lkgPath(), "utf-8").trim() : "";
+  }
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-live-effort-"));
+    // /tmp is noexec in the dev container — the fake CLI must live on an
+    // exec-capable fs or every live read silently fails (exit 126). Same
+    // convention as the model suite above.
+    fakeBin = mkdtempSync(join("/var/tmp", "switchroom-live-effort-bin-"));
+    cfgPath = join(tmpDir, "switchroom.yaml");
+    writeFileSync(cfgPath, "agents: {}\n");
+    scaffold("low");
+  });
+
+  afterEach(() => {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+    if (fakeBin) rmSync(fakeBin, { recursive: true, force: true });
+  });
+
+  // THE regression test for the bug this PR fixes: yaml effort edited after
+  // apply (bake still low) + plain restart → boots the LIVE level.
+  it("boots the LIVE yaml effort when it differs from the apply-time bake", () => {
+    fakeSwitchroom("    echo high");
+    const { effort, effortArg } = runLive();
+    expect(effort).toBe("high");
+    expect(effortArg).toBe("--effort high"); // what claude is actually launched with
+    // Resolved via the CLI verb against the LIVE mounted config, not re-derived.
+    expect(fakeArgs()).toContain("--config");
+    expect(fakeArgs()).toContain("agent effective-effort live-effort-agent");
+    // Live value becomes the next boot's last-known-good, and no operator alert.
+    expect(lkg()).toBe("high");
+    expect(alertText()).toBe("");
+  });
+
+  it("retries once on a torn/failed first read, then uses the live value", () => {
+    const marker = join(fakeBin, "second-effort-call");
+    fakeSwitchroom(
+      `    if [ -f ${JSON.stringify(marker)} ]; then echo max; else touch ${JSON.stringify(marker)}; exit 1; fi`,
+    );
+    expect(runLive().effort).toBe("max");
+    expect(alertText()).toBe("");
+  });
+
+  it("live read fails → falls back to last-known-good with an operator alert", () => {
+    writeFileSync(lkgPath(), "xhigh\n");
+    fakeSwitchroom("    exit 1");
+    const { effort, effortArg } = runLive();
+    expect(effort).toBe("xhigh"); // NOT the 'low' bake
+    expect(effortArg).toBe("--effort xhigh");
+    expect(alertText()).toContain("last-known-good configured effort `xhigh`");
+    // Nothing was live-read this boot, so the LKG must survive unchanged —
+    // overwriting it with the fallback would let a later failed read cite a
+    // "last-known-good" that was never live truth.
+    expect(lkg()).toBe("xhigh");
+  });
+
+  it("live read fails with no last-known-good → falls back to the bake with an operator alert", () => {
+    fakeSwitchroom("    exit 1");
+    expect(runLive().effort).toBe("low");
+    expect(alertText()).toContain("apply-time default `low`");
+    // Bake-fallback boot: no live truth to record, so no LKG is written.
+    expect(lkg()).toBe("");
+  });
+
+  it("an unrecognised level fails the allowlist and falls back (never reaches --effort)", () => {
+    // e.g. the fable/model-name confusion, or a typo'd yaml level.
+    fakeSwitchroom("    echo fable");
+    const { effort, effortArg } = runLive();
+    expect(effort).toBe("low");
+    expect(effortArg).toBe("--effort low");
+    expect(effortArg).not.toContain("fable");
+    // The alert must name BOTH causes — the yaml read fine here, it just held
+    // a level this launcher does not recognise.
+    expect(alertText()).toContain("could not be read, or it held a value this launcher does not recognise");
+    expect(lkg()).toBe("");
+  });
+
+  it("no SWITCHROOM_CONFIG mount → bake, silently, and no LKG is invented", () => {
+    fakeSwitchroom("    echo high");
+    const script = [
+      "set -e",
+      `export PATH=${JSON.stringify(fakeBin)}:"$PATH"`,
+      "unset SWITCHROOM_CONFIG ANTHROPIC_BASE_URL SWITCHROOM_LITELLM_DECLARED",
+      '_LITELLM_OK="1"',
+      block,
+      'echo "EFFORT=$_EFFECTIVE_EFFORT"',
+    ].join("\n");
+    const out = execFileSync("bash", ["-c", script], { encoding: "utf-8" });
+    expect(out).toContain("EFFORT=low");
+    expect(alertText()).toBe("");
+    expect(fakeArgs()).toBe(""); // CLI never invoked
+    expect(lkg()).toBe(""); // nothing was live-read → nothing recorded
+  });
+
+  // Ordering: the live effort must land BEFORE the .session-effort carrier
+  // compare, so the carrier is invalidated against live truth, not the bake.
+  it("carrier written against a SUPERSEDED configured default is dropped (compare uses the LIVE value)", () => {
+    fakeSwitchroom("    echo high");
+    writeFileSync(
+      join(agentDir, ".session-effort"),
+      `${JSON.stringify({ level: "max", configuredDefaultAtWrite: "low", ts: Date.now() })}\n`,
+    );
+    expect(runLive().effort).toBe("high");
+    expect(alertText()).toContain("configured default effort changed");
+  });
+
+  it("a carrier written against the LIVE default still applies (override wins this boot)", () => {
+    fakeSwitchroom("    echo high");
+    writeFileSync(
+      join(agentDir, ".session-effort"),
+      `${JSON.stringify({ level: "max", configuredDefaultAtWrite: "high", ts: Date.now() })}\n`,
+    );
+    expect(runLive().effort).toBe("max");
+    // …but the recorded configured default stays the LIVE configured value,
+    // never the session override.
+    expect(lkg()).toBe("high");
   });
 });
 

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -278,9 +278,28 @@ describe("scaffoldAgent", () => {
     const result = scaffoldAgent("effort-agent", config, tmpDir, telegramConfig);
     const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
     // #3039: the configured default seeds $_EFFECTIVE_EFFORT; a durable
-    // .session-effort override may replace it at boot.
-    expect(startSh).toContain("_EFFECTIVE_EFFORT='xhigh'");
+    // .session-effort override may replace it at boot. The yaml value is
+    // baked as the LAST-DITCH fallback only — $_EFFECTIVE_EFFORT is resolved
+    // live from switchroom.yaml at boot (see the live-read test below).
+    expect(startSh).toContain("_BAKED_EFFORT='xhigh'");
     expect(startSh).toContain('--effort $_EFFECTIVE_EFFORT');
+  });
+
+  it("start.sh resolves thinking_effort LIVE from switchroom.yaml, not just the bake", () => {
+    // The effort sibling of the model live-read: editing `thinking_effort:`
+    // and restarting must take effect WITHOUT a full `switchroom apply`.
+    // Asserts the outcome that matters — the launcher asks the CLI resolver
+    // against the live mounted config and prefers its answer over the bake.
+    const config = makeAgentConfig({ thinking_effort: "high" });
+    const result = scaffoldAgent("live-effort-agent", config, tmpDir, telegramConfig);
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    expect(startSh).toContain('agent effective-effort "live-effort-agent"');
+    expect(startSh).toContain('switchroom --config "$SWITCHROOM_CONFIG" agent effective-effort');
+    // Fallback chain: live → last-known-good → bake.
+    expect(startSh).toContain("/.configured-default-effort");
+    expect(startSh).toContain('_EFFECTIVE_EFFORT="$_le_live"');
+    expect(startSh).toContain('_EFFECTIVE_EFFORT="$_LKG_EFFORT"');
+    expect(startSh).toContain('_EFFECTIVE_EFFORT="$_BAKED_EFFORT"');
   });
 
   it("start.sh defaults --effort to 'low' when thinking_effort is not set in yaml", () => {
@@ -291,15 +310,15 @@ describe("scaffoldAgent", () => {
     const config = makeAgentConfig();
     const result = scaffoldAgent("no-effort-agent", config, tmpDir, telegramConfig);
     const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
-    expect(startSh).toContain("_EFFECTIVE_EFFORT='low'");
+    expect(startSh).toContain("_BAKED_EFFORT='low'");
   });
 
   it("start.sh respects an explicit thinking_effort override", () => {
     const config = makeAgentConfig({ thinking_effort: "high" });
     const result = scaffoldAgent("explicit-effort", config, tmpDir, telegramConfig);
     const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
-    expect(startSh).toContain("_EFFECTIVE_EFFORT='high'");
-    expect(startSh).not.toContain("_EFFECTIVE_EFFORT='low'");
+    expect(startSh).toContain("_BAKED_EFFORT='high'");
+    expect(startSh).not.toContain("_BAKED_EFFORT='low'");
   });
 
   it("start.sh defaults --model to claude-sonnet-5 when model is not set in yaml", () => {
@@ -363,7 +382,7 @@ describe("scaffoldAgent", () => {
     scaffoldAgent("effort-reconcile", config, tmpDir, telegramConfig, switchroomConfig);
     reconcileAgent("effort-reconcile", config, tmpDir, telegramConfig, switchroomConfig);
     const startSh = readFileSync(join(tmpDir, "effort-reconcile", "start.sh"), "utf-8");
-    expect(startSh).toContain("_EFFECTIVE_EFFORT='medium'");
+    expect(startSh).toContain("_BAKED_EFFORT='medium'");
   });
 
   it("reconcile re-renders start.sh with permission_mode flag", () => {


### PR DESCRIPTION
## Summary

`thinking_effort:` becomes a live yaml knob, the same way `model:` already is: edit it, restart the agent, done — no full `switchroom apply` needed.

- New verb `switchroom agent effective-effort <name>` — the effort sibling of `effective-model`. Same cascade resolver, same unset → `SWITCHROOM_DEFAULT_THINKING_EFFORT` fallback that `agent list --json` uses.
- `profiles/_base/start.sh.hbs` calls it against `$SWITCHROOM_CONFIG` at boot, with the model block's never-silent fallback chain: live read (one bounded retry) → `.configured-default-effort` last-known-good → the apply-time bake. Steps 2 and 3 append to `.session-model-alert` so the gateway tells the operator once.
- The bake moves to `_BAKED_EFFORT`. `_EFFECTIVE_EFFORT` is now the resolved value, so the consume-once `.session-effort` carrier compares its `configuredDefaultAtWrite` against live truth rather than a possibly-stale render.

## Why

Two concrete problems, both hit live on 2026-08-01 moving the fleet to Opus 5 + medium:

1. **Asymmetry.** A `model:` change took effect on a bare `docker restart`; a `thinking_effort:` change silently did not. The launcher logged `session-model: live configured model 'opus' differs from apply-time bake` and booted the new model — with the old effort.
2. **Drift the operator can see.** The gateway's `/effort` menu takes its configured default from `agent list --json`, i.e. the live yaml. start.sh took it from the render. After a yaml edit without an apply, the menu and the process disagreed.

No routing-class gate is needed here (the model block has one because compose bakes routing at render time). Effort is a pure `claude --effort` flag, so a live change is always safe on a bare restart.

## Test plan

- `tests/scaffold.test.ts` — new `start.sh resolves thinking_effort LIVE from switchroom.yaml, not just the bake` asserts the launcher shells the resolver and pins all three legs of the fallback chain; existing effort tests re-pointed at `_BAKED_EFFORT`.
- `src/cli/agent.test.ts` — `effective-effort` registration test (an unregistered verb would drop the whole fleet to the bake silently, same drift class the `effective-model` test guards).
- Scoped run green: `vitest run tests/scaffold.test.ts src/cli/agent.test.ts` → 267 passed.
- Rendered block syntax-checked under both `bash -n` and `sh -n`.
- `tsc --noEmit` clean on the touched files.

**Pre-existing failure, not from this diff:** `scaffoldAgent > context7 lands on the .claude.json MCP trust allowlist` fails identically on a pristine `origin/main` worktree. Filed as a follow-up.

## Risk

Boot path for every agent, so: the fallback chain is loud at every step and the last-ditch leg is exactly today's behaviour (the bake). Worst case of a failed live read is what ships today, plus an operator alert. The live value is allowlist-gated to `low|medium|high|xhigh|max` byte-identically to the carrier gate, so a malformed read is treated as a failed read, never passed to `claude --effort`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)