### PR TITLE
fix(telegram): progress_update turn-less attention cap + doctor WARN on disabled edit-flood fuse

### DIFF
--- a/src/cli/doctor-edit-fuse.test.ts
+++ b/src/cli/doctor-edit-fuse.test.ts
@@ -1,0 +1,79 @@
+/**
+ * `switchroom doctor` edit-flood fuse section.
+ *
+ * The fuse's own kill-switch parsing is proved in
+ * `telegram-plugin/tests/feed-edit-rate-ceiling.test.ts`. What is proved here
+ * is the operator-facing wiring: a fuse left enabled (or unset) is silent, a
+ * disabled fuse produces a WARN row that names the affected agents, and the
+ * decision runs through the SAME env parser the runtime uses (so `false`/`off`
+ * — which the runtime does NOT treat as disabling — do not produce a false
+ * warning).
+ */
+import { describe, it, expect } from "vitest";
+
+import { runEditFuseChecks } from "./doctor-edit-fuse.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+function config(
+  agents: Record<string, { env?: Record<string, string> }>,
+  defaults?: { env?: Record<string, string> },
+): SwitchroomConfig {
+  return { agents, defaults } as unknown as SwitchroomConfig;
+}
+
+describe("runEditFuseChecks", () => {
+  it("is silent when no agent sets the fuse env var", () => {
+    const results = runEditFuseChecks(config({ alpha: {}, beta: {} }));
+    expect(results).toEqual([]);
+  });
+
+  it("is silent when the fuse is explicitly enabled", () => {
+    const results = runEditFuseChecks(
+      config({ alpha: { env: { SWITCHROOM_EDIT_FUSE: "1" } } }),
+    );
+    expect(results).toEqual([]);
+  });
+
+  it("WARNs when an agent disables the fuse with 0", () => {
+    const results = runEditFuseChecks(
+      config({ alpha: { env: { SWITCHROOM_EDIT_FUSE: "0" } }, beta: {} }),
+    );
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe("warn");
+    expect(results[0].name).toBe("edit-flood fuse enabled");
+    expect(results[0].detail).toContain("alpha");
+    expect(results[0].detail).not.toContain("beta");
+    expect(results[0].detail).toContain("SWITCHROOM_EDIT_FUSE");
+  });
+
+  it("names every disabled agent, including via defaults.env", () => {
+    // defaults.env=0 should propagate to every agent via resolveAgentConfig.
+    const results = runEditFuseChecks(
+      config({ alpha: {}, beta: {} }, { env: { SWITCHROOM_EDIT_FUSE: "0" } }),
+    );
+    expect(results).toHaveLength(1);
+    expect(results[0].detail).toContain("alpha");
+    expect(results[0].detail).toContain("beta");
+  });
+
+  it("agent env overrides defaults: agent re-enables the fuse → silent", () => {
+    const results = runEditFuseChecks(
+      config(
+        { alpha: { env: { SWITCHROOM_EDIT_FUSE: "1" } } },
+        { env: { SWITCHROOM_EDIT_FUSE: "0" } },
+      ),
+    );
+    expect(results).toEqual([]);
+  });
+
+  it("does not false-warn on values the runtime keeps enabled (false/off)", () => {
+    // edit-flood-fuse.ts treats ONLY '0' as disabling; 'false'/'off' leave the
+    // fuse ON. The probe must not claim reduced protection when there is none.
+    for (const value of ["false", "off", "no"]) {
+      const results = runEditFuseChecks(
+        config({ alpha: { env: { SWITCHROOM_EDIT_FUSE: value } } }),
+      );
+      expect(results).toEqual([]);
+    }
+  });
+});

