### PR TITLE
fix(litellm): release the pacer concurrency lease on the passthrough path (#3549)

### DIFF
--- a/docker/litellm-pacer/custom_pacing.py
+++ b/docker/litellm-pacer/custom_pacing.py
@@ -35,6 +35,17 @@ LiteLLM v3's per-key reject-based limiter):
     PACE_LEASE_TTL_S — no leaked permanent slots).
   * Bounded global RATE: rolling 60s cap (PACE_MAX_RPM) + rolling 1s burst
     smoother (PACE_MAX_RPS).
+  * EXPLICIT LEASE RELEASE on the passthrough path. litellm exposes no
+    callback that fires on a passthrough stream, and the one
+    post_call_success_hook call site on the non-streaming passthrough path is
+    nested under a guardrails condition that is false with no passthrough
+    guardrails configured. So every passthrough request used to leak its
+    lease and only age out by TTL, which made the concurrency counter
+    meaningless and admission control fail-open in practice. Two narrow,
+    idempotent, install-once wrappers fix that — see
+    _install_streaming_release_patch / _install_nonstreaming_release_patch at
+    the bottom of this file. The lease id rides on the per-request logging
+    object because metadata is popped off the body before the upstream call.
   * ADAPTIVE 429 cooldown: async_post_call_failure_hook watches for upstream
     429s carrying Retry-After and parks a fleet-wide `pace:cooldown_until`
     in Redis. While cooling, pre_call paces harder — honoring Anthropic's
@@ -66,6 +77,7 @@ import os
 import random
 import time
 import uuid
+from collections import OrderedDict
 from typing import Any, Optional
 
 from litellm._logging import verbose_proxy_logger
@@ -136,8 +148,10 @@ class _Cfg:
     # Hard ceiling on how long a single request will wait in the pacer
     # before failing open and proceeding regardless.
     MAX_WAIT_S = _float_env("PACE_MAX_WAIT_S", 20.0)
-    # A concurrency lease auto-expires after this many seconds so a missed
-    # release (crash / streaming edge) cannot permanently consume a slot.
+    # A concurrency lease auto-expires after this many seconds. This is a
+    # BACKSTOP ONLY — since the streaming/non-streaming release patches landed
+    # the explicit release is the load-bearing mechanism, and the TTL only
+    # covers a proxy crash mid-stream. Do not remove it.
     LEASE_TTL_S = _int_env("PACE_LEASE_TTL_S", 300)
     # Cap on how long a Retry-After-driven cooldown can park the fleet.
     MAX_COOLDOWN_S = _float_env("PACE_MAX_COOLDOWN_S", 60.0)
