### PR TITLE
feat(gateway): reopen activity feed after a substantive early reply

### DIFF
--- a/telegram-plugin/gateway/feed-open-gate.ts
+++ b/telegram-plugin/gateway/feed-open-gate.ts
@@ -184,6 +184,21 @@ export interface FeedOpenInput {
    * this see no behaviour change.
    */
   postAnswerSubagentActivity?: boolean
+  /**
+   * Post-substantive feed reopen (long multi-phase MAIN-agent turns). True when
+   * the turn delivered a substantive final answer EARLY and then kept doing real
+   * tool work — `>= SUBSTANTIVE_REOPEN_MIN_LABELS` post-answer tool labels have
+   * arrived (`feed-reopen-gate.ts` → `decideFeedReopen().liftLeverOne`). The
+   * sibling of `postAnswerSubagentActivity`, but for the foreground agent's own
+   * post-answer tool labels rather than a sub-agent watcher.
+   *
+   * When true AND `producer === 'tool'`, Lever 1's blanket post-answer block is
+   * lifted so a fresh activity card may open below the delivered reply to show
+   * the still-working agent. Idle producers (`liveness`, `narrative`) stay
+   * blocked. Defaults to `false` (Lever 1 fully active) — callers that don't
+   * pass it see no behaviour change.
+   */
+  postAnswerMainActivity?: boolean
 }
 
 /**
@@ -194,13 +209,15 @@ export interface FeedOpenInput {
  *  - crossTurnAnswerDelivered → false: lever 4. A cross-turn synthetic surface
  *    whose exchange already delivered a substantive answer in an EARLIER turn;
  *    no card may open below it (any producer). Checked FIRST.
- *  - finalAnswerEverDelivered && !postAnswerSubagentActivity → false: lever 1.
- *    A substantive final already landed THIS turn; no card may open below it.
- *    Exception: when `postAnswerSubagentActivity === true` AND `producer ===
- *    'tool'`, Lever 1 is lifted so the background-agent liveness heartbeat can
- *    surface a card below the reply showing the watcher's real new activity.
- *    Idle producers ('liveness', 'narrative') stay blocked — no card opens from
- *    wall-clock alone after the final answer.
+ *  - finalAnswerEverDelivered && !(postAnswerSubagentActivity ||
+ *    postAnswerMainActivity) → false: lever 1. A substantive final already
+ *    landed THIS turn; no card may open below it. Exception: when EITHER
+ *    post-answer activity signal is true AND `producer === 'tool'`, Lever 1 is
+ *    lifted so a card can surface below the reply — the background-agent
+ *    liveness heartbeat (`postAnswerSubagentActivity`) OR the foreground
+ *    agent's own still-working post-answer tool labels (`postAnswerMainActivity`,
+ *    the post-substantive feed reopen). Idle producers ('liveness', 'narrative')
+ *    stay blocked — no card opens from wall-clock alone after the final answer.
  *  - producer 'narrative': always allowed when pre-answer (lever 5 is INERT —
  *    Lever 2 / clearActivitySummary guarantees reply-is-last ordering instead).
  *  - producer 'tool' or 'liveness' → true (unless lever 1/4).
@@ -216,7 +233,10 @@ export function mayOpenActivityCard(input: FeedOpenInput): boolean {
   // (Fix 2 / #2587 supersede). Only 'tool' is exempted so idle liveness and
   // narrative producers remain blocked after the final answer.
   if (input.finalAnswerEverDelivered) {
-    if (input.postAnswerSubagentActivity && input.producer === 'tool') return true
+    if (
+      (input.postAnswerSubagentActivity || input.postAnswerMainActivity)
+      && input.producer === 'tool'
+    ) return true
     return false
   }
   // Lever 5 — INERT (see module comment above). Pre-answer narrative may now

--- a/telegram-plugin/gateway/feed-reopen-gate.ts
+++ b/telegram-plugin/gateway/feed-reopen-gate.ts
@@ -66,6 +66,37 @@
  *     (correct — the user got only an ack, no answer).
  *  3. the feed gate itself — this module.
  *
+ * ## Post-SUBSTANTIVE reopen (long multi-phase turns)
+ *
+ * The ACK-only refinement above deliberately keeps the feed dark after a
+ * GENUINE final answer — routine post-answer housekeeping (a memory write /
+ * TodoWrite) should not resurrect the card. But that same gate blanks the
+ * feed for a legitimately DIFFERENT shape: a turn that delivers a substantive
+ * reply EARLY ("Here's the plan — starting now") and then keeps doing real
+ * tool work for 10+ minutes. The user sees the reply, then goes completely
+ * dark for the rest of the turn even though the agent is visibly working.
+ *
+ * The post-substantive reopen closes that gap WITHOUT reintroducing the
+ * duplicate-answer hazard the ACK-only refinement fixed:
+ *  - It fires only after `SUBSTANTIVE_REOPEN_MIN_LABELS` (>= 2) post-answer
+ *    tool labels have arrived, so a genuinely-final single-reply turn (0-1
+ *    housekeeping tools) never flaps the card.
+ *  - Crucially it does NOT clear `finalAnswerDelivered` (the ack path does):
+ *    clearing it would trip the turn-end silent-end re-prompt (`turn-end-
+ *    gate.ts`: `finalAnswerDelivered === false → reprompt`) → the exact
+ *    duplicate-answer failure the ACK-only guard exists to prevent. The
+ *    substantive answer STAYS delivered; only the visual feed reopens.
+ *  - Because the sticky lever-1 latch stays true (it is never cleared by a
+ *    reopen), the caller must LIFT lever 1 for this drain so the fresh card opens
+ *    BELOW the delivered reply — exactly the exemption the post-answer
+ *    sub-agent liveness path already uses (`feed-open-gate.ts`,
+ *    `postAnswerSubagentActivity`). The outcome flags this via `liftLeverOne`.
+ *
+ * Gated by its own flag `SWITCHROOM_FEED_REOPEN_AFTER_SUBSTANTIVE` (default
+ * ON), passed by the caller as `reopenAfterSubstantiveEnabled`. When that flag
+ * is off (or omitted), the substantive branch returns `false` exactly as
+ * before — byte-identical legacy behaviour.
+ *
  * ## Kill switch
  *
  * `SWITCHROOM_FEED_REOPEN_AFTER_ACK=0` reverts to the legacy behaviour: a
@@ -73,6 +104,12 @@
  * post-ack feed stays dark. The kill switch is read by the CALLER, which
  * passes `enabled` here.
  */
