### PR TITLE
fix(buzz): provision token-union + status expiry + rotate relay-removal guidance (follow-up #4277)

### DIFF
--- a/src/buzz-provision.test.ts
+++ b/src/buzz-provision.test.ts
@@ -11,26 +11,30 @@ import {
   runBuzzProvision,
   provisionBuzzIdentity,
   computeBuzzStatus,
+  isBuzzFullyLive,
   buzzNsecKey,
   buzzAddMemberCommand,
   type BuzzProvisionStore,
   type BuzzGrantOutcome,
+  type BuzzExistingGrantKeys,
 } from "./buzz-provision.js";
 
 /** In-memory store recording every write + grant. Never touches real state. */
 function makeStore(
   seed: Record<string, string> = {},
   grantResult: BuzzGrantOutcome = { ok: true },
+  existing: BuzzExistingGrantKeys = { read: [], write: [] },
 ) {
   const keys = new Map<string, string>(Object.entries(seed));
-  const grants: { agent: string; key: string }[] = [];
+  const grants: { agent: string; readKeys: string[]; writeKeys: string[] }[] = [];
   const store: BuzzProvisionStore = {
     hasNsec: (key) => keys.has(key),
     writeNsec: (key, nsec) => {
       keys.set(key, nsec);
     },
-    grantRead: async (agent, key) => {
-      grants.push({ agent, key });
+    existingGrantKeys: async () => existing,
+    grantRead: async (agent, readKeys, writeKeys) => {
+      grants.push({ agent, readKeys, writeKeys });
       return grantResult;
     },
   };
@@ -96,8 +100,42 @@ describe("provisionBuzzIdentity", () => {
   it("grants read for the correct agent + key by default", async () => {
     const { store, grants } = makeStore();
     const res = await provisionBuzzIdentity("robby", store);
-    expect(grants).toEqual([{ agent: "robby", key: "buzz/robby-nsec" }]);
+    expect(grants).toEqual([
+      { agent: "robby", readKeys: ["buzz/robby-nsec"], writeKeys: [] },
+    ]);
     if (res.kind === "ok") expect(res.grant).toBe("granted");
+  });
+
+  it("MAJOR-1: unions the nsec key with the agent's existing grant keys so a prior capability survives", async () => {
+    // Agent already holds an unrelated read grant (e.g. a coolify token) plus
+    // a write grant. Provisioning must NOT clobber those — the mint has to
+    // carry them forward alongside the new nsec key.
+    const { store, grants } = makeStore({}, { ok: true }, {
+      read: ["coolify/api-token"],
+      write: ["OPENAI_*"],
+    });
+    const res = await provisionBuzzIdentity("robby", store);
+    expect(grants).toHaveLength(1);
+    // The unrelated read key survives AND the nsec key is added.
+    expect(grants[0]!.readKeys.sort()).toEqual(
+      ["buzz/robby-nsec", "coolify/api-token"].sort(),
+    );
+    // The existing write capability is preserved too.
+    expect(grants[0]!.writeKeys).toEqual(["OPENAI_*"]);
+    if (res.kind === "ok") {
+      expect(res.grant).toBe("granted");
+      expect(res.grantUnion).toEqual({ kind: "unioned", priorKeys: 2 });
+    }
+  });
+
+  it("MAJOR-1: mints nsec-only and flags `unknown` when existing grants can't be read", async () => {
+    // Broker unreadable → existingGrantKeys returns null. Fail open: still
+    // mint the nsec key, but flag that the token was REPLACED so the run path
+    // can warn.
+    const { store, grants } = makeStore({}, { ok: true }, null);
+    const res = await provisionBuzzIdentity("robby", store);
+    expect(grants[0]!.readKeys).toEqual(["buzz/robby-nsec"]);
+    if (res.kind === "ok") expect(res.grantUnion).toEqual({ kind: "unknown" });
   });
 
   it("skips the grant with noGrant", async () => {
@@ -144,6 +182,52 @@ describe("runBuzzProvision — nsec is never printed", () => {
         expect(output).toContain(buzzAddMemberCommand(result.npub));
         expect(output).toContain("nsec_vault_key");
       }
+    } finally {
+      restore();
+    }
+  });
+
+  it("MAJOR-3: on rotate, reminds the operator to remove the agent's PRIOR npub from the relay", async () => {
+    const { store } = makeStore({ [buzzNsecKey("klanker")]: "nsec1old" });
+    const { lines, io, restore } = captureOutput();
+    try {
+      const { exitCode, result } = await runBuzzProvision(
+        "klanker",
+        store,
+        { rotate: true },
+        io,
+      );
+      expect(exitCode).toBe(0);
+      expect(result.kind === "ok" && result.rotated).toBe(true);
+      const output = lines.join("\n");
+      // The load-bearing reminder: rotating does NOT drop the old relay member.
+      expect(output).toMatch(/PREVIOUS npub/);
+      expect(output).toMatch(/remove/i);
+      expect(output).toContain("buzz-admin --help");
+    } finally {
+      restore();
+    }
+  });
+
+  it("MAJOR-3: does NOT print the relay-removal reminder on a first-time provision", async () => {
+    const { store } = makeStore();
+    const { lines, io, restore } = captureOutput();
+    try {
+      await runBuzzProvision("klanker", store, {}, io);
+      const output = lines.join("\n");
+      expect(output).not.toMatch(/PREVIOUS npub/);
+    } finally {
+      restore();
+    }
+  });
+
+  it("MAJOR-1: warns the mint replaced the token when existing grants are unreadable", async () => {
+    const { store } = makeStore({}, { ok: true }, null);
+    const { lines, io, restore } = captureOutput();
+    try {
+      await runBuzzProvision("klanker", store, {}, io);
+      const output = lines.join("\n");
+      expect(output).toMatch(/REPLACED the agent's vault token/);
     } finally {
       restore();
     }
@@ -241,6 +325,44 @@ describe("computeBuzzStatus", () => {
     expect(r.grant.status).toBe("unknown");
     expect(r.composeEnv.status).toBe("unknown");
     expect(r.sidecar.status).toBe("unknown");
+  });
+
+  it("MAJOR-2: an EXPIRED grant is red (not a false green) and fails isBuzzFullyLive", () => {
+    const now = 1_000_000;
+    const r = computeBuzzStatus(agent, {
+      vaultKeys: [key],
+      // Right agent, right key, but the grant expired an hour ago.
+      grants: [{ agent_slug: agent, key_allow: [key], expires_at: now - 3600 }],
+      composeYaml: composeWithBuzz,
+      logTail: "buzz nostr: AUTH accepted\nbuzz nostr: EOSE (live)",
+      now,
+    });
+    expect(r.grant.status).toBe("red");
+    expect(r.grant.detail).toMatch(/EXPIRED/);
+    // The exit-code gate the CLI uses (process.exitCode = 2) keys off this.
+    expect(isBuzzFullyLive(r)).toBe(false);
+  });
+
+  it("MAJOR-2: a future-dated (unexpired) grant stays green", () => {
+    const now = 1_000_000;
+    const r = computeBuzzStatus(agent, {
+      vaultKeys: [key],
+      grants: [{ agent_slug: agent, key_allow: [key], expires_at: now + 3600 }],
+      composeYaml: composeWithBuzz,
+      logTail: "EOSE (live)",
+      now,
+    });
+    expect(r.grant.status).toBe("green");
+  });
+
+  it("MAJOR-2: a non-expiring grant (expires_at null/absent) stays green", () => {
+    const r = computeBuzzStatus(agent, {
+      vaultKeys: [key],
+      grants: [{ agent_slug: agent, key_allow: [key], expires_at: null }],
+      composeYaml: composeWithBuzz,
+      logTail: "EOSE (live)",
+    });
+    expect(r.grant.status).toBe("green");
   });
 
   it("sidecar green on AUTH accepted alone", () => {

--- a/src/buzz-provision.ts
+++ b/src/buzz-provision.ts
@@ -63,6 +63,31 @@ export function buzzAddMemberCommand(npub: string): string {
 }
 
 /**
+ * Reminder lines printed on a ROTATE. Rotation exists for a suspected nsec
+ * compromise — but re-enrolling the NEW npub is only half the job: the OLD
+ * npub is still on the closed relay's member list and a leaked key still
+ * authenticates and can read the group. The overwritten nsec means the prior
+ * npub is no longer derivable here, so we can't print a targeted
+ * `remove-member <npub>`; instead we tell the operator to list the current
+ * members and remove the agent's prior one.
+ *
+ * `buzz-admin` is the off-repo relay tool (the same one that runs
+ * `add-member`); its member list/remove subcommands live with it, so we point
+ * at `buzz-admin --help` rather than fabricate a subcommand name this repo
+ * cannot verify.
+ */
+export function buzzRelayMemberRemovalReminder(agent: string): string[] {
+  return [
+    `SECURITY: rotation does NOT remove '${agent}'s PREVIOUS npub from the relay.`,
+    "A leaked old key still authenticates and can read the group until you",
+    "remove it. The prior npub is no longer derivable here (the nsec was",
+    "overwritten), so list the relay's current members and remove the agent's",
+    "prior npub on the relay host:",
+    `  docker exec ${BUZZ_RELAY_CONTAINER} buzz-admin --help   # find the member list/remove subcommands`,
+  ];
+}
+
+/**
  * The `channels.buzz` YAML block to paste under the agent in switchroom.yaml.
  * Placeholders (`<…>`) are the operator's to fill from the live relay; the
  * nsec_vault_key and operator allowlist wiring are pre-filled. Dark by default
@@ -91,7 +116,15 @@ export function buzzChannelYamlBlock(agent: string, npub: string): string {
 export type BuzzGrantOutcome = { ok: true } | { ok: false; error: string };
 
 /**
- * The two side-effecting operations the CLI wires to the real vault + broker;
+ * The agent's CURRENT active grant key sets, as read back before minting.
+ * `read`/`write` are the `key_allow`/`write_allow` of the agent's active
+ * (non-revoked, non-expired) grant. `null` means the broker could not be read
+ * — provisioning then warns that the mint REPLACES the token.
+ */
+export type BuzzExistingGrantKeys = { read: string[]; write: string[] } | null;
+
+/**
+ * The side-effecting operations the CLI wires to the real vault + broker;
  * tests inject fakes. The nsec flows ONLY into {@link writeNsec} — no method
  * ever hands it back, so no caller of `provisionBuzzIdentity` can print it.
  */
@@ -100,8 +133,26 @@ export interface BuzzProvisionStore {
   hasNsec(key: string): boolean | Promise<boolean>;
   /** Write (or overwrite) the nsec value at the vault key. */
   writeNsec(key: string, nsec: string): void | Promise<void>;
-  /** Grant the agent READ on the key via the broker. */
-  grantRead(agent: string, key: string): Promise<BuzzGrantOutcome>;
+  /**
+   * Read the agent's current active grant key sets so provisioning can UNION
+   * the new nsec key into them. A grant mints a fresh single `.vault-token`
+   * that REPLACES the agent's prior one, so minting `[nsecKey]` alone would
+   * silently drop every other capability the agent already holds (e.g. a
+   * `coolify/api-token` read grant). Mirrors the gateway's grant-union flow
+   * (`telegram-plugin/gateway/callback-query-handlers.ts` #1051). `null` =
+   * broker unreadable; provisioning then warns and mints nsec-only.
+   */
+  existingGrantKeys(agent: string): Promise<BuzzExistingGrantKeys>;
+  /**
+   * Grant the agent READ on `readKeys` (and WRITE on `writeKeys`) via the
+   * broker. `readKeys` already includes the nsec key UNIONed with the agent's
+   * existing keys, so the mint preserves prior capabilities.
+   */
+  grantRead(
+    agent: string,
+    readKeys: string[],
+    writeKeys: string[],
+  ): Promise<BuzzGrantOutcome>;
 }
 
 export interface BuzzProvisionOpts {
@@ -115,6 +166,18 @@ export interface BuzzProvisionOpts {
   genKeypair?: () => BuzzKeypair;
 }
 
+/**
+ * How the new nsec key was combined with the agent's existing grant keys.
+ * - `unioned`: existing keys were read and folded in (`priorKeys` = count).
+ * - `unknown`: the broker could not be read, so the mint REPLACED the token
+ *   with an nsec-only grant, dropping any prior capabilities — caller warns.
+ * - `n/a`: grant was skipped (`--no-grant`).
+ */
+export type BuzzGrantUnion =
+  | { kind: "unioned"; priorKeys: number }
+  | { kind: "unknown" }
+  | { kind: "n/a" };
+
 export type BuzzProvisionResult =
   | { kind: "exists"; nsecKey: string }
   | {
@@ -124,6 +187,8 @@ export type BuzzProvisionResult =
       /** True when an existing key was overwritten (--rotate). */
       rotated: boolean;
       grant: "granted" | "skipped" | { failed: string };
+      /** Whether existing grant keys were preserved in the mint. */
+      grantUnion: BuzzGrantUnion;
     };
 
 /**
@@ -148,10 +213,34 @@ export async function provisionBuzzIdentity(
   await store.writeNsec(nsecKey, kp.nsec);
 
   let grant: "granted" | "skipped" | { failed: string };
+  let grantUnion: BuzzGrantUnion;
   if (opts.noGrant) {
     grant = "skipped";
+    grantUnion = { kind: "n/a" };
   } else {
-    const g = await store.grantRead(agent, nsecKey);
+    // UNION the nsec key with the agent's existing grant keys before minting,
+    // so the fresh single-token grant preserves prior capabilities instead of
+    // clobbering them. If the broker can't be read, fail open: mint nsec-only
+    // and flag `unknown` so the caller warns the token was replaced.
+    const existing = await store.existingGrantKeys(agent);
+    const readKeys = new Set<string>();
+    const writeKeys = new Set<string>();
+    if (existing === null) {
+      grantUnion = { kind: "unknown" };
+    } else {
+      for (const k of existing.read) readKeys.add(k);
+      for (const k of existing.write) writeKeys.add(k);
+      // priorKeys counts only keys OTHER than the nsec key we're about to add.
+      const priorKeys = new Set([...existing.read, ...existing.write]);
+      priorKeys.delete(nsecKey);
+      grantUnion = { kind: "unioned", priorKeys: priorKeys.size };
+    }
+    readKeys.add(nsecKey);
+    const g = await store.grantRead(
+      agent,
+      Array.from(readKeys),
+      Array.from(writeKeys),
+    );
     grant = g.ok ? "granted" : { failed: g.error };
   }
 
@@ -161,6 +250,7 @@ export async function provisionBuzzIdentity(
     nsecKey,
     rotated: Boolean(exists),
     grant,
+    grantUnion,
   };
 }
 
@@ -208,7 +298,22 @@ export async function runBuzzProvision(
   io.log(`  nsec written to vault key '${res.nsecKey}' (never printed).`);
 
   if (res.grant === "granted") {
-    io.log(`  granted '${agent}' read on '${res.nsecKey}'.`);
+    if (res.grantUnion.kind === "unioned" && res.grantUnion.priorKeys > 0) {
+      io.log(
+        `  granted '${agent}' read on '${res.nsecKey}' ` +
+          `(unioned with ${res.grantUnion.priorKeys} existing grant key(s), preserved).`,
+      );
+    } else {
+      io.log(`  granted '${agent}' read on '${res.nsecKey}'.`);
+    }
+    if (res.grantUnion.kind === "unknown") {
+      io.error(
+        `  WARNING: could not read '${agent}'s existing grants, so this mint ` +
+          `REPLACED the agent's vault token with an nsec-only grant. If the ` +
+          `agent held other capabilities (e.g. a coolify/api-token read), ` +
+          `re-grant them: switchroom vault grant ${agent} --keys <key>`,
+      );
+    }
   } else if (res.grant === "skipped") {
     io.log(
       `  grant skipped (--no-grant). Grant it before going live: ` +
@@ -233,6 +338,13 @@ export async function runBuzzProvision(
   io.log("Then add this block under the agent in switchroom.yaml:");
   io.log("");
   io.log(buzzChannelYamlBlock(agent, res.npub));
+
+  // On a rotate, re-enrolling the new npub is only half the job — the OLD
+  // npub is still a relay member and a leaked key still reads the group.
+  if (res.rotated) {
+    io.log("");
+    for (const line of buzzRelayMemberRemovalReminder(agent)) io.error(line);
+  }
 
   return { exitCode: 0, result: res };
 }
@@ -262,12 +374,23 @@ export interface BuzzStatusInputs {
   nsecKey?: string;
   /** Vault key names the caller can enumerate; null = couldn't determine. */
   vaultKeys: string[] | null;
-  /** Active grants; null = couldn't determine. */
-  grants: { agent_slug: string; key_allow: string[] }[] | null;
+  /**
+   * Active (non-revoked) grants; null = couldn't determine. `expires_at` is
+   * unix seconds, or null/undefined for a non-expiring grant. It MUST be
+   * carried through: the broker's `listGrants` filters `revoked_at` only, not
+   * `expires_at`, so an expired grant still appears here — treating it as
+   * present would false-green a channel the sidecar actually gets
+   * `grant-expired` on.
+   */
+  grants:
+    | { agent_slug: string; key_allow: string[]; expires_at?: number | null }[]
+    | null;
   /** Rendered compose YAML; null = not found / unreadable. */
   composeYaml: string | null;
   /** Sidecar log tail; null = unreadable (container down, no log). */
   logTail: string | null;
+  /** Test seam for "now" (unix seconds); defaults to the wall clock. */
+  now?: number;
 }
 
 /**
@@ -318,20 +441,34 @@ export function computeBuzzStatus(
     };
   }
 
-  // 2. Grant present for this agent on the key?
+  // 2. Grant present AND unexpired for this agent on the key? An expired grant
+  //    still shows up in listGrants (it filters revoked_at only) but the
+  //    sidecar gets `grant-expired` — so an expired-only match is RED, not a
+  //    false green.
   let grant: BuzzCheck;
   if (inputs.grants === null) {
     grant = { status: "unknown", detail: "could not read grants" };
   } else {
-    const has = inputs.grants.some(
+    const now = inputs.now ?? Math.floor(Date.now() / 1000);
+    const matching = inputs.grants.filter(
       (g) => g.agent_slug === agent && g.key_allow.includes(nsecKey),
     );
-    grant = has
-      ? { status: "green", detail: `'${agent}' granted read on '${nsecKey}'` }
-      : {
-          status: "red",
-          detail: `no grant for '${agent}' on '${nsecKey}' — run: switchroom vault grant ${agent} --keys ${nsecKey}`,
-        };
+    const active = matching.filter(
+      (g) => g.expires_at == null || g.expires_at > now,
+    );
+    if (active.length > 0) {
+      grant = { status: "green", detail: `'${agent}' granted read on '${nsecKey}'` };
+    } else if (matching.length > 0) {
+      grant = {
+        status: "red",
+        detail: `grant for '${agent}' on '${nsecKey}' EXPIRED — re-grant: switchroom vault grant ${agent} --keys ${nsecKey}`,
+      };
+    } else {
+      grant = {
+        status: "red",
+        detail: `no grant for '${agent}' on '${nsecKey}' — run: switchroom vault grant ${agent} --keys ${nsecKey}`,
+      };
+    }
   }
 
   // 3. Compose env projected?

--- a/src/cli/buzz.ts
+++ b/src/cli/buzz.ts
@@ -10,8 +10,9 @@
  * lives in `src/buzz-provision.ts`, which imports no vault/broker/commander
  * code. This file is the thin host wiring: it builds the real vault-backed
  * store and broker-backed grant, reads the compose file + sidecar log for
- * status, and delegates. The nsec never transits this file — it is generated
- * inside the core and written straight to the vault by the injected store.
+ * status, and delegates. The nsec transits this file only INTO the vault
+ * writer (the `writeNsec` closure hands it straight to `setStringSecret`); it
+ * is never logged, printed, or returned upward — the core never hands it back.
  */
 
 import type { Command } from "commander";
@@ -173,6 +174,7 @@ export function registerBuzzCommand(program: Command): void {
         const parentOpts = program.opts();
         const vaultPath = getVaultPath(parentOpts.config);
         const brokerOpts = getBrokerOpts(parentOpts.config);
+        const nsecKey = buzzNsecKey(agent);
 
         let ttlSeconds: number | null;
         try {
@@ -197,13 +199,42 @@ export function registerBuzzCommand(program: Command): void {
           async writeNsec(key, nsec) {
             setStringSecret(await pass(), vaultPath, key, nsec);
           },
-          async grantRead(agentName, key) {
+          async existingGrantKeys(agentName) {
+            // Read the agent's CURRENT active grant key sets so the mint below
+            // UNIONs the nsec key in rather than clobbering the agent's single
+            // .vault-token with an nsec-only grant. Mirrors the gateway's
+            // grant-union flow (callback-query-handlers.ts, #1051): pick the
+            // most-recent non-revoked, non-expired grant. `null` on any broker
+            // failure so the core fails open (nsec-only mint) with a warning.
+            try {
+              const r = await listGrantsViaBroker(agentName, brokerOpts);
+              if (r.kind !== "ok") return null;
+              const now = Math.floor(Date.now() / 1000);
+              // listGrants filters revoked_at only; drop expired locally.
+              const active = r.grants
+                .filter((g) => g.expires_at === null || g.expires_at > now)
+                .sort((a, b) => {
+                  const dt = (b.created_at ?? 0) - (a.created_at ?? 0);
+                  if (dt !== 0) return dt;
+                  return b.id.localeCompare(a.id);
+                });
+              if (active.length === 0) return { read: [], write: [] };
+              return {
+                read: active[0]!.key_allow ?? [],
+                write: active[0]!.write_allow ?? [],
+              };
+            } catch {
+              return null;
+            }
+          },
+          async grantRead(agentName, readKeys, writeKeys) {
             const r = await mintGrantViaBroker({
               ...brokerOpts,
               agent: agentName,
-              keys: [key],
+              keys: readKeys,
+              ...(writeKeys.length > 0 ? { write_keys: writeKeys } : {}),
               ttl_seconds: ttlSeconds,
-              description: `buzz nsec read (${key})`,
+              description: `buzz nsec read (${nsecKey})`,
             });
             return r.kind === "ok" ? { ok: true } : { ok: false, error: r.msg };
           },
@@ -260,14 +291,20 @@ export function registerBuzzCommand(program: Command): void {
         }
       }
 
-      // 2. Grants for this agent.
-      let grants: { agent_slug: string; key_allow: string[] }[] | null = null;
+      // 2. Grants for this agent. Carry expires_at through — the broker's
+      //    listGrants filters revoked_at only, so an EXPIRED grant still
+      //    arrives here; computeBuzzStatus must see the expiry to avoid
+      //    false-greening a channel the sidecar gets `grant-expired` on.
+      let grants:
+        | { agent_slug: string; key_allow: string[]; expires_at: number | null }[]
+        | null = null;
       try {
         const r = await listGrantsViaBroker(agent, brokerOpts);
         if (r.kind === "ok") {
           grants = r.grants.map((g) => ({
             agent_slug: g.agent_slug,
             key_allow: g.key_allow,
+            expires_at: g.expires_at,
           }));
         }
       } catch {


### PR DESCRIPTION
Fast-follow for #4277 (`switchroom buzz provision|status`). Fixes the three MAJOR findings from the adversarial review. Single PR, three majors + the header-comment correction. No unrelated code touched.

Job spec: `reference/jobs/use-my-team-from-the-desktop.md` (Production-readiness §Security — per-agent Nostr key broker-fetched, never leaked).

## MAJOR-1 — `provision` silently clobbered the agent's existing vault capability token
`mint_grant` replaces the agent's single `.vault-token`; `buzz.ts`'s `grantRead` minted `keys: [nsecKey]` only, so provisioning an agent that already held e.g. a `coolify/api-token` grant dropped that capability — its next read fell through to the standing config ACL and was denied. The gateway deliberately UNIONs (`telegram-plugin/gateway/callback-query-handlers.ts:1046`) to avoid exactly this.

**Fix:** the core now reads the agent's current active grant key sets via a new injected `BuzzProvisionStore.existingGrantKeys(agent)` (wired in `src/cli/buzz.ts` to `listGrantsViaBroker`, filtering expired locally + most-recent-grant selection, mirroring the gateway) and UNIONs the nsec key (read + write) in before minting (`src/buzz-provision.ts` `provisionBuzzIdentity`). If the broker can't be read it fails open — mints nsec-only and prints a loud WARNING that the mint replaced the token.

**Test:** `MAJOR-1: unions the nsec key ... so a prior capability survives` (asserts `coolify/api-token` + `OPENAI_*` write survive alongside the nsec key) and `MAJOR-1: warns the mint replaced the token when existing grants are unreadable`.

## MAJOR-2 — `status` false-greened on an expired grant
`listGrants` filters `revoked_at IS NULL` only, never `expires_at` (`src/vault/grants.ts:490,495-499`), and `buzz.ts`'s status path dropped `expires_at` before `computeBuzzStatus`, which did pure membership matching — so an expired grant showed green forever while the sidecar actually gets `grant-expired`. `status`'s exit code is a CI/scripts gate, so this was a wrong-answer bug.

**Fix:** `expires_at` is carried through `BuzzStatusInputs.grants` into `computeBuzzStatus` (`src/buzz-provision.ts`); an all-expired matching grant is now RED with a re-grant hint (green only for a non-expired match). Non-expiring (`expires_at` null/absent) stays green.

**Test:** `MAJOR-2: an EXPIRED grant is red (not a false green) and fails isBuzzFullyLive` (asserts red + `isBuzzFullyLive === false`, the exact condition the CLI turns into `process.exitCode = 2`), plus future-dated-green and non-expiring-green guards.

## MAJOR-3 — rotate guidance left the compromised key enrolled on the relay
Rotation exists for a suspected nsec compromise, but the rotate path printed "re-enroll the new key" and never said to REMOVE the old npub from the closed relay's member list — a leaked key still authenticates and can read the group.

**Fix:** on the rotate path, `runBuzzProvision` now prints `buzzRelayMemberRemovalReminder(agent)` (`src/buzz-provision.ts`). The prior npub isn't derivable after overwrite, so it tells the operator to list the relay's current members and remove the agent's prior npub. The only member-management surface in this repo is `buzz-admin add-member` (off-repo relay tool); no `remove-member`/`list-members` subcommand exists in-repo, so the reminder points at `buzz-admin --help` on the relay container rather than fabricate a subcommand name.

**Test:** `MAJOR-3: on rotate, reminds the operator to remove the agent's PRIOR npub from the relay` (asserts the reminder + `buzz-admin --help` printed) and a negative test that a first-time provision does NOT print it.

## Also — false header comment corrected
`src/cli/buzz.ts` claimed "The nsec never transits this file" — it does, via the `writeNsec` closure. Reworded to the accurate statement: the nsec transits only into the vault writer and is never logged/printed/returned upward.

## Test plan
- `vitest run src/buzz-provision.test.ts` → 20 passed (13 pre-existing + 7 new/updated).
- `tsc --noEmit` clean; `npm run lint` clean.

## Risk
Low. Change is confined to `src/buzz-provision.ts`, `src/cli/buzz.ts`, and its test. `BuzzProvisionStore.grantRead` signature changed (now takes unioned read+write key arrays) and `existingGrantKeys` was added — grepped: no other consumers. `BuzzStatusInputs.grants.expires_at` is optional, so existing green fixtures are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
