### PR TITLE
perf(hooks): run plugin hooks under bun

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -4464,6 +4464,17 @@ export const DOCKER_TELEGRAM_PLUGIN_PATH = "/opt/switchroom/telegram-plugin";
  * the operator's host repo path here, which doesn't exist inside the
  * container — hooks silently never ran (RFC Phase 3 §Bug 3 in
  * reference/rfcs/sub-agent-visibility.md).
+ *
+ * RUNTIME: these plugin `.mjs` hooks are invoked under `bun`, not `node`.
+ * Hooks run in parallel on every tool call / turn boundary and ~half of a
+ * ~40ms hook is interpreter boot; bun's cold-start is roughly half node's,
+ * so the swap halves that fixed cost per hook. bun ships in the base image
+ * (docker/Dockerfile.base "Phase 1b", pinned + sha-verified) and is already
+ * the runtime for the gateway/scheduler/autoaccept sidecars. Every hook
+ * under this path is proven byte-identical output/behaviour under bun vs
+ * node — including the secret-guard and secret-scrub SECURITY hooks. The
+ * bundled hooks under DOCKER_BUNDLED_HOOKS_PATH deliberately stay on `node`
+ * (esbuild output, not covered by that equivalence proof).
  */
 export const DOCKER_HOOKS_PATH = `${DOCKER_TELEGRAM_PLUGIN_PATH}/hooks`;
 
@@ -6852,7 +6863,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
       type: "command",
       command: wrap(
         "hook:secret-scrub-stop",
-        `node "${join(DOCKER_HOOKS_PATH, "secret-scrub-stop.mjs")}"`,
+        `bun "${join(DOCKER_HOOKS_PATH, "secret-scrub-stop.mjs")}"`,
       ),
       timeout: 15,
       async: true,
@@ -6861,7 +6872,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
       type: "command",
       command: wrap(
         "hook:silent-end-interrupt-stop",
-        `node "${join(DOCKER_HOOKS_PATH, "silent-end-interrupt-stop.mjs")}"`,
+        `bun "${join(DOCKER_HOOKS_PATH, "silent-end-interrupt-stop.mjs")}"`,
       ),
       timeout: 5,
       async: false,
@@ -6873,7 +6884,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
       type: "command",
       command: wrap(
         "hook:dispatch-claim-stop",
-        `node "${join(DOCKER_HOOKS_PATH, "dispatch-claim-stop.mjs")}"`,
+        `bun "${join(DOCKER_HOOKS_PATH, "dispatch-claim-stop.mjs")}"`,
       ),
       timeout: 5,
       async: false,
@@ -6884,7 +6895,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
       type: "command",
       command: wrap(
         "hook:tool-label-stop",
-        `node "${join(DOCKER_HOOKS_PATH, "tool-label-stop.mjs")}"`,
+        `bun "${join(DOCKER_HOOKS_PATH, "tool-label-stop.mjs")}"`,
       ),
       timeout: 5,
       async: true,
@@ -6917,7 +6928,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
               type: "command",
               command: wrap(
                 "hook:secret-guard-pretool",
-                `node "${join(DOCKER_HOOKS_PATH, "secret-guard-pretool.mjs")}"`,
+                `bun "${join(DOCKER_HOOKS_PATH, "secret-guard-pretool.mjs")}"`,
               ),
               timeout: 10,
             },
@@ -6934,7 +6945,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
               type: "command",
               command: wrap(
                 "hook:sentinel-reply-guard-pretool",
-                `node "${join(DOCKER_HOOKS_PATH, "sentinel-reply-guard-pretool.mjs")}"`,
+                `bun "${join(DOCKER_HOOKS_PATH, "sentinel-reply-guard-pretool.mjs")}"`,
               ),
               timeout: 5,
             },
@@ -6951,7 +6962,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
               type: "command",
               command: wrap(
                 "hook:subagent-tracker-pretool",
-                `node "${join(DOCKER_HOOKS_PATH, "subagent-tracker-pretool.mjs")}"`,
+                `bun "${join(DOCKER_HOOKS_PATH, "subagent-tracker-pretool.mjs")}"`,
               ),
               timeout: 10,
             },
@@ -7144,7 +7155,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
               type: "command",
               command: wrap(
                 "hook:tool-label-pretool",
-                `node "${join(DOCKER_HOOKS_PATH, "tool-label-pretool.mjs")}"`,
+                `bun "${join(DOCKER_HOOKS_PATH, "tool-label-pretool.mjs")}"`,
               ),
               timeout: 5,
             },
