### PR TITLE
fix(hostd): guard doc drift + fixture covers every optional knob (#4273, #4274)

### DIFF
--- a/scripts/check-hostd-template-guard.ts
+++ b/scripts/check-hostd-template-guard.ts
@@ -28,6 +28,12 @@
  *      relative to origin/main, `lastChanged` must be STRICTLY NEWER than
  *      origin/main's — i.e. you cannot change the template's shape and
  *      re-hash the baseline without also bumping the constant.
+ *   4. FIXTURE-COVERAGE rule (#4274): the fully-optioned fixture must cover
+ *      EVERY optional knob of the render input. The fixture is typed
+ *      `Required<RenderHostdComposeOptions>` (compile-time: adding a knob
+ *      without extending it fails `tsc --noEmit`), and `optionCoverageFailures`
+ *      renders-and-diffs to prove each knob is load-bearing (a knob rendering
+ *      as a no-op would let a shape change gated on it slip past the hash).
  *
  * When this guard fails after a deliberate template change:
  *   - bump HOSTD_TEMPLATE_LAST_CHANGED (src/config/hostd-template-version.ts)
@@ -46,7 +52,10 @@ import { execFileSync } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { renderHostdComposeFile } from "../src/cli/hostd.js";
+import {
+  renderHostdComposeFile,
+  type RenderHostdComposeOptions,
+} from "../src/cli/hostd.js";
 import { HOSTD_TEMPLATE_LAST_CHANGED } from "../src/config/hostd-template-version.js";
 
 export const BASELINE_PATH = "scripts/hostd-template-baseline.json";
@@ -64,15 +73,84 @@ export function renderCanonicalTemplate(): string {
     hostHome: "/home/operator",
     imageTag: "v0.0.0-guard",
   });
-  const full = renderHostdComposeFile({
+  // `Required<…>` is the fixture-coverage guarantee (#4274): every optional
+  // knob of the render input MUST appear here, or `tsc --noEmit` (part of
+  // `npm run lint`, which type-checks scripts/**) fails. So a newly-added
+  // optional knob with its own conditional block cannot slip past the hash —
+  // the author is forced to extend this fixture in the same PR.
+  const full: Required<RenderHostdComposeOptions> = {
     hostHome: "/home/operator",
     imageTag: "v0.0.0-guard",
     operatorUid: 1000,
     hostTz: "Etc/UTC",
     skillsTarget: "/home/operator/.switchroom-config/skills",
     dockerSocketPath: "/var/run/docker.sock",
-  });
-  return `${minimal}\n=== FULL ===\n${full}`;
+  };
+  return `${minimal}\n=== FULL ===\n${renderHostdComposeFile(full)}`;
+}
+
+/**
+ * Generic core of the fixture-coverage check: given a probe input and the
+ * render function, return the probe's keys that are NOT load-bearing — i.e.
+ * omitting the key does not change the render. A non-empty result means a knob
+ * whose shape change could slip past the template hash.
+ *
+ * Pure and render-agnostic so the failure path is unit-testable with a fake
+ * renderer that ignores a key (simulating a newly-added, un-exercised knob).
+ */
+export function unexercisedOptionKeys<T extends Record<string, unknown>>(
+  probe: T,
+  render: (opts: T) => string,
+): string[] {
+  const full = render(probe);
+  const unexercised: string[] = [];
+  for (const key of Object.keys(probe)) {
+    const without = { ...probe };
+    delete without[key];
+    if (render(without) === full) unexercised.push(key);
+  }
+  return unexercised;
+}
+
+/**
+ * Runtime companion to the `Required<…>` compile-time guarantee above:
+ * enumerates EVERY key of the render input and asserts each one is
+ * load-bearing — i.e. omitting it changes the rendered compose file. The
+ * `Required<RenderHostdComposeOptions>` type on the probe forces every
+ * optional knob to be named here (adding a knob without extending this probe
+ * fails `tsc --noEmit`), and the render diff proves each knob's value actually
+ * exercises its conditional block rather than rendering as a no-op.
+ *
+ * This is deliberately SEPARATE from the hashed canonical fixture, so the
+ * probe can use non-default values (e.g. a docker socket path distinct from
+ * DEFAULT_DOCKER_SOCKET_PATH) without perturbing the baseline hash.
+ *
+ * Pure (no I/O) — `renderHostdComposeFile` is hermetic — so it is unit-tested
+ * directly and also run inside `main()`.
+ */
+export function optionCoverageFailures(): string[] {
+  // Every value is deliberately DISTINCT from its omitted/default render so
+  // the diff is observable for each key. `Required<…>` forces the set to stay
+  // complete as the option shape grows.
+  const probe: Required<RenderHostdComposeOptions> = {
+    hostHome: "/home/probe-operator",
+    imageTag: "v0.0.0-probe",
+    operatorUid: 4242,
+    hostTz: "Antarctica/Troll",
+    skillsTarget: "/home/probe-operator/.switchroom-config/skills",
+    // Intentionally NOT DEFAULT_DOCKER_SOCKET_PATH — otherwise omitting it
+    // would render identically (the renderer defaults to that path) and the
+    // knob would look un-exercised.
+    dockerSocketPath: "/run/probe/docker.sock",
+  };
+  return unexercisedOptionKeys(probe, renderHostdComposeFile).map(
+    (key) =>
+      `render option "${key}" is not exercised by the fixture: omitting it ` +
+      `does not change renderHostdComposeFile()'s output, so a shape change ` +
+      `gated on it could slip past the template hash. Give it a ` +
+      `render-affecting value in renderCanonicalTemplate()'s fixture (and in ` +
+      `optionCoverageFailures()'s probe).`,
+  );
 }
 
 /**
@@ -207,12 +285,15 @@ function main(): void {
     process.exit(1);
   }
   const actualHash = templateHash(renderCanonicalTemplate());
-  const failures = evaluateHostdTemplateGuard({
-    actualHash,
-    constant: HOSTD_TEMPLATE_LAST_CHANGED,
-    baseline,
-    mainBaseline: readMainBaseline(),
-  });
+  const failures = [
+    ...optionCoverageFailures(),
+    ...evaluateHostdTemplateGuard({
+      actualHash,
+      constant: HOSTD_TEMPLATE_LAST_CHANGED,
+      baseline,
+      mainBaseline: readMainBaseline(),
+    }),
+  ];
   if (failures.length > 0) {
     process.stderr.write(
       `check-hostd-template-guard: FAIL\n` +

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -140,7 +140,14 @@ export const DOCKER_SOCKET_PROXY_IMAGE =
  * variable is the host home directory (for the bind mounts that map
  * `~/.switchroom` and `/var/run/docker.sock` into the daemon).
  */
