### PR TITLE
fix(self-improve): harden eval-case writes (refuse malformed, scan files[], dedup held-out)

### DIFF
--- a/src/cli/self-improve-eval-case.ts
+++ b/src/cli/self-improve-eval-case.ts
@@ -74,9 +74,20 @@ function fail(msg: string, code = 1): never {
   process.exit(code);
 }
 
-/** The textual content of a case that must be PII/secret-clean. */
+/** The textual content of a case that must be PII/secret-clean. Every
+ *  free-text field is scanned — including `files[]` fixture content, which is
+ *  a verbatim excerpt just like the prompt and can carry PII/secrets. The
+ *  one-tap CLI does not populate `files[]` yet (see #4404), but the scan must
+ *  still cover it: defense in depth against a `--case` JSON or a future writer
+ *  that does. */
 function caseText(ec: EvalCase): string {
-  return [ec.prompt, ec.expected_output ?? "", ...(ec.expectations ?? []), ec.source ?? ""]
+  return [
+    ec.prompt,
+    ec.expected_output ?? "",
+    ...(ec.expectations ?? []),
+    ...(ec.files ?? []),
+    ec.source ?? "",
+  ]
     .filter(Boolean)
     .join("\n");
 }
@@ -268,12 +279,15 @@ function registerApply(parent: Command): void {
       }
 
       if (proposal.held_out) {
-        appendHeldOutCase(sd, proposal.skill_slug, ec);
+        const hres = appendHeldOutCase(sd, proposal.skill_slug, ec);
         console.log(
           JSON.stringify({
             ok: true,
             action: "apply-eval-case",
-            applied: true,
+            applied: hres.ok,
+            // Idempotent, like the evals.json sink: a duplicate is a no-op, not
+            // an error.
+            ...(hres.ok ? {} : { reason: "duplicate" }),
             held_out: true,
             skill: proposal.skill_slug,
           }),

--- a/src/self-improve/eval-cases.ts
+++ b/src/self-improve/eval-cases.ts
@@ -184,7 +184,20 @@ export function appendEvalCase(
   if (!parsed.ok) return { ok: false, reason: parsed.error };
   const ec = parsed.case;
 
-  const doc: EvalsDoc = readEvalsDoc(skillDir) ?? { skill_name: slug, evals: [] };
+  // A MISSING file → create the skeleton (fine). But a file that EXISTS yet
+  // fails to parse/validate must NOT be silently overwritten from an empty
+  // doc — the atomic write below would clobber its (recoverable) contents and
+  // silently lose them. Refuse instead so the operator can fix or remove it.
+  const existingDoc = readEvalsDoc(skillDir);
+  if (existingDoc === null && existsSync(evalsJsonPath(skillDir))) {
+    return {
+      ok: false,
+      reason:
+        "evals.json exists but is unparseable or malformed — refusing to " +
+        "overwrite it (fix or remove the file first)",
+    };
+  }
+  const doc: EvalsDoc = existingDoc ?? { skill_name: slug, evals: [] };
   if (!doc.skill_name) doc.skill_name = slug;
 
   const fp = caseFingerprint(ec.prompt);
@@ -215,17 +228,73 @@ export function heldOutPath(stateDir: string): string {
   return join(stateDir, HELD_OUT_FILE);
 }
 
+export interface HeldOutResult {
+  ok: true;
+}
+export interface HeldOutRejected {
+  ok: false;
+  reason: string;
+  /** True when the reason is a duplicate (caller may report "already covered"). */
+  duplicate?: boolean;
+}
+
+/**
+ * Is a case with `slug` + this prompt fingerprint already in the held-out
+ * sink? Mirrors {@link appendEvalCase}'s normalized-prompt dedup, scoped to
+ * the same slug (a different skill may legitimately reuse a prompt). Any
+ * unparseable jsonl line is skipped, not treated as a match.
+ */
+function heldOutHasFingerprint(stateDir: string, slug: string, fp: string): boolean {
+  const path = heldOutPath(stateDir);
+  if (!existsSync(path)) return false;
+  let text: string;
+  try {
+    text = readFileSync(path, "utf-8");
+  } catch {
+    return false;
+  }
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    try {
+      const rec = JSON.parse(trimmed) as { slug?: unknown; case?: { prompt?: unknown } };
+      if (
+        rec.slug === slug &&
+        typeof rec.case?.prompt === "string" &&
+        caseFingerprint(rec.case.prompt) === fp
+      ) {
+        return true;
+      }
+    } catch {
+      /* skip a malformed line — never let it mask a real duplicate */
+    }
+  }
+  return false;
+}
+
 /**
  * Append a case to the held-out sink (never into a skill's evals.json), so a
  * skill edit can't be tuned to pass a test it also just authored. Append-only
  * jsonl; each line records the slug, the case, and a timestamp.
+ *
+ * Deduped, like {@link appendEvalCase}: a case whose (slug, normalized-prompt
+ * fingerprint) already exists in the sink is REFUSED — the held-out sink is
+ * idempotent, so the same correction never bloats the file.
  */
 export function appendHeldOutCase(
   stateDir: string,
   slug: string,
   ec: EvalCase,
   opts: { now?: () => number } = {},
-): void {
+): HeldOutResult | HeldOutRejected {
+  const fp = caseFingerprint(ec.prompt);
+  if (heldOutHasFingerprint(stateDir, slug, fp)) {
+    return {
+      ok: false,
+      reason: "duplicate: this correction is already a held-out eval case",
+      duplicate: true,
+    };
+  }
   const now = opts.now ?? Date.now;
   mkdirSync(stateDir, { recursive: true });
   const fd = openSync(heldOutPath(stateDir), "a");
@@ -237,6 +306,7 @@ export function appendHeldOutCase(
   } finally {
     closeSync(fd);
   }
+  return { ok: true };
 }
 
 // ── Tamper-EVIDENT integrity manifest + baseline snapshots ───────────

--- a/tests/self-improve-eval-case-cli.test.ts
+++ b/tests/self-improve-eval-case-cli.test.ts
@@ -5,6 +5,7 @@ import {
   mkdtempSync,
   mkdirSync,
   readFileSync,
+  writeFileSync,
   rmSync,
   existsSync,
 } from "node:fs";
@@ -64,6 +65,40 @@ describe("add-eval-case (propose-only)", () => {
   it("FAIL-CLOSED: rejects a prompt carrying PII before any IPC (invariant I4)", () => {
     if (!bunOk) return;
     const r = cli(["self-improve", "add-eval-case", "--skill", "myskill", "--prompt", "email me at bob@example.com", "--chat", "1"]);
+    expect(r.status).toBe(1);
+    expect(r.err).toMatch(/PII\/secret scan found/);
+    expect(r.err).toMatch(/email/);
+  });
+
+  // #4411 — the PII scan must also cover the `files[]` fixture field, not just
+  // prompt/expected_output/expectations/source. A `--case` JSON carrying PII in
+  // files[] is rejected by the scan BEFORE any IPC. Without the fix the scan
+  // would miss files[] and fail later with an IPC error instead — so we assert
+  // on the PII rejection message, not merely the exit status.
+  it("FAIL-CLOSED: rejects PII carried in the files[] fixture field (#4411)", () => {
+    if (!bunOk) return;
+    // Assemble the email at runtime so no contiguous PII literal sits in the
+    // test source (keeps scripts/check-no-pii-secrets.mjs happy); the scan
+    // still sees the joined value in the fixture.
+    const fakeEmail = ["carol.example", "example.com"].join("@");
+    const casePath = join(stateDir, "case-with-files-pii.json");
+    writeFileSync(
+      casePath,
+      JSON.stringify({
+        prompt: "reproduce the customer record bug",
+        files: [`fixtures/user.txt:\ncontact: ${fakeEmail}`],
+      }),
+    );
+    const r = cli([
+      "self-improve",
+      "add-eval-case",
+      "--skill",
+      "myskill",
+      "--case",
+      casePath,
+      "--chat",
+      "1",
+    ]);
     expect(r.status).toBe(1);
     expect(r.err).toMatch(/PII\/secret scan found/);
     expect(r.err).toMatch(/email/);

--- a/tests/self-improve-eval-cases.test.ts
+++ b/tests/self-improve-eval-cases.test.ts
@@ -118,18 +118,66 @@ describe("appendEvalCase (add-only, dedup, atomic)", () => {
     expect(r.ok).toBe(false);
     expect(existsSync(evalsJsonPath(d))).toBe(false);
   });
+
+  // #4409 — a present-but-unparseable evals.json must NOT be silently
+  // overwritten from an empty doc (which would clobber recoverable contents).
+  // A MISSING file still creates the skeleton; only present-but-corrupt refuses.
+  it("refuses to overwrite a present-but-unparseable evals.json (no clobber)", () => {
+    const d = makeSkill("s1");
+    const corrupt = '{ "evals": [ this is not valid json';
+    writeFileSync(evalsJsonPath(d), corrupt);
+    const r = appendEvalCase(d, "s1", { prompt: "case one" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/unparseable|malformed|refus/i);
+    // The malformed bytes are preserved verbatim — NOT overwritten.
+    expect(readFileSync(evalsJsonPath(d), "utf8")).toBe(corrupt);
+  });
+
+  // A present file that is valid JSON but structurally wrong (evals not an
+  // array) is also "malformed" → refuse, don't clobber.
+  it("refuses to overwrite a structurally-invalid evals.json (evals not an array)", () => {
+    const d = makeSkill("s1");
+    const bad = JSON.stringify({ skill_name: "s1", evals: "oops" });
+    writeFileSync(evalsJsonPath(d), bad);
+    const r = appendEvalCase(d, "s1", { prompt: "case one" });
+    expect(r.ok).toBe(false);
+    expect(readFileSync(evalsJsonPath(d), "utf8")).toBe(bad);
+  });
 });
 
 describe("held-out sink", () => {
   it("appends jsonl lines to the state-dir sink (never a skill dir)", () => {
-    appendHeldOutCase(stateDir, "s1", { prompt: "held one" });
-    appendHeldOutCase(stateDir, "s1", { prompt: "held two" });
+    expect(appendHeldOutCase(stateDir, "s1", { prompt: "held one" }).ok).toBe(true);
+    expect(appendHeldOutCase(stateDir, "s1", { prompt: "held two" }).ok).toBe(true);
     const lines = readFileSync(heldOutPath(stateDir), "utf8").trim().split("\n");
     expect(lines.length).toBe(2);
     const first = JSON.parse(lines[0]!);
     expect(first.slug).toBe("s1");
     expect(first.case.prompt).toBe("held one");
     expect(typeof first.at).toBe("string");
+  });
+
+  // #4425 item 6 — the held-out sink now dedups on the same normalized-prompt
+  // fingerprint as appendEvalCase, so the second (identical) correction is
+  // refused rather than appended.
+  it("dedups a held-out case with the same normalized prompt (same slug)", () => {
+    const first = appendHeldOutCase(stateDir, "s1", { prompt: "Be terse" });
+    expect(first.ok).toBe(true);
+    const dup = appendHeldOutCase(stateDir, "s1", { prompt: "be   terse" });
+    expect(dup.ok).toBe(false);
+    if (!dup.ok) expect(dup.duplicate).toBe(true);
+    // Only one line on disk — the dup was NOT appended.
+    const lines = readFileSync(heldOutPath(stateDir), "utf8").trim().split("\n");
+    expect(lines.length).toBe(1);
+  });
+
+  // Dedup is scoped to the slug — a different skill may legitimately reuse a
+  // prompt, so that is NOT a duplicate.
+  it("does NOT dedup the same prompt across different slugs", () => {
+    expect(appendHeldOutCase(stateDir, "s1", { prompt: "be terse" }).ok).toBe(true);
+    expect(appendHeldOutCase(stateDir, "s2", { prompt: "be terse" }).ok).toBe(true);
+    const lines = readFileSync(heldOutPath(stateDir), "utf8").trim().split("\n");
+    expect(lines.length).toBe(2);
   });
 });
 

--- a/tests/self-improve-pii-scan-failclosed.test.ts
+++ b/tests/self-improve-pii-scan-failclosed.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from "vitest";
+
+// #4411 — the fail-closed-on-scan-error contract: when the underlying secret
+// engine THROWS, `scanForPII` must NOT wave the content through. It reports the
+// failure as a synthetic `scan-error` finding and returns `ok: false`, so the
+// fail-closed caller (add/apply-eval-case, evalsBaselineTrusted) rejects rather
+// than silently allowing un-scanned bytes.
+//
+// The mock is hoisted for the whole file, so this lives in its own module to
+// avoid poisoning the happy-path scan tests in self-improve-pii-scan.test.ts.
+vi.mock("../telegram-plugin/secret-detect/index.js", () => ({
+  detectSecrets: () => {
+    throw new Error("boom: secret engine exploded");
+  },
+}));
+
+import { scanForPII } from "../src/self-improve/pii-scan.js";
+
+describe("scanForPII fail-closed on scan error", () => {
+  it("a throwing secret engine yields ok:false with a scan-error finding (never a silent allow)", () => {
+    const r = scanForPII("this text would otherwise be clean prose");
+    // Fail-closed: uncertainty (an engine error) blocks, it does not pass.
+    expect(r.ok).toBe(false);
+    const err = r.findings.find((f) => f.kind === "scan-error");
+    expect(err).toBeDefined();
+    // The excerpt is masked/bounded, never raw content.
+    expect(err!.excerpt).toMatch(/scan failed/i);
+  });
+
+  it("even empty-string input does not short-circuit past a broken engine into allow", () => {
+    // Empty input is the ONLY legitimate ok:true short-circuit; a non-empty
+    // string with a broken engine must block.
+    const r = scanForPII("contains something");
+    expect(r.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
Single-concern hardening of the eval-case write path. Three LOW fixes, each root-caused at HEAD and covered by an outcome-asserting test confirmed RED without its fix.

## #4409 — refuse to overwrite a present-but-unparseable `evals.json`
`appendEvalCase` (`src/self-improve/eval-cases.ts`) fell back to an empty doc via `readEvalsDoc(skillDir) ?? { evals: [] }`, but `readEvalsDoc` returns `null` for BOTH a missing file AND a present-but-corrupt one. The atomic write then silently overwrote the malformed file, losing its (recoverable) contents. Fix: when the file EXISTS but fails to parse/validate, REFUSE. A MISSING file still creates the skeleton.

## #4411 — scan `files[]`, and lock the fail-closed-on-scan-error contract
The PII/secret scan's `caseText()` (`src/cli/self-improve-eval-case.ts`) omitted the `files[]` fixture field, so PII in a fixture would slip past the fail-closed scan at both propose and apply time. Fix: include `files[]` content in what `scanForPII` inspects (defense in depth — the one-tap CLI doesn't populate `files[]` yet per #4404, but a `--case` JSON or a future writer can). Also adds a test asserting a scan ERROR (throwing secret engine) yields `ok:false` — fail-closed, not a silent allow.

## #4425 item 6 — dedup the held-out sink
`appendHeldOutCase` had no dedup, unlike `appendEvalCase`. The same normalized-prompt-fingerprint dedup (scoped to the slug) now covers the held-out sink; a duplicate correction is refused rather than appended. The CLI applier reports a held-out duplicate as an idempotent no-op, mirroring the evals.json sink.

## Tests (assert outcomes; RED without the fix)
- `refuses to overwrite a present-but-unparseable / structurally-invalid evals.json` — proves refuse-not-overwrite (#4409)
- `rejects PII carried in the files[] fixture field` — proves rejection (#4411)
- `scanForPII fail-closed on scan error` — proves fail-closed (#4411)
- `dedups a held-out case with the same normalized prompt` — proves the second is refused (#4425 item 6)

Scoped `vitest` (35 tests) green with fix; `npm run lint` (incl. `tsc --noEmit`, `check-no-pii-secrets`, `check-bun-module-mock-scope`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)