### PR TITLE
feat(hindsight): enable bounded dead-letter auto-requeue safety net (#3795/#3797)

### DIFF
--- a/src/setup/hindsight-recreate-env-survival.test.ts
+++ b/src/setup/hindsight-recreate-env-survival.test.ts
@@ -92,3 +92,33 @@ describe("reranker defaults survive a recreate with an empty hindsight.env", () 
     ]);
   });
 });
+
+/**
+ * The dead-letter auto-requeue safety net (#3795 / #3797) is OFF in the
+ * maintenance script's own defaults; it only runs on the fleet if the launcher
+ * PINS it onto the container env. This is the guard that it does — against the
+ * real derivation, on both GPU verdicts (it is unrelated to the GPU gate), with
+ * an empty `hindsight.env`. It goes red the instant the two pins are removed.
+ */
+const REQUEUE_ON = "SWITCHROOM_HINDSIGHT_REQUEUE_DEAD_LETTERS";
+const REQUEUE_MAX = "SWITCHROOM_HINDSIGHT_REQUEUE_MAX";
+
+describe("dead-letter requeue safety net is enabled on the launched container", () => {
+  it.each([true, false])(
+    "pins REQUEUE_DEAD_LETTERS=1 and REQUEUE_MAX=25 with nothing declared (gpu=%s)",
+    (gpu) => {
+      const env = envMap(gpu);
+      // ON, so the maintenance sidecar's Section-7 recovery sweep actually runs.
+      expect(env.get(REQUEUE_ON)).toBe("1");
+      // The exact bound the fleet runs — a drive-by retune has to come past this.
+      expect(env.get(REQUEUE_MAX)).toBe("25");
+    },
+  );
+
+  it("the pins survive a recreate — the next launch drops neither", () => {
+    const next = [...envMap(true)] as Array<[string, string]>;
+    const live = next.map(([k, v]) => `${k}=${v}`);
+    const dropped = diffDroppedHindsightEnv(live, next, []);
+    expect(dropped.some((d) => d.key === REQUEUE_ON || d.key === REQUEUE_MAX)).toBe(false);
+  });
+});

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -234,6 +234,32 @@ export const HINDSIGHT_DEFAULT_LITELLM_MODEL =
 export const HINDSIGHT_DEFAULT_MCP_STATELESS = true;
 
 /**
+ * Bounded dead-letter auto-requeue safety net (#3795 / #3797).
+ *
+ * `docker/hindsight-maintenance.sh` (Section 7) already implements a recovery
+ * sweep: it POSTs each FK-race dead-letter — a `retain` op the engine
+ * MISclassified as a deterministic failure during the unit_entities
+ * ForeignKeyViolation race (#3794), so it sits `status='failed'` with an
+ * intact `task_payload`, `retry_count=0`, `next_retry_at IS NULL` and is never
+ * revisited — back to the engine's own `/retry` endpoint (failed → pending),
+ * after which the worker's claim loop picks it up and the STALLED memory lands.
+ * The classifier PREVENTION fix is an engine change tracked in #3797 and is
+ * out of scope here; this is the RECOVERY half.
+ *
+ * The script reads these two knobs from its process environment and defaults
+ * them OFF (`REQUEUE_DEAD_LETTERS=0`). Nothing in `src/` surfaced them, so the
+ * sweep never ran on the fleet. Pinning them on the container's env here is the
+ * durable enable — it lands on BOTH launch paths (docker-run + compose).
+ *
+ * The bound matters because each requeued op re-runs LLM fact extraction (real
+ * spend). Steady-state FK-race rate is ~zero and the historical backlog was
+ * ~14-23, so 25/tick is a safe ceiling that clears a realistic burst without
+ * risking a large unexpected spend if the classifier regresses.
+ */
+export const HINDSIGHT_DEFAULT_REQUEUE_DEAD_LETTERS = "1";
+export const HINDSIGHT_DEFAULT_REQUEUE_MAX = "25";
+
+/**
  * DEFER the hindsight MCP tool-surface allowlist (29 advertised tools) — the
  * 2026-06-07 adversarial audit (3 independent host-caller hunts) found it is
  * high-blast-radius for ~no net benefit. Recorded so we don't re-attempt it.
@@ -1985,6 +2011,13 @@ export function hindsightContainerEnvPairs(opts: {
     // fails leaves pg0's own defaults in place rather than blocking boot.
     // See src/setup/hindsight-pg-defaults.ts.
     ...hindsightPgEnvPairs(perf),
+    // Dead-letter auto-requeue safety net, read by the maintenance sidecar
+    // (docker/hindsight-maintenance.sh Section 7). OFF in the script's own
+    // defaults; pinning it ON here is what durably enables the recovery sweep
+    // on the fleet, bounded at 25 requeues/tick to cap LLM re-extraction spend.
+    // See HINDSIGHT_DEFAULT_REQUEUE_DEAD_LETTERS / _MAX (#3795 / #3797).
+    ["SWITCHROOM_HINDSIGHT_REQUEUE_DEAD_LETTERS", HINDSIGHT_DEFAULT_REQUEUE_DEAD_LETTERS],
+    ["SWITCHROOM_HINDSIGHT_REQUEUE_MAX", HINDSIGHT_DEFAULT_REQUEUE_MAX],
   ];
 
   // The `claude-code` provider drives an underlying claude subprocess; pin
@@ -2687,6 +2720,11 @@ export function generateHindsightComposeSnippet(
     // pg0 sizing — compose twin of the docker-run block, from the SAME
     // resolver (see hindsightPgEnvPairs / hindsight-pg-defaults.ts).
     ...hindsightPgEnvPairs(perf).map(([k, v]) => `      - ${k}=${v}`),
+    // Dead-letter auto-requeue safety net — compose twin of the docker-run
+    // path's pins, so the recovery sweep is enabled identically on both launch
+    // paths (see HINDSIGHT_DEFAULT_REQUEUE_DEAD_LETTERS / _MAX, #3795 / #3797).
+    `      - SWITCHROOM_HINDSIGHT_REQUEUE_DEAD_LETTERS=${HINDSIGHT_DEFAULT_REQUEUE_DEAD_LETTERS}`,
+    `      - SWITCHROOM_HINDSIGHT_REQUEUE_MAX=${HINDSIGHT_DEFAULT_REQUEUE_MAX}`,
     `    mem_limit: ${HINDSIGHT_DEFAULT_MEM_LIMIT}`,
     `    mem_reservation: ${HINDSIGHT_DEFAULT_MEM_RESERVATION}`,
     `    pids_limit: ${HINDSIGHT_DEFAULT_PIDS_LIMIT}`,


### PR DESCRIPTION
## What

Flips **ON** the already-built, already-tested FK-race dead-letter **recovery sweep** (merged in #4083/#3795) by durably pinning its two enable knobs onto the `switchroom-hindsight` container's environment.

`docker/hindsight-maintenance.sh` (Section 7) already POSTs each dead-lettered `retain` op — the ones the engine MISclassified as a deterministic failure during the `unit_entities` `ForeignKeyViolation` race (#3794), which sit `status='failed'` with an intact `task_payload`, `retry_count=0`, `next_retry_at IS NULL` and are never revisited by the worker's claim loop — back to the engine's own `/v1/default/banks/{bank}/operations/{op}/retry` endpoint (`failed` → `pending`). The worker then re-picks it up, re-runs extraction, and the **STALLED** (not lost) memory finally lands.

The candidate query is scoped **exactly** to the FK-race signature:
`operation_type='retain' AND status='failed' AND task_payload IS NOT NULL AND retry_count=0 AND next_retry_at IS NULL`.

The two knobs (`SWITCHROOM_HINDSIGHT_REQUEUE_DEAD_LETTERS`, `SWITCHROOM_HINDSIGHT_REQUEUE_MAX`) were read **only** from the script's process environment and defaulted **OFF** — nothing in `src/` surfaced them, so the sweep never ran on the fleet.

## The change

- `src/setup/hindsight.ts`: pin `SWITCHROOM_HINDSIGHT_REQUEUE_DEAD_LETTERS=1` and `SWITCHROOM_HINDSIGHT_REQUEUE_MAX=25` in `hindsightContainerEnvPairs()` (docker-run path) and its compose twin, backed by `HINDSIGHT_DEFAULT_REQUEUE_DEAD_LETTERS` / `HINDSIGHT_DEFAULT_REQUEUE_MAX` constants.

**Why 25/tick:** each requeued op re-runs LLM fact extraction (real spend). Steady-state FK-race rate is ~zero (zero in the last 48h) and the historical backlog was ~14-23, so 25/tick is a safe ceiling that clears a realistic burst without risking a large unexpected LLM spend if the classifier regresses.

## Scope

Recovery half **only**. The classifier **prevention** fix is an engine change (`memory_engine.py`) tracked in **#3797** and is explicitly **out of scope** here — `memory_engine.py` / `Dockerfile.hindsight` are untouched.

## Test

Guard added to `src/setup/hindsight-recreate-env-survival.test.ts`: asserts both pins land on the launched container's env against the **real** derivation (`hindsightContainerEnvPairs`), on both GPU verdicts, with an empty `hindsight.env`, and survive a recreate. Verified **fails-red** without the pins (`env.get(...)` returns `undefined`) and **passes** with them. Sweep behaviour itself is already covered by `tests/docker/hindsight-maintenance.test.ts`.

## ⚠️ Operational caveat — RECREATE, not restart

Env is baked at `docker run -e` **creation** time, so a plain `docker restart` will **not** pick this up. The running `switchroom-hindsight` container needs a **recreate** — via `switchroom memory --restart` (recreates through `startHindsight`) or the next `switchroom apply`. First sweep lands **~30min** after recreate (`REFRESH_S=1800`, `docker/hindsight-entrypoint.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)