### PR TITLE
fix(metrics): guard turn duration_ms against epoch-as-duration corruption

### DIFF
--- a/telegram-plugin/gateway/liveness-wiring.ts
+++ b/telegram-plugin/gateway/liveness-wiring.ts
@@ -21,6 +21,7 @@ import * as silencePoke from '../silence-poke.js'
 import * as signalTracker from '../turn-signal-tracker.js'
 import * as pendingProgress from '../pending-work-progress.js'
 import { emitRuntimeMetric } from '../runtime-metrics.js'
+import { computeTurnDurationMs } from './turn-record-status.js'
 import { logStreamingEvent } from '../streaming-metrics.js'
 import { clearSilentEndState } from '../silent-end.js'
 import { purgeStaleTurnsForChat } from './turn-state-purge.js'
@@ -377,7 +378,11 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
       turnMatchesFallback && wedgedTurn != null && turnLiveForItsTopic(wedgedTurn)
     const turnStartedAt = activeTurnStartedAt.get(fbKey)
     if (turnStartedAt != null) {
-      const turnDurationMs = Date.now() - turnStartedAt
+      // Guard shared with buildTurnRecord + the stream-render turn_ended paths:
+      // a 0 / bogus start must never emit `Date.now() - 0` (an absolute epoch
+      // value) as a duration. This path previously did a bare subtraction and
+      // poisoned the turn_ended dataset when `activeTurnStartedAt` held 0.
+      const turnDurationMs = computeTurnDurationMs(turnStartedAt, Date.now())
       const outboundMetrics = signalTracker.getOutboundMetrics(fbKey)
       emitRuntimeMetric({
         kind: 'turn_ended',

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -90,7 +90,7 @@ import { formatTurnLifecycle } from './status-surface-log.js'
 import { removeTurnActiveMarker, touchTurnActiveMarker, writeTurnActiveMarker } from './turn-active-marker.js'
 import { withTurnEndGateBackstop } from './turn-end-gate-backstop.js'
 import { decideTurnEndGate } from './turn-end-gate.js'
-import { finalizeBackstopSendGated } from './turn-record-status.js'
+import { finalizeBackstopSendGated, computeTurnDurationMs } from './turn-record-status.js'
 import type { SilentEndDeps } from '../silent-end.js'
 import type { ChatKey as _ChatKey } from './inbound-delivery-machine.js'
 import type { SessionEvent } from '../session-tail.js'
@@ -2174,7 +2174,7 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
             chatId,
             threadId,
             turnId: turn.turnId,
-            turnDurationMs: turn.startedAt > 0 ? Date.now() - turn.startedAt : 0,
+            turnDurationMs: computeTurnDurationMs(turn.startedAt, Date.now()),
             reactionCount: reactionTransitionCounts.get(tKey) ?? 0,
           })
         }
