### PR TITLE
test(scaffold): key the context7 trust assertion by the agent's own project path

### DIFF
--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -770,20 +770,28 @@ describe("scaffoldAgent", () => {
     const claudeJson = JSON.parse(
       readFileSync(join(result.agentDir, ".claude", ".claude.json"), "utf-8"),
     );
-    const projectEntry = Object.values(
-      claudeJson.projects as Record<string, { enabledMcpjsonServers?: string[] }>,
-    )[0];
+    // Key by the agent's OWN project path, never the first entry of the
+    // projects map. scaffoldAgent copies the host's onboarding state, so
+    // `projects` also carries whatever directories the operator has already
+    // used Claude Code in. On a machine with any such history the first
+    // entry is one of those (with an empty `enabledMcpjsonServers`) and the
+    // assertion failed for a reason unrelated to the guarantee under test,
+    // while passing on a clean CI runner (#4106).
+    const projectKey = resolve(result.agentDir);
+    const projectEntry = (
+      claudeJson.projects as Record<string, { enabledMcpjsonServers?: string[] }>
+    )[projectKey];
     expect(projectEntry?.enabledMcpjsonServers).toContain("context7");
     // Reconcile must keep it trusted (the path every deployed agent takes).
     reconcileAgent("ctx7-trust", config, tmpDir, telegramConfig, switchroomConfig);
     const after = JSON.parse(
       readFileSync(join(result.agentDir, ".claude", ".claude.json"), "utf-8"),
     );
-    for (const p of Object.values(
-      after.projects as Record<string, { enabledMcpjsonServers?: string[] }>,
-    )) {
-      expect(p.enabledMcpjsonServers).toContain("context7");
-    }
+    expect(
+      (after.projects as Record<string, { enabledMcpjsonServers?: string[] }>)[
+        projectKey
+      ]?.enabledMcpjsonServers,
+    ).toContain("context7");
   });
 
   it("context7 opt-out removes BOTH the .mcp.json entry and the pre-approval", () => {


### PR DESCRIPTION
Closes #4106.

`tests/scaffold.test.ts > context7 lands on the .claude.json MCP trust allowlist` fails on a pristine `origin/main` worktree on this host, and passes on a clean CI runner. The bug is in the test, not the scaffold.

## Cause

`scaffoldAgent` copies the host's onboarding state, so the resulting `.claude.json` `projects` map carries every directory the operator has already used Claude Code in. The test read `Object.values(projects)[0]`, which on this host resolves to `/home/kenthompson` — an unrelated entry with an empty `enabledMcpjsonServers` — instead of the agent directory it just scaffolded:

```
DBG-PROJECTS {
 "/home/kenthompson": {
  "enabledMcpjsonServers": [],
  ...
```

The post-reconcile half had the same defect in a worse form: it looped over *every* project and asserted each contains `context7`, which the scaffold never promises about the operator's own unrelated directories.

## Fix

Key both assertions by `resolve(result.agentDir)` — the guarantee the test exists to pin.

## Verification

- `npx vitest run tests/scaffold.test.ts` → 241 passed.
- **Mutation-checked:** stubbing out the post-`preTrustWorkspace` `ensureMcpServersTrusted(agentDir, mcpServerKeysToTrust)` pass in `src/agents/scaffold.ts` makes exactly this test fail (`1 failed | 239 skipped`); restoring it passes. The test still guards the thing it claims to guard.

No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
