### PR TITLE
docs(buzz): truth-up stale config comments + document channels.buzz

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,6 +82,41 @@ Each field type has specific merge behavior when values exist at multiple layers
 | `cli_args` | concatenate | Escape hatch: extra `exec claude` flags |
 | `google_workspace` | deep merge | Google Drive/Docs/Sheets/Calendar integration. `google_client_id` / `google_client_secret` are install-wide (top level only); `tier` + `approvers` cascade per-agent. See § Google Workspace below. |
 | `notion_workspace` | deep merge top-level; per-agent `databases:` list REPLACES (does not concatenate) | Notion integration. Top-level `vault_key` + `databases:` map cascade via deep merge so a profile can add a DB without clobbering top-level entries. The per-agent `databases:` allowlist is **override** — an agent's list replaces the parent's, so a specialist agent inheriting a profile can narrow to fewer DBs. See § Notion Workspace below and [notion-integration.md](notion-integration.md). |
+| `channels.buzz` | override | Buzz desktop co-channel (a closed NIP-29 Nostr relay + one per-agent sidecar). **Dark by default** — omit the block or set `enabled: false` and nothing projects a live channel. See § Buzz co-channel below and [reference/jobs/use-my-team-from-the-desktop.md](../reference/jobs/use-my-team-from-the-desktop.md). |
+
+## Buzz co-channel — `channels.buzz`
+
+Buzz is the desktop door into the same fleet: a per-agent sidecar subscribes
+to a closed [NIP-29](https://github.com/nostr-protocol/nips/blob/master/29.md)
+Nostr relay, NIP-42-authenticates, and injects allowlisted messages onto the
+gateway socket as synthesized turns (`meta.source="buzz"`). Telegram stays the
+authoritative surface — every agent answer lands on Telegram first and Buzz
+only ever mirrors it (Phase 1 is inbound-only; the reply lands on Telegram).
+
+The block is **dark by default and fail-closed by construction**. Omitting
+`channels.buzz` projects **no** `BUZZ_*` container env at all — that agent's
+compose is byte-identical to pre-Buzz. When the block is present,
+`src/agents/compose.ts` maps it into `BUZZ_*` env, but `BUZZ_ENABLED=1` is
+projected **only** when `enabled: true`; an `enabled: false` (or absent) block
+leaves `BUZZ_ENABLED` unset, so `start.sh`'s `[ "$BUZZ_ENABLED" = "1" ]` guard
+never forks the sidecar. The nsec is never projected — only its vault **key
+name**; the sidecar broker-fetches the secret in-process at boot.
+
+| Field | Cascade | Required | Description |
+|-------|---------|----------|-------------|
+| `channels.buzz.enabled` | override | no (default `false`) | Master switch for the per-agent Buzz sidecar. Ships dark; `start.sh` forks the sidecar only when `true`. Projects `BUZZ_ENABLED=1`. |
+| `channels.buzz.mirror` | override | no (default `both`) | Cross-surface mirror mode. `both` answers on the origin channel and mirrors a copy to the other; `off` is a true kill-switch that disables the channel in both directions. `origin` is **deferred** in Phase 2b and degraded to `off` (dark) at runtime — only `both` and `off` ship live. Projects `BUZZ_MIRROR`. |
+| `channels.buzz.relay_url` | override | **yes** | Canonical `ws://`/`wss://` URL of the closed relay — the exact string the relay expects in the NIP-42 `relay` auth tag (e.g. `ws://127.0.0.1:3000`). The relay validates this tag as an exact string match before the membership check, so it is the relay's advertised identity, not necessarily the dial address. Projects `BUZZ_RELAY_URL`. |
+| `channels.buzz.relay_dial_url` | override | no | Reachable `ws://`/`wss://` address the sidecar actually **dials** when it differs from `relay_url` (e.g. a docker-network IP the relay's own `127.0.0.1` can't stand in for). The NIP-42 auth tag still uses `relay_url`. Defaults to `relay_url` when unset. Projects `BUZZ_RELAY_DIAL_URL`. |
+| `channels.buzz.relay_host` | override | **yes** | HTTP `Host` header authority sent verbatim on the WS upgrade (e.g. `127.0.0.1:3000`, port included). The relay resolves its community from this header before the upgrade and returns HTTP 404 if it is missing or wrong, so it must match the relay's configured authority and is deployment config, never derived from the dial URL. Projects `BUZZ_RELAY_HOST`. |
+| `channels.buzz.chat_id` | override | **yes** | Telegram chat id an injected Buzz turn is routed to — the agent's reply lands here on Telegram (the authoritative surface). The sidecar refuses to run live without it. Projects `BUZZ_CHAT_ID`. |
+| `channels.buzz.default_channel_id` | override | **yes** | Relay-minted group UUID (the NIP-29 `h` tag) the sidecar subscribes to and stamps on injected turns. Projects `BUZZ_CHANNEL_IDS`. |
+| `channels.buzz.operator_pubkey` | override | **yes** | The operator's Nostr pubkey (bech32 `npub1…` or 64-char hex). Always in the effective inbound allowlist — the fail-closed default is operator-only. Projects `BUZZ_OPERATOR_PUBKEY`. |
+| `channels.buzz.nsec_vault_key` | override | no (default `buzz/{agent}-nsec`) | Vault **key name** for the agent's Nostr secret key. `{agent}` is substituted with the agent name. Broker-fetched in-process at boot — never resolved into env or logged. Projects `BUZZ_NSEC_VAULT_KEY` (the key name, not the secret). |
+| `channels.buzz.authorized_pubkeys` | override | no (default `[]`) | Additional pubkeys (`npub` or hex) whose signed events may become turns. Effective allowlist = this ∪ `{operator_pubkey}`. Empty by default (operator-only). Projects `BUZZ_AUTHORIZED_PUBKEYS` (comma-joined) when non-empty. |
+| `channels.buzz.pubkey_names` | override | no (default `{}`) | Optional petnames: hex/`npub` pubkey → display name, used to label the sender on injected turns. Projects `BUZZ_PUBKEY_NAMES` (comma-joined `key=value`) when non-empty. |
+| `channels.buzz.channel_map` | override | no (default `{}`) | Optional map of extra group UUIDs → friendly labels. Not projected to env today. |
+| `channels.buzz.pinned_relay_digest` | override | no | **Reserved — not yet consumed.** Intended pinned relay image digest (M4); nothing projects or reads it today. Kept in the schema so the digest-pin can be wired later without a config-shape change. |
 
 ## Permission mode & auto-accept
 

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -547,14 +547,13 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
   #
   #     Default OFF and deterministic: the block is present for every agent
   #     (start.sh stays byte-identical fleet-wide) but forks the sidecar ONLY
-  #     when BUZZ_ENABLED=1 is set in the container env. NOTE: nothing in this
-  #     branch sets BUZZ_ENABLED (or the other BUZZ_* vars) — projecting an
-  #     ENABLED channels.buzz block into container env is DEFERRED to the
-  #     deploy-wiring phase. Until then the env is unset for every agent and
-  #     this block is a no-op, so the channel is dark by construction. The
-  #     sidecar itself also fails closed if its env is incomplete, and fetches
-  #     the nsec in-process from the vault broker (never an env var, never
-  #     logged).
+  #     when BUZZ_ENABLED=1 is set in the container env. That var is projected
+  #     by src/agents/compose.ts from the cascade-resolved channels.buzz block,
+  #     and BUZZ_ENABLED=1 lands ONLY when that block sets enabled:true. An
+  #     enabled:false/absent block leaves it unset, so for those agents this
+  #     block is a no-op and the channel is dark by construction. The sidecar
+  #     itself also fails closed if its env is incomplete, and fetches the nsec
+  #     in-process from the vault broker (never an env var, never logged).
   if [ "$BUZZ_ENABLED" = "1" ] \
      && [ -f /opt/switchroom/buzz-gateway/index.js ] \
      && command -v bun >/dev/null 2>&1; then

--- a/src/buzz-gateway/config.ts
+++ b/src/buzz-gateway/config.ts
@@ -7,14 +7,14 @@
  * no access to the config cascade. The one secret (the agent nsec) is NEVER an
  * env var; it is broker-fetched in-process at boot (see index.ts).
  *
- * IMPORTANT — these env vars are NOT populated by any config path in this
- * branch. The projection of the cascade-resolved `channels.buzz` block into
- * these env vars (at scaffold/compose time) is DEFERRED to the deploy-wiring
- * phase. Until that lands, `BUZZ_ENABLED` is unset everywhere, so the channel
- * is inert by construction and this sidecar never runs live. (Also deferred to
- * that phase: BuzzChannelSchema currently has no chat-id field, yet this loader
- * requires BUZZ_CHAT_ID when live — the schema→env mapping is part of the
- * env-projection work, not added here.)
+ * These env vars are projected at compose time from the cascade-resolved
+ * `channels.buzz` block: `src/agents/compose.ts` maps the block into BUZZ_*
+ * container env, gating `BUZZ_ENABLED=1` on `enabled === true`. An
+ * enabled:false/absent block leaves `BUZZ_ENABLED` unset, so start.sh's
+ * `[ "$BUZZ_ENABLED" = "1" ]` guard never forks the sidecar and the channel
+ * stays dark by construction — the default. `BuzzChannelSchema`
+ * (`src/config/schema.ts`) carries a REQUIRED `chat_id`, projected as
+ * `BUZZ_CHAT_ID`, which this loader requires when live.
  *
  * `loadConfigFromEnv` is pure w.r.t. a supplied env map so it is unit-testable.
  */

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2399,8 +2399,10 @@ export const BuzzChannelSchema = z
       .string()
       .optional()
       .describe(
-        "Pinned relay image digest (M4). The compat-check warns on mismatch; " +
-        "advisory in Phase 1.",
+        "Pinned relay image digest (M4). RESERVED — not yet consumed: nothing " +
+        "projects or reads this field today (no compat-check exists yet). Kept " +
+        "in the schema so the intended digest-pin can be wired without a config " +
+        "shape change.",
       ),
   })
   .strict();

