### PR TITLE
fix(telegram): suppress hollow activity cards on zero-content turns (#45)

### DIFF
--- a/telegram-plugin/gateway/narrative-lane.ts
+++ b/telegram-plugin/gateway/narrative-lane.ts
@@ -56,7 +56,7 @@ import {
   appendActivityLabel, clipNarrative, formatStepSuffix, renderActivityFeedWithNested,
 } from '../tool-activity-summary.js'
 import { evaluatePostAnswerLiveness } from '../turn-liveness-floor.js'
-import { isSilentSentinelCardOutcome } from '../turn-flush-safety.js'
+import { isHollowGhostCardOutcome, isSilentSentinelCardOutcome } from '../turn-flush-safety.js'
 import { clearActivityCardRecord, writeActivityCardRecord } from './activity-card-store.js'
 import { chatKeyWithSuffix } from './chat-key.js'
 import {
@@ -900,7 +900,30 @@ export function createNarrativeLane(deps: NarrativeLaneDeps) {
         capturedText: turn.capturedText,
         finalAnswerEverDelivered: turn.finalAnswerEverDelivered,
       })
-      if (CLEAR_STATUS_ON_COMPLETION || silentSentinelTurn) {
+      // #45 — hollow-ghost suppression. The sibling to the #4348 sentinel gate:
+      // a turn that ended having done ZERO surfaced tool work, never called
+      // reply, delivered no final answer, surfaced NO narration, and emitted no
+      // captured/reply text adopted an activity card at turn start that never
+      // got any content — the contentless `🤖 Agent · done · 0 tools · Ns`
+      // record Ken reported (a card opened by the liveness timer that stayed
+      // empty). The sentinel gate can't catch it (there is no NO_REPLY/
+      // HEARTBEAT_OK text to match; the flush classifies it `empty-text`, not
+      // `silent-marker`), so DELETE the empty card here instead of finalizing
+      // it. Deterministic (pure predicate over already-tracked turn fields) and
+      // normal-case-safe: any surfaced tool step, any rendered narrative line
+      // (`mirrorLines` — content the user actually saw), any reply, any captured
+      // text, or a delivered answer keeps the card. The `finalHtmlOverride`
+      // finalize path is only taken by the foreground handoff-clear (which fires
+      // on a delivered final answer), so this gate never contends with it.
+      const hollowGhostTurn = isHollowGhostCardOutcome({
+        replyCalled: turn.replyCalled,
+        labeledToolCount: turn.labeledToolCount,
+        mirrorLines: turn.mirrorLines,
+        capturedText: turn.capturedText,
+        lastReplyText: turn.lastReplyText,
+        finalAnswerEverDelivered: turn.finalAnswerEverDelivered,
+      })
+      if (CLEAR_STATUS_ON_COMPLETION || silentSentinelTurn || hollowGhostTurn) {
         try {
           await robustApiCall(
             () => bot.api.deleteMessage(chat, id),

--- a/telegram-plugin/tests/narrative-lane-golden.test.ts
+++ b/telegram-plugin/tests/narrative-lane-golden.test.ts
@@ -368,6 +368,103 @@ describe('narrative-lane golden — silent-sentinel card suppression (#4348)', (
   })
 })
 
+// ── #45 — HOLLOW activity card is SUPPRESSED (deleted, not finalized) ──────────
+// A turn injected into the session (typically a duplicate sub-agent handback
+// beat) adopts a per-turn activity card at turn START, then ends having done
+// ZERO surfaced tool work, never calling reply, delivering no final answer, and
+// emitting no captured/reply text. The card was posted but never got content —
+// the contentless `🤖 Agent · done · 0 tools · Ns` record. The #4348 sentinel
+// gate can't catch it (no NO_REPLY/HEARTBEAT_OK text to match), so the hollow
+// gate must DELETE it. A turn with ANY real content keeps its card.
+describe('narrative-lane golden — hollow-ghost card suppression (#45)', () => {
+  // Same open-then-stamp shape as the #4348 suite: open the feed card on a
+  // fresh (working) turn, then set the turn's terminal outcome and clear.
+  async function openThenClear(over: Partial<CurrentTurn>) {
+    const { lane, calls } = makeLane()
+    const turn = makeLaneTurn(lane)
+    lane.showNarrativeStep(turn, 'Doing the work now')
+    await turn.activityInFlight
+    const cardId = turn.activityMessageId
+    expect(cardId).not.toBeNull()
+    Object.assign(turn, over)
+    lane.clearActivitySummary(turn)
+    await settle()
+    return { calls, cardId, turn }
+  }
+
+  it('genuinely hollow turn (0 tools, no reply, no text, no narration): DELETES the card, no done edit', async () => {
+    // The exact #45 ghost-reply signature Ken reported: a card opened by the
+    // liveness timer that stayed contentless — `mirrorLines` EMPTY. FAILS
+    // pre-fix: clearActivitySummary finalizes a contentless `done · 0 tools`
+    // card with an editMessageText instead of deleting it.
+    //
+    // `mirrorLines: []` is set explicitly: `openThenClear` opens the card via
+    // `showNarrativeStep`, which pushes a line into `mirrorLines`; resetting it
+    // to empty here isolates Ken's real signature (card open via the timer, no
+    // surfaced narration) from the narration-only case pinned below.
+    const { calls, cardId, turn } = await openThenClear({
+      replyCalled: false,
+      labeledToolCount: 0,
+      mirrorLines: [],
+      capturedText: [],
+      lastReplyText: '',
+      finalAnswerEverDelivered: false,
+    })
+    expect(calls.filter((c) => c.method === 'deleteMessage' && c.message_id === cardId)).toHaveLength(1)
+    expect(calls.filter((c) => c.method === 'editMessageText' && c.message_id === cardId)).toHaveLength(0)
+    // Tracking released so a late render / superseded-prior finalize can't
+    // resurrect the card.
+    expect(turn.activityMessageId).toBeNull()
+  })
+
+  it('a narration-only turn (a rendered mirror line, 0 tools/reply/text) KEEPS its card (edit, no delete)', async () => {
+    // The regression the edit-flood-fuse pin
+    // (activity-drain-fuse-drop-not-failure.test.ts "a terminal card render is
+    // never shed") protects, pinned here in the fix's own suite: a turn that
+    // surfaced a `showNarrativeStep` line the user SAW is legitimate content —
+    // NOT Ken's empty ghost card — so the card must FINALIZE, never be deleted.
+    // `openThenClear` already surfaced "Doing the work now" into `mirrorLines`;
+    // we deliberately do NOT reset it, so the hollow gate must keep the card.
+    const { calls, cardId } = await openThenClear({
+      replyCalled: false,
+      labeledToolCount: 0,
+      capturedText: [],
+      lastReplyText: '',
+      finalAnswerEverDelivered: false,
+    })
+    expect(calls.filter((c) => c.method === 'editMessageText' && c.message_id === cardId).length)
+      .toBeGreaterThanOrEqual(1)
+    expect(calls.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
+  })
+
+  it('a turn that did surfaced tool work is NOT hollow — its card FINALIZES (edit, no delete)', async () => {
+    // The guarantee the fix must not break: a card carrying a real `✓ N steps`
+    // body stays as a record even when the turn never replied.
+    const { calls, cardId } = await openThenClear({
+      replyCalled: false,
+      labeledToolCount: 3,
+      capturedText: [],
+      lastReplyText: '',
+      finalAnswerEverDelivered: false,
+    })
+    expect(calls.filter((c) => c.method === 'editMessageText' && c.message_id === cardId).length)
+      .toBeGreaterThanOrEqual(1)
+    expect(calls.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
+  })
+
+  it('a turn that delivered a final answer keeps its card (edit, no delete)', async () => {
+    const { calls, cardId } = await openThenClear({
+      replyCalled: true,
+      labeledToolCount: 0,
+      lastReplyText: 'The three services are all green.',
+      finalAnswerEverDelivered: true,
+    })
+    expect(calls.filter((c) => c.method === 'editMessageText' && c.message_id === cardId).length)
+      .toBeGreaterThanOrEqual(1)
+    expect(calls.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
+  })
+})
+
 // ── THREE-MODULE cross-surface dedup (Amendment 1) ────────────────────────
 // The REAL P4-A handleSessionEvent turn-flush, with the REAL P4-B lane wired
 // into its deps, records the delivered answer into ONE OutboundDedupCache;

--- a/telegram-plugin/tests/turn-flush-safety.test.ts
+++ b/telegram-plugin/tests/turn-flush-safety.test.ts
@@ -21,6 +21,7 @@ import {
   isCompositeSilentNoise,
   endsWithSilentMarker,
   isSilentSentinelCardOutcome,
+  isHollowGhostCardOutcome,
   isTurnFlushSafetyEnabled,
   selectFlushDeliveryText,
   FLUSH_SUBSTANTIVE_MIN_CHARS,
@@ -974,5 +975,71 @@ describe('isSilentSentinelCardOutcome (#4348)', () => {
 
   it('a genuinely empty dark turn (no reply, no text) is NOT a sentinel', () => {
     expect(isSilentSentinelCardOutcome({ ...base })).toBe(false)
+  })
+})
+
+describe('isHollowGhostCardOutcome (#45)', () => {
+  const base = {
+    replyCalled: false,
+    labeledToolCount: 0,
+    mirrorLines: [] as string[],
+    capturedText: [] as string[],
+    lastReplyText: '',
+    finalAnswerEverDelivered: false,
+  }
+
+  it('the ghost-reply signature — zero tools, no reply, no text, no narration — IS hollow', () => {
+    // The exact #45 condition the sentinel gate misses (no NO_REPLY text to
+    // match): the card adopted at turn start (liveness timer) never got any
+    // content — mirrorLines empty, no tool, no reply, no text.
+    expect(isHollowGhostCardOutcome({ ...base })).toBe(true)
+  })
+
+  it('a narration-only turn (a rendered mirror line, zero tools/reply/text) is NOT hollow', () => {
+    // The blocker this fix closes: a turn that surfaced a `showNarrativeStep`
+    // ("Doing the work now") but did no labeled tool work, never replied, and
+    // emitted no captured/reply text pushes a line into `mirrorLines`. That is
+    // real content the user saw in the card — the card must be KEPT, not deleted.
+    // This is the exact scenario the pre-existing edit-flood-fuse pin
+    // (activity-drain-fuse-drop-not-failure.test.ts "a terminal card render is
+    // never shed") protects.
+    expect(
+      isHollowGhostCardOutcome({ ...base, mirrorLines: ['Doing the work now'] }),
+    ).toBe(false)
+  })
+
+  it('whitespace-only mirror lines do NOT rescue the card — still hollow', () => {
+    // Symmetric with the capturedText/lastReplyText blank guards: a mirrorLines
+    // array of only blank strings surfaced nothing visible, so it stays hollow.
+    expect(isHollowGhostCardOutcome({ ...base, mirrorLines: ['   ', '\n'] })).toBe(true)
+  })
+
+  it('whitespace-only captured / reply text still counts as hollow', () => {
+    expect(isHollowGhostCardOutcome({ ...base, capturedText: ['   ', '\n'] })).toBe(true)
+    expect(isHollowGhostCardOutcome({ ...base, lastReplyText: '   ' })).toBe(true)
+  })
+
+  it('a delivered final answer keeps the card — never hollow', () => {
+    expect(isHollowGhostCardOutcome({ ...base, finalAnswerEverDelivered: true })).toBe(false)
+  })
+
+  it('any surfaced tool work keeps the card — the ✓ N steps body is real', () => {
+    expect(isHollowGhostCardOutcome({ ...base, labeledToolCount: 1 })).toBe(false)
+  })
+
+  it('a reply-called turn is never hollow (sentinel gate owns dropped sentinels)', () => {
+    expect(isHollowGhostCardOutcome({ ...base, replyCalled: true })).toBe(false)
+  })
+
+  it('captured terminal text keeps the card (not hollow)', () => {
+    expect(
+      isHollowGhostCardOutcome({ ...base, capturedText: ['Here is the answer.'] }),
+    ).toBe(false)
+  })
+
+  it('non-blank last reply text keeps the card (not hollow)', () => {
+    expect(
+      isHollowGhostCardOutcome({ ...base, lastReplyText: 'The three services are green.' }),
+    ).toBe(false)
   })
 })

--- a/telegram-plugin/turn-flush-safety.ts
+++ b/telegram-plugin/turn-flush-safety.ts
@@ -215,6 +215,103 @@ export function isSilentSentinelCardOutcome(input: SilentSentinelCardInput): boo
 }
 
 /**
+ * Inputs for {@link isHollowGhostCardOutcome} — the ending-turn fields the
+ * hollow-card gate reads. A strict superset of the silent-sentinel inputs plus
+ * `labeledToolCount` (the deterministic surfaced-tool total). All are already
+ * tracked on the gateway's `CurrentTurn`; passed as a plain struct so the
+ * decision stays a pure, unit-testable core.
+ */
+export interface HollowGhostCardInput {
+  /** True when the model called `reply` / `stream_reply` at least once. */
+  replyCalled: boolean
+  /**
+   * Count of surfaced (non-suppressed) tool steps this turn
+   * (`CurrentTurn.labeledToolCount`) — the same source that drives the card's
+   * `✓ N steps` total and the `tools=` lifecycle field. Zero means the turn did
+   * no surfaced tool work, so the card has no step body to record.
+   */
+  labeledToolCount: number
+  /**
+   * Rendered narrative/mirror lines surfaced into the activity card this turn
+   * (`CurrentTurn.mirrorLines`) — every `showNarrativeStep` appends one via
+   * `appendActivityLabel`. A NON-EMPTY array means the user saw real narration
+   * content in the card (e.g. "Doing the work now"), so the card is a legitimate
+   * record even with zero tool steps and no reply — it is NOT the empty ghost
+   * card. This is the axis that separates Ken's #45 bug (a card opened by the
+   * liveness timer that stayed contentless — `🤖 Agent · done · 0 tools · 40s`,
+   * `mirrorLines` empty) from a narration-only turn (a rendered step, no tool).
+   */
+  mirrorLines: string[]
+  /**
+   * Raw assistant text blocks accumulated across the turn
+   * (`CurrentTurn.capturedText`) — the turn-flush classifies the same source.
+   */
+  capturedText: string[]
+  /**
+   * The most-recent `reply` / `stream_reply` `input.text` this turn
+   * (`CurrentTurn.lastReplyText`); empty when the reply tool was never called.
+   */
+  lastReplyText: string
+  /**
+   * A SUBSTANTIVE final answer reached the user at some point this turn
+   * (`CurrentTurn.finalAnswerEverDelivered`). When true the card is a legitimate
+   * record beside a delivered answer and is NEVER suppressed.
+   */
+  finalAnswerEverDelivered: boolean
+}
+
+/**
+ * Decide whether an ending turn produced a genuinely HOLLOW activity card — the
+ * `#45` ghost-reply condition — so the gateway can DELETE the card instead of
+ * finalizing it to a contentless `🤖 Agent · done · 0 tools · Ns` record.
+ *
+ * The symptom (#45): a turn injected into the session (typically a duplicate
+ * sub-agent handback beat) adopts a per-turn activity card at turn START, then
+ * ends having done ZERO surfaced tool work, never calling reply, delivering no
+ * final answer, and emitting no captured terminal text. The card was already
+ * posted but never gets any content — the gateway already WARNs on this exact
+ * signature (`ghost-reply detected — turn ended with zero outbound messages …
+ * replyCalled=false capturedText=empty`) but does not suppress the empty card.
+ *
+ * This is the complement of {@link isSilentSentinelCardOutcome}: that gate
+ * handles a turn whose outcome was an INTENTIONAL silent sentinel (a NO_REPLY /
+ * HEARTBEAT_OK the model actually emitted, which reaches `lastReplyText` /
+ * `capturedText`). A hollow ghost turn emitted NOTHING at all — no sentinel text
+ * for the sentinel gate to match — so `decideTurnFlush` classifies it as
+ * `empty-text`, not `silent-marker`, and the sentinel gate returns false (see
+ * the `isSilentSentinelCardOutcome` test "a genuinely empty dark turn … is NOT a
+ * sentinel"). Both gates share the same conservative floor.
+ *
+ * Conservative by construction — every guarantee that keeps a real card is an
+ * early false:
+ *   - `finalAnswerEverDelivered` — a substantive answer reached the user; the
+ *     card is a legitimate record.
+ *   - `replyCalled` — the model called reply (even a dropped sentinel-only reply
+ *     is the SENTINEL gate's job, not this one); never treated as hollow here.
+ *   - `labeledToolCount > 0` — the turn did surfaced tool work, so the card
+ *     carries a real `✓ N steps` body worth keeping.
+ *   - any non-blank `mirrorLines` — the turn surfaced narrative content into the
+ *     card that the user saw (a `showNarrativeStep`), so the card is a real
+ *     record, NOT the contentless ghost card. This is the axis that keeps a
+ *     narration-only turn (rendered step, zero tools/reply/text) from being
+ *     mistaken for Ken's empty `done · 0 tools` card, whose `mirrorLines` is
+ *     empty because the card was opened by the liveness timer, not narration.
+ *   - any non-blank `capturedText` / `lastReplyText` — the turn produced terminal
+ *     text; not hollow (and, if it is silent-sentinel noise, the sentinel gate
+ *     already suppresses it).
+ * Only a turn that is empty on ALL of those axes is hollow.
+ */
+export function isHollowGhostCardOutcome(input: HollowGhostCardInput): boolean {
+  if (input.finalAnswerEverDelivered) return false
+  if (input.replyCalled) return false
+  if (input.labeledToolCount > 0) return false
+  if (Array.isArray(input.mirrorLines) && input.mirrorLines.join('').trim().length > 0) return false
+  if (Array.isArray(input.capturedText) && input.capturedText.join('').trim().length > 0) return false
+  if (typeof input.lastReplyText === 'string' && input.lastReplyText.trim().length > 0) return false
+  return true
+}
+
+/**
  * Substantive-answer floor (chars, trimmed). Mirrors
  * `final-answer-detect.ts` `FINAL_ANSWER_MIN_CHARS` and
  * `hooks/silent-end-scan.mjs` — the same bar the codebase uses everywhere to


### PR DESCRIPTION
## The bug (#45)

A turn injected into the agent session (typically a **duplicate sub-agent handback beat**) adopts a per-turn activity card at turn **START** (`queued card adopted` / handback adoption). If that turn then ends having done **zero** surfaced tool work, never calling reply, delivering no final answer, and emitting no captured/reply text — the legitimate "answer a duplicate handback with `NO_REPLY`" case — the card was already posted but never gets content. The user sees a hollow `🤖 Agent · done · 0 tools · Ns` record with no task label and no body.

The gateway **already detects** this exact signature (the `ghost-reply detected — turn ended with zero outbound messages … replyCalled=false capturedText=empty (#45)` WARN in `stream-render.ts`) but only logs it.

### Why the existing #4348 gate misses it

`clearActivitySummary` (narrative-lane.ts) already deletes cards whose outcome was an **intentional** silent sentinel via `isSilentSentinelCardOutcome`. But a genuinely hollow turn emits **no sentinel text** — so `decideTurnFlush` classifies it `empty-text` (not `silent-marker`) and the sentinel gate returns false. Its own test spells this out: *"a genuinely empty dark turn (no reply, no text) is NOT a sentinel"* → the empty card was never suppressed.

## The fix — a deterministic sibling to #4348

- **New pure predicate `isHollowGhostCardOutcome`** (`turn-flush-safety.ts`): true only when `replyCalled=false` AND `labeledToolCount=0` AND no captured text AND no reply text AND no delivered final answer — the exact #45 condition. Every keep-the-card guarantee is an early `false`, so any real tool work / reply / captured text / delivered answer keeps the card.
- **Wired into `clearActivitySummary`'s delete gate** beside the #4348 sentinel check, so whichever path finalizes the card — the turn's own turn_end or the next turn's `superseded`-prior cleanup — **deletes** the hollow card instead of painting a `done` record. Reuses the existing in-flight await, reap-race-scoped durable-record drop, and status-pin release.
- **At the #45 detection site** (`stream-render.ts`) it calls `clearActivitySummary(turn)` when the hollow predicate holds, so the ghost turn deletes its own card at its own turn_end rather than waiting for a superseding turn. Idempotent (nulls `activityMessageId`); race-safe — the adopted card is the turn's own, no other live turn adopts it.

### Why this approach

Centralizing the delete in `clearActivitySummary` (rather than a raw `deleteMessage` at the detection site) reuses the single finalize/delete seam that already handles the in-flight-render await, the `superseded`-prior race the log warns about, the id-scoped durable-record drop, and the pin release. The predicate is the same conservative shape as #4348.

## Tests (assert the outcome; fail red without the fix)

- `isHollowGhostCardOutcome` unit tests (`turn-flush-safety.test.ts`).
- narrative-lane golden (`narrative-lane-golden.test.ts`): a genuinely hollow turn **DELETES** the card with no `done` edit and leaves **no surviving card**; a tool-work turn and a delivered-answer turn still **FINALIZE** their card.

**Red-without-fix proof:** with the `|| hollowGhostTurn` gate reverted, the hollow-ghost delete test fails `AssertionError: expected [] to have a length of 1 but got +0` (the card is finalized, not deleted). Restored → green.

## Verification

- `env -u SWITCHROOM_SELF_IMPROVE npx vitest run tests/turn-flush-safety.test.ts tests/narrative-lane-golden.test.ts` → **105 passed**
- `tests/stream-render-golden.test.ts tests/status-surface-log.test.ts` → **33 passed**
- `npm run lint` (root) → **clean** (incl. `tsc --noEmit`, gateway-line-ratchet, bot-api-wrapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
