### PR TITLE
fix(hindsight): debounce consolidation-triggered mental-model refreshes

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -133,6 +133,7 @@ jobs:
               - 'tests/docker/hindsight-search-patches.test.ts'
               - 'tests/docker/hindsight-recall-isolation-patches.test.ts'
               - 'tests/docker/hindsight-retry-perturbation-patches.test.ts'
+              - 'tests/docker/hindsight-mm-refresh-debounce-patch.test.ts'
               - 'tests/docker/hindsight-graph-seed-retirement.test.ts'
               - 'tests/docker/hindsight-maxitems-grammar-patch.test.ts'
               - 'src/setup/hindsight-perf-defaults.ts'
@@ -354,6 +355,19 @@ jobs:
           SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
         run: npx vitest run tests/docker/hindsight-retry-perturbation-patches.test.ts
 
+      - name: Run the hindsight MM-refresh-debounce probe (RED/GREEN, must not skip)
+        # Same contract again, for the MM-refresh-debounce patch. The bakes
+        # test cannot cover the failure that matters here: its assertions are
+        # unanchored substring matches, so a helper that exists but is never
+        # consulted by the trigger loop (the #3660-class indent-under-a-falsy-
+        # guard revert) stays green there while every consolidation round goes
+        # back to regenerating every mental model — the measured 1,902
+        # refreshes/day loop. Only running the shipping trigger loop and
+        # observing which candidates it actually submits catches it.
+        env:
+          SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
+        run: npx vitest run tests/docker/hindsight-mm-refresh-debounce-patch.test.ts
+
       - name: Run the hindsight graph-seed RETIREMENT probe (RED/GREEN, must not skip)
         # The v0.8.5 upstream #2968 carry was retired in the v0.8.6 base bump —
         # upstream ships the behaviour natively and exposes
@@ -434,7 +448,7 @@ jobs:
       - name: Label-scoped teardown
         if: always()
         run: |
-          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-graph-seed-retirement hindsight-maxitems-grammar-patch hindsight-reflect-directives-patch hindsight-recall-budget-reflect-grounding hindsight-pg-fsync-probe; do
+          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-mm-refresh-debounce-patch hindsight-graph-seed-retirement hindsight-maxitems-grammar-patch hindsight-reflect-directives-patch hindsight-recall-budget-reflect-grounding hindsight-pg-fsync-probe; do
             ids=$(docker ps -aq --filter "label=switchroom.test=$phase" 2>/dev/null || true)
             if [ -n "$ids" ]; then docker rm -f $ids 2>/dev/null || true; fi
           done

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -2699,6 +2699,188 @@ print(
 )
 PYEOF
 
