### PR TITLE
fix(scheduler): never drop cron registrations on unreadable schedule.d overlays

### DIFF
--- a/src/agent-scheduler/hot-reload.test.ts
+++ b/src/agent-scheduler/hot-reload.test.ts
@@ -11,10 +11,14 @@
  * node-cron, no container.
  */
 
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { SchedulerEntry } from "../scheduler/dispatch.js";
 import {
   createScheduleReloader,
+  loadAgentEntriesStrict,
   scheduleSignature,
   resolveReloadPollMs,
   isHotReloadEnabled,
@@ -181,6 +185,147 @@ describe("createScheduleReloader", () => {
     expect(registrations).toEqual([e2]); // exactly one re-register
   });
 });
+
+// chmod 0o000 does not stop root from reading — the unreadable-file
+// simulation below only works for an unprivileged test uid.
+const runningAsRoot = typeof process.getuid === "function" && process.getuid() === 0;
+
+describe.skipIf(runningAsRoot)(
+  "hot-reload × unreadable schedule.d overlay — OUTCOME (clerk EACCES incident)",
+  () => {
+    // End-to-end through the REAL loader stack (loadConfig →
+    // applyAgentOverlays → collectScheduleEntries) with a real tmp
+    // filesystem — only node-cron is faked. Pre-fix, the reloader's
+    // loadEntries used the non-strict pipeline: an EACCES'd overlay file
+    // yielded a config silently missing that file's entries, the reload
+    // diff saw "entry removed", and the live cron was UNREGISTERED
+    // ("schedule reloaded: 11 → 10") — every fire lost until the file's
+    // ownership was fixed (weeks, on the live fleet). This test asserts
+    // the outcome: a cron file that turns unreadable NEVER costs the
+    // registration.
+
+    let tmpHome: string;
+    let prevHome: string | undefined;
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      tmpHome = mkdtempSync(join(tmpdir(), "hot-reload-eacces-"));
+      prevHome = process.env.HOME;
+      process.env.HOME = tmpHome;
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      warnSpy.mockRestore();
+      try {
+        rmSync(tmpHome, { recursive: true, force: true });
+      } catch { /* best-effort */ }
+    });
+
+    const AGENT = "relay";
+
+    function writeFixture(): { configPath: string; overlayPath: string } {
+      const configPath = join(tmpHome, "switchroom.yaml");
+      writeFileSync(
+        configPath,
+        [
+          "switchroom:",
+          "  version: 1",
+          "telegram:",
+          '  bot_token: "x"',
+          '  forum_chat_id: "1"',
+          "agents:",
+          `  ${AGENT}:`,
+          '    bot_token: "vault:relay-bot"',
+          "    forum_chat_id: 1",
+          `    topic_name: "${AGENT}"`,
+          "",
+        ].join("\n"),
+      );
+      const dir = join(tmpHome, ".switchroom", "agents", AGENT, "schedule.d");
+      mkdirSync(dir, { recursive: true });
+      const overlayPath = join(dir, "cron-abcdefabcdef.yaml");
+      writeFileSync(
+        overlayPath,
+        "schedule:\n  - cron: '*/30 * * * *'\n    prompt: overlay-cron\n",
+      );
+      return { configPath, overlayPath };
+    }
+
+    it("a schedule.d file that turns unreadable never unregisters its live cron", () => {
+      const { configPath, overlayPath } = writeFixture();
+
+      // Boot: overlay readable → entry loads and registers.
+      const boot = loadAgentEntriesStrict(configPath, AGENT);
+      expect(boot.map((e) => e.prompt)).toEqual(["overlay-cron"]);
+
+      const registrations: SchedulerEntry[][] = [];
+      const errors: string[] = [];
+      let stops = 0;
+      const register = (es: SchedulerEntry[]): RegisteredTask[] => {
+        registrations.push(es);
+        return es.map((e) => ({ entry: e, task: { stop: () => { stops += 1; } } }));
+      };
+      const initialTasks = register(boot);
+      registrations.length = 0; // boot registration isn't a reload
+
+      // Wired exactly as main() wires it post-fix.
+      const reloader = createScheduleReloader({
+        loadEntries: () => loadAgentEntriesStrict(configPath, AGENT),
+        register,
+        initialTasks,
+        initialEntries: boot,
+        log: () => {},
+        onError: (e) => errors.push(e.message),
+      });
+
+      // The incident: file becomes unreadable (foreign-owner 0600 ≙ chmod 000).
+      chmodSync(overlayPath, 0o000);
+      reloader.tick();
+      reloader.tick();
+
+      // OUTCOME: the live cron is still registered — no stop, no shrink.
+      expect(stops).toBe(0);
+      expect(registrations).toHaveLength(0);
+      expect(reloader.currentTasks().map((t) => t.entry.prompt)).toEqual(["overlay-cron"]);
+      // And the refusal is surfaced, naming the file and errno.
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0]).toContain("EACCES");
+      expect(errors[0]).toContain(overlayPath);
+
+      // Heal the perms: schedule matches the live one → still no churn.
+      chmodSync(overlayPath, 0o600);
+      reloader.tick();
+      expect(stops).toBe(0);
+      expect(reloader.currentTasks().map((t) => t.entry.prompt)).toEqual(["overlay-cron"]);
+    });
+
+    it("a genuinely REMOVED overlay file still unregisters (no false retention)", () => {
+      const { configPath, overlayPath } = writeFixture();
+      const boot = loadAgentEntriesStrict(configPath, AGENT);
+      const registrations: SchedulerEntry[][] = [];
+      const register = (es: SchedulerEntry[]): RegisteredTask[] =>
+        (registrations.push(es), es.map((e) => ({ entry: e, task: { stop: () => {} } })));
+      const initialTasks = register(boot);
+      registrations.length = 0;
+      const reloader = createScheduleReloader({
+        loadEntries: () => loadAgentEntriesStrict(configPath, AGENT),
+        register,
+        initialTasks,
+        initialEntries: boot,
+        log: () => {},
+        onError: () => {},
+      });
+      rmSync(overlayPath);
+      reloader.tick();
+      // The zombie-cron fix stays intact: deletion really unregisters.
+      expect(registrations).toEqual([[]]);
+      expect(reloader.currentTasks()).toEqual([]);
+    });
+  },
+);
 
 describe("resolveReloadPollMs", () => {
   it("defaults to 30s and floors sub-1s overrides", () => {

--- a/src/agent-scheduler/index.ts
+++ b/src/agent-scheduler/index.ts
@@ -28,6 +28,7 @@
 
 import { resolve, join } from "node:path";
 import { loadConfig } from "../config/loader.js";
+import { overlayReadFailures, type OverlayReadFailure } from "../config/overlay-loader.js";
 import {
   collectScheduleEntries,
   dispatchAsInbound,
@@ -540,6 +541,49 @@ export function createScheduleReloader(opts: {
   };
 }
 
+/** Human-readable remedy appended to unreadable-overlay diagnostics. */
+function formatReadFailures(failures: OverlayReadFailure[]): string {
+  return (
+    failures.map((f) => `${f.file} (${f.code})`).join(", ") +
+    " — fix ownership/mode so the agent uid can read the file " +
+    "(a root-euid writer leaves cron overlays root-owned 0600; " +
+    "`switchroom apply` / a reconcile ownership sweep heals this)"
+  );
+}
+
+/**
+ * Load THIS agent's schedule entries, refusing (throwing) when any of its
+ * `schedule.d/*.yaml` overlay files exists but cannot be READ.
+ *
+ * Why strict: the overlay loader isolates per-file failures, so an
+ * EACCES'd cron file yields a config that simply LACKS that file's
+ * entries. For the boot path that is the best we can do (warn loudly —
+ * see main()), but for the hot-reload path it is poison: the reloader
+ * would diff the shrunken schedule against the live one and silently
+ * UNREGISTER a healthy cron ("schedule reloaded: 11 → 10"), losing every
+ * fire until the ownership is fixed (observed on clerk: 2,298 EACCES
+ * ticks over weeks, entries dropped the whole time). Throwing routes
+ * into createScheduleReloader's onError path, which keeps the current
+ * schedule — the same fail-safe already used for a config parse error.
+ *
+ * Content failures (malformed YAML, schema rejection) do NOT throw:
+ * those files were read fine and their entries are legitimately excluded.
+ */
+export function loadAgentEntriesStrict(
+  configPath: string,
+  agentName: string,
+): SchedulerEntry[] {
+  const config = loadConfig(configPath);
+  const failures = overlayReadFailures(config, agentName);
+  if (failures.length > 0) {
+    throw new Error(
+      `schedule.d overlay unreadable — refusing a reload that may be ` +
+        `missing entries: ${formatReadFailures(failures)}`,
+    );
+  }
+  return collectScheduleEntries(config).filter((e) => e.agent === agentName);
+}
+
 /** Reload poll cadence (ms). Overlay edits are rare and detection within
  *  ~30s is plenty; the poll is a yaml re-parse + a few overlay file reads,
  *  negligible CPU. Floored at 1s. */
@@ -616,6 +660,20 @@ export async function main(): Promise<void> {
   const config = loadConfig(configPath);
   const allEntries = collectScheduleEntries(config);
   const entries = allEntries.filter((e) => e.agent === agentName);
+
+  // Unreadable overlay files at BOOT: we cannot register entries we
+  // cannot read, so boot proceeds with what loaded — but say so loudly
+  // and actionably instead of the loader's per-file console.warn only.
+  // (The hot-reload path below is strict: it refuses to swap the live
+  // schedule against a load that is missing unreadable files.)
+  const bootReadFailures = overlayReadFailures(config, agentName);
+  if (bootReadFailures.length > 0) {
+    process.stderr.write(
+      `agent-scheduler: ${agentName} WARNING: ${bootReadFailures.length} ` +
+        `schedule.d overlay file(s) unreadable at boot — their cron entries ` +
+        `are NOT registered: ${formatReadFailures(bootReadFailures)}\n`,
+    );
+  }
 
   const channel = resolveChannelTarget(config, agentName);
   if (channel === null) {
@@ -988,17 +1046,31 @@ export async function main(): Promise<void> {
   let reloader: ScheduleReloader | undefined;
   let reloadTimer: ReturnType<typeof setInterval> | undefined;
   if (isHotReloadEnabled(process.env)) {
+    // Dedupe the per-tick error line: a persistently-unreadable overlay
+    // would otherwise emit an identical line every poll (~30s) — the
+    // 2,298-line log flood that buried the original clerk incident.
+    // A reload that actually lands resets the memo so a recurrence of
+    // the same error is reported again.
+    let lastReloadError: string | undefined;
     reloader = createScheduleReloader({
-      loadEntries: () =>
-        collectScheduleEntries(loadConfig(configPath)).filter((e) => e.agent === agentName),
+      // Strict on purpose: an unreadable schedule.d file throws, landing
+      // in onError (keep current schedule) instead of silently
+      // unregistering the file's crons. See loadAgentEntriesStrict.
+      loadEntries: () => loadAgentEntriesStrict(configPath, agentName),
       register: registerForEntries,
       initialTasks: tasks,
       initialEntries: entries,
-      log: (m) => process.stdout.write(`agent-scheduler: ${agentName} ${m}\n`),
-      onError: (e) =>
+      log: (m) => {
+        lastReloadError = undefined;
+        process.stdout.write(`agent-scheduler: ${agentName} ${m}\n`);
+      },
+      onError: (e) => {
+        if (e.message === lastReloadError) return;
+        lastReloadError = e.message;
         process.stderr.write(
           `agent-scheduler: ${agentName} reload skipped (config error, keeping current schedule): ${e.message}\n`,
-        ),
+        );
+      },
     });
     reloadTimer = setInterval(() => reloader!.tick(), resolveReloadPollMs(process.env));
   }

--- a/src/agents/agent-owned-tree.ts
+++ b/src/agents/agent-owned-tree.ts
@@ -80,6 +80,15 @@ export const SCOPED_RECURSIVE_SUBDIRS = [
   ".claude",
   ".claude-cron",
   "telegram",
+  // Cron/skill overlay dirs (overlay-writer.ts). Their *.yaml files are
+  // 0600 and MUST be agent-owned or the in-container agent-scheduler
+  // EACCESes on every hot-reload and the loader drops the cron entries
+  // (clerk incident: root-owned cron overlays, 2,298 EACCES ticks, fires
+  // lost for weeks until an apply-time full sweep healed them). The full
+  // sweep always covered these; the scoped sweep must too, or flipping
+  // the #3333 flag on would reopen that window for root-written overlays.
+  "schedule.d",
+  "skills.d",
 ] as const;
 
 /**

--- a/src/config/overlay-loader.test.ts
+++ b/src/config/overlay-loader.test.ts
@@ -16,10 +16,15 @@
  *     (non-enumerable so JSON.stringify ignores them)
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { applyAgentOverlays, OVERLAY_SOURCE, OVERLAY_TITLE } from "./overlay-loader.js";
+import {
+  applyAgentOverlays,
+  overlayReadFailures,
+  OVERLAY_SOURCE,
+  OVERLAY_TITLE,
+} from "./overlay-loader.js";
 import type { SwitchroomConfig } from "./schema.js";
 
 /**
@@ -330,6 +335,132 @@ describe("applyAgentOverlays", () => {
     expect(warnings).toEqual([]);
   });
 });
+
+// chmod 0o000 does not stop root from reading — the unreadable-file
+// simulation only works for an unprivileged test uid.
+const runningAsRoot = typeof process.getuid === "function" && process.getuid() === 0;
+
+describe.skipIf(runningAsRoot)(
+  "applyAgentOverlays — unreadable overlay files (EACCES drop incident)",
+  () => {
+    // Regression guards for the clerk incident: a root-euid writer left
+    // schedule.d/cron-*.yaml root-owned 0600; the in-container loader
+    // EACCESed, logged "parse error: EACCES", and SILENTLY excluded the
+    // file's entries — indistinguishable (to callers) from the file having
+    // been deleted, so the scheduler's hot-reload unregistered live crons.
+    // The fix classifies READ failures separately from content failures
+    // and surfaces them via overlayReadFailures().
+
+    let tmpHome: string;
+    let prevHome: string | undefined;
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      tmpHome = mkdtempSync(join(tmpdir(), "overlay-loader-eacces-"));
+      prevHome = process.env.HOME;
+      process.env.HOME = tmpHome;
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      warnSpy.mockRestore();
+      try {
+        rmSync(tmpHome, { recursive: true, force: true });
+      } catch { /* best-effort */ }
+    });
+
+    function scheduleDir(agentName: string): string {
+      const dir = join(tmpHome, ".switchroom", "agents", agentName, "schedule.d");
+      mkdirSync(dir, { recursive: true });
+      return dir;
+    }
+
+    it("classifies an unreadable file as a READ failure (code=EACCES), not a content failure", () => {
+      const dir = scheduleDir("foo");
+      const locked = join(dir, "cron-aaaaaaaaaaaa.yaml");
+      writeFileSync(locked, "schedule:\n  - cron: '0 1 * * *'\n    prompt: hidden\n");
+      chmodSync(locked, 0o000);
+      const cfg = makeConfig({ foo: { schedule: [] } });
+      const { warnings } = applyAgentOverlays(cfg);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].code).toBe("EACCES");
+      expect(warnings[0].reason).toMatch(/read error/);
+      const failures = overlayReadFailures(cfg, "foo");
+      expect(failures).toHaveLength(1);
+      expect(failures[0]).toMatchObject({ file: locked, code: "EACCES" });
+    });
+
+    it("still loads readable sibling files (per-file isolation preserved)", () => {
+      const dir = scheduleDir("foo");
+      const locked = join(dir, "cron-bbbbbbbbbbbb.yaml");
+      writeFileSync(locked, "schedule:\n  - cron: '0 1 * * *'\n    prompt: hidden\n");
+      chmodSync(locked, 0o000);
+      writeFileSync(join(dir, "good.yaml"), "schedule:\n  - cron: '0 2 * * *'\n    prompt: ok\n");
+      const cfg = makeConfig({
+        foo: { schedule: [{ cron: "0 0 * * *", prompt: "main", secrets: [] }] },
+      });
+      applyAgentOverlays(cfg);
+      const sched = cfg.agents.foo.schedule as Array<{ prompt: string }>;
+      expect(sched.map((e) => e.prompt)).toEqual(["main", "ok"]);
+    });
+
+    it("does NOT report content failures (malformed YAML) as read failures", () => {
+      const dir = scheduleDir("foo");
+      writeFileSync(join(dir, "broken.yaml"), "schedule: [unterminated\n");
+      const cfg = makeConfig({ foo: { schedule: [] } });
+      const { warnings } = applyAgentOverlays(cfg);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].code).toBeUndefined();
+      expect(overlayReadFailures(cfg, "foo")).toEqual([]);
+    });
+
+    it("reports an unreadable skills.d file too", () => {
+      const dir = join(tmpHome, ".switchroom", "agents", "foo", "skills.d");
+      mkdirSync(dir, { recursive: true });
+      const locked = join(dir, "ws.yaml");
+      writeFileSync(locked, "skills:\n  - webapp-testing\n");
+      chmodSync(locked, 0o000);
+      const cfg = makeConfig({ foo: { skills: [] } });
+      const { warnings } = applyAgentOverlays(cfg);
+      expect(warnings.some((w) => w.code === "EACCES" && w.file === locked)).toBe(true);
+      expect(overlayReadFailures(cfg, "foo")).toContainEqual({ file: locked, code: "EACCES" });
+    });
+
+    it("reports an unreadable schedule.d DIRECTORY as a read failure (dir-level variant)", () => {
+      const dir = scheduleDir("foo");
+      writeFileSync(join(dir, "cron-dddddddddddd.yaml"), "schedule: []\n");
+      chmodSync(dir, 0o000);
+      try {
+        const cfg = makeConfig({ foo: { schedule: [] } });
+        const { warnings } = applyAgentOverlays(cfg);
+        expect(warnings.some((w) => w.file === dir && w.code === "EACCES")).toBe(true);
+        expect(overlayReadFailures(cfg, "foo")).toContainEqual({ file: dir, code: "EACCES" });
+      } finally {
+        chmodSync(dir, 0o755); // so afterEach rmSync can clean up
+      }
+    });
+
+    it("returns [] for an agent with no read failures / unknown agent", () => {
+      const cfg = makeConfig({ foo: { schedule: [] } });
+      applyAgentOverlays(cfg);
+      expect(overlayReadFailures(cfg, "foo")).toEqual([]);
+      expect(overlayReadFailures(cfg, "nope")).toEqual([]);
+    });
+
+    it("keeps the read-failure marker non-enumerable (invisible to JSON paths)", () => {
+      const dir = scheduleDir("foo");
+      const locked = join(dir, "cron-cccccccccccc.yaml");
+      writeFileSync(locked, "schedule: []\n");
+      chmodSync(locked, 0o000);
+      const cfg = makeConfig({ foo: { schedule: [] } });
+      applyAgentOverlays(cfg);
+      expect(overlayReadFailures(cfg, "foo")).toHaveLength(1);
+      expect(JSON.stringify(cfg.agents.foo)).not.toMatch(/read-failures|EACCES/i);
+    });
+  },
+);
 
 describe("applyAgentOverlays — skills.d pass (#1163 Phase 2)", () => {
   // Regression guard for the #1209 review finding: pre-fix the

--- a/src/config/overlay-loader.ts
+++ b/src/config/overlay-loader.ts
@@ -70,6 +70,70 @@ export const OVERLAY_SOURCE = Symbol.for("switchroom.config.overlay-source");
 export const OVERLAY_TITLE = Symbol.for("switchroom.config.overlay-title");
 
 /**
+ * Marker stamped on an agent's config node listing overlay files that
+ * EXIST but could not be READ (EACCES/EPERM/EIO — anything except the
+ * benign ENOENT delete race). A read failure is fundamentally different
+ * from a content failure (malformed YAML, schema rejection): the file's
+ * entries are unknown, not invalid, so consumers must not treat the load
+ * as authoritative "these entries no longer exist".
+ *
+ * The concrete incident (clerk, 2,298 log hits): a root-euid writer left
+ * `schedule.d/cron-*.yaml` owned root:root 0600; the in-container
+ * agent-scheduler (agent uid) EACCESed on every hot-reload tick, the
+ * loader skipped the file with only a console.warn, and the reloader
+ * silently unregistered the cron ("schedule reloaded: 11 → 10") for
+ * weeks — cron fires lost until an apply-time chown sweep healed the
+ * ownership. The scheduler reads this marker (via
+ * {@link overlayReadFailures}) to refuse such a reload instead.
+ *
+ * Symbol-keyed and non-enumerable for the same reason as
+ * {@link OVERLAY_SOURCE}: invisible to JSON-serialisation paths.
+ */
+export const OVERLAY_READ_FAILURES = Symbol.for(
+  "switchroom.config.overlay-read-failures",
+);
+
+/** One unreadable overlay file: absolute path + fs errno code. */
+export interface OverlayReadFailure {
+  file: string;
+  code: string;
+}
+
+/** Record a read failure on the agent's config node (non-enumerable). */
+function recordReadFailure(agentCfg: object, failure: OverlayReadFailure): void {
+  const node = agentCfg as Record<symbol, unknown>;
+  const existing = node[OVERLAY_READ_FAILURES] as OverlayReadFailure[] | undefined;
+  if (Array.isArray(existing)) {
+    existing.push(failure);
+    return;
+  }
+  Object.defineProperty(agentCfg, OVERLAY_READ_FAILURES, {
+    value: [failure],
+    enumerable: false,
+    configurable: true,
+    writable: false,
+  });
+}
+
+/**
+ * Overlay files for `agent` that existed but could not be read during the
+ * last {@link applyAgentOverlays} pass over this config object. Empty when
+ * every overlay file was readable (content errors do NOT count — those
+ * files were read fine and are legitimately excluded).
+ */
+export function overlayReadFailures(
+  config: SwitchroomConfig,
+  agent: string,
+): OverlayReadFailure[] {
+  const agentCfg = config.agents?.[agent];
+  if (!agentCfg) return [];
+  const list = (agentCfg as unknown as Record<symbol, unknown>)[
+    OVERLAY_READ_FAILURES
+  ] as OverlayReadFailure[] | undefined;
+  return Array.isArray(list) ? list : [];
+}
+
+/**
  * Derive a human title for the cron(s) declared in an overlay file.
  *
  *   1. A top-of-file `# name: <title>` comment wins (authoritative even
@@ -99,11 +163,54 @@ export interface OverlayWarning {
   agent: string;
   file: string;
   reason: string;
+  /** fs errno code (e.g. "EACCES") when the file existed but could not be
+   *  READ. Absent for content failures (malformed YAML, schema rejection). */
+  code?: string;
 }
 
 export interface ApplyOverlaysResult {
   config: SwitchroomConfig;
   warnings: OverlayWarning[];
+}
+
+/**
+ * Read one overlay file, classifying READ failures separately from the
+ * content failures the callers' parse/schema catch handles.
+ *
+ *   - success → the raw text.
+ *   - ENOENT → undefined, silently: the file was deleted between the
+ *     directory listing and the read — a removed overlay legitimately
+ *     unregisters its entries.
+ *   - any other errno (EACCES/EPERM/EIO/…) → undefined, after recording
+ *     an {@link OverlayReadFailure} on the agent's config node and a
+ *     warning. The file EXISTS and its entries are unknown — consumers
+ *     (the agent-scheduler's hot-reload) must not treat this load as
+ *     proof the entries are gone.
+ */
+function readOverlayFile(
+  agentName: string,
+  file: string,
+  agentCfg: object,
+  warnings: OverlayWarning[],
+): string | undefined {
+  try {
+    return readFileSync(file, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return undefined;
+    const w: OverlayWarning = {
+      agent: agentName,
+      file,
+      reason: `read error: ${(err as Error).message}`,
+      code: code ?? "EUNKNOWN",
+    };
+    recordReadFailure(agentCfg, { file, code: w.code! });
+    warnings.push(w);
+    console.warn(
+      `[switchroom] overlay-loader: agent='${agentName}' file='${file}': ${w.reason}`,
+    );
+    return undefined;
+  }
 }
 
 /**
@@ -117,12 +224,21 @@ function overlayDirFor(agentName: string, subdir: string): string {
   return resolve(base);
 }
 
-function listYamlFiles(dir: string): string[] {
+function listYamlFiles(
+  dir: string,
+  /** Invoked when the directory EXISTS but cannot be listed (EACCES on
+   *  the dir itself — the dir-level variant of the unreadable-file
+   *  incident). ENOENT (deleted between existsSync and readdir) stays
+   *  silent. */
+  onUnreadableDir?: (code: string) => void,
+): string[] {
   if (!existsSync(dir)) return [];
   let entries: string[];
   try {
     entries = readdirSync(dir);
-  } catch {
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") onUnreadableDir?.(code ?? "EUNKNOWN");
     return [];
   }
   const out: string[] = [];
@@ -179,7 +295,19 @@ export function applyAgentOverlays(config: SwitchroomConfig): ApplyOverlaysResul
   for (const [agentName, agentCfg] of Object.entries(agents)) {
     try {
       const scheduleDir = overlayDirFor(agentName, "schedule.d");
-      const files = listYamlFiles(scheduleDir);
+      const files = listYamlFiles(scheduleDir, (code) => {
+        const w: OverlayWarning = {
+          agent: agentName,
+          file: scheduleDir,
+          reason: `read error: cannot list overlay directory (${code})`,
+          code,
+        };
+        recordReadFailure(agentCfg, { file: scheduleDir, code });
+        warnings.push(w);
+        console.warn(
+          `[switchroom] overlay-loader: agent='${agentName}' file='${scheduleDir}': ${w.reason}`,
+        );
+      });
       // #1209 review fix: don't `continue` past the skills.d pass when
       // an agent has no schedule.d files. Pre-fix the early-return
       // made the skills.d branch dead code for newly-scaffolded agents
@@ -198,8 +326,9 @@ export function applyAgentOverlays(config: SwitchroomConfig): ApplyOverlaysResul
       const merged: ScheduleEntry[] = [...(agentCfg.schedule ?? [])];
 
       for (const file of files) {
+        const raw = readOverlayFile(agentName, file, agentCfg, warnings);
+        if (raw === undefined) continue;
         try {
-          const raw = readFileSync(file, "utf-8");
           const parsed = parseYaml(raw);
           const doc = OverlayDocSchema.parse(parsed);
 
@@ -262,7 +391,19 @@ export function applyAgentOverlays(config: SwitchroomConfig): ApplyOverlaysResul
     // ── Skills overlay pass (#1163 Phase 2) ─────────────────────────
     try {
       const skillsDir = overlayDirFor(agentName, "skills.d");
-      const skillFiles = listYamlFiles(skillsDir);
+      const skillFiles = listYamlFiles(skillsDir, (code) => {
+        const w: OverlayWarning = {
+          agent: agentName,
+          file: skillsDir,
+          reason: `read error: cannot list overlay directory (${code})`,
+          code,
+        };
+        recordReadFailure(agentCfg, { file: skillsDir, code });
+        warnings.push(w);
+        console.warn(
+          `[switchroom] overlay-loader: agent='${agentName}' file='${skillsDir}': ${w.reason}`,
+        );
+      });
       // No early continue — this is the LAST pass in the for-agent loop,
       // but using `continue` here would still skip any future passes
       // added below. Gate the merge work on file presence instead, same
@@ -275,8 +416,9 @@ export function applyAgentOverlays(config: SwitchroomConfig): ApplyOverlaysResul
       const seen = new Set(merged);
 
       for (const file of skillFiles) {
+        const raw = readOverlayFile(agentName, file, agentCfg, warnings);
+        if (raw === undefined) continue;
         try {
-          const raw = readFileSync(file, "utf-8");
           const parsed = parseYaml(raw);
           const doc = OverlayDocSchema.parse(parsed);
           for (const skillName of doc.skills ?? []) {

--- a/src/config/overlay-writer.test.ts
+++ b/src/config/overlay-writer.test.ts
@@ -1,12 +1,14 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { mkdtempSync, existsSync, readFileSync, readdirSync } from "node:fs";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { mkdtempSync, existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   writeOverlayEntry,
+  writeSkillsOverlayEntry,
   deleteOverlayEntry,
   listOverlayEntries,
   overlayPathsFor,
+  overlayWriterRuntime,
 } from "./overlay-writer.js";
 
 let root: string;
@@ -68,5 +70,74 @@ describe("overlay-writer", () => {
     const entries = listOverlayEntries("a", { root });
     expect(entries).toHaveLength(1);
     expect(entries[0].raw).toContain("prompt: v2");
+  });
+});
+
+describe("overlay-writer — foreign-euid ownership alignment (clerk EACCES incident)", () => {
+  // A root/foreign-euid writer creating the staged inode leaves it owned
+  // by the WRITER, mode 0600 — the agent (dir owner) then EACCESes on its
+  // own cron overlay and the loader drops the entries. The writer must
+  // align the staged file to the target dir's owner before the rename.
+  // Unit tests run unprivileged, so the chown syscall is behind the
+  // injectable overlayWriterRuntime seam (same pattern as
+  // agent-owned-tree's ownershipRuntime).
+
+  const real = {
+    geteuid: overlayWriterRuntime.geteuid,
+    chown: overlayWriterRuntime.chown,
+  };
+
+  afterEach(() => {
+    overlayWriterRuntime.geteuid = real.geteuid;
+    overlayWriterRuntime.chown = real.chown;
+  });
+
+  it("chowns the staged file to the dir owner when the writer euid differs (root-writer case)", () => {
+    // Pre-create the dirs so their REAL owner is the test uid; simulate a
+    // root writer by stubbing euid=0 (≠ dir owner for an unprivileged run).
+    const paths = overlayPathsFor("alice", { root });
+    const dirStat = { uid: statSync(root).uid, gid: statSync(root).gid };
+    const chowns: Array<{ path: string; uid: number; gid: number }> = [];
+    overlayWriterRuntime.geteuid = () => (dirStat.uid === 0 ? 12345 : 0);
+    overlayWriterRuntime.chown = (path, uid, gid) => chowns.push({ path, uid, gid });
+
+    const finalPath = writeOverlayEntry("alice", "cron-444444444444", "schedule: []\n", { root });
+
+    expect(chowns).toHaveLength(1);
+    // Aligned to the target schedule.d dir's real owner, on the STAGED
+    // path (before rename — the publish is atomic with correct ownership).
+    expect(chowns[0]).toMatchObject({ uid: dirStat.uid, gid: dirStat.gid });
+    expect(chowns[0].path).toContain(paths.scheduleStagingDir);
+    expect(existsSync(finalPath)).toBe(true);
+  });
+
+  it("does not chown when the writer euid already matches the dir owner", () => {
+    const chowns: string[] = [];
+    overlayWriterRuntime.chown = (path) => { chowns.push(path); };
+    // real geteuid == real dir owner (both the test uid)
+    writeOverlayEntry("alice", "cron-555555555555", "schedule: []\n", { root });
+    expect(chowns).toEqual([]);
+  });
+
+  it("a chown failure (EPERM: unprivileged foreign writer) never blocks the write", () => {
+    overlayWriterRuntime.geteuid = () => (statSync(root).uid === 0 ? 12345 : 0);
+    overlayWriterRuntime.chown = () => {
+      const err = new Error("EPERM: operation not permitted") as NodeJS.ErrnoException;
+      err.code = "EPERM";
+      throw err;
+    };
+    const finalPath = writeOverlayEntry("alice", "cron-666666666666", "schedule: []\n", { root });
+    expect(existsSync(finalPath)).toBe(true);
+  });
+
+  it("aligns skills.d writes the same way", () => {
+    const dirUid = statSync(root).uid;
+    const chowns: Array<{ path: string }> = [];
+    overlayWriterRuntime.geteuid = () => (dirUid === 0 ? 12345 : 0);
+    overlayWriterRuntime.chown = (path) => chowns.push({ path });
+    const finalPath = writeSkillsOverlayEntry("alice", "ws", "skills:\n  - webapp-testing\n", { root });
+    expect(chowns).toHaveLength(1);
+    expect(chowns[0].path).toContain(join("skills.d", ".staging"));
+    expect(existsSync(finalPath)).toBe(true);
   });
 });

--- a/src/config/overlay-writer.ts
+++ b/src/config/overlay-writer.ts
@@ -29,6 +29,7 @@
  */
 
 import {
+  chownSync,
   closeSync,
   existsSync,
   fsyncSync,
@@ -157,6 +158,47 @@ function withAgentLock<T>(paths: OverlayPaths, fn: () => T): T {
 }
 
 /**
+ * Process/syscall seams, injectable for tests (unit tests run as an
+ * unprivileged UID and cannot chown to a foreign uid; they stub these to
+ * record calls and simulate a root euid). Same pattern as
+ * `ownershipRuntime` in `src/agents/agent-owned-tree.ts`.
+ */
+export const overlayWriterRuntime = {
+  geteuid: (): number | undefined => process.geteuid?.(),
+  chown: (path: string, uid: number, gid: number): void => chownSync(path, uid, gid),
+};
+
+/**
+ * Align a staged overlay file's ownership to its TARGET directory's owner
+ * before the rename publishes it.
+ *
+ * Why (CLAUDE.md "Root-context editing" rule; #3168 class): the overlay
+ * dirs are chowned to the agent's container uid, but the WRITER may run
+ * with a different euid — hostd verbs and sudo'd CLIs run as root, the
+ * operator's host CLI as uid 1000. A tmp+rename atomic write creates a NEW
+ * inode owned by the writer's euid with mode 0600, so the agent (dir
+ * owner) gets EACCES on its own cron overlay, the loader skips the file,
+ * and its crons silently stop firing until an ownership sweep runs — on
+ * the live fleet that window was write→next-`apply`, i.e. weeks (clerk:
+ * 2,298 EACCES loader hits, entries dropped throughout).
+ *
+ * Root writers are fixed here deterministically. An unprivileged foreign
+ * writer (operator uid, no CAP_CHOWN) gets EPERM — swallowed; the
+ * reconcile/apply ownership sweeps remain the backstop for that case.
+ */
+function alignStagedOwnerToDir(stagingPath: string, targetDir: string): void {
+  try {
+    const euid = overlayWriterRuntime.geteuid();
+    if (euid === undefined) return; // e.g. Windows — no uid semantics
+    const dirStat = statSync(targetDir);
+    if (dirStat.uid === euid) return; // same-owner write — already correct
+    overlayWriterRuntime.chown(stagingPath, dirStat.uid, dirStat.gid);
+  } catch {
+    /* best-effort — the reconcile/apply ownership sweeps are the backstop */
+  }
+}
+
+/**
  * Atomically write a YAML document to <slug>.yaml. Returns the absolute
  * path of the final on-disk file.
  */
@@ -178,6 +220,7 @@ export function writeOverlayEntry(
     } finally {
       closeSync(fd);
     }
+    alignStagedOwnerToDir(stagingPath, paths.scheduleDir);
     renameSync(stagingPath, finalPath);
     return finalPath;
   });
@@ -206,6 +249,7 @@ export function writeSkillsOverlayEntry(
     } finally {
       closeSync(fd);
     }
+    alignStagedOwnerToDir(stagingPath, paths.skillsDir);
     renameSync(stagingPath, finalPath);
     return finalPath;
   });

--- a/tests/reconcile.scoped-sweep.test.ts
+++ b/tests/reconcile.scoped-sweep.test.ts
@@ -151,6 +151,33 @@ describe("chownScopedTree — call shape (#3333 stage 2)", () => {
     }
   });
 
+  it("recurses into schedule.d/ and skills.d/ so root-written cron overlays are re-owned", () => {
+    // Clerk incident: root-owned 0600 schedule.d/cron-*.yaml → the agent's
+    // scheduler EACCESed on every hot-reload and the crons silently
+    // stopped firing. The FULL sweep always healed these; the scoped sweep
+    // must cover them too or flipping the #3333 flag on reopens the window.
+    const dir = makeTree();
+    try {
+      mkdirSync(join(dir, "schedule.d"), { recursive: true });
+      writeFileSync(join(dir, "schedule.d", "cron-abc123.yaml"), "schedule: []\n");
+      mkdirSync(join(dir, "skills.d"), { recursive: true });
+
+      const recursed: string[] = [];
+      ownershipRuntime.chownShallow = () => {};
+      ownershipRuntime.chownTree = (_u, _g, root) => recursed.push(root);
+
+      const uid = allocateAgentUid(AGENT);
+      chownScopedTree(uid, uid, dir);
+
+      expect(recursed).toContain(join(dir, "schedule.d"));
+      expect(recursed).toContain(join(dir, "skills.d"));
+      // Cache exclusions unchanged.
+      expect(recursed).not.toContain(join(dir, "home"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("skips a scoped subdir that does not exist", () => {
     const dir = mkdtempSync(join(tmpdir(), "switchroom-scoped-"));
     try {


### PR DESCRIPTION
## Summary

Fixes the clerk EACCES incident (fleet-audit Batch B3): **2,298** `overlay-loader … parse error: EACCES` lines in `logs/clerk/agent-scheduler.log`, with live crons silently unregistered (`schedule reloaded: 11 → 10`) for the whole window.

**Root cause (corrects the task premise):** the write path was already atomic (`overlay-writer.ts` stages + fsyncs + renames), and the EACCES window was not a transient write/reload race. A foreign-euid writer created the `schedule.d/*.yaml` inode owned by the writer with mode 0600 (tmp+rename replaces the inode and re-owns it to the writer's euid — the documented #3168 class). The in-container agent-scheduler (agent uid) then EACCESed on **every** hot-reload tick, `applyAgentOverlays` skipped the file with only a `console.warn`, and `createScheduleReloader` diffed the shrunken schedule and unregistered the healthy cron. Heal only came from an apply-time `alignAgentUid` chown sweep — ctime evidence on the live host shows files written Jul 1 / Jul 24 and healed **Aug 4 14:38** (identical batch ctime), i.e. weeks of lost fires.

## Fix — three deterministic legs, one concern

1. **Loader classification** (`src/config/overlay-loader.ts`): read failures (EACCES/EPERM/… on the file, or on listing the dir itself) are recorded on the agent's config node (non-enumerable symbol, `overlayReadFailures()`) and carry `code` on the warning. Content failures (malformed YAML, schema rejection) are unchanged — those files were read fine and are legitimately excluded. ENOENT stays a silent skip (deleted overlay ⇒ legitimate unregister).
2. **Scheduler fail-safe** (`src/agent-scheduler/index.ts`): hot-reload loads via `loadAgentEntriesStrict()`, which throws on read failures → the reloader's existing keep-current-schedule `onError` path. An unreadable overlay can no longer unregister a live cron. Boot warns loudly + actionably (it cannot register what it cannot read). Per-tick error lines are deduped (no more 2,298-line floods).
3. **Ownership at the source**: `writeOverlayEntry`/`writeSkillsOverlayEntry` chown the staged inode to the target dir's owner before rename when euids differ (root writers fixed deterministically; EPERM swallowed — sweeps are the backstop). The #3333 **scoped** ownership sweep now recurses `schedule.d/` + `skills.d/` — the full sweep always covered them; flipping the scoped flag on would have reopened this window.

## Test plan

- **Outcome test, verified RED on `origin/main`:** `src/agent-scheduler/hot-reload.test.ts` drives the REAL loader stack (loadConfig → overlays → collectScheduleEntries) on a tmp fs; chmod 000 on the overlay between ticks must NOT unregister the live cron (on main, the identical pre-fix wiring unregisters it — reproduced before writing the fix). Companion test pins that a genuinely deleted overlay still unregisters (zombie-cron fix intact).
- `src/config/overlay-loader.test.ts`: EACCES file → `code: "EACCES"` + `overlayReadFailures()`; unreadable **dir** variant; malformed YAML NOT a read failure; sibling isolation; marker non-enumerable. (Root-skipped: chmod-000 can't block root.)
- `src/config/overlay-writer.test.ts`: staged-file chown to dir owner via the injectable `overlayWriterRuntime` seam (foreign euid → chown with dir uid/gid; same euid → no chown; EPERM → write still lands).
- `tests/reconcile.scoped-sweep.test.ts`: scoped sweep recurses `schedule.d/`+`skills.d/`, cache exclusions unchanged.
- Local (scoped, as uid 1000): 88 passed / 2 root-gated skips; `npm run lint` clean; `tsc --noEmit` clean. `idle-smoke.test.ts` fails identically on pristine main in this sandbox (spawned-subprocess env artifact — CI is authority).

## Risk

- Behavior change: a persistently-unreadable overlay now FREEZES the last-good schedule (including stale entries from other files) instead of partially reloading — chosen deliberately: identical to the existing config-parse-error fail-safe, and losing a fire is worse than delaying an edit. The refusal is logged once with the exact chown remedy.
- Writer chown is best-effort inside the existing per-agent flock; no new failure modes on the write path.

Job-spec: fleet-audit 02-fable-redteam-review.md, correction #4 / Batch B item B3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
