### PR TITLE
fix(telegram): stop bridge disconnect→re-register churn (unhandled 'Failed to connect' + bogus reason=crash)

### DIFF
--- a/telegram-plugin/bridge/ipc-client.ts
+++ b/telegram-plugin/bridge/ipc-client.ts
@@ -215,10 +215,26 @@ export function createIpcClient(options: IpcClientOptions): Promise<IpcClientHan
 
   function scheduleReconnect(): void {
     if (closed) return;
+    // Single-flight: a broken connection can reach here twice (the
+    // Bun.connect failure catch AND the socket close handler both fire
+    // for the same attempt). Two live timers mean two parallel
+    // doConnect() calls and a spare socket — observed in gateway logs
+    // as an instant anonymous connect+disconnect (agent=null) right
+    // before the real re-register.
+    if (reconnectTimer) return;
     log(`reconnecting in ${currentDelay}ms`);
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null;
-      if (!closed) doConnect();
+      if (!closed) {
+        // Swallow the rejection: doConnect's own catch has already
+        // logged the failure and scheduled the next retry. Without this,
+        // every failed BACKGROUND reconnect (e.g. the gateway restarting
+        // out from under a long-lived bridge) surfaced as a process-level
+        // unhandledRejection — "Error: Failed to connect" in
+        // bridge-crash.log — and pre-#3033 killed the bridge process
+        // outright (Claude Code never respawns a dead MCP server).
+        doConnect().catch(() => {});
+      }
     }, currentDelay);
     currentDelay = Math.min(currentDelay * 2, maxReconnectDelayMs);
   }

