### PR TITLE
fix(gateway): route cheap-cron bridge-register drain through the spool-ack chokepoint (#4348)

### DIFF
--- a/telegram-plugin/gateway/cron-session.ts
+++ b/telegram-plugin/gateway/cron-session.ts
@@ -17,6 +17,10 @@
  * target via `cronIdentity()`. Pure string fns — pinned in cron-session.test.ts.
  */
 
+import type { InboundMessage, GatewayToClient } from './ipc-protocol.js'
+import type { InboundSpool } from './inbound-spool.js'
+import { redeliverBufferedInbound, type PendingInboundBuffer } from './pending-inbound-buffer.js'
+
 /** Suffix that distinguishes a cron-session bridge from the main agent bridge. */
 export const CRON_IDENTITY_SUFFIX = "-cron";
 
@@ -139,4 +143,66 @@ export function deliverInjectWithFallback(
     return { target: agentName, delivered: true, fellBackToMain: true };
   }
   return { target, delivered: false, fellBackToMain: false };
+}
+
+/** Minimal view of the IPC client the cron-bridge register handler needs.
+ *  A structural subset of `IpcClient` so this stays unit-testable without the
+ *  gateway's module-load side effects. */
+export interface CronBridgeRegisterClient {
+  agentName: string | null | undefined;
+  send: (msg: GatewayToClient) => void;
+}
+
+/**
+ * Drain a cheap-cron (`<agent>-cron`) bridge's buffered fires when it
+ * registers — the Tier-1 §2.4/§3.3 status-silent path (#4348).
+ *
+ * The cron bridge is STATUS-SILENT: it must NOT drive the gateway's singleton
+ * machinery (shadow bridge-state, warmup, boot card). But it MUST still flush
+ * any cron fire buffered+spooled during the boot window — a due tick that
+ * arrived before the cron bridge registered.
+ *
+ * THE BUG (#4348): the pre-fix path did a raw `pendingInboundBuffer.drain()` +
+ * `client.send()` loop and returned early WITHOUT ever reaching `spool.ack`.
+ * `spool.ack` lives ONLY inside `redeliverBufferedInbound` — the one chokepoint
+ * every other drain path (bridgeUp, idle-drain, silence-poke, turn-end) routes
+ * through. So the durable spool entry stayed live, boot-replay re-pushed it on
+ * the next restart, and the SAME cron fire re-fired: a duplicate delivery
+ * bounded only by the 15-min escalation sweep. This was the ONLY drain that
+ * bypassed the chokepoint.
+ *
+ * THE FIX: route the drain through `redeliverBufferedInbound` too, so each
+ * delivered fire is spool-acked exactly once and cannot re-fire after a
+ * restart. `beforeRedeliver` (the represent-veto) rides along by construction;
+ * it self-gates and is a no-op for cron-sourced fires. A `send` throw now
+ * re-buffers the fire (lossless) instead of dropping it — strictly safer than
+ * the pre-fix best-effort drop and identical to every sibling drain path.
+ *
+ * Returns the `redeliverBufferedInbound` counts for observability.
+ */
+export function drainCronBridgeOnRegister(
+  client: CronBridgeRegisterClient,
+  buffer: PendingInboundBuffer,
+  spool?: InboundSpool,
+  log?: (line: string) => void,
+): { drained: number; redelivered: number; rebuffered: number; retracted: number } {
+  // Status-silent handshake ack (unchanged from the pre-fix path).
+  client.send({ type: "status", status: "agent_connected" });
+  const send = (msg: InboundMessage): boolean => {
+    try {
+      client.send(msg);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  const result = redeliverBufferedInbound(buffer, client.agentName ?? "", send, spool);
+  if (result.drained > 0 && log != null) {
+    log(
+      `telegram gateway: cron-bridge drain agent=${client.agentName} ` +
+        `drained=${result.drained} redelivered=${result.redelivered} ` +
+        `rebuffered=${result.rebuffered}\n`,
+    );
+  }
+  return result;
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -660,7 +660,7 @@ import { handleRequestMs365Approval } from './ms365-write-approval.js'
 import { buildDiffPreviewCard } from './diff-preview-card.js'
 import { createPendingInboundBuffer, redeliverBufferedInbound, idleDrainTick } from './pending-inbound-buffer.js'
 import { makeRepresentRedeliveryGuard, makeSessionBusyDrainDeferral } from './represent-delivery-guard.js'
-import { isCronIdentity, isCronInjectFire, deliverInjectWithFallback, replyCallerIsForeignSession } from './cron-session.js'
+import { isCronIdentity, isCronInjectFire, deliverInjectWithFallback, replyCallerIsForeignSession, drainCronBridgeOnRegister } from './cron-session.js'
 import {
   ObligationLedger,
   obligationEscalationText,
@@ -10366,17 +10366,13 @@ if (isGatewayMain) ipcServer = createIpcServer({
 
   onClientRegistered(client: IpcClient) {
     process.stderr.write(`telegram gateway: bridge registered — agent=${client.agentName}\n`)
-    // Cheap-cron (§2.4/§3.3): a `<agent>-cron` bridge is the Tier-1 cheap
-    // session. It is STATUS-SILENT — it must NOT drive the gateway's
-    // singleton machinery (shadow bridge-state, warmup, boot card, which all
-    // track the MAIN agent's liveness). Drain any buffered cron fire to it
-    // (so a fire that triggered a lazy spawn lands), then return early.
+    // Cheap-cron (§2.4/§3.3): a `<agent>-cron` bridge is the Tier-1 cheap,
+    // STATUS-SILENT session — it must NOT drive the gateway's singleton
+    // machinery. Drain any boot-window cron fire to it, then return early.
+    // #4348: the drain routes through `redeliverBufferedInbound` (the shared
+    // ack chokepoint) so a spooled fire is acked and never re-fires on restart.
     if (isCronIdentity(client.agentName)) {
-      client.send({ type: 'status', status: 'agent_connected' })
-      const pending = pendingInboundBuffer.drain(client.agentName ?? '')
-      for (const m of pending) {
-        try { client.send(m) } catch { /* cron fire drop — best-effort, like today's cron */ }
-      }
+      drainCronBridgeOnRegister(client, pendingInboundBuffer, inboundSpool ?? undefined, (l) => process.stderr.write(l))
       return
     }
     // Phase 2b shadow: ONLY emit bridgeUp for the REAL bridge sidecar

--- a/telegram-plugin/tests/cron-bridge-drain-spool-ack.test.ts
+++ b/telegram-plugin/tests/cron-bridge-drain-spool-ack.test.ts
@@ -1,0 +1,150 @@
+/**
+ * #4348 — the Tier-1 cheap-cron bridge-register drain must route through the
+ * shared `redeliverBufferedInbound` chokepoint so a delivered cron fire is
+ * `spool.ack`'d exactly once and CANNOT re-fire after a restart.
+ *
+ * The bug: `onClientRegistered`'s `<agent>-cron` branch did a raw
+ * `pendingInboundBuffer.drain()` + `client.send()` loop and returned early,
+ * never reaching `spool.ack` (which lives only inside
+ * `redeliverBufferedInbound`). A due cron tick spooled during the boot window
+ * (before the cron bridge registered) stayed live in the durable spool, so
+ * boot-replay re-pushed it on the next restart and the SAME fire was delivered
+ * a second time — a duplicate cron delivery bounded only by the 15-min
+ * escalation sweep.
+ *
+ * These tests assert the OUTCOME on the real drain seam
+ * (`drainCronBridgeOnRegister`), against a REAL spool + buffer:
+ *   1. the boot-window fire is delivered to the cron bridge, AND
+ *   2. its durable spool entry is acked (liveCount → 0), AND
+ *   3. a simulated restart's boot-replay finds nothing to re-push, so the fire
+ *      does NOT re-fire.
+ *
+ * RED-before-GREEN: with the pre-#4348 raw-drain body the fire is delivered but
+ * the spool entry stays live, so assertions (2)+(3) fail. With the fix routing
+ * through `redeliverBufferedInbound` they pass.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  createInboundSpool,
+  type InboundSpoolFsSeam,
+  type InboundSpool,
+} from '../gateway/inbound-spool.js'
+import { createPendingInboundBuffer } from '../gateway/pending-inbound-buffer.js'
+import { drainCronBridgeOnRegister, cronIdentity } from '../gateway/cron-session.js'
+import type { InboundMessage } from '../gateway/ipc-protocol.js'
+
+const SPOOL_PATH = '/state/agent/telegram/inbound-spool.jsonl'
+
+/** In-memory fake fs for the spool — models append + atomic-rename compaction.
+ *  Shared across "restarts" so the durable JSONL survives, exactly like the
+ *  persistent per-agent volume. */
+function fakeFs(): InboundSpoolFsSeam {
+  const files = new Map<string, string>()
+  return {
+    appendFileSync: (p, d) => files.set(p, (files.get(p) ?? '') + d),
+    readFileSync: (p) => files.get(p) ?? '',
+    writeFileSync: (p, d) => files.set(p, d),
+    renameSync: (from, to) => {
+      files.set(to, files.get(from) ?? '')
+      files.delete(from)
+    },
+    existsSync: (p) => files.has(p),
+    statSizeSync: (p) => Buffer.byteLength(files.get(p) ?? ''),
+    fsyncFileSync: () => {},
+    fsyncDirSync: () => {},
+  }
+}
+
+function cronFire(over: Partial<InboundMessage> = {}): InboundMessage {
+  return {
+    type: 'inbound',
+    chatId: 'c1',
+    messageId: 0, // synthetic — cron fires carry no Telegram messageId
+    user: 'system',
+    userId: 0,
+    ts: 1000,
+    text: 'Time for the daily digest',
+    meta: { source: 'cron', session: 'cron' },
+    ...over,
+  } as InboundMessage
+}
+
+/** A capturing stand-in for the just-registered cron IPC client. */
+function fakeClient(agentName: string): {
+  agentName: string
+  send: (msg: unknown) => void
+  sent: unknown[]
+} {
+  const sent: unknown[] = []
+  return { agentName, send: (m) => void sent.push(m), sent }
+}
+
+/** Simulate the gateway's boot-replay: re-push every live (un-acked) spool
+ *  entry into a fresh in-memory buffer, exactly as gateway.ts does at boot. */
+function bootReplayInto(spool: InboundSpool): ReturnType<typeof createPendingInboundBuffer> {
+  const buffer = createPendingInboundBuffer({ log: () => {}, spool })
+  for (const { agent, msg } of spool.liveEntries()) buffer.push(agent, msg)
+  return buffer
+}
+
+describe('#4348 cron-bridge drain routes through the spool-ack chokepoint', () => {
+  it('acks the boot-window cron fire and does not re-fire after restart', () => {
+    const fs = fakeFs()
+    const spool = createInboundSpool({ path: SPOOL_PATH, fs, log: () => {} })
+    const cronAgent = cronIdentity('overlord') // "overlord-cron"
+
+    // Boot window: a due cron tick arrives BEFORE the cron bridge registers.
+    // It is buffered (in-memory) AND durably spooled by the same push.
+    const buffer = createPendingInboundBuffer({ log: () => {}, spool })
+    buffer.push(cronAgent, cronFire())
+    expect(spool.liveCount()).toBe(1) // durably recorded, not yet delivered
+
+    // The cron bridge registers → the drain seam under test runs.
+    const client = fakeClient(cronAgent)
+    const result = drainCronBridgeOnRegister(client, buffer, spool)
+
+    // (1) The fire was delivered to the cron bridge.
+    expect(result.drained).toBe(1)
+    expect(result.redelivered).toBe(1)
+    const deliveredFires = client.sent.filter(
+      (m): m is InboundMessage => (m as InboundMessage).type === 'inbound',
+    )
+    expect(deliveredFires).toHaveLength(1)
+    expect(deliveredFires[0]!.text).toBe('Time for the daily digest')
+
+    // (2) The durable spool entry is tombstoned — the whole point of #4348.
+    expect(spool.liveCount()).toBe(0)
+    expect(spool.liveEntries()).toHaveLength(0)
+
+    // (3) Simulated restart: boot-replay finds nothing to re-push, so the SAME
+    //     fire does NOT re-fire. (Pre-fix this replayed the un-acked entry.)
+    const afterRestart = bootReplayInto(spool)
+    expect(afterRestart.drain(cronAgent)).toHaveLength(0)
+  })
+
+  it('a send failure re-buffers the fire and leaves the spool entry live (lossless)', () => {
+    const fs = fakeFs()
+    const spool = createInboundSpool({ path: SPOOL_PATH, fs, log: () => {} })
+    const cronAgent = cronIdentity('overlord')
+
+    const buffer = createPendingInboundBuffer({ log: () => {}, spool })
+    buffer.push(cronAgent, cronFire())
+
+    // Client whose send throws for inbound fires (bridge wedged mid-drain).
+    const throwing = {
+      agentName: cronAgent,
+      send: (m: unknown) => {
+        if ((m as InboundMessage).type === 'inbound') throw new Error('socket gone')
+      },
+    }
+    const result = drainCronBridgeOnRegister(throwing, buffer, spool)
+
+    // Not delivered → re-buffered, and the spool entry stays LIVE so the next
+    // register (or boot-replay) retries it. Nothing is dropped, nothing acked.
+    expect(result.redelivered).toBe(0)
+    expect(result.rebuffered).toBe(1)
+    expect(spool.liveCount()).toBe(1)
+    expect(buffer.drain(cronAgent)).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
Closes #4348.

## Problem

The Tier-1 cheap-cron (`<agent>-cron`) bridge-register branch in `onClientRegistered` (`telegram-plugin/gateway/gateway.ts`) drained buffered cron fires with a **raw `pendingInboundBuffer.drain()` + `client.send()` loop and returned early**, never reaching `spool.ack`.

`spool.ack` lives ONLY inside `redeliverBufferedInbound` (`pending-inbound-buffer.ts:130-199`) — the one chokepoint every other drain path (bridgeUp, idle-drain, silence-poke, turn-end) routes through, hosting both the `beforeRedeliver` veto and the durable spool tombstone.

So a due cron tick spooled during the **boot window** (before the cron bridge registered) stayed live in the durable spool. Boot-replay (`gateway.ts` boot-replay loop) re-pushed it on the next restart and the SAME fire was delivered a second time — a **duplicate cron delivery**, bounded only by the 15-min escalation sweep. This was the only known drain that bypassed the chokepoint.

Root cause confirmed live against `origin/main` (`bc107185`): the cron-identity early-return skipped the ack.

## Fix — converge on the shared chokepoint

Extracted the drain into `drainCronBridgeOnRegister` (`cron-session.ts`), which routes through `redeliverBufferedInbound`. Each delivered fire is now `spool.ack`'d exactly once and cannot re-fire after a restart. Extracting it (rather than bolting a second ad-hoc ack onto the bypass) removes the last chokepoint bypass **and** makes the boot-window path unit-testable without gateway.ts's module-load side effects.

Behavioural note: a `send` throw now **re-buffers** the fire (lossless) instead of dropping it — strictly safer than the pre-fix best-effort drop, and identical to every sibling drain path. `beforeRedeliver` rides along by construction and is a no-op for cron-sourced fires.

## Test — asserts the outcome, RED-before-GREEN

`telegram-plugin/tests/cron-bridge-drain-spool-ack.test.ts` exercises the real drain seam against a real spool + buffer:
1. the boot-window fire is delivered to the cron bridge,
2. its durable spool entry is acked (`liveCount → 0`), and
3. a **simulated restart's boot-replay finds nothing to re-push** — no duplicate fire.

Plus a lossless case: a throwing `send` re-buffers the fire and leaves the spool entry live.

**RED-before-GREEN verified locally:** with the pre-#4348 raw-drain body the fire is delivered but the spool entry stays live, so the ack/no-refire assertions fail; routing through `redeliverBufferedInbound` makes them pass.

## Local verification

- `npx vitest run` on the new test + `cron-session`, `inbound-spool`, `pending-inbound-buffer`, `inbound-delivery-machine-dispatch` — all green.
- `npm run lint` (full gate: `tsc --noEmit` + all guards, including the gateway-line ratchet) — green. gateway.ts net **shrinks** (logic moved into the module).

## Follow-ups filed

- Dead import: `redeliverBufferedInbound` in `gateway.ts` is now referenced only in comments (was already unused on `main`). Left out of this single-concern PR — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)