### PR TITLE
fix(self-improve): catch fd-prefixed redirect bypass + re-verify skill ownership at apply

### DIFF
--- a/src/cli/self-improve-eval-case.ts
+++ b/src/cli/self-improve-eval-case.ts
@@ -29,8 +29,8 @@
 
 import { createConnection } from "node:net";
 import { homedir } from "node:os";
-import { join } from "node:path";
-import { existsSync, readFileSync } from "node:fs";
+import { join, resolve, sep } from "node:path";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import type { Command } from "commander";
 
 import { ownsSkill } from "../self-improve/apply-guard.js";
@@ -65,8 +65,86 @@ function gatewaySocketPath(): string {
   );
 }
 
+function skillsRoot(): string {
+  return join(homedir(), ".claude", "skills");
+}
+
 function skillDirFor(slug: string): string {
-  return join(homedir(), ".claude", "skills", slug);
+  return join(skillsRoot(), slug);
+}
+
+/**
+ * #4410 (defense in depth): authorize the APPLY target from the SLUG, not the
+ * persisted path. The proposal store is agent-writable (see
+ * gateway/self-improve-proposal-wiring.ts), so `proposal.skill_dir` is NOT
+ * trustworthy — a tampered proposal could point it outside the owned skills
+ * root, or (more subtly) keep a valid-looking `skill_dir` for one owned skill
+ * while naming a DIFFERENT slug, landing the case in the wrong skill's evals.
+ *
+ * So the applier derives the authoritative write target from the operator-
+ * approved `skill_slug` via `skillDirFor()` and writes ONLY there — the
+ * persisted `skill_dir` is never a write target. It then re-asserts, on that
+ * recomputed dir, that (a) it is a real OWNED skill dir (not a shared/bundled
+ * symlink) and (b) its canonical path resolves within the canonical skills
+ * root, and finally (c) that the persisted `skill_dir` still corresponds to the
+ * slug's dir — a mismatch means the stored proposal was tampered with and is
+ * refused fail-closed. Returns both the authoritative dir (the write target) and
+ * its resolved canonical path (surfaced for audit).
+ */
+function authorizeApplyTarget(
+  persistedDir: string,
+  slug: string,
+): { dir: string; resolvedDir: string } {
+  // Authoritative target: derived from the operator-approved slug, never the
+  // agent-writable persisted path.
+  const dir = skillDirFor(slug);
+
+  // Canonicalize the root; fall back to a lexical resolve if the root dir does
+  // not yet exist (nothing owned → nothing can pass the containment check).
+  let root: string;
+  try {
+    root = realpathSync(skillsRoot());
+  } catch {
+    root = resolve(skillsRoot());
+  }
+
+  // Ownership: a real directory under the agent's own writable skills root,
+  // not a symlink into a read-only shared/bundled pool (also catches a slug
+  // that traverses out via `../`, since the target then isn't a real dir).
+  if (!ownsSkill(dir)) {
+    fail(
+      `apply refused — "${slug}" is not an owned skill dir ` +
+        `(missing, or a shared/bundled symlink) — dir: ${dir}`,
+    );
+  }
+
+  let resolvedDir: string;
+  try {
+    resolvedDir = realpathSync(dir);
+  } catch {
+    fail(`apply refused — skill dir cannot be resolved: ${dir}`);
+  }
+
+  // Containment: the canonical skill dir must live within the canonical root,
+  // so a slug that resolves (via symlink/`..`) outside the root can't escape.
+  if (resolvedDir !== root && !resolvedDir.startsWith(root + sep)) {
+    fail(
+      `apply refused — skill dir escapes the skills root ` +
+        `(resolved: ${resolvedDir}, root: ${root})`,
+    );
+  }
+
+  // Correspondence: the persisted skill_dir must still match the slug's dir.
+  // Under normal operation add-eval-case persists exactly skillDirFor(slug), so
+  // any divergence is a tampered proposal — refuse rather than silently redirect.
+  if (resolve(persistedDir) !== resolve(dir)) {
+    fail(
+      `apply refused — persisted skill_dir does not correspond to slug "${slug}" ` +
+        `(persisted: ${persistedDir}, expected: ${dir})`,
+    );
+  }
+
+  return { dir, resolvedDir };
 }
 
 function fail(msg: string, code = 1): never {
@@ -295,8 +373,16 @@ function registerApply(parent: Command): void {
         process.exit(0);
       }
 
-      const dir = proposal.skill_dir;
-      if (!existsSync(dir)) fail(`skill dir gone: ${dir}`);
+      if (!existsSync(proposal.skill_dir)) {
+        fail(`skill dir gone: ${proposal.skill_dir}`);
+      }
+      // #4410: derive the write target from the slug (not the agent-writable
+      // persisted skill_dir), re-verify ownership + skills-root containment, and
+      // refuse a proposal whose persisted skill_dir no longer matches the slug.
+      const { dir, resolvedDir } = authorizeApplyTarget(
+        proposal.skill_dir,
+        proposal.skill_slug,
+      );
 
       const res = appendEvalCase(dir, proposal.skill_slug, ec);
       if (!res.ok) {
@@ -327,6 +413,7 @@ function registerApply(parent: Command): void {
           action: "apply-eval-case",
           applied: true,
           skill: proposal.skill_slug,
+          skill_dir: resolvedDir,
           case_id: res.ok ? res.case.id : undefined,
           total: res.ok ? res.total : undefined,
         }),

--- a/src/cli/skill-validate-pretool.ts
+++ b/src/cli/skill-validate-pretool.ts
@@ -156,10 +156,17 @@ function tokenIsSkillEvalsJson(token: string): boolean {
   return ABS_SKILL_EVALS_RE.test(resolve("/", t));
 }
 
-/** An output redirect (`>` / `>>`, not a `2>&1`-style fd-dup) whose TARGET is a
- *  skill's evals.json — the primary Bash vector (`echo … > …/evals.json`). */
+/** An output redirect whose TARGET is a skill's evals.json — the primary Bash
+ *  vector (`echo … > …/evals.json`). Catches plain (`>`/`>>`), fd-prefixed
+ *  (`1>`, `2>`, `1>>`, `2>>`), combined-stream in BOTH spellings (`&>`/`&>>`
+ *  and the reversed `>&`), and clobber (`>|`) redirects. A `>&1`/`>&2`/`2>&1`
+ *  fd-DUP is NOT a file write and stays excluded: `(?:&(?![\d-]))?` only
+ *  consumes a combined-stream `>&` when it is NOT followed by a digit/`-`, so a
+ *  fd-dup's `&N` target is left for the char-class to reject (no path captured);
+ *  `\|?` consumes the clobber `|`. */
 function redirectWritesEvals(command: string): boolean {
-  const re = /(?:^|[^0-9<>&])>>?\s*(['"]?)([^\s'"|;&()<>]+)\1/g;
+  const re =
+    /(?:^|[^<>&\d])(?:\d+|&)?>>?(?:&(?![\d-]))?\|?\s*(['"]?)([^\s'"|;&()<>]+)\1/g;
   let m: RegExpExecArray | null;
   while ((m = re.exec(command)) !== null) {
     if (m[2] && tokenIsSkillEvalsJson(m[2])) return true;

--- a/tests/self-improve-eval-case-cli.test.ts
+++ b/tests/self-improve-eval-case-cli.test.ts
@@ -140,10 +140,14 @@ describe("add-eval-case (propose-only)", () => {
 });
 
 describe("apply-eval-case (deterministic applier)", () => {
-  function seed(caseObj: { prompt: string }, status: "pending" | "approved") {
+  function seed(
+    caseObj: { prompt: string },
+    status: "pending" | "approved",
+    dirOverride?: string,
+  ) {
     const p = enqueueEvalCaseProposal(stateDir, {
       skill_slug: "myskill",
-      skill_dir: skillDir,
+      skill_dir: dirOverride ?? skillDir,
       case: caseObj,
       fingerprint: "fp-" + caseObj.prompt.length,
       held_out: false,
@@ -173,6 +177,43 @@ describe("apply-eval-case (deterministic applier)", () => {
     expect(doc.evals[0].prompt).toBe("be terse");
     // Applier recorded its own write as the baseline → no spurious drift.
     expect(verifyEvalIntegrity(stateDir, "myskill", skillDir)).toBe("ok");
+  });
+
+  it("#4410: refuses at apply when the stored skill_dir escapes the owned skills root", () => {
+    if (!bunOk) return;
+    // The proposal store is agent-writable, so a tampered proposal could set
+    // skill_dir to a real dir OUTSIDE the agent's skills root. existsSync alone
+    // would pass; the apply-time re-check must reject it (the recomputed slug
+    // dir is authoritative, so a persisted path that diverges is refused).
+    const outside = mkdtempSync(join(tmpdir(), "evcase-outside-"));
+    try {
+      const id = seed({ prompt: "be terse" }, "approved", outside);
+      const r = cli(["self-improve", "apply-eval-case", "--id", id]);
+      expect(r.status).toBe(1);
+      expect(r.err).toMatch(
+        /escapes the skills root|not an owned skill dir|does not correspond to slug/i,
+      );
+      // Nothing was written into the out-of-root target.
+      expect(existsSync(evalsJsonPath(outside))).toBe(false);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("#4410 (LOW): refuses when skill_dir points at a DIFFERENT owned in-root skill than the slug", () => {
+    if (!bunOk) return;
+    // Subtler tamper: skill_dir is a perfectly valid owned, in-root skill dir —
+    // just not the one the slug names. Without recomputing the target from the
+    // slug the case would land in the WRONG skill's evals. The slug's dir is
+    // authoritative; the persisted path must never be written to.
+    const otherDir = join(home, ".claude", "skills", "otherskill");
+    mkdirSync(otherDir, { recursive: true });
+    const id = seed({ prompt: "be terse" }, "approved", otherDir);
+    const r = cli(["self-improve", "apply-eval-case", "--id", id]);
+    expect(r.status).toBe(1);
+    expect(r.err).toMatch(/does not correspond to slug|not an owned skill dir/i);
+    // The mis-pointed dir was NEVER written to.
+    expect(existsSync(evalsJsonPath(otherDir))).toBe(false);
   });
 
   it("FAIL-CLOSED: re-scans at apply and refuses a stored case carrying PII (I4 both ends)", () => {

--- a/tests/skill-validate-pretool.test.ts
+++ b/tests/skill-validate-pretool.test.ts
@@ -361,6 +361,40 @@ describe("skill-validate-pretool hook", () => {
     }
   });
 
+  // #4414: an fd-prefixed redirect (`1>`, `2>`), an append (`>>`), a
+  // combined-stream redirect in EITHER spelling (`&>` / reversed `>&`), or a
+  // clobber (`>|`) redirect into evals.json bypassed the earlier regex (which
+  // excluded any digit before `>` and knew nothing of `>&` / `>|`). Enumerate
+  // the bypass variants — with and without a space before the target — and
+  // assert each is still blocked.
+  it("#4414: blocks fd-prefixed / append / combined-stream / clobber redirects into evals.json", () => {
+    if (!bunOk) return;
+    const target = join(skillsRoot, "demo", "evals", "evals.json");
+    const commands = [
+      `echo poison 1> ${target}`,
+      `echo poison 2> ${target}`,
+      `echo poison 1>> ${target}`,
+      `echo poison 2>> ${target}`,
+      `echo poison >> ${target}`,
+      `echo poison &> ${target}`,
+      `echo poison &>> ${target}`,
+      `echo poison >& ${target}`,
+      `echo poison >&${target}`,
+      `echo poison >| ${target}`,
+      `echo poison >|${target}`,
+    ];
+    for (const command of commands) {
+      const r = run(
+        { tool_name: "Bash", tool_input: { command } },
+        { SWITCHROOM_SELF_IMPROVE: "1" },
+      );
+      expect(r.status).toBe(0);
+      const out = JSON.parse(r.stdout);
+      expect(out.decision, `expected block for: ${command}`).toBe("block");
+      expect(out.reason).toMatch(/machine-managed|add-eval-case/);
+    }
+  });
+
   it("MAJOR2: Bash reads / the sanctioned CLI / unrelated redirects are allowed", () => {
     if (!bunOk) return;
     const target = join(skillsRoot, "demo", "evals", "evals.json");
@@ -370,6 +404,14 @@ describe("skill-validate-pretool hook", () => {
       `jq . ${target}`,
       `switchroom self-improve add-eval-case --skill demo --prompt 'fix evals'`,
       `echo done > /tmp/other.log && cat ${target}`,
+      `cat ${target} 2>&1`,
+      `jq . ${target} > /tmp/copy.json 2>&1`,
+      // fd-DUP regression guards: `>&N` / `2>&1` duplicate a descriptor, they
+      // are NOT a file write and must never be read as one — even when the
+      // command also reads evals.json.
+      `cat ${target} >&1`,
+      `cat ${target} >&2`,
+      `cat ${target} 1>&2`,
       `ls`,
     ];
     for (const command of allowed) {


### PR DESCRIPTION
Single-concern hardening of the self-improve write guard and the eval-case applier. Two LOW issues, both also pre-`T1_LIVE`-flip gates (now closed early per #4430).

## #4414 — fd-prefixed redirect bypasses the write guard
`src/cli/skill-validate-pretool.ts` `redirectWritesEvals()` used `/(?:^|[^0-9<>&])>>?\s*.../` — the `[^0-9<>&]` prefix explicitly excluded any digit before `>`, so an fd-prefixed redirect such as `echo poison 1> …/evals/evals.json` (and `2>`, `>>`, `&>`, `&>>`) slipped past the always-on guard and could poison a machine-managed `evals.json` without a PII scan or operator tap.

Fix: widen the operator match to `(?:\d+|&)?>>?` so fd-prefixed and combined-stream redirects are caught. A `2>&1`-style fd-**dup** stays excluded — its `&`-leading "target" is rejected by the existing target char-class, so no path is captured. Test enumerates `1>`/`2>`/`1>>`/`2>>`/`>>`/`&>`/`&>>` all blocked, plus fd-dup (`2>&1`) regression guards in the allowed set.

## #4410 (== #4425 item 4) — apply-time authorization not re-verified
`src/cli/self-improve-eval-case.ts` `apply-eval-case` only checked `existsSync(proposal.skill_dir)`. The proposal store is agent-writable (`gateway/self-improve-proposal-wiring.ts`), so a tampered proposal could point `skill_dir` outside the owned skills root and still apply.

Fix: at apply time, independently of the persisted value, re-assert (a) `ownsSkill` — a real owned dir, not a shared/bundled symlink — and (b) the canonicalized `skill_dir` resolves within the canonical skills root. The resolved path is surfaced (failure message + success JSON) for audit. Test: an approved proposal whose `skill_dir` escapes the root is REJECTED and nothing is written out-of-root.

## Verification
- Both new tests assert outcomes and were confirmed RED without the source fix, GREEN with it.
- `env -u SWITCHROOM_SELF_IMPROVE npx vitest run` over both touched test files: 27 passed.
- `npm run lint`: clean (exit 0).

Refs #4414 #4410 #4425. Also closes the corresponding #4430 / T1-flip gate items early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)