--- a/src/cli/doctor-edit-fuse.ts
+++ b/src/cli/doctor-edit-fuse.ts
@@ -1,0 +1,84 @@
+/**
+ * Doctor probe: WARN when the Telegram edit-flood fuse is disabled.
+ *
+ * ## Why this exists
+ *
+ * `SWITCHROOM_EDIT_FUSE=0` turns off the edit-flood fuse
+ * (`telegram-plugin/edit-flood-fuse.ts`) — the only outbound layer whose
+ * per-class ceilings sit BELOW Telegram's ban threshold (the ceilings in
+ * `edit-flood-fuse.ts:56-66`). With it off, the remaining pacing (the 20s /
+ * per-turn `progress_update` floor and `robustApiCall`'s post-hoc 429 backoff)
+ * is a single ban-capable layer: it slows the outbound stream but nothing keeps
+ * cadence under the threshold that earns an escalating flood ban.
+ *
+ * The kill-switch is meant for short local debugging. The failure mode is an
+ * operator who flips it to debug something, forgets, and re-exposes ban-capable
+ * edit cadence with no standing signal. This probe is that signal.
+ *
+ * ## What it reads
+ *
+ * The fuse runs inside each agent's gateway process, reading `process.env`; the
+ * container's environment is projected from the cascade-resolved `env:` block in
+ * `switchroom.yaml` (`src/agents/compose.ts` → compose `environment:`). So the
+ * doctor's own `process.env` is NOT authoritative — the per-agent resolved
+ * config is. This iterates agents, resolves each one's effective env, and asks
+ * the SAME function the runtime uses (`editFloodFuseConfigFromEnv`) whether the
+ * fuse would be disabled, so doctor and runtime can never disagree.
+ */
+
+import { resolveAgentConfig } from "../config/merge.js";
+import { editFloodFuseConfigFromEnv } from "../../telegram-plugin/edit-flood-fuse.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+import type { CheckStatus } from "./doctor-status.js";
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+const ENV_KEY = "SWITCHROOM_EDIT_FUSE";
+
+/**
+ * For each configured agent, resolve its effective env and flag the ones whose
+ * `SWITCHROOM_EDIT_FUSE` value disables the fuse. Silent (no row) when every
+ * agent keeps the fuse on — this section reports problems only, matching the
+ * flood-pressure section's posture.
+ */
+export function runEditFuseChecks(config: SwitchroomConfig): CheckResult[] {
+  const disabled: string[] = [];
+  for (const [name, agentConfig] of Object.entries(config.agents ?? {})) {
+    const resolved = resolveAgentConfig(
+      config.defaults,
+      config.profiles,
+      agentConfig,
+    );
+    const value = resolved.env?.[ENV_KEY];
+    if (value === undefined) continue;
+    // Decide disabled/enabled through the runtime's own parser so this probe
+    // can never diverge from what the gateway actually does with the value.
+    if (!editFloodFuseConfigFromEnv({ [ENV_KEY]: value }).enabled) {
+      disabled.push(name);
+    }
+  }
+
+  if (disabled.length === 0) return [];
+
+  return [
+    {
+      name: "edit-flood fuse enabled",
+      status: "warn",
+      detail:
+        `${ENV_KEY} is disabled for ${disabled.length} agent(s): ${disabled.join(", ")} — ` +
+        `flood protection is reduced to a single ban-capable layer. The edit-flood ` +
+        `fuse is the only layer whose ceilings sit below Telegram's flood-ban ` +
+        `threshold (edit-flood-fuse.ts:56-66); with it off, an escalating flood ban ` +
+        `can recur.`,
+      fix:
+        `Remove ${ENV_KEY} (or set it to 1) from each agent's env block in ` +
+        `switchroom.yaml, then restart the agent. The kill-switch is for short ` +
+        `debugging only — left off it re-exposes ban-capable edit cadence.`,
+    },
+  ];
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -72,6 +72,7 @@ import { runCascadeChecks } from "./doctor-cascade.js";
 import { runOpenRouterCreditChecks, usesOpenRouter } from "./doctor-openrouter-credit.js";
 import { runCronSessionChecks } from "./doctor-cron-session.js";
 import { runFloodPressureChecks } from "./doctor-flood-pressure.js";
+import { runEditFuseChecks } from "./doctor-edit-fuse.js";
 import { runGeneratedSurfaceDriftChecks } from "./doctor-drift.js";
 import { runComponentVersionChecks } from "./doctor-component-versions.js";
 import { runAssetPayloadChecks } from "./doctor-asset-payload.js";
@@ -4110,6 +4111,13 @@ export function registerDoctorCommand(program: Command): void {
             // pressure ledger the gateway's flood breaker now keeps.
             title: "Telegram flood pressure (429)",
             results: runFloodPressureChecks(config),
+          },
+          {
+            // SWITCHROOM_EDIT_FUSE=0 disables the only outbound layer whose
+            // ceilings sit below Telegram's flood-ban threshold. Meant for
+            // short debugging; forgotten, it re-exposes ban-capable cadence.
+            title: "Telegram edit-flood fuse",
+            results: runEditFuseChecks(config),
           },
           { title: "Agents", results: checkAgents(config, configPath) },
           {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -754,6 +754,7 @@ import { shadowEmit, isMachineInTurn } from './inbound-delivery-machine-shadow.j
 // #2996 P8 PR-B — the extracted turn-end funnel (state stays here; logic moved).
 import { createTurnEndFunnel, type TurnEndReason } from './turn-end.js'
 import { createTurnStartSurfaces } from './turn-start-surfaces.js'
+import { progressFallbackAtCap, recordProgressFallbackSend } from './progress-fallback-cap.js'
 // #2996 P8 PR-C1 — the extracted delivery-confirm sweep wiring.
 import { createDeliveryConfirmWiring } from './delivery-confirm-wiring.js'
 // #2996 P8 PR-C2 — the extracted obligation wiring.
@@ -12491,21 +12492,26 @@ async function executeProgressUpdate(args: Record<string, unknown>): Promise<unk
     }
   }
 
