### PR TITLE
fix(rollout): tolerate ENOENT chown races + stop masking restart failures

### DIFF
--- a/src/agents/agent-owned-tree.test.ts
+++ b/src/agents/agent-owned-tree.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for the reconcile ownership sweep's ENOENT-race tolerance.
+ *
+ * Incident: a full-mode rollout halted at a non-canary agent whose live
+ * `workspace/pgdata-*` Postgres data dir was churning files. The recursive
+ * `chown -h -R` over the whole agent tree hit `readdir`→`lchown` races on
+ * vanished inodes → per-file "No such file or directory" → aggregate exit
+ * status 1 → `execFileSync` threw → the sweep re-threw → reconcile aborted
+ * BEFORE the container was recreated. A benign race stalled the roll.
+ *
+ * The fix makes `chownTree` tolerant of a pure vanished-file race while
+ * STILL failing loudly on a real ownership failure (EPERM/EACCES/EROFS —
+ * the #3168 invariant: a still-present, still-mis-owned inode must throw).
+ *
+ * These tests assert the OUTCOME, not the code path:
+ *   - `isChownVanishedRaceOnly` classifies stderr correctly (fail-closed).
+ *   - `chownTree` SWALLOWS a pure-ENOENT throw and RE-THROWS a real failure.
+ * Both would fail on pre-fix `main` (the classifier does not exist and
+ * `chownTree` had no tolerance at all — every non-zero chown threw).
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { execFileSyncMock } = vi.hoisted(() => ({ execFileSyncMock: vi.fn() }));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, execFileSync: execFileSyncMock };
+});
+
+import { isChownVanishedRaceOnly, ownershipRuntime } from "./agent-owned-tree.js";
+
+/** Fabricate an execFileSync-style throw carrying status + captured stderr. */
+function chownError(stderr: string): Error & { status: number; stderr: Buffer } {
+  const err = new Error("Command failed: chown -h -R -- 10001:10001 /a") as Error & {
+    status: number;
+    stderr: Buffer;
+  };
+  err.status = 1;
+  err.stderr = Buffer.from(stderr);
+  return err;
+}
+
+describe("isChownVanishedRaceOnly", () => {
+  it("returns true when EVERY stderr line is a vanished-file (ENOENT) error", () => {
+    const stderr =
+      "chown: cannot access '/a/workspace/pgdata-r435/16384': No such file or directory\n" +
+      "chown: cannot access '/a/workspace/pgdata-r435/pg_wal/000001': No such file or directory\n" +
+      "chown: cannot read directory '/a/workspace/pgdata-r435/base': No such file or directory\n";
+    expect(isChownVanishedRaceOnly(chownError(stderr))).toBe(true);
+  });
+
+  it("returns false when ANY line is a real ownership failure (mixed)", () => {
+    const stderr =
+      "chown: cannot access '/a/workspace/pgdata/16384': No such file or directory\n" +
+      "chown: changing ownership of '/a/immutable': Operation not permitted\n";
+    expect(isChownVanishedRaceOnly(chownError(stderr))).toBe(false);
+  });
+
+  it("returns false for a pure EPERM failure", () => {
+    const stderr = "chown: changing ownership of '/a/x': Operation not permitted\n";
+    expect(isChownVanishedRaceOnly(chownError(stderr))).toBe(false);
+  });
+
+  it("returns false for a read-only filesystem failure", () => {
+    const stderr = "chown: changing ownership of '/a/ro': Read-only file system\n";
+    expect(isChownVanishedRaceOnly(chownError(stderr))).toBe(false);
+  });
+
+  it("is fail-closed on empty/absent stderr (non-zero exit, no evidence)", () => {
+    expect(isChownVanishedRaceOnly(chownError(""))).toBe(false);
+    expect(isChownVanishedRaceOnly({ status: 1 })).toBe(false);
+    expect(isChownVanishedRaceOnly(null)).toBe(false);
+    expect(isChownVanishedRaceOnly(undefined)).toBe(false);
+  });
+});
+
+describe("ownershipRuntime.chownTree ENOENT-race tolerance", () => {
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+  });
+
+  it("succeeds normally when chown exits 0", () => {
+    execFileSyncMock.mockReturnValue(Buffer.from(""));
+    expect(() => ownershipRuntime.chownTree(10001, 10001, "/a")).not.toThrow();
+  });
+
+  it("SWALLOWS a pure vanished-file race (the incident: today this throws)", () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw chownError(
+        "chown: cannot access '/a/workspace/pgdata-r435/16384': No such file or directory\n" +
+          "chown: cannot access '/a/workspace/pgdata-r435/pg_wal/x': No such file or directory\n",
+      );
+    });
+    expect(() => ownershipRuntime.chownTree(10001, 10001, "/a")).not.toThrow();
+  });
+
+  it("RE-THROWS a real ownership failure (preserves the #3168 invariant)", () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw chownError(
+        "chown: changing ownership of '/a/.claude/settings.json': Operation not permitted\n",
+      );
+    });
+    // The ORIGINAL error is re-thrown intact — its `.stderr` still carries the
+    // real EPERM failure so the upstack #3168 "could not restore ownership"
+    // wrap fires loudly.
+    let caught: (Error & { stderr?: Buffer }) | undefined;
+    try {
+      ownershipRuntime.chownTree(10001, 10001, "/a");
+    } catch (e) {
+      caught = e as Error & { stderr?: Buffer };
+    }
+    expect(caught).toBeDefined();
+    expect(caught?.stderr?.toString()).toMatch(/Operation not permitted/);
+  });
+
+  it("RE-THROWS when a real failure is mixed with vanished-file races", () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw chownError(
+        "chown: cannot access '/a/workspace/pgdata/16384': No such file or directory\n" +
+          "chown: changing ownership of '/a/ro': Read-only file system\n",
+      );
+    });
+    let caught: (Error & { stderr?: Buffer }) | undefined;
+    try {
+      ownershipRuntime.chownTree(10001, 10001, "/a");
+    } catch (e) {
+      caught = e as Error & { stderr?: Buffer };
+    }
+    expect(caught).toBeDefined();
+    expect(caught?.stderr?.toString()).toMatch(/Read-only file system/);
+  });
+
+  it("pins LC_ALL=C on the chown invocation so stderr wording is stable", () => {
+    execFileSyncMock.mockReturnValue(Buffer.from(""));
+    ownershipRuntime.chownTree(10001, 10001, "/a");
+    const [cmd, args, opts] = execFileSyncMock.mock.calls[0];
+    expect(cmd).toBe("chown");
+    expect(args).toEqual(["-h", "-R", "--", "10001:10001", "/a"]);
+    expect((opts as { env: Record<string, string> }).env.LC_ALL).toBe("C");
+  });
+});

