### PR TITLE
fix(gateway): dedup subagent handback against CLI task-notification wake

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -497,7 +497,7 @@ import {
   type ReplyOwnerTier, type ReplyOwnerCandidates,
   type AnswerDeliveredLatch,
 } from '../reply-owner-resolve.js'
-import { SubagentHandbackMarker } from './subagent-handback-marker.js'
+import { SubagentHandbackMarker, cliTaskNotifLedger } from './subagent-handback-marker.js'
 // PR A — deterministic answer-ready quiescence flush (late-delivery fix).
 import { AnswerReadyFlushController, resolveAnswerReadyFlushMs, resolveAnswerStageMs } from '../answer-ready-flush.js'
 // #1667 — pure decision core for the turn_end answer-delivery gate (#1664).
@@ -10693,6 +10693,7 @@ if (isGatewayMain) ipcServer = createIpcServer({
       }
     }
     const ev = msg.event as unknown as SessionEvent
+    if (ev.kind === 'task_notification') cliTaskNotifLedger.record(ev.taskId, ev.status, Date.now()) // double-wake dedup — ledger doc in subagent-handback-marker.ts
     // #1122/#1126: session events used to be ingested into the pinned progress
     // card here (`progressDriver.ingest`). The card is retired and the driver
     // is permanently null, so that call was a dead no-op — removed. Session
@@ -24372,11 +24373,12 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                   // deterministic dedup key — closes the #1719
                   // re-fire-on-restart class.
                   jsonlAgentId: agentId,
