### PR TITLE
feat(telegram): retire the pin_message MCP tool from the agent surface

### DIFF
--- a/docs/operators/stale-pin-cleanup.md
+++ b/docs/operators/stale-pin-cleanup.md
@@ -1,7 +1,8 @@
 # Clearing orphaned bot pins
 
 The gateway pins things: the foreground activity card, worker feeds, the slot
-banner, `pin_message` tool pins. A crash mid-turn can leave one of those pinned
+banner (plus legacy `pin_message` tool pins from builds before that tool was
+retired in #4452). A crash mid-turn can leave one of those pinned
 forever — an **orphan**. The boot sweep
 (`telegram-plugin/gateway/stale-pin-sweep.ts`) exists to drain them, and on a
 current build it does so automatically. This page is for the residue it

--- a/docs/telegram-plugin.md
+++ b/docs/telegram-plugin.md
@@ -17,7 +17,6 @@ The official Telegram plugin provides basic message send/receive. Switchroom's f
 | `edit_message` | Update a previously sent message. |
 | `delete_message` | Remove a bot-sent message (48h Telegram limit). |
 | `forward_message` | Quote/resurface earlier messages with thread support. |
-| `pin_message` | Pin important outputs in the chat (requires bot admin). |
 | `send_typing` | Show typing indicator during long operations (5s auto-expire). |
 | `download_attachment` | Fetch files attached to inbound messages. |
 | `get_recent_messages` | Query the local SQLite history buffer with pagination and thread filtering. |

--- a/reference/jobs/know-what-my-agent-is-doing.md
+++ b/reference/jobs/know-what-my-agent-is-doing.md
@@ -78,12 +78,14 @@ close that gap so the user never has to ask.
   a generous TTL is unpinned without waiting for a restart. A stale pin glued
   to the top of the chat for hours is exactly the "can't tell working from
   stuck" failure this job exists to prevent.
-- **Tool pins are different: no "finished" event, so restart ≠ reset.** A pin
-  the agent placed deliberately via the `pin_message` tool is registered in
-  the same durable store under a `tool:` key with a generous TTL (default 7
-  days). It survives restarts untouched until the TTL lapses, then the boot
-  sweep unpins it — the backstop against deliberate pins accumulating
-  forever, without ever yanking a pin the user still wants.
+- **Agents can no longer hand-pin.** The `pin_message` MCP tool was retired
+  (#4452): the ONE sanctioned pin is the framework's own auto-pin of the
+  status/activity card and the 🛠 Worker card, which the boot sweep reaps as a
+  work-scoped claim on restart. A message the USER deliberately pinned is never
+  recorded in the durable store, so the sweep — which only ever unpins the
+  message ids it recorded — leaves it untouched. Legacy `tool:` rows written by
+  an older build before the tool's removal still carry their TTL and drain on
+  expiry, so no already-placed pin is stranded.
 
 **Bad looks like: never ship this**
 

--- a/skills/switchroom-architecture/telegram.md
+++ b/skills/switchroom-architecture/telegram.md
@@ -11,7 +11,6 @@ Switchroom ships an enhanced `switchroom-telegram` MCP plugin that replaces the 
 | `edit_message` | Update a previously sent message. Edits are silent (no push notification). |
 | `delete_message` | Remove a bot-sent message (48h Telegram API limit). |
 | `forward_message` | Quote/resurface earlier messages with thread support. |
-| `pin_message` | Pin important outputs (requires bot admin). |
 | `send_typing` | Show typing indicator (5s auto-expire). Use during long operations. |
 | `download_attachment` | Fetch files attached to inbound messages. |
 | `get_recent_messages` | Query SQLite history buffer with pagination and thread filtering. |

--- a/skills/switchroom-cli/SKILL.md
+++ b/skills/switchroom-cli/SKILL.md
@@ -299,7 +299,6 @@ The `switchroom-telegram` plugin is an enhanced fork of the official Telegram MC
 | `edit_message` | Modify an earlier bot message's text |
 | `delete_message` | Remove an earlier bot message |
 | `forward_message` | Forward a message from another chat |
-| `pin_message` | Pin a message in the current chat |
 | `send_typing` | Show the "typing…" indicator |
 | `download_attachment` | Save a Telegram file attachment to the agent's inbox |
 | `get_recent_messages` | Fetch recent history for context |

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1183,7 +1183,6 @@ const SWITCHROOM_TELEGRAM_MCP_TOOLS = [
   "mcp__switchroom-telegram__react",
   "mcp__switchroom-telegram__edit_message",
   "mcp__switchroom-telegram__send_typing",
-  "mcp__switchroom-telegram__pin_message",
   "mcp__switchroom-telegram__delete_message",
   "mcp__switchroom-telegram__forward_message",
   "mcp__switchroom-telegram__download_attachment",

--- a/telegram-plugin/README.md
+++ b/telegram-plugin/README.md
@@ -38,8 +38,8 @@ adds the ergonomics and reliability that an always-on agent fleet needs:
 - **Switchroom slash-commands** — `/agents`, `/restart`, `/logs`, `/memory`,
   `/grant`, `/dangerous`, `/permissions`, `/reconcile` etc., handled by the
   plugin without consuming Claude Code tokens.
-- **11 MCP tools** — `reply`, `react`, `edit_message`,
-  `delete_message`, `forward_message`, `pin_message`, `send_typing`,
+- **10 MCP tools** — `reply`, `react`, `edit_message`,
+  `delete_message`, `forward_message`, `send_typing`,
   `download_attachment`, `get_recent_messages`, `send_checklist`,
   `update_checklist` (the latter two ship native Telegram checklists,
   see #272).
@@ -227,15 +227,6 @@ Sends a typing indicator ("Bot is typing...") to a chat. Auto-expires after ~5 s
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `chat_id` | yes | Target chat ID |
-
-### `pin_message` tool
-
-Pins a message in a chat. Requires admin rights in groups.
-
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `chat_id` | yes | Chat ID |
-| `message_id` | yes | Message to pin |
 
 ### `forward_message` tool
 

--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -214,18 +214,6 @@ const TOOL_SCHEMAS = [
     },
   },
   {
-    name: 'pin_message',
-    description: 'Pin a message in a Telegram chat. Useful for important outputs the user wants to find later. Requires admin rights in groups.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        chat_id: { type: 'string' },
-        message_id: { type: 'string' },
-      },
-      required: ['chat_id', 'message_id'],
-    },
-  },
-  {
     name: 'delete_message',
     description: 'Delete a message the bot previously sent. Prefer edit_message if you just want to update text — delete_message is for true removal.',
     inputSchema: {

--- a/telegram-plugin/chat-lock.ts
+++ b/telegram-plugin/chat-lock.ts
@@ -2,7 +2,7 @@
  * Per-(chat, thread) FIFO serialization for outbound Telegram API calls.
  *
  * Without this, concurrent MCP tool handlers (reply, stream_reply, react,
- * edit_message, delete_message, pin_message, forward_message) all call
+ * edit_message, delete_message, forward_message) all call
  * `bot.api.*` independently. When two calls race, HTTP latency can flip
  * their delivery order — a later `reply` can land before an earlier
  * `stream_reply` edit, or a `react` can resolve before the `reply` it

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8370,8 +8370,7 @@ const statusPinClaims = new Map<string, StatusPinClaim>()
 // Rights-aware negative cache (#3024): chats where an auto status-pin attempt
 // failed with the permanent "not enough rights to manage pinned messages" 400.
 // Per-process only — a restart clears it so a later-granted pin right re-enables
-// auto-pin. The explicit `pin_message` MCP tool deliberately does NOT consult
-// this cache (it always attempts and surfaces the error to the agent).
+// auto-pin.
 const statusPinRightsCache = new PinRightsCache()
 
 // Durable snapshot of the pin claim set on the persistent per-agent volume
@@ -8466,21 +8465,16 @@ const BANNER_PIN_KEY = 'banner:owner'
 // run → no-op). The boot-cleanup gate below is widened to cover this.
 const bannerPinPersistEnabled = !STATIC
 
-// `pin_message` MCP-tool pin registration (#3001). Tool pins ride the same
-// shared status-pins.json store under `tool:<chatId>:<messageId>` keys, but
-// with a TTL row (`expiresAt`): a tool pin is a deliberate agent action with
-// no "work finished" event, so a restart does NOT reset it — boot cleanup
-// keeps unexpired tool rows and only unpins them once the TTL lapses (the
-// backstop against agent-pinned messages accumulating forever). Independent
-// of PIN_STATUS_WHILE_WORKING (it gates the auto status pin, not the tool).
+// LEGACY `tool:` pin drain (#3001; the `pin_message` MCP tool was retired in
+// #4452). No new `tool:<chatId>:<messageId>` rows are ever written now that the
+// tool is gone, but rows an earlier build persisted may still sit in the shared
+// status-pins.json with a TTL (`expiresAt`). This flag keeps the boot cleanup /
+// stale-pin sweep aware of those legacy rows so they are still expired and
+// drained correctly on upgrade — an unexpired legacy row is preserved across
+// boots (never reaped as if it were a work-scoped card), then unpinned once its
+// TTL lapses, exactly as before. Independent of PIN_STATUS_WHILE_WORKING.
+// Self-clears within one TTL window since nothing writes new tool rows.
 const toolPinPersistEnabled = !STATIC
-// 7 days: generous — an agent-pinned message the operator still cares about
-// after a week has usually been re-pinned or acted on; anything older is the
-// stale-pin long tail this issue exists to clear. Override for tuning.
-const TOOL_PIN_TTL_MS = (() => {
-  const v = Number(process.env.SWITCHROOM_TOOL_PIN_TTL_MS)
-  return Number.isFinite(v) && v > 0 ? v : 7 * 24 * 60 * 60_000
-})()
 
 // Persist (or drop) the slot-banner's pin row into the shared store. Routes
 // through mutateStatusPinRow: a read-modify-write for ONLY the banner:owner key,
@@ -8950,8 +8944,7 @@ async function reconcileStatusPin(
   // "not enough rights to manage pinned messages" 400 in a supergroup took the
   // whole gateway down (marko, 2026-07-01). Auto status-pin is cosmetic; it
   // must NEVER be able to crash the gateway. Any throw here is logged and
-  // absorbed. (The `pin_message` MCP tool still surfaces failures to the agent
-  // as a normal tool-error — that path is `executePinMessage`, not this one.)
+  // absorbed.
   try {
     // Serialize per pinKey (F2): reconcileStatusPinInner reads `prev` from the
     // in-memory claim map at its top, so overlapping same-key reconciles must
@@ -11808,7 +11801,7 @@ if (isGatewayMain && !STATIC) {
  *  bridge from calling arbitrary functions by name. */
 const ALLOWED_TOOLS = new Set([
   'reply', 'progress_update', 'react', 'download_attachment',
-  'edit_message', 'send_typing', 'pin_message', 'delete_message',
+  'edit_message', 'send_typing', 'delete_message',
   'forward_message', 'get_recent_messages',
   'send_checklist', 'update_checklist',
   'ask_user',
@@ -11844,8 +11837,6 @@ async function executeToolCall(
       return executeEditMessage(args)
     case 'send_typing':
       return executeSendTyping(args)
-    case 'pin_message':
-      return executePinMessage(args)
     case 'delete_message':
       return executeDeleteMessage(args)
     case 'forward_message':
@@ -13193,44 +13184,6 @@ async function executeSendTyping(args: Record<string, unknown>): Promise<unknown
     if (key.startsWith(`${stChatId}:`)) ctrl.setTool()
   }
   return { content: [{ type: 'text', text: `${action} indicator sent (auto-refreshes every 4s, stops after 30s or next reply)` }] }
-}
-
-async function executePinMessage(args: Record<string, unknown>): Promise<unknown> {
-  if (!args.chat_id) throw new Error('pin_message: chat_id is required')
-  if (!args.message_id) throw new Error('pin_message: message_id is required')
-  const pinChatId = String(args.chat_id ?? '')
-  assertAllowedChat(pinChatId)
-  // #1075: wrap through robustApiCall so flood-wait / transient network
-  // errors are retried. THREAD_NOT_FOUND on a stale topic surfaces to the
-  // agent as a tool-error — pinning a vanished message is genuinely a
-  // failure the agent should see.
-  const pinMsgId = Number(args.message_id)
-  await robustApiCall(
-    () => lockedBot.api.pinChatMessage(pinChatId, pinMsgId), // allow-raw-pin: MCP `pin_message` tool — an explicit, agent-requested pin of an arbitrary message, not a progress surface with a claim.
-    { chat_id: pinChatId, verb: 'pin_message' },
-  )
-  // An explicit pin succeeded here, so the bot demonstrably HAS pin rights in
-  // this chat now — clear any auto-pin negative-cache entry (#3024) so the auto
-  // status-pin path resumes immediately rather than waiting for a restart. The
-  // explicit tool itself never consults the cache; a failure above still
-  // surfaces to the agent as a normal tool error (robustApiCall rethrows).
-  statusPinRightsCache.clear(pinChatId)
-  // #3001: register the tool pin in the shared status-pin store under a
-  // `tool:` key so it is no longer fire-and-forget. Unlike work-scoped
-  // fg:/wk: rows a tool pin has no "work finished" event, so a restart does
-  // NOT reset it — boot cleanup keeps the row until its TTL, then unpins the
-  // (likely long-forgotten) message. Best-effort fire-and-forget: a store
-  // failure must never fail the tool call the pin already landed for.
-  if (toolPinPersistEnabled) {
-    const toolPinKey = `tool:${pinChatId}:${pinMsgId}`
-    void mutateStatusPinRow(STATUS_PIN_STORE_PATH, statusPinStoreFs, toolPinKey, { // allow-raw-pin-store: records the TTL-scoped `tool:` row for the explicit pin above so the boot sweep can expire it.
-      pinKey: toolPinKey,
-      chatId: pinChatId,
-      messageId: pinMsgId,
-      expiresAt: Date.now() + TOOL_PIN_TTL_MS,
-    })
-  }
-  return { content: [{ type: 'text', text: `pinned message ${args.message_id}` }] }
 }
 
 async function executeDeleteMessage(args: Record<string, unknown>): Promise<unknown> {

--- a/telegram-plugin/gateway/stale-pin-sweep.ts
+++ b/telegram-plugin/gateway/stale-pin-sweep.ts
@@ -352,9 +352,10 @@ export function collectSweepTargets(input: {
 
 /**
  * The messageIds in `chatId` that must SURVIVE a drain because they belong to
- * deliberately-retained store rows: unexpired time-scoped `tool:` pins (the
- * `pin_message` MCP tool, #3001), which `runStatusPinBootCleanup` intentionally
- * KEEPS across restarts. Work-scoped rows (no `expiresAt`) are stale by
+ * deliberately-retained store rows: unexpired time-scoped `tool:` pins (legacy
+ * rows from the retired `pin_message` MCP tool, #3001 / #4452 — no new ones are
+ * written), which `runStatusPinBootCleanup` intentionally KEEPS across restarts
+ * until they expire. Work-scoped rows (no `expiresAt`) are stale by
  * definition after a restart and are NOT re-pin candidates; expired
  * time-scoped rows are due for sweeping.
  */

--- a/telegram-plugin/gateway/status-pin-store.ts
+++ b/telegram-plugin/gateway/status-pin-store.ts
@@ -17,7 +17,8 @@
  * — the turn it represented is over or crashed), dropping rows only after a
  * successful unpin (failed ones are retained with an attempt counter for a
  * next-boot retry — see runStatusPinBootCleanup). Time-scoped `tool:` rows
- * (the `pin_message` MCP tool, #3001) survive boots until their `expiresAt`.
+ * (legacy pins from the retired `pin_message` MCP tool, #3001 / #4452 — no new
+ * ones are written) survive boots until their `expiresAt`.
  * It does NOT re-adopt or re-pin — it only cleans up.
  *
  * Shape choice — SNAPSHOT, not append-log, mirroring obligation-store.ts. The
@@ -78,10 +79,10 @@ export interface PersistedStatusPin {
   /** Wall-clock ms after which this pin is stale and boot cleanup unpins it.
    *  Rows WITHOUT this field are work-scoped (fg:/wk:/banner:) — stale the
    *  moment their owning session dies, so boot cleanup unpins them
-   *  unconditionally. Rows WITH it (the `tool:` pins written by the
-   *  `pin_message` MCP tool, #3001) represent deliberate agent pins that have
-   *  no "work finished" event: they SURVIVE restarts and are only swept once
-   *  expired. */
+   *  unconditionally. Rows WITH it (legacy `tool:` pins from the retired
+   *  `pin_message` MCP tool, #3001 / #4452 — no new ones are written)
+   *  represented deliberate agent pins with no "work finished" event: they
+   *  SURVIVE restarts and are only swept once expired. */
   expiresAt?: number
   /** Boot-cleanup unpin retry counter (#3001). Incremented each boot the
    *  unpin fails (flood-wait exhausted / transient 5xx); the row is retained
@@ -282,10 +283,10 @@ export function pinnedMessageIsOurs(
  * record whose pin MAY have landed in Telegram, so we must treat it exactly
  * like a confirmed one and unpin it.
  *
- * TIME-SCOPED rows (`tool:` pins from the `pin_message` MCP tool, carrying
- * `expiresAt`) have no "work finished" event, so a restart does NOT reset
- * them: an unexpired row is RETAINED untouched across boots and only unpinned
- * once `now >= expiresAt`.
+ * TIME-SCOPED rows (legacy `tool:` pins from the retired `pin_message` MCP
+ * tool, #4452, carrying `expiresAt`) have no "work finished" event, so a
+ * restart does NOT reset them: an unexpired row is RETAINED untouched across
+ * boots and only unpinned once `now >= expiresAt`.
  *
  * RETRY-SAFETY (#3001): a row is dropped only AFTER its unpin resolves. A
  * failing unpin (flood-wait exhausted / transient 5xx) retains the row with an

--- a/telegram-plugin/hooks/narration-classify.mjs
+++ b/telegram-plugin/hooks/narration-classify.mjs
@@ -108,7 +108,7 @@ export function isStructuralNarration(text, followedByToolUse) {
  * follow-up, MF4). A text block followed ONLY by tools in this set is still the
  * TERMINAL answer for backstop-coalescing purposes — these tools carry no
  * model-authored answer text and are the only ones plausibly fired AFTER a
- * terminal answer (answer, then react / pin / typing / edit). Everything NOT in
+ * terminal answer (answer, then react / typing / edit). Everything NOT in
  * this set — work / deliverable tools (download_attachment, get_recent_messages,
  * send_checklist, ask_user, …) and every non-telegram tool (retain / read /
  * bash / web / …) — is turn-CONTINUING: a text block a real tool followed is
@@ -123,7 +123,6 @@ export function isStructuralNarration(text, followedByToolUse) {
 export const EPHEMERAL_TOOLS = new Set([
   'react',
   'send_typing',
-  'pin_message',
   'delete_message',
   'edit_message',
 ])

--- a/telegram-plugin/hooks/silent-end-scan.mjs
+++ b/telegram-plugin/hooks/silent-end-scan.mjs
@@ -41,7 +41,7 @@
 // Cross-checked the full tool surface in `telegram-plugin/bridge/bridge.ts`
 // (`TOOL_SCHEMAS`, kept in sync with `gateway/gateway.ts`): `edit_message`
 // explicitly does NOT ping/deliver a fresh answer (its own description says
-// "send a new reply when a long task completes"); `react`, `pin_message`,
+// "send a new reply when a long task completes"); `react`,
 // `delete_message`, `forward_message`, `send_typing`, `download_attachment`,
 // `get_recent_messages` carry no model-authored answer text at all;
 // `send_checklist` / `send_sticker` / `send_gif` / `ask_user` /

--- a/telegram-plugin/status-pin.ts
+++ b/telegram-plugin/status-pin.ts
@@ -210,12 +210,9 @@ export function isUnpinTerminalError(err: unknown): boolean {
  * Deliberately IN-MEMORY / per-boot only: pin rights may be granted later, and
  * Telegram surfaces the new permission to the bot only on a fresh chat-member
  * fetch — a gateway restart. Clearing the cache on restart is therefore the
- * correct re-enable trigger. An explicit `pin_message` tool success in a chat
- * also clears its entry (rights were granted mid-session).
+ * correct re-enable trigger.
  *
- * Scope: the AUTO status-pin path only. The explicit `pin_message` MCP tool
- * never consults this cache — it always attempts and surfaces the error to the
- * agent as a normal tool error.
+ * Scope: the AUTO status-pin path only (`pin_status_while_working`).
  */
 export class PinRightsCache {
   private readonly blocked = new Set<string>()

--- a/telegram-plugin/tests/backstop-exactly-once.test.ts
+++ b/telegram-plugin/tests/backstop-exactly-once.test.ts
@@ -121,15 +121,21 @@ describe('selectBackstopDelivery — deterministic backstop coalescer (#3513 fol
 // ── isEphemeralTool — MF4 exact set ─────────────────────────────────────────
 
 describe('isEphemeralTool — the exact ephemeral surface set (MF4)', () => {
-  it('recognises exactly {react, send_typing, pin_message, delete_message, edit_message}, MCP-prefixed or bare', () => {
+  it('recognises exactly {react, send_typing, delete_message, edit_message}, MCP-prefixed or bare', () => {
     expect([...EPHEMERAL_TOOLS].sort()).toEqual(
-      ['delete_message', 'edit_message', 'pin_message', 'react', 'send_typing'].sort(),
+      ['delete_message', 'edit_message', 'react', 'send_typing'].sort(),
     )
     for (const t of EPHEMERAL_TOOLS) {
       expect(isEphemeralTool(t)).toBe(true)
       expect(isEphemeralTool(`mcp__switchroom-telegram__${t}`)).toBe(true)
       expect(isEphemeralTool(`mcp__clerk-telegram__${t}`)).toBe(true)
     }
+  })
+
+  it('pin_message is NOT ephemeral — the pin_message MCP tool was retired (#4452)', () => {
+    expect(EPHEMERAL_TOOLS.has('pin_message')).toBe(false)
+    expect(isEphemeralTool('pin_message')).toBe(false)
+    expect(isEphemeralTool('mcp__switchroom-telegram__pin_message')).toBe(false)
   })
 
   it('progress_update is NOT ephemeral (MF4 — dropped from the set)', () => {

--- a/telegram-plugin/tests/pin-message-tool-retired.test.ts
+++ b/telegram-plugin/tests/pin-message-tool-retired.test.ts
@@ -1,0 +1,64 @@
+/**
+ * pin_message tool retirement (#4452).
+ *
+ * The agent-facing `pin_message` MCP tool was removed: agents may no longer
+ * hand-pin arbitrary messages. The framework's OWN auto-pin
+ * (`pin_status_while_working` — the status/activity card and the 🛠 Worker
+ * card) is unaffected; that is the one sanctioned pin and is exercised by
+ * status-pin-lifecycle.test.ts.
+ *
+ * These are OUTCOME assertions on the actual offered surface — they fail if the
+ * tool is ever re-registered in the bridge schema, re-wired into the gateway
+ * dispatch, or re-granted in the agent scaffold. bridge.ts and gateway.ts each
+ * run boot side-effects at import (a top-level `await main()` / the gateway boot
+ * IIFE), so they cannot be imported here; we assert against their source, which
+ * IS the registration surface.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const here = fileURLToPath(new URL('.', import.meta.url))
+const read = (rel: string) => readFileSync(new URL(rel, import.meta.url), 'utf8')
+
+describe('pin_message MCP tool is retired (#4452)', () => {
+  it('is NOT registered as a bridge tool schema', () => {
+    const bridge = read('../bridge/bridge.ts')
+    // The tool-schema registration form is `name: 'pin_message'`. Its absence
+    // means ListTools no longer offers it to the agent.
+    expect(bridge).not.toMatch(/name:\s*['"]pin_message['"]/)
+  })
+
+  it('is NOT in the gateway IPC tool allowlist and has no dispatch case', () => {
+    const gateway = read('../gateway/gateway.ts')
+    // ALLOWED_TOOLS gate: a bridge could not invoke it even by name.
+    expect(gateway).not.toMatch(/['"]pin_message['"]/)
+    // No dispatch arm and no handler.
+    expect(gateway).not.toMatch(/case\s+['"]pin_message['"]/)
+    expect(gateway).not.toContain('executePinMessage')
+  })
+
+  it('is NOT granted in the agent scaffold permission surface', () => {
+    const scaffold = read('../../src/agents/scaffold.ts')
+    expect(scaffold).not.toContain('mcp__switchroom-telegram__pin_message')
+  })
+
+  // Sanity: prove the assertions above are meaningful by confirming a tool that
+  // SURVIVED is still present in each surface (a test that can't fail is not a
+  // test — this pins the read paths to real content).
+  it('a surviving tool (delete_message) is still registered — guards false-green', () => {
+    expect(read('../bridge/bridge.ts')).toMatch(/name:\s*['"]delete_message['"]/)
+    expect(read('../gateway/gateway.ts')).toContain('executeDeleteMessage')
+    expect(read('../../src/agents/scaffold.ts')).toContain(
+      'mcp__switchroom-telegram__delete_message',
+    )
+  })
+
+  it('the framework auto status-pin machinery is untouched', () => {
+    // Change 1 must not disturb pin_status_while_working (the ONE sanctioned pin).
+    const gateway = read('../gateway/gateway.ts')
+    expect(gateway).toContain('PIN_STATUS_WHILE_WORKING')
+    expect(gateway).toContain('runStatusPinBootCleanup')
+    void here
+  })
+})

--- a/telegram-plugin/tests/status-pin-boot-recovery.test.ts
+++ b/telegram-plugin/tests/status-pin-boot-recovery.test.ts
@@ -259,6 +259,44 @@ describe("status-pin boot recovery (gateway wiring)", () => {
     expect(idOnly(loadStatusPins(PATH, fs))).toEqual([]);
   });
 
+  it("(SAFETY) boot cleanup NEVER unpins a message the framework did not record (a user's manual pin survives)", async () => {
+    // The hard safety constraint of the boot reap: it reaps ONLY the framework's
+    // own pins (the status/activity card, the 🛠 Worker card — the rows this
+    // process itself wrote to status-pins.json). A message the USER deliberately
+    // pinned is never recorded there, so the reap must leave it completely
+    // untouched. A boot that nuked a user's real pin is a regression worse than a
+    // stranded orphan. This test makes that structural guarantee an assertion:
+    // the store never sees the user's id, so the reap can never target it.
+    const { fs } = memFs();
+    const tg = fakeTelegram();
+
+    // Session 1: the framework pins its OWN work-scoped status card (recorded).
+    const gw1 = makeGateway(fs, tg);
+    await gw1.reconcileStatusPin("fg:c:3", "-100123", { pinned: true, messageId: 715 });
+
+    // A user manually pins their own message in the SAME chat. It lives in the
+    // Telegram pin stack but is NOT in status-pins.json — the framework has no
+    // record of it and no business touching it.
+    tg.pinned.add("-100123:999");
+
+    // The framework's pin is the ONLY recorded row; the user's is not present.
+    expect(idOnly(loadStatusPins(PATH, fs))).toEqual([
+      { pinKey: "fg:c:3", chatId: "-100123", messageId: 715 },
+    ]);
+    expect(loadStatusPins(PATH, fs).some((r) => r.messageId === 999)).toBe(false);
+
+    // ── CRASH, then a fresh boot runs the reap. ──
+    const gw2 = makeGateway(fs, tg);
+    const res = await gw2.bootCleanup();
+
+    // Exactly the framework's OWN pin was cleared …
+    expect(res).toEqual({ cleared: 1, retained: 0, kept: 0, total: 1 });
+    expect(tg.pinned.has("-100123:715")).toBe(false);
+    // … and the user's manual pin is untouched — never unpinned.
+    expect(tg.pinned.has("-100123:999")).toBe(true);
+    expect(idOnly(loadStatusPins(PATH, fs))).toEqual([]);
+  });
+
   it("clean shutdown (sweep DID run) leaves nothing for boot cleanup to do", async () => {
     // Contrast: when the SIGTERM sweep runs (unpin each key), the store is
     // emptied and the pin removed — boot cleanup is a no-op. This guards the

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1293,7 +1293,6 @@ describe("scaffoldAgent", () => {
       "mcp__switchroom-telegram__react",
       "mcp__switchroom-telegram__edit_message",
       "mcp__switchroom-telegram__send_typing",
-      "mcp__switchroom-telegram__pin_message",
       "mcp__switchroom-telegram__delete_message",
       "mcp__switchroom-telegram__forward_message",
       "mcp__switchroom-telegram__download_attachment",


### PR DESCRIPTION
## Summary

Removes the agent-facing **`pin_message` MCP tool**. Agents can no longer hand-pin arbitrary messages. Reconciled across the whole repo: bridge tool schema, gateway dispatch + handler (`executePinMessage`) + IPC allowlist, the scaffold permission grant, the `EPHEMERAL_TOOLS` classification, and every doc/comment reference.

The framework's own auto-pin — `pin_status_while_working`, which silently pins the per-turn status/activity card and the 🛠 Worker card and auto-unpins on completion — is the **one sanctioned pin** and is untouched.

## Why

Hand-pinning is being retired as an agent capability. The only pin agents should produce is the framework's own status/worker card, which the framework manages end-to-end.

## Safety constraint (the load-bearing part)

The boot-reap that unpins stale framework cards on restart **already exists** and already honours the hard constraint: it reaps ONLY framework-owned pins.

- `runStatusPinBootCleanup` (`telegram-plugin/gateway/status-pin-store.ts`) durably tracks every framework pin in `status-pins.json` keyed by `(chat, thread, messageId)`, and on boot unpins **exactly the message ids it recorded** — never a `getChat → unpin whatever is pinned`. A user's manual pin is never in that store, so it is structurally untouchable by the reap.
- Retiring the tool means every framework pin is now work-scoped and reaped on restart. Legacy `tool:` rows (carrying `expiresAt`) written by older builds still drain by TTL, so no already-placed pin is stranded. The internal `tool:` plumbing is kept (inert for new writes) precisely so those legacy rows expire cleanly rather than being reaped as if they were stale cards.

## Test plan (outcomes, not code paths)

- **`telegram-plugin/tests/pin-message-tool-retired.test.ts`** (new): `pin_message` is not in the bridge tool schema, not in the gateway IPC allowlist / dispatch, and not in the scaffold permission surface — with a surviving-tool (`delete_message`) false-green guard, and an assertion the auto-pin machinery is intact.
- **`telegram-plugin/tests/backstop-exactly-once.test.ts`**: `pin_message` dropped from `EPHEMERAL_TOOLS`.
- **`telegram-plugin/tests/status-pin-boot-recovery.test.ts`** (SAFETY case added): a boot-reap unpins the framework's own recorded pin **and leaves a user's manual pin in the same chat untouched**.
- Local: `npm run lint` clean (tsc + all 24 guards, incl. gateway line-ratchet, bot-api-wrapping, status-pin-single-path); the four touched test files pass (276 tests).

## Risk

Low. Pure removal of an agent capability plus doc/comment reconciliation; no change to the sanctioned auto-pin path or its persistence/boot-reap. Line count on `gateway.ts` decreases.

## Job spec

`reference/jobs/know-what-my-agent-is-doing.md` — updated the pin bullet to reflect that agents can no longer hand-pin and the reap only ever touches framework-recorded pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)