+# ── MM-refresh-debounce: floor the interval between consolidation-triggered ──
+# ── mental-model refreshes ───────────────────────────────────────────────────
+#
+# Upstream re-runs every `refresh_after_consolidation: true` mental model at
+# the end of EVERY completed consolidation operation, gated only by a
+# staleness check ("any in-scope memory ingested since last_refreshed_at",
+# memory_engine.py `compute_mental_model_is_stale`). Under sustained
+# ingestion that gate is ALWAYS true: each round consolidates freshly
+# retained memories, so each round finds every model stale and regenerates
+# it, and the next round a minute later does it again. Measured on this
+# fleet during the 2026-08-01 backlog drain (llm_requests table): the
+# `finn` bank refreshed its FOUR mental models 1,902 times in one day —
+# roughly one full regeneration per model per minute for ~9 hours — burning
+# 20.77M LLM tokens re-deriving near-identical content; fleet-wide the
+# refresh_mental_model operation cost 3,003 calls / 36.6M tokens that day.
+#
+# Upstream has no debounce (verified against vectorize-io/hindsight main
+# @ 2026-08-02: no merged or open PR adds one; #2866 fixed only the no-op
+# watermark advance, which this base already ships, and #3078 only widened
+# the candidate scope). So switchroom floors the interval here: a model
+# whose `last_refreshed_at` is younger than
+# HINDSIGHT_MM_REFRESH_MIN_INTERVAL_S (default 3600) is skipped by the
+# consolidation trigger. The NEXT consolidation after the floor elapses
+# still sees the model stale (staleness compares against last_refreshed_at,
+# which the skip leaves untouched) and refreshes it then — content is
+# delayed by at most the floor, never lost.
+#
+# Deliberately scoped to `_trigger_mental_model_refreshes` (the
+# consolidation side-effect) ONLY. Explicit refreshes — the MCP
+# refresh_mental_model tool, the HTTP endpoint, the user-profile Stop hook —
+# and the maintenance loop's cron-scheduled path are untouched, so an agent
+# or operator who wants freshness NOW still gets it.
+#
+# Rollback hatch (no rebuild): HINDSIGHT_MM_REFRESH_MIN_INTERVAL_S=0
+# restores upstream behaviour exactly. The var is a switchroom-patch knob
+# (no HINDSIGHT_API_ prefix — upstream's config parser never sees it), read
+# once at import like HINDSIGHT_CE_DECISIVE_RELATIVE_GAP, and reachable
+# declaratively via `hindsight.env` (HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS in
+# src/setup/hindsight-perf-defaults.ts). Unparseable / negative / NaN
+# values degrade to the default rather than raising out of the
+# consolidation path.
+#
+# Outcome proof: tests/docker/hindsight-mm-refresh-debounce-patch.test.ts
+# runs the REAL patched `_trigger_mental_model_refreshes` from the image
+# and asserts recently-refreshed models are skipped, elapsed ones are
+# submitted, never-refreshed ones always submit, and interval 0 is
+# byte-for-byte upstream. Shape pinned in dockerfile-hindsight-bakes.test.ts.
+RUN python3 - <<'PYEOF'
+import pathlib
+
+TAG = "switchroom hindsight MM-refresh-debounce patch"
+
+f = pathlib.Path("/app/api/hindsight_api/engine/consolidation/consolidator.py")
+s = f.read_text()
+
+# 1. Module-level knob + helper, inserted immediately above the trigger
+#    function. `datetime`/`timezone` are already module imports here.
+DEF_ANCHOR = "async def _trigger_mental_model_refreshes(\n"
+HELPER = (
+    "# switchroom hindsight MM-refresh-debounce patch: floor the interval between\n"
+    "# consolidation-triggered refreshes of one mental model. 0 disables (exact\n"
+    "# upstream behaviour). Read once at import; container restart applies changes.\n"
+    '_MM_REFRESH_MIN_INTERVAL_ENV: str = "HINDSIGHT_MM_REFRESH_MIN_INTERVAL_S"\n'
+    "_MM_REFRESH_MIN_INTERVAL_DEFAULT_S: float = 3600.0\n"
+    "\n"
+    "\n"
+    "def _mm_refresh_min_interval_s() -> float:\n"
+    "    import math\n"
+    "    import os\n"
+    "\n"
+    "    raw = os.environ.get(_MM_REFRESH_MIN_INTERVAL_ENV)\n"
+    "    if raw is None or not str(raw).strip():\n"
+    "        return _MM_REFRESH_MIN_INTERVAL_DEFAULT_S\n"
+    "    try:\n"
+    "        value = float(raw)\n"
+    "    except (TypeError, ValueError):\n"
+    "        return _MM_REFRESH_MIN_INTERVAL_DEFAULT_S\n"
+    "    if not math.isfinite(value) or value < 0.0:\n"
+    "        return _MM_REFRESH_MIN_INTERVAL_DEFAULT_S\n"
+    "    return value\n"
+    "\n"
+    "\n"
+    "_MM_REFRESH_MIN_INTERVAL_S: float = _mm_refresh_min_interval_s()\n"
+    "\n"
+    "\n"
+    "def _mm_refresh_debounced(candidate) -> bool:\n"
+    '    """True when this model refreshed more recently than the floor allows.\n'
+    "\n"
+    "    A skipped model's last_refreshed_at is untouched, so the staleness gate\n"
+    "    still fires on the first consolidation after the floor elapses — the\n"
+    "    refresh is deferred, never dropped. Never-refreshed models (NULL) and\n"
+    "    rows whose timestamp cannot be compared are never debounced.\n"
+    '    """\n'
+    "    if _MM_REFRESH_MIN_INTERVAL_S <= 0.0:\n"
+    "        return False\n"
+    "    try:\n"
+    '        last = candidate["last_refreshed_at"]\n'
+    "    except (KeyError, TypeError):\n"
+    "        last = None\n"
+    "    if not last:\n"
+    "        return False\n"
+    "    try:\n"
+    "        age_s = (datetime.now(timezone.utc) - last).total_seconds()\n"
+    "    except TypeError:\n"
+    "        return False\n"
+    "    return age_s < _MM_REFRESH_MIN_INTERVAL_S\n"
+    "\n"
+    "\n"
+    "async def _trigger_mental_model_refreshes(\n"
+)
+
+n = s.count(DEF_ANCHOR)
+assert n == 1, (
+    f"{TAG}: _trigger_mental_model_refreshes def anchor found {n}x (expected 1) in "
+    "engine/consolidation/consolidator.py — upstream renamed or split the trigger "
+    "function; re-author this patch in docker/Dockerfile.hindsight."
+)
+assert "from datetime import datetime, timezone" in s, (
+    f"{TAG}: consolidator.py no longer imports datetime/timezone at module level — "
+    "the helper relies on them; re-author this patch."
+)
+
+# 2. The staleness loop: consult the debounce BEFORE the per-candidate
+#    staleness query (a debounced model skips that round-trip too).
+LOOP_ANCHOR = (
+    "        rows = []\n"
+    "        for candidate in candidates:\n"
+    "            if await memory_engine.compute_mental_model_is_stale(conn, bank_id, candidate):\n"
+    "                rows.append(candidate)\n"
+)
+LOOP_REPL = (
+    "        rows = []\n"
+    "        _debounced = 0\n"
+    "        for candidate in candidates:\n"
+    "            # switchroom MM-refresh-debounce: refreshed within the floor -> skip\n"
+    "            # this round; the first consolidation after the floor elapses still\n"
+    "            # sees it stale and refreshes it.\n"
+    "            if _mm_refresh_debounced(candidate):\n"
+    "                _debounced += 1\n"
+    "                continue\n"
+    "            if await memory_engine.compute_mental_model_is_stale(conn, bank_id, candidate):\n"
+    "                rows.append(candidate)\n"
+    "        if _debounced:\n"
+    "            logger.info(\n"
+    '                f"[CONSOLIDATION] bank={bank_id} debounced {_debounced} mental model "\n'
+    '                f"refresh(es) (last refresh < {_MM_REFRESH_MIN_INTERVAL_S:.0f}s ago)"\n'
+    "            )\n"
+)
+
+n = s.count(LOOP_ANCHOR)
+assert n == 1, (
+    f"{TAG}: staleness-loop anchor found {n}x (expected 1) in "
+    "engine/consolidation/consolidator.py — upstream reworked the candidate loop; "
+    "re-author this patch in docker/Dockerfile.hindsight."
+)
+
+s = s.replace(DEF_ANCHOR, HELPER, 1)
+s = s.replace(LOOP_ANCHOR, LOOP_REPL, 1)
+f.write_text(s)
+
+t = f.read_text()
+assert t.count("def _mm_refresh_debounced(") == 1, f"{TAG}: helper missing after patch"
+assert t.count('_MM_REFRESH_MIN_INTERVAL_ENV: str = "HINDSIGHT_MM_REFRESH_MIN_INTERVAL_S"') == 1, (
+    f"{TAG}: env knob missing after patch"
+)
+assert t.count("_MM_REFRESH_MIN_INTERVAL_DEFAULT_S: float = 3600.0") == 1, (
+    f"{TAG}: 3600s default missing after patch"
+)
+assert t.count("if _mm_refresh_debounced(candidate):") == 1, (
+    f"{TAG}: debounce consult missing from the staleness loop after patch"
+)
+assert t.count(LOOP_ANCHOR) == 0, f"{TAG}: unpatched staleness loop still present"
+assert t.count("async def _trigger_mental_model_refreshes(") == 1, (
+    f"{TAG}: trigger function duplicated or lost by the patch"
+)
+import ast
+ast.parse(t)
+print(f"{TAG}: consolidation-triggered mental-model refreshes floored at "
+      "HINDSIGHT_MM_REFRESH_MIN_INTERVAL_S (default 3600s); explicit and cron "
+      "refresh paths untouched; 0 restores upstream behaviour")
+PYEOF
+
 # Pin the upstream `hindsight` user to UID 11000 to match
 # `HINDSIGHT_DEFAULT_UID` in src/setup/hindsight.ts (and the
 # `auth.consumers[hindsight].uid` value the operator writes in

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2735,7 +2735,13 @@ export const HindsightConfigSchema = z.object({
       "than RECALL_MAX_CONCURRENT or the engine refuses to boot; unset " +
       "means the image's derived default min(2, RECALL_MAX_CONCURRENT - 1); " +
       "1 biases hard toward the interactive lane while a consolidation " +
-      "backlog drains), plus the " +
+      "backlog drains; and " +
+      "HINDSIGHT_MM_REFRESH_MIN_INTERVAL_S — the rollback/tuning knob for " +
+      "switchroom's MM-refresh-debounce image patch: the minimum seconds " +
+      "between consolidation-triggered refreshes of one mental model; unset " +
+      "means the image's baked 3600, 0 restores upstream's " +
+      "refresh-every-round behaviour; explicit and cron-scheduled refreshes " +
+      "are never debounced), plus the " +
       "embedded-PostgreSQL (pg0) sizing keys switchroom manages in " +
       "src/setup/hindsight-pg-defaults.ts (`HINDSIGHT_PG_ENV_KEYS`: " +
       "SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE, " +

--- a/src/setup/hindsight-perf-defaults.test.ts
+++ b/src/setup/hindsight-perf-defaults.test.ts
@@ -351,7 +351,7 @@ describe("operator override wins", () => {
     expect(got.size).toBe(0);
   });
 
-  it("is overridable on exactly these forty-five keys, by name", () => {
+  it("is overridable on exactly these forty-six keys, by name", () => {
     // Spelled out, NOT derived from the three group arrays. HINDSIGHT_PERF_ENV_KEYS
     // is DEFINED as the union of those arrays, so asserting it equals that union
     // is a tautology — it passes no matter which keys are in the arrays. The
@@ -405,11 +405,12 @@ describe("operator override wins", () => {
       "HINDSIGHT_API_WORKER_REFRESH_MENTAL_MODEL_RESERVED_SLOTS",
       "HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS",
       "HINDSIGHT_API_WORKER_RETAIN_RESERVED_SLOTS",
-      // Not HINDSIGHT_API_* — switchroom-patch knobs (the CE-damping and MCP
-      // recall-budget rollback hatches), read by the patched modules, never
-      // by upstream's config parser. Sort last.
+      // Not HINDSIGHT_API_* — switchroom-patch knobs (the CE-damping, MCP
+      // recall-budget, and MM-refresh-debounce rollback hatches), read by the
+      // patched modules, never by upstream's config parser. Sort last.
       "HINDSIGHT_CE_DECISIVE_RELATIVE_GAP",
       "HINDSIGHT_MCP_RECALL_BUDGET_MODE",
+      "HINDSIGHT_MM_REFRESH_MIN_INTERVAL_S",
     ]);
   });
 
@@ -908,6 +909,75 @@ describe("HINDSIGHT_MCP_RECALL_BUDGET_MODE (override-only, patch rollback hatch)
     const perf = { env: { [KEY]: OFF }, processEnv: {} };
     startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, false, perf);
     expect(runEnv(runArgs()).get(KEY)).toEqual([OFF]);
+  });
+});
+
+// ── the MM-refresh-debounce rollback hatch ────────────────────────────────
+describe("HINDSIGHT_MM_REFRESH_MIN_INTERVAL_S (override-only, patch rollback hatch)", () => {
+  const KEY = "HINDSIGHT_MM_REFRESH_MIN_INTERVAL_S";
+  const CAPS = [
+    { gpu: false, localLlm: false },
+    { gpu: true, localLlm: false },
+    { gpu: false, localLlm: true },
+    { gpu: true, localLlm: true },
+  ];
+  /** The documented full back-out value: upstream's refresh-every-round. */
+  const OFF = "0";
+
+  it("is managed, so a hindsight.env line for it is not silently discarded", () => {
+    // docker/Dockerfile.hindsight's MM-refresh-debounce patch documents this
+    // var as its restart-level rollback (0 = upstream behaviour), and the
+    // patch reads it ONCE at import — an unreached value has no runtime
+    // fallback, so absence from HINDSIGHT_PERF_ENV_KEYS would make the
+    // documented escape hatch not exist (the CE-gap defect, re-run).
+    expect(HINDSIGHT_PERF_ENV_KEYS.has(KEY)).toBe(true);
+    // Override-only, not defaulted: the 3600s floor is baked into the image
+    // where the patch lives; emitting it here too would be a second copy of
+    // the same opinion to drift.
+    expect(HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS.has(KEY)).toBe(true);
+    for (const group of [
+      HINDSIGHT_PERF_DEFAULTS_UNGATED,
+      HINDSIGHT_PERF_DEFAULTS_GPU,
+      HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM,
+    ]) {
+      expect(group.map(([k]) => k)).not.toContain(KEY);
+    }
+  });
+
+  it("survives resolveHindsightPerfOverrides from BOTH sources", () => {
+    expect(resolveHindsightPerfOverrides({ [KEY]: OFF }).get(KEY)).toBe(OFF);
+    expect(resolveHindsightPerfOverrides(undefined, { [KEY]: OFF }).get(KEY)).toBe(OFF);
+  });
+
+  it.each(CAPS)(
+    "is NOT emitted on any host when unset (gpu=$gpu localLlm=$localLlm)",
+    (caps) => {
+      // Unset ⇒ the image's baked 3600s floor. A host that sets nothing must
+      // keep exactly the shipped behaviour.
+      expect(hindsightPerfEnv(caps).map(([k]) => k)).not.toContain(KEY);
+    },
+  );
+
+  it("reaches the docker-run argv AND the compose snippet with the operator's value", () => {
+    // The outcome that matters: the value an operator writes in
+    // switchroom.yaml is actually in the argv that launches the container.
+    // Without the key in the managed set both of these are undefined.
+    const perf = { env: { [KEY]: OFF }, processEnv: {} };
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false, perf);
+    expect(runEnv(runArgs()).get(KEY)).toEqual([OFF]);
+    expect(
+      composeEnv(
+        generateHindsightComposeSnippet(undefined, undefined, LOOPBACK_LITELLM, false, perf),
+      ).get(KEY),
+    ).toEqual([OFF]);
+  });
+
+  it("still reaches the container on a host with NO gated capability", () => {
+    // Cloud endpoint + no GPU: the harshest gating case. A rollback hatch that
+    // works only on GPU boxes is not a rollback hatch.
+    const perf = { env: { [KEY]: "7200" }, processEnv: {} };
+    startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, false, perf);
+    expect(runEnv(runArgs()).get(KEY)).toEqual(["7200"]);
   });
 });
 

