### PR TITLE
fix(hindsight): offload temporal extraction off the event loop and bound its input

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -141,6 +141,8 @@ jobs:
               - 'tests/docker/hindsight-recall-budget-reflect-grounding-patches.test.ts'
               - 'tests/docker/hindsight-reranker-priority-patch.test.ts'
               - 'tests/docker/hindsight-work-conserving-admission-patch.test.ts'
+              - 'tests/docker/hindsight-temporal-language-patch.test.ts'
+              - 'tests/docker/hindsight-temporal-offload-patch.test.ts'
               - 'tests/docker/dockerfile-hindsight-bakes.test.ts'
               - '.github/workflows/docker-e2e.yml'
 
@@ -502,6 +504,34 @@ jobs:
           SWITCHROOM_HINDSIGHT_BUILT_IMAGE: switchroom-hindsight:probe
         run: npx vitest run tests/docker/hindsight-work-conserving-admission-patch.test.ts
 
+      - name: Run the hindsight temporal-language probe (RED/GREEN, must not skip)
+        # Same contract, for the #4313 dateparser language-pin patch. The bakes
+        # test cannot cover the failure that matters here: its assertions are
+        # grep-on-file, so reverting the `languages=` pin on the search_dates
+        # call stays green there while every recall again auto-detects across
+        # 200+ locales inline on the shared asyncio loop. Only capturing the
+        # real search_dates call's kwargs (and confirming English extraction
+        # still parses under the pin) catches it. Runs against the raw pinned
+        # upstream image, applying the patch block by `docker exec`.
+        env:
+          SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
+        run: npx vitest run tests/docker/hindsight-temporal-language-patch.test.ts
+
+      - name: Run the hindsight temporal-offload probe (RED/GREEN, must not skip)
+        # Same contract, for the temporal-offload patch (this PR). The bakes
+        # test cannot cover the outcome that matters here: its assertions are
+        # grep-on-file, so a `run_in_executor` wrapper that exists but is never
+        # awaited at the call site — or a char cap wired but never applied —
+        # stays green there while temporal extraction again blocks the shared
+        # asyncio loop for seconds. Only an asyncio loop-lag probe (max
+        # inter-tick gap while a real ≥150ms extraction runs off-loop) catches
+        # it. RED applies only #4313 (sync-inline blocks the loop ≈ full parse);
+        # GREEN applies #4313 + this block (gap stays tiny, cap bounds cost).
+        # Both arms run against the raw pinned upstream image via `docker exec`.
+        env:
+          SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
+        run: npx vitest run tests/docker/hindsight-temporal-offload-patch.test.ts
+
       - name: Run the embedded-postgres fsync probe (RED/GREEN, must not skip)
         # NOT a patch probe: this one boots the REAL docker/hindsight-entrypoint.sh
         # inside the pinned image and reads `SHOW fsync` off the server it
@@ -521,7 +551,7 @@ jobs:
       - name: Label-scoped teardown
         if: always()
         run: |
-          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-mm-refresh-debounce-patch hindsight-graph-seed-retirement hindsight-maxitems-grammar-patch hindsight-reflect-directives-patch hindsight-recall-budget-reflect-grounding hindsight-reranker-priority-patch hindsight-pg-fsync-probe; do
+          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-mm-refresh-debounce-patch hindsight-graph-seed-retirement hindsight-maxitems-grammar-patch hindsight-reflect-directives-patch hindsight-recall-budget-reflect-grounding hindsight-reranker-priority-patch hindsight-temporal-language-patch hindsight-temporal-offload-patch hindsight-pg-fsync-probe; do
             ids=$(docker ps -aq --filter "label=switchroom.test=$phase" 2>/dev/null || true)
             if [ -n "$ids" ]; then docker rm -f $ids 2>/dev/null || true; fi
           done

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -3987,6 +3987,330 @@ print(
 )
 PYEOF
 
