### PR TITLE
fix(telegram): one nested-indent idiom; the last-resort card clip can't emit broken markdown (#4115, #4116)

### DIFF
--- a/telegram-plugin/card-layout.ts
+++ b/telegram-plugin/card-layout.ts
@@ -30,6 +30,7 @@
  */
 
 import { escapeMarkdown, stripMarkdown, truncate, stackCardLines } from './card-format.js'
+import { truncateMarkdownSafe } from './format.js'
 import { formatModelLabel } from './model-label.js'
 import { STATUS_CARD_CHAR_BUDGET, STATUS_LINE_MAX, STATUS_ROLLING_LINES } from './status-no-truncate.js'
 
@@ -338,9 +339,19 @@ export function fitCardToBudget(
  * Last-resort clip for a rendered card that no shrink level could fit — the
  * only place a card's text is cut without going through a spec.
  *
- * Keeps as many WHOLE lines as fit, so the survivors' markdown spans stay
- * balanced and only a single over-budget line is ever sliced mid-text. The tail
- * is then cleaned of the stack's own break chrome (hard-break spaces /
+ * Keeps as many WHOLE lines as fit, so line structure survives, and then runs
+ * the chosen cut through {@link truncateMarkdownSafe} so the emitted text is
+ * always PARSEABLE markdown (#4116). Two things make that necessary rather
+ * than decorative:
+ *
+ *   - a first line longer than the whole budget keeps no whole line at all, so
+ *     the cut lands mid-line — between a `**` pair, inside a `` ` `` span, in
+ *     the middle of a `[label](href)` — and Telegram parse-REJECTS the result.
+ *     The path that exists to guarantee delivery would itself fail the send.
+ *   - even a whole-line cut can leave a FENCED block open, which is a
+ *     multi-line entity and therefore invisible to a per-line rule.
+ *
+ * The tail is then cleaned of the stack's own break chrome (hard-break spaces /
  * `COLLAPSE_SAFE_SEPARATOR`) and of a dangling lone surrogate, so the wire
  * string is never invalid UTF-16.
  *
@@ -362,11 +373,12 @@ export function hardTruncateCard(
     if (trimBreakChrome(next).length > budget) break
     kept = next
   }
-  let out = trimBreakChrome(kept)
-  // A first line longer than the budget keeps nothing; slice it rather than
-  // emit a blank card.
-  if (out.length === 0) out = text.slice(0, budget)
-  if (out.length > budget) out = out.slice(0, budget)
+  // A first line longer than the budget keeps nothing; cut into it rather than
+  // emit a blank card. Either way the cut is taken against the FULL text — an
+  // entity straddling the boundary is only visible from there.
+  const target = kept.length > 0 ? kept.length : Math.min(budget, text.length)
+  let out = trimBreakChrome(truncateMarkdownSafe(text, target))
+  if (out.length > budget) out = trimBreakChrome(truncateMarkdownSafe(text, budget))
   // Finally, never leave a lone high surrogate from slicing through an astral
   // character.
   return /[\uD800-\uDBFF]$/.test(out) ? out.slice(0, -1) : out

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -1277,16 +1277,10 @@ export function splitMarkdownChunks(text: string, maxLen = RICH_MESSAGE_MAX_CHAR
       cut = spaceIdx
     }
 
-    // Back off so the cut doesn't fall inside an open ``` fence.
-    cut = backOffOpenFence(rest, cut)
-    // Back off so the cut doesn't bisect a table row (a line with `|`).
-    cut = backOffTableRow(rest, cut)
-    // Back off so the cut doesn't bisect an inline entity (`**bold**`,
-    // `` `code` ``, `_italic_`, `[label](href)`), which would leave an unclosed
-    // delimiter in the emitted chunk (Telegram then parse-rejects it to
-    // plaintext, or mis-renders the continuation). Runs LAST so it also cleans
-    // up a boundary the fence/table back-offs landed on.
-    cut = backOffOpenInline(rest, cut)
+    // Back the cut off any markdown entity it would bisect — fenced block,
+    // table row, inline span. One shared mechanism (`safeMarkdownCut`), also
+    // used by the card fitter's last-resort clip (#4116).
+    cut = safeMarkdownCut(rest, cut)
 
     if (cut <= 0) {
       // Could not find a safe boundary below maxLen — the region is one
@@ -1403,7 +1397,136 @@ const INLINE_SPAN_PATTERNS: readonly RegExp[] = [
   /__[^_\n]+__/g, // underline
   /(?<![\w*])_[^_\n]+_(?![\w*])/g, // italic (snake_case-guarded)
   /\[[^\]\n]*\]\([^)\n]*\)/g, // link [label](href)
+  /~~[^~\n]+~~/g, // strikethrough
+  /\|\|[^|\n]+\|\|/g, // spoiler
 ]
+
+/** Characters that form multi-character markdown delimiter runs (`**`, `~~`, `||`, ` ``` `). */
+const DELIMITER_RUN_CHARS = new Set(['*', '_', '`', '~', '|'])
+
+/**
+ * The opening delimiter of every entity kind {@link safeMarkdownCut} can
+ * retreat past, anchored at the head of a string. Used ONLY by
+ * {@link truncateMarkdownSafe}'s repair step — see the doc there for why
+ * dropping an opener is the right repair. Kept adjacent to
+ * `INLINE_SPAN_PATTERNS` so the two marker vocabularies stay in step.
+ */
+const FENCE_OPENER_AT_HEAD = /^(\n?)(?:`{3,}|~{3,})[^\n]*/
+const INLINE_OPENER_AT_HEAD = /^(?:\*{1,3}|_{1,3}|`+|~~|\|\||\[)/
+const TABLE_ROW_OPENER_AT_HEAD = /^(\n?[ \t]*)\|/
+
+/**
+ * Bound on {@link truncateMarkdownSafe}'s opener-drop repair loop. Each pass
+ * removes at least one character, so this only caps a pathologically nested
+ * head (`***` + `` ` `` + `[` …); eight is far past anything a card produces.
+ */
+const MAX_OPENER_REPAIRS = 8
+
+/**
+ * The largest index `<= cut` at which `text` can be split without bisecting a
+ * markdown entity — the ONE place "where is it safe to cut markdown?" is
+ * answered.
+ *
+ * Composes the three back-offs in the order the chunker has always applied
+ * them (fenced block → table row → inline span; the inline pass runs last so
+ * it also cleans a boundary the first two landed on), then refuses to split a
+ * surrogate pair so the result is always valid UTF-16 as well as valid
+ * markdown.
+ *
+ * Returns `0` when NO safe boundary exists at or below `cut` — i.e. an entity
+ * that starts at index 0 swallows the whole window. Callers must handle that
+ * case; see {@link truncateMarkdownSafe}.
+ */
+export function safeMarkdownCut(text: string, cut: number): number {
+  if (cut <= 0) return 0
+  if (cut >= text.length) return text.length
+  let safe = backOffOpenFence(text, cut)
+  safe = backOffTableRow(text, safe)
+  safe = backOffOpenInline(text, safe)
+  // Never cut INSIDE a delimiter run: `**bold**` cut between the two closing
+  // stars emits one lone `*` (odd marker count → parse-reject), and the span
+  // back-off above cannot see it because the run's first half is a complete
+  // span's tail, not a straddle. Retreat to the run's start.
+  while (safe > 0 && DELIMITER_RUN_CHARS.has(text[safe]) && text[safe - 1] === text[safe]) safe--
+  if (safe <= 0) return 0
+  // Never leave a lone high surrogate by cutting through an astral character.
+  const prev = text.charCodeAt(safe - 1)
+  const here = text.charCodeAt(safe)
+  if (prev >= 0xd800 && prev <= 0xdbff && here >= 0xdc00 && here <= 0xdfff) safe -= 1
+  return safe
+}
+
+/**
+ * Truncate `text` to at most `budget` characters such that the RESULT IS
+ * ALWAYS PARSEABLE MARKDOWN — no half-open `**`/`_`/`` ` ``/`~~`/`||` run, no
+ * unclosed fence, no bisected link or table row, no split surrogate pair.
+ *
+ * Why this exists (#4116): the card fitter's last-resort clip used to slice
+ * the raw markdown by character count. A cut landing between a `**` pair
+ * yields a body Telegram parse-REJECTS — so the code path that exists
+ * specifically to guarantee delivery within the char budget could itself make
+ * the send fail. A clipped card beats no card, but only if it can be sent.
+ *
+ * Two steps, in order:
+ *
+ *  1. **Back off** to the nearest safe boundary ({@link safeMarkdownCut}).
+ *     This is the normal case and it preserves formatting exactly: an entity
+ *     that straddles the limit simply doesn't make the cut.
+ *
+ *  2. **Drop the opener** when backing off would keep less than HALF the
+ *     window. That happens when a single entity is longer than the window —
+ *     `**<40k-char description>**`, the #3682 repro — and a back-off would
+ *     return a near-empty card, which is no better than the dropped card the
+ *     clip exists to prevent. The entity cannot render anyway (its closing
+ *     delimiter is past the window), so we drop its OPENING delimiter and ask
+ *     again: the text survives as literal prose, the markdown stays balanced,
+ *     and the card is delivered.
+ *
+ * The window END IS HELD FIXED IN SOURCE TERMS across a repair (`end` shrinks
+ * by exactly the characters removed). Letting the window slide forward by the
+ * dropped opener's width would pull the entity's CLOSING delimiter into the
+ * output — an orphan closer, unbalanced again. That is a real defect this
+ * function had before its property test swept every offset.
+ *
+ * The repair loop is bounded (each pass removes at least one character; at
+ * most `MAX_OPENER_REPAIRS` passes) so a pathological body cannot spin.
+ */
+export function truncateMarkdownSafe(text: string, budget: number): string {
+  if (budget <= 0) return ''
+  if (text.length <= budget) return text
+  let t = text
+  let end = budget
+  for (let pass = 0; pass <= MAX_OPENER_REPAIRS; pass++) {
+    const safe = safeMarkdownCut(t, end)
+    // A back-off that keeps at least half the window is the good outcome: the
+    // straddling entity is dropped whole and everything before it renders as
+    // authored.
+    if (safe * 2 >= end) return t.slice(0, safe)
+    const repaired = dropLeadingOpener(t.slice(safe))
+    // No opener to drop (unreachable in principle — every back-off above
+    // retreats TO one). Prefer the short-but-valid back-off over a slice that
+    // cannot be parsed.
+    if (repaired == null) return t.slice(0, safe)
+    end -= t.length - safe - repaired.length
+    t = t.slice(0, safe) + repaired
+  }
+  return t.slice(0, Math.max(0, safeMarkdownCut(t, end)))
+}
+
+/**
+ * Remove the opening delimiter of the entity that begins at the head of
+ * `rest`, preserving any leading newline so line structure survives. Returns
+ * `null` when the head is not an entity opener.
+ */
+function dropLeadingOpener(rest: string): string | null {
+  const fence = FENCE_OPENER_AT_HEAD.exec(rest)
+  if (fence != null) return fence[1] + rest.slice(fence[0].length)
+  const inline = INLINE_OPENER_AT_HEAD.exec(rest)
+  if (inline != null) return rest.slice(inline[0].length)
+  const row = TABLE_ROW_OPENER_AT_HEAD.exec(rest)
+  if (row != null) return row[1] + rest.slice(row[0].length)
+  return null
+}
 
 function backOffOpenInline(text: string, cut: number): number {
   if (cut <= 0 || cut >= text.length) return cut

--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -53,6 +53,7 @@ import {
   AGENT_LIVE_POLL_INTERVAL_MS,
 } from './boot-probes.js'
 import { escapeMarkdown, stackCardLines } from '../card-format.js'
+import { NESTED_PREFIX } from '../status-no-truncate.js'
 import {
   loadCache as loadBootIssueCache,
   diffProbes as diffBootProbes,
@@ -540,7 +541,11 @@ export function renderBootCard(opts: RenderBootCardOpts): string {
     const tailCmd = process.env.SWITCHROOM_RUNTIME === 'docker'
       ? `docker logs --tail 100 switchroom-${agentSlug}`
       : `journalctl --user -u switchroom-${agentSlug} -n 100`
-    degradedRows.push(`    ↳ Tail logs: \`${tailCmd}\``)
+    // One indent idiom, repo-wide (#4115): NESTED_PREFIX, not ASCII spaces.
+    // Telegram left-trims a leading ASCII-whitespace run off a content line,
+    // so the ASCII-space indent this row used to carry rendered FLAT on a
+    // phone — the #3668 failure, live-verified 2026-07-26.
+    degradedRows.push(`${NESTED_PREFIX}Tail logs: \`${tailCmd}\``)
   }
 
   // Probe rows — only those that surfaced as degraded/fail. Healthy
@@ -569,7 +574,7 @@ export function renderBootCard(opts: RenderBootCardOpts): string {
       // user does or doesn't see across consecutive boots.
       degradedRows.push(`${dot} **${PROBE_LABELS[key]}**  ${escapeMarkdown(r.detail)}`)
       if (r.nextStep) {
-        degradedRows.push(`    ↳ ${renderNextStep(r.nextStep)}`)
+        degradedRows.push(`${NESTED_PREFIX}${renderNextStep(r.nextStep)}`)
       }
     }
   }

--- a/telegram-plugin/gateway/update-announce.ts
+++ b/telegram-plugin/gateway/update-announce.ts
@@ -23,6 +23,7 @@ import { existsSync, mkdirSync, openSync, closeSync, readFileSync } from 'node:f
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { readAndFilter, defaultAuditLogPath, type AuditEntry } from '../../src/host-control/audit-reader.js'
+import { NESTED_PREFIX } from '../status-no-truncate.js'
 
 /** Default lookback window: 10 minutes is enough to catch the boot that
  *  follows a normal update_apply but small enough that an audit row from
@@ -98,9 +99,9 @@ function shortSha(s: string): string {
 }
 
 /**
- * Pure renderer. Returns the single line (HTML-safe — plain ASCII)
- * to append to the boot card body. `null` means nothing to surface
- * (entry too stale, schema invalid, etc.).
+ * Pure renderer. Returns the line(s) to append to the boot card body —
+ * markdown-safe (no unescaped entity markers of its own). `null` means
+ * nothing to surface (entry too stale, schema invalid, etc.).
  */
 export function renderUpdateOutcomeLine(entry: AuditEntry): string {
   const success = entry.exit_code === 0 && entry.result !== 'error' && entry.result !== 'denied'
@@ -117,7 +118,13 @@ export function renderUpdateOutcomeLine(entry: AuditEntry): string {
   const opStep = entry.op
   const hint = recoveryHint(entry.install_context?.install_type)
   // Single line is reader-friendly when short; multi-line when stderr is present.
-  const lines = [`❌ update failed at ${opStep}: ${stderrTail || '(no stderr captured)'}`, `    ↳ Recovery: ${hint}`]
+  // The recovery line is NESTED under the failure line with the repo's one
+  // indent idiom (#4115): a literal ASCII-space indent is left-trimmed off a
+  // content line by Telegram's parser and renders FLAT on a phone (#3668).
+  const lines = [
+    `❌ update failed at ${opStep}: ${stderrTail || '(no stderr captured)'}`,
+    `${NESTED_PREFIX}Recovery: ${hint}`,
+  ]
   return lines.join('\n')
 }
 

--- a/telegram-plugin/tests/boot-card-render.test.ts
+++ b/telegram-plugin/tests/boot-card-render.test.ts
@@ -14,6 +14,7 @@
 
 import { describe, it, expect } from 'vitest'
 import { renderBootCard, resolvePersonaName } from '../gateway/boot-card.js'
+import { NESTED_PREFIX } from '../status-no-truncate.js'
 
 describe('renderBootCard — quiet by default', () => {
   it('returns one-line ack with default ✅ when no probes and no restart reason', () => {
@@ -153,7 +154,7 @@ describe('renderBootCard — degraded conditions', () => {
       },
     })
     expect(out).toContain('🟡 **Skills**  10/10 dangling')
-    expect(out).toContain('    ↳ Run `switchroom agent reconcile lawgpt` to rebuild symlinks')
+    expect(out).toContain(`${NESTED_PREFIX}Run \`switchroom agent reconcile lawgpt\` to rebuild symlinks`)
   })
 
   it('crash row carries a tail-logs next-step', () => {

--- a/telegram-plugin/tests/card-hard-truncate-entity-safe.test.ts
+++ b/telegram-plugin/tests/card-hard-truncate-entity-safe.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest'
+import { hardTruncateCard } from '../card-layout.js'
+import { truncateMarkdownSafe, safeMarkdownCut } from '../format.js'
+import { validateRichMarkdown } from './rich-markdown-oracle.js'
+
+/**
+ * #4116 — the LAST-RESORT truncation must not be able to fail the send.
+ *
+ * `hardTruncateCard` is the path `fitCardToBudget` falls to when no shrink
+ * level can get a card under `STATUS_CARD_CHAR_BUDGET` (the #3682 repro: a
+ * 40k-char worker description, where every level keeps the same over-budget
+ * chrome). Its single-over-budget-line branch used to slice the raw markdown
+ * by character count. A cut landing between a `**` pair — or inside a
+ * `` `code` `` span, a `[label](href)`, an open ``` fence, a `~~strike~~`, a
+ * `||spoiler||` — emits a body Telegram parse-REJECTS with "can't find end of
+ * the entity". So the code path whose whole purpose is to guarantee delivery
+ * within budget could itself make the send fail.
+ *
+ * The fix routes the cut through `truncateMarkdownSafe`, which reuses the
+ * chunker's existing entity-boundary reasoning (`safeMarkdownCut` =
+ * fence → table row → inline span back-offs, plus surrogate-pair safety)
+ * rather than adding a second markdown parser.
+ *
+ * These tests assert the OUTCOME — "the emitted text parses" — using the
+ * repo's own parse-accept oracle (`rich-markdown-oracle.ts`, the same one the
+ * formatting-regression suite trusts), at EVERY cut offset rather than at a
+ * handful of hand-picked ones.
+ */
+
+/** A card body carrying one of every entity kind that can straddle a cut. */
+const MIXED_ENTITY_CARD = [
+  '🛠 **Worker · fix/telegram-w0-de** · 2m05s · 12 tools',
+  '~~_✓ Read `telegram-plugin/card-layout.ts` and `format.ts`_~~',
+  '**→ Rewriting the last-resort clip** with a [linked issue](https://github.com/switchroom/switchroom/issues/4116) inline',
+  '⠀⠀⠀↳ _nested_ step with a ||spoiler|| and ~~a struck phrase~~ plus 👍🏽 astral text',
+  '```ts',
+  'const out = hardTruncateCard(text, budget)',
+  'const safe = safeMarkdownCut(text, cut)',
+  '```',
+  'A trailing prose line with **bold**, `code`, _italic_ and an emoji 🧵 at the end.',
+].join('\n')
+
+describe('the source fixture is itself valid markdown', () => {
+  it('guards the property test against a vacuous baseline', () => {
+    // If the fixture were already invalid, "every truncation is valid" could
+    // only ever fail — or, worse, a broken oracle would make it vacuously pass.
+    expect(validateRichMarkdown(MIXED_ENTITY_CARD)).toEqual([])
+  })
+})
+
+describe('PROPERTY: hardTruncateCard emits parseable markdown at every offset (#4116)', () => {
+  it('every budget from 1 to the full length yields a card Telegram can parse', () => {
+    const failures: Array<{ budget: number; kinds: string[]; tail: string }> = []
+    for (let budget = 1; budget <= MIXED_ENTITY_CARD.length; budget++) {
+      const out = hardTruncateCard(MIXED_ENTITY_CARD, budget)
+      const issues = validateRichMarkdown(out)
+      if (issues.length > 0) {
+        failures.push({
+          budget,
+          kinds: [...new Set(issues.map((i) => i.kind))],
+          tail: out.slice(-24),
+        })
+      }
+    }
+    // Fail-before on origin/main: every offset whose cut lands inside a `**`
+    // pair / code span / link / fence produces an unsendable card.
+    expect(failures).toEqual([])
+  })
+
+  it('every truncation stays within its budget and is valid UTF-16', () => {
+    for (let budget = 1; budget <= MIXED_ENTITY_CARD.length; budget++) {
+      const out = hardTruncateCard(MIXED_ENTITY_CARD, budget)
+      expect(out.length, `budget ${budget}`).toBeLessThanOrEqual(budget)
+      // No lone surrogate — a split astral char is invalid UTF-16 on the wire.
+      expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(out), `budget ${budget}`).toBe(false)
+      expect(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(out), `budget ${budget}`).toBe(false)
+    }
+  })
+
+  it('a clipped card is still a card — it never collapses to (nearly) nothing', () => {
+    // The clip exists because "a clipped card beats no card". A back-off that
+    // retreated past a huge entity could return an empty string, which is the
+    // dropped card all over again. From a budget with room for real content,
+    // at least half of it survives — minus the handful of delimiter characters
+    // an opener-drop repair removes (measured worst case on this fixture: 8).
+    const REPAIR_SLACK = 12
+    for (let budget = 24; budget <= MIXED_ENTITY_CARD.length; budget++) {
+      const out = hardTruncateCard(MIXED_ENTITY_CARD, budget)
+      expect(out.length * 2 + REPAIR_SLACK, `budget ${budget}`).toBeGreaterThanOrEqual(budget)
+    }
+  })
+})
+
+describe('the specific entity kinds that can straddle a cut (#4116)', () => {
+  const cases: Array<[string, string]> = [
+    ['bold', 'lead in **a bold run that is long enough to straddle** tail'],
+    ['italic-underscore', 'lead in _an italic run long enough to straddle_ tail'],
+    ['bold-italic', 'lead in ***a bold-italic run long enough to straddle*** tail'],
+    ['inline code', 'lead in `a code span long enough to straddle the cut` tail'],
+    ['link', 'lead in [a label](https://example.com/a/long/path/here) tail'],
+    ['strikethrough', 'lead in ~~a struck run long enough to straddle~~ tail'],
+    ['spoiler', 'lead in ||a spoiler run long enough to straddle|| tail'],
+    ['table row', 'lead in\n| col a | col b | col c | col d |\ntail'],
+    ['fenced block', 'lead in\n```ts\nconst x = 1\nconst y = 2\n```\ntail'],
+  ]
+
+  for (const [kind, body] of cases) {
+    it(`never bisects a ${kind}`, () => {
+      expect(validateRichMarkdown(body)).toEqual([])
+      const bad: number[] = []
+      for (let budget = 1; budget <= body.length; budget++) {
+        if (validateRichMarkdown(hardTruncateCard(body, budget)).length > 0) bad.push(budget)
+      }
+      expect(bad).toEqual([])
+    })
+  }
+})
+
+describe('truncateMarkdownSafe — the shared mechanism', () => {
+  it('backs off rather than cutting inside a span, keeping formatting intact', () => {
+    const text = 'abcdefghij **bold text here** klmno'
+    // Budget 20 lands inside the bold span (which opens at 11).
+    const out = truncateMarkdownSafe(text, 20)
+    expect(out).toBe('abcdefghij ')
+    expect(validateRichMarkdown(out)).toEqual([])
+  })
+
+  it('drops the opener instead of returning a near-empty result when one entity swallows the budget', () => {
+    // The #3682 shape: a single span longer than the whole window. Backing off
+    // would return `🛠 ` — a card with no content. Dropping the (unrenderable,
+    // because its closer is far past the budget) opener keeps the text.
+    const text = `🛠 **${'d'.repeat(500)}**`
+    const out = truncateMarkdownSafe(text, 64)
+    // Within budget, and only the dropped `**` short of it — the window is
+    // held fixed in SOURCE terms so the repair can never pull the span's
+    // closing delimiter into the output.
+    expect(out.length).toBe(62)
+    expect(out.startsWith('🛠 d')).toBe(true)
+    expect(out).not.toContain('*')
+    expect(validateRichMarkdown(out)).toEqual([])
+  })
+
+  it('is a no-op when the text already fits', () => {
+    expect(truncateMarkdownSafe('**short**', 64)).toBe('**short**')
+  })
+
+  it('safeMarkdownCut never splits a surrogate pair', () => {
+    const text = 'ab👍cd'
+    // Index 3 is between the two halves of the astral char.
+    expect(safeMarkdownCut(text, 3)).toBe(2)
+    expect(safeMarkdownCut(text, 4)).toBe(4)
+  })
+})

--- a/telegram-plugin/tests/nested-indent-idiom.test.ts
+++ b/telegram-plugin/tests/nested-indent-idiom.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { renderBootCard } from '../gateway/boot-card.js'
+import { renderUpdateOutcomeLine } from '../gateway/update-announce.js'
+import { NESTED_PREFIX } from '../status-no-truncate.js'
+
+/**
+ * #4115 — ONE indent idiom in the repo, and it is the one that actually
+ * renders.
+ *
+ * #3668 fixed the status card's nested lines by moving `NESTED_PREFIX` off
+ * ASCII spaces onto U+2800 BRAILLE PATTERN BLANK: card bodies reach Telegram
+ * as GFM markdown parsed SERVER-SIDE, and that parser left-trims a leading
+ * whitespace run off a content line, so an ASCII (or U+00A0) indent is dropped
+ * on the wire and the line renders FLAT. Live-verified on a phone 2026-07-26 —
+ * the record is on `WORKER_STEP_INDENT` in `status-no-truncate.ts`.
+ *
+ * The boot card and the update-announce line were NOT migrated by that PR, so
+ * they kept shipping the collapsed non-indent to the user. These tests assert
+ * what RENDERS (the leading run survives a server-side left-trim), not merely
+ * that a constant was referenced — a byte-equality assertion against the old
+ * literal is exactly what let the pre-#3668 indent ship green and inert.
+ */
+
+/** Every rule a server-side trimmer could plausibly use. */
+const isTrimmableWhitespace = (ch: string): boolean =>
+  /\s/u.test(ch) || /\p{White_Space}/u.test(ch) || /\p{Zs}/u.test(ch)
+
+/**
+ * The assertion that ties to rendering: after a leading-whitespace left-trim
+ * of the kind Telegram applies, the line STILL carries its full indent, and it
+ * does not lead with either character already proven flat on a phone.
+ */
+function expectSurvivesLeftTrim(line: string): void {
+  expect(line.startsWith(NESTED_PREFIX)).toBe(true)
+  expect(
+    line.replace(/^[\s\p{White_Space}]+/u, '').startsWith(NESTED_PREFIX),
+    `nested line "${line.slice(0, 40)}…" loses its indent to a leading-whitespace trim — ` +
+      `it renders FLAT on a phone (#3668/#4115). Use NESTED_PREFIX.`,
+  ).toBe(true)
+  expect(line.startsWith(' ')).toBe(false)
+  expect(line.startsWith(' ')).toBe(false)
+  const indent = [...line.slice(0, line.indexOf('↳'))]
+  expect(indent.length).toBeGreaterThan(0)
+  for (const ch of indent) expect(isTrimmableWhitespace(ch)).toBe(false)
+}
+
+/** Card lines with the stack's own break chrome removed. */
+function linesOf(card: string): string[] {
+  return card.split('\n').map((l) => l.replace(/[ \t]+$/, ''))
+}
+
+describe('boot card nested lines render as a real indent (#4115)', () => {
+  it("a probe's next-step continuation line survives a server-side left-trim", () => {
+    // Fail-before: this row was `'    ↳ ' + nextStep` — four ASCII spaces, all
+    // of them trimmed, so the line rendered flush against its probe row.
+    const out = renderBootCard({
+      agentName: 'lawgpt',
+      version: 'v0.7.16',
+      probes: {
+        skills: {
+          status: 'degraded',
+          label: 'Skills',
+          detail: '10/10 dangling: a, b, c +7 more',
+          nextStep: 'Run `switchroom agent reconcile lawgpt` to rebuild symlinks',
+        },
+      },
+    })
+    const nested = linesOf(out).filter((l) => l.includes('↳'))
+    expect(nested.length).toBe(1)
+    expectSurvivesLeftTrim(nested[0])
+  })
+
+  it('the crash row tail-logs continuation line survives a server-side left-trim', () => {
+    const out = renderBootCard({
+      agentName: 'lawgpt',
+      version: 'v0.7.16',
+      restartReason: 'crash',
+      restartAgeMs: 6_100,
+    })
+    const nested = linesOf(out).filter((l) => l.includes('↳'))
+    expect(nested.length).toBe(1)
+    expect(nested[0]).toContain('Tail logs:')
+    expectSurvivesLeftTrim(nested[0])
+  })
+})
+
+describe('update-announce recovery line renders as a real indent (#4115)', () => {
+  it('the failure card\'s recovery continuation survives a server-side left-trim', () => {
+    // Fail-before: the recovery row was `'    ↳ Recovery: …'`.
+    const line = renderUpdateOutcomeLine({
+      ts: '2026-05-17T11:59:00.000Z',
+      op: 'update_apply',
+      caller: { kind: 'operator' },
+      request_id: 'req-2',
+      result: 'error',
+      exit_code: 1,
+      duration_ms: 100,
+      phase: 'terminal',
+      stderr_tail: 'compose pull failed: registry timeout',
+      install_context: { install_type: 'binary', detected_at: '2026-05-17T11:00:00Z' },
+    })
+    const nested = linesOf(line).filter((l) => l.includes('↳'))
+    expect(nested.length).toBe(1)
+    expect(nested[0]).toContain('Recovery:')
+    expectSurvivesLeftTrim(nested[0])
+  })
+})
+
+describe('GUARD: no ASCII-space nested indent may reappear in the source (#4115)', () => {
+  // A run of ASCII spaces/tabs immediately before the `↳` nesting glyph — the
+  // exact shape that renders flat. The one exported constant is the only legal
+  // way to indent a nested card line.
+  const ASCII_INDENT_BEFORE_ARROW = /[ \t]{2,}↳/
+
+  const here = fileURLToPath(import.meta.url)
+  const repoRoot = join(here, '..', '..', '..')
+  const ROOTS = ['telegram-plugin', 'src']
+  const SKIP_DIRS = new Set(['node_modules', 'dist', '.git', 'coverage'])
+
+  function walk(dir: string, out: string[]): string[] {
+    for (const name of readdirSync(dir)) {
+      if (SKIP_DIRS.has(name)) continue
+      const p = join(dir, name)
+      if (statSync(p).isDirectory()) walk(p, out)
+      else if (p.endsWith('.ts') && p !== here) out.push(p)
+    }
+    return out
+  }
+
+  it('no source file hardcodes an ASCII-indent-plus-↳ nested line', () => {
+    const offenders: string[] = []
+    for (const root of ROOTS) {
+      for (const file of walk(join(repoRoot, root), [])) {
+        const text = readFileSync(file, 'utf8')
+        text.split('\n').forEach((line, i) => {
+          if (ASCII_INDENT_BEFORE_ARROW.test(line)) {
+            offenders.push(`${relative(repoRoot, file)}:${i + 1}: ${line.trim().slice(0, 100)}`)
+          }
+        })
+      }
+    }
+    expect(
+      offenders,
+      `Hardcoded ASCII indent before a '↳' nesting glyph. Telegram left-trims a leading ` +
+        `ASCII-whitespace run off a content line, so this renders FLAT on a phone (#3668/#4115). ` +
+        `Import NESTED_PREFIX from status-no-truncate.js instead:\n  ${offenders.join('\n  ')}`,
+    ).toEqual([])
+  })
+
+  it('the guard actually fires on the shape it is guarding against', () => {
+    // A guard that cannot fail is not a guard: pin the detector on the exact
+    // literal the two migrated call sites used to carry.
+    expect(ASCII_INDENT_BEFORE_ARROW.test("degradedRows.push(`    ↳ ${next}`)")).toBe(true)
+    expect(ASCII_INDENT_BEFORE_ARROW.test('   ↳ Recovery: reinstall')).toBe(true)
+    // …and stays quiet on the legal idiom and on prose that merely mentions ↳.
+    expect(ASCII_INDENT_BEFORE_ARROW.test(`${NESTED_PREFIX}Recovery: reinstall`)).toBe(false)
+    expect(ASCII_INDENT_BEFORE_ARROW.test('the nested ↳ block is windowed')).toBe(false)
+  })
+})


### PR DESCRIPTION
Fixes #4115. Fixes #4116.

Both issues live on the card surface and would conflict as separate PRs, so they ship together.

## #4115 — one indent idiom, not three

`#3668` moved the status card's nested-line indent onto **U+2800 BRAILLE PATTERN BLANK** (`telegram-plugin/status-no-truncate.ts:130-138`). The reason is empirical and recorded in that file: a card body reaches Telegram as GFM parsed **server-side**, and that parser left-trims a leading whitespace run off a content line — so an ASCII or U+00A0 indent is dropped **on the wire** and the row renders flat. Live-verified on a phone 2026-07-26.

Two call sites were never migrated and kept shipping the collapsed non-indent:

| site | before | after |
|---|---|---|
| `telegram-plugin/gateway/boot-card.ts:543` | `` `    ↳ Tail logs: …` `` | `` `${NESTED_PREFIX}Tail logs: …` `` |
| `telegram-plugin/gateway/boot-card.ts:572` | `` `    ↳ ${renderNextStep(…)}` `` | `` `${NESTED_PREFIX}${renderNextStep(…)}` `` |
| `telegram-plugin/gateway/update-announce.ts` (`renderUpdateOutcomeLine`) | `'    ↳ Recovery: …'` | `` `${NESTED_PREFIX}Recovery: …` `` |

A repo-wide grep for the shape found no others; `telegram-plugin/tests/boot-card-render.test.ts:156` was asserting the old literal and now asserts the constant.

**Discrepancy vs. the issue text:** #4115 describes the literal as `'   ↳ '` (three spaces). The source actually carried **four** ASCII spaces at all three sites. Same bug, same fix — noting it so the issue's quote isn't taken as the search key.

### Guard
`telegram-plugin/tests/nested-indent-idiom.test.ts` walks every `.ts` under `telegram-plugin/` and `src/` and fails on `[ \t]{2,}↳`, with a self-test proving the detector fires on the exact literals removed here.

The render tests assert the property that actually matters — *the row still starts with the indent after a leading-whitespace left-trim, and no indent character is `\s`/`\p{White_Space}`/`\p{Zs}`* — rather than byte-comparing against the constant. A byte-equality test is exactly what let the pre-#3668 indent ship green and inert.

## #4116 — the last-resort truncation could itself fail to send

`hardTruncateCard`'s single-over-budget-line branch (`telegram-plugin/card-layout.ts:358`, added in #4111) sliced raw markdown mid-text. A cut between the two stars of a `**` pair leaves an odd delimiter count; Telegram answers `400 can't find end of the entity` — and this is the **rescue** path, so the card is lost outright. `guardAccidentalFormatting` can't save it: it only backslash-escapes *intra-word* `_`/`*`, never a dangling run.

### Reusing the existing entity reasoning, not adding a parser

`telegram-plugin/format.ts` already reasons about entity boundaries for the chunker (`backOffOpenFence`, `backOffTableRow`, `backOffOpenInline`, `INLINE_SPAN_PATTERNS`). That machinery is extracted into two exported helpers and now backs **both** cut sites:

- **`safeMarkdownCut(text, cut)`** — fence / table-row / inline-span back-off, plus two cases the chunker never hit:
  - a cut landing **inside a delimiter run** (`**bold|**`) — invisible to span back-off, because the run's first half is a *complete* span's tail, not a straddle;
  - a cut through a **surrogate pair** (astral emoji).
- **`truncateMarkdownSafe(text, budget)`** — back-off; and when a back-off would keep less than half the window, **drop the straddling opener** and keep the prose. Without that, the #3682 card shape `🛠 **<40k chars>**` truncates to 3 characters — a blank card. The window end is held fixed in *source* terms across repairs, so a dropped opener can never slide the window forward and pull its own closer into the output.

`splitMarkdownChunks` routes through `safeMarkdownCut` too, so the two cut sites share one mechanism instead of drifting. `INLINE_SPAN_PATTERNS` gains `~~strike~~` and `||spoiler||`.

**Why not `telegram-plugin/render/parse.ts`:** its own module doc states that nothing in it is wired into the live send path (Increment 1), and its micromark/mdast deps aren't installed at the repo root. Putting the rescue path's correctness on an unwired parser would be a second source of truth, not a reuse.

## Tests assert outcomes

`telegram-plugin/tests/card-hard-truncate-entity-safe.test.ts` — a 494-char mixed-entity fixture (bold, italic `_`, bold-italic, inline code, link, strikethrough, spoiler, table row, ` ```ts ` fence, astral `👍🏽`, U+2800 nested line):

- **property:** for **every** budget `1..len`, `validateRichMarkdown(hardTruncateCard(card, budget))` returns no findings;
- **property:** output never ends on a lone surrogate;
- **property:** output never collapses to empty (documented `REPAIR_SLACK = 12`; measured worst deficit was 8);
- nine per-entity-kind sweeps, plus four direct mechanism tests.

## Revert-check (exact numbers)

Both test files run against pristine `origin/main` @ `2c9132ec` in a separate worktree, fix backed out:

**#4116** — the property fails at **117 of 494 offsets** (0 on this branch). Offending-offset counts per entity kind:

| entity | offending offsets on main |
|---|---|
| bold `**` | 45 |
| bold-italic | 46 |
| inline code | 44 |
| link | 37 |
| strikethrough | 38 |
| fenced block | 28 |
| italic `_`, spoiler, table row | 0 (already safe) |

**#4115** — all **3** render tests fail (`expected false to be true`), and the source guard reports **4 offenders**, one of them the old assertion in `boot-card-render.test.ts:156`.

**11 failing tests on main, 0 on this branch.**

## Local verification

- Scoped suites (format, card-layout, boot-card, update-announce, worker/tool-activity/pinned cards, both new files): **36 files / 651 tests passed**.
- `npx tsc --noEmit` clean; full `npm run lint` chain clean (incl. `check-agent-attribution-trailers`, `check-gateway-line-ratchet`, `check-status-pin-single-path`).
- Full vitest run classified per CLAUDE.md's three buckets: no regression attributable to this change. `outbound-send-chunks`, `send-reply-golden`, `formatting-parse-regression`, `outbox-sweep-listen-button` and `gateway-boot-smoke` all pass on this branch when run scoped (their full-run failures were parallel-run interference). `approval-hold-record.test.ts` › "falls back … when the shared dir is not writable" fails **identically on pristine `2c9132ec`** — an environment artifact of running as uid 0, where a `0o500` directory is still writable.

CI is the full-suite authority. **Do not merge** — flagged for review.
