### PR TITLE
feat: default reflect budget mid + per-agent reflect_budget/reflect_max_tokens

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -485,6 +485,8 @@ A persona without its own memory is cosplay: banks should be *specialized*, not 
 | --- | --- | --- | --- |
 | `reflect_mission` | string | override | The bank's "who am I / what matters" framing applied during recall/reflect. Engine-accurate name for what `bank_mission` sets. |
 | `bank_mission` | string | override | **Alias** for `reflect_mission` (retained for back-compat — switchroom's `bank_mission` lands in the engine's `reflect_mission`). If both are set, `reflect_mission` wins. |
+| `reflect_budget` | `low`\|`mid`\|`high` | override | Budget injected into reflect MCP calls when the caller omits it. Shim default `mid`; explicit per-call `budget` always wins. stdio-shim transport only. Needs `switchroom apply` to reach existing agents. |
+| `reflect_max_tokens` | number (≤8192) | override | Token cap injected into reflect MCP calls when the caller omits it. Shim default `1024`; explicit per-call `max_tokens` always wins. stdio-shim transport only. Needs `switchroom apply` to reach existing agents. |
 | `retain_mission` | string | override | What the fact-extraction LLM keeps during auto-retain. Defaults to a curated mission on fresh agents. |
 | `observations_mission` | string | override | What the observation-consolidation LLM synthesizes from raw facts (the higher-order "what patterns matter" lens). |
 | `disposition` | object | **per-key merge** | Personality traits (`skepticism` / `literalism` / `empathy`, each `1`–`5`, engine default `3`) shaping recall/reflect/observation framing. |

--- a/docs/operators/hindsight-memory.md
+++ b/docs/operators/hindsight-memory.md
@@ -489,6 +489,7 @@ override / per-key merge, `src/config/schema.ts`):
 |-------|--------|
 | `memory.retain_mission` | steers fact extraction on retain |
 | `memory.reflect_mission` (a.k.a. legacy `bank_mission`) | steers the reflect read path |
+| `memory.reflect_budget` | `low`\|`mid`\|`high` budget injected into reflect MCP calls when the caller omits it (shim default `mid`); explicit per-call `budget` wins; stdio-shim transport only |
 | `memory.observations_mission` | steers observation synthesis |
 | `memory.disposition` | `{ skepticism, literalism, empathy }` (0–5 each), per-key inheritable |
 

--- a/src/cli/hindsight-mcp-shim.ts
+++ b/src/cli/hindsight-mcp-shim.ts
@@ -59,6 +59,13 @@
  *                             and the PINNED bank for the synthesized
  *                             directive tools
  *   HINDSIGHT_SHIM_CACHE_DIR  where the cached tools/list manifest lives
+ *   HINDSIGHT_SHIM_RECALL_MAX_TOKENS / HINDSIGHT_SHIM_REFLECT_MAX_TOKENS
+ *                             per-tool max_tokens injected when the caller
+ *                             omits it (default 1024 each; explicit wins)
+ *   HINDSIGHT_SHIM_RECALL_BUDGET / HINDSIGHT_SHIM_REFLECT_BUDGET
+ *                             per-tool budget injected when the caller omits
+ *                             it (default recall low, reflect mid; explicit
+ *                             wins; garbage falls back to the default)
  */
 
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
@@ -445,9 +452,28 @@ export function redactToolCallParams(params: unknown): unknown {
  * max_tokens=1024). Explicit caller values always win — see
  * {@link guardAndClampToolCall}. Tunable via
  * `HINDSIGHT_SHIM_RECALL_MAX_TOKENS` / `HINDSIGHT_SHIM_REFLECT_MAX_TOKENS`.
+ *
+ * The companion `budget` default lives in {@link DEFAULT_RECALL_BUDGET} /
+ * {@link DEFAULT_REFLECT_BUDGET}, tunable via
+ * `HINDSIGHT_SHIM_RECALL_BUDGET` / `HINDSIGHT_SHIM_REFLECT_BUDGET`.
  */
 export const DEFAULT_RECALL_MAX_TOKENS = 1024;
 export const DEFAULT_REFLECT_MAX_TOKENS = 1024;
