### PR TITLE
feat(buzz): NIP-10 thread continuity on outbound mirror

### DIFF
--- a/telegram-plugin/gateway/buzz-mirror-correlation-store.ts
+++ b/telegram-plugin/gateway/buzz-mirror-correlation-store.ts
@@ -43,6 +43,18 @@ import { dirname } from "node:path";
 export interface CorrelationValue {
   eventId: string;
   channelId: string;
+  /**
+   * The NIP-10 thread ROOT of `eventId` (#4280 follow-up — outbound thread
+   * continuity). For a top-level mirror this equals `eventId` itself; for a
+   * mirror that threaded under a parent it is that parent's thread root. Lets a
+   * LATER outbound reply whose Telegram antecedent is THIS message emit a correct
+   * NIP-10 `root` marker (thread root) alongside the `reply` marker (this
+   * `eventId`, the immediate parent), instead of collapsing a deep thread to a
+   * single mislabelled root. Optional for backward compatibility: a journal
+   * record written before this field existed replays with `threadRoot`
+   * undefined, degrading to a `reply`-only tag (still valid NIP-10).
+   */
+  threadRoot?: string;
 }
 
 export interface CorrelationFsLike {
@@ -100,6 +112,7 @@ interface JournalRecord {
   key?: unknown;
   eventId?: unknown;
   channelId?: unknown;
+  threadRoot?: unknown;
 }
 
 /**
@@ -129,10 +142,22 @@ export function createCorrelationStore(
     }
   }
 
+  function encodeRecord(key: string, v: CorrelationValue): string {
+    // Omit threadRoot when absent so pre-existing (pre-threadRoot) journals round-
+    // trip byte-identically and a value that never carried a root stays compact.
+    const record: { key: string; eventId: string; channelId: string; threadRoot?: string } = {
+      key,
+      eventId: v.eventId,
+      channelId: v.channelId,
+    };
+    if (v.threadRoot) record.threadRoot = v.threadRoot;
+    return JSON.stringify(record);
+  }
+
   function serialize(): string {
     let out = "";
     for (const [key, v] of map) {
-      out += JSON.stringify({ key, eventId: v.eventId, channelId: v.channelId }) + "\n";
+      out += encodeRecord(key, v) + "\n";
     }
     return out;
   }
@@ -162,7 +187,14 @@ export function createCorrelationStore(
               parsed.channelId
             ) {
               // Replay in order — put() enforces last-write-wins + FIFO bound.
-              put(parsed.key, { eventId: parsed.eventId, channelId: parsed.channelId });
+              // threadRoot is optional (added post-#4280): accept a non-empty
+              // string, otherwise leave undefined so an older record degrades to
+              // a reply-only tag rather than corrupting the map.
+              const threadRoot =
+                typeof parsed.threadRoot === "string" && parsed.threadRoot
+                  ? parsed.threadRoot
+                  : undefined;
+              put(parsed.key, { eventId: parsed.eventId, channelId: parsed.channelId, threadRoot });
             }
           } catch {
             // Tolerate a torn final line (crash mid-write) — skip it.
@@ -227,10 +259,7 @@ export function createCorrelationStore(
       put(key, value);
       if (fd !== null && journalPath) {
         try {
-          fs.writeSync(
-            fd,
-            JSON.stringify({ key, eventId: value.eventId, channelId: value.channelId }) + "\n",
-          );
+          fs.writeSync(fd, encodeRecord(key, value) + "\n");
           fs.fsyncSync(fd);
           journalLines++;
           if (journalLines > capacity * COMPACTION_FACTOR) compactInPlace();

--- a/telegram-plugin/gateway/buzz-mirror.ts
+++ b/telegram-plugin/gateway/buzz-mirror.ts
@@ -81,6 +81,18 @@ export interface MirrorReplyInput {
    * the published Buzz event to correct.
    */
   telegramMessageKeys: string[];
+  /**
+   * `${chatId}:${messageId}` of the Telegram message this outbound answer is
+   * itself a reply to (its Telegram `reply_to` antecedent), when it has one.
+   * Used ONLY on the telegram-origin path to thread the mirrored Buzz event
+   * under the antecedent's previously-published Buzz event (NIP-10 outbound
+   * continuity). When the antecedent was never mirrored (e.g. it is a user's
+   * inbound message, or it aged past the correlation bound) the lookup misses
+   * and the mirror stays a flat top-level post — no wrong/guessed tag. Absent
+   * for a non-reply answer. Ignored on the buzz-origin path (that thread is
+   * bound by `ownerBuzzCoords`, not a Telegram antecedent).
+   */
+  antecedentTelegramMessageKey?: string;
 }
 
 export interface MirrorCorrectionInput {
@@ -99,6 +111,14 @@ const MAX_TRACKED = 4096;
 interface PendingPublish {
   channelId: string;
   telegramMessageKeys: string[];
+  /**
+   * The NIP-10 thread root this in-flight event belongs to, when it threaded
+   * under a parent. Undefined for a fresh top-level post — in which case the
+   * event's OWN id (learned in `onPublishResult`) becomes the thread root. Stored
+   * so the correlation record carries the root a LATER reply's `root` marker
+   * needs.
+   */
+  threadRootId?: string;
 }
 
 class BuzzMirror {
@@ -199,10 +219,37 @@ class BuzzMirror {
         replyToEventId = input.ownerBuzzCoords.eventId;
         threadRootId = input.ownerBuzzCoords.threadRoot;
       } else {
-        // TELEGRAM-origin → fresh top-level post to the configured channel. Not
-        // an owner-bound thread, so the S1 guard does not apply (design §3.3).
+        // TELEGRAM-origin → post to the configured channel. Not an owner-bound
+        // thread, so the S1 guard does not apply (design §3.3).
         if (!this.cfg.defaultChannelId) return; // no channel to post into
         channelId = this.cfg.defaultChannelId;
+
+        // NIP-10 OUTBOUND thread continuity: if this answer is itself a reply to
+        // a Telegram message that was ALREADY mirrored to Buzz, thread the new
+        // event under that antecedent's published event — a `reply` marker for
+        // the immediate parent and a `root` marker for the thread root — so a
+        // Telegram-origin reply chain renders threaded on the Buzz desktop
+        // instead of flat. The antecedent→event resolution reuses the SAME
+        // durable msg→event correlation store (#4280) the correction path uses;
+        // no new lookup surface. A MISS (antecedent never mirrored — e.g. it is
+        // the user's own inbound message — or evicted past MAX_TRACKED) leaves
+        // the post flat rather than emitting a wrong/guessed tag.
+        if (input.antecedentTelegramMessageKey) {
+          const parent = this.msgToBuzz.get(input.antecedentTelegramMessageKey);
+          if (parent) {
+            replyToEventId = parent.eventId; // immediate parent → NIP-10 `reply`
+            // Thread root → NIP-10 `root`. Fall back to the parent's own id when
+            // the parent has no recorded root (it was itself top-level, or was
+            // journaled before threadRoot was tracked): then parent IS the root.
+            threadRootId = parent.threadRoot ?? parent.eventId;
+          } else {
+            this.log(
+              `buzz-mirror: outbound thread MISS — no Buzz correlation for ` +
+                `Telegram antecedent ${input.antecedentTelegramMessageKey}; ` +
+                `mirroring flat (never mirrored, or evicted past the bound)`,
+            );
+          }
+        }
       }
 
       this.publish(
@@ -295,10 +342,16 @@ class BuzzMirror {
       return;
     }
     // Record the published event against each Telegram message it mirrored, so
-    // a later edit_message on any of them can target it for a correction. The
-    // store persists (durable journal) + enforces the MAX_TRACKED FIFO bound.
+    // a later edit_message on any of them can target it for a correction AND a
+    // later reply whose antecedent is one of these messages can thread under it.
+    // The store persists (durable journal) + enforces the MAX_TRACKED FIFO bound.
+    //
+    // threadRoot: the root this event belongs to. If it threaded under a parent
+    // (`p.threadRootId` set) that parent's root IS this event's root; otherwise
+    // this is a fresh top-level post and its OWN id is the thread root.
+    const threadRoot = p.threadRootId ?? msg.eventId;
     for (const key of p.telegramMessageKeys) {
-      this.msgToBuzz.set(key, { eventId: msg.eventId, channelId: p.channelId });
+      this.msgToBuzz.set(key, { eventId: msg.eventId, channelId: p.channelId, threadRoot });
     }
   }
 
@@ -325,6 +378,7 @@ class BuzzMirror {
     this.pending.set(correlationId, {
       channelId: fields.channelId,
       telegramMessageKeys,
+      threadRootId: fields.threadRootId,
     });
     this.pendingOrder.push(correlationId);
     this.evict(this.pending, this.pendingOrder);

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -2619,6 +2619,12 @@ export async function sendReply(
         ownerEchoed,
         hasRecentDifferentOriginTurn,
         telegramMessageKeys: sentIds.map((id) => `${chat_id}:${id}`),
+        // NIP-10 outbound thread continuity: the Telegram message THIS answer
+        // replied to (its finalized `reply_to`, whether model-supplied or the
+        // quote-opt-in default). The mirror resolves it against the durable
+        // correlation store and threads under it only on a HIT (a previously-
+        // mirrored answer); a user inbound / evicted key misses → flat.
+        antecedentTelegramMessageKey: reply_to != null ? `${chat_id}:${reply_to}` : undefined,
       })
     }
   }

