### PR TITLE
docs(buzz): correct pinned_relay_digest + channels.buzz cascade (follow-up #4276)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,7 +82,7 @@ Each field type has specific merge behavior when values exist at multiple layers
 | `cli_args` | concatenate | Escape hatch: extra `exec claude` flags |
 | `google_workspace` | deep merge | Google Drive/Docs/Sheets/Calendar integration. `google_client_id` / `google_client_secret` are install-wide (top level only); `tier` + `approvers` cascade per-agent. See § Google Workspace below. |
 | `notion_workspace` | deep merge top-level; per-agent `databases:` list REPLACES (does not concatenate) | Notion integration. Top-level `vault_key` + `databases:` map cascade via deep merge so a profile can add a DB without clobbering top-level entries. The per-agent `databases:` allowlist is **override** — an agent's list replaces the parent's, so a specialist agent inheriting a profile can narrow to fewer DBs. See § Notion Workspace below and [notion-integration.md](notion-integration.md). |
-| `channels.buzz` | override | Buzz desktop co-channel (a closed NIP-29 Nostr relay + one per-agent sidecar). **Dark by default** — omit the block or set `enabled: false` and nothing projects a live channel. See § Buzz co-channel below and [reference/jobs/use-my-team-from-the-desktop.md](../reference/jobs/use-my-team-from-the-desktop.md). |
+| `channels.buzz` | per-field merge (agent wins) | Buzz desktop co-channel (a closed NIP-29 Nostr relay + one per-agent sidecar). **Dark by default** — omit the block or set `enabled: false` and nothing projects a live channel. See § Buzz co-channel below and [reference/jobs/use-my-team-from-the-desktop.md](../reference/jobs/use-my-team-from-the-desktop.md). |
 
 ## Buzz co-channel — `channels.buzz`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,7 +116,7 @@ name**; the sidecar broker-fetches the secret in-process at boot.
 | `channels.buzz.authorized_pubkeys` | override | no (default `[]`) | Additional pubkeys (`npub` or hex) whose signed events may become turns. Effective allowlist = this ∪ `{operator_pubkey}`. Empty by default (operator-only). Projects `BUZZ_AUTHORIZED_PUBKEYS` (comma-joined) when non-empty. |
 | `channels.buzz.pubkey_names` | override | no (default `{}`) | Optional petnames: hex/`npub` pubkey → display name, used to label the sender on injected turns. Projects `BUZZ_PUBKEY_NAMES` (comma-joined `key=value`) when non-empty. |
 | `channels.buzz.channel_map` | override | no (default `{}`) | Optional map of extra group UUIDs → friendly labels. Not projected to env today. |
-| `channels.buzz.pinned_relay_digest` | override | no | **Reserved — not yet consumed.** Intended pinned relay image digest (M4); nothing projects or reads it today. Kept in the schema so the digest-pin can be wired later without a config-shape change. |
+| `channels.buzz.pinned_relay_digest` | override | no | **Reserved — no consumer.** Intended pinned relay image digest (M4); the existing compat-check (`compat-check.ts`) validates only the wire contract and never reads this field. Kept in the schema so the digest-pin can be wired later without a config-shape change. |
 
 ## Permission mode & auto-accept
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2399,10 +2399,11 @@ export const BuzzChannelSchema = z
       .string()
       .optional()
       .describe(
-        "Pinned relay image digest (M4). RESERVED — not yet consumed: nothing " +
-        "projects or reads this field today (no compat-check exists yet). Kept " +
-        "in the schema so the intended digest-pin can be wired without a config " +
-        "shape change.",
+        "Pinned relay image digest (M4). RESERVED — no consumer of this field " +
+        "exists; the existing compat-check (compat-check.ts) validates only " +
+        "the wire contract (AUTH kind, message kind, tag names) and does not " +
+        "read this field. Kept in the schema so the intended digest-pin can " +
+        "be wired without a config shape change.",
       ),
   })
   .strict();


### PR DESCRIPTION
## Summary
- #4276 ("docs(buzz): truth-up") landed with two inaccurate statements of its own — a truth-up PR must not introduce a new wrong claim.
- `src/config/schema.ts` `pinned_relay_digest`'s `.describe(...)` claimed "no compat-check exists yet." False: `src/buzz-gateway/compat-check.ts` is committed and CI-exercised (see `src/buzz-gateway/compat-check.test.ts`, 9 passing tests). Reworded to the accurate claim: the field itself has no consumer, and the existing compat-check validates only the wire contract (AUTH kind, message kind, tag names) and never reads `pinned_relay_digest`.
- `docs/configuration.md`'s new top-level `channels.buzz` table row labeled Cascade as `override` (block-replace). Actual behavior is per-field, one-level shallow merge with the agent winning per field (`src/config/merge.ts:592-613`) — the doc's own cascade summary already lists `channels` under "Per-field merge". Corrected the Cascade cell to `per-field merge (agent wins)`. Left the per-field leaf rows *inside* the buzz section untouched — their `override` cells are correct (they match the `channels.telegram.*` leaf convention).

No behavior change — comment/doc text only.

Job spec: `reference/jobs/use-my-team-from-the-desktop.md`

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `./node_modules/.bin/vitest run src/config/schema.test.ts src/config/merge.test.ts src/buzz-gateway/compat-check.test.ts` — 214/214 passing
- [x] `node scripts/check-stale-tool-descriptions.mjs` clean
- [x] `node scripts/check-no-pii-secrets.mjs` clean
- [x] Verified `src/buzz-gateway/compat-check.ts` content directly — it validates only `nip42_auth_kind`, `message_kind`, `auth_tags`; no reference to `pinned_relay_digest`
- [x] Verified `src/config/merge.ts:592-613` — per-channel shallow merge, agent wins, applies generically to all `channels.*` keys including `buzz`

## Risk
Doc/comment-only, zero behavior change.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>