### PR TITLE
fix(telegram): turn-completion supersede window + foreign-session reply gate (#4166)

### DIFF
--- a/telegram-plugin/flushed-turn-supersede.ts
+++ b/telegram-plugin/flushed-turn-supersede.ts
@@ -68,16 +68,32 @@
  * SYNTHETIC turn_end (it nulls the gateway's turn atom so the session can
  * move on), but the claude session's REAL turn_end arrives later, when the
  * model actually stops. A `reply` landing on the MAIN session bridge BETWEEN
- * those two events is — by construction — that turn's own answer still being
- * composed: no other work can run on the serial session in that span. So the
- * record's lifetime is now three-phase:
+ * those two events is that turn's own answer still being composed — PROVIDED
+ * nothing else on that bridge can emit a reply in the span. Two things can, and
+ * neither is covered by this window; each is closed by its own deterministic
+ * gate, and the window is only sound in combination with them:
+ *
+ *   - a FOREIGN session (a Tier-1 cheap-cron bridge, an unregistered client) —
+ *     closed by caller identity at the send path (`replyCallerIsForeignSession`,
+ *     gateway/cron-session.ts, #4172);
+ *   - a background `Task` SUB-AGENT, which runs concurrently with the parent
+ *     loop and calls `reply` over the SAME main bridge, so identity cannot see
+ *     it — closed by gateway-observed sub-agent liveness refusing the
+ *     content-gate bypass (gateway/subagent-reply-authority.ts, #4176). The
+ *     claude session's own loop is serial; its sub-agents are not, and the
+ *     earlier revision of this header asserted the stronger, false claim that
+ *     "no other work can run on the serial session in that span".
+ *
+ * So the record's lifetime is now three-phase:
  *
  *   1. OPEN (`completedAt == null`) — the flush delivered, the real turn_end
  *      has not been observed yet. The turn is still composing (Stop-hook
  *      nudge, /compact, recompose all live here). A same-session reply
  *      supersedes REGARDLESS of how long this takes — a 20-minute compaction
  *      no longer reproduces #4166. Bounded only by the
- *      `SUPERSEDE_OPEN_WINDOW_CAP_MS` crash backstop below.
+ *      `SUPERSEDE_OPEN_WINDOW_CAP_MS` crash backstop below, and — for a reply
+ *      the two gates above cannot positively attribute to the session's own
+ *      loop — by the #3429 content gate, which this phase does NOT relax.
  *   2. COMPLETED (`completedAt` set) — the real turn_end (or a proxy for it:
  *      a new turn minting, or the bridge dying) was observed. The turn's own
  *      answer either already landed or can only arrive as a bounded REPLAY of

--- a/telegram-plugin/flushed-turn-supersede.ts
+++ b/telegram-plugin/flushed-turn-supersede.ts
@@ -27,8 +27,8 @@
  * NOT fully deterministic — a residual race remains. The flush→reply direction
  * this registry covers, plus the controller's fire-time recount for the
  * reply→flush direction, close the COMMON replay-gap case (~10 s for a
- * tool-call replay; minutes for the Stop-hook-nudged recompose after a
- * proactive /compact — see DEFAULT_SUPERSEDE_TTL_MS); but if a reply
+ * tool-call replay; unbounded for the Stop-hook-nudged recompose after a
+ * proactive /compact — see the turn-completion window below, #4173); but if a reply
  * and a flush interleave so the reply's `take()` runs BEFORE the flush's
  * `record()` (a much smaller window), `take` finds no record and the duplicate
  * can still slip through. We deliberately trade that residual window for the
@@ -48,30 +48,69 @@
  * `now`. Fully unit-testable; the gateway wires the actual delete/send.
  */
 
-/** TTL after which a recorded flush is forgotten.
+/**
+ * ## The supersede window is a TURN-COMPLETION SIGNAL, not a fixed TTL (#4173)
  *
- *  Originally 60 s, sized for the ~10 s tool-replay gap. That window missed the
- *  SLOW variant of the exact class this module exists for (2026-08-01, klanker
- *  DM, msgs 25680/25682): the quiescence flush delivered the composed answer,
- *  the Stop hook told the model its prose never reached the user, and the model
- *  recomposed and called `reply` — but a proactive `/compact` ran in between
- *  (occupancy ~393 k), so the canonical reply landed **2 m 24 s** after the
- *  flush. Every layer keyed on this TTL — the registry record itself
- *  (`decideSupersede` → 'expired'), the destructive latest-ended owner tier
- *  (`latestEndedAccepted` rejected the 143 s-old turn, so not even the
- *  answer-delivered latch was reachable), and the handback window — had aged
- *  out, and the reply shipped as a second bubble.
+ * The window in which a landing reply may claim a flushed turn used to be a
+ * single constant (`DEFAULT_SUPERSEDE_TTL_MS = 60_000`). That constant was
+ * sized for the ~10 s tool-replay gap and missed the SLOW variant of the exact
+ * class this module exists for (2026-08-01, klanker DM, msgs 25680/25682): the
+ * quiescence flush delivered the composed answer, the Stop hook told the model
+ * its prose never reached the user, and the model recomposed and called
+ * `reply` — but a proactive `/compact` ran in between (occupancy ~393 k), so
+ * the canonical reply landed **2 m 24 s** after the flush. Every layer keyed
+ * on the 60 s TTL had aged out and the reply shipped as a second bubble
+ * (#4166). Widening the constant (the first attempt: 5 min) merely moves the
+ * cliff — a longer compaction reproduces the duplicate — while ALSO holding
+ * the destructive window open for foreign late repliers (#4172).
  *
- *  5 min covers the flush → Stop-hook nudge → compact → recompose → `reply`
- *  loop with margin (the turn-flush safety net itself waits minutes before
- *  firing). The longer memory stays safe because every consumer is
- *  identity-scoped: a record is only ever matched by its own `turnId`, the
- *  latest-ended tier still demands the SAME ended turn, and the handback
- *  content gate widens in the fail-safe direction (more handbacks keep the
- *  gate → fresh send, never a silent edit-over). The exact-text #546 dedup
- *  keeps its own 60 s window (`recent-outbound-dedup.ts`) — it guards
- *  byte-identical replays, a different class. */
-export const DEFAULT_SUPERSEDE_TTL_MS = 5 * 60_000
+ * The framework already holds the right signal. The flush fires a
+ * SYNTHETIC turn_end (it nulls the gateway's turn atom so the session can
+ * move on), but the claude session's REAL turn_end arrives later, when the
+ * model actually stops. A `reply` landing on the MAIN session bridge BETWEEN
+ * those two events is — by construction — that turn's own answer still being
+ * composed: no other work can run on the serial session in that span. So the
+ * record's lifetime is now three-phase:
+ *
+ *   1. OPEN (`completedAt == null`) — the flush delivered, the real turn_end
+ *      has not been observed yet. The turn is still composing (Stop-hook
+ *      nudge, /compact, recompose all live here). A same-session reply
+ *      supersedes REGARDLESS of how long this takes — a 20-minute compaction
+ *      no longer reproduces #4166. Bounded only by the
+ *      `SUPERSEDE_OPEN_WINDOW_CAP_MS` crash backstop below.
+ *   2. COMPLETED (`completedAt` set) — the real turn_end (or a proxy for it:
+ *      a new turn minting, or the bridge dying) was observed. The turn's own
+ *      answer either already landed or can only arrive as a bounded REPLAY of
+ *      an un-acked tool_call (~10 s after a bridge reconnect), so the record
+ *      stays claimable for `SUPERSEDE_COMPLETED_GRACE_MS` and then expires.
+ *   3. EXPIRED — no supersede; a genuinely late duplicate ships as a second
+ *      visible bubble (safe direction — never an edit-over).
+ *
+ * In the COMMON case (real turn_end lands seconds after the flush) this is
+ * STRICTLY NARROWER than any widened TTL — the destructive window closes ~60 s
+ * after the session actually stopped — while being unbounded-correct in the
+ * slow case. The `FlushCompletionTracker` below carries the same signal onto
+ * the ended TURN ATOM (`realEndObservedAt`) so the latest-ended owner tier
+ * (`reply-owner-resolve.ts`) applies the identical three-phase rule.
+ */
+
+/** Crash backstop for an OPEN record: if the real turn_end signal is LOST
+ *  (every loss path — bridge death, new-turn mint, gateway restart dropping
+ *  the in-memory registry — normally closes the window explicitly), an open
+ *  record is forgotten after this long. Generous by design: it exists only
+ *  for signal loss, and the failure past it is a visible duplicate, never a
+ *  silent edit-over. Operator override: `SWITCHROOM_SUPERSEDE_OPEN_CAP_MS`
+ *  (resolved in gateway.ts — this module stays env-free/pure). */
+export const SUPERSEDE_OPEN_WINDOW_CAP_MS = 30 * 60_000
+
+/** How long a COMPLETED record stays claimable after the real turn_end was
+ *  observed. Sized for the bounded replay class the original 60 s TTL was
+ *  built for: claude-code re-sending an un-acked `reply` tool_call after a
+ *  bridge reconnect (~10 s), with margin. The exact-text #546 dedup keeps its
+ *  own 60 s window (`recent-outbound-dedup.ts`) — byte-identical replays, a
+ *  different class. Operator override: `SWITCHROOM_SUPERSEDE_GRACE_MS`
+ *  (resolved in gateway.ts). */
+export const SUPERSEDE_COMPLETED_GRACE_MS = 60_000
 
 export interface FlushedTurnRecord {
   /** The per-turn `turnId` nonce (`deriveTurnId` shape) of the flushed turn.
@@ -90,6 +129,13 @@ export interface FlushedTurnRecord {
   text: string
   /** Wall-clock ms when recorded. */
   ts: number
+  /** #4173 — wall-clock ms the flushed turn's REAL turn_end (or a proxy: new
+   *  turn mint / bridge death) was observed, or null while the session is
+   *  still composing (the OPEN phase — see the module header). Null records
+   *  are claimable indefinitely up to the `openCapMs` crash backstop; once
+   *  set, the record expires `completedGraceMs` later (the bounded
+   *  tool-call-replay window). */
+  completedAt: number | null
 }
 
 /**
@@ -208,12 +254,24 @@ export function decideSupersede(
     replyText?: string | null
     positiveAttribution?: boolean
     now: number
-    ttlMs?: number
+    /** OPEN-phase crash backstop (see module header). */
+    openCapMs?: number
+    /** COMPLETED-phase replay grace (see module header). */
+    completedGraceMs?: number
   },
 ): SupersedeDecision {
-  const ttlMs = args.ttlMs ?? DEFAULT_SUPERSEDE_TTL_MS
+  const openCapMs = args.openCapMs ?? SUPERSEDE_OPEN_WINDOW_CAP_MS
+  const completedGraceMs = args.completedGraceMs ?? SUPERSEDE_COMPLETED_GRACE_MS
   if (record == null) return { supersede: false, deleteMessageIds: [], reason: 'no-record' }
-  if (args.now - record.ts > ttlMs) {
+  // #4173 three-phase freshness (module header): an OPEN record (real turn_end
+  // not yet observed — the session is still composing this turn's answer) is
+  // claimable up to the crash-backstop cap; a COMPLETED record only for the
+  // bounded tool-call-replay grace after the observed completion.
+  const expired =
+    record.completedAt == null
+      ? args.now - record.ts > openCapMs
+      : args.now - record.completedAt > completedGraceMs
+  if (expired) {
     return { supersede: false, deleteMessageIds: [], reason: 'expired' }
   }
   const sameTurn =
@@ -334,20 +392,26 @@ function turnKey(turnId: string | null): string {
  */
 export class FlushedTurnSupersedeRegistry {
   private readonly entries = new Map<string, Map<string, FlushedTurnRecord>>()
-  private readonly ttlMs: number
+  private readonly openCapMs: number
+  private readonly completedGraceMs: number
 
-  constructor(opts: { ttlMs?: number } = {}) {
-    this.ttlMs = opts.ttlMs ?? DEFAULT_SUPERSEDE_TTL_MS
+  constructor(opts: { openCapMs?: number; completedGraceMs?: number } = {}) {
+    this.openCapMs = opts.openCapMs ?? SUPERSEDE_OPEN_WINDOW_CAP_MS
+    this.completedGraceMs = opts.completedGraceMs ?? SUPERSEDE_COMPLETED_GRACE_MS
   }
 
   /** Record a flush's posted message(s) so a later same-turn reply supersedes
    *  them, keyed on the flush's `turnId` within the chat/thread lane. No record
    *  is kept when the flush posted zero messages. Sweeps expired records first
-   *  (lightweight active GC — LOW-2) so orphan records never accumulate. */
+   *  (lightweight active GC — LOW-2) so orphan records never accumulate.
+   *  `completedAt` (#4173): the flush's async send can outlast the real
+   *  turn_end, so the record site passes the turn atom's `realEndObservedAt` —
+   *  a window that was closed BEFORE the record existed is born completed
+   *  (grace-bounded), never resurrected as open. */
   record(
     chatId: string,
     threadId: number | undefined,
-    rec: { turnId: string | null; messageIds: number[]; text: string },
+    rec: { turnId: string | null; messageIds: number[]; text: string; completedAt?: number | null },
     now: number,
   ): void {
     if (rec.messageIds.length === 0) return
@@ -363,7 +427,21 @@ export class FlushedTurnSupersedeRegistry {
       messageIds: [...rec.messageIds],
       text: rec.text,
       ts: now,
+      completedAt: rec.completedAt ?? null,
     })
+  }
+
+  /** #4173 — the real-turn-end signal (or a proxy: new turn mint / bridge
+   *  death) was observed. Close every OPEN record's window: from `now` each
+   *  has `completedGraceMs` (the bounded replay window) left to be claimed by
+   *  its own late replay, then expires. Records already completed keep their
+   *  original (earlier) completion — the signal only ever narrows. */
+  completeAll(now: number): void {
+    for (const laneMap of this.entries.values()) {
+      for (const rec of laneMap.values()) {
+        if (rec.completedAt == null) rec.completedAt = now
+      }
+    }
   }
 
   /** Decide supersede for a landing reply WITHOUT consuming the record. Selects
@@ -386,7 +464,8 @@ export class FlushedTurnSupersedeRegistry {
       replyText: args.replyText,
       positiveAttribution: args.positiveAttribution,
       now: args.now,
-      ttlMs: this.ttlMs,
+      openCapMs: this.openCapMs,
+      completedGraceMs: this.completedGraceMs,
     })
   }
 
@@ -426,11 +505,16 @@ export class FlushedTurnSupersedeRegistry {
     this.entries.clear()
   }
 
-  /** Evict every record past its TTL and prune emptied lanes. */
+  /** Evict every record past its window (three-phase rule, module header) and
+   *  prune emptied lanes. */
   private sweep(now: number): void {
     for (const [lane, laneMap] of this.entries) {
       for (const [tk, rec] of laneMap) {
-        if (now - rec.ts > this.ttlMs) laneMap.delete(tk)
+        const expired =
+          rec.completedAt == null
+            ? now - rec.ts > this.openCapMs
+            : now - rec.completedAt > this.completedGraceMs
+        if (expired) laneMap.delete(tk)
       }
       if (laneMap.size === 0) this.entries.delete(lane)
     }
@@ -447,4 +531,56 @@ export class FlushedTurnSupersedeRegistry {
 
 function makeKey(chatId: string, threadId: number | undefined): string {
   return threadId == null ? chatId : `${chatId}|${threadId}`
+}
+
+/**
+ * #4173 — carries the turn-completion signal onto the flushed TURN ATOMS, the
+ * registry's sibling surface. The registry above bounds the RECORD (message
+ * ids); the latest-ended owner tier (`reply-owner-resolve.ts`) is bounded by
+ * the TURN's `realEndObservedAt`, and this tracker is what stamps it:
+ *
+ *   - `open(turn)` at flush-fire time (stream-render's turn-flush branch, the
+ *     one path that ends a turn SYNTHETICALLY before the session stopped):
+ *     nulls `realEndObservedAt` and holds the atom pending.
+ *   - `closeAll(now)` when the real turn_end signal (or a proxy: a new turn
+ *     minting on the session, the bridge dying) is observed: stamps every
+ *     pending atom's `realEndObservedAt = now` and releases it. Every other
+ *     turn-end path stamps `realEndObservedAt` directly in
+ *     `endCurrentTurnAtomic` (turn-end.ts) — for a normally-ended turn the
+ *     real end IS its end.
+ *
+ * Serial-session note: claude processes one turn at a time, so pending atoms
+ * are naturally few (normally exactly one); `closeAll` closing every pending
+ * window on any completion signal is deliberate — closing early is the SAFE
+ * direction (a too-short window costs a visible duplicate, never an
+ * edit-over). Pure: no clock reads beyond the caller-supplied `now`, no I/O.
+ */
+export class FlushCompletionTracker {
+  private pending: Array<{ realEndObservedAt: number | null }> = []
+
+  /** Hold `turn` pending until the real-turn-end signal; marks its window
+   *  open (`realEndObservedAt = null`). */
+  open(turn: { realEndObservedAt: number | null }): void {
+    turn.realEndObservedAt = null
+    if (!this.pending.includes(turn)) this.pending.push(turn)
+  }
+
+  /** The real-turn-end signal (or a proxy) was observed: stamp every pending
+   *  atom and release it. Returns how many windows were closed. */
+  closeAll(now: number): number {
+    let closed = 0
+    for (const turn of this.pending) {
+      if (turn.realEndObservedAt == null) {
+        turn.realEndObservedAt = now
+        closed++
+      }
+    }
+    this.pending = []
+    return closed
+  }
+
+  /** Test/diagnostics: number of atoms still awaiting their real turn_end. */
+  pendingCount(): number {
+    return this.pending.length
+  }
 }

--- a/telegram-plugin/flushed-turn-supersede.ts
+++ b/telegram-plugin/flushed-turn-supersede.ts
@@ -26,7 +26,9 @@
  *
  * NOT fully deterministic — a residual race remains. The flush→reply direction
  * this registry covers, plus the controller's fire-time recount for the
- * reply→flush direction, close the COMMON ~10 s replay-gap case; but if a reply
+ * reply→flush direction, close the COMMON replay-gap case (~10 s for a
+ * tool-call replay; minutes for the Stop-hook-nudged recompose after a
+ * proactive /compact — see DEFAULT_SUPERSEDE_TTL_MS); but if a reply
  * and a flush interleave so the reply's `take()` runs BEFORE the flush's
  * `record()` (a much smaller window), `take` finds no record and the duplicate
  * can still slip through. We deliberately trade that residual window for the
@@ -46,10 +48,30 @@
  * `now`. Fully unit-testable; the gateway wires the actual delete/send.
  */
 
-/** TTL after which a recorded flush is forgotten. 60 s comfortably spans the
- *  observed ~10 s flush→reply replay gap with margin, and matches the outbound
- *  dedup window so the two mechanisms age out together. */
-export const DEFAULT_SUPERSEDE_TTL_MS = 60_000
+/** TTL after which a recorded flush is forgotten.
+ *
+ *  Originally 60 s, sized for the ~10 s tool-replay gap. That window missed the
+ *  SLOW variant of the exact class this module exists for (2026-08-01, klanker
+ *  DM, msgs 25680/25682): the quiescence flush delivered the composed answer,
+ *  the Stop hook told the model its prose never reached the user, and the model
+ *  recomposed and called `reply` — but a proactive `/compact` ran in between
+ *  (occupancy ~393 k), so the canonical reply landed **2 m 24 s** after the
+ *  flush. Every layer keyed on this TTL — the registry record itself
+ *  (`decideSupersede` → 'expired'), the destructive latest-ended owner tier
+ *  (`latestEndedAccepted` rejected the 143 s-old turn, so not even the
+ *  answer-delivered latch was reachable), and the handback window — had aged
+ *  out, and the reply shipped as a second bubble.
+ *
+ *  5 min covers the flush → Stop-hook nudge → compact → recompose → `reply`
+ *  loop with margin (the turn-flush safety net itself waits minutes before
+ *  firing). The longer memory stays safe because every consumer is
+ *  identity-scoped: a record is only ever matched by its own `turnId`, the
+ *  latest-ended tier still demands the SAME ended turn, and the handback
+ *  content gate widens in the fail-safe direction (more handbacks keep the
+ *  gate → fresh send, never a silent edit-over). The exact-text #546 dedup
+ *  keeps its own 60 s window (`recent-outbound-dedup.ts`) — it guards
+ *  byte-identical replays, a different class. */
+export const DEFAULT_SUPERSEDE_TTL_MS = 5 * 60_000
 
 export interface FlushedTurnRecord {
   /** The per-turn `turnId` nonce (`deriveTurnId` shape) of the flushed turn.

--- a/telegram-plugin/gateway/cron-session.ts
+++ b/telegram-plugin/gateway/cron-session.ts
@@ -36,6 +36,37 @@ export function baseAgent(name: string): string {
 }
 
 /**
+ * #4172 — is a `reply` tool call arriving on this IPC client identity a
+ * FOREIGN-SESSION reply, i.e. one that can NEVER be the main claude session's
+ * own (possibly late/reworded) answer to a turn the gateway attributed?
+ *
+ * The whole flushed-turn supersede/bypass/latch machinery
+ * (`outbound-send-path.ts`) rests on the premise that a decoupled late reply
+ * resolving an ended turn is that turn's own answer unless a handback marker
+ * says otherwise. That premise only holds for replies from the MAIN agent
+ * bridge — the one whose session the turns belong to. A Tier-1 cheap-cron
+ * fire's reply arrives on the derived `<agent>-cron` bridge: it never mints a
+ * gateway turn (its session events are dropped in `onSessionEvent`), never
+ * traverses `pendingInboundBuffer.push` (so it cannot stamp the handback
+ * marker), and lands decoupled with foreign content — the measured #4172
+ * failure was such a reply EDITING OVER a flushed answer (double loss: the
+ * flushed answer destroyed, the cron digest delivered as a silent edit).
+ * Identity is the one deterministic signal that separates it.
+ *
+ * Returns true (foreign — refuse supersede/bypass/latch authority, always
+ * send fresh) for:
+ *   - a cron-session identity (`<agent>-cron`);
+ *   - a null/absent identity (an unregistered client — it owns no session,
+ *     so fail SAFE: a visible fresh message, never destructive authority).
+ * Returns false only for a registered non-cron agent bridge — the main
+ * session.
+ */
+export function replyCallerIsForeignSession(name: string | null | undefined): boolean {
+  if (name == null || name === "") return true;
+  return isCronIdentity(name);
+}
+
+/**
  * True iff an inject_inbound fire is a scheduled cron fire — Tier-1 cheap-cron
  * (`meta.session='cron'`, routed to the derived `<agent>-cron` bridge) OR a
  * Tier-2 full-session cron (`meta.source='cron'`, lands on the main bridge).

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -87,6 +87,7 @@ import {
 import { OutboundDedupCache } from '../recent-outbound-dedup.js'
 import { FlushedTurnSupersedeRegistry } from '../flushed-turn-supersede.js'
 import { resolveReplyOwnerTurnWith, SUPERSEDE_OPEN_CAP_MS, SUPERSEDE_GRACE_MS } from './reply-owner-wiring.js'
+import { subagentReplyAuthority } from './subagent-reply-authority.js'
 import { createInboundCoalescer, inboundCoalesceKey } from './inbound-coalesce.js'
 import {
   splitCoalescedAttachments,
@@ -10735,6 +10736,7 @@ if (isGatewayMain) ipcServer = createIpcServer({
     // flush windows now (the replay grace still covers a reconnect replay).
     // Scoped to a registered non-cron agent; rationale in stream-render.ts.
     if (client.agentName != null && !isCronIdentity(client.agentName)) {
+      subagentReplyAuthority.reset() // #4176 — the sub-agents died with the session
       const closedWindows = closeFlushCompletionWindows(flushedTurnSupersede, Date.now())
       if (closedWindows > 0) {
         process.stderr.write(
@@ -12538,6 +12540,7 @@ function gatewaySendReplyDeps(): SendReplyGatewayDeps {
     resolveThreadId,
     getLatestInboundMessageId,
     getLastSubagentHandbackAt,
+    subagentReplyAuthority,
     recordOutbound,
     emissionAuthorityFor,
     clearActivitySummary,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -85,7 +85,8 @@ import {
   type TelegraphAccount,
 } from '../telegraph.js'
 import { OutboundDedupCache } from '../recent-outbound-dedup.js'
-import { FlushedTurnSupersedeRegistry, DEFAULT_SUPERSEDE_TTL_MS } from '../flushed-turn-supersede.js'
+import { FlushedTurnSupersedeRegistry } from '../flushed-turn-supersede.js'
+import { resolveReplyOwnerTurnWith, SUPERSEDE_OPEN_CAP_MS, SUPERSEDE_GRACE_MS } from './reply-owner-wiring.js'
 import { createInboundCoalescer, inboundCoalesceKey } from './inbound-coalesce.js'
 import {
   splitCoalescedAttachments,
@@ -455,7 +456,7 @@ import {
   type SendReplyGatewayDeps,
   type DeliverCapturedProseDeps,
 } from './outbound-send-path.js'
-import { handleSessionEvent as handleSessionEventCore, drainParkedTurnStartsForChat } from './stream-render.js'
+import { handleSessionEvent as handleSessionEventCore, drainParkedTurnStartsForChat, closeFlushCompletionWindows } from './stream-render.js'
 import { createNarrativeLane } from './narrative-lane.js'
 import {
   parseAgentCallback,
@@ -488,8 +489,6 @@ import {
   FLUSH_SUBSTANTIVE_MIN_CHARS,
 } from '../turn-flush-safety.js'
 import {
-  resolveReplyOwnerTurnId,
-  resolveReplyOwnerTier,
   type ReplyOwnerTier, type ReplyOwnerCandidates,
   type AnswerDeliveredLatch,
 } from '../reply-owner-resolve.js'
@@ -657,7 +656,7 @@ import { handleRequestDriveApproval } from './drive-write-approval.js'
 import { handleRequestMs365Approval } from './ms365-write-approval.js'
 import { buildDiffPreviewCard } from './diff-preview-card.js'
 import { createPendingInboundBuffer, redeliverBufferedInbound, idleDrainTick } from './pending-inbound-buffer.js'
-import { isCronIdentity, isCronInjectFire, deliverInjectWithFallback } from './cron-session.js'
+import { isCronIdentity, isCronInjectFire, deliverInjectWithFallback, replyCallerIsForeignSession } from './cron-session.js'
 import {
   ObligationLedger,
   obligationEscalationText,
@@ -2377,7 +2376,12 @@ const outboundDedup = new OutboundDedupCache()
 // a second message. Keyed on the per-turn `turnId` nonce, NOT on text — so it
 // catches the containment case the exact-text `outboundDedup` misses (a
 // `narration\n\nanswer` flush never equals the clean `answer`-only reply).
-const flushedTurnSupersede = new FlushedTurnSupersedeRegistry()
+// #4173/#4175 — window bounds (env kill-switch + rationale) live in
+// reply-owner-wiring.ts so this ctor and the owner-tier candidates share them.
+const flushedTurnSupersede = new FlushedTurnSupersedeRegistry({
+  openCapMs: SUPERSEDE_OPEN_CAP_MS,
+  completedGraceMs: SUPERSEDE_GRACE_MS,
+})
 // #3276 — the turn-flush backstop's per-turn delivery latch + per-chunk
 // idempotency ledger. The latch (keyed on `turnId`) is the deterministic
 // arbiter of backstop-vs-reply; the chunk ledger lets a retry after a partial
@@ -3457,12 +3461,18 @@ export type CurrentTurn = {
   // The `latest-ended` supersede tier carries DESTRUCTIVE authority (it drives
   // message deletion), so `resolveReplyOwnerTurn` only honours a latest-ended
   // turn whose `endedAt` is non-null (#3725 — the registry is populated at turn
-  // START, so the tail entry may still be RUNNING) AND within the supersede TTL —
-  // otherwise a late reply belonging to an OLDER turn could resolve its owner to
-  // a NEWER turn at the registry tail and delete that turn's legit answer. The
-  // unbounded ROUTING use (`endedOnly: false`) is unaffected: it only picks a
-  // topic to deliver into and deletes nothing.
+  // START, so the tail entry may still be RUNNING) AND within the
+  // turn-completion window (#4173) — otherwise a late reply belonging to an
+  // OLDER turn could resolve its owner to a NEWER turn at the registry tail and
+  // delete that turn's legit answer. The unbounded ROUTING use
+  // (`endedOnly: false`) is unaffected: it only picks a topic to deliver into
+  // and deletes nothing.
   endedAt: number | null
+  // #4173 — the turn-completion signal: ms the SESSION's real stop was
+  // observed, or null while the window is OPEN (a flush-ended turn still
+  // composing). Stamped in turn-end.ts / closed by stream-render's hooks;
+  // full three-phase model in flushed-turn-supersede.ts.
+  realEndObservedAt: number | null
   // #1675 (over-ping safety net): wall-clock ms of the first reply
   // this turn that landed with `disable_notification: false` (a real
   // device ping). The conversational-pacing contract
@@ -3985,60 +3995,21 @@ function findLatestTurnForChat(chatId: string, opts: { endedOnly: boolean }): Cu
   return latestTurnForChat(recentTurnsById.values(), chatId, opts)
 }
 
-/**
- * 2026-07 double-reply-on-DM fix (Part 1). Resolve the turn that OWNS a landing
- * reply using the SAME full chain the thread-router uses, so the supersede
- * resolver can never again diverge from routing (the exact bug: supersede
- * omitted the quoted-message and latest-ended recoveries, so a DM late reply —
- * no live turn, no `origin_turn_id` — resolved to a null owner and its flush
- * message was never superseded → duplicate).
- *
- * Precedence (first non-null wins), delegated to the pure
- * `resolveReplyOwnerTurnId` so the exact precedence is unit-tested:
- *   1. the live `currentTurn` passed in (null once the flush nulled the atom);
- *   2. `findTurnByOriginId(origin_turn_id)` — the model echo;
- *   3. `findTurnByQuotedMessageId(chat_id, reply_to)` — framework-owned quote;
- *   4. `findLatestTurnForChat(chat_id, {endedOnly:true})` — last ENDED turn.
- * Returns the CurrentTurn for the winning id (so callers can read its
- * `answerDelivered` latch), or null when every lookup missed.
- */
+/** 2026-07 double-reply-on-DM fix (Part 1) — thin wrapper over the extracted
+ *  composition (`reply-owner-wiring.ts`, which also carries the #4173
+ *  turn-completion-window bounds). Kept here only to bind the gateway's
+ *  stateful lookups. */
 function resolveReplyOwnerTurn(
   liveTurn: CurrentTurn | null,
   chatId: string,
   args: Record<string, unknown>,
 ): { turn: CurrentTurn | null; tier: ReplyOwnerTier; candidates: ReplyOwnerCandidates } {
-  const origin = findTurnByOriginId(args.origin_turn_id as string | undefined)
-  const quoted = findTurnByQuotedMessageId(chatId, args.reply_to)
-  const latestEnded = findLatestTurnForChat(chatId, { endedOnly: true })
-  const byId = new Map<string, CurrentTurn>()
-  // Populate lowest-precedence first so a higher tier's turn wins the id slot
-  // when two lookups resolve the same turn (they carry the same turnId anyway).
-  for (const t of [latestEnded, quoted, origin, liveTurn]) {
-    if (t != null) byId.set(t.turnId, t)
-  }
-  // F2 — bound the DESTRUCTIVE latest-ended tier to the supersede TTL so a stale
-  // latest-ended turn can't inherit deletion authority over a newer turn's flush
-  // record. #3725: the lookup above is `endedOnly`, so `endedAt` is non-null here
-  // and the age is ALWAYS a real number — a not-yet-ended turn is no longer a
-  // candidate at all, and an explicit null age now fails CLOSED downstream.
-  const latestEndedAgeMs =
-    latestEnded?.endedAt != null ? Date.now() - latestEnded.endedAt : null
-  const candidates: ReplyOwnerCandidates = {
-    liveTurnId: liveTurn?.turnId ?? null,
-    originTurnId: origin?.turnId ?? null,
-    quotedTurnId: quoted?.turnId ?? null,
-    latestEndedTurnId: latestEnded?.turnId ?? null,
-    latestEndedAgeMs,
-    latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
-  }
-  // #3429 — the winning tier AND the candidate set it came from travel with the
-  // turn. Tier alone no longer decides the content-gate bypass: the
-  // model-steerable `origin`/`quoted` tiers must be CORROBORATED against the
-  // framework-derived `latestEndedTurnId` (`decideContentGateBypass`). All three
-  // derive from these SAME candidates, so they can never disagree.
-  const tier = resolveReplyOwnerTier(candidates)
-  const winnerId = resolveReplyOwnerTurnId(candidates)
-  return { turn: winnerId != null ? (byId.get(winnerId) ?? null) : null, tier, candidates }
+  return resolveReplyOwnerTurnWith(
+    { findTurnByOriginId, findTurnByQuotedMessageId, findLatestTurnForChat, now: Date.now },
+    liveTurn,
+    chatId,
+    args,
+  )
 }
 
 /**
@@ -10759,12 +10730,26 @@ if (isGatewayMain) ipcServer = createIpcServer({
       },
       log: (msg) => process.stderr.write(`${msg}\n`),
     })
+    // #4173 — a MAIN-bridge death is a turn-completion proxy: the dead session
+    // can never deliver a flush-ended turn's real turn_end, so close any open
+    // flush windows now (the replay grace still covers a reconnect replay).
+    // Scoped to a registered non-cron agent; rationale in stream-render.ts.
+    if (client.agentName != null && !isCronIdentity(client.agentName)) {
+      const closedWindows = closeFlushCompletionWindows(flushedTurnSupersede, Date.now())
+      if (closedWindows > 0) {
+        process.stderr.write(
+          `telegram gateway: bridge disconnect closed ${closedWindows} open flush-completion window(s) (#4173)\n`,
+        )
+      }
+    }
   },
 
   async onToolCall(client: IpcClient, msg: ToolCallMessage): Promise<ToolCallResult> {
     process.stderr.write(`telegram gateway: ipc: tool_call tool=${msg.tool} agent=${client.agentName ?? '-'} clientId=${client.id ?? '-'} callId=${msg.id}\n`)
     try {
-      const result = await executeToolCall(msg.tool, msg.args)
+      // #4172 — the calling client's identity gates reply supersede authority
+      // (see replyCallerIsForeignSession, cron-session.ts).
+      const result = await executeToolCall(msg.tool, msg.args, client.agentName)
       return { type: 'tool_call_result', id: msg.id, success: true, result }
     } catch (err) {
       return {
@@ -11972,13 +11957,18 @@ const ALLOWED_TOOLS = new Set([
   'linear_agent_setup',
 ])
 
-async function executeToolCall(tool: string, args: Record<string, unknown>): Promise<unknown> {
+async function executeToolCall(
+  tool: string,
+  args: Record<string, unknown>,
+  // #4172 — calling client identity; only the reply path consumes it today.
+  callerAgentName: string | null = null,
+): Promise<unknown> {
   if (!ALLOWED_TOOLS.has(tool)) {
     throw new Error(`tool not allowed: ${tool}`)
   }
   switch (tool) {
     case 'reply':
-      return executeReply(args)
+      return executeReply(args, callerAgentName)
     case 'progress_update':
       return executeProgressUpdate(args)
     case 'react':
@@ -12490,14 +12480,22 @@ async function synthesizeVoiceOut(plan: {
   }
 }
 
-async function executeReply(args: Record<string, unknown>): Promise<{ content: Array<{ type: string; text: string }> }> {
+async function executeReply(
+  args: Record<string, unknown>,
+  callerAgentName: string | null = null,
+): Promise<{ content: Array<{ type: string; text: string }> }> {
   // #2996 P2: the ~1,400-line orchestration body moved VERBATIM to
   // outbound-send-path.ts `sendReply()` — the single tested send primitive.
   // #1664 — the turn is pinned HERE at entry (same read, same position as the
   // old inline `const turn = currentTurn`) and passed in `req`; the façade
   // also gets a live `getCurrentTurn()` accessor for the deliberate live
   // re-reads (Amendment 9: each call site keeps its pin-vs-live choice).
-  return sendReply(gatewaySendReplyDeps(), { args, turn: currentTurn })
+  // #4172 — a foreign-session caller gets no supersede/bypass/latch authority.
+  return sendReply(gatewaySendReplyDeps(), {
+    args,
+    turn: currentTurn,
+    callerIsForeignSession: replyCallerIsForeignSession(callerAgentName),
+  })
 }
 
 /** Live gateway deps for the extracted send façade (#2996 P2). Built fresh

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -78,6 +78,7 @@ import {
   type FlushedTurnSupersedeRegistry,
 } from '../flushed-turn-supersede.js'
 import { HANDBACK_RECENCY_WINDOW_MS } from './subagent-handback-marker.js'
+import type { SubagentReplyAuthorityView } from './subagent-reply-authority.js'
 import {
   decideAnswerLatchSuppression,
   decideContentGateBypass,
@@ -844,6 +845,12 @@ export interface SendReplyGatewayDeps {
   resolveThreadId(chatId: string, explicit?: string | number | null): number | undefined
   getLatestInboundMessageId(chatId: string, threadId: number | null): number | null | undefined
   getLastSubagentHandbackAt(chatId: string): number | null
+  /** #4176 — gateway-observed sub-agent liveness (`subagentReplyAuthority`,
+   *  subagent-reply-authority.ts). A background `Task` sub-agent replies over
+   *  THIS bridge, so neither the #4172 caller-identity gate nor the handback
+   *  marker can see it; while one is live the content-gate bypass is refused so
+   *  a sub-agent's reply can never edit over a flushed answer. */
+  subagentReplyAuthority: SubagentReplyAuthorityView
   recordOutbound(rec: {
     chat_id: string
     thread_id: number | null
@@ -908,7 +915,7 @@ export async function sendReply(
     statusKey, streamKey,
     resolveReplyOwnerTurn, findTurnByOriginId, findTurnByQuotedMessageId,
     resolveAnswerThreadWithLog, resolveThreadId,
-    getLatestInboundMessageId, getLastSubagentHandbackAt, recordOutbound,
+    getLatestInboundMessageId, getLastSubagentHandbackAt, subagentReplyAuthority, recordOutbound,
     emissionAuthorityFor, clearActivitySummary,
     startTypingLoop, stopTypingLoop, logOutbound,
     closeObligationOnSubstantiveReply, finalizeStatusReaction,
@@ -1163,11 +1170,27 @@ export async function sendReply(
     //                its OWN turn no longer loses the collapse it would have got
     //                by omitting the echo entirely (the observed 2026-07-27
     //                `via=origin` duplicate).
+    //
+    // #4176 — the SECOND ambiguity, which the marker structurally cannot see. A
+    // background `Task` sub-agent (the `researcher`/`reviewer` types hold the
+    // full tool set) calls `reply` over THIS bridge, mid-run: the #4172
+    // caller-identity gate sees the MAIN agent identity, and a direct tool call
+    // never traverses `pendingInboundBuffer.push`, so no handback marker is
+    // stamped either. Under the #4173 OPEN window that reply resolves the
+    // flush-ended turn at ANY age, so an unguarded bypass supersedes REGARDLESS
+    // of content and silently edits the sub-agent's message over the user's
+    // flushed answer (the review MAJOR on #4167; pre-existing on main at the
+    // 60 s TTL, extended by #4173 to the OPEN cap). Gateway-observed sub-agent
+    // liveness is the deterministic discriminator: while one is live the content
+    // gate is KEPT, so a reply that IS the flushed answer still collapses and a
+    // sub-agent's foreign content ships FRESH (visible, notifying).
+    const subagentCouldOwnReply = subagentReplyAuthority.subagentCouldOwnReply()
     const replyIsOwnAnswer = decideContentGateBypass({
       tier: ownerTier,
       resolvedTurnId,
       candidates: ownerCandidates,
       handbackCouldOwnReply,
+      subagentCouldOwnReply,
     })
     const decision = flushedTurnSupersede.take(
       chat_id,
@@ -1257,7 +1280,7 @@ export async function sendReply(
           // 2026-07-27 duplicate looked like a pure text-matcher failure and
           // took a log-archive dig to attribute to the tier restriction.
           `tier=${ownerTier} latestEnded=${JSON.stringify(ownerCandidates.latestEndedTurnId)} ` +
-          `handbackInWindow=${handbackCouldOwnReply}; sending fresh\n`,
+          `handbackInWindow=${handbackCouldOwnReply} subagentLive=${subagentCouldOwnReply}; sending fresh\n`,
         )
       }
       if (suppressByLatch) {

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -75,9 +75,9 @@ import { decideSilentReplyAnchor } from '../silent-reply-anchor.js'
 import {
   decideSupersedeCorrection,
   flushedAnswerMatchesReply,
-  DEFAULT_SUPERSEDE_TTL_MS,
   type FlushedTurnSupersedeRegistry,
 } from '../flushed-turn-supersede.js'
+import { HANDBACK_RECENCY_WINDOW_MS } from './subagent-handback-marker.js'
 import {
   decideAnswerLatchSuppression,
   decideContentGateBypass,
@@ -762,6 +762,16 @@ export interface SendReplyRequest {
    *  Late writes (finalAnswerDelivered) attribute to THIS turn even if the
    *  module-scope turn rolls over mid-call. */
   turn: CurrentTurn | null
+  /** #4172 — true when the calling IPC client is NOT the main agent bridge
+   *  (`replyCallerIsForeignSession`, cron-session.ts): a Tier-1 cheap-cron
+   *  session or an unregistered client. A foreign-session reply can never be
+   *  the main session's own late answer, so the flushed-turn
+   *  supersede/bypass/latch block is skipped wholesale — it always sends
+   *  FRESH (never edits/deletes a flushed answer, never gets latch-
+   *  suppressed). Omitted/false ⇒ main-bridge caller (the gateway's
+   *  `executeReply` always passes the computed value; the default only
+   *  affects test harnesses). */
+  callerIsForeignSession?: boolean
 }
 
 /** Gateway dependencies for {@link sendReply}. Function members use method
@@ -1025,7 +1035,20 @@ export async function sendReply(
   // when the reply fits one plain-text message, and falls back to the legacy
   // delete+resend otherwise. `supersedeFlushIds` carries the ids forward.
   let supersedeFlushIds: number[] = []
-  {
+  // #4172 — caller-identity gate, BEFORE any owner attribution. A reply from a
+  // foreign session (a Tier-1 cheap-cron bridge, or an unregistered client)
+  // can never be the main session's own late/reworded answer, so it gets NO
+  // supersede authority (it must never edit/delete a flushed answer — the
+  // measured #4172 double loss), NO content-gate bypass, and NO exposure to
+  // the answer-delivered latch (which could otherwise silently swallow a cron
+  // digest landing in the flush's pre-record race window). It simply sends
+  // fresh below, leaving any flush record intact for the genuine own-replay.
+  if (req.callerIsForeignSession === true) {
+    process.stderr.write(
+      `telegram gateway: reply: foreign-session caller — supersede/latch skipped (#4172) ` +
+      `chatId=${chat_id}\n`,
+    )
+  } else {
     const replyThreadId = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
     // 2026-07 double-reply-on-DM fix (Part 1) — resolve the turn this reply
     // belongs to by IDENTITY, via the SAME full chain the thread-router uses
@@ -1107,11 +1130,16 @@ export async function sendReply(
     // correction only ever touches ITS OWN topic's record.
     const handbackAt = getLastSubagentHandbackAt(chat_id)
     const now = Date.now()
+    // #4174 — the handback gate-hold keeps its OWN ~60 s bound
+    // (`HANDBACK_RECENCY_WINDOW_MS`), deliberately NOT the supersede window's:
+    // this read is CHAT-WIDE, so a longer bound would hold the content gate —
+    // and re-open the reworded-own-answer visible-dup class — for every topic
+    // in a delegation-heavy chat, near-continuously. Rationale on the constant.
     const handbackCouldOwnReply =
       handbackAt != null &&
       ownerEndedAt != null &&
       handbackAt > ownerEndedAt &&
-      now - handbackAt <= DEFAULT_SUPERSEDE_TTL_MS
+      now - handbackAt <= HANDBACK_RECENCY_WINDOW_MS
     // MUST-FIX 1 (silent-data-loss, PROVEN by Fable 2026-07-21) + the 2026-07-27
     // corroboration widening — decided by the pure `decideContentGateBypass` so
     // the gateway runs the exact code the unit tests exercise. The rule, in
@@ -1248,9 +1276,10 @@ export async function sendReply(
       // content and must deliver. Byte-identical replays of THIS answer are
       // deduped by the content-keyed #546 cache at the top of this function.
       // Honest bound: the dedup TTL (60 s) is anchored at reply RECORD time,
-      // while the latest-ended owner tier's 60 s is anchored at `endedAt` —
-      // later by the reply→turn_end gap. A byte-identical replay landing >60 s
-      // after record but ≤60 s after endedAt is evicted from dedup yet still
+      // while the latest-ended owner tier's bound is the turn-completion
+      // window (#4173), anchored at the turn's OBSERVED real end — later by
+      // the reply→turn_end gap. A byte-identical replay landing >60 s after
+      // record but still inside that window is evicted from dedup yet still
       // resolves this ended turn, so it now DELIVERS as a duplicate message.
       // Conscious trade: a rare duplicate beats the silent handback drop the
       // boolean latch caused (#3426).

--- a/telegram-plugin/gateway/reply-owner-wiring.ts
+++ b/telegram-plugin/gateway/reply-owner-wiring.ts
@@ -1,0 +1,128 @@
+/**
+ * Reply owner-turn resolution WIRING (#2996 anti-inflation extraction; #4173).
+ *
+ * The pure precedence/acceptance rules live in `../reply-owner-resolve.ts`;
+ * gateway.ts holds the stateful lookups (recent-turn registry, quoted-message
+ * reverse index). This module is the seam between them: it composes the four
+ * lookups into the `ReplyOwnerCandidates` set — INCLUDING the turn-completion
+ * window bounds (#4173) — exactly once, so the supersede path, the content-gate
+ * bypass, and the tier resolution can never disagree on the candidate set.
+ *
+ * 2026-07 double-reply-on-DM fix (Part 1): this composition uses the SAME full
+ * chain the thread-router uses, so the supersede resolver can never again
+ * diverge from routing (the exact bug: supersede omitted the quoted-message and
+ * latest-ended recoveries, so a DM late reply — no live turn, no
+ * `origin_turn_id` — resolved to a null owner and its flush message was never
+ * superseded → duplicate).
+ *
+ * Precedence (first non-null wins), delegated to the pure
+ * `resolveReplyOwnerTurnId` so the exact precedence is unit-tested:
+ *   1. the live `currentTurn` passed in (null once the flush nulled the atom);
+ *   2. `findTurnByOriginId(origin_turn_id)` — the model echo;
+ *   3. `findTurnByQuotedMessageId(chat_id, reply_to)` — framework-owned quote;
+ *   4. `findLatestTurnForChat(chat_id, {endedOnly:true})` — last ENDED turn.
+ * Returns the turn atom for the winning id (so callers can read its
+ * `answerDelivered` latch), or null when every lookup missed.
+ */
+
+import {
+  resolveReplyOwnerTier,
+  resolveReplyOwnerTurnId,
+  type ReplyOwnerCandidates,
+  type ReplyOwnerTier,
+} from '../reply-owner-resolve.js'
+import {
+  SUPERSEDE_OPEN_WINDOW_CAP_MS,
+  SUPERSEDE_COMPLETED_GRACE_MS,
+} from '../flushed-turn-supersede.js'
+
+/**
+ * #4173/#4175 — the two turn-completion-window bounds, env-overridable as the
+ * operator kill-switch for the window mechanism (clamp the open cap / grace to
+ * taste; e.g. `SWITCHROOM_SUPERSEDE_OPEN_CAP_MS=60000` restores something
+ * close to the pre-#4166 60 s behaviour). Resolved HERE once — the pure
+ * modules stay env-free — and consumed by BOTH window surfaces (the gateway's
+ * `FlushedTurnSupersedeRegistry` ctor and the latest-ended owner-tier
+ * candidates below) so they can never disagree.
+ */
+export const SUPERSEDE_OPEN_CAP_MS = (() => {
+  const raw = Number(process.env.SWITCHROOM_SUPERSEDE_OPEN_CAP_MS)
+  return Number.isFinite(raw) && raw > 0 ? raw : SUPERSEDE_OPEN_WINDOW_CAP_MS
+})()
+export const SUPERSEDE_GRACE_MS = (() => {
+  const raw = Number(process.env.SWITCHROOM_SUPERSEDE_GRACE_MS)
+  return Number.isFinite(raw) && raw > 0 ? raw : SUPERSEDE_COMPLETED_GRACE_MS
+})()
+
+/** The minimal turn-atom shape this wiring reads. Structural on purpose so the
+ *  module never imports gateway.ts (no cycle); gateway's `CurrentTurn`
+ *  satisfies it. */
+export interface OwnerTurnLike {
+  turnId: string
+  endedAt: number | null
+  realEndObservedAt: number | null
+}
+
+/**
+ * Compose the owner-resolution result from the gateway's four lookups.
+ * Generic over the concrete turn atom type so gateway.ts gets its own
+ * `CurrentTurn` back without a cast.
+ */
+export function resolveReplyOwnerTurnWith<T extends OwnerTurnLike>(
+  lookups: {
+    findTurnByOriginId(originTurnId: string | null | undefined): T | null
+    findTurnByQuotedMessageId(chatId: string, replyTo: unknown): T | null
+    findLatestTurnForChat(chatId: string, opts: { endedOnly: boolean }): T | null
+    now(): number
+  },
+  liveTurn: T | null,
+  chatId: string,
+  args: Record<string, unknown>,
+): { turn: T | null; tier: ReplyOwnerTier; candidates: ReplyOwnerCandidates } {
+  const origin = lookups.findTurnByOriginId(args.origin_turn_id as string | undefined)
+  const quoted = lookups.findTurnByQuotedMessageId(chatId, args.reply_to)
+  const latestEnded = lookups.findLatestTurnForChat(chatId, { endedOnly: true })
+  const byId = new Map<string, T>()
+  // Populate lowest-precedence first so a higher tier's turn wins the id slot
+  // when two lookups resolve the same turn (they carry the same turnId anyway).
+  for (const t of [latestEnded, quoted, origin, liveTurn]) {
+    if (t != null) byId.set(t.turnId, t)
+  }
+  // F2 — bound the DESTRUCTIVE latest-ended tier to the turn-completion window
+  // (#4173) so a stale latest-ended turn can't inherit deletion authority over
+  // a newer turn's flush record. #3725: the lookup above is `endedOnly`, so
+  // `endedAt` is non-null here and the age is ALWAYS a real number — a
+  // not-yet-ended turn is no longer a candidate at all, and an explicit null
+  // age fails CLOSED downstream (as does an omitted one, since #4175).
+  const latestEndedAgeMs =
+    latestEnded?.endedAt != null ? lookups.now() - latestEnded.endedAt : null
+  // #4173 — the completion signal: null while the flush-ended turn's REAL
+  // turn_end has not been observed (window OPEN — acceptance falls to the
+  // crash-backstop cap in `latestEndedTtlMs`); ms-since-real-end once observed
+  // (window COMPLETED — only the replay grace remains). For a normally-ended
+  // turn `realEndObservedAt === endedAt`, so the tier keeps its tight bound.
+  const latestEndedRealEndAgeMs =
+    latestEnded == null
+      ? null
+      : latestEnded.realEndObservedAt != null
+        ? lookups.now() - latestEnded.realEndObservedAt
+        : null
+  const candidates: ReplyOwnerCandidates = {
+    liveTurnId: liveTurn?.turnId ?? null,
+    originTurnId: origin?.turnId ?? null,
+    quotedTurnId: quoted?.turnId ?? null,
+    latestEndedTurnId: latestEnded?.turnId ?? null,
+    latestEndedAgeMs,
+    latestEndedTtlMs: SUPERSEDE_OPEN_CAP_MS,
+    latestEndedRealEndAgeMs,
+    latestEndedCompletedGraceMs: SUPERSEDE_GRACE_MS,
+  }
+  // #3429 — the winning tier AND the candidate set it came from travel with the
+  // turn. Tier alone no longer decides the content-gate bypass: the
+  // model-steerable `origin`/`quoted` tiers must be CORROBORATED against the
+  // framework-derived `latestEndedTurnId` (`decideContentGateBypass`). All three
+  // derive from these SAME candidates, so they can never disagree.
+  const tier = resolveReplyOwnerTier(candidates)
+  const winnerId = resolveReplyOwnerTurnId(candidates)
+  return { turn: winnerId != null ? (byId.get(winnerId) ?? null) : null, tier, candidates }
+}

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -74,6 +74,7 @@ import { appendActivityLabel } from '../tool-activity-summary.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { decideTurnFlush } from '../turn-flush-safety.js'
 import { FlushCompletionTracker } from '../flushed-turn-supersede.js'
+import { subagentReplyAuthority } from './subagent-reply-authority.js'
 import { decideTerminalReason, deriveTurnRole } from '../turn-liveness-floor.js'
 import { chatKey, chatKeyWithSuffix } from './chat-key.js'
 import { deriveTurnId } from './derive-turn-id.js'
@@ -958,6 +959,16 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
     const durationMs = ev.kind === 'turn_end' ? ev.durationMs : undefined
     idleTracker.noteEvent(ev.kind, Date.now(), durationMs)
   }
+  // #4176 — sub-agent liveness, fed from the SAME whole-stream position as the
+  // idle clock above and for the same reason: `sub_agent_*` events arrive with
+  // or without a live gateway turn, and the reply send path must know whether a
+  // background sub-agent could be the author of a decoupled reply (a sub-agent
+  // calls `reply` over the parent's OWN bridge, so neither the caller-identity
+  // gate nor the handback marker can see it). Deliberately BEFORE the switch:
+  // the `sub_agent_tool_use` case below early-returns when `getCurrentTurn()` is
+  // null, which is exactly the post-flush state this gate exists for. See
+  // gateway/subagent-reply-authority.ts.
+  subagentReplyAuthority.noteSessionEvent(ev as { kind: string; agentId?: string })
   switch (ev.kind) {
     case 'enqueue': {
       // #3927 FIX A — an `enqueue` is a QUEUE event, not a turn START event

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -73,6 +73,7 @@ import { logStreamingEvent } from '../streaming-metrics.js'
 import { appendActivityLabel } from '../tool-activity-summary.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { decideTurnFlush } from '../turn-flush-safety.js'
+import { FlushCompletionTracker } from '../flushed-turn-supersede.js'
 import { decideTerminalReason, deriveTurnRole } from '../turn-liveness-floor.js'
 import { chatKey, chatKeyWithSuffix } from './chat-key.js'
 import { deriveTurnId } from './derive-turn-id.js'
@@ -220,6 +221,38 @@ function discardParkedTurnStart(rawContent: string): ParkedTurnStart | null {
     }
   }
   return null
+}
+
+/**
+ * #4173 — the ONE turn-completion tracker for flush-ended turns (module-scope
+ * like `parkedTurnStarts`: one CLI session per gateway process). The
+ * quiescence flush ends a turn SYNTHETICALLY while the claude session is still
+ * composing; this holds that turn's atom pending until the session's REAL
+ * turn_end (or a proxy: a new turn minting, the bridge dying) is observed,
+ * then stamps `realEndObservedAt` — the signal that flips the supersede
+ * machinery from the unbounded OPEN phase to the ~60 s replay grace. See the
+ * `flushed-turn-supersede.ts` module header for the full three-phase model.
+ */
+export const flushCompletionTracker = new FlushCompletionTracker()
+
+/**
+ * #4173 — a turn-completion signal was observed: close every open flush
+ * window. Stamps the pending atoms (`flushCompletionTracker`) AND starts the
+ * replay grace on the registry's records (`completeAll`) in one call, so the
+ * two surfaces (latest-ended owner tier / supersede record) can never observe
+ * different phases. Called from the real-turn_end path, the new-turn mint, and
+ * the gateway's bridge-death sweep. Returns how many atom windows closed.
+ */
+export function closeFlushCompletionWindows(
+  // Optional-shaped on purpose: several test harnesses drive `beginTurn` /
+  // `handleSessionEvent` with a partial deps object that carries no supersede
+  // registry. The production deps builder always injects the real one.
+  registry: { completeAll?: (now: number) => void } | null | undefined,
+  now: number,
+): number {
+  const closed = flushCompletionTracker.closeAll(now)
+  registry?.completeAll?.(now)
+  return closed
 }
 
 /** Test seam: the parked store is module-scope (one CLI session, one queue), so
@@ -558,6 +591,9 @@ function beginTurn(deps: StreamRenderDeps, ev: TurnStartEnvelope): void {
       flushedAnswerText: null,
       // 2026-07 double-reply-on-DM fix (F2) — stamped at turn end.
       endedAt: null,
+      // #4173 — the turn-completion signal, stamped at turn end (or later, for
+      // a flush-ended turn, when the real turn_end is observed).
+      realEndObservedAt: null,
       firstPingAt: null,
       // Notification ownership (R8 / PR-2): no slot claimed yet, so the
       // "claimer was substantive" flag starts false. Set atomically with
@@ -682,6 +718,12 @@ function beginTurn(deps: StreamRenderDeps, ev: TurnStartEnvelope): void {
     //     already the single stop-owner for ALL turns, and a start is
     //     self-healing anyway, so this cannot leak an interval.
     startTurnTypingLoop(ev.chatId, enqThreadIdNum ?? null)
+    // #4173 — a new turn minting on the serial claude session is a completion
+    // PROXY for any still-open flush window: the session has moved on, so a
+    // prior flushed turn's own late reply can now only arrive as a bounded
+    // replay (the grace). Closing here is the SAFE direction — a window closed
+    // too early costs at most a visible duplicate, never an edit-over.
+    closeFlushCompletionWindows(deps.flushedTurnSupersede, Date.now())
     // PR-4e — route the turn-SET through the keyed accessor: flag-OFF assigns
     // the singleton (byte-identical to `currentTurn = next`); flag-ON sets the
     // per-topic `byKey[statusKey]` entry AND the most-recent mirror. The key is
@@ -1724,6 +1766,17 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
           return
         }
       }
+      // #4173 — every turn_end that PROCEEDS (a real turn_end always; a
+      // synthetic one only past the suppression guard above) is a completion
+      // signal for any flush window still open from an EARLIER turn: the
+      // serial session has reached a stop, so that turn's own late reply can
+      // now only arrive as a bounded replay. Close them BEFORE this event's
+      // own processing — the quiescence-flush branch below may OPEN a new
+      // window for THIS turn right after. The common case this serves: the
+      // flush's synthetic turn_end tore the atom down, so when the REAL
+      // turn_end for that same turn lands here it finds no live atom and
+      // otherwise no-ops — this close is how that real turn_end is observed.
+      closeFlushCompletionWindows(flushedTurnSupersede, Date.now())
       // #2094 finding 1 — turn_end gate-wedge backstop. Capture the turn
       // BEFORE the body runs (the body re-reads currentTurn as `turn`, then
       // nulls it via endCurrentTurnAtomic on every clean branch). The guarded
@@ -2244,6 +2297,22 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
         // #1556 wedge-safety reasons. `backstopTurnEndedAt` is null iff the
         // atom was already torn down elsewhere (no record to emit).
         const backstopTurnEndedAt = endCurrentTurnAtomic(turn, { deferRecord: true, deferObligationClose: true })
+        // #4173 — the ANSWER-READY QUIESCENCE variant of this branch ends the
+        // turn SYNTHETICALLY (durationMs === -1): the claude session is still
+        // composing and its REAL turn_end arrives later. Re-open the atom's
+        // completion window (endCurrentTurnAtomic just stamped
+        // `realEndObservedAt` with the default "ended = really ended" rule) and
+        // hold it pending, so the supersede window for this flush stays
+        // claimable until the real turn_end — or a proxy — is observed. This is
+        // what makes a same-session reply landing after a 20-minute /compact
+        // still collapse onto the flushed message (#4166), without holding the
+        // window open for even a second once the session actually stops.
+        // The TURN-END BACKSTOP variant (durationMs >= 0) fires ON the real
+        // turn_end: the session already stopped, so its window is born
+        // completed (grace-bounded) — it must NOT be re-opened.
+        if (ev.durationMs === -1) {
+          flushCompletionTracker.open(turn)
+        }
         // #549 fix — turn-flush takes ownership of the captured-text
         // backup; reset the preamble buffer (its content is already in
         // the captured `capturedText`, which turn-flush is about to send).
@@ -2446,7 +2515,17 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
               flushedTurnSupersede.record(
                 backstopChatId,
                 backstopThreadId,
-                { turnId: turn.turnId, messageIds: sentIds, text: capturedText },
+                // #4173 — inherit the atom's completion state: the async send
+                // above can outlast the real turn_end (a close that ran while
+                // we awaited stamped `realEndObservedAt`), and a window closed
+                // before its record existed must be born completed
+                // (grace-bounded), never resurrected as open.
+                {
+                  turnId: turn.turnId,
+                  messageIds: sentIds,
+                  text: capturedText,
+                  completedAt: turn.realEndObservedAt,
+                },
                 Date.now(),
               )
             }

--- a/telegram-plugin/gateway/subagent-handback-marker.ts
+++ b/telegram-plugin/gateway/subagent-handback-marker.ts
@@ -18,9 +18,9 @@
  *     #1177/#1182/#1201 double-sent).
  *   - CASE B — a background handback attributed to that ended turn. A
  *     `subagent_handback` WAS enqueued after the turn ended and within the
- *     supersede TTL, so the late reply might BE it → keep the #3429 content gate
- *     and send fresh (two messages), never silently edit/delete the flushed
- *     answer.
+ *     handback recency window (`HANDBACK_RECENCY_WINDOW_MS` below, #4174), so
+ *     the late reply might BE it → keep the #3429 content gate and send fresh
+ *     (two messages), never silently edit/delete the flushed answer.
  *
  * ## Why thread-keyed (F2, dup-audit 2026-07-21)
  *
@@ -65,12 +65,30 @@
  *     reply with NO live gateway turn of its own (a background worker completion),
  *     so its reply resolves a DIFFERENT, already-ended turn via the latest-ended
  *     tier. It is the F1 vector.
- *   - Every OTHER synthesized source (cron, resume_*, reaction, vault_*, …) lands
- *     as its OWN live inbound turn, so its reply resolves the `live` tier for its
- *     own turnId and structurally cannot supersede a different ended turn's flush
- *     record (`decideSupersede` requires `record.turnId === liveTurnId`). Those
- *     must NOT stamp — stamping them would needlessly hold the content gate open
- *     for an unrelated own-reply in the window (a safe but avoidable visible dup).
+ *   - Every OTHER synthesized source that traverses THIS chokepoint (resume_*,
+ *     reaction, vault_*, Tier-2 cron, …) lands as its OWN live inbound turn, so
+ *     its reply resolves the `live` tier for its own turnId and structurally
+ *     cannot supersede a different ended turn's flush record (`decideSupersede`
+ *     requires `record.turnId === liveTurnId`). Those must NOT stamp — stamping
+ *     them would needlessly hold the content gate open for an unrelated
+ *     own-reply in the window (a safe but avoidable visible dup).
+ *
+ * ## What this chokepoint CANNOT see (#4172 — the caller-identity gate)
+ *
+ * The invariant above only covers sources delivered through
+ * `pendingInboundBuffer.push`. A Tier-1 CHEAP-CRON fire is delivered via
+ * `sendToAgent` to the derived `<agent>-cron` bridge and never traverses the
+ * buffer — AND its session events are dropped for the cron identity in
+ * `onSessionEvent`, so it never mints a live gateway turn either. Its `reply`
+ * therefore arrives decoupled (turn == null) with foreign content and NO
+ * marker — exactly the shape marker-absence was claimed to disprove. The same
+ * holds for any reply arriving on a connection that is not the main agent
+ * bridge. That class is closed at a DIFFERENT chokepoint: the reply send path
+ * (`outbound-send-path.ts`) refuses supersede/bypass/latch authority to any
+ * caller that is not the main agent bridge (`replyCallerIsForeignSession`,
+ *  cron-session.ts) — identity, not marker stamping, is the deterministic
+ * signal there. Setting `cron: { decoupledCompletion: true }` below would NOT
+ * work: a Tier-1 fire never reaches this registry's write site.
  *
  * This predicate is therefore the SINGLE point of extension: any future feature
  * that synthesizes an inbound which can land as a DECOUPLED late reply (no live
@@ -114,6 +132,12 @@ export const INBOUND_SOURCE_CLASSIFICATION: Record<string, { decoupledCompletion
   // Everything below lands as its OWN live inbound turn (live tier), so its reply
   // resolves the live tier for its own turnId and structurally cannot supersede a
   // different ended turn's record → not a decoupled-completion vector, must not stamp.
+  //
+  // cron: `false` covers the TIER-2 (main-bridge, `context:'agent'`) fire, which
+  // does land as its own live turn through this chokepoint. The TIER-1 cheap-cron
+  // fire never traverses this chokepoint AT ALL (see "What this chokepoint
+  // CANNOT see" above) — it is closed by the caller-identity gate in the reply
+  // send path (#4172), and flipping this to `true` would not reach it.
   cron: { decoupledCompletion: false },
   reaction: { decoupledCompletion: false },
   subagent_progress: { decoupledCompletion: false },
@@ -167,6 +191,22 @@ export function stampsHandbackMarker(source: string | null | undefined): boolean
   if (known == null) return true // fail-safe: unknown synthesized source stamps
   return known.decoupledCompletion
 }
+
+/**
+ * #4174 — how long after a `subagent_handback` enqueue the content gate stays
+ * held for late replies attributed to an ended turn (`handbackCouldOwnReply`,
+ * outbound-send-path.ts). This deliberately does NOT follow the supersede
+ * window's bounds (#4173): the gate-hold is CHAT-WIDE (the latest-ended owner
+ * tier is chat-wide, so the read must be too — MUST-FIX 2 above), which means
+ * every in-window handback re-opens the reworded-own-answer visible-duplicate
+ * class for EVERY topic in the chat for the window's length. 60 s — the
+ * originally shipped bound — covers the enqueue→decoupled-reply gap the marker
+ * exists for, while keeping the chat-wide dup exposure per handback small. In
+ * a delegation-heavy agent, tying this to a minutes-long supersede bound would
+ * hold the gate almost continuously — re-opening the exact duplicate class the
+ * supersede machinery closes.
+ */
+export const HANDBACK_RECENCY_WINDOW_MS = 60_000
 
 /** Sentinel thread key for the no-thread (DM / bare-chat) lane. */
 const MAIN_THREAD_KEY = '<main>'

--- a/telegram-plugin/gateway/subagent-reply-authority.ts
+++ b/telegram-plugin/gateway/subagent-reply-authority.ts
@@ -1,0 +1,147 @@
+/**
+ * #4176 — sub-agent reply authority: the discriminator the "serial session"
+ * premise was missing.
+ *
+ * ## The premise that was false
+ *
+ * The turn-completion window (#4173, `flushed-turn-supersede.ts`) rests on this
+ * claim: a `reply` landing on the MAIN agent bridge between a flush's SYNTHETIC
+ * turn_end and the session's REAL turn_end is, by construction, that turn's own
+ * answer still being composed. The stated justification was that no other work
+ * can run on the serial claude session in that span.
+ *
+ * That is true of the session's OWN loop and false of its sub-agents. A
+ * background `Task` sub-agent runs CONCURRENTLY with the parent loop, and it
+ * calls MCP tools through the SAME plugin process and therefore the SAME IPC
+ * bridge — so `client.agentName` is the main agent and the #4172 caller-identity
+ * gate (`replyCallerIsForeignSession`) does not see it. In this fleet the
+ * `researcher` and `reviewer` sub-agent types hold the full tool set, `reply`
+ * included (`worker` holds only `progress_update`).
+ *
+ * The concrete loss that made this a MAJOR (review of #4167): the quiescence
+ * flush delivers the answer as message A and the window is OPEN; a background
+ * sub-agent calls `reply` into the same chat; owner resolution lands on the
+ * flush-ended turn (OPEN is accepted at ANY age up to the crash cap); no
+ * `subagent_handback` marker exists because a DIRECT tool call never traverses
+ * `pendingInboundBuffer.push`; `decideContentGateBypass` therefore grants
+ * `positiveAttribution`, and `decideSupersede` supersedes REGARDLESS of content
+ * — the sub-agent's message silently EDITS OVER the user's flushed answer
+ * (Telegram edits do not re-notify: both messages are lost client-side). The
+ * class pre-exists on `main` bounded by the old 60 s TTL; #4173 extends the tail
+ * to the OPEN-phase cap, which is why it is closed here rather than narrowed.
+ *
+ * ## The discriminator: gateway-observed sub-agent LIVENESS
+ *
+ * The gateway already receives the whole session-event stream, including every
+ * `sub_agent_*` kind, at `onSessionEvent` → `handleSessionEvent`. Those events
+ * are derived by the framework from the sidechain transcript
+ * (`projectSubagentLine`, session-tail.ts) — never from model discipline, never
+ * from anything a reply can steer.
+ *
+ * A sub-agent is tracked LIVE from any `sub_agent_*` event carrying its
+ * `agentId` until its `sub_agent_turn_end`. While ANY sub-agent is live, a
+ * decoupled reply on the main bridge MIGHT be that sub-agent's, so it is denied
+ * the #3429 content-gate bypass (`decideContentGateBypass`) — the reply must
+ * then BE the flushed answer to supersede it. A sub-agent's own (foreign)
+ * content therefore decides `'new-content'` and ships as a fresh, notifying
+ * message, with the flush record left intact for the turn's genuine replay.
+ *
+ * ### Why liveness and not per-reply correlation
+ *
+ * Correlating the landing MCP call with the `sub_agent_tool_use` event for that
+ * same `reply` would be exact, but the two arrive on independent transports (an
+ * MCP stdio round-trip vs. a JSONL tail), so the event can land AFTER the reply
+ * it describes — a race whose losing side is the silent edit-over. Liveness has
+ * the ordering the correlation lacks: a sub-agent cannot call a tool before it
+ * exists, and `sub_agent_started` is projected from its FIRST transcript line,
+ * which precedes any tool call it makes by a full model round-trip. The gate is
+ * therefore armed by the time the reply can exist — a structural ordering
+ * argument, not a tuned delay.
+ *
+ * ### Failure directions (all fail SAFE)
+ *
+ *   - A sub-agent whose `sub_agent_turn_end` is never observed (capped, killed,
+ *     crashed tail) stays live: the content gate holds, so the worst case is a
+ *     REWORDED own-answer shipping as a visible duplicate. Never an edit-over.
+ *     `reset()` on bridge death bounds it — the sub-agents die with the session.
+ *   - A sub-agent steered after its `turn_end` (switchroom's `SendMessage`
+ *     pattern) re-arms on its next `sub_agent_*` event, which again precedes any
+ *     reply it makes by a model round-trip.
+ *   - No sub-agent live ⇒ the premise HOLDS and the #4166 collapse is untouched;
+ *     this gate costs nothing in the non-delegating case.
+ *
+ * ### Residual, stated honestly
+ *
+ * Denying the BYPASS (rather than supersede authority wholesale) is deliberate:
+ * with the gate on, a reply still supersedes when it IS the flushed answer
+ * (`flushedAnswerMatchesReply` — equality, or containment above
+ * `SUPERSEDE_MATCH_MIN_CONTAINMENT_CHARS`). Superseding on equality is
+ * content-preserving by definition. The residual is the containment arm: a
+ * sub-agent reply that is a ≥32-char verbatim substring of the flushed answer
+ * would still collapse into it. Denying supersede outright instead would, in a
+ * delegation-heavy agent where a background worker is nearly always live,
+ * re-open #4166 for every own-answer replay — a far larger, constant cost for a
+ * class that requires a sub-agent to emit a verbatim substring of the parent's
+ * answer.
+ *
+ * Pure: a set of ids, no clock reads, no I/O. The gateway wires the feed
+ * (`onSessionEvent`) and the read (the `sendReply` deps).
+ */
+
+/** The read surface the reply send path consumes (injected, so the golden
+ *  harness drives it without touching the singleton). */
+export interface SubagentReplyAuthorityView {
+  /** True when at least one sub-agent is live on this session and could
+   *  therefore be the author of a decoupled reply landing right now. */
+  subagentCouldOwnReply(): boolean
+}
+
+/** The minimal session-event shape this tracker reads. Structural so the module
+ *  never imports the session-tail union (no cycle, trivially fake-able). */
+export interface SubagentLifecycleEvent {
+  kind: string
+  agentId?: string
+}
+
+const SUB_AGENT_KIND_PREFIX = 'sub_agent_'
+
+export class SubagentReplyAuthority implements SubagentReplyAuthorityView {
+  private readonly live = new Set<string>()
+
+  /** Feed EVERY session event here. Non-`sub_agent_*` kinds are ignored, so the
+   *  call site needs no filtering (and cannot drift from this one). */
+  noteSessionEvent(ev: SubagentLifecycleEvent | null | undefined): void {
+    if (ev == null) return
+    const kind = ev.kind
+    if (typeof kind !== 'string' || !kind.startsWith(SUB_AGENT_KIND_PREFIX)) return
+    const agentId = ev.agentId
+    // An id-less sub-agent event cannot be attributed to a lifecycle; ignoring
+    // it is the safe direction for `turn_end` (liveness persists → gate holds)
+    // and merely a missed arm otherwise — every other kind for a real sub-agent
+    // carries the id.
+    if (typeof agentId !== 'string' || agentId === '') return
+    if (kind === `${SUB_AGENT_KIND_PREFIX}turn_end`) this.live.delete(agentId)
+    else this.live.add(agentId)
+  }
+
+  subagentCouldOwnReply(): boolean {
+    return this.live.size > 0
+  }
+
+  /** The bridge died: the claude session and every sub-agent under it are gone.
+   *  Bounds a leaked liveness entry (see "Failure directions"). */
+  reset(): void {
+    this.live.clear()
+  }
+
+  /** Test/diagnostics: how many sub-agents are currently tracked live. */
+  liveCount(): number {
+    return this.live.size
+  }
+}
+
+/** The ONE live instance (one CLI session per gateway process — the same
+ *  module-singleton shape as `flushCompletionTracker` in stream-render.ts).
+ *  Re-`new`ing this anywhere else splits the signal and silently re-opens the
+ *  edit-over hole. */
+export const subagentReplyAuthority = new SubagentReplyAuthority()

--- a/telegram-plugin/gateway/turn-end.ts
+++ b/telegram-plugin/gateway/turn-end.ts
@@ -437,10 +437,18 @@ function endCurrentTurnAtomic(
   const turnEndedAt = Date.now()
   // 2026-07 double-reply-on-DM fix (F2) — stamp the turn's end time so the
   // `latest-ended` supersede tier can be recency-bounded to the
-  // supersede TTL (a stale latest-ended turn must not inherit deletion
+  // turn-completion window (a stale latest-ended turn must not inherit deletion
   // authority over a newer turn's flush record). Set once; idempotent on the
   // deferRecord flush path (which calls this synchronously before its send).
   turn.endedAt = turnEndedAt
+  // #4173 — default completion stamp: for every ordinary turn-end path, the
+  // turn ending IS the session's real stop, so the completion window is born
+  // closed (the latest-ended tier keeps its tight ~60 s replay grace). The ONE
+  // path where that is false — the answer-ready quiescence flush, which ends
+  // the turn synthetically while the session is still composing — re-opens the
+  // window right after this call (`flushCompletionTracker.open`, stream-render
+  // turn-flush branch) and holds it until the REAL turn_end is observed.
+  turn.realEndObservedAt = turnEndedAt
   process.stderr.write(
     `telegram gateway: ${formatTurnLifecycle('clear', 'turn_end', turn, turnEndedAt)}\n`,
   )

--- a/telegram-plugin/reply-owner-resolve.ts
+++ b/telegram-plugin/reply-owner-resolve.ts
@@ -41,6 +41,11 @@
  * feeds their resolved turnIds here; the precedence lives in one place.
  */
 
+// The one cross-module import this pure module takes — a sibling PURE module's
+// constant, so the two consumers of the turn-completion window (#4173) can
+// never disagree on the default replay grace.
+import { SUPERSEDE_COMPLETED_GRACE_MS } from './flushed-turn-supersede.js'
+
 /**
  * The four owner-turn candidate ids, in the gateway's resolution precedence.
  * Each is the `turnId` of the turn a given lookup resolved, or null when that
@@ -63,38 +68,75 @@ export interface ReplyOwnerCandidates {
   latestEndedTurnId: string | null
   /** Age (ms) of the latest-ended turn — `now - turn.endedAt`. The latest-ended
    *  tier carries DESTRUCTIVE authority (it drives supersede deletion), so it is
-   *  honoured ONLY when the turn ended within `latestEndedTtlMs` (the supersede
-   *  TTL). Without the bound, a late reply belonging to an OLDER turn could
-   *  resolve its owner to a NEWER turn now sitting at the registry tail and
-   *  delete THAT turn's legit answer.
+   *  honoured ONLY within the turn-completion window (#4173 — see
+   *  `latestEndedRealEndAgeMs`). Without a bound, a late reply belonging to an
+   *  OLDER turn could resolve its owner to a NEWER turn now sitting at the
+   *  registry tail and delete THAT turn's legit answer.
    *
    *  Two distinct absences (#3725):
-   *    - `undefined` (property omitted) ⇒ unbounded, the pre-F2 back-compat
-   *      escape for callers that don't supply an age at all;
+   *    - `undefined` (property omitted) ⇒ no age supplied at all — fails
+   *      CLOSED since #4175 (the pre-F2 "unbounded" escape granted unbounded
+   *      destructive authority exactly when the wiring was DROPPED, the
+   *      dangerous direction);
    *    - explicit `null` ⇒ the caller COMPUTED no age, i.e. its candidate turn
-   *      has no `endedAt` and has NOT ended. That cannot be TTL-bounded, so it
+   *      has no `endedAt` and has NOT ended. That cannot be bounded, so it
    *      fails CLOSED (not accepted) rather than granting unbounded authority
    *      to a turn that is still running. */
   latestEndedAgeMs?: number | null
-  /** The supersede TTL bound applied to `latestEndedAgeMs`. Undefined ⇒
-   *  unbounded. */
+  /** Bound applied to `latestEndedAgeMs` while the turn's completion window is
+   *  OPEN (#4173): for a flush-ended turn whose REAL turn_end has not been
+   *  observed yet, this is the crash-backstop cap
+   *  (`SUPERSEDE_OPEN_WINDOW_CAP_MS`). Undefined ⇒ fails closed (#4175). */
   latestEndedTtlMs?: number
+  /** #4173 — the turn-completion signal, ms since the candidate turn's REAL
+   *  turn_end was observed (`turn.realEndObservedAt`):
+   *    - `null` ⇒ the real turn_end has NOT been observed (a flush ended this
+   *      turn synthetically and the session is still composing) — the OPEN
+   *      phase; acceptance falls to `latestEndedAgeMs <= latestEndedTtlMs`
+   *      (the crash backstop), so a 20-minute compaction still resolves.
+   *    - a number ⇒ the session stopped that long ago — the COMPLETED phase;
+   *      accepted only within `latestEndedCompletedGraceMs` (the bounded
+   *      tool-call-replay window). For a normally-ended turn the real end IS
+   *      `endedAt`, so this equals `latestEndedAgeMs` and the tier keeps its
+   *      original tight ~60 s bound.
+   *    - `undefined` ⇒ legacy caller shape (no completion signal wired):
+   *      falls back to the plain `age <= ttl` rule. */
+  latestEndedRealEndAgeMs?: number | null
+  /** COMPLETED-phase bound for `latestEndedRealEndAgeMs`. Undefined ⇒ the
+   *  module default (`SUPERSEDE_COMPLETED_GRACE_MS`). */
+  latestEndedCompletedGraceMs?: number
 }
 
 /**
  * Whether the latest-ended candidate is fresh enough to carry supersede
- * (deletion) authority. An OMITTED age or TTL means unbounded (the pre-F2
- * back-compat escape); an EXPLICIT null age fails closed (#3725 — the caller
- * computed no age because its candidate turn has not ended, and an un-ended turn
- * must be resolved by the `live` tier, never by this destructive fallback).
+ * (deletion) authority — the turn-completion-window rule (#4173, three phases
+ * documented on `latestEndedRealEndAgeMs` above).
+ *
+ * An EXPLICIT null age fails closed (#3725 — the caller computed no age
+ * because its candidate turn has not ended, and an un-ended turn must be
+ * resolved by the `live` tier, never by this destructive fallback). An OMITTED
+ * age or TTL also fails closed (#4175): the old "omitted ⇒ unbounded"
+ * back-compat escape meant DROPPING the gateway's bound wiring silently
+ * granted unbounded destructive authority — failing toward silent edit-over.
+ * Now dropped wiring degrades to "tier never accepted" — a visible duplicate,
+ * the safe direction.
  */
 function latestEndedAccepted(candidates: ReplyOwnerCandidates): boolean {
   if (candidates.latestEndedTurnId == null) return false
   const age = candidates.latestEndedAgeMs
   const ttl = candidates.latestEndedTtlMs
-  if (age === null) return false
-  if (age === undefined || ttl == null) return true
-  return age <= ttl
+  if (age == null || ttl == null) return false
+  const realEndAge = candidates.latestEndedRealEndAgeMs
+  if (realEndAge === undefined || realEndAge === null) {
+    // Legacy caller (no completion signal) or OPEN window (real turn_end not
+    // yet observed): the plain age-vs-cap rule. For an open window `ttl` is
+    // the generous crash backstop, so a long compaction still resolves.
+    return age <= ttl
+  }
+  // COMPLETED: the session stopped `realEndAge` ago — only the bounded
+  // tool-call-replay grace remains.
+  const grace = candidates.latestEndedCompletedGraceMs ?? SUPERSEDE_COMPLETED_GRACE_MS
+  return realEndAge <= grace
 }
 
 /**
@@ -216,13 +258,15 @@ export function decideContentGateBypass(input: {
   /** The SAME candidate set both of the above were derived from — supplies the
    *  framework-derived `latestEndedTurnId` plus its freshness bound, so the
    *  corroboration reuses the EXACT rule `resolveReplyOwnerTier` applies
-   *  (`latestEndedAccepted`) instead of duplicating it: within the TTL, and —
-   *  since #3725 — not a turn that is still running. */
+   *  (`latestEndedAccepted`) instead of duplicating it: within the
+   *  turn-completion window (#4173), and — since #3725 — not a turn that is
+   *  still running. */
   candidates: ReplyOwnerCandidates
   /** True when a decoupled-completion inbound (`subagent_handback`) was enqueued
-   *  in this chat AFTER the owner turn ended and within the supersede TTL — the
-   *  ambiguous window where the late reply might BE that handback rather than
-   *  the turn's own answer. Keeps the content gate on every non-`live` tier. */
+   *  in this chat AFTER the owner turn ended and within the handback recency
+   *  window (`HANDBACK_RECENCY_WINDOW_MS`, #4174) — the ambiguous window where
+   *  the late reply might BE that handback rather than the turn's own answer.
+   *  Keeps the content gate on every non-`live` tier. */
   handbackCouldOwnReply: boolean
 }): boolean {
   if (input.tier === 'live') return true
@@ -260,16 +304,17 @@ export function decideContentGateBypass(input: {
  * handback pattern (#3426): the parent turn's interim ack (a substantive
  * `reply`) armed the latch, the turn ended, and the sub-agent completion
  * handback — a genuinely NEW answer arriving with no live gateway turn —
- * resolved the ended turn as owner (latest-ended tier, inside the 60 s
- * supersede TTL), saw the stale latch, and was silently dropped with a false
+ * resolved the ended turn as owner (latest-ended tier, inside the — then 60 s —
+ * supersede window), saw the stale latch, and was silently dropped with a false
  * "deduped" success. Tagging the source lets the suppression fire ONLY for the
  * flush races it exists for; byte-identical replays of a reply-delivered
  * answer remain covered by the content-keyed outbound dedup (#546).
  *
  * Honest bound on that dedup cover: the #546 TTL (60 s) is anchored at reply
- * RECORD time, while the latest-ended owner tier's 60 s is anchored at the
- * turn's `endedAt` — later by the reply→turn_end gap. A byte-identical replay
- * landing >60 s after record but ≤60 s after endedAt is evicted from dedup yet
+ * RECORD time, while the latest-ended owner tier's bound is the turn-completion
+ * window (#4173) anchored at the turn's OBSERVED real end — later by the
+ * reply→turn_end gap. A byte-identical replay landing >60 s after record but
+ * still inside the completion window is evicted from dedup yet
  * still resolves the ended turn, so it DELIVERS as a duplicate message. That
  * is a conscious trade: this fix also drops the weak "reworded/bridge-replayed
  * duplicate" suppression the reply-armed boolean latch used to provide —

--- a/telegram-plugin/reply-owner-resolve.ts
+++ b/telegram-plugin/reply-owner-resolve.ts
@@ -249,6 +249,21 @@ export function resolveReplyOwnerTurnId(candidates: ReplyOwnerCandidates): strin
  * `live` keeps its unconditional bypass: `currentTurn` is framework-owned, and
  * `decideSupersede`'s same-turnId requirement already bars it from reaching a
  * DIFFERENT ended turn's record. `none` never bypasses (nothing to attribute).
+ *
+ * ## The second ambiguity: a live sub-agent (#4176)
+ *
+ * `handbackCouldOwnReply` covers the sub-agent completion that the gateway
+ * SYNTHESIZED as an inbound. It does not cover a background sub-agent calling
+ * `reply` DIRECTLY, mid-run: that call rides the same main bridge as the parent
+ * loop (so the #4172 caller-identity gate cannot see it) and never traverses
+ * `pendingInboundBuffer.push` (so no marker is stamped). Marker-absence is only
+ * evidence of "the turn's own answer" if nothing else on the session could have
+ * emitted this reply — which is exactly what `subagentCouldOwnReply` reports,
+ * from gateway-observed `sub_agent_*` liveness. When it is true the content gate
+ * is KEPT on every non-`live` tier: a reply that IS the flushed answer still
+ * collapses, a sub-agent's foreign content sends fresh. See
+ * `gateway/subagent-reply-authority.ts` for the ordering argument and the
+ * failure directions.
  */
 export function decideContentGateBypass(input: {
   /** The winning owner tier (`resolveReplyOwnerTier`). */
@@ -268,10 +283,26 @@ export function decideContentGateBypass(input: {
    *  the late reply might BE that handback rather than the turn's own answer.
    *  Keeps the content gate on every non-`live` tier. */
   handbackCouldOwnReply: boolean
+  /** #4176 — true when a sub-agent is LIVE on this session
+   *  (`subagentReplyAuthority`, gateway/subagent-reply-authority.ts). A
+   *  background `Task` sub-agent calls `reply` over the SAME main bridge as the
+   *  parent loop, so the #4172 caller-identity gate cannot see it and — because
+   *  a DIRECT tool call never traverses `pendingInboundBuffer.push` — it stamps
+   *  no handback marker either. Marker-absence therefore does NOT prove "the
+   *  turn's own answer" while a sub-agent is live: the reply might be the
+   *  sub-agent's, and bypassing the content gate would silently EDIT OVER the
+   *  flushed answer. Typed REQUIRED and evaluated FAIL-CLOSED (anything but an
+   *  explicit `false` keeps the gate): `telegram-plugin/` is not covered by
+   *  `tsc --noEmit`, so the type alone cannot stop a caller from dropping the
+   *  wiring — and the #4175 precedent is that a dropped bound fails closed,
+   *  never open. */
+  subagentCouldOwnReply: boolean
 }): boolean {
   if (input.tier === 'live') return true
   if (input.tier === 'none') return false
   if (input.handbackCouldOwnReply) return false
+  // Fail-CLOSED on an omitted flag (see the field doc): `!== false`, not truthiness.
+  if (input.subagentCouldOwnReply !== false) return false
   // Total over degenerate input (#3726). TypeScript makes `candidates` mandatory
   // and the one production caller (`resolveReplyOwnerTurn`) always builds it, so
   // this cannot fire today — but this module is exported precisely so the

--- a/telegram-plugin/tests/flushed-turn-supersede.test.ts
+++ b/telegram-plugin/tests/flushed-turn-supersede.test.ts
@@ -23,7 +23,9 @@ import {
   decideSupersedeCorrection,
   flushedAnswerMatchesReply,
   FlushedTurnSupersedeRegistry,
-  DEFAULT_SUPERSEDE_TTL_MS,
+  FlushCompletionTracker,
+  SUPERSEDE_OPEN_WINDOW_CAP_MS,
+  SUPERSEDE_COMPLETED_GRACE_MS,
   SUPERSEDE_MATCH_MIN_CONTAINMENT_CHARS,
   type FlushedTurnRecord,
 } from '../flushed-turn-supersede.js'
@@ -33,6 +35,8 @@ const rec = (over: Partial<FlushedTurnRecord> = {}): FlushedTurnRecord => ({
   messageIds: [101, 102],
   text: 'narration\n\nthe real answer',
   ts: 1_000_000,
+  // #4173 — default fixture is an OPEN window (real turn_end not yet observed).
+  completedAt: null,
   ...over,
 })
 
@@ -133,11 +137,12 @@ describe('decideSupersede — the duplicate-reply decision core', () => {
     expect(d.reason).toBe('different-turn')
   })
 
-  it('2026-08-01 incident gap: a record is still live 143 s after the flush ' +
+  it('2026-08-01 incident gap: an OPEN record is still live 143 s after the flush ' +
     '(Stop-hook nudge + proactive /compact delayed the canonical reply)', () => {
     // klanker msgs 25680/25682: under the old 60 s TTL this returned 'expired'
-    // and the reply shipped as a second bubble. The default window must cover
-    // at least the observed slow-path gap.
+    // and the reply shipped as a second bubble. With the turn-completion window
+    // (#4173) the record stays claimable while the session is still composing
+    // (real turn_end not yet observed — completedAt null).
     const d = decideSupersede(rec(), {
       liveTurnId: 'turn-A',
       now: 1_000_000 + 143_000,
@@ -146,10 +151,46 @@ describe('decideSupersede — the duplicate-reply decision core', () => {
     expect(d.reason).toBe('supersede')
   })
 
-  it('does NOT supersede once the record is past its TTL', () => {
+  it('#4173 outcome: an OPEN record survives a 20-minute /compact — any fixed ' +
+    'sub-20-min TTL turns this red', () => {
+    // The point of the completion signal over a widened constant: a compaction
+    // longer than any tuned TTL still collapses to ONE bubble, because the
+    // claude session has not stopped (no real turn_end observed).
     const d = decideSupersede(rec(), {
       liveTurnId: 'turn-A',
-      now: 1_000_000 + DEFAULT_SUPERSEDE_TTL_MS + 1,
+      now: 1_000_000 + 20 * 60_000,
+    })
+    expect(d.supersede).toBe(true)
+    expect(d.reason).toBe('supersede')
+  })
+
+  it('an OPEN record past the crash-backstop cap does NOT supersede', () => {
+    const d = decideSupersede(rec(), {
+      liveTurnId: 'turn-A',
+      now: 1_000_000 + SUPERSEDE_OPEN_WINDOW_CAP_MS + 1,
+    })
+    expect(d.supersede).toBe(false)
+    expect(d.reason).toBe('expired')
+  })
+
+  it('#4173: a COMPLETED record stays claimable through the replay grace ' +
+    '(the bridge-reconnect tool_call replay class) …', () => {
+    const d = decideSupersede(rec({ completedAt: 1_010_000 }), {
+      liveTurnId: 'turn-A',
+      now: 1_010_000 + SUPERSEDE_COMPLETED_GRACE_MS - 1,
+    })
+    expect(d.supersede).toBe(true)
+  })
+
+  it('… and EXPIRES past the grace — a late claimant (the Task-sub-agent-after-' +
+    'turn-end shape) can no longer reach the record at all', () => {
+    // Once the session stopped and the grace lapsed, nothing may edit/delete
+    // the flushed answer — a genuinely late duplicate ships fresh (safe).
+    const d = decideSupersede(rec({ completedAt: 1_010_000 }), {
+      liveTurnId: 'turn-A',
+      replyText: 'unrelated worker handback content, definitely not the answer',
+      positiveAttribution: true,
+      now: 1_010_000 + SUPERSEDE_COMPLETED_GRACE_MS + 1,
     })
     expect(d.supersede).toBe(false)
     expect(d.reason).toBe('expired')
@@ -262,7 +303,7 @@ describe('FlushedTurnSupersedeRegistry — record / peek / take lifecycle', () =
   })
 
   it('size() evicts expired records and prunes emptied lanes', () => {
-    const reg = new FlushedTurnSupersedeRegistry({ ttlMs: 1000 })
+    const reg = new FlushedTurnSupersedeRegistry({ openCapMs: 1000 })
     reg.record('chat1', undefined, { turnId: 'turn-A', messageIds: [1], text: 'a' }, 1000)
     reg.record('chat1', undefined, { turnId: 'turn-B', messageIds: [2], text: 'b' }, 1000)
     expect(reg.size(1500)).toBe(2)
@@ -270,7 +311,7 @@ describe('FlushedTurnSupersedeRegistry — record / peek / take lifecycle', () =
   })
 
   it('record() actively sweeps expired records (LOW-2 GC — no orphan accumulation)', () => {
-    const reg = new FlushedTurnSupersedeRegistry({ ttlMs: 1000 })
+    const reg = new FlushedTurnSupersedeRegistry({ openCapMs: 1000 })
     reg.record('chat1', undefined, { turnId: 'turn-A', messageIds: [1], text: 'a' }, 1000)
     // A much later flush on a DIFFERENT lane sweeps the now-expired turn-A record.
     reg.record('chat2', undefined, { turnId: 'turn-B', messageIds: [2], text: 'b' }, 5000)
@@ -447,12 +488,12 @@ describe('positiveAttribution — tier-gated content check', () => {
     expect(d.reason).toBe('different-turn')
   })
 
-  it('positiveAttribution=true still respects the TTL (expired record never supersedes)', () => {
-    const d = decideSupersede(rec({ text: FLUSHED }), {
+  it('positiveAttribution=true still respects the window (expired record never supersedes)', () => {
+    const d = decideSupersede(rec({ text: FLUSHED, completedAt: 1_000_000 }), {
       liveTurnId: 'turn-A',
       replyText: REWORDED,
       positiveAttribution: true,
-      now: 1_000_000 + DEFAULT_SUPERSEDE_TTL_MS + 1,
+      now: 1_000_000 + SUPERSEDE_COMPLETED_GRACE_MS + 1,
     })
     expect(d.supersede).toBe(false)
     expect(d.reason).toBe('expired')
@@ -481,5 +522,53 @@ describe('positiveAttribution — tier-gated content check', () => {
     expect(positive.supersede).toBe(true)
     expect(positive.deleteMessageIds).toEqual([8001])
     expect(reg.peek('chatT', undefined, { liveTurnId: 'turn-Q', now: now + 7_000 }).reason).toBe('no-record')
+  })
+})
+
+describe('#4173 — turn-completion window plumbing (completeAll / FlushCompletionTracker)', () => {
+  it('completeAll(now) flips OPEN records to grace-bounded; already-completed keep their earlier stamp', () => {
+    const reg = new FlushedTurnSupersedeRegistry()
+    reg.record('chat1', undefined, { turnId: 'turn-A', messageIds: [1], text: 'a' }, 1_000)
+    reg.record('chat1', undefined, { turnId: 'turn-B', messageIds: [2], text: 'b', completedAt: 2_000 }, 1_000)
+    reg.completeAll(50_000)
+    // turn-A: completed at 50s → claimable until 50s+grace, expired after.
+    expect(reg.peek('chat1', undefined, { liveTurnId: 'turn-A', now: 50_000 + SUPERSEDE_COMPLETED_GRACE_MS - 1 }).supersede).toBe(true)
+    expect(reg.peek('chat1', undefined, { liveTurnId: 'turn-A', now: 50_000 + SUPERSEDE_COMPLETED_GRACE_MS + 1 }).reason).toBe('expired')
+    // turn-B kept its ORIGINAL earlier completion (2s) — completeAll never widens.
+    expect(reg.peek('chat1', undefined, { liveTurnId: 'turn-B', now: 2_000 + SUPERSEDE_COMPLETED_GRACE_MS + 1 }).reason).toBe('expired')
+  })
+
+  it('a record born completed (flush send finished AFTER the close) is grace-bounded, never open', () => {
+    const reg = new FlushedTurnSupersedeRegistry()
+    // The close ran at t=5s while the flush send was in flight; record lands at
+    // t=6s carrying the atom's stamped completion.
+    reg.record('chatX', undefined, { turnId: 'turn-C', messageIds: [9], text: 'c', completedAt: 5_000 }, 6_000)
+    expect(reg.peek('chatX', undefined, { liveTurnId: 'turn-C', now: 5_000 + SUPERSEDE_COMPLETED_GRACE_MS + 1 }).reason).toBe('expired')
+  })
+
+  it('FlushCompletionTracker: open() nulls realEndObservedAt; closeAll() stamps every pending atom once', () => {
+    const t = new FlushCompletionTracker()
+    const turnA = { realEndObservedAt: 111 as number | null }
+    const turnB = { realEndObservedAt: 222 as number | null }
+    t.open(turnA)
+    t.open(turnB)
+    expect(turnA.realEndObservedAt).toBeNull()
+    expect(turnB.realEndObservedAt).toBeNull()
+    expect(t.pendingCount()).toBe(2)
+    expect(t.closeAll(9_000)).toBe(2)
+    expect(turnA.realEndObservedAt).toBe(9_000)
+    expect(turnB.realEndObservedAt).toBe(9_000)
+    expect(t.pendingCount()).toBe(0)
+    // Idempotent: nothing pending → nothing closed, stamps untouched.
+    expect(t.closeAll(10_000)).toBe(0)
+    expect(turnA.realEndObservedAt).toBe(9_000)
+  })
+
+  it('FlushCompletionTracker: re-open of the same atom does not double-register', () => {
+    const t = new FlushCompletionTracker()
+    const turn = { realEndObservedAt: null as number | null }
+    t.open(turn)
+    t.open(turn)
+    expect(t.pendingCount()).toBe(1)
   })
 })

--- a/telegram-plugin/tests/flushed-turn-supersede.test.ts
+++ b/telegram-plugin/tests/flushed-turn-supersede.test.ts
@@ -133,6 +133,19 @@ describe('decideSupersede — the duplicate-reply decision core', () => {
     expect(d.reason).toBe('different-turn')
   })
 
+  it('2026-08-01 incident gap: a record is still live 143 s after the flush ' +
+    '(Stop-hook nudge + proactive /compact delayed the canonical reply)', () => {
+    // klanker msgs 25680/25682: under the old 60 s TTL this returned 'expired'
+    // and the reply shipped as a second bubble. The default window must cover
+    // at least the observed slow-path gap.
+    const d = decideSupersede(rec(), {
+      liveTurnId: 'turn-A',
+      now: 1_000_000 + 143_000,
+    })
+    expect(d.supersede).toBe(true)
+    expect(d.reason).toBe('supersede')
+  })
+
   it('does NOT supersede once the record is past its TTL', () => {
     const d = decideSupersede(rec(), {
       liveTurnId: 'turn-A',

--- a/telegram-plugin/tests/narrative-lane-golden.test.ts
+++ b/telegram-plugin/tests/narrative-lane-golden.test.ts
@@ -423,6 +423,8 @@ function makeSendReplyDeps(dedup: OutboundDedupCache) {
     streamKey: key,
     resolveReplyOwnerTurn: () => ownerRes(null, 'none'),
     getLastSubagentHandbackAt: () => null,
+    // #4176 — no sub-agent live on this session (see subagent-reply-authority.ts).
+    subagentReplyAuthority: { subagentCouldOwnReply: () => false },
     findTurnByOriginId: () => null,
     findTurnByQuotedMessageId: () => null,
     resolveAnswerThreadWithLog: (_c: string, explicit: number | undefined) => explicit,

--- a/telegram-plugin/tests/reply-owner-resolve.test.ts
+++ b/telegram-plugin/tests/reply-owner-resolve.test.ts
@@ -1216,3 +1216,101 @@ describe('#3725 — a still-running turn is not a supersede anchor', () => {
     expect(reg.peek(CHAT, undefined, { liveTurnId: RUNNING, now: NOW + 10 }).supersede).toBe(true)
   })
 })
+
+describe('2026-08-01 klanker incident — slow flush→reply gap (Stop-hook nudge + /compact)', () => {
+  // The observed double-send (gateway-supervisor.log, chat 12345):
+  //   21:17:04  answer-ready quiescence flush delivers msg 25680 (turn #25674)
+  //   21:17:04  proactive /compact fires (occupancy ~393k)
+  //   21:19:28  the model's canonical `reply` lands — 143 s AFTER the flush,
+  //             REWORDED post-compact (1770 vs 1563 chars), no live turn, no
+  //             origin echo (DM), no quote → latest-ended is the only tier.
+  //   21:19:39  msg 25682 ships → the user sees the same answer twice.
+  // Under the old 60 s window BOTH guards had expired: the latest-ended owner
+  // tier rejected the 143 s-old turn (owner=null → the answer-delivered latch
+  // was unreachable) and the registry record itself was 'expired'. These tests
+  // replay the incident timeline through the exact pure cores the gateway wires
+  // (`resolveReplyOwnerTurn` → `decideContentGateBypass` → registry.take`) and
+  // assert the OUTCOME: the late reply collapses onto the flushed message —
+  // one bubble, never two. Shrinking DEFAULT_SUPERSEDE_TTL_MS below the
+  // observed gap turns these red.
+  const CHAT = '424242'
+  const TURN = 'turn-25674'
+  const FLUSH_TS = 5_000_000
+  const REPLY_TS = FLUSH_TS + 143_000 // the observed 2 m 23 s flush→reply gap
+  const FLUSHED_TEXT =
+    'Pulled the live numbers from the usage table. Two findings, and the second one matters: ' +
+    'the per-turn cost is dominated by cache writes, not output tokens.'
+  // Post-compact the model REGENERATED the answer — same substance, different
+  // bytes — so neither the #546 exact-text dedup nor the containment matcher
+  // can catch it; only turnId identity + the content-gate bypass can.
+  const REWORDED_REPLY =
+    'I pulled the live numbers out of the usage table. Two findings — and the second is the ' +
+    'one that matters: cache writes, not output tokens, dominate per-turn cost.'
+
+  const incidentCandidates = (now: number): ReplyOwnerCandidates => ({
+    liveTurnId: null, // flush's synthetic turn_end already tore the atom down
+    originTurnId: null, // DM — no origin_turn_id echo
+    quotedTurnId: null, // no quote linkage
+    latestEndedTurnId: TURN,
+    latestEndedAgeMs: now - FLUSH_TS,
+    latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
+  })
+
+  it('the latest-ended owner tier still accepts the flushed turn 143 s after it ended', () => {
+    const c = incidentCandidates(REPLY_TS)
+    expect(resolveReplyOwnerTier(c)).toBe('latest-ended')
+    expect(resolveReplyOwnerTurnId(c)).toBe(TURN)
+  })
+
+  it('outcome: the reworded late reply supersedes the flushed message — exactly one bubble', () => {
+    const reg = new FlushedTurnSupersedeRegistry()
+    reg.record(CHAT, undefined, { turnId: TURN, messageIds: [25680], text: FLUSHED_TEXT }, FLUSH_TS)
+
+    // The gateway's own composition, step for step (outbound-send-path.ts):
+    const c = incidentCandidates(REPLY_TS)
+    const ownerId = resolveReplyOwnerTurnId(c)
+    const bypass = decideContentGateBypass({
+      tier: resolveReplyOwnerTier(c),
+      resolvedTurnId: ownerId,
+      candidates: c,
+      handbackCouldOwnReply: false, // no subagent_handback enqueued in the window
+    })
+    expect(bypass).toBe(true)
+    const d = reg.take(CHAT, undefined, {
+      liveTurnId: ownerId,
+      replyText: REWORDED_REPLY,
+      positiveAttribution: bypass,
+      now: REPLY_TS,
+    })
+    // The flushed message is corrected in place / replaced — the reply never
+    // ships as a second bubble alongside msg 25680.
+    expect(d).toMatchObject({ supersede: true, reason: 'supersede', deleteMessageIds: [25680] })
+  })
+
+  it('a handback landing in the widened window still keeps the content gate (fresh send, no edit-over)', () => {
+    // Safety half of the widening: MORE time in the window must never convert a
+    // genuinely-new background handback into a silent edit-over of the flushed
+    // answer. With a handback in flight the bypass stays off and different
+    // content declines as 'new-content' (two visible messages — the #3429 trade).
+    const reg = new FlushedTurnSupersedeRegistry()
+    reg.record(CHAT, undefined, { turnId: TURN, messageIds: [25680], text: FLUSHED_TEXT }, FLUSH_TS)
+    const c = incidentCandidates(REPLY_TS)
+    const bypass = decideContentGateBypass({
+      tier: resolveReplyOwnerTier(c),
+      resolvedTurnId: resolveReplyOwnerTurnId(c),
+      candidates: c,
+      handbackCouldOwnReply: true,
+    })
+    expect(bypass).toBe(false)
+    const d = reg.take(CHAT, undefined, {
+      liveTurnId: resolveReplyOwnerTurnId(c),
+      replyText: 'Worker finished: the deploy went out clean, all checks green.',
+      positiveAttribution: bypass,
+      now: REPLY_TS,
+    })
+    expect(d.supersede).toBe(false)
+    expect(d.reason).toBe('new-content')
+    // The record survives for the turn's OWN late replay.
+    expect(reg.peek(CHAT, undefined, { liveTurnId: TURN, now: REPLY_TS }).supersede).toBe(true)
+  })
+})

--- a/telegram-plugin/tests/reply-owner-resolve.test.ts
+++ b/telegram-plugin/tests/reply-owner-resolve.test.ts
@@ -757,6 +757,7 @@ describe('decideContentGateBypass — corroborated bypass of the #3429 content g
         resolvedTurnId: OWNER,
         candidates: cands({ originTurnId: OWNER }),
         handbackCouldOwnReply: false,
+        subagentCouldOwnReply: false,
       }),
     ).toBe(true)
   })
@@ -768,6 +769,7 @@ describe('decideContentGateBypass — corroborated bypass of the #3429 content g
         resolvedTurnId: OWNER,
         candidates: cands({ quotedTurnId: OWNER }),
         handbackCouldOwnReply: false,
+        subagentCouldOwnReply: false,
       }),
     ).toBe(true)
   })
@@ -785,6 +787,7 @@ describe('decideContentGateBypass — corroborated bypass of the #3429 content g
             latestEndedTurnId: OWNER,
           }),
           handbackCouldOwnReply: false,
+          subagentCouldOwnReply: false,
         }),
       ).toBe(false)
     }
@@ -801,6 +804,7 @@ describe('decideContentGateBypass — corroborated bypass of the #3429 content g
             quotedTurnId: tier === 'quoted' ? OWNER : null,
           }),
           handbackCouldOwnReply: true,
+          subagentCouldOwnReply: false,
         }),
       ).toBe(false)
     }
@@ -814,6 +818,7 @@ describe('decideContentGateBypass — corroborated bypass of the #3429 content g
         resolvedTurnId: OWNER,
         candidates: cands({ liveTurnId: OWNER }),
         handbackCouldOwnReply: true,
+        subagentCouldOwnReply: false,
       }),
     ).toBe(true)
   })
@@ -825,6 +830,7 @@ describe('decideContentGateBypass — corroborated bypass of the #3429 content g
         resolvedTurnId: null,
         candidates: cands({ latestEndedTurnId: null }),
         handbackCouldOwnReply: false,
+        subagentCouldOwnReply: false,
       }),
     ).toBe(false)
   })
@@ -841,6 +847,7 @@ describe('decideContentGateBypass — corroborated bypass of the #3429 content g
         resolvedTurnId: OWNER,
         candidates: stale,
         handbackCouldOwnReply: false,
+        subagentCouldOwnReply: false,
       }),
     ).toBe(false)
   })
@@ -852,6 +859,7 @@ describe('decideContentGateBypass — corroborated bypass of the #3429 content g
         resolvedTurnId: OWNER,
         candidates: cands(),
         handbackCouldOwnReply: false,
+        subagentCouldOwnReply: false,
       }),
     ).toBe(true)
   })
@@ -872,6 +880,7 @@ describe('decideContentGateBypass — corroborated bypass of the #3429 content g
             resolvedTurnId: OWNER,
             candidates: absent as unknown as ReplyOwnerCandidates,
             handbackCouldOwnReply: false,
+            subagentCouldOwnReply: false,
           }),
         ).toBe(false)
       }
@@ -934,7 +943,11 @@ describe('decideContentGateBypass — corroborated bypass of the #3429 content g
         for (const quotedTurnId of IDS)
           for (const latestEndedTurnId of IDS)
             for (const age of AGES)
-              for (const handbackCouldOwnReply of [false, true]) {
+              for (const handbackCouldOwnReply of [false, true])
+                // #4176 — the sweep now also spans sub-agent liveness, so a
+                // regression that ignores it on the steerable tiers is caught
+                // by the same zero-new-capability property.
+                for (const subagentCouldOwnReply of [false, true]) {
                 cases++
                 const c: ReplyOwnerCandidates = {
                   liveTurnId,
@@ -950,6 +963,7 @@ describe('decideContentGateBypass — corroborated bypass of the #3429 content g
                   resolvedTurnId: resolveReplyOwnerTurnId(c),
                   candidates: c,
                   handbackCouldOwnReply,
+                  subagentCouldOwnReply,
                 })
                 // Strip the model-supplied ids: the FRAMEWORK alone resolves the
                 // owner — the reach the model already had by staying silent.
@@ -963,6 +977,7 @@ describe('decideContentGateBypass — corroborated bypass of the #3429 content g
                   resolvedTurnId: resolveReplyOwnerTurnId(stripped),
                   candidates: stripped,
                   handbackCouldOwnReply,
+                  subagentCouldOwnReply,
                 })
                 if (withModelIds) {
                   bypasses++
@@ -972,7 +987,8 @@ describe('decideContentGateBypass — corroborated bypass of the #3429 content g
                   violations.push(
                     `tier=${tier} live=${liveTurnId} origin=${originTurnId} ` +
                       `quoted=${quotedTurnId} latestEnded=${latestEndedTurnId} ` +
-                      `age=${age.label} handback=${handbackCouldOwnReply}`,
+                      `age=${age.label} handback=${handbackCouldOwnReply} ` +
+                      `subagentLive=${subagentCouldOwnReply}`,
                   )
                 }
               }
@@ -986,7 +1002,7 @@ describe('decideContentGateBypass — corroborated bypass of the #3429 content g
     expect(r.violations).toEqual([])
     // Non-degeneracy: the sweep must actually cover the space and must actually
     // reach the branch under test, so it can never quietly become a no-op.
-    expect(r.cases).toBe(IDS.length ** 4 * AGES.length * 2)
+    expect(r.cases).toBe(IDS.length ** 4 * AGES.length * 2 * 2)
     expect(r.bypasses).toBeGreaterThan(0)
     // …and specifically, many cases must win their bypass on the WIDENED,
     // model-steerable `origin`/`quoted` tiers — the thing being vouched for.
@@ -1171,6 +1187,7 @@ describe('#3725 — a still-running turn is not a supersede anchor', () => {
         resolvedTurnId: resolveReplyOwnerTurnId(fixed),
         candidates: fixed,
         handbackCouldOwnReply: false,
+        subagentCouldOwnReply: false,
       }),
     ).toBe(false)
     // Red-on-main contrast: the same reply DID bypass the #3429 content gate
@@ -1191,6 +1208,7 @@ describe('#3725 — a still-running turn is not a supersede anchor', () => {
         resolvedTurnId: null,
         candidates: fixed,
         handbackCouldOwnReply: false,
+        subagentCouldOwnReply: false,
       }),
     ).toBe(false)
 
@@ -1217,6 +1235,7 @@ describe('#3725 — a still-running turn is not a supersede anchor', () => {
         resolvedTurnId: ENDED,
         candidates: { ...base, originTurnId: ENDED, latestEndedAgeMs: null },
         handbackCouldOwnReply: false,
+        subagentCouldOwnReply: false,
       }),
     ).toBe(false)
     // Property omitted entirely ⇒ fail CLOSED too (#4175 — the old unbounded
@@ -1307,6 +1326,7 @@ describe('2026-08-01 klanker incident — slow flush→reply gap (Stop-hook nudg
       resolvedTurnId: ownerId,
       candidates: c,
       handbackCouldOwnReply: false, // no subagent_handback enqueued in the window
+      subagentCouldOwnReply: false, // no sub-agent live on the session (#4176)
     })
     expect(bypass).toBe(true)
     const d = reg.take(CHAT, undefined, {
@@ -1333,6 +1353,7 @@ describe('2026-08-01 klanker incident — slow flush→reply gap (Stop-hook nudg
       resolvedTurnId: resolveReplyOwnerTurnId(c),
       candidates: c,
       handbackCouldOwnReply: true,
+      subagentCouldOwnReply: false,
     })
     expect(bypass).toBe(false)
     const d = reg.take(CHAT, undefined, {
@@ -1393,5 +1414,75 @@ describe('#4173 — the latest-ended tier follows the turn-completion window', (
         latestEndedRealEndAgeMs: 90_000,
       })),
     ).toBe('none')
+  })
+})
+
+/**
+ * #4176 — the sub-agent liveness input to the bypass, at the decision level.
+ * The behavioural proof lives in `send-reply-golden.test.ts`; these pin the
+ * pure rule, including the fail-CLOSED handling of an omitted flag (the
+ * telegram-plugin tree is NOT covered by `tsc --noEmit`, so the type alone
+ * cannot stop a caller dropping the wiring).
+ */
+describe('#4176 — a live sub-agent denies the content-gate bypass', () => {
+  const CHAT = '1001'
+  const TURN = `${CHAT}:_#flushed-4176`
+  const base = {
+    liveTurnId: null,
+    originTurnId: null,
+    quotedTurnId: null,
+    latestEndedTurnId: TURN,
+    latestEndedAgeMs: 90_000,
+    latestEndedTtlMs: 30 * 60_000,
+    latestEndedRealEndAgeMs: null,
+    latestEndedCompletedGraceMs: 60_000,
+  } as ReplyOwnerCandidates
+
+  for (const tier of ['latest-ended', 'origin', 'quoted'] as ReplyOwnerTier[]) {
+    it(`${tier}: bypass granted with no sub-agent live, DENIED while one is live`, () => {
+      const call = (subagentCouldOwnReply: boolean) =>
+        decideContentGateBypass({
+          tier,
+          resolvedTurnId: TURN,
+          candidates: { ...base, originTurnId: TURN, quotedTurnId: TURN },
+          handbackCouldOwnReply: false,
+          subagentCouldOwnReply,
+        })
+      expect(call(false)).toBe(true)
+      expect(call(true)).toBe(false)
+    })
+  }
+
+  it('fails CLOSED when the flag is omitted entirely (dropped wiring ⇒ no bypass)', () => {
+    const input = {
+      tier: 'latest-ended' as ReplyOwnerTier,
+      resolvedTurnId: TURN,
+      candidates: base,
+      handbackCouldOwnReply: false,
+    } as Parameters<typeof decideContentGateBypass>[0]
+    expect(decideContentGateBypass(input)).toBe(false)
+  })
+
+  it('the `none` tier stays denied and the `live` tier is untouched by the flag', () => {
+    expect(
+      decideContentGateBypass({
+        tier: 'none',
+        resolvedTurnId: null,
+        candidates: base,
+        handbackCouldOwnReply: false,
+        subagentCouldOwnReply: false,
+      }),
+    ).toBe(false)
+    // A LIVE turn owns the reply by framework identity, not by inference, so a
+    // background sub-agent cannot be the author of record here.
+    expect(
+      decideContentGateBypass({
+        tier: 'live',
+        resolvedTurnId: TURN,
+        candidates: { ...base, liveTurnId: TURN },
+        handbackCouldOwnReply: false,
+        subagentCouldOwnReply: true,
+      }),
+    ).toBe(true)
   })
 })

