### PR TITLE
feat(self-improve): failure-synthesis cron prompt + docs (PR5, slice 4b)

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -351,6 +351,43 @@ correction now defends itself. Silent auto-apply of a verified edit stays OFF
 by default (`SWITCHROOM_SELF_IMPROVE_T1_LIVE` opt-in); until set, every
 otherwise-allowable edit is downgraded to a T2 one-tap proposal.
 
+## Weekly failure-synthesis (one-tap self-improvement, RFC §"failure synthesis")
+
+The failure-driven sibling of skill-synthesis. Where skill-synthesis mines
+what **worked** and generalizes it, failure-synthesis mines what **broke** —
+the `self-improve:correction`-tagged memories the self-improve gate distilled
+— and proposes the smallest durable defense: a skill **EDIT** to a skill the
+agent owns, or a **NEW** personal skill where none covers the failure
+(create/update parity, RFC invariant 6). A NEW-skill-from-failure reuses the
+existing `synthesized-personal-skill` T2 carve-out
+(`src/self-improve/tier-router.ts`) — one tap into the agent's own reversible
+workspace, hard-T3 floors untouched — and records `origin: "failure-synthesis"`
+on the proposal. Every proposal ships with 1–3 regression eval cases routed
+through the propose-only `switchroom self-improve add-eval-case` path (never a
+direct `evals.json` write), so the fix defends itself against re-introduction.
+
+```yaml
+- cron: "0 9 * * 4"        # Thursdays 09:00 — OFFSET from skill-synthesis (Mon)
+  name: failure-synthesis
+  context: agent            # full live session (Tier 2)
+  prompt: |
+    <see reference/prompts/failure-synthesis-cron.md for the full prompt>
+```
+
+**Cadence and token budget are an operator decision — this cron is NOT
+auto-enabled fleet-wide.** Ship the prompt + docs; the operator adds and tunes
+the schedule entry. The **recommended default** is **one candidate proposal +
+one grader run per week** — enough to catch a recurring failure without
+burning a full Tier-2 live session more than weekly. Offset the day-of-week
+from the skill-synthesis cron (e.g. skill-synthesis Monday, failure-synthesis
+Thursday) so the two syntheses don't stack their token cost in a single wake.
+The cron mines the cheap `self-improve:correction` memories FIRST and only
+then reads the **implicated** on-disk transcripts, bounded to the N most
+recent sessions (default N=8) — so its cost stays close to skill-synthesis's,
+not a full-history scan. If a step is unavailable on the non-interactive cron
+fire (missing vault grant, PII scan fail-closed), it degrades gracefully and
+skips the candidate rather than card-spamming an empty topic.
+
 ## Comparison with Claude Code's native scheduling
 
 | | Switchroom (in-agent scheduler) | Claude Code CronCreate | Claude Code Desktop |

