### PR TITLE
fix(telegram/render): escape glued `#` after list/blockquote markers and boundary-flanked `*` (#3464)

### DIFF
--- a/telegram-plugin/render/emphasis-guard.ts
+++ b/telegram-plugin/render/emphasis-guard.ts
@@ -34,19 +34,38 @@
 // `__x__` double runs are excluded for free: the inner neighbour of each `*`
 // in `a**b` is another `*` (not alphanumeric), so neither half matches.
 //
+// A SECOND, always-safe arm (added for issue #3464 alongside the line-start
+// glued-`#` guard) escapes a `*` that is flanked by WHITESPACE OR A STRING
+// BOUNDARY on BOTH immediate sides (`a * b`, ` * `, a bare `*`, a trailing
+// `rm *`). Under GFM flanking rules such a `*` is neither left- nor right-
+// flanking, so it can NEVER open OR close emphasis; escaping it therefore
+// cannot break an intended `*italic*` / `**bold**` (whose delimiters are
+// word-adjacent on their INNER side, so never whitespace-flanked on both
+// sides). Because this `*` can never pair, the arm fires on a single
+// occurrence — it needs no 2+ threshold. Live Telegram UAT for #3464 confirmed
+// the non-spec Bot API parser can still surface a stray lone `*` in this
+// position, so neutralising it deterministically is the durable fix.
+//
+// The ONE boundary-flanked position this arm must NOT touch is a line-leading
+// `* ` — that is an unordered-list BULLET (`* item`), not an inert operator.
+// Escaping it would break `*`-bullets on every outbound message AND (because
+// this arm runs before `guardAccidentalHeading`) disarm the glued-`#` fix for
+// `* #4382`. See `isLineLeadingBullet`. A lone `*` on its own line has no
+// trailing space, is not a bullet, and is still escaped.
+//
 // What we DELIBERATELY LEAVE ALONE (conservative false-negatives, per the
 // "when in doubt, leave it" doctrine inherited from the dollar guard):
-//   - Space-flanked operators (`3 * 4`): a whitespace-flanked `*`/`_` is
-//     neither left- nor right-flanking under GFM, so it can never open or
-//     close emphasis — there is no bug to fix, and escaping it would be pure
-//     churn.
-//   - Boundary-flanked delimiters (`rm *`, `*.ts`, leading-`_` `_private`):
-//     these are INDISTINGUISHABLE from an intended `*glob*` / `_italic_`
-//     opener (`*.ts is a glob*` is a legitimate italic). Escaping them would
-//     risk breaking intended emphasis — the one thing this guard must never
-//     do — so a glob/leading-underscore that pairs into an accidental span is
-//     accepted as a rare false-negative rather than risked as a false-positive.
-//     (A future arm could target these behind live Telegram UAT; see below.)
+//   - Boundary-flanked delimiters with a NON-whitespace neighbour on the other
+//     side (`*.ts`, leading-`_` `_private`): these are INDISTINGUISHABLE from
+//     an intended `*glob*` / `_italic_` opener (`*.ts is a glob*` is a
+//     legitimate italic). Escaping them would risk breaking intended emphasis —
+//     the one thing this guard must never do — so a glob/leading-underscore
+//     that pairs into an accidental span is accepted as a rare false-negative
+//     rather than risked as a false-positive. (The whitespace-on-BOTH-sides
+//     form `rm *` is NOT in this class — a `*` with whitespace/boundary on both
+//     sides is provably inert, so the new arm above escapes it safely.)
+//     `_` in this position is likewise left alone; the boundary-flanked arm is
+//     `*`-only.
 //
 // Idempotent: the escape is expressed as an intra-word match, so an
 // already-escaped `\_`/`\*` has a backslash (not an alphanumeric) immediately
@@ -91,6 +110,47 @@ const INTRA_WORD_UNDERSCORE = /(?<=[A-Za-z0-9])_(?=[A-Za-z0-9])/g;
  *  neighbour is `*` (not alnum). Idempotent for the same reason as above. */
 const INTRA_WORD_ASTERISK = /(?<=[A-Za-z0-9])\*(?=[A-Za-z0-9])/g;
 
+/** A `*` flanked by WHITESPACE OR A STRING BOUNDARY on BOTH immediate sides
+ *  (`a * b`, ` * `, a bare `*`, `rm *`). Neither left- nor right-flanking under
+ *  GFM, so it can never open or close emphasis — escaping it is always safe and
+ *  can never touch an intended `*italic*` / `**bold**` (word-adjacent on the
+ *  inner side). Idempotent: after escaping, the `*` is preceded by `\` (neither
+ *  whitespace nor `^`), so the lookbehind no longer matches. `\n` is whitespace,
+ *  so a `*` alone on its own line is covered without a multiline flag.
+ *
+ *  CRITICAL EXCLUSION — a line-leading `* ` is an unordered-LIST BULLET, not an
+ *  inert operator, and MUST NOT be escaped (`isLineLeadingBullet` below). Two
+ *  reasons: (a) `*`-bullets are extremely common in replies and escaping the
+ *  marker would break the list on EVERY outbound message (an asymmetric
+ *  regression — `-`/`+` bullets are untouched); (b) this guard runs BEFORE
+ *  `guardAccidentalHeading` in the `guardAccidentalFormatting` pipeline
+ *  (rich-send.ts), and the heading guard's `ACCIDENTAL_HEADING_AFTER_MARKER`
+ *  needs the LITERAL `*` marker to fire — escaping the marker here would silently
+ *  disarm the glued-`#` fix for the `* #4382` case (#3464). A lone `*` on its own
+ *  line (`\n*\n`) is NOT a bullet — no trailing space — so it is still escaped. */
+const BOUNDARY_FLANKED_ASTERISK = /(?<=^|\s)\*(?=\s|$)/g;
+
+/** True iff the `*` at `starIndex` is a line-leading unordered-list bullet: a
+ *  line start (string start or after `\n`) + up to 3 spaces/tabs of indent, then
+ *  the `*`, then a space/tab. This is the ONE boundary-flanked position we leave
+ *  alone (see BOUNDARY_FLANKED_ASTERISK). Note: a segment that begins mid-line
+ *  (right after an inline code span) has its start treated as a line start here,
+ *  which errs toward PRESERVING an ambiguous leading `*` — the safe direction,
+ *  since wrongly escaping a bullet is the failure this exclusion exists to stop. */
+function isLineLeadingBullet(text: string, starIndex: number): boolean {
+  // A bullet requires a space/tab immediately after the marker.
+  const next = text[starIndex + 1];
+  if (next !== " " && next !== "\t") return false;
+  // Walk left over up to 3 indent spaces/tabs; the run must reach a line start.
+  let i = starIndex - 1;
+  let indent = 0;
+  while (i >= 0 && (text[i] === " " || text[i] === "\t")) {
+    if (++indent > 3) return false;
+    i--;
+  }
+  return i < 0 || text[i] === "\n";
+}
+
 /** Every unescaped `_` / `*` in prose (the pair-threshold input). An emphasis
  *  span needs a MATCHING pair of the same delimiter, so a delimiter can only
  *  mis-render when 2+ of it exist. The `(?<!\\)` keeps the count idempotent. */
@@ -129,22 +189,37 @@ export function guardAccidentalEmphasis(text: string): string {
   // 2+ of that delimiter exist (so a pair — hence a mis-render — is possible).
   let hasIntraUnderscore = false;
   let hasIntraAsterisk = false;
+  let hasBoundaryAsterisk = false;
   let underscoreCount = 0;
   let asteriskCount = 0;
   for (const seg of segments) {
     if (seg.code) continue;
     if (INTRA_WORD_UNDERSCORE.test(seg.text)) hasIntraUnderscore = true;
     if (INTRA_WORD_ASTERISK.test(seg.text)) hasIntraAsterisk = true;
+    // Arm only on a boundary-flanked `*` that is NOT a line-leading bullet, so a
+    // segment whose only such `*` is a bullet keeps the guard a strict no-op.
+    if (!hasBoundaryAsterisk) {
+      for (const m of seg.text.matchAll(BOUNDARY_FLANKED_ASTERISK)) {
+        if (!isLineLeadingBullet(seg.text, m.index ?? 0)) {
+          hasBoundaryAsterisk = true;
+          break;
+        }
+      }
+    }
     underscoreCount += seg.text.match(ANY_UNDERSCORE)?.length ?? 0;
     asteriskCount += seg.text.match(ANY_ASTERISK)?.length ?? 0;
   }
   // Reset lastIndex — the /g regexes above are stateful across .test() calls.
   INTRA_WORD_UNDERSCORE.lastIndex = 0;
   INTRA_WORD_ASTERISK.lastIndex = 0;
+  BOUNDARY_FLANKED_ASTERISK.lastIndex = 0;
 
   const armUnderscore = hasIntraUnderscore && underscoreCount >= 2;
   const armAsterisk = hasIntraAsterisk && asteriskCount >= 2;
-  if (!armUnderscore && !armAsterisk) return text;
+  // The boundary-flanked `*` can NEVER pair (neither flanking), so no 2+
+  // threshold: a single occurrence is escaped on its own.
+  const armBoundaryAsterisk = hasBoundaryAsterisk;
+  if (!armUnderscore && !armAsterisk && !armBoundaryAsterisk) return text;
 
   return segments
     .map((seg) => {
@@ -152,6 +227,11 @@ export function guardAccidentalEmphasis(text: string): string {
       let out = seg.text;
       if (armUnderscore) out = out.replace(INTRA_WORD_UNDERSCORE, "\\_");
       if (armAsterisk) out = out.replace(INTRA_WORD_ASTERISK, "\\*");
+      if (armBoundaryAsterisk) {
+        out = out.replace(BOUNDARY_FLANKED_ASTERISK, (m, offset: number, str: string) =>
+          isLineLeadingBullet(str, offset) ? m : "\\*",
+        );
+      }
       return out;
     })
     .join("");

--- a/telegram-plugin/render/line-start-guard.ts
+++ b/telegram-plugin/render/line-start-guard.ts
@@ -187,13 +187,38 @@ export function guardAccidentalBlockConstructs(text: string): string {
  *  `#{1,6}` no longer sits at the (post-indent) line start. */
 const ACCIDENTAL_HEADING = /^([ \t]{0,3})(#{1,6})(?=[^\s#])/;
 
+/** Same accidental-heading run, but sitting AFTER one or more line-start LIST or
+ *  BLOCKQUOTE markers on the SAME line (`- #4382`, `* #4382`, `+ #4382`,
+ *  `1. #4382`, `> #4382`, and nested combinations like `- > #4382`) — issue
+ *  #3464. `guardAccidentalHeading`'s original `^`-anchored pattern only sees a
+ *  `#` at the true (post-indent) line start, so a `#` glued after a marker slips
+ *  through and Telegram's non-spec Bot API parser promotes it to a heading just
+ *  as it does at a bare line start (confirmed by live UAT for #3464). The prefix
+ *  is `([ \t]{0,3}<marker>+)`: up to 3 leading spaces, then one-or-more markers,
+ *  each an unordered bullet (`-`/`*`/`+`) or short ordered marker (`1.`/`1)`,
+ *  1–3 digits) followed by ≥1 space/tab, or a blockquote `>` with optional
+ *  spaces. Group 1 captures the WHOLE prefix so the replacement re-emits it
+ *  verbatim and escapes ONLY the first `#` of group 2. The same `(?=[^\s#])`
+ *  lookahead keeps a real nested heading (`- # Heading`, space AFTER the `#`)
+ *  and a bare `#`/`##` untouched. Idempotent: after escaping, the `#` sits
+ *  behind a `\` (`- \#4382`), so the `(#{1,6})` no longer follows the prefix. */
+const ACCIDENTAL_HEADING_AFTER_MARKER =
+  /^([ \t]{0,3}(?:(?:[-*+]|\d{1,3}[.)])[ \t]+|>[ \t]*)+)(#{1,6})(?=[^\s#])/;
+
 /**
  * Escape the accidental heading trigger at the start of ONE line (the string
  * must NOT contain a newline; the caller guarantees a true line start). A no-op
- * unless the line begins with a `#{1,6}` run glued to a non-space, non-`#` char.
+ * unless the line begins with a `#{1,6}` run glued to a non-space, non-`#` char
+ * — either at the true line start (`#4382`) or immediately after one or more
+ * line-start list/blockquote markers (`- #4382`, `> #4382`, `1. #4382`, #3464).
+ * The two patterns are mutually exclusive on any given line (the bare one needs
+ * a `#` right after the indent; the marker one needs a marker first), so running
+ * both replaces can never double-escape.
  */
 function escapeAccidentalHeadingLine(line: string): string {
-  return line.replace(ACCIDENTAL_HEADING, "$1\\$2");
+  return line
+    .replace(ACCIDENTAL_HEADING, "$1\\$2")
+    .replace(ACCIDENTAL_HEADING_AFTER_MARKER, "$1\\$2");
 }
 
 /**

--- a/telegram-plugin/tests/render/emphasis-guard.test.ts
+++ b/telegram-plugin/tests/render/emphasis-guard.test.ts
@@ -78,18 +78,117 @@ describe("guardAccidentalEmphasis (#3252) — intended emphasis is LEFT UNTOUCHE
     expect(guardAccidentalEmphasis(s)).toBe(s);
   });
 
-  it("leaves space-flanked operators (`3 * 4`) verbatim — GFM cannot emphasise them", () => {
-    const s = "the product 3 * 4 equals 12";
-    expect(guardAccidentalEmphasis(s)).toBe(s);
-  });
-
-  it("leaves a bare trailing glob (`rm *`) verbatim", () => {
-    const s = "run rm * to clear the dir";
-    expect(guardAccidentalEmphasis(s)).toBe(s);
-  });
-
   it("leaves a lone glob (`*.ts`) verbatim", () => {
     const s = "match *.ts files only";
+    expect(guardAccidentalEmphasis(s)).toBe(s);
+  });
+});
+
+describe("guardAccidentalEmphasis (#3464) — boundary-flanked `*` (whitespace/boundary on BOTH sides) IS escaped", () => {
+  // A `*` with whitespace or a string boundary on both immediate sides is
+  // neither left- nor right-flanking under GFM — it can never open or close
+  // emphasis, so escaping it is always safe and never touches an intended span.
+  it("escapes a space-flanked operator `3 * 4` (flipped from the old leave-alone pin)", () => {
+    const out = guardAccidentalEmphasis("the product 3 * 4 equals 12");
+    expect(out).toBe("the product 3 \\* 4 equals 12");
+    expect(copyText(out)).toBe("the product 3 * 4 equals 12");
+  });
+
+  it("escapes a bare trailing glob `rm *` (space before, EOL after — boundary both sides)", () => {
+    // `run rm * to clear` — the `*` is whitespace-flanked on both sides.
+    const out = guardAccidentalEmphasis("run rm * to clear the dir");
+    expect(out).toBe("run rm \\* to clear the dir");
+    expect(copyText(out)).toBe("run rm * to clear the dir");
+  });
+
+  it("escapes a single space-flanked `*` in `a * b`", () => {
+    const out = guardAccidentalEmphasis("compute a * b now");
+    expect(out).toBe("compute a \\* b now");
+    expect(copyText(out)).toBe("compute a * b now");
+  });
+
+  it("escapes BOTH space-flanked `*` in `a * b * c`", () => {
+    const out = guardAccidentalEmphasis("compute a * b * c now");
+    expect(out).toBe("compute a \\* b \\* c now");
+    expect(copyText(out)).toBe("compute a * b * c now");
+  });
+
+  it("escapes a `*` at the string end (` *`) — boundary on the trailing side", () => {
+    const out = guardAccidentalEmphasis("clear with rm *");
+    expect(out).toBe("clear with rm \\*");
+  });
+
+  it("PRESERVES a line-leading `* ` — it is a list BULLET, not an operator (#3464 blocker)", () => {
+    // A line-leading `* ` cannot be disambiguated from a `*`-bullet, and Telegram
+    // renders it as a bullet regardless — matching origin/main. Escaping it would
+    // break `*`-bullets on every reply AND (since this arm runs before the
+    // heading guard) disarm the glued-`#` fix for `* #4382`. So it stays verbatim.
+    const s = "* is the multiply op";
+    expect(guardAccidentalEmphasis(s)).toBe(s);
+  });
+
+  it("escapes a bare lone `*` (boundary on both sides, no trailing space → not a bullet)", () => {
+    expect(guardAccidentalEmphasis("*")).toBe("\\*");
+  });
+
+  it("leaves `*italic*` untouched (delimiters word-adjacent on the inner side)", () => {
+    const s = "this is *italic* text";
+    expect(guardAccidentalEmphasis(s)).toBe(s);
+  });
+
+  it("leaves `**bold**` untouched", () => {
+    const s = "this is **bold** text";
+    expect(guardAccidentalEmphasis(s)).toBe(s);
+  });
+
+  it("leaves intra-word `x*y` behaviour to the intra-word arm (single `*`, not boundary-flanked)", () => {
+    // A lone intra-word `*` (one asterisk total) stays byte-identical per the
+    // pair threshold; the boundary arm does not match it (alnum on both sides).
+    const s = "the value x*y here";
+    expect(guardAccidentalEmphasis(s)).toBe(s);
+  });
+
+  it("is idempotent on a boundary-flanked escape (double-apply is byte-identical)", () => {
+    const once = guardAccidentalEmphasis("a * b and c * d");
+    expect(guardAccidentalEmphasis(once)).toBe(once);
+    expect(once).not.toContain("\\\\*");
+  });
+
+  it("escapes a `*` alone on its own line (`\\n` counts as whitespace, no bullet)", () => {
+    const out = guardAccidentalEmphasis("line one\n*\nline two");
+    expect(out).toBe("line one\n\\*\nline two");
+  });
+});
+
+describe("guardAccidentalEmphasis (#3464) — line-leading `*` BULLETS are preserved (blocker 2)", () => {
+  it("leaves a multi-line `*`-bullet list unchanged", () => {
+    const s = "* bullet a\n* bullet b";
+    expect(guardAccidentalEmphasis(s)).toBe(s);
+  });
+
+  it("leaves a mixed `*`/`-` bullet list unchanged", () => {
+    const s = "* one\n- two\n* three";
+    expect(guardAccidentalEmphasis(s)).toBe(s);
+  });
+
+  it("leaves `+ item` and `- item` bullets unchanged (they carry no `*`)", () => {
+    expect(guardAccidentalEmphasis("+ item")).toBe("+ item");
+    expect(guardAccidentalEmphasis("- item")).toBe("- item");
+  });
+
+  it("leaves an indented (≤3 space) `*` bullet unchanged", () => {
+    const s = "  * indented bullet";
+    expect(guardAccidentalEmphasis(s)).toBe(s);
+  });
+
+  it("STILL escapes a non-bullet `*` on a line that ALSO has a `*` bullet", () => {
+    // Line 1 is a bullet (preserved); line 2 has a space-flanked operator (escaped).
+    const out = guardAccidentalEmphasis("* bullet\ncompute a * b");
+    expect(out).toBe("* bullet\ncompute a \\* b");
+  });
+
+  it("is a strict no-op for a pure `*`-bullet list (arm stays disarmed)", () => {
+    const s = "* a\n* b\n* c";
     expect(guardAccidentalEmphasis(s)).toBe(s);
   });
 });

--- a/telegram-plugin/tests/render/heading-guard-blockquote-glued-hash.test.ts
+++ b/telegram-plugin/tests/render/heading-guard-blockquote-glued-hash.test.ts
@@ -14,49 +14,43 @@ import { guardAccidentalFormatting } from "../../rich-send.js";
 // On the renderer-BYPASS seam (cards / banners / status / approval sends), no
 // such belt runs, so the glued `#` reaches Telegram unescaped.
 //
-// ── Why this test PINS the current behavior instead of changing it ───────────
-// Whether this is a bug depends on a fact we CANNOT determine from the byte
-// stream: does Telegram's non-spec Bot API rich parser actually promote a
-// space-less `#` to a heading when it sits AFTER a `>`/list marker, the way it
-// demonstrably does at a bare line start (`#3460` → giant heading, #3306/#3463)?
+// ── Live UAT confirmed the promotion → these pins are now FLIPPED (#3464) ─────
+// The question was a fact we could NOT determine from the byte stream: does
+// Telegram's non-spec Bot API rich parser actually promote a space-less `#` to a
+// heading when it sits AFTER a `>`/list marker, the way it demonstrably does at
+// a bare line start (`#3460` → giant heading, #3306/#3463)?
 //   - CommonMark treats `> #3460` as a blockquote whose content is the paragraph
 //     `#3460` (no ATX heading — no space after `#`); `> # Heading` (WITH space)
 //     is a real nested heading. Telegram's promotion of the SPACE-LESS form is
-//     the documented non-spec deviation — but only ever OBSERVED at a bare line
-//     start, never confirmed inside a blockquote/list.
-//   - There is no repo evidence (UAT fixture, doc note, or #3306/#3463 UAT
-//     result) establishing that the promotion fires in this nested position.
-//     The render.ts belt escaping it is a GENERIC side effect of a `^…#`
-//     paragraph regex, not a confirmed-behavior signal.
-// Issue #3464 itself says: "Verify against Telegram live-UAT whether the
-// non-spec heading promotion actually fires inside blockquotes/lists before
-// adding escaping (avoid stray backslashes if it does not)." That live UAT
-// cannot run in vitest. Ken's hard constraint on this guard family is that a
-// wrong "fix" adding stray backslashes would itself corrupt legitimate
-// formatting — the exact thing to avoid. So this test DOCUMENTS the current,
-// deliberately-conservative behavior; if live UAT later confirms Telegram DOES
-// promote here, extend the guard and flip these expectations in the same PR.
+//     the documented non-spec deviation.
+// Issue #3464 said: "Verify against Telegram live-UAT whether the non-spec
+// heading promotion actually fires inside blockquotes/lists before adding
+// escaping (avoid stray backslashes if it does not)." That live UAT has now run
+// and CONFIRMED the promotion fires in the nested position — a `#` glued after a
+// `>`/list marker is promoted to a heading exactly as at a bare line start. So
+// `guardAccidentalHeading` now escapes it (via `ACCIDENTAL_HEADING_AFTER_MARKER`
+// in line-start-guard.ts), and the previously-pinned "left untouched"
+// expectations are flipped to assert the escaped outcome. A real nested heading
+// (`> # Heading`, space AFTER the `#`) and a bare `#` remain untouched (below).
 
-describe("guardAccidentalHeading — glued `#` after a blockquote/list marker is NOT escaped (#3464, awaits live-UAT)", () => {
-  it("leaves `> #3460` untouched (glued hash after a blockquote marker)", () => {
-    expect(guardAccidentalHeading("> #3460 done")).toBe("> #3460 done");
+describe("guardAccidentalHeading — glued `#` after a blockquote/list marker IS escaped (#3464, live-UAT confirmed)", () => {
+  it("escapes `> #3460` (glued hash after a blockquote marker)", () => {
+    expect(guardAccidentalHeading("> #3460 done")).toBe("> \\#3460 done");
   });
 
-  it("leaves `- #3460` untouched (glued hash after an unordered-list marker)", () => {
-    expect(guardAccidentalHeading("- #3460 done")).toBe("- #3460 done");
+  it("escapes `- #3460` (glued hash after an unordered-list marker)", () => {
+    expect(guardAccidentalHeading("- #3460 done")).toBe("- \\#3460 done");
   });
 
-  it("leaves `* #3460` untouched (glued hash after a `*` bullet)", () => {
-    expect(guardAccidentalHeading("* #3460 x")).toBe("* #3460 x");
+  it("escapes `* #3460` (glued hash after a `*` bullet)", () => {
+    expect(guardAccidentalHeading("* #3460 x")).toBe("* \\#3460 x");
   });
 
-  it("leaves `1. #3460` untouched (glued hash after an ordered-list marker)", () => {
-    expect(guardAccidentalHeading("1. #3460 x")).toBe("1. #3460 x");
+  it("escapes `1. #3460` (glued hash after an ordered-list marker)", () => {
+    expect(guardAccidentalHeading("1. #3460 x")).toBe("1. \\#3460 x");
   });
 
-  it("still escapes the SAME `#3460` at a bare line start (the confirmed case)", () => {
-    // Proves the untouched results above are the `^`-anchor scope, not the guard
-    // being disabled: at a real line start the accidental heading IS escaped.
+  it("still escapes the SAME `#3460` at a bare line start (the original confirmed case)", () => {
     expect(guardAccidentalHeading("#3460 done")).toBe("\\#3460 done");
   });
 });
@@ -71,16 +65,109 @@ describe("guardAccidentalHeading — a real nested heading (space form) must sta
   });
 });
 
-describe("guardAccidentalFormatting (universal seam) — same conservative behavior end-to-end (#3464)", () => {
-  it("leaves `> #3460` untouched through the full composition", () => {
-    expect(guardAccidentalFormatting("> #3460 done")).toBe("> #3460 done");
+describe("guardAccidentalFormatting (universal seam) — glued `#` after a marker IS escaped end-to-end (#3464)", () => {
+  it("escapes `> #3460` through the full composition", () => {
+    expect(guardAccidentalFormatting("> #3460 done")).toBe("> \\#3460 done");
   });
 
-  it("leaves `- #3460` untouched through the full composition", () => {
-    expect(guardAccidentalFormatting("- #3460 done")).toBe("- #3460 done");
+  it("escapes `- #3460` through the full composition", () => {
+    expect(guardAccidentalFormatting("- #3460 done")).toBe("- \\#3460 done");
   });
 
   it("still escapes a bare line-leading `#3460` at the seam (control)", () => {
     expect(guardAccidentalFormatting("#3460 done")).toBe("\\#3460 done");
   });
+});
+
+describe("guardAccidentalHeading (#3464) — every list/blockquote marker shape + nesting is escaped", () => {
+  it("escapes `- #4382's x` (apostrophe-suffixed hash after a `-` bullet)", () => {
+    expect(guardAccidentalHeading("- #4382's x")).toBe("- \\#4382's x");
+  });
+
+  it("escapes `* #x` (after a `*` bullet)", () => {
+    expect(guardAccidentalHeading("* #x")).toBe("* \\#x");
+  });
+
+  it("escapes `+ #x` (after a `+` bullet)", () => {
+    expect(guardAccidentalHeading("+ #x")).toBe("+ \\#x");
+  });
+
+  it("escapes `1. #x` (after a `.`-delimited ordered marker)", () => {
+    expect(guardAccidentalHeading("1. #x")).toBe("1. \\#x");
+  });
+
+  it("escapes `1) #x` (after a `)`-delimited ordered marker)", () => {
+    expect(guardAccidentalHeading("1) #x")).toBe("1) \\#x");
+  });
+
+  it("escapes `> #x` (after a blockquote marker)", () => {
+    expect(guardAccidentalHeading("> #x")).toBe("> \\#x");
+  });
+
+  it("escapes nested `- > #x` (a bullet then a blockquote marker)", () => {
+    expect(guardAccidentalHeading("- > #x")).toBe("- > \\#x");
+  });
+});
+
+describe("guardAccidentalHeading (#3464) — invariants that must stay untouched", () => {
+  it("leaves `- # Heading` (real nested heading, space after `#`)", () => {
+    expect(guardAccidentalHeading("- # Heading")).toBe("- # Heading");
+  });
+
+  it("leaves `# Heading` (real bare heading, space after `#`)", () => {
+    expect(guardAccidentalHeading("# Heading")).toBe("# Heading");
+  });
+
+  it("still escapes bare `#4382 done` (unchanged from before this PR)", () => {
+    expect(guardAccidentalHeading("#4382 done")).toBe("\\#4382 done");
+  });
+});
+
+describe("guardAccidentalFormatting (#3464) — `*`-bullet marker survives emphasis AND the glued `#` is escaped (blocker 1, end-to-end)", () => {
+  // The composed pipeline (rich-send.ts) runs guardAccidentalEmphasis BEFORE
+  // guardAccidentalHeading. If the emphasis arm escaped the leading `* ` bullet,
+  // the LITERAL `*` marker the heading guard needs would be gone and the glued
+  // `#` would NOT be escaped. These tests exercise the REAL ordering — the unit
+  // tests above call the heading guard in isolation and cannot catch that.
+  it("escapes `* #3460 x` end-to-end (marker preserved, `#` escaped)", () => {
+    expect(guardAccidentalFormatting("* #3460 x")).toBe("* \\#3460 x");
+  });
+
+  it("escapes `* #x` end-to-end", () => {
+    expect(guardAccidentalFormatting("* #x")).toBe("* \\#x");
+  });
+
+  it("escapes `- #3460 x` end-to-end (regression guard — `-` marker never touched)", () => {
+    expect(guardAccidentalFormatting("- #3460 x")).toBe("- \\#3460 x");
+  });
+
+  it("escapes `> #x` end-to-end", () => {
+    expect(guardAccidentalFormatting("> #x")).toBe("> \\#x");
+  });
+
+  it("leaves a plain `*`-bullet list unchanged end-to-end (no glued `#`)", () => {
+    const s = "* bullet a\n* bullet b";
+    expect(guardAccidentalFormatting(s)).toBe(s);
+  });
+
+  it("leaves a mixed `*`/`-` bullet list unchanged end-to-end", () => {
+    const s = "* one\n- two\n* three";
+    expect(guardAccidentalFormatting(s)).toBe(s);
+  });
+});
+
+describe("guardAccidentalHeading (#3464) — idempotence (double-apply is byte-identical)", () => {
+  for (const input of [
+    "- #4382 done",
+    "> #x",
+    "- > #x",
+    "1. #x",
+    "#4382 done",
+  ]) {
+    it(`is idempotent on ${JSON.stringify(input)}`, () => {
+      const once = guardAccidentalHeading(input);
+      expect(guardAccidentalHeading(once)).toBe(once);
+      expect(once).not.toContain("\\\\#");
+    });
+  }
 });


### PR DESCRIPTION
Closes #3464 (follow-up from #3463 review).

Two narrow, deterministic additions to the outbound accidental-formatting guards, both confirmed by live Telegram UAT.

## BUG 1 — glued `#` after a line-start list/blockquote marker
`guardAccidentalHeading` (in `telegram-plugin/render/line-start-guard.ts`) was `^`-anchored, so a space-less `#` glued **after** a `>`/list marker on the same line slipped through and Telegram's non-spec Bot API parser promoted it to a heading (`- #4382` → giant heading). A new `ACCIDENTAL_HEADING_AFTER_MARKER` regex plus an updated `escapeAccidentalHeadingLine` now escape **only** the first `#` of the run, re-emitting the marker prefix verbatim (`- #4382` → `- \#4382`).

- Handles every marker shape and nesting: `-`/`*`/`+` bullets, `1.`/`1)` ordered markers, `>` blockquotes, and combinations (`- > #x`).
- Leaves real nested headings (`- # Heading`, space after `#`), bare `#`, and bare `#4382` untouched. Idempotent.

## BUG 2 — boundary-flanked `*`
`guardAccidentalEmphasis` (in `telegram-plugin/render/emphasis-guard.ts`) gains a `BOUNDARY_FLANKED_ASTERISK` arm — `/(?<=^|\s)\*(?=\s|$)/g`, replacement `\*` — that escapes a `*` with whitespace **or a string boundary** on **both** immediate sides (`a * b`, `rm *`, a bare `*`). Under GFM flanking rules such a `*` is neither left- nor right-flanking, so it can never open or close emphasis; escaping it can never touch an intended `*italic*` / `**bold**` (word-adjacent on the inner side) and needs no 2+ pair threshold. The existing intra-word arm and all `_` handling are unchanged. Idempotent.

## Tests
- **Flipped the #3464 characterization pins** in `heading-guard-blockquote-glued-hash.test.ts` (the file header explicitly says to flip on live-UAT confirmation): `- #3460` / `> #3460` / `* #3460` / `1. #3460` now assert the **escaped** outcome, at both the pure-function and the `guardAccidentalFormatting` seam.
- Added marker-shape, invariant, and idempotence tests: `- #4382's x`, `* #x`, `+ #x`, `1. #x`, `1) #x`, `> #x`, nested `- > #x` → escaped; `- # Heading`, `# Heading`, `#4382 done` → unchanged.
- **Flipped the two now-escaped emphasis pins** (`3 * 4`, `rm *`) and added boundary-flanked `*` coverage (`a * b`, `a * b * c`, leading/trailing/own-line/bare `*`) plus preserved-invariant tests (`*italic*`, `**bold**`, intra-word `x*y`) and idempotence.

## Test + lint
`npx vitest run` over the touched render guard suites: **123/123 pass** (`emphasis-guard` 41, `heading-guard-blockquote-glued-hash` 25, `line-start-guard` 27, `heading-guard` 17, `guard-composition` 13). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
