### PR TITLE
feat(handoff-briefing): render reply antecedent in boot briefing

### DIFF
--- a/bin/handoff-briefing.sh
+++ b/bin/handoff-briefing.sh
@@ -192,7 +192,7 @@ try:
     )
 
     cur.execute(
-        "SELECT role, user, ts, text FROM messages WHERE "
+        "SELECT role, user, ts, text, reply_to_message_id, reply_to_text FROM messages WHERE "
         + " AND ".join(where)
         + " ORDER BY ts DESC LIMIT ?",
         params,
@@ -209,7 +209,27 @@ try:
             text = text[:600] + "… [truncated]"
         # Escape any literal backslash to keep the shell echo safe
         text = text.replace("\\", "\\\\")
+        # Reply antecedent (issue #119 native reply). recordInbound persists
+        # reply_to_message_id/reply_to_text — the latter recovered from the
+        # history buffer even when the reply target was the bot's OWN message
+        # (Telegram omits its text on the live update). Surfacing it as an
+        # indented "↪ replying to" line carries the antecedent STRUCTURE into
+        # the post-reset briefing, so a fresh session reading this transcript
+        # knows what "this"/"that" in the reply refers to instead of guessing.
+        # Without it the flat dump loses the thread of any native reply.
         print(f"[{ts_str}] {label}: {text}")
+        reply_id = row["reply_to_message_id"]
+        reply_text = row["reply_to_text"]
+        if reply_text is not None and reply_text != "":
+            rt = reply_text
+            if len(rt) > 200:
+                rt = rt[:200] + "…"
+            rt = rt.replace("\\", "\\\\").replace("\n", " ")
+            print(f"       ↪ replying to: {rt}")
+        elif reply_id is not None:
+            # Antecedent known by id only (text unavailable — reply target had
+            # no text, or predates the reply_to_text buffer backfill).
+            print(f"       ↪ replying to message #{reply_id}")
 except Exception as e:
     sys.stderr.write(f"handoff-briefing: sqlite query failed: {e}\n")
     sys.exit(0)

--- a/tests/handoff-briefing.test.ts
+++ b/tests/handoff-briefing.test.ts
@@ -573,6 +573,8 @@ interface SeedRow {
   user?: string | null;
   ts: number;
   text: string;
+  reply_to_message_id?: number | null;
+  reply_to_text?: string | null;
 }
 
 /**
@@ -600,10 +602,11 @@ c.execute(
 )
 for r in rows:
     c.execute(
-        "INSERT INTO messages(chat_id,thread_id,message_id,role,user,user_id,ts,text) "
-        "VALUES(?,?,?,?,?,?,?,?)",
+        "INSERT INTO messages(chat_id,thread_id,message_id,role,user,user_id,ts,text,reply_to_message_id,reply_to_text) "
+        "VALUES(?,?,?,?,?,?,?,?,?,?)",
         (r["chat_id"], r.get("thread_id"), r["message_id"], r["role"],
-         r.get("user"), None, r["ts"], r["text"]),
+         r.get("user"), None, r["ts"], r["text"],
+         r.get("reply_to_message_id"), r.get("reply_to_text")),
     )
 c.commit()
 c.close()
@@ -764,6 +767,86 @@ describe("handoff-briefing.sh recent-conversation scoping", () => {
     expect(status).toBe(0);
     expect(output).not.toContain("Recent conversation");
     expect(output.trim()).toBe("");
+  });
+});
+
+// ── Recent-conversation reply-antecedent rendering ──────────────────────────────
+//
+// recordInbound persists reply_to_message_id / reply_to_text on a native reply
+// (issue #119); for a reply to the BOT's OWN message the buffer fallback
+// (resolveReplyToFromBuffer, #4306) recovers the text Telegram omits from the
+// live update and persists it too. The briefing used to SELECT only
+// role/user/ts/text and flat-dump the transcript, dropping that antecedent
+// structure — so a post-reset session reading the reply had no idea what it
+// referred to. These tests seed the reply columns and assert the "↪ replying
+// to" annotation lands (text when present, id-only fallback otherwise). A
+// regression back to the columnless SELECT fails all three.
+describe("handoff-briefing.sh recent-conversation reply-antecedent rendering", () => {
+  let tmpDir: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "handoff-reply-"));
+    stateDir = join(tmpDir, "telegram");
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function runBriefing(
+    scopeEnv: Record<string, string> = {},
+  ): { status: number | null; output: string } {
+    const result = spawnSync("bash", [HANDOFF_BRIEFING_SCRIPT, "--stdout"], {
+      env: {
+        ...process.env,
+        AGENT_DIR: tmpDir,
+        TELEGRAM_STATE_DIR: stateDir,
+        HINDSIGHT_API_URL: "",
+        HINDSIGHT_BANK_ID: "",
+        WORKSPACE_DIR: tmpDir,
+        ...scopeEnv,
+      },
+      timeout: 10_000,
+    });
+    return { status: result.status, output: result.stdout.toString() };
+  }
+
+  it("renders the reply antecedent TEXT under a native reply (the reply-to-bot recovery case)", () => {
+    // The bot answered (message 1), then the user native-replied to that bot
+    // message (message 2). Telegram omitted the bot message's .text on the
+    // live update, but resolveReplyToFromBuffer recovered it and recordInbound
+    // persisted it as reply_to_text on the inbound row.
+    seedHistoryDb(stateDir, [
+      { chat_id: "c1", thread_id: null, message_id: 1, role: "assistant", ts: 1000, text: "Added the dentist appointment for Tuesday 3pm." },
+      { chat_id: "c1", thread_id: null, message_id: 2, role: "user", user: "ken", ts: 1001, text: "is this on my calendar yet?", reply_to_message_id: 1, reply_to_text: "Added the dentist appointment for Tuesday 3pm." },
+    ]);
+    const { status, output } = runBriefing({ SWITCHROOM_PENDING_CHAT_ID: "c1", SWITCHROOM_PENDING_THREAD_ID: "NULL" });
+    expect(status).toBe(0);
+    expect(output).toContain("is this on my calendar yet?");
+    // The antecedent structure the flat dump used to lose.
+    expect(output).toContain("↪ replying to: Added the dentist appointment for Tuesday 3pm.");
+  });
+
+  it("falls back to the message id when the antecedent id is known but its text is NULL", () => {
+    seedHistoryDb(stateDir, [
+      { chat_id: "c1", thread_id: null, message_id: 1, role: "assistant", ts: 1000, text: "(a photo)" },
+      { chat_id: "c1", thread_id: null, message_id: 2, role: "user", user: "ken", ts: 1001, text: "what is that?", reply_to_message_id: 1, reply_to_text: null },
+    ]);
+    const { status, output } = runBriefing({ SWITCHROOM_PENDING_CHAT_ID: "c1", SWITCHROOM_PENDING_THREAD_ID: "NULL" });
+    expect(status).toBe(0);
+    expect(output).toContain("what is that?");
+    expect(output).toContain("↪ replying to message #1");
+  });
+
+  it("emits no antecedent line for a plain (non-reply) message", () => {
+    seedHistoryDb(stateDir, [
+      { chat_id: "c1", thread_id: null, message_id: 1, role: "user", user: "ken", ts: 1000, text: "just a normal message" },
+    ]);
+    const { status, output } = runBriefing({ SWITCHROOM_PENDING_CHAT_ID: "c1", SWITCHROOM_PENDING_THREAD_ID: "NULL" });
+    expect(status).toBe(0);
+    expect(output).toContain("just a normal message");
+    expect(output).not.toContain("↪ replying to");
   });
 });
 


### PR DESCRIPTION
## Summary

The boot handoff briefing flat-dumped the last N messages (`SELECT role, user, ts, text`) and **ignored the persisted `reply_to_message_id` / `reply_to_text` columns** that `recordInbound` writes on a native reply (issue #119). This PR selects those columns and renders an indented `↪ replying to: <text>` line under each reply (id-only fallback `↪ replying to message #<id>` when the antecedent text is NULL), so a post-reset session reads a native reply with its antecedent structure intact instead of guessing what "this"/"that" refers to.

Scope is exactly **one file of behaviour** — `bin/handoff-briefing.sh` — plus tests.

## Not a duplicate of #4306 — it's the one consumer #4306 left unrendered

The live-inbound **3-tier antecedent resolver (quote → payload → history-buffer)** already shipped in **#4306 (commit `576dbb1c`)**:
- Tier 1 surgical quote + Tier 2 payload: `telegram-plugin/gateway/inbound-router.ts:162-167`
- Tier 3 history fallback: `resolveReplyToFromBuffer` (`inbound-router.ts:232-262`), wired at `gateway.ts:15104-15115`.

#4306 also fixed the boot-briefing **query scoping** (chat/thread) — but it never **rendered** the reply columns it made available. That's the gap this PR closes: the last remaining consumer (boot briefing) that saw a native reply as a structureless line.

The reactions path (`gateway.ts:19459`, `:19656`) already resolves via `lookupMessageRoleAndText` and is deliberately untouched — a reaction has no `reply_to_message`, so tiers 1-2 don't apply.

## Outbound-keying pre-check — PASS (no keying fix needed)

Tier 3 / the recovered text is sound because outbound is keyed by message id: `recordOutbound` (`telegram-plugin/history.ts:575-620`) INSERTs each delivered chunk keyed by `message_id` with `role='assistant'` (PRIMARY KEY `(chat_id, thread_id, message_id)`), and `lookupMessageRoleAndText` (`history.ts:781-794`) reads it back by `(chat_id, message_id)`.

## Test plan

- **3 new outcome tests** in `tests/handoff-briefing.test.ts`: reply-antecedent text render (the reply-to-bot recovery case), id-only fallback when `reply_to_text` is NULL, and no antecedent line for a plain non-reply message. The seed helper now carries the reply columns.
- **Mutation-verified**: reverting the SELECT to drop the columns reds the two positive tests; the negative test correctly stays green — the tests assert the outcome, not just the code path.
- `./node_modules/.bin/vitest run tests/handoff-briefing.test.ts` → **36/36 pass**.
- `tsc --noEmit` clean; `bash -n bin/handoff-briefing.sh` clean.

## Risk

Low. Additive render + two extra SELECT columns; no change to the query's scoping/filtering or to any live-inbound / reactions path. Degrades to the prior flat line when the reply columns are absent (older rows).

## Deferred follow-ups (out of scope)

- OpenClaw reply-chain-walk (depth-N) + window-dedup guard.
- `--resume` CLI-session-id reattach (Tier 3 on #4306's own deferral list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)