### PR TITLE
feat(release): ship an asset payload so a curl|sh install has profiles, skills, vendor and ui on disk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,16 @@ env:
   # scripts/check-release-asset-names.mjs. Keep the order stable.
   RELEASE_ASSETS: "switchroom-linux-amd64 switchroom-linux-arm64 switchroom-macos-amd64 switchroom-macos-arm64"
   CHECKSUMS_FILE: "switchroom-checksums.txt"
+  # The shipped-asset payload (#4163). `bun build --compile` embeds the JS
+  # bundle and nothing else, so profiles/, skills/, vendor/hindsight-memory/
+  # and the web UI ship as this tarball; install.sh extracts it to
+  # `<prefix>/share/switchroom`, which is where src/util/shipped-assets.ts
+  # probes. Without it the four binaries above install a CLI that cannot
+  # scaffold a single agent. Architecture-independent, so it is built ONCE in
+  # `bundle` rather than in the per-platform matrix — which is why it is not
+  # part of RELEASE_ASSETS (that list is the artifacts downloaded from the
+  # build legs). scripts/release-assets.mjs enforces both halves of that.
+  PAYLOAD_ASSET: "switchroom-assets.tar.gz"
 
 jobs:
   build:
@@ -319,6 +329,27 @@ jobs:
           done
           ls -lh dist-bins
 
+      - name: Build the shipped-asset payload (#4163)
+        env:
+          TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+        shell: bash
+        run: |
+          # The payload's manifest version is read OUT OF THE BINARY that is
+          # about to ship beside it, not out of the git ref. That is what makes
+          # binary/payload skew structurally impossible at build time: the two
+          # artifacts cannot carry different versions unless the binary lies
+          # about its own. (The build legs already assert `--version` == tag;
+          # on a tag we re-assert it here, cheaply, from the bundle job.)
+          chmod +x dist-bins/switchroom-linux-amd64
+          ver="$(./dist-bins/switchroom-linux-amd64 --version)"
+          echo "linux-amd64 binary reports version '$ver'"
+          if [ -n "$TAG" ] && [ "v$ver" != "$TAG" ]; then
+            echo "::error::binary reports v$ver but the tag is $TAG — refusing to cut a payload whose manifest would disagree with the CLI it ships with"
+            exit 1
+          fi
+          node scripts/build-asset-payload.mjs --version "v$ver" --out "dist-bins/$PAYLOAD_ASSET"
+          ls -lh "dist-bins/$PAYLOAD_ASSET"
+
       - name: Compute SHA256 checksums
         shell: bash
         working-directory: dist-bins
@@ -326,9 +357,12 @@ jobs:
           # sha256sum's canonical "<hash>  <name>" two-space format is what
           # install.sh matches with `grep -F "  ${asset}"`. Feed it the
           # explicit asset list so the checksums file can never pick up a
-          # stray file or miss one.
+          # stray file or miss one. The payload is in the SAME checksums file
+          # as the binaries and is verified by install.sh and `switchroom
+          # update` the same way — an unverified payload would be an
+          # arbitrary-file-write vector into every scaffolded agent.
           # shellcheck disable=SC2086
-          sha256sum $RELEASE_ASSETS > "$CHECKSUMS_FILE"
+          sha256sum $RELEASE_ASSETS "$PAYLOAD_ASSET" > "$CHECKSUMS_FILE"
           cat "$CHECKSUMS_FILE"
 
       - name: Verify the bundle against the install.sh contract
@@ -528,7 +562,7 @@ jobs:
           name: release-bundle
           path: dist-bins
 
-      - name: Attach binaries + checksums to the GitHub Release
+      - name: Attach binaries + payload + checksums to the GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # `EXPECT_TAG`, not a step-local `TAG`: the same variable names the
@@ -544,7 +578,7 @@ jobs:
         run: |
           files=""
           for asset in $RELEASE_ASSETS; do files="$files dist-bins/$asset"; done
-          files="$files dist-bins/$CHECKSUMS_FILE"
+          files="$files dist-bins/$PAYLOAD_ASSET dist-bins/$CHECKSUMS_FILE"
           # shellcheck disable=SC2086
           gh release upload "$EXPECT_TAG" $files --repo "$GITHUB_REPOSITORY" --clobber
 

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ switchroom-checksums.txt
 
 # Scratch dir for tests/ci-buildx-warm-pull.test.ts when /tmp is noexec.
 .buildx-warm-test-*/
+
+# Locally built release asset payload (#4163).
+switchroom-assets.tar.gz

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,25 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Switchroom static-binary installer.
+#
+# POSIX sh, deliberately. The documented invocation below pipes this file to
+# `sh`, and on Debian/Ubuntu `/bin/sh` is dash — where the old
+# `#!/usr/bin/env bash` + `set -euo pipefail` header aborted on line 1 with
+# "Illegal option -o pipefail" before a single byte was installed. The shebang
+# does not save it either: a piped script has no shebang. Keep this file free
+# of bashisms (#4163).
 #
 # Detects platform/arch, fetches the matching pre-built `switchroom`
 # binary from the latest GitHub release, verifies its SHA256 checksum,
 # and installs it to /usr/local/bin (falls back to ~/.local/bin if
 # /usr/local/bin is not writable).
+#
+# It ALSO fetches the shipped-asset payload (#4163). `bun build --compile`
+# embeds the JS bundle and nothing else, so `profiles/`, `skills/`,
+# `vendor/hindsight-memory/` and the dashboard UI have no on-disk home in a
+# binary-only install — and without them `switchroom apply` cannot scaffold a
+# single agent ("Profile not found: default"). The payload is verified against
+# the same checksums file as the binary and extracted to
+# <prefix>/share/switchroom, which is exactly where the CLI probes.
 #
 # Usage:
 #   curl -fsSL https://github.com/switchroom/switchroom/raw/main/install.sh | sh
@@ -12,12 +27,16 @@
 # Environment overrides:
 #   SWITCHROOM_INSTALL_DIR   target dir (default: /usr/local/bin or ~/.local/bin)
 #   SWITCHROOM_VERSION       pin a specific tag (default: latest release)
+#   SWITCHROOM_SHARE_DIR     asset payload dir (default: <prefix>/share/switchroom)
+#   SWITCHROOM_BASE_URL      override the release download base (offline / testing)
 #
 # The binary is self-contained (bun runtime is bundled). You'll still
 # need the `claude` CLI installed separately to run agents — see
 # https://github.com/switchroom/switchroom for the full setup guide.
 
-set -euo pipefail
+# `-o pipefail` is not POSIX (see the header). Nothing here depends on it:
+# every pipeline whose failure matters is checked for an empty result.
+set -eu
 
 REPO="switchroom/switchroom"
 
@@ -53,11 +72,21 @@ esac
 
 asset="switchroom-${platform}-${arch}"
 
+# The shipped-asset payload (#4163). Deliberately NOT versioned in the
+# filename: release assets are already namespaced by the tag in their download
+# URL, exactly like the four binaries and the checksums file, and a
+# `${version}` here would be a second thing for the installer and
+# `switchroom update` to derive independently and get wrong.
+# scripts/release-assets.mjs parses this literal out of this file and fails
+# `npm run lint` if the workflow stops producing it.
+assets_payload="switchroom-assets.tar.gz"
+
 log "Detected ${BOLD}${platform}/${arch}${RESET}, will fetch ${BOLD}${asset}${RESET}"
 
 # ---- prerequisites ----
 
 have curl || die "curl is required."
+have tar  || die "tar is required (the shipped-asset payload is a .tar.gz)."
 
 # Either sha256sum (linux) or shasum (macos) works for verification.
 if have sha256sum; then
@@ -89,7 +118,7 @@ ok "Version: $version"
 
 # ---- download binary + checksums ----
 
-base_url="https://github.com/${REPO}/releases/download/${version}"
+base_url="${SWITCHROOM_BASE_URL:-https://github.com/${REPO}/releases/download/${version}}"
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 
@@ -101,9 +130,8 @@ log "Downloading checksums"
 curl -fsSL --retry 3 -o "$tmp/switchroom-checksums.txt" "$base_url/switchroom-checksums.txt" \
   || die "Failed to download $base_url/switchroom-checksums.txt."
 
-# ---- verify checksum ----
+# ---- verify checksums ----
 
-log "Verifying SHA256"
 # The checksums file uses the `sha256sum`-canonical "<hash>  <file>"
 # two-space format. Older revisions of this script grep'd with a
 # pattern that only tolerated a single trailing space and was anchored
@@ -111,16 +139,50 @@ log "Verifying SHA256"
 # alternation, CRLF line endings) and silently missed valid entries.
 # Use a fixed-string match against the exact two-space-prefixed asset
 # name to find the line.
-expected=$(grep -F "  ${asset}" "$tmp/switchroom-checksums.txt" | awk '{print $1}' | head -n 1)
-[ -n "$expected" ] || die "No checksum entry for $asset in switchroom-checksums.txt."
+checksum_for() {
+  # `|| true`: under `set -e` a grep that matches nothing would otherwise take
+  # the whole command substitution's exit status non-zero at the call site,
+  # aborting the install with no message instead of reaching the
+  # "No checksum entry" die below. Callers test for an EMPTY result.
+  { grep -F "  ${1}" "$tmp/switchroom-checksums.txt" || true; } | awk '{print $1}' | head -n 1
+}
 
-actual=$($sha_cmd "$tmp/$asset" | awk '{print $1}')
-if [ "$expected" != "$actual" ]; then
-  die "Checksum mismatch for $asset. Expected $expected, got $actual."
-fi
-ok "Checksum verified ($expected)"
+verify_sha() {
+  # $1 = asset name. Dies on mismatch; never installs an unverified file.
+  _expected=$(checksum_for "$1")
+  [ -n "$_expected" ] || die "No checksum entry for $1 in switchroom-checksums.txt."
+  _actual=$($sha_cmd "$tmp/$1" | awk '{print $1}')
+  if [ "$_expected" != "$_actual" ]; then
+    die "Checksum mismatch for $1. Expected $_expected, got $_actual."
+  fi
+  ok "Checksum verified for $1 ($_expected)"
+}
 
+log "Verifying SHA256"
+verify_sha "$asset"
 chmod +x "$tmp/$asset"
+
+# ---- download + verify the shipped-asset payload (#4163) ----
+#
+# A binary with no payload installs fine and then fails at the first useful
+# thing you ask it to do. Distinguish the two reasons it can be absent:
+#
+#   - no checksum entry  -> this release predates the payload. Warn loudly and
+#     continue; the operator asked for an old version and gets the old (broken
+#     for scaffolding) behaviour, stated plainly rather than discovered later.
+#   - entry present, download or verification fails -> this release is
+#     incomplete or the artifact is corrupt. Die. Installing half of a release
+#     is how #4163 happened in the first place.
+payload_available=""
+if [ -n "$(checksum_for "$assets_payload")" ]; then
+  payload_available=1
+  log "Downloading $assets_payload"
+  curl -fsSL --retry 3 -o "$tmp/$assets_payload" "$base_url/$assets_payload" \
+    || die "Failed to download $base_url/$assets_payload. The checksums file lists it, so this release is incomplete — not installing a CLI that cannot scaffold."
+  verify_sha "$assets_payload"
+else
+  warn "Release $version ships no $assets_payload. Agent scaffolding (\`switchroom apply\`) needs profiles/, skills/ and vendor/ on disk and WILL fail on this version — upgrade to a release that ships the asset payload."
+fi
 
 # ---- choose install dir ----
 
@@ -140,14 +202,80 @@ fi
 
 target="$install_dir/switchroom"
 
+# ---- install the asset payload FIRST (#4163) ----
+#
+# Two artifacts, one release, and no syscall that swaps both at once. So:
+# the payload lands before the binary, each by an atomic rename. If this
+# script is killed between them the host has NEW templates + OLD (or no)
+# binary — the recoverable direction — and never a new CLI rendering agent
+# scaffolds from stale templates, which is the failure mode #4163 names as
+# worse than shipping nothing.
+#
+# The layout matches what `switchroom update`'s self-update writes and what
+# src/util/shipped-assets.ts probes:
+#
+#   <prefix>/share/switchroom-<version>/     extracted payload
+#   <prefix>/share/switchroom -> switchroom-<version>
+#
+# The extract-then-publish split means a failed download or a corrupt archive
+# never touches the live payload. The final `ln -s` is NOT atomic here (there
+# is no portable atomic symlink swap in POSIX sh — `mv -T` is GNU-only), so
+# there is a sub-millisecond window on an UPGRADE install where <share_dir>
+# does not exist. That is deliberate and bounded: a torn payload has no
+# manifest, `switchroom doctor` reports it and `switchroom update` reinstalls
+# it. `switchroom update`'s own self-update path, which runs far more often,
+# does do the atomic rename(2) swap (src/cli/self-update.ts).
+
+# One decision about privilege, used for both artifacts.
+SUDO=""
+if [ ! -w "$install_dir" ]; then
+  if have sudo; then
+    warn "$install_dir requires sudo"
+    SUDO="sudo"
+  else
+    die "$install_dir is not writable and sudo not available. Set SWITCHROOM_INSTALL_DIR to a writable directory."
+  fi
+fi
+
+if [ -n "$payload_available" ]; then
+  share_dir="${SWITCHROOM_SHARE_DIR:-$(dirname "$install_dir")/share/switchroom}"
+  share_parent=$(dirname "$share_dir")
+  payload_version="${version#v}"
+  version_dir="${share_dir}-${payload_version}"
+
+  log "Installing shipped assets to $share_dir"
+  $SUDO mkdir -p "$share_parent"
+  $SUDO rm -rf "${version_dir}.incoming" "$version_dir"
+  $SUDO mkdir -p "${version_dir}.incoming"
+  $SUDO tar -xzf "$tmp/$assets_payload" -C "${version_dir}.incoming" \
+    || die "Failed to unpack $assets_payload into ${version_dir}.incoming."
+
+  # Prove the tarball really is this release's payload before publishing it:
+  # these files become every agent's container entrypoint template.
+  manifest="${version_dir}.incoming/switchroom-assets.json"
+  [ -f "$manifest" ] \
+    || die "$assets_payload contains no switchroom-assets.json — refusing to install an unidentifiable payload."
+  manifest_version=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"v\{0,1\}\([^"]*\)".*/\1/p' "$manifest" | head -n 1)
+  if [ "$manifest_version" != "$payload_version" ]; then
+    die "$assets_payload declares version '$manifest_version' but this is release $version — refusing to pair a CLI with someone else's templates."
+  fi
+
+  $SUDO mv "${version_dir}.incoming" "$version_dir"
+  if [ -e "$share_dir" ] && [ ! -L "$share_dir" ]; then
+    warn "$share_dir already exists as a real directory — moving it to ${share_dir}.replaced"
+    $SUDO rm -rf "${share_dir}.replaced"
+    $SUDO mv "$share_dir" "${share_dir}.replaced"
+  fi
+  $SUDO rm -f "$share_dir"
+  $SUDO ln -s "$(basename "$version_dir")" "$share_dir"
+  ok "Shipped assets installed ($share_dir -> $(basename "$version_dir"))"
+fi
+
 log "Installing to $target"
-if [ -w "$install_dir" ]; then
+if [ -z "$SUDO" ]; then
   mv "$tmp/$asset" "$target"
-elif have sudo; then
-  warn "$install_dir requires sudo"
-  sudo mv "$tmp/$asset" "$target"
 else
-  die "$install_dir is not writable and sudo not available. Set SWITCHROOM_INSTALL_DIR to a writable directory."
+  sudo mv "$tmp/$asset" "$target"
 fi
 
 # macOS Gatekeeper: unsigned binaries get the quarantine xattr from curl.

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -1415,11 +1415,18 @@ fi
 # any auth break shows up on the Telegram issues card (#428) the day
 # it starts, not three weeks later. Async + best-effort: never blocks
 # boot and never fails it.
