### PR TITLE
test(buzz): discriminating NIP-10 marker cases for resolveReplyParent (follow-up #4278)

### DIFF
--- a/src/buzz-gateway/inbound-map.test.ts
+++ b/src/buzz-gateway/inbound-map.test.ts
@@ -89,6 +89,49 @@ describe("mapBuzzEvent", () => {
     expect(inbound!.meta.buzz_thread_root).toBe(root);
   });
 
+  it("prefers the NIP-10 reply marker over positional order when the reply tag is not last", () => {
+    const parent = "parentid".padEnd(64, "1");
+    const root = "rootid".padEnd(64, "0");
+    const e = ev({
+      tags: [
+        ["h", "group-uuid"],
+        ["e", parent, "", "reply"], // reply marker in FIRST position
+        ["e", root, "", "root"], // root marker last
+      ],
+    });
+    const inbound = mapBuzzEvent(e, ctx);
+    expect(inbound!.meta.buzz_reply_to).toBe(parent);
+    expect(inbound!.meta.buzz_thread_root).toBe(root);
+    expect(inbound!.text).toContain(`buzz_reply_to="${parent}"`);
+  });
+
+  it("omits buzz_reply_to when the only marked e-tag is a mention", () => {
+    const mention = "mentionid".padEnd(64, "2");
+    const e = ev({
+      tags: [["h", "group-uuid"], ["e", mention, "", "mention"]],
+    });
+    const inbound = mapBuzzEvent(e, ctx);
+    expect(inbound!.meta.buzz_reply_to).toBeUndefined();
+    expect("buzz_reply_to" in inbound!.meta).toBe(false);
+    expect(inbound!.text).not.toContain("buzz_reply_to=");
+  });
+
+  it("resolves buzz_reply_to to the root when a trailing mention marker follows the root", () => {
+    const root = "rootid".padEnd(64, "0");
+    const mention = "quoteid".padEnd(64, "3");
+    const e = ev({
+      tags: [
+        ["h", "group-uuid"],
+        ["e", root, "", "root"],
+        ["e", mention, "", "mention"], // mention marker LAST
+      ],
+    });
+    const inbound = mapBuzzEvent(e, ctx);
+    expect(inbound!.meta.buzz_reply_to).toBe(root);
+    expect(inbound!.meta.buzz_thread_root).toBe(root);
+    expect(inbound!.text).toContain(`buzz_reply_to="${root}"`);
+  });
+
   it("sets buzz_reply_to equal to the root when only a root e-tag exists", () => {
     const root = "onlyroot".padEnd(64, "0");
     const e = ev({


### PR DESCRIPTION
## Summary
Adds three test cases to `src/buzz-gateway/inbound-map.test.ts` that discriminate the NIP-10 marker-resolution branch of `resolveReplyParent` (`src/buzz-gateway/inbound-map.ts`). Test-only; no implementation change.

## Why
Adversarial review of #4278 found a MAJOR test gap: the four reply-parent tests it shipped all placed the reply/root-marked e-tag **last**, so a mutant that deletes the entire marker branch —
```ts
return eTags.length ? eTags[eTags.length - 1][1] : undefined;
```
— still passed all four, because positional-last fallback returned the same answer. The `mention` branch was entirely untested. #4278 merged (squash `c454a3d0`) before that gap could be closed, so this lands it as a fast-follow.

## What
Three cases that FAIL under the marker-branch-deletion mutant:
1. **Marker precedence over position** — reply-marked tag in first position, root last -> `buzz_reply_to` = the marked parent (positional-last would wrongly give root).
2. **Mention-only -> omitted** — a lone `mention`-marked e-tag -> `buzz_reply_to` absent (mutant returns the mention id).
3. **Root + trailing mention -> root** — `root` then trailing `mention` -> resolves to root (positional-last would wrongly give the mention).

## Test plan
- `vitest run src/buzz-gateway/inbound-map.test.ts` -> 12 passed on main's implementation.
- Applied the reviewer's mutant to `resolveReplyParent`: the 3 new tests FAIL (3 failed | 9 passed), the original 4 marker/positional tests still PASS — proving the new cases discriminate the marker branch and the old ones did not. Reverted; 12 pass. `tsc --noEmit` clean.

## Risk
None — test-only, no runtime change.

## Job spec
Guards the NIP-10 reply-parent surfacing behind the Buzz inbound path (`reference/jobs/` Buzz channel messaging); tightens test coverage of an already-merged feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)