### PR TITLE
fix(gateway): suppress activity card for silent-sentinel turns (#4348)

### DIFF
--- a/telegram-plugin/gateway/narrative-lane.ts
+++ b/telegram-plugin/gateway/narrative-lane.ts
@@ -56,6 +56,7 @@ import {
   appendActivityLabel, clipNarrative, formatStepSuffix, renderActivityFeedWithNested,
 } from '../tool-activity-summary.js'
 import { evaluatePostAnswerLiveness } from '../turn-liveness-floor.js'
+import { isSilentSentinelCardOutcome } from '../turn-flush-safety.js'
 import { clearActivityCardRecord, writeActivityCardRecord } from './activity-card-store.js'
 import { chatKeyWithSuffix } from './chat-key.js'
 import {
@@ -880,7 +881,26 @@ export function createNarrativeLane(deps: NarrativeLaneDeps) {
       // before the delete. turn-end stays the idempotent backstop: it no-ops
       // once nothing is claimed for the key.
       await reconcileStatusPin(`fg:${statusKey(chat, thread)}`, chat, { pinned: false })
-      if (CLEAR_STATUS_ON_COMPLETION) {
+      // #4348 — silent-sentinel suppression. A turn whose entire user-facing
+      // outcome is a bare NO_REPLY / HEARTBEAT_OK (the sentinel-reply-guard
+      // dropped a sentinel-only reply, or the flush safety net classified the
+      // captured text as silent) said nothing to the user, so its activity/
+      // telemetry card is pure noise — most visibly on the forced-synthesis
+      // handback turns a background sub-agent injects. DELETE the card rather
+      // than finalizing a visible `done · … · ✓ NO_REPLY` record. Deterministic
+      // (reuses the shared `turn-flush-safety` silent predicates, no model
+      // behaviour) and normal-case-safe (`finalAnswerEverDelivered` keeps every
+      // card for a turn that actually delivered a substantive answer). The
+      // `finalHtmlOverride` finalize path is only taken by the foreground
+      // handoff-clear, which fires on a delivered final answer — so this gate
+      // never contends with it.
+      const silentSentinelTurn = isSilentSentinelCardOutcome({
+        replyCalled: turn.replyCalled,
+        lastReplyText: turn.lastReplyText,
+        capturedText: turn.capturedText,
+        finalAnswerEverDelivered: turn.finalAnswerEverDelivered,
+      })
+      if (CLEAR_STATUS_ON_COMPLETION || silentSentinelTurn) {
         try {
           await robustApiCall(
             () => bot.api.deleteMessage(chat, id),

--- a/telegram-plugin/tests/narrative-lane-golden.test.ts
+++ b/telegram-plugin/tests/narrative-lane-golden.test.ts
@@ -282,6 +282,92 @@ describe('narrative-lane golden — clearActivitySummary finalize', () => {
   })
 })
 
+// ── #4348 — silent-sentinel activity card is SUPPRESSED (deleted, not finalized) ─
+// A turn whose entire user-facing outcome is a bare NO_REPLY / HEARTBEAT_OK
+// (the sentinel-reply-guard dropped the sentinel-only reply, or the flush net
+// classified the captured text as silent) must leave NO visible telemetry card
+// in the chat — most visibly on the forced-synthesis handback turns a
+// background sub-agent injects. A real reply's card must still finalize.
+describe('narrative-lane golden — silent-sentinel card suppression (#4348)', () => {
+  // Open the feed card on a fresh (working) turn FIRST — the card-open gate
+  // (mayOpenActivityCard) won't open one once the answer is already delivered —
+  // then stamp the turn's terminal outcome, exactly as the real turn does:
+  // the card opens mid-work, and lastReplyText / finalAnswerEverDelivered are
+  // only known at turn end.
+  async function openThenClear(over: Partial<CurrentTurn>) {
+    const { lane, calls } = makeLane()
+    const turn = makeLaneTurn(lane)
+    lane.showNarrativeStep(turn, 'Doing the work now')
+    await turn.activityInFlight
+    const cardId = turn.activityMessageId
+    expect(cardId).not.toBeNull()
+    Object.assign(turn, over)
+    lane.clearActivitySummary(turn)
+    await settle()
+    return { calls, cardId, turn }
+  }
+
+  it('reply("NO_REPLY") turn: DELETES the card, never edits a done record', async () => {
+    // The guard drops the sentinel-only reply before chat, but the blocked
+    // tool_use still stamps lastReplyText — the exact `✓ NO_REPLY` noise card.
+    const { calls, cardId, turn } = await openThenClear({
+      replyCalled: true,
+      lastReplyText: 'NO_REPLY',
+      finalAnswerEverDelivered: false,
+    })
+    expect(calls.filter((c) => c.method === 'deleteMessage' && c.message_id === cardId)).toHaveLength(1)
+    expect(calls.filter((c) => c.method === 'editMessageText' && c.message_id === cardId)).toHaveLength(0)
+    expect(turn.activityMessageId).toBeNull()
+  })
+
+  it('HEARTBEAT_OK. (trailing punctuation, case-insensitive) is also suppressed', async () => {
+    const { calls, cardId } = await openThenClear({
+      replyCalled: true,
+      lastReplyText: 'heartbeat_ok.',
+      finalAnswerEverDelivered: false,
+    })
+    expect(calls.filter((c) => c.method === 'deleteMessage' && c.message_id === cardId)).toHaveLength(1)
+    expect(calls.filter((c) => c.method === 'editMessageText' && c.message_id === cardId)).toHaveLength(0)
+  })
+
+  it('flush path (no reply): prose + trailing NO_REPLY (H6/#2053) is suppressed', async () => {
+    const { calls, cardId } = await openThenClear({
+      replyCalled: false,
+      lastReplyText: '',
+      capturedText: ["Nothing actionable in today's digest.", 'NO_REPLY'],
+      finalAnswerEverDelivered: false,
+    })
+    expect(calls.filter((c) => c.method === 'deleteMessage' && c.message_id === cardId)).toHaveLength(1)
+    expect(calls.filter((c) => c.method === 'editMessageText' && c.message_id === cardId)).toHaveLength(0)
+  })
+
+  it('normal reply turn: still FINALIZES the card (edit, no delete)', async () => {
+    // The guarantee the fix must not break: a real answer keeps its record.
+    const { calls, cardId, turn } = await openThenClear({
+      replyCalled: true,
+      lastReplyText: 'The fix is deployed and the tests are green.',
+      finalAnswerEverDelivered: true,
+    })
+    expect(calls.filter((c) => c.method === 'editMessageText' && c.message_id === cardId).length)
+      .toBeGreaterThanOrEqual(1)
+    expect(calls.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
+    expect(turn.activityMessageId).toBeNull()
+  })
+
+  it('reply "prose\\nNO_REPLY" that WAS delivered (finalAnswerEverDelivered) keeps its card', async () => {
+    // The guard does NOT drop a reply with non-marker content, so its prose
+    // reached chat — endsWithSilentMarker must NOT suppress a delivered reply.
+    const { calls, cardId } = await openThenClear({
+      replyCalled: true,
+      lastReplyText: 'Here is the full answer to your question.\nNO_REPLY',
+      finalAnswerEverDelivered: true,
+    })
+    expect(calls.filter((c) => c.method === 'editMessageText' && c.message_id === cardId).length)
+      .toBeGreaterThanOrEqual(1)
+    expect(calls.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
+  })
+})
+
 // ── THREE-MODULE cross-surface dedup (Amendment 1) ────────────────────────
 // The REAL P4-A handleSessionEvent turn-flush, with the REAL P4-B lane wired
 // into its deps, records the delivered answer into ONE OutboundDedupCache;

--- a/telegram-plugin/tests/turn-flush-safety.test.ts
+++ b/telegram-plugin/tests/turn-flush-safety.test.ts
@@ -20,6 +20,7 @@ import {
   isSilentFlushMarker,
   isCompositeSilentNoise,
   endsWithSilentMarker,
+  isSilentSentinelCardOutcome,
   isTurnFlushSafetyEnabled,
   selectFlushDeliveryText,
   FLUSH_SUBSTANTIVE_MIN_CHARS,
@@ -891,5 +892,87 @@ describe('selectFlushDeliveryText — structural provenance (followedByToolUse) 
     const out = selectFlushDeliveryText([shortPreamble, realAnswer], [true, false])
     expect(out).toBe(realAnswer)
     expect(out).not.toContain('Here are the figures')
+  })
+})
+
+// #4348 — the pure gate that suppresses the per-turn activity/telemetry card
+// when the turn's whole user-facing outcome was an intentional silent sentinel.
+describe('isSilentSentinelCardOutcome (#4348)', () => {
+  const base = { replyCalled: false, lastReplyText: '', capturedText: [] as string[], finalAnswerEverDelivered: false }
+
+  it('reply("NO_REPLY") — the blocked sentinel-only reply is a silent outcome', () => {
+    expect(isSilentSentinelCardOutcome({ ...base, replyCalled: true, lastReplyText: 'NO_REPLY' })).toBe(true)
+  })
+
+  it('trailing punctuation and case variants still count as silent', () => {
+    for (const t of ['NO_REPLY.', 'no_reply', 'HEARTBEAT_OK', 'heartbeat_ok!', ' NO_REPLY ']) {
+      expect(isSilentSentinelCardOutcome({ ...base, replyCalled: true, lastReplyText: t })).toBe(true)
+    }
+  })
+
+  it('composite silent noise ("Sent.\\nNO_REPLY\\nNO_REPLY") via the reply payload is silent', () => {
+    expect(
+      isSilentSentinelCardOutcome({ ...base, replyCalled: true, lastReplyText: 'Sent.\nNO_REPLY\nNO_REPLY' }),
+    ).toBe(true)
+  })
+
+  it('flush path (no reply): prose + trailing NO_REPLY (H6/#2053) is silent', () => {
+    expect(
+      isSilentSentinelCardOutcome({
+        ...base,
+        replyCalled: false,
+        capturedText: ["Nothing actionable in today's digest.", 'NO_REPLY'],
+      }),
+    ).toBe(true)
+  })
+
+  it('a real reply is NOT silent — the card is a legitimate record', () => {
+    expect(
+      isSilentSentinelCardOutcome({
+        ...base,
+        replyCalled: true,
+        lastReplyText: 'The three services are all green.',
+        finalAnswerEverDelivered: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('finalAnswerEverDelivered short-circuits even when a stray NO_REPLY is the last reply text', () => {
+    // An interim answer landed, then a trailing sentinel — the delivered answer wins.
+    expect(
+      isSilentSentinelCardOutcome({
+        ...base,
+        replyCalled: true,
+        lastReplyText: 'NO_REPLY',
+        finalAnswerEverDelivered: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('a delivered reply that merely mentions the sentinel in prose is NOT silent', () => {
+    // Non-marker content ⇒ the sentinel-reply-guard would not drop it ⇒ delivered.
+    expect(
+      isSilentSentinelCardOutcome({
+        ...base,
+        replyCalled: true,
+        lastReplyText: 'Reply with exactly NO_REPLY if there is nothing to add.',
+      }),
+    ).toBe(false)
+  })
+
+  it('endsWithSilentMarker does NOT suppress a DELIVERED reply of "prose\\nNO_REPLY"', () => {
+    // The guard lets prose+trailing-NO_REPLY through the reply tool, so its
+    // prose reached chat; the card must stay even though it ends with a marker.
+    expect(
+      isSilentSentinelCardOutcome({
+        ...base,
+        replyCalled: true,
+        lastReplyText: 'Here is the full answer.\nNO_REPLY',
+      }),
+    ).toBe(false)
+  })
+
+  it('a genuinely empty dark turn (no reply, no text) is NOT a sentinel', () => {
+    expect(isSilentSentinelCardOutcome({ ...base })).toBe(false)
   })
 })

--- a/telegram-plugin/turn-flush-safety.ts
+++ b/telegram-plugin/turn-flush-safety.ts
@@ -136,6 +136,85 @@ export function endsWithSilentMarker(text: string | undefined): boolean {
 }
 
 /**
+ * Inputs for {@link isSilentSentinelCardOutcome} — the fields of the ending
+ * turn the card-suppression gate reads. All are already tracked on the
+ * gateway's `CurrentTurn`; passed as a plain struct so the decision is a pure,
+ * unit-testable core (`gateway.ts` / `narrative-lane.ts` are not importable in
+ * tests).
+ */
+export interface SilentSentinelCardInput {
+  /** True when the model called `reply` / `stream_reply` at least once. */
+  replyCalled: boolean
+  /**
+   * The most-recent `reply` / `stream_reply` `input.text` this turn — empty
+   * string when the reply tool was never called (`CurrentTurn.lastReplyText`).
+   */
+  lastReplyText: string
+  /**
+   * Raw assistant text blocks accumulated across the turn — the same source
+   * `decideTurnFlush` classifies (`CurrentTurn.capturedText`). Only consulted
+   * on the reply-never-called (flush) path.
+   */
+  capturedText: string[]
+  /**
+   * A SUBSTANTIVE final answer reached the user at some point this turn
+   * (`CurrentTurn.finalAnswerEverDelivered`). When true the card is a
+   * legitimate record beside a delivered answer and is NEVER suppressed.
+   */
+  finalAnswerEverDelivered: boolean
+}
+
+/**
+ * Decide whether an ending turn's user-facing outcome was an INTENTIONAL silent
+ * sentinel (NO_REPLY / HEARTBEAT_OK) — the deterministic gate that suppresses
+ * the per-turn activity/telemetry card for a turn that said nothing to the user.
+ *
+ * The symptom (#4348): a background sub-agent handback injects a forced-synthesis
+ * turn, the parent legitimately answers `NO_REPLY`, and the gateway still
+ * finalizes a `🤖 Agent · done · 0 tools · … · ✓ NO_REPLY` card in the chat.
+ * `sentinel-reply-guard-pretool.mjs` already drops the sentinel-only reply so
+ * nothing reaches chat, but the blocked `tool_use` still stamps `lastReplyText`,
+ * and the activity card finalizes as pure noise.
+ *
+ * This reuses the SAME silent-turn predicates the flush safety net and the Stop
+ * hook use — it invents no second notion of "silent":
+ *   - Reply path (`replyCalled`): the model called `reply` with a sentinel-ONLY
+ *     payload, which `sentinel-reply-guard-pretool.mjs` drops before chat, so the
+ *     card's whole outcome is a silence signal that never became a message. Only
+ *     `isSilentFlushMarker` / `isCompositeSilentNoise` count here — a
+ *     `prose\nNO_REPLY` reply is NOT dropped by that guard (it has non-marker
+ *     content), so its prose WAS delivered and its card must stay. `endsWithSilentMarker`
+ *     is deliberately NOT applied to a delivered reply.
+ *   - Flush path (reply never called): the turn's captured terminal text is its
+ *     outcome, so match every shape `decideTurnFlush` treats as `silent-marker` —
+ *     bare marker, composite noise, and prose+trailing-`NO_REPLY` (#2053 / H6).
+ *
+ * The `finalAnswerEverDelivered` short-circuit is the normal-case guarantee: a
+ * turn that actually delivered a substantive answer keeps its card, so a real
+ * reply (even one a later stray `NO_REPLY` follows) is never suppressed.
+ */
+export function isSilentSentinelCardOutcome(input: SilentSentinelCardInput): boolean {
+  // A substantive answer reached the user — the card is a legitimate record.
+  if (input.finalAnswerEverDelivered) return false
+  // Reply-tool outcome: a sentinel-ONLY payload the guard dropped before chat.
+  if (isSilentFlushMarker(input.lastReplyText) || isCompositeSilentNoise(input.lastReplyText)) {
+    return true
+  }
+  // Flush outcome: reply never called; classify the captured terminal text with
+  // the exact predicates decideTurnFlush's `silent-marker` skip uses.
+  if (!input.replyCalled) {
+    const joined = input.capturedText.join('\n\n').trim()
+    if (
+      joined.length > 0 &&
+      (isSilentFlushMarker(joined) || isCompositeSilentNoise(joined) || endsWithSilentMarker(joined))
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
  * Substantive-answer floor (chars, trimmed). Mirrors
  * `final-answer-detect.ts` `FINAL_ANSWER_MIN_CHARS` and
  * `hooks/silent-end-scan.mjs` — the same bar the codebase uses everywhere to


### PR DESCRIPTION
## Summary
A turn whose entire user-facing outcome is a bare `NO_REPLY` / `HEARTBEAT_OK` still finalized a per-turn activity/telemetry card (`🤖 Agent · done · 0 tools · … · ✓ NO_REPLY`). This adds a deterministic gate so such a turn produces **no visible card**, while a turn that actually delivered an answer always keeps its card.

## Why
`sentinel-reply-guard-pretool.mjs` already drops a sentinel-only `reply` before it reaches chat, but the blocked `tool_use` still stamps `CurrentTurn.lastReplyText`, so `clearActivitySummary` finalizes a visible `done · ✓ NO_REPLY` record. This is pure noise — worst on the forced-synthesis handback turns a background sub-agent injects, which the parent legitimately answers `NO_REPLY`, leaving a noise card each time. A card that says nothing undermines the "feel like a colleague" job (`reference/jobs/feel-like-a-colleague.md`).

## Root cause
- Finalize chokepoint: `telegram-plugin/gateway/narrative-lane.ts` `clearActivitySummary` — at turn end it FINALIZES the card to a `done` record (or DELETES it under `CLEAR_STATUS_ON_COMPLETION`).
- The sentinel-only reply is dropped by `hooks/sentinel-reply-guard-pretool.mjs`, but `turn.lastReplyText` is still stamped from the blocked `tool_use`, so the card finalizes with `✓ NO_REPLY`.

## The fix
- New pure, unit-testable gate `isSilentSentinelCardOutcome` in `telegram-plugin/turn-flush-safety.ts`, reusing the **existing** shared silent predicates (`isSilentFlushMarker` / `isCompositeSilentNoise` / `endsWithSilentMarker`) — no second notion of "silent" is invented.
- `clearActivitySummary` now DELETES the card (the same path `CLEAR_STATUS_ON_COMPLETION` already uses) when the turn's whole outcome was a silent sentinel.
- **Normal-case guarantee:** `finalAnswerEverDelivered` short-circuits the gate, so any turn that delivered a substantive answer keeps its card and still delivers.
- The reply path uses sentinel-**only** detection (not `endsWithSilentMarker`): a `prose\nNO_REPLY` reply is not dropped by the guard, so its prose WAS delivered and its card stays.

## Test plan
- `telegram-plugin/tests/turn-flush-safety.test.ts`: 9 pure-function cases (bare marker, trailing punctuation/case, composite noise, H6 prose+trailing marker, delivered-prose-with-trailing-marker, `finalAnswerEverDelivered` short-circuit).
- `telegram-plugin/tests/narrative-lane-golden.test.ts`: 5 golden card-outcome cases — silent turn → `deleteMessage` fired / no `editMessageText`; normal reply and delivered prose+trailing-marker → card kept (RED/GREEN on the outcome, not the code path).
- Scoped vitest: `95 passed (95)`. Relevant lint guards clean (`check-gateway-line-ratchet`, `check-status-pin-single-path`, `check-stale-tool-descriptions`, `check-agent-attribution-trailers`). `gateway.ts` untouched.

## Risk
Low. Single deterministic gate at one finalize chokepoint; delete path is the pre-existing `CLEAR_STATUS_ON_COMPLETION` one. No sub-agent handbacks are disabled (the `SWITCHROOM_SUBAGENT_HANDBACK` kill-switch is untouched). The `finalAnswerEverDelivered` guard keeps the normal delivered-answer case intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)