### PR TITLE
fix(outbox): tag every captured message with its audience and refuse to deliver internal prose (#3865)

### DIFF
--- a/telegram-plugin/gateway/flood-reply-queue.ts
+++ b/telegram-plugin/gateway/flood-reply-queue.ts
@@ -145,6 +145,11 @@ export function queueFloodBlockedReply(input: FloodQueueInput): FloodQueueResult
     textSha256: sha256Hex(text),
     createdAt,
     source: FLOOD_QUEUED_SOURCE,
+    // W1-d (#3865): a flood-deferred record is a reply the agent ALREADY chose
+    // to send to this chat — its audience is never in question. Stamped
+    // explicitly rather than relying on the legacy default, so this producer
+    // stays correct if that default is ever revisited.
+    audience: 'user',
     ...(input.originChatId != null ? { originChatId: input.originChatId } : {}),
     ...(input.originThreadId != null ? { originThreadId: input.originThreadId } : {}),
   }

--- a/telegram-plugin/gateway/outbox-sweep.ts
+++ b/telegram-plugin/gateway/outbox-sweep.ts
@@ -26,6 +26,7 @@
  */
 
 import {
+  OUTBOX_MAX_AGE_MS,
   OUTBOX_QUIET_MS,
   appendDelivered,
   claimRecord,
@@ -42,6 +43,12 @@ import {
   sha256Hex,
   type OutboxRecord,
 } from '../outbox.js'
+import {
+  AUDIENCE_INTERNAL,
+  formatInternalSuppression,
+  resolveRecordAudience,
+  shouldSuppressForAudience,
+} from '../hooks/audience-classify.mjs'
 import { isShownBlock } from '../shown-ledger.js'
 import { richMessage, isParseEntitiesError } from '../rich-send.js'
 import { splitMarkdownChunks, splitPlainTextToCap } from '../format.js'
@@ -124,6 +131,22 @@ export interface OutboxSweepDeps {
    * does: a broken marker file must never permanently strand the outbox.
    */
   floodWaitRemainingMs?: () => number
+  /**
+   * W1-d (#3865) kill switch for the audience gate. Defaults to the env read
+   * `SWITCHROOM_TG_OUTBOX_AUDIENCE_GATE !== '0'` (ON by default; `=0` restores
+   * the pre-change leak). Injected rather than read at module scope so the
+   * revert-check test can flip it deterministically inside one process — a
+   * module-level const would be captured at import and the revert-check could
+   * not run at all.
+   */
+  audienceGateEnabled?: () => boolean
+  /**
+   * W1-d (#3865) structured-telemetry sink for a suppressed `'internal'`
+   * record. Mirrors `escalateOrphan` (#4104): a SEPARATE, non-chat channel, so
+   * the escalation path for internal prose is structurally incapable of
+   * becoming a message. Defaults to `log`.
+   */
+  escalateInternalSuppression?: (line: string) => void
 }
 
 export interface OutboxSweepSummary {
@@ -140,6 +163,12 @@ export interface OutboxSweepSummary {
   floodDeferred?: boolean
   /** Remaining ms of the window that caused `floodDeferred`. */
   floodRemainingMs?: number
+  /**
+   * W1-d (#3865): records withheld from the chat this sweep because their
+   * audience is `'internal'`. Counted separately from `skipped` so "we
+   * suppressed a leak" is never confused with "we deferred a delivery".
+   */
+  audienceSuppressed?: number
 }
 
 /**
@@ -190,8 +219,62 @@ export async function sweepOutbox(deps: OutboxSweepDeps): Promise<OutboxSweepSum
             : 0,
     )
 
+  const audienceGateEnabled = deps.audienceGateEnabled?.() ??
+    process.env.SWITCHROOM_TG_OUTBOX_AUDIENCE_GATE !== '0'
+  const escalateInternalSuppression = deps.escalateInternalSuppression ?? log
+
   for (const record of records) {
     summary.scanned++
+
+    // ── W1-d (#3865): AUDIENCE GATE ─────────────────────────────────────────
+    //
+    // Placed at ENTRY SELECTION — before routing, before the claim, before any
+    // adapter is consulted — and NOT inside the send adapter. That placement is
+    // the whole design: W1-b replaces the send adapter wholesale, and a gate
+    // living inside the adapter would leave with it. Here, an `'internal'`
+    // record simply never becomes a send candidate, whatever is wired below.
+    //
+    // Terminal, not deferred: we journal the nonce and delete the record, so a
+    // second tick has nothing to look at and the decision survives a restart.
+    // The escalation is STRUCTURED TELEMETRY on a non-chat channel — internal
+    // prose has exactly one exit from this pipeline, and it is not Telegram.
+    if (shouldSuppressForAudience(record, { gateEnabled: audienceGateEnabled })) {
+      summary.skipped++
+      summary.audienceSuppressed = (summary.audienceSuppressed ?? 0) + 1
+      const ageMs = now - record.createdAt
+      appendDelivered(
+        {
+          turnNonce: record.turnNonce,
+          textSha256: record.textSha256,
+          ts: now,
+          // The record is TERMINALLY resolved by the sweep machine — the same
+          // provenance a delivery would carry, so every exactly-once guard
+          // (`backstopAlreadyDelivered`, the turn-flush backstop) also treats
+          // this turn as settled and no other machine re-delivers the prose.
+          deliverySource: 'sweep',
+          replyAlreadyDeliveredThisTurn: record.replyAlreadyDeliveredThisTurn === true,
+          audience: AUDIENCE_INTERNAL,
+          // The honest terminal state: withheld by design. Recorded as an
+          // explicit named outcome rather than as an absence, so suppression
+          // reads as telemetry and never as a delivery failure.
+          suppressedAudience: AUDIENCE_INTERNAL,
+        },
+        deps.stateDir,
+      )
+      clearOutboxRecord(record.turnNonce, deps.stateDir)
+      escalateInternalSuppression(
+        formatInternalSuppression({
+          turnNonce: record.turnNonce,
+          turnId: turnIdFromNonce(record.turnNonce),
+          chatId: record.chatId,
+          textSha256: record.textSha256,
+          ageMs,
+          source: record.source,
+          pastWindow: ageMs > OUTBOX_MAX_AGE_MS,
+        }),
+      )
+      continue
+    }
 
     // Resolve destination (anchor → registry chain → per-session origin). Fails
     // CLOSED (null → held) rather than routing to an arbitrary chat (F2).
@@ -328,6 +411,20 @@ export async function sweepOutbox(deps: OutboxSweepDeps): Promise<OutboxSweepSum
     }
   }
   return summary
+}
+
+/**
+ * W1-d (#3865): recover the gateway `turnId` from an envelope-derived nonce.
+ *
+ * `deriveTurnNonce` builds `${chatId}:${threadId||'_'}#${messageId}` — byte-
+ * identical to the gateway's `deriveTurnId` — so an envelope-bearing nonce IS
+ * the turn id and `extractTurnId` in `src/fleet-health/detect.ts` can join the
+ * suppression telemetry back to the turn record. The sha256 fallback nonce
+ * (envelope-less anchors) carries no turn id; return null rather than emit a
+ * hash that looks like one.
+ */
+export function turnIdFromNonce(nonce: string): string | null {
+  return /^-?\d+:[^#]*#\d+$/.test(nonce) ? nonce : null
 }
 
 /** Read the flood probe, failing OPEN on any throw. */

--- a/telegram-plugin/hooks/audience-classify.d.mts
+++ b/telegram-plugin/hooks/audience-classify.d.mts
@@ -1,0 +1,31 @@
+export type Audience = 'user' | 'internal'
+
+export const AUDIENCE_USER: 'user'
+export const AUDIENCE_INTERNAL: 'internal'
+
+export function decideCaptureAudience(signals: {
+  replyToolThrewThisTurn?: boolean
+  openInboundObligation?: true | false | 'unknown'
+}): Audience
+
+export function resolveOpenObligation(args: {
+  snapshotRaw?: string | null
+  chatId?: string | null
+}): true | false | 'unknown'
+
+export function resolveRecordAudience(value: unknown): Audience
+
+export function shouldSuppressForAudience(
+  record: { audience?: unknown },
+  opts?: { gateEnabled?: boolean },
+): boolean
+
+export function formatInternalSuppression(s: {
+  turnNonce: string
+  turnId?: string | null
+  chatId?: string | null
+  textSha256?: string
+  ageMs?: number
+  source?: string
+  pastWindow?: boolean
+}): string

--- a/telegram-plugin/hooks/audience-classify.mjs
+++ b/telegram-plugin/hooks/audience-classify.mjs
@@ -1,0 +1,218 @@
+/**
+ * Audience classification — "who is this text FOR?" (W1-d, issue #3865).
+ *
+ * THE FAILURE THIS EXISTS FOR
+ * ---------------------------
+ * Nothing in the capture → journal → sweep pipeline recorded who a piece of
+ * text was addressed to. Capture selects the terminal assistant-prose run
+ * STRUCTURALLY (`narration-classify.mjs` `selectBackstopDelivery`, substance
+ * floor at `silent-end-scan.mjs`), so when the reply tool throws (#3861) the
+ * agent's trailing working notes are the terminal prose run — they get
+ * journaled as if they were the answer, and the outbox sweep faithfully
+ * delivers internal orchestration prose into the operator's DM hours later.
+ * That is a private-data leak, not a cosmetic one.
+ *
+ * SHARED-PURE-MODULE, ON PURPOSE
+ * ------------------------------
+ * This is a plain `.mjs` with a sibling `.d.mts` (the same shape as
+ * `narration-classify.mjs`) because BOTH halves of the pipeline must run the
+ * IDENTICAL predicate and there is no build step between them:
+ *   - the Stop hooks (`silent-end-scan.mjs`, `silent-end-interrupt-stop.mjs`)
+ *     run unbundled under node and can only import sibling `.mjs`;
+ *   - the gateway (`outbox.ts`, `gateway/outbox-sweep.ts`) is bundled TS.
+ * A second hand-synced copy would drift, and a drift here is a leak.
+ *
+ * EVERYTHING HERE IS PURE. No fs, no env, no clock. The callers own their IO.
+ */
+
+/** Audience: the text is for the human on the other end of the chat. */
+export const AUDIENCE_USER = 'user'
+
+/**
+ * Audience: the text is the agent talking to itself (working notes,
+ * orchestration prose). It may be journaled and inspected, but it must never
+ * be delivered to a chat.
+ */
+export const AUDIENCE_INTERNAL = 'internal'
+
+/**
+ * Obligation state for the resolved chat, as seen at capture time.
+ *
+ * `'unknown'` is a first-class value and is NOT the same as `false`: an
+ * unreadable / malformed `obligations.json` means we could not establish that
+ * the user is NOT waiting on an answer, and the fail-safe direction is to
+ * assume they ARE (see `decideCaptureAudience`).
+ */
+/** @typedef {true | false | 'unknown'} OpenObligationState */
+
+/**
+ * THE classifier. Conservative by construction, and deliberately asymmetric.
+ *
+ * We mark `internal` ONLY on positive evidence:
+ *
+ *     replyToolThrewThisTurn === true  AND  openInboundObligation === false
+ *
+ * Both halves are load-bearing:
+ *   - "the reply tool threw" is what makes the trailing prose suspect at all.
+ *     Without a throw, terminal prose after a bypassed reply tool is the
+ *     ordinary #3513 backstop case and IS the answer.
+ *   - "no open inbound obligation" is what says nobody is waiting. If the user
+ *     asked something and we still owe them a reply, the least-bad move is to
+ *     deliver the prose we have; suppressing it would leave them with silence.
+ *
+ * The asymmetry is the whole safety argument. Getting it wrong in the
+ * `internal` direction produces a SILENT NO-OP (severity 3: the user asked and
+ * got nothing, with no signal). Getting it wrong in the `user` direction
+ * reproduces today's status quo, which is bad but is not a NEW failure class.
+ * So every uncertain input resolves to `user`.
+ *
+ * The narration classifier is deliberately NOT an input here. It is a VETO
+ * only: it already decides, upstream in `selectBackstopDelivery`, whether a
+ * prose run is capturable at all. Promoting it to a positive `internal` signal
+ * would let a heuristic prose-shape match silently swallow a real answer —
+ * exactly the severity-3 error this function is built to avoid.
+ *
+ * @param {{
+ *   replyToolThrewThisTurn?: boolean,
+ *   openInboundObligation?: true | false | 'unknown',
+ * }} signals
+ * @returns {'user' | 'internal'}
+ */
+export function decideCaptureAudience(signals) {
+  const threw = signals?.replyToolThrewThisTurn === true
+  if (!threw) return AUDIENCE_USER
+  // Only a POSITIVE, known-empty obligation state clears the second gate.
+  // `'unknown'`, `true`, and `undefined` all mean "someone may be waiting".
+  if (signals?.openInboundObligation !== false) return AUDIENCE_USER
+  return AUDIENCE_INTERNAL
+}
+
+/**
+ * Resolve the open-inbound-obligation state for a chat from the RAW text of the
+ * gateway's durable obligation snapshot (`<STATE_DIR>/obligations.json`, written
+ * by `persistObligations` on every ledger mutation — open AND close, see
+ * `obligation-ledger.ts:156`). Pure: the caller does the `readFileSync` and
+ * passes `null` when the file is absent or unreadable.
+ *
+ * The three-valued result is the point:
+ *
+ *   - `null` snapshot            → `'unknown'`. An absent file is NOT proof that
+ *                                  nobody is waiting: it is equally the shape of
+ *                                  an agent running with `SWITCHROOM_OBLIGATION_
+ *                                  LEDGER=0`, or a STATIC gateway, where
+ *                                  obligations exist but are never persisted.
+ *                                  Reading it as "empty" would let us suppress on
+ *                                  an agent that simply doesn't track waiting
+ *                                  users — a manufactured silent no-op.
+ *   - unparseable / wrong shape  → `'unknown'` (same reasoning; a torn or
+ *                                  forward-incompatible snapshot proves nothing).
+ *   - `chatId == null` (the chat
+ *     could not be resolved) and
+ *     the open set is non-empty  → `'unknown'`. Someone is waiting and we cannot
+ *                                  rule out that it is this record's reader.
+ *   - `chatId == null` and the
+ *     open set is empty          → `false`. Nobody anywhere is waiting, so the
+ *                                  scoping question is moot.
+ *   - otherwise                  → `true` iff some open obligation names this chat.
+ *
+ * @param {{ snapshotRaw?: string | null, chatId?: string | null }} args
+ * @returns {true | false | 'unknown'}
+ */
+export function resolveOpenObligation(args) {
+  const raw = args?.snapshotRaw
+  if (typeof raw !== 'string' || raw.length === 0) return 'unknown'
+  let parsed
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return 'unknown'
+  }
+  if (parsed == null || typeof parsed !== 'object') return 'unknown'
+  const rows = parsed.obligations
+  if (!Array.isArray(rows)) return 'unknown'
+  const open = rows.filter(
+    (r) => r != null && typeof r === 'object' && typeof r.chatId === 'string',
+  )
+  const chatId = args?.chatId == null ? null : String(args.chatId)
+  if (chatId == null) return open.length === 0 ? false : 'unknown'
+  return open.some((r) => r.chatId === chatId)
+}
+
+/**
+ * Read the audience off a persisted record or journal entry.
+ *
+ * LEGACY-ROW POLICY (decided in this PR, documented here because this function
+ * IS the policy): a record with no `audience` field — every record written
+ * before this change, plus any record written by a hook that predates it during
+ * a rolling upgrade — resolves to `'user'` and delivers exactly as it does
+ * today.
+ *
+ * Rationale: a legacy record carries no evidence either way, and the
+ * fail-safe direction for no-evidence is the one whose error mode is the
+ * status quo rather than a new silent no-op (see `decideCaptureAudience`). A
+ * legacy record's window is at most `OUTBOX_MAX_AGE_MS` wide, so the legacy
+ * population is bounded and drains within 30 minutes of deploy.
+ *
+ * Any value that is not the exact `'internal'` literal (unknown strings,
+ * numbers, objects, `null`) is also `'user'` — suppression requires an
+ * affirmative, exact tag.
+ *
+ * @param {unknown} value
+ * @returns {'user' | 'internal'}
+ */
+export function resolveRecordAudience(value) {
+  return value === AUDIENCE_INTERNAL ? AUDIENCE_INTERNAL : AUDIENCE_USER
+}
+
+/**
+ * Entry-selection predicate for the sweep. Placed here, shared, and pure so the
+ * gate is a property of the RECORD rather than of whatever send adapter happens
+ * to be wired underneath it — W1-b swaps that adapter out, and this gate must
+ * survive the swap untouched.
+ *
+ * `gateEnabled` is the kill-switch seam (the sweep reads
+ * `SWITCHROOM_TG_OUTBOX_AUDIENCE_GATE !== '0'`). It exists so the revert-check
+ * can run: with the gate off, the leak reproduces and the zero-send assertion
+ * must fail. A test that still passes with the gate off is not testing the gate.
+ *
+ * @param {{ audience?: unknown }} record
+ * @param {{ gateEnabled?: boolean }} [opts]
+ * @returns {boolean}
+ */
+export function shouldSuppressForAudience(record, opts) {
+  if (opts?.gateEnabled === false) return false
+  return resolveRecordAudience(record?.audience) === AUDIENCE_INTERNAL
+}
+
+/**
+ * The structured telemetry line emitted when the sweep suppresses an
+ * `internal` record. Mirrors `formatOrphanEscalation` (#4104): an exported pure
+ * formatter plus an injected `writeLog`, so the line is greppable, unit-
+ * assertable, and CANNOT accidentally become a chat send.
+ *
+ * It carries `turnId=` in the gateway's `<chat>:<thread>#<message>` shape so
+ * `extractTurnId` in `src/fleet-health/detect.ts` can join it back to the turn,
+ * and it is worded so it matches NONE of that file's `GATEWAY_SIGNATURES`:
+ * suppression-by-design is telemetry, not a delivery failure, and must not page
+ * anyone.
+ *
+ * @param {{
+ *   turnNonce: string,
+ *   turnId?: string | null,
+ *   chatId?: string | null,
+ *   textSha256?: string,
+ *   ageMs?: number,
+ *   source?: string,
+ *   pastWindow?: boolean,
+ * }} s
+ * @returns {string}
+ */
+export function formatInternalSuppression(s) {
+  return (
+    `telegram gateway: outbox audience suppression nonce=${s.turnNonce} ` +
+    `turnId=${s.turnId ?? 'unknown'} chatId=${s.chatId ?? 'unresolved'} ` +
+    `sha=${(s.textSha256 ?? '').slice(0, 12)} ageMs=${s.ageMs ?? 0} ` +
+    `source=${s.source ?? 'unknown'} pastWindow=${s.pastWindow === true} ` +
+    `audience=internal — internal prose withheld from chat, journaled terminally\n`
+  )
+}

--- a/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
+++ b/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
@@ -69,6 +69,11 @@ import {
   isCapturedProseDeliveryEnabledEnv,
   isGatewayHeartbeatFresh,
 } from './silent-end-scan.mjs'
+import {
+  decideCaptureAudience,
+  resolveOpenObligation,
+  AUDIENCE_INTERNAL,
+} from './audience-classify.mjs'
 
 // MUST stay in sync with SILENT_END_MAX_RETRIES in telegram-plugin/silent-end.ts
 // (this hook is a standalone .mjs and can't import the TS module).
@@ -157,12 +162,44 @@ function outboxAlreadyDelivered(outboxDir, nonce) {
 }
 
 /**
+ * W1-d (#3865): classify WHO the captured prose is for, at capture time — the
+ * only point in the pipeline that can still see the turn.
+ *
+ * The obligation snapshot is read here (impure) and the verdict is computed by
+ * the shared pure classifier, so the hook and the gateway run the identical
+ * predicate. Any failure resolves to `'user'` via `resolveOpenObligation`'s
+ * `'unknown'` → the record delivers exactly as it does today.
+ *
+ * @param {string} stateDir
+ * @param {{ chatId: string|null, originChatId?: string|null, replyToolThrewThisTurn?: boolean }} capture
+ * @returns {'user' | 'internal'}
+ */
+function classifyCaptureAudience(stateDir, capture) {
+  let snapshotRaw = null
+  try {
+    const p = join(stateDir, 'obligations.json')
+    if (existsSync(p)) snapshotRaw = readFileSync(p, 'utf8')
+  } catch {
+    /* unreadable ⇒ null ⇒ 'unknown' ⇒ 'user' (fail-safe toward delivering) */
+  }
+  return decideCaptureAudience({
+    replyToolThrewThisTurn: capture.replyToolThrewThisTurn === true,
+    openInboundObligation: resolveOpenObligation({
+      snapshotRaw,
+      // Same chat the sweep will route to: the envelope chat when present,
+      // else this session's origin chat (`resolveOutboxChat`'s F2 fallback).
+      chatId: capture.chatId ?? capture.originChatId ?? null,
+    }),
+  })
+}
+
+/**
  * Write the durable outbox record for a captured undelivered final answer
  * (atomic tmp+rename), mirroring `writeOutboxRecordAtomic` in `../outbox.ts`.
  * The gateway heartbeat sweep is the single deliverer. Best-effort; never
  * throws. Returns true when a record exists on disk for the nonce afterward.
  */
-function writeOutboxRecord(stateDir, capture) {
+function writeOutboxRecord(stateDir, capture, audience) {
   const outboxDir = join(stateDir, 'outbox')
   try {
     mkdirSync(outboxDir, { recursive: true })
@@ -187,6 +224,11 @@ function writeOutboxRecord(stateDir, capture) {
       // journal alone. Driven by the SAME boolean that gates capture-vs-election
       // in main() — fix and telemetry cannot drift.
       replyAlreadyDeliveredThisTurn: capture.replyAlreadyDeliveredThisTurn === true,
+      // W1-d (#3865): WHO this text is for. Always stamped explicitly (never
+      // left implicit) so a post-change record is self-describing and the
+      // sweep's gate never has to infer. `'user'` is byte-for-byte the
+      // pre-change behaviour.
+      audience: audience === AUDIENCE_INTERNAL ? AUDIENCE_INTERNAL : 'user',
     }
     const tmpPath = join(outboxDir, `.${capture.turnNonce}.${process.pid}.tmp`)
     writeFileSync(tmpPath, JSON.stringify(record), 'utf8')
@@ -267,11 +309,16 @@ function main() {
             `deferring to single-writer election (#3510)\n`,
         )
       } else {
-        writeOutboxRecord(stateDir, capture)
+        const audience = classifyCaptureAudience(stateDir, capture)
+        writeOutboxRecord(stateDir, capture, audience)
         process.stderr.write(
           `[silent-end-interrupt] captured undelivered final answer to outbox ` +
             `(nonce=${capture.turnNonce} source=${capture.source} chars=${capture.text.length} ` +
-            `replyAlreadyDeliveredThisTurn=false) — sweep will deliver; allowing stop\n`,
+            `replyAlreadyDeliveredThisTurn=false audience=${audience} ` +
+            `replyToolThrewThisTurn=${capture.replyToolThrewThisTurn === true}) — ` +
+            `${audience === AUDIENCE_INTERNAL
+              ? 'internal prose: journaled for inspection, sweep will NOT deliver'
+              : 'sweep will deliver'}; allowing stop\n`,
         )
         process.exit(0)
       }

--- a/telegram-plugin/hooks/silent-end-scan.mjs
+++ b/telegram-plugin/hooks/silent-end-scan.mjs
@@ -917,7 +917,7 @@ function resolveSessionOriginChat(lines) {
  *
  * @param {string} jsonl
  * @param {number} [now]
- * @returns {{ capture: false, reason: string } | { capture: true, text: string, turnNonce: string, chatId: string|null, threadId: number|null, source: string, anchorContent: string, replyAlreadyDeliveredThisTurn: boolean, deliveredReplySha256: string|null }}
+ * @returns {{ capture: false, reason: string } | { capture: true, text: string, turnNonce: string, chatId: string|null, threadId: number|null, source: string, anchorContent: string, replyAlreadyDeliveredThisTurn: boolean, deliveredReplySha256: string|null, replyToolThrewThisTurn: boolean }}
  */
 export function scanForOutboxCapture(jsonl, now = Date.now()) {
   const lines = jsonl.split('\n')
@@ -925,12 +925,34 @@ export function scanForOutboxCapture(jsonl, now = Date.now()) {
   const { envelope } = anchor
 
   const blocks = []
+  // W1-d (#3865): ids of reply-tool `tool_use` blocks seen this turn, and the
+  // ids whose `tool_result` came back `is_error: true`. Their intersection is
+  // the "did the reply tool throw this turn" signal.
+  const replyToolUseIds = new Set()
+  const erroredToolUseIds = new Set()
   for (let i = anchor.startIdx + 1; i < lines.length; i++) {
     const line = lines[i]
     if (!line || line[0] !== '{') continue
     let obj
     try { obj = JSON.parse(line) } catch { continue }
     if (obj?.isSidechain === true) continue
+    // W1-d (#3865): tool RESULT lines are how a reply-tool THROW becomes
+    // visible. Claude Code writes the result of a `tool_use` as a `user`-type
+    // line whose content array carries `{type:'tool_result', tool_use_id,
+    // is_error}`. Nothing in this scanner read those before, which is exactly
+    // why an errored reply was indistinguishable from a delivered one — the
+    // transcript shape is otherwise identical.
+    if (obj?.type === 'user') {
+      const rc = obj?.message?.content
+      if (!Array.isArray(rc)) continue
+      for (const r of rc) {
+        if (r?.type !== 'tool_result') continue
+        if (r?.is_error !== true) continue
+        if (typeof r.tool_use_id !== 'string') continue
+        erroredToolUseIds.add(r.tool_use_id)
+      }
+      continue
+    }
     if (obj?.type !== 'assistant') continue
     const content = obj?.message?.content
     if (!Array.isArray(content)) continue
@@ -971,6 +993,12 @@ export function scanForOutboxCapture(jsonl, now = Date.now()) {
         }
         continue
       }
+      // W1-d (#3865): remember EVERY reply-tool call's id, not just the
+      // qualifying-final-answer ones. An interim ack that threw is still a
+      // reply-tool throw, and the #3861 shape (reply raises, agent then writes
+      // trailing working notes) does not require the errored call to have been
+      // a qualifying final answer.
+      if (typeof c.id === 'string') replyToolUseIds.add(c.id)
       const input = c.input ?? {}
       const text = String(input.text ?? '')
       if (SILENT_MARKER_RE.test(text.trim()) || endsWithSilentMarker(text)) {
@@ -1081,5 +1109,10 @@ export function scanForOutboxCapture(jsonl, now = Date.now()) {
     originThreadId: origin.threadId,
     replyAlreadyDeliveredThisTurn,
     deliveredReplySha256,
+    // W1-d (#3865): one of this turn's reply-tool calls came back an error.
+    // Reported as a raw SIGNAL, not a verdict — `decideCaptureAudience` in
+    // `audience-classify.mjs` combines it with the obligation state (which
+    // this pure transcript scanner cannot see) to decide the audience.
+    replyToolThrewThisTurn: [...replyToolUseIds].some((id) => erroredToolUseIds.has(id)),
   }
 }

--- a/telegram-plugin/outbox.ts
+++ b/telegram-plugin/outbox.ts
@@ -65,6 +65,13 @@ import {
 } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
+// W1-d (#3865). The audience vocabulary and its resolution rule live in ONE
+// shared pure module because the unbundled Stop hooks (which stamp it) and this
+// bundled gateway code (which persists and enforces it) must agree exactly. A
+// hand-synced second copy here would be a leak waiting on a drift.
+import type { Audience } from './hooks/audience-classify.mjs'
+
+export type { Audience }
 
 /** One captured, not-yet-delivered final message for a single main-session turn. */
 export interface OutboxRecord {
@@ -113,6 +120,23 @@ export interface OutboxRecord {
    * or in a sweep journal entry — is direct evidence of a regression.
    */
   replyAlreadyDeliveredThisTurn?: boolean
+  /**
+   * W1-d (#3865): WHO this text is addressed to, decided at capture time by
+   * `hooks/audience-classify.mjs` (`decideCaptureAudience`) — the only point in
+   * the pipeline that can still see the turn that produced it.
+   *
+   * `'internal'` means the text is the agent's own working notes (the #3861
+   * shape: the reply tool threw, nobody was waiting, and the structurally-
+   * selected terminal prose run is orchestration narration rather than an
+   * answer). Such a record is journaled and inspectable but MUST NEVER reach a
+   * chat — the sweep drops it at entry selection.
+   *
+   * OPTIONAL for legacy reasons: every record written before this field
+   * existed has no `audience`, and `resolveRecordAudience` maps missing (and
+   * any non-`'internal'` value) to `'user'`. Suppression requires an
+   * affirmative tag; absence is never evidence.
+   */
+  audience?: Audience
 }
 
 /** One line of the delivered-keys journal (`outbox/delivered.jsonl`). */
@@ -131,6 +155,19 @@ export interface DeliveredEntry {
   deliverySource?: 'sweep' | 'reply-tool' | 'flush'
   /** #3510 instrumentation: see `OutboxRecord.replyAlreadyDeliveredThisTurn`. */
   replyAlreadyDeliveredThisTurn?: boolean
+  /** W1-d (#3865): the record's audience, carried onto the journal line. */
+  audience?: Audience
+  /**
+   * W1-d (#3865): this journal line is a TERMINAL SUPPRESSION, not a delivery.
+   * The sweep withheld an `'internal'` record from the chat and wrote this line
+   * so the nonce is terminally claimed (a second tick sends nothing) and the
+   * decision is durably auditable.
+   *
+   * This is what keeps suppression honest: the outcome is recorded as an
+   * explicit, named state rather than as an absence. `tgMessageId` is absent on
+   * these lines because nothing was sent.
+   */
+  suppressedAudience?: Audience
 }
 
 export function sha256Hex(s: string): string {

--- a/telegram-plugin/tests/outbox-audience-3865.test.ts
+++ b/telegram-plugin/tests/outbox-audience-3865.test.ts
@@ -1,0 +1,579 @@
+/**
+ * outbox-audience-3865.test.ts — W1-d, "the audience bit" (issue #3865).
+ *
+ * THE BUG THIS GUARDS
+ * -------------------
+ * Nothing in capture → journal → sweep recorded WHO a piece of text was for.
+ * Capture picks the terminal assistant-prose run structurally, so when the
+ * reply tool throws (#3861) the agent's trailing WORKING NOTES become the
+ * "final answer", get journaled, and the sweep faithfully delivers internal
+ * orchestration prose into the operator's chat. That is a private-data leak.
+ *
+ * THE BAR
+ * -------
+ * Not "the right audience is delivered" — "the WRONG audience CANNOT receive".
+ * So every assertion below drives REAL machinery, never a stub of it:
+ *
+ *   - the REAL Stop hook (`hooks/silent-end-interrupt-stop.mjs`) spawned as a
+ *     subprocess against a REAL transcript, writing a REAL outbox record;
+ *   - the REAL `sweepOutbox` tick, with the REAL `createOutboxSend` adapter
+ *     wired to a RECORDING fake Bot API that counts every method that could
+ *     put bytes in a chat (sendRichMessage / sendMessage / editMessageText);
+ *   - the REAL fleet-health detectors from `src/fleet-health/detect.ts` for
+ *     the honesty claims.
+ *
+ * `revert check` below is the load-bearing one: it flips the gate off and
+ * asserts the leak REPRODUCES, proving the zero-sends assertion in the primary
+ * test is actually testing the gate and not passing for some unrelated reason.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readdirSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { sweepOutbox, createOutboxSend, turnIdFromNonce } from '../gateway/outbox-sweep.js'
+import { sha256Hex } from '../outbox.js'
+import {
+  decideCaptureAudience,
+  resolveOpenObligation,
+  resolveRecordAudience,
+  shouldSuppressForAudience,
+  formatInternalSuppression,
+} from '../hooks/audience-classify.mjs'
+import { scanForOutboxCapture } from '../hooks/silent-end-scan.mjs'
+import { buildTurnRecord } from '../gateway/turn-record-status.js'
+import {
+  detectTurnFindings,
+  detectGatewayFindings,
+  extractTurnId,
+  GATEWAY_SIGNATURES,
+} from '../../src/fleet-health/detect.js'
+
+const HOOK = resolve(__dirname, '..', 'hooks', 'silent-end-interrupt-stop.mjs')
+
+// Synthetic ids only (check-no-pii-secrets forbids real chat/user ids).
+const DM_CHAT = '5550001'
+const PRIOR_MSG_ID = 4242
+
+/** The internal working-notes prose that must never reach a chat. */
+const WORKING_NOTES = [
+  'Dispatched the worker onto the rebase and it came back clean, so the next',
+  'step is to re-run the scoped suite before touching the sweep at all. If the',
+  'suite is still red after that I will bisect from the merge base rather than',
+  'guessing, and I should double-check whether the earlier claim about the',
+  'adapter ordering actually holds, because I never verified it against HEAD.',
+].join(' ')
+
+/** A genuine answer, for the positive control. */
+const REAL_ANSWER = [
+  'The rebase is done and the suite is green. Two files changed: the sweep now',
+  'checks the record before it routes anything, and the capture hook stamps the',
+  'field it checks. Nothing else moved, and the flood queue behaves exactly as',
+  'it did before because it stamps the same value it always implied.',
+].join(' ')
+
+function makeStateDir(): string {
+  // NEVER ~/.switchroom — a test that writes there corrupts production state.
+  return mkdtempSync(join(tmpdir(), 'w1d-audience-'))
+}
+
+function writeTranscript(dir: string, lines: object[]): string {
+  const p = join(dir, 'transcript.jsonl')
+  writeFileSync(p, lines.map((l) => JSON.stringify(l)).join('\n'), 'utf8')
+  return p
+}
+
+function runHook(transcriptPath: string, stateDir: string) {
+  return spawnSync('node', [HOOK], {
+    input: JSON.stringify({ session_id: 's', transcript_path: transcriptPath }),
+    encoding: 'utf8',
+    timeout: 10_000,
+    env: { ...process.env, TELEGRAM_STATE_DIR: stateDir },
+  })
+}
+
+interface RecordShape {
+  turnNonce: string
+  text: string
+  audience?: string
+  chatId: string | null
+  originChatId?: string | null
+  source: string
+  textSha256: string
+  createdAt: number
+}
+
+function outboxRecords(dir: string): RecordShape[] {
+  const outbox = join(dir, 'outbox')
+  if (!existsSync(outbox)) return []
+  return readdirSync(outbox)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => JSON.parse(readFileSync(join(outbox, f), 'utf8')) as RecordShape)
+}
+
+function journalLines(dir: string): Array<Record<string, unknown>> {
+  const p = join(dir, 'outbox', 'delivered.jsonl')
+  if (!existsSync(p)) return []
+  return readFileSync(p, 'utf8')
+    .split('\n')
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l) as Record<string, unknown>)
+}
+
+function writeObligations(dir: string, obligations: object[]): void {
+  writeFileSync(join(dir, 'obligations.json'), JSON.stringify({ v: 1, obligations }), 'utf8')
+}
+
+function openObligation(chatId: string) {
+  return {
+    originTurnId: `${chatId}:_#${PRIOR_MSG_ID}`,
+    chatId,
+    messageId: PRIOR_MSG_ID,
+    text: 'where did the rebase land?',
+    openedAt: 1_000,
+    representCount: 0,
+  }
+}
+
+/**
+ * A RECORDING fake Bot API. Every method that can put bytes into a chat is
+ * counted, so "zero sends" means zero of ANY of them — not "zero of the one
+ * method I remembered to stub".
+ */
+function recordingBot() {
+  const calls: Array<{ method: string; chatId: string; text: string }> = []
+  let nextId = 900
+  return {
+    calls,
+    /** Every chat-visible call, whatever the method. */
+    chatCalls: () => calls,
+    api: {
+      sendRichMessage: async (chatId: string, body: { markdown: string }) => {
+        calls.push({ method: 'sendRichMessage', chatId, text: body.markdown })
+        return { message_id: nextId++ }
+      },
+      sendMessage: async (chatId: string, text: string) => {
+        calls.push({ method: 'sendMessage', chatId, text })
+        return { message_id: nextId++ }
+      },
+      editMessageText: async (chatId: string, _mid: number, text: string) => {
+        calls.push({ method: 'editMessageText', chatId, text })
+        return { message_id: nextId++ }
+      },
+    },
+  }
+}
+
+const passthroughRetry = <U>(fn: () => Promise<U>): Promise<U> => fn()
+
+/** Drive ONE real sweep tick against the recording bot. */
+async function realSweep(
+  stateDir: string,
+  bot: ReturnType<typeof recordingBot>,
+  opts: { gateEnabled?: boolean; now?: number } = {},
+) {
+  const logLines: string[] = []
+  const escalations: string[] = []
+  const summary = await sweepOutbox({
+    send: createOutboxSend({ getBot: () => bot, retry: passthroughRetry }),
+    textAlreadyDelivered: () => false,
+    stateDir,
+    // Past the quiet window so the record is eligible this tick.
+    now: () => opts.now ?? Date.now() + 60_000,
+    quietMs: 0,
+    log: (l) => logLines.push(l),
+    ...(opts.gateEnabled === undefined ? {} : { audienceGateEnabled: () => opts.gateEnabled! }),
+    escalateInternalSuppression: (l) => escalations.push(l),
+  })
+  return { summary, logLines, escalations }
+}
+
+/**
+ * The #3861 transcript shape, verbatim in structure:
+ *   1. an EARLIER Telegram inbound (the session's origin chat, already answered
+ *      — this is what `resolveSessionOriginChat` stamps as `originChatId`, and
+ *      it is the chat the leak lands in);
+ *   2. a background wake (task-notification) — the anchor for THIS turn;
+ *   3. an interim reply-tool ack, which THROWS;
+ *   4. trailing working-notes prose, which capture then selects as "the answer".
+ */
+function leakTranscript(dir: string, prose: string): string {
+  return writeTranscript(dir, [
+    {
+      type: 'queue-operation',
+      operation: 'enqueue',
+      content: `<channel source="telegram" chat_id="${DM_CHAT}" message_id="${PRIOR_MSG_ID}">where did the rebase land?</channel>`,
+      timestamp: 1000,
+    },
+    {
+      type: 'queue-operation',
+      operation: 'enqueue',
+      content: '<task-notification><task-id>a7cc7a0fa8f</task-id> worker done</task-notification>',
+      timestamp: 2000,
+    },
+    {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_reply_1',
+            name: 'mcp__switchroom-telegram__reply',
+            input: { text: 'On it.', disable_notification: true },
+          },
+        ],
+      },
+    },
+    {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_reply_1',
+            is_error: true,
+            content: 'Error: FLOOD_WAIT_ACTIVE — send rejected',
+          },
+        ],
+      },
+    },
+    { type: 'assistant', message: { content: [{ type: 'text', text: prose }] } },
+  ])
+}
+
+describe('W1-d — audience classifier (pure)', () => {
+  it('marks internal ONLY on positive evidence: reply threw AND no open obligation', () => {
+    expect(
+      decideCaptureAudience({ replyToolThrewThisTurn: true, openInboundObligation: false }),
+    ).toBe('internal')
+  })
+
+  it('every other combination resolves to user (the conservative direction)', () => {
+    // A misclassified answer is a SILENT NO-OP (sev-3). A misclassified note is
+    // the status quo. So uncertainty must always land on `user`.
+    for (const oblig of [true, false, 'unknown'] as const) {
+      expect(
+        decideCaptureAudience({ replyToolThrewThisTurn: false, openInboundObligation: oblig }),
+      ).toBe('user')
+    }
+    expect(
+      decideCaptureAudience({ replyToolThrewThisTurn: true, openInboundObligation: true }),
+    ).toBe('user')
+    expect(
+      decideCaptureAudience({ replyToolThrewThisTurn: true, openInboundObligation: 'unknown' }),
+    ).toBe('user')
+    expect(decideCaptureAudience({})).toBe('user')
+  })
+
+  it('obligation state is three-valued: absent/corrupt snapshots are unknown, not empty', () => {
+    expect(resolveOpenObligation({ snapshotRaw: null, chatId: DM_CHAT })).toBe('unknown')
+    expect(resolveOpenObligation({ snapshotRaw: '{not json', chatId: DM_CHAT })).toBe('unknown')
+    expect(resolveOpenObligation({ snapshotRaw: '{"v":1}', chatId: DM_CHAT })).toBe('unknown')
+    expect(
+      resolveOpenObligation({ snapshotRaw: '{"v":1,"obligations":[]}', chatId: DM_CHAT }),
+    ).toBe(false)
+    expect(
+      resolveOpenObligation({
+        snapshotRaw: JSON.stringify({ v: 1, obligations: [openObligation(DM_CHAT)] }),
+        chatId: DM_CHAT,
+      }),
+    ).toBe(true)
+    // Scoped: an obligation in ANOTHER chat does not block this one...
+    expect(
+      resolveOpenObligation({
+        snapshotRaw: JSON.stringify({ v: 1, obligations: [openObligation('5550002')] }),
+        chatId: DM_CHAT,
+      }),
+    ).toBe(false)
+    // ...but an UNRESOLVED chat with someone waiting somewhere is unknown.
+    expect(
+      resolveOpenObligation({
+        snapshotRaw: JSON.stringify({ v: 1, obligations: [openObligation('5550002')] }),
+        chatId: null,
+      }),
+    ).toBe('unknown')
+  })
+
+  it('suppression requires the exact `internal` literal — nothing else counts', () => {
+    expect(resolveRecordAudience('internal')).toBe('internal')
+    for (const v of [undefined, null, '', 'user', 'INTERNAL', 'internal ', 1, {}, ['internal']]) {
+      expect(resolveRecordAudience(v)).toBe('user')
+    }
+  })
+})
+
+describe('W1-d — capture tags the audience at the real Stop hook', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = makeStateDir()
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('reproduces #3861: the errored reply tool is visible in the transcript scan', () => {
+    const t = leakTranscript(dir, WORKING_NOTES)
+    const capture = scanForOutboxCapture(readFileSync(t, 'utf8')) as {
+      capture: boolean
+      text: string
+      replyToolThrewThisTurn: boolean
+      originChatId: string | null
+    }
+    // The bug shape: capture still fires (structural selection of terminal
+    // prose) — the working notes ARE what would be delivered.
+    expect(capture.capture).toBe(true)
+    expect(capture.text).toBe(WORKING_NOTES)
+    expect(capture.originChatId).toBe(DM_CHAT)
+    // The new signal. Pre-change the scanner never read tool_result at all.
+    expect(capture.replyToolThrewThisTurn).toBe(true)
+  })
+
+  it('the real hook writes audience:internal for the #3861 shape', () => {
+    writeObligations(dir, [])
+    const t = leakTranscript(dir, WORKING_NOTES)
+    const r = runHook(t, dir)
+    expect(r.status).toBe(0)
+    const records = outboxRecords(dir)
+    expect(records).toHaveLength(1)
+    expect(records[0].audience).toBe('internal')
+    expect(records[0].text).toBe(WORKING_NOTES)
+  })
+
+  it('the real hook writes audience:user when someone IS waiting on that chat', () => {
+    writeObligations(dir, [openObligation(DM_CHAT)])
+    const t = leakTranscript(dir, REAL_ANSWER)
+    const r = runHook(t, dir)
+    expect(r.status).toBe(0)
+    const records = outboxRecords(dir)
+    expect(records).toHaveLength(1)
+    expect(records[0].audience).toBe('user')
+  })
+
+  it('the real hook writes audience:user when no reply tool threw', () => {
+    writeObligations(dir, [])
+    const t = writeTranscript(dir, [
+      {
+        type: 'queue-operation',
+        operation: 'enqueue',
+        content: '<task-notification><task-id>a7cc7a0fa8f</task-id> worker done</task-notification>',
+        timestamp: 2000,
+      },
+      { type: 'assistant', message: { content: [{ type: 'text', text: REAL_ANSWER }] } },
+    ])
+    const r = runHook(t, dir)
+    expect(r.status).toBe(0)
+    expect(outboxRecords(dir)[0].audience).toBe('user')
+  })
+})
+
+describe('W1-d — the sweep cannot deliver internal prose', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = makeStateDir()
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  /** Capture the #3861 leak shape through the REAL hook. */
+  function captureLeak(): RecordShape {
+    writeObligations(dir, [])
+    const t = leakTranscript(dir, WORKING_NOTES)
+    expect(runHook(t, dir).status).toBe(0)
+    const records = outboxRecords(dir)
+    expect(records).toHaveLength(1)
+    expect(records[0].audience).toBe('internal')
+    return records[0]
+  }
+
+  it('PRIMARY: a real sweep tick makes ZERO chat calls, fires ONE telemetry line, and terminally claims the entry', async () => {
+    const rec = captureLeak()
+    const bot = recordingBot()
+
+    const first = await realSweep(dir, bot)
+
+    // 1. The bar: the wrong audience CANNOT receive. Not "no sendMessage" —
+    //    no call of ANY chat-visible method, carrying that content or not.
+    expect(bot.chatCalls()).toEqual([])
+    expect(first.summary.delivered).toBe(0)
+    expect(first.summary.audienceSuppressed).toBe(1)
+
+    // 2. Exactly one structured telemetry line, on the NON-CHAT channel.
+    expect(first.escalations).toHaveLength(1)
+    expect(first.escalations[0]).toContain('audience=internal')
+    expect(first.escalations[0]).toContain(`nonce=${rec.turnNonce}`)
+
+    // 3. Terminally claimed: the pending record is gone and the nonce is
+    //    journaled with an explicit, named suppression outcome.
+    expect(outboxRecords(dir)).toHaveLength(0)
+    const journal = journalLines(dir)
+    expect(journal).toHaveLength(1)
+    expect(journal[0].turnNonce).toBe(rec.turnNonce)
+    expect(journal[0].suppressedAudience).toBe('internal')
+    expect(journal[0].deliverySource).toBe('sweep')
+    expect(journal[0].tgMessageId).toBeUndefined()
+
+    // 4. A SECOND tick sends nothing and re-escalates nothing.
+    const second = await realSweep(dir, bot)
+    expect(bot.chatCalls()).toEqual([])
+    expect(second.summary.scanned).toBe(0)
+    expect(second.escalations).toHaveLength(0)
+  })
+
+  it('REVERT CHECK: with the gate disabled the leak REPRODUCES (so the assertion above is load-bearing)', async () => {
+    captureLeak()
+    const bot = recordingBot()
+
+    const run = await realSweep(dir, bot, { gateEnabled: false })
+
+    // The pre-change behaviour, verbatim: the working notes go to the chat.
+    expect(bot.chatCalls().length).toBe(1)
+    expect(bot.chatCalls()[0].chatId).toBe(DM_CHAT)
+    expect(bot.chatCalls()[0].text).toContain('I will bisect from the merge base')
+    expect(run.summary.delivered).toBe(1)
+    expect(run.summary.audienceSuppressed).toBeUndefined()
+    expect(run.escalations).toHaveLength(0)
+  })
+
+  it('POSITIVE CONTROL: an audience:user record with an open obligation delivers unchanged', async () => {
+    writeObligations(dir, [openObligation(DM_CHAT)])
+    const t = leakTranscript(dir, REAL_ANSWER)
+    expect(runHook(t, dir).status).toBe(0)
+    const rec = outboxRecords(dir)[0]
+    expect(rec.audience).toBe('user')
+
+    const bot = recordingBot()
+    const run = await realSweep(dir, bot)
+
+    expect(run.summary.delivered).toBe(1)
+    expect(run.summary.audienceSuppressed).toBeUndefined()
+    expect(bot.chatCalls().length).toBe(1)
+    expect(bot.chatCalls()[0].chatId).toBe(DM_CHAT)
+    expect(bot.chatCalls()[0].text).toContain('The rebase is done')
+    const journal = journalLines(dir)
+    expect(journal).toHaveLength(1)
+    expect(journal[0].suppressedAudience).toBeUndefined()
+    expect(journal[0].tgMessageId).toBeDefined()
+    expect(run.escalations).toHaveLength(0)
+  })
+
+  it('LEGACY: a record with NO audience field follows the documented default (user) and delivers', async () => {
+    // Byte-for-byte a pre-change record: no `audience` key at all.
+    const outbox = join(dir, 'outbox')
+    mkdirSync(outbox, { recursive: true })
+    const nonce = `${DM_CHAT}:_#5150`
+    const legacy = {
+      turnNonce: nonce,
+      chatId: DM_CHAT,
+      threadId: null,
+      text: REAL_ANSWER,
+      textSha256: sha256Hex(REAL_ANSWER),
+      createdAt: 1000,
+      source: 'channel',
+    }
+    expect(Object.keys(legacy)).not.toContain('audience')
+    writeFileSync(join(outbox, `${nonce}.json`), JSON.stringify(legacy), 'utf8')
+
+    const bot = recordingBot()
+    const run = await realSweep(dir, bot)
+
+    expect(run.summary.delivered).toBe(1)
+    expect(run.summary.audienceSuppressed).toBeUndefined()
+    expect(bot.chatCalls().length).toBe(1)
+    expect(bot.chatCalls()[0].text).toContain('The rebase is done')
+  })
+
+  it('the gate is a property of the RECORD, not of the send adapter (W1-b swap safety)', async () => {
+    captureLeak()
+    // A send adapter that would EXPLODE if it were ever reached. The gate sits
+    // upstream at entry selection, so swapping the adapter (W1-b) cannot
+    // reintroduce the leak.
+    const summary = await sweepOutbox({
+      send: async () => {
+        throw new Error('send adapter must never be reached for an internal record')
+      },
+      textAlreadyDelivered: () => false,
+      stateDir: dir,
+      now: () => Date.now() + 60_000,
+      quietMs: 0,
+      escalateInternalSuppression: () => {},
+    })
+    expect(summary.audienceSuppressed).toBe(1)
+    expect(summary.sendFailures).toBe(0)
+  })
+})
+
+describe('W1-d — suppression is honest telemetry, not a delivery failure', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = makeStateDir()
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('the suppression line matches NO gateway alarm signature', () => {
+    const line = formatInternalSuppression({
+      turnNonce: `${DM_CHAT}:_#${PRIOR_MSG_ID}`,
+      turnId: `${DM_CHAT}:_#${PRIOR_MSG_ID}`,
+      chatId: DM_CHAT,
+      textSha256: sha256Hex(WORKING_NOTES),
+      ageMs: 61_000,
+      source: 'task-notification',
+      pastWindow: true,
+    })
+    for (const [name, re] of Object.entries(GATEWAY_SIGNATURES)) {
+      expect(re.test(line), `${name} must not match a by-design suppression`).toBe(false)
+    }
+    const gw = detectGatewayFindings('klanker', line)
+    expect(gw.findings).toEqual([])
+  })
+
+  it('the suppression line carries a turn id the fleet-health scanner can join on', () => {
+    const nonce = `${DM_CHAT}:_#${PRIOR_MSG_ID}`
+    expect(turnIdFromNonce(nonce)).toBe(nonce)
+    // The sha256 fallback nonce (envelope-less anchor) is NOT a turn id and
+    // must not be emitted as one.
+    expect(turnIdFromNonce('a'.repeat(64))).toBeNull()
+    const line = formatInternalSuppression({ turnNonce: nonce, turnId: nonce, chatId: DM_CHAT })
+    expect(extractTurnId(line)).toBe(nonce)
+  })
+
+  it('a suppressed turn cannot present as silent-no-op:completed-zero-tools', () => {
+    // Structural argument, checked rather than asserted by hand: suppression is
+    // only reachable when the reply tool was CALLED and threw, so the turn has
+    // >= 1 tool call — and the detector's silent-no-op branch requires
+    // `tools === 0` (src/fleet-health/detect.ts:305-333). The two shapes are
+    // disjoint by construction.
+    const now = Math.floor(Date.now() / 1000)
+    const row = buildTurnRecord(
+      {
+        agent: 'klanker',
+        startedAt: 1000,
+        toolCallCount: 1, // the reply tool call that threw
+        turnId: `${DM_CHAT}:_#${PRIOR_MSG_ID}`,
+        finalAnswerDelivered: false,
+        replyCalled: true,
+      },
+      Date.now(),
+    )
+    expect(row.tools).toBe(1)
+    // The turn row is written honestly at turn end: nothing reached the user.
+    expect(row.status).toBe('no_reply')
+    expect(row.route).toBe('none')
+    const findings = detectTurnFindings('klanker', [{ ...row, ts: now }])
+    expect(findings.filter((f) => f.signal === 'silent-no-op-candidate')).toEqual([])
+  })
+
+  it('the sweep gate itself is pure and record-scoped', () => {
+    expect(shouldSuppressForAudience({ audience: 'internal' })).toBe(true)
+    expect(shouldSuppressForAudience({ audience: 'user' })).toBe(false)
+    expect(shouldSuppressForAudience({})).toBe(false)
+    // Kill switch (revert-check seam).
+    expect(shouldSuppressForAudience({ audience: 'internal' }, { gateEnabled: false })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #3865 (W1-d, "the audience bit"). Every captured message now records
**who it is for**, and the outbox sweep refuses to deliver anything addressed
to the agent itself.

- **New shared pure module** `telegram-plugin/hooks/audience-classify.mjs` (+
  sibling `.d.mts`) — the same one-implementation pattern as
  `narration-classify.mjs`, so the unbundled Stop hooks and the bundled gateway
  run the identical predicate with no hand-sync (a drift here is a leak).
- **Tag at capture.** `hooks/silent-end-scan.mjs` now reads `tool_result` /
  `is_error` blocks — it never did — to derive `replyToolThrewThisTurn`.
  `hooks/silent-end-interrupt-stop.mjs` reads the obligation snapshot and
  stamps `audience` on the record it writes.
- **Persist.** `OutboxRecord.audience` and `DeliveredEntry.audience` /
  `.suppressedAudience` in `telegram-plugin/outbox.ts`.
- **Enforce at sweep ENTRY SELECTION** in `gateway/outbox-sweep.ts` — upstream
  of routing, of the claim, and of the send adapter.
- `gateway/flood-reply-queue.ts` stamps `audience: 'user'` explicitly.

Job spec: `reference/jobs/talk-to-agents-from-anywhere.md:122-125` —
*"Delivery integrity: ... an outbound that matters reaches the user's device
rather than dying in a buffer."* This is the dual invariant: an outbound that
does **not** matter to the user must not reach their device at all.

## Why

Nothing in the capture -> journal -> sweep pipeline recorded who a piece of
text was for. Capture selects the terminal assistant-prose run **structurally**
(`narration-classify.mjs:176` `selectBackstopDelivery`; substance floor at
`hooks/silent-end-scan.mjs:72`). So when the reply tool throws (#3861), the
agent's trailing **working notes** are the terminal prose run: they get
journaled as if they were the answer, and the sweep faithfully delivers
internal orchestration prose into the operator's DM hours later. Private-data
leak, not a cosmetic one.

**The classifier is deliberately asymmetric.** `internal` requires POSITIVE
evidence: `replyToolThrewThisTurn === true` **AND**
`openInboundObligation === false`. Everything else — including every "I don't
know" — resolves to `user`. Misclassifying a real answer as internal is a
**silent no-op** (a separate sev-3 failure class); misclassifying a note as an
answer is merely the status quo. Obligation state is therefore three-valued:
an absent or corrupt `obligations.json` is `'unknown'`, never "empty" (it is
equally the shape of an agent running `SWITCHROOM_OBLIGATION_LEDGER=0`).

**The narration classifier stays a veto only.** It keeps its existing
structural veto over what is capturable at all; it is *not* promoted to a
positive `internal` signal. Letting a prose-shape heuristic grant suppression
is exactly how a real answer would get silently swallowed. (Flagging this as an
interpretation of the brief — see "Open questions".)

**Placement is load-bearing.** The gate is at entry selection, not in the send
adapter, because W1-b replaces the adapter wholesale. There is a test that
wires a send adapter which throws on any invocation and asserts the internal
record is still suppressed.

**Suppression is terminal, and it is telemetry — never a chat send.** The
nonce is journaled with `deliverySource: 'sweep'` (so every exactly-once guard
also treats the turn as settled and no other backstop re-delivers the prose)
plus an explicit `suppressedAudience: 'internal'`, and the record is deleted.
The escalation goes out through an injected `escalateInternalSuppression` sink
formatted by a pure `formatInternalSuppression` — the `escalateOrphan` pattern
from #4104. The line carries a `turnId=` in the gateway's
`<chat>:<thread>#<message>` shape so `extractTurnId` can join it, and it is
worded to match **none** of `GATEWAY_SIGNATURES` (asserted).

### Honesty: suppression cannot re-present as `silent-no-op:completed-zero-tools`

`src/fleet-health/detect.ts:305-333` only enters the silent-no-op branch when
`tools === 0`. Suppression is only reachable when the reply tool was **called
and threw**, so the turn has `tools >= 1`. The two shapes are disjoint by
construction, and the test asserts it through the real `buildTurnRecord` +
real `detectTurnFindings`. (The turn row is also written at turn end, append-
only, ~5s before the sweep runs — the sweep physically cannot rewrite it, which
is why the durable honest terminal stamp lives on the journal entry instead.)

### Legacy-row policy: missing `audience` => `user`

**Decision: agreed with the recommendation, and tested explicitly** (`LEGACY:`
in the suite writes a byte-for-byte pre-change record with no `audience` key
and asserts it delivers).

Rationale: a legacy record carries no evidence either way, and the fail-safe
direction for no-evidence is the one whose error mode is the status quo rather
than a new silent no-op. Suppression requires an affirmative, exact `'internal'`
literal — any other value (unknown string, wrong case, number, `null`) is also
`user`. The legacy population is bounded by `OUTBOX_MAX_AGE_MS` and drains
within 30 minutes of deploy, so the exposure window is short and known.

## Test plan

`telegram-plugin/tests/outbox-audience-3865.test.ts` (17 tests). Every
assertion drives real machinery: the **real Stop hook** spawned as a
subprocess against a real transcript writing a real record, the **real
`sweepOutbox`** with the **real `createOutboxSend`** adapter wired to a
**recording fake Bot API** that counts every chat-visible method
(`sendRichMessage` / `sendMessage` / `editMessageText`), and the **real**
fleet-health detectors.

1. **PRIMARY** — reproduce #3861 (interim reply tool call, `tool_result`
   `is_error: true`, trailing working notes). Journal record is
   `audience: 'internal'`; a real sweep tick makes **zero** chat calls of any
   method, fires **one** structured telemetry line, and terminally claims the
   entry (record gone, nonce journaled, `suppressedAudience: 'internal'`, no
   `tgMessageId`); a **second** tick scans nothing and sends nothing.
2. **REVERT CHECK** — gate disabled, the leak reproduces.
3. **POSITIVE CONTROL** — `audience: 'user'` with an open obligation (same
   reply-threw signal) delivers unchanged, one send, no suppression, no
   escalation.
4. **LEGACY** — a record with no `audience` field delivers.
5. Adapter-swap safety, the pure classifier's full truth table, three-valued
   obligation resolution, exact-literal resolution, `GATEWAY_SIGNATURES`
   non-match, `turnId` join, tools>=1 disjointness.

### Revert-check numbers

| | chat calls to the operator's DM | `summary.delivered` | telemetry lines |
|---|---|---|---|
| Gate ON (`SWITCHROOM_TG_OUTBOX_AUDIENCE_GATE` unset/1) | **0** | 0 | 1 |
| Gate OFF (`=0`) | **1** | 1 | 0 |

With the gate off, PRIMARY fails on exactly the zero-sends assertion, with the
working notes delivered verbatim to the DM:

```
FAIL  outbox-audience-3865.test.ts > PRIMARY: a real sweep tick makes ZERO chat calls...
AssertionError: expected [ { method: 'sendRichMessage', ...(2) } ] to deeply equal []
+   "chatId": "5550001",
+   "method": "sendRichMessage",
+   "text": "(from background task) Dispatched the worker onto the rebase..."
outbox-audience-3865.test.ts:403
```

### Local runs

- New suite: **17 passed**.
- Scoped neighbours (13 files: outbox capture/delivery/hook-capture/flush-ack/
  reply-then-recap/flood-breaker/listen-button/single-flight, silent-end
  interrupt-stop scan + integration, single-writer election, backstop
  exactly-once, narration-leak-3513): **228 passed**.
- `npm run lint`: clean (tsc, all 22 guards).

## Risk

- **Kill switch:** `SWITCHROOM_TG_OUTBOX_AUDIENCE_GATE=0` restores the previous
  behaviour exactly (sweep-side only; capture still stamps the field, which is
  inert without the gate). Injected via `OutboxSweepDeps.audienceGateEnabled`
  rather than read at module scope, so it is flippable in-process — otherwise
  the revert-check could not run at all.
- **Wrong-direction risk (a real answer suppressed):** requires the reply tool
  to have thrown AND a readable, well-formed, parseable obligation snapshot
  that names no open obligation for the resolved chat. Every degradation path
  (missing file, unreadable file, bad JSON, wrong envelope, unresolvable chat
  with anyone waiting) resolves to `user`.
- **No behaviour change** for records without the tag, for any record where the
  reply tool did not throw, or for flood-deferred replies.
- The `tool_result` scan adds one branch to a hot transcript loop over lines
  that were previously skipped outright; it does not change block selection.

## Open questions / follow-ups (low severity, filing separately)

1. **Premise correction.** The brief cites `telegram-plugin/reply-owner-resolve.ts`
   for "open inbound obligation for the resolved chat". That file resolves a
   reply's *owner turn* (`resolveReplyOwnerTier`, `decideContentGateBypass`,
   `decideAnswerLatchSuppression`); it carries no obligation state. Obligations
   live in `gateway/obligation-ledger.ts` / `gateway/obligation-store.ts` and
   the `obligations.json` snapshot (`gateway.ts:2800`), which is what this PR
   reads. Same signal, different source.
2. **The rule narrows the archetypal case.** An obligation only closes on a
   substantive delivered reply (`obligation-ledger.ts:153-157`), so for a
   *foreground Telegram* turn where the reply threw, the obligation is still
   OPEN at capture time and the record classifies `user` — it will still leak.
   The gate binds the background class (task-notification / cron / handback
   wakes, which never open an obligation and route to the DM via the
   `originChatId` fallback) — which is the class the reported symptom describes
   ("delivered to the operator's DM hours after the fact"). This is the
   conservative rule as specified and I have implemented it as specified;
   flagging that closing the foreground case needs a *different* signal than
   "no open obligation" and should be its own slice.
3. **Narration-as-veto** is an interpretation (see "Why"); worth an explicit
   ruling.
4. `hooks/silent-end-scan.mjs` still does not surface *which* reply call threw,
   only that one did. Sufficient here; worth revisiting if a future slice needs
   per-call provenance.
