### PR TITLE
fix(telegram): bold headings render as written, not flattened or wrongly kept

### DIFF
--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -782,8 +782,16 @@ function isFullyBolded(fragment: string): boolean {
  * treated as a legitimate pseudo-heading (`**Section**`) rather than an
  * over-bolded paragraph. Single source of truth for BOTH the per-block rule
  * and the global-ratio heading exemption.
+ *
+ * 64, not 48: at 48 a legitimate long section label
+ * (`**Deployment status across all three regions:**` — 50 chars with markers)
+ * was read as an over-bolded paragraph and flattened. 64 still bounds the
+ * exemption to something that reads as a label on a phone; the alternative of
+ * exempting any fully-bold line ending in `:` regardless of length was
+ * rejected because an arbitrarily long bolded paragraph that happens to end
+ * in a colon would then escape the tripwire entirely.
  */
-const PSEUDO_HEADING_MAX_CHARS = 48
+const PSEUDO_HEADING_MAX_CHARS = 64
 
 /**
  * True when a blank-line-delimited block is a single-line pseudo-heading: one
@@ -828,7 +836,10 @@ function unbold(fragment: string): string {
  *     encourages) and is NOT stripped — neither by the per-block rule NOR by
  *     the global-ratio rule (it still counts toward the global ratio, so a
  *     genuinely over-bolded message still trips, but its section headings
- *     survive instead of the whole reply going plain).
+ *     survive instead of the whole reply going plain). The one exception:
+ *     when EVERY block of the message is such a heading there is no body to
+ *     preserve contrast against, so the global rule strips them all rather
+ *     than leaving a 100%-bold message untouched.
  *   - A list with any non-fully-bolded item is left alone.
  *
  * Code spans/fences are masked (maskCodeRegions) and never counted or
@@ -862,8 +873,17 @@ export function stripExcessBold(
     // Clearly over-bolded — strip every bold span, keeping the text, EXCEPT
     // standalone short pseudo-heading blocks (`**Section**`), which stay bold
     // so a bold-dense digest keeps its section headings.
+    //
+    // The exemption only makes sense when there is body text for the headings
+    // to stand out FROM. A message whose every block is a pseudo-heading has
+    // no body: exempting all of them leaves a 100%-bold message untouched and
+    // unlogged. In that case the exemption is dropped and the whole message is
+    // stripped, which is what the ratio rule says.
+    const contentBlocks = blocks.filter((b) => b.trim() !== '')
+    const allHeadings =
+      contentBlocks.length > 0 && contentBlocks.every(isPseudoHeadingBlock)
     const rebuilt = blocks.map((block) =>
-      isPseudoHeadingBlock(block) ? block : unbold(block),
+      !allHeadings && isPseudoHeadingBlock(block) ? block : unbold(block),
     )
     const out = rejoinBlocks(masked, rebuilt)
     if (out !== masked) onStrip?.({ rule: 'global', ratio })

--- a/telegram-plugin/tests/format-consistency.test.ts
+++ b/telegram-plugin/tests/format-consistency.test.ts
@@ -397,20 +397,100 @@ describe('stripExcessBold', () => {
     expect(stripExcessBold(input)).toBe(input)
   })
 
-  test('48/49-char pseudo-heading boundary honoured under global strip', () => {
-    // Heading length is measured WITH the `**` markers. 44 inner chars → 48
-    // total (exempt); 45 inner chars → 49 total (stripped).
-    const heading48 = '**' + 'H'.repeat(44) + '**' // length 48
-    const heading49 = '**' + 'H'.repeat(45) + '**' // length 49
-    expect(heading48.length).toBe(48)
-    expect(heading49.length).toBe(49)
+  test('64/65-char pseudo-heading boundary honoured under global strip', () => {
+    // Heading length is measured WITH the `**` markers. 60 inner chars → 64
+    // total (exempt); 61 inner chars → 65 total (stripped).
+    const heading64 = '**' + 'H'.repeat(60) + '**' // length 64
+    const heading65 = '**' + 'H'.repeat(61) + '**' // length 65
+    expect(heading64.length).toBe(64)
+    expect(heading65.length).toBe(65)
 
-    const out48 = stripExcessBold(`${heading48}\n\n${boldDenseBody}`)
-    expect(out48).toContain(heading48)
+    const out64 = stripExcessBold(`${heading64}\n\n${boldDenseBody}`)
+    expect(out64).toContain(heading64)
 
-    const out49 = stripExcessBold(`${heading49}\n\n${boldDenseBody}`)
-    expect(out49).not.toContain(heading49)
-    expect(out49).toContain('H'.repeat(45))
+    const out65 = stripExcessBold(`${heading65}\n\n${boldDenseBody}`)
+    expect(out65).not.toContain(heading65)
+    expect(out65).toContain('H'.repeat(61))
+  })
+
+  // ── #4021: long-but-legitimate bold section labels survive ───────────────
+  // At PSEUDO_HEADING_MAX_CHARS=48 a real section label of 50-63 chars was
+  // read as an over-bolded paragraph and flattened. The cap is 64.
+
+  test.each([
+    // [label, survives?]
+    ['**Deployment status across all three regions:**', true], // 46
+    ['**Deployment status across all three AWS regions:**', true], // 50
+    ['**What changed in the delivery path since last Tuesday:**', true], // 56
+    ['**What actually changed in the delivery path since Tue:**', true], // 56
+    ['**Everything that changed across the delivery path this week:**', true], // 62
+    ['**Everything that changed across the whole delivery path today:**', false], // 65
+  ])('bold section label %s survives=%s under global strip', (label, survives) => {
+    // Sanity: the fixtures must straddle the 64-char boundary.
+    expect(label.length <= 64).toBe(survives)
+
+    const out = stripExcessBold(`${label}\n\n${boldDenseBody}`)
+    const inner = label.slice(2, -2)
+    if (survives) {
+      expect(out).toContain(label)
+    } else {
+      expect(out).not.toContain(label)
+      expect(out).toContain(inner)
+    }
+    // Either way the body is still flattened — the ratio guard is intact.
+    expect(out).not.toContain('**alpha**')
+  })
+
+  // ── #4017: a message that is ALL pseudo-headings still strips ────────────
+  // Every block exempted meant `out === masked`: a 100%-bold digest stayed
+  // fully bold and onStrip never fired.
+
+  test('all-pseudo-heading message strips (no body to contrast against)', () => {
+    const input = [
+      '**Deploy status**',
+      '**Open incidents**',
+      '**Merged today**',
+      '**Blocked on review**',
+      '**Rollout window tomorrow**',
+      '**Next steps:**',
+    ].join('\n\n')
+    expect(input.length).toBeGreaterThan(100)
+
+    const calls: Array<{ rule: string; ratio: number }> = []
+    const out = stripExcessBold(input, (d) => calls.push(d))
+
+    expect(out).not.toContain('**')
+    expect(out).toContain('Deploy status')
+    expect(out).toContain('Next steps:')
+    // Blank-line gaps between the headings are preserved.
+    expect(out).toBe(input.replace(/\*\*/g, ''))
+    // …and the strip is logged.
+    expect(calls).toHaveLength(1)
+    expect(calls[0].rule).toBe('global')
+    expect(calls[0].ratio).toBeGreaterThan(0.3)
+  })
+
+  test.each([
+    [
+      'all headings, no body → strip',
+      `**Deploy status**\n\n**Open incidents this morning**\n\n**Merged today since the last release**\n\n**Next steps:**`,
+      false,
+    ],
+    [
+      'headings + bold-dense body → headings survive',
+      `**Deploy status**\n\n${boldDenseBody}`,
+      true,
+    ],
+    [
+      'headings around a bold-dense body → headings survive',
+      `**Deploy status**\n\n**Open incidents**\n\n${boldDenseBody}\n\n**Next steps:**`,
+      true,
+    ],
+  ])('all-heading guard: %s', (_name, input, headingSurvives) => {
+    expect(input.length).toBeGreaterThan(100)
+    const out = stripExcessBold(input)
+    expect(out.includes('**Deploy status**')).toBe(headingSurvives)
+    expect(out).toContain('Deploy status')
   })
 
   test('multi-line fully-bolded block is NOT mislabelled a heading (global)', () => {


### PR DESCRIPTION
## Summary

Bold section headings now render the way they were written, instead of being flattened or wrongly kept. Two heuristics in the over-bold tripwire (`telegram-plugin/format.ts`) mangled legitimate formatting:

- **#4017 — an all-headings message never stripped.** In the global (>30% bold ratio) branch, every blank-line-delimited block that is a short standalone `**bold**` line is exempted as a pseudo-heading. A digest that is *only* such lines (5+ headings, blank gaps, no body) had every block exempted, so `out === masked`: nothing stripped, `onStrip` never fired, and a 100%-bold message went out fully bold with no signal. The heading exemption only earns its keep when there is body text for the headings to contrast *against*; with no body, the global rule now strips the whole message and logs it (`format.ts:867-881`).
- **#4021 — `PSEUDO_HEADING_MAX_CHARS = 48` flattened long labels.** A genuine section label like `**Deployment status across all three AWS regions:**` (50 chars with markers) was read as an over-bolded paragraph and flattened. Cap raised to **64** (`format.ts:786-796`).

**Why 64 and not "any fully-bold line ending in `:`".** The issue offered both. An unbounded colon rule lets an arbitrarily long bolded paragraph that happens to end in a colon escape the tripwire entirely — the exact failure the tripwire exists to catch. A bounded 64 keeps the exemption to something that still reads as a label on a phone, and the >30% global ratio guard is unchanged (a heading still counts toward the ratio, it just survives the strip).

**Why the all-heading guard is narrow.** It fires only when *every* content block is a pseudo-heading — i.e. exactly the no-body case from #4017. A digest of headings **plus** a bold-dense body keeps #4016's behaviour: headings survive, body flattens. Pinned by a table-driven test.

## Why

`reference/jobs/talk-to-agents-from-anywhere.md` — "Formatting reads naturally on a phone." A section label silently losing its bold, or a bold-dense digest arriving 100% bold with no diagnostic, both fail that on the surface the user actually reads.

Scoped from the Telegram delivery design's RC4 ("formatting implemented as N divergent subsets"). This PR deliberately does **not** attempt the seam unification — `normalizeOutboundBody` / streaming / captured-prose each still believe they are the single formatting seam. That convergence is tracked separately as W1-c (with #4018), and is sequenced after this PR precisely to avoid conflicting with it. These two fixes are local to `format.ts`, where the heuristics live.

## Test plan

`telegram-plugin/tests/format-consistency.test.ts` — outcome tests, revert-checked (reverted `format.ts` only, kept the tests):

```
× 64/65-char pseudo-heading boundary honoured under global strip
× bold section label **Deployment status across all three AWS regions:** survives=true
× bold section label **What changed in the delivery path since last Tuesday:** survives=true
× bold section label **What actually changed in the delivery path since Tue:** survives=true
× bold section label **Everything that changed across the delivery path this week:** survives=true
× all-pseudo-heading message strips (no body to contrast against)
× all-heading guard: all headings, no body → strip
Tests  7 failed | 59 passed (66)
```

With the fix: `66 passed`. Table-driven boundary cases included — bold labels straddling the 64-char cap (46/50/56/62 survive, 65 flattens), and the all-heading guard across all-headings / headings+body / headings-around-body. The all-heading test also asserts `onStrip` fires once with `rule: 'global'`, so the silent-strip half of #4017 is covered too.

Also green: `telegram-plugin/tests/outbound-send-path.test.ts`, `telegram-plugin/tests/turn-flush-safety.test.ts` (149 tests), and `npm run lint` (full gate, clean).

## Risk

Low, and bounded to one function. The change can only affect messages that already trip the >30% global ratio. Two behaviour deltas: bold labels of 49-64 chars now survive a global strip (previously flattened), and an all-pseudo-heading message now strips (previously kept, unlogged — the pre-#4016 behaviour). Per-block rule, code masking, the <100-char exemption and idempotence are untouched; the existing 48/49 boundary test was retargeted to 64/65 since it pins the constant, not an outcome.

Closes #4017
Closes #4021
