### PR TITLE
fix(outbox): state the provenance of a reply-throw capture instead of passing it off as the answer (#4141, #4146)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -666,7 +666,7 @@ import {
 } from './obligation-ledger.js'
 // (#2996 P8 PR-C2: buildObligationRepresentInbound is now imported by
 // obligation-wiring.ts, where the sweep lives.)
-import { loadObligations, persistObligations } from './obligation-store.js'
+import { loadObligations, persistObligations, removeUnmaintainedSnapshot } from './obligation-store.js'
 import { buildCapturedDeliverySnapshot, createCapturedResumeDispatcher } from './captured-answer-resume.js'
 import {
   loadStatusPins,
@@ -2803,7 +2803,7 @@ const obligationStoreFs = {
   writeFileSync: (p: string, d: string) => writeFileSync(p, d),
   renameSync: (a: string, b: string) => renameSync(a, b),
   existsSync: (p: string) => existsSync(p),
-  fsyncFileSync: fsyncPathSync, fsyncDirSync: fsyncPathSync,
+  fsyncFileSync: fsyncPathSync, fsyncDirSync: fsyncPathSync, unlinkSync,
 }
 const obligationLedger = new ObligationLedger(OBLIGATION_REPRESENT_MAX, {
   onChange:
@@ -2821,7 +2821,7 @@ if (isGatewayMain && !STATIC && OBLIGATION_LEDGER_ENABLED) {
       `telegram gateway: obligation-ledger hydrated ${restored.length} open obligation(s) from ${OBLIGATION_STORE_PATH}\n`,
     )
   }
-}
+} else if (isGatewayMain) removeUnmaintainedSnapshot(OBLIGATION_STORE_PATH, obligationStoreFs, `static=${STATIC} enabled=${OBLIGATION_LEDGER_ENABLED}`) // #4146: persistence is off, so a leftover snapshot must not read as "nobody is waiting" to the W1-d audience classifier (logic in obligation-store.ts)
 // Origin ids with an escalation send IN FLIGHT — prevents the 5s sweep from
 // firing a second concurrent send for the same obligation while the first is
 // still awaiting (an escalation that takes >5s, or repeated failures).

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -10051,7 +10051,7 @@ async function deliverCapturedProse(args: {
   originTurnId: string
   text: string
   /** Turn elapsed for the honest "(waited Ns)" apology clause; optional. */
-  turnDurationMs?: number
+  turnDurationMs?: number; replyToolThrewThisTurn?: boolean // #4141: label prose recovered from a turn whose reply tool threw (see outbound-send-path.ts)
 }): Promise<void> {
   // #2996 P2: body moved VERBATIM to outbound-send-path.ts (single tested
   // send module). Injects the ONE `outboundDedup` instance (Amendment 1/9).

--- a/telegram-plugin/gateway/obligation-store.ts
+++ b/telegram-plugin/gateway/obligation-store.ts
@@ -43,6 +43,11 @@ export interface ObligationStoreFsSeam {
    *  entry lives in the parent's own cached metadata and is otherwise lost
    *  in a power cut. */
   fsyncDirSync: (path: string) => void
+  /** #4146: remove a snapshot this process will not maintain. Optional so any
+   *  existing seam (tests, other callers) keeps compiling and keeps working —
+   *  an absent `unlinkSync` degrades to "no cleanup", which is what those
+   *  callers do today. */
+  unlinkSync?: (path: string) => void
 }
 
 interface SnapshotEnvelope {
@@ -124,6 +129,56 @@ export function loadObligations(path: string, fs: ObligationStoreFsSeam): Obliga
   const env = parsed as Record<string, unknown>
   if (env.v !== 1 || !Array.isArray(env.obligations)) return []
   return env.obligations.filter(isObligationRow).map(sanitizeCapturedDelivery)
+}
+
+/**
+ * #4146 — drop a snapshot this process is NOT going to maintain.
+ *
+ * When the gateway is STATIC or `SWITCHROOM_OBLIGATION_LEDGER=0`, the ledger's
+ * `onChange` persister is never wired, so obligations open and close purely in
+ * memory while any previously-written `obligations.json` sits on disk
+ * unchanged. That leftover is not harmless: the W1-d audience classifier
+ * (`hooks/audience-classify.mjs`) reads this exact file to decide whether
+ * anyone is waiting on a chat, and an empty-but-stale open set reads there as
+ * POSITIVE evidence that nobody is — which is the one input that can make the
+ * classifier suppress a message owed to a human.
+ *
+ * Removing the file restores that classifier's stated invariant ("absent ⇒
+ * unknown ⇒ deliver") deterministically, with no freshness heuristic and no
+ * clock. Note this is safe precisely because the snapshot has exactly one
+ * writer: with the ledger ON, a merely-stopped gateway leaves a snapshot that
+ * is accurate rather than stale, so nothing is lost by only cleaning up in the
+ * modes where persistence is disabled.
+ *
+ * Best-effort and never throws — a failure degrades to the reader-side
+ * ledger-off guard in the hook.
+ *
+ * @returns `true` iff a file was actually removed.
+ */
+export function removeUnmaintainedSnapshot(
+  path: string,
+  fs: ObligationStoreFsSeam,
+  reason = 'persistence disabled',
+  log: (line: string) => void = (l) => process.stderr.write(l),
+): boolean {
+  const unlink = fs.unlinkSync
+  if (unlink == null) return false
+  try {
+    if (!fs.existsSync(path)) return false
+    unlink(path)
+    log(
+      `obligation-store: persistence is off (${reason}) — removed unmaintained ` +
+        `snapshot path=${path} so it cannot be read as "nobody is waiting" (#4146)\n`,
+    )
+    return true
+  } catch (err) {
+    log(
+      `obligation-store: could not remove unmaintained snapshot path=${path}: ` +
+        `${(err as Error).message} — audience classification falls back to the ` +
+        `reader-side ledger-off guard (#4146)\n`,
+    )
+    return false
+  }
 }
 
 /**

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -59,6 +59,14 @@ import {
 } from '../format.js'
 import { richMessage } from '../rich-send.js'
 import { journalExternalDelivery } from './outbox-sweep.js'
+import { sha256Hex } from '../outbox.js'
+// #4141: the ONE shared framing implementation, also used by the outbox sweep
+// and (for the classifier half) the unbundled Stop hooks.
+import {
+  applyReplyThrowFraming,
+  formatReplyThrowFraming,
+  shouldFrameReplyThrow,
+} from '../hooks/audience-classify.mjs'
 import { queueFloodBlockedReply } from './flood-reply-queue.js'
 import { resolveChatIdFallback } from './chat-id-fallback.js'
 import { isFinalAnswerReply, isSubstantiveFinalReply, shouldJournalReplySiteDelivery } from '../final-answer-detect.js'
@@ -2577,6 +2585,15 @@ export async function deliverCapturedProse(
   text: string
   /** Turn elapsed for the honest "(waited Ns)" apology clause; optional. */
   turnDurationMs?: number
+  /**
+   * #4141 — this turn's reply tool threw, so `text` is prose the model wrote
+   * AFTER its delivery attempt failed, not text it chose to send as the answer.
+   * When `true` the send is prefixed with a one-line provenance banner. This is
+   * the ELECTED-path counterpart of the outbox sweep's framing: on this path
+   * the Stop hook defers to the single-writer election and writes NO outbox
+   * record, so the sweep's framing can never reach the message.
+   */
+  replyToolThrewThisTurn?: boolean
   },
 ): Promise<void> {
   const {
@@ -2586,6 +2603,18 @@ export async function deliverCapturedProse(
   } = deps
   const { chatId, threadId, statusKeyStr, registryKey, originTurnId, text, turnDurationMs } = args
   const now = Date.now()
+  // #4141 — framing is a rendering concern, decided ONCE here and applied only
+  // to the bytes handed to Telegram. Everything keyed on identity (the dedup
+  // check + record below, and the journal's `textSha256`) deliberately keeps
+  // using the RAW `text`, so the label cannot change what counts as "the same
+  // answer" — a later reply-tool retry of the same prose still dedups, and the
+  // exactly-once-among-backstops journal key is unchanged. Same
+  // additive-by-construction property the sweep path has, re-established here
+  // because this path has its own send ladder and its own dedup.
+  const framed = shouldFrameReplyThrow(
+    { replyToolThrewThisTurn: args.replyToolThrewThisTurn },
+    { frameEnabled: process.env.SWITCHROOM_TG_OUTBOX_PROVENANCE_FRAMING !== '0' },
+  )
   // #3228 Finding 1 — the three settlement points (sent / skipped-dedup /
   // failed) all funnel through the pure `settleCapturedProseDelivery` core so
   // the failure posture is deterministic and unit-tested. `outcome` is set on
@@ -2593,7 +2622,7 @@ export async function deliverCapturedProse(
   let outcome: CapturedProseSendOutcome
   const already = outboundDedup.check(chatId, threadId, text, now, registryKey)
   if (already == null) {
-    let out = normalizeParagraphBreaks(repairEscapedWhitespace(text))
+    let out = normalizeParagraphBreaks(repairEscapedWhitespace(framed ? applyReplyThrowFraming(text) : text))
     out = redactOutboundText(out, 'captured_prose')
     const chunks = splitMarkdownChunks(out, RICH_MESSAGE_MAX_CHARS)
     const sentIds: number[] = []
@@ -2640,11 +2669,31 @@ export async function deliverCapturedProse(
       // journal line from this site following a reply-tool line under the same
       // nonce (replyAlreadyDeliveredThisTurn:true) is direct, journal-only
       // proof of a bridge double-send.
-      journalExternalDelivery({ turnNonce: originTurnId, text, tgMessageId: sentIds[sentIds.length - 1], replyAlreadyDeliveredThisTurn: false })
+      journalExternalDelivery({
+        turnNonce: originTurnId,
+        text,
+        tgMessageId: sentIds[sentIds.length - 1],
+        replyAlreadyDeliveredThisTurn: false,
+        // #4141 durable terminal stamp — parity with the sweep's
+        // `DeliveredEntry.framedProvenance`, so "was this labelled?" is
+        // answerable from the journal alone, hours later.
+        ...(framed ? { framedProvenance: 'reply-throw' as const } : {}),
+      })
       process.stderr.write(
         `telegram gateway: captured-prose delivery — sent ${out.length} chars recovered from ` +
           `transcript scan (chat=${chatId} origin=${originTurnId})\n`,
       )
+      if (framed) {
+        process.stderr.write(
+          formatReplyThrowFraming({
+            turnNonce: originTurnId,
+            turnId: originTurnId,
+            chatId,
+            textSha256: sha256Hex(text),
+            source: 'captured-prose-bridge',
+          }),
+        )
+      }
       outcome = 'sent'
     } catch (err) {
       // #3228 Finding 1 — the send threw, so the answer did NOT reach the user.

--- a/telegram-plugin/gateway/outbox-sweep.ts
+++ b/telegram-plugin/gateway/outbox-sweep.ts
@@ -46,6 +46,7 @@ import {
 import {
   AUDIENCE_INTERNAL,
   formatInternalSuppression,
+  formatReplyThrowFraming,
   resolveRecordAudience,
   shouldSuppressForAudience,
 } from '../hooks/audience-classify.mjs'
@@ -147,6 +148,20 @@ export interface OutboxSweepDeps {
    * becoming a message. Defaults to `log`.
    */
   escalateInternalSuppression?: (line: string) => void
+  /**
+   * W1-d follow-up (#4141) kill switch for the reply-throw provenance banner.
+   * Defaults to `SWITCHROOM_TG_OUTBOX_PROVENANCE_FRAMING !== '0'` (ON). Same
+   * injected-seam reasoning as {@link audienceGateEnabled}: a module-scope env
+   * read would be captured at import and the revert-check could not run.
+   */
+  provenanceFramingEnabled?: () => boolean
+  /**
+   * W1-d follow-up (#4141) telemetry sink for a FRAMED delivery. Separate from
+   * {@link escalateInternalSuppression} because the two outcomes are different
+   * (withheld vs. delivered-with-provenance) and must be greppable apart.
+   * Defaults to `log`.
+   */
+  logProvenanceFraming?: (line: string) => void
 }
 
 export interface OutboxSweepSummary {
@@ -169,6 +184,12 @@ export interface OutboxSweepSummary {
    * suppressed a leak" is never confused with "we deferred a delivery".
    */
   audienceSuppressed?: number
+  /**
+   * W1-d follow-up (#4141): deliveries this sweep that carried the reply-throw
+   * provenance banner. These ARE counted in `delivered` — framing is a
+   * delivery, not a skip.
+   */
+  provenanceFramed?: number
 }
 
 /**
@@ -222,6 +243,9 @@ export async function sweepOutbox(deps: OutboxSweepDeps): Promise<OutboxSweepSum
   const audienceGateEnabled = deps.audienceGateEnabled?.() ??
     process.env.SWITCHROOM_TG_OUTBOX_AUDIENCE_GATE !== '0'
   const escalateInternalSuppression = deps.escalateInternalSuppression ?? log
+  const provenanceFramingEnabled = deps.provenanceFramingEnabled?.() ??
+    process.env.SWITCHROOM_TG_OUTBOX_PROVENANCE_FRAMING !== '0'
+  const logProvenanceFraming = deps.logProvenanceFraming ?? log
 
   for (const record of records) {
     summary.scanned++
@@ -301,6 +325,22 @@ export async function sweepOutbox(deps: OutboxSweepDeps): Promise<OutboxSweepSum
       // progress card for this turn (durable shown-ledger). The invariant forbids
       // a second, out-of-process delivery of an ephemeral-shown block.
       shownLedgerHit: isShownBlock(record.turnNonce, record.text, deps.stateDir),
+      // ── W1-d follow-up (#4141): PROVENANCE FRAMING ───────────────────────
+      //
+      // The residual case #4140 deliberately leaves open: the reply tool threw
+      // on a FOREGROUND turn, so the inbound obligation is still OPEN, the
+      // record classifies `'user'`, and the captured trailing prose delivers
+      // presented as if it were the answer.
+      //
+      // We do NOT suppress here, and that is the design, not a compromise.
+      // Someone is provably still waiting; there is no deterministic signal
+      // that separates "working notes" from "the answer re-written as plain
+      // prose after the tool errored" (see `audience-classify.mjs`). Dropping
+      // the text would trade a visible wrong-content failure for an invisible
+      // no-answer one — the exact severity-3 class this whole line of work
+      // exists to prevent. So we state the provenance instead, and the human
+      // (who can tell the difference, unlike any classifier here) decides.
+      provenanceFraming: provenanceFramingEnabled,
     })
 
     if (decision.action !== 'send' && decision.action !== 'send-delayed') {
@@ -376,9 +416,28 @@ export async function sweepOutbox(deps: OutboxSweepDeps): Promise<OutboxSweepSum
           // turn) is provable from the journal alone.
           deliverySource: 'sweep',
           replyAlreadyDeliveredThisTurn: record.replyAlreadyDeliveredThisTurn === true,
+          // #4141: the durable terminal stamp for a framed delivery. Written on
+          // the same line as the delivery it describes, so "what did the user
+          // actually see" is answerable from the journal alone after the logs
+          // have rotated.
+          ...(decision.framedProvenance != null
+            ? { framedProvenance: decision.framedProvenance }
+            : {}),
         },
         deps.stateDir,
       )
+      if (decision.framedProvenance != null) {
+        summary.provenanceFramed = (summary.provenanceFramed ?? 0) + 1
+        logProvenanceFraming(
+          formatReplyThrowFraming({
+            turnNonce: record.turnNonce,
+            turnId: turnIdFromNonce(record.turnNonce),
+            chatId: resolvedChat.chatId,
+            textSha256: record.textSha256,
+            source: record.source,
+          }),
+        )
+      }
       // Persist parity (mirrors outbound-send-path.ts + backstop-delivery.ts):
       // record the delivered chunk ids + texts to history so a net-delivered
       // answer is not silently absent from history.db. Best-effort — a missing

--- a/telegram-plugin/gateway/outbox-sweep.ts
+++ b/telegram-plugin/gateway/outbox-sweep.ts
@@ -972,6 +972,14 @@ export function journalExternalDelivery(
      * the flush send and its journal write), not just via the in-memory dedup.
      */
     deliverySource?: 'sweep' | 'reply-tool' | 'flush'
+    /**
+     * #4141: this delivery carried the reply-throw provenance banner. Durable
+     * terminal stamp mirroring the sweep's own `DeliveredEntry.framedProvenance`,
+     * so "was the recipient told where this text came from?" is answerable from
+     * the journal alone — on EITHER delivery path (sweep or captured-prose
+     * bridge), hours later.
+     */
+    framedProvenance?: 'reply-throw'
   },
   stateDir?: string,
   now: number = Date.now(),
@@ -981,6 +989,9 @@ export function journalExternalDelivery(
   appendDelivered(
     {
       turnNonce: nonce,
+      // Hashed on the RAW text, deliberately: the banner is presentation, and
+      // the journal key must stay stable across framed/unframed so
+      // exactly-once-among-backstops keeps working (#4141).
       textSha256: sha256Hex(args.text),
       tgMessageId: args.tgMessageId,
       ts: now,
@@ -988,6 +999,7 @@ export function journalExternalDelivery(
       ...(args.replyAlreadyDeliveredThisTurn == null
         ? {}
         : { replyAlreadyDeliveredThisTurn: args.replyAlreadyDeliveredThisTurn }),
+      ...(args.framedProvenance == null ? {} : { framedProvenance: args.framedProvenance }),
     },
     stateDir,
   )

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -2743,6 +2743,11 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
               registryKey: turn.registryKey ?? null,
               originTurnId: turn.turnId,
               text: proseDecision.text,
+              // #4141 — the Stop hook saw this turn's reply tool throw, so the
+              // prose is what the model wrote AFTER its delivery attempt failed,
+              // not what it chose to send. Pass the raw signal through so the
+              // send states that provenance. It never gates delivery.
+              replyToolThrewThisTurn: proseDecision.replyToolThrewThisTurn === true,
               // For the honest "(waited Ns)" clause if the exhaustion-boundary
               // apology fallback fires (#3228).
               turnDurationMs,

--- a/telegram-plugin/hooks/audience-classify.d.mts
+++ b/telegram-plugin/hooks/audience-classify.d.mts
@@ -11,6 +11,8 @@ export function decideCaptureAudience(signals: {
 export function resolveOpenObligation(args: {
   snapshotRaw?: string | null
   chatId?: string | null
+  /** #4146: `false` ⇒ persistence is off, so the file proves nothing. */
+  snapshotTrusted?: boolean
 }): true | false | 'unknown'
 
 export function resolveRecordAudience(value: unknown): Audience
@@ -19,6 +21,23 @@ export function shouldSuppressForAudience(
   record: { audience?: unknown },
   opts?: { gateEnabled?: boolean },
 ): boolean
+
+export const REPLY_THROW_PROVENANCE_NOTICE: string
+
+export function shouldFrameReplyThrow(
+  record: { replyToolThrewThisTurn?: unknown },
+  opts?: { frameEnabled?: boolean },
+): boolean
+
+export function applyReplyThrowFraming(text: string): string
+
+export function formatReplyThrowFraming(s: {
+  turnNonce: string
+  turnId?: string | null
+  chatId?: string | null
+  textSha256?: string
+  source?: string
+}): string
 
 export function formatInternalSuppression(s: {
   turnNonce: string

--- a/telegram-plugin/hooks/audience-classify.mjs
+++ b/telegram-plugin/hooks/audience-classify.mjs
@@ -96,6 +96,8 @@ export function decideCaptureAudience(signals) {
  *
  * The three-valued result is the point:
  *
+ *   - `snapshotTrusted === false` → `'unknown'`, WITHOUT reading the bytes. See
+ *                                  the stale-snapshot note below (#4146).
  *   - `null` snapshot            → `'unknown'`. An absent file is NOT proof that
  *                                  nobody is waiting: it is equally the shape of
  *                                  an agent running with `SWITCHROOM_OBLIGATION_
@@ -104,6 +106,34 @@ export function decideCaptureAudience(signals) {
  *                                  Reading it as "empty" would let us suppress on
  *                                  an agent that simply doesn't track waiting
  *                                  users — a manufactured silent no-op.
+ *
+ * ## The stale-snapshot hole (#4146) and why `snapshotTrusted` exists
+ *
+ * The bullet above used to be the WHOLE argument, and it was wrong: a leftover
+ * file is not an absent file. Turn the ledger off (or run STATIC) on an agent
+ * that previously ran with it on, and persistence stops while the old
+ * `obligations.json` lingers — so an empty (or merely out-of-date) snapshot
+ * reads as positive proof that nobody is waiting, while obligations are in fact
+ * going untracked. That is the one configuration where the asymmetric default
+ * inverts, and it is a direct path to swallowing a real answer.
+ *
+ * It is closed on BOTH sides, deterministically, with no freshness heuristic:
+ *
+ *   1. THE FILE IS REMOVED when it cannot be maintained. The gateway unlinks
+ *      the snapshot at boot whenever it is STATIC or the ledger is disabled
+ *      (`gateway.ts`, next to the hydrate branch) — the exact site that already
+ *      knows the condition. After that, "absent" genuinely does mean what the
+ *      bullet above claims.
+ *   2. THE READER DOES NOT TRUST IT ANYWAY when it knows persistence is off.
+ *      The hook passes `snapshotTrusted: SWITCHROOM_OBLIGATION_LEDGER !== '0'`,
+ *      which covers the window before that gateway boots, an older gateway
+ *      build that never cleaned up, and a gateway that is not running at all.
+ *
+ * Note the case that ISN'T staleness: with the ledger ON, the snapshot only
+ * ever mutates through the gateway, so a gateway that is merely stopped leaves
+ * a snapshot that is exactly correct rather than stale. That is why an mtime
+ * bound is the wrong instrument here — it would fail an idle-but-accurate
+ * snapshot (weakening #4140 for quiet agents) while still not proving liveness.
  *   - unparseable / wrong shape  → `'unknown'` (same reasoning; a torn or
  *                                  forward-incompatible snapshot proves nothing).
  *   - `chatId == null` (the chat
@@ -115,10 +145,14 @@ export function decideCaptureAudience(signals) {
  *                                  scoping question is moot.
  *   - otherwise                  → `true` iff some open obligation names this chat.
  *
- * @param {{ snapshotRaw?: string | null, chatId?: string | null }} args
+ * @param {{ snapshotRaw?: string | null, chatId?: string | null, snapshotTrusted?: boolean }} args
  * @returns {true | false | 'unknown'}
  */
 export function resolveOpenObligation(args) {
+  // #4146: an explicit "persistence is off" beats anything on disk. Only an
+  // exact `false` distrusts — absent/undefined keeps the pre-#4146 behaviour,
+  // so a caller that does not know cannot accidentally weaken the gate.
+  if (args?.snapshotTrusted === false) return 'unknown'
   const raw = args?.snapshotRaw
   if (typeof raw !== 'string' || raw.length === 0) return 'unknown'
   let parsed
@@ -182,6 +216,118 @@ export function resolveRecordAudience(value) {
 export function shouldSuppressForAudience(record, opts) {
   if (opts?.gateEnabled === false) return false
   return resolveRecordAudience(record?.audience) === AUDIENCE_INTERNAL
+}
+
+/**
+ * ── W1-d follow-up (#4141): the FOREGROUND reply-throw case ──────────────────
+ *
+ * `decideCaptureAudience` can only mark `internal` when the reply tool threw
+ * AND nobody is waiting. On a FOREGROUND Telegram turn the inbound obligation
+ * is still OPEN at capture time (it only closes on a substantive DELIVERED
+ * reply — `gateway/obligation-ledger.ts:153-157`), so the record classifies
+ * `user` and the trailing prose still delivers, presented as if it were the
+ * answer. That is the residual leak #4141 tracks.
+ *
+ * WHY THIS IS FRAMING AND NOT SUPPRESSION
+ * ---------------------------------------
+ * There is no deterministic discriminator here. When the reply tool throws, a
+ * model that has been told "every turn MUST end with a reply tool call" very
+ * plausibly re-writes its ANSWER as plain prose — and that prose is selected by
+ * exactly the same structural rule as working notes are. Position does not
+ * separate them (both follow the errored `tool_result`), and wording heuristics
+ * are provably incomplete (`narration-classify.mjs` says so in its own header).
+ *
+ * So suppressing here would trade a VISIBLE wrong-content failure for an
+ * INVISIBLE no-answer failure, against a human who is provably still waiting.
+ * That is strictly worse and it is the exact severity-3 class #3865/#4140 exist
+ * to avoid. Replacing the prose with a fixed notice has the same defect in
+ * milder form: it destroys content that may be the answer.
+ *
+ * What we CAN assert deterministically is the provenance: the reply tool threw
+ * this turn, so this text was never delivered as an answer by the agent — the
+ * safety net scraped it off the end of the turn. Stating that, verbatim, in
+ * front of the text restores exactly the context that #3865 says late delivery
+ * strips ("delivery hours later strips the context that would have made the
+ * difference obvious"). The reader can then tell notes from an answer, which is
+ * something no classifier in this pipeline can do.
+ *
+ * Properties, deliberately:
+ *   - it can NEVER produce silence (something is always delivered);
+ *   - it triggers on a hard structural fact (`is_error: true` on a reply-tool
+ *     `tool_result`), never on prose shape or model discipline;
+ *   - a missing / non-`true` signal changes nothing at all.
+ */
+
+/**
+ * The fixed provenance banner. Plain text in the established sweep-prefix
+ * idiom (`(delayed) `, `(from background task) `) — no markdown specials, so
+ * it cannot parse-reject a rich send, and no emoji.
+ */
+export const REPLY_THROW_PROVENANCE_NOTICE =
+  '(my reply tool errored this turn, so this was never sent as an answer — ' +
+  'the safety net captured the last thing I wrote, which may be working notes)'
+
+/**
+ * Should this record's delivered text carry the provenance banner?
+ *
+ * POSITIVE evidence only: an exact `true` on the record's persisted
+ * `replyToolThrewThisTurn`. Missing, `undefined`, `'true'`, `1` — anything that
+ * is not the boolean — changes nothing, so a legacy record (written before the
+ * field existed) delivers byte-for-byte as it does today.
+ *
+ * `frameEnabled === false` is the kill switch, and it is the seam the
+ * revert-check flips.
+ *
+ * @param {{ replyToolThrewThisTurn?: unknown }} record
+ * @param {{ frameEnabled?: boolean }} [opts]
+ * @returns {boolean}
+ */
+export function shouldFrameReplyThrow(record, opts) {
+  if (opts?.frameEnabled === false) return false
+  return record?.replyToolThrewThisTurn === true
+}
+
+/**
+ * Compose the banner onto the delivered body. Pure; the caller owns the
+ * `(delayed) ` / `(from background task) ` prefixes, which stay OUTSIDE (they
+ * describe the delivery, this describes the text).
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function applyReplyThrowFraming(text) {
+  const body = typeof text === 'string' ? text : ''
+  // Empty body: the sweep's send adapter early-returns on empty text, and a
+  // banner with nothing under it would be a message about nothing. Leave it.
+  if (body.trim().length === 0) return body
+  return `${REPLY_THROW_PROVENANCE_NOTICE}\n\n${body}`
+}
+
+/**
+ * Structured telemetry for a framed delivery — the observability half of the
+ * rule, mirroring {@link formatInternalSuppression}. Framing changes what a
+ * human sees, so it must never be inferable only from the absence of a log
+ * line. Worded to match NONE of `GATEWAY_SIGNATURES` in
+ * `src/fleet-health/detect.ts`: a framed delivery IS a delivery, and must not
+ * page anyone.
+ *
+ * @param {{
+ *   turnNonce: string,
+ *   turnId?: string | null,
+ *   chatId?: string | null,
+ *   textSha256?: string,
+ *   source?: string,
+ * }} s
+ * @returns {string}
+ */
+export function formatReplyThrowFraming(s) {
+  return (
+    `telegram gateway: outbox provenance framing nonce=${s.turnNonce} ` +
+    `turnId=${s.turnId ?? 'unknown'} chatId=${s.chatId ?? 'unresolved'} ` +
+    `sha=${(s.textSha256 ?? '').slice(0, 12)} source=${s.source ?? 'unknown'} ` +
+    `audience=user replyToolThrew=true — captured prose delivered with its ` +
+    `provenance stated, not suppressed\n`
+  )
 }
 
 /**

--- a/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
+++ b/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
@@ -119,6 +119,16 @@ function buildNextState(base, decision, retryCount) {
   } else {
     delete next.pendingText
   }
+  // #4141: carry THIS turn's reply-throw signal through to the captured-prose
+  // bridge, which is the delivering machine on the ELECTED path and has no
+  // transcript of its own. Same stale-carryover discipline as `pendingText` /
+  // `turnId`: explicitly DELETED when this turn's scan saw no throw, so a
+  // spread of a prior turn's file can never mislabel a clean turn.
+  if (decision.replyToolThrewThisTurn === true) {
+    next.replyToolThrewThisTurn = true
+  } else {
+    delete next.replyToolThrewThisTurn
+  }
   return next
 }
 
@@ -188,7 +198,18 @@ function classifyCaptureAudience(stateDir, capture) {
   // the one configuration in which the asymmetric default would invert. (The
   // gateway also unlinks the snapshot at boot in this mode; this is the
   // reader-side half, covering the window before it does.)
-  const snapshotTrusted = process.env.SWITCHROOM_OBLIGATION_LEDGER !== '0'
+  // STATIC is the second persistence-off mode (`gateway.ts:1343` gates the same
+  // `onChange` wiring on it at `:2810`), so it must distrust the file for the
+  // same reason. Writer-side cleanup already covers it at boot; this leg covers
+  // the window the writer cannot — an unlink that failed (EACCES) or a gateway
+  // that has not restarted since the mode changed. Honest caveat:
+  // `TELEGRAM_ACCESS_MODE` is supplied by the host, not by this repo, so if it
+  // is not exported into the hook's environment this leg degrades to a no-op and
+  // the writer-side unlink remains the cover. It can only ever move the verdict
+  // toward DELIVER, so a degraded read is never worse than today.
+  const snapshotTrusted =
+    process.env.SWITCHROOM_OBLIGATION_LEDGER !== '0' &&
+    process.env.TELEGRAM_ACCESS_MODE !== 'static'
   return decideCaptureAudience({
     replyToolThrewThisTurn: capture.replyToolThrewThisTurn === true,
     openInboundObligation: resolveOpenObligation({

--- a/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
+++ b/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
@@ -182,10 +182,18 @@ function classifyCaptureAudience(stateDir, capture) {
   } catch {
     /* unreadable ⇒ null ⇒ 'unknown' ⇒ 'user' (fail-safe toward delivering) */
   }
+  // #4146: with the ledger disabled, obligations are going UNTRACKED and any
+  // file on disk is a leftover, not a fact. Distrust it outright rather than
+  // read a stale empty set as positive proof that nobody is waiting — that is
+  // the one configuration in which the asymmetric default would invert. (The
+  // gateway also unlinks the snapshot at boot in this mode; this is the
+  // reader-side half, covering the window before it does.)
+  const snapshotTrusted = process.env.SWITCHROOM_OBLIGATION_LEDGER !== '0'
   return decideCaptureAudience({
     replyToolThrewThisTurn: capture.replyToolThrewThisTurn === true,
     openInboundObligation: resolveOpenObligation({
       snapshotRaw,
+      snapshotTrusted,
       // Same chat the sweep will route to: the envelope chat when present,
       // else this session's origin chat (`resolveOutboxChat`'s F2 fallback).
       chatId: capture.chatId ?? capture.originChatId ?? null,
@@ -229,6 +237,13 @@ function writeOutboxRecord(stateDir, capture, audience) {
       // sweep's gate never has to infer. `'user'` is byte-for-byte the
       // pre-change behaviour.
       audience: audience === AUDIENCE_INTERNAL ? AUDIENCE_INTERNAL : 'user',
+      // W1-d follow-up (#4141): the RAW structural signal, persisted alongside
+      // the verdict it fed. `audience` collapses it with the obligation state
+      // and loses it; the sweep needs it on its own to decide provenance
+      // framing for the `'user'` records the audience gate deliberately does
+      // not catch (the foreground case). Stamped here because this is the last
+      // point in the pipeline that can still see the transcript.
+      replyToolThrewThisTurn: capture.replyToolThrewThisTurn === true,
     }
     const tmpPath = join(outboxDir, `.${capture.turnNonce}.${process.pid}.tmp`)
     writeFileSync(tmpPath, JSON.stringify(record), 'utf8')

--- a/telegram-plugin/hooks/silent-end-scan.mjs
+++ b/telegram-plugin/hooks/silent-end-scan.mjs
@@ -248,9 +248,18 @@ function buildTurnId(chatId, threadId, messageId) {
  *   reply tool (Option A transcript-prose bridge). Only populated when it
  *   clears the substance floor, so the gateway never re-delivers a short
  *   trailing pleasantry. Omitted entirely otherwise.
+ * @param {boolean} [replyToolThrewThisTurn] W1-d follow-up (#4141): one of this
+ *   turn's reply-tool calls came back `is_error: true`. Carried on the BLOCK
+ *   result so the single-writer election can persist it onto the silent-end
+ *   state file — the captured-prose bridge (the machine that actually delivers
+ *   on the ELECTED path, where no outbox record is ever written) has no other
+ *   way to learn it. A raw SIGNAL, never a verdict: downstream it only ever
+ *   adds a provenance banner. Omitted rather than `false` when absent, so a
+ *   spread of a prior state file cannot be read as positive evidence.
  */
-function buildBlockResult(envelope, reason, pendingText, hasTrailingProse) {
+function buildBlockResult(envelope, reason, pendingText, hasTrailingProse, replyToolThrewThisTurn) {
   const block = { decided: 'block', reason }
+  if (replyToolThrewThisTurn === true) block.replyToolThrewThisTurn = true
   // Single-writer election input (#duplicate-message fix): does ANY
   // non-empty, non-silent trailing text block exist after the last
   // delivery event? The zero-reply election allows only when this is
@@ -381,6 +390,15 @@ export function scanTurnForFinalReply(jsonl) {
   //    whether emitted as plain text or as a reply-tool payload) or
   //    plain undelivered text.
   const blocks = []
+  // W1-d follow-up (#4141): the same reply-throw signal `scanForOutboxCapture`
+  // already derives, computed here too because the ELECTED path never reaches
+  // that scanner's capture branch (a thrown-but-qualifying reply sets
+  // `replyAlreadyDeliveredThisTurn`, so the hook defers to the election and
+  // writes NO outbox record). Collected as two id sets whose intersection is
+  // the signal. Read-only: nothing below branches on it, so no verdict of this
+  // scanner changes.
+  const replyToolUseIds = new Set()
+  const erroredToolUseIds = new Set()
   for (let i = startIdx + 1; i < lines.length; i++) {
     const line = lines[i]
     if (!line || line[0] !== '{') continue
@@ -390,6 +408,20 @@ export function scanTurnForFinalReply(jsonl) {
     // be in a separate transcript file, but `isSidechain:true` is the
     // documented marker if they leak).
     if (obj?.isSidechain === true) continue
+    if (obj?.type === 'user') {
+      // Tool RESULT lines: `user`-type, content array carrying
+      // `{type:'tool_result', tool_use_id, is_error}`. Same shape read by
+      // `scanForOutboxCapture` (#3865).
+      const rc = obj?.message?.content
+      if (!Array.isArray(rc)) continue
+      for (const r of rc) {
+        if (r?.type !== 'tool_result') continue
+        if (r?.is_error !== true) continue
+        if (typeof r.tool_use_id !== 'string') continue
+        erroredToolUseIds.add(r.tool_use_id)
+      }
+      continue
+    }
     if (obj?.type !== 'assistant') continue
     const content = obj?.message?.content
     if (!Array.isArray(content)) continue
@@ -449,6 +481,9 @@ export function scanTurnForFinalReply(jsonl) {
         }
         continue
       }
+      // #4141: EVERY reply-tool call's id, qualifying or not — an interim ack
+      // that threw is still a reply-tool throw.
+      if (typeof c.id === 'string') replyToolUseIds.add(c.id)
       const input = c.input ?? {}
       const text = String(input.text ?? '')
       // Silent-marker carve-out: the operator explicitly signaled
@@ -555,6 +590,10 @@ export function scanTurnForFinalReply(jsonl) {
   // delivers the joined prose instead of dropping. A pure narration run still
   // yields `undefined` (the #3228 Finding 2 guard, now structural).
   const zeroReplyPendingText = backstopText
+  // #4141 — one of this turn's reply-tool calls errored. Derived here, consumed
+  // only by `buildBlockResult` below (and thence the elected state file); it
+  // gates nothing in this scanner.
+  const replyToolThrewThisTurn = [...replyToolUseIds].some((id) => erroredToolUseIds.has(id))
 
   if (lastAllowBlockIdx === -1) {
     // No qualifying delivery/silence event anywhere in the turn.
@@ -567,7 +606,9 @@ export function scanTurnForFinalReply(jsonl) {
     if (envelope.source === 'cron') {
       return { decided: 'allow', reason: 'cron-source' }
     }
-    return buildBlockResult(envelope, 'no-final-reply', zeroReplyPendingText, hasTrailingProse)
+    return buildBlockResult(
+      envelope, 'no-final-reply', zeroReplyPendingText, hasTrailingProse, replyToolThrewThisTurn,
+    )
   }
 
   if (sawUndeliveredTextAfterAllow) {
@@ -576,7 +617,9 @@ export function scanTurnForFinalReply(jsonl) {
     // sent through a delivery tool. This is the "at least once" bug:
     // an early ack (or any qualifying reply) must not amnesty
     // everything written afterward.
-    return buildBlockResult(envelope, 'trailing-text-after-reply', pendingText, hasTrailingProse)
+    return buildBlockResult(
+      envelope, 'trailing-text-after-reply', pendingText, hasTrailingProse, replyToolThrewThisTurn,
+    )
   }
 
   return { decided: 'allow', reason: lastAllowReason }

--- a/telegram-plugin/outbox.ts
+++ b/telegram-plugin/outbox.ts
@@ -70,6 +70,12 @@ import { homedir } from 'node:os'
 // bundled gateway code (which persists and enforces it) must agree exactly. A
 // hand-synced second copy here would be a leak waiting on a drift.
 import type { Audience } from './hooks/audience-classify.mjs'
+// #4141: the provenance-framing rule lives in the same shared pure module, for
+// the same reason — the decision must be one implementation, not two.
+import {
+  applyReplyThrowFraming,
+  shouldFrameReplyThrow,
+} from './hooks/audience-classify.mjs'
 
 export type { Audience }
 
@@ -137,6 +143,25 @@ export interface OutboxRecord {
    * affirmative tag; absence is never evidence.
    */
   audience?: Audience
+  /**
+   * W1-d follow-up (#4141): did one of this turn's reply-tool calls come back
+   * `is_error: true`? Stamped at capture by `hooks/silent-end-scan.mjs` (which
+   * reads the `tool_result` blocks) and persisted here so the SWEEP — hours
+   * later, in another process, with the transcript long gone — can still state
+   * this text's provenance.
+   *
+   * This is the raw structural SIGNAL, not a verdict. `audience` already
+   * consumed it once (combined with the obligation state) to decide
+   * suppression; the sweep consumes it again, on its own, to decide FRAMING for
+   * the records suppression deliberately does NOT catch — the foreground case,
+   * where the reply threw but someone is provably still waiting, so the record
+   * is `'user'` and MUST deliver.
+   *
+   * OPTIONAL: absent on every pre-#4141 record and on gateway-authored records
+   * (`gateway/flood-reply-queue.ts`), both of which deliver unframed. Only an
+   * exact boolean `true` changes anything — see `shouldFrameReplyThrow`.
+   */
+  replyToolThrewThisTurn?: boolean
 }
 
 /** One line of the delivered-keys journal (`outbox/delivered.jsonl`). */
@@ -168,6 +193,17 @@ export interface DeliveredEntry {
    * these lines because nothing was sent.
    */
   suppressedAudience?: Audience
+  /**
+   * W1-d follow-up (#4141): this delivery carried the reply-throw provenance
+   * banner (`REPLY_THROW_PROVENANCE_NOTICE`) in front of the captured prose.
+   *
+   * Durable and terminal, for the same reason `suppressedAudience` is: framing
+   * changes what a human sees, so the outcome is recorded as an explicit named
+   * state on the journal line rather than being inferable only from a log line
+   * that may have rotated away. `tgMessageId` IS present on these lines — a
+   * framed delivery is a delivery.
+   */
+  framedProvenance?: 'reply-throw'
 }
 
 export function sha256Hex(s: string): string {
@@ -476,6 +512,13 @@ export interface OutboxSweepDecision {
   action: OutboxSweepAction
   /** The text to deliver (with any "(delayed)"/"(from background task)" prefix). */
   text?: string
+  /**
+   * W1-d follow-up (#4141): `text` carries the reply-throw provenance banner.
+   * Surfaced on the decision (rather than left implicit in a string compare) so
+   * the caller can journal the outcome and emit telemetry without re-deriving
+   * the rule.
+   */
+  framedProvenance?: 'reply-throw'
 }
 
 /**
@@ -493,7 +536,10 @@ export interface OutboxSweepDecision {
  *   send-delayed    — older than max-age; deliver with a "(delayed)" prefix, never drop.
  */
 export function decideOutboxSweep(input: {
-  record: Pick<OutboxRecord, 'turnNonce' | 'text' | 'createdAt'>
+  record: Pick<
+    OutboxRecord,
+    'turnNonce' | 'text' | 'createdAt' | 'replyToolThrewThisTurn'
+  >
   now: number
   deliveredNonces: Set<string>
   textAlreadyDelivered: boolean
@@ -513,6 +559,13 @@ export function decideOutboxSweep(input: {
    * `normalizeOutboundBody` (it sends via `bot.api.sendMessage` directly).
    */
   shownLedgerHit?: boolean
+  /**
+   * W1-d follow-up (#4141) kill switch for the reply-throw provenance banner.
+   * `false` restores the pre-change body byte-for-byte; the default is ON.
+   * Passed in rather than read from env here so this core stays pure and the
+   * revert-check can flip it in-process.
+   */
+  provenanceFraming?: boolean
 }): OutboxSweepDecision {
   const {
     record,
@@ -524,6 +577,7 @@ export function decideOutboxSweep(input: {
     quietMs = OUTBOX_QUIET_MS,
     maxAgeMs = OUTBOX_MAX_AGE_MS,
     shownLedgerHit = false,
+    provenanceFraming = true,
   } = input
   if (deliveredNonces.has(record.turnNonce)) return { action: 'skip-journaled' }
   if (shownLedgerHit) return { action: 'skip-ephemeral-shown' }
@@ -533,7 +587,17 @@ export function decideOutboxSweep(input: {
   if (!routable) return { action: 'skip-unroutable' }
   const delayed = age > maxAgeMs
   const prefix = (delayed ? '(delayed) ' : '') + routePrefix
-  return { action: delayed ? 'send-delayed' : 'send', text: prefix + record.text }
+  // #4141: the banner sits BETWEEN the delivery prefixes and the body — the
+  // prefixes describe the DELIVERY ("(delayed)", "(from background task)"),
+  // the banner describes the TEXT. It is additive only: it can never turn a
+  // send into a skip, so this branch cannot manufacture silence.
+  const framed = shouldFrameReplyThrow(record, { frameEnabled: provenanceFraming })
+  const body = framed ? applyReplyThrowFraming(record.text) : record.text
+  return {
+    action: delayed ? 'send-delayed' : 'send',
+    text: prefix + body,
+    ...(framed && body !== record.text ? { framedProvenance: 'reply-throw' as const } : {}),
+  }
 }
 
 export interface ResolvedChat {

--- a/telegram-plugin/silent-end.ts
+++ b/telegram-plugin/silent-end.ts
@@ -66,6 +66,22 @@ export interface SilentEndState {
    * absent for the zero-prose (genuinely empty) silent-end.
    */
   pendingText?: string
+  /**
+   * W1-d follow-up (#4141) — one of THIS turn's reply-tool calls came back
+   * `is_error: true`, so `pendingText` is prose the model wrote *after* its
+   * delivery attempt failed, not text it chose to send as the answer.
+   *
+   * Stamped by the Stop hook's single-writer election
+   * (`silent-end-interrupt-stop.mjs` → `buildNextState`), the only component
+   * that can see the transcript; the gateway's own `writeSilentEndState` never
+   * sets it. Consumed by `deliverCapturedProse`, which prefixes a one-line
+   * provenance banner so the recipient is told the text was scraped off a
+   * failed turn rather than sent as an answer.
+   *
+   * Optional and only ever `true`: absent means "no positive evidence of a
+   * throw", which delivers exactly as before. It never suppresses.
+   */
+  replyToolThrewThisTurn?: boolean
 }
 
 export interface SilentEndDeps {
@@ -320,8 +336,16 @@ export const CAPTURED_PROSE_MIN_CHARS = 200
 export interface CapturedProseDecision {
   /** True → the gateway should deliver `text` directly on this silent-end. */
   deliver: boolean
-  /** The prose to deliver; present iff `deliver === true`. */
+  /** The prose to deliver; present iff `deliver === true`. RAW — never framed
+   *  here, so the caller's dedup and journal keys stay computed on the same
+   *  bytes the sweep path uses (#4141). */
   text?: string
+  /**
+   * #4141 — the persisted record says this turn's reply tool threw. Surfaced
+   * (not acted on) so `deliverCapturedProse` can state the prose's provenance.
+   * `true` only on positive evidence; never affects `deliver`.
+   */
+  replyToolThrewThisTurn?: boolean
   /** Machine-readable reason (for logs / tests). */
   reason:
     | 'captured-prose'
@@ -394,7 +418,15 @@ export function decideCapturedProseDelivery(
   if (deps?.backstopDeliveredNonceHit?.(state.turnId) === true) {
     return { deliver: false, reason: 'already-delivered' }
   }
-  return { deliver: true, text, reason: 'captured-prose' }
+  return {
+    deliver: true,
+    text,
+    reason: 'captured-prose',
+    // #4141: pass the hook's raw signal through untouched. Deliberately placed
+    // AFTER every `deliver:false` gate above — the banner is a labelling
+    // concern, and must never become an input to whether we deliver at all.
+    ...(state.replyToolThrewThisTurn === true ? { replyToolThrewThisTurn: true } : {}),
+  }
 }
 
 /**

--- a/telegram-plugin/tests/obligation-store.test.ts
+++ b/telegram-plugin/tests/obligation-store.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   loadObligations,
   persistObligations,
+  removeUnmaintainedSnapshot,
   type ObligationStoreFsSeam,
 } from "../gateway/obligation-store.js";
 import type { Obligation } from "../gateway/obligation-ledger.js";
@@ -32,6 +33,10 @@ function memFs(seed: Record<string, string> = {}) {
     },
     fsyncDirSync: (p) => {
       calls.push(`fsyncDir:${p}`);
+    },
+    unlinkSync: (p) => {
+      calls.push(`unlink:${p}`);
+      files.delete(p);
     },
   };
   return { fs, files, calls };
@@ -239,5 +244,51 @@ describe("obligation-store — power-cut durability (fsync ordering)", () => {
     expect(logs.join("")).not.toContain("persist FAILED");
     expect(files.has(PATH)).toBe(true);
     expect(loadObligations(PATH, fs)).toHaveLength(1);
+  });
+
+  // ── #4146: a snapshot nobody maintains must not read as "nobody waiting" ──
+
+  it("removeUnmaintainedSnapshot deletes a leftover snapshot and says why", () => {
+    // The exact hazard: the agent once ran with the ledger on, so an EMPTY
+    // open set is on disk. Persistence is now off, so that emptiness is a
+    // leftover — and the W1-d audience classifier would read it as positive
+    // proof that nobody is waiting, and suppress a message owed to a human.
+    const { fs, files } = memFs({ [PATH]: JSON.stringify({ v: 1, obligations: [] }) });
+    const logs: string[] = [];
+    expect(removeUnmaintainedSnapshot(PATH, fs, "static=true enabled=false", (l) => logs.push(l))).toBe(true);
+    expect(files.has(PATH)).toBe(false);
+    // ...and the classifier's precondition now genuinely holds: absent file.
+    expect(fs.existsSync(PATH)).toBe(false);
+    expect(logs.join("")).toContain("static=true enabled=false");
+    expect(logs.join("")).toContain("#4146");
+  });
+
+  it("removeUnmaintainedSnapshot is a no-op when there is nothing to remove", () => {
+    const { fs } = memFs();
+    const logs: string[] = [];
+    expect(removeUnmaintainedSnapshot(PATH, fs, "reason", (l) => logs.push(l))).toBe(false);
+    expect(logs).toEqual([]);
+  });
+
+  it("removeUnmaintainedSnapshot never throws, and reports failure rather than claiming success", () => {
+    // A failure here must degrade to the reader-side ledger-off guard, not
+    // crash gateway boot and not be mistaken for a completed cleanup.
+    const { fs } = memFs({ [PATH]: "{}" });
+    const logs: string[] = [];
+    const failing: ObligationStoreFsSeam = {
+      ...fs,
+      unlinkSync: () => {
+        throw new Error("EACCES: permission denied, unlink");
+      },
+    };
+    expect(removeUnmaintainedSnapshot(PATH, failing, "reason", (l) => logs.push(l))).toBe(false);
+    expect(logs.join("")).toContain("could not remove unmaintained snapshot");
+  });
+
+  it("a seam with no unlinkSync degrades to no cleanup rather than throwing", () => {
+    const { fs, files } = memFs({ [PATH]: "{}" });
+    const { unlinkSync: _dropped, ...legacySeam } = fs;
+    expect(removeUnmaintainedSnapshot(PATH, legacySeam, "reason", () => {})).toBe(false);
+    expect(files.has(PATH)).toBe(true);
   });
 });

--- a/telegram-plugin/tests/outbox-provenance-4141.test.ts
+++ b/telegram-plugin/tests/outbox-provenance-4141.test.ts
@@ -1,0 +1,779 @@
+/**
+ * outbox-provenance-4141.test.ts — the FOREGROUND reply-throw case (issue
+ * #4141, follow-up to #3865 / PR #4140).
+ *
+ * THE GAP THIS GUARDS
+ * -------------------
+ * #4140's audience gate marks a record `'internal'` only on positive evidence:
+ * the reply tool threw AND no inbound obligation is open. An obligation only
+ * closes on a substantive DELIVERED reply (`gateway/obligation-ledger.ts:153`),
+ * so on a FOREGROUND Telegram turn where the reply tool threw, the obligation
+ * is still OPEN, the record classifies `'user'`, and the agent's trailing
+ * working notes are delivered to the waiting human presented as if they were
+ * the answer.
+ *
+ * THE DESIGN UNDER TEST — FRAMING, NOT SUPPRESSION
+ * -----------------------------------------------
+ * Suppressing here would convert a visible wrong-content failure into an
+ * invisible no-answer one, against a human who is provably still waiting. So
+ * the rule is: state the provenance in front of the text and deliver it. The
+ * two invariants this file exists to hold are therefore:
+ *
+ *   A. FRAMING NEVER SILENCES. Every framed case sends exactly as many
+ *      chat-visible calls as the unframed case did, and the body still
+ *      contains the captured prose verbatim.
+ *   B. FRAMING IS OBSERVABLE. Every framed delivery carries a durable terminal
+ *      stamp on the journal line plus one structured telemetry line.
+ *
+ * Every assertion drives REAL machinery: the REAL Stop hook spawned as a
+ * subprocess against a REAL transcript, the REAL `sweepOutbox` with the REAL
+ * `createOutboxSend` adapter against a RECORDING fake Bot API, the REAL flood
+ * producer, and the REAL fleet-health detectors.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readdirSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { sweepOutbox, createOutboxSend, turnIdFromNonce } from '../gateway/outbox-sweep.js'
+import { decideOutboxSweep, sha256Hex } from '../outbox.js'
+import { queueFloodBlockedReply } from '../gateway/flood-reply-queue.js'
+import {
+  REPLY_THROW_PROVENANCE_NOTICE,
+  applyReplyThrowFraming,
+  decideCaptureAudience,
+  formatReplyThrowFraming,
+  resolveOpenObligation,
+  shouldFrameReplyThrow,
+} from '../hooks/audience-classify.mjs'
+import { scanForOutboxCapture } from '../hooks/silent-end-scan.mjs'
+import { buildTurnRecord } from '../gateway/turn-record-status.js'
+import {
+  detectTurnFindings,
+  detectGatewayFindings,
+  extractTurnId,
+  GATEWAY_SIGNATURES,
+} from '../../src/fleet-health/detect.js'
+
+const HOOK = resolve(__dirname, '..', 'hooks', 'silent-end-interrupt-stop.mjs')
+
+// Synthetic ids only (check-no-pii-secrets forbids real chat/user ids).
+const DM_CHAT = '5550001'
+const INBOUND_MSG_ID = 7311
+const NONCE = `${DM_CHAT}:_#${INBOUND_MSG_ID}`
+
+/** Internal working notes — the text that must never masquerade as an answer. */
+const WORKING_NOTES = [
+  'Dispatched the worker onto the rebase and it came back clean, so the next',
+  'step is to re-run the scoped suite before touching the sweep at all. If the',
+  'suite is still red after that I will bisect from the merge base rather than',
+  'guessing, and I should double-check whether the earlier claim about the',
+  'adapter ordering actually holds, because I never verified it against HEAD.',
+].join(' ')
+
+/**
+ * A genuine answer written as plain prose AFTER the reply tool errored — the
+ * shape that makes suppression unsafe here. Structurally indistinguishable
+ * from WORKING_NOTES to every classifier in this pipeline.
+ */
+const REAL_ANSWER = [
+  'The rebase landed on the merge base and the suite is green. Two files moved:',
+  'the sweep now checks the record before it routes anything, and the capture',
+  'hook stamps the field it checks. Nothing else changed, and the flood queue',
+  'behaves exactly as it did before because it stamps the same value it implied.',
+].join(' ')
+
+function makeStateDir(): string {
+  // NEVER ~/.switchroom — a test that writes there corrupts production state.
+  return mkdtempSync(join(tmpdir(), 'w1d-provenance-'))
+}
+
+function writeTranscript(dir: string, lines: object[]): string {
+  const p = join(dir, 'transcript.jsonl')
+  writeFileSync(p, lines.map((l) => JSON.stringify(l)).join('\n'), 'utf8')
+  return p
+}
+
+function runHook(
+  transcriptPath: string,
+  stateDir: string,
+  extraEnv: Record<string, string> = {},
+) {
+  return spawnSync('node', [HOOK], {
+    input: JSON.stringify({ session_id: 's', transcript_path: transcriptPath }),
+    encoding: 'utf8',
+    timeout: 10_000,
+    env: { ...process.env, TELEGRAM_STATE_DIR: stateDir, ...extraEnv },
+  })
+}
+
+interface RecordShape {
+  turnNonce: string
+  text: string
+  audience?: string
+  replyToolThrewThisTurn?: unknown
+  chatId: string | null
+  source: string
+  textSha256: string
+  createdAt: number
+}
+
+function outboxRecords(dir: string): RecordShape[] {
+  const outbox = join(dir, 'outbox')
+  if (!existsSync(outbox)) return []
+  return readdirSync(outbox)
+    .filter((f) => f.endsWith('.json') && f !== 'delivered.jsonl')
+    .map((f) => JSON.parse(readFileSync(join(outbox, f), 'utf8')) as RecordShape)
+}
+
+function journalLines(dir: string): Array<Record<string, unknown>> {
+  const p = join(dir, 'outbox', 'delivered.jsonl')
+  if (!existsSync(p)) return []
+  return readFileSync(p, 'utf8')
+    .split('\n')
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l) as Record<string, unknown>)
+}
+
+/** The OPEN inbound obligation that makes this the foreground case. */
+function writeOpenObligation(dir: string): void {
+  writeFileSync(
+    join(dir, 'obligations.json'),
+    JSON.stringify({
+      v: 1,
+      obligations: [
+        {
+          originTurnId: NONCE,
+          chatId: DM_CHAT,
+          messageId: INBOUND_MSG_ID,
+          text: 'where did the rebase land?',
+          openedAt: 1_000,
+          representCount: 0,
+        },
+      ],
+    }),
+    'utf8',
+  )
+}
+
+/**
+ * A RECORDING fake Bot API. Every method that can put bytes into a chat is
+ * counted, so a send-count assertion covers ALL of them, not the one method
+ * the test remembered to stub.
+ */
+function recordingBot() {
+  const calls: Array<{ method: string; chatId: string; text: string }> = []
+  let nextId = 900
+  return {
+    calls,
+    chatCalls: () => calls,
+    api: {
+      sendRichMessage: async (chatId: string, body: { markdown: string }) => {
+        calls.push({ method: 'sendRichMessage', chatId, text: body.markdown })
+        return { message_id: nextId++ }
+      },
+      sendMessage: async (chatId: string, text: string) => {
+        calls.push({ method: 'sendMessage', chatId, text })
+        return { message_id: nextId++ }
+      },
+      editMessageText: async (chatId: string, _mid: number, text: string) => {
+        calls.push({ method: 'editMessageText', chatId, text })
+        return { message_id: nextId++ }
+      },
+    },
+  }
+}
+
+const passthroughRetry = <U>(fn: () => Promise<U>): Promise<U> => fn()
+
+/** Drive ONE real sweep tick against the recording bot. */
+async function realSweep(
+  stateDir: string,
+  bot: ReturnType<typeof recordingBot>,
+  opts: { framingEnabled?: boolean } = {},
+) {
+  const logLines: string[] = []
+  const framingLines: string[] = []
+  const escalations: string[] = []
+  const summary = await sweepOutbox({
+    send: createOutboxSend({ getBot: () => bot, retry: passthroughRetry }),
+    textAlreadyDelivered: () => false,
+    stateDir,
+    now: () => Date.now() + 60_000,
+    quietMs: 0,
+    log: (l) => logLines.push(l),
+    ...(opts.framingEnabled === undefined
+      ? {}
+      : { provenanceFramingEnabled: () => opts.framingEnabled! }),
+    logProvenanceFraming: (l) => framingLines.push(l),
+    escalateInternalSuppression: (l) => escalations.push(l),
+  })
+  return { summary, logLines, framingLines, escalations }
+}
+
+/**
+ * THE FOREGROUND SHAPE (#4141), verbatim in structure:
+ *   1. a Telegram inbound — the anchor for THIS turn, and the reason an
+ *      obligation is open;
+ *   2. a reply-tool call, which THROWS;
+ *   3. trailing prose, which capture then selects as "the answer".
+ *
+ * Note there is NO background wake here — that is the whole difference from
+ * #4140's leak transcript, and it is what keeps the obligation open.
+ */
+function foregroundThrowTranscript(dir: string, prose: string): string {
+  return writeTranscript(dir, [
+    {
+      type: 'queue-operation',
+      operation: 'enqueue',
+      content: `<channel source="telegram" chat_id="${DM_CHAT}" message_id="${INBOUND_MSG_ID}">where did the rebase land?</channel>`,
+      timestamp: 1000,
+    },
+    {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_reply_1',
+            name: 'mcp__switchroom-telegram__reply',
+            input: { text: 'On it.', disable_notification: true },
+          },
+        ],
+      },
+    },
+    {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_reply_1',
+            is_error: true,
+            content: 'Error: FLOOD_WAIT_ACTIVE — send rejected',
+          },
+        ],
+      },
+    },
+    { type: 'assistant', message: { content: [{ type: 'text', text: prose }] } },
+  ])
+}
+
+describe('#4141 — the framing rule is pure, positive-evidence-only, and additive', () => {
+  it('frames ONLY on an exact boolean true', () => {
+    expect(shouldFrameReplyThrow({ replyToolThrewThisTurn: true })).toBe(true)
+    // Anything else is no evidence → no change at all. A legacy record (the
+    // field did not exist before this PR) is the `undefined` row.
+    for (const v of [undefined, null, false, 'true', 'internal', 1, {}, []]) {
+      expect(shouldFrameReplyThrow({ replyToolThrewThisTurn: v })).toBe(false)
+    }
+    expect(shouldFrameReplyThrow({})).toBe(false)
+    // Kill switch — the seam the revert-check flips.
+    expect(
+      shouldFrameReplyThrow({ replyToolThrewThisTurn: true }, { frameEnabled: false }),
+    ).toBe(false)
+  })
+
+  it('framing is ADDITIVE: the captured prose survives verbatim', () => {
+    const framed = applyReplyThrowFraming(WORKING_NOTES)
+    expect(framed).toContain(WORKING_NOTES)
+    expect(framed.startsWith(REPLY_THROW_PROVENANCE_NOTICE)).toBe(true)
+    expect(framed.length).toBeGreaterThan(WORKING_NOTES.length)
+  })
+
+  it('the banner carries no markdown specials that could parse-reject a rich send', () => {
+    expect(REPLY_THROW_PROVENANCE_NOTICE).not.toMatch(/[*_`[\]]/)
+  })
+
+  it('an empty body is left alone — a banner about nothing is not a message', () => {
+    expect(applyReplyThrowFraming('')).toBe('')
+    expect(applyReplyThrowFraming('   \n ')).toBe('   \n ')
+  })
+
+  it('the pure sweep decision can never turn a send into a skip because of framing', () => {
+    const base = {
+      now: 100_000,
+      deliveredNonces: new Set<string>(),
+      textAlreadyDelivered: false,
+      routable: true,
+      quietMs: 0,
+    }
+    const rec = {
+      turnNonce: NONCE,
+      text: WORKING_NOTES,
+      createdAt: 1000,
+      replyToolThrewThisTurn: true,
+    }
+    const on = decideOutboxSweep({ ...base, record: rec })
+    const off = decideOutboxSweep({ ...base, record: rec, provenanceFraming: false })
+    expect(on.action).toBe(off.action)
+    expect(on.action).toBe('send')
+    expect(on.framedProvenance).toBe('reply-throw')
+    expect(off.framedProvenance).toBeUndefined()
+    expect(on.text).toContain(off.text!)
+  })
+
+  it('the banner sits between the delivery prefixes and the body, not in front of them', () => {
+    const d = decideOutboxSweep({
+      record: {
+        turnNonce: NONCE,
+        text: WORKING_NOTES,
+        createdAt: 0,
+        replyToolThrewThisTurn: true,
+      },
+      now: 60 * 60_000,
+      deliveredNonces: new Set<string>(),
+      textAlreadyDelivered: false,
+      routable: true,
+      routePrefix: '(from background task) ',
+      quietMs: 0,
+    })
+    expect(d.action).toBe('send-delayed')
+    expect(d.text!.startsWith('(delayed) (from background task) ')).toBe(true)
+    expect(d.text).toContain(REPLY_THROW_PROVENANCE_NOTICE)
+    expect(d.text).toContain(WORKING_NOTES)
+  })
+})
+
+describe('#4141 — capture persists the raw reply-throw signal onto the record', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = makeStateDir()
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('the REAL hook stamps replyToolThrewThisTurn alongside audience:user', () => {
+    writeOpenObligation(dir)
+    const t = foregroundThrowTranscript(dir, WORKING_NOTES)
+    const scan = scanForOutboxCapture(readFileSync(t, 'utf8')) as {
+      capture: boolean
+      replyToolThrewThisTurn: boolean
+    }
+    expect(scan.capture).toBe(true)
+    expect(scan.replyToolThrewThisTurn).toBe(true)
+
+    expect(runHook(t, dir).status).toBe(0)
+    const records = outboxRecords(dir)
+    expect(records).toHaveLength(1)
+    // The #4141 premise, confirmed against the real hook: the foreground case
+    // classifies `user` (someone is waiting) — #4140's gate does NOT bind here.
+    expect(records[0].audience).toBe('user')
+    // ...and the raw signal survives the write. THIS is the hop that would
+    // silently make the whole feature inert if it were dropped.
+    expect(records[0].replyToolThrewThisTurn).toBe(true)
+  })
+
+  it('a turn where the reply tool did NOT throw stamps false — no framing anywhere', () => {
+    writeOpenObligation(dir)
+    const t = writeTranscript(dir, [
+      {
+        type: 'queue-operation',
+        operation: 'enqueue',
+        content: `<channel source="telegram" chat_id="${DM_CHAT}" message_id="${INBOUND_MSG_ID}">where did the rebase land?</channel>`,
+        timestamp: 1000,
+      },
+      { type: 'assistant', message: { content: [{ type: 'text', text: REAL_ANSWER }] } },
+    ])
+    expect(runHook(t, dir).status).toBe(0)
+    const records = outboxRecords(dir)
+    expect(records).toHaveLength(1)
+    expect(records[0].replyToolThrewThisTurn).toBe(false)
+    expect(shouldFrameReplyThrow(records[0])).toBe(false)
+  })
+})
+
+describe('#4141 — the foreground leak, end to end through the real sweep', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = makeStateDir()
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  /** Capture the foreground reply-throw shape through the REAL hook. */
+  function captureForeground(prose: string): RecordShape {
+    writeOpenObligation(dir)
+    const t = foregroundThrowTranscript(dir, prose)
+    expect(runHook(t, dir).status).toBe(0)
+    const records = outboxRecords(dir)
+    expect(records).toHaveLength(1)
+    expect(records[0].audience).toBe('user')
+    expect(records[0].replyToolThrewThisTurn).toBe(true)
+    return records[0]
+  }
+
+  it('PRIMARY: the prose is delivered WITH its provenance stated, journaled terminally, and telemetered once', async () => {
+    const rec = captureForeground(WORKING_NOTES)
+    const bot = recordingBot()
+
+    const run = await realSweep(dir, bot)
+
+    // INVARIANT A — framing never silences. Exactly one chat-visible call.
+    expect(bot.chatCalls()).toHaveLength(1)
+    expect(run.summary.delivered).toBe(1)
+    expect(run.summary.audienceSuppressed).toBeUndefined()
+
+    // The user is told what this text IS before they read it...
+    const body = bot.chatCalls()[0].text
+    expect(body).toContain(REPLY_THROW_PROVENANCE_NOTICE)
+    // ...and none of the captured prose was destroyed to say so.
+    expect(body).toContain('I will bisect from the merge base')
+    expect(body.indexOf(REPLY_THROW_PROVENANCE_NOTICE)).toBeLessThan(
+      body.indexOf('Dispatched the worker'),
+    )
+    expect(bot.chatCalls()[0].chatId).toBe(DM_CHAT)
+
+    // INVARIANT B — observable. A durable terminal stamp on the journal line...
+    const journal = journalLines(dir)
+    expect(journal).toHaveLength(1)
+    expect(journal[0].turnNonce).toBe(rec.turnNonce)
+    expect(journal[0].framedProvenance).toBe('reply-throw')
+    expect(journal[0].deliverySource).toBe('sweep')
+    // A framed delivery IS a delivery — it carries a message id, unlike a
+    // #4140 suppression line.
+    expect(journal[0].tgMessageId).toBeDefined()
+    expect(journal[0].suppressedAudience).toBeUndefined()
+
+    // ...plus exactly one structured telemetry line, on its own channel.
+    expect(run.framingLines).toHaveLength(1)
+    expect(run.framingLines[0]).toContain(`nonce=${rec.turnNonce}`)
+    expect(run.framingLines[0]).toContain('replyToolThrew=true')
+    expect(run.escalations).toHaveLength(0)
+    expect(run.summary.provenanceFramed).toBe(1)
+
+    // A SECOND tick sends nothing more (exactly-once is untouched).
+    const second = await realSweep(dir, bot)
+    expect(bot.chatCalls()).toHaveLength(1)
+    expect(second.summary.scanned).toBe(0)
+    expect(second.framingLines).toHaveLength(0)
+  })
+
+  it('REVERT CHECK: with framing disabled the leak reproduces UNLABELLED (so the assertion above is load-bearing)', async () => {
+    captureForeground(WORKING_NOTES)
+    const bot = recordingBot()
+
+    const run = await realSweep(dir, bot, { framingEnabled: false })
+
+    // The pre-change behaviour, verbatim: the working notes go to the waiting
+    // human with nothing to say they are not the answer.
+    expect(bot.chatCalls()).toHaveLength(1)
+    expect(run.summary.delivered).toBe(1)
+    expect(bot.chatCalls()[0].text).not.toContain(REPLY_THROW_PROVENANCE_NOTICE)
+    expect(bot.chatCalls()[0].text).toContain('Dispatched the worker')
+    expect(run.summary.provenanceFramed).toBeUndefined()
+    expect(run.framingLines).toHaveLength(0)
+    expect(journalLines(dir)[0].framedProvenance).toBeUndefined()
+  })
+
+  it('ANTI-SILENCE: a genuine answer re-written as prose after the throw still reaches the user in full', async () => {
+    // This is why the rule is framing and not suppression. The transcript is
+    // structurally IDENTICAL to the working-notes case; only the prose differs,
+    // and no classifier in this pipeline can tell them apart. A suppression
+    // rule would silently swallow this answer from a waiting human.
+    captureForeground(REAL_ANSWER)
+    const bot = recordingBot()
+
+    const run = await realSweep(dir, bot)
+
+    expect(run.summary.delivered).toBe(1)
+    expect(bot.chatCalls()).toHaveLength(1)
+    expect(bot.chatCalls()[0].text).toContain(REAL_ANSWER)
+  })
+
+  it('LEGACY: a record with no replyToolThrewThisTurn field delivers byte-for-byte unframed', async () => {
+    const outbox = join(dir, 'outbox')
+    mkdirSync(outbox, { recursive: true })
+    const nonce = `${DM_CHAT}:_#5150`
+    const legacy = {
+      turnNonce: nonce,
+      chatId: DM_CHAT,
+      threadId: null,
+      text: REAL_ANSWER,
+      textSha256: sha256Hex(REAL_ANSWER),
+      // Inside the max-age window, so the body carries NO prefix at all and
+      // "byte-for-byte unframed" can be asserted as exact equality.
+      createdAt: Date.now(),
+      source: 'channel',
+      audience: 'user',
+    }
+    expect(Object.keys(legacy)).not.toContain('replyToolThrewThisTurn')
+    writeFileSync(join(outbox, `${nonce}.json`), JSON.stringify(legacy), 'utf8')
+
+    const bot = recordingBot()
+    const run = await realSweep(dir, bot)
+
+    expect(run.summary.delivered).toBe(1)
+    expect(bot.chatCalls()).toHaveLength(1)
+    expect(bot.chatCalls()[0].text).toBe(REAL_ANSWER)
+    expect(run.framingLines).toHaveLength(0)
+  })
+
+  it('#4140 still wins where it binds: an internal record is suppressed, never framed-and-sent', async () => {
+    // Interaction check between the two gates. A background record can carry
+    // BOTH signals (reply threw, nobody waiting); suppression is upstream at
+    // entry selection, so framing must never resurrect it as a send.
+    const outbox = join(dir, 'outbox')
+    mkdirSync(outbox, { recursive: true })
+    const nonce = `${DM_CHAT}:_#6160`
+    writeFileSync(
+      join(outbox, `${nonce}.json`),
+      JSON.stringify({
+        turnNonce: nonce,
+        chatId: DM_CHAT,
+        threadId: null,
+        text: WORKING_NOTES,
+        textSha256: sha256Hex(WORKING_NOTES),
+        createdAt: 1000,
+        source: 'task-notification',
+        audience: 'internal',
+        replyToolThrewThisTurn: true,
+      }),
+      'utf8',
+    )
+
+    const bot = recordingBot()
+    const run = await realSweep(dir, bot)
+
+    expect(bot.chatCalls()).toEqual([])
+    expect(run.summary.audienceSuppressed).toBe(1)
+    expect(run.summary.provenanceFramed).toBeUndefined()
+    expect(run.framingLines).toHaveLength(0)
+    expect(journalLines(dir)[0].suppressedAudience).toBe('internal')
+    expect(journalLines(dir)[0].framedProvenance).toBeUndefined()
+  })
+
+  it('the OTHER live producer (flood-reply-queue) writes no throw signal and delivers unframed', async () => {
+    // `gateway/flood-reply-queue.ts` is LIVE (imported by
+    // gateway/outbound-send-path.ts). Its records are replies the agent
+    // ALREADY chose to send — framing them would be a lie.
+    const res = queueFloodBlockedReply({
+      err: new Error('FLOOD_WAIT_ACTIVE — send rejected, retry_after 30'),
+      chatId: DM_CHAT,
+      threadId: null,
+      text: REAL_ANSWER,
+      createdAt: 1000,
+      stateDir: dir,
+    })
+    expect(res).not.toBeNull()
+    const rec = outboxRecords(dir)[0]
+    expect(rec.audience).toBe('user')
+    expect(rec.replyToolThrewThisTurn).toBeUndefined()
+
+    const bot = recordingBot()
+    const run = await realSweep(dir, bot)
+
+    expect(run.summary.delivered).toBe(1)
+    expect(bot.chatCalls()).toHaveLength(1)
+    expect(bot.chatCalls()[0].text).not.toContain(REPLY_THROW_PROVENANCE_NOTICE)
+    expect(bot.chatCalls()[0].text).toContain(REAL_ANSWER)
+    expect(run.framingLines).toHaveLength(0)
+  })
+})
+
+/**
+ * The BACKGROUND shape #4140's gate is built for: a task-notification wake
+ * (never opens an obligation), a reply-tool throw, trailing working notes.
+ * Used here to prove the stale-snapshot hole (#4146), because this is the only
+ * shape where a bad "nobody is waiting" verdict can actually suppress.
+ */
+function backgroundThrowTranscript(dir: string, prose: string): string {
+  return writeTranscript(dir, [
+    {
+      type: 'queue-operation',
+      operation: 'enqueue',
+      content: `<channel source="telegram" chat_id="${DM_CHAT}" message_id="${INBOUND_MSG_ID}">where did the rebase land?</channel>`,
+      timestamp: 1000,
+    },
+    {
+      type: 'queue-operation',
+      operation: 'enqueue',
+      content: '<task-notification><task-id>a7cc7a0fa8f</task-id> worker done</task-notification>',
+      timestamp: 2000,
+    },
+    {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_reply_1',
+            name: 'mcp__switchroom-telegram__reply',
+            input: { text: 'On it.', disable_notification: true },
+          },
+        ],
+      },
+    },
+    {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_reply_1',
+            is_error: true,
+            content: 'Error: FLOOD_WAIT_ACTIVE — send rejected',
+          },
+        ],
+      },
+    },
+    { type: 'assistant', message: { content: [{ type: 'text', text: prose }] } },
+  ])
+}
+
+describe('#4146 — a snapshot that is not being maintained is not evidence', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = makeStateDir()
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('an explicit distrust beats anything on disk, including an empty open set', () => {
+    const emptyButStale = JSON.stringify({ v: 1, obligations: [] })
+    // Trusted: the pre-#4146 reading — positive proof that nobody is waiting.
+    expect(
+      resolveOpenObligation({ snapshotRaw: emptyButStale, chatId: DM_CHAT }),
+    ).toBe(false)
+    // Distrusted: the SAME bytes prove nothing.
+    expect(
+      resolveOpenObligation({
+        snapshotRaw: emptyButStale,
+        chatId: DM_CHAT,
+        snapshotTrusted: false,
+      }),
+    ).toBe('unknown')
+    // ...which flips the classifier back to the delivering direction.
+    expect(
+      decideCaptureAudience({
+        replyToolThrewThisTurn: true,
+        openInboundObligation: resolveOpenObligation({
+          snapshotRaw: emptyButStale,
+          chatId: DM_CHAT,
+          snapshotTrusted: false,
+        }),
+      }),
+    ).toBe('user')
+    // Only an exact `false` distrusts — an unaware caller cannot weaken it.
+    expect(
+      resolveOpenObligation({ snapshotRaw: emptyButStale, chatId: DM_CHAT, snapshotTrusted: true }),
+    ).toBe(false)
+    expect(
+      resolveOpenObligation({
+        snapshotRaw: emptyButStale,
+        chatId: DM_CHAT,
+        snapshotTrusted: undefined,
+      }),
+    ).toBe(false)
+  })
+
+  it('OUTCOME: with the ledger off, a lingering empty snapshot no longer suppresses — the text still reaches the chat', async () => {
+    // The exact #4146 configuration: the agent once ran with the ledger on, so
+    // an empty `obligations.json` is on disk; the ledger is now off, so
+    // obligations are going untracked and that file is a leftover.
+    writeFileSync(join(dir, 'obligations.json'), JSON.stringify({ v: 1, obligations: [] }), 'utf8')
+    const t = backgroundThrowTranscript(dir, REAL_ANSWER)
+    expect(runHook(t, dir, { SWITCHROOM_OBLIGATION_LEDGER: '0' }).status).toBe(0)
+
+    const rec = outboxRecords(dir)[0]
+    expect(rec.audience).toBe('user')
+
+    const bot = recordingBot()
+    const run = await realSweep(dir, bot)
+    expect(run.summary.delivered).toBe(1)
+    expect(run.summary.audienceSuppressed).toBeUndefined()
+    expect(bot.chatCalls()).toHaveLength(1)
+    expect(bot.chatCalls()[0].text).toContain(REAL_ANSWER)
+  })
+
+  it('REVERT CHECK (#4146): with the ledger ON, the same lingering snapshot DOES suppress', async () => {
+    // Same bytes, same transcript — only the trust signal differs. This is what
+    // makes the assertion above load-bearing: without the guard the message is
+    // swallowed with zero chat calls.
+    writeFileSync(join(dir, 'obligations.json'), JSON.stringify({ v: 1, obligations: [] }), 'utf8')
+    const t = backgroundThrowTranscript(dir, REAL_ANSWER)
+    expect(runHook(t, dir, { SWITCHROOM_OBLIGATION_LEDGER: '1' }).status).toBe(0)
+
+    expect(outboxRecords(dir)[0].audience).toBe('internal')
+
+    const bot = recordingBot()
+    const run = await realSweep(dir, bot)
+    expect(bot.chatCalls()).toEqual([])
+    expect(run.summary.audienceSuppressed).toBe(1)
+  })
+})
+
+describe('#4141 — framing is honest telemetry and cannot launder a broken turn', () => {
+  it('the framing line matches NO gateway alarm signature (a framed delivery is a delivery)', () => {
+    const line = formatReplyThrowFraming({
+      turnNonce: NONCE,
+      turnId: NONCE,
+      chatId: DM_CHAT,
+      textSha256: sha256Hex(WORKING_NOTES),
+      source: 'channel',
+    })
+    for (const [name, re] of Object.entries(GATEWAY_SIGNATURES)) {
+      expect(re.test(line), `${name} must not match a by-design framed delivery`).toBe(false)
+    }
+    expect(detectGatewayFindings('klanker', line).findings).toEqual([])
+  })
+
+  it('the framing line carries a turn id the fleet-health scanner can join on', () => {
+    expect(turnIdFromNonce(NONCE)).toBe(NONCE)
+    const line = formatReplyThrowFraming({ turnNonce: NONCE, turnId: NONCE, chatId: DM_CHAT })
+    expect(extractTurnId(line)).toBe(NONCE)
+  })
+
+  it('DISJOINTNESS: a framed turn has tools>=1, so it can never enter the silent-no-op branch', () => {
+    // Checked through the REAL builder + REAL detector, not by inspection.
+    // Framing is only reachable when the reply tool was CALLED and threw, so
+    // the turn has >= 1 tool call; the silent-no-op branch requires
+    // `tools === 0` (src/fleet-health/detect.ts:305-333).
+    const now = Math.floor(Date.now() / 1000)
+    const row = buildTurnRecord(
+      {
+        agent: 'klanker',
+        startedAt: 1000,
+        toolCallCount: 1, // the reply tool call that threw
+        turnId: NONCE,
+        finalAnswerDelivered: false,
+        replyCalled: true,
+      },
+      Date.now(),
+    )
+    expect(row.tools).toBe(1)
+    expect(row.route).toBe('none')
+    const findings = detectTurnFindings('klanker', [{ ...row, ts: now }])
+    expect(findings.filter((f) => f.signal === 'silent-no-op-candidate')).toEqual([])
+  })
+
+  it('CONTROL: the silent-no-op detector is NOT blinded — a zero-tool no-op still scores', () => {
+    // The disjointness claim above is only meaningful if the detector would
+    // otherwise fire on the SAME call. This is that control: same detector,
+    // tools=0, complete, and no honest `route` — the regression shape
+    // `detect.ts:333-343` treats as `none` and scores sev-3.
+    const now = Math.floor(Date.now() / 1000)
+    const row = buildTurnRecord(
+      {
+        agent: 'klanker',
+        startedAt: 1000,
+        toolCallCount: 0,
+        turnId: `${DM_CHAT}:_#9999`,
+        finalAnswerDelivered: true,
+      },
+      Date.now(),
+    )
+    expect(row.tools).toBe(0)
+    expect(row.status).toBe('complete')
+    const { route: _dropped, ...legacyRow } = row
+    const findings = detectTurnFindings('klanker', [{ ...legacyRow, ts: now }])
+    expect(findings.filter((f) => f.signal === 'silent-no-op-candidate')).toHaveLength(1)
+  })
+})

--- a/telegram-plugin/tests/outbox-provenance-4141.test.ts
+++ b/telegram-plugin/tests/outbox-provenance-4141.test.ts
@@ -57,6 +57,10 @@ import {
   shouldFrameReplyThrow,
 } from '../hooks/audience-classify.mjs'
 import { scanForOutboxCapture } from '../hooks/silent-end-scan.mjs'
+import { deliverCapturedProse } from '../gateway/outbound-send-path.js'
+import { decideCapturedProseDelivery } from '../silent-end.js'
+import { OutboundDedupCache } from '../recent-outbound-dedup.js'
+import { decideTurnFlush } from '../turn-flush-safety.js'
 import { buildTurnRecord } from '../gateway/turn-record-status.js'
 import {
   detectTurnFindings,
@@ -775,5 +779,348 @@ describe('#4141 — framing is honest telemetry and cannot launder a broken turn
     const { route: _dropped, ...legacyRow } = row
     const findings = detectTurnFindings('klanker', [{ ...legacyRow, ts: now }])
     expect(findings.filter((f) => f.signal === 'silent-no-op-candidate')).toHaveLength(1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #4141 REVIEW FINDING — THE ELECTED PATH
+//
+// The sweep-path framing above binds only when the Stop hook writes an outbox
+// RECORD. On the dominant live shape it does not:
+//
+//   The reply tool is called with a QUALIFYING final answer and it THROWS.
+//   `scanForOutboxCapture` classifies a qualifying reply-tool call from its
+//   INPUT (`isFinalAnswerReply`, silent-end-scan.mjs:1008) and never consults
+//   the tool_result, so `replyAlreadyDeliveredThisTurn` is true even though the
+//   call errored. The hook therefore takes the #3510 branch, writes NO outbox
+//   record, and falls through to the single-writer election, which hands the
+//   trailing prose to the gateway's captured-prose bridge.
+//
+// So on a healthy gateway the FIRST, common occurrence goes out through a
+// machine the outbox sweep never touches. These tests pin the label onto THAT
+// machine, driving the real hook, the real `decideCapturedProseDelivery`, and
+// the real `deliverCapturedProse` against the recording bot.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The ELECTED foreground shape: a QUALIFYING final-answer reply (no
+ * `disable_notification`, so `isFinalAnswerReply` is true on the input alone)
+ * that throws, followed by trailing prose over the bridge's 200-char floor.
+ */
+function electedThrowTranscript(dir: string, prose: string, opts: { throws?: boolean } = {}) {
+  const lines: object[] = [
+    {
+      type: 'queue-operation',
+      operation: 'enqueue',
+      content: `<channel source="telegram" chat_id="${DM_CHAT}" message_id="${INBOUND_MSG_ID}">where did the rebase land?</channel>`,
+      timestamp: 1000,
+    },
+    {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_reply_elected',
+            name: 'mcp__switchroom-telegram__reply',
+            // No `disable_notification` ⇒ qualifying final answer by input.
+            input: { text: 'The rebase landed cleanly on the merge base.' },
+          },
+        ],
+      },
+    },
+  ]
+  if (opts.throws !== false) {
+    lines.push({
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_reply_elected',
+            is_error: true,
+            content: 'Error: request timed out after 30000ms',
+          },
+        ],
+      },
+    })
+  } else {
+    lines.push({
+      type: 'user',
+      message: {
+        content: [
+          { type: 'tool_result', tool_use_id: 'toolu_reply_elected', content: 'sent' },
+        ],
+      },
+    })
+  }
+  lines.push({ type: 'assistant', message: { content: [{ type: 'text', text: prose }] } })
+  return writeTranscript(dir, lines)
+}
+
+/** Make the election's gateway-liveness gate pass. */
+function writeFreshHeartbeat(dir: string): void {
+  writeFileSync(join(dir, 'gateway-heartbeat'), 'up', 'utf8')
+}
+
+function readElectedState(dir: string): Record<string, unknown> | null {
+  const p = join(dir, 'silent-end-pending.json')
+  if (!existsSync(p)) return null
+  return JSON.parse(readFileSync(p, 'utf8')) as Record<string, unknown>
+}
+
+/** Drive the REAL captured-prose bridge against the recording bot. */
+async function realBridge(
+  stateDir: string,
+  bot: ReturnType<typeof recordingBot>,
+  decision: { text?: string; replyToolThrewThisTurn?: boolean },
+) {
+  const stderr: string[] = []
+  // `journalExternalDelivery` resolves its state dir from the env (the bridge
+  // takes no stateDir arg), so point it at this test's dir for the duration.
+  const prevStateDir = process.env.TELEGRAM_STATE_DIR
+  process.env.TELEGRAM_STATE_DIR = stateDir
+  const origWrite = process.stderr.write.bind(process.stderr)
+  ;(process.stderr as unknown as { write: (s: string) => boolean }).write = (s: string) => {
+    stderr.push(String(s))
+    return true
+  }
+  try {
+    await deliverCapturedProse(
+      {
+        outboundDedup: new OutboundDedupCache({}),
+        bot: bot as never,
+        robustApiCall: passthroughRetry,
+        redactOutboundText: (t: string) => t,
+        recordOutbound: () => {},
+        HISTORY_ENABLED: false,
+        OBLIGATION_LEDGER_ENABLED: false,
+        obligationLedger: { close: () => {} },
+        clearSilentEndState: () => {},
+        recordUndeliveredTurnEnd: () => ({ exhausted: false }),
+        hasOutboundDeliveredSince: () => false,
+      },
+      {
+        chatId: DM_CHAT,
+        threadId: undefined,
+        statusKeyStr: `${DM_CHAT}:_`,
+        registryKey: null,
+        originTurnId: NONCE,
+        text: decision.text!,
+        replyToolThrewThisTurn: decision.replyToolThrewThisTurn === true,
+      },
+    )
+  } finally {
+    ;(process.stderr as unknown as { write: typeof origWrite }).write = origWrite
+    if (prevStateDir === undefined) delete process.env.TELEGRAM_STATE_DIR
+    else process.env.TELEGRAM_STATE_DIR = prevStateDir
+  }
+  return { stderr }
+}
+
+describe('#4141 elected path — the bridge, not the sweep, is the common deliverer', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = makeStateDir()
+    writeFreshHeartbeat(dir)
+    writeOpenObligation(dir)
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('PREMISE: a thrown QUALIFYING reply writes no outbox record and elects the bridge', () => {
+    const t = electedThrowTranscript(dir, WORKING_NOTES)
+    const res = runHook(t, dir)
+    expect(res.status).toBe(0)
+    // The sweep-path record — the only thing the outbox framing can label —
+    // is never written on this shape. This is exactly why the sweep-side fix
+    // alone left #4141 open.
+    expect(outboxRecords(dir)).toEqual([])
+    expect(res.stderr).toContain('deferring to single-writer election')
+    expect(res.stderr).toContain('single-writer election ALLOWED stop')
+    // ...and a real sweep tick therefore has nothing at all to deliver.
+    expect(outboxRecords(dir)).toHaveLength(0)
+  })
+
+  it('the elected state file carries the reply-throw signal to the bridge', () => {
+    runHook(electedThrowTranscript(dir, WORKING_NOTES), dir)
+    const state = readElectedState(dir)
+    expect(state).not.toBeNull()
+    expect(state!.replyToolThrewThisTurn).toBe(true)
+    expect(state!.pendingText).toBe(WORKING_NOTES)
+    expect(state!.turnId).toBe(NONCE)
+  })
+
+  it('a turn whose reply did NOT throw carries no signal — no stale carryover', () => {
+    // Seed a state file that already claims a throw, then run a CLEAN turn.
+    // `buildNextState` must DELETE the field, not spread it forward.
+    writeFileSync(
+      join(dir, 'silent-end-pending.json'),
+      JSON.stringify({ retryCount: 0, replyToolThrewThisTurn: true, turnKey: 'stale' }),
+      'utf8',
+    )
+    runHook(electedThrowTranscript(dir, WORKING_NOTES, { throws: false }), dir)
+    const state = readElectedState(dir)
+    expect(state).not.toBeNull()
+    expect(state!.replyToolThrewThisTurn).toBeUndefined()
+  })
+
+  it('OUTCOME: the bridge delivers the prose WITH its provenance stated', async () => {
+    runHook(electedThrowTranscript(dir, WORKING_NOTES), dir)
+    const decision = decideCapturedProseDelivery(
+      { turnKey: `${DM_CHAT}:_`, turnId: NONCE },
+      { stateDir: dir },
+    )
+    expect(decision.deliver).toBe(true)
+    expect(decision.text).toBe(WORKING_NOTES)
+    expect(decision.replyToolThrewThisTurn).toBe(true)
+
+    const bot = recordingBot()
+    const { stderr } = await realBridge(dir, bot, decision)
+
+    // A. FRAMING NEVER SILENCES — exactly one chat-visible call, prose intact.
+    expect(bot.chatCalls()).toHaveLength(1)
+    const sent = bot.chatCalls()[0]!.text
+    expect(sent).toContain(WORKING_NOTES)
+    expect(sent).toContain(REPLY_THROW_PROVENANCE_NOTICE)
+    expect(sent.indexOf(REPLY_THROW_PROVENANCE_NOTICE)).toBeLessThan(sent.indexOf(WORKING_NOTES))
+
+    // B. FRAMING IS OBSERVABLE — durable journal stamp + one telemetry line.
+    const journal = journalLines(dir)
+    expect(journal).toHaveLength(1)
+    expect(journal[0]!.framedProvenance).toBe('reply-throw')
+    expect(journal[0]!.tgMessageId).toBeDefined()
+    // The journal key stays on the RAW text so exactly-once-among-backstops
+    // is unaffected by the label.
+    expect(journal[0]!.textSha256).toBe(sha256Hex(WORKING_NOTES))
+    expect(stderr.filter((l) => l.includes('outbox provenance framing'))).toHaveLength(1)
+  })
+
+  it('REVERT CHECK: with framing off the bridge reproduces the #4141 leak', async () => {
+    const prev = process.env.SWITCHROOM_TG_OUTBOX_PROVENANCE_FRAMING
+    process.env.SWITCHROOM_TG_OUTBOX_PROVENANCE_FRAMING = '0'
+    try {
+      runHook(electedThrowTranscript(dir, WORKING_NOTES), dir)
+      const decision = decideCapturedProseDelivery(
+        { turnKey: `${DM_CHAT}:_`, turnId: NONCE },
+        { stateDir: dir },
+      )
+      const bot = recordingBot()
+      await realBridge(dir, bot, decision)
+      expect(bot.chatCalls()).toHaveLength(1)
+      // The bug: working notes delivered to a waiting human, unlabelled.
+      expect(bot.chatCalls()[0]!.text).toBe(WORKING_NOTES)
+      expect(bot.chatCalls()[0]!.text).not.toContain(REPLY_THROW_PROVENANCE_NOTICE)
+      expect(journalLines(dir)[0]!.framedProvenance).toBeUndefined()
+    } finally {
+      if (prev === undefined) delete process.env.SWITCHROOM_TG_OUTBOX_PROVENANCE_FRAMING
+      else process.env.SWITCHROOM_TG_OUTBOX_PROVENANCE_FRAMING = prev
+    }
+  })
+
+  it('ANTI-SILENCE: a genuine answer rewritten as prose still arrives in full', async () => {
+    runHook(electedThrowTranscript(dir, REAL_ANSWER), dir)
+    const decision = decideCapturedProseDelivery(
+      { turnKey: `${DM_CHAT}:_`, turnId: NONCE },
+      { stateDir: dir },
+    )
+    const bot = recordingBot()
+    await realBridge(dir, bot, decision)
+    expect(bot.chatCalls()).toHaveLength(1)
+    expect(bot.chatCalls()[0]!.text).toContain(REAL_ANSWER)
+  })
+
+  it('LEGACY: a state file with no signal delivers byte-for-byte unframed', async () => {
+    writeFileSync(
+      join(dir, 'silent-end-pending.json'),
+      JSON.stringify({
+        retryCount: 0,
+        turnKey: `${DM_CHAT}:_`,
+        turnId: NONCE,
+        chatId: DM_CHAT,
+        threadId: null,
+        timestamp: Date.now(),
+        pendingText: WORKING_NOTES,
+      }),
+      'utf8',
+    )
+    const decision = decideCapturedProseDelivery(
+      { turnKey: `${DM_CHAT}:_`, turnId: NONCE },
+      { stateDir: dir },
+    )
+    expect(decision.replyToolThrewThisTurn).toBeUndefined()
+    const bot = recordingBot()
+    await realBridge(dir, bot, decision)
+    expect(bot.chatCalls()[0]!.text).toBe(WORKING_NOTES)
+  })
+
+  it('the label is presentation only — dedup still keys on the RAW prose', async () => {
+    // Additive-by-construction, re-established on THIS path: this path has its
+    // own send ladder and its own dedup, so the sweep's proof does not carry.
+    // A second bridge call with the same raw text must dedup (zero new sends)
+    // even though the first send carried the banner.
+    const dedup = new OutboundDedupCache({})
+    const bot = recordingBot()
+    const deps = {
+      outboundDedup: dedup,
+      bot: bot as never,
+      robustApiCall: passthroughRetry,
+      redactOutboundText: (t: string) => t,
+      recordOutbound: () => {},
+      HISTORY_ENABLED: false,
+      OBLIGATION_LEDGER_ENABLED: false,
+      obligationLedger: { close: () => {} },
+      clearSilentEndState: () => {},
+      recordUndeliveredTurnEnd: () => ({ exhausted: false }),
+      hasOutboundDeliveredSince: () => false,
+    }
+    const args = {
+      chatId: DM_CHAT,
+      threadId: undefined,
+      statusKeyStr: `${DM_CHAT}:_`,
+      registryKey: null,
+      originTurnId: NONCE,
+      text: WORKING_NOTES,
+      replyToolThrewThisTurn: true,
+    }
+    await deliverCapturedProse(deps, args)
+    expect(bot.chatCalls()).toHaveLength(1)
+    // Same raw text arriving unframed (e.g. a late reply-tool retry) is still
+    // recognised as already-sent — the banner did not change the identity.
+    await deliverCapturedProse(deps, { ...args, replyToolThrewThisTurn: false })
+    expect(bot.chatCalls()).toHaveLength(1)
+  })
+
+  it('DISJOINTNESS: the turn-flush machine cannot deliver on a reply-throw turn', () => {
+    // The elected `no-final-reply` leg names the flush as the deliverer, so it
+    // is fair to ask whether IT also needs the label. It does not, and this is
+    // structural rather than a judgement: `turn.replyCalled` is set on the
+    // reply tool's CALL event (stream-render.ts:1196), before any result, so a
+    // thrown reply still sets it — and `decideTurnFlush` skips outright on
+    // `replyCalled`. A reply-throw turn can therefore never reach the flush
+    // send site, which is why framing lives on the bridge instead.
+    const flushed = decideTurnFlush({
+      replyCalled: true,
+      capturedText: [WORKING_NOTES],
+      turnFlushSafetyEnabled: true,
+    } as never)
+    expect(flushed.kind).toBe('skip')
+    expect(flushed.reason).toBe('reply-called')
+  })
+})
+
+describe('#4141 — the elected path is WIRED, not just implemented', () => {
+  it('stream-render forwards the signal from the decision into the bridge call', () => {
+    // The two ends of this path are covered by outcome tests above
+    // (`decideCapturedProseDelivery` surfaces the signal; `deliverCapturedProse`
+    // frames on it). The ONE link between them is a single argument in
+    // stream-render's turn_end handler, which cannot be driven in isolation —
+    // it lives inside a ~2000-line event handler with the whole gateway as its
+    // closure. So it is pinned structurally: without this argument the feature
+    // is inert in production while every other test in this file still passes,
+    // which is exactly the failure mode this pin exists to catch.
+    const src = readFileSync(resolve(__dirname, '..', 'gateway', 'stream-render.ts'), 'utf8')
+    const call = src.slice(src.indexOf('void deliverCapturedProse({'))
+    const body = call.slice(0, call.indexOf('\n            })'))
+    expect(body).toContain('replyToolThrewThisTurn: proseDecision.replyToolThrewThisTurn === true')
   })
 })