+
+/** Number of post-substantive-answer tool labels that must arrive before the
+ *  activity feed re-opens for a still-working turn. Two (not one) so a
+ *  genuinely-final single-reply turn with a stray bit of post-answer
+ *  housekeeping (0-1 tools) never flaps the card. */
+export const SUBSTANTIVE_REOPEN_MIN_LABELS = 2
 
 export interface FeedReopenInput {
   /** Whether the turn has already been classified as having delivered its
@@ -90,6 +127,19 @@ export interface FeedReopenInput {
   /** Kill-switch state. When false the reopen behaviour is OFF and a tool
    *  label after `finalAnswerDelivered` is dropped (legacy). */
   enabled: boolean
+  /** Post-SUBSTANTIVE reopen flag (`SWITCHROOM_FEED_REOPEN_AFTER_SUBSTANTIVE`,
+   *  default ON). When true, a turn that delivered a substantive final answer
+   *  and then kept doing tool work may RE-OPEN the feed once
+   *  `postSubstantiveToolLabelCount >= SUBSTANTIVE_REOPEN_MIN_LABELS`. Omitted
+   *  / false → the substantive branch returns false exactly as before (legacy).
+   *  Distinct from `enabled` (the ack-first kill switch) so the two behaviours
+   *  can be toggled independently. */
+  reopenAfterSubstantiveEnabled?: boolean
+  /** Count of tool labels that have arrived SINCE the substantive final answer
+   *  was delivered this turn (`turn.postSubstantiveToolLabelCount`). Only
+   *  consulted on the substantive branch; the reopen fires at
+   *  `>= SUBSTANTIVE_REOPEN_MIN_LABELS`. Omitted → treated as 0 (no reopen). */
+  postSubstantiveToolLabelCount?: number
 }
 
 /**
@@ -99,10 +149,12 @@ export interface FeedReopenInput {
  *
  * - !finalAnswerDelivered → false: the feed was never gated off; the normal
  *   append/drain path applies (no reopen needed).
- * - finalAnswerDelivered && finalAnswerSubstantive → false: the prior final
- *   was a genuine answer (not an ack). Post-answer housekeeping tool work
- *   must NOT reopen — keep the legacy gate so the silent-end re-prompt and
- *   the #2137 drain see the delivered final correctly.
+ * - finalAnswerDelivered && finalAnswerSubstantive: the prior final was a
+ *   genuine answer (not an ack). Reopen ONLY under the post-substantive path —
+ *   `reopenAfterSubstantiveEnabled` AND `>= SUBSTANTIVE_REOPEN_MIN_LABELS`
+ *   post-answer tool labels (a still-working multi-phase turn). Otherwise keep
+ *   the legacy gate so post-answer housekeeping does not flap the card and the
+ *   silent-end re-prompt / #2137 drain see the delivered final correctly.
  * - finalAnswerDelivered && !enabled (kill switch off) → false: legacy
  *   behaviour, the label is dropped by the caller.
  * - finalAnswerDelivered && !finalAnswerSubstantive && enabled → true: the
@@ -110,7 +162,14 @@ export interface FeedReopenInput {
  */
 export function shouldReopenFeedAfterAck(input: FeedReopenInput): boolean {
   if (!input.finalAnswerDelivered) return false
-  if (input.finalAnswerSubstantive) return false
+  if (input.finalAnswerSubstantive) {
+    // Post-substantive reopen: a genuine answer landed, then the model kept
+    // doing tool work. Reopen only under the dedicated flag AND once enough
+    // post-answer labels have arrived that this is plainly a still-working
+    // turn, not a single-reply turn with a stray housekeeping tool.
+    if (input.reopenAfterSubstantiveEnabled !== true) return false
+    return (input.postSubstantiveToolLabelCount ?? 0) >= SUBSTANTIVE_REOPEN_MIN_LABELS
+  }
   return input.enabled === true
 }
 
