### PR TITLE
fix(gateway): session-generation guard for boot-briefing respawns (#4242)

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -87,6 +87,18 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
     export SWITCHROOM_FORCE_FRESH=1
   fi
 
+  # Session-generation stamp for the gateway boot briefing (#4242). Set ONCE
+  # here, per real boot, before the gateway fork below. `_switchroom_supervise`
+  # respawns the gateway `bun` process in a `while` loop inside this same shell
+  # (it does NOT re-run start.sh), so every crash-respawn inherits this exact
+  # value, while the next real container boot re-derives a fresh one. The
+  # gateway persists it the first time it briefs and skips re-minting when the
+  # persisted stamp matches — that distinguishes "supervisor respawned me into
+  # a still-live Claude session" (skip) from "genuine new boot" (brief). The
+  # epoch second keeps it monotonic across boots; $$ (this outer pass's PID)
+  # plus ${RANDOM} guarantee uniqueness even for two boots within one second.
+  export SWITCHROOM_GATEWAY_BOOT_ID="$(date +%s)-$$-${RANDOM}"
+
   # Gateway-consumed env MUST be exported HERE, before the gateway fork
   # below. The gateway daemon reads channels.telegram.* knobs (and any
   # agent env) from process.env at startup — e.g. SWITCHROOM_TG_STREAM_

--- a/telegram-plugin/gateway/boot-briefing-wiring.ts
+++ b/telegram-plugin/gateway/boot-briefing-wiring.ts
@@ -13,7 +13,7 @@
  * never blocks: every failure path degrades to "no briefing".
  */
 
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { getHistoryDbForBriefing } from '../history.js'
 import type { InboundMessage } from './ipc-protocol.js'
@@ -54,6 +54,47 @@ export function maybeQueueBootBriefing(
     const agentDir = opts.stateDir.endsWith('/telegram')
       ? opts.stateDir.slice(0, -'/telegram'.length)
       : opts.stateDir
+    // Session-generation guard (#4242). This module re-evaluates on EVERY
+    // gateway process start, including a supervisor respawn after the
+    // gateway crashes — but a respawn does NOT restart the inner Claude
+    // session, so re-queuing a boot briefing would inject a "you just
+    // rebooted" reorientation into a live, mid-conversation session. The
+    // spool's dedup can't catch it: by respawn time boot-1's briefing has
+    // been delivered AND acked, so its spool entry is already gone.
+    //
+    // start.sh's OUTER pass stamps SWITCHROOM_GATEWAY_BOOT_ID once per REAL
+    // boot, before forking the gateway; `_switchroom_supervise` respawns
+    // `bun` in a loop within that same shell, so every respawn inherits the
+    // identical id, while the next real boot re-derives a fresh one. We
+    // persist the id the first time a generation actually queues (or
+    // determines it has nothing to queue) and skip when the persisted id
+    // matches — that is a respawn. Absent env (non-docker / pre-upgrade
+    // start.sh) leaves the guard inert: legacy best-effort behaviour.
+    const bootId = opts.env.SWITCHROOM_GATEWAY_BOOT_ID
+    const genMarkerPath = join(agentDir, '.boot-briefing-generation')
+    if (bootId) {
+      let prevGen: string | null = null
+      try {
+        prevGen = readFileSync(genMarkerPath, 'utf8').trim()
+      } catch {
+        prevGen = null
+      }
+      if (prevGen === bootId) {
+        log(
+          'telegram gateway: boot-briefing suppressed (supervisor respawn — this boot generation already briefed)\n',
+        )
+        return null
+      }
+    }
+    const markGeneration = (): void => {
+      if (!bootId) return
+      try {
+        writeFileSync(genMarkerPath, `${bootId}\n`)
+      } catch {
+        // Best-effort: a failed persist only risks one redundant re-queue on
+        // respawn, which the spool still dedups; never block boot.
+      }
+    }
     // Force-fresh suppression is keyed on env, NOT on existsSync at this
     // module-eval time. start.sh's OUTER pass snapshots the
     // `.force-fresh-session` marker into SWITCHROOM_FORCE_FRESH *before*
@@ -96,6 +137,10 @@ export function maybeQueueBootBriefing(
     })
     const text = renderBootBriefing(surfaces, { nowMs, restartReason })
     if (!text) {
+      // Consume the generation even when empty: had there been nothing to
+      // brief at boot, a later respawn must not suddenly brief mid-session
+      // just because fresh messages arrived after the session came up.
+      markGeneration()
       log('telegram gateway: boot-briefing empty (no recent surfaces) — nothing queued\n')
       return null
     }
@@ -107,6 +152,7 @@ export function maybeQueueBootBriefing(
       nowMs,
     })
     opts.put(selfAgent, msg)
