### PR TITLE
fix(gateway): refresh a re-put boot_briefing spool entry instead of keeping the stale one (#4246)

### DIFF
--- a/telegram-plugin/gateway/inbound-spool.ts
+++ b/telegram-plugin/gateway/inbound-spool.ts
@@ -497,7 +497,30 @@ export function createInboundSpool(opts: InboundSpoolOptions): InboundSpool {
   return {
     put(agent, msg) {
       const id = spoolId(msg)
-      if (live.has(id)) return false // dedup: already spooled & un-acked
+      const existing = live.get(id)
+      if (existing != null) {
+        // Dedup: the same logical event is already spooled and un-acked, so
+        // by default drop the duplicate (retried synthetics of one event).
+        //
+        // Exception (#4246): a boot_briefing is keyed per chat, NOT per boot
+        // (spoolId `s:boot-briefing:<chatId>`), so a LATER boot re-puts a
+        // FRESHER briefing under the same id. The strict-dedup path kept
+        // boot-1's now-stale text, so a boot-2 delivery carried boot-1's
+        // briefing (only self-corrected by the 60-min TTL). Refresh the
+        // entry's payload in place so the newest briefing wins, keeping the
+        // original firstAt so escalation timing isn't reset by repeated
+        // restarts. The refreshed put is re-appended durably (hydrate's
+        // "last put for an id wins" restores it across a crash). No new live
+        // entry is created, so this can never double-deliver.
+        if (msg.meta?.source === 'boot_briefing') {
+          existing.agent = agent
+          existing.msg = msg
+          appendRecord({ t: 'put', id, agent, msg, firstAt: existing.firstAt })
+          maybeCompact()
+          return true
+        }
+        return false
+      }
       const firstAt = now()
       live.set(id, { agent, msg, firstAt })
       appendRecord({ t: 'put', id, agent, msg, firstAt })

--- a/telegram-plugin/tests/inbound-spool.test.ts
+++ b/telegram-plugin/tests/inbound-spool.test.ts
@@ -264,6 +264,53 @@ describe('inbound-spool — put / ack / dedup', () => {
   })
 })
 
+describe('inbound-spool — boot_briefing refresh-on-reput (#4246)', () => {
+  function briefing(text: string, over: Partial<InboundMessage> = {}): InboundMessage {
+    // boot_briefing spoolId is `s:boot-briefing:<chatId>` — keyed per chat,
+    // not per boot — so successive boots share one id but carry fresh text.
+    return msg({
+      chatId: 'c1',
+      messageId: 0, // synthetics have no real Telegram messageId
+      text,
+      meta: { source: 'boot_briefing' },
+      ...over,
+    })
+  }
+
+  it('a later boot refreshes the spooled briefing text instead of keeping the stale one', () => {
+    const fs = fakeFs()
+    const s = createInboundSpool({ path: PATH, fs })
+    expect(s.put('klanker', briefing('boot-1 briefing'))).toBe(true)
+    // boot-2: same chat, same spool id, FRESHER text. Must win.
+    expect(s.put('klanker', briefing('boot-2 briefing'))).toBe(true)
+    // Still exactly one live entry (no stacking, no double-delivery)...
+    expect(s.liveCount()).toBe(1)
+    expect(s.liveEntries()).toHaveLength(1)
+    // ...and it carries boot-2's text, not boot-1's stale text.
+    expect(s.liveEntries()[0].msg.text).toBe('boot-2 briefing')
+  })
+
+  it('the refreshed briefing survives a crash/rebuild (durable last-put-wins)', () => {
+    const fs = fakeFs()
+    const s1 = createInboundSpool({ path: PATH, fs })
+    s1.put('klanker', briefing('boot-1 briefing'))
+    s1.put('klanker', briefing('boot-2 briefing'))
+    // Rebuild from the on-disk log (simulates a gateway restart).
+    const s2 = createInboundSpool({ path: PATH, fs })
+    expect(s2.liveCount()).toBe(1)
+    expect(s2.liveEntries()[0].msg.text).toBe('boot-2 briefing')
+  })
+
+  it('non-briefing sources keep strict dedup (re-put drops, old entry retained)', () => {
+    const fs = fakeFs()
+    const s = createInboundSpool({ path: PATH, fs })
+    expect(s.put('a', msg({ messageId: 7, text: 'first' }))).toBe(true)
+    expect(s.put('a', msg({ messageId: 7, text: 'second' }))).toBe(false) // dedup
+    expect(s.liveCount()).toBe(1)
+    expect(s.liveEntries()[0].msg.text).toBe('first') // original retained
+  })
+})
+
 describe('inbound-spool — crash-survivable replay (the core guarantee)', () => {
   it('a fresh spool over an existing file rebuilds live state (survives restart)', () => {
     const fs = fakeFs()


### PR DESCRIPTION
## Summary
Closes #4246 (follow-up low from #4214).

The boot briefing is spooled under a per-chat id (`s:boot-briefing:<chatId>`), so successive boots share one spool entry. `put` returned `false` on any already-live id and kept the existing payload, so a **second restart within the dedup window left boot-1's now-stale briefing text in the spool** — a boot-2 delivery carried boot-1's text (only self-corrected by the 60-min TTL).

## Fix
Refresh the entry's payload in place when a `boot_briefing` is re-put under a live id: replace `msg` (and `agent`), keeping the original `firstAt` so escalation timing isn't reset by repeated restarts, and re-append the `put` record durably so hydrate's "last put for an id wins" restores the fresh text across a crash. No new live entry is created, so this can never double-deliver. All other sources keep strict dedup.

## Tests
`telegram-plugin/tests/inbound-spool.test.ts` (runs under vitest), 49 pass (+3):
- a later boot's text wins (one live entry, boot-2 text);
- the refreshed briefing survives a crash/rebuild;
- non-briefing re-puts still dedup and retain the original.

Single concern. No auto-merge — left for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)