### PR TITLE
fix(obligations): re-check represent guard at delivery time, not only at decision

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -461,7 +461,7 @@ import {
   type SendReplyGatewayDeps,
   type DeliverCapturedProseDeps,
 } from './outbound-send-path.js'
-import { handleSessionEvent as handleSessionEventCore, drainParkedTurnStartsForChat, closeFlushCompletionWindows } from './stream-render.js'
+import { handleSessionEvent as handleSessionEventCore, drainParkedTurnStartsForChat, closeFlushCompletionWindows, parkedTurnStartCount } from './stream-render.js'
 import { createNarrativeLane } from './narrative-lane.js'
 import {
   parseAgentCallback,
@@ -659,6 +659,7 @@ import { handleRequestDriveApproval } from './drive-write-approval.js'
 import { handleRequestMs365Approval } from './ms365-write-approval.js'
 import { buildDiffPreviewCard } from './diff-preview-card.js'
 import { createPendingInboundBuffer, redeliverBufferedInbound, idleDrainTick } from './pending-inbound-buffer.js'
+import { makeRepresentRedeliveryGuard, makeSessionBusyDrainDeferral } from './represent-delivery-guard.js'
 import { isCronIdentity, isCronInjectFire, deliverInjectWithFallback, replyCallerIsForeignSession } from './cron-session.js'
 import {
   ObligationLedger,
@@ -9788,6 +9789,11 @@ const pendingInboundBuffer = createPendingInboundBuffer({
   // enqueue chokepoint so a boot-replayed handback (not just the live synthesis
   // push) populates it. Every `subagent_handback` push funnels through here.
   onHandbackEnqueue: (chatId, threadId, ts) => subagentHandbackMarker.record(chatId, threadId, ts),
+  // F1 (fix/represent-double-send-delivery-recheck) — delivery-time represent
+  // retract. Every drain path hands its buffered inbounds through this gate; a
+  // stale `obligation_represent` (its reply landed since the sweep decided it) is
+  // dropped here rather than duplicated into the CLI queue. See represent-delivery-guard.ts.
+  beforeRedeliver: makeRepresentRedeliveryGuard({ enabled: OBLIGATION_LEDGER_ENABLED, historyEnabled: HISTORY_ENABLED, ledger: obligationLedger, hasOutboundDeliveredSince, minReplyChars: OBLIGATION_REPRESENT_GUARD_MIN_REPLY_CHARS, log: (l) => process.stderr.write(l) }),
 })
 
 // PR2 obligation-ledger idle sweep. Re-present an OPEN obligation only at a
@@ -11742,30 +11748,19 @@ if (isGatewayMain) (() => {  // #2996 P0c: gated — starts webhook-ingest UDS s
 })()
 
 // ─── Opportunistic idle-drain of pendingInboundBuffer ─────────────────────
-// pendingInboundBuffer otherwise drains only on (a) bridge re-register
-// (onClientRegistered) or (b) the silence-poke framework fallback
-// clearing a wedged turn (#1546). NEITHER fires when a message is
-// buffered during a bridge-IPC flap that then settles with no
-// subsequent clean re-register AND claude is idle (no active turn →
-// silence-poke never arms). The message orphans until a manual restart
-// (finn, 2026-05-19 — buffered "verify with mff-query.py cashflow"
-// while idle; last `bridge registered` predated the buffer push, so
-// onClientRegistered's drain never ran for it).
-//
-// This is the third drain trigger. It's gated to be zero-cost and
-// zero-churn: skip entirely when nothing is buffered (one Map.get, no
-// log), when the bridge isn't alive (exactly sendToAgent's own guard —
-// so we never drain into a dead bridge and re-buffer/log-spin), OR
-// when a turn is in flight. The turn gate is #1556: a message
-// delivered while a turn is active is NOT safely queued by the bridge
-// — claude types it into its TUI composer and the auto-submit races
-// turn-completion, stranding it (the lawgpt wedge). Draining only at
-// `activeTurnStartedAt.size === 0` guarantees the channel notification
-// lands at an idle prompt and submits as a fresh turn. Only when there
-// IS a buffered message AND a live bridge AND no active turn do we
-// reuse the #1546 `redeliverBufferedInbound` (lossless: re-buffers any
-// per-message miss).
+// The THIRD drain trigger, beside bridge re-register (onClientRegistered) and
+// the silence-poke framework fallback (#1546): neither fires when a message is
+// buffered during a bridge-IPC flap that settles with no clean re-register while
+// claude is idle, so it orphans until a manual restart (finn, 2026-05-19). Gated
+// zero-cost/zero-churn: skip when nothing is buffered, when the bridge is dead,
+// or when a turn is in flight (#1556 — a message delivered mid-turn is typed into
+// claude's TUI composer and the auto-submit races turn-completion, stranding it).
 const IDLE_DRAIN_INTERVAL_MS = 5000
+// F2 (drain half) — bounded busy-defer. A ~5-min poke can clear the machine turn
+// while the CLI is still producing the answer; draining a represent into that busy
+// session re-queues it BEHIND the real reply → a duplicate. Defer while busy,
+// bounded so a wedged session still drains (F1 then retracts it post-reply).
+const idleDrainBusyDefer = makeSessionBusyDrainDeferral(OBLIGATION_BACKGROUND_WORK_GRACE_MS)
 if (isGatewayMain && !STATIC) {
   setInterval(() => {
     const selfAgent = process.env.SWITCHROOM_AGENT_NAME ?? ''
@@ -11775,8 +11770,11 @@ if (isGatewayMain && !STATIC) {
       () => {
         // #1556: never drain mid-turn — that re-creates the composer
         // wedge this buffer exists to prevent. Gate reads the delivery
-        // machine (turnInFlightForGate).
+        // machine (turnInFlightForGate) AND, per F2, stream-render's live-turn
+        // mirror (a poke can clear the former while the latter is still busy).
         if (turnInFlightForGate()) return false
+        const sessionBusy = (currentTurn != null && currentTurn.endedAt == null) || parkedTurnStartCount() > 0
+        if (idleDrainBusyDefer(sessionBusy, Date.now())) return false
         const c = ipcServer.getClient(selfAgent)
         return c != null && c.isAlive()
       },

--- a/telegram-plugin/gateway/obligation-ledger.ts
+++ b/telegram-plugin/gateway/obligation-ledger.ts
@@ -178,6 +178,15 @@ export class ObligationLedger {
     return this.open.has(originTurnId)
   }
 
+  /** The open obligation for `originTurnId`, or undefined if none is open. Read-
+   *  only accessor for the delivery-time represent re-check (represent-delivery-
+   *  guard.ts): a represent buffered while the obligation was open must be re-
+   *  evaluated against the obligation's CURRENT cutoff at the moment it is handed
+   *  to the CLI bridge, since a reply may have landed between decision and drain. */
+  get(originTurnId: string): Obligation | undefined {
+    return this.open.get(originTurnId)
+  }
+
   hasOpen(): boolean {
     return this.open.size > 0
   }

--- a/telegram-plugin/gateway/obligation-wiring.ts
+++ b/telegram-plugin/gateway/obligation-wiring.ts
@@ -23,6 +23,7 @@ import { buildObligationRepresentInbound, type Obligation } from './obligation-l
 import { driveEscalation } from './escalation-drive.js'
 import { shouldSuppressRepresent } from './represent-guard.js'
 import { shouldDeferEscalationForBridge } from './escalation-bridge-gate.js'
+import { parkedTurnStartCount } from './stream-render.js'
 
 export function createObligationWiring(deps: ObligationWiringDeps) {
   const {
@@ -161,13 +162,26 @@ function obligationSweep(): void {
   if (turnInFlightForGate()) return // a turn is running — let it finish/answer
   const agent = process.env.SWITCHROOM_AGENT_NAME ?? ''
   const now = Date.now()
+  // Session-busy signal (F2, decision half). A ~5-min silence poke can clear the
+  // machine turn (`turnInFlightForGate()` above → false) while the CLI session is
+  // STILL producing the answer — stream-render's live-turn mirror (`currentTurn`
+  // whose endedAt is null, or a parked turn-start) still knows it is busy. Without
+  // this, the sweep decides + buffers a represent mid-answer; the real reply lands
+  // seconds later and the model consumes the queued represent → a duplicate answer
+  // (the two-authorities-disagree defect). We treat a busy mirror the SAME as
+  // in-flight background work: defer the represent, BOUNDED by the same grace, so a
+  // wedged/hung session cannot silence a genuinely-unanswered turn forever.
+  const liveTurn = getCurrentTurn()
+  const sessionBusy = (liveTurn != null && liveTurn.endedAt == null) || parkedTurnStartCount() > 0
   // Background-work grace: while genuine autonomous sub-agent work is in flight
   // (a running worker, or an orphaned foreground sub-agent — neither visible to
-  // the turn machine), an obligation younger than the ceiling is NOT re-presented
-  // /escalated. Bounded by OBLIGATION_BACKGROUND_WORK_GRACE_MS so escalation
-  // always eventually fires. =0 disables it.
+  // the turn machine), OR the CLI session is still busy behind a poke-cleared
+  // machine turn, an obligation younger than the ceiling is NOT re-presented
+  // /escalated. Bounded by OBLIGATION_BACKGROUND_WORK_GRACE_MS (measured from
+  // openedAt in decideAtIdle) so escalation always eventually fires. =0 disables it.
   const backgroundWorkActive =
-    OBLIGATION_BACKGROUND_WORK_GRACE_MS > 0 && agentHasInFlightBackgroundWork(now)
+    OBLIGATION_BACKGROUND_WORK_GRACE_MS > 0 &&
+    (agentHasInFlightBackgroundWork(now) || sessionBusy)
   // Grace window: skip an obligation whose handling turn ended < grace ago — its
   // trailing slow/worker answer may still be landing (over-escalation fix).
   // Per-represent grace: skip an obligation re-presented < grace ago — prevents
@@ -189,6 +203,7 @@ function obligationSweep(): void {
       lastBgWorkDeferLogMs = now
       process.stderr.write(
         `telegram gateway: obligation sweep deferred — in-flight autonomous sub-agent work ` +
+          `or busy CLI session behind a poke-cleared turn ` +
           `(${obligationLedger.size()} open, bounded ${Math.round(OBLIGATION_BACKGROUND_WORK_GRACE_MS / 60_000)}m from receipt)\n`,
       )
     }

--- a/telegram-plugin/gateway/pending-inbound-buffer.ts
+++ b/telegram-plugin/gateway/pending-inbound-buffer.ts
@@ -49,6 +49,16 @@ export interface PendingInboundBuffer {
   depth: (agent: string) => number
   /** Test-only: total depth across all agents. */
   totalDepth: () => number
+  /**
+   * Delivery-time gate consulted by `redeliverBufferedInbound` for EVERY message
+   * it is about to hand to the bridge. Returns TRUE to proceed, FALSE to RETRACT
+   * (drop) the message (the spool entry is acked so it is not boot-replayed, and
+   * it is NOT re-buffered). The gateway wires this to the represent delivery
+   * re-check (represent-delivery-guard.ts): a represent buffered while its
+   * obligation was open must be re-evaluated at drain time, since a reply may have
+   * landed between the sweep's decision and this drain. Undefined ⇒ never retract.
+   */
+  beforeRedeliver?: (msg: InboundMessage) => boolean
 }
 
 export interface PendingInboundBufferOptions {
@@ -94,6 +104,13 @@ export interface PendingInboundBufferOptions {
    * breaks the push hot path.
    */
   onHandbackEnqueue?: (chatId: string, threadId: number | undefined, ts: number) => void
+  /**
+   * Delivery-time retract gate — see `PendingInboundBuffer.beforeRedeliver`. The
+   * gateway supplies the represent delivery re-check here so EVERY drain path
+   * (idle-drain, bridge re-register, silence-poke fallback, turn-end) inherits it
+   * by construction rather than by per-call-site discipline.
+   */
+  beforeRedeliver?: (msg: InboundMessage) => boolean
 }
 
 /**
@@ -123,16 +140,26 @@ export function redeliverBufferedInbound(
   // silently dropped (clerk 2026-06-03). `send` returning true only means
   // the bytes reached the bridge, NOT that claude consumed them.
   onDelivered?: (merged: InboundMessage, originals: InboundMessage[]) => void,
-): { drained: number; redelivered: number; rebuffered: number } {
+): { drained: number; redelivered: number; rebuffered: number; retracted: number } {
   const pending = buffer.drain(agent)
   let redelivered = 0
   let rebuffered = 0
+  let retracted = 0
   // Collapse consecutive same-sender Telegram user messages into one turn
   // (see planBufferedRedelivery) so a forwarded burst that spanned a turn
   // boundary doesn't fan out into N sequential replies. System inbounds
   // (vault grants, approvals, cron, handbacks — anything with meta.source)
   // are never merged and are delivered individually exactly as before.
   for (const { merged, originals } of planBufferedRedelivery(pending)) {
+    // Delivery-time retract (F1): a buffered `obligation_represent` whose reply
+    // has landed since the sweep decided it is stale — drop it rather than hand
+    // a duplicate to the CLI queue. Ack the spool so it is not boot-replayed and
+    // do NOT re-buffer. The gateway closure closes the ledger + logs the retract.
+    if (buffer.beforeRedeliver != null && !buffer.beforeRedeliver(merged)) {
+      for (const o of originals) spool?.ack(o)
+      retracted += originals.length
+      continue
+    }
     let delivered = false
     try {
       delivered = send(merged)
@@ -157,7 +184,7 @@ export function redeliverBufferedInbound(
       rebuffered += originals.length
     }
   }
-  return { drained: pending.length, redelivered, rebuffered }
+  return { drained: pending.length, redelivered, rebuffered, retracted }
 }
 
 /** True when `msg` is an ordinary Telegram user message eligible to be
@@ -312,7 +339,7 @@ export function idleDrainTick(
   // enrols redelivered inbounds in the deliver-until-acked queue (parity with
   // the bridgeUp drain — clerk lost-message incident, 2026-06-03).
   onDelivered?: (merged: InboundMessage, originals: InboundMessage[]) => void,
-): { drained: number; redelivered: number; rebuffered: number } | null {
+): { drained: number; redelivered: number; rebuffered: number; retracted: number } | null {
   if (!agent) return null
   if (buffer.depth(agent) === 0) return null
   if (!isBridgeAlive()) return null
@@ -412,5 +439,6 @@ export function createPendingInboundBuffer(
       for (const q of queues.values()) n += q.length
       return n
     },
+    beforeRedeliver: opts.beforeRedeliver,
   }
 }

--- a/telegram-plugin/gateway/pending-inbound-buffer.ts
+++ b/telegram-plugin/gateway/pending-inbound-buffer.ts
@@ -155,7 +155,19 @@ export function redeliverBufferedInbound(
     // has landed since the sweep decided it is stale — drop it rather than hand
     // a duplicate to the CLI queue. Ack the spool so it is not boot-replayed and
     // do NOT re-buffer. The gateway closure closes the ledger + logs the retract.
-    if (buffer.beforeRedeliver != null && !buffer.beforeRedeliver(merged)) {
+    // FAIL-OPEN: a throwing predicate must never silence or lose a real message,
+    // nor abort the drain loop (which would strand every following message and
+    // crash the setInterval tick). On throw we treat it as "deliver".
+    let proceed = true
+    if (buffer.beforeRedeliver != null) {
+      try {
+        proceed = buffer.beforeRedeliver(merged)
+      } catch (e) {
+        proceed = true
+        process.stderr.write(`redeliver beforeRedeliver threw — failing open (deliver): ${String(e)}\n`)
+      }
+    }
+    if (!proceed) {
       for (const o of originals) spool?.ack(o)
       retracted += originals.length
       continue

--- a/telegram-plugin/gateway/represent-delivery-guard.ts
+++ b/telegram-plugin/gateway/represent-delivery-guard.ts
@@ -1,0 +1,157 @@
+/**
+ * represent-delivery-guard.ts — the DELIVERY-time half of the duplicate-represent
+ * defence (fix/represent-double-send-delivery-recheck).
+ *
+ * Background — the race this closes (verified from history.db, 2026):
+ *   1. A ~5-min silence poke fires the framework fallback, which clears the
+ *      machine turn (`turnInFlightForGate()` → false) while the CLI session is
+ *      STILL producing the answer (it lands ~17s later). stream-render's live-turn
+ *      mirror (`currentTurn`/`parkedTurnStarts`) still knows the session is busy.
+ *   2. With the machine turn cleared, `obligationSweep` runs; `shouldSuppressRepresent`
+ *      correctly returns false (nothing has been sent YET) and the represent is
+ *      buffered; the idle-drain flushes it into the live CLI queue.
+ *   3. ~13s later the real answer is delivered + recorded (ledger closed by the
+ *      normal path). Then the model consumes the already-queued represent and
+ *      answers a SECOND time → the duplicate.
+ *
+ * The represent guard never FAILED — it was consulted BEFORE the reply existed,
+ * and there was no re-check between decision → delivery → model consumption. This
+ * module adds that missing re-check (F1) plus the bounded busy-defer for the
+ * idle-drain gate (F2). Layer F2 (obligation-wiring's sweep + this drain defer)
+ * keeps the represent BUFFERED while the session is busy so that, by the time a
+ * drain actually hands it to the bridge, the real answer has landed and been
+ * recorded — at which point F1 retracts the now-stale represent. `recordOutbound`
+ * is a synchronous SQLite write that completes before the reply tool result
+ * returns, so a post-reply drain observes the row.
+ *
+ * Both halves are PURE-ish factories (no Telegram, no SQLite) so the whole
+ * decision is executable in a unit test; the gateway injects the ledger accessor,
+ * the outbound-history predicate, and the logger.
+ */
+
+import type { InboundMessage } from './ipc-protocol.js'
+import { shouldSuppressRepresent, type RepresentGuardObligation } from './represent-guard.js'
+
+/** The minimal ledger surface the delivery re-check needs. */
+export interface RepresentDeliveryLedger {
+  /** The CURRENTLY-open obligation for `originTurnId`, or undefined if none is
+   *  open (already closed — answered or cancelled — since the represent was
+   *  buffered). */
+  get(originTurnId: string): RepresentGuardObligation | undefined
+  /** Close the obligation. Idempotent; returns whether an entry was removed. */
+  close(originTurnId: string | null | undefined): boolean
+}
+
+export interface RepresentRedeliveryGuardDeps {
+  /** OBLIGATION_LEDGER_ENABLED — when off, never retract (nothing is tracked). */
+  enabled: boolean
+  /** HISTORY_ENABLED — forwarded to the pure guard (no history ⇒ never suppress). */
+  historyEnabled: boolean
+  ledger: RepresentDeliveryLedger
+  /** history.hasOutboundDeliveredSince, already curried with the chat query. */
+  hasOutboundDeliveredSince: (
+    chatId: string,
+    sinceMs: number,
+    threadId?: number,
+    minChars?: number,
+  ) => boolean
+  /** The represent guard's OWN low reply-length threshold (a terse-but-real reply
+   *  must still suppress the duplicate — #2472/#2474). */
+  minReplyChars: number
+  log: (line: string) => void
+}
+
+/**
+ * Build the `beforeRedeliver` predicate the pending-inbound buffer consults for
+ * EVERY message it is about to hand to the CLI bridge. Returns TRUE to proceed
+ * with delivery, FALSE to RETRACT (drop) the message.
+ *
+ * Only `obligation_represent` inbounds are ever retracted; everything else always
+ * proceeds. A represent is retracted when, AT DELIVERY TIME:
+ *   - the obligation is no longer open (a reply landed and the normal close path
+ *     fired, or it was cancelled) — re-delivering would duplicate / re-ask a
+ *     resolved question; OR
+ *   - it IS still open but `shouldSuppressRepresent` now returns true against the
+ *     obligation's CURRENT cutoff (a reply landed since decision, but the normal
+ *     close path missed it because its routing did not resolve back to the origin
+ *     — the exact #2472 gap, now caught at delivery instead of only at decision).
+ *
+ * The cutoff is the obligation's own (`openedAt` for the first represent,
+ * `lastRepresentedAt` thereafter) — encoded inside `shouldSuppressRepresent`, so
+ * an OLD reply to a DIFFERENT earlier question does not suppress a legitimate new
+ * represent (#2472 second-represent semantics). The genuine plain-text-no-reply
+ * case (#2788) records NO outbound row, so the predicate reports false at BOTH
+ * decision and here ⇒ the represent still fires exactly once.
+ */
+export function makeRepresentRedeliveryGuard(
+  deps: RepresentRedeliveryGuardDeps,
+): (msg: InboundMessage) => boolean {
+  return (msg) => {
+    if (!deps.enabled) return true
+    if (msg.meta?.source !== 'obligation_represent') return true
+    const originTurnId = msg.meta?.origin_turn_id
+    if (originTurnId == null) return true
+
+    const o = deps.ledger.get(originTurnId)
+    if (o == null) {
+      // Closed since this represent was buffered — a reply landed (normal close)
+      // or the turn was cancelled/interrupted. Either way the buffered represent
+      // is stale: drop it rather than re-ask an already-resolved obligation.
+      deps.log(
+        `telegram gateway: represent retracted at delivery — obligation already ` +
+          `closed since decision (no re-fire) origin=${originTurnId}\n`,
+      )
+      return false
+    }
+
+    const suppress = shouldSuppressRepresent(o, {
+      historyEnabled: deps.historyEnabled,
+      hasOutboundDeliveredSince: (chatId, sinceMs, threadId) =>
+        deps.hasOutboundDeliveredSince(chatId, sinceMs, threadId, deps.minReplyChars),
+    })
+    if (suppress) {
+      // A reply landed since this obligation's cutoff but the normal close path
+      // missed it. Close the ledger entry ourselves and drop the represent.
+      deps.ledger.close(originTurnId)
+      deps.log(
+        `telegram gateway: represent retracted at delivery — reply landed since ` +
+          `decision (no re-fire) origin=${originTurnId}\n`,
+      )
+      return false
+    }
+    return true
+  }
+}
+
+/**
+ * Build the BOUNDED busy-defer predicate for the idle-drain gate (F2, drain
+ * half). Returns TRUE while the drain should be DEFERRED because the session is
+ * busy (stream-render's live-turn mirror), FALSE once it is safe to drain.
+ *
+ * Why bounded: the drain must not hand a buffered represent to a session that is
+ * mid-answer (that re-queues it BEHIND the real answer → the duplicate). But a
+ * session that is WEDGED busy forever must not silence a buffered represent
+ * forever (red-team #2). So the deferral is capped: once the session has been
+ * continuously busy for longer than `boundMs`, the drain proceeds regardless. The
+ * clock resets to "not deferring" the moment the session reads idle, so an
+ * ordinary busy turn (which ends well within the bound) defers cleanly and never
+ * consumes the wedge budget.
+ *
+ * `boundMs <= 0` disables the busy-defer entirely (kill switch / parity with the
+ * background-work grace being disabled).
+ */
+export function makeSessionBusyDrainDeferral(
+  boundMs: number,
+): (busy: boolean, now: number) => boolean {
+  let deferringSince: number | null = null
+  return (busy, now) => {
+    if (!busy || boundMs <= 0) {
+      deferringSince = null
+      return false
+    }
+    if (deferringSince == null) deferringSince = now
+    // Bounded: stop deferring once we have been busy past the ceiling, so a
+    // wedged/hung session still eventually drains the buffered represent.
+    return now - deferringSince < boundMs
+  }
+}

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -279,6 +279,19 @@ export function __resetParkedTurnStartsForTest(): void {
 export function __parkedTurnStartCountForTest(): number {
   return parkedTurnStarts.length
 }
+/**
+ * Production accessor for the parked-turn-start count — the second half of the
+ * stream-render "session busy" signal (the first being a live `currentTurn`
+ * whose `endedAt == null`). A parked turn-start means the CLI has an enqueued
+ * message it is about to turn on, so the session is NOT idle even when the
+ * gateway's machine-turn gate (`turnInFlightForGate`) reads clear — the exact
+ * disagreement a ~5-min silence poke opens (it clears the machine turn while the
+ * CLI is still producing the answer). The obligation sweep and the idle-drain
+ * consult this so they do not treat a poke-cleared-but-busy session as idle.
+ */
+export function parkedTurnStartCount(): number {
+  return parkedTurnStarts.length
+}
 
 /**
  * Silence-fallback unwedge for the parked store (the two-state desync fix).

--- a/telegram-plugin/tests/pending-inbound-buffer.test.ts
+++ b/telegram-plugin/tests/pending-inbound-buffer.test.ts
@@ -815,3 +815,37 @@ describe('redeliverBufferedInbound + F1 delivery-time represent re-check', () =>
     expect(ledger.isOpen(ORIGIN)).toBe(true) // still open — the represent will be answered
   })
 })
+
+/**
+ * FAIL-OPEN safety: a `beforeRedeliver` predicate that THROWS must never silence
+ * or lose a real message, nor abort the drain loop. The throw is swallowed, the
+ * message is treated as "deliver", and every following buffered message in the
+ * same drain is still delivered. This test fails if the try/catch around the
+ * predicate is removed (the throw would propagate out of redeliverBufferedInbound).
+ */
+describe('redeliverBufferedInbound — beforeRedeliver fail-open on throw', () => {
+  it('delivers the message and the rest of the drain when the predicate throws', () => {
+    const buf = createPendingInboundBuffer({
+      log: () => {},
+      beforeRedeliver: () => {
+        throw new Error('guard boom')
+      },
+    })
+    buf.push('a', inbound('cron', 1))
+    buf.push('a', inbound('vault_grant_approved', 2))
+
+    const seen: number[] = []
+    // Must not throw — the loop completes past a throwing predicate.
+    const r = redeliverBufferedInbound(buf, 'a', (m) => {
+      seen.push(m.messageId as number)
+      return true
+    })
+
+    expect(seen).toEqual([1, 2]) // both delivered, loop not aborted
+    expect(r.drained).toBe(2)
+    expect(r.redelivered).toBe(2) // failed open → delivered, not dropped
+    expect(r.retracted).toBe(0) // a throw is NOT a retract
+    expect(r.rebuffered).toBe(0)
+    expect(buf.depth('a')).toBe(0) // nothing stranded
+  })
+})

--- a/telegram-plugin/tests/pending-inbound-buffer.test.ts
+++ b/telegram-plugin/tests/pending-inbound-buffer.test.ts
@@ -9,6 +9,8 @@
 import { describe, it, expect } from 'vitest'
 import { createPendingInboundBuffer, redeliverBufferedInbound, idleDrainTick, planBufferedRedelivery, DEFAULT_PENDING_INBOUND_CAP } from '../gateway/pending-inbound-buffer.js'
 import type { InboundMessage } from '../gateway/ipc-protocol.js'
+import { ObligationLedger } from '../gateway/obligation-ledger.js'
+import { makeRepresentRedeliveryGuard } from '../gateway/represent-delivery-guard.js'
 
 function inbound(source: string, ts = Date.now()): InboundMessage {
   return {
@@ -223,7 +225,7 @@ describe('redeliverBufferedInbound — wedge-clear self-heal (fleet-update incid
       seen.push(m.messageId as number)
       return true
     })
-    expect(r).toEqual({ drained: 2, redelivered: 2, rebuffered: 0 })
+    expect(r).toEqual({ drained: 2, redelivered: 2, rebuffered: 0, retracted: 0 })
     expect(seen).toEqual([1, 2]) // FIFO preserved
     expect(buf.depth('klanker')).toBe(0)
   })
@@ -233,7 +235,7 @@ describe('redeliverBufferedInbound — wedge-clear self-heal (fleet-update incid
     buf.push('klanker', inbound('user', 1))
     buf.push('klanker', inbound('cron', 2))
     const r = redeliverBufferedInbound(buf, 'klanker', () => false)
-    expect(r).toEqual({ drained: 2, redelivered: 0, rebuffered: 2 })
+    expect(r).toEqual({ drained: 2, redelivered: 0, rebuffered: 2, retracted: 0 })
     expect(buf.depth('klanker')).toBe(2) // still there, nothing lost
     expect(buf.drain('klanker').map((m) => m.meta?.source)).toEqual(['user', 'cron'])
   })
@@ -244,7 +246,7 @@ describe('redeliverBufferedInbound — wedge-clear self-heal (fleet-update incid
     const r = redeliverBufferedInbound(buf, 'klanker', () => {
       throw new Error('bridge write failed')
     })
-    expect(r).toEqual({ drained: 1, redelivered: 0, rebuffered: 1 })
+    expect(r).toEqual({ drained: 1, redelivered: 0, rebuffered: 1, retracted: 0 })
     expect(buf.depth('klanker')).toBe(1)
   })
 
@@ -258,7 +260,7 @@ describe('redeliverBufferedInbound — wedge-clear self-heal (fleet-update incid
       n++
       return n !== 2 // 2nd send fails
     })
-    expect(r).toEqual({ drained: 3, redelivered: 2, rebuffered: 1 })
+    expect(r).toEqual({ drained: 3, redelivered: 2, rebuffered: 1, retracted: 0 })
     expect(buf.drain('klanker').map((m) => m.meta?.source)).toEqual(['b'])
   })
 
@@ -269,7 +271,7 @@ describe('redeliverBufferedInbound — wedge-clear self-heal (fleet-update incid
       calls++
       return true
     })
-    expect(r).toEqual({ drained: 0, redelivered: 0, rebuffered: 0 })
+    expect(r).toEqual({ drained: 0, redelivered: 0, rebuffered: 0, retracted: 0 })
     expect(calls).toBe(0)
   })
 
@@ -334,7 +336,7 @@ describe('idleDrainTick — the 3rd drain trigger (finn orphan gap, 2026-05-19)'
     buf.push('finn', inbound('user', 2013)) // the orphaned "verify with mff-query.py" class
     const seen: number[] = []
     const r = idleDrainTick(buf, 'finn', () => true, (m) => { seen.push(m.messageId as number); return true })
-    expect(r).toEqual({ drained: 1, redelivered: 1, rebuffered: 0 })
+    expect(r).toEqual({ drained: 1, redelivered: 1, rebuffered: 0, retracted: 0 })
     expect(seen).toEqual([2013])
     expect(buf.depth('finn')).toBe(0)
   })
@@ -343,7 +345,7 @@ describe('idleDrainTick — the 3rd drain trigger (finn orphan gap, 2026-05-19)'
     const buf = createPendingInboundBuffer({ log: () => {} })
     buf.push('finn', inbound('user', 1))
     const r = idleDrainTick(buf, 'finn', () => true, () => false)
-    expect(r).toEqual({ drained: 1, redelivered: 0, rebuffered: 1 })
+    expect(r).toEqual({ drained: 1, redelivered: 0, rebuffered: 1, retracted: 0 })
     expect(buf.depth('finn')).toBe(1) // nothing lost
     expect(idleDrainTick(buf, '', () => true, () => true)).toBeNull() // empty agent guard
   })