### PR DESCRIPTION
Closes #4141. Also fixes #4146 (a low filed against #4140, fixed here rather than deferred — see below).

**Stacked on #4140** (`fix/w1d-audience-bit`), because it builds directly on that PR's `audience` plumbing: the shared `hooks/audience-classify.mjs` classifier, the `OutboxRecord.audience` field, and the sweep-side suppression/telemetry seam. Retarget to `main` once #4140 merges. Note stacked PRs get no automatic CI (workflows gate on `pull_request: branches: [main]`), so the three workflows were dispatched manually — run URLs at the bottom.

## The residual #4140 leaves open

#4140 closes the **background** half. A captured record is marked `internal` only when the reply tool threw **and** no inbound obligation is open. But an obligation only closes on a substantive *delivered* reply (`telegram-plugin/gateway/obligation-ledger.ts:153-157`). So on a **foreground** Telegram turn where the reply tool threw:

- the obligation is still OPEN,
- the record therefore classifies `user`,
- and the agent's trailing working notes are delivered to the waiting human, presented as if they were the answer.

That is #4141, and it is the *common* case: a human is sitting there.

## The design decision: frame, do not suppress

**I did not extend suppression into the foreground class.** The brief explicitly allowed concluding that suppression is not the right answer here, and the source says it is not.

