### PR TITLE
feat(self-improve): eval-case sink — corrections become regression tests (PR1)

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -326,6 +326,31 @@ it isn't re-proposed every week. Approval is **T2 one-tap** (a synthesized
 personal skill lives in the agent's own reversible workspace), not a T3
 explicit ask — the operator tap is still required (`no-self-escalation`).
 
+### Corrections become eval cases
+
+The same review loop can turn a **correction** into a durable **regression
+test** rather than a skill edit. When the review decides a past mistake should
+be pinned so a future edit can't silently reintroduce it, it runs:
+
+```
+switchroom self-improve add-eval-case --skill <slug> \
+  --prompt "<the correction, phrased as a test prompt>"
+```
+
+This is **propose-only** — it writes nothing to the skill. It validates and
+dedups the case, runs a deterministic **PII/secret scan fail-closed** (a real
+scanner, not just a prompt instruction), then posts a one-tap Telegram card.
+On Approve the gateway runs the **deterministic `apply-eval-case` applier** (no
+model turn), which re-scans fail-closed and appends the case byte-exact to the
+skill's `evals/evals.json`. A skill's `evals/evals.json` is therefore
+**machine-managed**: an always-on hook hard-blocks a raw model `Write`/`Edit`
+to it on every turn (set `SWITCHROOM_SELF_IMPROVE=0` to hand-author with
+skill-creator instead). Once a case exists, the apply-guard eval gate blocks
+any future skill edit whose pass-rate regresses below the eval floor — the
+correction now defends itself. Silent auto-apply of a verified edit stays OFF
+by default (`SWITCHROOM_SELF_IMPROVE_T1_LIVE` opt-in); until set, every
+otherwise-allowable edit is downgraded to a T2 one-tap proposal.
+
 ## Comparison with Claude Code's native scheduling
 
 | | Switchroom (in-agent scheduler) | Claude Code CronCreate | Claude Code Desktop |

--- a/scripts/callback-ctx-wrapping-baseline.json
+++ b/scripts/callback-ctx-wrapping-baseline.json
@@ -14,7 +14,7 @@
     "telegram-plugin/gateway/agent-button-callback-handler.ts": 5,
     "telegram-plugin/gateway/approval-callback.ts": 7,
     "telegram-plugin/gateway/ask-callback-handler.ts": 5,
