### PR TITLE
fix(auth): classify OAuth-disabled-org 403 as entitlement_blocked

### DIFF
--- a/src/auth/broker/server-entitlement-403.test.ts
+++ b/src/auth/broker/server-entitlement-403.test.ts
@@ -29,6 +29,7 @@ import { AuthBroker } from "./server.js";
 import { decodeResponse, encodeRequest } from "./protocol.js";
 import type { SwitchroomConfig } from "../../config/schema.js";
 import { writeAccountCredentials } from "../account-store.js";
+import { fetchQuota } from "../quota.js";
 import type { FetchQuotaOptions, QuotaResult } from "../quota.js";
 
 interface Harness {
@@ -159,6 +160,32 @@ function entitlement403(): QuotaResult {
   };
 }
 
+/**
+ * The VERBATIM deactivated / OAuth-disabled-org 403 body, run through the REAL
+ * `fetchQuota` classifier (via a stubbed `fetchImpl`) — no hand-authored
+ * QuotaResult. This exercises the actual classification + persistence + skip
+ * chain from the exact production signature, so it fails RED without the
+ * quota.ts fix (the body's prose carries no "disabled"/"claude code", so the
+ * legacy matcher misses it → "other" → no mark → account stays selectable).
+ */
+function deactivatedOrgLiveClassified(): () => Promise<QuotaResult> {
+  const body = JSON.stringify({
+    type: "error",
+    error: {
+      type: "permission_error",
+      message: "OAuth authentication is currently not allowed for this organization.",
+      details: { error_code: "oauth_not_allowed_for_organization" },
+    },
+    request_id: "req_deactivated",
+  });
+  const fetchImpl = (async () =>
+    new Response(body, {
+      status: 403,
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch;
+  return async () => await fetchQuota({ accessToken: "tok", fetchImpl });
+}
+
 /** A non-entitlement 403 (bad token scope) — 403 but NOT a hard block. */
 function badScope403(): QuotaResult {
   return {
@@ -264,6 +291,35 @@ describe("entitlement-403 — broker persistence + eligibility", () => {
     });
     expect(res.data.results[0].result.ok).toBe(true);
     expect(broker._state().quota["disabled"]?.entitlement_blocked).toBeUndefined();
+    broker.stop();
+  });
+
+  it("the VERBATIM deactivated-org 403 body → classified via real fetchQuota → marked blocked → rolled past", async () => {
+    const h = makeHarness();
+    seedAccount(h, "primary");
+    seedAccount(h, "disabled");
+    seedAccount(h, "healthy2");
+    const classifyDeactivated = deactivatedOrgLiveClassified();
+    const broker = new AuthBroker(makeConfig(h, "primary", ["primary", "disabled", "healthy2"]), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: async (opts: FetchQuotaOptions) => {
+        const label = opts.accessToken.replace(/^at-/, "");
+        if (label === "disabled") return await classifyDeactivated();
+        if (label === "primary") return exhausted();
+        return healthy(1, 2);
+      },
+    });
+    await broker.start();
+    await broker.fleetQuotaProbeTick();
+
+    const st = broker._state();
+    // The exact production body was classified entitlement_blocked end-to-end:
+    // the account is marked (eligibility → blocked) and the fleet rolled past it.
+    expect(st.quota["disabled"]?.entitlement_blocked).toBe(true);
+    expect(st.quota["disabled"]?.entitlement_blocked_reason).toContain(
+      "OAuth authentication is currently not allowed",
+    );
+    expect(st.activeAccount).toBe("healthy2");
     broker.stop();
   });
 

--- a/src/auth/quota-403.test.ts
+++ b/src/auth/quota-403.test.ts
@@ -14,8 +14,10 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  extractApiErrorCode,
   extractApiErrorMessage,
   fetchQuota,
+  isEntitlementBlockedErrorCode,
   isEntitlementDisabledMessage,
 } from "./quota.js";
 
@@ -48,6 +50,32 @@ const BAD_SCOPE_BODY = {
   },
 };
 
