### PR TITLE
feat(memory): fleet skepticism floor + seeded anti-confabulation directive

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -504,7 +504,43 @@ agents:
 
 **Zero-config defaults.** Built-in profiles ship differentiated dispositions so a fresh `switchroom setup` needs no YAML — `health-coach` leans empathy-high (`2/2/5`), `executive-assistant` leans precise (`4/4/3`), `coding` leans skeptical + literal (`4/5/2`). Operator config overrides these per-key.
 
+**The fleet skepticism floor.** Every agent — including one with no profile and no `memory:` block at all — gets `skepticism: 4` by default. The engine's own default is `3` ("accepts stated information"); `4` flags contradictions and treats a single unsupported assertion as a claim rather than a fact, which is what keeps a bank from hardening the agent's own synthesized output into remembered truth. It is the lowest tier of a three-tier merge:
+
+```
+fleet default ({ skepticism: 4 })  →  profile disposition  →  agents.<name>.memory.disposition
+```
+
+so `health-coach`'s `skepticism: 2` still wins, and `memory: { disposition: { skepticism: 3 } }` in YAML still puts an individual agent back on the engine default. `literalism` and `empathy` have **no** fleet default — they are genuinely persona-shaped, and a fleet-wide value would be a guess imposed on every agent.
+
+The floor is **read-first**, so it never rewrites a bank you tuned by hand: `switchroom apply` reads the bank's live disposition and pushes a fleet-only trait only when the bank has it unset or sitting on the engine default `3`. A bank already at `5` is left at `5`; a bank at `2` is left at `2`. A trait that came from a profile or from your YAML is authoritative and is pushed normally. If the disposition read fails, nothing is pushed.
+
 All four apply at **both** scaffold (fresh agents) and reconcile (`switchroom apply` updates existing banks) — except the `retain_mission` *default*, which is seeded only at scaffold so a customized retain mission is never clobbered.
+
+### The seeded anti-confabulation directive — `memory.anti_confabulation_directive`
+
+Directives are hard rules Hindsight applies during `reflect`. Every agent's bank is seeded with one by default, named `no-confabulation`, which tells the bank to say it does not know rather than compose an answer retrieval does not support — including not asserting a date, number, attribution, or decision merely because the question presupposed it.
+
+This exists because `recall` has a `min_scores` relevance floor and **`reflect` has none**: with no floor, a query that retrieves nothing relevant still gets a fluent answer. Directives are the only lever that reaches reflect, so the seeded directive is prompt discipline standing in for a guarantee the engine should enforce.
+
+| Value | Effect |
+| --- | --- |
+| unset (default) | Seeds switchroom's directive text. |
+| `true` | Same as unset — explicit opt-in. |
+| `false` | Never seeds. Does **not** delete a directive already in the bank — removal is the agent's `delete_directive` MCP tool, not an apply-time side effect. |
+| a string | Seeds *your* text under the same name; switchroom then treats it as operator-owned and never rewrites it. |
+
+```yaml
+agents:
+  lawyer:
+    memory:
+      anti_confabulation_directive: |
+        Never state a holding, a citation, or a filing date that no retrieved
+        memory contains. Say "not in the bank" instead.
+```
+
+Seeding is **idempotent and never clobbers**: it runs at both scaffold and reconcile, writes nothing when the bank's directive already matches, and — using the same supersession registry mechanic as `retain_mission` — upgrades the text only when what is in the bank is byte-identical to a *previous* switchroom default. A directive you edited by hand in the Hindsight UI is left alone forever. Creation also respects the 30-directive-per-bank cap (`switchroom doctor` WARNs above 24): at the cap, seeding is skipped with a log line rather than pushing a bank over the edge where low-priority directives silently drop out of recall. An *upgrade* of an existing directive is not blocked by the cap, since it does not add one.
+
+The seeded directive carries the tag `switchroom-seeded` and priority `10` — above an unprioritized directive, below anything you deliberately prioritized higher.
 
 ### Demoting individual memories from auto-recall
 

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -781,7 +781,9 @@ import { reconcileAgentDefaultSkills } from "./reconcile-default-skills.js";
 import { applyTelegramProgressGuidance, applySubAgentLocalTimeGuidance } from "./sub-agent-telegram-prompt.js";
 import type { McpServerConfig } from "../memory/hindsight.js";
 import { RETAIN_TAGS_DEFAULT } from "../memory/hindsight-retain-provenance.js";
-import { createBank, updateBankMissions, ensureDeclaredMentalModels, DEFAULT_RETAIN_MISSION, resolveBankMissionExtras, isHindsightEnabled, fetchBankRetainMission, decideRetainMissionUpgrade, PROFILE_MEMORY_DEFAULTS, fetchBankObservationsMission, decideObservationsMissionUpgrade } from "../memory/hindsight.js";
+import { createBank, updateBankMissions, ensureDeclaredMentalModels, DEFAULT_RETAIN_MISSION, resolveBankMissionExtras, isHindsightEnabled, fetchBankRetainMission, decideRetainMissionUpgrade, PROFILE_MEMORY_DEFAULTS, fetchBankObservationsMission, decideObservationsMissionUpgrade, fetchBankDisposition, decideDispositionPush, fleetOnlyDispositionTraits } from "../memory/hindsight.js";
+import type { BankDisposition } from "../memory/hindsight.js";
+import { ensureAntiConfabulationDirective } from "../memory/hindsight-seed-directives.js";
 import { loadTopicState } from "../telegram/state.js";
 import { resolveDualPath } from "../config/paths.js";
 import { resolvePath } from "../config/loader.js";
@@ -2077,6 +2079,103 @@ async function resolveObservationsMissionPush(
     );
   }
   return decision.mission;
