### PR TITLE
fix(status-pin): unify pin-rights model, drop stale-sweep proactive precheck

### DIFF
--- a/scripts/check-status-pin-single-path.mjs
+++ b/scripts/check-status-pin-single-path.mjs
@@ -52,6 +52,19 @@
  *  6. single-wiring    Only one file outside the modules themselves may call
  *                      `runStatusPinReconcile(` / `executePinLeg(` — a second
  *                      composition is a second pin subsystem.
+ *  7. single-rights-detector  The pin-rights error class has ONE definition
+ *                      (`isPinRightsError` in status-pin.ts). A SECOND exported
+ *                      `isPinRightsError` anywhere else is a forked detector that
+ *                      drifts — exactly the stale-pin-sweep duplicate this guard
+ *                      was extended after deleting. No marker escape. (Named
+ *                      folds with OTHER names that check "not enough rights" for
+ *                      their own purpose are deliberately untouched.)
+ *  8. sweep-no-getchatmember  A `getChatMember(` call inside the stale-pin-sweep
+ *                      files is banned: the sweep classifies rights REACTIVELY
+ *                      from a real Telegram 400. A proactive precheck wired
+ *                      against the chat-lock-wrapped (botInfo-less) bot silently
+ *                      forfeited every group cursor. `getChatMember` elsewhere
+ *                      (e.g. the reaction admin lookup) is fine. No marker escape.
  *
  * Markers
  * -------