-  // Turn cap: max 5 calls per turn
+  // Attention cap: max 5 DELIVERIES per turn when a turn atom exists, else a
+  // rolling 15-min/chat fallback when the inbound minted none (handback /
+  // progress-inbound turns) so a worker can't send at the 20s floor forever
+  // and defeat the documented per-turn cap. Both count deliveries only — the
+  // counter/window is advanced AFTER a successful send below, so a thrown send
+  // never burns a slot.
   const turnStart = activeTurnStartedAt.get(key)
-  if (turnStart != null) {
-    const currentCount = progressUpdateTurnCount.get(key) ?? 0
-    if (currentCount >= 5) {
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify({ ok: false, reason: 'turn_limit' }),
-          },
-        ],
-      }
+  const atCap =
+    turnStart != null
+      ? (progressUpdateTurnCount.get(key) ?? 0) >= 5
+      : progressFallbackAtCap(key, now)
+  if (atCap) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({ ok: false, reason: 'turn_limit' }),
+        },
+      ],
     }
-    progressUpdateTurnCount.set(key, currentCount + 1)
   }
 
   // Issue #305 Option A — the card-injection path (route a sub-agent's
@@ -12550,6 +12556,15 @@ async function executeProgressUpdate(args: Record<string, unknown>): Promise<unk
   }
 
   progressUpdateLastSent.set(key, now)
+
+  // Count the delivery AFTER the send lands (never on a throw). Turn-scoped
+  // path ticks the per-turn counter; turn-less path records into the rolling
+  // fallback window.
+  if (turnStart != null) {
+    progressUpdateTurnCount.set(key, (progressUpdateTurnCount.get(key) ?? 0) + 1)
+  } else {
+    recordProgressFallbackSend(key, now)
+  }
 
   // Issue #203: progress_update is a user-visible signal — tick the
   // silent-gap tracker so it doesn't count as silent time.

