### PR TITLE
feat(gateway): /private /public toggle commands

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -626,6 +626,12 @@ import { readTurnUsages } from '../../src/agents/perf.js'
 import { buildContextOccupancy, writeContextOccupancySnapshot } from './context-occupancy.js'
 import { decideProactiveCompact, initialCompactState, type CompactState } from './proactive-compact.js'
 import { IdleTracker, idleDurationToMs, DEFAULT_IDLE_CLEAR_MS } from './idle-clear.js'
+import {
+  openPrivateInterval,
+  closePrivateInterval,
+  PRIVATE_ON_REPLY,
+  PUBLIC_REPLY,
+} from './privacy-state.js'
 import { nextCompactNotify, idleCompactNotifyState, type CompactNotifyState } from './compact-notify.js'
 import {
   tryHostdDispatch,
@@ -19805,6 +19811,19 @@ bot.command('compact', async ctx => {
 })
 bot.command('clear', async ctx => {
   await handleInjectCommand(ctx, buildInjectDeps({ open: true, fixedVerb: '/clear' }))
+})
+// Per-operator session privacy controls. NOT admin verbs (deliberately kept
+// out of ADMIN_COMMAND_NAMES) — they gate memory writing for THIS session, so
+// they share the plain per-command isAuthorizedSender gate like inject/clear.
+bot.command('private', async ctx => {
+  if (!isAuthorizedSender(ctx)) return
+  openPrivateInterval()
+  await switchroomReply(ctx, PRIVATE_ON_REPLY)
+})
+bot.command('public', async ctx => {
+  if (!isAuthorizedSender(ctx)) return
+  closePrivateInterval()
+  await switchroomReply(ctx, PUBLIC_REPLY)
 })
 // /model and /effort extracted to bot-commands-model-effort.ts
 // (switchroom#2996 P6 bot.command drain). Helper registration keeps grammy

--- a/telegram-plugin/gateway/privacy-state.test.ts
+++ b/telegram-plugin/gateway/privacy-state.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for privacy-state.ts — the gateway side of the `/private`
+ * `/public` feature (PR2: open/close/read/reset + the state-file contract).
+ *
+ * These lock in the on-disk contract shared with the Python retain side
+ * (`vendor/hindsight-memory`): the exact schema, `end: null` = open interval,
+ * idempotent open/close, atomic writes (no torn file), and best-effort,
+ * corrupt-tolerant reads.
+ *
+ * Run with: npx vitest run telegram-plugin/gateway/privacy-state.test.ts
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, readdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  readPrivacyState,
+  openPrivateInterval,
+  closePrivateInterval,
+  resetToPublic,
+  isPrivate,
+  privacyStatePath,
+  emptyPrivacyState,
+  type PrivacyState,
+} from './privacy-state.js'
+
+describe('privacy-state', () => {
+  let dir: string
+  let stderrSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'privacy-state-'))
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    stderrSpy.mockRestore()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  const path = () => privacyStatePath(dir)
+  const onDisk = (): PrivacyState => JSON.parse(readFileSync(path(), 'utf8'))
+
+  describe('readPrivacyState — best-effort, corrupt-tolerant', () => {
+    it('returns the public default when the file is missing', () => {
+      expect(readPrivacyState(dir)).toEqual(emptyPrivacyState())
+      expect(isPrivate(readPrivacyState(dir))).toBe(false)
+    })
+
+    it('does not throw and returns the default on corrupt JSON', () => {
+      writeFileSync(path(), '{ this is not json', 'utf8')
+      expect(() => readPrivacyState(dir)).not.toThrow()
+      expect(readPrivacyState(dir)).toEqual(emptyPrivacyState())
+    })
+
+    it('returns the default when intervals is not an array', () => {
+      writeFileSync(path(), JSON.stringify({ version: 1, intervals: 'nope' }), 'utf8')
+      expect(readPrivacyState(dir).intervals).toEqual([])
+    })
+
+    it('filters out malformed intervals but keeps valid ones', () => {
+      writeFileSync(
+        path(),
+        JSON.stringify({
+          version: 1,
+          intervals: [
+            { start: '2026-08-06T02:00:00.000Z', end: '2026-08-06T02:05:00.000Z' },
+            { start: 42, end: null }, // bad start
+            { end: null }, // missing start
+            { start: '2026-08-06T02:10:00.000Z', end: null }, // valid open
+          ],
+        }),
+        'utf8',
+      )
+      const state = readPrivacyState(dir)
+      expect(state.intervals).toHaveLength(2)
+      expect(state.intervals[1]).toEqual({ start: '2026-08-06T02:10:00.000Z', end: null })
+    })
+  })
+
+  describe('openPrivateInterval', () => {
+    it('appends a single open interval and writes the exact contract schema', () => {
+      const now = new Date('2026-08-06T02:00:25.558Z')
+      openPrivateInterval(now, dir)
+      expect(onDisk()).toEqual({
+        version: 1,
+        intervals: [{ start: '2026-08-06T02:00:25.558Z', end: null }],
+      })
+      expect(isPrivate(readPrivacyState(dir))).toBe(true)
+    })
+
+    it('is idempotent — a second /private while open does not stack', () => {
+      openPrivateInterval(new Date('2026-08-06T02:00:00.000Z'), dir)
+      openPrivateInterval(new Date('2026-08-06T02:03:00.000Z'), dir)
+      const state = readPrivacyState(dir)
+      expect(state.intervals).toHaveLength(1)
+      expect(state.intervals[0]).toEqual({ start: '2026-08-06T02:00:00.000Z', end: null })
+    })
+
+    it('opens a fresh interval after a prior one was closed', () => {
+      openPrivateInterval(new Date('2026-08-06T02:00:00.000Z'), dir)
+      closePrivateInterval(new Date('2026-08-06T02:05:00.000Z'), dir)
+      openPrivateInterval(new Date('2026-08-06T02:10:00.000Z'), dir)
+      const state = readPrivacyState(dir)
+      expect(state.intervals).toHaveLength(2)
+      expect(state.intervals[0].end).toBe('2026-08-06T02:05:00.000Z')
+      expect(state.intervals[1]).toEqual({ start: '2026-08-06T02:10:00.000Z', end: null })
+      expect(isPrivate(state)).toBe(true)
+    })
+  })
+
+  describe('closePrivateInterval', () => {
+    it('sets end on the open interval', () => {
+      openPrivateInterval(new Date('2026-08-06T02:00:00.000Z'), dir)
+      closePrivateInterval(new Date('2026-08-06T02:05:10.100Z'), dir)
+      expect(onDisk().intervals[0]).toEqual({
+        start: '2026-08-06T02:00:00.000Z',
+        end: '2026-08-06T02:05:10.100Z',
+      })
+      expect(isPrivate(readPrivacyState(dir))).toBe(false)
+    })
+
+    it('is idempotent — /public while already public is a no-op (no throw, no file)', () => {
+      expect(() => closePrivateInterval(new Date(), dir)).not.toThrow()
+      // No open interval existed → nothing was written.
+      expect(existsSync(path())).toBe(false)
+    })
+
+    it('does not reopen or touch an already-closed interval', () => {
+      openPrivateInterval(new Date('2026-08-06T02:00:00.000Z'), dir)
+      closePrivateInterval(new Date('2026-08-06T02:05:00.000Z'), dir)
+      closePrivateInterval(new Date('2026-08-06T02:09:00.000Z'), dir)
+      expect(onDisk().intervals[0].end).toBe('2026-08-06T02:05:00.000Z')
+    })
+  })
+
+  describe('resetToPublic', () => {
+    it('truncates to the empty public default', () => {
+      openPrivateInterval(new Date(), dir)
+      resetToPublic(dir)
+      expect(onDisk()).toEqual({ version: 1, intervals: [] })
+      expect(isPrivate(readPrivacyState(dir))).toBe(false)
+    })
+  })
+
+  describe('atomic writes', () => {
+    it('leaves no temp file behind after a write', () => {
+      openPrivateInterval(new Date(), dir)
+      closePrivateInterval(new Date(), dir)
+      // Exactly one file — the state file — no lingering `.tmp`/`.new` sibling.
+      const entries = readdirSync(dir)
+      expect(entries).toEqual(['privacy-state.json'])
+    })
+
+    it('a concurrent reader only ever sees a complete document', () => {
+      // Because the write is rename-based, the file at the destination path is
+      // always a fully-formed JSON doc — parsing it after any op never throws.
+      openPrivateInterval(new Date('2026-08-06T02:00:00.000Z'), dir)
+      expect(() => JSON.parse(readFileSync(path(), 'utf8'))).not.toThrow()
+      closePrivateInterval(new Date('2026-08-06T02:05:00.000Z'), dir)
+      expect(() => JSON.parse(readFileSync(path(), 'utf8'))).not.toThrow()
+    })
+  })
+})

