### PR TITLE
feat(gateway): Hindsight + daily-memory parity for boot briefing (#4243)

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -70,6 +70,21 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
   export SWITCHROOM_SESSION_BRIEFING="{{#if sessionBriefingMode}}{{{sessionBriefingMode}}}{{else}}legacy{{/if}}"
   export SWITCHROOM_RESUME_MODE="{{#if resumeMode}}{{{resumeMode}}}{{else}}handoff{{/if}}"
 
+{{#if hindsightEnabled}}
+  # Hindsight endpoint for the gateway boot briefing (session_continuity.briefing:
+  # gateway). When assembling the fresh-session reorientation briefing the gateway
+  # daemon does its OWN Hindsight recall — mirroring bin/handoff-briefing.sh — to
+  # fold recent memory into the briefing alongside the durable Telegram history.
+  # The authoritative exports live in the inner pass (~line 893), AFTER the
+  # gateway fork below, so without this hoist the forked daemon never sees the
+  # endpoint and the Hindsight section silently no-ops for every boot (same
+  # start.sh env-fork landmine as SWITCHROOM_SESSION_BRIEFING above). Hoist both
+  # here, before the fork; idempotent with the inner-pass exports (same rendered
+  # template values). Pinned by tests/scaffold.gateway-env-order.test.ts.
+  export HINDSIGHT_API_URL={{{hindsightApiBaseUrlQ}}}
+  export HINDSIGHT_BANK_ID={{{hindsightBankIdQ}}}
+{{/if}}
+
   # Force-fresh suppression signal for the gateway boot briefing. The gateway
   # suppresses the briefing when this boot is a /reset·/new fresh start —
   # re-feeding the just-reset conversation into the fresh session would defeat

--- a/telegram-plugin/gateway/boot-briefing-builder.ts
+++ b/telegram-plugin/gateway/boot-briefing-builder.ts
@@ -244,15 +244,37 @@ export function collectBriefingSurfaces(
   }
 }
 
-/** Codepoint-safe truncation (mirrors resume-inbound-builder's
- *  `truncatePrompt` — a naive .slice can split a surrogate pair). Also
- *  collapses whitespace runs so each message renders as one line. */
+/**
+ * Slice `s` to AT MOST `maxUnits` UTF-16 code units without ever bisecting a
+ * surrogate pair. `max` in this module is a UTF-16 `.length` budget (that is
+ * what Telegram / the char-budget invariant measure), so truncation MUST be
+ * expressed in UTF-16 units — measuring codepoints against a UTF-16 budget
+ * lets astral-plane input (each 😀 is 1 codepoint but 2 UTF-16 units) blow the
+ * bound. If the cut would land between a high and low surrogate we step back
+ * one unit, dropping the lone high surrogate rather than emitting a broken
+ * pair. Guarantees `result.length <= maxUnits`.
+ */
+function sliceUtf16Safe(s: string, maxUnits: number): string {
+  if (maxUnits <= 0) return ''
+  if (s.length <= maxUnits) return s
+  let end = maxUnits
+  // A high surrogate (0xD800–0xDBFF) at the last kept position means its low
+  // half sits at index `end` and would be severed — drop the high surrogate.
+  const code = s.charCodeAt(end - 1)
+  if (code >= 0xd800 && code <= 0xdbff) end -= 1
+  return s.slice(0, end)
+}
+
+/** UTF-16-safe truncation (a naive .slice can split a surrogate pair, and
+ *  measuring codepoints against a UTF-16 `max` can overflow it for astral
+ *  input). Also collapses whitespace runs so each message renders as one
+ *  line. Guarantees `result.length <= max`. */
 function truncateOneLine(s: string, max: number): string {
   const t = s.replace(/\s+/g, ' ').trim()
   if (t.length <= max) return t
-  const points = Array.from(t)
-  if (points.length <= max) return t
-  return points.slice(0, max - 1).join('').trimEnd() + '…'
+  if (max <= 0) return ''
+  // Reserve one UTF-16 unit for the ellipsis ('…' is a single BMP unit).
+  return sliceUtf16Safe(t, max - 1).trimEnd() + '…'
 }
 
 function surfaceLabel(s: { chatId: string; threadId: number | null }): string {
@@ -269,6 +291,35 @@ function renderMessageLine(
   return `- [${age} ago] ${label}: ${truncateOneLine(m.text, perMessageMax)}`
 }
 
+/**
+ * One Hindsight recall result, as folded into the briefing's Hindsight
+ * section. Mirrors the `.results[]` shape `bin/handoff-briefing.sh` reads:
+ * a `text` body and an optional `timestamp` string. `text` may be empty —
+ * rendered as `(no text)` to match the shell's `.text // "(no text)"`.
+ */
+export interface HindsightRecallResult {
+  text: string
+  timestamp?: string | null
+}
+
+/**
+ * Today's daily-memory input for the briefing — the `date` (agent-local
+ * `YYYY-MM-DD`, used only in the section header) and the file `content`.
+ * Absent/empty content renders no section (no empty header).
+ */
+export interface BriefingDailyMemory {
+  date: string
+  content: string
+}
+
+/** Section title for the Hindsight-recall block (mirrors the shell). */
+const HINDSIGHT_SECTION_TITLE = '## Hindsight recall (recent context)'
+
+/** Minimum chars of room a trailing (Hindsight / daily-memory) section
+ *  needs before it is worth appending at all — below this, a truncated
+ *  section would be just a header + a sliver, so skip it whole. */
+const TRAILING_SECTION_MIN_ROOM = 64
+
 export interface RenderBriefingOptions {
   nowMs: number
   /** Restart-reason breadcrumb (`.restart-reason` / SWITCHROOM_PENDING_*),
@@ -276,6 +327,64 @@ export interface RenderBriefingOptions {
   restartReason?: string | null
   charBudget?: number
   perMessageMax?: number
+  /** Hindsight recall results (source 2 of the legacy handoff contract).
+   *  Empty / absent → no Hindsight section. */
+  hindsight?: HindsightRecallResult[] | null
+  /** Today's daily memory (source 3). Absent / empty content → no section. */
+  dailyMemory?: BriefingDailyMemory | null
+}
+
+/** Render the Hindsight recall body (the lines under the section header).
+ *  Mirrors the shell's jq: `- <text> (<timestamp>)`, `(no text)` when the
+ *  text is blank, and no trailing ` (…)` when there is no timestamp.
+ *  Returns '' when there are no results (caller then emits no header). */
+function renderHindsightBody(results: HindsightRecallResult[]): string {
+  const lines: string[] = []
+  for (const r of results) {
+    const text = (r.text ?? '').replace(/\s+/g, ' ').trim() || '(no text)'
+    const ts = r.timestamp && String(r.timestamp).trim() ? ` (${String(r.timestamp).trim()})` : ''
+    lines.push(`- ${text}${ts}`)
+  }
+  return lines.join('\n')
+}
+
+/**
+ * Append a `## title` + body section to `base`, but only within the char
+ * budget. If the whole section fits, append it. If not, append the header
+ * plus as much body as fits (so an over-long daily memory truncates rather
+ * than vanishing) — unless there isn't even `TRAILING_SECTION_MIN_ROOM`
+ * left, in which case the section is skipped whole. Guarantees the result
+ * is always <= budget. A blank body is a no-op (no empty header).
+ */
+function appendSectionWithinBudget(
+  base: string,
+  title: string,
+  body: string,
+  budget: number,
+): string {
+  const trimmedBody = body.trimEnd()
+  if (!trimmedBody) return base
+  const sep = '\n\n'
+  const full = `${base}${sep}${title}${sep}${trimmedBody}`
+  if (full.length <= budget) return full
+  // Room left for the body after the base + separators + title.
+  const room = budget - base.length - sep.length - title.length - sep.length
+  if (room < TRAILING_SECTION_MIN_ROOM) return base
+  const truncated = truncateOneLineOrBlock(trimmedBody, room)
+  return `${base}${sep}${title}${sep}${truncated}`
+}
+
+/** UTF-16-safe hard truncation preserving newlines (unlike `truncateOneLine`,
+ *  which collapses whitespace to one line). Used for block sections (daily
+ *  memory / Hindsight) where line structure matters. Bounds the result in
+ *  UTF-16 units — measuring codepoints against a UTF-16 `max` overflows the
+ *  budget for astral input (each 😀 is 2 UTF-16 units). Guarantees
+ *  `result.length <= max`. */
+function truncateOneLineOrBlock(s: string, max: number): string {
+  if (s.length <= max) return s
+  if (max <= 0) return ''
+  // Reserve one UTF-16 unit for the ellipsis ('…' is a single BMP unit).
+  return sliceUtf16Safe(s, max - 1).trimEnd() + '…'
 }
 
 /**
@@ -351,7 +460,26 @@ export function renderBootBriefing(
     if (assemble(kept, [...secondaries, block]).length > charBudget) break
     secondaries.push(block)
   }
-  return assemble(kept, secondaries)
+
+  // Sources 2 + 3 of the legacy handoff contract, appended after the durable
+  // Telegram slice and within the SAME char budget (Telegram history is the
+  // freshest context, so it keeps priority; Hindsight then daily memory fill
+  // the remaining room, truncating rather than blowing the budget). Order
+  // mirrors bin/handoff-briefing.sh: telegram → hindsight → daily memory.
+  let out = assemble(kept, secondaries)
+  const hindsightBody = opts.hindsight && opts.hindsight.length > 0
+    ? renderHindsightBody(opts.hindsight)
+    : ''
+  out = appendSectionWithinBudget(out, HINDSIGHT_SECTION_TITLE, hindsightBody, charBudget)
+  if (opts.dailyMemory && opts.dailyMemory.content.trim()) {
+    out = appendSectionWithinBudget(
+      out,
+      `## Today's memory (${opts.dailyMemory.date})`,
+      opts.dailyMemory.content,
+      charBudget,
+    )
+  }
+  return out
 }
 
 /**

--- a/telegram-plugin/gateway/boot-briefing-wiring.ts
+++ b/telegram-plugin/gateway/boot-briefing-wiring.ts
@@ -25,7 +25,16 @@ import {
   excludeWindowFromResumeInbound,
   readRestartBreadcrumb,
   renderBootBriefing,
+  type BriefingDailyMemory,
+  type HindsightRecallResult,
 } from './boot-briefing-builder.js'
+
+/** Recall query the legacy handoff-briefing.sh sends verbatim. */
+const HINDSIGHT_RECALL_QUERY = 'what was happening recently in our conversation?'
+/** `max_tokens` the shell script sends (jq `--argjson m 800`). */
+const HINDSIGHT_RECALL_MAX_TOKENS = 800
+/** Recall HTTP budget — the shell's `curl -m 4`. */
+const HINDSIGHT_TIMEOUT_MS = 4000
 
 export interface MaybeQueueBootBriefingOptions {
   env: Record<string, string | undefined>
@@ -40,16 +49,139 @@ export interface MaybeQueueBootBriefingOptions {
   put: (agent: string, msg: InboundMessage) => unknown
   log?: (line: string) => void
   nowMs?: number
+  /** Test seam: injected `fetch` for the Hindsight recall. Defaults to the
+   *  runtime global `fetch`. Never used in production wiring. */
+  fetchImpl?: typeof fetch
+}
+
+/**
+ * Fetch the Hindsight recall slice (source 2 of the legacy handoff
+ * contract). Mirrors `bin/handoff-briefing.sh`'s request EXACTLY:
+ * `POST ${HINDSIGHT_API_URL}/v1/default/banks/${HINDSIGHT_BANK_ID}/memories/recall`
+ * with body `{query, max_tokens: 800}` and a 4s timeout.
+ *
+ * Graceful-skip on ANY failure — missing env, timeout, non-200, malformed
+ * JSON — returns `[]` so the briefing degrades to its other sources rather
+ * than crashing or blocking boot. Never throws.
+ */
+export async function fetchHindsightRecall(
+  env: Record<string, string | undefined>,
+  opts: { fetchImpl?: typeof fetch; timeoutMs?: number; log?: (line: string) => void } = {},
+): Promise<HindsightRecallResult[]> {
+  const base = (env.HINDSIGHT_API_URL ?? '').replace(/\/+$/, '')
+  const bank = env.HINDSIGHT_BANK_ID ?? ''
+  if (!base || !bank) return []
+  const doFetch = opts.fetchImpl ?? (globalThis.fetch as typeof fetch | undefined)
+  if (typeof doFetch !== 'function') return []
+  const log = opts.log
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? HINDSIGHT_TIMEOUT_MS)
+  try {
+    const url = `${base}/v1/default/banks/${encodeURIComponent(bank)}/memories/recall`
+    const resp = await doFetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query: HINDSIGHT_RECALL_QUERY,
+        max_tokens: HINDSIGHT_RECALL_MAX_TOKENS,
+      }),
+      signal: controller.signal,
+    })
+    if (!resp.ok) {
+      // Never log the URL/host — keep the deny reason generic (defence in
+      // depth even though the recall URL carries no token).
+      log?.(`telegram gateway: boot-briefing hindsight recall non-200 (${resp.status}) — skipping section\n`)
+      return []
+    }
+    const body = (await resp.json()) as { results?: Array<{ text?: unknown; timestamp?: unknown }> }
+    const results = Array.isArray(body?.results) ? body.results : []
+    return results.map((r) => ({
+      text: typeof r?.text === 'string' ? r.text : '',
+      timestamp: typeof r?.timestamp === 'string' ? r.timestamp : null,
+    }))
+  } catch {
+    // Timeout (abort), DNS/connection failure, malformed JSON — all graceful.
+    log?.('telegram gateway: boot-briefing hindsight recall unavailable — skipping section\n')
+    return []
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Read today's daily-memory file (source 3 of the legacy handoff contract):
+ * `<workspaceDir>/memory/<YYYY-MM-DD>.md`, with the date derived in the
+ * agent's LOCAL timezone (SWITCHROOM_TIMEZONE → TZ → system-local), exactly
+ * as `bin/workspace-dynamic-hook.sh` reads it.
+ *
+ * NOTE — deliberate divergence from bin/handoff-briefing.sh: that script
+ * reads `${WORKSPACE_DIR:-$AGENT_DIR}/memory/...`, but WORKSPACE_DIR is never
+ * set in the agent env, so it resolves to `<agentDir>/memory/...` — the WRONG
+ * path. Daily notes actually live at `<agentDir>/workspace/memory/...` (see
+ * `resolveAgentWorkspaceDir` and `bin/workspace-dynamic-hook.sh`, the
+ * authoritative reader). We mirror the correct path here (honouring an
+ * explicit WORKSPACE_DIR override if one is ever set), not the shell's bug.
+ * Returns null on a missing/empty file or any read error. Never throws.
+ */
+export function readDailyMemory(
+  agentDir: string,
+  env: Record<string, string | undefined>,
+  nowMs: number,
+  readFile: (path: string) => string = (p) => readFileSync(p, 'utf8'),
+): BriefingDailyMemory | null {
+  const date = agentLocalDate(nowMs, env.SWITCHROOM_TIMEZONE || env.TZ || undefined)
+  if (!date) return null
+  const workspaceDir = env.WORKSPACE_DIR && env.WORKSPACE_DIR.trim()
+    ? env.WORKSPACE_DIR
+    : join(agentDir, 'workspace')
+  const file = join(workspaceDir, 'memory', `${date}.md`)
+  try {
+    const content = readFile(file)
+    if (!content || !content.trim()) return null
+    return { date, content }
+  } catch {
+    return null // ENOENT / unreadable — no section, no crash.
+  }
+}
+
+/** Format `nowMs` as `YYYY-MM-DD` in `tz` (SWITCHROOM_TIMEZONE → TZ →
+ *  system-local). Uses `en-CA` which renders ISO `YYYY-MM-DD`. Returns ''
+ *  if the timezone is invalid (Intl throws) so the caller skips the
+ *  section rather than looking up the wrong day. */
+function agentLocalDate(nowMs: number, tz: string | undefined): string {
+  try {
+    const fmt = new Intl.DateTimeFormat('en-CA', {
+      timeZone: tz,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    })
+    // en-CA yields YYYY-MM-DD; guard against locale/impl drift anyway.
+    const s = fmt.format(new Date(nowMs))
+    return /^\d{4}-\d{2}-\d{2}$/.test(s) ? s : ''
+  } catch {
+    return ''
+  }
 }
 
 /**
  * Build + enqueue the boot briefing when the feature flag and suppression
  * rules allow. Returns the queued inbound (for observability/tests) or
  * null when nothing was queued.
+ *
+ * ASYNC because source 2 (Hindsight recall) is an HTTP fetch. The fetch is
+ * AWAITED to completion-or-timeout BEFORE `put` runs, so the briefing is
+ * only ever enqueued with its Hindsight section already assembled — it can
+ * never be delivered with the section racing in late. The 4s ceiling bounds
+ * the added boot latency, and (like every other path here) any failure
+ * degrades to "no Hindsight section", never a blocked or crashed boot. The
+ * caller must AWAIT this before the resume inbound is spooled / the
+ * boot-replay loop pulls live entries, to preserve briefing-before-resume
+ * delivery order.
  */
-export function maybeQueueBootBriefing(
+export async function maybeQueueBootBriefing(
   opts: MaybeQueueBootBriefingOptions,
-): InboundMessage | null {
+): Promise<InboundMessage | null> {
   const log = opts.log ?? ((l: string) => process.stderr.write(l))
   try {
     const agentDir = opts.stateDir.endsWith('/telegram')
@@ -131,12 +263,37 @@ export function maybeQueueBootBriefing(
       nowMs,
       exclude: excludeWindowFromResumeInbound(opts.resumeMsg),
     })
+    // No active Telegram surface = no delivery target for the synthetic
+    // briefing inbound (it routes to the primary surface's chat). Short-circuit
+    // BEFORE the Hindsight fetch so a zero-history boot never pays the 4s
+    // recall timeout. (Deliberate narrowing vs the file-writing legacy path,
+    // which has no routing target and can emit a Hindsight/daily-only
+    // briefing — documented in the PR.)
+    if (surfaces.length === 0) {
+      // Consume the generation even when empty (parity with the !text path
+      // below, and with main's pre-short-circuit behaviour where zero
+      // surfaces rendered to '' and hit markGeneration()). Had there been
+      // nothing to brief at boot, a later respawn on the same generation must
+      // not suddenly brief mid-session just because fresh messages arrived
+      // after the session came up.
+      markGeneration()
+      log('telegram gateway: boot-briefing empty (no recent surfaces) — nothing queued\n')
+      return null
+    }
     const restartReason = readRestartBreadcrumb({
       restartReasonPath: join(agentDir, '.restart-reason'),
       env: opts.env,
       readFile: (p) => readFileSync(p, 'utf8'),
     })
-    const text = renderBootBriefing(surfaces, { nowMs, restartReason })
+    // Sources 2 + 3 of the legacy handoff contract. The Hindsight fetch is
+    // AWAITED here (4s ceiling) so the section is present before `put` — the
+    // briefing is never enqueued mid-fetch.
+    const hindsight = await fetchHindsightRecall(opts.env, {
+      fetchImpl: opts.fetchImpl,
+      log,
+    })
+    const dailyMemory = readDailyMemory(agentDir, opts.env, nowMs)
+    const text = renderBootBriefing(surfaces, { nowMs, restartReason, hindsight, dailyMemory })
     if (!text) {
       // Consume the generation even when empty: had there been nothing to
       // brief at boot, a later respawn must not suddenly brief mid-session
@@ -157,7 +314,8 @@ export function maybeQueueBootBriefing(
     log(
       `telegram gateway: boot-briefing queued chat=${primary.chatId}` +
         `${primary.threadId != null ? ` thread=${primary.threadId}` : ''} ` +
-        `surfaces=${surfaces.length} chars=${text.length} ` +
+        `surfaces=${surfaces.length} hindsight=${hindsight.length} ` +
+        `daily=${dailyMemory != null ? 'yes' : 'no'} chars=${text.length} ` +
         `cap=${GATEWAY_BOOT_BRIEFING_CAPABILITY}\n`,
     )
     return msg

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -10181,7 +10181,7 @@ if (isGatewayMain && !STATIC && OBLIGATION_LEDGER_ENABLED) {
 // --continue suppression, resume-window dedup, budget) lives in
 // boot-briefing-wiring.ts / boot-briefing-builder.ts; never throws.
 if (isGatewayMain && HISTORY_ENABLED) {
-  maybeQueueBootBriefing({
+  await maybeQueueBootBriefing({
     env: process.env,
     stateDir: STATE_DIR,
     resumeMsg: bootResumeInbound?.msg ?? null,

--- a/telegram-plugin/tests/boot-briefing-builder.test.ts
+++ b/telegram-plugin/tests/boot-briefing-builder.test.ts
@@ -42,7 +42,12 @@ import {
   renderBootBriefing,
   type BriefingDb,
 } from '../gateway/boot-briefing-builder.js'
-import { maybeQueueBootBriefing } from '../gateway/boot-briefing-wiring.js'
+import {
+  maybeQueueBootBriefing,
+  fetchHindsightRecall,
+  readDailyMemory,
+} from '../gateway/boot-briefing-wiring.js'
+import type { BriefingSurface } from '../gateway/boot-briefing-builder.js'
 import { spoolId } from '../gateway/inbound-spool.js'
 import type { InboundMessage } from '../gateway/ipc-protocol.js'
 
@@ -352,11 +357,11 @@ describe('maybeQueueBootBriefing — end-to-end wiring', () => {
     }
   }
 
-  it('queues a briefing built from real history rows when the flag is gateway', () => {
+  it('queues a briefing built from real history rows when the flag is gateway', async () => {
     seedUser('321', null, 30 * 60, 'please review the deploy plan')
     seedBot('321', null, 25 * 60, 'on it — reviewing now')
     const puts: Array<{ agent: string; msg: InboundMessage }> = []
-    const queued = maybeQueueBootBriefing({
+    const queued = await maybeQueueBootBriefing({
       env: envFor('gateway'),
       stateDir: join(stateDir, 'telegram'),
       resumeMsg: null,
@@ -374,10 +379,10 @@ describe('maybeQueueBootBriefing — end-to-end wiring', () => {
     expect(puts[0]!.msg.text.length).toBeLessThanOrEqual(BRIEFING_CHAR_BUDGET)
   })
 
-  it('queues NOTHING when the flag is legacy (default) — legacy behaviour untouched', () => {
+  it('queues NOTHING when the flag is legacy (default) — legacy behaviour untouched', async () => {
     seedUser('321', null, 30 * 60, 'recent message')
     const puts: unknown[] = []
-    const queued = maybeQueueBootBriefing({
+    const queued = await maybeQueueBootBriefing({
       env: envFor('legacy'),
       stateDir: join(stateDir, 'telegram'),
       resumeMsg: null,
@@ -389,9 +394,9 @@ describe('maybeQueueBootBriefing — end-to-end wiring', () => {
     expect(puts.length).toBe(0)
   })
 
-  it('queues nothing when history is empty', () => {
+  it('queues nothing when history is empty', async () => {
     const puts: unknown[] = []
-    const queued = maybeQueueBootBriefing({
+    const queued = await maybeQueueBootBriefing({
       env: envFor('gateway'),
       stateDir: join(stateDir, 'telegram'),
       resumeMsg: null,
@@ -403,10 +408,10 @@ describe('maybeQueueBootBriefing — end-to-end wiring', () => {
     expect(puts.length).toBe(0)
   })
 
-  it('suppresses on a force-fresh (/reset) marker', () => {
+  it('suppresses on a force-fresh (/reset) marker', async () => {
     seedUser('321', null, 30 * 60, 'recent message')
     writeFileSync(join(stateDir, '.force-fresh-session'), '')
-    const queued = maybeQueueBootBriefing({
+    const queued = await maybeQueueBootBriefing({
       env: envFor('gateway'),
       stateDir: join(stateDir, 'telegram'),
       resumeMsg: null,
@@ -419,14 +424,14 @@ describe('maybeQueueBootBriefing — end-to-end wiring', () => {
     expect(queued).toBeNull()
   })
 
-  it('suppresses on SWITCHROOM_FORCE_FRESH=1 even when NO marker file exists (env-keyed, race-proof)', () => {
+  it('suppresses on SWITCHROOM_FORCE_FRESH=1 even when NO marker file exists (env-keyed, race-proof)', async () => {
     // The M1 fix: the decision keys on the env snapshot start.sh takes
     // BEFORE forking the gateway, not on fs state at gateway check time. So
     // the /reset boot is suppressed even after the inner pass has already
     // `rm`ed the marker — the exact race the old existsSync check lost.
     seedUser('321', null, 30 * 60, 'recent message')
     expect(existsSync(join(stateDir, '.force-fresh-session'))).toBe(false)
-    const queued = maybeQueueBootBriefing({
+    const queued = await maybeQueueBootBriefing({
       env: { ...envFor('gateway'), SWITCHROOM_FORCE_FRESH: '1' },
       stateDir: join(stateDir, 'telegram'),
       resumeMsg: null,
@@ -439,12 +444,12 @@ describe('maybeQueueBootBriefing — end-to-end wiring', () => {
     expect(queued).toBeNull()
   })
 
-  it('suppresses on SWITCHROOM_FORCE_FRESH=1 regardless of whether the marker is present', () => {
+  it('suppresses on SWITCHROOM_FORCE_FRESH=1 regardless of whether the marker is present', async () => {
     // Outcome does not depend on fs state at check time: with the env set,
     // the briefing is suppressed whether or not the marker file is on disk.
     seedUser('321', null, 30 * 60, 'recent message')
     writeFileSync(join(stateDir, '.force-fresh-session'), '')
-    const queued = maybeQueueBootBriefing({
+    const queued = await maybeQueueBootBriefing({
       env: { ...envFor('gateway'), SWITCHROOM_FORCE_FRESH: '1' },
       stateDir: join(stateDir, 'telegram'),
       resumeMsg: null,
@@ -457,9 +462,11 @@ describe('maybeQueueBootBriefing — end-to-end wiring', () => {
     expect(queued).toBeNull()
   })
 
-  it('never throws even when put itself throws', () => {
+  it('never throws even when put itself throws', async () => {
     seedUser('321', null, 30 * 60, 'recent message')
-    expect(() =>
+    // The internal try/catch swallows put's throw — the promise RESOLVES to
+    // null rather than rejecting, so boot is never blocked or crashed.
+    await expect(
       maybeQueueBootBriefing({
         env: envFor('gateway'),
         stateDir: join(stateDir, 'telegram'),
@@ -470,10 +477,390 @@ describe('maybeQueueBootBriefing — end-to-end wiring', () => {
         log: () => {},
         nowMs: NOW_MS,
       }),
-    ).not.toThrow()
+    ).resolves.toBeNull()
+  })
+})
+
+// A minimal primary surface for the pure render tests (no DB needed).
+function primarySurface(text = 'the primary ask'): BriefingSurface {
+  return {
+    chatId: '321',
+    threadId: null,
+    lastTs: NOW_SEC - 60,
+    messages: [{ role: 'user', user: 'ken', ts: NOW_SEC - 60, text }],
+  }
+}
+
+describe('renderBootBriefing — Hindsight + daily-memory sections (source 2 + 3 parity)', () => {
+  it('renders a Hindsight section with `- text (timestamp)` lines mirroring the shell jq', () => {
+    const out = renderBootBriefing([primarySurface()], {
+      nowMs: NOW_MS,
+      hindsight: [
+        { text: 'we agreed to ship the gateway briefing', timestamp: '2026-08-01T10:00:00Z' },
+        { text: 'no timestamp here', timestamp: null },
+      ],
+    })
+    expect(out).toContain('## Hindsight recall (recent context)')
+    expect(out).toContain('- we agreed to ship the gateway briefing (2026-08-01T10:00:00Z)')
+    // No dangling ` (…)` when a result has no timestamp.
+    expect(out).toContain('- no timestamp here')
+    expect(out).not.toContain('no timestamp here (')
   })
 
-  it('threads a real resumeMsg end-to-end: elides the interrupted-turn window from the queued briefing on that surface', () => {
+  it('renders `(no text)` for a blank Hindsight result (shell `.text // "(no text)"`)', () => {
+    const out = renderBootBriefing([primarySurface()], {
+      nowMs: NOW_MS,
+      hindsight: [{ text: '   ', timestamp: null }],
+    })
+    expect(out).toContain('- (no text)')
+  })
+
+  it('renders a daily-memory section under a dated header', () => {
+    const out = renderBootBriefing([primarySurface()], {
+      nowMs: NOW_MS,
+      dailyMemory: { date: '2026-08-02', content: 'Shipped X. Blocked on Y.' },
+    })
+    expect(out).toContain("## Today's memory (2026-08-02)")
+    expect(out).toContain('Shipped X. Blocked on Y.')
+  })
+
+  it('renders NO Hindsight/daily header when both inputs are absent or empty (no empty headers)', () => {
+    const noneOut = renderBootBriefing([primarySurface()], { nowMs: NOW_MS })
+    expect(noneOut).not.toContain('## Hindsight recall')
+    expect(noneOut).not.toContain("## Today's memory")
+
+    const emptyOut = renderBootBriefing([primarySurface()], {
+      nowMs: NOW_MS,
+      hindsight: [],
+      dailyMemory: { date: '2026-08-02', content: '   \n  ' },
+    })
+    expect(emptyOut).not.toContain('## Hindsight recall')
+    expect(emptyOut).not.toContain("## Today's memory")
+  })
+
+  it('orders sections telegram → hindsight → daily (mirrors bin/handoff-briefing.sh)', () => {
+    const out = renderBootBriefing([primarySurface()], {
+      nowMs: NOW_MS,
+      hindsight: [{ text: 'recall line', timestamp: null }],
+      dailyMemory: { date: '2026-08-02', content: 'daily line' },
+    })
+    const iPrimary = out.indexOf('the primary ask')
+    const iHind = out.indexOf('## Hindsight recall')
+    const iDaily = out.indexOf("## Today's memory")
+    expect(iPrimary).toBeGreaterThan(-1)
+    expect(iHind).toBeGreaterThan(iPrimary)
+    expect(iDaily).toBeGreaterThan(iHind)
+  })
+
+  it('respects the char budget: an oversized daily memory truncates, never blows the budget', () => {
+    const huge = 'x'.repeat(50_000)
+    const out = renderBootBriefing([primarySurface()], {
+      nowMs: NOW_MS,
+      hindsight: [{ text: 'a recall', timestamp: null }],
+      dailyMemory: { date: '2026-08-02', content: huge },
+      charBudget: BRIEFING_CHAR_BUDGET,
+    })
+    expect(out.length).toBeLessThanOrEqual(BRIEFING_CHAR_BUDGET)
+    // Telegram history keeps priority (present) and the daily section is
+    // truncated with an ellipsis rather than dropped or overflowing.
+    expect(out).toContain('the primary ask')
+    expect(out).toContain("## Today's memory (2026-08-02)")
+    expect(out).toContain('…')
+  })
+
+  it('respects the char budget for ASTRAL / non-BMP input and never cuts a surrogate pair', () => {
+    // Regression: the char budget is a UTF-16 `.length` bound, but the
+    // truncators used to measure CODEPOINTS against it — so an astral-plane
+    // daily memory (each 😀 is 1 codepoint but 2 UTF-16 units) overflowed the
+    // budget nearly 2x. ASCII-only budget tests can't see this.
+    const astral = '😀'.repeat(50_000) // 50k codepoints = 100k UTF-16 units
+    const out = renderBootBriefing([primarySurface()], {
+      nowMs: NOW_MS,
+      hindsight: [{ text: 'a short recall', timestamp: null }],
+      dailyMemory: { date: '2026-08-02', content: astral },
+      charBudget: BRIEFING_CHAR_BUDGET,
+    })
+    // The module's own asserted invariant: final UTF-16 length within budget.
+    expect(out.length).toBeLessThanOrEqual(BRIEFING_CHAR_BUDGET)
+    // And the cut must never bisect a surrogate pair (no lone/broken half).
+    const hasLoneSurrogate = (s: string): boolean => {
+      for (let i = 0; i < s.length; i++) {
+        const c = s.charCodeAt(i)
+        if (c >= 0xd800 && c <= 0xdbff) {
+          const next = i + 1 < s.length ? s.charCodeAt(i + 1) : 0
+          if (!(next >= 0xdc00 && next <= 0xdfff)) return true
+          i++ // valid pair — skip the low half
+        } else if (c >= 0xdc00 && c <= 0xdfff) {
+          return true // lone low surrogate
+        }
+      }
+      return false
+    }
+    expect(hasLoneSurrogate(out)).toBe(false)
+    // The daily section is still present (truncated, not dropped).
+    expect(out).toContain("## Today's memory (2026-08-02)")
+  })
+
+  it('skips a trailing section entirely when there is not even room for a truncated body', () => {
+    // Budget large enough for the telegram slice + a small header, but the
+    // daily body cannot fit — the section is skipped whole (no dangling
+    // header), and the result still respects the budget.
+    const base = renderBootBriefing([primarySurface()], { nowMs: NOW_MS })
+    const tightBudget = base.length + 20 // room for neither a real hindsight nor daily body
+    const out = renderBootBriefing([primarySurface()], {
+      nowMs: NOW_MS,
+      dailyMemory: { date: '2026-08-02', content: 'x'.repeat(5000) },
+      charBudget: tightBudget,
+    })
+    expect(out.length).toBeLessThanOrEqual(tightBudget)
+    expect(out).not.toContain("## Today's memory")
+  })
+})
+
+describe('fetchHindsightRecall — graceful-skip paths (source 2 wiring)', () => {
+  const okBody = {
+    results: [
+      { text: 'first memory', timestamp: '2026-08-01T00:00:00Z' },
+      { text: 'second memory' },
+    ],
+  }
+
+  function jsonResponse(status: number, body: unknown): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const liveEnv = {
+    HINDSIGHT_API_URL: 'http://hindsight.internal:8080/',
+    HINDSIGHT_BANK_ID: 'agent-bank',
+  }
+
+  it('mirrors the shell request contract (POST recall URL + {query, max_tokens})', async () => {
+    let seenUrl = ''
+    let seenInit: RequestInit | undefined
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+      seenUrl = String(url)
+      seenInit = init
+      return jsonResponse(200, okBody)
+    }) as unknown as typeof fetch
+    const results = await fetchHindsightRecall(liveEnv, { fetchImpl })
+    // Trailing slash trimmed; the exact recall path the bash script hits.
+    expect(seenUrl).toBe('http://hindsight.internal:8080/v1/default/banks/agent-bank/memories/recall')
+    expect(seenInit?.method).toBe('POST')
+    const parsed = JSON.parse(String(seenInit?.body))
+    expect(parsed.query).toBe('what was happening recently in our conversation?')
+    expect(parsed.max_tokens).toBe(800)
+    expect(results).toEqual([
+      { text: 'first memory', timestamp: '2026-08-01T00:00:00Z' },
+      { text: 'second memory', timestamp: null },
+    ])
+  })
+
+  it('returns [] when the env is missing (no HINDSIGHT_API_URL / BANK_ID) — no fetch at all', async () => {
+    let called = false
+    const fetchImpl = (async () => {
+      called = true
+      return jsonResponse(200, okBody)
+    }) as unknown as typeof fetch
+    expect(await fetchHindsightRecall({}, { fetchImpl })).toEqual([])
+    expect(await fetchHindsightRecall({ HINDSIGHT_API_URL: 'http://x' }, { fetchImpl })).toEqual([])
+    expect(called).toBe(false)
+  })
+
+  it('returns [] on a non-200 response (graceful skip, never throws)', async () => {
+    const fetchImpl = (async () => jsonResponse(503, { error: 'down' })) as unknown as typeof fetch
+    expect(await fetchHindsightRecall(liveEnv, { fetchImpl })).toEqual([])
+  })
+
+  it('returns [] on a fetch rejection / timeout (AbortError), never throws', async () => {
+    const fetchImpl = (async () => {
+      throw new DOMException('aborted', 'AbortError')
+    }) as unknown as typeof fetch
+    expect(await fetchHindsightRecall(liveEnv, { fetchImpl })).toEqual([])
+  })
+
+  it('honours the abort timeout (a slow endpoint yields [] within the budget)', async () => {
+    const fetchImpl = (async (_url: unknown, init?: RequestInit) => {
+      // Never resolve until aborted — mirrors a hung Hindsight.
+      return await new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () =>
+          reject(new DOMException('aborted', 'AbortError')),
+        )
+      })
+    }) as unknown as typeof fetch
+    const start = Date.now()
+    const results = await fetchHindsightRecall(liveEnv, { fetchImpl, timeoutMs: 50 })
+    expect(results).toEqual([])
+    expect(Date.now() - start).toBeLessThan(2000)
+  })
+
+  it('returns [] on malformed JSON (results absent / not an array)', async () => {
+    const fetchImpl = (async () => jsonResponse(200, { notResults: 1 })) as unknown as typeof fetch
+    expect(await fetchHindsightRecall(liveEnv, { fetchImpl })).toEqual([])
+  })
+})
+
+describe('readDailyMemory — graceful-skip paths (source 3 wiring)', () => {
+  // NOW_MS = 1_754_000_000_000 → 2025-07-31/08-01 depending on tz. Compute the
+  // expected date the same way the impl does so the assertion can't drift.
+  function expectedDate(tz: string): string {
+    return new Intl.DateTimeFormat('en-CA', {
+      timeZone: tz,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(new Date(NOW_MS))
+  }
+
+  it('reads <agentDir>/workspace/memory/<today>.md (correct path, not the shell bug path)', () => {
+    const date = expectedDate('UTC')
+    let seenPath = ''
+    const out = readDailyMemory(
+      '/state/agent',
+      { SWITCHROOM_TIMEZONE: 'UTC' },
+      NOW_MS,
+      (p) => {
+        seenPath = p
+        return '# today\nshipped the parity PR'
+      },
+    )
+    expect(seenPath).toBe(`/state/agent/workspace/memory/${date}.md`)
+    expect(out).toEqual({ date, content: '# today\nshipped the parity PR' })
+  })
+
+  it('honours an explicit WORKSPACE_DIR override when set', () => {
+    const date = expectedDate('UTC')
+    let seenPath = ''
+    readDailyMemory(
+      '/state/agent',
+      { SWITCHROOM_TIMEZONE: 'UTC', WORKSPACE_DIR: '/custom/ws' },
+      NOW_MS,
+      (p) => {
+        seenPath = p
+        return 'content'
+      },
+    )
+    expect(seenPath).toBe(`/custom/ws/memory/${date}.md`)
+  })
+
+  it('derives "today" in the agent LOCAL timezone (not UTC)', () => {
+    // A far-eastern zone can be a day ahead of UTC at this instant.
+    const dateSydney = expectedDate('Australia/Sydney')
+    let seenPath = ''
+    readDailyMemory('/a', { SWITCHROOM_TIMEZONE: 'Australia/Sydney' }, NOW_MS, (p) => {
+      seenPath = p
+      return 'x'
+    })
+    expect(seenPath).toBe(`/a/workspace/memory/${dateSydney}.md`)
+  })
+
+  it('returns null on ENOENT (missing daily file), never throws', () => {
+    const out = readDailyMemory('/a', { SWITCHROOM_TIMEZONE: 'UTC' }, NOW_MS, () => {
+      const e = new Error('ENOENT') as NodeJS.ErrnoException
+      e.code = 'ENOENT'
+      throw e
+    })
+    expect(out).toBeNull()
+  })
+
+  it('returns null on an empty / whitespace-only file (no empty section)', () => {
+    expect(
+      readDailyMemory('/a', { SWITCHROOM_TIMEZONE: 'UTC' }, NOW_MS, () => '   \n\t '),
+    ).toBeNull()
+  })
+})
+
+describe('maybeQueueBootBriefing — end-to-end with Hindsight + daily memory', () => {
+  it('folds a live Hindsight recall into the queued briefing (awaited before put)', async () => {
+    seedUser('321', null, 30 * 60, 'primary conversation ask')
+    const puts: Array<{ agent: string; msg: InboundMessage }> = []
+    const fetchImpl = (async () =>
+      new Response(
+        JSON.stringify({ results: [{ text: 'we were mid-deploy', timestamp: '2026-08-01T00:00:00Z' }] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      )) as unknown as typeof fetch
+    const queued = await maybeQueueBootBriefing({
+      env: {
+        SWITCHROOM_SESSION_BRIEFING: 'gateway',
+        SWITCHROOM_RESUME_MODE: 'handoff',
+        SWITCHROOM_AGENT_NAME: 'testagent',
+        HINDSIGHT_API_URL: 'http://hindsight.internal',
+        HINDSIGHT_BANK_ID: 'agent-bank',
+      },
+      stateDir: join(stateDir, 'telegram'),
+      resumeMsg: null,
+      put: (agent, msg) => puts.push({ agent, msg }),
+      log: () => {},
+      nowMs: NOW_MS,
+      fetchImpl,
+    })
+    expect(queued).not.toBeNull()
+    expect(puts.length).toBe(1)
+    // The section is PRESENT in the enqueued text — proving the fetch was
+    // awaited to completion before put, not raced in late.
+    expect(puts[0]!.msg.text).toContain('## Hindsight recall (recent context)')
+    expect(puts[0]!.msg.text).toContain('- we were mid-deploy (2026-08-01T00:00:00Z)')
+    expect(puts[0]!.msg.text).toContain('primary conversation ask')
+    expect(puts[0]!.msg.text.length).toBeLessThanOrEqual(BRIEFING_CHAR_BUDGET)
+  })
+
+  it('still queues (telegram-only) when Hindsight fails and no daily file exists', async () => {
+    seedUser('321', null, 30 * 60, 'primary conversation ask')
+    const puts: Array<{ agent: string; msg: InboundMessage }> = []
+    const fetchImpl = (async () => {
+      throw new Error('connection refused')
+    }) as unknown as typeof fetch
+    const queued = await maybeQueueBootBriefing({
+      env: {
+        SWITCHROOM_SESSION_BRIEFING: 'gateway',
+        SWITCHROOM_RESUME_MODE: 'handoff',
+        SWITCHROOM_AGENT_NAME: 'testagent',
+        HINDSIGHT_API_URL: 'http://hindsight.internal',
+        HINDSIGHT_BANK_ID: 'agent-bank',
+      },
+      stateDir: join(stateDir, 'telegram'),
+      resumeMsg: null,
+      put: (agent, msg) => puts.push({ agent, msg }),
+      log: () => {},
+      nowMs: NOW_MS,
+      fetchImpl,
+    })
+    expect(queued).not.toBeNull()
+    expect(puts[0]!.msg.text).toContain('primary conversation ask')
+    expect(puts[0]!.msg.text).not.toContain('## Hindsight recall')
+    expect(puts[0]!.msg.text).not.toContain("## Today's memory")
+  })
+
+  it('does not fetch Hindsight when there is no active surface (no delivery target)', async () => {
+    let called = false
+    const fetchImpl = (async () => {
+      called = true
+      return new Response('{}', { status: 200 })
+    }) as unknown as typeof fetch
+    const queued = await maybeQueueBootBriefing({
+      env: {
+        SWITCHROOM_SESSION_BRIEFING: 'gateway',
+        SWITCHROOM_RESUME_MODE: 'handoff',
+        SWITCHROOM_AGENT_NAME: 'testagent',
+        HINDSIGHT_API_URL: 'http://hindsight.internal',
+        HINDSIGHT_BANK_ID: 'agent-bank',
+      },
+      stateDir: join(stateDir, 'telegram'),
+      resumeMsg: null,
+      put: () => {
+        throw new Error('must not be called')
+      },
+      log: () => {},
+      nowMs: NOW_MS,
+      fetchImpl,
+    })
+    expect(queued).toBeNull()
+    expect(called).toBe(false)
+  })
+
+  it('threads a real resumeMsg end-to-end: elides the interrupted-turn window from the queued briefing on that surface', async () => {
     // #4247: every other wiring test passes resumeMsg: null, so the
     // resume-dedup path (interrupted-turn window elided so the boot-resume
     // synthetic and the briefing never double-inject the same messages) was
@@ -504,8 +891,12 @@ describe('maybeQueueBootBriefing — end-to-end wiring', () => {
       },
     } as InboundMessage
     const puts: Array<{ agent: string; msg: InboundMessage }> = []
-    const queued = maybeQueueBootBriefing({
-      env: envFor('gateway'),
+    const queued = await maybeQueueBootBriefing({
+      env: {
+        SWITCHROOM_SESSION_BRIEFING: 'gateway',
+        SWITCHROOM_RESUME_MODE: 'handoff',
+        SWITCHROOM_AGENT_NAME: 'testagent',
+      },
       stateDir: join(stateDir, 'telegram'),
       resumeMsg,
       put: (agent, msg) => puts.push({ agent, msg }),
@@ -547,12 +938,12 @@ describe('maybeQueueBootBriefing — session-generation guard (#4242)', () => {
       nowMs: NOW_MS,
     })
 
-  it('re-mints ONCE per boot generation: a supervisor respawn (same boot id) queues nothing', () => {
+  it('re-mints ONCE per boot generation: a supervisor respawn (same boot id) queues nothing', async () => {
     seedUser('321', null, 30 * 60, 'the deploy is half-done')
     const puts: Array<{ agent: string; msg: InboundMessage }> = []
 
     // Boot-1: first gateway process of this generation briefs.
-    const first = call(envGen('gen-1'), puts)
+    const first = await call(envGen('gen-1'), puts)
     expect(first).not.toBeNull()
     expect(puts.length).toBe(1)
     // Generation persisted for the respawn check.
@@ -561,43 +952,43 @@ describe('maybeQueueBootBriefing — session-generation guard (#4242)', () => {
     // Respawn: same shell → same SWITCHROOM_GATEWAY_BOOT_ID. The gateway
     // module re-evaluates, but the inner Claude session is still live from
     // boot-1 — re-injecting a "you just rebooted" briefing would be wrong.
-    const respawn = call(envGen('gen-1'), puts)
+    const respawn = await call(envGen('gen-1'), puts)
     expect(respawn).toBeNull()
     expect(puts.length).toBe(1) // no second put
   })
 
-  it('a GENUINE new boot (fresh boot id) briefs again', () => {
+  it('a GENUINE new boot (fresh boot id) briefs again', async () => {
     seedUser('321', null, 30 * 60, 'still pending your call')
     const puts: Array<{ agent: string; msg: InboundMessage }> = []
 
-    expect(call(envGen('gen-1'), puts)).not.toBeNull()
+    expect(await call(envGen('gen-1'), puts)).not.toBeNull()
     expect(puts.length).toBe(1)
     // Next real container boot re-derives a different id → not a respawn.
-    expect(call(envGen('gen-2'), puts)).not.toBeNull()
+    expect(await call(envGen('gen-2'), puts)).not.toBeNull()
     expect(puts.length).toBe(2)
   })
 
-  it('consumes the generation even when the first boot had nothing to brief (no mid-session brief on respawn)', () => {
+  it('consumes the generation even when the first boot had nothing to brief (no mid-session brief on respawn)', async () => {
     const puts: Array<{ agent: string; msg: InboundMessage }> = []
     // Boot-1: empty history → nothing queued, but the generation is consumed.
-    expect(call(envGen('gen-1'), puts)).toBeNull()
+    expect(await call(envGen('gen-1'), puts)).toBeNull()
     expect(puts.length).toBe(0)
     expect(existsSync(join(stateDir, '.boot-briefing-generation'))).toBe(true)
 
     // Messages arrive AFTER the session is live, then the gateway respawns.
     seedUser('321', null, 5 * 60, 'a message that landed mid-session')
-    const respawn = call(envGen('gen-1'), puts)
+    const respawn = await call(envGen('gen-1'), puts)
     expect(respawn).toBeNull()
     expect(puts.length).toBe(0) // must NOT brief into the live session
   })
 
-  it('guard is inert when SWITCHROOM_GATEWAY_BOOT_ID is absent (non-docker / pre-upgrade start.sh keeps legacy behaviour)', () => {
+  it('guard is inert when SWITCHROOM_GATEWAY_BOOT_ID is absent (non-docker / pre-upgrade start.sh keeps legacy behaviour)', async () => {
     seedUser('321', null, 30 * 60, 'legacy path message')
     const puts: Array<{ agent: string; msg: InboundMessage }> = []
     // With no boot id, every gateway start briefs as before — no marker
     // written, no suppression.
-    expect(call(envGen(undefined), puts)).not.toBeNull()
-    expect(call(envGen(undefined), puts)).not.toBeNull()
+    expect(await call(envGen(undefined), puts)).not.toBeNull()
+    expect(await call(envGen(undefined), puts)).not.toBeNull()
     expect(puts.length).toBe(2)
     expect(existsSync(join(stateDir, '.boot-briefing-generation'))).toBe(false)
   })

--- a/tests/scaffold.gateway-env-order.test.ts
+++ b/tests/scaffold.gateway-env-order.test.ts
@@ -166,3 +166,57 @@ describe("start.sh: gateway-consumed env exported before the gateway fork", () =
     expect(second).toBeGreaterThan(forkIdx);
   });
 });
+
+describe("start.sh: Hindsight endpoint hoisted before the gateway fork (#4243 boot-briefing parity)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-gw-hindsight-order-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function renderStartShWithHindsight(): string {
+    const config = {
+      extends: "default",
+      topic_name: "Test Topic",
+      schedule: [],
+    } as AgentConfig;
+    const sw = makeSwitchroomConfig("test-agent", config);
+    // Turn on the Hindsight backend so the scaffold renders the endpoint exports.
+    sw.memory = { backend: "hindsight" };
+    const result = scaffoldAgent("test-agent", config, tmpDir, telegramConfig, sw);
+    return readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+  }
+
+  it("hoists HINDSIGHT_API_URL and HINDSIGHT_BANK_ID AHEAD of the gateway fork so the daemon can recall for the boot briefing", () => {
+    const startSh = renderStartShWithHindsight();
+    const forkIdx = startSh.indexOf(GATEWAY_FORK);
+    expect(forkIdx).toBeGreaterThan(-1);
+
+    const apiIdx = startSh.indexOf("export HINDSIGHT_API_URL=");
+    const bankIdx = startSh.indexOf("export HINDSIGHT_BANK_ID=");
+    expect(apiIdx).toBeGreaterThan(-1);
+    expect(bankIdx).toBeGreaterThan(-1);
+    // The FIRST occurrence (outer-pass hoist) must precede the fork, or the
+    // gateway daemon's Hindsight recall in the boot briefing silently no-ops
+    // (the authoritative exports live in the inner pass, after the fork).
+    expect(apiIdx).toBeLessThan(forkIdx);
+    expect(bankIdx).toBeLessThan(forkIdx);
+  });
+
+  it("still re-exports the endpoint in the inner pass (after the fork) for the claude-side plugin", () => {
+    const startSh = renderStartShWithHindsight();
+    const forkIdx = startSh.indexOf(GATEWAY_FORK);
+
+    const firstApi = startSh.indexOf("export HINDSIGHT_API_URL=");
+    const secondApi = startSh.indexOf("export HINDSIGHT_API_URL=", firstApi + 1);
+    // Hoisted copy before the fork (gateway boot briefing), authoritative copy
+    // after it (the hindsight-memory plugin's hooks read it in the inner pass).
+    expect(firstApi).toBeGreaterThan(-1);
+    expect(firstApi).toBeLessThan(forkIdx);
+    expect(secondApi).toBeGreaterThan(forkIdx);
+  });
+});


### PR DESCRIPTION
## Summary

Brings the gateway boot briefing (`session_continuity.briefing: gateway`) to feature-parity with the legacy `bin/handoff-briefing.sh` by adding the two sources it was still missing — **Hindsight recall** and **today's daily-memory file** — alongside the durable-Telegram-history slice it already reproduced (#4214). Closes #4243.

## Why

The gateway-transport briefing only rendered Telegram history; the legacy shell briefing folded in Hindsight recall + the daily-memory note. Until parity lands, flipping the default away from `legacy` would silently drop reorientation context. This PR closes that gap. **The default stays `legacy` — no behaviour change until an operator opts in.**

Job spec: `reference/jobs/` session-continuity (fresh-session reorientation across restarts).

## What changed

- **`boot-briefing-builder.ts` (pure)** — two new optional `RenderBriefingOptions` inputs (`hindsight`, `dailyMemory`), rendered after the Telegram slice within the **same** `BRIEFING_CHAR_BUDGET`. Sections truncate rather than overflow the budget, are skipped whole when there's not even room for a header, and render nothing when empty (no dangling headers). Section order mirrors the shell: telegram → hindsight → daily.
- **`boot-briefing-wiring.ts` (impure)** — `fetchHindsightRecall` (native `fetch`, 4s `AbortController` timeout, mirrors the shell `POST .../memories/recall` with `{query, max_tokens: 800}`, graceful `[]` on any error/timeout/non-200/missing-env, never throws) and `readDailyMemory` (TZ-aware `<workspace>/memory/<date>.md`, `null` on ENOENT/empty). `maybeQueueBootBriefing` is now **async** and **awaits** the fetch before `put`, so the briefing is never enqueued mid-fetch. It short-circuits **before** the fetch when there is no active surface, so a zero-history boot never pays the 4s timeout.
- **`gateway.ts`** — `await` the now-async call. Net-neutral (only the keyword); it sits at module top-level so the fetch completes before the resume spool / boot-replay loop.
- **`start.sh.hbs`** — hoist `HINDSIGHT_API_URL` / `HINDSIGHT_BANK_ID` into the OUTER pass, before the gateway fork. The authoritative exports live in the inner pass (after the fork), so without the hoist the forked daemon never sees the endpoint and the Hindsight section would silently always no-op.

## Env wiring

The gateway process did **not** have `HINDSIGHT_API_URL` / `HINDSIGHT_BANK_ID` at boot (inner-pass only). Both are now hoisted before the fork, guarded by the same `{{#if hindsightEnabled}}` as the inner exports, and pinned by a new scaffold env-order test. `SWITCHROOM_TIMEZONE`/`TZ` were already in the compose env (no wiring needed). `WORKSPACE_DIR` is never set anywhere, so the daily-memory path is derived as `<agentDir>/workspace` in TS (honouring an env override if ever present) rather than adding a shell export.

## Deliberate divergence from the shell (reported per dev protocol)

`bin/handoff-briefing.sh` reads the daily note from `${WORKSPACE_DIR:-$AGENT_DIR}/memory/<date>.md`, but `WORKSPACE_DIR` is never set, so it resolves to `<agentDir>/memory/...` — the **wrong** directory. The authoritative reader (`bin/workspace-dynamic-hook.sh`) uses `<agentDir>/workspace/memory`. `readDailyMemory` mirrors the **correct** path, documented in a JSDoc note. Filed as a follow-up to fix the shell script.

## Test plan

- `bun test telegram-plugin/tests/boot-briefing-builder.test.ts` — 45 pass. New coverage: builder sections (render `- text (timestamp)`, `(no text)`, ordering, char-budget respected on oversized daily memory, skip-when-no-room, no empty headers); `fetchHindsightRecall` graceful-skip (request-contract, missing-env-no-fetch, non-200, abort, timeout-within-budget, malformed JSON); `readDailyMemory` (correct path, WORKSPACE_DIR override, local-tz, ENOENT→null, empty→null); end-to-end `maybeQueueBootBriefing` (folds live recall / degrades when Hindsight fails / no-fetch when no surface).
- `vitest run tests/scaffold.gateway-env-order.test.ts` — 7 pass, incl. the new `HINDSIGHT_*`-before-fork guard.
- `npm run lint` — green (tsc + all guards; gateway-line-ratchet clean, bot-api-wrapping clean, attribution trailers OK).
- `node telegram-plugin/scripts/build.mjs` — bundles clean (validates the top-level `await`).

## Risk

Low. Default `legacy` path returns before any fetch, so no boot-latency cost by default. On the opt-in `gateway` path, every new source degrades to "omit the section" on failure and is bounded by the 4s recall ceiling. The builder stays a pure function; all I/O is in wiring behind test seams.

## Follow-ups (out of scope here)

- Flip the `session_continuity.briefing` default from `legacy` to `gateway` once parity is confirmed in the fleet.
- Delete `bin/handoff-briefing.sh` after the default flip.
- Fix the `WORKSPACE_DIR` daily-memory path bug in `bin/handoff-briefing.sh`.

## Rebase dependency

Three sibling PRs (#4251/#4247, #4252/#4246, #4253/#4242) touch the same files; making `maybeQueueBootBriefing` async conflicts with #4247's new test — accepted, resolve on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)