+    markGeneration()
     log(
       `telegram gateway: boot-briefing queued chat=${primary.chatId}` +
         `${primary.threadId != null ? ` thread=${primary.threadId}` : ''} ` +

--- a/telegram-plugin/tests/boot-briefing-builder.test.ts
+++ b/telegram-plugin/tests/boot-briefing-builder.test.ts
@@ -473,3 +473,82 @@ describe('maybeQueueBootBriefing — end-to-end wiring', () => {
     ).not.toThrow()
   })
 })
+
+describe('maybeQueueBootBriefing — session-generation guard (#4242)', () => {
+  function envGen(bootId?: string): Record<string, string | undefined> {
+    return {
+      SWITCHROOM_SESSION_BRIEFING: 'gateway',
+      SWITCHROOM_RESUME_MODE: 'handoff',
+      SWITCHROOM_AGENT_NAME: 'testagent',
+      ...(bootId != null ? { SWITCHROOM_GATEWAY_BOOT_ID: bootId } : {}),
+    }
+  }
+
+  const call = (
+    env: Record<string, string | undefined>,
+    puts: Array<{ agent: string; msg: InboundMessage }>,
+  ) =>
+    maybeQueueBootBriefing({
+      env,
+      stateDir: join(stateDir, 'telegram'),
+      resumeMsg: null,
+      put: (agent, msg) => puts.push({ agent, msg }),
+      log: () => {},
+      nowMs: NOW_MS,
+    })
+
+  it('re-mints ONCE per boot generation: a supervisor respawn (same boot id) queues nothing', () => {
+    seedUser('321', null, 30 * 60, 'the deploy is half-done')
+    const puts: Array<{ agent: string; msg: InboundMessage }> = []
+
+    // Boot-1: first gateway process of this generation briefs.
+    const first = call(envGen('gen-1'), puts)
+    expect(first).not.toBeNull()
+    expect(puts.length).toBe(1)
+    // Generation persisted for the respawn check.
+    expect(existsSync(join(stateDir, '.boot-briefing-generation'))).toBe(true)
+
+    // Respawn: same shell → same SWITCHROOM_GATEWAY_BOOT_ID. The gateway
+    // module re-evaluates, but the inner Claude session is still live from
+    // boot-1 — re-injecting a "you just rebooted" briefing would be wrong.
+    const respawn = call(envGen('gen-1'), puts)
+    expect(respawn).toBeNull()
+    expect(puts.length).toBe(1) // no second put
+  })
+
+  it('a GENUINE new boot (fresh boot id) briefs again', () => {
+    seedUser('321', null, 30 * 60, 'still pending your call')
+    const puts: Array<{ agent: string; msg: InboundMessage }> = []
+
+    expect(call(envGen('gen-1'), puts)).not.toBeNull()
+    expect(puts.length).toBe(1)
+    // Next real container boot re-derives a different id → not a respawn.
+    expect(call(envGen('gen-2'), puts)).not.toBeNull()
+    expect(puts.length).toBe(2)
+  })
+
+  it('consumes the generation even when the first boot had nothing to brief (no mid-session brief on respawn)', () => {
+    const puts: Array<{ agent: string; msg: InboundMessage }> = []
+    // Boot-1: empty history → nothing queued, but the generation is consumed.
+    expect(call(envGen('gen-1'), puts)).toBeNull()
+    expect(puts.length).toBe(0)
+    expect(existsSync(join(stateDir, '.boot-briefing-generation'))).toBe(true)
+
+    // Messages arrive AFTER the session is live, then the gateway respawns.
+    seedUser('321', null, 5 * 60, 'a message that landed mid-session')
+    const respawn = call(envGen('gen-1'), puts)
+    expect(respawn).toBeNull()
+    expect(puts.length).toBe(0) // must NOT brief into the live session
+  })
+
+  it('guard is inert when SWITCHROOM_GATEWAY_BOOT_ID is absent (non-docker / pre-upgrade start.sh keeps legacy behaviour)', () => {
+    seedUser('321', null, 30 * 60, 'legacy path message')
+    const puts: Array<{ agent: string; msg: InboundMessage }> = []
+    // With no boot id, every gateway start briefs as before — no marker
+    // written, no suppression.
+    expect(call(envGen(undefined), puts)).not.toBeNull()
+    expect(call(envGen(undefined), puts)).not.toBeNull()
+    expect(puts.length).toBe(2)
+    expect(existsSync(join(stateDir, '.boot-briefing-generation'))).toBe(false)
+  })
+})

