### PR TITLE
feat(config-repo): switchroom config-repo sync verb + schema + doctor (slice 1)

### DIFF
--- a/src/cli/config-repo.ts
+++ b/src/cli/config-repo.ts
@@ -1,0 +1,160 @@
+/**
+ * `switchroom config-repo` — change control for the operator's private
+ * `~/.switchroom-config` git repo.
+ *
+ * Slice 1 ships the `sync` subcommand: a native, flock-guarded, secret-scanned
+ * port of the hand-written `sync.sh`, with the personal-skills force-add (GAP
+ * A) and the `require_private` push gate. See `src/config-repo/sync.ts` for the
+ * full rationale.
+ *
+ * Exit codes:
+ *   0  — synced cleanly (committed or already up to date; pushed if enabled).
+ *  10  — synced, but a WARN fired: a secret was withheld, a symlink escaped,
+ *        or the push was skipped/failed. The commit still landed locally.
+ *   1  — could not complete (not a git repo, live config missing, lock
+ *        contention, git commit failure).
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { Command } from "commander";
+import chalk from "chalk";
+
+import { loadConfig, resolvePath } from "../config/loader.js";
+import {
+  defaultSyncDeps,
+  runConfigRepoSyncLocked,
+  type ConfigRepoSyncOptions,
+} from "../config-repo/sync.js";
+import { VaultBusyError } from "../vault/flock.js";
+
+function switchroomHome(): string {
+  return process.env.SWITCHROOM_HOME ?? process.env.HOME ?? homedir();
+}
+
+interface SyncOptions {
+  message?: string;
+  push: boolean;
+  path?: string;
+  remote?: string;
+  requirePrivate?: boolean;
+}
+
+/**
+ * Resolve the effective sync options from CLI flags, then `config_repo:`, then
+ * built-in defaults — so the verb works with an empty/absent config block.
+ */
+function resolveSyncOptions(configPath: string | undefined, opts: SyncOptions): ConfigRepoSyncOptions {
+  let cfg: { path?: string; push?: boolean; remote?: string; require_private?: boolean } = {};
+  try {
+    const loaded = loadConfig(configPath);
+    if (loaded.config_repo) cfg = loaded.config_repo;
+  } catch {
+    /* tolerate missing/malformed config — defaults below still work */
+  }
+
+  const home = switchroomHome();
+  const repoPath = opts.path
+    ? resolvePath(opts.path)
+    : cfg.path
+      ? resolvePath(cfg.path)
+      : join(home, ".switchroom-config");
+
+  const livePath = process.env.SWITCHROOM_CONFIG ?? join(home, ".switchroom", "switchroom.yaml");
+  const agentsDir =
+    process.env.SWITCHROOM_AGENTS_DIR ?? join(home, ".switchroom", "agents");
+
+  // --no-push (commander sets push:false) always wins; otherwise config, else true.
+  const push = opts.push === false ? false : (cfg.push ?? true);
+  const remote = opts.remote ?? cfg.remote ?? "origin";
+  const requirePrivate = opts.requirePrivate ?? cfg.require_private ?? true;
+
+  return {
+    repoPath,
+    livePath,
+    agentsDir,
+    push,
+    remote,
+    requirePrivate,
+    message: opts.message,
+  };
+}
+
+export function registerConfigRepoCommand(program: Command): void {
+  const configRepo = program
+    .command("config-repo")
+    .description(
+      "Change control for the operator's private ~/.switchroom-config git repo " +
+        "(backup + audit trail of live host config, agent workspace state, and " +
+        "mirrored personal skills).",
+    );
+
+  configRepo
+    .command("sync")
+    .description(
+      "Copy live host config + owned agent workspace state + mirrored personal " +
+        "skills into the config repo, secret-scan, commit, and (unless " +
+        "--no-push) push — refusing to push a non-private remote.",
+    )
+    .option("-m, --message <msg>", "commit message override")
+    .option("--no-push", "commit locally only; do not push")
+    .option("--path <path>", "config repo path (default: config_repo.path or ~/.switchroom-config)")
+    .option("--remote <name>", "git remote to push to (default: config_repo.remote or origin)")
+    .option(
+      "--no-require-private",
+      "skip the private-remote push gate (DANGEROUS — allows push to a public remote)",
+    )
+    .action(async (opts: SyncOptions) => {
+      const parentOpts = program.opts();
+      const resolved = resolveSyncOptions(parentOpts.config, opts);
+      const log = (m: string): void => {
+        process.stderr.write(`${m}\n`);
+      };
+
+      let result;
+      try {
+        result = runConfigRepoSyncLocked(resolved, defaultSyncDeps(resolved.repoPath, log));
+      } catch (e) {
+        if (e instanceof VaultBusyError) {
+          process.stderr.write(
+            chalk.yellow(
+              `config-repo sync: another sync holds the lock — ${e.message}\n`,
+            ),
+          );
+          process.exitCode = 1;
+          return;
+        }
+        process.stderr.write(chalk.red(`config-repo sync: ${(e as Error).message}\n`));
+        process.exitCode = 1;
+        return;
+      }
+
+      // Summary.
+      if (result.committed) {
+        process.stdout.write(
+          `${chalk.green("✓")} committed ${result.commitSha ?? ""}`.trim() + "\n",
+        );
+      } else {
+        process.stdout.write(`${chalk.gray("•")} nothing to commit\n`);
+      }
+      if (resolved.push) {
+        if (result.pushed) {
+          process.stdout.write(`${chalk.green("✓")} pushed to ${resolved.remote}\n`);
+        } else {
+          process.stdout.write(
+            `${chalk.yellow("⚠")} not pushed: ${result.pushSkippedReason ?? "unknown"}\n`,
+          );
+        }
+      }
+      for (const f of result.secretFindings) {
+        process.stdout.write(
+          `${chalk.red("⚠")} secret withheld from ${f.file} (${f.pattern})\n`,
+        );
+      }
+      for (const s of result.skippedSymlinks) {
+        process.stdout.write(`${chalk.yellow("⚠")} skipped ${s.file}: ${s.reason}\n`);
+      }
+
+      process.exitCode = result.exitCode;
+    });
+}

--- a/src/cli/doctor-config-repo.test.ts
+++ b/src/cli/doctor-config-repo.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { classifyConfigRepo, UNPUSHED_STALE_MS, type ConfigRepoFacts } from "./doctor-config-repo.js";
+
+const base: ConfigRepoFacts = {
+  configured: true,
+  enabled: true,
+  repoPath: "/home/op/.switchroom-config",
+  isGitRepo: true,
+  isPrivate: true,
+  untrackedPersonalSkills: 0,
+  unpushedCount: 0,
+  oldestUnpushedAgeMs: null,
+};
+
+function row(rows: ReturnType<typeof classifyConfigRepo>, name: string) {
+  return rows.find((r) => r.name === name);
+}
+
+describe("classifyConfigRepo", () => {
+  it("emits no rows when config_repo is not configured", () => {
+    expect(classifyConfigRepo({ ...base, configured: false })).toHaveLength(0);
+  });
+
+  it("FAILs and short-circuits when the path is not a git repo", () => {
+    const rows = classifyConfigRepo({ ...base, isGitRepo: false });
+    expect(rows).toHaveLength(1);
+    expect(row(rows, "config repo present")?.status).toBe("fail");
+  });
+
+  it("FAILs when the remote is public", () => {
+    const rows = classifyConfigRepo({ ...base, isPrivate: false });
+    expect(row(rows, "config repo private")?.status).toBe("fail");
+  });
+
+  it("WARNs when visibility is unverifiable", () => {
+    const rows = classifyConfigRepo({ ...base, isPrivate: null });
+    expect(row(rows, "config repo private")?.status).toBe("warn");
+  });
+
+  it("WARNs on untracked personal skills (GAP A backstop) and clears when zero", () => {
+    expect(row(classifyConfigRepo({ ...base, untrackedPersonalSkills: 84 }), "config repo personal skills tracked")?.status).toBe("warn");
+    expect(row(classifyConfigRepo(base), "config repo personal skills tracked")?.status).toBe("ok");
+  });
+
+  it("FAILs on unpushed commits older than 24h, OK when recent", () => {
+    const stale = classifyConfigRepo({ ...base, unpushedCount: 3, oldestUnpushedAgeMs: UNPUSHED_STALE_MS + 1 });
+    expect(row(stale, "config repo unpushed")?.status).toBe("fail");
+    const recent = classifyConfigRepo({ ...base, unpushedCount: 1, oldestUnpushedAgeMs: 60_000 });
+    expect(row(recent, "config repo unpushed")?.status).toBe("ok");
+  });
+
+  it("WARNs when there is no upstream tracking ref", () => {
+    const rows = classifyConfigRepo({ ...base, unpushedCount: null });
+    expect(row(rows, "config repo unpushed")?.status).toBe("warn");
+  });
+});

