### PR TITLE
fix(vault): forward agent capability token from in-process env resolvers

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -55,7 +55,7 @@ import {
   HINDSIGHT_CONTAINER_NAME,
   REPAIR_FAILED_EXIT,
 } from "../memory/hindsight-repair.js";
-import { getViaBrokerStructured } from "../vault/broker/client.js";
+import { getViaBrokerStructured, readVaultTokenFile } from "../vault/broker/client.js";
 import { spawn } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { writeConfigFileSync } from "../util/atomic.js";
@@ -165,7 +165,18 @@ async function resolveLiteLLMForHindsight(
 ): Promise<LiteLLMHindsightConfig | undefined> {
   const topLiteLLM = (config as { litellm?: { enabled?: boolean; base_url?: string } }).litellm;
   if (!topLiteLLM?.enabled || !topLiteLLM.base_url) return undefined;
-  const result = await getViaBrokerStructured("litellm/hindsight/api-key").catch(() => null);
+  // Issue #1053: forward the agent's capability token so the broker's grant
+  // path bypasses the peercred ACL. Without it a freshly-minted grant is
+  // ignored and the `.catch(() => null)` silently swallows the DENIED,
+  // leaving LiteLLM routing (ANTHROPIC_BASE_URL/headers) underived. Mirrors
+  // the working `vault get` path in src/cli/vault.ts. Token stays undefined
+  // when SWITCHROOM_AGENT_NAME is unset — identical to prior host-operator
+  // peercred behavior.
+  const agentSlug = process.env.SWITCHROOM_AGENT_NAME;
+  const token = agentSlug ? readVaultTokenFile(agentSlug) ?? undefined : undefined;
+  const result = await getViaBrokerStructured("litellm/hindsight/api-key", {
+    ...(token ? { token } : {}),
+  }).catch(() => null);
   if (!result || result.kind !== "ok" || result.entry.kind !== "string") return undefined;
   return {
     baseUrl: topLiteLLM.base_url,

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -48,7 +48,7 @@ import {
   type LiteLLMHindsightConfig,
   type DockerProbe,
 } from "../setup/hindsight.js";
-import { getViaBrokerStructured } from "../vault/broker/client.js";
+import { getViaBrokerStructured, readVaultTokenFile } from "../vault/broker/client.js";
 import {
   ask,
   askHidden,
@@ -1029,7 +1029,18 @@ async function resolveLiteLLMForHindsight(
 ): Promise<LiteLLMHindsightConfig | undefined> {
   const topLiteLLM = (config as { litellm?: { enabled?: boolean; base_url?: string } }).litellm;
   if (!topLiteLLM?.enabled || !topLiteLLM.base_url) return undefined;
-  const result = await getViaBrokerStructured("litellm/hindsight/api-key").catch(() => null);
+  // Issue #1053: forward the agent's capability token so the broker's grant
+  // path bypasses the peercred ACL. Without it a freshly-minted grant is
+  // ignored and the `.catch(() => null)` silently swallows the DENIED,
+  // leaving LiteLLM routing (ANTHROPIC_BASE_URL/headers) underived. Mirrors
+  // the working `vault get` path in src/cli/vault.ts. Token stays undefined
+  // when SWITCHROOM_AGENT_NAME is unset — identical to prior host-operator
+  // peercred behavior.
+  const agentSlug = process.env.SWITCHROOM_AGENT_NAME;
+  const token = agentSlug ? readVaultTokenFile(agentSlug) ?? undefined : undefined;
+  const result = await getViaBrokerStructured("litellm/hindsight/api-key", {
+    ...(token ? { token } : {}),
+  }).catch(() => null);
   if (!result || result.kind !== "ok" || result.entry.kind !== "string") return undefined;
   return {
     baseUrl: topLiteLLM.base_url,

--- a/src/setup/hindsight-cp-access-key.test.ts
+++ b/src/setup/hindsight-cp-access-key.test.ts
@@ -22,6 +22,9 @@
  */
 
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import { join } from "node:path";
 
 const { execFileSyncMock } = vi.hoisted(() => ({ execFileSyncMock: vi.fn() }));
 vi.mock("node:child_process", async (importOriginal) => {
@@ -388,6 +391,25 @@ describe("resolveHindsightCpAccessKey", () => {
   const brokerOk = (value: string) =>
     vi.fn().mockResolvedValue({ kind: "ok", entry: { kind: "string", value } });
 
+  // These tests reason about the exact opts object handed to the broker, which
+  // depends on SWITCHROOM_AGENT_NAME / SWITCHROOM_AGENTS_DIR. The harness may
+  // itself run inside an agent container where those are set, so pin them for
+  // determinism and restore afterwards.
+  let savedName: string | undefined;
+  let savedDir: string | undefined;
+  beforeEach(() => {
+    savedName = process.env.SWITCHROOM_AGENT_NAME;
+    savedDir = process.env.SWITCHROOM_AGENTS_DIR;
+    delete process.env.SWITCHROOM_AGENT_NAME;
+    delete process.env.SWITCHROOM_AGENTS_DIR;
+  });
+  afterEach(() => {
+    if (savedName === undefined) delete process.env.SWITCHROOM_AGENT_NAME;
+    else process.env.SWITCHROOM_AGENT_NAME = savedName;
+    if (savedDir === undefined) delete process.env.SWITCHROOM_AGENTS_DIR;
+    else process.env.SWITCHROOM_AGENTS_DIR = savedDir;
+  });
+
   it("returns undefined when nothing is configured", async () => {
     await expect(resolveHindsightCpAccessKey({})).resolves.toBeUndefined();
     await expect(
@@ -414,7 +436,11 @@ describe("resolveHindsightCpAccessKey", () => {
         { getViaBrokerStructured: get as never },
       ),
     ).resolves.toBe(ACCESS_KEY);
-    expect(get).toHaveBeenCalledWith("hindsight_cp_access_key");
+    // No SWITCHROOM_AGENT_NAME in this test's env ⇒ token stays undefined ⇒
+    // the opts object is empty. The empty-opts call is wire-identical to the
+    // pre-fix bare-key call (getViaBrokerStructured omits `token` from the
+    // payload when absent), so the host-operator peercred path is unaffected.
+    expect(get).toHaveBeenCalledWith("hindsight_cp_access_key", {});
   });
 
   it("fails CLOSED on a denied/missing/erroring vault reference", async () => {
@@ -432,6 +458,38 @@ describe("resolveHindsightCpAccessKey", () => {
           { getViaBrokerStructured: get as never },
         ),
       ).resolves.toBeUndefined();
+    }
+  });
+
+  it("forwards the agent capability token to the broker when a token file exists", async () => {
+    // The bug: in-process resolvers called the broker WITHOUT the agent's
+    // capability token, so the broker denied on the peercred ACL and the
+    // `.catch(() => null)` swallowed it — HINDSIGHT_CP_ACCESS_KEY never
+    // resolved under `memory setup --recreate`. The fix mirrors the working
+    // `vault get` path: read the token file and thread `{ token }` into the
+    // broker opts. This asserts the forwarding actually happens; it FAILS
+    // against the unpatched resolver, which passes only the bare key.
+    const dir = fs.mkdtempSync(join(os.tmpdir(), "sr-vault-token-"));
+    const slug = "test-agent";
+    const token = "vault-cap-" + "token-not-real";
+    fs.mkdirSync(join(dir, slug), { recursive: true });
+    const tokenPath = join(dir, slug, ".vault-token");
+    fs.writeFileSync(tokenPath, token + "\n");
+    fs.chmodSync(tokenPath, 0o600); // readVaultTokenFile refuses non-0600 files
+    process.env.SWITCHROOM_AGENTS_DIR = dir;
+    process.env.SWITCHROOM_AGENT_NAME = slug;
+
+    try {
+      const get = brokerOk(ACCESS_KEY);
+      await expect(
+        resolveHindsightCpAccessKey(
+          { hindsight: { cp_access_key: "vault:hindsight_cp_access_key" } },
+          { getViaBrokerStructured: get as never },
+        ),
+      ).resolves.toBe(ACCESS_KEY);
+      expect(get).toHaveBeenCalledWith("hindsight_cp_access_key", { token });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -1497,10 +1497,19 @@ export async function resolveHindsightCpAccessKey(
   if (!ref) return undefined;
   const { isVaultReference, parseVaultReference } = await import("../vault/resolver.js");
   if (!isVaultReference(ref)) return ref;
-  const get =
-    deps.getViaBrokerStructured ??
-    (await import("../vault/broker/client.js")).getViaBrokerStructured;
-  const resolved = await get(parseVaultReference(ref)).catch(() => null);
+  const brokerClient = await import("../vault/broker/client.js");
+  const get = deps.getViaBrokerStructured ?? brokerClient.getViaBrokerStructured;
+  // Issue #1053: forward the agent's capability token so the broker's grant
+  // path bypasses the peercred ACL. Without it a freshly-minted grant is
+  // ignored and the `.catch(() => null)` silently swallows the DENIED,
+  // leaving HINDSIGHT_CP_ACCESS_KEY underived. Mirrors the working `vault get`
+  // path in src/cli/vault.ts. Token stays undefined when SWITCHROOM_AGENT_NAME
+  // is unset — identical to prior host-operator peercred behavior.
+  const agentSlug = process.env.SWITCHROOM_AGENT_NAME;
+  const token = agentSlug ? brokerClient.readVaultTokenFile(agentSlug) ?? undefined : undefined;
+  const resolved = await get(parseVaultReference(ref), {
+    ...(token ? { token } : {}),
+  }).catch(() => null);
   if (!resolved || resolved.kind !== "ok" || resolved.entry.kind !== "string") {
     return undefined;
   }


### PR DESCRIPTION
## The bug

Three in-process env resolvers call the vault broker **without** the agent's capability token, so the broker denies on the peercred ACL and the `.catch(() => null)` silently swallows the DENIED. Result: `switchroom memory setup --recreate` cannot derive `ANTHROPIC_BASE_URL`, `ANTHROPIC_CUSTOM_HEADERS` (LiteLLM routing), or `HINDSIGHT_CP_ACCESS_KEY`, and `--strict-env` refuses.

The CLI's own `switchroom vault get` works precisely because it **does** forward the token (`src/cli/vault.ts:861-866`, issue #1053). These resolvers never adopted that pattern.

## The fix

Mirror the canonical `vault get` path: read the token with `readVaultTokenFile(SWITCHROOM_AGENT_NAME)` and thread `{ token }` into the broker opts. When `SWITCHROOM_AGENT_NAME` is unset the token stays `undefined` and the call is **wire-identical** to before (`getViaBrokerStructured` omits `token` from the payload when absent), so the host-operator peercred path is unaffected.

### Call sites changed
- `src/cli/memory.ts` — `resolveLiteLLMForHindsight` (was `getViaBrokerStructured("litellm/hindsight/api-key").catch(() => null)`)
- `src/cli/setup.ts` — `resolveLiteLLMForHindsight` (the second copy of the same resolver)
- `src/setup/hindsight.ts` — `resolveHindsightCpAccessKey` (preserves the `deps.getViaBrokerStructured ?? client.getViaBrokerStructured` seam; token threaded into the same opts arg)

Single concern: only the token-forwarding fix, no drive-by refactors.

## Test

Extends `src/setup/hindsight-cp-access-key.test.ts` (the resolver's existing test, which already exposes a `deps.getViaBrokerStructured` seam) with a test asserting the broker is called with `{ token }` when `SWITCHROOM_AGENT_NAME` + a `0600` token file are present. The existing "bare key" assertion is updated to the new empty-opts shape (wire-identical to pre-fix).

**Mutation-checked:** reverting only the source fix makes the new test fail — the unpatched resolver calls the broker with the bare key and no token. Restored, all 56 tests in the file pass.

## Verification (real exit codes)
- `tsc --noEmit` — exit 0
- `npm run lint` (all ratchets) — exit 0
- `vitest run src/setup/hindsight-cp-access-key.test.ts` — 56 passed
- related suites (`src/setup/`, `memory-*`, `client-token`, `vault-get-broker`) — 491 passed

---

## Related gaps found while root-causing (NOT addressed in this PR — for separate triage)

1. **Release-process gap.** v0.20.3 shipped to GHCR images only; no GitHub Release was cut, so `releases/tags/v0.20.3` 404s. The host CLI ELF (`switchroom-linux-amd64`) is Releases-only, so the host binary is stuck at v0.20.2 and the `switchroom-cli-converge.timer` 404s every 30 min. Fix is operator-side: publish the v0.20.3 GH Release with host artifacts.

2. **Rollout robustness.** `switchroom rollout` commits `release.pin` to a version whose host CLI asset may not exist, and `verify-components` only WARNs (never fails) on host-binary drift, so the drift ships silently. Suggested follow-up: a preflight that the target's host asset exists before committing the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)