### PR TITLE
fix(hindsight): reconcile dual-signal rerank priority (#4212) and wire reranker-pool teardown (#4213)

### DIFF
--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -2901,11 +2901,22 @@ PYEOF
 # post-condition asserts below fail the build if the admission mod (or the reranking
 # boost-damping mod) is lost to an upstream reshuffle.
 #
-# LOW latent risk (dual-signal): reranker priority keys off RequestContext.internal, while
-# switchroom admission keys off the explicit `_background` recall param. On every current
-# v0.19.48 call path they agree (background recalls carry the internal context). A future
-# caller hand-rolling `_background=True` with `.internal=False` (or vice-versa) would give a
-# recall disagreeing admission vs rerank priority classes — latent coupling, not a bug today.
+# DUAL-SIGNAL RECONCILIATION (switchroom #4212): a recall carries TWO priority signals.
+# `_background` (the admission param on recall_async / _search_with_retries, the switchroom
+# recall-admission split) sets DB-admission priority; `request_context.internal` sets the
+# reranker-pool priority. They are DISTINCT axes on purpose — a REFLECT sub-recall
+# (reflect/tools.py `replace(request_context, internal=True)` with no `_background`) is
+# admission-FOREGROUND (a user is waiting on the reflect answer) yet rerank-BACKGROUND (it
+# fans out a wall of reranks that must not starve single interactive reranks). So
+# internal=True with _background=False is a LIVE, CORRECT path today — NOT a divergence to
+# assert away; a "the two must agree" guard would fire on every reflect. The ONLY harmful
+# direction is the converse: _background=True with .internal=False, where a background-
+# admitted recall would rerank as FOREGROUND and jump the queue ahead of interactive
+# recall, defeating the very starvation fix #3142 exists for. The call-site patch below
+# threads `_background` down to the rerank site and derives the rerank class as
+# (_background OR internal) so that invariant holds BY CONSTRUCTION (a future diverging
+# caller cannot silently slip past it), and log-warns on the harmful direction so the bug
+# is fixed at its source rather than merely masked.
 #
 # Self-verifying (anchor-assert / replace / post-condition + ast.parse). Guarded by
 # tests/docker/dockerfile-hindsight-bakes.test.ts and
@@ -3136,6 +3147,26 @@ apply(CE, (
     "                ex = cls._executor\n"
     "        return ex\n"
     "\n"
+    "    @classmethod\n"
+    "    def shutdown_executor(cls, wait: bool = True) -> None:\n"
+    "        \"\"\"Tear down the shared priority reranker pool (idempotent).\n"
+    "\n"
+    "        switchroom #4213: MemoryEngine.close() — the engine teardown hook the\n"
+    "        API lifespan (create_app) and the worker main loop both call — shuts\n"
+    "        down every other long-lived worker/pool (task backend, db pools, LLM\n"
+    "        providers); the reranker pool was the one omission. Workers are daemon\n"
+    "        threads so the process can still exit without this, but draining them\n"
+    "        here completes in-flight reranks cleanly and lets a re-created engine\n"
+    "        (tests, mounted sub-apps) start a fresh pool via the lazy\n"
+    "        _get_executor() path instead of inheriting a torn-down one. Nulling the\n"
+    "        class ref under the lock keeps it consistent with _get_executor().\n"
+    "        \"\"\"\n"
+    "        with cls._executor_lock:\n"
+    "            ex = cls._executor\n"
+    "            cls._executor = None\n"
+    "        if ex is not None:\n"
+    "            ex.shutdown(wait=wait)\n"
+    "\n"
     "    def _predict_sync(self, pairs: list[tuple[str, str]]) -> list[float]:\n"
 ), count=1)
 
@@ -3221,24 +3252,123 @@ apply(RR, (
     "        scores = await self.cross_encoder.predict(pairs, background=background)\n"
 ), count=1)
 
-# ---- memory_engine.py: recall call site derives background from RequestContext.internal ----
+# ---- memory_engine.py: module-level dual-signal reconciliation helper (switchroom #4212) ----
+# A recall carries TWO priority signals that must not silently diverge: `_background` (the
+# admission param, sets DB-admission priority) and request_context.internal (sets rerank-pool
+# priority). They are distinct axes — a reflect sub-recall is admission-foreground yet
+# rerank-background, so internal-without-_background is CORRECT. The harmful direction is the
+# converse: _background without internal, where a background-admitted recall would rerank as
+# FOREGROUND and jump the queue ahead of interactive recall, defeating #3142. This helper is
+# the single point that derives the rerank class as (_background OR internal) — so that
+# invariant holds by construction — and log-warns on the harmful direction so a diverging
+# caller is fixed at its source. Extracted to module scope so it is independently unit/probe
+# testable (drive it with a deliberately-mismatched call and observe the warning + return).
+apply(ME, (
+    "from .db_utils import acquire_with_retry, retry_with_backoff\n"
+    "\n"
+    "\n"
+    "def _get_tiktoken_encoding():\n"
+), (
+    "from .db_utils import acquire_with_retry, retry_with_backoff\n"
+    "\n"
+    "\n"
+    "def _reconcile_rerank_priority(_background: bool, request_context) -> bool:\n"
+    "    \"\"\"switchroom #4212: fold a recall's two priority signals into the reranker-pool class.\n"
+    "\n"
+    "    ``_background`` (DB-admission priority, the switchroom recall-admission split) and\n"
+    "    ``request_context.internal`` (reranker-pool priority) are DISTINCT axes: a reflect\n"
+    "    sub-recall is admission-foreground (a user waits on the answer) yet rerank-background\n"
+    "    (a fan-out that must not starve single interactive reranks), so internal=True with\n"
+    "    _background=False is correct and expected. The one invariant that must always hold is\n"
+    "    the other direction — anything admitted as pure background maintenance\n"
+    "    (_background=True) MUST also rerank as background, or a background fan-out would jump\n"
+    "    the rerank queue ahead of interactive recall, defeating #3142. Return\n"
+    "    (_background OR internal) so that holds by construction, and warn on the harmful\n"
+    "    direction so a diverging caller is fixed at its source rather than silently repaired.\n"
+    "\n"
+    "    Returns True when the rerank should run at BACKGROUND (lower) priority.\n"
+    "    \"\"\"\n"
+    "    internal = bool(request_context is not None and request_context.internal)\n"
+    "    if _background and not internal:\n"
+    "        logger.warning(\n"
+    "            \"recall: _background=True but request_context.internal is not set; a \"\n"
+    "            \"background-admitted recall would rerank as foreground and can starve \"\n"
+    "            \"interactive reranks (switchroom #4212). Forcing background rerank priority.\"\n"
+    "        )\n"
+    "    return bool(_background or internal)\n"
+    "\n"
+    "\n"
+    "def _get_tiktoken_encoding():\n"
+), count=1)
+
+# ---- memory_engine.py: recall call site reconciles admission + internal into rerank priority ----
 apply(ME, (
     "                    await reranker_instance.ensure_initialized()\n"
     "                    scored_results = await reranker_instance.rerank(query, merged_candidates)\n"
 ), (
     "                    await reranker_instance.ensure_initialized()\n"
-    "                    # Foreground vs background priority for the reranker pool.\n"
-    "                    # Internal/background operations — consolidation and reflect\n"
-    "                    # sub-recalls (RequestContext.internal=True) — fan out a wall of\n"
-    "                    # reranks; marking them background lets a local reranker keep\n"
-    "                    # interactive (foreground) recall reranks from being starved\n"
-    "                    # behind that queue. This is the reranker-thread-pool layer; it\n"
-    "                    # is orthogonal to the switchroom recall-admission split\n"
-    "                    # (_background_search_semaphore), which gates a step earlier.\n"
-    "                    background_rerank = bool(request_context is not None and request_context.internal)\n"
+    "                    # switchroom #4212: reconcile the recall's two priority signals\n"
+    "                    # (admission `_background`, threaded down from recall_async, and\n"
+    "                    # request_context.internal) into the reranker-pool priority class.\n"
+    "                    # See _reconcile_rerank_priority — the rerank class is\n"
+    "                    # (_background OR internal) so a background-admitted recall can\n"
+    "                    # never rerank as foreground and starve interactive reranks (#3142).\n"
+    "                    background_rerank = _reconcile_rerank_priority(_background, request_context)\n"
     "                    scored_results = await reranker_instance.rerank(\n"
     "                        query, merged_candidates, background=background_rerank\n"
     "                    )\n"
+), count=1)
+
+# ---- memory_engine.py: thread `_background` down to the rerank site (switchroom #4212) ----
+# The admission signal `_background` lives on recall_async; the rerank site lives one frame
+# down in _search_with_retries, which only saw `request_context`. Thread `_background`
+# through so the rerank class can be derived as (_background OR internal). The preceding
+# `max_source_facts_tokens_per_observation: int = -1,` line disambiguates this signature
+# from recall_async's (which has the same `reranking=` default but a different prior line).
+apply(ME, (
+    "        max_source_facts_tokens_per_observation: int = -1,\n"
+    "        reranking: RecallReranking = \"cross_encoder\",\n"
+    "    ) -> RecallResultModel:\n"
+), (
+    "        max_source_facts_tokens_per_observation: int = -1,\n"
+    "        reranking: RecallReranking = \"cross_encoder\",\n"
+    "        # switchroom #4212: mirrors recall_async's admission `_background` so the\n"
+    "        # rerank priority class is derived as (_background OR internal), keeping the\n"
+    "        # DB-admission and reranker-pool priority signals from silently diverging.\n"
+    "        _background: bool = False,\n"
+    "    ) -> RecallResultModel:\n"
+), count=1)
+apply(ME, (
+    "                            max_source_facts_tokens_per_observation=max_source_facts_tokens_per_observation,\n"
+    "                            reranking=reranking,\n"
+    "                        )\n"
+), (
+    "                            max_source_facts_tokens_per_observation=max_source_facts_tokens_per_observation,\n"
+    "                            reranking=reranking,\n"
+    "                            _background=_background,  # switchroom #4212\n"
+    "                        )\n"
+), count=1)
+
+# ---- memory_engine.py: wire the reranker-pool teardown into close() (switchroom #4213) ----
+# close() is the engine teardown hook (create_app lifespan + worker main both await it) and
+# already shuts down every other long-lived worker/pool; the priority reranker pool was the
+# omission. Offload the (bounded) join to a thread so it never blocks the event loop during
+# graceful shutdown. Anchored on the existing task-backend teardown so it sits among the
+# other worker shutdowns.
+apply(ME, (
+    "        # Shutdown task backend\n"
+    "        await self._task_backend.shutdown()\n"
+), (
+    "        # Shutdown task backend\n"
+    "        await self._task_backend.shutdown()\n"
+    "\n"
+    "        # switchroom #4213: tear down the shared priority reranker pool. Every\n"
+    "        # other long-lived pool is shut down here; this one was omitted. Daemon\n"
+    "        # threads mean the process can exit without it, but draining lets in-flight\n"
+    "        # reranks finish and a re-created engine start a fresh pool. Offloaded so\n"
+    "        # the join never blocks the event loop during graceful shutdown.\n"
+    "        from .cross_encoder import LocalSTCrossEncoder\n"
+    "        await asyncio.to_thread(LocalSTCrossEncoder.shutdown_executor)\n"
 ), count=1)
 
 # ---- post-conditions: full surface present, parses, switchroom-local mods survive ----
@@ -3246,6 +3376,8 @@ ce = pathlib.Path(CE).read_text()
 assert "class _PriorityRerankExecutor:" in ce, "switchroom #3142: executor class missing post-patch"
 assert ce.count("*, background: bool = False) -> list[float]:") == 14, "switchroom #3142: predict-sig count drift"
 assert "LocalSTCrossEncoder._get_executor().submit(self._predict_sync, pairs, background=background)" in ce, "switchroom #3142: local predict body not rewired"
+# switchroom #4213: the reranker-pool teardown classmethod must exist for close() to wire.
+assert "def shutdown_executor(cls, wait: bool = True) -> None:" in ce, "switchroom #4213: shutdown_executor classmethod missing after patch"
 ast.parse(ce)
 rr = pathlib.Path(RR).read_text()
 assert "self.cross_encoder.predict(pairs, background=background)" in rr, "switchroom #3142: rerank call site not forwarding background"
@@ -3253,12 +3385,26 @@ assert "self.cross_encoder.predict(pairs, background=background)" in rr, "switch
 assert "_boost_authority(" in rr and "measured cross-encoder saturation" in rr, "switchroom CE-saturation mod lost — patch ordering broke"
 ast.parse(rr)
 me = pathlib.Path(ME).read_text()
-assert "background_rerank = bool(request_context is not None and request_context.internal)" in me, "switchroom #3142: recall call site not patched"
+# switchroom #4212: the reconciliation helper exists, returns (_background OR internal),
+# carries the harmful-direction warning, and is the single derivation point at the call site.
+assert "def _reconcile_rerank_priority(_background: bool, request_context) -> bool:" in me, "switchroom #4212: reconciliation helper missing after patch"
+assert "return bool(_background or internal)" in me, "switchroom #4212: helper does not return (_background OR internal)"
+assert "background-admitted recall would rerank as foreground" in me, "switchroom #4212: dual-signal divergence warning missing"
+assert "background_rerank = _reconcile_rerank_priority(_background, request_context)" in me, "switchroom #4212: rerank call site does not route through the reconciliation helper"
+# The old #3142 single-signal derivation must be GONE — its survival means the #4212
+# reconciliation did not land and admission/rerank priority can still silently diverge.
+assert "background_rerank = bool(request_context is not None and request_context.internal)" not in me, "switchroom #4212: pre-reconciliation single-signal rerank derivation still present"
+# `_background` must be threaded into _search_with_retries and forwarded at its call site.
+assert "_background=_background,  # switchroom #4212" in me, "switchroom #4212: _background not forwarded to _search_with_retries"
+# switchroom #4213: close() tears down the reranker pool via the classmethod.
+assert "await asyncio.to_thread(LocalSTCrossEncoder.shutdown_executor)" in me, "switchroom #4213: reranker pool teardown not wired into close()"
 # switchroom-local recall-admission split MUST survive (orthogonal layer):
 assert "_background_search_semaphore" in me, "switchroom recall-admission-split mod lost — patch ordering broke"
 ast.parse(me)
 print("switchroom #3142: reranker foreground-priority lane baked "
       "(14 predict sigs, _PriorityRerankExecutor, rerank + call-site background flag); "
+      "#4212 dual-signal reconciliation (rerank = _background OR internal, threaded + guarded); "
+      "#4213 shutdown_executor wired into close(); "
       "_background_search_semaphore + CE-saturation mods preserved")
 PYEOF
 

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -1164,9 +1164,42 @@ describe("Dockerfile.hindsight shape", () => {
     expect(dockerfile).toMatch(
       /async def predict\(self, pairs: list\[tuple\[str, str\]\], \*, background: bool = False\) -> list\[float\]:/,
     );
-    // The recall call site derives priority from RequestContext.internal.
+    // #4212 dual-signal reconciliation: the rerank call site no longer derives
+    // priority from RequestContext.internal ALONE. It routes through a module-level
+    // helper that folds in the admission `_background` signal (threaded down from
+    // recall_async) so a background-admitted recall can never rerank as foreground.
     expect(dockerfile).toContain(
-      "background_rerank = bool(request_context is not None and request_context.internal)",
+      "def _reconcile_rerank_priority(_background: bool, request_context) -> bool:",
+    );
+    expect(dockerfile).toContain("return bool(_background or internal)");
+    expect(dockerfile).toContain(
+      "background_rerank = _reconcile_rerank_priority(_background, request_context)",
+    );
+    // `_background` is threaded into _search_with_retries and forwarded at the call site.
+    expect(dockerfile).toContain("_background=_background,  # switchroom #4212");
+    // The harmful-direction warning must be baked (fires when _background is set
+    // without the internal context — the one divergence that starves interactive reranks).
+    expect(dockerfile).toContain(
+      "background-admitted recall would rerank as foreground",
+    );
+    // The pre-reconciliation single-signal derivation must be GONE as an injection —
+    // the build's own post-condition asserts its absence in the patched source.
+    expect(dockerfile).toContain(
+      'assert "background_rerank = bool(request_context is not None and request_context.internal)" not in me',
+    );
+    // #4213: the reranker pool teardown classmethod + its wiring into close().
+    expect(dockerfile).toContain(
+      "def shutdown_executor(cls, wait: bool = True) -> None:",
+    );
+    expect(dockerfile).toContain(
+      "await asyncio.to_thread(LocalSTCrossEncoder.shutdown_executor)",
+    );
+    // Build-time post-conditions gate #4212/#4213 presence in the patched source.
+    expect(dockerfile).toMatch(
+      /_reconcile_rerank_priority\(_background, request_context\)" in me, "switchroom #4212/,
+    );
+    expect(dockerfile).toMatch(
+      /asyncio\.to_thread\(LocalSTCrossEncoder\.shutdown_executor\)" in me, "switchroom #4213/,
     );
     // Post-replace verification-on-build: full surface present, exact-14, and
     // both orthogonal switchroom-local mods asserted to SURVIVE the patch

--- a/tests/docker/hindsight-reranker-priority-patch.test.ts
+++ b/tests/docker/hindsight-reranker-priority-patch.test.ts
@@ -37,6 +37,16 @@
  *  - The `background` param reaches CrossEncoderModel.predict (abstract),
  *    LocalSTCrossEncoder.predict, and CrossEncoderReranker.rerank — keyword-
  *    only, default False — so the recall call site can steer priority.
+ *  - #4212 dual-signal reconciliation: `_reconcile_rerank_priority` folds the
+ *    admission `_background` and `request_context.internal` signals as
+ *    (_background OR internal), REPAIRS + WARNS on the harmful mismatch
+ *    (_background set without internal), and is background-but-silent on the
+ *    legitimate reflect divergence; `_background` is threaded into
+ *    `_search_with_retries` and the rerank site routes through the helper.
+ *  - #4213 `LocalSTCrossEncoder.shutdown_executor` exists, is idempotent, and
+ *    `MemoryEngine.close()` wires it (the engine teardown hook the API lifespan
+ *    and worker both call), so the reranker pool is no longer the one long-lived
+ *    pool close() forgets.
  *
  * Why the GREEN arm probes the through-built image rather than re-patching
  * upstream in-container: #3142's anchors and post-conditions depend on THREE
@@ -249,6 +259,108 @@ if Executor is not None:
     if not rejected:
         failures.append("max_workers=0 was not rejected")
 
+# ---- #4212: the dual-signal reconciliation helper ----
+# recall carries TWO priority signals: _background (DB admission) and
+# request_context.internal (reranker pool). They are distinct axes — a reflect
+# sub-recall is admission-foreground yet rerank-background — so the helper folds
+# them as (_background OR internal), and WARNS only on the harmful direction
+# (_background set without internal), the one case that would let a background
+# fan-out rerank as foreground and starve interactive reranks (#3142). This arm
+# proves the helper FIRES on a deliberately-mismatched call and stays silent on
+# the legitimate reflect divergence.
+import logging
+
+try:
+    import hindsight_api.engine.memory_engine as me
+    reconcile = getattr(me, "_reconcile_rerank_priority", None)
+    ME = getattr(me, "MemoryEngine", None)
+except Exception as e:  # noqa: BLE001
+    me = None
+    reconcile = None
+    ME = None
+    print("MEMORY_ENGINE_IMPORT_ERROR", repr(e))
+
+print("RECONCILE_PRESENT", reconcile is not None)
+if reconcile is None:
+    failures.append("no _reconcile_rerank_priority - #4212 not applied")
+else:
+    class _RC:
+        def __init__(self, internal):
+            self.internal = internal
+
+    _recs = []
+
+    class _H(logging.Handler):
+        def emit(self, r):
+            _recs.append(r.getMessage())
+
+    me.logger.addHandler(_H())
+    me.logger.setLevel(logging.WARNING)
+
+    # Harmful mismatch: _background=True, internal=False -> repair to background + WARN.
+    _recs.clear()
+    harmful = reconcile(True, _RC(False))
+    harmful_warned = any("#4212" in m for m in _recs)
+    print("RECONCILE_HARMFUL_REPAIR", harmful, "WARN", harmful_warned)
+    if harmful is not True:
+        failures.append("#4212 harmful mismatch (_background without internal) did not repair to background priority")
+    if not harmful_warned:
+        failures.append("#4212 harmful mismatch did not warn")
+
+    # Legitimate reflect divergence: internal=True, _background=False -> background, SILENT.
+    _recs.clear()
+    reflect_bg = reconcile(False, _RC(True))
+    reflect_silent = not _recs
+    print("RECONCILE_REFLECT", reflect_bg, "SILENT", reflect_silent)
+    if reflect_bg is not True or not reflect_silent:
+        failures.append("#4212 reflect divergence (internal without _background) must be background AND silent")
+
+    # Normal user recall: neither -> foreground, silent.
+    _recs.clear()
+    if reconcile(False, _RC(False)) is not False or _recs:
+        failures.append("#4212 normal recall must be foreground and silent")
+    # None context with _background set -> still repaired + warned.
+    _recs.clear()
+    if reconcile(True, None) is not True or not any("#4212" in m for m in _recs):
+        failures.append("#4212 _background with request_context=None must repair + warn")
+
+# The rerank site (in _search_with_retries) must route through the helper, and
+# _background must be threaded from recall_async's admission param down to it.
+if ME is not None:
+    sw_bg = inspect.signature(ME._search_with_retries).parameters.get("_background")
+    print("SEARCH_WITH_RETRIES_BG_PARAM", sw_bg is not None)
+    if sw_bg is None:
+        failures.append("#4212 _search_with_retries lost the _background kwarg")
+    elif sw_bg.default is not False:
+        failures.append("#4212 _search_with_retries _background default is not False")
+    sw_src = inspect.getsource(ME._search_with_retries)
+    routes = "_reconcile_rerank_priority(_background, request_context)" in sw_src
+    print("RERANK_ROUTES_THROUGH_HELPER", routes)
+    if not routes:
+        failures.append("#4212 rerank site does not route through _reconcile_rerank_priority")
+    if "_background=_background,  # switchroom #4212" not in inspect.getsource(ME.recall_async):
+        failures.append("#4212 recall_async does not forward _background to _search_with_retries")
+
+# ---- #4213: reranker pool teardown wired into MemoryEngine.close() ----
+shutdown_executor = getattr(getattr(ce, "LocalSTCrossEncoder", None), "shutdown_executor", None)
+print("SHUTDOWN_EXECUTOR_PRESENT", shutdown_executor is not None)
+if shutdown_executor is None:
+    failures.append("#4213 LocalSTCrossEncoder.shutdown_executor missing")
+else:
+    ce.LocalSTCrossEncoder._get_executor()
+    ce.LocalSTCrossEncoder.shutdown_executor()
+    reset = ce.LocalSTCrossEncoder._executor is None
+    ce.LocalSTCrossEncoder.shutdown_executor()  # idempotent second call must not raise
+    print("SHUTDOWN_EXECUTOR_RESETS", reset)
+    if not reset:
+        failures.append("#4213 shutdown_executor did not reset _executor to None")
+if ME is not None:
+    close_src = inspect.getsource(ME.close)
+    wired = "asyncio.to_thread(LocalSTCrossEncoder.shutdown_executor)" in close_src
+    print("CLOSE_WIRES_SHUTDOWN", wired)
+    if not wired:
+        failures.append("#4213 MemoryEngine.close() does not wire shutdown_executor")
+
 print("FAILURES", failures)
 # Sentinel: proves the probe ran to completion.
 print("PROBE_EXECUTED")
@@ -425,6 +537,9 @@ describe.skipIf(!dockerOk || !upstreamOk)(
       // The background kwarg is absent from every layer upstream.
       expect(stdout).toContain("BG_PARAM CrossEncoderModel.predict False");
       expect(stdout).toContain("BG_PARAM CrossEncoderReranker.rerank False");
+      // #4212 / #4213 surfaces are absent upstream.
+      expect(stdout).toContain("RECONCILE_PRESENT False");
+      expect(stdout).toContain("SHUTDOWN_EXECUTOR_PRESENT False");
     }, 240_000);
   }
 );