@@ -7175,7 +7186,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
               type: "command",
               command: wrap(
                 "hook:repo-context-pretool",
-                `node "${join(DOCKER_HOOKS_PATH, "repo-context-pretool.mjs")}"`,
+                `bun "${join(DOCKER_HOOKS_PATH, "repo-context-pretool.mjs")}"`,
               ),
               timeout: 5,
             },
@@ -7198,7 +7209,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
               type: "command",
               command: wrap(
                 "hook:subagent-tracker-posttool",
-                `node "${join(DOCKER_HOOKS_PATH, "subagent-tracker-posttool.mjs")}"`,
+                `bun "${join(DOCKER_HOOKS_PATH, "subagent-tracker-posttool.mjs")}"`,
               ),
               timeout: 10,
             },
@@ -7227,7 +7238,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
               type: "command",
               command: wrap(
                 "hook:sandbox-hint-posttool",
-                `node "${join(DOCKER_HOOKS_PATH, "sandbox-hint-posttool.mjs")}"`,
+                `bun "${join(DOCKER_HOOKS_PATH, "sandbox-hint-posttool.mjs")}"`,
               ),
               timeout: 3,
             },
@@ -7262,7 +7273,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
               type: "command",
               command: wrap(
                 "hook:wedge-detect-posttool",
-                `node "${join(DOCKER_HOOKS_PATH, "wedge-detect-posttool.mjs")}"`,
+                `bun "${join(DOCKER_HOOKS_PATH, "wedge-detect-posttool.mjs")}"`,
               ),
               timeout: 3,
             },

--- a/telegram-plugin/hooks/hooks.json
+++ b/telegram-plugin/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" node \"${CLAUDE_PLUGIN_ROOT}/hooks/secret-guard-pretool.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" bun \"${CLAUDE_PLUGIN_ROOT}/hooks/secret-guard-pretool.mjs\"",
             "timeout": 10
           }
         ]
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" node \"${CLAUDE_PLUGIN_ROOT}/hooks/sentinel-reply-guard-pretool.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" bun \"${CLAUDE_PLUGIN_ROOT}/hooks/sentinel-reply-guard-pretool.mjs\"",
             "timeout": 5
           }
         ]
@@ -25,7 +25,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" node \"${CLAUDE_PLUGIN_ROOT}/hooks/subagent-tracker-pretool.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" bun \"${CLAUDE_PLUGIN_ROOT}/hooks/subagent-tracker-pretool.mjs\"",
             "timeout": 10
           }
         ]
@@ -34,7 +34,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" node \"${CLAUDE_PLUGIN_ROOT}/hooks/tool-label-pretool.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" bun \"${CLAUDE_PLUGIN_ROOT}/hooks/tool-label-pretool.mjs\"",
             "timeout": 5
           }
         ]
@@ -44,7 +44,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" node \"${CLAUDE_PLUGIN_ROOT}/hooks/repo-context-pretool.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" bun \"${CLAUDE_PLUGIN_ROOT}/hooks/repo-context-pretool.mjs\"",
             "timeout": 5
           }
         ]
@@ -56,7 +56,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" node \"${CLAUDE_PLUGIN_ROOT}/hooks/subagent-tracker-posttool.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" bun \"${CLAUDE_PLUGIN_ROOT}/hooks/subagent-tracker-posttool.mjs\"",
             "timeout": 10
           }
         ]
@@ -66,7 +66,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" node \"${CLAUDE_PLUGIN_ROOT}/hooks/sandbox-hint-posttool.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" bun \"${CLAUDE_PLUGIN_ROOT}/hooks/sandbox-hint-posttool.mjs\"",
             "timeout": 3
           }
         ]
@@ -77,7 +77,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" node \"${CLAUDE_PLUGIN_ROOT}/hooks/compaction-marker-precompact.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" bun \"${CLAUDE_PLUGIN_ROOT}/hooks/compaction-marker-precompact.mjs\"",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" node \"${CLAUDE_PLUGIN_ROOT}/hooks/secret-scrub-stop.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" bun \"${CLAUDE_PLUGIN_ROOT}/hooks/secret-scrub-stop.mjs\"",
             "timeout": 15,
             "async": true
           }
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" node \"${CLAUDE_PLUGIN_ROOT}/hooks/silent-end-interrupt-stop.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" bun \"${CLAUDE_PLUGIN_ROOT}/hooks/silent-end-interrupt-stop.mjs\"",
             "timeout": 5
           }
         ]
@@ -107,7 +107,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" node \"${CLAUDE_PLUGIN_ROOT}/hooks/dispatch-claim-stop.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" bun \"${CLAUDE_PLUGIN_ROOT}/hooks/dispatch-claim-stop.mjs\"",
             "timeout": 5
           }
         ]
