### PR TITLE
fix(buzz): thread-continuity review follow-ups (#4299 #4300 #4301)

### DIFF
--- a/telegram-plugin/gateway/buzz-mirror.ts
+++ b/telegram-plugin/gateway/buzz-mirror.ts
@@ -93,6 +93,15 @@ export interface MirrorReplyInput {
    * bound by `ownerBuzzCoords`, not a Telegram antecedent).
    */
   antecedentTelegramMessageKey?: string;
+  /**
+   * True IFF `antecedentTelegramMessageKey` is the quote-opt-in DEFAULT — i.e.
+   * the caller had no explicit/model-supplied `reply_to` and defaulted it to the
+   * latest INBOUND user message (#4301). That message is never in the
+   * correlation store, so its lookup ALWAYS misses; distinguishing it lets the
+   * mirror log the expected flat fallback quietly with a distinct reason instead
+   * of as an "outbound thread MISS", so a genuine eviction miss stays visible.
+   */
+  antecedentIsQuoteOptInDefault?: boolean;
 }
 
 export interface MirrorCorrectionInput {
@@ -236,12 +245,36 @@ class BuzzMirror {
         // the post flat rather than emitting a wrong/guessed tag.
         if (input.antecedentTelegramMessageKey) {
           const parent = this.msgToBuzz.get(input.antecedentTelegramMessageKey);
-          if (parent) {
+          if (parent && parent.channelId === channelId) {
             replyToEventId = parent.eventId; // immediate parent → NIP-10 `reply`
             // Thread root → NIP-10 `root`. Fall back to the parent's own id when
             // the parent has no recorded root (it was itself top-level, or was
             // journaled before threadRoot was tracked): then parent IS the root.
             threadRootId = parent.threadRoot ?? parent.eventId;
+          } else if (parent) {
+            // #4299 CROSS-CHANNEL GUARD: the antecedent WAS mirrored, but into a
+            // DIFFERENT Buzz channel than this event's target (e.g. it was
+            // recorded via a buzz-origin threaded reply whose channelId came from
+            // the inbound event's own `h`-tag). This event publishes into
+            // `defaultChannelId`; threading it under a foreign-channel parent
+            // would carry e-tags that point into another group. Mirror FLAT
+            // instead — same fallback as a MISS, no cross-group e-tag.
+            this.log(
+              `buzz-mirror: outbound thread CROSS-CHANNEL — antecedent ` +
+                `${input.antecedentTelegramMessageKey} was mirrored into channel ` +
+                `${parent.channelId} != target ${channelId}; mirroring flat ` +
+                `(no cross-group e-tag)`,
+            );
+          } else if (input.antecedentIsQuoteOptInDefault) {
+            // #4301: quote-opt-in defaulted `reply_to` to the latest INBOUND user
+            // message, which is never in the correlation store — so this "miss"
+            // is EXPECTED, not an eviction. Log it quietly with a distinct reason
+            // (no "MISS") so genuine eviction misses stay visible in the logs.
+            this.log(
+              `buzz-mirror: outbound thread default-quote — antecedent ` +
+                `${input.antecedentTelegramMessageKey} is the latest inbound user ` +
+                `message (never mirrored); mirroring flat (expected, not an eviction)`,
+            );
           } else {
             this.log(
               `buzz-mirror: outbound thread MISS — no Buzz correlation for ` +

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -757,6 +757,30 @@ export interface VoiceOutPlan {
   ttsChunks: string[]
 }
 
+/**
+ * Resolve the Buzz-mirror NIP-10 antecedent key for an outbound answer, or
+ * `undefined` to mirror FLAT. Pure + deterministic so the gating is testable
+ * without the full send harness. Returns `${chatId}:${replyTo}` only when a
+ * genuine, renderable reply antecedent exists; `undefined` when:
+ *  - there is no antecedent (`replyTo == null`), or
+ *  - `replyTo` is not a finite number (a non-numeric model `reply_to` coerces to
+ *    `NaN`; #4301 — never build a bogus `chat:NaN` key the mirror logs as a
+ *    real miss), or
+ *  - `replyMode === 'off'` (#4300 — the Telegram copy renders NO reply, so the
+ *    Buzz mirror must stay flat too; without this the Buzz copy visibly threads
+ *    while the Telegram copy does not — a surface divergence).
+ */
+export function resolveMirrorAntecedentKey(
+  chatId: string,
+  replyTo: number | undefined,
+  replyMode: string,
+): string | undefined {
+  if (replyTo == null || !Number.isFinite(replyTo) || replyMode === 'off') {
+    return undefined
+  }
+  return `${chatId}:${replyTo}`
+}
+
 export interface SendReplyRequest {
   /** Raw `reply` tool args, exactly as the MCP dispatch received them. */
   args: Record<string, unknown>
@@ -1545,10 +1569,19 @@ export async function sendReply(
     )
   }
 
+  // #4301: track whether `reply_to` came from the quote-opt-in DEFAULT (the
+  // latest inbound user message) rather than an explicit/model-supplied value.
+  // The default antecedent is never in the Buzz correlation store, so its mirror
+  // lookup always misses — passing this flag lets the mirror log that expected
+  // flat fallback quietly instead of as an eviction "MISS".
+  let antecedentFromQuoteOptInDefault = false
   if (reply_to == null && quoteOptIn && HISTORY_ENABLED) {
     try {
       const latest = getLatestInboundMessageId(chat_id, threadId ?? null)
-      if (latest != null) reply_to = latest
+      if (latest != null) {
+        reply_to = latest
+        antecedentFromQuoteOptInDefault = true
+      }
     } catch (err) {
       process.stderr.write(`telegram gateway: quote-reply lookup failed: ${(err as Error).message}\n`)
     }
@@ -2624,7 +2657,15 @@ export async function sendReply(
         // quote-opt-in default). The mirror resolves it against the durable
         // correlation store and threads under it only on a HIT (a previously-
         // mirrored answer); a user inbound / evicted key misses → flat.
-        antecedentTelegramMessageKey: reply_to != null ? `${chat_id}:${reply_to}` : undefined,
+        //
+        // Guards:
+        //  - #4300: when `replyMode === 'off'` the Telegram copy renders NO
+        //    reply, so DON'T stamp the antecedent — keep the Buzz copy flat too
+        //    (surface parity; no threading the Buzz copy visibly threads on).
+        //  - #4301: `Number.isFinite` drops a non-numeric `reply_to` (→ `NaN`)
+        //    so it never becomes a bogus `chat:NaN` key that logs as a real miss.
+        antecedentTelegramMessageKey: resolveMirrorAntecedentKey(chat_id, reply_to, replyMode),
+        antecedentIsQuoteOptInDefault: antecedentFromQuoteOptInDefault,
       })
     }
   }

--- a/telegram-plugin/tests/buzz-mirror.test.ts
+++ b/telegram-plugin/tests/buzz-mirror.test.ts
@@ -234,6 +234,84 @@ describe('BuzzMirror.mirrorReplyDelivered — NIP-10 OUTBOUND thread continuity'
     expect(buildThreadTags({ threadRootId: msg.threadRootId, replyToEventId: msg.replyToEventId })).toEqual([])
     expect(logs.some((l) => /outbound thread MISS/.test(l))).toBe(true)
   })
+
+  it('#4299: a FOREIGN-CHANNEL antecedent mirrors FLAT (no cross-group e-tag)', () => {
+    const logs: string[] = []
+    __resetBuzzMirrorForTests()
+    const sender = vi.fn(() => true)
+    // Telegram-origin mirrors post into 'grp'; the antecedent below was mirrored
+    // into a DIFFERENT (buzz-origin) channel 'chan-A'.
+    const m = initBuzzMirror({ mode: 'both', agentName: 'klanker', defaultChannelId: 'grp', log: (l) => logs.push(l) })
+    m.attachSender(sender)
+
+    // Record '555:100' → an event published into buzz channel 'chan-A' (its
+    // channelId comes from ownerBuzzCoords, NOT defaultChannelId). This is the
+    // exact shape #4299 warns about: a parent recorded via a buzz-origin
+    // threaded reply whose channelId came from the inbound event's own h-tag.
+    m.mirrorReplyDelivered({
+      scrubbedText: 'buzz answer',
+      ownerOriginChannel: 'buzz',
+      ownerBuzzCoords: { channelId: 'chan-A', eventId: 'evt-buzz', threadRoot: 'root-buzz' },
+      ownerEchoed: true,
+      hasRecentDifferentOriginTurn: false,
+      telegramMessageKeys: ['555:100'],
+    })
+    const buzzCall = sender.mock.calls[sender.mock.calls.length - 1][0] as OutboundToBuzzMessage
+    expect(buzzCall.channelId).toBe('chan-A')
+    m.onPublishResult({ correlationId: buzzCall.correlationId, ok: true, eventId: 'evt-buzz' })
+
+    // A later TELEGRAM-origin answer replies to '555:100'. Its target channel is
+    // 'grp' ≠ 'chan-A' — threading under evt-buzz would carry e-tags into the
+    // foreign 'chan-A' group. It MUST mirror flat instead.
+    m.mirrorReplyDelivered({
+      scrubbedText: 'tele follow-up',
+      ownerOriginChannel: 'telegram',
+      ownerEchoed: false,
+      hasRecentDifferentOriginTurn: false,
+      telegramMessageKeys: ['555:200'],
+      antecedentTelegramMessageKey: '555:100',
+    })
+
+    const msg = sender.mock.calls[sender.mock.calls.length - 1][0] as OutboundToBuzzMessage
+    expect(msg.channelId).toBe('grp')
+    // FLAT: no thread tags at all — crucially NOT evt-buzz / root-buzz.
+    expect(msg.replyToEventId).toBeUndefined()
+    expect(msg.threadRootId).toBeUndefined()
+    expect(buildThreadTags({ threadRootId: msg.threadRootId, replyToEventId: msg.replyToEventId })).toEqual([])
+    // Logged distinctly as a cross-channel guard, NOT as an eviction MISS.
+    expect(logs.some((l) => /outbound thread CROSS-CHANNEL/.test(l))).toBe(true)
+    expect(logs.some((l) => /outbound thread MISS/.test(l))).toBe(false)
+  })
+
+  it('#4301: a quote-opt-in DEFAULT antecedent miss is NOT logged as an eviction MISS', () => {
+    const logs: string[] = []
+    __resetBuzzMirrorForTests()
+    const sender = vi.fn(() => true)
+    const m = initBuzzMirror({ mode: 'both', agentName: 'klanker', defaultChannelId: 'grp', log: (l) => logs.push(l) })
+    m.attachSender(sender)
+
+    // The antecedent is the latest INBOUND user message (quote-opt-in default),
+    // which is never in the correlation store — an EXPECTED miss, not eviction.
+    m.mirrorReplyDelivered({
+      scrubbedText: 'answer',
+      ownerOriginChannel: 'telegram',
+      ownerEchoed: false,
+      hasRecentDifferentOriginTurn: false,
+      telegramMessageKeys: ['555:200'],
+      antecedentTelegramMessageKey: '555:100', // latest inbound, never mirrored
+      antecedentIsQuoteOptInDefault: true,
+    })
+
+    expect(sender).toHaveBeenCalledTimes(1)
+    const msg = sender.mock.calls[0][0] as OutboundToBuzzMessage
+    // Still a flat top-level post.
+    expect(msg.replyToEventId).toBeUndefined()
+    expect(msg.threadRootId).toBeUndefined()
+    // The expected default-quote miss must NOT masquerade as an eviction MISS,
+    // so a genuine eviction miss stays distinguishable in the logs.
+    expect(logs.some((l) => /outbound thread MISS/.test(l))).toBe(false)
+    expect(logs.some((l) => /default-quote/.test(l))).toBe(true)
+  })
 })
 
 describe('BuzzMirror.mirrorCorrection — debounced, only for mirrored messages', () => {

--- a/telegram-plugin/tests/outbound-send-path.test.ts
+++ b/telegram-plugin/tests/outbound-send-path.test.ts
@@ -18,6 +18,7 @@ import {
   computeReplyChunks,
   resplitOversizeChunk,
   chunkText,
+  resolveMirrorAntecedentKey,
 } from '../gateway/outbound-send-path.js'
 
 /**
@@ -411,5 +412,28 @@ describe('outbound-send-path — temporal pass wiring (#3501)', () => {
     }).text
     const viaModule = normalizeTemporal(raw, TZ_MEL, NOW_THU)
     expect(viaSeam).toBe(viaModule)
+  })
+})
+
+// ── Buzz-mirror antecedent gating (#4300 / #4301) ──────────────────────────
+describe('resolveMirrorAntecedentKey — Buzz-mirror antecedent gating', () => {
+  it('#4300: replyMode "off" stamps NO antecedent → Buzz mirror stays flat', () => {
+    // With reply-mode off the Telegram copy renders no reply, so the Buzz copy
+    // must not thread either — otherwise the surfaces diverge.
+    expect(resolveMirrorAntecedentKey('555', 100, 'off')).toBeUndefined()
+  })
+
+  it('stamps the antecedent for reply-rendering modes (first / all)', () => {
+    expect(resolveMirrorAntecedentKey('555', 100, 'first')).toBe('555:100')
+    expect(resolveMirrorAntecedentKey('555', 100, 'all')).toBe('555:100')
+  })
+
+  it('#4301: a non-numeric reply_to (NaN) stamps NO antecedent (no chat:NaN key)', () => {
+    expect(resolveMirrorAntecedentKey('555', Number('not-a-number'), 'first')).toBeUndefined()
+    expect(resolveMirrorAntecedentKey('555', NaN, 'all')).toBeUndefined()
+  })
+
+  it('stamps NO antecedent when there is no reply_to', () => {
+    expect(resolveMirrorAntecedentKey('555', undefined, 'first')).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

Three reviewed **LOW** findings from #4297 (Buzz NIP-10 outbound thread continuity), as one focused follow-up. Each fix ships with an outcome-asserting test.

### #4299 — cross-channel thread e-tags not guarded
`buzz-mirror.ts` threaded a telegram-origin reply under `parent.eventId` but always published into `defaultChannelId`, ignoring the channel the parent was actually mirrored into. A parent recorded via a buzz-origin threaded reply carries a foreign `channelId` (from the inbound event's own `h`-tag), so the new default-channel event would carry e-tags pointing into a different group.
**Fix:** only thread when `parent.channelId === channelId`; on mismatch mirror **FLAT** (drop thread tags, same as a MISS) and log a distinct `CROSS-CHANNEL` reason.

### #4300 — `replyMode:'off'` surface divergence
The antecedent was stamped whenever `reply_to != null`, but the Telegram send only renders the reply when `replyMode !== 'off'`. With reply-mode off the Buzz copy threaded while the Telegram copy visibly did not.
**Decision (aligned surfaces):** when `replyMode === 'off'`, do **not** stamp the antecedent, so Buzz mirrors flat too. Extracted the gating into a pure, unit-tested `resolveMirrorAntecedentKey()`.

### #4301 — MISS log noise under quote-opt-in
Quote-opt-in defaults `reply_to` to the latest **inbound** user message, which is never in the correlation store, so every default-quoted answer emitted an `outbound thread MISS` — indistinguishable from a genuine eviction miss.
**Fix:** pass `antecedentIsQuoteOptInDefault` so the expected flat fallback logs a distinct `default-quote` reason (no "MISS"), keeping genuine eviction misses visible. Also drops a non-numeric `reply_to` (`NaN`) so it never becomes a bogus `chat:NaN` key.

## Why
Cleans up three correctness/observability gaps in the outbound Buzz mirror without widening any surface.

## Test plan
- `telegram-plugin/tests/buzz-mirror.test.ts`: foreign-channel antecedent -> flat post (no cross-group e-tag, `CROSS-CHANNEL` logged, no `MISS`); quote-opt-in default miss -> not logged as eviction (`default-quote` logged, no `MISS`).
- `telegram-plugin/tests/outbound-send-path.test.ts`: `resolveMirrorAntecedentKey` — replyMode `off` -> undefined; `first`/`all` -> `chat:id`; `NaN`/`undefined` reply_to -> undefined.
- Scoped vitest: 106 passing. `npm run lint`: clean. `tsc --noEmit`: clean.

## Risk
Low. No correlation-store schema change (#4280 byte-compatibility preserved). Fewer/quieter thread tags and log lines only; the flat fallback still publishes.

## Contract gate
Outbound mirror enrichment only, **kind:9** only. No inbound/action/approval/inject surface added. **`gateway.ts` and `auth-gate.ts` untouched** (line-ratchet + contract intact — `check-gateway-line-ratchet` unchanged at 24805). Telegram-and-buzz-only invariant held.

## Job spec
`reference/jobs/` — Buzz co-channel mirror (the "part that actually sends"): an outbound Telegram answer renders correctly threaded on the Buzz desktop without ever disturbing, delaying, or mis-scoping the Telegram copy.

Fixes #4299
Fixes #4300
Fixes #4301
