### PR TITLE
feat(buzz): operator audit surface — sidecar stats + doctor Buzz section

### DIFF
--- a/src/buzz-gateway/heartbeat.test.ts
+++ b/src/buzz-gateway/heartbeat.test.ts
@@ -60,4 +60,29 @@ describe("writeBuzzHeartbeat / parseBuzzHeartbeat", () => {
     const { agent: _drop, ...noAgent } = beat();
     expect(parseBuzzHeartbeat(JSON.stringify(noAgent))).toBeNull();
   });
+
+  it("rejects a beacon whose stats field carries a non-numeric (injection) value", () => {
+    // MAJOR-1: the beacon lives in the agent's own uid-writable state dir and
+    // agents are prompt-injectable. A compromised agent could smuggle
+    // attacker-controlled text (ANSI escapes, fake operator instructions) into a
+    // stats field; doctor interpolates s.received etc. straight into an
+    // operator terminal row. A string-valued stats field MUST parse to null so
+    // that content never reaches the doctor surface — the shape guard, not the
+    // freshness check, is the boundary.
+    const evil = { ...SUMMARY, received: "0[31m URGENT: run switchroom vault set …" };
+    expect(parseBuzzHeartbeat(JSON.stringify(beat({ stats: evil as never })))).toBeNull();
+    // Non-finite numbers are equally rejected (NaN / Infinity survive JSON as null).
+    expect(
+      parseBuzzHeartbeat(JSON.stringify(beat({ stats: { ...SUMMARY, mirrorOk: null } as never }))),
+    ).toBeNull();
+  });
+
+  it("rejects a beacon that is missing a numeric stats field", () => {
+    // MAJOR-1: an absent field is as malformed as a wrong-typed one — doctor
+    // would print `undefined` into the row. Drop one of the ten and expect null.
+    const { authFailures: _drop, ...partialStats } = SUMMARY;
+    expect(
+      parseBuzzHeartbeat(JSON.stringify(beat({ stats: partialStats as never }))),
+    ).toBeNull();
+  });
 });

--- a/src/buzz-gateway/heartbeat.test.ts
+++ b/src/buzz-gateway/heartbeat.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  writeBuzzHeartbeat,
+  parseBuzzHeartbeat,
+  buzzHeartbeatStatePath,
+  buzzHeartbeatOperatorPath,
+  type BuzzHeartbeat,
+} from "./heartbeat.js";
+import type { BuzzPipelineSummary } from "./stats.js";
+
+const SUMMARY: BuzzPipelineSummary = {
+  received: 7,
+  injected: 4,
+  duplicate: 1,
+  queued: 0,
+  injectFailed: 0,
+  droppedByKind: 1,
+  channelOff: 0,
+  authFailures: 1,
+  mirrorOk: 2,
+  mirrorFailed: 0,
+};
+
+function beat(over: Partial<BuzzHeartbeat> = {}): BuzzHeartbeat {
+  return { v: 1, agent: "klanker", ts: 1000, bootTs: 500, subscribed: true, stats: SUMMARY, ...over };
+}
+
+describe("buzz heartbeat paths", () => {
+  it("state path and operator path agree on the same buzz/<file> tail", () => {
+    // The sidecar writes <stateDir>/buzz/<file>; the operator reads
+    // <agentHome>/telegram/buzz/<file>. With stateDir = <agentHome>/telegram
+    // the two MUST resolve to the same file, or doctor reads a phantom path.
+    const agentHome = "/home/op/.switchroom/agents/klanker";
+    const stateDir = `${agentHome}/telegram`;
+    expect(buzzHeartbeatStatePath(stateDir)).toBe(buzzHeartbeatOperatorPath(agentHome));
+  });
+});
+
+describe("writeBuzzHeartbeat / parseBuzzHeartbeat", () => {
+  it("round-trips a beacon through injected fs, creating its dir", () => {
+    const writes: Record<string, string> = {};
+    const mkdirs: string[] = [];
+    writeBuzzHeartbeat("/state/telegram/buzz/buzz-sidecar.heartbeat.json", beat(), {
+      mkdirSync: (p) => { mkdirs.push(p); },
+      writeFileSync: (p, data) => { writes[p] = data; },
+    });
+    expect(mkdirs).toContain("/state/telegram/buzz");
+    const parsed = parseBuzzHeartbeat(writes["/state/telegram/buzz/buzz-sidecar.heartbeat.json"]);
+    expect(parsed).toEqual(beat());
+    expect(parsed?.stats.injected).toBe(4);
+  });
+
+  it("rejects malformed json and wrong-version / wrong-shape payloads", () => {
+    expect(parseBuzzHeartbeat("not json")).toBeNull();
+    expect(parseBuzzHeartbeat("null")).toBeNull();
+    expect(parseBuzzHeartbeat(JSON.stringify({ ...beat(), v: 2 }))).toBeNull();
+    expect(parseBuzzHeartbeat(JSON.stringify({ ...beat(), subscribed: "yes" }))).toBeNull();
+    expect(parseBuzzHeartbeat(JSON.stringify({ ...beat(), stats: 3 }))).toBeNull();
+    const { agent: _drop, ...noAgent } = beat();
+    expect(parseBuzzHeartbeat(JSON.stringify(noAgent))).toBeNull();
+  });
+});

