### PR TITLE
spec: sanction Telegram+Buzz as the two channels (co-channel contract reconciliation)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -434,7 +434,7 @@ map): `vision.md` (four outcomes: standing team / on the leash /
 subscription-honest / always available), `principles.md` (three checks —
 docs test, defaults test, consistency test; a "no" is a redesign),
 `invariants.md` (hard gates: claude-native, no-self-escalation, on-leash,
-single-tenant, telegram-only, chat-is-source-of-truth), `product-spec.md`
+single-tenant, telegram-and-buzz-only, chat-is-source-of-truth), `product-spec.md`
 (job index), `jobs/*.md` (outcome-focused job specs — survey with
 `head -7 reference/jobs/*.md`), `rfcs/` (the "how" layer + standing design
 records).

--- a/reference/invariants.md
+++ b/reference/invariants.md
@@ -127,25 +127,55 @@ isolation is *between the users they configured*, never from the operator.
   it is out. Multiple trusted **users** inside one tenant (including
   per-user memory isolation) is in scope, not a violation.
 
-## `telegram-only`
+## `telegram-and-buzz-only`
 
-One channel, Telegram, done properly. Not a multi-channel bridge across
-Slack, Discord, or Teams. Auxiliary services (e.g. voice transcription) are
-opt-in helpers, not second channels.
+Two sanctioned channels, each done properly: **Telegram**, the pocket
+channel and the authoritative surface, and **Buzz**, the desktop
+co-channel. Exactly these two, never a third. The rejection of the open
+multi-channel bridge stands unchanged — not Slack, not Discord, not Teams,
+not a channel SDK; what changed (deliberately, 2026-08) is that the leash
+holds two first-class surfaces instead of one. Auxiliary services (e.g.
+voice transcription) are opt-in helpers, not channels.
 
-- **By-construction test:** does this add a second human-facing chat
+Buzz is a co-channel **on Telegram's terms**, fail-closed by construction:
+
+- **Dark by default.** `channels.buzz.enabled` defaults to `false`
+  (`src/config/schema.ts`, `BuzzChannelSchema`); absent or false means the
+  sidecar never forks and fleet behaviour is byte-identical to pre-Buzz.
+- **Inbound fail-closed.** An event becomes a turn only after signature
+  verification AND membership of the operator-pinned allowlist
+  (`authorized_pubkeys ∪ {operator_pubkey}`, default operator-only) on a
+  closed, NIP-42-authenticated NIP-29 relay
+  (`src/buzz-gateway/auth-gate.ts`).
+- **Outbound is a mirror, not a second voice.** The only way a Buzz event
+  is emitted is as a mirror of an already-delivered Telegram message
+  (`telegram-plugin/gateway/buzz-mirror.ts`); there is no agent-facing
+  Buzz-only send path, and a Buzz failure never fails, delays, or retries
+  the Telegram answer. Approvals, liveness, and consent stay on Telegram.
+- **One session, one voice.** A Buzz turn is injected into the same single
+  agent session, exactly like a cron fire (`src/buzz-gateway/pump.ts`);
+  its answer lands on Telegram first and mirrors back to Buzz. There is no
+  second agent loop and no conversation the one session doesn't hold.
+- **Routing fail-safes to Telegram.** Any ambiguity in a turn's origin
+  resolves to Telegram (`telegram-plugin/gateway/channel-route.ts`).
+
+- **By-construction test:** does this add a **third** human-facing chat
   channel **for the people the team serves**, a bridge to WhatsApp, Signal,
-  Slack, Discord, Teams, or the like? If yes, it is out. This invariant is
-  about the *principal's* channel: there is exactly one, Telegram, done
-  properly. It is **not** a ban on operator/admin tooling.
+  Slack, Discord, Teams, or the like — or give Buzz an approval surface, an
+  unmirrored send path, or a conversation the one agent session doesn't
+  hold? If yes,
+  it is out. Adding any further channel is a change to *this contract*, not
+  a feature. This invariant is about the *principal's* channels: there are
+  exactly two, deliberately chosen, each done properly. It is **not** a ban
+  on operator/admin tooling.
 
 ### Scope: the admin console is not a channel
 
 An **operator/admin** management console (e.g. a Hermes-Desktop client pointed
 at a Switchroom adapter) is **out of this invariant's scope**: it is admin
 tooling for the person who runs the box, not a chat channel for the people the
-team serves. `telegram-only` stays strictly true: it governs *principal*
-channels, and the admin console is not one.
+team serves. `telegram-and-buzz-only` stays strictly true: it governs
+*principal* channels, and the admin console is not one.
 
 The console MAY let the operator send a turn to one of their own agents from
 outside Telegram. To stay admin tooling (and not quietly become a second
@@ -170,10 +200,11 @@ channel or a hidden conversation), it must hold all four:
    sole approval surface (`no-self-escalation`). A console that wires
    approvals is out.
 