--- a/telegram-plugin/tests/buzz-mirror-correlation-store.test.ts
+++ b/telegram-plugin/tests/buzz-mirror-correlation-store.test.ts
@@ -70,6 +70,33 @@ describe('createCorrelationStore — durable msg→Buzz correlation (#4222)', ()
     expect(b.size()).toBe(1)
   })
 
+  it('persists + replays the NIP-10 threadRoot (outbound thread continuity)', () => {
+    const fs = makeFakeFs()
+    const a = createCorrelationStore({ journalPath: JP, fs })
+    // A mirror that threaded under a deeper parent records a root distinct from
+    // its own event id — that root must survive a restart so a later reply can
+    // emit the correct NIP-10 `root` marker.
+    a.set('555:200', { eventId: 'evt-mid', channelId: 'chan-A', threadRoot: 'evt-root' })
+    a.close()
+
+    const b = createCorrelationStore({ journalPath: JP, fs })
+    expect(b.get('555:200')).toEqual({ eventId: 'evt-mid', channelId: 'chan-A', threadRoot: 'evt-root' })
+    // The record on disk actually carries the field (not just an in-memory echo).
+    expect(fs.files.get(JP) ?? '').toContain('"threadRoot":"evt-root"')
+  })
+
+  it('a pre-threadRoot journal record replays with threadRoot undefined (backward compat)', () => {
+    const fs = makeFakeFs()
+    fs.dirs.add('/state/buzz')
+    // A record written before threadRoot existed — no threadRoot key.
+    fs.files.set(JP, JSON.stringify({ key: '555:1', eventId: 'evt-A', channelId: 'chan-A' }) + '\n')
+    const s = createCorrelationStore({ journalPath: JP, fs })
+    const v = s.get('555:1')
+    expect(v?.eventId).toBe('evt-A')
+    expect(v?.channelId).toBe('chan-A')
+    expect(v?.threadRoot).toBeUndefined()
+  })
+
   it('in-memory-only mode (no journalPath) never touches the fs but still bounds', () => {
     const fs = makeFakeFs()
     const s = createCorrelationStore({ capacity: 2, fs })

--- a/telegram-plugin/tests/buzz-mirror.test.ts
+++ b/telegram-plugin/tests/buzz-mirror.test.ts
@@ -11,6 +11,7 @@ import {
   CORRECTION_DEBOUNCE_MS,
 } from '../gateway/buzz-mirror.js'
 import type { OutboundToBuzzMessage } from '../gateway/ipc-protocol.js'
+import { buildThreadTags } from '../../src/buzz-gateway/transform.js'
 
 // Hub-side mirror behaviour (Phase 2b). The mirror is DOWNSTREAM of a delivered
 // Telegram copy; a publish is emitted via the attached peer sender. These tests
@@ -123,6 +124,115 @@ describe('BuzzMirror.mirrorReplyDelivered — routing + S1 owner guard', () => {
         telegramMessageKeys: ['555:4004'],
       }),
     ).not.toThrow()
+  })
+})
+
+describe('BuzzMirror.mirrorReplyDelivered — NIP-10 OUTBOUND thread continuity', () => {
+  beforeEach(() => __resetBuzzMirrorForTests())
+
+  // Helper: mirror a telegram-origin answer, complete its publish so the
+  // correlation store learns its event id, and return the published event id.
+  function mirrorTelegramAndComplete(
+    m: ReturnType<typeof mirrorWith>,
+    sender: ReturnType<typeof vi.fn>,
+    opts: { telegramKey: string; antecedentKey?: string; eventId: string },
+  ): OutboundToBuzzMessage {
+    m.mirrorReplyDelivered({
+      scrubbedText: 'answer',
+      ownerOriginChannel: 'telegram',
+      ownerEchoed: false,
+      hasRecentDifferentOriginTurn: false,
+      telegramMessageKeys: [opts.telegramKey],
+      antecedentTelegramMessageKey: opts.antecedentKey,
+    })
+    const call = sender.mock.calls[sender.mock.calls.length - 1][0] as OutboundToBuzzMessage
+    m.onPublishResult({ correlationId: call.correlationId, ok: true, eventId: opts.eventId })
+    return call
+  }
+
+  it('threads a telegram-origin reply UNDER its antecedent`s mirrored event (root === parent for a top-level antecedent)', () => {
+    const sender = vi.fn(() => true)
+    const m = mirrorWith(sender, { defaultChannelId: 'grp' })
+
+    // A1: a top-level telegram-origin answer, published as evt-A.
+    mirrorTelegramAndComplete(m, sender, { telegramKey: '555:100', eventId: 'evt-A' })
+    // A2: a telegram-origin answer that REPLIES to A1's Telegram message.
+    m.mirrorReplyDelivered({
+      scrubbedText: 'follow-up',
+      ownerOriginChannel: 'telegram',
+      ownerEchoed: false,
+      hasRecentDifferentOriginTurn: false,
+      telegramMessageKeys: ['555:200'],
+      antecedentTelegramMessageKey: '555:100',
+    })
+
+    const msg = sender.mock.calls[sender.mock.calls.length - 1][0] as OutboundToBuzzMessage
+    // The immediate parent is A1's event; A1 was top-level so IT is the root.
+    expect(msg.replyToEventId).toBe('evt-A')
+    expect(msg.threadRootId).toBe('evt-A')
+    // NIP-10: root === parent collapses to a single reply-to-root e-tag.
+    expect(buildThreadTags({ threadRootId: msg.threadRootId, replyToEventId: msg.replyToEventId })).toEqual([
+      ['e', 'evt-A', '', 'root'],
+    ])
+  })
+
+  it('emits DISTINCT root + reply markers for a reply into a DEEPER thread', () => {
+    const sender = vi.fn(() => true)
+    const m = mirrorWith(sender, { defaultChannelId: 'grp' })
+
+    // A0 top-level → evt-root.
+    mirrorTelegramAndComplete(m, sender, { telegramKey: '555:100', eventId: 'evt-root' })
+    // A1 replies to A0 → threads under evt-root; published as evt-mid. Its
+    // recorded threadRoot must stay evt-root (NOT evt-mid).
+    mirrorTelegramAndComplete(m, sender, {
+      telegramKey: '555:200',
+      antecedentKey: '555:100',
+      eventId: 'evt-mid',
+    })
+    // A2 replies to A1 → parent is evt-mid, but the thread root is still evt-root.
+    m.mirrorReplyDelivered({
+      scrubbedText: 'deep',
+      ownerOriginChannel: 'telegram',
+      ownerEchoed: false,
+      hasRecentDifferentOriginTurn: false,
+      telegramMessageKeys: ['555:300'],
+      antecedentTelegramMessageKey: '555:200',
+    })
+
+    const msg = sender.mock.calls[sender.mock.calls.length - 1][0] as OutboundToBuzzMessage
+    expect(msg.replyToEventId).toBe('evt-mid') // immediate parent
+    expect(msg.threadRootId).toBe('evt-root') // thread root, NOT the parent
+    expect(buildThreadTags({ threadRootId: msg.threadRootId, replyToEventId: msg.replyToEventId })).toEqual([
+      ['e', 'evt-root', '', 'root'],
+      ['e', 'evt-mid', '', 'reply'],
+    ])
+  })
+
+  it('a reply whose antecedent is a correlation-store MISS mirrors FLAT (no wrong/guessed tag)', () => {
+    const logs: string[] = []
+    __resetBuzzMirrorForTests()
+    const sender = vi.fn(() => true)
+    const m = initBuzzMirror({ mode: 'both', agentName: 'klanker', defaultChannelId: 'grp', log: (l) => logs.push(l) })
+    m.attachSender(sender)
+
+    // The antecedent key was NEVER mirrored (e.g. it is the user's own inbound
+    // message) — the lookup misses. The mirror must NOT invent a thread tag.
+    m.mirrorReplyDelivered({
+      scrubbedText: 'answer',
+      ownerOriginChannel: 'telegram',
+      ownerEchoed: false,
+      hasRecentDifferentOriginTurn: false,
+      telegramMessageKeys: ['555:200'],
+      antecedentTelegramMessageKey: '555:100', // not in the store
+    })
+
+    expect(sender).toHaveBeenCalledTimes(1)
+    const msg = sender.mock.calls[0][0] as OutboundToBuzzMessage
+    expect(msg.replyToEventId).toBeUndefined()
+    expect(msg.threadRootId).toBeUndefined()
+    // The flat fallback still PUBLISHES (top-level), just with no thread tags.
+    expect(buildThreadTags({ threadRootId: msg.threadRootId, replyToEventId: msg.replyToEventId })).toEqual([])
+    expect(logs.some((l) => /outbound thread MISS/.test(l))).toBe(true)
   })
 })
 


