### PR TITLE
fix(lint): make agent-attribution check robust to GitHub squash trailer reparagraphing

### DIFF
--- a/scripts/check-agent-attribution-trailers.mjs
+++ b/scripts/check-agent-attribution-trailers.mjs
@@ -109,29 +109,20 @@ const AGENT_VALUE_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$/
 const MODEL_VALUE_RE = /^[A-Za-z0-9][A-Za-z0-9._@:+/-]{0,99}$/
 
 /**
- * Pull the trailer block out of a raw commit message.
+ * Parse ONE paragraph (a run of non-blank lines) into trailers.
  *
- * Implemented here rather than shelling to `git interpret-trailers --parse`
- * per commit: this is a hot loop over a PR's commits and the parse is the
- * same well-defined "last paragraph of `Token: value` lines" git uses.
- * Continuation lines (leading whitespace) fold into the previous trailer.
+ * Continuation lines (leading whitespace) fold into the previous trailer, per
+ * git's own rule. Returns `null` — not `[]` — when the paragraph contains any
+ * line that is neither a `Token: value` trailer nor a continuation: that
+ * distinction is load-bearing for the caller, which treats a prose-bearing
+ * paragraph as a hard stop rather than an empty result.
  *
- * @param {string} message raw commit message (subject + body)
- * @returns {{token: string, value: string}[]}
+ * @param {string[]} block lines of a single paragraph
+ * @returns {{token: string, value: string}[] | null}
  */
-export function parseTrailers(message) {
-  const lines = String(message).replace(/\r\n/g, '\n').split('\n')
-  // Drop trailing blank lines, then walk backwards over the final block.
-  let end = lines.length
-  while (end > 0 && lines[end - 1].trim() === '') end--
-  let start = end
-  while (start > 0 && lines[start - 1].trim() !== '') start--
-  const block = lines.slice(start, end)
-  if (block.length === 0) return []
-
+function parseParagraph(block) {
   /** @type {{token: string, value: string}[]} */
   const out = []
-  let valid = true
   for (const line of block) {
     if (/^\s/.test(line) && out.length > 0) {
       // Continuation of the previous trailer.
@@ -139,16 +130,72 @@ export function parseTrailers(message) {
       continue
     }
     const m = /^([A-Za-z0-9][A-Za-z0-9-]*)\s*:\s?(.*)$/.exec(line)
-    if (!m) {
-      valid = false
-      break
-    }
+    if (!m) return null
     out.push({ token: m[1], value: m[2].trim() })
   }
-  // git only treats the final paragraph as trailers when it is entirely
-  // made of trailer lines. A stray prose line means there is no trailer
-  // block at all — which is exactly the "the hook did not run" case.
-  return valid ? out : []
+  return out
+}
+
+/**
+ * Pull the trailer block out of a raw commit message.
+ *
+ * Implemented here rather than shelling to `git interpret-trailers --parse`
+ * per commit: this is a hot loop over a PR's commits and the parse is the
+ * same well-defined "last paragraph of `Token: value` lines" git uses.
+ *
+ * GitHub's squash-merge reparagraphs trailers: it collects the
+ * `Co-authored-by:` lines and re-emits them as a SEPARATE final paragraph,
+ * split from the `Switchroom-*` trailers the source commit carried by a blank
+ * line. Reading only the final paragraph then sees the Claude co-author but
+ * not the attribution that sits one paragraph above it, and the guard reds a
+ * fully-attributed PR (issue seen on #4381's squash `bb793cb`). So when the
+ * final paragraph is entirely trailer lines, fold in each IMMEDIATELY-
+ * PRECEDING paragraph that is ITSELF entirely trailer lines, treating the run
+ * of consecutive trailer-only paragraphs as one logical trailer block.
+ *
+ * Folding STOPS at the first paragraph carrying any non-trailer (prose) line.
+ * That preserves the original "a stray prose line means the hook did not run →
+ * no trailer block" detection: a prose separator (e.g. a `---------` line, or
+ * a PR-description paragraph) between the `Switchroom-*` trailers and a
+ * `Co-authored-by: Claude` final block still isolates them, so such a commit
+ * still fails. Folding only ADDS genuinely-present adjacent trailers into
+ * view; a truly unattributed commit has nothing to fold and still fails.
+ *
+ * @param {string} message raw commit message (subject + body)
+ * @returns {{token: string, value: string}[]}
+ */
+export function parseTrailers(message) {
+  const lines = String(message).replace(/\r\n/g, '\n').split('\n')
+  // Drop trailing blank lines.
+  let end = lines.length
+  while (end > 0 && lines[end - 1].trim() === '') end--
+  if (end === 0) return []
+
+  /** @type {{token: string, value: string}[]} */
+  const folded = []
+  let cursor = end
+  let isFinal = true
+  while (cursor > 0) {
+    // Skip the blank line(s) separating this paragraph from the next.
+    let pEnd = cursor
+    while (pEnd > 0 && lines[pEnd - 1].trim() === '') pEnd--
+    if (pEnd === 0) break
+    let pStart = pEnd
+    while (pStart > 0 && lines[pStart - 1].trim() !== '') pStart--
+
+    const parsed = parseParagraph(lines.slice(pStart, pEnd))
+    if (parsed === null) {
+      // A prose-bearing paragraph. If it IS the final paragraph, git treats
+      // the message as having no trailer block at all — the "hook did not run"
+      // case. If it merely precedes a trailer-only run, it is the stop line.
+      return isFinal ? [] : folded
+    }
+    // This paragraph precedes what we have collected, so prepend it.
+    folded.unshift(...parsed)
+    cursor = pStart
+    isFinal = false
+  }
+  return folded
 }
 
 /** @param {{token: string, value: string}[]} trailers @param {string} token */

--- a/tests/agent-attribution-check.test.ts
+++ b/tests/agent-attribution-check.test.ts
@@ -252,6 +252,117 @@ describe("check-agent-attribution-trailers — green on everything it must not b
   });
 });
 
