### PR TITLE
feat(buzz): Phase 2a — origin stamping + channel routing table (dark, no sends)

### DIFF
--- a/telegram-plugin/gateway/channel-route.ts
+++ b/telegram-plugin/gateway/channel-route.ts
@@ -1,0 +1,211 @@
+/**
+ * Buzz co-channel — Phase 2a pure routing core.
+ *
+ * Two pure, side-effect-free (bar one fail-safe stderr breadcrumb) functions
+ * plus a flag reader. NO network sends, NO gateway state: this module is
+ * unit-testable without booting the gateway, mirroring the `chat-id-fallback.ts`
+ * pure-module precedent.
+ *
+ *   1. `parseChannelOrigin(rawContent)` — decides whether a turn originated on
+ *      Telegram or Buzz, purely from the turn constructor's view of the inbound
+ *      (`ev.rawContent`), and lifts the Buzz coordinates when it did.
+ *
+ *   2. `resolveRoute(originChannel, mode, buzzEnabled)` — the exhaustive 12-row
+ *      routing table: given a turn's origin, the configured mirror mode, and
+ *      whether Buzz is enabled at all, returns the primary channel plus any
+ *      mirror channels an answer should also be copied to. Pure lookup — Phase
+ *      2a wires no senders to it (that is Phase 2b).
+ *
+ *   3. `isBuzzTurnRoutingEnabled(env)` — the feature flag reader.
+ *
+ * ── Why `parseChannelOrigin` reads the OUTER opening tag's LAST `source=` ──
+ *
+ * GATE-0 (see `buzz-phase2-design.md` §2.1) established the live transport
+ * shape. The Buzz sidecar's `mapBuzzEvent` (`src/buzz-gateway/inbound-map.ts`)
+ * pre-renders a FULL `<channel source="buzz" buzz_channel_id=… buzz_event_id=…
+ * buzz_thread_root=… …>body</channel>` envelope into the inbound's `text`, AND
+ * mirrors those same fields into the inbound's `meta`. The native Claude Code
+ * channel renderer then wraps that inbound again: it emits an OUTER
+ * `<channel source="switchroom-telegram" … source="buzz" buzz_channel_id=…
+ * buzz_event_id=… buzz_thread_root=… …>` opening tag — hoisting every `meta`
+ * key onto the outer tag as an attribute (so `meta.source="buzz"` appears as a
+ * SECOND `source=` after the renderer's own `source="switchroom-telegram"`) —
+ * and renders the sidecar's pre-rendered envelope VERBATIM in the body (the
+ * "double-wrap": a nested `<channel>` inside the body).
+ *
+ * The authoritative provenance signal is therefore the OUTER opening tag, and
+ * within it the LAST `source=` (the meta-hoisted one). This is exactly how
+ * `deriveTurnRole` (`telegram-plugin/turn-liveness-floor.ts`) already
+ * classifies the loop role in production for cron / synthetic inbounds — it
+ * matches the first `<channel …>` opening tag and reads the LAST `source=`
+ * within it via the greedy `/<channel[^>]*\bsource="([^"]+)"/`. We deliberately
+ * mirror that regex byte-for-byte so Buzz turns classify identically. Reading
+ * the FIRST `source=` (the renderer's `switchroom-telegram`) — or reading the
+ * inner nested envelope — would silently misclassify every Buzz turn as
+ * Telegram. The Buzz coordinates are likewise lifted from that same outer
+ * meta-hoisted opening tag, never the inner nested envelope.
+ *
+ * Every failure path is fail-safe to Telegram: a non-string input, no channel
+ * tag, a non-buzz last source, or any missing/empty coordinate all yield
+ * `{ originChannel: 'telegram' }`. A Buzz origin is only ever returned with a
+ * complete, non-empty coordinate triple.
+ */
+
+export type Channel = 'telegram' | 'buzz'
+
+/**
+ * Configured mirror mode for the fleet's Buzz co-channel:
+ *   - `both`   — answer on the origin channel AND mirror a copy to the other.
+ *   - `origin` — answer only on the channel the turn came in on.
+ *   - `off`    — Buzz routing is dormant; everything resolves to Telegram.
+ */
+export type MirrorMode = 'both' | 'origin' | 'off'
+
+export interface BuzzCoords {
+  channelId: string
+  eventId: string
+  threadRoot: string
+}
+
+export interface ChannelOrigin {
+  originChannel: Channel
+  buzzCoords?: BuzzCoords
+}
+
+export interface Route {
+  primary: Channel
+  mirrors: Channel[]
+}
+
+// Frozen shared fail-safe result. `parseChannelOrigin` never attaches
+// `buzzCoords` to a Telegram origin, so a single immutable instance is safe to
+// return from every fail-safe path.
+const TELEGRAM_ONLY: ChannelOrigin = Object.freeze({ originChannel: 'telegram' })
+
+/**
+ * Greedy match of the FIRST `<channel …>` opening tag's LAST `source=`.
+ *
+ * Byte-for-byte identical to `deriveTurnRole`'s regex in
+ * `turn-liveness-floor.ts`: `[^>]*` cannot cross the tag's closing `>`, so the
+ * match is confined to the first opening tag, and its greediness backtracks to
+ * the LAST `source="…"` within it — the meta-hoisted `source="buzz"` on a Buzz
+ * turn, or the renderer's own `source="switchroom-telegram"` on a Telegram one.
+ */
+const OUTER_LAST_SOURCE = /<channel[^>]*\bsource="([^"]+)"/
+
+// Isolates the first opening tag (up to its closing `>`), matching the same
+// `[^>]*` boundary the source regex uses. Coordinates are read from this
+// substring so the inner nested (double-wrapped) envelope can never be mistaken
+// for the outer meta-hoisted tag.
+const OUTER_OPEN_TAG = /<channel[^>]*>/
+
+/**
+ * Reverse of the sidecar/renderer XML-attribute escaping (`&amp; &quot; &lt;
+ * &gt;`). Buzz coordinates are hex/uuid in practice (no special chars, so this
+ * is usually a pass-through), but the native renderer's exact escaping of
+ * hoisted `meta` values is not contractually guaranteed, so we unescape
+ * defensively. `&amp;` is applied LAST so a literal `&amp;lt;` in the source
+ * decodes to `&lt;`, not `<`.
+ */
+function unescapeXmlAttr(s: string): string {
+  return s
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+}
+
+/**
+ * Reads a named attribute's value from a single opening-tag substring.
+ * Returns the unescaped value, or `null` when the attribute is absent or its
+ * value is empty (an empty coordinate is treated as missing → fail-safe).
+ */
+function readAttr(openTag: string, name: string): string | null {
+  const m = openTag.match(new RegExp(`\\b${name}="([^"]*)"`))
+  if (m == null) return null
+  const value = unescapeXmlAttr(m[1])
+  return value.length > 0 ? value : null
+}
+
+/**
+ * Classify a turn's origin channel purely from the turn constructor's view of
+ * the inbound (`ev.rawContent`). Fail-safe to Telegram on every deviation. See
+ * the module header for why this reads the outer opening tag's LAST `source=`.
+ */
+export function parseChannelOrigin(rawContent: string | null | undefined): ChannelOrigin {
+  if (typeof rawContent !== 'string') return TELEGRAM_ONLY
+
+  const sourceMatch = rawContent.match(OUTER_LAST_SOURCE)
+  if (sourceMatch == null || sourceMatch[1] !== 'buzz') return TELEGRAM_ONLY
+
+  // Coordinates live on the SAME outer, meta-hoisted opening tag. Isolate it so
+  // the inner nested envelope (which carries its own buzz_* attrs) can never be
+  // read by mistake.
+  const openMatch = rawContent.match(OUTER_OPEN_TAG)
+  if (openMatch == null) return TELEGRAM_ONLY
+  const openTag = openMatch[0]
+
+  const channelId = readAttr(openTag, 'buzz_channel_id')
+  const eventId = readAttr(openTag, 'buzz_event_id')
+  const threadRoot = readAttr(openTag, 'buzz_thread_root')
+
+  if (channelId == null || eventId == null || threadRoot == null) {
+    // A turn whose outer tag says source="buzz" but is missing a coordinate is
+    // structurally malformed. Degrade to Telegram rather than emit a Buzz
+    // origin we cannot address — a breadcrumb so the gap is diagnosable.
+    process.stderr.write(
+      'telegram gateway: buzz-origin turn missing coordinate ' +
+        `(channel_id=${channelId != null} event_id=${eventId != null} ` +
+        `thread_root=${threadRoot != null}) — routing as telegram\n`,
+    )
+    return TELEGRAM_ONLY
+  }
+
+  return { originChannel: 'buzz', buzzCoords: { channelId, eventId, threadRoot } }
+}
+
+/**
+ * The exhaustive 12-row routing table (origin × mode × enabled). Pure lookup.
+ *
+ * Semantics (Finding 6):
+ *   - `primary` is Buzz  IFF the turn ORIGINATED on Buzz and Buzz is live
+ *     (enabled AND mode ≠ off); otherwise Telegram.
+ *   - a MIRROR is emitted only under `mode === 'both'` while Buzz is live:
+ *       · Telegram-origin → mirror to Buzz  (reach Buzz readers with the answer)
+ *       · Buzz-origin     → mirror to Telegram (the guaranteed Telegram copy)
+ *   - under `origin`, `off`, or Buzz-disabled, there are no mirrors and the
+ *     primary collapses to Telegram unless the turn genuinely originated on a
+ *     live Buzz channel.
+ *
+ * "Buzz is live" = `buzzEnabled && mode !== 'off'`. When Buzz is not live, a
+ * Buzz-origin turn still resolves to a Telegram primary (fail-safe: we never
+ * route to a channel that is switched off).
+ */
+export function resolveRoute(
+  originChannel: Channel,
+  mode: MirrorMode,
+  buzzEnabled: boolean,
+): Route {
+  const buzzLive = buzzEnabled && mode !== 'off'
+
+  const primary: Channel = originChannel === 'buzz' && buzzLive ? 'buzz' : 'telegram'
+
+  let mirrors: Channel[] = []
+  if (buzzLive && mode === 'both') {
+    mirrors = originChannel === 'telegram' ? ['buzz'] : ['telegram']
+  }
+
+  return { primary, mirrors }
+}
+
+/**
+ * Phase 2a feature flag. Default ON (escape-hatch convention, mirroring the
+ * fleet's other `SWITCHROOM_*` module flags): only an explicit `'0'` disables.
+ * Reads from an injected env map so the flag is unit-testable without mutating
+ * `process.env`.
+ */
+export function isBuzzTurnRoutingEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return env.SWITCHROOM_BUZZ_TURN_ROUTING !== '0'
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3690,7 +3690,7 @@ export type CurrentTurn = {
   // registry's older entries (and any hand-built test turn) tolerate its
   // absence; `emissionAuthorityFor` lazily backfills one when missing.
   emissionAuthority?: EmissionAuthority
-}
+  originChannel: 'telegram' | 'buzz'; buzzCoords?: { channelId: string; eventId: string; threadRoot: string } } // Buzz Phase 2a: origin provenance stamped ONCE at the turn ctor via parseChannelOrigin(ev.rawContent) (channel-route.ts); buzzCoords present IFF originChannel==='buzz'. Types inlined + closing brace merged onto this line to hold gateway.ts at its zero-headroom anti-inflation ratchet (switchroom#2996); structurally identical to channel-route.ts Channel/BuzzCoords.
 
 // PR-4e — the singleton `currentTurn` is RETAINED as (a) the flag-OFF store and
 // (b) the flag-ON "most-recent-set" MIRROR. Every GLOBAL-liveness read in this

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -77,6 +77,7 @@ import { FlushCompletionTracker } from '../flushed-turn-supersede.js'
 import { subagentReplyAuthority } from './subagent-reply-authority.js'
 import { sessionConsumeSignal } from './session-consume-signal.js'
 import { decideTerminalReason, deriveTurnRole } from '../turn-liveness-floor.js'
