### PR TITLE
fix(errors): classify mid-response stream aborts as transport-transient, not a fabricated Reauth 4xx

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -411,6 +411,7 @@ import {
 import { createMcpFailureHook } from './mcp-failure-hook.js'
 import { pendingUserNoticeGate } from '../pending-user-notice.js'
 import { recordOperatorEvent } from '../operator-events-history.js'
+import { emitTransportTransientEvent, flushDeferredUserNotices, type UserFailureNoticeDeps } from './user-failure-notices.js'
 import {
   parseLlmError,
   renderLlmErrorSafe,
@@ -7887,6 +7888,14 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
   // 429 metrics — defense in depth, no secret survives in ANY downstream sink.
   event = { ...event, detail: redactOutboundText(event.detail, 'operator_event') }
 
+  // transport-transient (mid-response stream abort — `server_error`/`api_error`
+  // with no HTTP status): no broadcast card, no Reauth; record + deferred user
+  // notice, burst escalates. Orchestration in user-failure-notices.ts.
+  if (kind === 'transport-transient') {
+    emitTransportTransientEvent(event, userFailureNoticeDeps())
+    return
+  }
+
   // ── 429 throttle tier (operator spec: "retry in place under 5 min, else
   // mark + failover, honest reset messaging") ────────────────────────────
   // A terminal TRANSIENT ACCOUNT-scoped 429 — kind `rate-limited` carrying
@@ -8270,20 +8279,35 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
     // liveness only THAT topic's turn end resolves it (full rationale on
     // `PendingUserNotice.key`). `undefined` (no live turn — the event is
     // agent-level, empty wire chatId) keeps the legacy agent-wide resolution.
-    const liveTurn = currentTurn
-    const noticeKey =
-      liveTurn != null ? statusKey(liveTurn.sessionChatId, liveTurn.sessionThreadId) : undefined
-    pendingUserNoticeGate.schedule({
-      chatIds: userNoticeChats,
-      text: renderUserFacingFailureNotice(),
-      agent,
-      kind,
-      atMs: Date.now(),
-      key: noticeKey,
-    })
+    const noticeDeps = userFailureNoticeDeps()
+    const noticeKey = noticeDeps.liveTurnKey()
+    noticeDeps.scheduleUserNotice({ chatIds: userNoticeChats, agent, kind, key: noticeKey, atMs: Date.now() })
     process.stderr.write(
       `telegram gateway: operator-event user-notice deferred to turn-end agent=${agent} kind=${kind} chats=${userNoticeChats.length} topic=${noticeKey ?? '-'}\n`,
     )
+  }
+}
+
+/**
+ * Live gateway deps for the plain user-failure-notice subsystem
+ * (`user-failure-notices.ts`): transport-transient handling AND the turn-end
+ * flush share this one wiring. Every side effect is a closure over live state.
+ */
+function userFailureNoticeDeps(): UserFailureNoticeDeps {
+  return {
+    now: () => Date.now(),
+    allowFrom: () => loadAccess().allowFrom,
+    liveTurnKey: () => currentTurn != null ? statusKey(currentTurn.sessionChatId, currentTurn.sessionThreadId) : undefined,
+    record: (e) => { try { recordOperatorEvent(e) } catch { /* history best-effort */ } },
+    scheduleUserNotice: (i) => pendingUserNoticeGate.schedule({ ...i, text: renderUserFacingFailureNotice() }),
+    resolveNotices: (delivered, key) => pendingUserNoticeGate.resolveTurnEnd(key, delivered),
+    send: (chat_id, text, keyboard) => {
+      const thread = topicForRecipient({ recipientChatId: chat_id, resolvedTopic: resolveAgentOutboundTopic({ kind: 'compact-watchdog' }), supergroupChatId: resolveAgentSupergroupChatId() })
+      const opts = { ...(keyboard ? { reply_markup: keyboard } : {}), ...(thread != null ? { message_thread_id: thread } : {}) }
+      // allow-raw-bot-api: user-failure-notice / transport escalation send; topic-aware opts
+      void bot.api.sendRichMessage(chat_id, richMessage(text), opts as never).catch((e) => process.stderr.write(`telegram gateway: user-failure-notice send to ${chat_id} failed: ${e}\n`))
+    },
+    log: (m) => process.stderr.write(`telegram gateway: ${m}\n`),
   }
 }
 
