### PR TITLE
feat(google): opt-in read-only Calendar scope on `auth google account add`

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -405,7 +405,7 @@ it, and unblock the fleet — entirely from chat:
 Drive/Graph loopback OAuth flow is fully relayable — no SSH port-forward,
 no keyboard:
 
-- `/auth google add <email> [--replace] [--write]`
+- `/auth google add <email> [--replace] [--write] [--calendar]`
 - `/auth microsoft add <email> [--replace] [--org-mode]`
 
 The agent runs the loopback flow in its own container, relays the consent

--- a/docs/google-workspace.md
+++ b/docs/google-workspace.md
@@ -202,6 +202,7 @@ holds (or will hold) the grant:
 /auth google add you@gmail.com            # add or re-auth
 /auth google add you@gmail.com --replace  # re-consent an existing account
 /auth google add you@gmail.com --write    # request Drive write scope
+/auth google add you@gmail.com --calendar # request read-only Calendar scope
 ```
 
 The agent runs the loopback flow **in its own container**, relays the
@@ -242,6 +243,49 @@ unrelated Drive files (that would be the full `drive` scope, which
 switchroom deliberately does not request). It does **not** change
 behaviour for read-only accounts.
 
+#### Calendar is read-only and opt-in
+
+The `gdrive` MCP exposes Calendar tools (`list_calendars`, `get_events`)
+at **every** tier, but the token switchroom mints carries no Calendar
+scope by default, so those tools 403 — and the upstream MCP then falls
+back to its own browser OAuth, which cannot complete inside a container.
+
+Pass `--calendar` to mint `calendar.readonly` alongside the Drive scopes:
+
+```bash
+switchroom auth google account add you@gmail.com --calendar
+# add Calendar read to an already-connected account (re-consent):
+switchroom auth google account add you@gmail.com --replace --calendar
+```
+
+Two deliberate limits:
+
+- **Read-only only.** `calendar.readonly` lists calendars and reads
+  events. switchroom never requests the read/write `calendar` or
+  `calendar.events` scopes — creating or moving events is a write
+  surface with its own approval shape (same argument RFC G §5 makes
+  about Gmail).
+- **Never a tier default.** No tier grants Calendar. Folding it into a
+  tier's default set would mean an operator re-minting after an
+  unrelated tier bump silently hands over their whole calendar — a read
+  grant must never silently widen (RFC D §12), which is exactly why
+  `--write` is a flag too.
+
+#### Re-consent carries existing scopes forward
+
+OAuth scopes are fixed at consent time, so `--replace` mints exactly the
+set the flags describe. To stop an unrelated re-consent from silently
+revoking capability, `account add` reads the scopes the broker already
+holds for the account and **unions the opt-ins forward**: re-running
+with `--replace --calendar` on a write-capable account keeps
+`drive.file`, and prints a line saying so. The union only flows one way
+— a capability you did not ask for and the token does not already hold
+is never requested.
+
+Asking for a scope the stored token lacks *without* `--replace` is
+refused with an explicit "scopes are fixed at consent time, re-consent
+like this" error rather than appearing to succeed.
+
 #### Workspace API scopes are tied to the tier
 
 Creating or editing **native Google Docs / Sheets / Slides** needs
@@ -258,10 +302,11 @@ the `tier`** in your `google_workspace:` block:
 | `complete` | `documents`, `spreadsheets`, `presentations` |
 
 `presentations` (Slides) is added at `extended`/`complete` because
-Slides tools first appear at the `extended` tier. Calendar / Forms /
-Tasks / Chat / Gmail scopes are **not** minted — that is a separate,
-larger decision (Gmail in particular has an unresolved approval shape;
-see RFC G §5).
+Slides tools first appear at the `extended` tier. Forms / Tasks / Chat /
+Gmail scopes are **not** minted — that is a separate, larger decision
+(Gmail in particular has an unresolved approval shape; see RFC G §5).
+Calendar is available, but only read-only and only via the explicit
+`--calendar` flag — never as a tier default (see above).
 
 **Changing the tier requires re-running `account add`.** OAuth scopes
 are fixed at consent time — raising `tier: core` → `tier: extended`
@@ -269,7 +314,7 @@ does **not** retroactively widen an already-minted token. After a tier
 change, re-mint:
 
 ```bash