@@ -456,6 +571,17 @@ describe.skipIf(!dockerOk || !builtOk)(
       expect(stdout).toContain("CANCELLED_QUEUED_SKIPPED True");
       expect(stdout).toContain("SHUTDOWN_JOINED True");
       expect(stdout).toContain("REJECTS_ZERO_WORKERS True");
+      // #4212 dual-signal reconciliation: the helper repairs + WARNS on the
+      // harmful mismatch, and is background-but-SILENT on the reflect divergence.
+      expect(stdout).toContain("RECONCILE_PRESENT True");
+      expect(stdout).toContain("RECONCILE_HARMFUL_REPAIR True WARN True");
+      expect(stdout).toContain("RECONCILE_REFLECT True SILENT True");
+      expect(stdout).toContain("SEARCH_WITH_RETRIES_BG_PARAM True");
+      expect(stdout).toContain("RERANK_ROUTES_THROUGH_HELPER True");
+      // #4213 reranker pool teardown exists, is idempotent, and close() wires it.
+      expect(stdout).toContain("SHUTDOWN_EXECUTOR_PRESENT True");
+      expect(stdout).toContain("SHUTDOWN_EXECUTOR_RESETS True");
+      expect(stdout).toContain("CLOSE_WIRES_SHUTDOWN True");
     }, 240_000);
   }
 );


