### PR TITLE
feat(gateway): session-start reset to public + alert

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -632,7 +632,7 @@ import {
   PRIVATE_ON_REPLY,
   PUBLIC_REPLY,
 } from './privacy-state.js'
-import { makePrivacyResetForNewSession } from './privacy-reset.js'
+import { makePrivacyResetForNewSession, isContinueRestoreBoot } from './privacy-reset.js'
 import { nextCompactNotify, idleCompactNotifyState, type CompactNotifyState } from './compact-notify.js'
 import {
   tryHostdDispatch,
@@ -23524,8 +23524,8 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
             // Only when we KNOW it was a /model switch (reason) AND we will send the
             // confirmation (marker chat captured); otherwise the boot card fires
             // normally. Version/quota remain available via /status.
-            // Privacy: genuine boot (cold/crash/planned/model-switch) is a new session → reset to public, reusing boot-card's chat. NOT wired to bridge-reconnect (persisting session).
-            if (target) resetPrivacyForNewSession(target.chatId, target.threadId)
+            // Privacy: genuine FRESH boot (cold/crash/planned/model-switch) → reset to public, reusing boot-card's chat. Suppressed on a --continue/auto transcript-restore (state must persist) and never wired to bridge-reconnect.
+            if (target && !isContinueRestoreBoot(resolveAgentDirFromEnv())) resetPrivacyForNewSession(target.chatId, target.threadId)
             const suppressBootCardForModelSwitch =
               modelSwitchReason != null && modelSwitchMarkerChat != null
             if (target && suppressBootCardForModelSwitch) {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -632,6 +632,7 @@ import {
   PRIVATE_ON_REPLY,
   PUBLIC_REPLY,
 } from './privacy-state.js'
+import { makePrivacyResetForNewSession } from './privacy-reset.js'
 import { nextCompactNotify, idleCompactNotifyState, type CompactNotifyState } from './compact-notify.js'
 import {
   tryHostdDispatch,
@@ -5100,6 +5101,10 @@ function maybeIdleClear(): void {
           `telegram gateway: idle /clear suppressed for ${agentName} ` +
             `(activity in check-to-send gap)\n`,
         );
+      } else {
+        // The idle /clear fired → new logical session; reset privacy to public.
+        const idleChat = loadAccess().allowFrom[0];
+        if (idleChat) resetPrivacyForNewSession(String(idleChat), undefined);
       }
     })
     .catch((err: unknown) => {
@@ -5603,6 +5608,11 @@ const swallowingApiCall = createSwallowingRetryApiCall(
   robustApiCall,
   (line) => process.stderr.write(line),
 )
+// Privacy (#private-mode): reset to public on a genuine new session (boot / /clear); loud only on a private→public transition. See privacy-reset.ts.
+const resetPrivacyForNewSession = makePrivacyResetForNewSession((chatId, threadId, text) =>
+  void swallowingApiCall(
+    () => lockedBot.api.sendMessage(chatId, text, threadId != null ? { message_thread_id: threadId, disable_notification: false } : { disable_notification: false }),
+    { chat_id: chatId, verb: 'privacy-reset-alert', priorityClass: 'critical' }))
 
 /**
  * The ONE seam every `setMessageReaction` in this gateway goes through (#3155).
@@ -19811,6 +19821,9 @@ bot.command('compact', async ctx => {
 })
 bot.command('clear', async ctx => {
   await handleInjectCommand(ctx, buildInjectDeps({ open: true, fixedVerb: '/clear' }))
+  // A /clear starts a new logical session → reset privacy to public.
+  const clearChatId = String(ctx.chat!.id)
+  resetPrivacyForNewSession(clearChatId, resolveThreadId(clearChatId, ctx.message?.message_thread_id))
 })
 // Per-operator session privacy controls. NOT admin verbs (deliberately kept
 // out of ADMIN_COMMAND_NAMES) — they gate memory writing for THIS session, so
@@ -23511,6 +23524,8 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
             // Only when we KNOW it was a /model switch (reason) AND we will send the
             // confirmation (marker chat captured); otherwise the boot card fires
             // normally. Version/quota remain available via /status.
+            // Privacy: genuine boot (cold/crash/planned/model-switch) is a new session → reset to public, reusing boot-card's chat. NOT wired to bridge-reconnect (persisting session).
+            if (target) resetPrivacyForNewSession(target.chatId, target.threadId)
             const suppressBootCardForModelSwitch =
               modelSwitchReason != null && modelSwitchMarkerChat != null
             if (target && suppressBootCardForModelSwitch) {

--- a/telegram-plugin/gateway/privacy-reset.test.ts
+++ b/telegram-plugin/gateway/privacy-reset.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for the session-start privacy reset (PR3 of `/private` `/public`).
+ *
+ * Covers the two collaborating pieces:
+ *   - `resetPrivacyOnGenuineSessionStart` (privacy-state.ts): always truncates
+ *     to public; fires `onOpenIntervalReset` ONLY on a private→public
+ *     transition (a leftover OPEN interval).
+ *   - `makePrivacyResetForNewSession` (privacy-reset.ts): binds the loud-send
+ *     primitive so the alert is emitted exactly when — and only when — that
+ *     transition happened.
+ *
+ * The three spec scenarios:
+ *   1. leftover open interval  → file reset to empty AND loud alert emitted
+ *   2. already public          → file reset, NO alert
+ *   3. compact / no-reset path → state PRESERVED unchanged, NO alert
+ *
+ * Run with: npx vitest run telegram-plugin/gateway/privacy-reset.test.ts
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  openPrivateInterval,
+  readPrivacyState,
+  resetPrivacyOnGenuineSessionStart,
+  emptyPrivacyState,
+  privacyStatePath,
+  SESSION_RESET_ALERT,
+} from './privacy-state.js'
+import { makePrivacyResetForNewSession } from './privacy-reset.js'
+
+describe('privacy session-start reset', () => {
+  let dir: string
+  let stderrSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'privacy-reset-'))
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    stderrSpy.mockRestore()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  const onDisk = () => JSON.parse(readFileSync(privacyStatePath(dir), 'utf8'))
+
+  describe('resetPrivacyOnGenuineSessionStart', () => {
+    it('scenario 1: a leftover OPEN interval → file reset to empty AND callback fired', () => {
+      openPrivateInterval(new Date('2026-08-06T02:00:00.000Z'), dir)
+      const onReset = vi.fn()
+      const result = resetPrivacyOnGenuineSessionStart({ stateDir: dir, onOpenIntervalReset: onReset })
+      expect(result.hadOpenInterval).toBe(true)
+      expect(onReset).toHaveBeenCalledTimes(1)
+      expect(onDisk()).toEqual(emptyPrivacyState())
+    })
+
+    it('scenario 2: already public → file reset (idempotent), NO callback', () => {
+      const onReset = vi.fn()
+      const result = resetPrivacyOnGenuineSessionStart({ stateDir: dir, onOpenIntervalReset: onReset })
+      expect(result.hadOpenInterval).toBe(false)
+      expect(onReset).not.toHaveBeenCalled()
+      expect(onDisk()).toEqual(emptyPrivacyState())
+    })
+
+    it('scenario 2b: a CLOSED-only history is treated as public → NO callback, reset to empty', () => {
+      writeFileSync(
+        privacyStatePath(dir),
+        JSON.stringify({
+          version: 1,
+          intervals: [{ start: '2026-08-06T02:00:00.000Z', end: '2026-08-06T02:05:00.000Z' }],
+        }),
+        'utf8',
+      )
+      const onReset = vi.fn()
+      const result = resetPrivacyOnGenuineSessionStart({ stateDir: dir, onOpenIntervalReset: onReset })
+      expect(result.hadOpenInterval).toBe(false)
+      expect(onReset).not.toHaveBeenCalled()
+      expect(onDisk().intervals).toEqual([])
+    })
+
+    it('scenario 3: a NON-reset path (compact / resume) preserves state — no reset is called', () => {
+      // The compact/resume paths are EXEMPT by construction: the gateway simply
+      // never calls the reset there. This asserts the invariant that, absent a
+      // reset, an open private interval survives untouched.
+      openPrivateInterval(new Date('2026-08-06T02:00:00.000Z'), dir)
+      const before = readPrivacyState(dir)
+      // ...compaction happens here in the real gateway; privacy is not touched...
+      const after = readPrivacyState(dir)
+      expect(after).toEqual(before)
+      expect(after.intervals).toEqual([{ start: '2026-08-06T02:00:00.000Z', end: null }])
+    })
+  })
+
+  describe('makePrivacyResetForNewSession (loud-send binding)', () => {
+    // The factory uses the DEFAULT state-dir resolver (no stateDir param), so
+    // point TELEGRAM_STATE_DIR at the temp dir for the duration of this test.
+    let prevEnv: string | undefined
+    beforeEach(() => {
+      prevEnv = process.env.TELEGRAM_STATE_DIR
+      process.env.TELEGRAM_STATE_DIR = dir
+    })
+    afterEach(() => {
+      if (prevEnv === undefined) delete process.env.TELEGRAM_STATE_DIR
+      else process.env.TELEGRAM_STATE_DIR = prevEnv
+    })
+
+    it('emits the loud SESSION_RESET_ALERT to the chat only on a private→public transition', () => {
+      const send = vi.fn<(chatId: string, threadId: number | undefined, text: string) => void>()
+      const reset = makePrivacyResetForNewSession(send)
+
+      // Already public: no alert.
+      reset('chat-1', undefined)
+      expect(send).not.toHaveBeenCalled()
+      expect(onDisk()).toEqual(emptyPrivacyState())
+
+      // Now go private, then reset: exactly one loud alert with the pinned text.
+      openPrivateInterval(new Date('2026-08-06T02:00:00.000Z'))
+      reset('chat-1', 77)
+      expect(send).toHaveBeenCalledTimes(1)
+      expect(send).toHaveBeenCalledWith('chat-1', 77, SESSION_RESET_ALERT)
+      expect(onDisk()).toEqual(emptyPrivacyState())
+    })
+  })
+})

--- a/telegram-plugin/gateway/privacy-reset.test.ts
+++ b/telegram-plugin/gateway/privacy-reset.test.ts
@@ -29,7 +29,11 @@ import {
   privacyStatePath,
   SESSION_RESET_ALERT,
 } from './privacy-state.js'
-import { makePrivacyResetForNewSession } from './privacy-reset.js'
+import {
+  makePrivacyResetForNewSession,
+  bootRestoresTranscript,
+  isContinueRestoreBoot,
+} from './privacy-reset.js'
 
 describe('privacy session-start reset', () => {
   let dir: string
@@ -122,6 +126,91 @@ describe('privacy session-start reset', () => {
       expect(send).toHaveBeenCalledTimes(1)
       expect(send).toHaveBeenCalledWith('chat-1', 77, SESSION_RESET_ALERT)
       expect(onDisk()).toEqual(emptyPrivacyState())
+    })
+  })
+
+  describe('boot reset gating on --continue transcript-restore (MAJOR fix)', () => {
+    it('bootRestoresTranscript: continue/auto restore; handoff/none/undefined do not; force-fresh overrides', () => {
+      expect(bootRestoresTranscript({ resumeMode: 'continue', forceFresh: false })).toBe(true)
+      expect(bootRestoresTranscript({ resumeMode: 'auto', forceFresh: false })).toBe(true)
+      expect(bootRestoresTranscript({ resumeMode: 'handoff', forceFresh: false })).toBe(false)
+      expect(bootRestoresTranscript({ resumeMode: 'none', forceFresh: false })).toBe(false)
+      expect(bootRestoresTranscript({ resumeMode: undefined, forceFresh: false })).toBe(false)
+      // A /new /reset force-fresh boot is genuinely fresh even under continue/auto.
+      expect(bootRestoresTranscript({ resumeMode: 'continue', forceFresh: true })).toBe(false)
+      expect(bootRestoresTranscript({ resumeMode: 'auto', forceFresh: true })).toBe(false)
+    })
+
+    it('isContinueRestoreBoot reads SWITCHROOM_RESUME_MODE / SWITCHROOM_FORCE_FRESH', () => {
+      const saved = { ...process.env }
+      try {
+        delete process.env.SWITCHROOM_FORCE_FRESH
+        process.env.SWITCHROOM_RESUME_MODE = 'continue'
+        expect(isContinueRestoreBoot(null)).toBe(true)
+        process.env.SWITCHROOM_RESUME_MODE = 'handoff'
+        expect(isContinueRestoreBoot(null)).toBe(false)
+        // force-fresh env override wins over continue.
+        process.env.SWITCHROOM_RESUME_MODE = 'continue'
+        process.env.SWITCHROOM_FORCE_FRESH = '1'
+        expect(isContinueRestoreBoot(null)).toBe(false)
+      } finally {
+        process.env = saved
+      }
+    })
+
+    // Emulates the guarded boot call site: `if (target && !isContinueRestoreBoot(dir)) reset(...)`.
+    // This is the exact failure scenario the reviewer flagged.
+    function guardedBootReset(reset: (c: string, t: number | undefined) => void): void {
+      if (!isContinueRestoreBoot(null)) reset('boot-chat', undefined)
+    }
+
+    it('continue-restore boot: NO reset, NO alert, open interval PRESERVED', () => {
+      const saved = { ...process.env }
+      try {
+        process.env.TELEGRAM_STATE_DIR = dir
+        delete process.env.SWITCHROOM_FORCE_FRESH
+        process.env.SWITCHROOM_RESUME_MODE = 'continue'
+        openPrivateInterval(new Date('2026-08-06T02:00:00.000Z'))
+        const send = vi.fn<(chatId: string, threadId: number | undefined, text: string) => void>()
+        guardedBootReset(makePrivacyResetForNewSession(send))
+        expect(send).not.toHaveBeenCalled()
+        expect(onDisk().intervals).toEqual([{ start: '2026-08-06T02:00:00.000Z', end: null }])
+      } finally {
+        process.env = saved
+      }
+    })
+
+    it('fresh (handoff) boot: reset FIRES, loud alert emitted, interval cleared', () => {
+      const saved = { ...process.env }
+      try {
+        process.env.TELEGRAM_STATE_DIR = dir
+        delete process.env.SWITCHROOM_FORCE_FRESH
+        process.env.SWITCHROOM_RESUME_MODE = 'handoff'
+        openPrivateInterval(new Date('2026-08-06T02:00:00.000Z'))
+        const send = vi.fn<(chatId: string, threadId: number | undefined, text: string) => void>()
+        guardedBootReset(makePrivacyResetForNewSession(send))
+        expect(send).toHaveBeenCalledTimes(1)
+        expect(send).toHaveBeenCalledWith('boot-chat', undefined, SESSION_RESET_ALERT)
+        expect(onDisk()).toEqual(emptyPrivacyState())
+      } finally {
+        process.env = saved
+      }
+    })
+
+    it('continue-mode /new force-fresh boot: reset FIRES (genuinely fresh)', () => {
+      const saved = { ...process.env }
+      try {
+        process.env.TELEGRAM_STATE_DIR = dir
+        process.env.SWITCHROOM_RESUME_MODE = 'continue'
+        process.env.SWITCHROOM_FORCE_FRESH = '1'
+        openPrivateInterval(new Date('2026-08-06T02:00:00.000Z'))
+        const send = vi.fn<(chatId: string, threadId: number | undefined, text: string) => void>()
+        guardedBootReset(makePrivacyResetForNewSession(send))
+        expect(send).toHaveBeenCalledTimes(1)
+        expect(onDisk()).toEqual(emptyPrivacyState())
+      } finally {
+        process.env = saved
+      }
     })
   })
 })

--- a/telegram-plugin/gateway/privacy-reset.ts
+++ b/telegram-plugin/gateway/privacy-reset.ts
@@ -1,0 +1,47 @@
+/**
+ * Gateway-owned session-start privacy reset (PR3 of the `/private` `/public`
+ * feature).
+ *
+ * A genuine new session — cold boot / crash / planned restart, and a `/clear`
+ * (which starts a new logical session) — must return memory writing to its
+ * PUBLIC default. If the previous session ended while still private (an OPEN
+ * interval was left behind), the operator is told loudly, so they are never
+ * silently surprised that a stretch they thought was private is now being
+ * recorded again.
+ *
+ * The gateway is the SINGLE owner of this reset+announce (the Python
+ * `session_start.py` is deliberately NOT wired to it), which eliminates the
+ * two-owner clear/announce race. Reconnect paths (`bridge-reconnect`) and the
+ * compaction / resume / continue paths are EXEMPT by construction: they
+ * reattach to a PERSISTING session, so this is simply never called from them —
+ * there is no `source`-string branch to get wrong.
+ *
+ * This thin factory exists so gateway.ts holds only the loud-send primitive
+ * (which needs the bot handle) and the call sites stay one-liners; the
+ * reset/announce decision lives in `privacy-state.ts` and is unit-tested there.
+ */
+
+import { resetPrivacyOnGenuineSessionStart, SESSION_RESET_ALERT } from './privacy-state.js'
+
+/** Posts the loud (notification-ON) reset alert. Provided by the gateway. */
+export type LoudResetSender = (
+  chatId: string,
+  threadId: number | undefined,
+  text: string,
+) => void
+
+/**
+ * Bind the loud-send primitive into a `(chatId, threadId)` reset function.
+ * Calling the returned function always resets privacy to public; it invokes
+ * `send` (the loud alert) only when a private→public transition actually
+ * happened.
+ */
+export function makePrivacyResetForNewSession(
+  send: LoudResetSender,
+): (chatId: string, threadId: number | undefined) => void {
+  return (chatId, threadId) => {
+    resetPrivacyOnGenuineSessionStart({
+      onOpenIntervalReset: () => send(chatId, threadId, SESSION_RESET_ALERT),
+    })
+  }
+}

--- a/telegram-plugin/gateway/privacy-reset.ts
+++ b/telegram-plugin/gateway/privacy-reset.ts
@@ -21,6 +21,9 @@
  * reset/announce decision lives in `privacy-state.ts` and is unit-tested there.
  */
 
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
 import { resetPrivacyOnGenuineSessionStart, SESSION_RESET_ALERT } from './privacy-state.js'
 
 /** Posts the loud (notification-ON) reset alert. Provided by the gateway. */
@@ -44,4 +47,41 @@ export function makePrivacyResetForNewSession(
       onOpenIntervalReset: () => send(chatId, threadId, SESSION_RESET_ALERT),
     })
   }