@@ -116,7 +116,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" node \"${CLAUDE_PLUGIN_ROOT}/hooks/tool-label-stop.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" bun \"${CLAUDE_PLUGIN_ROOT}/hooks/tool-label-stop.mjs\"",
             "timeout": 5,
             "async": true
           }

--- a/tests/reconcile-hooks-drift.test.ts
+++ b/tests/reconcile-hooks-drift.test.ts
@@ -416,6 +416,44 @@ c.commit(); c.close()
     expect(fgHogEntry?.matcher).toBe("^Bash$");
   });
 
+  it("runs telegram-plugin .mjs hooks under bun and bundled .mjs hooks under node", () => {
+    // The live hook runtime is settings.json (this block), NOT the plugin's
+    // hooks.json (that mirror is only loaded via --plugin-dir). The telegram-
+    // plugin hooks under /opt/switchroom/telegram-plugin/hooks run under bun
+    // to halve interpreter boot (each proven byte-identical to node). The
+    // bundled hooks under /opt/switchroom/hooks are esbuild output outside
+    // that equivalence proof and deliberately stay on node. Pin both so the
+    // split can't silently drift.
+    const result = buildSettingsHooksBlock({
+      agentName: "runtime-split-agent",
+      agentConfig: makeAgentConfig({ plugin: "switchroom-telegram" }),
+      hindsightEnabled: true,
+      useSwitchroomPlugin: true,
+    });
+    const allCmds: string[] = [];
+    for (const groups of Object.values(result)) {
+      for (const g of (groups as Array<{ hooks: Array<{ command: string }> }>)) {
+        for (const h of g.hooks) allCmds.push(h.command);
+      }
+    }
+    const pluginHookCmds = allCmds.filter((c) =>
+      c.includes("/opt/switchroom/telegram-plugin/hooks/") && c.includes(".mjs"),
+    );
+    const bundledHookCmds = allCmds.filter((c) =>
+      c.includes("/opt/switchroom/hooks/") && c.includes(".mjs"),
+    );
+    expect(pluginHookCmds.length).toBeGreaterThan(0);
+    expect(bundledHookCmds.length).toBeGreaterThan(0);
+    for (const c of pluginHookCmds) {
+      // wrapped: bash run-hook.sh '<source>' bun "<path>.mjs"
+      expect(c).toMatch(/'\s*bun\s+"\/opt\/switchroom\/telegram-plugin\/hooks\//);
+      expect(c).not.toMatch(/\bnode\s+"\/opt\/switchroom\/telegram-plugin\/hooks\//);
+    }
+    for (const c of bundledHookCmds) {
+      expect(c).toMatch(/\bnode\s+"\/opt\/switchroom\/hooks\//);
+    }
+  });
+
   it("with user hooks declared merges them with switchroom-owned hooks", () => {
     const agentConfig = makeAgentConfig({
       hooks: {

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -5311,11 +5311,15 @@ describe("secret-detect hook wiring", () => {
     expect(pre).toBeDefined();
     const commands = pre.flatMap((e) => e.hooks).map((h) => h.command);
     expect(commands.some((c) => c.includes("secret-guard-pretool.mjs"))).toBe(true);
-    // Ends in .mjs and the inner command uses node (wrapped via run-hook.sh
-    // so the line begins with `bash <wrapper>` then `<source>` then `node ...`).
+    // Ends in .mjs and the inner command uses bun (wrapped via run-hook.sh
+    // so the line begins with `bash <wrapper>` then `<source>` then `bun ...`).
     const guardCmd = commands.find((c) => c.includes("secret-guard-pretool.mjs"))!;
     expect(guardCmd).toMatch(/run-hook\.sh/);
-    expect(guardCmd).toContain("node ");
+    // Plugin .mjs hooks run under bun (halved interpreter boot); the swap is
+    // proven byte-identical to node, secret-guard included. Bundled hooks
+    // (asserted elsewhere) stay on node.
+    expect(guardCmd).toContain("bun ");
+    expect(guardCmd).not.toContain("node ");
   });
 
   it("wires secret-scrub-stop.mjs into settings.json Stop when plugin is switchroom", () => {

--- a/tests/telegram-plugin-manifest.test.ts
+++ b/tests/telegram-plugin-manifest.test.ts
@@ -127,6 +127,32 @@ describe("telegram-plugin manifest (#229)", () => {
     }
   });
 
+  it("all hooks.json plugin .mjs hooks run under bun, never node", () => {
+    // The plugin's .mjs hooks are invoked under bun to halve interpreter
+    // boot per hook (proven byte-identical to node, secret-guard included).
+    // hooks.json is the plugin-system mirror of the scaffold-written
+    // settings.json commands (they MUST agree, #1811); pin the runtime so
+    // the mirror can't silently drift back to node.
+    const path = join(REPO_ROOT, "telegram-plugin", "hooks", "hooks.json");
+    const m = JSON.parse(readFileSync(path, "utf-8")) as {
+      hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+    };
+    const allCommands: string[] = [];
+    for (const eventGroups of Object.values(m.hooks)) {
+      for (const group of eventGroups) {
+        for (const h of group.hooks) allCommands.push(h.command);
+      }
+    }
+    // Every command runs a .mjs via run-hook.sh; the interpreter token must
+    // be bun. Match the exact `run-hook.sh" bun "` shape the commands use.
+    expect(allCommands.length).toBeGreaterThan(0);
+    for (const c of allCommands) {
+      expect(c).toContain(".mjs");
+      expect(c).toContain('run-hook.sh" bun "');
+      expect(c).not.toContain('run-hook.sh" node "');
+    }
+  });
+
   it("subagent-tracker hooks gate on Agent or Task (regex matcher)", () => {
     // Pre-#262: matcher was the literal "Agent". Post-fix: regex
     // covering both `Agent` and `Task` for Claude Code version


### PR DESCRIPTION
## What

Swap the interpreter for the **telegram-plugin `.mjs` hooks** from `node` to `bun`. bun already ships in the base image (`docker/Dockerfile.base` "Phase 1b", pinned + sha-verified) and is the runtime for the gateway/scheduler/autoaccept sidecars.

## Why

Hooks run **in parallel** on every tool call / turn boundary, so per-call latency is the *slowest* hook, not the sum. Roughly half of a ~40ms hook is fixed **node interpreter cold-start**. bun's cold-start is ~half node's, so this halves that fixed cost per hook — with no functional change.

## Scope

- **Live path:** `src/agents/scaffold.ts` `buildSettingsHooksBlock()` — this writes each agent's `settings.json`, which is what Claude Code actually reads at runtime. 12 hook invocations swapped `node` -> `bun`.
- **Mirror:** `telegram-plugin/hooks/hooks.json` — the plugin-system view that must agree with the scaffold (#1811). Same 12 hooks swapped.
- **Out of scope (stay on node):** the bundled esbuild hooks under `DOCKER_BUNDLED_HOOKS_PATH` (`/opt/switchroom/hooks`) — not covered by the equivalence proof, deliberately unchanged (8 invocations).

## HARD GATE — byte-identical bun vs node (all 13 telegram-plugin hooks)

Each hook was fed representative payloads and its **stdout / exit / side-effects** compared under `node` vs `bun`:

| Hook | Result |
|---|---|
| `secret-guard-pretool` (**SECURITY**) | fail-closed BLOCK JSON **identical** (fake-broker allow + block cases) |
| `secret-scrub-stop` (**SECURITY**) | scrubbed output + `.bak` side-effect **identical** |
| `subagent-tracker-pretool` / `-posttool` | SQLite rows + schema written **identical** (bun uses the `bun:sqlite` adapter; node emits an incidental `ExperimentalWarning: SQLite` on **stderr** only — no behavioural difference) |
| `wedge-detect-posttool` | 4 cases **identical** |
| `sentinel-reply-guard-pretool`, `tool-label-pretool`/`-stop`, `repo-context-pretool`, `sandbox-hint-posttool`, `silent-end-interrupt-stop`, `dispatch-claim-stop`, `compaction-marker-precompact` | stdout + exit **identical** |

The only observed divergence is incidental node-only stderr noise (the SQLite experimental warning); the guaranteed behaviour (stdout, exit code, file/DB side-effects) is byte-identical everywhere. **secret-guard and secret-scrub are byte-identical and therefore land.**

## Tests

- `tests/telegram-plugin-manifest.test.ts` — asserts every hooks.json `.mjs` command runs `run-hook.sh" bun "`, never `node`.
- `tests/reconcile-hooks-drift.test.ts` — drives `buildSettingsHooksBlock`: telegram-plugin hooks run under bun, bundled hooks stay under node.
- `tests/scaffold.test.ts` — the reply-guard command uses bun, not node.
- Full `npm run lint` + `tsc --noEmit` green (incl. `check-plugin-references` mirror guard, `check-test-runner-coverage`).

## Note on the task premise

The task framed this as "edit hooks.json / the runner shim". Reading the source, the **live** hook invocation for the telegram plugin is `scaffold.ts`'s `buildSettingsHooksBlock` -> per-agent `settings.json`; `hooks.json` is a dormant mirror (loaded only via `--plugin-dir`). Both are swapped so the effective change lands **and** the mirror can't drift; the mirror guard enforces agreement.

DO NOT MERGE yet (per request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)