--- a/telegram-plugin/gateway/privacy-state.ts
+++ b/telegram-plugin/gateway/privacy-state.ts
@@ -1,0 +1,174 @@
+/**
+ * Per-session privacy state — the gateway side of the `/private` `/public`
+ * feature (switchroom private-mode).
+ *
+ * The operator can pause Hindsight auto-retain for a stretch of a session with
+ * `/private`, then resume it with `/public`. The pause is recorded here as a
+ * list of half-open time intervals in a small JSON state file that the Python
+ * retain side (`vendor/hindsight-memory`) reads to EXCLUDE any turn whose
+ * timestamp falls inside an interval from memory.
+ *
+ * ── The state-file contract (MUST match the Python reader exactly) ──────────
+ * Path: `${TELEGRAM_STATE_DIR}/privacy-state.json` (dir resolved the same way
+ * `src/cli/self-improve-stop.ts:resolveStateDir()` does). Schema:
+ *
+ *   { "version": 1,
+ *     "intervals": [
+ *       { "start": "2026-08-06T02:00:25.558Z", "end": "2026-08-06T02:05:10.100Z" },
+ *       { "start": "2026-08-06T02:10:00.000Z", "end": null }
+ *     ] }
+ *
+ * `end: null` = an OPEN interval = "private right now". At most one is open at
+ * a time. A missing file (or `{"intervals":[]}`) means public — the default.
+ * Timestamps are ISO-8601 via `new Date().toISOString()`.
+ *
+ * ── Invariants ──────────────────────────────────────────────────────────────
+ *   - All writes are ATOMIC (tmp + fsync + rename via `atomicWriteFileSync`),
+ *     so a crash mid-write can never leave the Python reader a torn file.
+ *   - All reads are BEST-EFFORT and never throw: a missing, unreadable, or
+ *     corrupt file resolves to the public default. Losing this state is
+ *     fail-safe (memory records rather than drops), so — unlike the security
+ *     stores — a corrupt file here is tolerated silently rather than
+ *     quarantined.
+ *   - `openPrivateInterval` / `closePrivateInterval` are IDEMPOTENT: a second
+ *     `/private` while already private is a no-op, and `/public` while already
+ *     public is a no-op.
+ */
+
+import { readFileSync, mkdirSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+import { atomicWriteFileSync } from '../../src/util/atomic.js'
+
+/** One half-open privacy interval. `end: null` = still open ("private now"). */
+export interface PrivacyInterval {
+  start: string
+  end: string | null
+}
+
+/** The on-disk shape of `privacy-state.json`. */
+export interface PrivacyState {
+  version: 1
+  intervals: PrivacyInterval[]
+}
+
+/** The public (default) state — no private intervals. */
+export function emptyPrivacyState(): PrivacyState {
+  return { version: 1, intervals: [] }
+}
+
+// ── Loud, verbatim operator-facing strings ──────────────────────────────────
+// Exported so the gateway command handlers and the boot alert use the exact
+// wording the spec pins (and so tests assert against a single source).
+
+/** Reply to `/private`. */
+export const PRIVATE_ON_REPLY =
+  '🔒 Private mode ON — memory writing paused. Nothing said until /public is stored.'
+
+/** Reply to `/public`. */
+export const PUBLIC_REPLY =
+  '🔓 Public mode — memory writing resumed. The private stretch was excluded from memory.'
+
+/**
+ * Agent state dir — set by start.sh; resolved identically to
+ * `self-improve-stop.ts:resolveStateDir()` so the gateway writer and the
+ * Python reader agree on where `privacy-state.json` lives.
+ */
+export function resolvePrivacyStateDir(): string {
+  return (
+    process.env.TELEGRAM_STATE_DIR ??
+    join(homedir(), '.claude', 'channels', 'telegram')
+  )
+}
+
+/** Absolute path to the shared state file. */
+export function privacyStatePath(stateDir: string = resolvePrivacyStateDir()): string {
+  return join(stateDir, 'privacy-state.json')
+}
+
+/** True iff `v` is a well-formed interval object. */
+function isInterval(v: unknown): v is PrivacyInterval {
+  if (v === null || typeof v !== 'object') return false
+  const o = v as Record<string, unknown>
+  if (typeof o.start !== 'string') return false
+  return o.end === null || typeof o.end === 'string'
+}
+
+/**
+ * Read the current privacy state. BEST-EFFORT: a missing / unreadable /
+ * corrupt file resolves to the public default and NEVER throws. Only
+ * well-formed intervals survive; a partially-corrupt array is filtered down to
+ * its valid members rather than discarded wholesale.
+ */
+export function readPrivacyState(stateDir: string = resolvePrivacyStateDir()): PrivacyState {
+  try {
+    const raw = readFileSync(privacyStatePath(stateDir), 'utf8')
+    const parsed: unknown = JSON.parse(raw)
+    if (parsed === null || typeof parsed !== 'object') return emptyPrivacyState()
+    const rawIntervals = (parsed as Record<string, unknown>).intervals
+    if (!Array.isArray(rawIntervals)) return emptyPrivacyState()
+    return { version: 1, intervals: rawIntervals.filter(isInterval) }
+  } catch {
+    return emptyPrivacyState()
+  }
+}
+
+/**
+ * Atomically persist `state`. BEST-EFFORT: a write failure is logged to stderr
+ * and swallowed so a transient fs error can never crash a command handler or
+ * the boot path. (Losing the write is fail-safe — memory records the turn.)
+ */
+function writePrivacyState(state: PrivacyState, stateDir: string): void {
+  try {
+    mkdirSync(stateDir, { recursive: true })
+  } catch {
+    /* dir may already exist / be unwritable — the write below reports */
+  }
+  try {
+    atomicWriteFileSync(privacyStatePath(stateDir), JSON.stringify(state), 0o600)
+  } catch (err) {
+    process.stderr.write(
+      `telegram gateway: privacy-state write failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    )
+  }
+}
+
+/** True iff an interval is currently open ("private right now"). */
+export function isPrivate(state: PrivacyState): boolean {
+  return state.intervals.some(i => i.end === null)
+}
+
+/**
+ * Start a private stretch. IDEMPOTENT: if an interval is already open this is a
+ * no-op (a second `/private` doesn't stack).
+ */
+export function openPrivateInterval(
+  now: Date = new Date(),
+  stateDir: string = resolvePrivacyStateDir(),
+): void {
+  const state = readPrivacyState(stateDir)
+  if (isPrivate(state)) return
+  state.intervals.push({ start: now.toISOString(), end: null })
+  writePrivacyState(state, stateDir)
+}
+
+/**
+ * End the current private stretch. IDEMPOTENT: if no interval is open (already
+ * public) this is a no-op.
+ */
+export function closePrivateInterval(
+  now: Date = new Date(),
+  stateDir: string = resolvePrivacyStateDir(),
+): void {
+  const state = readPrivacyState(stateDir)
+  const open = state.intervals.find(i => i.end === null)
+  if (!open) return
+  open.end = now.toISOString()
+  writePrivacyState(state, stateDir)
+}
+
+/** Truncate the state file back to the public default. */
+export function resetToPublic(stateDir: string = resolvePrivacyStateDir()): void {
+  writePrivacyState(emptyPrivacyState(), stateDir)
+}

--- a/telegram-plugin/tests/gateway-handler-registration-wiring.test.ts
+++ b/telegram-plugin/tests/gateway-handler-registration-wiring.test.ts
@@ -57,6 +57,8 @@ const GOLDEN_REGISTRATIONS: readonly string[] = [
   'command:inject',
   'command:compact',
   'command:clear',
+  'command:private',
+  'command:public',
   'helper:registerModelEffortCommands',
   'command:agentstart',
   'command:agentstop',


### PR DESCRIPTION
## What

Adds per-operator, per-session privacy controls to the Telegram gateway:

- **`/private`** → `🔒 Private mode ON — memory writing paused. Nothing said until /public is stored.`
- **`/public`** → `🔓 Public mode — memory writing resumed. The private stretch was excluded from memory.`

`/private` pauses Hindsight auto-retain for a stretch of the session; `/public` resumes it. This is PR2 of the `/private` `/public` feature — the **gateway side that writes the shared state file**. A separate PR implements the Python retain-side enforcement that reads it.

## The state-file contract

New module `telegram-plugin/gateway/privacy-state.ts` owns the on-disk contract shared with the Python reader:

- **Path:** `${TELEGRAM_STATE_DIR}/privacy-state.json` (dir resolved identically to `src/cli/self-improve-stop.ts:resolveStateDir()`).
- **Schema:** `{ "version": 1, "intervals": [ { "start": ISO8601, "end": ISO8601 | null } ] }`
- `end: null` = the single **OPEN** interval ("private right now"; at most one open).
- Missing file / `{"intervals":[]}` = **public** (the default).
- All writes are **atomic** (tmp + fsync + rename via `atomicWriteFileSync`) so the Python reader can never observe a torn file.
- All reads are **best-effort and corrupt-tolerant** — a missing / unreadable / unparseable file resolves to the public default and never throws; a partially-corrupt interval array is filtered to its valid members.
- `openPrivateInterval` / `closePrivateInterval` are **idempotent**.

## Wiring

- The two commands sit alongside the existing plain gated `inject`/`compact`/`clear` handlers, each with `if (!isAuthorizedSender(ctx)) return` as the first line.
- They are **deliberately NOT** added to `ADMIN_COMMAND_NAMES` — they are per-operator session controls, not fleet-admin verbs (same treatment as `/inject`, `/clear`).

## Tests

- `telegram-plugin/gateway/privacy-state.test.ts` — the contract schema, `end:null` open semantics, open/close idempotency, atomic writes (no temp-file residue, always-complete document), and corrupt-file tolerance.
- Extended `telegram-plugin/tests/gateway-handler-registration-wiring.test.ts` golden sequence with `command:private` and `command:public`.

Full `npm run lint` (tsc + all guards) and the scoped vitest suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
