### PR TITLE
Resolve reply-to-bot antecedents from history buffer + fix handoff-briefing staleness race

### DIFF
--- a/bin/handoff-briefing.sh
+++ b/bin/handoff-briefing.sh
@@ -47,7 +47,21 @@ HINDSIGHT_BANK="${HINDSIGHT_BANK_ID:-}"
 AGENT_DIR="${AGENT_DIR:-}"
 WORKSPACE_DIR="${WORKSPACE_DIR:-$AGENT_DIR}"
 MAX_MESSAGES="${HANDOFF_BRIEFING_MAX_MESSAGES:-20}"
-HINDSIGHT_TIMEOUT="${HANDOFF_BRIEFING_HINDSIGHT_TIMEOUT:-4}"
+# Hindsight is the only network hop; cap it at 3s so it finishes well inside
+# start.sh's outer `timeout 10` kill budget (was 4s under a 5s outer, which
+# left almost no margin — a slow recall could be SIGKILLed mid-write). Local
+# SQLite + daily-memory reads are sub-second, so 3s is the whole network cost.
+HINDSIGHT_TIMEOUT="${HANDOFF_BRIEFING_HINDSIGHT_TIMEOUT:-3}"
+
+# Chat/thread scope for the recent-conversation section (#continuity). A
+# forum/group agent's history.db holds messages from many topics; an unscoped
+# "last 20" briefing pollutes the reorientation with unrelated threads. Prefer
+# the surface that was mid-turn when the prior session ended (exported by
+# start.sh from the pending-turn env on an interrupted boot); otherwise the
+# python fallback derives the single most-recently-active (chat_id, thread_id)
+# surface straight from the DB. Empty ⇒ let python derive it.
+TARGET_CHAT_ID="${SWITCHROOM_PENDING_CHAT_ID:-}"
+TARGET_THREAD_ID="${SWITCHROOM_PENDING_THREAD_ID:-}"
 
 # Determine output mode
 STDOUT_MODE=0
@@ -61,28 +75,92 @@ if [ -n "$TELEGRAM_STATE" ] && [ -d "$TELEGRAM_STATE" ]; then
   HISTORY_DB="$TELEGRAM_STATE/history.db"
   if [ -f "$HISTORY_DB" ] && command -v python3 >/dev/null 2>&1; then
     # Use python3's stdlib sqlite3 — no bun:sqlite, no extra deps.
