### PR TITLE
fix(doctor): bound the recall-health window by age, not just row count

### DIFF
--- a/src/cli/doctor-recall-health.test.ts
+++ b/src/cli/doctor-recall-health.test.ts
@@ -23,14 +23,26 @@ import {
   type RecallLogRow,
   checkAgentRecallHealth,
   classifyRecallHealth,
+  filterRecentRecallRows,
   readRecallLogTail,
   recallLogPath,
   summarizeRecallRows,
 } from "./doctor-recall-health.js";
 
+/**
+ * `ts` as `recall.py` writes it. Every real row carries one (verified: 0 of
+ * 10,627 live rows lack it), and since the recency window it is load-bearing —
+ * a row the check cannot date is a row it cannot prove is current. Fixtures
+ * default to "just now" so they describe present health.
+ */
+function isoAgo(msAgo = 0, now = Date.now()): string {
+  return new Date(now - msAgo).toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
 /** A healthy row: own bank answered inside budget. */
 function healthyRow(bank: string, elapsedMs = 3000): RecallLogRow {
   return {
+    ts: isoAgo(),
     bank_id: bank,
     result_count: 6,
     total_elapsed_ms: elapsedMs,
@@ -48,8 +60,9 @@ function healthyRow(bank: string, elapsedMs = 3000): RecallLogRow {
  * this is the masking case that made the outage look survivable in
  * result-count-only telemetry.
  */
-function ownBankTimedOutRow(bank: string, resultCount = 0): RecallLogRow {
+function ownBankTimedOutRow(bank: string, resultCount = 0, msAgo = 0): RecallLogRow {
   return {
+    ts: isoAgo(msAgo),
     bank_id: bank,
     result_count: resultCount,
     total_elapsed_ms: 8023,
@@ -63,6 +76,7 @@ function ownBankTimedOutRow(bank: string, resultCount = 0): RecallLogRow {
 
 function ownBankErroredRow(bank: string): RecallLogRow {
   return {
+    ts: isoAgo(),
     bank_id: bank,
     result_count: 0,
     total_elapsed_ms: 15,
@@ -352,5 +366,145 @@ describe("checkAgentRecallHealth", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+/**
+ * Regression guard for the 2026-08 STALE-WINDOW misdiagnosis.
+ *
+ * `RECALL_HEALTH_WINDOW_ROWS` bounds volume, not age. On a quiet agent the
+ * trailing 200 rows reached back 8-13 days on the live host, so after the
+ * 2026-07-28 own-bank-timeout fix landed, `doctor` kept scoring agents on rows
+ * from *during* the outage: carrie/marko warn, clerk/gymbro/reggie FAIL, while
+ * their actual last-72h rates were 2.9% / 0.0% / 0.9% / 0.0% / n/a. Those
+ * false reds were believed and drove remediation against an already-fixed bug.
+ *
+ * These tests assert the OUTCOME on fleet-shaped telemetry: a resolved outage
+ * must read `ok`, and a live one must still read `fail`. A test that only
+ * exercised `filterRecentRecallRows` in isolation would not have caught this —
+ * the defect was in what `checkAgentRecallHealth` composed, so the load-bearing
+ * assertions below go through the real read+filter+classify path on a real file.
+ */
+describe("recall-health window recency (2026-08 stale-window regression)", () => {
+  const DAY = 24 * 60 * 60 * 1000;
+
+  function writeLog(dir: string, rows: RecallLogRow[]): void {
+    const p = recallLogPath(dir);
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, rows.map((r) => JSON.stringify(r)).join("\n"));
+  }
+
+  function withAgent(fn: (dir: string) => void): void {
+    const dir = mkdtempSync(join(tmpdir(), "recall-recency-"));
+    try {
+      fn(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("does not report a RESOLVED outage as current health", () => {
+    withAgent((dir) => {
+      // clerk's real shape: a wall of outage rows, then the fix, then a
+      // healthy-but-quiet tail. Pre-fix this scored 31.0% -> fail.
+      writeLog(dir, [
+        ...Array.from({ length: 150 }, () => ownBankTimedOutRow("clerk", 0, 6 * DAY)),
+        ...Array.from({ length: 40 }, () => healthyRow("clerk")),
+      ]);
+      const result = checkAgentRecallHealth("clerk", dir);
+      expect(result.status).toBe("ok");
+      // And it must say WHY the number moved, not just move it.
+      expect(result.detail).toMatch(/150 older rows excluded/);
+      expect(result.detail).toMatch(/window: last 72h/);
+    });
+  });
+
+  it("still fails an agent that is degraded RIGHT NOW", () => {
+    withAgent((dir) => {
+      // The mutation check for the test above: same stale wall, but the recent
+      // rows are degraded too. Excluding stale data must not blunt a live red.
+      writeLog(dir, [
+        ...Array.from({ length: 150 }, () => ownBankTimedOutRow("klanker", 0, 6 * DAY)),
+        ...Array.from({ length: 40 }, () => ownBankTimedOutRow("klanker")),
+      ]);
+      const result = checkAgentRecallHealth("klanker", dir);
+      expect(result.status).toBe("fail");
+      expect(result.fix).toBeDefined();
+    });
+  });
+
+  it("does not let stale HEALTHY rows dilute a live degradation", () => {
+    withAgent((dir) => {
+      // The opposite masking direction, and the reason a row cap alone is not
+      // a safe approximation of recency in either direction: 160 old healthy
+      // rows + 40 fresh degraded ones averages to 25% (a borderline verdict on
+      // the whole tail) but the agent's CURRENT rate is 100%.
+      writeLog(dir, [
+        ...Array.from({ length: 160 }, () => ({
+          ...healthyRow("overlord"),
+          ts: isoAgo(9 * DAY),
+        })),
+        ...Array.from({ length: 40 }, () => ownBankTimedOutRow("overlord")),
+      ]);
+      const result = checkAgentRecallHealth("overlord", dir);
+      expect(result.status).toBe("fail");
+      expect(result.detail).toMatch(/40\/40/);
+    });
+  });
+
+  it("reports a quiet agent as unscored rather than inventing a verdict", () => {
+    withAgent((dir) => {
+      // reggie: every row predates the window. Pre-fix this scored 37.5% ->
+      // fail on 9-day-old rows. It must not silently become "no telemetry
+      // yet" either — that sends the operator hunting a dead plugin.
+      writeLog(dir, Array.from({ length: 24 }, () => ownBankTimedOutRow("reggie", 0, 9 * DAY)));
+      const result = checkAgentRecallHealth("reggie", dir);
+      expect(result.status).toBe("ok");
+      expect(result.detail).toMatch(/no recall in the last 72h/);
+      expect(result.detail).toMatch(/24 older rows outside the window/);
+      expect(result.detail).not.toMatch(/plugin not yet fired/);
+    });
+  });
+
+  it("keeps the row cap as the outer bound for a busy agent", () => {
+    withAgent((dir) => {
+      // All rows recent, more than the cap: the age filter must not widen the
+      // window past `RECALL_HEALTH_WINDOW_ROWS` (that cap is the IO bound).
+      writeLog(dir, [
+        ...Array.from({ length: 400 }, () => healthyRow("finn")),
+        ...Array.from({ length: 200 }, () => ownBankTimedOutRow("finn")),
+      ]);
+      const result = checkAgentRecallHealth("finn", dir);
+      // Scored on the last 200 rows only — all degraded — not on all 600.
+      expect(result.status).toBe("fail");
+      expect(result.detail).toMatch(new RegExp(`/${RECALL_HEALTH_WINDOW_ROWS}\\b`));
+    });
+  });
+
+  describe("filterRecentRecallRows", () => {
+    it("excludes a row it cannot date rather than assuming it is current", () => {
+      // The pre-schema row is exactly the one most likely to be ancient.
+      const undateable: RecallLogRow = { bank_id: "a", bank_timings: [] };
+      expect(filterRecentRecallRows([undateable], DAY, Date.now())).toHaveLength(0);
+    });
+
+    it("keeps a future-dated row (clock skew must not hide a live failure)", () => {
+      const now = Date.now();
+      const skewed: RecallLogRow = { ts: new Date(now + 60_000).toISOString() };
+      expect(filterRecentRecallRows([skewed], DAY, now)).toHaveLength(1);
+    });
+
+    it("is inclusive exactly at the cutoff", () => {
+      const now = Date.now();
+      const atCutoff: RecallLogRow = { ts: new Date(now - DAY).toISOString() };
+      const justPast: RecallLogRow = { ts: new Date(now - DAY - 1000).toISOString() };
+      expect(filterRecentRecallRows([atCutoff], DAY, now)).toHaveLength(1);
+      expect(filterRecentRecallRows([justPast], DAY, now)).toHaveLength(0);
+    });
+
+    it("disables the filter on a non-positive age, rather than dropping everything", () => {
+      const rows = [{ bank_id: "a" }, { ts: isoAgo(99 * DAY) }];
+      expect(filterRecentRecallRows(rows, 0, Date.now())).toHaveLength(2);
+    });
   });
 });

--- a/src/cli/doctor-recall-health.ts
+++ b/src/cli/doctor-recall-health.ts
@@ -91,6 +91,47 @@ export const RECALL_HEALTH_MIN_SAMPLE = 20;
 export const RECALL_HEALTH_WINDOW_ROWS = 200;
 
 /**
+ * Maximum age of a row that still counts toward the rate.
+ *
+ * `RECALL_HEALTH_WINDOW_ROWS` alone is a *volume* bound, not a *recency* one,
+ * and on a quiet agent the two diverge badly. Measured on the 2026-08-02 host,
+ * the trailing 200 rows reached back:
+ *
+ *   gymbro 13d · marko 10d · reggie 9d · carrie 8d · clerk 8d · finn 5d
+ *
+ * The fleet ran a real own-bank timeout regression that ended 2026-07-28.
+ * Days later `doctor` was still scoring those agents on rows from *during* it
+ * and reporting the resolved outage as current health:
+ *
+ *   agent     200-row window   last 72h   verdict(200-row) -> verdict(72h)
+ *   carrie           23.5%       2.9%     warn -> ok
+ *   marko            23.0%       0.0%     warn -> ok
+ *   clerk            31.0%       0.9%     fail -> ok
+ *   gymbro           36.7%       0.0%     fail -> ok
+ *   reggie           37.5%        n/a     fail -> ok (under the sample floor)
+ *   klanker          17.0%      15.7%     warn -> warn  (genuinely degraded)
+ *   overlord         14.0%       9.5%     warn -> warn  (genuinely degraded)
+ *
+ * That is not a cosmetic mislabel. Those false FAILs were read as a live
+ * fleet-wide outage and drove remediation work against a bug that was already
+ * fixed, while the two agents that *are* degraded sat in the same undiffer-
+ * entiated pile. A health check whose window predates its own subject is worse
+ * than no check, because it is believed.
+ *
+ * 72h is the smallest window that keeps every *active* agent above
+ * `RECALL_HEALTH_MIN_SAMPLE` on that host (klanker 287, overlord 317, finn
+ * 133, clerk 107, marko 39, carrie 35, gymbro 33) while excluding the resolved
+ * regression. An agent quieter than 20 rows / 72h falls under the sample floor
+ * and reports `ok` with its count — the safe direction, and already the
+ * documented behaviour for a low-traffic agent.
+ *
+ * The row cap still applies FIRST (it is the IO bound); this is an additional
+ * filter, so a busy agent is scored on its most recent 200 rows and a quiet one
+ * on however many of those are actually recent.
+ */
+export const RECALL_HEALTH_WINDOW_MAX_AGE_MS = 72 * 60 * 60 * 1000;
+
+/**
  * Byte cap on the tail read, sized to comfortably contain
  * `RECALL_HEALTH_WINDOW_ROWS` rows.
  *
@@ -105,6 +146,15 @@ export const RECALL_HEALTH_MAX_TAIL_BYTES = 1024 * 1024;
 
 /** One parsed `recall_log.jsonl` row, narrowed to the fields we classify on. */
 export interface RecallLogRow {
+  /**
+   * ISO-8601 UTC stamp written by `recall.py` on every row
+   * (`time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())`).
+   *
+   * Load-bearing since the recency window: a row we cannot date cannot be
+   * proven recent, so it is excluded rather than assumed current — see
+   * `filterRecentRecallRows`.
+   */
+  ts?: string;
   bank_id?: string;
   result_count?: number;
   total_elapsed_ms?: number;
@@ -138,6 +188,16 @@ export interface RecallHealthStats {
   ownBankErrors: number;
   /** Median `total_elapsed_ms` across rows that reported it, or null. */
   medianElapsedMs: number | null;
+  /**
+   * Rows dropped from the window for being older than
+   * `RECALL_HEALTH_WINDOW_MAX_AGE_MS` (or undateable).
+   *
+   * Surfaced in the detail line so the operator can see that the window is
+   * narrower than the row cap. Without it, "3/107 failed" and "3/107 failed,
+   * 93 older rows excluded" look identical, and the second is the one that
+   * explains why yesterday's FAIL is today's ok.
+   */
+  staleDropped: number;
 }
 
 /**
@@ -147,7 +207,45 @@ export interface RecallHealthStats {
  * and the threshold logic can be tested independently — the 2026-07 regression
  * was invisible partly because the two were never separable.
  */
-export function summarizeRecallRows(rows: RecallLogRow[]): RecallHealthStats {
+/**
+ * Pure: keep only rows recent enough to describe the agent's CURRENT health.
+ *
+ * A row is in-window iff it carries a parseable `ts` no older than `maxAgeMs`.
+ * An undateable row is EXCLUDED, deliberately: the whole failure this guards
+ * against is stale data being scored as current, and "keep what we cannot
+ * date" reintroduces it verbatim for exactly the oldest rows. Every row
+ * `recall.py` has written since the `bank_timings` schema landed carries `ts`
+ * (verified: 0 of 10,627 rows across klanker/carrie/overlord/gymbro lack it on
+ * the 2026-08-02 host), so in practice this drops only pre-schema rows, which
+ * `summarizeRecallRows` already cannot score.
+ *
+ * Dropping too much is safe and dropping too little is not: an over-filtered
+ * window falls under `RECALL_HEALTH_MIN_SAMPLE` and reports `ok` *with its
+ * count*, which is visibly "not enough data", whereas an under-filtered one
+ * reports a confident wrong verdict.
+ *
+ * Exported and `now`-injected so the window logic is testable without clocks.
+ */
+export function filterRecentRecallRows(
+  rows: RecallLogRow[],
+  maxAgeMs: number = RECALL_HEALTH_WINDOW_MAX_AGE_MS,
+  now: number = Date.now(),
+): RecallLogRow[] {
+  if (!Number.isFinite(maxAgeMs) || maxAgeMs <= 0) return rows;
+  const cutoff = now - maxAgeMs;
+  return rows.filter((r) => {
+    if (typeof r.ts !== "string") return false;
+    const t = Date.parse(r.ts);
+    // A future-dated row (host clock skew) is kept: it is certainly not stale,
+    // and silently discarding it would under-report a live degradation.
+    return Number.isFinite(t) && t >= cutoff;
+  });
+}
+
+export function summarizeRecallRows(
+  rows: RecallLogRow[],
+  staleDropped = 0,
+): RecallHealthStats {
   const withTimings = rows.filter(
     (r) => Array.isArray(r.bank_timings) && r.bank_timings.length > 0,
   );
@@ -175,6 +273,7 @@ export function summarizeRecallRows(rows: RecallLogRow[]): RecallHealthStats {
     ownBankTimeouts,
     ownBankErrors,
     medianElapsedMs,
+    staleDropped,
   };
 }
 
@@ -191,6 +290,15 @@ export function classifyRecallHealth(
 ): CheckResult {
   const name = `${agentName} auto-recall`;
   const { rowsSeen, considered, ownBankTimeouts, ownBankErrors, medianElapsedMs } = stats;
+  const staleDropped = stats.staleDropped ?? 0;
+  const windowHours = Math.round(RECALL_HEALTH_WINDOW_MAX_AGE_MS / 3_600_000);
+  // Always name the window, and name what it excluded. The 2026-08 misdiagnosis
+  // happened because the detail line said "the last recalls" while meaning
+  // "some of them from eight days ago".
+  const windowNote =
+    staleDropped > 0
+      ? ` [window: last ${windowHours}h; ${staleDropped} older rows excluded]`
+      : ` [window: last ${windowHours}h]`;
 
   if (considered === 0) {
     if (rowsSeen > 0) {
@@ -204,7 +312,21 @@ export function classifyRecallHealth(
         detail:
           `${rowsSeen} recall rows in the window, none carrying bank_timings ` +
           "(pre-A3 telemetry schema) — own-bank health not scoreable until the " +
-          "agent fires a recall on the current hook",
+          "agent fires a recall on the current hook" +
+          windowNote,
+      };
+    }
+    if (staleDropped > 0) {
+      // The log is not empty — every row in it is simply older than the window.
+      // Saying "agent idle, or plugin not yet fired" here would send the
+      // operator hunting a dead plugin on an agent that just hasn't been
+      // spoken to in three days.
+      return {
+        name,
+        status: "ok",
+        detail:
+          `no recall in the last ${windowHours}h (${staleDropped} older rows ` +
+          "outside the window) — agent quiet, not scored",
       };
     }
     return {
@@ -219,15 +341,39 @@ export function classifyRecallHealth(
   const pct = (rate * 100).toFixed(1);
   const med = medianElapsedMs === null ? "n/a" : `${medianElapsedMs}ms`;
   const detail =
-    `${degraded}/${considered} of the last recalls failed to read the agent's own bank ` +
-    `(${pct}%; ${ownBankTimeouts} timed out, ${ownBankErrors} errored), median recall ${med}`;
+    `${degraded}/${considered} recalls failed to read the agent's own bank ` +
+    `(${pct}%; ${ownBankTimeouts} timed out, ${ownBankErrors} errored), median recall ${med}` +
+    windowNote;
 
+  // Diagnosis corrected 2026-08-02. This text used to send the operator at the
+  // cross-encoder rerank stage. Measured against the live container that is
+  // the wrong stage by an order of magnitude: over 44,342 recalls in 24h,
+  // server-side recall WORK is p50 1.12s / p99 4.09s, while the wait for a
+  // recall admission slot is p50 11.59s / p90 30.0s / max 74.0s — ~90% of
+  // observed latency is queueing, and only 0.04% of recalls spend >9s doing
+  // actual work. Rerank tuning cannot buy back a 12s queue.
+  //
+  // The queue is `HINDSIGHT_API_RECALL_MAX_CONCURRENT` (8 slots), shared
+  // between latency-critical interactive auto-recall (10s deadline) and
+  // background consolidation, which issues its own unbounded recalls
+  // (13-26s per batch) while grinding five-figure backlogs. Interactive
+  // recall queues behind batch work that has no deadline at all.
+  //
+  // Do NOT "fix" this by raising the recall deadline. That was tried on the
+  // live fleet 2026-07-26/27 (16s vs 10s) and made every agent worse, not
+  // better — finn 3.5% -> 65.9%, clerk 21.5% -> 83.8%, carrie 40.7% -> 55.4%
+  // — which is what a fixed-slot queue does when clients become more patient.
   const fix =
-    "Auto-recall is silently degraded — the agent runs with little or no memory " +
-    "while looking healthy. Check hindsight server latency first " +
-    "(`switchroom doctor` hindsight rows, then the recall stage trace); the " +
-    "cross-encoder rerank stage dominates recall latency and is tuned by " +
-    "HINDSIGHT_API_RERANKER_MAX_CANDIDATES in src/setup/hindsight.ts.";
+    "Auto-recall is degraded — the agent runs with little or no memory. The " +
+    "agent IS told (recall.py emits the #3619 DEGRADED notice), so this is a " +
+    "capacity problem, not a visibility one. Measured cause is admission " +
+    "queueing, not ranking cost: check the `waits: sem=` field on the " +
+    "container's [RECALL ...] Complete log lines against the recall work time " +
+    "on the same line. If sem-wait dominates, the lever is recall admission " +
+    "capacity (HINDSIGHT_API_RECALL_MAX_CONCURRENT) and keeping background " +
+    "consolidation recalls off the interactive path — NOT the rerank stage, " +
+    "and NOT a longer deadline (raising it 10s->16s on 2026-07-26 made every " +
+    "agent's timeout rate worse).";
 
   if (considered < RECALL_HEALTH_MIN_SAMPLE) {
     // Too few rows to score, but still worth surfacing the raw counts so a
@@ -334,7 +480,17 @@ export function checkAgentRecallHealth(
   agentName: string,
   agentDir: string,
   windowRows: number = RECALL_HEALTH_WINDOW_ROWS,
+  maxAgeMs: number = RECALL_HEALTH_WINDOW_MAX_AGE_MS,
+  now: number = Date.now(),
 ): CheckResult {
+  // Two bounds, applied in this order and for different reasons: `windowRows`
+  // caps IO cost, `maxAgeMs` makes the verdict about the present. Only the
+  // second was missing, and its absence is what let a resolved regression keep
+  // reporting as a live one for days.
   const rows = readRecallLogTail(recallLogPath(agentDir), windowRows);
-  return classifyRecallHealth(agentName, summarizeRecallRows(rows));
+  const recent = filterRecentRecallRows(rows, maxAgeMs, now);
+  return classifyRecallHealth(
+    agentName,
+    summarizeRecallRows(recent, rows.length - recent.length),
+  );
 }


### PR DESCRIPTION
## Summary

`switchroom doctor`'s recall-health check bounds its window by **row count only** (`RECALL_HEALTH_WINDOW_ROWS = 200`), which is a volume bound, not a recency one. On a quiet agent the trailing 200 rows reach back 8-13 days. After the own-bank-timeout regression was fixed on ~2026-07-28, doctor kept scoring agents on rows from *during* the outage and reporting a resolved problem as current health.

This adds a 72h age bound applied **after** the row cap, corrects the now-wrong remediation text, and makes the window visible in the detail line.

## Why

Measured on the live host 2026-08-02 — old verdict vs actual last-72h rate:

| agent | old (200-row) | new (+72h) |
|---|---|---|
| carrie | **FAIL** 25.0% | ok 1.3% |
| marko | **WARN** 23.5% | ok 0.0% |
| clerk | **FAIL** 32.0% | ok 0.9% |
| gymbro | **FAIL** 36.7% | ok 0.0% |
| reggie | **FAIL** 37.5% | ok (under sample floor) |
| klanker | WARN 18.5% | **WARN 18.5%** (genuinely degraded — preserved) |
| overlord | WARN 15.5% | **WARN 15.5%** (genuinely degraded — preserved) |

Five false reds cleared, both true reds preserved. This is not a cosmetic mislabel: those false FAILs were believed, read as a live fleet-wide outage, and drove remediation work against an already-fixed bug — while the two agents that *are* degraded sat undifferentiated in the same pile. A health check whose window predates its own subject is worse than no check, because it is believed.

## The remediation text was also wrong

The `fix` string pointed operators at the cross-encoder rerank stage. Against the live container that is the wrong stage by an order of magnitude. Over **44,342 recalls in 24h** (`switchroom-hindsight` `[RECALL ...] Complete` lines):

- recall **work**: p50 **1.12s**, p95 2.75s, p99 **4.09s** — only **0.04%** exceed 9s
- wait for an admission slot (`waits: sem=`): p50 **11.59s**, p90 **30.0s**, max **74.0s**
- ~**90%** of observed latency at p50 is queueing

The queue is `HINDSIGHT_API_RECALL_MAX_CONCURRENT` (8 slots), shared between latency-critical interactive auto-recall (10s deadline) and background consolidation, which issues its own unbounded recalls (13-26s per batch) while grinding five-figure backlogs (klanker 59,038; overlord 62,898). Rerank tuning cannot buy back a 12s queue.

The text now also records the negative result: **raising the recall deadline 10s -> 16s was already tried live on 2026-07-26/27 and made every agent worse** — finn 3.5% -> 65.9%, clerk 21.5% -> 83.8%, carrie 40.7% -> 55.4%. That is what a fixed-slot queue does when clients become more patient. Future operators should not re-run that experiment.

## What this does NOT do

It does not reduce klanker's or overlord's timeout rate. Those two are genuinely degraded and this PR deliberately keeps them red. The actual lever is recall admission capacity and keeping background consolidation recalls off the interactive path — an env/`switchroom.yaml` change plus a Hindsight-side scheduling change, both out of scope here and needing operator sign-off.

It also does not touch the DEGRADED-notice path, because that is already working: #3619's notice reached the agent on **84/84** klanker and **43/43** overlord degraded turns since 2026-07-29 (counted by correlating `recall_log.jsonl` degraded rows against `Memory recall was DEGRADED` occurrences in the matching session transcripts). Recall degradation is a capacity problem now, not a visibility one.

## Test plan

- `src/cli/doctor-recall-health.test.ts` — 30 tests, all green. New outcome tests drive the real read+filter+classify path on real files: a resolved outage reads ok (and says *why* the number moved), a live one still fails, stale healthy rows cannot dilute a live degradation, a fully-stale log reads "no recall in the last 72h" rather than "plugin not yet fired", and the row cap remains the outer bound.
- **Mutation-checked** — every new test fails on the bug it guards:
  - filter disabled (old behaviour) -> **5 fail**
  - keep undateable rows -> 1 fail
  - row cap removed -> 1 fail
  - cutoff made exclusive -> 1 fail
  - excluded count not reported -> 2 fail
- Scoped: `vitest run src/cli/doctor-recall-health.test.ts src/hindsight-watch/ tests/cli.memory.recall-log.test.ts` -> 252 passed.
- `npm run lint` -> clean.
- Verified against live telemetry: ran old and new classifiers over all 10 agents' real `recall_log.jsonl` (read-only), producing the table above.

## Risk

Low and one-directional. The filter only ever narrows the window; a narrowed window that falls under `RECALL_HEALTH_MIN_SAMPLE` reports `ok` **with its count** (visibly "not enough data"), which is the safe failure direction. A future-dated row is kept, so clock skew cannot hide a live failure. `summarizeRecallRows`'s new parameter defaults to 0, so existing callers are unaffected.

Follow-up filed separately: `src/hindsight-watch/recall-log.ts:90` deliberately mirrors `RECALL_HEALTH_WINDOW_ROWS` and so likely carries the same staleness defect. Left out of this PR to keep it single-concern.

Job spec: `reference/jobs/` — "always available". An agent that cannot be trusted to report its own memory health is not dependably available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
