### PR TITLE
feat(worktree): extend gc to sweep per-agent home/work task trees (RFC §4)

### DIFF
--- a/src/cli/worktree.ts
+++ b/src/cli/worktree.ts
@@ -20,6 +20,7 @@ import {
   planGc,
   applyGc,
   defaultRoots,
+  defaultTaskTreeRoots,
   trashRoot,
   listTrashEntries,
   selectPurgeTargets,
@@ -236,16 +237,31 @@ export function registerWorktreeCommand(program: Command): void {
   worktree
     .command("gc")
     .description(
-      "Reclaim dev worktrees that outlived their PR.\n" +
+      "Reclaim dev worktrees that outlived their PR, and per-agent task trees.\n" +
         "Dry-run by default; pass --yes to act. Quarantines orphaned worktree\n" +
         "directories (move, not delete) and removes registered worktrees whose\n" +
-        "PR is MERGED and whose tree is clean.",
+        "PR is MERGED and whose tree is clean. Also sweeps per-agent home/work\n" +
+        "task trees (all shapes) that are clean + pushed + idle + merged/closed;\n" +
+        "dead-but-dirty/unpushed trees are surfaced and reclaimed only with\n" +
+        "--reclaim-dirty (reversible quarantine).",
     )
     .option(
       "--root <dir>",
-      "Scan root (repeatable). Default: ~/code",
+      "Dev-worktree scan root (repeatable). Default: ~/code",
       (val: string, acc: string[]) => [...acc, val],
       [] as string[],
+    )
+    .option(
+      "--task-root <dir>",
+      "Task-tree scan root (repeatable). Default: every agent's home/work + home/workspace",
+      (val: string, acc: string[]) => [...acc, val],
+      [] as string[],
+    )
+    .option("--no-task-roots", "Skip the per-agent task-tree sweep entirely")
+    .option("--idle-days <days>", "Idle threshold for task trees (default 14)", "14")
+    .option(
+      "--reclaim-dirty",
+      "Operator escape hatch: quarantine IDLE dirty/unpushed task trees (reversible)",
     )
     .option("--yes", "Actually act (default is dry-run)")
     .option("--json", "Output raw JSON")
@@ -254,6 +270,10 @@ export function registerWorktreeCommand(program: Command): void {
     .action(
       (opts: {
         root: string[];
+        taskRoot: string[];
+        taskRoots?: boolean;
+        idleDays: string;
+        reclaimDirty?: boolean;
         yes?: boolean;
         json?: boolean;
         purgeTrash?: boolean;
@@ -287,9 +307,27 @@ export function registerWorktreeCommand(program: Command): void {
         }
 
         const roots = opts.root.length > 0 ? opts.root : defaultRoots();
+        const taskTreeRoots =
+          opts.taskRoots === false
+            ? []
+            : opts.taskRoot.length > 0
+              ? opts.taskRoot
+              : defaultTaskTreeRoots();
+        const parsedIdle = Number(opts.idleDays);
+        const idleDays = Number.isFinite(parsedIdle) && parsedIdle >= 0 ? parsedIdle : 14;
         const dateStamp = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-        const plan = planGc(roots, { dateStamp });
+        const plan = planGc(
+          roots,
+          { dateStamp, idleDays, escapeHatch: opts.reclaimDirty },
+          taskTreeRoots,
+        );
         const toRemove = plan.registered.filter((r) => r.verdict === "remove");
+        const taskReap = plan.taskTrees.filter((t) => t.willAct);
+        // Surfaced-but-untouched: dead-but-dirty/unpushed trees the escape hatch
+        // would reclaim (RFC §4). Shown so the consequence is operator-visible.
+        const taskEscape = plan.taskTrees.filter(
+          (t) => !t.willAct && t.idle && (t.verdict === "skip-dirty" || t.verdict === "skip-unpushed"),
+        );
 
         if (!opts.yes) {
           if (opts.json) {
@@ -306,10 +344,33 @@ export function registerWorktreeCommand(program: Command): void {
             console.log(chalk.dim(`\nKept (${skips.length}):`));
             for (const r of skips) console.log(chalk.dim(`  ${r.verdict.replace("skip-", "")}: ${r.path} [${r.branch}] (pr=${r.prSignal})`));
           }
+          if (taskTreeRoots.length) {
+            const label = opts.reclaimDirty ? "reclaim (reap + escape-hatch)" : "reap (clean + pushed + idle + merged/closed)";
+            console.log(`\nTask trees to ${label}: ${chalk.bold(taskReap.length)}`);
+            for (const t of taskReap)
+              console.log(`  ${t.dir}  ${chalk.dim(`[${t.branch ?? "detached"}] ${t.shape} ${t.verdict} → ${t.dest}`)}`);
+            if (taskEscape.length) {
+              console.log(
+                chalk.yellow(
+                  `\nDead-but-dirty/unpushed task trees kept (${taskEscape.length}) — reclaim with --reclaim-dirty:`,
+                ),
+              );
+              for (const t of taskEscape)
+                console.log(chalk.dim(`  ${t.verdict.replace("skip-", "")}: ${t.dir} [${t.branch ?? "detached"}] ${t.shape}`));
+            }
+            const taskKept = plan.taskTrees.filter(
+              (t) => !t.willAct && !(t.idle && (t.verdict === "skip-dirty" || t.verdict === "skip-unpushed")) && t.verdict !== "skip-protected",
+            );
+            if (taskKept.length) {
+              console.log(chalk.dim(`\nOther task trees kept (${taskKept.length}):`));
+              for (const t of taskKept)
+                console.log(chalk.dim(`  ${t.verdict.replace("skip-", "")}: ${t.dir} [${t.branch ?? "detached"}] (pr=${t.prSignal})`));
+            }
+          }
           if (plan.skipped.length) {
             console.log(chalk.dim(`\nIgnored non-switchroom dirs: ${plan.skipped.length}`));
           }
-          console.log(chalk.dim("\nRe-run with --yes to act. Orphans are MOVED to the trash dir, not deleted."));
+          console.log(chalk.dim("\nRe-run with --yes to act. Reclaimed trees are MOVED to the trash dir, not deleted."));
           return;
         }
 
@@ -317,9 +378,16 @@ export function registerWorktreeCommand(program: Command): void {
         if (opts.json) {
           console.log(JSON.stringify(result));
         } else {
-          console.log(chalk.green(`Quarantined ${result.quarantined.length} orphan(s) → ${plan.trashDir}`));
+          console.log(chalk.green(`Quarantined ${result.quarantined.length} dir(s) → ${plan.trashDir}`));
           console.log(chalk.green(`Removed ${result.removed.length} merged worktree(s); deleted ${result.branchesDeleted.length} branch(es).`));
           console.log(chalk.dim(`Pruned metadata in ${result.pruned.length} repo(s).`));
+          if (taskEscape.length && !opts.reclaimDirty) {
+            console.log(
+              chalk.yellow(
+                `\n${taskEscape.length} dead-but-dirty/unpushed task tree(s) were kept. Reclaim reversibly with --reclaim-dirty.`,
+              ),
+            );
+          }
           for (const e of result.errors) console.warn(chalk.yellow(e));
           console.log(chalk.dim(`\nQuarantined dirs are recoverable until \`switchroom worktree gc --purge-trash --yes\`.`));
         }

--- a/src/worktree/gc.ts
+++ b/src/worktree/gc.ts
@@ -44,6 +44,7 @@ import {
 import { homedir } from "node:os";
 import { join, resolve, basename } from "node:path";
 import { listRecords } from "./registry.js";
+import { probePathInUse, type PathUseState } from "./reaper.js";
 
 // ── pure helpers ────────────────────────────────────────────────────────────
 
@@ -177,6 +178,116 @@ export function isEphemeralPath(path: string): boolean {
   return false;
 }
 
+// ── task-tree (home/work) coverage — RFC §4 ─────────────────────────────────
+//
+// The dev-worktree sweep above (Phase A/B) roots at ~/code and, via
+// `looksLikeAgentWorktree`, deliberately SKIP-protects anything under a
+// `work/` path — so per-task trees an agent/harness drops at
+// `~/.switchroom/agents/<name>/home/work/<slug>` are never touched, and grow
+// without bound (the ~25G+ overhang). RFC §4 closes that gap with a dedicated,
+// guard-gated sweep of the task-tree roots.
+//
+// Task trees are NOT uniformly git worktrees. A live census found three shapes:
+//   - "worktree" — `.git` is a FILE pointing at an owner repo's admin dir.
+//   - "clone"    — `.git` is a DIRECTORY (a full standalone clone, or a repo
+//                  nested inside another checkout). Same handling: it responds
+//                  to `git -C <dir> …` identically, and is quarantined as a
+//                  self-contained directory.
+// A naive coverage that keyed off worktree detection (as the old `work/` skip
+// does) would miss the majority of the overhang (the clones + nested repos).
+// Both shapes go through the SAME guard gauntlet below; only the post-reclaim
+// bookkeeping differs (a reaped worktree also prunes its owner repo's admin
+// metadata).
+
+/** Physical shape of a task-tree candidate directory. */
+export type TaskTreeShape = "worktree" | "clone";
+
+/**
+ * Push state of a task tree's branch. Everything other than `pushed` fails
+ * toward preservation (the tree is kept, or only the operator escape hatch
+ * may quarantine it).
+ */
+export type PushState = "pushed" | "unpushed" | "no-upstream" | "detached" | "error";
+
+/** Derive the push state from raw git facts. Pure, for unit testing. */
+export function pushStateFrom(opts: {
+  detached: boolean;
+  upstream: string | null;
+  /** commit count of `@{upstream}..HEAD`; negative ⇒ the count command failed. */
+  aheadCount: number;
+}): PushState {
+  if (opts.detached) return "detached";
+  if (!opts.upstream) return "no-upstream";
+  if (opts.aheadCount < 0) return "error";
+  if (opts.aheadCount > 0) return "unpushed";
+  return "pushed";
+}
+
+/**
+ * True for the agent's STABLE per-repo tree branch (`agent/<name>/main`,
+ * `agent-worktree.ts`). That tree is durable identity, not a disposable task
+ * tree, and must never be reaped even if it somehow lands under a task root.
+ */
+export function isStablePerRepoBranch(branch: string | null): boolean {
+  return !!branch && /^agent\/[^/]+\/main$/.test(branch);
+}
+
+export type TaskTreeVerdict =
+  /** clean + pushed + idle + (merged|closed) PR + provably free → reclaim. */
+  | "reap"
+  /** registry-claimed / stable per-repo tree / ephemeral mount → never touch. */
+  | "skip-protected"
+  /** no fuser/lsof to prove it idle → treat as live, keep (fail-safe). */
+  | "skip-probe-unavailable"
+  /** a live process holds the path open → keep. */
+  | "skip-in-use"
+  /** uncommitted effective changes → keep (escape-hatch eligible). */
+  | "skip-dirty"
+  /** detached / no upstream / commits ahead of upstream → keep (escape-hatch eligible). */
+  | "skip-unpushed"
+  /** newest tracked mtime within the idle window → keep. */
+  | "skip-active"
+  /** couldn't determine the PR state → keep. */
+  | "skip-unknown"
+  /** PR still open / no PR → keep. */
+  | "skip-unmerged";
+
+export interface TaskTreeClassifyInput {
+  isRegistryClaimed: boolean;
+  isStablePerRepoTree: boolean;
+  isEphemeralPath: boolean;
+  clean: boolean;
+  pushed: PushState;
+  prSignal: PrSignal;
+  idle: boolean;
+  inUse: PathUseState;
+}
+
+/**
+ * Decide the fate of ONE task tree. Order is safety-first — every guard that
+ * can preserve fires before the single `reap` outcome, and the two data-loss
+ * guards (in-use, dirty) come before anything the escape hatch can act on, so a
+ * live or dirty-and-in-use tree can never be quarantined.
+ */
+export function classifyTaskTree(i: TaskTreeClassifyInput): TaskTreeVerdict {
+  if (i.isRegistryClaimed || i.isStablePerRepoTree || i.isEphemeralPath) {
+    return "skip-protected";
+  }
+  // In-use guards come first: a tree a live process holds is never eligible for
+  // reap OR for the escape hatch, even if it is also dirty.
+  if (i.inUse === "unavailable") return "skip-probe-unavailable";
+  if (i.inUse === "in-use") return "skip-in-use";
+  // Data-loss guards. Both are escape-hatch eligible (operator quarantines,
+  // reversibly) but never auto-reaped.
+  if (!i.clean) return "skip-dirty";
+  if (i.pushed !== "pushed") return "skip-unpushed";
+  // Freshness before the PR signal so an active tree never spends a `gh` call.
+  if (!i.idle) return "skip-active";
+  if (i.prSignal === "error") return "skip-unknown";
+  if (i.prSignal !== "merged" && i.prSignal !== "closed") return "skip-unmerged";
+  return "reap";
+}
+
 // ── plan types ──────────────────────────────────────────────────────────────
 
 export interface OrphanAction {
@@ -193,11 +304,32 @@ export interface RegisteredAction {
   repo: string;
 }
 
+export interface TaskTreeAction {
+  dir: string;
+  shape: TaskTreeShape;
+  /** owner repo (worktree shape only) — pruned after reclaim; null for a clone. */
+  ownerRepo: string | null;
+  branch: string | null;
+  verdict: TaskTreeVerdict;
+  prSignal: PrSignal;
+  idle: boolean;
+  /** quarantine destination when this tree is actioned. */
+  dest: string;
+  /**
+   * True iff this run will move the tree to trash: an automatic `reap`, or —
+   * when the operator escape hatch (`escapeHatch`) is on — an IDLE
+   * dirty/unpushed tree. Everything else is surfaced but untouched.
+   */
+  willAct: boolean;
+}
+
 export interface GcPlan {
   roots: string[];
+  taskTreeRoots: string[];
   trashDir: string;
   orphans: OrphanAction[];
   registered: RegisteredAction[];
+  taskTrees: TaskTreeAction[];
   reposToPrune: string[];
   skipped: { dir: string; reason: string }[];
 }
@@ -214,6 +346,21 @@ export interface GcDeps {
   prSignal?: (repo: string, branch: string) => PrSignal;
   /** ISO-ish date stamp for the quarantine subdir (no Date.now in tests). */
   dateStamp?: string;
+
+  // ── task-tree (home/work) sweep seams (RFC §4) ──
+  /** Probe whether a path is held open by a live process. Default: reaper's. */
+  probeInUse?: (path: string) => PathUseState;
+  /** Newest tracked-file mtime (ms) under a task tree. Default: `git ls-files`. */
+  newestTrackedMtimeMs?: (dir: string) => number;
+  /** Idle threshold in days for a task tree (default 14). */
+  idleDays?: number;
+  /** "now" in ms for the idle comparison (default Date.now). */
+  nowMs?: number;
+  /**
+   * Operator escape hatch: when true, IDLE dirty/unpushed task trees are
+   * quarantined (reversibly) rather than merely surfaced. Default false.
+   */
+  escapeHatch?: boolean;
 }
 
 const defaultExec = (file: string, args: string[], cwd?: string): string =>
@@ -245,6 +392,36 @@ function defaultPrSignal(repo: string, branch: string, exec: GcDeps["exec"]): Pr
   }
 }
 
+/**
+ * Newest mtime (ms) across a task tree's git-TRACKED files — the RFC §2 idle
+ * signal. `git ls-files` excludes `node_modules` and other untracked/ignored
+ * churn, so a `bun install` does not reset the clock. On ANY error we return
+ * `Date.now()` (age 0 ⇒ not idle ⇒ keep) — fail toward preservation.
+ */
+function defaultNewestTrackedMtimeMs(
+  dir: string,
+  exec: NonNullable<GcDeps["exec"]>,
+): number {
+  let out: string;
+  try {
+    out = exec("git", ["-C", dir, "ls-files", "-z"]);
+  } catch {
+    return Date.now();
+  }
+  const files = out.split("\0").filter(Boolean);
+  let newest = 0;
+  for (const f of files) {
+    try {
+      const m = statSync(join(dir, f)).mtimeMs;
+      if (m > newest) newest = m;
+    } catch {
+      /* file vanished mid-scan — ignore */
+    }
+  }
+  // Empty/unreadable tree → treat as active (keep), never as ancient.
+  return newest || Date.now();
+}
+
 /** Default trash root. Override via SWITCHROOM_WORKTREE_TRASH for tests. */
 export function trashRoot(): string {
   return resolve(
@@ -258,9 +435,20 @@ export function trashRoot(): string {
 /**
  * Build a GC plan for the given roots without mutating anything.
  *
- * @param roots   directories whose IMMEDIATE subdirs are candidate worktrees.
+ * @param roots          directories whose IMMEDIATE subdirs are candidate dev
+ *                       worktrees (Phase A/B — the ~/code sweep).
+ * @param taskTreeRoots  per-agent `home/work` roots whose IMMEDIATE subdirs are
+ *                       candidate task trees (Phase C — RFC §4). These are a
+ *                       SEPARATE input, not folded into `roots`, because they
+ *                       carry different semantics (all tree shapes, the
+ *                       `work/` carve-out, the pushed + idle guards, and
+ *                       merged-OR-closed eligibility).
  */
-export function planGc(roots: string[], deps: GcDeps = {}): GcPlan {
+export function planGc(
+  roots: string[],
+  deps: GcDeps = {},
+  taskTreeRoots: string[] = [],
+): GcPlan {
   const exists = deps.existsSync ?? existsSync;
   const readDir = deps.readDir ?? ((p: string) => readdirSync(p));
   const readFile = deps.readFile ?? ((p: string) => readFileSync(p, "utf8"));
@@ -269,6 +457,11 @@ export function planGc(roots: string[], deps: GcDeps = {}): GcPlan {
   const prSignal = deps.prSignal ?? ((repo: string, branch: string) => defaultPrSignal(repo, branch, exec));
   const stamp = deps.dateStamp ?? "undated";
   const trash = join(trashRoot(), stamp);
+  const probeInUse = deps.probeInUse ?? probePathInUse;
+  const newestMtime = deps.newestTrackedMtimeMs ?? ((dir: string) => defaultNewestTrackedMtimeMs(dir, exec));
+  const idleDays = deps.idleDays ?? 14;
+  const nowMs = deps.nowMs ?? Date.now();
+  const escapeHatch = deps.escapeHatch ?? false;
 
   // registry-claimed worktree paths (excluded from the registered sweep).
   let claimed: Set<string>;
@@ -385,11 +578,163 @@ export function planGc(roots: string[], deps: GcDeps = {}): GcPlan {
     }
   }
 
+  // ── Phase C: per-agent task-tree sweep (home/work — RFC §4) ──
+  // A dedicated path, NOT routed through classifyRegistered, so the `work/`
+  // carve-out is achieved structurally (these roots never reach the blanket
+  // `looksLikeAgentWorktree` skip) and all three tree shapes are covered.
+  const taskTrees: TaskTreeAction[] = [];
+  for (const root of taskTreeRoots) {
+    if (!exists(root)) continue;
+    let entries: string[];
+    try {
+      entries = readDir(root);
+    } catch {
+      continue;
+    }
+    for (const name of entries) {
+      const dir = join(root, name);
+      if (isEphemeralPath(dir)) continue;
+      const dotGit = join(dir, ".git");
+      if (!exists(dotGit)) continue; // not a git tree — leave it
+      let shape: TaskTreeShape;
+      try {
+        shape = stat(dotGit).isDirectory() ? "clone" : "worktree";
+      } catch {
+        continue;
+      }
+
+      // Safety gate: only ever touch a checkout of the canonical switchroom
+      // repo. `git -C <dir> remote get-url origin` works for worktree AND clone.
+      let remoteOk = false;
+      try {
+        remoteOk = isSwitchroomRemote(exec("git", ["-C", dir, "remote", "get-url", "origin"]));
+      } catch {
+        remoteOk = false;
+      }
+      if (!remoteOk) {
+        skipped.push({ dir, reason: "not a switchroom task tree" });
+        continue;
+      }
+
+      // Owner repo (for post-reclaim `worktree prune`) — worktree shape only.
+      let ownerRepo: string | null = null;
+      if (shape === "worktree") {
+        try {
+          const ptr = parseGitdirPointer(readFile(dotGit));
+          if (ptr) ownerRepo = repoRootFromWorktreeGitdir(ptr);
+        } catch {
+          ownerRepo = null;
+        }
+      }
+
+      // Branch / detached HEAD.
+      let branch: string | null = null;
+      let detached = false;
+      try {
+        const b = exec("git", ["-C", dir, "rev-parse", "--abbrev-ref", "HEAD"]).trim();
+        if (b === "HEAD") detached = true;
+        else branch = b;
+      } catch {
+        detached = true; // can't read HEAD ⇒ treat as detached ⇒ unpushed ⇒ keep
+      }
+
+      const claimedWt = claimed.has(resolve(dir));
+      const stableTree = isStablePerRepoBranch(branch);
+      const ephemeral = isEphemeralPath(dir);
+      const protectedTree = claimedWt || stableTree || ephemeral;
+
+      // Effective cleanliness (build noise tolerated; anything else ⇒ dirty).
+      let clean = false;
+      try {
+        clean = isEffectivelyClean(exec("git", ["-C", dir, "status", "--porcelain"]).split("\n"));
+      } catch {
+        clean = false; // can't inspect ⇒ assume dirty ⇒ keep
+      }
+
+      // Push state: uncommitted-clean does NOT imply pushed.
+      let upstream: string | null = null;
+      let aheadCount = 0;
+      if (!detached) {
+        try {
+          upstream =
+            exec("git", ["-C", dir, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]).trim() ||
+            null;
+        } catch {
+          upstream = null;
+        }
+        if (upstream) {
+          try {
+            aheadCount = parseInt(exec("git", ["-C", dir, "rev-list", "--count", "@{upstream}..HEAD"]).trim(), 10);
+            if (!Number.isFinite(aheadCount)) aheadCount = -1;
+          } catch {
+            aheadCount = -1; // count failed ⇒ error ⇒ keep
+          }
+        }
+      }
+      const pushed = pushStateFrom({ detached, upstream, aheadCount });
+
+      // Idle: newest tracked mtime older than the idle window.
+      let idle = false;
+      try {
+        idle = (nowMs - newestMtime(dir)) / 86_400_000 >= idleDays;
+      } catch {
+        idle = false; // can't tell ⇒ treat as active ⇒ keep
+      }
+
+      // Spend the probe + `gh` call only when every cheaper guard has passed
+      // (mirrors Phase B). classifyTaskTree checks in-use/clean/pushed/idle
+      // before the PR signal, so an uncalled `error`/`unavailable` is only ever
+      // consulted when an earlier guard has already decided the verdict.
+      let inUse: PathUseState = "unavailable";
+      let sig: PrSignal = "error";
+      if (!protectedTree) {
+        inUse = probeInUse(dir);
+        if (inUse === "free" && clean && pushed === "pushed" && idle && branch) {
+          sig = prSignal(dir, branch);
+        }
+      }
+
+      const verdict = classifyTaskTree({
+        isRegistryClaimed: claimedWt,
+        isStablePerRepoTree: stableTree,
+        isEphemeralPath: ephemeral,
+        clean,
+        pushed,
+        prSignal: sig,
+        idle,
+        inUse,
+      });
+
+      // Automatic reap, OR — under the operator escape hatch — an IDLE
+      // dirty/unpushed tree (reversible quarantine; never a live/in-use one,
+      // since those resolve to skip-in-use before skip-dirty/skip-unpushed).
+      const willAct =
+        verdict === "reap" ||
+        (escapeHatch && idle && (verdict === "skip-dirty" || verdict === "skip-unpushed"));
+
+      if (willAct && ownerRepo) reposToPrune.add(ownerRepo);
+
+      taskTrees.push({
+        dir,
+        shape,
+        ownerRepo,
+        branch,
+        verdict,
+        prSignal: sig,
+        idle,
+        dest: join(trash, name),
+        willAct,
+      });
+    }
+  }
+
   return {
     roots,
+    taskTreeRoots,
     trashDir: trash,
     orphans,
     registered,
+    taskTrees,
     reposToPrune: [...reposToPrune],
     skipped,
   };
@@ -429,13 +774,28 @@ export function applyGc(plan: GcPlan, deps: ApplyDeps = {}): GcApplyResult {
 
   const res: GcApplyResult = { quarantined: [], removed: [], branchesDeleted: [], pruned: [], errors: [] };
 
-  if (plan.orphans.length) mkdirp(plan.trashDir);
+  const taskTreeActions = (plan.taskTrees ?? []).filter((t) => t.willAct);
+  if (plan.orphans.length || taskTreeActions.length) mkdirp(plan.trashDir);
   for (const o of plan.orphans) {
     try {
       move(o.dir, o.dest);
       res.quarantined.push(o.dir);
     } catch (e) {
       res.errors.push(`quarantine ${o.dir}: ${(e as Error).message}`);
+    }
+  }
+
+  // Task trees (RFC §4): quarantine to trash (recoverable) for BOTH automatic
+  // reaps and operator escape-hatch dirty/unpushed reclaims — "trash over rm".
+  // A worktree-shaped tree's owner repo is pruned afterward (it is already in
+  // plan.reposToPrune, handled by the prune loop below) to clear the now-dangling
+  // admin entry.
+  for (const t of taskTreeActions) {
+    try {
+      move(t.dir, t.dest);
+      res.quarantined.push(t.dir);
+    } catch (e) {
+      res.errors.push(`quarantine ${t.dir}: ${(e as Error).message}`);
     }
   }
 
@@ -531,4 +891,33 @@ export function purgeTrash(paths: string[]): { deleted: string[]; errors: string
 /** Default scan roots: ~/code (where dev worktrees live). */
 export function defaultRoots(): string[] {
   return [join(homedir(), "code")];
+}
+
+/**
+ * Default per-agent task-tree roots for the RFC §4 sweep. `planGc` reads the
+ * IMMEDIATE subdirs of each LITERAL root, so the per-agent
+ * `agents/<name>/home/{work,workspace}` glob must be expanded to concrete
+ * per-agent paths here — a bare glob string
+ * would be read as a literal directory name and match nothing. Only existing
+ * roots are returned. Container HOME (`/state/agent/home`) maps to
+ * `<agentDir>/home` on the host, so per-task trees land under
+ * `<agentDir>/home/work/<slug>`; the bounded stable per-repo tree
+ * (`<agentDir>/work/<slug>`) is deliberately NOT scanned.
+ */
+export function defaultTaskTreeRoots(): string[] {
+  const agentsDir = join(homedir(), ".switchroom", "agents");
+  let names: string[];
+  try {
+    names = readdirSync(agentsDir);
+  } catch {
+    return [];
+  }
+  const roots: string[] = [];
+  for (const name of names.sort()) {
+    for (const sub of ["home/work", "home/workspace"]) {
+      const r = join(agentsDir, name, sub);
+      if (existsSync(r)) roots.push(r);
+    }
+  }
+  return roots;
 }

--- a/tests/worktree.gc.test.ts
+++ b/tests/worktree.gc.test.ts
@@ -22,7 +22,11 @@ import {
   planGc,
   applyGc,
   selectPurgeTargets,
+  pushStateFrom,
+  isStablePerRepoBranch,
+  classifyTaskTree,
   type GcDeps,
+  type TaskTreeClassifyInput,
 } from "../src/worktree/gc.js";
 
 // ── pure helpers ──────────────────────────────────────────────────────────
@@ -284,6 +288,257 @@ describe("planGc — orphan attribution + merged sweep", () => {
   });
 });
 
+// ── task-tree coverage (RFC §4) ──────────────────────────────────────────────
+
+describe("pushStateFrom", () => {
+  it("pushed only when an upstream exists and HEAD is not ahead", () => {
+    expect(pushStateFrom({ detached: false, upstream: "origin/feat/x", aheadCount: 0 })).toBe("pushed");
+  });
+  it("detached HEAD ⇒ detached (fail toward keep)", () => {
+    expect(pushStateFrom({ detached: true, upstream: null, aheadCount: 0 })).toBe("detached");
+  });
+  it("no upstream ⇒ no-upstream (never-pushed abandoned branch)", () => {
+    expect(pushStateFrom({ detached: false, upstream: null, aheadCount: 0 })).toBe("no-upstream");
+  });
+  it("commits ahead of upstream ⇒ unpushed", () => {
+    expect(pushStateFrom({ detached: false, upstream: "origin/feat/x", aheadCount: 3 })).toBe("unpushed");
+  });
+  it("negative count (git failed) ⇒ error (fail toward keep)", () => {
+    expect(pushStateFrom({ detached: false, upstream: "origin/feat/x", aheadCount: -1 })).toBe("error");
+  });
+});
+
+describe("isStablePerRepoBranch", () => {
+  it("matches agent/<name>/main only", () => {
+    expect(isStablePerRepoBranch("agent/klanker/main")).toBe(true);
+    expect(isStablePerRepoBranch("agent/overlord/main")).toBe(true);
+    expect(isStablePerRepoBranch("feat/fix-3019")).toBe(false);
+    expect(isStablePerRepoBranch("agent/klanker/feature")).toBe(false);
+    expect(isStablePerRepoBranch(null)).toBe(false);
+  });
+});
+
+describe("classifyTaskTree — safety-first decision order", () => {
+  const clean: TaskTreeClassifyInput = {
+    isRegistryClaimed: false,
+    isStablePerRepoTree: false,
+    isEphemeralPath: false,
+    clean: true,
+    pushed: "pushed",
+    prSignal: "merged",
+    idle: true,
+    inUse: "free",
+  };
+  it("REAPS a clean + pushed + idle + merged + free tree", () => {
+    expect(classifyTaskTree(clean)).toBe("reap");
+  });
+  it("REAPS a closed-PR (abandoned) task tree — closed is eligible here", () => {
+    expect(classifyTaskTree({ ...clean, prSignal: "closed" })).toBe("reap");
+  });
+  it("protects registry-claimed / stable per-repo tree / ephemeral", () => {
+    expect(classifyTaskTree({ ...clean, isRegistryClaimed: true })).toBe("skip-protected");
+    expect(classifyTaskTree({ ...clean, isStablePerRepoTree: true })).toBe("skip-protected");
+    expect(classifyTaskTree({ ...clean, isEphemeralPath: true })).toBe("skip-protected");
+  });
+  it("NEVER reaps a dirty tree", () => {
+    expect(classifyTaskTree({ ...clean, clean: false })).toBe("skip-dirty");
+  });
+  it("NEVER reaps an in-use tree, even when otherwise reapable", () => {
+    expect(classifyTaskTree({ ...clean, inUse: "in-use" })).toBe("skip-in-use");
+  });
+  it("keeps when the in-use probe is unavailable (cannot prove idle)", () => {
+    expect(classifyTaskTree({ ...clean, inUse: "unavailable" })).toBe("skip-probe-unavailable");
+  });
+  it("in-use OUTRANKS dirty — a live dirty tree is skip-in-use, not escape-hatch eligible", () => {
+    expect(classifyTaskTree({ ...clean, inUse: "in-use", clean: false })).toBe("skip-in-use");
+  });
+  it("NEVER reaps an unpushed / detached / no-upstream tree", () => {
+    expect(classifyTaskTree({ ...clean, pushed: "unpushed" })).toBe("skip-unpushed");
+    expect(classifyTaskTree({ ...clean, pushed: "detached" })).toBe("skip-unpushed");
+    expect(classifyTaskTree({ ...clean, pushed: "no-upstream" })).toBe("skip-unpushed");
+    expect(classifyTaskTree({ ...clean, pushed: "error" })).toBe("skip-unpushed");
+  });
+  it("NEVER reaps a non-idle (recently active) tree", () => {
+    expect(classifyTaskTree({ ...clean, idle: false })).toBe("skip-active");
+  });
+  it("keeps open / no PR and gh errors", () => {
+    expect(classifyTaskTree({ ...clean, prSignal: "open" })).toBe("skip-unmerged");
+    expect(classifyTaskTree({ ...clean, prSignal: "none" })).toBe("skip-unmerged");
+    expect(classifyTaskTree({ ...clean, prSignal: "error" })).toBe("skip-unknown");
+  });
+});
+
+describe("planGc — task-tree sweep across all three tree shapes (RFC §4)", () => {
+  const NOW = 1_700_000_000_000;
+  const DAY = 86_400_000;
+  const root = "/agents/a1/home/work";
+  const OWNER = "/agents/a1/work/switchroom";
+  const SR = "https://github.com/switchroom/switchroom.git\n";
+
+  interface TreeSpec {
+    shape: "clone" | "worktree";
+    remote?: string;
+    branch?: string | null; // null ⇒ detached HEAD
+    status?: string[]; // porcelain lines (default clean)
+    upstream?: string | null; // default present
+    ahead?: number; // default 0
+    mtimeDaysAgo?: number; // default 30 (idle)
+    pr?: string; // default merged
+    inUse?: "free" | "in-use" | "unavailable"; // default free
+  }
+
+  function makeDeps(trees: Record<string, TreeSpec>, escapeHatch = false): GcDeps {
+    const names = Object.keys(trees);
+    const dirOf = (name: string) => `${root}/${name}`;
+    const specByDir = new Map<string, TreeSpec>();
+    for (const n of names) specByDir.set(dirOf(n), trees[n]);
+
+    return {
+      dateStamp: "2026-08-04",
+      idleDays: 14,
+      nowMs: NOW,
+      escapeHatch,
+      existsSync: (p: string) => p === root || p.endsWith("/.git") === true && specByDir.has(p.slice(0, -5)),
+      readDir: (p: string) => {
+        if (p === root) return names;
+        throw new Error("unexpected readDir " + p);
+      },
+      stat: (p: string) => {
+        const dir = p.slice(0, -5); // strip "/.git"
+        const spec = specByDir.get(dir);
+        return { isDirectory: () => spec?.shape === "clone" };
+      },
+      readFile: (p: string) => {
+        // only worktree shapes read the .git pointer
+        const dir = p.slice(0, -5);
+        return `gitdir: ${OWNER}/.git/worktrees/${dir.split("/").pop()}\n`;
+      },
+      probeInUse: (p: string) => specByDir.get(p)?.inUse ?? "free",
+      newestTrackedMtimeMs: (dir: string) => NOW - (specByDir.get(dir)?.mtimeDaysAgo ?? 30) * DAY,
+      exec: (file: string, args: string[]) => {
+        const dir = args[args.indexOf("-C") + 1];
+        const spec = specByDir.get(dir);
+        if (!spec) throw new Error("unexpected exec dir " + dir);
+        if (args.includes("remote")) return spec.remote ?? SR;
+        if (args.includes("status")) return (spec.status ?? []).join("\n");
+        if (args.includes("rev-parse") && args.includes("HEAD") && !args.includes("@{upstream}")) {
+          return spec.branch === null ? "HEAD\n" : `${spec.branch ?? "feat/x"}\n`;
+        }
+        if (args.includes("@{upstream}") && args.includes("rev-parse")) {
+          if (spec.upstream === null) throw new Error("no upstream");
+          return `${spec.upstream ?? "origin/feat/x"}\n`;
+        }
+        if (args.includes("rev-list")) return `${spec.ahead ?? 0}\n`;
+        throw new Error("unexpected exec " + file + " " + args.join(" "));
+      },
+      prSignal: (_repo: string, _branch: string) => {
+        const spec = specByDir.get(_repo);
+        return (spec?.pr ?? "merged") as any;
+      },
+    };
+  }
+
+  function verdictOf(trees: Record<string, TreeSpec>, name: string, escapeHatch = false) {
+    const plan = planGc([], makeDeps(trees, escapeHatch), [root]);
+    return plan.taskTrees.find((t) => t.dir === `${root}/${name}`);
+  }
+
+  it("a clean + pushed + idle + merged CLONE IS eligible (willAct)", () => {
+    const t = verdictOf({ "clone-x": { shape: "clone" } }, "clone-x");
+    expect(t?.verdict).toBe("reap");
+    expect(t?.willAct).toBe(true);
+    expect(t?.shape).toBe("clone");
+  });
+
+  it("a clean + pushed + idle + merged WORKTREE IS eligible, with its owner repo captured for prune", () => {
+    const t = verdictOf({ "wt-x": { shape: "worktree" } }, "wt-x");
+    expect(t?.verdict).toBe("reap");
+    expect(t?.willAct).toBe(true);
+    expect(t?.shape).toBe("worktree");
+    expect(t?.ownerRepo).toBe(OWNER);
+  });
+
+  it("a nested-repo-shaped (clone) closed-PR tree IS eligible", () => {
+    const t = verdictOf({ "nested-x": { shape: "clone", pr: "closed" } }, "nested-x");
+    expect(t?.verdict).toBe("reap");
+    expect(t?.willAct).toBe(true);
+  });
+
+  it("a DIRTY tree is NOT reaped (skip-dirty, willAct false)", () => {
+    const t = verdictOf({ dirty: { shape: "clone", status: ["A  docs/new.md"] } }, "dirty");
+    expect(t?.verdict).toBe("skip-dirty");
+    expect(t?.willAct).toBe(false);
+  });
+
+  it("an IN-USE tree is NOT reaped (skip-in-use), even under the escape hatch", () => {
+    const t = verdictOf(
+      { live: { shape: "clone", inUse: "in-use", status: ["A  docs/new.md"] } },
+      "live",
+      /* escapeHatch */ true,
+    );
+    expect(t?.verdict).toBe("skip-in-use");
+    expect(t?.willAct).toBe(false);
+  });
+
+  it("an UNPUSHED (ahead-of-upstream) tree is NOT reaped", () => {
+    const t = verdictOf({ ahead: { shape: "clone", ahead: 2 } }, "ahead");
+    expect(t?.verdict).toBe("skip-unpushed");
+    expect(t?.willAct).toBe(false);
+  });
+
+  it("a NO-UPSTREAM (never-pushed) tree is NOT reaped", () => {
+    const t = verdictOf({ orphanbr: { shape: "clone", upstream: null } }, "orphanbr");
+    expect(t?.verdict).toBe("skip-unpushed");
+  });
+
+  it("a DETACHED-HEAD tree is NOT reaped", () => {
+    const t = verdictOf({ det: { shape: "clone", branch: null } }, "det");
+    expect(t?.verdict).toBe("skip-unpushed");
+  });
+
+  it("a recently-active (non-idle) tree is NOT reaped", () => {
+    const t = verdictOf({ active: { shape: "clone", mtimeDaysAgo: 1 } }, "active");
+    expect(t?.verdict).toBe("skip-active");
+    expect(t?.willAct).toBe(false);
+  });
+
+  it("an OPEN-PR tree is NOT reaped", () => {
+    const t = verdictOf({ openpr: { shape: "clone", pr: "open" } }, "openpr");
+    expect(t?.verdict).toBe("skip-unmerged");
+  });
+
+  it("a NON-switchroom tree is ignored (recorded in skipped, never actioned)", () => {
+    const deps = makeDeps({ foreign: { shape: "clone", remote: "https://github.com/x/y.git\n" } });
+    const plan = planGc([], deps, [root]);
+    expect(plan.taskTrees.find((t) => t.dir === `${root}/foreign`)).toBeUndefined();
+    expect(plan.skipped.some((s) => s.dir === `${root}/foreign`)).toBe(true);
+  });
+
+  it("the stable per-repo tree (agent/<name>/main) is protected", () => {
+    const t = verdictOf({ stable: { shape: "worktree", branch: "agent/a1/main" } }, "stable");
+    expect(t?.verdict).toBe("skip-protected");
+    expect(t?.willAct).toBe(false);
+  });
+
+  it("escape hatch quarantines an IDLE dirty tree (willAct), but leaves auto behaviour off by default", () => {
+    const spec = { dirtyidle: { shape: "clone" as const, status: ["A  docs/new.md"] } };
+    expect(verdictOf(spec, "dirtyidle", false)?.willAct).toBe(false);
+    const withHatch = verdictOf(spec, "dirtyidle", true);
+    expect(withHatch?.verdict).toBe("skip-dirty");
+    expect(withHatch?.willAct).toBe(true);
+  });
+
+  it("escape hatch does NOT quarantine a non-idle dirty tree (recently active)", () => {
+    const t = verdictOf(
+      { dirtyactive: { shape: "clone", status: ["A  docs/new.md"], mtimeDaysAgo: 1 } },
+      "dirtyactive",
+      true,
+    );
+    expect(t?.verdict).toBe("skip-dirty");
+    expect(t?.willAct).toBe(false);
+  });
+});
+
 // ── applyGc quarantine (real temp dir) ───────────────────────────────────────
 
 describe("applyGc — quarantine move (real fs)", () => {
@@ -304,9 +559,11 @@ describe("applyGc — quarantine move (real fs)", () => {
 
     const result = applyGc({
       roots: [code],
+      taskTreeRoots: [],
       trashDir: trash,
       orphans: [{ dir: orphan, owner: "/x/switchroom", dest: join(trash, "sr-old") }],
       registered: [],
+      taskTrees: [],
       reposToPrune: [],
       skipped: [],
     });
@@ -320,13 +577,125 @@ describe("applyGc — quarantine move (real fs)", () => {
   it("does nothing destructive for a dry-run-shaped (empty) plan", () => {
     const result = applyGc({
       roots: [tmp],
+      taskTreeRoots: [],
       trashDir: join(tmp, "trash"),
       orphans: [],
       registered: [{ path: "/x", branch: "feat/x", verdict: "skip-dirty", prSignal: "merged", repo: "/r" }],
+      taskTrees: [],
       reposToPrune: [],
       skipped: [],
     });
     expect(result.quarantined).toHaveLength(0);
     expect(result.removed).toHaveLength(0);
+  });
+
+  it("quarantines an actioned task tree (recoverable move, not delete)", () => {
+    const work = join(tmp, "home", "work");
+    const tree = join(work, "fix-3019");
+    mkdirSync(tree, { recursive: true });
+    writeFileSync(join(tree, "src.ts"), "content");
+    const trash = join(tmp, "trash", "2026-08-04");
+
+    const result = applyGc({
+      roots: [],
+      taskTreeRoots: [work],
+      trashDir: trash,
+      orphans: [],
+      registered: [],
+      taskTrees: [
+        {
+          dir: tree,
+          shape: "clone",
+          ownerRepo: null,
+          branch: "feat/fix-3019",
+          verdict: "reap",
+          prSignal: "merged",
+          idle: true,
+          dest: join(trash, "fix-3019"),
+          willAct: true,
+        },
+      ],
+      reposToPrune: [],
+      skipped: [],
+    });
+
+    expect(result.quarantined).toEqual([tree]);
+    expect(existsSync(tree)).toBe(false); // moved out of home/work
+    expect(existsSync(join(trash, "fix-3019", "src.ts"))).toBe(true); // recoverable
+  });
+
+  it("does NOT move a task tree whose willAct is false (surfaced-only)", () => {
+    const work = join(tmp, "home", "work");
+    const tree = join(work, "dirty-tree");
+    mkdirSync(tree, { recursive: true });
+    writeFileSync(join(tree, "wip.ts"), "uncommitted");
+    const trash = join(tmp, "trash", "2026-08-04");
+
+    const result = applyGc({
+      roots: [],
+      taskTreeRoots: [work],
+      trashDir: trash,
+      orphans: [],
+      registered: [],
+      taskTrees: [
+        {
+          dir: tree,
+          shape: "clone",
+          ownerRepo: null,
+          branch: "feat/wip",
+          verdict: "skip-dirty",
+          prSignal: "error",
+          idle: true,
+          dest: join(trash, "dirty-tree"),
+          willAct: false,
+        },
+      ],
+      reposToPrune: [],
+      skipped: [],
+    });
+
+    expect(result.quarantined).toHaveLength(0);
+    expect(existsSync(join(tree, "wip.ts"))).toBe(true); // untouched
+  });
+
+  it("prunes the owner repo after quarantining a worktree-shaped task tree", () => {
+    const work = join(tmp, "home", "work");
+    const tree = join(work, "review-3022");
+    mkdirSync(tree, { recursive: true });
+    writeFileSync(join(tree, "a.ts"), "x");
+    const trash = join(tmp, "trash", "2026-08-04");
+    const owner = "/agents/a1/work/switchroom";
+    const execCalls: string[][] = [];
+
+    const result = applyGc(
+      {
+        roots: [],
+        taskTreeRoots: [work],
+        trashDir: trash,
+        orphans: [],
+        registered: [],
+        taskTrees: [
+          {
+            dir: tree,
+            shape: "worktree",
+            ownerRepo: owner,
+            branch: "feat/review-3022",
+            verdict: "reap",
+            prSignal: "merged",
+            idle: true,
+            dest: join(trash, "review-3022"),
+            willAct: true,
+          },
+        ],
+        reposToPrune: [owner],
+        skipped: [],
+      },
+      { exec: (file, args) => { execCalls.push([file, ...args]); return ""; } },
+    );
+
+    expect(result.quarantined).toEqual([tree]);
+    expect(existsSync(tree)).toBe(false);
+    expect(result.pruned).toEqual([owner]);
+    expect(execCalls).toContainEqual(["git", "-C", owner, "worktree", "prune"]);
   });
 });


### PR DESCRIPTION
## Summary

`switchroom worktree gc` only ever rooted at `~/code`, and its dev-worktree sweep SKIP-protects any `work/` path via `looksLikeAgentWorktree`. So the per-task trees agents/harnesses drop at `~/.switchroom/agents/<name>/home/work/<slug>` were **never** reclaimed and grow without bound — the ~25G+ task-tree overhang. This adds a dedicated, guard-gated **Phase C** sweep of the per-agent task-tree roots (`home/work` + `home/workspace`), implementing RFC §4.

## Why

- RFC: `reference/rfcs/agent-home-lifecycle.md` §4
- Job: `reference/jobs/give-each-agent-its-own-workspace.md`

Task trees are **not** uniformly git worktrees. A live census found three shapes: `.git`-file worktrees, full clones, and repos nested inside another checkout. A coverage that keyed off worktree detection (as the old `work/` skip does) would miss the majority of the overhang. Phase C classifies by physical shape (`.git` file ⇒ `worktree`, `.git` dir ⇒ `clone`; nested repos handled identically via `git -C`) so **all three** are covered.

## Safety (reaper safety is paramount — over-eager deletion is catastrophic data loss)

Every deletion is gated by a safety-first decision order in the pure `classifyTaskTree`:

1. `skip-protected` — registry-claimed / stable per-repo tree (`agent/<name>/main`) / ephemeral mount
2. `skip-probe-unavailable` — no `fuser`/`lsof` to prove idle ⇒ treat as live, keep
3. `skip-in-use` — `probePathInUse` says a live process holds the path
4. `skip-dirty` — `isEffectivelyClean` false
5. `skip-unpushed` — detached / no upstream / commits ahead of upstream
6. `skip-active` — newest **tracked** mtime within the idle window (14d default)
7. `skip-unknown` / `skip-unmerged` — PR signal error, or PR still open / no PR
8. `reap` — only when clean **and** pushed **and** idle **and** MERGED-or-CLOSED PR **and** provably free

The two data-loss guards (**in-use**, **dirty**) rank before anything the operator escape hatch can act on, so a live or dirty-and-in-use tree can never be quarantined. Every git error fails toward preservation (unreadable HEAD ⇒ detached ⇒ unpushed ⇒ keep; unreadable status ⇒ dirty ⇒ keep; unreadable mtime ⇒ active ⇒ keep). The `gh`/probe calls are spent lazily, only after every cheaper guard passes.

Reclaim is a recoverable **quarantine-move to trash**, never an `rm`. `--reclaim-dirty` (operator escape hatch) only ever quarantines **idle** dirty/unpushed trees, reversibly; otherwise those are surfaced and left untouched. `--no-task-roots` disables the sweep entirely.

## Test plan

`tests/worktree.gc.test.ts` (58 gc + 14 reaper green; scoped `vitest run`):

- `pushStateFrom` / `isStablePerRepoBranch` unit tests
- `classifyTaskTree` safety-first order — **dirty NOT reaped**, **in-use NOT reaped**, unavailable-probe keep, **in-use OUTRANKS dirty**, unpushed/detached/no-upstream/error kept, non-idle kept, open/none/error PR kept
- `planGc` Phase C harness across **all three shapes** — clone/worktree/nested reap; **dirty NOT reaped and in-use NOT reaped even under the escape hatch**; unpushed/detached/no-upstream kept; non-idle kept; open-PR kept; non-switchroom ignored; stable per-repo protected; escape hatch quarantines idle-dirty **only** (not non-idle dirty); worktree-shaped reap prunes owner repo
- `applyGc` — quarantines an actioned tree (recoverable move), does **not** move a `willAct=false` tree

RED/GREEN: on `origin/main` the new tests fail (`pushStateFrom is not a function`, etc., 32 failures); with the change, 72 green. Full `npm run lint` clean. A real dry-run over this host's live task trees classified 30 trees correctly (dirty/unpushed/in-use/active), flagged the in-use worktree as `in-use`, and reaped **0**.

## Risk

An over-eager reaper is catastrophic data loss, so the sweep fails toward preservation at every branch and quarantines (recoverable) rather than deleting. Default idle window 14 days; the sweep is off with `--no-task-roots`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