-The line that *would* cross `telegram-only` is a **principal-facing** bridge:
-giving the people the team serves a second way to chat (WhatsApp, Signal, a
-public web chat). That is still out. The detail contract for the admin console
-is [`rfcs/fleet-dashboard.md`](rfcs/fleet-dashboard.md).
+The line that *would* cross `telegram-and-buzz-only` is a
+**principal-facing** bridge: giving the people the team serves a third way to
+chat (WhatsApp, Signal, a public web chat). That is still out. The detail
+contract for the admin console is
+[`rfcs/fleet-dashboard.md`](rfcs/fleet-dashboard.md).
 
 ## `chat-is-the-single-source-of-truth`
 

--- a/reference/jobs/fleet-stays-healthy.md
+++ b/reference/jobs/fleet-stays-healthy.md
@@ -132,7 +132,7 @@ not just the happy path, and the sensor stays model-free across it.
   stale "fixed" issues that never actually recovered.
 - *Surface discipline:* the ranked view lives on the operator admin page, not
   in a principal's Telegram thread and not as a parallel pinned status mirror.
-  It is operator tooling (like the fleet dashboard), so `telegram-only` and
+  It is operator tooling (like the fleet dashboard), so `telegram-and-buzz-only` and
   `chat-is-the-single-source-of-truth` hold.
 
 ## Related

--- a/reference/jobs/operate-the-fleet-from-telegram.md
+++ b/reference/jobs/operate-the-fleet-from-telegram.md
@@ -3,7 +3,7 @@ job: operate the fleet from Telegram and see what a fleet operation is doing
 outcome: When the operator drives a fleet-wide operation from Telegram (a rollout, an update), they can see it progress and land — phase by phase, in the chat and in a durable record — without host-side grep, and without a live pinned surface running parallel to the conversation.
 stakes: A fleet rollout is the single riskiest thing the operator does, and today it goes dark: the roll writes one terminal row to a host-side log, `get_status` is blind to its phases, and nothing reaches Telegram. When a real roll (v0.16.35) half-failed, the only way to learn the outcome was to SSH in and grep. An operator who can't see a rollout land can't trust it, and can't catch a half-rolled fleet before a principal does. But the fix is one step from re-creating the retired pinned progress card — so the operability this job asks for must live in durable artifacts plus in-chat narration, never a parallel pinned mirror.
 serves: hold-the-leash
-invariants: [chat-is-the-single-source-of-truth, telegram-only, no-self-escalation, single-tenant]
+invariants: [chat-is-the-single-source-of-truth, telegram-and-buzz-only, no-self-escalation, single-tenant]
 ---
 
 # Job Spec: operate the fleet from Telegram and see what a fleet operation is doing

--- a/reference/jobs/see-my-whole-fleet-from-one-screen.md
+++ b/reference/jobs/see-my-whole-fleet-from-one-screen.md
@@ -3,7 +3,7 @@ job: see and manage my whole fleet from one operator screen
 outcome: The operator can open one management console and see every agent's live state, health, quota, history, sessions, memory, workspace, and approval/audit trail, run fleet ops (restart, config edits), and drive an agent with a turn from the console, without any secret reaching the client, without approvals ever leaving Telegram, and without the surface becoming the principal's source of truth or a separate conversation record (operator turns mirror into the agent's Telegram thread).
 stakes: An operator running a standing fleet 24/7 needs a place to glance across all of it at once. The chat is per-agent and per-topic, so a fleet-wide problem (a stuck agent, a quota wall, a drifted config, a failing memory backend) is invisible until a principal complains. Without a fleet view the operator debugs blind, one `docker exec` at a time. But a dashboard is also the easiest place to accidentally rebuild the retired progress card, leak a token, or grow a second approval path, so the screen earns its place only by staying an operator tool, never a principal one.
 serves: hold-the-leash
-invariants: [chat-is-the-single-source-of-truth, telegram-only, no-self-escalation, single-tenant, claude-native]
+invariants: [chat-is-the-single-source-of-truth, telegram-and-buzz-only, no-self-escalation, single-tenant, claude-native]
 ---
 
 # Job Spec: see and manage my whole fleet from one operator screen
@@ -93,10 +93,10 @@ channel or a second approval path.
   history; the decision never happens here.
 - A **principal-facing** way in from the console, or an operator turn that
   does **not** mirror into the Telegram thread (a hidden side-channel
-  conversation). The admin console stays out of `telegram-only`'s scope only
+  conversation). The admin console stays out of `telegram-and-buzz-only`'s scope only
   while it is operator-only and every turn surfaces in the one Telegram
   record. A prompt box the principal uses, or a bridge to WhatsApp/Signal,