--- a/src/setup/hindsight-perf-defaults.ts
+++ b/src/setup/hindsight-perf-defaults.ts
@@ -1295,6 +1295,37 @@ export const HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM: ReadonlyArray<readonly [string, 
  *                                                            # a backlog drains
  * ```
  *
+ * ### `HINDSIGHT_MM_REFRESH_MIN_INTERVAL_S`
+ *
+ * The documented rollback/tuning knob for switchroom's MM-refresh-debounce
+ * patch (`docker/Dockerfile.hindsight`, the `consolidation/consolidator.py`
+ * block). Upstream refreshes every `refresh_after_consolidation: true`
+ * mental model at the end of EVERY completed consolidation operation, gated
+ * only by "any in-scope memory since last_refreshed_at" — under sustained
+ * ingestion that is every round, i.e. roughly once a minute per model
+ * (measured 2026-08-01: the `finn` bank's 4 models refreshed 1,902 times in
+ * one day, 20.77M tokens; fleet-wide 3,003 refresh calls / 36.6M tokens).
+ * The patch floors the interval between consolidation-triggered refreshes
+ * of one model at this many seconds, default 3600 baked into the image.
+ * A skipped model's `last_refreshed_at` is untouched, so the first
+ * consolidation after the floor elapses still refreshes it — deferred,
+ * never dropped. Explicit refreshes (MCP tool, HTTP, the user-profile Stop
+ * hook) and the cron-scheduled maintenance path are not debounced.
+ *
+ * Not an upstream var (no `HINDSIGHT_API_` prefix — upstream's config
+ * parser never sees it; verified 2026-08-02 that upstream main has no
+ * debounce, merged or open). Read once at import, like
+ * `HINDSIGHT_CE_DECISIVE_RELATIVE_GAP` above, so changing it is a container
+ * restart, not a rebuild. Override-only rather than defaulted: the 3600s
+ * default is baked into the image where the patch lives, and emitting it
+ * here too would create a second copy of the same opinion to drift.
+ *
+ * ```yaml
+ * hindsight:
+ *   env:
+ *     HINDSIGHT_MM_REFRESH_MIN_INTERVAL_S: "0"   # upstream behaviour, patch inert
+ * ```
+ *
  * ### DELIBERATELY NOT ADOPTED from v0.8.6
  *
  * - `HINDSIGHT_API_LOOP_WATCHDOG_ENABLED` / `..._STALL_THRESHOLD_MS` /
@@ -1320,6 +1351,7 @@ export const HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS: ReadonlySet<string> = new Set([
   "HINDSIGHT_API_LLM_TEMPERATURE_REFLECT",
   "HINDSIGHT_API_RETAIN_WALL_TIMEOUT",
   "HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT",
+  "HINDSIGHT_MM_REFRESH_MIN_INTERVAL_S",
 ]);
 
 /**

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -1070,6 +1070,60 @@ describe("Dockerfile.hindsight shape", () => {
     );
   });
 
+  it("keeps the MM-refresh-debounce fix (assert-guarded, fail-loud)", () => {
+    // Upstream refreshes every `refresh_after_consolidation: true` mental
+    // model at the end of EVERY completed consolidation operation, gated only
+    // by "any in-scope memory since last_refreshed_at" — always true under
+    // sustained ingestion. Measured 2026-08-01 (llm_requests): finn's 4
+    // models refreshed 1,902x in one day (20.77M tokens); fleet-wide 3,003
+    // refresh calls / 36.6M tokens. The patch floors the interval between
+    // consolidation-triggered refreshes of one model.
+    //
+    // SCOPE: structural, not behavioural. The behavioural gate is
+    // tests/docker/hindsight-mm-refresh-debounce-patch.test.ts, which runs
+    // the shipping `_trigger_mental_model_refreshes` and asserts which
+    // candidates are actually submitted. Do not treat this file as
+    // sufficient.
+    expect(dockerfile).toMatch(/switchroom hindsight MM-refresh-debounce patch/);
+    // Exact-once anchor guards for both halves (fail-loud on upstream drift).
+    expect(dockerfile).toMatch(
+      /f"\{TAG\}: _trigger_mental_model_refreshes def anchor found \{n\}x \(expected 1\) in "/,
+    );
+    expect(dockerfile).toMatch(
+      /f"\{TAG\}: staleness-loop anchor found \{n\}x \(expected 1\) in "/,
+    );
+    // The helper's safety shape: NULL last_refreshed_at is never debounced,
+    // and interval <= 0 short-circuits to exact upstream behaviour.
+    expect(dockerfile).toMatch(/if _MM_REFRESH_MIN_INTERVAL_S <= 0\.0:/);
+    expect(dockerfile).toMatch(/if not last:/);
+    // A bad value degrades to the default, never raises out of consolidation.
+    expect(dockerfile).toMatch(/except \(TypeError, ValueError\):/);
+    expect(dockerfile).toMatch(/if not math\.isfinite\(value\) or value < 0\.0:/);
+    // The debounce is consulted BEFORE the staleness round-trip.
+    expect(dockerfile).toMatch(/if _mm_refresh_debounced\(candidate\):/);
+    // Post-replace re-assertions (verification-on-build).
+    expect(dockerfile).toMatch(
+      /assert t\.count\("if _mm_refresh_debounced\(candidate\):"\) == 1,/,
+    );
+    expect(dockerfile).toMatch(/assert t\.count\(LOOP_ANCHOR\) == 0,/);
+
+    // …and the knob the image reads must be one switchroom can actually set.
+    // `resolveHindsightPerfOverrides` drops any key outside
+    // HINDSIGHT_PERF_ENV_KEYS silently, and the patch reads this var once at
+    // import, so an unmanaged name here is a documented escape hatch that
+    // cannot be reached from switchroom.yaml at all. Derive the name from the
+    // Dockerfile rather than restating it, so the two cannot drift apart.
+    const envName = dockerfile.match(
+      /_MM_REFRESH_MIN_INTERVAL_ENV: str = "([A-Z0-9_]+)"/,
+    )?.[1];
+    expect(envName, "the patch must name its env knob").toBeDefined();
+    expect(
+      HINDSIGHT_PERF_ENV_KEYS.has(envName!),
+      `${envName} is read by the baked patch but is not in HINDSIGHT_PERF_ENV_KEYS, ` +
+        "so a hindsight.env line for it is discarded before it reaches the container",
+    ).toBe(true);
+  });
+
   it("preserves upstream's start-all.sh as the post-shim CMD", () => {
     // The shim does broker auth, then `exec "$@"` which is whatever
     // CMD docker passes — must be upstream's start-all.sh so the

--- a/tests/docker/hindsight-mm-refresh-debounce-patch.test.ts
+++ b/tests/docker/hindsight-mm-refresh-debounce-patch.test.ts
@@ -1,0 +1,453 @@
+/**
+ * Behavioural proof for the MM-refresh-debounce patch
+ * `docker/Dockerfile.hindsight` bakes into the pinned upstream Hindsight image.
+ *
+ * `dockerfile-hindsight-bakes.test.ts` pins the *shape* of that patch block
+ * (grep-on-file, runs everywhere). This file proves the *outcome*: it runs the
+ * same probe against unpatched upstream (must be RED — upstream refreshes the
+ * recently-refreshed model too) and against upstream + the patch block applied
+ * (must be GREEN on every property).
+ *
+ * THE DEFECT, in the real shipping source. `_trigger_mental_model_refreshes`
+ * (`engine/consolidation/consolidator.py`) runs at the end of EVERY completed
+ * consolidation operation and submits a refresh for every
+ * `refresh_after_consolidation: true` mental model that is "stale" — where
+ * stale means "any in-scope memory ingested since last_refreshed_at"
+ * (`memory_engine.py compute_mental_model_is_stale`). Under sustained
+ * ingestion that is true on every round, so every round regenerates every
+ * model. Measured on this fleet during the 2026-08-01 backlog drain
+ * (hindsight's own llm_requests table): the `finn` bank's FOUR mental models
+ * were refreshed 1,902 times in one day — roughly one full LLM regeneration
+ * per model per minute for ~9 hours, 20.77M tokens; fleet-wide the
+ * refresh_mental_model operation burned 3,003 calls / 36.6M tokens that day.
+ * Upstream has no debounce (verified against vectorize-io/hindsight main
+ * 2026-08-02, merged and open PRs).
+ *
+ * The properties this probe drives, none of which the patch TEXT can show:
+ *
+ *  1. FLOOR BINDS — with the default floor (env unset ⇒ 3600s baked into the
+ *     image), a model refreshed 100s ago is NOT submitted, and the debounce
+ *     decision happens BEFORE the per-candidate staleness query (a debounced
+ *     model costs zero DB round-trips).
+ *  2. FLOOR RELEASES — a model refreshed 7200s ago IS submitted: the floor
+ *     defers, it does not starve.
+ *  3. NULL IS NEVER DEBOUNCED — a never-refreshed model is always submitted;
+ *     debouncing it would leave a new mental model permanently empty.
+ *  4. ZERO IS EXACT UPSTREAM — HINDSIGHT_MM_REFRESH_MIN_INTERVAL_S=0 submits
+ *     all three models, i.e. the documented rollback hatch really restores
+ *     refresh-every-round.
+ *  5. BAD VALUES DEGRADE, NEVER RAISE — an unparseable or negative env value
+ *     behaves like the default floor rather than taking consolidation down.
+ *
+ * The probe drives the REAL `_trigger_mental_model_refreshes` from the image
+ * with fakes only at the engine boundary (`compute_mental_model_is_stale`
+ * always answers True and `submit_async_refresh_mental_model` records — the
+ * point is to observe WHICH candidates the shipping trigger loop actually
+ * submits), rather than re-implementing the loop here. The env knob is read
+ * once at module import, so the probe re-imports the module per scenario —
+ * exactly what a container restart does in production.
+ *
+ * The patch block is extracted from the Dockerfile itself rather than
+ * duplicated here, so this test cannot drift from what actually ships. It
+ * applies it by `docker exec` (not `docker build`) so it runs on daemons
+ * without buildx, and it never touches the production `switchroom-hindsight`
+ * container.
+ *
+ * SKIP DISCIPLINE: identical to `hindsight-retry-perturbation-patches.test.ts`.
+ * Locally, with no docker or no cached image, this skips (never pull a 6.4GB
+ * third-party image onto a dev box). In CI the `hindsight-probe` job pulls the
+ * pinned digest and sets SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1, under which an
+ * unavailable docker/image is a HARD FAILURE, never a green skip. Both runs
+ * assert a `PROBE_EXECUTED` sentinel so a probe that dies early can never be
+ * mistaken for a pass.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { execFileSync, execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const dockerfile = readFileSync(
+  resolve(root, "docker/Dockerfile.hindsight"),
+  "utf8",
+);
+
+const RUN_ID = randomUUID();
+const TEST_PHASE = "hindsight-mm-refresh-debounce-patch";
+
+/** The pinned upstream image, read from the Dockerfile so it can never drift. */
+const UPSTREAM_IMAGE = (() => {
+  const m = dockerfile.match(/^FROM\s+(\S+)/m);
+  if (!m) throw new Error("Dockerfile.hindsight has no FROM line");
+  return m[1];
+})();
+
+/** The patch this file proves, named by its unique in-block marker. */
+const PATCH_NAME = "MM-refresh-debounce patch";
+
+/**
+ * The patch block under test, pulled out of the Dockerfile's
+ * `RUN python3 - <<'PYEOF' ... PYEOF` heredocs by its unique patch name.
+ */
+function patchBlocks(): string[] {
+  const blocks = [
+    ...dockerfile.matchAll(/^RUN python3 - <<'PYEOF'\n([\s\S]*?)^PYEOF$/gm),
+  ].map((m) => m[1]);
+  const hits = blocks.filter((b) => b.includes(PATCH_NAME));
+  if (hits.length !== 1) {
+    throw new Error(
+      `Dockerfile.hindsight contains ${hits.length} "${PATCH_NAME}" RUN blocks ` +
+        `(expected exactly 1) — if the patch was deliberately removed, delete ` +
+        `this test with it.`,
+    );
+  }
+  return hits;
+}
+
+/**
+ * Python probe. Exits 0 only when all five properties above hold; prints the
+ * offending assertions otherwise.
+ *
+ * Deliberately asserts OUTCOMES: it runs the real trigger loop from the image
+ * and records which mental models it actually submits for refresh. Nothing
+ * here greps the patched source.
+ */
+const PROBE = String.raw`
+import asyncio
+import importlib
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+failures = []
+
+
+def fail(msg):
+    failures.append(msg)
+
+
+import hindsight_api.engine.consolidation.consolidator as consolidator
+
+ENV = "HINDSIGHT_MM_REFRESH_MIN_INTERVAL_S"
+
+
+def load(interval):
+    """Re-import the module under a given env value.
+
+    The knob is read once at import (a container restart in production), so
+    each scenario re-executes the module top level rather than poking a
+    global — the probe exercises the shipping read path, not a shortcut.
+    """
+    if interval is None:
+        os.environ.pop(ENV, None)
+    else:
+        os.environ[ENV] = interval
+    return importlib.reload(consolidator)
+
+
+NOW = datetime.now(timezone.utc)
+
+
+def rows():
+    return [
+        {
+            "id": "mm-fresh",
+            "name": "fresh (refreshed 100s ago)",
+            "tags": None,
+            "last_refreshed_at": NOW - timedelta(seconds=100),
+            "trigger": {"refresh_after_consolidation": True},
+        },
+        {
+            "id": "mm-old",
+            "name": "old (refreshed 7200s ago)",
+            "tags": None,
+            "last_refreshed_at": NOW - timedelta(seconds=7200),
+            "trigger": {"refresh_after_consolidation": True},
+        },
+        {
+            "id": "mm-never",
+            "name": "never refreshed",
+            "tags": None,
+            "last_refreshed_at": None,
+            "trigger": {"refresh_after_consolidation": True},
+        },
+    ]
+
+
+class FakeConn:
+    async def fetch(self, sql, *params):
+        return rows()
+
+
+class FakePool:
+    """Raw-pool shape for acquire_with_retry's legacy branch."""
+
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def acquire(self):
+        return self._conn
+
+    async def release(self, conn):
+        return None
+
+
+class FakeEngine:
+    """Fakes ONLY the engine boundary; the trigger loop under test is real."""
+
+    def __init__(self):
+        self._backend = FakePool(FakeConn())
+        self.staleness_checked = []
+        self.submitted = []
+
+    async def compute_mental_model_is_stale(self, conn, bank_id, candidate):
+        self.staleness_checked.append(candidate["id"])
+        # Always stale — the exact condition of a bank under sustained
+        # ingestion, which is the scenario the debounce exists for.
+        return True
+
+    async def submit_async_refresh_mental_model(self, bank_id, mental_model_id, request_context):
+        self.submitted.append(mental_model_id)
+
+
+async def drive(mod):
+    eng = FakeEngine()
+    n = await mod._trigger_mental_model_refreshes(
+        memory_engine=eng,
+        bank_id="probe-bank",
+        request_context=object(),
+        consolidated_tags=None,
+        perf=None,
+    )
+    return n, eng
+
+
+# ── 1-3. the default floor (env unset => image-baked 3600s) ───────────────
+mod = load(None)
+n, eng = asyncio.run(drive(mod))
+print("DEFAULT_SUBMITTED", json.dumps(sorted(eng.submitted)))
+print("DEFAULT_STALE_CHECKED", json.dumps(sorted(eng.staleness_checked)))
+if "mm-fresh" in eng.submitted:
+    fail("a model refreshed 100s ago was submitted under the default floor")
+if "mm-old" not in eng.submitted:
+    fail("a model refreshed 7200s ago was NOT submitted — the floor starves instead of deferring")
+if "mm-never" not in eng.submitted:
+    fail("a never-refreshed model was NOT submitted — NULL must never be debounced")
+if n != len(eng.submitted):
+    fail("returned count %r disagrees with %d submissions" % (n, len(eng.submitted)))
+if "mm-fresh" in eng.staleness_checked:
+    fail("the debounce did not precede the staleness round-trip — a debounced model still costs a query")
+
+# ── 4. zero is the exact-upstream rollback hatch ──────────────────────────
+mod = load("0")
+n0, eng0 = asyncio.run(drive(mod))
+print("OFF_SUBMITTED", json.dumps(sorted(eng0.submitted)))
+if sorted(eng0.submitted) != ["mm-fresh", "mm-never", "mm-old"]:
+    fail("interval 0 did not restore upstream refresh-every-round: " + json.dumps(sorted(eng0.submitted)))
+
+# ── 5. bad values degrade to the default floor, never raise ───────────────
+for bad in ("not-a-number", "-5", "nan"):
+    mod = load(bad)
+    try:
+        nb, engb = asyncio.run(drive(mod))
+    except Exception as e:
+        fail("env %r raised out of the consolidation path: %s: %s" % (bad, type(e).__name__, e))
+        continue
+    if "mm-fresh" in engb.submitted:
+        fail("env %r did not degrade to the default floor (fresh model submitted)" % (bad,))
+    if "mm-old" not in engb.submitted or "mm-never" not in engb.submitted:
+        fail("env %r over-blocked: submitted=%s" % (bad, json.dumps(sorted(engb.submitted))))
+
+print("FAILURES", failures)
+print("PROBE_EXECUTED")
+sys.exit(1 if failures else 0)
+`;
+
+function hasDocker(): boolean {
+  try {
+    execSync("docker version --format '{{.Server.Version}}'", {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasImage(ref: string): boolean {
+  try {
+    execSync(`docker image inspect ${ref}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * CI marker. When set, this suite MUST really execute — an absent docker or
+ * an absent upstream image becomes a hard failure instead of a green skip.
+ * `.github/workflows/docker-e2e.yml` sets it after pulling the pinned digest.
+ */
+const REQUIRED = process.env.SWITCHROOM_REQUIRE_HINDSIGHT_PROBE === "1";
+
+const dockerOk = hasDocker();
+const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
+
+type ProbeResult = { status: number; stdout: string };
+
+/** Run the probe in a throwaway container, optionally patching first. */
+function runProbe(patched: boolean): ProbeResult {
+  const name = `sr-hs-mmdeb-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
+    0,
+    8,
+  )}`;
+  try {
+    execFileSync(
+      "docker",
+      [
+        "run",
+        "-d",
+        "--name",
+        name,
+        "--label",
+        `switchroom.test=${TEST_PHASE}`,
+        "--label",
+        `switchroom.test.run=${RUN_ID}`,
+        "--user",
+        "root",
+        "--network",
+        "none",
+        UPSTREAM_IMAGE,
+        "sleep",
+        "300",
+      ],
+      { stdio: ["ignore", "ignore", "pipe"] },
+    );
+
+    if (patched) {
+      for (const block of patchBlocks()) {
+        // The block is self-verifying: it asserts its upstream anchor exists
+        // exactly once and re-asserts the result, so a non-zero exit here means
+        // upstream drifted and the patch must be re-authored.
+        execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
+          input: block,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      }
+    }
+
+    const res = execFileSync(
+      "docker",
+      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
+      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
+    );
+    return { status: 0, stdout: res };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: Buffer | string };
+    return {
+      status: err.status ?? -1,
+      stdout: (err.stdout ?? "").toString(),
+    };
+  } finally {
+    try {
+      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+describe("Dockerfile.hindsight MM-refresh-debounce probe is real, not a silent skip", () => {
+  it("pins the upstream image by digest so the probe tests the exact shipping bytes", () => {
+    expect(UPSTREAM_IMAGE).toMatch(/@sha256:[0-9a-f]{64}$/);
+  });
+
+  it("extracts exactly the one patch block it claims to prove", () => {
+    expect(patchBlocks()).toHaveLength(1);
+  });
+
+  it("hard-fails rather than skipping when CI demands a real run", () => {
+    if (!REQUIRED) {
+      // Local/dev path: skipping is legitimate (never pull a 6.4GB image onto
+      // a dev box), but it must be visible rather than silent.
+      expect(
+        REQUIRED,
+        "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE is unset — the behavioural probe " +
+          "is advisory here. CI's hindsight-probe job sets it after pulling " +
+          `${UPSTREAM_IMAGE}.`,
+      ).toBe(false);
+      return;
+    }
+    expect(
+      dockerOk,
+      "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but the docker daemon is unreachable",
+    ).toBe(true);
+    expect(
+      imageOk,
+      `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but ${UPSTREAM_IMAGE} is not present ` +
+        "locally — the workflow must pull the pinned digest before running this suite",
+    ).toBe(true);
+  });
+});
+
+describe.skipIf(!dockerOk || !imageOk)(
+  "Dockerfile.hindsight MM-refresh-debounce patch changes real behaviour",
+  () => {
+    afterAll(() => {
+      // Label-scoped teardown belt (never an unlabelled bulk removal).
+      try {
+        const ids = execSync(
+          `docker ps -aq --filter label=switchroom.test.run=${RUN_ID}`,
+          { encoding: "utf8" },
+        )
+          .split("\n")
+          .filter(Boolean);
+        if (ids.length) {
+          execFileSync("docker", ["rm", "-f", ...ids], { stdio: "ignore" });
+        }
+      } catch {
+        /* nothing to clean */
+      }
+    });
+
+    it("unpatched upstream is RED — the just-refreshed model is refreshed again", () => {
+      const { status, stdout } = runProbe(false);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED",
+      );
+      expect(status, `probe unexpectedly passed:\n${stdout}`).not.toBe(0);
+
+      // The defect, driven: upstream submits ALL three models — including the
+      // one refreshed 100 seconds ago — which is one consolidation round of
+      // the measured 1,902-refreshes-a-day loop.
+      expect(stdout).toContain(
+        'DEFAULT_SUBMITTED ["mm-fresh", "mm-never", "mm-old"]',
+      );
+    }, 240_000);
+
+    it("upstream + the baked patch block is GREEN on all five properties", () => {
+      const { status, stdout } = runProbe(true);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED",
+      );
+      expect(status, `probe failed:\n${stdout}`).toBe(0);
+      expect(stdout).toContain("FAILURES []");
+
+      // 1-3. the floor binds on the fresh model, releases the elapsed one,
+      // and never debounces a never-refreshed model…
+      expect(stdout).toContain('DEFAULT_SUBMITTED ["mm-never", "mm-old"]');
+      // …and the debounced model never reaches the staleness query.
+      expect(stdout).toContain(
+        'DEFAULT_STALE_CHECKED ["mm-never", "mm-old"]',
+      );
+      // 4. the documented rollback hatch is exact upstream behaviour.
+      expect(stdout).toContain(
+        'OFF_SUBMITTED ["mm-fresh", "mm-never", "mm-old"]',
+      );
+    }, 240_000);
+  },
+);


### PR DESCRIPTION
## Summary

Adds a Dockerfile.hindsight build-time patch that floors the interval between consolidation-triggered refreshes of one mental model at `HINDSIGHT_MM_REFRESH_MIN_INTERVAL_S` seconds (default 3600, baked into the image; `0` restores upstream behaviour exactly). Explicit refreshes (MCP tool, HTTP, user-profile Stop hook) and the cron-scheduled maintenance path are untouched.

## Why

Upstream re-runs every `refresh_after_consolidation: true` mental model at the end of EVERY completed consolidation operation, gated only by "any in-scope memory ingested since `last_refreshed_at`" (`engine/consolidation/consolidator.py` `_trigger_mental_model_refreshes` → `memory_engine.py` `compute_mental_model_is_stale`). Under sustained ingestion that gate is always true, so every round regenerates every model.

Measured on this fleet during the 2026-08-01 backlog drain (hindsight's own `llm_requests` table):

- `finn` bank: **1,902 `refresh_mental_model` LLM calls in one day for 4 mental models** (~one full regeneration per model per minute for ~9h) — 20.77M tokens re-deriving near-identical content.
- Fleet-wide that day: 3,003 refresh calls / 36.6M tokens.

Upstream has no debounce (checked vectorize-io/hindsight main 2026-08-02, merged and open PRs: #2866 fixed only the no-op watermark advance — already in the pinned 0.8.6 base — and #3078 only widened the candidate scope), so this ships as a switchroom carry with a fail-loud anchor-asserted patch block, same pattern as the existing carries.

Safety properties (all driven by the probe, not just asserted in text):

- A skipped model's `last_refreshed_at` is untouched, so the first consolidation after the floor elapses still refreshes it — deferred, never dropped.
- A never-refreshed model (`NULL`) is never debounced.
- The debounce runs BEFORE the per-candidate staleness query, so a debounced model costs zero DB round-trips.
- Bad env values (unparseable / negative / NaN) degrade to the default rather than raising out of the consolidation path.
- The knob is managed override-only (`HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS`), so a `hindsight.env` line for it actually reaches the container; rollback is a container restart, not a rebuild.

Job spec: `reference/jobs/` — memory that maintains itself without burning the subscription (subscription-honest pillar; this is pure waste elimination, no behaviour an agent relies on changes beyond refresh cadence under continuous ingestion).

## Test plan

- **Behavioural probe** `tests/docker/hindsight-mm-refresh-debounce-patch.test.ts`: runs the REAL `_trigger_mental_model_refreshes` from the pinned image, RED unpatched (upstream submits the just-refreshed model) / GREEN patched (floor binds, releases after elapse, NULL never debounced, `0` = exact upstream, bad values degrade). Wired into `docker-e2e.yml` `hindsight-probe` with `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1` so it can never silently skip in CI.
- Verified locally end-to-end against the cached upstream image (code-identical trigger region): RED exit=1 with the exact expected failures, GREEN exit=0, `FAILURES []`.
- Patch block also applied cleanly to the exact 0.8.6 source (revision 08995e30) the pinned digest ships.
- Shape: `dockerfile-hindsight-bakes.test.ts` (34 passing) pins anchors + env-knob reachability.
- `src/setup/hindsight-perf-defaults.test.ts` (193 passing incl. new override-only describe), `tests/hindsight-env-keys-are-reachable.test.ts` (16 passing), full `npm run lint` green.

## Risk

Low. The patch is scoped to one function; the rollback hatch (`HINDSIGHT_MM_REFRESH_MIN_INTERVAL_S=0`) restores upstream byte-behaviour without a rebuild. Worst case of the floor itself: a mental model's content lags ingestion by up to 1h under continuous consolidation, and an agent that needs freshness NOW still has the explicit refresh path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)