### PR TITLE
fix(hostd): unfreeze the rollout narration card after the pre-canary hindsight refresh

### DIFF
--- a/src/host-control/rollout-narrator.test.ts
+++ b/src/host-control/rollout-narrator.test.ts
@@ -513,6 +513,14 @@ describe("LogTailRolloutNarrator", () => {
     expect(first).toContain("- ⧗ `hostd` — host-side");
     expect(first).toContain("self-heal with the first agent restart");
 
+    // hindsight skip renders as an honest ○, not a ✓. Fed in REAL plan order:
+    // refresh-hindsight runs BEFORE the canary on both plan paths (#4047).
+    n.onPhase(entry, phase("hindsight-skipped"));
+    await vi.advanceTimersByTimeAsync(500);
+    expect(relay.edits.at(-1)!.text).toContain(
+      "- ○ `hindsight` — no hindsight container on this host",
+    );
+
     // First agent done → the shared singletons' self-heal ran (⏳, verified
     // at end — never a bare ✓ mid-roll).
     n.onPhase(entry, phase("canary-start", { agent: "test-harness", n: 1, m: 2 }));
@@ -529,12 +537,6 @@ describe("LogTailRolloutNarrator", () => {
     n.onPhase(entry, phase("web-refresh-done"));
     await vi.advanceTimersByTimeAsync(500);
     expect(relay.edits.at(-1)!.text).toContain("- ✓ `switchroom-web`");
-
-    // hindsight skip renders as an honest ○, not a ✓.
-    n.onPhase(entry, phase("hindsight-skipped"));
-    await vi.advanceTimersByTimeAsync(500);
-    const t = relay.edits.at(-1)!.text;
-    expect(t).toContain("- ○ `hindsight` — no hindsight container on this host");
   });
 
   it("terminal ✅ reconciles the singleton rows from the verify-components outcome", async () => {
@@ -754,5 +756,65 @@ describe("LogTailRolloutNarrator", () => {
       relay.edits.at(-1)?.text ?? relay.posts.at(-1)?.text ?? "";
     expect(finalText).toContain("❌");
     expect(finalText).toContain("test-harness");
+  });
+
+  // ── Regression: #4047 plan order vs the monotonic seq gate ─────────────────
+  // #4047 moved refresh-hindsight BEFORE the canary restart; the narrator's
+  // seq table still anchored the hindsight phases at their pre-#4047
+  // end-of-roll position (MAX_SAFE_INTEGER - 3). So the first
+  // hindsight-refresh phase pushed lastAppliedSeq near the ceiling and the
+  // monotonic gate DROPPED every later canary/agent/web phase — the
+  // operator's card froze at "hindsight refreshed" for the rest of the roll
+  // (observed on the v0.19.48 → v0.20.0 prod roll, request
+  // mcp-rollout-1785727512601: zero card edits for the entire 16-minute
+  // canary + 12-agent window). Drive the REAL executor over the REAL hostd
+  // plan so this test re-fails if the plan order and the seq table ever
+  // drift apart again.
+  it("keeps editing through canary + agents when hindsight refreshes BEFORE the canary (real hostd plan order)", async () => {
+    const TARGET = "v1.2.3";
+    const relay = makeRelay(100);
+    const n = new LogTailRolloutNarrator(relay, { debounceMs: 200 });
+
+    const steps = planRollout(["clerk", "overlord", "test-harness"], {
+      pinToPersist: TARGET,
+      hostdContext: true,
+      skipWeb: true, // web probes shell out; the frozen window under test is canary+agents
+    });
+    // Tether to the real plan: refresh-hindsight precedes the first
+    // restart-agent. If this ever flips back, the seq table must move with it.
+    expect(steps.findIndex((s) => s.kind === "refresh-hindsight")).toBeLessThan(
+      steps.findIndex((s) => s.kind === "restart-agent"),
+    );
+
+    const entry = makeEntry();
+    const deps: RolloutDeps = {
+      run: () => ({ status: 0 }),
+      probeVersion: () => "1.2.3", // every restart converges on the target
+      log: () => {},
+      emitPhase: (p) => n.onPhase(entry, p),
+      persistPin: () => true,
+      // Hermetic AND on the prod path: hindsight exists, so the executor
+      // emits hindsight-refresh → hindsight-refresh-done before the canary.
+      hindsightExists: () => true,
+      sleepMs: async () => {},
+    };
+
+    const result = await executeRollout(steps, TARGET, deps, {
+      hostdContext: true,
+    });
+    expect(result.ok).toBe(true);
+    await vi.runAllTimersAsync();
+
+    // The card kept editing THROUGH the agent window after the pre-canary
+    // hindsight refresh: the canary and every agent appear on the final
+    // mid-roll render, and hindsight kept its observed ✓. Before the fix the
+    // canary/agent phases were dropped by the seq gate, so no agent row ever
+    // reached the card.
+    expect(relay.edits.length).toBeGreaterThanOrEqual(1);
+    const last = relay.edits.at(-1)!.text;
+    expect(last).toContain("`test-harness` (canary)");
+    expect(last).toContain("- ✓ `clerk`");
+    expect(last).toContain("- ✓ `overlord`");
+    expect(last).toContain("- ✓ `hindsight`");
   });
 });

--- a/src/host-control/rollout-narrator.ts
+++ b/src/host-control/rollout-narrator.ts
@@ -413,16 +413,26 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
         return 2 * (phase.n ?? 1) + 1;
       case "web-refresh":
       case "web-refresh-done":
-        // In-plan web singleton refresh — after every agent restart, before
-        // the hindsight refresh. Equal-seq: -done REFINES -start (the
+        // In-plan web singleton refresh — after every agent restart, near
+        // the end of the roll. Equal-seq: -done REFINES -start (the
         // executor emits them strictly in order on one stdout).
         return Number.MAX_SAFE_INTEGER - 4;
       case "hindsight-refresh":
       case "hindsight-refresh-done":
       case "hindsight-skipped":
-        // After the web refresh, before the deferral note. Same equal-seq
-        // refine-only shape as web above.
-        return Number.MAX_SAFE_INTEGER - 3;
+        // Since #4047 the hindsight refresh runs BEFORE the canary on BOTH
+        // plan paths (planRollout pushes refresh-hindsight right after
+        // apply), so it slots between apply (0) and the n=1 canary window
+        // (2). The previous anchor here (MAX_SAFE_INTEGER - 3) encoded the
+        // pre-#4047 end-of-roll position and FROZE the narration card for
+        // the rest of the roll: once hindsight-refresh applied, every later
+        // canary/agent/web phase compared strictly lower and was dropped by
+        // the monotonic gate (observed on the v0.19.48 → v0.20.0 prod roll,
+        // request mcp-rollout-1785727512601: zero card edits between
+        // hindsight-refresh-done and hostd-web-deferred, 16 minutes). Same
+        // equal-seq refine-only shape as web (-done/-skipped refine
+        // -refresh).
+        return 1;
       case "hostd-web-deferred":
         return Number.MAX_SAFE_INTEGER - 1; // near the end, before terminal
       default:


### PR DESCRIPTION
## The bug (observed in prod, v0.19.48 → v0.20.0 roll)

The live rollout narration card froze at "hindsight refreshed / 1m 41s" for the entire 16-minute canary + 12-agent window of request `mcp-rollout-1785727512601` — zero card edits between 03:28:23 (`hindsight-refresh-done`) and 03:44:29 (`hostd-web-deferred`) in the caller gateway's log, while the durable phase audit rows show the roll progressing normally.

## Root cause

**Not** the suspected post-self-bump card-handle loss — the #4063 marker carry + `seedPostedMessage` re-attach worked (edits landed on the seeded card after the hostd recreate at 03:26:43, 03:26:46, 03:28:23).

#4047 moved `refresh-hindsight` BEFORE the canary restart on both plan paths (`planRollout`, `src/cli/rollout.ts:268`), but the narrator's monotonic seq table (`seqFor`, `src/host-control/rollout-narrator.ts`) still anchored `hindsight-refresh`/`-done`/`-skipped` at their pre-#4047 end-of-roll position, `Number.MAX_SAFE_INTEGER - 3`. So on every hostd/agent-invoked roll since #4047, the first hindsight phase pushed `lastAppliedSeq` near the ceiling and the strict monotonic gate dropped EVERY later phase: `canary-start` (2), `canary-pass`/`persist-pin` (3), all `agent-start`/`agent-done` (4–25), even `web-refresh` (MAX-4). Only `hostd-web-deferred` (MAX-1) and the ungated terminal edit still landed — which is why the terminal ✅ card appeared while the whole mid-roll window was frozen.

## Fix

Rank the hindsight phases at seq `1` — between `apply` (0) and the n=1 canary window (2) — matching the real plan order on both paths. Equal-seq refine-only semantics unchanged.

## Tests

- New regression test drives the REAL `executeRollout` over the REAL `hostdContext` plan (asserts `refresh-hindsight` precedes the first `restart-agent`, so the test re-fails if plan order and seq table drift apart again) into the narrator, and asserts the card still carries the canary + every agent row after the roll. **Fails on the old anchor** (verified by stash-revert), passes with the fix.
- The singleton-section test's phase feed is reordered to the real (#4047) plan order — it previously encoded the stale web-then-hindsight order, which the fixed gate rightly treats as out-of-order.

Local: `vitest run src/host-control/ src/cli/rollout.test.ts src/cli/rollout-pin-journal.test.ts tests/rollout-status-edit-retry-policy.test.ts tests/rollout-narration-edit-socket.test.ts` → 22 files, 416 tests passed. `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)