@@ -419,6 +421,7 @@ describe('durable-spool integration (finn/carrie lost-on-restart fix)', () => {
       drained: 1,
       redelivered: 1,
       rebuffered: 0,
+      retracted: 0,
     })
   })
 })
@@ -589,7 +592,7 @@ describe('planBufferedRedelivery — merge-on-drain (forwarded-burst across a tu
       return true
     })
     expect(sent).toEqual(['part 1\npart 2\npart 3']) // ONE turn, not three
-    expect(r).toEqual({ drained: 3, redelivered: 3, rebuffered: 0 })
+    expect(r).toEqual({ drained: 3, redelivered: 3, rebuffered: 0, retracted: 0 })
     expect(buf.depth('ziggy')).toBe(0)
   })
 
@@ -598,7 +601,7 @@ describe('planBufferedRedelivery — merge-on-drain (forwarded-burst across a tu
     buf.push('ziggy', userMsg({ text: 'part 1', ts: 1 }))
     buf.push('ziggy', userMsg({ text: 'part 2', ts: 2 }))
     const r = redeliverBufferedInbound(buf, 'ziggy', () => false)
-    expect(r).toEqual({ drained: 2, redelivered: 0, rebuffered: 2 })
+    expect(r).toEqual({ drained: 2, redelivered: 0, rebuffered: 2, retracted: 0 })
     expect(buf.depth('ziggy')).toBe(2) // both originals back, nothing lost
     expect(buf.drain('ziggy').map((m) => m.text)).toEqual(['part 1', 'part 2'])
   })