-  crosses `telegram-only`.
+  crosses `telegram-and-buzz-only`.
 - Any secret reaching the browser, an API response, or a log
   (`credentials.json`, vault values, OAuth/bot tokens).
 - A mutating path that lets the web grant access the operator's config
@@ -130,7 +130,7 @@ principal's chat jobs). Pin:
 - **Operator turn = one record** — a turn sent from the console produces a
   real turn in the target agent's Telegram thread (turn and reply observable
   there). *Invariant:* the console never opens a conversation the Telegram
-  thread can't see; the admin console stays out of telegram-only's scope.
+  thread can't see; the admin console stays out of telegram-and-buzz-only's scope.
 - **Exposure floor** — off by default; loopback bind default; unauthenticated
   non-loopback bind is refused. *Invariant:* a network-accessible bind
   without auth never serves.
@@ -179,6 +179,6 @@ principal's chat jobs). Pin:
 > artifact, `serves:` this job): the Hermes-Desktop adapter served from
 > `src/web/` (`switchroom-web`), with unmodified Hermes Desktop run in remote
 > mode as the client. `reference/invariants.md` records why the admin console
-> is out of `telegram-only`'s scope (it governs principal channels, not admin
+> is out of `telegram-and-buzz-only`'s scope (it governs principal channels, not admin
 > tooling) and the conditions that keep it so. Those churn; this job outlives
 > them.

--- a/reference/jobs/talk-to-agents-from-anywhere.md
+++ b/reference/jobs/talk-to-agents-from-anywhere.md
@@ -3,7 +3,7 @@ job: talk to my agents from anywhere
 outcome: The user can drive their fleet from a phone on the train as naturally as from a laptop at a desk. The interaction surface is where the user already is.
 stakes: If the product requires the user to be at a machine, it's a dev tool, not an assistant. Most of the user's life happens away from the keyboard.
 serves: always-available
-invariants: [telegram-only]
+invariants: [telegram-and-buzz-only]
 ---
 
 # Job Spec: talk to my agents from anywhere
@@ -24,7 +24,10 @@ or pause their agents must be reachable from where they already are.
 
 This is not porting a CLI to mobile. It's accepting
 the phone as the primary surface and designing back from there. The desktop
-benefits from that discipline rather than being diminished by it.
+benefits from that discipline rather than being diminished by it — and it
+has its own first-class surface, Buzz
+([`use-my-team-from-the-desktop`](use-my-team-from-the-desktop.md)); this
+job owns the phone.
 
 ## Good / bad
 
@@ -59,8 +62,9 @@ benefits from that discipline rather than being diminished by it.
   Silence on mobile reads as "dead," not "working."
 - Requiring the user to be in a specific view, or tap through a settings
   panel, to steer a task that's already running.
-- A second human-facing chat channel bolted on beside the one. One channel,
-  done properly, not a multi-channel bridge.
+- A third human-facing chat channel bolted on beside the two. Telegram in
+  the pocket, Buzz at the desk, each done properly — never an open
+  multi-channel bridge.
 
 ## Prove it
 
@@ -96,15 +100,16 @@ Named by job × surface, pointing at real scenarios.
 - **One fleet, addressable across surfaces (DM + channel)** —
   `jtbd-supergroup-reply-channel`, `fuzz-multitopic-routing-channel`.
   *Watch:* multiple agents are addressed naturally in DM and forum channel
-  alike. *Invariant:* the fleet stays one coherent surface, the single
-  Telegram channel, never a second one.
+  alike. *Invariant:* the fleet stays one coherent conversation on the two
+  sanctioned surfaces — Telegram authoritative, Buzz mirroring it — never a
+  third.
 
 **Fuzz corpus:** vary input type (text × photo × voice × location × album)
 × message timing (idle × mid-turn × rapid follow-up) × turn length (trivial
 × long-running with screen off) × surface (DM vs forum channel) ×
 connectivity (steady vs dead-zone reconnect). The invariants must hold
 across the corpus: reachable from chat alone, instant ack, never a silent
-walk-away, one channel only.
+walk-away, the two sanctioned channels only.
 
 ## Verdict
 
@@ -141,3 +146,5 @@ walk-away, one channel only.
   correction of a running turn.
 - [`deliver-files-i-can-open`](deliver-files-i-can-open.md) — files and
   attachments as first-class input and output on a phone.
+- [`use-my-team-from-the-desktop`](use-my-team-from-the-desktop.md) — the
+  desk half of the same loop: Buzz as co-channel, Telegram authoritative.

