### PR TITLE
fix(buzz): audit-surface review follow-ups (#4302 #4303 #4304 #4305)

### DIFF
--- a/src/buzz-gateway/heartbeat.test.ts
+++ b/src/buzz-gateway/heartbeat.test.ts
@@ -5,6 +5,10 @@ import {
   parseBuzzHeartbeat,
   buzzHeartbeatStatePath,
   buzzHeartbeatOperatorPath,
+  resolveStatsIntervalMs,
+  BUZZ_HEARTBEAT_INTERVAL_MS,
+  BUZZ_HEARTBEAT_STALE_MS,
+  BUZZ_HEARTBEAT_MAX_INTERVAL_MS,
   type BuzzHeartbeat,
 } from "./heartbeat.js";
 import type { BuzzPipelineSummary } from "./stats.js";
@@ -84,5 +88,36 @@ describe("writeBuzzHeartbeat / parseBuzzHeartbeat", () => {
     expect(
       parseBuzzHeartbeat(JSON.stringify(beat({ stats: partialStats as never }))),
     ).toBeNull();
+  });
+});
+
+describe("resolveStatsIntervalMs — stale-threshold coupling (#4302)", () => {
+  it("keeps the timing contract self-consistent: stale = interval × tolerance", () => {
+    // The whole fix rests on the stale threshold being DERIVED from the beat
+    // interval, not a hand-synced constant. Pin the relationship so a future
+    // edit to one without the other fails here.
+    expect(BUZZ_HEARTBEAT_STALE_MS).toBeGreaterThan(BUZZ_HEARTBEAT_INTERVAL_MS);
+    expect(BUZZ_HEARTBEAT_MAX_INTERVAL_MS * 3).toBe(BUZZ_HEARTBEAT_STALE_MS);
+  });
+
+  it("clamps an interval set ABOVE the stale threshold so a healthy sidecar can't false-red", () => {
+    // The exact bug: BUZZ_STATS_INTERVAL_MS set above ~180s made every healthy
+    // sidecar beat slower than doctor's stale window, so doctor false-redded it
+    // as stale on every run. The resolved interval must stay strictly inside
+    // the stale window, leaving room for at least a couple of missed beats.
+    const wayAboveStale = String(BUZZ_HEARTBEAT_STALE_MS * 5); // e.g. 900s
+    const resolved = resolveStatsIntervalMs(wayAboveStale);
+    expect(resolved).toBeLessThanOrEqual(BUZZ_HEARTBEAT_MAX_INTERVAL_MS);
+    // A sidecar beating at `resolved` beats at least 3× before the stale window
+    // elapses — the false-red is structurally impossible.
+    expect(resolved * 3).toBeLessThanOrEqual(BUZZ_HEARTBEAT_STALE_MS);
+  });
+
+  it("passes a faster-than-default interval through unchanged and floors junk to the default", () => {
+    expect(resolveStatsIntervalMs("15000")).toBe(15000); // faster beats are fine
+    expect(resolveStatsIntervalMs(undefined)).toBe(BUZZ_HEARTBEAT_INTERVAL_MS);
+    expect(resolveStatsIntervalMs("not-a-number")).toBe(BUZZ_HEARTBEAT_INTERVAL_MS);
+    expect(resolveStatsIntervalMs("0")).toBe(BUZZ_HEARTBEAT_INTERVAL_MS);
+    expect(resolveStatsIntervalMs("-5000")).toBe(BUZZ_HEARTBEAT_INTERVAL_MS);
   });
 });

--- a/src/buzz-gateway/heartbeat.ts
+++ b/src/buzz-gateway/heartbeat.ts
@@ -35,6 +35,50 @@ export const BUZZ_HEARTBEAT_FILE = "buzz-sidecar.heartbeat.json";
  *  this to reach the beacon from the operator-side agent home. */
 export const AGENT_STATE_SUBDIR = "telegram";
 
