### PR TITLE
fix(telegram): queued card 400s when the parked message id is synthetic

### DIFF
--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -1138,8 +1138,17 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
       }
       if (QUEUED_CARD_ENABLED && !handbackOwnsSurface) {
         const cardChatId = ev.chatId
-        const replyToRaw = ev.messageId != null ? Number(ev.messageId) : null
-        const replyTo = replyToRaw != null && Number.isFinite(replyToRaw) ? replyToRaw : null
+        // Reply-anchor ONLY to a plausible real Telegram message id. Synthetic
+        // enqueues (subagent handback, boot resume, cron) fabricate `messageId`
+        // from `Date.now()` (~1.78e13) — finite, so a bare `Number.isFinite`
+        // guard passes it, but `reply_parameters.message_id` hard-rejects
+        // anything beyond signed int32 with 400 `field "message_id" must be a
+        // valid Number` (`allow_sending_without_reply` does NOT bypass the
+        // range check), killing the whole card send (overlord
+        // gateway-supervisor.log 2026-08-04, e.g. msg=1785846295635). Same bug
+        // class as the resume-dark-feed incident — reuse its guard, don't
+        // re-derive a weaker one. An unanchored card is fine; no card is not.
+        const replyTo = parseSourceMessageId(ev.messageId)
         void openQueuedCard(deps, cardChatId, enqThreadIdNum ?? null, replyTo).then((cardId) => {
           if (cardId == null) return
           // Still parked → adopt on the next dequeue. Otherwise the entry already

--- a/telegram-plugin/tests/queued-card-surface.test.ts
+++ b/telegram-plugin/tests/queued-card-surface.test.ts
@@ -260,3 +260,69 @@ describe('Part B — handback-while-busy: exactly one card, never a frozen "Queu
     expect(rec.edits).toHaveLength(0)
   })
 })
+
+describe('Part B — synthetic (fabricated) message ids never 400 the queued card', () => {
+  /** Recording bot that enforces the REAL Telegram Bot API contract on
+   *  `reply_parameters.message_id`: anything non-integer or beyond signed int32
+   *  is hard-rejected with the exact 400 the live gateway hit
+   *  (gateway-supervisor.log 2026-08-04, msg=1785846295635) — BEFORE recording,
+   *  exactly like the wire call. `allow_sending_without_reply` does not bypass
+   *  the range check, only the message-not-found case. */
+  function withTelegramStrictBot(h: Harness) {
+    const sends: SendRec[] = []
+    let nextId = 9001
+    ;(h.deps as unknown as { bot: unknown }).bot = {
+      api: {
+        sendRichMessage: async (chatId: string, msg: { markdown: string }, opts: Record<string, unknown>) => {
+          const rp = opts.reply_parameters as { message_id?: unknown } | undefined
+          if (rp != null) {
+            const mid = rp.message_id
+            if (typeof mid !== 'number' || !Number.isInteger(mid) || mid <= 0 || mid >= 2 ** 31) {
+              throw new Error(
+                `Call to 'sendRichMessage' failed! (400: Bad Request: field "message_id" must be a valid Number)`,
+              )
+            }
+          }
+          const id = nextId++
+          sends.push({ chatId, markdown: msg.markdown, opts, id })
+          return { message_id: id }
+        },
+        editMessageText: async () => true,
+        deleteMessage: async () => true,
+      },
+    }
+    return { sends }
+  }
+
+  it('sends the queued card UNANCHORED (no 400) when the parked message id is a fabricated Date.now() timestamp', async () => {
+    const h = makeHarness()
+    const rec = withTelegramStrictBot(h)
+
+    // Turn A mints on an idle session.
+    handleSessionEvent(h.deps, enqueue('501'))
+    expect(rec.sends).toHaveLength(0)
+
+    // A synthetic enqueue (subagent handback / boot resume) parks mid-turn with
+    // a fabricated ms-timestamp message id — finite, but NOT a Telegram id.
+    handleSessionEvent(h.deps, enqueue('1785846295635', 'handback: worker done'))
+    await settle()
+    expect(__parkedTurnStartCountForTest()).toBe(1)
+
+    // The card SENT (no 400 — RED on the pre-fix guard, which forwarded the
+    // 13-digit id into reply_parameters and lost the whole card)…
+    expect(rec.sends).toHaveLength(1)
+    // …and it sent WITHOUT reply-linkage: no reply_parameters at all.
+    expect(rec.sends[0]!.opts.reply_parameters).toBeUndefined()
+  })
+
+  it('still reply-anchors when the parked message id is a real Telegram id', async () => {
+    const h = makeHarness()
+    const rec = withTelegramStrictBot(h)
+
+    handleSessionEvent(h.deps, enqueue('501'))
+    handleSessionEvent(h.deps, enqueue('502', 'real mid-turn message'))
+    await settle()
+    expect(rec.sends).toHaveLength(1)
+    expect((rec.sends[0]!.opts.reply_parameters as { message_id: number }).message_id).toBe(502)
+  })
+})


### PR DESCRIPTION
## Bug (confirmed live)

Fleet-audit B1. The gateway's queued-card path 400s on every mid-turn park of a **synthetic** inbound (subagent handback, boot resume, cron):

```
turn-start parked (session busy) chat=8248703757 thread=- msg=1785846295635 parked=1
tg-post method=sendRichMessage ... status=err err=telegram_400 code=400 desc=Bad Request: field "message_id" must be a valid Number
telegram gateway: queued card send failed: ...
```

(overlord `gateway-supervisor.log`, repeated hits 2026-08-04.)

## Root cause

Synthetic enqueues fabricate `messageId` from `Date.now()` (~1.78e13). The park-time reply-anchor guard in `stream-render.ts` was a bare `Number.isFinite`, which passes the fabricated 13-digit id — but Telegram hard-rejects `reply_parameters.message_id` beyond signed int32 with exactly this 400, and `allow_sending_without_reply` does **not** bypass the range check. The whole card send was lost, not just the anchor.

This is the same bug class as the resume-dark-feed incident (2026-06-05) that `parseSourceMessageId` (`telegram-plugin/gateway/source-message-id.ts`) was written for — the queued-card path re-derived a weaker guard instead of reusing it. The correct guard was already imported in the same file (used for `turn.sourceMessageId`).

## Fix

Use `parseSourceMessageId` for the queued-card reply anchor. A synthetic / out-of-range id now yields an **unanchored** card (still sent, still adopted on dequeue) instead of no card at all. Real message ids still reply-anchor exactly as before.

## Test (RED without fix)

New tests in `queued-card-surface.test.ts` use a strict recording bot that enforces Telegram's real int32 range check on `reply_parameters.message_id` (throws the verbatim 400 before recording, like the wire):

- a park with a fabricated ms-timestamp id must still SEND the card, unanchored → **fails on the old guard** (`expected [] to have a length of 1 but got +0` — the card is lost, the exact production symptom)
- a park with a real id must still reply-anchor to it → guards against over-stripping

Locally: `tsc --noEmit` clean, `check-bot-api-wrapping` clean, queued-card + stream-render suites green (queued-card-surface 8/8, adjacent suites 44 + 61 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
