### PR TITLE
feat(self-improve): T1 net-growth byte cap (PR3, slice 3)

### DIFF
--- a/src/cli/self-improve-apply-guard-pretool.ts
+++ b/src/cli/self-improve-apply-guard-pretool.ts
@@ -172,6 +172,10 @@ function main(): void {
       tier_reason: decision.reason,
       skill_slug: decision.candidate.skillSlug,
       triggered_by: (ctx.signals ?? []).map((s) => s.kind),
+      // Present only on the net-growth-cap downgrade; the one-tap card
+      // renders the before/after byte counts when they're set.
+      bytes_before: decision.bytesBefore,
+      bytes_after: decision.bytesAfter,
     });
     if (!q.ok) {
       // Queue full — the proposal is dropped; surface it rather than lose

--- a/src/self-improve/apply-guard.ts
+++ b/src/self-improve/apply-guard.ts
@@ -198,6 +198,58 @@ export function estimateChangedLines(
   return 0;
 }
 
+/**
+ * Estimate the on-disk byte size BEFORE and AFTER a Write/Edit/MultiEdit,
+ * and the net delta (after − before). This drives the T1 net-growth cap.
+ *
+ *   - before: the current file size from `statSync` (0 if the file is
+ *     absent — a brand-new file).
+ *   - after (Write): the new content's length.
+ *   - after (Edit): before − old_string.length + new_string.length.
+ *   - after (MultiEdit): before + Σ(new_string.length − old_string.length).
+ *
+ * Mirrors `estimateChangedLines`'s reading of the tool input. Skill
+ * bundles are text, so a string `.length` (UTF-16 code units) tracks the
+ * byte size closely enough for the cap's "is this growing a lot" purpose;
+ * `before` is real bytes from `statSync`. A negative/zero delta (shrink or
+ * size-neutral edit) is never blocked by the growth cap.
+ */
+export function estimateByteDelta(
+  toolName: string,
+  input: Record<string, unknown>,
+  filePath: string,
+): { before: number; after: number; delta: number } {
+  let before = 0;
+  try {
+    before = statSync(filePath).size;
+  } catch {
+    before = 0; // absent → brand-new file
+  }
+
+  let after = before;
+  if (toolName === "Write") {
+    const content = typeof input.content === "string" ? input.content : "";
+    after = content.length;
+  } else if (toolName === "Edit") {
+    const oldS = typeof input.old_string === "string" ? input.old_string : "";
+    const newS = typeof input.new_string === "string" ? input.new_string : "";
+    after = before - oldS.length + newS.length;
+  } else if (toolName === "MultiEdit") {
+    const edits = Array.isArray(input.edits) ? input.edits : [];
+    let net = 0;
+    for (const e of edits) {
+      if (!e || typeof e !== "object") continue;
+      const ed = e as Record<string, unknown>;
+      const oldS = typeof ed.old_string === "string" ? ed.old_string : "";
+      const newS = typeof ed.new_string === "string" ? ed.new_string : "";
+      net += newS.length - oldS.length;
+    }
+    after = before + net;
+  }
+
+  return { before, after, delta: after - before };
+}
+
 export type ApplyDecision =
   | {
       /** Allow the write to proceed (a verified T1). */
@@ -218,6 +270,11 @@ export type ApplyDecision =
       reason: string;
       /** A change candidate suitable for enqueuePending(). */
       candidate: ChangeCandidate;
+      /** Skill-file size (bytes) BEFORE the edit — for the proposal card.
+       *  Present on the net-growth-cap downgrade; omitted otherwise. */
+      bytesBefore?: number;
+      /** Projected skill-file size (bytes) AFTER the edit — for the card. */
+      bytesAfter?: number;
     };
 
 export interface DecideApplyParams {
@@ -327,6 +384,26 @@ export function decideApply(p: DecideApplyParams): ApplyDecision {
       downgradeTier: routed.tier === "T3" ? "T3" : "T2",
       reason: `not a T1 auto-apply: ${routed.reason}`,
       candidate: downgradeCandidate(target, owns, changedLines, lesson),
+    };
+  }
+
+  // (3b) net-growth cap — a T1-shaped edit that GROWS the owned skill by
+  //      more than the configured budget is NOT a silent T1. Byte-growth is
+  //      the axis a runaway self-edit loop bloats along, and the changed-
+  //      line cap doesn't catch a single very long line. Purely restrictive:
+  //      a shrink or size-neutral edit (delta ≤ 0) always falls through
+  //      untouched. The 2 MiB MAX_SKILL_BYTES ceiling (src/cli/skill-common.ts)
+  //      stays the OUTER wall; this is the INNER T1 cap.
+  const bytes = estimateByteDelta(p.toolName, p.input, p.filePath);
+  if (bytes.delta > cfg.t1MaxGrowthBytes) {
+    const over = bytes.delta - cfg.t1MaxGrowthBytes;
+    return {
+      action: "block",
+      downgradeTier: "T2",
+      reason: `T1 net-growth cap exceeded for "${target.slug}": +${bytes.delta} bytes (${bytes.before}→${bytes.after}) is ${over} over the ${cfg.t1MaxGrowthBytes}-byte budget — downgraded to a proposal`,
+      candidate: downgradeCandidate(target, owns, changedLines, lesson),
+      bytesBefore: bytes.before,
+      bytesAfter: bytes.after,
     };
   }
 

--- a/src/self-improve/config.ts
+++ b/src/self-improve/config.ts
@@ -26,6 +26,18 @@ export interface SelfImproveConfig {
    * is NOT a T1; it downgrades to a T2 proposal.
    */
   t1MaxChangedLines: number;
+  /**
+   * T1 auto-apply NET-GROWTH cap (bytes). A T1-shaped edit that GROWS an
+   * owned skill by more than this many bytes is NOT a silent T1; it
+   * downgrades to a T2 proposal. Byte-growth is the axis a runaway
+   * self-edit loop bloats along, and the changed-line cap doesn't catch a
+   * single very long line. Purely restrictive — a shrink or size-neutral
+   * edit (delta ≤ 0) is unaffected. `0` means "no growth allowed": ANY
+   * net-positive delta downgrades. This is the INNER T1 cap; the 2 MiB
+   * MAX_SKILL_BYTES hard ceiling (src/cli/skill-common.ts) remains the
+   * outer wall for every skill write.
+   */
+  t1MaxGrowthBytes: number;
   /** Max T1 auto-applies per agent per day. */
   maxAutoAppliesPerDay: number;
   /** Max outstanding (un-actioned) pending suggestions before we stop queueing. */
@@ -37,6 +49,7 @@ export interface SelfImproveConfig {
  * `clerk` without a rebuild:
  *   SWITCHROOM_SELF_IMPROVE_THRESHOLD
  *   SWITCHROOM_SELF_IMPROVE_T1_MAX_LINES
+ *   SWITCHROOM_SELF_IMPROVE_T1_MAX_GROWTH_BYTES
  *   SWITCHROOM_SELF_IMPROVE_MAX_AUTO_PER_DAY
  *   SWITCHROOM_SELF_IMPROVE_MAX_PENDING
  */
@@ -47,6 +60,11 @@ export function resolveSelfImproveConfig(): SelfImproveConfig {
       intEnv("SWITCHROOM_SELF_IMPROVE_THRESHOLD", 2),
     ),
     t1MaxChangedLines: intEnv("SWITCHROOM_SELF_IMPROVE_T1_MAX_LINES", 30),
+    // 0 = "no growth allowed" (intEnv accepts 0 as a valid override).
+    t1MaxGrowthBytes: intEnv(
+      "SWITCHROOM_SELF_IMPROVE_T1_MAX_GROWTH_BYTES",
+      4096,
+    ),
     maxAutoAppliesPerDay: intEnv("SWITCHROOM_SELF_IMPROVE_MAX_AUTO_PER_DAY", 3),
     maxOutstandingPending: intEnv("SWITCHROOM_SELF_IMPROVE_MAX_PENDING", 5),
   };

--- a/src/self-improve/pending-queue.ts
+++ b/src/self-improve/pending-queue.ts
@@ -52,6 +52,12 @@ export interface PendingSuggestion {
   skill_slug?: string;
   /** The signal kind(s) that triggered the review. */
   triggered_by: string[];
+  /** Skill-file size (bytes) BEFORE the proposed edit. Present when the
+   *  downgrade was the T1 net-growth cap — lets the one-tap card show the
+   *  before/after byte counts. Omitted for other downgrade reasons. */
+  bytes_before?: number;
+  /** Projected skill-file size (bytes) AFTER the proposed edit. */
+  bytes_after?: number;
   /** Set true once the operator actions it (reserved for a later slice). */
   actioned?: boolean;
 }

--- a/tests/self-improve-apply-guard.test.ts
+++ b/tests/self-improve-apply-guard.test.ts
@@ -15,6 +15,7 @@ import {
   parseSkillTarget,
   ownsSkill,
   estimateChangedLines,
+  estimateByteDelta,
   benchmarkJsonForSkill,
   skillTargetEscapes,
 } from "../src/self-improve/apply-guard.js";
@@ -25,6 +26,7 @@ import type { SelfImproveConfig } from "../src/self-improve/config.js";
 const CFG: SelfImproveConfig = {
   repetitionThreshold: 2,
   t1MaxChangedLines: 30,
+  t1MaxGrowthBytes: 4096,
   maxAutoAppliesPerDay: 3,
   maxOutstandingPending: 5,
 };
@@ -318,5 +320,151 @@ describe("decideApply — the deterministic T1 gate", () => {
     });
     expect(d.action).toBe("block");
     if (d.action === "block") expect(d.reason).toMatch(/cap reached/i);
+  });
+});
+
+describe("estimateByteDelta", () => {
+  it("Write: before=0 for an absent file, after=content.length, delta=after", () => {
+    const abs = join(agentDir, "does-not-exist.md");
+    const content = "x".repeat(500);
+    const r = estimateByteDelta("Write", { content }, abs);
+    expect(r.before).toBe(0);
+    expect(r.after).toBe(500);
+    expect(r.delta).toBe(500);
+  });
+
+  it("Write: shrinking an existing file yields a negative delta", () => {
+    const abs = join(agentDir, "big.md");
+    writeFileSync(abs, "a".repeat(1000)); // 1000 bytes on disk
+    const r = estimateByteDelta("Write", { content: "a".repeat(100) }, abs);
+    expect(r.before).toBe(1000);
+    expect(r.after).toBe(100);
+    expect(r.delta).toBe(-900);
+  });
+
+  it("Edit: after = before - old_string.length + new_string.length", () => {
+    const abs = join(agentDir, "edit.md");
+    writeFileSync(abs, "a".repeat(200)); // before = 200
+    const r = estimateByteDelta(
+      "Edit",
+      { old_string: "a".repeat(10), new_string: "b".repeat(40) },
+      abs,
+    );
+    expect(r.before).toBe(200);
+    expect(r.after).toBe(200 - 10 + 40);
+    expect(r.delta).toBe(30);
+  });
+
+  it("MultiEdit: delta sums (new-old) across edits", () => {
+    const abs = join(agentDir, "multi.md");
+    writeFileSync(abs, "a".repeat(100)); // before = 100
+    const r = estimateByteDelta(
+      "MultiEdit",
+      {
+        edits: [
+          { old_string: "a", new_string: "aaaa" }, // +3
+          { old_string: "aa", new_string: "" }, // -2
+          { old_string: "", new_string: "aaaaa" }, // +5
+        ],
+      },
+      abs,
+    );
+    expect(r.before).toBe(100);
+    expect(r.delta).toBe(3 - 2 + 5);
+    expect(r.after).toBe(106);
+  });
+
+  it("unknown tool: delta is 0 (after == before)", () => {
+    const abs = join(agentDir, "known.md");
+    writeFileSync(abs, "abc");
+    const r = estimateByteDelta("Read", {}, abs);
+    expect(r.before).toBe(3);
+    expect(r.after).toBe(3);
+    expect(r.delta).toBe(0);
+  });
+});
+
+describe("apply-guard T1 net-growth cap", () => {
+  // A small growth budget so a modest edit trips the cap while staying
+  // well under the changed-line cap (proving the two caps are independent).
+  const TIGHT: SelfImproveConfig = { ...CFG, t1MaxGrowthBytes: 50 };
+
+  it("BLOCKS (T2) a net-growth edit over the byte budget, naming the bytes over", () => {
+    makeOwnedSkill(true);
+    writeBenchmark(1.0, 0.9);
+    // One long line: 200 chars → 1 changed line (under the 30-line cap) but
+    // +200 bytes on a new file → over the 50-byte growth budget by 150.
+    const content = "x".repeat(200);
+    const d = decideApply({
+      toolName: "Write",
+      input: { content },
+      filePath: skillFile(),
+      stateDir,
+      cfg: TIGHT,
+      now,
+    });
+    expect(d.action).toBe("block");
+    if (d.action === "block") {
+      expect(d.downgradeTier).toBe("T2");
+      expect(d.reason).toMatch(/net-growth cap/i);
+      // The named budget + the "over" amount must be in the reason.
+      expect(d.reason).toContain("50-byte budget");
+      expect(d.reason).toContain("150 over");
+      // Before/after byte counts ride on the decision for the proposal card.
+      expect(d.bytesBefore).toBe(0);
+      expect(d.bytesAfter).toBe(200);
+    }
+  });
+
+  it("does NOT apply the growth cap to a SHRINK — it falls through untouched", () => {
+    makeOwnedSkill(true);
+    writeBenchmark(1.0, 0.9);
+    // Existing large file; an Edit that replaces a big block with a small one
+    // is a net shrink → the growth cap must NOT be the reason it's blocked.
+    // With T1_LIVE unset it should reach the silent-apply backstop instead,
+    // proving the shrink passed the growth check rather than being caught by it.
+    const prev = process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE;
+    delete process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE;
+    try {
+      writeFileSync(skillFile(), "b".repeat(400)); // before = 400 bytes
+      const d = decideApply({
+        toolName: "Edit",
+        input: { old_string: "b".repeat(400), new_string: "b".repeat(10) },
+        filePath: skillFile(),
+        stateDir,
+        cfg: TIGHT, // tiny growth budget — a shrink must still pass it
+        now,
+      });
+      expect(d.action).toBe("block");
+      if (d.action === "block") {
+        expect(d.reason).not.toMatch(/net-growth cap/i);
+        expect(d.reason).toMatch(/silent auto-apply is disabled/i);
+        // No byte fields on a non-growth downgrade.
+        expect(d.bytesBefore).toBeUndefined();
+        expect(d.bytesAfter).toBeUndefined();
+      }
+    } finally {
+      if (prev === undefined) delete process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE;
+      else process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE = prev;
+    }
+  });
+
+  it("t1MaxGrowthBytes:0 blocks ANY net-positive growth (no growth allowed)", () => {
+    makeOwnedSkill(true);
+    writeBenchmark(1.0, 0.9);
+    const ZERO: SelfImproveConfig = { ...CFG, t1MaxGrowthBytes: 0 };
+    const d = decideApply({
+      toolName: "Write",
+      input: { content: "tiny\n" }, // +5 bytes on a new file
+      filePath: skillFile(),
+      stateDir,
+      cfg: ZERO,
+      now,
+    });
+    expect(d.action).toBe("block");
+    if (d.action === "block") {
+      expect(d.reason).toMatch(/net-growth cap/i);
+      expect(d.reason).toContain("0-byte budget");
+    }
   });
 });