### PR DESCRIPTION
## What

Carries NIP-10 `e`-tag threading on Buzz **outbound mirrors** so a Telegram-origin reply chain renders as a thread on the Buzz desktop instead of a flat feed. Implements RFC `buzz-phase3.md` item **T1 — Telegram-origin mirror thread continuity** (CONTRACT-SAFE: pure mirror enrichment, no new inbound authority).

When mirroring an outbound answer that is itself a Telegram reply, the hub resolves the antecedent (the answer's finalized `reply_to`, `${chatId}:${messageId}`) against the durable msg→event correlation store and, on a **HIT**, stamps the kind:9 event with `replyToEventId` (immediate parent → NIP-10 `reply` marker) and `threadRootId` (thread root → `root` marker). The sidecar's existing `buildThreadTags` turns these into `["e", <id>, "", "reply"|"root"]`.

## Why

`telegram-plugin/gateway/buzz-mirror.ts` mirrors outbound hub messages to Buzz as kind:9 events. Inbound already surfaces NIP-10 metadata (`buzz_thread_root`, `buzz_reply_to`), but the outbound path never stamped threading tags, so a Telegram reply thread rendered flat on the desktop. This is the outbound half of NIP-10 threading.

## Correlation-store dependency (#4280)

Resolution reuses the merged #4280 durable correlation store (`buzz-mirror-correlation-store.ts`) — the same `msgToBuzz.get(key)` lookup the correction path uses; no new lookup surface. `onPublishResult` already records each mirrored answer's Telegram message keys → published Buzz event; a later reply whose antecedent is one of those keys resolves to that event id and threads under it.

To keep the `root` marker correct at depth, the store's `CorrelationValue` gains an **optional** `threadRoot`: each mirrored event records its thread root (its own id when top-level, else the parent's root). A reply into a deeper thread then emits a **distinct** root + reply marker instead of collapsing the thread. Backward-compatible — a journal record written before this field replays with `threadRoot` undefined and degrades to a `reply`-only tag (still valid NIP-10).