--- a/reference/jobs/use-my-team-from-the-desktop.md
+++ b/reference/jobs/use-my-team-from-the-desktop.md
@@ -1,0 +1,127 @@
+---
+job: use my team from the desktop
+outcome: The user at a desk drives the same fleet, in the same agent sessions, over Buzz — the desktop co-channel — while Telegram stays the authoritative surface. Every agent answer lands on Telegram first; Buzz only ever shows mirrors of it. Pocket and desk are two doors into one conversation, never two conversations.
+stakes: A phone-first surface alone tethers deep work to a thumb. But the moment a second surface becomes a second conversation — its own record, its own approvals, its own voice — the single source of truth is gone and the leash frays. The desktop surface earns its place only as a co-channel on Telegram's terms, dark by default, fail-closed by construction.
+serves: always-available
+invariants: [telegram-and-buzz-only, chat-is-the-single-source-of-truth, no-self-escalation, single-tenant]
+---
+
+# Job Spec: use my team from the desktop
+
+## The job
+
+The phone owns the away-from-keyboard loop
+([`talk-to-agents-from-anywhere`](talk-to-agents-from-anywhere.md)). This
+job owns the desk: during work hours the user lives in a desktop client,
+and reaching for the phone to talk to their own team is a tax. The job is
+to make the desk a first-class door into the same fleet — send a turn from
+the desktop, see the answers there — without ever forking the
+conversation. Buzz (a closed NIP-29 Nostr relay, one per-agent sidecar) is
+that door, and it is the *only* other door there will be.
+
+> [!IMPORTANT]
+> Buzz is a co-channel, not a peer authority. Telegram remains the
+> authoritative record and the sole approval/consent surface. Every Buzz
+> outbound is a mirror of a message Telegram already delivered.
+
+## Good / bad
+
+**Good looks like**
+
+- A message sent from the desk lands as an ordinary turn in the agent's
+  one session — same memory, same thread of work, injected exactly like a
+  cron fire — and the answer appears on both surfaces, Telegram first.
+- Every agent answer the user reads on Buzz is one the Telegram thread
+  already delivered: mirrors publish only after Telegram delivery, and a
+  Telegram edit mirrors as a correction.
+- The channel ships dark. Enabling it is a deliberate operator act per
+  agent (`channels.buzz.enabled`), and with it off, behaviour is
+  byte-identical to a Buzz-less fleet.
+- Only signed events from the operator-pinned allowlist ever become
+  turns; the default allowlist is the operator alone.
+- A relay outage costs nothing: Telegram answers land exactly as before,
+  and the desk surface catches up when the relay returns.
+
+**Bad looks like: never ship this**
+
+- A Buzz-only send path — an answer, status, or aside that exists on Buzz
+  but not in the Telegram thread. That is a second conversation.
+- An approve/deny/grant action tappable from Buzz. The human-validated
+  Telegram tap is the sole approval surface (`no-self-escalation`).
+- The agent reasoning about which channel to answer on. Routing is
+  deterministic mechanism in the gateway, never model judgement.
+- An open relay, a default allowlist that grows, or unsigned inbound
+  becoming a turn.
+- Generalising the sidecar into a channel SDK, adapter interface, or
+  "just one more" surface. The third channel is the line
+  (`telegram-and-buzz-only`).
+- Blocking, delaying, or failing a Telegram answer because the mirror
+  publish failed.
+
+## Prove it
+
+Named by mechanism, pointing at the shipped tests.
+
+- **Desk turn in, fail-closed** — `src/buzz-gateway/auth-gate.test.ts`,
+  `src/buzz-gateway/inbound-map.test.ts`,
+  `telegram-plugin/tests/buzz-origin-stamp-gate.test.ts`. *Watch:* a
+  signed, allowlisted event becomes an ordinary synthesized turn
+  (`meta.source="buzz"`); anything unsigned or unlisted never does.
+  *Invariant:* inbound is fail-closed; default allowlist is operator-only.
+- **Mirror, never a second voice** —
+  `telegram-plugin/tests/buzz-mirror.test.ts`,
+  `telegram-plugin/tests/ipc-server-buzz-peer.test.ts`. *Watch:* a Buzz
+  event is emitted only after the Telegram copy has landed; edits mirror
+  as corrections; a dead peer never fails the Telegram answer.
+  *Invariant:* no agent-facing Buzz-only send path exists.
+- **Dark by default** — `src/buzz-gateway/config.test.ts`,
+  `src/agents/compose-buzz-env.test.ts`. *Watch:* an absent or disabled
+  `channels.buzz` forks no sidecar and changes nothing. *Invariant:*
+  enabling the co-channel is an explicit operator act.
+- **One turn, once** — `src/buzz-gateway/dedup.test.ts`,
+  `telegram-plugin/tests/ipc-server-buzz-dedup.test.ts`,
+  `src/buzz-gateway/limits.test.ts`. *Watch:* replayed or duplicate relay
+  events inject one turn; volume is bounded. *Invariant:* the relay can
+  never storm the session.
+
+**Fuzz corpus:** vary origin (Telegram × Buzz) × mirror mode (`both` ×
+`off`) × relay state (up × down × flapping) × sender (operator ×
+allowlisted × stranger × unsigned). The invariants must hold across the
+corpus: Telegram record complete, approvals only on Telegram, fail-closed
+inbound, no third channel.
+
+## Verdict
+
+- **Done when:** the user can work a full desk session over Buzz — send
+  turns, read answers and corrections — while every agent answer lands on
+  Telegram first and Buzz shows only mirrors of it, approvals never leave
+  Telegram, and disabling Buzz returns the fleet to byte-identical
+  pre-Buzz behaviour.
+
+## Production-readiness
+
+- *Availability:* Buzz failing never degrades Telegram. Mirror publishes
+  are fire-and-forget with a bounded retry queue
+  (`src/buzz-gateway/retry-queue.ts`); the authoritative surface answers
+  regardless.
+- *Security:* NIP-42 auth to a closed relay; signature + allowlist before
+  any event becomes a turn; the agent's Nostr key is broker-fetched
+  in-process at sidecar boot, never written to env or logs.
+- *Leak discipline:* outbound text passes the Telegram scrub (layer 1)
+  and the sidecar re-scrubs before signing (layer 2); a secret never
+  reaches the relay.
+- *Honest scope:* mirror modes `both` and `off` are live; `origin` is
+  deferred (degrades to `off`). A desk-typed question is injected into
+  the session like a cron fire; its Telegram-feed copy is a later phase,
+  so today Telegram shows the answer, not the desk question itself.
+  Approvals, reactions, and other interactive affordances on Buzz are not
+  built; until a contract change says otherwise, they stay on Telegram.
+
+## Related
+
+- [`talk-to-agents-from-anywhere`](talk-to-agents-from-anywhere.md) — the
+  pocket half of the same loop; this spec is its desk counterpart.
+- [`approve-what-my-agent-can-touch`](approve-what-my-agent-can-touch.md)
+  — the approval surface Buzz must never grow.
+- [`know-what-my-agent-is-doing`](know-what-my-agent-is-doing.md) — the
+  in-chat liveness that stays on the authoritative surface.