+describe("check-agent-attribution-trailers — robust to GitHub squash reparagraphing", () => {
+  // GitHub's squash-merge collects `Co-authored-by:` trailers and re-emits
+  // them as a separate final paragraph, split by a blank line from the
+  // `Switchroom-*` trailers the source commit carried. See #4381's squash
+  // bb793cb. Reading only the final paragraph misses the attribution.
+  const SQUASH_LAYOUT = [
+    "feat(x): work that got squashed",
+    "",
+    "Closes #4379",
+    "",
+    "Switchroom-Agent: klanker",
+    "Switchroom-Model: claude-opus-4-8",
+    "",
+    "Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>",
+  ].join("\n");
+
+  it("PASSES the GitHub-squash layout — Switchroom-* one paragraph above the Claude co-author", () => {
+    const f = makeFixture("attrchk-squash-pass-");
+    f.commit(SQUASH_LAYOUT);
+
+    const r = f.check();
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("check-agent-attribution-trailers: OK");
+  });
+
+  it("STILL FAILS a genuinely unattributed squash — Claude co-author, no Switchroom-* anywhere", () => {
+    // Nothing to fold: the fix only surfaces attribution that genuinely
+    // exists in an adjacent trailer-only paragraph. A bypassed hook that left
+    // only the Claude co-author still reds, exactly as before.
+    const f = makeFixture("attrchk-squash-fail-");
+    f.commit(
+      [
+        "feat(x): the hook did not run, then got squashed",
+        "",
+        "Closes #4379",
+        "",
+        "Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>",
+      ].join("\n"),
+    );
+
+    const r = f.check();
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("missing `Switchroom-Agent:` trailer");
+    expect(r.out).toContain("missing `Switchroom-Model:` trailer");
+  });
+
+  it("PASSES a human squash — non-Claude co-author, no Switchroom-* — is never machine-authored", () => {
+    const f = makeFixture("attrchk-squash-human-");
+    f.commit(
+      [
+        "fix: human work that got squashed",
+        "",
+        "Closes #4379",
+        "",
+        "Co-authored-by: Some Human <human@example.test>",
+      ].join("\n"),
+    );
+
+    const r = f.check();
+    expect(r.code).toBe(0);
+  });
+
+  it("FAILS when a prose separator isolates the Switchroom-* trailers from the Claude co-author", () => {
+    // A `---------` (or any prose line) between the two trailer paragraphs is
+    // NOT what GitHub's squash normaliser produces — it comes from a PR body
+    // bleeding into the trailers. Folding deliberately stops at prose, so the
+    // Switchroom-* block is isolated and the commit reads as machine-authored
+    // (Claude co-author in the final block) but unattributed. This preserves
+    // the original "a stray prose line means the hook block was disrupted"
+    // detection. Decision recorded in the PR body.
+    const f = makeFixture("attrchk-squash-prose-");
+    f.commit(
+      [
+        "feat(x): prose separator between trailer paragraphs",
+        "",
+        "Switchroom-Agent: klanker",
+        "Switchroom-Model: claude-opus-4-8",
+        "",
+        "---------",
+        "",
+        "Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>",
+      ].join("\n"),
+    );
+
+    const r = f.check();
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("missing `Switchroom-Agent:` trailer");
+    expect(r.out).toContain("missing `Switchroom-Model:` trailer");
+  });
+
+  it("folds across MORE than two consecutive trailer-only paragraphs", () => {
+    // Defensive: the run of trailer-only paragraphs is treated as one block
+    // however many deep, stopping only at the subject prose.
+    const f = makeFixture("attrchk-squash-multi-");
+    f.commit(
+      [
+        "feat(x): deeply reparagraphed",
+        "",
+        "Switchroom-Agent: klanker",
+        "",
+        "Switchroom-Model: claude-opus-4-8",
+        "",
+        "Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>",
+      ].join("\n"),
+    );
+
+    const r = f.check();
+    expect(r.code).toBe(0);
+  });
+});
+
 describe("check-agent-attribution-trailers — wiring", () => {
   it("is part of `npm run lint`", () => {
     const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf-8"));


### PR DESCRIPTION
## Summary

`scripts/check-agent-attribution-trailers.mjs` was parsing trailers from **only the final paragraph** of a commit message (`parseTrailers`, ~L112-152: "last paragraph of `Token: value` lines"). That is not robust to GitHub's squash-merge output, and it was silently blocking agent-authored PRs from merging through the merge queue.

## Why (mechanism, confirmed from live squashes)

GitHub's squash-merge **reparagraphs** trailers: it collects the `Co-authored-by:` lines and re-emits them as a *separate final paragraph*, split by a blank line from the `Switchroom-*` trailers the source commit carried:

```
...
Closes #4379


Switchroom-Agent: klanker
Switchroom-Model: claude-opus-4-8

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>
```

- `isMachineAuthored` returns true because the last paragraph has a `Co-authored-by: Claude` trailer.
- But `Switchroom-Agent`/`Switchroom-Model` sit in the paragraph *above* the blank line, so the last-paragraph-only parse never sees them → the check reports **FAIL** and the merge-queue bot evicts the PR. Repeats forever.

**The luck contrast.** This guard has been passing *vacuously*, not correctly:
- **#4381** squash `bb793cb` ended with `Co-authored-by: Claude ...` → `isMachineAuthored` true, `Switchroom-*` split into an earlier paragraph → **FAIL** (the bug).
- **#4375** squash `bc098dd` ended with `Co-authored-by: klanker <klanker@local>` (does NOT match `/claude|anthropic/i`) → `isMachineAuthored` false → the guard skipped it — even though its `Switchroom-*` trailers were *also* split into an earlier paragraph. It passed only because the final co-author happened not to name Claude.

## Fix

When the final paragraph is entirely trailer lines, fold in each **immediately-preceding paragraph that is itself entirely trailer lines** (separated from the final block by only blank lines), treating the run of consecutive trailer-only paragraphs as one logical trailer block. Folding **stops at the first paragraph containing any non-trailer (prose) line**.

This is safe, not a loophole:
- Folding only **adds** `Switchroom-*` trailers into view when they genuinely exist in an adjacent trailer-only paragraph.
- A truly unattributed bypassed-hook commit (only `Co-authored-by: Claude`, no `Switchroom-*` anywhere) still has nothing to fold and still **FAILS**.
- A human laptop commit (no Claude co-author) is still never machine-authored and is never blocked.

The "a stray prose line means the hook did not run → no trailer block" detection (original ~L148-152) is preserved: it is exactly the fold stop condition.

## Decision: the prose-separator (`---------`) case

**Such a commit FAILS, deliberately.** #4375's real squash carried a `---------` line between the `Switchroom-*` paragraph and the `Co-authored-by` paragraph. GitHub's squash *normaliser* does **not** emit `---------` between trailer blocks — that separator comes from a PR **body/description** bleeding into the trailer region, i.e. human-authored content interleaving the machine trailers. Treating a prose line as a hard stop is the conservative, correct call: it keeps the original hook-disruption detection intact rather than reaching across arbitrary prose to rescue attribution. A test pins this outcome.

## Test plan

`tests/agent-attribution-check.test.ts` — real git repos, real commits, real script as a subprocess, asserting exit codes:
1. **GitHub-squash layout** (`Switchroom-*` one paragraph above the Claude co-author) → **PASSES** (was FAIL before the fix).
2. **Genuinely unattributed squash** (Claude co-author, no `Switchroom-*` anywhere) → **still FAILS**.
3. **Human squash** (non-Claude co-author, no `Switchroom-*`) → **PASSES** (never machine-authored).
4. **Prose separator** (`---------`) between the two trailer paragraphs → **FAILS** (hook-disruption detection preserved).
5. **Multi-paragraph fold** (>2 consecutive trailer-only paragraphs) → **PASSES**.

Verified 1 and 5 fail on pre-fix code and pass after; 2/3/4 pass on both (they pin intended semantics that don't depend on folding). Full `npm run lint` (tsc + all guard scripts) is green locally, and this PR's own commit passes the attribution check.

## Risk

Low. Single-concern: the check-script parse + its tests. No behavior change for correctly-formatted single-paragraph trailer blocks; the guard's intent (block unattributed machine commits, never block humans) is unchanged and re-pinned by tests.

Unblocks #4381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)