On a **MISS** (antecedent never mirrored — e.g. the user's own inbound message, which is never mirrored — or evicted past `MAX_TRACKED`), the mirror stays flat rather than emitting a wrong/guessed tag. Reuses the existing flat-fallback miss behavior; no new counter invented.

## Contract-safety

- **Outbound-only, kind:9 only.** No new inbound or action surface. `auth-gate.ts` and `gateway.ts` are untouched (verified — the only gateway-side edit is in `outbound-send-path.ts`, which passes the antecedent key). Stays inside `telegram-and-buzz-only`; T1 is recorded CONTRACT-SAFE in `buzz-phase3.md` (no invariant amendment required).
- Fire-and-forget, dark by default. No change to the Telegram delivery path.

## Job spec

`reference/jobs/use-my-team-from-the-desktop.md` — Buzz shows mirrors of Telegram answers; this makes those mirrors render as the same conversation, threaded.

## Test evidence

`./node_modules/.bin/vitest run telegram-plugin/tests/buzz-mirror.test.ts telegram-plugin/tests/buzz-mirror-correlation-store.test.ts` → **29 passed**.

- `buzz-mirror.test.ts`: a reply to a mirrored message emits e-tags with the correct root/reply ids + markers; a reply into a **deeper** thread emits a DISTINCT `root` + `reply`; an antecedent correlation-store **MISS** produces NO thread tags (flat) and logs the miss.
- `buzz-mirror-correlation-store.test.ts`: `threadRoot` persists + replays across a restart; a pre-`threadRoot` record replays with `threadRoot` undefined.
- Mutation check: both threading assertions **fail** when the antecedent-resolution block is disabled (confirmed the tests catch the bug, not just the code path).

Lint guards run locally (bot-api-wrapping, gateway-line-ratchet, callback-ctx-wrapping, no-pii-secrets, stale-tool-descriptions, bun-test-imports, test-runner-coverage) all clean. `tsc` is clean on the changed files; the `nostr-tools` / `@mtcute/node` resolution errors are an env gap in this worktree's shared `node_modules` (both are declared deps) — CI installs fresh.

## Risk

Low. Miss path preserves prior flat behavior; the store field is additive and backward-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
