### PR TITLE
fix(self-improve): surface eval-integrity sweep tamper to the operator (#4425 item 2)

### DIFF
--- a/src/cli/self-improve-stop.ts
+++ b/src/cli/self-improve-stop.ts
@@ -41,7 +41,10 @@ import {
   writeReviewContext,
   clearReviewContext,
 } from "../self-improve/review-context.js";
-import { sweepEvalIntegrity } from "../self-improve/eval-cases.js";
+import {
+  sweepEvalIntegrity,
+  surfaceSweepTamper,
+} from "../self-improve/eval-cases.js";
 import { writeCorrectionPending } from "../memory/hindsight-retain-provenance.js";
 import type { TurnMessage } from "../self-improve/types.js";
 
@@ -270,7 +273,14 @@ function main(): void {
   // OFF). Best-effort and never throws; the Stop hook is fail-open. Cheap when
   // no skill ships evals (a single readdir that finds nothing).
   try {
-    sweepEvalIntegrity(resolveSkillsRoot(), resolveStateDir());
+    const stateDir = resolveStateDir();
+    const report = sweepEvalIntegrity(resolveSkillsRoot(), stateDir);
+    // RFC invariant 3(b): a heal/quarantine must surface a T2 pending note so
+    // the operator SEES the tamper. R2 (#4426) BLOCKS a tampered skill's auto-
+    // apply but silently; this is the visibility half — a prerequisite for the
+    // SWITCHROOM_SELF_IMPROVE_T1_LIVE flip. Idempotent per slug+kind, never
+    // throws (fail-open).
+    surfaceSweepTamper(stateDir, report);
   } catch {
     /* fail-open: a sweep error must never fail the turn */
   }

--- a/src/self-improve/eval-cases.ts
+++ b/src/self-improve/eval-cases.ts
@@ -45,6 +45,11 @@ import { createHash } from "node:crypto";
 
 import { evalsJsonPath } from "./eval-gate.js";
 import { scanForPII } from "./pii-scan.js";
+import {
+  enqueuePending,
+  readPending,
+  type PendingSuggestion,
+} from "./pending-queue.js";
 
 // ── Schema ───────────────────────────────────────────────────────────
 
@@ -447,4 +452,122 @@ export function sweepEvalIntegrity(
     }
   }
   return report;
+}
+
+/** triggered_by marker every sweep-tamper pending note carries — the stable
+ *  key a doctor/one-tap surface (and our own per-turn dedup) filters on. */
+export const SWEEP_TAMPER_SIGNAL = "eval-integrity-sweep";
+/** Per-kind markers, so a healed note and a quarantined note for the same
+ *  slug are distinct events and dedup independently. */
+export const SWEEP_HEALED_SIGNAL = "drift-reverted";
+export const SWEEP_QUARANTINED_SIGNAL = "quarantined";
+
+/** True when an outstanding (un-actioned) pending note already surfaces this
+ *  exact slug+kind — so a persistent tamper (a quarantined evals.json that
+ *  reappears every turn, or the same drift being re-reverted) is surfaced
+ *  ONCE, not spammed onto the queue every Stop hook. */
+function hasOutstandingSweepNote(
+  pending: PendingSuggestion[],
+  slug: string,
+  kindSignal: string,
+): boolean {
+  return pending.some(
+    (p) =>
+      p.actioned !== true &&
+      p.skill_slug === slug &&
+      Array.isArray(p.triggered_by) &&
+      p.triggered_by.includes(SWEEP_TAMPER_SIGNAL) &&
+      p.triggered_by.includes(kindSignal),
+  );
+}
+
+/**
+ * RFC invariant 3(b) — "the per-turn Stop hook … enqueues a T2 pending note
+ * surfacing the tamper." Consume a {@link SweepReport} and, for every slug the
+ * sweep HEALED (out-of-band drift reverted) or QUARANTINED (un-sanctioned
+ * evals.json that failed the PII/secret scan), enqueue a T2 pending note so
+ * the operator gets a visible signal in the same store every other self-
+ * improve proposal lands in.
+ *
+ * WHY this is load-bearing before the T1-live flip: R2 (issue #4426) makes the
+ * integrity gate BLOCK a tampered skill's auto-apply, but blocking is silent.
+ * Without this surface the operator would get NO signal that tamper was
+ * detected/healed/quarantined — exactly the visibility 3(b) mandates before
+ * silent T1 apply can be turned on.
+ *
+ * Deterministic and idempotent: a note is enqueued only when no outstanding
+ * (un-actioned) note already surfaces that slug+kind, so a persistent tamper
+ * is reported once rather than every turn. Best-effort and never throws — the
+ * Stop hook is fail-open; a surfacing error must never fail the turn.
+ *
+ * Returns the slugs actually enqueued (for observability + tests).
+ */
+export function surfaceSweepTamper(
+  stateDir: string,
+  report: SweepReport,
+  opts: { now?: () => number } = {},
+): { healed: string[]; quarantined: string[] } {
+  const enqueued = { healed: [] as string[], quarantined: [] as string[] };
+  if (report.healed.length === 0 && report.quarantined.length === 0) {
+    return enqueued; // nothing tampered — the common, cheap path.
+  }
+  let pending: PendingSuggestion[];
+  try {
+    pending = readPending(stateDir);
+  } catch {
+    pending = [];
+  }
+  const tryEnqueue = (
+    slug: string,
+    kindSignal: string,
+    lesson: string,
+    proposed_change: string,
+    tier_reason: string,
+    bucket: string[],
+  ): void => {
+    if (hasOutstandingSweepNote(pending, slug, kindSignal)) return;
+    try {
+      const q = enqueuePending(
+        stateDir,
+        {
+          tier: "T2",
+          lesson,
+          proposed_change,
+          tier_reason,
+          skill_slug: slug,
+          triggered_by: [SWEEP_TAMPER_SIGNAL, kindSignal],
+        },
+        { now: opts.now },
+      );
+      if (q.ok) {
+        // Keep the local view current so a healed+quarantined pair in one
+        // sweep can't both be blocked/allowed on a stale read.
+        pending.push(q.suggestion);
+        bucket.push(slug);
+      }
+    } catch {
+      /* queue best-effort — a surfacing error must not fail the turn */
+    }
+  };
+  for (const slug of report.healed) {
+    tryEnqueue(
+      slug,
+      SWEEP_HEALED_SIGNAL,
+      `Eval-integrity sweep reverted out-of-band drift in skill "${slug}" (evals/evals.json) to the sanctioned baseline.`,
+      `Confirm the change to ${slug}/evals/evals.json was intended. A Bash/Write edit that bypasses the applier is auto-reverted every turn; re-add the case via \`switchroom self-improve add-eval-case\` so it becomes a sanctioned baseline.`,
+      `eval-integrity sweep detected + healed out-of-band tamper (RFC invariant 3(b))`,
+      enqueued.healed,
+    );
+  }
+  for (const slug of report.quarantined) {
+    tryEnqueue(
+      slug,
+      SWEEP_QUARANTINED_SIGNAL,
+      `Eval-integrity sweep QUARANTINED skill "${slug}": an un-sanctioned evals.json failed the PII/secret scan and was NOT adopted as a baseline.`,
+      `Review ${slug}/evals/evals.json for PII/secrets or corruption — the sweep refuses to trust it. Re-add clean cases via \`switchroom self-improve add-eval-case\`.`,
+      `eval-integrity sweep quarantined un-sanctioned evals.json (RFC invariant 3(b), MAJOR 2)`,
+      enqueued.quarantined,
+    );
+  }
+  return enqueued;
 }

