### PR TITLE
fix(self-improve): measure diff-cap in UTF-8 bytes + normalize proposal origin on read

### DIFF
--- a/src/cli/self-improve-propose-skill.ts
+++ b/src/cli/self-improve-propose-skill.ts
@@ -24,6 +24,11 @@ import { join } from "node:path";
 import { readFileSync } from "node:fs";
 import type { Command } from "commander";
 
+import {
+  PROPOSAL_ORIGINS,
+  type ProposalOrigin,
+} from "../self-improve/skill-proposals";
+
 const IPC_CONNECT_TIMEOUT_MS = 5000;
 
 function gatewaySocketPath(): string {
@@ -34,10 +39,6 @@ function gatewaySocketPath(): string {
       : join(homedir(), ".claude", "channels", "telegram", "gateway.sock"))
   );
 }
-
-/** Allowed proposal-provenance values (mirrors `ProposalOrigin`). */
-const ALLOWED_ORIGINS = ["skill-synthesis", "failure-synthesis"] as const;
-type ProposalOrigin = (typeof ALLOWED_ORIGINS)[number];
 
 interface ProposeOpts {
   slug: string;
@@ -102,7 +103,7 @@ export function registerSelfImproveProposeSkillCommand(program: Command): void {
     .option("--agent <name>", "agent name (defaults to $SWITCHROOM_AGENT_NAME)")
     .option(
       "--origin <origin>",
-      `proposal provenance (${ALLOWED_ORIGINS.join(" | ")}); absent ⇒ skill-synthesis`,
+      `proposal provenance (${PROPOSAL_ORIGINS.join(" | ")}); absent ⇒ skill-synthesis`,
     )
     .action((opts: ProposeOpts) => {
       const agent = opts.agent ?? process.env.SWITCHROOM_AGENT_NAME;
@@ -110,9 +111,9 @@ export function registerSelfImproveProposeSkillCommand(program: Command): void {
 
       let origin: ProposalOrigin | undefined;
       if (opts.origin != null) {
-        if (!ALLOWED_ORIGINS.includes(opts.origin as ProposalOrigin)) {
+        if (!PROPOSAL_ORIGINS.includes(opts.origin as ProposalOrigin)) {
           fail(
-            `--origin must be one of: ${ALLOWED_ORIGINS.join(", ")} (got "${opts.origin}")`,
+            `--origin must be one of: ${PROPOSAL_ORIGINS.join(", ")} (got "${opts.origin}")`,
           );
         }
         origin = opts.origin as ProposalOrigin;

--- a/src/self-improve/apply-guard.ts
+++ b/src/self-improve/apply-guard.ts
@@ -204,21 +204,31 @@ export function estimateChangedLines(
  *
  *   - before: the current file size from `statSync` (0 if the file is
  *     absent — a brand-new file).
- *   - after (Write): the new content's length.
- *   - after (Edit): before − old_string.length + new_string.length.
- *   - after (MultiEdit): before + Σ(new_string.length − old_string.length).
+ *   - after (Write): the new content's UTF-8 byte length.
+ *   - after (Edit): before − bytes(old_string) + bytes(new_string), scaled
+ *     by the match count when `replace_all` is set.
+ *   - after (MultiEdit): before + Σ per-edit byte delta (each scaled by its
+ *     own `replace_all` match count).
  *
- * Mirrors `estimateChangedLines`'s reading of the tool input. Skill
- * bundles are text, so a string `.length` (UTF-16 code units) tracks the
- * byte size closely enough for the cap's "is this growing a lot" purpose;
- * `before` is real bytes from `statSync`. A negative/zero delta (shrink or
- * size-neutral edit) is never blocked by the growth cap.
+ * Mirrors `estimateChangedLines`'s reading of the tool input. Measured in
+ * real UTF-8 bytes via `Buffer.byteLength(s, "utf8")` — the SAME axis as
+ * `before` (`statSync().size`) and the outer 2 MiB `MAX_SKILL_BYTES` wall
+ * (`Buffer.byteLength`, src/cli/skill-common.ts). A prior version measured
+ * the `after` side in UTF-16 code units (`.length`), which under/over-counts
+ * multibyte content (e.g. `"😀".repeat(2000)` is `.length=4000` but 8000
+ * real bytes) and could slip a multi-KB write under the cap (#4419). A
+ * `replace_all` Edit applies to EVERY match, so a single old→new delta is
+ * scaled by the occurrence count in the current file; a plain Edit applies
+ * once. A negative/zero delta (shrink or size-neutral edit) is never
+ * blocked by the growth cap.
  */
 export function estimateByteDelta(
   toolName: string,
   input: Record<string, unknown>,
   filePath: string,
 ): { before: number; after: number; delta: number } {
+  const byteLen = (s: string): number => Buffer.byteLength(s, "utf8");
+
   let before = 0;
   try {
     before = statSync(filePath).size;
@@ -226,14 +236,40 @@ export function estimateByteDelta(
     before = 0; // absent → brand-new file
   }
 
+  // Read the current file ONCE for any replace_all occurrence counting.
+  // A replace_all with an empty/absent old_string matches nothing, so its
+  // count is 0 (no growth) — mirrors the tool's real no-op behaviour.
+  let currentContent: string | null = null;
+  const occurrences = (needle: string): number => {
+    if (needle.length === 0) return 0;
+    if (currentContent === null) {
+      try {
+        currentContent = readFileSync(filePath, "utf-8");
+      } catch {
+        currentContent = "";
+      }
+    }
+    return currentContent.split(needle).length - 1;
+  };
+
+  const editDelta = (
+    oldS: string,
+    newS: string,
+    replaceAll: boolean,
+  ): number => {
+    const per = byteLen(newS) - byteLen(oldS);
+    const count = replaceAll ? occurrences(oldS) : 1;
+    return per * count;
+  };
+
   let after = before;
   if (toolName === "Write") {
     const content = typeof input.content === "string" ? input.content : "";
-    after = content.length;
+    after = byteLen(content);
   } else if (toolName === "Edit") {
     const oldS = typeof input.old_string === "string" ? input.old_string : "";
     const newS = typeof input.new_string === "string" ? input.new_string : "";
-    after = before - oldS.length + newS.length;
+    after = before + editDelta(oldS, newS, input.replace_all === true);
   } else if (toolName === "MultiEdit") {
     const edits = Array.isArray(input.edits) ? input.edits : [];
     let net = 0;
@@ -242,7 +278,7 @@ export function estimateByteDelta(
       const ed = e as Record<string, unknown>;
       const oldS = typeof ed.old_string === "string" ? ed.old_string : "";
       const newS = typeof ed.new_string === "string" ? ed.new_string : "";
-      net += newS.length - oldS.length;
+      net += editDelta(oldS, newS, ed.replace_all === true);
     }
     after = before + net;
   }

--- a/src/self-improve/skill-proposals.test.ts
+++ b/src/self-improve/skill-proposals.test.ts
@@ -136,7 +136,8 @@ describe("skill-proposals store", () => {
   it("reads a legacy record lacking benchmark/origin (back-compat)", () => {
     // A record written before PR2 — no `origin`, no `benchmark`. It must
     // still parse, and absence of `origin` MUST read as skill-synthesis
-    // (the documented default), never as undefined-is-an-error.
+    // (the documented default), materialized on read (#4428) so a consumer
+    // branching on `origin === "skill-synthesis"` can never miss it.
     const legacy = {
       id: "legacy-1",
       created_at: "2026-01-01T00:00:00.000Z",
@@ -150,9 +151,36 @@ describe("skill-proposals store", () => {
     appendFileSync(join(dir, "skill-proposals.jsonl"), JSON.stringify(legacy) + "\n");
     const fetched = getProposal(dir, "legacy-1");
     expect(fetched).toBeTruthy();
-    expect(fetched?.origin).toBeUndefined(); // absence ⇒ skill-synthesis
+    expect(fetched?.origin).toBe("skill-synthesis"); // absence ⇒ default, materialized
     expect(fetched?.benchmark).toBeUndefined();
     expect(fetched?.is_new).toBe(true);
+  });
+
+  it("normalizes an un-normalized stored origin on read (#4428)", () => {
+    // A hand-written / tampered JSONL line carrying an origin that is NOT one
+    // of the valid provenance values. readProposals must collapse it to the
+    // skill-synthesis default via the shared normalizer — the origin check a
+    // consumer runs on the loaded record must never see the raw junk value.
+    const tampered = {
+      id: "tampered-1",
+      created_at: "2026-01-01T00:00:00.000Z",
+      status: "pending",
+      skill_slug: "deploy-checklist",
+      is_new: true,
+      lesson: baseInput.lesson,
+      draft: baseInput.draft,
+      evidence: baseInput.evidence,
+      origin: "hand-written-bogus-origin",
+    };
+    appendFileSync(
+      join(dir, "skill-proposals.jsonl"),
+      JSON.stringify(tampered) + "\n",
+    );
+    const fetched = getProposal(dir, "tampered-1");
+    expect(fetched).toBeTruthy();
+    // Without read-normalization this would surface the raw "hand-written-
+    // bogus-origin" string and bypass the origin check.
+    expect(fetched?.origin).toBe("skill-synthesis");
   });
 
   it("matches reworded proposals via content-word jaccard", () => {

--- a/src/self-improve/skill-proposals.ts
+++ b/src/self-improve/skill-proposals.ts
@@ -62,6 +62,29 @@ export type ProposalStatus = "pending" | "approved" | "rejected";
  */
 export type ProposalOrigin = "skill-synthesis" | "failure-synthesis";
 
+/** The valid provenance values; anything else normalizes to the default. */
+export const PROPOSAL_ORIGINS: readonly ProposalOrigin[] = [
+  "skill-synthesis",
+  "failure-synthesis",
+];
+
+/** Back-compat default: absence (or any unrecognized value) ⇒ skill-synthesis. */
+export const DEFAULT_PROPOSAL_ORIGIN: ProposalOrigin = "skill-synthesis";
+
+/**
+ * Single source of truth for materializing a proposal's `origin`. An absent
+ * field (legacy record, written before `origin` existed) or any value not in
+ * `PROPOSAL_ORIGINS` (a hand-written / tampered JSONL line) collapses to the
+ * `skill-synthesis` default. Applied on BOTH read (`readProposals`) and write
+ * so no consumer branching on `origin === "skill-synthesis"` can silently miss
+ * a legacy/un-normalized record (#4428).
+ */
+export function normalizeProposalOrigin(value: unknown): ProposalOrigin {
+  return PROPOSAL_ORIGINS.includes(value as ProposalOrigin)
+    ? (value as ProposalOrigin)
+    : DEFAULT_PROPOSAL_ORIGIN;
+}
+
 /**
  * A benchmark summary attached to a proposal, precomputed by the
  * grader-subagent flow at synthesis time (NOT recomputed by the card).
@@ -196,7 +219,13 @@ function isRejectionRecord(v: unknown): v is RejectionFingerprint {
 export function readProposals(stateDir: string): SkillProposal[] {
   const all = readLines(proposalsPath(stateDir), isProposalRecord);
   const byId = new Map<string, SkillProposal>();
-  for (const p of all) byId.set(p.id, p); // later lines overwrite
+  // Materialize `origin` on read via the shared normalizer so a legacy record
+  // (no `origin`) or a hand-written line with an un-normalized value reads as
+  // a concrete, valid provenance — a consumer branching on
+  // `origin === "skill-synthesis"` must never silently miss it (#4428).
+  for (const p of all) {
+    byId.set(p.id, { ...p, origin: normalizeProposalOrigin(p.origin) }); // later lines overwrite
+  }
   return [...byId.values()];
 }
 
@@ -260,6 +289,9 @@ export function enqueueProposal(
     created_at: new Date(now()).toISOString(),
     status: "pending",
     ...input,
+    // Same normalizer as readProposals — provenance is always a concrete,
+    // valid value on disk, so read and write agree (#4428).
+    origin: normalizeProposalOrigin(input.origin),
   };
   appendLine(proposalsPath(stateDir), proposal);
   return proposal;

--- a/tests/self-improve-apply-guard.test.ts
+++ b/tests/self-improve-apply-guard.test.ts
@@ -440,6 +440,76 @@ describe("estimateByteDelta", () => {
     expect(r.after).toBe(3);
     expect(r.delta).toBe(0);
   });
+
+  it("Write: measures multibyte content in real UTF-8 bytes, not UTF-16 units (#4419)", () => {
+    // "😀" is a surrogate pair: .length === 2 (UTF-16 units) but 4 UTF-8 bytes.
+    // 20 copies → .length=40 (the OLD, wrong measure) vs 80 real bytes.
+    const abs = join(agentDir, "emoji.md");
+    const content = "😀".repeat(20);
+    expect(content.length).toBe(40); // UTF-16 code units — what the bug used
+    const r = estimateByteDelta("Write", { content }, abs);
+    expect(r.before).toBe(0);
+    expect(r.after).toBe(80); // Buffer.byteLength(content,"utf8")
+    expect(r.delta).toBe(80);
+  });
+
+  it("Edit: measures old/new in UTF-8 bytes (#4419)", () => {
+    const abs = join(agentDir, "edit-mb.md");
+    writeFileSync(abs, "😀"); // 4 bytes on disk
+    // Replace the emoji (4 bytes) with "abc" (3 bytes) → net −1 byte.
+    const r = estimateByteDelta(
+      "Edit",
+      { old_string: "😀", new_string: "abc" },
+      abs,
+    );
+    expect(r.before).toBe(4);
+    expect(r.after).toBe(3);
+    expect(r.delta).toBe(-1);
+  });
+
+  it("Edit + replace_all: scales the delta by the match count (#4419)", () => {
+    const abs = join(agentDir, "replace-all.md");
+    writeFileSync(abs, "aaa"); // 3 occurrences of "a", before = 3 bytes
+    // replace_all applies to EVERY match: 3 × (bytes("bb") − bytes("a")) = 3×1.
+    const r = estimateByteDelta(
+      "Edit",
+      { old_string: "a", new_string: "bb", replace_all: true },
+      abs,
+    );
+    expect(r.before).toBe(3);
+    expect(r.after).toBe(6); // OLD single-application bug would report 4
+    expect(r.delta).toBe(3);
+  });
+
+  it("Edit without replace_all: still a single application", () => {
+    const abs = join(agentDir, "single.md");
+    writeFileSync(abs, "aaa");
+    const r = estimateByteDelta(
+      "Edit",
+      { old_string: "a", new_string: "bb" }, // no replace_all
+      abs,
+    );
+    expect(r.after).toBe(4); // 3 − 1 + 2, one application only
+    expect(r.delta).toBe(1);
+  });
+
+  it("MultiEdit + per-edit replace_all: each edit scales by its own match count (#4419)", () => {
+    const abs = join(agentDir, "multi-ra.md");
+    writeFileSync(abs, "aabb"); // before = 4 bytes
+    const r = estimateByteDelta(
+      "MultiEdit",
+      {
+        edits: [
+          { old_string: "a", new_string: "xx", replace_all: true }, // 2 × (2−1) = +2
+          { old_string: "b", new_string: "" }, // single: (0−1) = −1
+        ],
+      },
+      abs,
+    );
+    expect(r.before).toBe(4);
+    expect(r.delta).toBe(2 - 1);
+    expect(r.after).toBe(5);
+  });
 });
 
 describe("apply-guard T1 net-growth cap", () => {
@@ -504,6 +574,34 @@ describe("apply-guard T1 net-growth cap", () => {
     } finally {
       if (prev === undefined) delete process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE;
       else process.env.SWITCHROOM_SELF_IMPROVE_T1_LIVE = prev;
+    }
+  });
+
+  it("TRIPS the growth cap on multibyte content that UTF-16 length would slip under (#4419)", () => {
+    makeOwnedSkill(true);
+    writeBenchmark(1.0, 0.9);
+    // 30 emoji: .length === 60 (would be UNDER the 64-byte budget on the old
+    // UTF-16 measure) but 120 real UTF-8 bytes → over by 56. The fix measures
+    // bytes, so the cap must trip; the old code would have silently allowed it.
+    const BUDGET64: SelfImproveConfig = { ...CFG, t1MaxGrowthBytes: 64 };
+    const content = "😀".repeat(30);
+    expect(content.length).toBe(60); // < 64: the bug would NOT block
+    const d = decideApply({
+      toolName: "Write",
+      input: { content },
+      filePath: skillFile(),
+      stateDir,
+      cfg: BUDGET64,
+      now,
+    });
+    expect(d.action).toBe("block");
+    if (d.action === "block") {
+      expect(d.downgradeTier).toBe("T2");
+      expect(d.reason).toMatch(/net-growth cap/i);
+      expect(d.reason).toContain("64-byte budget");
+      expect(d.reason).toContain("56 over"); // 120 − 64
+      expect(d.bytesBefore).toBe(0);
+      expect(d.bytesAfter).toBe(120);
     }
   });
 

--- a/tests/self-improve-propose-skill-cli.test.ts
+++ b/tests/self-improve-propose-skill-cli.test.ts
@@ -121,9 +121,10 @@ describe("propose-skill --origin (R1: origin threaded CLI → IPC → store)", (
     runHandler(msg as unknown as PostSkillProposalMessage);
     const stored = readProposals(stateDir);
     expect(stored).toHaveLength(1);
-    // Absence ⇒ skill-synthesis (the documented back-compat default) — the
-    // record carries no explicit origin field.
-    expect(stored[0]!.origin).toBeUndefined();
+    // Absence ⇒ skill-synthesis (the documented back-compat default),
+    // materialized on read by the shared normalizer (#4428) so a consumer
+    // branching on `origin === "skill-synthesis"` never misses it.
+    expect(stored[0]!.origin).toBe("skill-synthesis");
   });
 
   it("rejects an invalid --origin before any IPC (commander-level validation)", () => {


### PR DESCRIPTION
Two LOW-severity self-improve hygiene fixes, single concern each. Neither lands silently (`SWITCHROOM_SELF_IMPROVE_T1_LIVE` defaults OFF, no consumer branches on `origin` yet) — this is durability hardening.

## #4419 — T1 growth cap measured UTF-16 code units, not UTF-8 bytes (+ replace_all undercount)
`estimateByteDelta()` (`src/self-improve/apply-guard.ts`) computed the `after` side with string `.length` (UTF-16 code units) while `before` (`statSync().size`) and the outer 2 MiB `MAX_SKILL_BYTES` wall (`Buffer.byteLength`, `src/cli/skill-common.ts`) use real UTF-8 bytes. A multibyte Write could slip a multi-KB growth under the inner cap (`"😀".repeat(2000)` is `.length=4000` but 8000 bytes). Also: an Edit/MultiEdit with `replace_all` applies to every match, but the estimate assumed a single application, undercounting by ~(N−1)×.

Fix: every `after` computation now uses `Buffer.byteLength(s, "utf8")` — the same axis as `before` and the outer wall — and a `replace_all` edit is scaled by the occurrence count in the current file (read once). The CLAUDE.md byte-ratchet (`scripts/check-claude-md-byte-ratchet.mjs`) intentionally measures UTF-16 `.length` in a different file and is left untouched.

## #4428 — proposal `origin` not normalized on read
`origin` was normalized on write (CLI `ALLOWED_ORIGINS`) but `readProposals` left an absent/legacy value `undefined` and passed a hand-written/tampered JSONL value through raw — a future consumer branching on `origin === "skill-synthesis"` would silently miss those records. Fix: a single shared `normalizeProposalOrigin()` applied on **both** read (`readProposals`) and write (`enqueueProposal`); absence or any invalid value collapses to the `skill-synthesis` default.

## Tests (assert outcomes, RED without the fix)
- multibyte Write that trips the byte-growth cap (UTF-16 length would slip under the 64-byte budget); UTF-8 Write/Edit byte measurement; `replace_all` + per-edit MultiEdit occurrence scaling (#4419)
- legacy absent origin materialized to `skill-synthesis` on read, and an un-normalized stored origin normalized on read (#4428)

All 7 new/changed assertions fail against pre-fix source; `npm run lint` clean.

Closes #4419
Closes #4428

🤖 Generated with [Claude Code](https://claude.com/claude-code)