--- a/telegram-plugin/gateway/progress-fallback-cap.ts
+++ b/telegram-plugin/gateway/progress-fallback-cap.ts
@@ -1,0 +1,67 @@
+/**
+ * Fallback attention cap for `progress_update` when the inbound minted no turn
+ * atom.
+ *
+ * The documented ceiling for `progress_update` is "at most 5 per turn" — but
+ * that cap is enforced only when a turn atom exists (`activeTurnStartedAt` set
+ * by `turn-start-surfaces.ts`). Some inbounds mint no turn atom at all —
+ * handback turns and the synthesized progress-inbound turns — so on those a
+ * worker could call `progress_update` at the unconditional 20s floor forever
+ * (~3/min, ~180/hr into one chat), which defeats the documented cap and pings
+ * the operator's phone indefinitely.
+ *
+ * This module restores the attention cap on that path with a rolling window:
+ * at most {@link PROGRESS_FALLBACK_MAX} DELIVERIES per
+ * {@link PROGRESS_FALLBACK_WINDOW_MS} per chat/topic key. It is not a ban
+ * defence — the 20s floor and the edit-flood fuse still pace sends; this only
+ * bounds how many phone-pinging progress messages a turn-less path can emit.
+ *
+ * State is a per-key list of delivery timestamps, pruned in place on every
+ * access; a key whose window empties is dropped from the map so it cannot grow
+ * unbounded across chats that have gone quiet. Because each window holds at
+ * most {@link PROGRESS_FALLBACK_MAX} entries, the per-key array is O(1).
+ */
+
+const recentSends = new Map<string, number[]>();
+
+/** Rolling window length. */
+export const PROGRESS_FALLBACK_WINDOW_MS = 15 * 60_000;
+/** Max deliveries per window per key — mirrors the 5-per-turn cap. */
+export const PROGRESS_FALLBACK_MAX = 5;
+
+/**
+ * Prune timestamps older than the window for `key`, persisting the result.
+ * Drops the key entirely when its window is empty so the map stays bounded.
+ */
+function prune(key: string, now: number): number[] {
+  const cutoff = now - PROGRESS_FALLBACK_WINDOW_MS;
+  const recent = (recentSends.get(key) ?? []).filter((ts) => ts > cutoff);
+  if (recent.length === 0) recentSends.delete(key);
+  else recentSends.set(key, recent);
+  return recent;
+}
+
+/**
+ * True when the rolling window for `key` is already at capacity — the caller
+ * should refuse the send with `turn_limit`. Read-only w.r.t. the delivery
+ * count (it only prunes aged-out entries); record a delivery separately via
+ * {@link recordProgressFallbackSend} AFTER the send lands.
+ */
+export function progressFallbackAtCap(key: string, now: number): boolean {
+  return prune(key, now).length >= PROGRESS_FALLBACK_MAX;
+}
+
+/**
+ * Record one successful fallback-path delivery. Call ONLY after the send has
+ * actually landed, so a thrown send never consumes a window slot.
+ */
+export function recordProgressFallbackSend(key: string, now: number): void {
+  const recent = prune(key, now);
+  recent.push(now);
+  recentSends.set(key, recent);
+}
+
+/** Test-only: clear all fallback-window state. */
+export function _resetProgressFallbackCap(): void {
+  recentSends.clear();
+}

