### PR TITLE
feat(gateway): version-skew handshake for briefing:gateway bundle (#4245)

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -438,6 +438,32 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
 
   _gateway_bundle=/opt/switchroom/telegram-plugin/dist/gateway/gateway.js
   _telegram_enabled={{#if telegramEnabledFlag}}{{telegramEnabledFlag}}{{else}}true{{/if}}
+
+  # Version-skew handshake for the gateway boot briefing (#4245). This start.sh
+  # is fresh; the deployed /opt/switchroom gateway bundle may NOT be. When it
+  # sets briefing=gateway it also skips the legacy shell handoff-briefing
+  # assembler (inner pass, below) — so if the bundle PREDATES the boot-briefing
+  # builder, BOTH paths are dead and the agent gets a SILENT no-briefing until
+  # the image is updated. The stale bundle cannot self-report a feature it lacks,
+  # so this fresh start.sh does the handshake: grep the bundle for the capability
+  # sentinel the builder exports (GATEWAY_BOOT_BRIEFING_CAPABILITY in
+  # telegram-plugin/gateway/boot-briefing-capability.ts; the bundle is built
+  # un-minified so the literal survives verbatim). On a miss, warn LOUDLY and
+  # drop a marker so the inner pass runs the legacy handoff assembler as a
+  # fallback instead of leaving this boot with nothing. Resolve the marker afresh
+  # every boot (rm, then re-touch only on a confirmed miss) so a later image
+  # update self-heals with no leftover state.
+  _briefing_skew_marker="{{agentDir}}/.gateway-briefing-unavailable"
+  rm -f "$_briefing_skew_marker"
+  if [ "$SWITCHROOM_SESSION_BRIEFING" = "gateway" ]; then
+    if [ -f "$_gateway_bundle" ] && grep -q '{{gatewayBriefingCapability}}' "$_gateway_bundle" 2>/dev/null; then
+      : # bundle carries the boot-briefing builder — gateway path is live
+    else
+      echo "[start.sh] WARNING: session_continuity.briefing=gateway is configured, but the deployed gateway bundle ($_gateway_bundle) PREDATES the boot-briefing builder (capability sentinel '{{gatewayBriefingCapability}}' absent from the bundle). The gateway cannot assemble the reorientation briefing, and the legacy shell handoff path is skipped for 'gateway' mode — so this boot would otherwise get NO briefing at all. FALLING BACK to the legacy handoff-briefing assembler for this boot. Update the agent image (/opt/switchroom) to a build that includes the boot-briefing feature to use the gateway path." >&2
+      touch "$_briefing_skew_marker" 2>/dev/null || true
+    fi
+  fi
+
   if [ "$_telegram_enabled" = "true" ] && [ -f "$_gateway_bundle" ] && command -v bun >/dev/null 2>&1; then
     _switchroom_supervise gateway /var/log/switchroom/gateway-supervisor.log \
       bun "$_gateway_bundle" &
@@ -1418,7 +1444,18 @@ if [ "$_HANDOFF_STALE" = "1" ]; then
   # running the shell assembler here would double-inject the same recent
   # conversation. The Stop-hook .handoff.md path below is left untouched in
   # this stage of the migration.
-  if [ "$SWITCHROOM_RESUME_MODE" = "handoff" ] && [ "{{#if sessionBriefingMode}}{{{sessionBriefingMode}}}{{else}}legacy{{/if}}" != "gateway" ] && command -v handoff-briefing.sh >/dev/null 2>&1; then
+  #
+  # EXCEPTION (#4245): when the outer pass detected a bundle version skew
+  # (briefing=gateway requested but the deployed gateway bundle predates the
+  # boot-briefing builder), it dropped the .gateway-briefing-unavailable marker.
+  # In that case the gateway path is dead, so run the legacy assembler here as a
+  # fallback even in 'gateway' mode — the double-inject risk does not apply
+  # because the stale gateway never queues a briefing. This is a file-based
+  # handshake on purpose: the marker survives the outer→inner tmux re-exec
+  # deterministically (written before the exec, read after), unlike env.
+  if [ "$SWITCHROOM_RESUME_MODE" = "handoff" ] \
+     && { [ "{{#if sessionBriefingMode}}{{{sessionBriefingMode}}}{{else}}legacy{{/if}}" != "gateway" ] || [ -f "{{agentDir}}/.gateway-briefing-unavailable" ]; } \
+     && command -v handoff-briefing.sh >/dev/null 2>&1; then
     export AGENT_DIR="{{agentDir}}"
     timeout 5 handoff-briefing.sh 2>/dev/null || true
   fi

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -745,6 +745,7 @@ export function maybeWriteCronMcp(
 }
 import { resolveUsers, resolvePersonEntries } from "../config/users.js";
 import { isClaudeModel } from "../../telegram-plugin/gateway/model-command.js";
+import { GATEWAY_BOOT_BRIEFING_CAPABILITY } from "../../telegram-plugin/gateway/boot-briefing-capability.js";
 import {
   resolveAgentConfig,
   translateHooksToClaudeShape,
@@ -4361,6 +4362,11 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     // exported before the gateway fork) and the inner handoff block (which
     // skips handoff-briefing.sh when 'gateway' owns the briefing).
     sessionBriefingMode: agentConfig.session_continuity?.briefing ?? "legacy",
+    // Capability sentinel for the start.sh ↔ gateway-bundle version handshake
+    // (#4245). Templated into start.sh's outer pass, which greps the deployed
+    // gateway bundle for this literal before trusting `briefing: gateway`.
+    // Single source of truth in telegram-plugin/gateway/boot-briefing-capability.ts.
+    gatewayBriefingCapability: GATEWAY_BOOT_BRIEFING_CAPABILITY,
     // True only when the generated start.sh can actually set CONTINUE_FLAG="--continue"
     // at runtime (i.e. resume_mode is 'auto' or 'continue'). In handoff/none mode the
     // case branches for auto/continue are omitted entirely so the literal string
@@ -8001,6 +8007,9 @@ function reconcileAgentInner(
       // Boot-briefing transport flag (session_continuity.briefing; default
       // 'legacy'). Mirror of buildWorkspaceContext — reconcile must keep parity.
       sessionBriefingMode: agentConfig.session_continuity?.briefing ?? "legacy",
+      // Capability sentinel for the #4245 start.sh ↔ gateway-bundle handshake.
+      // Mirror of buildWorkspaceContext — reconcile must keep parity.
+      gatewayBriefingCapability: GATEWAY_BOOT_BRIEFING_CAPABILITY,
     };
     const beforeStartSh = existsSync(startShPath)
       ? readFileSync(startShPath, "utf-8")

--- a/telegram-plugin/gateway/boot-briefing-capability.ts
+++ b/telegram-plugin/gateway/boot-briefing-capability.ts
@@ -1,0 +1,31 @@
+/**
+ * Capability sentinel for the start.sh ↔ gateway-bundle version handshake
+ * (#4245). This is a DEPENDENCY-FREE leaf module on purpose: it is imported
+ * both by the gateway (`boot-briefing-wiring.ts`, which references it so the
+ * un-minified bundle carries the literal) AND by `src/agents/scaffold.ts`
+ * (which templates the value into the generated start.sh). Keeping it free of
+ * `bun:sqlite` / history imports lets the node-side scaffold import it without
+ * pulling in bun-only runtime deps.
+ *
+ * ## The skew it closes
+ *
+ * A freshly-scaffolded start.sh sets `SWITCHROOM_SESSION_BRIEFING=gateway` AND
+ * skips the legacy shell handoff-briefing assembler for that mode. If the
+ * deployed `/opt/switchroom/telegram-plugin/dist/gateway/gateway.js` bundle
+ * PREDATES the boot-briefing builder, the gateway path is dead too — the agent
+ * gets a SILENT no-briefing until the image is updated. The stale bundle cannot
+ * self-report a feature it doesn't contain, so the FRESH component (start.sh)
+ * performs the handshake: it greps the deployed bundle for this literal before
+ * trusting the flag. On a miss it warns loudly and drops a marker so the inner
+ * pass runs the legacy handoff assembler as a fallback (see
+ * `profiles/_base/start.sh.hbs`), rather than leaving the boot with nothing.
+ *
+ * The gateway bundle is built UN-minified (`telegram-plugin/scripts/build.mjs`:
+ * `bun build --target node`, no `--minify`), so this string literal survives
+ * verbatim into `gateway.js`.
+ *
+ * Bump the version suffix ONLY on a breaking change to the boot-briefing
+ * capability contract that an older start.sh must not treat as present. Both
+ * sides of the handshake read this single constant, so a bump stays in sync.
+ */
+export const GATEWAY_BOOT_BRIEFING_CAPABILITY = 'switchroom-cap:boot-briefing:v1'

--- a/telegram-plugin/gateway/boot-briefing-wiring.ts
+++ b/telegram-plugin/gateway/boot-briefing-wiring.ts
@@ -15,6 +15,7 @@
 
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { GATEWAY_BOOT_BRIEFING_CAPABILITY } from './boot-briefing-capability.js'
 import { getHistoryDbForBriefing } from '../history.js'
 import type { InboundMessage } from './ipc-protocol.js'
 import {
@@ -110,7 +111,8 @@ export function maybeQueueBootBriefing(
     log(
       `telegram gateway: boot-briefing queued chat=${primary.chatId}` +
         `${primary.threadId != null ? ` thread=${primary.threadId}` : ''} ` +
-        `surfaces=${surfaces.length} chars=${text.length}\n`,
+        `surfaces=${surfaces.length} chars=${text.length} ` +
+        `cap=${GATEWAY_BOOT_BRIEFING_CAPABILITY}\n`,
     )
     return msg
   } catch (err) {

--- a/tests/scaffold.briefing-capability-handshake.test.ts
+++ b/tests/scaffold.briefing-capability-handshake.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent } from "../src/agents/scaffold.js";
+import { GATEWAY_BOOT_BRIEFING_CAPABILITY } from "../telegram-plugin/gateway/boot-briefing-capability.js";
+import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+/**
+ * #4245 — start.sh ↔ gateway-bundle version-skew handshake.
+ *
+ * A fresh start.sh with `briefing: gateway` skips the legacy shell handoff
+ * assembler; if the deployed gateway bundle predates the boot-briefing builder,
+ * the agent gets a silent no-briefing. start.sh's outer pass greps the bundle
+ * for the capability sentinel and, on a miss, warns loudly + drops a marker so
+ * the inner pass runs the legacy assembler as a fallback.
+ */
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+function makeSwitchroomConfig(agentName: string, agentConfig: AgentConfig): SwitchroomConfig {
+  return {
+    switchroom: { version: 1, agents_dir: "~/.switchroom/agents", skills_dir: "~/.switchroom/skills" },
+    telegram: telegramConfig,
+    agents: { [agentName]: agentConfig },
+  };
+}
+
+const GATEWAY_FORK = 'bun "$_gateway_bundle"';
+
+describe("start.sh: gateway boot-briefing version-skew handshake (#4245)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-briefing-cap-"));
+  });
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function renderStartSh(briefing?: "gateway" | "legacy"): string {
+    const config = {
+      extends: "default",
+      topic_name: "Test Topic",
+      schedule: [],
+      ...(briefing ? { session_continuity: { briefing } } : {}),
+    } as AgentConfig;
+    const sw = makeSwitchroomConfig("test-agent", config);
+    const result = scaffoldAgent("test-agent", config, tmpDir, telegramConfig, sw);
+    return readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+  }
+
+  it("templates the capability sentinel from the single source of truth (no drift)", () => {
+    const startSh = renderStartSh("gateway");
+    // The literal grepped in start.sh MUST equal the constant the gateway bundle
+    // carries — a bump to one without the other silently breaks the handshake.
+    expect(startSh).toContain(GATEWAY_BOOT_BRIEFING_CAPABILITY);
+    expect(startSh).toContain(`grep -q '${GATEWAY_BOOT_BRIEFING_CAPABILITY}' "$_gateway_bundle"`);
+  });
+
+  it("runs the bundle capability grep BEFORE forking the gateway", () => {
+    const startSh = renderStartSh("gateway");
+    const grepIdx = startSh.indexOf(`grep -q '${GATEWAY_BOOT_BRIEFING_CAPABILITY}'`);
+    const forkIdx = startSh.indexOf(GATEWAY_FORK);
+    expect(grepIdx).toBeGreaterThan(-1);
+    expect(forkIdx).toBeGreaterThan(-1);
+    expect(grepIdx).toBeLessThan(forkIdx);
+  });
+
+  it("on a stale bundle: warns loudly and drops the fallback marker", () => {
+    const startSh = renderStartSh("gateway");
+    // Guarded on the requested mode so a legacy agent pays nothing.
+    expect(startSh).toContain('if [ "$SWITCHROOM_SESSION_BRIEFING" = "gateway" ]; then');
+    expect(startSh).toMatch(/WARNING: session_continuity\.briefing=gateway is configured/);
+    expect(startSh).toContain('touch "$_briefing_skew_marker"');
+    // Marker is resolved afresh each boot (rm first) so an image update self-heals.
+    expect(startSh).toContain('rm -f "$_briefing_skew_marker"');
+    expect(startSh).toContain('.gateway-briefing-unavailable');
+  });
+
+  it("inner-pass legacy assembler runs as a fallback when the skew marker is present", () => {
+    const startSh = renderStartSh("gateway");
+    // The gate keeps its `!= gateway` skip but ORs in the marker so a
+    // skew-detected boot still gets the legacy briefing.
+    expect(startSh).toContain('[ -f "');
+    expect(startSh).toMatch(/\|\| \[ -f "[^"]*\.gateway-briefing-unavailable" \]/);
+  });
+
+  it("the handshake block is present regardless of mode, gated on the runtime env (legacy pays nothing)", () => {
+    const startSh = renderStartSh("legacy");
+    // The block renders unconditionally but its body is gated on
+    // SWITCHROOM_SESSION_BRIEFING=gateway at runtime, so a legacy agent skips it.
+    expect(startSh).toContain('if [ "$SWITCHROOM_SESSION_BRIEFING" = "gateway" ]; then');
+  });
+});


### PR DESCRIPTION
Closes #4245.

## Problem
A freshly-scaffolded start.sh sets `SWITCHROOM_SESSION_BRIEFING=gateway` **and** skips the legacy shell `handoff-briefing.sh` assembler for that mode. If the deployed `/opt/switchroom/telegram-plugin/dist/gateway/gateway.js` bundle **predates** the boot-briefing builder, the gateway path is dead too — the agent gets a **silent no-briefing** until the image is updated, with no warning (adversarial review low #4 from #4214). A stale bundle cannot self-report a feature it does not contain.

## Fix — the fresh component does the handshake
- New dependency-free leaf module `telegram-plugin/gateway/boot-briefing-capability.ts` exports one sentinel `GATEWAY_BOOT_BRIEFING_CAPABILITY = 'switchroom-cap:boot-briefing:v1'`. Dependency-free so the node-side `scaffold.ts` can import it without pulling in `bun:sqlite`.
- It is **referenced in `maybeQueueBootBriefing`'s queued-log line** so the un-minified gateway bundle (`bun build --target node`, no `--minify`) carries the literal verbatim and the bundler can't tree-shake it. **Validated**: the freshly built `dist/gateway/gateway.js` contains the sentinel (1 occurrence).
- It is **templated into start.sh via scaffold** — single source of truth, so a version bump moves both sides of the handshake together (pinned by a drift-guard test).

start.sh's docker **outer pass**, before forking the gateway and only when `briefing=gateway` is requested, greps the deployed bundle for the sentinel:
- **hit** → gateway path is live, nothing to do;
- **miss** → warn **loudly** (naming the bundle path + the absent sentinel) and drop a `.gateway-briefing-unavailable` marker.

The **inner-pass** handoff gate now runs the legacy assembler as a fallback when that marker is present — even in `gateway` mode — so the boot gets a briefing instead of nothing. No double-inject risk: the stale gateway never queues one. The marker is resolved afresh each boot (`rm`, then re-`touch` only on a confirmed miss) so a later image update self-heals. **File-based on purpose**: the marker survives the outer→inner tmux re-exec deterministically (written before `exec`, read after), unlike env across the tmux boundary.

`gateway.ts` is untouched (line ratchet unaffected).

## Tests
`tests/scaffold.briefing-capability-handshake.test.ts` (5): the templated sentinel **equals** the exported constant (drift guard), the grep runs **before** the fork, the stale-bundle warn+marker path, the inner-pass marker fallback OR-clause, and the runtime gating (legacy pays nothing). `boot-briefing-builder` bun suite (24) still green with the added capability reference. `npm run lint` clean (tsc + all checks).

Single-concern follow-up from #4214's adversarial review. Left for review — auto-merge not enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)