--- a/src/agents/agent-owned-tree.ts
+++ b/src/agents/agent-owned-tree.ts
@@ -62,6 +62,27 @@ import { join } from "node:path";
 import { allocateAgentUid } from "./agent-uid.js";
 
 /**
+ * Classify a failed `chown -h -R` (execFileSync throw) as a benign
+ * vanished-file race vs a real ownership failure. Returns true ONLY when
+ * chown exited non-zero AND every stderr line is a "No such file or
+ * directory" (ENOENT) error — i.e. an inode disappeared mid-walk, which is
+ * safe to ignore because a gone file has no ownership to restore. Any other
+ * error line (Operation not permitted, Permission denied, Read-only file
+ * system, …) or empty/uninterpretable stderr → false → caller re-throws.
+ * Assumes LC_ALL=C wording (chownTree pins it).
+ */
+export function isChownVanishedRaceOnly(err: unknown): boolean {
+  const e = err as { stderr?: Buffer | string | null } | null | undefined;
+  const raw = e?.stderr == null ? "" : e.stderr.toString();
+  const lines = raw
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  if (lines.length === 0) return false; // fail-closed: no evidence it was a race
+  return lines.every((l) => /: No such file or directory$/.test(l));
+}
+
+/**
  * The agent-dir SUBDIRECTORIES the scoped sweep recurses into (#3333
  * amendment A). Root reconcile writers land inside these state dirs
  * (`.claude/` — settings.json + subagents + backups; `.claude-cron/` —
@@ -137,9 +158,23 @@ export const ownershipRuntime = {
    * `-h` is load-bearing on busybox hosts — see "Symlink safety" above.
    */
   chownTree: (uid: number, gid: number, rootDir: string): void => {
-    execFileSync("chown", ["-h", "-R", `${uid}:${gid}`, rootDir], {
-      stdio: ["ignore", "ignore", "pipe"],
-    });
+    try {
+      execFileSync("chown", ["-h", "-R", "--", `${uid}:${gid}`, rootDir], {
+        stdio: ["ignore", "ignore", "pipe"],
+        // LC_ALL=C pins chown's stderr wording so the race classifier below
+        // is deterministic across hosts/locales (busybox + GNU both honour it).
+        env: { ...process.env, LC_ALL: "C" },
+      });
+    } catch (err) {
+      // chown -R exits non-zero if ANY entry failed. During a live rollout the
+      // agent's own workspace may be churning (a mid-test Postgres data dir,
+      // a git checkout, node_modules) so inodes vanish between chown's readdir
+      // and its lchown — a benign ENOENT race, NOT an ownership failure. Swallow
+      // the exit ONLY when EVERY stderr line is such a vanished-file error, and
+      // re-throw on any real failure (EPERM/EACCES/EROFS): a still-present,
+      // still-mis-owned file is the #3168 invariant we must fail loudly on.
+      if (!isChownVanishedRaceOnly(err)) throw err;
+    }
   },
   /**
    * SHALLOW chown (no `-R`) of the given paths — the top-level pass of the

--- a/src/cli/agent-reconcile.test.ts
+++ b/src/cli/agent-reconcile.test.ts
@@ -253,4 +253,33 @@ describe("reconcileAndRestartAgent — compose regen before recreate (pin self-h
     expect(deps.writeComposeFile).toHaveBeenCalledTimes(1);
     expect(deps.gracefulRestartAgent).toHaveBeenCalledTimes(1);
   });
+
+  it("a reconcile THROW propagates and NEVER recreates the container", async () => {
+    // The incident seam: the ownership sweep runs at the END of
+    // reconcileAgent; if it throws (e.g. a real, non-ENOENT chown failure)
+    // the throw must abort reconcileAndRestartAgent BEFORE compose regen and
+    // recreate — "never restart on top of a broken reconcile". The existing
+    // tests only cover reconcileAgent RETURNING; this pins the THROW path.
+    const deps = mkDeps({
+      reconcileAgent: vi.fn(() => {
+        throw new Error("ownership sweep failed: could not restore agent ownership");
+      }) as never,
+    });
+
+    await expect(
+      reconcileAndRestartAgent(
+        "foo",
+        mkConfig("foo"),
+        "/state/agents",
+        undefined,
+        { silent: true, force: true },
+        deps,
+      ),
+    ).rejects.toThrow(/ownership sweep/);
+
+    // The container was never touched: no compose regen, no restart.
+    expect(deps.writeComposeFile).not.toHaveBeenCalled();
+    expect(deps.restartAgent).not.toHaveBeenCalled();
+    expect(deps.gracefulRestartAgent).not.toHaveBeenCalled();
+  });
 });

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1586,6 +1586,13 @@ export function registerAgentCommand(program: Command): void {
               console.error(
                 chalk.red(`Failed to restart ${n}: ${(err as Error).message}`)
               );
+              // A reconcile/restart throw must surface as a non-zero exit so a
+              // caller (the rollout driver spawning `agent restart --wait
+              // --force`) can detect it via the child's status, not only by a
+              // downstream version probe. Without this the CLI exits 0 despite
+              // never recreating the container. Loop continues for other agents;
+              // exitCode is process-global and set once.
+              process.exitCode = 1;
             }
           }
 

--- a/src/cli/restart.ts
+++ b/src/cli/restart.ts
@@ -129,6 +129,9 @@ export function registerRestartCommand(program: Command): void {
             }
           } catch (err) {
             console.error(chalk.red(`  ${name}: restart failed: ${(err as Error).message}`));
+            // Surface the failure as a non-zero process exit (see agent.ts
+            // sibling): a restart throw must not be swallowed to exit 0.
+            process.exitCode = 1;
           }
         }
 

--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -427,6 +427,36 @@ describe("executeRollout", () => {
     expect(runs).not.toContainEqual(["webd", "install", "--tag", TARGET]);
   });
 
+  it("STOPS on a non-zero restart status EVEN WHEN the version probe reads the target", async () => {
+    // The masking-bug regression. Incident: the child `agent restart`
+    // reconcile threw before recreating the container, but a lucky probe
+    // (matching the target) let the roll report success over a broken agent.
+    // Here the second agent's restart exits status:1 while its probe pretends
+    // the container DID come up on the target — the driver must STILL halt on
+    // the exit status, not fall through to the (passing) version gate.
+    // On pre-fix `main` the driver ignores `status` and reports success → this
+    // test fails; with the status gate it stops. Outcome, not code path.
+    const steps = planRollout(["clerk", "marko", "quill"]);
+    const { deps, runs } = harness({
+      // ALL agents probe as the target — no version mismatch to catch it.
+      versions: { clerk: "0.15.18", marko: "0.15.18", quill: "0.15.18" },
+      // marko's restart exits non-zero (reconcile/restart failure); all else 0.
+      runStatus: (args) =>
+        args[0] === "agent" && args[1] === "restart" && args[2] === "marko" ? 1 : 0,
+    });
+    const r = await executeRollout(steps, TARGET, deps);
+    expect(r.ok).toBe(false);
+    expect(r.failedStep).toBe("restart-agent");
+    expect(r.failedAgent).toBe("marko");
+    // Disjoint from the timeout shape: the child ran to completion, so no
+    // `timedOut` flag on this failure.
+    expect(r.timedOut).toBeUndefined();
+    expect(r.rolled).toEqual(["clerk"]); // only the one before the failure
+    // quill was never restarted; web/hostd never refreshed.
+    expect(runs).not.toContainEqual(["agent", "restart", "quill", "--wait", "--force"]);
+    expect(runs).not.toContainEqual(["webd", "install", "--tag", TARGET]);
+  });
+
   it("STOPS when an agent is unreachable (probe returns null)", async () => {
     const steps = planRollout(["clerk"]);
     const { deps } = harness({ versions: { clerk: null } });

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -1223,6 +1223,38 @@ export async function executeRollout(
               timedOut: true,
             });
           }
+
+          // The spawned `switchroom agent restart` exited on its own (not a
+          // timeout) but with a NON-ZERO status: reconcile or the restart
+          // itself failed — e.g. the ownership sweep threw before the container
+          // was ever recreated. Do NOT fall through to the version probe: the
+          // container is likely still on the OLD image, and even if the probe
+          // happened to read the target tag a non-zero restart means the
+          // post-reconcile invariant did not hold. Make the exit status a
+          // first-class gate so the halt is causal, not a lucky version
+          // mismatch.
+          if (restartRes.status !== 0) {
+            const gotAfterExit = deps.probeVersion(step.agent);
+            deps.log(
+              `  ✗ ${step.agent} → restart exited ${restartRes.status} ` +
+                `(probe says ${gotAfterExit ?? "<unreachable>"}) — STOPPING`,
+            );
+            emit(
+              isCanary
+                ? { phase: "canary-fail", target, agent: step.agent, n: agentIndex, m: totalAgents }
+                : { phase: "agent-done", target, agent: step.agent, n: agentIndex, m: totalAgents },
+            );
+            // Same failure shape as the version-mismatch fail below (no
+            // `timedOut`): the child ran to completion and exited non-zero, so
+            // there are no live SIGKILL-orphaned grandchildren to warn about —
+            // hostd/get_status recovery matches the "ran, wrong outcome" case.
+            return fail({
+              failedStep: "restart-agent",
+              failedAgent: step.agent,
+              got: gotAfterExit,
+            });
+          }
+
           const got = deps.probeVersion(step.agent);
           if (got === null || normalizeVersion(got) !== targetNorm) {
             deps.log(`  ✗ ${step.agent} → ${got ?? "<unreachable>"} (expected ${target}) — STOPPING`);


### PR DESCRIPTION
## Incident

A fleet rollout stalled at agent 4/12 (`finn`), a non-canary, whose live `workspace/pgdata-r435` Postgres data directory was churning files mid test-suite.

**Root cause chain (verified against source at `origin/main`):**
- The reconcile ownership sweep runs at the end of `reconcileAgent` (`scaffold.ts:8440`). In full mode it shells one unbounded `chown -h -R` over the **entire** agent dir with no exclusions (`agent-owned-tree.ts` `chownTree`).
- `pgdata-r435` is a direct grandchild (`workspace/`), so the `-R` walk descended straight into the churning Postgres dir. Files vanished between `readdir` and `lchown` → per-file "No such file or directory" → aggregate exit status 1 → `execFileSync` threw.
- The throw propagated **past** the container recreate (`reconcileAndRestartAgent` deliberately has no try/catch around reconcile — "never restart on a broken config"), so `finn` was never recreated.
- The roll halted only **by luck**: the container stayed on the old image, so `probeVersion` returned the old semver and the version gate fired. Nothing detected the reconcile failure itself. Had the recreate already put the container on the target tag before a *later* post-start failure, the probe would have matched and the roll would have reported **success over a broken agent**.

The scoped sweep (which skips `workspace/`) is injected only for the canary; `finn` at 4/12 got the full sweep.

## The three fixes

**(i) Durable root-cause — `src/agents/agent-owned-tree.ts`.** Make `chownTree` tolerant of a benign vanished-file (ENOENT) race while STILL re-throwing a real ownership failure (EPERM/EACCES/EROFS — the #3168 invariant). A pure exported `isChownVanishedRaceOnly()` classifier swallows the exit only when *every* stderr line is ENOENT (fail-closed on empty or mixed stderr). `LC_ALL=C` is pinned on the chown so the match is locale-stable across GNU/busybox. This fixes the class (any concurrent churn — a git checkout, `npm ci`, a test tmpdir), not just `pgdata`.

**(ii) Masking bug a — `src/cli/agent.ts` + `src/cli/restart.ts`.** The child `agent restart` (and sibling `restart`) catch logged a reconcile/restart throw but never set `process.exitCode`, exiting **0** despite never recreating the container. Set `process.exitCode = 1` on the failure path (loop still continues for other agents; exitCode is process-global).

**(iii) Masking bug b — `src/cli/rollout.ts`.** The driver checked only `restartRes.timedOut`, never `.status`, then fell through to the version probe. Added a `restartRes.status !== 0` gate between the timeout branch and the probe, returning the disjoint (no-`timedOut`) failure shape. Only causally effective once (ii) makes the child exit non-zero — hence shipped together.

## Tests (assert outcomes; verified RED on `origin/main` without each fix)

- **`src/agents/agent-owned-tree.test.ts` (new):** classifier truth table (ENOENT-only → true; mixed/EPERM/ROFS/empty → false) + `chownTree` swallows a pure ENOENT race but re-throws a real failure + `LC_ALL=C` is pinned. On unpatched `main`: 7/10 fail (classifier absent, no tolerance).
- **`src/cli/rollout.test.ts` (extend):** a restart returning `status:1` while the probe reads the **target** version must STILL fail the roll (`failedStep: "restart-agent"`, no later agents restarted). This is the "correct-by-luck" gap turned into a deterministic assertion. On unpatched `main`: fails (driver reports success).
- **`src/cli/agent-reconcile.test.ts` (extend):** a reconcile throw propagates and never regenerates compose or recreates the container.

## Verification

- Scoped tests: `vitest run src/agents/agent-owned-tree.test.ts src/cli/agent-reconcile.test.ts src/cli/rollout.test.ts` → **187 passed**.
- Typecheck: `tsc --noEmit` → **clean (exit 0)**.

Branched off `origin/main`. CI is the full-suite authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)