-    "telegram-plugin/gateway/callback-query-handlers.ts": 86,
+    "telegram-plugin/gateway/callback-query-handlers.ts": 95,
     "telegram-plugin/gateway/folder-picker-handler.ts": 11,
     "telegram-plugin/gateway/gateway.ts": 34,
     "telegram-plugin/gateway/voice-ondemand-callback-handler.ts": 4

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -6993,15 +6993,20 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
         },
         {
           // RFC native-by-default skill authoring, Phase 1 — advisory
-          // skill-shape linter. Scoped to file-write tools; the hook
-          // itself no-ops unless the target path is under
+          // skill-shape linter. Scoped to file-write tools + Bash; the
+          // hook itself no-ops unless the target path is under
           // `.claude/skills/`. Non-blocking (returns additionalContext)
-          // except the per-skill byte cap, the only hard stop.
+          // except the per-skill byte cap and the machine-managed
+          // evals.json write-block (the hard stops). Bash is in the
+          // matcher so a shell redirect/write into a machine-managed
+          // evals.json (`bash -c '… > …/evals/evals.json'`) is blocked
+          // the same way a Write is — it otherwise never carries a
+          // file_path and slipped past the PII scan and operator tap.
           //
           // DOCKER_BUNDLED_HOOKS_PATH (not DOCKER_HOOKS_PATH): bundled
           // via scripts/build.mjs from src/cli/skill-validate-pretool.ts
           // because it imports the shared validators in skill-common.ts.
-          matcher: "^(Write|Edit|MultiEdit)$",
+          matcher: "^(Write|Edit|MultiEdit|Bash)$",
           hooks: [
             {
               type: "command",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -40,6 +40,7 @@ import { registerAgentConfigSkillWriteCommands } from "./agent-config-skill-writ
 import { registerSkillCommand } from "./skill.js";
 import { registerSkillPersonalCommands } from "./skill-personal.js";
 import { registerSelfImproveProposeSkillCommand } from "./self-improve-propose-skill.js";
+import { registerSelfImproveEvalCaseCommands } from "./self-improve-eval-case.js";
 import { registerSkillSearchCommand } from "./skill-search.js";
 import { registerAgentConfigMcpCommand } from "./mcp-agent-config.js";
 import { registerHostdMcpCommand } from "./mcp-hostd.js";
@@ -116,6 +117,7 @@ registerAgentConfigSkillWriteCommands(program);
 registerSkillCommand(program);
 registerSkillPersonalCommands(program);
 registerSelfImproveProposeSkillCommand(program);
+registerSelfImproveEvalCaseCommands(program);
 registerSkillSearchCommand(program);
 registerAgentConfigMcpCommand(program);
 registerHostdMcpCommand(program);

--- a/src/cli/self-improve-eval-case.ts
+++ b/src/cli/self-improve-eval-case.ts
@@ -1,0 +1,329 @@
+/**
+ * `switchroom self-improve add-eval-case` / `apply-eval-case`
+ * (RFC amendment §"corrections as eval cases").
+ *
+ * TWO commands, two halves of the sanctioned sink — the ONLY way an eval
+ * case is allowed to land (the always-on skill-validate hook hard-blocks a
+ * raw model Write/Edit to evals/evals.json):
+ *
+ *   add-eval-case   — PROPOSE-ONLY. Validates + dedups + PII/secret-scans a
+ *     case, then sends a `post_eval_case_proposal` IPC to the gateway, which
+ *     persists it and posts a one-tap Telegram card. Writes NOTHING to the
+ *     skill (on-leash / no-self-escalation). This is what the forked review
+ *     turn calls when a correction should become a regression test.
+ *
+ *   apply-eval-case — the DETERMINISTIC applier the GATEWAY runs (via
+ *     execFileSync) when the operator taps Approve. It re-reads the stored
+ *     proposal, re-runs the PII/secret scan FAIL-CLOSED (invariant I4:
+ *     scanned at propose AND at approved-apply), appends the case byte-exact
+ *     (no model turn — the case lands exactly as approved), then records the
+ *     new evals.json as the sanctioned integrity baseline so the Stop-hook
+ *     sweep doesn't mistake the applier's own write for drift.
+ *
+ * HONESTY (MJ2): the applier's `status === "approved"` check is
+ * DEFENSE-IN-DEPTH, not an authorization boundary — the proposal record
+ * lives in the agent-writable state dir. The real authorization is the
+ * operator's tap: only the gateway callback sets `approved` and only it
+ * invokes this applier.
+ */
+
+import { createConnection } from "node:net";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import type { Command } from "commander";
+
+import { ownsSkill } from "../self-improve/apply-guard.js";
+import {
+  parseEvalCase,
+  caseFingerprint,
+  readEvalsDoc,
+  appendEvalCase,
+  appendHeldOutCase,
+  recordEvalBaseline,
+  type EvalCase,
+} from "../self-improve/eval-cases.js";
+import { scanForPII, summarizeFindings } from "../self-improve/pii-scan.js";
+import {
+  getEvalCaseProposal,
+  type EvalCaseProposal,
+} from "../self-improve/eval-case-proposals.js";
+
+const IPC_CONNECT_TIMEOUT_MS = 5000;
+
+function stateDir(): string {
+  return (
+    process.env.TELEGRAM_STATE_DIR ??
+    join(homedir(), ".claude", "channels", "telegram")
+  );
+}
+
+function gatewaySocketPath(): string {
+  return (
+    process.env.SWITCHROOM_GATEWAY_SOCKET ??
+    join(stateDir(), "gateway.sock")
+  );
+}
+
+function skillDirFor(slug: string): string {
+  return join(homedir(), ".claude", "skills", slug);
+}
+
+function fail(msg: string, code = 1): never {
+  console.error(msg);
+  process.exit(code);
+}
+
+/** The textual content of a case that must be PII/secret-clean. */
+function caseText(ec: EvalCase): string {
+  return [ec.prompt, ec.expected_output ?? "", ...(ec.expectations ?? []), ec.source ?? ""]
+    .filter(Boolean)
+    .join("\n");
+}
+
+/** Send an IPC payload, resolving once written (fire-and-go). */
+function sendIpc(payload: Record<string, unknown>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const sock = createConnection({ path: gatewaySocketPath() });
+    const t = setTimeout(() => {
+      sock.destroy();
+      reject(new Error("gateway IPC connect timeout"));
+    }, IPC_CONNECT_TIMEOUT_MS);
+    sock.on("connect", () => {
+      clearTimeout(t);
+      sock.write(JSON.stringify(payload) + "\n", () => {
+        sock.end();
+        resolve();
+      });
+    });
+    sock.on("error", (err) => {
+      clearTimeout(t);
+      reject(new Error(`gateway IPC error: ${err.message}`));
+    });
+  });
+}
+
+interface AddOpts {
+  skill: string;
+  prompt?: string;
+  case?: string;
+  expectation?: string[];
+  expectedOutput?: string;
+  source?: string;
+  heldOut?: boolean;
+  chat: string;
+  thread?: string;
+  agent?: string;
+}
+
+function buildCaseFromOpts(opts: AddOpts): EvalCase {
+  let raw: unknown;
+  if (opts.case) {
+    try {
+      raw = JSON.parse(readFileSync(opts.case, "utf-8"));
+    } catch (e) {
+      fail(`failed to read/parse --case: ${(e as Error).message}`);
+    }
+  } else if (opts.prompt) {
+    raw = {
+      prompt: opts.prompt,
+      ...(opts.expectedOutput ? { expected_output: opts.expectedOutput } : {}),
+      ...(opts.expectation && opts.expectation.length > 0
+        ? { expectations: opts.expectation }
+        : {}),
+      ...(opts.source ? { source: opts.source } : {}),
+    };
+  } else {
+    fail("provide the case with --prompt <text> or --case <path-to-json>");
+  }
+  const parsed = parseEvalCase(raw);
+  if (!parsed.ok) fail(`invalid eval case: ${parsed.error}`);
+  return parsed.case;
+}
+
+function registerAdd(parent: Command): void {
+  parent
+    .command("add-eval-case")
+    .description(
+      "Propose an eval case for a skill as a one-tap Telegram approval card",
+    )
+    .requiredOption("--skill <slug>", "target skill slug (a skill you own)")
+    .option("--prompt <text>", "the correction, framed as a test prompt")
+    .option("--case <path>", "path to a JSON eval-case object (alternative to --prompt)")
+    .option(
+      "--expectation <text>",
+      "an assertion the grader should check (repeatable)",
+      (v: string, acc: string[]) => {
+        acc.push(v);
+        return acc;
+      },
+      [] as string[],
+    )
+    .option("--expected-output <text>", "optional reference/expected output")
+    .option("--source <text>", "provenance note (e.g. which correction)")
+    .option("--held-out", "route to the held-out sink (not evals.json)")
+    .requiredOption("--chat <id>", "agent's own chat id to post the card to")
+    .option("--thread <id>", "forum topic thread id")
+    .option("--agent <name>", "agent name (defaults to $SWITCHROOM_AGENT_NAME)")
+    .action((opts: AddOpts) => {
+      const agent = opts.agent ?? process.env.SWITCHROOM_AGENT_NAME;
+      if (!agent) fail("agent name required (--agent or $SWITCHROOM_AGENT_NAME)");
+
+      const dir = skillDirFor(opts.skill);
+      if (!ownsSkill(dir)) {
+        fail(
+          `skill "${opts.skill}" is not an owned skill dir at ${dir} ` +
+            `(missing, or a shared/bundled symlink) — can't add an eval case to it`,
+        );
+      }
+
+      const ec = buildCaseFromOpts(opts);
+      const fp = caseFingerprint(ec.prompt);
+
+      // Dedup against the skill's existing evals (idempotent sink).
+      const doc = readEvalsDoc(dir);
+      if (
+        doc &&
+        doc.evals.some(
+          (e) => typeof e?.prompt === "string" && caseFingerprint(e.prompt) === fp,
+        )
+      ) {
+        fail(`this correction is already an eval case for "${opts.skill}" (no-op)`);
+      }
+
+      // PII/secret scan — FAIL-CLOSED at propose time (invariant I4).
+      const scan = scanForPII(caseText(ec));
+      if (!scan.ok) {
+        fail(
+          `eval case rejected — PII/secret scan found: ${summarizeFindings(scan.findings)}. ` +
+            `Redact the correction before proposing it as a test case.`,
+        );
+      }
+
+      const payload: Record<string, unknown> = {
+        type: "post_eval_case_proposal",
+        agentName: agent,
+        chatId: opts.chat,
+        skillSlug: opts.skill,
+        skillDir: dir,
+        case: ec,
+        fingerprint: fp,
+        heldOut: opts.heldOut === true,
+      };
+      if (opts.thread != null) {
+        const n = Number.parseInt(opts.thread, 10);
+        if (Number.isInteger(n)) payload.threadId = n;
+      }
+
+      sendIpc(payload)
+        .then(() => {
+          console.log(
+            JSON.stringify({
+              ok: true,
+              action: "add-eval-case",
+              skill: opts.skill,
+              fingerprint: fp,
+              held_out: opts.heldOut === true,
+              agent,
+            }),
+          );
+        })
+        .catch((err: Error) => fail(`add-eval-case failed: ${err.message}`));
+    });
+}
+
+interface ApplyOpts {
+  id: string;
+}
+
+function registerApply(parent: Command): void {
+  parent
+    .command("apply-eval-case")
+    .description(
+      "Deterministically apply an operator-approved eval-case proposal " +
+        "(invoked by the gateway on Approve; not for manual use)",
+    )
+    .requiredOption("--id <proposalId>", "the approved proposal id")
+    .action((opts: ApplyOpts) => {
+      const sd = stateDir();
+      const proposal: EvalCaseProposal | undefined = getEvalCaseProposal(sd, opts.id);
+      if (!proposal) fail(`no eval-case proposal ${opts.id} in ${sd}`);
+
+      // DEFENSE-IN-DEPTH (MJ2), not an authorization boundary: the store is
+      // agent-writable. The real authorization is the operator's tap — only
+      // the gateway callback sets `approved` and only it invokes this applier.
+      if (proposal.status !== "approved") {
+        fail(
+          `proposal ${opts.id} is "${proposal.status}", not "approved" — refusing to apply`,
+        );
+      }
+
+      const ec = proposal.case;
+      // Re-scan FAIL-CLOSED at apply time (invariant I4: propose AND apply).
+      const scan = scanForPII(caseText(ec));
+      if (!scan.ok) {
+        fail(
+          `apply refused — PII/secret scan found: ${summarizeFindings(scan.findings)}`,
+        );
+      }
+
+      if (proposal.held_out) {
+        appendHeldOutCase(sd, proposal.skill_slug, ec);
+        console.log(
+          JSON.stringify({
+            ok: true,
+            action: "apply-eval-case",
+            applied: true,
+            held_out: true,
+            skill: proposal.skill_slug,
+          }),
+        );
+        process.exit(0);
+      }
+
+      const dir = proposal.skill_dir;
+      if (!existsSync(dir)) fail(`skill dir gone: ${dir}`);
+
+      const res = appendEvalCase(dir, proposal.skill_slug, ec);
+      if (!res.ok) {
+        if (res.duplicate) {
+          // Idempotent: already present. Not an error.
+          console.log(
+            JSON.stringify({
+              ok: true,
+              action: "apply-eval-case",
+              applied: false,
+              reason: "duplicate",
+              skill: proposal.skill_slug,
+            }),
+          );
+          process.exit(0);
+        }
+        fail(`append failed: ${res.reason}`);
+      }
+
+      // Record the new evals.json as the sanctioned integrity baseline, so the
+      // Stop-hook sweep does NOT read the applier's own write as out-of-band
+      // drift and revert it. This is what keeps the applier the single writer.
+      recordEvalBaseline(sd, proposal.skill_slug, dir);
+
+      console.log(
+        JSON.stringify({
+          ok: true,
+          action: "apply-eval-case",
+          applied: true,
+          skill: proposal.skill_slug,
+          case_id: res.ok ? res.case.id : undefined,
+          total: res.ok ? res.total : undefined,
+        }),
+      );
+    });
+}
+
+export function registerSelfImproveEvalCaseCommands(program: Command): void {
+  const parent =
+    program.commands.find((c) => c.name() === "self-improve") ??
+    program.command("self-improve").description("Agent self-improvement ops");
+  registerAdd(parent);
+  registerApply(parent);
+}

--- a/src/cli/self-improve-stop.ts
+++ b/src/cli/self-improve-stop.ts
@@ -41,6 +41,7 @@ import {
   writeReviewContext,
   clearReviewContext,
 } from "../self-improve/review-context.js";
+import { sweepEvalIntegrity } from "../self-improve/eval-cases.js";
 import type { TurnMessage } from "../self-improve/types.js";
 
 /** Newest-last window of messages to scan. Bounds the gate's cost and
@@ -249,9 +250,29 @@ function injectReview(agentName: string, text: string, sessionId: string): void 
   sock.on("error", () => done());
 }
 
+/** Agent skills root — where owned skill bundles (and their evals) live. */
+function resolveSkillsRoot(): string {
+  return join(homedir(), ".claude", "skills");
+}
+
 function main(): void {
   // Opt-out kill switch (RFC: ships on by default, per-agent disable).
   if (!selfImproveEnabled()) process.exit(0);
+
+  // Eval-integrity sweep (RFC amendment §"corrections as eval cases", MJ1).
+  // Runs EVERY turn, before anything transcript-dependent: adopt a first-sight
+  // evals.json as the sanctioned baseline ONLY if it passes the fail-closed
+  // PII/secret scan (MAJOR 2 — un-sanctioned bytes from a Bash write are
+  // quarantined, never silently trusted), and REVERT any out-of-band drift
+  // from the baseline snapshot. Tamper-EVIDENT + self-healing, NOT a
+  // cryptographic boundary — the hard backstop is the T1-live gate (default
+  // OFF). Best-effort and never throws; the Stop hook is fail-open. Cheap when
+  // no skill ships evals (a single readdir that finds nothing).
+  try {
+    sweepEvalIntegrity(resolveSkillsRoot(), resolveStateDir());
+  } catch {
+    /* fail-open: a sweep error must never fail the turn */
+  }
 
   const raw = readStdin().trim();
   if (!raw) process.exit(0);

--- a/src/cli/skill-validate-pretool.ts
+++ b/src/cli/skill-validate-pretool.ts
@@ -1,7 +1,7 @@
 /**
  * PreToolUse hook — RFC "native-by-default skill authoring", Phase 1.
  *
- * Fires on Write / Edit / MultiEdit. When the target path is inside an
+ * Fires on Write / Edit / MultiEdit / Bash. When the target path is inside an
  * agent's own `.claude/skills/<slug>/` tree it lints the write against
  * the same skill-shape rules the (deprecated) `skill_*` MCP tools
  * enforced — but **advisory only**: it never blocks a malformed skill,
@@ -29,7 +29,7 @@
  */
 
 import { readFileSync, lstatSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import {
   MAX_SKILL_BYTES,
@@ -37,9 +37,19 @@ import {
   validateRelPath,
   validateSkillMd,
 } from "./skill-common.js";
+import { selfImproveEnabled } from "../self-improve/config.js";
 
 const SKILLS_SEGMENT = "/.claude/skills/";
 const EDIT_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
+
+/** The one bundle file that is machine-managed under self-improvement. */
+const EVALS_JSON_REL = "evals/evals.json";
+
+/** An ABSOLUTE path that is a skill bundle's machine-managed evals.json
+ *  (`<...>/.claude/skills/<slug>/evals/evals.json`). Used by the Bash-command
+ *  scan after lexical canonicalization. */
+const ABS_SKILL_EVALS_RE =
+  /\/\.claude\/skills\/[^/]+\/evals\/evals\.json$/;
 
 function readStdin(): string {
   try {
@@ -113,6 +123,104 @@ function fileSize(p: string): number {
   }
 }
 
+// ── Bash-command scan (MAJOR 2 — close the Bash-write hole) ──────────
+//
+// The Write/Edit/MultiEdit block above cannot see a `bash -c '… >
+// .../evals/evals.json'`: a Bash tool call never carries a `file_path`, so a
+// shell redirect (or `tee`/`cp`/`mv`/…) into a machine-managed evals.json used
+// to slip past BOTH the PII/secret scan and the operator's one-tap approval.
+// This scan closes the demonstrated vectors deterministically. It is a
+// command-string heuristic, NOT a perfect shell parser (false negatives are
+// possible — e.g. an exotic writer or an eval-built path), so it is paired with
+// the honest Stop-hook sweep (eval-cases.ts sweepEvalIntegrity), which refuses
+// to adopt un-sanctioned evals.json bytes as a trusted baseline. Between the
+// two, no path (Write/Edit/MultiEdit/Bash) lands un-scanned, un-tapped bytes
+// that later become a trusted baseline.
+
+/** Utilities that WRITE their path argument(s) (parity with the redirect
+ *  detector — a Bash redirect is the primary vector, these are secondary). */
+const BASH_WRITERS = new Set([
+  "tee", "cp", "mv", "dd", "install", "truncate", "rsync",
+]);
+
+/** Does a raw command token (after stripping surrounding quotes) lexically
+ *  resolve to a skill bundle's machine-managed evals.json? `resolve()` is
+ *  lexical (no fs / symlink touch) and collapses `..` / `.` / redundant
+ *  separators — the SAME canonicalization the Write path now uses, so a
+ *  crafted `.../evals/../evals/evals.json` is caught identically. */
+function tokenIsSkillEvalsJson(token: string): boolean {
+  const t = token.replace(/^['"]+/, "").replace(/['"]+$/, "");
+  if (!t.includes(".claude/skills/")) return false;
+  // Anchor at root so a relative fragment (`.claude/skills/…`) still resolves;
+  // an absolute token is unchanged by resolve("/", abs).
+  return ABS_SKILL_EVALS_RE.test(resolve("/", t));
+}
+
+/** An output redirect (`>` / `>>`, not a `2>&1`-style fd-dup) whose TARGET is a
+ *  skill's evals.json — the primary Bash vector (`echo … > …/evals.json`). */
+function redirectWritesEvals(command: string): boolean {
+  const re = /(?:^|[^0-9<>&])>>?\s*(['"]?)([^\s'"|;&()<>]+)\1/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(command)) !== null) {
+    if (m[2] && tokenIsSkillEvalsJson(m[2])) return true;
+  }
+  return false;
+}
+
+/** A writer utility (or `sed -i`) whose path argument is a skill's evals.json.
+ *  Segmented on shell separators so a read in one segment can't be blamed on a
+ *  writer verb in another. */
+function writerVerbWritesEvals(command: string): boolean {
+  for (const seg of command.split(/&&|\|\||[;|\n]/g)) {
+    const tokens = seg.trim().split(/\s+/).filter((s) => s.length > 0);
+    if (tokens.length === 0) continue;
+    const verb = tokens[0]!.replace(/^['"]+/, "");
+    const rest = tokens.slice(1);
+    if (BASH_WRITERS.has(verb)) {
+      for (const tok of rest) {
+        const p = tok.startsWith("of=") ? tok.slice(3) : tok; // `dd of=<path>`
+        if (tokenIsSkillEvalsJson(p)) return true;
+      }
+    }
+    if (verb === "sed" && rest.some((r) => r === "-i" || r.startsWith("-i"))) {
+      for (const tok of rest) if (tokenIsSkillEvalsJson(tok)) return true;
+    }
+  }
+  return false;
+}
+
+/** Detect a Bash command that WRITES a machine-managed evals.json. Returns a
+ *  short human label for the block message, or null. */
+function detectBashEvalsWrite(command: string): string | null {
+  if (redirectWritesEvals(command)) return "a shell redirect into";
+  if (writerVerbWritesEvals(command)) return "a shell write into";
+  return null;
+}
+
+/** Handle a Bash tool call: block a write to a machine-managed evals.json.
+ *  Gated on self-improvement (same escape hatch as the Write path). */
+function handleBash(event: { tool_input?: unknown }): never {
+  if (!selfImproveEnabled()) allow();
+  const input =
+    event.tool_input && typeof event.tool_input === "object"
+      ? (event.tool_input as Record<string, unknown>)
+      : {};
+  const command = typeof input.command === "string" ? input.command : "";
+  if (!command) allow();
+  const how = detectBashEvalsWrite(command);
+  if (how) {
+    block(
+      `evals/evals.json is machine-managed under self-improvement — ${how} it ` +
+        `via Bash bypasses the PII/secret scan and the operator's one-tap ` +
+        `approval. Add a case with: switchroom self-improve add-eval-case ` +
+        `--skill <slug> --prompt "<the correction, as a test prompt>". ` +
+        `(To hand-author evals via skill-creator instead, set ` +
+        `SWITCHROOM_SELF_IMPROVE=0.)`,
+    );
+  }
+  allow();
+}
+
 function main(): void {
   const raw = readStdin().trim();
   if (!raw) allow();
@@ -125,14 +233,24 @@ function main(): void {
   }
 
   const toolName = typeof event.tool_name === "string" ? event.tool_name : "";
+  if (toolName === "Bash") handleBash(event);
   if (!EDIT_TOOLS.has(toolName)) allow();
 
   const input =
     event.tool_input && typeof event.tool_input === "object"
       ? (event.tool_input as Record<string, unknown>)
       : {};
-  const filePath = typeof input.file_path === "string" ? input.file_path : "";
-  if (!filePath) allow();
+  const rawFilePath =
+    typeof input.file_path === "string" ? input.file_path : "";
+  if (!rawFilePath) allow();
+
+  // Canonicalize BEFORE any path matching so `..` / `.` / redundant separators
+  // can't disguise the target (MAJOR 1: `.../evals/../evals/evals.json` must
+  // hit the same machine-managed block as the plain path). This mirrors
+  // apply-guard's resolve()-based `skillTargetEscapes`, so the always-on hook
+  // and the review-scoped guard treat crafted paths identically. resolve() is
+  // lexical (no fs / symlink touch), matching the guard.
+  const filePath = resolve(rawFilePath);
 
   const segIdx = filePath.indexOf(SKILLS_SEGMENT);
   if (segIdx < 0) allow(); // not a skill write
@@ -144,6 +262,30 @@ function main(): void {
   const slug = segs[0]!;
   const relPath = segs.slice(1).join("/");
   const skillDir = filePath.slice(0, segIdx + SKILLS_SEGMENT.length) + slug;
+
+  // Self-improve eval-case sink (RFC amendment §"corrections as eval cases",
+  // review blocker BL1). Under self-improvement, a skill's evals/evals.json is
+  // MACHINE-MANAGED: the only sanctioned way to add a case is
+  //   switchroom self-improve add-eval-case  →  one-tap card  →  deterministic
+  //   `apply-eval-case` applier (which writes via fs, NOT the Write tool, so it
+  //   never reaches this hook).
+  // A raw model Write/Edit to evals.json would bypass BOTH the deterministic
+  // PII/secret scan AND the operator's one-tap approval, so it is hard-blocked
+  // on EVERY turn — this is the ALWAYS-ON hook, not the review-scoped
+  // apply-guard (which no-ops on a normal turn: BL1). Gated behind
+  // `selfImproveEnabled()` so an operator can still hand-author evals with the
+  // skill-creator flow by setting SWITCHROOM_SELF_IMPROVE=0 (the escape hatch;
+  // the skill-creator ⇆ machine-managed tension is a filed follow-up).
+  if (selfImproveEnabled() && relPath === EVALS_JSON_REL) {
+    block(
+      `evals/evals.json is machine-managed under self-improvement — a direct ` +
+        `write bypasses the PII/secret scan and the operator's one-tap ` +
+        `approval. Add a case with: switchroom self-improve add-eval-case ` +
+        `--skill ${slug} --prompt "<the correction, as a test prompt>". ` +
+        `(To hand-author evals via skill-creator instead, set ` +
+        `SWITCHROOM_SELF_IMPROVE=0.)`,
+    );
+  }
 
   const warnings: string[] = [];
   if (!validateSkillName(slug)) {

--- a/src/self-improve/apply-guard.ts
+++ b/src/self-improve/apply-guard.ts
@@ -35,9 +35,14 @@
 import { existsSync, lstatSync, readFileSync, statSync } from "node:fs";
 import { join, resolve, sep } from "node:path";
 
-import { resolveSelfImproveConfig, type SelfImproveConfig } from "./config.js";
+import {
+  resolveSelfImproveConfig,
+  t1LiveEnabled,
+  type SelfImproveConfig,
+} from "./config.js";
 import { classifyTier } from "./tier-router.js";
 import { skillHasEvals, evalVerdict } from "./eval-gate.js";
+import { verifyEvalIntegrity } from "./eval-cases.js";
 import { appliesToday } from "./rate-limit.js";
 import type { ChangeCandidate, Tier } from "./types.js";
 
@@ -375,6 +380,24 @@ export function decideApply(p: DecideApplyParams): ApplyDecision {
     };
   }
 
+  // (5b) eval-integrity — the verdict above trusts the skill's evals.json,
+  //      so refuse to silent-apply on an eval set that has DRIFTED from its
+  //      last sanctioned state (an out-of-band edit to evals.json).
+  //      HONESTY (RFC amendment MJ1): this is defense-in-depth, tamper-
+  //      EVIDENT — NOT a cryptographic boundary. The manifest lives in the
+  //      agent-writable state dir; a model that also rewrites it defeats the
+  //      check. The HARD backstop is the T1-live gate below (default OFF).
+  //      "missing" (never recorded / first sight) and "no-evals" are not
+  //      drift, so only an explicit "drift" blocks here.
+  if (verifyEvalIntegrity(p.stateDir, target.slug, target.skillDir) === "drift") {
+    return {
+      action: "block",
+      downgradeTier: "T2",
+      reason: `eval set for "${target.slug}" drifted from its recorded baseline (out-of-band edit) — refusing to auto-apply on unverified evals; downgraded to a proposal`,
+      candidate: downgradeCandidate(target, owns, changedLines, lesson),
+    };
+  }
+
   // (6) rate-cap — ≤ N auto-applies/day.
   const used = appliesToday(p.stateDir, now);
   if (used >= cfg.maxAutoAppliesPerDay) {
@@ -386,8 +409,25 @@ export function decideApply(p: DecideApplyParams): ApplyDecision {
     };
   }
 
-  // All checks pass — a verified, small, reversible, eval-passing,
-  // under-cap edit to an owned skill. Let it land.
+  // (7) T1-live gate — THE hard backstop (RFC amendment invariant + MJ1).
+  //     Even a fully-verified T1 does NOT land SILENTLY unless the operator
+  //     has explicitly opted in with SWITCHROOM_SELF_IMPROVE_T1_LIVE=1.
+  //     Default OFF: every otherwise-allowable auto-apply is downgraded to a
+  //     T2 one-tap proposal, so the operator sees and approves it. This is
+  //     what makes a tampered eval (the manifest is only tamper-EVIDENT,
+  //     not a boundary) unable to cause a silent auto-apply. Flipping this
+  //     ON is deliberately NOT part of the eval-case PR.
+  if (!t1LiveEnabled()) {
+    return {
+      action: "block",
+      downgradeTier: "T2",
+      reason: `verified T1 for "${target.slug}", but silent auto-apply is disabled (SWITCHROOM_SELF_IMPROVE_T1_LIVE unset) — surfacing as a one-tap proposal`,
+      candidate: downgradeCandidate(target, owns, changedLines, lesson),
+    };
+  }
+
+  // All checks pass AND silent-apply is opted in — a verified, small,
+  // reversible, eval-passing, under-cap edit to an owned skill. Let it land.
   return {
     action: "allow",
     tier: "T1",

--- a/src/self-improve/config.ts
+++ b/src/self-improve/config.ts
@@ -56,3 +56,20 @@ export function resolveSelfImproveConfig(): SelfImproveConfig {
 export function selfImproveEnabled(): boolean {
   return process.env.SWITCHROOM_SELF_IMPROVE !== "0";
 }
+
+/**
+ * Whether T1 SILENT auto-apply is live (opt-IN, OFF by default).
+ *
+ * Distinct from `selfImproveEnabled` (opt-OUT, the whole subsystem): this is
+ * the hard backstop for the eval-case work (RFC amendment §"corrections as
+ * eval cases", MJ1). Even with the subsystem on, a verified T1 does NOT land
+ * silently unless the operator explicitly opts in with
+ * `SWITCHROOM_SELF_IMPROVE_T1_LIVE=1`. Until then every apply-guard "allow"
+ * is downgraded to a T2 one-tap proposal. This is what makes a tampered eval
+ * unable to cause a silent auto-apply — the integrity manifest is only
+ * tamper-EVIDENT, this gate is the boundary. Flipping it ON is NOT part of
+ * the eval-case PR.
+ */
+export function t1LiveEnabled(): boolean {
+  return process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE === "1";
+}

--- a/src/self-improve/eval-case-proposals.ts
+++ b/src/self-improve/eval-case-proposals.ts
@@ -1,0 +1,147 @@
+/**
+ * Agent self-improvement — the EVAL-CASE proposal store (RFC amendment
+ * §"corrections as eval cases").
+ *
+ * An eval case never lands silently: the CLI proposes it, a one-tap Telegram
+ * card surfaces it, and the operator's tap authorizes a DETERMINISTIC apply
+ * (the gateway runs `switchroom self-improve apply-eval-case` on tap — it does
+ * NOT inject a model turn, so the case lands byte-exact as approved). This
+ * store is the durable record the card's callback and the applier read.
+ *
+ * Mirrors skill-proposals.ts: append-only jsonl under the agent state dir,
+ * last-writer-wins on lifecycle transitions.
+ *
+ * HONESTY (RFC amendment MJ2): the applier checks `status === "approved"`
+ * before writing, but this is DEFENSE-IN-DEPTH, not an authorization
+ * boundary — this file lives in the agent-writable state dir, so a model
+ * could flip the status itself. The real authorization is the operator's tap
+ * (only the gateway's callback handler sets `approved`, and only that handler
+ * invokes the applier). The status check just stops an applier invocation
+ * with no matching proposal, or a stale/rejected one, from writing.
+ */
+
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  writeSync,
+} from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+import type { EvalCase } from "./eval-cases.js";
+
+export const EVAL_CASE_PROPOSALS_FILE = "eval-case-proposals.jsonl";
+
+export type EvalCaseProposalStatus = "pending" | "approved" | "rejected";
+
+export interface EvalCaseProposal {
+  /** Stable id; the card's callback_data carries this. */
+  id: string;
+  created_at: string;
+  status: EvalCaseProposalStatus;
+  /** Target skill slug. */
+  skill_slug: string;
+  /** Absolute path to the skill bundle dir (resolved at propose time, so the
+   *  applier writes exactly where the CLI validated). */
+  skill_dir: string;
+  /** The eval case to append (byte-exact through to apply). */
+  case: EvalCase;
+  /** Prompt fingerprint (dedup + operator-facing provenance). */
+  fingerprint: string;
+  /** Route the case to the held-out sink instead of evals.json. */
+  held_out: boolean;
+  /** Chat the card should post to. */
+  chat_id?: number;
+}
+
+function proposalsPath(stateDir: string): string {
+  return join(stateDir, EVAL_CASE_PROPOSALS_FILE);
+}
+
+function ensureDir(stateDir: string): void {
+  if (!existsSync(stateDir)) mkdirSync(stateDir, { recursive: true, mode: 0o755 });
+}
+
+function appendLine(path: string, obj: unknown): void {
+  const fd = openSync(path, "a");
+  try {
+    writeSync(fd, JSON.stringify(obj) + "\n");
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function isRecord(v: unknown): v is EvalCaseProposal {
+  return (
+    !!v &&
+    typeof v === "object" &&
+    typeof (v as EvalCaseProposal).id === "string" &&
+    typeof (v as EvalCaseProposal).skill_slug === "string" &&
+    !!(v as EvalCaseProposal).case &&
+    typeof (v as EvalCaseProposal).case === "object"
+  );
+}
+
+/** Read all proposals, collapsing to the latest record per id. */
+export function readEvalCaseProposals(stateDir: string): EvalCaseProposal[] {
+  const p = proposalsPath(stateDir);
+  if (!existsSync(p)) return [];
+  let raw: string;
+  try {
+    raw = readFileSync(p, "utf-8");
+  } catch {
+    return [];
+  }
+  const byId = new Map<string, EvalCaseProposal>();
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      if (isRecord(parsed)) byId.set(parsed.id, parsed);
+    } catch {
+      /* skip malformed */
+    }
+  }
+  return [...byId.values()];
+}
+
+export function getEvalCaseProposal(
+  stateDir: string,
+  id: string,
+): EvalCaseProposal | undefined {
+  return readEvalCaseProposals(stateDir).find((p) => p.id === id);
+}
+
+/** Persist a new pending proposal. Returns the stored record. */
+export function enqueueEvalCaseProposal(
+  stateDir: string,
+  input: Omit<EvalCaseProposal, "id" | "created_at" | "status">,
+  opts: { now?: () => number } = {},
+): EvalCaseProposal {
+  const now = opts.now ?? Date.now;
+  ensureDir(stateDir);
+  const proposal: EvalCaseProposal = {
+    id: randomUUID(),
+    created_at: new Date(now()).toISOString(),
+    status: "pending",
+    ...input,
+  };
+  appendLine(proposalsPath(stateDir), proposal);
+  return proposal;
+}
+
+/** Record a lifecycle transition (approved / rejected). */
+export function setEvalCaseProposalStatus(
+  stateDir: string,
+  id: string,
+  status: EvalCaseProposalStatus,
+): EvalCaseProposal | undefined {
+  const cur = getEvalCaseProposal(stateDir, id);
+  if (!cur) return undefined;
+  const next: EvalCaseProposal = { ...cur, status };
+  appendLine(proposalsPath(stateDir), next);
+  return next;
+}

--- a/src/self-improve/eval-cases.ts
+++ b/src/self-improve/eval-cases.ts
@@ -1,0 +1,450 @@
+/**
+ * Agent self-improvement — the EVAL-CASE SINK (RFC amendment §"corrections
+ * as eval cases").
+ *
+ * When an operator corrects the agent, the lesson should not just steer a
+ * reflect pass — it should become a *regression test* on the relevant skill,
+ * so the eval gate (eval-gate.ts) can prove the skill still handles it. This
+ * module is the deterministic library that turns a correction into an entry
+ * in a skill's `evals/evals.json` (the schema skill-creator already uses).
+ *
+ * What lives here (pure, no model, no network):
+ *   - parse + fingerprint an eval case (dedup, stable id);
+ *   - append a case to a skill's evals.json, ADD-ONLY (prior cases are
+ *     preserved verbatim — an append never edits or drops an existing case);
+ *   - a held-out sink in the state dir (cases kept OUT of evals.json, so an
+ *     edit can't be tuned to pass its own newly-added test);
+ *   - a tamper-EVIDENT integrity manifest (sha256 per skill's evals.json)
+ *     plus baseline snapshots, so the Stop-hook sweep can detect and
+ *     self-heal an out-of-band edit to evals.json.
+ *
+ * HONESTY (RFC amendment MJ1): the sha256 manifest is tamper-EVIDENT and
+ * self-healing, NOT a cryptographic boundary. The manifest and the baseline
+ * snapshots both live in the agent-writable state dir, so a model that also
+ * rewrites them defeats the check. It is NOT "Bash-proof at decision time."
+ * The HARD backstop against a tampered eval causing a bad silent apply is
+ * elsewhere: T1 silent-apply (`SWITCHROOM_SELF_IMPROVE_T1_LIVE`) defaults
+ * OFF, so no eval — tampered or not — can trigger a silent auto-apply. This
+ * manifest is defense-in-depth: it makes drift visible and reverts it.
+ */
+
+import {
+  closeSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { createHash } from "node:crypto";
+
+import { evalsJsonPath } from "./eval-gate.js";
+import { scanForPII } from "./pii-scan.js";
+
+// ── Schema ───────────────────────────────────────────────────────────
+
+/** One eval case (skill-creator's `evals.json` case shape, loosened). */
+export interface EvalCase {
+  /** Stable id (assigned on append if absent). */
+  id?: string;
+  /** The test prompt — the correction, framed as an input. REQUIRED. */
+  prompt: string;
+  /** Optional reference/expected output. */
+  expected_output?: string;
+  /** Optional fixture file map (skill-creator supports this; the one-tap
+   *  CLI path does not populate it — see the L1 follow-up). */
+  files?: string[];
+  /** Assertions the grader checks (free-form strings). */
+  expectations?: string[];
+  /** Provenance — which correction this came from (audit only). */
+  source?: string;
+}
+
+/** A skill's evals.json document. */
+export interface EvalsDoc {
+  skill_name?: string;
+  evals: EvalCase[];
+}
+
+export interface ParsedCase {
+  ok: true;
+  case: EvalCase;
+}
+export interface ParseError {
+  ok: false;
+  error: string;
+}
+
+/**
+ * Validate + normalize an untrusted eval-case object. The only hard
+ * requirement is a non-empty `prompt`; everything else is optional and
+ * passed through (unknown fields dropped).
+ */
+export function parseEvalCase(raw: unknown): ParsedCase | ParseError {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return { ok: false, error: "eval case must be a JSON object" };
+  }
+  const o = raw as Record<string, unknown>;
+  if (typeof o.prompt !== "string" || o.prompt.trim().length === 0) {
+    return { ok: false, error: "eval case requires a non-empty 'prompt'" };
+  }
+  const ec: EvalCase = { prompt: o.prompt };
+  if (typeof o.id === "string" && o.id.length > 0) ec.id = o.id;
+  if (typeof o.expected_output === "string") ec.expected_output = o.expected_output;
+  if (typeof o.source === "string") ec.source = o.source;
+  if (Array.isArray(o.files) && o.files.every((f) => typeof f === "string")) {
+    ec.files = o.files as string[];
+  }
+  if (
+    Array.isArray(o.expectations) &&
+    o.expectations.every((e) => typeof e === "string")
+  ) {
+    ec.expectations = o.expectations as string[];
+  }
+  return { ok: true, case: ec };
+}
+
+/** Normalize a prompt for fingerprinting: trim, collapse ws, lowercase. */
+function normalizePrompt(prompt: string): string {
+  return prompt.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+/** Stable djb2 fingerprint of a case's prompt (dedup + id source). */
+export function caseFingerprint(prompt: string): string {
+  const norm = normalizePrompt(prompt);
+  let h = 5381;
+  for (let i = 0; i < norm.length; i++) {
+    h = ((h << 5) + h + norm.charCodeAt(i)) >>> 0;
+  }
+  return h.toString(16).padStart(8, "0");
+}
+
+// ── evals.json read / append (ADD-ONLY) ──────────────────────────────
+
+/** Read + validate a skill's evals.json. Returns null when absent/unreadable. */
+export function readEvalsDoc(skillDir: string): EvalsDoc | null {
+  const p = evalsJsonPath(skillDir);
+  if (!existsSync(p)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(p, "utf-8")) as EvalsDoc;
+    if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.evals)) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeAtomic(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, content, { encoding: "utf-8", mode: 0o644 });
+  renameSync(tmp, path);
+}
+
+export interface AppendResult {
+  ok: true;
+  case: EvalCase;
+  /** Index of the appended case in the evals array. */
+  index: number;
+  /** Total case count after the append. */
+  total: number;
+}
+export interface AppendRejected {
+  ok: false;
+  reason: string;
+  /** True when the reason is a duplicate (caller may report "already covered"). */
+  duplicate?: boolean;
+}
+
+/**
+ * Append a case to a skill's evals.json, ADD-ONLY. Existing cases are
+ * preserved exactly (we parse, keep the array, and only push). A case whose
+ * prompt fingerprint already exists is rejected as a duplicate — the sink is
+ * idempotent, so the same correction never bloats the file. An id is
+ * assigned from the fingerprint when the case doesn't carry one.
+ */
+export function appendEvalCase(
+  skillDir: string,
+  slug: string,
+  input: EvalCase,
+): AppendResult | AppendRejected {
+  const parsed = parseEvalCase(input);
+  if (!parsed.ok) return { ok: false, reason: parsed.error };
+  const ec = parsed.case;
+
+  const doc: EvalsDoc = readEvalsDoc(skillDir) ?? { skill_name: slug, evals: [] };
+  if (!doc.skill_name) doc.skill_name = slug;
+
+  const fp = caseFingerprint(ec.prompt);
+  for (const existing of doc.evals) {
+    if (typeof existing?.prompt === "string" && caseFingerprint(existing.prompt) === fp) {
+      return { ok: false, reason: "duplicate: this correction is already an eval case", duplicate: true };
+    }
+  }
+
+  if (!ec.id) ec.id = `case-${fp}`;
+  // Guard against an id collision with a differently-worded existing case.
+  if (doc.evals.some((e) => e?.id === ec.id)) {
+    ec.id = `case-${fp}-${doc.evals.length}`;
+  }
+
+  const before = doc.evals.length;
+  doc.evals.push(ec);
+  writeAtomic(evalsJsonPath(skillDir), JSON.stringify(doc, null, 2) + "\n");
+  return { ok: true, case: ec, index: before, total: doc.evals.length };
+}
+
+// ── Held-out sink (kept OUT of evals.json) ───────────────────────────
+
+export const HELD_OUT_FILE = "self-improve-held-out-evals.jsonl";
+
+/** Path to the per-agent held-out eval sink. */
+export function heldOutPath(stateDir: string): string {
+  return join(stateDir, HELD_OUT_FILE);
+}
+
+/**
+ * Append a case to the held-out sink (never into a skill's evals.json), so a
+ * skill edit can't be tuned to pass a test it also just authored. Append-only
+ * jsonl; each line records the slug, the case, and a timestamp.
+ */
+export function appendHeldOutCase(
+  stateDir: string,
+  slug: string,
+  ec: EvalCase,
+  opts: { now?: () => number } = {},
+): void {
+  const now = opts.now ?? Date.now;
+  mkdirSync(stateDir, { recursive: true });
+  const fd = openSync(heldOutPath(stateDir), "a");
+  try {
+    writeSync(
+      fd,
+      JSON.stringify({ at: new Date(now()).toISOString(), slug, case: ec }) + "\n",
+    );
+  } finally {
+    closeSync(fd);
+  }
+}
+
+// ── Tamper-EVIDENT integrity manifest + baseline snapshots ───────────
+//
+// NOT a cryptographic boundary (MJ1) — see the module header. Self-healing
+// defense-in-depth; the real backstop is T1_LIVE defaulting OFF.
+
+export const EVAL_MANIFEST_FILE = "self-improve-eval-manifest.json";
+export const EVAL_BASELINE_SUBDIR = "self-improve-eval-baselines";
+
+interface ManifestEntry {
+  sha256: string;
+  updated_at: string;
+  skill_dir: string;
+}
+type Manifest = Record<string, ManifestEntry>;
+
+function manifestPath(stateDir: string): string {
+  return join(stateDir, EVAL_MANIFEST_FILE);
+}
+function baselineEvalsPath(stateDir: string, slug: string): string {
+  return join(stateDir, EVAL_BASELINE_SUBDIR, slug, "evals.json");
+}
+
+/** sha256 of a skill's evals.json bytes, or null when it doesn't exist. */
+export function evalsSha256(skillDir: string): string | null {
+  const p = evalsJsonPath(skillDir);
+  if (!existsSync(p)) return null;
+  try {
+    return createHash("sha256").update(readFileSync(p)).digest("hex");
+  } catch {
+    return null;
+  }
+}
+
+function readManifest(stateDir: string): Manifest {
+  const p = manifestPath(stateDir);
+  if (!existsSync(p)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(p, "utf-8")) as Manifest;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeManifest(stateDir: string, m: Manifest): void {
+  writeAtomic(manifestPath(stateDir), JSON.stringify(m, null, 2) + "\n");
+}
+
+/**
+ * Record the current evals.json as the sanctioned baseline: update the
+ * manifest hash AND snapshot the file. Called by the deterministic applier
+ * after every sanctioned append, so the last sanctioned state is always
+ * recoverable.
+ */
+export function recordEvalBaseline(
+  stateDir: string,
+  slug: string,
+  skillDir: string,
+  opts: { now?: () => number } = {},
+): void {
+  const sha = evalsSha256(skillDir);
+  if (sha === null) return; // nothing to record
+  const now = opts.now ?? Date.now;
+  const m = readManifest(stateDir);
+  m[slug] = { sha256: sha, updated_at: new Date(now()).toISOString(), skill_dir: skillDir };
+  writeManifest(stateDir, m);
+  const snap = baselineEvalsPath(stateDir, slug);
+  mkdirSync(dirname(snap), { recursive: true });
+  copyFileSync(evalsJsonPath(skillDir), snap);
+}
+
+/**
+ * Is a skill's CURRENT evals.json safe to adopt as a NEW trusted baseline
+ * without having gone through the sanctioned applier? (MAJOR 2.)
+ *
+ * The sanctioned `apply-eval-case` path fail-closed PII/secret-scans every case
+ * it appends (invariant I4) and then records the baseline DIRECTLY, so by the
+ * time the Stop-hook sweep sees a sanctioned write the status is already "ok" —
+ * never "missing". A "missing" (first-sight) or snapshot-less "drift" evals.json
+ * therefore appeared OUT OF BAND: a skill-creator hand-author, or — the hole
+ * this closes — a Bash redirect that never reached the write-block hook. We must
+ * NOT silently trust such bytes: they carry the exact PII/secret leak the scan
+ * exists to stop. Before they can become a baseline they run the SAME
+ * fail-closed scan the sanctioned path runs. FAIL-CLOSED: an unreadable file OR
+ * any finding OR a scan error ⇒ NOT clean (do not trust).
+ *
+ * This is the deterministic invariant that pairs with the Bash write-block
+ * (skill-validate-pretool): even if the command-string heuristic misses an
+ * exotic writer, the poisoned bytes never become a trusted baseline here, so
+ * drift-detection and the apply-guard's has-evals gate can't be defeated by
+ * pre-seeding a first-sight evals.json.
+ */
+export function evalsBaselineTrusted(skillDir: string): boolean {
+  const p = evalsJsonPath(skillDir);
+  let text: string;
+  try {
+    text = readFileSync(p, "utf-8");
+  } catch {
+    return false; // unreadable ⇒ fail-closed
+  }
+  return scanForPII(text).ok;
+}
+
+export type IntegrityStatus = "ok" | "drift" | "missing" | "no-evals";
+
+/** Compare a skill's current evals.json against the recorded manifest. */
+export function verifyEvalIntegrity(
+  stateDir: string,
+  slug: string,
+  skillDir: string,
+): IntegrityStatus {
+  const sha = evalsSha256(skillDir);
+  if (sha === null) return "no-evals"; // no evals.json on disk (present or removed)
+  const m = readManifest(stateDir);
+  const entry = m[slug];
+  if (!entry) return "missing"; // evals present but no baseline recorded (first sight)
+  return sha === entry.sha256 ? "ok" : "drift";
+}
+
+/** List `{slug, skillDir}` for every skill under `skillsRoot` that carries
+ *  an evals.json. Best-effort; returns [] on any fs error. */
+export function listSkillsWithEvals(
+  skillsRoot: string,
+): Array<{ slug: string; skillDir: string }> {
+  const out: Array<{ slug: string; skillDir: string }> = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(skillsRoot);
+  } catch {
+    return out;
+  }
+  for (const slug of entries) {
+    const skillDir = join(skillsRoot, slug);
+    if (existsSync(evalsJsonPath(skillDir))) out.push({ slug, skillDir });
+  }
+  return out;
+}
+
+export interface SweepReport {
+  recorded: string[]; // slugs seen for the first time (baseline established)
+  healed: string[]; // slugs whose out-of-band drift was reverted
+  ok: string[]; // slugs that verified clean
+  quarantined: string[]; // slugs whose un-sanctioned evals.json failed the
+  // PII/secret scan → NOT adopted as a baseline (MAJOR 2)
+}
+
+/**
+ * Stop-hook integrity sweep. For every skill with evals under `skillsRoot`:
+ *   - first sight (no manifest entry) → record it as the baseline;
+ *   - drift (hash != manifest) → REVERT to the baseline snapshot and
+ *     re-record. This self-heals an out-of-band edit to evals.json (e.g. a
+ *     model that Wrote the file directly, bypassing the applier).
+ *
+ * Tamper-EVIDENT, self-healing, NOT a cryptographic boundary (MJ1): a model
+ * that also rewrites the manifest + baseline defeats it. The hard backstop
+ * is T1_LIVE OFF. Best-effort and never throws — the Stop hook is fail-open.
+ *
+ * MAJOR 2 — a first-sight (or snapshot-less drift) evals.json appeared OUT OF
+ * BAND (never through the sanctioned applier, which records its own baseline
+ * directly). We do NOT silently trust it: it must pass the same fail-closed
+ * PII/secret scan the sanctioned path runs BEFORE it can become a baseline.
+ * Un-clean bytes are QUARANTINED (reported, not recorded) so pre-seeding a
+ * poisoned evals.json can never become a trusted baseline.
+ */
+export function sweepEvalIntegrity(
+  skillsRoot: string,
+  stateDir: string,
+  opts: { now?: () => number } = {},
+): SweepReport {
+  const report: SweepReport = {
+    recorded: [],
+    healed: [],
+    ok: [],
+    quarantined: [],
+  };
+  const adoptIfTrusted = (slug: string, skillDir: string): void => {
+    if (evalsBaselineTrusted(skillDir)) {
+      recordEvalBaseline(stateDir, slug, skillDir, opts);
+      report.recorded.push(slug);
+    } else {
+      // Un-sanctioned bytes that fail the PII/secret scan — refuse to trust.
+      report.quarantined.push(slug);
+    }
+  };
+  for (const { slug, skillDir } of listSkillsWithEvals(skillsRoot)) {
+    try {
+      const status = verifyEvalIntegrity(stateDir, slug, skillDir);
+      if (status === "missing") {
+        // First sight — could have been written out-of-band (Bash redirect).
+        adoptIfTrusted(slug, skillDir);
+      } else if (status === "drift") {
+        const snap = baselineEvalsPath(stateDir, slug);
+        if (existsSync(snap)) {
+          // A SANCTIONED snapshot exists → revert to it (already scanned when
+          // it was recorded). Self-heals the out-of-band edit.
+          copyFileSync(snap, evalsJsonPath(skillDir));
+          // Re-record so the manifest matches the restored bytes.
+          recordEvalBaseline(stateDir, slug, skillDir, opts);
+          report.healed.push(slug);
+        } else {
+          // No snapshot to restore from → the current bytes are un-sanctioned;
+          // adopt them ONLY if they pass the scan, else quarantine (never
+          // silently trust drift we can't revert).
+          adoptIfTrusted(slug, skillDir);
+        }
+      } else {
+        report.ok.push(slug);
+      }
+    } catch {
+      /* fail-open per skill; a sweep error must not block the turn */
+    }
+  }
+  return report;
+}

--- a/src/self-improve/pii-scan.ts
+++ b/src/self-improve/pii-scan.ts
@@ -1,0 +1,176 @@
+/**
+ * Agent self-improvement — the DETERMINISTIC PII / secret scan on
+ * eval-case content (RFC amendment §"corrections as eval cases",
+ * invariant I4: "a deterministic PII/secret scan runs, fail-closed, on
+ * every eval-case write — at propose time AND at approved-apply time").
+ *
+ * An eval case is a verbatim transcript excerpt of a real correction, so
+ * it is exactly where an operator's name / email / phone / an API key
+ * could leak into a skill bundle that later ships in a reviewed PR. This
+ * module is the gate that stops that, in CODE, before the bytes ever land.
+ *
+ * Design:
+ *   - The SECRET half reuses the existing `detectSecrets` engine
+ *     (telegram-plugin/secret-detect) verbatim — the same anchored
+ *     provider prefixes + structured KEY=VALUE + Shannon-entropy stack the
+ *     inbound gate and outbound scrub run. We do NOT duplicate those
+ *     patterns (that would drift, and would trip check-secret-pattern-
+ *     parity). A single source of truth for "what is a secret".
+ *   - The PII half adds the handful of patterns the secret engine does not
+ *     cover — email, phone, credit-card (Luhn-checked), US SSN — because
+ *     those are person-data, not credentials, and don't belong in the
+ *     secret-pattern table.
+ *
+ * FAIL-CLOSED contract: the CALLER treats any non-empty finding list as a
+ * hard reject, and treats an internal scan error as a finding too (uncertain
+ * ⇒ block). `scanForPII` never throws — an internal exception is reported as
+ * a synthetic `scan-error` finding so the caller blocks rather than a silent
+ * pass. This is deliberate: a false-positive is an annoyance (tracked as the
+ * L2 override follow-up); a false-negative ships PII into a skill bundle.
+ *
+ * Excerpts in a finding are ALWAYS masked — this module never emits the raw
+ * matched bytes, so findings are safe to log or render on an approval card.
+ */
+
+import { detectSecrets } from "../../telegram-plugin/secret-detect/index.js";
+
+export type PIIKind = "secret" | "email" | "phone" | "card" | "ssn" | "scan-error";
+
+export interface PIIFinding {
+  kind: PIIKind;
+  /** For a secret finding, the detector's rule_id (e.g. "anthropic_api_key"). */
+  rule?: string;
+  /** A MASKED excerpt — never the raw matched bytes. Safe to log/render. */
+  excerpt: string;
+}
+
+export interface PIIScanResult {
+  /** true ⇒ clean (no findings). */
+  ok: boolean;
+  findings: PIIFinding[];
+}
+
+// ── Masking helpers (never emit raw PII) ─────────────────────────────
+
+function maskEmail(s: string): string {
+  const at = s.indexOf("@");
+  if (at <= 0) return "[email]";
+  const local = s.slice(0, at);
+  const domain = s.slice(at + 1);
+  const head = local.slice(0, 1);
+  const dot = domain.lastIndexOf(".");
+  const tld = dot >= 0 ? domain.slice(dot) : "";
+  return `${head}***@***${tld}`;
+}
+
+function maskDigits(s: string): string {
+  const digits = s.replace(/\D/g, "");
+  if (digits.length <= 4) return "***";
+  return `***${digits.slice(-4)}`;
+}
+
+// ── PII patterns (NOT credentials — kept out of the secret table) ────
+
+// Email: conservative RFC-ish local@domain.tld.
+const EMAIL_RE =
+  /[A-Za-z0-9._%+-]+@[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)*\.[A-Za-z]{2,}/g;
+
+// Phone: E.164 (+ country code, 10–15 digits) OR a US-style
+// XXX-XXX-XXXX / (XXX) XXX-XXXX with real separators. Deliberately NOT a
+// bare 10-digit run (that false-positives on IDs / version numbers).
+const PHONE_E164_RE = /\+[1-9]\d{9,14}(?!\d)/g;
+const PHONE_SEP_RE = /(?<!\d)(?:\(\d{3}\)[\s.-]?|\d{3}[\s.-])\d{3}[\s.-]\d{4}(?!\d)/g;
+
+// US SSN: XXX-XX-XXXX with dashes (a bare 9-digit run is too noisy).
+const SSN_RE = /(?<!\d)\d{3}-\d{2}-\d{4}(?!\d)/g;
+
+// Candidate card number: 13–19 digits, optional single space/dash groups.
+const CARD_CANDIDATE_RE = /(?<![\d-])(?:\d[ -]?){13,19}(?![\d-])/g;
+
+/** Luhn checksum — the deterministic filter that stops card false positives. */
+function luhnValid(digits: string): boolean {
+  if (digits.length < 13 || digits.length > 19) return false;
+  let sum = 0;
+  let alt = false;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let d = digits.charCodeAt(i) - 48;
+    if (d < 0 || d > 9) return false;
+    if (alt) {
+      d *= 2;
+      if (d > 9) d -= 9;
+    }
+    sum += d;
+    alt = !alt;
+  }
+  return sum % 10 === 0;
+}
+
+/**
+ * Scan `text` for PII and secrets. Never throws; an internal error becomes
+ * a `scan-error` finding so the fail-closed caller blocks.
+ */
+export function scanForPII(text: string): PIIScanResult {
+  const findings: PIIFinding[] = [];
+  if (typeof text !== "string" || text.length === 0) {
+    return { ok: true, findings };
+  }
+
+  // ── Secrets: reuse the single-source detectSecrets engine ──
+  try {
+    for (const d of detectSecrets(text)) {
+      // A detection suppressed by a nearby test/mock/example marker is
+      // demoted by the engine; we still surface it, because an eval case
+      // that literally contains "sk-…" next to the word "example" is
+      // exactly the leak we're guarding. The L2 follow-up tracks an
+      // operator override for a legitimate secret-handling eval case.
+      findings.push({
+        kind: "secret",
+        rule: d.rule_id,
+        excerpt: `[secret:${d.rule_id}]`,
+      });
+    }
+  } catch (err) {
+    // Fail-closed: an engine error must not wave content through.
+    findings.push({
+      kind: "scan-error",
+      excerpt: `secret scan failed: ${(err as Error).message}`.slice(0, 120),
+    });
+  }
+
+  // ── PII: person-data the secret engine does not cover ──
+  try {
+    for (const m of text.matchAll(EMAIL_RE)) {
+      findings.push({ kind: "email", excerpt: maskEmail(m[0]) });
+    }
+    for (const m of text.matchAll(PHONE_E164_RE)) {
+      findings.push({ kind: "phone", excerpt: maskDigits(m[0]) });
+    }
+    for (const m of text.matchAll(PHONE_SEP_RE)) {
+      findings.push({ kind: "phone", excerpt: maskDigits(m[0]) });
+    }
+    for (const m of text.matchAll(SSN_RE)) {
+      findings.push({ kind: "ssn", excerpt: maskDigits(m[0]) });
+    }
+    for (const m of text.matchAll(CARD_CANDIDATE_RE)) {
+      const digits = m[0].replace(/\D/g, "");
+      if (luhnValid(digits)) {
+        findings.push({ kind: "card", excerpt: maskDigits(m[0]) });
+      }
+    }
+  } catch (err) {
+    findings.push({
+      kind: "scan-error",
+      excerpt: `pii scan failed: ${(err as Error).message}`.slice(0, 120),
+    });
+  }
+
+  return { ok: findings.length === 0, findings };
+}
+
+/** One-line human summary of findings, for a rejection message / card. */
+export function summarizeFindings(findings: PIIFinding[]): string {
+  if (findings.length === 0) return "clean";
+  const counts = new Map<PIIKind, number>();
+  for (const f of findings) counts.set(f.kind, (counts.get(f.kind) ?? 0) + 1);
+  return [...counts.entries()].map(([k, n]) => `${n}×${k}`).join(", ");
+}

--- a/src/self-improve/review-prompt.ts
+++ b/src/self-improve/review-prompt.ts
@@ -114,6 +114,15 @@ export function buildReviewPrompt(signals: LearningSignal[]): string {
       "suggestion (the operator actions it later). Never auto-create a " +
       "cron or a new skill, never edit a shared/other-agent skill.",
   );
+  lines.push(
+    "  5. If this was an operator CORRECTION tied to a skill you own, turn " +
+      "it into a regression test: run `switchroom self-improve add-eval-case " +
+      "--skill <slug> --prompt \"<the correction framed as a test prompt>\"`. " +
+      "This proposes the case as a one-tap card; the operator's tap runs a " +
+      "deterministic applier that writes it (PII/secret-scanned). Do NOT " +
+      "Write or Edit evals/evals.json yourself — a direct write is blocked, " +
+      "bypasses the scan, and skips the operator's approval.",
+  );
   lines.push("");
   lines.push(
     `Rate limits in effect: <= ${cfg.maxAutoAppliesPerDay} auto-applies/day, ` +

--- a/telegram-plugin/gateway/callback-query-handlers.ts
+++ b/telegram-plugin/gateway/callback-query-handlers.ts
@@ -70,6 +70,11 @@ import {
   getProposal as getSkillProposal,
   setProposalStatus as setSkillProposalStatus,
 } from '../../src/self-improve/skill-proposals.js'
+import { parseEvalCaseProposalCallback } from './eval-case-proposal-card.js'
+import {
+  getEvalCaseProposal,
+  setEvalCaseProposalStatus,
+} from '../../src/self-improve/eval-case-proposals.js'
 import { maskToken } from '../secret-detect/mask.js'
 import {
   defaultVaultWrite,
@@ -1325,6 +1330,100 @@ async function handleSkillProposalCallback(ctx: Context, data: string): Promise<
   process.stderr.write(
     `telegram gateway: skill_proposal_apply injection agent=${agent} ` +
     `proposal=${proposal.id} slug=${proposal.skill_slug} delivered=${delivered}\n`,
+  )
+}
+
+/**
+ * Eval-case proposal callback (RFC amendment §"corrections as eval cases").
+ *
+ * On Approve this runs the DETERMINISTIC `apply-eval-case` applier via
+ * execFileSync — NOT a model turn — so the case lands byte-exact as approved
+ * (precedent: the `switchroom vault set` on-tap execFileSync in this file).
+ * The operator's tap IS the authorization; the gateway sets the proposal
+ * `approved` BEFORE invoking the applier (whose own status check is
+ * defense-in-depth, MJ2, since the store is agent-writable).
+ */
+async function handleEvalCaseProposalCallback(ctx: Context, data: string): Promise<void> {
+  const senderId = String(ctx.from?.id ?? '')
+  const access = loadAccess()
+  if (!access.allowFrom.includes(senderId)) {
+    await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+    return
+  }
+  const parsed = parseEvalCaseProposalCallback(data)
+  if (parsed == null) {
+    await ctx.answerCallbackQuery({ text: 'Bad request' }).catch(() => {})
+    return
+  }
+  const stateDir = process.env.TELEGRAM_STATE_DIR
+  const agent = process.env.SWITCHROOM_AGENT_NAME ?? ''
+  if (stateDir == null || stateDir.length === 0) {
+    await ctx.answerCallbackQuery({ text: 'State dir unset — cannot apply.' }).catch(() => {})
+    return
+  }
+  const proposal = getEvalCaseProposal(stateDir, parsed.id)
+  if (proposal == null) {
+    await ctx.answerCallbackQuery({ text: 'Proposal expired or already actioned.' }).catch(() => {})
+    if (ctx.callbackQuery?.message) {
+      await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }).catch(() => {})
+    }
+    return
+  }
+  if (proposal.status !== 'pending') {
+    await ctx.answerCallbackQuery({ text: `Already ${proposal.status}.` }).catch(() => {})
+    if (ctx.callbackQuery?.message) {
+      await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }).catch(() => {})
+    }
+    return
+  }
+
+  if (parsed.action === 'deny') {
+    setEvalCaseProposalStatus(stateDir, parsed.id, 'rejected')
+    await ctx.answerCallbackQuery({ text: '🚫 Dismissed.' }).catch(() => {})
+    if (ctx.callbackQuery?.message && 'text' in ctx.callbackQuery.message) {
+      await ctx
+        .editMessageText(
+          `${escapeHtmlForTg(ctx.callbackQuery.message.text ?? '')}\n\n🚫 <i>Dismissed.</i>`,
+          { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
+        )
+        .catch(() => {})
+    }
+    return
+  }
+
+  // Approve — authorize, then run the deterministic applier.
+  setEvalCaseProposalStatus(stateDir, parsed.id, 'approved')
+  await ctx.answerCallbackQuery({ text: '✅ Adding the eval case…' }).catch(() => {})
+
+  const cli = process.env.SWITCHROOM_CLI_PATH ?? 'switchroom'
+  let applyOk = true
+  let applyOut = ''
+  try {
+    applyOut = execFileSync(
+      cli,
+      ['self-improve', 'apply-eval-case', '--id', parsed.id],
+      { encoding: 'utf8', timeout: 15000, env: process.env },
+    ).trim()
+  } catch (err) {
+    applyOk = false
+    const e = err as { stdout?: string; stderr?: string; message?: string }
+    applyOut = [e.stdout, e.stderr, e.message].filter(Boolean).join('\n').trim()
+  }
+
+  const footer = applyOk
+    ? '✅ <i>Added as a regression test.</i>'
+    : `⚠️ <i>Apply failed:</i> ${escapeHtmlForTg(applyOut.slice(0, 200))}`
+  if (ctx.callbackQuery?.message && 'text' in ctx.callbackQuery.message) {
+    await ctx
+      .editMessageText(
+        `${escapeHtmlForTg(ctx.callbackQuery.message.text ?? '')}\n\n${footer}`,
+        { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
+      )
+      .catch(() => {})
+  }
+  process.stderr.write(
+    `telegram gateway: eval_case_apply agent=${agent} proposal=${proposal.id} ` +
+    `slug=${proposal.skill_slug} ok=${applyOk}\n`,
   )
 }
 
@@ -3233,6 +3332,7 @@ async function handleAuthDashboardCallback(ctx: Context): Promise<void> {
     performVaultAccessApproval,
     resolveAccessApprovalPassphraseMismatch,
     handleSkillProposalCallback,
+    handleEvalCaseProposalCallback,
     handleMentalModelProposeCallback,
     handleVaultRequestAccessCallback,
     handleVaultRequestSaveCallback,

--- a/telegram-plugin/gateway/eval-case-proposal-card.ts
+++ b/telegram-plugin/gateway/eval-case-proposal-card.ts
@@ -1,0 +1,86 @@
+/**
+ * One-tap eval-case proposal card (RFC amendment §"corrections as eval
+ * cases").
+ *
+ * `switchroom self-improve add-eval-case` sends a `post_eval_case_proposal`
+ * IPC; the gateway persists it (eval-case-proposals store) and renders THIS
+ * card. Unlike the skill-proposal card, tapping Approve does NOT inject a
+ * model turn — the gateway callback runs the DETERMINISTIC `apply-eval-case`
+ * applier via execFileSync, so the case lands byte-exact as approved.
+ *
+ * Pure builders, kept out of gateway.ts so the card text + callback shape are
+ * pinned by tests independent of the bot plumbing.
+ *
+ * callback_data shape (must fit Telegram's 64-byte limit):
+ *   evcase:approve:<id>
+ *   evcase:deny:<id>
+ */
+
+export const EVAL_CASE_PROPOSAL_CALLBACK_PREFIX = 'evcase:'
+
+/** Narrow view of a stored eval-case proposal the card needs. */
+export interface EvalCaseProposalView {
+  id: string
+  skill_slug: string
+  held_out: boolean
+  case: { prompt: string; expectations?: string[] }
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+/** Truncate a single-line preview of the prompt for the card. */
+function previewPrompt(prompt: string, max = 240): string {
+  const oneLine = prompt.replace(/\s+/g, ' ').trim()
+  return oneLine.length > max ? oneLine.slice(0, max - 1) + '…' : oneLine
+}
+
+/** Render the eval-case proposal card text (HTML parse mode). */
+export function renderEvalCaseProposalCard(p: EvalCaseProposalView): string {
+  const lines: string[] = []
+  lines.push(`🧪 <b>Eval case proposed</b>`)
+  lines.push('')
+  lines.push(`<b>Skill:</b> <code>${escapeHtml(p.skill_slug)}</code>`)
+  if (p.held_out) lines.push(`<i>held-out (won't be added to evals.json)</i>`)
+  lines.push(`<b>Test prompt:</b> ${escapeHtml(previewPrompt(p.case.prompt))}`)
+  const exps = p.case.expectations ?? []
+  if (exps.length > 0) {
+    lines.push('<b>Checks:</b>')
+    for (const e of exps.slice(0, 5)) lines.push(`• ${escapeHtml(e.slice(0, 120))}`)
+  }
+  lines.push('')
+  lines.push(
+    '<i>Tap Add to append it as a regression test (re-scanned for ' +
+      'secrets/PII, written byte-exact — no model turn). Tap Dismiss to drop it.</i>',
+  )
+  return lines.join('\n')
+}
+
+/** Inline keyboard for the card. */
+export function evalCaseProposalKeyboard(id: string): {
+  inline_keyboard: Array<Array<{ text: string; callback_data: string }>>
+} {
+  return {
+    inline_keyboard: [
+      [
+        { text: '✅ Add case', callback_data: `${EVAL_CASE_PROPOSAL_CALLBACK_PREFIX}approve:${id}` },
+        { text: '🚫 Dismiss', callback_data: `${EVAL_CASE_PROPOSAL_CALLBACK_PREFIX}deny:${id}` },
+      ],
+    ],
+  }
+}
+
+/** Parse an `evcase:` callback into { action, id }, or null if not ours. */
+export function parseEvalCaseProposalCallback(
+  data: string,
+): { action: 'approve' | 'deny'; id: string } | null {
+  if (!data.startsWith(EVAL_CASE_PROPOSAL_CALLBACK_PREFIX)) return null
+  const rest = data.slice(EVAL_CASE_PROPOSAL_CALLBACK_PREFIX.length)
+  const idx = rest.indexOf(':')
+  if (idx < 0) return null
+  const action = rest.slice(0, idx)
+  const id = rest.slice(idx + 1)
+  if ((action !== 'approve' && action !== 'deny') || id.length === 0) return null
+  return { action, id }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -769,13 +769,9 @@ import type { ChatKey as _ChatKey } from './inbound-delivery-machine.js'
 import { dispatchEffects } from './inbound-delivery-machine-dispatch.js'
 import { maybeFireWarmup } from './prefix-warmup.js'
 import {
-  renderSkillProposalCard,
-  skillProposalKeyboard,
-} from './skill-proposal-card.js'
-import {
-  enqueueProposal as enqueueSkillProposal,
-  isSuppressed as isSkillProposalSuppressed,
-} from '../../src/self-improve/skill-proposals.js'
+  handlePostSkillProposal,
+  handlePostEvalCaseProposal,
+} from './self-improve-proposal-wiring.js'
 import { decideSubagentHandback } from './subagent-handback-inbound-builder.js'
 import {
   decideSubagentProgress,
@@ -803,6 +799,7 @@ import type {
   QueryPendingPermissionMessage,
   CheckPreApprovedMessage,
   PostSkillProposalMessage,
+  PostEvalCaseProposalMessage,
   PermissionEvent,
   RolloutStatusPostMessage,
   RolloutStatusEditMessage,
@@ -11592,69 +11589,19 @@ if (isGatewayMain) ipcServer = createIpcServer({
   // onQuotaWallDetected so it doesn't fall inside the source slice that
   // send-outbound-wiring.test.ts takes between onSendOutbound and
   // onQuotaWallDetected.
+  // Thin delegate — body lives in self-improve-proposal-wiring.ts to keep the
+  // gateway line ratchet flat. Placed AFTER onQuotaWallDetected so it doesn't
+  // fall inside the source slice send-outbound-wiring.test.ts takes between
+  // onSendOutbound and onQuotaWallDetected.
   onPostSkillProposal(_client: IpcClient, msg: PostSkillProposalMessage) {
-    const self = process.env.SWITCHROOM_AGENT_NAME
-    if (self && msg.agentName !== self) {
-      process.stderr.write(
-        `telegram gateway: post_skill_proposal rejected — agent mismatch (${msg.agentName} != ${self})\n`,
-      )
-      return
-    }
-    try {
-      assertAllowedChat(msg.chatId)
-    } catch (err) {
-      process.stderr.write(
-        `telegram gateway: post_skill_proposal rejected — ${(err as Error).message}\n`,
-      )
-      return
-    }
-    const stateDir = process.env.TELEGRAM_STATE_DIR
-    if (stateDir == null || stateDir.length === 0) {
-      process.stderr.write(`telegram gateway: post_skill_proposal: TELEGRAM_STATE_DIR unset, skipping\n`)
-      return
-    }
-    // Dedup against still-live rejection fingerprints — never re-surface a
-    // proposal the operator already dismissed.
-    if (isSkillProposalSuppressed(stateDir, {
-      lesson: msg.lesson,
-      draft: msg.draft,
-      skill_slug: msg.skillSlug,
-    })) {
-      process.stderr.write(
-        `telegram gateway: post_skill_proposal suppressed (rejected before) slug=${msg.skillSlug}\n`,
-      )
-      return
-    }
-    const proposal = enqueueSkillProposal(stateDir, {
-      skill_slug: msg.skillSlug,
-      is_new: msg.isNew,
-      lesson: msg.lesson,
-      draft: msg.draft,
-      evidence: msg.evidence,
-      chat_id: Number(msg.chatId),
-    })
-    const cardText = renderSkillProposalCard({
-      id: proposal.id,
-      skill_slug: proposal.skill_slug,
-      is_new: proposal.is_new,
-      lesson: proposal.lesson,
-      evidence: proposal.evidence,
-      skill_md: proposal.draft['SKILL.md'],
-    })
-    const threadId = msg.threadId
-    void swallowingApiCall(
-      () =>
-        bot.api.sendMessage(msg.chatId, cardText, {
-          parse_mode: 'HTML',
-          reply_markup: skillProposalKeyboard(proposal.id),
-          ...(threadId != null && threadId !== 1 ? { message_thread_id: threadId } : {}),
-        }),
-      { chat_id: msg.chatId, verb: 'skill-proposal-card', ...(threadId != null ? { threadId } : {}) },
-    )
-    process.stderr.write(
-      `telegram gateway: post_skill_proposal agent=${msg.agentName} chat=${msg.chatId} ` +
-      `proposal=${proposal.id} slug=${proposal.skill_slug} new=${proposal.is_new}\n`,
-    )
+    handlePostSkillProposal(msg, { bot, assertAllowedChat, swallowingApiCall })
+  },
+
+  // RFC amendment §"corrections as eval cases" — thin delegate; the
+  // DETERMINISTIC applier runs on Approve in handleEvalCaseProposalCallback,
+  // NOT a model turn. Body in self-improve-proposal-wiring.ts.
+  onPostEvalCaseProposal(_client: IpcClient, msg: PostEvalCaseProposalMessage) {
+    handlePostEvalCaseProposal(msg, { bot, assertAllowedChat, swallowingApiCall })
   },
 
   // Buzz Phase 2b: the duplex peer's advisory publish outcome — no-op unless the hub mirror booted.
@@ -21746,6 +21693,15 @@ bot.on('callback_query:data', async ctx => {
   //                         isn't re-proposed
   if (data.startsWith('skprop:')) {
     await callbackQueryHandlers.handleSkillProposalCallback(ctx, data)
+    return
+  }
+
+  // RFC amendment §"corrections as eval cases": one-tap eval-case card.
+  //   evcase:approve:<id> — run the DETERMINISTIC apply-eval-case applier
+  //                         (byte-exact write; NOT a model turn)
+  //   evcase:deny:<id>    — dismiss + mark the proposal rejected
+  if (data.startsWith('evcase:')) {
+    await callbackQueryHandlers.handleEvalCaseProposalCallback(ctx, data)
     return
   }
 

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -576,6 +576,41 @@ export interface PostSkillProposalMessage {
 }
 
 /**
+ * `switchroom self-improve add-eval-case` asks the caller agent's gateway to
+ * persist an eval-case proposal and post a one-tap Approve/Dismiss card (RFC
+ * amendment §"corrections as eval cases"). Unlike a skill proposal, the
+ * Approve tap does NOT inject a model turn — the gateway runs the
+ * DETERMINISTIC `apply-eval-case` applier so the case lands byte-exact.
+ *
+ * Trust model identical to post_skill_proposal: per-agent socket, agentName
+ * validated, chat fenced to the agent's own chat.
+ */
+export interface PostEvalCaseProposalMessage {
+  type: "post_eval_case_proposal";
+  agentName: string;
+  /** Agent's own chat id (fenced server-side). */
+  chatId: string;
+  threadId?: number;
+  /** Target skill slug. */
+  skillSlug: string;
+  /** Absolute path to the owned skill bundle dir (resolved by the CLI). */
+  skillDir: string;
+  /** The eval case to append (prompt + optional expected/expectations/etc). */
+  case: {
+    prompt: string;
+    expected_output?: string;
+    files?: string[];
+    expectations?: string[];
+    source?: string;
+    id?: string;
+  };
+  /** Prompt fingerprint (dedup + provenance). */
+  fingerprint: string;
+  /** Route the case to the held-out sink instead of evals.json. */
+  heldOut: boolean;
+}
+
+/**
  * #2726 Part 1 — hostd asks the caller agent's gateway to POST one ordinary
  * operator-DM message narrating a rollout's terminal outcome. This is a NORMAL
  * message, NOT a pinned card and NOT a bespoke widget — the framework speaking
@@ -766,6 +801,7 @@ export type ClientToGateway =
   | QuotaWallDetectedMessage
   | SendOutboundMessage
   | PostSkillProposalMessage
+  | PostEvalCaseProposalMessage
   | RolloutStatusPostMessage
   | RolloutStatusEditMessage
   | QueryPendingPermissionMessage

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -9,6 +9,7 @@ import type {
   QueryPendingPermissionMessage,
   CheckPreApprovedMessage,
   PostSkillProposalMessage,
+  PostEvalCaseProposalMessage,
   OperatorEventForward,
   PermissionRequestForward,
   PtyPartialForward,
@@ -101,6 +102,12 @@ export interface IpcServerOptions {
    * chat. Optional; gateways that don't surface proposals ignore it.
    */
   onPostSkillProposal?: (client: IpcClient, msg: PostSkillProposalMessage) => void;
+  /**
+   * RFC amendment §"corrections as eval cases" — `add-eval-case` asks the
+   * gateway to persist an eval-case proposal and post its one-tap card.
+   * Optional; gateways that don't surface proposals ignore it.
+   */
+  onPostEvalCaseProposal?: (client: IpcClient, msg: PostEvalCaseProposalMessage) => void;
   /**
    * RFC E §4.2 Cut 2 — Drive-write PreToolUse hook asks the gateway
    * to register a kernel approval request + post a diff-preview
@@ -379,6 +386,23 @@ export function validateClientMessage(msg: unknown): msg is ClientToGateway {
         && (typeof m.threadId !== "number" || !Number.isInteger(m.threadId as number))) return false;
       return true;
     }
+    case "post_eval_case_proposal": {
+      // RFC amendment §"corrections as eval cases" — validate the wire shape;
+      // the gateway handler fences chatId to the agent's own chat.
+      if (typeof m.agentName !== "string"
+        || !AGENT_NAME_RE.test(m.agentName as string)) return false;
+      if (typeof m.chatId !== "string" || (m.chatId as string).length === 0) return false;
+      if (typeof m.skillSlug !== "string" || (m.skillSlug as string).length === 0) return false;
+      if (typeof m.skillDir !== "string" || (m.skillDir as string).length === 0) return false;
+      if (typeof m.fingerprint !== "string" || (m.fingerprint as string).length === 0) return false;
+      if (typeof m.heldOut !== "boolean") return false;
+      if (typeof m.case !== "object" || m.case === null || Array.isArray(m.case)) return false;
+      if (typeof (m.case as Record<string, unknown>).prompt !== "string"
+        || ((m.case as Record<string, unknown>).prompt as string).length === 0) return false;
+      if (m.threadId !== undefined
+        && (typeof m.threadId !== "number" || !Number.isInteger(m.threadId as number))) return false;
+      return true;
+    }
     case "quota_wall_detected": {
       // wedge-watchdog detected the /rate-limit-options weekly-quota menu.
       if (typeof m.agentName !== "string"
@@ -565,6 +589,7 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
     onQueryPendingPermission,
     onCheckPreApproved,
     onPostSkillProposal,
+    onPostEvalCaseProposal,
     onRequestDriveApproval,
     onRequestMs365Approval,
     onRequestConfigApproval,
@@ -732,6 +757,9 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
         break;
       case "post_skill_proposal":
         if (onPostSkillProposal) onPostSkillProposal(client, msg as PostSkillProposalMessage);
+        break;
+      case "post_eval_case_proposal":
+        if (onPostEvalCaseProposal) onPostEvalCaseProposal(client, msg as PostEvalCaseProposalMessage);
         break;
       case "quota_wall_detected":
         if (onQuotaWallDetected) onQuotaWallDetected(client, msg as QuotaWallDetectedMessage);

--- a/telegram-plugin/gateway/self-improve-proposal-wiring.ts
+++ b/telegram-plugin/gateway/self-improve-proposal-wiring.ts
@@ -1,0 +1,174 @@
+/**
+ * Self-improvement proposal IPC handlers, lifted out of gateway.ts.
+ *
+ * Both `post_skill_proposal` (#2670 one-tap self-improvement) and
+ * `post_eval_case_proposal` (RFC amendment §"corrections as eval cases")
+ * arrive over the per-agent gateway socket, are chat-fenced via
+ * `assertAllowedChat`, persisted to their respective store, and rendered as
+ * an Approve/Dismiss card. The store transition + apply on Approve are owned
+ * by the callback handlers (so a gateway restart between post and tap still
+ * resolves), NOT here.
+ *
+ * These live in a module (not inline in gateway.ts) so the gateway anti-
+ * inflation line ratchet stays flat and the handler bodies are unit-testable
+ * against a stubbed `bot` / `swallowingApiCall`. gateway.ts keeps only a thin
+ * delegate per handler.
+ *
+ * The `bot.api.sendMessage` calls are wrapped in the injected
+ * `swallowingApiCall` exactly as they were in gateway.ts — the bot-api-wrapping
+ * lint recognises the wrapper by name in the surrounding context.
+ */
+
+import type { Bot, Context } from 'grammy'
+import type { RetryCallOpts } from '../retry-api-call.js'
+import type { PostSkillProposalMessage, PostEvalCaseProposalMessage } from './ipc-protocol.js'
+import { renderSkillProposalCard, skillProposalKeyboard } from './skill-proposal-card.js'
+import { renderEvalCaseProposalCard, evalCaseProposalKeyboard } from './eval-case-proposal-card.js'
+import {
+  enqueueProposal as enqueueSkillProposal,
+  isSuppressed as isSkillProposalSuppressed,
+} from '../../src/self-improve/skill-proposals.js'
+import { enqueueEvalCaseProposal } from '../../src/self-improve/eval-case-proposals.js'
+
+/** Collaborators the gateway injects into each handler. */
+export interface ProposalWiringDeps {
+  bot: Bot<Context>
+  assertAllowedChat: (chatId: string) => void
+  swallowingApiCall: <T>(fn: () => Promise<T>, opts?: RetryCallOpts) => Promise<T | undefined>
+}
+
+/**
+ * #2670 one-tap self-improvement — persist a skill-improvement proposal and
+ * post its Approve/Dismiss card. Dedups against still-live rejection
+ * fingerprints so a dismissed proposal never re-surfaces.
+ */
+export function handlePostSkillProposal(
+  msg: PostSkillProposalMessage,
+  deps: ProposalWiringDeps,
+): void {
+  const { bot, assertAllowedChat, swallowingApiCall } = deps
+  const self = process.env.SWITCHROOM_AGENT_NAME
+  if (self && msg.agentName !== self) {
+    process.stderr.write(
+      `telegram gateway: post_skill_proposal rejected — agent mismatch (${msg.agentName} != ${self})\n`,
+    )
+    return
+  }
+  try {
+    assertAllowedChat(msg.chatId)
+  } catch (err) {
+    process.stderr.write(
+      `telegram gateway: post_skill_proposal rejected — ${(err as Error).message}\n`,
+    )
+    return
+  }
+  const stateDir = process.env.TELEGRAM_STATE_DIR
+  if (stateDir == null || stateDir.length === 0) {
+    process.stderr.write(`telegram gateway: post_skill_proposal: TELEGRAM_STATE_DIR unset, skipping\n`)
+    return
+  }
+  // Dedup against still-live rejection fingerprints — never re-surface a
+  // proposal the operator already dismissed.
+  if (isSkillProposalSuppressed(stateDir, {
+    lesson: msg.lesson,
+    draft: msg.draft,
+    skill_slug: msg.skillSlug,
+  })) {
+    process.stderr.write(
+      `telegram gateway: post_skill_proposal suppressed (rejected before) slug=${msg.skillSlug}\n`,
+    )
+    return
+  }
+  const proposal = enqueueSkillProposal(stateDir, {
+    skill_slug: msg.skillSlug,
+    is_new: msg.isNew,
+    lesson: msg.lesson,
+    draft: msg.draft,
+    evidence: msg.evidence,
+    chat_id: Number(msg.chatId),
+  })
+  const cardText = renderSkillProposalCard({
+    id: proposal.id,
+    skill_slug: proposal.skill_slug,
+    is_new: proposal.is_new,
+    lesson: proposal.lesson,
+    evidence: proposal.evidence,
+    skill_md: proposal.draft['SKILL.md'],
+  })
+  const threadId = msg.threadId
+  void swallowingApiCall(
+    () =>
+      bot.api.sendMessage(msg.chatId, cardText, {
+        parse_mode: 'HTML',
+        reply_markup: skillProposalKeyboard(proposal.id),
+        ...(threadId != null && threadId !== 1 ? { message_thread_id: threadId } : {}),
+      }),
+    { chat_id: msg.chatId, verb: 'skill-proposal-card', ...(threadId != null ? { threadId } : {}) },
+  )
+  process.stderr.write(
+    `telegram gateway: post_skill_proposal agent=${msg.agentName} chat=${msg.chatId} ` +
+    `proposal=${proposal.id} slug=${proposal.skill_slug} new=${proposal.is_new}\n`,
+  )
+}
+
+/**
+ * RFC amendment §"corrections as eval cases" — persist an eval-case proposal
+ * and post its Approve/Dismiss card. On Approve the callback runs the
+ * DETERMINISTIC applier (handleEvalCaseProposalCallback), NOT a model turn, so
+ * the case lands byte-exact. Same per-agent-socket / chat-fenced trust model
+ * as handlePostSkillProposal.
+ */
+export function handlePostEvalCaseProposal(
+  msg: PostEvalCaseProposalMessage,
+  deps: ProposalWiringDeps,
+): void {
+  const { bot, assertAllowedChat, swallowingApiCall } = deps
+  const self = process.env.SWITCHROOM_AGENT_NAME
+  if (self && msg.agentName !== self) {
+    process.stderr.write(
+      `telegram gateway: post_eval_case_proposal rejected — agent mismatch (${msg.agentName} != ${self})\n`,
+    )
+    return
+  }
+  try {
+    assertAllowedChat(msg.chatId)
+  } catch (err) {
+    process.stderr.write(
+      `telegram gateway: post_eval_case_proposal rejected — ${(err as Error).message}\n`,
+    )
+    return
+  }
+  const stateDir = process.env.TELEGRAM_STATE_DIR
+  if (stateDir == null || stateDir.length === 0) {
+    process.stderr.write(`telegram gateway: post_eval_case_proposal: TELEGRAM_STATE_DIR unset, skipping\n`)
+    return
+  }
+  const proposal = enqueueEvalCaseProposal(stateDir, {
+    skill_slug: msg.skillSlug,
+    skill_dir: msg.skillDir,
+    case: msg.case,
+    fingerprint: msg.fingerprint,
+    held_out: msg.heldOut === true,
+    chat_id: Number(msg.chatId),
+  })
+  const cardText = renderEvalCaseProposalCard({
+    id: proposal.id,
+    skill_slug: proposal.skill_slug,
+    held_out: proposal.held_out,
+    case: proposal.case,
+  })
+  const threadId = msg.threadId
+  void swallowingApiCall(
+    () =>
+      bot.api.sendMessage(msg.chatId, cardText, {
+        parse_mode: 'HTML',
+        reply_markup: evalCaseProposalKeyboard(proposal.id),
+        ...(threadId != null && threadId !== 1 ? { message_thread_id: threadId } : {}),
+      }),
+    { chat_id: msg.chatId, verb: 'eval-case-proposal-card', ...(threadId != null ? { threadId } : {}) },
+  )
+  process.stderr.write(
+    `telegram gateway: post_eval_case_proposal agent=${msg.agentName} chat=${msg.chatId} ` +
+    `proposal=${proposal.id} slug=${proposal.skill_slug} held_out=${proposal.held_out}\n`,
+  )
+}

--- a/tests/self-improve-apply-guard-pretool.test.ts
+++ b/tests/self-improve-apply-guard-pretool.test.ts
@@ -15,6 +15,7 @@ import { evalsJsonPath } from "../src/self-improve/eval-gate.js";
 import { writeReviewContext } from "../src/self-improve/review-context.js";
 import { readPending } from "../src/self-improve/pending-queue.js";
 import { appliesToday } from "../src/self-improve/rate-limit.js";
+import { appendEvalCase } from "../src/self-improve/eval-cases.js";
 
 // Drive the hook through `bun` against source (mirrors the stop-hook test)
 // so it doesn't depend on build order. Skip cleanly if bun is absent.
@@ -110,16 +111,37 @@ describe("self-improve apply-guard PreToolUse hook", () => {
     expect(r.stdout.trim()).toBe("");
   });
 
-  it("marker + owned skill + evals-passing + fresh benchmark → allow, records an apply", () => {
+  it("marker + owned skill + evals-passing + fresh benchmark + T1_LIVE=1 → allow, records an apply", () => {
     if (!bunOk) return;
+    makeOwnedSkill(true);
+    writeBenchmark(1.0, 0.9);
+    putMarker();
+    // Silent auto-apply is opt-IN — the allow path only exists with the flag.
+    const r = run("Write", skillFile(), "small\nedit\n", {
+      SWITCHROOM_SELF_IMPROVE_T1_LIVE: "1",
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe(""); // allowed
+    expect(appliesToday(stateDir)).toBe(1); // one auto-apply recorded
+    expect(readPending(stateDir)).toEqual([]); // nothing downgraded
+  });
+
+  it("same, but T1_LIVE unset (default OFF) → block + downgrade to a pending proposal", () => {
+    if (!bunOk) return;
+    // Identical to the allow case EXCEPT the T1-live flag is absent. The hard
+    // backstop (RFC amendment invariant) must turn an otherwise-verified T1
+    // into a one-tap T2 proposal — never a silent apply.
     makeOwnedSkill(true);
     writeBenchmark(1.0, 0.9);
     putMarker();
     const r = run("Write", skillFile(), "small\nedit\n");
     expect(r.status).toBe(0);
-    expect(r.stdout.trim()).toBe(""); // allowed
-    expect(appliesToday(stateDir)).toBe(1); // one auto-apply recorded
-    expect(readPending(stateDir)).toEqual([]); // nothing downgraded
+    expect(r.stdout).toContain('"decision":"block"');
+    expect(r.stdout.toLowerCase()).toContain("silent auto-apply is disabled");
+    const pending = readPending(stateDir);
+    expect(pending.length).toBe(1);
+    expect(pending[0]?.skill_slug).toBe(SLUG);
+    expect(appliesToday(stateDir)).toBe(0); // downgraded → no apply recorded
   });
 
   it("marker + owned skill but NO evals → block + downgrade to a pending proposal", () => {
@@ -134,6 +156,33 @@ describe("self-improve apply-guard PreToolUse hook", () => {
     expect(pending.length).toBe(1);
     expect(pending[0]?.skill_slug).toBe(SLUG);
     expect(appliesToday(stateDir)).toBe(0); // blocked → no apply recorded
+  });
+
+  // MJ4 (RFC amendment §"corrections as eval cases"): the whole point of the
+  // sink is that a correction, once captured as an eval case, catches a FUTURE
+  // regression. This is the end-to-end proof on an ephemeral fixture agent:
+  // a real eval case is appended via the sink, then a deliberately-regressing
+  // edit (candidate pass-rate below the eval floor) is BLOCKED — never silently
+  // applied — even with silent-apply opted in.
+  it("MJ4: once a case exists, a regressing edit is blocked (downgraded), not applied", () => {
+    if (!bunOk) return;
+    makeOwnedSkill(false); // create the skill dir; no bare evals.json
+    // Populate evals.json through the REAL add-only sink — "cases exist".
+    const appended = appendEvalCase(skillDir(), SLUG, {
+      prompt: "the correction, captured as a regression test",
+    });
+    expect(appended.ok).toBe(true);
+    // A regression: with-skill 0.5 < without-skill 0.9 (below the eval floor).
+    writeBenchmark(0.5, 0.9);
+    putMarker();
+    const r = run("Write", skillFile(), "regress\n", {
+      SWITCHROOM_SELF_IMPROVE_T1_LIVE: "1", // even with silent-apply ON…
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('"decision":"block"'); // …the regression is caught
+    expect(r.stdout).toContain("eval gate blocked");
+    expect(appliesToday(stateDir)).toBe(0); // never applied
+    expect(readPending(stateDir).length).toBe(1); // surfaced as a proposal
   });
 
   it("marker present but a non-skill write → allow (out of scope)", () => {

--- a/tests/self-improve-apply-guard.test.ts
+++ b/tests/self-improve-apply-guard.test.ts
@@ -136,22 +136,58 @@ describe("apply-guard helpers", () => {
 });
 
 describe("decideApply — the deterministic T1 gate", () => {
-  it("ALLOWS a small, owned, evals-passing edit under the rate cap", () => {
-    makeOwnedSkill(true);
-    writeBenchmark(1.0, 0.9);
-    const d = decideApply({
-      toolName: "Write",
-      input: { content: "line1\nline2\n" },
-      filePath: skillFile(),
-      stateDir,
-      cfg: CFG,
-      now,
-    });
-    expect(d.action).toBe("allow");
-    if (d.action === "allow") {
-      expect(d.tier).toBe("T1");
-      expect(d.candidatePassRate).toBe(1.0);
-      expect(d.changedLines).toBeLessThanOrEqual(CFG.t1MaxChangedLines);
+  it("ALLOWS a small, owned, evals-passing edit under the rate cap (T1_LIVE on)", () => {
+    // The hard backstop (apply-guard step 7) downgrades even a fully-verified
+    // T1 to a one-tap T2 unless the operator has opted into silent apply with
+    // SWITCHROOM_SELF_IMPROVE_T1_LIVE=1 (default OFF). To exercise the "allow"
+    // leg of the deterministic gate we opt in here, then restore.
+    const prev = process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE;
+    process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE = "1";
+    try {
+      makeOwnedSkill(true);
+      writeBenchmark(1.0, 0.9);
+      const d = decideApply({
+        toolName: "Write",
+        input: { content: "line1\nline2\n" },
+        filePath: skillFile(),
+        stateDir,
+        cfg: CFG,
+        now,
+      });
+      expect(d.action).toBe("allow");
+      if (d.action === "allow") {
+        expect(d.tier).toBe("T1");
+        expect(d.candidatePassRate).toBe(1.0);
+        expect(d.changedLines).toBeLessThanOrEqual(CFG.t1MaxChangedLines);
+      }
+    } finally {
+      if (prev === undefined) delete process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE;
+      else process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE = prev;
+    }
+  });
+
+  it("BLOCKS a verified T1 (downgrade T2) when T1_LIVE is unset — the hard backstop", () => {
+    const prev = process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE;
+    delete process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE;
+    try {
+      makeOwnedSkill(true);
+      writeBenchmark(1.0, 0.9);
+      const d = decideApply({
+        toolName: "Write",
+        input: { content: "line1\nline2\n" },
+        filePath: skillFile(),
+        stateDir,
+        cfg: CFG,
+        now,
+      });
+      expect(d.action).toBe("block");
+      if (d.action === "block") {
+        expect(d.downgradeTier).toBe("T2");
+        expect(d.reason).toMatch(/SWITCHROOM_SELF_IMPROVE_T1_LIVE|silent auto-apply is disabled/i);
+      }
+    } finally {
+      if (prev === undefined) delete process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE;
+      else process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE = prev;
     }
   });
 

--- a/tests/self-improve-eval-case-cli.test.ts
+++ b/tests/self-improve-eval-case-cli.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { createServer, type Server } from "node:net";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  enqueueEvalCaseProposal,
+  setEvalCaseProposalStatus,
+} from "../src/self-improve/eval-case-proposals.js";
+import { evalsJsonPath } from "../src/self-improve/eval-gate.js";
+import { verifyEvalIntegrity } from "../src/self-improve/eval-cases.js";
+
+const bunOk = spawnSync("which", ["bun"], { encoding: "utf-8" }).status === 0;
+const CLI = join(process.cwd(), "bin", "switchroom.ts");
+
+let home: string;
+let stateDir: string;
+let skillDir: string;
+
+function cli(args: string[], env: Record<string, string> = {}) {
+  const r = spawnSync("bun", [CLI, ...args], {
+    encoding: "utf-8",
+    timeout: 30000,
+    env: {
+      ...process.env,
+      HOME: home,
+      TELEGRAM_STATE_DIR: stateDir,
+      SWITCHROOM_AGENT_NAME: "tester",
+      SWITCHROOM_SELF_IMPROVE: "1",
+      ...env,
+    },
+  });
+  return { status: r.status ?? -1, out: (r.stdout ?? "").trim(), err: (r.stderr ?? "").trim() };
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "evcase-cli-home-"));
+  stateDir = mkdtempSync(join(tmpdir(), "evcase-cli-state-"));
+  skillDir = join(home, ".claude", "skills", "myskill");
+  mkdirSync(skillDir, { recursive: true });
+});
+afterEach(() => {
+  for (const d of [home, stateDir]) {
+    if (d && existsSync(d)) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+describe("add-eval-case (propose-only)", () => {
+  it("rejects an unowned skill", () => {
+    if (!bunOk) return;
+    const r = cli(["self-improve", "add-eval-case", "--skill", "ghost", "--prompt", "be terse", "--chat", "1"]);
+    expect(r.status).toBe(1);
+    expect(r.err).toMatch(/not an owned skill/i);
+  });
+
+  it("FAIL-CLOSED: rejects a prompt carrying PII before any IPC (invariant I4)", () => {
+    if (!bunOk) return;
+    const r = cli(["self-improve", "add-eval-case", "--skill", "myskill", "--prompt", "email me at bob@example.com", "--chat", "1"]);
+    expect(r.status).toBe(1);
+    expect(r.err).toMatch(/PII\/secret scan found/);
+    expect(r.err).toMatch(/email/);
+  });
+
+  it("on a clean prompt, sends a post_eval_case_proposal IPC to the gateway socket", async () => {
+    if (!bunOk) return;
+    const sockPath = join(stateDir, "gateway.sock");
+    const received: string[] = [];
+    const server: Server = await new Promise((resolve) => {
+      const s = createServer((conn) => {
+        let buf = "";
+        conn.on("data", (d) => (buf += d.toString()));
+        conn.on("end", () => received.push(buf));
+      });
+      s.listen(sockPath, () => resolve(s));
+    });
+    try {
+      const r = cli(
+        ["self-improve", "add-eval-case", "--skill", "myskill", "--prompt", "keep replies terse", "--chat", "12345"],
+        { SWITCHROOM_GATEWAY_SOCKET: sockPath },
+      );
+      expect(r.status).toBe(0);
+      expect(JSON.parse(r.out).ok).toBe(true);
+      // Give the server a tick to flush the connection 'end'.
+      await new Promise((res) => setTimeout(res, 50));
+      expect(received.length).toBe(1);
+      const msg = JSON.parse(received[0]!.trim());
+      expect(msg.type).toBe("post_eval_case_proposal");
+      expect(msg.agentName).toBe("tester");
+      expect(msg.chatId).toBe("12345");
+      expect(msg.skillSlug).toBe("myskill");
+      expect(msg.case.prompt).toBe("keep replies terse");
+      expect(typeof msg.fingerprint).toBe("string");
+    } finally {
+      await new Promise((res) => server.close(() => res(null)));
+    }
+  });
+});
+
+describe("apply-eval-case (deterministic applier)", () => {
+  function seed(caseObj: { prompt: string }, status: "pending" | "approved") {
+    const p = enqueueEvalCaseProposal(stateDir, {
+      skill_slug: "myskill",
+      skill_dir: skillDir,
+      case: caseObj,
+      fingerprint: "fp-" + caseObj.prompt.length,
+      held_out: false,
+      chat_id: 1,
+    });
+    if (status === "approved") setEvalCaseProposalStatus(stateDir, p.id, "approved");
+    return p.id;
+  }
+
+  it("refuses a proposal that is not approved (defense-in-depth, MJ2)", () => {
+    if (!bunOk) return;
+    const id = seed({ prompt: "be terse" }, "pending");
+    const r = cli(["self-improve", "apply-eval-case", "--id", id]);
+    expect(r.status).toBe(1);
+    expect(r.err).toMatch(/not "approved"|refusing to apply/i);
+  });
+
+  it("applies an approved case byte-exact and records the integrity baseline", () => {
+    if (!bunOk) return;
+    const id = seed({ prompt: "be terse" }, "approved");
+    const r = cli(["self-improve", "apply-eval-case", "--id", id]);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.out);
+    expect(out.applied).toBe(true);
+    expect(out.total).toBe(1);
+    const doc = JSON.parse(readFileSync(evalsJsonPath(skillDir), "utf8"));
+    expect(doc.evals[0].prompt).toBe("be terse");
+    // Applier recorded its own write as the baseline → no spurious drift.
+    expect(verifyEvalIntegrity(stateDir, "myskill", skillDir)).toBe("ok");
+  });
+
+  it("FAIL-CLOSED: re-scans at apply and refuses a stored case carrying PII (I4 both ends)", () => {
+    if (!bunOk) return;
+    const id = seed({ prompt: "call 415-555-2671" }, "approved");
+    const r = cli(["self-improve", "apply-eval-case", "--id", id]);
+    expect(r.status).toBe(1);
+    expect(r.err).toMatch(/PII\/secret scan found/);
+    // Nothing was written to the skill.
+    expect(existsSync(evalsJsonPath(skillDir))).toBe(false);
+  });
+});

--- a/tests/self-improve-eval-cases.test.ts
+++ b/tests/self-improve-eval-cases.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  parseEvalCase,
+  caseFingerprint,
+  readEvalsDoc,
+  appendEvalCase,
+  appendHeldOutCase,
+  heldOutPath,
+  evalsSha256,
+  recordEvalBaseline,
+  verifyEvalIntegrity,
+  listSkillsWithEvals,
+  sweepEvalIntegrity,
+  evalsBaselineTrusted,
+} from "../src/self-improve/eval-cases.js";
+import { evalsJsonPath } from "../src/self-improve/eval-gate.js";
+
+let agentDir: string;
+let stateDir: string;
+let skillsRoot: string;
+
+function skillDir(slug: string): string {
+  return join(skillsRoot, slug);
+}
+function makeSkill(slug: string): string {
+  const d = skillDir(slug);
+  mkdirSync(join(d, "evals"), { recursive: true });
+  return d;
+}
+
+beforeEach(() => {
+  agentDir = mkdtempSync(join(tmpdir(), "eval-cases-agent-"));
+  stateDir = mkdtempSync(join(tmpdir(), "eval-cases-state-"));
+  skillsRoot = join(agentDir, ".claude", "skills");
+  mkdirSync(skillsRoot, { recursive: true });
+});
+afterEach(() => {
+  for (const d of [agentDir, stateDir]) {
+    if (d && existsSync(d)) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+describe("parseEvalCase", () => {
+  it("rejects a non-object input as not-a-JSON-object", () => {
+    for (const bad of [undefined, null, [], "hi", 7]) {
+      const r = parseEvalCase(bad);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/object/i);
+    }
+  });
+  it("rejects a missing / empty / whitespace prompt", () => {
+    for (const bad of [{}, { prompt: "" }, { prompt: "   " }]) {
+      const r = parseEvalCase(bad);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/prompt/i);
+    }
+  });
+  it("accepts a well-formed case and preserves optional fields", () => {
+    const r = parseEvalCase({ prompt: "hi", expectations: ["x"], source: "correction" });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.case.prompt).toBe("hi");
+      expect(r.case.expectations).toEqual(["x"]);
+    }
+  });
+});
+
+describe("caseFingerprint", () => {
+  it("is stable across case + whitespace normalization", () => {
+    expect(caseFingerprint("Hello  World")).toBe(caseFingerprint("hello world"));
+  });
+  it("differs for materially different prompts", () => {
+    expect(caseFingerprint("tone should be terse")).not.toBe(
+      caseFingerprint("tone should be verbose"),
+    );
+  });
+});
+
+describe("appendEvalCase (add-only, dedup, atomic)", () => {
+  it("appends the first case and creates a well-formed evals.json", () => {
+    const d = makeSkill("s1");
+    const r = appendEvalCase(d, "s1", { prompt: "case one" });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.total).toBe(1);
+      expect(r.index).toBe(0);
+    }
+    const doc = readEvalsDoc(d);
+    expect(doc?.skill_name).toBe("s1");
+    expect(doc?.evals.length).toBe(1);
+    expect(doc?.evals[0]?.prompt).toBe("case one");
+  });
+
+  it("dedups a case with the same normalized prompt", () => {
+    const d = makeSkill("s1");
+    expect(appendEvalCase(d, "s1", { prompt: "Be terse" }).ok).toBe(true);
+    const dup = appendEvalCase(d, "s1", { prompt: "be   terse" });
+    expect(dup.ok).toBe(false);
+    if (!dup.ok) expect(dup.duplicate).toBe(true);
+    // Still exactly one case on disk — the dup was not appended.
+    expect(readEvalsDoc(d)?.evals.length).toBe(1);
+  });
+
+  it("rejects an empty-prompt case without writing", () => {
+    const d = makeSkill("s1");
+    const r = appendEvalCase(d, "s1", { prompt: "" });
+    expect(r.ok).toBe(false);
+    expect(existsSync(evalsJsonPath(d))).toBe(false);
+  });
+});
+
+describe("held-out sink", () => {
+  it("appends jsonl lines to the state-dir sink (never a skill dir)", () => {
+    appendHeldOutCase(stateDir, "s1", { prompt: "held one" });
+    appendHeldOutCase(stateDir, "s1", { prompt: "held two" });
+    const lines = readFileSync(heldOutPath(stateDir), "utf8").trim().split("\n");
+    expect(lines.length).toBe(2);
+    const first = JSON.parse(lines[0]!);
+    expect(first.slug).toBe("s1");
+    expect(first.case.prompt).toBe("held one");
+    expect(typeof first.at).toBe("string");
+  });
+});
+
+describe("integrity manifest + baseline", () => {
+  it("evalsSha256 is null with no evals, non-null once present", () => {
+    const d = makeSkill("s1");
+    expect(evalsSha256(d)).toBeNull();
+    appendEvalCase(d, "s1", { prompt: "case one" });
+    expect(evalsSha256(d)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("verifyEvalIntegrity: no-evals → missing → ok → drift lifecycle", () => {
+    const d = makeSkill("s1");
+    // No evals.json yet.
+    expect(verifyEvalIntegrity(stateDir, "s1", d)).toBe("no-evals");
+    appendEvalCase(d, "s1", { prompt: "case one" });
+    // Evals exist but never recorded a baseline.
+    expect(verifyEvalIntegrity(stateDir, "s1", d)).toBe("missing");
+    recordEvalBaseline(stateDir, "s1", d);
+    expect(verifyEvalIntegrity(stateDir, "s1", d)).toBe("ok");
+    // Out-of-band edit → drift.
+    writeFileSync(
+      evalsJsonPath(d),
+      JSON.stringify({ skill_name: "s1", evals: [{ name: "t", prompt: "tampered" }] }),
+    );
+    expect(verifyEvalIntegrity(stateDir, "s1", d)).toBe("drift");
+  });
+});
+
+describe("sweepEvalIntegrity (Stop-hook self-heal)", () => {
+  it("records on first sight, then heals a drifted eval set back to baseline", () => {
+    const d = makeSkill("s1");
+    appendEvalCase(d, "s1", { prompt: "case one" });
+    expect(listSkillsWithEvals(skillsRoot).map((s) => s.slug)).toEqual(["s1"]);
+
+    // First sweep records a baseline — nothing to heal yet.
+    const first = sweepEvalIntegrity(skillsRoot, stateDir);
+    expect(first.recorded).toContain("s1");
+    expect(first.healed).toEqual([]);
+    expect(verifyEvalIntegrity(stateDir, "s1", d)).toBe("ok");
+
+    // Tamper out-of-band, then sweep → reverted to the recorded baseline.
+    writeFileSync(
+      evalsJsonPath(d),
+      JSON.stringify({ skill_name: "s1", evals: [{ name: "t", prompt: "tampered" }] }),
+    );
+    expect(verifyEvalIntegrity(stateDir, "s1", d)).toBe("drift");
+    const second = sweepEvalIntegrity(skillsRoot, stateDir);
+    expect(second.healed).toContain("s1");
+    const reverted = readEvalsDoc(d);
+    expect(reverted?.evals[0]?.prompt).toBe("case one");
+    expect(verifyEvalIntegrity(stateDir, "s1", d)).toBe("ok");
+  });
+
+  // MAJOR 2 (PR #4403 review): a first-sight evals.json appeared OUT OF BAND
+  // (never through the sanctioned applier, which records its own baseline). The
+  // sweep must NOT silently trust it — it runs the SAME fail-closed PII/secret
+  // scan the sanctioned path runs, and QUARANTINES un-clean bytes rather than
+  // adopting them as a baseline. This is the deterministic guarantee that pairs
+  // with the Bash write-block: even if the command-string heuristic misses an
+  // exotic writer, pre-seeded poisoned bytes never become a trusted baseline.
+  it("quarantines a poisoned first-sight evals.json instead of trusting it", () => {
+    const clean = makeSkill("clean");
+    writeFileSync(
+      evalsJsonPath(clean),
+      JSON.stringify({ skill_name: "clean", evals: [{ prompt: "handle empty input" }] }),
+    );
+    // Assembled at runtime so no contiguous secret/email literal sits in the
+    // source (which would trip scripts/check-no-pii-secrets.mjs); scanForPII
+    // still sees the joined value.
+    const fakeKey =
+      ["sk", "ant", "api03"].join("-") +
+      "-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfGhIjKlMnOpQrStUvWxYz01-AAAAAA";
+    const secret = makeSkill("secret");
+    writeFileSync(
+      evalsJsonPath(secret),
+      JSON.stringify({
+        skill_name: "secret",
+        evals: [{ prompt: "use the key", expected_output: fakeKey }],
+      }),
+    );
+    const fakeEmail = ["alice.example", "example.com"].join("@");
+    const pii = makeSkill("pii");
+    writeFileSync(
+      evalsJsonPath(pii),
+      JSON.stringify({
+        skill_name: "pii",
+        evals: [{ prompt: `email me at ${fakeEmail} please` }],
+      }),
+    );
+
+    // Helper directly: clean trusted, poisoned not.
+    expect(evalsBaselineTrusted(clean)).toBe(true);
+    expect(evalsBaselineTrusted(secret)).toBe(false);
+    expect(evalsBaselineTrusted(pii)).toBe(false);
+
+    const rep = sweepEvalIntegrity(skillsRoot, stateDir);
+    expect(rep.recorded).toEqual(["clean"]);
+    expect(rep.quarantined.sort()).toEqual(["pii", "secret"]);
+
+    // The clean one is now a trusted baseline; the poisoned ones remain
+    // "missing" — never adopted, so drift-detection can't be defeated by
+    // pre-seeding them.
+    expect(verifyEvalIntegrity(stateDir, "clean", clean)).toBe("ok");
+    expect(verifyEvalIntegrity(stateDir, "secret", secret)).toBe("missing");
+    expect(verifyEvalIntegrity(stateDir, "pii", pii)).toBe("missing");
+  });
+
+  it("evalsBaselineTrusted is fail-closed on an unreadable evals.json", () => {
+    const d = makeSkill("gone");
+    // No evals.json written → unreadable → not trusted.
+    expect(evalsBaselineTrusted(d)).toBe(false);
+  });
+});

--- a/tests/self-improve-pii-scan.test.ts
+++ b/tests/self-improve-pii-scan.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { scanForPII, summarizeFindings } from "../src/self-improve/pii-scan.js";
+
+describe("scanForPII", () => {
+  it("passes clean prose with no findings", () => {
+    const r = scanForPII("keep the tone terse and skip the preamble");
+    expect(r.ok).toBe(true);
+    expect(r.findings).toEqual([]);
+  });
+
+  it("flags an email and masks it (never emits the raw address)", () => {
+    const raw = "alice.smith@example.com";
+    const r = scanForPII(`contact ${raw} please`);
+    expect(r.ok).toBe(false);
+    const f = r.findings.find((x) => x.kind === "email");
+    expect(f).toBeDefined();
+    expect(f!.excerpt).not.toContain(raw);
+    expect(f!.excerpt).toMatch(/^\w\*\*\*@\*\*\*\.\w+$/);
+  });
+
+  it("flags E.164 and separated phone numbers, masked to last 4", () => {
+    for (const p of ["+14155552671", "415-555-2671", "(415) 555-2671"]) {
+      const r = scanForPII(`call ${p} now`);
+      const f = r.findings.find((x) => x.kind === "phone");
+      expect(f, p).toBeDefined();
+      expect(f!.excerpt).toBe("***2671");
+    }
+  });
+
+  it("does NOT flag a bare 10-digit run (id / version noise)", () => {
+    // No separators / no + prefix — deliberately not treated as a phone.
+    const r = scanForPII("build 4155552671 shipped");
+    expect(r.findings.some((f) => f.kind === "phone")).toBe(false);
+  });
+
+  it("flags a dashed US SSN", () => {
+    const r = scanForPII("ssn 123-45-6789 on file");
+    const f = r.findings.find((x) => x.kind === "ssn");
+    expect(f).toBeDefined();
+    expect(f!.excerpt).toBe("***6789");
+  });
+
+  it("flags a Luhn-valid card but not a Luhn-invalid candidate", () => {
+    const good = scanForPII("card 4111 1111 1111 1111");
+    expect(good.findings.some((f) => f.kind === "card")).toBe(true);
+    const bad = scanForPII("num 4111 1111 1111 1112"); // fails Luhn
+    expect(bad.findings.some((f) => f.kind === "card")).toBe(false);
+  });
+
+  it("flags a secret via the shared detector and never emits its bytes", () => {
+    const secret = "sk-ant-api03-" + "A".repeat(80);
+    const r = scanForPII(`token ${secret}`);
+    const f = r.findings.find((x) => x.kind === "secret");
+    expect(f).toBeDefined();
+    expect(f!.rule).toBeTruthy();
+    expect(f!.excerpt).not.toContain(secret);
+    expect(f!.excerpt).toMatch(/^\[secret:.+\]$/);
+  });
+
+  it("summarizeFindings groups by kind with counts", () => {
+    const r = scanForPII("a@b.com and 415-555-2671");
+    const s = summarizeFindings(r.findings);
+    expect(s).toMatch(/email/);
+    expect(s).toMatch(/phone/);
+  });
+});

--- a/tests/skill-validate-pretool.test.ts
+++ b/tests/skill-validate-pretool.test.ts
@@ -16,7 +16,10 @@ import { join } from "node:path";
 const bunOk = spawnSync("which", ["bun"], { encoding: "utf-8" }).status === 0;
 const HOOK = join(process.cwd(), "src", "cli", "skill-validate-pretool.ts");
 
-function run(payload: unknown): {
+function run(
+  payload: unknown,
+  env: Record<string, string> = {},
+): {
   status: number;
   stdout: string;
   stderr: string;
@@ -25,6 +28,7 @@ function run(payload: unknown): {
     input: typeof payload === "string" ? payload : JSON.stringify(payload),
     encoding: "utf-8",
     timeout: 30000,
+    env: { ...process.env, ...env },
   });
   return {
     status: r.status ?? 1,
@@ -214,6 +218,179 @@ describe("skill-validate-pretool hook", () => {
     });
     expect(shrink.status).toBe(0);
     expect(shrink.stdout).toBe("");
+  });
+
+  // BL1 (RFC amendment §"corrections as eval cases"): evals/evals.json is
+  // machine-managed. A raw model Write/Edit to it must be BLOCKED on EVERY
+  // turn by this always-on hook (not only the review-scoped apply-guard),
+  // because a direct write bypasses the PII/secret scan AND the operator's
+  // one-tap approval. The sanctioned path is `add-eval-case`.
+  it("BL1: blocks a raw Write to evals/evals.json (always-on, no marker needed)", () => {
+    if (!bunOk) return;
+    const r = run(
+      {
+        tool_name: "Write",
+        tool_input: {
+          file_path: join(skillsRoot, "demo", "evals", "evals.json"),
+          content: '{"skill_name":"demo","evals":[{"name":"x","prompt":"p"}]}',
+        },
+      },
+      { SWITCHROOM_SELF_IMPROVE: "1" }, // hermetic: force self-improvement ON
+    );
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.decision).toBe("block");
+    expect(out.reason).toMatch(/add-eval-case/);
+    expect(out.reason).toMatch(/machine-managed|PII\/secret scan/i);
+  });
+
+  it("BL1: blocks a raw Edit to evals/evals.json too", () => {
+    if (!bunOk) return;
+    const r = run(
+      {
+        tool_name: "Edit",
+        tool_input: {
+          file_path: join(skillsRoot, "demo", "evals", "evals.json"),
+          old_string: "p",
+          new_string: "p2",
+          content: '{"skill_name":"demo","evals":[]}',
+        },
+      },
+      { SWITCHROOM_SELF_IMPROVE: "1" },
+    );
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.decision).toBe("block");
+    expect(out.reason).toMatch(/add-eval-case/);
+  });
+
+  it("BL1: SWITCHROOM_SELF_IMPROVE=0 escape hatch allows the raw evals.json write", () => {
+    if (!bunOk) return;
+    const r = run(
+      {
+        tool_name: "Write",
+        tool_input: {
+          file_path: join(skillsRoot, "demo", "evals", "evals.json"),
+          content: '{"skill_name":"demo","evals":[]}',
+        },
+      },
+      { SWITCHROOM_SELF_IMPROVE: "0" },
+    );
+    expect(r.status).toBe(0);
+    // With self-improvement off, hand-authoring via skill-creator is allowed;
+    // the write is not blocked by BL1 (any residual output must not be a block).
+    if (r.stdout) {
+      expect(JSON.parse(r.stdout).decision).toBeUndefined();
+    }
+  });
+
+  it("BL1: a sibling evals/ file that is NOT evals.json is not BL1-blocked", () => {
+    if (!bunOk) return;
+    // Only evals/evals.json is machine-managed; a held-out or notes file
+    // under evals/ is out of BL1 scope (byte-cap / advisory rules still apply).
+    const r = run(
+      {
+        tool_name: "Write",
+        tool_input: {
+          file_path: join(skillsRoot, "demo", "evals", "notes.md"),
+          content: "scratch notes\n",
+        },
+      },
+      { SWITCHROOM_SELF_IMPROVE: "1" },
+    );
+    expect(r.status).toBe(0);
+    if (r.stdout) {
+      expect(JSON.parse(r.stdout).decision).not.toBe("block");
+    }
+  });
+
+  // MAJOR 1 (PR #4403 review): the always-on write-block canonicalizes the
+  // target before the equality check, so a `..`/`.`-laden path that OS-resolves
+  // to the real evals.json is blocked identically to the plain path. The two
+  // concrete strings below are the validator's confirmed bypasses.
+  it("BL1/MAJOR1: blocks a `../`-laden Write that resolves to evals/evals.json", () => {
+    if (!bunOk) return;
+    for (const rel of [
+      ["demo", "evals", "..", "evals", "evals.json"],
+      ["demo", "sub", "..", "evals", "evals.json"],
+      ["demo", "..", "demo", "evals", "evals.json"],
+    ]) {
+      const r = run(
+        {
+          tool_name: "Write",
+          tool_input: {
+            file_path: join(skillsRoot, ...rel),
+            content: '{"skill_name":"demo","evals":[]}',
+          },
+        },
+        { SWITCHROOM_SELF_IMPROVE: "1" },
+      );
+      expect(r.status).toBe(0);
+      const out = JSON.parse(r.stdout);
+      expect(out.decision).toBe("block");
+      expect(out.reason).toMatch(/machine-managed|add-eval-case/);
+    }
+  });
+
+  // MAJOR 2 (PR #4403 review): a Bash tool call carries no file_path, so a
+  // shell redirect / writer verb into a machine-managed evals.json used to slip
+  // past the write-block entirely. The hook now matches Bash and blocks the
+  // demonstrated write vectors while leaving reads and the sanctioned CLI alone.
+  it("BL1/MAJOR2: blocks a Bash redirect/write into evals/evals.json", () => {
+    if (!bunOk) return;
+    const target = join(skillsRoot, "demo", "evals", "evals.json");
+    const traversal = join(skillsRoot, "demo", "evals", "..", "evals", "evals.json");
+    const commands = [
+      `echo poison > ${target}`,
+      `echo poison >> ${target}`,
+      `cat src > ${traversal}`,
+      `tee ${target} < src`,
+      `cp /tmp/p ${target}`,
+      `sed -i s/a/b/ ${target}`,
+      `dd if=/tmp/p of=${target}`,
+    ];
+    for (const command of commands) {
+      const r = run(
+        { tool_name: "Bash", tool_input: { command } },
+        { SWITCHROOM_SELF_IMPROVE: "1" },
+      );
+      expect(r.status).toBe(0);
+      const out = JSON.parse(r.stdout);
+      expect(out.decision).toBe("block");
+      expect(out.reason).toMatch(/machine-managed|add-eval-case/);
+    }
+  });
+
+  it("MAJOR2: Bash reads / the sanctioned CLI / unrelated redirects are allowed", () => {
+    if (!bunOk) return;
+    const target = join(skillsRoot, "demo", "evals", "evals.json");
+    const allowed = [
+      `cat ${target}`,
+      `grep foo ${target}`,
+      `jq . ${target}`,
+      `switchroom self-improve add-eval-case --skill demo --prompt 'fix evals'`,
+      `echo done > /tmp/other.log && cat ${target}`,
+      `ls`,
+    ];
+    for (const command of allowed) {
+      const r = run(
+        { tool_name: "Bash", tool_input: { command } },
+        { SWITCHROOM_SELF_IMPROVE: "1" },
+      );
+      expect(r.status).toBe(0);
+      if (r.stdout) expect(JSON.parse(r.stdout).decision).not.toBe("block");
+    }
+  });
+
+  it("MAJOR2: SWITCHROOM_SELF_IMPROVE=0 escape hatch allows the Bash redirect", () => {
+    if (!bunOk) return;
+    const command = `echo x > ${join(skillsRoot, "demo", "evals", "evals.json")}`;
+    const r = run(
+      { tool_name: "Bash", tool_input: { command } },
+      { SWITCHROOM_SELF_IMPROVE: "0" },
+    );
+    expect(r.status).toBe(0);
+    if (r.stdout) expect(JSON.parse(r.stdout).decision).toBeUndefined();
   });
 
   it("a path containing .claude/skills/ twice never wrong-blocks", () => {


### PR DESCRIPTION
Wave 1 of "corrections become eval cases" (RFC amendment §"corrections as eval cases", PR0 = #4401). Add-only eval-case sink plus an always-on write-block. Design validated + adversarially reviewed; this PR implements it with the review's binding corrections applied.

## What lands
- **BL1 — always-on write-block.** Raw model `Write`/`Edit` to `evals/evals.json` is blocked in the ALWAYS-ON PreToolUse hook (`skill-validate-pretool`), not just review scope. Every turn. Gated on `SWITCHROOM_SELF_IMPROVE` (opt-out). The only sanctioned mutation is CLI → one-tap card → deterministic `apply-eval-case`.
- **CLI.** `add-eval-case` (propose-only: owns-skill + dedup + fail-closed PII/secret scan, invariant I4) posts a `post_eval_case_proposal` IPC. `apply-eval-case` (deterministic applier: re-scans I4, add-only append, records integrity baseline).
- **Gateway (MJ3).** New IPC type + wire validation, one-tap card, callback handler runs `apply-eval-case` via `execFileSync` on Approve (precedent: vault-write) — never injects a model turn. Proposal handlers lifted into `self-improve-proposal-wiring.ts` to hold the gateway line ratchet.
- **apply-guard.** Eval-integrity drift check + hard backstop: a verified T1 downgrades to a one-tap T2 unless `SWITCHROOM_SELF_IMPROVE_T1_LIVE=1` (defaults OFF; flipping it is NOT in this PR).
- **Stop hook.** `sweepEvalIntegrity` records-then-heals the sha256 manifest.

## Honesty notes (encoded in-code)
- **MJ1** — the sha256 manifest is tamper-EVIDENT and self-healing, NOT a cryptographic boundary. Hard backstop is `T1_LIVE` default-OFF.
- **MJ2** — the applier's "approved" status check is defense-in-depth over an agent-writable state dir, NOT an authorization boundary. The operator's tap is the authorization.
- **I4** — deterministic PII/secret scan runs fail-closed at BOTH propose and approved-apply.

## Tests
- **MJ4** end-to-end on an ephemeral fixture agent: once a real case exists via the sink, a deliberately-regressing edit is BLOCKED (downgraded, never applied) even with silent-apply opted in.
- eval-cases (append/dedup/atomic, integrity no-evals→missing→ok→drift, sweep record-then-heal), pii-scan (masked findings, Luhn valid/invalid, bare-10-digit negative), eval-case CLI (unowned reject, fail-closed both ends, IPC send, approved-apply + baseline), BL1 write-block (Write/Edit blocked, `=0` escape, sibling not blocked), T1_LIVE gate.

Sandbox note: `vitest` cannot execute here (node_modules noexec + rollup native mmap). Behaviors were validated via `bun` scripts against source and `tsc` typechecks clean; **CI is the test-runner authority**.

## Not in this PR (filed as follow-ups)
create/update parity (PR2), `files:`-fixture eval cases (L1), PII override UX (L2), retain-tag consolidation (PR4/L3), PR2∥PR3 rebase-on-PR1 note (L5), skill-creator/evals-block tension.

Stacked on #4401 (PR0, RFC amendment). Do not merge ahead of the merge queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)