--- a/telegram-plugin/tests/reply-owner-resolve.test.ts
+++ b/telegram-plugin/tests/reply-owner-resolve.test.ts
@@ -39,7 +39,7 @@ import {
   type ReplyOwnerTier,
   type AnswerDeliveredLatch,
 } from '../reply-owner-resolve.js'
-import { FlushedTurnSupersedeRegistry, DEFAULT_SUPERSEDE_TTL_MS } from '../flushed-turn-supersede.js'
+import { FlushedTurnSupersedeRegistry, SUPERSEDE_OPEN_WINDOW_CAP_MS, SUPERSEDE_COMPLETED_GRACE_MS } from '../flushed-turn-supersede.js'
 import { OutboundDedupCache } from '../recent-outbound-dedup.js'
 import { latestTurnForChat } from '../gateway/latest-turn-lookup.js'
 
@@ -48,6 +48,10 @@ const NONE: ReplyOwnerCandidates = {
   originTurnId: null,
   quotedTurnId: null,
   latestEndedTurnId: null,
+  // #4175 — an omitted age/ttl now fails CLOSED, so precedence fixtures carry a
+  // fresh bound; the fail-closed default has its own dedicated tests below.
+  latestEndedAgeMs: 1_000,
+  latestEndedTtlMs: 60_000,
 }
 
 /** The OLD (pre-fix) resolver chain the gateway ran on main — the 2-tier
@@ -229,6 +233,8 @@ describe('F2 — recency-bound the destructive latest-ended supersede tier', () 
     originTurnId: null,
     quotedTurnId: null,
     latestEndedTurnId: null,
+    latestEndedAgeMs: 1_000,
+    latestEndedTtlMs: 60_000,
   }
 
   it('accepts a latest-ended turn that ended within the supersede TTL', () => {
@@ -236,8 +242,8 @@ describe('F2 — recency-bound the destructive latest-ended supersede tier', () 
       resolveReplyOwnerTurnId({
         ...base,
         latestEndedTurnId: 'turn-T',
-        latestEndedAgeMs: DEFAULT_SUPERSEDE_TTL_MS - 1,
-        latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
+        latestEndedAgeMs: SUPERSEDE_OPEN_WINDOW_CAP_MS - 1,
+        latestEndedTtlMs: SUPERSEDE_OPEN_WINDOW_CAP_MS,
       }),
     ).toBe('turn-T')
   })
@@ -248,8 +254,8 @@ describe('F2 — recency-bound the destructive latest-ended supersede tier', () 
       resolveReplyOwnerTurnId({
         ...base,
         latestEndedTurnId: 'turn-STALE',
-        latestEndedAgeMs: DEFAULT_SUPERSEDE_TTL_MS + 5_000,
-        latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
+        latestEndedAgeMs: SUPERSEDE_OPEN_WINDOW_CAP_MS + 5_000,
+        latestEndedTtlMs: SUPERSEDE_OPEN_WINDOW_CAP_MS,
       }),
     ).toBeNull()
   })
@@ -267,8 +273,8 @@ describe('F2 — recency-bound the destructive latest-ended supersede tier', () 
     const ownerId = resolveReplyOwnerTurnId({
       ...base,
       latestEndedTurnId: 'turn-STALE',
-      latestEndedAgeMs: DEFAULT_SUPERSEDE_TTL_MS + 5_000,
-      latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
+      latestEndedAgeMs: SUPERSEDE_OPEN_WINDOW_CAP_MS + 5_000,
+      latestEndedTtlMs: SUPERSEDE_OPEN_WINDOW_CAP_MS,
     })
     expect(ownerId).toBeNull()
     const decision = reg.take(CHAT, undefined, { liveTurnId: ownerId, now: now + 10 })
@@ -277,10 +283,29 @@ describe('F2 — recency-bound the destructive latest-ended supersede tier', () 
     expect(reg.peek(CHAT, undefined, { liveTurnId: 'turn-T2', now: now + 10 }).supersede).toBe(true)
   })
 
-  it('unbounded when no age is supplied (back-compat: pre-F2 precedence intact)', () => {
+  it('#4175 — an OMITTED age fails CLOSED: dropped bound wiring degrades to a ' +
+    'visible dup, never unbounded destructive authority', () => {
+    // Pre-#4175 this was the "unbounded back-compat escape": omitting the age
+    // granted UNBOUNDED deletion authority — i.e. the failure mode of DROPPING
+    // the gateway's `latestEndedAgeMs`/`latestEndedTtlMs` wiring was fail-OPEN.
+    // Restoring that escape (return true on undefined age/ttl) turns this red.
     expect(
-      resolveReplyOwnerTurnId({ ...base, latestEndedTurnId: 'turn-T' }),
-    ).toBe('turn-T')
+      resolveReplyOwnerTurnId({
+        ...base,
+        latestEndedTurnId: 'turn-T',
+        latestEndedAgeMs: undefined,
+        latestEndedTtlMs: undefined,
+      }),
+    ).toBeNull()
+    // ttl alone omitted → also closed.
+    expect(
+      resolveReplyOwnerTurnId({
+        ...base,
+        latestEndedTurnId: 'turn-T',
+        latestEndedAgeMs: 1_000,
+        latestEndedTtlMs: undefined,
+      }),
+    ).toBeNull()
   })
 })
 
@@ -475,7 +500,7 @@ describe('#3426 — async sub-agent handback after an interim-ack turn', () => {
       quotedTurnId: null,
       latestEndedTurnId: owner.turnId,
       latestEndedAgeMs: HANDBACK_AGE_MS,
-      latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
+      latestEndedTtlMs: SUPERSEDE_OPEN_WINDOW_CAP_MS,
     })
     expect(ownerId).toBe(ACK_TURN)
 
@@ -629,6 +654,8 @@ describe('resolveReplyOwnerTier — precedence + latest-ended TTL bound', () => 
     originTurnId: null,
     quotedTurnId: null,
     latestEndedTurnId: null,
+    latestEndedAgeMs: 1_000,
+    latestEndedTtlMs: 60_000,
   }
 
   it('live wins over every lower tier', () => {
@@ -657,8 +684,8 @@ describe('resolveReplyOwnerTier — precedence + latest-ended TTL bound', () => 
     const stale: ReplyOwnerCandidates = {
       ...base,
       latestEndedTurnId: 'E',
-      latestEndedAgeMs: DEFAULT_SUPERSEDE_TTL_MS + 1,
-      latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
+      latestEndedAgeMs: SUPERSEDE_OPEN_WINDOW_CAP_MS + 1,
+      latestEndedTtlMs: SUPERSEDE_OPEN_WINDOW_CAP_MS,
     }
     expect(resolveReplyOwnerTier(stale)).toBe('none')
     // And the id resolver agrees (no destructive authority granted to a stale turn).
@@ -718,7 +745,7 @@ describe('decideContentGateBypass — corroborated bypass of the #3429 content g
     quotedTurnId: null,
     latestEndedTurnId: OWNER,
     latestEndedAgeMs: 30_000,
-    latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
+    latestEndedTtlMs: SUPERSEDE_OPEN_WINDOW_CAP_MS,
     ...over,
   })
 
@@ -806,7 +833,7 @@ describe('decideContentGateBypass — corroborated bypass of the #3429 content g
     'still denies a past-TTL turn any bypass authority', () => {
     const stale = cands({
       originTurnId: OWNER,
-      latestEndedAgeMs: DEFAULT_SUPERSEDE_TTL_MS + 1,
+      latestEndedAgeMs: SUPERSEDE_OPEN_WINDOW_CAP_MS + 1,
     })
     expect(
       decideContentGateBypass({
@@ -871,8 +898,8 @@ describe('decideContentGateBypass — corroborated bypass of the #3429 content g
   const IDS = [null, OWNER, OTHER] as const
   /** fresh / stale / unbounded (no age+ttl — the documented back-compat path). */
   const AGES = [
-    { label: 'fresh', ageMs: 30_000 as number | null, ttlMs: DEFAULT_SUPERSEDE_TTL_MS as number | undefined },
-    { label: 'stale', ageMs: DEFAULT_SUPERSEDE_TTL_MS + 1, ttlMs: DEFAULT_SUPERSEDE_TTL_MS },
+    { label: 'fresh', ageMs: 30_000 as number | null, ttlMs: SUPERSEDE_OPEN_WINDOW_CAP_MS as number | undefined },
+    { label: 'stale', ageMs: SUPERSEDE_OPEN_WINDOW_CAP_MS + 1, ttlMs: SUPERSEDE_OPEN_WINDOW_CAP_MS },
     { label: 'unbounded', ageMs: null, ttlMs: undefined },
   ]
 