@@ -711,5 +714,104 @@ describe('planBufferedRedelivery — seeded fuzz over random burst schedules', (
       // Whatever didn't deliver is still buffered (nothing lost).
       expect(buf.depth('fuzz')).toBe(r.rebuffered)
     }
+  })
+})
+
+/**
+ * F1 end-to-end: the delivery-time represent re-check wired into
+ * redeliverBufferedInbound via `beforeRedeliver`. These exercise the WHOLE
+ * drain path (buffer → plan → guard → send) against a real ObligationLedger,
+ * asserting OUTCOMES: a stale represent is dropped and the ledger closed; a
+ * truly-unanswered obligation fires exactly one represent.
+ */
+describe('redeliverBufferedInbound + F1 delivery-time represent re-check', () => {
+  const CHAT = 'c1'
+  const ORIGIN = 'turn-abc'
+  const OPENED_AT = 1_000
+
+  function representInbound(): InboundMessage {
+    return {
+      type: 'inbound',
+      chatId: CHAT,
+      messageId: 5_000,
+      user: 'obligation-ledger',
+      userId: 0,
+      ts: 5_000,
+      text: 'You asked earlier and I want to make sure I did not miss it…',
+      meta: { source: 'obligation_represent', origin_turn_id: ORIGIN },
+    }
+  }
+
+  function openLedger(): ObligationLedger {
+    const l = new ObligationLedger()
+    l.openIfAbsent({
+      originTurnId: ORIGIN,
+      chatId: CHAT,
+      messageId: 42,
+      text: 'original question',
+      openedAt: OPENED_AT,
+    })
+    return l
+  }
+
+  function guardFor(
+    ledger: ObligationLedger,
+    hasOutboundDeliveredSince: (chatId: string, sinceMs: number) => boolean,
+  ) {
+    return makeRepresentRedeliveryGuard({
+      enabled: true,
+      historyEnabled: true,
+      ledger,
+      hasOutboundDeliveredSince: (chatId, sinceMs) => hasOutboundDeliveredSince(chatId, sinceMs),
+      minReplyChars: 1,
+      log: () => {},
+    })
+  }
+
+  it('drops a buffered represent whose reply landed since decision, and closes the ledger', () => {
+    const ledger = openLedger()
+    // A real answer was delivered AT/AFTER the obligation's cutoff (openedAt).
+    const buf = createPendingInboundBuffer({
+      log: () => {},
+      beforeRedeliver: guardFor(ledger, (_chat, sinceMs) => sinceMs <= 2_000),
+    })
+    buf.push('a', representInbound())
+
+    let sends = 0
+    const r = redeliverBufferedInbound(buf, 'a', () => {
+      sends++
+      return true
+    })
+
+    expect(sends).toBe(0) // never handed to the CLI bridge
+    expect(r.drained).toBe(1)
+    expect(r.retracted).toBe(1)
+    expect(r.redelivered).toBe(0)
+    expect(r.rebuffered).toBe(0)
+    expect(ledger.isOpen(ORIGIN)).toBe(false) // F1 closed the stale obligation
+    expect(buf.depth('a')).toBe(0) // dropped, not re-buffered
+  })
+
+  it('delivers exactly one represent for a truly-unanswered obligation (no outbound row)', () => {
+    const ledger = openLedger()
+    // Plain-text-no-reply / genuinely unanswered: no outbound recorded since cutoff.
+    const buf = createPendingInboundBuffer({
+      log: () => {},
+      beforeRedeliver: guardFor(ledger, () => false),
+    })
+    buf.push('a', representInbound())
+
+    let sends = 0
+    const r = redeliverBufferedInbound(buf, 'a', () => {
+      sends++
+      return true
+    })
+
+    expect(sends).toBe(1)
+    expect(r.drained).toBe(1)
+    expect(r.redelivered).toBe(1)
+    expect(r.retracted).toBe(0)
+    expect(r.rebuffered).toBe(0)
+    expect(ledger.isOpen(ORIGIN)).toBe(true) // still open — the represent will be answered
   })
 })

