### PR TITLE
fix(telegram): a code-only block is not body for the all-heading bold guard

### DIFF
--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -839,7 +839,9 @@ function unbold(fragment: string): string {
  *     survive instead of the whole reply going plain). The one exception:
  *     when EVERY block of the message is such a heading there is no body to
  *     preserve contrast against, so the global rule strips them all rather
- *     than leaving a 100%-bold message untouched.
+ *     than leaving a 100%-bold message untouched. A block that is nothing but
+ *     masked code (a bare fence, a lone inline span) does NOT count as body
+ *     for that test — see the note at the call site.
  *   - A list with any non-fully-bolded item is left alone.
  *
  * Code spans/fences are masked (maskCodeRegions) and never counted or
@@ -879,7 +881,23 @@ export function stripExcessBold(
     // no body: exempting all of them leaves a 100%-bold message untouched and
     // unlogged. In that case the exemption is dropped and the whole message is
     // stripped, which is what the ratio rule says.
-    const contentBlocks = blocks.filter((b) => b.trim() !== '')
+    //
+    // "Body" here means VISIBLE (non-code) text, so a block that is nothing but
+    // masked code is skipped rather than counted as body (#4114). Masked code
+    // is invisible to every other measurement in this function — it is stripped
+    // out of `visible` before the ratio is taken — so counting a bare fence as
+    // body would be the one place code influences the bold decision, and it
+    // would do so by RESTORING the exact #4017 symptom: a headings-plus-one-
+    // snippet digest (a very ordinary agent status report) stayed 100% bold
+    // with no onStrip line, because the code block broke `every(...)`. The
+    // contrast a code block provides is real but partial, and it does not make
+    // every remaining visible character being bold the right render.
+    //
+    // Filtering with `stripPlaceholders` (the masker's own "remove EVERY mask"
+    // primitive) rather than a fence-specific test means all mask kinds — the
+    // FENCE and INLINE prefixes today, anything maskCodeRegions adds later —
+    // are handled by construction instead of by enumeration.
+    const contentBlocks = blocks.filter((b) => stripPlaceholders(b).trim() !== '')
     const allHeadings =
       contentBlocks.length > 0 && contentBlocks.every(isPseudoHeadingBlock)
     const rebuilt = blocks.map((block) =>

--- a/telegram-plugin/tests/format-consistency.test.ts
+++ b/telegram-plugin/tests/format-consistency.test.ts
@@ -493,6 +493,72 @@ describe('stripExcessBold', () => {
     expect(out).toContain('Deploy status')
   })
 
+  // ── #4114: a code-only block is NOT body for the all-heading guard ───────
+  // #4108's short-circuit tested `blocks.every(isPseudoHeadingBlock)` on every
+  // non-blank block. A masked code block satisfies neither side, so ONE code
+  // fence in an all-headings digest flipped `every(...)` to false, re-exempted
+  // every heading, and reproduced #4017 exactly: 100% bold, onStrip silent.
+  // Decision pinned here: masked code is not body — it is invisible to every
+  // other measurement in stripExcessBold (it is stripped before the ratio is
+  // taken), so it does not buy the headings an exemption either.
+
+  const HEADINGS = ['**Deploy status**', '**Open incidents**', '**Merged today**']
+  const TAIL = ['**Blocked on review**', '**Rollout window tomorrow**', '**Next steps:**']
+
+  test.each([
+    ['fenced code block', '```\nswitchroom agent restart klanker\n```'],
+    ['inline code span', '`switchroom agent restart klanker`'],
+    ['fenced block with a language tag', '```bash\nswitchroom agent restart klanker\n```'],
+    ['several inline spans on one line', '`alpha` `beta` `gamma` `delta` `epsilon`'],
+  ])('all-heading guard: headings + a code-only block (%s) still strips', (_name, code) => {
+    const input = [...HEADINGS, code, ...TAIL].join('\n\n')
+    expect(input.length).toBeGreaterThan(100)
+
+    const calls: Array<{ rule: string; ratio: number }> = []
+    const out = stripExcessBold(input, (d) => calls.push(d))
+
+    // Outcome 1: no bold survives — this is the assertion that fails on the
+    // real bug, where `out` was the input verbatim.
+    expect(out).not.toContain('**')
+    expect(out).toContain('Deploy status')
+    expect(out).toContain('Next steps:')
+    // Outcome 2: the code block itself is preserved byte-for-byte.
+    expect(out).toContain(code)
+    expect(out).toBe(input.replace(/\*\*/g, ''))
+    // Outcome 3: the strip is logged (the #4017 silence is what made this
+    // class of bug invisible in the first place).
+    expect(calls).toHaveLength(1)
+    expect(calls[0].rule).toBe('global')
+    expect(calls[0].ratio).toBeGreaterThan(0.3)
+  })
+
+  test('all-heading guard: real prose body CONTAINING inline code keeps headings', () => {
+    // The counterpart that stops the #4114 fix from over-correcting: a block
+    // with visible text around its code span IS body, so the headings keep
+    // their bold. Only blocks that are *nothing but* code are skipped.
+    const input = [
+      ...HEADINGS,
+      'Run `switchroom agent restart klanker` now, then check the gateway log for errors.',
+      ...TAIL,
+    ].join('\n\n')
+
+    const calls: Array<{ rule: string; ratio: number }> = []
+    const out = stripExcessBold(input, (d) => calls.push(d))
+
+    expect(out).toContain('**Deploy status**')
+    expect(out).toContain('**Next steps:**')
+    expect(calls).toHaveLength(0)
+  })
+
+  test('all-heading guard: a code-only block does not rescue a headings-only digest', () => {
+    // Degenerate shape: the code block is the ONLY non-heading block and sits
+    // last. Same verdict, so the rule does not depend on block position.
+    const input = [...HEADINGS, ...TAIL, '```\nok\n```'].join('\n\n')
+    const out = stripExcessBold(input)
+    expect(out).not.toContain('**')
+    expect(out).toContain('```\nok\n```')
+  })
+
   test('multi-line fully-bolded block is NOT mislabelled a heading (global)', () => {
     // Two bolded lines in one block must be flattened, not exempted — the
     // heading exemption is single-line only.


### PR DESCRIPTION
## Summary

`stripExcessBold`'s all-pseudo-heading short-circuit (#4108, `format.ts:882`) tested
**every** non-blank block with `isPseudoHeadingBlock`. A masked code block satisfies
neither side of that predicate, so one code fence in an all-headings digest flipped
`every(...)` to `false`, re-exempted every heading, and reproduced #4017's exact
symptom: 100% bold output with `onStrip` silent.

Fix: filter the content blocks through the masker's own `stripPlaceholders`
primitive, so a block that is *nothing but* masked code is skipped rather than
counted as body.

## Why — the judgement call

The ticket asks whether a mask placeholder should count as body content. **It should
not**, for three reasons:

1. **Consistency with the rest of the function.** Masked code is invisible to every
   other measurement in `stripExcessBold` — it is stripped out of `visible` before the
   ratio is taken (`format.ts:862`), and it is never counted or modified. Counting a
   bare fence as body would be the single place where code influences the bold
   decision, cutting against the function's own stated contract.
2. **It reinstates the bug the short-circuit exists to kill.** Headings plus one
   command snippet is what an agent status report actually looks like — the most
   plausible digest shape in the fleet, not a corner case. In that shape the message
   went fully bold *and unlogged*, which is precisely #4017.
3. **The contrast argument is real but partial.** A code block does render with
   distinct monospace styling, so this shape is less of an eyesore than all-bold
   prose. But partial contrast does not make "every remaining visible character is
   bold" the right render, and the ratio here is ~0.71 — well past the 0.3 tripwire.

The counter-position (code counts as contrast, full bold allowed) was a legitimate
outcome per the ticket, but it makes the guard's behaviour depend on a construct the
guard otherwise refuses to measure. Rejected on that consistency ground.

## All mask kinds, not just fences

`stripExcessBold` masks via `maskCodeRegions` only, which has exactly two kinds:
`FENCE` (`\x00RMF…`) and `INLINE` (`\x00RMI…`) (`format.ts:196-197`). Both hit this
path — a standalone `` `inline span` `` block reproduced the bug identically to a
fence. The link masking at `format.ts:687-719` is local to `normalizePunctuation` and
never reaches here.

Rather than enumerate kinds, the filter reuses `stripPlaceholders` — the masker's own
documented "remove EVERY mask" primitive (`format.ts:174`). Any future mask kind is
handled by construction.

The fix is scoped to *code-only* blocks. A block with visible text around its code
span is still body, so a digest whose body is ``Run `restart` now, then check the
log`` keeps its bold headings — pinned by an explicit over-correction test.

## Test plan

`telegram-plugin/tests/format-consistency.test.ts:496-561` — table-driven over four
mask shapes (fence, inline span, fence with language tag, multiple inline spans),
asserting outcomes: no bold survives, the code block is preserved byte-for-byte, and
`onStrip` fires once with `rule: 'global'`. Plus the over-correction guard and a
block-position-independence case.

**Revert-check** (restore unfixed `format.ts`, keep the new tests):
`5 failed | 67 passed (72)` — exactly the 5 new bug-guard tests fail. With the fix:
`72 passed (72)`. The over-correction guard passes on both sides by design; it pins
non-regression, not the bug.

- Scoped vitest across all three `stripExcessBold` consumers: **221 passed (221)**
- `npx tsc --noEmit`: clean
- `npm run lint`: all guards clean

## Risk

Low, and narrowing rather than widening. The only behaviour change is for messages
over the 0.3 ratio whose every visible-text block is a short pseudo-heading and which
contain at least one code-only block. Those previously emitted fully-bold, unlogged
output; they now strip and log. Code content is untouched in all paths.

Closes #4114
