### PR TITLE
fix(pins): wire the boot-seed reseed so a discharged pin cursor drains again (#3953)

### DIFF
--- a/telegram-plugin/gateway/boot-sweep-gate.ts
+++ b/telegram-plugin/gateway/boot-sweep-gate.ts
@@ -103,6 +103,21 @@ export interface BootPinSweepSteps {
   /** Flips the flag authorising the stale-pin drain — for this sweep AND for
    *  later lazy first-inbound sweeps. */
   enableSweep: () => void
+  /**
+   * BOOT-SEED PRUNE (#3953 regression fix). Drops discharged (`done: true`)
+   * cursor rows from the sweep ledger so a `(chat, thread)` that drained in a
+   * PRIOR session is re-evaluated live this boot, instead of short-circuiting
+   * forever on a stale `done`. Kind-agnostic — clears DM, forum-topic and
+   * supergroup rows alike. Forfeited rows (`attempts >= SWEEP_MAX_ATTEMPTS`)
+   * are RETAINED by the underlying `pruneSweepCursors`, so a chat the bot
+   * cannot pin does not re-burn its attempt budget every boot.
+   *
+   * MUST stay BOOT-scoped. The lazy first-inbound sweep fires on EVERY message;
+   * pruning there would re-arm a full re-drain per message = a Telegram flood.
+   * Runs once here, before the `sweepTarget` loop, so the loop re-evaluates the
+   * freshly-reseeded ledger.
+   */
+  seedPruneSweepCursors: () => void
   sweepTarget: (target: SweepTarget) => Promise<unknown>
   log?: (line: string) => void
 }
@@ -160,6 +175,15 @@ export async function runBootPinSweepSteps(deps: BootPinSweepSteps): Promise<voi
   await step('status-pin-cleanup', deps.statusPinCleanup, log)
   await step('activity-card-reaper', deps.activityCardReaper, log)
   await step('queued-card-reaper', deps.queuedCardReaper, log)
+
+  // Boot-seed prune (#3953): reseed the cursor ledger so a chat that drained in
+  // a prior session is re-evaluated live below, rather than short-circuiting on
+  // a stale `done`. Boot-scoped ONLY — never on the per-inbound path. Runs
+  // BEFORE enableSweep so eligibility (which also gates the lazy first-inbound
+  // sweep) is granted only once the ledger is reseeded — no window where an
+  // inbound observes a stale `done`. Isolated: a throw here must not strand the
+  // drain, and enableSweep below still runs regardless.
+  await step('seed-prune-sweep-cursors', async () => deps.seedPruneSweepCursors(), log)
 
   // Unconditional: reached even when every step above threw. See the docblock.
   await step('enable-sweep', async () => deps.enableSweep(), log)

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -648,6 +648,7 @@ import { withDeadline } from './with-deadline.js'
 import { createStatusPinApi, type PinCapableBot, type RobustApiSeam } from './status-pin-api.js'
 import { collectSweepTargets, type StalePinSweeper, type SweepTarget } from './stale-pin-sweep.js'
 import { createGatewayStalePinSweeper } from './stale-pin-sweep-wiring.js'
+import { reseedSweepLedger } from './stale-pin-sweep-store.js'
 import { atomicWriteFileSync } from '../../src/util/atomic.js'
 import { startWebhookIngestServer } from './webhook-ingest-server.js'
 import { recordWebhookEvent } from '../../src/web/webhook-gateway-record.js'
@@ -9041,6 +9042,11 @@ let stalePinSweepEligible = false
 // the previous complete ledger or the new one — never a truncated file that
 // forgets an in-flight drain.
 const STALE_PIN_SWEEP_STORE_PATH = join(STATE_DIR, 'stale-pin-sweep.json')
+const sweepStoreFs = {
+  readFileSync: (p: string) => readFileSync(p, 'utf-8'),
+  writeFileSync: (p: string, data: string) => atomicWriteFileSync(p, data, 0o600),
+  existsSync: (p: string) => existsSync(p),
+}
 const stalePinSweeper: StalePinSweeper = createGatewayStalePinSweeper({
   telegram: { handle: () => lockedBot, call: robustApiCall },
   claims: () => statusPinClaims.values(),
@@ -9049,14 +9055,7 @@ const stalePinSweeper: StalePinSweeper = createGatewayStalePinSweeper({
       ? loadStatusPins(STATUS_PIN_STORE_PATH, statusPinStoreFs)
       : [],
   eligible: () => stalePinSweepEligible,
-  store: {
-    path: STALE_PIN_SWEEP_STORE_PATH,
-    fs: {
-      readFileSync: (p) => readFileSync(p, 'utf-8'),
-      writeFileSync: (p, data) => atomicWriteFileSync(p, data, 0o600),
-      existsSync: (p) => existsSync(p),
-    },
-  },
+  store: { path: STALE_PIN_SWEEP_STORE_PATH, fs: sweepStoreFs },
   // Per-deployment override only. UNSET (the normal case) means "take the
   // standing policy" — UNPIN_ALL_FORUM_TOPIC_ENABLED in stale-pin-sweep.ts,
   // i.e. the WHOLESALE topic drain stays off because it also removes pins this
@@ -9099,6 +9098,7 @@ function runBootPinCleanupAndStalePinSweep(): Promise<void> {
     enableSweep: () => {
       stalePinSweepEligible = true
     },
+    seedPruneSweepCursors: () => reseedSweepLedger(STALE_PIN_SWEEP_STORE_PATH, sweepStoreFs),
     sweepTarget: (t: SweepTarget) => stalePinSweeper.sweepTarget(t),
     log: (line) => process.stderr.write(line),
   })

--- a/telegram-plugin/gateway/stale-pin-sweep-store.ts
+++ b/telegram-plugin/gateway/stale-pin-sweep-store.ts
@@ -221,7 +221,44 @@ export function pendingSweepCursors(cursors: readonly SweepCursor[]): SweepCurso
   return cursors.filter((c) => !c.done && c.attempts < SWEEP_MAX_ATTEMPTS)
 }
 
-/** Drop discharged and forfeited rows — called once the ledger is reseeded. */
+/**
+ * Boot seed pass: drop DISCHARGED (`done: true`) rows ONLY, so a chat that
+ * drained in a prior session is re-evaluated LIVE on the next sweep instead of
+ * short-circuiting forever on a stale `done` (#3953 regression — the seed pass
+ * was never wired, so `done` was effectively permanent).
+ *
+ * FORFEITED rows (`attempts >= SWEEP_MAX_ATTEMPTS`, still `!done`) are
+ * deliberately RETAINED. Their whole purpose is to remember that a chat's
+ * attempt budget is spent (bot kicked, pin rights revoked, a chat that
+ * flood-waits forever). Pruning one would let the next boot re-seed it from the
+ * pin stores and re-burn the full 8-attempt budget on every boot for the rest
+ * of time — precisely the Telegram flood the attempt cap exists to prevent. So
+ * this filters on `done` ALONE; it must NOT also gate on `attempts`.
+ */
 export function pruneSweepCursors(cursors: readonly SweepCursor[]): SweepCursor[] {
-  return cursors.filter((c) => !c.done && c.attempts < SWEEP_MAX_ATTEMPTS)
+  return cursors.filter((c) => !c.done)
+}
+
+/**
+ * BOOT-SEED reseed of the durable ledger (#3953): drop discharged (`done:true`)
+ * rows so a `(chat, thread)` that drained in a prior session is re-evaluated
+ * LIVE on the next sweep instead of short-circuiting forever on a stale `done`.
+ * Forfeited rows are retained (see {@link pruneSweepCursors}).
+ *
+ * Writes ONLY when the prune changed the ledger, so a no-op boot never churns
+ * the durable file. Never throws — a reseed failure degrades to the pre-fix
+ * behaviour (the stale `done` survives one more boot), it must not break boot.
+ *
+ * BOOT-SCOPED BY CONTRACT: the caller must invoke this once at boot, never on
+ * the per-inbound path (which fires on every message — re-arming a full re-drain
+ * per message is a Telegram flood).
+ */
+export function reseedSweepLedger(
+  path: string,
+  fs: SweepStoreFsSeam,
+  log: (line: string) => void = (l) => process.stderr.write(l),
+): void {
+  const rows = loadSweepCursors(path, fs)
+  const pruned = pruneSweepCursors(rows)
+  if (pruned.length !== rows.length) persistSweepCursors(path, fs, pruned, log)
 }

--- a/telegram-plugin/gateway/stale-pin-sweep.test.ts
+++ b/telegram-plugin/gateway/stale-pin-sweep.test.ts
@@ -32,6 +32,8 @@ import {
 import {
   SWEEP_MAX_ATTEMPTS,
   loadSweepCursors,
+  pruneSweepCursors,
+  reseedSweepLedger,
   upsertSweepCursor,
   type SweepCursor,
   type SweepStoreFsSeam,
@@ -905,5 +907,165 @@ describe('stale-pin sweep — classification and seeding', () => {
       true,
     )
     expect(isNothingToUnpinError(new Error('something else'))).toBe(false)
+  })
+})
+
+// ─── #3953: the boot-seed prune reseeds a discharged obligation ───────────────
+//
+// Regression #3953 replaced the per-boot DM self-heal with a cursor-gated stack
+// drain, but the boot "seed pass" that clears discharged cursors was never
+// wired — so `done:true` was effectively PERMANENT and every later boot /
+// first-inbound sweep short-circuited on `already-drained`, orphaning any pin
+// that leaked AFTER the first drain. These tests pin the reseed contract:
+//   1. `pruneSweepCursors` drops `done` rows ONLY and RETAINS forfeited
+//      (attempts-exhausted) rows — a store-level test that FAILS on the pre-fix
+//      filter (which also dropped forfeited rows, re-burning the attempt budget
+//      every boot = flood risk).
+//   2. Running that prune between two fresh-process sweeps re-arms the drain, so
+//      a pin leaked after a prior discharge is reaped — for a DM AND a
+//      supergroup (channel-class) target alike.
+
+/** The boot-seed reseed exactly as the gateway wires it (`gateway.ts`
+ *  `seedPruneSweepCursors` → `reseedSweepLedger`). */
+function bootSeedPrune(fs: SweepStoreFsSeam, path: string): void {
+  reseedSweepLedger(path, fs, () => {})
+}
+
+/** A sweeper over a SHARED durable store — a distinct instance models a fresh
+ *  process (reboot), so the only state carried across is the on-disk ledger. */
+function sweeperOver(
+  fs: SweepStoreFsSeam,
+  path: string,
+  fake: ReturnType<typeof fakeChat>,
+  opts: { recordedPinIds?: number[] } = {},
+) {
+  let clock = 1_000_000
+  const deps: StalePinSweepDeps = {
+    getTopPinnedMessageId: fake.getTopPinnedMessageId,
+    pinSilent: fake.pinSilent,
+    unpin: fake.unpin,
+    unpinAllForumTopicMessages: fake.unpinAllForumTopicMessages,
+    canPinInChat: fake.canPinInChat,
+    protectedMessageIds: () => [],
+    recordedPinIds: () => opts.recordedPinIds ?? [],
+    eligible: () => true,
+    sleep: async (ms) => {
+      clock += ms
+    },
+    now: () => clock,
+    store: { path, fs },
+    log: () => {},
+  }
+  return createStalePinSweeper(deps)
+}
+
+describe('pruneSweepCursors — boot-seed reseed (#3953)', () => {
+  const now = 1_000_000
+
+  it('drops discharged rows but RETAINS forfeited (attempts-exhausted) rows', () => {
+    const discharged: SweepCursor = {
+      chatId: DM,
+      kind: 'dm',
+      popped: 3,
+      done: true,
+      attempts: 1,
+      updatedAt: now,
+    }
+    // A no-rights group that spent its whole attempt budget: `done` is false,
+    // but re-seeding it would re-burn all 8 attempts on the NEXT boot, and every
+    // boot after — the exact Telegram flood the attempt cap exists to stop.
+    const forfeited: SweepCursor = {
+      chatId: GROUP,
+      kind: 'supergroup',
+      popped: 0,
+      done: false,
+      attempts: SWEEP_MAX_ATTEMPTS,
+      lastStatus: 'skipped-no-rights',
+      updatedAt: now,
+    }
+    const stillOwed: SweepCursor = {
+      chatId: '900000002',
+      kind: 'dm',
+      popped: 0,
+      done: false,
+      attempts: 2,
+      updatedAt: now,
+    }
+
+    const keys = pruneSweepCursors([discharged, forfeited, stillOwed]).map((c) => c.chatId)
+
+    expect(keys).not.toContain(DM) // discharged → reseeded (dropped)
+    expect(keys).toContain(GROUP) // forfeited no-rights → RETAINED (no re-burn)
+    expect(keys).toContain('900000002') // still owed → retained untouched
+  })
+
+  it('clears discharged rows for EVERY surface — dm, forum-topic, supergroup', () => {
+    // The prune must be kind-agnostic: a stuck `done` on a topic or a channel is
+    // the same regression as on a DM, so none may be left short-circuiting.
+    const rows: SweepCursor[] = [
+      { chatId: '1', kind: 'dm', popped: 1, done: true, attempts: 1, updatedAt: now },
+      { chatId: '2', kind: 'forum-topic', threadId: 5, popped: 1, done: true, attempts: 1, updatedAt: now },
+      { chatId: '3', kind: 'supergroup', popped: 1, done: true, attempts: 1, updatedAt: now },
+    ]
+    expect(pruneSweepCursors(rows)).toEqual([])
+  })
+})
+
+describe('stale-pin sweep — re-drain after the boot-seed prune (#3953)', () => {
+  it('re-drains a DM whose obligation was discharged in a prior session', async () => {
+    const fs = memFs()
+    const path = '/state/stale-pin-sweep.json'
+
+    // Session 1: an orphan bot pin is drained and the obligation discharged.
+    const s1 = await sweeperOver(fs, path, fakeChat({ stack: [11] })).sweepTarget({ chatId: DM })
+    expect(s1.status).toBe('drained')
+    expect(loadSweepCursors(path, fs).find((c) => c.chatId === DM)?.done).toBe(true)
+
+    // A NEW orphan pin leaks in after that drain.
+    // Fresh process, no prune: the sweep short-circuits on the stale `done` —
+    // the #3953 regression, verbatim. The orphan is left pinned.
+    const stuckChat = fakeChat({ stack: [99] })
+    const stuck = await sweeperOver(fs, path, stuckChat).sweepTarget({ chatId: DM })
+    expect(stuck.status).toBe('already-drained')
+    expect(stuck.popped).toBe(0)
+    expect(stuckChat.stack).toEqual([99])
+
+    // Reboot WITH the boot-seed prune: the discharged row is reseeded, so the
+    // next sweep re-evaluates the chat LIVE and reaps the orphan.
+    bootSeedPrune(fs, path)
+    const rebootChat = fakeChat({ stack: [99] })
+    const redrain = await sweeperOver(fs, path, rebootChat).sweepTarget({ chatId: DM })
+    expect(redrain.status).toBe('drained')
+    expect(redrain.popped).toBe(1)
+    expect(rebootChat.stack).toEqual([])
+  })
+
+  it('re-drains a supergroup (channel-class) discharged in a prior session', async () => {
+    const fs = memFs()
+    const path = '/state/stale-pin-sweep.json'
+
+    // Session 1: the one recorded orphan is reaped, obligation discharged.
+    const s1 = await sweeperOver(fs, path, fakeChat({ stack: [77], canPin: true }), {
+      recordedPinIds: [77],
+    }).sweepTarget({ chatId: GROUP })
+    expect(s1.status).toBe('drained')
+    expect(loadSweepCursors(path, fs).find((c) => c.chatId === GROUP)?.done).toBe(true)
+
+    // A fresh recorded orphan leaks in; a fresh process short-circuits on `done`.
+    const stuckChat = fakeChat({ stack: [88], canPin: true })
+    const stuck = await sweeperOver(fs, path, stuckChat, { recordedPinIds: [88] }).sweepTarget({
+      chatId: GROUP,
+    })
+    expect(stuck.status).toBe('already-drained')
+    expect(stuckChat.stack).toEqual([88])
+
+    // Reboot + prune: the supergroup row is reseeded and re-swept.
+    bootSeedPrune(fs, path)
+    const rebootChat = fakeChat({ stack: [88], canPin: true })
+    const redrain = await sweeperOver(fs, path, rebootChat, { recordedPinIds: [88] }).sweepTarget({
+      chatId: GROUP,
+    })
+    expect(redrain.status).toBe('drained')
+    expect(rebootChat.stack).toEqual([])
   })
 })

--- a/telegram-plugin/tests/boot-sweep-gate.test.ts
+++ b/telegram-plugin/tests/boot-sweep-gate.test.ts
@@ -161,6 +161,7 @@ describe('runBootPinSweepSteps (#3664 salvage S2)', () => {
         order.push('queued-cards')
       },
       enableSweep: () => order.push('enable-sweep'),
+      seedPruneSweepCursors: () => order.push('seed-prune'),
       sweepTarget: async (t) => {
         order.push(`sweep:${t.chatId}:${t.threadId ?? '-'}`)
       },
@@ -177,6 +178,7 @@ describe('runBootPinSweepSteps (#3664 salvage S2)', () => {
       'status-pins',
       'activity-cards',
       'queued-cards',
+      'seed-prune',
       'enable-sweep',
       'sweep:900000001:-',
     ])
@@ -194,6 +196,7 @@ describe('runBootPinSweepSteps (#3664 salvage S2)', () => {
       'scan',
       'status-pins',
       'queued-cards',
+      'seed-prune',
       'enable-sweep',
       'sweep:900000001:-',
     ])
@@ -210,7 +213,7 @@ describe('runBootPinSweepSteps (#3664 salvage S2)', () => {
       queuedCardReaper: boom,
     })
     await runBootPinSweepSteps(d.deps)
-    expect(d.order).toEqual(['scan', 'enable-sweep', 'sweep:900000001:-'])
+    expect(d.order).toEqual(['scan', 'seed-prune', 'enable-sweep', 'sweep:900000001:-'])
   })
 
   it('a failing store scan still lets the reapers and the DM enable run', async () => {
@@ -221,7 +224,13 @@ describe('runBootPinSweepSteps (#3664 salvage S2)', () => {
     })
     await runBootPinSweepSteps(d.deps)
     // No targets to sweep, but nothing behind the scan is stranded.
-    expect(d.order).toEqual(['status-pins', 'activity-cards', 'queued-cards', 'enable-sweep'])
+    expect(d.order).toEqual([
+      'status-pins',
+      'activity-cards',
+      'queued-cards',
+      'seed-prune',
+      'enable-sweep',
+    ])
     expect(d.logs.join('')).toContain("step 'sweep-target-scan' failed: ENOENT")
   })
 
@@ -272,6 +281,7 @@ describe('runBootPinSweepSteps (#3664 salvage S2)', () => {
           order.push('queued-cards')
         },
         enableSweep: () => order.push('enable-sweep'),
+        seedPruneSweepCursors: () => {},
         sweepTarget: async () => {},
         log: () => {
           throw new Error('EPIPE')
@@ -294,6 +304,9 @@ describe('runBootPinSweepSteps (#3664 salvage S2)', () => {
         activityCardReaper: boom,
         queuedCardReaper: boom,
         enableSweep: () => {
+          throw new Error('boom')
+        },
+        seedPruneSweepCursors: () => {
           throw new Error('boom')
         },
         sweepTarget: boom,


### PR DESCRIPTION
## Root cause

#3953 (\`26250345\`) replaced the per-boot DM \`unpinAllChatMessages\` self-heal with a cursor-gated stack drain, but the boot **seed pass** that clears discharged cursors was never written.

- \`sweepTarget\` short-circuits on \`if (cursor.done) return 'already-drained'\` (\`stale-pin-sweep.ts:1116\`).
- \`pruneSweepCursors\` (\`stale-pin-sweep-store.ts\`) and \`pendingSweepCursors\` are both exported but had **zero** non-test callers — the reseed was never wired.

So once a \`(chat, thread)\` drained, \`done:true\` persisted **forever**: every later boot and every first-inbound sweep short-circuited, and any orphan pin that leaked *after* the first drain (a DM targeted \`unpinChatMessage\` on a non-top stack entry is a silent \`ok:true\` no-op, and \`executePinLeg\` drops the durable claim on that false ok) was never reaped. Pre-#3953 the per-boot sweep self-healed this — that is the regression.

Second latent bug: \`pruneSweepCursors\` filtered \`!done && attempts < SWEEP_MAX_ATTEMPTS\` (identical to \`pendingSweepCursors\`). Wired as-is it would also drop **forfeited** rows (attempts-exhausted, e.g. no-rights groups/channels), letting the next boot re-seed them and re-burn the full 8-attempt budget every boot = a Telegram flood.

## Fix (minimal, deterministic)

1. \`pruneSweepCursors\` now filters on \`done\` **alone** → forfeited rows are RETAINED (no budget re-burn). Kind-agnostic across dm / forum-topic / supergroup(channel).
2. New \`reseedSweepLedger(path, fs)\` in the **store module** (not gateway): load → drop discharged → persist only on change. Never throws; boot-scoped by contract.
3. Wired as an injected \`seedPruneSweepCursors\` step in \`runBootPinSweepSteps\`, run **before** \`enableSweep\` so eligibility (which also gates the lazy first-inbound sweep) is granted only once the ledger is reseeded — closing any window where an inbound could observe a stale \`done\`.

## Flooding safety (no regressions)

- Reseed is **boot-scoped only** — never on the per-message first-inbound path (that path re-arming a full re-drain per message would be a flood).
- Forfeited rows retained; \`SWEEP_MAX_ATTEMPTS=8\`, DM write throttle / 40-pop cap / per-minute budget, PEER_FLOOD / retry_after circuit breaker, and the verify-empty-before-write short-circuit are all untouched.
- No \`unpinAllChatMessages\` reintroduced; the opt-in wholesale forum \`unpinAllForumTopic\` path stays off by default (no 429 retry loop).
- A clean re-drain over an empty stack costs only \`getChat\` reads and exits before any write.

## Per-surface (DM / forum-topic / supergroup-channel)

The prune is kind-agnostic, so a stuck \`done\` clears on every surface; the re-drain then follows each surface's existing, unchanged semantics — DM repin+unpin loop; group/channel targeted unpin of recorded ids behind the rights precheck; wholesale forum drain remains opt-in-only. Forfeit retention holds for all kinds, so a channel the bot cannot pin never re-burns its budget.

## Tests

- **Store test** (\`pruneSweepCursors\`): forfeited rows retained, discharged dropped, kind-agnostic across dm/forum-topic/supergroup. The forfeit-retention case **fails on the pre-fix filter**, passes after (verified against pristine \`origin/main\`).
- **Re-drain tests** for a DM and a supergroup (channel-class): drain to \`done\`, run the boot-seed reseed, leak a fresh pin, assert the sweep re-drains it (\`drained\`, popped 1) — and that *without* the reseed it short-circuits on \`already-drained\` (the regression, verbatim).
- boot-sweep-gate order tests updated for the new step (seed-prune before enable-sweep).

## Local verification

- \`npx tsc --noEmit\` → clean.
- \`vitest run\` on \`stale-pin-sweep\`, \`boot-sweep-gate\`, \`boot-pin-sweep-wiring\`, \`status-pin-boot-recovery\`, \`activity-card-wiring\` → **88 passed**.
- \`check-gateway-line-ratchet\` clean (net-neutral, 24855 == ceiling+slack), plus \`check-status-pin-single-path\`, \`check-retry-flood-hooks\`, \`check-callback-ctx-wrapping\`, \`check-no-pii-secrets\` clean.
- \`check-plugin-references\` fails locally on missing UAT/render deps (\`@mtcute/node\`, \`mdast-*\`) — identical on pristine \`origin/main\`; environment artifact, CI is authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)