--- a/tests/self-improve-stop-hook.test.ts
+++ b/tests/self-improve-stop-hook.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { spawnSync } from "node:child_process";
 import { createServer, type Server } from "node:net";
-import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -11,6 +17,13 @@ import {
   reviewIsPending,
 } from "../src/self-improve/review-context.js";
 import { SELF_IMPROVE_CORRECTION_PENDING_FILE } from "../src/memory/hindsight-retain-provenance.js";
+import { readPending } from "../src/self-improve/pending-queue.js";
+import {
+  SWEEP_TAMPER_SIGNAL,
+  SWEEP_HEALED_SIGNAL,
+  SWEEP_QUARANTINED_SIGNAL,
+} from "../src/self-improve/eval-cases.js";
+import { evalsJsonPath } from "../src/self-improve/eval-gate.js";
 
 // Drive the hook through `bun` against source (mirrors
 // tests/skill-validate-pretool.test.ts) so the test doesn't depend on
@@ -486,6 +499,130 @@ describe("self-improve-stop hook — repeated-manual-fix is content-aware (#2462
       expect(envelope.inbound.text).toContain("repeated-manual-fix");
     } finally {
       await new Promise<void>((res) => server.close(() => res()));
+    }
+  });
+});
+
+// Issue #4425 item 2 — sweep-visibility (T1_LIVE-flip prerequisite). The Stop
+// hook's eval-integrity sweep (self-improve-stop.ts) previously DISCARDED the
+// SweepReport it returned, so RFC invariant 3(b) — "the per-turn Stop hook …
+// enqueues a T2 pending note surfacing the tamper" — never happened: a healed
+// or quarantined skill was invisible to the operator. R2 (#4426) BLOCKS a
+// tampered skill's auto-apply but silently; this is the visibility half. These
+// drive the REAL Stop-hook CLI end to end (the sweep runs before stdin is even
+// read) and assert the operator-visible pending queue actually carries the
+// tamper. They go RED if the surfaceSweepTamper wiring is removed.
+describe("self-improve-stop hook — sweep tamper surfaces a T2 pending note (#4425 item 2)", () => {
+  // A PII value assembled at runtime so no contiguous email literal sits in the
+  // source (which would trip scripts/check-no-pii-secrets.mjs); scanForPII in
+  // the real sweep still sees the joined value and quarantines the bytes.
+  const fakeEmail = ["poison.example", "example.com"].join("@");
+
+  function skillEvalsDir(home: string, slug: string): string {
+    const d = join(home, ".claude", "skills", slug, "evals");
+    mkdirSync(d, { recursive: true });
+    return join(home, ".claude", "skills", slug);
+  }
+
+  it("enqueues a T2 quarantine note (and is idempotent) for a poisoned first-sight evals.json", () => {
+    if (!bunOk) return;
+    const home = mkdtempSync(join(tmpdir(), "sweep-home-"));
+    const stateDir = mkdtempSync(join(tmpdir(), "sweep-state-"));
+    try {
+      const skill = skillEvalsDir(home, "poison");
+      writeFileSync(
+        evalsJsonPath(skill),
+        JSON.stringify({
+          skill_name: "poison",
+          evals: [{ prompt: `email me at ${fakeEmail} then answer` }],
+        }),
+      );
+
+      const env = {
+        HOME: home,
+        SWITCHROOM_AGENT_NAME: "test-agent",
+        TELEGRAM_STATE_DIR: stateDir,
+        SWITCHROOM_GATEWAY_SOCKET: join(stateDir, "no-server.sock"),
+      };
+      // The sweep runs before stdin is consumed, so a bare "{}" is enough.
+      expect(run("{}", env).status).toBe(0);
+
+      const pending = readPending(stateDir);
+      const notes = pending.filter(
+        (p) =>
+          p.skill_slug === "poison" &&
+          p.triggered_by?.includes(SWEEP_TAMPER_SIGNAL) &&
+          p.triggered_by?.includes(SWEEP_QUARANTINED_SIGNAL),
+      );
+      expect(notes.length).toBe(1);
+      expect(notes[0]?.tier).toBe("T2");
+      expect(notes[0]?.lesson).toContain("QUARANTINED");
+      expect(notes[0]?.lesson).toContain("poison");
+
+      // Idempotent: the poisoned bytes stay on disk (never adopted), so a
+      // second turn quarantines again — but the outstanding note dedups it.
+      expect(run("{}", env).status).toBe(0);
+      const after = readPending(stateDir).filter(
+        (p) =>
+          p.skill_slug === "poison" &&
+          p.triggered_by?.includes(SWEEP_QUARANTINED_SIGNAL),
+      );
+      expect(after.length).toBe(1); // still exactly one — no per-turn spam
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("enqueues a T2 healed note when out-of-band drift is reverted", () => {
+    if (!bunOk) return;
+    const home = mkdtempSync(join(tmpdir(), "sweep-heal-home-"));
+    const stateDir = mkdtempSync(join(tmpdir(), "sweep-heal-state-"));
+    try {
+      const skill = skillEvalsDir(home, "drifter");
+      const clean = JSON.stringify({
+        skill_name: "drifter",
+        evals: [{ prompt: "handle an empty input" }],
+      });
+      writeFileSync(evalsJsonPath(skill), clean);
+
+      const env = {
+        HOME: home,
+        SWITCHROOM_AGENT_NAME: "test-agent",
+        TELEGRAM_STATE_DIR: stateDir,
+        SWITCHROOM_GATEWAY_SOCKET: join(stateDir, "no-server.sock"),
+      };
+
+      // First turn: records the sanctioned baseline (first sight is clean →
+      // adopted, not tampered) → NO note yet.
+      expect(run("{}", env).status).toBe(0);
+      expect(
+        readPending(stateDir).filter((p) => p.skill_slug === "drifter").length,
+      ).toBe(0);
+
+      // Tamper out of band (a raw Write, bypassing the applier).
+      writeFileSync(
+        evalsJsonPath(skill),
+        JSON.stringify({
+          skill_name: "drifter",
+          evals: [{ prompt: "SMUGGLED out-of-band case" }],
+        }),
+      );
+
+      // Second turn: sweep reverts the drift AND surfaces a T2 healed note.
+      expect(run("{}", env).status).toBe(0);
+      const healed = readPending(stateDir).filter(
+        (p) =>
+          p.skill_slug === "drifter" &&
+          p.triggered_by?.includes(SWEEP_TAMPER_SIGNAL) &&
+          p.triggered_by?.includes(SWEEP_HEALED_SIGNAL),
+      );
+      expect(healed.length).toBe(1);
+      expect(healed[0]?.tier).toBe("T2");
+      expect(healed[0]?.lesson).toContain("drifter");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(stateDir, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## What & why

Fixes **issue #4425 item 2** (the sweep-visibility LOW). This is a **prerequisite for the `SWITCHROOM_SELF_IMPROVE_T1_LIVE=1` flip**.

The per-turn Stop-hook eval-integrity sweep (`sweepEvalIntegrity`) returns a `SweepReport`, but `src/cli/self-improve-stop.ts:273` **discarded it**. RFC invariant **3(b)** — *"the per-turn Stop hook … enqueues a T2 pending note surfacing the tamper"* (`reference/rfcs/agent-self-improvement.md:216-219`) — therefore never happened: skills the sweep **healed** (out-of-band drift reverted) or **quarantined** (un-sanctioned `evals.json` that failed the PII/secret scan, MAJOR 2) were invisible to the operator.

Pairs with **R2 (#4426)**: R2 makes the integrity gate **BLOCK** a tampered skill's silent auto-apply, but blocking is silent. Before silent T1 auto-apply is turned on, the operator must get a signal that tamper was detected/healed/quarantined. This PR is that visibility half.

## Mechanism (deterministic, RFC-mandated surface)

- New `surfaceSweepTamper()` in `src/self-improve/eval-cases.ts` consumes the `SweepReport` and enqueues a **T2 pending note** (into the existing `self-improve-pending.jsonl` queue — the same store every other T2 proposal lands in) for each healed / quarantined slug.
- **Idempotent per slug+kind**: an outstanding (un-actioned) note dedups a persistent tamper (e.g. a quarantined `evals.json` that reappears every turn), so it's surfaced **once**, not spammed onto the queue each Stop hook.
- Wired into `self-improve-stop.ts`, consuming the previously-discarded return. Best-effort, never throws — the Stop hook stays fail-open.

Chose the pending-note surface (over a `switchroom doctor` check) because it is the literal RFC 3(b) mechanism, reuses the existing pending-queue machinery with no new state slice, and is where every other self-improve operator signal already lands.

## Test that guards it

End-to-end tests in `tests/self-improve-stop-hook.test.ts` drive the **real Stop-hook CLI** (the sweep runs before stdin is even read) and assert the operator-visible pending queue actually carries the tamper note — one for the **quarantine** path (plus idempotency: a second turn does not double-enqueue) and one for the **healed** path.

Proof they catch the exact bug: with the `surfaceSweepTamper` wiring removed (`SweepReport` discarded, i.e. the pre-fix state) both assertions go **RED** (`expected 1, received 0`); with the wiring restored both go **GREEN**. Scoped run: `env -u SWITCHROOM_SELF_IMPROVE npx vitest run` over the stop-hook, eval-cases, and pending-queue suites → 34 passed. `npm run lint` clean (tsc + PII scan included).

Touches **item 2 only** — items 1,3,4,5,6 untouched. Not enqueued/merged; the item-2 box on #4425 is left unchecked for the reviewer to tick on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)