+}
+
+/**
+ * Does this boot RESTORE the previous Claude transcript (via `--continue`)?
+ *
+ * The boot reset must NOT fire when the transcript persists: a `continue`/`auto`
+ * agent whose container restarts mid-`/private` task replays the SAME transcript,
+ * so flipping privacy to public would resume storing that very task (the FIX-3
+ * mid-task-reset shape). Mirrors `decideBootBriefing` (boot-briefing-builder.ts):
+ * `continue` always replays; `auto` MAY replay (only when the JSONL is under
+ * `resume_max_bytes`) — the gateway can't see the inner CONTINUE_FLAG, so `auto`
+ * is treated conservatively as a restore (privacy persists; safe direction — an
+ * over-retained private interval merely excludes more, never leaks). A `/new`
+ * `/reset` force-fresh boot is genuinely fresh even under continue/auto.
+ */
+export function bootRestoresTranscript(opts: {
+  resumeMode: string | undefined
+  forceFresh: boolean
+}): boolean {
+  if (opts.forceFresh) return false
+  return opts.resumeMode === 'continue' || opts.resumeMode === 'auto'
+}
+
+/**
+ * Env/marker-reading convenience over `bootRestoresTranscript` for the gateway
+ * boot site. Reads `SWITCHROOM_RESUME_MODE` and the force-fresh signal
+ * (`SWITCHROOM_FORCE_FRESH`, hoisted by start.sh, with the `.force-fresh-session`
+ * marker as the non-docker fallback — same pair `boot-briefing-wiring.ts` uses).
+ */
+export function isContinueRestoreBoot(agentDir: string | null): boolean {
+  const forceFresh =
+    process.env.SWITCHROOM_FORCE_FRESH === '1' ||
+    (agentDir != null && existsSync(join(agentDir, '.force-fresh-session')))
+  return bootRestoresTranscript({
+    resumeMode: process.env.SWITCHROOM_RESUME_MODE,
+    forceFresh,
+  })
 }

