### PR TITLE
chore(self-improve): drop dead proposal benchmark field (#4425 item 1)

### DIFF
--- a/reference/rfcs/agent-self-improvement.md
+++ b/reference/rfcs/agent-self-improvement.md
@@ -260,10 +260,12 @@ turns without re-mining raw transcripts.
 1. **Slice 1 — the eval-case sink.** CLI + guard + manifest + Stop-hook
    integrity check + PII scan + review-prompt step. Makes the dormant gate
    able to BLOCK. Does NOT flip T1-live.
-2. **Slice 2 — measurement surface + parity plumbing.** Optional
-   `benchmark` field on proposals (advisory, rendered on the card,
-   computed on-tap not eagerly), `switchroom self-improve bench <skill>`
-   CLI, and store/type support for failure-origin edit-or-create proposals.
+2. **Slice 2 — measurement surface + parity plumbing.** The
+   `switchroom self-improve bench <skill>` CLI, and store/type support for
+   failure-origin edit-or-create proposals. (Score-carrying proposal cards —
+   a `benchmark` field on proposals, advisory and rendered on the card — are
+   deferred to a future, tracked feature; the dead field was dropped in
+   #4425 item 1 as it was never written or rendered.)
 3. **Slice 3 — net-growth cap.** Env-tunable per-edit growth budget in
    `decideApply()`; breach downgrades to T2. Purely restrictive.
 4. **Slice 4 — failure synthesis.** `self-improve:correction` retain tag

--- a/src/cli/self-improve-bench.ts
+++ b/src/cli/self-improve-bench.ts
@@ -5,8 +5,8 @@
  * Aggregates an EXISTING set of grading files for a skill's evals into a
  * pass/regress verdict and prints it as JSON. This is the read-only
  * numbers surface behind the eval gate (`eval-gate.ts`): the review /
- * synthesis flow attaches the resulting numbers to a proposal
- * (`SkillProposal.benchmark`), and an operator can recompute them on demand.
+ * synthesis flow computes these numbers, and an operator can recompute
+ * them on demand.
  *
  * CLAUDE-NATIVE / SUBSCRIPTION-HONEST — HARD CONSTRAINT:
  *   This command NEVER triggers an eval run. `skills/skill-creator/scripts/

--- a/src/self-improve/skill-proposals.test.ts
+++ b/src/self-improve/skill-proposals.test.ts
@@ -116,25 +116,17 @@ describe("skill-proposals store", () => {
     ).toBe(false);
   });
 
-  it("round-trips optional benchmark + origin fields untouched", () => {
+  it("round-trips the optional origin field untouched", () => {
     const p = enqueueProposal(dir, {
       ...baseInput,
       origin: "failure-synthesis",
-      benchmark: {
-        candidate_pass_rate: 1.0,
-        baseline_pass_rate: 0.5,
-        computed_at: "2026-08-06T00:00:00.000Z",
-      },
     });
     const fetched = getProposal(dir, p.id);
     expect(fetched?.origin).toBe("failure-synthesis");
-    expect(fetched?.benchmark?.candidate_pass_rate).toBe(1.0);
-    expect(fetched?.benchmark?.baseline_pass_rate).toBe(0.5);
-    expect(fetched?.benchmark?.computed_at).toBe("2026-08-06T00:00:00.000Z");
   });
 
-  it("reads a legacy record lacking benchmark/origin (back-compat)", () => {
-    // A record written before PR2 — no `origin`, no `benchmark`. It must
+  it("reads a legacy record lacking origin (back-compat)", () => {
+    // A record written before PR2 — no `origin`. It must
     // still parse, and absence of `origin` MUST read as skill-synthesis
     // (the documented default), materialized on read (#4428) so a consumer
     // branching on `origin === "skill-synthesis"` can never miss it.
@@ -152,7 +144,6 @@ describe("skill-proposals store", () => {
     const fetched = getProposal(dir, "legacy-1");
     expect(fetched).toBeTruthy();
     expect(fetched?.origin).toBe("skill-synthesis"); // absence ⇒ default, materialized
-    expect(fetched?.benchmark).toBeUndefined();
     expect(fetched?.is_new).toBe(true);
   });
 

--- a/src/self-improve/skill-proposals.ts
+++ b/src/self-improve/skill-proposals.ts
@@ -85,22 +85,6 @@ export function normalizeProposalOrigin(value: unknown): ProposalOrigin {
     : DEFAULT_PROPOSAL_ORIGIN;
 }
 
-/**
- * A benchmark summary attached to a proposal, precomputed by the
- * grader-subagent flow at synthesis time (NOT recomputed by the card).
- * `switchroom self-improve bench` produces the same numbers on demand.
- * Absent on a legacy record (back-compat) and on any proposal whose skill
- * had no runnable evals when it was drafted.
- */
-export interface ProposalBenchmark {
-  /** Candidate ("with_skill") pass-rate mean, 0..1. */
-  candidate_pass_rate: number;
-  /** Baseline ("without_skill") pass-rate mean, 0..1, when a baseline ran. */
-  baseline_pass_rate?: number;
-  /** ISO timestamp the benchmark was computed. */
-  computed_at: string;
-}
-
 export interface SkillProposal {
   /** Stable id; the card's callback_data carries this. */
   id: string;
@@ -127,14 +111,6 @@ export interface SkillProposal {
    * `ProposalOrigin`.
    */
   origin?: ProposalOrigin;
-  /**
-   * Precomputed benchmark numbers for the drafted skill, when its evals
-   * were runnable at synthesis time. Carried on the record so the card can
-   * surface pass-rates without re-running anything; `switchroom
-   * self-improve bench` recomputes the same shape. Absent on a legacy
-   * record or an unbenchmarked draft.
-   */
-  benchmark?: ProposalBenchmark;
 }
 
 /** One rejection fingerprint, used to suppress re-proposals. */


### PR DESCRIPTION
## What

Removes the dead `benchmark` field on `SkillProposal` and its `ProposalBenchmark` type (#4425 item 1). The field was defined but **never written** by any producer and **never rendered** by the proposal card — confirmed by a repo-wide grep at HEAD (zero writers, zero renderers).

## Changes

- `src/self-improve/skill-proposals.ts` — remove the `ProposalBenchmark` interface and the `benchmark?` field on `SkillProposal`.
- `src/self-improve/skill-proposals.test.ts` — drop the dead-field assertions; keep origin round-trip + legacy back-compat coverage (renamed accordingly).
- `src/cli/self-improve-bench.ts` — update a doc comment that claimed the CLI attaches numbers to `SkillProposal.benchmark`.
- `reference/rfcs/agent-self-improvement.md` — the RFC claimed the field was advisory/rendered-on-card. Rewritten to note score-carrying proposal cards are **deferred to a future, tracked feature**, rather than silently deleting the design intent — while dropping the claim that it's implemented.

## Not touched (live machinery)

`aggregateBenchmark()` / `eval-gate.ts` and the `switchroom self-improve bench` CLI are the real, live benchmark surface and stay exactly as they are. Only the dead proposal-record field, its type, and its dead references were removed.

## Verification

- `tsc --noEmit` clean (removing the type surfaced no usages).
- `env -u SWITCHROOM_SELF_IMPROVE vitest run` over the proposals suite: 9/9 pass. The card renderer has zero benchmark references.
- `npm run lint` clean.

## Note

#4434 (in review) also touches `skill-proposals.ts` (origin normalization). This diff is deliberately minimal and localized to the benchmark field to ease that rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)