--- a/tests/self-improve-config.test.ts
+++ b/tests/self-improve-config.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, afterEach } from "vitest";
+
+import { resolveSelfImproveConfig } from "../src/self-improve/config.js";
+
+const ENV = "SWITCHROOM_SELF_IMPROVE_T1_MAX_GROWTH_BYTES";
+
+afterEach(() => {
+  delete process.env[ENV];
+});
+
+describe("resolveSelfImproveConfig — t1MaxGrowthBytes", () => {
+  it("defaults to 4096 bytes when the env is unset", () => {
+    delete process.env[ENV];
+    expect(resolveSelfImproveConfig().t1MaxGrowthBytes).toBe(4096);
+  });
+
+  it("honours a positive env override", () => {
+    process.env[ENV] = "1024";
+    expect(resolveSelfImproveConfig().t1MaxGrowthBytes).toBe(1024);
+  });
+
+  it("accepts 0 (no growth allowed)", () => {
+    process.env[ENV] = "0";
+    expect(resolveSelfImproveConfig().t1MaxGrowthBytes).toBe(0);
+  });
+
+  it("falls back to the default on a non-numeric / negative value", () => {
+    process.env[ENV] = "not-a-number";
+    expect(resolveSelfImproveConfig().t1MaxGrowthBytes).toBe(4096);
+    process.env[ENV] = "-5";
+    expect(resolveSelfImproveConfig().t1MaxGrowthBytes).toBe(4096);
+  });
+});

