### PR TITLE
feat(voice): misaki G2P for heteronym-correct Kokoro TTS

### DIFF
--- a/docker/Dockerfile.voice
+++ b/docker/Dockerfile.voice
@@ -79,13 +79,78 @@ RUN apt-get update \
 # Installing onnxruntime-gpu AFTER kokoro-onnx replaces the transitively-pulled
 # CPU onnxruntime with the GPU build (same import name, so kokoro-onnx picks it
 # up unchanged). Dependabot bumps all four pins.
+# misaki is the POS-aware grapheme→phoneme engine that fixes English
+# heteronyms Kokoro's built-in espeak phonemizer mispronounces (espeak is not
+# part-of-speech aware): the verb "live" /lˈɪv/ vs the adjective "live"
+# /lˈaɪv/, "read" present /ɹˈid/ vs past /ɹˈɛd/, etc. server.py runs it
+# in-process and feeds the phoneme string to Kokoro via is_phonemes=True.
+#
+# Deliberately NOT `misaki[en]`: that extra pulls spacy-curated-transformers,
+# which drags in torch — undoing the whole no-torch design of the kokoro-onnx
+# path above (lines ~64-69). We install BASE misaki + spaCy (tok2vec + tagger
+# only; misaki runs with trf=False so no transformer pipeline is needed) +
+# num2words. espeakng-loader / phonemizer-fork are already pinned transitively
+# by kokoro-onnx and stay — misaki's OOV EspeakFallback (and the non-English
+# path) use them.
+#
+# en_core_web_sm is baked as a WHEEL rather than fetched at runtime because
+# misaki.en.G2P.__init__ otherwise calls spacy.cli.download() on first use — a
+# network fetch AND a site-packages write that fails under the non-root runtime
+# UID (65532) and breaks offline boots. Its major.minor (3.8) MUST match the
+# spacy pin (3.8.x); a mismatch makes spaCy refuse to load the model.
+#
+# `click` is an UNDECLARED runtime dependency of spaCy's CLI here: spacy/cli/
+# _util.py does `from click import NoSuchOption`, but the transitive chain
+# (typer 0.27 no longer hard-depends on click) leaves it uninstalled on a clean
+# image, so `import spacy` — which misaki does at module load — dies with
+# `ModuleNotFoundError: No module named 'click'`. Same class of bug as the
+# `requests`/faster-whisper pin above. Pin it explicitly.
+#
+# numpy floor: spaCy 3.8 + kokoro-onnx 0.5.0 both build against numpy 2; the
+# resolver lands 2.2.x. Pin the >=2.0.2 floor so a resolver wobble can never
+# drag the image back to numpy 1.x (which the Kokoro ONNX path can't use).
+#
+# DEPENDABOT: keep misaki pinned at 0.9.4. misaki's `main` branch imports
+# torch/transformers at the TOP of en.py; 0.9.4 does not. Any bump MUST re-check
+# misaki/en.py's module-level imports stay torch-free, or the no-torch design
+# regresses silently.
 RUN pip3 install --no-cache-dir \
         "faster-whisper==1.0.3" \
         "huggingface_hub==0.25.2" \
         "requests==2.32.3" \
         "kokoro-onnx==0.5.0" \
+        "misaki==0.9.4" \
+        "num2words==0.5.14" \
+        "spacy==3.8.7" \
+        "click==8.1.7" \
+        "numpy>=2.0.2" \
+        "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" \
     && pip3 uninstall -y onnxruntime \
     && pip3 install --no-cache-dir "onnxruntime-gpu==1.20.2"
+
+# Build-time OUTCOME guard (fail-loud) — proves misaki's POS-aware G2P actually
+# emits DIFFERENT phonemes for the two senses of each heteronym, which is the
+# entire point of this dependency. A bare `import misaki` check would stay green
+# even if spaCy silently failed to load the tagger and every word collapsed to
+# the espeak fallback, so we assert the exact phoneme substrings, verified
+# empirically against misaki 0.9.4 in a python:3.10 container:
+#   verb "live"  → lˈɪv   vs  adjective "live" → lˈIv   (capital I = /aɪ/)
+#   base "read"  → ɹˈid   vs  past      "read" → ɹˈɛd
+# Two independent pairs so one lexicon change can't quietly vacate the guard.
+# This also transitively proves the two load-bearing assumptions: (a) misaki's
+# English path is torch-free with trf=False (torch is never installed here, so
+# an import of it would ImportError), and (b) the baked en_core_web_sm wheel
+# loads offline under spaCy. If any of that regresses, THIS build turns red.
+RUN python3 -c "\
+from misaki import en, espeak; \
+g2p = en.G2P(trf=False, british=False, fallback=espeak.EspeakFallback(british=False)); \
+lv, _ = g2p('They live in Sydney.'); \
+la, _ = g2p('It was a live show.'); \
+rp, _ = g2p('Please read this book.'); \
+rd, _ = g2p('He read it yesterday.'); \
+assert 'lˈɪv' in lv and 'lˈIv' in la, ('live sense collapsed', lv, la); \
+assert 'ɹˈid' in rp and 'ɹˈɛd' in rd, ('read sense collapsed', rp, rd); \
+print('misaki G2P heteronym guard OK:', lv, '|', la, '|', rp, '|', rd)"
 
 COPY docker/voice-sidecar/server.py /opt/voice-sidecar/server.py
 

