### PR TITLE
feat(hindsight): make HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY reachable

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2664,7 +2664,12 @@ export const HindsightConfigSchema = z.object({
       "HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS — the reserved slot FLOOR for the " +
       "retain (memory write) lane, carved from that same total; unset means " +
       "upstream's own 0, i.e. no floor and retain competes for the shared " +
-      "pool), plus the " +
+      "pool; and " +
+      "HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY — the cosine-similarity floor a " +
+      "candidate must reach to be returned by the semantic retrieval arm at " +
+      "all (0..1); unset means upstream's own 0.3, and where it should sit " +
+      "depends on the bank's embedding model and phrasing diversity, so " +
+      "switchroom ships no opinion), plus the " +
       "embedded-PostgreSQL (pg0) sizing keys switchroom manages in " +
       "src/setup/hindsight-pg-defaults.ts (`HINDSIGHT_PG_ENV_KEYS`: " +
       "SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE, " +

--- a/src/setup/hindsight-perf-defaults.test.ts
+++ b/src/setup/hindsight-perf-defaults.test.ts
@@ -347,7 +347,7 @@ describe("operator override wins", () => {
     expect(got.size).toBe(0);
   });
 
-  it("is overridable on exactly these twenty-eight keys, by name", () => {
+  it("is overridable on exactly these twenty-nine keys, by name", () => {
     // Spelled out, NOT derived from the three group arrays. HINDSIGHT_PERF_ENV_KEYS
     // is DEFINED as the union of those arrays, so asserting it equals that union
     // is a tautology — it passes no matter which keys are in the arrays. The
@@ -377,6 +377,7 @@ describe("operator override wins", () => {
       "HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT",
       "HINDSIGHT_API_RERANKER_MAX_CANDIDATES",
       "HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT",
+      "HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY",
       "HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY",
       "HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS",
       "HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT",
@@ -627,6 +628,69 @@ describe("HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS (override-only)", () => {
     expect(fromRun.get("HINDSIGHT_API_WORKER_MAX_SLOTS")).toEqual(["16"]);
     expect(fromRun.get("HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS")).toEqual(["5"]);
     expect(fromRun.get("HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT")).toEqual(["6"]);
+  });
+});
+
+describe("HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY (override-only)", () => {
+  const KEY = "HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY";
+  const CAPS = [
+    { gpu: false, localLlm: false },
+    { gpu: true, localLlm: false },
+    { gpu: false, localLlm: true },
+    { gpu: true, localLlm: true },
+  ];
+
+  it("is in the managed set but in NO defaults group", () => {
+    expect(HINDSIGHT_PERF_ENV_KEYS.has(KEY)).toBe(true);
+    expect(HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS.has(KEY)).toBe(true);
+    for (const group of [
+      HINDSIGHT_PERF_DEFAULTS_UNGATED,
+      HINDSIGHT_PERF_DEFAULTS_GPU,
+      HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM,
+    ]) {
+      expect(group.map(([k]) => k)).not.toContain(KEY);
+    }
+  });
+
+  it("survives resolveHindsightPerfOverrides from BOTH sources", () => {
+    expect(resolveHindsightPerfOverrides({ [KEY]: "0.2" }).get(KEY)).toBe("0.2");
+    expect(resolveHindsightPerfOverrides(undefined, { [KEY]: "0.2" }).get(KEY)).toBe("0.2");
+  });
+
+  it.each(CAPS)(
+    "is NOT emitted when unset (gpu=$gpu localLlm=$localLlm) — upstream's own 0.3 stands",
+    (caps) => {
+      // Override-only means REACHABLE, not changed: a host that sets nothing
+      // keeps upstream's 0.3 floor byte-for-byte. Emitting a value here would
+      // change retrieval behaviour on every install to fix a symptom measured
+      // on one.
+      expect(hindsightPerfEnv(caps).map(([k]) => k)).not.toContain(KEY);
+    },
+  );
+
+  it("reaches BOTH launch paths, with the operator's value, when set in hindsight.env", () => {
+    // The outcome that matters. Before this key entered the managed set, both
+    // of these were undefined: resolveHindsightPerfOverrides drops an
+    // unmanaged key silently, so the operator's line read as durable config in
+    // yaml and never reached the container — the floor stayed at 0.3 and the
+    // phrasing-sensitive semantic recall misses it causes stayed unfixable.
+    const perf = { env: { [KEY]: "0.2" }, processEnv: {} };
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false, perf);
+    const fromRun = runEnv(runArgs());
+    const fromCompose = composeEnv(
+      generateHindsightComposeSnippet(undefined, undefined, LOOPBACK_LITELLM, false, perf),
+    );
+    expect(fromRun.get(KEY)).toEqual(["0.2"]);
+    expect(fromCompose.get(KEY)).toEqual(["0.2"]);
+  });
+
+  it("still reaches the container on a host with NO gated capability", () => {
+    // It belongs to no capability group, so a gate-shaped regression that only
+    // emits grouped keys would drop it. Cloud endpoint + no GPU is the
+    // harshest gating case.
+    const perf = { env: { [KEY]: "0.25" }, processEnv: {} };
+    startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, false, perf);
+    expect(runEnv(runArgs()).get(KEY)).toEqual(["0.25"]);
   });
 });
 

--- a/src/setup/hindsight-perf-defaults.ts
+++ b/src/setup/hindsight-perf-defaults.ts
@@ -1041,6 +1041,48 @@ export const HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM: ReadonlyArray<readonly [string, 
  * one is set at all — must sit between that type's own reservation and
  * `WORKER_MAX_SLOTS`), so an incoherent combination fails loudly in the
  * container rather than silently here.
+ *
+ * ### `HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY`
+ *
+ * The floor on cosine similarity a candidate must reach to be returned by the
+ * semantic retrieval arm at all — upstream's configuration reference:
+ * "Minimum cosine similarity a candidate must reach to be returned by the
+ * semantic retrieval strategy. Must be between 0 and 1." Default **0.3**
+ * (`DEFAULT_SEMANTIC_MIN_SIMILARITY`, engine `config.py`), applied as a SQL
+ * `WHERE` floor inside the semantic retrieval arms — a candidate below it is
+ * not down-ranked, it is never fetched, so no amount of reranking or RRF
+ * consensus can recover it. The knob is upstream-documented since 0.8.0
+ * ("Semantic recall sensitivity is adjustable with a configurable minimum
+ * similarity threshold").
+ *
+ * The observed symptom that makes this worth managing: on a live bank, the
+ * query "What stage is each ProductOS article at right now?" returned
+ * nothing, while "Which are published and which are still in draft?" returned
+ * a full correct answer off the same bank seconds later. The first phrasing
+ * embedded below 0.3 against the relevant fact, so the semantic arm returned
+ * ZERO candidates and the query survived only on BM25 lexical overlap — a
+ * recall miss that is invisible in telemetry (the arm "succeeded", it just
+ * found nothing) and highly phrasing-sensitive. Where on a given bank the
+ * floor should sit depends on that bank's embedding model and phrasing
+ * diversity, which is a property of the deployment, not of switchroom.
+ *
+ * Override-only rather than defaulted, deliberately: this key exists to make
+ * the knob REACHABLE, not to change anyone's retrieval behaviour. Unset ⇒
+ * upstream's 0.3, byte-for-byte what every host runs today. Shipping a lower
+ * value fleet-wide would trade an unmeasured amount of semantic-arm precision
+ * (more marginal candidates competing for the reranker budget) on every
+ * install to fix a symptom measured on one — the same reasoning as the four
+ * keys above. Before this entry the key appeared nowhere in switchroom, so a
+ * `hindsight.env` line for it was silently discarded by
+ * `resolveHindsightPerfOverrides` — no error, no warning, the container kept
+ * 0.3 while the yaml read as durable config.
+ *
+ * ```yaml
+ * hindsight:
+ *   env:
+ *     # widen the semantic arm on a bank with paraphrase-heavy queries
+ *     HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY: "0.2"
+ * ```
  */
 export const HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS: ReadonlySet<string> = new Set([
   "HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY",
@@ -1048,6 +1090,7 @@ export const HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS: ReadonlySet<string> = new Set([
   "HINDSIGHT_API_RECENCY_DECAY_LINEAR_WINDOW_DAYS",
   "HINDSIGHT_API_WORKER_MAX_SLOTS",
   "HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS",
+  "HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY",
 ]);
 
 /**


### PR DESCRIPTION
## Summary

Adds `HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY` to `HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS` in `src/setup/hindsight-perf-defaults.ts`, so an operator `hindsight.env` line for it actually reaches the hindsight container. Override-only, no shipped default: a host that sets nothing keeps upstream's 0.3 floor byte-for-byte — this makes the knob reachable, it changes no one's retrieval behaviour.

## Why

**The silent-discard mechanism.** `resolveHindsightPerfOverrides()` does `if (!HINDSIGHT_PERF_ENV_KEYS.has(key)) continue;` — any `hindsight.env` key outside the managed set is dropped with no error and no warning. The operator writes a line, commits it, and believes they changed something they did not. This class of defect has already bitten the fleet once (`HINDSIGHT_API_WORKER_MAX_SLOTS: 16` sat in switchroom.yaml while the container booted `max_slots=10`; documented in this module's own comments).

**The knob is real and upstream-documented.** Hindsight's configuration reference: "Minimum cosine similarity a candidate must reach to be returned by the semantic retrieval strategy. Must be between 0 and 1", default **0.3**; the 0.8.0 changelog announces it verbatim: "Semantic recall sensitivity is adjustable with a configurable minimum similarity threshold (HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY)." It is applied as a SQL floor in the semantic retrieval arms — a candidate below it is never fetched, so no reranking or RRF consensus can recover it. Before this PR the key appeared nowhere in the switchroom repo, so setting it was a silent no-op.

**The observed symptom.** On a live bank, "What stage is each ProductOS article at right now?" returned nothing, while "Which are published and which are still in draft?" returned a full correct answer off the same bank seconds later. The first phrasing embedded below 0.3 against the relevant fact, got zero semantic candidates, and survived only on BM25 lexical overlap. The right floor depends on the bank's embedding model and phrasing diversity — a deployment property — which is exactly the shape `HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS` exists for ("an escape hatch that cannot be reached is not an escape hatch").

## Test plan

New `describe` block in `src/setup/hindsight-perf-defaults.test.ts`, modelled on the sibling override-only keys, asserting outcomes:

- an operator value reaches BOTH launch paths — the `docker run` argv (`startHindsight`) and the compose snippet (`generateHindsightComposeSnippet`)
- it still reaches the container on a host with NO gated capability (cloud LLM + no GPU)
- it survives `resolveHindsightPerfOverrides` from both yaml and process env
- absent an override, NO default is emitted for it on any of the four capability combinations
- the pinned 29-key managed-set literal list updated (forces the `src/config/schema.ts` doc update, also included)

**Mutation verification:** with the one-line source change reverted to `origin/main` (tests kept), the suite fails 5 tests — including both launch-path outcome assertions (`fromRun.get(KEY)` / `fromCompose.get(KEY)` came back undefined). Restored, 152/152 pass; scoped run of `hindsight-perf-defaults.test.ts` + `tests/hindsight-env-keys-are-reachable.test.ts` + `hindsight-env-drift.test.ts` is 188/188 green. `npm run lint` exit 0.

## Risk

Minimal: no default is emitted, so an unset key produces byte-identical container env to today. The only behaviour change is that a key operators could previously write-and-lose is now honoured.

Job spec: `reference/jobs/remember-across-sessions.md` — a recall miss that depends on how the user happened to phrase the question is precisely "the agent brings back relevant facts ... without the user reminding it" failing; this gives the operator the sanctioned upstream lever to tune it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