--- a/reference/prompts/failure-synthesis-cron.md
+++ b/reference/prompts/failure-synthesis-cron.md
@@ -1,0 +1,169 @@
+# Weekly failure-synthesis cron prompt (one-tap self-improvement, RFC §"failure synthesis")
+
+Serves the JTBD `reference/jobs/get-better-the-longer-they-run.md`
+(invariants: `no-self-escalation`, `on-leash`): when an agent keeps hitting
+the SAME failure across runs, that lesson should bind on every future run
+without re-teaching — and the agent must **propose, never self-create** the
+fix. This is the failure-driven sibling of
+`reference/prompts/skill-synthesis-cron.md`: skill-synthesis mines what
+*worked* and generalizes it; failure-synthesis mines what *broke* and
+proposes the smallest durable defense.
+
+This is the prompt body the operator drops into a weekly schedule entry in
+`switchroom.yaml`. Recommended cadence: weekly, in the agent's full live
+session (Tier 2), **offset from the skill-synthesis cron** so the two
+syntheses don't stack in one wake. Cadence and token budget are an
+**operator decision** — see `docs/scheduling.md` for the recommended default
+(one candidate proposal + one grader run per week) and how to add/tune the
+schedule entry.
+
+```yaml
+- cron: "0 9 * * 4"        # Thursdays 09:00 (agent timezone) — offset from skill-synthesis (Mon)
+  name: failure-synthesis
+  context: agent            # FULL live session (Tier 2) — needs own context
+  prompt: |
+    <paste the SYNTHESIS PROMPT below>
+```
+
+The cron drafts AT MOST ONE candidate (or zero) and surfaces it as a one-tap
+Telegram Approve/Dismiss card via `switchroom self-improve propose-skill`.
+Each proposal ships with 1–3 regression eval cases routed through
+`switchroom self-improve add-eval-case` — a one-tap, PII-scanned,
+propose-only path that appends to the skill's `evals/evals.json` only after
+the operator tap (invariants I1/I4). It must **never** call
+`skill_init_personal` / `skill_edit_personal` itself, and **never** write
+`evals/evals.json` directly — the operator's tap authorizes every write,
+which then runs through the secret-scanning personal-skill / eval-case
+pipeline.
+
+**Create/update parity (invariant I6).** A recurring failure whose fix
+belongs in a skill the agent already owns becomes a skill-**EDIT** proposal.
+A recurring failure with **no** existing home skill becomes a **NEW** personal
+skill: the proposal carries `is_new` and rides the existing
+`proposalKind: "synthesized-personal-skill"` T2 carve-out
+(`src/self-improve/tier-router.ts`), and its provenance is
+`origin: "failure-synthesis"` (`SkillProposal.origin` in
+`src/self-improve/skill-proposals.ts`). The carve-out means one tap into the
+agent's OWN reversible workspace — NOT a T3 explicit-ask — while the hard-T3
+floors (new cron / cross-agent / irreversible) stay untouched. A dismissed
+proposal is fingerprinted and suppressed for 90 days
+(`REJECTION_TTL_MS` / `isSuppressed`) so the same failure isn't re-proposed
+every week.
+
+**Non-interactive fire (cron), degrade gracefully.** This cron fires without
+an operator in the loop (`meta.source="cron"`). If a Hindsight recall, a
+transcript read, or a vault-backed step is unavailable (missing grant, PII
+scan tripping fail-closed), do **not** spam approval cards into an empty
+topic: note the gap in your output, skip that candidate, and continue. The
+operator sees the gap on the next interactive turn and can grant access then.
+
+---
+
+## SYNTHESIS PROMPT
+
+> It's the weekly failure-synthesis review. Your job: find the ONE failure
+> you keep repeating across recent sessions and propose the smallest durable
+> defense — a skill EDIT if you own a skill that should have prevented it, or
+> a NEW personal skill if nothing covers it. Then propose it for one-tap
+> approval, with 1–3 regression eval cases — do NOT create, edit, or write
+> anything yourself.
+>
+> **1. Gather failure signal — cheapest source FIRST.** Start with your
+> `self-improve:correction`-tagged memories: run `recall` (and, for
+> enumeration, `mcp__hindsight__list_memories`) scoped to that tag. These are
+> the corrections the self-improve gate already distilled — mining them is
+> cheap and precise. Only AFTER you have a cluster, open the **implicated**
+> on-disk Claude Code transcripts (`~/.claude/projects/**/*.jsonl`) to read
+> "why did it fail" for those specific sessions — and bound it to the **N
+> most recent sessions** (default N=8). Never scan the full transcript
+> history; the tagged memories are the index, the transcripts are the
+> targeted lookup.
+>
+> **2. Cluster genuinely recurring failures.** A candidate must recur across
+> **at least 2 distinct sessions** (cluster on the session retain tag; fall
+> back to ≥2 distinct calendar days). A single session that failed once does
+> NOT qualify — a one-off is noise, not a pattern. If nothing clears this
+> bar, **stop — proposing nothing is the correct, successful outcome.** Do
+> not manufacture a failure to have something to say.
+>
+> **3. Decide EDIT vs NEW (create/update parity).** Read your existing skills
+> with `skill_list_personal` and `skill_search` (include shared + bundled).
+> - If a skill you **own** should have prevented the failure, propose an
+>   **EDIT** to it (`--edit`).
+> - If a **bundled/shared** skill covers the area, propose **nothing** (note
+>   the operator could clone it to make it editable).
+> - If **nothing** covers the failure, propose a **NEW** personal skill. This
+>   is a `failure-synthesis`-origin, `synthesized-personal-skill` proposal: it
+>   rides the same one-tap T2 carve-out as skill-synthesis (one tap into your
+>   own reversible workspace), so routing is unchanged — only the provenance
+>   differs.
+>
+> **4. Respect the caps and the suppression window.** You may hold at most 20
+> personal skills — if you're at the cap, only propose **edits**, never a new
+> one. If this exact failure was proposed and **dismissed** within the last
+> 90 days, it is suppressed — do not re-propose it (a genuinely improved
+> redraft for the same slug may still surface; a re-run of the same draft
+> will not).
+>
+> **5. Draft the fix — and NEVER copy personal data, PII, or secrets.**
+> Write a clean, generalized SKILL.md edit or new bundle (plus optional
+> `scripts/*.{sh,py}` / `reference/*.md`). **Never copy credentials, API
+> keys, tokens, passwords, email addresses, phone numbers, names, or any
+> other personal/PII data from your conversation history into the skill
+> content.** A skill is a reusable *procedure*, not a transcript. Where a
+> procedure needs a secret, reference it by its vault key name (e.g.
+> `vault:service/key`) — never the value. Keep it to ONE procedure per skill.
+>
+> **6. Propose the skill (do NOT write it).** Save the drafted bundle to a
+> temp JSON file mapping skill-relative paths to contents, e.g.:
+> `{"SKILL.md": "...", "scripts/foo.sh": "..."}`, then run:
+>
+> ```
+> switchroom self-improve propose-skill \
+>   --slug <skill-slug> \
+>   --lesson "<one-line lesson — the failure this defends against>" \
+>   --evidence "failed across N sessions" \
+>   --draft /tmp/failure-skill-draft.json \
+>   --chat <your chat id> \
+>   [--edit]            # include ONLY when editing an existing owned skill;
+>                       # omit for a NEW skill (is_new) — it rides the
+>                       # synthesized-personal-skill T2 carve-out
+> ```
+>
+> This posts a one-tap Approve/Dismiss card. On Approve, you'll receive a
+> `skill_proposal_apply` turn telling you to write the stored draft via
+> `skill_init_personal` / `skill_edit_personal` — at THAT point (and only
+> then) you apply it. The operator's tap is the authorization; you never
+> self-apply.
+>
+> **7. Pin the failure as a regression eval case (1–3, propose-only).** A
+> skill edit that doesn't defend against the failure can silently reintroduce
+> it. So for the SAME slug, turn the failure into 1–3 regression tests — each
+> the failing prompt phrased as a test — via the propose-only, PII-scanned
+> path:
+>
+> ```
+> switchroom self-improve add-eval-case --skill <slug> \
+>   --prompt "<the failure, phrased as a test prompt>" \
+>   --chat <your chat id>
+> ```
+>
+> This writes **nothing** to the skill. It validates, dedups, and runs a
+> deterministic PII/secret scan **fail-closed**, then posts a one-tap card;
+> on Approve the gateway runs the deterministic `apply-eval-case` applier (no
+> model turn) and appends the case byte-exact to `evals/evals.json`. **Never**
+> edit or `Write` `evals/evals.json` yourself — an always-on hook hard-blocks
+> a raw model write to it. Once a case exists, the apply-guard eval gate
+> blocks any future edit whose pass-rate regresses below the floor — the
+> failure now defends itself.
+>
+> **8. NEVER directive-first.** A failure earns a *skill* (edit or new) plus
+> *eval cases* — a durable, testable, reversible artifact — not a standing
+> directive. Directives are for judgment rules code can't enforce; a
+> recurring failure with a reproducible fix is exactly what code (a skill +
+> its eval gate) should enforce deterministically. Do not resolve a
+> failure-synthesis finding by proposing a directive.
+>
+> If nothing clears the ≥2-session bar, just note "no recurring failure
+> worth a durable fix this week" and end the turn. Emit **at most one**
+> skill proposal per run.