There is no deterministic discriminator in the foreground case. When the reply tool throws, a model whose instructions say *"every turn MUST end with a reply tool call"* very plausibly re-writes its **answer** as plain prose — and that prose is selected by *exactly* the same structural rule as working notes. Position does not separate them (both follow the errored `tool_result`), and wording heuristics are provably incomplete — `hooks/narration-classify.mjs` says so in its own header. Suppressing on a coin-flip would trade a **visible** wrong-content failure for an **invisible** no-answer failure against a human who is provably still waiting. That is the severity-3 class this whole line of work exists to prevent, and the brief's asymmetric default ("ambiguity resolves to deliver") forbids it.

What *can* be asserted deterministically is **provenance**: the reply tool threw, so this text was never delivered as an answer — the safety net scraped it off the end of the turn. So the fix states that, verbatim, in front of the text:

```
(my reply tool errored this turn, so this was never sent as an answer —
the safety net captured the last thing I wrote, which may be working notes)

<the captured text, byte-for-byte>
```

This restores the context #3865 says late delivery strips, and hands the judgement to the reader — who, unlike any classifier available here, can tell notes from an answer.

Framing is **additive by construction**: it can never turn a `send` into a `skip`, so it cannot manufacture a silence. A record without an exact `replyToolThrewThisTurn === true` delivers byte-for-byte as it does today.