+
+/**
+ * Injected `budget` for a bare `recall` / `reflect` when the caller names
+ * none. Recall stays "low" (fast, shallow — it fires on every inbound turn).
+ * Reflect ships "mid": budget:"low" bounded reflect depth but made
+ * slightly-off queries return empty; the original overflow hazard was driven
+ * by max_tokens (still clamped to 1024, see above), so "mid" cannot resurrect
+ * it — the only cost of "mid" is added reflect latency / backend compute.
+ * Explicit caller values always win. Tunable via
+ * `HINDSIGHT_SHIM_RECALL_BUDGET` / `HINDSIGHT_SHIM_REFLECT_BUDGET`.
+ */
+export const DEFAULT_RECALL_BUDGET = "low";
+export const DEFAULT_REFLECT_BUDGET = "mid";
+
+const VALID_BUDGETS = new Set(["low", "mid", "high"]);
 
 /** Parse a positive-int env override, falling back on absent/garbage input. */
 function resolveClampMaxTokens(
@@ -457,6 +483,15 @@ function resolveClampMaxTokens(
   if (envVal === undefined || envVal === "") return fallback;
   const n = Number.parseInt(envVal, 10);
   return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/** Parse a budget env override, falling back on absent/garbage input. */
+function resolveClampBudget(
+  envVal: string | undefined,
+  fallback: string,
+): string {
+  if (envVal === undefined || envVal === "") return fallback;
+  return VALID_BUDGETS.has(envVal) ? envVal : fallback;
 }
 
 /** The accepted-argument union (required ∪ optional) for a table tool. */
@@ -503,9 +538,9 @@ function unknownArgMessage(
  *     drop. Tools not in the table are passed through unvalidated (no ground
  *     truth to validate against).
  *  2. DEFAULT BUDGET CLAMP — for `recall`/`reflect` only, inject
- *     max_tokens (env-tunable) + budget:"low" when the caller OMITS them.
- *     Explicit caller values ALWAYS win (a deliberate max_tokens:4096 passes
- *     untouched).
+ *     max_tokens (env-tunable) + budget (env-tunable; recall low, reflect
+ *     mid) when the caller OMITS them. Explicit caller values ALWAYS win (a
+ *     deliberate max_tokens:4096 passes untouched).
  *
  * Returns the (possibly rewritten) params to forward, or a loud error text.
  */
@@ -548,7 +583,18 @@ export function guardAndClampToolCall(
               DEFAULT_REFLECT_MAX_TOKENS,
             );
     }
-    if (injected.budget === undefined) injected.budget = "low";
+    if (injected.budget === undefined) {
+      injected.budget =
+        name === "recall"
+          ? resolveClampBudget(
+              env.HINDSIGHT_SHIM_RECALL_BUDGET,
+              DEFAULT_RECALL_BUDGET,
+            )
+          : resolveClampBudget(
+              env.HINDSIGHT_SHIM_REFLECT_BUDGET,
+              DEFAULT_REFLECT_BUDGET,
+            );
+    }
     return { ok: true, params: { ...called, arguments: injected } };
   }
 

--- a/src/config/schema.mirror-parity.test.ts
+++ b/src/config/schema.mirror-parity.test.ts
@@ -8,7 +8,7 @@ import {
   HindsightConfigSchema,
   HindsightPerOpLlmSchema,
 } from "./schema.js";
-import { mergeAgentConfig } from "./merge.js";
+import { mergeAgentConfig, resolveAgentConfig } from "./merge.js";
 
 /**
  * ── The class-killer parity test (#3909 / #3779 / #3687) ────────────────────
@@ -138,6 +138,8 @@ describe("newly mirrored keys survive parse + merge cascade", () => {
       retain: { every_n_turns: 7, overlap_turns: 4 },
       bank_mission: "bm",
       reflect_mission: "rm",
+      reflect_budget: "mid",
+      reflect_max_tokens: 2048,
       retain_mission: "rtm",
       observations_mission: "om",
       disposition: { skepticism: 5, literalism: 2 },
@@ -153,6 +155,8 @@ describe("newly mirrored keys survive parse + merge cascade", () => {
     expect(m.retain?.overlap_turns).toBe(4);
     expect(m.bank_mission).toBe("bm");
     expect(m.reflect_mission).toBe("rm");
+    expect(m.reflect_budget).toBe("mid");
+    expect(m.reflect_max_tokens).toBe(2048);
     expect(m.retain_mission).toBe("rtm");
     expect(m.observations_mission).toBe("om");
     expect(m.disposition?.skepticism).toBe(5);
@@ -185,9 +189,39 @@ describe("newly mirrored keys survive parse + merge cascade", () => {
     expect(m.retain?.overlap_turns).toBe(4);
     expect(m.bank_mission).toBe("bm");
     expect(m.reflect_mission).toBe("rm");
+    expect(m.reflect_budget).toBe("mid");
+    expect(m.reflect_max_tokens).toBe(2048);
     expect(m.retain_mission).toBe("rtm");
     expect(m.observations_mission).toBe("om");
     expect(m.disposition?.skepticism).toBe(5);
+  });
+
+  it("cascade: per-agent reflect_budget/reflect_max_tokens override the defaults (via resolveAgentConfig)", () => {
+    const agent = AgentSchema.parse({
+      topic_name: "ops",
+      memory: { collection: "ops-bank", reflect_budget: "high", reflect_max_tokens: 512 },
+    });
+    // Inheritance path: an agent that OMITS them picks up the defaults.
+    const inherited = resolveAgentConfig(defaults, undefined, AgentSchema.parse({
+      topic_name: "ops",
+      memory: { collection: "ops-bank" },
+    }));
+    expect(inherited.memory?.reflect_budget).toBe("mid");
+    expect(inherited.memory?.reflect_max_tokens).toBe(2048);
+    // Override path: per-agent wins over the fleet default.
+    const overridden = resolveAgentConfig(defaults, undefined, agent);
+    expect(overridden.memory?.reflect_budget).toBe("high");
+    expect(overridden.memory?.reflect_max_tokens).toBe(512);
+  });
+
+  it("rejects an invalid reflect_budget enum value at parse", () => {
+    expect(() =>
+      AgentMemorySchema.parse({ reflect_budget: "turbo" }),
+    ).toThrow();
+    // The defaults-tier mirror must reject it too (not silently strip).
+    expect(() =>
+      AgentDefaultsSchema.parse({ memory: { reflect_budget: "turbo" } }),
+    ).toThrow();
   });
 
   it("cascade: retain + disposition per-key merge (agent overrides one, inherits siblings)", () => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -509,6 +509,30 @@ export const AgentMemorySchema = z
         "'who am I / what matters' framing applied during recall). The " +
         "engine-accurate name for what `bank_mission` sets. Cascade: override."
       ),
+    reflect_budget: z
+      .enum(["low", "mid", "high"])
+      .optional()
+      .describe(
+        "Thinking/retrieval budget injected into reflect MCP calls when the " +
+        "caller omits budget. Unset ⇒ shim default (mid). Explicit per-call " +
+        "budget always wins. Higher = better recall on fuzzy queries, more " +
+        "backend latency/compute. stdio-shim transport only (ignored under " +
+        "memory.config.mcp_transport: http). Cascade: override (per-agent " +
+        "wins over default)."
+      ),
+    reflect_max_tokens: z
+      .number()
+      .int()
+      .positive()
+      .max(8192)
+      .optional()
+      .describe(
+        "Token cap injected into reflect MCP calls when caller omits " +
+        "max_tokens. Unset ⇒ shim default 1024. Values much above ~2048 risk " +
+        "exceeding Claude Code's MCP output cap, silently dropping the " +
+        "payload — raise deliberately. Explicit per-call values always win. " +
+        "stdio-shim transport only. Cascade: override."
+      ),
     retain_mission: z
       .string()
       .optional()
@@ -3575,14 +3599,19 @@ const profileFields = {
         })
         .optional(),
       // Mirrors of AgentMemorySchema.{bank_mission,reflect_mission,
-      // retain_mission,observations_mission,disposition} — accepted at the
-      // defaults/profile tier too so a bank's mission framing and disposition
-      // cascade fleet-wide (per-key merge for `disposition`, override for the
-      // missions). mental_models is DELIBERATELY not mirrored: it is per-agent
-      // only by design (see AgentMemorySchema.mental_models) so a model can
-      // never be fleet-seeded. Descriptions live on AgentMemorySchema.
+      // reflect_budget,reflect_max_tokens,retain_mission,observations_mission,
+      // disposition} — accepted at the defaults/profile tier too so a bank's
+      // mission framing, reflect budget/token caps and disposition cascade
+      // fleet-wide (per-key merge for `disposition`, override for the scalars).
+      // Without the reflect_budget/reflect_max_tokens mirror the keys were
+      // stripped at parse (the #3773 silent-no-op class). mental_models is
+      // DELIBERATELY not mirrored: it is per-agent only by design (see
+      // AgentMemorySchema.mental_models) so a model can never be fleet-seeded.
+      // Descriptions live on AgentMemorySchema.
       bank_mission: z.string().optional(),
       reflect_mission: z.string().optional(),
+      reflect_budget: z.enum(["low", "mid", "high"]).optional(),
+      reflect_max_tokens: z.number().int().positive().max(8192).optional(),
       retain_mission: z.string().optional(),
       observations_mission: z.string().optional(),
       disposition: z

--- a/src/memory/hindsight.ts
+++ b/src/memory/hindsight.ts
@@ -61,14 +61,30 @@ export const HINDSIGHT_SHIM_AGENT_HOME = "/state/agent/home";
  *
  * Escape hatch: `memory.config.mcp_transport: "http"` restores the old
  * direct HTTP entry.
+ *
+ * `opts.reflectBudget` / `opts.reflectMaxTokens` (from the per-agent
+ * memory.reflect_budget / memory.reflect_max_tokens cascade) are threaded
+ * into the shim's env as HINDSIGHT_SHIM_REFLECT_BUDGET / _MAX_TOKENS ONLY
+ * when set — the fleet default (reflect budget:mid, max_tokens:1024) lives in
+ * the shim constants, so an unconfigured agent emits the minimal 4-key env
+ * and picks up the default from the image with no reconcile. Both are shim
+ * (stdio) concepts; under mcp_transport:"http" they bypass the shim entirely,
+ * so a set value there is a no-op and we warn.
  */
 export function generateHindsightMcpConfig(
   collection: string,
   memoryConfig: MemoryBackendConfig,
+  opts: { reflectBudget?: "low" | "mid" | "high"; reflectMaxTokens?: number } = {},
 ): McpServerConfig {
   const url = (memoryConfig.config?.url as string | undefined)
     ?? HINDSIGHT_DEFAULT_MCP_URL;
   if (memoryConfig.config?.mcp_transport === "http") {
+    if (opts.reflectBudget !== undefined || opts.reflectMaxTokens !== undefined) {
+      console.error(
+        "memory.reflect_budget/reflect_max_tokens have no effect under " +
+        "mcp_transport: http — bypasses the shim",
+      );
+    }
     return {
       type: "http",
       url,
@@ -89,6 +105,12 @@ export function generateHindsightMcpConfig(
       HINDSIGHT_BANK_ID: collection,
       HINDSIGHT_SHIM_CACHE_DIR: `${HINDSIGHT_SHIM_AGENT_HOME}/.hindsight-shim`,
       HOME: HINDSIGHT_SHIM_AGENT_HOME,
+      ...(opts.reflectBudget
+        ? { HINDSIGHT_SHIM_REFLECT_BUDGET: opts.reflectBudget }
+        : {}),
+      ...(opts.reflectMaxTokens
+        ? { HINDSIGHT_SHIM_REFLECT_MAX_TOKENS: String(opts.reflectMaxTokens) }
+        : {}),
     },
   };
 }

--- a/src/memory/scaffold-integration.ts
+++ b/src/memory/scaffold-integration.ts
@@ -1,3 +1,4 @@
+import { resolveAgentConfig } from "../config/merge.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 import {
   generateHindsightMcpConfig,
@@ -31,7 +32,17 @@ export function getHindsightSettingsEntry(
   }
 
   const collection = getCollectionForAgent(agentName, config);
-  const mcpConfig = generateHindsightMcpConfig(collection, memoryConfig);
+  // Resolve the per-agent memory cascade (defaults → profile → agent) so the
+  // reflect_budget / reflect_max_tokens overrides thread into the shim env.
+  const resolved = resolveAgentConfig(
+    config.defaults,
+    config.profiles,
+    config.agents[agentName] ?? {},
+  );
+  const mcpConfig = generateHindsightMcpConfig(collection, memoryConfig, {
+    reflectBudget: resolved.memory?.reflect_budget,
+    reflectMaxTokens: resolved.memory?.reflect_max_tokens,
+  });
 
   // Defer hindsight's 32 MCP tools via tool search. Auto-recall (recall.py
   // via UserPromptSubmit hook) and auto-retain (retain.py via Stop hook) call

--- a/tests/hindsight-mcp-shim.test.ts
+++ b/tests/hindsight-mcp-shim.test.ts
@@ -27,6 +27,8 @@ import {
   SYNTHESIZED_TOOL_NAMES,
   guardAndClampToolCall,
   DEFAULT_RECALL_MAX_TOKENS,
+  DEFAULT_RECALL_BUDGET,
+  DEFAULT_REFLECT_BUDGET,
   isReflectToolCallFailure,
   REFLECT_TOOL_CALL_RETRIES,
   REFLECT_NO_TOOL_CALL_SIGNATURE,
@@ -645,7 +647,9 @@ describe("guardAndClampToolCall (unit)", () => {
     expect(args.max_tokens).toBe(1024); // the omitted one is still clamped
   });
 
-  it("clamps reflect the same way", () => {
+  it("clamps reflect's max_tokens the same way, but injects budget:mid", () => {
+    // The shipped fleet default: reflect budget defaults to "mid" (recall
+    // stays "low"). On origin/main both defaulted to "low" — this FAILS there.
     const res = guardAndClampToolCall(
       { name: "reflect", arguments: { query: "x" } },
       {},
@@ -653,10 +657,70 @@ describe("guardAndClampToolCall (unit)", () => {
     if (!res.ok) throw new Error("unexpected rejection");
     const args = (res.params as { arguments: Record<string, unknown> }).arguments;
     expect(args.max_tokens).toBe(1024);
+    expect(args.budget).toBe("mid");
+  });
+
+  it("injects reflect budget:mid but recall budget:low when omitted", () => {
+    expect(DEFAULT_REFLECT_BUDGET).toBe("mid");
+    expect(DEFAULT_RECALL_BUDGET).toBe("low");
+    const reflect = guardAndClampToolCall(
+      { name: "reflect", arguments: { query: "x" } },
+      {},
+    );
+    const recall = guardAndClampToolCall(
+      { name: "recall", arguments: { query: "x" } },
+      {},
+    );
+    if (!reflect.ok || !recall.ok) throw new Error("unexpected rejection");
+    const rArgs = (reflect.params as { arguments: Record<string, unknown> }).arguments;
+    const cArgs = (recall.params as { arguments: Record<string, unknown> }).arguments;
+    expect(rArgs.budget).toBe("mid");
+    expect(cArgs.budget).toBe("low");
+  });
+
+  it("honors HINDSIGHT_SHIM_REFLECT_BUDGET override (low and high)", () => {
+    const low = guardAndClampToolCall(
+      { name: "reflect", arguments: { query: "x" } },
+      { HINDSIGHT_SHIM_REFLECT_BUDGET: "low" },
+    );
+    const high = guardAndClampToolCall(
+      { name: "reflect", arguments: { query: "x" } },
+      { HINDSIGHT_SHIM_REFLECT_BUDGET: "high" },
+    );
+    if (!low.ok || !high.ok) throw new Error("unexpected rejection");
+    expect((low.params as { arguments: Record<string, unknown> }).arguments.budget).toBe("low");
+    expect((high.params as { arguments: Record<string, unknown> }).arguments.budget).toBe("high");
+  });
+
+  it("falls back to reflect default mid on a garbage budget env value", () => {
+    const res = guardAndClampToolCall(
+      { name: "reflect", arguments: { query: "x" } },
+      { HINDSIGHT_SHIM_REFLECT_BUDGET: "turbo" },
+    );
+    if (!res.ok) throw new Error("unexpected rejection");
+    const args = (res.params as { arguments: Record<string, unknown> }).arguments;
+    expect(args.budget).toBe("mid");
+  });
+
+  it("leaves an explicit reflect budget UNTOUCHED even with an env override set", () => {
+    const res = guardAndClampToolCall(
+      { name: "reflect", arguments: { query: "x", budget: "low" } },
+      { HINDSIGHT_SHIM_REFLECT_BUDGET: "high" },
+    );
+    if (!res.ok) throw new Error("unexpected rejection");
+    const args = (res.params as { arguments: Record<string, unknown> }).arguments;
     expect(args.budget).toBe("low");
   });
 
-  it("honors the env override for the injected budget", () => {
+  it("injects reflect budget:mid + max_tokens:1024 when arguments is undefined", () => {
+    const res = guardAndClampToolCall({ name: "reflect" }, {});
+    if (!res.ok) throw new Error("unexpected rejection");
+    const args = (res.params as { arguments: Record<string, unknown> }).arguments;
+    expect(args.budget).toBe("mid");
+    expect(args.max_tokens).toBe(1024);
+  });
+
+  it("honors the env override for the injected recall max_tokens", () => {
     const res = guardAndClampToolCall(
       { name: "recall", arguments: { query: "x" } },
       { HINDSIGHT_SHIM_RECALL_MAX_TOKENS: "600" },
@@ -664,6 +728,16 @@ describe("guardAndClampToolCall (unit)", () => {
     if (!res.ok) throw new Error("unexpected rejection");
     const args = (res.params as { arguments: Record<string, unknown> }).arguments;
     expect(args.max_tokens).toBe(600);
+  });
+
+  it("honors the env override for the injected reflect max_tokens", () => {
+    const res = guardAndClampToolCall(
+      { name: "reflect", arguments: { query: "x" } },
+      { HINDSIGHT_SHIM_REFLECT_MAX_TOKENS: "2048" },
+    );
+    if (!res.ok) throw new Error("unexpected rejection");
+    const args = (res.params as { arguments: Record<string, unknown> }).arguments;
+    expect(args.max_tokens).toBe(2048);
   });
 
   it("does NOT clamp non-recall/reflect tools (retain passes through)", () => {
@@ -728,6 +802,22 @@ describe("tools/call clamp + rejection through the live shim", () => {
     const args = call?.params?.arguments as Record<string, unknown>;
     expect(args.max_tokens).toBe(1024);
     expect(args.budget).toBe("low");
+    expect(args.query).toBe("x");
+  });
+
+  it("a bare reflect forwards budget:mid to the backend", async () => {
+    backend = await startMockBackend();
+    const shim = makeShim({ url: backend.url, cacheDir });
+    await shim.handle(rpc(1, "initialize", { protocolVersion: "2025-06-18" }) as never);
+
+    await shim.handle(
+      rpc(2, "tools/call", { name: "reflect", arguments: { query: "x" } }) as never,
+    );
+    const call = backend.requests.find((r) => r.method === "tools/call");
+    expect(call).toBeDefined();
+    const args = call?.params?.arguments as Record<string, unknown>;
+    expect(args.budget).toBe("mid");
+    expect(args.max_tokens).toBe(1024);
     expect(args.query).toBe("x");
   });
 

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -11,6 +11,7 @@ import {
   DOCKER_SWITCHROOM_CLI_PATH,
   DOCKER_AGENT_HOME,
 } from "../src/agents/scaffold.js";
+import { getHindsightSettingsEntry } from "../src/memory/scaffold-integration.js";
 import { reflectAcrossAgents } from "../src/memory/search.js";
 import {
   getHindsightMcpUrl,
@@ -89,6 +90,109 @@ describe("generateHindsightMcpConfig", () => {
     // this pin is the drift guard the comment in hindsight.ts promises.
     expect(HINDSIGHT_SHIM_CLI_PATH).toBe(DOCKER_SWITCHROOM_CLI_PATH);
     expect(HINDSIGHT_SHIM_AGENT_HOME).toBe(DOCKER_AGENT_HOME);
+  });
+
+  it("threads reflect budget/max_tokens opts into the shim env (max_tokens as STRING)", () => {
+    const memConfig = makeMemoryConfig();
+    const result = generateHindsightMcpConfig("my-collection", memConfig, {
+      reflectBudget: "high",
+      reflectMaxTokens: 2048,
+    });
+    expect(result.env?.HINDSIGHT_SHIM_REFLECT_BUDGET).toBe("high");
+    expect(result.env?.HINDSIGHT_SHIM_REFLECT_MAX_TOKENS).toBe("2048");
+  });
+
+  it("omits the reflect env vars when the opts are unconfigured (minimal 4-key env)", () => {
+    const memConfig = makeMemoryConfig();
+    const result = generateHindsightMcpConfig("my-collection", memConfig, {});
+    // The fleet default lives in the shim constant; an unconfigured agent
+    // emits exactly the 4-key env, so the image-baked default reaches it with
+    // no reconcile. This mirrors the toEqual contract above.
+    expect(result.env).toEqual({
+      HINDSIGHT_MCP_URL: "http://127.0.0.1:18888/mcp/",
+      HINDSIGHT_BANK_ID: "my-collection",
+      HINDSIGHT_SHIM_CACHE_DIR: "/state/agent/home/.hindsight-shim",
+      HOME: "/state/agent/home",
+    });
+  });
+
+  it("under mcp_transport: http, opts produce no env and leave headers unchanged", () => {
+    const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+    const memConfig = makeMemoryConfig({
+      config: { provider: "ollama", docker_service: true, mcp_transport: "http" },
+    });
+    const result = generateHindsightMcpConfig("my-collection", memConfig, {
+      reflectBudget: "high",
+      reflectMaxTokens: 2048,
+    });
+    expect(result.type).toBe("http");
+    expect(result.env).toBeUndefined();
+    expect(result.headers).toEqual({ "X-Bank-Id": "my-collection" });
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe("getHindsightSettingsEntry reflect cascade", () => {
+  function configWith(opts: {
+    defaults?: Record<string, unknown>;
+    agents?: Record<string, any>;
+  }): SwitchroomConfig {
+    return {
+      switchroom: { version: 1, agents_dir: "~/.switchroom/agents" },
+      telegram: { bot_token: "test-token", forum_chat_id: "-100123" },
+      memory: makeMemoryConfig(),
+      defaults: opts.defaults,
+      agents: opts.agents ?? {},
+    } as unknown as SwitchroomConfig;
+  }
+
+  function envOf(config: SwitchroomConfig, agent: string) {
+    const entry = getHindsightSettingsEntry(agent, config);
+    if (!entry) throw new Error("expected a hindsight entry");
+    return (entry.value as { env?: Record<string, string> }).env;
+  }
+
+  it("cascades defaults.memory.reflect_budget to an agent with no override", () => {
+    const config = configWith({
+      defaults: { memory: { reflect_budget: "high" } },
+      agents: { foo: {} },
+    });
+    // FAILS on origin/main: reflect_budget is stripped at parse and never
+    // threaded into the shim env.
+    expect(envOf(config, "foo")?.HINDSIGHT_SHIM_REFLECT_BUDGET).toBe("high");
+  });
+
+  it("lets a per-agent reflect_budget beat the fleet default", () => {
+    const config = configWith({
+      defaults: { memory: { reflect_budget: "high" } },
+      agents: { foo: { memory: { reflect_budget: "low" } } },
+    });
+    expect(envOf(config, "foo")?.HINDSIGHT_SHIM_REFLECT_BUDGET).toBe("low");
+  });
+
+  it("omits the reflect env when nothing is configured", () => {
+    const config = configWith({ agents: { foo: {} } });
+    const env = envOf(config, "foo");
+    expect(env?.HINDSIGHT_SHIM_REFLECT_BUDGET).toBeUndefined();
+    expect(env?.HINDSIGHT_SHIM_REFLECT_MAX_TOKENS).toBeUndefined();
+  });
+
+  it("cascades reflect_max_tokens (default, override, and absent)", () => {
+    const inherited = configWith({
+      defaults: { memory: { reflect_max_tokens: 2048 } },
+      agents: { foo: {} },
+    });
+    expect(envOf(inherited, "foo")?.HINDSIGHT_SHIM_REFLECT_MAX_TOKENS).toBe("2048");
+
+    const overridden = configWith({
+      defaults: { memory: { reflect_max_tokens: 2048 } },
+      agents: { foo: { memory: { reflect_max_tokens: 512 } } },
+    });
+    expect(envOf(overridden, "foo")?.HINDSIGHT_SHIM_REFLECT_MAX_TOKENS).toBe("512");
+
+    const absent = configWith({ agents: { foo: {} } });
+    expect(envOf(absent, "foo")?.HINDSIGHT_SHIM_REFLECT_MAX_TOKENS).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## What

Changes the hindsight MCP shim's injected default `budget` for a bare `reflect`
from `low` → **`mid`** (fleet-wide, in the shim constant), and exposes the
reflect budget/token-cap knobs to `switchroom.yaml`.

## Behavior changes

1. **Reflect injected default budget `low` → `mid`** for every stdio agent on
   image update — **no reconcile required** (the default lives in the shim
   constant `DEFAULT_REFLECT_BUDGET`). Explicit per-call `budget` and both yaml
   tiers (`defaults.memory` / per-agent) override it.
2. **Recall is unchanged at `low`** (`DEFAULT_RECALL_BUDGET`) — it fires on every
   inbound turn, so it stays fast and shallow.
3. **`memory.reflect_max_tokens`** exposes the *pre-existing*
   `HINDSIGHT_SHIM_REFLECT_MAX_TOKENS` clamp to yaml — **shim untouched** for
   this half.
4. **http-transport caveat:** `memory.reflect_budget` / `reflect_max_tokens` are
   stdio-shim concepts. Under `memory.config.mcp_transport: http` they bypass the
   shim entirely; the generator logs a one-line warning and emits no env (does
   not throw).
5. **Opt-down recipe:** set `defaults.memory.reflect_budget: low` to restore the
   prior fleet behavior.
6. **`switchroom apply` required** for the yaml overrides to reach existing
   agents (they land in `settings.json` at scaffold time).

New env overrides `HINDSIGHT_SHIM_RECALL_BUDGET` / `HINDSIGHT_SHIM_REFLECT_BUDGET`
mirror the existing `*_MAX_TOKENS` pair (garbage value → falls back to default).

## Why mid is safe

`budget:"low"` bounded reflect depth but made slightly-off queries return empty.
The original overflow hazard was driven by `max_tokens` (still clamped to 1024),
**not** budget — so `mid` cannot resurrect it. The only cost of `mid` is added
reflect latency / backend compute.

## Mirror discipline

`reflect_budget` / `reflect_max_tokens` are mirrored into the defaults/profile
tier (`profileFields.memory`). Without the mirror they'd be stripped at parse
(the #3773 silent-no-op class); the class-killer parity test in
`schema.mirror-parity.test.ts` enforces the mirror ≡ per-agent shape.

## Tests

- `tests/hindsight-mcp-shim.test.ts`: reflect injects `mid` (recall stays `low`),
  env override honored, garbage → default, explicit wins over env, undefined-args
  path, reflect max_tokens override, live-shim forwards `budget:mid` to backend.
- `tests/memory.test.ts`: opts thread into env (max_tokens as **string**),
  unconfigured emits minimal 4-key env, http-transport emits no env + warns; new
  `getHindsightSettingsEntry` cascade suite (defaults→agent, per-agent wins,
  absent = key omitted, for both fields).
- `src/config/schema.mirror-parity.test.ts`: both fields survive parse at the
  defaults tier, cascade via `resolveAgentConfig` (inherit + override), and an
  invalid enum (`turbo`) is rejected at parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)