--- a/telegram-plugin/gateway/buzz-mirror.ts
+++ b/telegram-plugin/gateway/buzz-mirror.ts
@@ -300,8 +300,10 @@ export function getBuzzMirror(): BuzzMirror | null {
  *   (1) `BUZZ_ENABLED` is truthy, AND
  *   (2) the S2-narrowed mode (`parseConfiguredMirrorMode`) is `both`;
  *       a configured `origin`/`off` degrades to dark, never a half-live mirror.
- * The Buzz env vars are UNSET everywhere in this branch (projection deferred),
- * so in practice this is inert. `sender` is the transport to the duplex peer
+ * The Buzz env vars are projected at compose time from `channels.buzz`
+ * (src/agents/compose.ts), with BUZZ_ENABLED=1 gated on `enabled === true`;
+ * an enabled:false/absent block leaves them unset, so for those agents this
+ * is inert by construction. `sender` is the transport to the duplex peer
  * (`ipcServer.sendToBuzzPeer`). Returns the booted instance for tests.
  */
 export function maybeBootBuzzMirror(


### PR DESCRIPTION
## Summary

PR-1 of the Buzz live-enablement plan. The Buzz co-channel pipeline is fully built on `main` and dark by config, but several code comments predate the deploy-wiring PRs (#4217) and still claim env projection / `chat_id` / `BUZZ_ENABLED` are "deferred" or "unset in this branch". This corrects those stale comments to match current source and documents the `channels.buzz` config surface. **No behavior change — comments and docs only.**

## Why

Stale prose in load-bearing config files misleads the next reader (and the next enablement PR) about what is already wired. Every corrected claim was verified against current `main`:

- `src/agents/compose.ts:2606-2636` projects the full `BUZZ_*` env from `channels.buzz`, gating `BUZZ_ENABLED=1` on `enabled === true`.
- `src/config/schema.ts` `BuzzChannelSchema` carries a **required** `chat_id` (projected as `BUZZ_CHAT_ID`).
- `profiles/_base/start.sh.hbs:558` forks the sidecar off `[ "$BUZZ_ENABLED" = "1" ]`.

## Corrected comments

- **`src/buzz-gateway/config.ts`** — header no longer claims the env is "NOT populated by any config path in this branch" or that `BuzzChannelSchema` "has no chat-id field"; now describes the compose-time projection and the required `chat_id`.
- **`profiles/_base/start.sh.hbs`** — the "nothing in this branch sets BUZZ_ENABLED … DEFERRED" NOTE now points at the `compose.ts` projection gated on `enabled:true`.
- **`telegram-plugin/gateway/buzz-mirror.ts`** — "env vars are UNSET everywhere in this branch (projection deferred)" corrected to describe the projection.
- **`src/config/schema.ts`** — `pinned_relay_digest`: the describe claimed a "compat-check warns on mismatch" that does not exist (projected/consumed nowhere, repo-wide grep). Kept the field with an honest **reserved / not yet consumed** note, consistent with the codebase's reserved-field precedent (`servesField` at ~:3587), rather than dropping it.

## New docs

- **`docs/configuration.md`** — new "Buzz co-channel — `channels.buzz`" reference section + field table. Field names, requiredness, defaults, and projected env vars all verified against `src/config/schema.ts` and the projection in `src/agents/compose.ts`.

## Test plan

- `vitest run src/agents/compose-buzz-env.test.ts` → **5/5 green** (no behavior change).
- Lint guards run scoped: `check-gateway-line-ratchet`, `check-no-pii-secrets`, `check-callback-ctx-wrapping` → all clean.
- `tsc --noEmit`: the only errors are `Cannot find module 'nostr-tools'` — a declared dep (`package.json:67`) absent from the local stale `node_modules`, unrelated to this diff (comment/describe-string only). CI type-checks with real deps.

## Risk

Minimal. No runtime code path changes; edits are code comments, one Zod `.describe()` string, and a docs section.

## Job spec

`reference/jobs/use-my-team-from-the-desktop.md` — this advances the "use my team from the desktop" outcome by making the `channels.buzz` config surface accurate and discoverable, keeping the co-channel dark-by-default and fail-closed as the spec requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)