### PR TITLE
fix(agents): stop start.sh clobbering compose-set SWITCHROOM_CONFIG

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -805,7 +805,26 @@ export SWITCHROOM_AGENT_START_CWD="{{agentDir}}"
 # already gets this via .mcp.json env, but the Claude Code process
 # doesn't inherit that — so without this export, `switchroom auth status`
 # from Bash inside the agent fails with "No switchroom.yaml found".
-export SWITCHROOM_CONFIG={{{switchroomConfigPathQ}}}
+#
+# DEFER to a pre-set value: in Docker, compose.ts already sets
+# SWITCHROOM_CONFIG to the in-container mount (/state/config/
+# switchroom.yaml). The value baked here is the HOST path — resolve()d on
+# the machine that ran the scaffold — which does not exist inside the
+# container. Unconditionally exporting it clobbered the correct compose
+# value and silently killed the live model/effort resolvers below (their
+# [ -f "$SWITCHROOM_CONFIG" ] guard failed and fell into the quiet
+# no-config-mount branch), so `model:` edits + bare restart did nothing.
+# The bake stays as the fallback for host-run (non-Docker) agents, where
+# nothing else sets the var. ${VAR:-} also treats a set-but-EMPTY var as
+# unset, so an empty compose env can never blank the fallback.
+#
+# NB the baked path is pre-single-quoted by the scaffold, so it is
+# assigned BARE to a temp var first — embedding it directly inside
+# "${SWITCHROOM_CONFIG:-...}" would keep the literal quote characters in
+# the value.
+_SR_CONFIG_BAKED={{{switchroomConfigPathQ}}}
+export SWITCHROOM_CONFIG="${SWITCHROOM_CONFIG:-$_SR_CONFIG_BAKED}"
+unset _SR_CONFIG_BAKED
 {{/if}}
 {{#if hindsightEnabled}}
 # Hindsight memory plugin (vendored at .claude/plugins/hindsight-memory/).
@@ -1722,9 +1741,11 @@ fi
 #      launcher recorded on every prior boot (read BEFORE it is overwritten);
 #   3. the apply-time bake.
 # Steps 2/3 append to `.session-model-alert` so the gateway tells the
-# operator once at boot. No SWITCHROOM_CONFIG mount at all means there is
-# nothing to read live — the bake IS the truth there (stderr note only; an
-# operator alert every boot forever would be noise with no action).
+# operator once at boot. No SWITCHROOM_CONFIG at all means there is
+# nothing to read live — the bake IS the truth there and the fallback is
+# silent. But SWITCHROOM_CONFIG set with the FILE MISSING is a
+# misconfiguration that kills live resolution outright, so that case is
+# loud (stderr + operator alert) — see the else branch below.
 #
 # The yaml file bind mount re-resolves by PATH at container start, so a
 # host-side atomic-rename write is always picked up by the NEXT boot — the
@@ -1785,6 +1806,23 @@ if [ -n "$SWITCHROOM_CONFIG" ] && [ -f "$SWITCHROOM_CONFIG" ] && command -v swit
   unset _lm_live _lm_try _lm_baked_class _lm_live_class
 else
   _EFFECTIVE_MODEL="$_BAKED_MODEL"
+  # No live read possible. Distinguish the legitimately quiet case — no
+  # SWITCHROOM_CONFIG at all (host-run agent scaffolded without a config
+  # path; the bake IS the truth) — from a broken resolver hiding behind
+  # it. SWITCHROOM_CONFIG set but pointing at a file that does not exist
+  # is a misconfiguration (e.g. a host path leaking into a container env)
+  # that silently disables live `model:`/`thinking_effort:` resolution:
+  # exactly the defect that let the start.sh host-path clobber of the
+  # compose-set env go unnoticed. That case is LOUD — stderr + a one-boot
+  # operator alert. A set config whose file exists but with no
+  # `switchroom` CLI on PATH is equally dead, stderr-only (nothing the
+  # operator can act on from chat).
+  if [ -n "$SWITCHROOM_CONFIG" ] && [ ! -f "$SWITCHROOM_CONFIG" ]; then
+    echo "session-model: SWITCHROOM_CONFIG='$SWITCHROOM_CONFIG' is set but the file does not exist — live config resolution is DISABLED; using apply-time baked model '$_BAKED_MODEL'" >&2
+    printf '`SWITCHROOM_CONFIG` points at `%s`, which does not exist in this environment, so live `model:`/`thinking_effort:` resolution is disabled and the agent booted on the apply-time default `%s`. Edits to switchroom.yaml will NOT take effect on a bare restart until this is fixed.\n' "$SWITCHROOM_CONFIG" "$_BAKED_MODEL" >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+  elif [ -n "$SWITCHROOM_CONFIG" ]; then
+    echo "session-model: SWITCHROOM_CONFIG is set but no 'switchroom' CLI is on PATH — live config resolution is DISABLED; using apply-time baked model '$_BAKED_MODEL'" >&2
+  fi
 fi
 unset _BAKED_MODEL _LKG_MODEL
 # Record the RESOLVED configured default (raw, unquoted) every boot, before
@@ -2078,6 +2116,12 @@ if [ -n "$SWITCHROOM_CONFIG" ] && [ -f "$SWITCHROOM_CONFIG" ] && command -v swit
   unset _le_live _le_try
 else
   _EFFECTIVE_EFFORT="$_BAKED_EFFORT"
+  # Misconfig visibility, parity with the model sibling above — which
+  # owns the operator alert for this shared root cause; a second alert
+  # here would double-post for the same broken env. stderr only.
+  if [ -n "$SWITCHROOM_CONFIG" ] && [ ! -f "$SWITCHROOM_CONFIG" ]; then
+    echo "session-effort: SWITCHROOM_CONFIG='$SWITCHROOM_CONFIG' is set but the file does not exist — live config resolution is DISABLED; using apply-time baked thinking_effort '${_BAKED_EFFORT:-<unset>}'" >&2
+  fi
 fi
 unset _BAKED_EFFORT _LKG_EFFORT
 # Record the LIVE-RESOLVED configured default, BEFORE the carrier below can

--- a/tests/scaffold.session-model.test.ts
+++ b/tests/scaffold.session-model.test.ts
@@ -864,13 +864,50 @@ if [ -f "$marker" ]; then echo claude-opus-4-8; else touch "$marker"; echo "mang
       `export PATH=${JSON.stringify(fakeBin)}:"$PATH"`,
       "unset SWITCHROOM_CONFIG ANTHROPIC_BASE_URL SWITCHROOM_LITELLM_DECLARED",
       '_LITELLM_OK="1"',
+      "{",
       block,
+      "} 2>&1", // merge stderr so "silently" is actually asserted
       'echo "EFFECTIVE=$_EFFECTIVE_MODEL"',
     ].join("\n");
     const out = execFileSync("bash", ["-c", script], { encoding: "utf-8" });
     expect(out).toContain(`EFFECTIVE=${DEFAULT_MODEL}`);
+    // The unset case must stay QUIET even with the missing-file hardening:
+    // there is nothing to read and nothing actionable.
+    expect(out).not.toContain("DISABLED");
     expect(alertText()).toBe("");
     expect(fakeArgs()).toBe(""); // CLI never invoked
+  });
+
+  // The hardening that would have caught the start.sh host-path clobber the
+  // day it shipped: SWITCHROOM_CONFIG SET but pointing at a file that does
+  // not exist (a host path leaking into a container env) is a broken live
+  // resolver, not a "no config mount" — it must be LOUD, not silent.
+  it("SWITCHROOM_CONFIG set but file MISSING → bake with stderr + operator alert (misconfiguration, not silence)", () => {
+    fakeSwitchroom("echo fable");
+    const missingPath = join(tmpDir, "does-not-exist", "switchroom.yaml");
+    const script = [
+      "set -e",
+      `export PATH=${JSON.stringify(fakeBin)}:"$PATH"`,
+      `export SWITCHROOM_CONFIG=${JSON.stringify(missingPath)}`,
+      "unset ANTHROPIC_BASE_URL SWITCHROOM_LITELLM_DECLARED",
+      '_LITELLM_OK="1"',
+      "{",
+      block,
+      "} 2>&1", // stderr carries the loud warning — assert it
+      'echo "EFFECTIVE=$_EFFECTIVE_MODEL"',
+    ].join("\n");
+    const out = execFileSync("bash", ["-c", script], { encoding: "utf-8" });
+    // Outcome: still boots the bake (nothing live to read)…
+    expect(out).toContain(`EFFECTIVE=${DEFAULT_MODEL}`);
+    expect(fakeArgs()).toBe(""); // CLI never invoked against a missing file
+    // …but LOUDLY: stderr names the env var and the missing path…
+    expect(out).toContain("SWITCHROOM_CONFIG=");
+    expect(out).toContain("does not exist");
+    expect(out).toContain("DISABLED");
+    // …and the operator gets a one-boot alert saying yaml edits won't apply.
+    expect(alertText()).toContain(missingPath);
+    expect(alertText()).toContain("does not exist");
+    expect(alertText()).toContain("will NOT take effect");
   });
 
   // SE-3 ordering: the live value must land before the carrier compare, so a