--- a/docker/voice-sidecar/server.py
+++ b/docker/voice-sidecar/server.py
@@ -13,6 +13,25 @@ GPU (the PR-B1 `engine='local'` verdict).
 One sidecar, two endpoints, one port (8126). STT and TTS each get their
 OWN concurrency lane so a synth never serializes behind a transcribe.
 
+English G2P (heteronyms)
+------------------------
+By default (VOICE_TTS_G2P=misaki) the TTS path runs misaki's POS-aware
+English grapheme→phoneme conversion in-process and feeds the resulting
+phoneme string to Kokoro with is_phonemes=True. This fixes English
+heteronyms Kokoro's built-in espeak phonemizer mispronounces because
+espeak is not part-of-speech aware — e.g. the verb "live" /lˈɪv/ vs the
+adjective "live" /lˈaɪv/, or "read" present /ɹˈid/ vs past /ɹˈɛd/. It is
+a strict ENHANCEMENT: misaki is loaded in its own try/except beside the
+Kokoro model, and any failure (or VOICE_TTS_G2P=espeak, or a non-English
+locale) leaves _g2p None so synthesis degrades to today's espeak path
+with the sidecar fully healthy. VOICE_TTS_G2P=espeak is the rollback
+lever — no image rebuild. See _load_tts / _phonemize_piece / _run_synthesis.
+FUTURE (not built): misaki also accepts a per-word phoneme override via
+`[word](/phoneme/)` markup — a hook for a caller-supplied pronunciation
+override, but normalizeForSpeech (telegram-plugin/voice-normalize-text.ts)
+currently strips `[text](...)` link markup, so wiring it end-to-end would
+need that pass to pass the `/…/` form through first.
+
 HTTP contract
 -------------
   POST /stt   multipart: audio=<bytes>, optional language=<iso-639-1>
@@ -109,6 +128,16 @@ TTS_VOICES_SHA256 = os.environ.get("VOICE_TTS_VOICES_SHA256", "").strip()
 # af_heart is a clear, natural Kokoro US-English voice — a sensible default.
 TTS_VOICE = os.environ.get("VOICE_TTS_VOICE", "af_heart")
 TTS_LANG = os.environ.get("VOICE_TTS_LANG", "en-us")
+# ── G2P engine selection (grapheme→phoneme) ────────────────────────────
+# "misaki" (default) runs misaki's POS-aware English G2P in-process and hands
+# the resulting phoneme string to Kokoro with is_phonemes=True. That fixes
+# English heteronyms Kokoro's built-in espeak phonemizer gets wrong because
+# espeak is NOT part-of-speech aware — e.g. the verb "live" /lˈɪv/ vs the
+# adjective "live" /lˈaɪv/, or "read" present /ɹˈid/ vs past /ɹˈɛd/. misaki is
+# applied ONLY to the English locales (en-us / en-gb); every other TTS_LANG
+# keeps the espeak path. Set VOICE_TTS_G2P=espeak to restore the espeak-only
+# path fleet-wide — the rollback lever, no image rebuild required.
+TTS_G2P = os.environ.get("VOICE_TTS_G2P", "misaki").lower()
 # Only OGG/Opus is wired (Telegram sendVoice requires it); the env exists so
 # a future format can be added without a contract change.
 TTS_FORMAT = os.environ.get("VOICE_TTS_FORMAT", "ogg").lower()
@@ -197,6 +226,14 @@ _tts_lock = threading.Lock()
 _tts_error: str | None = None
 _tts_sem = threading.Semaphore(TTS_CONCURRENCY)
 _tts_pool = ThreadPoolExecutor(max_workers=TTS_CONCURRENCY + 2)
+# misaki English G2P handle (POS-aware phonemizer), loaded alongside _tts in
+# _load_tts when TTS_G2P == "misaki" and TTS_LANG is English. None otherwise or
+# if its (optional) load fails — synthesis then degrades to Kokoro's espeak
+# phonemization. Guarded by _tts_lock (same lane as _tts).
+_g2p = None
+# A phonemize failure is logged ONCE (not per request) so a persistent misaki
+# fault degrades quietly to the espeak path instead of flooding the log.
+_g2p_warned = False
 
 
 def _log(msg: str) -> None:
@@ -396,7 +433,7 @@ def _load_tts() -> None:
     """Fetch-once + load the Kokoro ONNX model. Runs in a background thread
     (like _load_model) so /healthz reports 'not ready' during the cold load
     and the server doesn't block on boot."""
-    global _tts, _tts_error
+    global _tts, _tts_error, _g2p
     try:
         os.makedirs(MODEL_CACHE, exist_ok=True)
         model_path = os.path.join(MODEL_CACHE, TTS_MODEL)
