### PR TITLE
chore: bump Claude CLI pin 2.1.219 → 2.1.221

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## Unreleased
+
+### Claude CLI pinned 2.1.219 → 2.1.221
+
+The base image and the hindsight memory-provider image now pin claude-code
+**2.1.221** (up from 2.1.219), and `dependencies.json` records the same set as
+tested together at delivery time. All three pins move in lockstep (#1978): the
+agent/scheduler containers, the hindsight reflection sidecar, and the manifest
+that `switchroom doctor`/`switchroom versions` compares installed versions
+against.
+
+The motivating upstream fixes across 2.1.220 (bug-fixes-only) and 2.1.221:
+
+- **Bash-tool permission-check bypass closed (security).** A crafted command
+  could execute hidden commands inside a zsh `[[ ]]` regex conditional without
+  going through the permission check; the tool now prompts on them. This is the
+  security-relevant one for a prompt-injectable, always-on agent fleet, where
+  the permission boundary is load-bearing.
+- **Auto-mode permission checks made prompt-cache-efficient.** Lower token spend
+  on the auto-accept path the fleet runs by default.
+- **MCP `--mcp-config` servers now connect before the first turn in `-p` print
+  mode**, so a print-mode invocation no longer races its own MCP servers.
+- **Crash fix for SDK MCP tools named after built-ins** (e.g. a tool named
+  `constructor`), which previously threw on prototype-key collisions.
+
+### Obligation represent re-checked at delivery time (duplicate-answer fix)
+
+An `obligation_represent` decided and queued to the live session at decision
+time could be consumed by the model after a real reply had already landed,
+producing a duplicate answer. The trigger was a silence poke clearing a turn
+that was in fact still working: the represent was authored against the state at
+decision time and then delivered into a session where the answer had since
+arrived. The guard is now re-checked at delivery time and folds a bounded
+session-busy signal into the idle decision, so a represent whose antecedent
+answer has already been delivered is dropped rather than replayed. The
+redeliver predicate fails open — if the busy/idle signal can't be resolved,
+delivery still proceeds — so the fix removes the duplicate without introducing
+a new silent-drop path. (Covers PR #4341, which merged without its own
+changelog entry.)
+
 ## v0.20.6 — Telegram pin cleanup self-heals again: the boot sweep reseeds its discharged cursor
 
 Reliability fix (2026-08-04): pinned-message cleanup that silently stopped

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,12 +1,12 @@
 {
   "switchroom_version": "0.7.3",
-  "tested_at": "2026-07-25T08:35:00+10:00",
+  "tested_at": "2026-08-04T18:45:00+10:00",
   "runtime": {
     "bun": "1.3.13",
     "node": "22.22.2"
   },
   "claude": {
-    "cli": "2.1.219"
+    "cli": "2.1.221"
   },
   "playwright_mcp": "0.0.71",
   "hindsight": {

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -154,7 +154,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # (`--build-arg CLAUDE_CODE_VERSION=<latest>`) to build a throwaway image on the
 # next version and prove it boots BEFORE the pin is bumped. Keep this default in
 # lockstep with docker/Dockerfile.hindsight's CLAUDE_CODE_VERSION (#1978).
-ARG CLAUDE_CODE_VERSION=2.1.219
+ARG CLAUDE_CODE_VERSION=2.1.221
 # Fail-fast: if the npm install or the resulting binary is broken we
 # want the image build to die here, not produce a base that ships
 # downstream and explodes at agent boot. Previously this had a

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -94,7 +94,7 @@ USER root
 # claude bundle as the agent containers — a version skew here could reintroduce
 # the thinking-block / thinking-effort class of failures on memory reflection
 # (see #1978). The canary overrides it the same way base does.
-ARG CLAUDE_CODE_VERSION=2.1.219
+ARG CLAUDE_CODE_VERSION=2.1.221
 RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
  && claude --version >&2
 


### PR DESCRIPTION
## Summary

Bumps the production claude-code pin **2.1.219 → 2.1.221** across all three lockstep locations, plus a CHANGELOG entry for v0.20.7 that also back-documents PR #4341 (merged without its own entry).

**Pin bump (3 files, must stay in lockstep — #1978):**
- `docker/Dockerfile.base` — `ARG CLAUDE_CODE_VERSION=2.1.221`
- `docker/Dockerfile.hindsight` — `ARG CLAUDE_CODE_VERSION=2.1.221`
- `dependencies.json` — `claude.cli = "2.1.221"`, and `tested_at` refreshed to `2026-08-04T18:45:00+10:00` (the field records when the version set was last validated together; the release pipeline builds+boots this set at delivery).

**CHANGELOG — new `## Unreleased` section, two subsections:**
- *Claude CLI pinned 2.1.219 → 2.1.221* — notable upstream fixes: Bash-tool permission-check bypass (zsh hidden commands in `[[ ]]` regex conditionals now prompt — the security-relevant one for a prompt-injectable fleet); auto-mode permission checks made prompt-cache-efficient; MCP `--mcp-config` servers connect before the first turn in `-p` print mode; crash fix for SDK MCP tools named after built-ins like `constructor`. (2.1.220 was bug-fixes-only.)
- *Obligation represent re-checked at delivery time (duplicate-answer fix)* — documents PR #4341: an `obligation_represent` queued at decision time could be consumed after a real reply had landed (a silence poke clearing a still-working turn was the trigger), producing a duplicate answer; the guard is now re-checked at delivery time and folds a bounded session-busy signal into the idle decision, with the redeliver predicate failing open.

## Why

Feeds the imminent v0.20.7 release. 2.1.221 closes a Bash-tool permission bypass that matters for an always-on, prompt-injectable agent fleet.

## Test plan

- `npx vitest run tests/manifest.test.ts tests/doctor-claude-cli.test.ts` → 48 passed (includes the "Dockerfile.base pin ≥ #1978 floor" test that reads the real Dockerfile).
- `npx vitest run src/config/thinking-effort-risk.test.ts tests/doctor.test.ts` → 68 passed / 2 skipped.
- `npm run lint` → fully green (tsc + all 24 guard scripts).

## Risk

Low. Config-only bump; no TypeScript touched. No test asserts Dockerfile↔dependencies.json equality, but all three are moved together for lockstep discipline and doctor's runtime drift probe. CI (`images-ok`, `vitest`, `lint`) is the full authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)