+}
+
+/**
+ * Decide which disposition traits to push to a bank, read-first.
+ *
+ * Shared by the scaffold and reconcile bank-op chains. Before the fleet-wide
+ * floor existed, `disposition` was only ever non-empty for an agent on a
+ * specialist profile or with explicit yaml, so pushing it unconditionally was
+ * nearly free. A floor makes it non-empty for EVERY agent, which without this
+ * would (a) send an `update_bank` on every apply for every agent forever, and
+ * (b) overwrite the disposition of every bank an operator had tuned by hand.
+ * See {@link decideDispositionPush}.
+ *
+ * Returns `undefined` for "push nothing" — including when the read fails,
+ * because "unknown" must never be treated as "unset".
+ */
+async function resolveDispositionPush(
+  apiUrl: string,
+  bankId: string,
+  desired: BankDisposition | undefined,
+  memory: { disposition?: BankDisposition } | undefined,
+  profileName: string,
+  label: string,
+): Promise<BankDisposition | undefined> {
+  if (!desired) return undefined;
+  const current = await fetchBankDisposition(apiUrl, bankId, { timeoutMs: 5000 });
+  if (!current.ok) {
+    console.warn(
+      `  ${chalk.yellow("⚠")} Could not read current disposition for ${label} (${current.reason}) — leaving it untouched`,
+    );
+    return undefined;
+  }
+  return decideDispositionPush(
+    desired,
+    current.disposition,
+    fleetOnlyDispositionTraits(memory, profileName),
+  );
+}
+
+/**
+ * Seed / upgrade the anti-confabulation directive on one bank, and report the
+ * outcome in the same voice as the sibling bank ops.
+ *
+ * Shared by BOTH the scaffold and reconcile bank-op chains, for the reason
+ * `resolveObservationsMissionPush` is: `switchroom apply` re-scaffolds every
+ * existing agent and never calls `reconcileAgent`, so a seed wired into only
+ * one of the two paths reaches roughly none of the fleet.
+ *
+ * Best-effort by contract — {@link ensureAntiConfabulationDirective} never
+ * throws, and this never rejects. A guardrail directive is worth an apply, not
+ * worth failing one.
+ */
+async function seedAntiConfabulationDirective(
+  apiUrl: string,
+  bankId: string,
+  configured: boolean | string | undefined,
+  label: string,
+): Promise<void> {
+  try {
+    const outcome = await ensureAntiConfabulationDirective(
+      apiUrl,
+      bankId,
+      configured,
+      { timeoutMs: 5000 },
+    );
+    switch (outcome.action) {
+      case "created":
+        console.log(
+          `  ${chalk.green("✓")} Seeded "${outcome.name}" directive for ${label}`,
+        );
+        break;
+      case "upgraded":
+        console.log(
+          `  ${chalk.green("✓")} Upgrading superseded default "${outcome.name}" directive for ${label}`,
+        );
+        break;
+      case "skipped":
+        // "disabled" is the operator's own choice, not news.
+        if (outcome.reason !== "disabled") {
+          console.warn(
+            `  ${chalk.yellow("⚠")} Skipped "${outcome.name}" directive for ${label}: ${outcome.reason}`,
+          );
+        }
+        break;
+      case "failed":
+        console.warn(
+          `  ${chalk.yellow("⚠")} Failed to ensure "${outcome.name}" directive for ${label}: ${outcome.reason}`,
+        );
+        break;
+      case "unchanged":
+        break;
+    }
+  } catch (err) {
+    console.warn(
+      `  ${chalk.yellow("⚠")} Directive seed error for ${label}: ${err}`,
+    );
+  }
 }
 
 /**
@@ -6306,6 +6405,21 @@ export function scaffoldAgent(
       // retain_mission it is a switchroom-managed default, so it goes through a
       // read-first decision that never clobbers an operator's hand-edit.
       delete missions.observations_mission;
+
+      // disposition gets the same read-first treatment, for the same reason:
+      // it is now non-empty for every agent (fleet floor), so pushing it
+      // blindly would both re-send it forever and overwrite hand-tuned banks.
+      delete missions.disposition;
+      const dispositionPush = await resolveDispositionPush(
+        apiUrl,
+        hindsightBankId,
+        extras.disposition,
+        agentConfig.memory,
+        resolveMemoryProfile(agentConfig),
+        formatAgentBankLabel(name, hindsightBankId),
+      );
+      if (dispositionPush) missions.disposition = dispositionPush;
+
       const seededObservationsMission = await resolveObservationsMissionPush(
         apiUrl,
         hindsightBankId,
@@ -6365,6 +6479,16 @@ export function scaffoldAgent(
         .catch((err) => {
           console.warn(`  ${chalk.yellow("⚠")} Mental model ensure error for ${formatAgentBankLabel(name, hindsightBankId)}: ${err}`);
         });
+
+      // Seed the anti-confabulation guardrail directive (default ON, no yaml
+      // required). Idempotent and never-clobbering — see
+      // src/memory/hindsight-seed-directives.ts.
+      await seedAntiConfabulationDirective(
+        apiUrl,
+        hindsightBankId,
+        agentConfig.memory?.anti_confabulation_directive,
+        formatAgentBankLabel(name, hindsightBankId),
+      );
     }));
   }
 
@@ -8751,6 +8875,21 @@ function reconcileAgentInner(
       // Same read-first treatment for observations_mission — see
       // `resolveObservationsMissionPush`.
       delete missions.observations_mission;
+
+      // disposition gets the same read-first treatment, for the same reason:
+      // it is now non-empty for every agent (fleet floor), so pushing it
+      // blindly would both re-send it forever and overwrite hand-tuned banks.
+      delete missions.disposition;
+      const dispositionPush = await resolveDispositionPush(
+        apiUrl,
+        hindsightBankId,
+        extras.disposition,
+        agentConfig.memory,
+        resolveMemoryProfile(agentConfig),
+        formatAgentBankLabel(name, hindsightBankId),
+      );
+      if (dispositionPush) missions.disposition = dispositionPush;
+
       const observationsMission = await resolveObservationsMissionPush(
         apiUrl,
         hindsightBankId,
@@ -8796,6 +8935,16 @@ function reconcileAgentInner(
         .catch((err) => {
           console.warn(`  ${chalk.yellow("⚠")} Mental model ensure error for ${formatAgentBankLabel(name, hindsightBankId)}: ${err}`);
         });
+
+      // Seed the anti-confabulation guardrail directive (default ON, no yaml
+      // required). Idempotent and never-clobbering — see
+      // src/memory/hindsight-seed-directives.ts.
+      await seedAntiConfabulationDirective(
+        apiUrl,
+        hindsightBankId,
+        agentConfig.memory?.anti_confabulation_directive,
+        formatAgentBankLabel(name, hindsightBankId),
+      );
     }));
   }
 

--- a/src/cli/doctor-memory.ts
+++ b/src/cli/doctor-memory.ts
@@ -30,6 +30,7 @@ import {
   HINDSIGHT_MIN_API_VERSION,
 } from "../memory/hindsight-tools.js";
 import { compareApiVersion, fetchHindsightApiVersion } from "../memory/hindsight-repair.js";
+import { MAX_DIRECTIVES } from "../memory/hindsight-directive-admin.js";
 import {
   HINDSIGHT_DATA_VOLUME,
   HINDSIGHT_DEFAULT_WORKER_ID,
@@ -47,15 +48,13 @@ export interface CheckResult {
 export const MIN_HINDSIGHT_SHM_BYTES = 1024 * 1024 * 1024;
 
 /**
- * Hard cap on how many active directives the recall hook ever injects into the
- * prompt — MUST mirror `MAX_DIRECTIVES` in
- * `vendor/hindsight-memory/scripts/lib/directives.py`. A bank with MORE active
- * directives than this has its list truncated (`directives[:30]`) in the
- * `<active_directives>` recall block: the lowest-priority directives beyond the
- * cap never reach the agent. The plugin now also warns to stderr when it
- * truncates; the doctor surfaces the same condition fleet-wide (workstream C2).
+ * Re-exported for back-compat; the constant now lives in the memory layer
+ * (`src/memory/hindsight-directive-admin.ts`) because directive WRITERS need it
+ * too — the seeded anti-confabulation directive must not push a bank over the
+ * cap — and a memory module importing a `cli/` module to learn it would invert
+ * the layering.
  */
