### PR TITLE
docs(profiles): broaden Grounding rule to cover real-world facts, not just code

### DIFF
--- a/profiles/_shared/execution-discipline.md.hbs
+++ b/profiles/_shared/execution-discipline.md.hbs
@@ -3,7 +3,7 @@
 Your memory and prior context are leads, not facts. Anything you state as true — code, config, a system's state, a number, a status, or what you can and can't do — must come from something you actually checked this turn.
 
 - **Read the ground truth live.** Files, git status, config, versions, running services, schedules, permissions — read them with a tool, don't recall them.
-- **Training memory is a lead, not a source — prefer finding over guessing.** A library's API, a version, a CLI flag, whether a repo even exists: validate against the real thing (repo, docs, the web) before you assert it. Never answer "I don't recognize X" from model recall when X is one fetch away.
+- **Training memory is a lead, not a source — prefer finding over guessing.** A library's API, a version, a CLI flag, whether a repo exists — but equally a real-world fact: who a person is, what a company does, a product, a current event: validate against the real thing (the web, docs, the repo) before you assert it. Never answer "I don't recognize X" from model recall when X is one search away.
 - **Don't assert a limit you haven't tested.** Before saying "no access" / "operator-only" / "not editable", verify it live. A fabricated boundary is as wrong as a fabricated fact.
 - **A weak or empty result isn't a conclusion.** Vary the query, path, command, or source before deciding something doesn't exist.
 - **Final answers carry evidence** — tool output, a file you read, a check you ran, or a named blocker; not "it should work."


### PR DESCRIPTION
## What

Broadens the **"Grounding — check before you assert"** rule in `profiles/_shared/execution-discipline.md.hbs` (the shared fragment landed in #4402) so its example set unmistakably covers **real-world facts**, not just code.

The `Training memory is a lead, not a source` bullet previously listed only dev examples — a library's API, a version, a CLI flag, whether a repo exists. An agent reading it could reasonably conclude the "validate before you assert" rule was code-only. Ken asked (2026-08-05/06) for it to unmistakably cover a person, a company, a product, and a current event too.

## The change (one line)

- Added real-world examples inline: *"but equally a real-world fact: who a person is, what a company does, a product, a current event"* alongside the existing dev examples.
- Promoted **the web** to the first-listed validation surface (`(the web, docs, the repo)`), since for a real-world fact the web (perplexity/websearch) is the ground truth, not a repo or docs.
- `one fetch away` → `one search away` to match the web-first framing.

The domain-agnostic principle sentence (`validate against the real thing … before you assert it`; `never answer "I don't recognize X" from model recall`) is unchanged — only the concrete example list widens.

## Constraints honored

- **Byte ratchet:** rendered root-tier + default-profile CLAUDE.md is **30281 bytes**, under the **30620 + 500** ceiling. No ratchet-file change (no raise).
- **profiles.test.ts pins preserved:** still contains `training memory is a lead, not a source`, `i don't recognize x`, and matches `validate.*against the real thing`. The pinned test still asserts the substance.

## Validation

`env -u SWITCHROOM_SELF_IMPROVE npx vitest run src/agents/profiles.test.ts tests/scaffold.persona.test.ts` → 76 passed. `npm run lint` clean.

Please review before merging — do not fast-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)