--- a/telegram-plugin/tests/represent-guard.test.ts
+++ b/telegram-plugin/tests/represent-guard.test.ts
@@ -4,6 +4,12 @@ import {
   type RepresentGuardObligation,
 } from "../gateway/represent-guard.js";
 import { ObligationLedger } from "../gateway/obligation-ledger.js";
+import {
+  makeRepresentRedeliveryGuard,
+  makeSessionBusyDrainDeferral,
+} from "../gateway/represent-delivery-guard.js";
+import { createObligationWiring } from "../gateway/obligation-wiring.js";
+import type { InboundMessage } from "../gateway/ipc-protocol.js";
 
 // Executable verification of the #2472 fix: obligation_represent must NOT re-fire
 // for an origin_turn_id that has already been answered by a reply since the last
@@ -168,6 +174,250 @@ describe("represent guard — terse genuine reply suppresses the duplicate (#247
       hasOutboundDeliveredSince: terseReplyDeliveredAt(500, "ok".length),
     });
     expect(suppress).toBe(false);
+  });
+});
+
+// F1 (fix/represent-double-send-delivery-recheck) — the DELIVERY-time re-check.
+// The decision-time guard (shouldSuppressRepresent) is consulted when the sweep
+// buffers a represent, which can be BEFORE the reply exists. This layer re-runs it
+// at the moment the buffered represent is handed to the CLI bridge, catching the
+// reply that landed in between (the double-send race).
+describe("makeRepresentRedeliveryGuard — F1 delivery-time represent re-check", () => {
+  const MSG_ID = 42;
+
+  function representInbound(originTurnId: string, chatId: string): InboundMessage {
+    return {
+      type: "inbound",
+      chatId,
+      messageId: MSG_ID,
+      user: "switchroom",
+      userId: 0,
+      ts: 1,
+      text: "you have an earlier message…",
+      meta: { source: "obligation_represent", origin_turn_id: originTurnId, chat_id: chatId },
+    };
+  }
+
+  function openRepresented(ledger: ObligationLedger, representedAt: number, openedAt = 1000): void {
+    ledger.openIfAbsent({ originTurnId: ORIGIN, chatId: CHAT, messageId: MSG_ID, text: "q", openedAt });
+    ledger.markRepresented(ORIGIN, representedAt); // mirror the sweep stamping lastRepresentedAt
+  }
+
+  it("RETRACTS (drops + closes) a represent whose reply landed since the decision", () => {
+    const ledger = new ObligationLedger();
+    openRepresented(ledger, 2000); // sweep decided this represent at t=2000
+    // The real reply was recorded at t=3000 (AFTER the decision) but its routing
+    // missed the normal close path — the exact double-send race.
+    const guard = makeRepresentRedeliveryGuard({
+      enabled: true,
+      historyEnabled: true,
+      ledger,
+      // Chat-scoped: only the obligation's OWN (resolved) chat id has the row —
+      // outbound was recorded under the fallback-resolved id, which is o.chatId.
+      hasOutboundDeliveredSince: (chat, sinceMs) => chat === CHAT && 3000 >= sinceMs,
+      minReplyChars: 1,
+      log: () => {},
+    });
+    expect(guard(representInbound(ORIGIN, CHAT))).toBe(false); // do NOT deliver
+    expect(ledger.isOpen(ORIGIN)).toBe(false); // ledger closed by the retract
+  });
+
+  it("RETRACTS a represent whose obligation was already closed since it was buffered", () => {
+    const ledger = new ObligationLedger();
+    openRepresented(ledger, 2000);
+    ledger.close(ORIGIN); // the normal close path DID fire after buffering
+    const guard = makeRepresentRedeliveryGuard({
+      enabled: true,
+      historyEnabled: true,
+      ledger,
+      hasOutboundDeliveredSince: () => false, // irrelevant — obligation is gone
+      minReplyChars: 1,
+      log: () => {},
+    });
+    expect(guard(representInbound(ORIGIN, CHAT))).toBe(false); // stale → drop
+  });
+
+  it("PROCEEDS (delivers once) when NO outbound row exists — plain-text-no-reply (#2788)", () => {
+    const ledger = new ObligationLedger();
+    openRepresented(ledger, 2000);
+    const guard = makeRepresentRedeliveryGuard({
+      enabled: true,
+      historyEnabled: true,
+      ledger,
+      hasOutboundDeliveredSince: () => false, // the agent never called the reply tool
+      minReplyChars: 1,
+      log: () => {},
+    });
+    expect(guard(representInbound(ORIGIN, CHAT))).toBe(true); // still fires exactly once
+    expect(ledger.isOpen(ORIGIN)).toBe(true); // guard did NOT close it
+  });
+
+  it("PROCEEDS when the only reply PREDATES lastRepresentedAt (#2472 second-represent cutoff)", () => {
+    const ledger = new ObligationLedger();
+    openRepresented(ledger, 5000); // second represent decided at t=5000
+    // A reply exists but only at t=3000 — it answered an EARLIER question, not
+    // this represent. The delivery re-check must use the obligation's own cutoff
+    // (lastRepresentedAt=5000), so this old reply does NOT suppress.
+    const guard = makeRepresentRedeliveryGuard({
+      enabled: true,
+      historyEnabled: true,
+      ledger,
+      hasOutboundDeliveredSince: (_chat, sinceMs) => 3000 >= sinceMs,
+      minReplyChars: 1,
+      log: () => {},
+    });
+    expect(guard(representInbound(ORIGIN, CHAT))).toBe(true); // legitimate new represent fires
+    expect(ledger.isOpen(ORIGIN)).toBe(true);
+  });
+
+  it("passes NON-represent inbounds through untouched", () => {
+    const ledger = new ObligationLedger();
+    openRepresented(ledger, 2000);
+    const guard = makeRepresentRedeliveryGuard({
+      enabled: true,
+      historyEnabled: true,
+      ledger,
+      hasOutboundDeliveredSince: () => true, // would suppress a represent — but this isn't one
+      minReplyChars: 1,
+      log: () => {},
+    });
+    const userMsg: InboundMessage = {
+      type: "inbound",
+      chatId: CHAT,
+      messageId: 7,
+      user: "ken",
+      userId: 1,
+      ts: 1,
+      text: "hello",
+    };
+    expect(guard(userMsg)).toBe(true);
+    expect(ledger.isOpen(ORIGIN)).toBe(true);
+  });
+
+  it("is inert when the obligation ledger is disabled", () => {
+    const ledger = new ObligationLedger();
+    openRepresented(ledger, 2000);
+    const guard = makeRepresentRedeliveryGuard({
+      enabled: false,
+      historyEnabled: true,
+      ledger,
+      hasOutboundDeliveredSince: () => true,
+      minReplyChars: 1,
+      log: () => {},
+    });
+    expect(guard(representInbound(ORIGIN, CHAT))).toBe(true); // never retracts when off
+  });
+});
+
+// F2 (fix/represent-double-send-delivery-recheck) — a poke-cleared session that is
+// STILL busy must not be treated as idle. Two halves: the bounded drain-defer
+// (drain half) and the sweep decision folding session-busy into the bounded
+// background-work grace (decision half).
+describe("makeSessionBusyDrainDeferral — F2 bounded busy-defer for the idle drain", () => {
+  it("defers while busy, then STOPS deferring once the bound elapses (red-team #2: no forever-silence)", () => {
+    const defer = makeSessionBusyDrainDeferral(1000);
+    expect(defer(true, 0)).toBe(true); // busy → defer the drain
+    expect(defer(true, 500)).toBe(true); // still within the bound
+    expect(defer(true, 999)).toBe(true);
+    expect(defer(true, 1000)).toBe(false); // bound reached → drain anyway (bounded)
+  });
+
+  it("resets the deferral clock whenever the session reads idle", () => {
+    const defer = makeSessionBusyDrainDeferral(1000);
+    expect(defer(true, 0)).toBe(true);
+    expect(defer(false, 400)).toBe(false); // idle → reset
+    expect(defer(true, 500)).toBe(true); // fresh window opens at 500
+    expect(defer(true, 1499)).toBe(true); // 999ms into the new window
+    expect(defer(true, 1500)).toBe(false); // new bound elapsed
+  });
+
+  it("is disabled when the bound is <= 0 (kill switch)", () => {
+    const off = makeSessionBusyDrainDeferral(0);
+    expect(off(true, 0)).toBe(false);
+    expect(off(true, 10_000)).toBe(false);
+  });
+});
+
+describe("obligationSweep — F2 decision half: a poke-cleared-but-busy session defers, then re-asks (bounded)", () => {
+  const GRACE = 20 * 60_000;
+  const SWEEP_ORIGIN = "12345:_#77001";
+
+  function makeWiring(opts: { ledger: ObligationLedger; pushed: InboundMessage[]; sessionBusy: boolean }) {
+    const liveTurn = opts.sessionBusy ? ({ turnId: "live", endedAt: null } as any) : null;
+    const deps = {
+      OBLIGATION_LEDGER_ENABLED: true,
+      HISTORY_ENABLED: true,
+      OBLIGATION_BACKGROUND_WORK_GRACE_MS: GRACE,
+      OBLIGATION_ESCALATE_GRACE_MS: 0,
+      OBLIGATION_REPRESENT_GRACE_MS: 0,
+      OBLIGATION_REPRESENT_MAX: 2,
+      OBLIGATION_REPRESENT_GUARD_MIN_REPLY_CHARS: 1,
+      OBLIGATION_ESCALATE_MAX: 3,
+      OBLIGATION_ESCALATE_SEND_DEADLINE_MS: 10_000,
+      obligationLedger: opts.ledger,
+      obligationEscalateInFlight: new Set<string>(),
+      pendingCrossTurnGate: { set: () => {} },
+      pendingInboundBuffer: {
+        depth: () => 0,
+        push: (_agent: string, m: InboundMessage) => {
+          opts.pushed.push(m);
+          return true;
+        },
+      },
+      capturedResume: { dispatch: () => {} },
+      getCurrentTurn: () => liveTurn,
+      // The ~5-min silence poke has ALREADY cleared the machine turn.
+      turnInFlightForGate: () => false,
+      agentHasInFlightBackgroundWork: () => false,
+      // No reply has been delivered — a genuinely unanswered turn.
+      hasOutboundDeliveredSince: () => false,
+      findTurnByOriginId: () => undefined,
+      bridgeAlive: () => true,
+      sendEscalationNudge: () => {},
+    };
+    // The wiring's dep type is derived from the gateway; the shape above matches
+    // the fields the sweep reads.
+    return createObligationWiring(deps as unknown as Parameters<typeof createObligationWiring>[0]);
+  }
+
+  function open(ledger: ObligationLedger, openedAt: number): void {
+    ledger.openIfAbsent({
+      originTurnId: SWEEP_ORIGIN,
+      chatId: CHAT,
+      messageId: 77001,
+      text: "an unanswered question",
+      openedAt,
+    });
+  }
+
+  it("DEFERS the represent while the session is busy and the obligation is younger than the grace", () => {
+    const ledger = new ObligationLedger(2);
+    const pushed: InboundMessage[] = [];
+    const wiring = makeWiring({ ledger, pushed, sessionBusy: true });
+    open(ledger, Date.now()); // age ~0 < GRACE
+    wiring.obligationSweep();
+    expect(pushed).toHaveLength(0); // deferred — no represent buffered
+    expect(ledger.isOpen(SWEEP_ORIGIN)).toBe(true);
+  });
+
+  it("RE-ASKS once the bound expires even though the session is still busy (bounded, not silent)", () => {
+    const ledger = new ObligationLedger(2);
+    const pushed: InboundMessage[] = [];
+    const wiring = makeWiring({ ledger, pushed, sessionBusy: true });
+    open(ledger, Date.now() - (GRACE + 60_000)); // age > GRACE → bound expired
+    wiring.obligationSweep();
+    expect(pushed).toHaveLength(1); // represent fires despite the still-busy session
+    expect(pushed[0]?.meta?.source).toBe("obligation_represent");
+  });
+
+  it("does NOT defer when the session is idle (represent fires immediately)", () => {
+    const ledger = new ObligationLedger(2);
+    const pushed: InboundMessage[] = [];
+    const wiring = makeWiring({ ledger, pushed, sessionBusy: false });
+    open(ledger, Date.now()); // young, but session is genuinely idle
+    wiring.obligationSweep();
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0]?.meta?.source).toBe("obligation_represent");
   });
 });
 


