### PR TITLE
fix(scheduler): scope strict overlay freeze to schedule.d, not skills.d (#4373)

### DIFF
--- a/src/agent-scheduler/hot-reload.test.ts
+++ b/src/agent-scheduler/hot-reload.test.ts
@@ -302,6 +302,57 @@ describe.skipIf(runningAsRoot)(
       expect(reloader.currentTasks().map((t) => t.entry.prompt)).toEqual(["overlay-cron"]);
     });
 
+    it("an unreadable skills.d overlay does NOT freeze schedule reloads (#4373)", () => {
+      // schedule.d is fine; only a skills.d overlay is unreadable. On main,
+      // loadAgentEntriesStrict throws on ANY overlay read failure (incl.
+      // skills.d), routing the reloader into its keep-current onError path —
+      // so a legitimate schedule.d edit made in the same window never lands.
+      // Post-fix, the strict guard is schedule-scoped: the skills.d failure
+      // is ignored and the new cron registers.
+      const { configPath } = writeFixture();
+      const skillsDir = join(tmpHome, ".switchroom", "agents", AGENT, "skills.d");
+      mkdirSync(skillsDir, { recursive: true });
+      const skillPath = join(skillsDir, "ws.yaml");
+      writeFileSync(skillPath, "skills:\n  - webapp-testing\n");
+
+      const boot = loadAgentEntriesStrict(configPath, AGENT);
+      expect(boot.map((e) => e.prompt)).toEqual(["overlay-cron"]);
+
+      const registrations: SchedulerEntry[][] = [];
+      const errors: string[] = [];
+      let stops = 0;
+      const register = (es: SchedulerEntry[]): RegisteredTask[] => {
+        registrations.push(es);
+        return es.map((e) => ({ entry: e, task: { stop: () => { stops += 1; } } }));
+      };
+      const initialTasks = register(boot);
+      registrations.length = 0;
+
+      const reloader = createScheduleReloader({
+        loadEntries: () => loadAgentEntriesStrict(configPath, AGENT),
+        register,
+        initialTasks,
+        initialEntries: boot,
+        log: () => {},
+        onError: (e) => errors.push(e.message),
+      });
+
+      // skills.d overlay turns unreadable (foreign-owner 0600 ≙ chmod 000)…
+      chmodSync(skillPath, 0o000);
+      // …and a NEW schedule.d cron is added in the same window.
+      const newCronPath = join(tmpHome, ".switchroom", "agents", AGENT, "schedule.d", "cron-bbbbbbbbbbbb.yaml");
+      writeFileSync(newCronPath, "schedule:\n  - cron: '0 9 * * *'\n    prompt: new-cron\n");
+      reloader.tick();
+
+      // OUTCOME: the schedule reload applied — the new cron registered — and
+      // the skills.d failure did NOT freeze it or surface as a reload error.
+      expect(errors).toEqual([]);
+      expect(reloader.currentTasks().map((t) => t.entry.prompt).sort())
+        .toEqual(["new-cron", "overlay-cron"]);
+
+      chmodSync(skillPath, 0o600);
+    });
+
     it("a genuinely REMOVED overlay file still unregisters (no false retention)", () => {
       const { configPath, overlayPath } = writeFixture();
       const boot = loadAgentEntriesStrict(configPath, AGENT);

--- a/src/agent-scheduler/index.ts
+++ b/src/agent-scheduler/index.ts
@@ -568,13 +568,20 @@ function formatReadFailures(failures: OverlayReadFailure[]): string {
  *
  * Content failures (malformed YAML, schema rejection) do NOT throw:
  * those files were read fine and their entries are legitimately excluded.
+ *
+ * Scope is `schedule.d` ONLY (#4373): the strict loader is agent-wide over
+ * the config object, but an unreadable `skills.d` overlay is unrelated to
+ * the schedule and must not freeze cron reloads. `skills.d` read failures
+ * still warn (the loader's per-file `console.warn`); they just don't throw
+ * here. Filtering on `source: "schedule"` keeps the freeze targeted at the
+ * only class that can silently unregister a live cron.
  */
 export function loadAgentEntriesStrict(
   configPath: string,
   agentName: string,
 ): SchedulerEntry[] {
   const config = loadConfig(configPath);
-  const failures = overlayReadFailures(config, agentName);
+  const failures = overlayReadFailures(config, agentName, "schedule");
   if (failures.length > 0) {
     throw new Error(
       `schedule.d overlay unreadable — refusing a reload that may be ` +
@@ -666,7 +673,10 @@ export async function main(): Promise<void> {
   // and actionably instead of the loader's per-file console.warn only.
   // (The hot-reload path below is strict: it refuses to swap the live
   // schedule against a load that is missing unreadable files.)
-  const bootReadFailures = overlayReadFailures(config, agentName);
+  // Scoped to schedule.d (#4373): this warning is specifically about
+  // unregistered cron entries — an unreadable skills.d overlay is a
+  // different concern and still surfaces via the loader's console.warn.
+  const bootReadFailures = overlayReadFailures(config, agentName, "schedule");
   if (bootReadFailures.length > 0) {
     process.stderr.write(
       `agent-scheduler: ${agentName} WARNING: ${bootReadFailures.length} ` +

--- a/src/config/overlay-loader.test.ts
+++ b/src/config/overlay-loader.test.ts
@@ -389,7 +389,7 @@ describe.skipIf(runningAsRoot)(
       expect(warnings[0].reason).toMatch(/read error/);
       const failures = overlayReadFailures(cfg, "foo");
       expect(failures).toHaveLength(1);
-      expect(failures[0]).toMatchObject({ file: locked, code: "EACCES" });
+      expect(failures[0]).toMatchObject({ file: locked, code: "EACCES", source: "schedule" });
     });
 
     it("still loads readable sibling files (per-file isolation preserved)", () => {
@@ -425,7 +425,33 @@ describe.skipIf(runningAsRoot)(
       const cfg = makeConfig({ foo: { skills: [] } });
       const { warnings } = applyAgentOverlays(cfg);
       expect(warnings.some((w) => w.code === "EACCES" && w.file === locked)).toBe(true);
-      expect(overlayReadFailures(cfg, "foo")).toContainEqual({ file: locked, code: "EACCES" });
+      expect(overlayReadFailures(cfg, "foo")).toContainEqual({ file: locked, code: "EACCES", source: "skills" });
+    });
+
+    it("scopes overlayReadFailures by source — a skills.d failure is EXCLUDED from the schedule scope (#4373)", () => {
+      // Both classes unreadable in the same pass.
+      const schedDir = scheduleDir("foo");
+      const lockedSchedule = join(schedDir, "cron-eeeeeeeeeeee.yaml");
+      writeFileSync(lockedSchedule, "schedule:\n  - cron: '0 1 * * *'\n    prompt: hidden\n");
+      chmodSync(lockedSchedule, 0o000);
+      const skillsD = join(tmpHome, ".switchroom", "agents", "foo", "skills.d");
+      mkdirSync(skillsD, { recursive: true });
+      const lockedSkill = join(skillsD, "ws.yaml");
+      writeFileSync(lockedSkill, "skills:\n  - webapp-testing\n");
+      chmodSync(lockedSkill, 0o000);
+
+      const cfg = makeConfig({ foo: { schedule: [], skills: [] } });
+      applyAgentOverlays(cfg);
+
+      // Unfiltered: both failures present.
+      expect(overlayReadFailures(cfg, "foo")).toHaveLength(2);
+      // schedule scope: only the schedule.d failure — the freeze must NOT be
+      // triggered by an unrelated skills.d permission problem.
+      const scheduleFailures = overlayReadFailures(cfg, "foo", "schedule");
+      expect(scheduleFailures.map((f) => f.file)).toEqual([lockedSchedule]);
+      // skills scope: only the skills.d failure.
+      const skillsFailures = overlayReadFailures(cfg, "foo", "skills");
+      expect(skillsFailures.map((f) => f.file)).toEqual([lockedSkill]);
     });
 
     it("reports an unreadable schedule.d DIRECTORY as a read failure (dir-level variant)", () => {
@@ -436,7 +462,7 @@ describe.skipIf(runningAsRoot)(
         const cfg = makeConfig({ foo: { schedule: [] } });
         const { warnings } = applyAgentOverlays(cfg);
         expect(warnings.some((w) => w.file === dir && w.code === "EACCES")).toBe(true);
-        expect(overlayReadFailures(cfg, "foo")).toContainEqual({ file: dir, code: "EACCES" });
+        expect(overlayReadFailures(cfg, "foo")).toContainEqual({ file: dir, code: "EACCES", source: "schedule" });
       } finally {
         chmodSync(dir, 0o755); // so afterEach rmSync can clean up
       }

--- a/src/config/overlay-loader.ts
+++ b/src/config/overlay-loader.ts
@@ -93,10 +93,20 @@ export const OVERLAY_READ_FAILURES = Symbol.for(
   "switchroom.config.overlay-read-failures",
 );
 
-/** One unreadable overlay file: absolute path + fs errno code. */
+/** One unreadable overlay file: absolute path + fs errno code + which
+ *  overlay class it belongs to.
+ *
+ *  `source` matters because the two overlay classes have DIFFERENT
+ *  fail-safes (#4373): an unreadable `schedule.d` overlay must freeze cron
+ *  hot-reloads (a silently-unregistered live cron is worse than a delayed
+ *  edit — the clerk EACCES incident #4371), but an unreadable `skills.d`
+ *  overlay must NOT freeze schedule reloads — a skills permission problem is
+ *  unrelated to the schedule and only warrants a warn-and-skip. Consumers
+ *  filter on this via {@link overlayReadFailures}'s `source` argument. */
 export interface OverlayReadFailure {
   file: string;
   code: string;
+  source: "schedule" | "skills";
 }
 
 /** Record a read failure on the agent's config node (non-enumerable). */
@@ -120,17 +130,24 @@ function recordReadFailure(agentCfg: object, failure: OverlayReadFailure): void 
  * last {@link applyAgentOverlays} pass over this config object. Empty when
  * every overlay file was readable (content errors do NOT count — those
  * files were read fine and are legitimately excluded).
+ *
+ * `source` scopes the result to one overlay class (`"schedule"` or
+ * `"skills"`); omit it to get every read failure. The scheduler's strict
+ * hot-reload guard passes `"schedule"` so an unreadable `skills.d` overlay
+ * can no longer freeze cron reloads (#4373).
  */
 export function overlayReadFailures(
   config: SwitchroomConfig,
   agent: string,
+  source?: "schedule" | "skills",
 ): OverlayReadFailure[] {
   const agentCfg = config.agents?.[agent];
   if (!agentCfg) return [];
   const list = (agentCfg as unknown as Record<symbol, unknown>)[
     OVERLAY_READ_FAILURES
   ] as OverlayReadFailure[] | undefined;
-  return Array.isArray(list) ? list : [];
+  const all = Array.isArray(list) ? list : [];
+  return source ? all.filter((f) => f.source === source) : all;
 }
 
 /**
@@ -192,6 +209,7 @@ function readOverlayFile(
   file: string,
   agentCfg: object,
   warnings: OverlayWarning[],
+  source: "schedule" | "skills",
 ): string | undefined {
   try {
     return readFileSync(file, "utf-8");
@@ -204,7 +222,7 @@ function readOverlayFile(
       reason: `read error: ${(err as Error).message}`,
       code: code ?? "EUNKNOWN",
     };
-    recordReadFailure(agentCfg, { file, code: w.code! });
+    recordReadFailure(agentCfg, { file, code: w.code!, source });
     warnings.push(w);
     console.warn(
       `[switchroom] overlay-loader: agent='${agentName}' file='${file}': ${w.reason}`,
@@ -302,7 +320,7 @@ export function applyAgentOverlays(config: SwitchroomConfig): ApplyOverlaysResul
           reason: `read error: cannot list overlay directory (${code})`,
           code,
         };
-        recordReadFailure(agentCfg, { file: scheduleDir, code });
+        recordReadFailure(agentCfg, { file: scheduleDir, code, source: "schedule" });
         warnings.push(w);
         console.warn(
           `[switchroom] overlay-loader: agent='${agentName}' file='${scheduleDir}': ${w.reason}`,
@@ -326,7 +344,7 @@ export function applyAgentOverlays(config: SwitchroomConfig): ApplyOverlaysResul
       const merged: ScheduleEntry[] = [...(agentCfg.schedule ?? [])];
 
       for (const file of files) {
-        const raw = readOverlayFile(agentName, file, agentCfg, warnings);
+        const raw = readOverlayFile(agentName, file, agentCfg, warnings, "schedule");
         if (raw === undefined) continue;
         try {
           const parsed = parseYaml(raw);
@@ -398,7 +416,7 @@ export function applyAgentOverlays(config: SwitchroomConfig): ApplyOverlaysResul
           reason: `read error: cannot list overlay directory (${code})`,
           code,
         };
-        recordReadFailure(agentCfg, { file: skillsDir, code });
+        recordReadFailure(agentCfg, { file: skillsDir, code, source: "skills" });
         warnings.push(w);
         console.warn(
           `[switchroom] overlay-loader: agent='${agentName}' file='${skillsDir}': ${w.reason}`,
@@ -416,7 +434,7 @@ export function applyAgentOverlays(config: SwitchroomConfig): ApplyOverlaysResul
       const seen = new Set(merged);
 
       for (const file of skillFiles) {
-        const raw = readOverlayFile(agentName, file, agentCfg, warnings);
+        const raw = readOverlayFile(agentName, file, agentCfg, warnings, "skills");
         if (raw === undefined) continue;
         try {
           const parsed = parseYaml(raw);


### PR DESCRIPTION
## What & why

Follow-up to #4371. The strict scheduler loader (`loadAgentEntriesStrict`) throws on any overlay read failure so an unreadable/mid-write `schedule.d` overlay **freezes** the live schedule rather than silently unregistering a live cron — the correct fail-safe from the clerk EACCES incident (#4371).

The bug (#4373): `overlayReadFailures` was agent-wide, so an unreadable **`skills.d`** overlay — unrelated to the schedule — also tripped the throw and froze **all** cron hot-reloads. A skills permission problem should never stop cron reloads.

## Fix

- Tag each read failure with its overlay class: new `source: "schedule" | "skills"` field on `OverlayReadFailure` (`src/config/overlay-loader.ts`).
- `overlayReadFailures(config, agent, source?)` filters by it; omit `source` for all failures (back-compatible).
- The scheduler's strict guard and boot warning (`src/agent-scheduler/index.ts`) pass `"schedule"`.

Net effect: an unreadable `skills.d` overlay still **warns** (the loader's per-file `console.warn`) but no longer freezes cron reloads. The `schedule.d` fail-safe is unchanged.

## Test (RED on main, GREEN with fix)

- `src/agent-scheduler/hot-reload.test.ts` — OUTCOME test "an unreadable skills.d overlay does NOT freeze schedule reloads (#4373)": with a chmod-000 `skills.d` overlay present, a newly-added `schedule.d` cron is expected to register on the next reload. Verified RED on pristine `origin/main` (the skills.d failure throws → `createScheduleReloader` onError freezes → the new cron never registers) and GREEN with the fix. Requires a non-root uid (chmod-000 can't block root; guarded by the repo's existing `skipIf(runningAsRoot)`).
- `src/config/overlay-loader.test.ts` — unit test asserting `source`-scoped filtering.

Scoped vitest: 48 passed, 0 skipped under uid 1000. Full `src` `tsc --noEmit` clean.

Closes #4373

🤖 Generated with [Claude Code](https://claude.com/claude-code)