### PR TITLE
feat(profiles): validate externally checkable facts before asserting from training memory

### DIFF
--- a/profiles/_shared/execution-discipline.md.hbs
+++ b/profiles/_shared/execution-discipline.md.hbs
@@ -1,10 +1,10 @@
 ## Grounding — check before you assert
 
-Your memory and prior context are leads, not facts. Anything you state as true — about code, a file, a system's state, a config value, a number, a status, or what you can and can't do — must come from something you actually checked this turn. When you have a way to look, look.
+Your memory and prior context are leads, not facts. Anything you state as true — code, config, a system's state, a number, a status, or what you can and can't do — must come from something you actually checked this turn.
 
-- **Read the ground truth live.** File and code contents, git status, config, versions, running services, processes, schedules, permissions — read them with a tool, don't recall them.
-- **Prefer finding over guessing.** If the fact is reachable — the codebase, a system, a doc, a tool's output, the web — go get it before answering.
-- **Don't assert a limit you haven't tested.** Before saying "no access" / "operator-only" / "not editable" / "no handle", verify it live. A fabricated boundary is as wrong as a fabricated fact, and it stops work that was actually possible.
+- **Read the ground truth live.** Files, git status, config, versions, running services, schedules, permissions — read them with a tool, don't recall them.
+- **Training memory is a lead, not a source — prefer finding over guessing.** A library's API, a version, a CLI flag, whether a repo even exists: validate against the real thing (repo, docs, the web) before you assert it. Never answer "I don't recognize X" from model recall when X is one fetch away.
+- **Don't assert a limit you haven't tested.** Before saying "no access" / "operator-only" / "not editable", verify it live. A fabricated boundary is as wrong as a fabricated fact.
 - **A weak or empty result isn't a conclusion.** Vary the query, path, command, or source before deciding something doesn't exist.
 - **Final answers carry evidence** — tool output, a file you read, a check you ran, or a named blocker; not "it should work."
 

--- a/src/agents/profiles.test.ts
+++ b/src/agents/profiles.test.ts
@@ -494,6 +494,21 @@ describe("execution-discipline partial — fleet-wide grounding / verify-before-
     expect(fragment.toLowerCase()).toMatch(/limit you haven't tested|fabricated boundary/);
   });
 
+  it("treats training memory as a lead that needs external validation", async () => {
+    // Ken's rule (2026-08-05): an agent must not answer "I don't
+    // recognize X" from its own parametric/training memory when X is
+    // externally checkable (a repo, a library API, a version, a CLI
+    // flag) — it must fetch the real thing and validate first. This is
+    // distinct from the bank-scoped no-confabulation directive, which
+    // guards Hindsight reflect (where the model has no web tools);
+    // this one guards live turns, where it does.
+    const { renderExecutionDisciplineFragment } = await import("./profiles.js");
+    const fragment = renderExecutionDisciplineFragment();
+    expect(fragment.toLowerCase()).toContain("training memory is a lead, not a source");
+    expect(fragment.toLowerCase()).toContain("i don't recognize x");
+    expect(fragment.toLowerCase()).toMatch(/validate.*against the real thing/);
+  });
+
   it("says a weak or empty result isn't a conclusion", async () => {
     const { renderExecutionDisciplineFragment } = await import("./profiles.js");
     const fragment = renderExecutionDisciplineFragment();


### PR DESCRIPTION
## Summary
Encodes Ken's fleet-wide rule (2026-08-05): an agent must not answer "I don't recognize X" from its own parametric/training memory when X is externally checkable (a repo, a library API, a version, a CLI flag) — it must fetch the real thing (repo, docs, the web) and validate before asserting. This is stronger than the existing no-confabulation directive, which covers Hindsight recall, not training memory.

## Why this surface (design call)
Single surface: prose in `profiles/_shared/execution-discipline.md.hbs` (the Grounding section).

- **Not a seeded directive:** directives fire inside Hindsight's reflect pipeline, where the model has no web/repo tools — "validate against the web" is unactionable there, and it would permanently consume 1 of 30 MAX_DIRECTIVES slots on every agent.
- **Not SOUL:** persona/tone floor is the wrong altitude for a work-discipline rule.
- The Grounding fragment is appended unconditionally to every agent on every profile and is always loaded — exactly the scope of the rule (live turns, where fetch tools exist).

The new rule is merged into the overlapping "Prefer finding over guessing" bullet rather than added beside it, and adjacent enumerations are trimmed, to stay inside the CLAUDE.md byte anti-inflation ratchet (31506 + 500 grace; main was already ~450 bytes into the grace band, so a net-new bullet busts it).

## Test plan
- New pinning test in `src/agents/profiles.test.ts` ("treats training memory as a lead that needs external validation") — fails without the fragment change.
- Local: `vitest run src/agents/profiles.test.ts tests/scaffold.persona.test.ts` (byte ratchet) plus `tests/scaffold.claude-md-two-section`, `rerender-claude-md`, `check-claude-md-byte-ratchet`, `scaffold.test.ts`, `soul-user-owned`, `src/memory/` — 378+76 passed. `npm run lint` clean.
- Verified no test or code pins the trimmed phrases ("When you have a way to look, look", "no handle", "File and code contents", "stops work that was actually possible").

## Risk
Prompt-only change to a shared fragment; lands on agents at next reconcile/restart. Rendered root-tier default CLAUDE.md is ~31993 bytes, just under the ratchet ceiling+grace — the next always-loaded prompt addition will need to cut elsewhere (that is the ratchet working as designed).

Job: `reference/jobs/feel-like-a-colleague.md` ("verifies before claiming").

🤖 Generated with [Claude Code](https://claude.com/claude-code)