@@ -128,8 +187,20 @@ export interface FeedReopenOutcome {
   /** True → the handler returns early (legacy: label dropped, feed dark). */
   dropLabel: boolean
   /** When dropLabel is false, the new feed-state fields to write on `turn`
-   *  before the normal append/drain proceeds. */
+   *  before the normal append/drain proceeds. Present on the ACK-reopen path
+   *  (which reclassifies the interim ack). ABSENT on the post-substantive
+   *  reopen path: there `finalAnswerDelivered` MUST stay true (clearing it
+   *  trips the turn-end re-prompt → duplicate answer) and `activityMessageId`
+   *  is already null (the substantive answer's `clearActivitySummary` nulled
+   *  it), so the drain opens a fresh card then edits it — no reset needed. */
   reset?: FeedReopenState
+  /** Post-substantive reopen only. True → the caller must lift lever 1 for
+   *  this drain (`drainActivitySummary(..., { postAnswerMainActivity: true })`)
+   *  so the fresh card may OPEN below the already-delivered substantive reply.
+   *  The sticky lever-1 latch stays set, so without this lift
+   *  `mayOpenActivityCard` would refuse the OPEN. Absent/false on the ack path
+   *  (an ack never sets the sticky latch, so lever 1 is inert there). */
+  liftLeverOne?: boolean
 }
 
 /**
@@ -151,6 +222,17 @@ export function decideFeedReopen(input: FeedReopenInput): FeedReopenOutcome {
   if (!shouldReopenFeedAfterAck(input)) {
     return { dropLabel: true }
   }
+  // Post-substantive reopen: KEEP finalAnswerDelivered true (clearing it would
+  // trip the turn-end silent-end re-prompt → duplicate answer) and do NOT
+  // reset activityMessageId (the substantive answer's clearActivitySummary
+  // already nulled it; the drain OPENs once then EDITs). Only signal the
+  // caller to lift lever 1 so the fresh card may open below the reply.
+  if (input.finalAnswerSubstantive) {
+    return { dropLabel: false, liftLeverOne: true }
+  }
+  // ACK reopen (legacy): reclassify the interim ack — finalAnswerDelivered
+  // back to false, a FRESH feed message (activityMessageId null), last-sent
+  // render cleared so the drain re-sends.
   return {
     dropLabel: false,
     reset: {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2798,6 +2798,13 @@ const MIDFLIGHT_BUSY_ACK_ENABLED =
 // the finalAnswerDelivered-consumer interactions.
 const FEED_REOPEN_AFTER_ACK_ENABLED =
   process.env.SWITCHROOM_FEED_REOPEN_AFTER_ACK !== '0'
+// Feed-reopen-after-SUBSTANTIVE. Distinct from the ack kill switch above: a
+// turn that delivered a real answer EARLY and then kept doing tool work had
+// its feed go dark for the rest of the turn. Lets the feed RE-OPEN after >=2
+// post-answer labels WITHOUT clearing finalAnswerDelivered. Off (=0) → legacy.
+// See `feed-reopen-gate.ts` for the full rationale.
+const FEED_REOPEN_AFTER_SUBSTANTIVE_ENABLED =
+  process.env.SWITCHROOM_FEED_REOPEN_AFTER_SUBSTANTIVE !== '0'
 
 // Activity-feed heartbeat (PR1). The feed is pull-only — it only re-renders on
 // a tool_label event, so a long single step that emits no new label leaves the
@@ -3291,6 +3298,18 @@ export type CurrentTurn = {
   // Reset to false on every fresh-turn enqueue alongside
   // `finalAnswerDelivered`.
   finalAnswerSubstantive: boolean
+  // Post-SUBSTANTIVE feed-reopen counter — incremented on each tool label that
+  // arrives while `finalAnswerDelivered && finalAnswerSubstantive` (a real
+  // answer landed early, model still working). At `SUBSTANTIVE_REOPEN_MIN_LABELS`
+  // (>=2) the tool_label handler reopens the feed (see `feed-reopen-gate.ts`).
+  // Reset to 0 on every fresh-turn enqueue.
+  postSubstantiveToolLabelCount: number
+  // Post-SUBSTANTIVE feed-reopen lever-1 lift latch. Set true by the tool_label
+  // handler when the long-turn reopen fires (>=2 post-answer labels). The drain
+  // reads it as `mayOpenActivityCard`'s `postAnswerMainActivity` so the fresh
+  // card may OPEN below the already-delivered reply despite the sticky lever-1
+  // latch. Sticky for the rest of the turn; reset to false on fresh-turn enqueue.
+  postAnswerMainActivity: boolean
   // Sticky "a substantive final answer has been delivered this turn" latch
   // (design `docs/message-emission-determinism.md` §9 preamble / R0). Distinct
   // from the MUTABLE `finalAnswerDelivered`, which the ack-reopen path clears
@@ -13921,6 +13940,7 @@ function gatewayStreamRenderDeps() {
     CONTEXT_EXHAUSTION_COOLDOWN_MS,
     DELIVERY_CONFIRM_ENABLED,
     FEED_REOPEN_AFTER_ACK_ENABLED,
+    FEED_REOPEN_AFTER_SUBSTANTIVE_ENABLED,
     HANDBACK_PRETURN_ENABLED,
     HISTORY_ENABLED,
     LIVENESS_TERMINAL_HONESTY,

--- a/telegram-plugin/gateway/narrative-lane.ts
+++ b/telegram-plugin/gateway/narrative-lane.ts
@@ -374,6 +374,10 @@ export function createNarrativeLane(deps: NarrativeLaneDeps) {
             labeledToolCount: turn.labeledToolCount,
             crossTurnAnswerDelivered,
             postAnswerSubagentActivity: openFlags?.postAnswerSubagentActivity,
+            // Post-SUBSTANTIVE reopen: the tool_label handler latches this sticky
+            // on `turn` when the long-turn reopen fires, so the drain lifts lever 1
+            // and the fresh card opens BELOW the already-delivered substantive reply.
+            postAnswerMainActivity: turn.postAnswerMainActivity,
           })
         ) {
           break

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -604,6 +604,10 @@ function beginTurn(deps: StreamRenderDeps, ev: TurnStartEnvelope): void {
       replyCalled: false,
       finalAnswerDelivered: false,
       finalAnswerSubstantive: false,
+      // Post-substantive feed-reopen counter — reset each turn.
+      postSubstantiveToolLabelCount: 0,
+      // Post-substantive lever-1 lift latch — reset each turn.
+      postAnswerMainActivity: false,
       // Sticky latch — reset ONLY here (turn start), never by reopen.
       finalAnswerEverDelivered: false,
       // 2026-07 double-reply-on-DM fix (Part 2) — answer-delivered race
@@ -879,6 +883,7 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
     CONTEXT_EXHAUSTION_COOLDOWN_MS,
     DELIVERY_CONFIRM_ENABLED,
     FEED_REOPEN_AFTER_ACK_ENABLED,
+    FEED_REOPEN_AFTER_SUBSTANTIVE_ENABLED,
     HANDBACK_PRETURN_ENABLED,
     HISTORY_ENABLED,
     LIVENESS_TERMINAL_HONESTY,
@@ -1377,25 +1382,45 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
       // liveness is the bounded no-reply timer's job) and lets the silent-end
       // re-prompt fire if the turn ends on only an ack.
       // Kill switch SWITCHROOM_FEED_REOPEN_AFTER_ACK=0 → legacy `return`.
+      //
+      // POST-SUBSTANTIVE reopen: a turn that delivered a real answer and then
+      // kept doing tool work reopens the feed once >= SUBSTANTIVE_REOPEN_MIN_
+      // LABELS post-answer labels arrive — WITHOUT clearing finalAnswerDelivered
+      // (that would trip the turn-end re-prompt → duplicate answer). Instead the
+      // decision returns liftLeverOne, and the drain below opens the fresh card
+      // below the reply via `postAnswerMainActivity` (the foreground sibling of
+      // the sub-agent post-answer liveness exemption). Kill switch
+      // SWITCHROOM_FEED_REOPEN_AFTER_SUBSTANTIVE=0 → post-substantive labels stay
+      // dropped (legacy).
       if (turn.finalAnswerDelivered) {
-        // decideFeedReopen returns dropLabel (legacy return) or the reset
-        // deltas: finalAnswerDelivered→false (the turn has NOT delivered its
-        // final answer while still doing tool work), activityMessageId→null
-        // (a FRESH feed message opens below the ack), activityLastSentRender
-        // →null (so the drain loop's `pending !== lastSent` guard never
-        // mistakes the fresh render for the ack's finalized one and skips it).
+        // Count post-substantive-answer labels so the reopen fires only once the
+        // turn is plainly still working (>=2), not on a stray housekeeping tool.
+        if (turn.finalAnswerSubstantive) turn.postSubstantiveToolLabelCount++
+        // decideFeedReopen returns dropLabel (legacy return), or — on the ACK
+        // path — the reset deltas (finalAnswerDelivered→false, a FRESH feed
+        // message, last-sent cleared), or — on the SUBSTANTIVE path — no reset
+        // but liftLeverOne=true (keep finalAnswerDelivered true, open the card
+        // below the reply).
         const reopen = decideFeedReopen({
           finalAnswerDelivered: turn.finalAnswerDelivered,
-          // ACK-ONLY: reopen only when the prior final was a short ack, not a
-          // substantive answer — otherwise post-answer housekeeping would
-          // reset finalAnswerDelivered and trip the silent-end re-prompt.
           finalAnswerSubstantive: turn.finalAnswerSubstantive,
           enabled: FEED_REOPEN_AFTER_ACK_ENABLED,
+          reopenAfterSubstantiveEnabled: FEED_REOPEN_AFTER_SUBSTANTIVE_ENABLED,
+          postSubstantiveToolLabelCount: turn.postSubstantiveToolLabelCount,
         })
         if (reopen.dropLabel) return
-        turn.finalAnswerDelivered = reopen.reset!.finalAnswerDelivered
-        turn.activityMessageId = reopen.reset!.activityMessageId
-        turn.activityLastSentRender = reopen.reset!.activityLastSentRender
+        // ACK reopen carries a reset; the substantive reopen deliberately does
+        // not (finalAnswerDelivered stays true, activityMessageId is already
+        // null from the answer's clearActivitySummary).
+        if (reopen.reset != null) {
+          turn.finalAnswerDelivered = reopen.reset.finalAnswerDelivered
+          turn.activityMessageId = reopen.reset.activityMessageId
+          turn.activityLastSentRender = reopen.reset.activityLastSentRender
+        }
+        // Post-substantive reopen: latch the lever-1 lift so the drain (which
+        // reads this off `turn`) opens the fresh card below the delivered reply.
+        // Sticky for the rest of the turn — the model stays "still working".
+        if (reopen.liftLeverOne) turn.postAnswerMainActivity = true
       }
       const rendered = appendActivityLabel(turn.mirrorLines, ev.label)
       if (rendered != null) {

--- a/telegram-plugin/tests/feed-open-gate.test.ts
+++ b/telegram-plugin/tests/feed-open-gate.test.ts
@@ -179,6 +179,48 @@ describe('mayOpenActivityCard — lever 1 exception: post-answer sub-agent liven
   })
 })
 
+describe('mayOpenActivityCard — lever 1 exception: post-substantive MAIN-agent reopen', () => {
+  // The foreground sibling of the sub-agent exemption above: a turn that
+  // delivered a substantive answer early and kept doing tool work sets
+  // `postAnswerMainActivity=true` (via decideFeedReopen().liftLeverOne) so a
+  // fresh activity card can open below the reply. Same 'tool'-only scoping.
+
+  it('post-answer MAIN-agent tool activity DOES open a card (tool + postAnswerMainActivity)', () => {
+    expect(
+      mayOpenActivityCard({
+        producer: 'tool',
+        finalAnswerEverDelivered: true,
+        labeledToolCount: 4,
+        postAnswerMainActivity: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('without the signal Lever 1 stays active (no postAnswerMainActivity → blocked)', () => {
+    expect(
+      mayOpenActivityCard({
+        producer: 'tool',
+        finalAnswerEverDelivered: true,
+        labeledToolCount: 4,
+        postAnswerMainActivity: false,
+      }),
+    ).toBe(false)
+  })
+
+  it('only the tool producer is exempted (liveness/narrative stay blocked with the signal)', () => {
+    for (const producer of ['liveness', 'narrative'] as const) {
+      expect(
+        mayOpenActivityCard({
+          producer,
+          finalAnswerEverDelivered: true,
+          labeledToolCount: 4,
+          postAnswerMainActivity: true,
+        }),
+      ).toBe(false)
+    }
+  })
+})
+
 describe('shouldEarlyOpenLiveness — the early-open WHEN gate (enqueue + heartbeat)', () => {
   // The minimal "Working…" placeholder is due to open for a 0-label turn once it
   // has been alive past the threshold and NO card is open yet. Both the

--- a/telegram-plugin/tests/feed-reopen-gate.test.ts
+++ b/telegram-plugin/tests/feed-reopen-gate.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  SUBSTANTIVE_REOPEN_MIN_LABELS,
   decideFeedReopen,
   shouldReopenFeedAfterAck,
 } from '../gateway/feed-reopen-gate.js'
@@ -129,5 +130,118 @@ describe('decideFeedReopen — tool_label branch outcome for a delivered turn', 
     })
     expect(outcome.dropLabel).toBe(true)
     expect(outcome.reset).toBeUndefined()
+  })
+})
+
+/**
+ * Post-SUBSTANTIVE feed reopen — a turn that delivered a real answer EARLY and
+ * then kept doing tool work for minutes had its live feed go dark for the rest
+ * of the turn. It reopens once >= SUBSTANTIVE_REOPEN_MIN_LABELS post-answer
+ * labels arrive, WITHOUT clearing finalAnswerDelivered (which would trip the
+ * turn-end re-prompt → duplicate answer). Gated by
+ * `reopenAfterSubstantiveEnabled` (SWITCHROOM_FEED_REOPEN_AFTER_SUBSTANTIVE).
+ */
+describe('post-substantive feed reopen', () => {
+  const substantiveBase = {
+    finalAnswerDelivered: true,
+    finalAnswerSubstantive: true,
+    enabled: true,
+    reopenAfterSubstantiveEnabled: true,
+  }
+
+  it('reopens once >= SUBSTANTIVE_REOPEN_MIN_LABELS post-answer labels have arrived', () => {
+    // The bug: with the flag ON but the counter at threshold, the old gate
+    // hard-returned false. Now it reopens.
+    expect(
+      shouldReopenFeedAfterAck({
+        ...substantiveBase,
+        postSubstantiveToolLabelCount: SUBSTANTIVE_REOPEN_MIN_LABELS,
+      }),
+    ).toBe(true)
+    // And it keeps returning true for further labels (a long multi-phase turn).
+    expect(
+      shouldReopenFeedAfterAck({
+        ...substantiveBase,
+        postSubstantiveToolLabelCount: SUBSTANTIVE_REOPEN_MIN_LABELS + 5,
+      }),
+    ).toBe(true)
+  })
+
+  it('does NOT reopen before the threshold (0 or 1 post-answer labels → no flap)', () => {
+    // A genuinely-final single-reply turn with a stray housekeeping tool must
+    // not flap the card.
+    for (const n of [0, 1]) {
+      expect(
+        shouldReopenFeedAfterAck({
+          ...substantiveBase,
+          postSubstantiveToolLabelCount: n,
+        }),
+      ).toBe(false)
+    }
+    // The threshold is exactly 2 (not 1) by design.
+    expect(SUBSTANTIVE_REOPEN_MIN_LABELS).toBe(2)
+  })
+
+  it('flag OFF → never reopens after a substantive final, even past the threshold (legacy)', () => {
+    expect(
+      shouldReopenFeedAfterAck({
+        finalAnswerDelivered: true,
+        finalAnswerSubstantive: true,
+        enabled: true,
+        reopenAfterSubstantiveEnabled: false,
+        postSubstantiveToolLabelCount: SUBSTANTIVE_REOPEN_MIN_LABELS + 10,
+      }),
+    ).toBe(false)
+    // Omitting the flag entirely is also legacy (default-off at the pure gate).
+    expect(
+      shouldReopenFeedAfterAck({
+        finalAnswerDelivered: true,
+        finalAnswerSubstantive: true,
+        enabled: true,
+        postSubstantiveToolLabelCount: SUBSTANTIVE_REOPEN_MIN_LABELS + 10,
+      }),
+    ).toBe(false)
+  })
+
+  it('decideFeedReopen: at threshold → reopen with liftLeverOne and NO reset (finalAnswerDelivered stays true)', () => {
+    const outcome = decideFeedReopen({
+      ...substantiveBase,
+      postSubstantiveToolLabelCount: SUBSTANTIVE_REOPEN_MIN_LABELS,
+    })
+    expect(outcome.dropLabel).toBe(false)
+    // Crucially NO reset: finalAnswerDelivered must stay true so the turn-end
+    // silent-end re-prompt does not fire → no duplicate answer.
+    expect(outcome.reset).toBeUndefined()
+    // Lever 1 must be lifted so the fresh card opens below the delivered reply.
+    expect(outcome.liftLeverOne).toBe(true)
+  })
+
+  it('decideFeedReopen: below threshold → drops the label (feed stays gated, no flap)', () => {
+    const outcome = decideFeedReopen({
+      ...substantiveBase,
+      postSubstantiveToolLabelCount: 1,
+    })
+    expect(outcome.dropLabel).toBe(true)
+    expect(outcome.reset).toBeUndefined()
+    expect(outcome.liftLeverOne).toBeUndefined()
+  })
+
+  it('ack reopen is unchanged: reset clears finalAnswerDelivered and does NOT lift lever 1', () => {
+    // The ack path (non-substantive) is orthogonal — the new flag/counter must
+    // not perturb it.
+    const outcome = decideFeedReopen({
+      finalAnswerDelivered: true,
+      finalAnswerSubstantive: false,
+      enabled: true,
+      reopenAfterSubstantiveEnabled: true,
+      postSubstantiveToolLabelCount: 99,
+    })
+    expect(outcome.dropLabel).toBe(false)
+    expect(outcome.reset).toEqual({
+      finalAnswerDelivered: false,
+      activityMessageId: null,
+      activityLastSentRender: null,
+    })
+    expect(outcome.liftLeverOne).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Problem

The Telegram auto **activity card** (rendered by `renderActivityFeedWithNested`) retires on the agent's first **substantive** reply and cannot reopen while that same turn keeps making tool calls. A turn that answers early ("here's the plan — starting now") and then works for 10+ minutes goes **dark** for the rest of the turn even though the agent is visibly working.

Root cause (two gates):
- `shouldReopenFeedAfterAck` (`feed-reopen-gate.ts`) hard-returned `false` whenever `finalAnswerSubstantive` was true. The pre-existing `SWITCHROOM_FEED_REOPEN_AFTER_ACK` flag only covers **non-substantive** acks.
- Even if the reopen decision flipped, **Lever 1** (`finalAnswerEverDelivered`, the sticky latch in `mayOpenActivityCard`) blocks any fresh card OPEN below a delivered reply.

The retired `progressDriver` is intentionally null and is **not** resurrected.

## Fix

New env flag **`SWITCHROOM_FEED_REOPEN_AFTER_SUBSTANTIVE`** (default **ON**, parsed like the ack flag). When ON, the feed reopens after `>= SUBSTANTIVE_REOPEN_MIN_LABELS` (**2**) post-answer tool labels arrive — so a genuinely-final single-reply turn with 0-1 housekeeping tools never flaps the card.

Crucially the substantive reopen **does not clear `finalAnswerDelivered`** (unlike the ack path): clearing it would trip the turn-end silent-end re-prompt (`turn-end-gate.ts`) → duplicate answer. Instead `decideFeedReopen` returns `liftLeverOne`; the `tool_label` handler latches `turn.postAnswerMainActivity`, and the drain passes it to `mayOpenActivityCard` as the foreground sibling of the existing `postAnswerSubagentActivity` Lever-1 exemption.

**When the flag is OFF (or omitted), behaviour is byte-identical to today** — the substantive branch returns `false` as before.

## Files (source + tests only; no `dist/` edits)

- `telegram-plugin/gateway/feed-reopen-gate.ts` — `SUBSTANTIVE_REOPEN_MIN_LABELS`, new input fields, `liftLeverOne` outcome, threshold logic
- `telegram-plugin/gateway/feed-open-gate.ts` — Lever 1 exemption extended to `postAnswerMainActivity`
- `telegram-plugin/gateway/gateway.ts` — `FEED_REOPEN_AFTER_SUBSTANTIVE_ENABLED` env, `postSubstantiveToolLabelCount` + `postAnswerMainActivity` turn fields, dep threading
- `telegram-plugin/gateway/stream-render.ts` — tool_label reopen block wiring + turn init
- `telegram-plugin/gateway/narrative-lane.ts` — drain reads `turn.postAnswerMainActivity` for `mayOpenActivityCard`
- `telegram-plugin/tests/feed-reopen-gate.test.ts`, `telegram-plugin/tests/feed-open-gate.test.ts` — new coverage

## Tests (fail on the current bug)

- substantive + `>= 2` labels → feed reopens (was: never)
- substantive + 0/1 labels → **no** reopen (no flap)
- flag OFF → no reopen preserved (legacy)
- `decideFeedReopen`: keeps `finalAnswerDelivered` true, signals `liftLeverOne`, no reset
- ack path unchanged
- `mayOpenActivityCard` lifts Lever 1 for a post-answer MAIN-agent `tool` producer

Mutation-checked: reverting the substantive branch to `return false` fails the two threshold tests.

## Verification

- `tsc --noEmit`: clean
- Scoped vitest (feed-reopen-gate, feed-open-gate, emission-determinism-wiring, emission-authority-facade + 13 activity/emission/turn-end suites): **334 passed**
- bun: emission-authority open/ping/card-drain gate suites: **26 passed**
- `npm run lint`: clean (gateway ratchet 24849 vs 24805 baseline, within 50 slack; bot-api-wrapping, attribution trailers all green)
- `npm run build`: succeeds

Single-concern change. No deploy, no merge, no container restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)