### PR TITLE
test(hindsight): guard compose-path REQUEUE_* env pins (#4396)

### DIFF
--- a/src/setup/hindsight-recreate-env-survival.test.ts
+++ b/src/setup/hindsight-recreate-env-survival.test.ts
@@ -22,7 +22,12 @@
 
 import { describe, expect, it } from "vitest";
 
-import { hindsightContainerEnvPairs } from "./hindsight.js";
+import {
+  HINDSIGHT_DEFAULT_REQUEUE_DEAD_LETTERS,
+  HINDSIGHT_DEFAULT_REQUEUE_MAX,
+  generateHindsightComposeSnippet,
+  hindsightContainerEnvPairs,
+} from "./hindsight.js";
 import { diffDroppedHindsightEnv } from "./hindsight-env-drift.js";
 import {
   HINDSIGHT_DEFAULT_RERANKER_LOCAL_BATCH_SIZE,
@@ -103,6 +108,17 @@ describe("reranker defaults survive a recreate with an empty hindsight.env", () 
 const REQUEUE_ON = "SWITCHROOM_HINDSIGHT_REQUEUE_DEAD_LETTERS";
 const REQUEUE_MAX = "SWITCHROOM_HINDSIGHT_REQUEUE_MAX";
 
+/** `      - KEY=VALUE` environment lines from a compose snippet. */
+const composeEnv = (snippet: string): Map<string, string[]> => {
+  const out = new Map<string, string[]>();
+  for (const line of snippet.split("\n")) {
+    const m = line.match(/^ {6}- ([A-Z0-9_]+)=(.*)$/);
+    if (!m) continue;
+    out.set(m[1], [...(out.get(m[1]) ?? []), m[2]]);
+  }
+  return out;
+};
+
 describe("dead-letter requeue safety net is enabled on the launched container", () => {
   it.each([true, false])(
     "pins REQUEUE_DEAD_LETTERS=1 and REQUEUE_MAX=25 with nothing declared (gpu=%s)",
@@ -120,5 +136,35 @@ describe("dead-letter requeue safety net is enabled on the launched container", 
     const live = next.map(([k, v]) => `${k}=${v}`);
     const dropped = diffDroppedHindsightEnv(live, next, []);
     expect(dropped.some((d) => d.key === REQUEUE_ON || d.key === REQUEUE_MAX)).toBe(false);
+  });
+
+  // The compose snippet is an INDEPENDENT launch path with its own hand-written
+  // `environment` array (src/setup/hindsight.ts, generateHindsightComposeSnippet)
+  // — it does not derive from `hindsightContainerEnvPairs`. The docker-run
+  // assertions above therefore prove nothing about it. Without this, an edit
+  // that dropped ONLY the compose pins would leave the suite green and half the
+  // fleet (compose-launched hosts) would silently run with the recovery sweep
+  // OFF. See issue #4396 (the coverage gap left by PR #4395).
+  it("the compose snippet pins both keys too — the run/compose twin holds", () => {
+    const env = composeEnv(generateHindsightComposeSnippet());
+    expect(env.get(REQUEUE_ON)).toEqual([HINDSIGHT_DEFAULT_REQUEUE_DEAD_LETTERS]);
+    expect(env.get(REQUEUE_MAX)).toEqual([HINDSIGHT_DEFAULT_REQUEUE_MAX]);
+    // Literal values, spelled out so a drive-by retune of the constants has to
+    // come past BOTH launch paths, not just the docker-run one above.
+    expect(env.get(REQUEUE_ON)).toEqual(["1"]);
+    expect(env.get(REQUEUE_MAX)).toEqual(["25"]);
+  });
+
+  it("run and compose paths agree on the two pins, key by key", () => {
+    // Set-equality parity for the launcher-derived pins: whatever value one
+    // path emits, the other must emit the same — so the twin invariant can
+    // never drift on these keys even if the constants change.
+    const fromRun = new Map(hindsightContainerEnvPairs({ apiPort: 18888, gpu: true }));
+    const fromCompose = composeEnv(generateHindsightComposeSnippet());
+    for (const key of [REQUEUE_ON, REQUEUE_MAX]) {
+      expect(fromCompose.get(key), `${key} must match across paths`).toEqual([
+        fromRun.get(key),
+      ]);
+    }
   });
 });


### PR DESCRIPTION
## What

Closes the compose-path coverage gap from merged PR #4395.

PR #4395 pinned `SWITCHROOM_HINDSIGHT_REQUEUE_DEAD_LETTERS=1` / `SWITCHROOM_HINDSIGHT_REQUEUE_MAX=25` on the `switchroom-hindsight` container via **both** independent launch paths in `src/setup/hindsight.ts`:
- docker-run: `hindsightContainerEnvPairs()`
- compose snippet: `generateHindsightComposeSnippet`'s own local `environment` array

But the guard test `hindsight-recreate-env-survival.test.ts` only asserted the two keys on the **docker-run** path. Nothing exercised the compose snippet, so an edit dropping *only* the compose pins would leave the suite green while compose-launched hosts silently ran the dead-letter recovery sweep OFF — the run/compose twin invariant could drift on these two keys undetected.

## Change (test-only)

Extends `hindsight-recreate-env-survival.test.ts` with two compose-path assertions, mirroring the `composeEnv(...)` helper pattern from `hindsight-pg-defaults.test.ts`:
1. the compose snippet pins both keys (literal `1` / `25`), and
2. a run-vs-compose set-equality parity check for the two pins.

Production `hindsight.ts` is untouched (the pins are already correct on both paths).

## Fails-red proof

Temporarily deleting the two compose pins (`hindsight.ts` ~L2726-2727) turns both new tests red:

```
AssertionError: SWITCHROOM_HINDSIGHT_REQUEUE_DEAD_LETTERS must match across paths: expected undefined to deeply equal [ '1' ]
 Tests  2 failed | 8 passed (10)
```

Restored, all 10 tests pass. `tsc --noEmit` clean on the touched file.

Closes #4396

🤖 Generated with [Claude Code](https://claude.com/claude-code)