### PR TITLE
fix(voice): pin lead heteronym as explicit G2P known gap (#4270)

### DIFF
--- a/docker/Dockerfile.voice
+++ b/docker/Dockerfile.voice
@@ -162,6 +162,20 @@ RUN pip3 install --no-cache-dir \
 # English path is torch-free with trf=False (torch is never installed here, so
 # an import of it would ImportError), and (b) the baked en_core_web_sm wheel
 # loads offline under spaCy. If any of that regresses, THIS build turns red.
+#
+# KNOWN GAP (#4270) — "lead" is NOT fixed, and CANNOT be fixed by misaki 0.9.4
+# (nor by enabling the trf/transformer POS pipeline): misaki's us_gold.json has
+# `"lead": "lˈid"` as a PLAIN STRING, not a POS-keyed dict like live/read, and
+# Lexicon.lookup only consults the POS tag when the entry is a dict — a forced
+# perfect tag (NN/VB/JJ/…) still returns lˈid for every sense. Upstream misaki
+# `main` has the same plain-string entry, so a version bump doesn't close it
+# either. It is also not purely POS-reducible: the metal ("made of lead",
+# lˈɛd) and the leed-nouns ("took the lead", "dog on a lead", lˈid) are BOTH
+# tagged NN, so a naive {NN: lˈɛd} override would regress common phrases —
+# closing it needs a lexicon-level word-sense fix upstream. Until then we PIN
+# the wrong-but-current behaviour below so the gap is explicit: if a misaki
+# bump ever starts emitting lˈɛd for the metal, THIS build turns red and
+# forces the guard + test_g2p.py xfail + docs to flip to a real assertion.
 RUN python3 -c "\
 from misaki import en, espeak; \
 g2p = en.G2P(trf=False, british=False, fallback=espeak.EspeakFallback(british=False)); \
@@ -171,7 +185,12 @@ rp, _ = g2p('Please read this book.'); \
 rd, _ = g2p('He read it yesterday.'); \
 assert 'lˈɪv' in lv and 'lˈIv' in la, ('live sense collapsed', lv, la); \
 assert 'ɹˈid' in rp and 'ɹˈɛd' in rd, ('read sense collapsed', rp, rd); \
-print('misaki G2P heteronym guard OK:', lv, '|', la, '|', rp, '|', rd)"
+lm, _ = g2p('The pipe is made of lead.'); \
+lw, _ = g2p('Lead the way.'); \
+assert 'lˈid' in lw, ('lead verb sense broke', lw); \
+assert 'lˈid' in lm and 'lˈɛd' not in lm, ('lead KNOWN GAP (#4270) closed? metal sense changed - flip this guard, the test_g2p.py xfail, and the docs to real assertions', lm); \
+print('misaki G2P heteronym guard OK:', lv, '|', la, '|', rp, '|', rd); \
+print('KNOWN GAP (#4270): lead metal sense still lˈid (should be lˈɛd) — misaki lexicon lacks a POS-keyed entry:', lm)"
 
 COPY docker/voice-sidecar/server.py /opt/voice-sidecar/server.py
 

--- a/docker/voice-sidecar/server.py
+++ b/docker/voice-sidecar/server.py
@@ -21,6 +21,12 @@ phoneme string to Kokoro with is_phonemes=True. This fixes English
 heteronyms Kokoro's built-in espeak phonemizer mispronounces because
 espeak is not part-of-speech aware — e.g. the verb "live" /lˈɪv/ vs the
 adjective "live" /lˈaɪv/, or "read" present /ɹˈid/ vs past /ɹˈɛd/. It is
+NOT a blanket heteronym fix: "lead" is a KNOWN GAP (#4270) — misaki's
+lexicon carries it as a plain string /lˈid/ (not a POS-keyed entry), so
+the metal ("made of lead", should be /lˈɛd/) comes out as "leed" in every
+sense, and no POS model can split it (the metal and the leed-nouns "took
+the lead" are both NN). Pinned explicitly in the Dockerfile.voice build
+guard and test_g2p.py's xfail. It is
 a strict ENHANCEMENT: misaki is loaded in its own try/except beside the
 Kokoro model, and any failure (or VOICE_TTS_G2P=espeak, or a non-English
 locale) leaves _g2p None so synthesis degrades to today's espeak path

--- a/docker/voice-sidecar/test_g2p.py
+++ b/docker/voice-sidecar/test_g2p.py
@@ -211,6 +211,30 @@ class RealMisakiHeteronymTests(unittest.TestCase):
         self.assertIn("ɹˈid", base)
         self.assertIn("ɹˈɛd", past)
 
+    def test_lead_verb_sense(self) -> None:
+        # The verb sense IS correct today — pin it so a fix attempt for the
+        # metal sense can't regress the common verb reading.
+        verb, _ = self.g2p("Lead the way.")
+        self.assertIn("lˈid", verb)
+
+    @unittest.expectedFailure
+    def test_lead_metal_vs_verb_KNOWN_GAP_4270(self) -> None:
+        """xfail (#4270): asserts the CORRECT behaviour — metal "lead" should
+        be lˈɛd — which misaki 0.9.4 cannot produce: us_gold.json has "lead"
+        as a plain string ("lˈid"), not a POS-keyed dict like live/read, so
+        Lexicon.lookup never consults the tag (a forced perfect NN tag still
+        returns lˈid; upstream main has the same entry, and the metal vs the
+        leed-nouns "took the lead"/"dog on a lead" are all NN anyway, so no
+        POS model at any cost can split them). If a misaki bump ever fixes
+        the lexicon, this becomes an UNEXPECTED SUCCESS (a test failure):
+        remove this decorator and flip the Dockerfile.voice known-gap guard
+        to a real assertion in the same PR."""
+        metal, _ = self.g2p("The pipe is made of lead.")
+        verb, _ = self.g2p("Lead the way.")
+        self.assertIn("lˈɛd", metal)
+        self.assertIn("lˈid", verb)
+        self.assertNotEqual(metal, verb)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Closes the silent `lead` heteronym gap from #4270 (follow-up to #4250) the honest way: the misaki G2P path **cannot** pronounce metal `lead` as /lˈɛd/ — proven a lexicon-data gap, not a tagger gap — so the build guard and test suite now pin it as an EXPLICIT known gap instead of never testing it.

## Why (root cause — contradicts the issue's suspected cause)

The issue suspected the torch-free `trf=False` path lacked the POS model. Proven false inside the live v0.20.0 sidecar:

- misaki 0.9.4 `us_gold.json` has `"lead": "lˈid"` as a **plain string**; `live`/`read` are POS-keyed dicts. `Lexicon.lookup` (`misaki/en.py:228-246`) only consults the tag when the entry is a dict — a **forced perfect tag** (NN/VB/JJ/NOUN/VERB/ADJ) still returns `lˈid` for every sense.
- Upstream misaki `main` has the same plain-string entry — no bump closes it.
- `lead` is not POS-reducible anyway: metal ("made of lead", lˈɛd) and the leed-nouns ("took the lead", "dog on a lead", lˈid) are all tagged NN by the baked en_core_web_sm tagger. `misaki[en]`'s transformer extra (spacy-curated-transformers + torch, multi-GB) would change nothing.

So no "real fix" exists at any image-size/latency cost short of an upstream word-sense lexicon fix; per #4270's option 2 this takes the explicit known-gap route.

## Changes

- **`docker/Dockerfile.voice` guard**: now also asserts `lead` — verb sense `lˈid` (correct, pinned) AND metal sense still `lˈid` with a loud `KNOWN GAP (#4270)` line in build output. If a misaki bump ever emits `lˈɛd` for the metal, the build turns red and forces guard + xfail + docs to flip to real assertions. `lead` can never silently pass again.
- **`docker/voice-sidecar/test_g2p.py`**: `test_lead_verb_sense` (pins correct verb reading) + `@unittest.expectedFailure` `test_lead_metal_vs_verb_KNOWN_GAP_4270` asserting the CORRECT behaviour; unexpected success reports as a failure, forcing the flip.
- **`docker/voice-sidecar/server.py`**: heteronym docs state the gap honestly. No runtime change; `VOICE_TTS_G2P=espeak` rollback lever untouched.

## Test plan

- Reproduced live in `switchroom-voice-sidecar` v0.20.0: all 5 `lead` senses → `lˈid`.
- New guard command executed in an ephemeral `ghcr.io/switchroom/switchroom-voice:v0.20.0` container: passes, prints the KNOWN GAP line.
- Full suite in same image: `Ran 39 tests ... OK (expected failures=1)`.
- **Fail-on-bug proof**: with the `@expectedFailure` decorator stripped, the test FAILS (`'lˈɛd' not found in 'ðə pˈIp ɪz mˌAd ʌv lˈid.'`).
- Stdlib-only CI-parity run (no misaki): `Ran 39 tests ... OK (skipped=4)`.
- `npm run lint`: clean.

## Risk

Docs/guard/test only — zero runtime behaviour change. Worst case: a future misaki bump that fixes `lead` fails the image build loudly, which is the designed behaviour.

Refs #4270, #4250

🤖 Generated with [Claude Code](https://claude.com/claude-code)