### PR TITLE
feat(scaffold): pre-approve Bash and the two checklist Telegram MCP tools fleet-wide

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1189,6 +1189,13 @@ const SWITCHROOM_TELEGRAM_MCP_TOOLS = [
   "mcp__switchroom-telegram__download_attachment",
   "mcp__switchroom-telegram__get_recent_messages",
   "mcp__switchroom-telegram__progress_update",
+  // Native Telegram checklists (#272). The plugin registers both
+  // send_checklist and update_checklist (telegram-plugin/bridge/bridge.ts);
+  // they were missing here, so the first checklist call wedged on a
+  // per-call permission prompt. Same drift class as the progress_update
+  // omission the parity test below guards against.
+  "mcp__switchroom-telegram__send_checklist",
+  "mcp__switchroom-telegram__update_checklist",
 ];
 
 /**
@@ -1465,16 +1472,32 @@ const LEGACY_SWITCHROOM_MCP_TOKENS = ["mcp__switchroom", "mcp__switchroom__*"];
 const LEGACY_HOSTD_BLANKET_TOKENS = ["mcp__hostd", "mcp__hostd__*"];
 
 /**
- * Read-only built-in tools that are safe to pre-approve for every agent,
- * regardless of dangerous_mode. Discovering files, searching content, and
- * reading back data don't mutate host state, so gating them just adds
- * latency for no safety benefit.
+ * Built-in tools that are safe to pre-approve for every agent, regardless
+ * of dangerous_mode. Discovering files, searching content, and reading back
+ * data don't mutate host state, so gating them just adds latency for no
+ * safety benefit.
  *
- * Risky tools (Bash, Edit, Write, WebFetch, WebSearch, NotebookEdit, and
- * anything that reaches the network or writes to disk) are deliberately
- * NOT in this list — they go through the standard permission prompt,
- * which in switchroom becomes the Telegram inline-button approval flow
- * via the plugin's permission_request notification handler.
+ * `Bash` is included deliberately. An ordinary fleet agent runs in its own
+ * Docker container (one per agent), so the blast radius of a shell command
+ * is that agent's sandbox — the same isolation boundary that already makes
+ * Read/Grep/Glob safe. Gating Bash bought no real containment (the agent
+ * could already script the host it can't reach via other pre-approved
+ * tools); it only stormed the operator with an approval card on the first,
+ * routine shell call of nearly every task. Bash STAYS operator-controllable:
+ * an agent that should be kept shell-free sets `tools.deny: ["Bash"]`
+ * (deny wins in Claude Code), and adding it here — rather than as an
+ * unconditional spread in computeDesiredPermissionAllow — means it is only
+ * seeded for default agents and never becomes an always-on grant that only
+ * tools.deny could remove. (Root-tier agents whose Bash reaches the host run
+ * with tools.allow: [all] already, so this default-set change adds them no
+ * new exposure; their coverage is the deliberate root-debug tier, not
+ * container isolation.)
+ *
+ * Edit and Write are NOT here — they remain covered by the `acceptEdits`
+ * defaultMode gate. WebFetch/WebSearch/NotebookEdit and anything that
+ * reaches the network stay off this list too and go through the standard
+ * permission prompt, which in switchroom becomes the Telegram inline-button
+ * approval flow via the plugin's permission_request notification handler.
  *
  * Used when the agent's tools.allow is empty AND dangerous_mode is
  * off/unset — otherwise explicit user config wins.
@@ -1487,6 +1510,9 @@ const DEFAULT_READ_ONLY_PREAPPROVED_TOOLS = [
   "Task",
   "TodoWrite",
   "ExitPlanMode",
+  // Safe because ordinary agents are per-container isolated — see the
+  // block comment above for the full rationale and the tools.deny lever.
+  "Bash",
   // Skill itself just loads instruction context — the side-effecting
   // tools the skill body invokes (Bash, Write, etc) retain their own
   // approval gates. Pre-approving Skill lets routine "/loop", "/init",

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1299,6 +1299,8 @@ describe("scaffoldAgent", () => {
       "mcp__switchroom-telegram__download_attachment",
       "mcp__switchroom-telegram__get_recent_messages",
       "mcp__switchroom-telegram__progress_update",
+      "mcp__switchroom-telegram__send_checklist",
+      "mcp__switchroom-telegram__update_checklist",
     ];
     for (const tool of expectedTools) {
       expect(settings.permissions.allow).toContain(tool);
@@ -1946,7 +1948,7 @@ describe("scaffoldAgent", () => {
     expect(customScript).toContain('SWITCHROOM_RESUME_MAX_BYTES="500000"');
   });
 
-  it("seeds safe read-only tool defaults when tools.allow is empty and dangerous_mode is off", () => {
+  it("seeds safe default tools (incl. Bash) when tools.allow is empty and dangerous_mode is off", () => {
     const config = makeAgentConfig(); // no tools, no dangerous_mode
     const result = scaffoldAgent("readonly-agent", config, tmpDir, telegramConfig);
     const settings = JSON.parse(
@@ -1954,11 +1956,59 @@ describe("scaffoldAgent", () => {
     );
     const allow: string[] = settings.permissions.allow;
     expect(allow).toEqual(expect.arrayContaining(["Read", "Grep", "Glob"]));
-    // Risky tools must NOT be auto-allowed.
-    expect(allow).not.toContain("Bash");
+    // Bash is pre-approved for default agents: ordinary fleet agents are
+    // per-container isolated, so a shell command's blast radius is the
+    // sandbox. Gating it only stormed the approval UI on the first routine
+    // shell call of nearly every task. This assertion fails on pre-change
+    // code (Bash was deliberately excluded).
+    expect(allow).toContain("Bash");
+    // Edit/Write still gated by defaultMode: acceptEdits — not pre-approved.
     expect(allow).not.toContain("Edit");
     expect(allow).not.toContain("Write");
+    // Network-reaching / gated tools must NOT be auto-allowed.
     expect(allow).not.toContain("WebFetch");
+  });
+
+  it("does NOT pre-approve any keep-gated tool via the default set", () => {
+    // The default read-only seed must not smuggle in a hostd mutator, a
+    // vault verb, a mental-model write, or Write/Edit. Guards against a
+    // future careless addition to DEFAULT_READ_ONLY_PREAPPROVED_TOOLS.
+    const config = makeAgentConfig(); // plain default agent
+    const result = scaffoldAgent("gated-check-agent", config, tmpDir, telegramConfig);
+    const settings = JSON.parse(
+      readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
+    );
+    const allow: string[] = settings.permissions.allow;
+    for (const forbidden of [
+      "Write",
+      "Edit",
+      "mcp__hostd__agent_restart",
+      "mcp__hostd__agent_exec",
+      "mcp__hostd__update_apply",
+      "mcp__switchroom-telegram__vault_request_access",
+      "mcp__hindsight__create_mental_model",
+      "mcp__hindsight__update_mental_model",
+    ]) {
+      expect(allow).not.toContain(forbidden);
+    }
+    // The fleet deny entries must survive on the deny list.
+    expect(settings.permissions.deny).toContain("AskUserQuestion");
+  });
+
+  it("tools.deny: [Bash] surfaces Bash on the deny list (deny wins in Claude Code)", () => {
+    // Bash is seeded into the default allow set, but an operator who wants a
+    // shell-free agent sets tools.deny: ["Bash"]. Claude Code resolves the
+    // union with deny-always-wins, so the effective capability excludes Bash.
+    // The scaffold's job is to faithfully emit the deny entry; we assert at
+    // that layer (CC enforces precedence itself).
+    const config = makeAgentConfig({
+      tools: { allow: [], deny: ["Bash"] },
+    } as Partial<AgentConfig>);
+    const result = scaffoldAgent("shell-free-agent", config, tmpDir, telegramConfig);
+    const settings = JSON.parse(
+      readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
+    );
+    expect(settings.permissions.deny).toContain("Bash");
   });
 
   it("does not inject read-only defaults when user set explicit tools.allow", () => {
@@ -2305,8 +2355,10 @@ describe("reconcileAgent", () => {
     expect(settingsAfter.permissions.allow).toEqual(
       expect.arrayContaining(["Read", "Grep", "Glob"]),
     );
-    // Risky tools still must NOT be auto-allowed.
-    expect(settingsAfter.permissions.allow).not.toContain("Bash");
+    // Bash is part of the default seed (per-container isolation) and must
+    // survive reconcile via the same shared computeDesiredPermissionAllow.
+    expect(settingsAfter.permissions.allow).toContain("Bash");
+    // Edit/Write stay gated by defaultMode: acceptEdits — not pre-approved.
     expect(settingsAfter.permissions.allow).not.toContain("Edit");
     expect(settingsAfter.permissions.allow).not.toContain("Write");
   });
@@ -2336,8 +2388,9 @@ describe("reconcileAgent", () => {
     expect(settings.permissions.allow).toEqual(
       expect.arrayContaining(["Read", "Grep", "Glob"]),
     );
-    // Risky tools must still NOT be auto-allowed with dangerous_mode=off.
-    expect(settings.permissions.allow).not.toContain("Bash");
+    // Bash is part of the default seed and must be present via reconcile.
+    // Edit/Write stay gated by defaultMode: acceptEdits with dangerous_mode=off.
+    expect(settings.permissions.allow).toContain("Bash");
     expect(settings.permissions.allow).not.toContain("Edit");
     expect(settings.permissions.allow).not.toContain("Write");
   });


### PR DESCRIPTION
## Summary

Pre-approves `Bash` and the two native-checklist Telegram MCP tools
(`send_checklist`, `update_checklist`) fleet-wide, via the scaffold converge
engine. Single-concern permissions change; both edits land in
`src/agents/scaffold.ts` and flow through the one shared
`computeDesiredPermissionAllow` so scaffold and reconcile stay in lockstep.

## Why

`Bash` prompted on **every** fleet agent's first shell call of nearly every
task. Claude Code permission precedence is a **UNION** — `--allowedTools`
merges with `settings.json` `permissions.allow`, and `deny` always wins — so
gating `Bash` bought no real containment for an ordinary agent. Each agent
runs in its **own Docker container** (one per agent), so a shell command's
blast radius is that agent's sandbox, the same isolation boundary that already
makes the pre-approved `Read`/`Grep`/`Glob` safe. The gate only stormed the
operator with an approval card for no safety benefit.

### Verified root cause (evidence)
- `src/agents/scaffold.ts:1467-1497` (pre-change) — the block comment that
  deliberately excluded `Bash`/`Edit`/`Write` from
  `DEFAULT_READ_ONLY_PREAPPROVED_TOOLS`.
- `src/agents/scaffold.ts:4340-4342` — the "granular-only-when-present (Claude
  Code's own OR semantics)" comment: switchroom itself relies on the union.
- `computeDesiredPermissionAllow` (`:5024`) seeds `readOnlyDefaults` **only**
  when `tools.allow` is empty AND `dangerous_mode` is off (`:5046`), and
  `reconcileAgent` (`:7688`) consumes the same function — so touching the
  default set alone keeps `Bash` operator-controllable.
- The two checklist tools are registered by the plugin at
  `telegram-plugin/bridge/bridge.ts:269` (`send_checklist`) and `:358`
  (`update_checklist`) but were absent from `SWITCHROOM_TELEGRAM_MCP_TOOLS`, so
  the first checklist call wedged on a per-call prompt — the exact drift class
  the parity test already guards for `progress_update`.

## The diff

1. **`"Bash"` → `DEFAULT_READ_ONLY_PREAPPROVED_TOOLS`** (`scaffold.ts:1515`),
   with the block comment rewritten to explain the per-container-isolation
   rationale, the `tools.deny: ["Bash"]` lever, and the root-tier caveat.
   `Edit`/`Write` stay OFF the list — still covered by
   `defaultMode: acceptEdits`.
2. **`send_checklist` + `update_checklist` → `SWITCHROOM_TELEGRAM_MCP_TOOLS`**
   (`scaffold.ts:1197-1198`).

### Why part "b" of the earlier audit draft was DROPPED
The earlier draft also proposed an **unconditional `Bash` spread inside
`computeDesiredPermissionAllow`**. Rejected. An unconditional spread would make
`Bash` removable **only** via `tools.deny`, converting it from
operator-controllable to always-on — a latent footgun. By touching **only** the
read-only default set, `Bash` is seeded solely for default agents (empty
`tools.allow`, non-dangerous), and any agent with an explicit `tools.allow`
self-serves `Bash` as it already does. A future "keep this agent shell-free"
agent uses `tools.deny: ["Bash"]` (deny wins in Claude Code).

## Per-agent consequences (verified)

| Class | Effect |
|---|---|
| **Default agents, no explicit `tools.allow`** (e.g. **kdogg**) | Now get `Bash` in computed allow. **Intended** and consistent with container isolation. NOT special-cased. |
| **Agents WITH explicit `tools.allow`** | Unchanged — `hadExplicitAllow` suppresses the default seed, and they already carry `Bash` via `all` or a literal entry. Verified: `tests/scaffold.all-wildcard-keeps-explicit.test.ts:120` still asserts a non-`all` explicit-allow agent does NOT get `Bash` injected, and passes untouched. |
| **Root-tier agents** (`klanker` + the other `root: true` agent) | Run uid 0 with the docker socket + `/host` mounted rw — their `Bash` reaches the **host**, not just a sandbox. They already have `Bash` via `all`, so this adds **no new exposure**. Their `Bash` auto-approve is safe because of the deliberate **root-debug tier design**, NOT container isolation. (Stated honestly — this PR does not claim universal sandbox safety.) |

`tools.deny: ["Bash"]` is the lever if any agent should ever be kept
shell-free.

## Preserved safety properties (verified)

- **No keep-gated tool leaks.** New `does NOT pre-approve any keep-gated tool
  via the default set` test asserts a plain default agent's allow excludes
  every `mcp__hostd__*` mutator, the vault verb, the mental-model writes, and
  `Write`/`Edit`.
- **Deny survives.** `WebFetch`/`WebSearch`/`AskUserQuestion` deny entries are
  untouched; the keep-gated test also asserts `AskUserQuestion` remains on the
  deny list.
- **`Bash` stays operator-controllable.** New `tools.deny: ["Bash"]` test
  proves `Bash` surfaces on `permissions.deny`; Claude Code enforces
  deny-always-wins at its own layer.
- **`Edit`/`Write` still prompt** — asserted absent from the default allow in
  both scaffold and reconcile tests.

## Test plan

- `tests/scaffold.test.ts`:
  - `seeds safe default tools (incl. Bash) …` — asserts default allow now
    **contains** `Bash` (fails on pre-change code, which deliberately excluded
    it), still excludes `Edit`/`Write`/`WebFetch`.
  - telegram parity test — expected list now includes `send_checklist` +
    `update_checklist`.
  - reconcile-path defaults tests (`preserves read-only tool defaults …`,
    `keeps read-only defaults when tools.allow=[] …`) flipped to assert `Bash`
    present via reconcile.
  - **New**: `does NOT pre-approve any keep-gated tool via the default set`.
  - **New**: `tools.deny: ["Bash"] surfaces Bash on the deny list`.
- **Local scoped run** (exec-capable dir; scratchpad tmpfs is `noexec`):
  `vitest run tests/scaffold.test.ts tests/scaffold.all-wildcard-keeps-explicit.test.ts`
  → all target cases green. The only 2 remaining reds
  (`generates start.sh with correct env vars`, `hoists TELEGRAM_STATE_DIR …`)
  are **pre-existing env-path artifacts** — verified failing identically on
  pristine `origin/main` via `git stash`; they depend on the runner's
  `$HOME`/`CLAUDE_CONFIG_DIR` and are unrelated to this diff. CI is the
  full-suite authority.
- `npm run lint` (full: `tsc --noEmit` + all guard scripts) → **clean**.

## Risk

Low, and deliberately bounded to the default seed. The one behavioural change
operators will see: default agents no longer tap-to-approve their first shell
call. Reversible per-agent with `tools.deny: ["Bash"]`. No gated capability is
widened. Not merged / no auto-merge — `switchroom apply` is operator-run.

## Job spec

`reference/jobs/approve-what-my-agent-can-touch.md` — "Make granting hard or
opaque and a helpful agent improvises around the gate … burns taps." This
removes needless taps on a container-safe tool while preserving
`no-self-escalation`: gated tools still fall through to the approval card, the
agent still cannot self-grant, and no credential path changes.

## For the reviewer to scrutinize

- The honesty of the root-tier caveat: `Bash` for `root: true` agents reaches
  the host; safe here only because they already hold `Bash` via `all` and the
  root-debug tier is deliberate. Confirm no NEW root exposure is introduced.
- That `Bash` truly stays operator-controllable — i.e. part "b" (unconditional
  spread) was correctly dropped and no equivalent always-on path was added.
- Any fleet doc or agent CLAUDE.md that still tells users "Bash will prompt";
  none found in this repo, but worth a reviewer sweep.
