### PR TITLE
feat(config-repo): scheduled auto-backup cron + doctor + update reconcile (slice 2)

### DIFF
--- a/src/cli/config-repo.ts
+++ b/src/cli/config-repo.ts
@@ -26,6 +26,18 @@ import {
   runConfigRepoSyncLocked,
   type ConfigRepoSyncOptions,
 } from "../config-repo/sync.js";
+import {
+  CRON_LOG_PATH,
+  CRON_PATH,
+  DEFAULT_INTERVAL_MINUTES,
+  DAILY_CRON_SCHEDULE,
+  ensureLogFile,
+  installCron,
+  installLogrotate,
+  uninstallCron,
+  uninstallLogrotate,
+  type IncludeVaultBackup,
+} from "../config-repo/install-cron.js";
 import { VaultBusyError } from "../vault/flock.js";
 
 function switchroomHome(): string {
@@ -157,4 +169,189 @@ export function registerConfigRepoCommand(program: Command): void {
 
       process.exitCode = result.exitCode;
     });
+
+  configRepo
+    .command("install-cron")
+    .description(
+      "Arm the scheduled auto-backup: write /etc/cron.d/switchroom-config-sync " +
+        "(30-min `config-repo sync` tick + a daily `vault backup && sync` leg), " +
+        "provision its log, and install a logrotate drop-in. Gated on " +
+        "config_repo.enabled; refuses to run as root.",
+    )
+    .option("--cron-user <user>", "unix user the cron tick runs as (default: current user)")
+    .action((opts: { cronUser?: string }) => {
+      const parentOpts = program.opts();
+      process.exitCode = runInstallCron(parentOpts.config, opts.cronUser);
+    });
+
+  configRepo
+    .command("uninstall-cron")
+    .description(
+      "Disarm the scheduled auto-backup: remove /etc/cron.d/switchroom-config-sync " +
+        "and its logrotate drop-in (the sync verb still works on demand). Idempotent.",
+    )
+    .action(() => {
+      process.exitCode = runUninstallCron();
+    });
+}
+
+/**
+ * `install-cron`: arm the config-repo auto-backup schedule.
+ *
+ * Gated and refuse-guarded like `hindsight-watch --install-cron`, because the
+ * two ways a guess installs a cron that never does its job are the same here:
+ *
+ *  - **running as root with no `--cron-user`.** The push rides the OPERATOR's
+ *    `gh` credential helper; a root tick has no such auth and would fail every
+ *    push forever. Hard error, not a warning.
+ *  - **an unresolvable binary path.** A relative/dev-mode argv in a cron line
+ *    fails every tick with a message only visible in syslog.
+ *
+ * Additionally gated on `config_repo.enabled`: arming a schedule for a feature
+ * the operator has not turned on would start pushing workspace/memory state to
+ * the remote without an explicit opt-in.
+ */
+function runInstallCron(configPath: string | undefined, cronUser?: string): number {
+  // Config gate: refuse to arm unless the feature is enabled.
+  let intervalMinutes = DEFAULT_INTERVAL_MINUTES;
+  let includeVaultBackup: IncludeVaultBackup = "daily";
+  let enabled = false;
+  try {
+    const loaded = loadConfig(configPath);
+    if (loaded.config_repo) {
+      enabled = loaded.config_repo.enabled;
+      intervalMinutes = loaded.config_repo.interval_minutes ?? DEFAULT_INTERVAL_MINUTES;
+      includeVaultBackup = loaded.config_repo.include_vault_backup ?? "daily";
+    }
+  } catch {
+    /* fall through — enabled stays false, gate fires below */
+  }
+  if (!enabled) {
+    process.stderr.write(
+      chalk.red("config-repo: refusing to arm the auto-backup cron.\n") +
+        "  config_repo.enabled is not true. Set `config_repo.enabled: true` in " +
+        "switchroom.yaml (and confirm the repo is present + private with " +
+        "`switchroom doctor`) before arming the schedule.\n",
+    );
+    return 1;
+  }
+
+  const user = cronUser ?? process.env.SUDO_USER ?? process.env.USER ?? process.env.LOGNAME;
+  if (!user || user === "root") {
+    process.stderr.write(
+      chalk.red("config-repo: refusing to install a cron for `root`.\n") +
+        "  The push rides the OPERATOR's `gh` credential helper, so the tick " +
+        "must run as the operator — a root tick has no push auth and every " +
+        "push would fail forever.\n" +
+        "  Re-run with `--cron-user <operator>`.\n",
+    );
+    return 1;
+  }
+
+  const binary = process.env.SWITCHROOM_BINARY ?? "/usr/local/bin/switchroom";
+  if (!binary.startsWith("/")) {
+    process.stderr.write(
+      chalk.red(`config-repo: SWITCHROOM_BINARY must be an absolute path (got ${binary})\n`),
+    );
+    return 1;
+  }
+
+  let res: ReturnType<typeof installCron>;
+  try {
+    res = installCron({ user, binary, intervalMinutes, includeVaultBackup });
+  } catch (e) {
+    process.stderr.write(
+      chalk.red(`config-repo: could not write ${CRON_PATH}: ${(e as Error).message}\n`) +
+        "  This path needs root; re-run under sudo with `--cron-user <operator>`.\n",
+    );
+    return 1;
+  }
+
+  // Provision the log file the cron redirects into, owned by the cron user
+  // (#3991 class): without it the `>>` redirection dies "Permission denied"
+  // before switchroom is exec'd and every tick fails silently. FATAL here — an
+  // armed cron that cannot write its log is the exact silent-failure this verb
+  // exists to close.
+  let logStatus: string;
+  try {
+    const logRes = ensureLogFile({ user });
+    logStatus =
+      logRes.status === "created"
+        ? `created ${logRes.path} (owned by ${user})`
+        : `${logRes.path} already present`;
+  } catch (e) {
+    process.stderr.write(
+      chalk.red(`config-repo: could not provision the log file: ${(e as Error).message}\n`) +
+        `  The cron redirects into ${CRON_LOG_PATH} and would die at the ` +
+        "redirection every tick.\n  This path needs root; re-run under sudo with " +
+        "`--cron-user <operator>`.\n",
+    );
+    return 1;
+  }
+
+  // Bound the log with a logrotate drop-in. Best-effort: a missing config only
+  // means unbounded growth, not a broken tick, so a failure here WARNs.
+  let rotateStatus: string;
+  try {
+    const rotateRes = installLogrotate({ user });
+    rotateStatus =
+      rotateRes.status === "installed"
+        ? `installed ${rotateRes.path}`
+        : `${rotateRes.path} already up to date`;
+  } catch (e) {
+    rotateStatus = chalk.yellow(
+      `logrotate drop-in NOT written (${(e as Error).message}) — log growth is unbounded`,
+    );
+  }
+
+  const verb = res.status === "installed" ? "installed" : "already up to date";
+  const backupNote =
+    includeVaultBackup === "off"
+      ? "no vault backup"
+      : includeVaultBackup === "every_tick"
+        ? "vault backup every tick"
+        : `daily vault backup at ${DAILY_CRON_SCHEDULE}`;
+  process.stdout.write(
+    `${chalk.green("✓")} config-repo auto-backup cron ${verb} at ${res.path} ` +
+      `(*/${intervalMinutes} * * * *, ${backupNote}, as ${user})\n` +
+      `  log: ${logStatus}\n` +
+      `  logrotate: ${rotateStatus}\n` +
+      `  Verify with: switchroom doctor\n`,
+  );
+  return 0;
+}
+
+/** `uninstall-cron`: remove the schedule + logrotate drop-in (idempotent). */
+function runUninstallCron(): number {
+  let cronRes: ReturnType<typeof uninstallCron>;
+  try {
+    cronRes = uninstallCron();
+  } catch (e) {
+    process.stderr.write(
+      chalk.red(`config-repo: could not remove ${CRON_PATH}: ${(e as Error).message}\n`) +
+        "  This path needs root; re-run under sudo.\n",
+    );
+    return 1;
+  }
+  // Logrotate removal is best-effort — a stranded drop-in for a missing log is
+  // harmless (`missingok`).
+  let rotateNote = "";
+  try {
+    const r = uninstallLogrotate();
+    rotateNote = r.status === "removed" ? ` and its logrotate drop-in (${r.path})` : "";
+  } catch {
+    /* leave it — harmless */
+  }
+
+  if (cronRes.status === "removed") {
+    process.stdout.write(
+      `${chalk.green("✓")} config-repo auto-backup cron removed (${cronRes.path})${rotateNote}\n` +
+        "  The `config-repo sync` verb still works on demand.\n",
+    );
+  } else {
+    process.stdout.write(
+      `${chalk.gray("•")} config-repo auto-backup cron was not installed (${cronRes.path})\n`,
+    );
+  }
+  return 0;
 }