+# --- switchroom: run temporal extraction off the event loop and bound its input ---
+#
+# The #4313 language pin above cut dateparser's PER-LOCALE cost, but it cannot
+# bound the PER-CALL cost on unbounded input. `dateparser.search_dates()` is
+# synchronous, pure-Python CPU work whose cost is linear in input length x date
+# density, and it ran INLINE on the single shared asyncio loop:
+#
+#   retrieval.py retrieve_all_fact_types_parallel() (an async def) called
+#   extract_temporal_constraint() -> temporal_extraction.py ->
+#   query_analyzer.py analyze() -> search_dates(...) synchronously, BEFORE any
+#   await. The consolidation caller (consolidator.py, query=m["text"]) passes
+#   full multi-KB memory text, so one extraction blocked recall + consolidation
+#   + reranker together for seconds: 186 `EVENT LOOP BLOCKED` events in 4.5h,
+#   p50 1.36s, max 14.95s (measured: 16KB date-dense text ~988ms).
+#
+# This patch does two things:
+#
+#  (a) OFF-LOOP. temporal_extraction.py gains a module-level
+#      ThreadPoolExecutor(max_workers=1) and an async
+#      extract_temporal_constraint_async() that runs the existing sync function
+#      via loop.run_in_executor; retrieval.py's single async call site awaits it.
+#      Deliberately ONE worker: dateparser's module-level caches are not
+#      documented thread-safe, so serialising extractions removes that concern
+#      and bounds temporal CPU to a single core. HONEST CAVEAT: dateparser is
+#      pure-Python + `re`, so the worker holds the GIL during matching -- this
+#      does NOT fully free the loop, it collapses a multi-second uninterruptible
+#      stall into ~5ms scheduler slices (sys.setswitchinterval granularity).
+#
+#  (b) BOUND THE INPUT. A new config knob, HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS
+#      (default 2000, 0 = unlimited), wired exactly like the #4313 language knob,
+#      truncates the query fed to search_dates in analyze(). Correctness: the
+#      temporal constraint gates only ONE of four retrieval arms
+#      (retrieve_temporal_combined); semantic/BM25/graph see the full query.
+#      Live recall-hook queries are short and never hit the cap; only multi-KB
+#      consolidation queries lose date matches past char 2000.
+#
+# The #4313 language pin (`languages=self._languages` on the search_dates call)
+# MUST survive this patch -- a verification assert below pins it. Runs AFTER the
+# #4313 block, so its anchors are the post-#4313 file state.
+#
+# Self-verifying; guarded structurally by
+# tests/docker/dockerfile-hindsight-bakes.test.ts and behaviourally (RED against
+# the sync path / GREEN off-loop + bounded) by
+# tests/docker/hindsight-temporal-offload-patch.test.ts.
+RUN python3 - <<'PYEOF'
+import ast
+import pathlib
+
+BASE = pathlib.Path("/app/api/hindsight_api")
+
+
+def apply(rel, edits):
+    f = BASE / rel
+    s = f.read_text()
+    for anchor, repl in edits:
+        n = s.count(anchor)
+        assert n == 1, (
+            f"switchroom hindsight temporal-offload patch: anchor found {n}x "
+            f"(expected 1) in {rel} — upstream reformatted; re-author this patch in "
+            f"docker/Dockerfile.hindsight. Anchor head: {anchor.splitlines()[0]!r}"
+        )
+        s = s.replace(anchor, repl, 1)
+    f.write_text(s)
+    return s
+
+
+# ---- 1. config.py: the HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS knob (default 2000) ----
+cfg = apply("config.py", [
+    (
+        'ENV_TEMPORAL_LANGUAGES = "HINDSIGHT_API_TEMPORAL_LANGUAGES"\n',
+        'ENV_TEMPORAL_LANGUAGES = "HINDSIGHT_API_TEMPORAL_LANGUAGES"\n'
+        "# switchroom: max chars of query text fed to dateparser.search_dates()\n"
+        "# during temporal analysis (0 = unlimited). Bounds the per-call cost of\n"
+        "# the (now off-loop) extraction on multi-KB consolidation queries.\n"
+        'ENV_TEMPORAL_MAX_QUERY_CHARS = "HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS"\n',
+    ),
+    (
+        'DEFAULT_TEMPORAL_LANGUAGES = "en"\n',
+        'DEFAULT_TEMPORAL_LANGUAGES = "en"\n'
+        "# switchroom: 2000 chars is far above any live recall-hook query yet well\n"
+        "# below the multi-KB consolidation text that made search_dates block for\n"
+        "# seconds. 0 disables the cap (full-scan).\n"
+        "DEFAULT_TEMPORAL_MAX_QUERY_CHARS = 2000\n",
+    ),
+    (
+        "    temporal_languages: list[str]  # switchroom: dateparser language pin (default ['en'])\n",
+        "    temporal_languages: list[str]  # switchroom: dateparser language pin (default ['en'])\n"
+        "    temporal_max_query_chars: int  # switchroom: cap on search_dates input (0 = unlimited)\n",
+    ),
+    (
+        "            temporal_languages=_parse_str_list(\n"
+        "                os.getenv(ENV_TEMPORAL_LANGUAGES, DEFAULT_TEMPORAL_LANGUAGES)\n"
+        '            ) or ["en"],\n',
+        "            temporal_languages=_parse_str_list(\n"
+        "                os.getenv(ENV_TEMPORAL_LANGUAGES, DEFAULT_TEMPORAL_LANGUAGES)\n"
+        '            ) or ["en"],\n'
+        "            # switchroom: non-negative int (0 = unlimited); reuses upstream's\n"
+        "            # fail-fast parser so a malformed value stops boot rather than\n"
+        "            # silently disabling the cap.\n"
+        "            temporal_max_query_chars=_parse_non_negative_int(\n"
+        "                ENV_TEMPORAL_MAX_QUERY_CHARS,\n"
+        "                os.getenv(ENV_TEMPORAL_MAX_QUERY_CHARS),\n"
+        "                DEFAULT_TEMPORAL_MAX_QUERY_CHARS,\n"
+        "            ),\n",
+    ),
+])
+
+# ---- 2. query_analyzer.py: resolve the cap and truncate the search_dates input ----
+qa = apply("engine/query_analyzer.py", [
+    (
+        "        if langs:\n"
+        "            return langs\n"
+        "    except Exception:\n"
+        "        pass\n"
+        '    return ["en"]\n',
+        "        if langs:\n"
+        "            return langs\n"
+        "    except Exception:\n"
+        "        pass\n"
+        '    return ["en"]\n'
+        "\n"
+        "\n"
+        "def _resolve_temporal_max_query_chars() -> int:\n"
+        '    """switchroom: max chars fed to dateparser.search_dates (0 = unlimited).\n'
+        "\n"
+        "    Read from HindsightConfig.temporal_max_query_chars\n"
+        "    (HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS, default 2000). Defensive: if config\n"
+        "    is not yet loaded (analyzer constructed in isolation), fall back to 2000 so\n"
+        "    an unbounded multi-KB consolidation query can never reach search_dates\n"
+        "    unclamped.\n"
+        '    """\n'
+        "    try:\n"
+        "        from hindsight_api.config import get_config\n"
+        "\n"
+        "        n = int(get_config().temporal_max_query_chars)\n"
+        "        if n >= 0:\n"
+        "            return n\n"
+        "    except Exception:\n"
+        "        pass\n"
+        "    return 2000\n",
+    ),
+    (
+        "        self._languages = _resolve_temporal_languages()\n",
+        "        self._languages = _resolve_temporal_languages()\n"
+        "        # switchroom: cap the chars handed to dateparser.search_dates (0 = off).\n"
+        "        self._max_query_chars = _resolve_temporal_max_query_chars()\n",
+    ),
+    (
+        "        try:\n"
+        "            results = self._search_dates(query, settings=settings, languages=self._languages)\n",
+        "        # switchroom: bound the text handed to dateparser.search_dates. Its cost\n"
+        "        # is linear in input length x date density; a multi-KB consolidation query\n"
+        "        # could otherwise block the (now off-loop) worker for seconds. Live recall\n"
+        "        # queries are short and never hit the cap. 0 = unlimited (full-scan). Only\n"
+        "        # the temporal retrieval arm sees this truncation; semantic/BM25/graph get\n"
+        "        # the full query text upstream.\n"
+        "        search_query = query\n"
+        "        if self._max_query_chars and len(search_query) > self._max_query_chars:\n"
+        "            search_query = search_query[: self._max_query_chars]\n"
+        "\n"
+        "        try:\n"
+        "            results = self._search_dates(search_query, settings=settings, languages=self._languages)\n",
+    ),
+])
+
+# ---- 3. temporal_extraction.py: single-worker executor + async wrapper ----
+te = apply("engine/search/temporal_extraction.py", [
+    (
+        "import logging\n"
+        "from datetime import datetime\n"
+        "\n"
+        "from hindsight_api.engine.query_analyzer import DateparserQueryAnalyzer, QueryAnalyzer\n"
+        "\n"
+        "logger = logging.getLogger(__name__)\n",
+        "import asyncio\n"
+        "import functools\n"
+        "import logging\n"
+        "from concurrent.futures import ThreadPoolExecutor\n"
+        "from datetime import datetime\n"
+        "\n"
+        "from hindsight_api.engine.query_analyzer import DateparserQueryAnalyzer, QueryAnalyzer\n"
+        "\n"
+        "logger = logging.getLogger(__name__)\n"
+        "\n"
+        "# switchroom: dateparser.search_dates() is synchronous, pure-Python CPU work.\n"
+        "# It historically ran INLINE on the single shared asyncio loop from\n"
+        "# retrieve_all_fact_types_parallel() (retrieval.py), blocking recall +\n"
+        "# consolidation + reranker together: 186 `EVENT LOOP BLOCKED` events in 4.5h\n"
+        "# (p50 1.36s, max 14.95s). Offload it to a dedicated worker thread so the\n"
+        "# loop keeps ticking while an extraction runs.\n"
+        "#\n"
+        "# Deliberately max_workers=1: dateparser's module-level caches are not\n"
+        "# documented thread-safe, so serialising every extraction removes that\n"
+        "# concern and bounds temporal CPU to a single core. HONEST CAVEAT: dateparser\n"
+        "# is pure-Python + `re`, so the worker holds the GIL during matching -- this\n"
+        "# does NOT fully free the loop, it collapses a multi-second uninterruptible\n"
+        "# stall into ~5ms scheduler slices (sys.setswitchinterval granularity). The\n"
+        "# HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS input cap bounds the residual.\n"
+        '_temporal_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="hindsight-temporal")\n',
+    ),
+    (
+        "    if analysis.temporal_constraint:\n"
+        "        result = (analysis.temporal_constraint.start_date, analysis.temporal_constraint.end_date)\n"
+        "        return result\n"
+        "\n"
+        "    return None\n",
+        "    if analysis.temporal_constraint:\n"
+        "        result = (analysis.temporal_constraint.start_date, analysis.temporal_constraint.end_date)\n"
+        "        return result\n"
+        "\n"
+        "    return None\n"
+        "\n"
+        "\n"
+        "async def extract_temporal_constraint_async(\n"
+        "    query: str,\n"
+        "    reference_date: datetime | None = None,\n"
+        "    analyzer: QueryAnalyzer | None = None,\n"
+        ") -> tuple[datetime, datetime] | None:\n"
+        '    """switchroom: off-loop wrapper for extract_temporal_constraint().\n'
+        "\n"
+        "    Runs the synchronous dateparser extraction on the dedicated single-worker\n"
+        "    _temporal_executor via loop.run_in_executor, so the shared asyncio loop is\n"
+        "    not blocked for the full parse duration. Identical return contract to the\n"
+        "    sync function: (start_date, end_date) or None.\n"
+        '    """\n'
+        "    loop = asyncio.get_running_loop()\n"
+        "    return await loop.run_in_executor(\n"
+        "        _temporal_executor,\n"
+        "        functools.partial(\n"
+        "            extract_temporal_constraint,\n"
+        "            query,\n"
+        "            reference_date=reference_date,\n"
+        "            analyzer=analyzer,\n"
+        "        ),\n"
+        "    )\n",
+    ),
+])
+
+# ---- 4. retrieval.py: await the off-loop wrapper at the single async call site ----
+rt = apply("engine/search/retrieval.py", [
+    (
+        "    from .temporal_extraction import extract_temporal_constraint\n",
+        "    from .temporal_extraction import extract_temporal_constraint_async\n",
+    ),
+    (
+        "    temporal_constraint = extract_temporal_constraint(query_text, reference_date=question_date, analyzer=query_analyzer)\n",
+        "    temporal_constraint = await extract_temporal_constraint_async(query_text, reference_date=question_date, analyzer=query_analyzer)\n",
+    ),
+])
+
+# ---- verification ----
+# (a) config knob wired end to end: env name, default, dataclass field, from_env.
+assert 'ENV_TEMPORAL_MAX_QUERY_CHARS = "HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS"' in cfg, (
+    "switchroom hindsight temporal-offload patch: ENV name missing after patch"
+)
+assert "DEFAULT_TEMPORAL_MAX_QUERY_CHARS = 2000" in cfg, (
+    "switchroom hindsight temporal-offload patch: default missing after patch"
+)
+assert "    temporal_max_query_chars: int" in cfg, (
+    "switchroom hindsight temporal-offload patch: dataclass field missing after patch"
+)
+assert "temporal_max_query_chars=_parse_non_negative_int(" in cfg, (
+    "switchroom hindsight temporal-offload patch: from_env wiring missing after patch"
+)
+
+# (b) analyzer resolves the cap and truncates BEFORE search_dates.
+assert "def _resolve_temporal_max_query_chars() -> int:" in qa, (
+    "switchroom hindsight temporal-offload patch: cap resolver missing after patch"
+)
+assert "self._max_query_chars = _resolve_temporal_max_query_chars()" in qa, (
+    "switchroom hindsight temporal-offload patch: analyzer does not resolve its char cap"
+)
+assert "search_query = search_query[: self._max_query_chars]" in qa, (
+    "switchroom hindsight temporal-offload patch: analyze() does not truncate the input"
+)
+# The RED guard: the untruncated call must be GONE from analyze() — this is what
+# would fail if the cap were not actually wired into the search_dates call.
+assert qa.count("self._search_dates(query, settings=settings, languages=self._languages)") == 0, (
+    "switchroom hindsight temporal-offload patch: analyze() still passes the FULL "
+    "query to search_dates — the char cap is not wired in"
+)
+# …and the #4313 language pin MUST survive: the truncated call still carries it.
+assert "self._search_dates(search_query, settings=settings, languages=self._languages)" in qa, (
+    "switchroom hindsight temporal-offload patch: #4313 language pin lost — the "
+    "search_dates call no longer carries languages=self._languages"
+)
+
+# (c) off-loop machinery present.
+assert 'ThreadPoolExecutor(max_workers=1, thread_name_prefix="hindsight-temporal")' in te, (
+    "switchroom hindsight temporal-offload patch: single-worker executor missing"
+)
+assert "async def extract_temporal_constraint_async(" in te, (
+    "switchroom hindsight temporal-offload patch: async wrapper missing"
+)
+assert "loop.run_in_executor(" in te, (
+    "switchroom hindsight temporal-offload patch: wrapper does not offload via run_in_executor"
+)
+# The sync entry point must still exist — the wrapper delegates to it.
+assert "def extract_temporal_constraint(" in te, (
+    "switchroom hindsight temporal-offload patch: sync extract_temporal_constraint removed"
+)
+
+# (d) the single async call site now awaits the off-loop wrapper; the inline
+# sync call must be GONE (the RED guard for the off-loop change).
+assert "await extract_temporal_constraint_async(query_text" in rt, (
+    "switchroom hindsight temporal-offload patch: retrieval call site not awaited off-loop"
+)
+assert rt.count("temporal_constraint = extract_temporal_constraint(query_text") == 0, (
+    "switchroom hindsight temporal-offload patch: retrieval still calls extract_temporal_constraint "
+    "synchronously on the loop"
+)
+
+ast.parse(cfg)
+ast.parse(qa)
+ast.parse(te)
+ast.parse(rt)
+print(
+    "switchroom hindsight temporal-offload patch: temporal extraction runs on a "
+    "single-worker ThreadPoolExecutor off the shared asyncio loop, its input bounded "
+    "by HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS (default 2000); the #4313 language pin "
+    "is preserved"
+)
+PYEOF
+
 # Pin the upstream `hindsight` user to UID 11000 to match
 # `HINDSIGHT_DEFAULT_UID` in src/setup/hindsight.ts (and the
 # `auth.consumers[hindsight].uid` value the operator writes in

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2978,7 +2978,14 @@ export const HindsightConfigSchema = z.object({
       "temporal-language image patch (which ended a 200+-locale auto-detection " +
       "pass that blocked the shared asyncio loop on every recall); " +
       "comma-separated, unset means the image's baked `en`, set e.g. `en,es` to " +
-      "restore i18n parsing), plus the " +
+      "restore i18n parsing; and " +
+      "HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS — the max chars of query text " +
+      "dateparser.search_dates() is handed during temporal analysis (0 = " +
+      "unlimited), made live by switchroom's temporal-offload image patch " +
+      "(which moved the synchronous extraction off the shared asyncio loop onto " +
+      "a single-worker thread and bounds its input, ending multi-second loop " +
+      "stalls on multi-KB consolidation queries); unset means the image's baked " +
+      "2000, set 0 to restore an unbounded full scan), plus the " +
       "embedded-PostgreSQL (pg0) sizing keys switchroom manages in " +
       "src/setup/hindsight-pg-defaults.ts (`HINDSIGHT_PG_ENV_KEYS`: " +
       "SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE, " +

--- a/src/setup/hindsight-perf-defaults.test.ts
+++ b/src/setup/hindsight-perf-defaults.test.ts
@@ -351,7 +351,7 @@ describe("operator override wins", () => {
     expect(got.size).toBe(0);
   });
 
-  it("is overridable on exactly these forty-seven keys, by name", () => {
+  it("is overridable on exactly these forty-eight keys, by name", () => {
     // Spelled out, NOT derived from the three group arrays. HINDSIGHT_PERF_ENV_KEYS
     // is DEFINED as the union of those arrays, so asserting it equals that union
     // is a tautology — it passes no matter which keys are in the arrays. The
@@ -388,6 +388,7 @@ describe("operator override wins", () => {
       "HINDSIGHT_API_RETAIN_WALL_TIMEOUT",
       "HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY",
       "HINDSIGHT_API_TEMPORAL_LANGUAGES",
+      "HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS",
       "HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY",
       // Both spellings of every per-type slot reservation are ACCEPTED as
       // input (see HINDSIGHT_WORKER_RESERVED_SLOT_ALIASES); only the
@@ -849,6 +850,72 @@ describe("HINDSIGHT_API_TEMPORAL_LANGUAGES (override-only, i18n restore hatch)",
     const perf = { env: { [KEY]: "en,es" }, processEnv: {} };
     startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, false, perf);
     expect(runEnv(runArgs()).get(KEY)).toEqual(["en,es"]);
+  });
+});
+
+describe("HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS (override-only, temporal-offload input cap)", () => {
+  const KEY = "HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS";
+  const CAPS = [
+    { gpu: false, localLlm: false },
+    { gpu: true, localLlm: false },
+    { gpu: false, localLlm: true },
+    { gpu: true, localLlm: true },
+  ];
+  /** The documented full back-out value: unbounded full scan (upstream shape). */
+  const OFF = "0";
+
+  it("is in the managed set but in NO defaults group", () => {
+    // switchroom's temporal-offload image patch caps the query fed to
+    // dateparser.search_dates (default 2000, baked in config.py) to bound the
+    // per-call cost that blocked the shared asyncio loop on multi-KB
+    // consolidation queries. Managed so an operator's hindsight.env line is not
+    // silently dropped; override-only because the default lives in the image.
+    expect(HINDSIGHT_PERF_ENV_KEYS.has(KEY)).toBe(true);
+    expect(HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS.has(KEY)).toBe(true);
+    for (const group of [
+      HINDSIGHT_PERF_DEFAULTS_UNGATED,
+      HINDSIGHT_PERF_DEFAULTS_GPU,
+      HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM,
+    ]) {
+      expect(group.map(([k]) => k)).not.toContain(KEY);
+    }
+  });
+
+  it("survives resolveHindsightPerfOverrides from BOTH sources", () => {
+    expect(resolveHindsightPerfOverrides({ [KEY]: OFF }).get(KEY)).toBe(OFF);
+    expect(resolveHindsightPerfOverrides(undefined, { [KEY]: OFF }).get(KEY)).toBe(OFF);
+  });
+
+  it.each(CAPS)(
+    "is NOT emitted when unset (gpu=$gpu localLlm=$localLlm) — the image's baked 2000 stands",
+    (caps) => {
+      // Override-only means REACHABLE, not changed: a host that sets nothing
+      // keeps the image's baked default 2000. Emitting a value here would pin
+      // every install to switchroom's copy of that opinion.
+      expect(hindsightPerfEnv(caps).map(([k]) => k)).not.toContain(KEY);
+    },
+  );
+
+  it("reaches BOTH launch paths, with the operator's value, when set in hindsight.env", () => {
+    // The outcome that matters: an operator restoring an unbounded scan from
+    // declarative yaml must actually reach the container.
+    const perf = { env: { [KEY]: OFF }, processEnv: {} };
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false, perf);
+    const fromRun = runEnv(runArgs());
+    const fromCompose = composeEnv(
+      generateHindsightComposeSnippet(undefined, undefined, LOOPBACK_LITELLM, false, perf),
+    );
+    expect(fromRun.get(KEY)).toEqual([OFF]);
+    expect(fromCompose.get(KEY)).toEqual([OFF]);
+  });
+
+  it("still reaches the container on a host with NO gated capability", () => {
+    // It belongs to no capability group, so a gate-shaped regression that only
+    // emits grouped keys would drop it. Cloud endpoint + no GPU is the harshest
+    // gating case.
+    const perf = { env: { [KEY]: "4000" }, processEnv: {} };
+    startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, false, perf);
+    expect(runEnv(runArgs()).get(KEY)).toEqual(["4000"]);
   });
 });
 

--- a/src/setup/hindsight-perf-defaults.ts
+++ b/src/setup/hindsight-perf-defaults.ts
@@ -1352,6 +1352,34 @@ export const HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM: ReadonlyArray<readonly [string, 
  *     HINDSIGHT_API_TEMPORAL_LANGUAGES: "en,es"   # re-enable Spanish parsing
  * ```
  *
+ * ### `HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS`
+ *
+ * The max chars of query text `dateparser.search_dates()` is handed during
+ * temporal analysis (0 = unlimited). The #4313 language pin cut dateparser's
+ * per-locale cost but could not bound the per-CALL cost, which is linear in
+ * input length × date density: multi-KB consolidation queries
+ * (`consolidator.py`, `query=m["text"]`) blocked the shared asyncio loop for up
+ * to ~15s. switchroom's temporal-offload image patch
+ * (`docker/Dockerfile.hindsight`, the `config.py` + `engine/query_analyzer.py` +
+ * `engine/search/{temporal_extraction,retrieval}.py` block) runs the extraction
+ * off the loop on a single-worker thread AND caps its input here, defaulting to
+ * 2000 — far above any live recall-hook query yet well below the consolidation
+ * text that caused the stalls. Only the temporal retrieval arm sees the
+ * truncation; semantic/BM25/graph get the full query.
+ *
+ * Like the language knob, this IS a real `HINDSIGHT_API_` config.py field the
+ * patch adds. Override-only here because the 2000 default lives in the image,
+ * not switchroom's TS layer — emitting a second copy would only create drift.
+ * Set to `0` to restore an unbounded full scan; raise it if you genuinely want
+ * dates matched deeper into long consolidation text (at the loop-time cost the
+ * patch exists to bound).
+ *
+ * ```yaml
+ * hindsight:
+ *   env:
+ *     HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS: "0"   # unbounded full scan
+ * ```
+ *
  * ### DELIBERATELY NOT ADOPTED from v0.8.6
  *
  * - `HINDSIGHT_API_LOOP_WATCHDOG_ENABLED` / `..._STALL_THRESHOLD_MS` /
@@ -1379,6 +1407,7 @@ export const HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS: ReadonlySet<string> = new Set([
   "HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT",
   "HINDSIGHT_MM_REFRESH_MIN_INTERVAL_S",
   "HINDSIGHT_API_TEMPORAL_LANGUAGES",
+  "HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS",
 ]);
 
 /**

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -1365,6 +1365,66 @@ describe("Dockerfile.hindsight shape", () => {
     );
   });
 
+  it("keeps the temporal-offload fix (assert-guarded, fail-loud)", () => {
+    // dateparser.search_dates() ran synchronously on the shared asyncio loop
+    // from retrieve_all_fact_types_parallel() — 186 EVENT LOOP BLOCKED events in
+    // 4.5h, max 14.95s, driven by multi-KB consolidation queries. The patch
+    // offloads it to a single-worker ThreadPoolExecutor and bounds its input
+    // with HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS (default 2000).
+
+    // The exact-once anchor guard (fail-loud on upstream drift).
+    expect(dockerfile).toMatch(
+      /switchroom hindsight temporal-offload patch: anchor found \{n\}x/,
+    );
+
+    // The config.py char-cap knob, wired end to end.
+    expect(dockerfile).toContain(
+      'ENV_TEMPORAL_MAX_QUERY_CHARS = "HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS"',
+    );
+    expect(dockerfile).toContain("DEFAULT_TEMPORAL_MAX_QUERY_CHARS = 2000");
+    expect(dockerfile).toContain("    temporal_max_query_chars: int");
+    expect(dockerfile).toContain(
+      "temporal_max_query_chars=_parse_non_negative_int(",
+    );
+
+    // The off-loop machinery: a DELIBERATELY single-worker executor and an
+    // async wrapper that offloads via run_in_executor.
+    expect(dockerfile).toContain(
+      'ThreadPoolExecutor(max_workers=1, thread_name_prefix="hindsight-temporal")',
+    );
+    expect(dockerfile).toContain(
+      "async def extract_temporal_constraint_async(",
+    );
+    expect(dockerfile).toContain("loop.run_in_executor(");
+    // The single async call site now awaits the off-loop wrapper.
+    expect(dockerfile).toContain(
+      "await extract_temporal_constraint_async(query_text",
+    );
+
+    // The analyzer truncates its input before search_dates.
+    expect(dockerfile).toContain(
+      "search_query = search_query[: self._max_query_chars]",
+    );
+
+    // The #4313 language pin MUST survive: the (now truncated) call still
+    // carries languages=self._languages. This is the in-patch guard that reds
+    // if this fix ever regresses #4313.
+    expect(dockerfile).toContain(
+      "self._search_dates(search_query, settings=settings, languages=self._languages)",
+    );
+    expect(dockerfile).toMatch(
+      /switchroom hindsight temporal-offload patch: #4313 language pin lost/,
+    );
+
+    // The RED guard: the untruncated on-loop call must be GONE from analyze().
+    expect(dockerfile).toContain(
+      'assert qa.count("self._search_dates(query, settings=settings, languages=self._languages)") == 0,',
+    );
+    expect(dockerfile).toMatch(
+      /switchroom hindsight temporal-offload patch: temporal extraction runs on a/,
+    );
+  });
+
   it("preserves upstream's start-all.sh as the post-shim CMD", () => {
     // The shim does broker auth, then `exec "$@"` which is whatever
     // CMD docker passes — must be upstream's start-all.sh so the

--- a/tests/docker/hindsight-temporal-offload-patch.test.ts
+++ b/tests/docker/hindsight-temporal-offload-patch.test.ts
@@ -52,11 +52,12 @@
  *
  * SKIP DISCIPLINE: identical to `hindsight-temporal-language-patch.test.ts`.
  * Locally, with no docker or no cached image, this skips (never pull a 6.4GB
- * third-party image onto a dev box). In CI the `hindsight-probe` job pulls the
- * pinned digest and sets `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1`, under which an
- * unavailable docker/image is a HARD FAILURE, never a green skip. Both runs
- * assert a `PROBE_EXECUTED` sentinel so a probe that dies early can never be
- * mistaken for a pass.
+ * third-party image onto a dev box). In CI the `hindsight-probe` job
+ * (`.github/workflows/docker-e2e.yml`) pulls the pinned digest and runs this
+ * suite in its own dedicated step under `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1`,
+ * under which an unavailable docker/image is a HARD FAILURE, never a green skip.
+ * Both runs assert a `PROBE_EXECUTED` sentinel so a probe that dies early can
+ * never be mistaken for a pass.
  */
 
 import { describe, it, expect, afterAll } from "vitest";

--- a/tests/docker/hindsight-temporal-offload-patch.test.ts
+++ b/tests/docker/hindsight-temporal-offload-patch.test.ts
@@ -1,0 +1,481 @@
+/**
+ * Behavioural proof for the temporal-OFFLOAD patch
+ * `docker/Dockerfile.hindsight` bakes into the pinned upstream Hindsight image.
+ * `dockerfile-hindsight-bakes.test.ts` pins the *shape* of the patch block
+ * (grep-on-file, runs everywhere). This file proves the *outcome*: that temporal
+ * extraction no longer blocks the shared asyncio loop, and that its input is
+ * bounded.
+ *
+ * The defect, measured live on `switchroom-hindsight` before the fix:
+ *
+ *   `retrieve_all_fact_types_parallel()` (engine/search/retrieval.py, an
+ *   `async def`) called `extract_temporal_constraint()` SYNCHRONOUSLY before any
+ *   await → `temporal_extraction.py` → `query_analyzer.py analyze()` →
+ *   `dateparser.search_dates(...)`. `search_dates` is synchronous pure-Python
+ *   CPU work whose cost is linear in input length × date density. The
+ *   consolidation caller (`consolidator.py`, `query=m["text"]`) passes full
+ *   multi-KB memory text, so one extraction blocked recall + consolidation +
+ *   reranker together for seconds: 186 `EVENT LOOP BLOCKED` events in 4.5h, p50
+ *   1.36s, max 14.95s (16KB date-dense text ≈ 988ms measured).
+ *
+ * The #4313 language pin (a SEPARATE, already-shipped patch) cut dateparser's
+ * per-locale cost but cannot bound the per-CALL cost on unbounded input. This
+ * patch does two things: (a) offloads `search_dates` to a dedicated
+ * single-worker `ThreadPoolExecutor` via `loop.run_in_executor`, and (b) caps
+ * the query fed to it with `HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS` (default
+ * 2000, 0 = unlimited).
+ *
+ * HONEST CAVEAT encoded below: dateparser is pure-Python + `re`, so the worker
+ * thread holds the GIL during matching. Offloading does NOT fully free the loop
+ * — it collapses a multi-second uninterruptible stall into ~5ms scheduler slices
+ * (`sys.setswitchinterval` granularity). So this file does NOT assert "zero
+ * loop lag"; it asserts an asyncio loop-lag probe (a ticker coroutine recording
+ * the max inter-tick gap) stays SMALL — orders of magnitude below the parse
+ * duration — while a real ≥200ms extraction completes. A test that merely
+ * grepped for `run_in_executor` would not fail on the defect; this one bites.
+ *
+ * RED  = upstream + only the #4313 language block (offload patch ABSENT):
+ *        `extract_temporal_constraint` called inline on the loop blocks the
+ *        ticker for ≈ the full parse duration, and the async wrapper / config
+ *        knob do not exist.
+ * GREEN = upstream + #4313 + this offload block: awaiting
+ *        `extract_temporal_constraint_async` keeps the max inter-tick gap tiny
+ *        while the same parse runs, the char cap collapses a 34KB parse from
+ *        ~800ms to <200ms, and the cap drops a date past char 2000 while cap=0
+ *        preserves the full scan.
+ *
+ * The patch blocks are extracted from the Dockerfile itself rather than
+ * duplicated here, so this test cannot drift from what actually ships. It
+ * applies them by `docker exec` (not `docker build`) so it runs on daemons
+ * without buildx, and it never touches the production `switchroom-hindsight`
+ * container.
+ *
+ * SKIP DISCIPLINE: identical to `hindsight-temporal-language-patch.test.ts`.
+ * Locally, with no docker or no cached image, this skips (never pull a 6.4GB
+ * third-party image onto a dev box). In CI the `hindsight-probe` job pulls the
+ * pinned digest and sets `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1`, under which an
+ * unavailable docker/image is a HARD FAILURE, never a green skip. Both runs
+ * assert a `PROBE_EXECUTED` sentinel so a probe that dies early can never be
+ * mistaken for a pass.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { execFileSync, execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const dockerfile = readFileSync(
+  resolve(root, "docker/Dockerfile.hindsight"),
+  "utf8"
+);
+
+const RUN_ID = randomUUID();
+const TEST_PHASE = "hindsight-temporal-offload-patch";
+
+/** The pinned upstream image, read from the Dockerfile so it can never drift. */
+const UPSTREAM_IMAGE = (() => {
+  const m = dockerfile.match(/^FROM\s+(\S+)/m);
+  if (!m) throw new Error("Dockerfile.hindsight has no FROM line");
+  return m[1];
+})();
+
+/** Pull a named `RUN python3 - <<'PYEOF' … PYEOF` heredoc out of the Dockerfile. */
+function patchBlockNamed(name: string): string {
+  const blocks = [
+    ...dockerfile.matchAll(/^RUN python3 - <<'PYEOF'\n([\s\S]*?)^PYEOF$/gm),
+  ].map((m) => m[1]);
+  const b = blocks.find((x) => x.includes(name));
+  if (!b) {
+    throw new Error(
+      `Dockerfile.hindsight no longer contains the "${name}" RUN block — if it ` +
+        `was deliberately removed, delete this test with it.`
+    );
+  }
+  return b;
+}
+
+// The offload patch's anchors are the POST-#4313 file state, so #4313 must be
+// applied first — the same order the Dockerfile applies them.
+const LANG_BLOCK = patchBlockNamed("temporal-language patch");
+const OFFLOAD_BLOCK = patchBlockNamed("temporal-offload patch");
+
+/**
+ * GREEN probe. Runs against upstream + #4313 + the offload block. Exits 0 only
+ * when the loop stays responsive off-loop AND the char cap behaves. Asserts
+ * OUTCOMES, never source text.
+ */
+const GREEN_PROBE = String.raw`
+import asyncio
+import os
+import sys
+import time
+
+sys.path.insert(0, "/app/api")
+
+failures = []
+
+from hindsight_api.config import HindsightConfig
+from hindsight_api.engine import query_analyzer as QA
+from hindsight_api.engine.search.temporal_extraction import (
+    extract_temporal_constraint,
+    extract_temporal_constraint_async,
+)
+
+# ---- the config knob resolves to 2000 through the REAL loader ----
+cap_default = getattr(HindsightConfig.from_env(), "temporal_max_query_chars", "__ABSENT__")
+print("DEFAULT_CAP", cap_default)
+if cap_default != 2000:
+    failures.append("default temporal_max_query_chars != 2000: %r" % (cap_default,))
+
+# A big, date-dense text: long enough that the parse is unambiguously real work.
+chunk = "on june 10 2025 and march 3 2024 and 5 days ago something happened; "
+text = chunk * 500
+print("TEXT_LEN", len(text))
+
+
+async def ticker(stop, gaps):
+    last = time.perf_counter()
+    while not stop.is_set():
+        await asyncio.sleep(0.005)
+        now = time.perf_counter()
+        gaps.append((now - last) * 1000.0)
+        last = now
+
+
+async def measure_offloop():
+    # Uncapped analyzer so the off-loop parse is genuinely long.
+    an = QA.DateparserQueryAnalyzer()
+    an._max_query_chars = 0
+    stop = asyncio.Event()
+    gaps = []
+    tk = asyncio.create_task(ticker(stop, gaps))
+    await asyncio.sleep(0.05)  # let the ticker settle
+    t0 = time.perf_counter()
+    await extract_temporal_constraint_async(text, analyzer=an)
+    dur = (time.perf_counter() - t0) * 1000.0
+    stop.set()
+    await tk
+    return dur, max(gaps)
+
+
+extract_ms, max_gap = asyncio.run(measure_offloop())
+print("OFFLOOP_EXTRACT_MS", round(extract_ms, 1))
+print("MAX_INTERTICK_GAP_MS", round(max_gap, 1))
+
+# The load-bearing outcome. The extraction must be real work (>=150ms) so this
+# is not a vacuous pass, and the loop must have kept ticking: max gap tiny in
+# absolute terms AND a small fraction of the parse. On the unpatched sync path
+# the gap is ~= the full parse duration (see the RED probe).
+if extract_ms < 150:
+    failures.append("off-loop extraction too fast to be a real probe: %.1fms" % (extract_ms,))
+if max_gap >= 150:
+    failures.append("loop stalled off-loop: max inter-tick gap %.1fms >= 150ms" % (max_gap,))
+if max_gap >= extract_ms * 0.5:
+    failures.append(
+        "loop gap not decoupled from parse: gap %.1fms vs extract %.1fms" % (max_gap, extract_ms)
+    )
+
+# ---- the char cap collapses per-call cost on a huge query ----
+big = chunk * 500  # ~34KB
+an_cap = QA.DateparserQueryAnalyzer()
+an_cap._max_query_chars = 2000
+t0 = time.perf_counter()
+extract_temporal_constraint(big, analyzer=an_cap)
+capped_ms = (time.perf_counter() - t0) * 1000.0
+print("CAPPED_MS", round(capped_ms, 1))
+if capped_ms >= 200:
+    failures.append("cap=2000 did not bound cost: %.1fms >= 200ms" % (capped_ms,))
+
+# ---- correctness: a date past char 2000 is dropped under the cap, kept at 0 ----
+# Head has no temporal content; the only date lives well past 2000 chars.
+head = ("plain words with no temporal content here " * 60)[:2100]
+mixed = head + " on june 10 2025 clearly a date"
+an_c = QA.DateparserQueryAnalyzer()
+an_c._max_query_chars = 2000
+capped_res = extract_temporal_constraint(mixed, analyzer=an_c)
+an_u = QA.DateparserQueryAnalyzer()
+an_u._max_query_chars = 0
+full_res = extract_temporal_constraint(mixed, analyzer=an_u)
+print("MIXED_HEADLEN", len(head))
+print("CAPPED_DROPS_LATE_DATE", capped_res is None)
+print("FULLSCAN_KEEPS_LATE_DATE", full_res is not None)
+if capped_res is not None:
+    failures.append("cap=2000 did NOT drop a date past char 2000: %r" % (capped_res,))
+if full_res is None:
+    failures.append("cap=0 (full scan) missed the late date it should keep")
+
+# ---- and the cap does not harm a short live-recall-shaped query ----
+short = extract_temporal_constraint("what happened on june 10 2025", analyzer=QA.DateparserQueryAnalyzer())
+print("SHORT_QUERY_NONNULL", short is not None)
+if short is None:
+    failures.append("cap regressed a short explicit-date query (would break live recall)")
+
+print("FAILURES", failures)
+print("PROBE_EXECUTED")
+sys.exit(1 if failures else 0)
+`;
+
+/**
+ * RED probe. Runs against upstream + only the #4313 language block (offload
+ * patch ABSENT). Proves the defect bites: the async wrapper and config knob do
+ * not exist, and calling the sync extractor inline on the loop blocks the
+ * ticker for ≈ the full parse duration.
+ */
+const RED_PROBE = String.raw`
+import asyncio
+import sys
+import time
+
+sys.path.insert(0, "/app/api")
+
+from hindsight_api.config import HindsightConfig
+from hindsight_api.engine import query_analyzer as QA
+import hindsight_api.engine.search.temporal_extraction as TE
+
+# The async wrapper must not exist yet, and neither must the config knob.
+has_async = hasattr(TE, "extract_temporal_constraint_async")
+print("HAS_ASYNC_WRAPPER", has_async)
+cap_default = getattr(HindsightConfig.from_env(), "temporal_max_query_chars", "__ABSENT__")
+print("DEFAULT_CAP", cap_default)
+
+chunk = "on june 10 2025 and march 3 2024 and 5 days ago something happened; "
+text = chunk * 500
+print("TEXT_LEN", len(text))
+
+
+async def ticker(stop, gaps):
+    last = time.perf_counter()
+    while not stop.is_set():
+        await asyncio.sleep(0.005)
+        now = time.perf_counter()
+        gaps.append((now - last) * 1000.0)
+        last = now
+
+
+async def measure_inline():
+    an = QA.DateparserQueryAnalyzer()
+    stop = asyncio.Event()
+    gaps = []
+    tk = asyncio.create_task(ticker(stop, gaps))
+    await asyncio.sleep(0.05)
+    t0 = time.perf_counter()
+    # The pre-patch retrieval.py behaviour: sync extraction inline on the loop.
+    TE.extract_temporal_constraint(text, analyzer=an)
+    dur = (time.perf_counter() - t0) * 1000.0
+    stop.set()
+    await tk
+    return dur, max(gaps)
+
+
+extract_ms, max_gap = asyncio.run(measure_inline())
+print("INLINE_EXTRACT_MS", round(extract_ms, 1))
+print("MAX_INTERTICK_GAP_MS", round(max_gap, 1))
+print("PROBE_EXECUTED")
+`;
+
+function hasDocker(): boolean {
+  try {
+    execSync("docker version --format '{{.Server.Version}}'", {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasImage(ref: string): boolean {
+  try {
+    execSync(`docker image inspect ${ref}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * CI marker. When set, this suite MUST really execute — an absent docker or
+ * an absent upstream image becomes a hard failure instead of a green skip.
+ */
+const REQUIRED = process.env.SWITCHROOM_REQUIRE_HINDSIGHT_PROBE === "1";
+
+const dockerOk = hasDocker();
+const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
+
+type ProbeResult = { status: number; stdout: string };
+
+/**
+ * Run a probe in a throwaway container. Always applies the #4313 language block
+ * first (it is already-shipped); applies the offload block too iff `offload`.
+ */
+function runProbe(offload: boolean, probe: string): ProbeResult {
+  const name = `sr-hs-toff-${offload ? "green" : "red"}-${RUN_ID.slice(0, 8)}`;
+  try {
+    execFileSync(
+      "docker",
+      [
+        "run",
+        "-d",
+        "--name",
+        name,
+        "--label",
+        `switchroom.test=${TEST_PHASE}`,
+        "--label",
+        `switchroom.test.run=${RUN_ID}`,
+        "--user",
+        "root",
+        "--network",
+        "none",
+        UPSTREAM_IMAGE,
+        "sleep",
+        "400",
+      ],
+      { stdio: ["ignore", "ignore", "pipe"] }
+    );
+
+    // #4313 first (its anchors are upstream); it is the baseline both RED and
+    // GREEN share, since it ships independently of this fix.
+    execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
+      input: LANG_BLOCK,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    if (offload) {
+      // Self-verifying: asserts its post-#4313 anchors exist exactly once, so a
+      // non-zero exit here means upstream (or #4313) drifted and the patch must
+      // be re-authored.
+      execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
+        input: OFFLOAD_BLOCK,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    }
+
+    const res = execFileSync(
+      "docker",
+      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
+      { input: probe, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" }
+    );
+    return { status: 0, stdout: res };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: Buffer | string };
+    return {
+      status: err.status ?? -1,
+      stdout: (err.stdout ?? "").toString(),
+    };
+  } finally {
+    try {
+      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+describe("Dockerfile.hindsight temporal-offload probe is real, not a silent skip", () => {
+  it("pins the upstream image by digest so the probe tests the exact shipping bytes", () => {
+    expect(UPSTREAM_IMAGE).toMatch(/@sha256:[0-9a-f]{64}$/);
+  });
+
+  it("hard-fails rather than skipping when CI demands a real run", () => {
+    if (!REQUIRED) {
+      expect(
+        REQUIRED,
+        "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE is unset — the behavioural probe " +
+          "is advisory here. CI's hindsight-probe job sets it after pulling " +
+          `${UPSTREAM_IMAGE}.`
+      ).toBe(false);
+      return;
+    }
+    expect(
+      dockerOk,
+      "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but the docker daemon is unreachable"
+    ).toBe(true);
+    expect(
+      imageOk,
+      `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but ${UPSTREAM_IMAGE} is not present ` +
+        "locally — the workflow must pull the pinned digest before running this suite"
+    ).toBe(true);
+  });
+});
+
+describe.skipIf(!dockerOk || !imageOk)(
+  "Dockerfile.hindsight temporal-offload patch changes real behaviour",
+  () => {
+    afterAll(() => {
+      try {
+        const ids = execSync(
+          `docker ps -aq --filter label=switchroom.test.run=${RUN_ID}`,
+          { encoding: "utf8" }
+        )
+          .split("\n")
+          .filter(Boolean);
+        if (ids.length) {
+          execFileSync("docker", ["rm", "-f", ...ids], { stdio: "ignore" });
+        }
+      } catch {
+        /* nothing to clean */
+      }
+    });
+
+    it("unpatched (offload absent) is RED — sync extraction blocks the loop for ≈ the full parse, and the wrapper/knob don't exist", () => {
+      const { stdout } = runProbe(false, RED_PROBE);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED"
+      );
+      // The async off-loop wrapper does not exist yet…
+      expect(stdout).toContain("HAS_ASYNC_WRAPPER False");
+      // …nor the config knob (getattr sentinel on the real loader).
+      expect(stdout).toContain("DEFAULT_CAP __ABSENT__");
+
+      // The concrete defect: the loop was blocked for ≈ the whole parse. Parse
+      // the two numbers out and assert the gap is a large fraction of it.
+      const extract = Number(
+        stdout.match(/INLINE_EXTRACT_MS ([\d.]+)/)?.[1] ?? "0"
+      );
+      const gap = Number(
+        stdout.match(/MAX_INTERTICK_GAP_MS ([\d.]+)/)?.[1] ?? "0"
+      );
+      expect(extract, `probe did not do real work:\n${stdout}`).toBeGreaterThan(
+        150
+      );
+      expect(
+        gap,
+        `expected the loop to be blocked for ~the full parse but gap=${gap}ms extract=${extract}ms:\n${stdout}`
+      ).toBeGreaterThan(extract * 0.5);
+    }, 240_000);
+
+    it("upstream + #4313 + the offload block is GREEN — the loop stays responsive off-loop and the char cap bounds cost", () => {
+      const { status, stdout } = runProbe(true, GREEN_PROBE);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED"
+      );
+      expect(status, `probe failed:\n${stdout}`).toBe(0);
+      expect(stdout).toContain("FAILURES []");
+
+      // The knob resolves to 2000 through the real loader.
+      expect(stdout).toContain("DEFAULT_CAP 2000");
+      // The load-bearing outcome: real work off-loop, loop stayed responsive.
+      expect(stdout).toContain("CAPPED_DROPS_LATE_DATE True");
+      expect(stdout).toContain("FULLSCAN_KEEPS_LATE_DATE True");
+      expect(stdout).toContain("SHORT_QUERY_NONNULL True");
+
+      // Cross-check the numbers directly too: gap must be tiny vs the parse.
+      const extract = Number(
+        stdout.match(/OFFLOOP_EXTRACT_MS ([\d.]+)/)?.[1] ?? "0"
+      );
+      const gap = Number(
+        stdout.match(/MAX_INTERTICK_GAP_MS ([\d.]+)/)?.[1] ?? "0"
+      );
+      expect(extract, `off-loop parse too short:\n${stdout}`).toBeGreaterThan(
+        150
+      );
+      expect(
+        gap,
+        `loop stalled off-loop: gap=${gap}ms extract=${extract}ms:\n${stdout}`
+      ).toBeLessThan(150);
+      expect(gap).toBeLessThan(extract * 0.5);
+    }, 240_000);
+  }
+);


### PR DESCRIPTION
## The defect

`dateparser.search_dates()` runs synchronously **on the single shared asyncio loop**. `retrieve_all_fact_types_parallel()` (`engine/search/retrieval.py:812`, an `async def`) calls `extract_temporal_constraint()` synchronously *before any await* → `temporal_extraction.py:55` → `query_analyzer.py:276 search_dates(...)`. Since recall + consolidation + reranker all share one process/loop, one extraction blocks all of them.

The consolidation caller (`consolidator.py:1618`, `query=m["text"]`) passes full multi-KB memory text, and cost is linear in input length × date density (16KB date-dense ≈ 988ms measured). Live signal: **186 `EVENT LOOP BLOCKED` events in 4.5h, p50 1.36s, max 14.95s.**

The v0.20.3 #4313 language pin (`languages=["en"]`) is live and **preserved** here — it cut per-locale cost but cannot bound the per-**call** cost on unbounded input.

## The fix (single PR, "temporal extraction off-loop and bounded")

The blocking Python lives in the **upstream `vectorize-io/hindsight` image** (pinned by digest), not switchroom TS. It's patched via a new anchored `RUN python3 - <<'PYEOF'` block in `docker/Dockerfile.hindsight` — same shape as the 7 existing patches (unique-anchor `count==1` asserts that fail the build on upstream reformat, plus RED/GREEN behavioral tests).

**(a) Off-loop.** `temporal_extraction.py` gains a module-level `ThreadPoolExecutor(max_workers=1, thread_name_prefix="hindsight-temporal")` and an `async extract_temporal_constraint_async()` wrapping the sync function via `loop.run_in_executor`. The single async call site (`retrieval.py`) now `await`s it. **Deliberately one worker:** dateparser's module-level caches aren't documented thread-safe, so serialising removes the concern and bounds temporal CPU to one core.

**(b) Bound the input.** New knob `HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS` (default 2000, 0 = unlimited), wired exactly like the #4313 language knob (`config.py` env/default/dataclass/`from_env` + override-only registration in `src/setup/hindsight-perf-defaults.ts`). `analyze()` truncates the query fed to `search_dates`. Correctness: the temporal constraint gates only **one of four** retrieval arms (`retrieve_temporal_combined`); semantic/BM25/graph see the full query. Live recall-hook queries are short and never hit the cap.

## The GIL caveat (encoded in the test, not overclaimed)

dateparser is pure-Python + `re`, so the worker thread **holds the GIL during matching**. Offloading does **not** fully free the loop — it collapses a multi-second uninterruptible stall into ~5ms scheduler slices (`sys.setswitchinterval` granularity). The behavioral test asserts the outcome that matters, not a `run_in_executor` grep:

- `tests/docker/hindsight-temporal-offload-patch.test.ts` — an asyncio loop-lag probe (ticker coroutine recording max inter-tick gap). **GREEN**: max gap < 150ms while a ≥150ms off-loop extraction runs (measured ~11ms gap vs ~650ms parse). **RED** (offload absent, sync inline): max gap ≈ full parse (~1084ms). Plus a char-cap probe: 34KB query with cap=2000 completes <200ms (measured 80ms vs 805ms full-scan), a date past char 2000 is dropped under the cap and kept at cap=0, and a short query is unaffected.
- `tests/docker/dockerfile-hindsight-bakes.test.ts` — structural asserts; in-patch guard pins `languages=self._languages` still present (no #4313 regression) and the untruncated on-loop call is gone.
- `src/setup/hindsight-perf-defaults.test.ts` — the override-only knob reaches both launch paths, is emitted only when set, and is in no defaults group.

## CI wiring

This PR also adds a **dedicated step to the `hindsight-probe` job** in `.github/workflows/docker-e2e.yml` that runs `hindsight-temporal-offload-patch.test.ts` (after the pinned-image pull) under `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1`, so the runtime loop-lag outcome is regression-guarded on every merge and can never green-skip. The sibling #4313 probe (`hindsight-temporal-language-patch.test.ts`) had the same pre-existing gap and is wired in the same step. Both are added to the job's `changes` path filter and the label-scoped teardown. Verified locally that both suites **execute** (not skip) under the required flag: 8/8, ~16s of real docker probes each.

## Blast radius / rollback

- Requires an **image rebuild** + a single `switchroom-hindsight` container restart.
- Override-only knob ⇒ **no `switchroom.yaml` change** needed to land the default.
- Rollback: set `HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS=0` to restore the full scan; reverting the Dockerfile block restores the sync-on-loop path.
- No Telegram/messaging path touched.

## Verification

- Both patch blocks (#4313 + this one) apply cleanly in order against the real pinned upstream image (`count==1` anchors hold).
- Behavioral RED/GREEN suite passes with `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1` (4/4), and now runs in CI via the wired step above.
- `tsc --noEmit`, full `bun run lint`, and the scoped TS suites (perf-defaults, schema, dockerfile-bakes, env-key-reachability) all green.

## Follow-up (separate, non-blocking)

File an upstream PR to `vectorize-io/hindsight` to move the temporal extraction off-loop natively — tracked as its own issue, not blocking this image-layer fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