--- a/src/self-improve/failure-synthesis.test.ts
+++ b/src/self-improve/failure-synthesis.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Failure-synthesis cron (PR5, RFC §"failure synthesis").
+ *
+ * This slice is prompt + docs, not new gate/router code — the failure-
+ * synthesis NEW-skill proposal deliberately RIDES the existing
+ * `synthesized-personal-skill` T2 carve-out (`tier-router.ts`) and the
+ * existing `origin: "failure-synthesis"` proposal field (`skill-proposals.ts`,
+ * landed in PR2). These tests therefore guard two contracts:
+ *
+ *   1. Prompt-lint — `reference/prompts/failure-synthesis-cron.md` exists,
+ *      routes eval cases through the propose-only `add-eval-case` path (never
+ *      a direct `evals.json` write), and carries the PII/secret clause.
+ *   2. Store + routing (I6 end-to-end) — a NEW-skill proposal stamped
+ *      `origin: "failure-synthesis"` round-trips through the store AND its
+ *      corresponding change candidate routes to T2 (one-tap) through
+ *      `classifyTier`, while a plain new skill with no carve-out stays T3.
+ *      This is the whole point of create/update parity: a failure with no
+ *      home skill still binds, at one-tap friction, with the hard floors
+ *      intact.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { classifyTier } from "./tier-router.js";
+import type { ChangeCandidate } from "./types.js";
+import {
+  enqueueProposal,
+  getProposal,
+  type SkillProposal,
+} from "./skill-proposals.js";
+
+const PROMPT_PATH = fileURLToPath(
+  new URL("../../reference/prompts/failure-synthesis-cron.md", import.meta.url),
+);
+
+function readPrompt(): string {
+  return readFileSync(PROMPT_PATH, "utf-8");
+}
+
+/**
+ * Map a persisted proposal to the change candidate the tier-router sees.
+ * A NEW (is_new) failure-synthesis proposal ALWAYS carries the
+ * `synthesized-personal-skill` kind so it rides the T2 carve-out — that
+ * mapping is the "wiring" this test guards end-to-end.
+ */
+function candidateFor(p: SkillProposal): ChangeCandidate {
+  return {
+    lesson: p.lesson,
+    proposedChange: `add personal skill "${p.skill_slug}" from an observed failure`,
+    createsNewSkill: p.is_new,
+    ...(p.is_new ? { proposalKind: "synthesized-personal-skill" as const } : {}),
+  };
+}
+
+describe("failure-synthesis cron — prompt-lint", () => {
+  it("the prompt file exists and is non-trivial", () => {
+    const md = readPrompt();
+    expect(md.length).toBeGreaterThan(500);
+    expect(md).toMatch(/failure-synthesis/i);
+  });
+
+  it("routes eval cases through add-eval-case, NOT a direct evals.json write", () => {
+    const md = readPrompt();
+    // The sanctioned propose-only path is present …
+    expect(md).toContain("switchroom self-improve add-eval-case");
+    // … and the prompt explicitly forbids a direct evals.json write.
+    expect(md).toMatch(/never\b[^\n]*evals\.json|evals\.json[^\n]*yourself/i);
+    // It must never instruct self-writing the skill either (on-leash).
+    expect(md).toMatch(/do NOT (?:create|write)|never self-appl/i);
+  });
+
+  it("carries the PII/secret clause mirrored from skill-synthesis-cron", () => {
+    const md = readPrompt();
+    expect(md).toMatch(/NEVER copy personal data, PII, or secrets/i);
+    expect(md).toContain("email addresses, phone numbers, names");
+    expect(md).toContain("vault:service/key");
+  });
+
+  it("proposes a failure fix as a skill (edit or new), never directive-first", () => {
+    const md = readPrompt();
+    expect(md).toContain("switchroom self-improve propose-skill");
+    expect(md).toMatch(/NEVER directive-first|not[^\n]*directive/i);
+  });
+});
+
+describe("failure-synthesis cron — store + routing (I6 end-to-end)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "failure-synthesis-"));
+  });
+
+  const newSkillInput = {
+    skill_slug: "handle-rate-limits",
+    is_new: true,
+    lesson: "Back off and retry on a 429 instead of hammering the API",
+    draft: {
+      "SKILL.md":
+        "---\nname: handle-rate-limits\ndescription: rate-limit handling\n---\n\n" +
+        "1. detect 429\n2. read Retry-After\n3. exponential backoff\n",
+    },
+    evidence: "failed across 3 sessions",
+    origin: "failure-synthesis" as const,
+  };
+
+  it("round-trips a failure-synthesis-origin NEW-skill proposal through the store", () => {
+    const p = enqueueProposal(dir, newSkillInput);
+    const fetched = getProposal(dir, p.id);
+    expect(fetched?.origin).toBe("failure-synthesis");
+    expect(fetched?.is_new).toBe(true);
+    expect(fetched?.skill_slug).toBe("handle-rate-limits");
+  });
+
+  it("routes the failure-synthesis NEW-skill proposal to T2 (one-tap)", () => {
+    const p = enqueueProposal(dir, newSkillInput);
+    const fetched = getProposal(dir, p.id)!;
+    const decision = classifyTier(candidateFor(fetched));
+    expect(decision.tier).toBe("T2");
+    expect(decision.reason).toMatch(/one-tap/);
+  });
+
+  it("does NOT lower a plain new skill (no carve-out kind) below T3", () => {
+    // Proves it is the `synthesized-personal-skill` carve-out that lowers the
+    // tier, NOT the `origin` field — origin is provenance only and must not
+    // touch routing. A new skill lacking the carve-out kind stays T3.
+    const plain: ChangeCandidate = {
+      lesson: newSkillInput.lesson,
+      proposedChange: "add a new skill from a failure",
+      createsNewSkill: true,
+    };
+    expect(classifyTier(plain).tier).toBe("T3");
+  });
+
+  it("a failure-synthesis EDIT proposal is a same-skill edit candidate, not a new-skill T3", () => {
+    const editProposal = enqueueProposal(dir, {
+      ...newSkillInput,
+      is_new: false,
+    });
+    const fetched = getProposal(dir, editProposal.id)!;
+    const cand = candidateFor(fetched);
+    expect(cand.createsNewSkill).toBe(false);
+    // An edit candidate never rides the createsNewSkill T3 leg. With no owned-
+    // skill target asserted it surfaces as a T2 one-tap suggestion (never T3).
+    expect(classifyTier(cand).tier).toBe("T2");
+  });
+});


