### PR TITLE
fix(telegram): stage the quiescence flush; stop re-injecting consumed handbacks

### DIFF
--- a/telegram-plugin/answer-ready-flush.ts
+++ b/telegram-plugin/answer-ready-flush.ts
@@ -34,6 +34,61 @@ import { decideTurnFlush, type FlushDecisionInput } from './turn-flush-safety.js
 export const ANSWER_READY_FLUSH_MS = 1000
 
 /**
+ * Default STAGE window (ms) — the stage-don't-send fix for the live
+ * flush-then-late-reply duplicate (2026-08-02, klanker DM, msgs 25843/25844).
+ *
+ * The quiescence flush used to SEND the composed terminal answer the moment the
+ * ~1 s debounce fired. But quiescence is a heuristic, not a completion signal:
+ * the model routinely goes quiet for a few seconds BETWEEN its terminal
+ * narration and its `reply` tool call (observed gap: 6 s). The flush then posts
+ * a PROVISIONAL message that the supersede machinery must claw back — and the
+ * claw-back is deliberately conservative (#3429 content gate, #4176 sub-agent
+ * liveness hold), so a REWORDED own-answer with a background sub-agent live
+ * ships as a visible duplicate even on current main (the accepted residual
+ * documented in gateway/subagent-reply-authority.ts).
+ *
+ * Stage-don't-send removes the provisional send instead of reconciling it:
+ * when the quiescence debounce fires, the composed answer is STAGED (held on
+ * the still-live turn — the turn is NOT ended, so the typing indicator keeps
+ * running) and promoted to a real send only when the completion window closes
+ * with no reply:
+ *
+ *   - the model's `reply` lands → the staged text is DISCARDED (fire-time
+ *     re-verify declines on `replyCalled`) — exactly one message, the canonical
+ *     reply, on its normal path;
+ *   - the REAL turn_end lands first → the turn-flush branch at turn_end
+ *     delivers the captured answer (the pre-PR-A path) — promotion at the true
+ *     completion signal, usually seconds;
+ *   - neither arrives within this window (the KNOWN-UNRELIABLE turn_end case
+ *     PR A was built for) → the stage timer promotes through the same
+ *     synthetic-turn_end flush path as before.
+ *
+ * Worst-case added latency for a silent no-op turn whose turn_end never lands
+ * is this window (30 s) — still ~5× faster than the ~150 s orphaned-reply
+ * backstop PR A replaced, and it buys the hard guarantee that a composing
+ * model can no longer race the flush into a duplicate. Env-tunable via
+ * SWITCHROOM_ANSWER_STAGE_MS; 0 (or any non-positive value) disables staging
+ * and restores the legacy immediate flush.
+ */
+export const ANSWER_STAGE_MS = 30_000
+
+/**
+ * Resolve the stage window from the environment. Returns a positive integer
+ * ms, or 0 when explicitly disabled (non-positive value = legacy immediate
+ * flush). Unparseable values fail safe to the default.
+ */
+export function resolveAnswerStageMs(
+  env: Record<string, string | undefined>,
+): number {
+  const raw = env.SWITCHROOM_ANSWER_STAGE_MS
+  if (raw == null || raw.trim() === '') return ANSWER_STAGE_MS
+  const n = Number(raw)
+  if (!Number.isFinite(n)) return ANSWER_STAGE_MS
+  if (n <= 0) return 0
+  return Math.floor(n)
+}
+
+/**
  * Resolve the debounce window from the environment. Returns a positive integer
  * ms, or 0 when disabled (kill-switch) / unparseable / non-positive. The
  * gateway treats 0 as "never arm", so a bad env value fails safe to the default
@@ -117,6 +172,17 @@ export interface AnswerReadyFlushDeps<Turn> {
    * short-circuits — the exactly-once guarantee.
    */
   onFlush(turn: Turn): void
+  /**
+   * Stage-don't-send window (ms) — see {@link ANSWER_STAGE_MS}. When > 0 the
+   * quiescence expiry STAGES the answer (turn stays live, typing hold) and
+   * arms a promotion timer for this many ms instead of flushing immediately;
+   * the promotion re-verifies before delivering, so a `reply` that landed in
+   * the window discards the staged text, and a real turn_end that landed first
+   * delivered it through the turn-flush branch already (its
+   * `endCurrentTurnAtomic` → `clear` cancels the promotion). 0 / undefined =
+   * legacy immediate flush at quiescence.
+   */
+  stageWindowMs?: number
   /** Injectable timer primitives (default to the globals). */
   setTimeoutFn?: (fn: () => void, ms: number) => FlushTimerHandle
   clearTimeoutFn?: (handle: FlushTimerHandle) => void
@@ -139,8 +205,13 @@ export interface AnswerReadyFlushDeps<Turn> {
  * landed since the arm cancels the flush deterministically), then dispatches
  * exactly one `onFlush`.
  */