--- a/tests/self-improve-eval-gate.test.ts
+++ b/tests/self-improve-eval-gate.test.ts
@@ -14,6 +14,7 @@ import {
 const cfg = {
   repetitionThreshold: 2,
   t1MaxChangedLines: 30,
+  t1MaxGrowthBytes: 4096,
   maxAutoAppliesPerDay: 3,
   maxOutstandingPending: 5,
 };

--- a/tests/self-improve-gate.test.ts
+++ b/tests/self-improve-gate.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from "vitest";
 import { runGate } from "../src/self-improve/gate.js";
 import type { TurnMessage } from "../src/self-improve/types.js";
 
-const cfg = { repetitionThreshold: 2, t1MaxChangedLines: 30, maxAutoAppliesPerDay: 3, maxOutstandingPending: 5 };
+const cfg = { repetitionThreshold: 2, t1MaxChangedLines: 30, t1MaxGrowthBytes: 4096, maxAutoAppliesPerDay: 3, maxOutstandingPending: 5 };
 
 function user(text: string): TurnMessage {
   return { role: "user", text };

--- a/tests/self-improve-tier-router.test.ts
+++ b/tests/self-improve-tier-router.test.ts
@@ -6,6 +6,7 @@ import type { ChangeCandidate } from "../src/self-improve/types.js";
 const cfg = {
   repetitionThreshold: 2,
   t1MaxChangedLines: 30,
+  t1MaxGrowthBytes: 4096,
   maxAutoAppliesPerDay: 3,
   maxOutstandingPending: 5,
 };


### PR DESCRIPTION
## What

Slice 3 of the self-improve subsystem: an **inner net-growth byte cap** on the deterministic apply-guard. A T1-shaped skill edit that **grows** an owned skill by more than `t1MaxGrowthBytes` is downgraded to a **T2 one-tap proposal** instead of landing silently.

- **`src/self-improve/config.ts`** — new `t1MaxGrowthBytes` (env `SWITCHROOM_SELF_IMPROVE_T1_MAX_GROWTH_BYTES`, default `4096`, operator-tunable via the existing `intEnv` helper). `0` = "no growth allowed" (documented).
- **`src/self-improve/apply-guard.ts`** — new exported `estimateByteDelta(toolName, input, filePath)` (before from `statSync`, after from the tool input — Write `content.length`, Edit `before − old + new`, MultiEdit summed — mirroring `estimateChangedLines`). New leg in `decideApply()` right after the tier-router: `delta > t1MaxGrowthBytes` → `block` / `downgradeTier:"T2"` with a reason naming the budget and the bytes over. The block decision now carries `bytesBefore`/`bytesAfter`.
- **`src/self-improve/pending-queue.ts`** — new optional `bytes_before`/`bytes_after` on `PendingSuggestion` so a later one-tap card can render the before/after counts.
- **`src/cli/self-improve-apply-guard-pretool.ts`** — threads the byte counts from the decision into `enqueuePending`.

## Why

Byte-growth is the axis a runaway self-edit loop bloats along, and the existing changed-line cap doesn't catch a single very long line. This adds a deterministic inner guard.

## Purely restrictive

A shrink or size-neutral edit (`delta ≤ 0`) falls through **untouched** — no previously-allowed edit becomes blocked by anything except a net-positive growth over budget. The 2 MiB `MAX_SKILL_BYTES` hard ceiling (`src/cli/skill-common.ts`) remains the **outer** wall; this is a new inner T1 cap, not a replacement.

## Tests

Real vitest (`env -u SWITCHROOM_SELF_IMPROVE`):
- `estimateByteDelta` for Write (new/shrink), Edit, MultiEdit, unknown-tool shapes.
- growth-breach → `block` T2 with the named `50-byte budget` + `150 over`, and `bytesBefore/After` populated.
- shrink → falls through to the silent-apply backstop (asserts reason is **not** the growth cap), proving the shrink passed the check rather than being caught by it.
- `t1MaxGrowthBytes:0` blocks any net-positive growth.
- config default / positive override / `0` / invalid-fallback.

## Scope / deps

Cap + card bytes only. No benchmark field, no cron, no retain tag. Depends on PR1 (#4403, merged). Does not touch PR2's files (`skill-proposals.ts`, `types.ts`, `self-improve-bench.ts`).

Follow-up (deferred optional): #4415 — `switchroom doctor` soft-nudge on a skill **line** budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)