### PR TITLE
feat(google): per-account read-only + service scope selection (v1)

### DIFF
--- a/docs/google-workspace.md
+++ b/docs/google-workspace.md
@@ -271,6 +271,46 @@ Two deliberate limits:
   grant must never silently widen (RFC D §12), which is exactly why
   `--write` is a flag too.
 
+#### Read-only accounts and per-service selection
+
+For an account that should never hold a write scope at all, pass
+`--readonly`. Every selected service then mints only its `.readonly`
+scope variant — `documents.readonly`, `spreadsheets.readonly`,
+`presentations.readonly`, `calendar.readonly` — and the `gdrive` MCP
+runs upstream in `--read-only` mode, so write tools are not even
+registered. `--readonly` and `--write` are mutually exclusive.
+
+You can also narrow *which* services the account covers with
+`--services` (comma-separated: `cal`, `drive`, `docs`, `sheets`,
+`slides`; `calendar` is accepted for `cal`):
+
+```bash
+# a calendar-only, read-only account:
+switchroom auth google account add you@gmail.com --readonly --services cal
+# read-only Drive + Docs + Sheets (no Slides, no Calendar):
+switchroom auth google account add you@gmail.com --readonly --services drive,docs,sheets
+```
+
+The selection controls **both halves** of the grant from one record:
+the OAuth scopes minted at consent, and the tools the MCP exposes
+(upstream `--tools` / `--read-only`) — so the tools an agent sees are
+exactly the tools its token can authenticate.
+
+The selection is **persisted** into
+`google_accounts.<email>.{readonly,services}` in switchroom.yaml and
+**re-read on `--replace`**: re-consenting a read-only account for an
+unrelated reason (say, a tier bump) mints the same read-only selection
+again — it cannot silently re-widen. Changing the selection is always
+an explicit flag, and any capability a change drops is announced before
+the consent screen.
+
+Omitting both flags keeps today's behaviour exactly: tier-tied
+read-write document scopes, Drive read-only base, `--write` /
+`--calendar` opt-ins.
+
+v1 limits (deliberate follow-ups): no `gmail` service, no per-service
+write levels, no `calendar.events.readonly`.
+
 #### Re-consent carries existing scopes forward
 
 OAuth scopes are fixed at consent time, so `--replace` mints exactly the

--- a/src/agents/scaffold-gdrive-entry.test.ts
+++ b/src/agents/scaffold-gdrive-entry.test.ts
@@ -164,3 +164,76 @@ describe("resolveGdriveMcpEntry — does NOT emit", () => {
     ).toBeNull();
   });
 });
+
+// ── v1 per-account selection threading (readonly/services) ───────────────
+
+describe("resolveGdriveMcpEntry — per-account selection threading (v1)", () => {
+  it("threads the persisted services + readonly record as --services/--read-only", () => {
+    const entry = resolveGdriveMcpEntry(
+      "carrie",
+      agent({ google_workspace: { account: "you@example.com", tier: "core" } }),
+      cfg({
+        "you@example.com": {
+          enabled_for: ["carrie"],
+          readonly: true,
+          services: ["cal", "drive"],
+        },
+      }),
+    );
+    const args = entry?.value.args ?? [];
+    const i = args.indexOf("--services");
+    expect(i).toBeGreaterThan(-1);
+    expect(args[i + 1]).toBe("cal,drive");
+    expect(args).toContain("--read-only");
+  });
+
+  it("services without readonly threads --services only", () => {
+    const entry = resolveGdriveMcpEntry(
+      "carrie",
+      agent({ google_workspace: { account: "you@example.com" } }),
+      cfg({
+        "you@example.com": { enabled_for: ["carrie"], services: ["docs"] },
+      }),
+    );
+    const args = entry?.value.args ?? [];
+    expect(args).toContain("--services");
+    expect(args[args.indexOf("--services") + 1]).toBe("docs");
+    expect(args).not.toContain("--read-only");
+  });
+
+  it("readonly: false is NOT threaded (legacy arg shape preserved)", () => {
+    const entry = resolveGdriveMcpEntry(
+      "carrie",
+      agent({ google_workspace: { account: "you@example.com" } }),
+      cfg({
+        "you@example.com": { enabled_for: ["carrie"], readonly: false },
+      }),
+    );
+    expect(entry?.value.args).not.toContain("--read-only");
+  });
+
+  it("a legacy record (no selection) emits byte-identical pre-v1 args", () => {
+    const entry = resolveGdriveMcpEntry(
+      "carrie",
+      agent({ google_workspace: { account: "you@example.com", tier: "core" } }),
+      cfg({ "you@example.com": { enabled_for: ["carrie"] } }),
+    );
+    expect(entry?.value.args).toEqual(["drive-mcp-launcher", "--tier", "core"]);
+  });
+
+  it("account key lookup is case-insensitive (schema normalizes to lowercase)", () => {
+    const entry = resolveGdriveMcpEntry(
+      "carrie",
+      agent({ google_workspace: { account: "You@Example.com" } }),
+      cfg({
+        "you@example.com": {
+          enabled_for: ["carrie"],
+          readonly: true,
+          services: ["cal"],
+        },
+      }),
+    );
+    const args = entry?.value.args ?? [];
+    expect(args).toContain("--read-only");
+  });
+});

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -4502,10 +4502,22 @@ export function resolveGdriveMcpEntry(
   const tier =
     agentConfig.google_workspace?.tier ??
     switchroomConfig?.google_workspace?.tier;
-  const entry = getGdriveMcpSettingsEntry(
-    DOCKER_SWITCHROOM_CLI_PATH,
-    tier ? { tier } : {},
-  );
+  // Per-account selection (v1 read-only scope model): thread the
+  // persisted `google_accounts.<email>.{readonly,services}` record to
+  // the launcher alongside --tier. The launcher re-reads the record
+  // from config and is authoritative; threading makes the resolved
+  // choice visible in settings.json — and the SAME record minted the
+  // account's OAuth scopes, so tool exposure and token scope agree.
+  const accountRecord = account
+    ? googleAccounts?.[account.trim().toLowerCase()]
+    : undefined;
+  const entry = getGdriveMcpSettingsEntry(DOCKER_SWITCHROOM_CLI_PATH, {
+    ...(tier ? { tier } : {}),
+    ...(accountRecord?.services && accountRecord.services.length > 0
+      ? { services: accountRecord.services }
+      : {}),
+    ...(accountRecord?.readonly ? { readOnly: true } : {}),
+  });
   // Claude Code spawns MCP servers with a SANITIZED env (not the
   // parent/container env), so the drive-mcp-launcher gets none of the
   // compose-emitted SWITCHROOM_* / HOME vars unless we thread them onto

--- a/src/cli/auth-google.test.ts
+++ b/src/cli/auth-google.test.ts
@@ -311,3 +311,26 @@ describe("buildCarryForwardNotices — carry-forward is announced, not silent", 
     expect(lines[1]).toContain("--calendar");
   });
 });
+
+// ── buildSelectionReconsentRequiredError (v1 selection flags) ────────────
+
+describe("buildSelectionReconsentRequiredError", () => {
+  it("names the exact --replace command carrying the requested selection", () => {
+    const msg = _testing.buildSelectionReconsentRequiredError("a@b.com", {
+      readonly: true,
+      services: "cal,drive",
+    });
+    expect(msg).toContain(
+      "switchroom auth google account add a@b.com --replace --readonly --services cal,drive",
+    );
+    expect(msg).toContain("fixed at consent time");
+  });
+
+  it("readonly-only request omits --services from the recovery command", () => {
+    const msg = _testing.buildSelectionReconsentRequiredError("a@b.com", {
+      readonly: true,
+    });
+    expect(msg).toContain("--replace --readonly");
+    expect(msg).not.toContain("--services");
+  });
+});

--- a/src/cli/auth-google.ts
+++ b/src/cli/auth-google.ts
@@ -40,6 +40,7 @@ import {
   enableAgentsOnGoogleAccount,
   getEnabledAgentsForGoogleAccount,
   listGoogleAccounts,
+  setGoogleAccountSelection,
 } from "./google-accounts-yaml.js";
 import type { PutResult, GetResult } from "../vault/broker/client.js";
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
@@ -82,7 +83,7 @@ export function registerAuthGoogleSubcommands(
     .description(
       "Manage Google account credentials in the auth-broker (add / remove / list).",
     );
-  registerAccountAdd(account);
+  registerAccountAdd(account, program);
   registerAccountRemove(account);
   registerAccountList(account);
 }