-switchroom auth google account add you@gmail.com --replace [--write]
+switchroom auth google account add you@gmail.com --replace [--write] [--calendar]
 ```
 
 If you skip the re-mint, the `gdrive` MCP launcher prints a loud

--- a/src/cli/auth-google.test.ts
+++ b/src/cli/auth-google.test.ts
@@ -253,3 +253,61 @@ describe("interpretRefGetResult", () => {
     expect(v.message).toContain("scope excludes operator");
   });
 });
+
+
+describe("buildScopeReconsentRequiredError — never a silent no-op", () => {
+  const { buildScopeReconsentRequiredError } = _testing;
+
+  it("names the missing scope and prints the exact --replace command", () => {
+    const msg = buildScopeReconsentRequiredError("you@example.com", [
+      "calendar",
+    ]);
+    expect(msg).toContain("you@example.com");
+    expect(msg).toContain("calendar.readonly");
+    expect(msg).toContain("already registered");
+    expect(msg).toContain(
+      "switchroom auth google account add you@example.com --replace --calendar",
+    );
+  });
+
+  it("explains WHY (scopes fixed at consent time) so the operator can recover", () => {
+    const msg = buildScopeReconsentRequiredError("a@b.com", ["calendar"]);
+    expect(msg).toContain("fixed at consent time");
+  });
+
+  it("reassures that existing scopes are carried forward, not dropped", () => {
+    const msg = buildScopeReconsentRequiredError("a@b.com", ["calendar"]);
+    expect(msg).toMatch(/carried forward/i);
+  });
+
+  it("lists every newly-requested capability in one command", () => {
+    const msg = buildScopeReconsentRequiredError("a@b.com", [
+      "write",
+      "calendar",
+    ]);
+    expect(msg).toContain("drive.file, calendar.readonly");
+    expect(msg).toContain("--replace --write --calendar");
+  });
+});
+
+describe("buildCarryForwardNotices — carry-forward is announced, not silent", () => {
+  const { buildCarryForwardNotices } = _testing;
+
+  it("nothing carried → no notices", () => {
+    expect(buildCarryForwardNotices([])).toEqual([]);
+  });
+
+  it("names the scope, the flag that was omitted, and the consequence", () => {
+    const [line] = buildCarryForwardNotices(["write"]);
+    expect(line).toContain("drive.file");
+    expect(line).toContain("--write");
+    expect(line).toMatch(/revoke/i);
+  });
+
+  it("emits one notice per carried capability", () => {
+    const lines = buildCarryForwardNotices(["write", "calendar"]);
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toContain("calendar.readonly");
+    expect(lines[1]).toContain("--calendar");
+  });
+});

--- a/src/cli/auth-google.ts
+++ b/src/cli/auth-google.ts
@@ -602,7 +602,7 @@ function registerAccountAdd(accountParent: Command): void {
   accountParent
     .command("add <account>")
     .description(
-      "Mint a Google OAuth refresh token for <account> and register it with the auth-broker. For Drive scopes the effective flow is desktop-loopback (device-code returns invalid_scope for Drive; OOB is retired) — use a Desktop OAuth client; on a headless host complete the browser step over an SSH port-forward. Add --write for create/edit (drive.file); default is read-only.",
+      "Mint a Google OAuth refresh token for <account> and register it with the auth-broker. For Drive scopes the effective flow is desktop-loopback (device-code returns invalid_scope for Drive; OOB is retired) — use a Desktop OAuth client; on a headless host complete the browser step over an SSH port-forward. Add --write for create/edit (drive.file) and --calendar for read-only Calendar; default is Drive read-only.",
     )
     .option(
       "--replace",
@@ -614,16 +614,29 @@ function registerAccountAdd(accountParent: Command): void {
       "Request Drive WRITE scope (drive.file: create + edit app-created files) in addition to read. Default is read-only — a read grant never silently becomes a write grant. Re-consent an existing account with `--replace --write`.",
       false,
     )
+    .option(
+      "--calendar",
+      "Request READ-ONLY Calendar scope (calendar.readonly) so the gdrive MCP's list_calendars / get_events tools authenticate. Opt-in — no tier grants it by default, and switchroom never requests a Calendar WRITE scope. Re-consent an existing account with `--replace --calendar`.",
+      false,
+    )
     .action(
       withConfigError(
-        async (account: string, opts: { replace?: boolean; write?: boolean }) => {
+        async (
+          account: string,
+          opts: { replace?: boolean; write?: boolean; calendar?: boolean },
+        ) => {
         const normalizedAccount = validateAndNormalizeAccountEmail(account);
 
         // Lazy-import the OAuth flow + vault resolver — they pull in
         // sizeable trees (Drive scaffolding, AES vault) that the
         // sibling enable/disable/list verbs don't need.
         const [
-          { runDriveOAuthFlow, selectGoogleWorkspaceScopes },
+          {
+            runDriveOAuthFlow,
+            selectGoogleWorkspaceScopes,
+            capabilitiesFromScopeString,
+            resolveReconsentCapabilities,
+          },
           { selectInitialTier },
           { brokerCall },
           { loadConfig, resolvePath },
@@ -757,8 +770,43 @@ function registerAccountAdd(accountParent: Command): void {
         // (instead of advertising Slides/Docs/Sheets tools that 403 and
         // trigger upstream's doomed port-8000 OAuth fallback).
         const tier = gw.tier ?? "core";
+
+        // Re-consent safety — opt-in capability carry-forward. OAuth
+        // scopes are fixed at consent time, so `--replace` mints EXACTLY
+        // the set the flags describe: re-consenting for an unrelated
+        // reason without re-passing `--write` used to silently strip
+        // `drive.file`. Read what the broker already holds and union the
+        // opt-in capabilities forward, reporting the carry-forward out
+        // loud. The union only flows old → new, so nothing widens.
+        //
+        // The broker is already a hard dependency of this command (the
+        // final `addAccount` goes through it), so reading it up front
+        // costs nothing and fails BEFORE a consent is burned rather than
+        // after.
+        const existingEntry = (
+          await brokerCall(async (client) => client.listGoogleAccounts())
+        ).accounts.find((a) => a.account === normalizedAccount);
+        const plan = resolveReconsentCapabilities(
+          { write: opts.write ?? false, calendar: opts.calendar ?? false },
+          existingEntry
+            ? capabilitiesFromScopeString(existingEntry.scope)
+            : undefined,
+        );
+
+        // Asking for a NEW capability on an already-registered account
+        // WITHOUT `--replace` cannot do anything: the broker refuses the
+        // overwrite and the stored token keeps its old, narrower scopes.
+        // Say that plainly instead of letting it surface as a generic
+        // "already registered" collision the operator reads as success.
+        if (existingEntry && !opts.replace && plan.added.length > 0) {
+          throw new Error(
+            buildScopeReconsentRequiredError(normalizedAccount, plan.added),
+          );
+        }
+
         const accountScopes = selectGoogleWorkspaceScopes({
-          write: opts.write ?? false,
+          write: plan.effective.write,
+          calendar: plan.effective.calendar,
           tier,
         });
         const oauthCfg = {
@@ -766,12 +814,22 @@ function registerAccountAdd(accountParent: Command): void {
           client_secret: clientSecretRaw,
           scopes: accountScopes,
         };
-        if (opts.write) {
+        if (plan.effective.write) {
           console.log(
             chalk.yellow(
               "  Requesting Drive WRITE scope (drive.file — create/edit app-created files).",
             ),
           );
+        }
+        if (plan.effective.calendar) {
+          console.log(
+            chalk.yellow(
+              "  Requesting Calendar READ-ONLY scope (calendar.readonly — list calendars, read events).",
+            ),
+          );
+        }
+        for (const line of buildCarryForwardNotices(plan.carried)) {
+          console.log(chalk.gray(line));
         }
         console.log(
           chalk.gray(
@@ -871,6 +929,81 @@ function registerAccountAdd(accountParent: Command): void {
         console.log();
       }),
     );
+}
+
+// ── Opt-in capability messaging (pure, unit-pinned) ─────────────────────
+
+/** CLI flag / scope / prose for each opt-in capability. */
+const CAPABILITY_LABELS: Record<
+  "write" | "calendar",
+  { flag: string; scope: string; summary: string }
+> = {
+  write: {
+    flag: "--write",
+    scope: "drive.file",
+    summary: "Drive write (create + edit app-created files)",
+  },
+  calendar: {
+    flag: "--calendar",
+    scope: "calendar.readonly",
+    summary: "Calendar read-only (list calendars, read events)",
+  },
+};
+
+/**
+ * Error text for "you asked for a new scope on an account that is
+ * already registered, but did not pass `--replace`".
+ *
+ * Without this the command hits the broker's generic already-registered
+ * refusal, which says nothing about scopes — and the operator reasonably
+ * concludes the flag was applied. OAuth scopes are fixed at consent
+ * time: the ONLY way an existing account gains a scope is a fresh
+ * consent.
+ *
+ * Exported so the wording contract is unit-pinned.
+ */
+export function buildScopeReconsentRequiredError(
+  account: string,
+  added: ("write" | "calendar")[],
+): string {
+  const flags = added.map((k) => CAPABILITY_LABELS[k].flag);
+  const scopes = added.map((k) => CAPABILITY_LABELS[k].scope).join(", ");
+  return [
+    `'${account}' is already registered with the auth-broker, and its stored ` +
+      `token does not carry ${scopes}.`,
+    "",
+    "OAuth scopes are fixed at consent time — a stored token cannot be",
+    "widened in place. Re-consent to mint a new token that includes it:",
+    "",
+    `  switchroom auth google account add ${account} --replace ${flags.join(" ")}`,
+    "",
+    "Scopes the account already holds are carried forward automatically,",
+    "so re-consenting will not drop existing capabilities.",
+  ].join("\n");
+}
+
+/**
+ * Operator-facing notices for capabilities carried forward from the
+ * existing token because the operator did not re-pass their flag.
+ *
+ * The carry-forward is deliberately never silent: it changes the scope
+ * set actually sent to Google relative to the flags typed, so the
+ * operator has to be able to see it before the consent screen and know
+ * why.
+ *
+ * Exported so the wording contract is unit-pinned.
+ */
+export function buildCarryForwardNotices(
+  carried: ("write" | "calendar")[],
+): string[] {
+  return carried.map((k) => {
+    const { flag, scope, summary } = CAPABILITY_LABELS[k];
+    return (
+      `  Carrying forward ${summary} — the existing token holds ${scope}, ` +
+      `so it is re-requested even though ${flag} was not passed ` +
+      `(re-consent would otherwise silently revoke it).`
+    );
+  });
 }
 
 /**
@@ -1292,6 +1425,8 @@ export const _testing = {
   expandAllAgents,
   buildGoogleCredentials,
   oauthClientSetupGuidance,
+  buildScopeReconsentRequiredError,
+  buildCarryForwardNotices,
   interpretConnectPutResult,
   interpretRefGetResult,
 };

--- a/src/cli/drive-mcp-launcher.test.ts
+++ b/src/cli/drive-mcp-launcher.test.ts
@@ -22,9 +22,14 @@ import {
   findMissingWorkspaceScopes,
   requiredWorkspaceScopesForTier,
   resolveCredentialsDir,
+  seedOptInCapabilities,
+  CALENDAR_READONLY_SCOPE,
   sanitizeToolsListMessage,
 } from "./drive-mcp-launcher.js";
-import { workspaceScopesForTier } from "./drive.js";
+import {
+  GOOGLE_CALENDAR_READONLY_SCOPE,
+  workspaceScopesForTier,
+} from "./drive.js";
 import { GOOGLE_WORKSPACE_MCP_PINNED_SHA } from "../memory/scaffold-integration.js";
 
 describe("buildSeedCredentials — exact upstream shape", () => {
@@ -325,16 +330,56 @@ describe("findMissingWorkspaceScopes — scope↔tier preflight (#1663)", () => 
   });
 });
 
+describe("seedOptInCapabilities — opt-in flags read off the seed token", () => {
+  const DRIVE_FILE = "https://www.googleapis.com/auth/drive.file";
+  const CAL = "https://www.googleapis.com/auth/calendar.readonly";
+
+  it("mirrors GOOGLE_CALENDAR_READONLY_SCOPE from drive.ts (no drift)", () => {
+    expect(CALENDAR_READONLY_SCOPE).toBe(GOOGLE_CALENDAR_READONLY_SCOPE);
+  });
+
+  it("read-only Drive seed → neither capability", () => {
+    expect(
+      seedOptInCapabilities("https://www.googleapis.com/auth/drive.readonly"),
+    ).toEqual({ write: false, calendar: false });
+  });
+
+  it("detects drive.file and calendar.readonly independently", () => {
+    expect(seedOptInCapabilities(DRIVE_FILE)).toEqual({
+      write: true,
+      calendar: false,
+    });
+    expect(seedOptInCapabilities(CAL)).toEqual({
+      write: false,
+      calendar: true,
+    });
+    expect(seedOptInCapabilities(`${DRIVE_FILE} ${CAL}`)).toEqual({
+      write: true,
+      calendar: true,
+    });
+  });
+
+  it("does NOT treat a Calendar WRITE scope as calendar read capability", () => {
+    // switchroom never mints these; if one ever appears the warning must
+    // not print `--calendar` as though it round-trips (it wouldn't).
+    expect(
+      seedOptInCapabilities("https://www.googleapis.com/auth/calendar"),
+    ).toEqual({ write: false, calendar: false });
+  });
+});
+
 describe("buildMissingScopeWarning — actionable re-mint guidance (#1663)", () => {
   const DRIVE_FILE = "https://www.googleapis.com/auth/drive.file";
+  const CAL = "https://www.googleapis.com/auth/calendar.readonly";
   const PRESENTATIONS = "https://www.googleapis.com/auth/presentations";
+  const NONE = { write: false, calendar: false };
 
   it("names the account, the tier, and the exact recovery command", () => {
     const msg = buildMissingScopeWarning(
       [PRESENTATIONS],
       "extended",
       "you@example.com",
-      false,
+      NONE,
     );
     expect(msg).toContain("you@example.com");
     expect(msg).toContain("extended");
@@ -355,7 +400,12 @@ describe("buildMissingScopeWarning — actionable re-mint guidance (#1663)", () 
       "https://www.googleapis.com/auth/spreadsheets",
     ]);
     expect(missing).not.toContain(DRIVE_FILE);
-    const msg = buildMissingScopeWarning(missing, "core", "a@b.com", true);
+    const msg = buildMissingScopeWarning(
+      missing,
+      "core",
+      "a@b.com",
+      seedOptInCapabilities(DRIVE_FILE),
+    );
     expect(msg).toContain("--replace --write");
   });
 
@@ -364,9 +414,46 @@ describe("buildMissingScopeWarning — actionable re-mint guidance (#1663)", () 
     // the re-minted token stays read-only and capability isn't widened
     // beyond what the operator originally consented to.
     const missing = findMissingWorkspaceScopes("", "core");
-    const msg = buildMissingScopeWarning(missing, "core", "a@b.com", false);
+    const msg = buildMissingScopeWarning(missing, "core", "a@b.com", NONE);
     expect(msg).toContain("--replace\n");
     expect(msg).not.toContain("--write");
+  });
+
+  it("appends --calendar when the EXISTING token already carries calendar.readonly", () => {
+    // Same downgrade hazard as --write: calendar.readonly is never in
+    // `missing` (no tier requires it), so running the printed command
+    // without --calendar would silently revoke Calendar read.
+    const missing = findMissingWorkspaceScopes(CAL, "core");
+    expect(missing).not.toContain(CAL);
+    const msg = buildMissingScopeWarning(
+      missing,
+      "core",
+      "a@b.com",
+      seedOptInCapabilities(CAL),
+    );
+    expect(msg).toContain("--replace --calendar");
+    expect(msg).toContain("Calendar read capability");
+  });
+
+  it("omits --calendar for a token without the calendar scope", () => {
+    const missing = findMissingWorkspaceScopes(DRIVE_FILE, "core");
+    const msg = buildMissingScopeWarning(
+      missing,
+      "core",
+      "a@b.com",
+      seedOptInCapabilities(DRIVE_FILE),
+    );
+    expect(msg).not.toContain("--calendar");
+  });
+
+  it("carries BOTH opt-ins forward, in flag order", () => {
+    const msg = buildMissingScopeWarning(
+      [PRESENTATIONS],
+      "extended",
+      "a@b.com",
+      seedOptInCapabilities(`${DRIVE_FILE} ${CAL}`),
+    );
+    expect(msg).toContain("--replace --write --calendar");
   });
 });
 

--- a/src/cli/drive-mcp-launcher.ts
+++ b/src/cli/drive-mcp-launcher.ts
@@ -268,6 +268,48 @@ export function findMissingWorkspaceScopes(
 const DRIVE_FILE_SCOPE = "https://www.googleapis.com/auth/drive.file";
 
 /**
+ * The Calendar READ scope minted by `auth google account add --calendar`.
+ * Mirrors `GOOGLE_CALENDAR_READONLY_SCOPE` in src/cli/drive.ts —
+ * duplicated here for the same reason as
+ * {@link requiredWorkspaceScopesForTier} (keep the launcher's hot path
+ * free of the drive.ts import tree). A launcher unit test asserts the
+ * two literals are identical.
+ */
+export const CALENDAR_READONLY_SCOPE =
+  "https://www.googleapis.com/auth/calendar.readonly";
+
+/** Opt-in capabilities an already-minted seed token may carry. */
+export interface SeedOptInCapabilities {
+  /** `--write` → `drive.file`. */
+  write: boolean;
+  /** `--calendar` → `calendar.readonly`. */
+  calendar: boolean;
+}
+
+/**
+ * Read the opt-in capabilities out of a seed token's scope string, so
+ * {@link buildMissingScopeWarning} can carry every one of them into the
+ * recovery command it prints.
+ *
+ * Pure + exported — this is the "never print a command that downgrades
+ * the operator" guard, so it is unit-pinned separately.
+ */
+export function seedOptInCapabilities(
+  seedScope: string,
+): SeedOptInCapabilities {
+  const have = new Set(
+    seedScope
+      .split(/\s+/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0),
+  );
+  return {
+    write: have.has(DRIVE_FILE_SCOPE),
+    calendar: have.has(CALENDAR_READONLY_SCOPE),
+  };
+}
+
+/**
  * Build the operator-facing warning shown when the seed token is
  * missing scopes the requested tier needs (issue #1663). The launcher
  * still spawns upstream — Drive tools and any in-scope Workspace tools
@@ -275,24 +317,37 @@ const DRIVE_FILE_SCOPE = "https://www.googleapis.com/auth/drive.file";
  * loud and tells the operator exactly how to fix it, instead of the
  * silent doomed port-8000 fallback.
  *
- * `hasWriteScope` MUST reflect the EXISTING token's scopes (whether the
- * current credential already carries `drive.file`), NOT the `missing`
+ * `granted` MUST reflect the EXISTING token's scopes, NOT the `missing`
  * set. `missing` only ever holds Docs/Sheets/Slides scopes — never
- * `drive.file` — so deriving the recovery command's `--write` suffix
- * from `missing` would always drop it, and an operator with a
- * write-capable token who runs the printed command verbatim would
- * silently downgrade to a read-only token and lose Drive file creation
- * that previously worked. Carry the existing write capability forward.
+ * `drive.file` or `calendar.readonly` — so deriving the recovery
+ * command's opt-in suffixes from `missing` would always drop them, and
+ * an operator with a write-capable (or calendar-enabled) token who runs
+ * the printed command verbatim would silently downgrade and lose
+ * capability that previously worked. Carry them forward.
+ *
+ * (`account add` also unions existing capabilities forward on its own
+ * now, so this is belt-and-braces — but the printed command still has to
+ * read correctly on its own.)
  */
 export function buildMissingScopeWarning(
   missing: string[],
   tier: string | undefined,
   accountEmail: string,
-  hasWriteScope: boolean,
+  granted: SeedOptInCapabilities,
 ): string {
   const short = missing
     .map((s) => s.replace(/^https:\/\/www\.googleapis\.com\/auth\//, ""))
     .join(", ");
+  const suffix =
+    (granted.write ? " --write" : "") + (granted.calendar ? " --calendar" : "");
+  const preserved = [
+    granted.write
+      ? "--write preserves the existing Drive write capability"
+      : "",
+    granted.calendar
+      ? "--calendar preserves the existing Calendar read capability"
+      : "",
+  ].filter((s) => s.length > 0);
   return (
     `drive-mcp-launcher: WARNING — the Google account '${accountEmail}' was ` +
     `consented WITHOUT the scope(s) needed for tier '${tier ?? "core"}': ` +
@@ -301,10 +356,10 @@ export function buildMissingScopeWarning(
     `to authenticate. OAuth scopes are fixed at consent time — re-run on the ` +
     `host to re-mint the token with the correct scopes:\n` +
     `    switchroom auth google account add ${accountEmail} --replace` +
-    `${hasWriteScope ? " --write" : ""}\n` +
+    `${suffix}\n` +
     `  (scopes are derived from \`google_workspace.tier\` — set the tier ` +
-    `before re-running${hasWriteScope ? "; --write preserves the existing " +
-    "Drive write capability" : ""}). Drive read/file tools are unaffected.\n`
+    `before re-running${preserved.length > 0 ? "; " + preserved.join("; ") : ""}` +
+    `). Drive read/file tools are unaffected.\n`
   );
 }
 