@@ -8292,34 +8316,10 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
  * Called from `endCurrentTurnAtomic` — the ONE funnel every turn-end path
  * passes through. `turnDeliveredReply` is `finalAnswerDelivered || replyCalled`
  * (the model explicitly replied → the turn recovered → notices are dropped by
- * the gate). Only a reply-less turn end flushes the pending notices to the
- * non-operator chats, so the user notice fires IFF the turn genuinely died.
- * `turnKey` (#3294) scopes resolution to the ending turn's topic — a concurrent
- * topic's pending notice is left for its own turn end under keyed liveness.
+ * the gate). The send loop lives in `user-failure-notices.ts`.
  */
 function flushPendingUserFailureNotices(turnDeliveredReply: boolean, turnKey: string): void {
-  const notices = pendingUserNoticeGate.resolveTurnEnd(turnKey, turnDeliveredReply)
-  if (notices.length === 0) return
-  const noticeTopic = resolveAgentOutboundTopic({ kind: 'compact-watchdog' })
-  const noticeSupergroup = resolveAgentSupergroupChatId()
-  for (const notice of notices) {
-    process.stderr.write(
-      `telegram gateway: user-notice flush (turn died reply-less) agent=${notice.agent} kind=${notice.kind} chats=${notice.chatIds.length}\n`,
-    )
-    for (const chat_id of notice.chatIds) {
-      const thread = topicForRecipient({ recipientChatId: chat_id, resolvedTopic: noticeTopic, supergroupChatId: noticeSupergroup })
-      const opts = {
-        ...(thread != null ? { message_thread_id: thread } : {}),
-      }
-      // allow-raw-bot-api: deferred user-notice flush loop; topic-aware opts
-      void bot.api.sendRichMessage(chat_id, richMessage(notice.text), opts as never)
-        .catch(e => {
-          process.stderr.write(
-            `telegram gateway: user-notice send to ${chat_id} failed agent=${notice.agent} kind=${notice.kind}: ${e}\n`,
-          )
-        })
-    }
-  }
+  flushDeferredUserNotices(turnDeliveredReply, turnKey, userFailureNoticeDeps())
 }
 
 /**

--- a/telegram-plugin/gateway/user-failure-notices.ts
+++ b/telegram-plugin/gateway/user-failure-notices.ts
@@ -1,0 +1,172 @@
+/**
+ * user-failure-notices.ts — gateway-side handling of the plain-language
+ * "couldn't complete that" user notice, plus the `transport-transient`
+ * classifier kind (a mid-response stream abort reaching Anthropic).
+ *
+ * Two concerns, one subsystem (the plain user-failure-notice send side):
+ *
+ *  1. `emitTransportTransientEvent` — the calm path for a `transport-transient`
+ *     operator event. Claude Code emits `error: "server_error"` with NO HTTP
+ *     status on a mid-response stream abort; that is a transport failure, not an
+ *     account/auth/quota fault, and Claude retries it internally. So there is NO
+ *     broadcast card (a Reauth card would be the wrong remedy and reach every
+ *     chat). Instead: record for `/status` history, and DEFER one plain user
+ *     notice to the turn-end gate (`pending-user-notice.ts`) so a genuinely
+ *     reply-less dead turn still gets one calm line while a recovered retry
+ *     sends nothing. A BURST — >=3 terminal transport-transient events for one
+ *     agent within ~10min — escalates to exactly ONE operator-only, Dismiss-only
+ *     card ("repeated stream failures reaching Anthropic"), so honest
+ *     suppression never hides a genuinely degraded pipe.
+ *
+ *  2. `flushDeferredUserNotices` — the turn-end send loop for notices the gate
+ *     released (moved here from the gateway; see #3293 finding 1).
+ *
+ * Pure orchestration: every side effect (record, schedule, resolve, send, log,
+ * clock) crosses in through `UserFailureNoticeDeps`, so the outcomes are
+ * unit-testable with fakes and no gateway/grammy/IPC coupling leaks in.
+ */
+
+import { escapeMarkdown } from '../format.js'
+import type { InlineKeyboardMarkup, OperatorEvent } from '../operator-events.js'
+import type { PendingUserNotice } from '../pending-user-notice.js'
+
+// ─── transport-transient escalation counter (pure) ───────────────────────────
+
+const ESCALATION_WINDOW_MS = 10 * 60_000
+const ESCALATION_THRESHOLD = 3
+
+/** Per-agent sliding window of terminal transport-transient event timestamps. */
+const transportEscalation = new Map<string, number[]>()
+
+/**
+ * Record one terminal transport-transient event for `agent` at `now` and decide
+ * whether it crosses the escalation threshold. Returns `true` at most once per
+ * burst: crossing the threshold RESETS the window so a sustained outage emits
+ * one operator card per ~`windowMs`, not one per event.
+ */
+export function noteTransportTransientAndShouldEscalate(
+  agent: string,
+  now: number,
+  opts?: { windowMs?: number; threshold?: number },
+): boolean {
+  const windowMs = opts?.windowMs ?? ESCALATION_WINDOW_MS
+  const threshold = opts?.threshold ?? ESCALATION_THRESHOLD
+  const recent = (transportEscalation.get(agent) ?? []).filter((t) => now - t < windowMs)
+  recent.push(now)
+  if (recent.length >= threshold) {
+    transportEscalation.set(agent, [])
+    return true
+  }
+  transportEscalation.set(agent, recent)
+  return false
+}
+
+/** Test/reauth-recovery helper: forget the escalation window (all or one agent). */
+export function resetTransportTransientEscalation(agent?: string): void {
+  if (agent == null) transportEscalation.clear()
+  else transportEscalation.delete(agent)
+}
+
+/**
+ * The ONE operator-only card a transport-transient BURST escalates to. Dismiss-
+ * only — no Reauth (a dropped stream is not a credential fault), no failover
+ * (every account hits the same degraded pipe).
+ */
+export function renderTransportEscalationCard(agent: string): {
+  text: string
+  keyboard: InlineKeyboardMarkup
+} {
+  const a = escapeMarkdown(agent)
+  return {
+    text: [
+      `🔌 **Repeated stream failures** reaching Anthropic for **${a}**.`,
+      `3+ mid-response aborts within ~10 min. Turns retry automatically; if this persists, Anthropic's API may be degraded.`,
+    ].join('\n'),
+    keyboard: {
+      inline_keyboard: [
+        [{ text: '❌ Dismiss', callback_data: `op:dismiss:${encodeURIComponent(agent)}` }],
+      ],
+    },
+  }
+}
+
+// ─── Deps + orchestration ────────────────────────────────────────────────────
+
+export interface UserFailureNoticeDeps {
+  /** Injectable clock. */
+  now(): number
+  /** Allowlist chats (broadcast audience). */
+  allowFrom(): readonly string[]
+  /** Topic key of the live turn, or undefined (agent-level / between turns). */
+  liveTurnKey(): string | undefined
+  /** Persist to /status history (best-effort — must swallow its own errors). */
+  record(event: OperatorEvent): void
+  /** Schedule the turn-end-gated plain user notice for `chatIds`. */
+  scheduleUserNotice(input: {
+    chatIds: string[]
+    agent: string
+    kind: string
+    key: string | undefined
+    atMs: number
+  }): void
+  /** Release the notices resolved by this turn end (may be empty). */
+  resolveNotices(turnDeliveredReply: boolean, turnKey: string): PendingUserNotice[]
+  /** Topic-aware raw send (fire-and-forget). `keyboard` omitted → plain message. */
+  send(chatId: string, text: string, keyboard?: InlineKeyboardMarkup): void
+  /** stderr line (the gateway prefixes "telegram gateway: "). */
+  log(msg: string): void
+}
+
+/**
+ * Handle a `transport-transient` operator event: record it, defer the plain
+ * user notice to turn-end, and — on a burst — post exactly one operator-only
+ * escalation card. Never sends a broadcast card.
+ */
+export function emitTransportTransientEvent(
+  event: OperatorEvent,
+  deps: UserFailureNoticeDeps,
+): void {
+  const now = deps.now()
+  deps.record(event)
+  const escalate = noteTransportTransientAndShouldEscalate(event.agent, now)
+  deps.log(
+    `transport-transient agent=${event.agent} escalate=${escalate} ` +
+      `(no broadcast card; user-notice deferred to turn-end)`,
+  )
+  const allowFrom = deps.allowFrom()
+  if (allowFrom.length === 0) return
+  deps.scheduleUserNotice({
+    chatIds: [...allowFrom],
+    agent: event.agent,
+    kind: event.kind,
+    key: deps.liveTurnKey(),
+    atMs: now,
+  })
+  if (escalate) {
+    const card = renderTransportEscalationCard(event.agent)
+    deps.send(allowFrom[0], card.text, card.keyboard)
+  }
+}
+
+/**
+ * Turn-end resolution of deferred user failure notices (#3293 finding 1, moved
+ * out of gateway.ts). `turnDeliveredReply` is `finalAnswerDelivered ||
+ * replyCalled` — a delivered reply DROPS the notices (turn recovered); a
+ * reply-less end flushes them (turn genuinely died). `turnKey` scopes resolution
+ * to the ending turn's topic under keyed liveness.
+ */
+export function flushDeferredUserNotices(
+  turnDeliveredReply: boolean,
+  turnKey: string,
+  deps: UserFailureNoticeDeps,
+): void {
+  const notices = deps.resolveNotices(turnDeliveredReply, turnKey)
+  if (notices.length === 0) return
+  for (const notice of notices) {
+    deps.log(
+      `user-notice flush (turn died reply-less) agent=${notice.agent} ` +
+        `kind=${notice.kind} chats=${notice.chatIds.length}`,
+    )
+    for (const chatId of notice.chatIds) deps.send(chatId, notice.text)
+  }
+}