--- a/telegram-plugin/tests/progress-fallback-cap.test.ts
+++ b/telegram-plugin/tests/progress-fallback-cap.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for the `progress_update` turn-less fallback attention cap
+ * (`gateway/progress-fallback-cap.ts`).
+ *
+ * The bug this guards: when an inbound mints no turn atom (handback / progress
+ * inbound turns), the per-turn 5-call cap never applied, so a worker could
+ * `progress_update` at the 20s floor indefinitely. This is the real module the
+ * gateway calls — it exercises the rolling-window cap, the delivery-only
+ * counting, and the prune-to-empty memory behaviour directly.
+ */
+import { describe, it, expect, beforeEach } from 'bun:test'
+import {
+  progressFallbackAtCap,
+  recordProgressFallbackSend,
+  _resetProgressFallbackCap,
+  PROGRESS_FALLBACK_MAX,
+  PROGRESS_FALLBACK_WINDOW_MS,
+} from '../gateway/progress-fallback-cap.js'
+
+const KEY = 'chat123:_'
+
+describe('progress fallback cap', () => {
+  beforeEach(() => {
+    _resetProgressFallbackCap()
+  })
+
+  it('allows exactly PROGRESS_FALLBACK_MAX deliveries then caps', () => {
+    let now = 1_000
+    for (let i = 0; i < PROGRESS_FALLBACK_MAX; i++) {
+      expect(progressFallbackAtCap(KEY, now)).toBe(false)
+      recordProgressFallbackSend(KEY, now)
+      now += 25_000 // past the 20s floor, still well inside the window
+    }
+    // The (MAX+1)th within the window is refused.
+    expect(progressFallbackAtCap(KEY, now)).toBe(true)
+  })
+
+  it('rolls: a delivery ages out after the window and frees a slot', () => {
+    const start = 1_000
+    let now = start
+    for (let i = 0; i < PROGRESS_FALLBACK_MAX; i++) {
+      recordProgressFallbackSend(KEY, now)
+      now += 25_000
+    }
+    expect(progressFallbackAtCap(KEY, now)).toBe(true)
+
+    // Jump past the window relative to the FIRST send: the oldest entries age
+    // out, so we are under cap again.
+    now = start + PROGRESS_FALLBACK_WINDOW_MS + 1
+    expect(progressFallbackAtCap(KEY, now)).toBe(false)
+  })
+
+  it('a slot is consumed only by recordProgressFallbackSend, not by the check', () => {
+    const now = 1_000
+    // Checking the cap repeatedly must not itself consume slots (models a
+    // thrown send: cap checked, send throws, nothing recorded).
+    for (let i = 0; i < 100; i++) {
+      expect(progressFallbackAtCap(KEY, now)).toBe(false)
+    }
+    // Full budget still available.
+    for (let i = 0; i < PROGRESS_FALLBACK_MAX; i++) {
+      expect(progressFallbackAtCap(KEY, now)).toBe(false)
+      recordProgressFallbackSend(KEY, now + i)
+    }
+    expect(progressFallbackAtCap(KEY, now + PROGRESS_FALLBACK_MAX)).toBe(true)
+  })
+
+  it('keys are independent', () => {
+    const now = 1_000
+    for (let i = 0; i < PROGRESS_FALLBACK_MAX; i++) {
+      recordProgressFallbackSend('a:_', now + i)
+    }
+    expect(progressFallbackAtCap('a:_', now + PROGRESS_FALLBACK_MAX)).toBe(true)
+    expect(progressFallbackAtCap('b:_', now + PROGRESS_FALLBACK_MAX)).toBe(false)
+  })
+
+  it('prunes an emptied key so the map does not grow unbounded', () => {
+    // A single delivery, then a check well past the window: the key should be
+    // dropped, restoring the full budget (proves the array was pruned, not
+    // just skipped over).
+    recordProgressFallbackSend(KEY, 1_000)
+    const later = 1_000 + PROGRESS_FALLBACK_WINDOW_MS + 1
+    expect(progressFallbackAtCap(KEY, later)).toBe(false)
+    // And a fresh full budget is available from `later`.
+    for (let i = 0; i < PROGRESS_FALLBACK_MAX; i++) {
+      expect(progressFallbackAtCap(KEY, later + i)).toBe(false)
+      recordProgressFallbackSend(KEY, later + i)
+    }
+    expect(progressFallbackAtCap(KEY, later + PROGRESS_FALLBACK_MAX)).toBe(true)
+  })
+})

--- a/telegram-plugin/tests/progress-update.test.ts
+++ b/telegram-plugin/tests/progress-update.test.ts
@@ -8,6 +8,11 @@
  * (failed 9/1931) for the original symptom.
  */
 import { describe, it, expect, beforeEach, afterEach, spyOn, type Mock } from 'bun:test'
