### PR TITLE
feat(self-improve): tag correction turns for retain (PR4 slice 4a)

### DIFF
--- a/src/cli/self-improve-stop.ts
+++ b/src/cli/self-improve-stop.ts
@@ -42,6 +42,7 @@ import {
   clearReviewContext,
 } from "../self-improve/review-context.js";
 import { sweepEvalIntegrity } from "../self-improve/eval-cases.js";
+import { writeCorrectionPending } from "../memory/hindsight-retain-provenance.js";
 import type { TurnMessage } from "../self-improve/types.js";
 
 /** Newest-last window of messages to scan. Bounds the gate's cost and
@@ -325,6 +326,21 @@ function main(): void {
 
   // Cost guarantee: no signal → return immediately, zero added work.
   if (!gate.tripped) process.exit(0);
+
+  // Slice 4a: when the gate fired on an operator-correction, drop a per-turn
+  // sentinel so THIS turn's Hindsight auto-retain (a SEPARATE process — the
+  // vendored retain hook reads-and-clears it) carries a `self-improve:correction`
+  // tag, which PR5's failure-synthesis cron recalls against. Runs BEFORE the
+  // agent-name bail below so the marker still lands on a turn where routing the
+  // review is impossible. Best-effort, wrapped: a marker write must never fail
+  // the turn (the Stop hook is fail-open).
+  if (gate.signals.some((s) => s.kind === "operator-correction")) {
+    try {
+      writeCorrectionPending(resolveStateDir());
+    } catch {
+      /* marker best-effort; the retain simply carries no correction tag */
+    }
+  }
 
   const agentName = process.env.SWITCHROOM_AGENT_NAME ?? "";
   if (!agentName) process.exit(0); // can't route without identity — fail-open

--- a/src/memory/hindsight-retain-provenance.ts
+++ b/src/memory/hindsight-retain-provenance.ts
@@ -64,6 +64,9 @@
  * {@link RETAIN_PROVENANCE_TAG_SCOPE_PATTERN} pins the two halves together.
  */
 
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
 /**
  * The provenance tag stamped on every auto-retained transcript slice.
  *
@@ -97,3 +100,83 @@ export const RETAIN_TAGS_DEFAULT: readonly string[] = Object.freeze([
   "{session_id}",
   RETAIN_PROVENANCE_TAG,
 ]);
+
+// ---------------------------------------------------------------------------
+// self-improve correction tag (PR4 — slice 4a)
+// ---------------------------------------------------------------------------
+
+/**
+ * The tag stamped on a turn's auto-retain when the deterministic self-improve
+ * gate (`src/self-improve/gate.ts`) fired on an `operator-correction` signal.
+ * PR5's failure-synthesis cron recalls correction turns cheaply by filtering on
+ * it (metadata is not filterable, tags are — same rationale as
+ * {@link RETAIN_PROVENANCE_TAG}).
+ *
+ * `<kind>:<name>` per the docs' tag-naming conventions.
+ *
+ * ## STABLE, by contract — and deliberately NOT excluded from the scope
+ *
+ * Unlike {@link RETAIN_PROVENANCE_TAG} (stamped on EVERY retain, hence forced
+ * volatile so it never re-partitions the whole bank), this tag rides only the
+ * rare correction turns. It MUST NOT match `^source:` — or any entry of the
+ * vendored `DEFAULT_VOLATILE_SCOPE_PATTERNS` — so it stays STABLE and the
+ * correction turns it marks consolidate together in their own
+ * `[["self-improve:correction"]]` scope, which is exactly the partition PR5
+ * synthesises over. Because the tag is absent on every non-correction turn, the
+ * bank-wide `"shared"` scope those turns compute is byte-identical to before
+ * this shipped — the all-volatile → `"shared"` invariant is untouched.
+ *
+ * Pinned to the vendored retain hook's copy (`SELF_IMPROVE_CORRECTION_TAG` in
+ * `vendor/hindsight-memory/scripts/retain.py`) by
+ * `tests/scaffold.retain-provenance.test.ts`.
+ */
+export const SELF_IMPROVE_CORRECTION_TAG = "self-improve:correction";
+
+/**
+ * Per-turn sentinel filename the self-improve Stop hook drops into the agent
+ * state dir when the gate fires on an `operator-correction`. The auto-retain
+ * hook (a SEPARATE process — `retain.py`) reads-and-clears it and, when present,
+ * adds {@link SELF_IMPROVE_CORRECTION_TAG} to that retain's tag set. The Stop
+ * hook and the retain hook cannot share env, so this file in the shared state
+ * dir is the seam between them.
+ *
+ * Pinned to `SELF_IMPROVE_CORRECTION_PENDING_FILE` in
+ * `vendor/hindsight-memory/scripts/retain.py` by
+ * `tests/scaffold.retain-provenance.test.ts`.
+ */
+export const SELF_IMPROVE_CORRECTION_PENDING_FILE = "self-improve-correction-pending";
+
+function correctionPendingPath(stateDir: string): string {
+  return join(stateDir, SELF_IMPROVE_CORRECTION_PENDING_FILE);
+}
+
+/**
+ * Drop the per-turn correction sentinel. Called by the self-improve Stop hook
+ * at gate-trip time (operator-correction signal only). Best-effort — a marker
+ * write must never fail the turn (the Stop hook is fail-open); worst case the
+ * next retain simply carries no correction tag.
+ */
+export function writeCorrectionPending(stateDir: string): void {
+  if (!existsSync(stateDir)) {
+    mkdirSync(stateDir, { recursive: true, mode: 0o755 });
+  }
+  // Content is immaterial — presence is the whole signal. A stamp aids forensics.
+  writeFileSync(correctionPendingPath(stateDir), new Date().toISOString(), "utf-8");
+}
+
+/**
+ * Read-once: true iff the sentinel is present, clearing it as a side effect so
+ * exactly one retain carries the tag. The production reader is the Python
+ * `retain.py`; this mirrors the contract in TS for symmetry and unit tests.
+ * Best-effort; never throws.
+ */
+export function readAndClearCorrectionPending(stateDir: string): boolean {
+  const p = correctionPendingPath(stateDir);
+  if (!existsSync(p)) return false;
+  try {
+    rmSync(p, { force: true });
+  } catch {
+    /* nothing to do */
+  }
+  return true;
+}

