### PR TITLE
docs: align dev guidance with ProductOS contract + fix release/spec drift

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,18 +55,20 @@ symlinked to the workspace `dist/`), the CLI is always fresh after
 
 ### 2. Release to npm (canonical maintainers only)
 
-When the canonical `switchroom/switchroom:main` is ready to ship:
+Releases are **not** cut by hand. Do not bump `package.json` in a commit and
+do not run `npm publish` yourself — the version source of truth is the git
+tag (`scripts/build.mjs:resolveVersion()`), the committed `package.json`
+version is a stale placeholder by design, and the pack-time bump + publish
+happen in CI.
 
-```
-# On switchroom/switchroom:main
-# 1. Bump package.json version
-# 2. Update CHANGELOG.md
-# 3. Commit: "chore: release vX.Y.Z"
-# 4. Tag: git tag vX.Y.Z && git push origin vX.Y.Z
-# 5. Publish: npm publish
-```
-
-npm publishes come from the canonical repo only.
+Follow the **`switchroom-release`** skill (`skills/switchroom-release/SKILL.md`)
+for the full ordered, gated checklist. In short: a CHANGELOG-only
+`chore: release vX.Y.Z` PR is merged to `main`, then a `vX.Y.Z` tag is pushed
+on the pinned merge SHA. The tag push fires `.github/workflows/release.yml`,
+which orchestrates everything — builds the static binaries, waits for the
+`docker-images` build, then `workflow_call`s `npm-publish.yml` and un-drafts
+the GitHub Release. `npm-publish.yml` has no tag trigger and is the only leg
+that publishes to npm. Never run `npm publish` by hand from a worktree.
 
 #### Rolling a release back — on-disk state the newer build already wrote
 
@@ -128,7 +130,10 @@ your agents are on the latest code.
    `refactor:`, `test:`) + short imperative description.
 7. PR body: what changed, why, and how to test it. A short test-plan
    checklist is appreciated.
-8. **Liveness-surface PRs declare their guarantee delta.** Any PR touching
+8. **Non-trivial PRs cite the job spec they satisfy.** Cite the job spec
+   from `reference/jobs/` in the PR description — the outcome-focused spec
+   the change satisfies (see `CLAUDE.md`).
+9. **Liveness-surface PRs declare their guarantee delta.** Any PR touching
    `feedHeartbeatTick`, `feed-open-gate.ts`, `silence-poke.ts`,
    `turn-liveness-floor.ts`, or the card-edit path must state, in the PR
    body, what the framework still guarantees to deliver WITHOUT the model

--- a/reference/invariants.md
+++ b/reference/invariants.md
@@ -210,5 +210,5 @@ retired line.
   pinned widget, or status surface that mirrors conversation state in *parallel*,
   or render new content solely to pin it? If yes, that is still the retired line
   — change the prompt so the model communicates instead. See the "chat IS the
-  artifact" sub-principle in `principles.md` and `know-my-agent-is-doing`'s design
+  artifact" sub-principle in `principles.md` and `know-what-my-agent-is-doing`'s design
   artifact `rfcs/conversational-pacing.md`.

--- a/reference/principles.md
+++ b/reference/principles.md
@@ -251,7 +251,7 @@ telegram-only, chat-is-the-single-source-of-truth. Before you open the
 PR, confirm the change crosses none of them. A "yes" on all three
 principle checks plus a crossed invariant is still out of scope.
 
-These principles don't replace the existing JTBDs in `reference/`.
+These principles don't replace the job specs in `reference/jobs/`.
 They *judge* them. A feature can satisfy a JTBD outcome and still fail
 all three principle checks. When that happens, the JTBD outcome is the
 goal, and the principles are how we get there without making the product

--- a/reference/vision.md
+++ b/reference/vision.md
@@ -1,6 +1,6 @@
 ---
 title: Switchroom product vision
