### PR TITLE
fix(manifest): self-report the real switchroom version, not a stale hardcoded field

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,5 +1,4 @@
 {
-  "switchroom_version": "0.7.3",
   "tested_at": "2026-08-04T18:45:00+10:00",
   "runtime": {
     "bun": "1.3.13",

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -34,6 +34,7 @@ import { getSlotInfos, type SlotInfo } from "../auth/accounts.js";
 import type { AgentConfig, SwitchroomConfig } from "../config/schema.js";
 import { resolveMemoryProfile } from "../config/schema.js";
 import { loadManifest, detectDrift, type DriftProbers } from "../manifest.js";
+import { SWITCHROOM_VERSION } from "./resolve-version.js";
 import {
   probeHindsight,
   isHindsightEnabled,
@@ -3812,7 +3813,7 @@ export async function checkManifestDrift(probers?: DriftProbers): Promise<CheckR
       {
         name: "dependency manifest",
         status: "ok",
-        detail: `all versions match (manifest ${manifest.switchroom_version})`,
+        detail: `all versions match (switchroom ${SWITCHROOM_VERSION})`,
       },
     ];
   }

--- a/src/cli/versions.ts
+++ b/src/cli/versions.ts
@@ -11,6 +11,7 @@ import type { Command } from "commander";
 import chalk from "chalk";
 import { loadManifest, detectDrift } from "../manifest.js";
 import type { DriftItem } from "../manifest.js";
+import { SWITCHROOM_VERSION } from "./resolve-version.js";
 
 function formatRow(
   component: string,
@@ -74,7 +75,10 @@ export function registerVersionsCommand(program: Command): void {
       );
 
       console.log(chalk.bold("\nDependency manifest"));
-      console.log(chalk.gray(`  switchroom ${manifest.switchroom_version}  ·  tested ${manifest.tested_at}`));
+      // Version comes from SWITCHROOM_VERSION (the git-tag-stamped build-info,
+      // same source as `--version`), not a hand-maintained manifest field that
+      // drifts; `tested_at` still reports when the pinned deps were validated.
+      console.log(chalk.gray(`  switchroom ${SWITCHROOM_VERSION}  ·  tested ${manifest.tested_at}`));
       console.log();
 
       // --- runtime ---

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -20,7 +20,14 @@ import { execSync } from "node:child_process";
 // ─── Schema ────────────────────────────────────────────────────────────────
 
 export const ManifestSchema = z.object({
-  switchroom_version: z.string().min(1),
+  // NOTE: no `switchroom_version` field. The BOM's switchroom version is not
+  // hand-recorded here — it drifted for ~13 minors (frozen at 0.7.3 while
+  // `tested_at` and the pinned deps were kept fresh). The self-reported version
+  // in `switchroom versions` / `doctor` comes from `SWITCHROOM_VERSION`
+  // (resolve-version.ts — the git-tag-stamped build-info, the same
+  // source-of-truth as `--version`), so it can never drift from the release
+  // tag. An old on-disk manifest that still carries the key parses fine —
+  // z.object() strips unknown keys.
   tested_at: z.string().min(1),
   runtime: z.object({
     bun: z.string().min(1),

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -9,6 +9,7 @@ import {
   type DriftProbers,
 } from "../src/manifest.js";
 import { checkManifestDrift } from "../src/cli/doctor.js";
+import { SWITCHROOM_VERSION } from "../src/cli/resolve-version.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -16,7 +17,6 @@ import { checkManifestDrift } from "../src/cli/doctor.js";
 
 function validManifestData() {
   return {
-    switchroom_version: "0.4.0",
     tested_at: "2026-04-29T20:30:00+10:00",
     runtime: { bun: "1.3.11", node: "22.22.2" },
     claude: { cli: "2.1.123" },
@@ -60,7 +60,6 @@ describe("loadManifest", () => {
     const path = join(tempDir, "dependencies.json");
     writeFileSync(path, validManifestJson());
     const manifest = loadManifest(path);
-    expect(manifest.switchroom_version).toBe("0.4.0");
     expect(manifest.runtime.bun).toBe("1.3.11");
     expect(manifest.runtime.node).toBe("22.22.2");
     expect(manifest.claude.cli).toBe("2.1.123");
@@ -83,14 +82,24 @@ describe("loadManifest", () => {
 
   it("throws a clear error when required fields are missing", () => {
     const path = join(tempDir, "dependencies.json");
-    writeFileSync(path, JSON.stringify({ switchroom_version: "0.4.0" }));
+    writeFileSync(path, JSON.stringify({ tested_at: "2026-04-29T20:30:00+10:00" }));
     expect(() => loadManifest(path)).toThrowError(/schema validation failed/);
+  });
+
+  it("ignores a legacy switchroom_version key — an old on-disk manifest still parses (key stripped, not required)", () => {
+    const path = join(tempDir, "dependencies.json");
+    // Older manifests hand-recorded (and drifted) switchroom_version. The schema
+    // no longer carries it; z.object() strips the unknown key rather than
+    // failing, so a pre-existing manifest still loads.
+    writeFileSync(path, validManifestJson({ switchroom_version: "0.7.3" }));
+    const manifest = loadManifest(path);
+    expect((manifest as Record<string, unknown>).switchroom_version).toBeUndefined();
+    expect(manifest.tested_at).toBe("2026-04-29T20:30:00+10:00");
   });
 
   it("throws a clear error when runtime.bun is the wrong type", () => {
     const path = join(tempDir, "dependencies.json");
     const bad = {
-      switchroom_version: "0.4.0",
       tested_at: "2026-04-29T20:30:00+10:00",
       runtime: { bun: 123, node: "22.22.2" }, // bun should be string
       claude: { cli: "2.1.123" },
@@ -236,6 +245,10 @@ describe("checkManifestDrift (doctor integration)", () => {
     expect(results).toHaveLength(1);
     expect(results[0].status).toBe("ok");
     expect(results[0].name).toBe("dependency manifest");
+    // The clean-drift detail reports the REAL switchroom version
+    // (SWITCHROOM_VERSION), not a hand-maintained manifest field that drifts.
+    expect(results[0].detail).toContain(SWITCHROOM_VERSION);
+    expect(results[0].detail).not.toContain("0.7.3");
   });
 
   it("surfaces bun drift as a check result with fail status on major mismatch", async () => {


### PR DESCRIPTION
## Problem (v0.20.7 merge-review follow-up)

`dependencies.json`'s `switchroom_version` was `0.7.3` — ~13 minors behind the release tag — while `tested_at` and the pinned dependency versions (bun `1.3.13`, claude cli `2.1.221`) were kept fresh. It's a hand-maintained field nobody bumps. Both `switchroom versions` (`src/cli/versions.ts:77`) and `switchroom doctor` (`checkManifestDrift`, `src/cli/doctor.ts`) printed it, so the shipped tool self-reported a wildly stale version.

## Why not just bump the string

The tag-as-source-of-truth model already exists: `SWITCHROOM_VERSION` (`src/cli/resolve-version.ts`) resolves from the git-tag-stamped `build-info.ts` (build.mjs stamps it at CI time from `TAG_VERSION`, with a mis-stamp guard; package.json is the dev fallback) — the same source `--version` uses. The manifest field was a redundant, drift-prone duplicate with **no logic consumer** (analytics stamps `switchroom_version` from `process.env.SWITCHROOM_VERSION`, not the manifest). Bumping the string would just drift again. The durable fix is to stop hardcoding it.

## Change

- Remove `switchroom_version` from `dependencies.json` and `ManifestSchema`. `z.object()` strips the key from any older on-disk manifest, so `loadManifest` stays backward-compatible.
- Print `SWITCHROOM_VERSION` in both `versions` and `doctor`; `tested_at` still reports when the pinned deps were validated.

## Tests

- `checkManifestDrift` clean-drift detail now asserts it contains `SWITCHROOM_VERSION` and **not** `0.7.3`.
- New test: a legacy manifest still carrying `switchroom_version` loads fine with the key stripped.

16/16 in `tests/manifest.test.ts` pass; `tsc --noEmit` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)