--- a/reference/principles.md
+++ b/reference/principles.md
@@ -18,7 +18,7 @@ coherence bar (docs / defaults / consistency). The other half, the
 non-functional trust and safety bar, is **not** a principle you trade
 off on a gradient. It's enforced as hard lines in
 [`invariants.md`](invariants.md): claude-native, no-self-escalation,
-on-leash, single-tenant, telegram-only,
+on-leash, single-tenant, telegram-and-buzz-only,
 chat-is-the-single-source-of-truth. Security, the on-leash stakes, and
 the subscription-honest stakes live there as binary pass/fail gates. A
 feature can ace all three principle checks and still be out of scope
@@ -247,7 +247,7 @@ non-functional trust bar (security, the on-leash stakes, the
 subscription-honest stakes) is owned as binary lines in
 [`invariants.md`](invariants.md), not as anything you weigh here:
 claude-native, no-self-escalation, on-leash, single-tenant,
-telegram-only, chat-is-the-single-source-of-truth. Before you open the
+telegram-and-buzz-only, chat-is-the-single-source-of-truth. Before you open the
 PR, confirm the change crosses none of them. A "yes" on all three
 principle checks plus a crossed invariant is still out of scope.
 

--- a/reference/product-spec.md
+++ b/reference/product-spec.md
@@ -110,7 +110,9 @@ cron you created. Median ack within seconds.
 
 One agent per specialist, each a long-running service in its own Docker
 container, running the unmodified `claude` CLI authenticated with the