--- a/telegram-plugin/gateway/boot-reason.ts
+++ b/telegram-plugin/gateway/boot-reason.ts
@@ -83,3 +83,64 @@ export function determineRestartReason(opts: {
   if (sessionMarker != null) return 'crash'
   return 'fresh'
 }
+
+/**
+ * Boot-reason window during which a bridge re-register reuses the reason
+ * the boot path already determined. Matches the restart-marker and
+ * operator-marker freshness windows (5 min) — a bridge that survived a
+ * gateway restart reconnects within seconds of the new gateway's boot,
+ * comfortably inside it.
+ */
+export const BOOT_REASON_REUSE_WINDOW_MS = 5 * 60_000
+
+/**
+ * Determine the restart reason for a BRIDGE RE-REGISTER (gateway.ts
+ * `onClientRegistered`, the `bridge-reconnect` path) — as opposed to the
+ * gateway's own boot path.
+ *
+ * Why this exists (fleet-audit B2, kdogg 2026-08-02 06:27 trace): on a
+ * planned gateway restart (`cli: restart` SIGTERM), the bridge — living
+ * inside the separate claude process — survives and reconnects a few
+ * seconds after the new gateway boots. By then the boot path has already
+ * READ AND CLEARED the restart / clean-shutdown markers (the 2026-05-25
+ * GC, gateway.ts boot path), so re-deriving the reason from disk falls
+ * through to the sessionMarker branch and every such re-register logs —
+ * and, when a chat is resolvable, POSTS a boot card claiming —
+ * `reason=crash` for a perfectly graceful restart. Hundreds of these per
+ * agent fleet-wide (lawgpt 310, reggie 179, ziggy 175, kdogg 174).
+ *
+ * Decision:
+ *   1. Any on-disk marker still present → normal `determineRestartReason`
+ *      (in-gateway /restart flows where the gateway never went down write
+ *      a marker the boot path never consumed — keep honoring it).
+ *   2. No markers, but the gateway booted recently (<5 min) and recorded
+ *      the reason it determined at boot → reuse that reason. The bridge
+ *      is re-registering into the SAME restart episode the boot path
+ *      already classified.
+ *   3. Otherwise (gateway long-lived, markers absent) → fall through to
+ *      `determineRestartReason` — a marker-less bridge re-register hours
+ *      into a gateway's life still classifies conservatively as 'crash'
+ *      (the claude/bridge side genuinely died and came back).
+ */
+export function determineBridgeReconnectReason(opts: {
+  marker: { ts: number } | null
+  cleanMarker: CleanShutdownMarker | null
+  sessionMarker: SessionMarker | null
+  now: number
+  /** `GATEWAY_STARTED_AT_MS` of the running gateway process. */
+  gatewayStartedAtMs: number
+  /** Reason the gateway's own boot path determined (null if it never ran). */
+  bootReason: RestartReason | null
+  bootReasonReuseWindowMs?: number
+  cleanMaxAgeMs?: number
+  markerMaxAgeMs?: number
+  operatorMaxAgeMs?: number
+}): RestartReason {
+  const { gatewayStartedAtMs, bootReason, bootReasonReuseWindowMs = BOOT_REASON_REUSE_WINDOW_MS } = opts
+  if (opts.marker == null && opts.cleanMarker == null
+    && bootReason != null
+    && opts.now - gatewayStartedAtMs < bootReasonReuseWindowMs) {
+    return bootReason
+  }
+  return determineRestartReason(opts)
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -857,7 +857,7 @@ import {
   resolvePersonaName, shouldSkipDuplicateBootCard,
   type BootCardHandle, type RestartReason,
 } from './boot-card.js'
-import { determineRestartReason } from './boot-reason.js'
+import { determineRestartReason, determineBridgeReconnectReason } from './boot-reason.js'
 import { maybeRenderUpdateAnnouncement } from './update-announce.js'
 import { createIssuesCardHandle, type IssuesCardHandle } from '../issues-card.js'
 import { startIssuesWatcher, type IssuesWatcherHandle } from '../issues-watcher.js'
@@ -9163,6 +9163,8 @@ let activeBootCard: BootCardHandle | null = null
 // dedupe checks this so it can't race against the boot path's await.
 // See issue #489 (klanker msgId 4715 + 4716, 2026-05-01 10:13:15).
 let bootCardPending = false
+// Boot-determined restart reason — see determineBridgeReconnectReason (B2).
+let bootReasonAtStartup: RestartReason | null = null
 
 // Issues card (#428) — pinned per-agent surface listing current
 // unresolved entries from the issue sink (#425). Idempotent across
@@ -10450,15 +10452,12 @@ if (isGatewayMain) ipcServer = createIpcServer({
       })
     }
 
-    // If the agent reconnected after a /restart (or any restart), post a boot
-    // card. The restart-marker carries the ack chat; if absent we fall back to
-    // resolveBootChatId so crash-recovery reconnects also get a card.
-    //
-    // Skip if the boot path already posted a card OR is currently in-flight
-    // on its sendMessage await (issue #489 — klanker msgId 4715+4716,
-    // 2026-05-01). The original dedupe (msgId 2245+2248, 2026-04-26) only
-    // covered the post-resolution case; bootCardPending closes the in-flight
-    // race window. See `shouldSkipDuplicateBootCard`.
+    // If the agent reconnected after a restart, post a boot card. The
+    // restart-marker carries the ack chat; else fall back to resolveBootChatId
+    // so crash-recovery reconnects also get a card. Skip if the boot path
+    // already posted a card OR its sendMessage is in-flight (issue #489,
+    // klanker 2026-05-01; earlier dedupe 2026-04-26 only covered the
+    // post-resolution case). See `shouldSkipDuplicateBootCard`.
     const dedupeDecision = shouldSkipDuplicateBootCard({ activeBootCard, bootCardPending }, 'bridge-reconnect')
     if (dedupeDecision.skip) {
       process.stderr.write(`telegram gateway: bridge-reconnect: skipping boot card (${dedupeDecision.reason})\n`)
@@ -10475,7 +10474,9 @@ if (isGatewayMain) ipcServer = createIpcServer({
         clearRestartMarker()
       }
 
-      const reason = determineRestartReason({ marker, cleanMarker, sessionMarker: storedSession, now: nowMs })
+      // B2: boot path cleared the markers — reuse its reason (boot-reason.ts).
+      const reason = determineBridgeReconnectReason({ marker, cleanMarker, sessionMarker: storedSession,
+        now: nowMs, gatewayStartedAtMs: GATEWAY_STARTED_AT_MS, bootReason: bootReasonAtStartup })
       const target = resolveBootChatId(marker, markerAgeMs)
 
       if (target) {
@@ -23492,15 +23493,14 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
           } else {
             const markerAgeMs = marker ? nowMs - marker.ts : undefined
             const reason = determineRestartReason({ marker, cleanMarker, sessionMarker: storedSession, now: nowMs })
+            // Markers were cleared above — stash for bridge re-register (B2).
+            bootReasonAtStartup = reason
             const target = resolveBootChatId(marker, markerAgeMs)
 
-            // Issue #92: when reason='crash' AND no chat is resolvable,
-            // the gateway used to silently skip — the only signal a user
-            // got was their next message landing on a fresh process. Now
-            // we always surface unplanned crashes via the operator-events
-            // pipeline, which broadcasts to access.allowFrom (same path
-            // permission requests use). The pipeline's per-agent per-kind
-            // cooldown protects against crash loops spamming the chat.
+            // Issue #92: when reason='crash' AND no chat is resolvable, the
+            // gateway used to silently skip. Always surface unplanned crashes
+            // via the operator-events pipeline (broadcasts to access.allowFrom;
+            // its per-agent per-kind cooldown absorbs crash loops).
             if (reason === 'crash') {
               const cleanMarkerStale = cleanMarker
                 ? !shouldSuppressRecoveryBanner(cleanMarker, nowMs, CLEAN_SHUTDOWN_MAX_AGE_MS)

--- a/telegram-plugin/tests/boot-card-reason.test.ts
+++ b/telegram-plugin/tests/boot-card-reason.test.ts
@@ -164,3 +164,91 @@ describe('determineRestartReason', () => {
     expect(result).toBe('crash')
   })
 })
+
+// ── determineBridgeReconnectReason (fleet-audit B2) ────────────────────────
+//
+// Live trace this pins (kdogg gateway-supervisor.log, 2026-08-02):
+//   06:27:43  shutdown.clean_marker_written reason="cli: restart"
+//   06:27:46  boot.clean_shutdown_detected → boot path logs reason=graceful
+//             …and CLEARS the clean-shutdown marker (2026-05-25 GC)
+//   06:27:55  surviving bridge re-registers → old code re-derived from the
+//             now-empty disk and logged reason=crash for a graceful restart.
+// Fleet-wide: lawgpt 310 / reggie 179 / ziggy 175 / kdogg 174 such lines.
+
+import { determineBridgeReconnectReason } from '../gateway/boot-reason.js'
+
+describe('determineBridgeReconnectReason', () => {
+  it('reuses the boot-determined reason when the boot path consumed the markers (kdogg 2026-08-02 trace)', () => {
+    const result = determineBridgeReconnectReason({
+      marker: null,               // cleared by the boot path
+      cleanMarker: null,          // cleared by the boot path
+      sessionMarker: sessionMarker(),
+      now: NOW,
+      gatewayStartedAtMs: NOW - 10_000, // bridge re-registered 10s after boot
+      bootReason: 'graceful',
+    })
+    // Old behavior (plain determineRestartReason on the empty disk state)
+    // returned 'crash' here — the B2 mislabel.
+    expect(result).toBe('graceful')
+  })
+
+  it('a still-present fresh restart marker wins over the cached boot reason', () => {
+    const result = determineBridgeReconnectReason({
+      marker: recentMarker(10_000),
+      cleanMarker: null,
+      sessionMarker: sessionMarker(),
+      now: NOW,
+      gatewayStartedAtMs: NOW - 10_000,
+      bootReason: 'graceful',
+    })
+    expect(result).toBe('planned')
+  })
+
+  it('a still-present fresh clean-shutdown marker wins over the cached boot reason', () => {
+    const result = determineBridgeReconnectReason({
+      marker: null,
+      cleanMarker: recentCleanMarker(5_000),
+      sessionMarker: sessionMarker(),
+      now: NOW,
+      gatewayStartedAtMs: NOW - 10_000,
+      bootReason: 'crash',
+    })
+    expect(result).toBe('graceful')
+  })
+
+  it('late re-register (gateway up past the reuse window) still classifies as crash', () => {
+    const result = determineBridgeReconnectReason({
+      marker: null,
+      cleanMarker: null,
+      sessionMarker: sessionMarker(),
+      now: NOW,
+      gatewayStartedAtMs: NOW - 6 * 60_000, // gateway alive 6 min — bridge side died
+      bootReason: 'graceful',
+    })
+    expect(result).toBe('crash')
+  })
+
+  it('no recorded boot reason falls back to the plain derivation', () => {
+    const result = determineBridgeReconnectReason({
+      marker: null,
+      cleanMarker: null,
+      sessionMarker: sessionMarker(),
+      now: NOW,
+      gatewayStartedAtMs: NOW - 10_000,
+      bootReason: null,
+    })
+    expect(result).toBe('crash')
+  })
+
+  it('fresh first boot (no session marker) reuses bootReason fresh', () => {
+    const result = determineBridgeReconnectReason({
+      marker: null,
+      cleanMarker: null,
+      sessionMarker: null,
+      now: NOW,
+      gatewayStartedAtMs: NOW - 3_000,
+      bootReason: 'fresh',
+    })
+    expect(result).toBe('fresh')
+  })
+})

--- a/telegram-plugin/tests/ipc-client-reconnect-rejection.test.ts
+++ b/telegram-plugin/tests/ipc-client-reconnect-rejection.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression test for fleet-audit B2 — the bridge's background reconnect
+ * loop must never surface a failed connect attempt as a process-level
+ * unhandledRejection.
+ *
+ * Live evidence (kdogg, 2026-07-17):
+ *   bridge-crash.log: `unhandledRejection … Error: Failed to connect
+ *     | at doConnect (dist/server.js:24188) …`
+ *
+ * Mechanism: `scheduleReconnect()`'s timer invoked `doConnect()` without a
+ * rejection handler. `doConnect` returns a promise that REJECTS whenever
+ * the `Bun.connect` attempt fails (gateway restarting out from under a
+ * long-lived bridge — the exact window every planned `docker restart`
+ * opens). The initial-connect call sites attach a `.catch`; the retry
+ * timer did not, so every failed background retry escaped as an
+ * unhandledRejection. Pre-#3033 that killed the bridge process outright
+ * (Claude Code never respawns a dead MCP server → mute agent); post-#3033
+ * it still spams `bridge-crash.log` with pseudo-crash breadcrumbs and
+ * leans on a global process handler for survival.
+ *
+ * Outcome asserted: with nothing listening on the socket path, the client
+ * runs through its initial attempt AND several background retries without
+ * a single unhandledRejection reaching the process. RED without the
+ * `.catch` in scheduleReconnect's timer, GREEN with it.
+ *
+ * Run with: bun test telegram-plugin/tests/ipc-client-reconnect-rejection.test.ts
+ */
+import { describe, it, expect } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createIpcClient } from "../bridge/ipc-client.js";
+
+describe("ipc-client background reconnect", () => {
+  it("a failed reconnect attempt never escapes as a process-level unhandledRejection", async () => {
+    const captured: unknown[] = [];
+    const onUnhandled = (err: unknown) => {
+      captured.push(err);
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    // Nothing listens here — every connect attempt fails, exercising both
+    // the (already-handled) initial attempt and the retry-timer path.
+    const socketPath = join(tmpdir(), `ipc-b2-${crypto.randomUUID()}.sock`);
+
+    const handle = await createIpcClient({
+      socketPath,
+      agentName: "b2-test",
+      onInbound: () => {},
+      onPermission: () => {},
+      onStatus: () => {},
+      log: () => {},
+      reconnectDelayMs: 15,
+      maxReconnectDelayMs: 30,
+    });
+
+    try {
+      // Long enough for several background retries (15ms, 30ms, 30ms, …)
+      // plus the macrotask on which unhandledRejection is delivered.
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    } finally {
+      handle.close();
+      // Give any in-flight rejection its delivery tick before detaching.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      process.off("unhandledRejection", onUnhandled);
+    }
+
+    expect(handle.isConnected()).toBe(false);
+    expect(captured).toEqual([]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -213,6 +213,9 @@ export default defineConfig({
       "**/telegram-plugin/tests/fleet-fallback-gate.test.ts",
       "**/telegram-plugin/tests/ipc-server-client.test.ts",
       "**/telegram-plugin/tests/ipc-server-race.test.ts",
+      // ipc-client-reconnect-rejection.test.ts (fleet-audit B2) drives the
+      // real bridge ipc-client (Bun.connect) — bun built-in, run via bun.
+      "**/telegram-plugin/tests/ipc-client-reconnect-rejection.test.ts",
       // ipc-server-buzz-dedup.test.ts (Buzz Phase 1) drives a real
       // createIpcServer (Bun.listen) over a tmp UDS to exercise the hub-side
       // Buzz dedup ring — Bun.listen is a bun built-in, so run via bun.


### PR DESCRIPTION
## Root cause (fleet-audit B2)

One incident class drives both symptoms: a **planned gateway restart while the bridge survives** inside the separate claude process. Verified against live evidence (kdogg `gateway-supervisor.log` 2026-08-02 06:27):

```
06:27:43 shutdown.clean_marker_written signal=SIGTERM reason="cli: restart"
06:27:46 boot.clean_shutdown_detected … boot: no known chat for boot card (reason=graceful)
06:27:55 ipc — client disconnected (agent=null)   ← spare socket from a double-scheduled reconnect
06:27:55 bridge registered — agent=kdogg
06:27:55 bridge-reconnect: no known chat for boot card (reason=crash)   ← mislabel
```

Fleet-wide counts of the mislabel line: lawgpt 310, reggie 179, ziggy 175, kdogg 174, carrie 46, marko 26, finn 20. Container `RestartCount=0` everywhere — nothing actually crashed.

### Defect 1 — `bridge/ipc-client.ts` unhandled rejection (the `bridge-crash.log` artifact)

`scheduleReconnect()`'s retry timer called `doConnect()` bare. `doConnect` returns a promise that **rejects** whenever the `Bun.connect` attempt fails (`reject(err)` in its catch) — exactly what happens while the gateway is down for a restart. The initial-connect callsite attaches `.catch`; the retry timer did not, so every failed background retry escaped as a process-level `unhandledRejection` — the captured breadcrumb `unhandledRejection … Error: Failed to connect | at doConnect (dist/server.js:24188)` maps to source `telegram-plugin/bridge/ipc-client.ts` (`doConnect`'s promise, invoked from the retry timer). Pre-#3033 this **killed the bridge process** (Claude Code never respawns a dead MCP server → mute agent); post-#3033 it writes pseudo-crash breadcrumbs and survives only via the global handler.

Also: `scheduleReconnect` had no single-flight guard — the connect-failure catch and the socket `close` handler can both schedule a timer for one broken connection, yielding two parallel `doConnect()`s (the instant `agent=null` connect+disconnect visible right before each re-register).

### Defect 2 — `reason=crash` mislabel on bridge re-register

The bridge-reconnect path re-derived the restart reason from the on-disk markers (`determineRestartReason`), but the gateway's own boot path had already **read-and-cleared** the restart / clean-shutdown markers (the 2026-05-25 GC). By the time the surviving bridge re-registers seconds later, the disk is empty → the derivation falls through to the `sessionMarker` branch → `'crash'` for a perfectly graceful restart. When a chat *is* resolvable this posts a boot card claiming a crash.

## Fix

- `ipc-client.ts`: retry-path `doConnect().catch(() => {})` (failure is already logged + next retry scheduled inside `doConnect`), plus a pending-timer guard making reconnect single-flight.
- `boot-reason.ts`: new pure `determineBridgeReconnectReason` — still-present markers keep priority; marker-less re-registers within 5 min of gateway boot reuse the reason the boot path determined (`bootReasonAtStartup`, stashed in gateway.ts before the markers are cleared); marker-less late re-registers still classify conservatively as `'crash'` (the claude/bridge side genuinely died).

`gateway.ts` stays at 24855 lines (ratchet 24805+50): inline additions are offset by compressing comment blocks in the two hunks touched.

## Tests — RED without fix, GREEN with

- `tests/ipc-client-reconnect-rejection.test.ts` (bun): dead socket path, initial attempt + several background retries, asserts **zero** process-level unhandledRejections. Pre-fix it fails and reproduces the exact production stack (`new Promise` → `doConnect` → retry timer).
- `tests/boot-card-reason.test.ts` (extended): pins the kdogg trace — markers consumed + re-register 10s after boot ⇒ `'graceful'` (old code: `'crash'`); marker priority; >5-min late re-register ⇒ `'crash'`; null bootReason fallback; fresh-first-boot.

## Local verification

- `bun node_modules/typescript/bin/tsc --noEmit` clean
- Scoped bun suites (boot-card-reason, boot-card-reason-to-render, boot-card-dedupe, gateway-bridge, gateway-clean-shutdown-marker, ipc-server-client, ipc-server-race, ipc-client-reconnect-rejection, gateway-update-placeholder-dispatch): 140 pass / 0 fail
- `check-gateway-line-ratchet`, `check-plugin-references`, `check-bun-test-imports`, `check-test-runner-coverage`, `check-bun-module-mock-scope` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)