### PR TITLE
fix(ci): skip agent-attribution guard on merge_group (queue false positive)

### DIFF
--- a/scripts/check-agent-attribution-trailers.mjs
+++ b/scripts/check-agent-attribution-trailers.mjs
@@ -369,6 +369,33 @@ function loadAllowlist(root) {
  * @returns {{status: 'pass'|'skip'|'fail', lines: string[]}}
  */
 export function run(cwd = resolveRepoRoot(process.cwd()), env = process.env) {
+  // GitHub's merge queue builds a synthetic squash-merge commit SERVER-SIDE at
+  // merge time and pushes it to a `gh-readonly-queue/main/...` ref, firing this
+  // workflow with `GITHUB_EVENT_NAME=merge_group`. That commit inherits the
+  // PR's `Co-authored-by: Claude ...` trailer — so `isMachineAuthored` is true —
+  // but the in-container `prepare-commit-msg` hook cannot reach it: GitHub, not
+  // an agent container, authored it, so it carries no `Switchroom-*` trailers,
+  // and when the PR body puts prose between the trailer paragraphs the fold in
+  // `parseTrailers` cannot recover them either. Enforcing here reds a PR whose
+  // REAL branch commits were already inspected and passed at the `pull_request`
+  // event — by THIS same script via the required `lint` context, and again by
+  // `agent-attribution.yml`'s always-on `agent-trailers` job. So a merge_group
+  // run is a guaranteed false positive on an unstampable synthetic commit; skip
+  // it. Attribution is NOT weakened: the enforcing pass is the pull_request one,
+  // which still runs on every PR and is what actually gates the branch commits.
+  // (Allowlisting can't fix this — the synthetic SHA changes on every requeue.)
+  if (env.GITHUB_EVENT_NAME === 'merge_group') {
+    return {
+      status: 'skip',
+      lines: [
+        'check-agent-attribution-trailers: SKIP — merge_group event.',
+        '  The merge queue builds a synthetic squash-merge commit server-side that',
+        '  the in-container hook cannot stamp. Attribution was already enforced on',
+        "  the PR's real branch commits at the pull_request event.",
+      ],
+    }
+  }
+
   const range = resolveRange(cwd, env)
   if (!range) {
     return {

--- a/tests/agent-attribution-check.test.ts
+++ b/tests/agent-attribution-check.test.ts
@@ -63,6 +63,12 @@ function makeFixture(prefix: string): Fixture {
   env.GIT_AUTHOR_EMAIL = "operator@example.test";
   env.GIT_COMMITTER_NAME = "Operator";
   env.GIT_COMMITTER_EMAIL = "operator@example.test";
+  // Hermetic against the ambient CI event. `ci-tests-core.yml` runs this suite
+  // on `merge_group` too, and the guard SKIPs when `GITHUB_EVENT_NAME` is
+  // `merge_group` (the synthetic squash commit is unstampable — see the guard).
+  // Left inherited, that would silently turn every red-case fixture below into a
+  // skip during a queue run. Each test that cares sets the event explicitly.
+  delete env.GITHUB_EVENT_NAME;
 
   const git = (args: string[], extra: Record<string, string> = {}) =>
     execFileSync("git", args, {
@@ -360,6 +366,58 @@ describe("check-agent-attribution-trailers — robust to GitHub squash reparagra
 
     const r = f.check();
     expect(r.code).toBe(0);
+  });
+});
+
+describe("check-agent-attribution-trailers — merge-queue synthetic squash commit", () => {
+  // GitHub's merge queue builds a squash-merge commit SERVER-SIDE and fires the
+  // workflow with GITHUB_EVENT_NAME=merge_group. That commit inherits the PR's
+  // `Co-authored-by: Claude` trailer (so it reads as machine-authored) but the
+  // in-container hook cannot stamp it, and when the PR body puts prose between
+  // the trailer paragraphs the fold cannot recover the Switchroom-* trailers
+  // either. It is a guaranteed false positive: the branch commits were already
+  // enforced at the pull_request event. (Observed on #4446's queue squash.)
+  const MERGE_QUEUE_SQUASH = [
+    "feat(gateway): session-start reset to public + alert (#4446)",
+    "",
+    // Prose body bled in from the PR description, sitting BETWEEN the two
+    // trailer paragraphs — this is what defeats parseTrailers' fold and reds
+    // the commit on a normal (non-merge_group) run.
+    "This reworks the session-start path so that a fresh session resets to",
+    "public and emits an alert. Details in the PR description above.",
+    "",
+    "Switchroom-Agent: carrie",
+    "Switchroom-Model: claude-opus-4-8",
+    "",
+    "More prose that GitHub carried through from the squashed body, which",
+    "isolates the attribution paragraph from the co-author paragraph below.",
+    "",
+    "Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>",
+  ].join("\n");
+
+  it("SKIPs on the merge_group event — the synthetic squash commit is unstampable", () => {
+    const f = makeFixture("attrchk-mq-skip-");
+    f.commit(MERGE_QUEUE_SQUASH);
+
+    const r = f.check({ GITHUB_EVENT_NAME: "merge_group" });
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("SKIP — merge_group event");
+  });
+
+  it("STILL FAILS that same commit shape on a normal (non-merge_group) run", () => {
+    // The guard is only relaxed for the merge queue's own synthetic commit.
+    // The identical shape on the branch (pull_request / local) is exactly the
+    // genuine-enforcement path and must still red — otherwise the skip would
+    // blind real unattributed work. GITHUB_EVENT_NAME is set to '' so this
+    // holds even when the suite itself runs under a merge_group CI event.
+    const f = makeFixture("attrchk-mq-fail-");
+    f.commit(MERGE_QUEUE_SQUASH);
+
+    const r = f.check({ GITHUB_EVENT_NAME: "" });
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("check-agent-attribution-trailers: FAIL");
+    expect(r.out).toContain("missing `Switchroom-Agent:` trailer");
+    expect(r.out).toContain("missing `Switchroom-Model:` trailer");
   });
 });
 


### PR DESCRIPTION
## Problem

`scripts/check-agent-attribution-trailers.mjs` (run via `bun lint` in `ci-lint.yml`) is FAILING in the GitHub merge-queue `merge_group` event and repeatedly bouncing PRs (#4444, #4446) out of the queue. The same check PASSES on the standalone `pull_request` event, where the PR's real branch commits are correctly stamped.

### Root cause (confirmed)

In a `merge_group` run, GitHub builds a **synthetic squash-merge commit server-side** and pushes it to a `gh-readonly-queue/main/...` ref. The guard resolves its range to `origin/main..HEAD` (no `GITHUB_BASE_REF` in `merge_group`, so it falls through to `origin/main`), and that range contains the synthetic squash commit — a **single-parent** commit, so the guard's merge-commit skip (`rev-list --no-merges`, which only drops parent-count > 1) does not catch it.

That squash commit inherits the PR's `Co-authored-by: Claude` trailer, so `isMachineAuthored` returns true — but:
- the in-container `prepare-commit-msg` hook (`bin/git-agent-attribution-hook.sh`) cannot stamp it (GitHub, not an agent container, authored it), so it has no `Switchroom-*` trailers of its own; and
- when the squashed PR body puts **prose between the trailer paragraphs**, `parseTrailers`' fold (which deliberately stops at the first prose paragraph) cannot recover the source commits' `Switchroom-*` trailers either.

So the guard reds a PR whose real branch commits were **already enforced and passed** at the `pull_request` event — both by this same script via the required `lint` context and by `agent-attribution.yml`'s always-on `agent-trailers` job. #4445 merged only because its squash body happened to keep the trailers foldable; #4446's prose-bodied commits defeat the fold. It's message-shape-dependent and unreliable. The synthetic SHA changes on every requeue, so the allowlist cannot address it.

## Fix

The guard **SKIPs when `GITHUB_EVENT_NAME === 'merge_group'`**. This matches the header's existing design intent (merge-generated commits are out of scope; attribution lives in the merged commits). Attribution is **not** weakened: the enforcing pass is the `pull_request` one, which still runs on every PR and gates the real branch commits — the merge-queue re-run only ever sees the unstampable synthetic commit.

Chosen over "skip only the synthetic squash tip commit" (option b): matching a `(#\d+)` subject + base-tip parent is fragile, gameable, and multiplies in a multi-PR merge group, whereas gating on the event is deterministic and can't be gamed because the genuine enforcement runs on a separate event.

## Tests

New `merge_group` cases in `tests/agent-attribution-check.test.ts`:
- a merge-queue-style synthetic squash (Claude co-author, prose between trailer paragraphs, no foldable `Switchroom-*`) is **NOT** flagged under `merge_group` (verified to FAIL on pre-fix code); and
- the **identical** shape on a normal run **STILL fails** — the skip does not blind genuine enforcement.

The fixture now deletes `GITHUB_EVENT_NAME` so the existing red-case tests stay hermetic — `ci-tests-core.yml` also triggers on `merge_group`, which would otherwise silently turn every red-case fixture into a skip during a queue run.

Local: 18/18 guard tests pass, `tsc --noEmit` clean, guard green on `pull_request`-equiv and SKIP on simulated `merge_group`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)