### PR TITLE
fix(hindsight-watch): retain-queue-growth is WARN, not a red loss page

### DIFF
--- a/src/hindsight-watch/evaluate.test.ts
+++ b/src/hindsight-watch/evaluate.test.ts
@@ -172,7 +172,51 @@ describe("evaluateQueueGrowth — recalibrated for #3610's split (parts, not mem
   });
 });
 
+describe("evaluateQueueGrowth — a backlog is WARN, never a loss-grade page", () => {
+  it("a high, under-cap backlog fires at most a WARN so it can never read as loss", () => {
+    // The 2026-08-05 false alarm: a ~2,300-part fleet backlog (klanker 1,051 +
+    // overlord 860, both under the 2,000-entry per-agent cap) rising and
+    // draining slowly, with every loss channel at zero. It must alert as 🟠
+    // "degraded" (severity `warn`), NOT the 🔴 red an operator reads as
+    // "memories are being lost", and its wording must disclaim loss.
+    const v = evaluateQueueGrowth([sample(0, { pending: 0 }), sample(4, { pending: 2308 })]);
+    expect(v.state).toBe("breach");
+    expect(v.severity).toBe("warn");
+    expect(v.detail).toContain("NOT loss");
+  });
+});
+
 describe("evaluateRetainLoss — memory that left the queue unpersisted", () => {
+  it("does NOT fire on a high, under-cap backlog with archive-count trims present", () => {
+    // The other half of the 2026-08-05 false alarm: pending-retains climbing
+    // to ~2,300 parts (under the 2,000-entry per-agent cap) while
+    // `pending-evictions.log` fills with `reason=archive-count` trims of the
+    // DURABLE `pending-reconciled/` archive. Those trims are housekeeping of
+    // already-persisted entries; this signal reads `pending-evicted/` (real
+    // undrained eviction), never the archive-count ledger, so a deep-but-
+    // draining spool with flat loss channels must NOT claim memory loss.
+    const v = evaluateRetainLoss([
+      sample(0, { pending: 1900, dead: 0, evicted: 0, drops: 0 }),
+      sample(1, { pending: 2308, dead: 0, evicted: 0, drops: 0 }),
+    ]);
+    expect(v.state).toBe("ok");
+    expect(v.detail).toContain("no new memory loss");
+  });
+
+  it("DOES fire when undrained entries are evicted at the per-agent cap", () => {
+    // The real loss case the false alarm was drowning out: `pending-retains`
+    // hit `HINDSIGHT_PENDING_MAX_ENTRIES` and `_evict_to_fit` shed undrained
+    // (non-durable) entries into `pending-evicted/`. That IS memory leaving
+    // the queue unpersisted and MUST fire the loss alarm.
+    const v = evaluateRetainLoss([
+      sample(0, { pending: 2000, evicted: 0 }),
+      sample(1, { pending: 2000, evicted: 37 }),
+    ]);
+    expect(v.state).toBe("breach");
+    expect(v.measured?.evictedAdded).toBe(37);
+    expect(v.detail).toContain("memory left the queue unpersisted");
+  });
+
   it("FIRES on a single new .dead marker", () => {
     const v = evaluateRetainLoss([sample(0, { dead: 135 }), sample(1, { dead: 136 })]);
     expect(v.state).toBe("breach");

--- a/src/hindsight-watch/evaluate.ts
+++ b/src/hindsight-watch/evaluate.ts
@@ -137,6 +137,23 @@ export function evaluateFailureRate(ring: Sample[]): Verdict {
  * not memories — because that is what a queue entry is once oversized
  * retains are split. `QUEUE_FLOOR` and `QUEUE_GROWTH_MIN_ABS` carry the
  * conversion and its measurement.
+ *
+ * Severity is `warn`, NEVER a page — this is the correction to the 2026-08-05
+ * false alarm. A rising spool is a retry backlog draining slowly, NOT memory
+ * loss: the spool is DURABLE, every entry is retried until it persists, and a
+ * memory only leaves it UNpersisted at the per-agent
+ * `HINDSIGHT_PENDING_MAX_ENTRIES` / `MAX_BYTES` cap — which `retain-loss`
+ * watches via the `pending-evicted/` sibling. So this signal must render 🟠
+ * "degraded", not the 🔴 red an operator reads as "memories are being lost".
+ *
+ * Evidence (host `switchroom`, live, read-only, 2026-08-05): a ~2,300-part
+ * fleet backlog (klanker 1,051 + overlord 860, both well under the 2,000-entry
+ * per-agent cap) drained steadily with EVERY loss channel at zero — no
+ * `.dead`, no evicted entry, no drop — while all 5,459 lines of that day's
+ * `pending-evictions.log` were `reason=archive-count` trims of the DURABLE
+ * `pending-reconciled/` archive (housekeeping of already-persisted entries,
+ * capped at 500), not undrained eviction. An under-cap backlog is drain-lag;
+ * only `retain-loss` may claim loss.
  */
 export function evaluateQueueGrowth(ring: Sample[]): Verdict {
   const signal = "retain-queue-growth" as const;
@@ -150,14 +167,16 @@ export function evaluateQueueGrowth(ring: Sample[]): Verdict {
   const need = Math.max(QUEUE_GROWTH_MIN_ABS, Math.ceil(QUEUE_GROWTH_FRACTION * first));
   const breach = last >= QUEUE_FLOOR && growth >= need;
   const trend = growth > 0 ? `+${growth}` : String(growth);
-  return {
-    signal,
-    state: breach ? "breach" : "ok",
-    detail:
-      `pending retains ${first} → ${last} (${trend}) over ${mins}m ` +
-      `— fires at ≥${QUEUE_FLOOR} deep AND +${need} growth`,
-    measured: { pending: last, growth, windowMinutes: mins, growthNeeded: need },
-  };
+  const detail =
+    `pending retains ${first} → ${last} (${trend}) over ${mins}m ` +
+    `— backlog draining slowly, NOT loss (retries persist; memory is only ` +
+    `shed at the per-agent cap, watched by retain-loss). ` +
+    `Fires at ≥${QUEUE_FLOOR} deep AND +${need} growth`;
+  const measured = { pending: last, growth, windowMinutes: mins, growthNeeded: need };
+  if (breach) {
+    return { signal, state: "breach", severity: "warn", detail, measured };
+  }
+  return { signal, state: "ok", detail, measured };
 }
 
 /**
@@ -180,7 +199,12 @@ export function evaluateQueueGrowth(ring: Sample[]): Verdict {
  *    other than 408/425/429), which is close to always a genuine fault.
  *  - `pending-evicted/` — memory shed at the queue's `MAX_ENTRIES` /
  *    `MAX_BYTES` cap. Archived rather than persisted, and under a full disk
- *    `_evict_to_fit` removes outright.
+ *    `_evict_to_fit` removes outright. This is the ONLY eviction channel this
+ *    signal reads. It is NOT the `pending-evictions.log` ledger, whose
+ *    `reason=archive-count` lines are trims of DURABLE archives
+ *    (`pending-reconciled/`, capped at 500) — housekeeping of
+ *    already-persisted entries, not undrained loss. Counting those was the
+ *    root of the 2026-08-05 false alarm; this signal never has.
  *  - `pending-drops.json` — `record_drop`: the retain could not be written
  *    to the queue at all. The rarest and the most final.
  *

--- a/src/hindsight-watch/run.test.ts
+++ b/src/hindsight-watch/run.test.ts
@@ -129,6 +129,27 @@ function evicted(n: number): void {
   for (let i = 0; i < n; i++) writeFileSync(join(d, `e${i}.json`), "{}");
 }
 
+/**
+ * The DURABLE `pending-reconciled/` archive — where drained (persisted)
+ * entries are retired, capped at 500 and trimmed by `reason=archive-count`.
+ * A SIBLING of `pending-retains/`, and NOT a loss channel: the watchdog must
+ * never count it as live queue depth or as eviction. Also writes a matching
+ * `pending-evictions.log` full of archive-count trims, exactly as the live
+ * fleet had on 2026-08-05, to prove neither is read as loss.
+ */
+function reconciledArchive(n: number): void {
+  const base = join(agentsDir, "alpha", "home", ".hindsight");
+  const d = join(base, "pending-reconciled");
+  rmSync(d, { recursive: true, force: true });
+  mkdirSync(d, { recursive: true });
+  for (let i = 0; i < n; i++) writeFileSync(join(d, `r${i}.json`), "{}");
+  let log = "";
+  for (let i = 0; i < n; i++) {
+    log += `2026-08-05T11:0${i % 10}:00Z trimmed=r${i}.json bytes=1000 archive=pending-reconciled reason=archive-count archive_depth=500\n`;
+  }
+  writeFileSync(join(base, "pending-evictions.log"), log);
+}
+
 /** #3599's `record_drop` ledger — retains that never reached the queue. */
 function drops(count: number): void {
   writeFileSync(
@@ -343,6 +364,41 @@ describe("tick — end to end over a real state file", () => {
     expect(loss?.verdict.measured).toMatchObject({ evicted: 4, dead: 0, drops: 0 });
     const growth = r.outcomes.find((o) => o.verdict.signal === "retain-queue-growth");
     expect(growth?.verdict.measured?.pending).toBe(10);
+  });
+
+  // The 2026-08-05 false alarm, end to end: a deep-but-under-cap backlog with
+  // a durable `pending-reconciled/` archive being archive-count-trimmed must
+  // (a) never fire `retain-loss`, and (b) surface the backlog as an ORANGE
+  // "degraded" notice, not the RED page an operator reads as "memories are
+  // being lost". Fails against the pre-fix build, where queue-growth paged red.
+  it("a deep under-cap backlog with archive-count trims is WARN, never a loss page", async () => {
+    const sent: Sent = { texts: [] };
+    reconciledArchive(600); // durable, trimmed — must be invisible to the probe
+    spool(400); // under the 2,000-entry per-agent cap
+    const base = {
+      statePath,
+      agentsDir,
+      notify: makeNotify(sent),
+      run: dockerOk(),
+      fetchImpl: fakeFetch(metricsBody(100, 0)),
+    };
+    const t0 = Date.parse("2026-08-05T09:00:00Z");
+    // First breach: spool jumps 400 → 1200 (rising, past the floor). Level
+    // signal — silent on the first breach.
+    await tick({ ...base, nowFn: () => t0 });
+    spool(1200);
+    const r = await tick({ ...base, nowFn: () => t0 + 900_000 });
+
+    // The archive is neither live depth nor loss.
+    const growth = r.outcomes.find((o) => o.verdict.signal === "retain-queue-growth");
+    expect(growth?.verdict.measured?.pending).toBe(1200); // NOT 1200 + 600 archive
+    expect(growth?.verdict.state).toBe("breach");
+    expect(growth?.verdict.severity).toBe("warn");
+    const loss = r.outcomes.find((o) => o.verdict.signal === "retain-loss");
+    expect(loss?.verdict.state).toBe("ok");
+    // No red loss page reached the operator; the second breach would DM orange.
+    expect(sent.texts.some((t) => t.includes("🔴 hindsight: retain-loss"))).toBe(false);
+    expect(sent.texts.some((t) => t.includes("🔴 hindsight: retain-queue-growth"))).toBe(false);
   });
 
   it("fires when a retain never reached the queue at all (record_drop ledger)", async () => {


### PR DESCRIPTION
## The false alarm

`hindsight-watch` was paging the operator 🔴 red on `retain-queue-growth`
whenever the retain spool rose past the floor — a card that reads as
"memories are being lost" even when nothing is. The genuine loss signal
(`retain-loss`) was clean throughout.

## Root cause (real source, HEAD)

`evaluateQueueGrowth` fires on raw fleet part-depth (`>= QUEUE_FLOOR` and
rising) and returns **no severity**, so `formatFiring` renders it 🔴 red —
indistinguishable from a real loss page. But the spool is **durable**:
every entry is retried until it persists, and a memory only leaves it
*unpersisted* at the per-agent `HINDSIGHT_PENDING_MAX_ENTRIES` /
`MAX_BYTES` cap, which `retain-loss` already watches via the
`pending-evicted/` sibling.

Note on the premise: `retain-loss` was **already** correct — it counts
`pending-evicted/`, `.dead`, and the `record_drop` ledger, and never reads
`pending-evictions.log`. So archive-count trims were never miscounted as
loss *there*. The card an operator sees as a loss alarm is
`retain-queue-growth`, and the fix is its severity/wording.

## Live evidence (host `switchroom`, read-only, 2026-08-05)

- Fleet `pending-retains` ≈ 2,300 **parts** (klanker 1,051 + overlord 860),
  both well under the 2,000-entry per-agent cap → nothing evicted.
- Every loss channel at zero: no `.dead`, no `pending-evicted/`, no drops.
- All 5,459 lines of that day's `pending-evictions.log` were
  `reason=archive-count` trims of the **durable** `pending-reconciled/`
  archive (already-persisted entries, capped at 500) — housekeeping, not
  undrained eviction.
- The queue is measured in memory **parts**, not memories (`PARTS_PER_MEMORY`
  ≈ 6 post-#3610), so ~2,300 parts is only ~385 logical memories.

## The fix (single concern)

- `evaluateQueueGrowth` now returns `severity: "warn"` on breach, with
  reworded detail that disclaims loss ("backlog draining slowly, **NOT**
  loss — retries persist; memory is only shed at the per-agent cap, watched
  by retain-loss"). The card renders 🟠 "degraded" instead of a red loss
  page.
- `retain-loss` is unchanged and remains the **sole** loss-claiming signal;
  its docstring now states explicitly that it never reads the
  `reason=archive-count` ledger.

## Tests (assert outcomes; the severity tests fail against the pre-fix build)

- `evaluateQueueGrowth — a backlog is WARN, never a loss-grade page > a high,
  under-cap backlog fires at most a WARN so it can never read as loss`
- `evaluateRetainLoss — ... > does NOT fire on a high, under-cap backlog with
  archive-count trims present`
- `evaluateRetainLoss — ... > DOES fire when undrained entries are evicted at
  the per-agent cap`
- `tick — end to end ... > a deep under-cap backlog with archive-count trims
  is WARN, never a loss page` (proves the probe ignores `pending-reconciled/`
  and the `pending-evictions.log` ledger).

Scoped local run: `vitest run src/hindsight-watch/*.test.ts` → **106 passed**.
`tsc --noEmit` → clean. Attribution-trailer lint → OK (single commit).

## Follow-up (out of scope, filed separately)

The deployed cron watchdog's persisted ring read `pending 0` for hours while
a live probe read 2,308 — the cron appears blind to the real backlog. That
is an under-reporting bug with a different root cause than this false alarm;
filing as a separate issue rather than folding it in here.