@@ -1069,7 +1096,7 @@ describe('#3725 — a still-running turn is not a supersede anchor', () => {
       quotedTurnId: null,
       latestEndedTurnId: latestEnded?.turnId ?? null,
       latestEndedAgeMs: latestEnded?.endedAt != null ? NOW - latestEnded.endedAt : null,
-      latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
+      latestEndedTtlMs: SUPERSEDE_OPEN_WINDOW_CAP_MS,
       ...over,
     }
   }
@@ -1172,14 +1199,14 @@ describe('#3725 — a still-running turn is not a supersede anchor', () => {
     expect(preFixOwnerId(prefix)).toBe(RUNNING)
   })
 
-  it('layer 2: an EXPLICIT null age is rejected outright, while an OMITTED age ' +
-    'keeps the pre-F2 back-compat escape', () => {
+  it('layer 2: an EXPLICIT null age is rejected outright, and an OMITTED age ' +
+    'fails closed too (#4175)', () => {
     const base: ReplyOwnerCandidates = {
       liveTurnId: null,
       originTurnId: null,
       quotedTurnId: null,
       latestEndedTurnId: ENDED,
-      latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
+      latestEndedTtlMs: SUPERSEDE_OPEN_WINDOW_CAP_MS,
     }
     // Computed-null (the caller's candidate turn has not ended) ⇒ closed.
     expect(resolveReplyOwnerTier({ ...base, latestEndedAgeMs: null })).toBe('none')
@@ -1192,9 +1219,10 @@ describe('#3725 — a still-running turn is not a supersede anchor', () => {
         handbackCouldOwnReply: false,
       }),
     ).toBe(false)
-    // Property omitted entirely ⇒ unchanged pre-F2 behaviour.
-    expect(resolveReplyOwnerTier(base)).toBe('latest-ended')
-    expect(resolveReplyOwnerTurnId(base)).toBe(ENDED)
+    // Property omitted entirely ⇒ fail CLOSED too (#4175 — the old unbounded
+    // back-compat escape failed toward silent edit-over when wiring dropped).
+    expect(resolveReplyOwnerTier(base)).toBe('none')
+    expect(resolveReplyOwnerTurnId(base)).toBeNull()
   })
 
   it('end-to-end: a late reply while another topic is still running cannot ' +
@@ -1231,7 +1259,7 @@ describe('2026-08-01 klanker incident — slow flush→reply gap (Stop-hook nudg
   // replay the incident timeline through the exact pure cores the gateway wires
   // (`resolveReplyOwnerTurn` → `decideContentGateBypass` → registry.take`) and
   // assert the OUTCOME: the late reply collapses onto the flushed message —
-  // one bubble, never two. Shrinking DEFAULT_SUPERSEDE_TTL_MS below the
+  // one bubble, never two. Shrinking SUPERSEDE_OPEN_WINDOW_CAP_MS below the
   // observed gap turns these red.
   const CHAT = '424242'
   const TURN = 'turn-25674'
@@ -1253,7 +1281,12 @@ describe('2026-08-01 klanker incident — slow flush→reply gap (Stop-hook nudg
     quotedTurnId: null, // no quote linkage
     latestEndedTurnId: TURN,
     latestEndedAgeMs: now - FLUSH_TS,
-    latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
+    latestEndedTtlMs: SUPERSEDE_OPEN_WINDOW_CAP_MS,
+    // #4173 — the completion window is OPEN: the flush ended the turn
+    // synthetically, and the session's REAL turn_end has not been observed
+    // (the model is mid Stop-hook-nudge → /compact → recompose).
+    latestEndedRealEndAgeMs: null,
+    latestEndedCompletedGraceMs: SUPERSEDE_COMPLETED_GRACE_MS,
   })
 
   it('the latest-ended owner tier still accepts the flushed turn 143 s after it ended', () => {
@@ -1312,5 +1345,53 @@ describe('2026-08-01 klanker incident — slow flush→reply gap (Stop-hook nudg
     expect(d.reason).toBe('new-content')
     // The record survives for the turn's OWN late replay.
     expect(reg.peek(CHAT, undefined, { liveTurnId: TURN, now: REPLY_TS }).supersede).toBe(true)
+  })
+})
+
+
+describe('#4173 — the latest-ended tier follows the turn-completion window', () => {
+  const ENDED = 'turn-ENDED'
+  const c = (over: Partial<ReplyOwnerCandidates>): ReplyOwnerCandidates => ({
+    liveTurnId: null,
+    originTurnId: null,
+    quotedTurnId: null,
+    latestEndedTurnId: ENDED,
+    latestEndedTtlMs: SUPERSEDE_OPEN_WINDOW_CAP_MS,
+    latestEndedCompletedGraceMs: SUPERSEDE_COMPLETED_GRACE_MS,
+    ...over,
+  })
+
+  it('OPEN window (real turn_end not observed): accepted at 143 s AND at 20 min — ' +
+    'a compaction longer than any tuned TTL still resolves the owner (#4166)', () => {
+    expect(resolveReplyOwnerTier(c({ latestEndedAgeMs: 143_000, latestEndedRealEndAgeMs: null }))).toBe('latest-ended')
+    expect(resolveReplyOwnerTier(c({ latestEndedAgeMs: 20 * 60_000, latestEndedRealEndAgeMs: null }))).toBe('latest-ended')
+  })
+
+  it('OPEN window past the crash-backstop cap: rejected (signal loss cannot grant forever)', () => {
+    expect(
+      resolveReplyOwnerTier(c({
+        latestEndedAgeMs: SUPERSEDE_OPEN_WINDOW_CAP_MS + 1,
+        latestEndedRealEndAgeMs: null,
+      })),
+    ).toBe('none')
+  })
+
+  it('COMPLETED window: accepted inside the replay grace, rejected past it — the ' +
+    'Task-sub-agent-after-parent-turn-end reply resolves NO owner and gets no ' +
+    'destructive authority', () => {
+    // Normal turn: realEnd == end, 30 s ago → the original tight bound holds.
+    expect(
+      resolveReplyOwnerTier(c({ latestEndedAgeMs: 30_000, latestEndedRealEndAgeMs: 30_000 })),
+    ).toBe('latest-ended')
+    // 90 s after the session really stopped: a same-bridge decoupled reply (a
+    // background Task sub-agent replying after the parent turn ended) resolves
+    // null — it can neither supersede nor bypass the content gate; it sends
+    // fresh. Widening the completed bound past the grace turns this red.
+    expect(
+      resolveReplyOwnerTier(c({
+        latestEndedAgeMs: 90_000,
+        latestEndedRealEndAgeMs: 90_000,
+      })),
+    ).toBe('none')
   })
 })

--- a/telegram-plugin/tests/reply-quote-wire.test.ts
+++ b/telegram-plugin/tests/reply-quote-wire.test.ts
@@ -164,6 +164,8 @@ function makeHarness(opts: { errors?: ScriptedError[] } = {}) {
     resolveThreadId: () => undefined,
     getLatestInboundMessageId: () => null,
     getLastSubagentHandbackAt: () => null,
+    // #4176 — no sub-agent live on this session (see subagent-reply-authority.ts).
+    subagentReplyAuthority: { subagentCouldOwnReply: () => false },
     recordOutbound: noop,
     emissionAuthorityFor: () =>
       ({

--- a/telegram-plugin/tests/send-reply-golden.test.ts
+++ b/telegram-plugin/tests/send-reply-golden.test.ts
@@ -1467,3 +1467,73 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
   })
 })
