### PR TITLE
fix(telegram): route caller-supplied reply anchors through parseSourceMessageId (#4368)

### DIFF
--- a/telegram-plugin/ask-user.ts
+++ b/telegram-plugin/ask-user.ts
@@ -21,6 +21,7 @@
  */
 
 import { randomBytes } from 'crypto'
+import { parseSourceMessageId } from './gateway/source-message-id.js'
 
 /** Default TTL when caller doesn't pass timeout_ms. 5 min. */
 export const ASK_USER_DEFAULT_TIMEOUT_MS = 300_000
@@ -99,13 +100,11 @@ export function validateAskUserArgs(args: AskUserArgs): ValidatedAskUserArgs {
       throw new Error('ask_user: message_thread_id must be a positive integer string')
     }
   }
-  let replyTo: number | undefined
-  if (args.reply_to != null) {
-    replyTo = Number(args.reply_to)
-    if (!Number.isFinite(replyTo) || replyTo <= 0) {
-      throw new Error('ask_user: reply_to must be a positive integer string')
-    }
-  }
+  // #4368 — route the agent-supplied reply anchor through the canonical
+  // guard. A fabricated (synthetic / out-of-int32) message id yields null so
+  // the ask_user prompt sends UNANCHORED rather than 400ing the whole send on
+  // `reply_parameters.message_id` (Telegram hard-rejects an out-of-range id).
+  const replyTo = parseSourceMessageId(args.reply_to) ?? undefined
   // Clamp timeout: floor to 5s, ceiling to 30min, default 5min.
   let timeoutMs = args.timeout_ms ?? ASK_USER_DEFAULT_TIMEOUT_MS
   if (typeof timeoutMs !== 'number' || !Number.isFinite(timeoutMs)) {

--- a/telegram-plugin/gateway/checklist-fallback.ts
+++ b/telegram-plugin/gateway/checklist-fallback.ts
@@ -33,6 +33,8 @@
  * (same pattern as checklist-message-handler.ts).
  */
 
+import { parseSourceMessageId } from './source-message-id.js'
+
 export interface ChecklistTaskState {
   /** 1-based sequential id assigned at send time (mirrors the native API's
    *  required per-task integer id; doubles as the patch handle in text mode). */
@@ -130,6 +132,11 @@ export function buildNativeChecklistPayload(p: {
   replyToMessageId?: number
   protectContent?: boolean
 }): Record<string, unknown> {
+  // #4368 — defense at the payload boundary: a fabricated / out-of-int32
+  // reply anchor is dropped here so the native checklist sends UNANCHORED
+  // rather than Telegram 400ing on `reply_parameters.message_id`. Independent
+  // of any caller-side guard so this builder can never emit a bad anchor.
+  const replyAnchor = parseSourceMessageId(p.replyToMessageId)
   return {
     business_connection_id: p.businessConnectionId,
     chat_id: p.chatId,
@@ -137,7 +144,7 @@ export function buildNativeChecklistPayload(p: {
       title: p.title,
       tasks: p.tasks.map((t) => ({ id: t.id, text: t.text })),
     },
-    ...(p.replyToMessageId != null ? { reply_parameters: { message_id: p.replyToMessageId } } : {}),
+    ...(replyAnchor != null ? { reply_parameters: { message_id: replyAnchor } } : {}),
     ...(p.protectContent === true ? { protect_content: true } : {}),
   }
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -11917,7 +11917,7 @@ async function executeSendChecklist(args: Record<string, unknown>): Promise<{ co
   const tasks = args.tasks as Array<{ text: string; done?: boolean }> | undefined
   if (!Array.isArray(tasks) || tasks.length === 0) throw new Error('send_checklist: tasks must be a non-empty array')
   const threadId = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
-  const replyTo = args.reply_to != null ? Number(args.reply_to) : undefined
+  const replyTo = parseSourceMessageId(args.reply_to as string | number | null | undefined) ?? undefined // #4368: drop a fabricated/out-of-int32 anchor so the send lands unanchored, not 400
   const protectContent = args.protect_content === true
 
   assertAllowedChat(chat_id)

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -73,6 +73,7 @@ import { getBuzzMirror } from './buzz-mirror.js'
 import { isFinalAnswerReply, isSubstantiveFinalReply, shouldJournalReplySiteDelivery } from '../final-answer-detect.js'
 import { decideOverPing, type OverPingDecision } from '../over-ping-safety-net.js'
 import { decideSilentReplyAnchor } from '../silent-reply-anchor.js'
+import { parseSourceMessageId } from './source-message-id.js'
 import {
   decideSupersedeCorrection,
   flushedAnswerMatchesReply,
@@ -1343,7 +1344,14 @@ export async function sendReply(
 
   const files = (args.files as string[] | undefined) ?? []
   const quoteOptIn = args.quote !== false
-  let reply_to = args.reply_to != null ? Number(args.reply_to) : undefined
+  // #4368 — the model's reply tool can quote a synthetic inbound (a boot-
+  // resume/handback/cron fabricated id at `Date.now()` scale). Route it through
+  // the canonical guard so an out-of-int32 anchor is DROPPED (send lands
+  // unanchored) rather than 400ing every chunk on `reply_parameters.message_id`.
+  // A later `reply_to = latest` (quote-opt-in default) is a Telegram-returned
+  // id and needs no re-check. Also closes the pre-existing NaN hole: a non-
+  // numeric `reply_to` used to coerce to NaN and still build the anchor.
+  let reply_to = parseSourceMessageId(args.reply_to as string | number | null | undefined) ?? undefined
   const protectContent = args.protect_content === true
   const quoteText = args.quote_text as string | undefined
   const access = loadAccess()

--- a/telegram-plugin/sticker-aliases.ts
+++ b/telegram-plugin/sticker-aliases.ts
@@ -18,6 +18,8 @@
  * surface uses: trust-by-explicit-listing.
  */
 
+import { parseSourceMessageId } from './gateway/source-message-id.js'
+
 export interface StickerAliasMap {
   /** alias name → Telegram file_id. Both validated on read. */
   [alias: string]: string
@@ -132,13 +134,12 @@ export function resolveStickerSendArgs(
       throw new Error('send_sticker: message_thread_id must be a positive integer string')
     }
   }
-  let replyTo: number | undefined
-  if (raw.reply_to != null) {
-    replyTo = Number(raw.reply_to)
-    if (!Number.isFinite(replyTo) || replyTo <= 0) {
-      throw new Error('send_sticker: reply_to must be a positive integer string')
-    }
-  }
+  // #4368 — route the agent-supplied reply anchor through the canonical
+  // guard. A fabricated (synthetic / out-of-int32) message id — e.g. an agent
+  // echoing a boot-resume/handback inbound's `Date.now()`-scale id — yields
+  // null, so the sticker sends UNANCHORED rather than 400ing the whole send on
+  // `reply_parameters.message_id` (which Telegram hard-rejects out of range).
+  const replyTo = parseSourceMessageId(raw.reply_to) ?? undefined
 
   return {
     chatId: raw.chat_id,
@@ -230,13 +231,10 @@ export function resolveGifSendArgs(raw: GifSendArgs): ValidatedGifSendArgs {
       throw new Error('send_gif: message_thread_id must be a positive integer string')
     }
   }
-  let replyTo: number | undefined
-  if (raw.reply_to != null) {
-    replyTo = Number(raw.reply_to)
-    if (!Number.isFinite(replyTo) || replyTo <= 0) {
-      throw new Error('send_gif: reply_to must be a positive integer string')
-    }
-  }
+  // #4368 — route the agent-supplied reply anchor through the canonical guard
+  // (see resolveStickerSendArgs). A fabricated / out-of-int32 id sends the GIF
+  // UNANCHORED instead of 400ing on `reply_parameters.message_id`.
+  const replyTo = parseSourceMessageId(raw.reply_to) ?? undefined
 
   return {
     chatId: raw.chat_id,

--- a/telegram-plugin/tests/ask-user.test.ts
+++ b/telegram-plugin/tests/ask-user.test.ts
@@ -106,6 +106,21 @@ describe('validateAskUserArgs — optional fields', () => {
     const r = validateAskUserArgs({ chat_id: '1', question: 'q', options: ['a', 'b'], reply_to: '99' })
     expect(r.replyTo).toBe(99)
   })
+
+  // #4368 — a fabricated reply anchor (a synthetic boot-resume/handback/cron
+  // inbound id at `Date.now()` scale) is out of the signed-int32 range Telegram
+  // accepts for `reply_parameters.message_id`. It must be DROPPED so the
+  // ask_user prompt still sends (unanchored) rather than 400ing the whole send.
+  // Before the fix `Number(args.reply_to)` let a 13-digit id through unchanged.
+  it('drops an out-of-int32 reply_to so the prompt sends unanchored (#4368)', () => {
+    const r = validateAskUserArgs({
+      chat_id: '1',
+      question: 'q',
+      options: ['a', 'b'],
+      reply_to: String(1_785_000_000_000),
+    })
+    expect(r.replyTo).toBeUndefined()
+  })
 })
 
 describe('validateAskUserArgs — timeout clamping', () => {

--- a/telegram-plugin/tests/checklist-fallback.test.ts
+++ b/telegram-plugin/tests/checklist-fallback.test.ts
@@ -146,6 +146,27 @@ describe('native payloads — correct Bot API 9.1 shape', () => {
     expect(JSON.stringify(payload)).not.toContain('is_completed')
   })
 
+  // #4368 — a fabricated reply anchor (a synthetic boot-resume/handback/cron
+  // inbound id at `Date.now()` scale) is out of the signed-int32 range Telegram
+  // accepts for `reply_parameters.message_id`. The builder must DROP it so the
+  // native checklist sends UNANCHORED rather than 400ing the whole send. Before
+  // the fix the builder emitted `reply_parameters.message_id` verbatim.
+  it('drops an out-of-int32 replyToMessageId — no reply_parameters (#4368)', () => {
+    const payload = buildNativeChecklistPayload({
+      businessConnectionId: 'bc1',
+      chatId: 42,
+      title: 'T',
+      tasks: buildChecklistTasks([{ text: 'a' }]),
+      replyToMessageId: 1_785_000_000_000,
+    })
+    expect(payload.reply_parameters).toBeUndefined()
+    expect(payload).toEqual({
+      business_connection_id: 'bc1',
+      chat_id: 42,
+      checklist: { title: 'T', tasks: [{ id: 1, text: 'a' }] },
+    })
+  })
+
   it('editMessageChecklist sends the FULL checklist (native edits replace it)', () => {
     const payload = buildNativeEditChecklistPayload({
       businessConnectionId: 'bc1',

--- a/telegram-plugin/tests/reply-quote-wire.test.ts
+++ b/telegram-plugin/tests/reply-quote-wire.test.ts
@@ -433,3 +433,50 @@ describe('quote_text lands on the wire as ReplyParameters.quote (a String)', () 
     expect(long.startsWith(quote)).toBe(true)
   })
 })
+
+/**
+ * #4368 — a fabricated reply anchor on the wire.
+ *
+ * The model's `reply` tool can quote a SYNTHETIC inbound: a boot-resume /
+ * subagent-handback / cron turn fabricates a `message_id` from `Date.now()`
+ * (~1.78e13). Telegram's `reply_parameters.message_id` HARD-rejects anything
+ * out of the signed-int32 range (400 `field "message_id" must be a valid
+ * Number`), and `allow_sending_without_reply` does NOT bypass that — so quoting
+ * a synthetic id used to 400 EVERY chunk of the reply, losing the answer.
+ *
+ * `executeReply` (whose body is `sendReply`) must route `args.reply_to` through
+ * `parseSourceMessageId` so an out-of-range anchor is DROPPED and the reply
+ * lands UNANCHORED. This reads what actually goes over the wire — a builder-
+ * level assertion would not catch a future opts transform re-introducing it.
+ */
+describe('synthetic reply anchor is dropped on the wire (#4368)', () => {
+  it('quoting an out-of-int32 reply_to sends UNANCHORED and still delivers', async () => {
+    const h = makeHarness()
+    const res = await sendReply(h.deps, {
+      args: {
+        chat_id: CHAT,
+        text: 'The answer must land even when the quoted inbound was synthetic.',
+        reply_to: 1_785_000_000_000,
+      },
+      turn: null,
+    })
+
+    const sends = h.sends()
+    expect(sends.length).toBeGreaterThan(0)
+    // The fabricated id never reaches the wire: no reply_parameters at all …
+    expect(h.replyParams(sends[0])).toBeUndefined()
+    // … and specifically no out-of-range message_id anywhere in the payload.
+    expect(JSON.stringify(sends[0].payload)).not.toContain('1785000000000')
+    // … and the answer actually delivered (not a failure notice).
+    expect(res.content[0]?.text ?? '').toMatch(/sent/i)
+  })
+
+  it('a real (in-range) reply_to is still honored as a quote anchor', async () => {
+    const h = makeHarness()
+    await sendReply(h.deps, {
+      args: { chat_id: CHAT, text: 'ok', reply_to: 4242 },
+      turn: null,
+    })
+    expect(h.replyParams(h.sends()[0])!).toEqual({ message_id: 4242 })
+  })
+})

--- a/telegram-plugin/tests/sticker-aliases.test.ts
+++ b/telegram-plugin/tests/sticker-aliases.test.ts
@@ -230,3 +230,46 @@ describe('resolveGifSendArgs', () => {
     expect(r.replyTo).toBe(88)
   })
 })
+
+// #4368 — a fabricated reply anchor (a synthetic boot-resume/handback/cron
+// inbound id at `Date.now()` scale, ~1.78e13) is out of the signed-int32 range
+// Telegram accepts for `reply_parameters.message_id`. It must be DROPPED at the
+// resolver boundary so the sticker/GIF still sends (unanchored) rather than the
+// agent's echoed synthetic id 400ing the whole send. Before the fix these
+// resolvers ran `Number(raw.reply_to)`, which is finite and > 0 for a 13-digit
+// timestamp, so the fabricated id passed straight through onto the wire.
+const SYNTHETIC_MESSAGE_ID = String(1_785_000_000_000)
+
+describe('resolveStickerSendArgs — synthetic reply anchor (#4368)', () => {
+  it('drops an out-of-int32 reply_to so the sticker sends unanchored', () => {
+    const r = resolveStickerSendArgs(
+      { chat_id: '1', sticker: SAMPLE_FILE_ID, reply_to: SYNTHETIC_MESSAGE_ID },
+      {},
+    )
+    expect(r.replyTo).toBeUndefined()
+  })
+
+  it('still preserves a real (in-range) reply_to', () => {
+    const r = resolveStickerSendArgs(
+      { chat_id: '1', sticker: SAMPLE_FILE_ID, reply_to: '4242' },
+      {},
+    )
+    expect(r.replyTo).toBe(4242)
+  })
+})
+
+describe('resolveGifSendArgs — synthetic reply anchor (#4368)', () => {
+  it('drops an out-of-int32 reply_to so the GIF sends unanchored', () => {
+    const r = resolveGifSendArgs({
+      chat_id: '1',
+      gif: SAMPLE_FILE_ID,
+      reply_to: SYNTHETIC_MESSAGE_ID,
+    })
+    expect(r.replyTo).toBeUndefined()
+  })
+
+  it('still preserves a real (in-range) reply_to', () => {
+    const r = resolveGifSendArgs({ chat_id: '1', gif: SAMPLE_FILE_ID, reply_to: '4242' })
+    expect(r.replyTo).toBe(4242)
+  })
+})


### PR DESCRIPTION
## What & why

Follow-up audit from #4367. `parseSourceMessageId` (`telegram-plugin/gateway/source-message-id.ts`) is the canonical guard for reply anchors: Telegram's `reply_parameters.message_id` **hard-rejects** any value outside the signed-int32 range with `400 field "message_id" must be a valid Number`, and `allow_sending_without_reply` does **not** bypass it. An agent that quotes a **synthetic** inbound — a boot-resume / subagent-handback / cron turn fabricates a `message_id` from `Date.now()` (~1.78e13) — used to 400 the whole send at every remaining caller-supplied `reply_to` site (prior instances: the resume-dark-feed incident and the queued card #4367).

## Fix

Routed each agent/caller-supplied anchor through `parseSourceMessageId` at the boundary where it enters send-opts; an out-of-range id is **dropped** and the message sends **unanchored** (the anchor is a nicety, not required):

| Site | Boundary |
|---|---|
| `sticker-aliases.ts` `resolveStickerSendArgs` + `resolveGifSendArgs` | feeds `executeSendSticker`/`executeSendGif` (gateway.ts:12767/12821) |
| `ask-user.ts` `validateAskUserArgs` | feeds gateway.ts:12660 |
| `gateway.ts:11920` `executeSendChecklist` entry | covers the text-fallback send-opts (11942) **and** the native path |
| `outbound-send-path.ts:1346` `executeReply`/`sendReply` | covers all four downstream `reply_parameters` sites (2116/2191/2228/2351); also closes a pre-existing NaN hole |
| `checklist-fallback.ts` `buildNativeChecklistPayload` | self-sanitizes so the native payload builder can never emit a bad anchor (issue site #140) |

These replace the old `Number(reply_to)` + `Number.isFinite && > 0` checks, which accepted a 13-digit synthetic id (finite, > 0) and passed it straight onto the wire.

**Contract change:** a malformed `reply_to` now drops to unanchored instead of throwing — matching the issue's intended outcome ("the send still succeeds unanchored on a fabricated id").

## Contradiction with the issue's site list

`gateway.ts:2349` (listed in the issue) is **already safe** and left unchanged: its `args.replyToMessageId` originates from `turn.sourceMessageId`, which is set via `parseSourceMessageId(ev.messageId)` (stream-render.ts:600) and passed to `deliverAnswer` at stream-render.ts:2576. Reported here rather than force-fitting a redundant guard.

## Tests (RED on pristine `origin/main`, GREEN with fix)

Per-site **outcome** tests asserting a fabricated (out-of-int32) reply anchor is dropped and the send still lands, each paired with an in-range companion asserting a real anchor is preserved:

- `telegram-plugin/tests/sticker-aliases.test.ts` — sticker + gif resolvers (bun).
- `telegram-plugin/tests/ask-user.test.ts` — validator (bun).
- `telegram-plugin/tests/checklist-fallback.test.ts` — native payload builder (vitest).
- `telegram-plugin/tests/reply-quote-wire.test.ts` — wire-level: drives the real `sendReply` against a fetch-injected grammy `Bot` and asserts no out-of-range `message_id` reaches the wire and the answer still delivers (vitest).

Verified RED on pristine `origin/main` (5 new outcome tests fail; companions pass) and GREEN with the fix. Local: `tsc --noEmit` clean, gateway line-ratchet clean (net-zero change to gateway.ts), bot-api-wrapping / bun-test-imports / test-runner-coverage clean.

Closes #4368

🤖 Generated with [Claude Code](https://claude.com/claude-code)