@@ -232,6 +245,49 @@ export function findViolations({ path, source, allow }) {
           'bug. There is one wiring, in telegram-plugin/gateway/gateway.ts; use ' +
           'its `reconcileStatusPin(...)`. If a genuinely separate subsystem is ' +
           `intended, add the file under \`single-wiring\` in ${ALLOWLIST_PATH}.`,
+      })
+    }
+
+    // 7. single rights-detector — ONE `isPinRightsError` definition, in
+    //    status-pin.ts. A second EXPORTED definition anywhere else is a forked
+    //    detector that drifts (the deleted stale-pin-sweep copy). No escape.
+    if (
+      path !== DECISION &&
+      /\bexport\s+(?:async\s+)?(?:function|const|let|var)\s+isPinRightsError\b/.test(line)
+    ) {
+      out.push({
+        rule: 'single-rights-detector',
+        at,
+        line: line.trim(),
+        fix:
+          'The pin-rights error class has exactly ONE detector: ' +
+          '`isPinRightsError` in telegram-plugin/status-pin.ts. A second exported ' +
+          'copy is a fork that drifts from the source of truth (the reason the ' +
+          'stale-pin-sweep duplicate was deleted). Import it from ' +
+          "'../status-pin.js' instead of re-defining it. A fold with a DIFFERENT " +
+          'name for a different purpose is fine — only a second `isPinRightsError` ' +
+          'symbol is banned.',
+      })
+    }
+
+    // 8. no proactive getChatMember precheck in the stale-pin sweep — rights are
+    //    classified REACTIVELY from a real Telegram 400. A precheck against the
+    //    chat-lock-wrapped (botInfo-less) bot forfeited every group cursor
+    //    without a single unpin. getChatMember elsewhere is legitimate. No escape.
+    if (path.includes('stale-pin-sweep') && /\bgetChatMember\s*\(/.test(line)) {
+      out.push({
+        rule: 'sweep-no-getchatmember',
+        at,
+        line: line.trim(),
+        fix:
+          'The stale-pin sweep must NOT re-introduce a proactive getChatMember ' +
+          'rights precheck. It runs against the chat-lock-wrapped bot, which ' +
+          'carries only `.api` (no `.botInfo`), so a precheck always resolved to ' +
+          '"no rights" and forfeited every group cursor without ever attempting ' +
+          'an unpin. Rights are classified REACTIVELY: attempt the unpin and fold ' +
+          "Telegram's honest `400 not enough rights` via `isPinRightsError`. " +
+          '(getChatMember in non-sweep code — e.g. the reaction admin lookup — is ' +
+          'unaffected by this rule.)',
       })
     }
   }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -9055,6 +9055,11 @@ const stalePinSweeper: StalePinSweeper = createGatewayStalePinSweeper({
       ? loadStatusPins(STATUS_PIN_STORE_PATH, statusPinStoreFs)
       : [],
   eligible: () => stalePinSweepEligible,
+  // Share the live path's per-process pin-rights negative cache so the sweep
+  // and executePinLeg agree on rights-less chats (D3): the sweep skips a chat
+  // the live path already proved rights-less, and feeds its own reactive
+  // discoveries back so the live path skips too.
+  rightsCache: statusPinRightsCache,
   store: { path: STALE_PIN_SWEEP_STORE_PATH, fs: sweepStoreFs },
   // Per-deployment override only. UNSET (the normal case) means "take the
   // standing policy" — UNPIN_ALL_FORUM_TOPIC_ENABLED in stale-pin-sweep.ts,
@@ -17630,6 +17635,10 @@ async function refreshPinnedBanner(reason: string): Promise<void> {
       onError: (phase, err) => {
         process.stderr.write(`telegram gateway: banner ${phase} failed (${reason}): ${err}\n`)
       },
+      // Share the one per-process pin-rights negative cache with the status-pin
+      // path and the stale-pin sweep (D5): the banner skips a chat already known
+      // rights-less and records/clears its own pin-verb discoveries there.
+      rightsCache: statusPinRightsCache,
       // Durable pin persistence into the SHARED status-pin store (distinct
       // `banner:` pinKey). persist-BEFORE-pin ordering: pending() lands before
       // the pinChatMessage call so a crash in that window is recoverable by the

--- a/telegram-plugin/gateway/narrative-lane.ts
+++ b/telegram-plugin/gateway/narrative-lane.ts
@@ -455,10 +455,18 @@ export function createNarrativeLane(deps: NarrativeLaneDeps) {
             // stays in view when the feed scrolls past. Keyed to the same
             // status-key the canonical turn-end (purgeReactionTracking) unpins.
             // Fire-and-forget; the single-owner reconcile keeps state consistent.
+            // Pass `thread` as the 4th arg so the persisted row keeps the forum
+            // topic (D4): without it a forum-topic foreground card orphaned by a
+            // crash lands a threadId-less row, and the sweep cannot aim
+            // `unpinAllForumTopicMessages` at the right topic. Mirrors the worker
+            // feed's `reconcilePin` (gateway.ts). It does NOT change the pinKey —
+            // `statusKey(chat, thread)` already folds the topic into the key; the
+            // 4th arg only threads the topic into the claim + durable row.
             void reconcileStatusPin(
               `fg:${statusKey(chat, thread)}`,
               chat,
               { pinned: true, messageId: sent.message_id },
+              thread,
             )
           } else {
             const id = turn.activityMessageId

--- a/telegram-plugin/gateway/stale-pin-sweep-wiring.ts
+++ b/telegram-plugin/gateway/stale-pin-sweep-wiring.ts
@@ -51,9 +51,7 @@ export interface StalePinSweepBotSeam {
       ) => Promise<unknown>
       unpinChatMessage: (chatId: string, messageId: number) => Promise<unknown>
       unpinAllForumTopicMessages: (chatId: string, threadId: number) => Promise<unknown>
-      getChatMember: (chatId: string, userId: number) => Promise<unknown>
     }
-    botInfo?: { id?: number }
   }
   /** The gateway's retry/telemetry envelope (`robustApiCall`). */
   call: <T>(fn: () => Promise<T>, meta: { chat_id: string; verb: string }) => Promise<T>
@@ -68,6 +66,14 @@ export interface StalePinSweepWiring {
   loadPinRows: () => PersistedStatusPin[]
   /** Mutex-won AND bot-constructed. False ⇒ the drain must not write. */
   eligible: () => boolean
+  /**
+   * The SHARED per-process pin-rights negative cache (status-pin.ts
+   * `PinRightsCache`), unifying the sweep and the live status-pin path on which
+   * chats are rights-less. Only `isBlocked`/`block` are used here; the live
+   * path owns `clear` (on a successful explicit pin) and boot owns the reset.
+   * Optional — undefined ⇒ the sweep relies purely on its reactive classifier.
+   */
+  rightsCache?: { isBlocked: (chatId: string) => boolean; block: (chatId: string) => boolean }
   store: { path: string; fs: SweepStoreFsSeam }
   /** Per-deployment override of `UNPIN_ALL_FORUM_TOPIC_ENABLED`; undefined =
    *  take the standing policy (the wholesale topic drain stays OFF). */
@@ -168,18 +174,16 @@ export function createGatewayStalePinSweeper(w: StalePinSweepWiring): StalePinSw
         chat_id: chatId,
         verb: 'stale-pin-sweep.unpin-all-topic',
       }),
-    // Rights are checked before ANY write in a group. Telegram is HONEST about
-    // missing pin rights (400 "not enough rights to manage pinned messages"),
-    // but the precheck keeps a rights-less bot from emitting doomed traffic.
-    canPinInChat: async (chatId) => {
-      const self = bot().botInfo?.id
-      if (self == null) return false
-      const member = (await call(() => bot().api.getChatMember(chatId, self), {
-        chat_id: chatId,
-        verb: 'stale-pin-sweep.get-chat-member',
-      })) as { status?: string; can_pin_messages?: boolean } | undefined
-      return member?.status === 'administrator' && member.can_pin_messages === true
-    },
+    // No proactive rights precheck. The old `getChatMember` precheck read
+    // `bot().botInfo?.id`, but the sweep runs against the chat-lock-wrapped bot
+    // (`wrapBot({ api: bot.api })`), which carries only `.api` — `.botInfo` was
+    // always undefined, so `self` was always null and every group precheck
+    // returned false, forfeiting every group cursor without a single unpin. The
+    // sweep now relies SOLELY on its reactive classifier: it attempts the unpin
+    // and classifies Telegram's honest `400 "not enough rights"` via
+    // `isPinRightsError`. Telegram is authoritative about pin rights; a precheck
+    // could only ever be redundant with (and, wired against the wrong bot,
+    // wrong about) that answer.
     recordedPinIds: (chatId, threadId) => {
       try {
         return recordedPinIdsFor(w.loadPinRows(), chatId, threadId)
@@ -200,6 +204,12 @@ export function createGatewayStalePinSweeper(w: StalePinSweepWiring): StalePinSw
         log,
       }),
     eligible: w.eligible,
+    rightsBlocked: w.rightsCache ? (chatId) => w.rightsCache!.isBlocked(chatId) : undefined,
+    recordRightsBlock: w.rightsCache
+      ? (chatId) => {
+          w.rightsCache!.block(chatId)
+        }
+      : undefined,
     sleep: w.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms))),
     now,
     store: w.store,

