### PR TITLE
perf(hooks): scope sentinel-reply-guard to reply tools only

### DIFF
--- a/telegram-plugin/hooks/hooks.json
+++ b/telegram-plugin/hooks/hooks.json
@@ -11,6 +11,7 @@
         ]
       },
       {
+        "matcher": "^mcp__switchroom-telegram__(reply|stream_reply)$",
         "hooks": [
           {
             "type": "command",

--- a/tests/telegram-plugin-manifest.test.ts
+++ b/tests/telegram-plugin-manifest.test.ts
@@ -90,6 +90,43 @@ describe("telegram-plugin manifest (#229)", () => {
     expect(all).toContain("dispatch-claim-stop.mjs");
   });
 
+  it("sentinel-reply-guard is scoped to the reply tools only", () => {
+    // The guard no-ops for every non-reply tool (its REPLY_TOOLS set is
+    // {reply, stream_reply}), so firing it — and cold-starting node — on
+    // every Read/Bash/Edit is pure waste. Scope the matcher to the two
+    // reply tools it actually guards. Behaviour is identical; we just stop
+    // spawning node for tool calls it would immediately no-op on.
+    const path = join(REPO_ROOT, "telegram-plugin", "hooks", "hooks.json");
+    const m = JSON.parse(readFileSync(path, "utf-8")) as {
+      hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string }> }>>;
+    };
+    const entry = (m.hooks.PreToolUse ?? []).find((g) =>
+      g.hooks.some((h) => h.command.includes("sentinel-reply-guard-pretool.mjs")),
+    );
+    expect(entry).toBeDefined();
+    expect(entry!.matcher).toBe("^mcp__switchroom-telegram__(reply|stream_reply)$");
+
+    // The matcher MUST match exactly the tool names the hook acts on (its
+    // REPLY_TOOLS set) and nothing else — otherwise scoping it would change
+    // behaviour by skipping a guarded tool or needlessly firing on others.
+    const re = new RegExp(entry!.matcher!);
+    for (const guarded of [
+      "mcp__switchroom-telegram__reply",
+      "mcp__switchroom-telegram__stream_reply",
+    ]) {
+      expect(re.test(guarded)).toBe(true);
+    }
+    for (const other of [
+      "Read",
+      "Bash",
+      "Edit",
+      "mcp__switchroom-telegram__edit_message",
+      "mcp__switchroom-telegram__reply_extra",
+    ]) {
+      expect(re.test(other)).toBe(false);
+    }
+  });
+
   it("subagent-tracker hooks gate on Agent or Task (regex matcher)", () => {
     // Pre-#262: matcher was the literal "Agent". Post-fix: regex
     // covering both `Agent` and `Task` for Claude Code version


### PR DESCRIPTION
## Summary

The `sentinel-reply-guard` PreToolUse hook was registered in `telegram-plugin/hooks/hooks.json` with **no matcher**, so it fired on *every* tool call (Read, Bash, Edit, Grep, ...). Each fire cold-starts a node process through `run-hook.sh` only to immediately no-op: the hook's own `REPLY_TOOLS` set is exactly `{mcp__switchroom-telegram__reply, mcp__switchroom-telegram__stream_reply}`, and for any other tool name it hits `if (!REPLY_TOOLS.has(toolName)) process.exit(0)` on the first branch without reading the payload.

This scopes the hook's matcher to those two reply tools.

## Why

Hooks run in parallel in Claude Code, and ~half of each ~40ms hook is node interpreter boot. The sentinel guard was adding a needless node spawn to the hot path of nearly every tool call, purely to no-op. Scoping the matcher removes that spawn for all non-reply tools. **Zero behaviour change** — the hook already no-ops on everything except the two reply tools.

## Test plan

- `tests/telegram-plugin-manifest.test.ts` gains a test pinning the matcher to `^mcp__switchroom-telegram__(reply|stream_reply)$` AND asserting the compiled regex matches exactly the two guarded reply tool names while excluding `Read`/`Bash`/`Edit`/`edit_message`/`reply_extra` — so the matcher can't silently drift out of alignment with the hook's `REPLY_TOOLS`.
- Scoped `vitest run tests/telegram-plugin-manifest.test.ts telegram-plugin/tests/sentinel-reply-guard-pretool.test.ts` → 20/20 green.
- `hooks.json` re-validated as JSON; `check-plugin-references` clean.

## Risk

Low — config-only, single-line matcher addition + a test. The guard's block/allow decisions on reply/stream_reply payloads are unchanged (existing sentinel-reply-guard end-to-end tests still pass). Job spec: on-leash / always-available — reduces per-tool-call latency without altering the silent-sentinel (#2053) guard's behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)