### PR TITLE
fix(rollout): quiet ensure-banks when Hindsight is transiently busy

### DIFF
--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -45,6 +45,8 @@ import {
   type RolloutResult,
   type RolloutStep,
   VERIFY_COMPONENTS_STEP,
+  ENSURE_BANKS_ATTEMPTS,
+  ENSURE_BANKS_BACKOFF_MS,
   evaluateRolloutDrift,
   createRolloutDeps,
   isSpawnTimeout,
@@ -281,6 +283,7 @@ function harness(opts: {
   persisted: string[];
   phases: RolloutPhase[];
   ensureBankCalls: string[];
+  sleeps: number[];
 } {
   const runs: string[][] = [];
   const runEnvs: Array<Record<string, string> | undefined> = [];
@@ -288,6 +291,7 @@ function harness(opts: {
   const persisted: string[] = [];
   const phases: RolloutPhase[] = [];
   const ensureBankCalls: string[] = [];
+  const sleeps: number[] = [];
   const deps: RolloutDeps = {
     run: (args, runOpts) => {
       runs.push(args);
@@ -304,6 +308,12 @@ function harness(opts: {
     hindsightExists: () => opts.hindsightExists ?? false,
     webImageTag: () => opts.webImageTag ?? null,
     collectComponents: () => opts.components ?? [],
+    // Instant fake so the ensure-banks retry backoff is exercised without
+    // wall-clock delay; the requested waits are recorded for assertions.
+    sleepMs: (ms: number) => {
+      sleeps.push(ms);
+      return Promise.resolve();
+    },
     // Wired unless the test explicitly passes `ensureBank: null`. The default
     // reports every bank present; a custom verdict drives the backstop's
     // degrade/fail branches.
@@ -316,7 +326,7 @@ function harness(opts: {
           },
         }),
   };
-  return { deps, runs, runEnvs, logs, persisted, phases, ensureBankCalls };
+  return { deps, runs, runEnvs, logs, persisted, phases, ensureBankCalls, sleeps };
 }
 
 describe("executeRollout", () => {
@@ -590,25 +600,35 @@ describe("executeRollout — ensure-banks backstop", () => {
     expect(r.rolled).toEqual(["clerk", "marko"]);
   });
 
-  it("an UNREACHABLE probe degrades to a warning, not a roll failure", async () => {
+  it("an UNREACHABLE probe is retried with backoff, then degrades to a quiet log line — NOT a per-agent warning", async () => {
     const steps = planRollout(["clerk"]);
-    const { deps } = harness({
+    const { deps, ensureBankCalls, sleeps, logs } = harness({
       versions: { clerk: "0.15.18" },
       hindsightExists: true,
       ensureBank: () => ({ ok: false as const, reason: "Unreachable" }),
     });
     const r = await executeRollout(steps, TARGET, deps);
-    // A transient probe miss is not proof the bank is absent — each agent's own
-    // reconcile already had its chance — so the roll still SUCCEEDS with a
-    // named warning rather than a false-negative structural failure.
+    // A probe that can't get through is an environment limitation, not proof
+    // any bank is absent (#2781 philosophy) — the roll still SUCCEEDS.
     expect(r.ok).toBe(true);
     expect(r.drifted).toBeUndefined();
-    expect(r.warnings.join(" ")).toMatch(/could not reach Hindsight/);
+    // Retried before concluding unreachable, with the documented backoff.
+    expect(ensureBankCalls).toEqual(Array(ENSURE_BANKS_ATTEMPTS).fill("clerk"));
+    expect(sleeps).toEqual([...ENSURE_BANKS_BACKOFF_MS]);
+    // NO operator-facing alarm: the v0.19.46 roll emitted the per-agent
+    // "restart it to recreate the bank" warning 12 times while every bank
+    // sat healthy. That text must not reappear on this path.
+    expect(r.warnings).toEqual([]);
+    // The degrade is still visible — ONE informational log line that says
+    // there is nothing to do, not a data-loss implication.
+    const note = logs.filter((l) => /existing banks are unaffected/.test(l));
+    expect(note).toHaveLength(1);
+    expect(note[0]).toContain("clerk");
   });
 
-  it("a TIMEOUT probe also degrades to a warning (couldn't verify, not a rejection)", async () => {
+  it("a TIMEOUT probe also degrades quietly after retries (couldn't verify, not a rejection)", async () => {
     const steps = planRollout(["clerk"]);
-    const { deps } = harness({
+    const { deps, ensureBankCalls, logs } = harness({
       versions: { clerk: "0.15.18" },
       hindsightExists: true,
       // createBank normalizes an aborted probe to reason "Timeout".
@@ -617,7 +637,74 @@ describe("executeRollout — ensure-banks backstop", () => {
     const r = await executeRollout(steps, TARGET, deps);
     expect(r.ok).toBe(true);
     expect(r.drifted).toBeUndefined();
-    expect(r.warnings.join(" ")).toMatch(/could not reach Hindsight/);
+    expect(ensureBankCalls).toEqual(Array(ENSURE_BANKS_ATTEMPTS).fill("clerk"));
+    expect(r.warnings).toEqual([]);
+    expect(logs.filter((l) => /existing banks are unaffected/.test(l))).toHaveLength(1);
+  });
+
+  it("a consolidation blip that clears on retry is a clean pass — no note, no warning", async () => {
+    const steps = planRollout(["clerk"]);
+    let calls = 0;
+    const { deps, sleeps, logs } = harness({
+      versions: { clerk: "0.15.18" },
+      hindsightExists: true,
+      // First probe times out (hindsight busy), second succeeds.
+      ensureBank: () =>
+        ++calls === 1 ? { ok: false as const, reason: "Timeout" } : { ok: true as const },
+    });
+    const r = await executeRollout(steps, TARGET, deps);
+    expect(r.ok).toBe(true);
+    expect(calls).toBe(2);
+    expect(sleeps).toEqual([ENSURE_BANKS_BACKOFF_MS[0]]);
+    expect(r.warnings).toEqual([]);
+    expect(logs.filter((l) => /existing banks are unaffected/.test(l))).toHaveLength(0);
+    expect(logs.some((l) => /clerk: bank present/.test(l))).toBe(true);
+  });
+
+  it("MANY unreachable agents produce ONE consolidated note, never a per-agent alarm", async () => {
+    const steps = planRollout(["clerk", "marko", "nadia"]);
+    const { deps, logs, ensureBankCalls, sleeps } = harness({
+      versions: { clerk: "0.15.18", marko: "0.15.18", nadia: "0.15.18" },
+      hindsightExists: true,
+      ensureBank: () => ({ ok: false as const, reason: "Unreachable" }),
+    });
+    const r = await executeRollout(steps, TARGET, deps);
+    expect(r.ok).toBe(true);
+    expect(r.warnings).toEqual([]);
+    const note = logs.filter((l) => /existing banks are unaffected/.test(l));
+    expect(note).toHaveLength(1);
+    expect(note[0]).toContain("3 bank(s)");
+    expect(note[0]).toContain("clerk, marko, nadia");
+    // Only the FIRST agent burns the full retry budget; once that concludes
+    // Hindsight is unreachable, later agents get a single probe each so a
+    // 12-agent fleet does not stall the roll for minutes of backoff.
+    expect(ensureBankCalls).toEqual([
+      ...Array(ENSURE_BANKS_ATTEMPTS).fill("clerk"),
+      "marko",
+      "nadia",
+    ]);
+    expect(sleeps).toEqual([...ENSURE_BANKS_BACKOFF_MS]);
+  });
+
+  it("Hindsight REACHABLE but the create definitively rejected still fails the roll (no retry — a real answer)", async () => {
+    const steps = planRollout(["clerk"]);
+    const { deps, ensureBankCalls, sleeps } = harness({
+      versions: { clerk: "0.15.18" },
+      hindsightExists: true,
+      ensureBank: () => ({
+        ok: false as const,
+        reason: "create_bank returned error: bank rejected",
+      }),
+    });
+    const r = await executeRollout(steps, TARGET, deps);
+    // The real brand-new-bank signal is PRESERVED: a definitive rejection
+    // from a reachable Hindsight is structural, and it is answered on the
+    // first probe — retrying a real answer would only slow the roll.
+    expect(r.ok).toBe(false);
+    expect(r.failedStep).toBe("ensure-banks");
+    expect(r.drifted).toEqual(["clerk"]);
+    expect(ensureBankCalls).toEqual(["clerk"]);
+    expect(sleeps).toEqual([]);
   });
 
   it("no-ops (never calls ensureBank) when no hindsight container exists", async () => {

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -115,6 +115,23 @@ export const VERIFY_COMPONENTS_STEP = "verify-components";
  */
 export const ENSURE_BANKS_STEP = "ensure-banks";
 
+/**
+ * How many times the ensure-banks backstop probes a bank whose check came
+ * back Unreachable/Timeout before concluding Hindsight is genuinely down
+ * (total attempts, including the first), and how long it waits between
+ * attempts.
+ *
+ * Why retry at all: the roll's ensure-banks step runs while Hindsight is
+ * routinely busy (post-restart warm-up, consolidation load), and a single
+ * 5s probe timing out is far more often "Hindsight is busy" than "Hindsight
+ * is down". Before this retry existed, one busy blip during a fleet roll
+ * emitted a scary per-agent "could not verify <agent>'s bank … restart it
+ * to recreate the bank" warning for EVERY agent — 12 false alarms on the
+ * v0.19.46 roll while every bank sat healthy on the persistent pg volume.
+ */
+export const ENSURE_BANKS_ATTEMPTS = 3;
+export const ENSURE_BANKS_BACKOFF_MS: readonly number[] = [2_000, 5_000];
+
 export interface RolloutPlanOpts {
   /** Skip the web + hostd + hindsight refresh (step 3). */
   skipWeb?: boolean;
@@ -608,15 +625,27 @@ export interface RolloutDeps {
    * Production wires this to `createBank(apiUrl, bankIdFor(agent))` — needs
    * only a bank id + api url, no container reconcile — and it is idempotent.
    * Tests inject a fake that reports a bank present or missing. A false result
-   * whose `reason` is "Unreachable" degrades to a warning (each agent's own
-   * restart-reconcile already had its chance); any other failure is a
-   * structural, roll-failing residue (verify-components-class), NOT an
-   * operator instruction to run a host command.
+   * whose `reason` is "Unreachable"/"Timeout" is retried with backoff
+   * ({@link ENSURE_BANKS_ATTEMPTS} / {@link ENSURE_BANKS_BACKOFF_MS}) and, if
+   * it persists, degrades to a single quiet log line — NOT a warning: the
+   * probe not getting through is an environment limitation, not evidence any
+   * bank is absent, and each agent's own restart-reconcile already had its
+   * chance (#2781 philosophy). Any other failure is a structural,
+   * roll-failing residue (verify-components-class), NOT an operator
+   * instruction to run a host command.
    *
    * Optional — when unwired (no hindsight, or a test that never reaches the
    * step) the `ensure-banks` step is a clean no-op.
    */
   ensureBank?(agent: string): Promise<{ ok: true } | { ok: false; reason: string }>;
+  /**
+   * Sleep between `ensureBank` retry attempts (the ensure-banks backstop
+   * retries an Unreachable/Timeout probe with backoff before concluding
+   * Hindsight is down — a consolidation blip must not read as an outage).
+   * Defaults to a real `setTimeout` wait; tests inject an instant fake so
+   * the retry loop is exercised without wall-clock delay.
+   */
+  sleepMs?(ms: number): Promise<void>;
   /**
    * Probe whether the standalone `switchroom-hindsight` container exists on
    * this host (the `refresh-hindsight` step no-ops cleanly when it doesn't).
@@ -1403,38 +1432,86 @@ export async function executeRollout(
           deps.log(
             `ROLL_STEP ensure-banks — creating any missing agent bank (idempotent) for ${rolled.length} agent(s)`,
           );
+          const sleep =
+            deps.sleepMs ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+          const bankUnverified: string[] = [];
+          let lastUnreachableReason = "";
+          // Once ONE agent's full retry budget concludes unreachable, later
+          // agents get a single probe each (they'd almost certainly hit the
+          // same wall, and 12 agents × full backoff would stall the roll for
+          // minutes) — but still one probe, since Hindsight may come back
+          // mid-loop.
+          let concludedUnreachable = false;
           for (const a of rolled) {
-            let res: { ok: true } | { ok: false; reason: string };
-            try {
-              res = await deps.ensureBank(a);
-            } catch (e) {
-              res = { ok: false, reason: (e as Error).message };
+            let res: { ok: true } | { ok: false; reason: string } = {
+              ok: false,
+              reason: "not probed",
+            };
+            // Retry an Unreachable/Timeout probe with backoff before
+            // concluding anything: Hindsight is routinely busy during a roll
+            // (post-restart warm-up, consolidation load) and a single 5s
+            // probe miss is usually "busy", not "down". A DEFINITIVE create
+            // rejection is never retried — it is a real answer.
+            const maxAttempts = concludedUnreachable ? 1 : ENSURE_BANKS_ATTEMPTS;
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              try {
+                res = await deps.ensureBank(a);
+              } catch (e) {
+                res = { ok: false, reason: (e as Error).message };
+              }
+              if (res.ok || !/unreachable|timeout/i.test(res.reason)) break;
+              if (attempt < maxAttempts) {
+                const backoff =
+                  ENSURE_BANKS_BACKOFF_MS[attempt - 1] ??
+                  ENSURE_BANKS_BACKOFF_MS[ENSURE_BANKS_BACKOFF_MS.length - 1] ??
+                  0;
+                deps.log(
+                  `  ${a}: bank check ${res.reason.toLowerCase()} — retrying in ${backoff}ms ` +
+                    `(attempt ${attempt}/${maxAttempts})`,
+                );
+                await sleep(backoff);
+              }
             }
             if (res.ok) {
               deps.log(`  ${a}: bank present`);
               continue;
             }
             if (/unreachable|timeout/i.test(res.reason)) {
-              // Degrade, do NOT fail: the hindsight endpoint was momentarily
-              // unreachable from the roll process, or the probe timed out
-              // (createBank normalizes ECONNREFUSED/undici-connect to
-              // "Unreachable" and an abort to "Timeout"). Neither is proof the
-              // bank is absent — each agent's own restart-reconcile already had
-              // its chance to create it (and did, for every existing agent, off
-              // the persistent pg volume). Only a DEFINITIVE create rejection
-              // (an HTTP error or an MCP isError envelope) fails the roll;
-              // "couldn't reach it to check" is a warning, not a false-negative
-              // residue that drags a converged fleet backwards.
-              deps.log(`  ${a}: bank check ${res.reason.toLowerCase()} (degraded to warning)`);
-              warnings.push(
-                `ensure-banks could not reach Hindsight to verify ${a}'s bank ` +
-                  `(${res.reason}). If ${a} is brand-new and its first \`retain\` ` +
-                  `fails with a foreign-key error, restart it to recreate the bank.`,
+              // Still unreachable after the retries. Degrade QUIETLY, do NOT
+              // warn per-agent: "couldn't reach Hindsight to check" is an
+              // environment limitation of THIS probe, not evidence any bank
+              // is absent (same philosophy as apply's vault-broker-unreachable
+              // degrade, #2781). Every existing agent's bank persists on the
+              // pg volume and its own restart-reconcile already had its
+              // chance to create a missing one — so there is nothing for the
+              // operator to do, and a per-agent "restart it to recreate the
+              // bank" alarm here cried wolf 12 times on the v0.19.46 roll
+              // while every bank sat healthy. A truly brand-new agent whose
+              // bank never got created self-heals on its next
+              // restart-reconcile. The genuinely-broken case — Hindsight
+              // REACHABLE and the create definitively rejected — still falls
+              // through to `bankEnsureFailed` below and fails the roll.
+              deps.log(
+                `  ${a}: bank check ${res.reason.toLowerCase()} after ` +
+                  `${maxAttempts} attempt(s) (transient — not treated as a missing bank)`,
               );
+              bankUnverified.push(a);
+              lastUnreachableReason = res.reason;
+              concludedUnreachable = true;
               continue;
             }
             deps.log(`  ✗ ${a}: bank could NOT be created — ${res.reason}`);
             bankEnsureFailed.push(a);
+          }
+          if (bankUnverified.length > 0) {
+            // ONE informational line for the whole roll, in the log — not in
+            // `warnings`, which renders as an operator-facing alarm.
+            deps.log(
+              `ensure-banks: Hindsight was busy/unreachable (${lastUnreachableReason}) while ` +
+                `verifying ${bankUnverified.length} bank(s) (${bankUnverified.join(", ")}) — ` +
+                `existing banks are unaffected and nothing needs doing; a brand-new agent's ` +
+                `bank is created automatically on its next restart-reconcile.`,
+            );
           }
           break;
         }


### PR DESCRIPTION
## Summary
The rollout's terminal `ensure-banks` backstop probed each agent's bank once (5s) and, on `Unreachable`/`Timeout`, pushed a per-agent operator warning implying possible data loss ("…restart it to recreate the bank"). On the v0.19.46 roll Hindsight was briefly busy under consolidation load and this fired for **all 12 agents** while every bank was demonstrably healthy on the persistent pg volume — a false alarm that can't tell "Hindsight is busy" from "bank is genuinely absent".

## Why / what changed
Same philosophy as apply's vault-broker-unreachable degrade (#2781): *unreachable is an environment limitation of the probe, not evidence a bank is absent.*

- **Retry with backoff** (`ENSURE_BANKS_ATTEMPTS = 3`, backoff 2s/5s) on Unreachable/Timeout before concluding anything, so a consolidation blip never trips the step. Once one agent's full budget concludes unreachable, later agents get a single probe each — a 12-agent fleet doesn't stall the roll for minutes of backoff.
- **Transient-unreachable ≠ bank-absent.** Still-unreachable after retries now degrades to ONE quiet informational log line for the whole roll ("existing banks are unaffected and nothing needs doing; a brand-new agent's bank is created automatically on its next restart-reconcile") — never an operator-facing `warnings[]` alarm.
- **The real signal is preserved:** a DEFINITIVE create rejection from a *reachable* Hindsight is never retried (a real answer) and still fails the roll structurally via `bankEnsureFailed`/`drifted[]`, exactly as before. The unwired-hook warning is also unchanged.

Job spec: `reference/jobs/idempotent-update-and-restart.md` — the operator must be able to trust what a roll reports; 12 spurious data-loss warnings per roll erode that trust.

## Test plan
- `src/cli/rollout.test.ts` (164 tests green): rewrote the two degrade tests and added outcome coverage —
  - unreachable after retries → roll ok, `warnings` **empty**, exactly one quiet note, retry count + backoff asserted
  - timeout path same
  - blip that clears on retry → clean pass, no note
  - many unreachable agents → ONE consolidated note; only the first agent burns the retry budget
  - reachable-but-rejected → still fails the roll, no retry, `drifted: [agent]`
- `tsc --noEmit` green; full `npm run lint` green; adjacent `src/memory/hindsight-*` suites green.

## Risk
Low — confined to the `ensure-banks` step of `executeRollout`. Worst case on a genuinely-down Hindsight: ~7s of added backoff for the first agent, then single probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)