@@ -417,6 +454,32 @@ def _load_tts() -> None:
     except Exception as exc:  # noqa: BLE001 — fail closed, report on /healthz
         _tts_error = f"{type(exc).__name__}: {exc}"
         _log(f"TTS model load FAILED: {_tts_error}")
+        return
+
+    # Build the misaki English G2P in its OWN try/except: it is an ENHANCEMENT
+    # (heteronym-correct phonemes), NOT a requirement. If anything here fails —
+    # misaki not installed, spaCy model missing, espeak fallback init error —
+    # the sidecar stays fully healthy (_tts is already set, /healthz untouched)
+    # and synthesis degrades to Kokoro's built-in espeak phonemizer, i.e.
+    # exactly today's behavior. Only the English locales use it.
+    if TTS_G2P == "misaki" and TTS_LANG in ("en-us", "en-gb"):
+        try:
+            from misaki import en, espeak  # heavy import, deferred
+
+            british = TTS_LANG == "en-gb"
+            g2p = en.G2P(
+                trf=False,  # torch-free path (no spacy-curated-transformers)
+                british=british,
+                fallback=espeak.EspeakFallback(british=british),
+            )
+            with _tts_lock:
+                _g2p = g2p
+            _log(f"misaki G2P ready (lang={TTS_LANG}, british={british})")
+        except Exception as exc:  # noqa: BLE001 — enhancement; degrade gracefully
+            _log(
+                f"misaki G2P load FAILED ({type(exc).__name__}: {exc}); "
+                "falling back to espeak phonemization"
+            )
 
 
 def _pcm_to_wav_bytes(samples, sample_rate: int) -> bytes:
@@ -532,6 +595,41 @@ def _clamp_speed(value: object) -> float:
     return max(TTS_SPEED_MIN, min(TTS_SPEED_MAX, speed))
 
 