-operator's Pro/Max OAuth. The operator talks to the fleet from Telegram. A
+operator's Pro/Max OAuth. The operator talks to the fleet from Telegram —
+authoritative — plus an optional desktop co-channel, Buzz (dark by default,
+mirror of the Telegram record). A
 shared broker holds secrets; an approval kernel gates access an agent does
 not already have. Schedules and beck-and-call only, never a loop of its own.
 (Runtime detail lives in `CLAUDE.md` and `docs/`; this doc stays at the
@@ -149,5 +151,6 @@ Each links its job spec in `jobs/`.
 - [`survive-reboots-and-real-life.md`](jobs/survive-reboots-and-real-life.md) — turns silently dropped across reboots/network drops, target zero
 - [`idempotent-update-and-restart.md`](jobs/idempotent-update-and-restart.md) — update/restart operations completing cleanly and idempotently, target ~100%
 - [`talk-to-agents-from-anywhere.md`](jobs/talk-to-agents-from-anywhere.md) — median ack latency from Telegram message to acknowledgement
+- [`use-my-team-from-the-desktop.md`](jobs/use-my-team-from-the-desktop.md) — share of desk-origin turns whose full exchange also lands in the Telegram thread, target 100%
 - [`act-in-my-tools-with-an-identity.md`](jobs/act-in-my-tools-with-an-identity.md) — share of external-tool actions attributable to a named agent identity
 - [`fleet-stays-healthy.md`](jobs/fleet-stays-healthy.md) — share of recurring per-job failures the fleet surfaces and tracks itself vs found by a principal complaining

--- a/reference/rfcs/fleet-dashboard.md
+++ b/reference/rfcs/fleet-dashboard.md
@@ -36,7 +36,7 @@ The connection is **observe + operator-chat, approvals stay on Telegram**:
   methods/events; per the desktop's graceful-degradation behaviour that panel
   just stays empty. The Telegram tap remains the sole approval surface.
 
-**`telegram-only` is not crossed.** That invariant governs the *principal's*
+**`telegram-and-buzz-only` is not crossed.** That invariant governs the *principal's*
 channel. It bars a second chat channel for the people the team serves
 (WhatsApp, Signal, Slack). The dashboard is an **admin component** of
 switchroom, not a principal channel, so it is out of that invariant's scope.
@@ -48,7 +48,7 @@ desktop fork is maintained. We track upstream by implementing its contract.
 ## Decisions (owner-ratified)
 
 These were settled with the owner before this draft (see the admin-console
-scope note under `telegram-only` in `invariants.md`):
+scope note under `telegram-and-buzz-only` in `invariants.md`):
 
 1. **No return of the progress card.** This is not the retired #1122 card
    rebuilt anywhere. The live desktop activity stream is an **operator**
@@ -119,7 +119,7 @@ Model/provider/env endpoints return Switchroom's claude-native truth
    `message.delta` so the desktop is live too.
 
 Result: exactly one record (Telegram), the desktop is an input + live view,
-nothing is hidden. This is what keeps the admin console out of `telegram-only`'s scope (an input that feeds the one thread, not a second channel).
+nothing is hidden. This is what keeps the admin console out of `telegram-and-buzz-only`'s scope (an input that feeds the one thread, not a second channel).
 
 ## Alignment review of the original external plan (still valid)
 
@@ -183,7 +183,7 @@ embedded-terminal path; Hermes's own messaging-platform gateway; deprecating
 | `claude-native` | Pass — adapter emits events + answers RPCs over Switchroom's own data/IPC; no API/SDK/token; the agent runtime is still the unmodified CLI. |
 | `no-self-escalation` | Pass — approval methods are not implemented; the Telegram tap stays the sole approval surface. |
 | `chat-is-the-single-source-of-truth` | Pass — operator-audience surface; chat prompt untouched (no crutch); turns + replies mirror into the one Telegram thread. |
-| `telegram-only` | Pass — **not crossed.** The invariant governs *principal* channels; the dashboard is an admin component, out of scope. The admin-console conditions (operator audience, mirrored to the one Telegram thread, approvals on Telegram) keep it from becoming a second channel. A principal-facing bridge (WhatsApp/Signal/web chat) would still be out. |
+| `telegram-and-buzz-only` | Pass — **not crossed.** The invariant governs *principal* channels; the dashboard is an admin component, out of scope. The admin-console conditions (operator audience, mirrored to the one Telegram thread, approvals on Telegram) keep it from becoming a second channel. A principal-facing bridge (WhatsApp/Signal/web chat) would still be out. |
 | `single-tenant` | Pass — one operator, auth-gated, single deployment. |
 
 ## Testing

--- a/reference/rfcs/fleet-health.md
+++ b/reference/rfcs/fleet-health.md
@@ -319,7 +319,7 @@ It shows:
 It is an **operator surface** — same posture as the fleet dashboard
 (`see-my-whole-fleet-from-one-screen`): authenticated, single-tenant, never a
 principal channel, and it renders no parallel status mirror into a Telegram
-thread. `telegram-only` and `chat-is-the-single-source-of-truth` hold.
+thread. `telegram-and-buzz-only` and `chat-is-the-single-source-of-truth` hold.
 
 ## Evidence tiers + failure-mode taxonomy (the sensor's classification)
 

