### PR TITLE
perf(hindsight): pin temporal dateparser to configurable languages (default en) to end event-loop starvation

### DIFF
--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -3809,6 +3809,184 @@ print(
 )
 PYEOF
 
+# --- switchroom: pin temporal dateparser to a configurable language set ---
+#
+# dateparser.search_dates() with NO `languages=` auto-detects across 200+
+# locales on EVERY recall. That auto-detection runs INLINE on the single shared
+# asyncio loop (recall + consolidation + reranker all share one process), and
+# under consolidation recall fan-out it blocked the loop for 1-2.6s at a time —
+# the loop watchdog logged 128 `EVENT LOOP BLOCKED >=1s` events in 20 minutes,
+# with dateparser's per-locale language-split frames
+# (dateparser/languages/locale.py:_split, dictionary.py:_split_by_known_words /
+# _should_capture) appearing 1383x in the blocked stacks.
+#
+# Pinning `languages=` to a fixed list eliminates the auto-detection pass
+# entirely — those language-split frames stop executing by construction, not
+# merely run faster. Measured in this image's venv on a representative recall
+# query: auto-detect 99.8 ms/call vs languages=["en"] 0.6 ms/call (~165x).
+#
+# The list is a real config.py knob, HINDSIGHT_API_TEMPORAL_LANGUAGES
+# (comma-separated, default "en"), so the fleet runs English-only by default and
+# future i18n is a pure config change with no image edit. The default is baked
+# here in config.py; the knob is exposed to operators as an override-only key in
+# src/setup/hindsight-perf-defaults.ts (HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS).
+#
+# Self-verifying; guarded structurally by
+# tests/docker/dockerfile-hindsight-bakes.test.ts and behaviourally (RED against
+# unpatched upstream / GREEN patched) by
+# tests/docker/hindsight-temporal-language-patch.test.ts.
+RUN python3 - <<'PYEOF'
+import ast
+import pathlib
+
+BASE = pathlib.Path("/app/api/hindsight_api")
+
+
+def apply(rel, edits):
+    f = BASE / rel
+    s = f.read_text()
+    for anchor, repl in edits:
+        n = s.count(anchor)
+        assert n == 1, (
+            f"switchroom hindsight temporal-language patch: anchor found {n}x "
+            f"(expected 1) in {rel} — upstream reformatted; re-author this patch in "
+            f"docker/Dockerfile.hindsight. Anchor head: {anchor.splitlines()[0]!r}"
+        )
+        s = s.replace(anchor, repl, 1)
+    f.write_text(s)
+    return s
+
+
+# ---- 1. config.py: the HINDSIGHT_API_TEMPORAL_LANGUAGES knob (default "en") ----
+cfg = apply("config.py", [
+    (
+        'ENV_TEMPORAL_SEMANTIC_MIN_SIMILARITY = "HINDSIGHT_API_TEMPORAL_SEMANTIC_MIN_SIMILARITY"\n',
+        'ENV_TEMPORAL_SEMANTIC_MIN_SIMILARITY = "HINDSIGHT_API_TEMPORAL_SEMANTIC_MIN_SIMILARITY"\n'
+        "# switchroom: languages dateparser.search_dates() is restricted to during temporal\n"
+        '# query analysis. Comma-separated; default "en". Pinning this eliminates the\n'
+        "# 200+-locale auto-detection pass that blocked the shared asyncio loop.\n"
+        'ENV_TEMPORAL_LANGUAGES = "HINDSIGHT_API_TEMPORAL_LANGUAGES"\n',
+    ),
+    (
+        "DEFAULT_TEMPORAL_SEMANTIC_MIN_SIMILARITY = 0.1\n",
+        "DEFAULT_TEMPORAL_SEMANTIC_MIN_SIMILARITY = 0.1\n"
+        "# switchroom: English-only by default (the fleet is English); operators restore\n"
+        '# i18n with e.g. HINDSIGHT_API_TEMPORAL_LANGUAGES="en,es".\n'
+        'DEFAULT_TEMPORAL_LANGUAGES = "en"\n',
+    ),
+    (
+        "    temporal_semantic_min_similarity: float\n",
+        "    temporal_semantic_min_similarity: float\n"
+        "    temporal_languages: list[str]  # switchroom: dateparser language pin (default ['en'])\n",
+    ),
+    (
+        "            temporal_semantic_min_similarity=float(\n"
+        "                os.getenv(ENV_TEMPORAL_SEMANTIC_MIN_SIMILARITY, str(DEFAULT_TEMPORAL_SEMANTIC_MIN_SIMILARITY))\n"
+        "            ),\n",
+        "            temporal_semantic_min_similarity=float(\n"
+        "                os.getenv(ENV_TEMPORAL_SEMANTIC_MIN_SIMILARITY, str(DEFAULT_TEMPORAL_SEMANTIC_MIN_SIMILARITY))\n"
+        "            ),\n"
+        "            # switchroom: CSV -> stripped non-empty list; falls back to ['en'] if it\n"
+        "            # resolves empty, so the loop-starving no-languages call is unreachable.\n"
+        "            temporal_languages=_parse_str_list(\n"
+        "                os.getenv(ENV_TEMPORAL_LANGUAGES, DEFAULT_TEMPORAL_LANGUAGES)\n"
+        '            ) or ["en"],\n',
+    ),
+])
+
+# ---- 2. query_analyzer.py: pin languages= on BOTH search_dates call sites ----
+qa = apply("engine/query_analyzer.py", [
+    (
+        "logger = logging.getLogger(__name__)\n",
+        "logger = logging.getLogger(__name__)\n"
+        "\n"
+        "\n"
+        "def _resolve_temporal_languages() -> list[str]:\n"
+        '    """switchroom: the dateparser language pin, read from config (default ["en"]).\n'
+        "\n"
+        "    Read from HindsightConfig.temporal_languages, itself parsed from\n"
+        "    HINDSIGHT_API_TEMPORAL_LANGUAGES. Defensive: if config is not yet loaded\n"
+        "    (e.g. the analyzer is constructed in isolation), fall back to English so a\n"
+        "    bare search_dates(query) with no languages= -- the 200+-locale auto-detect\n"
+        "    that starves the shared asyncio loop -- can never be reached.\n"
+        '    """\n'
+        "    try:\n"
+        "        from hindsight_api.config import get_config\n"
+        "\n"
+        "        langs = [str(x).strip() for x in (get_config().temporal_languages or []) if str(x).strip()]\n"
+        "        if langs:\n"
+        "            return langs\n"
+        "    except Exception:\n"
+        "        pass\n"
+        '    return ["en"]\n',
+    ),
+    (
+        "    def __init__(self):\n"
+        '        """Initialize dateparser query analyzer."""\n'
+        "        self._search_dates = None\n",
+        "    def __init__(self):\n"
+        '        """Initialize dateparser query analyzer."""\n'
+        "        self._search_dates = None\n"
+        "        # switchroom: restrict dateparser to these languages on every call so it\n"
+        "        # never runs the 200+-locale auto-detection pass inline on the loop.\n"
+        "        self._languages = _resolve_temporal_languages()\n",
+    ),
+    (
+        "            self._search_dates = search_dates\n"
+        "            # Warm up: fire a dummy call to trigger lazy-loaded internal tables.\n"
+        '            self._search_dates("today")\n',
+        "            self._search_dates = search_dates\n"
+        "            # Warm up: fire a dummy call to trigger lazy-loaded internal tables.\n"
+        '            self._search_dates("today", languages=self._languages)\n',
+    ),
+    (
+        "            results = self._search_dates(query, settings=settings)\n",
+        "            results = self._search_dates(query, settings=settings, languages=self._languages)\n",
+    ),
+])
+
+# ---- verification ----
+# The knob is wired end to end: env name, default, dataclass field, and the
+# from_env parse that turns the CSV into a list with an ["en"] floor.
+assert 'ENV_TEMPORAL_LANGUAGES = "HINDSIGHT_API_TEMPORAL_LANGUAGES"' in cfg, (
+    "switchroom hindsight temporal-language patch: ENV name missing after patch"
+)
+assert 'DEFAULT_TEMPORAL_LANGUAGES = "en"' in cfg, (
+    "switchroom hindsight temporal-language patch: default missing after patch"
+)
+assert "    temporal_languages: list[str]" in cfg, (
+    "switchroom hindsight temporal-language patch: dataclass field missing after patch"
+)
+assert "temporal_languages=_parse_str_list(" in cfg, (
+    "switchroom hindsight temporal-language patch: from_env wiring missing after patch"
+)
+# Neither search_dates call may remain WITHOUT languages=. This is the assertion
+# that would RED if the pin were reverted -- the whole point of the patch.
+assert qa.count("self._search_dates(query, settings=settings)") == 0, (
+    "switchroom hindsight temporal-language patch: analyze() still calls search_dates "
+    "WITHOUT languages= -- the loop-starving auto-detection pass survives"
+)
+assert "self._search_dates(query, settings=settings, languages=self._languages)" in qa, (
+    "switchroom hindsight temporal-language patch: analyze() search_dates is not pinned"
+)
+assert 'self._search_dates("today")' not in qa, (
+    "switchroom hindsight temporal-language patch: load() warm-up still auto-detects"
+)
+assert 'self._search_dates("today", languages=self._languages)' in qa, (
+    "switchroom hindsight temporal-language patch: load() warm-up is not pinned"
+)
+assert "self._languages = _resolve_temporal_languages()" in qa, (
+    "switchroom hindsight temporal-language patch: analyzer does not resolve its language pin"
+)
+ast.parse(cfg)
+ast.parse(qa)
+print(
+    "switchroom hindsight temporal-language patch: dateparser pinned to "
+    "HINDSIGHT_API_TEMPORAL_LANGUAGES (default en) on both search_dates call sites; "
+    "the 200+-locale auto-detection pass that starved the shared asyncio loop is gone"
+)
+PYEOF
+
 # Pin the upstream `hindsight` user to UID 11000 to match
 # `HINDSIGHT_DEFAULT_UID` in src/setup/hindsight.ts (and the
 # `auth.consumers[hindsight].uid` value the operator writes in

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2972,7 +2972,13 @@ export const HindsightConfigSchema = z.object({
       "between consolidation-triggered refreshes of one mental model; unset " +
       "means the image's baked 3600, 0 restores upstream's " +
       "refresh-every-round behaviour; explicit and cron-scheduled refreshes " +
-      "are never debounced), plus the " +
+      "are never debounced; and " +
+      "HINDSIGHT_API_TEMPORAL_LANGUAGES — the language set dateparser is " +
+      "restricted to during temporal query analysis, made live by switchroom's " +
+      "temporal-language image patch (which ended a 200+-locale auto-detection " +
+      "pass that blocked the shared asyncio loop on every recall); " +
+      "comma-separated, unset means the image's baked `en`, set e.g. `en,es` to " +
+      "restore i18n parsing), plus the " +
       "embedded-PostgreSQL (pg0) sizing keys switchroom manages in " +
       "src/setup/hindsight-pg-defaults.ts (`HINDSIGHT_PG_ENV_KEYS`: " +
       "SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE, " +

--- a/src/setup/hindsight-perf-defaults.test.ts
+++ b/src/setup/hindsight-perf-defaults.test.ts
@@ -351,7 +351,7 @@ describe("operator override wins", () => {
     expect(got.size).toBe(0);
   });
 
-  it("is overridable on exactly these forty-six keys, by name", () => {
+  it("is overridable on exactly these forty-seven keys, by name", () => {
     // Spelled out, NOT derived from the three group arrays. HINDSIGHT_PERF_ENV_KEYS
     // is DEFINED as the union of those arrays, so asserting it equals that union
     // is a tautology — it passes no matter which keys are in the arrays. The
@@ -387,6 +387,7 @@ describe("operator override wins", () => {
       "HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT",
       "HINDSIGHT_API_RETAIN_WALL_TIMEOUT",
       "HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY",
+      "HINDSIGHT_API_TEMPORAL_LANGUAGES",
       "HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY",
       // Both spellings of every per-type slot reservation are ACCEPTED as
       // input (see HINDSIGHT_WORKER_RESERVED_SLOT_ALIASES); only the
@@ -780,6 +781,74 @@ describe("HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT (override-only)", ()
     const perf = { env: { [KEY]: "1" }, processEnv: {} };
     startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, false, perf);
     expect(runEnv(runArgs()).get(KEY)).toEqual(["1"]);
+  });
+});
+
+// ── the temporal-language pin ─────────────────────────────────────────────
+describe("HINDSIGHT_API_TEMPORAL_LANGUAGES (override-only, i18n restore hatch)", () => {
+  const KEY = "HINDSIGHT_API_TEMPORAL_LANGUAGES";
+  const CAPS = [
+    { gpu: false, localLlm: false },
+    { gpu: true, localLlm: false },
+    { gpu: false, localLlm: true },
+    { gpu: true, localLlm: true },
+  ];
+
+  it("is in the managed set but in NO defaults group", () => {
+    // switchroom's temporal-language image patch pins dateparser to this list
+    // (default "en", baked in config.py) to end the 200+-locale auto-detection
+    // pass that blocked the shared asyncio loop. Managed so an operator's
+    // hindsight.env line restoring i18n is not silently dropped by
+    // resolveHindsightPerfOverrides; override-only because the default lives in
+    // the image, so emitting one here would only create a second copy to drift.
+    expect(HINDSIGHT_PERF_ENV_KEYS.has(KEY)).toBe(true);
+    expect(HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS.has(KEY)).toBe(true);
+    for (const group of [
+      HINDSIGHT_PERF_DEFAULTS_UNGATED,
+      HINDSIGHT_PERF_DEFAULTS_GPU,
+      HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM,
+    ]) {
+      expect(group.map(([k]) => k)).not.toContain(KEY);
+    }
+  });
+
+  it("survives resolveHindsightPerfOverrides from BOTH sources", () => {
+    expect(resolveHindsightPerfOverrides({ [KEY]: "en,es" }).get(KEY)).toBe("en,es");
+    expect(resolveHindsightPerfOverrides(undefined, { [KEY]: "en,es" }).get(KEY)).toBe("en,es");
+  });
+
+  it.each(CAPS)(
+    "is NOT emitted when unset (gpu=$gpu localLlm=$localLlm) — the image's baked English default stands",
+    (caps) => {
+      // Override-only means REACHABLE, not changed: a host that sets nothing
+      // keeps the image's baked default "en". Emitting a value here would pin
+      // every install to switchroom's copy of that opinion.
+      expect(hindsightPerfEnv(caps).map(([k]) => k)).not.toContain(KEY);
+    },
+  );
+
+  it("reaches BOTH launch paths, with the operator's value, when set in hindsight.env", () => {
+    // The outcome that matters: an operator re-enabling i18n from declarative
+    // yaml must actually reach the container. Before the key entered the managed
+    // set, the line read as durable config yet was dropped and the pin stayed
+    // English-only regardless.
+    const perf = { env: { [KEY]: "en,es" }, processEnv: {} };
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false, perf);
+    const fromRun = runEnv(runArgs());
+    const fromCompose = composeEnv(
+      generateHindsightComposeSnippet(undefined, undefined, LOOPBACK_LITELLM, false, perf),
+    );
+    expect(fromRun.get(KEY)).toEqual(["en,es"]);
+    expect(fromCompose.get(KEY)).toEqual(["en,es"]);
+  });
+
+  it("still reaches the container on a host with NO gated capability", () => {
+    // It belongs to no capability group, so a gate-shaped regression that only
+    // emits grouped keys would drop it. Cloud endpoint + no GPU is the harshest
+    // gating case.
+    const perf = { env: { [KEY]: "en,es" }, processEnv: {} };
+    startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, false, perf);
+    expect(runEnv(runArgs()).get(KEY)).toEqual(["en,es"]);
   });
 });
 

--- a/src/setup/hindsight-perf-defaults.ts
+++ b/src/setup/hindsight-perf-defaults.ts
@@ -1326,6 +1326,32 @@ export const HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM: ReadonlyArray<readonly [string, 
  *     HINDSIGHT_MM_REFRESH_MIN_INTERVAL_S: "0"   # upstream behaviour, patch inert
  * ```
  *
+ * ### `HINDSIGHT_API_TEMPORAL_LANGUAGES`
+ *
+ * The language set `dateparser.search_dates()` is restricted to during temporal
+ * query analysis, comma-separated. Unpatched, `search_dates()` was called with
+ * NO `languages=`, so it auto-detected across 200+ locales INLINE on the shared
+ * asyncio loop on every recall that reached it — the loop watchdog logged 128
+ * `EVENT LOOP BLOCKED >=1s` events in 20 minutes with dateparser's per-locale
+ * language-split frames appearing 1383× in the blocked stacks (99.8 ms/call vs
+ * 0.6 ms/call once pinned, ~165×). switchroom's temporal-language image patch
+ * (`docker/Dockerfile.hindsight`, the `config.py` + `engine/query_analyzer.py`
+ * block) pins it, defaulting to `"en"` — the fleet is English.
+ *
+ * Unlike the CE-gap / MM-refresh knobs above, this IS a real `HINDSIGHT_API_`
+ * config.py field: the patch adds `ENV_TEMPORAL_LANGUAGES` and a
+ * `temporal_languages: list[str]` field that `from_env()` parses (CSV → stripped
+ * non-empty list, `["en"]` floor). Override-only here because that default lives
+ * in the image, not in switchroom's TS layer — emitting a second copy would only
+ * create drift. Restore i18n with e.g. `"en,es"`; an all-empty value floors back
+ * to English, so the loop-starving no-languages call is unreachable.
+ *
+ * ```yaml
+ * hindsight:
+ *   env:
+ *     HINDSIGHT_API_TEMPORAL_LANGUAGES: "en,es"   # re-enable Spanish parsing
+ * ```
+ *
  * ### DELIBERATELY NOT ADOPTED from v0.8.6
  *
  * - `HINDSIGHT_API_LOOP_WATCHDOG_ENABLED` / `..._STALL_THRESHOLD_MS` /
@@ -1352,6 +1378,7 @@ export const HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS: ReadonlySet<string> = new Set([
   "HINDSIGHT_API_RETAIN_WALL_TIMEOUT",
   "HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT",
   "HINDSIGHT_MM_REFRESH_MIN_INTERVAL_S",
+  "HINDSIGHT_API_TEMPORAL_LANGUAGES",
 ]);
 
 /**

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -1316,6 +1316,55 @@ describe("Dockerfile.hindsight shape", () => {
     );
   });
 
+  it("keeps the temporal-language fix (assert-guarded, fail-loud)", () => {
+    // dateparser.search_dates() with no `languages=` auto-detected across 200+
+    // locales inline on the shared asyncio loop on every recall — 128 loop
+    // blocks/20min, 1383 language-split frames in the blocked stacks. The patch
+    // pins `languages=` to a config knob (default en) on both search_dates
+    // call sites, eliminating the auto-detection pass.
+
+    // The exact-once anchor guard (fail-loud on upstream drift).
+    expect(dockerfile).toMatch(
+      /switchroom hindsight temporal-language patch: anchor found \{n\}x/,
+    );
+
+    // The config.py knob, wired end to end: env name, default, dataclass
+    // field, and the CSV-with-["en"]-floor parse in from_env.
+    expect(dockerfile).toContain(
+      'ENV_TEMPORAL_LANGUAGES = "HINDSIGHT_API_TEMPORAL_LANGUAGES"',
+    );
+    expect(dockerfile).toContain('DEFAULT_TEMPORAL_LANGUAGES = "en"');
+    expect(dockerfile).toContain("    temporal_languages: list[str]");
+    expect(dockerfile).toContain("temporal_languages=_parse_str_list(");
+    expect(dockerfile).toMatch(
+      /os\.getenv\(ENV_TEMPORAL_LANGUAGES, DEFAULT_TEMPORAL_LANGUAGES\)/,
+    );
+    expect(dockerfile).toMatch(/\) or \["en"\],/);
+
+    // Both search_dates call sites pinned — the load() warm-up and the
+    // analyze() call.
+    expect(dockerfile).toContain(
+      'self._search_dates("today", languages=self._languages)',
+    );
+    expect(dockerfile).toContain(
+      "results = self._search_dates(query, settings=settings, languages=self._languages)",
+    );
+    // The analyzer resolves its pin from config, defaulting to English.
+    expect(dockerfile).toContain(
+      "self._languages = _resolve_temporal_languages()",
+    );
+
+    // The post-replace assertion that would RED if the pin were reverted: the
+    // no-languages call must be GONE from analyze(). This is the guard that
+    // makes the fix's absence a build failure, not a silent regression.
+    expect(dockerfile).toContain(
+      'assert qa.count("self._search_dates(query, settings=settings)") == 0,',
+    );
+    expect(dockerfile).toMatch(
+      /switchroom hindsight temporal-language patch: dateparser pinned to/,
+    );
+  });
+
   it("preserves upstream's start-all.sh as the post-shim CMD", () => {
     // The shim does broker auth, then `exec "$@"` which is whatever
     // CMD docker passes — must be upstream's start-all.sh so the

--- a/tests/docker/hindsight-temporal-language-patch.test.ts
+++ b/tests/docker/hindsight-temporal-language-patch.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Behavioural proof for the temporal-language patch
+ * `docker/Dockerfile.hindsight` bakes into the pinned upstream Hindsight image.
+ * `dockerfile-hindsight-bakes.test.ts` pins the *shape* of the patch block
+ * (grep-on-file, runs everywhere). This file proves the *outcome*: it runs the
+ * same probe against unpatched upstream (must be RED on the defect) and against
+ * upstream + the patch block applied (must be GREEN).
+ *
+ * The defect, measured live on `switchroom-hindsight` before the fix:
+ *
+ *   `DateparserQueryAnalyzer.analyze()` (engine/query_analyzer.py) called
+ *   `dateparser.search_dates(query, settings=...)` with NO `languages=`
+ *   argument, so dateparser auto-detected across 200+ locales on EVERY recall
+ *   that reached it. That auto-detection runs INLINE on the single shared
+ *   asyncio loop (recall + consolidation + reranker all live in one process).
+ *   Under consolidation recall fan-out it blocked the loop for 1-2.6s at a
+ *   time: the loop watchdog logged 128 `EVENT LOOP BLOCKED >=1s` events in 20
+ *   minutes, with dateparser's per-locale language-split frames
+ *   (`dateparser/languages/locale.py:_split`,
+ *   `dictionary.py:_split_by_known_words` / `_should_capture`) appearing 1383x
+ *   in the blocked stacks. Measured in the image venv on a representative
+ *   query: auto-detect 99.8 ms/call vs `languages=["en"]` 0.6 ms/call (~165x).
+ *
+ * The patch pins `languages=` to a configurable list, `HINDSIGHT_API_TEMPORAL_
+ * LANGUAGES` (a real config.py knob, comma-separated, default "en"), on BOTH
+ * the `load()` warm-up call and the `analyze()` call. This file asserts the
+ * OUTCOMES that make that fix real, none of which is visible from the patch
+ * text alone:
+ *
+ *  - the default resolves to `["en"]` through the real `HindsightConfig.
+ *    from_env()`, and the CSV knob parses (`"en, es ,,fr"` -> `["en","es",
+ *    "fr"]`, whitespace/empties dropped) with an `["en"]` floor when it
+ *    resolves empty — so the loop-starving no-languages call is unreachable by
+ *    construction;
+ *  - the real `search_dates` a recall issues RECEIVES `languages=["en"]` —
+ *    the assertion that reds the instant the pin is reverted — driven through
+ *    a query that reaches dateparser (the relative-period fast-path in
+ *    `extract_period` short-circuits "last week"/"yesterday" BEFORE dateparser,
+ *    so the probe uses an explicit-date query that provably reaches it);
+ *  - English temporal extraction still works end to end through the real
+ *    `extract_temporal_constraint` ("last week", "yesterday", "3 days ago" all
+ *    resolve to a constraint), so pinning the language did not break the
+ *    behaviour it exists to keep fast.
+ *
+ * The patch block is extracted from the Dockerfile itself rather than
+ * duplicated here, so this test cannot drift from what actually ships. It
+ * applies it by `docker exec` (not `docker build`) so it runs on daemons
+ * without buildx, and it never touches the production `switchroom-hindsight`
+ * container.
+ *
+ * SKIP DISCIPLINE: identical to `hindsight-search-patches.test.ts`. Locally,
+ * with no docker or no cached image, this skips (never pull a 6.4GB
+ * third-party image onto a dev box). In CI the `hindsight-probe` job pulls the
+ * pinned digest and sets `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1`, under which an
+ * unavailable docker/image is a HARD FAILURE, never a green skip. Both runs
+ * assert a `PROBE_EXECUTED` sentinel so a probe that dies early can never be
+ * mistaken for a pass.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { execFileSync, execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const dockerfile = readFileSync(
+  resolve(root, "docker/Dockerfile.hindsight"),
+  "utf8"
+);
+
+const RUN_ID = randomUUID();
+const TEST_PHASE = "hindsight-temporal-language-patch";
+
+/** The pinned upstream image, read from the Dockerfile so it can never drift. */
+const UPSTREAM_IMAGE = (() => {
+  const m = dockerfile.match(/^FROM\s+(\S+)/m);
+  if (!m) throw new Error("Dockerfile.hindsight has no FROM line");
+  return m[1];
+})();
+
+/**
+ * The patch block under test, pulled out of the Dockerfile's
+ * `RUN python3 - <<'PYEOF' … PYEOF` heredocs by its unique patch name.
+ */
+function patchBlock(): string {
+  const blocks = [
+    ...dockerfile.matchAll(/^RUN python3 - <<'PYEOF'\n([\s\S]*?)^PYEOF$/gm),
+  ].map((m) => m[1]);
+  const b = blocks.find((x) => x.includes("temporal-language patch"));
+  if (!b) {
+    throw new Error(
+      `Dockerfile.hindsight no longer contains the "temporal-language patch" ` +
+        `RUN block — if it was deliberately removed, delete this test with it.`
+    );
+  }
+  return b;
+}
+
+/**
+ * Python probe. Exits 0 only when the language pin is in effect AND every
+ * property above holds; prints the offending assertions otherwise. Asserts
+ * OUTCOMES rather than grepping source.
+ */
+const PROBE = String.raw`
+import os
+import sys
+from datetime import datetime
+
+sys.path.insert(0, "/app/api")
+
+failures = []
+
+from hindsight_api.config import HindsightConfig
+
+
+def resolved_langs(**env):
+    # getattr sentinel, not attribute access: on UNPATCHED upstream the field
+    # does not exist, and the probe MUST still run to completion (print
+    # PROBE_EXECUTED) so an early crash can never read as a green skip.
+    for k, v in env.items():
+        os.environ[k] = v
+    try:
+        return getattr(HindsightConfig.from_env(), "temporal_languages", "__ABSENT__")
+    finally:
+        for k in env:
+            os.environ.pop(k, None)
+
+
+# ---- default resolves to ["en"] through the REAL loader ----
+default_langs = resolved_langs()
+print("DEFAULT_LANGS", default_langs)
+if default_langs != ["en"]:
+    failures.append("default temporal_languages != ['en']: %r" % (default_langs,))
+
+# ---- the CSV knob parses, dropping whitespace/empties ----
+csv_langs = resolved_langs(HINDSIGHT_API_TEMPORAL_LANGUAGES="en, es ,,fr")
+print("CSV_LANGS", csv_langs)
+if csv_langs != ["en", "es", "fr"]:
+    failures.append("CSV parse wrong: %r" % (csv_langs,))
+
+# ---- an all-empty CSV floors back to ["en"] (no-languages call unreachable) ----
+empty_langs = resolved_langs(HINDSIGHT_API_TEMPORAL_LANGUAGES="   ,  ")
+print("EMPTY_LANGS", empty_langs)
+if empty_langs != ["en"]:
+    failures.append("empty CSV did not floor to ['en']: %r" % (empty_langs,))
+
+# ---- the analyzer resolves its pin from config ----
+from hindsight_api.engine import query_analyzer as QA
+
+an = QA.DateparserQueryAnalyzer()
+analyzer_langs = getattr(an, "_languages", "__ABSENT__")
+print("ANALYZER_LANGS", analyzer_langs)
+if analyzer_langs != ["en"]:
+    failures.append("analyzer._languages != ['en']: %r" % (analyzer_langs,))
+
+# ---- the REAL search_dates a recall issues receives languages=["en"] ----
+# "last week"/"yesterday" are resolved by extract_period BEFORE dateparser, so
+# use an explicit-date query that provably reaches search_dates.
+an.load()
+_orig = an._search_dates
+captured = {}
+
+
+def _spy(q, **kw):
+    captured["languages"] = kw.get("languages", "__ABSENT__")
+    return _orig(q, **kw)
+
+
+an._search_dates = _spy
+an.analyze("what happened on june 10 2025")
+cap = captured.get("languages", "__NOT_CALLED__")
+print("CAPTURED_LANGUAGES", cap)
+if cap != ["en"]:
+    failures.append("search_dates did NOT receive languages=['en']: %r" % (cap,))
+
+# ---- English temporal extraction still works end to end ----
+from hindsight_api.engine.search.temporal_extraction import extract_temporal_constraint
+
+ref = datetime(2026, 8, 3, 12, 0, 0)
+for phrase in ["last week", "yesterday", "3 days ago"]:
+    tc = extract_temporal_constraint(phrase, reference_date=ref)
+    print("EXTRACT", repr(phrase), tc)
+    if tc is None:
+        failures.append("English temporal extraction failed for %r" % (phrase,))
+
+print("FAILURES", failures)
+# Sentinel: proves the probe ran to completion. The harness asserts this, so a
+# probe that dies early or short-circuits can never be mistaken for a pass.
+print("PROBE_EXECUTED")
+sys.exit(1 if failures else 0)
+`;
+
+function hasDocker(): boolean {
+  try {
+    execSync("docker version --format '{{.Server.Version}}'", {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasImage(ref: string): boolean {
+  try {
+    execSync(`docker image inspect ${ref}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * CI marker. When set, this suite MUST really execute — an absent docker or
+ * an absent upstream image becomes a hard failure instead of a green skip.
+ * `.github/workflows/docker-e2e.yml` sets it after pulling the pinned digest.
+ */
+const REQUIRED = process.env.SWITCHROOM_REQUIRE_HINDSIGHT_PROBE === "1";
+
+const dockerOk = hasDocker();
+const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
+
+type ProbeResult = { status: number; stdout: string };
+
+/** Run the probe in a throwaway container, optionally patching first. */
+function runProbe(patched: boolean): ProbeResult {
+  const name = `sr-hs-temporal-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
+    0,
+    8
+  )}`;
+  try {
+    execFileSync(
+      "docker",
+      [
+        "run",
+        "-d",
+        "--name",
+        name,
+        "--label",
+        `switchroom.test=${TEST_PHASE}`,
+        "--label",
+        `switchroom.test.run=${RUN_ID}`,
+        "--user",
+        "root",
+        "--network",
+        "none",
+        UPSTREAM_IMAGE,
+        "sleep",
+        "300",
+      ],
+      { stdio: ["ignore", "ignore", "pipe"] }
+    );
+
+    if (patched) {
+      // The block is self-verifying: it asserts its upstream anchors exist
+      // exactly once and re-asserts the result, so a non-zero exit here means
+      // upstream drifted and the patch must be re-authored.
+      execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
+        input: patchBlock(),
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    }
+
+    const res = execFileSync(
+      "docker",
+      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
+      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" }
+    );
+    return { status: 0, stdout: res };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: Buffer | string };
+    return {
+      status: err.status ?? -1,
+      stdout: (err.stdout ?? "").toString(),
+    };
+  } finally {
+    try {
+      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+describe("Dockerfile.hindsight temporal-language probe is real, not a silent skip", () => {
+  it("pins the upstream image by digest so the probe tests the exact shipping bytes", () => {
+    expect(UPSTREAM_IMAGE).toMatch(/@sha256:[0-9a-f]{64}$/);
+  });
+
+  it("hard-fails rather than skipping when CI demands a real run", () => {
+    if (!REQUIRED) {
+      // Local/dev path: skipping is legitimate (never pull a 6.4GB image onto
+      // a dev box), but it must be visible rather than silent.
+      expect(
+        REQUIRED,
+        "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE is unset — the behavioural probe " +
+          "is advisory here. CI's hindsight-probe job sets it after pulling " +
+          `${UPSTREAM_IMAGE}.`
+      ).toBe(false);
+      return;
+    }
+    expect(
+      dockerOk,
+      "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but the docker daemon is unreachable"
+    ).toBe(true);
+    expect(
+      imageOk,
+      `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but ${UPSTREAM_IMAGE} is not present ` +
+        "locally — the workflow must pull the pinned digest before running this suite"
+    ).toBe(true);
+  });
+});
+
+describe.skipIf(!dockerOk || !imageOk)(
+  "Dockerfile.hindsight temporal-language patch changes real behaviour",
+  () => {
+    afterAll(() => {
+      // Label-scoped teardown belt (never an unlabelled bulk removal).
+      try {
+        const ids = execSync(
+          `docker ps -aq --filter label=switchroom.test.run=${RUN_ID}`,
+          { encoding: "utf8" }
+        )
+          .split("\n")
+          .filter(Boolean);
+        if (ids.length) {
+          execFileSync("docker", ["rm", "-f", ...ids], { stdio: "ignore" });
+        }
+      } catch {
+        /* nothing to clean */
+      }
+    });
+
+    it("unpatched upstream is RED — search_dates gets no languages= and the config knob is absent (proves the probe bites)", () => {
+      const { status, stdout } = runProbe(false);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED"
+      );
+      expect(status, `probe unexpectedly passed:\n${stdout}`).not.toBe(0);
+
+      // The concrete defect: the real recall search_dates call carries no
+      // languages= at all, so dateparser auto-detects across 200+ locales.
+      expect(stdout).toContain("CAPTURED_LANGUAGES __ABSENT__");
+      expect(stdout).toContain(
+        "search_dates did NOT receive languages=['en']: '__ABSENT__'"
+      );
+      // …and there is no config knob to have pinned it with.
+      expect(stdout).toContain("default temporal_languages != ['en']");
+    }, 240_000);
+
+    it("upstream + the baked patch block is GREEN, including the CSV knob and that English extraction still works", () => {
+      const { status, stdout } = runProbe(true);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED"
+      );
+      expect(status, `probe failed:\n${stdout}`).toBe(0);
+      expect(stdout).toContain("FAILURES []");
+
+      // The knob: default English, CSV parses, empty floors back to English.
+      expect(stdout).toContain("DEFAULT_LANGS ['en']");
+      expect(stdout).toContain("CSV_LANGS ['en', 'es', 'fr']");
+      expect(stdout).toContain("EMPTY_LANGS ['en']");
+      // The load-bearing outcome: the real recall search_dates is pinned.
+      expect(stdout).toContain("ANALYZER_LANGS ['en']");
+      expect(stdout).toContain("CAPTURED_LANGUAGES ['en']");
+      // English temporal extraction survived the pin, all three phrases.
+      expect(stdout).toMatch(/EXTRACT 'last week' \(datetime/);
+      expect(stdout).toMatch(/EXTRACT 'yesterday' \(datetime/);
+      expect(stdout).toMatch(/EXTRACT '3 days ago' \(datetime/);
+    }, 240_000);
+  }
+);


### PR DESCRIPTION
## Problem

`DateparserQueryAnalyzer.analyze()` (`engine/query_analyzer.py`) called
`dateparser.search_dates(query, settings=...)` with **no `languages=`**, so it
auto-detected across 200+ locales **inline on the single shared asyncio loop**
(recall, consolidation, and the reranker all share one process) on every recall
that reached `search_dates`. Under consolidation recall fan-out this blocked the
loop for 1–2.6s.

**Evidence (live loop watchdog, 20-minute window):**
- **128** `EVENT LOOP BLOCKED ≥1s` events.
- dateparser's per-locale language-split frames
  (`dateparser/languages/locale.py:_split`,
  `dictionary.py:_split_by_known_words` / `_should_capture`) appeared **1383×**
  in the blocked stacks.

## Fix

Pin `languages=` to a fixed list. That removes the auto-detection pass entirely —
the 1383 language-split frames stop executing *by construction*, and each call
drops to sub-millisecond so it cannot accumulate into a ≥1s block.

**Measured in the image venv:**

| call | ms/call |
|---|---|
| `search_dates(auto-detect)` | **99.8** |
| `search_dates(languages=["en"])` | **0.6** |

~165× faster. (Confirms the prior ~160× finding.)

The list is a real `config.py` knob, **`HINDSIGHT_API_TEMPORAL_LANGUAGES`**
(comma-separated, default `"en"`), following config.py's existing
`ENV_`/`DEFAULT_`/dataclass/`from_env` pattern. It is threaded into
**both** `search_dates` call sites (the `load()` warm-up and the `analyze()`
call) via `DateparserQueryAnalyzer._languages`. English-only by default; future
i18n is a pure config change, no image edit.

## How it lands

hindsight_api source lives in the external upstream image, so — as with every
hindsight fix in this repo — the change ships as an anchored, self-verifying
Python patch in `docker/Dockerfile.hindsight` (each anchor asserted to appear
exactly once, `ast.parse()` post-check, revert-red guard). Registered as an
**override-only** key in `src/setup/hindsight-perf-defaults.ts` so a
`hindsight.env` line reaches the container and `switchroom doctor` stays green,
and documented in the `hindsight.env` contract in `src/config/schema.ts`.

## Tests (assert outcomes)

- **`tests/docker/hindsight-temporal-language-patch.test.ts`** (new) — extracts
  the patch block, applies it to a throwaway container from the pinned upstream
  image, and proves:
  - **RED** on unpatched upstream: `search_dates` receives no `languages=` and
    the config knob is absent (this is a permanent mutation check).
  - **GREEN** patched: default `["en"]`; CSV `"en, es ,,fr"` → `["en","es","fr"]`;
    empty/blank floors to `["en"]`; the real recall `search_dates` receives
    `languages=["en"]`; English `"last week"` / `"yesterday"` / `"3 days ago"`
    still extract.
- **`tests/docker/dockerfile-hindsight-bakes.test.ts`** — shape pin (grep-on-file).
- **`src/setup/hindsight-perf-defaults.test.ts`** — spelled-out managed-key set
  and override-only reach-both-launch-paths.

## Tradeoff (operator-relevant)

Non-English temporal queries no longer auto-parse by default. This is
acceptable for an English fleet and fully **config-restorable** via
`HINDSIGHT_API_TEMPORAL_LANGUAGES=en,es,…`.

## Deferred (single-concern PR)

The language pin alone was measured sufficient (sub-ms calls cannot form a ≥1s
block; the 1383 blocking frames are structurally gone), so these defense-in-depth
options are filed as follow-ups, not included here:
- **(A)** offload `extract_temporal_constraint` via `run_in_executor`
  (`retrieval.py:~812`).
- **(C)** skip temporal extraction on internal consolidation recalls
  (`consolidator.py:~2146`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