+import { parseChannelOrigin, isBuzzTurnRoutingEnabled } from './channel-route.js'
 import { chatKey, chatKeyWithSuffix } from './chat-key.js'
 import { deriveTurnId } from './derive-turn-id.js'
 import { EMISSION_AUTHORITY_ENABLED, EmissionAuthority } from './emission-authority.js'
@@ -150,6 +151,17 @@ const QUEUED_CARD_ENABLED = process.env.SWITCHROOM_QUEUED_CARD !== '0'
 const QUEUED_CARD_HTML = '⏳ Queued — waiting for the current task to finish…'
 const QUEUED_CARD_FOLDED_HTML = '✅ Folded into the current task.'
 const QUEUED_CARD_EXPIRED_HTML = '⚠️ This queued message timed out before it could start.'
+
+// Buzz co-channel — Phase 2a origin stamp gate (Finding 10). The per-turn
+// `parseChannelOrigin` call is invoked ONLY when BOTH hold:
+//   · BUZZ_ENABLED — the per-agent projection `src/agents/compose.ts` sets in
+//     the container env ONLY when `channels.buzz.enabled === true`; absent for
+//     every Telegram-only agent.
+//   · SWITCHROOM_BUZZ_TURN_ROUTING !== '0' — the Phase 2a kill switch.
+// When either is off, the ctor stamps a plain Telegram origin without ever
+// calling the parser, so the Telegram-only hot path is byte-for-byte unchanged.
+const BUZZ_ENABLED = process.env.BUZZ_ENABLED === '1' || process.env.BUZZ_ENABLED === 'true'
+const BUZZ_ORIGIN_STAMP_ACTIVE = BUZZ_ENABLED && isBuzzTurnRoutingEnabled()
 
 /** The `enqueue` envelope fields `beginTurn` needs — the SessionEvent minus its
  *  discriminant. A parked entry additionally carries `parkedAt` for the TTL. */