--- a/telegram-plugin/gateway/stale-pin-sweep.test.ts
+++ b/telegram-plugin/gateway/stale-pin-sweep.test.ts
@@ -22,7 +22,6 @@ import {
   createStalePinSweeper,
   isNothingToUnpinError,
   isPeerFloodError,
-  isPinRightsError,
   mayUnpinAllForumTopic,
   retryAfterSeconds,
   unexpiredStoreRepinIds,
@@ -38,6 +37,10 @@ import {
   type SweepCursor,
   type SweepStoreFsSeam,
 } from './stale-pin-sweep-store.js'
+// The sweep now imports its rights detector from the single source of truth
+// (status-pin.ts) — no second copy. The negative cache it shares with the live
+// pin path is that module's `PinRightsCache` (D3).
+import { isPinRightsError, PinRightsCache } from '../status-pin.js'
 
 // Synthetic ids (check-no-pii-secrets): DMs positive, groups negative.
 const DM = '900000001'
@@ -84,7 +87,10 @@ interface FakeOpts {
    * call-counted `popped` and an observation-counted `popped` disagree.
    */
   unpinAllTopicRemoves?: number[]
-  canPin?: boolean
+  /** Errors to throw from `unpinChatMessage`, consumed in order (null = normal).
+   *  The sweep classifies pin rights REACTIVELY from a real Telegram 400 here —
+   *  there is no proactive precheck to model. */
+  unpinErrors?: (unknown | null)[]
   /** Throws from `getChat`, consumed in order (null = normal read). */
   getChatErrors?: (unknown | null)[]
 }
@@ -93,6 +99,7 @@ function fakeChat(o: FakeOpts) {
   const stack = [...o.stack]
   const calls: string[] = []
   const pinErrors = [...(o.pinErrors ?? [])]
+  const unpinErrors = [...(o.unpinErrors ?? [])]
   const unpinAllErrors = [...(o.unpinAllErrors ?? [])]
   const getChatErrors = [...(o.getChatErrors ?? [])]
   return {
@@ -115,6 +122,10 @@ function fakeChat(o: FakeOpts) {
     },
     unpin: async (_chatId: string, messageId: number) => {
       calls.push(`unpin:${messageId}`)
+      // A real Telegram rejection (e.g. `400 not enough rights`) is injected
+      // here so the sweep's REACTIVE rights classifier is what gets exercised.
+      const err = unpinErrors.shift()
+      if (err != null) throw err
       // ALWAYS resolves ok:true — the whole point.
       if (o.unpinIsSilentNoop === true) return { ok: true }
       const at = stack.indexOf(messageId)
@@ -134,10 +145,6 @@ function fakeChat(o: FakeOpts) {
         }
       }
       return { ok: true }
-    },
-    canPinInChat: async () => {
-      calls.push('getChatMember')
-      return o.canPin !== false
     },
   }
 }