--- a/src/cli/doctor-config-repo.ts
+++ b/src/cli/doctor-config-repo.ts
@@ -1,0 +1,300 @@
+/**
+ * `switchroom doctor` — config-repo change-control health.
+ *
+ * Rows (only emitted when a `config_repo:` block is configured):
+ *   - **present**  — the configured path is a git repo (else FAIL: the sync
+ *     verb and every backup guarantee are dead).
+ *   - **private**  — the GitHub remote is private (FAIL if public — the
+ *     require_private gate will refuse every push; WARN if unverifiable).
+ *   - **personal skills tracked** — how many mirrored personal-skill files on
+ *     disk are still untracked. Fires today on GAP A (84 files across the
+ *     fleet) and self-clears after the first `config-repo sync`.
+ *   - **unpushed** — commits ahead of the upstream, red once the oldest is
+ *     older than 24h (the loud backstop for a broken push / offline host).
+ *
+ * The classifier is pure so both branches of each row are unit-testable without
+ * arranging a real repo state.
+ */
+
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { resolvePath } from "../config/loader.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+import { PERSONAL_SKILLS_SUBPATH, type CmdRunner } from "../config-repo/sync.js";
+
+export interface CheckResult {
+  name: string;
+  status: "ok" | "warn" | "fail";
+  detail?: string;
+  fix?: string;
+}
+
+/** How old the oldest unpushed commit may be before the row goes red. */
+export const UNPUSHED_STALE_MS = 24 * 60 * 60 * 1000;
+
+/** Host facts the classifier turns into rows. */
+export interface ConfigRepoFacts {
+  /** Is a `config_repo:` block present at all. */
+  configured: boolean;
+  enabled: boolean;
+  repoPath: string;
+  isGitRepo: boolean;
+  /** GitHub remote visibility: true=private, false=public, null=unverifiable. */
+  isPrivate: boolean | null;
+  /** Mirrored personal-skill files on disk that git is not tracking. */
+  untrackedPersonalSkills: number;
+  /** Commits ahead of upstream; null when the upstream ref is unknown. */
+  unpushedCount: number | null;
+  /** Age (ms) of the OLDEST unpushed commit; null when none/unknown. */
+  oldestUnpushedAgeMs: number | null;
+}
+
+const FIX_SYNC = "Run `switchroom config-repo sync` (add `--no-push` to commit only).";
+
+export function classifyConfigRepo(f: ConfigRepoFacts): CheckResult[] {
+  if (!f.configured) return [];
+  const rows: CheckResult[] = [];
+
+  // present
+  if (!f.isGitRepo) {
+    rows.push({
+      name: "config repo present",
+      status: "fail",
+      detail: `${f.repoPath} is not a git repo (no .git) — config-repo sync cannot run`,
+      fix: `Clone the operator's private config repo to ${f.repoPath}, or fix config_repo.path.`,
+    });
+    // Nothing else is meaningful without a repo.
+    return rows;
+  }
+  rows.push({
+    name: "config repo present",
+    status: "ok",
+    detail: `${f.repoPath}${f.enabled ? "" : " (config_repo.enabled: false)"}`,
+  });
+
+  // private
+  if (f.isPrivate === false) {
+    rows.push({
+      name: "config repo private",
+      status: "fail",
+      detail: "GitHub remote is PUBLIC — require_private will refuse every push, and workspace/memory state must not live in a public repo",
+      fix: "Make the remote private (GitHub → Settings → Danger Zone), or move the remote.",
+    });
+  } else if (f.isPrivate === null) {
+    rows.push({
+      name: "config repo private",
+      status: "warn",
+      detail: "could not confirm remote is private (gh unavailable / API unreachable) — pushes will be skipped until verifiable",
+      fix: "Check `gh auth status`; the require_private gate fails safe (no push) while unverifiable.",
+    });
+  } else {
+    rows.push({ name: "config repo private", status: "ok", detail: "remote is private" });
+  }
+
+  // personal skills tracked (GAP A)
+  if (f.untrackedPersonalSkills > 0) {
+    rows.push({
+      name: "config repo personal skills tracked",
+      status: "warn",
+      detail: `${f.untrackedPersonalSkills} mirrored personal-skill file(s) on disk are untracked (GAP A) — a repo clone would lose them`,
+      fix: FIX_SYNC,
+    });
+  } else {
+    rows.push({
+      name: "config repo personal skills tracked",
+      status: "ok",
+      detail: "all mirrored personal skills are tracked",
+    });
+  }
+
+  // unpushed
+  if (f.unpushedCount === null) {
+    rows.push({
+      name: "config repo unpushed",
+      status: "warn",
+      detail: "no upstream tracking ref — cannot tell whether commits are pushed",
+      fix: "Set an upstream: `git -C <repo> push -u origin HEAD`.",
+    });
+  } else if (f.unpushedCount === 0) {
+    rows.push({ name: "config repo unpushed", status: "ok", detail: "up to date with upstream" });
+  } else {
+    const ageMs = f.oldestUnpushedAgeMs ?? 0;
+    const hrs = Math.round(ageMs / 3_600_000);
+    if (ageMs > UNPUSHED_STALE_MS) {
+      rows.push({
+        name: "config repo unpushed",
+        status: "fail",
+        detail: `${f.unpushedCount} unpushed commit(s); oldest is ${hrs}h old (stale past 24h) — push is broken or the host is offline`,
+        fix: "Investigate push/auth: `git -C <repo> push`; check `gh auth status` and remote reachability.",
+      });
+    } else {
+      rows.push({
+        name: "config repo unpushed",
+        status: "ok",
+        detail: `${f.unpushedCount} unpushed commit(s), newest activity ${hrs}h ago (within 24h)`,
+      });
+    }
+  }
+
+  return rows;
+}
+
+function gitRunner(repoPath: string): CmdRunner {
+  return (args) => {
+    const r = spawnSync("git", ["-C", repoPath, ...args], { encoding: "utf-8" });
+    return { ok: r.status === 0, stdout: (r.stdout ?? "").trim(), stderr: (r.stderr ?? "").trim() };
+  };
+}
+
+function ghRunner(): CmdRunner {
+  return (args) => {
+    const r = spawnSync("gh", args, { encoding: "utf-8" });
+    return { ok: r.status === 0, stdout: (r.stdout ?? "").trim(), stderr: (r.stderr ?? "").trim() };
+  };
+}
+
+/** Walk each agent's personal-skills slice and count files not tracked by git. */
+export function countUntrackedPersonalSkills(repoPath: string, git: CmdRunner): number {
+  const agentsDir = join(repoPath, "agents");
+  if (!existsSync(agentsDir)) return 0;
+
+  const tracked = new Set<string>();
+  const ls = git(["ls-files"]);
+  if (ls.ok) {
+    for (const line of ls.stdout.split("\n")) {
+      if (line.includes(`/${PERSONAL_SKILLS_SUBPATH}/`)) tracked.add(line);
+    }
+  }
+
+  let untracked = 0;
+  const walk = (dir: string, relPrefix: string): void => {
+    let ents: string[];
+    try {
+      ents = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const ent of ents) {
+      const abs = join(dir, ent);
+      const rel = relPrefix ? `${relPrefix}/${ent}` : ent;
+      let st;
+      try {
+        st = statSync(abs);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) walk(abs, rel);
+      else if (st.isFile() && !tracked.has(rel)) untracked++;
+    }
+  };
+
+  for (const agent of safeReaddir(agentsDir)) {
+    const ps = join(agentsDir, agent, PERSONAL_SKILLS_SUBPATH);
+    if (!existsSync(ps)) continue;
+    for (const ent of safeReaddir(ps)) {
+      if (ent.startsWith(".")) continue; // staging/prior/trash/journal siblings
+      const abs = join(ps, ent);
+      let st;
+      try {
+        st = statSync(abs);
+      } catch {
+        continue;
+      }
+      const rel = `agents/${agent}/${PERSONAL_SKILLS_SUBPATH}/${ent}`;
+      if (st.isDirectory()) walk(abs, rel);
+      else if (st.isFile() && !tracked.has(rel)) untracked++;
+    }
+  }
+  return untracked;
+}
+
+function safeReaddir(p: string): string[] {
+  try {
+    return readdirSync(p);
+  } catch {
+    return [];
+  }
+}
+
+/** Compute unpushed count + oldest-commit age against the upstream ref. */
+export function readUnpushed(
+  git: CmdRunner,
+  now: number,
+): { count: number | null; oldestAgeMs: number | null } {
+  const branch = git(["rev-parse", "--abbrev-ref", "HEAD"]);
+  if (!branch.ok) return { count: null, oldestAgeMs: null };
+  // Resolve the configured upstream; if none, we can't judge.
+  const upstream = git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]);
+  if (!upstream.ok || upstream.stdout.length === 0) return { count: null, oldestAgeMs: null };
+
+  const log = git(["log", "--format=%ct", `${upstream.stdout}..HEAD`]);
+  if (!log.ok) return { count: null, oldestAgeMs: null };
+  const times = log.stdout
+    .split("\n")
+    .map((l) => Number.parseInt(l.trim(), 10))
+    .filter((n) => Number.isFinite(n));
+  if (times.length === 0) return { count: 0, oldestAgeMs: null };
+  const oldest = Math.min(...times);
+  return { count: times.length, oldestAgeMs: now - oldest * 1000 };
+}
+
+/** Read host facts and classify. */
+export function checkConfigRepo(
+  config: SwitchroomConfig,
+  now: number = Date.now(),
+): CheckResult[] {
+  const block = config.config_repo;
+  if (!block) return [];
+
+  const repoPath = block.path
+    ? resolvePath(block.path)
+    : join(process.env.SWITCHROOM_HOME ?? process.env.HOME ?? homedir(), ".switchroom-config");
+
+  const isGitRepo = existsSync(join(repoPath, ".git"));
+  if (!isGitRepo) {
+    return classifyConfigRepo({
+      configured: true,
+      enabled: block.enabled,
+      repoPath,
+      isGitRepo: false,
+      isPrivate: null,
+      untrackedPersonalSkills: 0,
+      unpushedCount: null,
+      oldestUnpushedAgeMs: null,
+    });
+  }
+
+  const git = gitRunner(repoPath);
+  const gh = ghRunner();
+
+  // Visibility probe (best-effort).
+  let isPrivate: boolean | null = null;
+  const remoteUrl = git(["remote", "get-url", block.remote]);
+  if (remoteUrl.ok) {
+    const m = remoteUrl.stdout.match(/github\.com[/:]([^/]+)\/(.+?)(?:\.git)?\/?$/);
+    if (m) {
+      const r = gh(["api", `repos/${m[1]}/${m[2]}`, "--jq", ".private"]);
+      if (r.ok) {
+        const v = r.stdout.trim().toLowerCase();
+        isPrivate = v === "true" ? true : v === "false" ? false : null;
+      }
+    }
+  }
+
+  const untracked = countUntrackedPersonalSkills(repoPath, git);
+  const unpushed = readUnpushed(git, now);
+
+  return classifyConfigRepo({
+    configured: true,
+    enabled: block.enabled,
+    repoPath,
+    isGitRepo: true,
+    isPrivate,
+    untrackedPersonalSkills: untracked,
+    unpushedCount: unpushed.count,
+    oldestUnpushedAgeMs: unpushed.oldestAgeMs,
+  });
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -59,6 +59,7 @@ import { checkAgentRecallHealth } from "./doctor-recall-health.js";
 import { checkHnswPartialIndexes } from "./doctor-hnsw-index.js";
 import { checkObservationScopeSaturation } from "./doctor-observation-scopes.js";
 import { checkHindsightWatchArmed } from "./doctor-hindsight-watch.js";
+import { checkConfigRepo } from "./doctor-config-repo.js";
 import { runLitellmModelChecks } from "../litellm/model-validation.js";
 import { runLitellmKeyAllowlistChecks } from "../litellm/key-allowlist-check.js";
 import { runRoutingModeChecks } from "./doctor-routing-mode.js";
@@ -608,6 +609,11 @@ export function checkConfig(config: SwitchroomConfig, configPath: string): Check
   // non-strict), so the operator's yaml reads as configured and does nothing.
   // A REMOVED knob is worse — they have evidence they once set it. Surface it.
   results.push(checkMemoryKeysAreKnown(configPath));
+
+  // Config-repo change control (only emits rows when `config_repo:` is set):
+  // repo-is-git, remote-is-private, personal-skills-tracked (GAP A backstop),
+  // and unpushed-commit staleness.
+  results.push(...checkConfigRepo(config));
 
   return results;
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -51,6 +51,7 @@ import { registerHostCommand } from "./host-repair.js";
 import { registerFleetHealthCommand } from "./fleet-health.js";
 import { registerHindsightWatchCommand } from "./hindsight-watch.js";
 import { registerOpenRouterWatchCommand } from "./openrouter-watch.js";
+import { registerConfigRepoCommand } from "./config-repo.js";
 import { captureEvent, installGlobalErrorHandlers } from "../analytics/posthog.js";
 
 installGlobalErrorHandlers();
@@ -129,3 +130,4 @@ registerHostCommand(program);
 registerFleetHealthCommand(program);
 registerHindsightWatchCommand(program);
 registerOpenRouterWatchCommand(program);
+registerConfigRepoCommand(program);

--- a/src/config-repo/sync.test.ts
+++ b/src/config-repo/sync.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  symlinkSync,
+  lstatSync,
+  existsSync,
+  readFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  runConfigRepoSync,
+  runConfigRepoSyncLocked,
+  defaultSyncDeps,
+  parseGitHubSlug,
+  guardedCopyFile,
+  type ConfigRepoSyncDeps,
+  type CmdRunner,
+} from "./sync.js";
+
+/** Run git in a repo and assert success (setup helper). */
+function git(repo: string, args: string[]): string {
+  const r = spawnSync("git", ["-C", repo, ...args], { encoding: "utf-8" });
+  if (r.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${r.stderr}`);
+  }
+  return (r.stdout ?? "").trim();
+}
+
+/** Every file git currently tracks in the repo. */
+function trackedFiles(repo: string): string[] {
+  return git(repo, ["ls-files"]).split("\n").filter(Boolean);
+}
+
+let base: string;
+let repo: string;
+let live: string;
+let agentsDir: string;
+const logs: string[] = [];
+
+/** A gh stub whose visibility answer is set per test. */
+function ghStub(visibility: "private" | "public" | "error"): CmdRunner {
+  return (args) => {
+    // Only the `api repos/<owner>/<repo> --jq .private` shape is exercised.
+    if (visibility === "error") return { ok: false, stdout: "", stderr: "gh not authed" };
+    return { ok: true, stdout: visibility === "private" ? "true" : "false", stderr: "" };
+  };
+}
+
+function deps(gh: CmdRunner): ConfigRepoSyncDeps {
+  const real = defaultSyncDeps(repo, (m) => logs.push(m));
+  return { git: real.git, gh, log: (m) => logs.push(m) };
+}
+
+beforeEach(() => {
+  logs.length = 0;
+  base = mkdtempSync(join(tmpdir(), "config-repo-sync-"));
+  repo = join(base, "repo");
+  live = join(base, "live");
+  agentsDir = join(live, "agents");
+
+  // --- config repo (git) ---
+  mkdirSync(repo, { recursive: true });
+  git(repo, ["init", "-q", "-b", "main"]);
+  git(repo, ["config", "user.email", "test@example.com"]);
+  git(repo, ["config", "user.name", "Test"]);
+  // Blanket agents/ ignore, exactly like the operator's real config repo.
+  writeFileSync(join(repo, ".gitignore"), "agents/\nvault.enc\n");
+  writeFileSync(join(repo, "README.md"), "# config\n");
+  git(repo, ["add", "-A"]);
+  git(repo, ["commit", "-q", "-m", "init"]);
+  // A GitHub remote so the private-gate path is exercised.
+  git(repo, ["remote", "add", "origin", "https://github.com/acme/switchroom-config.git"]);
+
+  // --- live tree ---
+  const ws = join(agentsDir, "klanker", "workspace");
+  mkdirSync(join(ws, "memory"), { recursive: true });
+  writeFileSync(join(ws, "SOUL.md"), "persona\n");
+  writeFileSync(join(ws, "memory", "2026-08-06.md"), "daily notes\n");
+  writeFileSync(join(live, "switchroom.yaml"), "switchroom:\n  version: 1\n");
+
+  // A mirrored personal skill already on disk in the repo (agents mirror
+  // writes directly into their slice) — blanket-ignored, so untracked.
+  const ps = join(repo, "agents", "klanker", "personal-skills", "foo");
+  mkdirSync(ps, { recursive: true });
+  writeFileSync(join(ps, "SKILL.md"), "---\nname: foo\ndescription: a skill\n---\nbody\n");
+});
+
+afterEach(() => {
+  rmSync(base, { recursive: true, force: true });
+});
+
+const baseOpts = () => ({
+  repoPath: repo,
+  livePath: join(live, "switchroom.yaml"),
+  agentsDir,
+  push: true,
+  remote: "origin",
+  requirePrivate: true,
+});
+
+describe("config-repo sync — GAP A + core invariants", () => {
+  it("tracks mirrored personal skills (ls-files goes zero -> non-zero) and commits workspace state", () => {
+    // RED-WITHOUT-FIX baseline: before sync, no personal-skill file is tracked.
+    expect(trackedFiles(repo).filter((f) => f.includes("personal-skills"))).toHaveLength(0);
+
+    const res = runConfigRepoSync(baseOpts(), deps(ghStub("private")));
+
+    expect(res.committed).toBe(true);
+    const tracked = trackedFiles(repo);
+    // GAP A closed: the personal skill is now tracked.
+    expect(tracked).toContain("agents/klanker/personal-skills/foo/SKILL.md");
+    // Workspace owned file + memory captured.
+    expect(tracked).toContain("agents/klanker/workspace/SOUL.md");
+    expect(tracked).toContain("agents/klanker/workspace/memory/2026-08-06.md");
+    // yaml copied in.
+    expect(tracked).toContain("switchroom.yaml");
+  });
+
+  it("stores switchroom.yaml as a REGULAR FILE, not a symlink (rename() trap)", () => {
+    // Even if a prior 'simplification' left a symlink, sync must replace it.
+    const repoYaml = join(repo, "switchroom.yaml");
+    symlinkSync(join(live, "switchroom.yaml"), repoYaml);
+    expect(lstatSync(repoYaml).isSymbolicLink()).toBe(true);
+
+    runConfigRepoSync(baseOpts(), deps(ghStub("private")));
+
+    expect(lstatSync(repoYaml).isSymbolicLink()).toBe(false);
+    expect(readFileSync(repoYaml, "utf-8")).toContain("version: 1");
+  });
+
+  it("withholds a planted secret from the commit and exits with a WARN", () => {
+    // A secret arrives by a direct rw-mount write into a personal-skill slice,
+    // bypassing the in-container CLI scan.
+    const evil = join(repo, "agents", "klanker", "personal-skills", "evil");
+    mkdirSync(evil, { recursive: true });
+    writeFileSync(
+      join(evil, "SKILL.md"),
+      "---\nname: evil\ndescription: leaks\n---\ntoken ghp_ABCDEFGHIJ0123456789KLMNOPqrst here\n",
+    );
+
+    const res = runConfigRepoSync(baseOpts(), deps(ghStub("private")));
+
+    expect(res.secretFindings.length).toBeGreaterThan(0);
+    expect(res.exitCode).toBe(10);
+    // The offending file is NOT tracked; the clean skill still is.
+    const tracked = trackedFiles(repo);
+    expect(tracked).not.toContain("agents/klanker/personal-skills/evil/SKILL.md");
+    expect(tracked).toContain("agents/klanker/personal-skills/foo/SKILL.md");
+  });
+
+  it("skips a workspace symlink that escapes the agent tree", () => {
+    // MEMORY.md -> outside the agent workspace (e.g. a credentials env file).
+    const secretOutside = join(base, "outside-secret.env");
+    writeFileSync(secretOutside, "API_KEY=ghp_ZZZZZZZZZZ0123456789ZZZZZZZZ\n");
+    const ws = join(agentsDir, "klanker", "workspace");
+    symlinkSync(secretOutside, join(ws, "MEMORY.md"));
+
+    const res = runConfigRepoSync(baseOpts(), deps(ghStub("private")));
+
+    expect(res.skippedSymlinks.some((s) => s.file.endsWith("MEMORY.md"))).toBe(true);
+    // The escaping target's content never reaches the repo.
+    expect(existsSync(join(repo, "agents", "klanker", "workspace", "MEMORY.md"))).toBe(false);
+    expect(trackedFiles(repo)).not.toContain("agents/klanker/workspace/MEMORY.md");
+  });
+
+  it("commits nothing on a second run with no changes", () => {
+    const first = runConfigRepoSync(baseOpts(), deps(ghStub("private")));
+    expect(first.committed).toBe(true);
+
+    const second = runConfigRepoSync(baseOpts(), deps(ghStub("private")));
+    expect(second.committed).toBe(false);
+  });
+
+  it("refuses to push when require_private and the remote is PUBLIC (commit still lands)", () => {
+    const res = runConfigRepoSync(baseOpts(), deps(ghStub("public")));
+
+    expect(res.committed).toBe(true);
+    expect(res.pushed).toBe(false);
+    expect(res.pushSkippedReason).toMatch(/PUBLIC/i);
+    expect(res.exitCode).toBe(10);
+  });
+
+  it("refuses to push when the visibility probe is unreachable (fail-safe)", () => {
+    const res = runConfigRepoSync(baseOpts(), deps(ghStub("error")));
+    expect(res.pushed).toBe(false);
+    expect(res.pushSkippedReason).toMatch(/could not confirm/i);
+  });
+
+  it("never commits or leaves the .sync.lock (flock file) tracked", () => {
+    const res = runConfigRepoSyncLocked({ ...baseOpts(), push: false }, deps(ghStub("private")));
+    expect(res.committed).toBe(true);
+    expect(trackedFiles(repo)).not.toContain(".sync.lock");
+    // Lock released after the run.
+    expect(existsSync(join(repo, ".sync.lock"))).toBe(false);
+  });
+
+  it("skips a workspace file reached through an escaping intermediate DIR symlink", () => {
+    // memory/ is itself a symlink out to a credentials dir.
+    const outsideDir = join(base, "creds");
+    mkdirSync(outsideDir, { recursive: true });
+    writeFileSync(join(outsideDir, "leak.md"), "API_KEY=ghp_AAAAAAAAAA0123456789BBBBBBBB\n");
+    const ws = join(agentsDir, "klanker", "workspace");
+    rmSync(join(ws, "memory"), { recursive: true, force: true });
+    symlinkSync(outsideDir, join(ws, "memory"));
+
+    const res = runConfigRepoSync(baseOpts(), deps(ghStub("private")));
+    // The escaping dir's content never reaches the repo.
+    expect(existsSync(join(repo, "agents", "klanker", "workspace", "memory", "leak.md"))).toBe(false);
+    expect(res.skippedSymlinks.some((s) => s.file.includes("memory"))).toBe(true);
+  });
+
+  it("does not attempt the private gate at all when push:false", () => {
+    const res = runConfigRepoSync({ ...baseOpts(), push: false }, deps(ghStub("public")));
+    expect(res.committed).toBe(true);
+    expect(res.pushed).toBe(false);
+    expect(res.pushSkippedReason).toBeUndefined();
+    expect(res.exitCode).toBe(0);
+  });
+});
+
+describe("parseGitHubSlug", () => {
+  it("parses https and ssh remotes", () => {
+    expect(parseGitHubSlug("https://github.com/acme/repo.git")).toEqual({ owner: "acme", repo: "repo" });
+    expect(parseGitHubSlug("git@github.com:acme/repo.git")).toEqual({ owner: "acme", repo: "repo" });
+    expect(parseGitHubSlug("https://github.com/acme/repo")).toEqual({ owner: "acme", repo: "repo" });
+  });
+  it("returns null for a non-GitHub remote", () => {
+    expect(parseGitHubSlug("https://gitlab.com/acme/repo.git")).toBeNull();
+  });
+});
+
+describe("guardedCopyFile", () => {
+  it("copies a regular file inside the tree", () => {
+    const root = mkdtempSync(join(tmpdir(), "guard-"));
+    writeFileSync(join(root, "a.md"), "hi");
+    const dest = join(root, "out", "a.md");
+    expect(guardedCopyFile(join(root, "a.md"), dest, root).status).toBe("copied");
+    expect(readFileSync(dest, "utf-8")).toBe("hi");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("refuses a symlink whose target escapes the tree", () => {
+    const outer = mkdtempSync(join(tmpdir(), "guard-outer-"));
+    const root = join(outer, "root");
+    mkdirSync(root);
+    writeFileSync(join(outer, "secret.env"), "K=v");
+    symlinkSync(join(outer, "secret.env"), join(root, "link.md"));
+    expect(guardedCopyFile(join(root, "link.md"), join(root, "out.md"), root).status).toBe("escape");
+    rmSync(outer, { recursive: true, force: true });
+  });
+});

--- a/src/config-repo/sync.ts
+++ b/src/config-repo/sync.ts
@@ -1,0 +1,587 @@
+/**
+ * `switchroom config-repo sync` — native port of the operator's hand-written
+ * `~/.switchroom-config/sync.sh`, with the four hardening properties that
+ * script never had.
+ *
+ * ## Why this exists (read before "simplifying")
+ *
+ * `~/.switchroom/switchroom.yaml` is NOT a symlink into the config repo and
+ * cannot be: `switchroom setup` / `switchroom auth use|rotate` rewrite that
+ * file via `atomicWriteFileSync` → `rename()`, and `rename()` on Linux
+ * REPLACES a destination symlink with a fresh regular file. A symlink would
+ * therefore silently detach on the first auth/setup mutation. The live file is
+ * the source of truth; this repo tracks a COPY, refreshed here. (The
+ * `~/.switchroom/skills` → repo symlink is fine — switchroom only reads that
+ * pool, never renames it.) {@link copyYamlAsRegularFile} preserves this
+ * invariant.
+ *
+ * ## What this adds over sync.sh
+ *
+ *  1. **flock** (`<repo>/.sync.lock`, via the vault PID-file lock) so a manual
+ *     run and a scheduled tick can never interleave and corrupt the index.
+ *  2. **Symlink-target guard** replacing `cp -L`: a workspace file that is a
+ *     symlink is only copied if its target resolves INSIDE that agent's own
+ *     workspace tree. `cp -L` would happily follow `MEMORY.md ->
+ *     ~/.switchroom/credentials/foo.env` and commit the secret content.
+ *  3. **Commit-time secret scan** with the same `scanBundleForSecrets` engine
+ *     that gates the personal-skill write path — so a secret that arrived by a
+ *     direct rw-mount write (bypassing the in-container CLI scan) is caught
+ *     before it is committed. On a hit the file is unstaged and a WARN is
+ *     emitted; the rest of the commit proceeds.
+ *  4. **Force-add of each `agents/<name>/personal-skills/` slice** — closes GAP A: today
+ *     `.gitignore`'s blanket `agents/` leaves every mirrored personal skill
+ *     untracked, so a repo clone loses them all. Kept as a force-add allowlist
+ *     (never a `!agents/**` gitignore negation, whose excluded-directory
+ *     semantics silently fail and risk tracking future secret-shaped files).
+ *
+ * Push is gated by {@link ConfigRepoSyncOptions.requirePrivate}: refuse to push
+ * unless the GitHub API confirms the remote is private. Push rides the
+ * operator's existing `gh` credential helper — no new secret, nothing moves
+ * into a container.
+ */
+
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+  unlinkSync,
+} from "node:fs";
+import { join, relative, sep } from "node:path";
+
+import { scanBundleForSecrets, type SkillFileMap } from "../cli/skill-common.js";
+import { acquireLock } from "../vault/flock.js";
+
+/**
+ * Hand-owned agent workspace files captured for rollback. Identical set to
+ * sync.sh's `OWNED` array. switchroom-GENERATED files (the agentDir CLAUDE.md,
+ * settings.json, .mcp.json, compose) are deliberately NOT captured — they
+ * regenerate from the product repo + this config.
+ */
+export const OWNED_WORKSPACE_FILES = [
+  "SOUL.md",
+  "SOUL.custom.md",
+  "IDENTITY.md",
+  "USER.md",
+  "TOOLS.md",
+  "MEMORY.md",
+  "HEARTBEAT.md",
+  "CLAUDE.md",
+  "CLAUDE.custom.md",
+] as const;
+
+/** Personal-skills subdir under each `agents/<name>/` slice in the repo. */
+export const PERSONAL_SKILLS_SUBPATH = "personal-skills";
+
+/**
+ * Upper bound on a single file read during the commit-time secret scan.
+ * A file larger than this is skipped (not scanned) — the scan targets
+ * human-authored config/skill text, not multi-MB blobs, and reading a
+ * runaway file into a utf-8 string would be wasteful. The private-repo
+ * push gate is the second wall for anything the scan does not read.
+ */
+export const SCAN_MAX_FILE_BYTES = 5 * 1024 * 1024;
+
+/** Result of one shelled command. */
+export interface CmdResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+/** Runs an argv and returns a normalized result. Injectable for tests. */
+export type CmdRunner = (args: string[]) => CmdResult;
+
+export interface ConfigRepoSyncDeps {
+  /** `git` runner already bound to the repo directory (`git -C <repo> …`). */
+  git: CmdRunner;
+  /** `gh` runner (used only for the require_private visibility probe). */
+  gh: CmdRunner;
+  /** Line logger (stderr in the CLI; a collector in tests). */
+  log: (msg: string) => void;
+}
+
+export interface ConfigRepoSyncOptions {
+  /** The config repo (must contain a `.git`). */
+  repoPath: string;
+  /** Live `~/.switchroom/switchroom.yaml` (source of truth, copied in). */
+  livePath: string;
+  /** Live `~/.switchroom/agents` scaffold dir. */
+  agentsDir: string;
+  /** When false, commit locally only. */
+  push: boolean;
+  /** Git remote name (default `origin`). */
+  remote: string;
+  /** Refuse to push unless the GitHub API confirms the remote is private. */
+  requirePrivate: boolean;
+  /** Commit message override. */
+  message?: string;
+}
+
+export interface SecretFinding {
+  file: string;
+  pattern: string;
+  rule_id: string;
+}
+
+export interface SkippedSymlink {
+  file: string;
+  reason: string;
+}
+
+export interface ConfigRepoSyncResult {
+  committed: boolean;
+  commitSha?: string;
+  pushed: boolean;
+  /** Present when a push was wanted but not performed. */
+  pushSkippedReason?: string;
+  secretFindings: SecretFinding[];
+  skippedSymlinks: SkippedSymlink[];
+  warnings: string[];
+  /** 0 = clean; 10 = completed but a WARN fired (secret dropped / push skipped). */
+  exitCode: number;
+}
+
+/** Build the default deps: real git bound to the repo, real gh. */
+export function defaultSyncDeps(
+  repoPath: string,
+  log: (msg: string) => void,
+): ConfigRepoSyncDeps {
+  const runner =
+    (bin: string, prefix: string[]): CmdRunner =>
+    (args) => {
+      const r = spawnSync(bin, [...prefix, ...args], { encoding: "utf-8" });
+      return {
+        ok: r.status === 0,
+        stdout: (r.stdout ?? "").trim(),
+        stderr: (r.stderr ?? "").trim(),
+      };
+    };
+  return {
+    git: runner("git", ["-C", repoPath]),
+    gh: runner("gh", []),
+    log,
+  };
+}
+
+/**
+ * Copy the live yaml into the repo AS A REGULAR FILE. If the destination is
+ * currently a symlink (a repo someone "simplified"), unlink it first so we
+ * never write through the link — see the file header for the rename() trap.
+ */
+export function copyYamlAsRegularFile(livePath: string, repoYamlPath: string): void {
+  try {
+    if (lstatSync(repoYamlPath).isSymbolicLink()) unlinkSync(repoYamlPath);
+  } catch {
+    /* dest absent — nothing to unlink */
+  }
+  copyFileSync(livePath, repoYamlPath);
+}
+
+/** True iff `child`'s realpath is inside (or equal to) `root`'s realpath. */
+function isInsideTree(childRealPath: string, rootRealPath: string): boolean {
+  if (childRealPath === rootRealPath) return true;
+  const rel = relative(rootRealPath, childRealPath);
+  return rel.length > 0 && !rel.startsWith("..") && !rel.startsWith(sep) && rel !== "..";
+}
+
+export type GuardedCopyStatus = "copied" | "missing" | "escape" | "irregular";
+
+export interface GuardedCopyResult {
+  status: GuardedCopyStatus;
+  /** Realpath the symlink resolved to (for escape/irregular diagnostics). */
+  target?: string;
+}
+
+/**
+ * Copy `src` → `dest`, following a symlink ONLY when its target resolves inside
+ * `allowedRoot`. This is the guarded replacement for sync.sh's `cp -L`:
+ *
+ *   - regular file inside the tree → copied
+ *   - symlink whose target escapes `allowedRoot` → NOT copied (`escape`)
+ *   - symlink/target that is not a regular file → NOT copied (`irregular`)
+ *   - src absent → `missing`
+ *
+ * The dest parent dir is created as needed.
+ */
+export function guardedCopyFile(
+  src: string,
+  dest: string,
+  allowedRoot: string,
+): GuardedCopyResult {
+  // lstat (does not follow) purely to distinguish "absent" from "escape".
+  try {
+    lstatSync(src);
+  } catch {
+    return { status: "missing" };
+  }
+
+  // Resolve through EVERY symlink (leaf AND any intermediate directory) and
+  // enforce containment. A `cp -L` follows all of them; checking only the leaf
+  // would miss a `workspace/memory -> ~/.switchroom/credentials` dir symlink.
+  // realpathSync throws on a dangling link — treat that as missing.
+  let real: string;
+  try {
+    real = realpathSync(src);
+  } catch {
+    return { status: "missing" };
+  }
+  let root: string;
+  try {
+    root = realpathSync(allowedRoot);
+  } catch {
+    return { status: "escape", target: real };
+  }
+  if (!isInsideTree(real, root)) {
+    return { status: "escape", target: real };
+  }
+
+  // Only ever copy a regular file's content.
+  let realStat;
+  try {
+    realStat = statSync(real);
+  } catch {
+    return { status: "missing" };
+  }
+  if (!realStat.isFile()) {
+    return { status: "irregular", target: real };
+  }
+
+  mkdirSync(join(dest, ".."), { recursive: true });
+  copyFileSync(real, dest);
+  return { status: "copied" };
+}
+
+/**
+ * Copy one agent's OWNED workspace files + memory + custom-MCP source from the
+ * live scaffold into the repo, using the guarded copy. Mutates `skipped` with
+ * any symlink-escape/irregular skips. Returns nothing — staging is a later
+ * step.
+ */
+function copyAgentWorkspace(
+  agentName: string,
+  liveWorkspace: string,
+  repoWorkspace: string,
+  skipped: SkippedSymlink[],
+  log: (m: string) => void,
+): void {
+  const guard = (src: string, dest: string): void => {
+    const r = guardedCopyFile(src, dest, liveWorkspace);
+    if (r.status === "escape") {
+      const rel = `agents/${agentName}/workspace/${relative(liveWorkspace, src)}`;
+      skipped.push({
+        file: rel,
+        reason: `symlink target ${r.target} is outside the agent workspace tree`,
+      });
+      log(`config-repo: SKIP ${rel} — symlink escapes workspace (${r.target})`);
+    } else if (r.status === "irregular") {
+      const rel = `agents/${agentName}/workspace/${relative(liveWorkspace, src)}`;
+      skipped.push({ file: rel, reason: `not a regular file (${r.target})` });
+    }
+  };
+
+  for (const f of OWNED_WORKSPACE_FILES) {
+    guard(join(liveWorkspace, f), join(repoWorkspace, f));
+  }
+
+  const memDir = join(liveWorkspace, "memory");
+  if (dirExists(memDir)) {
+    for (const ent of safeReaddir(memDir)) {
+      if (ent.endsWith(".md")) guard(join(memDir, ent), join(repoWorkspace, "memory", ent));
+    }
+  }
+
+  const mcpDir = join(liveWorkspace, "mcp");
+  if (dirExists(mcpDir)) {
+    for (const ent of safeReaddir(mcpDir)) {
+      if (ent.endsWith(".mjs") || ent === "package.json" || ent === ".gitignore") {
+        guard(join(mcpDir, ent), join(repoWorkspace, "mcp", ent));
+      }
+    }
+  }
+}
+
+function dirExists(p: string): boolean {
+  try {
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function safeReaddir(p: string): string[] {
+  try {
+    return readdirSync(p);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Force-add the OWNED workspace allowlist for one repo agent dir, past the
+ * blanket `agents/` gitignore. `git add -f` is a no-op for a path that does
+ * not exist, so unconditional adds are safe.
+ */
+function forceAddWorkspace(git: CmdRunner, repoAgentWorkspace: string): void {
+  for (const f of OWNED_WORKSPACE_FILES) {
+    const p = join(repoAgentWorkspace, f);
+    if (existsSync(p)) git(["add", "-f", "--", p]);
+  }
+  const memDir = join(repoAgentWorkspace, "memory");
+  for (const ent of safeReaddir(memDir)) {
+    if (ent.endsWith(".md")) git(["add", "-f", "--", join(memDir, ent)]);
+  }
+  const mcpDir = join(repoAgentWorkspace, "mcp");
+  for (const ent of safeReaddir(mcpDir)) {
+    if (ent.endsWith(".mjs") || ent === "package.json" || ent === ".gitignore") {
+      git(["add", "-f", "--", join(mcpDir, ent)]);
+    }
+  }
+}
+
+/**
+ * Force-add every non-dot entry under `agents/<name>/personal-skills/` — the
+ * GAP A fix. Dot-prefixed siblings (`.<slug>-staging-*`, `.<slug>-prior-*`,
+ * `.<slug>-trash-*`, `.journal.jsonl`) are staging/audit artifacts bounded by
+ * the mirror's own 24h sweep and are deliberately excluded.
+ */
+export function forceAddPersonalSkills(git: CmdRunner, repoPersonalSkillsDir: string): void {
+  for (const ent of safeReaddir(repoPersonalSkillsDir)) {
+    if (ent.startsWith(".")) continue;
+    git(["add", "-f", "--", join(repoPersonalSkillsDir, ent)]);
+  }
+}
+
+/**
+ * Parse `owner/repo` out of a GitHub remote URL (https or ssh form).
+ * Returns null for a non-GitHub or unparseable remote.
+ */
+export function parseGitHubSlug(remoteUrl: string): { owner: string; repo: string } | null {
+  const m = remoteUrl.trim().match(/github\.com[/:]([^/]+)\/(.+?)(?:\.git)?\/?$/);
+  if (!m) return null;
+  return { owner: m[1]!, repo: m[2]! };
+}
+
+/**
+ * Scan every currently-staged file for embedded secrets and unstage any file
+ * that matches. Reuses `scanBundleForSecrets` — the same engine that gates the
+ * personal-skill write path — so the host-side commit path enforces the same
+ * fail-closed contract for files that bypassed the in-container CLI. Returns
+ * the findings (value bytes are never surfaced).
+ */
+export function scanStagedForSecrets(
+  repoPath: string,
+  git: CmdRunner,
+  log: (m: string) => void,
+): SecretFinding[] {
+  const listed = git(["diff", "--cached", "--name-only"]);
+  const findings: SecretFinding[] = [];
+  if (!listed.ok || listed.stdout.length === 0) return findings;
+
+  const seen = new Set<string>();
+  for (const relPath of listed.stdout.split("\n").map((l) => l.trim()).filter(Boolean)) {
+    const abs = join(repoPath, relPath);
+    let content: string;
+    try {
+      const st = statSync(abs);
+      if (!st.isFile() || st.size > SCAN_MAX_FILE_BYTES) continue;
+      const buf = readFileSync(abs);
+      // Skip binary — a NUL byte in the first 8KB is the usual heuristic.
+      if (buf.subarray(0, 8192).includes(0)) continue;
+      content = buf.toString("utf-8");
+    } catch {
+      // Deletion or unreadable — nothing to scan.
+      continue;
+    }
+    const bundle: SkillFileMap = { [relPath]: content };
+    for (const f of scanBundleForSecrets(bundle)) {
+      findings.push({ file: relPath, pattern: f.pattern, rule_id: f.rule_id });
+      if (!seen.has(relPath)) {
+        seen.add(relPath);
+        // Unstage the offending file so it never enters the commit. The file
+        // stays on disk (the operator investigates); it is simply not tracked.
+        git(["reset", "-q", "HEAD", "--", relPath]);
+        log(
+          `config-repo: SECRET WITHHELD — unstaged ${relPath} ` +
+            `(${f.pattern}); the private repo push gate is the second wall`,
+        );
+      }
+    }
+  }
+  return findings;
+}
+
+/**
+ * Query the GitHub API for the remote's visibility. Returns:
+ *   - true/false when the API answered
+ *   - null when gh is unavailable / unauthenticated / the API was unreachable
+ *     (treated by the caller as "unknown → do not push", fail-safe).
+ */
+export function probeRemoteIsPrivate(
+  gh: CmdRunner,
+  slug: { owner: string; repo: string },
+): boolean | null {
+  const r = gh(["api", `repos/${slug.owner}/${slug.repo}`, "--jq", ".private"]);
+  if (!r.ok) return null;
+  const v = r.stdout.trim().toLowerCase();
+  if (v === "true") return true;
+  if (v === "false") return false;
+  return null;
+}
+
+/**
+ * The whole sync: copy → stage → secret-scan → commit → (gated) push.
+ * Pure of process concerns (no flock, no exit) — the CLI layer wraps this in
+ * the lock and maps {@link ConfigRepoSyncResult.exitCode}.
+ */
+export function runConfigRepoSync(
+  opts: ConfigRepoSyncOptions,
+  deps: ConfigRepoSyncDeps,
+): ConfigRepoSyncResult {
+  const { git, gh, log } = deps;
+  const warnings: string[] = [];
+  const skippedSymlinks: SkippedSymlink[] = [];
+
+  if (!existsSync(join(opts.repoPath, ".git"))) {
+    throw new Error(`config-repo: ${opts.repoPath} is not a git repo (no .git)`);
+  }
+  if (!existsSync(opts.livePath)) {
+    throw new Error(`config-repo: live config not found at ${opts.livePath}`);
+  }
+
+  // 1. yaml as a COPY (never a symlink).
+  copyYamlAsRegularFile(opts.livePath, join(opts.repoPath, "switchroom.yaml"));
+
+  // 2. Copy each agent's OWNED workspace state, guarded against symlink escape.
+  if (dirExists(opts.agentsDir)) {
+    for (const name of safeReaddir(opts.agentsDir)) {
+      const liveWs = join(opts.agentsDir, name, "workspace");
+      if (!dirExists(liveWs)) continue;
+      copyAgentWorkspace(
+        name,
+        liveWs,
+        join(opts.repoPath, "agents", name, "workspace"),
+        skippedSymlinks,
+        log,
+      );
+    }
+  }
+
+  // 3. Stage. `add -A` stages the yaml + any non-ignored change/deletion; the
+  // force-add loop pulls in the OWNED workspace allowlist and the mirrored
+  // personal skills that the blanket `agents/` ignore would otherwise drop.
+  git(["add", "-A"]);
+  // The flock file (`<repo>/.sync.lock`, held for the duration of this run)
+  // lives at the repo root and is NOT in the operator's `.gitignore`, so
+  // `add -A` would otherwise sweep this transient into the commit. Unstage it
+  // unconditionally; it is removed on lock release regardless.
+  git(["reset", "-q", "HEAD", "--", ".sync.lock"]);
+  const repoAgentsDir = join(opts.repoPath, "agents");
+  for (const name of safeReaddir(repoAgentsDir)) {
+    forceAddWorkspace(git, join(repoAgentsDir, name, "workspace"));
+    forceAddPersonalSkills(git, join(repoAgentsDir, name, PERSONAL_SKILLS_SUBPATH));
+  }
+
+  // 4. Secret scan every staged file; unstage any hit.
+  const secretFindings = scanStagedForSecrets(opts.repoPath, git, log);
+
+  // 5. Commit iff something remains staged.
+  const staged = git(["diff", "--cached", "--quiet"]);
+  const hasStaged = !staged.ok; // `--quiet` exits 1 when there ARE staged changes
+  let committed = false;
+  let commitSha: string | undefined;
+  if (hasStaged) {
+    const msg =
+      opts.message ??
+      "chore(config-repo): sync switchroom.yaml + workspace state + personal skills from live host";
+    const c = git(["commit", "-m", msg]);
+    if (!c.ok) {
+      throw new Error(`config-repo: git commit failed: ${c.stderr || c.stdout}`);
+    }
+    committed = true;
+    const rev = git(["rev-parse", "HEAD"]);
+    if (rev.ok) commitSha = rev.stdout.trim();
+    log(`config-repo: committed ${commitSha ?? "(sha unknown)"}`);
+  } else {
+    log("config-repo: nothing to commit (repo already matches live)");
+  }
+
+  // 6. Push, gated by require_private.
+  let pushed = false;
+  let pushSkippedReason: string | undefined;
+  if (opts.push) {
+    const remoteUrl = git(["remote", "get-url", opts.remote]);
+    if (!remoteUrl.ok) {
+      pushSkippedReason = `remote '${opts.remote}' not configured`;
+    } else if (opts.requirePrivate) {
+      const slug = parseGitHubSlug(remoteUrl.stdout);
+      if (!slug) {
+        pushSkippedReason = `require_private: cannot parse a GitHub owner/repo from '${remoteUrl.stdout}'`;
+      } else {
+        const priv = probeRemoteIsPrivate(gh, slug);
+        if (priv === null) {
+          pushSkippedReason =
+            `require_private: could not confirm ${slug.owner}/${slug.repo} is private ` +
+            `(gh unavailable / API unreachable) — refusing to push`;
+        } else if (priv === false) {
+          pushSkippedReason =
+            `require_private: remote ${slug.owner}/${slug.repo} is PUBLIC — refusing to push`;
+        }
+      }
+    }
+
+    if (!pushSkippedReason) {
+      const p = git(["push", opts.remote, "HEAD"]);
+      if (p.ok) {
+        pushed = true;
+        log(`config-repo: pushed to ${opts.remote}`);
+      } else {
+        pushSkippedReason = `push failed (offline/auth?) — commits are local, next run retries: ${p.stderr || p.stdout}`;
+      }
+    }
+
+    if (pushSkippedReason) {
+      warnings.push(pushSkippedReason);
+      log(`config-repo: WARN — ${pushSkippedReason}`);
+    }
+  }
+
+  const warned =
+    secretFindings.length > 0 || skippedSymlinks.length > 0 || warnings.length > 0;
+
+  return {
+    committed,
+    commitSha,
+    pushed,
+    pushSkippedReason,
+    secretFindings,
+    skippedSymlinks,
+    warnings,
+    exitCode: warned ? 10 : 0,
+  };
+}
+
+/**
+ * flock-guarded wrapper: acquire `<repo>/.sync.lock` (via the vault PID-file
+ * lock) so a manual run and a scheduled tick can never interleave, run the
+ * sync, and always release. `budgetMs` bounds how long to wait for a
+ * concurrent holder before giving up.
+ */
+export function runConfigRepoSyncLocked(
+  opts: ConfigRepoSyncOptions,
+  deps: ConfigRepoSyncDeps,
+  budgetMs = 30_000,
+): ConfigRepoSyncResult {
+  // acquireLock appends `.lock`, so `<repo>/.sync` → `<repo>/.sync.lock`.
+  const { release } = acquireLock(join(opts.repoPath, ".sync"), { budgetMs });
+  try {
+    return runConfigRepoSync(opts, deps);
+  } finally {
+    release();
+  }
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -5164,6 +5164,77 @@ export const UserSchema = z.object({
 });
 export type User = z.infer<typeof UserSchema>;
 
+/**
+ * Config-repo change control (`config_repo:`) — the operator's private
+ * `~/.switchroom-config` git repo as a first-class, product-managed backup +
+ * change-control target. Sibling of `vault:`.
+ *
+ * Historically the repo was fed by a hand-written `sync.sh` (copy live → repo,
+ * `git commit`, no push, no schedule, no secret scan). `switchroom config-repo
+ * sync` ports that natively and closes the gaps `sync.sh` left open:
+ *   - a `flock` so a manual run and a scheduled tick can never interleave;
+ *   - a symlink-target guard replacing `cp -L` (never follow a workspace
+ *     symlink out to `credentials/*.env` or any path outside the agent tree);
+ *   - a commit-time secret scan (the same `scanBundleForSecrets` engine that
+ *     gates the personal-skill write path) so a secret that arrived by a
+ *     direct rw-mount write — bypassing the in-container scan — is still caught
+ *     before it is committed;
+ *   - force-adding each `agents/<name>/personal-skills/` slice so the 84
+ *     mirrored personal skills that `.gitignore`'s blanket `agents/` leaves
+ *     untracked are finally captured (GAP A);
+ *   - a `require_private` push gate: refuse to auto-push unless the GitHub API
+ *     confirms the remote is private.
+ *
+ * The block is OPTIONAL and OFF by default — nothing changes for operators who
+ * do not set it. Push auth rides the operator's existing `gh` credential
+ * helper; no new secret is created and nothing moves into a container.
+ */
+export const ConfigRepoConfigSchema = z.object({
+  enabled: z
+    .boolean()
+    .default(false)
+    .describe(
+      "Master switch for config-repo change control. Default false (opt-in). " +
+      "When false the `config-repo sync` verb still runs on demand but the " +
+      "doctor check and (later) the scheduled tick treat the feature as off.",
+    ),
+  path: z
+    .string()
+    .regex(
+      /^[a-zA-Z0-9~._\-/]+$/,
+      "config_repo.path must not contain shell-special characters ($, `, \", ', \\, etc.)",
+    )
+    .default("~/.switchroom-config")
+    .describe(
+      "Filesystem path to the operator's private config repo. Must be a git " +
+      "repo (else `switchroom doctor` FAILs). Tilde-expanded at read time.",
+    ),
+  push: z
+    .boolean()
+    .default(true)
+    .describe(
+      "When true, `config-repo sync` pushes after committing (subject to the " +
+      "`require_private` gate). When false, it commits locally only — useful " +
+      "for offline hosts or a review-before-push workflow.",
+    ),
+  remote: z
+    .string()
+    .min(1)
+    .default("origin")
+    .describe("Git remote name to push to. Default `origin`."),
+  require_private: z
+    .boolean()
+    .default(true)
+    .describe(
+      "Refuse to PUSH unless the GitHub API confirms the remote repo is " +
+      "private. On a public remote — or when the API is unreachable — the " +
+      "push is skipped (commits still land locally) and a WARN is emitted. " +
+      "Fail-safe against exfiltrating memory files / workspace state to a " +
+      "repo that has been flipped public. Default true.",
+    ),
+});
+export type ConfigRepoConfig = z.infer<typeof ConfigRepoConfigSchema>;
+
 export const SwitchroomConfigSchema = z.object({
   switchroom: z.object({
     version: z.literal(1).describe("Config schema version"),
@@ -5219,6 +5290,12 @@ export const SwitchroomConfigSchema = z.object({
     "the next `switchroom apply` / `memory setup --recreate`.",
   ),
   vault: VaultConfigSchema.optional(),
+  config_repo: ConfigRepoConfigSchema.optional().describe(
+    "Change control for the operator's private ~/.switchroom-config git repo " +
+    "(backup + audit trail of live host config, agent workspace state, and " +
+    "mirrored personal skills). Consumed by `switchroom config-repo sync` and " +
+    "the `config repo` doctor check. Optional and OFF by default.",
+  ),
   auth: z
     .object({
       active: z


### PR DESCRIPTION
## Scope — Slice 1 only

First slice of native, product-managed change control for the operator's private `~/.switchroom-config` git repo. Converts today's *manual, push-less, personal-skills-losing* state into *every change captured, secret-scanned, and pushed on demand*. Slices 2–4 (schedule, attribution journal + T1 PostToolUse mirror, rollback) are intentionally out of scope.

### New `switchroom config-repo sync`
Native TypeScript port of the hand-written `sync.sh`, plus the four properties it never had:

- **Copy-not-symlink** for `switchroom.yaml` — preserves the rename()-detaches-symlink invariant (`setup`/`auth` rewrite the live file via `atomicWriteFileSync` → `rename()`, which replaces a dest symlink with a regular file). A pre-existing symlink at the dest is unlinked before a regular-file copy.
- **flock** on `<repo>/.sync.lock` (via the existing vault PID-file lock) so a manual run and a scheduled tick can never interleave.
- **Symlink-target guard** replacing `cp -L` — a workspace file is copied only when its realpath (through leaf *and* intermediate-directory symlinks) stays inside the agent's own workspace tree, closing the `MEMORY.md -> ~/.switchroom/credentials/*.env` exfil vector.
- **Commit-time secret scan** reusing `scanBundleForSecrets` (the same engine gating the personal-skill write path). Any staged file that matches is unstaged with a WARN — so a secret that arrived via a direct rw-mount write, bypassing the in-container CLI, is still caught before commit.

### GAP A closure
Today `.gitignore`'s blanket `agents/` leaves **all 84 mirrored personal-skill files untracked** (`git ls-files | grep personal-skills` → 0), so a clone silently loses every personal skill. The sync verb force-adds each `agents/<name>/personal-skills/` slice (dot-prefixed staging/prior/trash/journal siblings excluded), kept as a force-add allowlist rather than a `!agents/**` gitignore negation. Acceptance test asserts `ls-files` goes **zero → non-zero**.

### require_private push gate
Refuses to push unless `gh api repos/<owner>/<repo> --jq .private` confirms the remote is private. Public → refuse; API unreachable/unauthenticated → refuse (fail-safe); offline/auth push failure → non-fatal, commits stay local, next run retries. Rides the operator's existing `gh` credential helper — no new secret, nothing moves into a container.

### Schema + doctor
- New top-level `config_repo:` block (sibling of `vault:`): `enabled` (default false), `path` (default `~/.switchroom-config`), `push`, `remote`, `require_private`.
- New `switchroom doctor` rows (emitted only when `config_repo:` is set): repo-is-git, remote-is-private, personal-skills-tracked (the GAP A backstop, fires today and self-clears after first sync), unpushed-commit staleness (red past 24h). Pure classifier, both branches unit-tested.

## Acceptance evidence
`env -u SWITCHROOM_SELF_IMPROVE npx vitest run src/config-repo/sync.test.ts src/cli/doctor-config-repo.test.ts` → **21 passed**. Outcome assertions on a real fixture git repo: personal-skills tracked (0→non-zero), yaml is a regular file not a symlink, planted `ghp_` token withheld + exit 10, escaping workspace symlink (leaf and intermediate-dir) skipped, no-op second run commits nothing, public remote refuses push, `.sync.lock` never committed.

`npm run lint` (tsc --noEmit + all guards) clean.

### Red-without-fix proof
- Disabling the personal-skills force-add → the GAP A test fails (`expected [...] to include 'agents/klanker/personal-skills/foo/SKILL.md'`).
- Stubbing the secret scan to `[]` → the secret test fails (`res.secretFindings.length` not `> 0`).

## Note on `sync.sh` (dev-protocol contradiction, surfaced not force-fit)
The locked decision "convert `sync.sh` to a thin wrapper" cannot be part of *this* PR: `sync.sh` lives only in the operator's separate private config repo (`mekenthompson/switchroom-config`), not in `switchroom/switchroom` (`grep -rn sync.sh src/` finds no such file). Converting it to `exec switchroom config-repo sync` also cannot happen until this verb ships in a release, or the operator's working sync breaks. The wrapper conversion is a one-line change to land in the config repo after release — tracked as follow-up, not dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)