### PR TITLE
fix(telegram): reply_parameters.quote is a String, not an object

### DIFF
--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -108,7 +108,7 @@ const TOOL_SCHEMAS = [
         format: { type: 'string', enum: ['html', 'markdownv2', 'text'], description: "Rendering mode. Default renders your text as rich GFM markdown (Bot API 10.1). 'text' sends plain text verbatim. 'html' and 'markdownv2' are legacy aliases that route through the same single rich GFM path — no separate HTML engine, no auto-escaping." },
         disable_web_page_preview: { type: 'boolean', description: 'Disable link preview thumbnails. Default: true.' },
         protect_content: { type: 'boolean', description: 'When true, Telegram prevents the message from being forwarded or saved.' },
-        quote_text: { type: 'string', description: 'Surgical quote: specific text to highlight from the reply_to message. Requires reply_to.' },
+        quote_text: { type: 'string', description: 'Surgical quote: specific text to highlight from the reply_to message. Must be an EXACT substring of that message (copy it verbatim, do not paraphrase; max 1024 chars) — a quote Telegram cannot find is dropped and the reply lands unquoted. Requires reply_to.' },
         disable_notification: { type: 'boolean', description: 'When true, Telegram delivers the message silently — no device ping for this user. Default false (pings). Use true for mid-turn updates ("still working through X") so only the final answer pings. Always omit (or pass false) on the final answer of a turn.' },
         inline_keyboard: {
           type: 'array',

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -37,6 +37,12 @@ import { scrubVoice } from '../text-voice-scrub.js'
 import { normalizeTemporal } from '../temporal-normalize.js'
 import { resolveEnvTimezone } from '../shared/local-time.js'
 import { isMessageTooLongError, isHtmlParseRejectError } from '../retry-api-call.js'
+import {
+  buildReplyParameters,
+  dropQuoteFromSendOpts,
+  isQuoteRejectionError,
+  sendOptsHaveQuote,
+} from '../reply-quote.js'
 
 // ── send-orchestration façade imports (#2996 P2) ──
 // Pure/deterministic helpers are imported; stateful or side-effecting gateway
@@ -542,6 +548,20 @@ export async function sendReplyChunks(
           else if (isHtmlParseRejectError(retryErr)) await sendChunkPlainText(retryOpts)
           else throw retryErr
         }
+      } else if (isQuoteRejectionError(err) && sendOptsHaveQuote(sendOpts)) {
+        // Surgical-quote rejection: the quote must be an EXACT substring of the
+        // message being replied to, and Telegram 400s when it isn't found (a
+        // model paraphrase, a re-rendered fragment, an emoji/entity mismatch).
+        // That is a failure of the HIGHLIGHT, not of the answer — so drop the
+        // quote and land the reply as an ordinary reply to the same message,
+        // rather than throwing the composed answer away.
+        const retryOpts = dropQuoteFromSendOpts(sendOpts)
+        const sent = await sendChunk(retryOpts, false)
+        sentIds.push(sent.message_id)
+        deps.logOutbound('reply', chatId, sent.message_id, chunks[i].length, `chunk=${i + 1}/${chunks.length} quote-dropped`)
+        deps.stderr(
+          `telegram gateway: quote not found in the replied-to message — resent chunk ${i + 1}/${chunks.length} without the quote\n`,
+        )
       } else if (isMessageTooLongError(err)) {
         await sendChunkResplit(sendOpts)
       } else if (isHtmlParseRejectError(err)) {
@@ -1992,10 +2012,10 @@ export async function sendReply(
         return {
           ...(shouldReplyTo
             ? {
-                reply_parameters: {
-                  message_id: reply_to,
-                  ...(quoteText != null ? { quote: { text: quoteText, position: 0 } } : {}),
-                },
+                // `quote` is a Bot API String and `quote_position` a separate
+                // sibling Integer — see reply-quote.ts. Emitting an object here
+                // 400'd every quoted reply the fleet ever sent.
+                reply_parameters: buildReplyParameters(reply_to!, quoteText),
               }
             : {}),
           ...(tid != null ? { message_thread_id: tid } : {}),

--- a/telegram-plugin/reply-quote.ts
+++ b/telegram-plugin/reply-quote.ts
@@ -1,0 +1,135 @@
+/**
+ * Surgical quote-reply parameters (`reply_parameters.quote`).
+ *
+ * The `reply` / `stream_reply` tools document a `quote_text` argument: quote a
+ * specific fragment of the message being replied to, so the reply visibly
+ * anchors on that fragment instead of the whole message.
+ *
+ * WIRE SHAPE — the bug this module exists to make unrepeatable
+ * ------------------------------------------------------------
+ * Bot API `ReplyParameters` (https://core.telegram.org/bots/api#replyparameters):
+ *
+ *   quote           String   Quoted part of the message to be replied to;
+ *                            0-1024 characters after entities parsing.
+ *   quote_parse_mode String  Mode for parsing entities in the quote.
+ *   quote_entities   Array   Entities in the quote.
+ *   quote_position   Integer Position of the quote in the original message in
+ *                            UTF-16 code units.
+ *
+ * `quote` is a **String** and `quote_position` is a **separate sibling
+ * Integer**. Both send sites used to emit `quote: { text, position: 0 }` — an
+ * object — so Telegram rejected every quoted reply with
+ * `400 Bad Request: field "quote" must be of type String`, the reply threw, and
+ * the agent re-attempted a payload that could never be accepted. A fleet sweep
+ * of `tg-post method=sendRichMessage … status=err` lines found 378 of 384 total
+ * send failures were this one error (agent `overlord`, 2026-07-29 → 07-30, in
+ * retry bursts). The feature had never worked.
+ *
+ * DELIBERATE OMISSIONS
+ * --------------------
+ * - **No `quote_position`.** Telegram locates the quote text on its own; a
+ *   fabricated `0` is what encouraged the object shape in the first place, and
+ *   neither send site has a real position source (the model supplies text, not
+ *   an offset). A wrong position is worse than none: it either mislocates the
+ *   highlight or 400s.
+ * - **No `quote_parse_mode` / `quote_entities`, and therefore NO HTML
+ *   escaping.** With no parse mode the quote is matched as literal text, which
+ *   is exactly what `quote_text` carries (plain text the model copied out of
+ *   the user's message). Escaping it (`&` → `&amp;`) would make the string stop
+ *   being an exact substring of the original and guarantee a rejection.
+ *
+ * REJECTION HANDLING
+ * ------------------
+ * The quote must be an exact substring of the target message; Telegram 400s
+ * when it isn't found. That is a *quote* failure, not an answer failure — the
+ * reply body is still correct and must still be delivered. {@link
+ * isQuoteRejectionError} classifies it and {@link dropQuoteFromSendOpts}
+ * produces the same options with the quote removed, so callers can retry once
+ * and land the reply as an ordinary (unquoted) reply.
+ */
+
+import { GrammyError } from 'grammy'
+
+/** Bot API cap: `quote` is 0-1024 characters after entities parsing. */
+export const QUOTE_MAX_CHARS = 1024
+
+/**
+ * Normalize a caller-supplied `quote_text` into the string Telegram accepts, or
+ * `null` when there is nothing worth quoting.
+ *
+ * - empty / whitespace-only ⇒ `null` (an empty quote highlights nothing and is
+ *   a guaranteed rejection).
+ * - longer than {@link QUOTE_MAX_CHARS} ⇒ truncated. A PREFIX of an exact
+ *   substring is still an exact substring, so truncation still matches the
+ *   original message, whereas an over-length quote is a certain 400. The cut
+ *   never splits a surrogate pair (a lone surrogate is not valid UTF-8 on the
+ *   wire).
+ * - otherwise verbatim — never escaped, never trimmed (leading/trailing spaces
+ *   are part of the substring the user may have selected).
+ */
+export function normalizeQuoteText(quoteText: string | null | undefined): string | null {
+  if (typeof quoteText !== 'string') return null
+  if (quoteText.trim().length === 0) return null
+  if (quoteText.length <= QUOTE_MAX_CHARS) return quoteText
+  let end = QUOTE_MAX_CHARS
+  const code = quoteText.charCodeAt(end - 1)
+  // High surrogate at the cut boundary ⇒ drop it rather than emit half a pair.
+  if (code >= 0xd800 && code <= 0xdbff) end -= 1
+  return quoteText.slice(0, end)
+}
+
+/**
+ * Build the `reply_parameters` object for a reply to `messageId`, optionally
+ * carrying a surgical quote.
+ *
+ * This is the ONLY place the `quote` field is constructed. Both send sites (the
+ * `reply` chunk loop in `gateway/outbound-send-path.ts` and the `stream_reply`
+ * controller in `stream-controller.ts`) call it, so the wire shape cannot drift
+ * apart again.
+ */
+export function buildReplyParameters(
+  messageId: number,
+  quoteText?: string | null,
+): { message_id: number; quote?: string } {
+  const quote = normalizeQuoteText(quoteText)
+  return { message_id: messageId, ...(quote != null ? { quote } : {}) }
+}
+
+/**
+ * True when Telegram rejected the send because of the QUOTE, not the body.
+ *
+ * Covers the "quote isn't in the original message" family (the documented
+ * failure mode) and any other 400 naming the quote — deliberately matched on
+ * the word rather than one exact phrase, because the Bot API's wording for this
+ * class has changed before (`QUOTE_TEXT_INVALID` vs the prose form) and a
+ * missed match costs the whole answer, while a false positive costs only a
+ * harmless retry without the quote.
+ */
+export function isQuoteRejectionError(err: unknown): boolean {
+  if (!(err instanceof GrammyError) || err.error_code !== 400) return false
+  return (err.description || '').toLowerCase().includes('quote')
+}
+
+/** True when `opts` carries a `reply_parameters.quote`. Structural on purpose:
+ *  the reply path builds untyped `Record<string, unknown>` send options and the
+ *  stream path a typed `StreamSendOpts`, and both must be checkable. */
+export function sendOptsHaveQuote(opts: object): boolean {
+  const rp = (opts as { reply_parameters?: { quote?: unknown } }).reply_parameters
+  return rp != null && typeof rp === 'object' && rp.quote != null
+}
+
+/**
+ * Same send options with the surgical quote removed — the retry payload after a
+ * {@link isQuoteRejectionError}. Everything else (reply target, thread, markup,
+ * notification) is preserved, so the answer still lands as a reply to the right
+ * message; only the highlight is sacrificed.
+ */
+export function dropQuoteFromSendOpts<T extends object>(opts: T): T {
+  if (!sendOptsHaveQuote(opts)) return { ...opts }
+  const rp = { ...((opts as { reply_parameters: Record<string, unknown> }).reply_parameters) }
+  delete rp.quote
+  delete rp.quote_parse_mode
+  delete rp.quote_entities
+  delete rp.quote_position
+  return { ...opts, reply_parameters: rp }
+}

--- a/telegram-plugin/reply-quote.ts
+++ b/telegram-plugin/reply-quote.ts
@@ -50,6 +50,8 @@
 
 import { GrammyError } from 'grammy'
 
+import { isHtmlParseRejectError, isMessageTooLongError } from './retry-api-call.js'
+
 /** Bot API cap: `quote` is 0-1024 characters after entities parsing. */
 export const QUOTE_MAX_CHARS = 1024
 
@@ -99,14 +101,27 @@ export function buildReplyParameters(
  * True when Telegram rejected the send because of the QUOTE, not the body.
  *
  * Covers the "quote isn't in the original message" family (the documented
- * failure mode) and any other 400 naming the quote — deliberately matched on
- * the word rather than one exact phrase, because the Bot API's wording for this
- * class has changed before (`QUOTE_TEXT_INVALID` vs the prose form) and a
- * missed match costs the whole answer, while a false positive costs only a
- * harmless retry without the quote.
+ * failure mode) and any other 400 naming the quote — matched on the word rather
+ * than one exact phrase, because the Bot API's wording for this class has
+ * changed before (`QUOTE_TEXT_INVALID` vs the prose form) and a missed match
+ * costs the whole answer.
+ *
+ * A BODY error must never be claimed here, though, and the word alone is not
+ * enough to tell them apart: `<blockquote>` in a rich body produces
+ * `can't parse entities: Can't find end tag corresponding to start tag
+ * "blockquote"` / `Unsupported start tag "blockquote"` — 400s that contain the
+ * substring "quote" but are PARSE failures. Claiming one would drop the quote
+ * and resend the same unparseable body, hit the same 400, and throw straight
+ * out of the caller's fallback ladder — losing the answer that the plain-text
+ * rescue would otherwise have delivered. So defer to the body classifiers
+ * first, exactly as `isHtmlParseRejectError` defers to `isMessageTooLongError`
+ * (retry-api-call.ts) for the same reason. No false negative results: the real
+ * quote rejections (`QUOTE_TEXT_INVALID`, "message quote not found") contain
+ * neither a parse phrase nor a length phrase.
  */
 export function isQuoteRejectionError(err: unknown): boolean {
   if (!(err instanceof GrammyError) || err.error_code !== 400) return false
+  if (isHtmlParseRejectError(err) || isMessageTooLongError(err)) return false
   return (err.description || '').toLowerCase().includes('quote')
 }
 

--- a/telegram-plugin/stream-controller.ts
+++ b/telegram-plugin/stream-controller.ts
@@ -27,6 +27,12 @@ import {
 import { richMessage, isParseEntitiesError } from './rich-send.js'
 import { renderOutboundChunks } from './render/rich-render.js'
 import { isSendGateShed, type SendGateOpts } from './send-gate.js'
+import {
+  buildReplyParameters,
+  dropQuoteFromSendOpts,
+  isQuoteRejectionError,
+  sendOptsHaveQuote,
+} from './reply-quote.js'
 
 /**
  * Minimal bot.api surface the controller needs. Real callers pass grammy's
@@ -59,8 +65,14 @@ export interface StreamSendOpts {
    * message. Only meaningful on the initial `sendMessage` — `editMessageText`
    * cannot add a quote reference to an existing message, so the controller
    * strips this from edit opts internally.
+   *
+   * `quote` is a Bot API **String** — the quoted substring itself. The optional
+   * offset is a SIBLING `quote_position` Integer, which this plugin
+   * deliberately never emits. Typing it as an object is what produced
+   * `400 field "quote" must be of type String` on every quoted reply; see
+   * `reply-quote.ts`.
    */
-  reply_parameters?: { message_id: number; quote?: { text: string; position: number } }
+  reply_parameters?: { message_id: number; quote?: string }
   /**
    * Inline keyboard markup. Included in both sendMessage and editMessageText
    * so that inline buttons persist through text edits. Without this,
@@ -121,7 +133,10 @@ export interface StreamControllerConfig {
   /**
    * Optional quote text for surgical quoting. When set along with
    * `replyToMessageId`, the initial send includes
-   * `reply_parameters: { message_id, quote: { text, position: 0 } }`.
+   * `reply_parameters: { message_id, quote }` — `quote` is a Bot API String
+   * (see `reply-quote.ts`). A quote Telegram cannot find in the replied-to
+   * message is dropped and the send retried unquoted, so the answer still
+   * lands.
    */
   quoteText?: string
   /**
@@ -222,14 +237,16 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
     ...(disableLinkPreview ? { link_preview_options: { is_disabled: true } } : {}),
     ...(replyMarkup != null ? { reply_markup: replyMarkup } : {}),
   }
-  const sendOpts: StreamSendOpts = {
+  // `let`, not `const`: a quote Telegram cannot find in the replied-to message
+  // is stripped ONCE for the whole stream (see sendPieceWithQuoteFallback) —
+  // re-attaching it to the next piece would just 400 again.
+  let sendOpts: StreamSendOpts = {
     ...baseOpts,
     ...(replyToMessageId != null
       ? {
-          reply_parameters: {
-            message_id: replyToMessageId,
-            ...(quoteText != null ? { quote: { text: quoteText, position: 0 } } : {}),
-          },
+          // `quote` is a Bot API String; `quote_position` is a separate sibling
+          // Integer we deliberately don't emit. See reply-quote.ts.
+          reply_parameters: buildReplyParameters(replyToMessageId, quoteText),
         }
       : {}),
     ...(protectContent === true ? { protect_content: true } : {}),
@@ -262,6 +279,24 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
     const richOpts = { ...opts }
     delete richOpts.link_preview_options
     return bot.api.sendRichMessage(chatId, richMessage(piece.text), richOpts)
+  }
+  // Send a piece, degrading gracefully when the SURGICAL QUOTE is the thing
+  // Telegram rejected. `reply_parameters.quote` must be an exact substring of
+  // the replied-to message; when it isn't, the 400 kills a perfectly good
+  // answer. Drop the highlight (for this send and every later one on this
+  // stream) and re-send — the reply still lands, still threaded under the same
+  // message.
+  const sendPieceWithQuoteFallback = async (piece: { text: string; rich: boolean }) => {
+    try {
+      return await sendPiece(piece, sendOpts)
+    } catch (err) {
+      if (!isQuoteRejectionError(err) || !sendOptsHaveQuote(sendOpts)) throw err
+      warn?.(
+        `stream-controller: quote not found in the replied-to message — re-sending without the quote (${err instanceof Error ? err.message : String(err)})`,
+      )
+      sendOpts = dropQuoteFromSendOpts(sendOpts)
+      return await sendPiece(piece, sendOpts)
+    }
   }
   const editPiece = (id: number, piece: { text: string; rich: boolean }, opts: StreamSendOpts) => {
     if (!piece.rich) return bot.api.editMessageText(chatId, id, piece.text, opts)
@@ -395,7 +430,7 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
     }
     // First emission of this tail piece → a fresh follow-up message.
     try {
-      const sent = await retry(() => sendPiece(piece, sendOpts), { threadId, chat_id: chatId })
+      const sent = await retry(() => sendPieceWithQuoteFallback(piece), { threadId, chat_id: chatId })
       tailIds[ti] = sent.message_id
       tailLastText[ti] = piece.text
       onSend?.(sent.message_id, piece.text.length)
@@ -435,7 +470,7 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
       let anchorId: number | undefined
       try {
         const sent = await retry(
-          () => sendPiece(head, sendOpts),
+          () => sendPieceWithQuoteFallback(head),
           { threadId, chat_id: chatId },
         )
         anchorId = sent.message_id

--- a/telegram-plugin/stream-reply-handler.ts
+++ b/telegram-plugin/stream-reply-handler.ts
@@ -109,9 +109,11 @@ export interface StreamReplyArgs {
   disable_notification?: boolean
   /**
    * Optional surgical quote text. When set along with `reply_to`, the initial
-   * send includes `reply_parameters: { message_id, quote: { text, position: 0 } }`
-   * so Telegram highlights the specific quoted sentence rather than the whole
-   * referenced message. Ignored when `reply_to` is absent.
+   * send includes `reply_parameters: { message_id, quote }` — `quote` is a Bot
+   * API String (see `reply-quote.ts`) — so Telegram highlights the specific
+   * quoted sentence rather than the whole referenced message. It must be an
+   * exact substring of the referenced message; one Telegram cannot find is
+   * dropped and the send retried unquoted. Ignored when `reply_to` is absent.
    */
   quote_text?: string
   /**

--- a/telegram-plugin/tests/reply-quote-wire.test.ts
+++ b/telegram-plugin/tests/reply-quote-wire.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Wire-level outcome test for `quote_text` (surgical quote-reply).
+ *
+ * WHY AT THE FETCH LAYER
+ * ----------------------
+ * The bug this pins was a PAYLOAD-SHAPE bug: `reply_parameters.quote` was built
+ * as `{ text, position: 0 }` when the Bot API declares `quote` a **String**
+ * (`quote_position` is a separate sibling Integer). Telegram answered every
+ * quoted reply with `400 Bad Request: field "quote" must be of type String` —
+ * 378 of 384 total `sendRichMessage` failures across the live fleet
+ * (agent `overlord`, 2026-07-29 → 07-30). A unit test over the options builder
+ * would have asserted the same wrong shape happily; only a test that reads what
+ * actually goes over the wire can catch it, and only that keeps a future
+ * wrapper (a re-render, an opts transform, a new send adapter) from re-breaking
+ * it invisibly.
+ *
+ * So this drives the REAL send path — `sendReply` (the body of the gateway's
+ * `executeReply`, which is a thin wrapper over it) — against a REAL grammy
+ * `Bot` whose HTTP client is an injected `fetch`. Every assertion is made on
+ * the JSON body grammy serialized for `POST /botTOKEN/sendRichMessage`.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { Bot, type Context } from 'grammy'
+import { sendReply, type SendReplyGatewayDeps } from '../gateway/outbound-send-path.js'
+import { handleStreamReply, type StreamReplyDeps } from '../stream-reply-handler.js'
+import type { StreamBotApi } from '../stream-controller.js'
+import type { DraftStreamHandle } from '../draft-stream.js'
+import { OutboundDedupCache } from '../recent-outbound-dedup.js'
+import { FlushedTurnSupersedeRegistry } from '../flushed-turn-supersede.js'
+import { VoiceOnDemandCache } from '../voice-ondemand.js'
+import { PreSynthQueue } from '../voice-presynth.js'
+import type { Access } from '../gateway/gateway.js'
+
+const CHAT = '5550001'
+
+type WireCall = { method: string; payload: Record<string, unknown> }
+
+/** Scripted Telegram error for one wire method (fires once, then succeeds). */
+type ScriptedError = { method: string; description: string }
+
+/** A REAL grammy Bot whose HTTP client is an injected fetch — every call is
+ *  captured as the JSON body grammy actually serialized for the Bot API. */
+function makeWireBot(opts: { errors?: ScriptedError[] } = {}) {
+  const calls: WireCall[] = []
+  const errors = [...(opts.errors ?? [])]
+  let nextMessageId = 9000
+
+  const fetchImpl = (async (input: unknown, init?: { body?: unknown }) => {
+    const url = String(input)
+    const method = url.slice(url.lastIndexOf('/') + 1)
+    const body = typeof init?.body === 'string' ? init.body : '{}'
+    const payload = JSON.parse(body) as Record<string, unknown>
+    calls.push({ method, payload })
+    const scripted = errors.findIndex((e) => e.method === method)
+    if (scripted >= 0) {
+      const [err] = errors.splice(scripted, 1)
+      return new Response(
+        JSON.stringify({ ok: false, error_code: 400, description: err.description }),
+        { status: 400, headers: { 'content-type': 'application/json' } },
+      )
+    }
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        result: {
+          message_id: nextMessageId++,
+          date: Math.floor(Date.now() / 1000),
+          chat: { id: Number(CHAT), type: 'private' },
+        },
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    )
+  }) as unknown as typeof fetch
+
+  const bot = new Bot<Context>('123456:TEST-TOKEN', {
+    client: { fetch: fetchImpl },
+    botInfo: {
+      id: 123456,
+      is_bot: true,
+      first_name: 'test',
+      username: 'test_bot',
+      can_join_groups: false,
+      can_read_all_group_messages: false,
+      supports_inline_queries: false,
+      can_connect_to_business_account: false,
+      has_main_web_app: false,
+    },
+  })
+
+  const sends = () => calls.filter((c) => c.method.startsWith('send'))
+  const replyParams = (c: WireCall) => c.payload.reply_parameters as Record<string, unknown> | undefined
+  return { bot, calls, sends, replyParams }
+}
+
+function makeHarness(opts: { errors?: ScriptedError[] } = {}) {
+  const wire = makeWireBot(opts)
+  const bot = wire.bot
+
+  const access: Access = {
+    dmPolicy: 'allowlist',
+    allowFrom: [CHAT],
+    groups: {},
+    pending: {},
+    parseMode: 'html',
+    historyEnabled: false,
+  }
+
+  const noop = () => {}
+  const deps: SendReplyGatewayDeps = {
+    outboundDedup: new OutboundDedupCache(),
+    flushedTurnSupersede: new FlushedTurnSupersedeRegistry(),
+    firstTextReplyLogged: new Set<string>(),
+    suppressPtyPreview: new Set<string>(),
+    activeDraftStreams: new Map(),
+    lastPtyPreviewByChat: new Map(),
+    voiceOnDemandCache: new VoiceOnDemandCache(),
+    voicePreSynthQueue: new PreSynthQueue({ runJob: async () => {} }),
+    pendingProgress: { clearPending: noop, noteOutbound: noop },
+    signalTracker: { noteOutbound: noop, noteSignal: noop },
+    silencePoke: { noteOutbound: noop },
+    getCurrentTurn: () => null,
+    getLastActiveTurnChatId: () => undefined,
+    HISTORY_ENABLED: false,
+    TURN_ORIGIN_ROUTING_ENABLED: false,
+    AUTOCLASSIFY_MIDTURN_SHADOW: false,
+    MAX_ATTACHMENT_BYTES: 50 * 1024 * 1024,
+    MAX_CHUNK_LIMIT: 4000,
+    PHOTO_EXTS: new Set(['.png', '.jpg']),
+    lockedBot: bot,
+    robustApiCall: <T>(fn: () => Promise<T>) => fn(),
+    swallowingApiCall: async (fn: () => Promise<unknown>) => {
+      try {
+        return await fn()
+      } catch {
+        return undefined
+      }
+    },
+    loadAccess: () => access,
+    redactOutboundText: (t: string) => t,
+    assertAllowedChat: noop,
+    assertSendable: noop,
+    statusKey: (chatId: string, threadId?: number | null) => `${chatId}:${threadId ?? ''}`,
+    streamKey: (chatId: string, threadId?: number | null) => `${chatId}:${threadId ?? ''}`,
+    resolveReplyOwnerTurn: () => ({
+      turn: null,
+      tier: 'none',
+      candidates: {
+        liveTurnId: null,
+        originTurnId: null,
+        quotedTurnId: null,
+        latestEndedTurnId: null,
+      },
+    }),
+    findTurnByOriginId: () => null,
+    findTurnByQuotedMessageId: () => null,
+    resolveAnswerThreadWithLog: () => undefined,
+    resolveThreadId: () => undefined,
+    getLatestInboundMessageId: () => null,
+    getLastSubagentHandbackAt: () => null,
+    recordOutbound: noop,
+    emissionAuthorityFor: () =>
+      ({
+        claimOrDowngradePing: () => ({ allowed: true, ping: true }),
+      }) as never,
+    clearActivitySummary: noop,
+    startTypingLoop: noop,
+    stopTypingLoop: noop,
+    logOutbound: noop,
+    closeObligationOnSubstantiveReply: noop,
+    finalizeStatusReaction: noop,
+    releaseTurnBufferGate: noop,
+    reapQueuedStatus: noop,
+    noteAgentOutputAt: noop,
+    rememberAgentButtonMeta: noop,
+    resolveVoiceOutPlan: () => null,
+    synthesizeVoiceOut: async () => null,
+    publishToTelegraph: async () => null,
+    clearSilentEndState: noop,
+    emitRuntimeMetric: noop,
+    shadowEmit: noop,
+    progressDriver: null,
+  }
+
+  return { ...wire, deps }
+}
+
+/** Drive the REAL `stream_reply` handler against the same wire-capturing bot. */
+function makeStreamHarness(opts: { errors?: ScriptedError[] } = {}) {
+  const wire = makeWireBot(opts)
+  const noop = () => {}
+  const deps: StreamReplyDeps = {
+    bot: wire.bot as unknown as { api: StreamBotApi },
+    retry: <T>(fn: () => Promise<T>) => fn(),
+    repairEscapedWhitespace: (t: string) => t,
+    assertAllowedChat: noop,
+    resolveThreadId: () => undefined,
+    disableLinkPreview: true,
+    defaultFormat: 'html',
+    logStreamingEvent: noop,
+    historyEnabled: false,
+    recordOutbound: noop,
+    writeError: noop,
+    throttleMs: 0,
+  }
+  const state = {
+    activeDraftStreams: new Map<string, DraftStreamHandle>(),
+    suppressPtyPreview: new Set<string>(),
+    lastPtyPreviewByChat: new Map<string, string>(),
+  }
+  return { ...wire, deps, state }
+}
+
+describe('quote_text lands on the wire as ReplyParameters.quote (a String)', () => {
+  it('sends reply_parameters.quote as a string and resolves delivered', async () => {
+    const h = makeHarness()
+    const res = await sendReply(h.deps, {
+      args: {
+        chat_id: CHAT,
+        text: 'Yes — that line is the one that breaks.',
+        reply_to: 4242,
+        quote_text: 'the position is a separate field',
+      },
+      turn: null,
+    })
+
+    const sends = h.sends()
+    expect(sends.length).toBeGreaterThan(0)
+    const rp = h.replyParams(sends[0])
+    expect(rp).toBeDefined()
+    expect(rp!.message_id).toBe(4242)
+    // The bug: `quote` was an OBJECT (`{ text, position }`). Telegram requires
+    // a String, and rejected every such send with 400.
+    expect(typeof rp!.quote).toBe('string')
+    expect(rp!.quote).toBe('the position is a separate field')
+    // No fabricated position — Telegram locates the quote itself, and neither
+    // send site has a real position source.
+    expect(rp).not.toHaveProperty('quote_position')
+    expect(rp).not.toHaveProperty('quote_parse_mode')
+    // Delivered: the send resolved and the tool result is not a failure notice.
+    const out = res.content[0]?.text ?? ''
+    expect(out).not.toMatch(/fail/i)
+    expect(out).toMatch(/sent/i)
+  })
+
+  it('is NOT html-escaped — the quote must stay an exact substring of the original', async () => {
+    const h = makeHarness()
+    await sendReply(h.deps, {
+      args: {
+        chat_id: CHAT,
+        text: 'Checked.',
+        reply_to: 77,
+        quote_text: 'tom & jerry <b>not a tag</b>',
+      },
+      turn: null,
+    })
+    const rp = h.replyParams(h.sends()[0])!
+    expect(rp.quote).toBe('tom & jerry <b>not a tag</b>')
+  })
+
+  it('a quote Telegram cannot find degrades to an unquoted reply instead of losing the answer', async () => {
+    const h = makeHarness({
+      errors: [
+        { method: 'sendRichMessage', description: 'Bad Request: QUOTE_TEXT_INVALID' },
+      ],
+    })
+    const res = await sendReply(h.deps, {
+      args: {
+        chat_id: CHAT,
+        text: 'The answer still has to land.',
+        reply_to: 4242,
+        quote_text: 'a paraphrase that is not in the original',
+      },
+      turn: null,
+    })
+
+    const sends = h.sends()
+    expect(sends.length).toBe(2)
+    // First attempt carried the quote and was rejected …
+    expect(h.replyParams(sends[0])!.quote).toBe('a paraphrase that is not in the original')
+    // … the retry keeps the reply target and drops only the highlight.
+    const retry = h.replyParams(sends[1])!
+    expect(retry.message_id).toBe(4242)
+    expect(retry).not.toHaveProperty('quote')
+    expect(res.content[0]?.text ?? '').toMatch(/sent/i)
+  })
+
+  it('omits quote entirely when quote_text is absent (plain reply unchanged)', async () => {
+    const h = makeHarness()
+    await sendReply(h.deps, {
+      args: { chat_id: CHAT, text: 'plain reply', reply_to: 12 },
+      turn: null,
+    })
+    const rp = h.replyParams(h.sends()[0])!
+    expect(rp).toEqual({ message_id: 12 })
+  })
+
+  it('stream_reply carries the same String shape to the wire', async () => {
+    const h = makeStreamHarness()
+    await handleStreamReply(
+      {
+        chat_id: CHAT,
+        text: 'streamed answer',
+        done: true,
+        reply_to: '881',
+        quote_text: 'exactly this fragment',
+      },
+      h.state,
+      h.deps,
+    )
+    const sends = h.sends()
+    expect(sends.length).toBeGreaterThan(0)
+    const rp = h.replyParams(sends[0])!
+    expect(rp.message_id).toBe(881)
+    expect(typeof rp.quote).toBe('string')
+    expect(rp.quote).toBe('exactly this fragment')
+    expect(rp).not.toHaveProperty('quote_position')
+  })
+
+  it('stream_reply drops an unfindable quote and still delivers the message', async () => {
+    const h = makeStreamHarness({
+      errors: [
+        {
+          method: 'sendRichMessage',
+          description: 'Bad Request: message quote not found in the original message',
+        },
+      ],
+    })
+    const res = await handleStreamReply(
+      {
+        chat_id: CHAT,
+        text: 'streamed answer',
+        done: true,
+        reply_to: '881',
+        quote_text: 'not present in the original',
+      },
+      h.state,
+      h.deps,
+    )
+    const sends = h.sends()
+    expect(sends.length).toBe(2)
+    expect(h.replyParams(sends[0])!.quote).toBe('not present in the original')
+    expect(h.replyParams(sends[1])!).toEqual({ message_id: 881 })
+    expect(res.messageId).not.toBeNull()
+  })
+
+  it('truncates an over-long quote to the Bot API 1024-char cap (a prefix is still an exact substring)', async () => {
+    const h = makeHarness()
+    const long = 'x'.repeat(1500)
+    await sendReply(h.deps, {
+      args: { chat_id: CHAT, text: 'ok', reply_to: 5, quote_text: long },
+      turn: null,
+    })
+    const rp = h.replyParams(h.sends()[0])!
+    expect((rp.quote as string).length).toBe(1024)
+    expect(long.startsWith(rp.quote as string)).toBe(true)
+  })
+})

--- a/telegram-plugin/tests/reply-quote-wire.test.ts
+++ b/telegram-plugin/tests/reply-quote-wire.test.ts
@@ -36,8 +36,11 @@ const CHAT = '5550001'
 
 type WireCall = { method: string; payload: Record<string, unknown> }
 
-/** Scripted Telegram error for one wire method (fires once, then succeeds). */
-type ScriptedError = { method: string; description: string }
+/** Scripted Telegram error for one wire method. Fires `times` times (default 1),
+ *  then that method succeeds. `times` matters for the body-error cases: a real
+ *  unparseable body fails EVERY time it is re-sent to the same method, so a
+ *  fire-once script would let a wrong fallback branch pass by accident. */
+type ScriptedError = { method: string; description: string; times?: number }
 
 /** A REAL grammy Bot whose HTTP client is an injected fetch — every call is
  *  captured as the JSON body grammy actually serialized for the Bot API. */
@@ -54,7 +57,10 @@ function makeWireBot(opts: { errors?: ScriptedError[] } = {}) {
     calls.push({ method, payload })
     const scripted = errors.findIndex((e) => e.method === method)
     if (scripted >= 0) {
-      const [err] = errors.splice(scripted, 1)
+      const err = errors[scripted]
+      const remaining = (err.times ?? 1) - 1
+      if (remaining > 0) errors[scripted] = { ...err, times: remaining }
+      else errors.splice(scripted, 1)
       return new Response(
         JSON.stringify({ ok: false, error_code: 400, description: err.description }),
         { status: 400, headers: { 'content-type': 'application/json' } },
@@ -285,6 +291,52 @@ describe('quote_text lands on the wire as ReplyParameters.quote (a String)', () 
     expect(res.content[0]?.text ?? '').toMatch(/sent/i)
   })
 
+  // A `<blockquote>` parse failure is a BODY error whose description happens to
+  // contain the substring "quote". If the quote classifier claims it, the ladder
+  // takes the quote branch, re-sends the SAME unparseable body without the
+  // quote, hits the same 400 with no secondary handling, and throws — so the
+  // pre-existing plain-text rescue never runs and the composed answer is lost.
+  // This is an outcome test on purpose: asserting the classifier returns false
+  // in isolation would not have caught it, because the loss happens in the
+  // ladder, not in the predicate.
+  for (const description of [
+    'Bad Request: can\'t parse entities: Can\'t find end tag corresponding to start tag "blockquote"',
+    'Bad Request: can\'t parse entities: Unsupported start tag "blockquote"',
+  ]) {
+    it(`a blockquote parse error on a QUOTED reply still reaches the plain-text rescue (${description.slice(-24)})`, async () => {
+      const h = makeHarness({
+        // Fails every time it is attempted — a body Telegram cannot parse does
+        // not start parsing on the second try.
+        errors: [{ method: 'sendRichMessage', description, times: 5 }],
+      })
+
+      const res = await sendReply(h.deps, {
+        args: {
+          chat_id: CHAT,
+          text: 'The answer must survive a blockquote parse error.',
+          reply_to: 4242,
+          quote_text: 'a real substring of the original',
+        },
+        turn: null,
+      })
+
+      const sends = h.sends()
+      // The rich attempt failed; the rescue must have gone out over a DIFFERENT
+      // method (plain text, no rich wrapper ⇒ the entity parser never runs).
+      const rescue = sends.filter((c) => c.method !== 'sendRichMessage')
+      expect(rescue.length).toBeGreaterThan(0)
+      // The answer actually landed, with its body intact.
+      expect(String(rescue[0].payload.text ?? '')).toContain(
+        'The answer must survive a blockquote parse error.',
+      )
+      expect(res.content[0]?.text ?? '').toMatch(/sent/i)
+      // And the quote branch was never taken: no second rich send stripped of
+      // the quote (that path is what swallowed the answer).
+      const richSends = sends.filter((c) => c.method === 'sendRichMessage')
+      expect(richSends.length).toBe(1)
+    })
+  }
+
   it('omits quote entirely when quote_text is absent (plain reply unchanged)', async () => {
     const h = makeHarness()
     await sendReply(h.deps, {
@@ -354,5 +406,28 @@ describe('quote_text lands on the wire as ReplyParameters.quote (a String)', () 
     const rp = h.replyParams(h.sends()[0])!
     expect((rp.quote as string).length).toBe(1024)
     expect(long.startsWith(rp.quote as string)).toBe(true)
+  })
+
+  it('never cuts an astral character in half at the 1024 boundary', async () => {
+    const h = makeHarness()
+    // '𝄞' is one astral char = TWO UTF-16 units. 1023 filler units put its high
+    // surrogate at index 1023 and its low surrogate at 1024, so a naive
+    // slice(0, 1024) would emit a LONE HIGH SURROGATE — not valid UTF-8 on the
+    // wire, and no longer a substring of anything.
+    const long = 'x'.repeat(1023) + '𝄞' + 'y'.repeat(200)
+    await sendReply(h.deps, {
+      args: { chat_id: CHAT, text: 'ok', reply_to: 5, quote_text: long },
+      turn: null,
+    })
+    const quote = h.replyParams(h.sends()[0])!.quote as string
+    // Cut back to 1023 rather than splitting the pair …
+    expect(quote.length).toBe(1023)
+    // … so no unpaired surrogate survives …
+    for (const ch of quote) expect(ch.codePointAt(0)! >= 0xd800 && ch.codePointAt(0)! <= 0xdfff).toBe(false)
+    // … and it round-trips through UTF-8 unchanged (a lone surrogate would be
+    // replaced by U+FFFD here).
+    expect(Buffer.from(quote, 'utf8').toString('utf8')).toBe(quote)
+    // … and it is still an exact prefix of the original.
+    expect(long.startsWith(quote)).toBe(true)
   })
 })


### PR DESCRIPTION
Closes #4138.

## Summary

`quote_text` (surgical quote-reply) has never worked. Both send sites built
`reply_parameters.quote` as an object — `{ text, position: 0 }` — while Bot API's
[`ReplyParameters`](https://core.telegram.org/bots/api#replyparameters) declares `quote` a
**String** and puts the offset in a separate sibling `quote_position` Integer. Telegram
answered `400 Bad Request: field "quote" must be of type String` on every quoted reply, the
reply threw, and the agent re-attempted a payload that could never be accepted.

Fixed at both sites through one new module, `telegram-plugin/reply-quote.ts`:

- `quote` goes on the wire as the string.
- **No `quote_position`** — Telegram locates the quote itself, and neither send site has a
  real position source. The fabricated `0` is what invited the object shape.
- **No `quote_parse_mode` / `quote_entities`, therefore no HTML escaping.** With no parse
  mode the quote is matched literally, which is what `quote_text` carries. The quote must be
  an *exact substring* of the target message, so escaping it (`&` → `&amp;`) would guarantee
  a rejection.
- Over-long quotes truncate to the documented 1024-char cap (a prefix of an exact substring
  is still an exact substring), never splitting a surrogate pair. Empty/whitespace-only
  quotes are dropped.
- **Quote-not-found is handled, not fatal.** Telegram 400s when the quote isn't in the
  replied-to message (a paraphrase, an entity mismatch). Both paths now drop the highlight
  and re-send once as an ordinary reply to the same message — the answer still lands. The
  stream path drops it for the remainder of the stream rather than re-attaching a doomed
  quote to every piece.
- `StreamSendOpts.reply_parameters` typed the wrong shape too, so `tsc` agreed with the bug.
  Now `quote?: string`.
- The `quote_text` tool description now tells the model it must be an exact substring copied
  verbatim.

## Why

A sweep of every `tg-post method=sendRichMessage … status=err` line on disk across the live
fleet: **378 of 384 total send failures are this one error** — ~98% of the fleet's single
worst delivery signature. All on agent `overlord`, 2026-07-29 → 07-30, in retry bursts.

## Test plan

`telegram-plugin/tests/reply-quote-wire.test.ts` drives the **real** send paths — `sendReply`
(the body of the gateway's `executeReply`) and `handleStreamReply` — against a **real grammy
`Bot` whose HTTP client is an injected `fetch`**, and asserts on the JSON body grammy
serialized for `POST /bot<token>/sendRichMessage`.

Asserting at the fetch layer is the point, not a stylistic choice: a payload-shape unit test
over the options builder would have asserted the same wrong shape happily, and capturing at
the wire is what stops a future wrapper (a re-render, an opts transform, a new send adapter)
from re-breaking this invisibly.

Seven cases: string shape on the reply path, no `quote_position`/`quote_parse_mode`, no HTML
escaping, quote-not-found degradation (two sends, second unquoted, answer delivered),
plain-reply control, 1024-char truncation, plus the same string-shape and degradation cases
on the `stream_reply` path.

**Revert-check.** With the test in place, restoring the old `{ text, position }` shape at both
send sites: **6 of 7 fail** (`expected 'object' to be 'string'`). The 7th is the no-`quote_text`
control, shape-independent by design. With the fix: **7 of 7 pass**.

Local: `npm run lint` clean (exit 0). `vitest run telegram-plugin/tests` → 522/523 files, 8578
passed. The one failure (`approval-hold-record.test.ts` "falls back when the shared dir is not
writable") reproduces identically on pristine `origin/main` in this container and is an
environment artifact — the suite runs as uid 0, so a `0o500` dir is still writable. Not
touched by this diff.

## Risk

Low and strictly recovering. The unquoted reply path is byte-identical (`{ message_id }` and
nothing else, pinned by a test). The only behaviour change is on a path that was 100% broken:
quoted replies now succeed, and a quote Telegram can't find degrades to an unquoted reply
instead of throwing the composed answer away.

Job spec: `reference/jobs/talk-to-agents-from-anywhere.md` — the chat surface is first-class;
a documented reply feature that 400s on every use is not.