### PR TITLE
fix(gateway): reset represent drain-deferral clock on a new episode after a call gap

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -11760,7 +11760,9 @@ const IDLE_DRAIN_INTERVAL_MS = 5000
 // while the CLI is still producing the answer; draining a represent into that busy
 // session re-queues it BEHIND the real reply → a duplicate. Defer while busy,
 // bounded so a wedged session still drains (F1 then retracts it post-reply).
-const idleDrainBusyDefer = makeSessionBusyDrainDeferral(OBLIGATION_BACKGROUND_WORK_GRACE_MS)
+// staleGap = 3 poll intervals: a longer gap between busy consultations means the
+// buffer drained via a non-idle path so the next one is a NEW episode (#4341 f/u).
+const idleDrainBusyDefer = makeSessionBusyDrainDeferral(OBLIGATION_BACKGROUND_WORK_GRACE_MS, IDLE_DRAIN_INTERVAL_MS * 3)
 if (isGatewayMain && !STATIC) {
   setInterval(() => {
     const selfAgent = process.env.SWITCHROOM_AGENT_NAME ?? ''

--- a/telegram-plugin/gateway/represent-delivery-guard.ts
+++ b/telegram-plugin/gateway/represent-delivery-guard.ts
@@ -137,19 +137,50 @@ export function makeRepresentRedeliveryGuard(
  * ordinary busy turn (which ends well within the bound) defers cleanly and never
  * consumes the wedge budget.
  *
+ * Episode isolation (#4341 follow-up): `deferringSince` used to reset ONLY on a
+ * `busy=false` call, but the predicate is not consulted on every drain path. When
+ * a buffer is emptied by a bridge re-register (`onClientRegistered`) while the
+ * session is still busy, the idle-drain gate is never invoked with `busy=false`,
+ * so `deferringSince` stays pinned at the old t0. A later, UNRELATED deferral
+ * episode then computes `now - t0 >= boundMs` immediately and drains a represent
+ * into a mid-answer session — reopening the duplicate window this guard closes.
+ * Fix: a fresh deferral episode also starts the clock at `now` when the predicate
+ * has not been consulted within `staleGapMs`. The idle-drain gate polls on a
+ * fixed short interval while (and only while) the buffer is non-empty, so a gap
+ * between consecutive consultations longer than a few poll intervals means the
+ * prior episode's buffer drained via a non-idle path and this is a new episode.
+ *
  * `boundMs <= 0` disables the busy-defer entirely (kill switch / parity with the
- * background-work grace being disabled).
+ * background-work grace being disabled). `staleGapMs <= 0` disables the
+ * gap-based episode reset (leaving only the `busy=false` reset).
  */
+export const DEFAULT_DRAIN_DEFER_STALE_GAP_MS = 15_000
+
 export function makeSessionBusyDrainDeferral(
   boundMs: number,
+  staleGapMs: number = DEFAULT_DRAIN_DEFER_STALE_GAP_MS,
 ): (busy: boolean, now: number) => boolean {
   let deferringSince: number | null = null
+  let lastCallAt: number | null = null
   return (busy, now) => {
+    const gapSinceLastCall = lastCallAt == null ? null : now - lastCallAt
+    lastCallAt = now
     if (!busy || boundMs <= 0) {
       deferringSince = null
       return false
     }
-    if (deferringSince == null) deferringSince = now
+    // Start (or restart) the clock at the top of a NEW deferral episode:
+    //   - we were not deferring (deferringSince cleared by a busy=false call), OR
+    //   - the predicate has not been consulted within staleGapMs, which means the
+    //     prior episode's buffer drained via a path that never calls us with
+    //     busy=false (bridge re-register) and left deferringSince pinned at a
+    //     stale t0. Either way a fresh episode's bound must run from `now`.
+    if (
+      deferringSince == null ||
+      (staleGapMs > 0 && gapSinceLastCall != null && gapSinceLastCall > staleGapMs)
+    ) {
+      deferringSince = now
+    }
     // Bounded: stop deferring once we have been busy past the ceiling, so a
     // wedged/hung session still eventually drains the buffered represent.
     return now - deferringSince < boundMs

--- a/telegram-plugin/tests/represent-guard.test.ts
+++ b/telegram-plugin/tests/represent-guard.test.ts
@@ -336,6 +336,51 @@ describe("makeSessionBusyDrainDeferral — F2 bounded busy-defer for the idle dr
     expect(off(true, 0)).toBe(false);
     expect(off(true, 10_000)).toBe(false);
   });
+
+  it("starts a FRESH bound for a new deferral episode after a call gap — a buffer emptied by bridge re-register (no busy=false call) must not pin a stale t0 (#4341 follow-up)", () => {
+    const BOUND = 20_000; // small bound so a realistic 5s poll cadence spans it
+    const defer = makeSessionBusyDrainDeferral(BOUND); // default staleGap = 15s
+
+    // Episode A: a represent is buffered while the session is busy. The idle
+    // drain gate polls it every ~5s (< staleGap) and defers each time.
+    expect(defer(true, 0)).toBe(true); // t0 = 0
+    expect(defer(true, 5_000)).toBe(true);
+    expect(defer(true, 10_000)).toBe(true);
+
+    // The buffer is now emptied by a bridge re-register (onClientRegistered)
+    // while the session is STILL busy. That drain path does NOT consult this
+    // predicate, so there is no busy=false call — deferringSince stays at 0 on
+    // the buggy code. Time then advances well past the bound with the buffer
+    // empty (predicate not called).
+
+    // Episode B: a brand-new represent is buffered while the session is busy,
+    // long after t0. This is a NEW mid-answer session — the represent MUST stay
+    // deferred (its own bound has not elapsed), NOT be drained immediately.
+    // Buggy code: now - stalePinnedT0 (2_000_000 - 0) >= BOUND → false → the
+    // represent is drained into the mid-answer session, reopening the duplicate
+    // window. Fixed code: the >15s call gap starts a fresh episode clock at
+    // t=2_000_000, so it defers.
+    const B0 = 2_000_000;
+    expect(defer(true, B0)).toBe(true);
+    // ...and the fresh episode is still bounded from ITS OWN start, polled at the
+    // real ~5s cadence (each gap < staleGap, so no further reset).
+    expect(defer(true, B0 + 5_000)).toBe(true);
+    expect(defer(true, B0 + 10_000)).toBe(true);
+    expect(defer(true, B0 + 15_000)).toBe(true);
+    expect(defer(true, B0 + BOUND)).toBe(false); // fresh bound elapsed → drains
+  });
+
+  it("does NOT reset the clock on the normal poll cadence — a genuinely wedged busy session still drains at the bound (wedge budget preserved)", () => {
+    const BOUND = 20_000;
+    const defer = makeSessionBusyDrainDeferral(BOUND); // default staleGap = 15s
+    // Polls arrive every 5s (< staleGap) throughout one continuous episode, so
+    // the clock is never reset and the bound elapses on schedule.
+    expect(defer(true, 0)).toBe(true);
+    expect(defer(true, 5_000)).toBe(true);
+    expect(defer(true, 10_000)).toBe(true);
+    expect(defer(true, 15_000)).toBe(true);
+    expect(defer(true, 20_000)).toBe(false); // bound reached — drains, not silenced forever
+  });
 });
 
 describe("obligationSweep — F2 decision half: a poke-cleared-but-busy session defers, then re-asks (bounded)", () => {


### PR DESCRIPTION
## Problem (#4341 follow-up — merge-review correctness bug)

`makeSessionBusyDrainDeferral` in `telegram-plugin/gateway/represent-delivery-guard.ts` reset `deferringSince` **only** when the predicate was invoked with `busy=false`. But the idle-drain gate is not consulted on every drain path — `idleDrainTick` returns early (no gate call) when the buffer is empty, and a buffered represent can be flushed by a bridge re-register (`onClientRegistered`) while the session is still busy.

Result: after such a flush the gate never sees `busy=false`, so `deferringSince` stays pinned at the **old** episode's `t0`. A later, unrelated deferral episode then computes `now - t0 >= boundMs` immediately and drains a represent into a **mid-answer** session — re-queuing it behind the real reply and reopening the duplicate-answer window the #4341 fix was meant to close.

## Fix

Start (or restart) the deferral clock at the top of a **new** episode:
- when not already deferring (unchanged `busy=false` path), OR
- when the predicate has not been consulted within `staleGapMs`. While a represent is buffered the gate is polled every `IDLE_DRAIN_INTERVAL_MS`; a longer gap between busy consultations means the prior episode's buffer drained via a non-idle path, so the next busy consultation belongs to a new episode whose bound must run from *then*, not a stale `t0`.

The gateway passes `IDLE_DRAIN_INTERVAL_MS * 3`. The `busy=false` reset and the bounded-wedge behaviour (a wedged session still drains at the bound) are unchanged; `staleGapMs <= 0` disables the gap-based reset for parity.

## Test

Adds a regression test reproducing episode-A (defer starts at `t0`, buffer emptied while still busy with no `busy=false` call) then episode-B (new represent buffered while busy long after `t0`), asserting the represent is **deferred**, not drained mid-answer, and that the fresh episode is still bounded from its own start at the real ~5s poll cadence. Also a test that the normal poll cadence never resets the clock (wedge budget preserved).

Verified **RED** on the unpatched factory (`expected false to be true`) and **GREEN** after the fix (26/26 in the file). `tsc --noEmit` clean on the changed files; gateway line-ratchet clean (24855 ≤ 24805+50).

🤖 Generated with [Claude Code](https://claude.com/claude-code)