### PR TITLE
fix(reconcile): harden chown sweep against maxBuffer truncation + align chownShallow (#4365, #4366)

### DIFF
--- a/src/agents/agent-owned-tree.test.ts
+++ b/src/agents/agent-owned-tree.test.ts
@@ -40,6 +40,27 @@ function chownError(stderr: string): Error & { status: number; stderr: Buffer } 
   return err;
 }
 
+/**
+ * Fabricate the shape execFileSync throws when it SIGTERM-kills the child for
+ * exceeding maxBuffer (#4365): `status === null`, `.signal` set, and the
+ * captured stderr TRUNCATED (here, an all-ENOENT tail — the trap the classifier
+ * must not be fooled by).
+ */
+function chownKilledError(
+  stderr: string,
+  signal: string = "SIGTERM",
+): Error & { status: null; signal: string; stderr: Buffer } {
+  const err = new Error("stderr maxBuffer length exceeded") as Error & {
+    status: null;
+    signal: string;
+    stderr: Buffer;
+  };
+  err.status = null;
+  err.signal = signal;
+  err.stderr = Buffer.from(stderr);
+  return err;
+}
+
 describe("isChownVanishedRaceOnly", () => {
   it("returns true when EVERY stderr line is a vanished-file (ENOENT) error", () => {
     const stderr =
@@ -137,5 +158,66 @@ describe("ownershipRuntime.chownTree ENOENT-race tolerance", () => {
     expect(cmd).toBe("chown");
     expect(args).toEqual(["-h", "-R", "--", "10001:10001", "/a"]);
     expect((opts as { env: Record<string, string> }).env.LC_ALL).toBe("C");
+  });
+
+  it("passes a generous maxBuffer so churn stderr never truncates (#4365 part 1)", () => {
+    execFileSyncMock.mockReturnValue(Buffer.from(""));
+    ownershipRuntime.chownTree(10001, 10001, "/a");
+    const [, , opts] = execFileSyncMock.mock.calls[0];
+    // Explicit and far above the 1 MB default that let a churning tree
+    // SIGTERM-kill chown mid-walk.
+    expect((opts as { maxBuffer?: number }).maxBuffer).toBeGreaterThanOrEqual(
+      64 * 1024 * 1024,
+    );
+  });
+
+  it("RE-THROWS a maxBuffer-kill even when the TRUNCATED stderr is all-ENOENT (#4365 part 2, fail-closed)", () => {
+    // The incident's poison shape: >1 MB of churn ENOENT stderr overflows
+    // maxBuffer, execFileSync SIGTERM-kills chown (status===null, signal set),
+    // and the stderr we could classify is TRUNCATED — a real EPERM may have
+    // followed past the cutoff. Swallowing on the all-ENOENT tail would wrongly
+    // declare a benign race. Pre-fix (no signal/null-status guard) this stderr
+    // classifies as a pure race and the throw is SWALLOWED — the test goes red.
+    execFileSyncMock.mockImplementation(() => {
+      throw chownKilledError(
+        "chown: cannot access '/a/workspace/pgdata/16384': No such file or directory\n" +
+          "chown: cannot access '/a/workspace/pgdata/pg_wal/x': No such file or directory\n",
+      );
+    });
+    let caught: (Error & { signal?: string }) | undefined;
+    try {
+      ownershipRuntime.chownTree(10001, 10001, "/a");
+    } catch (e) {
+      caught = e as Error & { signal?: string };
+    }
+    expect(caught).toBeDefined();
+    // The ORIGINAL kill error is re-thrown intact (signal preserved) so the
+    // upstack #3168 "could not restore ownership" wrap fires loudly.
+    expect(caught?.signal).toBe("SIGTERM");
+  });
+});
+
+describe("ownershipRuntime.chownShallow hardening (#4366)", () => {
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+    execFileSyncMock.mockReturnValue(Buffer.from(""));
+  });
+
+  it("passes the `--` end-of-options guard before the owner spec", () => {
+    ownershipRuntime.chownShallow(10001, 10001, ["/a/-weird", "/a/start.sh"]);
+    const [cmd, args] = execFileSyncMock.mock.calls[0];
+    expect(cmd).toBe("chown");
+    expect(args).toEqual(["-h", "--", "10001:10001", "/a/-weird", "/a/start.sh"]);
+  });
+
+  it("pins LC_ALL=C on the invocation, mirroring chownTree", () => {
+    ownershipRuntime.chownShallow(10001, 10001, ["/a/start.sh"]);
+    const [, , opts] = execFileSyncMock.mock.calls[0];
+    expect((opts as { env: Record<string, string> }).env.LC_ALL).toBe("C");
+  });
+
+  it("is a no-op with no paths (never shells chown)", () => {
+    ownershipRuntime.chownShallow(10001, 10001, []);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/agent-owned-tree.ts
+++ b/src/agents/agent-owned-tree.ts
@@ -164,8 +164,25 @@ export const ownershipRuntime = {
         // LC_ALL=C pins chown's stderr wording so the race classifier below
         // is deterministic across hosts/locales (busybox + GNU both honour it).
         env: { ...process.env, LC_ALL: "C" },
+        // Generous maxBuffer (#4365). A churning tree can emit MANY per-file
+        // ENOENT lines; the default 1 MB cap makes execFileSync SIGTERM-KILL
+        // chown mid-walk (status===null, signal set) and TRUNCATE stderr. A
+        // truncated all-ENOENT tail is not evidence a real EPERM didn't follow,
+        // so overflow would defeat the fail-closed classifier below. 64 MB is
+        // far past any realistic churn so normal races never truncate.
+        maxBuffer: 64 * 1024 * 1024,
       });
     } catch (err) {
+      // Fail CLOSED on abnormal termination (#4365). execFileSync reports a
+      // clean non-zero EXIT as a numeric `.status` with no `.signal`; a
+      // maxBuffer overflow (or any kill) instead sets `.signal` and leaves
+      // `.status` null — and its captured stderr is TRUNCATED. An all-ENOENT
+      // tail of truncated stderr is NOT proof the run was a pure vanished-file
+      // race (a real EPERM could have been emitted past the cutoff), so the
+      // ENOENT-swallow is valid ONLY for a normal exited-non-zero chown with
+      // complete stderr. Re-throw anything else before classifying.
+      const e = err as { status?: number | null; signal?: string | null } | null | undefined;
+      if (e?.signal != null || typeof e?.status !== "number") throw err;
       // chown -R exits non-zero if ANY entry failed. During a live rollout the
       // agent's own workspace may be churning (a mid-test Postgres data dir,
       // a git checkout, node_modules) so inodes vanish between chown's readdir
@@ -186,8 +203,13 @@ export const ownershipRuntime = {
    */
   chownShallow: (uid: number, gid: number, paths: string[]): void => {
     if (paths.length === 0) return;
-    execFileSync("chown", ["-h", `${uid}:${gid}`, ...paths], {
+    // `--` end-of-options guard + LC_ALL=C mirror chownTree's hardening
+    // (#4366): a path beginning with `-` must not be parsed as a flag, and the
+    // pinned locale keeps chown's stderr wording stable across hosts. This
+    // helper has no race classifier and deliberately doesn't grow one here.
+    execFileSync("chown", ["-h", "--", `${uid}:${gid}`, ...paths], {
       stdio: ["ignore", "ignore", "pipe"],
+      env: { ...process.env, LC_ALL: "C" },
     });
   },
   /**


### PR DESCRIPTION
## Summary

Two follow-up hardenings to #4364's ENOENT-race tolerance in the reconcile ownership sweep (`src/agents/agent-owned-tree.ts`).

### Fix A — #4365: maxBuffer / truncated-stderr fail-closed in `chownTree`
1. The `chown -h -R` `execFileSync` ran with the **default 1 MB `maxBuffer`**. A churning agent tree (e.g. a mid-test Postgres `pgdata-*` dir) can emit >1 MB of per-file ENOENT stderr, which makes `execFileSync` **SIGTERM-kill chown mid-walk** (`status === null`, `.signal` set) and **truncate** stderr. Now passes an explicit **64 MB** `maxBuffer` so normal churn never truncates.
2. **Fail CLOSED on abnormal termination.** A truncated all-ENOENT stderr tail is *not* evidence the run was a pure vanished-file race — a real `EPERM` could have been emitted past the cutoff. The `catch` now re-throws unless the failure is a normal exited-non-zero chown (numeric `.status`, no `.signal`) **before** consulting `isChownVanishedRaceOnly()`. The classifier's own semantics are unchanged — the genuine-race path is intact.

### Fix B — #4366: `chownShallow` consistency
Mirror `chownTree`'s `--` end-of-options guard (a path beginning with `-` must not parse as a flag) and pin `LC_ALL=C`. No behavioural change beyond that; the shallow helper has no race classifier and deliberately doesn't grow one.

## Why

#4364 made the swallow path tolerant of a benign ENOENT race but left a hole: on a >1 MB churn burst, `chown` is killed and its stderr truncated, so an all-ENOENT tail would be misclassified as a pure race and swallowed — masking a real ownership failure that could re-wedge the fleet (#3168). `chownShallow` also silently diverged from `chownTree`'s option-injection hardening.

## Test plan

`src/agents/agent-owned-tree.test.ts` — outcome assertions, each verified **red without its fix**:
- a maxBuffer-kill (`status` null / `signal` set) with all-ENOENT truncated stderr is **RE-THROWN**, not swallowed (guards Fix A part 2).
- `chownTree` passes an explicit `>= 64 MB` `maxBuffer` (guards Fix A part 1).
- `chownShallow` invokes `chown` with `--` and `LC_ALL=C` (guards Fix B).

Local: `vitest run src/agents/agent-owned-tree.test.ts` → 15/15 green; `tsc --noEmit` → clean.

## Risk

Low. Change is confined to the two `ownershipRuntime` chown helpers. Fix A only *narrows* the swallow (fails louder); Fix B is an option-parsing/locale hardening with no behavioural change on well-formed paths.

Closes #4365
Closes #4366