## Change map

| File | What |
|---|---|
| `hooks/audience-classify.mjs` | `REPLY_THROW_PROVENANCE_NOTICE`; `shouldFrameReplyThrow` (positive evidence only — an exact boolean, never a truthy coercion); `applyReplyThrowFraming` (additive, empty body untouched, no markdown specials); `formatReplyThrowFraming` (telemetry line) |
| `outbox.ts` | Persist `OutboxRecord.replyToolThrewThisTurn`; compose the banner in `decideOutboxSweep` *between* the delivery prefixes and the body; surface `framedProvenance` on the decision and on `DeliveredEntry` |
| `hooks/silent-end-interrupt-stop.mjs` | Stamp the raw signal at capture — the last point that can see the transcript |
| `gateway/outbox-sweep.ts` | Kill switch `SWITCHROOM_TG_OUTBOX_PROVENANCE_FRAMING`; `summary.provenanceFramed`; the durable journal stamp and one telemetry line per framed delivery |

Observability matches #4140's shape: a durable terminal stamp on the journal entry (`framedProvenance: 'reply-throw'`, alongside a real `tgMessageId` — a framed delivery *is* a delivery) plus one telemetry line.

## #4146 — fixed here, not deferred

`classifyCaptureAudience` reads the persisted obligations snapshot. With `SWITCHROOM_OBLIGATION_LEDGER=0` or a STATIC gateway, the `onChange` persister is never wired: obligations open and close purely in memory while an old `obligations.json` sits on disk unchanged. An empty-but-stale open set then reads as **positive evidence that nobody is waiting** — the one input that can make #4140's classifier suppress a message owed to a human. The classifier's own doc comment claimed the absent-file case covered these modes; a leftover file is not an absent file. That contradiction is now corrected in the comment.

