### PR TITLE
feat(hindsight): make the background-recall reservation operator-reachable (#4178)

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2684,7 +2684,16 @@ export const HindsightConfigSchema = z.object({
       "temperature knob, made live by switchroom's reflect-temperature image " +
       "patch; a float, or `none` to omit the kwarg (provider default, " +
       "upstream's accidental pre-patch behaviour); unset means the image's " +
-      "baked default 0.1), plus the " +
+      "baked default 0.1; and " +
+      "HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT — the background " +
+      "half of switchroom's recall-admission split (#3660): of the " +
+      "RECALL_MAX_CONCURRENT admission slots, at most this many may be held " +
+      "by background consolidation recalls at once, so foreground per-turn " +
+      "recall always keeps the remainder; must be >= 1 and strictly less " +
+      "than RECALL_MAX_CONCURRENT or the engine refuses to boot; unset " +
+      "means the image's derived default min(2, RECALL_MAX_CONCURRENT - 1); " +
+      "1 biases hard toward the interactive lane while a consolidation " +
+      "backlog drains), plus the " +
       "embedded-PostgreSQL (pg0) sizing keys switchroom manages in " +
       "src/setup/hindsight-pg-defaults.ts (`HINDSIGHT_PG_ENV_KEYS`: " +
       "SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE, " +

--- a/src/setup/hindsight-perf-defaults.test.ts
+++ b/src/setup/hindsight-perf-defaults.test.ts
@@ -351,7 +351,7 @@ describe("operator override wins", () => {
     expect(got.size).toBe(0);
   });
 
-  it("is overridable on exactly these forty-four keys, by name", () => {
+  it("is overridable on exactly these forty-five keys, by name", () => {
     // Spelled out, NOT derived from the three group arrays. HINDSIGHT_PERF_ENV_KEYS
     // is DEFINED as the union of those arrays, so asserting it equals that union
     // is a tautology — it passes no matter which keys are in the arrays. The
@@ -362,6 +362,7 @@ describe("operator override wins", () => {
       "HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT",
       "HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM",
       "HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND",
+      "HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT",
       "HINDSIGHT_API_GRAPH_SEED_MIN_SIMILARITY",
       "HINDSIGHT_API_LINK_EXPANSION_PER_ENTITY_LIMIT",
       "HINDSIGHT_API_LINK_EXPANSION_TIMEOUT",
@@ -713,6 +714,71 @@ describe("HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY (override-only)", () => {
     const perf = { env: { [KEY]: "0.25" }, processEnv: {} };
     startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, false, perf);
     expect(runEnv(runArgs()).get(KEY)).toEqual(["0.25"]);
+  });
+});
+
+describe("HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT (override-only)", () => {
+  const KEY = "HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT";
+  const CAPS = [
+    { gpu: false, localLlm: false },
+    { gpu: true, localLlm: false },
+    { gpu: false, localLlm: true },
+    { gpu: true, localLlm: true },
+  ];
+
+  it("is in the managed set but in NO defaults group", () => {
+    expect(HINDSIGHT_PERF_ENV_KEYS.has(KEY)).toBe(true);
+    expect(HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS.has(KEY)).toBe(true);
+    for (const group of [
+      HINDSIGHT_PERF_DEFAULTS_UNGATED,
+      HINDSIGHT_PERF_DEFAULTS_GPU,
+      HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM,
+    ]) {
+      expect(group.map(([k]) => k)).not.toContain(KEY);
+    }
+  });
+
+  it("survives resolveHindsightPerfOverrides from BOTH sources", () => {
+    expect(resolveHindsightPerfOverrides({ [KEY]: "1" }).get(KEY)).toBe("1");
+    expect(resolveHindsightPerfOverrides(undefined, { [KEY]: "1" }).get(KEY)).toBe("1");
+  });
+
+  it.each(CAPS)(
+    "is NOT emitted when unset (gpu=$gpu localLlm=$localLlm) — the image's derived default stands",
+    (caps) => {
+      // Override-only means REACHABLE, not changed: a host that sets nothing
+      // keeps the image's derived default (min(2, recall_max_concurrent - 1),
+      // config.py _consolidation_recall_max_concurrent) byte-for-byte. Emitting
+      // a value here would pin every install to a number measured on one, and
+      // an explicit value forfeits the derivation's boot-safety clamp.
+      expect(hindsightPerfEnv(caps).map(([k]) => k)).not.toContain(KEY);
+    },
+  );
+
+  it("reaches BOTH launch paths, with the operator's value, when set in hindsight.env", () => {
+    // The outcome that matters. Before this key entered the managed set,
+    // resolveHindsightPerfOverrides dropped it silently: the operator's
+    // hindsight.env line read as durable config in yaml yet never reached the
+    // container, so the background-recall reservation stayed at the image
+    // default and the standing consolidation load under foreground recall
+    // could not be throttled from declarative config at all.
+    const perf = { env: { [KEY]: "1" }, processEnv: {} };
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false, perf);
+    const fromRun = runEnv(runArgs());
+    const fromCompose = composeEnv(
+      generateHindsightComposeSnippet(undefined, undefined, LOOPBACK_LITELLM, false, perf),
+    );
+    expect(fromRun.get(KEY)).toEqual(["1"]);
+    expect(fromCompose.get(KEY)).toEqual(["1"]);
+  });
+
+  it("still reaches the container on a host with NO gated capability", () => {
+    // It belongs to no capability group, so a gate-shaped regression that only
+    // emits grouped keys would drop it. Cloud endpoint + no GPU is the
+    // harshest gating case.
+    const perf = { env: { [KEY]: "1" }, processEnv: {} };
+    startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, false, perf);
+    expect(runEnv(runArgs()).get(KEY)).toEqual(["1"]);
   });
 });
 

--- a/src/setup/hindsight-perf-defaults.ts
+++ b/src/setup/hindsight-perf-defaults.ts
@@ -1264,6 +1264,37 @@ export const HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM: ReadonlyArray<readonly [string, 
  *                                                 # genuinely long-running
  * ```
  *
+ * ### `HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT`
+ *
+ * The background half of the switchroom recall-admission split (#3660,
+ * image-side: `memory_engine.py` `_recall_admission`): of the
+ * `HINDSIGHT_API_RECALL_MAX_CONCURRENT` admission slots, at most this many may
+ * be held by BACKGROUND (consolidation) recalls at once. The image derives its
+ * default (`min(2, recall_max_concurrent - 1)`, `config.py
+ * _consolidation_recall_max_concurrent`) and validates an explicit value at
+ * boot (`>= 1`, strictly `< recall_max_concurrent`).
+ *
+ * Adopted override-only, not defaulted, for the same reason as
+ * `HINDSIGHT_API_RETAIN_WALL_TIMEOUT`: the default already lives in the image
+ * where the mechanism lives, and a second copy of that opinion here would be
+ * something to drift. What an operator needs is REACH: on a fleet whose
+ * consolidation backlogs are five-figure, the standing background recall
+ * stream (measured 2026-08-01 on `switchroom-hindsight`: ~45k background
+ * recalls in 11h vs 225 foreground) is the contention floor under every
+ * foreground recall's embedding/SQL/rerank work, and this knob is the only
+ * lever that trades backlog drain rate against that floor without touching
+ * the foreground lane. Before this entry the key fell outside
+ * {@link HINDSIGHT_PERF_ENV_KEYS} and a `hindsight.env` line for it was
+ * silently discarded.
+ *
+ * ```yaml
+ * hindsight:
+ *   env:
+ *     HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT: 1   # halve the standing
+ *                                                            # background load while
+ *                                                            # a backlog drains
+ * ```
+ *
  * ### DELIBERATELY NOT ADOPTED from v0.8.6
  *
  * - `HINDSIGHT_API_LOOP_WATCHDOG_ENABLED` / `..._STALL_THRESHOLD_MS` /
@@ -1288,6 +1319,7 @@ export const HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS: ReadonlySet<string> = new Set([
   "HINDSIGHT_MCP_RECALL_BUDGET_MODE",
   "HINDSIGHT_API_LLM_TEMPERATURE_REFLECT",
   "HINDSIGHT_API_RETAIN_WALL_TIMEOUT",
+  "HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT",
 ]);
 
 /**


### PR DESCRIPTION
## What

Adds `HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT` to `HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS` so an operator's `hindsight.env` line for it reaches the container instead of being silently discarded by `resolveHindsightPerfOverrides`. Override-only, no shipped default — the image derives `min(2, recall_max_concurrent - 1)` and validates an explicit value at boot (`>= 1`, strictly `< recall_max_concurrent`).

## Why — the corrected #4178 diagnosis

#4178 says interactive recall queues behind consolidation on the shared 8-slot semaphore. **That was true, and it was already fixed**: the recall-admission split landed 2026-07-26 in 036681a4 (#3660) and is live in the running image. Splitting the last 11h of `[RECALL ...] Complete ... sem=` lines by lane:

| lane | n | sem p50 | p90 | p99 | max |
|---|---|---|---|---|---|
| foreground (`Complete:`) | 225 | **0.000s** | **0.000s** | **0.000s** | 0.000s |
| background (`Complete (quiet)`) | 45,234 | 11.7s | 30.2s | 52.8s | **73.98s** |

The issue's aggregate table (p50 11.59s, max 73.98s over 44,342 recalls) is the background lane — 99.5% of log volume; note the identical max. Background waits are consolidation queueing behind its own 2-slot reservation, by design, with no deadline.

**The timeouts that remain are work-time, not queueing.** Post-restart, klanker hit `deadline_hit` on 10/23 recalls, overlord 11/32, every one with own-bank `elapsed_ms` pinned at ~9,020 (the plugin's ~9s residual per-bank budget) and `sem=0.000s` server-side. Foreground own-bank work on the two 175-180k-unit banks runs 6.5-9.4s (klanker mean 6.86s, overlord 7.32s over 11h) versus ~1s measured on an idle box (the 2026-07-28 candidates-30 measurement in switchroom.yaml). The inflation is contention from the standing background stream — ~45k quiet recalls in 11h (~1.15/s), each doing a query embedding (cuda, shared with the reranker on the container's RTX 3070), semantic+bm25+graph SQL against pg0 (observed `LWLock.LockManager` waits), and a cross-encoder rerank on the shared 4-slot pool. The consolidation **LLM** lane is not the contended resource: LiteLLM spend logs show 4,344/4,344 consolidation calls in 12h went to OpenRouter.

Per the operator's stated priority (interactive recall/reflect wins over consolidation throughput), the lever is to shrink the background reservation from 2 to 1 — halving the standing contention floor under foreground work without touching the foreground lane, the deadlines (raising them was tried live 07-26/27 and regressed), or the Ollama boxes. That value is a fleet decision and belongs in `switchroom.yaml`; this PR only makes the key reachable.

## Config change to pair with this (operator applies)

```yaml
hindsight:
  env:
    # 2026-08-02 (#4178, klanker): bias the recall admission split hard toward
    # the interactive lane while the klanker/overlord consolidation backlogs
    # (58k/62k unconsolidated units) drain. Background (consolidation) recalls
    # may hold at most 1 of the 8 RECALL_MAX_CONCURRENT slots; foreground
    # keeps 7. Costs consolidation throughput (its batch time is recall-
    # dominated: recall=22-25s vs llm=5-8s per batch) — accepted, per Ken.
    # Rollback: delete this line and recreate; the image default (2) returns.
    HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT: 1
```

Order matters: this PR must roll out before the yaml line is added, or `switchroom doctor` will FAIL the line as unmanaged (`findUnmanagedHindsightEnvKeys`).

## Tests

`src/setup/hindsight-perf-defaults.test.ts`, new override-only block mirroring `HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY`, plus the pinned 45-key roster update. Mutation-proven:
- Remove the key from `HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS` → "reaches BOTH launch paths" fails (resolver drops the key; `fromRun.get(KEY)` is undefined) and the pinned roster test fails.
- Add the key to any defaults group → "is NOT emitted when unset" fails on all four capability combinations.
- Break the no-capability emission path → "still reaches the container on a host with NO gated capability" fails.

Local: `npx vitest run src/setup/ tests/hindsight-env-keys-are-reachable.test.ts tests/docker/hindsight-recall-isolation-patches.test.ts` → 486 passed. `npm run lint` clean.

## Expected effect and blast radius

- Foreground sem wait stays 0 (already is). Foreground own-bank work should fall from ~7s mean toward the idle ~1-3s band as the standing background embed/SQL/rerank load halves; own-bank deadline-hit on klanker/overlord (14-43% of turns in the last 72h) should drop by well over half. This is an estimate, not a guarantee — the halving of contention is exact, the latency response is not linear.
- Cost: consolidation batch recall phase roughly doubles (22s → ~45s), so backlog drain slows ~40-60%. Accepted trade per operator.
- If wrong: interactive path is untouched by construction (the key only caps the background reservation); rollback is deleting one yaml line and recreating the container.

Refs #4178

🤖 Generated with [Claude Code](https://claude.com/claude-code)