+// ────────────────────────────────────────────────────────────────────────
+// Heartbeat timing contract (single source of truth — #4302)
+//
+// The sidecar refreshes the beacon every `BUZZ_HEARTBEAT_INTERVAL_MS`; doctor
+// flags a beacon older than `BUZZ_HEARTBEAT_STALE_MS` as stale. Those two knobs
+// were decoupled: the beat interval is env-tunable (BUZZ_STATS_INTERVAL_MS in
+// index.ts) while the stale threshold was a fixed 180s, so setting the interval
+// above ~180s made every healthy sidecar false-red as stale. They now share
+// this module: the stale threshold is DERIVED (interval × tolerance) and the
+// runtime interval is CLAMPED so it can never exceed what the threshold
+// tolerates — a deterministic coupling rather than two hand-synced numbers.
+// ────────────────────────────────────────────────────────────────────────
+
+/** Default beat cadence: the sidecar refreshes the beacon this often. */
+export const BUZZ_HEARTBEAT_INTERVAL_MS = 60 * 1000;
+/** Missed-beat tolerance before doctor flags stale — 3 tolerates a couple of
+ *  dropped beats before warning. */
+export const BUZZ_HEARTBEAT_STALE_MULTIPLIER = 3;
+/** A beacon older than this reads as stale. DERIVED from the beat interval so
+ *  the two can't drift apart (interval × missed-beat tolerance). */
+export const BUZZ_HEARTBEAT_STALE_MS =
+  BUZZ_HEARTBEAT_INTERVAL_MS * BUZZ_HEARTBEAT_STALE_MULTIPLIER;
+/** The slowest the beat interval may be configured without the sidecar
+ *  false-reddening doctor: keeping interval ≤ stale ÷ tolerance guarantees the
+ *  stale window always spans at least `BUZZ_HEARTBEAT_STALE_MULTIPLIER` beats. */
+export const BUZZ_HEARTBEAT_MAX_INTERVAL_MS =
+  BUZZ_HEARTBEAT_STALE_MS / BUZZ_HEARTBEAT_STALE_MULTIPLIER;
+
+/**
+ * Resolve the sidecar's stats/heartbeat beat interval from its raw env value
+ * (BUZZ_STATS_INTERVAL_MS), clamped so it can never outrun doctor's stale
+ * threshold (#4302). A non-numeric / non-positive value falls back to the
+ * default; an over-large value is capped at `BUZZ_HEARTBEAT_MAX_INTERVAL_MS` so
+ * a healthy sidecar always beats inside the stale window. Faster-than-default
+ * intervals pass through unchanged.
+ */
+export function resolveStatsIntervalMs(raw: string | undefined): number {
+  const requested = Number(raw);
+  if (!Number.isFinite(requested) || requested <= 0) {
+    return BUZZ_HEARTBEAT_INTERVAL_MS;
+  }
+  return Math.min(requested, BUZZ_HEARTBEAT_MAX_INTERVAL_MS);
+}
+
 /** Content-free liveness + stats snapshot. */
 export interface BuzzHeartbeat {
   /** Schema version — bump on shape change so an old reader can reject cleanly. */

--- a/src/buzz-gateway/index.ts
+++ b/src/buzz-gateway/index.ts
@@ -28,10 +28,14 @@ import { createDedupStore } from "./dedup.js";
 import { makeInject } from "./ipc-peer.js";
 import { createNostrClient, type SocketFactory, type WsLike } from "./nostr-client.js";
 import { createBuzzPeerClient } from "./peer-client.js";
-import { publishOutbound, type PublishTransport } from "./publisher.js";
+import { publishOutboundTallied, type PublishTransport } from "./publisher.js";
 import { createInboundPump } from "./pump.js";
 import { createRetryQueue } from "./retry-queue.js";
-import { buzzHeartbeatStatePath, writeBuzzHeartbeat } from "./heartbeat.js";
+import {
+  buzzHeartbeatStatePath,
+  resolveStatsIntervalMs,
+  writeBuzzHeartbeat,
+} from "./heartbeat.js";
 import { createStatsReporter, summarizePipeline } from "./stats.js";
 
 function log(msg: string): void {
@@ -188,7 +192,11 @@ async function main(): Promise<void> {
     socketPath,
     agentName: config.agentName,
     onOutbound: async (req) => {
-      const result = await publishOutbound(
+      // publishOutboundTallied owns the mirror.ok/mirror.failed bookkeeping AND
+      // never throws: a transport-layer thrown rejection is counted as a
+      // mirror.failed too (#4305), so the tally is the true count of
+      // non-delivered mirrors, not just the resolved {ok:false} ones.
+      const result = await publishOutboundTallied(
         {
           channelId: req.channelId,
           replyToEventId: req.replyToEventId,
@@ -197,9 +205,8 @@ async function main(): Promise<void> {
         },
         secretKey,
         publishTransport,
+        mirror,
       );
-      if (result.ok) mirror.ok += 1;
-      else mirror.failed += 1;
       return {
         type: "buzz_publish_result",
         correlationId: req.correlationId,
@@ -218,7 +225,11 @@ async function main(): Promise<void> {
   // interval is overridable for tests/tuning (BUZZ_STATS_INTERVAL_MS).
   const bootTs = Date.now();
   const heartbeatPath = buzzHeartbeatStatePath(stateDir);
-  const statsIntervalMs = Number(process.env.BUZZ_STATS_INTERVAL_MS) || 60_000;
+  // Clamp the env-tunable beat interval so it can never outrun doctor's stale
+  // threshold (#4302): a value above the stale window would false-red every
+  // healthy sidecar. resolveStatsIntervalMs derives the cap from the same
+  // constants doctor's stale check uses.
+  const statsIntervalMs = resolveStatsIntervalMs(process.env.BUZZ_STATS_INTERVAL_MS);
   const statsReporter = createStatsReporter({
     intervalMs: statsIntervalMs,
     sample: () => ({

--- a/src/buzz-gateway/publisher.test.ts
+++ b/src/buzz-gateway/publisher.test.ts
@@ -3,8 +3,10 @@ import { generateSecretKey } from "nostr-tools";
 import {
   signChunkedMessage,
   publishOutbound,
+  publishOutboundTallied,
   contentHasUnsuppressedSecret,
   validateOutboundToBuzz,
+  type MirrorTally,
   type OutboundPayload,
   type PublishTransport,
   type SignedNostrEvent,
@@ -235,5 +237,57 @@ describe("publishOutbound relay-failure handling", () => {
     expect(res.ok).toBe(true);
     const eTags = seen[0].tags.filter((t) => t[0] === "e").map((t) => t[1]);
     expect(eTags).toContain("target-evt");
+  });
+});
+
+describe("publishOutboundTallied — mirror tally counts a THROWN publish (#4305)", () => {
+  const MSG: OutboundPayload = {
+    channelId: "chan",
+    payload: { kind: "message", text: "clean answer" },
+  };
+
+  it("counts a transport-layer THROWN rejection as mirror.failed and returns ok:false", async () => {
+    // The bug: the bare call site only bumped mirror.failed on a RESOLVED
+    // {ok:false}. A transport that THROWS (a WS/socket error, a publish-timeout
+    // throw) bumped neither counter and escaped out of onOutbound. The tally
+    // must count it as failed, and the caller must still get a well-formed
+    // result to report back to the hub.
+    const throwing = vi.fn(async () => {
+      throw new Error("ws error");
+    });
+    const tally: MirrorTally = { ok: 0, failed: 0 };
+    const res = await publishOutboundTallied(
+      MSG,
+      SK,
+      throwing as unknown as PublishTransport,
+      tally,
+      1_700_000_000,
+    );
+    expect(res.ok).toBe(false);
+    expect(tally).toEqual({ ok: 0, failed: 1 });
+    // Content-free error string — no thrown message text interpolated.
+    expect(res.error).toBe("publish failed: transport threw");
+  });
+
+  it("counts a RESOLVED {ok:false} relay rejection as mirror.failed too", async () => {
+    const rejecting = vi.fn(async () => ({ ok: false as const, message: "blocked" }));
+    const tally: MirrorTally = { ok: 0, failed: 0 };
+    const res = await publishOutboundTallied(
+      MSG,
+      SK,
+      rejecting as unknown as PublishTransport,
+      tally,
+      1_700_000_000,
+    );
+    expect(res.ok).toBe(false);
+    expect(tally).toEqual({ ok: 0, failed: 1 });
+  });
+
+  it("counts a successful publish as mirror.ok", async () => {
+    const { transport } = okTransport();
+    const tally: MirrorTally = { ok: 0, failed: 0 };
+    const res = await publishOutboundTallied(MSG, SK, transport, tally, 1_700_000_000);
+    expect(res.ok).toBe(true);
+    expect(tally).toEqual({ ok: 1, failed: 0 });
   });
 });

--- a/src/buzz-gateway/publisher.ts
+++ b/src/buzz-gateway/publisher.ts
@@ -258,3 +258,45 @@ export async function publishOutbound(
   }
   return { ok: true, eventId: signed.eventId };
 }
+
+/** The mutable outbound-mirror tally the sidecar owns (index.ts). */
+export interface MirrorTally {
+  ok: number;
+  failed: number;
+}
+
+/**
+ * Run `publishOutbound` and record its outcome in the sidecar's mirror tally,
+ * counting a THROWN transport/sign rejection as a `failed` too (#4305).
+ *
+ * The bare tally at the call site only bumped `mirror.failed` on a RESOLVED
+ * `{ok:false}` — a transport-layer *thrown* rejection (a WS/socket error, a
+ * publish-timeout throw) bumped neither counter and also escaped as an
+ * unhandled rejection out of the `onOutbound` handler, so the hub never got a
+ * result frame. This wrapper owns the try/catch so:
+ *   - `mirror.failed` is the true count of non-delivered mirrors, and
+ *   - the caller ALWAYS gets a well-formed `PublishResult` to report back (this
+ *     function never throws).
+ *
+ * The `error` on the thrown path is a FIXED, content-free string — the thrown
+ * value could carry attacker-influenced text, and this row is operator-facing,
+ * so no exception message is interpolated.
+ */
+export async function publishOutboundTallied(
+  req: OutboundPayload,
+  secretKey: Uint8Array,
+  transport: PublishTransport,
+  tally: MirrorTally,
+  nowSec?: number,
+): Promise<PublishResult> {
+  let result: PublishResult;
+  try {
+    result = await publishOutbound(req, secretKey, transport, nowSec);
+  } catch {
+    tally.failed += 1;
+    return { ok: false, error: "publish failed: transport threw" };
+  }
+  if (result.ok) tally.ok += 1;
+  else tally.failed += 1;
+  return result;
+}

--- a/src/cli/doctor-buzz.test.ts
+++ b/src/cli/doctor-buzz.test.ts
@@ -35,9 +35,14 @@ function heartbeat(over: Partial<BuzzHeartbeat> = {}): string {
   });
 }
 
-/** A deps bundle where the ONE agent 'alpha' has a heartbeat file. */
+/** A deps bundle where the ONE agent 'alpha' has a heartbeat file.
+ *
+ * `heartbeatReads`, when given, returns its entries on SUCCESSIVE readFileSync
+ * calls (then sticks on the last) — used to simulate a torn read that heals on
+ * the retry (#4303). `sleep` is a no-op so the retry back-off is instant. */
 function deps(opts: {
   heartbeatContent?: string | null;
+  heartbeatReads?: string[];
   heartbeatMtimeMs?: number;
   now?: number;
   acl?:
@@ -46,10 +51,12 @@ function deps(opts: {
     | { kind: "not_found" };
 }) {
   const path = buzzHeartbeatOperatorPath(`${AGENTS_DIR}/alpha`);
-  const has = opts.heartbeatContent != null;
+  const has = opts.heartbeatContent != null || (opts.heartbeatReads?.length ?? 0) > 0;
+  let readIdx = 0;
   return {
     homeDir: () => HOME,
     now: () => opts.now ?? 2_000_000,
+    sleep: async () => {},
     existsSync: (p: string) => p === path && has,
     statSync: (p: string) => {
       if (p !== path || !has) throw new Error("ENOENT");
@@ -57,6 +64,11 @@ function deps(opts: {
     },
     readFileSync: (p: string) => {
       if (p !== path || !has) throw new Error("ENOENT");
+      if (opts.heartbeatReads) {
+        const i = Math.min(readIdx, opts.heartbeatReads.length - 1);
+        readIdx += 1;
+        return opts.heartbeatReads[i];
+      }
       return opts.heartbeatContent as string;
     },
     vaultAclReader: async () => opts.acl ?? { kind: "ok" as const, allow: ["alpha"] },
@@ -222,5 +234,58 @@ describe("runBuzzChecks — sidecar liveness", () => {
     const r = row(results, "buzz:sidecar-live:alpha");
     expect(r?.status).toBe("warn");
     expect(r?.detail).toContain("malformed");
+  });
+
+  it("SELF-HEALS a torn read: retries once and reports OK when the re-read parses (#4303)", async () => {
+    // The beacon is written in place (non-atomic, to keep agent-uid ownership),
+    // so doctor can catch a half-written file mid-beat. The first read returns
+    // a truncated/torn payload that fails to parse; the retry read returns the
+    // complete beacon. Doctor must heal within the same run — NOT false-warn
+    // "malformed".
+    const results = await runBuzzChecks(
+      liveCfg,
+      deps({
+        heartbeatReads: ['{ "v": 1, "agent": "alpha", "ts": 1000, "boot', heartbeat()],
+        heartbeatMtimeMs: 2_000_000,
+        now: 2_030_000,
+      }),
+    );
+    const r = row(results, "buzz:sidecar-live:alpha");
+    expect(r?.status).toBe("ok");
+    expect(r?.detail).toContain("injected=6");
+    expect(r?.detail).not.toContain("malformed");
+  });
+
+  it("still WARNs malformed when BOTH the read and its retry fail to parse (#4303)", async () => {
+    const results = await runBuzzChecks(
+      liveCfg,
+      deps({
+        heartbeatReads: ["{ torn once", "{ torn twice"],
+        heartbeatMtimeMs: 2_000_000,
+        now: 2_010_000,
+      }),
+    );
+    const r = row(results, "buzz:sidecar-live:alpha");
+    expect(r?.status).toBe("warn");
+    expect(r?.detail).toContain("malformed");
+  });
+
+  it("WARNs not-live when the beacon's agent field does not match this agent (#4304)", async () => {
+    // A fresh, well-formed, subscribed beacon — but copied from a DIFFERENT
+    // agent's state dir (agent:'intruder'). The agent-name cross-check must
+    // reject it as a foreign/copied beacon rather than reporting the channel
+    // live. The foreign agent value is NOT echoed into the row (untrusted).
+    const results = await runBuzzChecks(
+      liveCfg,
+      deps({
+        heartbeatContent: heartbeat({ agent: "intruder" }),
+        heartbeatMtimeMs: 2_000_000,
+        now: 2_010_000,
+      }),
+    );
+    const r = row(results, "buzz:sidecar-live:alpha");
+    expect(r?.status).toBe("warn");
+    expect(r?.detail).toContain("different agent");
+    expect(r?.detail).not.toContain("intruder");
   });
 });

--- a/src/cli/doctor-buzz.ts
+++ b/src/cli/doctor-buzz.ts
@@ -40,7 +40,11 @@ import { homedir } from "node:os";
 
 import type { SwitchroomConfig } from "../config/schema.js";
 import { resolveAgentConfig } from "../config/merge.js";
-import { buzzHeartbeatOperatorPath, parseBuzzHeartbeat } from "../buzz-gateway/heartbeat.js";
+import {
+  BUZZ_HEARTBEAT_STALE_MS as HEARTBEAT_STALE_MS,
+  buzzHeartbeatOperatorPath,
+  parseBuzzHeartbeat,
+} from "../buzz-gateway/heartbeat.js";
 
 import type { CheckStatus } from "./doctor-status.js";
 
@@ -51,9 +55,18 @@ export interface CheckResult {
   fix?: string;
 }
 
-/** A heartbeat older than this reads as stale. The sidecar beats every 60s by
- *  default; 3× that tolerates a couple of missed beats before flagging. */
-export const BUZZ_HEARTBEAT_STALE_MS = 180 * 1000;
+/** A heartbeat older than this reads as stale. Re-exported from the heartbeat
+ *  module so the stale threshold and the sidecar's beat interval share ONE
+ *  timing contract (#4302): the sidecar clamps its (env-tunable) beat interval
+ *  to stay inside this window, so a healthy sidecar never false-reds. The
+ *  threshold is DERIVED there as interval × missed-beat tolerance, not a fixed
+ *  180s decoupled from the interval. */
+export const BUZZ_HEARTBEAT_STALE_MS = HEARTBEAT_STALE_MS;
+
+/** Small back-off before doctor re-reads a heartbeat that failed to parse, so a
+ *  transient torn read of the in-place (non-atomic) beacon write self-heals
+ *  within one doctor run instead of false-warning "malformed" (#4303). */
+export const BUZZ_HEARTBEAT_REREAD_DELAY_MS = 50;
 
 export interface BuzzProbeDeps {
   existsSync?: (path: string) => boolean;
@@ -62,6 +75,9 @@ export interface BuzzProbeDeps {
   homeDir?: () => string;
   /** Override clock for tests (default Date.now). */
   now?: () => number;
+  /** Injected async delay for the torn-read retry (#4303); default a real
+   *  setTimeout-backed sleep. Tests inject an instant no-op. */
+  sleep?: (ms: number) => Promise<void>;
   /** Inject the vault ACL reader for tests. Returns the agents allowed to read
    *  the key, or an unreachable/not-found signal. */
   vaultAclReader?: (
@@ -79,6 +95,7 @@ interface ResolvedDeps {
   statSync: (path: string) => { mtimeMs: number };
   agentsDir: string;
   now: () => number;
+  sleep: (ms: number) => Promise<void>;
   vaultAclReader: NonNullable<BuzzProbeDeps["vaultAclReader"]>;
 }
 
@@ -90,6 +107,7 @@ function resolveDeps(deps: BuzzProbeDeps): ResolvedDeps {
     statSync: deps.statSync ?? realStatSync,
     agentsDir: join(home, ".switchroom", "agents"),
     now: deps.now ?? Date.now,
+    sleep: deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms))),
     vaultAclReader:
       deps.vaultAclReader ??
       (async () => ({ kind: "unreachable", msg: "no default reader wired" })),
@@ -247,7 +265,7 @@ async function checkKeypairGrant(b: EffectiveBuzz, d: ResolvedDeps): Promise<Che
 // Probe 4: sidecar liveness (heartbeat beacon)
 // ────────────────────────────────────────────────────────────────────────
 
-function checkSidecarLive(b: EffectiveBuzz, d: ResolvedDeps): CheckResult {
+async function checkSidecarLive(b: EffectiveBuzz, d: ResolvedDeps): Promise<CheckResult> {
   if (!b.live) {
     return {
       name: `buzz:sidecar-live:${b.agent}`,
@@ -285,17 +303,45 @@ function checkSidecarLive(b: EffectiveBuzz, d: ResolvedDeps): CheckResult {
   }
 
   // Fresh beat — surface the last-sampled stats + subscription state.
-  let hb = null as ReturnType<typeof parseBuzzHeartbeat>;
-  try {
-    hb = parseBuzzHeartbeat(d.readFileSync(path, "utf-8"));
-  } catch {
-    hb = null;
+  //
+  // The beacon is written in place, non-atomically, to preserve the sidecar's
+  // agent-uid file ownership (repo #3168 landmine — a tmp+rename would re-own
+  // it). That leaves a narrow torn-read window where doctor can read a
+  // half-written file that fails to parse. Rather than change the write side,
+  // retry the READ once after a small delay (#4303): a genuine mid-write
+  // self-heals on the second read within the same doctor run, while a durably
+  // malformed beacon still fails both reads and warns.
+  const readOnce = (): ReturnType<typeof parseBuzzHeartbeat> => {
+    try {
+      return parseBuzzHeartbeat(d.readFileSync(path, "utf-8"));
+    } catch {
+      return null;
+    }
+  };
+  let hb = readOnce();
+  if (!hb) {
+    await d.sleep(BUZZ_HEARTBEAT_REREAD_DELAY_MS);
+    hb = readOnce();
   }
   if (!hb) {
     return {
       name: `buzz:sidecar-live:${b.agent}`,
       status: "warn",
       detail: `heartbeat ${Math.round(age / 1000)}s old but unreadable/malformed at ${path}`,
+    };
+  }
+  // Cross-check the beacon's own agent field against the agent this row is for
+  // (#4304). The beacon lives in the agent's uid-writable state dir and this
+  // fleet treats agents as prompt-injectable, so a beacon copied from another
+  // agent's dir (or a stale/foreign one) must NOT pass this liveness probe.
+  // A mismatch is treated as not-live/malformed. The beacon's agent value is
+  // NOT echoed into the row — it is untrusted, agent-controlled content.
+  if (hb.agent !== b.agent) {
+    return {
+      name: `buzz:sidecar-live:${b.agent}`,
+      status: "warn",
+      detail: `heartbeat ${Math.round(age / 1000)}s old at ${path} belongs to a different agent than '${b.agent}' — foreign/copied beacon, treating as not live`,
+      fix: `Confirm the sidecar for '${b.agent}' owns this beacon: \`switchroom agent restart ${b.agent} --wait\` and check /var/log/switchroom/buzz-gateway.log.`,
     };
   }
   const s = hb.stats;
@@ -336,7 +382,7 @@ export async function runBuzzChecks(
     results.push(checkChannelState(b));
     results.push(checkRelayConfig(b));
     results.push(await checkKeypairGrant(b, d));
-    results.push(checkSidecarLive(b, d));
+    results.push(await checkSidecarLive(b, d));
   }
   return results;
 }


### PR DESCRIPTION
## Summary

Four observability-only LOW findings from the Buzz audit surface PR (#4295), as one focused follow-up. All four live in the heartbeat/doctor/stats health surface; none touch `gateway.ts`, `auth-gate.ts`, `buzz-mirror.ts`, or `buzz-mirror-correlation-store.ts`, and no message text / ids / pubkeys enter any stat, log, or doctor row.

- **Fixes #4302 — stale-threshold decoupled from the tunable interval.** The doctor stale threshold was a fixed `180s` (`src/cli/doctor-buzz.ts`) while the sidecar beat interval is env-tunable via `BUZZ_STATS_INTERVAL_MS` (`src/buzz-gateway/index.ts`). An interval set above ~180s made every healthy sidecar false-red as stale. `heartbeat.ts` now owns ONE timing contract: `BUZZ_HEARTBEAT_STALE_MS` is DERIVED as `interval x tolerance`, and `resolveStatsIntervalMs()` clamps the runtime interval so it can never outrun the stale window. `doctor-buzz.ts` re-exports the shared constant instead of hard-coding 180s. Deterministic: the false-red is now structurally impossible.
- **Fixes #4303 — torn read on the non-atomic heartbeat write.** The beacon is written in place (non-atomic) on purpose, to preserve agent-uid file ownership (#3168 landmine — a tmp+rename would re-own it). Fixed on the READ side: doctor retries the read once after a small back-off before emitting the "malformed" warn, so a transient half-written file self-heals within the same doctor run. The write path is unchanged.
- **Fixes #4304 — no `hb.agent` cross-check in the liveness probe.** `checkSidecarLive` read the beacon but never verified the beacon's `agent` matched the expected agent, so a beacon copied from another agent's dir would pass. It now treats a mismatch as foreign/not-live. The untrusted, agent-controlled `agent` value is NOT echoed into the operator row.
- **Fixes #4305 — mirror tally missed a thrown publish.** `mirror.failed` only incremented on a resolved `{ok:false}`; a transport-layer *thrown* rejection bumped neither counter (and escaped out of `onOutbound`, so the hub got no result frame). New `publishOutboundTallied` wrapper owns the try/catch so a thrown rejection counts as `mirror.failed` and the handler always returns a well-formed `PublishResult`. The thrown-path `error` is a fixed, content-free string.

## Why

These are the reviewed LOWs held back from #4295 as follow-ups. Each is a correctness gap in the operator health surface: a false-red that erodes trust in doctor (#4302), a transient false "malformed" (#4303), a liveness probe that a copied beacon defeats (#4304), and an undercount of failed mirrors (#4305).

## Test plan

- New outcome-asserting tests (not just code-path):
  - `heartbeat.test.ts` — an interval above the stale threshold resolves to `<= BUZZ_HEARTBEAT_MAX_INTERVAL_MS` (false-red impossible); the `stale = interval x tolerance` relationship is pinned.
  - `doctor-buzz.test.ts` — torn first read + valid retry read reports OK (heals, no "malformed"); both reads torn still warns; a beacon whose `agent` != expected warns not-live and does not echo the foreign name.
  - `publisher.test.ts` — a thrown transport counts as `mirror.failed` and returns `ok:false`; resolved `{ok:false}` and success paths tally correctly.
- Scoped: `vitest run src/buzz-gateway/heartbeat.test.ts src/buzz-gateway/publisher.test.ts src/cli/doctor-buzz.test.ts` -> 45 passed.
- `npm run lint` (tsc + all guards) -> green.

## Risk

Low. Observability-only. The interval clamp caps the *slowest* beat (faster beats pass through unchanged); the doctor read gains one bounded retry only on a parse miss; the agent cross-check can only reject, never falsely pass.

Job spec: `reference/jobs/fleet-stays-healthy.md` — doctor is the operator's health surface; a probe that false-reds or undercounts is a health-surface defect.