### PR TITLE
fix(voice): correct nonexistent onnxruntime-gpu pin 1.20.1 -> 1.20.2

### DIFF
--- a/docker/Dockerfile.voice
+++ b/docker/Dockerfile.voice
@@ -85,7 +85,7 @@ RUN pip3 install --no-cache-dir \
         "requests==2.32.3" \
         "kokoro-onnx==0.5.0" \
     && pip3 uninstall -y onnxruntime \
-    && pip3 install --no-cache-dir "onnxruntime-gpu==1.20.1"
+    && pip3 install --no-cache-dir "onnxruntime-gpu==1.20.2"
 
 COPY docker/voice-sidecar/server.py /opt/voice-sidecar/server.py
 


### PR DESCRIPTION
## Summary

`docker/Dockerfile.voice:88` pinned `onnxruntime-gpu==1.20.1` — a version that **does not exist on PyPI**. The `onnxruntime-gpu` package skips 1.20.1 (releases go `1.20.0` -> `1.20.2`); only the CPU `onnxruntime` package ever shipped a 1.20.1. Any from-scratch voice image rebuild fails at that pip step with `No matching distribution found for onnxruntime-gpu==1.20.1`.

This one-line fix pins the closest real 1.20.x release, **`1.20.2`**.

## Why

Latent bug masked today only because the `build-voice` CI job is path-gated on `docker/Dockerfile.voice` and otherwise serves from buildcache, so no clean rebuild has re-resolved the pin since it landed.

- **Root cause:** nonexistent `onnxruntime-gpu==1.20.1` pin, introduced 2026-07-01 in #2717 (`feat(voice): GPU-accelerate Kokoro TTS`).
- **Fix:** `-> 1.20.2`, a real CUDA-12.x build with a **cp310 linux x86_64 wheel** (`onnxruntime_gpu-1.20.2-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl`, confirmed via the PyPI JSON API), matching the CUDA-12 base image and cuDNN 9 runtime already present, and consistent with the surrounding "onnxruntime-gpu 1.20.x is built for CUDA 12.x + cuDNN 9" comment.
- Deliberately **not** 1.21+, which would change the CUDA/cuDNN build target. This is a minimal correctness fix, not a version upgrade.

## Test plan

The real proof is CI's `build-voice` job going green. Since `build-voice` is path-gated on `docker/Dockerfile.voice`, this change triggers a real from-scratch rebuild that re-resolves the pin — exactly the step that fails on `main` today.

## Risk

Minimal — single-line pin correction. Same CUDA/cuDNN target, same wheel Python tag (cp310). No source or config changes.