+/**
+ * The observed DEACTIVATED / OAuth-disabled-org 403 body (verbatim signature).
+ * Its message carries neither "disabled" nor "claude code", so the prose
+ * matcher misses it — the structured `error.details.error_code` is the only
+ * reliable signal. This is the exact gap the fix closes.
+ */
+const OAUTH_DISABLED_ORG_BODY = {
+  type: "error",
+  error: {
+    type: "permission_error",
+    message: "OAuth authentication is currently not allowed for this organization.",
+    details: { error_code: "oauth_not_allowed_for_organization" },
+  },
+  request_id: "req_abc123",
+};
+
+/** A generic 403 carrying an UNRELATED structured error_code (over-block guard). */
+const UNRELATED_CODE_403_BODY = {
+  type: "error",
+  error: {
+    type: "permission_error",
+    message: "Some other permission problem.",
+    details: { error_code: "some_unrelated_permission_error" },
+  },
+};
+
 describe("fetchQuota — structured entitlement-403 classification", () => {
   it("a 403 with a Code-disabled body → structured entitlement_blocked failure", async () => {
     const res = await fetchQuota({
@@ -63,6 +91,36 @@ describe("fetchQuota — structured entitlement-403 classification", () => {
     );
     // The legacy log string is still present for observability.
     expect(res.reason).toContain("HTTP 403");
+  });
+
+  it("a deactivated-org 403 (oauth_not_allowed_for_organization) → entitlement_blocked via the structured error_code", async () => {
+    // This body's message has no "disabled"/"claude code" — the prose matcher
+    // misses it. Classification MUST come from error.details.error_code.
+    const res = await fetchQuota({
+      accessToken: "tok",
+      fetchImpl: stubFetch(403, OAUTH_DISABLED_ORG_BODY),
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.failureKind).toBe("entitlement_blocked");
+    expect(res.httpStatus).toBe(403);
+    expect(res.apiErrorMessage).toBe(
+      "OAuth authentication is currently not allowed for this organization.",
+    );
+    // Sanity: the prose matcher genuinely does NOT catch this message, so the
+    // pass is proving the CODE path, not accidentally the fallback path.
+    expect(isEntitlementDisabledMessage(res.apiErrorMessage)).toBe(false);
+  });
+
+  it("a generic 403 with an UNRELATED error_code stays 'other' (over-block guard)", async () => {
+    const res = await fetchQuota({
+      accessToken: "tok",
+      fetchImpl: stubFetch(403, UNRELATED_CODE_403_BODY),
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.failureKind).toBe("other");
+    expect(res.httpStatus).toBe(403);
   });
 
   it("a bad-token-scope 403 is NOT entitlement_blocked (failureKind 'other')", async () => {
@@ -143,5 +201,35 @@ describe("extractApiErrorMessage", () => {
 
   it("empty body → null", () => {
     expect(extractApiErrorMessage("")).toBeNull();
+  });
+});
+
+describe("extractApiErrorCode", () => {
+  it("pulls error.details.error_code from a deactivated-org body", () => {
+    expect(extractApiErrorCode(JSON.stringify(OAUTH_DISABLED_ORG_BODY))).toBe(
+      "oauth_not_allowed_for_organization",
+    );
+  });
+
+  it("returns null when there is no details.error_code", () => {
+    expect(extractApiErrorCode(JSON.stringify(ENTITLEMENT_BODY))).toBeNull();
+  });
+
+  it("null for non-JSON and empty bodies", () => {
+    expect(extractApiErrorCode("plain text error")).toBeNull();
+    expect(extractApiErrorCode("")).toBeNull();
+  });
+});
+
+describe("isEntitlementBlockedErrorCode", () => {
+  it("matches the deactivated-org code", () => {
+    expect(isEntitlementBlockedErrorCode("oauth_not_allowed_for_organization")).toBe(true);
+  });
+
+  it("does not match an unrelated code, null, or empty", () => {
+    expect(isEntitlementBlockedErrorCode("some_unrelated_permission_error")).toBe(false);
+    expect(isEntitlementBlockedErrorCode(null)).toBe(false);
+    expect(isEntitlementBlockedErrorCode(undefined)).toBe(false);
+    expect(isEntitlementBlockedErrorCode("")).toBe(false);
   });
 });

--- a/src/auth/quota.ts
+++ b/src/auth/quota.ts
@@ -137,12 +137,16 @@ export function isProbeThin(q: {
 
 /**
  * Structured probe-failure classification.
- *  - `entitlement_blocked` — a 403 whose body says the org/subscription has
- *    DISABLED Claude Code access ("Your organization has disabled Claude
- *    subscription access for Claude Code"). A hard, account-level block: the
- *    account can NEVER serve, and re-probing won't lift it until the org
- *    re-enables Code access. Distinct from a bad-token-scope 403 (that keeps
- *    `"other"`).
+ *  - `entitlement_blocked` — a 403 that denotes an org/subscription-level
+ *    Claude Code disablement, detected on EITHER the structured
+ *    `error.details.error_code` (see {@link ENTITLEMENT_BLOCKED_ERROR_CODES},
+ *    e.g. a deactivated org's `oauth_not_allowed_for_organization`) OR the
+ *    legacy prose matcher ({@link isEntitlementDisabledMessage}, "Your
+ *    organization has disabled Claude subscription access for Claude Code").
+ *    A hard, account-level block: the account can NEVER serve, and re-probing
+ *    won't lift it until the org re-enables Code access — at which point the
+ *    next successful probe self-heals the mark. Distinct from a bad-token-scope
+ *    403 (that keeps `"other"`).
  *  - `"other"` — any other non-ok HTTP status (bad scope 403, 401, 5xx, …) or
  *    a header-parse miss. Retains the legacy no-op semantics upstream.
  */
@@ -333,6 +337,64 @@ export function extractApiErrorMessage(bodyText: string): string | null {
 }
 
 /**
+ * Extract the STRUCTURED Anthropic error code from an error body. Anthropic
+ * nests a machine-readable code at `error.details.error_code` (e.g.
+ * `"oauth_not_allowed_for_organization"` for an OAuth-disabled org). Returns
+ * null when the body isn't JSON, isn't the error shape, or carries no code.
+ * PURE — no I/O.
+ *
+ * Keying on this stable code — rather than the human-facing `message` prose —
+ * is why {@link isEntitlementBlockedErrorCode} can classify a deactivated
+ * account deterministically even when its message wording differs from the
+ * legacy "organization has disabled…" string the prose matcher targets.
+ */
+export function extractApiErrorCode(bodyText: string): string | null {
+  if (!bodyText || bodyText.trim().length === 0) return null;
+  try {
+    const parsed = JSON.parse(bodyText) as unknown;
+    const code = (parsed as { error?: { details?: { error_code?: unknown } } })
+      ?.error?.details?.error_code;
+    if (typeof code === "string" && code.trim().length > 0) return code.trim();
+  } catch {
+    // Body isn't JSON — no structured code available.
+  }
+  return null;
+}
+
+/**
+ * Structured Anthropic `error.details.error_code` values that mean the account
+ * is DISABLED for Claude Code at the org/subscription level — a hard,
+ * self-healing entitlement block (NOT a transient failure).
+ *
+ *  - `oauth_not_allowed_for_organization` — the observed signature of a
+ *    deactivated / OAuth-disabled organization: a 403 whose message is "OAuth
+ *    authentication is currently not allowed for this organization." The prose
+ *    matcher ({@link isEntitlementDisabledMessage}) does NOT catch this — the
+ *    message carries no "disabled" nor "claude code" — so keying on the code is
+ *    what closes the gap where such an account decayed to `unknown` and could
+ *    still be selected to serve.
+ *
+ * DELIBERATELY NARROW. This is an allowlist, not a "any 403 is a block" rule —
+ * an unrelated/transient 403 (bad token scope, a flaky edge 403) must stay
+ * `"other"` so it never benches a healthy account. Add a new code here only
+ * when it is a confirmed org/subscription-level Claude Code disablement.
+ */
+export const ENTITLEMENT_BLOCKED_ERROR_CODES = new Set<string>([
+  "oauth_not_allowed_for_organization",
+]);
+
+/**
+ * Does this structured `error_code` denote an org/subscription-level Claude
+ * Code disablement (a hard entitlement block)? See
+ * {@link ENTITLEMENT_BLOCKED_ERROR_CODES}. PURE — no I/O.
+ */
+export function isEntitlementBlockedErrorCode(
+  code: string | null | undefined,
+): boolean {
+  return code != null && ENTITLEMENT_BLOCKED_ERROR_CODES.has(code);
+}
+
+/**
  * Does this API error message indicate the org/subscription has DISABLED Claude
  * Code access (the entitlement-403), as opposed to a bad-token-scope 403?
  *
@@ -418,8 +480,19 @@ export async function fetchQuota(opts: FetchQuotaOptions): Promise<QuotaResult> 
     }
     clearTimeout(timeout);
     const apiErrorMessage = extractApiErrorMessage(bodyText);
+    // Classify a 403 as a hard entitlement block on EITHER signal:
+    //  1. the STRUCTURED `error.details.error_code` (preferred — deterministic,
+    //     survives message-wording changes; catches the OAuth-disabled-org
+    //     deactivation whose prose the matcher below misses), or
+    //  2. the legacy prose matcher (fallback for the "organization has disabled
+    //     Claude subscription access…" body that carries no structured code).
+    // Deliberately narrow to an error-code allowlist + the existing matcher — an
+    // unrelated/transient 403 stays "other" and never benches a healthy account.
+    const apiErrorCode = extractApiErrorCode(bodyText);
     const entitlement =
-      resp.status === 403 && isEntitlementDisabledMessage(apiErrorMessage);
+      resp.status === 403 &&
+      (isEntitlementBlockedErrorCode(apiErrorCode) ||
+        isEntitlementDisabledMessage(apiErrorMessage));
     return {
       ok: false,
       reason: `HTTP ${resp.status} from Anthropic (${parsed.reason})`,


### PR DESCRIPTION
## Problem

A deactivated / OAuth-disabled Claude account is **not** classified as blocked. It sits at eligibility `unknown` and can still be selected to serve — then fails at request time.

The deactivated account returns, from `POST /v1/messages`:
- HTTP **403**, no rate-limit headers
- Body:
```json
{"type":"error","error":{"type":"permission_error","message":"OAuth authentication is currently not allowed for this organization.","details":{"error_code":"oauth_not_allowed_for_organization"}}}
```

## Root cause

`fetchQuota` (`src/auth/quota.ts`) classified a non-ok 403 as `entitlement_blocked` **only** when `isEntitlementDisabledMessage(body)` matched — a prose matcher requiring `"disabled"` + (`"claude code"`|`"claude subscription"`) + an org/sub reference. The deactivation body has none of those, so it fell through to `failureKind: "other"` → no snapshot cached, `markEntitlementBlocked` no-ops → eligibility resolves to `unknown` (not a block).

## Fix

Key the entitlement classification on the **structured** `error.details.error_code` via a narrow allowlist, keeping the prose matcher as a fallback:

- New pure helpers `extractApiErrorCode()` and `isEntitlementBlockedErrorCode()`, plus `ENTITLEMENT_BLOCKED_ERROR_CODES = { "oauth_not_allowed_for_organization" }`.
- `fetchQuota` now classifies a 403 as `entitlement_blocked` when the code is on the allowlist **OR** the legacy prose matcher fires.

**Deliberately narrow** — not "any 403". An unrelated/transient 403 (bad scope, edge 403) and any 5xx stay `"other"` and never bench a healthy account.

**Self-heals** — no eligibility/broker changes were needed. The existing `entitlement_blocked` mark path (`markEntitlementBlocked` → `clearEntitlementBlocked` on the next successful probe) already gates selection and clears on recovery; verified by the existing "later successful manual probe clears the mark" test staying green.

**Untouched by design:** `out_of_credits` (the #2455 reversal in `account-eligibility.ts`) is not touched.

## Tests (assert outcomes, fail red on the bug)

Added to `src/auth/quota-403.test.ts` and `src/auth/broker/server-entitlement-403.test.ts`:

- **Verbatim deactivated-org 403 body → `entitlement_blocked` → eligibility `blocked`.** The broker test drives the exact production body through the *real* `fetchQuota` classifier (stubbed `fetchImpl`) end-to-end: the account is marked and the fleet rolls past it to a healthy fallback. The unit test also asserts the prose matcher genuinely misses this message, so the pass proves the *code* path, not the fallback.
- **Over-block guards:** a generic 403 with an unrelated `error_code`, and a 5xx, both stay `"other"` → NOT blocked.
- **Regression:** the legacy `"Your organization has disabled Claude subscription access for Claude Code"` 403 still classifies `entitlement_blocked`.
- Unit coverage for the two new pure helpers.

**Fail-red proof:** reverting only the `quota.ts` classification edit locally, the two new deactivation tests fail (`expected 'other' to be 'entitlement_blocked'` and `expected undefined to be true`) while all over-block/regression tests stay green. Restored, all 91 scoped tests pass.

## Validation

- `vitest run` on `quota-403`, `server-entitlement-403`, `account-eligibility` → 91 passed.
- `tsc --noEmit` clean on touched files (pre-existing `nostr-tools` module-not-found errors in `src/buzz-gateway/*` are an unrelated checkout-dep gap).
- `check-auth-test-hermeticity` and `check-test-runner-coverage` lints pass.

## Follow-up (out of scope)

**401 handling is intentionally not touched here** — a 401 interacts with the token-refresh path, and conflating a deactivation with a stale-token refresh could wrongly hard-block a recoverable account. If we want deactivation-via-401 coverage, it should be a separate change that coordinates with the refresh logic. Filing as a follow-up if warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)