### PR TITLE
fix(buzz): durable msg→event correlation so corrections survive restart (#4222)

### DIFF
--- a/telegram-plugin/gateway/buzz-mirror-correlation-store.ts
+++ b/telegram-plugin/gateway/buzz-mirror-correlation-store.ts
@@ -1,0 +1,256 @@
+/**
+ * Durable msg→Buzz correlation store for the hub-side mirror (#4222).
+ *
+ * `BuzzMirror` records `${chatId}:${messageId}` → the published Buzz event it
+ * mirrored to, so a later `edit_message` on that Telegram message can publish a
+ * superseding `correction`. Before this module that map lived IN MEMORY ONLY
+ * (a bounded FIFO). After a gateway restart the map was empty, so a correction
+ * to an answer mirrored before the restart was SILENTLY skipped — the Buzz copy
+ * went stale with no signal.
+ *
+ * This store closes that gap the same way the sidecar's inbound dedup does
+ * (`src/buzz-gateway/dedup.ts`): an in-memory insertion-ordered map backed by an
+ * append-only JSONL journal, fsync'd after each record so a gateway restart
+ * reloads the correlation and corrections survive. It lives at a DIFFERENT path
+ * from the sidecar's `journal.jsonl` (`mirror-correlation.jsonl`) — the two share
+ * `$TELEGRAM_STATE_DIR/buzz/` and a filename collision would corrupt both.
+ *
+ * Bounding: on construction the journal is compacted to the last `capacity`
+ * unique keys (matching the in-memory FIFO bound); during a session the journal
+ * is re-compacted in place once it grows past `capacity * COMPACTION_FACTOR`
+ * appends, so it never grows unbounded even in a long-lived gateway.
+ *
+ * The filesystem is injected so the pure map/journal logic is unit-testable with
+ * an in-memory fake (see `buzz-mirror-correlation-store.test.ts`). When no
+ * journal path is configured (dev/one-shot contexts, or `TELEGRAM_STATE_DIR`
+ * unset) the store degrades to in-memory only — identical bound, no durability.
+ */
+
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
+import { dirname } from "node:path";
+
+/** The value a Telegram message key maps to: the Buzz event that mirrored it. */
+export interface CorrelationValue {
+  eventId: string;
+  channelId: string;
+}
+
+export interface CorrelationFsLike {
+  existsSync(path: string): boolean;
+  mkdirSync(path: string, opts: { recursive: true }): void;
+  readFileSync(path: string, enc: "utf8"): string;
+  writeFileSync(path: string, data: string): void;
+  renameSync(from: string, to: string): void;
+  openSync(path: string, flags: "a"): number;
+  writeSync(fd: number, data: string): void;
+  fsyncSync(fd: number): void;
+  closeSync(fd: number): void;
+}
+
+const NODE_FS: CorrelationFsLike = {
+  existsSync,
+  mkdirSync: (p, opts) => {
+    mkdirSync(p, opts);
+  },
+  readFileSync: (p, enc) => readFileSync(p, enc),
+  writeFileSync: (p, data) => writeFileSync(p, data),
+  renameSync: (from, to) => renameSync(from, to),
+  openSync: (p, flags) => openSync(p, flags),
+  writeSync: (fd, data) => {
+    writeSync(fd, data);
+  },
+  fsyncSync: (fd) => fsyncSync(fd),
+  closeSync: (fd) => closeSync(fd),
+};
+
+export interface CorrelationStore {
+  /** The Buzz event `key` was mirrored to, or undefined if not tracked. */
+  get(key: string): CorrelationValue | undefined;
+  /** Record `key` → `value`: update memory (FIFO) AND append+fsync the journal. */
+  set(key: string, value: CorrelationValue): void;
+  /** Number of keys currently tracked in memory. */
+  size(): number;
+  /** Release the append fd. */
+  close(): void;
+}
+
+export interface CorrelationStoreOptions {
+  /** Journal path. Omit for in-memory-only (no durability, same bound). */
+  journalPath?: string;
+  /** Max keys retained in memory / after compaction. Default 4096 (MAX_TRACKED). */
+  capacity?: number;
+  fs?: CorrelationFsLike;
+  log?: (msg: string) => void;
+}
+
+/** Re-compact the on-disk journal once appends exceed capacity * this factor. */
+const COMPACTION_FACTOR = 4;
+
+interface JournalRecord {
+  key?: unknown;
+  eventId?: unknown;
+  channelId?: unknown;
+}
+
+/**
+ * Open (and boot-compact) the correlation store. On construction it replays any
+ * existing journal into the in-memory map (last-write-wins per key, oldest-first
+ * insertion order preserved), keeps the last `capacity` unique keys, rewrites the
+ * journal compacted, then opens a persistent append fd.
+ */
+export function createCorrelationStore(
+  opts: CorrelationStoreOptions = {},
+): CorrelationStore {
+  const capacity = opts.capacity ?? 4096;
+  const fs = opts.fs ?? NODE_FS;
+  const log = opts.log ?? (() => {});
+  const journalPath = opts.journalPath;
+
+  // Insertion-ordered map → FIFO. Re-setting a key moves it to newest.
+  const map = new Map<string, CorrelationValue>();
+
+  function put(key: string, value: CorrelationValue): void {
+    if (map.has(key)) map.delete(key); // move to newest on update
+    map.set(key, value);
+    while (map.size > capacity) {
+      const oldest = map.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      map.delete(oldest);
+    }
+  }
+
+  function serialize(): string {
+    let out = "";
+    for (const [key, v] of map) {
+      out += JSON.stringify({ key, eventId: v.eventId, channelId: v.channelId }) + "\n";
+    }
+    return out;
+  }
+
+  // Number of physical lines in the journal since the last compaction (seeded to
+  // the compacted size below). Bounds on-disk growth in a long-lived session.
+  let journalLines = 0;
+
+  // --- Boot compaction (only when a journal path is configured) ---
+  if (journalPath) {
+    try {
+      const dir = dirname(journalPath);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      if (fs.existsSync(journalPath)) {
+        const raw = fs.readFileSync(journalPath, "utf8");
+        for (const line of raw.split("\n")) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          try {
+            const parsed = JSON.parse(trimmed) as JournalRecord;
+            if (
+              typeof parsed.key === "string" &&
+              parsed.key &&
+              typeof parsed.eventId === "string" &&
+              parsed.eventId &&
+              typeof parsed.channelId === "string" &&
+              parsed.channelId
+            ) {
+              // Replay in order — put() enforces last-write-wins + FIFO bound.
+              put(parsed.key, { eventId: parsed.eventId, channelId: parsed.channelId });
+            }
+          } catch {
+            // Tolerate a torn final line (crash mid-write) — skip it.
+          }
+        }
+        // Rewrite compacted, atomically (tmp + rename).
+        const tmp = `${journalPath}.tmp`;
+        fs.writeFileSync(tmp, serialize());
+        fs.renameSync(tmp, journalPath);
+        journalLines = map.size;
+        log(`buzz-mirror correlation: compacted journal, ${map.size} keys retained`);
+      }
+    } catch (err) {
+      // A journal we cannot read must not disturb the gateway — degrade to an
+      // empty in-memory map. The cross-restart guarantee is degraded until the
+      // journal is writable again, but the Telegram copy is unaffected.
+      log(
+        `buzz-mirror correlation: journal load failed, starting empty: ${(err as Error).message}`,
+      );
+      map.clear();
+      journalLines = 0;
+    }
+  }
+
+  let fd: number | null = null;
+  if (journalPath) {
+    try {
+      fd = fs.openSync(journalPath, "a");
+    } catch (err) {
+      log(`buzz-mirror correlation: could not open append fd: ${(err as Error).message}`);
+      fd = null;
+    }
+  }
+
+  function compactInPlace(): void {
+    if (!journalPath) return;
+    try {
+      // Close the append fd, rewrite from memory, reopen.
+      if (fd !== null) {
+        try {
+          fs.closeSync(fd);
+        } catch {
+          /* nothing to do */
+        }
+        fd = null;
+      }
+      const tmp = `${journalPath}.tmp`;
+      fs.writeFileSync(tmp, serialize());
+      fs.renameSync(tmp, journalPath);
+      journalLines = map.size;
+      fd = fs.openSync(journalPath, "a");
+    } catch (err) {
+      log(`buzz-mirror correlation: in-session compaction failed: ${(err as Error).message}`);
+    }
+  }
+
+  return {
+    get(key: string): CorrelationValue | undefined {
+      return map.get(key);
+    },
+    set(key: string, value: CorrelationValue): void {
+      put(key, value);
+      if (fd !== null && journalPath) {
+        try {
+          fs.writeSync(
+            fd,
+            JSON.stringify({ key, eventId: value.eventId, channelId: value.channelId }) + "\n",
+          );
+          fs.fsyncSync(fd);
+          journalLines++;
+          if (journalLines > capacity * COMPACTION_FACTOR) compactInPlace();
+        } catch (err) {
+          log(`buzz-mirror correlation: journal append failed: ${(err as Error).message}`);
+        }
+      }
+    },
+    size(): number {
+      return map.size;
+    },
+    close(): void {
+      if (fd !== null) {
+        try {
+          fs.closeSync(fd);
+        } catch {
+          /* nothing to do */
+        }
+        fd = null;
+      }
+    },
+  };
+}

