### PR TITLE
fix(hindsight): run the SessionStart hook async so drain/reconcile stop being killed mid-work

### DIFF
--- a/tests/hindsight-session-start-async.test.ts
+++ b/tests/hindsight-session-start-async.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  resolveHindsightRecallTunables,
+  renderHindsightHooksOverrides,
+} from "../src/setup/hindsight-recall-tunables.js";
+
+/**
+ * The hindsight SessionStart hook must run ASYNC.
+ *
+ * session_start.py does the durability work a prior session's abrupt death
+ * skipped — drain the SessionEnd-queued retains (#1071) and reconcile
+ * un-committed transcript turns (#3244). Both carry independent 4s
+ * wall-clock budgets, and a Mode-1 external server adds a ~2s health probe;
+ * summed, they routinely overran the old synchronous 5s SessionStart
+ * timeout, so Claude Code SIGKILLed the hook mid-drain on a large share of
+ * firings (fleet-wide `hook_cancelled` transcript attachments, all with
+ * `durationMs > 5000` and `timedOut: true`). That truncated exactly the
+ * durability work the hook exists to do.
+ *
+ * The fix is `"async": true` on the hook (hooks/hooks.json): the hook
+ * injects NO additionalContext, so nothing in the session depends on it
+ * finishing before the first prompt, and async's dropped context costs
+ * nothing here. Empirically the fleet's two async hooks (retain.py,
+ * subagent_retain.py) record ZERO cancellations while every synchronous
+ * hook does — so async is what actually stops the timeout kill.
+ *
+ * These assert the OUTCOME (async + a timeout ceiling that clears the
+ * summed sub-budgets) so a vendor bump or a hand-edit can't silently
+ * revert it back to a synchronous 5s hook that gets cut off.
+ */
+
+const HOOKS_JSON = join(
+  process.cwd(),
+  "vendor",
+  "hindsight-memory",
+  "hooks",
+  "hooks.json",
+);
+
+/** drain budget (4s) + reconcile budget (4s) + Mode-1 health probe (~2s). */
+const SUMMED_DURABILITY_BUDGET_SECONDS = 10;
+
+interface HookLeaf {
+  command?: string;
+  timeout?: number;
+  async?: boolean;
+}
+
+function sessionStartHook(rawJson: string): HookLeaf {
+  const parsed = JSON.parse(rawJson) as {
+    hooks: Record<string, Array<{ hooks: HookLeaf[] }>>;
+  };
+  const matchers = parsed.hooks.SessionStart;
+  expect(Array.isArray(matchers)).toBe(true);
+  const leaves = matchers
+    .flatMap((m) => m.hooks ?? [])
+    .filter((h) => typeof h.command === "string" && h.command.includes("session_start.py"));
+  expect(leaves).toHaveLength(1);
+  return leaves[0];
+}
+
+describe("hindsight SessionStart hook is async", () => {
+  const raw = readFileSync(HOOKS_JSON, "utf-8");
+
+  it("runs async so drain + reconcile can't be killed at the SessionStart budget", () => {
+    const hook = sessionStartHook(raw);
+    expect(hook.async).toBe(true);
+  });
+
+  it("carries a timeout ceiling above the summed drain+reconcile+probe budgets", () => {
+    const hook = sessionStartHook(raw);
+    expect(typeof hook.timeout).toBe("number");
+    // A ceiling at or under the summed sub-budgets would reintroduce the
+    // mid-work kill even while async. Require real headroom over ~10s.
+    expect(hook.timeout).toBeGreaterThan(SUMMED_DURABILITY_BUDGET_SECONDS);
+  });
+
+  it("keeps the async flag after the scaffold's recall-hook override runs", () => {
+    // installHindsightPlugin re-stamps only the UserPromptSubmit recall
+    // timeout via renderHindsightHooksOverrides on every reconcile/restart.
+    // The SessionStart async flag must survive that round-trip untouched, or
+    // the fix would silently revert on the next `switchroom apply`.
+    const tunables = resolveHindsightRecallTunables({ hook_timeout_seconds: 12 });
+    const stamped = renderHindsightHooksOverrides(raw, tunables);
+    expect(stamped).not.toBeNull();
+    const hook = sessionStartHook(stamped!);
+    expect(hook.async).toBe(true);
+    expect(hook.timeout).toBeGreaterThan(SUMMED_DURABILITY_BUDGET_SECONDS);
+  });
+});

--- a/vendor/hindsight-memory/CHANGELOG.md
+++ b/vendor/hindsight-memory/CHANGELOG.md
@@ -54,6 +54,37 @@
 
 ### Changed (switchroom divergence)
 
