### PR TITLE
fix(telegram): stop escalating retried-and-delivered replies; delete the dead robustApiCall factory (#3931, #3863, #4044)

### DIFF
--- a/docs/fleet-health.md
+++ b/docs/fleet-health.md
@@ -105,7 +105,7 @@ The model-free sensor's explicit, documented mapping (source of truth:
 |---|---|---|---|
 | `silent-no-op-candidate` (complete, 0 tools, real turn) | silent-no-op | 3 | `know-what-my-agent-is-doing` |
 | `duplicate-delivery-represent` (`represent duplicate-send`) | duplicate | 2 | `talk-to-agents-from-anywhere` |
-| `reply-delivery-failure` (`sendRichMessage … status=err`) | success-theater | 3 | `talk-to-agents-from-anywhere` |
+| `reply-delivery-failure` (`sendRichMessage … status=err` — terminal only; a retried attempt logs `status=retry`, #3931) | success-theater | 3 | `talk-to-agents-from-anywhere` |
 | `hang-long-stalled` (>6 min AND ≤2 tools) | partial | 2 | `steer-or-queue-mid-flight` |
 | `killed-incomplete-turn` (status ∉ complete/no_reply) | missed-trigger | 3 | `steer-or-queue-mid-flight` |
 | `represent-escalation` (`obligation escalation`) | drift | 1 | `feel-like-a-colleague` |

--- a/src/fleet-health/detect.ts
+++ b/src/fleet-health/detect.ts
@@ -149,12 +149,24 @@ export interface AgentScanResult {
  * Precise gateway log signatures. Precision-filtered so a `getUpdates` network
  * blip never counts as a delivery failure — the reply-delivery pattern matches
  * ONLY a `sendRichMessage` non-ok status. Regex sources match the reference
- * detector's `grep -E` patterns exactly.
+ * detector's `grep -E` patterns exactly, except where noted below.
+ *
+ * #3931 — `reply-delivery-failure` is an OUTCOME signal, not an attempt signal.
+ * The `tg-post` transformer runs below the retry policy and logs one line per
+ * POST attempt, so a 429 that was slept and retried SUCCESSFULLY used to emit a
+ * matching `status=err` line and escalate a reply the operator had already
+ * received — a severity-3 alert on a delivered message. The transformer now
+ * labels a failure the policy is about to retry `status=retry`
+ * (`telegram-plugin/shared/bot-runtime.ts`, `willRetryTelegramFailure` in
+ * `telegram-plugin/retry-api-call.ts`), so only terminal failures carry
+ * `status=err`. The `(?![a-z])` guard makes that structural rather than
+ * incidental: it pins the match to the exact token `err`, so no future
+ * `err<suffix>` tier can silently re-enter this signal.
  */
 export const GATEWAY_SIGNATURES: Record<GatewaySignal, RegExp> = {
   "duplicate-delivery-represent": /represent duplicate-send/,
   "represent-escalation": /obligation escalation/,
-  "reply-delivery-failure": /tg-post method=sendRichMessage[^\n]*status=err/,
+  "reply-delivery-failure": /tg-post method=sendRichMessage[^\n]*status=err(?![a-z])/,
 };
 
 /** Parse `turns.jsonl` text into records, silently skipping malformed lines

--- a/src/fleet-health/mapping.ts
+++ b/src/fleet-health/mapping.ts
@@ -36,9 +36,11 @@ export interface SignalMapping {
  *   no-op — the operator cannot tell the agent did nothing. severity 3.
  * - `duplicate-delivery-represent` / `reply-delivery-failure` →
  *   `talk-to-agents-from-anywhere`: the answer's delivery to the principal is
- *   the job; a duplicate send or a failed `sendRichMessage` is a delivery
- *   defect on that job. (The clerk/marko represent-duplicate case the RFC
- *   validated on lands here.) duplicate = severity 2, delivery-failure = 3.
+ *   the job; a duplicate send or a TERMINALLY failed `sendRichMessage` is a
+ *   delivery defect on that job. (The clerk/marko represent-duplicate case the
+ *   RFC validated on lands here.) duplicate = severity 2, delivery-failure = 3.
+ *   #3931: a retried-and-delivered attempt is not a delivery failure and is
+ *   excluded at the log-line level (`status=retry`), not by this mapping.
  * - `hang-long-stalled` / `killed-incomplete-turn` →
  *   `steer-or-queue-mid-flight`: a turn that hangs or is killed mid-flight is
  *   a responsiveness failure on the in-flight-control job. hang = 2, killed = 3
@@ -72,6 +74,11 @@ export const SIGNAL_MAP: Record<L0Signal, SignalMapping> = {
     signature: "represent-duplicate-send:reply-tool-not-called",
   },
   "reply-delivery-failure": {
+    // #3931 — a TERMINAL send failure only. The `tg-post` transformer labels an
+    // attempt the retry policy is about to repeat `status=retry`, so a 429 that
+    // succeeded on retry no longer lands here. Severity 3 is only honest under
+    // that rule: before it, this signal opened sev-3 issues about replies the
+    // operator had already read.
     failure_mode: "success-theater",
     severity: 3,
     job_spec: "talk-to-agents-from-anywhere",

--- a/telegram-plugin/flood-429-ledger.ts
+++ b/telegram-plugin/flood-429-ledger.ts
@@ -362,9 +362,11 @@ export function writeFlood429Ledger(
  * call at the ~5s cadence a long ban produces, because the fold collapses
  * those into a single episode instead of growing the file.
  *
- * Read-fold-write is not atomic across processes: the gateway and the MCP
- * server's `createRobustApiCall` share one state dir, so a simultaneous 429 in
- * both could drop one episode. That is deliberate — the alternative is a lock
+ * Read-fold-write is not atomic across processes. Today every writer lives in
+ * the gateway process (its two `createRetryApiCall` wirings plus the outbox
+ * sweep's, all on one event loop), but the ledger is keyed by state DIR, so a
+ * second process wiring the breaker could drop one episode on a simultaneous
+ * 429. That is deliberate — the alternative is a lock
  * on the send path's error handler, and the cost of losing an episode is
  * nil: a penalty stays on the ledger for seven days and is re-recorded by the
  * next 429, so no verdict tier turns on a single write landing.

--- a/telegram-plugin/flood-circuit-breaker.ts
+++ b/telegram-plugin/flood-circuit-breaker.ts
@@ -235,9 +235,17 @@ export function writeFloodState(
  * classifies it (`src/cli/doctor-flood-pressure.ts`).
  *
  * Recording here rather than at the gateway callsites is deliberate: this is
- * the one function EVERY `onFloodWait` wiring goes through (gateway.ts's two
- * hooks and `shared/bot-runtime.ts`'s `createRobustApiCall`), so no future
- * callsite can record a window without also recording its history.
+ * the one function EVERY `onFloodWait` wiring goes through, so no future
+ * callsite can record a window without also recording its history. The live
+ * wirings are `gateway/gateway.ts:5715` (`robustApiCall`) and `:5849`
+ * (`nonEssentialApiCall`), plus `gateway/outbox-sweep.ts:582` — and
+ * `scripts/check-retry-flood-hooks.mjs` fails the build if a new
+ * `createRetryApiCall` site omits either breaker hook.
+ *
+ * (Until #3863 this docblock also cited `shared/bot-runtime.ts`'s
+ * `createRobustApiCall` as a live wiring. It had zero production callers and
+ * its breaker hooks were OPTIONAL, so it was deleted rather than counted.
+ * Cite only wirings the lint gate can see.)
  */
 export function makeFloodWaitRecorder(
   path: string,

--- a/telegram-plugin/retry-api-call.ts
+++ b/telegram-plugin/retry-api-call.ts
@@ -27,6 +27,96 @@
  */
 
 import { GrammyError } from 'grammy'
+import { AsyncLocalStorage } from 'async_hooks'
+
+// ─── retry-attempt context (#3931) ────────────────────────────────────────
+
+/**
+ * What the retry policy knows about the attempt currently on the wire.
+ *
+ * Published so the layer BELOW the policy — the `tg-post` observability
+ * transformer in `shared/bot-runtime.ts`, which runs inside `fn()` and
+ * therefore sees a failure *before* the policy decides what to do with it —
+ * can label a doomed-but-non-terminal attempt honestly instead of as a
+ * delivery failure. Without it, a 429 that the policy sleeps and retries
+ * SUCCESSFULLY still wrote `status=err` to the gateway log, and fleet-health's
+ * per-line `reply-delivery-failure` detector escalated a delivered reply
+ * (#3931).
+ */
+export interface TgAttemptContext {
+  /** 0-based index of the attempt currently executing. */
+  attempt: number
+  /** Total attempts this policy will make. */
+  maxRetries: number
+  /** Longest 429 `retry_after` the policy will sleep in-process. */
+  maxFloodSleepMs: number
+}
+
+const attemptStore = new AsyncLocalStorage<TgAttemptContext>()
+
+/** The attempt context of the enclosing `retryApiCall`, or undefined outside one. */
+export function _getTgAttemptContext(): TgAttemptContext | undefined {
+  return attemptStore.getStore()
+}
+
+/** Run `fn` with `ctx` visible to `_getTgAttemptContext()` for its whole async chain. */
+function withAttemptContext<T>(ctx: TgAttemptContext, fn: () => Promise<T>): Promise<T> {
+  return attemptStore.run(ctx, fn)
+}
+
+/**
+ * The transient network-error classifier the retry loop uses. Exported so the
+ * "will this be retried?" predicate cannot drift from the loop's own decision.
+ */
+export function isTransientNetworkMessage(msg: string): boolean {
+  return (
+    msg.includes('ECONNRESET') ||
+    msg.includes('ETIMEDOUT') ||
+    msg.includes('fetch failed') ||
+    msg.includes('ENOTFOUND')
+  )
+}
+
+/** The parts of a Telegram failure that decide retryability. */
+export interface TgFailureShape {
+  /** Telegram `error_code`, or null/undefined for a transport-level error. */
+  errorCode?: number | null
+  /** Telegram `parameters.retry_after`, seconds. */
+  retryAfterSec?: number | null
+  /** Transport-level error message (only consulted when `errorCode` is absent). */
+  message?: string | null
+}
+
+/**
+ * Will the enclosing retry policy issue ANOTHER attempt after this failure?
+ *
+ * `true` means the failure is non-terminal: a later attempt may still deliver,
+ * so it must not be logged (or detected) as a delivery failure. `false` means
+ * either there is no retry policy above this call, or this attempt is the last
+ * one, or the error class is not retryable — i.e. the failure IS the outcome.
+ *
+ * Mirrors `createRetryApiCall`'s loop exactly:
+ *   - no enclosing policy                           ⇒ terminal
+ *   - last attempt (`attempt >= maxRetries-1`)      ⇒ terminal (loop falls through)
+ *   - 429 with `retry_after` over the sleep ceiling ⇒ terminal (FLOOD_WAIT_ACTIVE)
+ *   - 429 under the ceiling                         ⇒ retried
+ *   - transient transport error                     ⇒ retried
+ *   - anything else                                 ⇒ terminal (rethrown)
+ */
+export function willRetryTelegramFailure(
+  failure: TgFailureShape,
+  ctx: TgAttemptContext | undefined = _getTgAttemptContext(),
+): boolean {
+  if (ctx == null) return false
+  if (ctx.attempt >= ctx.maxRetries - 1) return false
+  if (failure.errorCode === 429) {
+    const retryAfter = Number(failure.retryAfterSec ?? 5)
+    const delayMs = (Number.isFinite(retryAfter) ? retryAfter : 5) * 1000
+    return delayMs <= ctx.maxFloodSleepMs
+  }
+  if (failure.errorCode != null) return false
+  return isTransientNetworkMessage(failure.message ?? '')
+}
 
 export interface RetryCallOpts {
   /**
@@ -379,7 +469,10 @@ export function createRetryApiCall(
         throw gated
       }
       try {
-        return await fn()
+        // #3931 — publish the attempt context for the duration of the wire
+        // call so the `tg-post` transformer underneath can tell a retried
+        // failure from a terminal one.
+        return await withAttemptContext({ attempt, maxRetries, maxFloodSleepMs }, fn)
       } catch (err) {
         const isGrammyErr = err instanceof GrammyError
         const msg = err instanceof Error ? err.message : String(err)
@@ -459,13 +552,7 @@ export function createRetryApiCall(
         }
 
         // Network-level transient errors — exponential backoff, bounded.
-        if (
-          !isGrammyErr &&
-          (msg.includes('ECONNRESET') ||
-            msg.includes('ETIMEDOUT') ||
-            msg.includes('fetch failed') ||
-            msg.includes('ENOTFOUND'))
-        ) {
+        if (!isGrammyErr && isTransientNetworkMessage(msg)) {
           if (attempt < maxRetries - 1) {
             const delayMs = Math.pow(2, attempt) * 1000
             log?.(

--- a/telegram-plugin/shared/bot-runtime.ts
+++ b/telegram-plugin/shared/bot-runtime.ts
@@ -5,8 +5,8 @@
  * standalone foreman bot before its retirement.
  *
  * What lives here:
- *   - `createRobustApiCall` — thin re-export of createRetryApiCall pre-wired
- *     with stderr logging (mirrors how gateway.ts constructs `robustApiCall`).
+ *   - `installTgPostLogger` / `installRichMarkdownGuard` — the grammy API
+ *     transformers every outbound call transits.
  *   - `makeSwitchroomExec` / `makeSwitchroomExecCombined` — factory fns for
  *     the switchroom CLI exec helpers (callers pass their own CLI path / config
  *     env so each process can be configured independently).
@@ -28,8 +28,7 @@ import { execFileSync, spawnSync } from 'child_process'
 import { createHash } from 'crypto'
 import { AsyncLocalStorage } from 'async_hooks'
 import { clearStaleTelegramPollingState } from '../startup-reset.js'
-import { createRetryApiCall, classifyBenignTelegram400 } from '../retry-api-call.js'
-import { makeFloodWaitRecorder, makeFloodWaitProbe } from '../flood-circuit-breaker.js'
+import { classifyBenignTelegram400, willRetryTelegramFailure } from '../retry-api-call.js'
 import { RICH_MESSAGE_MAX_CHARS } from '../format.js'
 import { shouldEmitTgPost, type TgPostStatus } from './gw-trace-gate.js'
 import { guardAccidentalFormatting } from '../rich-send.js'
@@ -102,7 +101,7 @@ function shortDesc(raw: string | undefined): string {
  *
  * Log shape (one line per POST, on both success and failure):
  *
- *   tg-post method=<m> chat=<id> thread=<id|-> parse_mode=<HTML|MarkdownV2|none> bytes=<n> hash=<sha1-12> status=<ok|benign|err> err=<class-or--> code=<http-or--> desc=<short|-->
+ *   tg-post method=<m> chat=<id> thread=<id|-> parse_mode=<HTML|MarkdownV2|none> bytes=<n> hash=<sha1-12> status=<ok|benign|retry|err> err=<class-or--> code=<http-or--> desc=<short|-->
  *
  * TRUTHFULNESS (#3927): grammY resolves the transformer chain with the raw
  * `ApiResponse`, and only converts `{ok:false}` into a thrown `GrammyError`
@@ -126,6 +125,17 @@ function shortDesc(raw: string | undefined): string {
  * classified by the shared `classifyBenignTelegram400`) gets `status=benign`
  * instead, so promoting real rejections out of `status=ok` doesn't bury
  * `grep status=err` under high-volume card-repaint no-ops.
+ *
+ * ATTEMPT vs OUTCOME (#3931): this transformer runs INSIDE `fn()`, i.e. below
+ * the retry policy, so it sees each attempt separately. A 429 that
+ * `createRetryApiCall` sleeps and then retries successfully is not a delivery
+ * failure — but it used to write `status=err`, and fleet-health's
+ * `reply-delivery-failure` detector (`src/fleet-health/detect.ts`) matches per
+ * LINE, so every retried-and-DELIVERED reply raised a severity-3 alert. The
+ * retry policy now publishes its attempt context (`_getTgAttemptContext`), and
+ * a failure the policy is about to retry is logged `status=retry` instead.
+ * `status=err` is therefore an OUTCOME: the logical send is over and nothing
+ * landed. Nothing is hidden — the retry lines are still emitted verbatim.
  *
  * Body content is never logged — only its length and a 12-char sha1 prefix
  * so we can recognise repeated identical sends without leaking PII. The
@@ -164,12 +174,27 @@ export function installTgPostLogger(bot: Bot): void {
       // converts `{ok:false}` to a thrown GrammyError only after this chain
       // returns (see the docblock). Same defensive shape as the edit fuse's
       // `runObserved` (edit-flood-fuse.ts).
-      const r = res as unknown as { ok?: boolean; error_code?: number; description?: string }
+      const r = res as unknown as {
+        ok?: boolean
+        error_code?: number
+        description?: string
+        parameters?: { retry_after?: number }
+      }
       if (r != null && typeof r === 'object' && r.ok === false) {
         const code = r.error_code
         const benign = classifyBenignTelegram400(code, r.description)
+        // #3931 — an attempt the enclosing retry policy is about to repeat is
+        // not an outcome; label it `retry` so it is never read as a delivery
+        // failure. Terminal rejections keep `status=err`.
+        const retrying =
+          benign === null &&
+          willRetryTelegramFailure({
+            errorCode: code ?? null,
+            retryAfterSec: r.parameters?.retry_after ?? null,
+            message: r.description ?? null,
+          })
         emit(
-          benign !== null ? 'benign' : 'err',
+          benign !== null ? 'benign' : retrying ? 'retry' : 'err',
           `telegram_${code ?? 'unknown'}`,
           code != null ? String(code) : '-',
           shortDesc(r.description),
@@ -186,7 +211,18 @@ export function installTgPostLogger(bot: Bot): void {
       const rawDesc = err instanceof GrammyError
         ? (err as GrammyError).description
         : (err instanceof Error ? err.message : '')
-      emit('err', errClass, code, shortDesc(rawDesc))
+      // #3931 — same attempt-vs-outcome rule as the resolved-rejection branch
+      // above. This branch carries the transport (`HttpError`) failures, whose
+      // transient members the retry policy backs off and repeats.
+      const retrying = willRetryTelegramFailure({
+        errorCode: err instanceof GrammyError ? (err as GrammyError).error_code : null,
+        retryAfterSec:
+          err instanceof GrammyError
+            ? ((err as GrammyError).parameters?.retry_after ?? null)
+            : null,
+        message: err instanceof Error ? err.message : String(err ?? ''),
+      })
+      emit(retrying ? 'retry' : 'err', errClass, code, shortDesc(rawDesc))
       throw err
     }
   })
@@ -248,32 +284,23 @@ export function installRichMarkdownGuard(bot: Bot): void {
   })
 }
 
-// ─── robustApiCall factory ────────────────────────────────────────────────
-
-/**
- * Creates a robust API call wrapper pre-wired with stderr logging.
- * This is exactly how gateway.ts constructs its `robustApiCall`.
- *
- * Usage:
- *   const robustApiCall = createRobustApiCall()
- */
-export function createRobustApiCall(opts: { floodStatePath?: string } = {}) {
-  return createRetryApiCall({
-    log: (line) => process.stderr.write(line),
-    // #2923: persist every observed 429 flood-wait window so a restart during
-    // the ban can suppress non-essential sends (boot cards) instead of feeding
-    // the per-bot flood counter and prolonging the ban.
-    // #3084: and refuse to issue a call while that window is still open —
-    // otherwise the card heartbeats re-drive a request into the ban every
-    // few seconds once the policy stops sleeping long waits.
-    ...(opts.floodStatePath
-      ? {
-          onFloodWait: makeFloodWaitRecorder(opts.floodStatePath),
-          floodWaitRemainingMs: makeFloodWaitProbe(opts.floodStatePath),
-        }
-      : {}),
-  })
-}
+// ─── robustApiCall factory: REMOVED (#3863) ───────────────────────────────
+//
+// `createRobustApiCall` used to live here as a second `createRetryApiCall`
+// wiring "pre-wired with stderr logging", kept for a standalone foreman bot
+// that was retired. It had ZERO production callers, and its breaker hooks were
+// OPTIONAL (`floodStatePath` defaulted to absent), so the one thing a second
+// wiring must never be — a send path blind to the shared flood window — was
+// its default. Docblocks in `flood-circuit-breaker.ts` and `flood-429-ledger.ts`
+// cited it as a live wiring, which is how a dead function became load-bearing
+// documentation for the breaker's completeness argument.
+//
+// There is one retry wiring per process, built at its own callsite with both
+// breaker hooks (`gateway.ts`'s `robustApiCall`, `outbox-sweep.ts`'s sweep
+// caller) and enforced by `scripts/check-retry-flood-hooks.mjs`. Do not
+// reintroduce a convenience factory here: it re-creates the hook-optional
+// default this deletion removed. `tests/no-robust-api-call-factory.test.ts`
+// guards that.
 
 // ─── Markdown escape helpers (#2669) ──────────────────────────────────────
 

--- a/telegram-plugin/shared/gw-trace-gate.ts
+++ b/telegram-plugin/shared/gw-trace-gate.ts
@@ -68,8 +68,18 @@ const ZERO_SIGNAL_POLL_METHODS = new Set(['getUpdates', 'getMe'])
  * `status=err` signal in high-volume card-repaint no-ops: `grep status=err`
  * stays a list of real failures, and the benign lines are still there,
  * honestly labelled, for anyone who wants them.
+ *
+ * `retry` (#3931) is a REJECTED call that the enclosing retry policy is about
+ * to attempt AGAIN — a 429 under the in-process sleep ceiling, or a transient
+ * transport error with attempts left. It is not an outcome: the logical send
+ * may still be delivered by the next attempt, and usually is. It exists
+ * because `status=err` is consumed as a delivery FAILURE by fleet-health's
+ * `reply-delivery-failure` detector (`src/fleet-health/detect.ts`), which
+ * matches per LINE — so labelling a survivable attempt `err` escalated
+ * successfully delivered replies. Post-#3931 a `status=err` line means the
+ * logical send is over and it did not land.
  */
-export type TgPostStatus = 'ok' | 'benign' | 'err'
+export type TgPostStatus = 'ok' | 'benign' | 'err' | 'retry'
 
 /**
  * Decide whether a `tg-post` line should be written.
@@ -79,6 +89,8 @@ export type TgPostStatus = 'ok' | 'benign' | 'err'
  *
  * Always emitted:
  *   - any `status=err` (real failures — the whole point of the log),
+ *   - any `status=retry` (the survivable attempts behind a flood episode —
+ *     suppressing them would hide the run-up to a ban, #3931),
  *   - every other method's `ok` line (sendMessage/editMessageText/... are
  *     genuine outbound observability, #656/#657),
  *   - `status=benign` on any non-poll method — same volume as the
@@ -90,7 +102,7 @@ export function shouldEmitTgPost(
   verbose: boolean = gwTraceVerbose,
 ): boolean {
   if (verbose) return true
-  if (status === 'err') return true
+  if (status === 'err' || status === 'retry') return true
   return !ZERO_SIGNAL_POLL_METHODS.has(method)
 }
 

--- a/telegram-plugin/tests/flood-reply-queue.test.ts
+++ b/telegram-plugin/tests/flood-reply-queue.test.ts
@@ -36,7 +36,7 @@ import {
   floodQueueNonce,
   FLOOD_QUEUED_SOURCE,
 } from '../gateway/flood-reply-queue.js'
-import { sweepOutbox } from '../gateway/outbox-sweep.js'
+import { sweepOutbox, type OutboxSendResult } from '../gateway/outbox-sweep.js'
 import { listPendingRecords, resolveOutboxDir, type OutboxRecord } from '../outbox.js'
 import {
   floodStatePath,
@@ -58,6 +58,32 @@ function floodWaitActiveError(retryAfterSec: number): Error {
 /** The reply path's own partial-failure wrapper around the marker. */
 function wrappedReplyFailure(): Error {
   return new Error('reply failed after 0 of 1 chunk(s) sent: FLOOD_WAIT_ACTIVE')
+}
+
+/**
+ * A sweep `send` stub with the REAL {@link OutboxSendResult} shape (#4044).
+ *
+ * These tests used to stub `send` as `async () => 4242` — a bare number, the
+ * pre-#3510 contract. `sweepOutbox` has read `.messageId` / `.chunks` off the
+ * result since, so the stub was silently lying: it journalled
+ * `tgMessageId: undefined` and would have THROWN on `.chunks.length` had the
+ * test wired `recordOutbound` — which the sweep's catch turns into a
+ * `sendFailure` and a re-send on the next tick, i.e. a duplicate delivery of
+ * the very answer this file exists to protect. The `journals the landed message id`
+ * test below asserts that outcome; this helper is what makes it representable.
+ */
+function makeSendStub(firstMessageId = 4242) {
+  let next = firstMessageId
+  return vi.fn(
+    async (
+      _chatId: string,
+      _threadId: number | null,
+      text: string,
+    ): Promise<OutboxSendResult> => {
+      const messageId = next++
+      return { messageId, chunks: [{ messageId, text }] }
+    },
+  )
 }
 
 function readRecords(dir: string): OutboxRecord[] {
@@ -280,7 +306,7 @@ describe('end-to-end: queued during the window, delivered after it closes', () =
 
     // 4. Sweeping WHILE the window is open must not touch the wire, and must
     //    not lose the record.
-    const send = vi.fn(async () => 4242)
+    const send = makeSendStub(4242)
     const during = await sweepOutbox({
       stateDir: dir,
       send,
@@ -318,6 +344,65 @@ describe('end-to-end: queued during the window, delivered after it closes', () =
     expect(listPendingRecords(dir)).toHaveLength(0)
   })
 
+  it('journals the landed message id and records history parity — not a send failure (#4044)', async () => {
+    // Regression for the stale `send` stub. `sweepOutbox` reads `.messageId`
+    // and `.chunks` off its `send` result (`OutboxSendResult`, outbox-sweep.ts
+    // :63-80). While these tests stubbed `send` as a bare number the contract
+    // was unguarded, and a stub-shaped production sender would (a) journal
+    // `tgMessageId: undefined`, losing the pointer to the delivered message,
+    // and (b) throw on `sendResult.chunks.length` — which the sweep's catch
+    // converts into `sendFailures++` and a claim RELEASE, so the next tick
+    // re-sends the operator's answer a second time. This asserts the outcome:
+    // delivered once, journalled with the REAL id, mirrored to history.
+    const answer = 'the answer that must land exactly once'
+    const t0 = 1_000_000
+    queueFloodBlockedReply({
+      err: floodWaitActiveError(30),
+      chatId: '777',
+      threadId: null,
+      text: answer,
+      priorityClass: 'critical',
+      stateDir: dir,
+      createdAt: t0,
+    })
+
+    const send = makeSendStub(9001)
+    const recorded: Array<[string, number | null, number[], string[]]> = []
+    const summary = await sweepOutbox({
+      stateDir: dir,
+      send,
+      recordOutbound: (chatId, threadId, messageIds, texts) => {
+        recorded.push([chatId, threadId, messageIds, texts])
+      },
+      textAlreadyDelivered: () => false,
+      now: () => t0 + 10_000,
+    })
+
+    // Delivered — and NOT counted as a send failure.
+    expect(summary.delivered).toBe(1)
+    expect(summary.sendFailures).toBe(0)
+    expect(send).toHaveBeenCalledTimes(1)
+
+    // The journal carries the id the wire actually returned, so a duplicate is
+    // provable from the journal alone (#3510).
+    const journal = readFileSync(join(resolveOutboxDir(dir), 'delivered.jsonl'), 'utf8')
+      .split('\n')
+      .filter((l) => l.trim() !== '')
+      .map((l) => JSON.parse(l) as { tgMessageId?: number; deliverySource?: string })
+    expect(journal).toHaveLength(1)
+    expect(journal[0]!.tgMessageId).toBe(9001)
+    expect(journal[0]!.deliverySource).toBe('sweep')
+
+    // And history got the landed ids + their delivered texts.
+    expect(recorded).toHaveLength(1)
+    expect(recorded[0]![0]).toBe('777')
+    expect(recorded[0]![2]).toEqual([9001])
+    expect(recorded[0]![3]!.join('')).toContain(answer)
+
+    // Nothing left to re-send.
+    expect(listPendingRecords(dir)).toHaveLength(0)
+  })
+
   it('does not double-deliver when the caller retries after the window closed', async () => {
     const answer = 'the one answer'
     const t0 = 1_000_000
@@ -331,7 +416,7 @@ describe('end-to-end: queued during the window, delivered after it closes', () =
       createdAt: t0,
     })
 
-    const send = vi.fn(async () => 1)
+    const send = makeSendStub(1)
     await sweepOutbox({
       stateDir: dir,
       send,
@@ -381,7 +466,7 @@ describe('end-to-end: queued during the window, delivered after it closes', () =
       })
     })
 
-    const send = vi.fn(async () => 1)
+    const send = makeSendStub(1)
     await sweepOutbox({
       stateDir: dir,
       send,

--- a/telegram-plugin/tests/no-robust-api-call-factory.test.ts
+++ b/telegram-plugin/tests/no-robust-api-call-factory.test.ts
@@ -1,0 +1,62 @@
+/**
+ * `createRobustApiCall` must stay deleted (#3863).
+ *
+ * It was a second `createRetryApiCall` wiring in `shared/bot-runtime.ts`,
+ * described as "exactly how gateway.ts constructs its robustApiCall". It had
+ * ZERO production callers — and, worse, its flood-breaker hooks were OPTIONAL
+ * (`floodStatePath` defaulted to absent), so the default construction was a
+ * send path blind to the shared flood window: the exact failure
+ * `scripts/check-retry-flood-hooks.mjs` exists to prevent, sitting in the file
+ * a future caller would naturally reach for.
+ *
+ * It was also load-bearing DOCUMENTATION: `flood-circuit-breaker.ts` and
+ * `flood-429-ledger.ts` both cited it as a live wiring, so the breaker's
+ * "every onFloodWait goes through here" completeness argument was partly
+ * anchored to dead code.
+ *
+ * This is a source-level guard on purpose: the defect is the existence of the
+ * identifier, and there is no runtime behaviour to assert.
+ *
+ * The rule is "the name may appear only inside backticks" — i.e. as PROSE in a
+ * docblock explaining why it is gone. Any bare occurrence is code (a
+ * declaration, an import, a call) and fails.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, extname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = fileURLToPath(new URL('../../', import.meta.url))
+const SEARCH_ROOTS = ['telegram-plugin', 'src', 'bin', 'scripts', 'docs']
+const SKIP_DIRS = new Set(['node_modules', 'dist', '.git', 'vendor', 'coverage'])
+const SEARCH_EXTS = new Set(['.ts', '.tsx', '.js', '.mjs', '.cjs', '.md'])
+
+function* walk(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry)) continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) yield* walk(full)
+    else if (SEARCH_EXTS.has(extname(entry))) yield full
+  }
+}
+
+describe('#3863 — the dead createRobustApiCall factory', () => {
+  it('appears in no source, script or doc file except as backticked prose', () => {
+    const selfPath = fileURLToPath(import.meta.url)
+    const offenders: string[] = []
+    for (const root of SEARCH_ROOTS) {
+      for (const file of walk(join(REPO_ROOT, root))) {
+        if (file === selfPath) continue
+        // Drop the backticked (prose) occurrences; anything left is code.
+        const bare = readFileSync(file, 'utf8').replaceAll('`createRobustApiCall`', '')
+        if (bare.includes('createRobustApiCall')) offenders.push(file.slice(REPO_ROOT.length))
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+
+  it('is not exported by shared/bot-runtime.ts', async () => {
+    const mod = (await import('../shared/bot-runtime.js')) as Record<string, unknown>
+    expect(Object.keys(mod)).not.toContain('createRobustApiCall')
+  })
+})

--- a/telegram-plugin/tests/tg-post-logger-error-shape.test.ts
+++ b/telegram-plugin/tests/tg-post-logger-error-shape.test.ts
@@ -77,6 +77,10 @@ afterEach(() => {
 })
 
 describe('tg-post logger — resolved ok:false responses (#3927)', () => {
+  // These calls are made directly on `bot.api.*` with NO enclosing retry
+  // policy, so every rejection here IS the outcome and stays `status=err`.
+  // The `status=retry` tier (#3931) only applies inside `createRetryApiCall`
+  // — see `tg-post-retry-attribution.test.ts`.
   it('logs a 429 flood-wait as status=err code=429 (FAILS before the fix: logged status=ok)', async () => {
     const lines = await tgPostLinesFor({
       ok: false,

--- a/telegram-plugin/tests/tg-post-retry-attribution.test.ts
+++ b/telegram-plugin/tests/tg-post-retry-attribution.test.ts
@@ -1,0 +1,196 @@
+/**
+ * A reply that was rate-limited and then DELIVERED on retry must not raise a
+ * fleet-health delivery-failure alert (#3931).
+ *
+ * ── The bug ──────────────────────────────────────────────────────────────
+ * `installTgPostLogger` is a grammy API transformer, so it runs INSIDE the
+ * function the retry policy calls — it observes one POST ATTEMPT, never the
+ * logical send's outcome. A 429 that `createRetryApiCall` slept and retried
+ * successfully therefore left a `tg-post method=sendRichMessage … status=err`
+ * line in the gateway log, and fleet-health's `reply-delivery-failure`
+ * signature (`src/fleet-health/detect.ts`) matches per LINE. Result: a
+ * severity-3 "the answer never reached the principal" escalation for an answer
+ * the operator had already read. Under flood pressure (the class of event that
+ * produces 429s in the first place) that is the alarm that fires most.
+ *
+ * ── The fix these tests pin ──────────────────────────────────────────────
+ * The retry policy publishes its attempt context; the transformer labels an
+ * attempt the policy is about to repeat `status=retry`. `status=err` now means
+ * the logical send is OVER and nothing landed. Nothing is suppressed — the
+ * retry lines are still written, they just no longer masquerade as outcomes.
+ *
+ * These tests drive a REAL grammy `Bot` (a mock-`api` harness sits above the
+ * transformer layer, so it would be a false guard) through the REAL retry
+ * policy, and feed the REAL emitted lines to the REAL detector.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { Bot } from 'grammy'
+import { installTgPostLogger } from '../shared/bot-runtime.js'
+import { createRetryApiCall, willRetryTelegramFailure } from '../retry-api-call.js'
+import { detectGatewayFindings, scanAgent } from '../../src/fleet-health/detect.js'
+
+/** A real Bot whose transport answers with `envelopes[i]` for the i-th call. */
+function makeBot(envelopes: Array<Record<string, unknown>>): Bot {
+  let i = 0
+  const fakeFetch = (async () => {
+    const envelope = envelopes[Math.min(i, envelopes.length - 1)]
+    i++
+    // A Bot API rejection is an HTTP 200 carrying `ok:false` — which is
+    // precisely why it RESOLVES the transformer chain (see #3927).
+    return { ok: true, status: 200, json: async () => envelope } as unknown as Response
+  }) as unknown as typeof fetch
+
+  const bot = new Bot('123456:TEST_TOKEN', {
+    botInfo: {
+      id: 123456,
+      is_bot: true,
+      first_name: 'Test',
+      username: 'test_bot',
+      can_join_groups: false,
+      can_read_all_group_messages: false,
+      supports_inline_queries: false,
+      can_connect_to_business: false,
+      has_main_web_app: false,
+    },
+    client: { fetch: fakeFetch },
+  })
+  installTgPostLogger(bot)
+  return bot
+}
+
+const OK_ENVELOPE = {
+  ok: true,
+  result: { message_id: 7, date: 0, chat: { id: 4242, type: 'private' } },
+}
+const FLOOD_429 = {
+  ok: false,
+  error_code: 429,
+  description: 'Too Many Requests: retry after 3',
+  parameters: { retry_after: 3 },
+}
+
+/**
+ * Send one user-facing reply through the production composition
+ * (retry policy → transformer → wire) and return the gateway log lines it
+ * produced, shaped exactly as `gateway-supervisor.log` carries them.
+ */
+async function gatewayLinesForReply(
+  envelopes: Array<Record<string, unknown>>,
+): Promise<{ lines: string[]; threw: boolean }> {
+  const written: string[] = []
+  const spy = vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: unknown) => {
+    written.push(String(chunk))
+    return true
+  }) as unknown as typeof process.stderr.write)
+  let threw = false
+  try {
+    const bot = makeBot(envelopes)
+    // The real policy, with sleeping stubbed out so a 3s flood-wait doesn't
+    // cost the suite 3 seconds. Everything else is production behaviour.
+    const robustApiCall = createRetryApiCall({ sleep: async () => {} })
+    await robustApiCall(() =>
+      bot.api.sendRichMessage(4242, { markdown: 'the answer' }),
+    ).catch(() => {
+      threw = true
+    })
+  } finally {
+    spy.mockRestore()
+  }
+  const lines = written
+    .filter((l) => l.startsWith('tg-post '))
+    .map((l) => `2026-08-01T12:00:00Z gateway: ${l.trimEnd()}`)
+  return { lines, threw }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('#3931 — a retried-and-delivered reply raises no delivery-failure alert', () => {
+  it('429-then-ok: fleet-health sees zero reply-delivery-failures and does not escalate', async () => {
+    const { lines, threw } = await gatewayLinesForReply([FLOOD_429, OK_ENVELOPE])
+
+    // Ground truth: the reply WAS delivered. If this ever fails, the fixture
+    // stopped modelling the scenario and the assertions below mean nothing.
+    expect(threw).toBe(false)
+    expect(lines).toHaveLength(2)
+    expect(lines[1]).toContain('status=ok')
+
+    // THE outcome: the detector raises nothing, and the agent is not escalated.
+    const { gw_hits, findings } = detectGatewayFindings('alpha', lines.join('\n'))
+    expect(gw_hits['reply-delivery-failure']).toBe(0)
+    expect(findings.filter((f) => f.signal === 'reply-delivery-failure')).toHaveLength(0)
+    expect(scanAgent('alpha', '', lines.join('\n')).escalate).toBe(false)
+
+    // The evidence is not hidden — the rate-limit attempt is still on the log,
+    // honestly labelled as an attempt rather than an outcome.
+    expect(lines[0]).toContain('status=retry')
+    expect(lines[0]).toContain('code=429')
+  })
+
+  it('an ok:true reply is untouched — no retry tier leaks onto the happy path', async () => {
+    const { lines, threw } = await gatewayLinesForReply([OK_ENVELOPE])
+    expect(threw).toBe(false)
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain('status=ok')
+    expect(lines[0]).toContain('err=- code=- desc=-')
+  })
+})
+
+describe('#3931 — a genuinely undelivered reply still escalates', () => {
+  it('a terminal 403 escalates', async () => {
+    const { lines, threw } = await gatewayLinesForReply([
+      { ok: false, error_code: 403, description: 'Forbidden: bot was blocked by the user' },
+    ])
+    expect(threw).toBe(true)
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain('status=err')
+
+    expect(detectGatewayFindings('alpha', lines.join('\n')).gw_hits['reply-delivery-failure']).toBe(1)
+    expect(scanAgent('alpha', '', lines.join('\n')).escalate).toBe(true)
+  })
+
+  it('a 429 on EVERY attempt (retries exhausted, nothing landed) escalates exactly once', async () => {
+    const { lines, threw } = await gatewayLinesForReply([FLOOD_429])
+    expect(threw).toBe(true)
+    // Three attempts: two survivable, the last one terminal.
+    expect(lines).toHaveLength(3)
+    expect(lines.filter((l) => l.includes('status=retry'))).toHaveLength(2)
+    expect(lines.filter((l) => l.includes('status=err'))).toHaveLength(1)
+
+    // One alert for one lost answer — not one per attempt.
+    expect(detectGatewayFindings('alpha', lines.join('\n')).gw_hits['reply-delivery-failure']).toBe(1)
+    expect(scanAgent('alpha', '', lines.join('\n')).escalate).toBe(true)
+  })
+})
+
+describe('willRetryTelegramFailure — the predicate mirrors the retry loop', () => {
+  const ctx = { attempt: 0, maxRetries: 3, maxFloodSleepMs: 120_000 }
+
+  it('is false with no enclosing retry policy (a raw bot.api.* call is its own outcome)', () => {
+    expect(willRetryTelegramFailure({ errorCode: 429, retryAfterSec: 3 }, undefined)).toBe(false)
+  })
+
+  it('is false on the last attempt — the loop falls through to give-up', () => {
+    expect(
+      willRetryTelegramFailure({ errorCode: 429, retryAfterSec: 3 }, { ...ctx, attempt: 2 }),
+    ).toBe(false)
+  })
+
+  it('is false for a 429 over the in-process sleep ceiling (FLOOD_WAIT_ACTIVE, not retried)', () => {
+    expect(willRetryTelegramFailure({ errorCode: 429, retryAfterSec: 15908 }, ctx)).toBe(false)
+  })
+
+  it('is true for a 429 under the ceiling and for a transient transport error', () => {
+    expect(willRetryTelegramFailure({ errorCode: 429, retryAfterSec: 3 }, ctx)).toBe(true)
+    expect(willRetryTelegramFailure({ message: 'ECONNRESET' }, ctx)).toBe(true)
+  })
+
+  it('is false for the error classes the loop rethrows immediately', () => {
+    expect(willRetryTelegramFailure({ errorCode: 400, message: 'Bad Request' }, ctx)).toBe(false)
+    expect(willRetryTelegramFailure({ errorCode: 403 }, ctx)).toBe(false)
+    // Local disk exhaustion must NOT look retryable — retrying it is what
+    // trips the flood ban in the first place (#2923).
+    expect(willRetryTelegramFailure({ message: 'ENOSPC: no space left on device' }, ctx)).toBe(false)
+  })
+})

--- a/tests/check-retry-flood-hooks.test.ts
+++ b/tests/check-retry-flood-hooks.test.ts
@@ -165,8 +165,33 @@ describe('the real tree', () => {
     }
     const r = evaluateRetryHookWiring(files)
     expect(r.errors).toEqual([])
+
     // Sanity: the guard is actually finding wirings, not silently scanning zero
     // files (which would make the assertion above vacuous).
-    expect(r.sites.length).toBeGreaterThanOrEqual(4)
+    //
+    // The floor was 4 until #3863 (shipped in #4113) deleted
+    // `shared/bot-runtime.ts`'s `createRobustApiCall` — a fourth wiring with
+    // ZERO production callers whose breaker hooks were OPTIONAL (spread in only
+    // when the caller passed `floodStatePath`). It was deleted, not re-wired,
+    // so the live count is now 3. Do NOT lower this again to make a red build
+    // green: a drop below 3 means a real send path lost its wiring — or moved
+    // somewhere this scan no longer looks — which is exactly the #3849
+    // regression this guard exists to catch. Prove the wiring is gone on
+    // purpose first, and record why here.
+    expect(r.sites.length).toBeGreaterThanOrEqual(3)
+
+    // A bare count can be satisfied by the WRONG three sites — e.g. a rename or
+    // glob change hides the gateway's wirings while three others appear
+    // elsewhere. Pin the files that must still carry a wiring, so a scanner
+    // blind spot fails loudly by name instead of being masked by the count.
+    // Adding a genuinely new wiring is fine — add its file here in the same
+    // diff, so a new outbound send path is an acknowledged review decision.
+    const paths = r.sites.map((s: { path: string }) => s.path)
+    expect([...new Set(paths)].sort()).toEqual([
+      'telegram-plugin/gateway/gateway.ts',
+      'telegram-plugin/gateway/outbox-sweep.ts',
+    ])
+    // gateway.ts carries two: `robustApiCall` and `nonEssentialApiCall`.
+    expect(paths.filter((p: string) => p === 'telegram-plugin/gateway/gateway.ts')).toHaveLength(2)
   })
 })


### PR DESCRIPTION
## User-visible outcome

Fewer false delivery alarms. A reply that hit a Telegram 429, slept, and was **delivered on retry** no longer raises a severity-3 `reply-delivery-failure` escalation for an answer the operator has already read. Under flood pressure — precisely the condition that produces 429s — that was the alarm that fired most. Genuinely lost answers still escalate, exactly once per lost answer rather than once per attempt.

## #3931 — retried-and-delivered replies escalated

Root cause (validated in source, not assumed): `installTgPostLogger` is a grammy **API transformer**, so it runs *inside* the function `createRetryApiCall` retries. It observes one POST **attempt**, never the logical send's **outcome**. fleet-health's signature matches per LINE (`src/fleet-health/detect.ts:157`), so a survivable attempt read as a lost answer.

Fix is structural rather than heuristic (no err→ok line pairing in the detector):

- `telegram-plugin/retry-api-call.ts` — the retry loop publishes its attempt context (`attempt`, `maxRetries`, `maxFloodSleepMs`) over `AsyncLocalStorage` for the duration of the wire call, and exports `willRetryTelegramFailure()`, which mirrors the loop's own branch decisions. The loop's transient-network branch now calls the same exported predicate, so the two cannot drift.
- `telegram-plugin/shared/bot-runtime.ts` — the transformer labels an attempt the policy is about to repeat `status=retry` (both the resolved-`ok:false` path and the `catch` path).
- `telegram-plugin/shared/gw-trace-gate.ts` — new `retry` tier; still always emitted, so the run-up to a flood ban stays greppable. **Nothing is suppressed** — the lines just stop masquerading as outcomes.
- `src/fleet-health/detect.ts` — signature tightened to `status=err(?![a-z])`, so no future `err<suffix>` tier can silently re-enter the signal.
- Docs: `docs/fleet-health.md`, `src/fleet-health/mapping.ts` (sev-3 is honest *because* the signal is now terminal-only).

Post-change, `status=err` means: the logical send is over and nothing landed.

## #3863 — dead `createRobustApiCall` factory cited as a live wiring

`createRobustApiCall` in `shared/bot-runtime.ts` had **zero production callers**, and its flood-breaker hooks were OPTIONAL (`floodStatePath` defaulted absent) — i.e. the default construction was a send path blind to the shared flood window, the exact failure `scripts/check-retry-flood-hooks.mjs` exists to prevent, sitting in the file a future caller would reach for first. It was also load-bearing *documentation*: `flood-circuit-breaker.ts` and `flood-429-ledger.ts` both cited it, anchoring the breaker's "every `onFloodWait` goes through here" completeness argument to dead code.

Deleted. Docblocks now cite only the three wirings the lint gate can actually see: `gateway/gateway.ts:5715`, `:5849`, `gateway/outbox-sweep.ts:582`.

## #4044 — stale send stubs (contradicts the design doc)

The design doc flagged as UNVERIFIED that `flood-reply-queue.ts` has no production callers. **It is live.** `telegram-plugin/gateway/outbound-send-path.ts:55` imports `queueFloodBlockedReply` and `:1984` calls it inside `sendReply`'s chunk-loop catch; an existing source-scan guard test already asserts that wiring. So the stubs were fixed, not the module deleted.

The stale `vi.fn(async () => 4242)` number stubs masked a real hazard: against the real `OutboxSendResult` contract (#3510), with a `recordOutbound` dep wired, `sendResult.chunks.length` throws → the sweep's catch converts it to `sendFailures++` + claim release → **duplicate delivery on the next tick**.

## Tests (outcomes, not code paths)

- `tests/tg-post-retry-attribution.test.ts` (new, 9 tests) — drives a REAL grammy `Bot` through the REAL retry policy and feeds the REAL emitted lines to the REAL `detectGatewayFindings`/`scanAgent`. A mock-`api` harness sits *above* the transformer layer and would be a false guard.
- `tests/no-robust-api-call-factory.test.ts` (new, 2 tests) — the identifier may appear only as backticked prose.
- `tests/flood-reply-queue.test.ts` — `OutboxSendResult`-shaped stub + an outcome test asserting `delivered === 1`, `sendFailures === 0`, journalled `tgMessageId`, `recordOutbound` args, and an empty pending set.

**Revert checks (all performed, then restored):**
- #3931 — revert the transformer tiering + regex ⇒ 2 of 9 new tests fail (the 429-then-ok escalation; "escalates exactly once" sees 3 err lines).
- #4044 — restore `vi.fn(async () => 9001)` ⇒ new test fails (`expected +0 to be 1`; delivered 0, counted as a send failure).
- #3863 — reintroduce the factory ⇒ both tests fail.

Local: 436 passed / 3 skipped across 28 outbox/retry/flood/backstop suites; `tsc --noEmit` clean; `check-retry-flood-hooks`, `check-bot-api-wrapping`, `check-callback-ctx-wrapping`, `check-gateway-line-ratchet`, `check-test-runner-coverage` all clean. CI is the full-suite authority.

## Follow-ups found, deliberately not fixed here

1. grammy wraps transport failures in `HttpError` with message `Network request for '<method>' failed!`, which matches none of the retry loop's `fetch failed`/`ECONNRESET`/`ETIMEDOUT`/`ENOTFOUND` substrings — so grammy transport failures are **not** actually retried today. Pre-existing; out of scope.
2. `retryWithThreadFallback`'s thread-not-found fallback is a second retry layer that still logs `status=err` on its first attempt — a residual, narrower instance of the #3931 class.

Closes #3931
Closes #3863
Closes #4044