--- a/telegram-plugin/llm-error-present.ts
+++ b/telegram-plugin/llm-error-present.ts
@@ -252,10 +252,15 @@ function classifyKindAndSource(text: string): { kind: LlmErrorKind; source: LlmE
   if (claudeKind === 'rate-limited') {
     return { kind: 'rate_limit', source: 'anthropic' }
   }
-  if (claudeKind === 'unknown-5xx') {
-    return { kind: 'overload_529', source: 'anthropic' }
-  }
-
+  // NOTE: we deliberately do NOT map the taxonomy's `unknown-5xx` to
+  // `overload_529` here. `classifyClaudeError` is called above with only
+  // {message, type} (no HTTP status), so `unknown-5xx` at this point is the
+  // taxonomy's neutral no-status DEFAULT — not evidence of a genuine 529/5xx.
+  // A real Anthropic overload/5xx always carries recognizable wording and is
+  // resolved earlier by detectModelUnavailable (step 3). Fabricating
+  // "Anthropic is overloaded (529) — retrying automatically" for an
+  // unrecognized error would be a false diagnosis, so it falls through to the
+  // honest `unknown` kind.
   return { kind: 'unknown', source: 'anthropic' }
 }
 

--- a/telegram-plugin/model-unavailable.ts
+++ b/telegram-plugin/model-unavailable.ts
@@ -474,6 +474,10 @@ export function detectModelUnavailable(
     'socket hang up',
     'request timed out',
     'connection refused',
+    // Mid-response stream aborts reaching Anthropic surface these markers
+    // (a transport failure, not an account/quota fault) — treat as network.
+    'connection closed',
+    'mid-response',
     'getaddrinfo',
   ]
   if (networkSignals.some(s => lower.includes(s))) {

--- a/telegram-plugin/operator-events.fixtures.json
+++ b/telegram-plugin/operator-events.fixtures.json
@@ -119,18 +119,6 @@
       "_source": "Bare 403 with no recognised type",
       "status": 403,
       "message": "Forbidden"
-    },
-    {
-      "_source": "null input — always unknown-4xx",
-      "_value": null
-    },
-    {
-      "_source": "Completely empty object",
-      "_value": {}
-    },
-    {
-      "_source": "Non-object string",
-      "_value": "something went wrong"
     }
   ],
   "unknown-5xx": [
@@ -146,6 +134,18 @@
         "type": "service_unavailable",
         "message": "Service temporarily unavailable"
       }
+    },
+    {
+      "_source": "null input — no status, neutral 5xx default (never a fabricated 4xx)",
+      "_value": null
+    },
+    {
+      "_source": "Completely empty object — no status → unknown-5xx",
+      "_value": {}
+    },
+    {
+      "_source": "Non-object string — no status → unknown-5xx",
+      "_value": "something went wrong"
     }
   ]
 }

