### PR TITLE
fix: handoff legacy-DB render (#4316) + temporal parse non-empty assert (#4318)

### DIFF
--- a/bin/handoff-briefing.sh
+++ b/bin/handoff-briefing.sh
@@ -104,6 +104,18 @@ try:
     conn.row_factory = sqlite3.Row
     cur = conn.cursor()
 
+    # Probe ONCE whether this history DB carries the native-reply columns
+    # (reply_to_message_id / reply_to_text, added with issue #119). A DB
+    # predating them would raise OperationalError on the extended SELECT and,
+    # via the outer `except → sys.exit(0)`, silently drop the ENTIRE
+    # Telegram-history section. Detect the columns explicitly here and degrade
+    # to the legacy column list (skipping the antecedent render) rather than
+    # swallowing a real query failure. The outer try/except still catches
+    # genuine errors — this only distinguishes "columns absent" from those.
+    cur.execute("PRAGMA table_info(messages)")
+    _msg_cols = {r[1] for r in cur.fetchall()}
+    has_reply_cols = "reply_to_message_id" in _msg_cols and "reply_to_text" in _msg_cols
+
     # Resolve the surface to scope to.
     #  - explicit env target (pending-turn chat/thread) wins — UNLESS that chat
     #    has zero rows (rotated/fresh DB), in which case we fall through to
@@ -191,8 +203,11 @@ try:
         % (scope_chat, "NULL" if scope_thread_is_null else (scope_thread if scope_thread_known else "any"), scope_source)
     )
 