@@ -253,11 +267,37 @@ return 1
 """
 
 
+# Attribute/key name the lease id is pinned under, on every carrier that can
+# survive to a terminal path (request metadata, litellm_params.metadata, and
+# the per-request LiteLLMLoggingObj).
+_PACE_ATTR = "_pace_id"
+# Bound on the per-worker already-released LRU. Purely a Redis-round-trip
+# saver — ZREM is idempotent on its own — so any bound works; this one keeps
+# the dict trivially small for a long-lived proxy worker.
+_RELEASED_LRU_MAX = 4096
+
+
 class FleetPacer(CustomLogger):
     def __init__(self) -> None:
         super().__init__()
         self._redis = None
         self._redis_init_failed = False
+        # Bounded LRU of already-released lease ids, so the several terminal
+        # paths that can fire for one request (streaming wrapper, success
+        # handler, failure hook) don't each pay a Redis round-trip.
+        self._released: "OrderedDict[str, None]" = OrderedDict()
+        # Strong refs to fire-and-forget release tasks so the event loop
+        # cannot GC them mid-flight.
+        self._pending_tasks: set = set()
+
+    # ----- idempotency -------------------------------------------------
+    def _already_released(self, pace_id: str) -> bool:
+        if pace_id in self._released:
+            return True
+        self._released[pace_id] = None
+        while len(self._released) > _RELEASED_LRU_MAX:
+            self._released.popitem(last=False)
+        return False
 
     # ----- redis -------------------------------------------------------
     async def _get_redis(self):
@@ -340,7 +380,12 @@ class FleetPacer(CustomLogger):
             return True
 
     async def _release(self, pace_id: Optional[str]) -> None:
+        """Release a concurrency lease. IDEMPOTENT: ZREM of an absent member
+        is a no-op in Redis, and the per-worker LRU short-circuits repeat
+        calls, so it is safe for several terminal paths to race here."""
         if not pace_id:
+            return
+        if self._already_released(pace_id):
             return
         r = await self._get_redis()
         if r is None:
@@ -349,6 +394,22 @@ class FleetPacer(CustomLogger):
             await r.zrem(_INFLIGHT_KEY, pace_id)
         except Exception:
             pass
+
+    def _release_soon(self, pace_id: Optional[str]) -> None:
+        """Schedule a release without blocking the caller. Used from the
+        streaming wrapper's `finally`, which may be running under
+        GeneratorExit during a client disconnect — awaiting there is legal,
+        but stream teardown must never hang on Redis."""
+        if not pace_id:
+            return
+        try:
+            task = asyncio.get_running_loop().create_task(self._release(pace_id))
+            self._pending_tasks.add(task)
+            task.add_done_callback(self._pending_tasks.discard)
+        except Exception as e:  # no running loop / loop closing
+            verbose_proxy_logger.debug(
+                "custom_pacing: release_soon failed (TTL backstop): %s", e
+            )
 
     # ----- gating ------------------------------------------------------
     @staticmethod
@@ -460,23 +521,77 @@ class FleetPacer(CustomLogger):
         except Exception as e:
             verbose_proxy_logger.debug("custom_pacing: pre_call error (fail open): %s", e)
 
-        # Stash id so post hooks can release the concurrency lease. Even if
-        # this is lost, the lease self-heals via LEASE_TTL_S.
+        # Stash id so terminal paths can release the concurrency lease. Even
+        # if every carrier is lost, the lease self-heals via LEASE_TTL_S.
         if admitted:
-            try:
-                meta = data.setdefault("metadata", {})
-                if isinstance(meta, dict):
-                    meta["_pace_id"] = pace_id
-            except Exception:
-                pass
+            self._stash_pace_id(data, pace_id)
         return data
 
-    def _extract_pace_id(self, data: Any) -> Optional[str]:
+    @staticmethod
+    def _stash_pace_id(data: Any, pace_id: str) -> None:
+        """Pin the lease id on every carrier that can survive to a terminal
+        path.
+
+        `data["metadata"]` alone is NOT enough: litellm's
+        `_init_kwargs_for_pass_through_endpoint` pops every key in
+        `all_litellm_params` (which includes "metadata") off the parsed body
+        before the upstream call, so by the time a post hook runs the key is
+        gone from the body — it survives only INTO
+        `kwargs["litellm_params"]["metadata"]`, which the failure path
+        re-attaches. The per-request logging object is the durable handle: it
+        is passed BY REFERENCE into the streaming chunk processor, which is
+        the only terminal point the passthrough streaming path has.
+        """
+        if not isinstance(data, dict):
+            return
         try:
-            if isinstance(data, dict):
-                meta = data.get("metadata")
-                if isinstance(meta, dict):
-                    return meta.get("_pace_id")
+            meta = data.setdefault("metadata", {})
+            if isinstance(meta, dict):
+                meta[_PACE_ATTR] = pace_id
+        except Exception:
+            pass
+        try:
+            lobj = data.get("litellm_logging_obj")
+            if lobj is not None:
+                setattr(lobj, _PACE_ATTR, pace_id)
+                mcd = getattr(lobj, "model_call_details", None)
+                if isinstance(mcd, dict):
+                    mcd[_PACE_ATTR] = pace_id
+        except Exception:
+            pass
+
+    @staticmethod
+    def _pace_id_from_logging_obj(lobj: Any) -> Optional[str]:
+        if lobj is None:
+            return None
+        try:
+            pid = getattr(lobj, _PACE_ATTR, None)
+            if isinstance(pid, str):
+                return pid
+            mcd = getattr(lobj, "model_call_details", None)
+            if isinstance(mcd, dict):
+                pid = mcd.get(_PACE_ATTR)
+                if isinstance(pid, str):
+                    return pid
+        except Exception:
+            pass
+        return None
+
+    def _extract_pace_id(self, data: Any) -> Optional[str]:
+        """Best-effort recovery of the lease id from whatever shape of
+        request payload a terminal hook happens to hand us."""
+        try:
+            if not isinstance(data, dict):
+                return None
+            meta = data.get("metadata")
+            if isinstance(meta, dict) and isinstance(meta.get(_PACE_ATTR), str):
+                return meta[_PACE_ATTR]
+            lp = data.get("litellm_params")
+            if isinstance(lp, dict):
+                lp_meta = lp.get("metadata")
+                if isinstance(lp_meta, dict) and isinstance(lp_meta.get(_PACE_ATTR), str):
+                    return lp_meta[_PACE_ATTR]
+            return self._pace_id_from_logging_obj(data.get("litellm_logging_obj"))
         except Exception:
             pass
         return None
@@ -544,3 +659,201 @@ class FleetPacer(CustomLogger):
 # LiteLLM loads the callback by importing this module and resolving the
 # dotted path "custom_pacing.pacer_instance" to this singleton.
 pacer_instance = FleetPacer()
+
+
+# ---------------------------------------------------------------------------
+# Streaming lease release for the passthrough path.
+#
+# WHY A PATCH AND NOT A HOOK: litellm v1.91.0 offers no callback on the
+# passthrough streaming path. Verified in the installed package:
+#   * pass_through_endpoints.py:1075 and :1134 both `return StreamingResponse(
+#     PassThroughStreamingHandler.chunk_processor(...))` — the
+#     post_call_success_hook call at :1175 is unreachable for streams.
+#   * async_post_call_streaming_hook / async_post_call_streaming_iterator_hook
+#     are only ever invoked from proxy/common_request_processing.py:2465 and
+#     :2476, i.e. the managed /chat/completions + /v1/messages request
+#     processor — never from the passthrough router.
+# chunk_processor's own `finally:` is litellm's own chosen terminal point for
+# the same reason (it is where they schedule spend logging so a client
+# disconnect still records usage). We attach the lease release to that same
+# guaranteed point. Claude Code always streams, so before this every agent
+# request leaked its lease and only ever aged out by TTL.
+#
+# Terminal outcomes covered by the wrapper's `finally`:
+#   success (generator exhausts) / client disconnect (GeneratorExit raised
+#   into the generator by starlette) / upstream or parse exception.
+# Not covered: upstream failing BEFORE the StreamingResponse is constructed
+# (raise_for_status at :1057/:1126) — that raises out to the outer handler,
+# which calls post_call_failure_hook at :1367 with a payload carrying
+# litellm_logging_obj, so async_post_call_failure_hook releases it. And a
+# proxy crash mid-stream, which is what LEASE_TTL_S remains a backstop for.
+#
+# The patch is install-once, fails open (any error leaves litellm untouched),
+# and never changes the bytes yielded to the client.
+# ---------------------------------------------------------------------------
+
+_PATCH_FLAG = "_switchroom_pace_patched"
+
+
+def _install_streaming_release_patch() -> bool:
+    try:
+        from litellm.proxy.pass_through_endpoints.streaming_handler import (
+            PassThroughStreamingHandler,
+        )
+    except Exception as e:  # pragma: no cover - version drift
+        verbose_proxy_logger.error(
+            "custom_pacing: cannot import PassThroughStreamingHandler — streaming "
+            "leases will only expire by TTL (%ss). Error: %s",
+            _Cfg.LEASE_TTL_S,
+            e,
+        )
+        return False
+
+    original = getattr(PassThroughStreamingHandler, "chunk_processor", None)
+    if original is None:
+        verbose_proxy_logger.error(
+            "custom_pacing: PassThroughStreamingHandler.chunk_processor missing — "
+            "streaming leases will only expire by TTL (%ss).",
+            _Cfg.LEASE_TTL_S,
+        )
+        return False
+    if getattr(original, _PATCH_FLAG, False):
+        return True  # already installed (module re-imported)
+
+    async def _paced_chunk_processor(*args, **kwargs):
+        pace_id: Optional[str] = None
+        try:
+            # Call site uses keywords exclusively (pass_through_endpoints.py
+            # :1076-1084, :1135-1143); positional is handled defensively.
+            lobj = kwargs.get("litellm_logging_obj")
+            if lobj is None and len(args) >= 3:
+                lobj = args[2]
+            pace_id = FleetPacer._pace_id_from_logging_obj(lobj)
+            if pace_id is None:
+                body = kwargs.get("request_body")
+                if body is None and len(args) >= 2:
+                    body = args[1]
+                pace_id = pacer_instance._extract_pace_id(body)
+        except Exception as e:
+            verbose_proxy_logger.debug(
+                "custom_pacing: stream pace_id lookup failed: %s", e
+            )
+
+        try:
+            async for chunk in original(*args, **kwargs):
+                yield chunk
+        finally:
+            # Runs on success, GeneratorExit (client disconnect) and
+            # exception. Scheduled rather than awaited so stream teardown
+            # never blocks on Redis; release itself is idempotent.
+            try:
+                pacer_instance._release_soon(pace_id)
+            except Exception:
+                pass
+
+    setattr(_paced_chunk_processor, _PATCH_FLAG, True)
+    setattr(_paced_chunk_processor, "__wrapped__", original)
+    PassThroughStreamingHandler.chunk_processor = staticmethod(_paced_chunk_processor)
+    verbose_proxy_logger.info(
+        "custom_pacing: streaming lease-release patch installed on "
+        "PassThroughStreamingHandler.chunk_processor"
+    )
+    return True
+
+
+def _install_streaming_release_patch_safe() -> bool:
+    """Import-time invocation must be TOTAL: this module is imported by the
+    proxy at startup, so an unexpected throw in here (a litellm layout change,
+    a logger without .error) would take the whole proxy down rather than
+    degrade to the TTL backstop."""
+    try:
+        return _install_streaming_release_patch()
+    except Exception:
+        return False
+
+
+_STREAMING_PATCH_OK = _install_streaming_release_patch_safe()
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming passthrough release.
+#
+# The non-streaming passthrough path DOES reach a post_call_success_hook call
+# site (pass_through_endpoints.py:1175) — but it is nested inside
+# `if response_body is not None and guardrails_to_run:` at :1160. With no
+# passthrough guardrails configured (our case) the hook never runs, so the
+# non-streaming leases leaked too. Measured on a throwaway proxy: 10
+# non-streaming /anthropic requests left 10 leases held.
+#
+# The one thing that IS unconditional on every non-streaming passthrough
+# success is the enqueue of
+# PassThroughEndpointLogging.pass_through_async_success_handler at :1252,
+# which receives the same logging object we pinned the lease id to. We wrap it
+# the same way. Failures on this path still go to post_call_failure_hook.
+#
+# Residual gap (documented, TTL-covered): if GLOBAL_LOGGING_WORKER ever drops
+# the enqueued coroutine, that lease falls back to LEASE_TTL_S. That is the
+# same reliability litellm itself accepts for spend logging on this path.
+# ---------------------------------------------------------------------------
+
+
+def _install_nonstreaming_release_patch() -> bool:
+    try:
+        from litellm.proxy.pass_through_endpoints.success_handler import (
+            PassThroughEndpointLogging,
+        )
+    except Exception as e:  # pragma: no cover - version drift
+        verbose_proxy_logger.error(
+            "custom_pacing: cannot import PassThroughEndpointLogging — non-streaming "
+            "leases will only expire by TTL (%ss). Error: %s",
+            _Cfg.LEASE_TTL_S,
+            e,
+        )
+        return False
+
+    original = getattr(
+        PassThroughEndpointLogging, "pass_through_async_success_handler", None
+    )
+    if original is None or getattr(original, _PATCH_FLAG, False):
+        return original is not None
+
+    async def _paced_success_handler(self, *args, **kwargs):
+        pace_id: Optional[str] = None
+        try:
+            lobj = kwargs.get("logging_obj")
+            pace_id = FleetPacer._pace_id_from_logging_obj(lobj)
+            if pace_id is None:
+                pace_id = pacer_instance._extract_pace_id(kwargs.get("request_body"))
+        except Exception as e:
+            verbose_proxy_logger.debug(
+                "custom_pacing: non-stream pace_id lookup failed: %s", e
+            )
+        try:
+            return await original(self, *args, **kwargs)
+        finally:
+            try:
+                await pacer_instance._release(pace_id)
+            except Exception:
+                pacer_instance._release_soon(pace_id)
+
+    setattr(_paced_success_handler, _PATCH_FLAG, True)
+    setattr(_paced_success_handler, "__wrapped__", original)
+    PassThroughEndpointLogging.pass_through_async_success_handler = (
+        _paced_success_handler
+    )
+    verbose_proxy_logger.info(
+        "custom_pacing: non-streaming lease-release patch installed on "
+        "PassThroughEndpointLogging.pass_through_async_success_handler"
+    )
+    return True
+
+
+def _install_nonstreaming_release_patch_safe() -> bool:
+    """Total for the same reason as the streaming sibling above."""
+    try:
+        return _install_nonstreaming_release_patch()
+    except Exception:
+        return False
+
+
+_NONSTREAMING_PATCH_OK = _install_nonstreaming_release_patch_safe()

--- a/docker/litellm-pacer/test_custom_pacing.py
+++ b/docker/litellm-pacer/test_custom_pacing.py
@@ -23,6 +23,7 @@ Run: python3 -m unittest discover -s docker/litellm-pacer -p 'test_*.py'
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import os
 import random
@@ -52,6 +53,18 @@ def _install_litellm_stubs() -> None:
             pass
 
         def debug(self, *a, **k):
+            pass
+
+        # The lease-release patch installers log at .error (litellm layout
+        # drift) and .info (patch installed) at IMPORT time. A stub missing
+        # either would raise AttributeError during `import custom_pacing` —
+        # which is exactly the failure mode the installers' _safe() wrappers
+        # exist to contain, so the stub must be complete enough that these
+        # tests exercise the real path rather than the swallow.
+        def error(self, *a, **k):
+            pass
+
+        def info(self, *a, **k):
             pass
 
     logging_mod.verbose_proxy_logger = _SilentLogger()
@@ -93,6 +106,7 @@ class FakeRedis:
         self.eval_raises = eval_raises
         self.set_calls: list = []
         self.eval_calls = 0
+        self.zrem_calls: list = []
 
     async def ping(self):
         return True
@@ -112,6 +126,9 @@ class FakeRedis:
         return self.eval_result
 
     async def zrem(self, *args, **kwargs):
+        # Records every lease-release round trip so the release tests can
+        # assert BOTH that a release happened and that it happened once.
+        self.zrem_calls.append(args)
         return 0
 
 
@@ -720,6 +737,425 @@ class RouterCooldownHoldsTests(_CfgPatchMixin, unittest.IsolatedAsyncioTestCase)
         self.assertLessEqual(
             elapsed, custom_pacing._Cfg.COOLDOWN_HOLD_CEILING_S + 0.4
         )
+
+
+# --- Lease release on the passthrough path -----------------------------------
+#
+# THE BUG THESE GUARD (switchroom#3549): a lease taken in the pre-call hook was
+# only ever released by `async_post_call_success_hook` /
+# `async_post_call_failure_hook`. Neither fires on the passthrough STREAMING
+# path (litellm returns a StreamingResponse before any post hook), and the one
+# non-streaming call site is nested under a guardrails condition that is false
+# with no passthrough guardrails configured. So on the /anthropic passthrough
+# route — the route the entire fleet uses — every lease leaked and only expired
+# by LEASE_TTL_S. Concurrency drifted to a standstill under sustained load, and
+# the live mitigation was to raise PACE_MAX_CONCURRENCY 16 -> 64, which bought
+# headroom without fixing the leak.
+#
+# These are CORRECTNESS tests, not latency tests: the assertion is that a lease
+# is actually released on every terminal outcome, and released at most once.
+
+
+def _fake_logging_obj(pace_id=None):
+    """Stand-in for LiteLLMLoggingObj: an object the pacer can pin an attribute
+    to, carrying the `model_call_details` dict litellm really has."""
+
+    class _LObj:
+        pass
+
+    lobj = _LObj()
+    lobj.model_call_details = {}
+    if pace_id is not None:
+        setattr(lobj, custom_pacing._PACE_ATTR, pace_id)
+    return lobj
+
+
+class StashAndExtractPaceIdTests(unittest.TestCase):
+    """The lease id must survive to a terminal path. `data["metadata"]` alone
+    does not: litellm's `_init_kwargs_for_pass_through_endpoint` pops every key
+    in `all_litellm_params` (which includes "metadata") off the parsed body
+    before the upstream call. The logging object is the durable carrier."""
+
+    def test_stash_pins_the_id_on_metadata_and_the_logging_obj(self):
+        lobj = _fake_logging_obj()
+        data = {"litellm_logging_obj": lobj}
+        custom_pacing.FleetPacer._stash_pace_id(data, "pace-1")
+
+        self.assertEqual(data["metadata"][custom_pacing._PACE_ATTR], "pace-1")
+        self.assertEqual(getattr(lobj, custom_pacing._PACE_ATTR), "pace-1")
+        self.assertEqual(lobj.model_call_details[custom_pacing._PACE_ATTR], "pace-1")
+
+    def test_id_is_recoverable_after_metadata_is_popped(self):
+        """The regression in one assertion: simulate litellm stripping
+        `metadata` off the body, and require the id still be found."""
+        lobj = _fake_logging_obj()
+        data = {"litellm_logging_obj": lobj}
+        custom_pacing.FleetPacer._stash_pace_id(data, "pace-2")
+
+        data.pop("metadata")  # what _init_kwargs_for_pass_through_endpoint does
+
+        pacer = custom_pacing.FleetPacer()
+        self.assertEqual(pacer._extract_pace_id(data), "pace-2")
+
+    def test_extract_reads_litellm_params_metadata(self):
+        """The failure path re-attaches metadata under litellm_params."""
+        pacer = custom_pacing.FleetPacer()
+        data = {"litellm_params": {"metadata": {custom_pacing._PACE_ATTR: "pace-3"}}}
+        self.assertEqual(pacer._extract_pace_id(data), "pace-3")
+
+    def test_extract_never_raises_on_junk(self):
+        pacer = custom_pacing.FleetPacer()
+        for junk in (None, "", 42, [], {"metadata": "not-a-dict"}, {"litellm_params": 7}):
+            self.assertIsNone(pacer._extract_pace_id(junk))
+
+    def test_stash_never_raises_on_junk(self):
+        for junk in (None, "", 42, []):
+            custom_pacing.FleetPacer._stash_pace_id(junk, "pace-x")  # must not raise
+
+
+class ReleaseIdempotencyTests(unittest.IsolatedAsyncioTestCase):
+    """Several terminal paths can fire for one request (streaming wrapper,
+    success handler, failure hook). Releasing twice must not double-free a
+    future lease that reuses the id, and must not cost a Redis round trip."""
+
+    async def test_release_issues_one_zrem(self):
+        pacer = custom_pacing.FleetPacer()
+        r = FakeRedis()
+        pacer._redis = r
+        await pacer._release("pace-a")
+        self.assertEqual(len(r.zrem_calls), 1)
+        self.assertIn("pace-a", r.zrem_calls[0])
+
+    async def test_repeat_release_is_a_no_op(self):
+        pacer = custom_pacing.FleetPacer()
+        r = FakeRedis()
+        pacer._redis = r
+        for _ in range(5):
+            await pacer._release("pace-a")
+        self.assertEqual(len(r.zrem_calls), 1)
+
+    async def test_release_of_empty_id_is_a_no_op(self):
+        pacer = custom_pacing.FleetPacer()
+        r = FakeRedis()
+        pacer._redis = r
+        await pacer._release(None)
+        await pacer._release("")
+        self.assertEqual(r.zrem_calls, [])
+
+    async def test_release_survives_a_redis_error(self):
+        """Release must never propagate — a throwing Redis on the teardown path
+        would surface as an error mid-stream."""
+
+        class _BoomRedis(FakeRedis):
+            async def zrem(self, *a, **k):
+                raise RuntimeError("redis down")
+
+        pacer = custom_pacing.FleetPacer()
+        pacer._redis = _BoomRedis()
+        await pacer._release("pace-a")  # must not raise
+
+    async def test_released_lru_stays_bounded(self):
+        """The idempotency cache must not grow without bound in a long-lived
+        proxy worker."""
+        pacer = custom_pacing.FleetPacer()
+        pacer._redis = FakeRedis()
+        for i in range(custom_pacing._RELEASED_LRU_MAX + 250):
+            await pacer._release(f"pace-{i}")
+        self.assertLessEqual(
+            len(pacer._released), custom_pacing._RELEASED_LRU_MAX
+        )
+
+    async def test_release_soon_actually_releases(self):
+        pacer = custom_pacing.FleetPacer()
+        r = FakeRedis()
+        pacer._redis = r
+        pacer._release_soon("pace-b")
+        # Fire-and-forget: yield to the loop so the scheduled task runs.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        self.assertEqual(len(r.zrem_calls), 1)
+
+    async def test_release_soon_keeps_a_strong_ref(self):
+        """Without a strong ref the loop can GC the task mid-flight and the
+        release silently never happens (falling back to the TTL)."""
+        pacer = custom_pacing.FleetPacer()
+        pacer._redis = FakeRedis()
+        pacer._release_soon("pace-c")
+        self.assertEqual(len(pacer._pending_tasks), 1)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        self.assertEqual(len(pacer._pending_tasks), 0)  # discarded when done
+
+    def test_release_soon_outside_a_loop_does_not_raise(self):
+        """Sync context, no running loop: degrade to the TTL backstop, quietly."""
+        pacer = custom_pacing.FleetPacer()
+        pacer._redis = FakeRedis()
+        pacer._release_soon("pace-d")  # must not raise
+
+
+class StreamingReleasePatchTests(unittest.IsolatedAsyncioTestCase):
+    """Installs the streaming patch against a fake
+    PassThroughStreamingHandler and asserts the lease is released on EVERY way
+    a stream can end: normal completion, client disconnect, upstream error."""
+
+    def setUp(self):
+        self._saved = {
+            k: v for k, v in sys.modules.items()
+            if k.startswith("litellm.proxy.pass_through_endpoints")
+        }
+        self.chunks_seen = []
+
+        handler_mod = types.ModuleType(
+            "litellm.proxy.pass_through_endpoints.streaming_handler"
+        )
+        outer = self
+
+        class PassThroughStreamingHandler:
+            @staticmethod
+            async def chunk_processor(*args, **kwargs):
+                mode = kwargs.get("_test_mode", "ok")
+                for i in range(3):
+                    if mode == "raise" and i == 1:
+                        raise RuntimeError("upstream blew up")
+                    outer.chunks_seen.append(i)
+                    yield i
+
+        handler_mod.PassThroughStreamingHandler = PassThroughStreamingHandler
+        self.handler_cls = PassThroughStreamingHandler
+
+        pkg = types.ModuleType("litellm.proxy.pass_through_endpoints")
+        proxy = sys.modules.get("litellm.proxy") or types.ModuleType("litellm.proxy")
+        sys.modules["litellm.proxy"] = proxy
+        sys.modules["litellm.proxy.pass_through_endpoints"] = pkg
+        sys.modules[
+            "litellm.proxy.pass_through_endpoints.streaming_handler"
+        ] = handler_mod
+
+        self.assertTrue(custom_pacing._install_streaming_release_patch())
+
+        self.pacer = custom_pacing.pacer_instance
+        self.redis = FakeRedis()
+        self._saved_redis = self.pacer._redis
+        self._saved_released = self.pacer._released
+        self.pacer._redis = self.redis
+        self.pacer._released = type(self.pacer._released)()
+
+    def tearDown(self):
+        self.pacer._redis = self._saved_redis
+        self.pacer._released = self._saved_released
+        for k in list(sys.modules):
+            if k.startswith("litellm.proxy.pass_through_endpoints"):
+                del sys.modules[k]
+        sys.modules.update(self._saved)
+
+    async def _drain(self, gen, stop_after=None):
+        n = 0
+        async for _ in gen:
+            n += 1
+            if stop_after is not None and n >= stop_after:
+                break
+        return n
+
+    async def _settle(self):
+        # _release_soon schedules; give the loop turns to run it.
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+    async def test_lease_released_on_normal_stream_completion(self):
+        lobj = _fake_logging_obj("pace-stream-ok")
+        gen = self.handler_cls.chunk_processor(litellm_logging_obj=lobj)
+        await self._drain(gen)
+        await self._settle()
+        self.assertEqual(len(self.redis.zrem_calls), 1)
+        self.assertIn("pace-stream-ok", self.redis.zrem_calls[0])
+
+    async def test_lease_released_on_client_disconnect(self):
+        """Abandoning the generator mid-stream throws GeneratorExit into the
+        wrapper's finally. This is the dominant real-world case — a user
+        stopping a long completion — and the one the TTL used to paper over."""
+        lobj = _fake_logging_obj("pace-stream-disconnect")
+        gen = self.handler_cls.chunk_processor(litellm_logging_obj=lobj)
+        await self._drain(gen, stop_after=1)
+        await gen.aclose()
+        await self._settle()
+        self.assertEqual(len(self.redis.zrem_calls), 1)
+        self.assertIn("pace-stream-disconnect", self.redis.zrem_calls[0])
+
+    async def test_lease_released_when_the_stream_raises(self):
+        lobj = _fake_logging_obj("pace-stream-boom")
+        gen = self.handler_cls.chunk_processor(
+            litellm_logging_obj=lobj, _test_mode="raise"
+        )
+        with self.assertRaises(RuntimeError):
+            await self._drain(gen)
+        await self._settle()
+        self.assertEqual(len(self.redis.zrem_calls), 1)
+
+    async def test_chunks_still_flow_through_the_wrapper(self):
+        """The patch must be transparent: same chunks, same order."""
+        lobj = _fake_logging_obj("pace-stream-passthru")
+        gen = self.handler_cls.chunk_processor(litellm_logging_obj=lobj)
+        out = []
+        async for c in gen:
+            out.append(c)
+        self.assertEqual(out, [0, 1, 2])
+
+    async def test_id_recovered_from_the_request_body_when_the_lobj_is_bare(self):
+        lobj = _fake_logging_obj()  # no pinned attribute
+        body = {"metadata": {custom_pacing._PACE_ATTR: "pace-from-body"}}
+        gen = self.handler_cls.chunk_processor(
+            litellm_logging_obj=lobj, request_body=body
+        )
+        await self._drain(gen)
+        await self._settle()
+        self.assertIn("pace-from-body", self.redis.zrem_calls[0])
+
+    async def test_no_lease_id_means_no_release_call(self):
+        gen = self.handler_cls.chunk_processor(litellm_logging_obj=_fake_logging_obj())
+        await self._drain(gen)
+        await self._settle()
+        self.assertEqual(self.redis.zrem_calls, [])
+
+    def test_patch_is_not_installed_twice(self):
+        """Module re-import must not stack wrappers (each layer would release
+        again and the chunk path would nest)."""
+        first = self.handler_cls.chunk_processor
+        self.assertTrue(custom_pacing._install_streaming_release_patch())
+        self.assertIs(self.handler_cls.chunk_processor, first)
+
+
+class NonStreamingReleasePatchTests(unittest.IsolatedAsyncioTestCase):
+    """The non-streaming passthrough success hook is nested under
+    `if response_body is not None and guardrails_to_run:` — false for us — so
+    these leases leaked too. We wrap the one unconditional success handler."""
+
+    def setUp(self):
+        self._saved = {
+            k: v for k, v in sys.modules.items()
+            if k.startswith("litellm.proxy.pass_through_endpoints")
+        }
+        self.calls = []
+        outer = self
+
+        mod = types.ModuleType(
+            "litellm.proxy.pass_through_endpoints.success_handler"
+        )
+
+        class PassThroughEndpointLogging:
+            async def pass_through_async_success_handler(self, *args, **kwargs):
+                outer.calls.append(kwargs)
+                if kwargs.get("_test_mode") == "raise":
+                    raise RuntimeError("handler blew up")
+                return "handled"
+
+        mod.PassThroughEndpointLogging = PassThroughEndpointLogging
+        self.cls = PassThroughEndpointLogging
+
+        pkg = types.ModuleType("litellm.proxy.pass_through_endpoints")
+        proxy = sys.modules.get("litellm.proxy") or types.ModuleType("litellm.proxy")
+        sys.modules["litellm.proxy"] = proxy
+        sys.modules["litellm.proxy.pass_through_endpoints"] = pkg
+        sys.modules["litellm.proxy.pass_through_endpoints.success_handler"] = mod
+
+        self.assertTrue(custom_pacing._install_nonstreaming_release_patch())
+
+        self.pacer = custom_pacing.pacer_instance
+        self.redis = FakeRedis()
+        self._saved_redis = self.pacer._redis
+        self._saved_released = self.pacer._released
+        self.pacer._redis = self.redis
+        self.pacer._released = type(self.pacer._released)()
+
+    def tearDown(self):
+        self.pacer._redis = self._saved_redis
+        self.pacer._released = self._saved_released
+        for k in list(sys.modules):
+            if k.startswith("litellm.proxy.pass_through_endpoints"):
+                del sys.modules[k]
+        sys.modules.update(self._saved)
+
+    async def test_lease_released_on_success(self):
+        inst = self.cls()
+        out = await inst.pass_through_async_success_handler(
+            logging_obj=_fake_logging_obj("pace-ns-ok")
+        )
+        self.assertEqual(out, "handled")  # return value preserved
+        self.assertEqual(len(self.redis.zrem_calls), 1)
+        self.assertIn("pace-ns-ok", self.redis.zrem_calls[0])
+
+    async def test_lease_released_when_the_handler_raises(self):
+        inst = self.cls()
+        with self.assertRaises(RuntimeError):
+            await inst.pass_through_async_success_handler(
+                logging_obj=_fake_logging_obj("pace-ns-boom"), _test_mode="raise"
+            )
+        self.assertEqual(len(self.redis.zrem_calls), 1)
+
+    async def test_the_wrapped_handler_still_receives_its_kwargs(self):
+        inst = self.cls()
+        lobj = _fake_logging_obj("pace-ns-args")
+        await inst.pass_through_async_success_handler(logging_obj=lobj, url="/x")
+        self.assertEqual(self.calls[0]["url"], "/x")
+        self.assertIs(self.calls[0]["logging_obj"], lobj)
+
+    def test_patch_is_not_installed_twice(self):
+        first = self.cls.pass_through_async_success_handler
+        self.assertTrue(custom_pacing._install_nonstreaming_release_patch())
+        self.assertIs(self.cls.pass_through_async_success_handler, first)
+
+
+class PatchInstallFailOpenTests(unittest.TestCase):
+    """This module is imported by the proxy at startup. A litellm layout change
+    must degrade to the TTL backstop, never take the proxy down."""
+
+    def _without_passthrough_modules(self):
+        saved = {
+            k: v for k, v in sys.modules.items()
+            if k.startswith("litellm.proxy.pass_through_endpoints")
+        }
+        for k in saved:
+            del sys.modules[k]
+        # Block re-import: a bare ModuleType with no submodules makes the
+        # `from ... import` raise, which is the drift case.
+        return saved
+
+    def _restore(self, saved):
+        for k in list(sys.modules):
+            if k.startswith("litellm.proxy.pass_through_endpoints"):
+                del sys.modules[k]
+        sys.modules.update(saved)
+
+    def test_streaming_installer_returns_false_when_litellm_is_absent(self):
+        saved = self._without_passthrough_modules()
+        try:
+            self.assertFalse(custom_pacing._install_streaming_release_patch())
+        finally:
+            self._restore(saved)
+
+    def test_nonstreaming_installer_returns_false_when_litellm_is_absent(self):
+        saved = self._without_passthrough_modules()
+        try:
+            self.assertFalse(custom_pacing._install_nonstreaming_release_patch())
+        finally:
+            self._restore(saved)
+
+    def test_safe_wrappers_swallow_everything(self):
+        """Total-ness is the load-bearing property: even a logger without
+        .error (an older litellm) must not escape as an import-time crash."""
+        saved_logger = custom_pacing.verbose_proxy_logger
+
+        class _BrokenLogger:
+            def __getattr__(self, name):
+                raise AttributeError(name)
+
+        custom_pacing.verbose_proxy_logger = _BrokenLogger()
+        saved = self._without_passthrough_modules()
+        try:
+            self.assertFalse(custom_pacing._install_streaming_release_patch_safe())
+            self.assertFalse(custom_pacing._install_nonstreaming_release_patch_safe())
+        finally:
+            self._restore(saved)
+            custom_pacing.verbose_proxy_logger = saved_logger
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #3549.

## The bug

The pacer takes a Redis concurrency lease in `async_pre_call_hook` and released it only from `async_post_call_success_hook` / `async_post_call_failure_hook`. **Neither fires on the passthrough route the entire fleet uses.**

- **Streaming:** `pass_through_endpoints.py` returns a `StreamingResponse` wrapping `PassThroughStreamingHandler.chunk_processor` before any post hook can run. litellm exposes no callback at all on that path.
- **Non-streaming:** the one `post_call_success_hook` call site is nested under `if response_body is not None and guardrails_to_run:`. With no passthrough guardrails configured — our case — it never runs. Measured on a throwaway proxy: **10 non-streaming `/anthropic` requests left 10 leases held.**

So every `/anthropic` lease leaked and expired only by `LEASE_TTL_S`. Effective concurrency drifted down under sustained load until the fleet crawled.

**This is a correctness fix, not a latency optimisation.** The live mitigation was `PACE_MAX_CONCURRENCY` 16 → 64, which bought headroom without fixing the leak. This PR does **not** revert that setting — it removes the reason it was needed.

## The fix

Wrap the two terminal points litellm actually reaches, and release there.

- `chunk_processor` gets a `finally` that fires on normal completion, on `GeneratorExit` (client disconnect — the dominant real case), and on exception. It *schedules* the release rather than awaiting it, so stream teardown can never block on Redis.
- `pass_through_async_success_handler` — the one thing that is unconditional on non-streaming success — is wrapped the same way.

Supporting changes:

- The lease id is pinned to the per-request logging object as well as `data["metadata"]`. `data["metadata"]` alone is not enough: litellm's `_init_kwargs_for_pass_through_endpoint` pops every `all_litellm_params` key (including `metadata`) off the body before the upstream call.
- `_release` is idempotent — a bounded per-worker LRU plus Redis `ZREM`'s own no-op semantics — so the several terminal paths that can race for one request are safe.
- Both installers are **total**. A litellm layout change degrades to the TTL backstop and can never take the proxy down at import time.
- `LEASE_TTL_S` is now documented as a backstop, not the release mechanism.

## Tests

`docker/litellm-pacer/test_custom_pacing.py` — 76 pass, pure stdlib, no Redis and no litellm required (same lane as the existing suite).

The new tests assert **outcomes**, not code paths: a lease is released on stream completion, on client disconnect, and on stream error; on non-streaming success and on handler exception; release is idempotent and the LRU stays bounded; the id survives litellm stripping `metadata`; and the installers fail open when litellm's modules are absent.

Verified by mutation — each of these independently fails the suite:

| Mutation | Result |
|---|---|
| remove the streaming `finally` release | 3 failures, 1 error |
| remove the non-streaming release | 2 failures |
| disable the idempotency check | 1 failure |
| pin the id to `metadata` only (the original leak) | 1 failure, 1 error |

```
python3 -m unittest discover -s docker/litellm-pacer -p 'test_*.py'
Ran 76 tests in 3.7s
OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)