### PR TITLE
test(gateway): pin the 429 classify→route wiring to fireProbeOnly (#4379)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -425,9 +425,9 @@ import {
 } from '../model-unavailable.js'
 import {
   build429ClassifiedMetric,
-  classification429WarrantsCorroboration,
   classify429Detail,
   decideThrottleTier,
+  routeRateLimit429,
   throttleRetryInPlaceMaxMs,
 } from '../throttle-tier.js'
 import { createThrottleTierRunner } from './throttle-tier-wiring.js'
@@ -7828,7 +7828,7 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
       agent,
       shouldEmitCard: (a) => shouldEmitOperatorEvent(a, 'rate-limited'),
     })
-    if (classification429WarrantsCorroboration(rateLimit429Classification)) void throttleTierRunner.fireProbeOnly(agent) // #failover-429-corroborate probe-only; see fireProbeOnly docstring
+    routeRateLimit429(rateLimit429Classification, throttleTierRunner, agent) // #failover-429-corroborate probe-only seam; see routeRateLimit429 docstring
     if (surface === 'litellm-local-notice') {
       process.stderr.write(
         `telegram gateway: 429 classified litellm-proxy-local agent=${agent} — ` +

--- a/telegram-plugin/tests/throttle-tier-route-429.test.ts
+++ b/telegram-plugin/tests/throttle-tier-route-429.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the classify→route WIRING of the gateway's 429 corroboration path
+ * (#failover-429-corroborate, follow-up switchroom#4379).
+ *
+ * The pure gate `classification429WarrantsCorroboration` is already unit-tested
+ * (throttle-tier-probe-only.test.ts), and the runner's `fireProbeOnly` outcomes
+ * are pinned there too. What was NOT covered is the WIRING that connects them:
+ * the gateway callsite (gateway.ts, `handleOperatorEvent` rate-limited branch)
+ * that decides whether to invoke `throttleTierRunner.fireProbeOnly(agent)` for a
+ * given classification.
+ *
+ * gateway.ts is hard to unit-test in isolation and is under a hard line ratchet,
+ * so rather than stand up a gateway harness the decision was extracted into a
+ * pure, injectable seam — `routeRateLimit429(classification, runner, agent)` in
+ * throttle-tier.ts — which the gateway callsite now calls verbatim. These tests
+ * exercise that seam with a fake runner that records which entrypoint fired,
+ * pinning the three routing outcomes the gateway promises:
+ *
+ *   - generic-transient → routes to fireProbeOnly (the probe fires)
+ *   - litellm-local     → does NOT route to fireProbeOnly (account-inert by
+ *                         mechanism: the request never reached Anthropic)
+ *   - account-scoped    → does NOT route to fireProbeOnly (that classification
+ *                         takes its own `fire` path, not the probe)
+ */
+
+import { describe, it, expect } from 'vitest'
+import { routeRateLimit429, type RateLimit429ProbeRunner } from '../throttle-tier.js'
+
+interface FakeRunner extends RateLimit429ProbeRunner {
+  probeCalls: string[]
+}
+
+function makeFakeRunner(): FakeRunner {
+  const probeCalls: string[] = []
+  return {
+    probeCalls,
+    async fireProbeOnly(triggerAgent: string) {
+      probeCalls.push(triggerAgent)
+    },
+  }
+}
+
+describe('routeRateLimit429 — gateway classify→route wiring (switchroom#4379)', () => {
+  it('generic-transient → routes to fireProbeOnly', () => {
+    const runner = makeFakeRunner()
+    const fired = routeRateLimit429('generic-transient', runner, 'carrie')
+    expect(fired).toBe(true)
+    expect(runner.probeCalls).toEqual(['carrie'])
+  })
+
+  it('litellm-local → does NOT route to fireProbeOnly (stays account-inert)', () => {
+    const runner = makeFakeRunner()
+    const fired = routeRateLimit429('litellm-local', runner, 'carrie')
+    expect(fired).toBe(false)
+    expect(runner.probeCalls).toHaveLength(0)
+  })
+
+  it('account-scoped → does NOT route to fireProbeOnly (uses fire, not the probe)', () => {
+    const runner = makeFakeRunner()
+    const fired = routeRateLimit429('account-scoped', runner, 'carrie')
+    expect(fired).toBe(false)
+    expect(runner.probeCalls).toHaveLength(0)
+  })
+
+  it('null (not a rate-limited event) → does NOT route to fireProbeOnly', () => {
+    const runner = makeFakeRunner()
+    const fired = routeRateLimit429(null, runner, 'carrie')
+    expect(fired).toBe(false)
+    expect(runner.probeCalls).toHaveLength(0)
+  })
+})

--- a/telegram-plugin/throttle-tier.ts
+++ b/telegram-plugin/throttle-tier.ts
@@ -150,6 +150,36 @@ export function classification429WarrantsCorroboration(
 }
 
 /**
+ * Minimal runner shape the classify→route seam needs: just the PROBE-ONLY
+ * entrypoint. The full gateway `ThrottleTierRunner` satisfies it structurally,
+ * and a test can supply a fake that records the call.
+ */
+export interface RateLimit429ProbeRunner {
+  fireProbeOnly(triggerAgent: string): Promise<void>
+}
+
+/**
+ * #failover-429-corroborate — the classify→route WIRING extracted from the
+ * gateway callsite so the routing decision (not just the gate) is unit-testable
+ * without a gateway harness. Fires the runner's PROBE-ONLY entrypoint IFF the
+ * classification warrants corroboration (`generic-transient` only, per
+ * `classification429WarrantsCorroboration`); `litellm-local`, `account-scoped`,
+ * and `null` never fire it. Fire-and-forget: the runner promise is intentionally
+ * not awaited (the gateway must not block the operator-event path on a probe).
+ * Returns `true` when a probe was fired, `false` otherwise — observable in tests
+ * and unused at the gateway callsite.
+ */
+export function routeRateLimit429(
+  classification: RateLimit429Classification | null,
+  runner: RateLimit429ProbeRunner,
+  agent: string,
+): boolean {
+  if (!classification429WarrantsCorroboration(classification)) return false
+  void runner.fireProbeOnly(agent)
+  return true
+}
+
+/**
  * Build the `rate_limit_429_classified` runtime metric for one terminal
  * rate-limited operator event — the instrumentation that lets an operator
  * correlate Anthropic ACCOUNT 429s with fleet TPM (the prerequisite for


### PR DESCRIPTION
## What & why

Follow-up to #4375 (`bc098dd`). The pure gate `classification429WarrantsCorroboration` and the runner's `fireProbeOnly` outcomes are already unit-tested, but the **wiring** that connects them at the gateway callsite (`telegram-plugin/gateway/gateway.ts`, rate-limited branch) was untested — a future edit could route the wrong classification to the probe, or drop the probe, without any test going red.

## Approach — pure injectable seam (no gateway harness)

`gateway.ts` is hard to unit-test in isolation and sits **at** its line-count ratchet ceiling, so rather than stand up a gateway harness this extracts the classify→route decision into a pure, injectable function in a non-gateway module:

`routeRateLimit429(classification, runner, agent)` in `telegram-plugin/throttle-tier.ts` — internally consults `classification429WarrantsCorroboration` and, when true, invokes `runner.fireProbeOnly(agent)` (fire-and-forget, promise intentionally unawaited, byte-identical to the previous inline callsite).

The gateway callsite now calls that seam verbatim. The edit is **line-neutral**: `gateway.ts` stays at 24855 lines (ratchet 24805 + 50 slack → clean). No runtime behavior changes; `scripts/gateway-line-ratchet.txt` is untouched.

## Test — outcome assertions against the seam

`telegram-plugin/tests/throttle-tier-route-429.test.ts` drives the seam with a fake runner recording which entrypoint fired:

- `generic-transient` → routes to `fireProbeOnly` (probe fires)
- `litellm-local` → does **not** route (account-inert by mechanism)
- `account-scoped` → does **not** route (takes its own `fire` path)
- `null` → does **not** route (not a rate-limited event)

## Verification (local)

- `vitest run` on the new + existing probe-only test: 11 passed
- `tsc --noEmit`: clean
- `bun run lint` (incl. `check-gateway-line-ratchet`): clean, gateway.ts = 24855 lines

Closes #4379

🤖 Generated with [Claude Code](https://claude.com/claude-code)