+    select_cols = "role, user, ts, text"
+    if has_reply_cols:
+        select_cols += ", reply_to_message_id, reply_to_text"
     cur.execute(
-        "SELECT role, user, ts, text, reply_to_message_id, reply_to_text FROM messages WHERE "
+        "SELECT " + select_cols + " FROM messages WHERE "
         + " AND ".join(where)
         + " ORDER BY ts DESC LIMIT ?",
         params,
@@ -218,6 +233,11 @@ try:
         # knows what "this"/"that" in the reply refers to instead of guessing.
         # Without it the flat dump loses the thread of any native reply.
         print(f"[{ts_str}] {label}: {text}")
+        if not has_reply_cols:
+            # Legacy DB (pre-#119): no reply columns were selected, so the
+            # antecedent render is skipped entirely. The history section still
+            # renders every message above — just without "↪ replying to" lines.
+            continue
         reply_id = row["reply_to_message_id"]
         reply_text = row["reply_to_text"]
         if reply_text is not None and reply_text != "":

--- a/tests/docker/hindsight-temporal-language-patch.test.ts
+++ b/tests/docker/hindsight-temporal-language-patch.test.ts
@@ -32,11 +32,13 @@
  *    "fr"]`, whitespace/empties dropped) with an `["en"]` floor when it
  *    resolves empty — so the loop-starving no-languages call is unreachable by
  *    construction;
- *  - the real `search_dates` a recall issues RECEIVES `languages=["en"]` —
- *    the assertion that reds the instant the pin is reverted — driven through
- *    a query that reaches dateparser (the relative-period fast-path in
- *    `extract_period` short-circuits "last week"/"yesterday" BEFORE dateparser,
- *    so the probe uses an explicit-date query that provably reaches it);
+ *  - the real `search_dates` a recall issues RECEIVES `languages=["en"]` AND
+ *    still RETURNS a non-empty temporal parse under that pin (#4318) — the
+ *    assertions that red the instant the pin is reverted or the pin narrows the
+ *    locale set so far it stops parsing — driven through a query that reaches
+ *    dateparser (the relative-period fast-path in `extract_period`
+ *    short-circuits "last week"/"yesterday" BEFORE dateparser, so the probe
+ *    uses an explicit-date query that provably reaches it);
  *  - English temporal extraction still works end to end through the real
  *    `extract_temporal_constraint` ("last week", "yesterday", "3 days ago" all
  *    resolve to a constraint), so pinning the language did not break the
@@ -165,7 +167,9 @@ captured = {}
 
 def _spy(q, **kw):
     captured["languages"] = kw.get("languages", "__ABSENT__")
-    return _orig(q, **kw)
+    result = _orig(q, **kw)
+    captured["result"] = result
+    return result
 
 
 an._search_dates = _spy
@@ -174,6 +178,19 @@ cap = captured.get("languages", "__NOT_CALLED__")
 print("CAPTURED_LANGUAGES", cap)
 if cap != ["en"]:
     failures.append("search_dates did NOT receive languages=['en']: %r" % (cap,))
+
+# ---- and the pinned ['en'] parse still RETURNS a temporal result ----
+# The pin only earns its keep if the explicit-date query still parses under
+# ['en']: a "fast" pin that returned nothing would be a silent regression.
+# Assert the REAL search_dates return value (captured from _orig, not a stub)
+# is non-empty — dateparser yields a list of (matched_text, datetime) tuples
+# for a date it recognises, and None/[] when it parses nothing.
+parsed = captured.get("result", "__NOT_CALLED__")
+print("CAPTURED_RESULT_NONEMPTY", bool(parsed) and parsed != "__NOT_CALLED__")
+if not (bool(parsed) and parsed != "__NOT_CALLED__"):
+    failures.append(
+        "explicit-date query parsed to EMPTY temporal result under ['en']: %r" % (parsed,)
+    )
 
 # ---- English temporal extraction still works end to end ----
 from hindsight_api.engine.search.temporal_extraction import extract_temporal_constraint
@@ -365,6 +382,9 @@ describe.skipIf(!dockerOk || !imageOk)(
       // The load-bearing outcome: the real recall search_dates is pinned.
       expect(stdout).toContain("ANALYZER_LANGS ['en']");
       expect(stdout).toContain("CAPTURED_LANGUAGES ['en']");
+      // …and the pin did not neuter the parse: the explicit-date query still
+      // yields a non-empty temporal result under ['en'] (#4318).
+      expect(stdout).toContain("CAPTURED_RESULT_NONEMPTY True");
       // English temporal extraction survived the pin, all three phrases.
       expect(stdout).toMatch(/EXTRACT 'last week' \(datetime/);
       expect(stdout).toMatch(/EXTRACT 'yesterday' \(datetime/);

--- a/tests/handoff-briefing.test.ts
+++ b/tests/handoff-briefing.test.ts
@@ -850,6 +850,121 @@ describe("handoff-briefing.sh recent-conversation reply-antecedent rendering", (
   });
 });
 
+// ── Legacy (pre-reply-column) history DB compatibility (#4316) ───────────────────
+//
+// The reply-antecedent SELECT lists reply_to_message_id / reply_to_text. On a
+// history.db that predates those columns (a DB written before the #119 schema
+// bump), that extended SELECT raises sqlite3.OperationalError, which the Python
+// block's outer `except → sys.exit(0)` swallows — silently dropping the ENTIRE
+// Telegram-history section. The fix probes PRAGMA table_info(messages) once and
+// falls back to the legacy column list (skipping the antecedent render) when the
+// reply columns are absent, so the history still renders. This test seeds a DB
+// WITHOUT the reply columns and asserts the section STILL appears; reverting the
+// fix (restoring the unconditional extended SELECT) turns it red.
+
+/**
+ * Create a history.db whose `messages` table LACKS the reply_to_message_id /
+ * reply_to_text columns — the pre-#119 gateway schema. Mirrors seedHistoryDb but
+ * with the legacy column set only.
+ */
+function seedLegacyHistoryDb(stateDir: string, rows: SeedRow[]): string {
+  mkdirSync(stateDir, { recursive: true });
+  const dbPath = join(stateDir, "history.db");
+  const py = `
+import sys, json, sqlite3
+db = sys.argv[1]
+rows = json.loads(sys.argv[2])
+c = sqlite3.connect(db)
+c.execute(
+    "CREATE TABLE IF NOT EXISTS messages ("
+    "chat_id TEXT NOT NULL, thread_id INTEGER, message_id INTEGER NOT NULL, "
+    "role TEXT NOT NULL, user TEXT, user_id TEXT, ts INTEGER NOT NULL, "
+    "text TEXT NOT NULL, attachment_kind TEXT, group_id INTEGER, "
+    "PRIMARY KEY (chat_id, thread_id, message_id))"
+)
+for r in rows:
+    c.execute(
+        "INSERT INTO messages(chat_id,thread_id,message_id,role,user,user_id,ts,text) "
+        "VALUES(?,?,?,?,?,?,?,?)",
+        (r["chat_id"], r.get("thread_id"), r["message_id"], r["role"],
+         r.get("user"), None, r["ts"], r["text"]),
+    )
+c.commit()
+c.close()
+`;
+  const res = spawnSync("python3", ["-c", py, dbPath, JSON.stringify(rows)], {
+    timeout: 10_000,
+  });
+  if (res.status !== 0) {
+    throw new Error(`seedLegacyHistoryDb failed: ${res.stderr?.toString() ?? ""}`);
+  }
+  // Guard the fixture itself: the columns really must be absent, else the test
+  // would pass vacuously against a modern DB.
+  const check = spawnSync(
+    "python3",
+    [
+      "-c",
+      "import sys,sqlite3;c=sqlite3.connect(sys.argv[1]);cols={r[1] for r in c.execute('PRAGMA table_info(messages)')};sys.exit(0 if 'reply_to_text' not in cols and 'reply_to_message_id' not in cols else 1)",
+      dbPath,
+    ],
+    { timeout: 10_000 },
+  );
+  if (check.status !== 0) {
+    throw new Error("seedLegacyHistoryDb fixture unexpectedly has reply columns");
+  }
+  return dbPath;
+}
+
+describe("handoff-briefing.sh recent-conversation legacy-DB compatibility (#4316)", () => {
+  let tmpDir: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "handoff-legacy-"));
+    stateDir = join(tmpDir, "telegram");
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function runBriefing(
+    scopeEnv: Record<string, string> = {},
+  ): { status: number | null; output: string } {
+    const result = spawnSync("bash", [HANDOFF_BRIEFING_SCRIPT, "--stdout"], {
+      env: {
+        ...process.env,
+        AGENT_DIR: tmpDir,
+        TELEGRAM_STATE_DIR: stateDir,
+        HINDSIGHT_API_URL: "",
+        HINDSIGHT_BANK_ID: "",
+        WORKSPACE_DIR: tmpDir,
+        ...scopeEnv,
+      },
+      timeout: 10_000,
+    });
+    return { status: result.status, output: result.stdout.toString() };
+  }
+
+  it("renders the Telegram-history section on a pre-reply-column DB (no soft-fail, no antecedent lines)", () => {
+    seedLegacyHistoryDb(stateDir, [
+      { chat_id: "c1", thread_id: null, message_id: 1, role: "user", user: "ken", ts: 1000, text: "LEGACY-MSG-user" },
+      { chat_id: "c1", thread_id: null, message_id: 2, role: "assistant", ts: 1001, text: "LEGACY-MSG-bot" },
+    ]);
+    const { status, output } = runBriefing({
+      SWITCHROOM_PENDING_CHAT_ID: "c1",
+      SWITCHROOM_PENDING_THREAD_ID: "NULL",
+    });
+    expect(status).toBe(0);
+    // The whole section must survive — the pre-fix bug dropped it entirely.
+    expect(output).toContain("Recent conversation");
+    expect(output).toContain("LEGACY-MSG-user");
+    expect(output).toContain("LEGACY-MSG-bot");
+    // No reply columns exist, so no antecedent render is attempted.
+    expect(output).not.toContain("↪ replying to");
+  });
+});
+
 // ── Migration warning ───────────────────────────────────────────────────────────
 
 describe("reconcileAgent: migration warning for auto → handoff default change", () => {


### PR DESCRIPTION
Bundled fast-follow for two LOW follow-ups from #4312 / #4313.

Closes #4316
Closes #4318

## #4316 — handoff-briefing: reply-antecedent SELECT soft-fails on pre-reply-column DBs
**Was wrong:** `bin/handoff-briefing.sh`'s Python block SELECTs `reply_to_message_id, reply_to_text`. On a history `messages` table predating those columns (pre-#119 schema) the extended SELECT raises `sqlite3.OperationalError`, which the outer `except → sys.exit(0)` swallows — silently dropping the **entire** Telegram-history section from the briefing.

**Fix:** probe `PRAGMA table_info(messages)` **once** up front; select the extended column list only when both reply columns exist, else the legacy `role,user,ts,text` list; guard the antecedent render block (`↪ replying to`) on the same flag with an early `continue`. The outer try/except still catches genuine failures — this only distinguishes "columns absent" (degrade to legacy render) from a real error.

**Test proves:** `tests/handoff-briefing.test.ts` seeds a history DB **without** the reply columns (fixture self-guards that the columns are truly absent) and asserts the `Recent conversation` section STILL renders both messages, with no `↪ replying to` lines. **Mutation:** reverting to the unconditional extended SELECT reds it exactly on `expect(output).toContain("Recent conversation")` (the pre-fix bug dropped the section).

## #4318 — hindsight temporal-language probe: assert explicit-date query parses non-empty
**Was wrong:** the GREEN probe's `search_dates` spy captured the `languages=` kwarg and asserted `== ['en']`, but discarded `_orig`'s return value — so nothing proved the explicit-date query (`"what happened on june 10 2025"`) still parses to a non-empty temporal result under the `['en']` pin. A pin that narrowed the locale set so far it stopped parsing would have been "fast" and green.

**Fix:** capture the spy's REAL return value (from `_orig`, not a stub) and assert it is non-empty, both in the probe's `failures` (drives the exit code) and as a harness-level `expect(stdout).toContain("CAPTURED_RESULT_NONEMPTY True")` in the GREEN test.

**Test proves:** exercises the real dateparser parse end to end. **Mutation:** forcing the captured result empty reds the GREEN test (`status !== 0`, `FAILURES` non-empty).

## Validation
- `tests/handoff-briefing.test.ts` — 37 pass (incl. new legacy-DB test); mutation confirmed red.
- `tests/docker/hindsight-temporal-language-patch.test.ts` — ran live against the pinned image (docker present locally): 4 pass incl. new assertion; mutation confirmed red. CI's `hindsight-probe` gate is the authority.
- `tsc --noEmit` clean; `bash -n` + embedded-Python compile clean; `check-test-runner-coverage` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)