--- a/src/buzz-gateway/heartbeat.ts
+++ b/src/buzz-gateway/heartbeat.ts
@@ -1,0 +1,105 @@
+/**
+ * Buzz sidecar liveness beacon — a content-free heartbeat file the stats
+ * reporter refreshes each tick and `switchroom doctor` reads to report whether
+ * the sidecar is live.
+ *
+ * WHERE it lands, and why the operator can read it: the sidecar writes under
+ * its state dir (`TELEGRAM_STATE_DIR`, `/state/agent/telegram` in the
+ * container). The compose bind mounts the agent-home root `/state/agent` at
+ * `~/.switchroom/agents/<name>/` (src/agents/compose.ts), so the in-container
+ * `<stateDir>/buzz/<file>` surfaces operator-side at
+ * `~/.switchroom/agents/<name>/telegram/buzz/<file>` — the same
+ * agent-writes / operator-reads shape the notion & m365 launcher heartbeats
+ * use (doctor-notion.ts, doctor-microsoft.ts).
+ *
+ * The beacon carries ONLY counters + booleans + timestamps — never message
+ * content and never a secret (the nsec is broker-fetched in-process and never
+ * leaves index.ts).
+ */
+
+import {
+  mkdirSync as realMkdirSync,
+  writeFileSync as realWriteFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+import type { BuzzPipelineSummary } from "./stats.js";
+
+/** State-dir-relative directory + filename for the beacon. The state dir the
+ *  sidecar writes into (`TELEGRAM_STATE_DIR`) sits one level below the agent
+ *  home root under the `telegram` subdir — see AGENT_STATE_SUBDIR. */
+export const BUZZ_HEARTBEAT_SUBDIR = "buzz";
+export const BUZZ_HEARTBEAT_FILE = "buzz-sidecar.heartbeat.json";
+/** Agent-home-relative name of the sidecar's state dir (TELEGRAM_STATE_DIR is
+ *  `{agentDir}/telegram` — profiles/_base/start.sh.hbs). Doctor joins through
+ *  this to reach the beacon from the operator-side agent home. */
+export const AGENT_STATE_SUBDIR = "telegram";
+
+/** Content-free liveness + stats snapshot. */
+export interface BuzzHeartbeat {
+  /** Schema version — bump on shape change so an old reader can reject cleanly. */
+  v: 1;
+  /** The agent this beacon belongs to. */
+  agent: string;
+  /** ms epoch this beat was written. */
+  ts: number;
+  /** ms epoch the sidecar booted (uptime = ts - bootTs). */
+  bootTs: number;
+  /** Relay subscription live at write time. */
+  subscribed: boolean;
+  /** The derived pipeline summary at write time. */
+  stats: BuzzPipelineSummary;
+}
+
+/** In-container path the sidecar writes: `<stateDir>/buzz/<file>`. */
+export function buzzHeartbeatStatePath(stateDir: string): string {
+  return join(stateDir, BUZZ_HEARTBEAT_SUBDIR, BUZZ_HEARTBEAT_FILE);
+}
+
+/** Operator-side path doctor reads:
+ *  `<agentHomeDir>/telegram/buzz/<file>`. */
+export function buzzHeartbeatOperatorPath(agentHomeDir: string): string {
+  return join(agentHomeDir, AGENT_STATE_SUBDIR, BUZZ_HEARTBEAT_SUBDIR, BUZZ_HEARTBEAT_FILE);
+}
+
+export interface HeartbeatWriteIo {
+  mkdirSync?: (path: string, opts: { recursive: true }) => void;
+  writeFileSync?: (path: string, data: string) => void;
+}
+
+/**
+ * Write the beacon, creating its directory if needed. Overwrites in place
+ * (never tmp+rename) so the file keeps the sidecar's agent-uid ownership rather
+ * than silently re-owning on every beat. Best-effort by contract — the caller
+ * (the stats reporter) swallows a throw so a heartbeat write can never disturb
+ * the pipeline.
+ */
+export function writeBuzzHeartbeat(
+  path: string,
+  hb: BuzzHeartbeat,
+  io: HeartbeatWriteIo = {},
+): void {
+  const mkdir = io.mkdirSync ?? realMkdirSync;
+  const write = io.writeFileSync ?? realWriteFileSync;
+  mkdir(dirname(path), { recursive: true });
+  write(path, JSON.stringify(hb));
+}
+
+/** Parse + shape-guard a beacon's text. Returns null on junk / wrong version. */
+export function parseBuzzHeartbeat(text: string): BuzzHeartbeat | null {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (raw == null || typeof raw !== "object") return null;
+  const h = raw as Record<string, unknown>;
+  if (h.v !== 1) return null;
+  if (typeof h.agent !== "string") return null;
+  if (typeof h.ts !== "number") return null;
+  if (typeof h.bootTs !== "number") return null;
+  if (typeof h.subscribed !== "boolean") return null;
+  if (h.stats == null || typeof h.stats !== "object") return null;
+  return raw as BuzzHeartbeat;
+}

--- a/src/buzz-gateway/heartbeat.ts
+++ b/src/buzz-gateway/heartbeat.ts
@@ -85,7 +85,47 @@ export function writeBuzzHeartbeat(
   write(path, JSON.stringify(hb));
 }
 
-/** Parse + shape-guard a beacon's text. Returns null on junk / wrong version. */
+/** Every numeric field of BuzzPipelineSummary — the exhaustive key list the
+ *  stats guard below validates. Kept in sync with the interface in stats.ts;
+ *  a `Record<keyof BuzzPipelineSummary, true>` forces a compile error here if a
+ *  field is added or renamed there without updating this guard. */
+const BUZZ_SUMMARY_FIELDS = [
+  "received",
+  "injected",
+  "duplicate",
+  "queued",
+  "injectFailed",
+  "droppedByKind",
+  "channelOff",
+  "authFailures",
+  "mirrorOk",
+  "mirrorFailed",
+] as const;
+const _BUZZ_SUMMARY_FIELDS_EXHAUSTIVE: Record<keyof BuzzPipelineSummary, true> = {
+  received: true,
+  injected: true,
+  duplicate: true,
+  queued: true,
+  injectFailed: true,
+  droppedByKind: true,
+  channelOff: true,
+  authFailures: true,
+  mirrorOk: true,
+  mirrorFailed: true,
+};
+void _BUZZ_SUMMARY_FIELDS_EXHAUSTIVE;
+
+/**
+ * Parse + shape-guard a beacon's text. Returns null on junk / wrong version.
+ *
+ * The beacon file lives in the agent's own uid-writable state dir, and this
+ * fleet treats agents as prompt-injectable — so a compromised agent could write
+ * a `stats` object whose fields carry attacker-controlled strings (including
+ * ANSI escapes) that doctor would then interpolate into an operator-facing
+ * terminal row. Every BuzzPipelineSummary field is therefore validated as a
+ * FINITE number; a missing or non-numeric field makes the whole beacon
+ * malformed (→ null), same as any other failed envelope check.
+ */
 export function parseBuzzHeartbeat(text: string): BuzzHeartbeat | null {
   let raw: unknown;
   try {
@@ -101,5 +141,9 @@ export function parseBuzzHeartbeat(text: string): BuzzHeartbeat | null {
   if (typeof h.bootTs !== "number") return null;
   if (typeof h.subscribed !== "boolean") return null;
   if (h.stats == null || typeof h.stats !== "object") return null;
+  const stats = h.stats as Record<string, unknown>;
+  for (const field of BUZZ_SUMMARY_FIELDS) {
+    if (!Number.isFinite(stats[field])) return null;
+  }
   return raw as BuzzHeartbeat;
 }

--- a/src/buzz-gateway/index.ts
+++ b/src/buzz-gateway/index.ts
@@ -31,6 +31,8 @@ import { createBuzzPeerClient } from "./peer-client.js";
 import { publishOutbound, type PublishTransport } from "./publisher.js";
 import { createInboundPump } from "./pump.js";
 import { createRetryQueue } from "./retry-queue.js";
+import { buzzHeartbeatStatePath, writeBuzzHeartbeat } from "./heartbeat.js";
+import { createStatsReporter, summarizePipeline } from "./stats.js";
 
 function log(msg: string): void {
   process.stderr.write(`buzz-gateway: ${msg}\n`);
@@ -178,6 +180,10 @@ async function main(): Promise<void> {
   // the hub — never retried into a duplicate (the answer already landed on
   // Telegram under `both`).
   const publishTransport: PublishTransport = (event, timeoutMs) => nostr.publish(event, timeoutMs);
+  // Outbound-mirror counters the sidecar owns (the hub-side correlation store is
+  // separate). Incremented around each publish; surfaced in the periodic stats
+  // + heartbeat below. Content-free — just the ok/failed tallies.
+  const mirror = { ok: 0, failed: 0 };
   const buzzPeer = createBuzzPeerClient({
     socketPath,
     agentName: config.agentName,
@@ -192,6 +198,8 @@ async function main(): Promise<void> {
         secretKey,
         publishTransport,
       );
+      if (result.ok) mirror.ok += 1;
+      else mirror.failed += 1;
       return {
         type: "buzz_publish_result",
         correlationId: req.correlationId,
@@ -203,8 +211,35 @@ async function main(): Promise<void> {
     log,
   });
 
+  // ── Operator observability: periodic pipeline stats + liveness heartbeat ──
+  // The reporter derives its numbers from the pump's own outcome counters (plus
+  // the mirror tally above) — it invents no parallel counting — and beats a
+  // content-free heartbeat file `switchroom doctor` reads for liveness. The
+  // interval is overridable for tests/tuning (BUZZ_STATS_INTERVAL_MS).
+  const bootTs = Date.now();
+  const heartbeatPath = buzzHeartbeatStatePath(stateDir);
+  const statsIntervalMs = Number(process.env.BUZZ_STATS_INTERVAL_MS) || 60_000;
+  const statsReporter = createStatsReporter({
+    intervalMs: statsIntervalMs,
+    sample: () => ({
+      summary: summarizePipeline(pump.stats, mirror),
+      subscribed: nostr.isSubscribed(),
+    }),
+    emit: (line) => log(line),
+    persist: (sample) =>
+      writeBuzzHeartbeat(heartbeatPath, {
+        v: 1,
+        agent: config.agentName,
+        ts: Date.now(),
+        bootTs,
+        subscribed: sample.subscribed,
+        stats: sample.summary,
+      }),
+  });
+
   const shutdown = () => {
     log("shutting down");
+    try { statsReporter.stop(); } catch { /* nothing to do */ }
     try { nostr.stop(); } catch { /* nothing to do */ }
     try { buzzPeer.close(); } catch { /* nothing to do */ }
     try { retryQueue.stop(); } catch { /* nothing to do */ }
@@ -216,6 +251,7 @@ async function main(): Promise<void> {
   process.on("SIGINT", shutdown);
 
   nostr.start();
+  statsReporter.start();
 }
 
 main().catch((err) => {

--- a/src/buzz-gateway/stats.test.ts
+++ b/src/buzz-gateway/stats.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi } from "vitest";
+import { finalizeEvent, generateSecretKey, getPublicKey, verifyEvent } from "nostr-tools";
+
+import { createInboundPump } from "./pump.js";
+import { buildAuthorizedSet } from "./auth-gate.js";
+import type { NostrEventLike } from "./auth-gate.js";
+import type { BuzzRuntimeConfig } from "./config.js";
+import type { DedupStore } from "./dedup.js";
+import type { InboundMessage } from "../../telegram-plugin/gateway/ipc-protocol.js";
+import {
+  summarizePipeline,
+  formatStatsLine,
+  createStatsReporter,
+  type BuzzPipelineSummary,
+  type StatsSample,
+} from "./stats.js";
+
+// ── helpers mirrored from pump.test.ts so the stats derive from a REAL pump ──
+
+function memDedup(): DedupStore {
+  const s = new Set<string>();
+  return { has: (id) => s.has(id), record: (id) => { s.add(id); }, size: () => s.size, close: () => {} };
+}
+
+function sign(sk: Uint8Array, over: Partial<NostrEventLike> = {}): NostrEventLike {
+  return finalizeEvent(
+    {
+      kind: over.kind ?? 9,
+      created_at: over.created_at ?? Math.floor(Date.now() / 1000),
+      tags: over.tags ?? [["h", "group-uuid"]],
+      content: over.content ?? "hello",
+    },
+    sk,
+  ) as NostrEventLike;
+}
+
+function makeConfig(over: Partial<BuzzRuntimeConfig> = {}): BuzzRuntimeConfig {
+  return {
+    enabled: true,
+    agentName: "klanker",
+    chatId: "555",
+    relayUrl: "ws://relay",
+    relayTagUrl: "ws://relay",
+    relayHost: "",
+    groupId: "group-uuid",
+    authorized: over.authorized ?? new Set<string>(),
+    nsecVaultKey: "buzz/klanker-nsec",
+    pubkeyNames: {},
+    mirror: "both",
+    ...over,
+  };
+}
+
+function harness(cfg: BuzzRuntimeConfig, opts: { injectOk?: boolean; dedup?: DedupStore } = {}) {
+  const frames: InboundMessage[] = [];
+  const pump = createInboundPump({
+    config: cfg,
+    dedup: opts.dedup ?? memDedup(),
+    inject: (inbound) => { if (opts.injectOk === false) return false; frames.push(inbound); return true; },
+    verify: verifyEvent,
+    agentPubkey: null,
+  });
+  return { pump, frames };
+}
+
+describe("summarizePipeline — derives from real pump outcomes", () => {
+  it("counts injected / dropped-by-kind / auth-failures / duplicate from actual events", () => {
+    const sk = generateSecretKey();
+    const pk = getPublicKey(sk);
+    const strangerSk = generateSecretKey();
+    const cfg = makeConfig({ authorized: buildAuthorizedSet(pk) });
+    const { pump, frames } = harness(cfg);
+
+    // 1 injected (kind:9, allowlisted)
+    const ev = sign(sk);
+    expect(pump.handleEvent(ev)).toBe("injected");
+    // duplicate redelivery of the SAME id
+    expect(pump.handleEvent(ev)).toBe("duplicate");
+    // 1 dropped-by-kind (kind:1, allowlisted but unmapped)
+    expect(pump.handleEvent(sign(sk, { kind: 1 }))).toBe("unmapped");
+    // 2 auth failures: a stranger (not_allowlisted) and a tampered sig (bad_signature)
+    expect(pump.handleEvent(sign(strangerSk))).toBe("rejected:not_allowlisted");
+    const good = sign(sk);
+    const tampered = JSON.parse(JSON.stringify({ ...good, content: good.content + " EVIL" }));
+    expect(pump.handleEvent(tampered)).toBe("rejected:bad_signature");
+
+    // exactly one turn was really injected
+    expect(frames.length).toBe(1);
+
+    const s = summarizePipeline(pump.stats, { ok: 3, failed: 1 });
+    // received = every handleEvent call = 5
+    expect(s.received).toBe(5);
+    expect(s.injected).toBe(1);
+    expect(s.duplicate).toBe(1);
+    expect(s.droppedByKind).toBe(1);
+    // authFailures = sum of the two distinct rejected:* buckets
+    expect(s.authFailures).toBe(2);
+    expect(s.queued).toBe(0);
+    expect(s.injectFailed).toBe(0);
+    expect(s.channelOff).toBe(0);
+    // mirror counters passed through verbatim
+    expect(s.mirrorOk).toBe(3);
+    expect(s.mirrorFailed).toBe(1);
+  });
+
+  it("counts inject_failed and queued distinctly (retry queue absent vs present)", () => {
+    const sk = generateSecretKey();
+    const pk = getPublicKey(sk);
+
+    // No retry queue → a failed inject is inject_failed.
+    const noRetry = harness(makeConfig({ authorized: buildAuthorizedSet(pk) }), { injectOk: false });
+    expect(noRetry.pump.handleEvent(sign(sk))).toBe("inject_failed");
+    const s1 = summarizePipeline(noRetry.pump.stats, { ok: 0, failed: 0 });
+    expect(s1.injectFailed).toBe(1);
+    expect(s1.queued).toBe(0);
+    expect(s1.received).toBe(1);
+
+    // With a retry queue → a failed inject is queued.
+    const queued = new Set<string>();
+    const pump = createInboundPump({
+      config: makeConfig({ authorized: buildAuthorizedSet(pk) }),
+      dedup: memDedup(),
+      inject: () => false,
+      retryQueue: { has: (id) => queued.has(id), enqueue: (id) => { queued.add(id); } },
+      verify: verifyEvent,
+      agentPubkey: null,
+    });
+    expect(pump.handleEvent(sign(sk))).toBe("queued");
+    const s2 = summarizePipeline(pump.stats, { ok: 0, failed: 0 });
+    expect(s2.queued).toBe(1);
+    expect(s2.injectFailed).toBe(0);
+  });
+
+  it("an empty pump summarizes to all-zeros", () => {
+    const empty = Object.create(null) as Record<string, number>;
+    const s = summarizePipeline(empty, { ok: 0, failed: 0 });
+    expect(s).toEqual<BuzzPipelineSummary>({
+      received: 0,
+      injected: 0,
+      duplicate: 0,
+      queued: 0,
+      injectFailed: 0,
+      droppedByKind: 0,
+      channelOff: 0,
+      authFailures: 0,
+      mirrorOk: 0,
+      mirrorFailed: 0,
+    });
+  });
+});
+
+describe("formatStatsLine", () => {
+  it("emits a single greppable line with every field", () => {
+    const line = formatStatsLine({
+      received: 5, injected: 1, duplicate: 1, queued: 0, injectFailed: 0,
+      droppedByKind: 1, channelOff: 0, authFailures: 2, mirrorOk: 3, mirrorFailed: 1,
+    });
+    expect(line).toBe(
+      "buzz stats: received=5 injected=1 duplicate=1 queued=0 inject_failed=0 " +
+      "dropped_by_kind=1 channel_off=0 auth_failures=2 mirror_ok=3 mirror_failed=1",
+    );
+  });
+});
+
+describe("createStatsReporter", () => {
+  function fakeTimers() {
+    const scheduled: Array<{ fn: () => void; ms: number }> = [];
+    const setTimer = vi.fn((fn: () => void, ms: number) => {
+      scheduled.push({ fn, ms });
+      return scheduled.length as unknown as ReturnType<typeof setTimeout>;
+    });
+    const clearTimer = vi.fn();
+    // run the most-recently scheduled timer
+    const runNext = () => {
+      const next = scheduled.pop();
+      if (next) next.fn();
+    };
+    return { setTimer, clearTimer, runNext, scheduled };
+  }
+
+  it("emits + persists a first beat immediately on start, then on each tick", () => {
+    const { setTimer, runNext } = fakeTimers();
+    const emitted: string[] = [];
+    const persisted: StatsSample[] = [];
+    let received = 0;
+    const reporter = createStatsReporter({
+      intervalMs: 60_000,
+      setTimer,
+      sample: () => ({
+        summary: summarizePipeline({ injected: received } as Record<string, number>, { ok: 0, failed: 0 }),
+        subscribed: true,
+      }),
+      emit: (l) => emitted.push(l),
+      persist: (s) => persisted.push(s),
+    });
+
+    reporter.start();
+    // immediate first beat
+    expect(emitted.length).toBe(1);
+    expect(persisted.length).toBe(1);
+    expect(emitted[0]).toContain("injected=0");
+
+    // pipeline advances, timer fires → a new (changed) line is emitted + persisted
+    received = 2;
+    runNext();
+    expect(emitted.length).toBe(2);
+    expect(emitted[1]).toContain("injected=2");
+    expect(persisted.length).toBe(2);
+    expect(persisted[1].summary.injected).toBe(2);
+  });
+
+  it("suppresses an unchanged log line but ALWAYS persists the heartbeat", () => {
+    const { setTimer, runNext } = fakeTimers();
+    const emitted: string[] = [];
+    const persisted: StatsSample[] = [];
+    const reporter = createStatsReporter({
+      intervalMs: 60_000,
+      setTimer,
+      sample: () => ({
+        summary: summarizePipeline(Object.create(null), { ok: 0, failed: 0 }),
+        subscribed: true,
+      }),
+      emit: (l) => emitted.push(l),
+      persist: (s) => persisted.push(s),
+    });
+
+    reporter.start();
+    runNext(); // identical all-zero summary
+    runNext();
+
+    // one emit (first beat), but three heartbeat persists (liveness must keep beating)
+    expect(emitted.length).toBe(1);
+    expect(persisted.length).toBe(3);
+  });
+
+  it("a persist that throws never breaks the loop", () => {
+    const { setTimer, runNext } = fakeTimers();
+    const emitted: string[] = [];
+    let n = 0;
+    const reporter = createStatsReporter({
+      intervalMs: 60_000,
+      setTimer,
+      sample: () => ({
+        summary: summarizePipeline({ injected: n++ } as Record<string, number>, { ok: 0, failed: 0 }),
+        subscribed: true,
+      }),
+      emit: (l) => emitted.push(l),
+      persist: () => { throw new Error("disk full"); },
+    });
+
+    expect(() => { reporter.start(); runNext(); }).not.toThrow();
+    expect(emitted.length).toBe(2);
+  });
+
+  it("stop() clears the pending timer and halts ticking", () => {
+    const { setTimer, clearTimer } = fakeTimers();
+    const emitted: string[] = [];
+    const reporter = createStatsReporter({
+      intervalMs: 60_000,
+      setTimer,
+      clearTimer,
+      sample: () => ({ summary: summarizePipeline(Object.create(null), { ok: 0, failed: 0 }), subscribed: true }),
+      emit: (l) => emitted.push(l),
+    });
+    reporter.start();
+    reporter.stop();
+    expect(clearTimer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/buzz-gateway/stats.ts
+++ b/src/buzz-gateway/stats.ts
@@ -1,0 +1,189 @@
+/**
+ * Buzz sidecar pipeline stats — the operator-visible health surface.
+ *
+ * The inbound pump already keeps a content-free `stats` record: one monotonic
+ * counter per outcome (`injected`, `duplicate`, `queued`, `inject_failed`,
+ * `unmapped`, `channel_off`, and a `rejected:<reason>` bucket per auth-gate
+ * refusal). This module DERIVES an operator-facing summary from that record
+ * (plus the outbound mirror counters the sidecar owns), formats it as one
+ * structured log line, and drives a periodic reporter loop.
+ *
+ * It invents no new counting mechanism — every number is either a pump counter
+ * or a sum of pump counters — so a summary field can only move because a real
+ * pipeline event moved the underlying bucket. Nothing here carries message
+ * content or a secret: the pump's counters never did, and the derived summary
+ * is pure arithmetic over them.
+ */
+
+/**
+ * Content-free summary of the Buzz pipeline. Every field is a monotonic counter
+ * (or a derived sum of counters). NONE carries message content or a secret.
+ */
+export interface BuzzPipelineSummary {
+  /** Total events handed to the pump — the sum of every outcome bucket. */
+  received: number;
+  /** Admitted, mapped kind:9, and injected as a turn. */
+  injected: number;
+  /** Already-seen ids skipped (durable journal OR pending retry). */
+  duplicate: number;
+  /** Inject failed and held in the volatile retry queue (MAJOR-1). */
+  queued: number;
+  /** Inject failed with no retry queue — relying on relay resubscribe. */
+  injectFailed: number;
+  /** Admitted but dropped by kind — a non-kind:9 event the mapper refused. */
+  droppedByKind: number;
+  /** Dropped because the channel resolved not-live at handle time. */
+  channelOff: number;
+  /** Refused by the auth gate (bad signature, not on the allowlist, self-echo,
+   *  or malformed) — the sum of every `rejected:*` bucket. */
+  authFailures: number;
+  /** Outbound mirror publishes the relay ACKed. */
+  mirrorOk: number;
+  /** Outbound mirror publishes that failed (reported honestly, never retried). */
+  mirrorFailed: number;
+}
+
+/** The two outbound-mirror counters the sidecar maintains around its publisher. */
+export interface MirrorCounters {
+  readonly ok: number;
+  readonly failed: number;
+}
+
+const REJECT_PREFIX = "rejected:";
+
+/**
+ * Derive the operator summary from the pump's raw outcome record + the mirror
+ * counters. `received` is the sum of every bucket (the pump bumps exactly one
+ * bucket per `handleEvent`), and `authFailures` is the sum of the
+ * `rejected:*` buckets — so both track the real pipeline, not a parallel count.
+ */
+export function summarizePipeline(
+  pumpStats: Readonly<Record<string, number>>,
+  mirror: MirrorCounters,
+): BuzzPipelineSummary {
+  let received = 0;
+  let authFailures = 0;
+  for (const [key, count] of Object.entries(pumpStats)) {
+    received += count;
+    if (key.startsWith(REJECT_PREFIX)) authFailures += count;
+  }
+  return {
+    received,
+    injected: pumpStats.injected ?? 0,
+    duplicate: pumpStats.duplicate ?? 0,
+    queued: pumpStats.queued ?? 0,
+    injectFailed: pumpStats.inject_failed ?? 0,
+    droppedByKind: pumpStats.unmapped ?? 0,
+    channelOff: pumpStats.channel_off ?? 0,
+    authFailures,
+    mirrorOk: mirror.ok,
+    mirrorFailed: mirror.failed,
+  };
+}
+
+/** One structured, greppable stats line in the sidecar's `buzz ...:` idiom. */
+export function formatStatsLine(s: BuzzPipelineSummary): string {
+  return (
+    `buzz stats: received=${s.received} injected=${s.injected} ` +
+    `duplicate=${s.duplicate} queued=${s.queued} inject_failed=${s.injectFailed} ` +
+    `dropped_by_kind=${s.droppedByKind} channel_off=${s.channelOff} ` +
+    `auth_failures=${s.authFailures} mirror_ok=${s.mirrorOk} mirror_failed=${s.mirrorFailed}`
+  );
+}
+
+/** A single sample: the derived summary plus the relay subscription state. */
+export interface StatsSample {
+  summary: BuzzPipelineSummary;
+  /** Relay subscription live at sample time (nostrClient.isSubscribed()). */
+  subscribed: boolean;
+}
+
+export interface StatsReporterDeps {
+  /** Sample the pipeline + liveness. Called on the first beat and every tick. */
+  sample: () => StatsSample;
+  /** Emit one structured stats line (the sidecar's stderr logger). */
+  emit: (line: string) => void;
+  /** Persist a heartbeat snapshot (best-effort — MUST be crash-safe; the
+   *  reporter wraps it so a write failure never disturbs the loop). */
+  persist?: (sample: StatsSample) => void;
+  /** Tick period in ms. Default 60_000. */
+  intervalMs?: number;
+  /** Injected timer (deterministic tests); default setTimeout. */
+  setTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  /** Injected clear (deterministic tests); default clearTimeout. */
+  clearTimer?: (t: ReturnType<typeof setTimeout>) => void;
+}
+
+export interface StatsReporter {
+  /** Emit the first beat now, then tick every `intervalMs`. */
+  start(): void;
+  /** Stop ticking. */
+  stop(): void;
+  /** Sample → persist (always) → emit (only when the summary line changed).
+   *  Exposed for tests and as the timer body. */
+  tick(): void;
+}
+
+/**
+ * Periodic stats reporter. Each tick ALWAYS persists a heartbeat (so doctor's
+ * liveness probe sees a fresh beat even on an idle-but-healthy channel) but
+ * only EMITS a log line when the summary changed since the last emit — so an
+ * idle channel logs one line and then stays quiet instead of writing an
+ * identical line every minute.
+ */
+export function createStatsReporter(deps: StatsReporterDeps): StatsReporter {
+  const intervalMs = deps.intervalMs && deps.intervalMs > 0 ? deps.intervalMs : 60_000;
+  const setTimer = deps.setTimer ?? ((fn, ms) => setTimeout(fn, ms));
+  const clearTimer = deps.clearTimer ?? ((t) => clearTimeout(t));
+
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+  let lastLine: string | null = null;
+
+  function tick(): void {
+    const sample = deps.sample();
+    const line = formatStatsLine(sample.summary);
+    if (line !== lastLine) {
+      deps.emit(line);
+      lastLine = line;
+    }
+    // The heartbeat beats every tick regardless of change — it is the liveness
+    // signal, so a quiet-but-healthy sidecar must keep refreshing it.
+    try {
+      deps.persist?.(sample);
+    } catch {
+      /* best-effort — a heartbeat write must never disturb the pipeline */
+    }
+  }
+
+  function schedule(): void {
+    if (stopped) return;
+    timer = setTimer(() => {
+      timer = null;
+      if (stopped) return;
+      tick();
+      schedule();
+    }, intervalMs);
+    // Don't keep the process alive solely for the stats loop (mirrors the
+    // publish-timeout timers in nostr-client.ts).
+    if (timer && typeof (timer as { unref?: () => void }).unref === "function") {
+      (timer as { unref: () => void }).unref();
+    }
+  }
+
+  return {
+    start(): void {
+      stopped = false;
+      tick(); // first beat immediately so doctor sees liveness soon after boot
+      schedule();
+    },
+    stop(): void {
+      stopped = true;
+      if (timer !== null) {
+        clearTimer(timer);
+        timer = null;
+      }
+    },
+    tick,
+  };
+}

--- a/src/cli/doctor-buzz.test.ts
+++ b/src/cli/doctor-buzz.test.ts
@@ -113,6 +113,18 @@ describe("runBuzzChecks — channel state", () => {
     const results = await runBuzzChecks(config, deps({ heartbeatContent: null }));
     expect(row(results, "buzz:channel:alpha")?.status).toBe("warn");
   });
+
+  it("mirror:origin is NOT live, so the liveness probe SKIPs (no false-red)", async () => {
+    // LOW-1: `origin` degrades to dark at runtime (config.ts loadConfigFromEnv),
+    // so the sidecar never writes a beacon. Running the liveness probe would emit
+    // a false-red "sidecar not running" warn whose restart fix can't help and
+    // that contradicts the channel-state warn. It must SKIP, exactly like off.
+    const config = cfg({ alpha: { enabled: true, mirror: "origin", ...FULL_RELAY } });
+    const agents = computeBuzzAgents(config);
+    expect(agents[0].live).toBe(false);
+    const results = await runBuzzChecks(config, deps({ heartbeatContent: null }));
+    expect(row(results, "buzz:sidecar-live:alpha")?.status).toBe("skip");
+  });
 });
 
 describe("runBuzzChecks — relay config", () => {

--- a/src/cli/doctor-buzz.test.ts
+++ b/src/cli/doctor-buzz.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from "vitest";
+
+import type { SwitchroomConfig } from "../config/schema.js";
+import { runBuzzChecks, computeBuzzAgents, BUZZ_HEARTBEAT_STALE_MS } from "./doctor-buzz.js";
+import { buzzHeartbeatOperatorPath, type BuzzHeartbeat } from "../buzz-gateway/heartbeat.js";
+import type { BuzzPipelineSummary } from "../buzz-gateway/stats.js";
+
+const HOME = "/home/op";
+const AGENTS_DIR = `${HOME}/.switchroom/agents`;
+
+const FULL_RELAY = {
+  relay_url: "ws://127.0.0.1:3000",
+  relay_host: "127.0.0.1:3000",
+  operator_pubkey: "a".repeat(64),
+  chat_id: "555",
+  default_channel_id: "group-uuid",
+};
+
+function cfg(buzzByAgent: Record<string, Record<string, unknown> | undefined>): SwitchroomConfig {
+  const agents: Record<string, unknown> = {};
+  for (const [name, buzz] of Object.entries(buzzByAgent)) {
+    agents[name] = buzz ? { channels: { buzz } } : {};
+  }
+  return { agents } as unknown as SwitchroomConfig;
+}
+
+const SUMMARY: BuzzPipelineSummary = {
+  received: 10, injected: 6, duplicate: 1, queued: 0, injectFailed: 0,
+  droppedByKind: 1, channelOff: 0, authFailures: 2, mirrorOk: 3, mirrorFailed: 0,
+};
+
+function heartbeat(over: Partial<BuzzHeartbeat> = {}): string {
+  return JSON.stringify({
+    v: 1, agent: "alpha", ts: 1_000_000, bootTs: 900_000, subscribed: true, stats: SUMMARY, ...over,
+  });
+}
+
+/** A deps bundle where the ONE agent 'alpha' has a heartbeat file. */
+function deps(opts: {
+  heartbeatContent?: string | null;
+  heartbeatMtimeMs?: number;
+  now?: number;
+  acl?:
+    | { kind: "ok"; allow: string[] }
+    | { kind: "unreachable"; msg: string }
+    | { kind: "not_found" };
+}) {
+  const path = buzzHeartbeatOperatorPath(`${AGENTS_DIR}/alpha`);
+  const has = opts.heartbeatContent != null;
+  return {
+    homeDir: () => HOME,
+    now: () => opts.now ?? 2_000_000,
+    existsSync: (p: string) => p === path && has,
+    statSync: (p: string) => {
+      if (p !== path || !has) throw new Error("ENOENT");
+      return { mtimeMs: opts.heartbeatMtimeMs ?? 2_000_000 };
+    },
+    readFileSync: (p: string) => {
+      if (p !== path || !has) throw new Error("ENOENT");
+      return opts.heartbeatContent as string;
+    },
+    vaultAclReader: async () => opts.acl ?? { kind: "ok" as const, allow: ["alpha"] },
+  };
+}
+
+function row(results: Awaited<ReturnType<typeof runBuzzChecks>>, prefix: string) {
+  return results.find((r) => r.name.startsWith(prefix));
+}
+
+describe("computeBuzzAgents", () => {
+  it("returns only agents that declare channels.buzz, with defaults applied", () => {
+    const config = cfg({ alpha: { enabled: true, ...FULL_RELAY }, beta: undefined });
+    const agents = computeBuzzAgents(config);
+    expect(agents.map((a) => a.agent)).toEqual(["alpha"]);
+    expect(agents[0].mirror).toBe("both"); // schema default re-applied
+    expect(agents[0].live).toBe(true);
+    expect(agents[0].nsecVaultKey).toBe("buzz/alpha-nsec"); // {agent} substituted
+  });
+
+  it("no agent with channels.buzz → runBuzzChecks yields zero rows", async () => {
+    const results = await runBuzzChecks(cfg({ beta: undefined }), deps({ acl: { kind: "ok", allow: [] } }));
+    expect(results).toEqual([]);
+  });
+});
+
+describe("runBuzzChecks — channel state", () => {
+  it("a live 'both' agent reports the channel OK", async () => {
+    const config = cfg({ alpha: { enabled: true, mirror: "both", ...FULL_RELAY } });
+    const results = await runBuzzChecks(config, deps({ heartbeatContent: heartbeat() }));
+    const r = row(results, "buzz:channel:alpha");
+    expect(r?.status).toBe("ok");
+    expect(r?.detail).toContain("mirror=both");
+  });
+
+  it("a disabled agent SKIPs the channel and the liveness probe", async () => {
+    const config = cfg({ alpha: { enabled: false, ...FULL_RELAY } });
+    const results = await runBuzzChecks(config, deps({ heartbeatContent: null }));
+    expect(row(results, "buzz:channel:alpha")?.status).toBe("skip");
+    expect(row(results, "buzz:sidecar-live:alpha")?.status).toBe("skip");
+    // config + keypair still evaluated
+    expect(row(results, "buzz:relay-config:alpha")?.status).toBe("ok");
+  });
+
+  it("mirror:off (kill-switch) SKIPs channel + liveness", async () => {
+    const config = cfg({ alpha: { enabled: true, mirror: "off", ...FULL_RELAY } });
+    const results = await runBuzzChecks(config, deps({ heartbeatContent: null }));
+    expect(row(results, "buzz:channel:alpha")?.detail).toContain("kill-switch");
+    expect(row(results, "buzz:sidecar-live:alpha")?.status).toBe("skip");
+  });
+
+  it("mirror:origin (deferred) WARNs that it degrades to dark", async () => {
+    const config = cfg({ alpha: { enabled: true, mirror: "origin", ...FULL_RELAY } });
+    const results = await runBuzzChecks(config, deps({ heartbeatContent: null }));
+    expect(row(results, "buzz:channel:alpha")?.status).toBe("warn");
+  });
+});
+
+describe("runBuzzChecks — relay config", () => {
+  it("FAILs when a required relay field is missing", async () => {
+    const { relay_host: _omit, ...partial } = FULL_RELAY;
+    const config = cfg({ alpha: { enabled: true, ...partial } });
+    const results = await runBuzzChecks(config, deps({ heartbeatContent: heartbeat() }));
+    const r = row(results, "buzz:relay-config:alpha");
+    expect(r?.status).toBe("fail");
+    expect(r?.detail).toContain("relay_host");
+  });
+});
+
+describe("runBuzzChecks — keypair / vault grant", () => {
+  it("FAILs when the nsec vault key is missing", async () => {
+    const config = cfg({ alpha: { enabled: true, ...FULL_RELAY } });
+    const results = await runBuzzChecks(config, deps({ heartbeatContent: heartbeat(), acl: { kind: "not_found" } }));
+    const r = row(results, "buzz:keypair:alpha");
+    expect(r?.status).toBe("fail");
+    expect(r?.detail).toContain("missing");
+    expect(r?.fix).toContain("buzz/alpha-nsec");
+  });
+
+  it("FAILs when the key exists but the agent is not on its ACL", async () => {
+    const config = cfg({ alpha: { enabled: true, ...FULL_RELAY } });
+    const results = await runBuzzChecks(
+      config,
+      deps({ heartbeatContent: heartbeat(), acl: { kind: "ok", allow: ["someone-else"] } }),
+    );
+    const r = row(results, "buzz:keypair:alpha");
+    expect(r?.status).toBe("fail");
+    expect(r?.detail).toContain("NOT on its ACL");
+  });
+
+  it("WARNs (not fails) when the broker is unreachable", async () => {
+    const config = cfg({ alpha: { enabled: true, ...FULL_RELAY } });
+    const results = await runBuzzChecks(
+      config,
+      deps({ heartbeatContent: heartbeat(), acl: { kind: "unreachable", msg: "socket gone" } }),
+    );
+    expect(row(results, "buzz:keypair:alpha")?.status).toBe("warn");
+  });
+
+  it("passes when the key exists and the agent is on the ACL", async () => {
+    const config = cfg({ alpha: { enabled: true, ...FULL_RELAY } });
+    const results = await runBuzzChecks(config, deps({ heartbeatContent: heartbeat(), acl: { kind: "ok", allow: ["alpha"] } }));
+    expect(row(results, "buzz:keypair:alpha")?.status).toBe("ok");
+  });
+});
+
+describe("runBuzzChecks — sidecar liveness", () => {
+  const liveCfg = cfg({ alpha: { enabled: true, ...FULL_RELAY } });
+
+  it("OK on a fresh, subscribed heartbeat, surfacing the stats", async () => {
+    const results = await runBuzzChecks(liveCfg, deps({ heartbeatContent: heartbeat(), heartbeatMtimeMs: 2_000_000, now: 2_030_000 }));
+    const r = row(results, "buzz:sidecar-live:alpha");
+    expect(r?.status).toBe("ok");
+    expect(r?.detail).toContain("injected=6");
+    expect(r?.detail).toContain("subscribed");
+  });
+
+  it("WARNs when the heartbeat is missing", async () => {
+    const results = await runBuzzChecks(liveCfg, deps({ heartbeatContent: null }));
+    const r = row(results, "buzz:sidecar-live:alpha");
+    expect(r?.status).toBe("warn");
+    expect(r?.detail).toContain("no heartbeat");
+  });
+
+  it("WARNs when the heartbeat is stale", async () => {
+    const now = 2_000_000;
+    const results = await runBuzzChecks(
+      liveCfg,
+      deps({ heartbeatContent: heartbeat(), heartbeatMtimeMs: now - BUZZ_HEARTBEAT_STALE_MS - 1, now }),
+    );
+    const r = row(results, "buzz:sidecar-live:alpha");
+    expect(r?.status).toBe("warn");
+    expect(r?.detail).toContain("stale");
+  });
+
+  it("WARNs when the sidecar is up but the relay subscription is down", async () => {
+    const results = await runBuzzChecks(
+      liveCfg,
+      deps({ heartbeatContent: heartbeat({ subscribed: false }), heartbeatMtimeMs: 2_000_000, now: 2_010_000 }),
+    );
+    const r = row(results, "buzz:sidecar-live:alpha");
+    expect(r?.status).toBe("warn");
+    expect(r?.detail).toContain("subscription is DOWN");
+  });
+
+  it("WARNs when the heartbeat file is fresh but malformed", async () => {
+    const results = await runBuzzChecks(
+      liveCfg,
+      deps({ heartbeatContent: "{ not valid", heartbeatMtimeMs: 2_000_000, now: 2_010_000 }),
+    );
+    const r = row(results, "buzz:sidecar-live:alpha");
+    expect(r?.status).toBe("warn");
+    expect(r?.detail).toContain("malformed");
+  });
+});

--- a/src/cli/doctor-buzz.ts
+++ b/src/cli/doctor-buzz.ts
@@ -131,7 +131,12 @@ export function computeBuzzAgents(config: SwitchroomConfig): EffectiveBuzz[] {
       agent: name,
       enabled,
       mirror,
-      live: enabled && mirror !== "off",
+      // `origin` is degraded to dark at runtime (config.ts loadConfigFromEnv:
+      // an explicit `origin` returns `off`), so the sidecar exits idle and never
+      // writes a beacon. Treating it as live would run the liveness probe and
+      // produce a false-red "sidecar not running" warn whose restart fix can't
+      // help — so `origin` is NOT live here, matching `off`.
+      live: enabled && mirror !== "off" && mirror !== "origin",
       relayUrl: raw.relay_url ?? "",
       relayHost: raw.relay_host ?? "",
       operatorPubkey: raw.operator_pubkey ?? "",

--- a/src/cli/doctor-buzz.ts
+++ b/src/cli/doctor-buzz.ts
@@ -1,0 +1,337 @@
+/**
+ * Buzz (Nostr co-channel) doctor checks — the operator-visible health surface
+ * for the per-agent Buzz sidecar (`src/buzz-gateway/`).
+ *
+ * Mirrors the shape of `doctor-notion.ts` / `doctor-microsoft.ts`: a per-agent
+ * matrix of cheap config rows plus a vault-grant probe and a heartbeat-driven
+ * liveness probe. It reports, for every agent that declares a `channels.buzz`
+ * block:
+ *
+ *   1. **channel state** — enabled / mirror mode, and whether that resolves to
+ *      a live sidecar (`enabled && mirror != off`) or a deliberately-dark one.
+ *   2. **relay config** — the operationally-required relay fields are present
+ *      (relay_url, relay_host, operator_pubkey, chat_id, default_channel_id).
+ *      Belt-and-suspenders: the schema already enforces these at config-load,
+ *      so a red row here means the load step was skipped/bypassed.
+ *   3. **keypair / vault grant** — the agent's nsec vault key exists AND the
+ *      agent is on its ACL. Without the grant the sidecar broker-fetch fails
+ *      closed at boot and the channel silently never runs — the highest-leverage
+ *      probe here, exactly like notion's vault-acl-aligned.
+ *   4. **sidecar live** — the sidecar's heartbeat beacon
+ *      (`buzz-sidecar.heartbeat.json`) is present and fresh, and its
+ *      last-sampled subscription is up. Only meaningful for a live channel; a
+ *      dark channel skips it (deliberately not running, not a fault).
+ *
+ * The buzz config is read cascade-resolved (`resolveAgentConfig`), because a
+ * `channels.buzz` block can be inherited from a profile / defaults — matching
+ * how `compose.ts` projects the sidecar env.
+ *
+ * Filesystem + vault access are dependency-injected for branch coverage,
+ * mirroring `doctor-notion.ts`.
+ */
+
+import {
+  existsSync as realExistsSync,
+  readFileSync as realReadFileSync,
+  statSync as realStatSync,
+} from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+import type { SwitchroomConfig } from "../config/schema.js";
+import { resolveAgentConfig } from "../config/merge.js";
+import { buzzHeartbeatOperatorPath, parseBuzzHeartbeat } from "../buzz-gateway/heartbeat.js";
+
+import type { CheckStatus } from "./doctor-status.js";
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+/** A heartbeat older than this reads as stale. The sidecar beats every 60s by
+ *  default; 3× that tolerates a couple of missed beats before flagging. */
+export const BUZZ_HEARTBEAT_STALE_MS = 180 * 1000;
+
+export interface BuzzProbeDeps {
+  existsSync?: (path: string) => boolean;
+  readFileSync?: (path: string, encoding: "utf-8" | "utf8") => string;
+  statSync?: (path: string) => { mtimeMs: number };
+  homeDir?: () => string;
+  /** Override clock for tests (default Date.now). */
+  now?: () => number;
+  /** Inject the vault ACL reader for tests. Returns the agents allowed to read
+   *  the key, or an unreachable/not-found signal. */
+  vaultAclReader?: (
+    key: string,
+  ) => Promise<
+    | { kind: "ok"; allow: string[] }
+    | { kind: "unreachable"; msg: string }
+    | { kind: "not_found" }
+  >;
+}
+
+interface ResolvedDeps {
+  existsSync: (path: string) => boolean;
+  readFileSync: (path: string, encoding: "utf-8" | "utf8") => string;
+  statSync: (path: string) => { mtimeMs: number };
+  agentsDir: string;
+  now: () => number;
+  vaultAclReader: NonNullable<BuzzProbeDeps["vaultAclReader"]>;
+}
+
+function resolveDeps(deps: BuzzProbeDeps): ResolvedDeps {
+  const home = deps.homeDir?.() ?? homedir();
+  return {
+    existsSync: deps.existsSync ?? realExistsSync,
+    readFileSync: deps.readFileSync ?? realReadFileSync,
+    statSync: deps.statSync ?? realStatSync,
+    agentsDir: join(home, ".switchroom", "agents"),
+    now: deps.now ?? Date.now,
+    vaultAclReader:
+      deps.vaultAclReader ??
+      (async () => ({ kind: "unreachable", msg: "no default reader wired" })),
+  };
+}
+
+/** The effective, defaults-applied Buzz config for one agent (mirrors how
+ *  compose.ts re-applies schema defaults over the merged raw cascade). */
+export interface EffectiveBuzz {
+  agent: string;
+  enabled: boolean;
+  mirror: "both" | "origin" | "off";
+  /** enabled AND not the off kill-switch — the sidecar actually runs. */
+  live: boolean;
+  relayUrl: string;
+  relayHost: string;
+  operatorPubkey: string;
+  chatId: string;
+  channelIds: string;
+  /** nsec vault key with `{agent}` substituted. */
+  nsecVaultKey: string;
+}
+
+/**
+ * Every agent with a `channels.buzz` block (cascade-resolved), with schema
+ * defaults re-applied. An agent without the block is omitted entirely — Buzz is
+ * default-OFF and absent-block agents must produce zero rows.
+ */
+export function computeBuzzAgents(config: SwitchroomConfig): EffectiveBuzz[] {
+  const out: EffectiveBuzz[] = [];
+  for (const [name, agentConfig] of Object.entries(config.agents ?? {})) {
+    if (!agentConfig) continue;
+    const resolved = resolveAgentConfig(config.defaults, config.profiles, agentConfig);
+    const raw = resolved.channels?.buzz;
+    if (!raw) continue;
+    const enabled = raw.enabled === true;
+    const mirror = raw.mirror ?? "both";
+    out.push({
+      agent: name,
+      enabled,
+      mirror,
+      live: enabled && mirror !== "off",
+      relayUrl: raw.relay_url ?? "",
+      relayHost: raw.relay_host ?? "",
+      operatorPubkey: raw.operator_pubkey ?? "",
+      chatId: raw.chat_id ?? "",
+      channelIds: raw.default_channel_id ?? "",
+      nsecVaultKey: (raw.nsec_vault_key ?? "buzz/{agent}-nsec").replace(/\{agent\}/g, name),
+    });
+  }
+  return out;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Probe 1 + 2: channel state + relay config (cheap, no IO)
+// ────────────────────────────────────────────────────────────────────────
+
+function checkChannelState(b: EffectiveBuzz): CheckResult {
+  if (!b.enabled) {
+    return {
+      name: `buzz:channel:${b.agent}`,
+      status: "skip",
+      detail: `configured but disabled (enabled:false) — sidecar dark`,
+    };
+  }
+  if (b.mirror === "off") {
+    return {
+      name: `buzz:channel:${b.agent}`,
+      status: "skip",
+      detail: `enabled but mirror:off (kill-switch) — sidecar exits idle`,
+    };
+  }
+  // mirror `origin` is degraded to dark at runtime (S2 deferred) — surface it so
+  // an operator who set it knows the channel is not actually mirroring.
+  if (b.mirror === "origin") {
+    return {
+      name: `buzz:channel:${b.agent}`,
+      status: "warn",
+      detail: `mirror:origin is deferred (S2) and degrades to dark at runtime — set mirror:both to run live, or mirror:off to make the kill-switch explicit`,
+    };
+  }
+  return {
+    name: `buzz:channel:${b.agent}`,
+    status: "ok",
+    detail: `enabled, mirror=${b.mirror} (live)`,
+  };
+}
+
+function checkRelayConfig(b: EffectiveBuzz): CheckResult {
+  const missing: string[] = [];
+  if (!b.relayUrl) missing.push("relay_url");
+  if (!b.relayHost) missing.push("relay_host");
+  if (!b.operatorPubkey) missing.push("operator_pubkey");
+  if (!b.chatId) missing.push("chat_id");
+  if (!b.channelIds) missing.push("default_channel_id");
+  if (missing.length > 0) {
+    return {
+      name: `buzz:relay-config:${b.agent}`,
+      status: "fail",
+      detail: `channels.buzz for '${b.agent}' is missing required field(s): ${missing.join(", ")}`,
+      fix: `Set the missing field(s) under agents.${b.agent}.channels.buzz (or the profile it inherits from) in switchroom.yaml. relay_host is the verbatim HTTP Host authority the relay resolves its community from; without it the sidecar fails closed.`,
+    };
+  }
+  return {
+    name: `buzz:relay-config:${b.agent}`,
+    status: "ok",
+    detail: `relay=${b.relayUrl} host=${b.relayHost} group=${b.channelIds}`,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Probe 3: keypair / vault grant
+// ────────────────────────────────────────────────────────────────────────
+
+async function checkKeypairGrant(b: EffectiveBuzz, d: ResolvedDeps): Promise<CheckResult> {
+  const acl = await d.vaultAclReader(b.nsecVaultKey);
+  if (acl.kind === "unreachable") {
+    return {
+      name: `buzz:keypair:${b.agent}`,
+      status: "warn",
+      detail: `vault-broker unreachable checking '${b.nsecVaultKey}': ${acl.msg}`,
+      fix: "Ensure the vault-broker is running and the operator socket is reachable, then re-run doctor.",
+    };
+  }
+  if (acl.kind === "not_found") {
+    return {
+      name: `buzz:keypair:${b.agent}`,
+      status: "fail",
+      detail: `vault key '${b.nsecVaultKey}' is missing — the sidecar broker-fetches the agent nsec at boot and fails closed without it, so the channel never runs`,
+      fix: `Store the agent's Nostr nsec: \`switchroom vault set ${b.nsecVaultKey} --allow ${b.agent}\` on the host (paste the nsec at the prompt).`,
+    };
+  }
+  if (!acl.allow.includes(b.agent)) {
+    const updated = [...acl.allow, b.agent].join(",");
+    return {
+      name: `buzz:keypair:${b.agent}`,
+      status: "fail",
+      detail: `vault key '${b.nsecVaultKey}' exists but agent '${b.agent}' is NOT on its ACL — the sidecar's broker fetch will be denied and the channel fails closed`,
+      fix: `Re-run \`switchroom vault set ${b.nsecVaultKey} --allow ${updated}\` on the host (vault set overwrites the scope, so re-state the full list including '${b.agent}').`,
+    };
+  }
+  return {
+    name: `buzz:keypair:${b.agent}`,
+    status: "ok",
+    detail: `vault key '${b.nsecVaultKey}' present; agent on ACL`,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Probe 4: sidecar liveness (heartbeat beacon)
+// ────────────────────────────────────────────────────────────────────────
+
+function checkSidecarLive(b: EffectiveBuzz, d: ResolvedDeps): CheckResult {
+  if (!b.live) {
+    return {
+      name: `buzz:sidecar-live:${b.agent}`,
+      status: "skip",
+      detail: `channel not live (enabled=${b.enabled}, mirror=${b.mirror}) — sidecar intentionally not running`,
+    };
+  }
+  const path = buzzHeartbeatOperatorPath(join(d.agentsDir, b.agent));
+  if (!d.existsSync(path)) {
+    return {
+      name: `buzz:sidecar-live:${b.agent}`,
+      status: "warn",
+      detail: `no heartbeat at ${path} — the sidecar is not running (or has not emitted its first beat)`,
+      fix: `Check the sidecar: \`switchroom agent restart ${b.agent} --wait\`, then tail its /var/log/switchroom/buzz-gateway.log for boot errors (a missing vault grant, an unreachable relay).`,
+    };
+  }
+  let mtimeMs: number;
+  try {
+    mtimeMs = d.statSync(path).mtimeMs;
+  } catch (err) {
+    return {
+      name: `buzz:sidecar-live:${b.agent}`,
+      status: "warn",
+      detail: `cannot stat heartbeat ${path}: ${(err as Error).message}`,
+    };
+  }
+  const age = d.now() - mtimeMs;
+  if (age > BUZZ_HEARTBEAT_STALE_MS) {
+    return {
+      name: `buzz:sidecar-live:${b.agent}`,
+      status: "warn",
+      detail: `heartbeat is ${Math.round(age / 1000)}s old (stale: >${BUZZ_HEARTBEAT_STALE_MS / 1000}s) — the sidecar has stalled or died`,
+      fix: `Restart the sidecar: \`switchroom agent restart ${b.agent} --wait\` and check /var/log/switchroom/buzz-gateway.log.`,
+    };
+  }
+
+  // Fresh beat — surface the last-sampled stats + subscription state.
+  let hb = null as ReturnType<typeof parseBuzzHeartbeat>;
+  try {
+    hb = parseBuzzHeartbeat(d.readFileSync(path, "utf-8"));
+  } catch {
+    hb = null;
+  }
+  if (!hb) {
+    return {
+      name: `buzz:sidecar-live:${b.agent}`,
+      status: "warn",
+      detail: `heartbeat ${Math.round(age / 1000)}s old but unreadable/malformed at ${path}`,
+    };
+  }
+  const s = hb.stats;
+  const statLine =
+    `received=${s.received} injected=${s.injected} dropped_by_kind=${s.droppedByKind} ` +
+    `auth_failures=${s.authFailures} mirror_ok=${s.mirrorOk} mirror_failed=${s.mirrorFailed}`;
+  if (!hb.subscribed) {
+    return {
+      name: `buzz:sidecar-live:${b.agent}`,
+      status: "warn",
+      detail: `sidecar up (heartbeat ${Math.round(age / 1000)}s old) but relay subscription is DOWN — inbound events are not being delivered; ${statLine}`,
+      fix: `Check /var/log/switchroom/buzz-gateway.log for relay AUTH/connect errors (a wrong relay_host 404s the WS upgrade; a bad nsec fails NIP-42 AUTH).`,
+    };
+  }
+  return {
+    name: `buzz:sidecar-live:${b.agent}`,
+    status: "ok",
+    detail: `sidecar live (heartbeat ${Math.round(age / 1000)}s old, subscribed); ${statLine}`,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Public — runBuzzChecks
+// ────────────────────────────────────────────────────────────────────────
+
+export async function runBuzzChecks(
+  config: SwitchroomConfig,
+  deps: BuzzProbeDeps = {},
+): Promise<CheckResult[]> {
+  const agents = computeBuzzAgents(config);
+  if (agents.length === 0) {
+    // No agent declares channels.buzz — Buzz not configured, skip silently.
+    return [];
+  }
+  const d = resolveDeps(deps);
+  const results: CheckResult[] = [];
+  for (const b of agents) {
+    results.push(checkChannelState(b));
+    results.push(checkRelayConfig(b));
+    results.push(await checkKeypairGrant(b, d));
+    results.push(checkSidecarLive(b, d));
+  }
+  return results;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -77,6 +77,7 @@ import { runComponentVersionChecks } from "./doctor-component-versions.js";
 import { runAssetPayloadChecks } from "./doctor-asset-payload.js";
 import { runMicrosoftChecks } from "./doctor-microsoft.js";
 import { runNotionChecks } from "./doctor-notion.js";
+import { runBuzzChecks } from "./doctor-buzz.js";
 import { runMcpSecretChecks } from "./doctor-mcp-secrets.js";
 import { runContextChecks } from "./doctor-context.js";
 import { runCredentialsMigrationChecks } from "./doctor-credentials-migration.js";
@@ -4159,6 +4160,10 @@ export function registerDoctorCommand(program: Command): void {
           {
             title: "Notion (RFC notion-integration)",
             results: await runNotionChecks(config, { vaultAclReader }),
+          },
+          {
+            title: "Buzz (Nostr co-channel)",
+            results: await runBuzzChecks(config, { vaultAclReader }),
           },
           {
             title: "MCP Connections (auth)",


### PR DESCRIPTION
## Summary

Give operators a way to see what the Buzz co-channel is actually doing, from the sidecar's own state — no reaching into the hub-side correlation store.

**Part 1 — sidecar stats emission** (`src/buzz-gateway/stats.ts`, `heartbeat.ts`, wired in `index.ts`). The Buzz sidecar derives a periodic, content-free pipeline summary from its OWN state: the inbound pump's existing outcome counters plus an outbound-mirror ok/failed tally it keeps around each `publishOutbound`. `summarizePipeline` folds those into `received / injected / duplicate / queued / inject_failed / dropped_by_kind (non-kind:9) / channel_off / auth_failures / mirror_ok / mirror_failed`. A greppable `buzz stats: …` line logs on change; a content-free `buzz-sidecar.heartbeat.json` beacon is written to the agent state dir every interval for liveness (`BUZZ_STATS_INTERVAL_MS`, default 60s). No parallel counting, no message content, no secrets.

**Part 2 — `switchroom doctor` Buzz section** (`src/cli/doctor-buzz.ts`, registered in `doctor.ts`). Per agent that declares `channels.buzz`: channel state (enabled / mirror mode / `off` kill-switch), relay config completeness, keypair vault-grant presence via the shared `vaultAclReader`, and sidecar liveness read from the heartbeat beacon (fresh / stale / subscription-down / malformed). Mirrors the existing notion/m365 launcher-heartbeat pattern — agent writes the beacon, operator's doctor reads it.

## Why

The Buzz co-channel is dark by default and fail-closed; when an operator turns it on there was no way to confirm it's alive, authenticating, and injecting — or to see drops. This gives both a live log surface and a doctor readout without touching the hub-side mirror path.

## Scope boundary (single-concern)

Does **not** touch `telegram-plugin/gateway/buzz-mirror.ts`, `buzz-mirror-correlation-store.ts`, or `gateway.ts`. The hub-side mirror correlation work is PR #4280's (unmerged); this PR's mirror counters are the sidecar's own ok/failed tallies, wholly independent of that store. No dependency on #4280 was hit.

## Test plan

- `src/buzz-gateway/stats.test.ts` drives the **real** inbound pump through injected / duplicate / dropped-by-kind / auth-failure events and asserts the summary reflects the actual outcomes (not a mock).
- `src/buzz-gateway/heartbeat.test.ts` round-trips + shape-guards the beacon and pins that the sidecar's write path and doctor's read path resolve to the same file.
- `src/cli/doctor-buzz.test.ts` covers channel-state / relay-config / keypair-grant / liveness rows.
- Local: scoped vitest green — `buzz-gateway` 121 tests, `doctor-buzz` 16; `tsc --noEmit` + full guard lint (`npm run lint`) green.

## Risk

Low. New code is additive; the reporter timer is `unref()`'d and its persist is try/catch-wrapped so a disk error never breaks the loop; doctor rows default to `skip`/`warn` (never `fail`) when liveness can't be verified from the host.

Job spec: `reference/jobs/fleet-stays-healthy.md` — the fleet surfaces its own state to the operator (here the Buzz co-channel of `reference/jobs/use-my-team-from-the-desktop.md`) instead of failing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)