-{{#if repoRoot}}
-if [ -x "{{repoRoot}}/bin/boot-self-test.sh" ]; then
-  ( "{{repoRoot}}/bin/boot-self-test.sh" >/dev/null 2>&1 ) &
+#
+# The path is the IN-CONTAINER one — docker/Dockerfile.agent:229 COPYs
+# `bin/*.sh` to /opt/switchroom/bin. It used to be `{{repoRoot}}/bin/…`,
+# rendered from the CLI's own `import.meta.dirname`: a HOST path baked into a
+# script that only ever runs inside the container. Under `bun build --compile`
+# `import.meta.dirname` is the bunfs root, so repoRoot rendered EMPTY and the
+# `-x` test silently skipped the self-test on every agent (#4163). Even from a
+# source checkout the host repo is not mounted
+# in the agent container, so this had never actually fired.
+if [ -x "/opt/switchroom/bin/boot-self-test.sh" ]; then
+  ( "/opt/switchroom/bin/boot-self-test.sh" >/dev/null 2>&1 ) &
 fi
-{{/if}}
 
 # --- Security-hooks plugin integrity check (sec WS8-F1 / #1416) ---
 # The image-baked, agent-unstrippable tool-safety plugin is loaded via

--- a/scripts/build-asset-payload.mjs
+++ b/scripts/build-asset-payload.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * Build the shipped-asset payload tarball (#4163).
+ *
+ * WHY THIS EXISTS
+ *
+ * `bun build --compile` embeds the JS bundle in a virtual bunfs and NOTHING
+ * else. `profiles/`, `skills/`, `vendor/hindsight-memory/` and the web UI are
+ * plain directories the CLI reads at runtime, so the four release binaries
+ * shipped an install that could not scaffold a single agent: `switchroom
+ * apply` died with `Profile not found: default`. #4162 taught every call site
+ * to PROBE `<prefix>/share/switchroom/<asset>`; this script produces the thing
+ * that lands there.
+ *
+ * WHAT GOES IN, AND WHAT DELIBERATELY DOES NOT
+ *
+ * Exactly the directories a host-side CLI reads off disk at runtime — see
+ * PAYLOAD_ENTRIES. `bin/` is NOT one of them: every `bin/*.sh` consumer is the
+ * agent container, which gets them from `/opt/switchroom/bin` (COPYed by
+ * Dockerfile.agent, referenced through `DOCKER_BIN_PATH` in scaffold.ts).
+ * `examples/` is not either: `src/cli/embedded-examples.ts` bundles the YAML
+ * into the binary as `with { type: "text" }` imports. Shipping a payload
+ * directory nothing reads is how a payload rots without anyone noticing.
+ *
+ * ONLY GIT-TRACKED FILES SHIP. The file list comes from `git ls-files`, so a
+ * stray `__pycache__/`, a local `.env`, a build artifact or an editor swap
+ * file in a maintainer's checkout can never end up on the release page. It
+ * also makes the tarball reproducible from a tag.
+ *
+ * THE MANIFEST IS THE ANTI-SKEW MECHANISM. `switchroom-assets.json` at the
+ * payload root records the version this payload was cut from. `switchroom
+ * update` refuses to leave a host where that version disagrees with the
+ * installed binary's, and `switchroom doctor` reports the skew. A payload
+ * with no manifest is treated as unknown-version, i.e. skewed.
+ *
+ * Usage:
+ *   node scripts/build-asset-payload.mjs --version <vX.Y.Z> --out <file.tar.gz>
+ *   node scripts/build-asset-payload.mjs --version <vX.Y.Z> --stage-only <dir>
+ */
+
+import { execFileSync } from "node:child_process";
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+/**
+ * The payload contents, as `[repo path, path inside the payload]`.
+ *
+ * The destination names are what `src/util/shipped-assets.ts` probes for, so
+ * these two lists are one contract — `tests/asset-payload-contract.test.ts`
+ * asserts every `ShippedAssetSpec.asset` the CLI resolves has a producer here.
+ */
+export const PAYLOAD_ENTRIES = [
+  // Handlebars templates for every agent scaffold (`switchroom apply`).
+  ["profiles", "profiles"],
+  // Bundled skills pool, mirrored to ~/.switchroom/skills/_bundled.
+  ["skills", "skills"],
+  // The hindsight-memory plugin installed into each agent's .claude/plugins.
+  ["vendor/hindsight-memory", "vendor/hindsight-memory"],
+  // Web dashboard static assets. `npm run build` copies these to dist/cli/ui;
+  // the compiled binary has no such sibling, so `switchroom web` served a
+  // 404-only dashboard from a static-binary install.
+  ["src/web/ui", "ui"],
+];
+
+/** Filename of the version manifest at the payload root. */
+export const ASSET_MANIFEST_FILENAME = "switchroom-assets.json";
+
+/** Every git-tracked file under `dir`, repo-relative. Throws if empty. */
+function trackedFiles(dir) {
+  const out = execFileSync("git", ["ls-files", "-z", "--", dir], {
+    cwd: REPO_ROOT,
+    encoding: "utf-8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  const files = out.split("\0").filter(Boolean);
+  if (files.length === 0) {
+    throw new Error(
+      `asset payload: \`git ls-files -- ${dir}\` returned nothing. The payload ` +
+        `would ship without ${dir}, and every install would be broken in exactly ` +
+        `the way #4163 is about. Refusing to build.`,
+    );
+  }
+  return files;
+}
+
+/**
+ * Stage the payload into `stageDir` (created if absent) and write the
+ * manifest. Returns the manifest object.
+ */
+export function stagePayload(stageDir, version) {
+  mkdirSync(stageDir, { recursive: true });
+  let fileCount = 0;
+  for (const [src, dest] of PAYLOAD_ENTRIES) {
+    for (const rel of trackedFiles(src)) {
+      // rel is repo-relative and starts with `src`; re-root it under `dest`.
+      const suffix = rel.slice(src.length).replace(/^\//, "");
+      const target = join(stageDir, dest, suffix);
+      mkdirSync(dirname(target), { recursive: true });
+      cpSync(join(REPO_ROOT, rel), target, { dereference: true });
+      fileCount += 1;
+    }
+  }
+  const manifest = {
+    // `vX.Y.Z`. Compared against the CLI's own version by
+    // `assetPayloadSkew()` in src/util/shipped-assets.ts.
+    version: version.startsWith("v") ? version : `v${version}`,
+    entries: PAYLOAD_ENTRIES.map(([, dest]) => dest),
+    files: fileCount,
+  };
+  writeFileSync(
+    join(stageDir, ASSET_MANIFEST_FILENAME),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  return manifest;
+}
+
+/** Stage + tar. Returns the manifest. */
+export function buildPayloadTarball(outFile, version) {
+  const stage = mkdtempSync(join(tmpdir(), "switchroom-assets-"));
+  try {
+    const manifest = stagePayload(stage, version);
+    mkdirSync(dirname(resolve(outFile)), { recursive: true });
+    // Deterministic-ish: sorted names, fixed owner, no per-file mtime noise
+    // beyond the checkout's. GNU tar flags; the release job runs on ubuntu.
+    execFileSync(
+      "tar",
+      [
+        "--sort=name",
+        "--owner=0",
+        "--group=0",
+        "--numeric-owner",
+        "-czf",
+        resolve(outFile),
+        "-C",
+        stage,
+        ".",
+      ],
+      { stdio: "inherit" },
+    );
+    return manifest;
+  } finally {
+    rmSync(stage, { recursive: true, force: true });
+  }
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────
+
+function argValue(flag) {
+  const i = process.argv.indexOf(flag);
+  return i === -1 ? undefined : process.argv[i + 1];
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  const version = argValue("--version");
+  if (!version) {
+    console.error("usage: build-asset-payload.mjs --version <vX.Y.Z> (--out <file.tar.gz> | --stage-only <dir>)");
+    process.exit(2);
+  }
+  const stageOnly = argValue("--stage-only");
+  if (stageOnly) {
+    const m = stagePayload(resolve(stageOnly), version);
+    console.log(`staged ${m.files} files (${m.version}) -> ${resolve(stageOnly)}`);
+  } else {
+    const out = argValue("--out");
+    if (!out) {
+      console.error("build-asset-payload.mjs: --out or --stage-only is required");
+      process.exit(2);
+    }
+    const m = buildPayloadTarball(out, version);
+    console.log(`built ${resolve(out)}: ${m.files} files, version ${m.version}`);
+  }
+}

--- a/scripts/check-release-asset-names.mjs
+++ b/scripts/check-release-asset-names.mjs
@@ -56,7 +56,7 @@ if (problems.length > 0) {
 }
 
 console.log(
-  `OK release asset contract: ${installer.assets.length} assets + ${installer.checksumsFile} ` +
-    `agree between install.sh and release.yml`,
+  `OK release asset contract: ${installer.assets.length} binaries + ${installer.payloadAsset} + ` +
+    `${installer.checksumsFile} agree between install.sh and release.yml`,
 );
-console.log(`   ${installer.assets.join("\n   ")}`);
+console.log(`   ${[...installer.assets, installer.payloadAsset].join("\n   ")}`);

--- a/scripts/ci/assert-release-assets-complete.mjs
+++ b/scripts/ci/assert-release-assets-complete.mjs
@@ -67,7 +67,11 @@ export const EXIT = { complete: 0, badInput: 1, incomplete: 3, notFound: 4 };
  */
 export function expectedAssets(opts = {}) {
   const { installer } = loadInstallerContract(opts);
-  return [...installer.assets, installer.checksumsFile];
+  // The payload tarball (#4163) is as required as the binaries: a release that
+  // carries four binaries and no payload installs a CLI that cannot scaffold a
+  // single agent, which is a worse user experience than a download 404 because
+  // it fails later, on `switchroom apply`, on the user's host.
+  return [...installer.assets, installer.checksumsFile, installer.payloadAsset];
 }
 
 /**

--- a/scripts/release-assets.mjs
+++ b/scripts/release-assets.mjs
@@ -70,7 +70,7 @@ function fail(message) {
  *
  * @param {string} text contents of install.sh
  * @returns {{assets: string[], platforms: string[], arches: string[],
- *            checksumsFile: string, template: string}}
+ *            checksumsFile: string, payloadAsset: string, template: string}}
  */
 export function parseInstallerContract(text) {
   // `Linux) platform=linux ;;` / `Darwin) platform=macos ;;`
@@ -113,9 +113,28 @@ export function parseInstallerContract(text) {
   }
   const checksumsFile = [...checksumNames][0];
 
+  // The shipped-asset payload (#4163): `assets_payload="switchroom-assets.tar.gz"`.
+  // A literal name, not a template — see the comment beside it in install.sh
+  // for why it carries no `${version}`. It is REQUIRED: an installer that no
+  // longer fetches a payload is a decision to go back to shipping binaries
+  // that cannot scaffold, and that decision has to be made here, in the
+  // contract, rather than by deleting one line of shell.
+  const payloadLine = text.match(/\bassets_payload="([A-Za-z0-9_.-]+)"/);
+  if (!payloadLine) {
+    fail(
+      'install.sh: could not find `assets_payload="…"`. The static binary embeds only the JS bundle, ' +
+        "so profiles/skills/vendor have to arrive as a separate release artifact (#4163) — the " +
+        "installer must fetch one.",
+    );
+  }
+  const payloadAsset = payloadLine[1];
+
   // The installer's fixed-string checksum lookup. Its literal leading spaces
   // are the format contract the workflow's `sha256sum` output must satisfy.
-  const grepLine = text.match(/grep -F "(\s+)\$\{asset\}"/);
+  // Any shell variable is accepted (the lookup is a helper function taking a
+  // positional, `grep -F "  ${1}"`, so both the binary and the payload go
+  // through one code path) — the SEPARATOR is what this asserts.
+  const grepLine = text.match(/grep -F "([ \t]+)\$\{[A-Za-z0-9_]+\}"/);
   if (!grepLine) {
     fail('install.sh: could not find the `grep -F "  ${asset}"` checksum lookup');
   }
@@ -126,7 +145,7 @@ export function parseInstallerContract(text) {
     );
   }
 
-  return { assets, platforms, arches, checksumsFile, template };
+  return { assets, platforms, arches, checksumsFile, payloadAsset, template };
 }
 
 /**
@@ -134,7 +153,7 @@ export function parseInstallerContract(text) {
  *
  * @param {string} text contents of release.yml
  * @returns {{matrixAssets: string[], matrixRunners: Record<string, string>,
- *            declaredAssets: string[], checksumsFile: string}}
+ *            declaredAssets: string[], checksumsFile: string, payloadAsset: string}}
  */
 export async function parseWorkflowContract(text) {
   // `yaml` is imported lazily and ONLY on this path. The release workflow runs
@@ -175,6 +194,25 @@ export async function parseWorkflowContract(text) {
     fail("release.yml: workflow-level env.CHECKSUMS_FILE is missing or empty");
   }
 
+  const payloadAsset = doc.env?.PAYLOAD_ASSET;
+  if (typeof payloadAsset !== "string" || payloadAsset.length === 0) {
+    fail(
+      "release.yml: workflow-level env.PAYLOAD_ASSET is missing or empty. The compiled binary embeds " +
+        "only the JS bundle; profiles/skills/vendor/ui ship as a separate tarball (#4163) that the " +
+        "workflow must build, checksum and upload.",
+    );
+  }
+
+  // The payload is only useful if it is actually produced. `env.PAYLOAD_ASSET`
+  // naming a file nothing builds would publish a release whose installer dies
+  // on a 404 — the #3633 failure shape, one artifact over.
+  if (!/\bscripts\/build-asset-payload\.mjs\b/.test(text)) {
+    fail(
+      "release.yml: declares env.PAYLOAD_ASSET but never runs scripts/build-asset-payload.mjs — " +
+        "nothing would produce the tarball install.sh downloads (#4163)",
+    );
+  }
+
   // The two-space checksum format the installer depends on comes from
   // `sha256sum`. If the workflow switches to another tool (shasum -a 256 emits
   // the same format; `openssl dgst` does not), that decision has to be made
@@ -197,7 +235,7 @@ export async function parseWorkflowContract(text) {
     );
   }
 
-  return { matrixAssets, matrixRunners, declaredAssets, checksumsFile };
+  return { matrixAssets, matrixRunners, declaredAssets, checksumsFile, payloadAsset };
 }
 
 /**
@@ -250,6 +288,29 @@ export function diffContracts(installer, workflow) {
     problems.push(
       `install.sh downloads checksums as '${installer.checksumsFile}' but release.yml publishes ` +
         `'${workflow.checksumsFile}'`,
+    );
+  }
+  if (installer.payloadAsset !== workflow.payloadAsset) {
+    problems.push(
+      `install.sh downloads the shipped-asset payload as '${installer.payloadAsset}' but release.yml ` +
+        `publishes '${workflow.payloadAsset}' (#4163) — the installer would 404 and the host would end ` +
+        "up with a CLI that cannot scaffold",
+    );
+  }
+  // The payload is built once, in the bundle job, not per-platform: it is
+  // architecture-independent text. If it ever appears in the per-platform
+  // matrix or in RELEASE_ASSETS, four jobs race to upload the same name.
+  if (workflow.matrixAssets.includes(workflow.payloadAsset)) {
+    problems.push(
+      `release.yml lists the payload '${workflow.payloadAsset}' in the per-platform build matrix; it is ` +
+        "architecture-independent and must be built once in the bundle job",
+    );
+  }
+  if (workflow.declaredAssets.includes(workflow.payloadAsset)) {
+    problems.push(
+      `release.yml lists the payload '${workflow.payloadAsset}' in env.RELEASE_ASSETS, which is the set of ` +
+        "per-platform binaries downloaded from the build matrix's artifacts — the payload is produced " +
+        "in the bundle job instead",
     );
   }
   if (new Set(workflow.matrixAssets).size !== workflow.matrixAssets.length) {

--- a/scripts/verify-release-bundle.mjs
+++ b/scripts/verify-release-bundle.mjs
@@ -45,7 +45,10 @@ try {
 }
 
 const problems = [];
-const expected = new Set([...installer.assets, installer.checksumsFile]);
+const expected = new Set([...installer.assets, installer.checksumsFile, installer.payloadAsset]);
+// Everything the installer downloads AND verifies against the checksums file.
+// The checksums file itself is the trust root and cannot check itself.
+const checksummed = [...installer.assets, installer.payloadAsset];
 
 let present;
 try {
@@ -70,7 +73,7 @@ for (const name of present) {
 // Checksum-line shape + correctness, exactly as install.sh consumes it.
 if (present.includes(installer.checksumsFile)) {
   const lines = readFileSync(join(dir, installer.checksumsFile), "utf-8").split("\n");
-  for (const asset of installer.assets) {
+  for (const asset of checksummed) {
     if (!present.includes(asset)) continue;
     // install.sh: grep -F "  ${asset}" | awk '{print $1}' | head -n 1
     const needle = `${CHECKSUM_SEPARATOR}${asset}`;
@@ -96,5 +99,8 @@ if (problems.length > 0) {
   process.exit(1);
 }
 
-console.log(`OK release bundle at ${dir}: ${installer.assets.length} assets + ${installer.checksumsFile}`);
-for (const asset of installer.assets) console.log(`   ${asset}`);
+console.log(
+  `OK release bundle at ${dir}: ${installer.assets.length} binaries + ` +
+    `${installer.payloadAsset} + ${installer.checksumsFile}`,
+);
+for (const asset of checksummed) console.log(`   ${asset}`);

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -43,8 +43,13 @@ import {
 } from "./generation-stamp.js";
 import { VERSION as SWITCHROOM_VERSION } from "../build-info.js";
 
-// Repo root for referencing bin/ scripts in hooks
-const REPO_ROOT = resolve(import.meta.dirname, "../..");
+// (There is deliberately no REPO_ROOT here any more. It was
+// `resolve(import.meta.dirname, "../..")` feeding a `repoRoot` template
+// variable used by exactly one line of start.sh.hbs — a HOST path baked into a
+// script that only ever runs INSIDE the agent container, so it never resolved
+// to anything real; under the compiled binary it rendered as `//`. Scripts the
+// container needs come from DOCKER_BIN_PATH; assets the host CLI needs come
+// from resolveShippedAsset(). #4163.)
 
 // Switchroom #3757 / #3760 — mirrors of the hindsight plugin's own DEFAULTS
 // (`vendor/hindsight-memory/scripts/lib/config.py`). These exist because the
@@ -4037,7 +4042,6 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     // HOST path, not the in-container /host-home, when apply runs inside hostd.
     // See toHostHomePath. The filesystem writes elsewhere keep the local value.
     agentDir: toHostHomePath(agentDir),
-    repoRoot: REPO_ROOT,
     topicId,
     topicName: agentConfig.topic_name,
     topicEmoji: agentConfig.topic_emoji,
@@ -7711,7 +7715,6 @@ function reconcileAgentInner(
       // when reconcile (apply) runs inside hostd. See toHostHomePath. startShPath
       // above and the FS writes below keep the local container-relative value.
       agentDir: toHostHomePath(agentDir),
-      repoRoot: REPO_ROOT,
       botToken: resolvedBotToken ?? rawBotToken,
       forumChatId: telegramConfig.forum_chat_id,
       dangerousMode: agentConfig.dangerous_mode === true,

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -23,13 +23,11 @@ import { describeKeyBudget, resolveKeyBudget } from "../litellm/budget.js";
 import { mkdir } from "node:fs/promises";
 import { spawnSync as childSpawnSync } from "node:child_process";
 import readline from "node:readline";
-// Embed example configs as text imports so they survive `bun build --compile`.
-// `import.meta.dirname` resolves to `/$bunfs/root` inside a compiled binary,
-// which means resolve(import.meta.dirname, "../../examples/...") points at a
-// path that doesn't exist on the host — apply --example would fail with
-// ENOENT. Text imports are bundled into the binary at compile time.
-import switchroomExample from "../../examples/switchroom.yaml" with { type: "text" };
-import minimalExample from "../../examples/minimal.yaml" with { type: "text" };
+// Example configs are EMBEDDED in the binary (text imports), never read from
+// disk: `import.meta.dirname` is the bunfs virtual root under `bun build
+// --compile`, so a disk read resolves to `/examples/…` and ENOENTs. The module
+// is shared with `switchroom setup`, which had the identical bug (#4163).
+import { exampleNames, readEmbeddedExample } from "./embedded-examples.js";
 import {
   reloadAuthBroker,
   reloadVaultBroker,
@@ -38,12 +36,6 @@ import {
   VAULT_BROKER_CONTAINER,
   type BrokerReloadResult,
 } from "./broker-reload.js";
-
-/** Embedded example configs, keyed by name. Mirrors files under examples/. */
-const EMBEDDED_EXAMPLES: Record<string, string> = {
-  switchroom: switchroomExample,
-  minimal: minimalExample,
-};
 import { dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { execFileSync } from "node:child_process";
@@ -67,6 +59,7 @@ import {
   ConfigError,
 } from "../config/loader.js";
 import { scaffoldAgent, alignAgentUid, renderFleetInvariants, toHostHomePath, flushPendingBankOps } from "../agents/scaffold.js";
+import { bootstrapBundledSkillsPool } from "./bootstrap-skills-pool.js";
 import {
   getGrantsDbDir,
   getGrantsDbPath,
@@ -1795,6 +1788,21 @@ export async function runApply(
     }
   };
 
+  // Seed the bundled-skills pool if this host has never run `switchroom
+  // update` (#4163). Without it the FIRST apply after a `curl … | sh` install
+  // scaffolds every agent against an empty pool and skips every bundled skill.
+  // Bootstrap-only and soft-failing — see bootstrap-skills-pool.ts.
+  if (options.composeOnly !== true) {
+    const seed = bootstrapBundledSkillsPool();
+    if (seed.status === "seeded") {
+      writeOut(
+        chalk.gray(
+          `  Seeded bundled skills pool (${seed.skills} skills) from ${seed.source}\n`,
+        ),
+      );
+    }
+  }
+
   // ── 1. Scaffold each agent ────────────────────────────────────────
   let scaffolded = 0;
   const failures: ScaffoldFailure[] = [];
@@ -2583,27 +2591,18 @@ function copyExampleConfig(name: string): void {
     return;
   }
 
-  // Prefer embedded examples (works under both `bun run` and `bun build
-  // --compile`). Fall back to disk lookup so contributors can add new
-  // examples in-tree without rebuilding — only relevant in dev because
-  // the compiled binary's `import.meta.dirname` is the bunfs virtual root.
-  const embedded = EMBEDDED_EXAMPLES[name];
-  if (embedded !== undefined) {
-    writeFileSync(dest, embedded, { encoding: "utf8" });
-    console.log(chalk.green(`Copied ${name}.yaml -> switchroom.yaml`));
-    return;
-  }
-
-  const exampleFile = resolve(
-    import.meta.dirname,
-    `../../examples/${name}.yaml`,
-  );
-  if (!existsSync(exampleFile)) {
+  // Embedded, with no disk fallback. The old fallback read
+  // `resolve(import.meta.dirname, "../../examples/…")`, which is `/examples/…`
+  // inside the compiled binary — it could only ever succeed in a source
+  // checkout, so it made dev and release behave differently on the one path
+  // where that difference is invisible until a user hits it (#4163).
+  const embedded = readEmbeddedExample(name);
+  if (embedded === null) {
     throw new Error(
-      `Example config not found: ${name}.yaml (available: ${Object.keys(EMBEDDED_EXAMPLES).join(", ")})`,
+      `Example config not found: ${name}.yaml (available: ${exampleNames().join(", ")})`,
     );
   }
-  copyFileSync(exampleFile, dest);
+  writeFileSync(dest, embedded, { encoding: "utf8" });
   console.log(chalk.green(`Copied ${name}.yaml -> switchroom.yaml`));
 }
 

--- a/src/cli/bootstrap-skills-pool.test.ts
+++ b/src/cli/bootstrap-skills-pool.test.ts
@@ -1,0 +1,74 @@
+/**
+ * #4163: the first `switchroom apply` on a `curl … | sh` host must not
+ * scaffold agents against an empty bundled-skills pool.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { bootstrapBundledSkillsPool } from "./bootstrap-skills-pool.js";
+import { BUNDLED_SKILL_MANIFEST_NAME } from "./sync-bundled-skills.js";
+
+let tmp: string;
+let shareRoot: string;
+let poolDir: string;
+
+/** A minimal SEA layout: `<prefix>/bin/switchroom` + `<prefix>/share/switchroom/skills`. */
+function seaProbe(): { bundleDir: string; execPath: string; env: NodeJS.ProcessEnv } {
+  return {
+    bundleDir: "/$bunfs/root",
+    execPath: join(tmp, "usr", "local", "bin", "switchroom"),
+    env: {},
+  };
+}
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "sr-pool-"));
+  shareRoot = join(tmp, "usr", "local", "share", "switchroom");
+  poolDir = join(tmp, "home", ".switchroom", "skills", "_bundled");
+  for (const name of ["file-bug", "humanizer"]) {
+    mkdirSync(join(shareRoot, "skills", name), { recursive: true });
+    writeFileSync(join(shareRoot, "skills", name, "SKILL.md"), `# ${name}\n`);
+  }
+});
+
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+describe("bootstrapBundledSkillsPool", () => {
+  it("populates an ABSENT pool from the shipped payload", () => {
+    const r = bootstrapBundledSkillsPool({ poolDir, probe: seaProbe(), version: "0.19.44" });
+    expect(r.status).toBe("seeded");
+    // The outcome that matters is the skill being READABLE at the path
+    // scaffold looks in — not merely that the function returned.
+    expect(readFileSync(join(poolDir, "file-bug", "SKILL.md"), "utf8")).toContain("file-bug");
+    expect(existsSync(join(poolDir, "humanizer", "SKILL.md"))).toBe(true);
+  });
+
+  it("writes the same ownership manifest `switchroom update` writes", () => {
+    // Otherwise the next `update` sees a manifest-less pool, adopts every dir
+    // as operator-owned, and can never retire a skill it shipped.
+    bootstrapBundledSkillsPool({ poolDir, probe: seaProbe(), version: "0.19.44" });
+    const m = JSON.parse(readFileSync(join(poolDir, BUNDLED_SKILL_MANIFEST_NAME), "utf8"));
+    expect(m.version).toBe("0.19.44");
+    expect(m.skills.sort()).toEqual(["file-bug", "humanizer"]);
+  });
+
+  it("does NOT touch an existing pool — `switchroom update` owns it", () => {
+    mkdirSync(join(poolDir, "hand-added"), { recursive: true });
+    writeFileSync(join(poolDir, "hand-added", "SKILL.md"), "operator's own\n");
+    const r = bootstrapBundledSkillsPool({ poolDir, probe: seaProbe(), version: "0.19.44" });
+    expect(r.status).toBe("exists");
+    expect(readFileSync(join(poolDir, "hand-added", "SKILL.md"), "utf8")).toBe("operator's own\n");
+    // …and nothing was copied in behind the operator's back.
+    expect(existsSync(join(poolDir, "file-bug"))).toBe(false);
+  });
+
+  it("reports no-payload (and does not throw) when nothing ships skills/", () => {
+    rmSync(join(shareRoot, "skills"), { recursive: true, force: true });
+    const r = bootstrapBundledSkillsPool({ poolDir, probe: seaProbe(), version: "0.19.44" });
+    expect(r.status).toBe("no-payload");
+    // apply must still proceed: the pool is simply absent, as before.
+    expect(existsSync(poolDir)).toBe(false);
+  });
+});

--- a/src/cli/bootstrap-skills-pool.ts
+++ b/src/cli/bootstrap-skills-pool.ts
@@ -1,0 +1,93 @@
+/**
+ * Seed `~/.switchroom/skills/_bundled/` from the shipped `skills/` payload
+ * when the pool does not exist yet (#4163).
+ *
+ * The pool is populated by the `sync-bundled-skills` step of `switchroom
+ * update`. On a host that has only ever run `curl -fsSL … | sh`, that step has
+ * never run, so the FIRST `switchroom apply` scaffolds every agent against an
+ * empty pool: `installSwitchroomSkills` and `reconcileAgentDefaultSkills` each
+ * print "bundled skills pool dir not found … run `switchroom update`" and skip
+ * every skill. Observed end-to-end on a fresh Debian container: 10 skills
+ * skipped on the only agent in the example config. Hand-syncing the pool was
+ * the operator stopgap this issue exists to remove.
+ *
+ * Deliberately BOOTSTRAP-ONLY: this runs iff the pool directory is absent.
+ * Once it exists, `switchroom update` owns it — its manifest tracks which
+ * names switchroom shipped so it can retire them without wiping hand-added
+ * skills, and apply must not race that ownership model. The sync itself is the
+ * same additive, manifest-writing `syncBundledSkills`, so the pool apply
+ * creates is indistinguishable from the one update would have created.
+ *
+ * Soft-fails: a missing payload (source checkout, unusual layout) or a copy
+ * error must not fail `apply`. The pre-existing per-skill warnings still fire
+ * downstream, which is exactly the behaviour before this module existed.
+ */
+
+import { existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { SKILLS_ASSET, resolveShippedAsset, type ShippedAssetProbe } from "../util/shipped-assets.js";
+import { SWITCHROOM_VERSION } from "./resolve-version.js";
+import { syncBundledSkills } from "./sync-bundled-skills.js";
+
+export interface BootstrapSkillsPoolOptions {
+  /** Pool dir. Defaults to `~/.switchroom/skills/_bundled`. */
+  poolDir?: string;
+  /** Asset probe. Defaults to the running bundle / executable. */
+  probe?: ShippedAssetProbe;
+  /** Version stamped into the pool manifest. */
+  version?: string;
+  /** Diagnostics sink. Defaults to stderr. */
+  warn?: (msg: string) => void;
+}
+
+export type BootstrapSkillsPoolResult =
+  /** Pool already present — update owns it from here. */
+  | { status: "exists"; poolDir: string }
+  /** Pool created and populated from the shipped payload. */
+  | { status: "seeded"; poolDir: string; source: string; skills: number }
+  /** No shipped skills/ payload could be resolved. */
+  | { status: "no-payload"; poolDir: string; candidates: readonly string[] }
+  /** The copy failed. Apply continues; downstream warnings still fire. */
+  | { status: "failed"; poolDir: string; error: string };
+
+export function bootstrapBundledSkillsPool(
+  opts: BootstrapSkillsPoolOptions = {},
+): BootstrapSkillsPoolResult {
+  const poolDir = opts.poolDir ?? join(homedir(), ".switchroom", "skills", "_bundled");
+  const warn = opts.warn ?? ((m: string) => process.stderr.write(`${m}\n`));
+
+  if (existsSync(poolDir)) return { status: "exists", poolDir };
+
+  const resolution = resolveShippedAsset(
+    SKILLS_ASSET,
+    opts.probe ?? { bundleDir: import.meta.dirname, execPath: process.execPath },
+  );
+  if (resolution.path === null) {
+    return { status: "no-payload", poolDir, candidates: resolution.candidates };
+  }
+
+  try {
+    mkdirSync(dirname(poolDir), { recursive: true });
+    const r = syncBundledSkills({
+      source: resolution.path,
+      dest: poolDir,
+      version: opts.version ?? SWITCHROOM_VERSION,
+    });
+    return {
+      status: "seeded",
+      poolDir,
+      source: resolution.path,
+      skills: r.added.length + r.updated.length,
+    };
+  } catch (err) {
+    const error = (err as Error).message;
+    warn(
+      `switchroom: could not seed the bundled skills pool at ${poolDir} from ` +
+        `${resolution.path} (${error}) — agents will scaffold without bundled ` +
+        `skills. Run \`switchroom update\` to repair.`,
+    );
+    return { status: "failed", poolDir, error };
+  }
+}

--- a/src/cli/doctor-asset-payload.test.ts
+++ b/src/cli/doctor-asset-payload.test.ts
@@ -1,0 +1,98 @@
+/**
+ * `switchroom doctor` × the shipped-asset payload (#4163).
+ *
+ * The outcomes that matter: a static-binary install with a missing or skewed
+ * payload goes RED (it cannot scaffold, or scaffolds from the wrong release),
+ * and a contributor's checkout does NOT — the assets are inside the package
+ * there and there is no payload to verify.
+ */
+
+import { describe, it, expect } from "vitest";
+import { runAssetPayloadChecks } from "./doctor-asset-payload.js";
+
+const BUNFS = "/$bunfs/root";
+const SEA = { bundleDir: BUNFS, execPath: "/usr/local/bin/switchroom", env: {} };
+const SHARE = "/usr/local/share/switchroom";
+
+describe("runAssetPayloadChecks", () => {
+  it("is OK when the payload matches the running CLI", () => {
+    const [r] = runAssetPayloadChecks({
+      cliVersion: "0.19.44",
+      probe: { ...SEA, exists: (p) => p.startsWith(SHARE) },
+      readText: () => '{"version":"v0.19.44"}',
+    });
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("v0.19.44");
+  });
+
+  it("FAILS on skew — the failure that otherwise looks like a working install", () => {
+    const [r] = runAssetPayloadChecks({
+      cliVersion: "0.19.44",
+      probe: { ...SEA, exists: (p) => p.startsWith(SHARE) },
+      readText: () => '{"version":"v0.19.28"}',
+    });
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("v0.19.28");
+    expect(r.fix).toBe("switchroom update");
+  });
+
+  it("FAILS when nothing was installed at all", () => {
+    const [r] = runAssetPayloadChecks({
+      cliVersion: "0.19.44",
+      probe: { ...SEA, exists: () => false },
+    });
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("no shipped-asset payload");
+    expect(r.fix).toBe("switchroom update");
+  });
+
+  it("FAILS when the manifest is unreadable rather than assuming agreement", () => {
+    const [r] = runAssetPayloadChecks({
+      cliVersion: "0.19.44",
+      probe: { ...SEA, exists: (p) => p.startsWith(SHARE) },
+      readText: () => "{ truncated",
+    });
+    expect(r.status).toBe("fail");
+  });
+
+  it("SKIPS for an npm/dev install — assets ship inside the package, no manifest", () => {
+    // Getting this wrong would leave doctor permanently red for every
+    // contributor, which is how a check stops being read.
+    const [r] = runAssetPayloadChecks({
+      cliVersion: "0.19.44",
+      probe: {
+        bundleDir: "/srv/switchroom/dist/cli",
+        execPath: "/usr/bin/node",
+        env: {},
+        exists: (p) => p === "/srv/switchroom/profiles",
+      },
+    });
+    expect(r.status).toBe("skip");
+    expect(r.detail).toContain("/srv/switchroom/profiles");
+  });
+
+  it("SKIPS inside the agent/hostd Docker image", () => {
+    const [r] = runAssetPayloadChecks({
+      cliVersion: "0.19.44",
+      probe: {
+        bundleDir: "/opt/switchroom",
+        execPath: "/usr/bin/node",
+        env: {},
+        exists: (p) => p === "/opt/switchroom/profiles",
+      },
+    });
+    expect(r.status).toBe("skip");
+  });
+
+  it("SKIPS when an operator has pointed SWITCHROOM_PROFILES_ROOT somewhere", () => {
+    const [r] = runAssetPayloadChecks({
+      cliVersion: "0.19.44",
+      probe: {
+        ...SEA,
+        env: { SWITCHROOM_PROFILES_ROOT: "/srv/custom/profiles" },
+        exists: () => false,
+      },
+    });
+    expect(r.status).toBe("skip");
+  });
+});

--- a/src/cli/doctor-asset-payload.ts
+++ b/src/cli/doctor-asset-payload.ts
@@ -1,0 +1,99 @@
+/**
+ * `switchroom doctor` section: the shipped-asset payload (#4163).
+ *
+ * A `bun build --compile` binary embeds only the JS bundle. `profiles/`,
+ * `skills/`, `vendor/hindsight-memory/` and the web `ui/` are NOT in it, so a
+ * `curl … | sh` install fetches them as a separate release artifact and stages
+ * them at `<prefix>/share/switchroom`. Two failure modes follow, and both are
+ * silent without a check:
+ *
+ *   MISSING   — no payload at all. `switchroom apply` dies with "Profile not
+ *               found: default (searched …)" and `sync-bundled-skills` used to
+ *               no-op while still reporting success (#4160/#4161).
+ *   SKEWED    — payload from a different release than the running CLI. This is
+ *               the WORSE one: everything appears to work while agents are
+ *               scaffolded from templates the CLI no longer matches. It cannot
+ *               arise from `switchroom update` (the payload is installed first,
+ *               from the same tag, and repaired on every run — see
+ *               `installAssetPayload`), so seeing it here means something
+ *               outside that path touched the share directory.
+ *
+ * Scope: this only applies to installs whose assets come from an on-disk
+ * payload. An npm/dev checkout and the Docker images ship the directories
+ * inside the package/image and carry no manifest, so a missing manifest there
+ * is normal, not a finding — hence the `skip` when the payload layout is not in
+ * use. Getting that wrong would turn doctor permanently amber for every
+ * contributor.
+ */
+
+import type { CheckResult } from "./doctor.js";
+import { SWITCHROOM_VERSION } from "./resolve-version.js";
+import {
+  PROFILES_ASSET,
+  assetPayloadSkew,
+  resolveShippedAsset,
+  type ShippedAssetProbe,
+} from "../util/shipped-assets.js";
+
+export interface AssetPayloadCheckOpts {
+  /** Test seam — the layout to probe. Defaults to this process's. */
+  probe?: ShippedAssetProbe;
+  /** Test seam — override the running CLI's version. */
+  cliVersion?: string;
+  /** Test seam — manifest reader. */
+  readText?: (path: string) => string | null;
+}
+
+export function runAssetPayloadChecks(
+  opts: AssetPayloadCheckOpts = {},
+): CheckResult[] {
+  const probe: ShippedAssetProbe = opts.probe ?? {
+    bundleDir: import.meta.dirname,
+    execPath: process.execPath,
+  };
+  const cliVersion = opts.cliVersion ?? SWITCHROOM_VERSION;
+
+  // Which layout is actually serving assets right now? `profiles/` is the
+  // representative asset — it is the one `apply` cannot proceed without.
+  const profiles = resolveShippedAsset(PROFILES_ASSET, probe);
+  const bundled =
+    profiles.source === "npm" ||
+    profiles.source === "image" ||
+    profiles.source === "env";
+  if (bundled) {
+    return [
+      {
+        name: "shipped-asset payload",
+        status: "skip",
+        detail:
+          `assets are bundled with this install (${profiles.source}: ` +
+          `${profiles.path}) — no separate payload to verify`,
+      },
+    ];
+  }
+
+  const skew = assetPayloadSkew({ cliVersion, probe, readText: opts.readText });
+  if (skew.status === "matched") {
+    return [
+      {
+        name: "shipped-asset payload",
+        status: "ok",
+        detail: `${skew.payloadVersion} at ${skew.manifestPath}`,
+      },
+    ];
+  }
+
+  // Every remaining status is a fail. A CLI that cannot scaffold, or that
+  // scaffolds from templates of another release, is a broken install — not a
+  // "worth a look" warning. `switchroom update` is the in-band repair for all
+  // three, because it reinstalls the payload for the running release even when
+  // the binary itself is already current.
+  return [
+    {
+      name: "shipped-asset payload",
+      status: "fail",
+      detail: skew.message,
+      fix: "switchroom update",
+    },
+  ];
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -73,6 +73,7 @@ import { runCronSessionChecks } from "./doctor-cron-session.js";
 import { runFloodPressureChecks } from "./doctor-flood-pressure.js";
 import { runGeneratedSurfaceDriftChecks } from "./doctor-drift.js";
 import { runComponentVersionChecks } from "./doctor-component-versions.js";
+import { runAssetPayloadChecks } from "./doctor-asset-payload.js";
 import { runMicrosoftChecks } from "./doctor-microsoft.js";
 import { runNotionChecks } from "./doctor-notion.js";
 import { runMcpSecretChecks } from "./doctor-mcp-secrets.js";
@@ -4237,6 +4238,26 @@ export function registerDoctorCommand(program: Command): void {
                 return [
                   {
                     name: "component versions",
+                    status: "skip",
+                    detail: `not checkable: ${(err as Error)?.message ?? String(err)}`,
+                  },
+                ];
+              }
+            })(),
+          },
+          {
+            // #4163: a static-binary install carries profiles/skills/vendor
+            // in a SEPARATE release artifact. Missing → apply cannot scaffold
+            // at all; skewed → it scaffolds happily from another release's
+            // templates, which is the silent one. See doctor-asset-payload.
+            title: "Shipped-asset payload (#4163)",
+            results: ((): CheckResult[] => {
+              try {
+                return runAssetPayloadChecks();
+              } catch (err) {
+                return [
+                  {
+                    name: "shipped-asset payload",
                     status: "skip",
                     detail: `not checkable: ${(err as Error)?.message ?? String(err)}`,
                   },

--- a/src/cli/embedded-examples.test.ts
+++ b/src/cli/embedded-examples.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Example configs are EMBEDDED, never read from disk (#4163).
+ *
+ * `switchroom setup` is the first thing a `curl … | sh` user runs, and its
+ * bootstrap read `examples/switchroom.yaml` relative to `import.meta.dirname`
+ * — which inside a `bun build --compile` binary is the bunfs root, so the read
+ * resolved to `/examples/switchroom.yaml` and setup died with "Example config
+ * not found" on every static-binary install. `apply --example` had already
+ * been fixed by embedding; `setup` had not, because the two kept their own
+ * copies of the lookup.
+ *
+ * These assert the embedding is real and COMPLETE — that no example file can
+ * exist on disk without an embedded counterpart — because a partial embedding
+ * fails exactly the same way, just for one example instead of all of them.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { parse } from "yaml";
+
+import {
+  DEFAULT_EXAMPLE,
+  EMBEDDED_EXAMPLES,
+  exampleNames,
+  readEmbeddedExample,
+} from "./embedded-examples.js";
+
+const EXAMPLES_DIR = join(import.meta.dirname, "..", "..", "examples");
+
+describe("embedded examples", () => {
+  it("embeds EVERY examples/*.yaml in the repo", () => {
+    // The failure this catches: someone adds examples/foo.yaml, wires it into
+    // the `--example` help text, and it works in dev (disk) but 'not found' in
+    // the release binary.
+    const onDisk = readdirSync(EXAMPLES_DIR)
+      .filter((f) => f.endsWith(".yaml"))
+      .map((f) => f.replace(/\.yaml$/, ""))
+      .sort();
+    expect(exampleNames().sort()).toEqual(onDisk);
+  });
+
+  it("names an example that exists on disk for every embedded key", () => {
+    // The CONTENT cannot be asserted here: vitest does not implement the
+    // `with { type: "text" }` import attribute and hands back the module path
+    // instead of the file body. Both real build paths (`bun build` for the npm
+    // bundle, `bun build --compile` for the released binary) inline it, and
+    // that is covered end-to-end by tests/install/static-binary.test.ts, which
+    // compiles a real binary and reads the config it writes.
+    for (const name of exampleNames()) {
+      const onDisk = readFileSync(join(EXAMPLES_DIR, `${name}.yaml`), "utf8");
+      const doc = parse(onDisk) as { agents?: unknown };
+      expect(doc.agents, `${name}.yaml must be a usable config`).toBeDefined();
+    }
+  });
+
+  it("the default example is one of the embedded ones", () => {
+    expect(EMBEDDED_EXAMPLES[DEFAULT_EXAMPLE]).toBeDefined();
+  });
+
+  it("returns null for an unknown name instead of falling back to disk", () => {
+    expect(readEmbeddedExample("nope")).toBeNull();
+    // …and specifically does not resolve a real file by another route.
+    expect(readEmbeddedExample("../examples/switchroom")).toBeNull();
+  });
+});

--- a/src/cli/embedded-examples.ts
+++ b/src/cli/embedded-examples.ts
@@ -1,0 +1,47 @@
+/**
+ * Example switchroom.yaml configs, EMBEDDED IN THE BINARY.
+ *
+ * `import.meta.dirname` resolves to `/$bunfs/root` inside a `bun build
+ * --compile` artifact, so `resolve(import.meta.dirname, "../../examples/…")`
+ * points at `/examples/…` on the host — a path that does not exist. `apply
+ * --example` was fixed by embedding the YAML as `with { type: "text" }`
+ * imports; `setup`'s bootstrap path (`copyExampleConfig`) still read from disk
+ * and therefore died with "Example config not found" on any static-binary
+ * install, which is the first thing a `curl | sh` user runs (#4163).
+ *
+ * These live here, in one module, rather than in `apply.ts`, so there is
+ * exactly one answer to "where do the examples come from" and a second call
+ * site cannot re-introduce the disk read. They are deliberately NOT part of the
+ * shipped-asset payload (scripts/build-asset-payload.mjs): text imports are
+ * compiled in, and shipping a payload directory nothing reads is how a payload
+ * silently rots.
+ */
+
+import switchroomExample from "../../examples/switchroom.yaml" with { type: "text" };
+import minimalExample from "../../examples/minimal.yaml" with { type: "text" };
+
+/** Embedded example configs, keyed by name. Mirrors files under examples/. */
+export const EMBEDDED_EXAMPLES: Record<string, string> = {
+  switchroom: switchroomExample,
+  minimal: minimalExample,
+};
+
+/** The example `switchroom setup --non-interactive` bootstraps from. */
+export const DEFAULT_EXAMPLE = "switchroom";
+
+/** Names available to `--example` / the setup prompt, in stable order. */
+export function exampleNames(): string[] {
+  return Object.keys(EMBEDDED_EXAMPLES);
+}
+
+/**
+ * The YAML for `name`, or `null` if there is no such example.
+ *
+ * Returns the embedded copy. There is no disk fallback: a contributor adding
+ * `examples/foo.yaml` adds it here too, and that is a compile-time edit rather
+ * than a runtime probe that behaves differently in dev and in the release
+ * binary — which is exactly the divergence that hid this bug.
+ */
+export function readEmbeddedExample(name: string): string | null {
+  return EMBEDDED_EXAMPLES[name] ?? null;
+}

--- a/src/cli/self-update-io.ts
+++ b/src/cli/self-update-io.ts
@@ -14,11 +14,15 @@ import {
   copyFileSync,
   createWriteStream,
   existsSync,
+  lstatSync,
   mkdirSync,
   openSync,
+  readdirSync,
+  readFileSync,
   readSync,
   renameSync,
   rmSync,
+  symlinkSync,
 } from "node:fs";
 import { dirname } from "node:path";
 import { Readable } from "node:stream";
@@ -107,6 +111,50 @@ export function defaultSelfUpdateIO(): SelfUpdateIO {
     },
     dirname(path) {
       return dirname(path);
+    },
+    readText(path) {
+      try {
+        return readFileSync(path, "utf-8");
+      } catch {
+        return null;
+      }
+    },
+    extractTarGz(archive, destDir) {
+      mkdirSync(destDir, { recursive: true });
+      // `tar` rather than a JS tar library: it is present in the base system
+      // on every platform the static binary ships for (GNU tar on Linux,
+      // bsdtar on macOS), and pulling a runtime dependency into the compiled
+      // binary for one call site is the worse trade.
+      const r = spawnSync("tar", ["-xzf", archive, "-C", destDir], {
+        encoding: "utf-8",
+        timeout: 300_000,
+      });
+      if (r.error) throw r.error;
+      if (r.status !== 0) {
+        throw new Error(
+          `tar -xzf exited ${r.status}: ${(r.stderr ?? "").trim() || "no stderr"}`,
+        );
+      }
+    },
+    symlink(target, linkPath) {
+      symlinkSync(target, linkPath);
+    },
+    isSymlink(path) {
+      try {
+        return lstatSync(path).isSymbolicLink();
+      } catch {
+        return false;
+      }
+    },
+    removeTree(path) {
+      rmSync(path, { recursive: true, force: true });
+    },
+    listDir(dir) {
+      try {
+        return readdirSync(dir);
+      } catch {
+        return [];
+      }
     },
   };
 }

--- a/src/cli/self-update.test.ts
+++ b/src/cli/self-update.test.ts
@@ -2,11 +2,15 @@ import { describe, it, expect } from "vitest";
 
 import {
   alreadySelfUpdated,
+  ASSET_PAYLOAD_ASSET_NAME,
   detectInstallKind,
   expectedChecksum,
+  installAssetPayload,
   parseLatestReleaseTag,
+  payloadVersionDir,
   performSelfUpdate,
   planSelfUpdate,
+  readPayloadVersion,
   releaseAssetName,
   rollbackHint,
   versionStorePath,
@@ -177,36 +181,125 @@ describe("alreadySelfUpdated", () => {
 
 const GOOD_SHA = "d".repeat(64);
 
+/**
+ * An in-memory filesystem carrying the two things the shipped-asset payload
+ * (#4163) actually depends on: SYMLINKS (the publish step is a rename over a
+ * link) and DIRECTORY renames (the extract-then-publish split). Modelling
+ * those as flat string keys would let the ordering tests pass over code that
+ * could not work on a real filesystem.
+ */
 function makeIO(overrides: Partial<SelfUpdateIO> = {}) {
   const files = new Map<string, string>([
     ["/usr/local/bin/switchroom", "OLD-BINARY"],
   ]);
   const dirs = new Set<string>(["/usr/local/bin"]);
+  /** linkPath -> target (relative, as installAssetPayload writes it). */
+  const links = new Map<string, string>();
+  const dirnameOf = (p: string) => p.slice(0, p.lastIndexOf("/")) || "/";
+
+  /** Resolve one level of symlink on `p` or on any of its parents. */
+  function realpath(p: string): string {
+    for (const [link, target] of links) {
+      if (p === link) return `${dirnameOf(link)}/${target}`;
+      if (p.startsWith(`${link}/`)) {
+        return `${dirnameOf(link)}/${target}${p.slice(link.length)}`;
+      }
+    }
+    return p;
+  }
+  function removeTree(p: string) {
+    links.delete(p);
+    files.delete(p);
+    for (const k of [...files.keys()]) if (k.startsWith(`${p}/`)) files.delete(k);
+    for (const k of [...links.keys()]) if (k.startsWith(`${p}/`)) links.delete(k);
+    for (const k of [...dirs]) if (k === p || k.startsWith(`${p}/`)) dirs.delete(k);
+  }
+
   const io: SelfUpdateIO = {
     async httpGetText(url) {
       if (url.endsWith("switchroom-checksums.txt")) {
-        return `${GOOD_SHA}  switchroom-linux-amd64\n`;
+        return (
+          `${GOOD_SHA}  switchroom-linux-amd64\n` +
+          `${GOOD_SHA}  ${ASSET_PAYLOAD_ASSET_NAME}\n`
+        );
       }
       return '{"tag_name":"v0.19.28"}';
     },
-    async httpDownload(_url, dest) {
+    async httpDownload(url, dest) {
+      // The payload archive carries the tag it was fetched for, so
+      // extractTarGz can unpack a manifest that matches it — or, in the
+      // negative tests, deliberately does not.
+      if (url.endsWith(ASSET_PAYLOAD_ASSET_NAME)) {
+        const tag = url.split("/download/")[1]?.split("/")[0] ?? "v0.0.0";
+        files.set(dest, `PAYLOAD:${tag}`);
+        return;
+      }
       files.set(dest, "NEW-BINARY");
     },
     sha256File: () => GOOD_SHA,
     probeBinaryVersion: () => "0.19.28",
     mkdirp: (d) => void dirs.add(d),
-    copyFile: (src, dest) => void files.set(dest, files.get(src) ?? ""),
+    copyFile: (src, dest) => void files.set(dest, files.get(realpath(src)) ?? ""),
     chmodExec: () => {},
     rename: (src, dest) => {
-      files.set(dest, files.get(src) ?? "");
-      files.delete(src);
+      // A file, a symlink, or a whole subtree — the payload publish step uses
+      // all three shapes.
+      if (links.has(src)) {
+        links.set(dest, links.get(src) as string);
+        links.delete(src);
+        files.delete(dest);
+        return;
+      }
+      if (files.has(src)) {
+        files.set(dest, files.get(src) as string);
+        files.delete(src);
+        return;
+      }
+      for (const k of [...files.keys()]) {
+        if (k.startsWith(`${src}/`)) {
+          files.set(`${dest}${k.slice(src.length)}`, files.get(k) as string);
+          files.delete(k);
+        }
+      }
+      dirs.add(dest);
+      dirs.delete(src);
     },
-    remove: (p) => void files.delete(p),
-    exists: (p) => files.has(p),
-    dirname: (p) => p.slice(0, p.lastIndexOf("/")) || "/",
+    remove: (p) => {
+      files.delete(p);
+      links.delete(p);
+    },
+    exists: (p) =>
+      files.has(p) ||
+      links.has(p) ||
+      dirs.has(p) ||
+      [...files.keys()].some((k) => k.startsWith(`${p}/`)),
+    dirname: dirnameOf,
+    readText: (p) => files.get(realpath(p)) ?? null,
+    extractTarGz: (archive, destDir) => {
+      const body = files.get(archive);
+      if (body === undefined) throw new Error(`no such archive: ${archive}`);
+      const tag = body.startsWith("PAYLOAD:") ? body.slice("PAYLOAD:".length) : "v0.0.0";
+      dirs.add(destDir);
+      files.set(
+        `${destDir}/switchroom-assets.json`,
+        JSON.stringify({ version: tag, entries: ["profiles", "skills"] }),
+      );
+      files.set(`${destDir}/profiles/_base/start.sh.hbs`, "#!/bin/sh\n");
+    },
+    symlink: (target, linkPath) => void links.set(linkPath, target),
+    isSymlink: (p) => links.has(p),
+    removeTree,
+    listDir: (dir) => {
+      const out = new Set<string>();
+      for (const k of [...files.keys(), ...links.keys(), ...dirs]) {
+        if (!k.startsWith(`${dir}/`)) continue;
+        out.add(k.slice(dir.length + 1).split("/")[0]);
+      }
+      return [...out];
+    },
     ...overrides,
   };
-  return { io, files, dirs };
+  return { io, files, dirs, links };
 }
 
 const PLAN: Extract<SelfUpdateAction, { action: "update" }> = {
@@ -294,5 +387,172 @@ describe("performSelfUpdate", () => {
     expect(
       files.get("/usr/local/bin/.switchroom-versions/switchroom-0.19.23"),
     ).toBe("PRISTINE-0.19.23");
+  });
+});
+
+// ─── the shipped-asset payload (#4163) ───────────────────────────────────
+//
+// The non-negotiable property: the binary and the templates it renders from
+// move together. If they can drift, a new CLI scaffolds agents from old
+// templates — worse than today's "no templates at all", because it fails
+// silently and much later.
+
+const SHARE_ROOT = "/usr/local/share/switchroom";
+
+describe("installAssetPayload", () => {
+  it("publishes the payload as a versioned dir behind a symlink", async () => {
+    const { io, files, links } = makeIO();
+    const r = await installAssetPayload({
+      tag: "v0.19.28",
+      binaryPath: "/usr/local/bin/switchroom",
+      io,
+    });
+
+    expect(r.installed).toBe(true);
+    expect(r.version).toBe("v0.19.28");
+    expect(r.root).toBe(SHARE_ROOT);
+    // The published path is a SYMLINK — that is what makes the swap a
+    // rename(2) rather than a recursive delete of a live directory.
+    expect(links.get(SHARE_ROOT)).toBe("switchroom-0.19.28");
+    expect(files.has(`${payloadVersionDir(SHARE_ROOT, "v0.19.28")}/profiles/_base/start.sh.hbs`)).toBe(true);
+    // Resolving THROUGH the link is what the CLI actually does.
+    expect(readPayloadVersion(io, SHARE_ROOT)).toBe("v0.19.28");
+    // No staging debris left behind.
+    expect([...files.keys()].filter((k) => k.includes(".incoming"))).toEqual([]);
+    expect([...files.keys()].filter((k) => k.includes(".download"))).toEqual([]);
+  });
+
+  it("is a no-op when the payload on disk is already the wanted version", async () => {
+    const { io } = makeIO();
+    await installAssetPayload({ tag: "v0.19.28", binaryPath: "/usr/local/bin/switchroom", io });
+    let downloads = 0;
+    const second = await installAssetPayload({
+      tag: "v0.19.28",
+      binaryPath: "/usr/local/bin/switchroom",
+      io: {
+        ...io,
+        httpDownload: async (...args) => {
+          downloads += 1;
+          return io.httpDownload(...args);
+        },
+      },
+    });
+    expect(second.installed).toBe(false);
+    expect(downloads).toBe(0);
+  });
+
+  it("refuses to unpack a payload whose checksum does not match", async () => {
+    const { io, files, links } = makeIO({ sha256File: () => "e".repeat(64) });
+    await expect(
+      installAssetPayload({ tag: "v0.19.28", binaryPath: "/usr/local/bin/switchroom", io }),
+    ).rejects.toThrow(/SHA256 mismatch/);
+    expect(links.has(SHARE_ROOT)).toBe(false);
+    expect([...files.keys()].filter((k) => k.includes(".download"))).toEqual([]);
+  });
+
+  it("refuses when the release ships no payload checksum entry (a pre-#4163 tag)", async () => {
+    const { io, links } = makeIO({
+      httpGetText: async () => `${GOOD_SHA}  switchroom-linux-amd64\n`,
+    });
+    await expect(
+      installAssetPayload({ tag: "v0.19.28", binaryPath: "/usr/local/bin/switchroom", io }),
+    ).rejects.toThrow(/no checksum entry/);
+    expect(links.has(SHARE_ROOT)).toBe(false);
+  });
+
+  it("refuses a payload whose manifest names a DIFFERENT release than the tag", async () => {
+    // The skew guard: a correctly-hashed archive cut from another release
+    // must not become the templates this CLI scaffolds from.
+    const { io, links, files } = makeIO({
+      async httpDownload(url, dest) {
+        files.set(dest, url.endsWith(ASSET_PAYLOAD_ASSET_NAME) ? "PAYLOAD:v9.9.9" : "NEW-BINARY");
+      },
+    });
+    await expect(
+      installAssetPayload({ tag: "v0.19.28", binaryPath: "/usr/local/bin/switchroom", io }),
+    ).rejects.toThrow(/unpacked with version v9\.9\.9/);
+    expect(links.has(SHARE_ROOT)).toBe(false);
+  });
+
+  it("moves a pre-existing REAL directory aside instead of deleting it", async () => {
+    // The dev-host stopgap shape: someone hand-staged profiles/ into
+    // /usr/local/share/switchroom. rename(2) cannot replace a non-empty
+    // directory, and silently rm -rf'ing an operator's files is not on.
+    const { io, files, links } = makeIO();
+    files.set(`${SHARE_ROOT}/profiles/hand-staged.hbs`, "OPERATOR-FILE");
+    await installAssetPayload({ tag: "v0.19.28", binaryPath: "/usr/local/bin/switchroom", io });
+    expect(files.get(`${SHARE_ROOT}.replaced/profiles/hand-staged.hbs`)).toBe("OPERATOR-FILE");
+    expect(links.get(SHARE_ROOT)).toBe("switchroom-0.19.28");
+  });
+
+  it("keeps the current payload and ONE previous version, pruning the rest", async () => {
+    // A binary rollback still has templates to render from; /usr/local/share
+    // does not grow by ~7MB per release forever.
+    const { io, files } = makeIO();
+    for (const v of ["0.19.20", "0.19.21", "0.19.23"]) {
+      files.set(`/usr/local/share/switchroom-${v}/switchroom-assets.json`, `{"version":"v${v}"}`);
+    }
+    await installAssetPayload({ tag: "v0.19.28", binaryPath: "/usr/local/bin/switchroom", io });
+    const kept = [...files.keys()]
+      .map((k) => k.match(/^\/usr\/local\/share\/switchroom-(\d+\.\d+\.\d+)\//)?.[1])
+      .filter((v): v is string => Boolean(v));
+    expect([...new Set(kept)].sort()).toEqual(["0.19.23", "0.19.28"]);
+  });
+});
+
+describe("performSelfUpdate — binary and payload move together", () => {
+  it("installs the payload for the SAME tag as the binary", async () => {
+    const { io, files, links } = makeIO();
+    const r = await run(io);
+    expect(r.payload?.version).toBe("v0.19.28");
+    expect(r.newVersion).toBe("v0.19.28");
+    expect(links.get(SHARE_ROOT)).toBe("switchroom-0.19.28");
+    expect(files.get("/usr/local/bin/switchroom")).toBe("NEW-BINARY");
+    expect(r.message).toContain("asset payload v0.19.28");
+  });
+
+  it("publishes the payload BEFORE the binary swap", async () => {
+    // The ordering IS the guarantee. An interruption between the two renames
+    // must leave new-templates/old-CLI (recoverable, and the old CLI can read
+    // newer templates) — never new-CLI/old-templates.
+    const order: string[] = [];
+    const base = makeIO();
+    const io: SelfUpdateIO = {
+      ...base.io,
+      symlink: (target, linkPath) => {
+        order.push(`payload:${linkPath}`);
+        base.io.symlink(target, linkPath);
+      },
+      rename: (src, dest) => {
+        if (dest === "/usr/local/bin/switchroom") order.push("binary:swap");
+        base.io.rename(src, dest);
+      },
+    };
+    await performSelfUpdate({ plan: PLAN, assetName: "switchroom-linux-amd64", io });
+    expect(order).toEqual([`payload:${SHARE_ROOT}.new-link`, "binary:swap"]);
+  });
+
+  it("leaves the binary UNTOUCHED when the payload cannot be installed", async () => {
+    // The direction that must never happen: a new CLI on $PATH with stale or
+    // absent templates. A failed payload is a failed update.
+    const { io, files, links } = makeIO({
+      extractTarGz: () => {
+        throw new Error("tar: unexpected EOF");
+      },
+    });
+    await expect(run(io)).rejects.toThrow(/could not unpack/);
+    expect(files.get("/usr/local/bin/switchroom")).toBe("OLD-BINARY");
+    expect(links.has(SHARE_ROOT)).toBe(false);
+  });
+
+  it("refuses the whole update when the release has no payload at all", async () => {
+    const { io, files } = makeIO({
+      httpGetText: async (url) =>
+        url.endsWith("switchroom-checksums.txt")
+          ? `${GOOD_SHA}  switchroom-linux-amd64\n`
+          : '{"tag_name":"v0.19.28"}',
+    });
+    await expect(run(io)).rejects.toThrow(/no checksum entry for switchroom-assets\.tar\.gz/);
+    expect(files.get("/usr/local/bin/switchroom")).toBe("OLD-BINARY");
   });
 });

--- a/src/cli/self-update.ts
+++ b/src/cli/self-update.ts
@@ -91,6 +91,11 @@
  */
 
 import { compareReleaseTags } from "../config/release-resolve.js";
+import {
+  ASSET_MANIFEST_FILENAME,
+  parseAssetPayloadManifest,
+  payloadInstallRoot,
+} from "../util/shipped-assets.js";
 
 export const SELF_UPDATE_ENV_SENTINEL = "SWITCHROOM_SELF_UPDATED";
 export const VERSION_STORE_DIRNAME = ".switchroom-versions";
@@ -222,6 +227,20 @@ export function releaseAssetName(
   if (!os || !cpu) return null;
   return `switchroom-${os}-${cpu}`;
 }
+
+/**
+ * The shipped-asset payload asset name (#4163). Platform-independent — it is
+ * a tar.gz of `profiles/`, `skills/`, `vendor/hindsight-memory/` and `ui/`,
+ * all of which are text/templates, so one artifact serves all four binaries.
+ *
+ * UNVERSIONED on purpose, exactly like the four binaries and the checksums
+ * file: release assets are already namespaced by the tag in their download
+ * URL, and a `${version}` in the filename would give install.sh and
+ * self-update a second thing to derive and get wrong. `install.sh` names this
+ * literal string and `scripts/release-assets.mjs` derives the contract from
+ * it, so a rename fails `npm run lint` before it can fail a release.
+ */
+export const ASSET_PAYLOAD_ASSET_NAME = "switchroom-assets.tar.gz";
 
 /**
  * Extract `tag_name` from the GitHub `/releases/latest` payload.
@@ -366,6 +385,20 @@ export interface SelfUpdateIO {
   remove(path: string): void;
   exists(path: string): boolean;
   dirname(path: string): string;
+
+  // ── shipped-asset payload (#4163) ──────────────────────────────────
+  /** Read a UTF-8 file, or null when it cannot be read. */
+  readText(path: string): string | null;
+  /** Extract a .tar.gz into `destDir` (created if absent). */
+  extractTarGz(archive: string, destDir: string): void;
+  /** Create a symlink at `linkPath` pointing at `target`. */
+  symlink(target: string, linkPath: string): void;
+  /** True when `path` is itself a symlink (does NOT follow it). */
+  isSymlink(path: string): boolean;
+  /** Recursive remove. No-op when absent. */
+  removeTree(path: string): void;
+  /** Entry names in `dir`, or [] when it cannot be listed. */
+  listDir(dir: string): string[];
 }
 
 export interface SelfUpdateResult {
@@ -377,6 +410,8 @@ export interface SelfUpdateResult {
   newVersion?: string;
   /** Path of the (now new) binary, when replaced. */
   binaryPath?: string;
+  /** Outcome of the shipped-asset payload install that preceded the swap. */
+  payload?: AssetPayloadResult;
 }
 
 /**
@@ -392,6 +427,251 @@ export async function fetchLatestReleaseTag(
     return parseLatestReleaseTag(await io.httpGetText(GITHUB_LATEST_RELEASE_URL));
   } catch {
     return null;
+  }
+}
+
+// ─── shipped-asset payload (#4163) ───────────────────────────────────────
+//
+// THE ATOMICITY PROBLEM, AND WHAT WE ACTUALLY GUARANTEE
+//
+// The CLI and the templates it renders are two artifacts. No syscall swaps
+// two filesystem objects at once, so "atomic" here is a property built out of
+// four smaller guarantees, not a claim about one rename:
+//
+//   1. SAME RELEASE BY CONSTRUCTION. Binary and payload are fetched from one
+//      resolved tag's `releases/download/<tag>/` prefix and verified against
+//      that release's single `switchroom-checksums.txt`. There is no code
+//      path that can pair version A's binary with version B's payload.
+//   2. PAYLOAD FIRST, BINARY SECOND. Each is installed with an atomic
+//      `rename(2)`, payload before binary. A crash, a SIGKILL or a power cut
+//      between them therefore leaves NEW payload + OLD binary — an old CLI
+//      reading templates one version ahead — and never the inverse, which is
+//      the failure #4163 calls out as worse than the status quo.
+//   3. CONVERGENCE, NOT JUST ORDERING. Ordering alone would strand a host
+//      whose payload step failed: the next `switchroom update` would see the
+//      binary already current and skip everything. So the payload is checked
+//      and repaired on EVERY update run, including the "already current" one.
+//   4. DETECTION. The payload carries `switchroom-assets.json` naming the
+//      release it was cut from; `assetPayloadSkew()` compares it to the
+//      running CLI, and `switchroom doctor` fails on disagreement.
+//
+// The payload is installed as a VERSIONED DIRECTORY plus a symlink:
+//
+//   /usr/local/share/switchroom-0.19.44/   (extracted, verified)
+//   /usr/local/share/switchroom -> switchroom-0.19.44   (atomic swap)
+//
+// `rename(2)` cannot replace a non-empty directory, but it CAN replace a
+// symlink — which is what makes the publish step atomic. A pre-existing real
+// directory (a hand-staged one, or an older install) is moved aside once, to
+// `<root>.replaced`, so the first upgrade to this scheme is recoverable.
+
+export interface AssetPayloadResult {
+  /** True when the payload on disk was replaced. */
+  installed: boolean;
+  /** Payload version now on disk. */
+  version: string;
+  /** The symlink path the CLI resolves through. */
+  root: string;
+  message: string;
+}
+
+/** Where a version's payload is extracted, beside the symlink root. */
+export function payloadVersionDir(root: string, version: string): string {
+  return `${root}-${version.replace(/^v/, "")}`;
+}
+
+/**
+ * Download, verify and install the shipped-asset payload for `tag`.
+ *
+ * THROWS on every failure. A binary without its payload cannot scaffold a
+ * single agent, so a payload that cannot be installed is a failed update, not
+ * a warning — that is the whole lesson of #4161.
+ *
+ * Idempotent: when the payload already on disk reports `tag`, nothing is
+ * downloaded and `installed` is false.
+ */
+export async function installAssetPayload(opts: {
+  /** Release tag to install, e.g. `v0.19.44`. */
+  tag: string;
+  /** Path of the installed binary; the payload root is derived from it. */
+  binaryPath: string;
+  io: SelfUpdateIO;
+  /** Pre-fetched checksums text, to avoid a second GET in the update path. */
+  checksumsText?: string;
+  /** Force a reinstall even when the on-disk version already matches. */
+  force?: boolean;
+  log?: (s: string) => void;
+}): Promise<AssetPayloadResult> {
+  const { tag, binaryPath, io } = opts;
+  const log = opts.log ?? (() => {});
+  const wanted = `v${tag.replace(/^v/, "")}`;
+  const root = payloadInstallRoot(binaryPath);
+  const parent = io.dirname(root);
+  const versionDir = payloadVersionDir(root, wanted);
+
+  if (!opts.force) {
+    const current = readPayloadVersion(io, root);
+    if (current === wanted) {
+      return {
+        installed: false,
+        version: wanted,
+        root,
+        message: `shipped-asset payload already ${wanted} at ${root}`,
+      };
+    }
+  }
+
+  const base = `https://github.com/switchroom/switchroom/releases/download/${wanted}`;
+  const tmpArchive = `${versionDir}.download.tar.gz`;
+  const incoming = `${versionDir}.incoming`;
+
+  io.mkdirp(parent);
+  io.remove(tmpArchive);
+  io.removeTree(incoming);
+
+  log(`downloading ${ASSET_PAYLOAD_ASSET_NAME} ${wanted}`);
+  try {
+    await io.httpDownload(`${base}/${ASSET_PAYLOAD_ASSET_NAME}`, tmpArchive);
+  } catch (err) {
+    io.remove(tmpArchive);
+    throw new Error(
+      `self-update: download of ${base}/${ASSET_PAYLOAD_ASSET_NAME} failed ` +
+        `(${(err as Error).message}). The shipped-asset payload (profiles, skills, ` +
+        `vendor) is what \`switchroom apply\` scaffolds from, so the update stops ` +
+        `here rather than leave a CLI that cannot scaffold. Nothing was changed.`,
+    );
+  }
+
+  // Same supply-chain boundary as the binary: never unpack an unverified
+  // archive. The payload contains shell templates that end up executing as
+  // every agent's container entrypoint.
+  let checksums: string;
+  if (opts.checksumsText !== undefined) {
+    checksums = opts.checksumsText;
+  } else {
+    try {
+      checksums = await io.httpGetText(`${base}/switchroom-checksums.txt`);
+    } catch (err) {
+      io.remove(tmpArchive);
+      throw new Error(
+        `self-update: could not fetch switchroom-checksums.txt for ${wanted} ` +
+          `(${(err as Error).message}) — refusing to unpack an unverified asset ` +
+          `payload. Nothing was changed.`,
+      );
+    }
+  }
+  const expected = expectedChecksum(checksums, ASSET_PAYLOAD_ASSET_NAME);
+  if (!expected) {
+    io.remove(tmpArchive);
+    throw new Error(
+      `self-update: release ${wanted} has no checksum entry for ` +
+        `${ASSET_PAYLOAD_ASSET_NAME}. Either the release predates the asset ` +
+        `payload (#4163) or it is incomplete — refusing to unpack it. Nothing ` +
+        `was changed.`,
+    );
+  }
+  const actual = io.sha256File(tmpArchive).toLowerCase();
+  if (actual !== expected) {
+    io.remove(tmpArchive);
+    throw new Error(
+      `self-update: SHA256 mismatch for ${ASSET_PAYLOAD_ASSET_NAME} (expected ` +
+        `${expected}, got ${actual}) — refusing to unpack. Nothing was changed.`,
+    );
+  }
+
+  try {
+    io.extractTarGz(tmpArchive, incoming);
+  } catch (err) {
+    io.remove(tmpArchive);
+    io.removeTree(incoming);
+    throw new Error(
+      `self-update: could not unpack ${ASSET_PAYLOAD_ASSET_NAME} into ${incoming} ` +
+        `(${(err as Error).message}). Nothing was changed.`,
+    );
+  }
+  io.remove(tmpArchive);
+
+  // Prove the archive really is this release's payload before it can become
+  // the templates every agent boots from — the payload equivalent of running
+  // `<candidate> version` on the binary.
+  const unpacked = parseAssetPayloadManifest(
+    io.readText(`${incoming}/${ASSET_MANIFEST_FILENAME}`) ?? "",
+  );
+  if (!unpacked || unpacked.version !== wanted) {
+    io.removeTree(incoming);
+    throw new Error(
+      `self-update: the ${wanted} asset payload unpacked with version ` +
+        `${unpacked?.version ?? "<none>"} in ${ASSET_MANIFEST_FILENAME} — refusing ` +
+        `to install a payload that does not match the release it came from. ` +
+        `Nothing was changed.`,
+    );
+  }
+
+  io.removeTree(versionDir);
+  io.rename(incoming, versionDir);
+
+  // ── the publish step: one atomic rename over the symlink ──────────────
+  if (io.exists(root) && !io.isSymlink(root)) {
+    // First upgrade from a hand-staged / pre-#4163 real directory. Moved
+    // aside rather than deleted so an operator who staged something there
+    // can get it back; only ONE such copy is ever kept.
+    const aside = `${root}.replaced`;
+    io.removeTree(aside);
+    io.rename(root, aside);
+    log(`moved the pre-existing ${root} aside to ${aside}`);
+  }
+  const linkTmp = `${root}.new-link`;
+  io.remove(linkTmp);
+  io.symlink(basenameOf(versionDir), linkTmp);
+  io.rename(linkTmp, root);
+
+  prunePayloadVersions(io, root, wanted);
+
+  return {
+    installed: true,
+    version: wanted,
+    root,
+    message: `shipped-asset payload ${wanted} installed at ${root} -> ${basenameOf(versionDir)}`,
+  };
+}
+
+/** Payload version currently published at `root`, or null. */
+export function readPayloadVersion(
+  io: Pick<SelfUpdateIO, "readText">,
+  root: string,
+): string | null {
+  const body = io.readText(`${root}/${ASSET_MANIFEST_FILENAME}`);
+  if (body === null) return null;
+  return parseAssetPayloadManifest(body)?.version ?? null;
+}
+
+function basenameOf(p: string): string {
+  const i = p.lastIndexOf("/");
+  return i === -1 ? p : p.slice(i + 1);
+}
+
+/**
+ * Keep the live payload and ONE previous version (so a binary rollback still
+ * has templates to render from), delete the rest. Unbounded growth would add
+ * ~7 MB per release to `/usr/local/share` forever.
+ */
+function prunePayloadVersions(
+  io: SelfUpdateIO,
+  root: string,
+  keepVersion: string,
+): void {
+  const parent = io.dirname(root);
+  const prefix = `${basenameOf(root)}-`;
+  const versions = io
+    .listDir(parent)
+    .filter((n) => n.startsWith(prefix) && /^\d+\.\d+\.\d+$/.test(n.slice(prefix.length)))
+    .map((n) => n.slice(prefix.length))
+    .sort((a, b) => compareReleaseTags(`v${a}`, `v${b}`) ?? 0);
+  const keep = new Set([keepVersion.replace(/^v/, "")]);
+  const previous = versions.filter((v) => !keep.has(v)).pop();
+  if (previous) keep.add(previous);
+  for (const v of versions) {
+    if (!keep.has(v)) io.removeTree(`${parent}/${prefix}${v}`);
   }
 }
 
@@ -477,6 +757,20 @@ export async function performSelfUpdate(opts: {
     );
   }
 
+  // ── payload BEFORE binary (#4163) ──────────────────────────────────
+  // Both artifacts come from `plan.to` and are verified against the same
+  // `checksums` text fetched above, so they cannot be mismatched versions.
+  // Installing the payload first means an interruption between the two
+  // atomic renames leaves new-templates/old-CLI, never new-CLI/old-templates.
+  const payload = await installAssetPayload({
+    tag: plan.to,
+    binaryPath: plan.binaryPath,
+    io,
+    checksumsText: checksums,
+    log,
+  });
+  log(payload.message);
+
   // Archive the OUTGOING binary before the swap so rollback is a copy.
   const previousArchive = versionStorePath(installDir, plan.from);
   try {
@@ -504,8 +798,10 @@ export async function performSelfUpdate(opts: {
     replaced: true,
     newVersion: plan.to,
     binaryPath: plan.binaryPath,
+    payload,
     message:
-      `host CLI ${plan.from} → ${plan.to} (verified sha256, ran clean). ` +
+      `host CLI ${plan.from} → ${plan.to} (verified sha256, ran clean; ` +
+      `asset payload ${payload.version}). ` +
       rollbackHint(installDir, plan.from),
   };
 }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import chalk from "chalk";
-import { existsSync, copyFileSync, readFileSync, mkdirSync, statSync } from "node:fs";
+import { existsSync, copyFileSync, readFileSync, mkdirSync, statSync, writeFileSync } from "node:fs";
+import { DEFAULT_EXAMPLE, exampleNames, readEmbeddedExample } from "./embedded-examples.js";
 import { execFileSync } from "node:child_process";
 import { writeConfigFileSync } from "../util/atomic.js";
 import { resolve, dirname } from "node:path";
@@ -369,11 +370,10 @@ async function stepConfigFile(
 async function copyExampleConfig(
   nonInteractive: boolean,
 ): Promise<LoadedConfig> {
-  const examplesDir = resolve(import.meta.dirname, "../../examples");
   let choice: string;
 
   if (nonInteractive) {
-    choice = "switchroom";
+    choice = DEFAULT_EXAMPLE;
   } else {
     choice = await askChoice("  Which example config?", [
       "switchroom — Full example: one active agent + commented templates",
@@ -382,7 +382,19 @@ async function copyExampleConfig(
     choice = choice.split(" ")[0];
   }
 
-  const srcFile = resolve(examplesDir, `${choice}.yaml`);
+  // From the EMBEDDED copy, not from disk. This used to be
+  // `resolve(import.meta.dirname, "../../examples")`, which is `/examples`
+  // inside a `bun build --compile` artifact — so `switchroom setup` on a
+  // static-binary install (the advertised `curl | sh` path, and the very first
+  // command a new user runs) died with "Example config not found: switchroom.yaml"
+  // and there was no way forward. #4163.
+  const exampleBody = readEmbeddedExample(choice);
+  if (exampleBody === null) {
+    throw new ConfigError(
+      `Example config not found: ${choice}.yaml (available: ${exampleNames().join(", ")})`,
+    );
+  }
+
   // Bootstrap to the canonical user-wide path, NOT cwd. Every later
   // command (apply, agent ops, daemonized gateways) resolves config
   // via findConfigFile, which ranks ~/.switchroom/switchroom.yaml as
@@ -392,12 +404,8 @@ async function copyExampleConfig(
   // docs/install.md has always told users it lands here.
   const destFile = resolvePath("~/.switchroom/switchroom.yaml");
 
-  if (!existsSync(srcFile)) {
-    throw new ConfigError(`Example config not found: ${choice}.yaml`);
-  }
-
   mkdirSync(dirname(destFile), { recursive: true });
-  copyFileSync(srcFile, destFile);
+  writeFileSync(destFile, exampleBody, { encoding: "utf8" });
   console.log(chalk.green(`  Copied ${choice}.yaml -> ${destFile}`));
   console.log(
     chalk.yellow(`  Edit ${destFile} to customize, then re-run switchroom setup.`),

--- a/src/cli/update-self-update.test.ts
+++ b/src/cli/update-self-update.test.ts
@@ -21,6 +21,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { planUpdate, runUpdate, buildReexecArgs } from "./update.js";
+import { SWITCHROOM_VERSION } from "./resolve-version.js";
 import type { SelfUpdateIO } from "./self-update.js";
 
 function withCompose<T>(fn: (composePath: string) => T): T {
@@ -44,27 +45,89 @@ const baseOpts = {
   componentExec: () => ({ status: 1, stdout: "" }),
 };
 
-/** A self-update IO that swaps successfully, with no network or disk. */
-function fakeIO(): SelfUpdateIO {
+/**
+ * A self-update IO that swaps successfully, with no network or disk.
+ *
+ * It also models enough of a filesystem (symlinks, subtree renames) for the
+ * shipped-asset payload install (#4163), because the payload is not optional:
+ * `performSelfUpdate` and the convergence path both go through it, and an IO
+ * that could not satisfy it would let these tests pass against a build that
+ * had quietly dropped the payload.
+ */
+function fakeIO(): SelfUpdateIO & { files: Map<string, string>; links: Map<string, string> } {
   const files = new Map<string, string>([["/usr/local/bin/switchroom", "OLD"]]);
+  const links = new Map<string, string>();
+  const dirnameOf = (p: string) => p.slice(0, p.lastIndexOf("/")) || "/";
+  const under = (prefix: string) =>
+    [...files.keys()].filter((k) => k === prefix || k.startsWith(`${prefix}/`));
+  const removeTree = (p: string) => {
+    for (const k of under(p)) files.delete(k);
+    links.delete(p);
+  };
   return {
+    files,
+    links,
     httpGetText: async (url) =>
       url.endsWith("switchroom-checksums.txt")
-        ? `${"a".repeat(64)}  switchroom-linux-amd64\n${"a".repeat(64)}  switchroom-linux-arm64\n${"a".repeat(64)}  switchroom-macos-amd64\n${"a".repeat(64)}  switchroom-macos-arm64\n`
+        ? `${"a".repeat(64)}  switchroom-linux-amd64\n${"a".repeat(64)}  switchroom-linux-arm64\n${"a".repeat(64)}  switchroom-macos-amd64\n${"a".repeat(64)}  switchroom-macos-arm64\n${"a".repeat(64)}  switchroom-assets.tar.gz\n`
         : '{"tag_name":"v9.9.9"}',
-    httpDownload: async (_u, dest) => void files.set(dest, "NEW"),
+    httpDownload: async (url, dest) => {
+      const tag = /download\/(v[^/]+)\//.exec(url)?.[1] ?? "v9.9.9";
+      files.set(dest, url.endsWith(".tar.gz") ? `PAYLOAD:${tag}` : "NEW");
+    },
     sha256File: () => "a".repeat(64),
     probeBinaryVersion: () => "9.9.9",
     mkdirp: () => {},
     copyFile: (s, d) => void files.set(d, files.get(s) ?? ""),
     chmodExec: () => {},
     rename: (s, d) => {
-      files.set(d, files.get(s) ?? "");
-      files.delete(s);
+      if (links.has(s)) {
+        links.set(d, links.get(s) as string);
+        links.delete(s);
+        return;
+      }
+      for (const k of under(s)) {
+        files.set(d + k.slice(s.length), files.get(k) as string);
+        files.delete(k);
+      }
     },
-    remove: (p) => void files.delete(p),
-    exists: (p) => files.has(p),
-    dirname: (p) => p.slice(0, p.lastIndexOf("/")) || "/",
+    remove: (p) => {
+      files.delete(p);
+      links.delete(p);
+    },
+    exists: (p) => files.has(p) || links.has(p) || under(p).length > 0,
+    dirname: dirnameOf,
+    readText: (p) => {
+      const direct = files.get(p);
+      if (direct !== undefined) return direct;
+      // Resolve one level of symlink on any ancestor, as readText(2) would.
+      for (const [link, target] of links) {
+        if (p.startsWith(`${link}/`)) {
+          const real = `${dirnameOf(link)}/${target}${p.slice(link.length)}`;
+          const v = files.get(real);
+          if (v !== undefined) return v;
+        }
+      }
+      return null;
+    },
+    extractTarGz: (archive, destDir) => {
+      const tag = (files.get(archive) ?? "").replace(/^PAYLOAD:/, "");
+      files.set(
+        `${destDir}/switchroom-assets.json`,
+        JSON.stringify({ version: tag, entries: ["profiles"], files: 1 }),
+      );
+      files.set(`${destDir}/profiles/_base/start.sh.hbs`, "#!/bin/sh\n");
+    },
+    symlink: (target, linkPath) => void links.set(linkPath, target),
+    isSymlink: (p) => links.has(p),
+    removeTree,
+    listDir: (dir) => {
+      const names = new Set<string>();
+      for (const k of [...files.keys(), ...links.keys()]) {
+        if (k.startsWith(`${dir}/`)) names.add(k.slice(dir.length + 1).split("/")[0]);
+      }
+      return [...names];
+    },
   };
 }
 
@@ -279,6 +342,123 @@ describe("swap → re-exec", () => {
       expect(code).toBe(1);
       expect(err).toContain("self-update-cli failed");
       expect(err).toContain("did not run cleanly");
+    });
+  });
+});
+
+describe("shipped-asset payload convergence (#4163)", () => {
+  it("installs the payload alongside the binary on a real self-update", async () => {
+    await withCompose(async (composePath) => {
+      const io = fakeIO();
+      await runUpdate({
+        composePath,
+        ...baseOpts,
+        installProbe: STATIC_PROBE,
+        selfUpdateIO: io,
+        latestReleaseTagFn: async () => "v9.9.9",
+        runner: () => ({ status: 0 }),
+        reexecFn: () => ({ status: 0 }),
+        stdout: () => {},
+        stderr: () => {},
+      });
+      expect(io.links.get("/usr/local/share/switchroom")).toBe("switchroom-9.9.9");
+      expect(
+        io.files.get("/usr/local/share/switchroom-9.9.9/profiles/_base/start.sh.hbs"),
+      ).toBeDefined();
+    });
+  });
+
+  it("REPAIRS a missing payload even when the CLI is already current", async () => {
+    // Ordering payload-before-binary is only safe if a half-finished update
+    // can still finish. Without this the "already current" path would short-
+    // circuit and the host would sit on a new CLI with no templates forever.
+    await withCompose(async (composePath) => {
+      const io = fakeIO();
+      let out = "";
+      await runUpdate({
+        composePath,
+        ...baseOpts,
+        installProbe: STATIC_PROBE,
+        selfUpdateIO: {
+          ...io,
+          httpGetText: async (url) =>
+            url.endsWith("switchroom-checksums.txt")
+              ? `${"a".repeat(64)}  switchroom-assets.tar.gz\n`
+              : `{"tag_name":"v${SWITCHROOM_VERSION}"}`,
+        },
+        latestReleaseTagFn: async () => `v${SWITCHROOM_VERSION}`,
+        runner: () => ({ status: 0 }),
+        reexecFn: () => ({ status: 0 }),
+        stdout: (s) => {
+          out += s;
+        },
+        stderr: () => {},
+      });
+      // The CLI itself needed nothing…
+      expect(out).toContain("already on");
+      // The repair actually happened — not just a log line.
+      expect(io.links.get("/usr/local/share/switchroom")).toBe(
+        `switchroom-${SWITCHROOM_VERSION}`,
+      );
+    });
+  });
+
+  it("does not re-download the payload when it is already the current version", async () => {
+    await withCompose(async (composePath) => {
+      const io = fakeIO();
+      // Pre-publish the payload the way a completed update leaves it.
+      io.files.set(
+        `/usr/local/share/switchroom-${SWITCHROOM_VERSION}/switchroom-assets.json`,
+        JSON.stringify({ version: `v${SWITCHROOM_VERSION}`, entries: ["profiles"], files: 1 }),
+      );
+      io.links.set("/usr/local/share/switchroom", `switchroom-${SWITCHROOM_VERSION}`);
+      let downloads = 0;
+      await runUpdate({
+        composePath,
+        ...baseOpts,
+        installProbe: STATIC_PROBE,
+        selfUpdateIO: {
+          ...io,
+          httpDownload: async (...args) => {
+            downloads += 1;
+            return io.httpDownload(...args);
+          },
+        },
+        latestReleaseTagFn: async () => `v${SWITCHROOM_VERSION}`,
+        runner: () => ({ status: 0 }),
+        reexecFn: () => ({ status: 0 }),
+        stdout: () => {},
+        stderr: () => {},
+      });
+      expect(downloads).toBe(0);
+    });
+  });
+
+  it("fails the update when the payload cannot be installed — never a new CLI on old templates", async () => {
+    await withCompose(async (composePath) => {
+      const io = fakeIO();
+      let err = "";
+      const code = await runUpdate({
+        composePath,
+        ...baseOpts,
+        installProbe: STATIC_PROBE,
+        selfUpdateIO: {
+          ...io,
+          extractTarGz: () => {
+            throw new Error("tar: unexpected EOF");
+          },
+        },
+        latestReleaseTagFn: async () => "v9.9.9",
+        runner: () => ({ status: 0 }),
+        reexecFn: () => ({ status: 0 }),
+        stdout: () => {},
+        stderr: (s) => {
+          err += s;
+        },
+      });
+      expect(code).toBe(1);
+      expect(err).toContain("self-update-cli failed");
+      expect(io.files.get("/usr/local/bin/switchroom")).toBe("OLD");
     });
   });
 });

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -56,6 +56,7 @@ import {
   alreadySelfUpdated,
   detectInstallKind,
   fetchLatestReleaseTag,
+  installAssetPayload,
   performSelfUpdate,
   planSelfUpdate,
   releaseAssetName,
@@ -521,7 +522,7 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
   steps.push({
     name: "self-update-cli",
     description:
-      "Replace the host operator CLI binary with the latest published release (checksum-verified, run-proved, atomic swap + versioned rollback copy), then re-exec the new binary for the remaining steps",
+      "Replace the host operator CLI binary AND its shipped-asset payload (profiles/skills/vendor) with the latest published release — both checksum-verified, payload installed first so the pair can never end up new-CLI/old-templates — then re-exec the new binary for the remaining steps",
     skipReason: opts.skipSelfUpdate
       ? "--skip-self-update flag set"
       : alreadySelfUpdated(process.env)
@@ -562,6 +563,24 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
       }
       if (plan.action === "current") {
         say(chalk.gray(`  host CLI already on ${plan.version}\n`));
+        // CONVERGENCE (#4163). Ordering the payload before the binary is only
+        // safe if a half-completed update can still finish: a run whose
+        // payload step failed leaves the binary current, so without this the
+        // next `switchroom update` would skip out here and the host would sit
+        // on a new CLI with a missing or stale payload forever. Re-checking
+        // (and repairing) the payload on the no-op path is what makes the
+        // pair converge instead of merely being ordered.
+        const repaired = await installAssetPayload({
+          tag: plan.version,
+          binaryPath: detection.binaryPath as string,
+          io,
+          log: (s) => say(chalk.gray(`  ${s}\n`)),
+        });
+        say(
+          repaired.installed
+            ? chalk.green(`  ${repaired.message}\n`)
+            : chalk.gray(`  ${repaired.message}\n`),
+        );
         return;
       }
       const asset = releaseAssetName(process.platform, process.arch);

--- a/src/util/shipped-assets.test.ts
+++ b/src/util/shipped-assets.test.ts
@@ -8,6 +8,9 @@ import {
   describeShippedAssetSearch,
   resolveShippedAsset,
   shippedAssetCandidates,
+  assetPayloadSkew,
+  parseAssetPayloadManifest,
+  payloadInstallRoot,
 } from "./shipped-assets.js";
 
 /**
@@ -196,5 +199,155 @@ describe("the real repo layout still resolves (no simulation)", () => {
     const r = resolveShippedAsset(SKILLS_ASSET, { ...devProbe, env: {} });
     expect(r.path).not.toBeNull();
     expect(existsSync(r.path as string)).toBe(true);
+  });
+});
+
+// ─── payload version skew (#4163) ────────────────────────────────────────
+
+describe("parseAssetPayloadManifest", () => {
+  it("reads the version and normalises the v prefix", () => {
+    expect(parseAssetPayloadManifest('{"version":"0.19.44"}')?.version).toBe("v0.19.44");
+    expect(parseAssetPayloadManifest('{"version":"v0.19.44"}')?.version).toBe("v0.19.44");
+  });
+
+  it("keeps the entry list when present", () => {
+    const m = parseAssetPayloadManifest(
+      '{"version":"v1.2.3","entries":["profiles","skills",7]}',
+    );
+    expect(m?.entries).toEqual(["profiles", "skills"]);
+  });
+
+  it("returns null rather than a bogus version for unusable input", () => {
+    // Each of these previously would have had to be handled by the caller;
+    // null here is what makes assetPayloadSkew report `unreadable` instead of
+    // silently treating garbage as agreement.
+    for (const body of ["", "not json", "{}", '{"version":42}', '{"version":"latest"}']) {
+      expect(parseAssetPayloadManifest(body)).toBeNull();
+    }
+  });
+});
+
+describe("assetPayloadSkew", () => {
+  const SEA = { bundleDir: BUNFS, execPath: "/usr/local/bin/switchroom", env: {} };
+  const MANIFEST = "/usr/local/share/switchroom/switchroom-assets.json";
+
+  it("matches when the payload names the running release", () => {
+    const skew = assetPayloadSkew({
+      cliVersion: "0.19.44",
+      probe: { ...SEA, exists: (p) => p === MANIFEST },
+      readText: () => '{"version":"v0.19.44"}',
+    });
+    expect(skew.status).toBe("matched");
+    expect(skew.ok).toBe(true);
+    expect(skew.manifestPath).toBe(MANIFEST);
+  });
+
+  it("reports SKEWED — the silent failure — when the payload is another release", () => {
+    const skew = assetPayloadSkew({
+      cliVersion: "0.19.44",
+      probe: { ...SEA, exists: (p) => p === MANIFEST },
+      readText: () => '{"version":"v0.19.28"}',
+    });
+    expect(skew.status).toBe("skewed");
+    expect(skew.ok).toBe(false);
+    expect(skew.payloadVersion).toBe("v0.19.28");
+    expect(skew.message).toContain("v0.19.28");
+    expect(skew.message).toContain("v0.19.44");
+  });
+
+  it("reports MISSING and names every path it probed", () => {
+    const skew = assetPayloadSkew({
+      cliVersion: "0.19.44",
+      probe: { ...SEA, exists: () => false },
+    });
+    expect(skew.status).toBe("missing");
+    expect(skew.ok).toBe(false);
+    expect(skew.candidates).toContain(MANIFEST);
+    // #4160's lesson: name every location, not just the first.
+    for (const c of skew.candidates) expect(skew.message).toContain(c);
+  });
+
+  it("reports UNREADABLE — never `matched` — for a corrupt manifest", () => {
+    const skew = assetPayloadSkew({
+      cliVersion: "0.19.44",
+      probe: { ...SEA, exists: (p) => p === MANIFEST },
+      readText: () => "{ truncated",
+    });
+    expect(skew.status).toBe("unreadable");
+    expect(skew.ok).toBe(false);
+  });
+
+  it("treats a throwing reader as unreadable rather than propagating", () => {
+    // doctor must not crash on an EACCES manifest.
+    const skew = assetPayloadSkew({
+      cliVersion: "0.19.44",
+      probe: { ...SEA, exists: (p) => p === MANIFEST },
+      readText: () => {
+        throw new Error("EACCES");
+      },
+    });
+    expect(skew.status).toBe("unreadable");
+  });
+});
+
+describe("payloadInstallRoot", () => {
+  it("is the FIRST SEA candidate the resolver probes — installer and resolver cannot disagree", () => {
+    const execPath = "/opt/tools/bin/switchroom";
+    const root = payloadInstallRoot(execPath);
+    const candidates = shippedAssetCandidates(PROFILES_ASSET, {
+      bundleDir: BUNFS,
+      execPath,
+    });
+    // Skip the two bundle-relative candidates, which are bunfs garbage here.
+    expect(candidates[2]).toBe(`${root}/profiles`);
+  });
+});
+
+describe("symlinked share root (#4163)", () => {
+  // The payload publishes `<prefix>/share/switchroom` as a SYMLINK to
+  // `switchroom-<version>` so an update is an atomic rename. Consumers that do
+  // a containment check then compared a realpath'd child against the symlink
+  // path and refused — observed as `Invalid profile name: default`, which
+  // failed every agent scaffold on a real `curl | sh` install.
+  const EXEC = "/usr/local/bin/switchroom";
+  const LINK = "/usr/local/share/switchroom/profiles";
+  const REAL = "/usr/local/share/switchroom-0.19.44/profiles";
+
+  const symlinked = {
+    bundleDir: BUNFS,
+    execPath: EXEC,
+    env: {},
+    exists: (p: string) => p === LINK,
+    realpath: (p: string) => (p === LINK ? REAL : p),
+  };
+
+  it("returns the REAL path of a resolved candidate, not the symlink", () => {
+    const res = resolveShippedAsset(PROFILES_ASSET, symlinked);
+    expect(res.source).toBe("sea-sibling");
+    expect(res.path).toBe(REAL);
+  });
+
+  it("still reports the probed (symlink) paths in candidates for diagnostics", () => {
+    const res = resolveShippedAsset(PROFILES_ASSET, symlinked);
+    expect(res.candidates).toContain(LINK);
+  });
+
+  it("canonicalises an env override too", () => {
+    const res = resolveShippedAsset(PROFILES_ASSET, {
+      ...symlinked,
+      env: { [PROFILES_ASSET.envVar]: LINK },
+    });
+    expect(res.source).toBe("env");
+    expect(res.path).toBe(REAL);
+  });
+
+  it("falls back to the literal path when realpath throws", () => {
+    const res = resolveShippedAsset(PROFILES_ASSET, {
+      ...symlinked,
+      realpath: () => {
+        throw new Error("EACCES");
+      },
+    });
+    expect(res.path).toBe(LINK);
   });
 });

--- a/src/util/shipped-assets.ts
+++ b/src/util/shipped-assets.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
 /**
@@ -64,6 +64,42 @@ export const HINDSIGHT_VENDOR_ASSET: ShippedAssetSpec = {
   envVar: "SWITCHROOM_HINDSIGHT_VENDOR_ROOT",
 };
 
+/**
+ * Web dashboard static assets. `npm run build` copies `src/web/ui` to
+ * `dist/cli/ui`, so the npm/dev layout finds it as the "image"-shaped
+ * `<bundleDir>/ui` candidate; a source checkout finds `src/web/ui` the same
+ * way. The compiled binary has no sibling `ui/` at all — `switchroom web`
+ * from a static-binary install served a dashboard whose every static route
+ * 404'd (#4163).
+ */
+export const WEB_UI_ASSET: ShippedAssetSpec = {
+  asset: "ui",
+  envVar: "SWITCHROOM_WEB_UI_ROOT",
+};
+
+/**
+ * Version manifest written at the root of the shipped-asset payload by
+ * `scripts/build-asset-payload.mjs`. Resolved through the SAME probe as the
+ * asset directories, so "which payload am I using" can never answer a
+ * different location than "which profiles am I using".
+ */
+export const ASSET_MANIFEST_FILENAME = "switchroom-assets.json";
+
+export const ASSET_MANIFEST_ASSET: ShippedAssetSpec = {
+  asset: ASSET_MANIFEST_FILENAME,
+  envVar: "SWITCHROOM_ASSET_MANIFEST",
+};
+
+/**
+ * Where a static-binary install stages its payload, derived from the real
+ * binary path: `/usr/local/bin/switchroom` → `/usr/local/share/switchroom`.
+ * This is the FIRST SEA candidate `orderedCandidates` probes, so the
+ * installer and the resolver cannot disagree about the destination.
+ */
+export function payloadInstallRoot(execPath: string): string {
+  return resolve(dirname(execPath), "../share/switchroom");
+}
+
 /** Runtime facts the probe needs. Every field is injectable so a test can
  *  simulate a layout it is not running under (that is the whole point —
  *  the SEA layout is unreachable from vitest otherwise). */
@@ -76,6 +112,8 @@ export interface ShippedAssetProbe {
   env?: Record<string, string | undefined>;
   /** Defaults to `fs.existsSync`. */
   exists?: (p: string) => boolean;
+  /** Defaults to `fs.realpathSync`. See `canonicalise` for why it exists. */
+  realpath?: (p: string) => string;
 }
 
 /** Which layout produced the resolved path. `"none"` when nothing existed. */
@@ -157,7 +195,7 @@ export function resolveShippedAsset(
   const env = probe.env ?? process.env;
   const override = env[spec.envVar]?.trim();
   if (override) {
-    const path = resolve(override);
+    const path = canonicalise(resolve(override), probe);
     return { path, candidates: [path], source: "env" };
   }
 
@@ -165,10 +203,44 @@ export function resolveShippedAsset(
   const candidates = orderedCandidates(spec, probe);
   for (const c of candidates) {
     if (exists(c.path)) {
-      return { path: c.path, candidates: candidates.map((x) => x.path), source: c.source };
+      return {
+        path: canonicalise(c.path, probe),
+        candidates: candidates.map((x) => x.path),
+        source: c.source,
+      };
     }
   }
   return { path: null, candidates: candidates.map((x) => x.path), source: "none" };
+}
+
+/**
+ * Resolve symlinks in a hit before handing it back.
+ *
+ * Load-bearing for the SEA layout (#4163): the asset payload is published as
+ * `<prefix>/share/switchroom -> switchroom-<version>`, a SYMLINK, because
+ * swapping a symlink is the only atomic way to replace a directory. Callers
+ * that do a containment check against the resolved root then compare a
+ * `realpath`'d child (`…/share/switchroom-0.19.44/profiles/default`) against an
+ * un-realpath'd root (`…/share/switchroom/profiles`), decide the child escapes
+ * the root, and refuse. Observed as `Invalid profile name: default` from
+ * `getProfilePath` on a real `curl | sh` install — every agent failed to
+ * scaffold, i.e. the exact #4160 symptom with a new cause.
+ *
+ * Canonicalising HERE fixes every consumer at once instead of asking each one
+ * to remember. The probe list is deliberately left un-canonicalised: it is a
+ * record of what was searched, and an operator needs to see the paths that were
+ * actually probed.
+ *
+ * Falls back to the input on any error — a resolvable-but-unreadable path
+ * should behave as it did before, not throw out of a resolver.
+ */
+function canonicalise(path: string, probe: ShippedAssetProbe): string {
+  const realpath = probe.realpath ?? realpathSync;
+  try {
+    return realpath(path);
+  } catch {
+    return path;
+  }
 }
 
 /**
@@ -180,4 +252,166 @@ export function describeShippedAssetSearch(
   resolution: Pick<ShippedAssetResolution, "candidates">,
 ): string {
   return `searched ${resolution.candidates.length} location(s): ${resolution.candidates.join(", ")}`;
+}
+
+// ── payload version skew (#4163) ─────────────────────────────────────────
+//
+// The binary and the payload are two artifacts. Nothing at the filesystem
+// level can swap both in one syscall, so instead of hoping they stay
+// together we make disagreement DETECTABLE and REPAIRABLE:
+//
+//   - the installer and self-update fetch both from ONE release tag and
+//     verify both against that release's switchroom-checksums.txt;
+//   - the payload lands BEFORE the binary, so an interrupted update leaves
+//     new-payload/old-binary, never new-binary/old-templates;
+//   - `switchroom update` re-checks the manifest on EVERY run — including
+//     the run where the binary is already current — and reinstalls a skewed
+//     or missing payload, so an interrupted update converges on the next one;
+//   - `switchroom doctor` reports skew with the repair command.
+//
+// Anything that reads a payload version goes through here, so the four
+// sites above cannot drift in what "skewed" means.
+
+/** Parsed `switchroom-assets.json`. */
+export interface AssetPayloadManifest {
+  /** The release tag the payload was cut from, normalised to `vX.Y.Z`. */
+  version: string;
+  entries?: readonly string[];
+}
+
+/**
+ * Parse a manifest body. Returns null for anything that is not a manifest
+ * with a usable version — a corrupt manifest must read as "unknown", which
+ * `assetPayloadSkew` treats as skew, never as agreement.
+ */
+export function parseAssetPayloadManifest(
+  body: string,
+): AssetPayloadManifest | null {
+  try {
+    const parsed = JSON.parse(body) as { version?: unknown; entries?: unknown };
+    const version = parsed?.version;
+    if (typeof version !== "string" || !/^v?\d+\.\d+\.\d+/.test(version.trim())) {
+      return null;
+    }
+    return {
+      version: normaliseVersion(version),
+      entries: Array.isArray(parsed.entries)
+        ? parsed.entries.filter((e): e is string => typeof e === "string")
+        : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function normaliseVersion(v: string): string {
+  return `v${v.trim().replace(/^v/, "")}`;
+}
+
+export type AssetPayloadSkewStatus =
+  /** No payload manifest was found at any probed location. */
+  | "missing"
+  /** A payload exists but its version could not be read. */
+  | "unreadable"
+  /** Payload version differs from the running CLI's. */
+  | "skewed"
+  /** Payload and CLI agree. */
+  | "matched";
+
+export interface AssetPayloadSkew {
+  status: AssetPayloadSkewStatus;
+  cliVersion: string;
+  payloadVersion: string | null;
+  /** Where the manifest was found, when it was. */
+  manifestPath: string | null;
+  /** Every path probed for the manifest. */
+  candidates: readonly string[];
+  /** True when the CLI must not be trusted to render current scaffolds. */
+  ok: boolean;
+  /** Operator-facing one-liner. */
+  message: string;
+}
+
+/**
+ * Compare the running CLI's version against the installed payload's.
+ *
+ * `readText` is injected so this is testable without a fixture tree; it must
+ * return the file body or null/throw when unreadable.
+ */
+export function assetPayloadSkew(opts: {
+  cliVersion: string;
+  probe: ShippedAssetProbe;
+  readText?: (path: string) => string | null;
+}): AssetPayloadSkew {
+  const cliVersion = normaliseVersion(opts.cliVersion);
+  const resolution = resolveShippedAsset(ASSET_MANIFEST_ASSET, opts.probe);
+  const base = {
+    cliVersion,
+    candidates: resolution.candidates,
+  };
+  if (resolution.path === null) {
+    return {
+      ...base,
+      status: "missing",
+      payloadVersion: null,
+      manifestPath: null,
+      ok: false,
+      message:
+        `no shipped-asset payload found for switchroom ${cliVersion} ` +
+        `(${describeShippedAssetSearch(resolution)}). Agent scaffolding needs ` +
+        `profiles/, skills/ and vendor/ on disk; re-run the installer or ` +
+        `\`switchroom update\` to fetch the payload for this release.`,
+    };
+  }
+  const readText =
+    opts.readText ??
+    ((p: string): string | null => {
+      try {
+        return readFileSync(p, "utf-8");
+      } catch {
+        return null;
+      }
+    });
+  let body: string | null = null;
+  try {
+    body = readText(resolution.path);
+  } catch {
+    body = null;
+  }
+  const manifest = body === null ? null : parseAssetPayloadManifest(body);
+  if (!manifest) {
+    return {
+      ...base,
+      status: "unreadable",
+      payloadVersion: null,
+      manifestPath: resolution.path,
+      ok: false,
+      message:
+        `the shipped-asset payload at ${resolution.path} has no readable ` +
+        `version. Treating it as skewed from switchroom ${cliVersion} — ` +
+        `re-run \`switchroom update\` to reinstall it.`,
+    };
+  }
+  if (manifest.version !== cliVersion) {
+    return {
+      ...base,
+      status: "skewed",
+      payloadVersion: manifest.version,
+      manifestPath: resolution.path,
+      ok: false,
+      message:
+        `shipped-asset payload is ${manifest.version} but the CLI is ` +
+        `${cliVersion} (${resolution.path}). The CLI renders agent scaffolds ` +
+        `from these templates, so a mismatched pair ships a new CLI against ` +
+        `old templates — re-run \`switchroom update\` to bring them together.`,
+    };
+  }
+  return {
+    ...base,
+    status: "matched",
+    payloadVersion: manifest.version,
+    manifestPath: resolution.path,
+    ok: true,
+    message: `shipped-asset payload ${manifest.version} matches the CLI (${resolution.path})`,
+  };
 }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -65,6 +65,11 @@ import { fetchAgentLogsViaHostd } from "./hostd-read-client.js";
 import { handleWebhookIngest } from "./webhook-handler.js";
 import { loadEdgeSecret } from "./webhook-edge.js";
 import {
+  WEB_UI_ASSET,
+  resolveShippedAsset,
+  type ShippedAssetProbe,
+} from "../util/shipped-assets.js";
+import {
   handleHermesRest,
   onHermesOpen,
   onHermesClose,
@@ -710,14 +715,41 @@ function parseRoute(
   return null;
 }
 
+/**
+ * The directory `switchroom web` serves static dashboard files from.
+ *
+ * Exported so a test can drive the SEA layout, which vitest cannot otherwise
+ * reach. Falls back to the historical `<bundleDir>/ui` when nothing exists, so
+ * the 404 path is unchanged rather than throwing at server start.
+ */
+export function resolveUiDir(
+  probe: ShippedAssetProbe = {
+    bundleDir: import.meta.dirname,
+    execPath: process.execPath,
+  },
+): string {
+  return (
+    resolveShippedAsset(WEB_UI_ASSET, probe).path ??
+    resolve(probe.bundleDir, WEB_UI_ASSET.asset)
+  );
+}
+
 export function startWebServer(
   config: SwitchroomConfig,
   port: number,
   hostname = "127.0.0.1",
   configPath?: string,
 ): { token: string } {
-  const uiDirRaw = resolve(import.meta.dirname, "ui");
-  // Resolve symlinks once at startup so the traversal check compares real paths.
+  // `resolve(import.meta.dirname, "ui")` alone is the #3346/#4161 shape: it
+  // finds `dist/cli/ui` (npm) and `/opt/switchroom/ui` (image), but inside a
+  // `bun build --compile` binary `import.meta.dirname` is the bunfs root, so
+  // it resolved to `/$bunfs/root/ui` and every static route of `switchroom
+  // web` 404'd. Route it through the shared resolver so the SEA layout picks
+  // the directory up from the shipped-asset payload beside the binary (#4163).
+  const uiDirRaw = resolveUiDir();
+  // Resolve symlinks once at startup so the traversal check compares real
+  // paths — load-bearing here, not tidiness: the payload publishes
+  // `<prefix>/share/switchroom` AS a symlink to a versioned directory.
   const uiDir = existsSync(uiDirRaw) ? realpathSync(uiDirRaw) : uiDirRaw;
   const token = resolveWebToken();
 

--- a/tests/asset-payload-contract.test.ts
+++ b/tests/asset-payload-contract.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The shipped-asset payload must actually CONTAIN everything the CLI resolves
+ * through `resolveShippedAsset` (#4163).
+ *
+ * The bug this guards: the resolver and the payload builder are two lists in
+ * two files (`src/util/shipped-assets.ts` and
+ * `scripts/build-asset-payload.mjs`). Adding a new shipped asset to the
+ * resolver without adding a producer to the payload reproduces #4161 exactly —
+ * a static-binary install that resolves the asset to a path nothing ever wrote.
+ * That failure is invisible until an operator runs the affected command on a
+ * `curl … | sh` host, which is the worst possible place to discover it.
+ *
+ * These tests stage a REAL payload from this checkout (git-tracked files only,
+ * same code path the release job runs) and resolve against it with the SEA
+ * layout, so they assert the outcome — "the file is there and the resolver
+ * finds it" — rather than comparing two hard-coded lists.
+ */
+
+import { describe, it, expect } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  HINDSIGHT_VENDOR_ASSET,
+  PROFILES_ASSET,
+  SKILLS_ASSET,
+  WEB_UI_ASSET,
+  ASSET_MANIFEST_FILENAME,
+  parseAssetPayloadManifest,
+  resolveShippedAsset,
+  type ShippedAssetSpec,
+} from "../src/util/shipped-assets.js";
+// The builder is plain ESM with no bundler-specific syntax, so vitest can
+// import it directly — the point is to exercise the SHIPPING code path, not a
+// re-implementation of it.
+import {
+  PAYLOAD_ENTRIES,
+  stagePayload,
+} from "../scripts/build-asset-payload.mjs";
+
+/**
+ * Every asset the CLI resolves from the shipped payload. The manifest itself
+ * is excluded: it is written BY the builder rather than copied from the repo,
+ * and is asserted separately below.
+ */
+const RESOLVED_ASSETS: ShippedAssetSpec[] = [
+  PROFILES_ASSET,
+  SKILLS_ASSET,
+  HINDSIGHT_VENDOR_ASSET,
+  WEB_UI_ASSET,
+];
+
+const VERSION = "v0.0.0-contract";
+
+function withStagedPayload<T>(fn: (installRoot: string) => T): T {
+  const tmp = mkdtempSync(join(tmpdir(), "payload-contract-"));
+  try {
+    // Mirror the real install layout: <prefix>/bin/switchroom next to
+    // <prefix>/share/switchroom/<asset>, which is the SEA candidate.
+    const installRoot = join(tmp, "share", "switchroom");
+    stagePayload(installRoot, VERSION);
+    return fn(installRoot);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+describe("the payload contains every asset the CLI resolves (#4163)", () => {
+  it("resolves each asset from a staged payload via the SEA layout", () => {
+    withStagedPayload((installRoot) => {
+      const execPath = join(installRoot, "..", "..", "bin", "switchroom");
+      for (const spec of RESOLVED_ASSETS) {
+        const r = resolveShippedAsset(spec, {
+          // The bunfs root, as a compiled binary genuinely sees it.
+          bundleDir: "/$bunfs/root",
+          execPath,
+          env: {},
+        });
+        expect(
+          r.path,
+          `${spec.asset} is resolved by the CLI but has no producer in ` +
+            `PAYLOAD_ENTRIES (scripts/build-asset-payload.mjs) — a ` +
+            `static-binary install would resolve it to a path nothing wrote`,
+        ).not.toBeNull();
+        expect(r.source).toBe("sea-sibling");
+        expect(existsSync(r.path as string)).toBe(true);
+      }
+    });
+  });
+
+  it("ships the content each asset is actually used FOR, not just the directory", () => {
+    // An empty directory would satisfy an existsSync-only check while still
+    // failing `switchroom apply`. Assert one load-bearing file per asset.
+    withStagedPayload((installRoot) => {
+      for (const rel of [
+        "profiles/default/CLAUDE.md.hbs",
+        "profiles/_base/start.sh.hbs",
+        "ui/index.html",
+      ]) {
+        expect(existsSync(join(installRoot, rel)), rel).toBe(true);
+      }
+      // skills/ and vendor/ are pools whose exact members change; assert they
+      // are non-empty by way of the manifest's file count instead.
+    });
+  });
+
+  it("writes a manifest the CLI can parse, naming every entry", () => {
+    withStagedPayload((installRoot) => {
+      const body = readFileSync(join(installRoot, ASSET_MANIFEST_FILENAME), "utf8");
+      const manifest = parseAssetPayloadManifest(body);
+      expect(manifest?.version).toBe(VERSION.replace(/^v?/, "v"));
+      expect(new Set(manifest?.entries)).toEqual(
+        new Set(PAYLOAD_ENTRIES.map(([, dest]: [string, string]) => dest)),
+      );
+      const parsed = JSON.parse(body) as { files: number };
+      expect(parsed.files).toBeGreaterThan(0);
+    });
+  });
+
+  it("resolves the manifest through the SAME probe as the assets", () => {
+    // Otherwise "which payload am I running" could answer a different
+    // directory than "which profiles am I using", which is how skew hides.
+    withStagedPayload((installRoot) => {
+      const execPath = join(installRoot, "..", "..", "bin", "switchroom");
+      const profiles = resolveShippedAsset(PROFILES_ASSET, {
+        bundleDir: "/$bunfs/root",
+        execPath,
+        env: {},
+      });
+      expect(profiles.path).toBe(join(installRoot, "profiles"));
+    });
+  });
+});

--- a/tests/e2e/sea-install/Dockerfile
+++ b/tests/e2e/sea-install/Dockerfile
@@ -1,0 +1,14 @@
+FROM debian:bookworm-slim
+# curl/tar/gzip: what install.sh needs. python3: the local artifact server.
+RUN apt-get update -qq && apt-get install -y -qq \
+      curl ca-certificates python3 tar gzip docker.io \
+  && rm -rf /var/lib/apt/lists/*
+# The compose v2 plugin. `switchroom apply` runs a compose-v2 preflight, and a
+# host WITHOUT it (and without a vault) fingerprints as an AGENT container via
+# isInAgentContainer and refuses the per-agent scaffold. The preflight only
+# runs `docker compose version`; no daemon is contacted.
+RUN mkdir -p /usr/libexec/docker/cli-plugins \
+ && curl -fsSL -o /usr/libexec/docker/cli-plugins/docker-compose \
+      https://github.com/docker/compose/releases/download/v2.29.7/docker-compose-linux-x86_64 \
+ && chmod +x /usr/libexec/docker/cli-plugins/docker-compose \
+ && docker compose version

--- a/tests/e2e/sea-install/acceptance.sh
+++ b/tests/e2e/sea-install/acceptance.sh
@@ -1,0 +1,146 @@
+#!/bin/sh
+# Runs INSIDE a fresh container. Nothing switchroom-related is pre-staged:
+# the only inputs are the release artifacts served over HTTP and install.sh.
+set -eu
+
+fail() { echo "E2E-FAIL: $*" >&2; exit 1; }
+step() { echo; echo "=== $* ==="; }
+
+step "0. prove the host is virgin"
+[ ! -e /usr/local/bin/switchroom ] || fail "binary pre-staged"
+[ ! -e /usr/local/share/switchroom ] || fail "assets pre-staged"
+[ ! -e /usr/share/switchroom ] || fail "assets pre-staged in /usr/share"
+if env | grep -E '^SWITCHROOM_(PROFILES|SKILLS|HINDSIGHT_VENDOR|WEB_UI|ASSET_MANIFEST)'; then
+  fail "an asset-root override is set — the acceptance criterion forbids it"
+fi
+echo "ok: no binary, no assets, no *_ROOT override"
+
+step "1. serve the release artifacts over HTTP"
+python3 -m http.server 8000 --directory /artifacts --bind 127.0.0.1 >/tmp/http.log 2>&1 &
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  curl -fsS http://127.0.0.1:8000/switchroom-checksums.txt >/dev/null 2>&1 && break
+  sleep 0.3
+done
+curl -fsS http://127.0.0.1:8000/switchroom-checksums.txt >/dev/null || fail "artifact server did not come up"
+
+step "2. run the REAL install.sh (the curl | sh path)"
+SWITCHROOM_VERSION="$SR_VERSION" \
+SWITCHROOM_BASE_URL="http://127.0.0.1:8000" \
+  sh /repo/install.sh
+
+step "3. what did the installer actually put on disk?"
+[ -x /usr/local/bin/switchroom ] || fail "no binary at /usr/local/bin/switchroom"
+[ -L /usr/local/share/switchroom ] || fail "/usr/local/share/switchroom is not a symlink"
+echo "  share symlink -> $(readlink /usr/local/share/switchroom)"
+[ -d /usr/local/share/switchroom/profiles ] || fail "no profiles/ in the payload"
+[ -d /usr/local/share/switchroom/skills ] || fail "no skills/ in the payload"
+[ -d /usr/local/share/switchroom/vendor/hindsight-memory ] || fail "no vendor/hindsight-memory/"
+[ -d /usr/local/share/switchroom/ui ] || fail "no web ui/"
+[ -f /usr/local/share/switchroom/switchroom-assets.json ] || fail "no manifest"
+cat /usr/local/share/switchroom/switchroom-assets.json
+
+step "4. the CLI runs and reports its version"
+/usr/local/bin/switchroom --version
+
+step "5. doctor's payload check agrees with the CLI"
+switchroom doctor 2>&1 | grep -iA2 "shipped-asset payload" | head -8 || true
+
+step "6. bootstrap a config with `switchroom setup --non-interactive`"
+# The first command a curl|sh user runs. It does much more than write the
+# config (bot tokens etc) so it is expected to exit non-zero here; what is
+# under test is that the EMBEDDED example is written at all.
+switchroom setup --non-interactive >/tmp/setup.log 2>&1 || true
+[ -f "$HOME/.switchroom/switchroom.yaml" ] \
+  || { tail -20 /tmp/setup.log; fail "setup did not bootstrap a config"; }
+if grep -q "Example config not found" /tmp/setup.log; then
+  fail "setup still cannot find its embedded example"
+fi
+echo "ok: $HOME/.switchroom/switchroom.yaml written by setup"
+
+step "6b. initialise the vault + the one secret the example config references"
+# The example config references `vault:` keys, and apply refuses to scaffold
+# against a missing vault. A real operator does this through the interactive
+# `switchroom setup`; scripted here so the run stays non-interactive. Note this
+# stages NO profiles/skills/assets — only a secret.
+export SWITCHROOM_VAULT_PASSPHRASE="e2e-passphrase"
+switchroom vault init >/tmp/vault.log 2>&1 || { tail -5 /tmp/vault.log; fail "vault init"; }
+for key in $(grep -oE 'vault:[A-Za-z0-9_./-]+' "$HOME/.switchroom/switchroom.yaml" | sed 's/^vault://' | sort -u); do
+  printf 'e2e-dummy-value' > /tmp/secret.txt
+  switchroom vault set "$key" --file /tmp/secret.txt >>/tmp/vault.log 2>&1 \
+    || { tail -5 /tmp/vault.log; fail "vault set $key"; }
+  echo "  vaulted $key"
+done
+
+step "7. THE ACCEPTANCE CRITERION: switchroom apply --non-interactive"
+cd "$HOME/.switchroom"
+# The ONE concession to running the acceptance check inside a container: apply
+# refuses to deploy from a container unless told where the HOST's home is, so
+# it can translate bind-mount sources. Unrelated to asset resolution, and NOT
+# an asset-root override (the criterion forbids SWITCHROOM_*_ROOT only).
+export SWITCHROOM_HOST_HOME="$HOME"
+set +e
+switchroom apply --non-interactive --no-doctor > /tmp/apply.log 2>&1
+apply_status=$?
+set -e
+tail -40 /tmp/apply.log
+echo "apply exit status: $apply_status"
+
+step "8. did every agent in the config actually get scaffolded?"
+agents=$(switchroom config agents 2>/dev/null || true)
+if [ -z "$agents" ]; then
+  # Fall back to reading the config directly.
+  agents=$(python3 - <<'PY'
+import re,sys,os
+p=os.path.expanduser("~/.switchroom/switchroom.yaml")
+body=open(p).read()
+m=re.search(r'^agents:\s*$', body, re.M)
+out=[]
+if m:
+    for line in body[m.end():].splitlines():
+        if re.match(r'^\S', line): break
+        n=re.match(r'^  ([A-Za-z0-9_-]+):\s*$', line)
+        if n: out.append(n.group(1))
+print("\n".join(out))
+PY
+)
+fi
+echo "agents in config: $(echo "$agents" | tr '\n' ' ')"
+[ -n "$agents" ] || fail "could not determine the agent list"
+for a in $agents; do
+  d="$HOME/.switchroom/agents/$a"
+  [ -f "$d/start.sh" ] || fail "agent $a: no start.sh scaffolded"
+  [ -f "$d/CLAUDE.md" ] || fail "agent $a: no CLAUDE.md scaffolded"
+  if grep -q 'Profile not found' "$d/CLAUDE.md"; then fail "agent $a: profile did not resolve"; fi
+  # #4163: repoRoot rendered empty under SEA and the self-test never ran.
+  if grep -q '//bin/boot-self-test.sh' "$d/start.sh"; then
+    fail "agent $a: start.sh still has the empty-repoRoot self-test path"
+  fi
+  grep -q '/opt/switchroom/bin/boot-self-test.sh' "$d/start.sh" \
+    || fail "agent $a: start.sh lost the boot self-test"
+  echo "  ok: $a (start.sh, CLAUDE.md, in-container self-test path)"
+done
+
+step "9. skills pool seeded from the payload, not hand-staged"
+pool="$HOME/.switchroom/skills/_bundled"
+[ -d "$pool" ] || fail "no bundled skills pool — apply did not seed it from the payload"
+[ -f "$pool/.switchroom-manifest.json" ] || fail "pool has no ownership manifest"
+echo "  pool: $(ls "$pool" | wc -l) entries, e.g. $(ls "$pool" | head -3 | tr '\n' ' ')"
+if grep -q "bundled skills pool dir not found" /tmp/apply.log; then
+  fail "apply still reported a missing bundled skills pool"
+fi
+# PRE-EXISTING, orthogonal to #4163: a name in `skills:` is looked up in the
+# pool ROOT (syncGlobalSkills -> resolveSkillsPoolDir), but bundled skills live
+# in <pool>/_bundled, so the example config's `skills:` list warns even on a
+# long-lived dev host. Reported, not asserted. The bundled-DEFAULTS path
+# (reconcileAgentDefaultSkills) reads _bundled directly and is asserted below.
+grep -c 'not found in pool' /tmp/apply.log | sed 's/^/  (pre-existing) skills: entries unresolved in pool root: /'
+
+# The skills actually reached the agent, not just the pool.
+for a in $agents; do
+  n=$(ls "$HOME/.switchroom/agents/$a/.claude/skills" 2>/dev/null | wc -l)
+  [ "$n" -gt 0 ] || fail "agent $a: no skills linked into .claude/skills"
+  echo "  $a: $n skills linked, e.g. $(ls "$HOME/.switchroom/agents/$a/.claude/skills" | head -3 | tr '\n' ' ')"
+done
+
+echo
+echo "E2E-PASS"

--- a/tests/e2e/sea-install/run.sh
+++ b/tests/e2e/sea-install/run.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Reproduce the #4163 acceptance criterion end to end:
+#
+#   "A host that has only ever run `curl -fsSL … | sh` can run
+#    `switchroom apply --non-interactive` and scaffold every agent, with no
+#    SWITCHROOM_*_ROOT env override and no hand-staged directories."
+#
+# Builds the real release artifacts (static binary + asset payload + checksums),
+# serves them over local HTTP inside a fresh Debian container, runs the REAL
+# install.sh against them, and then applies. Not wired into CI — it needs a
+# docker daemon and a bun toolchain — but it is the only check that exercises
+# installer + payload + resolver + scaffold together.
+#
+# Usage:  sh tests/e2e/sea-install/run.sh
+set -eu
+
+repo=$(cd "$(dirname "$0")/../../.." && pwd)
+work=${SR_E2E_WORK:-/var/tmp/sr-e2e}
+version=v$(node -e "process.stdout.write(require('$repo/package.json').version)")
+
+mkdir -p "$work/dist"
+( cd "$repo" \
+  && npm run build:cli \
+  && node scripts/build-asset-payload.mjs --version "$version" --out switchroom-assets.tar.gz )
+cp "$repo/switchroom-linux-amd64" "$repo/switchroom-assets.tar.gz" "$work/dist/"
+( cd "$work/dist" \
+  && sha256sum switchroom-linux-amd64 switchroom-assets.tar.gz > switchroom-checksums.txt )
+
+docker build -q -t sr-e2e:latest -f "$(dirname "$0")/Dockerfile" "$(dirname "$0")"
+docker run --rm \
+  --label switchroom.test=e2e-4163 \
+  -e SR_VERSION="$version" \
+  -v "$work/dist:/artifacts:ro" \
+  -v "$repo:/repo:ro" \
+  sr-e2e:latest sh /repo/tests/e2e/sea-install/acceptance.sh

--- a/tests/install/static-binary.test.ts
+++ b/tests/install/static-binary.test.ts
@@ -29,45 +29,66 @@ function bunAvailable(): boolean {
   }
 }
 
+/**
+ * Compile the CLI into a single static binary in `dir`. Mirrors the production
+ * `package.json` build:cli target but stripped down (no --target / --minify so
+ * the build is fast).
+ */
+function compileStaticBinary(dir: string): string {
+  const binPath = join(dir, "switchroom-bin");
+  const compile = spawnSync(
+    "bun",
+    [
+      "build",
+      "--compile",
+      resolve(REPO_ROOT, "bin/switchroom.ts"),
+      "--outfile",
+      binPath,
+    ],
+    { cwd: REPO_ROOT, encoding: "utf8" },
+  );
+  if (compile.status !== 0) {
+    throw new Error(
+      `bun build --compile failed:\nstdout: ${compile.stdout}\nstderr: ${compile.stderr}`,
+    );
+  }
+  return binPath;
+}
+
+/**
+ * A process env with EVERY `SWITCHROOM_*` var stripped.
+ *
+ * Without this the test inherits the developer's / CI runner's own switchroom
+ * environment: `SWITCHROOM_CONFIG` pointed the binary at a live fleet config
+ * (observed on a dev host — setup happily loaded a real 5-agent config and
+ * never bootstrapped anything), and `SWITCHROOM_PROFILES_ROOT` and friends
+ * would mask exactly the resolution bug these tests exist to catch.
+ */
+function sandboxEnv(fakeHome: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (!k.startsWith("SWITCHROOM_")) env[k] = v;
+  }
+  env.HOME = fakeHome;
+  // Skip the docker-compose-v2 preflight; these tests only care about the
+  // config-bootstrap step.
+  env.SWITCHROOM_SKIP_PREFLIGHT = "1";
+  return env;
+}
+
 describe("static binary — import.meta.dirname regression", () => {
   it.skipIf(!bunAvailable())(
     "apply --example switchroom works inside a `bun build --compile` artifact",
     () => {
       const tmp = mkdtempSync(join(tmpdir(), "switchroom-static-"));
-      const binPath = join(tmp, "switchroom-bin");
-
-      // Compile the CLI into a single static binary. Mirrors the
-      // production `package.json` build:cli target but stripped down
-      // (no --target / --minify so the build is fast).
-      const compile = spawnSync(
-        "bun",
-        [
-          "build",
-          "--compile",
-          resolve(REPO_ROOT, "bin/switchroom.ts"),
-          "--outfile",
-          binPath,
-        ],
-        { cwd: REPO_ROOT, encoding: "utf8" },
-      );
-      if (compile.status !== 0) {
-        throw new Error(
-          `bun build --compile failed:\nstdout: ${compile.stdout}\nstderr: ${compile.stderr}`,
-        );
-      }
+      const binPath = compileStaticBinary(tmp);
       expect(existsSync(binPath)).toBe(true);
 
       // Need a writable home + cwd so apply doesn't blow up writing
       // the compose file or hitting the agents-dir.
       const fakeHome = join(tmp, "home");
       const cwd = join(tmp, "work");
-      const env = {
-        ...process.env,
-        HOME: fakeHome,
-        // Skip docker-compose-v2 preflight; we only care that the
-        // example-copy step succeeds.
-        SWITCHROOM_SKIP_PREFLIGHT: "1",
-      };
+      const env = sandboxEnv(fakeHome);
       execFileSync("mkdir", ["-p", fakeHome, cwd]);
 
       // Run `apply --example switchroom` — but we don't actually want
@@ -96,6 +117,47 @@ describe("static binary — import.meta.dirname regression", () => {
       // Sanity: the embedded example is non-empty and looks like YAML.
       expect(contents.length).toBeGreaterThan(50);
       expect(contents).toMatch(/agents\s*:/);
+    },
+    120_000,
+  );
+
+  it.skipIf(!bunAvailable())(
+    "setup --non-interactive bootstraps switchroom.yaml from the EMBEDDED example (#4163)",
+    () => {
+      // `setup` is the first command a `curl … | sh` user runs, and it kept
+      // its own copy of the example lookup: `resolve(import.meta.dirname,
+      // "../../examples")` → `/examples` inside the binary, so it died with
+      // "Example config not found" while `apply --example` (already embedded)
+      // worked. Both now go through src/cli/embedded-examples.ts.
+      const tmp = mkdtempSync(join(tmpdir(), "switchroom-static-setup-"));
+      const binPath = compileStaticBinary(tmp);
+
+      const fakeHome = join(tmp, "home");
+      const cwd = join(tmp, "work");
+      execFileSync("mkdir", ["-p", fakeHome, cwd]);
+
+      const run = spawnSync(binPath, ["setup", "--non-interactive"], {
+        cwd,
+        env: sandboxEnv(fakeHome),
+        encoding: "utf8",
+        timeout: 60_000,
+      });
+
+      // setup does a lot more than write the config and may well not exit 0
+      // in a bare sandbox — but the bootstrap step runs first, and the bug
+      // being guarded made it THROW rather than write anything. The
+      // destination is the user-wide path, not cwd (see copyExampleConfig).
+      const dest = join(fakeHome, ".switchroom", "switchroom.yaml");
+      expect(
+        existsSync(dest),
+        `Expected switchroom.yaml at ${dest}.\nstdout: ${run.stdout}\nstderr: ${run.stderr}`,
+      ).toBe(true);
+      const contents = readFileSync(dest, "utf8");
+      expect(contents).toMatch(/agents\s*:/);
+      // The precise failure mode of an un-inlined text import: the module
+      // PATH written out instead of the file body.
+      expect(contents.trim()).not.toMatch(/^\/?examples\/\S+\.yaml$/);
+      expect(run.stderr ?? "").not.toContain("Example config not found");
     },
     120_000,
   );

--- a/tests/release-asset-contract.test.ts
+++ b/tests/release-asset-contract.test.ts
@@ -24,7 +24,16 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -82,9 +91,40 @@ const ASSETS = [
   "switchroom-macos-arm64",
 ];
 const CHECKSUMS = "switchroom-checksums.txt";
+/** #4163 — the shipped-asset payload, alongside the four binaries. */
+const PAYLOAD = "switchroom-assets.tar.gz";
+const PAYLOAD_VERSION = "v0.0.0-test";
+
+/**
+ * A real gzip tarball shaped like the one scripts/build-asset-payload.mjs
+ * produces: a version manifest at the root plus the asset directories the CLI
+ * probes for. Real, not a stub, because install.sh actually untars it and
+ * reads the manifest back out.
+ */
+function makePayloadTarball(dest: string, opts: { version?: string } = {}): void {
+  const stage = tmp();
+  mkdirSync(join(stage, "profiles/_base"), { recursive: true });
+  writeFileSync(join(stage, "profiles/_base/start.sh.hbs"), "#!/bin/sh\n");
+  mkdirSync(join(stage, "skills"), { recursive: true });
+  writeFileSync(join(stage, "skills/.keep"), "");
+  writeFileSync(
+    join(stage, "switchroom-assets.json"),
+    `${JSON.stringify({ version: opts.version ?? PAYLOAD_VERSION, entries: ["profiles", "skills"], files: 2 }, null, 2)}\n`,
+  );
+  const r = spawnSync("tar", ["-czf", dest, "-C", stage, "."], { encoding: "utf8" });
+  if (r.status !== 0) throw new Error(`tar failed: ${r.stderr}`);
+}
 
 /** Build a bundle dir shaped exactly like the workflow's `dist-bins`. */
-function makeBundle(opts: { separator?: string; omit?: string[]; extra?: string[]; corrupt?: string } = {}): string {
+function makeBundle(
+  opts: {
+    separator?: string;
+    omit?: string[];
+    extra?: string[];
+    corrupt?: string;
+    payloadVersion?: string;
+  } = {},
+): string {
   const d = tmp();
   const sep = opts.separator ?? "  ";
   const omit = new Set(opts.omit ?? []);
@@ -98,6 +138,14 @@ function makeBundle(opts: { separator?: string; omit?: string[]; extra?: string[
         ? "0".repeat(64)
         : createHash("sha256").update(Buffer.from(body)).digest("hex");
     lines.push(`${hash}${sep}${asset}`);
+  }
+  if (!omit.has(PAYLOAD)) {
+    makePayloadTarball(join(d, PAYLOAD), { version: opts.payloadVersion });
+    const hash =
+      opts.corrupt === PAYLOAD
+        ? "0".repeat(64)
+        : createHash("sha256").update(readFileSync(join(d, PAYLOAD))).digest("hex");
+    lines.push(`${hash}${sep}${PAYLOAD}`);
   }
   if (!omit.has(CHECKSUMS)) writeFileSync(join(d, CHECKSUMS), `${lines.join("\n")}\n`);
   for (const extra of opts.extra ?? []) writeFileSync(join(d, extra), "stray\n");
@@ -166,10 +214,58 @@ describe("check-release-asset-names (static contract)", () => {
   });
 
   it("fails when install.sh's checksum lookup separator stops matching sha256sum output", () => {
-    const env = stage({ installSh: (s) => s.replace('grep -F "  ${asset}"', 'grep -F " ${asset}"') });
+    const env = stage({ installSh: (s) => s.replace('grep -F "  ${1}"', 'grep -F " ${1}"') });
     const r = runCheck(env);
     expect(r.ok).toBe(false);
     expect(r.out).toContain("separator");
+  });
+
+  // ---- #4163: the shipped-asset payload is part of the contract ----
+  //
+  // A release that ships four binaries and no payload installs a CLI that
+  // cannot scaffold a single agent. That failure surfaces LATER than a 404 —
+  // on the user's host, at `switchroom apply` — so the naming contract has to
+  // cover the tarball exactly as it covers the binaries.
+
+  it("names the asset payload on the real files", () => {
+    const r = runCheck();
+    expect(r.ok).toBe(true);
+    expect(r.out).toContain(PAYLOAD);
+  });
+
+  it("fails when the workflow renames the payload the installer still asks for", () => {
+    const env = stage({ workflow: (s) => s.replace(/PAYLOAD_ASSET: ".*"/, 'PAYLOAD_ASSET: "switchroom-share.tgz"') });
+    const r = runCheck(env);
+    expect(r.ok).toBe(false);
+    expect(r.out).toContain("switchroom-share.tgz");
+    expect(r.out).toContain(PAYLOAD);
+  });
+
+  it("fails loudly when install.sh stops fetching a payload at all", () => {
+    const env = stage({ installSh: (s) => s.replace(/assets_payload="[^"]*"/, 'assets_payload_gone=""') });
+    const r = runCheck(env);
+    expect(r.ok).toBe(false);
+    expect(r.out).toContain("could not derive the contract");
+    expect(r.out).toContain("#4163");
+  });
+
+  it("fails when the workflow declares a payload but never builds one", () => {
+    const env = stage({ workflow: (s) => s.replaceAll("scripts/build-asset-payload.mjs", "scripts/nope.mjs") });
+    const r = runCheck(env);
+    expect(r.ok).toBe(false);
+    expect(r.out).toContain("build-asset-payload.mjs");
+  });
+
+  it("fails when the payload is smuggled into the per-platform RELEASE_ASSETS list", () => {
+    // Four build legs would then race to upload the same architecture-
+    // independent file, and `bundle`'s flatten step would look for it in an
+    // artifact that never contained it.
+    const env = stage({
+      workflow: (s) => s.replace(/RELEASE_ASSETS: "(.*)"/, `RELEASE_ASSETS: "$1 ${PAYLOAD}"`),
+    });
+    const r = runCheck(env);
+    expect(r.ok).toBe(false);
+    expect(r.out).toContain("env.RELEASE_ASSETS");
   });
 
   // ---- #3634: every asset is built on its own OS ----
@@ -242,6 +338,19 @@ describe("verify-release-bundle (runtime contract)", () => {
     const r = runVerify(makeBundle({ extra: ["switchroom-linux-amd64.dSYM"] }));
     expect(r.ok).toBe(false);
     expect(r.out).toContain("unexpected file");
+  });
+
+  it("rejects a bundle with every binary but no asset payload (#4163)", () => {
+    const r = runVerify(makeBundle({ omit: [PAYLOAD] }));
+    expect(r.ok).toBe(false);
+    expect(r.out).toContain(`missing: ${PAYLOAD}`);
+  });
+
+  it("checksum-verifies the payload, not just the binaries", () => {
+    const r = runVerify(makeBundle({ corrupt: PAYLOAD }));
+    expect(r.ok).toBe(false);
+    expect(r.out).toContain(PAYLOAD);
+    expect(r.out).toContain("hashes to");
   });
 
   it("rejects a missing checksums file", () => {
@@ -342,7 +451,7 @@ describe("install.sh against a workflow-shaped bundle", () => {
     return d;
   }
 
-  function runInstaller(bundleDir: string): Run {
+  function runInstaller(bundleDir: string, out?: { shareDir?: string }): Run {
     // The stub is an EXPORTED bash function, not a file on PATH: a script file
     // would need the exec bit, and a `noexec` tmpdir (common in hardened
     // sandboxes) would silently fall through to the real curl and hit
@@ -368,7 +477,14 @@ describe("install.sh against a workflow-shaped bundle", () => {
       "export -f curl",
       'bash "$INSTALL_SH"',
     ].join("\n");
-    const installDir = tmp();
+    const prefix = tmp();
+    const installDir = join(prefix, "bin");
+    mkdirSync(installDir, { recursive: true });
+    // Pinned INSIDE the test's tmp prefix. The default is
+    // `<dirname install_dir>/share/switchroom`, which for a real install is
+    // `/usr/local/share/switchroom` — never write there from a test.
+    const shareDir = join(prefix, "share/switchroom");
+    if (out) out.shareDir = shareDir;
     const r = spawnSync("bash", ["-c", stub], {
       cwd: REPO,
       encoding: "utf8",
@@ -376,8 +492,9 @@ describe("install.sh against a workflow-shaped bundle", () => {
         ...process.env,
         INSTALL_SH: REAL_INSTALL_SH,
         BUNDLE_DIR: bundleDir,
-        SWITCHROOM_VERSION: "v0.0.0-test",
+        SWITCHROOM_VERSION: PAYLOAD_VERSION,
         SWITCHROOM_INSTALL_DIR: installDir,
+        SWITCHROOM_SHARE_DIR: shareDir,
       },
     });
     return { ok: r.status === 0, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
@@ -398,5 +515,84 @@ describe("install.sh against a workflow-shaped bundle", () => {
     const r = runInstaller(d);
     expect(r.ok).toBe(false);
     expect(r.out).toContain("Checksum mismatch");
+  });
+
+  // ---- #4163: the payload has to actually land where the CLI probes ----
+
+  it("extracts the asset payload to <prefix>/share/switchroom via a versioned dir + symlink", () => {
+    const out: { shareDir?: string } = {};
+    const r = runInstaller(fakeBinaryBundle(), out);
+    expect(r.ok, r.out).toBe(true);
+    const shareDir = out.shareDir as string;
+
+    // The published path is a SYMLINK to a versioned directory. That is what
+    // makes the swap on the next install a rename of a link rather than a
+    // recursive delete of a live directory.
+    expect(lstatSync(shareDir).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(shareDir)).toBe(`switchroom-${PAYLOAD_VERSION.replace(/^v/, "")}`);
+
+    // And the contents are the ones src/util/shipped-assets.ts probes for.
+    expect(existsSync(join(shareDir, "profiles/_base/start.sh.hbs"))).toBe(true);
+    expect(existsSync(join(shareDir, "skills"))).toBe(true);
+    const manifest = JSON.parse(readFileSync(join(shareDir, "switchroom-assets.json"), "utf-8"));
+    expect(manifest.version).toBe(PAYLOAD_VERSION);
+  });
+
+  it("refuses to install a payload whose checksum does not match", () => {
+    const d = fakeBinaryBundle();
+    writeFileSync(join(d, PAYLOAD), "tampered\n");
+    const out: { shareDir?: string } = {};
+    const r = runInstaller(d, out);
+    expect(r.ok).toBe(false);
+    expect(r.out).toContain("Checksum mismatch");
+    expect(r.out).toContain(PAYLOAD);
+    // Nothing published: a payload that failed verification must not become
+    // the templates every agent is scaffolded from.
+    expect(existsSync(out.shareDir as string)).toBe(false);
+  });
+
+  it("refuses a payload whose manifest names a different release than the binary", () => {
+    // The skew guard the issue calls non-negotiable, at INSTALL time: a CLI
+    // must never be paired with someone else's templates.
+    const d = fakeBinaryBundle();
+    makePayloadTarball(join(d, PAYLOAD), { version: "v9.9.9" });
+    const hash = createHash("sha256").update(readFileSync(join(d, PAYLOAD))).digest("hex");
+    writeFileSync(
+      join(d, CHECKSUMS),
+      readFileSync(join(d, CHECKSUMS), "utf-8")
+        .split("\n")
+        .map((l) => (l.endsWith(`  ${PAYLOAD}`) ? `${hash}  ${PAYLOAD}` : l))
+        .join("\n"),
+    );
+    const out: { shareDir?: string } = {};
+    const r = runInstaller(d, out);
+    expect(r.ok).toBe(false);
+    expect(r.out).toContain("9.9.9");
+    expect(existsSync(out.shareDir as string)).toBe(false);
+  });
+
+  it("warns loudly, and does not silently succeed, on a release that predates the payload", () => {
+    // Installing an old tag is legal. Getting a CLI that dies at `switchroom
+    // apply` with no warning is not.
+    const d = makeBundle({ omit: [PAYLOAD] });
+    const platform = process.platform === "darwin" ? "macos" : "linux";
+    const arch = process.arch === "arm64" ? "arm64" : "amd64";
+    const asset = `switchroom-${platform}-${arch}`;
+    const body = '#!/bin/sh\necho "switchroom 0.0.0-test"\n';
+    writeFileSync(join(d, asset), body, { mode: 0o755 });
+    const hash = createHash("sha256").update(Buffer.from(body)).digest("hex");
+    writeFileSync(
+      join(d, CHECKSUMS),
+      readFileSync(join(d, CHECKSUMS), "utf-8")
+        .split("\n")
+        .map((l) => (l.endsWith(`  ${asset}`) ? `${hash}  ${asset}` : l))
+        .join("\n"),
+    );
+    const out: { shareDir?: string } = {};
+    const r = runInstaller(d, out);
+    expect(r.ok, r.out).toBe(true);
+    expect(r.out).toContain(PAYLOAD);
+    expect(r.out).toMatch(/WILL fail/);
+    expect(existsSync(out.shareDir as string)).toBe(false);
   });
 });

--- a/tests/release-gate-scripts.test.ts
+++ b/tests/release-gate-scripts.test.ts
@@ -211,15 +211,26 @@ function mkRelease(assets: string[], over: Record<string, unknown> = {}) {
 
 describe("assert-release-assets-complete — what a release must carry", () => {
   it("derives the expected set from install.sh, not from a hard-coded list", () => {
-    // Same four binaries + checksums file the installer downloads. If
-    // install.sh grows a platform, this set grows with it (proved below).
+    // Same four binaries + checksums file + shipped-asset payload the
+    // installer downloads. If install.sh grows a platform, this set grows with
+    // it (proved below).
     expect(REAL_EXPECTED).toEqual([
       "switchroom-linux-amd64",
       "switchroom-linux-arm64",
       "switchroom-macos-amd64",
       "switchroom-macos-arm64",
       "switchroom-checksums.txt",
+      "switchroom-assets.tar.gz",
     ]);
+  });
+
+  it("blocks a release that carries every binary but no asset payload (#4163)", () => {
+    // The half-ship this gate exists to catch, one artifact over: four green
+    // binaries and no templates is a release that installs cleanly and then
+    // fails on the user's host at `switchroom apply`.
+    const withoutPayload = REAL_EXPECTED.filter((a) => a !== "switchroom-assets.tar.gz");
+    const missing = missingAssets(REAL_EXPECTED, mkRelease(withoutPayload));
+    expect(missing).toEqual(["switchroom-assets.tar.gz"]);
   });
 
   it("grows the requirement when install.sh adds a platform", () => {

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -169,6 +169,38 @@ describe("scaffoldAgent", () => {
     expect(startSh).not.toContain("$(node -v)");
   });
 
+  it("start.sh launches the boot self-test from the in-container bin dir (#427, #4163)", () => {
+    // The boot self-test is what surfaces broken agent auth on the Telegram
+    // issues card. It was invoked as `{{repoRoot}}/bin/boot-self-test.sh`,
+    // where repoRoot came from the CLI's own `import.meta.dirname` — a HOST
+    // path baked into a script that only ever runs inside the container. Under
+    // `bun build --compile` that is the bunfs root, so every scaffolded agent
+    // got the literal `//bin/boot-self-test.sh`, the `-x` test failed, and the
+    // self-test silently never ran. Guarded from three sides because the
+    // failure mode was SILENCE: the invocation vanishing, or pointing anywhere
+    // other than the image's own bin dir, must each go red.
+    const config = makeAgentConfig();
+    const result = scaffoldAgent("selftest-agent", config, tmpDir, telegramConfig);
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+
+    // 1. It is still invoked at all.
+    expect(startSh).toContain("boot-self-test.sh");
+    // 2. From the path docker/Dockerfile.agent COPYs bin/*.sh to.
+    expect(startSh).toContain('[ -x "/opt/switchroom/bin/boot-self-test.sh" ]');
+    expect(startSh).toContain('( "/opt/switchroom/bin/boot-self-test.sh" >/dev/null 2>&1 ) &');
+    // 3. And from NOWHERE else — not the `//bin/…` the bunfs root rendered,
+    //    and not this repo's own path from a source checkout.
+    for (const line of startSh.split("\n")) {
+      if (!line.includes("boot-self-test.sh")) continue;
+      if (line.trimStart().startsWith("#")) continue;
+      expect(line, `unexpected boot-self-test path: ${line}`).toContain(
+        '"/opt/switchroom/bin/boot-self-test.sh"',
+      );
+    }
+    expect(startSh).not.toContain("//bin/boot-self-test.sh");
+    expect(startSh).not.toContain(`${resolve(__dirname, "..")}/bin/boot-self-test.sh`);
+  });
+
   it("start.sh does NOT export CLAUDE_CODE_OAUTH_TOKEN (RFC H §7.4)", () => {
     // Pre-RFC-H, start.sh exported CLAUDE_CODE_OAUTH_TOKEN from
     // <agentDir>/.claude/.oauth-token into the live claude process env.


### PR DESCRIPTION
Closes #4163. Stacked on #4162 (merged as e0a0ec79); this branch is rebased onto `origin/main`.

#4162 taught every call site to **probe** for `profiles/`, `skills/`, `vendor/hindsight-memory/` and the web `ui/`. It could not fix the actual gap: on a `curl … | sh` host those directories exist **nowhere**, because the release ships four binaries and a checksums file and nothing else (`release.yml` `RELEASE_ASSETS`, verified). This PR gives the probe something to find.

## What ships

- **`scripts/build-asset-payload.mjs`** builds `switchroom-assets.tar.gz` containing `profiles/`, `skills/`, `vendor/hindsight-memory/`, `ui/` plus a `switchroom-assets.json` manifest naming the release it belongs to (388 files).
- **`release.yml`** publishes the tarball and hashes it into the **same** `switchroom-checksums.txt` as the binaries. `scripts/check-release-asset-names.mjs`, `scripts/ci/assert-release-assets-complete.mjs`, `scripts/release-assets.mjs` and `scripts/verify-release-bundle.mjs` know about it, so a release that forgets the payload fails the gate rather than shipping a CLI with no templates.
- **`install.sh`** downloads it, sha256-verifies it against that checksums file **exactly as it verifies the binary** (same `checksum_for` helper, same refusal on mismatch), and publishes it as `<prefix>/share/switchroom-<version>` with a `<prefix>/share/switchroom` symlink — the third probe candidate `resolveShippedAsset` already looks in.
- **`src/cli/self-update.ts`** installs the payload and swaps the binary together (see below).
- **`switchroom doctor`** grows a "Shipped-asset payload" row (`src/cli/doctor-asset-payload.ts`) that goes red on skew, with `fix: switchroom update`. It **skips** on npm / Docker-image / env layouts so contributors are not permanently amber.

## How binary/payload atomicity is guaranteed

Four independent properties, because "atomic" across two downloads is not achievable on its own:

1. **Same release by construction.** Both artifacts come from one tag's download prefix and are verified against that tag's single checksums file. There is no code path that can fetch a payload from a different release than the binary.
2. **Ordered, each atomic.** The payload is installed **first** and the binary swapped **second**, and each is a single `rename(2)`: the payload unpacks to `<root>-<version>.incoming`, is renamed to `<root>-<version>`, then a `<root>.new-link` symlink is renamed over `<root>`. If either step fails the update aborts and the **old binary is untouched** — the worst case is a new payload with the old CLI, which is the direction that degrades gracefully (old CLI, newer templates) rather than the direction the issue warns about. Asserted: `self-update.test.ts` pins the order `["payload:<root>.new-link", "binary:swap"]`, and a failing `extractTarGz` leaves the binary at `"OLD-BINARY"` with no symlink published.
3. **Convergence, not just first-write.** The payload check/repair runs on **every** `switchroom update`, including the "already on the latest version" early-exit path. A host that somehow ends up with a stale or missing payload repairs it on the next update instead of drifting forever. Asserted in `update-self-update.test.ts`: with the CLI already current and no payload on disk, the run still publishes `switchroom-<version>`.
4. **Detectability.** `switchroom-assets.json` records the payload's version; `assetPayloadSkew()` compares it to the running CLI; doctor reports it. Skew cannot be silent.

Pruning keeps the current plus one previous version, so a rollback has something to roll back to.

## Also fixed (each was a live break on the SEA path)

- **`resolveShippedAsset` now returns the `realpath` of a hit** (`src/util/shipped-assets.ts`). The payload root *is* a symlink — the only atomic way to swap a directory — and `getProfilePath` compares a `realpath`'d child against the resolved root. Symlinked root vs real child ⇒ "escapes the root" ⇒ **`Invalid profile name: default` on every agent**. Caught by the container e2e below, not by unit tests, which is why the e2e exists.
- **`src/agents/scaffold.ts` `REPO_ROOT`** rendered `//bin/boot-self-test.sh` into `start.sh` under SEA — the boot self-test has silently never run on a binary install. `profiles/_base/start.sh.hbs` now uses the in-container path; `tests/scaffold.test.ts` fails if the empty-root form comes back.
- **`src/cli/setup.ts`** read its example config from a bunfs path and died with "Example config not found" — the first command a `curl … | sh` user runs. It now uses the embedded copy (`src/cli/embedded-examples.ts`), shared with `apply --example`.
- **`src/web/server.ts:719`** `ui` path now goes through the shared resolver (`resolveUiDir`).
- **First `apply` seeds the bundled-skills pool** (`src/cli/bootstrap-skills-pool.ts`). The pool is populated by `switchroom update`'s `sync-bundled-skills`; a fresh host has never run it, so the first apply scaffolded every agent against an empty pool. Bootstrap-only (never touches an existing pool — `update` owns it), writes the same ownership manifest, soft-fails.
- **`install.sh` is now POSIX `sh`.** The documented invocation pipes it to `sh`; on Debian/Ubuntu that is dash, where `set -euo pipefail` aborted on line 1 **before a single byte was installed** (a shebang does not save a piped script). Pre-existing, but it blocked this issue's own acceptance criterion. `dash -n install.sh` parses clean.

## Evidence: the acceptance criterion, end to end

`tests/e2e/sea-install/` (committed, `sh tests/e2e/sea-install/run.sh`). Fresh `debian:bookworm-slim`, asserts up front that there is no binary, no `/usr/local/share/switchroom`, and no `SWITCHROOM_*_ROOT` in the environment; serves locally built release artifacts over HTTP; runs the **real `install.sh`**; then:

```
=== 3. what did the installer actually put on disk? ===
  share symlink -> switchroom-0.18.0
  {"version":"0.18.0","files":388,...}
=== 7. THE ACCEPTANCE CRITERION: switchroom apply --non-interactive ===
  Seeded bundled skills pool (23 skills) from /usr/local/share/switchroom-0.18.0/skills
  + assistant (default) — 19 files created
  Done. Scaffolded 1/1 agents.
apply exit status: 0
=== 8. did every agent in the config actually get scaffolded? ===
  ok: assistant (start.sh, CLAUDE.md, in-container self-test path)
=== 9. skills pool seeded from the payload, not hand-staged ===
  pool: 23 entries
  assistant: 13 skills linked
E2E-PASS
```

**What was simulated, honestly:** the artifacts were built locally and served from `127.0.0.1:8000` rather than pulled from a real GitHub release — the tarball, the checksums file, the URL shape and the verification path are the real ones, but the actual `release.yml` run is unverified until a tag is cut. Three container concessions, none of them an asset-root override: the compose-v2 plugin is installed (without it `isInAgentContainer` fingerprints the box as an agent container and refuses to scaffold), the vault is initialised with dummy secrets (apply refuses against a missing vault), and `SWITCHROOM_HOST_HOME` is set (apply refuses to deploy from a container without it). macOS/arm64 payload extraction is unverified — the tarball is arch-independent, but only linux-amd64 was run.

## Deliberate deviations

- The asset is `switchroom-assets.tar.gz`, **not** version-stamped in the filename: the tag already namespaces the download URL, and the version is inside the manifest where the skew check reads it.
- The payload carries `profiles/`, `skills/`, `vendor/hindsight-memory/`, `ui/` — **not** `bin/` or `examples/`. `bin/*.sh` is consumed by the agent container at `/opt/switchroom/bin` (`docker/Dockerfile.agent:229`), and `examples/` is compiled into the binary via text imports.

## Notes for the reviewer

- **vitest does not implement `with { type: "text" }`** — it hands back the module path instead of the file body, so `embedded-examples.test.ts` cannot assert example *content*. Both real build paths (`bun build` and `bun build --compile`) do inline it; the content guarantee is covered by `tests/install/static-binary.test.ts`, which compiles a real binary and reads the config it writes.
- `tests/install/static-binary.test.ts` was **leaking the developer's environment** (`...process.env` handed the spawned binary a live `SWITCHROOM_CONFIG`, so setup loaded a real 5-agent fleet instead of bootstrapping). Fixed with `sandboxEnv()`, which strips every `SWITCHROOM_*` var — without it the test could not have caught the bug it exists for.
- On a host where `/tmp` is mounted `noexec`, that suite fails for environmental reasons only; it passes under `TMPDIR=/var/tmp/...`.
- **Pre-existing, filed separately, not fixed here:** a name in `skills:` is looked up in the pool **root** (`syncGlobalSkills` → `resolveSkillsPoolDir`) while bundled skills live in `<pool>/_bundled`, so the shipped example config's `skills:` list warns "not found in pool" on every host, including long-lived ones. The bundled-*defaults* path reads `_bundled` directly and works.

Job spec: `reference/jobs/get-from-zero-to-a-working-fleet.md`.