+import {
+  progressFallbackAtCap,
+  recordProgressFallbackSend,
+  _resetProgressFallbackCap,
+} from '../gateway/progress-fallback-cap.js'
 
 // Mock state shared across tests (simulates the module-level state in server.ts / gateway.ts)
 const progressUpdateLastSent = new Map<string, number>()
@@ -25,17 +30,24 @@ type ProgressUpdateResult =
 
 /**
  * Simplified progress_update implementation for testing.
- * Returns the same shape as the real tool handler.
+ * Mirrors the real tool handler's ORDERING (gateway.ts `executeProgressUpdate`):
+ * check caps → send (may throw) → count the delivery only AFTER it lands. The
+ * turn-less fallback path calls the REAL cap module, not a copy.
+ *
+ * `send` is an injectable seam so a test can make the send throw and assert no
+ * slot is consumed (Fix 2). It defaults to a successful send.
  */
 function executeProgressUpdate(args: {
   chat_id: string
   text: string
   message_thread_id?: number
+  send?: () => number
 }): ProgressUpdateResult {
   const { chat_id, message_thread_id } = args
   let { text } = args
   const threadId = message_thread_id
   const key = statusKey(chat_id, threadId)
+  const send = args.send ?? (() => Math.floor(Math.random() * 100000))
 
   // Truncate to 300 chars
   if (text.length > 300) {
@@ -53,20 +65,30 @@ function executeProgressUpdate(args: {
     }
   }
 
-  // Turn cap: max 5 calls per turn
+  // Attention cap: max 5 deliveries per turn atom, else a rolling fallback
+  // window when no turn atom exists. Checked BEFORE the send; the count is
+  // advanced only after a successful send (below).
   const turnStart = activeTurnStartedAt.get(key)
-  if (turnStart != null) {
-    const currentCount = progressUpdateTurnCount.get(key) ?? 0
-    if (currentCount >= 5) {
-      return { ok: false, reason: 'turn_limit' }
-    }
-    progressUpdateTurnCount.set(key, currentCount + 1)
+  const atCap =
+    turnStart != null
+      ? (progressUpdateTurnCount.get(key) ?? 0) >= 5
+      : progressFallbackAtCap(key, now)
+  if (atCap) {
+    return { ok: false, reason: 'turn_limit' }
   }
 
-  progressUpdateLastSent.set(key, now)
+  // Send. A throw here must NOT consume a slot — it propagates before any
+  // bookkeeping runs.
+  const message_id = send()
 
-  // Mock message_id
-  return { ok: true, message_id: Math.floor(Math.random() * 100000) }
+  progressUpdateLastSent.set(key, now)
+  if (turnStart != null) {
+    progressUpdateTurnCount.set(key, (progressUpdateTurnCount.get(key) ?? 0) + 1)
+  } else {
+    recordProgressFallbackSend(key, now)
+  }
+
+  return { ok: true, message_id }
 }
 
 // Manual time mocking — bun:test compatible (bun lacks vi.setSystemTime).
@@ -81,6 +103,7 @@ describe('progress_update tool', () => {
     progressUpdateLastSent.clear()
     progressUpdateTurnCount.clear()
     activeTurnStartedAt.clear()
+    _resetProgressFallbackCap()
     mockNow = 1000
     dateSpy = spyOn(Date, 'now').mockImplementation(() => mockNow)
   })
@@ -220,7 +243,7 @@ describe('progress_update tool', () => {
     expect(progressUpdateTurnCount.get(key2)).toBe(1)
   })
 
-  it('when no active turn, still rate-limits but does not increment counter', () => {
+  it('when no active turn, still rate-limits but does not increment the turn counter', () => {
     // No activeTurnStartedAt entry for this chat
     const r1 = executeProgressUpdate({ chat_id: '999', text: 'First' })
     expect(r1.ok).toBe(true)
@@ -229,8 +252,81 @@ describe('progress_update tool', () => {
     const r2 = executeProgressUpdate({ chat_id: '999', text: 'Second' })
     expect(r2.ok).toBe(false)
 
-    // Counter should not have been incremented (no active turn)
+    // The per-turn counter is untouched on the turn-less path (the fallback
+    // window carries the count instead).
     const key = statusKey('999')
     expect(progressUpdateTurnCount.get(key)).toBeUndefined()
+  })
+
+  // Fix 1: with NO turn atom, the fallback rolling window still caps at 5.
+  it('null-turn-atom context caps at 5 sends per window (Fix 1)', () => {
+    // No activeTurnStartedAt entry — the pre-fix code applied no cap here at
+    // all, so this loop would let a 6th (and every subsequent) send through.
+    for (let i = 1; i <= 5; i++) {
+      advance(25_000) // clear the 20s floor each time
+      const r = executeProgressUpdate({ chat_id: '888', text: `Update ${i}` })
+      expect(r.ok).toBe(true)
+    }
+    advance(25_000)
+    const r6 = executeProgressUpdate({ chat_id: '888', text: 'Update 6' })
+    expect(r6.ok).toBe(false)
+    if (!r6.ok) {
+      expect(r6.reason).toBe('turn_limit')
+    }
+  })
+
+  // Fix 2: a thrown send must NOT consume a cap slot (turn-scoped path).
+  it('a thrown send does not consume a turn-cap slot (Fix 2)', () => {
+    const key = statusKey('777')
+    activeTurnStartedAt.set(key, 1000)
+    progressUpdateTurnCount.set(key, 0)
+
+    // A send that throws: the cap was checked, but nothing was delivered.
+    expect(() =>
+      executeProgressUpdate({
+        chat_id: '777',
+        text: 'boom',
+        send: () => {
+          throw new Error('telegram 500')
+        },
+      }),
+    ).toThrow('telegram 500')
+
+    // Slot NOT consumed — pre-fix the counter incremented before the send.
+    expect(progressUpdateTurnCount.get(key)).toBe(0)
+
+    // A subsequent successful send still has its full budget and counts once.
+    advance(25_000)
+    const r = executeProgressUpdate({ chat_id: '777', text: 'real' })
+    expect(r.ok).toBe(true)
+    expect(progressUpdateTurnCount.get(key)).toBe(1)
+  })
+
+  // Fix 2 composed with Fix 1: a thrown send on the turn-less path records
+  // nothing in the fallback window either.
+  it('a thrown send does not consume a fallback-window slot (Fix 2 × Fix 1)', () => {
+    // Five throwing sends on the turn-less path.
+    for (let i = 0; i < 5; i++) {
+      advance(25_000)
+      expect(() =>
+        executeProgressUpdate({
+          chat_id: '666',
+          text: 'boom',
+          send: () => {
+            throw new Error('telegram 500')
+          },
+        }),
+      ).toThrow('telegram 500')
+    }
+    // The window is still empty — five throws consumed no slots, so five real
+    // sends are still allowed.
+    for (let i = 1; i <= 5; i++) {
+      advance(25_000)
+      const r = executeProgressUpdate({ chat_id: '666', text: `real ${i}` })
+      expect(r.ok).toBe(true)
+    }
+    advance(25_000)
+    const capped = executeProgressUpdate({ chat_id: '666', text: 'over' })
+    expect(capped.ok).toBe(false)
   })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -245,6 +245,8 @@ export default defineConfig({
       // bun:ffi SO_PEERCRED gate (null under node) — run via test:bun.
       "**/telegram-plugin/gateway/webhook-ingest-server.test.ts",
       "**/telegram-plugin/tests/progress-update.test.ts",
+      // progress-fallback-cap.test.ts imports bun:test — run via test:bun.
+      "**/telegram-plugin/tests/progress-fallback-cap.test.ts",
       "**/telegram-plugin/tests/quota-cache.test.ts",
       "**/telegram-plugin/tests/unhandled-rejection-policy.test.ts",
       // The following tests transitively import bun:sqlite (via grants-db.ts


### PR DESCRIPTION
Three minor, deterministic flood-safety fixes from the Fable review of the progress-card path at `origin/main` HEAD `dc452cdc`. Single-concern, tight diff. None is a ban risk on its own — they restore documented caps and surface a latent one.

## Summary

**Fix 1 — `progress_update` turn cap silently absent when no turn atom exists.**
`gateway/gateway.ts` `executeProgressUpdate` only applied the "5 per turn" cap `if (turnStart != null)`. Inbounds that mint no turn atom (handback / progress-inbound turns) had **no** attention cap, so a worker could call `progress_update` at the unconditional 20s floor indefinitely (~3/min, ~180/hr into one chat), defeating the documented cap and pinging the operator's phone. Adds a rolling **15-min / chat** fallback window (`PROGRESS_FALLBACK_MAX = 5`) in a new module `telegram-plugin/gateway/progress-fallback-cap.ts`. The turn-scoped path is unchanged when a turn atom is present. Not a ban defence — the 20s floor and the edit-flood fuse still pace sends; this restores only the attention cap.

**Fix 2 — turn-cap slot burned on failed send.**
The per-turn counter was incremented **before** `robustApiCall`, so a throw consumed a slot with nothing delivered. Now both the per-turn counter and the fallback window advance **only after a successful send**, so a thrown send never burns a slot. Composes with Fix 1 (both count deliveries, not attempts).

**Fix 3 — `switchroom doctor` WARN when the edit-flood fuse is disabled.**
`SWITCHROOM_EDIT_FUSE=0` disables the only outbound layer whose ceilings sit below Telegram's flood-ban threshold (`telegram-plugin/edit-flood-fuse.ts:56-66`). An operator flips it to debug, forgets, and re-exposes ban-capable cadence with no standing signal. New probe `src/cli/doctor-edit-fuse.ts` iterates each agent's cascade-resolved `env`, decides disabled/enabled through the runtime's **own** parser (`editFloodFuseConfigFromEnv`) so doctor and gateway can never disagree, and emits a **WARN** naming the affected agents.

## Why

Serves `reference/jobs/fleet-stays-healthy.md` (doctor surfaces a latent flood risk before it becomes a multi-hour ban outage — the always-available outcome) and `reference/jobs/know-what-my-agent-is-doing.md` (the `progress_update` attention cap keeps that surface from becoming phone-spam). A flood ban takes an agent offline for hours; these restore the caps and visibility that prevent it.

## Test plan (local, all green)

- `bun test telegram-plugin/tests/progress-fallback-cap.test.ts telegram-plugin/tests/progress-update.test.ts` — 16 pass. Fix 1: turn-less context caps at 5/window (would let the 6th through pre-fix). Fix 2: a thrown send does not consume a turn-cap **or** fallback-window slot. Plus rolling-window aging and prune-to-empty (memory bound).
- `vitest run src/cli/doctor-edit-fuse.test.ts` — 6 pass. WARN fires when disabled (incl. via `defaults.env`), silent when enabled/unset, agent env overrides defaults, and no false-warn on `false`/`off` (values the runtime does NOT treat as disabling).
- `tsc --noEmit` clean; `npm run lint` (all 24 guards) green, incl. `check-gateway-line-ratchet` (24851 ≤ 24805+50 slack, no ratchet change) and `check-bot-api-wrapping`.

## Risk

Low. New module is self-contained; gateway change is a re-shape of one existing block (cap check moved before the send, counting moved after). Fallback map prunes aged-out timestamps and drops emptied keys, so it stays bounded. Doctor probe is read-only and reuses the runtime parser.

## Deferred

Minor 3 from the review (per-token 25/s window is per-process) is **not** addressed here — it's a no-op under today's one-token-per-agent layout and only matters if the fleet ever shares a bot token. Filed as #4327.

Follow-up issue: #4327