--- a/telegram-plugin/gateway/buzz-mirror.ts
+++ b/telegram-plugin/gateway/buzz-mirror.ts
@@ -24,6 +24,7 @@
  */
 
 import { randomUUID } from "crypto";
+import { join } from "path";
 import type { OutboundToBuzzMessage } from "./ipc-protocol.js";
 import {
   resolveRoute,
@@ -32,6 +33,10 @@ import {
   type BuzzCoords,
   type Channel,
 } from "./channel-route.js";
+import {
+  createCorrelationStore,
+  type CorrelationStore,
+} from "./buzz-mirror-correlation-store.js";
 
 export type BuzzPeerSender = (msg: OutboundToBuzzMessage) => boolean;
 
@@ -47,6 +52,14 @@ export interface BuzzMirrorConfig {
    * threaded replies still work (they carry their own channelId).
    */
   defaultChannelId: string;
+  /**
+   * Absolute path to the durable msg→Buzz correlation journal (#4222). When
+   * set, the `${chatId}:${messageId}` → published-event map is persisted and
+   * reloaded on construction, so an `edit_message` correction survives a gateway
+   * restart. Omit (dev/one-shot/tests) to keep the map in-memory only — same
+   * bound, no durability. See `buzz-mirror-correlation-store.ts`.
+   */
+  correlationJournalPath?: string;
   /** Optional log sink (defaults to a no-op). */
   log?: (msg: string) => void;
 }
@@ -97,9 +110,20 @@ class BuzzMirror {
   private readonly pending = new Map<string, PendingPublish>();
   private readonly pendingOrder: string[] = [];
 
-  /** `${chatId}:${messageId}` → the published Buzz event it maps to. */
-  private readonly msgToBuzz = new Map<string, { eventId: string; channelId: string }>();
-  private readonly msgOrder: string[] = [];
+  /**
+   * `${chatId}:${messageId}` → the published Buzz event it maps to. Durable
+   * (JSONL journal) when `correlationJournalPath` is configured, so a correction
+   * survives a gateway restart (#4222); the store enforces the same MAX_TRACKED
+   * FIFO bound in memory and on disk.
+   */
+  private readonly msgToBuzz: CorrelationStore;
+
+  /**
+   * Count of `mirrorCorrection` calls whose key was genuinely absent from the
+   * correlation store (never mirrored, or evicted past the bound) — surfaced for
+   * the loud-miss regression assertion, not just the log line.
+   */
+  private correctionMisses = 0;
 
   /** `${chatId}:${messageId}` → live correction debounce timer. */
   private readonly correctionTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -107,11 +131,28 @@ class BuzzMirror {
   constructor(cfg: BuzzMirrorConfig) {
     this.cfg = cfg;
     this.log = cfg.log ?? (() => {});
+    this.msgToBuzz = createCorrelationStore({
+      journalPath: cfg.correlationJournalPath,
+      capacity: MAX_TRACKED,
+      log: this.log,
+    });
+  }
+
+  /** Test/introspection: number of corrections that missed the correlation store. */
+  getCorrectionMisses(): number {
+    return this.correctionMisses;
   }
 
   /** Register the transport to the duplex Buzz peer (ipcServer.sendToBuzzPeer). */
   attachSender(sender: BuzzPeerSender): void {
     this.sender = sender;
+  }
+
+  /** Release the correlation journal fd and cancel any pending correction timers. */
+  close(): void {
+    for (const timer of this.correctionTimers.values()) clearTimeout(timer);
+    this.correctionTimers.clear();
+    this.msgToBuzz.close();
   }
 
   private evict<T>(map: Map<string, T>, order: string[]): void {
@@ -187,7 +228,22 @@ class BuzzMirror {
   mirrorCorrection(input: MirrorCorrectionInput): void {
     try {
       const target = this.msgToBuzz.get(input.telegramMessageKey);
-      if (!target) return; // this Telegram message was never mirrored to Buzz
+      if (!target) {
+        // No mapping for this key — either it was genuinely never mirrored, or
+        // it aged out past MAX_TRACKED (memory AND journal). Either way the
+        // correction cannot land, so DON'T fail silently: emit a loud log and
+        // bump the miss counter so the gap is observable (#4222, audit "at
+        // minimum" ask). Pre-#4222 a restart also landed here (empty map) — the
+        // durable journal is what keeps that from being the common case.
+        this.correctionMisses++;
+        this.log(
+          `buzz-mirror: CORRECTION MISS — no Buzz correlation for Telegram ` +
+            `message ${input.telegramMessageKey}; the edit could NOT be mirrored ` +
+            `(never mirrored, or evicted past MAX_TRACKED=${MAX_TRACKED}). ` +
+            `Buzz copy may be stale. total_misses=${this.correctionMisses}`,
+        );
+        return;
+      }
 
       const existing = this.correctionTimers.get(input.telegramMessageKey);
       if (existing) clearTimeout(existing);
@@ -239,12 +295,11 @@ class BuzzMirror {
       return;
     }
     // Record the published event against each Telegram message it mirrored, so
-    // a later edit_message on any of them can target it for a correction.
+    // a later edit_message on any of them can target it for a correction. The
+    // store persists (durable journal) + enforces the MAX_TRACKED FIFO bound.
     for (const key of p.telegramMessageKeys) {
       this.msgToBuzz.set(key, { eventId: msg.eventId, channelId: p.channelId });
-      this.msgOrder.push(key);
     }
-    this.evict(this.msgToBuzz, this.msgOrder);
   }
 
   private publish(
@@ -285,12 +340,31 @@ let singleton: BuzzMirror | null = null;
  * every hook site is a no-op.
  */
 export function initBuzzMirror(cfg: BuzzMirrorConfig): BuzzMirror {
+  singleton?.close(); // release any prior instance's journal fd + timers
   singleton = new BuzzMirror(cfg);
   return singleton;
 }
 
 export function getBuzzMirror(): BuzzMirror | null {
   return singleton;
+}
+
+/**
+ * Resolve the durable msg→Buzz correlation journal path from env (#4222). Lives
+ * under the same `$TELEGRAM_STATE_DIR/buzz/` dir as the sidecar's dedup journal
+ * but at a DISTINCT filename — a collision on `journal.jsonl` would corrupt
+ * both. `BUZZ_MIRROR_CORRELATION_PATH` overrides. When `TELEGRAM_STATE_DIR` is
+ * unset (dev/one-shot), returns undefined so the store degrades to in-memory
+ * only rather than scattering a journal under the home dir.
+ */
+export function resolveCorrelationJournalPath(
+  env: Record<string, string | undefined> = process.env,
+): string | undefined {
+  const override = env.BUZZ_MIRROR_CORRELATION_PATH?.trim();
+  if (override) return override;
+  const stateDir = env.TELEGRAM_STATE_DIR?.trim();
+  if (!stateDir) return undefined;
+  return join(stateDir, "buzz", "mirror-correlation.jsonl");
 }
 
 /**
@@ -315,6 +389,7 @@ export function maybeBootBuzzMirror(
     mode,
     agentName: env.SWITCHROOM_AGENT_NAME?.trim() ?? "",
     defaultChannelId: env.BUZZ_CHANNEL_IDS?.trim() ?? "",
+    correlationJournalPath: resolveCorrelationJournalPath(env),
     log: (m) => process.stderr.write(`telegram gateway: buzz-mirror — ${m}\n`),
   });
   bm.attachSender(sender);
@@ -323,6 +398,7 @@ export function maybeBootBuzzMirror(
 
 /** Test-only: tear down the singleton so cases don't leak state into each other. */
 export function __resetBuzzMirrorForTests(): void {
+  singleton?.close();
   singleton = null;
 }
 

--- a/telegram-plugin/tests/buzz-mirror-correlation-store.test.ts
+++ b/telegram-plugin/tests/buzz-mirror-correlation-store.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createCorrelationStore,
+  type CorrelationFsLike,
+} from '../gateway/buzz-mirror-correlation-store.js'
+
+/**
+ * In-memory fake filesystem implementing CorrelationFsLike. Shared across store
+ * instances to simulate a gateway restart against the SAME journal — the core
+ * of the #4222 fix (an edit_message correction must survive a restart).
+ */
+function makeFakeFs(): CorrelationFsLike & { files: Map<string, string>; dirs: Set<string> } {
+  const files = new Map<string, string>()
+  const dirs = new Set<string>()
+  const fdPaths = new Map<number, string>()
+  let nextFd = 3
+  return {
+    files,
+    dirs,
+    existsSync: (p) => files.has(p) || dirs.has(p),
+    mkdirSync: (p) => { dirs.add(p) },
+    readFileSync: (p) => {
+      if (!files.has(p)) throw new Error(`ENOENT ${p}`)
+      return files.get(p)!
+    },
+    writeFileSync: (p, data) => { files.set(p, data) },
+    renameSync: (from, to) => {
+      files.set(to, files.get(from) ?? '')
+      files.delete(from)
+    },
+    openSync: (p) => {
+      if (!files.has(p)) files.set(p, '')
+      const fd = nextFd++
+      fdPaths.set(fd, p)
+      return fd
+    },
+    writeSync: (fd, data) => {
+      const p = fdPaths.get(fd)!
+      files.set(p, (files.get(p) ?? '') + data)
+    },
+    fsyncSync: () => { /* no-op */ },
+    closeSync: (fd) => { fdPaths.delete(fd) },
+  }
+}
+
+const JP = '/state/buzz/mirror-correlation.jsonl'
+
+describe('createCorrelationStore — durable msg→Buzz correlation (#4222)', () => {
+  it('replays a persisted mapping into a NEW store instance (restart survival)', () => {
+    const fs = makeFakeFs()
+    const a = createCorrelationStore({ journalPath: JP, fs })
+    a.set('555:1001', { eventId: 'evt-A', channelId: 'chan-A' })
+    a.close()
+
+    // Fresh instance over the SAME journal — the mapping must reload.
+    const b = createCorrelationStore({ journalPath: JP, fs })
+    expect(b.get('555:1001')).toEqual({ eventId: 'evt-A', channelId: 'chan-A' })
+    expect(b.size()).toBe(1)
+  })
+
+  it('last-write-wins on a re-set key across a restart', () => {
+    const fs = makeFakeFs()
+    const a = createCorrelationStore({ journalPath: JP, fs })
+    a.set('555:1', { eventId: 'evt-old', channelId: 'chan-A' })
+    a.set('555:1', { eventId: 'evt-new', channelId: 'chan-A' })
+    a.close()
+
+    const b = createCorrelationStore({ journalPath: JP, fs })
+    expect(b.get('555:1')).toEqual({ eventId: 'evt-new', channelId: 'chan-A' })
+    expect(b.size()).toBe(1)
+  })
+
+  it('in-memory-only mode (no journalPath) never touches the fs but still bounds', () => {
+    const fs = makeFakeFs()
+    const s = createCorrelationStore({ capacity: 2, fs })
+    s.set('a', { eventId: 'e1', channelId: 'c' })
+    s.set('b', { eventId: 'e2', channelId: 'c' })
+    s.set('c', { eventId: 'e3', channelId: 'c' })
+    expect(s.get('a')).toBeUndefined() // evicted (FIFO, capacity 2)
+    expect(s.size()).toBe(2)
+    expect(fs.files.size).toBe(0) // no journal written
+  })
+
+  it('enforces the FIFO capacity bound in memory AND on disk after compaction', () => {
+    const fs = makeFakeFs()
+    const capacity = 4
+    const a = createCorrelationStore({ journalPath: JP, fs, capacity })
+    // Insert more than capacity — oldest keys evict.
+    for (let i = 0; i < 20; i++) a.set(`k:${i}`, { eventId: `e${i}`, channelId: 'c' })
+    expect(a.size()).toBe(capacity)
+    expect(a.get('k:0')).toBeUndefined()
+    expect(a.get('k:19')).toEqual({ eventId: 'e19', channelId: 'c' })
+    a.close()
+
+    // Restart: boot compaction must keep the on-disk journal bounded too — a new
+    // instance sees exactly `capacity` keys, and the compacted journal file has
+    // no more than `capacity` lines.
+    const b = createCorrelationStore({ journalPath: JP, fs, capacity })
+    expect(b.size()).toBe(capacity)
+    const lines = (fs.files.get(JP) ?? '').split('\n').filter((l) => l.trim())
+    expect(lines.length).toBeLessThanOrEqual(capacity)
+    expect(b.get('k:19')).toEqual({ eventId: 'e19', channelId: 'c' })
+  })
+
+  it('re-compacts in-session so the journal never grows unbounded', () => {
+    const fs = makeFakeFs()
+    const capacity = 4
+    const s = createCorrelationStore({ journalPath: JP, fs, capacity })
+    // Churn far more writes than capacity; the in-session compaction (at
+    // capacity * COMPACTION_FACTOR appends) must keep the file bounded.
+    for (let i = 0; i < 200; i++) s.set(`k:${i}`, { eventId: `e${i}`, channelId: 'c' })
+    const lines = (fs.files.get(JP) ?? '').split('\n').filter((l) => l.trim())
+    // Bounded by roughly capacity * COMPACTION_FACTOR (4*4=16) + the compacted
+    // baseline — assert it stays a small multiple of capacity, never 200.
+    expect(lines.length).toBeLessThan(capacity * 8)
+    expect(s.size()).toBe(capacity)
+    s.close()
+  })
+
+  it('tolerates a torn final journal line (crash mid-write)', () => {
+    const fs = makeFakeFs()
+    fs.dirs.add('/state/buzz')
+    fs.files.set(
+      JP,
+      JSON.stringify({ key: '1:1', eventId: 'e1', channelId: 'c' }) + '\n' + '{"key":"1:2","eventId', // truncated
+    )
+    const s = createCorrelationStore({ journalPath: JP, fs })
+    expect(s.get('1:1')).toEqual({ eventId: 'e1', channelId: 'c' })
+    expect(s.get('1:2')).toBeUndefined()
+  })
+
+  it('degrades to empty in-memory when the journal cannot be read', () => {
+    const fs = makeFakeFs()
+    fs.dirs.add('/state/buzz')
+    fs.files.set(JP, 'exists-but-unreadable')
+    const throwingFs: CorrelationFsLike = {
+      ...fs,
+      readFileSync: () => { throw new Error('EIO') },
+    }
+    const s = createCorrelationStore({ journalPath: JP, fs: throwingFs })
+    // No crash; store is empty and still usable.
+    expect(s.size()).toBe(0)
+    s.set('1:1', { eventId: 'e1', channelId: 'c' })
+    expect(s.get('1:1')).toEqual({ eventId: 'e1', channelId: 'c' })
+  })
+})

--- a/telegram-plugin/tests/buzz-mirror.test.ts
+++ b/telegram-plugin/tests/buzz-mirror.test.ts
@@ -1,8 +1,12 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import {
   initBuzzMirror,
   getBuzzMirror,
   maybeBootBuzzMirror,
+  resolveCorrelationJournalPath,
   __resetBuzzMirrorForTests,
   CORRECTION_DEBOUNCE_MS,
 } from '../gateway/buzz-mirror.js'
@@ -201,6 +205,110 @@ describe('BuzzMirror.mirrorCorrection — debounced, only for mirrored messages'
       targetEventId: 'published-evt',
     })
     vi.useRealTimers()
+  })
+})
+
+describe('BuzzMirror correction correlation SURVIVES a gateway restart (#4222)', () => {
+  let dir: string
+  let journalPath: string
+
+  beforeEach(() => {
+    __resetBuzzMirrorForTests()
+    vi.useFakeTimers()
+    dir = mkdtempSync(join(tmpdir(), 'buzz-mirror-corr-'))
+    journalPath = join(dir, 'buzz', 'mirror-correlation.jsonl')
+  })
+  afterEach(() => {
+    __resetBuzzMirrorForTests()
+    vi.useRealTimers()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  function bootMirror(sender: (m: OutboundToBuzzMessage) => boolean) {
+    const m = initBuzzMirror({
+      mode: 'both',
+      agentName: 'klanker',
+      defaultChannelId: 'default-chan',
+      correlationJournalPath: journalPath,
+    })
+    m.attachSender(sender)
+    return m
+  }
+
+  it('an edit_message on a pre-restart-mirrored answer STILL emits the superseding correction', () => {
+    // --- Session 1: mirror an answer and record its published Buzz event. ---
+    const sender1 = vi.fn(() => true)
+    const m1 = bootMirror(sender1)
+    m1.mirrorReplyDelivered({
+      scrubbedText: 'answer',
+      ownerOriginChannel: 'buzz',
+      ownerBuzzCoords: BUZZ_COORDS,
+      ownerEchoed: true,
+      hasRecentDifferentOriginTurn: false,
+      telegramMessageKeys: ['555:1001'],
+    })
+    const correlationId = sender1.mock.calls[0][0].correlationId
+    m1.onPublishResult({ correlationId, ok: true, eventId: 'published-evt' })
+
+    // --- Restart: a NEW BuzzMirror over the SAME journal (map reloads from disk).
+    __resetBuzzMirrorForTests() // closes m1's journal fd
+    const sender2 = vi.fn(() => true)
+    const m2 = bootMirror(sender2)
+
+    // An edit lands AFTER the restart on a message mirrored BEFORE it. On today's
+    // in-memory-only code the reloaded map is empty and this is silently skipped;
+    // with the durable journal the correction still fires.
+    m2.mirrorCorrection({ telegramMessageKey: '555:1001', scrubbedText: 'corrected' })
+    vi.advanceTimersByTime(CORRECTION_DEBOUNCE_MS + 1000)
+
+    expect(sender2).toHaveBeenCalledTimes(1)
+    const corr = sender2.mock.calls[0][0]
+    expect(corr.payload).toEqual({
+      kind: 'correction',
+      text: 'corrected',
+      targetEventId: 'published-evt',
+    })
+    expect(m2.getCorrectionMisses()).toBe(0)
+  })
+
+  it('a correction on a truly-unknown key logs a LOUD miss (never silent) and never publishes', () => {
+    const logs: string[] = []
+    __resetBuzzMirrorForTests()
+    const sender = vi.fn(() => true)
+    const m = initBuzzMirror({
+      mode: 'both',
+      agentName: 'klanker',
+      defaultChannelId: 'default-chan',
+      correlationJournalPath: journalPath,
+      log: (msg) => logs.push(msg),
+    })
+    m.attachSender(sender)
+
+    m.mirrorCorrection({ telegramMessageKey: '555:404', scrubbedText: 'fixed' })
+    vi.advanceTimersByTime(CORRECTION_DEBOUNCE_MS + 1000)
+
+    expect(sender).not.toHaveBeenCalled()
+    expect(m.getCorrectionMisses()).toBe(1)
+    expect(logs.some((l) => /CORRECTION MISS/.test(l))).toBe(true)
+  })
+})
+
+describe('resolveCorrelationJournalPath — distinct from the sidecar dedup journal', () => {
+  it('derives mirror-correlation.jsonl under $TELEGRAM_STATE_DIR/buzz (NOT journal.jsonl)', () => {
+    const p = resolveCorrelationJournalPath({ TELEGRAM_STATE_DIR: '/state/agent/telegram' })
+    expect(p).toBe('/state/agent/telegram/buzz/mirror-correlation.jsonl')
+    // Must not collide with the sidecar's journal.jsonl on the shared buzz dir.
+    expect(p).not.toContain('journal.jsonl')
+  })
+
+  it('honours the BUZZ_MIRROR_CORRELATION_PATH override', () => {
+    expect(
+      resolveCorrelationJournalPath({ BUZZ_MIRROR_CORRELATION_PATH: '/custom/corr.jsonl' }),
+    ).toBe('/custom/corr.jsonl')
+  })
+
+  it('returns undefined (in-memory only) when TELEGRAM_STATE_DIR is unset', () => {
+    expect(resolveCorrelationJournalPath({})).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary
The hub-side `BuzzMirror` kept the `${chatId}:${messageId}` → published Buzz event map (`msgToBuzz`) **in memory only**, as a bounded FIFO (`MAX_TRACKED=4096`). After a gateway restart that map is empty, so an `edit_message` correction to an answer mirrored *before* the restart was **silently skipped** in `mirrorCorrection` (`if (!target) return`) — the Buzz copy went stale with no signal (#4222).

This is the foundational, contract-safe correlation the Buzz enablement + Phase 3b (thread continuity) plans depend on.

## Why
- Advances the **telegram-and-buzz-only** delivery outcome: a mirrored answer's correction must not be lost across a restart.
- Job spec: Buzz co-channel thread continuity (Phase 3b prerequisite).
- Also delivers the audit PR's "at minimum" ask: a genuine correlation miss is now **loud**, not silent.

## What
- **New module** `telegram-plugin/gateway/buzz-mirror-correlation-store.ts`: an in-memory insertion-ordered map backed by an append-only JSONL journal, fsync'd per record — mirroring the sidecar dedup store (`src/buzz-gateway/dedup.ts`). Boot compaction + in-session re-compaction keep the journal bounded to the in-memory FIFO capacity. Filesystem injected for unit tests.
- **Distinct journal path**: `$TELEGRAM_STATE_DIR/buzz/mirror-correlation.jsonl` — deliberately NOT the sidecar's `journal.jsonl` on the shared `buzz/` dir (a collision would corrupt both). Overridable via `BUZZ_MIRROR_CORRELATION_PATH`.
- **`buzz-mirror.ts` wiring**: `BuzzMirror` loads the journal on construction (corrections survive restart); `mirrorCorrection` on a truly-unknown key now emits a **LOUD log + bumps a miss counter** instead of returning silently. In-memory-only fallback preserved when no path is configured.
- No `gateway.ts` change — `maybeBootBuzzMirror` already the wiring seam; path resolution happens inside it (keeps the gateway line-ratchet untouched).

## Test plan
Scoped: `vitest run telegram-plugin/tests/buzz-mirror-correlation-store.test.ts telegram-plugin/tests/buzz-mirror.test.ts` — 24 passing.
- `buzz-mirror-correlation-store.test.ts`: restart replay, last-write-wins, FIFO bound in memory **and** on disk after compaction, in-session compaction bound, torn-line tolerance, unreadable-journal degradation.
- `buzz-mirror.test.ts`: **restart-survival** (publish → new `BuzzMirror` over the same journal → `mirrorCorrection` still emits the superseding correction) — verified to **FAIL** on in-memory-only behaviour and pass on this branch; loud-miss on unknown key (asserts counter + log); journal-path derivation distinct from the sidecar's.
- `tsc` clean over changed files; `check-gateway-line-ratchet`, `check-bot-api-wrapping`, `check-plugin-references`, `check-agent-state-dir-hermeticity`, `check-no-pii-secrets` pass locally.

## Risk
Low. Dark by default (Buzz env unset in this branch). No-journal fallback reproduces prior behaviour exactly.

Fixes #4222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)