### PR TITLE
fix(docker): move runtime PLAYWRIGHT_BROWSERS_PATH off the read-only bake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## unreleased — Playwright version-skew: project-pinned browser installs now work
+
+### Runtime PLAYWRIGHT_BROWSERS_PATH moves off the read-only bake
+
+The agent image bakes one pinned Playwright (`ARG PLAYWRIGHT_VERSION`) and its
+matching chromium revision at `/opt/playwright/browsers`, and used to point
+the global `PLAYWRIGHT_BROWSERS_PATH` at that bake. Playwright resolves
+browsers from exactly ONE directory, keyed by revision subdir, and each
+Playwright version demands one exact revision — so a project whose
+`package.json` pinned a *different* Playwright version (observed live:
+`@playwright/test ^1.58.2` needing `chromium-1208` against the baked 1.61.0 /
+`chromium-1228`) could never provision its browser: `playwright install`
+targeted the bake, which is root-owned inside a compose `read_only: true`
+root fs, and hard-failed — even when a matching build already sat unused in
+`~/.cache/ms-playwright`. The runtime env now points at that persistent,
+agent-writable per-agent HOME cache (`/state/agent/home/.cache/ms-playwright`,
+Playwright's own default under the compose HOME), so skewed-version installs
+land in a writable dir that survives container recreate. The bake keeps its
+zero-download fast path: build-time installs still target `/opt` via an
+inline override, and `start.sh` symlinks each baked revision into the HOME
+cache at boot (real agent-installed dirs always win; stale bake links are
+swept after an image bump). `switchroom doctor` additionally probes the bake
+path directly so chromium detection doesn't depend on the boot seeding.
+
+The zero-download guarantee is also GC-hardened. Every `playwright install`
+GC-sweeps the browsers dir before downloading, deleting any revision not
+referenced by a `.links/<sha1>` entry — and the baked packages registered
+their reference in `/opt/.../.links` at build time, not in the HOME cache. So
+a skewed-version project install would otherwise delete the fleet-default seed
+symlinks (`fs.rm` on a symlink removes only the link, leaving the read-only
+bake intact) and force a silent ~150MB re-download on the next fleet-default
+use — the exact skew workflow this change enables. The runtime env now sets
+`PLAYWRIGHT_SKIP_BROWSER_GC=1` to disable that sweep; immutable version-keyed
+revisions coexist safely, at the cost of not auto-reclaiming a superseded
+project browser (rare, per-agent, operator-prunable).
+(`docker/Dockerfile.agent`, `profiles/_base/start.sh.hbs`,
+`src/cli/doctor.ts`.)
+
 ## v0.20.9 — first-hit 429 corroboration, plus three duplicate-/dropped-message reliability fixes
 
 Reliability (2026-08-05): the broker's 429 throttle tier now corroborates a

--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -109,7 +109,12 @@ COPY --from=ghcr.io/astral-sh/uv:0.7.13 /uv /uvx /usr/local/bin/
 # newest was 1.61.0) — pick the newest that exists on both, or the pip
 # install fails "No matching distribution".
 ARG PLAYWRIGHT_VERSION=1.61.0
-ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright/browsers
+# Where the fleet-default browser build is BAKED (an immutable, root-owned
+# image layer — and the whole root fs is `read_only: true` under compose
+# anyway). Build-time installs below target it via an inline env override;
+# the RUNTIME PLAYWRIGHT_BROWSERS_PATH is deliberately NOT this path — see
+# the ENV further down.
+ARG PLAYWRIGHT_BAKED_BROWSERS=/opt/playwright/browsers
 
 # JS binding + chromium browser + system libs. The `npx playwright` here is
 # safe (and NOT the unpinned-npx trap): the pinned global was just installed
@@ -118,7 +123,8 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright/browsers
 # with no local install — guarded by scripts/check-no-unpinned-npx-playwright.mjs.
 RUN --mount=type=cache,target=/root/.npm,sharing=locked \
     npm install -g playwright@${PLAYWRIGHT_VERSION} \
- && npx playwright install --with-deps chromium
+ && PLAYWRIGHT_BROWSERS_PATH=${PLAYWRIGHT_BAKED_BROWSERS} \
+    npx playwright install --with-deps chromium
 
 # Python binding — same pinned version, so it resolves the SAME
 # chromium revision already baked above (no second ~150MB download).
@@ -129,7 +135,52 @@ RUN --mount=type=cache,target=/root/.npm,sharing=locked \
 # bake, a safety net if a future bump ever desyncs the revision.
 RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip3 install --break-system-packages "playwright==${PLAYWRIGHT_VERSION}" \
- && python3 -m playwright install chromium
+ && PLAYWRIGHT_BROWSERS_PATH=${PLAYWRIGHT_BAKED_BROWSERS} \
+    python3 -m playwright install chromium
+
+# Runtime browsers path = the PERSISTENT, AGENT-WRITABLE per-agent HOME
+# cache (Playwright's own default location given HOME=/state/agent/home,
+# a host bind mount — see compose.ts), NOT the read-only bake above.
+#
+# Why not point it at the bake (the pre-#playwright-skew behaviour):
+# Playwright resolves browsers from ONE directory, keyed by revision
+# subdir (chromium-1228/ etc), and each Playwright version demands one
+# exact revision. A project whose package.json pins a DIFFERENT
+# Playwright version than PLAYWRIGHT_VERSION needs a revision the bake
+# doesn't carry, so `playwright install` tries to write into the env
+# path — and the bake is root-owned inside a `read_only: true` root fs,
+# so the install hard-fails with EACCES and the project's tests can
+# never run. Pointing the env at the HOME cache makes version-skewed
+# installs land in a writable dir that also SURVIVES container recreate.
+#
+# The bake still serves the fleet default with zero downloads:
+# start.sh.hbs symlinks each baked revision dir into this cache at boot
+# (revision dirs are immutable + version-keyed, so links and real
+# agent-installed dirs coexist side by side). Keep this in lockstep
+# with compose.ts's HOME env and the seeding block in
+# profiles/_base/start.sh.hbs.
+ENV PLAYWRIGHT_BROWSERS_PATH=/state/agent/home/.cache/ms-playwright
+
+# Protect the boot-seeded baked revisions from Playwright's browser GC.
+# Every `playwright install` runs registry.install(), which — before
+# downloading — GC-sweeps the browsers dir: any revision NOT referenced by
+# a `.links/<sha1(pkg)>` entry is deleted with `fs.rm(dir,{recursive,force})`
+# (playwright-core registry index.ts `_validateInstallationCache` /
+# `_deleteStaleBrowsers`; the marker/skip check itself is INSTALLATION_COMPLETE
+# inside each revision dir, browserFetcher.ts). The seed links we plant in the
+# HOME cache have NO matching `.links` entry there — the baked packages
+# registered their reference in /opt/playwright/browsers/.links at build time
+# (build-time registryDirectory), which the boot seeding deliberately does not
+# copy. So a project that pins a DIFFERENT Playwright version and runs
+# `playwright install` would GC-delete the fleet-default seed symlinks (rm on a
+# symlink removes only the link, leaving the read-only /opt bake intact), and
+# the next fleet-default use would re-download ~150MB — silently breaking the
+# zero-download guarantee for exactly the skew workflow this change enables.
+# Skipping GC keeps the seeds (and any project's own installs) untouched;
+# revisions are immutable + version-keyed so they safely coexist, and the only
+# cost is that a superseded project browser is not auto-reclaimed (rare;
+# per-agent HOME; operator-prunable).
+ENV PLAYWRIGHT_SKIP_BROWSER_GC=1
 
 # Cloakbrowser — the local stealth Chromium driver used by webkite's
 # `webkite mcp` MCP server to fetch bot-gated sites. The webkite binary

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -1692,6 +1692,55 @@ if ! ls -d "$sr_cb_dir"/chromium-*/ >/dev/null 2>&1; then
 fi
 unset sr_cb_dir
 
+# Playwright browsers cache seeding. The agent image bakes the fleet-default
+# Playwright version's chromium at /opt/playwright/browsers (immutable:
+# root-owned inside a `read_only: true` root fs), but PLAYWRIGHT_BROWSERS_PATH
+# points at the persistent per-agent HOME cache (Dockerfile.agent ENV) so a
+# project pinning a DIFFERENT Playwright version can `playwright install` its
+# matching browser revision — revision-keyed dirs coexist side by side, and
+# the install survives container recreate via the HOME bind mount. Symlink
+# each baked revision into the cache so the fleet default (@playwright/mcp,
+# webapp-testing skill) still resolves with ZERO download; a real
+# agent-installed dir with the same name always wins over the link. Dangling
+# links into the bake (stale after an image bump changed the default
+# revision) are swept first. Dot-entries (.links) are untouched by the glob —
+# they must stay real + writable so project installs can register there.
+#
+# Zero-download depends on TWO things, not just this seeding. (1) Playwright
+# decides "already installed / skip download" purely by the INSTALLATION_COMPLETE
+# marker inside each revision dir (playwright-core browserFetcher.ts) — which
+# resolves fine through these symlinks, so the seed alone is enough at launch.
+# (2) BUT `playwright install` first GC-sweeps the browsers dir, deleting any
+# revision not referenced by a `.links/<sha1>` entry. The baked packages
+# registered their reference in /opt/.../.links at build time, not here, so a
+# skewed-version project install would otherwise GC these seed links and force a
+# re-download. Dockerfile.agent sets PLAYWRIGHT_SKIP_BROWSER_GC=1 in the runtime
+# env to disable that sweep — keep the two in lockstep. (`.links` is still
+# written by every install; we just never run the removal pass.)
+if [ -d /opt/playwright/browsers ]; then
+  sr_pw_cache="${PLAYWRIGHT_BROWSERS_PATH:-$HOME/.cache/ms-playwright}"
+  mkdir -p "$sr_pw_cache" 2>/dev/null || true
+  if [ -d "$sr_pw_cache" ] && [ -w "$sr_pw_cache" ]; then
+    for sr_pw_link in "$sr_pw_cache"/*; do
+      if [ -L "$sr_pw_link" ] && [ ! -e "$sr_pw_link" ]; then
+        case "$(readlink "$sr_pw_link")" in
+          /opt/playwright/browsers/*) rm -f "$sr_pw_link" ;;
+        esac
+      fi
+    done
+    for sr_pw_rev in /opt/playwright/browsers/*/; do
+      [ -d "$sr_pw_rev" ] || continue
+      sr_pw_name="$(basename "$sr_pw_rev")"
+      if [ ! -e "$sr_pw_cache/$sr_pw_name" ]; then
+        ln -s "${sr_pw_rev%/}" "$sr_pw_cache/$sr_pw_name" 2>/dev/null || true
+      fi
+    done
+  else
+    echo "WARNING (playwright cache): $sr_pw_cache missing or not writable — baked browsers not linked; playwright-based skills may attempt a fresh ~150MB download" >&2
+  fi
+  unset sr_pw_cache sr_pw_rev sr_pw_name sr_pw_link
+fi
+
 # LiteLLM routing (opt-in, #litellm). When SWITCHROOM_LITELLM is set (compose
 # env, gated on litellm.enabled && keyConfirmed), route the unmodified `claude`
 # CLI through the operator's LiteLLM proxy at ANTHROPIC_BASE_URL: fetch the

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -406,19 +406,23 @@ function checkNodeVersion(): CheckResult {
  * browser cache. Returns the path to the first match, or null.
  *
  * Search order for the Playwright cache:
- *   1. $PLAYWRIGHT_BROWSERS_PATH (set in v0.7.13+ agent images at
- *      `/opt/playwright/browsers/`; placed in an image layer so the
- *      browser binary is shared across the fleet rather than
- *      per-agent in HOME).
- *   2. $HOME/.cache/ms-playwright (legacy on-demand cache from
- *      pre-v0.7.13 hosts where every agent ran `npx playwright`
- *      and downloaded chromium into its own home dir).
+ *   1. $PLAYWRIGHT_BROWSERS_PATH — since #playwright-skew this points at
+ *      the persistent per-agent HOME cache (agent-writable, holds any
+ *      project-pinned extra revisions); on v0.7.13..pre-skew images it
+ *      pointed at the /opt bake directly.
+ *   2. $HOME/.cache/ms-playwright (Playwright's own default — also the
+ *      legacy on-demand cache from pre-v0.7.13 hosts).
+ *   3. /opt/playwright/browsers — the image-baked fleet-default layout
+ *      (read-only image layer; start.sh symlinks it into the HOME cache
+ *      at boot, but probe it directly so doctor still finds the bake on
+ *      a container where the seeding hasn't run).
  *
  * @internal exported for testing
  */
 export function findChromium(
   homeDir: string = process.env.HOME ?? "",
   envBrowsersPath: string | undefined = process.env.PLAYWRIGHT_BROWSERS_PATH,
+  bakedBrowsersPath = "/opt/playwright/browsers",
 ): string | null {
   const candidates = [
     "chromium",
@@ -432,12 +436,15 @@ export function findChromium(
   }
 
   // Search Playwright cache locations in priority order: env-set
-  // location first (v0.7.13+ baked layout), then legacy ~/.cache/.
+  // location first, then the HOME default, then the image bake.
   const cacheLocations: string[] = [];
   if (envBrowsersPath && envBrowsersPath.length > 0) {
     cacheLocations.push(envBrowsersPath);
   }
   cacheLocations.push(join(homeDir, ".cache", "ms-playwright"));
+  if (bakedBrowsersPath && bakedBrowsersPath.length > 0) {
+    cacheLocations.push(bakedBrowsersPath);
+  }
 
   for (const cacheDir of cacheLocations) {
     if (!existsSync(cacheDir)) continue;

--- a/tests/docker/dockerfile-agent-bakes.test.ts
+++ b/tests/docker/dockerfile-agent-bakes.test.ts
@@ -163,6 +163,79 @@ describe("Dockerfile.agent Playwright provisioning", () => {
 });
 
 /**
+ * Version-skew provisioning (#playwright-skew). The bake at
+ * /opt/playwright/browsers is an immutable, root-owned image layer — and the
+ * whole agent root fs is `read_only: true` under compose (compose.ts). When
+ * the runtime PLAYWRIGHT_BROWSERS_PATH pointed AT the bake, a project pinning
+ * a different Playwright version could never `playwright install` its
+ * matching browser revision (EACCES/EROFS on the bake), so its tests were
+ * unrunnable. The fix: runtime env points at the persistent, agent-writable
+ * per-agent HOME cache; build-time installs still target the bake via an
+ * inline override; start.sh symlinks the baked revisions into the HOME cache
+ * at boot so the fleet default keeps its zero-download path.
+ */
+describe("Dockerfile.agent Playwright browsers-path split (bake vs runtime)", () => {
+  const startSh = readFileSync(
+    resolve(root, "profiles/_base/start.sh.hbs"),
+    "utf8",
+  );
+
+  it("declares the bake location as a build arg at /opt/playwright/browsers", () => {
+    expect(dockerfile).toMatch(
+      /ARG\s+PLAYWRIGHT_BAKED_BROWSERS=\/opt\/playwright\/browsers\s*$/m,
+    );
+  });
+
+  it("build-time JS + Python browser installs target the bake, not the runtime path", () => {
+    const inlineOverrides =
+      dockerfile.match(
+        /PLAYWRIGHT_BROWSERS_PATH=\$\{PLAYWRIGHT_BAKED_BROWSERS\}/g,
+      ) ?? [];
+    // One per binding install (JS `npx playwright install`, Python
+    // `python3 -m playwright install`).
+    expect(inlineOverrides.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("runtime PLAYWRIGHT_BROWSERS_PATH is the persistent agent-writable HOME cache", () => {
+    expect(dockerfile).toMatch(
+      /ENV\s+PLAYWRIGHT_BROWSERS_PATH=\/state\/agent\/home\/\.cache\/ms-playwright\s*$/m,
+    );
+  });
+
+  it("never points the runtime env back at the read-only bake (the regression)", () => {
+    expect(dockerfile).not.toMatch(
+      /ENV\s+PLAYWRIGHT_BROWSERS_PATH=\/opt\//,
+    );
+  });
+
+  it("start.sh seeds the baked revisions into the runtime cache via symlinks", () => {
+    // The zero-download path for the fleet default depends on this boot
+    // seeding; without it every agent re-downloads ~150MB for the baked
+    // version too.
+    expect(startSh).toMatch(/\/opt\/playwright\/browsers/);
+    expect(startSh).toMatch(
+      /ln\s+-s\s+"\$\{sr_pw_rev%\/\}"\s+"\$sr_pw_cache\/\$sr_pw_name"/,
+    );
+    // Seeding must never clobber a real agent-installed revision dir.
+    expect(startSh).toMatch(/\[\s+!\s+-e\s+"\$sr_pw_cache\/\$sr_pw_name"\s+\]/);
+  });
+
+  it("disables Playwright's browser GC so a skew install can't delete the seeds", () => {
+    // The seed symlinks in the HOME cache carry no `.links/<sha1>` reference
+    // entry (the baked packages registered theirs in /opt/.../.links at build
+    // time, which the boot seeding does not copy). So the GC sweep that every
+    // `playwright install` runs before downloading — deleting any revision not
+    // referenced in `.links` — would remove the fleet-default seed symlinks the
+    // first time a project pins a DIFFERENT Playwright version and installs its
+    // browser, silently breaking the zero-download guarantee. Disabling GC via
+    // this env is what keeps the seeds (and the project's own installs) intact.
+    // Without this line the skew workflow this change enables regresses the
+    // fleet-default zero-download path, so guard it deterministically.
+    expect(dockerfile).toMatch(/ENV\s+PLAYWRIGHT_SKIP_BROWSER_GC=1\s*$/m);
+  });
+});
+
+/**
  * Cloakbrowser — the local stealth Chromium driver used by webkite's
  * `webkite mcp` stdio MCP. The webkite binary itself is operator-
  * mounted (private beta); cloakbrowser's Python tool is baked here

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -537,6 +537,31 @@ describe("findChromium", () => {
     }
   });
 
+  it("falls back to the image-baked /opt layout when env + HOME caches are empty (#playwright-skew)", () => {
+    // Since #playwright-skew the runtime PLAYWRIGHT_BROWSERS_PATH points
+    // at the per-agent HOME cache, not the /opt bake — doctor must still
+    // find the baked chromium directly (e.g. before start.sh's boot
+    // seeding has linked it into the HOME cache).
+    const bakedDir = join(tempHome, "opt", "playwright", "browsers");
+    const browserDir = join(bakedDir, "chromium-1228", "chrome-linux64");
+    mkdirSync(browserDir, { recursive: true });
+    const chromePath = join(browserDir, "chrome");
+    writeFileSync(chromePath, "#!/bin/sh\nexit 0\n");
+    chmodSync(chromePath, 0o755);
+
+    const origPath = process.env.PATH;
+    process.env.PATH = "";
+    try {
+      // env empty ("" — not undefined, which would fall back to the
+      // HOST's real PLAYWRIGHT_BROWSERS_PATH when the suite runs inside
+      // an agent container) + empty HOME cache → only the baked-path
+      // fallback hits.
+      expect(findChromium(tempHome, "", bakedDir)).toBe(chromePath);
+    } finally {
+      process.env.PATH = origPath;
+    }
+  });
+
   it("finds chromium_headless_shell binaries (Playwright >=1.40 layout)", () => {
     // Playwright 1.40+ ships a separate `chromium_headless_shell-*`
     // browser whose binary is `headless_shell`, not `chrome`. v0.7.13's


### PR DESCRIPTION
## Summary

A project that pins a different Playwright version than the image bake can now `playwright install` its matching browser revision. The runtime `PLAYWRIGHT_BROWSERS_PATH` moves from the immutable image bake (`/opt/playwright/browsers`) to the persistent, agent-writable per-agent HOME cache (`/state/agent/home/.cache/ms-playwright`); the bake keeps its zero-download fast path via boot-time symlinks.

Serves `reference/jobs/` outcome: agents that can actually do the work handed to them (a repo's `npx playwright test` is table stakes for webapp work).

## Why

**Verified live** (bank-analysis workspace on a fleet agent): the project pins `@playwright/test ^1.58.2`, which requires `chromium-1208`. The image bakes only 1.61.0's `chromium-1228` and sets `ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright/browsers` globally. Playwright resolves browsers from exactly ONE directory, keyed by revision subdir, so the project's runtime demands a revision the bake doesn't carry, and the auto-triggered `playwright install` writes into the bake — root-owned, **and** inside a compose `read_only: true` root fs (`src/agents/compose.ts:2268`) → hard EACCES/EROFS failure. The matching `chromium-1208` build even already sat in `~/.cache/ms-playwright`, pointed *past* by the forced env var.

**Note on the original theory:** the defect was framed as an ownership problem ("root-owned dir, non-root agent"). Root-causing against source showed ownership is only half of it — non-root agent containers run with `read_only: true`, so **no** chmod/chown/group scheme on `/opt` can ever make it runtime-writable. Any fix keeping the env on `/opt` would need a writable shared mount, which is worse (below).

## The fix

- `docker/Dockerfile.agent` — browsers still baked at `/opt/playwright/browsers` (build-time installs target it via an inline `PLAYWRIGHT_BROWSERS_PATH=${PLAYWRIGHT_BAKED_BROWSERS}` override on the two install RUNs). Runtime `ENV PLAYWRIGHT_BROWSERS_PATH=/state/agent/home/.cache/ms-playwright` — Playwright's own default location given the compose `HOME`, on the persistent host bind mount, so a skewed-version install is writable **and survives container recreate**.
- `profiles/_base/start.sh.hbs` — boot seeding (same pattern as the webkite config re-sync): symlink each baked revision dir into the HOME cache. Revision dirs are immutable + version-keyed, so links and real agent-installed dirs coexist side by side; a real dir with the same name always wins; dangling links into the bake (stale after an image bump changed the default revision) are swept. Dot-entries (`.links`) are excluded by the glob — they must stay real + writable so project installs can register. Fleet default (`@playwright/mcp`, `webapp-testing` skill) therefore still resolves with zero downloads and ~0 first-call latency.
- `src/cli/doctor.ts` — `findChromium()` probes `/opt/playwright/browsers` directly as a third fallback, so chromium detection no longer depends on the env var pointing at the bake (or on the boot seeding having run).
- In the live bank-analysis case the fix is *immediate*: the already-downloaded `chromium-1208` in `~/.cache/ms-playwright` becomes the resolved path with zero new downloads.

## Alternatives rejected

1. **Group-writable `/opt` bake (shared group + `g+w`/setgid, the initially proposed direction)** — defeated outright by `read_only: true`; also `user:` is emitted as `\"uid:uid\"` (explicit-group form), under which runc does not apply supplementary groups from `/etc/group`, so it would additionally have needed compose `group_add` plumbing. Dead end twice over.
2. **Shared writable named volume at `/opt/playwright/browsers`** — gives true fleet sharing, but: (a) volume seeds from the image only when empty, so an image bump with a new default revision silently strands the whole fleet on a stale cache (the exact drift class the bake exists to prevent); (b) a fleet-shared *writable executable* store is a real cross-agent binary-planting channel (agent A pre-creates `chromium-1208` with a trojaned binary + `INSTALLATION_COMPLETE` marker; agent B executes it) — directly against the WS6 posture. The chosen design keeps extra revisions per-agent-private.
3. **Baking multiple Playwright versions** — unbounded; every project can pin a different version.
4. **Unsetting the env per-project / documenting an override** — prompt discipline, not a mechanism; the repo's own convention (foreground-hog gate, unpinned-npx guard) is deterministic enforcement.

## Security self-review

No new writable surface outside each agent's own HOME (already agent-writable by design). `/opt` stays root-owned, read-only, byte-identical. No `chmod 0777`, no group machinery, no shared mutable executables. An agent can symlink-or-replace entries in its own HOME cache — that was already true pre-change (it owns the dir) and is same-trust-domain. Verdict: attack surface unchanged.

## Accepted residual

A project-local `playwright install` may garbage-collect the baked-revision *symlink* (if no `.links` registration references it). The bake itself is untouchable; the link is restored on next boot. Worst case is a temporary re-download-sized gap for the default MCP until restart — self-healing, and strictly better than today's hard failure.

## Test plan

- [x] `vitest run tests/docker/dockerfile-agent-bakes.test.ts tests/doctor.test.ts` — 93 passed (new pins: runtime env = HOME cache and never `/opt`; build installs target the bake; start.sh seeds symlinks non-clobbering; doctor bake-path fallback)
- [x] Existing JS==Python single-version invariant tests untouched and green
- [x] Broader sweep: `tests/docker/compose-generator.test.ts`, `tests/claude-cli-contract.test.ts`, `tests/cheap-cron-session-render.test.ts` — 342 passed / 1 skipped
- [x] `tsc --noEmit` clean; `scripts/check-no-unpinned-npx-playwright.mjs` OK
- [x] Seeding block: `bash -n` + functional sandbox run (baked revision linked; real agent-installed dir preserved; dangling stale-bake link swept; `.links` untouched)
- [ ] **Not run in-sandbox:** an actual `docker build` of the agent image (no docker daemon in the authoring sandbox; host is production per repo test discipline). Relying on the dockerfile-bakes structural tests + the fact that build-time semantics are unchanged (same installs, same bake path, env override inline). Flag for canary before fleet rollout.

## Risk

Low-medium. The env flip changes where *every* playwright consumer resolves browsers; the boot seeding is the load-bearing bridge for the fleet default. If seeding fails (unwritable HOME cache) it warns loudly and the doctor probe still reports the bake. Rollout note: first boot on the new image creates ~10 symlinks per agent; no downloads, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)