-export class AnswerReadyFlushController<Turn> {
+export class AnswerReadyFlushController<Turn extends object> {
   constructor(private readonly deps: AnswerReadyFlushDeps<Turn>) {}
+
+  /** Turns whose composed answer is currently STAGED (stage-don't-send): the
+   *  quiescence debounce fired, but delivery is held for the promotion window.
+   *  WeakSet so a superseded/ended turn atom can never leak an entry. */
+  private readonly staged = new WeakSet<Turn>()
 
   private get setTimeoutFn(): (fn: () => void, ms: number) => FlushTimerHandle {
     return this.deps.setTimeoutFn ?? ((fn, ms) => setTimeout(fn, ms))
@@ -150,14 +221,21 @@ export class AnswerReadyFlushController<Turn> {
     return this.deps.clearTimeoutFn ?? ((h) => clearTimeout(h))
   }
 
-  /** Disarm the flush timer for a turn (idempotent). */
+  /** Disarm the flush timer for a turn (idempotent). Clears BOTH phases: a
+   *  pending quiescence debounce or a pending staged promotion. */
   clear(turn: Turn | null): void {
     if (turn == null) return
+    this.staged.delete(turn)
     const handle = this.deps.getTimerHandle(turn)
     if (handle != null) {
       this.clearTimeoutFn(handle)
       this.deps.setTimerHandle(turn, null)
     }
+  }
+
+  /** True IFF `turn`'s composed answer is currently staged (test/diagnostics). */
+  isStaged(turn: Turn): boolean {
+    return this.staged.has(turn)
   }
 
   /** (Re)arm the flush timer for the current turn — the debounce. */
@@ -171,7 +249,10 @@ export class AnswerReadyFlushController<Turn> {
     this.deps.setTimerHandle(turn, handle)
   }
 
-  /** Timer-expiry callback. Re-pins the turn, re-verifies quiescence, fires once. */
+  /** Timer-expiry callback — BOTH phases share it. Re-pins the turn,
+   *  re-verifies quiescence, then either STAGES (first fire, window > 0) or
+   *  delivers (legacy immediate mode, or the staged promotion firing after the
+   *  completion window closed with no reply). */
   private onExpiry(armedTurn: Turn): void {
     const live = this.deps.getCurrentTurn()
     // Rollover guard: a superseded turn's timer must not fire against a fresh atom.
@@ -179,9 +260,40 @@ export class AnswerReadyFlushController<Turn> {
     this.deps.setTimerHandle(live, null)
     // Fire-time re-verification: a tool that started (or a reply that landed)
     // since the arm deterministically cancels the flush even if the explicit
-    // disarm was somehow missed.
-    if (!shouldArmAnswerReadyFlush(this.deps.getArmInput(live))) return
-    this.deps.log?.('answer-ready quiescence flush — delivering composed terminal answer')
+    // disarm was somehow missed. On a staged promotion this is the DISCARD
+    // path: the reply landed inside the window, so the staged provisional text
+    // is dropped and the canonical reply is the one message the user sees.
+    if (!shouldArmAnswerReadyFlush(this.deps.getArmInput(live))) {
+      if (this.staged.delete(live)) {
+        this.deps.log?.(
+          'answer-ready stage discarded — reply/tool activity landed inside the completion window',
+        )
+      }
+      return
+    }
+    const stageMs = this.deps.stageWindowMs ?? 0
+    if (stageMs > 0 && !this.staged.has(live)) {
+      // STAGE-DON'T-SEND (see ANSWER_STAGE_MS): hold the composed answer on
+      // the still-live turn instead of posting a provisional message. The turn
+      // is NOT ended, so the typing indicator keeps running (the "typing
+      // hold") and a real turn_end landing first delivers through the normal
+      // turn-flush branch (endCurrentTurnAtomic's `clear` cancels this timer).
+      this.staged.add(live)
+      this.deps.log?.(
+        `answer-ready quiescence — staging composed terminal answer ` +
+          `(promotes in ${stageMs}ms unless the reply lands or the turn completes)`,
+      )
+      const handle = this.setTimeoutFn(() => this.onExpiry(live), stageMs)
+      this.deps.setTimerHandle(live, handle)
+      return
+    }
+    if (this.staged.delete(live)) {
+      this.deps.log?.(
+        'answer-ready stage promoted — completion window closed with no reply; delivering composed terminal answer',
+      )
+    } else {
+      this.deps.log?.('answer-ready quiescence flush — delivering composed terminal answer')
+    }
     this.deps.onFlush(live)
   }
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -283,6 +283,7 @@ import { NarrativeFlushController, PENDING_NARRATIVE_FLUSH_MS } from '../narrati
 import { createTypingWrapper } from '../typing-wrap.js'
 import { createTurnTypingLoop } from './turn-typing-loop.js'
 import { createHandbackPreturnSignal } from './handback-preturn-signal.js'
+import { sessionConsumeSignal } from './session-consume-signal.js'
 import { createHandbackOrphanRecovery } from './handback-orphan-recovery.js'
 import { deriveTurnId } from './derive-turn-id.js'
 import { createTypingEmitter, TYPING_REFRESH_MS } from '../typing-emitter.js'
@@ -495,10 +496,7 @@ import {
 } from '../reply-owner-resolve.js'
 import { SubagentHandbackMarker } from './subagent-handback-marker.js'
 // PR A — deterministic answer-ready quiescence flush (late-delivery fix).
-import {
-  AnswerReadyFlushController,
-  resolveAnswerReadyFlushMs,
-} from '../answer-ready-flush.js'
+import { AnswerReadyFlushController, resolveAnswerReadyFlushMs, resolveAnswerStageMs } from '../answer-ready-flush.js'
 // #1667 — pure decision core for the turn_end answer-delivery gate (#1664).
 import { decideTurnEndGate } from './turn-end-gate.js'
 // #1122 PR3: turn-flush-prose-recovery removed with the progress card.
@@ -10748,6 +10746,7 @@ if (isGatewayMain) ipcServer = createIpcServer({
 
   async onToolCall(client: IpcClient, msg: ToolCallMessage): Promise<ToolCallResult> {
     process.stderr.write(`telegram gateway: ipc: tool_call tool=${msg.tool} agent=${client.agentName ?? '-'} clientId=${client.id ?? '-'} callId=${msg.id}\n`)
+    if (!isCronIdentity(client.agentName)) sessionConsumeSignal.noteMainToolCall() // consumption proxy (session-consume-signal.ts)
     try {
       // #4172 — the calling client's identity gates reply supersede authority
       // (see replyCallerIsForeignSession, cron-session.ts).
@@ -13547,29 +13546,29 @@ function resetOrphanedReplyTimeout(): void {
  * PR A — DETERMINISTIC answer-ready quiescence flush controller.
  *
  * The orchestration (arm / debounce / rollover-guard / fire-time re-verify /
- * disarm) lives in the extracted, unit-tested `AnswerReadyFlushController`
- * (answer-ready-flush.ts) — the gateway only supplies the thin deps below and
- * calls `.reset()` / `.clear(turn)`. Behaviour:
+ * stage-don't-send / disarm) lives in the extracted, unit-tested
+ * `AnswerReadyFlushController` (answer-ready-flush.ts) — the gateway only
+ * supplies the thin deps below and calls `.reset()` / `.clear(turn)`.
  *
  * - `reset()` (from `case 'text'`): (re)arm iff the turn has a genuine composed
  *   terminal answer (the SAME `decideTurnFlush` classifier the turn-flush branch
  *   uses) AND is quiescent. Each text chunk re-arms → the debounce.
  * - `clear(turn)` (from tool activity + `endCurrentTurnAtomic`): the DISARM.
- * - on fire: re-pin `currentTurn === turn`, re-verify quiescence, then dispatch
- *   a positive `answer-ready-quiescence` synthetic turn_end that routes through
- *   the IDENTICAL turn-flush send path (endCurrentTurnAtomic → send-gated IIFE →
- *   honest PR-B record). Replaces the ~150 s dead wait with ~1 s, in code.
+ * - on fire: re-pin `currentTurn === turn`, re-verify quiescence, then STAGE the
+ *   answer on the still-live turn (`stageWindowMs` — see ANSWER_STAGE_MS) and
+ *   promote only when the completion window closes with no reply, dispatching
+ *   the positive `answer-ready-quiescence` synthetic turn_end through the
+ *   IDENTICAL turn-flush send path. A reply landing in the window discards the
+ *   stage (msgs 25843/25844); a real turn_end delivers via the turn-flush branch.
  *
  * Exactly-once: the synthetic turn_end's `endCurrentTurnAtomic` nulls the atom,
  * so a later REAL turn_end (or the orphaned backstop) short-circuits at its
  * `turn != null` guard; `endCurrentTurnAtomic` also calls `.clear(turn)` so a
- * real turn_end that lands FIRST cancels a pending flush. `outboundDedup` is the
- * second layer.
+ * real turn_end that lands FIRST cancels a pending flush/stage.
  *
  * The `answer-ready-quiescence` reason bypasses the `durationMs===-1`
- * recently-streaming SUPPRESSION guard (the terminal answer text itself stamps
- * recentlyStreaming): quiescence IS the positive "streaming has settled" signal,
- * the opposite of the hung-turn backstop that guard protects.
+ * recently-streaming SUPPRESSION guard: quiescence IS the positive "streaming
+ * has settled" signal, the opposite of the hung-turn backstop that guard covers.
  */
 const answerReadyFlush = new AnswerReadyFlushController<CurrentTurn>({
   getCurrentTurn: () => currentTurn,
@@ -13593,6 +13592,7 @@ const answerReadyFlush = new AnswerReadyFlushController<CurrentTurn>({
   },
   onFlush: () =>
     handleSessionEvent({ kind: 'turn_end', durationMs: -1, reason: 'answer-ready-quiescence' }),
+  stageWindowMs: resolveAnswerStageMs(process.env), // stage-don't-send — see ANSWER_STAGE_MS
   log: (msg) => process.stderr.write(`telegram gateway: ${msg}\n`),
 })
 
@@ -13831,9 +13831,10 @@ const handbackPreturnSignal = createHandbackPreturnSignal({
     return statusKey(live.sessionChatId, live.sessionThreadId) === key
   },
   // Queue-state gate for the orphan reap (see the signal's `isClaudeBusy` doc):
-  // while a turn is in flight the handback is enqueued behind it, not orphaned.
-  // False for both `bridge_alive_idle` and `bridge_dead` → genuine orphan reaps.
+  // a handback queued behind an in-flight turn is not orphaned.
   isClaudeBusy: () => isMachineInTurn(),
+  // 2026-08-02 invisible-consumption gate — see session-consume-signal.ts.
+  sessionActivitySince: (sinceTs) => sessionConsumeSignal.activitySince(sinceTs),
 })
 
 /**

--- a/telegram-plugin/gateway/handback-preturn-signal.ts
+++ b/telegram-plugin/gateway/handback-preturn-signal.ts
@@ -238,6 +238,18 @@ export interface HandbackPreturnSignalDeps {
    *  is the GLOBAL busy signal because the handback queues behind whatever turn
    *  is running, regardless of topic. Optional; defaults to "not busy". */
   isClaudeBusy?: () => boolean
+  /** True IFF the gateway observed the SESSION consume input after `sinceTs` —
+   *  a turn minting at the enqueue seam, or a main-session MCP tool call over
+   *  the IPC bridge (`session-consume-signal.ts`). Consulted at the moment the
+   *  reap would otherwise declare a genuine orphan: claude holds ONE FIFO input
+   *  queue, so post-delivery consumption evidence means the delivered handback
+   *  entered the model's context even though no adopting turn was ever minted
+   *  (the 2026-08-02 invisible-consumption incident — the session answered the
+   *  handback via a `reply` from idle with zero session-tail events, then the
+   *  reap re-injected the already-answered report twice). When true the reap
+   *  CLEANS UP (card + typing + entry) without re-injecting and without
+   *  escalating. Optional; defaults to "no evidence" (legacy re-inject). */
+  sessionActivitySince?: (sinceTs: number) => boolean
   now?: () => number
   /** Debounce before painting the pre-turn card (kills sub-second flicker). */
   debounceMs?: number
@@ -487,13 +499,27 @@ export function createHandbackPreturnSignal(
       entry.reapTimer = setTimer(() => reap(entry), adoptTimeoutMs)
       return
     }
+    // INVISIBLE-CONSUMPTION GATE (2026-08-02 klanker incident). We are at the
+    // point the reap would declare a genuine orphan: claude is idle, the
+    // delivered TTL elapsed, and no adopting turn ever minted. But "no adopting
+    // turn" is NOT proof the handback went un-consumed — the session can
+    // consume injected input WITHOUT the gateway minting a turn (zero
+    // session-tail events; the only trace was a `reply` tool call from idle).
+    // If the gateway observed the session consume input after this handback
+    // was delivered (a later turn minting, or a main-session tool call —
+    // claude's single FIFO queue means either proves the earlier delivery
+    // entered the model's context), the handback was already processed:
+    // re-injecting it re-runs an answered report (observed: the same worker
+    // report processed three times). Clean up WITHOUT re-injection.
+    const consumedElsewhere = deps.sessionActivitySince?.(entry.deliveredAt) === true
     entry.consumed = true
-    // GENUINE ORPHAN. Recover DETERMINISTICALLY — never ask the operator to
-    // nudge. Stop the forever-running typing loop, DELETE the frozen card (do
-    // not leave a stale "needs a nudge" message), then re-inject the handback so
-    // the machine re-processes it itself. Cap the re-injections; past the cap
-    // escalate to fleet-health telemetry (NOT a chat card).
-    stopTypingUnlessTurnLive(entry, 'orphan reap')
+    // GENUINE ORPHAN (or consumed-elsewhere cleanup). Recover DETERMINISTICALLY
+    // — never ask the operator to nudge. Stop the forever-running typing loop,
+    // DELETE the frozen card (do not leave a stale "needs a nudge" message),
+    // then — for a genuine orphan only — re-inject the handback so the machine
+    // re-processes it itself. Cap the re-injections; past the cap escalate to
+    // fleet-health telemetry (NOT a chat card).
+    stopTypingUnlessTurnLive(entry, consumedElsewhere ? 'consumed reap' : 'orphan reap')
     if (entry.activityMessageId != null) {
       const record: PreTurnCardRecord = {
         turnKey: entry.syntheticTurnKey,
@@ -518,6 +544,18 @@ export function createHandbackPreturnSignal(
     // synchronously) is not swallowed by the per-topic dedupe guard. The entry
     // object stays valid for the captured re-inject below.
     dropEntry(entry)
+    if (consumedElsewhere) {
+      // Distinct structured line so fleet-health can track how often the
+      // session consumes a handback without a gateway-visible adopting turn
+      // (the underlying session-tail anomaly stays observable even though the
+      // false re-injection is gone).
+      log(
+        `handback-preturn-signal: reap resolved key=${entry.statusKey} ` +
+          `turnId=${entry.adoptTurnId} — session consumed input after delivery ` +
+          `(no adopting turn observed); cleaned up without re-injection\n`,
+      )
+      return
+    }
     if (entry.reinjectCount < maxReinjects) {
       const nextCount = entry.reinjectCount + 1
       // Stamp the counter on the inbound so it survives the buffer round trip

--- a/telegram-plugin/gateway/session-consume-signal.ts
+++ b/telegram-plugin/gateway/session-consume-signal.ts
@@ -1,0 +1,72 @@
+/**
+ * session-consume-signal.ts — "did the claude session consume input after T?"
+ *
+ * Built for the 2026-08-02 klanker false-orphan incident (handback turnId
+ * `#1785628912223`). A background worker's `subagent_handback` was released and
+ * DELIVERED to the bridge at 00:01:53Z; the session consumed it and answered it
+ * (a `reply` tool call at 00:02:58Z, IPC-observed, while the gateway's shadow
+ * state was `bridge_alive_idle`) — but NO gateway turn ever minted for it: the
+ * session-tail produced no `enqueue`/stream events for that consumption, so
+ * `handback-preturn-signal`'s entry was never adopted. After the delivered TTL
+ * the reap declared a genuine orphan and RE-INJECTED the already-answered
+ * handback — twice — re-processing the same worker report three times.
+ *
+ * The orphan reap's existing gates (`isClaudeBusy`, the delivered TTL) key off
+ * gateway-minted TURN state, which is exactly the signal that was absent. This
+ * module tracks the two consumption proxies the gateway CAN always observe,
+ * independent of the session-tail:
+ *
+ *   - a TURN MINT (the `enqueue` seam in stream-render): claude holds a single
+ *     FIFO input queue, so a turn minting for an inbound delivered AFTER the
+ *     handback proves everything delivered before it entered the model's
+ *     context (2026-08-02: real turn `#25821` minted 00:04:13Z and completed,
+ *     while the reap still declared the 00:01:53Z handback orphaned);
+ *   - a MAIN-SESSION MCP TOOL CALL over the IPC bridge (reply, progress_update,
+ *     …): the session can only produce a tool call by processing input, so a
+ *     tool call arriving after the delivery is direct evidence the session is
+ *     alive and consuming — the 00:02:58Z reply was the ONLY observable trace
+ *     of the invisible consumption. Cron/foreign sessions are excluded at the
+ *     call site (their activity says nothing about the main session's queue).
+ *
+ * Consumers ask `activitySince(deliveredAt)`. The deliberate trade: when this
+ * returns true for a handback that was in fact DROPPED before reaching claude
+ * (bridge death in the release→write window) while unrelated session activity
+ * happened to occur, the reap now cleans up instead of re-injecting — a lost
+ * recovery for a rare double-fault, logged distinctly for fleet-health. The
+ * previous behaviour re-injected an already-answered handback on every
+ * invisible consumption, which is the incident that actually occurs.
+ *
+ * Pure state, no I/O; module singleton mirrors `subagentReplyAuthority`.
+ */
+
+export class SessionConsumeSignal {
+  private lastTurnMintAt = 0
+  private lastMainToolCallAt = 0
+
+  /** A gateway turn minted at the `enqueue` seam (stream-render). */
+  noteTurnMint(now: number = Date.now()): void {
+    if (now > this.lastTurnMintAt) this.lastTurnMintAt = now
+  }
+
+  /** A NON-CRON client's MCP tool call arrived over the IPC bridge. The call
+   *  site excludes cron identities — a Tier-1 cheap-cron session consuming its
+   *  own input proves nothing about the main session's queue. */
+  noteMainToolCall(now: number = Date.now()): void {
+    if (now > this.lastMainToolCallAt) this.lastMainToolCallAt = now
+  }
+
+  /** True IFF either consumption proxy was observed strictly after `sinceTs`. */
+  activitySince(sinceTs: number): boolean {
+    return this.lastTurnMintAt > sinceTs || this.lastMainToolCallAt > sinceTs
+  }
+
+  /** Test-only: forget all observations. */
+  reset(): void {
+    this.lastTurnMintAt = 0
+    this.lastMainToolCallAt = 0
+  }
+}
+
+/** The ONE live instance (one CLI session per gateway process — the same
+ *  module-singleton shape as `subagentReplyAuthority`). */
+export const sessionConsumeSignal = new SessionConsumeSignal()

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -75,6 +75,7 @@ import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { decideTurnFlush } from '../turn-flush-safety.js'
 import { FlushCompletionTracker } from '../flushed-turn-supersede.js'
 import { subagentReplyAuthority } from './subagent-reply-authority.js'
+import { sessionConsumeSignal } from './session-consume-signal.js'
 import { decideTerminalReason, deriveTurnRole } from '../turn-liveness-floor.js'
 import { chatKey, chatKeyWithSuffix } from './chat-key.js'
 import { deriveTurnId } from './derive-turn-id.js'
@@ -747,6 +748,10 @@ function beginTurn(deps: StreamRenderDeps, ev: TurnStartEnvelope): void {
     process.stderr.write(
       `telegram gateway: ${formatTurnLifecycle('set', 'enqueue', next, startedAt)}\n`,
     )
+    // Consumption proxy for the handback orphan reap (session-consume-signal):
+    // claude holds ONE FIFO input queue, so this turn minting proves every
+    // inbound delivered before its own entered the model's context.
+    sessionConsumeSignal.noteTurnMint(startedAt)
     // Component 3 — retain in the bounded recently-ended registry so a
     // LATE reply (landing after currentTurn flips to a successor) can
     // still resolve THIS turn's origin thread by its turnId.

--- a/telegram-plugin/tests/answer-ready-flush.test.ts
+++ b/telegram-plugin/tests/answer-ready-flush.test.ts
@@ -30,11 +30,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   shouldArmAnswerReadyFlush,
   resolveAnswerReadyFlushMs,
+  resolveAnswerStageMs,
   ANSWER_READY_FLUSH_MS,
+  ANSWER_STAGE_MS,
   AnswerReadyFlushController,
   type AnswerReadyArmInput,
   type FlushTimerHandle,
 } from '../answer-ready-flush.js'
+import { decideTurnFlush } from '../turn-flush-safety.js'
 import { ToolFlightTracker } from '../gateway/interrupt-defer.js'
 
 const CHAT = '12345'
@@ -174,9 +177,10 @@ class GatewayWorld {
   window = WINDOW
   readonly controller: AnswerReadyFlushController<FakeTurn>
 
-  constructor() {
+  constructor(stageMs = 0) {
     this.currentTurn = { capturedText: [], replyCalled: false, answerReadyFlushTimeoutId: null }
     this.controller = new AnswerReadyFlushController<FakeTurn>({
+      stageWindowMs: stageMs,
       getCurrentTurn: () => this.currentTurn,
       getArmInput: (turn) => ({
         flush: { chatId: CHAT, replyCalled: turn.replyCalled, capturedText: turn.capturedText, flushEnabled: true },
@@ -203,12 +207,30 @@ class GatewayWorld {
   }
 
   /** = handleSessionEvent({turn_end}). A null atom short-circuits (no second
-   *  send); otherwise deliver once and tear the turn down. */
+   *  send); otherwise the turn-flush branch runs the REAL `decideTurnFlush`
+   *  classifier (exactly as stream-render does at turn_end): a reply-served
+   *  turn tears down without a flush send; a captured-answer turn delivers
+   *  once. Then tear the turn down. */
   dispatchTurnEnd(): void {
     const turn = this.currentTurn
     if (turn == null) return // atom already gone → exactly-once
-    this.sends++
+    const d = decideTurnFlush({
+      chatId: CHAT,
+      replyCalled: turn.replyCalled,
+      capturedText: turn.capturedText,
+      flushEnabled: true,
+    })
+    if (d.kind === 'flush') this.sends++
     this.endCurrentTurnAtomic(turn)
+  }
+
+  /** = the model's `reply` tool call landing on the live turn: the canonical
+   *  answer message is sent on the normal reply path and the turn is marked
+   *  reply-served (turn teardown waits for the real turn_end). */
+  onReply(): void {
+    if (this.currentTurn == null) return
+    this.currentTurn.replyCalled = true
+    this.sends++ // the ONE canonical user-visible message
   }
 
   /** = case 'text': push the chunk, then (re)arm via the REAL controller. */
@@ -339,5 +361,127 @@ describe('answer-ready quiescence flush — real controller integration', () => 
     vi.advanceTimersByTime(BACKSTOP_MS)
     expect(w.sends).toBe(0)
     expect(vi.getTimerCount()).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Stage-don't-send (2026-08-02 live repro — klanker DM, msgs 25843/25844).
+// The quiescence flush posted the composed answer at 00:22:02Z; the model's
+// `reply` tool call landed 4 s later (delivered 00:22:36Z as msg 25844, a
+// REWORDING — not containment-equal) while a background sub-agent was live, so
+// the #4176 content-gate hold shipped it FRESH: two near-identical messages.
+// With staging, the quiescence expiry HOLDS the answer on the live turn and
+// only promotes when the completion window closes with no reply — the
+// provisional send (and everything downstream that had to claw it back) never
+// happens. These timelines assert OUTCOMES: user-visible messages sent.
+// ---------------------------------------------------------------------------
+
+const STAGE = 30_000
+
+describe('answer-ready stage-don\'t-send — completion-window staging', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('LIVE REPRO (msgs 25843/25844): a reply landing inside the stage window → exactly ONE message', () => {
+    const w = new GatewayWorld(STAGE)
+    // 00:21:30–00:22:00 — the model streams its terminal narration.
+    w.onText('Yes, that one\'s done, not pending. …the composed terminal answer…')
+    // 00:22:01 — quiescence fires. Pre-fix this SENT msg 25843; staged, it must
+    // send NOTHING (the turn stays live — typing hold — awaiting completion).
+    vi.advanceTimersByTime(WINDOW)
+    expect(w.sends).toBe(0) // ← RED on the immediate-flush behaviour
+    expect(w.currentTurn).not.toBeNull() // turn NOT ended by a provisional flush
+    // 00:22:06 — the model's `reply` lands (the reworded canonical answer).
+    vi.advanceTimersByTime(5_000)
+    w.onReply()
+    expect(w.sends).toBe(1) // the one canonical message (msg 25844)
+    // The stage promotion timer expires → fire-time re-verify sees replyCalled
+    // and DISCARDS the staged text. No second message, ever.
+    vi.advanceTimersByTime(STAGE)
+    expect(w.sends).toBe(1)
+    // The real turn_end finally lands: reply-served → teardown, no flush.
+    w.dispatchTurnEnd()
+    expect(w.sends).toBe(1)
+    expect(w.records).toBe(1)
+    vi.advanceTimersByTime(BACKSTOP_MS)
+    expect(w.sends).toBe(1)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('promotes the staged answer when the completion window closes with NO reply (delivery preserved)', () => {
+    const w = new GatewayWorld(STAGE)
+    w.onText('The composed final answer.')
+    vi.advanceTimersByTime(WINDOW)
+    expect(w.sends).toBe(0) // staged, not sent
+    // No reply, no real turn_end (the KNOWN-UNRELIABLE turn_end case PR A was
+    // built for): the stage window closes → promote through the same flush path.
+    vi.advanceTimersByTime(STAGE - 1)
+    expect(w.sends).toBe(0)
+    vi.advanceTimersByTime(1)
+    expect(w.sends).toBe(1)
+    expect(w.records).toBe(1)
+    // Exactly once: a late real turn_end short-circuits on the null atom.
+    w.dispatchTurnEnd()
+    expect(w.sends).toBe(1)
+  })
+
+  it('a REAL turn_end during the stage window delivers via the turn-flush branch — no double-send', () => {
+    const w = new GatewayWorld(STAGE)
+    w.onText('The composed final answer.')
+    vi.advanceTimersByTime(WINDOW) // staged
+    expect(w.sends).toBe(0)
+    vi.advanceTimersByTime(5_000)
+    w.dispatchTurnEnd() // the true completion signal lands first
+    expect(w.sends).toBe(1) // delivered by the turn-flush branch at turn_end
+    // endCurrentTurnAtomic's clear() cancelled the pending promotion timer.
+    expect(vi.getTimerCount()).toBe(0)
+    vi.advanceTimersByTime(BACKSTOP_MS)
+    expect(w.sends).toBe(1)
+  })
+
+  it('new text during the stage window re-stages (model still composing) and promotes once', () => {
+    const w = new GatewayWorld(STAGE)
+    w.onText('First part of the answer. ')
+    vi.advanceTimersByTime(WINDOW) // staged
+    expect(w.sends).toBe(0)
+    vi.advanceTimersByTime(10_000)
+    w.onText('Second part — the model was still composing.') // re-arms the debounce
+    vi.advanceTimersByTime(WINDOW) // re-staged with a fresh window
+    expect(w.sends).toBe(0)
+    vi.advanceTimersByTime(STAGE)
+    expect(w.sends).toBe(1) // promoted exactly once, with the full text captured
+  })
+
+  it('a tool starting during the stage window discards the stage (model resumed work)', () => {
+    const w = new GatewayWorld(STAGE)
+    w.onText('Interim narration that looked terminal.')
+    vi.advanceTimersByTime(WINDOW) // staged
+    w.onToolUse('bash_1') // clear() → unstaged + promotion timer cancelled
+    vi.advanceTimersByTime(BACKSTOP_MS)
+    expect(w.sends).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('stageMs=0 keeps the legacy immediate flush at quiescence', () => {
+    const w = new GatewayWorld(0)
+    w.onText('The composed final answer.')
+    vi.advanceTimersByTime(WINDOW)
+    expect(w.sends).toBe(1) // legacy: delivered at the ~1 s debounce
+  })
+})
+
+describe('resolveAnswerStageMs', () => {
+  it('defaults to ANSWER_STAGE_MS when unset', () => {
+    expect(resolveAnswerStageMs({})).toBe(ANSWER_STAGE_MS)
+  })
+  it('parses a positive override', () => {
+    expect(resolveAnswerStageMs({ SWITCHROOM_ANSWER_STAGE_MS: '15000' })).toBe(15_000)
+  })
+  it('treats 0 (and negatives) as the legacy immediate flush (0)', () => {
+    expect(resolveAnswerStageMs({ SWITCHROOM_ANSWER_STAGE_MS: '0' })).toBe(0)
+    expect(resolveAnswerStageMs({ SWITCHROOM_ANSWER_STAGE_MS: '-5' })).toBe(0)
+  })
+  it('fails safe to the default on an unparseable value', () => {
+    expect(resolveAnswerStageMs({ SWITCHROOM_ANSWER_STAGE_MS: 'soon' })).toBe(ANSWER_STAGE_MS)
   })
 })

--- a/telegram-plugin/tests/handback-preturn-signal.test.ts
+++ b/telegram-plugin/tests/handback-preturn-signal.test.ts
@@ -12,6 +12,7 @@ import {
   type PreTurnCardRecord,
 } from '../gateway/handback-preturn-signal.js'
 import { createTurnTypingLoop } from '../gateway/turn-typing-loop.js'
+import { SessionConsumeSignal } from '../gateway/session-consume-signal.js'
 import type { InboundMessage } from '../gateway/ipc-protocol.js'
 
 /**
@@ -469,6 +470,82 @@ describe('handback-preturn-signal — dead-air pre-turn emit→adopt→reap', ()
     expect(h.reinjected).toHaveLength(1)
     expect(h.escalations).toEqual([])
     expect(h.signal.pendingCount()).toBe(0)
+  })
+
+  // ── 2026-08-02 LIVE REPRO REPLAY (klanker, turnId #1785628912223) ──
+  // A handback was released+delivered at T0; the session CONSUMED it and
+  // answered (a reply tool call from idle at T0+65s — the only observable
+  // trace; no adopting turn ever minted), a later real turn minted and
+  // completed — yet at T0+TTL the reap declared a genuine orphan and
+  // RE-INJECTED the already-answered report (attempt 1/2 at 00:06:53Z,
+  // 2/2 at 00:11:58Z, escalation 00:17:34Z). The invisible-consumption gate
+  // must clean up WITHOUT re-injection. This test is RED on the pre-fix seam
+  // (it re-injects) and GREEN with `sessionActivitySince` consulted.
+  it('does NOT re-inject a handback the session already consumed (reply-from-idle after delivery)', async () => {
+    const consume = new SessionConsumeSignal()
+    const h = makeHarness({
+      deliveredTtlMs: 300_000,
+      sessionActivitySince: (sinceTs) => consume.activitySince(sinceTs),
+    })
+    // T0: release (= delivery) — pre-turn entry armed, card painted at debounce.
+    h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatConsumed', messageId: 900 }))
+    await h.sched.advance(700)
+    const cardId = await h.openCard.mock.results[0]!.value
+    expect(h.records.size).toBe(1)
+
+    // T0+65s: the session answers the handback — a main-session reply tool
+    // call observed over IPC while the gateway shows no live turn (the
+    // 00:02:58Z reply). NO gateway turn ever mints, so tryAdopt never fires.
+    await h.sched.advance(65_000)
+    consume.noteMainToolCall(h.sched.now())
+
+    // T0+TTL and beyond: the reap fires (idle, delivered TTL elapsed). The
+    // consumption evidence must resolve the entry WITHOUT re-injection and
+    // WITHOUT escalation — the frozen card is deleted, typing stops, entry
+    // dropped. OUTCOME: zero re-injected inbounds ever reach the buffer.
+    await h.sched.advance(600_000)
+    expect(h.reinjected).toEqual([])
+    expect(h.escalations).toEqual([])
+    expect(h.deletedIds).toEqual([cardId])
+    expect(h.records.size).toBe(0)
+    expect(h.signal.pendingCount()).toBe(0)
+    expect(h.typing.activeCount()).toBe(0)
+  })
+
+  it('a later turn MINT after delivery also counts as consumption (coalesced-turn case)', async () => {
+    const consume = new SessionConsumeSignal()
+    const h = makeHarness({
+      deliveredTtlMs: 300_000,
+      sessionActivitySince: (sinceTs) => consume.activitySince(sinceTs),
+    })
+    h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatCoalesced', messageId: 901 }))
+    await h.sched.advance(700)
+    // A real user turn mints AFTER the delivery (the 00:04:13Z turn #25821):
+    // FIFO queue ⇒ the earlier-delivered handback entered the model context.
+    await h.sched.advance(140_000)
+    consume.noteTurnMint(h.sched.now())
+    await h.sched.advance(600_000)
+    expect(h.reinjected).toEqual([])
+    expect(h.escalations).toEqual([])
+    expect(h.signal.pendingCount()).toBe(0)
+  })
+
+  it('still re-injects a GENUINE orphan (no session activity since delivery)', async () => {
+    const consume = new SessionConsumeSignal()
+    const h = makeHarness({
+      deliveredTtlMs: 300_000,
+      sessionActivitySince: (sinceTs) => consume.activitySince(sinceTs),
+    })
+    // Activity BEFORE the delivery must not mask a genuine orphan.
+    consume.noteMainToolCall(h.sched.now())
+    await h.sched.advance(10)
+    h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatDead', messageId: 902 }))
+    await h.sched.advance(700)
+    // Nothing consumes anything; past the TTL the deterministic recovery must
+    // still fire exactly as before the gate (delete + re-inject, no nudge).
+    await h.sched.advance(600_000)
+    expect(h.reinjected).toHaveLength(1)
+    expect(h.deletedIds).toHaveLength(1)
   })
 
   // ── deterministic-recovery retry cap: re-inject up to 2×, THEN escalate ──


### PR DESCRIPTION
## Summary

Two delivery races reproduced **live** on klanker at 2026-08-02 ~00:22Z (DM `8248703757`, gateway-supervisor.log) and **both survive on current origin/main HEAD**:

### Race 1 — flush-then-late-reply duplicate (msgs 25843/25844)

Timeline (log evidence):
- `00:22:01.453` `answer-ready quiescence flush — delivering composed terminal answer`
- `00:22:02.043` `turn-flush firing — 911 chars without reply tool` → **msg 25843 sent**
- `00:22:06.556` the model's canonical `reply` tool call lands (4 s later, turn `#25840` resolved `via=recovered`)
- `00:22:36.862` → **msg 25844 sent** — a REWORDING of 25843 (verified against `history.db`: "That's a separate piece…" vs "It's a separate piece…"), not whitespace-equal, not ≥32-char containment.

Why #4167 (v0.19.45) does NOT close this exact instance: a background sub-agent was live at reply time (`obligation sweep deferred — in-flight autonomous sub-agent work (1 open)` at 00:22:04), so the #4176 liveness hold correctly refuses the content-gate bypass (`subagent-reply-authority.ts`), `flushedAnswerMatchesReply` fails on the rewording, and the reply ships fresh — the residual documented in that module's header ("a REWORDED own-answer shipping as a visible duplicate"). For a delegation-heavy agent a live sub-agent is the common case.

**Fix — stage-don't-send** (`answer-ready-flush.ts`): the quiescence expiry now STAGES the composed answer on the still-live turn (turn not ended → typing hold) and promotes only when the completion window closes with no reply:
- reply lands in the window → stage discarded, ONE message (the canonical reply, normal path);
- real `turn_end` lands → the existing turn-flush branch delivers (promotion at the true completion signal);
- neither (the known-unreliable-turn_end case PR A targeted) → promote after `ANSWER_STAGE_MS` (30 s, env `SWITCHROOM_ANSWER_STAGE_MS`, `0` = legacy immediate flush).

The provisional send — and the supersede claw-back machinery it forces downstream — never happens. The supersede registry stays untouched as the backstop for replies landing after a promotion.

### Race 2 — false-orphan re-injection of an already-answered handback (turnId `#1785628912223`)

Timeline (log evidence):
- `00:01:53.068` handback released+delivered (`armed=yes`)
- `00:02:58.920` the session ANSWERS it — `reply` from idle ("Calendar PR reviewed clean and queued to merge", `global=bridge_alive_idle`) with **zero session-tail events**: no gateway turn ever minted, so `tryAdopt` never fired
- `00:04:13` real turn `#25821` mints and completes — further FIFO proof the delivery was consumed
- `00:06:53` / `00:11:58` orphan reap **re-injects the answered report** (attempts 1/2, 2/2); `00:17:34` escalation

`handback-preturn-signal.ts` is byte-identical between v0.19.43 (klanker's runtime) and main — **not fixed on main**. The reap's gates (`isClaudeBusy`, delivered TTL) key off gateway-minted turn state, which is exactly the signal that was absent.

**Fix — invisible-consumption gate** (`gateway/session-consume-signal.ts`, new): at the moment the reap would declare a genuine orphan, it consults gateway-observed consumption proxies — any turn mint at the enqueue seam, or any main-session (non-cron) IPC tool call, after the delivery; claude holds ONE FIFO input queue, so either proves the delivered handback entered the model's context. When true: clean up (card + typing + entry, distinct fleet-health log line) **without re-injection**. A genuine dead-session orphan (no activity since delivery) still re-injects up to the cap exactly as before (#4104 behaviour preserved, pinned by test).

### Merged-PR survey (per Ken's instruction)

Surveyed all commits since v0.19.43 touching the delivery machinery: only `1c991f2d` (#4167, v0.19.45) is in this area. It fixes the identity/window/foreign-session variants of race 1 but not this live timeline (rewording + live sub-agent), and touches race 2 not at all. Deploying v0.19.45 is still worthwhile but does not fix either observed bug.

## Test plan

Regression tests **replay the live timelines** and assert outcomes (messages sent / inbounds re-injected), not flags:
- `tests/handback-preturn-signal.test.ts` — `does NOT re-inject a handback the session already consumed` and `a later turn MINT after delivery also counts` are **RED on the pre-fix seam** (verified: 2 fail on stashed fix), plus `still re-injects a GENUINE orphan` pins the recovery path.
- `tests/answer-ready-flush.test.ts` — `LIVE REPRO (msgs 25843/25844)` is **RED on immediate-flush behaviour** (`stageMs=0` world sends 2 messages); plus promote-on-window-close, real-turn_end-during-stage, re-stage-on-new-text, tool-discard, legacy `stageMs=0`, and `resolveAnswerStageMs` units.

Local: `tsc --noEmit` clean; full `npm run lint` green (gateway line ratchet respected: 24917 ≤ 24867+50); scoped vitest 208/208 across 9 delivery-path suites; dual-runner check `bun test` 54/54 on the two edited suites; full `telegram-plugin/tests` vitest 8724 passed, 1 pre-existing env-only failure (`approval-hold-record.test.ts` root-uid artifact — fails identically on pristine main).

## Risk

- Stage window adds up to 30 s latency ONLY for a silent-terminal-text turn whose real turn_end never lands (vs the ~150 s backstop PR A replaced; the common case promotes at the real turn_end within seconds). Operator kill-switch: `SWITCHROOM_ANSWER_STAGE_MS=0` restores the immediate flush.
- The consumption gate trades re-injection coverage in a rare double-fault (handback dropped pre-bridge AND unrelated session activity since) for eliminating the observed re-injection of answered reports; the cleanup path logs a distinct line so fleet-health keeps seeing the underlying session-tail anomaly (a session consuming injected input with no `enqueue` event — worth a follow-up issue).

Follow-up filed as part of review: extend stage-don't-send to the older turn-end backstop flush if the same provisional-send class is observed there.

Job spec: `reference/jobs/always-available.md` — exactly one answer, delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)