--- a/tests/scaffold.retain-provenance.test.ts
+++ b/tests/scaffold.retain-provenance.test.ts
@@ -7,6 +7,8 @@ import {
   RETAIN_PROVENANCE_TAG,
   RETAIN_PROVENANCE_TAG_SCOPE_PATTERN,
   RETAIN_TAGS_DEFAULT,
+  SELF_IMPROVE_CORRECTION_TAG,
+  SELF_IMPROVE_CORRECTION_PENDING_FILE,
 } from "../src/memory/hindsight-retain-provenance.js";
 import type { SwitchroomConfig } from "../src/config/schema.js";
 
@@ -117,6 +119,51 @@ describe("hindsight retain — transcript provenance tag", () => {
     expect(new RegExp(RETAIN_PROVENANCE_TAG_SCOPE_PATTERN).test(RETAIN_PROVENANCE_TAG)).toBe(
       true,
     );
+  });
+
+  /**
+   * PR4 slice 4a cross-language pin. The self-improve Stop hook (TS) writes the
+   * correction sentinel by NAME and the vendored retain hook (Python) reads it
+   * by NAME and stamps the tag by VALUE — two separate processes that share only
+   * these two strings. If either copy drifts, correction turns silently stop
+   * being tagged and PR5's synthesis goes blind. This guards both halves against
+   * the TS source of truth.
+   */
+  it("retain.py pins the correction sentinel filename and tag to the TS constants", () => {
+    const retainPy = readFileSync(
+      resolve(
+        __dirname,
+        "..",
+        "vendor",
+        "hindsight-memory",
+        "scripts",
+        "retain.py",
+      ),
+      "utf-8",
+    );
+    expect(retainPy).toContain(
+      `SELF_IMPROVE_CORRECTION_PENDING_FILE = "${SELF_IMPROVE_CORRECTION_PENDING_FILE}"`,
+    );
+    expect(retainPy).toContain(
+      `SELF_IMPROVE_CORRECTION_TAG = "${SELF_IMPROVE_CORRECTION_TAG}"`,
+    );
+  });
+
+  /**
+   * The correction tag is STABLE, by contract — the opposite of the provenance
+   * tag's forced-volatile treatment. It rides only rare correction turns, so it
+   * SHOULD reach the consolidation scope (grouping those turns into their own
+   * `[["self-improve:correction"]]` partition for PR5). It must therefore NOT
+   * match any volatile scope pattern, and in particular not `^source:`.
+   */
+  it("the correction tag is stable — excluded by NO volatile scope pattern", () => {
+    expect(RETAIN_PROVENANCE_TAG_SCOPE_PATTERN).toBe("^source:");
+    expect(new RegExp(RETAIN_PROVENANCE_TAG_SCOPE_PATTERN).test(SELF_IMPROVE_CORRECTION_TAG)).toBe(
+      false,
+    );
+    // Same <kind>:<name> shape as the provenance tag, distinct namespace.
+    expect(SELF_IMPROVE_CORRECTION_TAG).toMatch(/^[a-z-]+:[a-z-]+$/);
+    expect(SELF_IMPROVE_CORRECTION_TAG).not.toBe(RETAIN_PROVENANCE_TAG);
   });
 
   it("the provenance tag is addressable by the existing recall tag-weight surface", () => {

--- a/tests/self-improve-stop-hook.test.ts
+++ b/tests/self-improve-stop-hook.test.ts
@@ -10,6 +10,7 @@ import {
   writeReviewContext,
   reviewIsPending,
 } from "../src/self-improve/review-context.js";
+import { SELF_IMPROVE_CORRECTION_PENDING_FILE } from "../src/memory/hindsight-retain-provenance.js";
 
 // Drive the hook through `bun` against source (mirrors
 // tests/skill-validate-pretool.test.ts) so the test doesn't depend on
@@ -320,6 +321,86 @@ describe("self-improve-stop hook — fires the forked review on a real signal", 
       });
       expect(r.status).toBe(0);
       expect(reviewIsPending(stateDir)).toBe(false); // marker cleared — no leak
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// PR4 slice 4a: on an operator-correction trip the Stop hook drops a per-turn
+// sentinel into the state dir so the (separate-process) auto-retain hook can
+// tag that turn's retain `self-improve:correction`. The marker is written ONLY
+// for the operator-correction signal — never on other trips, never on a clean
+// turn — so a mutation that wrote it unconditionally would fail these.
+describe("self-improve-stop hook — operator-correction retain sentinel (slice 4a)", () => {
+  function sentinelPresent(stateDir: string): boolean {
+    return existsSync(join(stateDir, SELF_IMPROVE_CORRECTION_PENDING_FILE));
+  }
+
+  it("writes the correction sentinel when the gate trips on operator-correction", () => {
+    if (!bunOk) return;
+    const stateDir = mkdtempSync(join(tmpdir(), "self-improve-correction-"));
+    try {
+      const tp = writeTranscript("correction-trip.jsonl", [
+        { role: "user", text: "Send the digest." },
+        { role: "assistant", text: "Sent." },
+        { role: "user", text: "No, that's wrong — you included drafts again." },
+        { role: "assistant", text: "Fixed." },
+        { role: "user", text: "That's not what I asked, I told you to exclude drafts." },
+      ]);
+      const r = run(JSON.stringify({ session_id: "corr", transcript_path: tp }), {
+        SWITCHROOM_AGENT_NAME: "test-agent",
+        TELEGRAM_STATE_DIR: stateDir,
+        SWITCHROOM_GATEWAY_SOCKET: join(stateDir, "no-server.sock"),
+      });
+      expect(r.status).toBe(0);
+      expect(sentinelPresent(stateDir)).toBe(true);
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does NOT write the sentinel on a non-correction trip (repeated-manual-fix only)", () => {
+    if (!bunOk) return;
+    const stateDir = mkdtempSync(join(tmpdir(), "self-improve-nocorr-"));
+    try {
+      // The same Bash remediation twice trips repeated-manual-fix WITHOUT any
+      // operator-correction pattern — so the correction sentinel must stay absent.
+      const cmd = "rm -f /tmp/stale.lock && systemctl restart worker";
+      const tp = writeToolTranscript("fix-only.jsonl", [
+        { role: "user", text: "It's stuck." },
+        { role: "assistant", tools: [{ name: "Bash", input: { command: cmd } }] },
+        { role: "user", text: "still stuck, retry." },
+        { role: "assistant", tools: [{ name: "Bash", input: { command: cmd } }] },
+      ]);
+      const r = run(JSON.stringify({ session_id: "fixonly", transcript_path: tp }), {
+        SWITCHROOM_AGENT_NAME: "test-agent",
+        TELEGRAM_STATE_DIR: stateDir,
+        SWITCHROOM_GATEWAY_SOCKET: join(stateDir, "no-server.sock"),
+      });
+      expect(r.status).toBe(0);
+      expect(sentinelPresent(stateDir)).toBe(false);
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does NOT write the sentinel on a clean turn (no signal)", () => {
+    if (!bunOk) return;
+    const stateDir = mkdtempSync(join(tmpdir(), "self-improve-clean-"));
+    try {
+      const tp = writeTranscript("clean-nocorr.jsonl", [
+        { role: "user", text: "Summarise the logs." },
+        { role: "assistant", text: "Done — all green." },
+        { role: "user", text: "Thanks!" },
+      ]);
+      const r = run(JSON.stringify({ session_id: "clean", transcript_path: tp }), {
+        SWITCHROOM_AGENT_NAME: "test-agent",
+        TELEGRAM_STATE_DIR: stateDir,
+        SWITCHROOM_GATEWAY_SOCKET: join(stateDir, "no-server.sock"),
+      });
+      expect(r.status).toBe(0);
+      expect(sentinelPresent(stateDir)).toBe(false);
     } finally {
       rmSync(stateDir, { recursive: true, force: true });
     }

--- a/vendor/hindsight-memory/scripts/retain.py
+++ b/vendor/hindsight-memory/scripts/retain.py
@@ -25,6 +25,17 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+# Switchroom self-improve PR4 (slice 4a) — per-turn correction tagging.
+# The self-improve Stop hook (a SEPARATE process — src/cli/self-improve-stop.ts)
+# drops SELF_IMPROVE_CORRECTION_PENDING_FILE into the shared agent state dir when
+# the deterministic gate fires on an operator-correction. This hook reads-and-
+# clears it and stamps SELF_IMPROVE_CORRECTION_TAG on that turn's retain so PR5's
+# failure-synthesis cron can recall correction turns cheaply. Both constants are
+# pinned to their TS source (src/memory/hindsight-retain-provenance.ts) by
+# tests/scaffold.retain-provenance.test.ts — they must not drift.
+SELF_IMPROVE_CORRECTION_PENDING_FILE = "self-improve-correction-pending"
+SELF_IMPROVE_CORRECTION_TAG = "self-improve:correction"
+
 from lib import watermark
 from lib.bank import derive_bank_id, ensure_bank_mission
 from lib.client import HindsightClient
@@ -36,6 +47,43 @@ from lib.content import (
 from lib.daemon import get_api_url
 from lib.pacing import inflight_lock
 from lib.state import increment_turn_count, track_retention
+
+
+def _self_improve_state_dir() -> str:
+    """State dir the self-improve Stop hook drops its correction sentinel into.
+
+    Mirrors ``resolveStateDir()`` in ``src/cli/self-improve-stop.ts``:
+    ``TELEGRAM_STATE_DIR`` when set, else ``~/.claude/channels/telegram``. Both
+    hooks run in the same agent process env, so they agree on this path.
+    """
+    env = os.environ.get("TELEGRAM_STATE_DIR")
+    if env:
+        return env
+    return os.path.join(os.path.expanduser("~"), ".claude", "channels", "telegram")
+
+
+def read_and_clear_correction_pending(state_dir: str | None = None) -> list:
+    """Read-and-clear the per-turn operator-correction sentinel (PR4 slice 4a).
+
+    Returns ``[SELF_IMPROVE_CORRECTION_TAG]`` when the sentinel is present (and
+    REMOVES it, so exactly one retain carries the tag — read-once), else ``[]``.
+    Called from ``run_retain`` only (the live Stop-hook entry), NOT from the
+    network-free ``build_retain_payload`` seam, so backfill / reconcile /
+    subagent retains never consume a live turn's marker. Best-effort and NEVER
+    raises — a triage marker must not be able to fail a retain.
+    """
+    try:
+        d = state_dir if state_dir is not None else _self_improve_state_dir()
+        path = os.path.join(d, SELF_IMPROVE_CORRECTION_PENDING_FILE)
+        if not os.path.exists(path):
+            return []
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+        return [SELF_IMPROVE_CORRECTION_TAG]
+    except Exception:
+        return []
 
 
 def read_transcript(transcript_path: str, max_bytes: int | None = None) -> list:
@@ -254,6 +302,7 @@ def build_retain_payload(
     api_token,
     retain_full_window: bool = True,
     document_id=None,
+    extra_tags=None,
 ) -> dict | None:
     """Pure transcript → retain payload + deterministic id (switchroom #3244 §1.4).
 
@@ -322,6 +371,23 @@ def build_retain_payload(
             if lt not in merged:
                 merged.append(lt)
         tags = merged
+
+    # Switchroom self-improve PR4 (slice 4a) — per-turn correction tag. The
+    # caller (``run_retain``) reads-and-clears the operator-correction sentinel
+    # and threads the resulting tag(s) in here; this seam stays network-free and
+    # state-free (no sentinel IO), so it composes with lesson tags and rides the
+    # SAME payload the pending-retains queue persists. ``self-improve:correction``
+    # is STABLE by contract (it must NOT match DEFAULT_VOLATILE_SCOPE_PATTERNS),
+    # so on a correction turn the retain lands in its own
+    # ``[["self-improve:correction"]]`` consolidation scope — exactly the
+    # partition PR5's failure-synthesis cron works over. Absent ⇒ tag absent ⇒
+    # scope stays byte-identical to a normal turn's ``"shared"``.
+    if extra_tags:
+        merged = list(tags) if tags else []
+        for et in extra_tags:
+            if isinstance(et, str) and et and et not in merged:
+                merged.append(et)
+        tags = merged or None
 
     metadata = {
         "retained_at": template_vars["timestamp"],
@@ -564,6 +630,14 @@ def run_retain(hook_input: dict, force: bool = False) -> dict:
         # chunk 0 → plain session_id (backwards compatible with existing docs)
         document_id = session_id if chunk_index == 0 else f"{session_id}-c{chunk_index}"
 
+    # Switchroom self-improve PR4 (slice 4a) — read-and-clear the per-turn
+    # operator-correction sentinel here, in the live Stop path only, AFTER the
+    # throttle / re-fire / empty-transcript early-returns above so only a retain
+    # that actually FIRES consumes the marker (a throttled turn leaves it for the
+    # next firing retain, whose overlapping window still contains the correction).
+    # Read-once: the tag rides exactly one retain. Best-effort; never raises.
+    extra_tags = read_and_clear_correction_pending()
+
     # Build the payload via the shared, network-free seam (§1.4). This carries
     # the deterministic id, connection info, formatted transcript, tags and
     # metadata — sufficient to retry from a different process (drain_pending).
@@ -577,6 +651,7 @@ def run_retain(hook_input: dict, force: bool = False) -> dict:
         api_token=api_token,
         retain_full_window=retain_full_window,
         document_id=document_id,
+        extra_tags=extra_tags,
     )
     if built is None:
         debug_log(config, "Empty transcript after formatting, skipping retain")

--- a/vendor/hindsight-memory/scripts/tests/test_self_improve_correction_tag.py
+++ b/vendor/hindsight-memory/scripts/tests/test_self_improve_correction_tag.py
@@ -1,0 +1,167 @@
+"""Per-turn operator-correction tag on auto-retained turns (switchroom PR4 4a).
+
+When switchroom's self-improve gate (``src/self-improve/gate.ts``) fires on an
+``operator-correction`` signal, the Stop hook drops a per-turn sentinel into the
+shared agent state dir. This hook — a SEPARATE process — reads-and-clears that
+sentinel and stamps ``self-improve:correction`` on the turn's retain, so PR5's
+failure-synthesis cron can recall correction turns cheaply by tag filter.
+
+This module asserts the OUTCOMES at the retain seam:
+
+  1. read-and-clear is read-ONCE: a present sentinel yields the tag and is then
+     gone; a second read yields nothing.
+  2. the tag reaches the wire payload when (and ONLY when) it is threaded in —
+     a mutation that stamped it unconditionally, or never, fails here.
+  3. the tag is STABLE and therefore DOES move the consolidation scope to its
+     own ``[["self-improve:correction"]]`` partition — the opposite of the
+     forced-volatile ``source:transcript`` tag — and it matches NO volatile
+     scope pattern (in particular not ``^source:``). Absent tag ⇒ scope stays
+     the byte-identical ``"shared"``.
+
+Stdlib-only; runs under ``python3 -m unittest discover tests/``.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from lib.config import (  # noqa: E402
+    DEFAULTS,
+    DEFAULT_VOLATILE_SCOPE_PATTERNS,
+    compute_observation_scopes,
+)
+from retain import (  # noqa: E402
+    SELF_IMPROVE_CORRECTION_PENDING_FILE,
+    SELF_IMPROVE_CORRECTION_TAG,
+    build_retain_payload,
+    read_and_clear_correction_pending,
+)
+
+PROVENANCE_TAG = "source:transcript"
+SESSION_ID = "4c386b32-ddfd-40d1-b557-da8135b294af"
+
+
+def _cfg(**over):
+    c = {
+        "retainRoles": ["user", "assistant"],
+        "retainToolCalls": True,
+        "retainContext": "claude-code",
+        "retainMetadata": {},
+        "retainTags": ["{session_id}", PROVENANCE_TAG],
+        "lessonTagging": DEFAULTS["lessonTagging"],
+        "lessonTagMarkers": DEFAULTS["lessonTagMarkers"],
+        "observationScopeStrategy": "curated",
+    }
+    c.update(over)
+    return c
+
+
+def _build(extra_tags=None, **cfg_over):
+    msgs = [
+        {"role": "user", "content": "why did you include drafts?", "uuid": "u1"},
+        {"role": "assistant", "content": "Fixed the digest filter.", "uuid": "a1"},
+    ]
+    built = build_retain_payload(
+        _cfg(**cfg_over),
+        SESSION_ID,
+        msgs,
+        msgs,
+        bank_id="bank",
+        api_url="http://x",
+        api_token=None,
+        extra_tags=extra_tags,
+    )
+    assert built is not None
+    return built["payload"]
+
+
+class ReadAndClearIsReadOnce(unittest.TestCase):
+    def test_present_sentinel_yields_the_tag_and_is_cleared(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, SELF_IMPROVE_CORRECTION_PENDING_FILE)
+            with open(path, "w") as f:
+                f.write("2026-08-06T00:00:00Z")
+            self.assertTrue(os.path.exists(path))
+
+            first = read_and_clear_correction_pending(d)
+            self.assertEqual(first, [SELF_IMPROVE_CORRECTION_TAG])
+            # Cleared as a side effect — read-once.
+            self.assertFalse(os.path.exists(path))
+
+            # A second read finds nothing: exactly one retain carries the tag.
+            second = read_and_clear_correction_pending(d)
+            self.assertEqual(second, [])
+
+    def test_absent_sentinel_yields_no_tag(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertEqual(read_and_clear_correction_pending(d), [])
+
+    def test_never_raises_on_a_bad_state_dir(self):
+        # A nonexistent dir must degrade to "no tag", never raise.
+        self.assertEqual(
+            read_and_clear_correction_pending("/nonexistent/does/not/exist"),
+            [],
+        )
+
+
+class CorrectionTagReachesTheWire(unittest.TestCase):
+    def test_tag_on_payload_when_threaded_in(self):
+        tags = _build(extra_tags=[SELF_IMPROVE_CORRECTION_TAG])["tags"]
+        self.assertIn(SELF_IMPROVE_CORRECTION_TAG, tags)
+        # It composes — it does not clobber the session / provenance tags.
+        self.assertIn(SESSION_ID, tags)
+        self.assertIn(PROVENANCE_TAG, tags)
+
+    def test_tag_absent_when_not_threaded_in(self):
+        # Mutation guard: the tag is DATA carried by extra_tags, not unconditional
+        # behaviour. A normal turn carries no correction tag.
+        for extra in (None, []):
+            tags = _build(extra_tags=extra)["tags"]
+            self.assertNotIn(SELF_IMPROVE_CORRECTION_TAG, tags)
+
+    def test_no_duplicate_when_already_present(self):
+        tags = _build(
+            extra_tags=[SELF_IMPROVE_CORRECTION_TAG, SELF_IMPROVE_CORRECTION_TAG]
+        )["tags"]
+        self.assertEqual(tags.count(SELF_IMPROVE_CORRECTION_TAG), 1)
+
+
+class CorrectionTagScopeContract(unittest.TestCase):
+    """The tag is STABLE — it SHOULD partition scope, and matches no volatile pat."""
+
+    def test_tag_matches_no_volatile_scope_pattern(self):
+        import re
+
+        for pat in DEFAULT_VOLATILE_SCOPE_PATTERNS:
+            self.assertIsNone(
+                re.search(pat, SELF_IMPROVE_CORRECTION_TAG),
+                f"correction tag must be STABLE but matched volatile pattern {pat!r}",
+            )
+
+    def test_correction_turn_lands_in_its_own_scope(self):
+        scope = _build(extra_tags=[SELF_IMPROVE_CORRECTION_TAG])["observation_scopes"]
+        self.assertEqual(scope, [[SELF_IMPROVE_CORRECTION_TAG]])
+
+    def test_normal_turn_scope_stays_shared_and_byte_identical(self):
+        with_none = _build(extra_tags=None)["observation_scopes"]
+        with_empty = _build(extra_tags=[])["observation_scopes"]
+        self.assertEqual(with_none, "shared")
+        self.assertEqual(with_empty, "shared")
+
+    def test_compute_scope_directly_partitions_on_the_stable_tag(self):
+        # Guards the guard: prove the [[tag]] result is caused by the tag being
+        # stable, straight through compute_observation_scopes.
+        scope, err = compute_observation_scopes(
+            [SESSION_ID, PROVENANCE_TAG, SELF_IMPROVE_CORRECTION_TAG], _cfg()
+        )
+        self.assertIsNone(err)
+        self.assertEqual(scope, [[SELF_IMPROVE_CORRECTION_TAG]])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## PR4 — Slice 4a: `self-improve:correction` retain tag

Depends on PR1 (#4403, merged). Branches off `origin/main` @ `41bc4cc2`. **Tag only — no cron** (that's PR5). Open for independent review; do not merge yet.

### What & why
When the deterministic self-improve gate (`src/self-improve/gate.ts`) fires on an **operator-correction** signal, this persists a marker so the turn's Hindsight auto-retain carries a `self-improve:correction` tag. PR5's failure-synthesis cron will recall correction turns cheaply by filtering on that tag (metadata is not filterable, tags are — same rationale as `source:transcript`).

The Stop hook and the auto-retain hook are **separate processes** that cannot share env, so the marker passes through the shared agent **state dir** — a per-turn sentinel the retain hook reads-and-clears.

### How
- **`src/cli/self-improve-stop.ts`** — on a gate trip whose signals include `operator-correction`, drop `self-improve-correction-pending` into `resolveStateDir()` (the file's existing `TELEGRAM_STATE_DIR` convention). Wrapped in try/catch; the fail-open contract is intact (a marker write never fails the turn). Placed before the agent-name bail so the marker still lands where routing the review is impossible.
- **`vendor/hindsight-memory/scripts/retain.py`** — `run_retain` reads-and-clears the sentinel (**read-once**), in the live Stop path only, *after* the throttle / re-fire / empty-transcript early-returns, so only a retain that actually fires consumes it. The tag is threaded into `build_retain_payload` via a keyword-only `extra_tags` param and merged next to the lesson-tag merge — so the network-free/state-free payload seam is untouched and **backfill / reconcile / subagent** retains (which call `build_retain_payload` directly) never consume a live turn's marker.
- **`src/memory/hindsight-retain-provenance.ts`** — single source of truth for `SELF_IMPROVE_CORRECTION_TAG` and `SELF_IMPROVE_CORRECTION_PENDING_FILE`, plus best-effort `writeCorrectionPending` / `readAndClearCorrectionPending` helpers. `retain.py`'s copies of both strings are pinned to it by test.

### Scope contract (the non-obvious half)
`self-improve:correction` is **stable** by contract — it matches no entry of `DEFAULT_VOLATILE_SCOPE_PATTERNS`, in particular not `^source:`. So a correction turn consolidates in its own `[["self-improve:correction"]]` scope, exactly the partition PR5 synthesises over. Because the tag rides only rare correction turns (not every retain, unlike `source:transcript`), this partitioning is intentional, not the whole-bank discontinuity the provenance tag had to avoid. **Absent sentinel ⇒ tag absent ⇒ scope stays the byte-identical `"shared"`**, so every non-correction turn is unchanged.

### Tests
- **TS** (`tests/self-improve-stop-hook.test.ts`): sentinel written on an operator-correction trip; NOT written on a repeated-manual-fix-only trip or a clean turn (mutation-grade — an unconditional write fails these).
- **TS** (`tests/scaffold.retain-provenance.test.ts`): cross-language pin of the filename + tag to `retain.py`; the tag is stable (excluded by no volatile pattern).
- **Python** (`tests/test_self_improve_correction_tag.py`): read-once clear; tag on the payload only when threaded in (mutation-grade); the stable-tag scope contract (`[["self-improve:correction"]]` when present, `"shared"` when absent; matches no volatile pattern).

Validated with real vitest + `python3 -m unittest`, `tsc --noEmit` clean, `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)