@@ -824,21 +879,17 @@ export async function runDriveMcpLauncher(opts: {
   // than refusing to start.
   const missingScopes = findMissingWorkspaceScopes(brokerCreds.scope, tier);
   if (missingScopes.length > 0) {
-    // Decide the recovery command's --write suffix from the EXISTING
+    // Decide the recovery command's opt-in suffixes from the EXISTING
     // token's scopes — NOT from `missingScopes` (which never contains
-    // drive.file). A token that already carries drive.file was minted
-    // write-capable; the printed `account add --replace` must keep
-    // --write or the operator silently downgrades to read-only.
-    const hasWriteScope = brokerCreds.scope
-      .split(/\s+/)
-      .map((s) => s.trim())
-      .includes(DRIVE_FILE_SCOPE);
+    // drive.file or calendar.readonly). A token that already carries
+    // those was minted with them; the printed `account add --replace`
+    // must keep the matching flags or the operator silently downgrades.
     process.stderr.write(
       buildMissingScopeWarning(
         missingScopes,
         tier,
         brokerCreds.accountEmail,
-        hasWriteScope,
+        seedOptInCapabilities(brokerCreds.scope),
       ),
     );
   }

--- a/src/cli/drive.test.ts
+++ b/src/cli/drive.test.ts
@@ -46,6 +46,9 @@ import {
   GOOGLE_DOCS_SCOPE,
   GOOGLE_SHEETS_SCOPE,
   GOOGLE_SLIDES_SCOPE,
+  GOOGLE_CALENDAR_READONLY_SCOPE,
+  capabilitiesFromScopeString,
+  resolveReconsentCapabilities,
   type DriveCliDeps,
 } from "./drive.js";
 import type { WaitForApprovalResult } from "../vault/approvals/wait.js";
@@ -546,5 +549,239 @@ describe("selectGoogleWorkspaceScopes (issue #1663)", () => {
       const s = selectGoogleWorkspaceScopes({ write: true, tier });
       expect(s).not.toContain("https://www.googleapis.com/auth/drive");
     }
+  });
+});
+
+
+// ── Calendar read-only, opt-in (gdrive list_calendars / get_events) ──────
+
+describe("GOOGLE_CALENDAR_READONLY_SCOPE", () => {
+  it("is the READ-ONLY calendar scope, never the read/write ones", () => {
+    expect(GOOGLE_CALENDAR_READONLY_SCOPE).toBe(
+      "https://www.googleapis.com/auth/calendar.readonly",
+    );
+    // Guards against a careless "just drop .readonly" edit: the
+    // read/write `calendar` and `calendar.events` scopes are deliberately
+    // never offered by any switchroom code path.
+    expect(GOOGLE_CALENDAR_READONLY_SCOPE).not.toBe(
+      "https://www.googleapis.com/auth/calendar",
+    );
+    expect(GOOGLE_CALENDAR_READONLY_SCOPE).toMatch(/\.readonly$/);
+  });
+});
+
+describe("selectGoogleWorkspaceScopes — --calendar is opt-in", () => {
+  const cal = GOOGLE_CALENDAR_READONLY_SCOPE;
+
+  // The full flag matrix, asserting the EXACT emitted scope set — not
+  // just "contains", so an accidental extra scope fails too.
+  const drive = [
+    "https://www.googleapis.com/auth/drive.readonly",
+    "https://www.googleapis.com/auth/drive.metadata.readonly",
+  ];
+  const driveFile = "https://www.googleapis.com/auth/drive.file";
+  const docs = [GOOGLE_DOCS_SCOPE, GOOGLE_SHEETS_SCOPE];
+
+  it("write=false calendar=false → Drive read + Docs/Sheets only", () => {
+    expect(
+      selectGoogleWorkspaceScopes({ write: false, calendar: false, tier: "core" }),
+    ).toEqual([...drive, ...docs]);
+  });
+
+  it("write=false calendar=true → adds ONLY calendar.readonly", () => {
+    expect(
+      selectGoogleWorkspaceScopes({ write: false, calendar: true, tier: "core" }),
+    ).toEqual([...drive, ...docs, cal]);
+  });
+
+  it("write=true calendar=false → adds ONLY drive.file", () => {
+    expect(
+      selectGoogleWorkspaceScopes({ write: true, calendar: false, tier: "core" }),
+    ).toEqual([...drive, driveFile, ...docs]);
+  });
+
+  it("write=true calendar=true → both opt-ins, nothing else", () => {
+    expect(
+      selectGoogleWorkspaceScopes({ write: true, calendar: true, tier: "core" }),
+    ).toEqual([...drive, driveFile, ...docs, cal]);
+  });
+
+  it("omitting `calendar` behaves exactly as calendar:false (no silent widening)", () => {
+    for (const tier of ["core", "extended", "complete"] as const) {
+      for (const write of [false, true]) {
+        expect(selectGoogleWorkspaceScopes({ write, tier })).toEqual(
+          selectGoogleWorkspaceScopes({ write, calendar: false, tier }),
+        );
+      }
+    }
+  });
+
+  it("NO tier grants calendar by default — the whole point of opt-in", () => {
+    for (const tier of ["core", "extended", "complete"] as const) {
+      for (const write of [false, true]) {
+        expect(
+          selectGoogleWorkspaceScopes({ write, calendar: false, tier }),
+        ).not.toContain(cal);
+      }
+    }
+  });
+
+  it("--calendar never implies --write, and vice versa", () => {
+    expect(
+      selectGoogleWorkspaceScopes({ write: false, calendar: true, tier: "complete" }),
+    ).not.toContain(driveFile);
+    expect(
+      selectGoogleWorkspaceScopes({ write: true, calendar: false, tier: "complete" }),
+    ).not.toContain(cal);
+  });
+
+  it("--calendar never pulls in a calendar WRITE scope", () => {
+    const s = selectGoogleWorkspaceScopes({
+      write: true,
+      calendar: true,
+      tier: "complete",
+    });
+    expect(s).not.toContain("https://www.googleapis.com/auth/calendar");
+    expect(s).not.toContain("https://www.googleapis.com/auth/calendar.events");
+    expect(s.filter((x) => x.includes("calendar"))).toEqual([cal]);
+  });
+
+  it("emits no duplicates with every flag on", () => {
+    const s = selectGoogleWorkspaceScopes({
+      write: true,
+      calendar: true,
+      tier: "extended",
+    });
+    expect(new Set(s).size).toBe(s.length);
+  });
+});
+
+describe("capabilitiesFromScopeString", () => {
+  const cal = GOOGLE_CALENDAR_READONLY_SCOPE;
+  const driveFile = "https://www.googleapis.com/auth/drive.file";
+
+  it("reads both opt-ins off a real broker scope string", () => {
+    expect(
+      capabilitiesFromScopeString(
+        `https://www.googleapis.com/auth/drive.readonly ${driveFile} ${cal}`,
+      ),
+    ).toEqual({ write: true, calendar: true });
+  });
+
+  it("read-only token → no capabilities", () => {
+    expect(
+      capabilitiesFromScopeString(
+        "https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/documents",
+      ),
+    ).toEqual({ write: false, calendar: false });
+  });
+
+  it("empty / whitespace scope string → no capabilities (no crash)", () => {
+    expect(capabilitiesFromScopeString("")).toEqual({
+      write: false,
+      calendar: false,
+    });
+    expect(capabilitiesFromScopeString("   \n  ")).toEqual({
+      write: false,
+      calendar: false,
+    });
+  });
+
+  it("a calendar WRITE scope does not count as calendar read capability", () => {
+    expect(
+      capabilitiesFromScopeString("https://www.googleapis.com/auth/calendar"),
+    ).toEqual({ write: false, calendar: false });
+  });
+});
+
+describe("resolveReconsentCapabilities — no drop, no silent widening", () => {
+  const cal = GOOGLE_CALENDAR_READONLY_SCOPE;
+  const driveFile = "https://www.googleapis.com/auth/drive.file";
+  const READ_ONLY = "https://www.googleapis.com/auth/drive.readonly";
+
+  it("fresh account (no existing token) → flags used verbatim", () => {
+    expect(
+      resolveReconsentCapabilities({ write: false, calendar: true }),
+    ).toEqual({
+      effective: { write: false, calendar: true },
+      carried: [],
+      added: [],
+    });
+  });
+
+  it("re-consent with --calendar keeps an existing write grant (no drop)", () => {
+    // The regression this guards: `--replace --calendar` on a
+    // write-capable account used to mint a token WITHOUT drive.file,
+    // silently revoking doc creation that previously worked.
+    const plan = resolveReconsentCapabilities(
+      { write: false, calendar: true },
+      capabilitiesFromScopeString(`${READ_ONLY} ${driveFile}`),
+    );
+    expect(plan.effective).toEqual({ write: true, calendar: true });
+    expect(plan.carried).toEqual(["write"]);
+    expect(plan.added).toEqual(["calendar"]);
+  });
+
+  it("carried capability reaches the emitted scope set, not just the plan", () => {
+    // End-to-end on the two pure functions the CLI actually composes —
+    // a plan that says "write" but a scope set that omits drive.file
+    // would still ship the bug.
+    const plan = resolveReconsentCapabilities(
+      { write: false, calendar: true },
+      capabilitiesFromScopeString(`${READ_ONLY} ${driveFile}`),
+    );
+    const scopes = selectGoogleWorkspaceScopes({
+      write: plan.effective.write,
+      calendar: plan.effective.calendar,
+      tier: "core",
+    });
+    expect(scopes).toContain(driveFile);
+    expect(scopes).toContain(cal);
+  });
+
+  it("re-consent with NO flags on a fully-capable token drops nothing", () => {
+    const plan = resolveReconsentCapabilities(
+      { write: false, calendar: false },
+      capabilitiesFromScopeString(`${driveFile} ${cal}`),
+    );
+    expect(plan.effective).toEqual({ write: true, calendar: true });
+    expect(plan.carried).toEqual(["write", "calendar"]);
+    expect(plan.added).toEqual([]);
+  });
+
+  it("does NOT widen: a read-only token re-consented with no flags stays read-only", () => {
+    const plan = resolveReconsentCapabilities(
+      { write: false, calendar: false },
+      capabilitiesFromScopeString(READ_ONLY),
+    );
+    expect(plan.effective).toEqual({ write: false, calendar: false });
+    expect(plan.carried).toEqual([]);
+    expect(plan.added).toEqual([]);
+    expect(
+      selectGoogleWorkspaceScopes({ ...plan.effective, tier: "complete" }),
+    ).not.toContain(cal);
+  });
+
+  it("does NOT widen: --calendar on a read-only token adds calendar only", () => {
+    const plan = resolveReconsentCapabilities(
+      { write: false, calendar: true },
+      capabilitiesFromScopeString(READ_ONLY),
+    );
+    expect(plan.effective).toEqual({ write: false, calendar: true });
+    expect(plan.added).toEqual(["calendar"]);
+    expect(
+      selectGoogleWorkspaceScopes({ ...plan.effective, tier: "core" }),
+    ).not.toContain(driveFile);
+  });
+
+  it("re-requesting a capability already held is not reported as added", () => {
+    // `added` drives the "you need --replace" error; an operator who
+    // re-passes a flag they already hold must not be told to re-consent.
+    const plan = resolveReconsentCapabilities(
+      { write: true, calendar: true },
+      capabilitiesFromScopeString(`${driveFile} ${cal}`),
+    );
+    expect(plan.added).toEqual([]);
+    expect(plan.carried).toEqual([]);
   });
 });

