### PR TITLE
fix(auth): corroborate 429 throttle on first hit, rate-bounded

### DIFF
--- a/src/auth/broker/client.ts
+++ b/src/auth/broker/client.ts
@@ -690,16 +690,22 @@ export class AuthBrokerClient {
    * 429 throttle tier — record a transient per-account rate limit on the
    * caller's bound account (`throttled_until` in the quota ledger). Never
    * rolls the fleet and never blocks eligibility; the broker's escalation
-   * guard may corroborate repeated hits into a real mark-exhausted (see
+   * guard may corroborate a hit into a real mark-exhausted (see
    * `MarkThrottledData.escalated`). Non-admin, same posture as
    * `markExhausted`.
+   *
+   * `probeOnly` (#failover-429-corroborate, generic-transient origin): run ONLY
+   * the rate-bounded escalation probe — a corroborated wall still escalates
+   * (mark-exhausted + roll), but a healthy probe records NOTHING (no
+   * `throttled_until`, no hit, no soft-defer), keeping the account inert.
    */
-  async markThrottled(until: number): Promise<MarkThrottledData> {
+  async markThrottled(until: number, probeOnly = false): Promise<MarkThrottledData> {
     const data = await this.send({
       v: PROTOCOL_VERSION,
       id: randomUUID(),
       op: "mark-throttled",
       until,
+      ...(probeOnly ? { probeOnly: true } : {}),
     });
     return data as MarkThrottledData;
   }

--- a/src/auth/broker/protocol.ts
+++ b/src/auth/broker/protocol.ts
@@ -148,8 +148,13 @@ export const MarkThrottledRequestSchema = z.object({
   op: z.literal("mark-throttled"),
   id: z.string().min(1),
   /** Unix ms when the throttle clears. Server-side clamped to a short
-   *  ceiling (throttles are minutes, never days). */
+   *  ceiling (throttles are minutes, never days). Ignored when probeOnly. */
   until: z.number().int().positive(),
+  /** #failover-429-corroborate — probe-only mode (generic-transient 429
+   *  origin). Run ONLY the rate-bounded escalation probe: on a corroborated
+   *  wall, mark-exhausted + roll; on a healthy probe, record NOTHING (no
+   *  throttled_until, no hit, no soft-defer) so the account stays inert. */
+  probeOnly: z.boolean().optional(),
 });
 
 export const RefreshAccountRequestSchema = z.object({

--- a/src/auth/broker/server-mark-throttled.test.ts
+++ b/src/auth/broker/server-mark-throttled.test.ts
@@ -402,8 +402,9 @@ describe("mark-throttled — first-hit corroboration + probe rate-bound", () => 
     clock.set(late);
     const r3 = await markThrottled(b, late + 60_000, "3");
     expect(r3.data.escalated).toBe(false);
-    // The window is pruned to just the fresh hit — THROTTLE_ESCALATION_HITS /
-    // _WINDOW are bookkeeping now, they no longer gate escalation.
+    // The window is pruned to just the fresh hit — the hit list is
+    // bookkeeping now (THROTTLE_ESCALATION_WINDOW_MS), it no longer gates
+    // escalation.
     expect(b.quota["alice"].throttle_hits).toEqual([late]);
   });
 });

--- a/src/auth/broker/server-mark-throttled.test.ts
+++ b/src/auth/broker/server-mark-throttled.test.ts
@@ -10,13 +10,17 @@
  *  - NO roll and NO ineligibility: agent mirrors untouched, `auth.active`
  *    untouched, the account still reads eligible / not exhausted;
  *  - the clamp: a bogus long throttle is bounded to the short ceiling;
- *  - the escalation guard: 3 hits inside the window trigger ONE live probe;
- *    a probe that corroborates a wall converts to the standard
+ *  - first-hit corroboration (#failover-429-corroborate): a SINGLE mark runs
+ *    ONE live probe; a probe that corroborates a wall converts to the standard
  *    mark-exhausted + fleet roll (mirror fanout, durable promote, audit
- *    reason "throttle-escalation") — announced by the RAISING gateway from
- *    the response, NOT via `last_fleet_roll` (reactive-path doctrine, which
- *    also covers pinned-account rolls); a healthy probe leaves the account
- *    merely throttled and re-arms the counter;
+ *    reason "throttle-escalation", hit window cleared) — announced by the
+ *    RAISING gateway from the response, NOT via `last_fleet_roll`
+ *    (reactive-path doctrine, which also covers pinned-account rolls); a
+ *    healthy probe leaves the account merely throttled with the hit window
+ *    CARRIED FORWARD (not cleared);
+ *  - the probe rate-bound: after a probe, a second hit >5s later but WITHIN
+ *    THROTTLE_ESCALATION_PROBE_MIN_INTERVAL_MS runs NO second probe; a hit past
+ *    that interval probes again (≤1 probe/min/account);
  *  - the re-mark dedup: a mark within 5s of the previous hit refreshes the
  *    expiry but adds NO hit and can trigger NO probe (probe-flood bound);
  *  - a later mark-exhausted PRESERVES the throttle fields in the entry.
@@ -27,7 +31,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:f
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { AuthBroker } from "./server.js";
+import { AuthBroker, THROTTLE_ESCALATION_PROBE_MIN_INTERVAL_MS } from "./server.js";
 import type { Identity } from "./peercred.js";
 import type { SwitchroomConfig } from "../../config/schema.js";
 import { writeAccountCredentials } from "../account-store.js";
@@ -80,14 +84,36 @@ function quotaFor(table: QuotaTable, accessToken: string): QuotaResult {
   const label = accessToken.replace(/^at-/, "");
   const q = table[label];
   if (!q) return { ok: false, reason: "no fixture for " + label };
+  const fiveWalled = q.fiveHour >= 99.5;
+  const sevenWalled = q.sevenDay >= 99.5;
   return {
     ok: true,
     data: {
       fiveHourUtilizationPct: q.fiveHour,
       sevenDayUtilizationPct: q.sevenDay,
+      // A walled 5h window resets in 3h; a walled 7d window in 3d — so a test
+      // can assert the mark took the maxed window's real reset.
+      fiveHourResetAt: fiveWalled ? new Date(NOW + 3 * 3_600_000) : null,
+      sevenDayResetAt: sevenWalled ? new Date(NOW + 3 * 86_400_000) : null,
+      representativeClaim: sevenWalled ? "seven_day" : fiveWalled ? "five_hour" : null,
+      overageStatus: null,
+      overageDisabledReason: null,
+    },
+  };
+}
+
+/** A minimal always-healthy probe result — for tests that only want to COUNT
+ *  probe calls (spy on `fetchQuotaImpl`) without threading the quota table.
+ *  Healthy so the first-hit corroboration stays put (no escalation). */
+function healthyProbe(): QuotaResult {
+  return {
+    ok: true,
+    data: {
+      fiveHourUtilizationPct: 10,
+      sevenDayUtilizationPct: 20,
       fiveHourResetAt: null,
-      sevenDayResetAt: q.sevenDay >= 99.5 ? new Date(NOW + 3 * 86_400_000) : null,
-      representativeClaim: q.sevenDay >= 99.5 ? "seven_day" : null,
+      sevenDayResetAt: null,
+      representativeClaim: null,
       overageStatus: null,
       overageDisabledReason: null,
     },
@@ -226,62 +252,67 @@ describe("mark-throttled — ledger round-trip, no roll, no ineligibility", () =
 });
 
 describe("mark-throttled — re-mark dedup (probe-flood bound)", () => {
-  it("a re-mark within 5s refreshes the expiry but adds NO escalation hit", async () => {
-    const { b } = makeBroker({
-      accounts: ["alice", "bob"],
-      quotas: { alice: { fiveHour: 10, sevenDay: 100 }, bob: { fiveHour: 5, sevenDay: 10 } },
-    });
-    const r1 = await markThrottled(b, NOW + 60_000, "1");
-    expect(r1.data.throttled_until).toBe(NOW + 60_000);
-    // Simultaneous second agent marks a slightly later reset.
-    const r2 = await markThrottled(b, NOW + 90_000, "2");
-    expect(r2.data.escalated).toBe(false);
-    // Expiry keeps the LATER value; hit count stays 1.
-    expect(r2.data.throttled_until).toBe(NOW + 90_000);
-    expect(b.quota["alice"].throttle_hits).toEqual([NOW]);
-  });
-
-  it("a simultaneous 3-agent burst counts once and cannot trigger the probe", async () => {
+  it("a re-mark within 5s refreshes the expiry, adds NO hit, and runs NO extra probe", async () => {
     let probes = 0;
     const { b } = makeBroker({
       accounts: ["alice", "bob"],
-      quotas: { alice: { fiveHour: 10, sevenDay: 100 }, bob: { fiveHour: 5, sevenDay: 10 } },
+      // Healthy account: the first-hit probe stays put, so this isolates the
+      // 5s dedup from escalation.
+      quotas: { alice: { fiveHour: 10, sevenDay: 20 }, bob: { fiveHour: 5, sevenDay: 10 } },
     });
     (b as any).fetchQuotaImpl = async () => {
       probes += 1;
-      return { ok: false as const, reason: "should not be probed" };
+      return healthyProbe();
+    };
+    const r1 = await markThrottled(b, NOW + 60_000, "1");
+    expect(r1.data.throttled_until).toBe(NOW + 60_000);
+    // First hit corroborates (healthy → stay put): exactly one probe.
+    expect(probes).toBe(1);
+    // Simultaneous second agent marks a slightly later reset, within 5s.
+    const r2 = await markThrottled(b, NOW + 90_000, "2");
+    expect(r2.data.escalated).toBe(false);
+    // Expiry keeps the LATER value; hit count stays 1; NO second probe.
+    expect(r2.data.throttled_until).toBe(NOW + 90_000);
+    expect(b.quota["alice"].throttle_hits).toEqual([NOW]);
+    expect(probes).toBe(1);
+  });
+
+  it("a simultaneous 3-agent burst shares ONE hit and ONE probe (the first)", async () => {
+    let probes = 0;
+    const { b } = makeBroker({
+      accounts: ["alice", "bob"],
+      quotas: { alice: { fiveHour: 10, sevenDay: 20 }, bob: { fiveHour: 5, sevenDay: 10 } },
+    });
+    (b as any).fetchQuotaImpl = async () => {
+      probes += 1;
+      return healthyProbe();
     };
     await markThrottled(b, NOW + 60_000, "1");
     await markThrottled(b, NOW + 60_000, "2");
     const r3 = await markThrottled(b, NOW + 60_000, "3");
     expect(r3.data.escalated).toBe(false);
-    expect(probes).toBe(0);
+    // The first hit probes; the 2nd/3rd land within 5s and dedup — one probe,
+    // one recorded hit, for the whole burst.
+    expect(probes).toBe(1);
     expect(b.quota["alice"].throttle_hits).toEqual([NOW]);
   });
 });
 
-describe("mark-throttled — escalation guard (3 hits / 10 min)", () => {
-  it("escalates to mark-exhausted + fleet roll when the live probe corroborates a wall", async () => {
-    const { b, h, clock } = makeBroker({
+describe("mark-throttled — first-hit corroboration + probe rate-bound", () => {
+  it("escalates on a SINGLE hit when the live probe corroborates a wall", async () => {
+    const { b, h } = makeBroker({
       accounts: ["alice", "bob"],
-      // alice is genuinely weekly-walled — the probe corroborates.
-      quotas: { alice: { fiveHour: 10, sevenDay: 100 }, bob: { fiveHour: 5, sevenDay: 10 } },
+      // alice is genuinely 5h-walled — the FIRST-hit probe corroborates it,
+      // no 3-hit staging required.
+      quotas: { alice: { fiveHour: 100, sevenDay: 20 }, bob: { fiveHour: 5, sevenDay: 10 } },
     });
     const r1 = await markThrottled(b, NOW + 60_000, "1");
-    clock.set(NOW + HIT_SPACING_MS);
-    const r2 = await markThrottled(b, NOW + 60_000, "2");
-    expect(r1.data.escalated).toBe(false);
-    expect(r2.data.escalated).toBe(false);
-    expect(mirrorToken(h, "ziggy")).toBe(null); // still no roll after 2 hits
+    expect(r1.data.escalated).toBe(true);
+    expect(r1.data.rolledTo).toBe("bob");
 
-    clock.set(NOW + 2 * HIT_SPACING_MS);
-    const r3 = await markThrottled(b, NOW + 60_000 + 2 * HIT_SPACING_MS, "3");
-    expect(r3.data.escalated).toBe(true);
-    expect(r3.data.rolledTo).toBe("bob");
-
-    // Standard exhaustion mechanics ran: mark with the probe's weekly reset,
-    // fleet mirror fanout, durable promote.
-    expect(b.quota["alice"].exhausted_until).toBe(NOW + 3 * 86_400_000);
+    // Standard exhaustion mechanics ran off the probe's 5h reset (NOW + 3h):
+    // mark, fleet mirror fanout, durable promote.
+    expect(b.quota["alice"].exhausted_until).toBe(NOW + 3 * 3_600_000);
     expect(mirrorToken(h, "ziggy")).toBe("at-bob");
     expect(b.config.auth?.active).toBe("bob");
     expect(b.isAccountExhausted("alice")).toBe(true);
@@ -298,46 +329,81 @@ describe("mark-throttled — escalation guard (3 hits / 10 min)", () => {
     // covers pinned (non-fleet-active) rolls the fleet channel would skip.
     expect(b.lastFleetRoll).toBe(null);
 
-    // Counter cleared after the escalation probe.
+    // Hit window cleared after the corroborated escalation.
     expect(b.quota["alice"].throttle_hits).toEqual([]);
   });
 
-  it("does NOT escalate when the live probe shows the account healthy — counter re-arms", async () => {
-    const { b, h, clock } = makeBroker({
+  it("a healthy first-hit probe stays throttled and CARRIES the hit window forward", async () => {
+    const { b, h } = makeBroker({
       accounts: ["alice", "bob"],
       quotas: { alice: { fiveHour: 40, sevenDay: 30 }, bob: { fiveHour: 5, sevenDay: 10 } },
     });
-    await markThrottled(b, NOW + 60_000, "1");
-    clock.set(NOW + HIT_SPACING_MS);
-    await markThrottled(b, NOW + 60_000, "2");
-    clock.set(NOW + 2 * HIT_SPACING_MS);
-    const until3 = NOW + 60_000 + 2 * HIT_SPACING_MS;
-    const r3 = await markThrottled(b, until3, "3");
-    expect(r3.data.escalated).toBe(false);
-    expect(r3.data.rolledTo).toBe(null);
+    const until = NOW + 60_000;
+    const r1 = await markThrottled(b, until, "1");
+    expect(r1.data.escalated).toBe(false);
+    expect(r1.data.rolledTo).toBe(null);
 
-    // Still merely throttled: no mark, no roll, counter cleared (one probe
-    // per burst, not one per subsequent hit).
+    // Still merely throttled: throttle recorded, no exhaustion mark, no roll.
+    expect(b.quota["alice"].throttled_until).toBe(until);
     expect(b.quota["alice"].exhausted_until).toBeUndefined();
-    expect(b.quota["alice"].throttled_until).toBe(until3);
-    expect(b.quota["alice"].throttle_hits).toEqual([]);
     expect(mirrorToken(h, "ziggy")).toBe(null);
+    expect(b.config.auth?.active).toBe("alice");
+    expect(b.isAccountExhausted("alice")).toBe(false);
     expect(auditRows(h).some((r) => r.op === "mark-exhausted")).toBe(false);
+
+    // The pruned window is CARRIED FORWARD (not cleared) — a healthy probe does
+    // not reset the observability ledger. This is the core NEW-model contrast
+    // with an escalation, which clears it to [].
+    expect(b.quota["alice"].throttle_hits).toEqual([NOW]);
   });
 
-  it("hits OUTSIDE the 10-min window do not count toward escalation", async () => {
+  it("rate-bounds the probe to at most one per THROTTLE_ESCALATION_PROBE_MIN_INTERVAL_MS", async () => {
+    let probes = 0;
     const { b, clock } = makeBroker({
       accounts: ["alice", "bob"],
-      quotas: { alice: { fiveHour: 10, sevenDay: 100 }, bob: { fiveHour: 5, sevenDay: 10 } },
+      quotas: { alice: { fiveHour: 40, sevenDay: 30 }, bob: { fiveHour: 5, sevenDay: 10 } },
     });
-    // Two old hits, spaced past the dedup, then aged past the window.
+    (b as any).fetchQuotaImpl = async () => {
+      probes += 1;
+      return healthyProbe();
+    };
+
+    // First hit probes.
+    await markThrottled(b, NOW + 60_000, "1");
+    expect(probes).toBe(1);
+
+    // Second hit >5s later (clears the re-mark dedup) but WITHIN the rate-bound
+    // interval of the last probe → NO second probe; account stays throttled.
+    const t2 = NOW + HIT_SPACING_MS; // +30s: past the 5s dedup, inside 60s
+    clock.set(t2);
+    const r2 = await markThrottled(b, t2 + 60_000, "2");
+    expect(probes).toBe(1);
+    expect(r2.data.escalated).toBe(false);
+    expect(b.quota["alice"].throttled_until).toBe(t2 + 60_000);
+
+    // Advance PAST the rate-bound interval → the next hit probes again.
+    const t3 = NOW + THROTTLE_ESCALATION_PROBE_MIN_INTERVAL_MS + 1;
+    clock.set(t3);
+    await markThrottled(b, t3 + 60_000, "3");
+    expect(probes).toBe(2);
+  });
+
+  it("prunes hits aged past the 10-min window from the observability ledger", async () => {
+    const { b, clock } = makeBroker({
+      accounts: ["alice", "bob"],
+      // Healthy — no escalation; this test is about window pruning only.
+      quotas: { alice: { fiveHour: 10, sevenDay: 20 }, bob: { fiveHour: 5, sevenDay: 10 } },
+    });
+    // Two hits, spaced past the dedup, then a third after both age out.
     await markThrottled(b, NOW + 60_000, "1");
     clock.set(NOW + HIT_SPACING_MS);
     await markThrottled(b, NOW + 60_000, "2");
-    const late = NOW + 12 * 60_000; // both prior hits now outside the window
+    const late = NOW + 12 * 60_000; // both prior hits now outside the 10-min window
     clock.set(late);
     const r3 = await markThrottled(b, late + 60_000, "3");
     expect(r3.data.escalated).toBe(false);
+    // The window is pruned to just the fresh hit — THROTTLE_ESCALATION_HITS /
+    // _WINDOW are bookkeeping now, they no longer gate escalation.
     expect(b.quota["alice"].throttle_hits).toEqual([late]);
   });
 });

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -174,11 +174,10 @@ const MARK_EXHAUSTED_DEFAULT_MS = 5 * 60 * 60 * 1000;
  * bogus long throttle is clamped rather than lingering in the ledger. */
 const MARK_THROTTLED_MAX_MS = 30 * 60 * 1000;
 
-/** Escalation guard (429 throttle tier): this many transient-429 hits on the
- * same account inside the window trigger a live quota probe; a probe that
- * corroborates a genuine wall converts the throttle into the standard
- * mark-exhausted + fleet roll. */
-const THROTTLE_ESCALATION_HITS = 3;
+/** Escalation window (429 throttle tier): `throttle_hits` older than this are
+ * pruned from the observability ledger on each mark. Bookkeeping only since
+ * #failover-429-corroborate — it no longer gates escalation (the live probe
+ * runs on the FIRST hit, rate-bounded), it just bounds the recorded window. */
 const THROTTLE_ESCALATION_WINDOW_MS = 10 * 60 * 1000;
 
 /** First-hit corroboration rate bound (#failover-429-corroborate): a terminal
@@ -1245,7 +1244,7 @@ export class AuthBroker {
           await this.opMarkExhausted(socket, reqId, identity, req.until);
           break;
         case "mark-throttled":
-          await this.opMarkThrottled(socket, reqId, identity, req.until);
+          await this.opMarkThrottled(socket, reqId, identity, req.until, req.probeOnly);
           break;
         case "refresh-account": {
           const provider: ProviderName = req.provider ?? "anthropic";
@@ -2968,9 +2967,19 @@ export class AuthBroker {
    * so a 429 burst costs ≤1 haiku token/min. Marks within
    * MARK_THROTTLED_MIN_INTERVAL_MS of the previous hit only refresh
    * `throttled_until` (no hit, no probe) — a simultaneous multi-agent burst
-   * counts once and cannot flood probes. THROTTLE_ESCALATION_HITS /
-   * THROTTLE_ESCALATION_WINDOW_MS are retained for window bookkeeping /
-   * observability only; they no longer gate escalation.
+   * counts once and cannot flood probes. THROTTLE_ESCALATION_WINDOW_MS is
+   * retained for window bookkeeping / observability only; it no longer gates
+   * escalation.
+   *
+   * PROBE-ONLY mode (`probeOnly` — #failover-429-corroborate, generic-transient
+   * origin): run ONLY the rate-bounded escalation probe and, iff it corroborates
+   * a wall, the mark-exhausted + roll. Record NOTHING otherwise — no
+   * `throttled_until`, no hit, no soft-defer. A generic-transient 429 (bare
+   * `rate_limit_error` wording that neither names the account nor is proxy-local)
+   * must stay account-inert on a HEALTHY probe: the calm rate-limited card the
+   * gateway already emitted is the only user-visible output, exactly as before
+   * the escalation was ever wired. The shared escalation semantics live in
+   * `maybeEscalateThrottle` so the two entrypoints cannot diverge.
    *
    * Announcement doctrine: an escalated roll is NOT recorded in
    * `last_fleet_roll` — this is a REACTIVE path (see the LastFleetRoll
@@ -2983,6 +2992,7 @@ export class AuthBroker {
     id: string,
     identity: Identity,
     until: number,
+    probeOnly = false,
   ): Promise<void> {
     const account = this.callerAccount(identity);
     if (!account) {
@@ -2991,6 +3001,27 @@ export class AuthBroker {
       return;
     }
     const now = this.now();
+
+    // PROBE-ONLY (generic-transient origin): corroborate WITHOUT recording a
+    // throttle. No throttled_until, no hit, no soft-defer — a healthy probe is
+    // account-inert (its only effect is the silent quota self-heal inside the
+    // probe). Only a corroborated wall converts to mark-exhausted + roll.
+    if (probeOnly) {
+      const { escalated, rolledTo } = await this.maybeEscalateThrottle(account, identity, now);
+      this.audit({ op: "mark-throttled", identity, account, accountKind: "claude", ok: true });
+      socket.write(
+        encodeSuccess(id, {
+          account,
+          // Nothing recorded — echo any pre-existing expiry (else 0) so the
+          // response shape holds; the probe-only caller ignores this field.
+          throttled_until: this.quota[account]?.throttled_until ?? 0,
+          escalated,
+          rolledTo: escalated ? rolledTo : null,
+        }),
+      );
+      return;
+    }
+
     // Clamp: a throttle is minutes, never days. Past/short values still get
     // a floor of now+1s so the entry is observably "throttled right now".
     const throttledUntil = Math.min(
@@ -3025,21 +3056,6 @@ export class AuthBroker {
 
     const hits = priorHits.filter((t) => now - t < THROTTLE_ESCALATION_WINDOW_MS);
     hits.push(now);
-    // #failover-429-corroborate — corroborate on the FIRST hit, not the 3rd.
-    // A terminal transient 429 can be a genuine 5h/7d wall hiding behind
-    // generic/transient wording (the outage-class miss: the old 3-hit
-    // threshold left a dead turn stranded, or never escalated at all when the
-    // retries stopped). So run the live probe on every hit that clears the 5s
-    // re-mark dedup — but RATE-BOUNDED to at most one probe per account per
-    // THROTTLE_ESCALATION_PROBE_MIN_INTERVAL_MS (plus the single-flight wrapper
-    // in probeThrottleEscalation) so a 429 burst costs ≤1 haiku token/min.
-    // A healthy probe means the 429 really was transient → today's stay-put
-    // behavior is then correct. THROTTLE_ESCALATION_HITS is retained for the
-    // ledger's window bookkeeping / observability only.
-    const lastProbeAt = this.lastEscalationProbeAt[account];
-    const probeAllowed =
-      lastProbeAt === undefined ||
-      now - lastProbeAt >= THROTTLE_ESCALATION_PROBE_MIN_INTERVAL_MS;
     this.quota[account] = {
       ...entry,
       throttled_until: throttledUntil,
@@ -3050,35 +3066,15 @@ export class AuthBroker {
     this.audit({ op: "mark-throttled", identity, account, accountKind: "claude", ok: true });
     process.stdout.write(
       `auth-broker: mark-throttled ${account} until ${new Date(throttledUntil).toISOString()} ` +
-        `(hit ${hits.length} in window, probe ${probeAllowed ? "allowed" : "rate-bounded"})\n`,
+        `(hit ${hits.length} in window)\n`,
     );
 
-    let escalated = false;
-    let rolledTo: string | null = null;
-    if (probeAllowed) {
-      this.lastEscalationProbeAt[account] = now;
-      const probe = await this.probeThrottleEscalation(account);
-      if (probe.exhausted) {
-        escalated = true;
-        // Clear the hit window — the throttle converted to a durable
-        // exhaustion mark, so the escalation counter starts fresh.
-        this.quota[account] = { ...this.quota[account], throttle_hits: [] };
-        this.persistQuota();
-        process.stdout.write(
-          `auth-broker: throttle-escalation probe corroborates wall on ${account} — mark-exhausted + roll\n`,
-        );
-        this.audit({ op: "mark-exhausted", identity, account, accountKind: "claude", ok: true, reason: "throttle-escalation" });
-        const roll = await this.markExhaustedAndRoll(account, probe.until ?? undefined, identity);
-        rolledTo = roll.rolledTo;
-        // Deliberately NO recordFleetRoll here — reactive-path doctrine (see
-        // op docstring): the raising gateway announces from this response,
-        // covering pinned-account rolls the fleet channel would skip and
-        // avoiding a double announcement for fleet-active rolls.
-      } else {
-        process.stdout.write(
-          `auth-broker: throttle-escalation probe on ${account} did NOT corroborate a wall — staying throttled\n`,
-        );
-      }
+    const { escalated, rolledTo } = await this.maybeEscalateThrottle(account, identity, now);
+    if (escalated) {
+      // Clear the hit window — the throttle converted to a durable exhaustion
+      // mark, so the escalation counter starts fresh.
+      this.quota[account] = { ...this.quota[account], throttle_hits: [] };
+      this.persistQuota();
     }
     socket.write(
       encodeSuccess(id, {
@@ -3088,6 +3084,55 @@ export class AuthBroker {
         rolledTo: escalated ? rolledTo : null,
       }),
     );
+  }
+
+  /**
+   * #failover-429-corroborate — the shared FIRST-hit corroboration probe, used
+   * by both mark-throttled entrypoints (the account-scoped throttle write and
+   * the generic-transient probe-only path) so they cannot diverge in
+   * escalation semantics.
+   *
+   * A terminal transient 429 can be a genuine 5h/7d wall hiding behind
+   * generic/transient wording. So the live quota probe runs on the FIRST hit
+   * (not the 3rd) — but RATE-BOUNDED to at most one probe per account per
+   * THROTTLE_ESCALATION_PROBE_MIN_INTERVAL_MS (plus the single-flight wrapper in
+   * probeThrottleEscalation) so a 429 burst costs ≤1 haiku token/min. A healthy
+   * probe means the 429 really was transient → stay put (the caller records or
+   * omits the throttle as appropriate). A corroborated wall converts to the
+   * standard mark-exhausted + fleet roll here; the caller owns any hit-window
+   * bookkeeping around it. Deliberately NO recordFleetRoll — reactive-path
+   * doctrine (see opMarkThrottled docstring): the raising gateway announces
+   * from the response.
+   */
+  private async maybeEscalateThrottle(
+    account: string,
+    identity: Identity,
+    now: number,
+  ): Promise<{ escalated: boolean; rolledTo: string | null }> {
+    const lastProbeAt = this.lastEscalationProbeAt[account];
+    const probeAllowed =
+      lastProbeAt === undefined ||
+      now - lastProbeAt >= THROTTLE_ESCALATION_PROBE_MIN_INTERVAL_MS;
+    if (!probeAllowed) {
+      process.stdout.write(
+        `auth-broker: throttle-escalation probe on ${account} rate-bounded — skipped\n`,
+      );
+      return { escalated: false, rolledTo: null };
+    }
+    this.lastEscalationProbeAt[account] = now;
+    const probe = await this.probeThrottleEscalation(account);
+    if (!probe.exhausted) {
+      process.stdout.write(
+        `auth-broker: throttle-escalation probe on ${account} did NOT corroborate a wall — staying put\n`,
+      );
+      return { escalated: false, rolledTo: null };
+    }
+    process.stdout.write(
+      `auth-broker: throttle-escalation probe corroborates wall on ${account} — mark-exhausted + roll\n`,
+    );
+    this.audit({ op: "mark-exhausted", identity, account, accountKind: "claude", ok: true, reason: "throttle-escalation" });
+    const roll = await this.markExhaustedAndRoll(account, probe.until ?? undefined, identity);
+    return { escalated: true, rolledTo: roll.rolledTo };
   }
 
   /**

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -181,6 +181,15 @@ const MARK_THROTTLED_MAX_MS = 30 * 60 * 1000;
 const THROTTLE_ESCALATION_HITS = 3;
 const THROTTLE_ESCALATION_WINDOW_MS = 10 * 60 * 1000;
 
+/** First-hit corroboration rate bound (#failover-429-corroborate): a terminal
+ * transient 429 now runs the live escalation probe on the FIRST hit (not the
+ * 3rd) so a 5h wall hiding behind transient/generic 429 wording converts to
+ * failover in one round-trip instead of stranding a dead turn. To keep a 429
+ * burst from costing a probe per hit, the probe is bounded to at most once per
+ * this interval per account — combined with the single-flight wrapper and the
+ * 5s re-mark dedup, a storm costs ≤1 haiku token/min/account. */
+export const THROTTLE_ESCALATION_PROBE_MIN_INTERVAL_MS = 60 * 1000;
+
 /** Re-mark dedup (429 throttle tier): a mark landing within this interval of
  * the account's previous hit only refreshes `throttled_until` (keeping the
  * later expiry) — it adds no escalation hit and can trigger no probe. Bounds
@@ -652,6 +661,11 @@ export class AuthBroker {
    *  label. Concurrent `probe-quota` requests for the same label share the one
    *  pending upstream call (a render storm = 1 API call per account, not N). */
   private probeInFlight = new Map<string, Promise<QuotaResult>>();
+  /** #failover-429-corroborate — per-account unix-ms of the last throttle
+   *  escalation probe. Rate-bounds first-hit corroboration to at most one live
+   *  probe per THROTTLE_ESCALATION_PROBE_MIN_INTERVAL_MS per account (in-memory
+   *  only; a broker restart re-arms it, which just permits one extra probe). */
+  private lastEscalationProbeAt: Record<string, number> = {};
   private shaIndex: ShaIndex = {};
   private thresholdViolations: ThresholdViolations = {};
   /** Fleet notification-dedup claims: key → unix-ms of last grant.
@@ -2941,17 +2955,22 @@ export class AuthBroker {
    * Consumers of `list-state` (cron quota-preflight) read `throttled_until`
    * to soft-defer scheduled fires until the throttle clears.
    *
-   * Escalation guard: THROTTLE_ESCALATION_HITS transient 429s on the same
-   * account inside THROTTLE_ESCALATION_WINDOW_MS smell like a genuine wall
-   * hiding behind transient wording. Run ONE live quota probe; only a probe
-   * that CORROBORATES exhaustion (same overage-aware test every other trigger
-   * uses) converts the throttle into the standard mark-exhausted + fleet roll.
-   * The hit counter is cleared after any escalation probe — corroborated or
-   * not — so a persistent burst re-arms over a fresh window instead of
-   * probing on every subsequent hit. Marks within
+   * Escalation guard (#failover-429-corroborate): a terminal transient 429 can
+   * be a genuine 5h/7d wall hiding behind transient/generic wording, so the
+   * live quota probe runs on the FIRST hit — not the 3rd — converting a real
+   * wall to failover in one round-trip instead of stranding a dead turn. Only
+   * a probe that CORROBORATES exhaustion (same overage-aware test every other
+   * trigger uses) converts the throttle into the standard mark-exhausted +
+   * fleet roll; a healthy probe leaves the account merely throttled and
+   * CARRIES the pruned hit window forward (it is cleared only on a corroborated
+   * escalation). The probe is RATE-BOUNDED to at most one per account per
+   * THROTTLE_ESCALATION_PROBE_MIN_INTERVAL_MS (plus the single-flight wrapper),
+   * so a 429 burst costs ≤1 haiku token/min. Marks within
    * MARK_THROTTLED_MIN_INTERVAL_MS of the previous hit only refresh
    * `throttled_until` (no hit, no probe) — a simultaneous multi-agent burst
-   * counts once and cannot flood probes.
+   * counts once and cannot flood probes. THROTTLE_ESCALATION_HITS /
+   * THROTTLE_ESCALATION_WINDOW_MS are retained for window bookkeeping /
+   * observability only; they no longer gate escalation.
    *
    * Announcement doctrine: an escalated roll is NOT recorded in
    * `last_fleet_roll` — this is a REACTIVE path (see the LastFleetRoll
@@ -3006,27 +3025,45 @@ export class AuthBroker {
 
     const hits = priorHits.filter((t) => now - t < THROTTLE_ESCALATION_WINDOW_MS);
     hits.push(now);
-    const escalate = hits.length >= THROTTLE_ESCALATION_HITS;
+    // #failover-429-corroborate — corroborate on the FIRST hit, not the 3rd.
+    // A terminal transient 429 can be a genuine 5h/7d wall hiding behind
+    // generic/transient wording (the outage-class miss: the old 3-hit
+    // threshold left a dead turn stranded, or never escalated at all when the
+    // retries stopped). So run the live probe on every hit that clears the 5s
+    // re-mark dedup — but RATE-BOUNDED to at most one probe per account per
+    // THROTTLE_ESCALATION_PROBE_MIN_INTERVAL_MS (plus the single-flight wrapper
+    // in probeThrottleEscalation) so a 429 burst costs ≤1 haiku token/min.
+    // A healthy probe means the 429 really was transient → today's stay-put
+    // behavior is then correct. THROTTLE_ESCALATION_HITS is retained for the
+    // ledger's window bookkeeping / observability only.
+    const lastProbeAt = this.lastEscalationProbeAt[account];
+    const probeAllowed =
+      lastProbeAt === undefined ||
+      now - lastProbeAt >= THROTTLE_ESCALATION_PROBE_MIN_INTERVAL_MS;
     this.quota[account] = {
       ...entry,
       throttled_until: throttledUntil,
-      // Clear the counter when the escalation probe runs (below); otherwise
-      // carry the pruned window forward.
-      throttle_hits: escalate ? [] : hits,
+      // Carry the pruned window forward; cleared below iff the probe escalates.
+      throttle_hits: hits,
     };
     this.persistQuota();
     this.audit({ op: "mark-throttled", identity, account, accountKind: "claude", ok: true });
     process.stdout.write(
       `auth-broker: mark-throttled ${account} until ${new Date(throttledUntil).toISOString()} ` +
-        `(hit ${hits.length}/${THROTTLE_ESCALATION_HITS} in window)\n`,
+        `(hit ${hits.length} in window, probe ${probeAllowed ? "allowed" : "rate-bounded"})\n`,
     );
 
     let escalated = false;
     let rolledTo: string | null = null;
-    if (escalate) {
+    if (probeAllowed) {
+      this.lastEscalationProbeAt[account] = now;
       const probe = await this.probeThrottleEscalation(account);
       if (probe.exhausted) {
         escalated = true;
+        // Clear the hit window — the throttle converted to a durable
+        // exhaustion mark, so the escalation counter starts fresh.
+        this.quota[account] = { ...this.quota[account], throttle_hits: [] };
+        this.persistQuota();
         process.stdout.write(
           `auth-broker: throttle-escalation probe corroborates wall on ${account} — mark-exhausted + roll\n`,
         );
@@ -3059,6 +3096,9 @@ export class AuthBroker {
    * error) is `exhausted:false` — never escalate on missing evidence.
    * Caches a successful probe so the dashboard / eligibility see the fresh
    * snapshot (and so markExhaustedAndRoll's corroboration gate can act on it).
+   * Routed through probeQuotaSingleFlight so concurrent escalation probes (or
+   * a probe-quota render storm) for the same account collapse to ONE upstream
+   * call — part of the first-hit corroboration cost bound.
    */
   private async probeThrottleEscalation(
     account: string,
@@ -3068,7 +3108,7 @@ export class AuthBroker {
     if (!token) return { exhausted: false, until: null };
     let result: QuotaResult;
     try {
-      result = await this.fetchQuotaImpl({ accessToken: token });
+      result = await this.probeQuotaSingleFlight(account, token);
     } catch (err) {
       this.logErr(`throttle-escalation probe ${account}: ${(err as Error).message}`);
       return { exhausted: false, until: null };

--- a/telegram-plugin/gateway/auth-broker-client.ts
+++ b/telegram-plugin/gateway/auth-broker-client.ts
@@ -28,7 +28,7 @@ export function createAuthBrokerClient(): {
     listState: () => broker.listState(),
     setActive: (label: string) => broker.setActive(label),
     markExhausted: (until?: number) => broker.markExhausted(until),
-    markThrottled: (until: number) => broker.markThrottled(until),
+    markThrottled: (until: number, probeOnly?: boolean) => broker.markThrottled(until, probeOnly),
     rmAccount: (label: string) => broker.rmAccount(label),
     refreshAccount: (label: string) => broker.refreshAccount(label),
     setOverride: (agent: string, account: string | null) =>

--- a/telegram-plugin/gateway/auth-command.ts
+++ b/telegram-plugin/gateway/auth-command.ts
@@ -334,10 +334,12 @@ export interface AuthBrokerClient {
    * per-account rate limit on the CALLER's own account — `throttled_until`
    * in the quota ledger — WITHOUT rolling the fleet and WITHOUT touching
    * eligibility. `escalated` is true when the broker's escalation guard
-   * (repeated hits corroborated by a live probe) converted it into the
+   * (a first-hit live probe corroborating a wall) converted it into the
    * standard mark-exhausted + roll; `rolledTo` names the roll target then.
+   * `probeOnly` (#failover-429-corroborate, generic-transient origin): run ONLY
+   * the escalation probe — a healthy probe records nothing (account stays inert).
    */
-  markThrottled(until: number): Promise<{
+  markThrottled(until: number, probeOnly?: boolean): Promise<{
     account: string
     throttled_until: number
     escalated: boolean

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -428,7 +428,6 @@ import {
   classification429WarrantsCorroboration,
   classify429Detail,
   decideThrottleTier,
-  THROTTLE_DEFAULT_WAIT_MS,
   throttleRetryInPlaceMaxMs,
 } from '../throttle-tier.js'
 import { createThrottleTierRunner } from './throttle-tier-wiring.js'
@@ -7829,8 +7828,7 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
       agent,
       shouldEmitCard: (a) => shouldEmitOperatorEvent(a, 'rate-limited'),
     })
-    // #failover-429-corroborate — a generic-transient 429 used to drop on the calm-card floor with NO broker contact; route it to the PROBE-ONLY runner for a rate-bounded first-hit escalation probe. A healthy probe stays account-inert (no notice/nudge/soft-defer — the calm card is the only output); only a corroborated wall escalates. NEVER litellm-local — the predicate's docstring owns that account-inert invariant.
-    if (classification429WarrantsCorroboration(rateLimit429Classification)) void throttleTierRunner.fireProbeOnly(agent)
+    if (classification429WarrantsCorroboration(rateLimit429Classification)) void throttleTierRunner.fireProbeOnly(agent) // #failover-429-corroborate probe-only; see fireProbeOnly docstring
     if (surface === 'litellm-local-notice') {
       process.stderr.write(
         `telegram gateway: 429 classified litellm-proxy-local agent=${agent} — ` +

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -7829,8 +7829,8 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
       agent,
       shouldEmitCard: (a) => shouldEmitOperatorEvent(a, 'rate-limited'),
     })
-    // #failover-429-corroborate — a generic-transient 429 used to drop on the calm-card floor with NO broker contact; route it to the runner for a rate-bounded first-hit escalation probe (NEVER litellm-local — the predicate's docstring owns that account-inert invariant).
-    if (classification429WarrantsCorroboration(rateLimit429Classification)) void throttleTierRunner.fire(agent, Date.now() + THROTTLE_DEFAULT_WAIT_MS, false)
+    // #failover-429-corroborate — a generic-transient 429 used to drop on the calm-card floor with NO broker contact; route it to the PROBE-ONLY runner for a rate-bounded first-hit escalation probe. A healthy probe stays account-inert (no notice/nudge/soft-defer — the calm card is the only output); only a corroborated wall escalates. NEVER litellm-local — the predicate's docstring owns that account-inert invariant.
+    if (classification429WarrantsCorroboration(rateLimit429Classification)) void throttleTierRunner.fireProbeOnly(agent)
     if (surface === 'litellm-local-notice') {
       process.stderr.write(
         `telegram gateway: 429 classified litellm-proxy-local agent=${agent} — ` +

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -425,8 +425,10 @@ import {
 } from '../model-unavailable.js'
 import {
   build429ClassifiedMetric,
+  classification429WarrantsCorroboration,
   classify429Detail,
   decideThrottleTier,
+  THROTTLE_DEFAULT_WAIT_MS,
   throttleRetryInPlaceMaxMs,
 } from '../throttle-tier.js'
 import { createThrottleTierRunner } from './throttle-tier-wiring.js'
@@ -7827,6 +7829,8 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
       agent,
       shouldEmitCard: (a) => shouldEmitOperatorEvent(a, 'rate-limited'),
     })
+    // #failover-429-corroborate — a generic-transient 429 used to drop on the calm-card floor with NO broker contact; route it to the runner for a rate-bounded first-hit escalation probe (NEVER litellm-local — the predicate's docstring owns that account-inert invariant).
+    if (classification429WarrantsCorroboration(rateLimit429Classification)) void throttleTierRunner.fire(agent, Date.now() + THROTTLE_DEFAULT_WAIT_MS, false)
     if (surface === 'litellm-local-notice') {
       process.stderr.write(
         `telegram gateway: 429 classified litellm-proxy-local agent=${agent} — ` +

--- a/telegram-plugin/gateway/throttle-tier-wiring.ts
+++ b/telegram-plugin/gateway/throttle-tier-wiring.ts
@@ -35,6 +35,18 @@
  * (`LastFleetRoll` docstring in src/auth/broker/server.ts), which also
  * covers PINNED (non-fleet-active) account rolls — then nudges the resume
  * immediately through the same turn-safety guards.
+ *
+ * Two entrypoints (#failover-429-corroborate):
+ *   - `fire` — the FULL path above, for an ACCOUNT-SCOPED 429 (wording that
+ *     names the account's own usage limit). Records `throttled_until`, notices,
+ *     nudges, escalates.
+ *   - `fireProbeOnly` — for a GENERIC-TRANSIENT 429 (bare `rate_limit_error`
+ *     wording that neither names the account nor is proxy-local). Runs ONLY the
+ *     broker's rate-bounded escalation probe: a corroborated wall escalates
+ *     exactly like `fire`, but a HEALTHY probe is account-inert — no notice, no
+ *     nudge, no `throttled_until`, no second card. The gateway's calm
+ *     rate-limited card stays the only user-visible output. The two share the
+ *     escalation announce/resume via `announceEscalation`.
  */
 
 import {
@@ -56,7 +68,7 @@ export const THROTTLE_RETRY_NUDGE_JITTER_MAX_MS = 30_000
 /** The narrow broker surface the runner needs (structurally satisfied by
  *  the gateway's AuthBrokerClient). */
 export interface ThrottleBrokerClient {
-  markThrottled(until: number): Promise<{
+  markThrottled(until: number, probeOnly?: boolean): Promise<{
     account: string
     throttled_until: number
     escalated: boolean
@@ -92,10 +104,21 @@ export interface ThrottleTierRunnerDeps {
 
 export interface ThrottleTierRunner {
   /**
-   * Run the throttle path for one terminal transient 429. Fire-and-forget
-   * from the caller's perspective — never throws.
+   * Run the FULL throttle path for one terminal account-scoped 429: record
+   * `throttled_until`, post one deduped notice, arm the retry nudge, and
+   * escalate to failover when the first-hit probe corroborates a wall.
+   * Fire-and-forget from the caller's perspective — never throws.
    */
   fire(triggerAgent: string, throttledUntilMs: number, resetParsed: boolean): Promise<void>
+  /**
+   * PROBE-ONLY path for a generic-transient 429 (#failover-429-corroborate).
+   * Runs ONLY the broker's rate-bounded escalation probe: a corroborated wall
+   * escalates (announce + resume nudge) exactly like `fire`; a HEALTHY probe is
+   * account-inert — NO notice, NO nudge, NO `throttled_until` soft-defer, NO
+   * second card. The calm rate-limited card the gateway already emitted stays
+   * the only user-visible output. Fire-and-forget; never throws.
+   */
+  fireProbeOnly(triggerAgent: string): Promise<void>
   /** Test/debug view of internal state. */
   inspect(): { noticeState: ThrottleNoticeState; nudgePending: boolean }
 }
@@ -180,6 +203,33 @@ export function createThrottleTierRunner(deps: ThrottleTierRunnerDeps): Throttle
     }
   }
 
+  /**
+   * The escalated outcome, shared by `fire` and `fireProbeOnly`: the broker
+   * corroborated a genuine wall via a live probe and already ran mark-exhausted
+   * + roll (fleet active AND pinned accounts alike). The RAISING gateway
+   * announces — reactive-path doctrine — fleet-deduped so N gateways sharing
+   * the account produce one copy per chat, then nudges the resume.
+   */
+  async function announceEscalation(
+    client: ThrottleBrokerClient | null,
+    account: string | null,
+    rolledTo: string | null,
+    triggerAgent: string,
+    armedAtMs: number,
+  ): Promise<void> {
+    deps.log(
+      `[throttle-tier] escalated to wall account=${account ?? '?'} ` +
+        `rolledTo=${rolledTo ?? 'none (all blocked)'}`,
+    )
+    await broadcastDeduped(
+      client,
+      'throttle-escalation',
+      account,
+      renderThrottleEscalationNotice({ account, agent: triggerAgent, rolledTo }),
+    )
+    if (rolledTo) nudgeResume('throttle-escalation-resume', armedAtMs)
+  }
+
   async function fire(
     triggerAgent: string,
     throttledUntilMs: number,
@@ -209,21 +259,7 @@ export function createThrottleTierRunner(deps: ThrottleTierRunnerDeps): Throttle
     }
 
     if (escalated) {
-      // The broker corroborated a genuine wall via a live probe and already
-      // ran mark-exhausted + roll (fleet active AND pinned accounts alike).
-      // The RAISING gateway announces — reactive-path doctrine — fleet-
-      // deduped so N gateways sharing the account produce one copy per chat.
-      deps.log(
-        `[throttle-tier] escalated to wall account=${account ?? '?'} ` +
-          `rolledTo=${rolledTo ?? 'none (all blocked)'}`,
-      )
-      await broadcastDeduped(
-        client,
-        'throttle-escalation',
-        account,
-        renderThrottleEscalationNotice({ account, agent: triggerAgent, rolledTo }),
-      )
-      if (rolledTo) nudgeResume('throttle-escalation-resume', armedAtMs)
+      await announceEscalation(client, account, rolledTo, triggerAgent, armedAtMs)
       return
     }
 
@@ -261,8 +297,47 @@ export function createThrottleTierRunner(deps: ThrottleTierRunnerDeps): Throttle
     }, delayMs)
   }
 
+  async function fireProbeOnly(triggerAgent: string): Promise<void> {
+    const armedAtMs = now()
+    let client: ThrottleBrokerClient | null = null
+    let account: string | null = null
+    let escalated = false
+    let rolledTo: string | null = null
+    try {
+      client = await deps.getBrokerClient()
+      if (client) {
+        // `until` is ignored by the broker in probeOnly mode (nothing is
+        // recorded) but the protocol requires a positive int — pass a nominal.
+        const r = await client.markThrottled(now() + 1, true)
+        account = r.account
+        escalated = r.escalated
+        rolledTo = r.rolledTo ?? null
+      } else {
+        deps.log(
+          `[throttle-tier] broker unreachable — probe-only skipped agent=${triggerAgent}`,
+        )
+      }
+    } catch (err) {
+      deps.log(
+        `[throttle-tier] probe-only markThrottled failed agent=${triggerAgent}: ${(err as Error)?.message ?? err}`,
+      )
+    }
+
+    if (escalated) {
+      await announceEscalation(client, account, rolledTo, triggerAgent, armedAtMs)
+      return
+    }
+
+    // HEALTHY / rate-bounded / broker-down: account-inert. NOTHING else — no
+    // notice, no retry nudge, no throttled_until soft-defer. The calm
+    // rate-limited card the gateway already emitted is the only user-visible
+    // output, exactly as before the escalation probe was wired.
+    deps.log(`[throttle-tier] generic-transient probe-only inert (no wall) agent=${triggerAgent}`)
+  }
+
   return {
     fire,
+    fireProbeOnly,
     inspect: () => ({ noticeState, nudgePending: pendingNudge != null }),
   }
 }

--- a/telegram-plugin/tests/throttle-tier-probe-only.test.ts
+++ b/telegram-plugin/tests/throttle-tier-probe-only.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for the generic-transient PROBE-ONLY 429 path (#failover-429-corroborate).
+ *
+ * This pins the OUTCOMES the gateway promises for a bare `rate_limit_error`
+ * (generic-transient) 429 after Ken picked Option A (probe-only):
+ *
+ *   - generic-transient + HEALTHY probe → the probe's ONLY effect is the
+ *     silent broker quota refresh. Account-inert at the runner: NO throttle
+ *     notice, NO self-restart nudge, NO `throttled_until` soft-defer, NO second
+ *     card. The calm rate-limited card the gateway already emitted stays the
+ *     ONLY user-visible output.
+ *   - generic-transient + WALL (probe corroborates) → the escalation path runs
+ *     exactly like the account-scoped `fire`: the corroborated-wall announcement
+ *     posts and the dead turn is resumed. No redundant calm card is emitted from
+ *     this branch — the announcement IS the output.
+ *   - litellm-local → the runner does NOT fire at all (account-inert by
+ *     mechanism, not discipline): the request never reached Anthropic, so
+ *     account state must not be touched. `account-scoped` likewise takes its own
+ *     `fire` path, not `fireProbeOnly`. Pinned via the pure classification gate
+ *     the gateway consults before calling `fireProbeOnly`.
+ *
+ * The runner side is exercised with fully injected deps (no gateway import),
+ * mirroring throttle-tier-wiring.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  createThrottleTierRunner,
+  type ThrottleBrokerClient,
+  type ThrottleTierRunnerDeps,
+} from '../gateway/throttle-tier-wiring.js'
+import { classification429WarrantsCorroboration } from '../throttle-tier.js'
+
+const NOW = Date.UTC(2026, 6, 12, 8, 0, 0)
+
+interface Harness {
+  deps: ThrottleTierRunnerDeps
+  calls: {
+    markThrottled: Array<{ until: number; probeOnly?: boolean }>
+    claims: string[]
+    notices: Array<{ chatId: string | number; markdown: string }>
+    deferrals: string[]
+    restarts: string[]
+    logs: string[]
+    timers: Array<{ ms: number; fn: () => void; cancelled: boolean }>
+  }
+}
+
+function makeHarness(opts: {
+  markThrottledResult?:
+    | { account: string; throttled_until: number; escalated: boolean; rolledTo?: string | null }
+    | 'unreachable'
+    | 'throw'
+  turnInFlight?: () => boolean
+  newestTurnStartedAt?: () => number | null
+} = {}): Harness {
+  const nowMs = NOW
+  const calls: Harness['calls'] = {
+    markThrottled: [],
+    claims: [],
+    notices: [],
+    deferrals: [],
+    restarts: [],
+    logs: [],
+    timers: [],
+  }
+  const client: ThrottleBrokerClient = {
+    async markThrottled(until: number, probeOnly?: boolean) {
+      calls.markThrottled.push({ until, probeOnly })
+      if (opts.markThrottledResult === 'throw') throw new Error('boom')
+      const r = opts.markThrottledResult
+      if (r && r !== 'unreachable') return r
+      return { account: 'alice', throttled_until: until, escalated: false, rolledTo: null }
+    },
+    async claimNotification(key: string) {
+      calls.claims.push(key)
+      return { granted: true }
+    },
+  }
+  const deps: ThrottleTierRunnerDeps = {
+    agentName: 'carrie',
+    getBrokerClient: async () =>
+      opts.markThrottledResult === 'unreachable' ? null : client,
+    listNoticeChats: () => ['111', '222'],
+    sendNotice: (chatId, markdown) => calls.notices.push({ chatId, markdown }),
+    resumeDecide: () => 'resume',
+    newestActiveTurnStartedAtMs: opts.newestTurnStartedAt ?? (() => null),
+    turnInFlight: opts.turnInFlight ?? (() => false),
+    deferRestartToTurnComplete: (_agent, reason) => calls.deferrals.push(reason),
+    restartNow: (_agent, reason) => calls.restarts.push(reason),
+    log: (m) => calls.logs.push(m),
+    now: () => nowMs,
+    schedule: (fn, ms) => {
+      const t = { ms, fn, cancelled: false }
+      calls.timers.push(t)
+      return { cancel: () => { t.cancelled = true } }
+    },
+    jitterMs: () => 0,
+  }
+  return { deps, calls }
+}
+
+describe('generic-transient probe-only — classification gate (litellm-local never fires)', () => {
+  it('fires the corroboration probe ONLY for generic-transient', () => {
+    expect(classification429WarrantsCorroboration('generic-transient')).toBe(true)
+    // litellm-local: request never reached Anthropic — account-inert by mechanism.
+    expect(classification429WarrantsCorroboration('litellm-local')).toBe(false)
+    // account-scoped: runs its own throttle tier / failover (fire, not fireProbeOnly).
+    expect(classification429WarrantsCorroboration('account-scoped')).toBe(false)
+    // null: not a rate-limited event.
+    expect(classification429WarrantsCorroboration(null)).toBe(false)
+  })
+})
+
+describe('generic-transient probe-only — HEALTHY probe is account-inert', () => {
+  it('probes the broker but emits NOTHING else (calm card stays the only output)', async () => {
+    const h = makeHarness() // default result: escalated:false (healthy)
+    const runner = createThrottleTierRunner(h.deps)
+    await runner.fireProbeOnly('carrie')
+
+    // The probe reached the broker in probe-only mode…
+    expect(h.calls.markThrottled).toHaveLength(1)
+    expect(h.calls.markThrottled[0].probeOnly).toBe(true)
+
+    // …but produced NO user-visible or account-mutating side effects:
+    expect(h.calls.notices).toHaveLength(0) // no throttle notice, no second card
+    expect(h.calls.claims).toHaveLength(0) // no fleet-dedup broadcast at all
+    expect(h.calls.restarts).toHaveLength(0) // no self-restart nudge
+    expect(h.calls.deferrals).toHaveLength(0)
+    expect(h.calls.timers).toHaveLength(0) // no throttled_until soft-defer / retry nudge
+    expect(runner.inspect().nudgePending).toBe(false)
+  })
+
+  it('a broker-unreachable probe is inert and never throws', async () => {
+    const h = makeHarness({ markThrottledResult: 'unreachable' })
+    const runner = createThrottleTierRunner(h.deps)
+    await expect(runner.fireProbeOnly('carrie')).resolves.toBeUndefined()
+    expect(h.calls.markThrottled).toHaveLength(0)
+    expect(h.calls.notices).toHaveLength(0)
+    expect(h.calls.restarts).toHaveLength(0)
+    expect(h.calls.timers).toHaveLength(0)
+  })
+
+  it('a markThrottled throw is swallowed and stays inert (no card, no restart)', async () => {
+    const h = makeHarness({ markThrottledResult: 'throw' })
+    const runner = createThrottleTierRunner(h.deps)
+    await expect(runner.fireProbeOnly('carrie')).resolves.toBeUndefined()
+    expect(h.calls.notices).toHaveLength(0)
+    expect(h.calls.restarts).toHaveLength(0)
+    expect(h.calls.timers).toHaveLength(0)
+  })
+})
+
+describe('generic-transient probe-only — WALL corroborated → escalation', () => {
+  it('posts the corroborated-wall announcement and resumes immediately (no calm card, no nudge timer)', async () => {
+    const h = makeHarness({
+      markThrottledResult: {
+        account: 'alice',
+        throttled_until: NOW + 60_000,
+        escalated: true,
+        rolledTo: 'bob',
+      },
+    })
+    const runner = createThrottleTierRunner(h.deps)
+    await runner.fireProbeOnly('carrie')
+
+    // Probe ran in probe-only mode, then escalation took over.
+    expect(h.calls.markThrottled[0].probeOnly).toBe(true)
+
+    // The escalation announcement (fleet-deduped), NOT the staying-put notice.
+    expect(h.calls.claims).toEqual([
+      `throttle-escalation:alice:111`,
+      `throttle-escalation:alice:222`,
+    ])
+    expect(h.calls.notices).toHaveLength(2)
+    expect(h.calls.notices[0].markdown).toContain('actually a wall')
+    expect(h.calls.notices[0].markdown).toContain('bob')
+
+    // Immediate resume via the escalation lever; NO delayed retry nudge armed.
+    expect(h.calls.restarts).toEqual(['throttle-escalation-resume'])
+    expect(h.calls.timers).toHaveLength(0)
+  })
+
+  it('escalated with rolledTo=null (all blocked) announces but does NOT restart', async () => {
+    const h = makeHarness({
+      markThrottledResult: {
+        account: 'alice',
+        throttled_until: NOW + 60_000,
+        escalated: true,
+        rolledTo: null,
+      },
+    })
+    const runner = createThrottleTierRunner(h.deps)
+    await runner.fireProbeOnly('carrie')
+    expect(h.calls.notices[0].markdown).toContain('all blocked')
+    expect(h.calls.restarts).toHaveLength(0)
+    expect(h.calls.timers).toHaveLength(0)
+  })
+
+  it('escalated resume respects the live-turn guards (defers under the dead turn gate)', async () => {
+    const h = makeHarness({
+      markThrottledResult: {
+        account: 'alice',
+        throttled_until: NOW + 60_000,
+        escalated: true,
+        rolledTo: 'bob',
+      },
+      turnInFlight: () => true,
+      newestTurnStartedAt: () => NOW - 60_000, // the dead turn still holds the gate
+    })
+    const runner = createThrottleTierRunner(h.deps)
+    await runner.fireProbeOnly('carrie')
+    expect(h.calls.restarts).toHaveLength(0)
+    expect(h.calls.deferrals).toEqual(['throttle-escalation-resume'])
+  })
+})

--- a/telegram-plugin/throttle-tier.ts
+++ b/telegram-plugin/throttle-tier.ts
@@ -121,6 +121,32 @@ export function classify429Detail(text: string): RateLimit429Classification {
 }
 
 /**
+ * #failover-429-corroborate — does this terminal 429 classification warrant a
+ * fire-and-forget broker corroboration probe (throttle-tier runner) IN ADDITION
+ * to the calm rate-limited card?
+ *
+ * TRUE for `generic-transient` ONLY. That family (a bare `rate_limit_error`
+ * body / novel wording that matches neither the account-scoped negation
+ * strings nor litellm-local) used to drop on the calm-card floor with NO broker
+ * contact — so a genuine 5h/7d wall hiding behind transient wording was never
+ * probed, and the turn died with no failover. Routing it through the runner
+ * lets the broker take ONE live quota probe (rate-bounded) and convert a real
+ * wall into failover; a healthy probe leaves the calm path unchanged.
+ *
+ * FALSE (never corroborate) for:
+ *   - `litellm-local` — INVARIANT: the request never reached Anthropic (the
+ *     proxy's own tpm/rpm limiter tripped), so account state must not be
+ *     touched. This mechanism, not discipline, keeps that path account-inert.
+ *   - `account-scoped` — already runs its own throttle tier / failover path.
+ *   - `null` — not a rate-limited event.
+ */
+export function classification429WarrantsCorroboration(
+  classification: RateLimit429Classification | null,
+): boolean {
+  return classification === 'generic-transient'
+}
+
+/**
  * Build the `rate_limit_429_classified` runtime metric for one terminal
  * rate-limited operator event — the instrumentation that lets an operator
  * correlate Anthropic ACCOUNT 429s with fleet TPM (the prerequisite for

--- a/telegram-plugin/throttle-tier.ts
+++ b/telegram-plugin/throttle-tier.ts
@@ -122,16 +122,19 @@ export function classify429Detail(text: string): RateLimit429Classification {
 
 /**
  * #failover-429-corroborate — does this terminal 429 classification warrant a
- * fire-and-forget broker corroboration probe (throttle-tier runner) IN ADDITION
- * to the calm rate-limited card?
+ * fire-and-forget broker corroboration probe (throttle-tier runner's
+ * PROBE-ONLY entrypoint) IN ADDITION to the calm rate-limited card?
  *
  * TRUE for `generic-transient` ONLY. That family (a bare `rate_limit_error`
  * body / novel wording that matches neither the account-scoped negation
  * strings nor litellm-local) used to drop on the calm-card floor with NO broker
  * contact — so a genuine 5h/7d wall hiding behind transient wording was never
- * probed, and the turn died with no failover. Routing it through the runner
- * lets the broker take ONE live quota probe (rate-bounded) and convert a real
- * wall into failover; a healthy probe leaves the calm path unchanged.
+ * probed, and the turn died with no failover. Routing it through the runner's
+ * `fireProbeOnly` lets the broker take ONE live quota probe (rate-bounded) and
+ * convert a real wall into failover. A HEALTHY probe is fully account-inert:
+ * probe-only records NO `throttled_until`, sends NO throttle notice, arms NO
+ * self-restart nudge, and adds NO second card — so the calm rate-limited card
+ * stays the ONLY user-visible output, exactly as before this path existed.
  *
  * FALSE (never corroborate) for:
  *   - `litellm-local` — INVARIANT: the request never reached Anthropic (the


### PR DESCRIPTION
## Summary

The 429 throttle tier now corroborates a terminal transient 429 with a live quota probe on the **first hit** instead of waiting for 3 hits in a 10-min window. A probe that corroborates a genuine 5h/7d wall converts the throttle into the standard mark-exhausted + fleet roll in one round-trip; a healthy probe leaves the account merely throttled and carries the pruned hit window forward. The probe is **rate-bounded** to at most one per account per `THROTTLE_ESCALATION_PROBE_MIN_INTERVAL_MS` (60s) — combined with the single-flight wrapper and the 5s re-mark dedup, a 429 storm costs at most one probe per minute per account. `generic-transient` 429s (which used to drop on the calm-card floor with no broker contact) are now routed through the throttle-tier runner so the broker can take that corroboration probe.

**Follow-up (Option A — generic-transient is probe-only):** a `generic-transient` 429 goes through the runner's dedicated `fireProbeOnly` entrypoint, which runs ONLY the rate-bounded corroboration probe via a new `probeOnly` flag on the broker `mark-throttled` verb. A healthy probe is fully **account-inert** — no `throttled_until` write, no throttle notice, no self-restart nudge, no second card — so the calm rate-limited card the gateway already emitted stays the only user-visible output, exactly as before this path existed. Only a corroborated wall escalates (mark-exhausted + roll + announce + resume), sharing `announceEscalation` with the account-scoped `fire` path so the two cannot diverge. `litellm-local` never fires the probe (account-inert by mechanism via `classification429WarrantsCorroboration`); `account-scoped` keeps its own `fire` path.

This PR finishes the half-migrated broker unit test `src/auth/broker/server-mark-throttled.test.ts`: `quotaFor` was already generalized, but the test CASES still encoded the old 3-hit model and 5 of 8 failed. They now assert the new first-hit corroboration + rate-bound OUTCOMES. It also corrects the `opMarkThrottled` docstring to match shipped behavior and exports `THROTTLE_ESCALATION_PROBE_MIN_INTERVAL_MS` so the test references the real constant.

## Why

A genuine 5h/7d wall can hide behind generic/transient 429 wording. The old 3-hit threshold either stranded a dead turn or never escalated at all when the retries stopped, so failover did not fire. Corroborating on the first hit converts a real wall to failover immediately, while a healthy probe preserves today's stay-put behavior. Rate-bounding + single-flight keep the cost at <=1 haiku token/min/account under a burst — a mechanism, not prompt discipline.

## Test plan

- `bun test src/auth/broker/server-mark-throttled.test.ts` -> **9 pass / 0 fail**
- `vitest run src/auth/broker/server-mark-throttled.test.ts` -> 9 pass
- `vitest run telegram-plugin/tests/throttle-tier-probe-only.test.ts` -> 7 pass (new probe-only outcome test)
- `vitest run telegram-plugin/tests/throttle-tier-wiring.test.ts` -> 12 pass
- `vitest run src/auth/broker/net-hermeticity.test.ts` -> 3 pass (the net guard is a vitest `setupFiles` entry; that suite is vitest-run — it fails under `bun test` on `main` too, by design)
- `tsc --noEmit` -> clean
- `npm run lint` -> clean (all guards incl. `check-gateway-line-ratchet`, `check-bot-api-wrapping`, `check-auth-test-hermeticity`)

New / reconciled coverage:
- **First-hit escalation** on a walled account: `exhausted_until` from the probe's 5h reset, mirror fanout, durable promote, `mark-exhausted` audit reason `throttle-escalation`, `throttle_hits === []`.
- **Healthy first hit** stays throttled with `throttle_hits` carried forward (not cleared).
- **Probe rate-bound**: probe count 1 -> stays 1 for a 2nd hit within 60s -> 2 past 60s.
- 5s re-mark dedup and 3-agent-burst-shares-one-probe.
- Window pruning as bookkeeping only.
- **Probe-only outcomes** (gateway-side): healthy probe -> account-inert (one calm card only, no notice/nudge/timer); wall -> escalation announcement + resume; `litellm-local`/`account-scoped`/`null` -> probe never fires.

## Rollout ordering

**Update the singleton auth-broker with (or before) the agent gateways.** The `probeOnly` flag is a new optional field on the broker `mark-throttled` request. A new gateway talking to an **old, pre-`probeOnly` broker** will have zod strip the unknown field, so the broker takes the FULL mark-throttled path for a generic-transient 429 rather than the probe-only path. During that skew window generic-transient is not fully inert: it briefly records a `throttled_until` soft-defer (<=60s cron reset) plus a single self-pruning `throttle_hit`. This **fails safe** — no crash, no operator notice/nudge, no eligibility change, and the hit prunes itself out of the window — but the deployer should sequence **broker-before-agents** to avoid it entirely. (Old gateway -> new broker is unaffected: the field simply isn't sent and the broker takes the full path, which is the pre-PR behavior.)

## Risk

Low. The behavior change lives in already-committed `server.ts`; this PR is predominantly test reconciliation plus the probe-only follow-up and a docstring/const-export cleanup. See Rollout ordering above for the one version-skew caveat.

Job spec: `reference/jobs/share-auth-across-the-fleet.md` (fallback lives at the account level; the fanout/failover loop). Serves: **subscription-honest**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