@@ -1096,14 +1133,53 @@ describe("scaffoldAgent: live configured-default effort resolution (start.sh)", 
       `export PATH=${JSON.stringify(fakeBin)}:"$PATH"`,
       "unset SWITCHROOM_CONFIG ANTHROPIC_BASE_URL SWITCHROOM_LITELLM_DECLARED",
       '_LITELLM_OK="1"',
+      "{",
       block,
+      "} 2>&1", // merge stderr so "silently" is actually asserted
       'echo "EFFORT=$_EFFECTIVE_EFFORT"',
     ].join("\n");
     const out = execFileSync("bash", ["-c", script], { encoding: "utf-8" });
     expect(out).toContain("EFFORT=low");
+    expect(out).not.toContain("DISABLED"); // hardening must not fire when unset
     expect(alertText()).toBe("");
     expect(fakeArgs()).toBe(""); // CLI never invoked
     expect(lkg()).toBe(""); // nothing was live-read → nothing recorded
+  });
+
+  // Effort sibling of the model suite's missing-file hardening. The
+  // extracted block spans BOTH resolvers (model first, then effort), and one
+  // broken env kills both — so the outcome contract is: each resolver warns
+  // on stderr in its own name, but the operator alert for the shared root
+  // cause is posted exactly ONCE (by the model block, whose text covers
+  // `thinking_effort:` too; an effort-side alert would double-post one
+  // misconfiguration to the operator).
+  it("SWITCHROOM_CONFIG set but file MISSING → effort bakes with its own stderr warning; ONE shared operator alert", () => {
+    fakeSwitchroom("    echo high");
+    const missingPath = join(tmpDir, "does-not-exist", "switchroom.yaml");
+    const script = [
+      "set -e",
+      `export PATH=${JSON.stringify(fakeBin)}:"$PATH"`,
+      `export SWITCHROOM_CONFIG=${JSON.stringify(missingPath)}`,
+      "unset ANTHROPIC_BASE_URL SWITCHROOM_LITELLM_DECLARED",
+      '_LITELLM_OK="1"',
+      "{",
+      block,
+      "} 2>&1",
+      'echo "EFFORT=$_EFFECTIVE_EFFORT"',
+    ].join("\n");
+    const out = execFileSync("bash", ["-c", script], { encoding: "utf-8" });
+    expect(out).toContain("EFFORT=low"); // the bake
+    // Each resolver names itself on stderr — a dead effort resolver must
+    // not hide behind the model warning.
+    expect(out).toContain("session-model: SWITCHROOM_CONFIG=");
+    expect(out).toContain("session-effort: SWITCHROOM_CONFIG=");
+    expect(fakeArgs()).toBe(""); // CLI never invoked against a missing file
+    // Exactly ONE operator alert for the one root cause, and it covers both
+    // settings the dead resolver disables.
+    expect(alertText()).toContain(missingPath);
+    expect(alertText()).toContain("`thinking_effort:`");
+    expect(alertText().match(/does not exist/g)).toHaveLength(1);
+    expect(lkg()).toBe("");
   });
 
   // Ordering: the live effort must land BEFORE the .session-effort carrier

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -16,6 +16,7 @@ function expectRelativePoolLink(linkPath: string, expectedPoolTarget: string): v
   expect(resolve(dirname(linkPath), stored)).toBe(resolve(expectedPoolTarget));
 }
 import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
 import { scaffoldAgent, reconcileAgent, installHindsightPlugin, installSwitchroomSkills, renderFleetInvariants, computeDesiredPermissionAllow, HINDSIGHT_RECALL_QUERY_MAX_TOKENS_DEFAULT, HINDSIGHT_RECALL_REQUEST_TIMEOUT_SECONDS_DEFAULT } from "../src/agents/scaffold.js";
 import { resolveHindsightRecallTunables } from "../src/setup/hindsight-recall-tunables.js";
 import { createVault, setStringSecret } from "../src/vault/vault.js";