Closed on **both** sides, deterministically:

- **Writer side** — `removeUnmaintainedSnapshot` (`gateway/obligation-store.ts`) unlinks the file at gateway boot in exactly those modes, restoring the classifier's stated "absent ⇒ unknown ⇒ deliver" invariant.
- **Reader side** — the hook passes `snapshotTrusted: process.env.SWITCHROOM_OBLIGATION_LEDGER !== '0'`, so it distrusts the file regardless of whether cleanup ran. Only an exact `false` distrusts; absent/undefined keeps pre-#4146 behaviour, so a caller that does not know cannot accidentally weaken the gate.

**Why not an mtime freshness bound** (the issue's other suggested instrument): the snapshot has exactly one writer, so a merely-stopped-and-restarted gateway leaves a snapshot that is *accurate*, not stale. A freshness bound would fail idle-but-correct snapshots — introducing a clock dependency and flakiness to solve a problem that has an exact answer.

## Verification

New: `telegram-plugin/tests/outbox-provenance-4141.test.ts` — 21 outcome tests, driving the **real** Stop hook as a subprocess, the **real** `sweepOutbox` + **real** `createOutboxSend` against a recording fake Bot API that counts every chat-visible method, the **real** flood producer, and the **real** fleet-health detectors. Plus 4 tests added to `obligation-store.test.ts`.

Scoped: **306 passed / 306** across 12 files. `npm run lint` clean (including `check-gateway-line-ratchet` — `gateway.ts` is **net zero** added lines; the cleanup logic lives in `obligation-store.ts`).

**Revert-checks** (each proven to fail on the bug it guards):

| Reverted | Result |
|---|---|
| `SWITCHROOM_TG_OUTBOX_PROVENANCE_FRAMING=0` | 1 failed / 20 passed — working notes delivered unlabelled, i.e. the #4141 bug reproduces |
| Drop `replyToolThrewThisTurn` from the hook's record | **5 failed / 16 passed** — proves the feature is not inert; the signal is load-bearing across every hop |
| Remove the `snapshotTrusted === false` guard | 2 failed / 19 passed, incl. `expected 'internal' to be 'user'` — the #4146 swallow reproduces |

**Disjointness from `detect.ts` (asserted, not inspected).** Through the real `buildTurnRecord` + real `detectTurnFindings`: a framed turn has `tools === 1` and `route === 'none'` and yields **zero** `silent-no-op-candidate` findings — because it has tool calls, and the silent-no-op branch requires `tools === 0`. A control row (`tools: 0`, legacy shape) yields exactly **1** finding, proving the detector is not simply blinded. The telemetry line matches no `GATEWAY_SIGNATURES` and produces no `detectGatewayFindings`, while still carrying a joinable `turnId`. And `sweepOutbox` only *reads* `getTurnsDb`; it writes nothing to `turns.jsonl`, so it cannot rewrite `route`.

**Which machines carry the leak** (correcting an earlier, wrong claim in this body that there is "exactly one reader/deliverer" — that is true of outbox *records*, and false of the leak):

The captured prose reaches chat by **two** machines, and which one runs depends on whether the thrown reply's *input text* happened to qualify as a final answer:

| Shape | Hook branch | Deliverer | Framed by |
|---|---|---|---|
| Thrown reply qualified (`isFinalAnswerReply` on the input) | #3510 defer → single-writer election | captured-prose **bridge** (`deliverCapturedProse`) | this PR's elected-path fix |
| Thrown reply did not qualify (interim ack) | outbox capture, `process.exit(0)` | outbox **sweep** (`sweepOutbox`) | this PR's sweep-path fix |

They are mutually exclusive — the capture branch exits the hook, so on the elected path **no outbox record exists at all**. Turn flush is a third machine but provably cannot carry this leak (see below). The other outbox record writer, `gateway/flood-reply-queue.ts`, writes no throw signal and delivers unframed — correct, since a flood-blocked reply returns a normal tool result (`outbound-send-path.ts:2056`) and is a real reply.

`readOutboxRecord` is a bare `JSON.parse` cast with no field stripping, so the new record field survives every hop on the sweep path.

## Review round 2 — the MAJOR, and what it changed

Review found the first cut put the banner **only on the outbox sweep**, which never fires on the dominant live shape, so #4141 was not actually closed.

Root cause, verified in source: `scanForOutboxCapture` classifies a reply-tool call as a delivery from its **input** alone (`isFinalAnswerReply`, `hooks/silent-end-scan.mjs:1008`) and never reads the `tool_result`. A **qualifying** final-answer reply that **threw** therefore still sets `replyAlreadyDeliveredThisTurn`, the hook takes the #3510 branch (`hooks/silent-end-interrupt-stop.mjs:305`), writes **no outbox record**, and falls through to the single-writer election — which hands the prose to the captured-prose bridge. `decideCapturedProseDelivery` knew nothing about the throw, so it shipped unframed.

One correction to the reported mechanism: the record write and the election are **mutually exclusive** (the capture branch `process.exit(0)`s), so on the elected path there is no record at all — the gap is strictly worse than described. The reachable scan reason is `trailing-text-after-reply`, not `no-final-reply`.

Fixed by option (a) — extend the same shared framing to the elected path:

| File | What |
|---|---|
| `hooks/silent-end-scan.mjs` | `scanTurnForFinalReply` derives the same errored-`tool_result` ∩ reply-`tool_use` signal and carries it on the BLOCK result. Read-only — nothing branches on it, so no verdict changes |
| `hooks/silent-end-interrupt-stop.mjs` | `buildNextState` persists it on the elected state file, explicitly **deleted** when this turn saw no throw (same stale-carryover discipline as `pendingText`/`turnId`) |
| `silent-end.ts` | `SilentEndState.replyToolThrewThisTurn`, surfaced on `CapturedProseDecision` **after** every `deliver:false` gate, so labelling can never become an input to whether we deliver |
| `gateway/stream-render.ts`, `gateway/gateway.ts` | forward it to the bridge |
| `gateway/outbound-send-path.ts` | `deliverCapturedProse` applies the shared `applyReplyThrowFraming`, journals `framedProvenance: 'reply-throw'`, emits one telemetry line, same kill switch |

**Additive-by-construction re-established, not assumed.** This path has its own send ladder and its own dedup, so the sweep's proof does not transfer. Framing is applied only to the bytes handed to Telegram; the dedup check/record and the journal's `textSha256` keep using the **raw** text, so the label cannot change what counts as "the same answer" and exactly-once-among-backstops is untouched. Asserted: a second, unframed call with the same raw prose dedups to **zero** new sends.

**Turn flush needs no framing — structurally, not by judgement.** `turn.replyCalled` is set on the reply tool's **call** event (`gateway/stream-render.ts:1196`), before any result exists, so a thrown reply still sets it; `decideTurnFlush` skips outright on `replyCalled` (`turn-flush-safety.ts:347`). A reply-throw turn can never reach the flush send site. Asserted.

**Review low, also fixed:** the #4146 reader-side guard now distrusts the snapshot under STATIC as well as ledger-off (`gateway.ts:1343` gates the same `onChange` wiring on STATIC at `:2810`). Writer-side cleanup already covered STATIC at boot; this covers the window it cannot — a failed unlink, or no restart yet. Honest caveat, stated in the comment: `TELEGRAM_ACCESS_MODE` is host-supplied and set nowhere in this repo, so if it is not exported into the hook's environment this leg no-ops and the unlink remains the cover. It can only ever move the verdict toward **deliver**.

**Round-2 verification.** 11 new outcome tests through the real hook subprocess, the real `decideCapturedProseDelivery`, and the real `deliverCapturedProse` against the recording fake Bot API — including a PREMISE test proving **no outbox record is written** on this shape (the fact the first cut missed), and a structural pin on the one `stream-render` argument that cannot be driven in isolation (it lives inside a ~2000-line handler with the whole gateway as its closure; without it the feature is inert in production while every other test still passes).

New revert-checks:

| Reverted | Result |
|---|---|
| `SWITCHROOM_TG_OUTBOX_PROVENANCE_FRAMING=0` | **2 failed / 29 passed** — the leak now reproduces on **both** paths |
| Drop the elected-state stamp (`buildNextState`) | **3 failed / 28 passed**, incl. the stale-carryover test — proves the signal is load-bearing end to end |

Scoped: 416/416 across 21 files; full plugin vitest 8623 passed, 1 failed (the known `approval-hold-record` uid-0 environment artifact, fails identically on pristine main). `npm run lint` clean; `gateway.ts` still **net zero** added lines.

## Contradiction to report

The coordinator's steer framed this slice as "extending suppression into the foreground class", which would remove the ledger's last backstop. **It does not.** This change never suppresses — it frames and always delivers. #4146 is still fixed here because it is a genuine pre-existing hole in #4140's *background* suppression path.

## Observation (not fixed here)

`silent-no-op-candidate` at severity 3 is effectively unreachable via `buildTurnRecord` for `route === 'none'`: `computeTurnStatus` / `computeTurnRoute` make `status === 'complete'` and `route === 'none'` mutually unreachable, so the live sev-3 path is the *legacy* branch (`route` field absent, `ts >= routeFieldShipTs`). Worth a look independently; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