--- a/telegram-plugin/operator-events.ts
+++ b/telegram-plugin/operator-events.ts
@@ -73,6 +73,17 @@ export const OPERATOR_EVENT_KINDS = [
   'mcp-dependency-blocked',
   'quota-exhausted',
   'rate-limited',
+  /**
+   * A TRANSPORT / network failure reaching Anthropic — Claude Code emits
+   * `error: "server_error"` (or `api_error`, which Anthropic documents as an
+   * HTTP 500) with NO `apiErrorStatus` on a mid-response stream abort. It is a
+   * pipe/transport failure, NOT an account, auth, or quota fault: retryable, and
+   * recovered by Claude's own internal retry. Handled by the gateway's dedicated
+   * calm path (no broadcast card; record for /status + a turn-end-gated plain
+   * user notice; a burst escalates to ONE operator-only card) — deliberately
+   * NEVER a Reauth card. See `gateway/user-failure-notices.ts`.
+   */
+  'transport-transient',
   'agent-crashed',
   'agent-restarted-unexpectedly',
   'unknown-4xx',
@@ -110,19 +121,21 @@ export interface InlineKeyboardMarkup {
  * Classify an error value from any source (Anthropic SDK throw, JSONL error
  * field, etc.) into an OperatorEventKind.
  *
- * CONTRACT: never throws. Unfamiliar shapes fall through to unknown-4xx or
- * unknown-5xx based on HTTP status, defaulting to unknown-4xx.
+ * CONTRACT: never throws. Unfamiliar shapes fall through to unknown-5xx or
+ * unknown-4xx based on HTTP status. With NO status the neutral default is
+ * unknown-5xx — an unrecognized shape with no HTTP status must NOT fabricate a
+ * "4xx" label (whose card historically carried a wrong Reauth remedy).
  */
 export function classifyClaudeError(raw: unknown): OperatorEventKind {
   try {
     return classifyInner(raw)
   } catch {
-    return 'unknown-4xx'
+    return 'unknown-5xx'
   }
 }
 
 function classifyInner(raw: unknown): OperatorEventKind {
-  if (raw == null) return 'unknown-4xx'
+  if (raw == null) return 'unknown-5xx'
 
   // Extract common fields defensively — never throw on bad shapes.
   const obj = typeof raw === 'object' ? (raw as Record<string, unknown>) : {}
@@ -258,13 +271,39 @@ function classifyInner(raw: unknown): OperatorEventKind {
     return 'agent-restarted-unexpectedly'
   }
 
+  // TRANSPORT / network failure reaching Anthropic. Claude Code emits
+  // `error: "server_error"` (and `api_error`, documented as HTTP 500) with NO
+  // `apiErrorStatus` on a mid-response stream abort — a pipe/transport failure,
+  // not an account/auth/quota fault. Without this branch it fell through to the
+  // status fallback below and FABRICATED `unknown-4xx`, whose card carried a
+  // wrong Reauth remedy and broadcast to every chat. It is retryable (Claude
+  // retries internally), so it maps to the calm `transport-transient` kind.
+  //
+  // Placed AFTER the auth-wording matches above ON PURPOSE: a genuine auth
+  // failure that upstream mislabels `server_error` still classifies as a
+  // credential fault. Matched only on EXACT type/code equality (never a message
+  // substring) so an unrelated error whose text merely mentions "server error"
+  // is untouched.
+  if (
+    errorType === 'server_error' ||
+    errorCode === 'server_error' ||
+    sdkCode === 'server_error' ||
+    errorType === 'api_error' ||
+    errorCode === 'api_error' ||
+    sdkCode === 'api_error'
+  ) {
+    return 'transport-transient'
+  }
+
   // Fallback: HTTP status-based.
   if (status != null) {
     if (status >= 400 && status < 500) return 'unknown-4xx'
     if (status >= 500 && status < 600) return 'unknown-5xx'
   }
 
-  return 'unknown-4xx'
+  // No recognized shape and NO status: neutral 5xx default. Do NOT claim 4xx —
+  // a fabricated client-error label mis-routed a Reauth card (the bug this fixes).
+  return 'unknown-5xx'
 }
 
 function extractString(obj: Record<string, unknown>, key: string): string | null {
@@ -508,6 +547,12 @@ export function renderOperatorEvent(ev: OperatorEvent): RenderResult {
         },
       }
 
+    // Dismiss-only, matching unknown-5xx / proxy-misconfig. The Reauth button
+    // was REMOVED: unknown-4xx is a catch-all for unrecognized client-error
+    // shapes, and re-auth is the wrong remedy for almost all of them. Post-RFC-H
+    // the auth-broker is the SOLE writer of `.credentials.json`, so a per-agent
+    // reauth is re-mirrored over anyway. Reauth buttons now live ONLY on the
+    // credentials-* cards, where the diagnosis IS a login fault.
     case 'unknown-4xx':
       return {
         text: [
@@ -518,10 +563,28 @@ export function renderOperatorEvent(ev: OperatorEvent): RenderResult {
           .join('\n'),
         keyboard: {
           inline_keyboard: [
-            [
-              { text: '🔐 Reauth', callback_data: `op:reauth:${encodeURIComponent(ev.agent)}` },
-              { text: '❌ Dismiss', callback_data: `op:dismiss:${encodeURIComponent(ev.agent)}` },
-            ],
+            [{ text: '❌ Dismiss', callback_data: `op:dismiss:${encodeURIComponent(ev.agent)}` }],
+          ],
+        },
+      }
+
+    // transport-transient is normally handled by the gateway's dedicated calm
+    // path (no broadcast card; a burst escalates via renderTransportEscalationCard
+    // in gateway/user-failure-notices.ts). This case exists so the switch stays
+    // exhaustive and any incidental render is calm + Dismiss-only — NEVER a
+    // Reauth button (a dropped stream is not a credential fault).
+    case 'transport-transient':
+      return {
+        text: [
+          `🔌 **Transient transport error** for **${agent}**.`,
+          detail ? `\`${detail}\`` : '',
+          `A mid-response stream to Anthropic dropped. Will retry automatically.`,
+        ]
+          .filter(Boolean)
+          .join('\n'),
+        keyboard: {
+          inline_keyboard: [
+            [{ text: '❌ Dismiss', callback_data: `op:dismiss:${encodeURIComponent(ev.agent)}` }],
           ],
         },
       }

--- a/telegram-plugin/operator-events.ts
+++ b/telegram-plugin/operator-events.ts
@@ -284,13 +284,22 @@ function classifyInner(raw: unknown): OperatorEventKind {
   // credential fault. Matched only on EXACT type/code equality (never a message
   // substring) so an unrelated error whose text merely mentions "server error"
   // is untouched.
+  //
+  // GUARDED to status-less OR 5xx shapes (`status == null || status >= 500`): a
+  // mid-response abort carries NO status, and a genuine 500 is server-side. But
+  // LiteLLM stamps a generic `type: "api_error"` onto WRAPPED upstream faults
+  // that DO carry a 4xx status (e.g. a 401), and session-tail threads that
+  // `apiErrorStatus` through as `status`. Without this guard such a 401 would be
+  // swallowed as transport-transient (silent, no card) when it must reach the
+  // status fallback below and surface an operator card. The status wins.
   if (
-    errorType === 'server_error' ||
-    errorCode === 'server_error' ||
-    sdkCode === 'server_error' ||
-    errorType === 'api_error' ||
-    errorCode === 'api_error' ||
-    sdkCode === 'api_error'
+    (status == null || status >= 500) &&
+    (errorType === 'server_error' ||
+      errorCode === 'server_error' ||
+      sdkCode === 'server_error' ||
+      errorType === 'api_error' ||
+      errorCode === 'api_error' ||
+      sdkCode === 'api_error')
   ) {
     return 'transport-transient'
   }

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -1075,7 +1075,13 @@ export function detectErrorInTranscriptLine(
   // with no retry state is ambiguous → treat as in-flight and suppress
   // (the silence-poke covers a genuinely stuck turn; a false card is
   // the bug we are fixing, a missed ambiguous card costs nothing).
-  const transient = kind === 'rate-limited'
+  // `transport-transient` joins the transient family so Claude's retry
+  // annotations gate `terminal`: a mid-response abort Claude is still retrying
+  // (retryAttempt < maxRetries) is in-flight, not terminal, and must NOT count
+  // toward the operator escalation counter (which is bounded to ≥3 TERMINAL
+  // events). The primary bug shape (`isApiErrorMessage`) returns earlier with
+  // terminal:true by construction, so it is unaffected by this.
+  const transient = kind === 'rate-limited' || kind === 'transport-transient'
   const retry = extractRetryState(obj)
   const terminal = !transient
     ? true

--- a/telegram-plugin/tests/operator-events-session-tail.test.ts
+++ b/telegram-plugin/tests/operator-events-session-tail.test.ts
@@ -156,6 +156,33 @@ describe('detectErrorInTranscriptLine — error detection', () => {
     expect(result!.detail).toContain('hit your limit')
   })
 
+  // Regression — the transport-abort bug this PR fixes. On a mid-response stream
+  // abort Claude Code emits `isApiErrorMessage:true` with `error:"server_error"`
+  // and NO `apiErrorStatus`. Pre-fix that had no transport branch and fell
+  // through to the status fallback, FABRICATING `unknown-4xx` — a card carrying a
+  // wrong Reauth button, broadcast to every chat. It must classify
+  // transport-transient (terminal, non-transient) instead.
+  it('classifies the verbatim server_error mid-stream abort as transport-transient (not unknown-4xx)', () => {
+    // The exact on-disk shape: isApiErrorMessage, error "server_error", NO status.
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        model: '<synthetic>',
+        content: [{ type: 'text', text: 'API Error: Connection closed mid-response' }],
+      },
+      error: 'server_error',
+      isApiErrorMessage: true,
+    })
+    const result = detectErrorInTranscriptLine(line)
+    expect(result).not.toBeNull()
+    expect(result!.kind).toBe('transport-transient')
+    expect(result!.kind).not.toBe('unknown-4xx')
+    // Claude writes this shape only after its own retries are exhausted → terminal.
+    expect(result!.terminal).toBe(true)
+    expect(result!.transient).toBe(false)
+  })
+
   // Regression — the carrie incident (2026-07-12). Anthropic also emits a
   // 429 for a TRANSIENT per-account burst / RPM throttle whose wording
   // explicitly negates the account-quota reading ("would exceed your

--- a/telegram-plugin/tests/operator-events-session-tail.test.ts
+++ b/telegram-plugin/tests/operator-events-session-tail.test.ts
@@ -107,6 +107,42 @@ describe('detectErrorInTranscriptLine — error detection', () => {
     expect(result!.terminal).toBe(true)
   })
 
+  it('marks an in-flight transport-transient retry NOT terminal (does not count toward escalation)', () => {
+    // A flaky request Claude Code is internally retrying (retryAttempt <
+    // maxRetries), surfaced as a bare `server_error` with no status. Pre-fix
+    // `transient` was false for transport-transient, so it was UNCONDITIONALLY
+    // terminal → a single recoverable request retried 3x could cross the ≥3
+    // escalation threshold and fire the operator "Repeated stream failures"
+    // card. It must be transient + in-flight (suppressed), counting nothing.
+    const line = JSON.stringify({
+      type: 'system',
+      subtype: 'api_error',
+      error: { type: 'server_error', message: 'Connection closed mid-response' },
+      retryAttempt: 2,
+      maxRetries: 10,
+    })
+    const result = detectErrorInTranscriptLine(line)
+    expect(result!.kind).toBe('transport-transient')
+    expect(result!.transient).toBe(true)
+    // 2 < 10 — still retrying → in-flight → the caller suppresses it (not counted).
+    expect(result!.terminal).toBe(false)
+  })
+
+  it('marks an exhausted transport-transient retry terminal (counts toward escalation)', () => {
+    const line = JSON.stringify({
+      type: 'system',
+      subtype: 'api_error',
+      error: { type: 'server_error', message: 'Connection closed mid-response' },
+      retryAttempt: 10,
+      maxRetries: 10,
+    })
+    const result = detectErrorInTranscriptLine(line)
+    expect(result!.kind).toBe('transport-transient')
+    expect(result!.transient).toBe(true)
+    // retries exhausted → terminal → escalates.
+    expect(result!.terminal).toBe(true)
+  })
+
   it('marks non-transient errors terminal (always escalate)', () => {
     const line = JSON.stringify({
       type: 'api_error',

--- a/telegram-plugin/tests/operator-events.test.ts
+++ b/telegram-plugin/tests/operator-events.test.ts
@@ -142,13 +142,44 @@ describe('classifyClaudeError — safety: must never throw', () => {
   }
 })
 
-describe('classifyClaudeError — unknown-4xx is the default fallback', () => {
-  it('unknown object with no status defaults to unknown-4xx', () => {
-    expect(classifyClaudeError({ totally: 'unrecognised' })).toBe('unknown-4xx')
+describe('classifyClaudeError — no-status default is the neutral 5xx (never a fabricated 4xx)', () => {
+  it('unknown object with no status defaults to unknown-5xx, NOT unknown-4xx', () => {
+    // Regression: an unrecognized shape with no HTTP status used to fabricate
+    // `unknown-4xx`, whose card carried a wrong Reauth remedy broadcast to every
+    // chat. With no status the honest neutral default is unknown-5xx.
+    expect(classifyClaudeError({ totally: 'unrecognised' })).toBe('unknown-5xx')
+    expect(classifyClaudeError({ totally: 'unrecognised' })).not.toBe('unknown-4xx')
   })
 
-  it('empty string → unknown-4xx', () => {
-    expect(classifyClaudeError('')).toBe('unknown-4xx')
+  it('empty string → unknown-5xx', () => {
+    expect(classifyClaudeError('')).toBe('unknown-5xx')
+  })
+
+  it('still honors an explicit 4xx status', () => {
+    expect(classifyClaudeError({ status: 404 })).toBe('unknown-4xx')
+  })
+})
+
+describe('classifyClaudeError — transport-transient (mid-response stream abort)', () => {
+  it('classifies a bare server_error type as transport-transient', () => {
+    expect(classifyClaudeError({ type: 'server_error' })).toBe('transport-transient')
+  })
+
+  it('classifies server_error via error_code / code / nested error.type', () => {
+    expect(classifyClaudeError({ error_code: 'server_error' })).toBe('transport-transient')
+    expect(classifyClaudeError({ code: 'server_error' })).toBe('transport-transient')
+    expect(classifyClaudeError({ error: { type: 'server_error' } })).toBe('transport-transient')
+  })
+
+  it('classifies api_error (Anthropic HTTP 500) as transport-transient', () => {
+    expect(classifyClaudeError({ type: 'api_error' })).toBe('transport-transient')
+  })
+
+  it('does NOT fire on an unrelated error that merely mentions "server error" in prose', () => {
+    // Exact type/code equality only — never a message substring — so a genuine
+    // auth fault mislabeled with server-error prose still classifies as auth.
+    expect(classifyClaudeError({ type: 'authentication_error', message: 'server error while validating' }))
+      .toBe('credentials-invalid')
   })
 })
 
@@ -238,10 +269,25 @@ describe('renderOperatorEvent — agent-restarted-unexpectedly', () => {
 })
 
 describe('renderOperatorEvent — unknown-4xx', () => {
-  it('surfaces "API error (4xx)" with dismiss button', () => {
+  it('surfaces "API error (4xx)" with a Dismiss button and NO Reauth button', () => {
     const { text, keyboard } = renderOperatorEvent(makeEvent('unknown-4xx'))
     expect(text).toContain('4xx')
-    expect(keyboard.inline_keyboard.flat().some(b => b.callback_data?.includes('dismiss'))).toBe(true)
+    const buttons = keyboard.inline_keyboard.flat()
+    expect(buttons.some(b => b.callback_data?.includes('dismiss'))).toBe(true)
+    // Reauth was REMOVED — it is the wrong remedy for a catch-all client error,
+    // and Reauth buttons now live ONLY on credentials-* cards. Assert the OUTCOME.
+    expect(buttons.some(b => b.callback_data?.includes('op:reauth'))).toBe(false)
+    expect(buttons.some(b => b.callback_data?.includes('reauth'))).toBe(false)
+  })
+})
+
+describe('renderOperatorEvent — transport-transient (defensive fallback)', () => {
+  it('is calm and Dismiss-only — NEVER a Reauth button', () => {
+    const { text, keyboard } = renderOperatorEvent(makeEvent('transport-transient'))
+    expect(text).toContain('transport')
+    const buttons = keyboard.inline_keyboard.flat()
+    expect(buttons.some(b => b.callback_data?.includes('dismiss'))).toBe(true)
+    expect(buttons.some(b => b.callback_data?.includes('reauth'))).toBe(false)
   })
 })
 
@@ -289,6 +335,7 @@ describe('renderOperatorEvent — all kinds produce valid keyboard structure', (
     'rate-limited',
     'agent-crashed',
     'agent-restarted-unexpectedly',
+    'transport-transient',
     'unknown-4xx',
     'unknown-5xx',
     'config-warning',

--- a/telegram-plugin/tests/operator-events.test.ts
+++ b/telegram-plugin/tests/operator-events.test.ts
@@ -175,6 +175,23 @@ describe('classifyClaudeError — transport-transient (mid-response stream abort
     expect(classifyClaudeError({ type: 'api_error' })).toBe('transport-transient')
   })
 
+  it('classifies api_error/server_error carrying a 5xx status as transport-transient', () => {
+    expect(classifyClaudeError({ type: 'api_error', status: 500 })).toBe('transport-transient')
+    expect(classifyClaudeError({ type: 'server_error', status: 503 })).toBe('transport-transient')
+  })
+
+  it('does NOT swallow a status-bearing 4xx api_error (LiteLLM-wrapped 401) as transport-transient', () => {
+    // LiteLLM stamps a generic `type: "api_error"` on WRAPPED upstream faults
+    // that carry a 4xx status; session-tail threads that status through. The
+    // transport branch is guarded to status-less/5xx shapes, so the HTTP status
+    // wins and this surfaces an operator card (unknown-4xx) — NOT the silent
+    // transport-transient path. Branch-order regression guard: unlike the bare
+    // `{status:404}` test above, this exercises a TYPED api_error + 4xx status.
+    expect(classifyClaudeError({ type: 'api_error', status: 401 })).toBe('unknown-4xx')
+    expect(classifyClaudeError({ type: 'api_error', status: 401 })).not.toBe('transport-transient')
+    expect(classifyClaudeError({ type: 'server_error', status: 429 })).toBe('unknown-4xx')
+  })
+
   it('does NOT fire on an unrelated error that merely mentions "server error" in prose', () => {
     // Exact type/code equality only — never a message substring — so a genuine
     // auth fault mislabeled with server-error prose still classifies as auth.

--- a/telegram-plugin/tests/user-failure-notices.test.ts
+++ b/telegram-plugin/tests/user-failure-notices.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  emitTransportTransientEvent,
+  flushDeferredUserNotices,
+  noteTransportTransientAndShouldEscalate,
+  renderTransportEscalationCard,
+  resetTransportTransientEscalation,
+  type UserFailureNoticeDeps,
+} from '../gateway/user-failure-notices.js'
+import type { OperatorEvent } from '../operator-events.js'
+import type { PendingUserNotice } from '../pending-user-notice.js'
+
+// ─── Fake deps: capture every side effect, drive time explicitly ─────────────
+
+interface Capture {
+  recorded: OperatorEvent[]
+  scheduled: Array<{ chatIds: string[]; agent: string; kind: string; key: string | undefined; atMs: number }>
+  sent: Array<{ chatId: string; text: string; hasKeyboard: boolean }>
+  logs: string[]
+  /** Notices the fake gate will release on the next resolveNotices call. */
+  resolvedQueue: PendingUserNotice[]
+  lastResolve?: { delivered: boolean; key: string }
+}
+
+function makeDeps(over?: {
+  allowFrom?: string[]
+  liveTurnKey?: string | undefined
+  now?: number
+}): { deps: UserFailureNoticeDeps; cap: Capture } {
+  const cap: Capture = { recorded: [], scheduled: [], sent: [], logs: [], resolvedQueue: [] }
+  const deps: UserFailureNoticeDeps = {
+    now: () => over?.now ?? 1_000,
+    allowFrom: () => over?.allowFrom ?? ['op', 'user-a', 'user-b'],
+    liveTurnKey: () => ('liveTurnKey' in (over ?? {}) ? over!.liveTurnKey : 'chat:topic'),
+    record: (e) => cap.recorded.push(e),
+    scheduleUserNotice: (i) => cap.scheduled.push(i),
+    resolveNotices: (delivered, key) => {
+      cap.lastResolve = { delivered, key }
+      // Emulate the real gate: a delivered reply drops everything.
+      return delivered ? [] : cap.resolvedQueue
+    },
+    send: (chatId, text, keyboard) => cap.sent.push({ chatId, text, hasKeyboard: keyboard != null }),
+    log: (m) => cap.logs.push(m),
+  }
+  return { deps, cap }
+}
+
+function ev(overrides?: Partial<OperatorEvent>): OperatorEvent {
+  return {
+    kind: 'transport-transient',
+    agent: 'gymbro',
+    detail: 'API Error: Connection closed mid-response',
+    suggestedActions: [],
+    firstSeenAt: new Date('2026-08-02T00:00:00Z'),
+    ...overrides,
+  }
+}
+
+beforeEach(() => resetTransportTransientEscalation())
+
+// ─── emitTransportTransientEvent — outcomes ──────────────────────────────────
+
+describe('emitTransportTransientEvent', () => {
+  it('records history and schedules a deferred user notice, but sends NO card (single event)', () => {
+    const { deps, cap } = makeDeps()
+    emitTransportTransientEvent(ev(), deps)
+    // history recorded for /status
+    expect(cap.recorded).toHaveLength(1)
+    expect(cap.recorded[0].kind).toBe('transport-transient')
+    // user notice scheduled to ALL allowlist chats, keyed to the live turn
+    expect(cap.scheduled).toHaveLength(1)
+    expect(cap.scheduled[0].chatIds).toEqual(['op', 'user-a', 'user-b'])
+    expect(cap.scheduled[0].key).toBe('chat:topic')
+    // NO broadcast / escalation card for a single event
+    expect(cap.sent).toHaveLength(0)
+  })
+
+  it('records even when there is no allowlist, but schedules nothing', () => {
+    const { deps, cap } = makeDeps({ allowFrom: [] })
+    emitTransportTransientEvent(ev(), deps)
+    expect(cap.recorded).toHaveLength(1)
+    expect(cap.scheduled).toHaveLength(0)
+    expect(cap.sent).toHaveLength(0)
+  })
+
+  it('carries an undefined notice key when there is no live turn', () => {
+    const { deps, cap } = makeDeps({ liveTurnKey: undefined })
+    emitTransportTransientEvent(ev(), deps)
+    expect(cap.scheduled[0].key).toBeUndefined()
+  })
+})
+
+// ─── Escalation: >=3 within the window → exactly ONE operator-only card ───────
+
+describe('transport-transient escalation bound', () => {
+  it('sends exactly ONE operator-only Dismiss-only card at the 3rd event in the window', () => {
+    const { deps, cap } = makeDeps()
+    emitTransportTransientEvent(ev(), deps) // 1 — no card
+    emitTransportTransientEvent(ev(), deps) // 2 — no card
+    expect(cap.sent).toHaveLength(0)
+    emitTransportTransientEvent(ev(), deps) // 3 — ONE card
+    expect(cap.sent).toHaveLength(1)
+    // operator-only: goes to the allowlist HEAD, and carries a keyboard (Dismiss)
+    expect(cap.sent[0].chatId).toBe('op')
+    expect(cap.sent[0].hasKeyboard).toBe(true)
+    expect(cap.sent[0].text).toContain('Repeated stream failures')
+    // and only ONE — a 4th event in the same (reset) window does not re-fire yet
+    emitTransportTransientEvent(ev(), deps) // 4
+    expect(cap.sent).toHaveLength(1)
+  })
+
+  it('does not escalate when the events fall outside the window', () => {
+    // Two events far apart never reach threshold-3-within-window.
+    expect(noteTransportTransientAndShouldEscalate('gymbro', 0)).toBe(false)
+    expect(noteTransportTransientAndShouldEscalate('gymbro', 60 * 60_000)).toBe(false)
+    expect(noteTransportTransientAndShouldEscalate('gymbro', 120 * 60_000)).toBe(false)
+  })
+
+  it('counts per-agent — one agent bursting does not escalate another', () => {
+    expect(noteTransportTransientAndShouldEscalate('a', 0)).toBe(false)
+    expect(noteTransportTransientAndShouldEscalate('a', 1)).toBe(false)
+    expect(noteTransportTransientAndShouldEscalate('b', 2)).toBe(false)
+    // a's 3rd crosses; b has only seen 1
+    expect(noteTransportTransientAndShouldEscalate('a', 3)).toBe(true)
+    expect(noteTransportTransientAndShouldEscalate('b', 4)).toBe(false)
+  })
+})
+
+describe('renderTransportEscalationCard', () => {
+  it('is Dismiss-only with NO Reauth button', () => {
+    const { keyboard, text } = renderTransportEscalationCard('gymbro')
+    const buttons = keyboard.inline_keyboard.flat()
+    expect(buttons.some((b) => b.callback_data?.includes('dismiss'))).toBe(true)
+    expect(buttons.some((b) => b.callback_data?.includes('reauth'))).toBe(false)
+    expect(text).toContain('gymbro')
+  })
+})
+
+// ─── flushDeferredUserNotices — turn-outcome gate ────────────────────────────
+
+describe('flushDeferredUserNotices', () => {
+  it('sends nothing when the turn delivered a reply (notice dropped)', () => {
+    const { deps, cap } = makeDeps()
+    cap.resolvedQueue = [{ chatIds: ['user-a'], text: 'notice', agent: 'gymbro', kind: 'transport-transient', atMs: 1, key: 'k' }]
+    flushDeferredUserNotices(/* turnDeliveredReply */ true, 'k', deps)
+    expect(cap.lastResolve).toEqual({ delivered: true, key: 'k' })
+    expect(cap.sent).toHaveLength(0)
+  })
+
+  it('flushes the plain notice (no keyboard) when the turn ended reply-less', () => {
+    const { deps, cap } = makeDeps()
+    cap.resolvedQueue = [{ chatIds: ['user-a', 'user-b'], text: 'notice', agent: 'gymbro', kind: 'transport-transient', atMs: 1, key: 'k' }]
+    flushDeferredUserNotices(/* turnDeliveredReply */ false, 'k', deps)
+    expect(cap.sent.map((s) => s.chatId)).toEqual(['user-a', 'user-b'])
+    // plain user notice — never a card/keyboard
+    expect(cap.sent.every((s) => s.hasKeyboard === false)).toBe(true)
+    expect(cap.sent.every((s) => s.text === 'notice')).toBe(true)
+  })
+
+  it('does nothing when no notices resolve', () => {
+    const { deps, cap } = makeDeps()
+    flushDeferredUserNotices(false, 'k', deps)
+    expect(cap.sent).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Problem

On a **mid-response stream abort** reaching Anthropic, Claude Code writes a transcript line with `error: "server_error"` (or `api_error`) and **no `apiErrorStatus`**. `classifyClaudeError` (`telegram-plugin/operator-events.ts`) had no transport branch, so the value fell through the status fallback and — with no status present — hit the terminal `return 'unknown-4xx'`. That **fabricated** a client-error label whose operator card carried a `🔐 Reauth` button and was **broadcast to every allowlisted chat**.

Reauth is the wrong remedy: the pipe dropped at the transport layer, the credential is intact, and post-RFC-H the auth-broker is the **sole** writer of `.credentials.json` (a per-agent reauth is re-mirrored over anyway). This surfaces the fleet's "know what my agent is doing" operator-event contract (`reference/jobs/know-what-my-agent-is-doing.md`) with a false, alarming, wrong-action card.

## Fix (five parts + one ripple)

1. **Classifier** — new `transport-transient` kind in `OPERATOR_EVENT_KINDS`. Matched on **exact** `type`/`code`/`sdkCode` equality with `server_error`/`api_error` (never a message substring), placed **after** the auth-wording matches so a genuine auth fault mislabelled `server_error` still classifies as a credential fault. `detectModelUnavailable` networkSignals gain `connection closed` / `mid-response` (`model-unavailable.ts`).
2. **Terminal default** — an unrecognized shape with **no** HTTP status now defaults to `unknown-5xx` (neutral), never `unknown-4xx`. A no-status shape must not fabricate a client-error label that mis-routes Reauth.
3. **Card gate** (`gateway/user-failure-notices.ts`, new pure module) — transport-transient logs + `recordOperatorEvent` for `/status` but sends **no broadcast card**. It schedules the existing turn-end-gated plain user notice (#3293/#3294 `pendingUserNoticeGate`), so a reply-less dead turn gets **one** calm line and a recovered retry sends nothing.
4. **Button gate** — the `unknown-4xx` card is now **Dismiss-only** (Reauth button removed). Reauth buttons live only on the `credentials-*` cards, where the diagnosis *is* a login fault. (Re-targeting the credentials-card reauth flow is intentionally **out of scope** — see follow-ups.)
5. **Escalation bound** — a per-agent sliding window: **≥3** terminal transport-transient events within ~10 min emit **exactly one** operator-only, Dismiss-only card ("Repeated stream failures reaching Anthropic"). Crossing the threshold resets the window, so a sustained outage fires once per burst, not once per event. Honest suppression never hides a genuinely degraded pipe.

**Ripple fix** (`llm-error-present.ts`): the pre-existing `unknown-5xx → overload_529` branch was **unreachable** from `parseLlmError` (it calls `classifyClaudeError({message, type})` with no status, and `unknown-5xx` previously required a 500-599 status). Part 2's default flip made it reachable, so a genuinely unknown error would fabricate *"Anthropic is overloaded (529) — retrying automatically."* Removed — unknown stays honest; real overloads are resolved earlier by `detectModelUnavailable`.

## Test evidence

Scoped vitest — all green:
- `operator-events.test.ts`, `operator-events-session-tail.test.ts`, `user-failure-notices.test.ts` (new), `model-unavailable.test.ts`: **181 passed**
- `llm-error-present.test.ts`, `litellm-proxy-auth-misconfig.test.ts`, `provider-credit-402.test.ts`, `gateway-outbound-redact.test.ts`: **88 passed**

New/updated coverage: verbatim `server_error`-no-status transcript line → `transport-transient` (terminal, non-transient); no-status/null/`{}`/bare-string → `unknown-5xx`; explicit-404 still `unknown-4xx`; unknown-4xx card asserts **no** Reauth; escalation fires exactly one operator-only card at the 3rd event, per-agent, windowed; deferred-notice flush drops on reply / sends plain (no keyboard) reply-less.

`npm run lint`: **green** (tsc clean, `check-gateway-line-ratchet` clean at 24917, `check-bot-api-wrapping`, `check-no-broadcast-delivery`, `check-status-pin-single-path`, all guards). `gateway.ts` **net-zero: 24917 → 24917** (the flush send-loop moved into the new pure module).

## Follow-ups (deferred, not in this PR)

- Re-target the `credentials-*` card Reauth flow to the auth-broker mirror path (RFC-H) — out of scope here by design.

---
Draft — do **not** merge/enqueue/deploy. Opened for review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