### PR DESCRIPTION
## What

The failure-driven sibling of the weekly skill-synthesis cron (#2670). Where skill-synthesis mines what **worked**, failure-synthesis mines what **broke** — the `self-improve:correction`-tagged memories the self-improve gate distills (PR4 owns the tag; referenced by name only here) — and proposes the smallest durable defense.

Slice 4b of the self-improvement subsystem. Depends conceptually on PR2 (#4418, merged — the `origin`/`benchmark` proposal fields + the `synthesized-personal-skill` T2 carve-out) and PR4 (the `self-improve:correction` retain tag, in flight — referenced by string only).

This is a **prompt + docs + one routing test** PR. No gate/retain or gateway code is touched.

## Files

- **`reference/prompts/failure-synthesis-cron.md`** (new) — the Tier-2 synthesis prompt, structured as a sibling of `skill-synthesis-cron.md`:
  - Mines `self-improve:correction` memories FIRST (cheap recall), then only the **implicated** on-disk transcripts for "why did it fail", bounded to the N most recent sessions.
  - Clusters ≥2-session recurrences; emits **at most one** proposal per run: a skill-**EDIT** to an owned skill, or a **NEW** personal skill where none covers the failure (create/update parity, RFC invariant 6). The NEW case rides the existing `synthesized-personal-skill` T2 carve-out (`tier-router.ts`) with `origin: "failure-synthesis"` provenance and the 90-day rejection-suppression window (`REJECTION_TTL_MS`/`isSuppressed`).
  - Every proposal ships 1–3 eval cases through the propose-only, PII-scanned `switchroom self-improve add-eval-case` path — **never** a direct `evals.json` write (invariants I1/I4).
  - **Never directive-first.** Mirrors the PII/secret clause verbatim. Degrades gracefully on the non-interactive cron fire (no card-spam into an empty topic).
- **`docs/scheduling.md`** — a weekly failure-synthesis section (day-of-week offset from skill-synthesis so they don't stack) with a token-budget note.
- **`src/self-improve/failure-synthesis.test.ts`** (new) — prompt-lint (file exists, routes through `add-eval-case` not a direct `evals.json` write, carries the PII clause, never directive-first) + store/routing coverage: a `failure-synthesis`-origin NEW-skill proposal round-trips through the store AND routes **T2** through `classifyTier`, while a plain new skill with no carve-out stays **T3** (guards the I6 wiring end-to-end).

## Operator decision — NOT auto-enabled

This PR does **not** enable the cron fleet-wide (no `switchroom.yaml` fleet-default change). Cadence and token budget are an operator decision; the docs document a **recommended default of one candidate proposal + one grader run per week**, and the operator adds/tunes the schedule entry.

## Validation

- `env -u SWITCHROOM_SELF_IMPROVE npx vitest run` on the new test + `tier-router.test.ts` + `skill-proposals.test.ts` → **22 passed**.
- `tsc --noEmit` clean; full `npm run lint` clean.

## Note for review — a real gap surfaced

The store-level `origin` field + round-trip landed in PR2, but **no CLI/IPC path currently threads `--origin` through** `propose-skill` → `PostSkillProposalMessage` (`telegram-plugin/gateway/ipc-protocol.ts:560`) → `self-improve-proposal-wiring.ts:82` (which enqueues without `origin`). So a proposal raised by the existing `propose-skill` CLI persists as the `skill-synthesis` default, not `failure-synthesis`. The tier routing (what this PR's test guards) is unaffected — the carve-out rides `proposalKind`, not `origin`. Threading `--origin` to make the persisted provenance match is a small follow-up **outside this prompt+docs+test boundary**; flagging it rather than force-fitting a gateway change into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)