### PR TITLE
fix(self-improve): wire proposal origin, close latent T1 integrity gap, fix review-prompt eval-case cmd

### DIFF
--- a/reference/prompts/failure-synthesis-cron.md
+++ b/reference/prompts/failure-synthesis-cron.md
@@ -125,6 +125,9 @@ operator sees the gap on the next interactive turn and can grant access then.
 >   --evidence "failed across N sessions" \
 >   --draft /tmp/failure-skill-draft.json \
 >   --chat <your chat id> \
+>   --origin failure-synthesis \  # tags provenance on the stored proposal
+>                                 # (SkillProposal.origin); routing is
+>                                 # unchanged — provenance only
 >   [--edit]            # include ONLY when editing an existing owned skill;
 >                       # omit for a NEW skill (is_new) — it rides the
 >                       # synthesized-personal-skill T2 carve-out

--- a/src/cli/self-improve-propose-skill.ts
+++ b/src/cli/self-improve-propose-skill.ts
@@ -35,6 +35,10 @@ function gatewaySocketPath(): string {
   );
 }
 
+/** Allowed proposal-provenance values (mirrors `ProposalOrigin`). */
+const ALLOWED_ORIGINS = ["skill-synthesis", "failure-synthesis"] as const;
+type ProposalOrigin = (typeof ALLOWED_ORIGINS)[number];
+
 interface ProposeOpts {
   slug: string;
   lesson: string;
@@ -44,6 +48,7 @@ interface ProposeOpts {
   chat: string;
   thread?: string;
   agent?: string;
+  origin?: string;
 }
 
 function fail(msg: string, code = 1): never {
@@ -95,9 +100,23 @@ export function registerSelfImproveProposeSkillCommand(program: Command): void {
     .requiredOption("--chat <id>", "agent's own chat id to post the card to")
     .option("--thread <id>", "forum topic thread id")
     .option("--agent <name>", "agent name (defaults to $SWITCHROOM_AGENT_NAME)")
+    .option(
+      "--origin <origin>",
+      `proposal provenance (${ALLOWED_ORIGINS.join(" | ")}); absent ⇒ skill-synthesis`,
+    )
     .action((opts: ProposeOpts) => {
       const agent = opts.agent ?? process.env.SWITCHROOM_AGENT_NAME;
       if (!agent) fail("agent name required (--agent or $SWITCHROOM_AGENT_NAME)");
+
+      let origin: ProposalOrigin | undefined;
+      if (opts.origin != null) {
+        if (!ALLOWED_ORIGINS.includes(opts.origin as ProposalOrigin)) {
+          fail(
+            `--origin must be one of: ${ALLOWED_ORIGINS.join(", ")} (got "${opts.origin}")`,
+          );
+        }
+        origin = opts.origin as ProposalOrigin;
+      }
 
       let draft: Record<string, string>;
       try {
@@ -122,6 +141,7 @@ export function registerSelfImproveProposeSkillCommand(program: Command): void {
         evidence: opts.evidence ?? "",
         draft,
       };
+      if (origin != null) payload.origin = origin;
       if (opts.thread != null) {
         const n = Number.parseInt(opts.thread, 10);
         if (Number.isInteger(n)) payload.threadId = n;

--- a/src/self-improve/apply-guard.ts
+++ b/src/self-improve/apply-guard.ts
@@ -458,19 +458,34 @@ export function decideApply(p: DecideApplyParams): ApplyDecision {
   }
 
   // (5b) eval-integrity — the verdict above trusts the skill's evals.json,
-  //      so refuse to silent-apply on an eval set that has DRIFTED from its
-  //      last sanctioned state (an out-of-band edit to evals.json).
+  //      so a silent T1 auto-apply requires the eval set to be in its last
+  //      SANCTIONED state. Only `"ok"` (current hash matches the recorded
+  //      baseline) is T1-eligible; ANY other status is downgraded to a
+  //      one-tap T2 proposal:
+  //        - "drift"    — an out-of-band edit to evals.json;
+  //        - "missing"  — evals present but never recorded a baseline (the
+  //                       sanctioned applier records its own baseline, so a
+  //                       legit skill is "ok" immediately — a "missing" here
+  //                       means the evals never went through a trusted path);
+  //        - "no-evals" — can't reach here (step 4 already blocked it), but
+  //                       covered for completeness.
   //      HONESTY (RFC amendment MJ1): this is defense-in-depth, tamper-
   //      EVIDENT — NOT a cryptographic boundary. The manifest lives in the
   //      agent-writable state dir; a model that also rewrites it defeats the
   //      check. The HARD backstop is the T1-live gate below (default OFF).
-  //      "missing" (never recorded / first sight) and "no-evals" are not
-  //      drift, so only an explicit "drift" blocks here.
-  if (verifyEvalIntegrity(p.stateDir, target.slug, target.skillDir) === "drift") {
+  //      Purely restrictive: a legit skill is "ok" the moment the sanctioned
+  //      applier records the baseline, so this costs real flows nothing while
+  //      closing the reopened-B1 path for anyone who flips T1_LIVE on.
+  const integrity = verifyEvalIntegrity(p.stateDir, target.slug, target.skillDir);
+  if (integrity !== "ok") {
+    const why =
+      integrity === "drift"
+        ? `eval set for "${target.slug}" drifted from its recorded baseline (out-of-band edit)`
+        : `eval set for "${target.slug}" has no sanctioned baseline (integrity: ${integrity})`;
     return {
       action: "block",
       downgradeTier: "T2",
-      reason: `eval set for "${target.slug}" drifted from its recorded baseline (out-of-band edit) — refusing to auto-apply on unverified evals; downgraded to a proposal`,
+      reason: `${why} — refusing to auto-apply on unverified evals; downgraded to a proposal`,
       candidate: downgradeCandidate(target, owns, changedLines, lesson),
     };
   }

--- a/src/self-improve/review-prompt.ts
+++ b/src/self-improve/review-prompt.ts
@@ -117,11 +117,15 @@ export function buildReviewPrompt(signals: LearningSignal[]): string {
   lines.push(
     "  5. If this was an operator CORRECTION tied to a skill you own, turn " +
       "it into a regression test: run `switchroom self-improve add-eval-case " +
-      "--skill <slug> --prompt \"<the correction framed as a test prompt>\"`. " +
-      "This proposes the case as a one-tap card; the operator's tap runs a " +
-      "deterministic applier that writes it (PII/secret-scanned). Do NOT " +
-      "Write or Edit evals/evals.json yourself — a direct write is blocked, " +
-      "bypasses the scan, and skips the operator's approval.",
+      "--skill <slug> --chat <operator chat id> " +
+      "--prompt \"<the correction framed as a test prompt>\"`. The `--chat` " +
+      "flag is REQUIRED — pass the real operator chat id from this session's " +
+      "context (the chat the correction arrived in), NOT the review turn's " +
+      "own placeholder chat id, or the command is rejected. This proposes " +
+      "the case as a one-tap card; the operator's tap runs a deterministic " +
+      "applier that writes it (PII/secret-scanned). Do NOT Write or Edit " +
+      "evals/evals.json yourself — a direct write is blocked, bypasses the " +
+      "scan, and skips the operator's approval.",
   );
   lines.push("");
   lines.push(

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -573,6 +573,13 @@ export interface PostSkillProposalMessage {
   evidence: string;
   /** Full drafted skill bundle (SKILL.md + optional files). */
   draft: Record<string, string>;
+  /**
+   * Provenance of the proposal — `"skill-synthesis"` (the weekly cron) or
+   * `"failure-synthesis"` (a skill drafted from an observed failure). Absent
+   * ⇒ the store defaults it to `"skill-synthesis"` (back-compat). Provenance
+   * is orthogonal to tier routing.
+   */
+  origin?: "skill-synthesis" | "failure-synthesis";
 }
 
 /**

--- a/telegram-plugin/gateway/self-improve-proposal-wiring.ts
+++ b/telegram-plugin/gateway/self-improve-proposal-wiring.ts
@@ -86,6 +86,8 @@ export function handlePostSkillProposal(
     draft: msg.draft,
     evidence: msg.evidence,
     chat_id: Number(msg.chatId),
+    // Provenance — absent ⇒ the store's back-compat default (skill-synthesis).
+    ...(msg.origin != null ? { origin: msg.origin } : {}),
   })
   const cardText = renderSkillProposalCard({
     id: proposal.id,

--- a/tests/self-improve-apply-guard-pretool.test.ts
+++ b/tests/self-improve-apply-guard-pretool.test.ts
@@ -15,7 +15,7 @@ import { evalsJsonPath } from "../src/self-improve/eval-gate.js";
 import { writeReviewContext } from "../src/self-improve/review-context.js";
 import { readPending } from "../src/self-improve/pending-queue.js";
 import { appliesToday } from "../src/self-improve/rate-limit.js";
-import { appendEvalCase } from "../src/self-improve/eval-cases.js";
+import { appendEvalCase, recordEvalBaseline } from "../src/self-improve/eval-cases.js";
 
 // Drive the hook through `bun` against source (mirrors the stop-hook test)
 // so it doesn't depend on build order. Skip cleanly if bun is absent.
@@ -32,7 +32,11 @@ function skillDir(): string {
 function skillFile(): string {
   return join(skillDir(), "SKILL.md");
 }
-function makeOwnedSkill(withEvals: boolean): void {
+// `recordBaseline` defaults ON so an owned skill with evals reflects the REAL
+// flow: the sanctioned applier records an integrity baseline, so the eval set
+// is "ok" (T1-eligible) and reaches the T1_LIVE backstop. Only "ok" integrity
+// is T1-eligible (R2).
+function makeOwnedSkill(withEvals: boolean, recordBaseline = true): void {
   mkdirSync(skillDir(), { recursive: true });
   if (withEvals) {
     mkdirSync(dirname(evalsJsonPath(skillDir())), { recursive: true });
@@ -40,6 +44,7 @@ function makeOwnedSkill(withEvals: boolean): void {
       evalsJsonPath(skillDir()),
       JSON.stringify({ skill_name: SLUG, evals: [{ name: "e1", prompt: "p" }] }),
     );
+    if (recordBaseline) recordEvalBaseline(stateDir, SLUG, skillDir());
   }
 }
 function writeBenchmark(candidate: number, baseline: number): void {

--- a/tests/self-improve-apply-guard.test.ts
+++ b/tests/self-improve-apply-guard.test.ts
@@ -20,6 +20,7 @@ import {
   skillTargetEscapes,
 } from "../src/self-improve/apply-guard.js";
 import { evalsJsonPath } from "../src/self-improve/eval-gate.js";
+import { recordEvalBaseline } from "../src/self-improve/eval-cases.js";
 import { recordAutoApply } from "../src/self-improve/rate-limit.js";
 import type { SelfImproveConfig } from "../src/self-improve/config.js";
 
@@ -45,7 +46,11 @@ function skillFile(rel = "SKILL.md"): string {
   return join(skillDir(), rel);
 }
 
-function makeOwnedSkill(withEvals: boolean): void {
+// `recordBaseline` defaults ON so a skill with evals reflects the REAL flow:
+// the sanctioned applier records an integrity baseline as it writes, so the
+// eval set is "ok" (T1-eligible) immediately. Pass `false` to model a skill
+// whose evals never went through a trusted path (integrity "missing").
+function makeOwnedSkill(withEvals: boolean, recordBaseline = true): void {
   mkdirSync(skillDir(), { recursive: true });
   if (withEvals) {
     mkdirSync(dirname(evalsJsonPath(skillDir())), { recursive: true });
@@ -53,6 +58,7 @@ function makeOwnedSkill(withEvals: boolean): void {
       evalsJsonPath(skillDir()),
       JSON.stringify({ skill_name: SLUG, evals: [{ name: "e1", prompt: "p" }] }),
     );
+    if (recordBaseline) recordEvalBaseline(stateDir, SLUG, skillDir());
   }
 }
 
@@ -320,6 +326,58 @@ describe("decideApply — the deterministic T1 gate", () => {
     });
     expect(d.action).toBe("block");
     if (d.action === "block") expect(d.reason).toMatch(/cap reached/i);
+  });
+});
+
+// R2 (reopened-B1): only integrity status "ok" is T1-eligible. Any other
+// status (notably "missing" — evals present but never sanctioned) must be
+// downgraded to a one-tap T2, even with T1_LIVE=1. These two cases differ
+// ONLY in whether a sanctioned baseline was recorded, so the split proves the
+// downgrade fires SPECIFICALLY on non-ok integrity — not on some other gate.
+describe("decideApply — eval-integrity gate (only 'ok' is T1-eligible)", () => {
+  function decideWithLiveOn() {
+    writeBenchmark(1.0, 0.9);
+    return decideApply({
+      toolName: "Write",
+      input: { content: "line1\nline2\n" },
+      filePath: skillFile(),
+      stateDir,
+      cfg: CFG,
+      now,
+    });
+  }
+
+  it("status 'missing' (evals never sanctioned) → DOWNGRADED to T2 even with T1_LIVE=1", () => {
+    const prev = process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE;
+    process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE = "1";
+    try {
+      makeOwnedSkill(true, /* recordBaseline */ false); // integrity "missing"
+      const d = decideWithLiveOn();
+      expect(d.action).toBe("block");
+      if (d.action === "block") {
+        expect(d.downgradeTier).toBe("T2");
+        expect(d.reason).toMatch(/no sanctioned baseline|integrity: missing|unverified evals/i);
+        // Crucially NOT the T1_LIVE backstop — the integrity gate fired first.
+        expect(d.reason).not.toMatch(/silent auto-apply is disabled/i);
+      }
+    } finally {
+      if (prev === undefined) delete process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE;
+      else process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE = prev;
+    }
+  });
+
+  it("status 'ok' (baseline recorded) → still T1-eligible (ALLOWS) with T1_LIVE=1", () => {
+    const prev = process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE;
+    process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE = "1";
+    try {
+      makeOwnedSkill(true, /* recordBaseline */ true); // integrity "ok"
+      const d = decideWithLiveOn();
+      expect(d.action).toBe("allow");
+      if (d.action === "allow") expect(d.tier).toBe("T1");
+    } finally {
+      if (prev === undefined) delete process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE;
+      else process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE = prev;
+    }
   });
 });
 

--- a/tests/self-improve-propose-skill-cli.test.ts
+++ b/tests/self-improve-propose-skill-cli.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { createServer, type Server } from "node:net";
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { handlePostSkillProposal } from "../telegram-plugin/gateway/self-improve-proposal-wiring.js";
+import type { PostSkillProposalMessage } from "../telegram-plugin/gateway/ipc-protocol.js";
+import type { ProposalWiringDeps } from "../telegram-plugin/gateway/self-improve-proposal-wiring.js";
+import { readProposals } from "../src/self-improve/skill-proposals.js";
+
+const bunOk = spawnSync("which", ["bun"], { encoding: "utf-8" }).status === 0;
+const CLI = join(process.cwd(), "bin", "switchroom.ts");
+
+let home: string;
+let stateDir: string;
+let draftPath: string;
+
+function cli(args: string[], env: Record<string, string> = {}) {
+  const r = spawnSync("bun", [CLI, ...args], {
+    encoding: "utf-8",
+    timeout: 30000,
+    env: {
+      ...process.env,
+      HOME: home,
+      TELEGRAM_STATE_DIR: stateDir,
+      SWITCHROOM_AGENT_NAME: "tester",
+      SWITCHROOM_SELF_IMPROVE: "1",
+      ...env,
+    },
+  });
+  return { status: r.status ?? -1, out: (r.stdout ?? "").trim(), err: (r.stderr ?? "").trim() };
+}
+
+/** Spawn propose-skill against a stub gateway socket; return the parsed IPC. */
+async function captureIpc(args: string[]): Promise<Record<string, unknown>> {
+  const sockPath = join(stateDir, "gateway.sock");
+  const received: string[] = [];
+  const server: Server = await new Promise((resolve) => {
+    const s = createServer((conn) => {
+      let buf = "";
+      conn.on("data", (d) => (buf += d.toString()));
+      conn.on("end", () => received.push(buf));
+    });
+    s.listen(sockPath, () => resolve(s));
+  });
+  try {
+    const r = cli(
+      ["self-improve", "propose-skill", "--draft", draftPath, ...args],
+      { SWITCHROOM_GATEWAY_SOCKET: sockPath },
+    );
+    expect(r.status).toBe(0);
+    await new Promise((res) => setTimeout(res, 50));
+    expect(received.length).toBe(1);
+    return JSON.parse(received[0]!.trim()) as Record<string, unknown>;
+  } finally {
+    await new Promise((res) => server.close(() => res(null)));
+  }
+}
+
+/** Feed a captured IPC message through the gateway handler (the enqueue leg). */
+function runHandler(msg: PostSkillProposalMessage): void {
+  // The handler resolves its store + identity from the environment, exactly as
+  // it does inside the gateway process.
+  process.env.TELEGRAM_STATE_DIR = stateDir;
+  process.env.SWITCHROOM_AGENT_NAME = "tester";
+  const deps: ProposalWiringDeps = {
+    // Minimal stub — we only exercise the persist path, not the card render.
+    bot: { api: { sendMessage: async () => ({}) } } as unknown as ProposalWiringDeps["bot"],
+    assertAllowedChat: () => {},
+    swallowingApiCall: async (fn) => fn(),
+  };
+  handlePostSkillProposal(msg, deps);
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "propose-cli-home-"));
+  stateDir = mkdtempSync(join(tmpdir(), "propose-cli-state-"));
+  draftPath = join(home, "draft.json");
+  writeFileSync(
+    draftPath,
+    JSON.stringify({ "SKILL.md": "---\nname: t\ndescription: d\n---\nbody\n" }),
+  );
+});
+afterEach(() => {
+  for (const d of [home, stateDir]) {
+    if (d && existsSync(d)) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+describe("propose-skill --origin (R1: origin threaded CLI → IPC → store)", () => {
+  it("threads --origin failure-synthesis into the IPC and persists it (not the default)", async () => {
+    if (!bunOk) return;
+    const msg = await captureIpc([
+      "--slug", "myskill",
+      "--lesson", "always X",
+      "--chat", "12345",
+      "--origin", "failure-synthesis",
+    ]);
+    expect(msg.type).toBe("post_skill_proposal");
+    expect(msg.origin).toBe("failure-synthesis");
+
+    // Full round-trip: run the captured IPC through the gateway enqueue, then
+    // read the persisted store — the origin must survive as failure-synthesis.
+    runHandler(msg as unknown as PostSkillProposalMessage);
+    const stored = readProposals(stateDir);
+    expect(stored).toHaveLength(1);
+    expect(stored[0]!.origin).toBe("failure-synthesis");
+  });
+
+  it("absent --origin ⇒ no origin on the IPC and store default (skill-synthesis, back-compat)", async () => {
+    if (!bunOk) return;
+    const msg = await captureIpc([
+      "--slug", "myskill",
+      "--lesson", "always X",
+      "--chat", "12345",
+    ]);
+    expect(msg.origin).toBeUndefined();
+
+    runHandler(msg as unknown as PostSkillProposalMessage);
+    const stored = readProposals(stateDir);
+    expect(stored).toHaveLength(1);
+    // Absence ⇒ skill-synthesis (the documented back-compat default) — the
+    // record carries no explicit origin field.
+    expect(stored[0]!.origin).toBeUndefined();
+  });
+
+  it("rejects an invalid --origin before any IPC (commander-level validation)", () => {
+    if (!bunOk) return;
+    const r = cli([
+      "self-improve", "propose-skill",
+      "--draft", draftPath,
+      "--slug", "myskill",
+      "--lesson", "always X",
+      "--chat", "12345",
+      "--origin", "bogus",
+    ]);
+    expect(r.status).toBe(1);
+    expect(r.err).toMatch(/--origin must be one of/);
+  });
+});

--- a/tests/self-improve-review-prompt.test.ts
+++ b/tests/self-improve-review-prompt.test.ts
@@ -48,6 +48,21 @@ describe("forked-review prompt", () => {
   it("opens with the shared banner constant (builder/detector single source)", () => {
     expect(buildReviewPrompt(signals).startsWith(REVIEW_BANNER)).toBe(true);
   });
+
+  it("step-5 add-eval-case example passes the REQUIRED --chat flag (R3)", () => {
+    // `switchroom self-improve add-eval-case` has `.requiredOption("--chat")`,
+    // so a review turn running the documented command verbatim WITHOUT --chat
+    // hits a commander error. The example must carry --chat, and must steer
+    // the agent to the real operator chat id (not the review placeholder).
+    const p = buildReviewPrompt(signals);
+    expect(p).toContain("add-eval-case");
+    expect(p).toContain("--chat");
+    // The example command names both required options together.
+    const cmd = p.slice(p.indexOf("add-eval-case"));
+    expect(cmd).toMatch(/--skill[\s\S]*--chat|--chat[\s\S]*--skill/);
+    // Steers to the operator chat id, not the review turn's placeholder.
+    expect(p.toLowerCase()).toContain("operator chat id");
+  });
 });
 
 describe("isReviewTurn — review-turn detector (issue #2462)", () => {


### PR DESCRIPTION
Three closing-gap fixes to the self-improve subsystem from Fable's end-to-end judgment pass. One focused PR (all three touch the same subsystem). **Independent review first — do not merge, and do NOT flip `SWITCHROOM_SELF_IMPROVE_T1_LIVE`.**

Branch off `origin/main` at `269d8c5e`.

## R1 (MAJOR) — wire `origin` end-to-end
`SkillProposal.origin` had a type + back-compat reader but **no writer**, yet `reference/prompts/failure-synthesis-cron.md` and `docs/scheduling.md` both tell the operator the record carries `origin:"failure-synthesis"`.

- Added a validated `--origin <skill-synthesis|failure-synthesis>` option to `switchroom self-improve propose-skill`.
- Threaded it into the `post_skill_proposal` IPC (`PostSkillProposalMessage.origin`) and through the gateway enqueue. Absent ⇒ the store's `skill-synthesis` back-compat default; `isProposalRecord` doesn't require it.
- Updated the failure-synthesis cron prompt to actually pass `--origin failure-synthesis`, making the doc claim TRUE (wiring, not retraction).

## R2 (MAJOR, latent) — non-`ok` integrity is T1-ineligible
`decideApply` blocked only explicit `"drift"`; `"missing"` (evals present, never sanctioned) fell through to the silent-allow leg. Now ANY integrity status other than `"ok"` downgrades to a one-tap T2 — closing a reopened-B1 path for anyone who flips `SWITCHROOM_SELF_IMPROVE_T1_LIVE=1`. Purely restrictive: a legit skill is `"ok"` the moment the sanctioned applier records its baseline, so zero cost to real flows.

## R3 — review-prompt step-5 command was broken
The step-5 `add-eval-case` example omitted the CLI's `.requiredOption("--chat")`, so a review turn running it verbatim hits a commander error. Added `--chat` and worded it to supply the real operator chat id from session context (not the review turn's `self-improve` placeholder, which `assertAllowedChat` rejects).

## Tests
- `tests/self-improve-propose-skill-cli.test.ts` (new): `--origin failure-synthesis` round-trips CLI → IPC → persisted store as `failure-synthesis`; absent ⇒ no origin field (default); invalid origin rejected pre-IPC.
- `tests/self-improve-apply-guard.test.ts`: integrity `"missing"` downgrades to T2 even with `T1_LIVE=1` while `"ok"` stays eligible — the two cases differ ONLY in whether a baseline was recorded, so the split proves the downgrade fires specifically on non-ok.
- `tests/self-improve-review-prompt.test.ts`: asserts the step-5 example carries `--chat` and steers to the operator chat id.
- Existing apply-guard / pretool tests updated so their owned-skill helper records a sanctioned baseline (models the real `"ok"` flow).

`tsc --noEmit`, `npm run lint`, and the scoped vitest suites are green.

Follow-ups: #4425 (6 LOWs). Item 2 there SHOULD land before any T1_LIVE flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)