--- a/reference/rfcs/user-concept.md
+++ b/reference/rfcs/user-concept.md
@@ -161,7 +161,10 @@ with no `users:` block generates empty maps and behaves exactly as today.
   the speaker's profile is a natural follow-on, now that `user` exists.
 - **Identity-keyed approvals / scheduling / quotas** — the `user` entity is
   the anchor; those are separate RFCs.
-- **A user driving from a non-Telegram channel** — out by `telegram-only`.
+- **A user driving from outside the two sanctioned channels** — out by
+  `telegram-and-buzz-only`. (Buzz identity is a separate question: its
+  inbound allowlist is operator-pinned pubkeys, and this RFC's `user`
+  entity is Telegram-keyed.)
 
 ## Open questions
 

--- a/reference/vision.md
+++ b/reference/vision.md
@@ -18,8 +18,8 @@ It asks first on anything that matters.
 
 Not a general-purpose orchestrator. Not a multi-channel bridge. Not a
 hosted service. Not multi-tenant. Not an agent that roams on its own.
-One idea, done properly: a personal team that lives in Telegram and
-stays on your leash.
+One idea, done properly: a personal team that lives in Telegram — with
+Buzz as its desktop co-channel — and stays on your leash.
 
 ---
 
@@ -38,8 +38,11 @@ being the one I needed, and nothing else fixed them.
 - **On the leash.** Give an assistant broad standing access and one day
   it helpfully does something irreversible. Credentials, tools, skills:
   granted deliberately, approved by a human, no way around it.
-- **Telegram, done properly.** Not a bridge spread thin across Slack,
-  Discord, Teams. One channel. Opinionated. Excellent.
+- **The channel, done properly.** Not a bridge spread thin across Slack,
+  Discord, Teams. One channel — Telegram — done excellently. (In 2026-08
+  a second was sanctioned, once, deliberately: Buzz, the desktop
+  co-channel, on Telegram's terms. Two chosen surfaces, never a third,
+  still no bridge.)
 
 So I built it.
 
@@ -64,11 +67,12 @@ functions to deliver them, and the jobs that ladder up to each live in
    guardrails: still the unmodified CLI on the same OAuth, forwarded
    unchanged, fail-open. See the claude-native gateway carve-out in
    [`invariants.md`](invariants.md).
-4. **Always available, in Telegram, done properly** — there when you want it.
+4. **Always available, in Telegram and Buzz, done properly** — there when
+   you want it: Telegram in your pocket, Buzz at your desk.
 
 The hard constraints under these (claude-native, no-self-escalation,
-on-leash, single-tenant, telegram-only) are the lines we won't cross by
-construction: [`invariants.md`](invariants.md).
+on-leash, single-tenant, telegram-and-buzz-only) are the lines we won't
+cross by construction: [`invariants.md`](invariants.md).
 
 ---
 
@@ -94,7 +98,7 @@ hidden.
 |---|---|
 | A harness or wrapper | Switchroom never intercepts auth or inference. The `claude` CLI is the runtime. |
 | A multi-provider orchestrator | No OpenAI, Gemini, Llama, or model swapping for inference. Auxiliary services (e.g. voice transcription via Whisper) are opt-in helpers, not Claude replacements. |
-| A multi-channel bridge | Not Slack, not Discord, not Teams. Telegram, done properly. |
+| A multi-channel bridge | Not Slack, not Discord, not Teams. Two deliberate surfaces — Telegram (pocket) and Buzz (desktop) — never a third. |
 | An autonomous agent | No heartbeats. Beck-and-call plus explicit schedules, on your leash. |
 | Multi-tenant | Single-tenant by design — one operator's deployment. Multiple *trusted* users within that one tenant are supported; serving *separate* tenants is not. |
 | A hosted service | Self-hosted only. Your box, your tokens, your data. |

--- a/src/web/hermes-adapter.ts
+++ b/src/web/hermes-adapter.ts
@@ -10,7 +10,7 @@
  * Not implemented (panels degrade gracefully in Hermes Desktop):
  *   approval.*, sudo.*, secret.*, pet.*, billing.*, voice.*
  *
- * Operator-console invariants (invariants.md §telegram-only admin-console scope):
+ * Operator-console invariants (invariants.md §telegram-and-buzz-only admin-console scope):
  *   1. Operator-only audience — token-gated, same auth as the dashboard.
  *   2. prompt.submit mirrors into the agent's Telegram thread via inject_inbound.
  *   3. Same inject_inbound path as cron (synthesized turn, not a new channel).


### PR DESCRIPTION
**Awaits operator confirmation of wording — draft on purpose; do not enqueue.**