-export const MAX_DIRECTIVES = 30;
+export { MAX_DIRECTIVES };
 
 /**
  * Soft threshold: a bank with MORE active directives than this earns a WARN

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -414,6 +414,47 @@ const ObservationScopeStrategySchema = z
     "Cascade: override (per-agent wins over default)."
   );
 
+/**
+ * `memory.anti_confabulation_directive` — the seeded guardrail directive that
+ * tells reflect to answer "the bank does not know" rather than synthesising an
+ * answer retrieval does not support.
+ *
+ * Three shapes, one knob, matching the "defaults do the right thing;
+ * complexity is opt-in" rule:
+ *
+ *   - **unset / `true`** → switchroom seeds and maintains its own default. The
+ *     zero-config path; nothing in yaml is required to get the guardrail.
+ *   - **`false`** → seed nothing, and leave any existing directive of that
+ *     name alone (a bank that already has one keeps it — opting out of
+ *     MANAGEMENT is not a delete).
+ *   - **a string** → operator-authored text. Wins outright and is re-asserted
+ *     on every apply, exactly like `memory.retain_mission`.
+ *
+ * A fourth override path needs no yaml at all: edit the directive in the bank.
+ * Seeding only ever upgrades text that byte-matches a default switchroom
+ * itself shipped, so a hand-edit is permanent (see
+ * `src/memory/hindsight-seed-directives.ts`).
+ *
+ * Declared once and reused by BOTH `AgentMemorySchema` and the
+ * defaults/profile-tier mirror so the two tiers cannot drift.
+ */
+const AntiConfabulationDirectiveSchema = z
+  .union([z.boolean(), z.string().min(1)])
+  .optional()
+  .describe(
+    "The seeded anti-confabulation directive: reflect has no relevance " +
+    "floor (`min_scores` is a /recall-only parameter), so a bank holding " +
+    "nothing relevant still yields a confident answer, and a question that " +
+    "presupposes a decision reliably produces one. Directives ARE applied " +
+    "during reflect, so this is the lever. Unset or true (the default) " +
+    "seeds and maintains switchroom's own text; false disables seeding and " +
+    "leaves any existing directive untouched; a string is operator-authored " +
+    "text that wins outright. Switchroom only ever upgrades directive text " +
+    "byte-equal to a default it shipped, so editing the directive in the " +
+    "bank is also a permanent override. " +
+    "Cascade: override (per-agent wins over default)."
+  );
+
 export const AgentMemorySchema = z
   .object({
     collection: z.string().describe("Hindsight collection name for this agent"),
@@ -600,6 +641,7 @@ export const AgentMemorySchema = z
         "silent hook-side write). Set false to disable per-agent. " +
         "Cascade: override (per-agent wins over default)."
       ),
+    anti_confabulation_directive: AntiConfabulationDirectiveSchema,
     observation_scopes: ObservationScopesSchema,
     observation_scope_strategy: ObservationScopeStrategySchema,
     recall: z
@@ -3393,6 +3435,12 @@ const profileFields = {
       // defaults/profile tier too, so `defaults.memory.directive_capture_nudge:
       // false` can disable the #2848 nudge fleet-wide (per-agent `true` opt-in).
       directive_capture_nudge: z.boolean().optional(),
+      // Mirror of AgentMemorySchema.anti_confabulation_directive — accepted at
+      // the defaults/profile tier too, so `defaults.memory.
+      // anti_confabulation_directive: false` opts a whole fleet out of the
+      // seeded guardrail (or pins one house text for every agent), with
+      // per-agent override.
+      anti_confabulation_directive: AntiConfabulationDirectiveSchema,
       // Mirror of AgentMemorySchema.observation_scopes — accepted at the
       // defaults/profile tier too, so `defaults.memory.observation_scopes:
       // shared` pins a whole fleet's observations to one scope. A per-agent

--- a/src/memory/hindsight-directive-admin.ts
+++ b/src/memory/hindsight-directive-admin.ts
@@ -58,6 +58,22 @@
  * silently assumed away.
  */
 
+/**
+ * Hard cap on how many active directives the recall hook ever injects into the
+ * prompt — MUST mirror `MAX_DIRECTIVES` in
+ * `vendor/hindsight-memory/scripts/lib/directives.py`. A bank with MORE active
+ * directives than this has its list truncated (`directives[:30]`) in the
+ * `<active_directives>` recall block: the lowest-priority directives beyond the
+ * cap never reach the agent. The plugin also warns to stderr when it truncates;
+ * the doctor surfaces the same condition fleet-wide (workstream C2).
+ *
+ * It lives here, in the memory layer, because both READERS (`switchroom
+ * doctor`, which re-exports it from `cli/doctor-memory.ts`) and WRITERS (the
+ * seeded directive in `hindsight-seed-directives.ts`, which must not push a
+ * bank over the cap) need it, and the writer is a memory module.
+ */
+export const MAX_DIRECTIVES = 30;
+
 /** Directive as returned by `GET .../directives`. */
 export interface HindsightDirective {
   id: string;

--- a/src/memory/hindsight-seed-directives.ts
+++ b/src/memory/hindsight-seed-directives.ts
@@ -1,0 +1,274 @@
+/**
+ * The switchroom-seeded **anti-confabulation directive**, and the idempotent
+ * ensure/upgrade path that keeps it on every managed bank.
+ *
+ * ## Why a directive, and why this one
+ *
+ * `reflect` synthesises an answer from whatever retrieval hands it. Unlike
+ * `/recall`, **it has no relevance floor**: `min_scores` is a `/recall`-only
+ * parameter, and `/reflect` accepts only `query`, `budget`, `max_tokens`,
+ * `response_schema`, `tags`, `tags_match`, `fact_types`,
+ * `exclude_mental_models` and `exclude_mental_model_ids` (verified against the
+ * live OpenAPI on the pinned image, 2026-08-02). So when a bank holds nothing
+ * relevant, reflect still gets the best of a bad set and still writes a fluent,
+ * confident paragraph — and a question that PRESUPPOSES a decision ("when did
+ * we decide X?") reliably produces one.
+ *
+ * Directives ARE applied during reflect. That makes a seeded directive the only
+ * lever switchroom has on this failure from the outside.
+ *
+ * ## Stated honestly: this is prompt discipline, not a guarantee
+ *
+ * A model told not to confabulate can still confabulate. This directive raises
+ * the floor; it does not install one. The real fix is upstream — reflect needs
+ * a relevance floor (the `/recall` `min_scores` equivalent) so "nothing scored
+ * above the floor" is a *structural* answer rather than an instruction the
+ * synthesiser may ignore. Nothing here should be read as having done that.
+ *
+ * ## Never clobber a human
+ *
+ * Seeding follows the same rule as the managed missions, using the SAME
+ * decision function ({@link decideMissionUpgrade}) rather than a parallel one:
+ *
+ *   - operator text in yaml wins outright;
+ *   - a bank whose directive is missing, empty, or byte-equal to a previously
+ *     shipped default is upgraded to the current default;
+ *   - anything else — any hand-edit, even whitespace — is left alone forever.
+ *
+ * That is what makes "edit the directive in the bank" a real override path and
+ * not something the next `switchroom apply` undoes.
+ */
+
+import { decideMissionUpgrade } from "./hindsight.js";
+import { MAX_DIRECTIVES } from "./hindsight-directive-admin.js";
+
+/** Stable identity key for the seeded directive. Never change it. */
+export const ANTI_CONFABULATION_DIRECTIVE_NAME = "no-confabulation";
+
+/**
+ * Marks the directive as switchroom-managed, so an operator listing directives
+ * can tell a seeded guardrail from one they or the agent wrote.
+ */
+export const SWITCHROOM_SEEDED_TAG = "switchroom-seeded";
+
+/**
+ * Priority 10, deliberately, not 100.
+ *
+ * Priority orders injection, and the recall block truncates past
+ * `MAX_DIRECTIVES` — so a guardrail at the engine default of 0 is among the
+ * first to fall out of a crowded bank, which is exactly when it matters most.
+ * 10 keeps it ahead of unprioritised directives while leaving every operator
+ * directive with an explicit priority able to outrank it. A seeded default
+ * should not be able to shout down a rule a human set on purpose.
+ */
+export const ANTI_CONFABULATION_DIRECTIVE_PRIORITY = 10;
+
+/**
+ * The seeded text.
+ *
+ * Two named failures, both observed in the fleet: an answer synthesised from
+ * retrieval that supports nothing, and a presupposed decision supplied on
+ * demand. The closing clause about transcript-derived memories is inert on a
+ * bank that carries no such tag, so this text is safe to ship independently.
+ */
+export const ANTI_CONFABULATION_DIRECTIVE =
+  "When the retrieved memories do not support an answer, say so instead of composing one.\n" +
+  "\n" +
+  "- If nothing retrieved scores meaningfully above zero, or what came back is off-topic, the honest answer is that the bank does not know. Say that plainly, and say what would settle it.\n" +
+  "- Never assert a date, a version, a number, an attribution, a decision, or an outcome that no retrieved memory states. A question that presupposes something is not evidence for it: asked when a decision was made, when the bank records no such decision, answer that none is recorded — do not supply one.\n" +
+  "- Keep what the bank RECORDED separate from what you INFER. State inferences as inferences, and say which memory a recorded fact came from.\n" +
+  "- Treat a memory that was extracted from a conversation transcript as an unverified claim, not an established fact — it may be an assistant's own earlier guess. If it is the only support for an answer, say that it is.\n" +
+  "- Partial knowledge with its gaps named is more useful than a fluent answer that fills them in.";
+
+/**
+ * Every text switchroom has EVER shipped as the anti-confabulation default.
+ *
+ * Append-only, byte-exact, never reorder or reformat: membership here is what
+ * licenses an automatic upgrade, so an entry that no longer byte-matches what
+ * a bank actually carries silently strands that bank on an old default. Empty
+ * on first ship — there is no previous default to supersede.
+ */
+export const SUPERSEDED_ANTI_CONFABULATION_DIRECTIVES: readonly string[] = [];
+
+/** A directive as returned by `GET .../directives`. */
+export interface SeededDirectiveRecord {
+  id: string;
+  name: string;
+  content?: string;
+  is_active?: boolean;
+  priority?: number;
+  tags?: string[];
+}
+
+export type SeedDirectiveOutcome =
+  | { action: "created"; name: string }
+  | { action: "upgraded"; name: string }
+  | { action: "unchanged"; name: string }
+  | { action: "skipped"; name: string; reason: string }
+  | { action: "failed"; name: string; reason: string };
+
+/**
+ * Resolve the operator's `memory.anti_confabulation_directive` value into the
+ * two things the seeding path needs: whether to act at all, and (when the
+ * operator supplied text) the text that wins outright.
+ *
+ * Accepted shapes, matching the yaml schema:
+ *   - `undefined` → seed the shipped default (the zero-config path);
+ *   - `true`      → same, stated explicitly;
+ *   - `false`     → do nothing, and touch nothing that already exists;
+ *   - a string    → operator-authored text, pushed and maintained as theirs.
+ */
+export function resolveAntiConfabulationDirective(
+  configured: boolean | string | undefined,
+): { enabled: boolean; operatorText?: string; desired: string } {
+  if (configured === false) {
+    return { enabled: false, desired: ANTI_CONFABULATION_DIRECTIVE };
+  }
+  if (typeof configured === "string" && configured.trim() !== "") {
+    return { enabled: true, operatorText: configured, desired: configured };
+  }
+  return { enabled: true, desired: ANTI_CONFABULATION_DIRECTIVE };
+}
+
+/**
+ * Decide what to do about the seeded directive, given the bank's live
+ * directives. Pure, so the policy is testable without a server.
+ *
+ * `activeCount` gates CREATION only: a bank already at `MAX_DIRECTIVES` has no
+ * room, and pushing it over the cap would silently truncate the recall block —
+ * dropping somebody's directive to make room for ours. Upgrading an existing
+ * one consumes no slot and is therefore never gated.
+ */
+export function decideDirectiveSeed(
+  existing: SeededDirectiveRecord | undefined,
+  configured: boolean | string | undefined,
+  opts: { activeCount: number; desired?: string; shipped?: readonly string[] },
+): { action: "create" | "upgrade" | "none" | "skip"; content?: string; reason?: string } {
+  const resolved = resolveAntiConfabulationDirective(configured);
+  if (!resolved.enabled) return { action: "none", reason: "disabled" };
+
+  const desired = opts.desired ?? resolved.desired;
+  const shipped = opts.shipped ?? SUPERSEDED_ANTI_CONFABULATION_DIRECTIVES;
+
+  if (!existing) {
+    if (opts.activeCount >= MAX_DIRECTIVES) {
+      return {
+        action: "skip",
+        reason:
+          `bank already has ${opts.activeCount} active directives ` +
+          `(MAX_DIRECTIVES=${MAX_DIRECTIVES}); seeding would truncate the recall block`,
+      };
+    }
+    return { action: "create", content: desired };
+  }
+
+  // An existing directive goes through the shared mission-upgrade rule, so the
+  // never-clobber semantics cannot drift from the ones the missions use.
+  const decision = decideMissionUpgrade(
+    resolved.operatorText,
+    existing.content ?? null,
+    desired,
+    shipped,
+  );
+  if (decision.action === "none") return { action: "none" };
+  if (decision.mission === existing.content) return { action: "none" };
+  return { action: "upgrade", content: decision.mission };
+}
+
+/**
+ * Ensure the anti-confabulation directive on one bank. Best-effort by
+ * contract: it NEVER throws and never blocks an apply — a bank without its
+ * guardrail is worse than one with it, but a failed apply is worse than both.
+ *
+ * REST rather than MCP because the MCP surface has no update verb: the pinned
+ * image registers `create_directive` / `list_directives` / `delete_directive`
+ * only, so an upgrade would have to be delete-then-recreate (losing the id,
+ * and briefly leaving the bank unguarded). `PATCH .../directives/{id}` is the
+ * honest primitive. Both paths are unauthenticated on the same host — see the
+ * boundary note in `hindsight-directive-admin.ts`.
+ */
+export async function ensureAntiConfabulationDirective(
+  apiUrl: string,
+  bankId: string,
+  configured: boolean | string | undefined,
+  opts?: { fetchImpl?: typeof fetch; timeoutMs?: number },
+): Promise<SeedDirectiveOutcome> {
+  const name = ANTI_CONFABULATION_DIRECTIVE_NAME;
+  if (resolveAntiConfabulationDirective(configured).enabled === false) {
+    return { action: "skipped", name, reason: "disabled" };
+  }
+
+  const fetchImpl = opts?.fetchImpl ?? fetch;
+  const timeoutMs = opts?.timeoutMs ?? 5000;
+  const base = apiUrl.replace(/\/mcp\/?$/, "").replace(/\/+$/, "");
+  const path = `${base}/v1/default/banks/${encodeURIComponent(bankId)}/directives`;
+
+  const send = async (url: string, init?: { method: string; body?: string }) => {
+    const ctl = new AbortController();
+    const timer = setTimeout(() => ctl.abort(), timeoutMs);
+    try {
+      return await fetchImpl(url, {
+        method: init?.method ?? "GET",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json",
+          "X-Bank-Id": bankId,
+        },
+        ...(init?.body === undefined ? {} : { body: init.body }),
+        signal: ctl.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+
+  try {
+    // `active_only=false` so a directive an operator DEACTIVATED is still
+    // found — reseeding one they deliberately turned off would be a clobber
+    // wearing a create's clothes.
+    const listRes = await send(`${path}?active_only=false&limit=1000`);
+    if (!listRes.ok) {
+      return { action: "failed", name, reason: `list HTTP ${listRes.status}` };
+    }
+    const parsed = (await listRes.json()) as
+      | { items?: SeededDirectiveRecord[] }
+      | SeededDirectiveRecord[];
+    const items = Array.isArray(parsed) ? parsed : (parsed?.items ?? []);
+    const existing = items.find((d) => d?.name === name);
+    const activeCount = items.filter((d) => d?.is_active !== false).length;
+
+    const decision = decideDirectiveSeed(existing, configured, { activeCount });
+
+    if (decision.action === "none") return { action: "unchanged", name };
+    if (decision.action === "skip") {
+      return { action: "skipped", name, reason: decision.reason ?? "skipped" };
+    }
+
+    if (decision.action === "create") {
+      const res = await send(path, {
+        method: "POST",
+        body: JSON.stringify({
+          name,
+          content: decision.content,
+          priority: ANTI_CONFABULATION_DIRECTIVE_PRIORITY,
+          is_active: true,
+          tags: [SWITCHROOM_SEEDED_TAG],
+        }),
+      });
+      if (!res.ok) return { action: "failed", name, reason: `create HTTP ${res.status}` };
+      return { action: "created", name };
+    }
+
+    const res = await send(`${path}/${encodeURIComponent(existing!.id)}`, {
+      method: "PATCH",
+      body: JSON.stringify({ content: decision.content }),
+    });
+    if (!res.ok) return { action: "failed", name, reason: `update HTTP ${res.status}` };
+    return { action: "upgraded", name };
+  } catch (err) {
+    if ((err as Error)?.name === "AbortError") {
+      return { action: "failed", name, reason: "Timeout" };
+    }
+    return { action: "failed", name, reason: String((err as Error)?.message ?? err) };
+  }
+}

--- a/src/memory/hindsight.ts
+++ b/src/memory/hindsight.ts
@@ -1169,7 +1169,8 @@ export interface BankMissionExtras {
  * Only `disposition` + `observations_mission` are defaulted here; the
  * persona statement (`reflect_mission` / `bank_mission`) stays operator-driven
  * so there is no code-vs-yaml persona conflict. Profiles not listed (notably
- * `default`) inherit the engine disposition (all traits 3) and
+ * `default`) inherit {@link FLEET_DEFAULT_DISPOSITION} for the traits it sets,
+ * the engine disposition (3) for the rest, and
  * {@link DEFAULT_OBSERVATIONS_MISSION} — a `default` entry here would only
  * duplicate the fleet default.
  *
@@ -1203,6 +1204,42 @@ export interface BankMissionExtras {
  * characters — roughly 400 tokens per batch, the same order as the
  * unconditional `_PROCESSING_RULES` block it sits beside.
  */
+/**
+ * The FLEET-WIDE disposition floor — what every managed bank gets with zero
+ * yaml, under the profile defaults and under operator config.
+ *
+ * Only `skepticism` is set, and only to 4. The reasoning, and the reason the
+ * other two traits are deliberately left at the engine default of 3:
+ *
+ * - **Why skepticism at all.** Disposition steers reflect (and observation
+ *   synthesis). The failure this fleet actually hits is a bank asserting
+ *   something it cannot support — a date, a decision — because the
+ *   synthesiser fills a gap rather than reporting one. Hindsight documents
+ *   skepticism as how much the bank doubts unverified claims and flags
+ *   contradictions, which is precisely the dial for that.
+ *
+ * - **Why 4 and not 5.** Every specialist profile that already sets a
+ *   disposition on purpose sits at skepticism 4 (`coding` 4/5/2,
+ *   `executive-assistant` 4/4/3); the published common profiles agree (code
+ *   review 4/5/1, research assistant 4/4/2) and reserve 5 for the medical
+ *   profile. Shipping 5 fleet-wide would make every ordinary bank more
+ *   doubting than any profile a human chose. 4 is the value the codebase and
+ *   the vendor docs independently converged on; it also means agents on the
+ *   `default` profile stop being the ONLY ones left at 3.
+ *
+ * - **Why not literalism / empathy.** Both are genuinely persona-shaped: the
+ *   right literalism for a code reviewer (5) is wrong for a coach (2), and
+ *   empathy runs 1→5 across the published profiles. There is no defensible
+ *   fleet-wide value, and picking one would quietly override the engine
+ *   default for every bank in service of nothing. Defaults do the right thing;
+ *   complexity is opt-in — so these stay opt-in.
+ *
+ * Overriding: per-key, no new syntax. `memory.disposition.skepticism: 3` at
+ * the agent, profile, or `defaults` tier wins, because
+ * {@link resolveBankMissionExtras} merges fleet → profile → config per trait.
+ */
+export const FLEET_DEFAULT_DISPOSITION: BankDisposition = { skepticism: 4 };
+
 export const PROFILE_MEMORY_DEFAULTS: Record<string, BankMissionExtras> = {
   "health-coach": {
     disposition: { skepticism: 2, literalism: 2, empathy: 5 },
@@ -1300,10 +1337,138 @@ export function resolveBankMissionExtras(
   const observations = memory?.observations_mission ?? pd.observations_mission;
   if (observations != null) out.observations_mission = observations;
 
-  const disposition = mergeDisposition(pd.disposition, memory?.disposition);
+  // Three tiers, merged per-trait: fleet floor → profile → operator config.
+  // A profile that sets skepticism on purpose (health-coach at 2) overrides
+  // the fleet floor, and operator yaml overrides both — including back DOWN to
+  // the engine default, since the merge is per-key rather than
+  // all-or-nothing.
+  const disposition = mergeDisposition(
+    mergeDisposition(FLEET_DEFAULT_DISPOSITION, pd.disposition),
+    memory?.disposition,
+  );
   if (disposition) out.disposition = disposition;
 
   return out;
+}
+
+/**
+ * The engine's own default for every disposition trait when the bank leaves it
+ * null (confirmed against `/v1/bank-template-schema`: integers 1-5, default 3).
+ */
+export const ENGINE_DEFAULT_DISPOSITION_TRAIT = 3;
+
+/**
+ * Which traits of the resolved disposition came ONLY from
+ * {@link FLEET_DEFAULT_DISPOSITION} — i.e. neither the profile nor operator
+ * yaml said anything about them.
+ *
+ * This is the distinction {@link decideDispositionPush} needs. A trait a human
+ * chose (yaml) or a specialist profile pinned is authoritative and is pushed;
+ * a trait that exists only because switchroom picked a fleet-wide floor is a
+ * DEFAULT, and a default must never overwrite a value somebody set on the bank
+ * itself. Without this split, shipping a fleet floor would silently rewrite
+ * every hand-tuned bank in the fleet on the next apply.
+ */
+export function fleetOnlyDispositionTraits(
+  memory: { disposition?: BankDisposition } | undefined,
+  profileName: string,
+): (keyof BankDisposition)[] {
+  const pd = PROFILE_MEMORY_DEFAULTS[profileName]?.disposition ?? {};
+  const cfg = memory?.disposition ?? {};
+  return (Object.keys(FLEET_DEFAULT_DISPOSITION) as (keyof BankDisposition)[]).filter(
+    (t) => pd[t] === undefined && cfg[t] === undefined,
+  );
+}
+
+/**
+ * Decide which disposition traits to actually PUT on the wire.
+ *
+ * Two jobs, both outcomes an operator can see:
+ *
+ * 1. **Silence the no-op.** A trait the bank already carries is dropped. In
+ *    post-upgrade steady state the whole object drops out, so `switchroom
+ *    apply` sends no `update_bank` and prints no success line for a call that
+ *    changed nothing (the PR #3529 N1 regression, which a fleet default would
+ *    otherwise reintroduce for every agent on every apply).
+ *
+ * 2. **Never clobber a hand-tuned bank.** For a trait that came only from the
+ *    fleet floor, the push is skipped unless the bank is unset or still sitting
+ *    on the engine default — the same rule the managed missions use, expressed
+ *    per-trait because disposition has no text to byte-compare.
+ *
+ * A FAILED read must not reach here: pass nothing and push nothing, exactly as
+ * `resolveRetainMissionPush` does, or a Hindsight hiccup becomes a fleet-wide
+ * disposition rewrite.
+ */
+export function decideDispositionPush(
+  desired: BankDisposition | undefined,
+  current: BankDisposition,
+  fleetOnly: readonly (keyof BankDisposition)[],
+): BankDisposition | undefined {
+  if (!desired) return undefined;
+  const out: BankDisposition = {};
+  for (const [k, v] of Object.entries(desired) as [keyof BankDisposition, number][]) {
+    if (v === undefined) continue;
+    const live = current[k];
+    if (live === v) continue; // already there
+    if (
+      fleetOnly.includes(k) &&
+      live != null &&
+      live !== ENGINE_DEFAULT_DISPOSITION_TRAIT
+    ) {
+      continue; // somebody tuned this bank; a fleet default does not outrank them
+    }
+    out[k] = v;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Read a bank's live disposition. Same contract and unrecognised-shape posture
+ * as {@link fetchBankRetainMission}: a 200 whose body has no `config` object is
+ * `{ ok: false }`, NOT "everything unset" — mapping an unrecognised shape to
+ * unset would make every trait look pushable.
+ *
+ * Absent traits come back as `undefined` (the bank is on the engine default),
+ * which is distinct from a failed read.
+ */
+export async function fetchBankDisposition(
+  apiUrl: string,
+  bankId: string,
+  opts?: { fetchImpl?: typeof fetch; timeoutMs?: number },
+): Promise<{ ok: true; disposition: BankDisposition } | { ok: false; reason: string }> {
+  const fetchImpl = opts?.fetchImpl ?? fetch;
+  const timeoutMs = opts?.timeoutMs ?? 5000;
+  const base = apiUrl.replace(/\/mcp\/?$/, "").replace(/\/$/, "");
+  const url = `${base}/v1/default/banks/${encodeURIComponent(bankId)}/config`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const resp = await fetchImpl(url, { signal: controller.signal });
+    clearTimeout(timeout);
+    if (!resp.ok) return { ok: false, reason: `HTTP ${resp.status}` };
+    const body = (await resp.json()) as { config?: Record<string, unknown> | null };
+    const config = body?.config;
+    if (config == null || typeof config !== "object") {
+      return { ok: false, reason: "Unexpected shape" };
+    }
+    const read = (field: string): number | undefined => {
+      const v = config[field];
+      return typeof v === "number" ? v : undefined;
+    };
+    const disposition: BankDisposition = {};
+    const skepticism = read("disposition_skepticism");
+    const literalism = read("disposition_literalism");
+    const empathy = read("disposition_empathy");
+    if (skepticism !== undefined) disposition.skepticism = skepticism;
+    if (literalism !== undefined) disposition.literalism = literalism;
+    if (empathy !== undefined) disposition.empathy = empathy;
+    return { ok: true, disposition };
+  } catch (err) {
+    clearTimeout(timeout);
+    if ((err as Error).name === "AbortError") return { ok: false, reason: "Timeout" };
+    return { ok: false, reason: String((err as Error).message ?? err) };
+  }
 }
 
 /**

--- a/tests/memory.bank-missions.test.ts
+++ b/tests/memory.bank-missions.test.ts
@@ -8,6 +8,7 @@ import {
   fetchBankRetainMission,
   resolveBankMissionExtras,
   PROFILE_MEMORY_DEFAULTS,
+  FLEET_DEFAULT_DISPOSITION,
   DEFAULT_OBSERVATIONS_MISSION,
   SUPERSEDED_OBSERVATIONS_MISSIONS,
   decideObservationsMissionUpgrade,
@@ -1241,6 +1242,14 @@ describe("scaffoldAgent — observations_mission seed", () => {
     currentObservations: string | null,
     config: AgentConfig,
     updateBankCalls: Record<string, unknown>[] = [],
+    /**
+     * The bank's live disposition. Defaults to a bank already carrying the
+     * fleet floor, so the disposition half is a no-op and these tests stay
+     * about the mission under test; pass `{}` to model a bank that has none.
+     */
+    currentDisposition: Record<string, number> = {
+      disposition_skepticism: FLEET_DEFAULT_DISPOSITION.skepticism as number,
+    },
   ): Promise<Record<string, unknown>> {
     tmpDir = mkdtempSync(resolve(tmpdir(), "switchroom-obs-mission-"));
     let resolveArgs: (a: Record<string, unknown>) => void;
@@ -1256,6 +1265,7 @@ describe("scaffoldAgent — observations_mission seed", () => {
               // confused with the observations push under test.
               retain_mission: DEFAULT_RETAIN_MISSION,
               observations_mission: currentObservations,
+              ...currentDisposition,
             },
           }),
         } as any;
@@ -1342,7 +1352,9 @@ describe("scaffoldAgent — observations_mission seed", () => {
       extends: "default",
       memory: { profile: "coding" },
     } as Partial<AgentConfig>);
-    const args = await runScaffold(null, config);
+    // A bank with NO disposition yet, so all three traits are genuinely on the
+    // wire rather than suppressed as already-current.
+    const args = await runScaffold(null, config, [], {});
     const updates = args.config_updates as Record<string, unknown>;
     // Observations: the coding profile mission, not the generic fleet default.
     expect(updates.observations_mission).toBe(
@@ -1537,7 +1549,14 @@ describe("scaffoldAgent — retain_mission against an existing bank", () => {
       if (u.endsWith("/config")) {
         return {
           ok: true,
-          json: async () => ({ config: { retain_mission: "CUSTOM operator mission" } }),
+          json: async () => ({
+            config: {
+              retain_mission: "CUSTOM operator mission",
+              // Steady state: the bank already carries the fleet disposition
+              // floor, so "nothing to update" really is nothing.
+              disposition_skepticism: FLEET_DEFAULT_DISPOSITION.skepticism,
+            },
+          }),
         } as any;
       }
       const body = init?.body ? JSON.parse(init.body) : {};
@@ -1901,9 +1920,16 @@ describe("resolveBankMissionExtras", () => {
     });
   });
 
-  it("returns nothing for a profile without defaults and no config", () => {
-    expect(resolveBankMissionExtras(undefined, "default")).toEqual({});
-    expect(resolveBankMissionExtras({}, "some-unknown-profile")).toEqual({});
+  it("returns no MISSIONS for a profile without defaults — only the fleet disposition floor", () => {
+    // Was `{}` before the fleet-wide disposition floor. The floor is the ONLY
+    // thing a profile-less, config-less agent now gets: no mission text is
+    // invented for it, which is what this test has always guarded.
+    expect(resolveBankMissionExtras(undefined, "default")).toEqual({
+      disposition: FLEET_DEFAULT_DISPOSITION,
+    });
+    expect(resolveBankMissionExtras({}, "some-unknown-profile")).toEqual({
+      disposition: FLEET_DEFAULT_DISPOSITION,
+    });
   });
 
   it("merges disposition per-key: config trait overrides, others inherit profile", () => {

--- a/tests/memory.smart-defaults.test.ts
+++ b/tests/memory.smart-defaults.test.ts
@@ -1,0 +1,497 @@
+import { describe, it, expect } from "vitest";
+import {
+  FLEET_DEFAULT_DISPOSITION,
+  PROFILE_MEMORY_DEFAULTS,
+  resolveBankMissionExtras,
+  decideDispositionPush,
+  fleetOnlyDispositionTraits,
+  fetchBankDisposition,
+} from "../src/memory/hindsight.js";
+import {
+  ANTI_CONFABULATION_DIRECTIVE,
+  ANTI_CONFABULATION_DIRECTIVE_NAME,
+  ANTI_CONFABULATION_DIRECTIVE_PRIORITY,
+  SUPERSEDED_ANTI_CONFABULATION_DIRECTIVES,
+  SWITCHROOM_SEEDED_TAG,
+  decideDirectiveSeed,
+  ensureAntiConfabulationDirective,
+  resolveAntiConfabulationDirective,
+  type SeededDirectiveRecord,
+} from "../src/memory/hindsight-seed-directives.js";
+import { MAX_DIRECTIVES } from "../src/memory/hindsight-directive-admin.js";
+import { AgentMemorySchema } from "../src/config/schema.js";
+import { mergeAgentConfig } from "../src/config/merge.js";
+
+/**
+ * Smart memory defaults: what an agent gets with ZERO yaml, and what an
+ * operator can do about it.
+ *
+ * Every assertion here is on an outcome — the disposition that would be
+ * PUSHED to a bank, the HTTP requests a seed actually issues — not on whether
+ * a code path ran.
+ */
+
+describe("fleet default disposition", () => {
+  it("gives a zero-config agent skepticism 4 and nothing else", () => {
+    const extras = resolveBankMissionExtras(undefined, "default");
+    expect(extras.disposition).toEqual({ skepticism: 4 });
+  });
+
+  it("leaves literalism and empathy at the engine default (unset on the wire)", () => {
+    // Sending 3/3 would be indistinguishable from the engine default in effect
+    // but would pin the bank against a future engine change, for no benefit.
+    const extras = resolveBankMissionExtras(undefined, "default");
+    expect(extras.disposition).not.toHaveProperty("literalism");
+    expect(extras.disposition).not.toHaveProperty("empathy");
+  });
+
+  it("is overridden per-trait by a profile that sets skepticism on purpose", () => {
+    // health-coach is the interesting direction: it wants LESS skepticism than
+    // the fleet floor, so a floor that could not be lowered would break it.
+    const extras = resolveBankMissionExtras(undefined, "health-coach");
+    expect(extras.disposition).toEqual(
+      PROFILE_MEMORY_DEFAULTS["health-coach"].disposition,
+    );
+    expect(extras.disposition?.skepticism).toBe(2);
+  });
+
+  it("is overridden by operator yaml, including back down to the engine default", () => {
+    const extras = resolveBankMissionExtras({ disposition: { skepticism: 3 } }, "default");
+    expect(extras.disposition).toEqual({ skepticism: 3 });
+  });
+
+  it("merges per-trait rather than replacing: yaml empathy keeps the fleet skepticism", () => {
+    const extras = resolveBankMissionExtras({ disposition: { empathy: 5 } }, "default");
+    expect(extras.disposition).toEqual({ skepticism: 4, empathy: 5 });
+  });
+
+  it("layers fleet under profile under yaml, all three at once", () => {
+    const extras = resolveBankMissionExtras({ disposition: { empathy: 1 } }, "coding");
+    // coding pins 4/5/2; yaml overrides empathy only; skepticism 4 agrees with
+    // the fleet floor by construction.
+    expect(extras.disposition).toEqual({ skepticism: 4, literalism: 5, empathy: 1 });
+  });
+
+  it("no profile default is weaker than a deliberate choice — the floor never invents literalism/empathy", () => {
+    expect(Object.keys(FLEET_DEFAULT_DISPOSITION)).toEqual(["skepticism"]);
+    expect(FLEET_DEFAULT_DISPOSITION.skepticism).toBe(4);
+  });
+});
+
+describe("decideDispositionPush — what the floor may and may not overwrite", () => {
+  const FLEET_ONLY: ("skepticism" | "literalism" | "empathy")[] = ["skepticism"];
+
+  it("seeds the floor onto a bank that has no disposition at all", () => {
+    expect(decideDispositionPush({ skepticism: 4 }, {}, FLEET_ONLY)).toEqual({
+      skepticism: 4,
+    });
+  });
+
+  it("seeds over the ENGINE default, which is not a choice anybody made", () => {
+    expect(
+      decideDispositionPush({ skepticism: 4 }, { skepticism: 3 }, FLEET_ONLY),
+    ).toEqual({ skepticism: 4 });
+  });
+
+  it("REFUSES to lower a bank an operator tuned to 5", () => {
+    // The live `overlord` bank is at skepticism 5 (read 2026-08-02). A fleet
+    // floor that silently rewrote it to 4 would be a regression dressed as a
+    // default. This is the assertion that forbids it.
+    expect(
+      decideDispositionPush({ skepticism: 4 }, { skepticism: 5 }, FLEET_ONLY),
+    ).toBeUndefined();
+  });
+
+  it("REFUSES to raise a bank an operator tuned to 2", () => {
+    expect(
+      decideDispositionPush({ skepticism: 4 }, { skepticism: 2 }, FLEET_ONLY),
+    ).toBeUndefined();
+  });
+
+  it("sends nothing when the bank already carries the value (silences the no-op apply)", () => {
+    expect(
+      decideDispositionPush({ skepticism: 4 }, { skepticism: 4 }, FLEET_ONLY),
+    ).toBeUndefined();
+  });
+
+  it("a trait from a PROFILE or from yaml is authoritative and overwrites a tuned bank", () => {
+    // Not fleet-only ⇒ not a default ⇒ the operator's config wins, which is
+    // the pre-existing contract for disposition and must not change.
+    expect(
+      decideDispositionPush({ skepticism: 2 }, { skepticism: 5 }, []),
+    ).toEqual({ skepticism: 2 });
+  });
+
+  it("decides per-trait: pushes the changed one, drops the current one", () => {
+    expect(
+      decideDispositionPush(
+        { skepticism: 4, literalism: 5, empathy: 2 },
+        { skepticism: 4, literalism: 3 },
+        FLEET_ONLY,
+      ),
+    ).toEqual({ literalism: 5, empathy: 2 });
+  });
+});
+
+describe("fleetOnlyDispositionTraits", () => {
+  it("is the whole floor for a bare agent", () => {
+    expect(fleetOnlyDispositionTraits(undefined, "default")).toEqual(["skepticism"]);
+  });
+
+  it("is empty when the PROFILE sets the trait — the profile made a choice", () => {
+    expect(fleetOnlyDispositionTraits(undefined, "coding")).toEqual([]);
+  });
+
+  it("is empty when YAML sets the trait", () => {
+    expect(
+      fleetOnlyDispositionTraits({ disposition: { skepticism: 5 } }, "default"),
+    ).toEqual([]);
+  });
+});
+
+describe("fetchBankDisposition", () => {
+  const respond = (body: unknown, status = 200) =>
+    (async () => new Response(JSON.stringify(body), { status })) as unknown as typeof fetch;
+
+  it("reads the engine's flat trait fields off the bank config endpoint", async () => {
+    let seen = "";
+    const fetchImpl = (async (url: string) => {
+      seen = url;
+      return new Response(
+        JSON.stringify({
+          config: { disposition_skepticism: 5, disposition_literalism: 4, disposition_empathy: 2 },
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+    const r = await fetchBankDisposition("http://h:18888/mcp/", "probe", { fetchImpl });
+    expect(seen).toBe("http://h:18888/v1/default/banks/probe/config");
+    expect(r).toEqual({
+      ok: true,
+      disposition: { skepticism: 5, literalism: 4, empathy: 2 },
+    });
+  });
+
+  it("reports an unset trait as absent, not as a number", async () => {
+    const r = await fetchBankDisposition("http://h:18888/mcp/", "probe", {
+      fetchImpl: respond({ config: { disposition_skepticism: null } }),
+    });
+    expect(r).toEqual({ ok: true, disposition: {} });
+  });
+
+  it("an unrecognised shape is a FAILED read, never 'everything unset'", async () => {
+    // The dangerous confusion: "unset" makes every trait pushable, so a
+    // renamed upstream field would rewrite the fleet.
+    const r = await fetchBankDisposition("http://h:18888/mcp/", "probe", {
+      fetchImpl: respond({ notConfig: {} }),
+    });
+    expect(r).toEqual({ ok: false, reason: "Unexpected shape" });
+  });
+
+  it("an HTTP error is a failed read", async () => {
+    const r = await fetchBankDisposition("http://h:18888/mcp/", "probe", {
+      fetchImpl: respond({}, 503),
+    });
+    expect(r).toEqual({ ok: false, reason: "HTTP 503" });
+  });
+});
+
+describe("anti_confabulation_directive — yaml surface", () => {
+  it("accepts unset, true, false, and operator text", () => {
+    for (const v of [undefined, true, false, "house rule"]) {
+      const parsed = AgentMemorySchema.parse({
+        collection: "probe",
+        ...(v === undefined ? {} : { anti_confabulation_directive: v }),
+      });
+      expect(parsed.anti_confabulation_directive).toBe(v);
+    }
+  });
+
+  it("rejects an empty string (that is `false`, said ambiguously)", () => {
+    expect(() =>
+      AgentMemorySchema.parse({ collection: "probe", anti_confabulation_directive: "" }),
+    ).toThrow();
+  });
+
+  it("cascades from defaults to an agent, and the agent wins", () => {
+    const merged = mergeAgentConfig(
+      { memory: { anti_confabulation_directive: false } },
+      { memory: { anti_confabulation_directive: true } },
+    );
+    expect(merged.memory?.anti_confabulation_directive).toBe(true);
+  });
+
+  it("a fleet-tier opt-out reaches an agent that says nothing", () => {
+    const merged = mergeAgentConfig(
+      { memory: { anti_confabulation_directive: false } },
+      { memory: {} },
+    );
+    expect(merged.memory?.anti_confabulation_directive).toBe(false);
+  });
+});
+
+describe("resolveAntiConfabulationDirective", () => {
+  it("seeds the shipped default with zero config", () => {
+    const r = resolveAntiConfabulationDirective(undefined);
+    expect(r.enabled).toBe(true);
+    expect(r.desired).toBe(ANTI_CONFABULATION_DIRECTIVE);
+    expect(r.operatorText).toBeUndefined();
+  });
+
+  it("treats a string as operator-authored text that wins outright", () => {
+    const r = resolveAntiConfabulationDirective("never guess");
+    expect(r.operatorText).toBe("never guess");
+    expect(r.desired).toBe("never guess");
+  });
+
+  it("false disables", () => {
+    expect(resolveAntiConfabulationDirective(false).enabled).toBe(false);
+  });
+});
+
+describe("decideDirectiveSeed — never clobber a human", () => {
+  const rec = (content: string): SeededDirectiveRecord => ({
+    id: "d1",
+    name: ANTI_CONFABULATION_DIRECTIVE_NAME,
+    content,
+  });
+
+  it("creates when the bank has no directive of that name", () => {
+    expect(decideDirectiveSeed(undefined, undefined, { activeCount: 0 })).toEqual({
+      action: "create",
+      content: ANTI_CONFABULATION_DIRECTIVE,
+    });
+  });
+
+  it("does nothing when the bank already carries the current default", () => {
+    expect(
+      decideDirectiveSeed(rec(ANTI_CONFABULATION_DIRECTIVE), undefined, { activeCount: 1 }),
+    ).toEqual({ action: "none" });
+  });
+
+  it("upgrades a bank still carrying a PREVIOUS switchroom default", () => {
+    const old = "an older switchroom default";
+    const d = decideDirectiveSeed(rec(old), undefined, {
+      activeCount: 1,
+      shipped: [old],
+    });
+    expect(d).toEqual({ action: "upgrade", content: ANTI_CONFABULATION_DIRECTIVE });
+  });
+
+  it("LEAVES ALONE text a human edited — even by one character", () => {
+    const edited = ANTI_CONFABULATION_DIRECTIVE + " ";
+    expect(decideDirectiveSeed(rec(edited), undefined, { activeCount: 1 })).toEqual({
+      action: "none",
+    });
+  });
+
+  it("pushes operator yaml text over a switchroom default", () => {
+    const d = decideDirectiveSeed(rec(ANTI_CONFABULATION_DIRECTIVE), "house rule", {
+      activeCount: 1,
+    });
+    expect(d).toEqual({ action: "upgrade", content: "house rule" });
+  });
+
+  it("does nothing once operator yaml text is already in place", () => {
+    expect(
+      decideDirectiveSeed(rec("house rule"), "house rule", { activeCount: 1 }),
+    ).toEqual({ action: "none" });
+  });
+
+  it("false leaves an existing directive untouched (opting out is not a delete)", () => {
+    expect(decideDirectiveSeed(rec("anything"), false, { activeCount: 1 })).toEqual({
+      action: "none",
+      reason: "disabled",
+    });
+  });
+
+  it("refuses to CREATE past MAX_DIRECTIVES rather than truncate somebody's rule", () => {
+    const d = decideDirectiveSeed(undefined, undefined, { activeCount: MAX_DIRECTIVES });
+    expect(d.action).toBe("skip");
+    expect(d.reason).toContain(String(MAX_DIRECTIVES));
+  });
+
+  it("still creates at one slot below the cap", () => {
+    expect(
+      decideDirectiveSeed(undefined, undefined, { activeCount: MAX_DIRECTIVES - 1 }).action,
+    ).toBe("create");
+  });
+
+  it("upgrades a full bank — an upgrade consumes no slot", () => {
+    const old = "older default";
+    const d = decideDirectiveSeed(rec(old), undefined, {
+      activeCount: MAX_DIRECTIVES + 5,
+      shipped: [old],
+    });
+    expect(d.action).toBe("upgrade");
+  });
+
+  it("the shipped registry is append-only and starts empty", () => {
+    expect(SUPERSEDED_ANTI_CONFABULATION_DIRECTIVES).toEqual([]);
+    expect(SUPERSEDED_ANTI_CONFABULATION_DIRECTIVES).not.toContain(
+      ANTI_CONFABULATION_DIRECTIVE,
+    );
+  });
+});
+
+describe("ensureAntiConfabulationDirective — what actually goes on the wire", () => {
+  type Call = { url: string; method: string; body?: unknown };
+
+  function harness(listItems: SeededDirectiveRecord[], opts?: { listStatus?: number }) {
+    const calls: Call[] = [];
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      calls.push({
+        url,
+        method,
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+      });
+      if (method === "GET") {
+        const status = opts?.listStatus ?? 200;
+        return new Response(JSON.stringify({ items: listItems }), { status });
+      }
+      return new Response(JSON.stringify({ id: "d1" }), { status: 200 });
+    }) as unknown as typeof fetch;
+    return { calls, fetchImpl };
+  }
+
+  it("POSTs the directive to the agent's own bank, tagged and prioritised", async () => {
+    const { calls, fetchImpl } = harness([]);
+    const out = await ensureAntiConfabulationDirective(
+      "http://h:18888/mcp/",
+      "probe",
+      undefined,
+      { fetchImpl },
+    );
+    expect(out).toEqual({ action: "created", name: ANTI_CONFABULATION_DIRECTIVE_NAME });
+
+    const post = calls.find((c) => c.method === "POST");
+    expect(post?.url).toBe("http://h:18888/v1/default/banks/probe/directives");
+    expect(post?.body).toEqual({
+      name: ANTI_CONFABULATION_DIRECTIVE_NAME,
+      content: ANTI_CONFABULATION_DIRECTIVE,
+      priority: ANTI_CONFABULATION_DIRECTIVE_PRIORITY,
+      is_active: true,
+      tags: [SWITCHROOM_SEEDED_TAG],
+    });
+  });
+
+  it("lists with active_only=false so a DEACTIVATED directive is not reseeded", async () => {
+    const { calls, fetchImpl } = harness([
+      {
+        id: "d1",
+        name: ANTI_CONFABULATION_DIRECTIVE_NAME,
+        content: ANTI_CONFABULATION_DIRECTIVE,
+        is_active: false,
+      },
+    ]);
+    const out = await ensureAntiConfabulationDirective(
+      "http://h:18888/mcp/",
+      "probe",
+      undefined,
+      { fetchImpl },
+    );
+    expect(calls[0].url).toContain("active_only=false");
+    expect(out.action).toBe("unchanged");
+    expect(calls.some((c) => c.method === "POST")).toBe(false);
+  });
+
+  it("is idempotent: a second apply issues no write at all", async () => {
+    const { calls, fetchImpl } = harness([
+      {
+        id: "d1",
+        name: ANTI_CONFABULATION_DIRECTIVE_NAME,
+        content: ANTI_CONFABULATION_DIRECTIVE,
+      },
+    ]);
+    const out = await ensureAntiConfabulationDirective(
+      "http://h:18888/mcp/",
+      "probe",
+      undefined,
+      { fetchImpl },
+    );
+    expect(out.action).toBe("unchanged");
+    expect(calls.filter((c) => c.method !== "GET")).toEqual([]);
+  });
+
+  it("PATCHes only `content` when upgrading — never name, priority or tags", async () => {
+    const { calls, fetchImpl } = harness([
+      { id: "d1", name: ANTI_CONFABULATION_DIRECTIVE_NAME, content: "old text" },
+    ]);
+    await ensureAntiConfabulationDirective(
+      "http://h:18888/mcp/",
+      "probe",
+      "operator text",
+      { fetchImpl },
+    );
+    const patch = calls.find((c) => c.method === "PATCH");
+    expect(patch?.url).toBe("http://h:18888/v1/default/banks/probe/directives/d1");
+    expect(Object.keys(patch?.body as object)).toEqual(["content"]);
+    expect((patch?.body as { content: string }).content).toBe("operator text");
+  });
+
+  it("issues NO request when disabled", async () => {
+    const { calls, fetchImpl } = harness([]);
+    const out = await ensureAntiConfabulationDirective(
+      "http://h:18888/mcp/",
+      "probe",
+      false,
+      { fetchImpl },
+    );
+    expect(out).toEqual({
+      action: "skipped",
+      name: ANTI_CONFABULATION_DIRECTIVE_NAME,
+      reason: "disabled",
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it("writes NOTHING when the list read fails — unknown is never treated as unset", async () => {
+    const { calls, fetchImpl } = harness([], { listStatus: 503 });
+    const out = await ensureAntiConfabulationDirective(
+      "http://h:18888/mcp/",
+      "probe",
+      undefined,
+      { fetchImpl },
+    );
+    expect(out.action).toBe("failed");
+    expect(calls.filter((c) => c.method !== "GET")).toEqual([]);
+  });
+
+  it("never throws when the transport explodes", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const out = await ensureAntiConfabulationDirective(
+      "http://h:18888/mcp/",
+      "probe",
+      undefined,
+      { fetchImpl },
+    );
+    expect(out.action).toBe("failed");
+  });
+
+  it("addresses ONLY the bank it was given (path-pinned)", async () => {
+    const { calls, fetchImpl } = harness([]);
+    await ensureAntiConfabulationDirective("http://h:18888/mcp/", "other agent", undefined, {
+      fetchImpl,
+    });
+    for (const c of calls) {
+      expect(c.url).toContain("/banks/other%20agent/directives");
+    }
+  });
+});
+
+describe("the directive text itself", () => {
+  it("names both failures it exists to stop", () => {
+    // If someone rewrites the text into vague encouragement, these fail.
+    expect(ANTI_CONFABULATION_DIRECTIVE).toMatch(/does not know/i);
+    expect(ANTI_CONFABULATION_DIRECTIVE).toMatch(/presupposes/i);
+  });
+
+  it("is a directive, not a mission — small enough to ride every reflect", () => {
+    // Directives are injected into the prompt on every recall/reflect and are
+    // capped at MAX_DIRECTIVES; a page-long guardrail crowds out the operator's.
+    expect(ANTI_CONFABULATION_DIRECTIVE.length).toBeLessThan(1500);
+  });
+});


### PR DESCRIPTION
## Summary

Two zero-config Hindsight defaults, both overridable in `switchroom.yaml`, neither able to clobber an operator:

1. **A fleet skepticism floor** — every agent's bank gets `skepticism: 4` unless a profile or YAML says otherwise.
2. **A seeded `no-confabulation` directive** — every bank is told to say it does not know rather than compose an answer retrieval does not support.

Companion to #4164 (provenance tagging of auto-retained transcript memories). That PR makes contaminated memories *identifiable*; this one makes the bank *less credulous* about them in the first place, and less willing to synthesize over a thin retrieval.

Serves `reference/jobs/get-from-zero-to-a-working-fleet.md` ("one setup pass, with zero config") and `reference/jobs/remember-across-sessions.md` ("brings back relevant facts … without the user reminding it" — a bank that recalls its own fabrications back to the user fails that outcome). Defaults do the right thing; complexity is opt-in.

## Why

**Skepticism.** The engine default is `3` — "accepts stated information". A bank that accepts stated information will accept the agent's own synthesized output, which is exactly how a wrong `reflect` answer becomes a `fact_type: world` memory with a clean `event_date` and gets served back next session as fact (the live `carrie` unit `f3ae7546-d37d-4977-a40b-4d53d8b32e65`). `4` flags contradictions and treats a lone unsupported assertion as a claim.

**The directive.** `min_scores` — the reranker relevance floor — exists on `/recall` **only**. `/reflect` accepts `query`, `budget`, `max_tokens`, `response_schema`, `tags`, `tags_match`, `fact_types`, `exclude_mental_models`, `exclude_mental_model_ids` and **no relevance floor** (verified against the running engine's `openapi.json`, 2026-08-02). With no floor, a reflect query that retrieves nothing relevant still returns a fluent, confident answer. Directives *are* applied during reflect, so a seeded directive is the only lever switchroom has.

**Being honest about that:** this directive is prompt discipline standing in for a guarantee code should enforce. Nothing here makes confabulation *impossible* — it asks an LLM nicely, and an LLM can ignore it. The real fix is a relevance floor on `/reflect` upstream in Hindsight, so that a retrieval scoring near zero returns "no relevant memories" as a *structural* result rather than as a hoped-for behaviour. Filed as a follow-up to raise upstream. Until then this is the best available lever, and it is worth having, but it should not be mistaken for a guard.

## The default values, and why these

| Setting | Default | Why not something else |
| --- | --- | --- |
| `disposition.skepticism` | **4** | Not 3: that is the engine default this is trying to move off. Not 5: 5 is the fleet's reserved top end — the `coding` profile is `4/5/2`, `executive-assistant` `4/4/3`, and published Hindsight profiles put code-review at `4/5/1` and research at `4/4/2`, with 5 kept for domains where a wrong recall is dangerous (medical). 4 is the value the fleet's own opinionated profiles already converged on. |
| `disposition.literalism` | **none** | Genuinely persona-shaped — a coach and a lawyer want opposite values. A fleet-wide guess imposed on every agent is worse than the engine default. |
| `disposition.empathy` | **none** | Same. |
| `anti_confabulation_directive` | **on**, priority `10`, tag `switchroom-seeded` | Priority above an unprioritized directive, below anything a human deliberately prioritized higher. Not `100` — a seeded default should never outrank an operator's explicit ranking. |

## Override + supersession

**Disposition merges in three tiers**, per-trait (matching the existing `disposition` deep-merge in `resolveBankMissionExtras`):

```
{ skepticism: 4 }  →  profile disposition  →  agents.<name>.memory.disposition
```

`health-coach`'s `skepticism: 2` wins. `memory: { disposition: { skepticism: 3 } }` puts an individual agent back on the engine default. No new override syntax — this is the existing `memory.disposition` key with a new lowest tier underneath it.

**The push is read-first**, which is the part that took the design work. A permanently non-empty `disposition` naively pushed on every apply does two bad things: it re-introduces the idle `update_bank` that PR #3529 N1 removed, and it *lowers* hand-tuned banks — the live `overlord` bank is at skepticism **5**, and a blanket floor of 4 would have quietly rewritten it. So:

- `fleetOnlyDispositionTraits()` labels which traits came from the fleet floor alone versus from a profile or YAML.
- `fetchBankDisposition()` reads the bank's live `disposition_*` fields. An unrecognized response shape is a **failed read**, not "everything unset" — otherwise a renamed upstream field would rewrite the whole fleet.
- `decideDispositionPush()` drops traits the bank already matches (apply stays a no-op), and refuses to push a *fleet-only* trait when the bank's live value is non-null and ≠ 3. A trait from a profile or YAML is authoritative and pushes normally.
- On a failed read, nothing is pushed.

**Directive seeding** reuses the `retain_mission` supersession mechanic rather than reimplementing it: `decideDirectiveSeed` delegates the existing-directive case straight to `decideMissionUpgrade`, so never-clobber semantics cannot drift between the two. Byte-equality against an append-only `SUPERSEDED_ANTI_CONFABULATION_DIRECTIVES` registry (currently empty — nothing has shipped yet to supersede) decides upgrade-vs-leave-alone. A hand-edited directive is left alone forever. It lists with `active_only=false` so a directive the operator *deactivated* is not resurrected as a new one. `false` means never seed — it does **not** delete.

The `MAX_DIRECTIVES = 30` cap gates **creation only**: at the cap, seeding is skipped with a log line rather than pushing a bank past the point where low-priority directives silently drop out of recall. Upgrading existing text is not blocked, since it adds nothing.

Both run at scaffold **and** reconcile, because `switchroom apply` re-scaffolds every existing agent and never calls `reconcileAgent` — a bank op wired into only one of the two chains reaches half the fleet.

## Changes

- `src/memory/hindsight-seed-directives.ts` **(new)** — directive text, the supersession registry, `resolveAntiConfabulationDirective` / `decideDirectiveSeed` / `ensureAntiConfabulationDirective`. Uses REST (`GET`/`POST`/`PATCH /v1/default/banks/{bank}/directives`) because the MCP surface has create/list/delete but no update. Never throws; writes nothing on a failed list.
- `src/memory/hindsight.ts` — `FLEET_DEFAULT_DISPOSITION`, merged as the lowest tier in `resolveBankMissionExtras`; `fleetOnlyDispositionTraits`, `decideDispositionPush`, `fetchBankDisposition`.
- `src/agents/scaffold.ts` — `resolveDispositionPush` and `seedAntiConfabulationDirective` helpers, wired into both bank-op chains.
- `src/config/schema.ts` — `memory.anti_confabulation_directive: boolean | string`, declared in `AgentMemorySchema` and in the defaults/profile-tier mirror (`schema.mirror-parity.test.ts` shape-diffs the two).
- `src/memory/hindsight-directive-admin.ts` / `src/cli/doctor-memory.ts` — `MAX_DIRECTIVES` moves to the memory layer and is re-exported from its old home. A memory-layer writer importing a constant out of `src/cli/` is a layering inversion; no precedent existed either way, so this establishes the memory layer as canonical.
- `docs/configuration.md` — the fleet floor, its read-first semantics, and the full `anti_confabulation_directive` table.

## Test plan

`tests/memory.smart-defaults.test.ts` **(new, 49 tests)** — outcome assertions, not code paths:

- **Zero-config**: an agent with no profile and no `memory:` block gets `{ skepticism: 4 }` and *not* literalism/empathy.
- **Override**: `health-coach`'s 2 wins; YAML wins including *back down to 3*; per-trait merge leaves siblings intact; full 3-tier layering.
- **Never-clobber** (the load-bearing ones): `decideDispositionPush` **refuses to lower a bank tuned to 5** — the test cites the live `overlord` bank read on 2026-08-02, and would fail on a blanket-push implementation. Refuses to raise a 2. Silent when equal. Profile/YAML traits still push.
- **Wire-level directive tests** with a recording `fetchImpl`: exact POST url + body; `active_only=false`; a second apply issues **no write**; the PATCH body carries `["content"]` only; nothing is sent when disabled; **no write after a failed list**; never throws; bank path-pinned including `%20` encoding.
- **Cap**: refuses to create at 30; creates at 1; upgrades past the cap.

```
✓ tests/memory.smart-defaults.test.ts (49 tests)
```

Affected suites, all green:

```
✓ tests/memory.bank-missions.test.ts (97)   ✓ tests/merge.test.ts
✓ tests/schema.memory-profile.test.ts (6)   ✓ src/config/schema.mirror-parity.test.ts
✓ src/memory/hindsight-mcp-ops.test.ts      ✓ src/config/schema.test.ts
✓ tests/memory.bank-health.test.ts
  Test Files 8 passed | Tests 484 passed

✓ tests/scaffold.test.ts (241)  ✓ tests/scaffold-idempotent-writes.test.ts
✓ tests/scaffold.memory-cascade.test.ts  ✓ tests/scaffold.observation-scope*.test.ts (3)
✓ tests/cli.doctor.memory*.test.ts (3)   ✓ tests/doctor.test.ts
✓ src/cli/doctor-scaffold-wiring.test.ts
  Test Files 11 passed | Tests 458 passed | 2 skipped
```

`tsc --noEmit` clean; full `npm run lint` clean.

4 pre-existing tests in `tests/memory.bank-missions.test.ts` failed when the floor was first added. That was a real regression, not stale expectations — it is what surfaced both the idle-`update_bank` and the clobber problem — so it was fixed in the implementation (read-first push) and the harnesses were then updated honestly to carry a bank disposition.

## Risk

- **The directive is not a guarantee.** Stated above and in the module header. It can be ignored by the model; the real fix is upstream.
- **Skepticism 4 is a behaviour change for banks currently on the engine default 3.** Recall/reflect framing gets more cautious. Deliberate, and it is the whole point; overridable per-agent.
- **The read-first push adds one `GET .../config` per agent per apply.** Same shape as the existing `observations_mission` read-before-push.
- **A bank an operator deliberately set to exactly 3** is indistinguishable from an unset bank, so the floor will move it to 4. Recording that intent needs `memory.disposition.skepticism: 3` in YAML, which then makes it authoritative and permanent. Documented.

## Deliberately left out

- No relevance floor is enforced anywhere in switchroom — it belongs on `/reflect` upstream.
- No `retain_extraction_mode` change (the other lever named in the brief): it changes what the extractor produces fleet-wide, and belongs in its own PR with its own evidence.
- No deletion path for a seeded directive an operator later wants gone — `delete_directive` already exists on the agent's MCP surface.