+
+describe('2026-08-01 klanker incident — slow flush→reply gap through the REAL send path', () => {
+  // gateway-supervisor.log, chat 12345: the answer-ready quiescence flush
+  // delivered msg 25680 at 21:17:04, a proactive /compact ran, the Stop hook
+  // nudged the model, and the canonical `reply` landed at 21:19:28 — 143 s
+  // after the flush, REWORDED post-compact (1770 vs 1563 chars). Under the old
+  // 60 s DEFAULT_SUPERSEDE_TTL_MS the registry record was 'expired' AND the
+  // latest-ended owner tier rejected the 143 s-old turn, so msg 25682 shipped
+  // as a visible duplicate. This drives the REAL sendReply with the incident
+  // timeline and asserts the outcome: the late reply corrects the flushed
+  // message in place — never a second bubble.
+  const OWNER_TURN_ID = `${CHAT}:_#25674`
+  const FLUSH_MSG_ID = 25680
+  const GAP_MS = 143_000
+  const FLUSHED_TEXT =
+    'Pulled the live numbers from the usage table. Two findings, and the second one matters: ' +
+    'the per-turn cost is dominated by cache writes, not output tokens, so trimming the reply ' +
+    'length will not move the bill much.'
+  // Post-compact the model REGENERATED the answer — same substance, different
+  // bytes. Neither exact-text dedup nor containment matching can catch this;
+  // only turnId identity + the content-gate bypass (no handback in window) can.
+  const REWORDED_REPLY =
+    'I pulled the live numbers out of the usage table. Two findings — and the second is the one ' +
+    'that matters: cache writes, not output tokens, dominate the per-turn cost, so shortening ' +
+    'replies will barely move the bill.'
+
+  function makeStaleFlushDeliveredTurn(): CurrentTurn {
+    return {
+      turnId: OWNER_TURN_ID,
+      sessionChatId: CHAT,
+      answerDelivered: 'flush',
+      flushedAnswerText: FLUSHED_TEXT,
+      endedAt: Date.now() - GAP_MS,
+      replyCalled: false,
+      finalAnswerDelivered: true,
+      finalAnswerSubstantive: true,
+    } as unknown as CurrentTurn
+  }
+
+  it('outcome: the reworded reply landing 143 s after the flush edits the flushed ' +
+    'message in place — exactly one bubble, no duplicate', async () => {
+    const h = makeHarness()
+    const owner = makeStaleFlushDeliveredTurn()
+    // The flush recorded its message 143 s ago (NOT freshly — the incident gap).
+    h.deps.flushedTurnSupersede.record(
+      CHAT,
+      undefined,
+      { turnId: OWNER_TURN_ID, messageIds: [FLUSH_MSG_ID], text: FLUSHED_TEXT },
+      Date.now() - GAP_MS,
+    )
+    // Late DM reply: no live turn, no origin echo, no quote → latest-ended tier,
+    // with the REAL 143 s age the gateway would compute from `endedAt`.
+    h.deps.resolveReplyOwnerTurn = () =>
+      ownerRes(owner, 'latest-ended', { latestEndedAgeMs: GAP_MS })
+    // No subagent handback anywhere in the window (the incident had none).
+    h.deps.getLastSubagentHandbackAt = () => null
+
+    const res = await sendReply(h.deps, req(REWORDED_REPLY))
+
+    // The flushed message was edited into the canonical reply…
+    const edits = h.calls.filter((c) => c.method === 'editMessageText')
+    expect(edits).toHaveLength(1)
+    expect(edits[0]!.message_id).toBe(FLUSH_MSG_ID)
+    expect(edits[0]!.text).toContain('cache writes')
+    // …and NO second bubble shipped — the exact duplicate the incident produced.
+    expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(0)
+    expect(h.calls.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
+    expect(res.content[0]!.text).toMatch(/^sent/)
+  })
+})

--- a/telegram-plugin/tests/send-reply-golden.test.ts
+++ b/telegram-plugin/tests/send-reply-golden.test.ts
@@ -55,6 +55,7 @@ import type { ReplyOwnerTier, ReplyOwnerCandidates } from '../reply-owner-resolv
 import { resolveReplyOwnerTier, resolveReplyOwnerTurnId } from '../reply-owner-resolve.js'
 import { SubagentHandbackMarker, stampsHandbackMarker } from '../gateway/subagent-handback-marker.js'
 import { createPendingInboundBuffer } from '../gateway/pending-inbound-buffer.js'
+import { SubagentReplyAuthority } from '../gateway/subagent-reply-authority.js'
 import { redact } from '../secret-detect/redact.js'
 import type { CurrentTurn, Access } from '../gateway/gateway.js'
 
@@ -254,6 +255,9 @@ function makeHarness(opts?: {
     streamKey: key,
     resolveReplyOwnerTurn: () => ownerRes(null, 'none'),
     getLastSubagentHandbackAt: () => null,
+    // #4176 — default: no sub-agent live (the non-delegating case). Tests that
+    // exercise the gate override `h.deps.subagentReplyAuthority`.
+    subagentReplyAuthority: { subagentCouldOwnReply: () => false },
     findTurnByOriginId: () => null,
     findTurnByQuotedMessageId: () => null,
     resolveAnswerThreadWithLog: (_c, explicit) => explicit,
@@ -1813,5 +1817,215 @@ describe('#4174 — the handback gate-hold is bounded by its OWN 60 s recency wi
     expect(edits[0]!.message_id).toBe(FLUSH_MSG_ID)
     expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(0)
     expect(res.content[0]!.text).toMatch(/^sent/)
+  })
+})
+
+describe('#4176 — a BACKGROUND SUB-AGENT reply can never silently edit over a flushed answer', () => {
+  // The MAJOR from the #4167 review. The #4173 window rests on "a reply landing
+  // between the synthetic and the real turn_end is this turn's own answer,
+  // because nothing else can run on the serial session". A background `Task`
+  // sub-agent falsifies that: it runs CONCURRENTLY and calls `reply` over the
+  // PARENT's IPC bridge, so #4172's identity gate cannot see it and no
+  // `subagent_handback` marker is stamped (a direct tool call never traverses
+  // pendingInboundBuffer). Owner resolution then lands on the flush-ended turn
+  // (OPEN is accepted at any age up to the crash cap), the bypass grants
+  // positive attribution, and the sub-agent's FOREIGN content supersedes —
+  // editing over the user's delivered answer with no notification for either.
+  const OWNER_TURN_ID = `${CHAT}:_#flushed-4176`
+  const FLUSH_MSG_ID = 44176
+  const FLUSHED_TEXT =
+    'Traced the wedge to the broker socket: the gateway reconnects but never re-arms the ' +
+    'heartbeat, so the supervisor sees it as healthy while every vault read times out.'
+  // Genuinely foreign content — a researcher sub-agent reporting its own finding.
+  // Defeats both arms of flushedAnswerMatchesReply, so nothing here can pass by
+  // accident through the content matcher.
+  const SUBAGENT_REPLY =
+    'Sub-agent report: the calendar scope audit found four call sites that request the ' +
+    'write scope where a read scope would do, all reachable from the OAuth consent screen.'
+
+  function makeFlushedOwner(): CurrentTurn {
+    return {
+      turnId: OWNER_TURN_ID,
+      sessionChatId: CHAT,
+      answerDelivered: 'flush',
+      flushedAnswerText: FLUSHED_TEXT,
+      endedAt: Date.now() - 90_000,
+      // Window OPEN: the flush ended the turn synthetically, the session's real
+      // turn_end has not been observed (the parent is still delegating).
+      realEndObservedAt: null,
+      replyCalled: false,
+      finalAnswerDelivered: true,
+      finalAnswerSubstantive: true,
+    } as unknown as CurrentTurn
+  }
+
+  function seed(h: ReturnType<typeof makeHarness>): void {
+    h.deps.flushedTurnSupersede.record(
+      CHAT,
+      undefined,
+      { turnId: OWNER_TURN_ID, messageIds: [FLUSH_MSG_ID], text: FLUSHED_TEXT },
+      Date.now() - 90_000,
+    )
+    // Latest-ended tier, corroborated, no handback marker, MAIN bridge → every
+    // other gate passes. The sub-agent liveness signal is the only thing left.
+    h.deps.resolveReplyOwnerTurn = () => ownerRes(makeFlushedOwner(), 'latest-ended')
+    h.deps.getLastSubagentHandbackAt = () => null
+  }
+
+  it('the content matcher cannot save this case (foreign content, both arms fail)', () => {
+    expect(flushedAnswerMatchesReply(FLUSHED_TEXT, SUBAGENT_REPLY)).toBe(false)
+  })
+
+  it('MAJOR REPRO: with a live sub-agent, its reply ships FRESH — zero edits/deletes ' +
+    'of the flushed message, record intact for the parent turn\'s own replay', async () => {
+    const h = makeHarness()
+    seed(h)
+    // The REAL tracker, driven by the REAL framework-derived session events the
+    // gateway feeds it — not a hand-set boolean.
+    const authority = new SubagentReplyAuthority()
+    authority.noteSessionEvent({ kind: 'sub_agent_started', agentId: 'researcher-1' })
+    expect(authority.subagentCouldOwnReply()).toBe(true)
+    h.deps.subagentReplyAuthority = authority
+
+    const res = await sendReply(h.deps, {
+      args: { chat_id: CHAT, text: SUBAGENT_REPLY },
+      turn: null, // decoupled — the parent turn was ended by the flush
+      callerIsForeignSession: false, // SAME bridge: #4172 cannot see this caller
+    })
+
+    // OUTCOME: msg A untouched; the sub-agent's report is a fresh, NOTIFYING
+    // message the user actually receives.
+    expect(h.calls.filter((c) => c.method === 'editMessageText')).toHaveLength(0)
+    expect(h.calls.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
+    const fresh = h.calls.filter((c) => c.method === 'sendRichMessage')
+    expect(fresh).toHaveLength(1)
+    expect(fresh[0]!.text).toContain('calendar scope audit')
+    expect(fresh[0]!.message_id).not.toBe(FLUSH_MSG_ID)
+    expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
+    // The flush record survives for the parent turn's own genuine late replay.
+    expect(
+      h.deps.flushedTurnSupersede.peek(CHAT, undefined, {
+        liveTurnId: OWNER_TURN_ID,
+        now: Date.now(),
+      }).supersede,
+    ).toBe(true)
+  })
+
+  it('NEGATIVE CONTROL (the reviewed failure): the SAME reply with NO sub-agent live ' +
+    'destroys the flushed answer by edit — proving the liveness gate is load-bearing', async () => {
+    const h = makeHarness()
+    seed(h)
+    // Identical scenario, gate disarmed (the pre-fix behaviour): the bypass
+    // applies and the foreign report edits over msg A — the double loss (the
+    // user's answer destroyed, the report delivered without a notification).
+    h.deps.subagentReplyAuthority = new SubagentReplyAuthority()
+
+    await sendReply(h.deps, {
+      args: { chat_id: CHAT, text: SUBAGENT_REPLY },
+      turn: null,
+      callerIsForeignSession: false,
+    })
+
+    const edits = h.calls.filter((c) => c.method === 'editMessageText')
+    expect(edits).toHaveLength(1)
+    expect(edits[0]!.message_id).toBe(FLUSH_MSG_ID)
+    expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(0)
+  })
+
+  it('liveness is released by sub_agent_turn_end: after the sub-agent finishes, the ' +
+    'parent\'s OWN reworded answer still collapses to ONE message (#4166 preserved)', async () => {
+    const h = makeHarness()
+    seed(h)
+    const authority = new SubagentReplyAuthority()
+    authority.noteSessionEvent({ kind: 'sub_agent_started', agentId: 'researcher-1' })
+    authority.noteSessionEvent({ kind: 'sub_agent_tool_use', agentId: 'researcher-1' })
+    authority.noteSessionEvent({ kind: 'sub_agent_turn_end', agentId: 'researcher-1' })
+    expect(authority.liveCount()).toBe(0)
+    h.deps.subagentReplyAuthority = authority
+
+    // The parent's own answer, reworded (defeats the content matcher) — this is
+    // the collapse the #4173/#4166 work exists to preserve.
+    const REWORDED_OWN =
+      'The wedge is the broker socket: the gateway does reconnect, but the heartbeat is ' +
+      'never re-armed, so the supervisor reports healthy while all vault reads time out.'
+    expect(flushedAnswerMatchesReply(FLUSHED_TEXT, REWORDED_OWN)).toBe(false)
+
+    await sendReply(h.deps, { args: { chat_id: CHAT, text: REWORDED_OWN }, turn: null })
+
+    const edits = h.calls.filter((c) => c.method === 'editMessageText')
+    expect(edits).toHaveLength(1)
+    expect(edits[0]!.message_id).toBe(FLUSH_MSG_ID)
+    expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(0)
+  })
+
+  it('a live sub-agent does NOT block a genuine same-content replay (supersede on ' +
+    'equality is content-preserving)', async () => {
+    const h = makeHarness()
+    seed(h)
+    const authority = new SubagentReplyAuthority()
+    authority.noteSessionEvent({ kind: 'sub_agent_started', agentId: 'worker-2' })
+    h.deps.subagentReplyAuthority = authority
+
+    await sendReply(h.deps, { args: { chat_id: CHAT, text: FLUSHED_TEXT }, turn: null })
+
+    const edits = h.calls.filter((c) => c.method === 'editMessageText')
+    expect(edits).toHaveLength(1)
+    expect(edits[0]!.message_id).toBe(FLUSH_MSG_ID)
+    expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(0)
+  })
+
+  it('an UNFINISHED sub-agent keeps the gate armed (missing turn_end fails SAFE), ' +
+    'and reset() on bridge death releases it', async () => {
+    const authority = new SubagentReplyAuthority()
+    authority.noteSessionEvent({ kind: 'sub_agent_started', agentId: 'reviewer-3' })
+    authority.noteSessionEvent({ kind: 'sub_agent_started', agentId: 'researcher-4' })
+    authority.noteSessionEvent({ kind: 'sub_agent_turn_end', agentId: 'reviewer-3' })
+    // One still live → gate armed.
+    expect(authority.subagentCouldOwnReply()).toBe(true)
+
+    const h = makeHarness()
+    seed(h)
+    h.deps.subagentReplyAuthority = authority
+    await sendReply(h.deps, {
+      args: { chat_id: CHAT, text: SUBAGENT_REPLY },
+      turn: null,
+    })
+    expect(h.calls.filter((c) => c.method === 'editMessageText')).toHaveLength(0)
+    expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(1)
+
+    // Bridge death: the claude session and every sub-agent under it are gone.
+    authority.reset()
+    expect(authority.subagentCouldOwnReply()).toBe(false)
+  })
+
+  it('non-sub_agent events never arm the gate (the feed takes the WHOLE stream ' +
+    'un-filtered, so this is the discrimination that matters)', () => {
+    const authority = new SubagentReplyAuthority()
+    authority.noteSessionEvent({ kind: 'turn_end' })
+    authority.noteSessionEvent({ kind: 'tool_use', agentId: 'not-a-subagent' })
+    authority.noteSessionEvent({ kind: 'assistant_text' })
+    authority.noteSessionEvent(null)
+    authority.noteSessionEvent({ kind: 'sub_agent_started' }) // id-less → ignorable
+    expect(authority.subagentCouldOwnReply()).toBe(false)
+  })
+
+  // Structural pins: gateway.ts / stream-render.ts are not importable from a
+  // test runner (the singleton + boot-gated lockedBot), so the wiring that makes
+  // the gate reachable in production is pinned by source assertion — the same
+  // accepted pattern as the #4172 pin above. Dropping any of these three lines
+  // silently disarms the gate with every behavioural test above still green.
+  it('#4176 wiring — the session-event feed, the bridge-death reset, and the ' +
+    'send-path dep are all present', () => {
+    const streamSrc = readFileSync(new URL('../gateway/stream-render.ts', import.meta.url), 'utf8')
+    // FEED: every event, before the kind switch (the `sub_agent_tool_use` case
+    // early-returns when no turn is live, so the switch is not a usable site).
+    expect(streamSrc).toContain('subagentReplyAuthority.noteSessionEvent(')
+    const gwSrc = readFileSync(new URL('../gateway/gateway.ts', import.meta.url), 'utf8')
+    // RESET on main-bridge disconnect + READ wired into the sendReply deps.
+    expect(gwSrc).toContain('subagentReplyAuthority.reset()')
+    expect(gwSrc).toMatch(/subagentReplyAuthority,/)
+    const sendSrc = readFileSync(new URL('../gateway/outbound-send-path.ts', import.meta.url), 'utf8')
+    expect(sendSrc).toContain('subagentReplyAuthority.subagentCouldOwnReply()')
+    expect(sendSrc).toContain('subagentCouldOwnReply,')
   })
 })

--- a/telegram-plugin/tests/send-reply-golden.test.ts
+++ b/telegram-plugin/tests/send-reply-golden.test.ts
@@ -47,10 +47,12 @@ import {
 import { OutboundDedupCache } from '../recent-outbound-dedup.js'
 import {
   FlushedTurnSupersedeRegistry,
-  DEFAULT_SUPERSEDE_TTL_MS,
+  SUPERSEDE_OPEN_WINDOW_CAP_MS,
+  SUPERSEDE_COMPLETED_GRACE_MS,
   flushedAnswerMatchesReply,
 } from '../flushed-turn-supersede.js'
 import type { ReplyOwnerTier, ReplyOwnerCandidates } from '../reply-owner-resolve.js'
+import { resolveReplyOwnerTier, resolveReplyOwnerTurnId } from '../reply-owner-resolve.js'
 import { SubagentHandbackMarker, stampsHandbackMarker } from '../gateway/subagent-handback-marker.js'
 import { createPendingInboundBuffer } from '../gateway/pending-inbound-buffer.js'
 import { redact } from '../secret-detect/redact.js'
@@ -83,7 +85,7 @@ function ownerRes(
       quotedTurnId: tier === 'quoted' ? id : null,
       latestEndedTurnId: id,
       latestEndedAgeMs: 30_000,
-      latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
+      latestEndedTtlMs: SUPERSEDE_OPEN_WINDOW_CAP_MS,
       ...over,
     },
   }
@@ -624,10 +626,35 @@ describe('structural wiring — the singleton + the gateway entry point (#2996 P
     expect(moduleSrc.match(/new OutboundDedupCache\(/g) ?? []).toHaveLength(0)
   })
 
-  it('executeReply is a thin wrapper: pins the turn and delegates to sendReply', () => {
+  it('executeReply is a thin wrapper: pins the turn, computes the caller-identity ' +
+    'gate (#4172), and delegates to sendReply', () => {
     const after = gatewaySrc.split('async function executeReply(')[1] ?? ''
     const body = after.split('\nasync function ')[0] ?? after
-    expect(body).toContain('return sendReply(gatewaySendReplyDeps(), { args, turn: currentTurn })')
+    expect(body).toContain('return sendReply(gatewaySendReplyDeps(), {')
+    expect(body).toContain('turn: currentTurn')
+    // #4172 wiring pin — dropping the identity plumbing silently re-opens the
+    // cron-edits-over-flushed-answer hole, so its presence is pinned here.
+    expect(body).toContain('callerIsForeignSession: replyCallerIsForeignSession(callerAgentName)')
+  })
+
+  it('#4172 wiring — onToolCall threads the calling client identity into the dispatch', () => {
+    expect(gatewaySrc).toContain('executeToolCall(msg.tool, msg.args, client.agentName)')
+  })
+
+  it('#4173/#4175 wiring — the owner-resolver candidates carry the completion ' +
+    'window bounds (dropping them now fails CLOSED, not open)', () => {
+    // The composition lives in reply-owner-wiring.ts (anti-inflation ratchet);
+    // the gateway keeps a thin wrapper that binds its stateful lookups.
+    const wiringSrc = readFileSync(
+      new URL('../gateway/reply-owner-wiring.ts', import.meta.url),
+      'utf8',
+    )
+    expect(wiringSrc).toContain('latestEndedTtlMs: SUPERSEDE_OPEN_CAP_MS')
+    expect(wiringSrc).toContain('latestEndedRealEndAgeMs')
+    expect(wiringSrc).toContain('latestEndedCompletedGraceMs: SUPERSEDE_GRACE_MS')
+    const after = gatewaySrc.split('function resolveReplyOwnerTurn(')[1] ?? ''
+    const body = after.split('\nfunction ')[0] ?? after
+    expect(body).toContain('resolveReplyOwnerTurnWith(')
   })
 
   it('the injected deps carry the singleton + BOTH turn accessors (Amendment 9)', () => {
@@ -1455,7 +1482,7 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     const owner = makeFlushDeliveredEndedTurn()
     seedRecord(h, owner)
     h.deps.resolveReplyOwnerTurn = () =>
-      ownerRes(owner, 'origin', { latestEndedAgeMs: DEFAULT_SUPERSEDE_TTL_MS + 1 })
+      ownerRes(owner, 'origin', { latestEndedAgeMs: SUPERSEDE_OPEN_WINDOW_CAP_MS + 1 })
     h.deps.getLastSubagentHandbackAt = () => null
 
     const res = await sendReply(h.deps, req(REWORDED_SAME_TURN_ANSWER))
@@ -1473,7 +1500,7 @@ describe('2026-08-01 klanker incident — slow flush→reply gap through the REA
   // delivered msg 25680 at 21:17:04, a proactive /compact ran, the Stop hook
   // nudged the model, and the canonical `reply` landed at 21:19:28 — 143 s
   // after the flush, REWORDED post-compact (1770 vs 1563 chars). Under the old
-  // 60 s DEFAULT_SUPERSEDE_TTL_MS the registry record was 'expired' AND the
+  // 60 s SUPERSEDE_OPEN_WINDOW_CAP_MS the registry record was 'expired' AND the
   // latest-ended owner tier rejected the 143 s-old turn, so msg 25682 shipped
   // as a visible duplicate. This drives the REAL sendReply with the incident
   // timeline and asserts the outcome: the late reply corrects the flushed
@@ -1534,6 +1561,257 @@ describe('2026-08-01 klanker incident — slow flush→reply gap through the REA
     // …and NO second bubble shipped — the exact duplicate the incident produced.
     expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(0)
     expect(h.calls.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
+    expect(res.content[0]!.text).toMatch(/^sent/)
+  })
+})
+
+
+describe('#4172 — a foreign-session (cheap-cron) reply can never touch a flushed answer', () => {
+  const OWNER_TURN_ID = `${CHAT}:_#flushed-90`
+  const FLUSH_MSG_ID = 25680
+  const FLUSHED_TEXT =
+    'Pulled the live numbers from the usage table. Two findings, and the second one matters: ' +
+    'the per-turn cost is dominated by cache writes, not output tokens, so trimming reply ' +
+    'length will not move the bill much.'
+  // The measured #4172 shape: an unrelated Tier-1 cron digest landing 90 s
+  // after the flush — decoupled (no live turn), foreign content, NO handback
+  // marker (a cheap-cron fire never traverses pendingInboundBuffer.push).
+  const CRON_DIGEST =
+    'Morning digest: 3 PRs merged overnight, CI green on main, no pages. ' +
+    'Standup is at 9:30 and the vault broker cert renews tomorrow.'
+
+  function makeFlushedOwner(): CurrentTurn {
+    return {
+      turnId: OWNER_TURN_ID,
+      sessionChatId: CHAT,
+      answerDelivered: 'flush',
+      flushedAnswerText: FLUSHED_TEXT,
+      endedAt: Date.now() - 90_000,
+      // #4173 — window OPEN: the flush ended the turn synthetically and the
+      // session's real turn_end has not been observed.
+      realEndObservedAt: null,
+      replyCalled: false,
+      finalAnswerDelivered: true,
+      finalAnswerSubstantive: true,
+    } as unknown as CurrentTurn
+  }
+
+  function seed(h: ReturnType<typeof makeHarness>): CurrentTurn {
+    const owner = makeFlushedOwner()
+    h.deps.flushedTurnSupersede.record(
+      CHAT,
+      undefined,
+      { turnId: OWNER_TURN_ID, messageIds: [FLUSH_MSG_ID], text: FLUSHED_TEXT },
+      Date.now() - 90_000,
+    )
+    // Latest-ended tier, corroborated, no marker → the bypass would apply for
+    // a MAIN-session reply. The identity gate is the only thing standing
+    // between the cron digest and the flushed answer.
+    h.deps.resolveReplyOwnerTurn = () => ownerRes(owner, 'latest-ended')
+    h.deps.getLastSubagentHandbackAt = () => null
+    return owner
+  }
+
+  it('BLOCKER REPRO: the cron digest sends FRESH — zero edits/deletes of the ' +
+    'flushed message, record intact for the turn\'s own replay', async () => {
+    const h = makeHarness()
+    seed(h)
+
+    const res = await sendReply(h.deps, {
+      args: { chat_id: CHAT, text: CRON_DIGEST },
+      turn: null,
+      callerIsForeignSession: true, // the `<agent>-cron` bridge (#4172)
+    })
+
+    // OUTCOME: msg A untouched; the digest is a fresh, NOTIFYING message.
+    expect(h.calls.filter((c) => c.method === 'editMessageText')).toHaveLength(0)
+    expect(h.calls.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
+    const fresh = h.calls.filter((c) => c.method === 'sendRichMessage')
+    expect(fresh).toHaveLength(1)
+    expect(fresh[0]!.text).toContain('Morning digest')
+    expect(fresh[0]!.message_id).not.toBe(FLUSH_MSG_ID)
+    expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
+    // The record survives for the flushed turn's own genuine late replay.
+    expect(
+      h.deps.flushedTurnSupersede.peek(CHAT, undefined, {
+        liveTurnId: OWNER_TURN_ID,
+        now: Date.now(),
+      }).supersede,
+    ).toBe(true)
+  })
+
+  it('NEGATIVE CONTROL (the measured failure): the SAME reply on the main-bridge ' +
+    'path destroys the flushed answer by edit — proving the identity gate is ' +
+    'load-bearing, not incidental', async () => {
+    const h = makeHarness()
+    seed(h)
+
+    // Identical scenario, but the caller is treated as the main session (the
+    // pre-fix behaviour): bypass applies → the digest edits over msg A — the
+    // #4172 double loss (flushed answer destroyed, digest delivered silently).
+    await sendReply(h.deps, {
+      args: { chat_id: CHAT, text: CRON_DIGEST },
+      turn: null,
+      callerIsForeignSession: false,
+    })
+
+    const edits = h.calls.filter((c) => c.method === 'editMessageText')
+    expect(edits).toHaveLength(1)
+    expect(edits[0]!.message_id).toBe(FLUSH_MSG_ID)
+    expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(0)
+  })
+
+  it('a foreign-session reply is never swallowed by the flush-armed latch ' +
+    '(pre-record race window)', async () => {
+    // The flush FIRED but has not recorded yet (no supersede record, latch
+    // armed, no flushed text stashed → replyMatchesFlushedAnswer resolves
+    // null). A main-session late reply is suppressed here (the flush race);
+    // the cron digest must NOT be — suppressing it silently drops the user's
+    // scheduled output.
+    const h = makeHarness()
+    const owner = {
+      ...makeFlushedOwner(),
+      flushedAnswerText: null,
+    } as unknown as CurrentTurn
+    h.deps.resolveReplyOwnerTurn = () => ownerRes(owner, 'latest-ended')
+    h.deps.getLastSubagentHandbackAt = () => null
+
+    const res = await sendReply(h.deps, {
+      args: { chat_id: CHAT, text: CRON_DIGEST.repeat(2) }, // ≥200 chars → substantive
+      turn: null,
+      callerIsForeignSession: true,
+    })
+
+    expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
+    expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(1)
+  })
+})
+
+describe('#4173 — the completed window closes the same-bridge decoupled-reply hole ' +
+  '(Task sub-agent replying after the parent turn ended)', () => {
+  const OWNER_TURN_ID = `${CHAT}:_#flushed-77`
+  const FLUSH_MSG_ID = 31337
+  const FLUSHED_TEXT =
+    'Deployment review finished: the canary is healthy, error rates are flat, and the ' +
+    'rollout can proceed to the next ring this afternoon.'
+  const LATE_WORKER_REPLY =
+    'Background worker done: the log-archive sweep compressed 14 GB across three agents ' +
+    'and freed the disk pressure alert. Full manifest is in the shared drive.'
+
+  it('a foreign-content reply landing 90 s AFTER the real turn_end resolves NO owner ' +
+    'through the REAL tier rule → sends fresh, flushed answer untouched', async () => {
+    const h = makeHarness()
+    const realEndAgo = 90_000 // > SUPERSEDE_COMPLETED_GRACE_MS
+    const owner = {
+      turnId: OWNER_TURN_ID,
+      sessionChatId: CHAT,
+      answerDelivered: 'flush',
+      flushedAnswerText: FLUSHED_TEXT,
+      endedAt: Date.now() - realEndAgo,
+      realEndObservedAt: Date.now() - realEndAgo, // real turn_end OBSERVED
+      replyCalled: false,
+      finalAnswerDelivered: true,
+      finalAnswerSubstantive: true,
+    } as unknown as CurrentTurn
+    h.deps.flushedTurnSupersede.record(
+      CHAT,
+      undefined,
+      {
+        turnId: OWNER_TURN_ID,
+        messageIds: [FLUSH_MSG_ID],
+        text: FLUSHED_TEXT,
+        completedAt: Date.now() - realEndAgo,
+      },
+      Date.now() - realEndAgo,
+    )
+    // Drive the REAL acceptance rule (the exact composition the gateway runs):
+    // the candidates carry the completed-window signal, so the latest-ended
+    // tier REJECTS the 90 s-stale turn and the owner resolves null.
+    const candidates: ReplyOwnerCandidates = {
+      liveTurnId: null,
+      originTurnId: null,
+      quotedTurnId: null,
+      latestEndedTurnId: OWNER_TURN_ID,
+      latestEndedAgeMs: realEndAgo,
+      latestEndedTtlMs: SUPERSEDE_OPEN_WINDOW_CAP_MS,
+      latestEndedRealEndAgeMs: realEndAgo,
+      latestEndedCompletedGraceMs: SUPERSEDE_COMPLETED_GRACE_MS,
+    }
+    const tier = resolveReplyOwnerTier(candidates)
+    expect(tier).toBe('none') // the completed window did its job
+    const winnerId = resolveReplyOwnerTurnId(candidates)
+    h.deps.resolveReplyOwnerTurn = () => ({
+      turn: winnerId != null ? owner : null,
+      tier,
+      candidates,
+    })
+    h.deps.getLastSubagentHandbackAt = () => null
+
+    const res = await sendReply(h.deps, {
+      args: { chat_id: CHAT, text: LATE_WORKER_REPLY },
+      turn: null, // decoupled — the parent turn ended long ago
+    })
+
+    // OUTCOME: fresh send; the flushed answer is not edited or deleted.
+    expect(h.calls.filter((c) => c.method === 'editMessageText')).toHaveLength(0)
+    expect(h.calls.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
+    const fresh = h.calls.filter((c) => c.method === 'sendRichMessage')
+    expect(fresh).toHaveLength(1)
+    expect(fresh[0]!.text).toContain('log-archive sweep')
+    expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
+  })
+})
+
+
+describe('#4174 — the handback gate-hold is bounded by its OWN 60 s recency window', () => {
+  const OWNER_TURN_ID = `${CHAT}:_#flushed-55`
+  const FLUSH_MSG_ID = 8181
+  const FLUSHED_TEXT =
+    'Checked the backup job: last night\'s run completed in 41 minutes, all four volumes ' +
+    'verified clean, and the retention sweep pruned the January snapshots as scheduled.'
+  const REWORDED_OWN_REPLY =
+    'Backup status: the overnight run finished in about forty minutes, every volume passed ' +
+    'verification, and the retention sweep removed the January snapshots on schedule.'
+
+  it('a handback enqueued 90 s ago (outside HANDBACK_RECENCY_WINDOW_MS) no longer ' +
+    'holds the content gate — the turn\'s own reworded reply still collapses to ONE message', async () => {
+    const h = makeHarness()
+    const owner = {
+      turnId: OWNER_TURN_ID,
+      sessionChatId: CHAT,
+      answerDelivered: 'flush',
+      flushedAnswerText: FLUSHED_TEXT,
+      endedAt: Date.now() - 120_000,
+      realEndObservedAt: null, // window open — session still composing
+      replyCalled: false,
+      finalAnswerDelivered: true,
+      finalAnswerSubstantive: true,
+    } as unknown as CurrentTurn
+    h.deps.flushedTurnSupersede.record(
+      CHAT,
+      undefined,
+      { turnId: OWNER_TURN_ID, messageIds: [FLUSH_MSG_ID], text: FLUSHED_TEXT },
+      Date.now() - 120_000,
+    )
+    h.deps.resolveReplyOwnerTurn = () => ownerRes(owner, 'latest-ended', {
+      latestEndedAgeMs: 120_000,
+      latestEndedRealEndAgeMs: null,
+    })
+    // A handback WAS enqueued after the turn ended — but 90 s ago, outside the
+    // 60 s recency window. Tying this read to the (minutes-long) supersede
+    // bound would hold the gate here and ship a visible duplicate — the exact
+    // #4174 regression; this test goes red under that mutation.
+    h.deps.getLastSubagentHandbackAt = () => Date.now() - 90_000
+
+    const res = await sendReply(h.deps, {
+      args: { chat_id: CHAT, text: REWORDED_OWN_REPLY },
+      turn: null,
+    })
+
+    const edits = h.calls.filter((c) => c.method === 'editMessageText')
+    expect(edits).toHaveLength(1)
+    expect(edits[0]!.message_id).toBe(FLUSH_MSG_ID)
+    expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(0)
     expect(res.content[0]!.text).toMatch(/^sent/)
   })
 })

--- a/telegram-plugin/tests/stream-render-golden.test.ts
+++ b/telegram-plugin/tests/stream-render-golden.test.ts
@@ -26,6 +26,7 @@ import {
   handleSessionEvent,
   __resetParkedTurnStartsForTest,
   flushCompletionTracker,
+  closeFlushCompletionWindows,
   type StreamRenderDeps,
 } from '../gateway/stream-render.js'
 import {
@@ -280,6 +281,9 @@ function makeSendReplyDeps(dedup: OutboundDedupCache, sharedSupersede?: FlushedT
     streamKey: key,
     resolveReplyOwnerTurn: () => ownerRes(null, 'none'),
     getLastSubagentHandbackAt: () => null,
+    // #4176 — no sub-agent live (these suites drive the parent session's own
+    // flush→reply collapse). The gate is exercised in send-reply-golden.test.ts.
+    subagentReplyAuthority: { subagentCouldOwnReply: () => false },
     findTurnByOriginId: () => null,
     findTurnByQuotedMessageId: () => null,
     resolveAnswerThreadWithLog: (_c: string, explicit: number | undefined) => explicit,
@@ -789,5 +793,111 @@ describe('#4173 — quiescence flush opens the completion window; the real turn_
         now: Date.now() + SUPERSEDE_COMPLETED_GRACE_MS + 5_000,
       }).reason,
     ).toBe('expired')
+  })
+})
+
+// ── LOW #2 (#4167 review) — the two CLOSE PROXIES, which nothing covered ──────
+//
+// `closeFlushCompletionWindows` has three call sites: the real turn_end (pinned
+// by the #4173 block above) and two PROXIES — a new turn minting on the serial
+// session (`case 'enqueue'`), and the main bridge dying (gateway.ts). Both were
+// untested: deleting the `beginTurn` call left all 18 stream-render tests green,
+// and the bridge-death sweep had no coverage at all. A silently-dropped proxy
+// leaves a flushed turn's window OPEN for the full 30-minute crash cap, which is
+// exactly the tail that makes an edit-over of a delivered answer possible.
+describe('#4173 close proxies — a new turn mint and bridge death both close open windows', () => {
+  const settleFlush = () => new Promise((r) => setTimeout(r, 650))
+  const ANSWER =
+    'The composed terminal answer that the model never sent via reply, long enough to be a ' +
+    'genuine substantive flush delivery for the close-proxy wiring tests.'
+  const CLOSED_BY_GRACE = SUPERSEDE_COMPLETED_GRACE_MS + 5_000
+  // Well inside the 30-minute OPEN cap: if the window did NOT close, the record
+  // is still claimable here — which is what makes these assertions bite.
+  const STILL_OPEN_AT = 10 * 60_000
+
+  beforeEach(() => {
+    __resetParkedTurnStartsForTest()
+    flushCompletionTracker.closeAll(Date.now())
+  })
+
+  async function flushWithOpenWindow(supersede: FlushedTurnSupersedeRegistry) {
+    const turn = makeTurn({ capturedText: [ANSWER], realEndObservedAt: 111 } as Partial<CurrentTurn>)
+    const sh = makeStreamDeps({ turn, flushedTurnSupersede: supersede })
+    handleSessionEvent(sh.deps, { kind: 'turn_end', durationMs: -1, reason: 'answer-ready-quiescence' })
+    await settleFlush()
+    expect(sh.delivered).toContain(ANSWER)
+    // Precondition: the window is genuinely OPEN (claimable 10 minutes out).
+    expect((turn as unknown as { realEndObservedAt: number | null }).realEndObservedAt).toBeNull()
+    expect(
+      supersede.peek(CHAT, undefined, { liveTurnId: turn.turnId, now: Date.now() + STILL_OPEN_AT }).reason,
+    ).toBe('supersede')
+    return { turn, sh }
+  }
+
+  it('PROXY A: a NEW TURN minting (case `enqueue`) closes the prior flush window — ' +
+    'the record then expires on the replay grace, not the 30-minute open cap', async () => {
+    const supersede = new FlushedTurnSupersedeRegistry()
+    const { turn, sh } = await flushWithOpenWindow(supersede)
+
+    // The serial session moved on: the CLI enqueues the next turn. The harness's
+    // fake `endCurrentTurnAtomic` does not null the turn, so clear it here — an
+    // idle session is what makes `enqueue` MINT rather than park.
+    ;(sh.deps as unknown as { setCurrentTurn: (t: CurrentTurn | null) => void }).setCurrentTurn(null)
+    handleSessionEvent(sh.deps, {
+      kind: 'enqueue',
+      chatId: CHAT,
+      messageId: null,
+      threadId: null,
+      rawContent: 'the next user message',
+    })
+
+    // The atom is stamped…
+    expect((turn as unknown as { realEndObservedAt: number | null }).realEndObservedAt).not.toBeNull()
+    // …the bounded replay grace still honours the flushed turn's own late reply…
+    expect(
+      supersede.peek(CHAT, undefined, { liveTurnId: turn.turnId, now: Date.now() + 1_000 }).reason,
+    ).toBe('supersede')
+    // …and past the grace it is EXPIRED. Deleting `closeFlushCompletionWindows`
+    // from `beginTurn` turns BOTH of the assertions below red (the record would
+    // still read 'supersede' out to the 30-minute cap).
+    expect(
+      supersede.peek(CHAT, undefined, { liveTurnId: turn.turnId, now: Date.now() + CLOSED_BY_GRACE }).reason,
+    ).toBe('expired')
+    expect(
+      supersede.peek(CHAT, undefined, { liveTurnId: turn.turnId, now: Date.now() + STILL_OPEN_AT }).reason,
+    ).toBe('expired')
+  })
+
+  it('PROXY B: the bridge-death sweep (`closeFlushCompletionWindows`) closes an open ' +
+    'window to the grace and reports how many atoms it stamped', async () => {
+    const supersede = new FlushedTurnSupersedeRegistry()
+    const { turn } = await flushWithOpenWindow(supersede)
+
+    // The main claude bridge disconnected: the exact call gateway.ts makes.
+    const closed = closeFlushCompletionWindows(supersede, Date.now())
+    expect(closed).toBe(1) // the open atom was stamped, not silently skipped
+
+    expect((turn as unknown as { realEndObservedAt: number | null }).realEndObservedAt).not.toBeNull()
+    expect(
+      supersede.peek(CHAT, undefined, { liveTurnId: turn.turnId, now: Date.now() + CLOSED_BY_GRACE }).reason,
+    ).toBe('expired')
+    // Idempotent: a second disconnect sweep stamps nothing further.
+    expect(closeFlushCompletionWindows(supersede, Date.now())).toBe(0)
+  })
+
+  it('PROXY B wiring: gateway.ts calls the sweep on MAIN-bridge disconnect and the ' +
+    '#4176 sub-agent liveness reset alongside it (gateway.ts is not importable)', () => {
+    const src = readFileSync(new URL('../gateway/gateway.ts', import.meta.url), 'utf8')
+    const call = 'const closedWindows = closeFlushCompletionWindows(flushedTurnSupersede, Date.now())'
+    expect(src).toContain(call)
+    // The sweep must sit under the main-bridge guard: a CRON bridge dying says
+    // nothing about the main session's flush windows, so closing there would
+    // shorten a live window on an unrelated session.
+    const idx = src.indexOf(call)
+    expect(idx).toBeGreaterThan(0)
+    const before = src.slice(Math.max(0, idx - 1200), idx)
+    expect(before).toContain('isCronIdentity')
+    // #4176 — the sub-agents die with the session; the reset is co-located.
+    expect(before).toContain('subagentReplyAuthority.reset()')
   })
 })

--- a/telegram-plugin/tests/stream-render-golden.test.ts
+++ b/telegram-plugin/tests/stream-render-golden.test.ts
@@ -25,6 +25,7 @@ import { tmpdir } from 'node:os'
 import {
   handleSessionEvent,
   __resetParkedTurnStartsForTest,
+  flushCompletionTracker,
   type StreamRenderDeps,
 } from '../gateway/stream-render.js'
 import {
@@ -33,7 +34,7 @@ import {
   type SendReplyRequest,
 } from '../gateway/outbound-send-path.js'
 import { OutboundDedupCache } from '../recent-outbound-dedup.js'
-import { FlushedTurnSupersedeRegistry } from '../flushed-turn-supersede.js'
+import { FlushedTurnSupersedeRegistry, SUPERSEDE_COMPLETED_GRACE_MS } from '../flushed-turn-supersede.js'
 import { BackstopDeliveryLedger } from '../gateway/backstop-delivery.js'
 import { redact } from '../secret-detect/redact.js'
 import { createTurnTypingLoop } from '../gateway/turn-typing-loop.js'
@@ -696,5 +697,97 @@ describe('#3544 — turn-start typing is unconditional at the enqueue seam', () 
     expect(rig.sent).toHaveLength(2)
     rig.loop.stopAll()
     rig.emitter.reset()
+  })
+})
+
+
+// ── #4173 — the turn-completion window wiring, driven through the REAL paths ──
+//
+// The pure three-phase rule is pinned in flushed-turn-supersede.test.ts /
+// reply-owner-resolve.test.ts; THESE tests pin the stream-render WIRING — the
+// quiescence flush OPENING the window and the real turn_end CLOSING it — which
+// nothing else covers (deleting either hook leaves every pure test green).
+describe('#4173 — quiescence flush opens the completion window; the real turn_end closes it', () => {
+  const settleFlush = () => new Promise((r) => setTimeout(r, 650))
+  const ANSWER =
+    'The composed terminal answer that the model never sent via reply, long enough to be a ' +
+    'genuine substantive flush delivery for the completion-window wiring tests.'
+
+  beforeEach(() => {
+    // drain module-scope tracker state left by other suites
+    flushCompletionTracker.closeAll(Date.now())
+  })
+
+  it('END-TO-END: the synthetic quiescence turn_end OPENS the window (atom + record ' +
+    'claimable far past any fixed TTL); the REAL turn_end then CLOSES both to the ' +
+    'replay grace', async () => {
+    const supersede = new FlushedTurnSupersedeRegistry()
+    // Pre-stamp a bogus value so the OPEN assertion proves the flush branch
+    // actively nulled it (not that it was merely never written).
+    const turn = makeTurn({ capturedText: [ANSWER], realEndObservedAt: 111 } as Partial<CurrentTurn>)
+    const sh = makeStreamDeps({ turn, flushedTurnSupersede: supersede })
+
+    // The answer-ready quiescence flush: a SYNTHETIC turn_end.
+    handleSessionEvent(sh.deps, { kind: 'turn_end', durationMs: -1, reason: 'answer-ready-quiescence' })
+    await settleFlush()
+    expect(sh.delivered).toContain(ANSWER)
+
+    // OPEN: the atom's window was re-opened at fire time…
+    expect((turn as unknown as { realEndObservedAt: number | null }).realEndObservedAt).toBeNull()
+    // …and the record is claimable 20 minutes out (a /compact longer than any
+    // tuned TTL still collapses to one bubble — the #4166 unbounded case).
+    // Removing the flush branch's `flushCompletionTracker.open(turn)` leaves
+    // the record born-completed via turn-end stamping in prod; in this harness
+    // the observable red is the atom assertion above.
+    expect(
+      supersede.peek(CHAT, undefined, { liveTurnId: turn.turnId, now: Date.now() + 20 * 60_000 }).reason,
+    ).toBe('supersede')
+
+    // The session's REAL turn_end lands later — the completion signal.
+    handleSessionEvent(sh.deps, { kind: 'turn_end', durationMs: 1200 })
+    await settleFlush()
+
+    // CLOSED: the atom is stamped…
+    const stamped = (turn as unknown as { realEndObservedAt: number | null }).realEndObservedAt
+    expect(stamped).not.toBeNull()
+    // …the record still honours the bounded tool-call-replay grace…
+    expect(
+      supersede.peek(CHAT, undefined, { liveTurnId: turn.turnId, now: Date.now() + 1_000 }).reason,
+    ).toBe('supersede')
+    // …and EXPIRES past it: a decoupled same-bridge reply (the Task-sub-agent-
+    // after-parent-turn-end shape) can no longer edit over the flushed answer.
+    // Removing the close hook (`closeFlushCompletionWindows` in case 'turn_end')
+    // turns THIS red — the record would stay open for 30 minutes.
+    expect(
+      supersede.peek(CHAT, undefined, {
+        liveTurnId: turn.turnId,
+        now: Date.now() + SUPERSEDE_COMPLETED_GRACE_MS + 5_000,
+      }).reason,
+    ).toBe('expired')
+  })
+
+  it('the REAL-turn_end backstop variant does NOT re-open the window ' +
+    '(the `durationMs === -1` conditional is load-bearing)', async () => {
+    const supersede = new FlushedTurnSupersedeRegistry()
+    const turn = makeTurn({ capturedText: [ANSWER], realEndObservedAt: 999 } as Partial<CurrentTurn>)
+    const sh = makeStreamDeps({ turn, flushedTurnSupersede: supersede })
+
+    // The turn-end BACKSTOP: the flush fires ON a real turn_end. The session
+    // already stopped, so the window must stay closed (born completed).
+    handleSessionEvent(sh.deps, { kind: 'turn_end', durationMs: 1200 })
+    await settleFlush()
+    expect(sh.delivered).toContain(ANSWER)
+
+    // Unconditionally opening in the flush branch (dropping the -1 check)
+    // nulls this and turns the test red.
+    expect((turn as unknown as { realEndObservedAt: number | null }).realEndObservedAt).not.toBeNull()
+    // The record was born completed (inherited from the atom), so it expires
+    // on the grace, never the 30-minute open cap.
+    expect(
+      supersede.peek(CHAT, undefined, {
+        liveTurnId: turn.turnId,
+        now: Date.now() + SUPERSEDE_COMPLETED_GRACE_MS + 5_000,
+      }).reason,
+    ).toBe('expired')
   })
 })