--- a/src/cli/drive.ts
+++ b/src/cli/drive.ts
@@ -117,11 +117,40 @@ const DEFAULT_SCOPES = DRIVE_READONLY_SCOPES;
 // surfaces explicitly broken today. Calendar/Forms/Tasks/Chat/Gmail are
 // a separate, larger scope-expansion decision (Gmail in particular has
 // an unresolved per-thread-approval shape — RFC G §5 out-of-scope).
+//
+// Calendar has since been un-deferred, but ONLY as read-only and ONLY as
+// an explicit opt-in — see GOOGLE_CALENDAR_READONLY_SCOPE below. It is
+// still not part of any tier's default scope set, so the invariant this
+// comment protects (a tier bump never silently widens the grant into a
+// new product surface) is intact.
 export const GOOGLE_DOCS_SCOPE = "https://www.googleapis.com/auth/documents";
 export const GOOGLE_SHEETS_SCOPE =
   "https://www.googleapis.com/auth/spreadsheets";
 export const GOOGLE_SLIDES_SCOPE =
   "https://www.googleapis.com/auth/presentations";
+
+// ── Calendar (read-only, opt-in) ─────────────────────────────────────────
+//
+// Upstream's `list_calendars` / `get_events` tools are exposed at EVERY
+// tier (`core` already advertises Calendar — see GoogleWorkspaceTierSchema
+// in src/config/schema.ts), but the token switchroom mints carries no
+// calendar scope, so those tools 403 and upstream falls back to its own
+// port-8000 browser OAuth — unrecoverable inside a container. Requesting
+// this scope is what makes the already-exposed tools actually work.
+//
+// Two deliberate narrowings:
+//   1. **Read-only only.** `calendar.readonly` grants list/read of
+//      calendars and events. The read/write `calendar` and
+//      `calendar.events` scopes are NOT offered — creating/moving events
+//      is a write surface with its own approval shape, exactly the
+//      argument RFC G §5 makes about Gmail.
+//   2. **Opt-in, never tier-default.** Folding it into a tier's default
+//      set would mean an operator who re-mints after a tier bump
+//      silently hands over their whole calendar. A read grant must never
+//      silently widen (RFC D §12) — the same invariant `--write` exists
+//      to protect. Hence the separate `--calendar` flag on `account add`.
+export const GOOGLE_CALENDAR_READONLY_SCOPE =
+  "https://www.googleapis.com/auth/calendar.readonly";
 
 /**
  * The Google Workspace document scopes available at each tier. Tied to
@@ -176,14 +205,116 @@ export function selectDriveAccountScopes(write: boolean): string[] {
  */
 export function selectGoogleWorkspaceScopes(opts: {
   write: boolean;
+  /**
+   * Opt-in Calendar READ. Adds {@link GOOGLE_CALENDAR_READONLY_SCOPE} and
+   * nothing else. Never implied by a tier — see that constant's comment.
+   */
+  calendar?: boolean;
   tier?: "core" | "extended" | "complete";
 }): string[] {
   const base = selectDriveAccountScopes(opts.write);
   const workspace = workspaceScopesForTier(opts.tier ?? "core");
+  const calendar = opts.calendar ? [GOOGLE_CALENDAR_READONLY_SCOPE] : [];
   // De-dup defensively — base and workspace sets are disjoint today but
   // a future scope move shouldn't silently produce a doubled scope
   // string in the consent URL.
-  return [...new Set([...base, ...workspace])];
+  return [...new Set([...base, ...workspace, ...calendar])];
+}
+
+// ── Opt-in capability carry-forward (re-consent safety) ──────────────────
+
+/**
+ * The opt-in capabilities an `account add` token can carry beyond the
+ * always-minted Drive read baseline. One boolean per `account add` flag.
+ */
+export interface GoogleOptInCapabilities {
+  /** `--write` → `drive.file`. */
+  write: boolean;
+  /** `--calendar` → `calendar.readonly`. */
+  calendar: boolean;
+}
+
+/**
+ * Derive the opt-in capabilities a stored token actually carries, from
+ * the space-separated scope string the broker holds
+ * (`list-google-accounts` → `scope`).
+ *
+ * Pure + exported: this is the input to the re-consent carry-forward, so
+ * it has to be independently pinnable.
+ */
+export function capabilitiesFromScopeString(
+  scope: string,
+): GoogleOptInCapabilities {
+  const have = new Set(
+    scope
+      .split(/\s+/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0),
+  );
+  return {
+    write: have.has("https://www.googleapis.com/auth/drive.file"),
+    calendar: have.has(GOOGLE_CALENDAR_READONLY_SCOPE),
+  };
+}
+
+/** Outcome of {@link resolveReconsentCapabilities}. */
+export interface ReconsentCapabilityPlan {
+  /** The capability set the new consent should actually request. */
+  effective: GoogleOptInCapabilities;
+  /**
+   * Capabilities the existing token already held that the operator did
+   * NOT re-request on this invocation — carried forward rather than
+   * dropped. Surfaced to the operator so the carry-forward is never
+   * silent.
+   */
+  carried: (keyof GoogleOptInCapabilities)[];
+  /**
+   * Capabilities newly requested on this invocation that the existing
+   * token does not hold. Empty for a fresh account (nothing to widen
+   * FROM). Drives the "this needs re-consent" guidance.
+   */
+  added: (keyof GoogleOptInCapabilities)[];
+}
+
+/**
+ * Reconcile the flags passed to `account add` against the capabilities
+ * an already-registered token holds.
+ *
+ * Two failure modes this closes, both previously silent:
+ *
+ *  1. **Silent DOWNGRADE on re-consent.** OAuth scopes are fixed at
+ *     consent time, so `account add --replace` mints exactly the scope
+ *     set the flags describe. Re-consenting for an unrelated reason (a
+ *     tier bump) without re-passing `--write` used to quietly strip
+ *     `drive.file` and break every doc the agent could previously
+ *     create. Existing capabilities are therefore UNIONed in, not
+ *     replaced, and reported via `carried`.
+ *  2. **Silent WIDENING.** The union only ever flows old → new. A
+ *     capability the operator did not ask for and the token does not
+ *     already hold is never requested — `--calendar` alone cannot pull
+ *     in `--write`, and no tier implies either.
+ *
+ * `existing` is `undefined` for an account the broker does not hold yet
+ * (a fresh add), in which case the requested flags are used verbatim.
+ *
+ * Pure + exported so both invariants are unit-pinned.
+ */
+export function resolveReconsentCapabilities(
+  requested: GoogleOptInCapabilities,
+  existing?: GoogleOptInCapabilities,
+): ReconsentCapabilityPlan {
+  const keys: (keyof GoogleOptInCapabilities)[] = ["write", "calendar"];
+  if (!existing) {
+    return { effective: { ...requested }, carried: [], added: [] };
+  }
+  return {
+    effective: {
+      write: requested.write || existing.write,
+      calendar: requested.calendar || existing.calendar,
+    },
+    carried: keys.filter((k) => existing[k] && !requested[k]),
+    added: keys.filter((k) => requested[k] && !existing[k]),
+  };
 }
 
 export interface DriveCliDeps {

--- a/telegram-plugin/gateway/auth-command.ts
+++ b/telegram-plugin/gateway/auth-command.ts
@@ -65,6 +65,8 @@ export type ParsedAuthCommand =
       replace: boolean
       /** Google `--write` (Drive write scope). */
       write: boolean
+      /** Google `--calendar` (read-only Calendar scope). */
+      calendar: boolean
       /** Microsoft `--org-mode`. */
       orgMode: boolean
     }
