### PR TITLE
test(gateway): guard the 429 route-seam callsite (L1/L2 follow-up to #4381)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -7828,7 +7828,7 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
       agent,
       shouldEmitCard: (a) => shouldEmitOperatorEvent(a, 'rate-limited'),
     })
-    routeRateLimit429(rateLimit429Classification, throttleTierRunner, agent) // #failover-429-corroborate probe-only seam; see routeRateLimit429 docstring
+    routeRateLimit429(rateLimit429Classification, throttleTierRunner, agent) // #failover-429-corroborate probe-only seam; boolean return is for test observability (throttle-tier-route-429.test.ts), intentionally discarded here — see docstring
     if (surface === 'litellm-local-notice') {
       process.stderr.write(
         `telegram gateway: 429 classified litellm-proxy-local agent=${agent} — ` +

--- a/telegram-plugin/tests/throttle-tier-route-429-wiring.test.ts
+++ b/telegram-plugin/tests/throttle-tier-route-429-wiring.test.ts
@@ -1,0 +1,92 @@
+/**
+ * L1 SEAM-BOUNDARY GUARD for the 429 classify→route wiring (follow-up to
+ * switchroom#4381 / #4379).
+ *
+ * `throttle-tier-route-429.test.ts` proves the ROUTING LOGIC of the pure seam
+ * `routeRateLimit429` in isolation (generic-transient → fireProbeOnly;
+ * litellm-local / account-scoped / null → no probe). But nothing asserted that
+ * the GATEWAY still calls that seam at its 429-handling path. That is the exact
+ * gap the extraction opened: a future edit deleting the gateway callsite
+ * (gateway.ts, `emitGatewayOperatorEvent` rate-limited calm branch) would
+ * silently drop the corroboration probe for every `generic-transient` 429 —
+ * a real 5h/7d wall hiding behind transient wording would again die with no
+ * failover — while the seam's own unit suite stayed fully green.
+ *
+ * gateway.ts is a side-effecting IIFE that cannot be imported in a unit test
+ * (same constraint documented in turn-flush-suppression-wiring.test.ts /
+ * activity-card-wiring.test.ts): `emitGatewayOperatorEvent` is a module-scoped,
+ * un-exported function reachable only after the gateway boots. So an
+ * outcome-level "drive emitGatewayOperatorEvent and observe fireProbeOnly" test
+ * is infeasible without exporting internal gateway state — scope creep the
+ * repo deliberately avoids. Following the established wiring-guard pattern,
+ * this is a STRUCTURAL assertion that pins the load-bearing call site. It
+ * COMPLEMENTS the seam suite: the routing outcomes are proven there; this
+ * guards that the gateway actually routes through them.
+ *
+ * The outcome that flips on the regression: with the callsite present, a
+ * `generic-transient` 429 reaches `routeRateLimit429(..., throttleTierRunner,
+ * agent)` and fires the probe on the REAL runner; delete or neuter the
+ * callsite and these assertions go red. Verified fails-red by deleting
+ * gateway.ts:7831 locally (see PR body).
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const gatewaySrc = readFileSync(resolve(__dirname, '..', 'gateway', 'gateway.ts'), 'utf-8')
+
+function between(src: string, startMarker: string, endMarker: string): string {
+  const after = src.split(startMarker)[1] ?? ''
+  return after.split(endMarker)[0] ?? ''
+}
+
+/** Strip comment lines so prose (a docstring mentioning the call, or a comment
+ *  describing the OLD shape) can neither satisfy nor trip an assertion about
+ *  the actual CODE. */
+function codeOnly(src: string): string {
+  return src
+    .split('\n')
+    .filter((l) => !l.trim().startsWith('//'))
+    .filter((l) => !l.trim().startsWith('*') && !l.trim().startsWith('/*'))
+    .join('\n')
+}
+
+describe('429 route-seam wiring — the gateway calls routeRateLimit429 (switchroom#4381 L1)', () => {
+  // The calm-429 branch: from the classification binding through the surface
+  // decision that immediately follows the seam call.
+  const branch = between(
+    gatewaySrc,
+    'const rateLimit429Classification =',
+    "if (surface === 'litellm-local-notice')",
+  )
+
+  it('the calm-429 branch routes the classification through routeRateLimit429', () => {
+    expect(branch.length).toBeGreaterThan(100)
+    const code = codeOnly(branch)
+    // The load-bearing call site. Deleting it drops the corroboration probe for
+    // every generic-transient 429 with the seam's unit suite still green — the
+    // exact regression this guard exists to catch.
+    expect(code).toMatch(/routeRateLimit429\(/)
+    // It must be fed the CLASSIFICATION computed for this event, not a literal
+    // or a stale variable — otherwise the wrong family would (not) be probed.
+    expect(code).toMatch(
+      /routeRateLimit429\(\s*rateLimit429Classification\s*,/,
+    )
+  })
+
+  it('the seam is handed the REAL throttleTierRunner (a live probe, not a no-op)', () => {
+    const code = codeOnly(branch)
+    // Passing anything other than the gateway's real runner (e.g. a stub) would
+    // make the probe fire into the void — the branch outcome would look correct
+    // in a naive grep but corroborate nothing.
+    expect(code).toMatch(
+      /routeRateLimit429\(\s*rateLimit429Classification\s*,\s*throttleTierRunner\s*,\s*agent\s*\)/,
+    )
+  })
+
+  it('routeRateLimit429 is imported into the gateway (the seam is actually linked)', () => {
+    // A dangling call to an unimported symbol would fail tsc, but pinning the
+    // import makes the dependency edge explicit and its removal a red test too.
+    expect(codeOnly(gatewaySrc)).toMatch(/\brouteRateLimit429\b/)
+  })
+})


### PR DESCRIPTION
Two low-severity follow-ups to #4381 (the 429 classify→route seam), in one focused PR.

## L1 (the real one) — seam-boundary coverage gap
`throttle-tier-route-429.test.ts` pins the ROUTING LOGIC of the pure `routeRateLimit429` seam, but nothing asserted the gateway still *calls* it. A future edit deleting the gateway callsite (`gateway.ts` `emitGatewayOperatorEvent` rate-limited calm branch, the `routeRateLimit429(...)` at the seam) would silently drop the corroboration probe for every `generic-transient` 429 — a genuine 5h/7d wall behind transient wording would again die with no failover — while the seam's own unit suite stayed fully green.

**Why structural, not outcome-level.** `gateway.ts` is a side-effecting IIFE; its 429 handler `emitGatewayOperatorEvent` is a module-scoped, un-exported function reachable only after the gateway boots. Driving it in a unit test to observe `fireProbeOnly` would require exporting internal gateway state — scope creep the repo deliberately avoids (documented in `turn-flush-suppression-wiring.test.ts` / `activity-card-wiring.test.ts`). So `throttle-tier-route-429-wiring.test.ts` follows the established **wiring-guard** pattern: it isolates the calm-429 branch of `gateway.ts` and asserts the load-bearing callsite `routeRateLimit429(rateLimit429Classification, throttleTierRunner, agent)` is present, fed the event's classification, and handed the **real** `throttleTierRunner` (not a stub that would probe into the void). It complements the seam suite — routing outcomes proven there, the gateway's routing-*through* pinned here.

**What it asserts and fails-red proof.** With the callsite present, a `generic-transient` 429 reaches `routeRateLimit429(..., throttleTierRunner, agent)` and fires the probe on the real runner; delete/neuter the callsite and the guard goes red. Verified locally by deleting `gateway.ts:7831` — 2 of the 3 assertions (the branch-level ones) fail; the 3rd is a secondary import guard. Restored, all green.

## L2 (cosmetic) — unused boolean return → route (b)
`routeRateLimit429` returns `boolean` consumed only by tests; the gateway discards it intentionally (test observability of the routing decision). Route **(b)**: no consumer adds value within the gateway line ratchet — `gateway.ts` sits exactly at the ceiling (`24855 = 24805 + 50 slack`), so route (a)'s debug-log would trip the ratchet, and a fabricated consumer would be worse than the discard. Kept the return; made the intent explicit in the callsite comment (the definition docstring in `throttle-tier.ts` already documents "observable in tests and unused at the gateway callsite"). Repo lint is `tsc --noEmit` + custom scripts — **no ESLint** — so no `no-unused-expressions`/`no-void` rule flags the discard. The edit is **line-neutral**: `gateway.ts` stays at 24855.

## Validation
- `throttle-tier-route-429-wiring.test.ts` (3) + `throttle-tier-route-429.test.ts` (4): **7 passed**.
- Fails-red confirmed by removing `gateway.ts:7831` locally.
- `tsc --noEmit`: clean.
- `check-gateway-line-ratchet.mjs`: clean (24855 lines, ratchet 24805, slack 50). CLAUDE.md byte-ratchet untouched.

Follow-up to #4381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)