@@ -2214,7 +2214,7 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
         // still appear in turn-duration graphs.
         {
           const sKey = streamKey(chatId, threadId)
-          const turnDurationMs = turn.startedAt > 0 ? Date.now() - turn.startedAt : 0
+          const turnDurationMs = computeTurnDurationMs(turn.startedAt, Date.now())
           logStreamingEvent({
             kind: 'turn_end',
             chatId,
@@ -2799,7 +2799,7 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
       finalizeStatusReaction(chatId, threadId, terminalReason)
       {
         const sKey = streamKey(chatId, threadId)
-        const turnDurationMs = turn.startedAt > 0 ? Date.now() - turn.startedAt : 0
+        const turnDurationMs = computeTurnDurationMs(turn.startedAt, Date.now())
         logStreamingEvent({
           kind: 'turn_end',
           chatId,

--- a/telegram-plugin/gateway/turn-record-status.ts
+++ b/telegram-plugin/gateway/turn-record-status.ts
@@ -24,6 +24,37 @@
  */
 export type DeliveryOutcome = 'delivered' | 'failed' | 'suppressed'
 
+/**
+ * The ONE way a turn's `duration_ms` is computed, shared by every emitter
+ * (`buildTurnRecord` → turns.jsonl, and all three `turn_ended` runtime-metric
+ * sites: the two stream-render turn-end paths + the liveness framework_fallback).
+ *
+ * Why a single helper: the three `turn_ended` emitters each hand-rolled the
+ * subtraction, and one drifted. `stream-render.ts` guarded with
+ * `startedAt > 0 ? now - startedAt : 0`; the framework_fallback path in
+ * `liveness-wiring.ts` did a bare `Date.now() - turnStartedAt` with only a
+ * `!= null` presence check. When `activeTurnStartedAt` held `0` (or any
+ * non-positive / non-finite value), that path emitted `duration_ms = now - 0`,
+ * i.e. the absolute Unix-epoch-ms — a ~56,000-year "duration". This poisoned the
+ * analysed turn_ended dataset (observed: 110 rows where `duration_ms === ts`),
+ * making every latency aggregate unusable.
+ *
+ * The invariant this helper enforces: a `duration_ms` is ALWAYS a non-negative
+ * elapsed-milliseconds value derived from a positive, finite start stamp — never
+ * an absolute epoch value, never negative (clock step back), never NaN. A start
+ * that is missing / zero / bogus yields `0` (a bounded, filterable sentinel)
+ * instead of a value that destroys aggregates.
+ */
+export function computeTurnDurationMs(
+  startedAt: number | null | undefined,
+  now: number,
+): number {
+  if (typeof startedAt !== 'number' || !Number.isFinite(startedAt) || startedAt <= 0) {
+    return 0
+  }
+  return Math.max(0, now - startedAt)
+}
+
 /** The status strings written to turns.jsonl. `send_failed` is new in PR B. */
 export type TurnStatus = 'complete' | 'no_reply' | 'send_failed'
 
@@ -261,7 +292,7 @@ export function buildTurnRecord(
   return {
     ts: Math.floor(endedAt / 1000),
     agent: turn.agent,
-    duration_ms: turn.startedAt > 0 ? endedAt - turn.startedAt : 0,
+    duration_ms: computeTurnDurationMs(turn.startedAt, endedAt),
     tools: turn.toolCallCount ?? 0,
     status: computeTurnStatus(turn),
     turn_id: turn.turnId,

--- a/telegram-plugin/tests/framework-fallback-duration-guard.test.ts
+++ b/telegram-plugin/tests/framework-fallback-duration-guard.test.ts
@@ -1,0 +1,125 @@
+/**
+ * M0 metric-corruption regression — the framework_fallback `turn_ended` emitter
+ * must never write an absolute Unix-epoch value as `duration_ms`.
+ *
+ * ROOT CAUSE (fixed by this change): the 300 s framework-fallback unwedge in
+ * `liveness-wiring.ts` read the turn's start from `activeTurnStartedAt.get(key)`
+ * and, guarded only by a `!= null` presence check, computed
+ * `Date.now() - turnStartedAt` inline. When the map held `0` (a bogus / not-yet
+ * stamped start — reproduced here exactly as the parked-turn fixture does with
+ * `activeTurnStartedAt.set(KEY, 0)`), it emitted `duration_ms = Date.now() - 0`,
+ * i.e. the current epoch-ms — a ~56,000-year "duration". The analysed dataset
+ * carried 110 such rows (`duration_ms === ts`, `ended_via: "framework_fallback"`),
+ * making every latency aggregate unusable.
+ *
+ * The two `stream-render.ts` turn_ended paths already guarded with
+ * `startedAt > 0 ? … : 0`; this path had drifted. The fix routes all emitters
+ * through the shared `computeTurnDurationMs`, which returns 0 for a non-positive
+ * start.
+ *
+ * This test drives the REAL `onFrameworkFallback` (via `buildSilencePokeOptions`,
+ * same standard as the other liveness-wiring tests) with a 0 start and asserts on
+ * the ACTUAL emitted `turn_ended` row (captured through the real runtime-metrics
+ * JSONL sink, pinned to a temp file). It asserts the OUTCOME — the emitted
+ * `duration_ms` — not a code path.
+ *
+ * Pre-fix: `duration_ms` ≈ `Date.now()` (~1.78e12). Post-fix: `duration_ms === 0`.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { buildSilencePokeOptions } from '../gateway/liveness-wiring.js'
+import {
+  __setRuntimeMetricsPathForTests,
+} from '../runtime-metrics.js'
+import { makeLivenessFixture, makeTurn, statusKeyForTests } from './helpers/liveness-wiring-fixture.js'
+
+const CHAT = '-100999'
+
+function readTurnEndedRows(path: string): Array<Record<string, unknown>> {
+  if (!existsSync(path)) return []
+  return readFileSync(path, 'utf-8')
+    .split('\n')
+    .filter((l) => l.trim() !== '')
+    .map((l) => JSON.parse(l) as Record<string, unknown>)
+    .filter((r) => r.kind === 'turn_ended')
+}
+
+describe('framework_fallback turn_ended never emits an epoch value as duration_ms', () => {
+  let metricsPath: string
+
+  beforeEach(() => {
+    const dir = mkdtempSync(join(tmpdir(), 'fallback-duration-'))
+    metricsPath = join(dir, 'runtime-metrics.jsonl')
+    __setRuntimeMetricsPathForTests(metricsPath)
+  })
+
+  afterEach(() => {
+    __setRuntimeMetricsPathForTests(null)
+  })
+
+  it('emits duration_ms === 0 for a zero/bogus start instead of Date.now()', async () => {
+    const KEY = statusKeyForTests(CHAT, null)
+    const fx = makeLivenessFixture()
+
+    // The wedged turn's start is 0 — the exact corruption trigger. Before the
+    // fix this made the fallback emit `Date.now() - 0`.
+    fx.activeTurnStartedAt.set(KEY, 0)
+    fx.setCurrentTurn(
+      makeTurn({ sessionChatId: CHAT, sessionThreadId: undefined, turnId: `${KEY}#42` }),
+    )
+
+    const opts = buildSilencePokeOptions(fx.deps)
+    await opts.onFrameworkFallback({
+      key: KEY,
+      chatId: CHAT,
+      threadId: null,
+      fallbackKind: 'working',
+      silenceMs: 302_000,
+      inFlightTools: [],
+    })
+
+    const rows = readTurnEndedRows(metricsPath)
+    const fallbackRow = rows.find((r) => r.ended_via === 'framework_fallback')
+    expect(fallbackRow, 'framework_fallback turn_ended row was emitted').toBeDefined()
+
+    const duration = fallbackRow!.duration_ms as number
+    // The falsifying assertion: pre-fix this is ~Date.now() (an epoch-ms value,
+    // ~1.78e12), and in particular equals the row's own `ts`. Post-fix it is 0.
+    expect(duration).toBe(0)
+    // Belt-and-braces: a duration can never be an absolute epoch stamp, and can
+    // never equal the emission timestamp.
+    expect(duration).not.toBe(fallbackRow!.ts as number)
+    expect(duration).toBeLessThan(365 * 24 * 60 * 60 * 1000) // < 1 year, sane bound
+  })
+
+  it('emits a real elapsed duration for a valid positive start', async () => {
+    const KEY = statusKeyForTests(CHAT, null)
+    const fx = makeLivenessFixture()
+
+    const startedAt = Date.now() - 302_000 // ~5 min ago
+    fx.activeTurnStartedAt.set(KEY, startedAt)
+    fx.setCurrentTurn(
+      makeTurn({ sessionChatId: CHAT, sessionThreadId: undefined, turnId: `${KEY}#43` }),
+    )
+
+    const opts = buildSilencePokeOptions(fx.deps)
+    await opts.onFrameworkFallback({
+      key: KEY,
+      chatId: CHAT,
+      threadId: null,
+      fallbackKind: 'working',
+      silenceMs: 302_000,
+      inFlightTools: [],
+    })
+
+    const fallbackRow = readTurnEndedRows(metricsPath).find(
+      (r) => r.ended_via === 'framework_fallback',
+    )
+    const duration = fallbackRow!.duration_ms as number
+    // Around 302 s, with generous slack for test-runtime jitter.
+    expect(duration).toBeGreaterThanOrEqual(302_000)
+    expect(duration).toBeLessThan(360_000)
+  })
+})


### PR DESCRIPTION
## M0 — the `duration_ms` metric was corrupt

Every \"X ms saved\" latency claim in downstream optimisation work is unmeasurable until this lands, because the analysed `turn_ended` dataset contains rows whose `duration_ms` is an absolute Unix-epoch timestamp, not an elapsed duration.

### Root cause (file:line)
The 300s framework-fallback `turn_ended` emitter in `telegram-plugin/gateway/liveness-wiring.ts` read the turn's start from `activeTurnStartedAt.get(fbKey)` and computed:

```ts
const turnStartedAt = activeTurnStartedAt.get(fbKey)
if (turnStartedAt != null) {
  const turnDurationMs = Date.now() - turnStartedAt   // <-- no `> 0` guard
```

Guarded only by `!= null`, a `0` start (`0 != null` is true) flows through and yields `duration_ms = Date.now() - 0` — the current epoch-ms, a ~56,000-year \"duration\". The two `stream-render.ts` `turn_ended` paths already guarded with `startedAt > 0 ? … : 0`; this path had **drifted** from them.

### Evidence
In a real `runtime-metrics.jsonl`: **110** rows with `duration_ms === ts` and `ended_via: "framework_fallback"` (e.g. `duration_ms: 1785025299474`). Distribution max was `1.78e12` ms. These destroy any mean/p99. The corrupt rows all sit on the liveness test-fixture chat id in one window — the emitter has **no** guard against a bogus start, so any path (parked-turn edge, test fixture, future refactor) that leaves the start non-positive re-corrupts the metric.

### Fix (durable, deterministic)
Introduce one shared `computeTurnDurationMs(startedAt, now)` in `turn-record-status.ts`:

```ts
if (typeof startedAt !== 'number' || !Number.isFinite(startedAt) || startedAt <= 0) return 0
return Math.max(0, now - startedAt)
```

Routed through **all** duration emitters so the guard can no longer drift between copies:
- `liveness-wiring.ts` framework_fallback `turn_ended` (the bug)
- both `stream-render.ts` `turn_ended` paths (silent-marker + normal turn-end)
- `buildTurnRecord` → `turns.jsonl` (also gains clock-step-back clamp to 0)

A non-positive/missing start now yields `0` — a bounded, filterable sentinel — never an epoch value.

### Test
`telegram-plugin/tests/framework-fallback-duration-guard.test.ts` drives the REAL `onFrameworkFallback` (via `buildSilencePokeOptions`) with a `0` start and asserts on the actual emitted row: `duration_ms === 0`. Proven to guard the bug:
- **old code:** `AssertionError: expected 1785993867845 to be +0` (emits ~`Date.now()`)
- **new code:** passes

A second case asserts a valid ~302s start still produces a real elapsed duration.

### Validation
- Scoped tests green: this + `framework-fallback-drains-parked`, `turn-record-status`, `runtime-metrics`, `post-fallback-outbound-count` (36 tests).
- `tsc --noEmit` clean.
- Lint guards run: `check-test-runner-coverage`, `check-bun-test-imports`, `check-agent-state-dir-hermeticity`, `check-plugin-references` — all OK.

### Note (out of scope, flagged)
The 110 existing corrupt rows already written to production `runtime-metrics.jsonl` should be filtered/purged by the analysing team (`duration_ms === ts`, or `ended_via==framework_fallback` with `duration_ms > 1e12`). This PR stops new corruption; it does not rewrite historical data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)