-    # Query the most recent $MAX_MESSAGES rows ordered by ts DESC, then
-    # reverse for chronological display. We skip system messages (role NULL).
-    TELEGRAM_ROWS=$(python3 - "$HISTORY_DB" "$MAX_MESSAGES" 2>/dev/null <<'PYEOF'
+    # Query the most recent $MAX_MESSAGES rows for the ACTIVE surface only
+    # (chat/thread-scoped, see above), ordered by ts DESC, then reverse for
+    # chronological display. We skip system messages (role NULL). The scope
+    # source is logged to stderr for boot diagnostics.
+    # python stderr is NOT suppressed: the script's only stderr output is the
+    # intentional scope breadcrumb + a single graceful line on any caught error
+    # (every DB path is wrapped in try/except → sys.exit(0)). start.sh runs this
+    # under `2>/dev/null`, so the breadcrumb is a debug/manual-run diagnostic.
+    TELEGRAM_ROWS=$(python3 - "$HISTORY_DB" "$MAX_MESSAGES" "$TARGET_CHAT_ID" "$TARGET_THREAD_ID" <<'PYEOF'
 import sys, sqlite3, datetime
 
 db_path = sys.argv[1]
 limit = int(sys.argv[2])
+target_chat = sys.argv[3] if len(sys.argv) > 3 else ""
+target_thread = sys.argv[4] if len(sys.argv) > 4 else ""
 
 try:
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     cur = conn.cursor()
-    # Fetch most recent rows; reverse for chronological output.
+
+    # Resolve the surface to scope to.
+    #  - explicit env target (pending-turn chat/thread) wins;
+    #  - else derive the single most-recently-active (chat_id, thread_id).
+    # thread is tri-state: a real value, NULL (DM / general), or unknown.
+    scope_chat = None
+    scope_thread = None          # int thread id
+    scope_thread_known = False   # True once we know the exact thread (incl. NULL)
+    scope_thread_is_null = False # True when the surface's thread is NULL
+    scope_source = "unscoped"
+
+    if target_chat:
+        scope_chat = target_chat
+        scope_source = "env"
+        if target_thread != "":
+            try:
+                scope_thread = int(target_thread)
+                scope_thread_known = True
+            except ValueError:
+                scope_thread = None  # unparseable → chat-only scope
+        # else: chat-only scope (all threads of the chat)
+    else:
+        cur.execute(
+            """
+            SELECT chat_id, thread_id
+            FROM messages
+            WHERE role IN ('user', 'assistant')
+            ORDER BY ts DESC
+            LIMIT 1
+            """
+        )
+        latest = cur.fetchone()
+        if latest is not None:
+            scope_chat = latest["chat_id"]
+            scope_source = "db-latest"
+            scope_thread_known = True
+            if latest["thread_id"] is None:
+                scope_thread_is_null = True
+            else:
+                scope_thread = latest["thread_id"]
+
+    if scope_chat is None:
+        # Empty DB (nothing to scope) — nothing to show.
+        sys.stderr.write("handoff-briefing: no messages to scope; empty section\n")
+        sys.exit(0)
+
+    where = ["role IN ('user', 'assistant')", "chat_id = ?"]
+    params = [scope_chat]
+    if scope_thread_known:
+        if scope_thread_is_null:
+            where.append("thread_id IS NULL")
+        else:
+            where.append("thread_id = ?")
+            params.append(scope_thread)
+    params.append(limit)
+
+    sys.stderr.write(
+        "handoff-briefing: scoping recent conversation to chat=%s thread=%s (source=%s)\n"
+        % (scope_chat, "NULL" if scope_thread_is_null else (scope_thread if scope_thread_known else "any"), scope_source)
+    )
+
     cur.execute(
-        """
-        SELECT role, user, ts, text
-        FROM messages
-        WHERE role IN ('user', 'assistant')
-        ORDER BY ts DESC
-        LIMIT ?
-        """,
-        (limit,),
+        "SELECT role, user, ts, text FROM messages WHERE "
+        + " AND ".join(where)
+        + " ORDER BY ts DESC LIMIT ?",
+        params,
     )
     rows = list(reversed(cur.fetchall()))
     conn.close()
@@ -110,6 +188,70 @@ $TELEGRAM_ROWS"
   fi
 fi
 
+# ── Header (cheap, no network) — computed early so the recent-conversation
+# section can be flushed to disk BEFORE the slow Hindsight hop. ──────────────
+# Restart timestamp — model-facing: it lands in the resume-turn system prompt
+# via --append-system-prompt ("You just restarted at …"). Render the agent's
+# LOCAL am/pm wall clock, NOT UTC, so the restart turn never sees a competing
+# UTC "now". Same SWITCHROOM_TIMEZONE → TZ → UTC cascade the daily section uses.
+_TZ_VAL="${SWITCHROOM_TIMEZONE:-${TZ:-UTC}}"
+TIMESTAMP=$(TZ="$_TZ_VAL" date '+%A %Y-%m-%d %I:%M %p %Z' 2>/dev/null || date '+%A %Y-%m-%d %I:%M %p %Z')
+RESTART_REASON="unknown"
+if [ -n "$AGENT_DIR" ] && [ -f "$AGENT_DIR/.restart-reason" ]; then
+  RESTART_REASON=$(cat "$AGENT_DIR/.restart-reason" 2>/dev/null | head -1 | tr -d '\r\n')
+fi
+if [ -n "${SWITCHROOM_PENDING_ENDED_VIA:-}" ]; then
+  RESTART_REASON="$SWITCHROOM_PENDING_ENDED_VIA"
+fi
+BRIEFING_HEADER="You just restarted at ${TIMESTAMP}. Previous session ended via: ${RESTART_REASON}. Consult this briefing before responding."
+
+# Resolve the output destination up front (file mode only).
+OUTPUT_FILE=""
+OUTPUT_TMP=""
+if [ "$STDOUT_MODE" != "1" ] && [ -n "$AGENT_DIR" ]; then
+  OUTPUT_FILE="$AGENT_DIR/.handoff-briefing.md"
+  OUTPUT_TMP="${OUTPUT_FILE}.tmp.$$"
+fi
+
+# Incremental emit (#continuity). Sections are flushed to the output file as
+# each source resolves — the recent-conversation section (the highest-value,
+# always-local part) is written BEFORE the network-bound Hindsight hop. So a
+# late-stage SIGKILL (e.g. start.sh's outer `timeout`) mid-Hindsight still
+# leaves the recent conversation on disk instead of nothing. The first flush
+# writes header+section atomically via tmp+mv; later sections append. In
+# stdout/no-AGENT_DIR mode we buffer and print once at the end instead.
+FILE_STARTED=0
+STDOUT_BUFFER=""
+emit_section() {
+  # $1 = section content (assumed non-empty)
+  section="$1"
+  if [ -n "$OUTPUT_FILE" ]; then
+    if [ "$FILE_STARTED" = "0" ]; then
+      # First section: header + divider + section, written atomically.
+      printf '%s\n\n---\n\n%s' "$BRIEFING_HEADER" "$section" > "$OUTPUT_TMP" \
+        && mv -f "$OUTPUT_TMP" "$OUTPUT_FILE"
+      FILE_STARTED=1
+    else
+      printf '\n\n---\n\n%s' "$section" >> "$OUTPUT_FILE"
+    fi
+  else
+    if [ -z "$STDOUT_BUFFER" ]; then
+      STDOUT_BUFFER="$section"
+    else
+      STDOUT_BUFFER="$STDOUT_BUFFER
+
+---
+
+$section"
+    fi
+  fi
+}
+
+# Flush the recent-conversation section NOW, before Hindsight.
+if [ -n "$TELEGRAM_SECTION" ]; then
+  emit_section "$TELEGRAM_SECTION"
+fi
+
 # ── Source 2: Hindsight recall ──────────────────────────────────────────────────
 HINDSIGHT_SECTION=""
 if [ -n "$HINDSIGHT_URL" ] && [ -n "$HINDSIGHT_BANK" ] && command -v curl >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
@@ -133,14 +275,16 @@ $RECALL_TEXT"
     fi
   fi
 fi
+if [ -n "$HINDSIGHT_SECTION" ]; then
+  emit_section "$HINDSIGHT_SECTION"
+fi
 
 # ── Source 3: Today's daily memory ─────────────────────────────────────────────
-# Resolve "today" in the agent's LOCAL time — NOT the process default (UTC on
-# most hosts/CI). TODAY keys the daily-memory lookup (memory/${TODAY}.md); using
-# UTC here would look up the wrong day's file during the window where the local
-# date is ahead of/behind UTC, silently dropping today's memory. Same
-# SWITCHROOM_TIMEZONE → TZ → UTC cascade the restart-timestamp render below uses.
-_TZ_VAL="${SWITCHROOM_TIMEZONE:-${TZ:-UTC}}"
+# TODAY keys the daily-memory lookup (memory/${TODAY}.md) in the agent's LOCAL
+# time (_TZ_VAL, resolved in the header block above) — NOT the process default
+# (UTC on most hosts/CI). Using UTC here would look up the wrong day's file
+# during the window where the local date is ahead of/behind UTC, silently
+# dropping today's memory.
 DAILY_SECTION=""
 TODAY=$(TZ="$_TZ_VAL" date +%Y-%m-%d 2>/dev/null || date +%Y-%m-%d 2>/dev/null || true)
 if [ -n "$TODAY" ] && [ -n "$WORKSPACE_DIR" ]; then
@@ -154,66 +298,26 @@ $DAILY_CONTENT"
     fi
   fi
 fi
-
-# ── Assemble briefing ───────────────────────────────────────────────────────────
-# Restart timestamp — model-facing: it lands in the resume-turn system prompt
-# via --append-system-prompt ("You just restarted at …"). Render the agent's
-# LOCAL am/pm wall clock, NOT UTC, so the restart turn never sees a competing
-# UTC "now" (the whole point of the deterministic-local-time work). Same
-# SWITCHROOM_TIMEZONE → TZ → UTC cascade and `%A %Y-%m-%d %I:%M %p %Z` am/pm
-# format the UserPromptSubmit local-time hook (bin/timezone-hook.sh) uses.
-# (_TZ_VAL is computed once above, in the daily-memory section.)
-TIMESTAMP=$(TZ="$_TZ_VAL" date '+%A %Y-%m-%d %I:%M %p %Z' 2>/dev/null || date '+%A %Y-%m-%d %I:%M %p %Z')
-
-# Determine restart reason if available
-RESTART_REASON="unknown"
-if [ -n "$AGENT_DIR" ] && [ -f "$AGENT_DIR/.restart-reason" ]; then
-  RESTART_REASON=$(cat "$AGENT_DIR/.restart-reason" 2>/dev/null | head -1 | tr -d '\r\n')
-fi
-# Also check SWITCHROOM_PENDING_ENDED_VIA if set by start.sh
-if [ -n "${SWITCHROOM_PENDING_ENDED_VIA:-}" ]; then
-  RESTART_REASON="$SWITCHROOM_PENDING_ENDED_VIA"
+if [ -n "$DAILY_SECTION" ]; then
+  emit_section "$DAILY_SECTION"
 fi
 
-# Build the briefing body
-SECTIONS=""
-for section in "$TELEGRAM_SECTION" "$HINDSIGHT_SECTION" "$DAILY_SECTION"; do
-  if [ -n "$section" ]; then
-    if [ -n "$SECTIONS" ]; then
-      SECTIONS="$SECTIONS
-
----
-
-$section"
-    else
-      SECTIONS="$section"
-    fi
+# ── Finalize ────────────────────────────────────────────────────────────────────
+# Every section was flushed as it resolved (emit_section). Here we only close
+# out the chosen sink. An all-empty briefing wrote nothing — leave it that way
+# so start.sh skips the --append-system-prompt arg.
+if [ -n "$OUTPUT_FILE" ]; then
+  # File mode. FILE_STARTED=1 means at least one section was written atomically
+  # (header+first) with the rest appended; add the trailing newline the
+  # single-shot writer used to emit. If nothing was written, no file exists.
+  if [ "$FILE_STARTED" = "1" ]; then
+    printf '\n' >> "$OUTPUT_FILE"
   fi
-done
-
-# Empty briefing — nothing to inject
-if [ -z "$SECTIONS" ]; then
-  exit 0
-fi
-
-BRIEFING="You just restarted at ${TIMESTAMP}. Previous session ended via: ${RESTART_REASON}. Consult this briefing before responding.
-
----
-
-${SECTIONS}"
-
-# ── Output ──────────────────────────────────────────────────────────────────────
-if [ "$STDOUT_MODE" = "1" ]; then
-  printf '%s\n' "$BRIEFING"
 else
-  if [ -z "$AGENT_DIR" ]; then
-    # Fallback: write to stdout if AGENT_DIR is not set
-    printf '%s\n' "$BRIEFING"
-    exit 0
+  # stdout / no-AGENT_DIR mode — buffered; print the whole briefing once.
+  if [ -n "$STDOUT_BUFFER" ]; then
+    printf '%s\n\n---\n\n%s\n' "$BRIEFING_HEADER" "$STDOUT_BUFFER"
   fi
-  OUTPUT_FILE="$AGENT_DIR/.handoff-briefing.md"
-  OUTPUT_TMP="${OUTPUT_FILE}.tmp.$$"
-  printf '%s\n' "$BRIEFING" > "$OUTPUT_TMP" && mv -f "$OUTPUT_TMP" "$OUTPUT_FILE"
 fi
 
 exit 0

--- a/bin/handoff-briefing.sh
+++ b/bin/handoff-briefing.sh
@@ -49,7 +49,7 @@ WORKSPACE_DIR="${WORKSPACE_DIR:-$AGENT_DIR}"
 MAX_MESSAGES="${HANDOFF_BRIEFING_MAX_MESSAGES:-20}"
 # Hindsight is the only network hop; cap it at 3s so it finishes well inside
 # start.sh's outer `timeout 10` kill budget (was 4s under a 5s outer, which
-# left almost no margin — a slow recall could be SIGKILLed mid-write). Local
+# left almost no margin — a slow recall could be killed mid-write). Local
 # SQLite + daily-memory reads are sub-second, so 3s is the whole network cost.
 HINDSIGHT_TIMEOUT="${HANDOFF_BRIEFING_HINDSIGHT_TIMEOUT:-3}"
 
@@ -59,7 +59,15 @@ HINDSIGHT_TIMEOUT="${HANDOFF_BRIEFING_HINDSIGHT_TIMEOUT:-3}"
 # the surface that was mid-turn when the prior session ended (exported by
 # start.sh from the pending-turn env on an interrupted boot); otherwise the
 # python fallback derives the single most-recently-active (chat_id, thread_id)
-# surface straight from the DB. Empty ⇒ let python derive it.
+# surface straight from the DB. Empty chat ⇒ let python derive it.
+#
+# TARGET_THREAD_ID is tri-state: a numbered thread scopes to that topic; the
+# literal sentinel `NULL` means the surface's thread is genuinely NULL (a DM /
+# forum General topic) and scopes with `thread_id IS NULL`; empty means the
+# thread is UNKNOWN and falls back to chat-only scope (all threads). The
+# pending-turn env writer emits `NULL` when it knows the interrupted turn's
+# thread was null, so a General-topic interrupt reboots correctly scoped
+# instead of pulling in every other topic's messages.
 TARGET_CHAT_ID="${SWITCHROOM_PENDING_CHAT_ID:-}"
 TARGET_THREAD_ID="${SWITCHROOM_PENDING_THREAD_ID:-}"
 
@@ -97,26 +105,32 @@ try:
     cur = conn.cursor()
 
     # Resolve the surface to scope to.
-    #  - explicit env target (pending-turn chat/thread) wins;
+    #  - explicit env target (pending-turn chat/thread) wins — UNLESS that chat
+    #    has zero rows (rotated/fresh DB), in which case we fall through to
+    #    db-latest so a stale env target doesn't yield an empty section;
     #  - else derive the single most-recently-active (chat_id, thread_id).
     # thread is tri-state: a real value, NULL (DM / general), or unknown.
+    #  - target_thread == "NULL" (sentinel from start.sh / pending-turn-env)
+    #    means the surface's thread is GENUINELY NULL (DM / general topic) —
+    #    scope with `thread_id IS NULL`, do NOT pull in numbered-thread rows.
+    #  - target_thread == "" (empty) means UNKNOWN — chat-only scope (all
+    #    threads), the safe backward-compatible fallback.
     scope_chat = None
     scope_thread = None          # int thread id
     scope_thread_known = False   # True once we know the exact thread (incl. NULL)
     scope_thread_is_null = False # True when the surface's thread is NULL
     scope_source = "unscoped"
 
-    if target_chat:
-        scope_chat = target_chat
-        scope_source = "env"
-        if target_thread != "":
-            try:
-                scope_thread = int(target_thread)
-                scope_thread_known = True
-            except ValueError:
-                scope_thread = None  # unparseable → chat-only scope
-        # else: chat-only scope (all threads of the chat)
-    else:
+    def _chat_has_rows(chat_id):
+        cur.execute(
+            "SELECT 1 FROM messages WHERE role IN ('user', 'assistant') "
+            "AND chat_id = ? LIMIT 1",
+            [chat_id],
+        )
+        return cur.fetchone() is not None
+
+    def _derive_db_latest():
+        # The single most-recently-active (chat_id, thread_id) surface.
         cur.execute(
             """
             SELECT chat_id, thread_id
@@ -126,7 +140,28 @@ try:
             LIMIT 1
             """
         )
-        latest = cur.fetchone()
+        return cur.fetchone()
+
+    # Env target — accept it only when its chat actually has rows (2b). A
+    # rotated/fresh DB can leave a pending-turn chat with no persisted
+    # messages; scoping to it would silently emit an empty section, so we
+    # fall through to db-latest instead.
+    if target_chat and _chat_has_rows(target_chat):
+        scope_chat = target_chat
+        scope_source = "env"
+        if target_thread == "NULL":
+            scope_thread_is_null = True
+            scope_thread_known = True
+        elif target_thread != "":
+            try:
+                scope_thread = int(target_thread)
+                scope_thread_known = True
+            except ValueError:
+                scope_thread = None  # unparseable → chat-only scope
+        # else: unknown thread → chat-only scope (all threads of the chat)
+
+    if scope_chat is None:
+        latest = _derive_db_latest()
         if latest is not None:
             scope_chat = latest["chat_id"]
             scope_source = "db-latest"
@@ -216,7 +251,7 @@ fi
 # Incremental emit (#continuity). Sections are flushed to the output file as
 # each source resolves — the recent-conversation section (the highest-value,
 # always-local part) is written BEFORE the network-bound Hindsight hop. So a
-# late-stage SIGKILL (e.g. start.sh's outer `timeout`) mid-Hindsight still
+# late-stage kill (e.g. start.sh's outer `timeout`, SIGTERM by default) mid-Hindsight still
 # leaves the recent conversation on disk instead of nothing. The first flush
 # writes header+section atomically via tmp+mv; later sections append. In
 # stdout/no-AGENT_DIR mode we buffer and print once at the end instead.

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -1486,18 +1486,20 @@ if [ "$_HANDOFF_STALE" = "1" ]; then
     # Clear any prior-boot briefing BEFORE rebuilding (#continuity). The
     # sidecar rm below (post-injection) is skipped if a boot crashes between
     # the rebuild and injection, leaving last boot's .handoff-briefing.md on
-    # disk. If this boot's rebuild is then SIGKILLed by the outer `timeout`
-    # before handoff-briefing.sh's atomic write, the injection would re-serve
-    # that STALE prior-boot briefing. Deleting the target up front makes a
-    # killed rebuild yield a MISSING file (injection skips) rather than a
-    # stale one. handoff-briefing.sh recreates it via tmp+mv on success.
+    # disk. If this boot's rebuild is then killed by the outer `timeout`
+    # (SIGTERM — `timeout 10` sends SIGTERM by default, not SIGKILL) before
+    # handoff-briefing.sh's atomic write, the injection would re-serve that
+    # STALE prior-boot briefing. Deleting the target up front makes a killed
+    # rebuild yield a MISSING file (injection skips) rather than a stale one.
+    # handoff-briefing.sh recreates it via tmp+mv on success.
     rm -f "$HANDOFF_BRIEFING_FILE" 2>/dev/null || true
     # Outer kill budget (10s) must strictly exceed the inner Hindsight cap
-    # (3s, HANDOFF_BRIEFING_HINDSIGHT_TIMEOUT) with margin, so the SIGKILL
-    # lands only on a genuinely wedged run — never mid-write of a recall that
-    # was about to return. The local SQLite (Telegram) and daily-memory reads
-    # are sub-second; Hindsight is the only network hop and is self-capped, so
-    # 10s leaves ~7s of headroom over the worst-case source.
+    # (3s, HANDOFF_BRIEFING_HINDSIGHT_TIMEOUT) with margin, so the SIGTERM
+    # (`timeout 10`'s default signal) lands only on a genuinely wedged run —
+    # never mid-write of a recall that was about to return. The local SQLite
+    # (Telegram) and daily-memory reads are sub-second; Hindsight is the only
+    # network hop and is self-capped, so 10s leaves ~7s of headroom over the
+    # worst-case source.
     export HANDOFF_BRIEFING_HINDSIGHT_TIMEOUT="${HANDOFF_BRIEFING_HINDSIGHT_TIMEOUT:-3}"
     timeout 10 handoff-briefing.sh 2>/dev/null || true
   fi

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -1483,7 +1483,23 @@ if [ "$_HANDOFF_STALE" = "1" ]; then
      && { [ "{{#if sessionBriefingMode}}{{{sessionBriefingMode}}}{{else}}legacy{{/if}}" != "gateway" ] || [ -f "{{agentDir}}/.gateway-briefing-unavailable" ]; } \
      && command -v handoff-briefing.sh >/dev/null 2>&1; then
     export AGENT_DIR="{{agentDir}}"
-    timeout 5 handoff-briefing.sh 2>/dev/null || true
+    # Clear any prior-boot briefing BEFORE rebuilding (#continuity). The
+    # sidecar rm below (post-injection) is skipped if a boot crashes between
+    # the rebuild and injection, leaving last boot's .handoff-briefing.md on
+    # disk. If this boot's rebuild is then SIGKILLed by the outer `timeout`
+    # before handoff-briefing.sh's atomic write, the injection would re-serve
+    # that STALE prior-boot briefing. Deleting the target up front makes a
+    # killed rebuild yield a MISSING file (injection skips) rather than a
+    # stale one. handoff-briefing.sh recreates it via tmp+mv on success.
+    rm -f "$HANDOFF_BRIEFING_FILE" 2>/dev/null || true
+    # Outer kill budget (10s) must strictly exceed the inner Hindsight cap
+    # (3s, HANDOFF_BRIEFING_HINDSIGHT_TIMEOUT) with margin, so the SIGKILL
+    # lands only on a genuinely wedged run — never mid-write of a recall that
+    # was about to return. The local SQLite (Telegram) and daily-memory reads
+    # are sub-second; Hindsight is the only network hop and is self-capped, so
+    # 10s leaves ~7s of headroom over the worst-case source.
+    export HANDOFF_BRIEFING_HINDSIGHT_TIMEOUT="${HANDOFF_BRIEFING_HINDSIGHT_TIMEOUT:-3}"
+    timeout 10 handoff-briefing.sh 2>/dev/null || true
   fi
 fi
 APPEND_PROMPT={{#if systemPromptAppendShellQuoted}}{{{systemPromptAppendShellQuoted}}}{{else}}""{{/if}}

--- a/telegram-plugin/gateway/boot-briefing-wiring.ts
+++ b/telegram-plugin/gateway/boot-briefing-wiring.ts
@@ -56,9 +56,11 @@ export interface MaybeQueueBootBriefingOptions {
 
 /**
  * Fetch the Hindsight recall slice (source 2 of the legacy handoff
- * contract). Mirrors `bin/handoff-briefing.sh`'s request EXACTLY:
+ * contract). Mirrors `bin/handoff-briefing.sh`'s request shape:
  * `POST ${HINDSIGHT_API_URL}/v1/default/banks/${HINDSIGHT_BANK_ID}/memories/recall`
- * with body `{query, max_tokens: 800}` and a 4s timeout.
+ * with body `{query, max_tokens: 800}`. This gateway path uses a 4s abort
+ * timeout; the shell script caps its curl at 3s (it runs under start.sh's
+ * outer `timeout`, which the async gateway daemon is not subject to).
  *
  * Graceful-skip on ANY failure — missing env, timeout, non-200, malformed
  * JSON — returns `[]` so the briefing degrades to its other sources rather

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -127,6 +127,7 @@ import {
   routeInbound,
   admitInbound,
   buildReplyForwardContext,
+  resolveReplyToFromBuffer,
   buildInboundEnvelope,
   INBOUND_ROUTER_V2,
   runPreTurnIntercepts,
@@ -15078,17 +15079,39 @@ export async function handleInbound(
 
   // Reply-to + forward-origin context — moved to buildReplyForwardContext
   // (#2996 P7 PR-10, pure builder).
-  const {
-    replyToMessageId,
-    replyToText,
-    replyToTextEscaped,
-    forwardOrigins,
-    forwardOriginMeta,
-    primaryForwardOrigin,
-  } = buildReplyForwardContext({
+  const replyForwardCtx = buildReplyForwardContext({
     ctx,
     coalescedForwardOrigins,
     replyToTextMax: REPLY_TO_TEXT_MAX,
+  })
+  const {
+    replyToMessageId,
+    forwardOrigins,
+    forwardOriginMeta,
+    primaryForwardOrigin,
+  } = replyForwardCtx
+
+  // Reply-to buffer fallback (post-reset continuity, resolveReplyToFromBuffer).
+  // On a native reply to the BOT's OWN message, Telegram delivers
+  // reply_to_message.message_id but NOT its .text — so the live reply text is
+  // empty even though we authored (and, via recordOutbound, persisted) that
+  // message to history.db (role='assistant', 30-day retention). Recover it so
+  // the antecedent survives a session reset. Fills replyToText (raw, so the
+  // recordInbound write below persists it — envelope-only would leave the row
+  // NULL and starve future briefings), replyToTextEscaped (channel meta), and
+  // replyToRole (the reply_to_role attribute). Only when the live text is
+  // empty; degrades silently when history is off / the row is missing.
+  const {
+    replyToText,
+    replyToTextEscaped,
+    replyToRole,
+  } = resolveReplyToFromBuffer({
+    replyToMessageId,
+    replyToText: replyForwardCtx.replyToText,
+    replyToTextEscaped: replyForwardCtx.replyToTextEscaped,
+    historyEnabled: HISTORY_ENABLED,
+    replyToTextMax: REPLY_TO_TEXT_MAX,
+    lookup: (messageId) => lookupMessageRoleAndText(chat_id, messageId),
   })
 
   if (HISTORY_ENABLED) {
@@ -15165,6 +15188,7 @@ export async function handleInbound(
     priorAssistantPreview,
     replyToMessageId,
     replyToTextEscaped,
+    replyToRole,
     forwardOriginMeta,
     topicFramingEnabled: TOPIC_FRAMING_ENABLED,
     personDirectory: PERSON_DIRECTORY,

--- a/telegram-plugin/gateway/inbound-router.ts
+++ b/telegram-plugin/gateway/inbound-router.ts
@@ -151,9 +151,20 @@ export function buildReplyForwardContext(p: ReplyForwardContextParams): {
   // (for channel meta).
   const replyToMsg = p.ctx.message?.reply_to_message
   const replyToMessageId = replyToMsg?.message_id
-  const replyToTextRaw = replyToMsg
-    ? (replyToMsg.text ?? replyToMsg.caption ?? undefined)
-    : undefined
+  // Native partial-quote preference (Bot API 7.0+ `message.quote`, issue #119
+  // follow-up). When the user long-presses a message and drag-selects a
+  // substring before choosing Reply, Telegram delivers only that quoted span
+  // on `message.quote.text` — the user is pointing at that exact slice, so it
+  // is a stronger antecedent than the full parent message. Prefer it over the
+  // parent `.text`/`.caption`, and over the history-buffer fallback the
+  // gateway runs when neither is present. Accessed defensively in case the
+  // installed grammy/@grammyjs/types predate `TextQuote`.
+  const quoteText = p.ctx.message?.quote?.text
+  const replyToTextRaw = (quoteText != null && quoteText.length > 0)
+    ? quoteText
+    : replyToMsg
+      ? (replyToMsg.text ?? replyToMsg.caption ?? undefined)
+      : undefined
   const replyToText = replyToTextRaw != null
     ? (replyToTextRaw.length > p.replyToTextMax
         ? replyToTextRaw.slice(0, p.replyToTextMax - 1) + '…'
@@ -183,6 +194,73 @@ export function buildReplyForwardContext(p: ReplyForwardContextParams): {
   }
 }
 
+/** Inputs for {@link resolveReplyToFromBuffer}. */
+export interface ReplyToBufferFallbackParams {
+  /** From {@link buildReplyForwardContext}. */
+  replyToMessageId: number | undefined
+  /** Raw reply text off the live update (for the SQLite write); empty when the
+   *  reply target is the bot's own message (Telegram omits its text). */
+  replyToText: string | undefined
+  /** XML-escaped reply text for the channel meta; empty in the same case. */
+  replyToTextEscaped: string | undefined
+  /** HISTORY_ENABLED — the DB is only present when history is on. */
+  historyEnabled: boolean
+  /** REPLY_TO_TEXT_MAX. */
+  replyToTextMax: number
+  /** `lookupMessageRoleAndText` bound to the chat, or any equivalent. May
+   *  throw (e.g. requireDb when history disabled mid-run) — this is caught. */
+  lookup: (messageId: number) => { role: 'user' | 'assistant'; text: string } | null
+}
+
+/**
+ * Reply-to buffer fallback (post-reset continuity). On a native reply to the
+ * BOT's OWN message, Telegram delivers `reply_to_message.message_id` but NOT
+ * its `.text` — so the live reply text is empty even though the gateway
+ * authored (and, via `recordOutbound`, persisted) that message. This recovers
+ * the antecedent from the local history buffer so it survives a session reset
+ * (`resume_mode: handoff`), where the transcript is gone.
+ *
+ * Returns updated `replyToText` (raw, for the SQLite `recordInbound` write —
+ * envelope-only would leave the row NULL and starve future handoff briefings),
+ * `replyToTextEscaped` (for the channel-meta `reply_to_text`), and the
+ * recovered `replyToRole` ('assistant' = the bot's own message, disambiguating
+ * the "you're replying to yourself" case). Pure except for the injected
+ * `lookup`. Only fills in when the live reply text is empty — never overwrites
+ * a non-empty live value (a partial-quote or a reply to a person's message).
+ * Degrades silently to the id-only inputs on any lookup failure.
+ */
+export function resolveReplyToFromBuffer(p: ReplyToBufferFallbackParams): {
+  replyToText: string | undefined
+  replyToTextEscaped: string | undefined
+  replyToRole: 'user' | 'assistant' | undefined
+} {
+  let replyToText = p.replyToText
+  let replyToTextEscaped = p.replyToTextEscaped
+  let replyToRole: 'user' | 'assistant' | undefined
+  const liveTextEmpty = replyToTextEscaped == null || replyToTextEscaped.length === 0
+  if (p.historyEnabled && p.replyToMessageId != null && liveTextEmpty) {
+    try {
+      const recovered = p.lookup(p.replyToMessageId)
+      if (recovered && recovered.text.length > 0) {
+        replyToText =
+          recovered.text.length > p.replyToTextMax
+            ? recovered.text.slice(0, p.replyToTextMax - 1) + '…'
+            : recovered.text
+        replyToTextEscaped = formatReplyToText(recovered.text, p.replyToTextMax)
+        replyToRole = recovered.role
+      } else if (recovered) {
+        // Row exists (authorship known) but text is empty/redacted — still
+        // surface the role so the model knows whose message it is replying to.
+        replyToRole = recovered.role
+      }
+    } catch {
+      // History disabled mid-run / requireDb throws / row missing — degrade
+      // silently to the id-only inputs (current behavior).
+    }
+  }
+  return { replyToText, replyToTextEscaped, replyToRole }
+}
+
 /** Inputs for {@link buildInboundEnvelope} — every field is an at-call
  * captured value (steering meta, at-receipt snapshots, resolved attachments),
  * never a live getter. */
@@ -206,6 +284,11 @@ export interface EnvelopeBuildParams {
   priorAssistantPreview: string | undefined
   replyToMessageId: number | undefined
   replyToTextEscaped: string | undefined
+  /** Authorship of the replied-to message ('assistant' = the bot's own
+   * message, 'user' = a person's), when known — recovered from the history
+   * buffer by handleInbound's reply-to fallback. Undefined when the role
+   * can't be determined (e.g. text came live off the update, not the DB). */
+  replyToRole: 'user' | 'assistant' | undefined
   forwardOriginMeta: Record<string, string>
   /** TOPIC_FRAMING_ENABLED — fixed constant. */
   topicFramingEnabled: boolean
@@ -300,6 +383,13 @@ export function buildInboundEnvelope(p: EnvelopeBuildParams): InboundMessage {
       // Use the XML-escaped form for the meta — the raw form is in the
       // SQLite buffer for verbatim retrieval via get_recent_messages.
       ...(p.replyToTextEscaped != null && p.replyToTextEscaped.length > 0 ? { reply_to_text: p.replyToTextEscaped } : {}),
+      // Authorship of the replied-to message. Disambiguates "you are replying
+      // to the BOT's own message" (assistant) from "…to a person's message"
+      // (user) — the incident where a native reply to one of the bot's own
+      // messages ("is this added as a calendar invite yet?") left the agent
+      // guessing the antecedent. Free: the history-buffer lookup that recovers
+      // reply_to_text already returns the role. Emitted only when known.
+      ...(p.replyToRole != null ? { reply_to_role: p.replyToRole } : {}),
       // Forwarded-message origin (server-stamped, attrs-only — see above).
       // forwarded_from / forwarded_from_type / forwarded_from_id /
       // forwarded_date, plus numbered _2.. siblings for a multi-origin

--- a/telegram-plugin/gateway/pending-turn-env.ts
+++ b/telegram-plugin/gateway/pending-turn-env.ts
@@ -32,9 +32,18 @@ export function writePendingTurnEnv(
         `SWITCHROOM_PENDING_TURN=true`,
         `SWITCHROOM_PENDING_TURN_KEY=${pending.turn_key}`,
         `SWITCHROOM_PENDING_CHAT_ID=${pending.chat_id}`,
+        // Tri-state thread signal for the handoff-briefing scope resolver.
+        // A pending Turn ALWAYS knows its thread: a numbered forum topic, or
+        // NULL (a DM / forum General topic). Emit the numeric id for a topic,
+        // and the literal sentinel `NULL` when the thread is genuinely null —
+        // so bin/handoff-briefing.sh scopes the reorientation to `thread_id IS
+        // NULL` instead of falling back to chat-only (all-threads) scope. An
+        // empty value is reserved for "thread unknown"; the writer never emits
+        // it, but an older gateway would, and the resolver treats empty as the
+        // safe chat-only fallback.
         pending.thread_id != null
           ? `SWITCHROOM_PENDING_THREAD_ID=${pending.thread_id}`
-          : `SWITCHROOM_PENDING_THREAD_ID=`,
+          : `SWITCHROOM_PENDING_THREAD_ID=NULL`,
         pending.last_user_msg_id != null
           ? `SWITCHROOM_PENDING_USER_MSG_ID=${pending.last_user_msg_id}`
           : `SWITCHROOM_PENDING_USER_MSG_ID=`,

--- a/telegram-plugin/tests/reply-to-buffer-fallback.test.ts
+++ b/telegram-plugin/tests/reply-to-buffer-fallback.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Reply-to buffer fallback + role tag + native partial-quote preference.
+ *
+ * WHAT THESE PIN (post-reset conversation continuity)
+ * ---------------------------------------------------
+ * The real incident: after a session reset (`resume_mode: handoff` → fresh
+ * session, transcript gone) a user native-REPLIED to one of the BOT's OWN
+ * messages ("is this added as a calendar invite yet?"). Telegram delivers
+ * `reply_to_message.message_id` on such a reply but NOT the message's `.text`
+ * (it omits the text when the reply target is the bot's own message), so the
+ * live update carried no antecedent — and the agent had to guess. The bot had
+ * already persisted that outbound to `history.db` via `recordOutbound`
+ * (role='assistant'); the fix reads it back.
+ *
+ * These are OUTCOME tests against the real pure builders, not the code paths:
+ *   - `resolveReplyToFromBuffer` recovers the text AND the role from a buffer
+ *     hit, truncates to the cap, and — critically — sets BOTH the raw
+ *     `replyToText` (which the gateway's recordInbound write persists, so the
+ *     DB row is non-NULL for future briefings) and the escaped form (for the
+ *     envelope). A test that only checked the envelope would pass on the
+ *     rejected envelope-only design and miss the NULL-row regression.
+ *   - The history-disabled / lookup-throws guard degrades silently (no throw).
+ *   - A non-empty LIVE reply text is never overwritten.
+ *   - `buildReplyForwardContext` prefers `message.quote.text` (a native
+ *     partial quote) over the full parent `.text`.
+ *   - `buildInboundEnvelope` emits `reply_to_role` when known and `reply_to_text`
+ *     from the recovered escaped form.
+ *
+ * The persisted-row-non-NULL half of the 1a contract (which needs a real
+ * bun:sqlite history.db) lives in reply-to-buffer-history.test.ts (bun).
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { Context } from 'grammy'
+import {
+  buildReplyForwardContext,
+  resolveReplyToFromBuffer,
+  buildInboundEnvelope,
+  type EnvelopeBuildParams,
+} from '../gateway/inbound-router.js'
+
+const REPLY_TO_TEXT_MAX = 200
+
+/** A minimal grammy Context carrying only the message fields the builders read. */
+function makeCtx(message: Record<string, unknown>): Context {
+  return { message: { date: 1_700_000_000, ...message } } as unknown as Context
+}
+
+describe('resolveReplyToFromBuffer — reply-to buffer fallback (1a)', () => {
+  it('recovers a bot-authored antecedent: sets raw text, escaped text, AND role', () => {
+    // Live update: a native reply to the bot's own message → id present, text empty.
+    const out = resolveReplyToFromBuffer({
+      replyToMessageId: 42,
+      replyToText: undefined,
+      replyToTextEscaped: undefined,
+      historyEnabled: true,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+      lookup: (id) =>
+        id === 42
+          ? { role: 'assistant', text: 'Added the calendar invite for Friday 3pm.' }
+          : null,
+    })
+    // Raw text (for the SQLite recordInbound write — NOT envelope-only).
+    expect(out.replyToText).toBe('Added the calendar invite for Friday 3pm.')
+    // Escaped form (for the channel-meta reply_to_text).
+    expect(out.replyToTextEscaped).toBe('Added the calendar invite for Friday 3pm.')
+    // Role disambiguates "you are replying to the bot's own message".
+    expect(out.replyToRole).toBe('assistant')
+  })
+
+  it("tags a person's message as role='user'", () => {
+    const out = resolveReplyToFromBuffer({
+      replyToMessageId: 7,
+      replyToText: undefined,
+      replyToTextEscaped: undefined,
+      historyEnabled: true,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+      lookup: () => ({ role: 'user', text: 'the thing I asked earlier' }),
+    })
+    expect(out.replyToRole).toBe('user')
+    expect(out.replyToText).toBe('the thing I asked earlier')
+  })
+
+  it('truncates the recovered text to REPLY_TO_TEXT_MAX (raw and escaped)', () => {
+    const long = 'x'.repeat(500)
+    const out = resolveReplyToFromBuffer({
+      replyToMessageId: 1,
+      replyToText: undefined,
+      replyToTextEscaped: undefined,
+      historyEnabled: true,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+      lookup: () => ({ role: 'assistant', text: long }),
+    })
+    // Raw: sliced to max-1 chars + ellipsis = exactly max glyphs.
+    expect([...(out.replyToText ?? '')].length).toBe(REPLY_TO_TEXT_MAX)
+    expect(out.replyToText?.endsWith('…')).toBe(true)
+    expect([...(out.replyToTextEscaped ?? '')].length).toBe(REPLY_TO_TEXT_MAX)
+  })
+
+  it('does NOT overwrite a non-empty LIVE reply text (reply to a person, or a partial quote)', () => {
+    const lookup = () => {
+      throw new Error('lookup must not be called when live text is present')
+    }
+    const out = resolveReplyToFromBuffer({
+      replyToMessageId: 9,
+      replyToText: 'live raw text',
+      replyToTextEscaped: 'live escaped text',
+      historyEnabled: true,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+      lookup,
+    })
+    expect(out.replyToText).toBe('live raw text')
+    expect(out.replyToTextEscaped).toBe('live escaped text')
+    expect(out.replyToRole).toBeUndefined()
+  })
+
+  it('history-disabled guard: never calls lookup, degrades to id-only, does not throw', () => {
+    let called = false
+    const call = () =>
+      resolveReplyToFromBuffer({
+        replyToMessageId: 5,
+        replyToText: undefined,
+        replyToTextEscaped: undefined,
+        historyEnabled: false,
+        replyToTextMax: REPLY_TO_TEXT_MAX,
+        lookup: () => {
+          called = true
+          throw new Error('requireDb would throw with history disabled')
+        },
+      })
+    expect(call).not.toThrow()
+    expect(called).toBe(false)
+    expect(call().replyToText).toBeUndefined()
+    expect(call().replyToRole).toBeUndefined()
+  })
+
+  it('a lookup that throws (requireDb mid-run) degrades silently', () => {
+    let out: ReturnType<typeof resolveReplyToFromBuffer> | undefined
+    expect(() => {
+      out = resolveReplyToFromBuffer({
+        replyToMessageId: 5,
+        replyToText: undefined,
+        replyToTextEscaped: undefined,
+        historyEnabled: true,
+        replyToTextMax: REPLY_TO_TEXT_MAX,
+        lookup: () => {
+          throw new Error('SQLITE_ERROR')
+        },
+      })
+    }).not.toThrow()
+    expect(out?.replyToText).toBeUndefined()
+    expect(out?.replyToRole).toBeUndefined()
+  })
+
+  it('a missing row (reacted-to message predates retention) yields id-only', () => {
+    const out = resolveReplyToFromBuffer({
+      replyToMessageId: 999,
+      replyToText: undefined,
+      replyToTextEscaped: undefined,
+      historyEnabled: true,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+      lookup: () => null,
+    })
+    expect(out.replyToText).toBeUndefined()
+    expect(out.replyToRole).toBeUndefined()
+  })
+
+  it('a row with empty text still surfaces the role (authorship known, text redacted)', () => {
+    const out = resolveReplyToFromBuffer({
+      replyToMessageId: 3,
+      replyToText: undefined,
+      replyToTextEscaped: undefined,
+      historyEnabled: true,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+      lookup: () => ({ role: 'assistant', text: '' }),
+    })
+    expect(out.replyToRole).toBe('assistant')
+    expect(out.replyToText).toBeUndefined()
+  })
+})
+
+describe('buildReplyForwardContext — native partial-quote preference (2a)', () => {
+  it('prefers message.quote.text over the full parent .text', () => {
+    const ctx = makeCtx({
+      reply_to_message: { message_id: 100, text: 'the entire long parent message body' },
+      quote: { text: 'the exact fragment I selected', position: 5, is_manual: true },
+    })
+    const out = buildReplyForwardContext({ ctx, coalescedForwardOrigins: undefined, replyToTextMax: REPLY_TO_TEXT_MAX })
+    expect(out.replyToMessageId).toBe(100)
+    expect(out.replyToText).toBe('the exact fragment I selected')
+    expect(out.replyToTextEscaped).toBe('the exact fragment I selected')
+  })
+
+  it('falls back to the parent .text when there is no quote', () => {
+    const ctx = makeCtx({
+      reply_to_message: { message_id: 101, text: 'parent body only' },
+    })
+    const out = buildReplyForwardContext({ ctx, coalescedForwardOrigins: undefined, replyToTextMax: REPLY_TO_TEXT_MAX })
+    expect(out.replyToText).toBe('parent body only')
+  })
+
+  it('leaves reply text empty when the bot-authored parent carries no text (the 1a trigger)', () => {
+    const ctx = makeCtx({ reply_to_message: { message_id: 102 } })
+    const out = buildReplyForwardContext({ ctx, coalescedForwardOrigins: undefined, replyToTextMax: REPLY_TO_TEXT_MAX })
+    expect(out.replyToMessageId).toBe(102)
+    expect(out.replyToText).toBeUndefined()
+    expect(out.replyToTextEscaped).toBeUndefined()
+  })
+})
+
+function makeEnvelopeParams(overrides: Partial<EnvelopeBuildParams>): EnvelopeBuildParams {
+  return {
+    ctx: makeCtx({}),
+    chat_id: '5550001',
+    messageThreadId: undefined,
+    msgId: 200,
+    effectiveText: 'is this added as a calendar invite yet?',
+    imagePath: undefined,
+    attachment: undefined,
+    attachmentCount: 0,
+    extraMeta: {},
+    from: { id: 111, username: 'alice' },
+    access: { groups: {} },
+    isSteering: false,
+    isQueuedPrefix: false,
+    isQueuedMidTurn: false,
+    priorTurnInProgress: false,
+    secondsSinceTurnStart: undefined,
+    priorAssistantPreview: undefined,
+    replyToMessageId: 42,
+    replyToTextEscaped: undefined,
+    replyToRole: undefined,
+    forwardOriginMeta: {},
+    topicFramingEnabled: false,
+    personDirectory: { byTelegramKey: {} },
+    isDmChatId: () => true,
+    ...overrides,
+  }
+}
+
+describe('buildInboundEnvelope — reply_to_role + reply_to_text emission', () => {
+  it('emits reply_to_role and reply_to_text when the buffer fallback recovered them', () => {
+    const msg = buildInboundEnvelope(
+      makeEnvelopeParams({
+        replyToMessageId: 42,
+        replyToTextEscaped: 'Added the calendar invite for Friday 3pm.',
+        replyToRole: 'assistant',
+      }),
+    )
+    expect(msg.meta?.reply_to_message_id).toBe('42')
+    expect(msg.meta?.reply_to_text).toBe('Added the calendar invite for Friday 3pm.')
+    expect(msg.meta?.reply_to_role).toBe('assistant')
+  })
+
+  it('omits reply_to_role when unknown (no buffer hit) but still emits the id', () => {
+    const msg = buildInboundEnvelope(
+      makeEnvelopeParams({ replyToMessageId: 42, replyToTextEscaped: undefined, replyToRole: undefined }),
+    )
+    expect(msg.meta?.reply_to_message_id).toBe('42')
+    expect('reply_to_role' in (msg.meta ?? {})).toBe(false)
+    expect('reply_to_text' in (msg.meta ?? {})).toBe(false)
+  })
+
+  it("emits reply_to_role='user' for a recovered person message", () => {
+    const msg = buildInboundEnvelope(
+      makeEnvelopeParams({
+        replyToTextEscaped: 'the thing I asked earlier',
+        replyToRole: 'user',
+      }),
+    )
+    expect(msg.meta?.reply_to_role).toBe('user')
+  })
+})

--- a/telegram-plugin/tests/reply-to-buffer-history.test.ts
+++ b/telegram-plugin/tests/reply-to-buffer-history.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Reply-to buffer fallback — REAL history.db integration (1a persistence half).
+ *
+ * The pure-builder outcomes live in reply-to-buffer-fallback.test.ts (vitest).
+ * This file pins the half that needs a real bun:sqlite `history.db`: that the
+ * recovered antecedent is actually PERSISTED to the inbound row (reply_to_text
+ * non-NULL), not just emitted on the envelope. Envelope-only was the rejected
+ * design — it leaves the DB row NULL and starves the next handoff briefing,
+ * which reads reply_to_text back out of this store. So this drives the exact
+ * production chain: recordOutbound (the bot's own message) → lookup it back →
+ * resolveReplyToFromBuffer → recordInbound(reply_to_text) → read the row.
+ *
+ * Runs under `bun test` (bun:sqlite is a Bun built-in vitest/Node can't
+ * resolve); vitest-excluded in vitest.config.ts, covered by the bun `tests/`
+ * target in telegram-plugin/scripts/bun-test-ci.sh.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdtempSync, rmSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  initHistory,
+  recordInbound,
+  recordOutbound,
+  lookupMessageRoleAndText,
+  query,
+  _resetForTests,
+} from '../history.js'
+import { resolveReplyToFromBuffer } from '../gateway/inbound-router.js'
+
+const REPLY_TO_TEXT_MAX = 200
+const CHAT = '5550001'
+
+let stateDir: string
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), 'reply-to-buffer-'))
+  initHistory(stateDir, 30)
+})
+
+afterEach(() => {
+  _resetForTests()
+  if (existsSync(stateDir)) rmSync(stateDir, { recursive: true, force: true })
+})
+
+describe('reply-to buffer fallback persists the recovered antecedent (1a)', () => {
+  it('a native reply to the bot own message recovers text+role from history and writes a non-NULL row', () => {
+    // 1. The bot sent a message earlier; recordOutbound persisted it (role='assistant').
+    const botMsgId = 4242
+    recordOutbound({
+      chat_id: CHAT,
+      thread_id: null,
+      message_ids: [botMsgId],
+      texts: ['Added the calendar invite for Friday 3pm.'],
+      ts: 1000,
+    })
+
+    // 2. Session reset happened (transcript gone). The user native-replies to
+    //    that bot message. Telegram gives us the id but NOT the text, so the
+    //    live reply text is empty — exactly the incident condition.
+    const recovered = resolveReplyToFromBuffer({
+      replyToMessageId: botMsgId,
+      replyToText: undefined,
+      replyToTextEscaped: undefined,
+      historyEnabled: true,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+      lookup: (id) => lookupMessageRoleAndText(CHAT, id),
+    })
+
+    // The buffer recovered both the text and the authorship.
+    expect(recovered.replyToText).toBe('Added the calendar invite for Friday 3pm.')
+    expect(recovered.replyToRole).toBe('assistant')
+
+    // 3. The gateway records the inbound with the recovered reply_to_text.
+    const userMsgId = 4300
+    recordInbound({
+      chat_id: CHAT,
+      thread_id: null,
+      message_id: userMsgId,
+      user: 'alice',
+      user_id: '111',
+      ts: 2000,
+      text: 'is this added as a calendar invite yet?',
+      reply_to_message_id: botMsgId,
+      reply_to_text: recovered.replyToText ?? null,
+    })
+
+    // 4. THE outcome that would fail on the old bug and the rejected
+    //    envelope-only design: the persisted inbound row's reply_to_text is
+    //    non-NULL and carries the recovered antecedent.
+    const rows = query({ chat_id: CHAT, thread_id: null, limit: 10 })
+    const inboundRow = rows.find((r) => r.message_id === userMsgId) as
+      | { reply_to_text?: string | null; reply_to_message_id?: number | null }
+      | undefined
+    expect(inboundRow).toBeDefined()
+    expect(inboundRow!.reply_to_message_id).toBe(botMsgId)
+    expect(inboundRow!.reply_to_text).not.toBeNull()
+    expect(inboundRow!.reply_to_text).toBe('Added the calendar invite for Friday 3pm.')
+  })
+
+  it('a reply target absent from history (predates retention) writes a NULL row without throwing — no regression', () => {
+    const missingId = 99999
+    const recovered = resolveReplyToFromBuffer({
+      replyToMessageId: missingId,
+      replyToText: undefined,
+      replyToTextEscaped: undefined,
+      historyEnabled: true,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+      lookup: (id) => lookupMessageRoleAndText(CHAT, id),
+    })
+    expect(recovered.replyToText).toBeUndefined()
+    expect(recovered.replyToRole).toBeUndefined()
+
+    const userMsgId = 4301
+    recordInbound({
+      chat_id: CHAT,
+      thread_id: null,
+      message_id: userMsgId,
+      user: 'alice',
+      user_id: '111',
+      ts: 2000,
+      text: 'what about this one?',
+      reply_to_message_id: missingId,
+      reply_to_text: recovered.replyToText ?? null,
+    })
+    const rows = query({ chat_id: CHAT, thread_id: null, limit: 10 })
+    const inboundRow = rows.find((r) => r.message_id === userMsgId) as
+      | { reply_to_text?: string | null }
+      | undefined
+    expect(inboundRow).toBeDefined()
+    expect(inboundRow!.reply_to_text ?? null).toBeNull()
+  })
+})

--- a/tests/handoff-briefing.test.ts
+++ b/tests/handoff-briefing.test.ts
@@ -554,6 +554,219 @@ describe("handoff-briefing.sh assembler", () => {
   });
 });
 
+// ── Recent-conversation chat/thread scoping ─────────────────────────────────────
+//
+// The scope resolver in bin/handoff-briefing.sh picks a SINGLE surface for the
+// "Recent conversation" section so a forum/group agent's multi-topic history.db
+// doesn't pollute reorientation with unrelated threads. These tests seed a real
+// history.db — the EXACT gateway schema (telegram-plugin/history.ts `messages`
+// table) — via python3's stdlib sqlite3 (the same engine the script reads it
+// back with, so no bun:sqlite → the suite stays in the vitest pass) and assert
+// which messages land in the output. Each asserts the OUTCOME (which texts
+// appear), so a regression in the scoping SQL would fail them.
+
+interface SeedRow {
+  chat_id: string;
+  thread_id: number | null;
+  message_id: number;
+  role: "user" | "assistant";
+  user?: string | null;
+  ts: number;
+  text: string;
+}
+
+/**
+ * Create + populate a history.db matching the gateway's `messages` schema
+ * (chat_id TEXT, thread_id INTEGER NULL, message_id INTEGER, role, user, ts,
+ * text, …) under `<stateDir>/history.db`, using python3 stdlib sqlite3. Pass
+ * an empty `rows` array to create the table with zero rows (the "empty DB but
+ * file exists" case).
+ */
+function seedHistoryDb(stateDir: string, rows: SeedRow[]): string {
+  mkdirSync(stateDir, { recursive: true });
+  const dbPath = join(stateDir, "history.db");
+  const py = `
+import sys, json, sqlite3
+db = sys.argv[1]
+rows = json.loads(sys.argv[2])
+c = sqlite3.connect(db)
+c.execute(
+    "CREATE TABLE IF NOT EXISTS messages ("
+    "chat_id TEXT NOT NULL, thread_id INTEGER, message_id INTEGER NOT NULL, "
+    "role TEXT NOT NULL, user TEXT, user_id TEXT, ts INTEGER NOT NULL, "
+    "text TEXT NOT NULL, attachment_kind TEXT, group_id INTEGER, "
+    "reply_to_message_id INTEGER, reply_to_text TEXT, "
+    "PRIMARY KEY (chat_id, thread_id, message_id))"
+)
+for r in rows:
+    c.execute(
+        "INSERT INTO messages(chat_id,thread_id,message_id,role,user,user_id,ts,text) "
+        "VALUES(?,?,?,?,?,?,?,?)",
+        (r["chat_id"], r.get("thread_id"), r["message_id"], r["role"],
+         r.get("user"), None, r["ts"], r["text"]),
+    )
+c.commit()
+c.close()
+`;
+  const res = spawnSync("python3", ["-c", py, dbPath, JSON.stringify(rows)], {
+    timeout: 10_000,
+  });
+  if (res.status !== 0) {
+    throw new Error(`seedHistoryDb failed: ${res.stderr?.toString() ?? ""}`);
+  }
+  return dbPath;
+}
+
+describe("handoff-briefing.sh recent-conversation scoping", () => {
+  let tmpDir: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "handoff-scope-"));
+    stateDir = join(tmpDir, "telegram");
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Run the assembler in --stdout mode with the given scope env, return stdout. */
+  function runBriefing(
+    scopeEnv: Record<string, string> = {},
+  ): { status: number | null; output: string } {
+    const result = spawnSync("bash", [HANDOFF_BRIEFING_SCRIPT, "--stdout"], {
+      env: {
+        ...process.env,
+        AGENT_DIR: tmpDir,
+        TELEGRAM_STATE_DIR: stateDir,
+        HINDSIGHT_API_URL: "",
+        HINDSIGHT_BANK_ID: "",
+        WORKSPACE_DIR: tmpDir,
+        ...scopeEnv,
+      },
+      timeout: 10_000,
+    });
+    return { status: result.status, output: result.stdout.toString() };
+  }
+
+  // A fixture spanning two chats and, within chatA, two numbered threads plus a
+  // NULL-thread (general/DM) row. ts values make chatB the most-recently-active
+  // surface overall, and chatA/thread5 the most recent WITHIN chatA.
+  const FIXTURE: SeedRow[] = [
+    { chat_id: "chatA", thread_id: 5, message_id: 1, role: "user", user: "alice", ts: 1000, text: "MSG-A-T5-user" },
+    { chat_id: "chatA", thread_id: 5, message_id: 2, role: "assistant", ts: 1001, text: "MSG-A-T5-bot" },
+    { chat_id: "chatA", thread_id: 9, message_id: 3, role: "user", user: "alice", ts: 900, text: "MSG-A-T9-user" },
+    { chat_id: "chatA", thread_id: null, message_id: 4, role: "user", user: "alice", ts: 950, text: "MSG-A-NULL-user" },
+    { chat_id: "chatB", thread_id: null, message_id: 5, role: "user", user: "bob", ts: 2000, text: "MSG-B-NULL-user" },
+  ];
+
+  const ALL_MARKERS = [
+    "MSG-A-T5-user",
+    "MSG-A-T5-bot",
+    "MSG-A-T9-user",
+    "MSG-A-NULL-user",
+    "MSG-B-NULL-user",
+  ];
+
+  /** Assert ONLY the expected markers appear in the recent-conversation output. */
+  function expectOnly(output: string, expected: string[]): void {
+    for (const m of expected) expect(output).toContain(m);
+    for (const m of ALL_MARKERS) {
+      if (!expected.includes(m)) expect(output).not.toContain(m);
+    }
+  }
+
+  it("env-target scoping: PENDING_CHAT_ID + numbered PENDING_THREAD_ID selects only that chat+thread", () => {
+    seedHistoryDb(stateDir, FIXTURE);
+    const { status, output } = runBriefing({
+      SWITCHROOM_PENDING_CHAT_ID: "chatA",
+      SWITCHROOM_PENDING_THREAD_ID: "5",
+    });
+    expect(status).toBe(0);
+    expect(output).toContain("Recent conversation");
+    // Only chatA/thread5 rows — never thread9, the NULL thread, or chatB.
+    expectOnly(output, ["MSG-A-T5-user", "MSG-A-T5-bot"]);
+  });
+
+  it("db-latest derivation: with no env target, the single most-recently-active (chat,thread) surface wins", () => {
+    seedHistoryDb(stateDir, FIXTURE);
+    // No SWITCHROOM_PENDING_* → python derives db-latest. chatB/NULL (ts=2000)
+    // is the most recent surface, so only its rows appear.
+    const { status, output } = runBriefing();
+    expect(status).toBe(0);
+    expectOnly(output, ["MSG-B-NULL-user"]);
+  });
+
+  it("db-latest derivation scopes to the exact thread, excluding other threads of the SAME chat", () => {
+    // Drop chatB so the most-recently-active surface is chatA/thread5 (ts=1001).
+    // db-latest must scope to thread5 only — not chatA/thread9 or chatA/NULL.
+    const noB = FIXTURE.filter((r) => r.chat_id !== "chatB");
+    seedHistoryDb(stateDir, noB);
+    const { status, output } = runBriefing();
+    expect(status).toBe(0);
+    expectOnly(output, ["MSG-A-T5-user", "MSG-A-T5-bot"]);
+  });
+
+  it("tri-state thread: PENDING_THREAD_ID='NULL' scopes to thread_id IS NULL (excludes numbered threads)", () => {
+    seedHistoryDb(stateDir, FIXTURE);
+    const { status, output } = runBriefing({
+      SWITCHROOM_PENDING_CHAT_ID: "chatA",
+      SWITCHROOM_PENDING_THREAD_ID: "NULL",
+    });
+    expect(status).toBe(0);
+    // Only the NULL-thread row of chatA — NOT the numbered-thread rows.
+    expectOnly(output, ["MSG-A-NULL-user"]);
+  });
+
+  it("tri-state thread: numbered PENDING_THREAD_ID scopes to that thread (excludes the NULL-thread rows)", () => {
+    seedHistoryDb(stateDir, FIXTURE);
+    const { status, output } = runBriefing({
+      SWITCHROOM_PENDING_CHAT_ID: "chatA",
+      SWITCHROOM_PENDING_THREAD_ID: "9",
+    });
+    expect(status).toBe(0);
+    expectOnly(output, ["MSG-A-T9-user"]);
+  });
+
+  it("empty PENDING_THREAD_ID (unknown) falls back to chat-only scope (all threads of the chat)", () => {
+    // The backward-compatible fallback: an OLD gateway (or genuinely-unknown
+    // thread) emits an empty thread var → chat-only scope pulls every thread of
+    // chatA (thread5, thread9, NULL) but never chatB.
+    seedHistoryDb(stateDir, FIXTURE);
+    const { status, output } = runBriefing({
+      SWITCHROOM_PENDING_CHAT_ID: "chatA",
+      SWITCHROOM_PENDING_THREAD_ID: "",
+    });
+    expect(status).toBe(0);
+    expectOnly(output, ["MSG-A-T5-user", "MSG-A-T5-bot", "MSG-A-T9-user", "MSG-A-NULL-user"]);
+  });
+
+  it("env-target-with-zero-rows fallback: a stale env chat absent from the DB falls back to db-latest", () => {
+    // Rotated/fresh DB: the pending-turn chat has no rows. Instead of silently
+    // emitting an empty section, the resolver falls through to db-latest
+    // (chatB/NULL, ts=2000).
+    seedHistoryDb(stateDir, FIXTURE);
+    const { status, output } = runBriefing({
+      SWITCHROOM_PENDING_CHAT_ID: "chatGONE",
+      SWITCHROOM_PENDING_THREAD_ID: "3",
+    });
+    expect(status).toBe(0);
+    expect(output).toContain("Recent conversation");
+    expectOnly(output, ["MSG-B-NULL-user"]);
+  });
+
+  it("empty DB (table exists, zero rows): no crash, no recent-conversation section, exit 0", () => {
+    seedHistoryDb(stateDir, []);
+    const { status, output } = runBriefing({
+      SWITCHROOM_PENDING_CHAT_ID: "chatA",
+      SWITCHROOM_PENDING_THREAD_ID: "5",
+    });
+    expect(status).toBe(0);
+    expect(output).not.toContain("Recent conversation");
+    expect(output.trim()).toBe("");
+  });
+});
+
 // ── Migration warning ───────────────────────────────────────────────────────────
 
 describe("reconcileAgent: migration warning for auto → handoff default change", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -166,6 +166,9 @@ export default defineConfig({
       // PR #994.
       "**/telegram-plugin/uat/**",
       "**/telegram-plugin/tests/history.test.ts",
+      // reply-to-buffer-history.test.ts seeds a real history.db via bun:sqlite
+      // (recordOutbound → lookup → recordInbound) — excluded here, run via bun.
+      "**/telegram-plugin/tests/reply-to-buffer-history.test.ts",
       // boot-briefing-builder.test.ts seeds a real history.db via bun:sqlite
       // (gateway boot briefing) — excluded here, run via test:bun.
       "**/telegram-plugin/tests/boot-briefing-builder.test.ts",


### PR DESCRIPTION
## Problem

After a session reset (`resume_mode: handoff` → fresh session, transcript gone), the agent loses conversation context. Real incident: a user **native-replied to one of the BOT's OWN messages** — "is this added as a calendar invite yet?" — and the agent had to guess the antecedent.

**Root cause:** on a native reply to the bot's own message, Telegram delivers `reply_to_message.message_id` but **not** `.text` (it omits the text when the reply target is the bot's own message). switchroom sourced reply text only from the live update — but that text was already in the local `history.db` buffer, written by `recordOutbound` (role=`assistant`, 30-day retention). We just weren't reading it back.

## Convergence rationale

Hermes' `rich_sent_store` and OpenClaw's message-id cache both keep a local record of the bot's own outbound so a later reply can resolve its antecedent. switchroom already **has** that store via `recordOutbound` — this PR wires it into the inbound reply-to path rather than adding new storage.

## What each change does

**1a — Reply-to buffer fallback + role tag** (`resolveReplyToFromBuffer` in `inbound-router.ts`, called from `handleInbound`). When the live reply text is empty and history is on, look the replied-to `message_id` up in `history.db`. On a hit it sets:
- the **raw** `replyToText` — so the `recordInbound` write persists it; envelope-only was the rejected design (it leaves the DB row NULL and starves the next handoff briefing, which reads `reply_to_text` back out of this store),
- the **escaped** `replyToTextEscaped` (channel meta),
- a new `reply_to_role` envelope attribute (`assistant` = the bot's own message, `user` = a person's) — disambiguates "you're replying to yourself".

Never overwrites a non-empty live value; degrades silently when history is off / the row is missing / the lookup throws.

**1b — Handoff-briefing staleness race** (`start.sh.hbs`, `handoff-briefing.sh`):
- `rm -f` the target `.handoff-briefing.md` at the **top** of the rebuild branch so a SIGKILLed rebuild yields MISSING (injection skips) rather than a stale prior-boot file.
- Raise the outer `timeout` 5→10s and cap Hindsight ≤3s (`HANDOFF_BRIEFING_HINDSIGHT_TIMEOUT`) so the kill lands only on a genuinely wedged run.
- Write the Telegram-history section to disk **incrementally** (atomic tmp+mv for the first section, append later sections) so a late kill still leaves recent-messages context on disk.

**2a — Native partial-quote preference** (`buildReplyForwardContext`). Prefer `message.quote.text` (Bot API 7.0+ partial quote) over the full parent `.text`/`.caption` and over the 1a fallback — the user drag-selected that exact span, so it's the stronger antecedent. Accessed defensively in case the installed grammy types predate `TextQuote`.

**2b — Chat/thread-scope the briefing query** (`handoff-briefing.sh`). The last-20 recent-messages query is scoped to the agent's active chat/thread (env target wins, else the DB most-recent `(chat_id, thread_id)` surface), with a stderr breadcrumb naming the scope + source. Never silently ships unscoped when a surface is derivable.

## Tests run + results

- `reply-to-buffer-fallback.test.ts` (vitest, **14 pass**) — pins `resolveReplyToFromBuffer` outcomes (raw+escaped+role on hit; user role; truncation to cap; no-overwrite of live text; history-disabled guard never calls lookup / no throw; lookup-throws degrades; missing row id-only; empty-text row still surfaces role), the 2a quote preference, and the `reply_to_role`/`reply_to_text` envelope emission.
- `reply-to-buffer-history.test.ts` (bun:sqlite, **2 pass**) — drives the real chain `recordOutbound → lookupMessageRoleAndText → resolveReplyToFromBuffer → recordInbound` and asserts the **persisted inbound row's `reply_to_text` is non-NULL** (the half that would pass on the rejected envelope-only design), plus the missing-target → NULL-row-no-throw path.
- Existing suites green: `handoff-briefing.test.ts` (25) + `reply-quote-wire` + `inbound-message-types` + `multitopic-routing-wiring` (95 total), full `history.test.ts` (bun) with no regressions.
- Shell: `bash -n` clean on `handoff-briefing.sh`; a mid-Hindsight kill (`timeout 1` + blackhole recall URL) confirmed the Telegram section is already on disk. `HANDOFF_BRIEFING_FILE` is defined (start.sh:1435) before the new `rm -f`.
- `bun run lint` fully green (tsc clean, test-runner-coverage, bun-test-imports, gateway-line-ratchet within slack, stale-tool-descriptions, secret-pattern-parity).

## Deferred (follow-up)

Chain-walk depth-N, dedup guard, `--resume` CLI-session-id reattach (Tier 3) — intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
