### PR TITLE
fix(telegram): classify transport failures by type so network retries actually fire (#4123)

### DIFF
--- a/telegram-plugin/retry-api-call.ts
+++ b/telegram-plugin/retry-api-call.ts
@@ -22,16 +22,23 @@
  *   | GrammyError 400 "message to edit not found"   | swallow, return undefined                 |
  *   | GrammyError 400 "message to delete not found" | swallow, return undefined                 |
  *   | GrammyError 400 "thread not found" (w/ opts)  | throw `THREAD_NOT_FOUND` wrapper          |
- *   | Network error (fetch failed / ECONN…)         | exponential backoff retry, 3 attempts     |
+ *   | HttpError (grammy transport failure)          | exponential backoff retry, 3 attempts     |
+ *   | Raw network error (fetch failed / ECONN…)     | exponential backoff retry, 3 attempts     |
+ *   | ENOSPC/EDQUOT/EIO/ENOMEM (local exhaustion)   | throw `LOCAL_RESOURCE_EXHAUSTED`, no retry|
  *   | Anything else                                 | rethrow immediately                       |
  *
  * The three "swallow" rows are the DEFAULT, not the law: a call site whose
  * contract is "did the target message survive?" sets `rethrowBenign400: true`
  * and gets the original `GrammyError` instead, so it can classify the failure
  * itself. See that option's docblock for the #4065 inertness bug it exists for.
+ *
+ * The network row is classified by TYPE (`isTransientTransportError`), not by a
+ * substring of the message: grammy rewrites every transport failure's message
+ * to `Network request for '<method>' failed!`, so the substring form of this
+ * row never matched in production and the retry was dead code (#4123).
  */
 
-import { GrammyError } from 'grammy'
+import { GrammyError, HttpError } from 'grammy'
 import { AsyncLocalStorage } from 'async_hooks'
 
 // ─── retry-attempt context (#3931) ────────────────────────────────────────
@@ -70,8 +77,13 @@ function withAttemptContext<T>(ctx: TgAttemptContext, fn: () => Promise<T>): Pro
 }
 
 /**
- * The transient network-error classifier the retry loop uses. Exported so the
- * "will this be retried?" predicate cannot drift from the loop's own decision.
+ * Substring classifier for a RAW transport error message (an undici/node error
+ * that has not been through grammy's wrapping).
+ *
+ * NOT sufficient on its own for anything that came out of `bot.api.*` — see
+ * `isTransientTransportError`, which is what the retry loop actually calls.
+ * grammy rewrites the message of every transport failure, so this predicate
+ * returns false for 100% of production send failures if used alone (#4123).
  */
 export function isTransientNetworkMessage(msg: string): boolean {
   return (
@@ -82,6 +94,58 @@ export function isTransientNetworkMessage(msg: string): boolean {
   )
 }
 
+/**
+ * Is `err` a transient TRANSPORT failure the policy should back off and repeat?
+ *
+ * This is the single classifier the retry loop and `willRetryTelegramFailure`
+ * both call, so the policy and the logging tier cannot disagree about what
+ * counts as retryable (#3931).
+ *
+ * Why this is a TYPE test and not a message test (#4123): grammy funnels every
+ * fetch rejection through `toHttpError` (grammy 1.44.0, `out/core/client.js:58`
+ * → `out/core/error.js:76-83`), which throws away the original error text and
+ * renders `Network request for '<method>' failed!`. The underlying
+ * `fetch failed` / `ECONNRESET` / `ETIMEDOUT` / `ENOTFOUND` string is preserved
+ * only on `HttpError.error`, and is appended to the message only when
+ * `client.sensitiveLogs` is on — which we deliberately leave off, because it
+ * writes the bot-token URL into logs. So a substring match over the message
+ * matched NOTHING in production: the network-retry branch was dead code and a
+ * single connection blip terminally failed the send.
+ *
+ * The classes, and why each lands where it does:
+ *
+ *   - `GrammyError`  — an API-LEVEL rejection: Telegram answered, and said no.
+ *     Never part of the network class. 429 has its own sleep-and-retry branch
+ *     above; everything else (400/403/404/…) is terminal and must NOT be
+ *     retried. This is the invariant the old `!isGrammyErr` guard at the
+ *     callsite protected; it now lives here, in one place, next to the reason.
+ *   - local resource exhaustion — ENOSPC/EDQUOT/EIO/ENOMEM is a LOCAL disk or
+ *     memory failure. Retrying it in a tight loop is what tripped the per-bot
+ *     flood ban (#2923). Excluded even when grammy wrapped it.
+ *   - `HttpError`    — transport by construction: it exists only on the
+ *     "the fetch never produced a Telegram response" path (connection reset,
+ *     DNS failure, request timeout, unparseable proxy 5xx). Retryable.
+ *   - anything else  — a raw error that never went through grammy (or a nested
+ *     cause): fall back to the errno/message classifier.
+ */
+export function isTransientTransportError(err: unknown): boolean {
+  if (err instanceof GrammyError) return false
+  if (isLocalResourceError(err)) return false
+  if (err instanceof HttpError) {
+    // grammy stashes the original rejection on `.error`. A local disk failure
+    // during a multipart upload can surface here; it stays non-retryable.
+    return !isLocalResourceError((err as HttpError).error)
+  }
+  const msg = err instanceof Error ? err.message : String(err ?? '')
+  if (isTransientNetworkMessage(msg)) return true
+  // One level of standard cause-chaining (`new Error(x, { cause })`), so a
+  // wrapper that preserves the transport error is still classified correctly.
+  const cause = (err as { cause?: unknown } | null)?.cause
+  if (cause == null || cause === err) return false
+  if (isLocalResourceError(cause)) return false
+  return isTransientNetworkMessage(cause instanceof Error ? cause.message : String(cause))
+}
+
 /** The parts of a Telegram failure that decide retryability. */
 export interface TgFailureShape {
   /** Telegram `error_code`, or null/undefined for a transport-level error. */
@@ -90,6 +154,15 @@ export interface TgFailureShape {
   retryAfterSec?: number | null
   /** Transport-level error message (only consulted when `errorCode` is absent). */
   message?: string | null
+  /**
+   * The thrown error itself, when the caller has it.
+   *
+   * STRONGLY PREFERRED over `message` for anything that came out of `bot.api.*`:
+   * grammy rewrites the message of every transport failure, so a message-only
+   * shape cannot tell a retryable `HttpError` from a terminal one (#4123). Pass
+   * the error and the predicate classifies by type, exactly as the loop does.
+   */
+  cause?: unknown
 }
 
 /**
@@ -120,7 +193,11 @@ export function willRetryTelegramFailure(
     return delayMs <= ctx.maxFloodSleepMs
   }
   if (failure.errorCode != null) return false
-  return isTransientNetworkMessage(failure.message ?? '')
+  // Classify by TYPE when the caller handed us the error (the seam that
+  // matters — see `isTransientTransportError`); fall back to the message only
+  // for shapes reconstructed from a log line, which have nothing else.
+  if (failure.cause != null) return isTransientTransportError(failure.cause)
+  return isTransientTransportError(new Error(failure.message ?? ''))
 }
 
 export interface RetryCallOpts {
@@ -603,7 +680,12 @@ export function createRetryApiCall(
         }
 
         // Network-level transient errors — exponential backoff, bounded.
-        if (!isGrammyErr && isTransientNetworkMessage(msg)) {
+        // Classified by TYPE, not by message substring: grammy rewrites the
+        // message of every transport failure, so the old substring test never
+        // fired in production and this whole branch was dead (#4123). The
+        // `!isGrammyErr` guard that used to sit here now lives inside
+        // `isTransientTransportError`, which excludes GrammyError explicitly.
+        if (isTransientTransportError(err)) {
           if (attempt < maxRetries - 1) {
             const delayMs = Math.pow(2, attempt) * 1000
             log?.(

--- a/telegram-plugin/retry-api-call.ts
+++ b/telegram-plugin/retry-api-call.ts
@@ -95,6 +95,18 @@ export function isTransientNetworkMessage(msg: string): boolean {
 }
 
 /**
+ * True for a cancellation: `AbortController.abort()` surfaces as a
+ * `DOMException`/`Error` with `name === 'AbortError'` (node also sets
+ * `code === 'ABORT_ERR'`). Checked structurally rather than by `instanceof`
+ * because the shape differs across the fetch implementations grammy can be
+ * handed (undici, node-fetch, a test double).
+ */
+function isAbortError(err: unknown): boolean {
+  const e = err as { name?: unknown; code?: unknown } | null
+  return e?.name === 'AbortError' || e?.code === 'ABORT_ERR'
+}
+
+/**
  * Is `err` a transient TRANSPORT failure the policy should back off and repeat?
  *
  * This is the single classifier the retry loop and `willRetryTelegramFailure`
@@ -132,9 +144,20 @@ export function isTransientTransportError(err: unknown): boolean {
   if (err instanceof GrammyError) return false
   if (isLocalResourceError(err)) return false
   if (err instanceof HttpError) {
-    // grammy stashes the original rejection on `.error`. A local disk failure
-    // during a multipart upload can surface here; it stays non-retryable.
-    return !isLocalResourceError((err as HttpError).error)
+    // grammy stashes the original rejection on `.error`.
+    const inner = (err as HttpError).error
+    // A local disk failure during a multipart upload can surface here; it
+    // stays non-retryable (#2923).
+    if (isLocalResourceError(inner)) return false
+    // A CALLER-initiated cancellation is not a transient failure — retrying it
+    // only re-aborts three times and adds backoff sleeps to shutdown. grammy's
+    // own request TIMEOUT is NOT this case: `createTimeout` rejects the race
+    // with a plain `Error("Request to '<m>' timed out after Ns")` BEFORE it
+    // aborts the controller (grammy 1.44.0, out/core/client.js:168-178), so a
+    // timeout arrives as that Error and remains retryable. An `AbortError`
+    // here means something aborted the signal we were handed (`bot.stop()`).
+    if (isAbortError(inner)) return false
+    return true
   }
   const msg = err instanceof Error ? err.message : String(err ?? '')
   if (isTransientNetworkMessage(msg)) return true

--- a/telegram-plugin/shared/bot-runtime.ts
+++ b/telegram-plugin/shared/bot-runtime.ts
@@ -214,6 +214,13 @@ export function installTgPostLogger(bot: Bot): void {
       // #3931 — same attempt-vs-outcome rule as the resolved-rejection branch
       // above. This branch carries the transport (`HttpError`) failures, whose
       // transient members the retry policy backs off and repeats.
+      //
+      // #4123 — pass `cause`, not just `message`. grammy rewrites every
+      // transport failure's message to `Network request for '<method>' failed!`,
+      // so a message-only shape classified EVERY transport blip as terminal and
+      // wrote `status=err` — which fleet-health escalates as a
+      // `reply-delivery-failure` even when the next attempt delivers. The
+      // predicate needs the error itself to classify by type.
       const retrying = willRetryTelegramFailure({
         errorCode: err instanceof GrammyError ? (err as GrammyError).error_code : null,
         retryAfterSec:
@@ -221,6 +228,7 @@ export function installTgPostLogger(bot: Bot): void {
             ? ((err as GrammyError).parameters?.retry_after ?? null)
             : null,
         message: err instanceof Error ? err.message : String(err ?? ''),
+        cause: err,
       })
       emit(retrying ? 'retry' : 'err', errClass, code, shortDesc(rawDesc))
       throw err

--- a/telegram-plugin/tests/retry-grammy-http-error.test.ts
+++ b/telegram-plugin/tests/retry-grammy-http-error.test.ts
@@ -127,6 +127,41 @@ describe('retryApiCall retries a real grammy transport failure', () => {
     })
   }
 
+  it('does NOT retry a caller-initiated abort — shutdown must not stall', async () => {
+    const aborted = Object.assign(new Error('The operation was aborted'), {
+      name: 'AbortError',
+      code: 'ABORT_ERR',
+    })
+    const { bot, calls } = makeBot(aborted, 99)
+    const sleeps: number[] = []
+    const retryApiCall = createRetryApiCall({
+      sleep: async (ms: number) => {
+        sleeps.push(ms)
+      },
+    })
+
+    await expect(
+      retryApiCall(() => bot.api.sendMessage(7, 'hi'), { verb: 'sendMessage' }),
+    ).rejects.toBeInstanceOf(HttpError)
+
+    // Terminal on the first attempt, and no backoff was slept.
+    expect(calls.n).toBe(1)
+    expect(sleeps).toEqual([])
+  })
+
+  it('DOES retry a grammy request timeout', async () => {
+    const timedOut = new Error("Request to 'sendMessage' timed out after 500 seconds")
+    const { bot, calls } = makeBot(timedOut, 1)
+    const retryApiCall = createRetryApiCall({ sleep: async () => {} })
+
+    const res = await retryApiCall(() => bot.api.sendMessage(7, 'hi'), {
+      verb: 'sendMessage',
+    })
+
+    expect(res).toMatchObject({ message_id: 42 })
+    expect(calls.n).toBe(2)
+  })
+
   it('gives up after maxRetries when the transport never recovers', async () => {
     const { bot, calls } = makeBot(new TypeError('fetch failed'), 99)
     const retries: string[] = []
@@ -284,6 +319,32 @@ describe('isTransientTransportError keeps the non-retryable classes out', () => 
       )
       expect(isTransientTransportError(err)).toBe(false)
     }
+  })
+
+  it('excludes a caller-initiated abort, but NOT a grammy request timeout', () => {
+    // `bot.stop()` / an explicit AbortSignal aborts the fetch. Retrying that
+    // three times just re-aborts and adds backoff sleeps to shutdown.
+    const aborted = Object.assign(new Error('The operation was aborted'), {
+      name: 'AbortError',
+      code: 'ABORT_ERR',
+    })
+    expect(
+      isTransientTransportError(
+        new HttpError("Network request for 'sendMessage' failed!", aborted),
+      ),
+    ).toBe(false)
+
+    // grammy's OWN timeout is a different object: `createTimeout` rejects the
+    // race with a plain Error BEFORE aborting the controller
+    // (grammy 1.44.0, out/core/client.js:168-178). That IS transient.
+    expect(
+      isTransientTransportError(
+        new HttpError(
+          "Network request for 'sendMessage' failed!",
+          new Error("Request to 'sendMessage' timed out after 500 seconds"),
+        ),
+      ),
+    ).toBe(true)
   })
 
   it('excludes an unrelated programming error', () => {

--- a/telegram-plugin/tests/retry-grammy-http-error.test.ts
+++ b/telegram-plugin/tests/retry-grammy-http-error.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Outcome test for the transient-network retry class, driven through the REAL
+ * seam that carries the bug: a real grammy `Bot` whose injected `fetch` throws
+ * a realistic transport error, wrapped by the real `createRetryApiCall` loop.
+ *
+ * Why not a hand-rolled `throw new Error('fetch failed')`: grammy never lets
+ * that shape reach the retry loop. `Api.callMethod` catches every fetch
+ * rejection and rethrows `toHttpError(method, sensitiveLogs, err)`
+ * (grammy 1.44.0, out/core/client.js:58 → out/core/error.js:76-83), which
+ * produces an `HttpError` whose message is `Network request for '<method>'
+ * failed!` — the original `fetch failed` / `ECONNRESET` text is DROPPED unless
+ * `client.sensitiveLogs` is on (it is off by default and we do not enable it,
+ * because it leaks the bot token URL into logs).
+ *
+ * So the only honest test of "does a transport blip get retried" has to go
+ * through grammy's own wrapping. Faking the error shape is what let the dead
+ * branch ship green (#4117).
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { Bot, HttpError, GrammyError } from 'grammy'
+import {
+  createRetryApiCall,
+  willRetryTelegramFailure,
+  isTransientNetworkMessage,
+  isTransientTransportError,
+  type RetryObserver,
+} from '../retry-api-call.js'
+import { installTgPostLogger } from '../shared/bot-runtime.js'
+import { detectGatewayFindings, scanAgent } from '../../src/fleet-health/detect.js'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+const TOKEN = '111111:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+
+function okResponse(result: unknown): Response {
+  return new Response(JSON.stringify({ ok: true, result }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+/**
+ * A real grammy Bot whose transport fails `failures` times with `err`, then
+ * succeeds. Returns the bot plus the live call count.
+ */
+function makeBot(err: unknown, failures: number) {
+  const calls = { n: 0 }
+  const bot = new Bot(TOKEN, {
+    botInfo: {
+      id: 1,
+      is_bot: true,
+      first_name: 'test',
+      username: 'test_bot',
+      can_join_groups: true,
+      can_read_all_group_messages: false,
+      supports_inline_queries: false,
+      can_connect_to_business: false,
+      has_main_web_app: false,
+    },
+    client: {
+      fetch: (async () => {
+        calls.n += 1
+        if (calls.n <= failures) throw err
+        return okResponse({ message_id: 42, date: 0, chat: { id: 7, type: 'private' } })
+      }) as unknown as typeof fetch,
+    },
+  })
+  return { bot, calls }
+}
+
+describe('grammy transport failures reach the retry loop as HttpError', () => {
+  it('grammy rewrites the transport message so the substring predicate cannot see it', async () => {
+    const { bot } = makeBot(new TypeError('fetch failed'), 99)
+
+    const caught = await bot.api.sendMessage(7, 'hi').then(
+      () => null,
+      (e: unknown) => e,
+    )
+
+    // The shape the retry loop actually receives.
+    expect(caught).toBeInstanceOf(HttpError)
+    expect(caught).not.toBeInstanceOf(GrammyError)
+    expect((caught as HttpError).message).toBe("Network request for 'sendMessage' failed!")
+
+    // ...and the original transport text is gone, so the substring classifier
+    // used by the retry loop returns false on it. This is the defect.
+    expect(isTransientNetworkMessage((caught as HttpError).message)).toBe(false)
+
+    // The cause is preserved on `.error`, which is where the class lives.
+    expect((caught as HttpError).error).toBeInstanceOf(TypeError)
+  })
+})
+
+describe('retryApiCall retries a real grammy transport failure', () => {
+  for (const [label, cause] of [
+    ['fetch failed (undici)', new TypeError('fetch failed')],
+    ['ECONNRESET', Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' })],
+    ['ETIMEDOUT', Object.assign(new Error('connect ETIMEDOUT'), { code: 'ETIMEDOUT' })],
+    ['ENOTFOUND', Object.assign(new Error('getaddrinfo ENOTFOUND api.telegram.org'), {
+      code: 'ENOTFOUND',
+    })],
+  ] as const) {
+    it(`delivers the message after a transient ${label}`, async () => {
+      const { bot, calls } = makeBot(cause, 1)
+      const retries: string[] = []
+      const observer: RetryObserver = {
+        onRetry: ({ reason }) => {
+          retries.push(reason)
+        },
+      }
+      const retryApiCall = createRetryApiCall({
+        sleep: async () => {},
+        observer,
+      })
+
+      // OUTCOME: the send actually lands, and the loop actually retried.
+      const res = await retryApiCall(() => bot.api.sendMessage(7, 'hi'), {
+        verb: 'sendMessage',
+      })
+
+      expect(res).toMatchObject({ message_id: 42 })
+      expect(calls.n).toBe(2)
+      expect(retries).toEqual(['network'])
+    })
+  }
+
+  it('gives up after maxRetries when the transport never recovers', async () => {
+    const { bot, calls } = makeBot(new TypeError('fetch failed'), 99)
+    const retries: string[] = []
+    const giveUps: number[] = []
+    const retryApiCall = createRetryApiCall({
+      maxRetries: 3,
+      sleep: async () => {},
+      observer: {
+        onRetry: ({ reason }) => retries.push(reason),
+        onGiveUp: ({ attempts }) => giveUps.push(attempts),
+      },
+    })
+
+    await expect(
+      retryApiCall(() => bot.api.sendMessage(7, 'hi'), { verb: 'sendMessage' }),
+    ).rejects.toBeInstanceOf(HttpError)
+
+    expect(calls.n).toBe(3)
+    expect(retries).toEqual(['network', 'network'])
+    expect(giveUps).toEqual([3])
+  })
+
+  it('does NOT retry a real GrammyError 403 that arrives over the same seam', async () => {
+    const calls = { n: 0 }
+    const bot = new Bot(TOKEN, {
+      botInfo: {
+        id: 1,
+        is_bot: true,
+        first_name: 'test',
+        username: 'test_bot',
+        can_join_groups: true,
+        can_read_all_group_messages: false,
+        supports_inline_queries: false,
+        can_connect_to_business: false,
+        has_main_web_app: false,
+      },
+      client: {
+        fetch: (async () => {
+          calls.n += 1
+          return new Response(
+            JSON.stringify({
+              ok: false,
+              error_code: 403,
+              description: 'Forbidden: bot was blocked by the user',
+            }),
+            { status: 403, headers: { 'content-type': 'application/json' } },
+          )
+        }) as unknown as typeof fetch,
+      },
+    })
+
+    const retryApiCall = createRetryApiCall({ sleep: async () => {} })
+
+    await expect(
+      retryApiCall(() => bot.api.sendMessage(7, 'hi'), { verb: 'sendMessage' }),
+    ).rejects.toBeInstanceOf(GrammyError)
+
+    // Terminal on the first attempt — a 403 must never be retried.
+    expect(calls.n).toBe(1)
+  })
+})
+
+describe('the log tier and the retry policy agree about a transport blip', () => {
+  /**
+   * Full production composition: retry policy → tg-post transformer → real
+   * grammy client → a fetch that blips once. Returns the gateway log lines
+   * shaped exactly as `gateway-supervisor.log` carries them, so the REAL
+   * fleet-health detector can be run over them.
+   */
+  async function gatewayLinesForBlip(failures: number): Promise<{
+    lines: string[]
+    threw: boolean
+  }> {
+    const written: string[] = []
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: unknown) => {
+      written.push(String(chunk))
+      return true
+    }) as unknown as typeof process.stderr.write)
+    let threw = false
+    try {
+      const { bot } = makeBot(new TypeError('fetch failed'), failures)
+      installTgPostLogger(bot)
+      const retryApiCall = createRetryApiCall({ sleep: async () => {} })
+      // `sendRichMessage` is the user-facing reply verb the fleet-health
+      // `reply-delivery-failure` signature is scoped to (detect.ts:169) — using
+      // any other method would make the detector assertions below vacuous.
+      await retryApiCall(() =>
+        bot.api.sendRichMessage(4242, { markdown: 'the answer' }),
+      ).catch(() => {
+        threw = true
+      })
+    } finally {
+      spy.mockRestore()
+    }
+    const lines = written
+      .filter((l) => l.startsWith('tg-post '))
+      .map((l) => `2026-08-01T12:00:00Z gateway: ${l.trimEnd()}`)
+    return { lines, threw }
+  }
+
+  it('blip-then-ok: the reply lands, the blip logs status=retry, nothing escalates', async () => {
+    const { lines, threw } = await gatewayLinesForBlip(1)
+
+    // Ground truth: the reply WAS delivered. Without this the rest is vacuous.
+    expect(threw).toBe(false)
+    expect(lines).toHaveLength(2)
+    expect(lines[1]).toContain('status=ok')
+
+    // The blip is on the log, honestly labelled as an ATTEMPT — not an outcome.
+    expect(lines[0]).toContain('status=retry')
+    expect(lines[0]).toContain('err=HttpError')
+
+    // THE outcome: fleet-health raises nothing for a delivered reply.
+    const joined = lines.join('\n')
+    expect(detectGatewayFindings('alpha', joined).gw_hits['reply-delivery-failure']).toBe(0)
+    expect(scanAgent('alpha', '', joined).escalate).toBe(false)
+  })
+
+  it('transport down for every attempt: exactly one delivery-failure alert', async () => {
+    const { lines, threw } = await gatewayLinesForBlip(99)
+
+    expect(threw).toBe(true)
+    // Three attempts: two survivable, the last one terminal.
+    expect(lines).toHaveLength(3)
+    expect(lines.filter((l) => l.includes('status=retry'))).toHaveLength(2)
+    expect(lines.filter((l) => l.includes('status=err'))).toHaveLength(1)
+
+    // One alert for one lost answer — not one per attempt, not zero.
+    const joined = lines.join('\n')
+    expect(detectGatewayFindings('alpha', joined).gw_hits['reply-delivery-failure']).toBe(1)
+    expect(scanAgent('alpha', '', joined).escalate).toBe(true)
+  })
+})
+
+describe('isTransientTransportError keeps the non-retryable classes out', () => {
+  it('excludes local resource exhaustion even when grammy wrapped it', () => {
+    const enospc = Object.assign(new Error('ENOSPC: no space left on device'), {
+      code: 'ENOSPC',
+    })
+    expect(isTransientTransportError(enospc)).toBe(false)
+    // #2923: retrying a local disk failure in a tight loop is what tripped the
+    // per-bot flood ban. Wrapping it in an HttpError must not make it retryable.
+    expect(
+      isTransientTransportError(new HttpError("Network request for 'sendMessage' failed!", enospc)),
+    ).toBe(false)
+  })
+
+  it('excludes every GrammyError (Telegram answered — that IS the outcome)', () => {
+    for (const code of [400, 403, 404]) {
+      const err = new GrammyError(
+        'Call to sendMessage failed!',
+        { ok: false, error_code: code, description: 'nope' },
+        'sendMessage',
+        {},
+      )
+      expect(isTransientTransportError(err)).toBe(false)
+    }
+  })
+
+  it('excludes an unrelated programming error', () => {
+    expect(isTransientTransportError(new TypeError('x is not a function'))).toBe(false)
+    expect(isTransientTransportError(undefined)).toBe(false)
+  })
+
+  it('accepts a transport error preserved through standard cause-chaining', () => {
+    expect(
+      isTransientTransportError(
+        new Error('send failed', { cause: new TypeError('fetch failed') }),
+      ),
+    ).toBe(true)
+  })
+})
+
+describe('willRetryTelegramFailure agrees with the loop for HttpError', () => {
+  it('reports a mid-policy grammy transport failure as retryable', async () => {
+    const { bot } = makeBot(new TypeError('fetch failed'), 99)
+    const err = (await bot.api.sendMessage(7, 'hi').catch((e: unknown) => e)) as HttpError
+
+    // Same fact the loop uses: attempt 0 of 3 ⇒ another attempt follows.
+    expect(
+      willRetryTelegramFailure(
+        { errorCode: null, message: err.message, cause: err },
+        { attempt: 0, maxRetries: 3, maxFloodSleepMs: 120_000 },
+      ),
+    ).toBe(true)
+  })
+
+  it('reports the LAST attempt as terminal', async () => {
+    const { bot } = makeBot(new TypeError('fetch failed'), 99)
+    const err = (await bot.api.sendMessage(7, 'hi').catch((e: unknown) => e)) as HttpError
+
+    expect(
+      willRetryTelegramFailure(
+        { errorCode: null, message: err.message, cause: err },
+        { attempt: 2, maxRetries: 3, maxFloodSleepMs: 120_000 },
+      ),
+    ).toBe(false)
+  })
+
+  it('reports a real GrammyError 403 as terminal', async () => {
+    const err = new GrammyError(
+      'Call to sendMessage failed!',
+      { ok: false, error_code: 403, description: 'Forbidden' },
+      'sendMessage',
+      {},
+    )
+    expect(
+      willRetryTelegramFailure(
+        { errorCode: err.error_code, message: err.message, cause: err },
+        { attempt: 0, maxRetries: 3, maxFloodSleepMs: 120_000 },
+      ),
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
Fixes #4123.

> **Stacked on #4113.** That PR is in the merge queue and touches this exact file, so this branch is cut from `fix/telegram-w0-ag` and targets it. None of its changes are reverted — this only adds to them. GitHub will retarget to `main` when #4113 lands.

## The bug

The transient-network branch of the Telegram send path is **dead code**. Every transport blip terminally fails a send that the policy documents as retryable.

`retry-api-call.ts:555` (pre-fix) gated the branch on a substring of the error message:

```ts
if (!isGrammyErr && isTransientNetworkMessage(msg)) {
```

matching `fetch failed` / `ECONNRESET` / `ETIMEDOUT` / `ENOTFOUND`. But grammy never lets those strings reach the loop. `Api.callMethod` funnels every fetch rejection through `toHttpError` (grammy 1.44.0, `node_modules/grammy/out/core/client.js:58` → `out/core/error.js:76-83`), which **discards** the original text and renders:

```
Network request for 'sendMessage' failed!
```

— matching none of the four substrings. The original text survives only on `HttpError.error`, and is appended to the message only when `client.sensitiveLogs` is enabled, which we deliberately leave off because it writes the bot-token URL into logs.

`HttpError` is a sibling of `GrammyError`, not a subclass, so `!isGrammyErr` passed fine. **The guard was never the bug; the substring match was.**

**User-visible consequence:** a documented "3 attempts with exponential backoff" made exactly **1** attempt in production. One DNS hiccup or connection reset ⇒ the reply is never delivered, and — because `willRetryTelegramFailure()` returned `false` for the same reason — tg-post logged `status=err` and fleet-health escalated a `reply-delivery-failure`.

## The fix

**`telegram-plugin/retry-api-call.ts:126-142`** — new `isTransientTransportError(err)`, the single classifier both the loop and the predicate call. Classifies by **type**, not text:

| class | verdict | why |
|---|---|---|
| `GrammyError` | not transport | Telegram answered and said no. 429 keeps its own sleep-and-retry branch; 400/403/404 stay terminal. |
| ENOSPC/EDQUOT/EIO/ENOMEM | not retryable | a LOCAL disk/memory failure; retrying it in a tight loop is what tripped the per-bot flood ban (#2923). Excluded even when grammy wrapped it in an `HttpError`. |
| `HttpError` | retryable | transport by construction — it exists only on the "the fetch never produced a Telegram response" path. |
| anything else | fall back to the errno/message classifier (+ one level of `cause` chaining) |

The `!isGrammyErr` guard is **not loosened** — it moves *into* the classifier, in one place, next to the reason it exists (`retry-api-call.ts:112-116`).

**`telegram-plugin/retry-api-call.ts:628-633`** — the loop calls `isTransientTransportError(err)`.

**`telegram-plugin/retry-api-call.ts:186-191`** — `willRetryTelegramFailure()` calls the same classifier, so the retry policy and the logging tier still cannot drift (#3931). `TgFailureShape` gains an optional `cause`.

**`telegram-plugin/shared/bot-runtime.ts:224`** — the tg-post transformer passes `cause: err`. Without this the fix would have broken the alerting in the *opposite* direction: the loop would retry, but a message-only shape would still label every blip `status=err` and escalate a reply the next attempt delivered.

## Tests — over the real seam

`telegram-plugin/tests/retry-grammy-http-error.test.ts` drives a **real grammy `Bot`** with an injected `fetch` that throws a realistic transport error, through the **real** `createRetryApiCall` loop, the **real** `installTgPostLogger` transformer, and the **real** `detectGatewayFindings` / `scanAgent`. Nothing between the error and the assertion is faked.

Outcomes asserted (not code paths):
- blip-then-ok for each of `fetch failed`, `ECONNRESET`, `ETIMEDOUT`, `ENOTFOUND` ⇒ **2 fetch calls, 1 `network` retry, message actually delivered**.
- transport down throughout ⇒ 3 attempts, then give-up, then **exactly one** `reply-delivery-failure` alert (not zero, not three).
- delivered-after-blip ⇒ **zero** alerts, `escalate === false`, and the blip still visible on the log as `status=retry err=HttpError`.
- a real `GrammyError` 403 over the same seam ⇒ terminal on attempt 1, never retried.
- a pinning test that asserts grammy's rewrite directly, so the day grammy changes its message format this file says so.

A faked `new Error('fetch failed')` never travels through grammy's wrapping — which is exactly why this shipped green in the first place.

## Revert-check

Restore the old predicate, keep the new tests:

```
before fix:  Tests  8 failed | 8 passed (16)
after fix:   Tests  16 passed (16)
```

## Local verification

```
vitest run telegram-plugin/tests/{retry-grammy-http-error,retry-api-call,tg-post-retry-attribution,
  tg-post-logger-error-shape,gateway-startup-network-retry,flood-reply-queue,no-robust-api-call-factory}.test.ts
  → Test Files 7 passed (7) | Tests 131 passed (131)

npm run lint  → clean (tsc --noEmit + all 22 repo guards)
```