--- a/telegram-plugin/gateway/privacy-state.ts
+++ b/telegram-plugin/gateway/privacy-state.ts
@@ -70,6 +70,10 @@ export const PRIVATE_ON_REPLY =
 export const PUBLIC_REPLY =
   '🔓 Public mode — memory writing resumed. The private stretch was excluded from memory.'
 
+/** Loud alert posted when a genuine session start reset a leftover open interval. */
+export const SESSION_RESET_ALERT =
+  '🔓 New session — memory writing is ON by default. Private mode from the previous session was reset.'
+
 /**
  * Agent state dir — set by start.sh; resolved identically to
  * `self-improve-stop.ts:resolveStateDir()` so the gateway writer and the
@@ -171,4 +175,32 @@ export function closePrivateInterval(
 /** Truncate the state file back to the public default. */
 export function resetToPublic(stateDir: string = resolvePrivacyStateDir()): void {
   writePrivacyState(emptyPrivacyState(), stateDir)
+}
+
+/** Outcome of a session-start reset. */
+export interface SessionResetResult {
+  /** True iff an OPEN interval existed and was reset (a private→public transition). */
+  hadOpenInterval: boolean
+}
+
+/**
+ * Reset privacy to public at a GENUINE session start (cold boot / crash /
+ * planned restart / `/clear`). Always truncates the state file. If — and only
+ * if — an OPEN interval existed (the previous session ended still private),
+ * `onOpenIntervalReset` is invoked so the caller can post the loud alert. When
+ * the previous session was already public there is no transition, so no alert
+ * fires (silent reset).
+ *
+ * The alert is delegated to a callback rather than sent here so this module
+ * stays free of gateway/bot dependencies and unit-testable in isolation.
+ */
+export function resetPrivacyOnGenuineSessionStart(opts: {
+  stateDir?: string
+  onOpenIntervalReset?: () => void
+} = {}): SessionResetResult {
+  const stateDir = opts.stateDir ?? resolvePrivacyStateDir()
+  const hadOpenInterval = isPrivate(readPrivacyState(stateDir))
+  resetToPublic(stateDir)
+  if (hadOpenInterval) opts.onOpenIntervalReset?.()
+  return { hadOpenInterval }
 }