@@ -251,7 +253,7 @@ export function parseAuthCommand(text: string): ParsedAuthCommand | null {
  * wired; anything else is a help-with-reason so the operator sees the shape.
  *
  * Flags mirror the CLI:
- *   google:    `add <email> [--replace] [--write]`
+ *   google:    `add <email> [--replace] [--write] [--calendar]`
  *   microsoft: `add <email> [--replace] [--org-mode]`
  */
 export function parseProviderVerb(
@@ -265,7 +267,7 @@ export function parseProviderVerb(
   if (sub !== 'add') {
     const usage =
       provider === 'google'
-        ? 'Usage: /auth google add <email> [--replace] [--write]'
+        ? 'Usage: /auth google add <email> [--replace] [--write] [--calendar]'
         : 'Usage: /auth microsoft add <email> [--replace] [--org-mode]'
     return {
       kind: 'help',
@@ -280,7 +282,7 @@ export function parseProviderVerb(
   if (!email) {
     const usage =
       provider === 'google'
-        ? 'Usage: /auth google add <email> [--replace] [--write]'
+        ? 'Usage: /auth google add <email> [--replace] [--write] [--calendar]'
         : 'Usage: /auth microsoft add <email> [--replace] [--org-mode]'
     return { kind: 'help', reason: usage }
   }
@@ -288,7 +290,7 @@ export function parseProviderVerb(
   if (emailErr) return { kind: 'help', reason: emailErr }
   // Reject unknown flags so a typo (`--replaced`) isn't silently dropped.
   const allowed = provider === 'google'
-    ? new Set(['--replace', '--write'])
+    ? new Set(['--replace', '--write', '--calendar'])
     : new Set(['--replace', '--org-mode'])
   for (const f of flags) {
     if (!allowed.has(f)) {
@@ -304,6 +306,7 @@ export function parseProviderVerb(
     email,
     replace: flags.has('--replace'),
     write: provider === 'google' && flags.has('--write'),
+    calendar: provider === 'google' && flags.has('--calendar'),
     orgMode: provider === 'microsoft' && flags.has('--org-mode'),
   }
 }

--- a/telegram-plugin/gateway/auth-loopback-relay.ts
+++ b/telegram-plugin/gateway/auth-loopback-relay.ts
@@ -84,6 +84,8 @@ export interface SpawnRelayOpts {
   replace?: boolean
   /** Google `--write` (Drive write scope). */
   write?: boolean
+  /** Google `--calendar` (read-only Calendar scope). */
+  calendar?: boolean
   /** Microsoft `--org-mode`. */
   orgMode?: boolean
   /** Override the CLI binary (tests / non-default install). */
@@ -95,6 +97,42 @@ export type SpawnRelay = (
   email: string,
   opts: SpawnRelayOpts,
 ) => RelayChild
+
+/**
+ * Build the `switchroom auth <provider> account add` argv the relay spawns.
+ *
+ * Pure + exported so the flag plumbing is unit-pinned: every opt-in flag
+ * the chat command accepts has to actually reach the CLI, and a flag that
+ * was NOT requested must never appear (the relay is the only path most
+ * operators use, so a dropped `--calendar` here is indistinguishable from
+ * the feature not existing, and a spurious one silently widens a grant).
+ */
+export function buildRelayArgs(
+  provider: LoopbackProvider,
+  email: string,
+  opts: SpawnRelayOpts,
+): string[] {
+  return provider === 'google'
+    ? [
+        'auth',
+        'google',
+        'account',
+        'add',
+        email,
+        ...(opts.replace ? ['--replace'] : []),
+        ...(opts.write ? ['--write'] : []),
+        ...(opts.calendar ? ['--calendar'] : []),
+      ]
+    : [
+        'auth',
+        'microsoft',
+        'account',
+        'add',
+        email,
+        ...(opts.replace ? ['--replace'] : []),
+        ...(opts.orgMode ? ['--org-mode'] : []),
+      ]
+}
 
 /**
  * Default spawn: the real `switchroom` CLI, stdout+stderr piped, stdin
@@ -109,26 +147,7 @@ export function defaultSpawnRelay(
   opts: SpawnRelayOpts,
 ): RelayChild {
   const binary = opts.binary ?? 'switchroom'
-  const args =
-    provider === 'google'
-      ? [
-          'auth',
-          'google',
-          'account',
-          'add',
-          email,
-          ...(opts.replace ? ['--replace'] : []),
-          ...(opts.write ? ['--write'] : []),
-        ]
-      : [
-          'auth',
-          'microsoft',
-          'account',
-          'add',
-          email,
-          ...(opts.replace ? ['--replace'] : []),
-          ...(opts.orgMode ? ['--org-mode'] : []),
-        ]
+  const args = buildRelayArgs(provider, email, opts)
   const child: ChildProcess = spawn(binary, args, {
     stdio: ['ignore', 'pipe', 'pipe'],
     env: {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -20737,7 +20737,7 @@ bot.command("auth", async ctx => {
       const { consentUrl, state, port, child } = await startLoopbackFlow(
         parsed.provider,
         parsed.email,
-        { replace: parsed.replace, write: parsed.write, orgMode: parsed.orgMode },
+        { replace: parsed.replace, write: parsed.write, calendar: parsed.calendar, orgMode: parsed.orgMode },
       )
       const newFlow = {
         provider: parsed.provider,

--- a/telegram-plugin/tests/auth-loopback-relay.test.ts
+++ b/telegram-plugin/tests/auth-loopback-relay.test.ts
@@ -22,6 +22,7 @@ import { describe, it, expect } from 'vitest'
 import { EventEmitter } from 'node:events'
 
 import {
+  buildRelayArgs,
   parseLoopbackRedirect,
   extractConsentUrl,
   parseConsentUrl,
@@ -492,6 +493,7 @@ describe('parseAuthCommand — provider verbs (#2582)', () => {
       email: 'user@example.com',
       replace: false,
       write: false,
+      calendar: false,
       orgMode: false,
     })
   })
@@ -499,6 +501,26 @@ describe('parseAuthCommand — provider verbs (#2582)', () => {
   it('parses google flags --replace --write', () => {
     const p = parseAuthCommand('/auth google add user@example.com --replace --write')
     expect(p).toMatchObject({ kind: 'provider-add', replace: true, write: true })
+  })
+
+  it('parses google --calendar, and it does not imply --write', () => {
+    const p = parseAuthCommand('/auth google add user@example.com --replace --calendar')
+    expect(p).toMatchObject({
+      kind: 'provider-add',
+      replace: true,
+      calendar: true,
+      write: false,
+    })
+  })
+
+  it('parses --write and --calendar together', () => {
+    const p = parseAuthCommand('/auth google add user@example.com --write --calendar')
+    expect(p).toMatchObject({ kind: 'provider-add', write: true, calendar: true })
+  })
+
+  it('--calendar is google-only — microsoft rejects it as an unknown flag', () => {
+    const p = parseAuthCommand('/auth microsoft add user@corp.com --calendar')
+    expect(p).toMatchObject({ kind: 'help' })
   })
 
   it('parses /auth microsoft add with --org-mode', () => {
@@ -529,5 +551,41 @@ describe('parseAuthCommand — provider verbs (#2582)', () => {
   it('does not treat --write as a Microsoft flag', () => {
     const p = parseAuthCommand('/auth microsoft add user@corp.com --write')
     expect(p).toMatchObject({ kind: 'help' })
+  })
+})
+
+
+describe('buildRelayArgs — chat flags actually reach the CLI', () => {
+  it('bare google add: no opt-in flags', () => {
+    expect(buildRelayArgs('google', 'a@b.com', {})).toEqual([
+      'auth', 'google', 'account', 'add', 'a@b.com',
+    ])
+  })
+
+  it('forwards --calendar', () => {
+    expect(buildRelayArgs('google', 'a@b.com', { calendar: true })).toEqual([
+      'auth', 'google', 'account', 'add', 'a@b.com', '--calendar',
+    ])
+  })
+
+  it('forwards --replace --write --calendar together, in order', () => {
+    expect(
+      buildRelayArgs('google', 'a@b.com', {
+        replace: true,
+        write: true,
+        calendar: true,
+      }),
+    ).toEqual([
+      'auth', 'google', 'account', 'add', 'a@b.com',
+      '--replace', '--write', '--calendar',
+    ])
+  })
+
+  it('--calendar never leaks into the microsoft argv', () => {
+    expect(
+      buildRelayArgs('microsoft', 'a@corp.com', { calendar: true, orgMode: true }),
+    ).toEqual([
+      'auth', 'microsoft', 'account', 'add', 'a@corp.com', '--org-mode',
+    ])
   })
 })


### PR DESCRIPTION
## The gap

The gdrive MCP already exposes Calendar tools (`list_calendars`, `get_events`) at **every** tier — `GoogleWorkspaceTierSchema` documents `core` as "Drive+Docs+Sheets+Calendar" (`src/config/schema.ts:2343`) and the launcher passes only `--tool-tier`, with no tool-name gate. But the token switchroom mints carries no Calendar scope, so those tools 403, and upstream then falls back to its own browser OAuth on `WORKSPACE_MCP_PORT` — unrecoverable inside a container. The scope was deliberately excluded under #1663 (`src/cli/drive.ts`: *"Deliberately NOT added here: `calendar`, `gmail.*` … a separate, larger scope-expansion decision"*).

This un-defers Calendar, narrowly, and honours the reasoning of that comment rather than overriding it.

## What landed

**`--calendar` on `switchroom auth google account add`**, mirroring `--write`.

- Mints `https://www.googleapis.com/auth/calendar.readonly` **and nothing else**.
- **Read-only only.** The read/write `calendar` and `calendar.events` scopes are never offered by any code path. Creating or moving events is a write surface with its own approval shape — exactly the argument RFC G §5 makes about Gmail. A unit test pins that the constant ends in `.readonly` and that no flag combination emits a calendar write scope.
- Also wired through the Telegram relay (`/auth google add <email> --calendar`), since that is the path most operators actually use and a dropped flag there would be indistinguishable from the feature not existing.

### Why opt-in and not a tier default

`workspaceScopesForTier` is **untouched** — no tier grants Calendar. Three reasons:

1. **A read grant must never silently widen** (RFC D §12). That is the invariant `--write` exists to protect; Calendar is a strictly larger blast radius than `drive.file` (your whole calendar vs. files the app itself created).
2. **Tier bumps re-mint.** Scopes are fixed at consent time, so raising `tier: core → extended` for Slides forces an `account add --replace`. If Calendar rode the tier, that unrelated re-mint would silently hand over the operator's calendar on a consent screen they were clicking through for Slides.
3. **The tier is not per-account** (see below), so a tier-default Calendar scope would be un-declinable for any account on a fleet whose tier was set for a different reason.

The existing `workspaceScopesForTier` test *"does NOT add calendar/gmail scopes (deferred per #1663)"* still passes unchanged — it is now the guard that keeps Calendar out of the tier default.

### Re-consent safety (the other half)

Scopes are fixed at consent time, so `--replace` mints *exactly* the set the flags describe. Before this, re-consenting for an unrelated reason without re-passing `--write` **silently stripped `drive.file`**, breaking every doc the agent could previously create. `buildMissingScopeWarning` already documented that hazard but only worked around it by printing the flag back into its recovery command.

`account add` now reads the scopes the broker holds (`list-google-accounts`) and unions the opt-ins forward (`resolveReconsentCapabilities`), announcing each carry-forward on stdout:

```
  Carrying forward Drive write (create + edit app-created files) — the existing
  token holds drive.file, so it is re-requested even though --write was not
  passed (re-consent would otherwise silently revoke it).
```

The union only flows **old → new**, so nothing widens: `--calendar` cannot pull in `--write`, and no tier implies either. A capability the operator did not request and the token does not already hold is never requested.

The broker read happens *before* the OAuth flow, so a broker problem fails without burning a consent. The broker was already a hard dependency of this command (`addAccount`), so this adds no new failure mode.

**No more silent no-ops.** Asking for a scope the stored token lacks *without* `--replace` used to hit the broker's generic already-registered refusal — which says nothing about scopes and reads as success. It now fails with an explicit error naming the exact recovery command, and stating that existing scopes are carried forward.

### Visibility

The granted scope set was **already** surfaced verbatim — broker `opListGoogleAccounts` returns `scope` (`src/auth/broker/server.ts:2280`), and `auth google account list` renders it in both the table and `--json`. `calendar.readonly` therefore appears there with no change required.

### Did the MCP need extra wiring?

**No.** Verified: there is no `ENABLED_TOOLS` / tool-name regex for Google (`reference/rfcs/microsoft-multi-account-per-agent.md:16` says the same), the only gate is upstream's `--tool-tier`, and Calendar tools ship at every tier. The scope was the sole missing piece.

`calendar.readonly` is deliberately **not** added to `requiredWorkspaceScopesForTier` — that function drives the launcher's startup preflight, and adding an opt-in scope to it would fire a spurious "missing scope" warning at every account that legitimately declined Calendar. `buildMissingScopeWarning` was, however, changed to carry **both** opt-ins into the recovery command it prints (it previously carried only `--write`, so a calendar-enabled operator running it verbatim would have silently downgraded — the exact bug class its own docstring warns about).

## Open question answered from the code: is the tier per-account?

**No. The tier is settable globally and per-agent, never per-account — and `account add` reads only the global one.**

- Global: `google_workspace.tier` (`GoogleWorkspaceConfigSchema`, `src/config/schema.ts:2343`).
- Per-agent: `agents.<name>.google_workspace.tier` (`AgentGoogleWorkspaceConfigSchema`, `src/config/schema.ts:2932`) — *"Per-agent tier override … most agents on `core`, one specialist on `extended`"*.
- Per-account: **does not exist.** `google_accounts.<email>` (`src/config/schema.ts:5153`) carries only `enabled_for[]`.
- And `account add` uses `const tier = gw.tier ?? "core"` off the **top-level** block only (`src/cli/auth-google.ts`) — the per-agent override never influences which scopes a token is minted with.

**Consequence for the "can a work account be registered read-only?" question: not fully, today.** Every tier mints `documents` + `spreadsheets`, which are **read/write** Google API scopes, and there is no per-account knob to decline them. So a work account can be registered without Drive write (`drive.file`) and without Calendar, but it will still carry read-write Docs/Sheets scopes. That is a pre-existing #1663 consequence, out of scope here; filed as #4191 — a read-only Workspace-document scope path (`documents.readonly` / `spreadsheets.readonly`) — rather than fixed here.

## Tests

`src/cli/drive.test.ts`, `src/cli/drive-mcp-launcher.test.ts`, `src/cli/auth-google.test.ts`, `telegram-plugin/tests/auth-loopback-relay.test.ts`.

Scope tests assert the **exact emitted array** (not `toContain`) for all four `--write` × `--calendar` combinations, plus: omitting `calendar` is byte-identical to `calendar:false` across all three tiers; no tier grants calendar; neither flag implies the other; no duplicates; no calendar write scope ever. Carry-forward tests cover fresh-add, re-consent-with-`--calendar`-keeps-`drive.file`, re-consent-with-no-flags-drops-nothing, and two explicit no-widening cases — including one that runs the plan through `selectGoogleWorkspaceScopes` so a correct plan with a wrong scope set still fails.

**Mutation check — 10 mutants, all killed** (baseline 178/178 green):

| mutant | tests failed |
|---|---|
| calendar always granted (silent widening) | 5 |
| calendar never granted (flag inert) | 4 |
| carry-forward dropped for `write` | 3 |
| carry-forward dropped for `calendar` | 1 |
| capability probe reads the calendar WRITE scope | 4 |
| launcher recovery command drops `--calendar` | 2 |
| relay drops `--calendar` from argv | 2 |
| chat parser ignores `--calendar` | 2 |
| re-consent error omits the recovery command | 2 |
| carry-forward notices silenced | 2 |

`npm run lint` clean (all 23 guards). Broader `vitest run src/cli/ src/auth/ telegram-plugin/tests/auth*` = 2729 passed; the single failure was `src/auth/broker/claude-compat.test.ts` "(6) the on-disk claude binary" timing out at 5s under parallel load — it execs the real `claude` binary, and passes in isolation both **with** the diff and on stashed-clean HEAD. Environment artifact, bucket 3.

## Operator follow-up (nothing is automatic)

Existing tokens do **not** gain the scope — scopes are fixed at consent time. To enable Calendar for an already-registered account, re-consent on the host (or from Telegram):

```bash
switchroom auth google account add <email> --replace --calendar
```

Existing capabilities (`drive.file`) are carried forward automatically and announced. Verify with `switchroom auth google account list`. No `switchroom.yaml` change is needed or made by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