+- **SessionStart hook runs async so its durability work stops being killed
+  mid-drain** (`hooks/hooks.json`, `scripts/session_start.py`). The hook does
+  the recovery a prior session's abrupt death skipped — drain the
+  SessionEnd-queued retains (#1071) and reconcile un-committed transcript turns
+  (#3244). Those two carry independent 4s wall-clock budgets
+  (`HINDSIGHT_DRAIN_BUDGET_S` / `HINDSIGHT_RECONCILE_BUDGET_S`), each sized in
+  isolation against the old synchronous 5s SessionStart timeout, plus a ~2s
+  Mode-1 external-server health probe. Summed, they routinely overran 5s, so
+  Claude Code SIGKILLed the hook part-way through — truncating exactly the
+  durability work it exists to do and letting the pending-retains backlog grow
+  (fleet transcripts carry 1000+ `hook_cancelled` attachments for
+  `session_start.py`, all `timedOut: true` with `durationMs > 5000`; a
+  successful firing injects no `additionalContext` and so leaves no record,
+  which made the failures look like ~100% of firings when the true rate is
+  unmeasurable from attachments). Setting `"async": true` on the hook (the same
+  non-blocking pattern the Stop-event `retain.py` already uses) detaches it from
+  the SessionStart critical path: it injects no context, so nothing depends on
+  it finishing first and async's dropped context costs nothing. The `timeout`
+  ceiling rises 5s → 30s purely as a background-lifetime bound above the ~10s
+  summed sub-budgets — it never re-introduces a startup block, because drain and
+  reconcile self-cap at their budgets regardless. The drain stays in the hook
+  (not deferred wholly to the `hindsight-drain` sidecar, which `start.sh` only
+  starts conditionally — when it is absent this hook is the sole backlog path)
+  and `reconcile_tail`, which has no sidecar equivalent, stays here and now runs
+  to completion; its over-budget remainder still resumes on the next boot.
+  Concurrent drain with the sidecar stays safe via `drain_pending`'s exclusive
+  `fcntl.flock`. Pinned by `scripts/tests/test_session_start_durability.py`
+  (drain + reconcile are still invoked, in order) and
+  `tests/hindsight-session-start-async.test.ts` (the async flag + budget-clearing
+  ceiling survive the scaffold's hooks-override round-trip).
+
 - **Recall/retain hygiene guard-rail batch** (`scripts/recall.py`,
   `scripts/subagent_retain.py`, `scripts/lib/content.py`, `scripts/tests/**`).
   Closes guard-rail debt in the fork's hook scripts before extending them:

--- a/vendor/hindsight-memory/hooks/hooks.json
+++ b/vendor/hindsight-memory/hooks/hooks.json
@@ -6,7 +6,8 @@
           {
             "type": "command",
             "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/session_start.py\"",
-            "timeout": 5
+            "async": true,
+            "timeout": 30
           }
         ]
       }

--- a/vendor/hindsight-memory/scripts/session_start.py
+++ b/vendor/hindsight-memory/scripts/session_start.py
@@ -1,12 +1,39 @@
 #!/usr/bin/env python3
-"""SessionStart hook: health check + session logging.
+"""SessionStart hook: health check + durability drain/reconcile.
 
-Fires once when a Claude Code session begins. Uses additionalContext
-(supported on SessionStart) to inject an initial system note if
-Hindsight is available.
+Fires once when a Claude Code session begins (startup / compact / clear).
+This is the Claude Code equivalent of Openclaw's service.start() — verify
+the server is reachable early, then do the durability work that a prior
+session's abrupt death may have skipped: drain SessionEnd-queued retains
+(#1071) and reconcile un-committed transcript turns (#3244).
 
-This is the Claude Code equivalent of Openclaw's service.start() —
-verify the server is reachable early, before the first prompt.
+Runs ASYNC (``"async": true`` in hooks/hooks.json), for a reason specific
+to THIS hook: it injects NO additionalContext — every return path is a
+pure side effect — so nothing in the session depends on it finishing
+before the first prompt, and losing async's dropped context costs us
+nothing here (unlike recall.py, which must stay synchronous to inject).
+
+Why async matters: drain and reconcile each carry an independent
+wall-clock budget (``HINDSIGHT_DRAIN_BUDGET_S`` / ``HINDSIGHT_RECONCILE_BUDGET_S``,
+4s each) plus a Mode-1 health probe (~2s). Those budgets were each sized
+against the old synchronous 5s SessionStart timeout in ISOLATION, but they
+STACK on one hook: drain(4s) + reconcile(4s, added later in #3244) +
+probe(2s) routinely overran 5s, so the hook was SIGKILLed mid-drain on a
+large share of firings (see the fleet-wide ``hook_cancelled`` transcript
+attachments) — truncating exactly the durability work it exists to do,
+and growing the pending-retains backlog it was meant to clear. Async
+detaches it from the SessionStart critical path so the bounded, resumable
+drain/reconcile can run to completion instead of being cut off. Both are
+crash-safe under an eventual reap anyway: drain holds an ``fcntl.flock``
+the kernel releases on death and re-queues unsent entries, and reconcile
+is idempotent and resumes any over-budget remainder on the next boot.
+
+Keeping the drain here (rather than deferring wholly to the hindsight-drain
+sidecar) is deliberate: that sidecar is only CONDITIONALLY started — its
+own "NOT STARTED" branch in start.sh notes that when it is absent the
+memory queue is drained ONLY at session boot — so this hook stays the
+backlog path for agents without the sidecar. reconcile_tail has no sidecar
+equivalent at all and lives only here.
 """
 
 import json

--- a/vendor/hindsight-memory/scripts/tests/test_session_start_durability.py
+++ b/vendor/hindsight-memory/scripts/tests/test_session_start_durability.py
@@ -1,0 +1,107 @@
+"""The SessionStart hook must still DO its durability work.
+
+The hook was made ``"async": true`` (hooks/hooks.json) so a stacked
+drain + reconcile + health-probe budget can no longer overrun the
+SessionStart timeout and get the process SIGKILLed mid-drain. Async only
+helps if the two durability calls are still MADE on the healthy path —
+if a refactor drops one, the queue silently stops draining and abrupt-kill
+turns stop being recovered, which is the exact outage the hook exists to
+prevent and which no attachment record would surface (a successful
+SessionStart hook that injects no context leaves no transcript trace).
+
+So this pins the OUTCOME, not the wiring: on a reachable server,
+``session_start.main()`` invokes ``drain_pending.drain`` and then
+``reconcile_tail.reconcile``, in that order (reconcile runs AFTER the
+drain by design — it recovers what SessionEnd never managed to enqueue).
+
+Lives under ``scripts/tests/`` because that is the only python test
+directory CI discovers (``ci-tests-python.yml`` runs ``unittest discover``
+from ``vendor/hindsight-memory/scripts``).
+"""
+
+import io
+import os
+import sys
+import unittest
+import unittest.mock
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import drain_pending  # noqa: E402
+import reconcile_tail  # noqa: E402
+import session_start  # noqa: E402
+
+
+class _ReachableClient:
+    """Stand-in for HindsightClient — reachable, no network."""
+
+    def __init__(self, *_a, **_kw):
+        pass
+
+    def health_check(self, timeout=5, retries=3):
+        return True
+
+
+class DurabilityWorkStillRunsTest(unittest.TestCase):
+    CONFIG = {"autoRetain": True, "autoRecall": True}
+
+    def _run_main(self, config=None):
+        """Run ``session_start.main()`` against a reachable server with the
+        two durability calls stubbed, returning the ordered call log."""
+        calls = []
+
+        def fake_drain(cfg):
+            calls.append("drain")
+
+        def fake_reconcile(cfg, hook_input=None):
+            calls.append("reconcile")
+
+        cfg = dict(self.CONFIG if config is None else config)
+        with unittest.mock.patch.object(drain_pending, "drain", fake_drain), \
+            unittest.mock.patch.object(reconcile_tail, "reconcile", fake_reconcile), \
+            unittest.mock.patch.object(session_start, "load_config", lambda: cfg), \
+            unittest.mock.patch.object(
+                session_start,
+                "get_api_url",
+                lambda c, debug_fn=None, allow_daemon_start=True: (
+                    "http://127.0.0.1:9/none"
+                ),
+            ), \
+            unittest.mock.patch.object(
+                session_start, "HindsightClient", _ReachableClient
+            ), \
+            unittest.mock.patch.object(sys, "stdin", io.StringIO("{}")):
+            session_start.main()
+        return calls
+
+    def test_drain_and_reconcile_both_run_on_a_reachable_server(self):
+        calls = self._run_main()
+        self.assertIn("drain", calls, "queued retains must still be drained")
+        self.assertIn(
+            "reconcile",
+            calls,
+            "un-committed abrupt-kill turns must still be reconciled",
+        )
+
+    def test_reconcile_runs_after_the_drain(self):
+        calls = self._run_main()
+        self.assertEqual(
+            calls,
+            ["drain", "reconcile"],
+            "reconcile recovers what SessionEnd never enqueued, so it must "
+            "run AFTER the drain replays what it did",
+        )
+
+    def test_disabled_memory_skips_both(self):
+        """The control case: with both autoRecall and autoRetain off, the
+        hook returns before touching the durability path. Without this the
+        assertions above could be satisfied by calls that fire
+        unconditionally."""
+        calls = self._run_main(config={"autoRetain": False, "autoRecall": False})
+        self.assertEqual(calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## P2 of the conversation-continuity plan — durability leg

The hindsight-memory `SessionStart` hook (`vendor/hindsight-memory/scripts/session_start.py`, wired `timeout: 5`) does the durability recovery a prior session's abrupt death skipped: **drain** the SessionEnd-queued retains (#1071) and **reconcile** un-committed transcript turns (#3244). It injects no context — its whole value is those two side effects, which feed what a later `recall` can surface.

### Root cause
The two durability calls carry **independent 4s wall-clock budgets** (`HINDSIGHT_DRAIN_BUDGET_S` / `HINDSIGHT_RECONCILE_BUDGET_S`), and a Mode-1 external server adds a **~2s health probe**. Each budget was sized in isolation against the old synchronous 5s hook timeout, but they **stack** on one hook: `drain(4s) + reconcile(4s, added later in #3244) + probe(2s)` routinely overruns 5s. Claude Code then SIGKILLs the hook part-way through, truncating exactly the durability work it exists to do and letting the pending-retains backlog grow. #3244 added reconcile after drain without accounting for the drain already eating most of the 5s.

### On the "100% of firings time out" reading — it's a measurement artifact
Fleet transcripts carry **1065** `hook_cancelled` attachments for `session_start.py`, all `timedOut: true` with `durationMs > 5000`. But Claude Code only records a SessionStart hook attachment when it **times out** or **injects `additionalContext`** — this hook injects none, so a *successful* firing leaves **no record at all**. So "1065/1065 recorded = timeout" means only that recorded firings are timeouts, not that 100% of firings time out; the true per-firing rate is **unmeasurable from attachments**. (Proof: `recall.py`, which injects context, shows 9209 `hook_additional_context` success records alongside its timeouts; `session_start.py` shows zero success records.) The bug is real and worth fixing — 1065 truncated drains is a real durability hole — but the "100%" framing is overstated, and this PR does not lean on it.

### Fix
Set `"async": true` on the hook — the same non-blocking pattern the Stop-event `retain.py` already uses. Because the hook injects no context, nothing in the session depends on it finishing before the first prompt, and async's dropped context costs nothing here. **Empirically dispositive:** the fleet's two async hooks (`retain.py`, `subagent_retain.py`) record **zero** cancellations across every transcript, while every synchronous hook (`recall.py`, `session_start.py`) is cancelled — so async is precisely what stops the timeout kill.

`timeout` rises `5 → 30` **only** as a background-lifetime ceiling above the ~10s summed sub-budgets. It never re-introduces a startup block: drain and reconcile self-cap at their own budgets regardless of the ceiling, so even if a reader worried `async` were ignored on SessionStart, the worst case is a ~10s self-terminating background run, not a 30s block.

### Preserving the guarantees (per the plan's fable corrections)
- **Drain stays in the hook**, not deferred wholly to the `hindsight-drain` sidecar: `start.sh` starts that sidecar only conditionally, and its own `NOT STARTED` branch notes that when absent the queue is drained *only* at session boot. So this hook remains the sole backlog path for agents without the sidecar. Concurrent drain with the sidecar stays safe via `drain_pending`'s exclusive `fcntl.flock` (the other holder returns `skipped_locked`).
- **`reconcile_tail` has no sidecar equivalent** — it stays here and now runs to completion instead of being cut off; its over-budget remainder still resumes on the next boot (idempotent by design).

### Source of truth
The vendored copy is **switchroom's own fork**. Upstream `vectorize-io/hindsight`'s `session_start.py` (`hindsight-integrations/claude-code/scripts/session_start.py`) is a 58-line health-check with **no drain/reconcile at all** — that machinery exists only in this fork. So the fix lands here and has **no upstream counterpart to also patch**.

### Tests (assert outcomes)
- `scripts/tests/test_session_start_durability.py` — on a reachable server, `main()` still invokes **drain then reconcile**, in order; disabled-memory skips both. (Ran green as part of the full `python3 -m unittest discover` — 1012 tests pass.)
- `tests/hindsight-session-start-async.test.ts` — the SessionStart hook is `async: true` with a timeout above the summed sub-budgets, and both survive the scaffold's `renderHindsightHooksOverrides` round-trip (which re-stamps only the UserPromptSubmit recall timeout on every reconcile/apply). Validated against the real scaffold function via Node type-stripping (7/7 assertions pass); the full vitest run is left to CI (esbuild's postinstall is network-blocked in this sandbox).

### One residual for review
`async` is directly attested working on `Stop`/`SubagentStop` in this fleet, not on `SessionStart` specifically. The evidence that it's honoured on SessionStart is (a) the fleet-wide async-hook zero-cancellation pattern, (b) Claude Code documenting `async` as a general per-command hook option, and (c) the self-capping budgets that bound the downside even under the pessimistic reading. Worth a CI/live smoke confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)