+def _phonemize_piece(piece: str) -> tuple[str, bool]:
+    """Convert one text piece to a Kokoro phoneme string via misaki's POS-aware
+    English G2P.
+
+    Returns (phonemes, True) on success — the caller then hands `phonemes` to
+    Kokoro with is_phonemes=True, which is what makes heteronyms come out right.
+    Returns (piece, False) — the raw TEXT, unchanged — when misaki is not in
+    play (VOICE_TTS_G2P=espeak, a non-English locale, or a failed G2P load left
+    _g2p None) OR when the misaki call itself raises / yields nothing; the
+    caller then passes the text to Kokoro and gets today's espeak
+    phonemization. A phonemize failure is logged ONCE, never per request.
+
+    Pure and stub-testable WITHOUT misaki installed: the G2P handle is read from
+    the module global, so a test can inject a fake (or None) and exercise both
+    branches. Never raises — a phoneme miss must never fail a synthesis."""
+    global _g2p_warned
+    with _tts_lock:
+        g2p = _g2p
+    if g2p is None:
+        return piece, False
+    try:
+        phonemes, _tokens = g2p(piece)
+        if not phonemes:
+            return piece, False
+        return phonemes, True
+    except Exception as exc:  # noqa: BLE001 — degrade to the espeak text path
+        if not _g2p_warned:
+            _g2p_warned = True
+            _log(
+                f"misaki phonemize failed ({type(exc).__name__}: {exc}); "
+                "falling back to espeak text path (logged once)"
+            )
+        return piece, False
+
+
 def _run_synthesis(text: str, voice: str, speed: float = TTS_SPEED_DEFAULT) -> tuple[bytes, dict]:
     """The TTS-serialized synthesis. Acquires the TTS semaphore so only
     TTS_CONCURRENCY synths run at once — a separate lane from STT.
@@ -556,9 +654,23 @@ def _run_synthesis(text: str, voice: str, speed: float = TTS_SPEED_DEFAULT) -> t
         chunks: list[np.ndarray] = []
         sample_rate = TTS_SAMPLE_RATE
         for i, piece in enumerate(pieces):
-            samples, sample_rate = _tts.create(  # type: ignore[union-attr]
-                piece, voice=voice, speed=speed, lang=TTS_LANG
-            )
+            # misaki's POS-aware G2P runs here, INSIDE _tts_sem — so with
+            # VOICE_TTS_CONCURRENCY defaulting to 1, spaCy is never called
+            # concurrently. On a hit we hand Kokoro the phoneme string
+            # (is_phonemes=True — the heteronym fix); on any miss we hand it the
+            # raw TEXT and Kokoro phonemizes via espeak (today's path). A
+            # regression must never route a phoneme string through the espeak
+            # text path, so the two branches are kept explicit. See
+            # _phonemize_piece / VOICE_TTS_G2P=espeak (rollback lever).
+            content, is_phonemes = _phonemize_piece(piece)
+            if is_phonemes:
+                samples, sample_rate = _tts.create(  # type: ignore[union-attr]
+                    content, voice=voice, speed=speed, is_phonemes=True
+                )
+            else:
+                samples, sample_rate = _tts.create(  # type: ignore[union-attr]
+                    piece, voice=voice, speed=speed, lang=TTS_LANG
+                )
             arr = np.asarray(samples, dtype=np.float32)
             if i > 0:
                 chunks.append(pad)

--- a/docker/voice-sidecar/test_g2p.py
+++ b/docker/voice-sidecar/test_g2p.py
@@ -1,0 +1,216 @@
+"""Unit tests for the misaki G2P integration on the TTS path.
+
+The sidecar's default G2P engine (VOICE_TTS_G2P=misaki) runs misaki's
+POS-aware English grapheme→phoneme conversion in-process and hands the
+resulting phoneme string to Kokoro with is_phonemes=True — the fix for
+English heteronyms Kokoro's built-in espeak phonemizer mispronounces
+(verb "live" /lˈɪv/ vs adjective "live" /lˈaɪv/, "read" present /ɹˈid/ vs
+past /ɹˈɛd/). These tests pin two contracts:
+
+  1. _phonemize_piece degrades correctly — (piece, False) when misaki is
+     absent / disabled / raises, (phonemes, True) only on a real hit.
+  2. _run_synthesis ROUTES on that flag: a phoneme string goes to Kokoro
+     with is_phonemes=True, and a fallback goes as raw TEXT with
+     lang=TTS_LANG and NO is_phonemes. A regression that silently routed a
+     phoneme string through the espeak text path (or vice-versa) would be a
+     silent mispronunciation, so it is pinned here.
+
+Like test_server.py these run WITHOUT misaki / numpy / onnxruntime / ffmpeg
+installed (the CI voice-sidecar job is stdlib-only): server.py imports
+misaki and numpy lazily, so the module imports clean, _g2p is injected via
+the module global, and the numpy + ffmpeg touchpoints of _run_synthesis are
+stubbed. The one test that needs a real misaki is skipped unless it is
+installed.
+
+Run: python3 -m unittest discover -s docker/voice-sidecar -p 'test_*.py'
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+
+import server
+
+
+class PhonemizePieceTests(unittest.TestCase):
+    """The pure degrade/hit helper — the heart of the fallback contract."""
+
+    def setUp(self) -> None:
+        self._orig_g2p = server._g2p
+        self._orig_warned = server._g2p_warned
+        server._g2p = None
+        server._g2p_warned = False
+
+    def tearDown(self) -> None:
+        server._g2p = self._orig_g2p
+        server._g2p_warned = self._orig_warned
+
+    def test_returns_text_and_false_when_g2p_none(self) -> None:
+        # misaki disabled / not loaded → hand back the RAW text, flagged False.
+        server._g2p = None
+        self.assertEqual(server._phonemize_piece("hello world"), ("hello world", False))
+
+    def test_returns_phonemes_and_true_on_hit(self) -> None:
+        # A working G2P returns (phonemes, tokens); the helper surfaces the
+        # phoneme STRING and True so the caller sets is_phonemes=True.
+        server._g2p = lambda piece: ("fˈOni:mz", ["tok"])
+        out, is_ph = server._phonemize_piece("phonemes")
+        self.assertEqual(out, "fˈOni:mz")
+        self.assertTrue(is_ph)
+
+    def test_raising_g2p_degrades_to_text(self) -> None:
+        # A misaki call that raises must NEVER fail synthesis — degrade to the
+        # espeak text path, flagged False.
+        def boom(_piece):
+            raise RuntimeError("spaCy exploded")
+
+        server._g2p = boom
+        self.assertEqual(server._phonemize_piece("boom"), ("boom", False))
+
+    def test_empty_phoneme_output_degrades_to_text(self) -> None:
+        # An empty phoneme string is a miss, not a valid result — Kokoro must
+        # get the real text so it can at least espeak-phonemize it.
+        server._g2p = lambda piece: ("", [])
+        self.assertEqual(server._phonemize_piece("edge"), ("edge", False))
+
+    def test_failure_logged_once(self) -> None:
+        # A persistent misaki fault must not flood the log: the warned flag
+        # latches after the first failure.
+        def boom(_piece):
+            raise RuntimeError("x")
+
+        server._g2p = boom
+        self.assertFalse(server._g2p_warned)
+        server._phonemize_piece("a")
+        self.assertTrue(server._g2p_warned)
+        server._phonemize_piece("b")  # still degrades, no reset
+        self.assertTrue(server._g2p_warned)
+
+
+class _RecordingTTS:
+    """A stand-in for the Kokoro handle: records every create() call's kwargs
+    and returns a trivial one-sample PCM result."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def create(self, text, voice=None, speed=None, lang=None, is_phonemes=False):  # noqa: ANN001
+        self.calls.append(
+            {"text": text, "voice": voice, "speed": speed, "lang": lang, "is_phonemes": is_phonemes}
+        )
+        return ([0.0], server.TTS_SAMPLE_RATE)
+
+
+def _install_fake_numpy() -> types.ModuleType | None:
+    """Inject a fake `numpy` sufficient for _run_synthesis (zeros / asarray /
+    concatenate / float32) so the routing can be exercised without the real
+    dependency. Returns the previously-installed module (or None) to restore."""
+    prev = sys.modules.get("numpy")
+    fake = types.ModuleType("numpy")
+    fake.float32 = "float32"
+    fake.zeros = lambda n, dtype=None: [0.0] * int(n)
+    fake.asarray = lambda x, dtype=None: list(x)
+    fake.concatenate = lambda chunks: [v for c in chunks for v in c]
+    sys.modules["numpy"] = fake
+    return prev
+
+
+class RunSynthesisRoutingTests(unittest.TestCase):
+    """Pins that _run_synthesis routes on the is_phonemes flag — the guarantee
+    that a phoneme string never silently rides the espeak text path."""
+
+    def setUp(self) -> None:
+        self._orig_g2p = server._g2p
+        self._orig_warned = server._g2p_warned
+        self._orig_tts = server._tts
+        self._orig_pcm = server._pcm_to_wav_bytes
+        self._orig_ogg = server._wav_to_ogg_opus
+        self._prev_numpy = _install_fake_numpy()
+        # Stub the numpy/ffmpeg-backed byte producers — this suite tests
+        # ROUTING, not audio encoding.
+        server._pcm_to_wav_bytes = lambda samples, sample_rate: b"WAV"
+        server._wav_to_ogg_opus = lambda wav: b"OGG"
+        self.tts = _RecordingTTS()
+        server._tts = self.tts
+        server._g2p_warned = False
+
+    def tearDown(self) -> None:
+        server._g2p = self._orig_g2p
+        server._g2p_warned = self._orig_warned
+        server._tts = self._orig_tts
+        server._pcm_to_wav_bytes = self._orig_pcm
+        server._wav_to_ogg_opus = self._orig_ogg
+        if self._prev_numpy is None:
+            sys.modules.pop("numpy", None)
+        else:
+            sys.modules["numpy"] = self._prev_numpy
+
+    def test_phoneme_hit_routes_with_is_phonemes_true(self) -> None:
+        server._g2p = lambda piece: ("lˈɪv", ["tok"])
+        ogg, meta = server._run_synthesis("live", voice="af_heart")
+        self.assertEqual(ogg, b"OGG")
+        self.assertEqual(len(self.tts.calls), 1)
+        call = self.tts.calls[0]
+        self.assertEqual(call["text"], "lˈɪv")  # the PHONEME string, not "live"
+        self.assertTrue(call["is_phonemes"])
+        self.assertIsNone(call["lang"])  # lang is NOT passed on the phoneme path
+
+    def test_fallback_routes_as_text_with_lang(self) -> None:
+        server._g2p = None  # misaki off → espeak text path
+        ogg, meta = server._run_synthesis("live", voice="af_heart")
+        self.assertEqual(ogg, b"OGG")
+        self.assertEqual(len(self.tts.calls), 1)
+        call = self.tts.calls[0]
+        self.assertEqual(call["text"], "live")  # the RAW text
+        self.assertFalse(call["is_phonemes"])
+        self.assertEqual(call["lang"], server.TTS_LANG)
+
+    def test_raising_g2p_falls_back_to_text_path(self) -> None:
+        def boom(_piece):
+            raise RuntimeError("spaCy exploded")
+
+        server._g2p = boom
+        server._run_synthesis("live", voice="af_heart")
+        call = self.tts.calls[0]
+        self.assertEqual(call["text"], "live")
+        self.assertFalse(call["is_phonemes"])
+        self.assertEqual(call["lang"], server.TTS_LANG)
+
+
+@unittest.skipUnless(
+    importlib.util.find_spec("misaki") is not None,
+    "misaki not installed — the real-G2P heteronym assertion runs in the "
+    "build-voice image (Dockerfile.voice build guard)",
+)
+class RealMisakiHeteronymTests(unittest.TestCase):
+    """The OUTCOME test: real misaki emits DIFFERENT phonemes for the two
+    senses of each heteronym. Mirrors the Dockerfile build-time guard so the
+    behaviour is pinned wherever misaki happens to be installed."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        from misaki import en, espeak
+
+        cls.g2p = en.G2P(
+            trf=False, british=False, fallback=espeak.EspeakFallback(british=False)
+        )
+
+    def test_live_verb_vs_adjective(self) -> None:
+        verb, _ = self.g2p("They live in Sydney.")
+        adj, _ = self.g2p("It was a live show.")
+        self.assertIn("lˈɪv", verb)
+        self.assertIn("lˈIv", adj)
+        self.assertNotEqual(verb, adj)
+
+    def test_read_base_vs_past(self) -> None:
+        base, _ = self.g2p("Please read this book.")
+        past, _ = self.g2p("He read it yesterday.")
+        self.assertIn("ɹˈid", base)
+        self.assertIn("ɹˈɛd", past)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/telegram-plugin/voice-normalize-text.ts
+++ b/telegram-plugin/voice-normalize-text.ts
@@ -431,6 +431,11 @@ export function normalizeForSpeech(input: string): string {
   s = s.replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
 
   // 3. Links [text](url) → text ; drop the URL entirely.
+  // FUTURE (not built): the Kokoro sidecar's misaki G2P (docker/voice-sidecar/
+  // server.py) accepts a per-word phoneme override via `[word](/phoneme/)`
+  // markup. Wiring a caller-supplied pronunciation override end-to-end would
+  // mean detecting that `/…/` form HERE and passing it through instead of
+  // collapsing it to the link text below. Deliberately left as a hook.
   s = s.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
 
   // 4. Autolinks <https://…> and bare URLs → "a link" (never spell a URL).

--- a/tests/docker/dockerfile-voice-misaki.test.ts
+++ b/tests/docker/dockerfile-voice-misaki.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Pin the docker/Dockerfile.voice misaki-G2P bake shape.
+ *
+ * The voice sidecar runs misaki's POS-aware English G2P in-process and feeds
+ * the phoneme string to Kokoro with is_phonemes=True, which fixes English
+ * heteronyms Kokoro's built-in espeak phonemizer mispronounces. The design has
+ * two load-bearing invariants that a grep-on-file test can pin far more cheaply
+ * than a full image build:
+ *
+ *   1. NO TORCH. misaki[en] pulls spacy-curated-transformers → torch, which
+ *      would undo the entire no-torch reason the sidecar is on kokoro-onnx.
+ *      This file asserts the torch-bearing packages never appear.
+ *   2. The build-time heteronym GUARD is not vacuous — it asserts the actual,
+ *      empirically-verified phoneme strings for two heteronym pairs, so a
+ *      lexicon/tagger regression that collapsed both senses would fail the
+ *      build instead of shipping a silent mispronunciation.
+ *
+ * These are structural tests (no docker required). The authoritative proof of
+ * the two assumptions is the build-voice CI job actually executing the guard;
+ * this file guards the SHAPE that keeps that guard meaningful.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const dockerfile = readFileSync(
+  resolve(root, "docker/Dockerfile.voice"),
+  "utf8",
+);
+
+/**
+ * Every `RUN` instruction as its own array of physical lines (continuations
+ * folded in). Scoping the guard assertions to the instruction that actually
+ * contains them — rather than a file-wide search — cannot drift vacuous the way
+ * a positional slice can. (Same pattern as dockerfile-hindsight-bakes.test.ts.)
+ */
+function runInstructions(): string[][] {
+  const lines = dockerfile.split("\n");
+  const out: string[][] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^RUN\b/.test(lines[i])) continue;
+    const block = [lines[i]];
+    while (/\\\s*$/.test(block[block.length - 1]) && i + 1 < lines.length) {
+      block.push(lines[++i]);
+    }
+    out.push(block);
+  }
+  return out;
+}
+
+/** The single RUN instruction carrying the misaki heteronym guard. */
+function heteronymGuardRun(): string[] {
+  const matches = runInstructions().filter((b) =>
+    b.join("\n").includes("from misaki import en, espeak"),
+  );
+  expect(
+    matches,
+    "exactly one RUN instruction must carry the misaki heteronym guard",
+  ).toHaveLength(1);
+  return matches[0];
+}
+
+describe("Dockerfile.voice misaki-G2P shape", () => {
+  it("keeps the existing whisper/kokoro/onnxruntime-gpu shape intact", () => {
+    // The misaki additions must not disturb the STT/TTS base: kokoro-onnx is
+    // still the ONNX inference path, and the CPU→GPU onnxruntime swap is the
+    // confirmed root-cause fix for slow synth.
+    expect(dockerfile).toMatch(/"kokoro-onnx==0\.5\.0"/);
+    expect(dockerfile).toMatch(/pip3 uninstall -y onnxruntime\b/);
+    expect(dockerfile).toMatch(/"onnxruntime-gpu==1\.20\.2"/);
+  });
+
+  it("installs base misaki pinned at 0.9.4 (torch-free English path)", () => {
+    // Pinned exactly: misaki's main branch imports torch/transformers at the
+    // top of en.py; 0.9.4 does not. A bump must re-verify that.
+    expect(dockerfile).toMatch(/"misaki==0\.9\.4"/);
+  });
+
+  it("does NOT install the misaki[en] extra (it drags torch)", () => {
+    // misaki[en] → spacy-curated-transformers → torch. Forbidden. Scoped to the
+    // executable RUN lines: the comment above the pip layer names `misaki[en]`
+    // to explain the exclusion, so a file-wide ban would fail on its own docs.
+    const runText = runInstructions()
+      .map((b) => b.join("\n"))
+      .join("\n");
+    expect(runText).not.toMatch(/misaki\[en\]/);
+  });
+
+  it("never installs torch / transformers / spacy-curated-transformers", () => {
+    // The no-torch invariant. Scoped to the EXECUTABLE lines of the RUN
+    // instructions (not the file), because the explanatory comments above the
+    // pip layer legitimately NAME these packages to say why they're excluded —
+    // a file-wide substring ban would fail on its own documentation. The RUN
+    // blocks contain only install args, so a match here is a real install.
+    const runText = runInstructions()
+      .map((b) => b.join("\n"))
+      .join("\n");
+    // torch as a pip requirement (quoted, pinned, or with an extra) — never as
+    // the English word in prose.
+    expect(runText).not.toMatch(/["']torch(==|>=|<=|~=|\[|["'])/);
+    expect(runText).not.toMatch(/spacy-curated-transformers/);
+    expect(runText).not.toMatch(/spacy_curated_transformers/);
+    expect(runText).not.toMatch(/["']transformers["\[=]/);
+    // And the misaki[en] extra spelled inside an install line.
+    expect(runText).not.toMatch(/misaki\[en\]/);
+  });
+
+  it("installs spaCy plus the click dep spaCy's CLI needs", () => {
+    // misaki does `import spacy` at module load; spaCy's cli/_util.py does
+    // `from click import NoSuchOption`, but typer 0.27 no longer hard-depends
+    // on click, so it must be pinned explicitly (undeclared-dep, like the
+    // requests/faster-whisper pin).
+    expect(dockerfile).toMatch(/"spacy==3\.8\.7"/);
+    expect(dockerfile).toMatch(/"click==/);
+    expect(dockerfile).toMatch(/"num2words==0\.5\.14"/);
+  });
+
+  it("keeps numpy on the v2 line (the Kokoro ONNX path needs it)", () => {
+    // A resolver wobble back to numpy 1.x would break the ONNX/TTS path.
+    expect(dockerfile).toMatch(/"numpy>=2\.0\.2"/);
+  });
+
+  it("bakes en_core_web_sm as a wheel whose version matches the spacy pin", () => {
+    // Baked as a wheel because misaki.en.G2P otherwise calls spacy.cli.download
+    // at runtime — a network fetch + site-packages write that fails under the
+    // non-root UID and breaks offline boots. spaCy refuses to load a model
+    // whose major.minor differs from its own, so the two versions are coupled.
+    const wheel = dockerfile.match(
+      /en_core_web_sm-(\d+)\.(\d+)\.(\d+)-py3-none-any\.whl/,
+    );
+    expect(wheel, "the en_core_web_sm wheel URL must be present").not.toBeNull();
+    const spacy = dockerfile.match(/"spacy==(\d+)\.(\d+)\.\d+"/);
+    expect(spacy, "the spacy pin must be present").not.toBeNull();
+    // major.minor of the model must equal major.minor of spaCy.
+    expect(wheel![1]).toBe(spacy![1]);
+    expect(wheel![2]).toBe(spacy![2]);
+    // And it must be the explosion release URL, fetched at build time.
+    expect(dockerfile).toMatch(
+      /https:\/\/github\.com\/explosion\/spacy-models\/releases\/download\/en_core_web_sm-\d+\.\d+\.\d+\/en_core_web_sm-\d+\.\d+\.\d+-py3-none-any\.whl/,
+    );
+  });
+
+  it("carries a NON-VACUOUS build-time heteronym guard", () => {
+    // The guard must assert the exact phoneme substrings for BOTH senses of
+    // BOTH heteronym pairs — verified empirically against misaki 0.9.4. A guard
+    // that only imported misaki would pass even if every word collapsed to the
+    // espeak fallback, so the literal phonemes are the load-bearing content.
+    const block = heteronymGuardRun();
+    const text = block.join("\n");
+
+    // Constructed torch-free — the guard proves assumption (a) at build time.
+    expect(text).toMatch(/en\.G2P\(trf=False/);
+    expect(text).toMatch(/EspeakFallback\(british=False\)/);
+
+    // live: verb /lˈɪv/ vs adjective /lˈIv/ (capital I = /aɪ/ in misaki).
+    expect(text).toContain("lˈɪv");
+    expect(text).toContain("lˈIv");
+    // read: base /ɹˈid/ vs past /ɹˈɛd/.
+    expect(text).toContain("ɹˈid");
+    expect(text).toContain("ɹˈɛd");
+
+    // The two senses of each pair must be DISTINCT literals — a guard asserting
+    // the same string twice would be vacuous.
+    expect("lˈɪv").not.toBe("lˈIv");
+    expect("ɹˈid").not.toBe("ɹˈɛd");
+
+    // The assertions must actually run against the G2P output, not just mention
+    // the strings — pin the `in` membership asserts.
+    expect(text).toMatch(/assert 'lˈɪv' in \w+ and 'lˈIv' in \w+/);
+    expect(text).toMatch(/assert 'ɹˈid' in \w+ and 'ɹˈɛd' in \w+/);
+  });
+
+  it("runs the guard AFTER the pip install, on system python3", () => {
+    // A guard that preceded the install would prove nothing. The guard RUN must
+    // come after the RUN that installs misaki.
+    const runs = runInstructions();
+    const installIdx = runs.findIndex((b) =>
+      b.join("\n").includes('"misaki==0.9.4"'),
+    );
+    const guardIdx = runs.findIndex((b) =>
+      b.join("\n").includes("from misaki import en, espeak"),
+    );
+    expect(installIdx, "the misaki install RUN must exist").toBeGreaterThanOrEqual(0);
+    expect(guardIdx).toBeGreaterThan(installIdx);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes English heteronym pronunciation in the Kokoro TTS voice sidecar. Today Kokoro phonemizes via espeak, which is **not** part-of-speech aware, so it can't tell the verb "live" /lˈɪv/ from the adjective "live" /lˈaɪv/, or present "read" /ɹˈid/ from past "read" /ɹˈɛd/.

This runs **misaki**'s POS-aware English G2P in-process (`docker/voice-sidecar/server.py`) and feeds the resulting phoneme string to Kokoro with `is_phonemes=True`. The HTTP contract (`/tts`, `/stt`, `/healthz`) is byte-identical — nothing on the telegram-plugin side changes.

## Integration decision — and why no torch

`kokoro-onnx==0.5.0` and its ONNX inference path are **unchanged**. misaki is a **strict enhancement**, built in its own `try/except` beside the Kokoro model in `_load_tts`:

- On success, `_g2p` is set and `_run_synthesis` routes each piece through `_phonemize_piece` → `_tts.create(phonemes, is_phonemes=True)`.
- On **any** miss — `VOICE_TTS_G2P=espeak`, a non-English locale, a failed G2P load, or a per-call phonemize error — `_g2p` stays `None`, synthesis passes the **raw text** to `_tts.create(text, lang=TTS_LANG)`, and the sidecar stays fully healthy (`/healthz` untouched). That is exactly today's behavior.

Deliberately **not** `misaki[en]`: that extra pulls `spacy-curated-transformers` → **torch**, which would undo the entire no-torch reason the sidecar is on `kokoro-onnx`. We install base misaki + spaCy (`trf=False`, tok2vec+tagger only) + num2words, and bake `en_core_web_sm` as a wheel so `misaki.en.G2P` never calls `spacy.cli.download()` at runtime (a network fetch + site-packages write that fails under the non-root UID and breaks offline boots).

## Dependency delta (`docker/Dockerfile.voice`)

| Package | Pin | Why |
|---|---|---|
| `misaki` | `==0.9.4` | POS-aware G2P. Pinned: misaki `main` imports torch/transformers at the top of `en.py`; 0.9.4 does not. |
| `spacy` | `==3.8.7` | misaki's tagger backbone (`trf=False`). |
| `num2words` | `==0.5.14` | misaki number expansion. |
| `click` | `==8.1.7` | Undeclared dep of spaCy's CLI (`typer 0.27` no longer hard-depends on it); `import spacy` dies without it. Same class of bug as the existing `requests` pin. |
| `numpy` | `>=2.0.2` | Floor so a resolver wobble can't drag the image to numpy 1.x. |
| `en_core_web_sm` | `3.8.0` wheel | Baked, offline. major.minor coupled to the spaCy pin. |

No torch, transformers, or spacy-curated-transformers anywhere.

## Test plan

- **`docker/voice-sidecar/test_g2p.py`** (stdlib-only, runs in the existing `ci-tests-python` voice-sidecar job without misaki/numpy/ffmpeg): `_phonemize_piece` degrade/hit matrix; `_run_synthesis` **routing** — a stubbed `_tts` proves `is_phonemes=True` on a hit and `lang=TTS_LANG` (no `is_phonemes`) on fallback, so a regression can't silently route phonemes through the espeak text path. A `@skipUnless(misaki)` case asserts the real live/read phoneme pairs.
- **`tests/docker/dockerfile-voice-misaki.test.ts`** (structural, no docker): misaki==0.9.4 present; `misaki[en]` / torch / transformers / spacy-curated-transformers absent from install lines; wheel version matches the spaCy pin; the build guard is **non-vacuous** (contains the literal expected phoneme strings) and runs after the install.
- **Build-time guard** in `Dockerfile.voice` asserts misaki emits **distinct** phonemes for both senses of both pairs — the authoritative proof of the two load-bearing assumptions runs in the `build-voice` CI job.

Local results: `python3 -m unittest discover -s docker/voice-sidecar` → 47 tests OK (2 skipped = real-misaki). `vitest run tests/docker/dockerfile-voice-misaki.test.ts` → 9 passed. `tsc --noEmit` clean. The exact build guard command was run in a `python:3.10` container against the real dependency set and exits 0.

## Risks

- misaki pinned at 0.9.4 (main adds torch) — Dependabot note added in the Dockerfile.
- numpy kept `>=2.0.2`.
- misaki 0.9.4 needs Python <3.13; the base is Python 3.10.

## Rollback lever

Set `VOICE_TTS_G2P=espeak` to restore the espeak-only path fleet-wide — no image rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)