Reconciles the design contract with the merged (dark) Buzz Phase 2 code, per the operator's product decision: the sanctioned channels are **Telegram + Buzz, exactly those two, never a third**. Telegram is the pocket channel and stays authoritative; Buzz is the desktop co-channel. This is a deliberate two-surface stance, NOT a reversal of the anti-open-bridge position.

## Before → after, per doc

### `reference/invariants.md`
- **Before:** `## telegram-only` — "One channel, Telegram, done properly. Not a multi-channel bridge…" with a by-construction test banning "a second human-facing chat channel."
- **After:** `## telegram-and-buzz-only` — two sanctioned channels, Telegram authoritative + Buzz desktop co-channel, "exactly these two, never a third"; the open-bridge rejection stands. Fail-closed grounding in the merged code: dark by default (`channels.buzz.enabled` defaults false, `src/config/schema.ts`), allowlist+signature inbound (`src/buzz-gateway/auth-gate.ts`), mirror-only outbound (`telegram-plugin/gateway/buzz-mirror.ts` — no Buzz-only send path), one-session-one-voice (`src/buzz-gateway/pump.ts`), routing fail-safes to Telegram (`channel-route.ts`). By-construction test now bans a THIRD channel, a Buzz approval surface, an unmirrored send path, or a conversation the one session doesn't hold. Admin-console scope subsection retained, slug updated.
- `chat-is-the-single-source-of-truth` untouched: Buzz shows only mirrors of already-delivered Telegram messages.

### `reference/vision.md` (lightest touch)
- "a personal team that lives in Telegram and stays on your leash" → "…lives in Telegram — with Buzz as its desktop co-channel — and stays on your leash."
- "**Telegram, done properly.** … One channel. Opinionated. Excellent." → "**The channel, done properly.** … One channel — Telegram — done excellently. (In 2026-08 a second was sanctioned, once, deliberately: Buzz… never a third, still no bridge.)"
- Outcome 4: "Always available, in Telegram, done properly" → "…in Telegram and Buzz, done properly — Telegram in your pocket, Buzz at your desk."
- What-it-isn't table: "Telegram, done properly." → "Two deliberate surfaces — Telegram (pocket) and Buzz (desktop) — never a third."

### `reference/jobs/talk-to-agents-from-anywhere.md`
- frontmatter `invariants: [telegram-only]` → `[telegram-and-buzz-only]`
- "A second human-facing chat channel bolted on beside the one" → "A third … beside the two"
- Prove-it/fuzz "the single Telegram channel, never a second one" / "one channel only" → two sanctioned surfaces, Telegram authoritative, Buzz mirroring; body cross-links the new desk job (this spec keeps the phone).

### `reference/jobs/use-my-team-from-the-desktop.md` (NEW)
Desk half of the loop, `serves: always-available`, invariants `[telegram-and-buzz-only, chat-is-the-single-source-of-truth, no-self-escalation, single-tenant]`. Good/bad + Prove-it wired to the shipped tests (auth-gate, inbound-map, buzz-mirror, ipc-server-buzz-*, dedup/limits, compose-buzz-env). Honest scope: mirror `origin` deferred; the desk question's Telegram-feed copy is a later phase; approvals/reactions on Buzz are NOT built and stay on Telegram.

### `reference/product-spec.md`
- Job index (always-available): added `use-my-team-from-the-desktop.md` — "share of desk-origin turns whose full exchange also lands in the Telegram thread, target 100%."
- "How it functions": operator talks from Telegram "— authoritative — plus an optional desktop co-channel, Buzz (dark by default, mirror of the Telegram record)."

### Mechanical slug rename (`telegram-only` → `telegram-and-buzz-only`)
`principles.md` (×2), `CLAUDE.md` design-contract line, `jobs/operate-the-fleet-from-telegram.md`, `jobs/see-my-whole-fleet-from-one-screen.md`, `jobs/fleet-stays-healthy.md`, `rfcs/fleet-dashboard.md`, `rfcs/fleet-health.md`, `rfcs/user-concept.md` (out-of-scope bullet reworded so Buzz isn't wrongly excluded), one code comment `src/web/hermes-adapter.ts:13`.

## Verdict-rule mapping for the Buzz co-channel
Outcome: `always-available` → Job spec: `jobs/use-my-team-from-the-desktop.md` → Invariants crossed: none (`telegram-and-buzz-only` sanctions it; `chat-is-the-single-source-of-truth` holds via mirror-only outbound + Telegram-first delivery).

## Not touched (deliberate)
`messaging/copy-kit.md` still says "One channel" — public copy is a messaging decision; follow-up once wording is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