--- a/tests/scaffold.gateway-env-order.test.ts
+++ b/tests/scaffold.gateway-env-order.test.ts
@@ -129,6 +129,27 @@ describe("start.sh: gateway-consumed env exported before the gateway fork", () =
     expect(startSh).toContain('rm -f "');
   });
 
+  it("hoists the SWITCHROOM_GATEWAY_BOOT_ID stamp AHEAD of the gateway fork (#4242: respawn-stable session generation)", () => {
+    const startSh = renderStartSh();
+    const forkIdx = startSh.indexOf(GATEWAY_FORK);
+    expect(forkIdx).toBeGreaterThan(-1);
+
+    // The outer pass stamps a per-boot session-generation id BEFORE forking
+    // the gateway. _switchroom_supervise respawns the gateway `bun` in a loop
+    // within this same shell (no re-run of start.sh), so a crash-respawn
+    // inherits the identical id and the gateway skips re-minting the briefing
+    // into the still-live Claude session; a genuine new boot re-derives a
+    // fresh id. If this slid after the fork, the daemon would never see it and
+    // the guard would be inert on docker — exactly where the respawn race
+    // lives.
+    const bootIdIdx = startSh.indexOf("export SWITCHROOM_GATEWAY_BOOT_ID=");
+    expect(bootIdIdx).toBeGreaterThan(-1);
+    expect(bootIdIdx).toBeLessThan(forkIdx);
+    // The value must be derived per boot (not a fixed literal), so distinct
+    // container boots never collide on the same generation.
+    expect(startSh).toContain('export SWITCHROOM_GATEWAY_BOOT_ID="$(date +%s)-$$-${RANDOM}"');
+  });
+
   it("still re-exports the same vars in the inner pass (after the fork) for claude", () => {
     const startSh = renderStartSh();
     const forkIdx = startSh.indexOf(GATEWAY_FORK);


### PR DESCRIPTION
Closes #4242.

## Problem
The gateway module re-evaluates `maybeQueueBootBriefing` on **every** gateway process start. Under the docker supervisor, `_switchroom_supervise` respawns the gateway `bun` process in a loop after a crash **without** re-running `start.sh` and **without** restarting the inner Claude session. A mid-session gateway crash therefore re-mints the boot briefing and injects a "you just rebooted" reorientation into a live, in-progress conversation.

The inbound-spool dedup cannot catch this: by respawn time boot-1's briefing has already been delivered **and** acked, so its spool entry is already gone (per-chat spool id, "last put wins").

## Fix (deterministic, not prompt-dependent)
Stamp a per-boot **session generation** id:

- `start.sh`'s OUTER pass exports `SWITCHROOM_GATEWAY_BOOT_ID="$(date +%s)-$$-${RANDOM}"` **once per real boot**, before the gateway fork. `_switchroom_supervise` loops `bun` in that same shell, so every crash-respawn inherits the identical id; the next real container boot re-derives a fresh one.
- `maybeQueueBootBriefing` (in `boot-briefing-wiring.ts`) persists the id to `<agentDir>/.boot-briefing-generation` the first time a generation reaches a briefing decision (queued **or** determined-empty), and skips when the persisted id matches — that match is a respawn.
- Absent env (non-docker / pre-upgrade `start.sh`) leaves the guard **inert**: unchanged legacy best-effort behaviour.

Consuming the generation even on the empty-history path closes a subtle variant: messages that land **after** the session is live must not trigger a briefing on the next respawn.

The guard lives entirely in `boot-briefing-wiring.ts` — **gateway.ts is untouched** (line ratchet unaffected, still 24909).

## Tests
- `boot-briefing-builder.test.ts` (new `session-generation guard (#4242)` block): respawn with the same id queues nothing; a fresh id briefs again; empty-first-boot still consumes the generation so a respawn won't brief mid-session; absent env keeps legacy behaviour. 28 pass.
- `scaffold.gateway-env-order.test.ts`: `SWITCHROOM_GATEWAY_BOOT_ID` is hoisted ahead of the gateway fork and derived per boot (not a fixed literal). 6 pass.
- `npm run lint` clean (incl. `tsc --noEmit` and gateway-line-ratchet).

Single-concern follow-up from #4214's adversarial review. Left for review — auto-merge not enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)