### PR TITLE
fix(assets): one shared resolver for shipped profiles/skills/vendor (SEA binary)

### DIFF
--- a/src/agents/profiles.test.ts
+++ b/src/agents/profiles.test.ts
@@ -9,6 +9,8 @@ import {
   renderProfileClaudeTemplate,
   renderVaultProtocolFragment,
   resolveProfilesRoot,
+  resolveProfilesRootDetailed,
+  PROFILES_ROOT_SEARCH,
 } from "./profiles.js";
 import { scaffoldAgent } from "./scaffold.js";
 import type { AgentConfig, TelegramConfig } from "../config/schema.js";
@@ -40,6 +42,21 @@ describe("resolveProfilesRoot (#3346)", () => {
     const root = resolveProfilesRoot();
     expect(existsSync(root)).toBe(true);
     expect(existsSync(join(root, "default"))).toBe(true);
+  });
+
+  it("probes SEA-layout candidates too, so a published binary can find profiles (#4160)", () => {
+    // The published `bun build --compile` binary sees
+    // `import.meta.dirname === "/$bunfs/root"`, so both pre-#4160
+    // candidates collapsed to `/profiles` and `switchroom apply` failed
+    // for every agent. The resolver must ALSO probe locations anchored on
+    // the real binary (process.execPath) and the FHS share roots.
+    delete process.env[ENV_KEY];
+    const detailed = resolveProfilesRootDetailed();
+    expect(detailed.candidates).toContain("/usr/local/share/switchroom/profiles");
+    expect(detailed.candidates).toContain("/usr/share/switchroom/profiles");
+    // And the search list is what an error message would report — every
+    // path tried, not just the first.
+    expect(PROFILES_ROOT_SEARCH.length).toBeGreaterThanOrEqual(4);
   });
 
   it("does not resolve to the historically-broken /profiles path", () => {

--- a/src/agents/profiles.ts
+++ b/src/agents/profiles.ts
@@ -1,6 +1,12 @@
 import { readFileSync, writeFileSync, existsSync, readdirSync, statSync, copyFileSync, mkdirSync, realpathSync } from "node:fs";
 import { resolve, join, sep as pathSep } from "node:path";
 import Handlebars from "handlebars";
+import {
+  PROFILES_ASSET,
+  describeShippedAssetSearch,
+  resolveShippedAsset,
+  type ShippedAssetResolution,
+} from "../util/shipped-assets.js";
 
 /**
  * Resolve the root of the filesystem profiles directory (project-level).
@@ -10,46 +16,35 @@ import Handlebars from "handlebars";
  * (start.sh.hbs, settings.json.hbs) that every agent uses regardless
  * of their `extends:` choice.
  *
- * The bundle can live in two layouts and the profiles dir sits in a
- * DIFFERENT relative spot in each — a single hardcoded relative path
- * only works for one and silently breaks the other (#3346):
+ * The bundle ships in three layouts and the profiles dir sits in a
+ * DIFFERENT place in each. The candidate probe lives in
+ * `src/util/shipped-assets.ts` so `profiles/`, `skills/` and
+ * `vendor/hindsight-memory/` cannot drift apart again (#3346, #3492,
+ * #4160). `SWITCHROOM_PROFILES_ROOT` still wins outright.
  *
- *   - npm / dev layout: bundle at `<pkg>/dist/cli/switchroom.js`, so
- *     profiles are two dirs up at `<pkg>/profiles` (`../../profiles`).
- *   - agent Docker image: bundle at `/opt/switchroom/switchroom.js`,
- *     so `../../profiles` resolves to `/profiles` — a path the image
- *     never shipped, which broke every in-container `rollout`/`apply`
- *     with `Profile not found: default (searched /profiles)`. The
- *     Dockerfile now COPYs profiles to `/opt/switchroom/profiles`, i.e.
- *     `./profiles` relative to the bundle dir.
- *
- * Rather than hardcode one relative path, probe an ordered list of
- * candidates and pick the first that actually exists on disk. The
- * `SWITCHROOM_PROFILES_ROOT` env override wins for tests and operator
- * escape hatches. If none exist we fall back to the npm-layout path so
- * the downstream "Profile not found" error still names a sensible root.
+ * If nothing exists we return the npm-layout path so the historical
+ * error shape survives — but the error now also names EVERY candidate
+ * (`PROFILES_ROOT_SEARCH`). "searched /profiles" named a path no
+ * install has ever used, which is why #4160 read as a mystery.
  */
-export function resolveProfilesRoot(): string {
-  const envOverride = process.env.SWITCHROOM_PROFILES_ROOT?.trim();
-  if (envOverride) {
-    return resolve(envOverride);
-  }
-  const candidates = [
-    // npm / dev layout: <pkg>/dist/cli -> <pkg>/profiles
-    resolve(import.meta.dirname, "../../profiles"),
-    // agent Docker image: /opt/switchroom -> /opt/switchroom/profiles
-    resolve(import.meta.dirname, "profiles"),
-  ];
-  for (const candidate of candidates) {
-    if (existsSync(candidate)) {
-      return candidate;
-    }
-  }
-  // Preserve the historical default so error messages stay meaningful.
-  return candidates[0];
+export function resolveProfilesRootDetailed(): ShippedAssetResolution {
+  return resolveShippedAsset(PROFILES_ASSET, {
+    bundleDir: import.meta.dirname,
+    execPath: process.execPath,
+  });
 }
 
-export const PROFILES_ROOT = resolveProfilesRoot();
+export function resolveProfilesRoot(): string {
+  const resolution = resolveProfilesRootDetailed();
+  return resolution.path ?? resolution.candidates[0];
+}
+
+const PROFILES_RESOLUTION = resolveProfilesRootDetailed();
+export const PROFILES_ROOT =
+  PROFILES_RESOLUTION.path ?? PROFILES_RESOLUTION.candidates[0];
+/** Every path probed while resolving PROFILES_ROOT — for error messages. */
+export const PROFILES_ROOT_SEARCH: readonly string[] =
+  PROFILES_RESOLUTION.candidates;
 
 /**
  * Resolve the filesystem path for a named profile. Falls back to
@@ -93,7 +88,15 @@ export function getProfilePath(profileName: string): string {
   if (existsSync(fallback)) {
     return fallback;
   }
-  throw new Error(`Profile not found: ${profileName} (searched ${PROFILES_ROOT})`);
+  // Name EVERY path that was probed. When PROFILES_ROOT itself is the
+  // "nothing existed" fall-through (the SEA case, #4160), reporting only
+  // it tells the operator switchroom looked somewhere it never could
+  // have found anything.
+  const searched =
+    PROFILES_RESOLUTION.path === null
+      ? describeShippedAssetSearch(PROFILES_RESOLUTION)
+      : PROFILES_ROOT;
+  throw new Error(`Profile not found: ${profileName} (searched ${searched})`);
 }
 
 function hasProfileFiles(dir: string): boolean {

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -25,6 +25,12 @@ import { CRON_SCRIPT_BASENAME_RE, LEGACY_CRON_SCRIPT_BASENAME_RE } from "./cron-
 import { expandModelAlias } from "./model-aliases.js";
 import { atomicWriteFileSync } from "../util/atomic.js";
 import {
+  HINDSIGHT_VENDOR_ASSET,
+  describeShippedAssetSearch,
+  resolveShippedAsset,
+  type ShippedAssetResolution,
+} from "../util/shipped-assets.js";
+import {
   alignAgentTreeOwnershipIfRoot,
   findAgentUnreadablePaths,
   scopedAssertCandidates,
@@ -3098,11 +3104,19 @@ Thumbs.db
 }
 
 /**
- * Vendored hindsight-memory plugin location inside the switchroom repo.
- * Pinned to the version we ship; updated by `switchroom update`.
+ * Vendored hindsight-memory plugin location. Pinned to the version we
+ * ship; updated by `switchroom update`.
+ *
+ * Shares the shipped-asset probe with profiles/ and skills/ (#4160) —
+ * the bare `resolve(import.meta.dirname, "../../vendor/hindsight-memory")`
+ * resolved to `/vendor/hindsight-memory` inside a `bun build --compile`
+ * binary, where `import.meta.dirname` is the bunfs virtual root.
  */
-function resolveHindsightVendorPath(): string {
-  return resolve(import.meta.dirname, "../../vendor/hindsight-memory");
+function resolveHindsightVendorResolution(): ShippedAssetResolution {
+  return resolveShippedAsset(HINDSIGHT_VENDOR_ASSET, {
+    bundleDir: import.meta.dirname,
+    execPath: process.execPath,
+  });
 }
 
 /**
@@ -3170,8 +3184,8 @@ export function installHindsightPlugin(
     return null;
   }
 
-  const sourcePath = resolveHindsightVendorPath();
-  if (!existsSync(sourcePath)) {
+  const vendorResolution = resolveHindsightVendorResolution();
+  if (vendorResolution.path === null) {
     // Loud about it: a missing vendor dir means the npm tarball was
     // packed without the `vendor/` entry (regression of the bug fixed
     // in this PR — `files` array in package.json must include
@@ -3179,12 +3193,14 @@ export function installHindsightPlugin(
     // never refreshing the hindsight plugin tree on existing agents,
     // forcing manual sed workarounds across 9 agents.
     process.stderr.write(
-      `installHindsightPlugin: vendor source missing at ${sourcePath} ` +
+      `installHindsightPlugin: vendor source missing ` +
+        `(${describeShippedAssetSearch(vendorResolution)}) ` +
         `— hindsight plugin NOT installed for ${agentName}. ` +
         `Likely a packaging regression: check the npm tarball's files array.\n`,
     );
     return null;
   }
+  const sourcePath = vendorResolution.path;
 
   // Copy the vendored plugin into the agent's .claude/plugins dir.
   // Force overwrite on every reconcile so plugin updates from

--- a/src/cli/update-shipped-skills.test.ts
+++ b/src/cli/update-shipped-skills.test.ts
@@ -1,0 +1,154 @@
+/**
+ * #4161 — `sync-bundled-skills` must not report SUCCESS when it could
+ * not find the shipped `skills/` payload.
+ *
+ * Pre-fix the step resolved its source as
+ * `resolve(import.meta.dirname, "../../skills")`, which inside a
+ * `bun build --compile` binary (`import.meta.dirname === "/$bunfs/root"`)
+ * is `/skills`. It wrote one stderr line and RETURNED — the step was
+ * ticked green, the pool at `~/.switchroom/skills/_bundled/` went
+ * un-refreshed for weeks, and `switchroom apply` then told the operator
+ * to "re-run `switchroom update` to repair the pool", i.e. to re-run the
+ * very step that was broken.
+ *
+ * These tests drive the REAL step body with an injected layout probe, so
+ * they fail on the pre-fix behaviour (silent return, no throw, no
+ * warning) rather than merely walking the code path.
+ */
+
+import { describe, it, expect } from "vitest";
+import { planUpdate } from "./update.js";
+import type { InstallProbe } from "./self-update.js";
+
+/** The layout a published static binary actually sees: virtual bundle
+ *  dir, real binary on disk, and no shipped payload anywhere. */
+const SEA_LAYOUT_NO_PAYLOAD = {
+  bundleDir: "/$bunfs/root",
+  execPath: "/usr/local/bin/switchroom",
+  env: {},
+  exists: () => false,
+};
+
+const installProbe = (
+  over: Partial<InstallProbe> = {},
+): InstallProbe => ({
+  bundleDir: "/$bunfs/root",
+  execPath: "/usr/local/bin/switchroom",
+  scriptPath: "/usr/local/bin/switchroom",
+  inContainer: false,
+  ...over,
+});
+
+function syncStep(opts: Parameters<typeof planUpdate>[0]) {
+  return planUpdate({ composePath: "unused", ...opts }).find(
+    (s) => s.name === "sync-bundled-skills",
+  )!;
+}
+
+describe("sync-bundled-skills with no shipped skills/ payload", () => {
+  it("FAILS the step on a published static binary (packaging defect)", () => {
+    const step = syncStep({
+      hostControlEnabled: false,
+      webServiceManaged: false,
+      memoryBackendHindsight: false,
+      shippedSkillsProbe: SEA_LAYOUT_NO_PAYLOAD,
+      installProbe: installProbe(),
+    });
+    // The bug: this used to return normally.
+    expect(() => step.run()).toThrow(/sync-bundled-skills/);
+    let message = "";
+    try {
+      step.run();
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    // The error must name every path tried, so the operator can stage one.
+    expect(message).toContain("/usr/local/share/switchroom/skills");
+    expect(message).toContain("/usr/share/switchroom/skills");
+    expect(message).toContain("static-binary");
+  });
+
+  it("FAILS the step inside a container image (payload is part of the image)", () => {
+    const step = syncStep({
+      hostControlEnabled: false,
+      webServiceManaged: false,
+      memoryBackendHindsight: false,
+      shippedSkillsProbe: {
+        bundleDir: "/opt/switchroom",
+        execPath: "/usr/local/bin/bun",
+        env: {},
+        exists: () => false,
+      },
+      installProbe: installProbe({ inContainer: true }),
+    });
+    expect(() => step.run()).toThrow(/packaging defect/);
+  });
+
+  it("FAILS the step on an npm install", () => {
+    const step = syncStep({
+      hostControlEnabled: false,
+      webServiceManaged: false,
+      memoryBackendHindsight: false,
+      shippedSkillsProbe: {
+        bundleDir: "/usr/lib/node_modules/switchroom/dist/cli",
+        execPath: "/usr/local/bin/node",
+        env: {},
+        exists: () => false,
+      },
+      installProbe: installProbe({
+        bundleDir: "/usr/lib/node_modules/switchroom/dist/cli",
+        scriptPath: "/usr/lib/node_modules/switchroom/dist/cli/switchroom.js",
+      }),
+    });
+    expect(() => step.run()).toThrow(/packaging defect/);
+  });
+
+  it("does NOT fail a source checkout, but records a surfaced warning", () => {
+    // A local dev layout without an adjacent skills/ is unusual, not a
+    // shipping defect — failing hard there would be the regression the
+    // fix must avoid. It still must not look like a clean run.
+    const warningSink: string[] = [];
+    const step = syncStep({
+      hostControlEnabled: false,
+      webServiceManaged: false,
+      memoryBackendHindsight: false,
+      shippedSkillsProbe: {
+        bundleDir: "/home/dev/switchroom/dist/cli",
+        execPath: "/usr/local/bin/bun",
+        env: {},
+        exists: () => false,
+      },
+      installProbe: installProbe({
+        bundleDir: "/home/dev/switchroom/dist/cli",
+        scriptPath: "/home/dev/switchroom/dist/cli/switchroom.js",
+      }),
+      warningSink,
+    });
+    expect(() => step.run()).not.toThrow();
+    // The bug this guards: a lone stderr line inside a long log, with the
+    // step ticked green and nothing in the summary.
+    expect(warningSink).toHaveLength(1);
+    expect(warningSink[0]).toMatch(/sync-bundled-skills SKIPPED/);
+    expect(warningSink[0]).toContain("skills/_bundled");
+  });
+
+  it("still copies normally when the payload IS found (no regression)", () => {
+    // Proves the loud path is gated on the MISSING case only: with a
+    // resolvable payload the step runs its real body. The test seam
+    // `syncBundledSkillsFn` stands in for the filesystem copy so this
+    // never writes to the operator's real ~/.switchroom.
+    let copied = 0;
+    const step = syncStep({
+      hostControlEnabled: false,
+      webServiceManaged: false,
+      memoryBackendHindsight: false,
+      syncBundledSkillsFn: () => {
+        copied += 1;
+      },
+      shippedSkillsProbe: SEA_LAYOUT_NO_PAYLOAD,
+      installProbe: installProbe(),
+    });
+    expect(() => step.run()).not.toThrow();
+    expect(copied).toBe(1);
+  });
+});

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -60,8 +60,15 @@ import {
   planSelfUpdate,
   releaseAssetName,
   SELF_UPDATE_ENV_SENTINEL,
+  type InstallKind,
   type SelfUpdateIO,
 } from "./self-update.js";
+import {
+  SKILLS_ASSET,
+  describeShippedAssetSearch,
+  resolveShippedAsset,
+  type ShippedAssetProbe,
+} from "../util/shipped-assets.js";
 import { defaultSelfUpdateIO } from "./self-update-io.js";
 import { resolveSelfInvocation } from "./self-invoke.js";
 import {
@@ -203,6 +210,11 @@ interface UpdateOptions {
   latestReleaseTagFn?: () => Promise<string | null>;
   /** Test seam — override install-kind detection inputs. */
   installProbe?: Parameters<typeof detectInstallKind>[0];
+  /** Test seam — override the layout probe `sync-bundled-skills` uses to
+   *  find the shipped `skills/` payload. Lets a test simulate the SEA
+   *  layout (bunfs bundle dir + no on-disk payload), which is otherwise
+   *  unreachable from a vitest run. */
+  shippedSkillsProbe?: ShippedAssetProbe;
   /** Test seam — exec used by the component-version inventory. */
   componentExec?: ExecFn;
   /**
@@ -213,6 +225,14 @@ interface UpdateOptions {
    * decision in one place.
    */
   selfUpdateSink?: { replacedWith?: string; binaryPath?: string };
+  /**
+   * Mutable sink for NON-FATAL step warnings. Same shared-holder pattern
+   * as `selfUpdateSink`: a step that completed but could not do its whole
+   * job pushes an operator-facing line here, and `runUpdate` reprints the
+   * lot in the final summary. A degraded step must not look identical to
+   * a clean one in the transcript (#4161).
+   */
+  warningSink?: string[];
   /** Test seam — replace the re-exec of the freshly installed binary. */
   reexecFn?: (binaryPath: string, args: string[]) => { status: number };
   /** Test seam — override the /etc/cron.d/hindsight-watch path the
@@ -247,6 +267,21 @@ const DEFAULT_COMPOSE_PATH = join(
   "compose",
   "docker-compose.yml",
 );
+
+/**
+ * Install kinds where the shipped asset payloads (`skills/`, `profiles/`,
+ * `vendor/`) are part of the artifact itself. If one is missing on these,
+ * the artifact is broken — the update must fail rather than tick a step
+ * green it could not perform (#4161). `source-checkout` and `unknown` are
+ * deliberately absent: a local layout without an adjacent `skills/` is
+ * unusual but not a shipping defect, so those degrade to a surfaced
+ * warning instead.
+ */
+const PACKAGED_INSTALL_KINDS: ReadonlySet<InstallKind> = new Set<InstallKind>([
+  "static-binary",
+  "npm-global",
+  "container",
+]);
 
 /**
  * Detect whether the running CLI lives inside a git checkout (so
@@ -453,6 +488,7 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
   const composePath = opts.composePath ?? DEFAULT_COMPOSE_PATH;
   const runner = opts.runner ?? defaultRunner;
   const scriptPath = opts.scriptPath ?? process.argv[1] ?? "";
+  const warningSink = opts.warningSink ?? [];
   // #3963: every self-invoking step below must NOT pass a compiled
   // binary's bunfs bundle path as argv[1] — the binary is its own
   // entrypoint and commander would parse the path as the subcommand.
@@ -989,21 +1025,65 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
         opts.syncBundledSkillsFn();
         return;
       }
-      // SOURCE: the skills/ directory shipped alongside the running
-      // CLI bundle. `import.meta.dirname` is dist/cli/ at runtime; the
-      // skills/ payload lives two levels up beside dist/ (see package
-      // .json "files" — skills/ is shipped). This is the only place
-      // the legacy `resolve(import.meta.dirname, "../../skills")`
-      // expression is still correct, because here it really IS the
-      // source for the copy.
-      const source = resolve(import.meta.dirname, "../../skills");
+      // SOURCE: the shipped skills/ payload. Resolved through the SAME
+      // probe as profiles/ and vendor/ (src/util/shipped-assets.ts) —
+      // the old bare `resolve(import.meta.dirname, "../../skills")`
+      // became `/skills` inside a `bun build --compile` binary, where
+      // `import.meta.dirname` is the bunfs virtual root, so this step
+      // silently no-op'd on every published-binary host while still
+      // being ticked green (#4161).
+      const resolution = resolveShippedAsset(
+        SKILLS_ASSET,
+        opts.shippedSkillsProbe ?? {
+          bundleDir: import.meta.dirname,
+          execPath: process.execPath,
+        },
+      );
       const dest = join(homedir(), ".switchroom", "skills", "_bundled");
-      if (!existsSync(source)) {
-        process.stderr.write(
-          `switchroom update: sync-bundled-skills — CLI bundle has no adjacent skills/ at ${source}; skipping.\n`,
+      if (resolution.path === null) {
+        // A step that cannot do its job must NOT report success. On a
+        // PACKAGED install (published binary / npm / container image)
+        // the skills payload is part of the artifact, so its absence is
+        // a packaging defect: fail the step and stop the update rather
+        // than leave the pool stale and every agent's CLAUDE.md
+        // pointing at default skills that never reach it.
+        //
+        // A source checkout (or an install we cannot classify) is the
+        // one case where "no adjacent skills/" can be a legitimate
+        // local layout, so that stays a warning — but a warning the
+        // final summary reprints, not a lone stderr line buried in a
+        // long log.
+        const detection = detectInstallKind(
+          opts.installProbe ?? {
+            bundleDir: import.meta.dirname,
+            execPath: process.execPath,
+            scriptPath,
+            inContainer:
+              process.env.SWITCHROOM_HOSTD_CONTEXT === "1" ||
+              existsSync("/.dockerenv"),
+          },
         );
+        const detail =
+          `no shipped skills/ payload found for this install ` +
+          `(${detection.kind}; ${describeShippedAssetSearch(resolution)})`;
+        if (PACKAGED_INSTALL_KINDS.has(detection.kind)) {
+          throw new Error(
+            `sync-bundled-skills: ${detail}. Every packaged switchroom ` +
+              `artifact ships skills/, so this is a packaging defect, not an ` +
+              `operator opt-out — the bundled pool at ${dest} cannot be ` +
+              `repaired by re-running \`switchroom update\`. Stage the payload ` +
+              `at /usr/local/share/switchroom/skills (or point ` +
+              `${SKILLS_ASSET.envVar} at a checkout's skills/) and re-run.`,
+          );
+        }
+        const warning =
+          `sync-bundled-skills SKIPPED — ${detail}. The bundled pool at ` +
+          `${dest} was NOT refreshed; default skills may be missing or stale.`;
+        process.stderr.write(`switchroom update: ${warning}\n`);
+        warningSink.push(warning);
         return;
       }
+      const source = resolution.path;
       try {
         mkdirSync(dirname(dest), { recursive: true });
         // Manifest-owned ADDITIVE sync (footgun B): copies/updates every
@@ -1597,7 +1677,19 @@ async function runUpdate(opts: UpdateOptions): Promise<number> {
   // loop below knows it must re-exec the NEW code for the remaining steps.
   const selfUpdateSink: { replacedWith?: string; binaryPath?: string } =
     opts.selfUpdateSink ?? {};
-  const steps = planUpdate({ ...opts, selfUpdateSink });
+  // Non-fatal degradations a step reports. Reprinted in the summary so a
+  // partially-working run never reads like a clean one (#4161).
+  const warningSink: string[] = opts.warningSink ?? [];
+  const steps = planUpdate({ ...opts, selfUpdateSink, warningSink });
+  const renderWarnings = (): void => {
+    if (warningSink.length === 0) return;
+    stdout(
+      chalk.yellow(
+        `\n⚠ ${warningSink.length} step(s) completed WITHOUT doing their full job:\n`,
+      ),
+    );
+    for (const w of warningSink) stdout(chalk.yellow(`  • ${w}\n`));
+  };
 
   if (opts.check) {
     stdout(chalk.bold("switchroom update --check (dry-run)\n\n"));
@@ -1652,6 +1744,7 @@ async function runUpdate(opts: UpdateOptions): Promise<number> {
       stderr(
         chalk.red(`✗ ${step.name} failed: ${(err as Error).message}\n`),
       );
+      renderWarnings();
       // Even on failure, emit the sentinel if any deferred steps exist so
       // the server can record which steps were left pending (#2458).
       const deferredOnFailure = steps
@@ -1663,7 +1756,12 @@ async function runUpdate(opts: UpdateOptions): Promise<number> {
       return 1;
     }
   }
-  stdout(chalk.green("\n✓ update complete\n"));
+  renderWarnings();
+  stdout(
+    warningSink.length > 0
+      ? chalk.yellow(`\n✓ update complete (with ${warningSink.length} warning(s))\n`)
+      : chalk.green("\n✓ update complete\n"),
+  );
   // Emit the structured sentinel when any steps were deferred so the server
   // can populate StatusEntry.deferred without parsing human output (#2458).
   const deferred = steps

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -1959,13 +1959,13 @@ export class HostdServer {
   /**
    * Apply-asset preflight. `apply` / `update_apply` shell out to the
    * bundled `switchroom` CLI, which resolves profiles + the vendored
-   * hindsight plugin RELATIVE TO ITSELF (no path arg):
-   *   profiles.ts:  resolve(import.meta.dirname,"../../profiles")
-   *   scaffold.ts:  resolve(import.meta.dirname,"../../vendor/hindsight-memory")
-   * The `update` flow ALSO resolves a package-relative asset the same
-   * way — `sync-bundled-skills` mirrors the shipped `skills/` payload
-   * into the host pool:
-   *   update.ts:  resolve(import.meta.dirname,"../../skills")
+   * hindsight plugin RELATIVE TO ITSELF (no path arg). Those three
+   * assets — `profiles/`, `vendor/hindsight-memory/` (scaffold.ts) and
+   * `skills/` (update.ts's `sync-bundled-skills`) — now share one probe,
+   * `resolveShippedAsset` in src/util/shipped-assets.ts (#4160/#4161).
+   * Inside the hostd image its FIRST candidate is the npm-shaped
+   * `<bundleDir>/../../<asset>` = `/opt/switchroom/<asset>`, which is
+   * exactly what the `root` below reproduces.
    * If the hostd image was built without those (the klanker incident
    * for profiles/vendor; the ghost-skills incident #3492-follow-up for
    * skills/), `update_apply` pulls images then either dies at

--- a/src/util/shipped-assets.test.ts
+++ b/src/util/shipped-assets.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from "vitest";
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import {
+  HINDSIGHT_VENDOR_ASSET,
+  PROFILES_ASSET,
+  SKILLS_ASSET,
+  describeShippedAssetSearch,
+  resolveShippedAsset,
+  shippedAssetCandidates,
+} from "./shipped-assets.js";
+
+/**
+ * #4160 / #4161. The published `bun build --compile` binary sees
+ * `import.meta.dirname === "/$bunfs/root"` (verified against a real
+ * compiled probe), so `resolve(import.meta.dirname, "../../profiles")`
+ * is `/profiles` and `resolve(import.meta.dirname, "../../skills")` is
+ * `/skills` — neither has ever existed on any host. `switchroom apply`
+ * failed for EVERY agent and `sync-bundled-skills` silently no-op'd.
+ *
+ * Every test here drives the resolver with an injected `exists`, so the
+ * layouts (SEA, npm/dev, Docker image) are exercised for real instead of
+ * being asserted about.
+ */
+
+const BUNFS = "/$bunfs/root";
+
+/** An `exists` probe that answers true for exactly these paths. */
+const only = (...present: string[]) => {
+  const set = new Set(present);
+  return (p: string): boolean => set.has(p);
+};
+
+describe("resolveShippedAsset — SEA (bun build --compile) layout", () => {
+  const seaProbe = {
+    bundleDir: BUNFS,
+    execPath: "/usr/local/bin/switchroom",
+    env: {},
+  };
+
+  it("never lands on the historically-broken /profiles when nothing exists", () => {
+    // The pre-fix fall-through returned candidates[0] === "/profiles".
+    const r = resolveShippedAsset(PROFILES_ASSET, {
+      ...seaProbe,
+      exists: () => false,
+    });
+    expect(r.path).toBeNull();
+    expect(r.source).toBe("none");
+  });
+
+  it("finds profiles staged beside the binary at <prefix>/share/switchroom", () => {
+    const staged = "/usr/local/share/switchroom/profiles";
+    const r = resolveShippedAsset(PROFILES_ASSET, {
+      ...seaProbe,
+      exists: only(staged),
+    });
+    expect(r.path).toBe(staged);
+    // /usr/local/bin/switchroom -> ../share/switchroom is the FIRST
+    // execPath-derived candidate, so it wins before the absolute FHS list.
+    expect(r.source).toBe("sea-sibling");
+  });
+
+  it("finds skills under an absolute FHS share root for a binary elsewhere", () => {
+    const r = resolveShippedAsset(SKILLS_ASSET, {
+      bundleDir: BUNFS,
+      execPath: "/opt/tools/switchroom",
+      env: {},
+      exists: only("/usr/share/switchroom/skills"),
+    });
+    expect(r.path).toBe("/usr/share/switchroom/skills");
+    expect(r.source).toBe("fhs");
+  });
+
+  it("still produces the FHS candidates when execPath is unavailable", () => {
+    const candidates = shippedAssetCandidates(SKILLS_ASSET, {
+      bundleDir: BUNFS,
+      execPath: "",
+    });
+    expect(candidates).toContain("/usr/local/share/switchroom/skills");
+    expect(candidates).toContain("/usr/share/switchroom/skills");
+  });
+});
+
+describe("resolveShippedAsset — layouts that already worked must keep working", () => {
+  it("npm / dev: <pkg>/dist/cli -> <pkg>/<asset>", () => {
+    const r = resolveShippedAsset(PROFILES_ASSET, {
+      bundleDir: "/srv/app/node_modules/switchroom/dist/cli",
+      execPath: "/usr/local/bin/node",
+      env: {},
+      exists: only("/srv/app/node_modules/switchroom/profiles"),
+    });
+    expect(r.path).toBe("/srv/app/node_modules/switchroom/profiles");
+    expect(r.source).toBe("npm");
+  });
+
+  it("agent / hostd Docker image: /opt/switchroom -> /opt/switchroom/<asset>", () => {
+    const r = resolveShippedAsset(SKILLS_ASSET, {
+      bundleDir: "/opt/switchroom",
+      execPath: "/usr/local/bin/bun",
+      env: {},
+      exists: only("/opt/switchroom/skills"),
+    });
+    expect(r.path).toBe("/opt/switchroom/skills");
+    expect(r.source).toBe("image");
+  });
+
+  it("prefers the npm candidate over the image one when BOTH exist", () => {
+    // Ordering is load-bearing: a source checkout has <repo>/profiles at
+    // ../.. and must not be shadowed by a stray adjacent dir.
+    const r = resolveShippedAsset(PROFILES_ASSET, {
+      bundleDir: "/repo/dist/cli",
+      execPath: "/usr/local/bin/bun",
+      env: {},
+      exists: only("/repo/profiles", "/repo/dist/cli/profiles"),
+    });
+    expect(r.path).toBe("/repo/profiles");
+  });
+
+  it("handles a nested asset path (vendor/hindsight-memory)", () => {
+    const r = resolveShippedAsset(HINDSIGHT_VENDOR_ASSET, {
+      bundleDir: BUNFS,
+      execPath: "/usr/local/bin/switchroom",
+      env: {},
+      exists: only("/usr/local/share/switchroom/vendor/hindsight-memory"),
+    });
+    expect(r.path).toBe("/usr/local/share/switchroom/vendor/hindsight-memory");
+  });
+});
+
+describe("resolveShippedAsset — env override", () => {
+  it("wins outright and is not existence-checked", () => {
+    const r = resolveShippedAsset(PROFILES_ASSET, {
+      bundleDir: "/repo/dist/cli",
+      execPath: "/usr/local/bin/bun",
+      env: { [PROFILES_ASSET.envVar]: "/tmp/my-profiles" },
+      exists: only("/repo/profiles"),
+    });
+    expect(r.path).toBe(resolve("/tmp/my-profiles"));
+    expect(r.source).toBe("env");
+  });
+
+  it("each asset has its own override key", () => {
+    expect(PROFILES_ASSET.envVar).toBe("SWITCHROOM_PROFILES_ROOT");
+    expect(SKILLS_ASSET.envVar).toBe("SWITCHROOM_SKILLS_ROOT");
+    expect(
+      new Set([
+        PROFILES_ASSET.envVar,
+        SKILLS_ASSET.envVar,
+        HINDSIGHT_VENDOR_ASSET.envVar,
+      ]).size,
+    ).toBe(3);
+  });
+});
+
+describe("failure reporting names every path tried (#4160)", () => {
+  it("lists all candidates, not just the first", () => {
+    const r = resolveShippedAsset(PROFILES_ASSET, {
+      bundleDir: BUNFS,
+      execPath: "/usr/local/bin/switchroom",
+      env: {},
+      exists: () => false,
+    });
+    const described = describeShippedAssetSearch(r);
+    // The pre-fix message was "searched /profiles" and nothing else —
+    // an operator staging profiles anywhere plausible was told switchroom
+    // had looked in a place it never could have found them.
+    expect(r.candidates.length).toBeGreaterThanOrEqual(4);
+    for (const c of r.candidates) expect(described).toContain(c);
+    expect(described).toContain("/usr/local/share/switchroom/profiles");
+    expect(described).toContain("/usr/share/switchroom/profiles");
+  });
+
+  it("de-duplicates candidates so the list stays honest", () => {
+    // /usr/local/bin/switchroom's sibling candidate IS
+    // /usr/local/share/switchroom/<asset>, which is also an FHS root.
+    const candidates = shippedAssetCandidates(SKILLS_ASSET, {
+      bundleDir: BUNFS,
+      execPath: "/usr/local/bin/switchroom",
+    });
+    expect(new Set(candidates).size).toBe(candidates.length);
+  });
+});
+
+describe("the real repo layout still resolves (no simulation)", () => {
+  // Outcome check against this checkout: the resolver must find the
+  // genuine shipped payloads from the vitest bundle dir.
+  const devProbe = { bundleDir: join(import.meta.dirname, "..", "cli"), execPath: process.execPath };
+
+  it("resolves profiles/ and it contains the default profile", () => {
+    const r = resolveShippedAsset(PROFILES_ASSET, { ...devProbe, env: {} });
+    expect(r.path).not.toBeNull();
+    expect(existsSync(join(r.path as string, "default"))).toBe(true);
+  });
+
+  it("resolves skills/", () => {
+    const r = resolveShippedAsset(SKILLS_ASSET, { ...devProbe, env: {} });
+    expect(r.path).not.toBeNull();
+    expect(existsSync(r.path as string)).toBe(true);
+  });
+});

--- a/src/util/shipped-assets.ts
+++ b/src/util/shipped-assets.ts
@@ -1,0 +1,183 @@
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+/**
+ * Resolution of a directory the switchroom CLI *ships* — `profiles/`,
+ * `skills/`, `vendor/hindsight-memory/`. One helper, used by every call
+ * site, because these sites have drifted apart three times now and each
+ * drift stranded a fleet:
+ *
+ *   - #3346  the agent Docker image: `resolve(import.meta.dirname,
+ *            "../../profiles")` → `/profiles`, a path the image never
+ *            shipped. Fixed by probing a second, image-shaped candidate.
+ *   - #3492  the same shape for `skills/` in the hostd image.
+ *   - #4160 / #4161  the published SEA (`bun build --compile`) binary.
+ *            `import.meta.dirname` inside a compiled binary is the bunfs
+ *            virtual root `/$bunfs/root` (verified: `resolve("/$bunfs/root",
+ *            "../../profiles") === "/profiles"`), so BOTH existing
+ *            candidates miss and `switchroom apply` failed for every agent
+ *            with `Profile not found: default (searched /profiles)` while
+ *            `sync-bundled-skills` silently no-op'd and still reported
+ *            success.
+ *
+ * The layouts, and the candidate each one needs:
+ *
+ *   npm / dev      bundle at `<pkg>/dist/cli/switchroom.js`  → `../../<asset>`
+ *   agent/hostd    bundle at `/opt/switchroom/switchroom.js` → `./<asset>`
+ *     Docker image
+ *   SEA binary     bundle at `/$bunfs/root` (virtual); the REAL file is
+ *                  `process.execPath`, so probe FHS share dirs next to it.
+ *
+ * Nothing here writes; it only probes. When every candidate misses, the
+ * caller gets the full candidate list so its error can name every path
+ * that was actually tried — the old fall-through returned `candidates[0]`
+ * and the operator was told switchroom "searched /profiles", a path no
+ * install has ever used.
+ */
+
+/** Absolute FHS locations a packaged install may stage shipped assets in. */
+export const FHS_SHARE_ROOTS: readonly string[] = [
+  "/usr/local/share/switchroom",
+  "/usr/share/switchroom",
+];
+
+/** Identifies one shipped asset directory and its operator escape hatch. */
+export interface ShippedAssetSpec {
+  /** Path of the asset relative to the package root, e.g. `"profiles"`. */
+  readonly asset: string;
+  /** Env var that, when set, wins outright (tests + operator escape hatch). */
+  readonly envVar: string;
+}
+
+export const PROFILES_ASSET: ShippedAssetSpec = {
+  asset: "profiles",
+  envVar: "SWITCHROOM_PROFILES_ROOT",
+};
+
+export const SKILLS_ASSET: ShippedAssetSpec = {
+  asset: "skills",
+  envVar: "SWITCHROOM_SKILLS_ROOT",
+};
+
+export const HINDSIGHT_VENDOR_ASSET: ShippedAssetSpec = {
+  asset: "vendor/hindsight-memory",
+  envVar: "SWITCHROOM_HINDSIGHT_VENDOR_ROOT",
+};
+
+/** Runtime facts the probe needs. Every field is injectable so a test can
+ *  simulate a layout it is not running under (that is the whole point —
+ *  the SEA layout is unreachable from vitest otherwise). */
+export interface ShippedAssetProbe {
+  /** `import.meta.dirname` of the CALLING bundle. */
+  bundleDir: string;
+  /** `process.execPath`. Empty/undefined disables the SEA-sibling candidate. */
+  execPath?: string;
+  /** Defaults to `process.env`. */
+  env?: Record<string, string | undefined>;
+  /** Defaults to `fs.existsSync`. */
+  exists?: (p: string) => boolean;
+}
+
+/** Which layout produced the resolved path. `"none"` when nothing existed. */
+export type ShippedAssetSource =
+  | "env"
+  | "npm"
+  | "image"
+  | "sea-sibling"
+  | "fhs"
+  | "none";
+
+export interface ShippedAssetResolution {
+  /** First candidate that exists on disk, else null. */
+  path: string | null;
+  /** EVERY path probed, in probe order. Never empty. */
+  candidates: readonly string[];
+  source: ShippedAssetSource;
+}
+
+interface Candidate {
+  path: string;
+  source: ShippedAssetSource;
+}
+
+/**
+ * The ordered candidate list for `spec`, ignoring the env override and
+ * without touching the filesystem. Exported for error messages and tests.
+ */
+export function shippedAssetCandidates(
+  spec: ShippedAssetSpec,
+  probe: ShippedAssetProbe,
+): readonly string[] {
+  return orderedCandidates(spec, probe).map((c) => c.path);
+}
+
+function orderedCandidates(
+  spec: ShippedAssetSpec,
+  probe: ShippedAssetProbe,
+): Candidate[] {
+  const out: Candidate[] = [];
+  const push = (path: string, source: ShippedAssetSource): void => {
+    if (!out.some((c) => c.path === path)) out.push({ path, source });
+  };
+
+  if (probe.bundleDir) {
+    // npm / dev: <pkg>/dist/cli -> <pkg>/<asset>
+    push(resolve(probe.bundleDir, "../..", spec.asset), "npm");
+    // agent + hostd Docker images: /opt/switchroom -> /opt/switchroom/<asset>
+    push(resolve(probe.bundleDir, spec.asset), "image");
+  }
+
+  // SEA: the bundle dir is virtual, so anchor on the real binary instead.
+  // `/usr/local/bin/switchroom` -> `/usr/local/share/switchroom/<asset>`.
+  if (probe.execPath) {
+    push(
+      resolve(dirname(probe.execPath), "../share/switchroom", spec.asset),
+      "sea-sibling",
+    );
+  }
+  for (const root of FHS_SHARE_ROOTS) {
+    push(resolve(root, spec.asset), "fhs");
+  }
+
+  return out;
+}
+
+/**
+ * Resolve a shipped asset directory.
+ *
+ * The env override wins outright and is NOT existence-checked — an
+ * operator or test pointing at a specific root wants exactly that root,
+ * and a silent fall-through to a bundled copy would hide their typo.
+ * (This preserves `resolveProfilesRoot`'s pre-#4160 behaviour.)
+ */
+export function resolveShippedAsset(
+  spec: ShippedAssetSpec,
+  probe: ShippedAssetProbe,
+): ShippedAssetResolution {
+  const env = probe.env ?? process.env;
+  const override = env[spec.envVar]?.trim();
+  if (override) {
+    const path = resolve(override);
+    return { path, candidates: [path], source: "env" };
+  }
+
+  const exists = probe.exists ?? existsSync;
+  const candidates = orderedCandidates(spec, probe);
+  for (const c of candidates) {
+    if (exists(c.path)) {
+      return { path: c.path, candidates: candidates.map((x) => x.path), source: c.source };
+    }
+  }
+  return { path: null, candidates: candidates.map((x) => x.path), source: "none" };
+}
+
+/**
+ * Human-readable "here is everything I tried" clause for an error message.
+ * Report every path — naming only the first candidate is what made #4160
+ * unactionable.
+ */
+export function describeShippedAssetSearch(
+  resolution: Pick<ShippedAssetResolution, "candidates">,
+): string {
+  return `searched ${resolution.candidates.length} location(s): ${resolution.candidates.join(", ")}`;
+}


### PR DESCRIPTION
## Summary

`#4160` and `#4161` are one root cause at two call sites. This PR replaces
three independent `import.meta.dirname`-relative asset expressions with a
single shared probe, `src/util/shipped-assets.ts`.

**Ground truth first.** The issues say `import.meta.dirname` is `/` in the SEA
build. It is actually `/$bunfs/root` — verified against a real compiled probe:

```
$ bun build --compile probe.ts --outfile probe-bin && ./probe-bin
dirname=  /$bunfs/root
execPath= /root/probe-bin
../../profiles= /profiles          <-- the reported symptom
profiles=       /$bunfs/root/profiles
```

Same derived path, same bug; `src/cli/self-update.ts:113` already documents the
`/$bunfs` prefix, and `detectInstallKind` keys off it.

### The resolver

`resolveShippedAsset(spec, probe)` probes, in order, and returns the first that
exists **plus the full candidate list**:

1. env override (`SWITCHROOM_PROFILES_ROOT`, new `SWITCHROOM_SKILLS_ROOT`,
   `SWITCHROOM_HINDSIGHT_VENDOR_ROOT`) — wins outright, not existence-checked,
   preserving `resolveProfilesRoot`'s pre-existing semantics
2. `resolve(bundleDir, "../..", asset)` — npm / dev *(unchanged, still first)*
3. `resolve(bundleDir, asset)` — agent Docker image *(unchanged)*
4. `resolve(dirname(process.execPath), "../share/switchroom", asset)` — SEA
5. `/usr/local/share/switchroom/<asset>`
6. `/usr/share/switchroom/<asset>`

De-duplicated, so `/usr/local/bin/switchroom` doesn't list its `../share`
candidate twice.

### Call sites

| site | before | after |
|---|---|---|
| `src/agents/profiles.ts` | 2 candidates, fall-through returns `candidates[0]` | shared probe; `PROFILES_ROOT_SEARCH` records every path, and `Profile not found` names all of them when nothing resolved |
| `src/cli/update.ts` sync-bundled-skills | `resolve(dirname,"../../skills")`, silent `return` on miss | shared probe; loud on miss (below) |
| `src/agents/scaffold.ts` `resolveHindsightVendorPath` | `resolve(dirname,"../../vendor/hindsight-memory")` | shared probe; stderr names every path tried |

Folded the vendor site in because it is the *same* defect and the same triple
that `src/host-control/server.ts`'s `missingApplyAssets()` already guards
together. Its doc comment (which quoted the three now-removed expressions) is
refreshed; the preflight logic itself is unchanged and still correct — inside
the hostd image the probe's first candidate is `/opt/switchroom/<asset>`, which
is exactly what that root reproduces.

### Why sync-bundled-skills fails hard (and where it doesn't)

Requirement 3 asked for a judgement call. The rule used:

- **`static-binary` / `npm-global` / `container` → throw.** These artifacts
  *contain* the payload (`package.json` `files` includes `skills`;
  `docker/Dockerfile.hostd:119` COPYs it). A missing payload is a packaging
  defect. Ticking the step green there is what produced #4161: the pool went
  un-refreshed for weeks while `apply` told the operator to "re-run
  `switchroom update` to repair the pool" — the step that was broken. The error
  names every path probed and how to stage one.
- **`source-checkout` / `unknown` → surfaced warning.** A local layout without
  an adjacent `skills/` is unusual but not a shipping defect; failing hard there
  would be the regression the brief warned about. It is no longer a lone stderr
  line: it lands in a `warningSink` that `runUpdate` reprints as
  `⚠ N step(s) completed WITHOUT doing their full job` and downgrades the final
  line to `✓ update complete (with N warning(s))`.

No new wedge: a SEA host with no staged assets already dies earlier, at
`apply-config`.

## Why

`reference/jobs/keep-the-fleet-current.md` — `switchroom update` from the
published binary was dead at `apply-config` (`Scaffolded 0/12 agents`), and the
step that repairs the skill pool was a no-op reporting success.

## Test plan

New — `src/util/shipped-assets.test.ts` (14) and
`src/cli/update-shipped-skills.test.ts` (5), plus 1 in `profiles.test.ts`. All
drive the real code with an injected `exists`/layout probe, so the SEA layout is
exercised rather than asserted about.

**Red-on-bug, proved.** Reverting only the update.ts hunk to the old silent
`return`:

```
× FAILS the step on a published static binary (packaging defect)
× FAILS the step inside a container image
× FAILS the step on an npm install
× does NOT fail a source checkout, but records a surfaced warning
✓ still copies normally when the payload IS found
Tests  4 failed | 1 passed (5)
```

Scoped runs, all green:

- `shipped-assets` + `update-shipped-skills` + `update` + `update-self-update` +
  `profiles` + `apply-asset-preflight` + `sync-bundled-skills` — 187 passed
- `tests/scaffold.test.ts` + `src/cli/apply.test.ts` + `src/agents/` +
  `src/cli/hostd.test.ts` — 825 passed, 2 skipped
- `src/host-control/` + `src/cli/hostd.test.ts` — 255 passed
- `npm run lint` — clean (all 23 guards)

## Risk

Low–medium. Candidate order is unchanged for the two layouts that already
worked, and both are pinned by tests (`npm` wins over `image` when both exist).
The behavioural change with teeth is sync-bundled-skills throwing on a packaged
install — deliberate, scoped to the case where it is a packaging defect, and
strictly more informative than the silent success it replaces.

## Known gap — deliberately NOT in this PR

**Nothing currently stages the assets for a SEA install.** `release.yml` ships
four bare binaries (`RELEASE_ASSETS` at :137) and `install.sh` copies one file;
there is no `share/switchroom/` payload. So this PR makes the SEA search
correct, honest and actionable — an operator staging profiles/skills at
`/usr/local/share/switchroom/` (per #4160's own suggested fix) is now on a
supported path, and a missing payload can no longer masquerade as success — but
shipping that payload with the release is packaging work, filed separately
rather than smuggled into an asset-resolution PR. Same follow-up covers
`REPO_ROOT` in `scaffold.ts:41` (`/` under SEA, so start.sh's
`bin/boot-self-test.sh` guard silently never fires), `src/cli/setup.ts:372`
(`examples/`) and `src/web/server.ts:719` (`ui/`).

Fixes #4160
Fixes #4161