--- a/telegram-plugin/tests/privacy-reset-call-sites.test.ts
+++ b/telegram-plugin/tests/privacy-reset-call-sites.test.ts
@@ -80,6 +80,21 @@ describe('privacy reset call sites (PR3 FIX 2 / FIX 3)', () => {
     expect(contexts).toEqual(['boot', 'command:clear', 'maybeIdleClear'])
   })
 
+  it('the boot reset is GUARDED against a --continue transcript-restore (MAJOR fix)', () => {
+    // The boot-branch call must be gated by !isContinueRestoreBoot(...) so a
+    // continue/auto restart that replays the SAME transcript does NOT flip
+    // privacy to public. The /clear + idle calls are always genuine new
+    // sessions and must NOT carry the guard.
+    const lines = GATEWAY_SRC.split('\n')
+    const bootLine = resetCallLines().find(l => enclosingContext(l) === 'boot')
+    expect(bootLine).toBeDefined()
+    expect(lines[bootLine! - 1]).toContain('isContinueRestoreBoot')
+    for (const l of resetCallLines()) {
+      if (enclosingContext(l) === 'boot') continue
+      expect(lines[l - 1]).not.toContain('isContinueRestoreBoot')
+    }
+  })
+
   it('is NOT wired into the bridge-reconnect boot-card path', () => {
     // Scope tightly to the bridge-reconnect block: from its dedupe tag to the
     // `startBootCard(` it posts. The boot-path reset sits right before ITS

--- a/telegram-plugin/tests/privacy-reset-call-sites.test.ts
+++ b/telegram-plugin/tests/privacy-reset-call-sites.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Call-site pin for the gateway-owned session-start privacy reset (PR3).
+ *
+ * The whole point of PR3 (FIX 2 / FIX 3) is that the reset fires on GENUINE new
+ * sessions and is EXEMPT on paths that reattach to a persisting session. That
+ * is a wiring invariant, not a behavior a unit test on the module can observe —
+ * so this test parses gateway.ts and asserts WHERE `resetPrivacyForNewSession`
+ * is (and is not) called, the same source-parsing approach as
+ * `gateway-handler-registration-wiring.test.ts`.
+ *
+ * Instrumented (must call resetPrivacyForNewSession):
+ *   - the `'boot'` boot-card branch (cold start / crash / planned restart)
+ *   - the `bot.command('clear')` handler
+ *   - the idle-clear dispatch (`maybeIdleClear`)
+ *
+ * Exempt by construction (must NOT call it):
+ *   - `bridge-reconnect` (reattaches to a persisting session)
+ *   - `bot.command('compact')` and resume/continue
+ *
+ * Run: npx vitest run telegram-plugin/tests/privacy-reset-call-sites.test.ts
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import ts from 'typescript'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const GATEWAY_PATH = resolve(__dirname, '..', 'gateway', 'gateway.ts')
+const GATEWAY_SRC = readFileSync(GATEWAY_PATH, 'utf8')
+const RESET = 'resetPrivacyForNewSession'
+
+const sourceFile = ts.createSourceFile(
+  GATEWAY_PATH,
+  GATEWAY_SRC,
+  ts.ScriptTarget.Latest,
+  true,
+  ts.ScriptKind.TS,
+)
+
+/** Line number (1-based) of every CALL to `resetPrivacyForNewSession(...)`. */
+function resetCallLines(): number[] {
+  const lines: number[] = []
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === RESET
+    ) {
+      lines.push(sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return lines.sort((a, b) => a - b)
+}
+
+/** The enclosing function/arrow name for a source line, best-effort. */
+function enclosingContext(line: number): string {
+  const idx = line - 1
+  // Walk upward for the nearest recognizable anchor.
+  const lines = GATEWAY_SRC.split('\n')
+  for (let i = idx; i >= 0 && i > idx - 200; i--) {
+    const t = lines[i]
+    if (/bot\.command\('clear'/.test(t)) return 'command:clear'
+    if (/function maybeIdleClear/.test(t)) return 'maybeIdleClear'
+    if (/resolveBootChatId\(marker, markerAgeMs\)/.test(t)) return 'boot'
+  }
+  return 'unknown'
+}
+
+describe('privacy reset call sites (PR3 FIX 2 / FIX 3)', () => {
+  it('calls resetPrivacyForNewSession exactly THREE times', () => {
+    expect(resetCallLines()).toHaveLength(3)
+  })
+
+  it('the three calls are the boot branch, the /clear handler, and idle-clear', () => {
+    const contexts = resetCallLines().map(enclosingContext).sort()
+    expect(contexts).toEqual(['boot', 'command:clear', 'maybeIdleClear'])
+  })
+
+  it('is NOT wired into the bridge-reconnect boot-card path', () => {
+    // Scope tightly to the bridge-reconnect block: from its dedupe tag to the
+    // `startBootCard(` it posts. The boot-path reset sits right before ITS
+    // startBootCard, so if the reconnect path were (wrongly) instrumented the
+    // reset would land in this same window. It must not.
+    const reconnectIdx = GATEWAY_SRC.indexOf("shouldSkipDuplicateBootCard({ activeBootCard, bootCardPending }, 'bridge-reconnect')")
+    expect(reconnectIdx).toBeGreaterThan(-1)
+    const reconnectBootCard = GATEWAY_SRC.indexOf('startBootCard(', reconnectIdx)
+    expect(reconnectBootCard).toBeGreaterThan(reconnectIdx)
+    const window = GATEWAY_SRC.slice(reconnectIdx, reconnectBootCard)
+    expect(window.includes(RESET)).toBe(false)
+  })
+
+  it("is NOT wired into the /compact handler", () => {
+    const compactIdx = GATEWAY_SRC.indexOf("bot.command('compact'")
+    const clearIdx = GATEWAY_SRC.indexOf("bot.command('clear'")
+    expect(compactIdx).toBeGreaterThan(-1)
+    expect(clearIdx).toBeGreaterThan(compactIdx)
+    // The compact handler body sits between the compact and clear registrations.
+    const compactBody = GATEWAY_SRC.slice(compactIdx, clearIdx)
+    expect(compactBody.includes(RESET)).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

PR3 of the `/private` `/public` feature: the gateway becomes the **single owner** of resetting privacy back to public at a genuine new session, with a loud alert if the previous session ended still private.

> **Stacked on #4445.** Base is `feat/private-mode-gateway`, so this PR's diff is just its own commit. Merge #4445 first (or review this as the second commit of the stack).

New-session reset alert (notification ON):

> `🔓 New session — memory writing is ON by default. Private mode from the previous session was reset.`

## Why the gateway is the single owner

`session_start.py` is deliberately **not** touched. Making the gateway the only party that resets + announces eliminates the two-owner clear/announce race. The compaction/resume exemption is **by construction**: the reset is simply never wired into those paths, so there is no `source`-string branch to get wrong.

## Behavior

`privacy-state.ts:resetPrivacyOnGenuineSessionStart()` reads state, truncates it to public, and — **only** when a leftover OPEN interval existed (a private→public transition) — invokes a callback so the caller posts the loud alert. An already-public session start resets silently (no transition, no alert). `privacy-reset.ts` binds the gateway's loud-send primitive into a `(chatId, threadId)` reset function, keeping `gateway.ts` to the send primitive plus one-line call sites (under the gateway line ratchet).

## Call sites instrumented (genuine new session → reset + conditional announce)

- The **`'boot'` boot-card branch** — cold start / crash / planned restart / model-switch apply-boot — reusing boot-card's already-resolved `chatId`.
- **`bot.command('clear')`** — a `/clear` starts a new logical session.
- **The idle-clear dispatch** in `maybeIdleClear` (fires only when the idle `/clear` actually lands, not when suppressed).

## Call sites deliberately EXEMPT (reattach to a PERSISTING session — never wired)

- The **`'bridge-reconnect'`** boot-card path — a reconnect reattaches to a persisting session; privacy state must survive it.
- **`/compact`** and resume / continue.

## Tests

- `telegram-plugin/gateway/privacy-reset.test.ts` — leftover-open-interval → file reset to empty AND callback (loud alert) fired; already-public → reset, no callback; a non-reset (compact/resume) path → state preserved unchanged; and the loud-send binding emits `SESSION_RESET_ALERT` only on a transition.
- `telegram-plugin/tests/privacy-reset-call-sites.test.ts` — a source-parse pin asserting `resetPrivacyForNewSession` is called at exactly the three instrumented sites and NOT in the bridge-reconnect or `/compact` paths.

Full `npm run lint` (tsc + all guards, incl. gateway line ratchet and bot-api-wrapping) and the scoped vitest suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