### PR DESCRIPTION
Two LOW follow-ups to the #3142 reranker foreground-priority bake, both living in `docker/Dockerfile.hindsight`'s anchor-asserted source-fork patch. One focused PR.

## #4212 — dual-signal rerank priority reconciliation

**Finding (contradicts the original latent-risk framing).** The #3142 block's comment claimed admission (`_background`) and rerank (`request_context.internal`) priority signals "agree on all current v0.19.48 paths." That is **false**: a **reflect sub-recall** (`reflect/tools.py` does `replace(request_context, internal=True)` with **no** `_background`) is admission-**foreground** (a user is waiting on the reflect answer) yet rerank-**background** (it fans out a wall of reranks that must not starve single interactive reranks). So `internal=True, _background=False` is a **live, correct** path today — a "the two must agree" hard guard would fire on every reflect.

The **only** harmful direction is the converse: `_background=True` with `.internal=False`, where a background-admitted recall would rerank as **foreground** and jump the queue ahead of interactive recall — defeating the exact starvation problem that upstream #3142 exists to fix.

**Fix (least-fragile, deterministic).** Thread `_background` down from `recall_async` into `_search_with_retries`, and derive the rerank class through a single module-level helper `_reconcile_rerank_priority(_background, request_context)` returning `(_background OR internal)`. The invariant now holds **by construction** — a future diverging caller cannot silently slip past it — and the helper **log-warns** on the harmful direction so the source is fixed rather than merely masked. Behaviour-preserving on every current path (verified via the full matrix in the probe).

