### PR TITLE
docs(docker): correct stale bun comment in agent base image

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -190,8 +190,10 @@ RUN mkdir -p /etc/claude-code \
 # napi-ffi (a separate slice with its own surface-area review), we ship
 # the bun runtime alongside node in every server image and invoke
 # broker / kernel-server with `bun` instead of `node`. Agent containers
-# don't run bun — they shell out to claude (via tmux) which has its
-# own runtime.
+# ALSO ship and depend on bun: the telegram-plugin `.mjs` hooks —
+# including the secret-guard PreToolUse and secret-scrub Stop security
+# hooks — run under bun. Do NOT strip bun from the agent image, or those
+# hooks fail open (the PreToolUse secret guard silently stops firing).
 # Pin the bun version AND verify the download by sha256 so a
 # `docker build` next month produces the same runtime as today, and
 # a compromised bun.sh / GitHub mirror can't slip a different binary


### PR DESCRIPTION
## What

Comment-only fix in `docker/Dockerfile.base` (Phase 1b, bun install block).

The existing comment claimed:

> Agent containers don't run bun — they shell out to claude (via tmux) which has its own runtime.

That is now false and dangerous. Since PR #4456 moved 12 telegram-plugin `.mjs` hooks (including the **secret-guard** PreToolUse and **secret-scrub** Stop security hooks) from node to bun, the agent image both ships and depends on bun. A maintainer trusting the stale comment could strip bun from the agent image and silently **fail-open** the PreToolUse secret guard.

## Change

Corrected the comment to state the agent image ships and depends on bun, and that stripping it fails the security hooks open. No build steps changed — comment text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)