@@ -165,6 +172,9 @@ function harness(
     allowUnpinAllForumTopic?: boolean
     /** Ids the gateway is on record as having pinned (the group drain's list). */
     recordedPinIds?: number[]
+    /** D3: shared per-process pin-rights negative cache seam. */
+    rightsBlocked?: (chatId: string) => boolean
+    recordRightsBlock?: (chatId: string) => void
   },
 ): Harness {
   const fake = fakeChat(o)
@@ -183,10 +193,11 @@ function harness(
     pinSilent: costed(fake.pinSilent),
     unpin: costed(fake.unpin),
     unpinAllForumTopicMessages: costed(fake.unpinAllForumTopicMessages),
-    canPinInChat: costed(fake.canPinInChat),
     protectedMessageIds: () => o.protectedMessageIds ?? [],
     recordedPinIds: () => o.recordedPinIds ?? [],
     eligible: () => o.eligible !== false,
+    rightsBlocked: o.rightsBlocked,
+    recordRightsBlock: o.recordRightsBlock,
     sleep: async (ms) => {
       sleeps.push(ms)
       if (o.clockAdvances !== false) clock += ms
@@ -552,8 +563,22 @@ describe('stale-pin sweep — forum topics', () => {
 // ─── group safety: rights + service-message spam ─────────────────────────────
 
 describe('stale-pin sweep — group safety', () => {
-  it('skips a group without pin rights WITHOUT writing anything', async () => {
-    const h = harness({ stack: [151, 152], canPin: false })
+  // The honest Telegram rejection a rights-less bot gets from EVERY pin verb.
+  const RIGHTS_400 = {
+    error_code: 400,
+    description: 'Bad Request: not enough rights to manage pinned messages in the chat',
+  }
+
+  it('ATTEMPTS the drain (no proactive precheck) and classifies a real 400 as rights', async () => {
+    // The pre-fix bug: a proactive getChatMember precheck against the wrapped
+    // (botInfo-less) bot always returned false, so a group forfeited WITHOUT a
+    // single unpin ever going out. The sweep must instead ATTEMPT the unpin and
+    // read Telegram's honest 400 — so `unpin:151` MUST appear in the call log.
+    const h = harness({
+      stack: [151, 152],
+      recordedPinIds: [151],
+      unpinErrors: [RIGHTS_400],
+    })
     const res = await createStalePinSweeper(h.deps).sweepTarget({
       chatId: GROUP,
       threadId: 5,
@@ -561,22 +586,31 @@ describe('stale-pin sweep — group safety', () => {
     })
 
     expect(res.status).toBe('skipped-no-rights')
-    expect(h.fake.calls).toEqual(['getChatMember']) // the precheck and nothing else
-    expect(h.fake.stack).toEqual([151, 152])
+    expect(h.fake.calls).toContain('unpin:151') // the drain was ATTEMPTED
+    expect(h.fake.stack).toEqual([151, 152]) // the rejected unpin popped nothing
   })
 
-  it('treats a throwing rights check as "no rights"', async () => {
-    const h = harness({ stack: [161] })
-    h.deps.canPinInChat = async () => {
-      throw new Error('Bad Request: chat not found')
+  it('increments attempts and eventually FORFEITS a rights-less group via the reactive path (no infinite retry)', async () => {
+    const fs = memFs()
+    const path = '/state/stale-pin-sweep.json'
+    // Every boot: a fresh process attempts the recorded unpin, Telegram answers
+    // 400 not enough rights, the sweep records skipped-no-rights and bumps
+    // attempts. After SWEEP_MAX_ATTEMPTS boots the cursor forfeits and stops
+    // re-burning the pin-op budget — the bounded reactive path, no precheck.
+    let last = ''
+    for (let boot = 0; boot < SWEEP_MAX_ATTEMPTS + 1; boot++) {
+      const chat = fakeChat({ stack: [161], unpinErrors: [RIGHTS_400] })
+      const res = await sweeperOver(fs, path, chat, { recordedPinIds: [161] }).sweepTarget({
+        chatId: GROUP,
+      })
+      last = res.status
     }
-    const res = await createStalePinSweeper(h.deps).sweepTarget({
-      chatId: GROUP,
-      threadId: 5,
-      isForum: true,
-    })
-    expect(res.status).toBe('skipped-no-rights')
-    expect(h.fake.calls).toEqual([])
+    // The final boot is past the attempt budget: it forfeits instead of
+    // attempting yet another doomed unpin.
+    expect(last).toBe('forfeited')
+    const cursor = loadSweepCursors(path, fs).find((c) => c.chatId === GROUP)
+    expect(cursor?.attempts).toBe(SWEEP_MAX_ATTEMPTS)
+    expect(cursor?.done).toBe(false)
   })
 
   it('NEVER pins in a group — a pin is the only op that emits a service message', async () => {
@@ -623,10 +657,74 @@ describe('stale-pin sweep — group safety', () => {
     expect(h.cursors().find((c) => c.chatId === GROUP)?.done).toBe(false)
   })
 
-  it('runs a DM sweep with NO rights precheck (getChatMember is meaningless there)', async () => {
+  it('runs a DM sweep straight into a drain (no rights gating whatsoever)', async () => {
     const h = harness({ stack: [181] })
-    await createStalePinSweeper(h.deps).sweepTarget({ chatId: DM })
+    const res = await createStalePinSweeper(h.deps).sweepTarget({ chatId: DM })
+    // No proactive precheck anywhere: the DM goes straight to the repin+unpin
+    // drain and clears the orphan.
     expect(h.fake.calls).not.toContain('getChatMember')
+    expect(res.status).toBe('drained')
+    expect(h.fake.stack).toEqual([])
+  })
+})
+
+// ─── D3: shared per-process pin-rights negative cache ─────────────────────────
+
+describe('stale-pin sweep — shared PinRightsCache (D3)', () => {
+  const RIGHTS_400 = {
+    error_code: 400,
+    description: 'Bad Request: not enough rights to manage pinned messages in the chat',
+  }
+
+  it('SKIPS a group the live path already blocked, without issuing any unpin', async () => {
+    const cache = new PinRightsCache()
+    cache.block(GROUP) // the live status-pin path already proved this chat rights-less
+    const h = harness({
+      stack: [201],
+      recordedPinIds: [201],
+      rightsBlocked: (c) => cache.isBlocked(c),
+      recordRightsBlock: (c) => {
+        cache.block(c)
+      },
+    })
+    const res = await createStalePinSweeper(h.deps).sweepTarget({ chatId: GROUP })
+
+    expect(res.status).toBe('skipped-no-rights')
+    // No doomed traffic: the shared cache short-circuited BEFORE any unpin.
+    expect(h.fake.calls.filter((c) => c.startsWith('unpin'))).toEqual([])
+  })
+
+  it('FEEDS the cache from its own reactive rights discovery so the live path skips too', async () => {
+    const cache = new PinRightsCache()
+    const h = harness({
+      stack: [202],
+      recordedPinIds: [202],
+      unpinErrors: [RIGHTS_400],
+      rightsBlocked: (c) => cache.isBlocked(c),
+      recordRightsBlock: (c) => {
+        cache.block(c)
+      },
+    })
+    const res = await createStalePinSweeper(h.deps).sweepTarget({ chatId: GROUP })
+
+    expect(res.status).toBe('skipped-no-rights')
+    expect(h.fake.calls).toContain('unpin:202') // it ATTEMPTED before classifying
+    expect(cache.isBlocked(GROUP)).toBe(true) // and recorded the block for the live path
+  })
+
+  it('does NOT skip a DM even when its chat id is in the cache (DMs are never rights-gated)', async () => {
+    const cache = new PinRightsCache()
+    cache.block(DM)
+    const h = harness({
+      stack: [203],
+      rightsBlocked: (c) => cache.isBlocked(c),
+      recordRightsBlock: (c) => {
+        cache.block(c)
+      },
+    })
+    const res = await createStalePinSweeper(h.deps).sweepTarget({ chatId: DM })
+    expect(res.status).toBe('drained')
+    expect(h.fake.stack).toEqual([])
   })
 })
 
@@ -945,7 +1043,6 @@ function sweeperOver(
     pinSilent: fake.pinSilent,
     unpin: fake.unpin,
     unpinAllForumTopicMessages: fake.unpinAllForumTopicMessages,
-    canPinInChat: fake.canPinInChat,
     protectedMessageIds: () => [],
     recordedPinIds: () => opts.recordedPinIds ?? [],
     eligible: () => true,
@@ -1045,7 +1142,7 @@ describe('stale-pin sweep — re-drain after the boot-seed prune (#3953)', () =>
     const path = '/state/stale-pin-sweep.json'
 
     // Session 1: the one recorded orphan is reaped, obligation discharged.
-    const s1 = await sweeperOver(fs, path, fakeChat({ stack: [77], canPin: true }), {
+    const s1 = await sweeperOver(fs, path, fakeChat({ stack: [77] }), {
       recordedPinIds: [77],
     }).sweepTarget({ chatId: GROUP })
     expect(s1.status).toBe('drained')

--- a/telegram-plugin/gateway/stale-pin-sweep.ts
+++ b/telegram-plugin/gateway/stale-pin-sweep.ts
@@ -132,6 +132,12 @@ import {
   upsertSweepCursor,
   SWEEP_MAX_ATTEMPTS,
 } from './stale-pin-sweep-store.js'
+// The single source of truth for the pin-rights concept. The sweep classifies
+// a rights failure REACTIVELY — it attempts the unpin and reads Telegram's
+// honest `400 "not enough rights"` — using the same detector the live status-pin
+// path uses, so the two paths can never disagree on what "no pin rights" means
+// (this file must stay Telegram-import-free; status-pin.ts is dependency-free).
+import { isPinRightsError } from '../status-pin.js'
 
 // ─── Rate gates (operator-mandated; do not inline these numbers) ─────────────
 
@@ -401,17 +407,6 @@ export function isPeerFloodError(err: unknown): boolean {
 }
 
 /**
- * The bot is not allowed to manage pins here. Verified live: a bot without
- * `can_pin_messages` gets `400 "not enough rights to manage pinned messages in
- * the chat"` from EVERY pin method — an honest, stable rejection, unlike the
- * silent-success unpin. So a rights failure is terminal for the chat, not a
- * retry.
- */
-export function isPinRightsError(err: unknown): boolean {
-  return description(err).includes('not enough rights')
-}
-
-/**
  * `unpinChatMessage` with NO `message_id` on an EMPTY stack answers `400
  * "message to unpin not found"`. That is a real, positive termination signal —
  * one of the very few honest answers in this API surface — so we use it as a
@@ -566,10 +561,18 @@ export interface StalePinSweepDeps {
   /** `unpinAllForumTopicMessages(chat, thread)` — the one topic-scoped verb. */
   unpinAllForumTopicMessages: (chatId: string, threadId: number) => Promise<unknown>
   /**
-   * `getChatMember(chat, self)` folded to "is administrator AND can_pin_messages".
-   * Consulted BEFORE any write in a group. A throw is treated as "no rights".
+   * The SHARED per-process pin-rights negative cache (status-pin.ts
+   * `PinRightsCache`), so the sweep and the live status-pin path agree on which
+   * chats are rights-less. `rightsBlocked` is TRUE only when a REAL Telegram
+   * `400 "not enough rights"` was already observed (by the live pin path or an
+   * earlier sweep) — never a proactive network probe — so consulting it cannot
+   * resurrect the deleted `getChatMember` precheck. When it returns true the
+   * sweep skips the doomed group drain; `recordRightsBlock` feeds the cache from
+   * the sweep's OWN reactive rights discoveries. Both optional: undefined ⇒ the
+   * sweep relies purely on its reactive classifier.
    */
-  canPinInChat: (chatId: string) => Promise<boolean>
+  rightsBlocked?: (chatId: string) => boolean
+  recordRightsBlock?: (chatId: string) => void
   /**
    * Message ids in this chat that must be RE-PINNED once the drain finishes:
    * live in-memory claims plus the deliberately-retained store rows (unexpired
@@ -1126,24 +1129,32 @@ export function createStalePinSweeper(deps: StalePinSweepDeps): StalePinSweeper 
       }
     }
 
-    // RIGHTS PRECHECK, before ANY write, in every group. A bot without
-    // can_pin_messages is honestly rejected by Telegram, but burning a rejected
-    // write per orphan against the flood ledger is pointless. DMs need no
-    // precheck — getChatMember is not meaningful there.
-    if (kind !== 'dm') {
-      let allowed = false
-      try {
-        allowed = await deps.canPinInChat(target.chatId)
-      } catch {
-        allowed = false
-      }
-      if (!allowed) {
-        cursor.attempts++
-        cursor.lastStatus = 'skipped-no-rights'
-        cursor.updatedAt = deps.now()
-        commit(cursor)
-        return { status: 'skipped-no-rights', popped: 0, issued: 0 }
-      }
+    // NO proactive rights precheck. A `getChatMember`-based precheck was
+    // DELETED (see below): the sweep runs against the chat-lock-wrapped bot,
+    // which carries only `.api` and no `.botInfo`, so `self` was always null,
+    // the precheck always returned false, and every group target forfeited at
+    // SWEEP_MAX_ATTEMPTS without a single unpin ever going out
+    // (`getChatMember` appeared 0× in a 35MB live gateway log). Rights are now
+    // classified REACTIVELY and only from a real Telegram `400 "not enough
+    // rights"`: each drain primitive attempts the unpin and folds that error to
+    // `{ kind: 'rights' }` via `classify`, returning `skipped-no-rights`. The
+    // attempt is counted below BEFORE the drain, so a genuinely rights-less
+    // chat still increments `attempts` on every boot and forfeits at
+    // SWEEP_MAX_ATTEMPTS — no infinite retry — while a chat the bot CAN pin in
+    // is no longer wrongly skipped.
+    //
+    // Same-process negative cache (D3): if the LIVE status-pin path (or an
+    // earlier sweep) already observed a REAL `400 not enough rights` for this
+    // chat, skip the doomed group drain rather than re-attempting it. This is
+    // NOT a network probe — it is fed only by observed rights failures — so it
+    // does not resurrect the deleted precheck. DMs are never rights-gated. The
+    // attempt is still counted so the cursor forfeits at SWEEP_MAX_ATTEMPTS.
+    if (kind !== 'dm' && deps.rightsBlocked?.(target.chatId) === true) {
+      cursor.attempts++
+      cursor.lastStatus = 'skipped-no-rights'
+      cursor.updatedAt = deps.now()
+      commit(cursor)
+      return { status: 'skipped-no-rights', popped: 0, issued: 0 }
     }
 
     cursor.attempts++
@@ -1195,6 +1206,11 @@ export function createStalePinSweeper(deps: StalePinSweepDeps): StalePinSweeper 
     cursor.lastStatus = result.status
     cursor.updatedAt = deps.now()
     commit(cursor)
+
+    // Feed the shared negative cache (D3): a reactive `skipped-no-rights` is a
+    // real observed `400 not enough rights`, so record it so the live pin path
+    // and later sweeps of this chat skip the doomed attempt too.
+    if (result.status === 'skipped-no-rights') deps.recordRightsBlock?.(target.chatId)
 
     // Restore the deliberately-retained pins the blind DM drain cleared.
     // Rate-gated like any other write; a failure is logged and never fatal.

--- a/telegram-plugin/slot-banner-driver.ts
+++ b/telegram-plugin/slot-banner-driver.ts
@@ -22,6 +22,11 @@
 
 import type { BannerState } from './slot-banner.js';
 import { decideBannerAction } from './slot-banner.js';
+// Shared rights model (D5): the banner adopts the status-pin path's rights
+// detector, terminal-unpin classifier and per-process negative cache, so the two
+// pin owners agree on which chats are rights-less instead of the banner's old
+// drop-on-ANY-unpin. status-pin.ts is dependency-free.
+import { isPinRightsError, isUnpinTerminalError, type PinRightsCache } from './status-pin.js';
 
 /** Minimal subset of grammy's `bot.api` we depend on. Letting tests
  *  swap in `fake-bot-api.ts` without dragging in the full Bot type. */
@@ -72,6 +77,15 @@ export interface RefreshBannerArgs {
   /** Optional API-failure observer. Phase identifies which Bot API
    *  call failed so the caller can log meaningfully. Default: silent. */
   onError?: (phase: 'pin' | 'edit' | 'unpin', err: unknown) => void;
+  /** Shared per-process pin-rights negative cache (status-pin.ts
+   *  `PinRightsCache`), unifying the banner with the status-pin path on
+   *  rights-less chats (D5). When the chat is already known rights-less the pin
+   *  action is skipped so we never emit an un-pinnable notice; a real pin-rights
+   *  400 from the pin/unpin verb records the block and a confirmed pin clears
+   *  it. Fed ONLY from the pin/unpin verbs — a `sendMessage` failure is never
+   *  cached, because a send failure is not a pin-rights signal. Optional;
+   *  omitted in unit tests. */
+  rightsCache?: Pick<PinRightsCache, 'isBlocked' | 'block' | 'clear'>;
   /** Optional durable-persistence hooks so an orphaned banner pin is
    *  recoverable across a gateway crash. The gateway wires these to the
    *  shared status-pin store (a distinct `banner:` pinKey), mirroring the
@@ -127,20 +141,34 @@ export async function refreshBanner(
 
   if (action.kind === 'unpin') {
     try {
+      // allow-raw-pin: the slot banner is a sanctioned separate pin owner (see
+      // scripts/check-status-pin-single-path-allowlist.txt); its unpin is not
+      // routed through reconcileStatusPin.
       await args.bot.api.unpinChatMessage(args.ownerChatId, action.messageId);
     } catch (err) {
       args.onError?.('unpin', err);
+      // Feed the shared negative cache ONLY from a real pin-rights 400 on the
+      // unpin verb — never from any other failure class (D5).
+      if (isPinRightsError(err)) args.rightsCache?.block(String(args.ownerChatId));
+      // Adopt the status-pin terminal-vs-never-confirmed contract (#3664 Defect
+      // B) instead of drop-on-ANY-unpin: retain the claim when the unpin did
+      // NOT terminally land (transient flood/5xx/network), so the next refresh
+      // retries rather than orphaning a still-pinned banner with no record. A
+      // terminal 4xx (rights, message gone, bot kicked) — and a success — fall
+      // through to the drop below, because re-issuing cannot help.
+      if (!isUnpinTerminalError(err)) return args.prevState;
     }
-    // Even if unpin failed, drop our claim — the message may have been
-    // unpinned out-of-band (operator did it manually) and re-pinning
-    // would be more confusing than surfacing it again later. Drop the
-    // persisted record too (unpin-then-clear mirrors the status-pin store:
-    // a crash between unpin and clear just re-unpins next boot, idempotent).
+    // Terminal outcome: drop our claim and the persisted record. A crash
+    // between unpin and clear just re-unpins next boot (idempotent).
     safePersist(args.persist?.clear);
     return null;
   }
 
   if (action.kind === 'pin') {
+    // The banner is a PINNED notice: if this chat is already known rights-less
+    // (proved by the status-pin path or an earlier banner pin), skip the whole
+    // send+pin — an un-pinnable send is pure noise (D5).
+    if (args.rightsCache?.isBlocked(String(args.ownerChatId))) return args.prevState;
     let sent: { message_id: number };
     try {
       // sendRichMessage doesn't accept link_preview_options — omit it.
@@ -150,6 +178,8 @@ export async function refreshBanner(
         disable_notification: true,
       });
     } catch (err) {
+      // SEND failure — deliberately NOT a pin-rights signal, so the cache is
+      // NEVER written here even though the phase tag below is 'pin' (D5).
       args.onError?.('pin', err);
       return args.prevState;
     }
@@ -158,17 +188,24 @@ export async function refreshBanner(
     // unpins next boot — closing the persist-after-pin leak.
     safePersist(() => args.persist?.pending?.(String(args.ownerChatId), sent.message_id));
     try {
+      // allow-raw-pin: sanctioned banner pin owner (see the allowlist).
       await args.bot.api.pinChatMessage(args.ownerChatId, sent.message_id, {
         disable_notification: true,
       });
     } catch (err) {
       args.onError?.('pin', err);
+      // The PIN verb failing with a real pin-rights 400 IS the rights signal —
+      // record it so later refreshes skip the doomed send+pin (D5).
+      if (isPinRightsError(err)) args.rightsCache?.block(String(args.ownerChatId));
       // sendMessage succeeded but pin failed — don't claim the message, and
       // drop the pending record so we don't leave a phantom claim for a pin
       // that never landed.
       safePersist(args.persist?.clear);
       return args.prevState;
     }
+    // Pin confirmed — rights are present, so clear any stale block for this chat
+    // (mirrors the status-pin path clearing on a successful pin).
+    args.rightsCache?.clear(String(args.ownerChatId));
     // Pin confirmed — rewrite the record without the pending flag.
     safePersist(() => args.persist?.confirm?.(String(args.ownerChatId), sent.message_id));
     return { messageId: sent.message_id, slot: action.slot };

--- a/telegram-plugin/tests/status-pin-store.test.ts
+++ b/telegram-plugin/tests/status-pin-store.test.ts
@@ -569,6 +569,31 @@ describe("status-pin-store — envelope version compat", () => {
     expect(loadStatusPins(PATH, fs)[0].threadId).toBe(77);
   });
 
+  it("D4: a forum-topic foreground pin threads its topic THROUGH the orchestrator into the persisted row", async () => {
+    // The narrative-lane fix passes `thread` as reconcileStatusPin's 4th arg;
+    // this locks the plumbing beneath it — runStatusPinReconcile → the durable
+    // row — so a forum-topic foreground card orphaned by a crash keeps a
+    // threadId the sweep can aim `unpinAllForumTopicMessages` at. Before the
+    // fix the producer dropped `thread`, landing a threadId-less row here.
+    const { fs } = memFs();
+    const claims = new Map<string, StatusPinClaim>();
+    await runStatusPinReconcile({
+      pinKey: "fg:-100123:9",
+      chatId: "-100123",
+      threadId: 9,
+      prev: null,
+      desired: { pinned: true, messageId: 715 },
+      persist: { path: PATH, fs },
+      runPin: async (action) =>
+        action.kind === "pin" ? { messageId: action.messageId } : null,
+      claims,
+    });
+
+    // The durable row AND the in-memory claim both carry the topic.
+    expect(loadStatusPins(PATH, fs)[0]?.threadId).toBe(9);
+    expect(claims.get("fg:-100123:9")?.threadId).toBe(9);
+  });
+
   it("drops a row with a non-numeric threadId", () => {
     const { fs } = memFs({
       [PATH]: JSON.stringify({

--- a/tests/check-status-pin-single-path.test.ts
+++ b/tests/check-status-pin-single-path.test.ts
@@ -185,6 +185,82 @@ describe('a second wiring of the subsystem', () => {
   })
 })
 
+describe('single rights-detector — one isPinRightsError, no forked copy', () => {
+  it('reds on a SECOND exported isPinRightsError outside status-pin.ts', () => {
+    // The exact fork this PR deleted: the stale-pin-sweep had its own copy that
+    // could drift from the status-pin source of truth.
+    const v = scan(
+      'telegram-plugin/gateway/stale-pin-sweep.ts',
+      `export function isPinRightsError(err: unknown): boolean {\n  return description(err).includes('not enough rights')\n}\n`,
+    )
+    expect(rules(v)).toEqual(['single-rights-detector'])
+    expect(v[0].fix).toContain("'../status-pin.js'")
+  })
+
+  it('also reds on an exported const form', () => {
+    expect(
+      rules(
+        scan(
+          'telegram-plugin/slot-banner-driver.ts',
+          `export const isPinRightsError = (e: unknown) => String(e).includes('rights')\n`,
+        ),
+      ),
+    ).toEqual(['single-rights-detector'])
+  })
+
+  it('leaves the ONE definition in status-pin.ts alone', () => {
+    expect(
+      scan('telegram-plugin/status-pin.ts', `export function isPinRightsError(err: unknown): boolean {\n}\n`),
+    ).toEqual([])
+  })
+
+  it('does NOT red on IMPORTING or CALLING it, or on a differently-named rights fold', () => {
+    // Importing the single source is exactly what the sweep now does.
+    expect(
+      scan('telegram-plugin/gateway/stale-pin-sweep.ts', `import { isPinRightsError } from '../status-pin.js'\n`),
+    ).toEqual([])
+    expect(
+      scan('telegram-plugin/gateway/stale-pin-sweep.ts', `if (isPinRightsError(err)) return { kind: 'rights' }\n`),
+    ).toEqual([])
+    // The seven sanctioned folds have DIFFERENT names; only isPinRightsError is
+    // the guarded symbol.
+    expect(
+      scan(
+        'telegram-plugin/worker-activity-feed.ts',
+        `function isRightsFailure(e: unknown) { return String(e).includes('not enough rights') }\n`,
+      ),
+    ).toEqual([])
+  })
+})
+
+describe('sweep must not re-introduce a proactive getChatMember precheck', () => {
+  it('reds on a getChatMember call inside a stale-pin-sweep file', () => {
+    const v = scan(
+      'telegram-plugin/gateway/stale-pin-sweep-wiring.ts',
+      `const member = await bot().api.getChatMember(chatId, self)\n`,
+    )
+    expect(rules(v)).toEqual(['sweep-no-getchatmember'])
+    expect(v[0].fix).toContain('REACTIVELY')
+  })
+
+  it('leaves getChatMember in NON-sweep code alone (e.g. the reaction admin lookup)', () => {
+    expect(
+      scan('telegram-plugin/gateway/gateway.ts', `await bot.api.getChatMember(update.chat.id, reacter.id)\n`),
+    ).toEqual([])
+  })
+
+  it('has no marker escape — a precheck must not come back with a rubber stamp', () => {
+    expect(
+      rules(
+        scan(
+          'telegram-plugin/gateway/stale-pin-sweep.ts',
+          `await getChatMember(c, s) // allow-raw-pin: I promise it is fine\n`,
+        ),
+      ),
+    ).toEqual(['sweep-no-getchatmember'])
+  })
+})
+
 describe('allowlist parsing', () => {
   it('throws on a malformed entry rather than silently granting nothing', () => {
     expect(() => parseAllowlist('raw-pin-api :: some/file.ts\n')).toThrow(/malformed entry/)


### PR DESCRIPTION
## Root cause

The stale-pin-sweep reaper carried a **proactive `canPinInChat` precheck** — a `getChatMember` self-membership lookup wired through a seam field — that returned `skipped-no-rights` *before* attempting any drain. Under chat-lock the bot is wrapped as `{ api }` with **no `botInfo`**, so the precheck could not resolve self-membership and wedged the sweep. That precheck was a second, divergent rights model layered on top of the reactive classifier the drain already had. The sweep also carried a **duplicate `isPinRightsError`** that could drift from the status-pin source of truth.

## Changes

- **D1 (blocker):** DELETE the proactive `canPinInChat` precheck end-to-end — the injected dep, the `getChatMember` seam, the `botInfo` handle field, and the pre-drain skip. Rights are now classified **solely reactively**: attempt the unpin, classify a real Telegram 400 via `isPinRightsError`. Attempts/forfeit accounting is preserved through the reactive path (bounded by `SWEEP_MAX_ATTEMPTS`, no infinite retry).
- **D2:** remove the duplicate `isPinRightsError` from `stale-pin-sweep.ts`; import the single source from `../status-pin.js`.
- **D3 (applied):** share the per-process `PinRightsCache` into the sweep. **Process-topology finding:** verified same-process — one `statusPinRightsCache` singleton in `gateway.ts` feeds both `executePinLeg` and the sweeper wiring, so a rights-less chat proved by either owner is skipped by the other.
- **D4:** capture `threadId` at the **narrative-lane** foreground-card producer by passing `thread` through to `reconcileStatusPin`, so a forum-topic orphan persists its topic in the durable row.
- **D5:** the **slot-banner driver** adopts the shared `isPinRightsError`, `isUnpinTerminalError` and `PinRightsCache` instead of drop-on-ANY-unpin. A `sendMessage` failure is **never** cached as a pin-rights signal — only a real 400 from the pin/unpin verb records the block; a confirmed pin clears it.
- **Regression guard:** `check-status-pin-single-path.mjs` gains a **single-rights-detector** rule (reds a second exported `isPinRightsError` outside `status-pin.ts`) and a **sweep-no-getchatmember** rule (reds a re-introduced proactive precheck in any sweep file), each with teeth in `tests/check-status-pin-single-path.test.ts`.

### What's DELETED
`canPinInChat` (dep + wiring impl), the `getChatMember` seam field, the `botInfo` handle field, the pre-drain `skipped-no-rights` short-circuit, and the duplicate `isPinRightsError` in the sweep.

## Deviation (per red-team / coordinator)

The **gateway `executePinMessage` half of D4 was DROPPED**: there is no reliable `threadId` source at that producer and tool pins are already excluded from the sweep, so persisting a threadId there would be guesswork. Only the narrative-lane producer is fixed.

## Test plan

Scoped vitest (137 passing across the 4 touched suites) + relevant lint guards:
- sweep proceeds when the wrapped bot has **no `botInfo`** (the wedge case);
- a real Telegram 400 is classified as rights via the **reactive path**, with correct forfeit accounting across boots;
- a **forum-topic** foreground-card orphan retains its `threadId` in the persisted row;
- guard reds on a second `isPinRightsError` export and on `getChatMember` in a sweep file; leaves the sanctioned folds and non-sweep `getChatMember` alone.

`tsc` over touched files is clean (the only local `tsc` failures are a pre-existing `nostr-tools` install-drift in the checkout, unrelated to this PR; CI resolves it). Full suite is CI's authority — not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)