@@ -598,7 +599,7 @@ function pad(s: string, width: number): string {
 // a `list-google-accounts` broker op (tracked follow-up).
 // ────────────────────────────────────────────────────────────────────────
 
-function registerAccountAdd(accountParent: Command): void {
+function registerAccountAdd(accountParent: Command, program: Command): void {
   accountParent
     .command("add <account>")
     .description(
@@ -619,11 +620,26 @@ function registerAccountAdd(accountParent: Command): void {
       "Request READ-ONLY Calendar scope (calendar.readonly) so the gdrive MCP's list_calendars / get_events tools authenticate. Opt-in — no tier grants it by default, and switchroom never requests a Calendar WRITE scope. Re-consent an existing account with `--replace --calendar`.",
       false,
     )
+    .option(
+      "--readonly",
+      "Mint ONLY read-only scope variants for every selected service (zero write scopes), and run the gdrive MCP in upstream --read-only mode. Mutually exclusive with --write. Persisted per account and carried forward on --replace — a read-only account cannot silently re-widen.",
+      false,
+    )
+    .option(
+      "--services <list>",
+      "Comma-separated per-account service selection: cal,drive,docs,sheets,slides ('calendar' accepted for 'cal'). Selects BOTH the OAuth scopes minted AND the tools the gdrive MCP exposes (upstream --tools). Omitted = the tier's default services (drive,docs,sheets; +slides at extended/complete). Persisted per account and carried forward on --replace.",
+    )
     .action(
       withConfigError(
         async (
           account: string,
-          opts: { replace?: boolean; write?: boolean; calendar?: boolean },
+          opts: {
+            replace?: boolean;
+            write?: boolean;
+            calendar?: boolean;
+            readonly?: boolean;
+            services?: string;
+          },
         ) => {
         const normalizedAccount = validateAndNormalizeAccountEmail(account);
 
@@ -636,6 +652,8 @@ function registerAccountAdd(accountParent: Command): void {
             selectGoogleWorkspaceScopes,
             capabilitiesFromScopeString,
             resolveReconsentCapabilities,
+            parseServicesOption,
+            resolveScopeSelection,
           },
           { selectInitialTier },
           { brokerCall },
@@ -771,6 +789,33 @@ function registerAccountAdd(accountParent: Command): void {
         // trigger upstream's doomed port-8000 OAuth fallback).
         const tier = gw.tier ?? "core";
 
+        // ── v1 per-account selection flags ─────────────────────────────
+        // Hard error BEFORE any broker/OAuth work: a read-only account
+        // minting write scopes is a contradiction, not a preference.
+        if (opts.readonly && opts.write) {
+          throw new Error(
+            "--readonly and --write are mutually exclusive. A read-only " +
+              "account mints zero write scopes; drop one of the flags.",
+          );
+        }
+        const requestedServices = opts.services
+          ? parseServicesOption(opts.services)
+          : undefined;
+        // The persisted selection is the deterministic `--replace`
+        // carry-forward: without it, re-consenting a read-only /
+        // service-narrowed account for an unrelated reason would
+        // silently re-widen to the tier default.
+        const persistedRecord = config.google_accounts?.[normalizedAccount];
+        const persistedSelection =
+          persistedRecord &&
+          (persistedRecord.readonly !== undefined ||
+            persistedRecord.services !== undefined)
+            ? {
+                readonly: persistedRecord.readonly,
+                services: persistedRecord.services,
+              }
+            : undefined;
+
         // Re-consent safety — opt-in capability carry-forward. OAuth
         // scopes are fixed at consent time, so `--replace` mints EXACTLY
         // the set the flags describe: re-consenting for an unrelated
@@ -803,10 +848,37 @@ function registerAccountAdd(accountParent: Command): void {
             buildScopeReconsentRequiredError(normalizedAccount, plan.added),
           );
         }
+        // Same shape for the v1 selection flags: changing readonly/
+        // services on an existing account is a scope change, and scopes
+        // are fixed at consent time.
+        if (
+          existingEntry &&
+          !opts.replace &&
+          (opts.readonly || requestedServices)
+        ) {
+          throw new Error(
+            buildSelectionReconsentRequiredError(normalizedAccount, {
+              readonly: opts.readonly ?? false,
+              services: opts.services,
+            }),
+          );
+        }
 
+        const selPlan = resolveScopeSelection({
+          flags: {
+            readonly: opts.readonly ?? false,
+            write: opts.write ?? false,
+            calendar: opts.calendar ?? false,
+            services: requestedServices,
+          },
+          persisted: persistedSelection,
+          existing: plan.effective,
+          tier,
+        });
         const accountScopes = selectGoogleWorkspaceScopes({
-          write: plan.effective.write,
-          calendar: plan.effective.calendar,
+          write: selPlan.selection.driveWrite,
+          readonly: selPlan.selection.readonly,
+          services: selPlan.selection.services,
           tier,
         });
         const oauthCfg = {
@@ -814,32 +886,62 @@ function registerAccountAdd(accountParent: Command): void {
           client_secret: clientSecretRaw,
           scopes: accountScopes,
         };
-        if (plan.effective.write) {
+        if (selPlan.selection.readonly) {
+          console.log(
+            chalk.yellow(
+              "  READ-ONLY selection: minting only .readonly scope variants — zero write scopes.",
+            ),
+          );
+        }
+        if (selPlan.selection.driveWrite && !selPlan.selection.readonly) {
           console.log(
             chalk.yellow(
               "  Requesting Drive WRITE scope (drive.file — create/edit app-created files).",
             ),
           );
         }
-        if (plan.effective.calendar) {
+        if (selPlan.selection.services.includes("cal")) {
           console.log(
             chalk.yellow(
               "  Requesting Calendar READ-ONLY scope (calendar.readonly — list calendars, read events).",
             ),
           );
         }
-        for (const line of buildCarryForwardNotices(plan.carried)) {
+        for (const d of selPlan.dropped) {
+          console.log(chalk.yellow(`  NOT carried forward: ${d}.`));
+        }
+        // Suppress a #4190 carry-forward notice when the v1 selection
+        // just dropped that capability (the dropped notice above is the
+        // truthful one).
+        const carried = plan.carried.filter(
+          (k) =>
+            !(k === "write" && selPlan.selection.readonly) &&
+            !(
+              k === "calendar" && !selPlan.selection.services.includes("cal")
+            ),
+        );
+        for (const line of buildCarryForwardNotices(carried)) {
           console.log(chalk.gray(line));
         }
-        console.log(
-          chalk.gray(
-            `  Workspace tier: ${tier} — requesting Docs + Sheets` +
-              (tier === "extended" || tier === "complete"
-                ? " + Slides"
-                : "") +
-              " API scopes so the tier's tools can authenticate.",
-          ),
-        );
+        if (selPlan.persist) {
+          console.log(
+            chalk.gray(
+              `  Service selection: ${selPlan.selection.services.join(", ")}` +
+                (selPlan.selection.readonly ? " (read-only)" : "") +
+                " — persisted per account and carried forward on --replace.",
+            ),
+          );
+        } else {
+          console.log(
+            chalk.gray(
+              `  Workspace tier: ${tier} — requesting Docs + Sheets` +
+                (tier === "extended" || tier === "complete"
+                  ? " + Slides"
+                  : "") +
+                " API scopes so the tier's tools can authenticate.",
+            ),
+          );
+        }
         console.log(
           chalk.gray(
             "  Changing the tier later requires re-running this command\n" +
@@ -919,6 +1021,31 @@ function registerAccountAdd(accountParent: Command): void {
             `  ✓ Registered Google account ${chalk.bold(normalizedAccount)} with auth-broker.`,
           ),
         );
+
+        // Persist the v1 selection into google_accounts.<email> AFTER
+        // the broker accepted the new token — the YAML record must
+        // describe a token that actually exists. This record is what
+        // `--replace` re-reads (deterministic carry-forward) and what
+        // the scaffold/launcher derive `--tools`/`--read-only` from.
+        if (selPlan.persist) {
+          const configPath = getConfigPath(program);
+          const raw = readFileSync(configPath, "utf-8");
+          const patched = setGoogleAccountSelection(raw, normalizedAccount, {
+            readonly: selPlan.persist.readonly ?? false,
+            services: selPlan.persist.services ?? [],
+          });
+          if (patched !== raw) {
+            writeGoogleYaml(configPath, patched);
+            console.log(
+              chalk.gray(
+                `  Persisted selection to google_accounts.${normalizedAccount} ` +
+                  `(readonly: ${selPlan.persist.readonly ?? false}, services: ` +
+                  `${(selPlan.persist.services ?? []).join(",")}). Agents pick ` +
+                  `it up on their next restart.`,
+              ),
+            );
+          }
+        }
         console.log();
         console.log(`  Next: enable on one or more agents:`);
         console.log(
@@ -979,6 +1106,39 @@ export function buildScopeReconsentRequiredError(
     "",
     "Scopes the account already holds are carried forward automatically,",
     "so re-consenting will not drop existing capabilities.",
+  ].join("\n");
+}
+
+/**
+ * Error text for "you asked for a different readonly/services selection
+ * on an already-registered account, but did not pass `--replace`".
+ * The v1-selection sibling of {@link buildScopeReconsentRequiredError}:
+ * without it the broker's generic already-registered refusal reads as
+ * success while the stored token keeps its old scope set.
+ *
+ * Exported so the wording contract is unit-pinned.
+ */
+export function buildSelectionReconsentRequiredError(
+  account: string,
+  requested: { readonly: boolean; services?: string },
+): string {
+  const flags = [
+    requested.readonly ? "--readonly" : "",
+    requested.services ? `--services ${requested.services}` : "",
+  ]
+    .filter((s) => s.length > 0)
+    .join(" ");
+  return [
+    `'${account}' is already registered with the auth-broker, and changing ` +
+      `its readonly/services selection changes the OAuth scope set.`,
+    "",
+    "OAuth scopes are fixed at consent time — a stored token cannot be",
+    "reshaped in place. Re-consent to mint a token with the new selection:",
+    "",
+    `  switchroom auth google account add ${account} --replace ${flags}`,
+    "",
+    "The persisted selection (and any capabilities the flags don't",
+    "explicitly change) is carried forward, never silently widened.",
   ].join("\n");
 }
 
@@ -1426,6 +1586,7 @@ export const _testing = {
   buildGoogleCredentials,
   oauthClientSetupGuidance,
   buildScopeReconsentRequiredError,
+  buildSelectionReconsentRequiredError,
   buildCarryForwardNotices,
   interpretConnectPutResult,
   interpretRefGetResult,

--- a/src/cli/drive-mcp-launcher.test.ts
+++ b/src/cli/drive-mcp-launcher.test.ts
@@ -25,9 +25,18 @@ import {
   seedOptInCapabilities,
   CALENDAR_READONLY_SCOPE,
   sanitizeToolsListMessage,
+  LAUNCHER_GOOGLE_SERVICES,
+  UPSTREAM_SERVICE_NAMES,
+  parseLauncherServices,
+  requiredScopesForSelection,
+  findMissingScopesForSelection,
+  resolveLauncherSelection,
 } from "./drive-mcp-launcher.js";
 import {
   GOOGLE_CALENDAR_READONLY_SCOPE,
+  GOOGLE_SERVICES,
+  parseServicesOption,
+  scopesForSelection,
   workspaceScopesForTier,
 } from "./drive.js";
 import { GOOGLE_WORKSPACE_MCP_PINNED_SHA } from "../memory/scaffold-integration.js";
@@ -570,5 +579,209 @@ describe("resolveCredentialsDir — per-agent, env override honoured", () => {
     expect(resolveCredentialsDir({ HOME: "/home/dev" })).toBe(
       "/home/dev/google-workspace-mcp/credentials",
     );
+  });
+});
+
+// ── v1 per-account READ-ONLY scope selection (launcher half) ─────────────
+
+const RO_DOCS = "https://www.googleapis.com/auth/documents.readonly";
+const RO_SHEETS = "https://www.googleapis.com/auth/spreadsheets.readonly";
+const RO_SLIDES = "https://www.googleapis.com/auth/presentations.readonly";
+const RW_DOCS = "https://www.googleapis.com/auth/documents";
+const RW_SHEETS = "https://www.googleapis.com/auth/spreadsheets";
+
+describe("launcher service vocabulary — stays in sync with drive.ts", () => {
+  it("mirrors GOOGLE_SERVICES exactly (no drift)", () => {
+    expect([...LAUNCHER_GOOGLE_SERVICES]).toEqual([...GOOGLE_SERVICES]);
+  });
+
+  it("parseLauncherServices agrees with drive.ts parseServicesOption", () => {
+    for (const input of ["cal", "calendar,drive", "slides,docs,sheets", "drive,cal"]) {
+      expect(parseLauncherServices(input)).toEqual(parseServicesOption(input));
+    }
+  });
+
+  it("rejects unknown services loudly (a typo must not silently drop a service)", () => {
+    expect(() => parseLauncherServices("gmail")).toThrow(/unknown service 'gmail'/);
+  });
+
+  it("maps cal → upstream 'calendar', everything else 1:1", () => {
+    expect(UPSTREAM_SERVICE_NAMES.cal).toBe("calendar");
+    for (const s of ["drive", "docs", "sheets", "slides"] as const) {
+      expect(UPSTREAM_SERVICE_NAMES[s]).toBe(s);
+    }
+  });
+});
+
+describe("buildUvxArgs — per-account selection → upstream --tools/--read-only", () => {
+  it("selection {services:[cal], readonly:true} emits '--tools calendar --read-only'", () => {
+    const args = buildUvxArgs("core", { readonly: true, services: ["cal"] });
+    expect(args.slice(-5)).toEqual([
+      "--tool-tier",
+      "core",
+      "--tools",
+      "calendar",
+      "--read-only",
+    ]);
+  });
+
+  it("each service is its OWN argv token (upstream nargs='*'), upstream names", () => {
+    const args = buildUvxArgs(undefined, {
+      readonly: false,
+      services: ["drive", "docs", "sheets", "slides", "cal"],
+    });
+    expect(args.slice(-6)).toEqual([
+      "--tools",
+      "drive",
+      "docs",
+      "sheets",
+      "slides",
+      "calendar",
+    ]);
+    expect(args).not.toContain("--read-only");
+    expect(args.some((a) => a.includes(","))).toBe(false);
+  });
+
+  it("no selection → argv is byte-identical to the pre-v1 launcher", () => {
+    expect(buildUvxArgs("extended")).toEqual(buildUvxArgs("extended", undefined));
+    expect(buildUvxArgs("extended")).not.toContain("--tools");
+    expect(buildUvxArgs("extended")).not.toContain("--read-only");
+  });
+
+  it("readonly without services still emits --read-only (and no --tools)", () => {
+    const args = buildUvxArgs("core", { readonly: true, services: [] });
+    expect(args.slice(-1)).toEqual(["--read-only"]);
+    expect(args).not.toContain("--tools");
+  });
+});
+
+describe("requiredScopesForSelection — preflight derives from the selection", () => {
+  it("read-only selection requires exactly the readonly variants", () => {
+    expect(
+      requiredScopesForSelection({
+        readonly: true,
+        services: ["drive", "docs", "sheets", "slides", "cal"],
+      }),
+    ).toEqual([RO_DOCS, RO_SHEETS, RO_SLIDES, CALENDAR_READONLY_SCOPE]);
+  });
+
+  it("RW selection matches the drive.ts mint for the same selection (minus Drive base)", () => {
+    const sel = { readonly: false, services: ["docs", "sheets"] as ("docs" | "sheets")[] };
+    expect(requiredScopesForSelection(sel)).toEqual(
+      scopesForSelection({ readonly: false, driveWrite: false, services: sel.services }),
+    );
+    expect(requiredScopesForSelection(sel)).toEqual([RW_DOCS, RW_SHEETS]);
+  });
+
+  it("drive is never preflight-checked (broker always mints the base)", () => {
+    expect(
+      requiredScopesForSelection({ readonly: false, services: ["drive"] }),
+    ).toEqual([]);
+  });
+});
+
+describe("findMissingScopesForSelection — a valid read-only token does NOT warn", () => {
+  const RO_SEED =
+    "https://www.googleapis.com/auth/drive.readonly " +
+    "https://www.googleapis.com/auth/drive.metadata.readonly " +
+    `${RO_DOCS} ${RO_SHEETS}`;
+
+  it("read-only seed + read-only selection → nothing missing (the v1 fix)", () => {
+    expect(
+      findMissingScopesForSelection(RO_SEED, "core", {
+        readonly: true,
+        services: ["drive", "docs", "sheets"],
+      }),
+    ).toEqual([]);
+  });
+
+  it("the SAME read-only seed under the legacy tier path WOULD warn — the coupling this replaces", () => {
+    // Pre-v1, required scopes were hard-coded to the RW doc scopes, so a
+    // read-only token warned on EVERY boot. Pin the contrast so the fix
+    // is visible: legacy path missing = RW docs+sheets, selection path = [].
+    expect(findMissingScopesForSelection(RO_SEED, "core", undefined)).toEqual([
+      RW_DOCS,
+      RW_SHEETS,
+    ]);
+  });
+
+  it("read-only seed missing a selected service's scope IS reported", () => {
+    expect(
+      findMissingScopesForSelection(RO_SEED, "core", {
+        readonly: true,
+        services: ["drive", "docs", "sheets", "cal"],
+      }),
+    ).toEqual([CALENDAR_READONLY_SCOPE]);
+  });
+
+  it("no selection → identical to the legacy tier-derived preflight", () => {
+    for (const tier of ["core", "extended", "complete", undefined] as const) {
+      expect(findMissingScopesForSelection("", tier, undefined)).toEqual(
+        findMissingWorkspaceScopes("", tier),
+      );
+    }
+  });
+});
+
+describe("resolveLauncherSelection — legacy passthrough + partial records", () => {
+  it("no record / empty record → undefined (legacy behaviour preserved)", () => {
+    expect(resolveLauncherSelection(undefined, "core")).toBeUndefined();
+    expect(resolveLauncherSelection({}, "core")).toBeUndefined();
+  });
+
+  it("services-only record → readonly defaults false", () => {
+    expect(resolveLauncherSelection({ services: ["cal", "drive"] }, "core")).toEqual({
+      readonly: false,
+      services: ["drive", "cal"],
+    });
+  });
+
+  it("readonly-only record → services default to the tier's services", () => {
+    expect(resolveLauncherSelection({ readonly: true }, "core")).toEqual({
+      readonly: true,
+      services: ["drive", "docs", "sheets"],
+    });
+    expect(resolveLauncherSelection({ readonly: true }, "extended")).toEqual({
+      readonly: true,
+      services: ["drive", "docs", "sheets", "slides"],
+    });
+  });
+});
+
+describe("buildMissingScopeWarning — recovery command carries the selection", () => {
+  it("prints --readonly and --services so a verbatim re-run cannot re-widen", () => {
+    const msg = buildMissingScopeWarning(
+      [CALENDAR_READONLY_SCOPE],
+      "core",
+      "ops@example.com",
+      seedOptInCapabilities(""),
+      { readonly: true, services: ["drive", "cal"] },
+    );
+    expect(msg).toContain(
+      "switchroom auth google account add ops@example.com --replace --readonly --services drive,cal",
+    );
+    expect(msg).not.toContain("--write");
+  });
+
+  it("selection without readonly keeps --write when the token carries drive.file", () => {
+    const msg = buildMissingScopeWarning(
+      [RW_DOCS],
+      "core",
+      "ops@example.com",
+      seedOptInCapabilities("https://www.googleapis.com/auth/drive.file"),
+      { readonly: false, services: ["drive", "docs"] },
+    );
+    expect(msg).toContain("--replace --write --services drive,docs");
+  });
+
+  it("no selection → legacy wording unchanged (tier-derived guidance)", () => {
+    const msg = buildMissingScopeWarning(
+      [RW_DOCS],
+      "core",
+      "ops@example.com",
+      seedOptInCapabilities(""),
+    );
+    expect(msg).toContain("for tier 'core'");
+    expect(msg).toContain("--replace\n");
   });
 });

--- a/src/cli/drive-mcp-launcher.ts
+++ b/src/cli/drive-mcp-launcher.ts
@@ -175,6 +175,7 @@ export function buildSeedCredentials(
  *
  *   uvx --from git+https://github.com/taylorwilsdon/google_workspace_mcp.git@<sha> \
  *       workspace-mcp --single-user [--tool-tier <tier>]
+ *       [--tools <svc>...] [--read-only]
  *
  * NB: the executable is `workspace-mcp`, NOT `google-workspace-mcp`.
  * The upstream package is named `workspace-mcp` and provides exactly
@@ -278,6 +279,148 @@ const DRIVE_FILE_SCOPE = "https://www.googleapis.com/auth/drive.file";
 export const CALENDAR_READONLY_SCOPE =
   "https://www.googleapis.com/auth/calendar.readonly";
 
+// ─── Per-account selection (v1 read-only scope model) ─────────────────────
+//
+// Mirrors `GOOGLE_SERVICES` + the readonly-aware service→scope map in
+// src/cli/drive.ts — duplicated here (not imported) for the same reason
+// as {@link requiredWorkspaceScopesForTier}: the launcher's hot path
+// stays free of the heavier drive.ts import tree. Launcher unit tests
+// assert equivalence against the drive.ts source of truth.
+
+/** Short service tokens (config/CLI vocabulary), canonical order. */
+export const LAUNCHER_GOOGLE_SERVICES = [
+  "drive",
+  "docs",
+  "sheets",
+  "slides",
+  "cal",
+] as const;
+export type LauncherGoogleService =
+  (typeof LAUNCHER_GOOGLE_SERVICES)[number];
+
+/**
+ * Short token → upstream `workspace-mcp --tools` service name. Upstream's
+ * VALID_SERVICES vocabulary at the pinned SHA (`main.py` SERVICE_MODULES)
+ * uses `calendar`, not `cal`; the rest map 1:1. Verified against SHA
+ * 9d69115b — `--tools` is argparse `nargs="*"` with these choices, so
+ * each service is its OWN argv token (never comma-joined).
+ */
+export const UPSTREAM_SERVICE_NAMES: Record<LauncherGoogleService, string> = {
+  drive: "drive",
+  docs: "docs",
+  sheets: "sheets",
+  slides: "slides",
+  cal: "calendar",
+};
+
+/** The persisted per-account selection as the launcher consumes it. */
+export interface LauncherScopeSelection {
+  /** Upstream `--read-only` + readonly scope expectations. */
+  readonly: boolean;
+  /** Selected services (short tokens; canonical order applied). */
+  services: LauncherGoogleService[];
+}
+
+/**
+ * Parse the `--services` CSV the scaffold threads onto the launcher
+ * entry. Tolerant of `calendar` as an alias for `cal`; unknown tokens
+ * are REJECTED loudly (a typo silently dropping a service would surface
+ * as tools 403ing much later). Pure + exported for unit-pinning.
+ */
+export function parseLauncherServices(
+  raw: string,
+): LauncherGoogleService[] {
+  const tokens = raw
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s.length > 0)
+    .map((s) => (s === "calendar" ? "cal" : s));
+  for (const t of tokens) {
+    if (!(LAUNCHER_GOOGLE_SERVICES as readonly string[]).includes(t)) {
+      throw new Error(
+        `drive-mcp-launcher: unknown service '${t}' in --services ` +
+          `(valid: ${LAUNCHER_GOOGLE_SERVICES.join(", ")})`,
+      );
+    }
+  }
+  const set = new Set(tokens as LauncherGoogleService[]);
+  return LAUNCHER_GOOGLE_SERVICES.filter((s) => set.has(s));
+}
+
+/**
+ * The scopes a persisted selection expects the seed token to carry —
+ * i.e. exactly what `account add` mints for that selection, minus the
+ * Drive base scopes (the broker has always minted those; the preflight
+ * has never checked them, and keeps not checking them) and minus
+ * `drive.file` (a capability opt-in, not a selection requirement).
+ *
+ * This is the selection-aware replacement for
+ * {@link requiredWorkspaceScopesForTier}: derived from the SAME
+ * persisted `{readonly, services}` record the argv is derived from, so
+ * a valid read-only token can never trip the missing-scope warning
+ * (the pre-v1 behaviour hard-coded the RW doc scopes as required and
+ * would have warned on EVERY boot of a read-only account).
+ */
+export function requiredScopesForSelection(
+  selection: LauncherScopeSelection,
+): string[] {
+  const ro = selection.readonly;
+  const out: string[] = [];
+  for (const s of selection.services) {
+    switch (s) {
+      case "docs":
+        out.push(
+          ro
+            ? "https://www.googleapis.com/auth/documents.readonly"
+            : "https://www.googleapis.com/auth/documents",
+        );
+        break;
+      case "sheets":
+        out.push(
+          ro
+            ? "https://www.googleapis.com/auth/spreadsheets.readonly"
+            : "https://www.googleapis.com/auth/spreadsheets",
+        );
+        break;
+      case "slides":
+        out.push(
+          ro
+            ? "https://www.googleapis.com/auth/presentations.readonly"
+            : "https://www.googleapis.com/auth/presentations",
+        );
+        break;
+      case "cal":
+        out.push(CALENDAR_READONLY_SCOPE);
+        break;
+      case "drive":
+        // Drive base scopes are always minted by the broker; never
+        // preflight-checked (pre-existing contract).
+        break;
+    }
+  }
+  return out;
+}
+
+/**
+ * Selection-aware missing-scope preflight. With a persisted selection,
+ * required scopes derive from `{readonly, services}`; without one, the
+ * legacy tier-derived requirement applies unchanged.
+ */
+export function findMissingScopesForSelection(
+  seedScope: string,
+  tier: string | undefined,
+  selection: LauncherScopeSelection | undefined,
+): string[] {
+  if (!selection) return findMissingWorkspaceScopes(seedScope, tier);
+  const have = new Set(
+    seedScope
+      .split(/\s+/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0),
+  );
+  return requiredScopesForSelection(selection).filter((s) => !have.has(s));
+}
+
 /** Opt-in capabilities an already-minted seed token may carry. */
 export interface SeedOptInCapabilities {
   /** `--write` → `drive.file`. */
@@ -334,36 +477,61 @@ export function buildMissingScopeWarning(
   tier: string | undefined,
   accountEmail: string,
   granted: SeedOptInCapabilities,
+  selection?: LauncherScopeSelection,
 ): string {
   const short = missing
     .map((s) => s.replace(/^https:\/\/www\.googleapis\.com\/auth\//, ""))
     .join(", ");
-  const suffix =
-    (granted.write ? " --write" : "") + (granted.calendar ? " --calendar" : "");
+  // The recovery command must carry the FULL selection, not just the
+  // legacy opt-ins: a read-only / service-narrowed account whose
+  // operator runs the printed command verbatim must re-mint the SAME
+  // selection — never silently re-widen to the tier default.
+  const suffix = selection
+    ? (selection.readonly ? " --readonly" : granted.write ? " --write" : "") +
+      ` --services ${selection.services.join(",")}`
+    : (granted.write ? " --write" : "") +
+      (granted.calendar ? " --calendar" : "");
   const preserved = [
-    granted.write
+    selection
+      ? `--services ${selection.services.join(",")}` +
+        `${selection.readonly ? " --readonly" : ""} preserves the persisted per-account selection`
+      : "",
+    !selection && granted.write
       ? "--write preserves the existing Drive write capability"
       : "",
-    granted.calendar
+    !selection && granted.calendar
       ? "--calendar preserves the existing Calendar read capability"
       : "",
   ].filter((s) => s.length > 0);
+  const scopeSource = selection
+    ? `for its persisted selection (services: ${selection.services.join(",")}` +
+      `${selection.readonly ? ", read-only" : ""})`
+    : `for tier '${tier ?? "core"}'`;
   return (
     `drive-mcp-launcher: WARNING — the Google account '${accountEmail}' was ` +
-    `consented WITHOUT the scope(s) needed for tier '${tier ?? "core"}': ` +
+    `consented WITHOUT the scope(s) needed ${scopeSource}: ` +
     `${short}.\n` +
-    `  The matching MCP tools (Docs / Sheets / Slides create+edit) will FAIL ` +
+    `  The matching MCP tools will FAIL ` +
     `to authenticate. OAuth scopes are fixed at consent time — re-run on the ` +
     `host to re-mint the token with the correct scopes:\n` +
     `    switchroom auth google account add ${accountEmail} --replace` +
     `${suffix}\n` +
-    `  (scopes are derived from \`google_workspace.tier\` — set the tier ` +
-    `before re-running${preserved.length > 0 ? "; " + preserved.join("; ") : ""}` +
-    `). Drive read/file tools are unaffected.\n`
+    `  (${
+      selection
+        ? ""
+        : "scopes are derived from `google_workspace.tier` — set the tier before re-running"
+    }${
+      preserved.length > 0
+        ? (selection ? "" : "; ") + preserved.join("; ")
+        : ""
+    }). Drive read/file tools are unaffected.\n`
   );
 }
 
-export function buildUvxArgs(tier?: string): string[] {
+export function buildUvxArgs(
+  tier?: string,
+  selection?: LauncherScopeSelection,
+): string[] {
   const args = [
     "--from",
     `git+https://github.com/taylorwilsdon/google_workspace_mcp.git@${GOOGLE_WORKSPACE_MCP_PINNED_SHA}`,
@@ -385,6 +553,23 @@ export function buildUvxArgs(tier?: string): string[] {
   ];
   if (tier && tier.length > 0) {
     args.push("--tool-tier", tier);
+  }
+  // Per-account selection → upstream tool gating. `--tools` narrows
+  // registration to the selected services (upstream argparse nargs="*":
+  // one argv token per service, upstream names — `cal` → `calendar`);
+  // `--read-only` makes upstream request only readonly scopes and skip
+  // registering write tools. Combined with `--tool-tier`, upstream
+  // filters the tier's tools to the selected services (verified at the
+  // pinned SHA). Same persisted record mints the OAuth scopes, so tool
+  // exposure and token scope cannot disagree.
+  if (selection && selection.services.length > 0) {
+    args.push(
+      "--tools",
+      ...selection.services.map((s) => UPSTREAM_SERVICE_NAMES[s]),
+    );
+  }
+  if (selection?.readonly) {
+    args.push("--read-only");
   }
   return args;
 }
@@ -765,6 +950,44 @@ interface ConfigSecrets {
   clientId: string | undefined;
   clientSecret: string | undefined;
   tier: string | undefined;
+  /**
+   * Per-account selection records from `google_accounts:` (keyed by
+   * normalized email). The launcher looks up the broker-selected
+   * account's record to derive `--tools` / `--read-only` and the
+   * scope preflight — same persisted record `account add` minted the
+   * scopes from.
+   */
+  googleAccounts: Record<
+    string,
+    { readonly?: boolean; services?: string[] }
+  >;
+}
+
+/**
+ * Resolve the effective launcher selection for one account record.
+ * Returns `undefined` for a legacy record (neither `readonly` nor
+ * `services` set) — legacy accounts keep the exact pre-v1 behaviour
+ * (tier-gated tools, tier-derived scope preflight, no `--tools`).
+ * A partial record fills the missing axis deterministically: absent
+ * `services` → the tier's default services; absent `readonly` → false.
+ *
+ * Pure + exported so the legacy-passthrough contract is unit-pinned.
+ */
+export function resolveLauncherSelection(
+  record: { readonly?: boolean; services?: string[] } | undefined,
+  tier: string | undefined,
+): LauncherScopeSelection | undefined {
+  if (!record) return undefined;
+  if (record.readonly === undefined && record.services === undefined) {
+    return undefined;
+  }
+  const services =
+    record.services && record.services.length > 0
+      ? parseLauncherServices(record.services.join(","))
+      : tier === "extended" || tier === "complete"
+        ? (["drive", "docs", "sheets", "slides"] as LauncherGoogleService[])
+        : (["drive", "docs", "sheets"] as LauncherGoogleService[]);
+  return { readonly: record.readonly ?? false, services };
 }
 
 /**
@@ -790,7 +1013,17 @@ async function loadConfigSecrets(): Promise<ConfigSecrets> {
     gw.google_client_secret,
     "google_client_secret",
   );
-  return { clientId, clientSecret, tier: gw.tier };
+  const googleAccounts: ConfigSecrets["googleAccounts"] = {};
+  for (const [email, record] of Object.entries(
+    config.google_accounts ?? {},
+  )) {
+    if (!record) continue;
+    googleAccounts[email.toLowerCase()] = {
+      readonly: record.readonly,
+      services: record.services,
+    };
+  }
+  return { clientId, clientSecret, tier: gw.tier, googleAccounts };
 }
 
 // ─── Entry ────────────────────────────────────────────────────────────────
@@ -803,6 +1036,10 @@ async function loadConfigSecrets(): Promise<ConfigSecrets> {
  */
 export async function runDriveMcpLauncher(opts: {
   tier?: string;
+  /** `--services` CSV override (scaffold-threaded); wins over config. */
+  services?: string;
+  /** `--read-only` override (scaffold-threaded); wins over config. */
+  readOnly?: boolean;
 }): Promise<never> {
   let brokerCreds: BrokerGoogleCreds;
   let configSecrets: ConfigSecrets;
@@ -867,6 +1104,38 @@ export async function runDriveMcpLauncher(opts: {
   // wins over the config top-level tier.
   const tier = opts.tier ?? configSecrets.tier;
 
+  // Per-account selection (v1 read-only scope model). Scaffold-threaded
+  // flags win (mirroring --tier); otherwise the persisted
+  // `google_accounts.<email>.{readonly,services}` record for the
+  // broker-selected account. Legacy accounts (no record) → undefined →
+  // byte-identical pre-v1 behaviour.
+  let selection: LauncherScopeSelection | undefined;
+  try {
+    const configSelection = resolveLauncherSelection(
+      configSecrets.googleAccounts[brokerCreds.accountEmail.toLowerCase()],
+      tier,
+    );
+    if (opts.services !== undefined || opts.readOnly) {
+      selection = {
+        readonly: opts.readOnly ?? configSelection?.readonly ?? false,
+        services:
+          opts.services !== undefined
+            ? parseLauncherServices(opts.services)
+            : (configSelection?.services ??
+              // No config record and no --services: readonly-only
+              // override applies to the tier's default services.
+              resolveLauncherSelection({ readonly: false }, tier)!.services),
+      };
+    } else {
+      selection = configSelection;
+    }
+  } catch (err) {
+    process.stderr.write(
+      `drive-mcp-launcher: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(1);
+  }
+
   // Scope ↔ tier preflight (issue #1663). The broker's seed token was
   // minted by `auth google account add` at whatever tier was configured
   // THEN. If the operator later raised the tier (e.g. core → extended
@@ -877,24 +1146,30 @@ export async function runDriveMcpLauncher(opts: {
   // the first Docs/Sheets/Slides call. We warn (not exit): Drive tools
   // and any in-scope Workspace tools still work, so degrading is better
   // than refusing to start.
-  const missingScopes = findMissingWorkspaceScopes(brokerCreds.scope, tier);
+  const missingScopes = findMissingScopesForSelection(
+    brokerCreds.scope,
+    tier,
+    selection,
+  );
   if (missingScopes.length > 0) {
     // Decide the recovery command's opt-in suffixes from the EXISTING
     // token's scopes — NOT from `missingScopes` (which never contains
     // drive.file or calendar.readonly). A token that already carries
     // those was minted with them; the printed `account add --replace`
-    // must keep the matching flags or the operator silently downgrades.
+    // must keep the matching flags (and the persisted selection) or the
+    // operator silently downgrades / re-widens.
     process.stderr.write(
       buildMissingScopeWarning(
         missingScopes,
         tier,
         brokerCreds.accountEmail,
         seedOptInCapabilities(brokerCreds.scope),
+        selection,
       ),
     );
   }
 
-  const args = buildUvxArgs(tier);
+  const args = buildUvxArgs(tier, selection);
   const env = buildChildEnv(
     process.env,
     credentialsDir,
@@ -964,7 +1239,25 @@ export function registerDriveMcpLauncherCommand(program: Command): void {
       "--tier <tier>",
       "Upstream --tool-tier (core|extended|complete). Overrides config.",
     )
-    .action(async (opts: { tier?: string }) => {
-      await runDriveMcpLauncher({ tier: opts.tier });
-    });
+    .option(
+      "--services <list>",
+      "Comma-separated per-account service selection (cal,drive,docs,sheets,slides) → upstream --tools. Overrides the persisted google_accounts.<email>.services record.",
+    )
+    .option(
+      "--read-only",
+      "Run upstream in --read-only mode (readonly scopes, write tools not registered). Overrides the persisted google_accounts.<email>.readonly record.",
+    )
+    .action(
+      async (opts: {
+        tier?: string;
+        services?: string;
+        readOnly?: boolean;
+      }) => {
+        await runDriveMcpLauncher({
+          tier: opts.tier,
+          services: opts.services,
+          readOnly: opts.readOnly,
+        });
+      },
+    );
 }

--- a/src/cli/drive.test.ts
+++ b/src/cli/drive.test.ts
@@ -47,6 +47,14 @@ import {
   GOOGLE_SHEETS_SCOPE,
   GOOGLE_SLIDES_SCOPE,
   GOOGLE_CALENDAR_READONLY_SCOPE,
+  GOOGLE_DOCS_READONLY_SCOPE,
+  GOOGLE_SHEETS_READONLY_SCOPE,
+  GOOGLE_SLIDES_READONLY_SCOPE,
+  GOOGLE_SERVICES,
+  parseServicesOption,
+  tierDefaultServices,
+  scopesForSelection,
+  resolveScopeSelection,
   capabilitiesFromScopeString,
   resolveReconsentCapabilities,
   type DriveCliDeps,
@@ -783,5 +791,354 @@ describe("resolveReconsentCapabilities — no drop, no silent widening", () => {
     );
     expect(plan.added).toEqual([]);
     expect(plan.carried).toEqual([]);
+  });
+});
+
+// ── v1 per-account READ-ONLY scope selection ─────────────────────────────
+
+const DRIVE_RO = [
+  "https://www.googleapis.com/auth/drive.readonly",
+  "https://www.googleapis.com/auth/drive.metadata.readonly",
+];
+const DRIVE_FILE = "https://www.googleapis.com/auth/drive.file";
+const CAL_RO = GOOGLE_CALENDAR_READONLY_SCOPE;
+
+describe("read-only Workspace scope constants", () => {
+  it("every readonly constant ends in .readonly and is not a write scope", () => {
+    for (const s of [
+      GOOGLE_DOCS_READONLY_SCOPE,
+      GOOGLE_SHEETS_READONLY_SCOPE,
+      GOOGLE_SLIDES_READONLY_SCOPE,
+    ]) {
+      expect(s).toMatch(/\.readonly$/);
+    }
+    expect(GOOGLE_DOCS_READONLY_SCOPE).toBe(
+      "https://www.googleapis.com/auth/documents.readonly",
+    );
+    expect(GOOGLE_SHEETS_READONLY_SCOPE).toBe(
+      "https://www.googleapis.com/auth/spreadsheets.readonly",
+    );
+    expect(GOOGLE_SLIDES_READONLY_SCOPE).toBe(
+      "https://www.googleapis.com/auth/presentations.readonly",
+    );
+  });
+});
+
+describe("parseServicesOption", () => {
+  it("parses, de-dups, and canonicalizes order", () => {
+    expect(parseServicesOption("cal,drive,cal")).toEqual(["drive", "cal"]);
+    expect(parseServicesOption("slides, docs")).toEqual(["docs", "slides"]);
+  });
+
+  it("accepts 'calendar' as an alias for 'cal'", () => {
+    expect(parseServicesOption("calendar")).toEqual(["cal"]);
+  });
+
+  it("rejects an unknown service naming the full vocabulary", () => {
+    expect(() => parseServicesOption("gmail")).toThrow(/unknown service 'gmail'/);
+    expect(() => parseServicesOption("gmail")).toThrow(/cal, drive, docs, sheets, slides|drive, docs, sheets, slides, cal/);
+  });
+
+  it("rejects an empty list", () => {
+    expect(() => parseServicesOption(" , ")).toThrow(/at least one service/);
+  });
+});
+
+describe("tierDefaultServices", () => {
+  it("core → drive,docs,sheets; extended/complete add slides; cal NEVER default", () => {
+    expect(tierDefaultServices("core")).toEqual(["drive", "docs", "sheets"]);
+    expect(tierDefaultServices("extended")).toEqual([
+      "drive",
+      "docs",
+      "sheets",
+      "slides",
+    ]);
+    expect(tierDefaultServices("complete")).toEqual([
+      "drive",
+      "docs",
+      "sheets",
+      "slides",
+    ]);
+    for (const tier of ["core", "extended", "complete"] as const) {
+      expect(tierDefaultServices(tier)).not.toContain("cal");
+    }
+  });
+});
+
+describe("scopesForSelection — the readonly-aware service→scope map", () => {
+  it("readonly=true mints ZERO write scopes (exact set, full selection)", () => {
+    expect(
+      scopesForSelection({
+        readonly: true,
+        driveWrite: false,
+        services: ["drive", "docs", "sheets", "slides", "cal"],
+      }),
+    ).toEqual([
+      ...DRIVE_RO,
+      GOOGLE_DOCS_READONLY_SCOPE,
+      GOOGLE_SHEETS_READONLY_SCOPE,
+      GOOGLE_SLIDES_READONLY_SCOPE,
+      CAL_RO,
+    ]);
+  });
+
+  it("readonly=true ignores driveWrite — drive.file cannot leak into a read-only grant", () => {
+    const s = scopesForSelection({
+      readonly: true,
+      driveWrite: true,
+      services: ["drive", "docs"],
+    });
+    expect(s).toEqual([...DRIVE_RO, GOOGLE_DOCS_READONLY_SCOPE]);
+    expect(s).not.toContain(DRIVE_FILE);
+  });
+
+  it("readonly=false default selection reproduces today's scopes exactly", () => {
+    expect(
+      scopesForSelection({
+        readonly: false,
+        driveWrite: false,
+        services: ["drive", "docs", "sheets"],
+      }),
+    ).toEqual([...DRIVE_RO, GOOGLE_DOCS_SCOPE, GOOGLE_SHEETS_SCOPE]);
+  });
+
+  it("cal alone mints ONLY calendar.readonly", () => {
+    expect(
+      scopesForSelection({ readonly: false, driveWrite: false, services: ["cal"] }),
+    ).toEqual([CAL_RO]);
+    // Even asking for write mints nothing extra — cal has no write scope.
+    expect(
+      scopesForSelection({ readonly: false, driveWrite: true, services: ["cal"] }),
+    ).toEqual([CAL_RO]);
+  });
+
+  it("no readonly selection ever contains a write scope, for every service subset", () => {
+    const writeScopes = [
+      DRIVE_FILE,
+      GOOGLE_DOCS_SCOPE,
+      GOOGLE_SHEETS_SCOPE,
+      GOOGLE_SLIDES_SCOPE,
+      "https://www.googleapis.com/auth/drive",
+      "https://www.googleapis.com/auth/calendar",
+      "https://www.googleapis.com/auth/calendar.events",
+    ];
+    // All 31 non-empty subsets of the 5 services.
+    for (let mask = 1; mask < 1 << GOOGLE_SERVICES.length; mask++) {
+      const services = GOOGLE_SERVICES.filter((_, i) => mask & (1 << i));
+      const s = scopesForSelection({
+        readonly: true,
+        driveWrite: true,
+        services,
+      });
+      for (const w of writeScopes) expect(s).not.toContain(w);
+    }
+  });
+});
+
+describe("selectGoogleWorkspaceScopes — readonly + services (v1)", () => {
+  it("readonly + write is a hard error", () => {
+    expect(() =>
+      selectGoogleWorkspaceScopes({ write: true, readonly: true, tier: "core" }),
+    ).toThrow(/mutually exclusive/);
+  });
+
+  it("services: ['cal'] mints ONLY calendar.readonly", () => {
+    expect(
+      selectGoogleWorkspaceScopes({ write: false, services: ["cal"], tier: "core" }),
+    ).toEqual([CAL_RO]);
+  });
+
+  it("readonly core default mints exactly the readonly variants", () => {
+    expect(
+      selectGoogleWorkspaceScopes({ write: false, readonly: true, tier: "core" }),
+    ).toEqual([
+      ...DRIVE_RO,
+      GOOGLE_DOCS_READONLY_SCOPE,
+      GOOGLE_SHEETS_READONLY_SCOPE,
+    ]);
+  });
+
+  it("omitting readonly/services is byte-identical to the pre-v1 behaviour", () => {
+    for (const tier of ["core", "extended", "complete"] as const) {
+      for (const write of [false, true]) {
+        for (const calendar of [false, true]) {
+          expect(
+            selectGoogleWorkspaceScopes({ write, calendar, tier }),
+          ).toEqual(
+            selectGoogleWorkspaceScopes({
+              write,
+              calendar,
+              tier,
+              readonly: false,
+              services: calendar
+                ? [...tierDefaultServices(tier), "cal"]
+                : tierDefaultServices(tier),
+            }),
+          );
+        }
+      }
+    }
+  });
+
+  it("input service order does not change the emitted set (canonical order)", () => {
+    expect(
+      selectGoogleWorkspaceScopes({
+        write: false,
+        services: ["cal", "sheets", "drive"],
+        tier: "core",
+      }),
+    ).toEqual(
+      selectGoogleWorkspaceScopes({
+        write: false,
+        services: ["drive", "sheets", "cal"],
+        tier: "core",
+      }),
+    );
+  });
+});
+
+describe("resolveScopeSelection — deterministic carry-forward (v1)", () => {
+  const NONE = { write: false, calendar: false };
+  const noFlags = {
+    readonly: false,
+    write: false,
+    calendar: false,
+    services: undefined,
+  };
+
+  it("readonly + write flags are a hard error", () => {
+    expect(() =>
+      resolveScopeSelection({
+        flags: { ...noFlags, readonly: true, write: true },
+        existing: NONE,
+        tier: "core",
+      }),
+    ).toThrow(/mutually exclusive/);
+  });
+
+  it("fresh add, no flags → tier default selection, nothing persisted", () => {
+    const plan = resolveScopeSelection({
+      flags: noFlags,
+      existing: NONE,
+      tier: "core",
+    });
+    expect(plan.selection).toEqual({
+      readonly: false,
+      services: ["drive", "docs", "sheets"],
+      driveWrite: false,
+    });
+    expect(plan.persist).toBeNull();
+    expect(plan.dropped).toEqual([]);
+  });
+
+  it("--replace with NO flags re-reads the persisted selection and does NOT re-widen", () => {
+    // The design's headline outcome: a read-only, service-narrowed
+    // account re-consented for an unrelated reason keeps its exact
+    // selection — the minted scope set carries zero write scopes.
+    const plan = resolveScopeSelection({
+      flags: noFlags,
+      persisted: { readonly: true, services: ["drive", "cal"] },
+      existing: NONE,
+      tier: "extended", // tier bump must NOT re-widen the selection
+      });
+    expect(plan.selection).toEqual({
+      readonly: true,
+      services: ["drive", "cal"],
+      driveWrite: false,
+    });
+    expect(plan.persist).toEqual({ readonly: true, services: ["drive", "cal"] });
+    expect(scopesForSelection(plan.selection)).toEqual([...DRIVE_RO, CAL_RO]);
+  });
+
+  it("--readonly on a token that carries drive.file DROPS write, loudly", () => {
+    const plan = resolveScopeSelection({
+      flags: { ...noFlags, readonly: true },
+      existing: { write: true, calendar: false },
+      tier: "core",
+    });
+    expect(plan.selection.readonly).toBe(true);
+    expect(plan.selection.driveWrite).toBe(false);
+    expect(plan.dropped.some((d) => d.includes("drive.file"))).toBe(true);
+    expect(scopesForSelection(plan.selection)).not.toContain(DRIVE_FILE);
+  });
+
+  it("--write on a persisted read-only record flips readonly off, loudly", () => {
+    const plan = resolveScopeSelection({
+      flags: { ...noFlags, write: true },
+      persisted: { readonly: true, services: ["drive", "docs"] },
+      existing: { write: true, calendar: false },
+      tier: "core",
+    });
+    expect(plan.selection.readonly).toBe(false);
+    expect(plan.selection.driveWrite).toBe(true);
+    expect(plan.dropped.some((d) => d.includes("read-only"))).toBe(true);
+  });
+
+  it("explicit --services narrows and announces every dropped service", () => {
+    const plan = resolveScopeSelection({
+      flags: { ...noFlags, services: ["drive"] },
+      persisted: { readonly: false, services: ["drive", "docs", "cal"] },
+      existing: NONE,
+      tier: "core",
+    });
+    expect(plan.selection.services).toEqual(["drive"]);
+    expect(plan.dropped.some((d) => d.includes("'docs'"))).toBe(true);
+    expect(plan.dropped.some((d) => d.includes("'cal'"))).toBe(true);
+  });
+
+  it("legacy token with calendar capability, no persisted record → cal carried, nothing persisted... unless flags say otherwise", () => {
+    const plan = resolveScopeSelection({
+      flags: noFlags,
+      existing: { write: false, calendar: true },
+      tier: "core",
+    });
+    expect(plan.selection.services).toEqual(["drive", "docs", "sheets", "cal"]);
+    expect(plan.persist).toBeNull();
+  });
+
+  it("--calendar alongside explicit --services unions cal in (no drop notice)", () => {
+    const plan = resolveScopeSelection({
+      flags: { ...noFlags, calendar: true, services: ["drive"] },
+      existing: NONE,
+      tier: "core",
+    });
+    expect(plan.selection.services).toEqual(["drive", "cal"]);
+    expect(plan.dropped.filter((d) => d.includes("'cal'"))).toEqual([]);
+  });
+
+  it("--services on a fresh add persists the selection", () => {
+    const plan = resolveScopeSelection({
+      flags: { ...noFlags, readonly: true, services: ["cal"] },
+      existing: NONE,
+      tier: "core",
+    });
+    expect(plan.selection).toEqual({
+      readonly: true,
+      services: ["cal"],
+      driveWrite: false,
+    });
+    expect(plan.persist).toEqual({ readonly: true, services: ["cal"] });
+  });
+
+  it("nothing widens: no flags + no persisted + no existing capability never mints cal or drive.file", () => {
+    for (const tier of ["core", "extended", "complete"] as const) {
+      const plan = resolveScopeSelection({
+        flags: noFlags,
+        existing: NONE,
+        tier,
+      });
+      const scopes = scopesForSelection(plan.selection);
+      expect(scopes).not.toContain(CAL_RO);
+      expect(scopes).not.toContain(DRIVE_FILE);
+    }
+  });
+});
+
+describe("GOOGLE_SERVICES ↔ GoogleServiceTokenSchema sync pin", () => {
+  it("the config enum and the CLI vocabulary are the same set", async () => {
+    const { GoogleServiceTokenSchema } = await import("../config/schema.js");
+    expect([...GoogleServiceTokenSchema.options].sort()).toEqual(
+      [...GOOGLE_SERVICES].sort(),
+    );
   });
 });

--- a/src/cli/drive.ts
+++ b/src/cli/drive.ts
@@ -152,6 +152,161 @@ export const GOOGLE_SLIDES_SCOPE =
 export const GOOGLE_CALENDAR_READONLY_SCOPE =
   "https://www.googleapis.com/auth/calendar.readonly";
 
+// ── Read-only Workspace document scopes (per-account selection v1) ───────
+//
+// The read-only counterparts of GOOGLE_DOCS/SHEETS/SLIDES_SCOPE. Minted
+// when the account's persisted selection says `readonly: true` — a
+// read-only account carries ZERO write scopes (RFC D §12 taken to its
+// conclusion: the narrowest grant that still lets every selected tool
+// authenticate for reads).
+export const GOOGLE_DOCS_READONLY_SCOPE =
+  "https://www.googleapis.com/auth/documents.readonly";
+export const GOOGLE_SHEETS_READONLY_SCOPE =
+  "https://www.googleapis.com/auth/spreadsheets.readonly";
+export const GOOGLE_SLIDES_READONLY_SCOPE =
+  "https://www.googleapis.com/auth/presentations.readonly";
+
+// ── Per-account service selection (v1) ───────────────────────────────────
+//
+// The services an operator can select per Google account via
+// `auth google account add --services <csv>`. Short tokens (config +
+// CLI vocabulary); the MCP launcher maps them to upstream
+// `workspace-mcp --tools` service names (`cal` → `calendar`).
+//
+// v1 deliberately stops here: Gmail (`gmail.readonly`), per-service
+// write levels, and `calendar.events.readonly` are follow-ups — each is
+// a new grant surface with its own approval shape.
+//
+// Order is load-bearing: it is the canonical emission order for minted
+// scope sets (Drive base first, then Docs/Sheets/Slides, Calendar
+// last), which keeps `selectGoogleWorkspaceScopes` byte-stable with the
+// pre-selection behaviour for the default selection.
+export const GOOGLE_SERVICES = [
+  "drive",
+  "docs",
+  "sheets",
+  "slides",
+  "cal",
+] as const;
+export type GoogleService = (typeof GOOGLE_SERVICES)[number];
+
+/**
+ * Parse the `--services` comma-selector into validated service tokens.
+ * Accepts the canonical short tokens plus `calendar` as an alias for
+ * `cal` (operators will type it). De-dups, preserves nothing of input
+ * order (canonical GOOGLE_SERVICES order is applied downstream). Throws
+ * with the full valid vocabulary on an unknown token or an empty list.
+ *
+ * Pure + exported so the CSV contract is unit-pinned.
+ */
+export function parseServicesOption(raw: string): GoogleService[] {
+  const tokens = raw
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s.length > 0)
+    .map((s) => (s === "calendar" ? "cal" : s));
+  if (tokens.length === 0) {
+    throw new Error(
+      `--services requires at least one service (valid: ${GOOGLE_SERVICES.join(", ")})`,
+    );
+  }
+  for (const t of tokens) {
+    if (!(GOOGLE_SERVICES as readonly string[]).includes(t)) {
+      throw new Error(
+        `--services: unknown service '${t}' (valid: ${GOOGLE_SERVICES.join(", ")}; ` +
+          `'calendar' is accepted as an alias for 'cal')`,
+      );
+    }
+  }
+  const set = new Set(tokens as GoogleService[]);
+  return GOOGLE_SERVICES.filter((s) => set.has(s));
+}
+
+/**
+ * The default service set a tier mints when no explicit `--services`
+ * selection exists — exactly the pre-selection behaviour: Drive + Docs +
+ * Sheets at every tier, Slides added at extended/complete. Calendar is
+ * NEVER a tier default (see GOOGLE_CALENDAR_READONLY_SCOPE — a tier bump
+ * must not silently widen into a new product surface).
+ *
+ * Pure + exported so the tier→services contract is unit-pinned.
+ */
+export function tierDefaultServices(
+  tier: "core" | "extended" | "complete",
+): GoogleService[] {
+  if (tier === "extended" || tier === "complete") {
+    return ["drive", "docs", "sheets", "slides"];
+  }
+  return ["drive", "docs", "sheets"];
+}
+
+/**
+ * A fully-resolved per-account scope selection — the single value both
+ * halves of the grant derive from: `scopesForSelection` mints the OAuth
+ * scope set, and the MCP launcher emits the matching upstream
+ * `--tools` / `--read-only` argv. Same input ⇒ tool exposure and token
+ * scope can never disagree.
+ */
+export interface GoogleScopeSelection {
+  /**
+   * true → every selected service mints ONLY its `.readonly` scope
+   * variant, and `driveWrite` is ignored (a read-only selection carries
+   * zero write scopes, deterministically).
+   */
+  readonly: boolean;
+  /** Selected services (canonical GOOGLE_SERVICES order applied). */
+  services: GoogleService[];
+  /**
+   * `--write` → `drive.file`. Only meaningful when `readonly` is false
+   * and `drive` is selected. Kept as its own axis (not folded into
+   * `readonly`) because the pre-selection default is docs-write WITHOUT
+   * drive-write — collapsing them would change existing grants.
+   */
+  driveWrite: boolean;
+}
+
+/**
+ * The readonly-aware service→scope map. Mint the exact OAuth scope set
+ * for a resolved selection:
+ *
+ *   drive  → Drive read base (+ `drive.file` when driveWrite && !readonly)
+ *   docs   → `documents` | `documents.readonly`
+ *   sheets → `spreadsheets` | `spreadsheets.readonly`
+ *   slides → `presentations` | `presentations.readonly`
+ *   cal    → `calendar.readonly` (always read-only — calendar write is
+ *            deliberately never offered, see GOOGLE_CALENDAR_READONLY_SCOPE)
+ *
+ * Pure + exported so the selection→scope contract is unit-pinned (this
+ * is the "readonly mints ZERO write scopes" invariant's home).
+ */
+export function scopesForSelection(sel: GoogleScopeSelection): string[] {
+  const selected = new Set(sel.services);
+  const out: string[] = [];
+  if (selected.has("drive")) {
+    out.push(...DRIVE_READONLY_SCOPES);
+    if (sel.driveWrite && !sel.readonly) {
+      out.push("https://www.googleapis.com/auth/drive.file");
+    }
+  }
+  if (selected.has("docs")) {
+    out.push(sel.readonly ? GOOGLE_DOCS_READONLY_SCOPE : GOOGLE_DOCS_SCOPE);
+  }
+  if (selected.has("sheets")) {
+    out.push(
+      sel.readonly ? GOOGLE_SHEETS_READONLY_SCOPE : GOOGLE_SHEETS_SCOPE,
+    );
+  }
+  if (selected.has("slides")) {
+    out.push(
+      sel.readonly ? GOOGLE_SLIDES_READONLY_SCOPE : GOOGLE_SLIDES_SCOPE,
+    );
+  }
+  if (selected.has("cal")) {
+    out.push(GOOGLE_CALENDAR_READONLY_SCOPE);
+  }
+  return [...new Set(out)];
+}
+
 /**
  * The Google Workspace document scopes available at each tier. Tied to
  * the tier→tool mapping in `GoogleWorkspaceTierSchema`:
@@ -165,11 +320,15 @@ export const GOOGLE_CALENDAR_READONLY_SCOPE =
 export function workspaceScopesForTier(
   tier: "core" | "extended" | "complete",
 ): string[] {
-  const docScopes = [GOOGLE_DOCS_SCOPE, GOOGLE_SHEETS_SCOPE];
-  if (tier === "extended" || tier === "complete") {
-    return [...docScopes, GOOGLE_SLIDES_SCOPE];
-  }
-  return docScopes;
+  // Derived from the readonly-aware service→scope map so there is one
+  // source of truth: a tier's document scopes are exactly the RW scopes
+  // of its default services minus the Drive base (Drive scopes are the
+  // always-minted base handled by selectDriveAccountScopes).
+  return scopesForSelection({
+    readonly: false,
+    driveWrite: false,
+    services: tierDefaultServices(tier).filter((s) => s !== "drive"),
+  });
 }
 
 /**
@@ -208,17 +367,45 @@ export function selectGoogleWorkspaceScopes(opts: {
   /**
    * Opt-in Calendar READ. Adds {@link GOOGLE_CALENDAR_READONLY_SCOPE} and
    * nothing else. Never implied by a tier — see that constant's comment.
+   * Equivalent to including `cal` in `services`.
    */
   calendar?: boolean;
   tier?: "core" | "extended" | "complete";
+  /**
+   * `--readonly` — mint ONLY `.readonly` scope variants for every
+   * selected service (zero write scopes). Mutually exclusive with
+   * `write` (enforced here as a hard error, belt-and-braces with the
+   * CLI-level check).
+   */
+  readonly?: boolean;
+  /**
+   * Explicit per-account service selection (`--services`, or the
+   * persisted `google_accounts.<email>.services` record). Omitted →
+   * the tier's default services (pre-selection behaviour, byte-stable).
+   */
+  services?: GoogleService[];
 }): string[] {
-  const base = selectDriveAccountScopes(opts.write);
-  const workspace = workspaceScopesForTier(opts.tier ?? "core");
-  const calendar = opts.calendar ? [GOOGLE_CALENDAR_READONLY_SCOPE] : [];
-  // De-dup defensively — base and workspace sets are disjoint today but
-  // a future scope move shouldn't silently produce a doubled scope
-  // string in the consent URL.
-  return [...new Set([...base, ...workspace, ...calendar])];
+  if (opts.readonly && opts.write) {
+    throw new Error(
+      "--readonly and --write are mutually exclusive: a read-only " +
+        "selection mints zero write scopes by definition.",
+    );
+  }
+  const services = opts.services ?? tierDefaultServices(opts.tier ?? "core");
+  const withCal =
+    opts.calendar && !services.includes("cal")
+      ? [...services, "cal" as const]
+      : services;
+  // Canonical order (GOOGLE_SERVICES) keeps the emitted set byte-stable
+  // regardless of input order; scopesForSelection de-dups defensively so
+  // a future scope move can't produce a doubled scope string in the
+  // consent URL.
+  const set = new Set(withCal);
+  return scopesForSelection({
+    readonly: opts.readonly ?? false,
+    driveWrite: opts.write,
+    services: GOOGLE_SERVICES.filter((s) => set.has(s)),
+  });
 }
 
 // ── Opt-in capability carry-forward (re-consent safety) ──────────────────
@@ -314,6 +501,174 @@ export function resolveReconsentCapabilities(
     },
     carried: keys.filter((k) => existing[k] && !requested[k]),
     added: keys.filter((k) => requested[k] && !existing[k]),
+  };
+}
+
+// ── Per-account selection resolution (v1 read-only scope model) ──────────
+
+/**
+ * The selection persisted in `google_accounts.<email>` — written by
+ * `account add` when the operator uses the new-style flags, re-read on
+ * `--replace` so a re-consent mints the SAME selection instead of
+ * silently re-widening to the tier default. This persisted record is the
+ * deterministic carry-forward: OAuth scope strings can't distinguish
+ * "operator chose readonly" from "operator chose these services" in
+ * every case, the YAML record can.
+ */
+export interface PersistedGoogleSelection {
+  readonly?: boolean;
+  services?: GoogleService[];
+}
+
+/** Outcome of {@link resolveScopeSelection}. */
+export interface ScopeSelectionPlan {
+  /** The fully-resolved selection to mint scopes from. */
+  selection: GoogleScopeSelection;
+  /**
+   * The record to persist into `google_accounts.<email>` after a
+   * successful mint — or `null` to leave the YAML untouched (legacy
+   * flag-free adds stay tier-driven, so a later tier bump keeps its
+   * pre-selection semantics).
+   */
+  persist: PersistedGoogleSelection | null;
+  /**
+   * Capabilities the existing token/record held that this invocation
+   * explicitly DROPPED (e.g. `--readonly` on a token that carried
+   * `drive.file`). Never silent — the caller must announce each.
+   */
+  dropped: string[];
+}
+
+/**
+ * Resolve the effective per-account scope selection for
+ * `auth google account add`, folding together (highest precedence
+ * first):
+ *
+ *   1. Explicit flags (`--services`, `--readonly` / `--write`) — an
+ *      explicit flag is authoritative for its axis, including explicit
+ *      NARROWING (announced via `dropped`, never silent).
+ *   2. The persisted `google_accounts.<email>` selection — the
+ *      deterministic `--replace` carry-forward.
+ *   3. The existing token's capabilities (#4190's scope-string union) —
+ *      covers pre-selection accounts with no persisted record.
+ *   4. The tier default (pre-selection behaviour, byte-stable).
+ *
+ * Invariants:
+ *   - `--readonly` + `--write` is a hard error (checked by the caller
+ *      at flag level AND by selectGoogleWorkspaceScopes).
+ *   - Nothing widens silently: a capability neither requested nor held
+ *     is never minted (tier defaults aside, which are pre-existing
+ *     behaviour).
+ *   - Nothing narrows silently: every drop comes from an explicit flag
+ *     and is surfaced in `dropped`.
+ *
+ * Pure + exported so all of the above is unit-pinned.
+ */
+export function resolveScopeSelection(args: {
+  flags: {
+    readonly: boolean;
+    write: boolean;
+    calendar: boolean;
+    services?: GoogleService[];
+  };
+  persisted?: PersistedGoogleSelection;
+  /** Existing-token capabilities, already unioned per #4190 (or fresh-add defaults). */
+  existing: GoogleOptInCapabilities;
+  tier: "core" | "extended" | "complete";
+}): ScopeSelectionPlan {
+  const { flags, persisted, existing, tier } = args;
+  if (flags.readonly && flags.write) {
+    throw new Error(
+      "--readonly and --write are mutually exclusive. A read-only account " +
+        "mints zero write scopes; use --write (without --readonly) for the " +
+        "drive.file write grant.",
+    );
+  }
+
+  const dropped: string[] = [];
+
+  // readonly axis: explicit flag wins; else the persisted record; else
+  // false (pre-selection default — docs/sheets mint their RW scopes).
+  const readonly = flags.readonly
+    ? true
+    : flags.write
+      ? false
+      : (persisted?.readonly ?? false);
+  if (flags.write && persisted?.readonly) {
+    dropped.push(
+      "read-only mode (persisted `readonly: true`) — dropped because --write was passed",
+    );
+  }
+
+  // drive.file axis: the #4190 union (explicit --write OR carried from
+  // the token), except an explicit --readonly drops it.
+  let driveWrite = existing.write;
+  if (readonly && existing.write) {
+    driveWrite = false;
+    dropped.push(
+      "Drive write (drive.file) — the existing token carries it, but --readonly was passed",
+    );
+  }
+
+  // services axis: explicit --services wins; else persisted; else tier
+  // default. `--calendar` (and the carried calendar capability) union
+  // `cal` in — except into an explicit --services list that deliberately
+  // omits it without a `--calendar` alongside (an explicit narrowing,
+  // announced below).
+  const explicitServices = !!(flags.services && flags.services.length > 0);
+  let services: GoogleService[];
+  let persistServices: boolean;
+  if (explicitServices) {
+    services = [...flags.services!];
+    persistServices = true;
+    if (flags.calendar && !services.includes("cal")) services.push("cal");
+  } else if (persisted?.services && persisted.services.length > 0) {
+    services = [...persisted.services];
+    persistServices = true;
+    if ((flags.calendar || existing.calendar) && !services.includes("cal")) {
+      services.push("cal");
+    }
+  } else {
+    services = [...tierDefaultServices(tier)];
+    persistServices = false;
+    if ((flags.calendar || existing.calendar) && !services.includes("cal")) {
+      services.push("cal");
+    }
+  }
+  const set = new Set(services);
+  const canonical = GOOGLE_SERVICES.filter((s) => set.has(s));
+
+  if (explicitServices) {
+    // Announce every previously-granted service the explicit list drops.
+    const prior =
+      persisted?.services ??
+      (existing.calendar
+        ? [...tierDefaultServices(tier), "cal" as const]
+        : tierDefaultServices(tier));
+    for (const s of prior) {
+      if (!set.has(s)) {
+        dropped.push(
+          `service '${s}' — previously granted, not in the --services list passed`,
+        );
+      }
+    }
+  }
+
+  // Persist when the new-style selection is active — an explicit
+  // --services/--readonly flag on this invocation, or a persisted record
+  // being carried forward. Legacy flag-free adds persist nothing.
+  const persist =
+    flags.readonly || persistServices || persisted !== undefined
+      ? {
+          readonly,
+          services: canonical,
+        }
+      : null;
+
+  return {
+    selection: { readonly, services: canonical, driveWrite },
+    persist,
+    dropped,
   };
 }
 

--- a/src/cli/google-accounts-yaml.test.ts
+++ b/src/cli/google-accounts-yaml.test.ts
@@ -197,3 +197,70 @@ describe("removeGoogleAccountEntry", () => {
     expect(removeGoogleAccountEntry(baseYaml, "alice@example.com")).toBe(baseYaml);
   });
 });
+
+// ── setGoogleAccountSelection (v1 read-only scope model) ─────────────────
+
+import { setGoogleAccountSelection } from "./google-accounts-yaml.js";
+
+describe("setGoogleAccountSelection", () => {
+  const withAccount = `${baseYaml}google_accounts:
+  alice@example.com:
+    enabled_for: [klanker]
+`;
+
+  it("writes readonly + services under an existing account, preserving the rest", () => {
+    const out = setGoogleAccountSelection(withAccount, "alice@example.com", {
+      readonly: true,
+      services: ["drive", "cal"],
+    });
+    expect(out).toContain("# top of file"); // comments preserved
+    expect(out).toContain("readonly: true");
+    expect(out).toMatch(/services:\s*\n?\s*(\[\s*drive,\s*cal\s*\]|- drive\s*\n\s*- cal)/);
+    // enabled_for untouched (allow either flow or block sequence style)
+    expect(out).toMatch(/enabled_for:\s*(\[\s*klanker\s*\]|\n\s*- klanker)/);
+  });
+
+  it("creates the account entry (empty enabled_for) when absent", () => {
+    const out = setGoogleAccountSelection(baseYaml, "new@example.com", {
+      readonly: false,
+      services: ["docs"],
+    });
+    expect(out).toContain("new@example.com");
+    expect(out).toContain("readonly: false");
+    expect(out).toContain("docs");
+  });
+
+  it("writes readonly: false explicitly (self-describing record, never pruned)", () => {
+    const out = setGoogleAccountSelection(withAccount, "alice@example.com", {
+      readonly: false,
+      services: ["drive"],
+    });
+    expect(out).toContain("readonly: false");
+  });
+
+  it("is byte-identical when the stored selection already matches", () => {
+    const once = setGoogleAccountSelection(withAccount, "alice@example.com", {
+      readonly: true,
+      services: ["drive", "cal"],
+    });
+    const twice = setGoogleAccountSelection(once, "alice@example.com", {
+      readonly: true,
+      services: ["drive", "cal"],
+    });
+    expect(twice).toBe(once);
+  });
+
+  it("round-trips: a written selection is re-read identically (the --replace carry-forward)", () => {
+    const written = setGoogleAccountSelection(withAccount, "alice@example.com", {
+      readonly: true,
+      services: ["cal"],
+    });
+    // Re-write with a different selection and confirm it replaces cleanly.
+    const rewritten = setGoogleAccountSelection(written, "alice@example.com", {
+      readonly: false,
+      services: ["drive", "docs"],
+    });
+    expect(rewritten).toContain("readonly: false");
+    expect(rewritten).not.toMatch(/services:.*\bcal\b/s);
+  });
+});

--- a/src/cli/google-accounts-yaml.ts
+++ b/src/cli/google-accounts-yaml.ts
@@ -136,6 +136,45 @@ export function listGoogleAccounts(
 }
 
 /**
+ * Persist the per-account scope selection (v1 read-only scope model)
+ * into `google_accounts.<account>.{readonly,services}`. Written by
+ * `auth google account add` after a successful mint so `--replace` can
+ * re-read the SAME selection instead of silently re-widening to the
+ * tier default. Creates the account entry (with an empty `enabled_for`)
+ * if absent — mirrors `enableAgentsOnGoogleAccount`'s create-on-demand.
+ *
+ * `readonly: false` is written explicitly (not pruned): once an account
+ * is on the new-style selection, the record must be self-describing —
+ * an absent key means "legacy tier-driven", never "false".
+ *
+ * Pass-through (byte-identical return) when the stored selection
+ * already matches.
+ */
+export function setGoogleAccountSelection(
+  yamlText: string,
+  account: string,
+  selection: { readonly: boolean; services: string[] },
+): string {
+  const doc = parseDocument(yamlText);
+  ensureGoogleAccountEntry(doc, account);
+  const currentReadonly = doc.getIn([
+    "google_accounts",
+    account,
+    "readonly",
+  ]);
+  const currentServices = doc.getIn(["google_accounts", account, "services"]);
+  const currentServicesArr = readEnabledFor(currentServices);
+  const unchanged =
+    currentReadonly === selection.readonly &&
+    currentServicesArr.length === selection.services.length &&
+    currentServicesArr.every((s, i) => s === selection.services[i]);
+  if (unchanged) return yamlText;
+  doc.setIn(["google_accounts", account, "readonly"], selection.readonly);
+  doc.setIn(["google_accounts", account, "services"], [...selection.services]);
+  return String(doc);
+}
+
+/**
  * Remove the entire `google_accounts.<account>` entry from the YAML.
  * Used by `auth google account remove`. The CLI verb is responsible for
  * checking that `enabled_for` is empty first (so we don't strand any

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -1570,3 +1570,66 @@ describe("AgentSchema — memory.recall query shaping (#3757)", () => {
     expect(() => AgentSchema.parse(agent({ request_timeout_seconds: 0 }))).toThrow();
   });
 });
+
+// ── v1 per-account selection: google_accounts.{readonly,services} ────────
+
+describe("google_accounts per-account selection (v1 read-only scope model)", () => {
+  const base = {
+    switchroom: { version: 1 },
+    telegram: { bot_token: "x", forum_chat_id: "1" },
+    agents: {},
+  };
+
+  it("accepts readonly + services on an account record", () => {
+    const result = SwitchroomConfigSchema.parse({
+      ...base,
+      google_accounts: {
+        "alice@example.com": {
+          enabled_for: ["klanker"],
+          readonly: true,
+          services: ["cal", "drive"],
+        },
+      },
+    });
+    const rec = result.google_accounts?.["alice@example.com"];
+    expect(rec?.readonly).toBe(true);
+    expect(rec?.services).toEqual(["cal", "drive"]);
+  });
+
+  it("both are optional (legacy records keep parsing, undefined selection)", () => {
+    const result = SwitchroomConfigSchema.parse({
+      ...base,
+      google_accounts: {
+        "alice@example.com": { enabled_for: ["klanker"] },
+      },
+    });
+    const rec = result.google_accounts?.["alice@example.com"];
+    expect(rec?.readonly).toBeUndefined();
+    expect(rec?.services).toBeUndefined();
+  });
+
+  it("rejects an unknown service token (closed enum — a typo must not be inert)", () => {
+    expect(() =>
+      SwitchroomConfigSchema.parse({
+        ...base,
+        google_accounts: {
+          "alice@example.com": {
+            enabled_for: ["klanker"],
+            services: ["gmail"],
+          },
+        },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects an empty services list (min 1 — empty means 'remove the key')", () => {
+    expect(() =>
+      SwitchroomConfigSchema.parse({
+        ...base,
+        google_accounts: {
+          "alice@example.com": { enabled_for: ["klanker"], services: [] },
+        },
+      }),
+    ).toThrow();
+  });
+});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2290,6 +2290,14 @@ const ApproverIdSchema = z.union([z.number(), z.string().regex(/^\d+$/)]);
  *   - complete ~60+ tools: + Gmail (note: Gmail's per-thread approval
  *     shape is unsuitable here today — see RFC G §5 out-of-scope)
  *
+ * NOTE the tier governs which TOOLS upstream exposes, not which scopes
+ * the minted token carries. Calendar tools in particular are exposed at
+ * every tier but only authenticate when the account was consented with
+ * the calendar scope (`account add --calendar`, or `cal` in the
+ * per-account `services` selection) — no tier mints it by default. The
+ * per-account `google_accounts.<email>.{readonly,services}` selection
+ * is what keeps tool exposure and token scope in agreement.
+ *
  * RFC D shipped without this knob (hardcoded to upstream's full surface
  * via the no-flag default). Phase 1 makes the tier explicit at the
  * config level; Phase 3 wires it through the MCP launcher.
@@ -2300,6 +2308,30 @@ export const GoogleWorkspaceTierSchema = z.enum([
   "complete",
 ]);
 export type GoogleWorkspaceTier = z.infer<typeof GoogleWorkspaceTierSchema>;
+
+/**
+ * One selectable Google service in the per-account scope selection
+ * (v1 read-only scope model). Short tokens are the config + CLI
+ * vocabulary; the gdrive MCP launcher maps them to upstream
+ * `workspace-mcp --tools` service names (`cal` → `calendar`).
+ *
+ * A closed enum (unlike `MicrosoftToolTokenSchema`'s regex): Microsoft
+ * tokens feed a runtime-built regex where the charset is the guard,
+ * these feed a fixed service→scope map where an unknown token would be
+ * silently inert — reject it at parse time instead. MUST stay in sync
+ * with `GOOGLE_SERVICES` in src/cli/drive.ts (unit-pinned there).
+ *
+ * v1 is READ-surface-selection only: gmail, per-service write levels,
+ * and `calendar.events.readonly` are deliberate follow-ups.
+ */
+export const GoogleServiceTokenSchema = z.enum([
+  "cal",
+  "drive",
+  "docs",
+  "sheets",
+  "slides",
+]);
+export type GoogleServiceToken = z.infer<typeof GoogleServiceTokenSchema>;
 
 /**
  * Top-level drive / google_workspace config block. Centralizes Google OAuth
@@ -2342,7 +2374,9 @@ export const GoogleWorkspaceConfigSchema = z
       ),
     tier: GoogleWorkspaceTierSchema.optional().describe(
       "RFC G Phase 1: which upstream MCP tier to expose. " +
-      "core (default) = ~16 tools (Drive+Docs+Sheets+Calendar). " +
+      "core (default) = ~16 tools (Drive+Docs+Sheets+Calendar tools; the " +
+      "Calendar tools only authenticate when the account holds the opt-in " +
+      "calendar scope — no tier mints it). " +
       "extended = ~40 tools (+Slides, Forms, Tasks, Chat). " +
       "complete = ~60+ tools (+Gmail; not recommended yet — see RFC G §5)."
     ),
@@ -5183,6 +5217,30 @@ export const SwitchroomConfigSchema = z.object({
             "enforced at the broker, not at the agent identity layer — " +
             "the agent still authenticates via socket-path-as-identity " +
             "per RFC D §4.1, broker just gates the cross-agent token share."
+          ),
+        readonly: z
+          .boolean()
+          .optional()
+          .describe(
+            "Per-account read-only selection (v1 scope model). true → the " +
+            "token minted by `auth google account add` carries ONLY " +
+            ".readonly scope variants (zero write scopes), and the gdrive " +
+            "MCP launcher passes upstream `--read-only` so write tools are " +
+            "not exposed. Written by `account add --readonly`; re-read on " +
+            "`--replace` so a re-consent cannot silently re-widen. Omitted " +
+            "= legacy behaviour (tier-tied read-write document scopes)."
+          ),
+        services: z
+          .array(GoogleServiceTokenSchema)
+          .min(1)
+          .optional()
+          .describe(
+            "Per-account service selection (v1 scope model). Which Google " +
+            "services the minted token covers AND the gdrive MCP exposes " +
+            "(upstream `--tools`): cal, drive, docs, sheets, slides. " +
+            "Written by `account add --services`; re-read on `--replace`. " +
+            "Omitted = the tier's default services (drive,docs,sheets; " +
+            "+slides at extended/complete)."
           ),
       }),
     )

--- a/src/memory/scaffold-integration.ts
+++ b/src/memory/scaffold-integration.ts
@@ -167,6 +167,23 @@ export interface GdriveMcpEntryOptions {
    * change, not Phase 1's job.
    */
   tier?: GdriveMcpTier;
+  /**
+   * Per-account service selection (v1 read-only scope model) from the
+   * persisted `google_accounts.<email>.services` record. When set,
+   * threaded as `--services a,b,c` so the launcher narrows upstream to
+   * those services (upstream `--tools`). Short tokens: cal, drive,
+   * docs, sheets, slides. The launcher re-reads the record from config
+   * and is authoritative; threading makes the resolved choice visible
+   * in settings.json (mirrors `tier`).
+   */
+  services?: string[];
+  /**
+   * Per-account read-only selection from the persisted
+   * `google_accounts.<email>.readonly` record. When true, threaded as
+   * `--read-only` (upstream requests readonly scopes and does not
+   * register write tools). Same visibility rationale as `services`.
+   */
+  readOnly?: boolean;
 }
 
 /**
@@ -219,11 +236,21 @@ export function getGdriveMcpSettingsEntry(
   // (doctor/debug surfaces) and so a future caller without config in
   // scope can pin it explicitly.
   const tierArgs = options.tier ? ["--tier", options.tier] : [];
+  const servicesArgs =
+    options.services && options.services.length > 0
+      ? ["--services", options.services.join(",")]
+      : [];
+  const readOnlyArgs = options.readOnly ? ["--read-only"] : [];
   return {
     key: "gdrive",
     value: {
       command: switchroomCliPath,
-      args: ["drive-mcp-launcher", ...tierArgs],
+      args: [
+        "drive-mcp-launcher",
+        ...tierArgs,
+        ...servicesArgs,
+        ...readOnlyArgs,
+      ],
     },
   };
 }


### PR DESCRIPTION
## Summary

v1 of the customisable, per-account, READ-ONLY Google Workspace scope model. One persisted per-account selection — `google_accounts.<email>.{readonly,services}` — now drives **both halves** of a grant: the OAuth scopes `auth google account add` mints, and the tools the gdrive MCP exposes (upstream `--tools` / `--read-only`). Same input on both paths ⇒ tool exposure and token scope can never disagree.

**Blocking unknown, verified first:** the pinned upstream `workspace-mcp` SHA `9d69115b` (v1.20.4) DOES support both flags — `main.py` argparse defines `--tools` (`nargs="*"`, choices incl. `drive/docs/sheets/slides/calendar`) and `--read-only` (switches to `TOOL_READONLY_SCOPES_MAP` in `auth/scopes.py` and skips registering write tools); both combine with `--tool-tier` (only `--permissions` is mutually exclusive). No pin bump needed. Upstream's last 2 weeks (through v1.23.0) contain no changes to these flags — only tool fixes, README, dep bumps.

## What's in

- `account add --readonly` — every selected service mints only its `.readonly` scope variant (`documents.readonly`, `spreadsheets.readonly`, `presentations.readonly`, `calendar.readonly`); **zero write scopes**. Mutually exclusive with `--write` (hard error at flag level AND in the pure selector). Launcher passes upstream `--read-only`.
- `account add --services cal,drive,docs,sheets,slides` — per-account service narrowing (comma selector; `calendar` alias accepted). Mints only those services' scopes; launcher emits `--tools drive docs …` (one argv token per service, upstream names, `cal`→`calendar`).
- **Persisted + re-read on `--replace`** (`src/cli/google-accounts-yaml.ts:setGoogleAccountSelection`, comment-preserving): a read-only / narrowed account re-consented for an unrelated reason mints the same selection — cannot silently re-widen. Explicit narrowing is announced (`resolveScopeSelection.dropped`), never silent. #4190's scope-string capability union remains the fallback for legacy accounts.
- **Launcher warning decoupled from tier:** required scopes now derive from the persisted selection (`requiredScopesForSelection` / `findMissingScopesForSelection`), so a valid read-only token no longer trips the missing-scope warning on every boot; `buildMissingScopeWarning`'s printed recovery command carries `--readonly --services …` so a verbatim re-run cannot re-widen.
- Scaffold threads the record onto the gdrive entry (`--services a,b,c` / `--read-only`) alongside `--tier`; the launcher re-reads config and is authoritative (mirrors tier semantics).
- Schema: `GoogleServiceTokenSchema` (closed enum, sync-pinned against `GOOGLE_SERVICES`), `google_accounts.<email>.{readonly,services}` optional fields, tier docstrings fixed (Calendar tools ≠ Calendar scope).

## Back-compat (pinned by tests)

- Empty selection reproduces today's scopes byte-for-byte (`selectGoogleWorkspaceScopes` matrix parity test) and today's launcher argv exactly (`buildUvxArgs("extended")` unchanged; legacy record → identical entry args).
- All 95 pre-existing tests in the touched suites pass unmodified (one yaml assertion loosened for flow/block sequence style only).
- No live-grant behaviour changes: accounts without a persisted record keep the exact pre-v1 path.

## Deviations from the dispatched design (evidence-grounded)

1. **#4190 landed on main mid-flight** (calendar opt-in + scope-string carry-forward + warning suffixes) — design items 1 (calendar constant) and parts of 6 pre-existed; this PR builds on them instead of duplicating.
2. Design said "`--readonly` (default)" but also "empty selection reproduces today's scopes" — contradictory; back-compat wins: `--readonly` is opt-in.
3. Upstream `--tools` is space-separated `nargs="*"`, not comma-joined — CLI/config keep the comma selector, launcher expands to separate argv tokens.
4. `workspaceScopesForTier` kept exported (now derived from the new service→scope map) rather than replaced — launcher parity test + existing callers pin its signature.

## Follow-ups (filed as deliberate v1 limits, in docs + commit)

gmail service (`gmail.readonly`), per-service write levels, `calendar.events.readonly`, Telegram relay flags for `--readonly/--services` (relay `--replace` is already safe — carry-forward reads the persisted record regardless of caller flags).

## Test plan

- `vitest run` on the 10 affected suites: **432 passed** (drive, drive-mcp-launcher, auth-google, google-accounts-yaml, google-workspace-yaml, schema, google-workspace-acl, scaffold-gdrive-entry, scaffold mcp-json parity/regenerate).
- New outcome tests: exact minted scope sets (readonly mints ZERO write scopes across all 31 service subsets); `--readonly`+`--write` errors; `--services cal` mints only `calendar.readonly` and emits `--tools calendar`; read-only token + read-only selection → preflight `[]` (with a contrast test showing the legacy path WOULD have warned); `--replace` with no flags re-reads the persisted selection under a tier bump and mints zero write scopes; recovery command carries the selection; YAML round-trip/idempotency; schema accept/reject; scaffold arg threading incl. legacy byte-parity.
- `npm run lint` fully green (tsc + all guard scripts).

## Job spec

`reference/jobs/collaborate-on-documents.md` — this narrows the standing Google grant to least-privilege per account (on-the-leash outcome: a read grant can never silently become or re-become a write grant), while keeping tool exposure honest to what the token can actually do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)