### PR TITLE
fix(telegram): long answers stop failing to send; the outbox sweep can't double-run

### DIFF
--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -31,6 +31,20 @@
 export const RICH_MESSAGE_MAX_CHARS = 32768
 
 /**
+ * The legacy plain-text `sendMessage` / `editMessageText` wire cap (4096
+ * UTF-16 units). It does NOT apply to the rich path (`sendRichMessage`, up to
+ * {@link RICH_MESSAGE_MAX_CHARS}), but it DOES apply the moment a send path
+ * DEGRADES to the plain endpoint — the parse-reject fallbacks that resend a
+ * rich chunk as plain text, and `renderSafe`'s `mode: "plain"` results.
+ *
+ * Lives here (next to the rich cap and the splitters) rather than in
+ * `render/rich-render.ts` so every plain-degradation site can re-cap without
+ * importing the renderer; `render/rich-render.ts` re-exports it for its
+ * existing importers.
+ */
+export const PLAIN_TEXT_MAX_CHARS = 4096
+
+/**
  * Escape the GFM-markdown special characters so a dynamic value
  * (a filename, an id, arbitrary user text) renders LITERALLY inside a
  * hand-built markdown card instead of being parsed as formatting.
@@ -1158,6 +1172,41 @@ export function hardSliceToCap(text: string, cap = RICH_MESSAGE_MAX_CHARS): stri
     out.push(text.slice(i, i + cap))
   }
   return out
+}
+
+/**
+ * Re-cap a body that is about to be sent through the PLAIN `sendMessage` /
+ * `editMessageText` endpoint (switchroom #4043).
+ *
+ * Every plain-text FALLBACK in the send path inherits a chunk that was split
+ * for the RICH cap ({@link RICH_MESSAGE_MAX_CHARS} = 32768). Handing such a
+ * chunk to the plain endpoint (which caps at {@link PLAIN_TEXT_MAX_CHARS} =
+ * 4096) makes Telegram reject it with `message is too long` — so the fallback
+ * that exists precisely to rescue a failed send fails too, and the user never
+ * receives the message (in the outbox sweep it retries forever).
+ *
+ * Cuts at `splitMarkdownChunks`' safe boundaries first (never bisecting a
+ * fenced block or a table row) and hard-slices any residual indivisible region,
+ * so EVERY returned piece is guaranteed `<= cap`. Returns the input as a
+ * single-element array when it already fits (the overwhelmingly common case,
+ * byte-identical to the pre-fix behaviour).
+ */
+export function splitPlainTextToCap(text: string, cap = PLAIN_TEXT_MAX_CHARS): string[] {
+  if (cap <= 0) return [text]
+  if (text.length <= cap) return [text]
+  const out: string[] = []
+  for (const piece of splitMarkdownChunks(text, cap)) {
+    if (piece.length <= cap) {
+      if (piece.length > 0) out.push(piece)
+      continue
+    }
+    // `splitMarkdownChunks` emits an unsplittable region whole; hard-cut it so
+    // the plain endpoint can actually accept it.
+    for (const slice of hardSliceToCap(piece, cap)) {
+      if (slice.length > 0) out.push(slice)
+    }
+  }
+  return out.length > 0 ? out : [text]
 }
 
 // ---------------------------------------------------------------------------

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -29,6 +29,7 @@ import {
   stripExcessBold,
   addParagraphSpacers,
   splitMarkdownChunks,
+  splitPlainTextToCap,
   hardSliceToCap,
   RICH_MESSAGE_MAX_CHARS,
 } from '../format.js'