### PR DESCRIPTION
## Problem
An `obligation_represent` can be queued to the live CLI session at **decision** time (the sweep), then consumed by the model **after** a genuine reply has since landed → the user gets a near-duplicate answer. Trigger: a ~5-minute silence poke fires `clearTurnStarted` while the model is still working, so the sweep sees an "idle" session, the guard correctly reports "not answered yet" (nothing sent at that instant), buffers the represent, and idle-drain flushes it into the session queue. The real answer lands ~13s later; the model then processes the already-queued represent and answers twice. The guard never failed — it was consulted before the reply existed, with no re-check between decision → delivery → consumption.

## Fix
- **F1 (core)** — new `represent-delivery-guard.ts` (`makeRepresentRedeliveryGuard`) wired as the pending-inbound buffer's `beforeRedeliver` predicate, so it covers every drain path by construction. Before delivering a buffered `obligation_represent`, re-run `shouldSuppressRepresent` with the current clock and the obligation's own cutoff (`openedAt` first represent, `lastRepresentedAt` after). Reply landed since cutoff, or obligation already closed → drop, close ledger, log retract.
- **F2** — the sweep (`obligation-wiring.ts`) and idle-drain (`gateway.ts`) fold in stream-render's session-busy signal (`getCurrentTurn()?.endedAt == null || parkedTurnStartCount() > 0`) so a poke-cleared-but-still-busy session isn't treated as idle. **Bounded** by `OBLIGATION_BACKGROUND_WORK_GRACE_MS` (20m) so a wedged session still eventually re-asks.
- **F3** — suppression only; no fuzzy edit-merge of the two messages.

## Not regressed (tested)
- Plain-text-no-reply (no outbound row) still fires exactly one represent.
- Bounded busy-defer — a hung session is not silenced forever.
- Second-represent cutoff preserved (old reply to a different question does not suppress a new represent).

## Verification
148 scoped tests pass (represent-guard + pending-inbound-buffer + obligation-ledger). `npm run lint` clean, gateway line-ratchet respected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)