--- a/src/cli/doctor-config-repo.test.ts
+++ b/src/cli/doctor-config-repo.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { classifyConfigRepo, UNPUSHED_STALE_MS, type ConfigRepoFacts } from "./doctor-config-repo.js";
+import {
+  classifyConfigRepo,
+  classifyConfigSyncCron,
+  CONFIG_SYNC_STALE_INTERVALS,
+  UNPUSHED_STALE_MS,
+  type ConfigRepoFacts,
+  type ConfigSyncCronFacts,
+} from "./doctor-config-repo.js";
 
 const base: ConfigRepoFacts = {
   configured: true,
@@ -52,5 +59,74 @@ describe("classifyConfigRepo", () => {
   it("WARNs when there is no upstream tracking ref", () => {
     const rows = classifyConfigRepo({ ...base, unpushedCount: null });
     expect(row(rows, "config repo unpushed")?.status).toBe("warn");
+  });
+});
+
+describe("classifyConfigSyncCron", () => {
+  const NOW = 1_700_000_000_000;
+  const cronBase: ConfigSyncCronFacts = {
+    configured: true,
+    enabled: true,
+    cronInstalled: true,
+    logMtimeMs: NOW - 5 * 60_000, // 5m ago — fresh
+    intervalMinutes: 30,
+  };
+  const staleMs = 30 * CONFIG_SYNC_STALE_INTERVALS * 60_000;
+
+  it("emits no row when config_repo is not configured", () => {
+    expect(classifyConfigSyncCron({ ...cronBase, configured: false }, NOW)).toBeNull();
+  });
+
+  it("emits no row when the feature is off and no cron is installed", () => {
+    expect(
+      classifyConfigSyncCron({ ...cronBase, enabled: false, cronInstalled: false }, NOW),
+    ).toBeNull();
+  });
+
+  it("FAILs when enabled but the cron is not installed — backups are NOT running", () => {
+    const r = classifyConfigSyncCron({ ...cronBase, cronInstalled: false, logMtimeMs: null }, NOW);
+    expect(r?.status).toBe("fail");
+    expect(r?.detail).toContain("scheduled backups are NOT running");
+  });
+
+  it("WARNs when the cron is installed but the feature is disabled", () => {
+    const r = classifyConfigSyncCron(
+      { ...cronBase, enabled: false, cronInstalled: true },
+      NOW,
+    );
+    expect(r?.status).toBe("warn");
+    expect(r?.fix).toContain("uninstall-cron");
+  });
+
+  it("WARNs when armed but no tick has ever completed (no log)", () => {
+    const r = classifyConfigSyncCron({ ...cronBase, logMtimeMs: null }, NOW);
+    expect(r?.status).toBe("warn");
+    expect(r?.detail).toContain("no tick has completed");
+  });
+
+  it("is OK when armed, enabled, and a tick ran within the staleness window", () => {
+    const r = classifyConfigSyncCron({ ...cronBase, logMtimeMs: NOW - staleMs + 60_000 }, NOW);
+    expect(r?.status).toBe("ok");
+  });
+
+  it("FAILs when the last tick is stale past the window", () => {
+    const r = classifyConfigSyncCron({ ...cronBase, logMtimeMs: NOW - staleMs - 60_000 }, NOW);
+    expect(r?.status).toBe("fail");
+    expect(r?.detail).toContain("stale past");
+  });
+
+  it("WARNs on a future-dated log (clock skew)", () => {
+    const r = classifyConfigSyncCron({ ...cronBase, logMtimeMs: NOW + staleMs + 60_000 }, NOW);
+    expect(r?.status).toBe("warn");
+    expect(r?.detail).toContain("FUTURE");
+  });
+
+  it("scales the staleness window with interval_minutes", () => {
+    // 5-min cadence → window is 15m; a 20m-old tick is stale.
+    const r = classifyConfigSyncCron(
+      { ...cronBase, intervalMinutes: 5, logMtimeMs: NOW - 20 * 60_000 },
+      NOW,
+    );
+    expect(r?.status).toBe("fail");
   });
 });

--- a/src/cli/doctor-config-repo.ts
+++ b/src/cli/doctor-config-repo.ts
@@ -24,6 +24,11 @@ import { join } from "node:path";
 import { resolvePath } from "../config/loader.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 import { PERSONAL_SKILLS_SUBPATH, type CmdRunner } from "../config-repo/sync.js";
+import {
+  CRON_LOG_PATH,
+  CRON_PATH,
+  DEFAULT_INTERVAL_MINUTES,
+} from "../config-repo/install-cron.js";
 
 export interface CheckResult {
   name: string;
@@ -34,6 +39,114 @@ export interface CheckResult {
 
 /** How old the oldest unpushed commit may be before the row goes red. */
 export const UNPUSHED_STALE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * How many missed ticks before the "scheduled sync" row goes red. Three
+ * intervals is past any plausible transient (a slow sync holding the `flock`, a
+ * reboot, one gh probe hanging) and well short of letting a dead schedule look
+ * alive for a working day. Computed from `config_repo.interval_minutes` at read
+ * time; the constant here is the multiplier.
+ */
+export const CONFIG_SYNC_STALE_INTERVALS = 3;
+
+/**
+ * Facts the scheduled-sync classifier turns into a row. Kept separate from
+ * {@link ConfigRepoFacts} so the two rows are independently unit-testable.
+ */
+export interface ConfigSyncCronFacts {
+  /** Is a `config_repo:` block present at all. */
+  configured: boolean;
+  enabled: boolean;
+  /** Does /etc/cron.d/switchroom-config-sync exist. */
+  cronInstalled: boolean;
+  /** mtime (ms) of the sync log — evidence a tick actually ran; null if absent. */
+  logMtimeMs: number | null;
+  /** Cadence in minutes, used to size the staleness window. */
+  intervalMinutes: number;
+}
+
+/**
+ * Classify the scheduled-sync (cron) state. Pure, so every branch is asserted
+ * in a unit test rather than by arranging a real cron file.
+ *
+ * States (the plan's Slice 2 doctor contract, plus a firing/staleness signal):
+ *   - enabled + NOT installed  → FAIL: backups are simply not running.
+ *   - NOT enabled + installed   → WARN: the tick still runs+pushes, but the
+ *     feature is off — enable it or `config-repo uninstall-cron`.
+ *   - enabled + installed, never ticked → WARN: cron may not be running.
+ *   - enabled + installed, stale → FAIL: cron/the tick is failing.
+ *   - enabled + installed, fresh → OK.
+ *   - NOT enabled + NOT installed → null (feature fully off; no row).
+ */
+export function classifyConfigSyncCron(
+  f: ConfigSyncCronFacts,
+  now: number,
+): CheckResult | null {
+  if (!f.configured) return null;
+  const name = "config repo scheduled sync";
+  const staleMs = f.intervalMinutes * CONFIG_SYNC_STALE_INTERVALS * 60_000;
+
+  if (f.enabled && !f.cronInstalled) {
+    return {
+      name,
+      status: "fail",
+      detail:
+        `config_repo.enabled but no cron at ${CRON_PATH} — scheduled backups are NOT running; ` +
+        "the repo only captures changes when someone runs `config-repo sync` by hand",
+      fix: "Arm it: `switchroom config-repo install-cron --cron-user <operator>` (needs root to write /etc/cron.d).",
+    };
+  }
+
+  if (!f.enabled && f.cronInstalled) {
+    return {
+      name,
+      status: "warn",
+      detail:
+        `${CRON_PATH} is installed but config_repo.enabled is false — the tick still commits and pushes`,
+      fix: "Either set `config_repo.enabled: true`, or disarm with `switchroom config-repo uninstall-cron`.",
+    };
+  }
+
+  if (!f.enabled && !f.cronInstalled) return null;
+
+  // enabled && installed — judge firing via the log mtime.
+  if (f.logMtimeMs === null) {
+    return {
+      name,
+      status: "warn",
+      detail:
+        `cron armed but no tick has completed yet (no log at ${CRON_LOG_PATH}) — ` +
+        "cron may not be running, or every tick is failing before it writes",
+      fix: "Check cron is running and dry-run: `switchroom config-repo sync --no-push`.",
+    };
+  }
+
+  const ageMs = now - f.logMtimeMs;
+  const mins = Math.round(ageMs / 60_000);
+  if (ageMs < -staleMs) {
+    return {
+      name,
+      status: "warn",
+      detail: `sync log is dated ${Math.abs(mins)}m in the FUTURE — clock skew or a restored backup`,
+      fix: "Check the host clock.",
+    };
+  }
+  if (ageMs > staleMs) {
+    return {
+      name,
+      status: "fail",
+      detail:
+        `last scheduled sync was ${mins}m ago (stale past ${Math.round(staleMs / 60_000)}m) — ` +
+        "cron itself or the tick is failing",
+      fix: `Inspect ${CRON_LOG_PATH}; dry-run with \`switchroom config-repo sync --no-push\`.`,
+    };
+  }
+  return {
+    name,
+    status: "ok",
+    detail: `armed (*/${f.intervalMinutes} * * * *); last sync ${mins}m ago`,
+  };
+}
 
 /** Host facts the classifier turns into rows. */
 export interface ConfigRepoFacts {
@@ -253,18 +366,35 @@ export function checkConfigRepo(
     ? resolvePath(block.path)
     : join(process.env.SWITCHROOM_HOME ?? process.env.HOME ?? homedir(), ".switchroom-config");
 
-  const isGitRepo = existsSync(join(repoPath, ".git"));
-  if (!isGitRepo) {
-    return classifyConfigRepo({
+  // Scheduled-sync (cron) row — independent of whether the repo is a git repo,
+  // so it is read once and appended to whichever branch returns.
+  const cronRow = classifyConfigSyncCron(
+    {
       configured: true,
       enabled: block.enabled,
-      repoPath,
-      isGitRepo: false,
-      isPrivate: null,
-      untrackedPersonalSkills: 0,
-      unpushedCount: null,
-      oldestUnpushedAgeMs: null,
-    });
+      cronInstalled: existsSync(CRON_PATH),
+      logMtimeMs: safeMtimeMs(CRON_LOG_PATH),
+      intervalMinutes: block.interval_minutes ?? DEFAULT_INTERVAL_MINUTES,
+    },
+    now,
+  );
+  const withCron = (rows: CheckResult[]): CheckResult[] =>
+    cronRow ? [...rows, cronRow] : rows;
+
+  const isGitRepo = existsSync(join(repoPath, ".git"));
+  if (!isGitRepo) {
+    return withCron(
+      classifyConfigRepo({
+        configured: true,
+        enabled: block.enabled,
+        repoPath,
+        isGitRepo: false,
+        isPrivate: null,
+        untrackedPersonalSkills: 0,
+        unpushedCount: null,
+        oldestUnpushedAgeMs: null,
+      }),
+    );
   }
 
   const git = gitRunner(repoPath);
@@ -287,14 +417,25 @@ export function checkConfigRepo(
   const untracked = countUntrackedPersonalSkills(repoPath, git);
   const unpushed = readUnpushed(git, now);
 
-  return classifyConfigRepo({
-    configured: true,
-    enabled: block.enabled,
-    repoPath,
-    isGitRepo: true,
-    isPrivate,
-    untrackedPersonalSkills: untracked,
-    unpushedCount: unpushed.count,
-    oldestUnpushedAgeMs: unpushed.oldestAgeMs,
-  });
+  return withCron(
+    classifyConfigRepo({
+      configured: true,
+      enabled: block.enabled,
+      repoPath,
+      isGitRepo: true,
+      isPrivate,
+      untrackedPersonalSkills: untracked,
+      unpushedCount: unpushed.count,
+      oldestUnpushedAgeMs: unpushed.oldestAgeMs,
+    }),
+  );
+}
+
+/** mtime (ms) of a file, or null when absent/unreadable. */
+function safeMtimeMs(path: string): number | null {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return null;
+  }
 }

--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -55,6 +55,7 @@ describe("planUpdate", () => {
         "pull-images",
         "apply-config",
         "reconcile-hindsight-watch-cron",
+        "reconcile-config-repo-cron",
         "install-self-heal-timer",
         "refresh-hostd",
         "refresh-web",
@@ -122,6 +123,71 @@ describe("planUpdate", () => {
         const cronPath = join(tmp, "hindsight-watch");
         // Must not throw and must not create the file — arming stays opt-in.
         expect(() => stepFor({ watchCronPath: cronPath }).run()).not.toThrow();
+        expect(existsSync(cronPath)).toBe(false);
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it("is deferred (skipReason) in hostd-context — /etc/cron.d is on the host", () => {
+      expect(stepFor({ hostdContext: true }).skipReason).toMatch(/hostd-context/);
+      expect(stepFor({ hostdContext: false }).skipReason).toBeUndefined();
+    });
+  });
+
+  describe("reconcile-config-repo-cron step (auto-backup drift repair)", () => {
+    const OLD_ENV = { ...process.env };
+    function stepFor(opts: Parameters<typeof planUpdate>[0]) {
+      return planUpdate({ composePath: "unused", ...opts }).find(
+        (s) => s.name === "reconcile-config-repo-cron",
+      )!;
+    }
+
+    it("REWRITES the config-sync cron when it differs, then is a NO-OP when identical", () => {
+      const tmp = mkdtempSync(join(tmpdir(), "update-cfgcron-"));
+      try {
+        process.env.SWITCHROOM_BINARY = "/usr/local/bin/switchroom";
+        const cronPath = join(tmp, "switchroom-config-sync");
+        // Armed earlier as `ada` at a STALE binary path.
+        writeFileSync(
+          cronPath,
+          [
+            "# switchroom config-repo auto-backup — scheduled sync of ~/.switchroom-config.",
+            "# Managed by `switchroom config-repo --install-cron`; edits are overwritten.",
+            "# 30-min leg: commit+push live config / workspace / mirrored personal skills.",
+            "# vault backup: daily at 17 3 * * * (config_repo.include_vault_backup: daily).",
+            "SHELL=/bin/sh",
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "*/30 * * * * ada /usr/bin/flock -n /run/lock/switchroom-config-sync.lock /opt/old/switchroom config-repo sync >> /var/log/switchroom-config-sync.log 2>&1",
+            "17 3 * * * ada /usr/bin/flock -n /run/lock/switchroom-config-sync.lock /bin/sh -c '/opt/old/switchroom vault backup && /opt/old/switchroom config-repo sync' >> /var/log/switchroom-config-sync.log 2>&1",
+            "",
+          ].join("\n"),
+        );
+        const before = readFileSync(cronPath, "utf8");
+
+        // First run: the stale binary path is corrected → file changes.
+        stepFor({ configSyncCronPath: cronPath }).run();
+        const after = readFileSync(cronPath, "utf8");
+        expect(after).not.toBe(before);
+        expect(after).toContain("/usr/local/bin/switchroom config-repo sync");
+        expect(after).not.toContain("/opt/old/switchroom");
+        // The operator's chosen user is preserved, not overwritten to root.
+        expect(after).toContain("*/30 * * * * ada ");
+
+        // Second run: definition already current → byte-identical no-op.
+        stepFor({ configSyncCronPath: cronPath }).run();
+        expect(readFileSync(cronPath, "utf8")).toBe(after);
+      } finally {
+        process.env = { ...OLD_ENV };
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it("is a NO-OP when the host was never armed (no fragment present) — reconcile never ARMS", () => {
+      const tmp = mkdtempSync(join(tmpdir(), "update-cfgcron-absent-"));
+      try {
+        const cronPath = join(tmp, "switchroom-config-sync");
+        expect(() => stepFor({ configSyncCronPath: cronPath }).run()).not.toThrow();
         expect(existsSync(cronPath)).toBe(false);
       } finally {
         rmSync(tmp, { recursive: true, force: true });
@@ -420,6 +486,7 @@ describe("planUpdate", () => {
         "rebuild-source",
         "apply-config",
         "reconcile-hindsight-watch-cron",
+        "reconcile-config-repo-cron",
         "install-self-heal-timer",
         "refresh-hostd",
         "refresh-web",

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -80,6 +80,10 @@ import {
 } from "./component-versions.js";
 import { reconcileCron } from "../hindsight-watch/install-cron.js";
 import {
+  reconcileCron as reconcileConfigSyncCron,
+  DEFAULT_INTERVAL_MINUTES as CONFIG_SYNC_DEFAULT_INTERVAL,
+} from "../config-repo/install-cron.js";
+import {
   installSelfHealTimer,
   type InstallTimerDeps,
 } from "../host-cli-self-heal/install-timer.js";
@@ -240,6 +244,10 @@ interface UpdateOptions {
    *  `reconcile-hindsight-watch-cron` step reconciles (default: the real
    *  `CRON_PATH`). Lets the step be exercised against a temp file. */
   watchCronPath?: string;
+  /** Test seam — override the /etc/cron.d/switchroom-config-sync path the
+   *  `reconcile-config-repo-cron` step reconciles (default: the real
+   *  config-repo `CRON_PATH`). */
+  configSyncCronPath?: string;
   /** Test seam — override the self-heal timer install for the
    *  `install-self-heal-timer` step (systemd/privilege/user/path shims).
    *  Default: the real host detection + `/etc/systemd/system` writes. */
@@ -781,6 +789,79 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
         say(chalk.green(`  hindsight-watch cron reconciled at ${res.path}\n`));
       } else {
         say(chalk.gray(`  hindsight-watch cron already current at ${res.path}\n`));
+      }
+    },
+  });
+
+  // reconcile-config-repo-cron: re-assert the config-repo auto-backup cron
+  // definition on every update, so an already-armed host can't drift (stale
+  // binary path, or a changed `config_repo.interval_minutes` /
+  // `include_vault_backup`).
+  //
+  // REPAIR, not ARM — exactly like reconcile-hindsight-watch-cron above:
+  // `reconcileConfigSyncCron` is a no-op when the fragment is absent (arming
+  // stays the explicit, enabled-gated `config-repo install-cron` opt-in, and
+  // `switchroom doctor` FAILs while an ENABLED feature is un-armed), and
+  // idempotent when present and already correct. The operator's chosen
+  // `--cron-user` is preserved; the interval + vault-backup mode are re-read
+  // from config so a switchroom.yaml change is picked up on the next update.
+  //
+  // Deferred in hostd-context: /etc/cron.d is on the host, not in the hostd
+  // container. Never fatal — a failed reconcile warns and continues.
+  steps.push({
+    name: "reconcile-config-repo-cron",
+    description:
+      "Reconcile /etc/cron.d/switchroom-config-sync (binary path / interval / vault-backup mode) on already-armed hosts — idempotent; no-op when unarmed or already current",
+    skipReason: hostdContext
+      ? "deferred (hostd-context): /etc/cron.d is on the host, not in the hostd container — finish host-side with `switchroom config-repo install-cron`"
+      : undefined,
+    isHostdDeferred: hostdContext,
+    run: () => {
+      const say = opts.stdout ?? ((t: string) => process.stdout.write(t));
+      const binary = process.env.SWITCHROOM_BINARY ?? "/usr/local/bin/switchroom";
+      const fallbackUser =
+        process.env.SUDO_USER ?? process.env.USER ?? process.env.LOGNAME;
+      // Re-read the current cadence + vault-backup mode from config so a
+      // switchroom.yaml change reconciles. Tolerate a missing/malformed block.
+      let intervalMinutes = CONFIG_SYNC_DEFAULT_INTERVAL;
+      let includeVaultBackup: "off" | "daily" | "every_tick" = "daily";
+      try {
+        const block = loadConfig(opts.configPath).config_repo;
+        if (block) {
+          intervalMinutes = block.interval_minutes ?? CONFIG_SYNC_DEFAULT_INTERVAL;
+          includeVaultBackup = block.include_vault_backup ?? "daily";
+        }
+      } catch {
+        /* defaults above still reconcile a fragment to a sane definition */
+      }
+      let res: ReturnType<typeof reconcileConfigSyncCron>;
+      try {
+        res = reconcileConfigSyncCron({
+          binary,
+          intervalMinutes,
+          includeVaultBackup,
+          fallbackUser,
+          ...(opts.configSyncCronPath ? { path: opts.configSyncCronPath } : {}),
+        });
+      } catch (e) {
+        say(
+          chalk.yellow(
+            `  config-repo cron not reconciled: ${(e as Error).message}\n`,
+          ),
+        );
+        return;
+      }
+      if (res.status === "absent") {
+        say(
+          chalk.gray(
+            "  config-repo cron not armed — skipping reconcile " +
+              "(arm with `switchroom config-repo install-cron`; doctor FAILs while enabled+unarmed)\n",
+          ),
+        );
+      } else if (res.status === "reconciled") {
+        say(chalk.green(`  config-repo cron reconciled at ${res.path}\n`));
+      } else {
+        say(chalk.gray(`  config-repo cron already current at ${res.path}\n`));
       }
     },
   });

--- a/src/config-repo/install-cron.test.ts
+++ b/src/config-repo/install-cron.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  CRON_LOCK_PATH,
+  CRON_LOG_PATH,
+  CRON_PATH,
+  DAILY_CRON_SCHEDULE,
+  DEFAULT_INTERVAL_MINUTES,
+  installCron,
+  parseCronUser,
+  reconcileCron,
+  renderCron,
+  uninstallCron,
+} from "./install-cron.js";
+
+/**
+ * Slice 1 shipped the sync verb but no schedule. These tests pin the arming
+ * step — every property is a classic way a `/etc/cron.d` fragment exists and
+ * silently never runs, plus the two-leg (30-min + daily vault backup) contract.
+ */
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "cfgrepo-cron-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const OPTS = { user: "kenthompson", binary: "/usr/local/bin/switchroom" };
+
+describe("renderCron — default (daily vault backup)", () => {
+  const out = renderCron(OPTS);
+
+  it("ends with a newline — cron ignores a fragment without one", () => {
+    expect(out.endsWith("\n")).toBe(true);
+  });
+
+  it("sets an explicit PATH containing /usr/local/bin (git/gh/flock live there)", () => {
+    const path = out.split("\n").find((l) => l.startsWith("PATH="));
+    expect(path).toBeDefined();
+    expect(path).toContain("/usr/local/bin");
+    expect(path).toContain("/usr/bin");
+  });
+
+  it("runs the 30-min tick as the named user, flock-guarded, invoking `config-repo sync`", () => {
+    // The default cadence is Ken's approved 30 minutes.
+    expect(DEFAULT_INTERVAL_MINUTES).toBe(30);
+    expect(out).toContain(
+      `*/30 * * * * ${OPTS.user} /usr/bin/flock -n ${CRON_LOCK_PATH} ${OPTS.binary} config-repo sync >> ${CRON_LOG_PATH} 2>&1`,
+    );
+  });
+
+  it("adds a DAILY leg that runs `vault backup && config-repo sync` before the sync", () => {
+    expect(out).toContain(
+      `${DAILY_CRON_SCHEDULE} ${OPTS.user} /usr/bin/flock -n ${CRON_LOCK_PATH} ` +
+        `/bin/sh -c '${OPTS.binary} vault backup && ${OPTS.binary} config-repo sync' >> ${CRON_LOG_PATH} 2>&1`,
+    );
+  });
+
+  it("uses ONE shared lock for both legs so two git commits can never race", () => {
+    const lines = out.split("\n").filter((l) => l.includes("flock"));
+    expect(lines).toHaveLength(2); // 30-min tick + daily leg
+    for (const l of lines) expect(l).toContain(`/usr/bin/flock -n ${CRON_LOCK_PATH} `);
+  });
+
+  it("puts the daily leg OFF the 30-min grid so it is never pre-empted by a tick", () => {
+    // Minute 17 is not a multiple of 30 (:00/:30), so a plain tick and the
+    // backup leg never contend for the shared lock on the same minute.
+    const dailyMinute = Number(DAILY_CRON_SCHEDULE.split(" ")[0]);
+    expect(dailyMinute % 30).not.toBe(0);
+  });
+});
+
+describe("renderCron — include_vault_backup modes", () => {
+  it("off: a single sync tick, no daily leg, no `vault backup` command", () => {
+    const out = renderCron({ ...OPTS, includeVaultBackup: "off" });
+    const flockLines = out.split("\n").filter((l) => l.includes("flock"));
+    expect(flockLines).toHaveLength(1);
+    expect(flockLines[0]).toContain("config-repo sync");
+    // No cron COMMAND line runs `vault backup` (the comment note may mention it).
+    expect(flockLines[0]).not.toContain("vault backup");
+  });
+
+  it("every_tick: the 30-min tick itself runs `vault backup && config-repo sync`, no separate daily leg", () => {
+    const out = renderCron({ ...OPTS, includeVaultBackup: "every_tick" });
+    const flockLines = out.split("\n").filter((l) => l.includes("flock"));
+    expect(flockLines).toHaveLength(1);
+    expect(flockLines[0]).toContain(
+      `/bin/sh -c '${OPTS.binary} vault backup && ${OPTS.binary} config-repo sync'`,
+    );
+    // No daily-only backup line when it already runs every tick.
+    expect(out).not.toContain(DAILY_CRON_SCHEDULE);
+  });
+
+  it("honours a custom interval_minutes in the tick minute field", () => {
+    const out = renderCron({ ...OPTS, intervalMinutes: 15 });
+    expect(out).toContain(`*/15 * * * * ${OPTS.user} `);
+  });
+});
+
+describe("installCron", () => {
+  it("writes mode 0644 with the rendered content — cron refuses a group/world-writable fragment", () => {
+    const path = join(dir, "switchroom-config-sync");
+    installCron({ ...OPTS, path });
+    expect(statSync(path).mode & 0o777).toBe(0o644);
+    expect(readFileSync(path, "utf8")).toBe(renderCron(OPTS));
+  });
+
+  it("is idempotent: a second call reports unchanged and does not rewrite", () => {
+    const path = join(dir, "switchroom-config-sync");
+    expect(installCron({ ...OPTS, path }).status).toBe("installed");
+    expect(installCron({ ...OPTS, path }).status).toBe("unchanged");
+  });
+
+  it("rewrites a drifted fragment (e.g. an interval change)", () => {
+    const path = join(dir, "switchroom-config-sync");
+    installCron({ ...OPTS, path, intervalMinutes: 30 });
+    const r = installCron({ ...OPTS, path, intervalMinutes: 15 });
+    expect(r.status).toBe("installed");
+    expect(readFileSync(path, "utf8")).toBe(renderCron({ ...OPTS, intervalMinutes: 15 }));
+  });
+
+  it("leaves no .tmp file behind", () => {
+    const path = join(dir, "switchroom-config-sync");
+    installCron({ ...OPTS, path });
+    expect(() => statSync(`${path}.${process.pid}.tmp`)).toThrow();
+  });
+});
+
+describe("uninstallCron — removable and idempotent", () => {
+  it("removes an installed fragment, then reports absent on a second call", () => {
+    const path = join(dir, "switchroom-config-sync");
+    installCron({ ...OPTS, path });
+    expect(uninstallCron(path).status).toBe("removed");
+    expect(existsSync(path)).toBe(false);
+    // Double-uninstall is a clean no-op.
+    expect(uninstallCron(path).status).toBe("absent");
+  });
+
+  it("reports absent when nothing was installed", () => {
+    const path = join(dir, "switchroom-config-sync");
+    expect(uninstallCron(path).status).toBe("absent");
+  });
+});
+
+describe("parseCronUser", () => {
+  it("returns the user field of the managed `config-repo sync` line", () => {
+    expect(parseCronUser(renderCron(OPTS))).toBe("kenthompson");
+    expect(parseCronUser(renderCron({ ...OPTS, user: "ada" }))).toBe("ada");
+  });
+
+  it("returns null for a fragment with no managed line", () => {
+    expect(parseCronUser("# just a comment\nPATH=/bin\n")).toBeNull();
+    expect(parseCronUser("")).toBeNull();
+  });
+});
+
+describe("reconcileCron — repair an already-armed cron, never arm", () => {
+  it("is a no-op (absent) when the fragment does not exist — an unarmed host STAYS unarmed", () => {
+    const path = join(dir, "switchroom-config-sync");
+    const res = reconcileCron({ binary: OPTS.binary, path, fallbackUser: "ken" });
+    expect(res.status).toBe("absent");
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("REWRITES a drifted fragment (stale binary + interval) and preserves the user", () => {
+    const path = join(dir, "switchroom-config-sync");
+    // Armed earlier as `ada`, old binary, 30-min.
+    writeFileSync(path, renderCron({ user: "ada", binary: "/opt/old/switchroom", intervalMinutes: 30 }));
+    const res = reconcileCron({
+      binary: "/usr/local/bin/switchroom",
+      intervalMinutes: 15,
+      fallbackUser: "root", // must NOT be used — user is parsed from the file
+      path,
+    });
+    expect(res.status).toBe("reconciled");
+    expect(readFileSync(path, "utf8")).toBe(
+      renderCron({ user: "ada", binary: "/usr/local/bin/switchroom", intervalMinutes: 15 }),
+    );
+  });
+
+  it("is idempotent: a second reconcile of a current fragment is unchanged", () => {
+    const path = join(dir, "switchroom-config-sync");
+    writeFileSync(path, renderCron({ user: "ada", binary: "/usr/local/bin/switchroom" }));
+    expect(reconcileCron({ binary: "/usr/local/bin/switchroom", path }).status).toBe("unchanged");
+    expect(reconcileCron({ binary: "/usr/local/bin/switchroom", path }).status).toBe("unchanged");
+  });
+
+  it("defaults to the real CRON_PATH when none is given", () => {
+    const res = reconcileCron({ binary: OPTS.binary, fallbackUser: "ken" });
+    expect(res.path).toBe(CRON_PATH);
+  });
+});

--- a/src/config-repo/install-cron.ts
+++ b/src/config-repo/install-cron.ts
@@ -1,0 +1,406 @@
+/**
+ * Arming the config-repo auto-backup — the schedule Slice 1 deliberately left out.
+ *
+ * ## Why this file exists
+ *
+ * Slice 1 shipped `switchroom config-repo sync` — a native, flock-guarded,
+ * secret-scanned commit+push of the operator's private `~/.switchroom-config`
+ * repo — but it is a MANUAL verb. On paper the backup story is complete; in
+ * practice nothing runs it, so the repo captures a change only when a human
+ * remembers to. That is the exact "the mechanism exists but was never armed"
+ * trap `hindsight-watch/install-cron.ts` was written to close (its cron shipped
+ * disarmed for six weeks). This is the same mechanism for the config repo: a
+ * product-installed `/etc/cron.d` fragment that runs the sync on a schedule,
+ * and a `switchroom doctor` row that goes red when `config_repo.enabled` is set
+ * but the cron is not armed, so an un-armed backup says so out loud.
+ *
+ * ## Why /etc/cron.d and not a systemd timer
+ *
+ * The push rides the OPERATOR's `gh` credential helper (`~/.gitconfig` +
+ * `gh auth`), so the tick MUST run as `kenthompson`, not root. `/etc/cron.d`
+ * carries a user field and matches the hindsight-watch precedent exactly; the
+ * live self-heal *timer* runs as root, which is precisely the wrong identity
+ * for a git push. Cost of cron over a `Persistent=true` timer: no missed-run
+ * catch-up — acceptable at a 30-min cadence, where a missed tick self-heals
+ * within the interval.
+ *
+ * ## The two legs
+ *
+ *  - **30-min tick** (`config_repo.interval_minutes`, default 30): commit+push
+ *    live config, owned workspace state, and mirrored personal skills.
+ *  - **daily leg** (`config_repo.include_vault_backup: daily`): once a day, run
+ *    `switchroom vault backup` FIRST, then the same sync — the first automated
+ *    vault/memory snapshot on this host. `every_tick` folds the backup into the
+ *    30-min tick instead; `off` drops it.
+ *
+ * Both legs share ONE `flock -n` lock, so the daily leg and a still-running
+ * 30-min tick can never run git concurrently, and the daily minute (17) is off
+ * the 30-min grid (:00/:30) so the backup leg is never pre-empted by a plain
+ * tick landing on the same minute.
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  chownSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+
+/** Where the cron fragment lands. */
+export const CRON_PATH = "/etc/cron.d/switchroom-config-sync";
+
+/** Log the cron appends to (both legs redirect here). */
+export const CRON_LOG_PATH = "/var/log/switchroom-config-sync.log";
+
+/** Where the logrotate drop-in lands. */
+export const LOGROTATE_PATH = "/etc/logrotate.d/switchroom-config-sync";
+
+/**
+ * Lock file — `flock -n` so a slow sync cannot be overlapped by the next tick
+ * OR the daily backup leg. Sharing ONE lock across both legs is the whole
+ * point: two `git commit`s racing in the repo is the failure single-writer
+ * exists to prevent.
+ */
+export const CRON_LOCK_PATH = "/run/lock/switchroom-config-sync.lock";
+
+/** Default tick cadence in minutes (Ken's approved decision). */
+export const DEFAULT_INTERVAL_MINUTES = 30;
+
+/**
+ * Schedule for the daily `vault backup && sync` leg. Minute 17 is deliberately
+ * OFF the 30-min grid ({:00, :30}), so a plain tick and the backup leg never
+ * land on the same minute and contend for the shared lock — the backup leg
+ * always gets to run. 03:17 is a low-traffic hour.
+ */
+export const DAILY_CRON_SCHEDULE = "17 3 * * *";
+
+export type IncludeVaultBackup = "off" | "daily" | "every_tick";
+
+export interface CronRenderOptions {
+  /** Unix user the tick runs as (must own the gh credential helper). */
+  user: string;
+  /** Absolute path to the `switchroom` binary. */
+  binary: string;
+  /** Tick cadence in minutes (5..59). Default 30. */
+  intervalMinutes?: number;
+  /** Whether/when to run `vault backup` before the sync. Default "daily". */
+  includeVaultBackup?: IncludeVaultBackup;
+}
+
+/** `/usr/bin/flock -n <lock>` — shared by both legs. */
+function flockPrefix(): string {
+  return `/usr/bin/flock -n ${CRON_LOCK_PATH}`;
+}
+
+/**
+ * Render the cron fragment.
+ *
+ * Pure, so the exact bytes that land in `/etc/cron.d` are asserted in a unit
+ * test rather than discovered in production. The properties the test pins are
+ * the classic ways a `/etc/cron.d` fragment exists and silently never runs:
+ *
+ *  - **`flock -n`** on a SHARED lock, so the two legs (and a slow tick) can
+ *    never run git concurrently.
+ *  - **A trailing newline.** cron silently ignores a fragment whose last line
+ *    has no newline.
+ *  - **An explicit `PATH`.** `switchroom` shells out (git, gh, flock); cron's
+ *    default `/usr/bin:/bin` omits `/usr/local/bin`.
+ *  - **Absolute binary path**, since a relative argv in a cron line fails every
+ *    tick with a message only in syslog.
+ */
+export function renderCron(opts: CronRenderOptions): string {
+  const interval = opts.intervalMinutes ?? DEFAULT_INTERVAL_MINUTES;
+  const mode = opts.includeVaultBackup ?? "daily";
+  const bin = opts.binary;
+  const flock = flockPrefix();
+
+  const syncCmd = `${bin} config-repo sync`;
+  // `vault backup` must complete before the sync so the fresh snapshot is what
+  // gets committed. `&&` (not `;`) so a failed backup does not mask its exit in
+  // a sync that then reports success.
+  const backupThenSync = `/bin/sh -c '${bin} vault backup && ${bin} config-repo sync'`;
+
+  const tickCmd = mode === "every_tick" ? backupThenSync : syncCmd;
+  const tickLine =
+    `*/${interval} * * * * ${opts.user} ${flock} ${tickCmd} >> ${CRON_LOG_PATH} 2>&1\n`;
+
+  const dailyLine =
+    mode === "daily"
+      ? `${DAILY_CRON_SCHEDULE} ${opts.user} ${flock} ${backupThenSync} >> ${CRON_LOG_PATH} 2>&1\n`
+      : "";
+
+  const backupNote =
+    mode === "off"
+      ? "# vault backup: off (config_repo.include_vault_backup: off).\n"
+      : mode === "every_tick"
+        ? "# vault backup: every tick (config_repo.include_vault_backup: every_tick).\n"
+        : `# vault backup: daily at ${DAILY_CRON_SCHEDULE} (config_repo.include_vault_backup: daily).\n`;
+
+  return (
+    `# switchroom config-repo auto-backup — scheduled sync of ~/.switchroom-config.\n` +
+    `# Managed by \`switchroom config-repo --install-cron\`; edits are overwritten.\n` +
+    `# ${interval}-min leg: commit+push live config / workspace / mirrored personal skills.\n` +
+    backupNote +
+    `SHELL=/bin/sh\n` +
+    `PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n` +
+    tickLine +
+    dailyLine
+  );
+}
+
+export interface InstallResult {
+  /** `installed` on a write, `unchanged` when the file already matched. */
+  status: "installed" | "unchanged";
+  path: string;
+  content: string;
+}
+
+/**
+ * Write the cron fragment idempotently.
+ *
+ * Re-running is a no-op when the content already matches, so this is safe from
+ * an unconditional reconcile path. tmp+rename to mode 0644 — cron refuses a
+ * group- or world-writable fragment, and a half-written file would be parsed by
+ * whatever cron scan lands mid-write.
+ */
+export function installCron(
+  opts: CronRenderOptions & { path?: string },
+): InstallResult {
+  const path = opts.path ?? CRON_PATH;
+  const content = renderCron(opts);
+  if (existsSync(path)) {
+    try {
+      if (readFileSync(path, "utf8") === content) {
+        return { status: "unchanged", path, content };
+      }
+    } catch {
+      // Unreadable but present — fall through and rewrite it.
+    }
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, content, { mode: 0o644 });
+  renameSync(tmp, path);
+  return { status: "installed", path, content };
+}
+
+export interface UninstallResult {
+  /** `removed` when a fragment was deleted, `absent` when there was none. */
+  status: "removed" | "absent";
+  path: string;
+}
+
+/**
+ * Remove the cron fragment idempotently. `absent` when nothing was there, so a
+ * double-uninstall is a clean no-op. Removing the fragment stops both legs; the
+ * log and logrotate drop-in are cleaned up separately by the CLI verb (they are
+ * harmless if left, and an operator may want to keep the log).
+ */
+export function uninstallCron(path: string = CRON_PATH): UninstallResult {
+  if (!existsSync(path)) return { status: "absent", path };
+  rmSync(path, { force: true });
+  return { status: "removed", path };
+}
+
+/** Resolve a unix user name to `{uid, gid}` via `id -u` / `id -g`. */
+export type IdResolver = (user: string) => { uid: number; gid: number };
+
+const defaultIdResolver: IdResolver = (user) => {
+  const uid = Number(execFileSync("id", ["-u", user], { encoding: "utf8" }).trim());
+  const gid = Number(execFileSync("id", ["-g", user], { encoding: "utf8" }).trim());
+  if (!Number.isInteger(uid) || !Number.isInteger(gid)) {
+    throw new Error(`could not resolve uid/gid for user ${JSON.stringify(user)}`);
+  }
+  return { uid, gid };
+};
+
+export interface EnsureLogResult {
+  /** `created` on a fresh write, `unchanged` when the file already existed. */
+  status: "created" | "unchanged";
+  path: string;
+}
+
+/**
+ * Create the sync log file owned by the cron user — the same #3991 trap the
+ * watchdog hit: the rendered line ends `>> /var/log/switchroom-config-sync.log
+ * 2>&1`, and on a stock Ubuntu host `/var/log` is `root:syslog 0775`, so the
+ * operator cron user cannot CREATE that file — the redirection fails
+ * "Permission denied" BEFORE `switchroom` is exec'd and every tick dies
+ * silently. Pre-creating the file mode-0644 and chowning it to the cron user
+ * lets the `>>` append succeed without write on `/var/log`.
+ *
+ * Idempotent: an existing file is left untouched (never re-chowned, never
+ * truncated). The chown is BEST-EFFORT and root-only — the file EXISTING is the
+ * guarantee; ownership only matters when `/var/log` is unwritable by the cron
+ * user, and a non-root caller (or a restricted mount) must still get a created
+ * file, never a fatal EPERM that aborts the arm.
+ */
+export function ensureLogFile(
+  opts: { user: string; path?: string; resolveIds?: IdResolver },
+): EnsureLogResult {
+  const path = opts.path ?? CRON_LOG_PATH;
+  if (existsSync(path)) return { status: "unchanged", path };
+  const { uid, gid } = (opts.resolveIds ?? defaultIdResolver)(opts.user);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, "", { mode: 0o644, flag: "a" });
+  const isRoot = process.getuid?.() === 0;
+  let alreadyOwned = false;
+  try {
+    const st = statSync(path);
+    alreadyOwned = st.uid === uid && st.gid === gid;
+  } catch {
+    // stat failure is non-fatal; fall through to attempt the chown.
+  }
+  if (isRoot && !alreadyOwned) {
+    try {
+      chownSync(path, uid, gid);
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "EPERM") throw e;
+      // EPERM tolerated: the file exists and is mode-0644; the cron can still
+      // append. Ownership stays with the creating user.
+    }
+  }
+  return { status: "created", path };
+}
+
+/**
+ * Render the logrotate drop-in. Pure, so the exact bytes are asserted in a unit
+ * test. `copytruncate` because the log has no writer to signal (cron reopens
+ * `>>` each tick), and `su <user> <user>` runs the rotation as the cron user
+ * that owns the file.
+ */
+export function renderLogrotate(opts: { logPath: string; user: string }): string {
+  return (
+    `${opts.logPath} {\n` +
+    `  weekly\n` +
+    `  rotate 8\n` +
+    `  compress\n` +
+    `  delaycompress\n` +
+    `  missingok\n` +
+    `  notifempty\n` +
+    `  copytruncate\n` +
+    `  su ${opts.user} ${opts.user}\n` +
+    `}\n`
+  );
+}
+
+/**
+ * Write the logrotate drop-in idempotently — same tmp+rename, mode-0644,
+ * no-op-when-unchanged shape as {@link installCron}.
+ */
+export function installLogrotate(
+  opts: { user: string; logPath?: string; path?: string },
+): InstallResult {
+  const path = opts.path ?? LOGROTATE_PATH;
+  const content = renderLogrotate({ logPath: opts.logPath ?? CRON_LOG_PATH, user: opts.user });
+  if (existsSync(path)) {
+    try {
+      if (readFileSync(path, "utf8") === content) {
+        return { status: "unchanged", path, content };
+      }
+    } catch {
+      // Unreadable but present — fall through and rewrite it.
+    }
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, content, { mode: 0o644 });
+  renameSync(tmp, path);
+  return { status: "installed", path, content };
+}
+
+/** Remove the logrotate drop-in idempotently. */
+export function uninstallLogrotate(path: string = LOGROTATE_PATH): UninstallResult {
+  if (!existsSync(path)) return { status: "absent", path };
+  rmSync(path, { force: true });
+  return { status: "removed", path };
+}
+
+/**
+ * Parse the unix user field out of an existing cron fragment.
+ *
+ * `/etc/cron.d` lines are `MIN HOUR DOM MON DOW USER COMMAND` — the sixth
+ * field. We match a managed line (one that invokes `config-repo sync`) rather
+ * than any comment/`SHELL=`/`PATH=` line, so a reconcile PRESERVES the
+ * operator's chosen `--cron-user` instead of guessing it from the reconciling
+ * process's environment (which under `sudo switchroom update` is `root` — the
+ * value `--install-cron` refuses).
+ *
+ * Returns null when no managed schedule line is found.
+ */
+export function parseCronUser(content: string): string | null {
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    if (!trimmed.includes("config-repo sync")) continue;
+    const fields = trimmed.split(/\s+/);
+    if (fields.length >= 7) return fields[5];
+  }
+  return null;
+}
+
+export interface ReconcileResult {
+  /**
+   * `absent`     — no fragment present; reconcile does nothing (arming stays
+   *                the explicit `--install-cron` opt-in, gated on
+   *                `config_repo.enabled`).
+   * `reconciled` — the fragment existed but drifted (stale binary path,
+   *                schedule, flags, PATH) and was rewritten to match.
+   * `unchanged`  — the fragment existed and already matched — a true no-op.
+   */
+  status: "absent" | "reconciled" | "unchanged";
+  path: string;
+  content?: string;
+}
+
+/**
+ * Reconcile an ALREADY-ARMED config-sync cron to the current definition.
+ *
+ * REPAIR, not ARM: only touches a fragment that already exists, so
+ * `switchroom update` can keep every armed host's cron current (binary path,
+ * schedule, flags, PATH) without silently arming a host that never opted in.
+ * The user field is preserved from the existing fragment; the interval and
+ * vault-backup mode are re-read from config so a `switchroom.yaml` change is
+ * reconciled on the next update.
+ *
+ * Idempotent: re-running changes nothing once the fragment matches.
+ */
+export function reconcileCron(opts: {
+  binary: string;
+  intervalMinutes?: number;
+  includeVaultBackup?: IncludeVaultBackup;
+  path?: string;
+  fallbackUser?: string;
+}): ReconcileResult {
+  const path = opts.path ?? CRON_PATH;
+  if (!existsSync(path)) return { status: "absent", path };
+  let user = opts.fallbackUser;
+  try {
+    user = parseCronUser(readFileSync(path, "utf8")) ?? opts.fallbackUser;
+  } catch {
+    // Unreadable — fall back to the provided user and let installCron rewrite.
+  }
+  if (!user) {
+    throw new Error(
+      `cannot reconcile ${path}: no cron-user parseable from the existing fragment and no fallback user available`,
+    );
+  }
+  const r = installCron({
+    user,
+    binary: opts.binary,
+    intervalMinutes: opts.intervalMinutes,
+    includeVaultBackup: opts.includeVaultBackup,
+    path,
+  });
+  return {
+    status: r.status === "installed" ? "reconciled" : "unchanged",
+    path,
+    content: r.content,
+  };
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -5273,6 +5273,31 @@ export const ConfigRepoConfigSchema = z.object({
       "Fail-safe against exfiltrating memory files / workspace state to a " +
       "repo that has been flipped public. Default true.",
     ),
+  interval_minutes: z
+    .number()
+    .int()
+    .min(5)
+    .max(59)
+    .default(30)
+    .describe(
+      "Cadence (minutes) of the scheduled `config-repo sync` tick installed " +
+      "by `switchroom config-repo --install-cron`. Rendered as a cron " +
+      "`*/N * * * *` minute field, so it must be 5..59 (the 5-min floor " +
+      "matches the rest of the fleet's cron floor). Default 30 (Ken's " +
+      "approved cadence). Changing it takes effect on the next " +
+      "`--install-cron` / `switchroom update` reconcile.",
+    ),
+  include_vault_backup: z
+    .enum(["off", "daily", "every_tick"])
+    .default("daily")
+    .describe(
+      "Whether the scheduled tick also runs `switchroom vault backup` " +
+      "(an encrypted vault/memory snapshot into <path>/vault-backups/) " +
+      "before the sync. `off`: sync only. `daily`: an extra once-per-day " +
+      "cron leg runs `vault backup && config-repo sync` (the 30-min legs " +
+      "stay sync-only). `every_tick`: every tick runs the backup first. " +
+      "Default `daily` — the first automated vault backup on this host.",
+    ),
 });
 export type ConfigRepoConfig = z.infer<typeof ConfigRepoConfigSchema>;
 


### PR DESCRIPTION
## Slice 2 — scheduled auto-backup for `~/.switchroom-config`

Builds the *automation* that drives `switchroom config-repo sync` (Slice 1, #4448) on a schedule. Single concern: the scheduled tick + its arming/disarming/reconcile surface + doctor coverage.

### What lands
- **`src/config-repo/install-cron.ts`** — product-installed `/etc/cron.d/switchroom-config-sync` fragment following the `hindsight-watch/install-cron.ts` idiom (tmp+rename `0644`, idempotent compare, refuse-root, absolute binary, `flock -n`, log + logrotate). Two legs share **one** lock:
  - a **30-min tick** (`config_repo.interval_minutes`, default 30) running `config-repo sync`;
  - a once-**daily** `vault backup && config-repo sync` leg at **03:17** (deliberately off the 30-min grid so the backup leg is never pre-empted by a plain tick contending for the shared lock) when `include_vault_backup: daily` — the first automated vault/memory snapshot on this host.
  - `off` (sync only) and `every_tick` (fold the backup into the 30-min tick) modes also render.
  - `installCron` / `uninstallCron` / `reconcileCron` / `parseCronUser`, plus `ensureLogFile` + `installLogrotate`.
- **`src/cli/config-repo.ts`** — `config-repo install-cron` (gated on `config_repo.enabled`, refuses `root`, provisions the log, installs logrotate) and `config-repo uninstall-cron` (idempotent, removes fragment + logrotate; the sync verb still works on demand).
- **`src/config/schema.ts`** — `config_repo.interval_minutes` (5..59, default 30) and `include_vault_backup` (`off|daily|every_tick`, default `daily`).
- **`src/cli/doctor-config-repo.ts`** — `classifyConfigSyncCron`: enabled-but-unarmed **FAIL**, installed-but-disabled **WARN**, plus a firing/staleness signal from the sync-log mtime scaled by the interval.
- **`src/cli/update.ts`** — `reconcile-config-repo-cron` step (repair-only, never arms; no-op when absent; deferred in hostd-context), mirroring `reconcile-hindsight-watch-cron`, so an armed host's binary path / interval / vault-backup mode can't drift.

### Cron lines (default `daily`)
```
*/30 * * * * kenthompson /usr/bin/flock -n /run/lock/switchroom-config-sync.lock /usr/local/bin/switchroom config-repo sync >> /var/log/switchroom-config-sync.log 2>&1
17 3 * * * kenthompson /usr/bin/flock -n /run/lock/switchroom-config-sync.lock /bin/sh -c '/usr/local/bin/switchroom vault backup && /usr/local/bin/switchroom config-repo sync' >> /var/log/switchroom-config-sync.log 2>&1
```

### Tests (outcome-asserting)
- Exact cron argv for both legs and all three `include_vault_backup` modes; shared-lock invariant; daily-leg off-grid; custom interval.
- Idempotent install; drift-rewrite; no stale `.tmp`; clean removable uninstall (removed → absent).
- `reconcileCron`: absent no-op (never arms), drift-repair with user preserved, idempotent, defaults to real `CRON_PATH`.
- Doctor classifier: all six states + interval-scaled staleness window.
- `update` step order includes the new reconcile step (both plans) + its drift-repair / absent-no-op / hostd-defer behavior.

**Red-without-fix:** removing the daily-leg render line turns the "adds a DAILY leg" and "ONE shared lock for both legs" tests red (2 failed), green again once restored.

`npx tsc --noEmit` clean; full `npm run lint` clean; scoped vitest 114 passing across the three touched suites.

Do **not** enqueue — the operator drives the merge queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)