@@ -416,16 +417,35 @@ export async function sendReplyChunks(
     // rejects our markdown — better an unformatted answer than a
     // vanished one. The raw markdown source is itself readable prose, so
     // we send it verbatim rather than strip anything.
+    //
+    // #4043: chunks were split for the RICH cap (up to RICH_MESSAGE_MAX_CHARS =
+    // 32768), but this fallback ships them through the PLAIN `sendMessage`
+    // endpoint, which caps at 4096. Without a re-cap, the rescue send itself
+    // 400s with `message is too long` and the answer vanishes — the exact
+    // failure the fallback exists to prevent. Re-cap at safe boundaries first.
     const sendChunkPlainText = async (opts: Record<string, unknown>): Promise<void> => {
       const plain =
         chunks[i].length > 0
           ? chunks[i]
           : '⚠️ (a fragment could not be rendered for Telegram)'
-      const sent = await deps.sendLiteralRaw(opts, plain)
-      sentIds.push(sent.message_id)
-      deps.logOutbound('reply', chatId, sent.message_id, plain.length, `chunk=${i + 1}/${chunks.length} plaintext-fallback`)
+      const pieces = splitPlainTextToCap(plain)
+      for (let p = 0; p < pieces.length; p++) {
+        const sent = await deps.sendLiteralRaw(opts, pieces[p])
+        sentIds.push(sent.message_id)
+        deps.logOutbound(
+          'reply',
+          chatId,
+          sent.message_id,
+          pieces[p].length,
+          pieces.length > 1
+            ? `chunk=${i + 1}/${chunks.length} plaintext-fallback piece=${p + 1}/${pieces.length}`
+            : `chunk=${i + 1}/${chunks.length} plaintext-fallback`,
+        )
+      }
       deps.stderr(
-        `telegram gateway: markdown parse-reject — resent chunk ${i + 1}/${chunks.length} as plain text\n`,
+        `telegram gateway: markdown parse-reject — resent chunk ${i + 1}/${chunks.length} as plain text` +
+          (pieces.length > 1 ? ` in ${pieces.length} piece(s) (4096-char plain cap)` : '') +
+          `\n`,
       )
     }
 
@@ -2660,7 +2680,11 @@ export async function deliverCapturedProse(
         `(chat=${chatId} origin=${originTurnId})\n`,
     )
     const plain = redactOutboundText(text, 'captured_prose')
-    const plainChunks = splitMarkdownChunks(plain, RICH_MESSAGE_MAX_CHARS)
+    // #4043: these pieces go through the PLAIN `sendMessage` endpoint (4096
+    // cap), not the rich one — splitting at RICH_MESSAGE_MAX_CHARS produced
+    // pieces Telegram rejects with `message is too long`, so a long recovered
+    // answer fell through to the generic apology and was lost.
+    const plainChunks = splitPlainTextToCap(plain)
     try {
       let liveThreadId: number | undefined = threadId
       const plainSentIds: number[] = []

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -423,14 +423,37 @@ export async function sendReplyChunks(
     // endpoint, which caps at 4096. Without a re-cap, the rescue send itself
     // 400s with `message is too long` and the answer vanishes — the exact
     // failure the fallback exists to prevent. Re-cap at safe boundaries first.
+    //
+    // Per-piece trailers: `opts` was built for ONE message, so shipping it
+    // verbatim to every piece duplicates the MESSAGE-scoped params.
+    //   - `reply_markup` (an inline keyboard) would render a LIVE button on
+    //     every piece. `single_use` only strips the keyboard from the message
+    //     that was tapped, so the user can fire the same action N times. It
+    //     rides the FINAL piece only — the same treatment the sweep's own
+    //     fallback applies (`outbox-sweep.ts` `sendChunkRich`/`withoutMarkup`),
+    //     and the same message the caller attached it to (the last chunk).
+    //   - `reply_parameters` would quote-reply from every piece. Only the
+    //     FIRST piece quotes, matching the caller's `replyMode !== 'all'`
+    //     rule that quotes chunk 0 only.
+    // Thread / link-preview / protect_content / disable_notification are
+    // per-message policy and correctly ride every piece, unchanged.
     const sendChunkPlainText = async (opts: Record<string, unknown>): Promise<void> => {
       const plain =
         chunks[i].length > 0
           ? chunks[i]
           : '⚠️ (a fragment could not be rendered for Telegram)'
       const pieces = splitPlainTextToCap(plain)
+      const pieceOpts = (p: number): Record<string, unknown> => {
+        // Single piece ⇒ it is both first and final; pass `opts` through
+        // byte-identically so the non-split path stays exactly as it was.
+        if (pieces.length === 1) return opts
+        const o = { ...opts }
+        if (p !== pieces.length - 1) delete o.reply_markup
+        if (p !== 0) delete o.reply_parameters
+        return o
+      }
       for (let p = 0; p < pieces.length; p++) {
-        const sent = await deps.sendLiteralRaw(opts, pieces[p])
+        const sent = await deps.sendLiteralRaw(pieceOpts(p), pieces[p])
         sentIds.push(sent.message_id)
         deps.logOutbound(
           'reply',

--- a/telegram-plugin/gateway/outbox-sweep.ts
+++ b/telegram-plugin/gateway/outbox-sweep.ts
@@ -44,7 +44,7 @@ import {
 } from '../outbox.js'
 import { isShownBlock } from '../shown-ledger.js'
 import { richMessage, isParseEntitiesError } from '../rich-send.js'
-import { splitMarkdownChunks } from '../format.js'
+import { splitMarkdownChunks, splitPlainTextToCap } from '../format.js'
 import { resolveSubagentOriginTurnKey } from '../registry/subagents-schema.js'
 import { createRetryApiCall, retryWithThreadFallback } from '../retry-api-call.js'
 import {
@@ -460,19 +460,44 @@ type OutboxSendBot = {
  * caught here — it propagates so `retryWithThreadFallback` and the sweep's
  * claim-release retry handle it, exactly as before.
  */
+/**
+ * #4043: the plain fallback is RE-CAPPED to `PLAIN_TEXT_MAX_CHARS` (4096). The
+ * caller splits at the RICH cap (32768 — `splitMarkdownChunks`' default), so an
+ * oversized chunk that parse-rejected used to be re-sent to the plain endpoint
+ * whole, get `message is too long`, throw, release the claim, and retry on the
+ * NEXT tick forever: the record could never be delivered and never cleared.
+ * Returns one entry per message actually landed (the plain fallback can land
+ * several) so the caller's history / journal bookkeeping stays aligned with the
+ * wire. A trailing `reply_markup` (the Listen button) rides the FINAL piece
+ * only, exactly as it rides the final chunk.
+ */
 async function sendChunkRich(
   bot: OutboxSendBot,
   chatId: string,
   chunk: string,
   opts: object,
-): Promise<{ message_id?: number }> {
+): Promise<Array<{ message_id?: number; text: string }>> {
   try {
     // allow-raw-bot-api: caller (createOutboxSend) invokes this inside retryWithThreadFallback + createRetryApiCall
-    return await bot.api.sendRichMessage(chatId, richMessage(chunk), opts)
+    const sent = await bot.api.sendRichMessage(chatId, richMessage(chunk), opts)
+    return [{ message_id: sent?.message_id, text: chunk }]
   } catch (err) {
     if (isParseEntitiesError(err)) {
-      // allow-raw-bot-api: parse-reject plain fallback, still inside the sweep's retryWithThreadFallback wrapper
-      return await bot.api.sendMessage(chatId, chunk, opts)
+      const pieces = splitPlainTextToCap(chunk)
+      const withoutMarkup = { ...(opts as Record<string, unknown>) }
+      delete withoutMarkup.reply_markup
+      const landed: Array<{ message_id?: number; text: string }> = []
+      for (let p = 0; p < pieces.length; p++) {
+        const isFinalPiece = p === pieces.length - 1
+        // allow-raw-bot-api: parse-reject plain fallback, still inside the sweep's retryWithThreadFallback wrapper
+        const sent = await bot.api.sendMessage(
+          chatId,
+          pieces[p],
+          isFinalPiece ? opts : withoutMarkup,
+        )
+        landed.push({ message_id: sent?.message_id, text: pieces[p] })
+      }
+      return landed
     }
     throw err
   }
@@ -532,14 +557,111 @@ export function createOutboxSend(deps: {
         },
         { threadId: threadId ?? undefined, chat_id: chatId, verb: 'outbox-sweep.sendMessage' },
       )
-      const id = res?.message_id
-      if (id != null) landed.push({ messageId: id, text: chunk })
+      // One entry per message that actually landed — the #4043 plain fallback
+      // can split ONE rich chunk into several 4096-capped plain messages, and
+      // history/backstop bookkeeping must reflect the wire, not the pre-split
+      // chunk.
+      for (const sent of res ?? []) {
+        if (sent.message_id != null) landed.push({ messageId: sent.message_id, text: sent.text })
+      }
     }
     return {
       messageId: landed.length > 0 ? landed[landed.length - 1]!.messageId : undefined,
       chunks: landed,
     }
   }
+}
+
+/**
+ * Build the heartbeat tick that {@link startOutboxSweep} hands to `setInterval`,
+ * with the SINGLE-FLIGHT guard (#3864).
+ *
+ * The tick fires every `OUTBOX_SWEEP_INTERVAL_MS` and the sweep it starts is
+ * `void`-ed, so a sweep that outlives its interval used to have the NEXT tick
+ * start a second, concurrent sweep body against the same outbox directory. The
+ * per-record rename mutex (`claimRecord`, `../outbox.ts`) keeps that from
+ * double-sending a single record, but it is the only thing that does: the two
+ * bodies still race the same journal / dedup / backoff state, and every
+ * additional overlapping tick multiplies the wire pressure at exactly the
+ * moment (a slow or flood-throttled Telegram) when the sweep must issue LESS.
+ * `inFlight` makes overlap unrepresentable rather than merely survivable.
+ *
+ * Extracted + exported so the guard is unit-testable without a live gateway,
+ * a timer, or the filesystem: pass a `runSweep` you control and drive `tick()`
+ * directly.
+ */
+export function createOutboxSweepTick(deps: {
+  /** Nothing to sweep until the bot exists (unchanged pre-guard behaviour). */
+  getBot: () => unknown
+  backoff: ReturnType<typeof createSweepBackoff>
+  /** Run ONE sweep body. Wired by {@link startOutboxSweep} to {@link sweepOutbox}. */
+  runSweep: () => Promise<OutboxSweepSummary>
+  log?: (line: string) => void
+  /** Test seam — clock used for the backoff gate and the defer-log throttle. */
+  now?: () => number
+}): (() => void) & { inFlight: () => boolean } {
+  const now = deps.now ?? (() => Date.now())
+  let lastDeferLogAt = 0
+  let inFlight = false
+  let overlapSkips = 0
+  const tick = () => {
+    if (deps.getBot() == null) return
+    if (!deps.backoff.ready(now())) return
+    // #3864 — a sweep is still running; skip this tick entirely rather than
+    // starting a second concurrent body. Skipping is free: the outbox is a
+    // durable safety net with no latency SLA, and the in-flight sweep will
+    // pick up anything this tick would have.
+    if (inFlight) {
+      overlapSkips++
+      if (overlapSkips === 1) {
+        deps.log?.(
+          `outbox-sweep: tick skipped — the previous sweep is still in flight ` +
+            `(single-flight guard; no concurrent sweep started)\n`,
+        )
+      }
+      return
+    }
+    inFlight = true
+    void deps
+      .runSweep()
+      .then((summary) => {
+        // A flood-deferred sweep is neither success nor failure: it never
+        // reached the wire, so it must not clear a backoff earned by real
+        // failures, and it must not deepen one either.
+        if (summary.floodDeferred === true) {
+          const at = now()
+          if (at - lastDeferLogAt >= OUTBOX_SWEEP_DEFER_LOG_INTERVAL_MS) {
+            lastDeferLogAt = at
+            deps.log?.(
+              `outbox-sweep: deferred — Telegram flood window still open for ` +
+                `${Math.ceil((summary.floodRemainingMs ?? 0) / 1000)}s; not issuing any ` +
+                `send (would feed the ban)\n`,
+            )
+          }
+          return
+        }
+        if (summary.sendFailures > 0) {
+          const delay = deps.backoff.noteFailure(now())
+          deps.log?.(
+            `outbox-sweep: ${summary.sendFailures} send failure(s) — backing off ` +
+              `${Math.round(delay / 1000)}s before the next sweep (attempt ${deps.backoff.failures()})\n`,
+          )
+        } else {
+          deps.backoff.noteSuccess()
+        }
+      })
+      .catch((err) => deps.log?.(`outbox-sweep: tick failed: ${(err as Error).message}\n`))
+      .finally(() => {
+        inFlight = false
+        if (overlapSkips > 0) {
+          deps.log?.(
+            `outbox-sweep: sweep finished; ${overlapSkips} tick(s) were skipped while it ran\n`,
+          )
+          overlapSkips = 0
+        }
+      })
+  }
+  return Object.assign(tick, { inFlight: () => inFlight })
 }
 
 export function startOutboxSweep(deps: {
@@ -587,54 +709,26 @@ export function startOutboxSweep(deps: {
     ...(deps.resolveReplyMarkup != null ? { resolveReplyMarkup: deps.resolveReplyMarkup } : {}),
   })
   const backoff = deps.backoff ?? createSweepBackoff()
-  let lastDeferLogAt = 0
-  const tick = () => {
-    const bot = deps.getBot()
-    if (bot == null) return
-    const now = Date.now()
-    if (!backoff.ready(now)) return
-    void sweepOutbox({
-      stateDir: deps.stateDir,
-      log: deps.log,
-      send,
-      ...(deps.recordOutbound != null ? { recordOutbound: deps.recordOutbound } : {}),
-      floodWaitRemainingMs: floodProbe,
-      textAlreadyDelivered: (chatId, threadId, text) => deps.dedupCheck(chatId, threadId ?? undefined, text),
-      registryChainLookup: (taskId) => {
-        const db = deps.getTurnsDb()
-        if (db == null) return null
-        const turnKey = resolveSubagentOriginTurnKey(db, taskId)
-        return turnKey == null ? null : chatFromTurnKey(turnKey)
-      },
-    })
-      .then((summary) => {
-        // A flood-deferred sweep is neither success nor failure: it never
-        // reached the wire, so it must not clear a backoff earned by real
-        // failures, and it must not deepen one either.
-        if (summary.floodDeferred === true) {
-          const at = Date.now()
-          if (at - lastDeferLogAt >= OUTBOX_SWEEP_DEFER_LOG_INTERVAL_MS) {
-            lastDeferLogAt = at
-            deps.log?.(
-              `outbox-sweep: deferred — Telegram flood window still open for ` +
-                `${Math.ceil((summary.floodRemainingMs ?? 0) / 1000)}s; not issuing any ` +
-                `send (would feed the ban)\n`,
-            )
-          }
-          return
-        }
-        if (summary.sendFailures > 0) {
-          const delay = backoff.noteFailure(Date.now())
-          deps.log?.(
-            `outbox-sweep: ${summary.sendFailures} send failure(s) — backing off ` +
-              `${Math.round(delay / 1000)}s before the next sweep (attempt ${backoff.failures()})\n`,
-          )
-        } else {
-          backoff.noteSuccess()
-        }
-      })
-      .catch((err) => deps.log?.(`outbox-sweep: tick failed: ${(err as Error).message}\n`))
-  }
+  const tick = createOutboxSweepTick({
+    getBot: deps.getBot,
+    backoff,
+    log: deps.log,
+    runSweep: () =>
+      sweepOutbox({
+        stateDir: deps.stateDir,
+        log: deps.log,
+        send,
+        ...(deps.recordOutbound != null ? { recordOutbound: deps.recordOutbound } : {}),
+        floodWaitRemainingMs: floodProbe,
+        textAlreadyDelivered: (chatId, threadId, text) => deps.dedupCheck(chatId, threadId ?? undefined, text),
+        registryChainLookup: (taskId) => {
+          const db = deps.getTurnsDb()
+          if (db == null) return null
+          const turnKey = resolveSubagentOriginTurnKey(db, taskId)
+          return turnKey == null ? null : chatFromTurnKey(turnKey)
+        },
+      }),
+  })
   const timer = setInterval(tick, OUTBOX_SWEEP_INTERVAL_MS)
   timer.unref?.()
   return timer

--- a/telegram-plugin/gateway/outbox-sweep.ts
+++ b/telegram-plugin/gateway/outbox-sweep.ts
@@ -471,36 +471,80 @@ type OutboxSendBot = {
  * wire. A trailing `reply_markup` (the Listen button) rides the FINAL piece
  * only, exactly as it rides the final chunk.
  */
+/**
+ * Resume state for ONE chunk, owned by the caller and therefore SURVIVING a
+ * re-invocation of the send closure.
+ *
+ * The caller wraps this whole function — the multi-send plain-fallback loop
+ * included — in `retryWithThreadFallback(deps.retry, …)`, and
+ * `createRetryApiCall` re-invokes the closure it was given after a flood wait
+ * (`../retry-api-call.ts`). Without resume state, a 429 on plain piece 4 of 5
+ * meant the retry re-ran the closure from the top: the rich send
+ * DETERMINISTICALLY parse-rejects again and pieces 1-3 are re-delivered to the
+ * user's chat — repeating every attempt until the whole loop happens to
+ * succeed. A mid-loop 429 is likely precisely in the flood conditions the
+ * sweep runs under, so this is the common case, not the exotic one.
+ *
+ * Carrying landed-piece state (rather than wrapping each `sendMessage` in its
+ * own nested `deps.retry`) is what makes the send IDEMPOTENT under ANY
+ * re-invocation — the retry policy's flood re-drive AND
+ * `retryWithThreadFallback`'s thread-drop re-drive — instead of only the one
+ * we thought of. Nesting a retry inside the outer retry would instead multiply
+ * the attempt and flood-sleep budgets (maxRetries²) at exactly the moment the
+ * policy exists to issue LESS, and would still re-send pieces 1-3 whenever the
+ * inner budget was exhausted and the error bubbled to the outer wrapper.
+ */
+interface ChunkSendState {
+  /** The rich send already parse-rejected — skip straight to the plain loop. */
+  parseRejected: boolean
+  /** Plain pieces already ON THE WIRE, in order. Never re-sent. */
+  landed: Array<{ message_id?: number; text: string }>
+}
+
+function newChunkSendState(): ChunkSendState {
+  return { parseRejected: false, landed: [] }
+}
+
 async function sendChunkRich(
   bot: OutboxSendBot,
   chatId: string,
   chunk: string,
   opts: object,
+  state: ChunkSendState = newChunkSendState(),
 ): Promise<Array<{ message_id?: number; text: string }>> {
-  try {
-    // allow-raw-bot-api: caller (createOutboxSend) invokes this inside retryWithThreadFallback + createRetryApiCall
-    const sent = await bot.api.sendRichMessage(chatId, richMessage(chunk), opts)
-    return [{ message_id: sent?.message_id, text: chunk }]
-  } catch (err) {
-    if (isParseEntitiesError(err)) {
-      const pieces = splitPlainTextToCap(chunk)
-      const withoutMarkup = { ...(opts as Record<string, unknown>) }
-      delete withoutMarkup.reply_markup
-      const landed: Array<{ message_id?: number; text: string }> = []
-      for (let p = 0; p < pieces.length; p++) {
-        const isFinalPiece = p === pieces.length - 1
-        // allow-raw-bot-api: parse-reject plain fallback, still inside the sweep's retryWithThreadFallback wrapper
-        const sent = await bot.api.sendMessage(
-          chatId,
-          pieces[p],
-          isFinalPiece ? opts : withoutMarkup,
-        )
-        landed.push({ message_id: sent?.message_id, text: pieces[p] })
-      }
-      return landed
+  // A re-invocation after the rich send already parse-rejected must NOT
+  // re-issue it: the reject is deterministic (same body, same renderer), so
+  // the only thing another attempt buys is one more 400 against a
+  // flood-sensitive endpoint.
+  if (!state.parseRejected) {
+    try {
+      // allow-raw-bot-api: caller (createOutboxSend) invokes this inside retryWithThreadFallback + createRetryApiCall
+      const sent = await bot.api.sendRichMessage(chatId, richMessage(chunk), opts)
+      return [{ message_id: sent?.message_id, text: chunk }]
+    } catch (err) {
+      if (!isParseEntitiesError(err)) throw err
+      state.parseRejected = true
     }
-    throw err
   }
+
+  const pieces = splitPlainTextToCap(chunk)
+  const withoutMarkup = { ...(opts as Record<string, unknown>) }
+  delete withoutMarkup.reply_markup
+  // Resume at the first piece that has NOT landed. On a first invocation
+  // `landed` is empty and this is the plain 0..n loop.
+  for (let p = state.landed.length; p < pieces.length; p++) {
+    const isFinalPiece = p === pieces.length - 1
+    // allow-raw-bot-api: parse-reject plain fallback, still inside the sweep's retryWithThreadFallback wrapper
+    const sent = await bot.api.sendMessage(
+      chatId,
+      pieces[p],
+      isFinalPiece ? opts : withoutMarkup,
+    )
+    // Recorded BEFORE the next iteration can throw, so a mid-loop failure
+    // leaves the state pointing at the first UNSENT piece.
+    state.landed.push({ message_id: sent?.message_id, text: pieces[p] })
+  }
+  return state.landed
 }
 
 /**
@@ -546,6 +590,10 @@ export function createOutboxSend(deps: {
     for (let idx = 0; idx < chunks.length; idx++) {
       const chunk = chunks[idx]
       const isLast = idx === chunks.length - 1
+      // Per-chunk resume state, OUTSIDE the closure the retry policy
+      // re-invokes: a flood wait mid plain-fallback loop must resume at the
+      // first unsent piece, not re-deliver the ones already in the chat.
+      const chunkState = newChunkSendState()
       const res = await retryWithThreadFallback(
         deps.retry,
         (tid) => {
@@ -553,7 +601,7 @@ export function createOutboxSend(deps: {
           // Button on the LAST chunk only (final visible message).
           const opts =
             isLast && replyMarkup != null ? { ...base, reply_markup: replyMarkup } : base
-          return sendChunkRich(bot, chatId, chunk, opts)
+          return sendChunkRich(bot, chatId, chunk, opts, chunkState)
         },
         { threadId: threadId ?? undefined, chat_id: chatId, verb: 'outbox-sweep.sendMessage' },
       )

--- a/telegram-plugin/render/rich-render.ts
+++ b/telegram-plugin/render/rich-render.ts
@@ -28,7 +28,11 @@
 
 import { parse } from "./parse.js";
 import { renderSafe, type RenderResult } from "./render.js";
-import { RICH_MESSAGE_MAX_CHARS, splitMarkdownChunks } from "../format.js";
+import {
+  PLAIN_TEXT_MAX_CHARS,
+  RICH_MESSAGE_MAX_CHARS,
+  splitMarkdownChunks,
+} from "../format.js";
 
 /**
  * The legacy plain-text `sendMessage` / `editMessageText` wire cap (4096
@@ -38,8 +42,12 @@ import { RICH_MESSAGE_MAX_CHARS, splitMarkdownChunks } from "../format.js";
  * the plain `sendMessage` endpoint (see stream-controller `doSend`/`doEdit`).
  * A degraded plain body larger than this is rejected by Telegram with
  * `message is too long`, so `renderOutboundChunks` caps plain pieces here.
+ *
+ * Defined in `format.ts` (#4043) so the parse-reject plain FALLBACKS in the
+ * send path can share the one constant without importing the renderer;
+ * re-exported here for this module's existing importers.
  */
-export const PLAIN_TEXT_MAX_CHARS = 4096;
+export { PLAIN_TEXT_MAX_CHARS };
 
 /** Parse the `SWITCHROOM_RICH_RENDER` kill-switch value. Default ON; disabled
  *  only by an explicit falsey/off token (`0`/`false`/`off`/`no`,

--- a/telegram-plugin/tests/outbox-sweep-single-flight.test.ts
+++ b/telegram-plugin/tests/outbox-sweep-single-flight.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Regression: switchroom #3864 — the outbox sweep tick had no overlap guard.
+ *
+ * `startOutboxSweep` fires a tick every `OUTBOX_SWEEP_INTERVAL_MS` and `void`s
+ * the sweep it starts. A sweep slower than the interval (a flood-throttled
+ * Telegram, a big backlog, slow disk) therefore had the NEXT tick start a
+ * SECOND concurrent sweep body over the same outbox directory — and the one
+ * after that a third. The per-record rename mutex in `../outbox.ts` stopped a
+ * single record being double-SENT, but nothing stopped the bodies from
+ * multiplying: they race the same journal / dedup / backoff state and multiply
+ * wire pressure at exactly the moment the sweep should be issuing less.
+ *
+ * `createOutboxSweepTick` now single-flights: while a sweep is in flight, a
+ * tick is skipped outright.
+ *
+ * Outcome asserted: the number of sweep BODIES actually started. Without the
+ * guard the second tick starts a second body and `runs` is 2 — this test fails.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createOutboxSweepTick, createSweepBackoff } from '../gateway/outbox-sweep.js'
+import type { OutboxSweepSummary } from '../gateway/outbox-sweep.js'
+
+const OK: OutboxSweepSummary = { scanned: 0, delivered: 0, skipped: 0, sendFailures: 0 }
+
+/** A sweep whose completion the test controls. */
+function controllableSweep() {
+  let runs = 0
+  const pending: Array<(s: OutboxSweepSummary) => void> = []
+  const runSweep = () => {
+    runs++
+    return new Promise<OutboxSweepSummary>((resolve) => pending.push(resolve))
+  }
+  return {
+    runSweep,
+    runs: () => runs,
+    /** Complete the oldest in-flight sweep and let its .then/.finally settle. */
+    finish: async (summary: OutboxSweepSummary = OK) => {
+      pending.shift()?.(summary)
+      // Drain the .then → .catch → .finally microtask chain.
+      for (let i = 0; i < 8; i++) await Promise.resolve()
+    },
+  }
+}
+
+describe('outbox sweep tick — single flight (#3864)', () => {
+  it('a tick that fires while a sweep is still running starts NO second sweep', async () => {
+    const sweep = controllableSweep()
+    const logs: string[] = []
+    const tick = createOutboxSweepTick({
+      getBot: () => ({}),
+      backoff: createSweepBackoff(),
+      runSweep: sweep.runSweep,
+      log: (l) => logs.push(l),
+    })
+
+    tick()
+    expect(sweep.runs()).toBe(1)
+    expect(tick.inFlight()).toBe(true)
+
+    // Two more interval ticks land while the first sweep is still running.
+    tick()
+    tick()
+    expect(sweep.runs()).toBe(1)
+
+    // Once it completes, the next tick sweeps again — the guard defers, it
+    // does not disable the sweep.
+    await sweep.finish()
+    expect(tick.inFlight()).toBe(false)
+    tick()
+    expect(sweep.runs()).toBe(2)
+
+    // And it says so in the log, once per overlap streak plus a summary.
+    expect(logs.some((l) => l.includes('still in flight'))).toBe(true)
+    expect(logs.some((l) => l.includes('2 tick(s) were skipped'))).toBe(true)
+  })
+
+  it('releases the guard when the sweep REJECTS (a throwing sweep must not wedge it)', async () => {
+    let runs = 0
+    let reject: ((e: Error) => void) | null = null
+    const tick = createOutboxSweepTick({
+      getBot: () => ({}),
+      backoff: createSweepBackoff(),
+      runSweep: () => {
+        runs++
+        return new Promise<OutboxSweepSummary>((_res, rej) => {
+          reject = rej
+        })
+      },
+      log: () => {},
+    })
+
+    tick()
+    expect(runs).toBe(1)
+    reject!(new Error('disk on fire'))
+    for (let i = 0; i < 8; i++) await Promise.resolve()
+
+    expect(tick.inFlight()).toBe(false)
+    tick()
+    expect(runs).toBe(2)
+  })
+
+  it('does not sweep at all before the bot exists', () => {
+    const sweep = controllableSweep()
+    const tick = createOutboxSweepTick({
+      getBot: () => undefined,
+      backoff: createSweepBackoff(),
+      runSweep: sweep.runSweep,
+    })
+    tick()
+    expect(sweep.runs()).toBe(0)
+  })
+
+  it('honours the failure backoff independently of the in-flight guard', async () => {
+    const sweep = controllableSweep()
+    let now = 1_000_000
+    const tick = createOutboxSweepTick({
+      getBot: () => ({}),
+      backoff: createSweepBackoff(),
+      runSweep: sweep.runSweep,
+      now: () => now,
+      log: () => {},
+    })
+
+    tick()
+    await sweep.finish({ ...OK, sendFailures: 1 })
+    expect(sweep.runs()).toBe(1)
+    expect(tick.inFlight()).toBe(false)
+
+    // Guard released, but the backoff window is open → still no sweep.
+    tick()
+    expect(sweep.runs()).toBe(1)
+
+    now += 10 * 60 * 1000
+    tick()
+    expect(sweep.runs()).toBe(2)
+  })
+})

--- a/telegram-plugin/tests/plain-fallback-4096-cap.test.ts
+++ b/telegram-plugin/tests/plain-fallback-4096-cap.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Regression: switchroom #4043 — the plain-text FALLBACK was never re-capped to
+ * the plain endpoint's 4096-char wire limit.
+ *
+ * Every send path chunks for the RICH cap (`RICH_MESSAGE_MAX_CHARS` = 32768,
+ * `format.ts`). Three sites then degrade a chunk to the PLAIN `sendMessage`
+ * endpoint, which caps at 4096:
+ *
+ *   1. the reply path's markdown parse-reject fallback
+ *      (`gateway/outbound-send-path.ts`, `sendReplyChunks` → `sendChunkPlainText`)
+ *   2. the outbox sweep's parse-reject fallback
+ *      (`gateway/outbox-sweep.ts`, `sendChunkRich` → `bot.api.sendMessage`)
+ *   3. the captured-prose exhausted-boundary fallback
+ *      (`gateway/outbound-send-path.ts`, `deliverCapturedProse`)
+ *
+ * Pre-fix all three handed the FULL rich-sized chunk to the plain endpoint, so
+ * Telegram answered `Bad Request: message is too long` and the rescue send —
+ * the thing that exists so a long answer is never lost — failed too. In the
+ * sweep that is worse than a loss: the record is never journaled and never
+ * cleared, so the same doomed send is retried on every tick forever.
+ *
+ * These assert the USER OUTCOME, not the code path: the fake Telegram enforces
+ * the real 4096 limit, so a test that merely walked the fallback without the
+ * re-cap would throw and fail. The whole body must arrive, in pieces the plain
+ * endpoint accepts.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { GrammyError } from 'grammy'
+import {
+  PLAIN_TEXT_MAX_CHARS,
+  RICH_MESSAGE_MAX_CHARS,
+  splitPlainTextToCap,
+} from '../format.js'
+import {
+  sendReplyChunks,
+  deliverCapturedProse,
+  computeReplyChunks,
+  type ReplyChunkSendDeps,
+  type DeliverCapturedProseDeps,
+} from '../gateway/outbound-send-path.js'
+import { createOutboxSend } from '../gateway/outbox-sweep.js'
+import { OutboundDedupCache } from '../recent-outbound-dedup.js'
+
+const CHAT = '100200300'
+
+/** A body far past the plain cap but comfortably inside the rich cap, with
+ *  ordinary paragraph boundaries (so the splitter has somewhere safe to cut). */
+function longBody(chars: number): string {
+  const para = 'Sentence about the delivery seam that the user actually reads. '
+  let out = ''
+  let n = 0
+  while (out.length < chars) {
+    out += para.repeat(6) + `\n\nparagraph ${n++}\n\n`
+  }
+  return out.slice(0, chars)
+}
+
+/** Telegram's real plain-endpoint rejection for an oversized body. */
+function tooLongError(): GrammyError {
+  return new GrammyError(
+    'Call to sendMessage failed!',
+    { ok: false, error_code: 400, description: 'Bad Request: message is too long' },
+    'sendMessage',
+    {} as never,
+  )
+}
+
+/** Telegram's real markdown parse-reject (what triggers every plain fallback). */
+function parseRejectError(method: 'sendMessage' | 'sendRichMessage'): GrammyError {
+  return new GrammyError(
+    `Call to ${method} failed!`,
+    {
+      ok: false,
+      error_code: 400,
+      description: "Bad Request: can't parse entities: unexpected end of input",
+    },
+    method,
+    {} as never,
+  )
+}
+
+describe('splitPlainTextToCap (#4043 — the shared re-cap)', () => {
+  it('leaves a body that already fits untouched (single piece, byte-identical)', () => {
+    const body = 'short enough'
+    expect(splitPlainTextToCap(body)).toEqual([body])
+  })
+
+  it('caps every piece at 4096 and loses nothing', () => {
+    const body = longBody(20_000)
+    const pieces = splitPlainTextToCap(body)
+    expect(pieces.length).toBeGreaterThan(1)
+    for (const p of pieces) expect(p.length).toBeLessThanOrEqual(PLAIN_TEXT_MAX_CHARS)
+    expect(pieces.join('').replace(/\s+/g, '')).toBe(body.replace(/\s+/g, ''))
+  })
+
+  it('hard-slices an INDIVISIBLE region rather than emitting it oversized', () => {
+    // No newline, no space: `splitMarkdownChunks` emits such a region whole.
+    const blob = 'x'.repeat(10_000)
+    const pieces = splitPlainTextToCap(blob)
+    for (const p of pieces) expect(p.length).toBeLessThanOrEqual(PLAIN_TEXT_MAX_CHARS)
+    expect(pieces.join('')).toBe(blob)
+  })
+})
+
+describe('#4043 site 1 — reply path parse-reject fallback (sendReplyChunks)', () => {
+  /** Fake wire: the rich send parse-rejects; the plain send enforces 4096. */
+  function makeDeps() {
+    const plainSends: string[] = []
+    let id = 500
+    const deps: ReplyChunkSendDeps = {
+      sendRich: () => Promise.reject(parseRejectError('sendRichMessage')),
+      sendLiteral: () => Promise.reject(parseRejectError('sendMessage')),
+      sendLiteralRaw: (_opts, text) => {
+        if (text.length > PLAIN_TEXT_MAX_CHARS) return Promise.reject(tooLongError())
+        plainSends.push(text)
+        return Promise.resolve({ message_id: id++ })
+      },
+      sendRichRaw: () => Promise.reject(parseRejectError('sendRichMessage')),
+      editPreview: () => Promise.resolve({}),
+      richMessage: (s) => ({ markdown: s }),
+      logOutbound: () => {},
+      deleteStalePreview: () => Promise.resolve(),
+      stderr: () => {},
+    }
+    return { deps, plainSends }
+  }
+
+  it('delivers a 20k-char answer as ≤4096-char plain pieces instead of failing', async () => {
+    const body = longBody(20_000)
+    // The reply path splits for the RICH cap — one chunk, ~20k chars.
+    const chunks = computeReplyChunks({
+      effectiveText: body,
+      literalText: false,
+      limit: RICH_MESSAGE_MAX_CHARS,
+      chunkMode: 'newline',
+    })
+    expect(chunks).toHaveLength(1)
+
+    const { deps, plainSends } = makeDeps()
+    const sentIds: number[] = []
+    await sendReplyChunks(deps, {
+      chatId: CHAT,
+      chunks,
+      literalText: false,
+      suppressText: false,
+      threadId: undefined,
+      previewMessageId: null,
+      sentIds,
+      buildSendOpts: () => ({}),
+      buildPreviewEditOpts: () => ({}),
+    })
+
+    expect(plainSends.length).toBeGreaterThan(1)
+    for (const s of plainSends) expect(s.length).toBeLessThanOrEqual(PLAIN_TEXT_MAX_CHARS)
+    // Every delivered message is reported back to the caller (history / dedup).
+    expect(sentIds).toHaveLength(plainSends.length)
+    // Nothing was dropped on the floor.
+    expect(plainSends.join('').replace(/\s+/g, '')).toBe(body.replace(/\s+/g, ''))
+  })
+
+  it('still sends a short parse-rejected chunk as ONE plain message', async () => {
+    const { deps, plainSends } = makeDeps()
+    const sentIds: number[] = []
+    await sendReplyChunks(deps, {
+      chatId: CHAT,
+      chunks: ['a short answer'],
+      literalText: false,
+      suppressText: false,
+      threadId: undefined,
+      previewMessageId: null,
+      sentIds,
+      buildSendOpts: () => ({}),
+      buildPreviewEditOpts: () => ({}),
+    })
+    expect(plainSends).toEqual(['a short answer'])
+    expect(sentIds).toHaveLength(1)
+  })
+})
+
+describe('#4043 site 2 — outbox sweep parse-reject fallback (createOutboxSend)', () => {
+  function fakeBot() {
+    const plainSends: Array<{ text: string; opts: Record<string, unknown> }> = []
+    let id = 900
+    return {
+      plainSends,
+      api: {
+        sendRichMessage: async () => {
+          throw parseRejectError('sendRichMessage')
+        },
+        sendMessage: async (_chatId: string, text: string, opts: Record<string, unknown>) => {
+          if (text.length > PLAIN_TEXT_MAX_CHARS) throw tooLongError()
+          plainSends.push({ text, opts })
+          return { message_id: id++ }
+        },
+      },
+    }
+  }
+
+  const passthroughRetry = <U>(fn: () => Promise<U>): Promise<U> => fn()
+
+  it('delivers a 20k-char record as ≤4096-char plain pieces instead of retrying forever', async () => {
+    const bot = fakeBot()
+    const send = createOutboxSend({ getBot: () => bot as never, retry: passthroughRetry })
+    const body = longBody(20_000)
+
+    const res = await send(CHAT, null, body)
+
+    expect(bot.plainSends.length).toBeGreaterThan(1)
+    for (const s of bot.plainSends) {
+      expect(s.text.length).toBeLessThanOrEqual(PLAIN_TEXT_MAX_CHARS)
+    }
+    // The sweep reports one entry per message ACTUALLY landed, with the text
+    // that message carries — history / journal bookkeeping tracks the wire.
+    expect(res.chunks).toHaveLength(bot.plainSends.length)
+    expect(res.chunks.map((c) => c.text)).toEqual(bot.plainSends.map((s) => s.text))
+    expect(res.messageId).toBe(res.chunks[res.chunks.length - 1]!.messageId)
+    expect(bot.plainSends.map((s) => s.text).join('').replace(/\s+/g, '')).toBe(
+      body.replace(/\s+/g, ''),
+    )
+  })
+
+  it('the Listen keyboard rides the FINAL plain piece only (no duplicate buttons)', async () => {
+    const bot = fakeBot()
+    const markup = { inline_keyboard: [[{ text: '🔊 Listen', callback_data: 'voice:1' }]] }
+    const send = createOutboxSend({
+      getBot: () => bot as never,
+      retry: passthroughRetry,
+      resolveReplyMarkup: () => markup,
+    })
+
+    await send(CHAT, null, longBody(20_000))
+
+    const withMarkup = bot.plainSends.filter((s) => s.opts.reply_markup != null)
+    expect(withMarkup).toHaveLength(1)
+    expect(bot.plainSends[bot.plainSends.length - 1]!.opts.reply_markup).toEqual(markup)
+  })
+})
+
+describe('#4043 site 3 — captured-prose exhausted-boundary fallback', () => {
+  it('delivers a 20k-char recovered answer as ≤4096-char plain pieces', async () => {
+    const plainSends: string[] = []
+    let id = 700
+    const api = {
+      sendRichMessage: async () => {
+        throw parseRejectError('sendRichMessage')
+      },
+      sendMessage: async (_chatId: string, text: string) => {
+        if (text.length > PLAIN_TEXT_MAX_CHARS) throw tooLongError()
+        plainSends.push(text)
+        return { message_id: id++ }
+      },
+    }
+    const recorded: Array<{ message_ids: number[]; texts: string[] }> = []
+    const body = longBody(20_000)
+    const deps: DeliverCapturedProseDeps = {
+      outboundDedup: new OutboundDedupCache(),
+      bot: { api } as unknown as DeliverCapturedProseDeps['bot'],
+      robustApiCall: (fn) => fn(),
+      redactOutboundText: (t) => t,
+      recordOutbound: (rec) => recorded.push({ message_ids: rec.message_ids, texts: rec.texts }),
+      HISTORY_ENABLED: true,
+      OBLIGATION_LEDGER_ENABLED: true,
+      obligationLedger: { close: () => {} },
+      clearSilentEndState: () => {},
+      // Re-prompt budget already spent → the plain-text fallback arm fires.
+      recordUndeliveredTurnEnd: () => ({ exhausted: true }),
+      hasOutboundDeliveredSince: () => false,
+    }
+
+    await deliverCapturedProse(deps, {
+      chatId: CHAT,
+      threadId: undefined,
+      statusKeyStr: `${CHAT}:main`,
+      registryKey: null,
+      originTurnId: 'turn-4043',
+      text: body,
+    })
+
+    expect(plainSends.length).toBeGreaterThan(1)
+    for (const s of plainSends) expect(s.length).toBeLessThanOrEqual(PLAIN_TEXT_MAX_CHARS)
+    // The recovered answer reached the user AND landed in history (no generic
+    // apology instead of the answer).
+    expect(recorded).toHaveLength(1)
+    expect(recorded[0]!.texts).toEqual(plainSends)
+    expect(plainSends.join('').replace(/\s+/g, '')).toBe(body.replace(/\s+/g, ''))
+  })
+})

--- a/telegram-plugin/tests/plain-fallback-4096-cap.test.ts
+++ b/telegram-plugin/tests/plain-fallback-4096-cap.test.ts
@@ -40,6 +40,7 @@ import {
   type DeliverCapturedProseDeps,
 } from '../gateway/outbound-send-path.js'
 import { createOutboxSend } from '../gateway/outbox-sweep.js'
+import { createRetryApiCall } from '../retry-api-call.js'
 import { OutboundDedupCache } from '../recent-outbound-dedup.js'
 
 const CHAT = '100200300'
@@ -231,6 +232,226 @@ describe('#4043 site 2 — outbox sweep parse-reject fallback (createOutboxSend)
 
     await send(CHAT, null, longBody(20_000))
 
+    const withMarkup = bot.plainSends.filter((s) => s.opts.reply_markup != null)
+    expect(withMarkup).toHaveLength(1)
+    expect(bot.plainSends[bot.plainSends.length - 1]!.opts.reply_markup).toEqual(markup)
+  })
+})
+
+describe('reply-path plain fallback — message-scoped trailers ride ONE piece', () => {
+  /**
+   * MAJOR 1. `buildSendOpts` builds opts for ONE message: `reply_markup` on the
+   * LAST chunk, `reply_parameters` on the quoting chunk. `sendChunkPlainText`
+   * then re-caps that chunk into N plain pieces — and used to hand the SAME
+   * opts object to every one of them. Outcome the user sees: N copies of the
+   * inline keyboard (a `single_use` keyboard only clears off the message that
+   * was tapped, so the action can be double-fired) and N quote-replies.
+   *
+   * The sweep path already got this right for the button
+   * (`outbox-sweep.ts` `withoutMarkup`); this is the reply path's version.
+   */
+  const markup = {
+    inline_keyboard: [[{ text: 'Approve', callback_data: 'approve:42' }]],
+    single_use: true,
+  }
+  const replyParams = { message_id: 77, quote: { text: 'the question', position: 0 } }
+
+  function makeDeps() {
+    const plainSends: Array<{ text: string; opts: Record<string, unknown> }> = []
+    let id = 600
+    const deps: ReplyChunkSendDeps = {
+      sendRich: () => Promise.reject(parseRejectError('sendRichMessage')),
+      sendLiteral: () => Promise.reject(parseRejectError('sendMessage')),
+      sendLiteralRaw: (opts, text) => {
+        if (text.length > PLAIN_TEXT_MAX_CHARS) return Promise.reject(tooLongError())
+        plainSends.push({ text, opts: opts as Record<string, unknown> })
+        return Promise.resolve({ message_id: id++ })
+      },
+      sendRichRaw: () => Promise.reject(parseRejectError('sendRichMessage')),
+      editPreview: () => Promise.resolve({}),
+      richMessage: (s) => ({ markdown: s }),
+      logOutbound: () => {},
+      deleteStalePreview: () => Promise.resolve(),
+      stderr: () => {},
+    }
+    return { deps, plainSends }
+  }
+
+  /** Mirrors the live `buildSendOpts` (gateway/outbound-send-path.ts): quote on
+   *  the first chunk, keyboard on the last, thread on every one. */
+  const buildSendOpts = (i: number, isLastChunk: boolean) => ({
+    ...(i === 0 ? { reply_parameters: replyParams } : {}),
+    message_thread_id: 9,
+    ...(isLastChunk ? { reply_markup: markup } : {}),
+  })
+
+  it('an oversized keyboard-bearing reply: ONE keyboard (final piece), ONE quote (first piece)', async () => {
+    const body = longBody(20_000)
+    const chunks = computeReplyChunks({
+      effectiveText: body,
+      literalText: false,
+      limit: RICH_MESSAGE_MAX_CHARS,
+      chunkMode: 'newline',
+    })
+    // One rich chunk that is BOTH the first (quotes) and the last (keyboard).
+    expect(chunks).toHaveLength(1)
+
+    const { deps, plainSends } = makeDeps()
+    const sentIds: number[] = []
+    await sendReplyChunks(deps, {
+      chatId: CHAT,
+      chunks,
+      literalText: false,
+      suppressText: false,
+      threadId: 9,
+      previewMessageId: null,
+      sentIds,
+      buildSendOpts,
+      buildPreviewEditOpts: () => ({}),
+    })
+
+    // It really did split — otherwise the assertions below are vacuous.
+    expect(plainSends.length).toBeGreaterThan(1)
+
+    // Exactly ONE live keyboard, and it is on the LAST message the user sees.
+    const withMarkup = plainSends.filter((s) => s.opts.reply_markup != null)
+    expect(withMarkup).toHaveLength(1)
+    expect(plainSends[plainSends.length - 1]!.opts.reply_markup).toEqual(markup)
+
+    // Exactly ONE quote-reply, and it is on the FIRST message.
+    const withQuote = plainSends.filter((s) => s.opts.reply_parameters != null)
+    expect(withQuote).toHaveLength(1)
+    expect(plainSends[0]!.opts.reply_parameters).toEqual(replyParams)
+
+    // Per-message policy params still ride EVERY piece.
+    for (const s of plainSends) expect(s.opts.message_thread_id).toBe(9)
+
+    // And the answer itself is intact.
+    expect(plainSends.map((s) => s.text).join('').replace(/\s+/g, '')).toBe(
+      body.replace(/\s+/g, ''),
+    )
+  })
+
+  it('a single-piece fallback still carries both trailers on its one message', async () => {
+    const { deps, plainSends } = makeDeps()
+    const sentIds: number[] = []
+    await sendReplyChunks(deps, {
+      chatId: CHAT,
+      chunks: ['a short answer'],
+      literalText: false,
+      suppressText: false,
+      threadId: 9,
+      previewMessageId: null,
+      sentIds,
+      buildSendOpts,
+      buildPreviewEditOpts: () => ({}),
+    })
+    expect(plainSends).toHaveLength(1)
+    expect(plainSends[0]!.opts.reply_markup).toEqual(markup)
+    expect(plainSends[0]!.opts.reply_parameters).toEqual(replyParams)
+  })
+})
+
+describe('outbox sweep plain fallback — a mid-loop 429 does not re-deliver landed pieces', () => {
+  /**
+   * MAJOR 2. `createOutboxSend` wraps the WHOLE `sendChunkRich` — its
+   * multi-piece plain-fallback loop included — in
+   * `retryWithThreadFallback(deps.retry, …)`, and `createRetryApiCall`
+   * re-invokes that closure after a flood wait (`retry-api-call.ts`). So a 429
+   * on piece 4 of 5 re-ran the closure from the top: the rich send
+   * deterministically parse-rejects again and pieces 1-3 were re-sent into the
+   * user's chat. A mid-loop 429 is likely precisely in the flood conditions the
+   * sweep runs under.
+   *
+   * Asserted as the USER OUTCOME: every piece appears on the wire exactly once.
+   */
+  function floodError(retryAfter: number): GrammyError {
+    return new GrammyError(
+      'Call to sendMessage failed!',
+      {
+        ok: false,
+        error_code: 429,
+        description: 'Too Many Requests: retry after ' + retryAfter,
+        parameters: { retry_after: retryAfter },
+      },
+      'sendMessage',
+      {} as never,
+    )
+  }
+
+  /** Fake wire: rich always parse-rejects; the Nth plain send 429s ONCE. */
+  function fakeBot(floodOnCall: number) {
+    const plainSends: Array<{ text: string; opts: Record<string, unknown> }> = []
+    let richCalls = 0
+    let plainCalls = 0
+    let flooded = false
+    let id = 900
+    return {
+      plainSends,
+      richCalls: () => richCalls,
+      api: {
+        sendRichMessage: async () => {
+          richCalls++
+          throw parseRejectError('sendRichMessage')
+        },
+        sendMessage: async (_chatId: string, text: string, opts: Record<string, unknown>) => {
+          plainCalls++
+          if (text.length > PLAIN_TEXT_MAX_CHARS) throw tooLongError()
+          if (!flooded && plainCalls === floodOnCall) {
+            flooded = true
+            // Telegram rejected it — nothing landed for this piece.
+            throw floodError(1)
+          }
+          plainSends.push({ text, opts })
+          return { message_id: id++ }
+        },
+      },
+    }
+  }
+
+  it('resumes at the failed piece instead of re-sending pieces 1-3', async () => {
+    const bot = fakeBot(4)
+    // The REAL retry policy (which is what re-invokes the closure), with sleep
+    // stubbed so the flood wait costs no wall-clock time.
+    const retry = createRetryApiCall({ sleep: async () => {} })
+    const send = createOutboxSend({ getBot: () => bot as never, retry })
+    const body = longBody(20_000)
+
+    const res = await send(CHAT, null, body)
+
+    const expected = splitPlainTextToCap(body)
+    expect(expected.length).toBeGreaterThanOrEqual(5) // a real mid-loop failure
+
+    // Every piece delivered EXACTLY once, in order — no duplicate prefix.
+    expect(bot.plainSends.map((s) => s.text)).toEqual(expected)
+    // Bookkeeping matches the wire (no phantom / double-counted messages).
+    expect(res.chunks.map((c) => c.text)).toEqual(expected)
+    expect(res.chunks).toHaveLength(expected.length)
+    // The deterministic parse-reject is not re-issued on the retry either.
+    expect(bot.richCalls()).toBe(1)
+    // And nothing was lost.
+    expect(bot.plainSends.map((s) => s.text).join('').replace(/\s+/g, '')).toBe(
+      body.replace(/\s+/g, ''),
+    )
+  })
+
+  it('a 429 on the FINAL keyboard-bearing piece re-sends only that piece', async () => {
+    const body = longBody(20_000)
+    const expected = splitPlainTextToCap(body)
+    // Flood the LAST plain send — the piece that carries the button.
+    const bot = fakeBot(expected.length)
+    const markup = { inline_keyboard: [[{ text: '🔊 Listen', callback_data: 'voice:1' }]] }
+    const retry = createRetryApiCall({ sleep: async () => {} })
+    const send = createOutboxSend({
+      getBot: () => bot as never,
+      retry,
+      resolveReplyMarkup: () => markup,
+    })
+
+    await send(CHAT, null, body)
+
+    // The whole prefix is NOT re-delivered: one message per piece, no more.
+    expect(bot.plainSends.map((s) => s.text)).toEqual(expected)
     const withMarkup = bot.plainSends.filter((s) => s.opts.reply_markup != null)
     expect(withMarkup).toHaveLength(1)
     expect(bot.plainSends[bot.plainSends.length - 1]!.opts.reply_markup).toEqual(markup)


### PR DESCRIPTION
## Summary

Two independent defects in the outbox/send path. Both are cases where the machinery that exists to make sure a message *arrives* was the thing that dropped it.

**Long messages no longer fail to send (#4043).** Every send path chunks for the RICH wire cap (32768 chars). Three sites then degrade a chunk to the PLAIN `sendMessage` endpoint, which caps at **4096** — and none of them re-capped. Telegram answered `Bad Request: message is too long`, so the rescue send that exists precisely so a long answer is never lost failed too:

| # | Site | What the user lost |
|---|---|---|
| 1 | `telegram-plugin/gateway/outbound-send-path.ts:419` — reply parse-reject fallback | A long answer whose markdown Telegram rejects: partial-failure instead of an unformatted-but-delivered answer |
| 2 | `telegram-plugin/gateway/outbox-sweep.ts:473` — sweep parse-reject fallback | Worse than a loss: the record is never journaled and never cleared, so the same doomed send **retries on every 5s tick forever** |
| 3 | `telegram-plugin/gateway/outbound-send-path.ts:2680` — captured-prose exhausted-boundary fallback | The recovered answer replaced by the generic "sorry" apology |

Fixed once, at the source: `splitPlainTextToCap` in `format.ts` (safe markdown boundaries first, hard slice for an indivisible region), applied at all three. `PLAIN_TEXT_MAX_CHARS` moves to `format.ts` so a degradation site can re-cap without importing the renderer; `render/rich-render.ts` re-exports it for its existing importers.

**The sweep can't double-run (#3864).** `startOutboxSweep` fires every 5s and `void`s the sweep it starts, so a sweep slower than the interval had the *next* tick start a second concurrent body over the same outbox directory, and the tick after that a third. The per-record rename mutex (`outbox.ts` `claimRecord`) kept a single record from being double-SENT — that's the only thing that did. The bodies still race the same journal / dedup / backoff state and multiply wire pressure at exactly the moment (a slow or flood-throttled Telegram) the sweep must issue *less*. The tick is now `createOutboxSweepTick` with a real `inFlight` single-flight guard: overlap is unrepresentable rather than merely survivable, and the guard is unit-testable without a timer, a gateway, or the filesystem.

## Why

Wave 0 item **W0-b** of the Telegram delivery design (RC2 + RC4). Both are prerequisites for **W1-b** (routing the sweep through the gated seam) and **W1-c** (moving normalization inside `deliver()`), which touch the same two files.

Job spec: `reference/jobs/talk-to-agents-from-anywhere.md` — "The user can drive their fleet from a phone… the interaction surface is where the user already is." A reply that 400s on the wire because a fallback forgot the plain-text cap is that surface failing silently.

## Test plan

Two new vitest files, both **revert-checked** (each fix removed individually reds its own test):

- `telegram-plugin/tests/plain-fallback-4096-cap.test.ts` (8) — the fake Telegram **enforces the real 4096 limit**, so a test that merely walked the fallback without the re-cap throws. Reverting each of the 3 sites reds its test with the verbatim production error `Bad Request: message is too long`. Also asserts nothing is dropped (bodies reassemble) and that a short parse-rejected chunk still goes out as exactly one message.
- `telegram-plugin/tests/outbox-sweep-single-flight.test.ts` (4) — asserts the number of sweep **bodies started**. Reverting the guard: `expected 3 to be 1`. Plus: the guard releases on a *rejecting* sweep (a throwing sweep must not wedge it), and the failure backoff still gates independently.

Scoped regression run, all green: `outbox-delivery`, `outbox-sweep-listen-button`, `outbox-sweep-flood-breaker`, `outbox-reply-then-recap-e2e`, `send-reply-golden`, `outbound-send-path`, `render/render-outbound-chunks` (195 tests). `npm run lint` clean, including `check-bot-api-wrapping` and `check-retry-flood-hooks`.

## Risk

Low, and deliberately narrow — **no refactor of the delivery seam** (that is Wave 1 and would conflict).

- The re-cap is a **no-op on the common path**: `splitPlainTextToCap` returns `[text]` unchanged when the body already fits, so a short parse-rejected chunk behaves byte-identically to before.
- The sweep's plain fallback can now land several messages for one rich chunk, so `createOutboxSend` reports **one entry per message actually landed** — history / journal bookkeeping tracks the wire rather than the pre-split chunk. A trailing `reply_markup` (the 🔊 Listen button) rides the final piece only, pinned by a test (no duplicate buttons).
- The single-flight guard can only *defer* a tick, never disable the sweep: the outbox is a durable safety net with no latency SLA, and the in-flight sweep picks up whatever the skipped tick would have. Overlap is logged once per streak plus a completion summary, so a genuinely slow sweep is visible instead of silent.

Refs #3864, #4043

---

## Review follow-up (b55a80a1) — two MAJORs fixed

Both are consequences of splitting ONE logical message into N wire messages; both were found in adversarial review of the re-cap above, and both had a test gap.

### MAJOR 1 — the reply path duplicated message-scoped trailers (closes #4118)

`buildSendOpts` (`telegram-plugin/gateway/outbound-send-path.ts:1994-2011`) builds opts for **one** message: `reply_markup` on the last chunk, `reply_parameters` on the quoting chunk. `sendChunkPlainText` then re-caps that chunk into N plain pieces and passed the **same** opts object to every one. A parse-rejected final chunk over 4096 therefore landed N live inline keyboards — `single_use` only strips the keyboard off the message that was *tapped*, so the user could fire the same action N times — plus N quote-replies.

Fixed at `outbound-send-path.ts:446-454`: the keyboard rides the **final** piece only (the treatment the sweep path already applied via `withoutMarkup`), the quote the **first** piece only. A single-piece fallback returns `opts` unchanged, so the non-split path is byte-identical to before. Thread id / link-preview / `protect_content` / `disable_notification` are per-message policy and still ride every piece.

### MAJOR 2 — a mid-loop 429 replayed already-landed pieces

`createOutboxSend` wraps the whole of `sendChunkRich` — its multi-piece plain-fallback loop included — in `retryWithThreadFallback(deps.retry, …)`, and `createRetryApiCall` re-invokes that closure after a flood wait (`telegram-plugin/retry-api-call.ts:382`, `await sleep(delayMs); continue`). So a 429 on piece 4 of 5 re-ran the closure from the top: the rich send parse-rejects **deterministically** again and pieces 1-3 were re-delivered into the user's chat, repeating until the whole loop happened to succeed. A mid-loop 429 is likely precisely in the flood conditions the sweep runs under.

Fixed at `telegram-plugin/gateway/outbox-sweep.ts:496-545` + `:593-600` by carrying per-chunk resume state (`ChunkSendState`) **outside** the re-invoked closure, so the loop resumes at the first unsent piece.

**Why resume state rather than wrapping each `sendMessage` in its own `deps.retry`** (the other option the review offered): the state makes the send idempotent under **any** re-invocation — the retry policy's flood re-drive *and* `retryWithThreadFallback`'s thread-drop re-drive (`retry-api-call.ts:561`) alike — instead of only the one path we thought of. A nested per-piece retry would also multiply the attempt and flood-sleep budgets (`maxRetries²`) at exactly the moment the policy exists to issue *less*, and it would **still** re-send pieces 1-3 whenever the inner budget was exhausted and the error bubbled to the outer wrapper — so it does not actually close the defect. The state additionally suppresses re-issuing the known-deterministic rich parse-reject, saving one 400 against a flood-sensitive endpoint per retry.

### Tests

Added to `telegram-plugin/tests/plain-fallback-4096-cap.test.ts`, asserting the user-visible outcome:

- oversized keyboard+quote reply ⇒ exactly one keyboard (final piece), exactly one quote (first piece), thread id on every piece
- single-piece fallback ⇒ both trailers still on its one message
- 429 on piece 4 ⇒ each piece on the wire exactly once, rich send issued once, `res.chunks` aligned to the wire
- 429 on the final keyboard-bearing piece ⇒ the prefix is not re-delivered

**Revert-check** (source reverted, tests kept): **3 failed / 9 passed**. With the fix: **12 passed**. The three failures are the three new outcome assertions —
`expected [ … ] to have a length of 1 but got 6` (six live keyboards), and two `expected [ …(9) ] / [ …(11) ] to deeply equal [ …(6) ]` (nine and eleven messages delivered for a six-piece body).

### Deliberately out of scope

`sendChunkResplit` (same file, the **length**-error arm rather than the parse-reject arm) has the same trailer-duplication shape. Filed as #4119 rather than folded in here, per the Development Protocol's "lows get filed as follow-up issues rather than fixed now".

Closes #4118. Refs #4119