### PR DESCRIPTION
## What this now is

Take-over of the original TTL-widening PR after the adversarial review returned **DON'T MERGE** on #4172. The 5-minute `DEFAULT_SUPERSEDE_TTL_MS` is gone entirely; in its place:

### 1. Caller-identity gate (#4172 — the blocker)

`onToolCall` threads `client.agentName` → `executeToolCall` → `executeReply` → `sendReply.callerIsForeignSession` (`replyCallerIsForeignSession`, `cron-session.ts`). A foreign-session caller — the `<agent>-cron` Tier-1 bridge, or an unregistered client — **skips the entire supersede/bypass/latch block**: it can never edit or delete a flushed answer (the measured #4172 double loss), and it can never be swallowed by the flush-armed latch (which would have silently dropped a cron digest landing in the pre-record race window). It always sends fresh; the flush record stays intact for the turn's own replay.

### 2. Turn-completion window (#4173 — implemented here, not deferred)

The supersede window is now a **signal, not a constant** (three-phase model documented in the `flushed-turn-supersede.ts` header):

- **OPEN** — the flush fired its *synthetic* turn_end but the session's **real** turn_end has not been observed. A main-bridge reply in this span is by construction the turn's own answer: a **20-minute /compact now collapses to one bubble**, where any tuned constant eventually reproduces #4166. Bounded only by a 30-min crash backstop (`SUPERSEDE_OPEN_WINDOW_CAP_MS`).
- **COMPLETED** — the real turn_end (or a proxy: a new turn minting on the serial session, the bridge dying) was observed. Only a 60 s tool-call-replay grace remains (`SUPERSEDE_COMPLETED_GRACE_MS`). **This closes the same-bridge decoupled-reply hole**: a Task sub-agent replying after the parent turn ended previously had 5 minutes of bypass reach; now it has none past the grace. In the common case (turn_end lands seconds after the flush) this is *strictly narrower* than the old 60 s TTL, let alone 5 min.
- **EXPIRED** — visible duplicate at worst, never an edit-over.

Wiring: `turn-end.ts` stamps `realEndObservedAt` on every ordinary turn end; the stream-render flush branch re-opens it (`FlushCompletionTracker`); the real-turn_end hook, the new-turn-mint hook, and the gateway bridge-disconnect hook close it, completing the registry records in the same call (`closeFlushCompletionWindows`). The latest-ended owner tier consumes the same signal via `latestEndedRealEndAgeMs`.

### Why BOTH mechanisms (where the review was wrong)

The review's claim that #4173 "subsumes the blocker" is **incorrect for the cron instance**: cron session events are identity-filtered out of `handleSessionEvent` (`isCronIdentity` early-return), so a cron reply landing *mid-window* is indistinguishable from the turn's own answer by any turn-lifecycle signal — only caller identity separates it. Conversely, identity cannot separate a Task sub-agent (same bridge, same `agentName`) — only the completion signal can. Each mechanism covers exactly the hole the other cannot.

### Also in scope

- **#4174** — `handbackCouldOwnReply` gets its own `HANDBACK_RECENCY_WINDOW_MS` (60 s, `subagent-handback-marker.ts`); the chat-wide gate-hold no longer follows the supersede bound.
- **#4175** — `latestEndedAccepted` now **fails CLOSED** on an omitted age/ttl (the old "unbounded back-compat escape" failed OPEN precisely when the gateway wiring was dropped); env kill-switches `SWITCHROOM_SUPERSEDE_OPEN_CAP_MS` / `SWITCHROOM_SUPERSEDE_GRACE_MS`; structural pins on the gateway wiring.
- **#4171** — stale "60 s" comments rewritten; the **false invariant claim** in `subagent-handback-marker.ts` (cron "lands as its own live inbound turn") corrected for Tier-1, with an explicit pointer to the identity gate.
- Gateway anti-inflation ratchet: the owner-resolution composition extracted to `gateway/reply-owner-wiring.ts` (gateway.ts net −2 lines).

### Mutation matrix (all run locally, each restored green)

| Mutation | Red tests |
|---|---|
| identity gate removed (`callerIsForeignSession` ignored) | 2 — #4172 blocker repro + latch-protection (golden) |
| three-phase freshness → fixed 60 s TTL | 11 — 143 s + 20-min open-window outcomes across 3 files |
| unbounded escape restored / completion signal ignored | 4 — incl. Task-after-turn-end golden case |
| handback window widened to 5 min | 1 — #4174 outcome test |
| flush-branch `open()` removed / turn_end close hook removed / `-1` conditional dropped | 1 / 1 / 2 — stream-render wiring tests |

The blocker repro now shows: cron digest reply inside the window → **zero `editMessageText`/`deleteMessage` on the flushed id, exactly one fresh `sendRichMessage`**, record intact — with a negative control that reproduces the review's measured edit-over when the gate is bypassed.

Closes #4166. Closes #4172. Closes #4173. Closes #4174. Closes #4175. Closes #4171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