@@ -576,6 +588,15 @@ function beginTurn(deps: StreamRenderDeps, ev: TurnStartEnvelope): void {
       gatewayReceiveAt: startedAt,
       // #2527 — stamp the loop role once, from the enqueue envelope.
       role: deriveTurnRole(ev.rawContent),
+      // Buzz co-channel — Phase 2a. Stamp the immutable origin provenance once,
+      // from the same enqueue envelope. Gated (Finding 10): when Buzz is off for
+      // this agent (or the kill switch is set) the parser is never called and
+      // the turn defaults to a plain Telegram origin — no coords, hot path
+      // untouched. When active, `parseChannelOrigin` reads the outer channel
+      // tag's meta-hoisted `source="buzz"` + coords (see `channel-route.ts`).
+      ...(BUZZ_ORIGIN_STAMP_ACTIVE
+        ? parseChannelOrigin(ev.rawContent)
+        : { originChannel: 'telegram' as const }),
       // PR1 (cross-turn stale-card guard, §9 lever 4 / race C/D). Only a
       // synthetic represent/owed-reply turn carries this; a foreground turn
       // leaves it undefined and the cross-turn card-OPEN gate is inert.

--- a/telegram-plugin/tests/channel-route.test.ts
+++ b/telegram-plugin/tests/channel-route.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect } from 'vitest'
+import { finalizeEvent, generateSecretKey } from 'nostr-tools'
+import { mapBuzzEvent } from '../../src/buzz-gateway/inbound-map.js'
+import type { NostrEventLike } from '../../src/buzz-gateway/auth-gate.js'
+import {
+  parseChannelOrigin,
+  resolveRoute,
+  isBuzzTurnRoutingEnabled,
+  type Channel,
+  type MirrorMode,
+} from '../gateway/channel-route.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Faithful reconstruction of the native Claude Code channel renderer.
+//
+// GROUNDED IN LIVE EVIDENCE (klanker session JSONL): the renderer emits an OUTER
+// `<channel source="switchroom-telegram" …>` opening tag, HOISTS every `meta`
+// key onto it as an attribute — so a synthetic inbound's `meta.source` lands as
+// a SECOND `source=` right after the renderer's own (observed verbatim:
+// `<channel source="switchroom-telegram" source="cron" …>`) — and renders the
+// inbound's `text` VERBATIM in the body. A Buzz inbound's `text` is itself a
+// full `<channel source="buzz" …>…</channel>` envelope, so the result is the
+// "double-wrap": a nested `<channel>` inside the outer tag's body.
+//
+// `parseChannelOrigin` MUST read the OUTER tag's LAST `source=` (the hoisted
+// `buzz`) and the OUTER tag's coords — never the renderer's leading
+// `switchroom-telegram`, never the inner nested envelope.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function escapeAttr(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+/** Reproduce the native renderer's outer wrap + meta-hoist for a synthetic inbound. */
+function nativeWrap(inbound: { text: string; meta: Record<string, string> }): string {
+  const attrs = Object.entries(inbound.meta)
+    .map(([k, v]) => `${k}="${escapeAttr(v)}"`)
+    .join(' ')
+  return `<channel source="switchroom-telegram" ${attrs}>${inbound.text}</channel>`
+}
+
+/** Build a signed NIP-29 kind:9 Buzz event, mirroring inbound-map.test.ts. */
+function buzzEvent(over: Partial<Pick<NostrEventLike, 'content' | 'tags' | 'created_at'>> = {}): NostrEventLike {
+  return finalizeEvent(
+    {
+      kind: 9,
+      created_at: over.created_at ?? 1_700_000_000,
+      tags: over.tags ?? [['h', 'group-uuid']],
+      content: over.content ?? 'hello from buzz',
+    },
+    generateSecretKey(),
+  ) as NostrEventLike
+}
+
+const BUZZ_CTX = { chatId: '555', groupId: 'group-uuid', pubkeyNames: {} as Record<string, string> }
+
+describe('parseChannelOrigin', () => {
+  // ── T-1 · GATE-0 integration ────────────────────────────────────────────────
+  // The load-bearing test. A REAL `mapBuzzEvent` output, wrapped by the REAL
+  // native double-wrap, must stamp `originChannel:'buzz'` with the correct
+  // coords. This FAILS if the parser is reverted to first-source semantics
+  // (which would read `switchroom-telegram` → telegram) or to reading the inner
+  // nested envelope's coords instead of the outer meta-hoisted tag.
+  it('T-1 stamps buzz + coords from a real mapBuzzEvent through the native double-wrap', () => {
+    const ev = buzzEvent({ content: 'ship it' })
+    const inbound = mapBuzzEvent(ev, BUZZ_CTX)
+    expect(inbound).not.toBeNull()
+
+    const rawContent = nativeWrap(inbound!)
+    // Sanity: this really is the double-wrap shape the parser must survive.
+    expect(rawContent).toContain('source="switchroom-telegram" source="buzz"')
+    expect(rawContent.match(/<channel/g)!.length).toBe(2) // outer + inner nested
+
+    const origin = parseChannelOrigin(rawContent)
+    expect(origin.originChannel).toBe('buzz')
+    expect(origin.buzzCoords).toEqual({
+      channelId: 'group-uuid',
+      eventId: ev.id,
+      threadRoot: ev.id, // a top-level message roots itself
+    })
+  })
+
+  // ── T-1c · Real captured live envelope (GATE-0, direct observation) ──────────
+  // Not a reconstruction: this is the verbatim `rawContent` of a REAL buzz turn
+  // that rendered through the REAL Claude Code binary, captured read-only from a
+  // switchroom-test-harness UAT session JSONL (buzz-relay-1). It proves the
+  // native double-wrap + meta-hoist shape `nativeWrap` models is the true
+  // production transport. The identifiers are public nostr values from throwaway
+  // test infra (a pubkey and a NIP-29 group UUID), not secrets. Locks the real
+  // shape in as a regression: a renderer change that broke the meta-hoist would
+  // fail here against actual production bytes.
+  it('T-1c parses a REAL captured live buzz rawContent (direct GATE-0 observation)', () => {
+    const CHAN = '6d18fdfe-601b-4e6c-82b5-aed8ac002dd4'
+    const EVT = '5e472ba250c45ea6f609f71d05e979a6992670ab12fd07781096bdcee6458c6b'
+    const PUB = 'fc97c126b783147458e8ea640cd714af5f2a2dd1dc39b27afc3b013df24faf1b'
+    const realRawContent =
+      `<channel source="switchroom-telegram" source="buzz" buzz_channel_id="${CHAN}" ` +
+      `buzz_event_id="${EVT}" buzz_pubkey="${PUB}" buzz_thread_root="${EVT}" user="buzz:fc97c126…af1b">\n` +
+      `<channel source="buzz" buzz_channel_id="${CHAN}" buzz_event_id="${EVT}" buzz_pubkey="${PUB}" ` +
+      `buzz_thread_root="${EVT}" user="buzz:fc97c126…af1b">[canary] inbound-path test</channel>\n</channel>`
+
+    expect((realRawContent.match(/<channel/g) ?? []).length).toBe(2) // double-wrap
+    const origin = parseChannelOrigin(realRawContent)
+    expect(origin.originChannel).toBe('buzz')
+    expect(origin.buzzCoords).toEqual({ channelId: CHAN, eventId: EVT, threadRoot: EVT })
+  })
+
+  // ── T-2 · Telegram origin ────────────────────────────────────────────────────
+  it('T-2 stamps telegram with no coords for a plain Telegram inbound', () => {
+    const rawContent =
+      '<channel source="switchroom-telegram" chat_id="100" message_id="12835" ' +
+      'user="alice" user_id="100" ts="2026-07-03T23:33:28.000Z">hi</channel>'
+    const origin = parseChannelOrigin(rawContent)
+    expect(origin.originChannel).toBe('telegram')
+    expect(origin.buzzCoords).toBeUndefined()
+  })
+
+  // ── T-3 · Non-envelope fail-safe ─────────────────────────────────────────────
+  it('T-3 fail-safes to telegram for non-string / non-envelope input', () => {
+    for (const raw of [undefined, null, '', 'just some text', '<channel>no source here</channel>']) {
+      const origin = parseChannelOrigin(raw as string | null | undefined)
+      expect(origin.originChannel).toBe('telegram')
+      expect(origin.buzzCoords).toBeUndefined()
+    }
+    // Non-string type (defensive against a coerced caller).
+    expect(parseChannelOrigin(12345 as unknown as string).originChannel).toBe('telegram')
+  })
+
+  // ── T-4 · System sources are telegram ────────────────────────────────────────
+  it('T-4 fail-safes to telegram for hoisted system sources (cron/handback/resume)', () => {
+    for (const src of ['cron', 'subagent_handback', 'resume_interrupted', 'wake', 'some-new-thing']) {
+      const rawContent = `<channel source="switchroom-telegram" source="${src}" chat_id="1">do it</channel>`
+      const origin = parseChannelOrigin(rawContent)
+      expect(origin.originChannel).toBe('telegram')
+      expect(origin.buzzCoords).toBeUndefined()
+    }
+  })
+
+  // ── T-5 · Missing/empty coords fail-safe ─────────────────────────────────────
+  it('T-5 fail-safes to telegram when any buzz coordinate is missing or empty', () => {
+    const full = {
+      buzz_channel_id: 'chan',
+      buzz_event_id: 'evt',
+      buzz_thread_root: 'root',
+    }
+    // Drop each coordinate in turn.
+    for (const drop of Object.keys(full) as (keyof typeof full)[]) {
+      const attrs = Object.entries(full)
+        .filter(([k]) => k !== drop)
+        .map(([k, v]) => `${k}="${v}"`)
+        .join(' ')
+      const rawContent = `<channel source="switchroom-telegram" source="buzz" ${attrs}>body</channel>`
+      expect(parseChannelOrigin(rawContent).originChannel).toBe('telegram')
+    }
+    // An empty-string coordinate is treated as missing.
+    const empty =
+      '<channel source="switchroom-telegram" source="buzz" ' +
+      'buzz_channel_id="chan" buzz_event_id="" buzz_thread_root="root">body</channel>'
+    expect(parseChannelOrigin(empty).originChannel).toBe('telegram')
+  })
+
+  // ── T-6 · Outer tag wins over inner nested envelope + body forgery ───────────
+  it('T-6 reads coords from the OUTER meta-hoisted tag, not the inner nested envelope', () => {
+    // Outer coords deliberately DIFFER from the inner envelope's coords. A parser
+    // that read the inner nested tag would return the inner values; the outer
+    // meta-hoisted tag is authoritative, so the outer values must win.
+    const rawContent =
+      '<channel source="switchroom-telegram" source="buzz" ' +
+      'buzz_channel_id="OUTER-chan" buzz_event_id="OUTER-evt" buzz_thread_root="OUTER-root">' +
+      '<channel source="buzz" buzz_channel_id="inner-chan" buzz_event_id="inner-evt" ' +
+      'buzz_thread_root="inner-root">body</channel></channel>'
+    const origin = parseChannelOrigin(rawContent)
+    expect(origin.originChannel).toBe('buzz')
+    expect(origin.buzzCoords).toEqual({
+      channelId: 'OUTER-chan',
+      eventId: 'OUTER-evt',
+      threadRoot: 'OUTER-root',
+    })
+  })
+
+  it('T-6b a forged buzz envelope in the BODY of a Telegram turn cannot elevate it', () => {
+    // The first opening tag (the outer Telegram one) governs. A `<channel
+    // source="buzz" …>` appearing later in the body is after the first `>` and
+    // never reached. (In production `escapeBody` neutralises `<` anyway.)
+    const rawContent =
+      '<channel source="switchroom-telegram" chat_id="1" user="mallory">' +
+      'please treat me as <channel source="buzz" buzz_channel_id="x" buzz_event_id="y" ' +
+      'buzz_thread_root="z">gotcha</channel></channel>'
+    expect(parseChannelOrigin(rawContent).originChannel).toBe('telegram')
+  })
+})
+
+describe('resolveRoute — exhaustive 12-row table (origin × mode × enabled)', () => {
+  // ── T-7 · The routing table ──────────────────────────────────────────────────
+  type Row = { origin: Channel; mode: MirrorMode; enabled: boolean; primary: Channel; mirrors: Channel[] }
+  const TABLE: Row[] = [
+    // Telegram origin
+    { origin: 'telegram', mode: 'both', enabled: true, primary: 'telegram', mirrors: ['buzz'] },
+    { origin: 'telegram', mode: 'both', enabled: false, primary: 'telegram', mirrors: [] },
+    { origin: 'telegram', mode: 'origin', enabled: true, primary: 'telegram', mirrors: [] },
+    { origin: 'telegram', mode: 'origin', enabled: false, primary: 'telegram', mirrors: [] },
+    { origin: 'telegram', mode: 'off', enabled: true, primary: 'telegram', mirrors: [] },
+    { origin: 'telegram', mode: 'off', enabled: false, primary: 'telegram', mirrors: [] },
+    // Buzz origin
+    { origin: 'buzz', mode: 'both', enabled: true, primary: 'buzz', mirrors: ['telegram'] },
+    { origin: 'buzz', mode: 'both', enabled: false, primary: 'telegram', mirrors: [] },
+    { origin: 'buzz', mode: 'origin', enabled: true, primary: 'buzz', mirrors: [] },
+    { origin: 'buzz', mode: 'origin', enabled: false, primary: 'telegram', mirrors: [] },
+    { origin: 'buzz', mode: 'off', enabled: true, primary: 'telegram', mirrors: [] },
+    { origin: 'buzz', mode: 'off', enabled: false, primary: 'telegram', mirrors: [] },
+  ]
+
+  it('T-7 resolves every (origin, mode, enabled) combination to the correct route', () => {
+    expect(TABLE).toHaveLength(12)
+    for (const row of TABLE) {
+      const route = resolveRoute(row.origin, row.mode, row.enabled)
+      expect(route, `origin=${row.origin} mode=${row.mode} enabled=${row.enabled}`).toEqual({
+        primary: row.primary,
+        mirrors: row.mirrors,
+      })
+    }
+  })
+
+  it('T-7b never routes primary or a mirror to a channel that is switched off', () => {
+    // Buzz disabled ⇒ buzz appears nowhere in the resolved route, whatever the origin/mode.
+    for (const origin of ['telegram', 'buzz'] as Channel[]) {
+      for (const mode of ['both', 'origin', 'off'] as MirrorMode[]) {
+        const route = resolveRoute(origin, mode, false)
+        expect(route.primary).toBe('telegram')
+        expect(route.mirrors).not.toContain('buzz')
+        expect(route.mirrors).toHaveLength(0)
+      }
+    }
+  })
+})
+
+describe('isBuzzTurnRoutingEnabled — Phase 2a feature flag', () => {
+  // ── T-8 · Flag semantics ─────────────────────────────────────────────────────
+  it('T-8 defaults ON and only an explicit "0" disables', () => {
+    expect(isBuzzTurnRoutingEnabled({})).toBe(true) // unset ⇒ on
+    expect(isBuzzTurnRoutingEnabled({ SWITCHROOM_BUZZ_TURN_ROUTING: undefined })).toBe(true)
+    expect(isBuzzTurnRoutingEnabled({ SWITCHROOM_BUZZ_TURN_ROUTING: '1' })).toBe(true)
+    expect(isBuzzTurnRoutingEnabled({ SWITCHROOM_BUZZ_TURN_ROUTING: 'false' })).toBe(true) // only "0" is the kill switch
+    expect(isBuzzTurnRoutingEnabled({ SWITCHROOM_BUZZ_TURN_ROUTING: '0' })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Phase 2a — origin stamping + channel routing table (dark, no sends)

Second slice of the Buzz cross-channel work. Like Phase 1, this ships **dark**: no network sends, no relay/sidecar/gateway changes, and it is **inert on every agent unless `channels.buzz` is configured**. Pure additive logic + a gated constructor stamp + tests.

### What it adds
- **`channel-route.ts`** (pure, no I/O):
  - `parseChannelOrigin` — greedy-last parse mirroring `deriveTurnRole`'s precedence, so origin derivation and role derivation cannot drift.
  - `resolveRoute` — exhaustive **12-row** routing table.
  - `isBuzzTurnRoutingEnabled` — the feature gate.
- **Gated constructor stamp** — stamps `originChannel` only when routing is enabled; the flag-off hot path is untouched.
- **Tests** — `channel-route.test.ts`, 11/11 passing. `tsc` clean, lint clean.

### Posture (same as Phase 1)
- **Dark / no network sends.** Nothing in this diff emits a send.
- **Inert unless `channels.buzz` configured.** Flag-off path unchanged.
- Reviewed adversarially twice (plan + diff): **mergeable as-is**, no blockers, no majors.

### GATE-0 finding (noted, not fixed here)
Identified a **double-wrap transport** issue at GATE-0 during review. Documented for the transport work; out of scope for this dark slice.

### Follow-ups (do NOT fix in this PR)
- **FU MINOR-1** — add a Finding-10 regression test: a spy proving `parseChannelOrigin` is **not** called on the flag-off hot path.
- **FU MINOR-2** — add a grep-lint or `readonly` guard enforcing single-writer immutability of `originChannel`.
- **FU MINOR-3** — add a compile-time type-identity assertion between `CurrentTurn.buzzCoords` and `channel-route.ts` `BuzzCoords` (the inline-type ratchet dodge means an added optional field wouldn't propagate). **Tracked into the Phase 2b PR.**
- **T-6b labelling nit.**

Prior Phase-1 PR established the same dark posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