## #4213 — reranker-pool teardown

`_PriorityRerankExecutor` was created lazily but never shut down. `MemoryEngine.close()` — the engine teardown hook the API lifespan (`create_app`) and the worker main loop **both** await, which already shuts down every other long-lived worker/pool — was the one omission. **Investigated the actual shutdown lifecycle in the through-built image**: `close()` is the real, reachable hook, so this is **wire-in, not remove**. Added an idempotent `LocalSTCrossEncoder.shutdown_executor(wait=True)` classmethod (nulls the class ref under the existing lock, consistent with `_get_executor()`) and wired it into `close()` via `asyncio.to_thread` so the bounded join never blocks the event loop during graceful shutdown.

## Build-time guards

Extended the patch's post-condition asserts to gate both surfaces: helper present, returns `(_background OR internal)`, harmful-direction warning baked, old single-signal derivation **gone**, `_background` forwarded to `_search_with_retries`, `shutdown_executor` classmethod present and wired into `close()`. All still `ast.parse`-validated.

## Test plan

- `tsc --noEmit` — clean.
- `tests/docker/dockerfile-hindsight-bakes.test.ts` (structural) — **35/35**. New expects pin every #4212/#4213 injection + both new build-time post-condition asserts.
- `tests/docker/hindsight-reranker-priority-patch.test.ts` (behavioural probe) — **5/5**. RED arm (raw upstream) proves the surfaces are absent; GREEN arm proves: helper folds `(_background OR internal)`, **repairs + WARNS** on the harmful mismatch, is background-but-**silent** on the reflect divergence, `_background` threaded into `_search_with_retries`, rerank site routes through the helper, `shutdown_executor` idempotent + resets, and `close()` wires it.

**Build disclosure:** `docker buildx` is **not available** in this environment, so no real BuildKit heredoc build was run. The GREEN arm was validated against a **stand-in image**: the 13 `RUN python3 <<'PYEOF'` blocks extracted verbatim from this Dockerfile and applied in order onto the pinned base image (all 13 apply cleanly, `ast.parse` passes), then committed. CI's `hindsight-probe` job does the real `docker build` and sets `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1`, under which an unavailable build is a hard failure, never a green skip.

Closes #4212
Closes #4213

🤖 Generated with [Claude Code](https://claude.com/claude-code)