+                  cliTaskNotificationSeen: cliTaskNotifLedger.seenRecently(agentId, Date.now()), // double-wake dedup, fail-open — ledger doc in subagent-handback-marker.ts
                 })
                 if (!decision.deliver) {
-                  if (decision.reason === 'no-chat') {
+                  if (decision.reason === 'no-chat' || decision.reason === 'cli-task-notification') {
                     process.stderr.write(
-                      `telegram gateway: subagent-handback ${agentId} — no chat to deliver to; skipped\n`,
+                      `telegram gateway: subagent-handback ${agentId} skipped — ${decision.reason === 'no-chat' ? 'no chat to deliver to' : 'CLI task-notification already woke the parent for this completion (double-wake dedup)'}\n`,
                     )
                   }
                   return

--- a/telegram-plugin/gateway/subagent-handback-inbound-builder.ts
+++ b/telegram-plugin/gateway/subagent-handback-inbound-builder.ts
@@ -183,6 +183,17 @@ export interface SubagentHandbackDecisionInput {
    *  the built inbound's `meta.subagent_jsonl_id`. See
    *  `SubagentHandbackContext.jsonlAgentId` for the dedup rationale. */
   jsonlAgentId?: string
+  /**
+   * Double-wake dedup (v0.20.8 candidate): true iff the session tail already
+   * observed a TERMINAL CLI `<task-notification>` for EXACTLY this sub-agent's
+   * task id within `TASK_NOTIFICATION_DEDUP_TTL_MS` — i.e. the CLI itself has
+   * already woken (or queued the wake of) the parent with this completion, so
+   * a second gateway-synthesized wake would duplicate it. The caller resolves
+   * this from `CliTaskNotificationLedger.seenRecently(agentId, now)`
+   * (subagent-handback-marker.ts). FAIL-OPEN: omitted/false → deliver; only a
+   * confirmed exact-id in-window hit suppresses.
+   */
+  cliTaskNotificationSeen?: boolean
   /** Deterministic clock for tests. */
   nowMs?: number
 }
@@ -192,6 +203,7 @@ export type SubagentHandbackSkipReason =
   | 'env-disabled'
   | 'outcome-not-terminal'
   | 'foreground'
+  | 'cli-task-notification'
   | 'no-chat'
 
 export type SubagentHandbackDecision =
@@ -208,7 +220,12 @@ export type SubagentHandbackDecision =
  *      stale historical-at-boot row, not a fresh completion.
  *   3. foreground — a foreground sub-agent already handed its result
  *      back as the Task tool result in the parent's own turn.
- *   4. no-chat — neither the fleet entry nor the owner chat resolved,
+ *   4. cli-task-notification — the claude CLI's OWN `<task-notification>`
+ *      for exactly this task id was already observed in-window, so the CLI
+ *      has already woken the parent with this completion; a second
+ *      gateway-synthesized wake would double it (the double-message bug).
+ *      Fail-open: only a confirmed exact-id hit skips.
+ *   5. no-chat — neither the fleet entry nor the owner chat resolved,
  *      so there is nowhere to deliver.
  */
 export function decideSubagentHandback(
@@ -222,6 +239,9 @@ export function decideSubagentHandback(
   }
   if (!input.isBackground) {
     return { deliver: false, reason: 'foreground' }
+  }
+  if (input.cliTaskNotificationSeen === true) {
+    return { deliver: false, reason: 'cli-task-notification' }
   }
   const chatId = input.fleetChatId || input.ownerChatId
   if (!chatId) {

--- a/telegram-plugin/gateway/subagent-handback-marker.ts
+++ b/telegram-plugin/gateway/subagent-handback-marker.ts
@@ -220,6 +220,100 @@ export function stampsHandbackMarker(source: string | null | undefined): boolean
  */
 export const HANDBACK_RECENCY_WINDOW_MS = 60_000
 
+// ───────────────────────────────────────────────────────────────────────────
+// CLI task-notification dedup ledger (double-wake fix, v0.20.8 candidate)
+// ───────────────────────────────────────────────────────────────────────────
+//
+// One background sub-agent completion used to produce TWO independent wakes of
+// the parent session:
+//   1. The claude CLI's OWN `<task-notification>` — the CLI proactively
+//      enqueues it into the parent session when a backgrounded task/agent
+//      completes (projected as a `task_notification` SessionEvent at the
+//      queue-operation enqueue line, session-tail.ts). The parent wakes,
+//      sees the notification + summary, and typically reports to the user.
+//   2. The gateway-synthesized `subagent_handback` inbound (subagent-watcher
+//      `onFinish` → pendingInboundBuffer.push) — switchroom's deliberate
+//      beat-4 wake, added because older CLIs surfaced a background result
+//      only on the parent's NEXT user turn.
+// Nothing linked them, so a single completion fanned out to two turns and two
+// user-visible replies. The CLI-native wake cannot be suppressed (it is the
+// CLI's internal queue); the ONE lever switchroom holds is the handback
+// enqueue. This ledger records every terminal `<task-notification>` the
+// session tail observes, keyed by its `<task-id>` — which is EXACTLY the
+// sub-agent watcher's `agentId` (both are the `agent-<id>.jsonl` stem;
+// verified against live transcripts: `<task-id>a204deeaedb27b580</task-id>`
+// ↔ `subagents/agent-a204deeaedb27b580.jsonl`). `decideSubagentHandback`
+// then skips the redundant handback ONLY on an exact-id hit inside a short
+// TTL.
+//
+// FAIL-OPEN by construction — every uncertain path DELIVERS the handback:
+//   - no notification seen for this exact id → deliver (a dropped real wake
+//     means a silent worker and a user waiting forever; an occasional double
+//     is strictly better);
+//   - notification older than the TTL → deliver (a resumed worker's second
+//     completion must not be swallowed by its first completion's entry);
+//   - non-terminal notification status → never recorded, so → deliver;
+//   - gateway restart (ledger is in-memory) → boot-replayed handbacks
+//     deliver;
+//   - the CLI notification landing AFTER the handback enqueue (lost race) →
+//     deliver (the residual occasional double, accepted).
+// The liveness consumer (background-shell-liveness.ts) is untouched: the same
+// `task_notification` event still drives noteBackgroundShellDead —
+// recording here is an independent, additive read of the event.
+
+/**
+ * How long a recorded terminal `<task-notification>` suppresses the matching
+ * `subagent_handback`. The real gap between the CLI's notification enqueue
+ * and the watcher's `onFinish` (its ~1s jsonl rescan) is a few seconds; 30s
+ * covers scheduler jitter with a wide margin while staying far below any
+ * plausible resume-and-complete-again cycle for the same agent id, so a
+ * resumed worker's second completion falls outside the window → fail-open.
+ */
+export const TASK_NOTIFICATION_DEDUP_TTL_MS = 30_000
+
+/** `<task-notification>` statuses that mean the task genuinely ended and the
+ *  CLI woke (or will wake) the parent with the completion. Mirrors the
+ *  liveness consumer's terminal set (background-shell-liveness.ts). */
+const NOTIF_TERMINAL_STATUSES = new Set(['completed', 'failed', 'killed'])
+
+/**
+ * In-memory seen-set of terminal CLI `<task-notification>` task ids.
+ * Deliberately process-local: absence after a restart fails open (deliver).
+ */
+export class CliTaskNotificationLedger {
+  private readonly seen = new Map<string, number>()
+
+  /** Record a parsed `task_notification` session event. Non-terminal
+   *  statuses and empty ids are ignored (they must never suppress). */
+  record(taskId: string, status: string, now: number): void {
+    if (taskId.length === 0 || !NOTIF_TERMINAL_STATUSES.has(status)) return
+    this.seen.set(taskId, now)
+    // Bounded: prune expired entries on write so the map tracks only the
+    // live window (a handful of ids), never the process lifetime.
+    for (const [id, ts] of this.seen) {
+      if (now - ts > TASK_NOTIFICATION_DEDUP_TTL_MS) this.seen.delete(id)
+    }
+  }
+
+  /** True iff a terminal notification for EXACTLY `taskId` was recorded
+   *  within the TTL. Anything else → false → the handback delivers. */
+  seenRecently(taskId: string, now: number): boolean {
+    const ts = this.seen.get(taskId)
+    return ts != null && now - ts <= TASK_NOTIFICATION_DEDUP_TTL_MS
+  }
+}
+
+/**
+ * The gateway's process-wide ledger instance (one gateway process per agent,
+ * one main session — a module singleton keeps the gateway.ts wiring to two
+ * lines under the anti-inflation ratchet, #2996). Written at the gateway's
+ * `onSessionEvent` (OUTSIDE the currentTurn guard — the CLI enqueues the
+ * notification while the parent is typically idle with no live gateway turn);
+ * read at the `onFinish` handback decide site. Tests construct their own
+ * `CliTaskNotificationLedger` instances.
+ */
+export const cliTaskNotifLedger = new CliTaskNotificationLedger()
+
 /** Sentinel thread key for the no-thread (DM / bare-chat) lane. */
 const MAIN_THREAD_KEY = '<main>'
 

--- a/telegram-plugin/tests/handback-tasknotif-dedup.test.ts
+++ b/telegram-plugin/tests/handback-tasknotif-dedup.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Double-wake dedup (v0.20.8 candidate) — one background sub-agent completion
+ * must produce ONE parent wake, not two.
+ *
+ * The bug: a single background sub-agent completion fanned out to TWO
+ * independent wakes of the parent session —
+ *   1. the claude CLI's own `<task-notification>` (enqueued by the CLI itself;
+ *      switchroom read it only as a background-shell liveness signal), and
+ *   2. the gateway-synthesized `subagent_handback` inbound (subagent-watcher
+ *      `onFinish` → `pendingInboundBuffer.push`).
+ * Nothing linked them. The CLI-native wake cannot be suppressed (it is the
+ * CLI's internal queue), so the fix gates the ONE lever switchroom holds — the
+ * handback enqueue — on a recently-seen terminal `<task-notification>` for
+ * EXACTLY the same task/agent id (`CliTaskNotificationLedger`,
+ * subagent-handback-marker.ts; consumed by `decideSubagentHandback`).
+ *
+ * FAIL-OPEN contract pinned here: every uncertain path DELIVERS the handback.
+ * A dropped real wake (silent worker, user waits forever) is strictly worse
+ * than an occasional double.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  CliTaskNotificationLedger,
+  TASK_NOTIFICATION_DEDUP_TTL_MS,
+} from '../gateway/subagent-handback-marker.js'
+import { decideSubagentHandback } from '../gateway/subagent-handback-inbound-builder.js'
+import { projectTranscriptLine } from '../session-tail.js'
+import { applyBackgroundShellLiveness } from '../gateway/background-shell-liveness.js'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const T0 = 1_700_000_000_000
+
+const base = {
+  handbackEnvValue: undefined as string | undefined,
+  outcome: 'completed' as 'completed' | 'failed' | 'orphan',
+  isBackground: true,
+  fleetChatId: '777',
+  ownerChatId: '999',
+  taskDescription: 'Do the thing',
+  resultText: 'Done.',
+  jsonlAgentId: 'a204deeaedb27b580',
+  nowMs: T0,
+}
+
+// A real captured queue-operation enqueue line shape (fixture
+// bg-shell-liveness-3519.jsonl), retargeted at an AGENT task id — the live
+// transcripts prove `<task-id>` for a backgrounded agent equals the
+// `agent-<id>.jsonl` stem the subagent-watcher uses as `agentId`
+// (verified: <task-id>a204deeaedb27b580</task-id> ↔
+// subagents/agent-a204deeaedb27b580.jsonl).
+function notifLine(taskId: string, status: string): string {
+  return JSON.stringify({
+    type: 'queue-operation',
+    operation: 'enqueue',
+    timestamp: '2026-08-04T00:00:00.000Z',
+    sessionId: 'deadbeef-0000-4000-8000-000000000000',
+    content:
+      `<task-notification>\n<task-id>${taskId}</task-id>\n` +
+      `<tool-use-id>toolu_01TESTTESTTESTTEST</tool-use-id>\n` +
+      `<output-file>/tmp/tasks/${taskId}.output</output-file>\n` +
+      `<status>${status}</status>\n<summary>Agent done</summary>\n</task-notification>`,
+  })
+}
+
+describe('CliTaskNotificationLedger', () => {
+  it('records a terminal notification and reports it within the TTL', () => {
+    const l = new CliTaskNotificationLedger()
+    l.record('a204deeaedb27b580', 'completed', T0)
+    expect(l.seenRecently('a204deeaedb27b580', T0 + 5_000)).toBe(true)
+    expect(l.seenRecently('a204deeaedb27b580', T0 + TASK_NOTIFICATION_DEDUP_TTL_MS)).toBe(true)
+  })
+
+  it('fail-open: expires after the TTL (a resumed worker second completion delivers)', () => {
+    const l = new CliTaskNotificationLedger()
+    l.record('a204deeaedb27b580', 'completed', T0)
+    expect(l.seenRecently('a204deeaedb27b580', T0 + TASK_NOTIFICATION_DEDUP_TTL_MS + 1)).toBe(false)
+  })
+
+  it('fail-open: a DIFFERENT task id never matches', () => {
+    const l = new CliTaskNotificationLedger()
+    l.record('a204deeaedb27b580', 'completed', T0)
+    expect(l.seenRecently('a999999999999999', T0 + 1)).toBe(false)
+  })
+
+  it('fail-open: non-terminal statuses and empty ids are never recorded', () => {
+    const l = new CliTaskNotificationLedger()
+    l.record('a204deeaedb27b580', 'running', T0)
+    l.record('', 'completed', T0)
+    expect(l.seenRecently('a204deeaedb27b580', T0 + 1)).toBe(false)
+    expect(l.seenRecently('', T0 + 1)).toBe(false)
+  })
+
+  it('records failed and killed as terminal (the CLI wakes the parent for those too)', () => {
+    const l = new CliTaskNotificationLedger()
+    l.record('aaa', 'failed', T0)
+    l.record('bbb', 'killed', T0)
+    expect(l.seenRecently('aaa', T0 + 1)).toBe(true)
+    expect(l.seenRecently('bbb', T0 + 1)).toBe(true)
+  })
+
+  it('prunes expired entries on write (bounded memory)', () => {
+    const l = new CliTaskNotificationLedger()
+    l.record('old', 'completed', T0)
+    l.record('new', 'completed', T0 + TASK_NOTIFICATION_DEDUP_TTL_MS + 60_000)
+    // The old entry is both expired AND physically pruned; either way the
+    // observable contract is: it no longer suppresses.
+    expect(l.seenRecently('old', T0 + TASK_NOTIFICATION_DEDUP_TTL_MS + 60_001)).toBe(false)
+    expect(l.seenRecently('new', T0 + TASK_NOTIFICATION_DEDUP_TTL_MS + 60_001)).toBe(true)
+  })
+})
+
+describe('decideSubagentHandback × CLI task-notification dedup', () => {
+  // ── Outcome (a): one background completion → exactly ONE parent wake ──────
+  // RED-before/GREEN-after core: on pre-fix code this decision delivered a
+  // second wake; post-fix it is suppressed with the dedicated reason.
+  it('suppresses the handback when the CLI already woke the parent for this exact completion', () => {
+    const ledger = new CliTaskNotificationLedger()
+    // The CLI's wake for this completion (wake #1) is observed by the tail…
+    for (const ev of projectTranscriptLine(notifLine('a204deeaedb27b580', 'completed'))) {
+      if (ev.kind === 'task_notification') ledger.record(ev.taskId, ev.status, T0)
+    }
+    // …then the watcher's onFinish runs the decide gate (would-be wake #2).
+    const wakes: string[] = ['cli-task-notification'] // wake #1 already happened
+    const d = decideSubagentHandback({
+      ...base,
+      cliTaskNotificationSeen: ledger.seenRecently(base.jsonlAgentId, T0 + 2_000),
+    })
+    if (d.deliver) wakes.push('subagent_handback')
+    expect(d).toEqual({ deliver: false, reason: 'cli-task-notification' })
+    expect(wakes).toHaveLength(1) // exactly one parent wake, not two
+  })
+
+  it('suppresses a FAILED completion the CLI already reported, too', () => {
+    const d = decideSubagentHandback({
+      ...base,
+      outcome: 'failed',
+      cliTaskNotificationSeen: true,
+    })
+    expect(d).toEqual({ deliver: false, reason: 'cli-task-notification' })
+  })
+
+  // ── Outcome (b): fail-open — a handback with NO matching notification fires ─
+  it('fail-open: delivers when no notification was seen (flag false)', () => {
+    const d = decideSubagentHandback({ ...base, cliTaskNotificationSeen: false })
+    expect(d.deliver).toBe(true)
+    if (d.deliver) {
+      expect(d.chatId).toBe('777')
+      expect(d.inbound.meta?.source).toBe('subagent_handback')
+    }
+  })
+
+  it('fail-open: delivers when the flag is omitted entirely (older callers)', () => {
+    const d = decideSubagentHandback({ ...base })
+    expect(d.deliver).toBe(true)
+  })
+
+  it('fail-open end-to-end: a notification for a DIFFERENT agent id does not suppress', () => {
+    const ledger = new CliTaskNotificationLedger()
+    for (const ev of projectTranscriptLine(notifLine('a999999999999999', 'completed'))) {
+      if (ev.kind === 'task_notification') ledger.record(ev.taskId, ev.status, T0)
+    }
+    const d = decideSubagentHandback({
+      ...base,
+      cliTaskNotificationSeen: ledger.seenRecently(base.jsonlAgentId, T0 + 2_000),
+    })
+    expect(d.deliver).toBe(true)
+  })
+
+  it('fail-open end-to-end: an EXPIRED notification does not suppress', () => {
+    const ledger = new CliTaskNotificationLedger()
+    ledger.record(base.jsonlAgentId, 'completed', T0)
+    const d = decideSubagentHandback({
+      ...base,
+      cliTaskNotificationSeen: ledger.seenRecently(
+        base.jsonlAgentId,
+        T0 + TASK_NOTIFICATION_DEDUP_TTL_MS + 1,
+      ),
+    })
+    expect(d.deliver).toBe(true)
+  })
+
+  it('gate ordering: foreground/outcome/env gates still win over the dedup reason', () => {
+    expect(
+      decideSubagentHandback({ ...base, isBackground: false, cliTaskNotificationSeen: true }),
+    ).toEqual({ deliver: false, reason: 'foreground' })
+    expect(
+      decideSubagentHandback({ ...base, outcome: 'orphan', cliTaskNotificationSeen: true }),
+    ).toEqual({ deliver: false, reason: 'outcome-not-terminal' })
+    expect(
+      decideSubagentHandback({ ...base, handbackEnvValue: '0', cliTaskNotificationSeen: true }),
+    ).toEqual({ deliver: false, reason: 'env-disabled' })
+  })
+})
+
+// ── Outcome (c): the task-notification keeps working as a liveness signal ────
+// Recording into the dedup ledger is an ADDITIVE read of the same event; the
+// background-shell-liveness consumer must still see the shell as DEAD.
+describe('task_notification still drives background-shell liveness (not swallowed)', () => {
+  it('one projected event feeds BOTH the liveness registry and the dedup ledger', () => {
+    const dead: string[] = []
+    const alive: string[] = []
+    const registry = {
+      noteBackgroundShellAlive: (_k: string, id: string) => void alive.push(id),
+      noteBackgroundShellDead: (_k: string, id: string) => void dead.push(id),
+    }
+    const ledger = new CliTaskNotificationLedger()
+    const events = projectTranscriptLine(notifLine('bxa4sv3dq', 'completed'))
+    expect(events).toHaveLength(1)
+    for (const ev of events) {
+      applyBackgroundShellLiveness(registry, 'chat:-', ev)
+      if (ev.kind === 'task_notification') ledger.record(ev.taskId, ev.status, T0)
+    }
+    expect(dead).toEqual(['bxa4sv3dq']) // liveness signal intact
+    expect(ledger.seenRecently('bxa4sv3dq', T0 + 1)).toBe(true) // dedup recorded
+    expect(alive).toEqual([])
+  })
+
+  it('a foreground-shell task-notification with NO handback in flight changes nothing else', () => {
+    // A background Bash shell death has no subagent-watcher onFinish — the
+    // ledger entry simply ages out; nothing consults it for shells.
+    const ledger = new CliTaskNotificationLedger()
+    ledger.record('bxa4sv3dq', 'completed', T0)
+    expect(ledger.seenRecently('bxa4sv3dq', T0 + TASK_NOTIFICATION_DEDUP_TTL_MS + 1)).toBe(false)
+  })
+})
+
+// ── Wiring pins — the gateway must actually consult the ledger ───────────────
+// gateway.ts is not unit-instantiable; pin the two wiring sites statically
+// (repo precedent: subagent-handback-marker.test.ts scans gateway source).
+describe('gateway wiring pins', () => {
+  const here = dirname(fileURLToPath(import.meta.url))
+  const gatewaySrc = readFileSync(join(here, '..', 'gateway', 'gateway.ts'), 'utf8')
+
+  it('onSessionEvent records terminal task-notifications into the ledger', () => {
+    expect(gatewaySrc).toMatch(
+      /if \(ev\.kind === 'task_notification'\) cliTaskNotifLedger\.record\(ev\.taskId, ev\.status, Date\.now\(\)\)/,
+    )
+  })
+
+  it('the onFinish decide callsite passes the fail-open seenRecently read', () => {
+    expect(gatewaySrc).toMatch(
+      /cliTaskNotificationSeen: cliTaskNotifLedger\.seenRecently\(agentId, Date\.now\(\)\)/,
+    )
+  })
+})


### PR DESCRIPTION
## Summary

One background sub-agent completion produced **two independent wakes** of the parent session — and two user-visible replies:

1. **CLI-native `<task-notification>`** — the claude CLI proactively enqueues it into the parent session when a backgrounded task/agent completes. Switchroom read it only as a background-shell liveness signal (`session-tail.ts:567` → `task_notification` event; `gateway/background-shell-liveness.ts:48`) and never suppressed anything.
2. **Gateway-synthesized `subagent_handback`** — the deliberate beat-4 wake (builder `gateway/subagent-handback-inbound-builder.ts`; subagent-watcher `onFinish` → `pendingInboundBuffer.push`).

Nothing linked them. The CLI-native wake cannot be suppressed (it is the CLI's internal queue), so this PR gates the one lever switchroom holds — the handback enqueue — on a recently-seen **terminal** `<task-notification>` for **exactly the same task id**.

**Key grounding:** the notification's `<task-id>` IS the sub-agent watcher's `agentId` — both are the `agent-<id>.jsonl` stem. Verified against live fleet transcripts: `<task-id>a204deeaedb27b580</task-id>` ↔ `subagents/agent-a204deeaedb27b580.jsonl`. The match is exact-id, never heuristic.

## Mechanism (and why it is fail-open)

`CliTaskNotificationLedger` (colocated in `gateway/subagent-handback-marker.ts` — gateway.ts sits 2 lines under its anti-inflation ratchet ceiling, so the wiring is exactly two lines): written at `onSessionEvent` (deliberately **outside** the `currentTurn` guard — the CLI enqueues while the parent is idle with no live gateway turn), read as a new optional input `cliTaskNotificationSeen` to the pure `decideSubagentHandback` gate (new skip reason `cli-task-notification`, ordered after env/outcome/foreground, before no-chat).

Every uncertain path **delivers** the handback — a dropped real wake (silent worker, user waits forever) is strictly worse than an occasional double:

- no notification for this exact id → deliver
- notification older than the 30s TTL → deliver (a resumed worker's second completion is never swallowed by its first completion's entry)
- non-terminal status → never recorded → deliver
- gateway restart (in-memory ledger) → boot-replayed handbacks deliver
- notification landing after the enqueue (lost race) → deliver — the residual occasional double, accepted by design
- `handback-orphan-recovery.ts` re-injects bypass the decide gate entirely → recovery always delivers

The liveness consumer is untouched: the same `task_notification` event still drives `noteBackgroundShellDead`.

## Tests — RED-before / GREEN-after

`telegram-plugin/tests/handback-tasknotif-dedup.test.ts` (17 tests, all green on this branch; adjacent handback/session-tail/liveness suites all green, 142 tests total):

- **(a) one completion → one wake:** with a notification recorded for the exact id, `decideSubagentHandback` suppresses (`reason: 'cli-task-notification'`) — **RED on pre-fix code** (verified by stashing only the builder: exactly the 2 suppress tests fail behaviorally, the handback delivers), GREEN post-fix.
- **(b) fail-open:** no-match / different-id / expired-TTL / omitted-flag all deliver — pinned (these pass pre- and post-fix by design; they guard the fail-open contract against future regression).
- **(c) liveness not swallowed:** a real captured `queue-operation` line projected through `projectTranscriptLine` feeds BOTH `applyBackgroundShellLiveness` (shell marked dead) and the ledger in one pass; background-shell (`bxa4sv3dq`-shaped) notifications age out harmlessly since nothing consults the ledger for shells.
- Static wiring pins on the two `gateway.ts` sites (repo precedent: the marker exhaustiveness scan).

Local: scoped vitest green; `tsc --noEmit` (root) clean; all lint guards green including the gateway line ratchet (24855 ≤ 24805+50). The plugin-tsc `uat/*.ts` mtcute typing errors reproduce identically on pristine `origin/main` in this sandbox (noexec `/tmp`, `--ignore-scripts` install) — environment artifact; CI is the authority.

## Sibling audit — the same duplicate-delivery class, swept

Every synthesized inbound source in `INBOUND_SOURCE_CLASSIFICATION` was assessed for "can one underlying event produce two wakes". Verdicts (v0.20.7 anchors):

**Affected (follow-ups filed):**
- `cron` Tier-1 cheap-cron — the bridge-register drain at `gateway.ts:10376` bypasses `redeliverBufferedInbound` and never `spool.ack`s → duplicate fire after restart. **#4348** (also the only known bypass of the exit chokepoint — highest-value structural fix).
- `vault_grant_*` / `vault_save_*` — approve flow holds the pending entry across passphrase/mint awaits with no reaper-collision re-check (`callback-query-handlers.ts:1584`→`:1170`) → timeout + approved can both fire. **#4350**
- `webhook`/`linear` — dedup gated `source === 'github'` (`webhook-gateway-record.ts:138`); Linear retries have no idempotency key. **#4351**

**Safe / guarded:** `subagent_progress` (spoolId + TTL + handback sweep), Tier-2 `cron` (ack'd drain + `s:cron-replay` keys), `resume_*` (single slot + `s:resume:<turn_key>` + `markTurnResumed` ledger; original-inbound double structurally excluded), `obligation_represent` (closed by cec68e11's delivery-time `beforeRedeliver` guard), `secret_*` / `mental_model_*` / `skill_proposal_apply` (synchronous consume-before-await), `bridge_dead_restart` (structural mutual exclusion with resume), `missed_approval_retry` (digest consumed first), `warmup` (cooldown, never spooled), `reaction`, `buzz`, `boot_briefing` (content-deduped, deliberate).

**Shared-chokepoint assessment:** `pendingInboundBuffer.push` / `redeliverBufferedInbound` + the spool's `spoolId` already form the intra-gateway dedup layer, and `beforeRedeliver` is the right shared seam for delivery-time retraction (the represent guard proves it). But **cross-transport doubles — a CLI-native signal or a provider retry pairing with a gateway synthesis — cannot be covered there**: the second wake never traverses the buffer. Those are legitimately point-guards, which is why this PR ships the ledger as a point patch rather than forcing a shared layer, and why the class registry doc in `subagent-handback-marker.ts` now records the pattern.

## Risk

Worst case of a wrong suppress is bounded: it requires an exact-id terminal notification within 30s, which by construction means the CLI itself already woke the parent with this completion (summary + output file in hand). Worst case of the guard failing is the status quo (occasional double). No behavior change for foreground sub-agents, shells, or any other synthesized source.

Job spec: `reference/jobs/know-what-my-agent-is-doing.md` (its outcome UAT covers the handback: `jtbd-subagent-handback-dm`); vision outcome "hold the leash" — one clean handback, no duplicate agent chatter. Candidate for v0.20.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