-export function renderHostdComposeFile(opts: {
+/**
+ * Inputs to {@link renderHostdComposeFile}. The optional knobs each gate a
+ * conditional block in the rendered compose file; the hostd-template guard
+ * (`scripts/check-hostd-template-guard.ts`) types its fully-optioned fixture
+ * as `Required<RenderHostdComposeOptions>`, so adding an optional knob here
+ * without extending the fixture fails `tsc --noEmit` (part of `npm run lint`).
+ */
+export interface RenderHostdComposeOptions {
   hostHome: string;
   imageTag: string;
   /** Host operator UID — hostd chowns its operator socket to this so
@@ -183,7 +190,9 @@ export function renderHostdComposeFile(opts: {
    * conventional default.
    */
   dockerSocketPath?: string;
-}): string {
+}
+
+export function renderHostdComposeFile(opts: RenderHostdComposeOptions): string {
   const { hostHome, imageTag, operatorUid, hostTz, skillsTarget } = opts;
   // KEPT PURE: default to the conventional socket constant rather than
   // shelling out to `docker context inspect` here, so this renderer stays

--- a/src/config/hostd-template-version.ts
+++ b/src/config/hostd-template-version.ts
@@ -18,7 +18,7 @@
  * required.
  *
  * KEEPING IT HONEST is not left to reviewer memory: the lint guard
- * `scripts/check-hostd-template-guard.mjs` hashes the template region of
+ * `scripts/check-hostd-template-guard.ts` hashes the template region of
  * src/cli/hostd.ts against `scripts/hostd-template-baseline.json` and FAILS
  * when the region changes without this constant (and the baseline) being
  * bumped in the same PR. When you change the hostd template:

--- a/src/host-control/render-rollout-status.ts
+++ b/src/host-control/render-rollout-status.ts
@@ -26,7 +26,7 @@
 // runtime consumers of this renderer already load it.
 import { VERIFY_COMPONENTS_STEP as VERIFY_COMPONENTS_FAILED_STEP } from "../cli/rollout.js";
 // #4269 — the definite "hostd template regen required / not needed" verdict.
-// The constant is kept honest by scripts/check-hostd-template-guard.mjs.
+// The constant is kept honest by scripts/check-hostd-template-guard.ts.
 import {
   HOSTD_TEMPLATE_LAST_CHANGED,
   hostdTemplateRegenVerdict,

--- a/tests/check-hostd-template-guard.test.ts
+++ b/tests/check-hostd-template-guard.test.ts
@@ -19,6 +19,8 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   evaluateHostdTemplateGuard,
+  optionCoverageFailures,
+  unexercisedOptionKeys,
   renderCanonicalTemplate,
   normalizeTemplate,
   templateHash,
@@ -26,6 +28,7 @@ import {
   type HostdTemplateBaseline,
 } from "../scripts/check-hostd-template-guard.js";
 import { HOSTD_TEMPLATE_LAST_CHANGED } from "../src/config/hostd-template-version.js";
+import { renderHostdComposeFile } from "../src/cli/hostd.js";
 
 const REPO = resolve(import.meta.dirname, "..");
 
@@ -123,6 +126,46 @@ describe("check-hostd-template-guard (#4269)", () => {
     expect(templateHash(rendered + "\n# a new comment line")).toBe(
       templateHash(rendered),
     );
+  });
+
+  it("every render option is exercised by the fixture at HEAD (#4274)", () => {
+    // The real repo: no optional knob renders as a no-op, so a shape change
+    // gated on any of them moves the canonical hash.
+    expect(optionCoverageFailures()).toEqual([]);
+  });
+
+  it("coverage check FAILS loudly when a newly-added knob is not exercised (#4274)", () => {
+    // Simulate an optional knob that was added to the render input but whose
+    // fixture value doesn't trigger its conditional block — the exact bug
+    // #4274 guards. A fake renderer ignores `newKnob`, so omitting it does not
+    // change the output and the check must flag it.
+    const probe = {
+      hostHome: "/home/probe",
+      newKnob: "unused",
+    };
+    const render = (o: typeof probe | Partial<typeof probe>): string =>
+      `home=${o.hostHome}`; // newKnob deliberately never read
+    const unexercised = unexercisedOptionKeys(probe, render as (o: typeof probe) => string);
+    expect(unexercised).toContain("newKnob");
+    expect(unexercised).not.toContain("hostHome");
+  });
+
+  it("the fully-optioned fixture actually differs from the minimal render (#4274)", () => {
+    // Belt-and-braces: the FULL fixture's optional block collectively fires,
+    // so `renderCanonicalTemplate` genuinely hashes two distinct shapes.
+    const minimal = renderHostdComposeFile({
+      hostHome: "/home/operator",
+      imageTag: "v0.0.0-guard",
+    });
+    const full = renderHostdComposeFile({
+      hostHome: "/home/operator",
+      imageTag: "v0.0.0-guard",
+      operatorUid: 1000,
+      hostTz: "Etc/UTC",
+      skillsTarget: "/home/operator/.switchroom-config/skills",
+      dockerSocketPath: "/var/run/docker.sock",
+    });
+    expect(full).not.toBe(minimal);
   });
 
   it("origin/main baseline unreadable ⇒ the lockstep + hash rules still bind", () => {


### PR DESCRIPTION
Two LOW follow-ups from PR #4272's adversarial review, in the hostd-template-guard area.

## Summary
- **#4273 (doc drift):** the header comment in `src/config/hostd-template-version.ts` and the import comment in `src/host-control/render-rollout-status.ts` referenced the guard as `check-hostd-template-guard.mjs`; the real file is `scripts/check-hostd-template-guard.ts`. Both corrected. A repo-wide grep confirms these were the only two `.mjs` references to the guard.
- **#4274 (fixture-coverage gap):** the guard hashed a fully-optioned fixture over *today's* optional knobs, so a newly-added optional knob with its own conditional block could slip past the hash unless the author also remembered to extend the fixture. Now closed deterministically.

## Why
`#4274` is exactly the discipline-over-mechanism failure the guard itself exists to kill: it left "extend the fixture when you add a knob" to author memory. This makes it enforced.

## How (#4274)
- Extract the inline render-input type into an exported `interface RenderHostdComposeOptions` (`src/cli/hostd.ts`), signature otherwise unchanged.
- Type the guard's fully-optioned fixture as `Required<RenderHostdComposeOptions>` so **adding an optional knob without extending the fixture fails `tsc --noEmit`** (part of `npm run lint`, which type-checks `scripts/**`). This enumerates optional keys via the type system — no hand-maintained list.
- Add `optionCoverageFailures()` (run in `main()` and unit-tested): enumerates every render-input key and asserts each is *load-bearing* (omitting it changes the render), so a knob whose fixture value renders as a no-op is flagged loudly. It uses a probe with a non-default docker socket path, deliberately **separate from the hashed canonical fixture**, so the baseline hash is untouched.

The canonical template hash is unchanged (`7b85714af5be`), so there is no baseline or `HOSTD_TEMPLATE_LAST_CHANGED` bump — the template shape did not change, only the guard's coverage enforcement.

## Test plan
- Scoped vitest green: `tests/check-hostd-template-guard.test.ts` (11), `src/config/hostd-template-version.test.ts` (8), `src/cli/hostd.test.ts` (43), `tests/hostd-timezone-capture.test.ts` (11) — 73 passed.
- `bun scripts/check-hostd-template-guard.ts` → OK, hash unchanged.
- `tsc --noEmit` shows no errors in touched files (the 41 pre-existing `bun:sqlite` errors are identical on pristine `main` — environment-only).
- Fail-on-bug proven two ways: (a) mutation test adding a `fooBar?` knob without extending the fixtures errors at both fixture sites; (b) unit test drives `unexercisedOptionKeys` with a renderer that ignores a key and asserts it is flagged.

## Risk
Low. Doc-comment edits plus a guard/test-only mechanism and a type extraction with an unchanged signature. No runtime behavior change to the compose template.

Closes #4273
Closes #4274

🤖 Generated with [Claude Code](https://claude.com/claude-code)