@@ -216,13 +217,23 @@ describe("scaffoldAgent", () => {
     expect(startSh).not.toContain(".oauth-token");
   });
 
-  it("start.sh exports SWITCHROOM_CONFIG when a config path is passed", () => {
+  it("start.sh exports SWITCHROOM_CONFIG when a config path is passed, DEFERRING to a pre-set env", () => {
     // Without this export, `switchroom <anything>` from the agent's own
     // Bash tool fails with "No switchroom.yaml found" because the CLI's
     // search paths (cwd + ~/.switchroom) don't cover where the user
     // actually keeps their config. The telegram plugin already gets the
     // var via .mcp.json, but the Claude Code process itself doesn't
     // inherit that — start.sh has to export it.
+    //
+    // CRITICAL (silent model-drift bug): the baked value is the HOST path,
+    // but in Docker compose.ts already set SWITCHROOM_CONFIG to the
+    // in-container mount (/state/config/switchroom.yaml). An unconditional
+    // `export SWITCHROOM_CONFIG=<host path>` clobbered that with a path
+    // that does not exist in the container, so the live model/effort
+    // resolvers' [ -f ] guard failed and every `model:` edit + bare
+    // restart silently booted the stale bake. The export must be the
+    // ${VAR:-bake} defer form, and these are OUTCOME assertions: the
+    // rendered snippet is executed both ways.
     const config = makeAgentConfig();
     const configPath = join(tmpDir, "switchroom.yaml");
     writeFileSync(configPath, "switchroom: { agents_dir: . }\n");
@@ -237,11 +248,41 @@ describe("scaffoldAgent", () => {
     );
     const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
 
-    expect(startSh).toContain(`export SWITCHROOM_CONFIG='${configPath}'`);
+    // Rendered form: bake assigned bare (pre-quoted), export defers to a
+    // pre-set env var.
+    expect(startSh).toContain(`_SR_CONFIG_BAKED='${configPath}'`);
+    expect(startSh).toContain('export SWITCHROOM_CONFIG="${SWITCHROOM_CONFIG:-$_SR_CONFIG_BAKED}"');
     const exportIdx = startSh.indexOf("export SWITCHROOM_CONFIG=");
     const execIdx = startSh.indexOf("exec claude");
     expect(exportIdx).toBeGreaterThanOrEqual(0);
     expect(exportIdx).toBeLessThan(execIdx);
+
+    // Execute the rendered snippet. Extract exactly the assignment + export
+    // lines so the outcome (which value wins) is tested, not the spelling.
+    const snippet = startSh
+      .split("\n")
+      .filter(
+        (l) =>
+          l.startsWith("_SR_CONFIG_BAKED=") ||
+          l.startsWith("export SWITCHROOM_CONFIG=") ||
+          l === "unset _SR_CONFIG_BAKED",
+      )
+      .join("\n");
+    expect(snippet).not.toBe("");
+    const runSnippet = (pre: string): string =>
+      execFileSync("bash", ["-c", `${pre}\n${snippet}\necho "CFG=$SWITCHROOM_CONFIG"`], {
+        encoding: "utf-8",
+      })
+        .match(/CFG=(.*)/)![1]
+        .trim();
+    // Docker case: compose already set the container path — it must WIN.
+    expect(runSnippet("export SWITCHROOM_CONFIG=/state/config/switchroom.yaml")).toBe(
+      "/state/config/switchroom.yaml",
+    );
+    // Host-run case: nothing pre-set — the bake is the fallback.
+    expect(runSnippet("unset SWITCHROOM_CONFIG")).toBe(configPath);
+    // Set-but-empty degenerates to the bake, never to an empty config path.
+    expect(runSnippet('export SWITCHROOM_CONFIG=""')).toBe(configPath);
   });
 
   it("start.sh omits SWITCHROOM_CONFIG export when no config path is passed", () => {
@@ -249,6 +290,7 @@ describe("scaffoldAgent", () => {
     const result = scaffoldAgent("no-cfg-agent", config, tmpDir, telegramConfig);
     const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
     expect(startSh).not.toContain("export SWITCHROOM_CONFIG=");
+    expect(startSh).not.toContain("_SR_CONFIG_BAKED=");
   });
 
   it("start.sh symlinks $HOME/.switchroom to host home (#910 tilde-path fix)", () => {


### PR DESCRIPTION
## Summary

Editing `model:` (or `thinking_effort:`) in `switchroom.yaml` and doing a bare `docker restart` **silently did nothing** — the agent booted the stale apply-time bake, with no stderr and no operator alert. Reproduced twice on the `test-harness` canary. The fleet is currently on the correct model only because a full `switchroom apply` re-baked it; the live resolver is still dead in every containerised agent until this lands.

## Why (root cause)

- `src/agents/compose.ts:1450` correctly sets `SWITCHROOM_CONFIG=/state/config/switchroom.yaml` in every agent container; the file is mounted and readable there.
- The scaffolded `start.sh` then **clobbered it with the HOST path**: `profiles/_base/start.sh.hbs:808` rendered `export SWITCHROOM_CONFIG='<host>/.switchroom/switchroom.yaml'` (from `resolve(switchroomConfigPath)` at `src/agents/scaffold.ts:3464-3466`). That path does not exist inside the container.
- Both live resolvers (`agent effective-model` at start.sh.hbs:1742, `agent effective-effort` at :2047) guard on `[ -f "$SWITCHROOM_CONFIG" ]`, which failed — and fell into a **deliberately silent** `else` branch that treats the condition as "no config mount at all" and boots the bake with zero signal.
- It looked fine under testing because `docker exec` inherits the **compose** env, not start.sh's export — so `switchroom agent effective-model` in an exec shell returned the right value while boot did not.

## Fix

`profiles/_base/start.sh.hbs`: stop clobbering an env the runtime already set correctly —

```sh
_SR_CONFIG_BAKED='<baked host path>'
export SWITCHROOM_CONFIG="${SWITCHROOM_CONFIG:-$_SR_CONFIG_BAKED}"
unset _SR_CONFIG_BAKED
```

The bake stays as the fallback, so host-run (non-Docker) agents are unaffected. `${VAR:-}` also treats set-but-empty as unset, so an empty env can never blank the path. (The bake is pre-single-quoted by the scaffold, hence the bare temp-var assignment — embedding it inside `"${...:-...}"` would keep the literal quote chars.)

## Hardening (why this went unnoticed)

The silent fallback that hid a broken resolver is the actual defect; the path bug just triggered it. The `else` branch now distinguishes:

- **`SWITCHROOM_CONFIG` unset** → legitimately quiet (no config mount; the bake IS the truth). Unchanged.
- **Set but the file is MISSING** → genuine misconfiguration: loud stderr in both resolvers + ONE `.session-model-alert` (owned by the model block, its text covers `thinking_effort:` too, so one root cause posts one operator alert, relayed by the gateway at boot).
- **Set, file exists, but no `switchroom` CLI on PATH** → stderr note (nothing the operator can act on from chat).

## Test plan

All are outcome tests that execute the rendered script/blocks, and all fail on the unfixed template (verified by stash-running them against `origin/main`'s template: 3/3 fail there, pass with the fix):

- `tests/scaffold.test.ts` — "start.sh exports SWITCHROOM_CONFIG when a config path is passed, DEFERRING to a pre-set env": asserts the rendered `${VAR:-bake}` form and **executes the snippet** three ways (pre-set container path wins; unset → bake; set-but-empty → bake).
- `tests/scaffold.session-model.test.ts` — "SWITCHROOM_CONFIG set but file MISSING → bake with stderr + operator alert (misconfiguration, not silence)" (model suite): bake boots, CLI never invoked, stderr names the var+path, alert says yaml edits will NOT take effect.
- `tests/scaffold.session-model.test.ts` — "SWITCHROOM_CONFIG set but file MISSING → effort bakes with its own stderr warning; ONE shared operator alert" (effort suite): both resolvers warn on stderr in their own name; exactly one `does not exist` operator alert for the shared root cause.
- Existing "no SWITCHROOM_CONFIG mount → bake, silently" tests in both suites now merge stderr and pin that the unset case stays quiet even with the hardening.

Local: `vitest run tests/scaffold.test.ts` (242 passed), `vitest run tests/scaffold.session-model.test.ts` (62 passed), `npm run lint` exit 0.

## Risk

- Host-run agents: behavior change only if the launching shell already exported `SWITCHROOM_CONFIG` — previously the bake clobbered it, now the env wins. That is the correct precedence (the env is set by whoever launched the process; the bake is a scaffold-time snapshot), and systemd/compose launch env is controlled.
- Audited every other `SWITCHROOM_CONFIG` assignment in the repo: `compose.ts:1450/1663/1752/2313`, the `.mcp.json` env sites (`scaffold.ts:3729/3796/3872/4683ff`), `cli/webd.ts:240`, `cli/hostd.ts:384` — all already use the correct in-container `/state/config/switchroom.yaml`. start.sh.hbs was the only site baking a host path into container-executed code.
- Rollout note: the template change reaches agents on the next `switchroom apply` / reconcile that regenerates `start.sh`, not on a bare restart.

Job spec: `reference/jobs/restart-and-know-what-im-running.md` — after a restart the user must know what config is live; a resolver that silently boots a stale model is the exact failure that job exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)