-source: switchroom.ai (canonical), README.md, reference/*.md JTBDs
+source: switchroom.ai (canonical), README.md, reference/jobs/*.md JTBDs
 audience: anyone deciding whether a feature, PR, or release belongs in switchroom
 ---
 
@@ -112,7 +112,7 @@ specific PR or design:
 - [`invariants.md`](invariants.md) — the lines we won't cross by
   construction.
 - [`product-spec.md`](product-spec.md) — the four outcomes (in full) and the
-  job index. The per-job **job specs** (`reference/*.md` with `job:`
+  job index. The per-job **job specs** (`reference/jobs/*.md` with `job:`
   frontmatter) each `serves:` one outcome.
 
 > [!IMPORTANT]

--- a/skills/dev-protocol/SKILL.md
+++ b/skills/dev-protocol/SKILL.md
@@ -18,6 +18,32 @@ judgement criteria. This skill carries the parts that are *this fleet's
 specific opinion* — the ones you would get wrong by defaulting to generic
 good practice, because our answer differs from the obvious one.
 
+## 0. The design contract binds first (repos that declare one)
+
+Switchroom declares its design contract in `reference/` (`reference/README.md`
+is the map; the repo CLAUDE.md "Design contract" section binds it to every
+PR). When the repo you are changing carries one, the whole protocol below
+runs *inside* that contract:
+
+- **Before non-trivial work, place the change in the contract:** which of the
+  four outcomes it advances, and which job spec it satisfies —
+  `reference/product-spec.md` owns the job index; survey specs cheaply with
+  `head -7 reference/jobs/*.md`. A change that maps to no outcome and no job
+  is a scoping question, not a coding task.
+- **The ship gate is the verdict rule, not just CI green:** a change ships
+  only when it (a) advances one of the four outcomes, (b) satisfies its job
+  spec — proven by that job's outcome UAT, (c) passes all three principle
+  checks in `reference/principles.md` (docs / defaults / consistency; a "no"
+  is a redesign, not a ship-and-patch), and (d) crosses no invariant in
+  `reference/invariants.md`. Cite the job spec in the PR body.
+- **Design lives in `reference/`, not `docs/`.** A design decision worth
+  recording is an RFC or design record in `reference/rfcs/` (`serves:` a job
+  or `backs:` an invariant), never a new doc under `docs/`.
+
+This does not add ceremony to small changes: §1's fast path stands, and on a
+single-concern change the verdict check is a one-line sanity pass, not a
+report.
+
 ## 1. Is this a "larger" task? (decides whether you design-align first)
 
 Treat it as larger — design report before implementing — when ANY of these hold:
@@ -37,7 +63,10 @@ Design-aligning a one-liner is its own failure mode.
 
 The report states what exists today **with citations**, what will change, the
 chosen approach, the alternatives you rejected and why, and the PR staging
-plan. Get alignment before implementing.
+plan. In a contract-carrying repo (§0) it opens with the verdict-rule
+mapping: the outcome advanced, the job spec satisfied, and any principle
+check or invariant the design brushes against. Get alignment before
+implementing.
 
 Then red-team your own plan item by item. Each item gets a verdict —
 `SOUND`, `RISK`, or `WRONG` — backed by evidence you can point at (a file you

--- a/skills/switchroom-architecture/SKILL.md
+++ b/skills/switchroom-architecture/SKILL.md
@@ -59,3 +59,8 @@ Switchroom is a multi-agent orchestrator built on Claude Code. It manages multip
 - [cascade.md](cascade.md) — three-layer config cascade semantics
 - [sub-agents.md](sub-agents.md) — delegation patterns and model routing
 - [telegram.md](telegram.md) — enhanced Telegram plugin features
+
+**Why it's built this way** lives in the repo's `reference/` directory — the
+design contract (`reference/README.md` is the map: vision, principles,
+invariants, product spec, job specs, RFCs). For "why does switchroom do X"
+questions, that is the source of truth; `docs/` is usage/operation only.

--- a/skills/switchroom-cli/SKILL.md
+++ b/skills/switchroom-cli/SKILL.md
@@ -290,7 +290,7 @@ config-plus-recreate operation with three known traps. **Follow the runbook:
 
 ## Telegram plugin reference — "what MCP tools", "how does reply work"
 
-The `switchroom-telegram` plugin is an enhanced fork of the official Telegram MCP plugin and is the default for all switchroom agents. It exposes **9 MCP tools** (all prefixed `mcp__switchroom-telegram__`):
+The `switchroom-telegram` plugin is an enhanced fork of the official Telegram MCP plugin and is the default for all switchroom agents. It exposes **20+ MCP tools** (all prefixed `mcp__switchroom-telegram__`; the authoritative list is the tool declarations in `telegram-plugin/bridge/bridge.ts`). The core messaging set:
 
 | Tool | Purpose |
 |---|---|


### PR DESCRIPTION
Doc-only alignment branch. No code or behavior change.

## A — Dev-guidance edits (commit ce37902d, already in branch)
Binds the ProductOS design contract into the dev playbook, pointing agents at the `reference/` verdict rule (a change lands only when it advances an outcome, satisfies the job spec it cites, passes the principle checks, and crosses no invariant). Touches `skills/dev-protocol/SKILL.md`, `skills/switchroom-architecture/SKILL.md`, `skills/switchroom-cli/SKILL.md`.

## B — Three stale spec-citation fixes
- `reference/vision.md`: job specs live at `reference/jobs/*.md`, not `reference/*.md` — fixed the frontmatter `source:` line and the "how vision becomes verdict" reference.
- `reference/invariants.md`: fixed the dangling slug `know-my-agent-is-doing` → `know-what-my-agent-is-doing` (matches the real file `reference/jobs/know-what-my-agent-is-doing.md`).
- `reference/principles.md`: "the existing JTBDs in `reference/`" → "the job specs in `reference/jobs/`".

## CONTRIBUTING — remove the manual-publish contradiction
The root `CONTRIBUTING.md` release section told contributors to bump `package.json` and run `npm publish` by hand, contradicting the sanctioned flow. Replaced it with the accurate tag-driven / CI-published process: the git tag is the version source of truth, `package.json` version is a placeholder by design, and publishing runs in CI via the `switchroom-release` skill and the `release.yml` orchestrator (which `workflow_call`s `npm-publish.yml`). Also added a PR-body item requiring non-trivial PRs to cite the job spec they satisfy, mirroring `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)