### PR TITLE
fix(hindsight): stamp recall tunables from cascade, close settings/env drift

### DIFF
--- a/src/agents/drift.ts
+++ b/src/agents/drift.ts
@@ -46,8 +46,10 @@ import {
 import { isHindsightEnabled } from "../memory/hindsight.js";
 import {
   resolveHindsightRecallTunables,
+  resolveHindsightRecallCaps,
   readHooksRecallTimeout,
   type RecallTunableInput,
+  type RecallCapInput,
 } from "../setup/hindsight-recall-tunables.js";
 import { VERSION } from "../build-info.js";
 import { buildSettingsHooksBlock, detectHooksDrift } from "./scaffold.js";
@@ -444,6 +446,14 @@ export function detectHindsightRecallTunableDrift(
   const expected = resolveHindsightRecallTunables(
     resolved.memory?.recall as RecallTunableInput | undefined,
   );
+  // Count + token caps resolved from the SAME cascade as the stamp
+  // (resolveHindsightRecallCaps) — recallMaxMemories drifted silently for months
+  // as a hardcoded 8 while start.sh exported the operator's value, and
+  // recallMaxTokens was never stamped at all, so this row is the doctor-side
+  // guard that a future stamp regression can't hide behind the env export.
+  const expectedCaps = resolveHindsightRecallCaps(
+    resolved.memory?.recall as RecallCapInput | undefined,
+  );
 
   const findings: DriftFinding[] = [];
   const mismatches: string[] = [];
@@ -491,6 +501,16 @@ export function detectHindsightRecallTunableDrift(
           "recallRequestTimeoutSeconds",
           "memory.recall.request_timeout_seconds",
           expected.requestTimeoutSeconds,
+        ],
+        [
+          "recallMaxMemories",
+          "memory.recall.max_memories",
+          expectedCaps.maxMemories,
+        ],
+        [
+          "recallMaxTokens",
+          "memory.recall.max_tokens",
+          expectedCaps.maxTokens,
         ],
       ];
       for (const [key, yamlKey, want] of checks) {

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -814,9 +814,12 @@ import {
 import { HINDSIGHT_DEFAULT_MCP_URL, HINDSIGHT_DEFAULT_API_BASE_URL } from "../setup/hindsight.js";
 import {
   resolveHindsightRecallTunables,
+  resolveHindsightRecallCaps,
   renderHindsightHooksOverrides,
   type HindsightRecallTunables,
+  type HindsightRecallCaps,
   type RecallTunableInput,
+  type RecallCapInput,
 } from "../setup/hindsight-recall-tunables.js";
 import {
   resolveHindsightRecallPassthrough,
@@ -3380,9 +3383,20 @@ export function installHindsightPlugin(
   // timeout) from the CASCADED config. Stamped onto the deployed plugin below
   // so `switchroom apply` RE-ASSERTS these values instead of reverting them —
   // see src/setup/hindsight-recall-tunables.ts for the full rationale.
-  const recallTunables = resolveHindsightRecallTunables(
-    resolveHindsightRecallConfig(switchroomConfig, agentName, resolvedAgentConfig),
+  const recallConfig = resolveHindsightRecallConfig(
+    switchroomConfig,
+    agentName,
+    resolvedAgentConfig,
   );
+  const recallTunables = resolveHindsightRecallTunables(recallConfig);
+  // Count + token caps (recallMaxMemories / recallMaxTokens), resolved from the
+  // SAME cascaded recall config as the latency envelope and the start.sh env
+  // exports. Stamping these from the cascade — rather than the old hardcoded 8 /
+  // unstamped 1024 — is what keeps settings.json in agreement with
+  // HINDSIGHT_RECALL_MAX_MEMORIES / HINDSIGHT_RECALL_MAX_TOKENS, so an invocation
+  // that does NOT inherit start.sh's env (a docker-exec'd retain/backfill) no
+  // longer silently reverts to the shipped defaults.
+  const recallCaps = resolveHindsightRecallCaps(recallConfig);
   const contentOverrides: Record<string, string> = {};
   try {
     const vendorSettingsPath = join(sourcePath, "settings.json");
@@ -3392,6 +3406,7 @@ export function installHindsightPlugin(
         additionalBanks,
         retainConfig,
         recallTunables,
+        recallCaps,
         observationScopeSettings,
       );
       if (expectedSettings != null) contentOverrides["settings.json"] = expectedSettings;
@@ -3455,6 +3470,7 @@ export function installHindsightPlugin(
     additionalBanks,
     retainConfig,
     recallTunables,
+    recallCaps,
     observationScopeSettings,
   );
   // Stamp the UserPromptSubmit recall-hook ceiling into the deployed
@@ -3606,9 +3622,11 @@ export function resolveHindsightRecallConfig(
    * caller's raw config is not literally that map entry.
    */
   resolvedAgentConfig?: AgentConfig,
-): RecallTunableInput | undefined {
+): (RecallTunableInput & RecallCapInput) | undefined {
   if (resolvedAgentConfig) {
-    return resolvedAgentConfig.memory?.recall as RecallTunableInput | undefined;
+    return resolvedAgentConfig.memory?.recall as
+      | (RecallTunableInput & RecallCapInput)
+      | undefined;
   }
   if (!switchroomConfig) return undefined;
   // Fallback for callers with no cascaded config (direct unit-test calls).
@@ -3622,7 +3640,7 @@ export function resolveHindsightRecallConfig(
     switchroomConfig.profiles,
     switchroomConfig.agents[agentName] ?? ({} as AgentConfig),
   );
-  return resolved?.memory?.recall as RecallTunableInput | undefined;
+  return resolved?.memory?.recall as (RecallTunableInput & RecallCapInput) | undefined;
 }
 
 /**
@@ -3651,13 +3669,15 @@ function applyHindsightHooksOverrides(
 /**
  * Per-bank recall slot floors, switchroom's shipped defaults.
  *
- * Sized against the cap this fleet actually deploys — 6, from
- * `defaults.memory.recall.max_memories` in switchroom.yaml, which cascades to
- * HINDSIGHT_RECALL_MAX_MEMORIES and wins over the 8 stamped into the plugin's
- * settings.json. recall.py bounds the two floors to half the cap between them
- * (`_reservable_slots`), so 2 + 1 is the largest pair that is fully honoured at
- * cap 6 while still leaving three slots to pure global relevance. Floors that
- * summed to the cap would stop being floors and become a fixed quota.
+ * These are FLOORS inside `recallMaxMemories`, not fixed quotas. The effective
+ * cap is whatever the operator sets in `memory.recall.max_memories` (cascaded to
+ * both HINDSIGHT_RECALL_MAX_MEMORIES and the settings.json stamp — see
+ * resolveHindsightRecallCaps; switchroom's own default is 8, the vendor ships
+ * 12). recall.py bounds the two floors to HALF the cap between them
+ * (`_reservable_slots`), so 2 + 1 stays comfortably within a floor at any cap
+ * the fleet realistically runs (e.g. at cap 8 it reserves 3 of 8 and leaves 5 to
+ * pure global relevance; larger caps only widen that margin). Floors that summed
+ * to the cap would stop being floors and become a fixed quota.
  *
  * These are also the values exported to the environment unconditionally (see
  * `start.sh.hbs`) so a stale `~/.hindsight/claude-code.json` — which loads
@@ -3696,9 +3716,10 @@ const HINDSIGHT_RECALL_MIN_SCORE_SCOPE_DEFAULT = "degraded";
  *   - `retainMode`: full-session → chunked (Phase 6b: window, not whole
  *     transcript, re-consolidated per fire; paired with the vendor
  *     retain.py divergence)
- *   - `recallMaxMemories`: 12 → 8 (tighter prompt, less model noise)
+ *   - `recallMaxMemories`: 12 → cascade (default 8; `memory.recall.max_memories`)
+ *   - `recallMaxTokens`: cascade (default 1024; `memory.recall.max_tokens`)
  *   - `recallOwnBankMinSlots` / `recallAdditionalBankMinSlots`: 0/0 → 2/1
- *     (neither bank can take every slot of the deployed cap of 6)
+ *     (FLOORS inside recallMaxMemories, bounded to half the cap by recall.py)
  *
  * Future overrides go here, NOT in the vendor file. The vendor is
  * third-party code and must remain untouched for clean upstream
@@ -3710,6 +3731,7 @@ function applyHindsightSettingsOverrides(
   additionalBanks: readonly string[],
   retainConfig: HindsightRetainConfig,
   recallTunables: HindsightRecallTunables,
+  recallCaps: HindsightRecallCaps,
   observationScopeSettings: HindsightObservationScopeSettings,
 ): void {
   const settingsPath = join(pluginDestPath, "settings.json");
@@ -3725,6 +3747,7 @@ function applyHindsightSettingsOverrides(
     additionalBanks,
     retainConfig,
     recallTunables,
+    recallCaps,
     observationScopeSettings,
   );
   if (next == null) return; // malformed settings; don't make it worse
@@ -3744,6 +3767,7 @@ function renderHindsightSettingsOverrides(
   additionalBanks: readonly string[],
   retainConfig: HindsightRetainConfig,
   recallTunables: HindsightRecallTunables,
+  recallCaps: HindsightRecallCaps,
   observationScopeSettings: HindsightObservationScopeSettings,
 ): string | null {
   let settings: Record<string, unknown>;
@@ -3798,12 +3822,24 @@ function renderHindsightSettingsOverrides(
   // why the paired vendor change keeps the new tag OUT of the consolidation
   // scope so this is not a silent scope migration.
   settings.retainTags = [...RETAIN_TAGS_DEFAULT];
-  // v0.13.22 smart defaults: at our recallBudget=low the vendor's 12
-  // memories is generous; 8 keeps prompt noise down without hurting
-  // the substantive recall@N (top-8 carries the same dominant facts
-  // that top-12 does, per the 2026-05-24 audit's recall-quality sample).
-  // Operators can re-raise via memory.recall.max_memories in switchroom.yaml.
-  settings.recallMaxMemories = 8;
+  // Count + token caps, stamped from the CASCADE-RESOLVED operator config, NOT
+  // hardcoded literals. recallMaxMemories used to be a bare `8` here and
+  // recallMaxTokens was never stamped (the vendor's 1024 rode through), while
+  // start.sh exported HINDSIGHT_RECALL_MAX_MEMORIES / HINDSIGHT_RECALL_MAX_TOKENS
+  // from the operator's memory.recall.max_memories / .max_tokens. Env wins at
+  // runtime (DEFAULTS → settings.json → claude-code.json → env), so the live
+  // supervised session was correct — but any invocation WITHOUT that env (a
+  // docker-exec'd retain/backfill, or the plugin before the export ran) silently
+  // reverted to 8/1024, and `switchroom doctor` was blind to the split. Resolving
+  // both from the same cascade as the env export closes the drift.
+  //
+  // Defaults when the operator sets neither: 8 (switchroom's tightened
+  // recallMaxMemories, vendor ships 12) and 1024 (the vendor recallMaxTokens),
+  // i.e. byte-identical to what the fleet ran before this was cascade-stamped.
+  // Operators re-raise via memory.recall.max_memories / .max_tokens in
+  // switchroom.yaml. See resolveHindsightRecallCaps.
+  settings.recallMaxMemories = recallCaps.maxMemories;
+  settings.recallMaxTokens = recallCaps.maxTokens;
   // Recall latency envelope. Both of these were previously UNMANAGED:
   // `recallParallelDeadlineSeconds` was readable from config but nothing in
   // switchroom ever resolved it from switchroom.yaml, and the per-bank timeout
@@ -3852,13 +3888,15 @@ function renderHindsightSettingsOverrides(
   // field that would have caught the own-bank outage, since a fully timed-out
   // own bank still logs a full `result_count`.
   //
-  // 2/1 against the cap this fleet actually deploys — which is 6, not the 8
-  // stamped above: `defaults.memory.recall.max_memories: 6` in switchroom.yaml
-  // cascades to HINDSIGHT_RECALL_MAX_MEMORIES, and env wins over settings.json.
+  // 2/1 against recallMaxMemories, whatever the operator set it to
+  // (`memory.recall.max_memories` cascades to both HINDSIGHT_RECALL_MAX_MEMORIES
+  // and the settings.json stamp above — the two now carry the same value, so the
+  // floors bind against the same cap on every invocation, env-inheriting or not).
   // FLOORS, not quotas, and enforced as such: recall.py bounds the two floors to
-  // HALF the cap between them (`_reservable_slots`), so at least three of six
-  // slots are always won on pure relevance and composition still moves with the
-  // scores. Floors that summed to the cap (4+2 at 6) would be a fixed quota with
+  // HALF the cap between them (`_reservable_slots`), so at least half the slots
+  // are always won on pure relevance and composition still moves with the
+  // scores (at the default cap of 8, that reserves 3 and leaves 5). Floors that
+  // summed to the cap would be a fixed quota with
   // no score influence at all. Each side also gets its floor only if it returned
   // that many, so a silent bank wastes nothing. Operators re-tune via
   // memory.recall.own_bank_min_slots / .additional_bank_min_slots in

--- a/src/setup/hindsight-recall-tunables.ts
+++ b/src/setup/hindsight-recall-tunables.ts
@@ -50,8 +50,23 @@
  * `switchroom doctor` can surface it.
  */
 
+import { RECALL_PASSTHROUGH_DEFAULTS } from "./hindsight-recall-passthrough.js";
+
 /** Vendor/shipped default for the UserPromptSubmit hook ceiling (seconds). */
 export const DEFAULT_RECALL_HOOK_TIMEOUT_SECONDS = 12;
+
+/**
+ * switchroom smart-default for `recallMaxMemories` — the count cap on memories
+ * injected per turn. The vendor ships 12 (`vendor/hindsight-memory/settings.json`
+ * / `lib/config.py` DEFAULTS); switchroom tightens it to 8 (less prompt noise at
+ * our `recallBudget: low`, per the 2026-05-24 recall-quality audit). This is the
+ * value stamped into the deployed settings.json when the operator sets no
+ * `memory.recall.max_memories`, so it MUST equal what the fleet ran before this
+ * became a stamped-from-cascade value or turning the stamp on would move
+ * behaviour. Operators re-raise via `memory.recall.max_memories` in
+ * switchroom.yaml, which start.sh also exports as HINDSIGHT_RECALL_MAX_MEMORIES.
+ */
+export const DEFAULT_RECALL_MAX_MEMORIES = 8;
 
 /**
  * Headroom (seconds) reserved between the hook ceiling and the shared parallel
@@ -115,6 +130,68 @@ export interface RecallTunableInput {
   hook_timeout_seconds?: number | undefined;
   parallel_deadline_seconds?: number | undefined;
   request_timeout_seconds?: number | undefined;
+}
+
+/**
+ * The two recall CAPS stamped into the deployed settings.json — the count cap
+ * (`recallMaxMemories`) and the injected-block token budget (`recallMaxTokens`).
+ *
+ * These are NOT part of the latency envelope above; they are a separate pair,
+ * broken out so `applyHindsightSettingsOverrides` (the stamp) and
+ * `detectHindsightRecallTunableDrift` (the doctor check) resolve them from the
+ * SAME cascade input and cannot disagree. Before this, `recallMaxMemories` was a
+ * hardcoded `8` literal in scaffold.ts and `recallMaxTokens` was never stamped
+ * at all — so an operator who set `memory.recall.max_memories`/`.max_tokens` in
+ * switchroom.yaml got the value only via the start.sh env export (which wins at
+ * runtime), while settings.json silently kept 8/1024. Any hindsight invocation
+ * that did NOT inherit that env (a docker-exec'd retain/backfill, or the plugin
+ * before the export ran) then reverted to 8/1024, and `switchroom doctor` was
+ * blind to the split. Stamping from the cascade closes both gaps.
+ */
+export interface HindsightRecallCaps {
+  /** Count cap on injected memories, stamped into settings.json. */
+  maxMemories: number;
+  /** Token budget for the injected block, stamped into settings.json. */
+  maxTokens: number;
+}
+
+/** The `memory.recall.*` subset the caps resolver reads (post-cascade). */
+export interface RecallCapInput {
+  max_memories?: number | undefined;
+  max_tokens?: number | undefined;
+}
+
+/**
+ * Resolve the recall caps from cascaded config, mirroring the start.sh export
+ * source exactly:
+ *
+ *   - `max_memories` → HINDSIGHT_RECALL_MAX_MEMORIES (start.sh.hbs), default
+ *     {@link DEFAULT_RECALL_MAX_MEMORIES} (8) when unset. start.sh exports this
+ *     one CONDITIONALLY (only when the operator set it), so when unset the
+ *     settings.json stamp is the sole authority and MUST carry the switchroom
+ *     smart-default.
+ *   - `max_tokens` → HINDSIGHT_RECALL_MAX_TOKENS, resolved through the recall
+ *     passthrough whose default is {@link RECALL_PASSTHROUGH_DEFAULTS}.maxTokens
+ *     (1024, the vendor settings.json value). Matching that keeps an unset agent
+ *     byte-identical.
+ *
+ * Pure and total like `resolveHindsightRecallTunables`: any absent/NaN/non-positive
+ * input falls back to the default rather than throwing, so a config typo cannot
+ * brick an agent's memory install at scaffold time.
+ */
+export function resolveHindsightRecallCaps(
+  recall: RecallCapInput | undefined,
+): HindsightRecallCaps {
+  // `min` is the smallest value that is meaningful for the key: max_memories
+  // admits 0 (start.sh.hbs documents `0` as "disable the cap entirely", and
+  // start.sh exports it verbatim, so the settings.json stamp must match), while
+  // max_tokens is a token budget with a schema floor of 1.
+  const usable = (v: number | undefined, min: number): number | undefined =>
+    typeof v === "number" && Number.isFinite(v) && v >= min ? Math.floor(v) : undefined;
+  return {
+    maxMemories: usable(recall?.max_memories, 0) ?? DEFAULT_RECALL_MAX_MEMORIES,
+    maxTokens: usable(recall?.max_tokens, 1) ?? RECALL_PASSTHROUGH_DEFAULTS.maxTokens,
+  };
 }
 
 /**

--- a/tests/scaffold.recall-tunables-survive-apply.test.ts
+++ b/tests/scaffold.recall-tunables-survive-apply.test.ts
@@ -6,13 +6,16 @@ import { installHindsightPlugin } from "../src/agents/scaffold.js";
 import { detectHindsightRecallTunableDrift } from "../src/agents/drift.js";
 import {
   resolveHindsightRecallTunables,
+  resolveHindsightRecallCaps,
   readHooksRecallTimeout,
   renderHindsightHooksOverrides,
   DEFAULT_RECALL_HOOK_TIMEOUT_SECONDS,
   DEFAULT_RECALL_REQUEST_TIMEOUT_SECONDS,
+  DEFAULT_RECALL_MAX_MEMORIES,
   RECALL_DEADLINE_HEADROOM_SECONDS,
   MIN_RECALL_HOOK_TIMEOUT_SECONDS,
 } from "../src/setup/hindsight-recall-tunables.js";
+import { RECALL_PASSTHROUGH_DEFAULTS } from "../src/setup/hindsight-recall-passthrough.js";
 import type { SwitchroomConfig, AgentConfig } from "../src/config/schema.js";
 
 /**
@@ -156,6 +159,61 @@ describe("recall latency tunables are declarative and survive apply", () => {
     expect(readSettings().recallRequestTimeoutSeconds).toBeLessThanOrEqual(
       readSettings().recallParallelDeadlineSeconds as number,
     );
+    // Count + token caps with no operator override: the switchroom smart-default
+    // (8, vendor ships 12) and the vendor token budget (1024). Stamping these
+    // from the cascade must be byte-identical to what the fleet ran when
+    // recallMaxMemories was a hardcoded 8 and recallMaxTokens was never stamped.
+    expect(readSettings().recallMaxMemories).toBe(DEFAULT_RECALL_MAX_MEMORIES);
+    expect(readSettings().recallMaxTokens).toBe(RECALL_PASSTHROUGH_DEFAULTS.maxTokens);
+  });
+
+  /**
+   * THE R2 drift regression. The operator sets memory.recall.max_memories /
+   * .max_tokens in switchroom.yaml; start.sh exports them as env (which wins at
+   * runtime), but settings.json used to keep a hardcoded 8 and the vendor's
+   * unstamped 1024. Any hindsight invocation WITHOUT that env (a docker-exec'd
+   * retain/backfill) then silently ran 8/1024. The stamp must now carry the
+   * operator's cascaded values — this test fails on the old 8 / 1024 literals.
+   */
+  it("stamps recallMaxMemories/recallMaxTokens from the cascaded operator values", () => {
+    installHindsightPlugin("probe", tmpDir, configFor({ max_memories: 16, max_tokens: 6144 }));
+    const s = readSettings();
+    expect(s.recallMaxMemories).toBe(16);
+    expect(s.recallMaxTokens).toBe(6144);
+    // Guard the exact pre-fix defect: neither may fall back to the old literals
+    // once the operator has configured them.
+    expect(s.recallMaxMemories).not.toBe(8);
+    expect(s.recallMaxTokens).not.toBe(1024);
+  });
+
+  it("re-asserts the caps when a reinstall has clobbered them back to 8/1024", () => {
+    const config = configFor({ max_memories: 16, max_tokens: 6144 });
+    installHindsightPlugin("probe", tmpDir, config);
+
+    // Clobber the deployed settings.json back to the pre-fix literals, exactly
+    // as a vendor re-copy + the old hardcoded stamp would.
+    const clobbered = readSettings();
+    clobbered.recallMaxMemories = 8;
+    clobbered.recallMaxTokens = 1024;
+    writeFileSync(settingsPath(), JSON.stringify(clobbered, null, 2) + "\n");
+    expect(readSettings().recallMaxMemories).toBe(8);
+
+    // The apply.
+    installHindsightPlugin("probe", tmpDir, config);
+    expect(readSettings().recallMaxMemories).toBe(16);
+    expect(readSettings().recallMaxTokens).toBe(6144);
+  });
+
+  it("honours max_memories/max_tokens set at the `defaults:` tier", () => {
+    const cfg = {
+      defaults: { memory: { recall: { max_memories: 16, max_tokens: 6144 } } },
+      agents: { probe: {} },
+      memory: { backend: "hindsight", config: { url: "http://localhost:18888/mcp/" } },
+      telegram: { bot_token: "t", forum_chat_id: "c" },
+    } as unknown as SwitchroomConfig;
+    installHindsightPlugin("probe", tmpDir, cfg);
+    expect(readSettings().recallMaxMemories).toBe(16);
+    expect(readSettings().recallMaxTokens).toBe(6144);
   });
 
   it("leaves the vendor tree untouched", () => {
@@ -224,6 +282,47 @@ describe("drift row: installed plugin vs switchroom.yaml", () => {
     const f = detectHindsightRecallTunableDrift("probe", agentConfig(), tmpDir, config());
     expect(f).toHaveLength(1);
     expect(f[0].detail).toContain("`recallRequestTimeoutSeconds` is 8, expected 13");
+  });
+
+  it("FAILS when recallMaxMemories has been reverted to the old hardcoded 8", () => {
+    const capRecall = { ...recall, max_memories: 16, max_tokens: 6144 };
+    const capCfg = configFor(capRecall);
+    installHindsightPlugin("probe", tmpDir, capCfg);
+    const p = join(tmpDir, ...PLUGIN_REL, "settings.json");
+    const s = JSON.parse(readFileSync(p, "utf-8"));
+    s.recallMaxMemories = 8; // the pre-fix hardcoded literal
+    writeFileSync(p, JSON.stringify(s, null, 2) + "\n");
+
+    const f = detectHindsightRecallTunableDrift(
+      "probe",
+      { memory: { recall: capRecall } } as unknown as AgentConfig,
+      tmpDir,
+      capCfg,
+    );
+    expect(f).toHaveLength(1);
+    expect(f[0].surface).toBe("memory-tunables");
+    expect(f[0].detail).toContain("`recallMaxMemories` is 8, expected 16");
+    expect(f[0].detail).toContain("memory.recall.max_memories");
+  });
+
+  it("FAILS when recallMaxTokens has been reverted to the vendor 1024", () => {
+    const capRecall = { ...recall, max_memories: 16, max_tokens: 6144 };
+    const capCfg = configFor(capRecall);
+    installHindsightPlugin("probe", tmpDir, capCfg);
+    const p = join(tmpDir, ...PLUGIN_REL, "settings.json");
+    const s = JSON.parse(readFileSync(p, "utf-8"));
+    s.recallMaxTokens = 1024; // the vendor default that used to ride through unstamped
+    writeFileSync(p, JSON.stringify(s, null, 2) + "\n");
+
+    const f = detectHindsightRecallTunableDrift(
+      "probe",
+      { memory: { recall: capRecall } } as unknown as AgentConfig,
+      tmpDir,
+      capCfg,
+    );
+    expect(f).toHaveLength(1);
+    expect(f[0].detail).toContain("`recallMaxTokens` is 1024, expected 6144");
+    expect(f[0].detail).toContain("memory.recall.max_tokens");
   });
 
   it("FAILS when a managed key is missing entirely", () => {
@@ -413,6 +512,40 @@ describe("resolveHindsightRecallTunables", () => {
       expect(resolveHindsightRecallTunables(bad).hookTimeoutSeconds).toBe(
         DEFAULT_RECALL_HOOK_TIMEOUT_SECONDS,
       );
+    }
+  });
+});
+
+describe("resolveHindsightRecallCaps", () => {
+  it("defaults to the switchroom smart-default (8) and vendor token budget (1024)", () => {
+    const c = resolveHindsightRecallCaps(undefined);
+    expect(c.maxMemories).toBe(DEFAULT_RECALL_MAX_MEMORIES);
+    expect(c.maxMemories).toBe(8);
+    expect(c.maxTokens).toBe(RECALL_PASSTHROUGH_DEFAULTS.maxTokens);
+    expect(c.maxTokens).toBe(1024);
+  });
+
+  it("passes through the operator's configured caps", () => {
+    const c = resolveHindsightRecallCaps({ max_memories: 16, max_tokens: 6144 });
+    expect(c.maxMemories).toBe(16);
+    expect(c.maxTokens).toBe(6144);
+  });
+
+  it("preserves max_memories: 0 (the documented `disable the cap` value)", () => {
+    // start.sh exports 0 verbatim, so the settings.json stamp must match it
+    // rather than folding it back to the default 8.
+    expect(resolveHindsightRecallCaps({ max_memories: 0 }).maxMemories).toBe(0);
+  });
+
+  it("falls back rather than throwing on unusable input", () => {
+    for (const bad of [
+      { max_memories: -5, max_tokens: -1 },
+      { max_memories: Number.NaN, max_tokens: Number.NaN },
+      { max_tokens: 0 }, // below the token floor of 1 → default
+    ]) {
+      const c = resolveHindsightRecallCaps(bad);
+      expect(c.maxMemories).toBe(DEFAULT_RECALL_MAX_MEMORIES);
+      expect(c.maxTokens).toBe(RECALL_PASSTHROUGH_DEFAULTS.maxTokens);
     }
   });
 });


### PR DESCRIPTION
## Summary

`recallMaxMemories` was stamped into the hindsight plugin's `settings.json` as a **hardcoded 8**, and `recallMaxTokens` was **never stamped at all** (the vendor's 1024 rode through), while `start.sh` exports `HINDSIGHT_RECALL_MAX_MEMORIES` / `HINDSIGHT_RECALL_MAX_TOKENS` from the operator's cascaded `memory.recall.max_memories` / `.max_tokens`.

Env wins at runtime (`DEFAULTS → settings.json → claude-code.json → env`, `lib/config.py`), so the supervised session was correct. But any invocation **without** that env — a docker-exec'd retain/backfill, or the plugin before the export ran — silently reverted to 8/1024, and `switchroom doctor` was blind to the split because its tunable-drift check only covered the latency envelope.

## Why

This is the same defect class the recall latency envelope already fixed (see `src/setup/hindsight-recall-tunables.ts`): a value that switchroom manages through env must also be stamped into `settings.json` from the **same cascade source**, or the two channels drift and the drift is invisible.

Job spec: `reference/jobs/remember-across-sessions.md` — the count/token caps decide how much memory reaches the model; a settings.json that disagrees with the operator's config is exactly the "memory feels worse lately" failure that spec exists to prevent.

## Changes

- **`resolveHindsightRecallCaps`** (`hindsight-recall-tunables.ts`) — resolves `recallMaxMemories` / `recallMaxTokens` from the same cascade input the start.sh exports use. Defaults 8 (switchroom smart-default, vendor ships 12) and 1024 (vendor token budget) when unset, so an agent that configured neither is **byte-identical** to before. Preserves `max_memories: 0` (documented "disable the cap"), matching the verbatim env export.
- **`applyHindsightSettingsOverrides`** (`scaffold.ts`) — stamps both caps from the cascade instead of the hardcoded `8` / unstamped `1024`.
- **`detectHindsightRecallTunableDrift`** (`drift.ts`) — adds `recallMaxMemories` / `recallMaxTokens` to the `checks` array so `switchroom doctor` catches a future stamp regression instead of it hiding behind the env export.
- Fixes the stale "deployed cap of 6" comments — the effective cap is whatever the operator sets; the 2/1 slot floors are bounded to half the cap by `recall.py`, well within range at any realistic cap.

## Test plan

Extended `tests/scaffold.recall-tunables-survive-apply.test.ts`:
- stamps `recallMaxMemories`/`recallMaxTokens` from cascaded operator values (16/6144) — **fails on the old 8/1024 literals**
- re-asserts the caps after a reinstall clobbers them back to 8/1024 (idempotent, not one-shot)
- honours caps set at the `defaults:` tier
- unset config still stamps 8/1024 (no regression)
- drift FAILS when `recallMaxMemories` reverted to 8 / `recallMaxTokens` reverted to 1024 — **would pass silently on the old drift check**
- `resolveHindsightRecallCaps` unit tests (defaults, passthrough, `max_memories: 0`, unusable input)

Local: 33/33 in the touched suite, plus scaffold core (244), recall-passthrough (26), additional-banks/optout/nudge (16), reranker-budget + thresholds (15), perf-defaults (209). `npm run lint` green (tsc + all guards).

## Risk

Low. Precedence unchanged (env still wins at runtime); the stamp only fixes the non-env fallback path. No behaviour change when the operator has set neither key (falls back to the exact 8/1024 the fleet already ran, not a new default). Vendor tree untouched. Not merging — operator-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)