### PR TITLE
feat(doctor): live-state alarm when hindsight runs CPU-only on a GPU host

### DIFF
--- a/src/cli/doctor-hindsight-gpu.test.ts
+++ b/src/cli/doctor-hindsight-gpu.test.ts
@@ -1,0 +1,83 @@
+/**
+ * `switchroom doctor` — the live-container hindsight GPU drift row (#4459).
+ *
+ * The decision table itself is exhaustively covered in
+ * `src/setup/hindsight-gpu-drift.test.ts`. This file pins the doctor ADAPTER:
+ * that the assessment's status/detail/fix become a well-formed `CheckResult`,
+ * and that the `hindsight.gpu` pin is read off the config into the fix text.
+ */
+
+import { describe, it, expect } from "vitest";
+import { checkHindsightGpuLiveState } from "./doctor-hindsight-gpu.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+import type { GpuCapabilities } from "../setup/gpu-detect.js";
+import type { HostCapabilitiesRead } from "../setup/host-capabilities.js";
+import type { HindsightDeviceRequest } from "../setup/hindsight.js";
+
+const CONFIG = { agents: {} } as unknown as SwitchroomConfig;
+const CONFIG_GPU_PINNED = { agents: {}, hindsight: { gpu: true } } as unknown as SwitchroomConfig;
+
+const usableProbe: GpuCapabilities = {
+  gpuPresent: true,
+  containerToolkit: true,
+  engine: "local",
+  reason: "GPU detected — voice will run locally (free, private, on-device).",
+};
+
+const okVerdict: HostCapabilitiesRead = {
+  status: "ok",
+  path: "/home/x/.switchroom/host-capabilities.json",
+  caps: {
+    version: 1,
+    voice: { gpuPresent: true, containerToolkit: true, engine: "local", detectedAt: "2026-06-30T00:00:00.000Z" },
+  },
+  detail: "",
+};
+
+const GPUS_ALL: HindsightDeviceRequest[] = [
+  { Driver: "", Count: -1, DeviceIDs: null, Capabilities: [["gpu"]] },
+];
+
+describe("checkHindsightGpuLiveState", () => {
+  it("FAILs — a usable GPU host serving a CPU-only container", () => {
+    const r = checkHindsightGpuLiveState(CONFIG, {
+      probe: () => usableProbe,
+      capsRead: () => okVerdict,
+      deviceRequests: () => [],
+    });
+    expect(r.name).toBe("hindsight GPU (live container)");
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("USABLE GPU");
+    expect(r.fix).toContain("--recreate");
+  });
+
+  it("is OK when the container has GPU passthrough", () => {
+    const r = checkHindsightGpuLiveState(CONFIG, {
+      probe: () => usableProbe,
+      capsRead: () => okVerdict,
+      deviceRequests: () => GPUS_ALL,
+    });
+    expect(r.status).toBe("ok");
+    expect(r.fix).toBeUndefined();
+  });
+
+  it("stays OK — never false-alarms — when the container cannot be read (docker down)", () => {
+    const r = checkHindsightGpuLiveState(CONFIG, {
+      probe: () => usableProbe,
+      capsRead: () => okVerdict,
+      deviceRequests: () => null,
+    });
+    expect(r.status).toBe("ok");
+    expect(r.fix).toBeUndefined();
+  });
+
+  it("reads the hindsight.gpu pin into the fix wording", () => {
+    const r = checkHindsightGpuLiveState(CONFIG_GPU_PINNED, {
+      probe: () => usableProbe,
+      capsRead: () => okVerdict,
+      deviceRequests: () => [],
+    });
+    expect(r.status).toBe("fail");
+    expect(r.fix).toContain("already set");
+  });
+});

--- a/src/cli/doctor-hindsight-gpu.ts
+++ b/src/cli/doctor-hindsight-gpu.ts
@@ -1,0 +1,62 @@
+/**
+ * `switchroom doctor` — the live-state hindsight GPU drift check.
+ *
+ * `checkHostCapabilitiesReadable` (in `doctor.ts`) inspects the caps FILE:
+ * what a future recreate would DECIDE. This check inspects the LIVE
+ * `switchroom-hindsight` container's actual device state and compares it
+ * against what the host can actually do. It is the standing counterpart to the
+ * recreate-time drop guard (`hindsight-gpu-guard.ts`) — the incident that
+ * motivated it (issue #4459) had a green doctor while hindsight served CPU-only
+ * recalls on a GPU host, precisely because nothing looked at the running
+ * container.
+ *
+ * The decision logic lives in `src/setup/hindsight-gpu-drift.ts` so the nightly
+ * fleet-health sensor and this check share one assessment and cannot drift.
+ */
+
+import type { SwitchroomConfig } from "../config/schema.js";
+import type { CheckStatus } from "./doctor-status.js";
+import {
+  runHindsightGpuDriftAssessment,
+  type HindsightGpuDriftDeps,
+} from "../setup/hindsight-gpu-drift.js";
+
+/** Structurally identical to `doctor.ts`'s `CheckResult` (each doctor module
+ *  declares its own to avoid a circular import back into `doctor.ts`). */
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+/**
+ * Assess whether the live hindsight container is running CPU-only on a
+ * GPU-capable host.
+ *
+ * - **fail** — the host has a PROVABLY usable GPU (nvidia-smi + the nvidia
+ *   container runtime) but the running container requests no devices.
+ * - **warn** — the persisted verdict records a usable GPU but the live probe
+ *   could not confirm it, and the container is CPU-only.
+ * - **ok** — they agree (GPU host + GPU container, or a genuine no-GPU host +
+ *   CPU container), OR the container state could not be read (no container /
+ *   docker down) — a "could not tell" never false-alarms.
+ *
+ * @internal exported for testing
+ */
+export function checkHindsightGpuLiveState(
+  config: SwitchroomConfig,
+  deps?: HindsightGpuDriftDeps,
+): CheckResult {
+  const gpuPinned =
+    typeof config.hindsight?.gpu === "boolean" ? config.hindsight.gpu : undefined;
+
+  const assessment = runHindsightGpuDriftAssessment({ gpuPinned, deps });
+
+  return {
+    name: "hindsight GPU (live container)",
+    status: assessment.status,
+    detail: assessment.detail,
+    ...(assessment.fix ? { fix: assessment.fix } : {}),
+  };
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -59,6 +59,7 @@ import { checkAgentRecallHealth } from "./doctor-recall-health.js";
 import { checkHnswPartialIndexes } from "./doctor-hnsw-index.js";
 import { checkObservationScopeSaturation } from "./doctor-observation-scopes.js";
 import { checkHindsightWatchArmed } from "./doctor-hindsight-watch.js";
+import { checkHindsightGpuLiveState } from "./doctor-hindsight-gpu.js";
 import { checkConfigRepo } from "./doctor-config-repo.js";
 import { runLitellmModelChecks } from "../litellm/model-validation.js";
 import { runLitellmKeyAllowlistChecks } from "../litellm/key-allowlist-check.js";
@@ -1758,6 +1759,14 @@ async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> 
   // an unparseable URL) is exactly when an operator is reading doctor output,
   // and the verdict file is a plausible reason the container came back wrong.
   results.push(checkHostCapabilitiesReadable(config));
+
+  // Live-state counterpart to the row above: that one reads the caps FILE (what
+  // a future recreate would decide); this one reads the RUNNING container's
+  // actual device state and FAILs loudly when a usable GPU sits idle while
+  // hindsight serves CPU-only recalls (issue #4459). Also pushed before the URL
+  // parse / reachability early-returns — a CPU-only container is a plausible
+  // reason recalls got slow, which is exactly when doctor is being read.
+  results.push(checkHindsightGpuLiveState(config));
 
   // Parse host and port out of the URL
   const match = url.match(/^https?:\/\/([^:/]+):?(\d+)?/);

--- a/src/fleet-health/detect.ts
+++ b/src/fleet-health/detect.ts
@@ -105,7 +105,13 @@ export type GatewaySignal =
  *  invariant it guards is violated. */
 export type SensorSignal =
   | "litellm-header-passthrough-misconfig"
-  | "litellm-timeout-budget-drift";
+  | "litellm-timeout-budget-drift"
+  // The live `switchroom-hindsight` container is running CPU-only
+  // (`HostConfig.DeviceRequests` empty) while the host has a PROVABLY usable
+  // GPU (nvidia-smi + the nvidia container runtime). Reranker + local
+  // embeddings fall to CPU on the interactive recall path — the 2026-07-28
+  // incident (#4459) that no green doctor caught.
+  | "hindsight-gpu-cpu-on-gpu-host";
 
 export type L0Signal = TurnSignal | GatewaySignal | SensorSignal;
 

--- a/src/fleet-health/hindsight-gpu-drift-sensor.test.ts
+++ b/src/fleet-health/hindsight-gpu-drift-sensor.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Fleet Health — the hindsight GPU drift sensor (#4459).
+ *
+ * The core decision table lives in `src/setup/hindsight-gpu-drift.test.ts`.
+ * This file pins the SENSOR contract: a PROVABLE CPU-on-GPU-host drift emits
+ * exactly one ledger-bound `Finding`; the unconfirmable WARN case and the
+ * agreement/could-not-tell cases emit NONE (they must not open a nightly
+ * GitHub issue).
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { scanHindsightGpuDrift, HINDSIGHT_PSEUDO_AGENT } from "./hindsight-gpu-drift-sensor.js";
+import { SIGNAL_MAP } from "./mapping.js";
+import type { GpuCapabilities } from "../setup/gpu-detect.js";
+import type { HostCapabilitiesRead } from "../setup/host-capabilities.js";
+import type { HindsightDeviceRequest } from "../setup/hindsight.js";
+
+const usableProbe: GpuCapabilities = {
+  gpuPresent: true,
+  containerToolkit: true,
+  engine: "local",
+  reason: "GPU detected — voice will run locally (free, private, on-device).",
+};
+const noGpuProbe: GpuCapabilities = {
+  gpuPresent: false,
+  containerToolkit: false,
+  engine: "cloud",
+  reason: "No GPU detected — voice will use cloud providers if you enable it.",
+};
+
+function verdict(gpuPresent: boolean, containerToolkit: boolean): HostCapabilitiesRead {
+  return {
+    status: "ok",
+    path: "/home/x/.switchroom/host-capabilities.json",
+    caps: {
+      version: 1,
+      voice: { gpuPresent, containerToolkit, engine: gpuPresent && containerToolkit ? "local" : "cloud", detectedAt: "2026-06-30T00:00:00.000Z" },
+    },
+    detail: "",
+  };
+}
+
+const GPUS_ALL: HindsightDeviceRequest[] = [
+  { Driver: "", Count: -1, DeviceIDs: null, Capabilities: [["gpu"]] },
+];
+
+describe("scanHindsightGpuDrift", () => {
+  it("emits ONE ledger finding on a provable CPU-on-GPU-host drift", () => {
+    const r = scanHindsightGpuDrift({
+      deps: { probe: () => usableProbe, capsRead: () => verdict(true, true), deviceRequests: () => [] },
+      nowIso: "2026-08-06T00:00:00.000Z",
+    });
+    expect(r.status).toBe("violation");
+    expect(r.findings).toHaveLength(1);
+    const f = r.findings[0];
+    expect(f.signal).toBe("hindsight-gpu-cpu-on-gpu-host");
+    expect(f.agent).toBe(HINDSIGHT_PSEUDO_AGENT);
+    expect(f.ts).toBe("2026-08-06T00:00:00.000Z");
+    expect(f.log_pointer).toContain("DeviceRequests");
+    // The signal must be mapped, or the ledger writer would throw on it.
+    expect(SIGNAL_MAP["hindsight-gpu-cpu-on-gpu-host"]).toBeDefined();
+    expect(SIGNAL_MAP["hindsight-gpu-cpu-on-gpu-host"].severity).toBe(3);
+  });
+
+  it("emits NO finding for the unconfirmable WARN case (verdict claims GPU, probe can't confirm)", () => {
+    const r = scanHindsightGpuDrift({
+      deps: { probe: () => noGpuProbe, capsRead: () => verdict(true, true), deviceRequests: () => [] },
+    });
+    expect(r.status).toBe("warn");
+    expect(r.findings).toHaveLength(0);
+  });
+
+  it("emits NO finding when host + container agree (GPU host, GPU container)", () => {
+    const r = scanHindsightGpuDrift({
+      deps: { probe: () => usableProbe, capsRead: () => verdict(true, true), deviceRequests: () => GPUS_ALL },
+    });
+    expect(r.status).toBe("ok");
+    expect(r.findings).toHaveLength(0);
+  });
+
+  it("emits NO finding when the container cannot be read (docker down / absent)", () => {
+    const r = scanHindsightGpuDrift({
+      deps: { probe: () => usableProbe, capsRead: () => verdict(true, true), deviceRequests: () => null },
+    });
+    expect(r.status).toBe("ok");
+    expect(r.findings).toHaveLength(0);
+  });
+
+  it("emits NO finding on a genuine no-GPU host running CPU-only", () => {
+    const r = scanHindsightGpuDrift({
+      deps: { probe: () => noGpuProbe, capsRead: () => verdict(false, false), deviceRequests: () => [] },
+    });
+    expect(r.status).toBe("ok");
+    expect(r.findings).toHaveLength(0);
+  });
+});

--- a/src/fleet-health/hindsight-gpu-drift-sensor.ts
+++ b/src/fleet-health/hindsight-gpu-drift-sensor.ts
@@ -1,0 +1,91 @@
+/**
+ * Fleet Health — hindsight GPU drift sensor.
+ *
+ * The nightly, no-one-looking counterpart to the `switchroom doctor` check
+ * (`src/cli/doctor-hindsight-gpu.ts`). Both route through the ONE assessment in
+ * `src/setup/hindsight-gpu-drift.ts`, so their verdicts cannot diverge.
+ *
+ * It emits a `Finding` (→ priority ledger → GitHub issue) ONLY for the FAIL
+ * case: a PROVABLY usable GPU (nvidia-smi + the nvidia container runtime) paired
+ * with a live container that requests no devices. That is the 2026-07-28
+ * incident (#4459) — CPU-only recalls on an idle GPU, missed by a green doctor.
+ *
+ * The WARN case (the persisted verdict records a GPU but the live probe cannot
+ * confirm it) is deliberately NOT escalated into the ledger: it is an
+ * unconfirmable conflict — a false-negative probe from a non-login `$PATH`, or a
+ * genuinely-absent GPU — and opening a severity-3 GitHub issue on it would cry
+ * wolf. Doctor still surfaces it interactively; only the provable degradation
+ * opens an issue. A "could not tell" about the container (no container / docker
+ * down) never produces a finding either.
+ *
+ * STRICTLY MODEL-FREE: a host probe, a caps-file read, one `docker inspect`.
+ * No LLM, no network.
+ */
+
+import type { Finding } from "./detect.js";
+import {
+  runHindsightGpuDriftAssessment,
+  type HindsightGpuDriftDeps,
+} from "../setup/hindsight-gpu-drift.js";
+
+/** The pseudo-agent the GPU-drift finding is attributed to. It names the shared
+ *  hindsight container, not a real switchroom agent, so the ledger's `reach`
+ *  and occurrence pointers read sensibly. `isTestAgent` never matches it, and
+ *  `runScan` injects it directly (not via the per-agent artifact loop), so it
+ *  never collides with an agent directory. */
+export const HINDSIGHT_PSEUDO_AGENT = "switchroom-hindsight";
+
+export interface HindsightGpuSensorOptions {
+  /** `hindsight.gpu` pin from switchroom.yaml, if set — shapes the fix text. */
+  gpuPinned?: boolean;
+  /** I/O seams (host probe / caps read / docker inspect). Injected by tests so
+   *  the suite never depends on a real GPU, container, or filesystem. */
+  deps?: HindsightGpuDriftDeps;
+  log?: (msg: string) => void;
+  /** Timestamp for the finding (ISO). Defaults to now. */
+  nowIso?: string;
+}
+
+export interface HindsightGpuSensorResult {
+  status: "ok" | "warn" | "violation";
+  findings: Finding[];
+}
+
+/**
+ * Run the hindsight GPU drift sensor. A provable CPU-on-GPU-host drift → one
+ * `Finding` attributed to the hindsight pseudo-agent, escalating into the
+ * ledger. Everything else (agreement, unconfirmable conflict, could-not-tell)
+ * → no finding, with a visible log line.
+ */
+export function scanHindsightGpuDrift(
+  opts: HindsightGpuSensorOptions = {},
+): HindsightGpuSensorResult {
+  const log = opts.log ?? (() => {});
+  const nowIso = opts.nowIso ?? new Date().toISOString();
+
+  const assessment = runHindsightGpuDriftAssessment({
+    gpuPinned: opts.gpuPinned,
+    deps: opts.deps,
+  });
+
+  if (assessment.status === "fail") {
+    log(`fleet-health: hindsight-gpu sensor VIOLATION — ${assessment.detail}`);
+    const finding: Finding = {
+      signal: "hindsight-gpu-cpu-on-gpu-host",
+      agent: HINDSIGHT_PSEUDO_AGENT,
+      turn_id: "hindsight-gpu:cpu-only-on-gpu-host",
+      log_pointer: `docker inspect ${HINDSIGHT_PSEUDO_AGENT} HostConfig.DeviceRequests — ${assessment.detail}`,
+      ts: nowIso,
+    };
+    return { status: "violation", findings: [finding] };
+  }
+
+  if (assessment.status === "warn") {
+    // Surfaced by doctor; NOT escalated into the nightly ledger (unconfirmable).
+    log(`fleet-health: hindsight-gpu sensor WARN (not ledgered) — ${assessment.detail}`);
+    return { status: "warn", findings: [] };
+  }
+
+  log(`fleet-health: hindsight-gpu sensor OK — ${assessment.detail}`);
+  return { status: "ok", findings: [] };
+}

--- a/src/fleet-health/ledger.test.ts
+++ b/src/fleet-health/ledger.test.ts
@@ -133,6 +133,14 @@ describe("runScan (I/O) — defensive over a synthetic fleet tree", () => {
         // dropped. Mirrors how detect.test.ts neutralizes the floor for
         // sub-floor fixtures. (prod CLI keeps the real floor — see fleet-health.ts)
         silentNoopFloorTs: 0,
+        // Hermeticity: fully stub the live-state hindsight GPU sensor so it
+        // neither shells out (docker/nvidia-smi) nor picks up a host-dependent
+        // finding. "could not tell" ⇒ always ok, no finding.
+        hindsightGpuDeps: {
+          probe: () => ({ gpuPresent: false, containerToolkit: false, engine: "cloud", reason: "test stub" }),
+          capsRead: () => ({ status: "absent", path: "/x", caps: null, detail: "" }),
+          deviceRequests: () => null,
+        },
       });
       expect(res.agentsSkipped).toContain("ghost");
       // clerk contributed a silent no-op + a duplicate delivery

--- a/src/fleet-health/mapping.ts
+++ b/src/fleet-health/mapping.ts
@@ -136,6 +136,19 @@ export const SIGNAL_MAP: Record<L0Signal, SignalMapping> = {
     job_spec: "fleet-stays-healthy",
     signature: "litellm-timeout-budget:tier-drift",
   },
+  "hindsight-gpu-cpu-on-gpu-host": {
+    // The live hindsight container is CPU-only on a host with a PROVABLY usable
+    // GPU. Classic `drift`: nothing errors, the container is "healthy", but the
+    // reranker and local embeddings run on CPU on the interactive recall path —
+    // 5-9s recalls with deadline hits. It ran undetected through a green doctor
+    // for an unknown length of time (#4459), which is exactly why it earns a
+    // standing nightly sensor. severity 3 — a real, measured recall-latency
+    // degradation of the whole memory layer, not an informational drift.
+    failure_mode: "drift",
+    severity: 3,
+    job_spec: "fleet-stays-healthy",
+    signature: "hindsight-gpu:cpu-only-on-gpu-host",
+  },
 };
 
 /** The full set of 23 job-spec slugs the ledger carries a record for. Kept

--- a/src/fleet-health/scan.ts
+++ b/src/fleet-health/scan.ts
@@ -26,6 +26,8 @@ import { scanAgent, type Finding, type AgentScanResult } from "./detect.js";
 import { buildLedger } from "./ledger.js";
 import { isTestAgent } from "./test-agents.js";
 import { scanLitellmConfig } from "./litellm-config-sensor.js";
+import { scanHindsightGpuDrift } from "./hindsight-gpu-drift-sensor.js";
+import type { HindsightGpuDriftDeps } from "../setup/hindsight-gpu-drift.js";
 
 /**
  * Resolve the `.switchroom` base dir, matching the read-side
@@ -51,6 +53,11 @@ export interface ScanOptions {
    *  Defaults to `LITELLM_CONFIG_PATH` env → the host-correct default. Exposed
    *  for tests; absent file → the sensor skips with a visible notice. */
   litellmConfigPath?: string;
+  /** I/O seams for the hindsight GPU-drift sensor (host probe / caps read /
+   *  docker inspect). Exposed for tests so the scan never depends on a real
+   *  GPU or a running container; absent → the sensor runs the real probes and
+   *  degrades to a no-op when docker/nvidia are unavailable. */
+  hindsightGpuDeps?: HindsightGpuDriftDeps;
 }
 
 export interface ScanResult {
@@ -151,6 +158,15 @@ export function runScan(opts: ScanOptions = {}): ScanResult {
   // agent finding.
   const litellm = scanLitellmConfig({ path: opts.litellmConfigPath, log });
   findings.push(...litellm.findings);
+
+  // Standalone live-state sensor: the hindsight container running CPU-only on a
+  // GPU host (#4459). Same division of labour as the litellm sensor — it runs
+  // where the scan runs (on-host, where docker + the GPU actually are), reads
+  // the LIVE container's device state, and escalates only a PROVABLE drift into
+  // the ledger. docker/nvidia unavailable → it degrades to a no-op, never a
+  // false finding. The doctor check is the interactive counterpart.
+  const gpuDrift = scanHindsightGpuDrift({ deps: opts.hindsightGpuDeps, log });
+  findings.push(...gpuDrift.findings);
 
   const prior = readLedgerIfPresent(base);
   const ledger = buildLedger(findings, {

--- a/src/fleet-health/test-agents.test.ts
+++ b/src/fleet-health/test-agents.test.ts
@@ -71,7 +71,17 @@ describe("runScan excludes test agents from the ledger", () => {
     makeAgent(base, "test-harness", Array(5).fill(ESCALATION_LINE));
     makeAgent(base, "marko", [ESCALATION_LINE]);
 
-    const res = runScan({ base });
+    // Hermeticity: fully stub the live-state hindsight GPU sensor so it neither
+    // shells out (docker/nvidia-smi) nor injects a host-dependent finding into
+    // this fixture scan. "could not tell" ⇒ always ok, no finding.
+    const res = runScan({
+      base,
+      hindsightGpuDeps: {
+        probe: () => ({ gpuPresent: false, containerToolkit: false, engine: "cloud", reason: "test stub" }),
+        capsRead: () => ({ status: "absent", path: "/x", caps: null, detail: "" }),
+        deviceRequests: () => null,
+      },
+    });
 
     expect(res.agentsExcluded).toContain("test-harness");
     expect(res.agentsScanned).toBe(1); // only marko

--- a/src/setup/hindsight-gpu-drift.test.ts
+++ b/src/setup/hindsight-gpu-drift.test.ts
@@ -1,0 +1,234 @@
+/**
+ * The live-state hindsight GPU drift assessment (issue #4459).
+ *
+ * The regression this guards: the `switchroom-hindsight` container ran CPU-only
+ * (`HostConfig.DeviceRequests: null`) on a host with a working RTX 3070 +
+ * nvidia-container-toolkit. Reranker + local embeddings fell to CPU, recalls
+ * hit 5-9s and the deadline, and `switchroom doctor` stayed GREEN — because
+ * nothing inspected the LIVE container's device state.
+ *
+ * Every cell of the decision table is pinned here, and each of the three
+ * load-bearing outcomes would independently have caught the incident:
+ *
+ *   1. a PROVABLY usable GPU + a provably CPU-only container ⇒ FAIL (loud);
+ *   2. a container we could NOT read (docker down / absent) ⇒ never alarms;
+ *   3. a caps verdict that says GPU but a probe that can't confirm ⇒ WARN,
+ *      not a false FAIL.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { GpuCapabilities } from "./gpu-detect.js";
+import type {
+  HostCapabilitiesRead,
+  HostCapabilities,
+} from "./host-capabilities.js";
+import type { HindsightDeviceRequest } from "./hindsight.js";
+import {
+  assessHindsightGpuDrift,
+  runHindsightGpuDriftAssessment,
+} from "./hindsight-gpu-drift.js";
+
+/** `--gpus all`, exactly as docker materialises it in HostConfig.DeviceRequests. */
+const GPUS_ALL: HindsightDeviceRequest[] = [
+  { Driver: "", Count: -1, DeviceIDs: null, Capabilities: [["gpu"]] },
+];
+
+/** A GPU probe result. Defaults to a fully usable GPU host. */
+function probe(over: Partial<GpuCapabilities> = {}): GpuCapabilities {
+  return {
+    gpuPresent: true,
+    containerToolkit: true,
+    engine: "local",
+    reason: "GPU detected — voice will run locally (free, private, on-device).",
+    ...over,
+  };
+}
+
+/** A host-capabilities read. Defaults to an `ok` verdict proving a usable GPU. */
+function capsRead(over: Partial<HostCapabilitiesRead> = {}): HostCapabilitiesRead {
+  const caps: HostCapabilities = {
+    version: 1,
+    voice: {
+      gpuPresent: true,
+      containerToolkit: true,
+      engine: "local",
+      detectedAt: "2026-06-30T00:00:00.000Z",
+    },
+  };
+  return {
+    status: "ok",
+    path: "/home/x/.switchroom/host-capabilities.json",
+    caps,
+    detail: "",
+    ...over,
+  };
+}
+
+/** A verdict `ok`-read but recording a specific pair of probe booleans. */
+function capsVerdict(gpuPresent: boolean, containerToolkit: boolean): HostCapabilitiesRead {
+  return capsRead({
+    caps: {
+      version: 1,
+      voice: {
+        gpuPresent,
+        containerToolkit,
+        engine: gpuPresent && containerToolkit ? "local" : "cloud",
+        detectedAt: "2026-06-30T00:00:00.000Z",
+      },
+    },
+  });
+}
+
+describe("assessHindsightGpuDrift — the decision table", () => {
+  it("FAILs when a provably usable GPU host runs a CPU-only container", () => {
+    const a = assessHindsightGpuDrift({
+      probe: probe(),
+      capsRead: capsRead(),
+      deviceRequests: [], // container exists, requests no devices
+    });
+    expect(a.status).toBe("fail");
+    expect(a.hostGpu).toBe("proven");
+    expect(a.container).toBe("cpu");
+    // The message must name the fix.
+    expect(a.fix).toBeDefined();
+    expect(a.fix).toContain("--recreate");
+    expect(a.fix).toContain("hindsight.gpu");
+  });
+
+  it("is OK when a GPU host runs a GPU container (agreement)", () => {
+    const a = assessHindsightGpuDrift({
+      probe: probe(),
+      capsRead: capsRead(),
+      deviceRequests: GPUS_ALL,
+    });
+    expect(a.status).toBe("ok");
+    expect(a.container).toBe("gpu");
+    expect(a.fix).toBeUndefined();
+  });
+
+  it("is OK (could-not-tell) when the container state is null — NO false alarm", () => {
+    // This is the docker-down / no-container case. A usable GPU host with an
+    // unreadable container MUST NOT fail — else doctor cries wolf every time the
+    // container is stopped.
+    const a = assessHindsightGpuDrift({
+      probe: probe(),
+      capsRead: capsRead(),
+      deviceRequests: null,
+    });
+    expect(a.status).toBe("ok");
+    expect(a.container).toBe("unknown");
+    expect(a.fix).toBeUndefined();
+  });
+
+  it("WARNs (not FAILs) when the caps verdict claims a GPU the probe can't confirm", () => {
+    // Live probe sees no usable GPU (e.g. nvidia-smi off a non-login $PATH),
+    // but the persisted verdict records one. CPU-only container → surface it,
+    // but do not open a provable-FAIL — the probe might be a false negative.
+    const a = assessHindsightGpuDrift({
+      probe: probe({ gpuPresent: false, containerToolkit: false, engine: "cloud", reason: "No GPU detected" }),
+      capsRead: capsVerdict(true, true),
+      deviceRequests: [],
+    });
+    expect(a.status).toBe("warn");
+    expect(a.hostGpu).toBe("suspected");
+    expect(a.fix).toBeDefined();
+  });
+
+  it("is OK when neither the probe nor the verdict proves a usable GPU (genuine no-GPU host)", () => {
+    const a = assessHindsightGpuDrift({
+      probe: probe({ gpuPresent: false, containerToolkit: false, engine: "cloud", reason: "No GPU detected" }),
+      capsRead: capsVerdict(false, false),
+      deviceRequests: [],
+    });
+    expect(a.status).toBe("ok");
+    expect(a.hostGpu).toBe("unproven");
+    expect(a.fix).toBeUndefined();
+  });
+
+  it("does NOT alarm on a GPU-present-but-no-toolkit host (passthrough impossible)", () => {
+    // A GPU with no container runtime cannot be passed in, so a CPU container is
+    // correct. Probe reports not-usable; the verdict also records toolkit=false.
+    const a = assessHindsightGpuDrift({
+      probe: probe({ containerToolkit: false, engine: "cloud", reason: "GPU detected but nvidia-container-toolkit isn't installed" }),
+      capsRead: capsVerdict(true, false),
+      deviceRequests: [],
+    });
+    expect(a.status).toBe("ok");
+    expect(a.hostGpu).toBe("unproven");
+  });
+
+  it("does NOT alarm when the caps read is DEGRADED (unreadable) and the probe can't prove GPU", () => {
+    // A degraded verdict is "could not tell", not "usable GPU". With no positive
+    // probe either, a CPU container must stay quiet — the degraded read has its
+    // own loud doctor row (`checkHostCapabilitiesReadable`).
+    const a = assessHindsightGpuDrift({
+      probe: probe({ gpuPresent: false, containerToolkit: false, engine: "cloud", reason: "No GPU detected" }),
+      capsRead: capsRead({ status: "unreadable", caps: null, code: "EACCES", detail: "EACCES: permission denied" }),
+      deviceRequests: [],
+    });
+    expect(a.status).toBe("ok");
+    expect(a.hostGpu).toBe("unproven");
+  });
+
+  it("still FAILs on a proven-usable probe even when the caps read is degraded", () => {
+    // The live probe is the strong signal; a degraded verdict does not soften a
+    // proven GPU + CPU container into a mere warning.
+    const a = assessHindsightGpuDrift({
+      probe: probe(),
+      capsRead: capsRead({ status: "unreadable", caps: null, code: "EACCES", detail: "EACCES: permission denied" }),
+      deviceRequests: [],
+    });
+    expect(a.status).toBe("fail");
+    expect(a.hostGpu).toBe("proven");
+  });
+
+  it("recognises `--gpus device=0` shape as a GPU container", () => {
+    const a = assessHindsightGpuDrift({
+      probe: probe(),
+      capsRead: capsRead(),
+      deviceRequests: [{ Driver: "nvidia", Count: 0, DeviceIDs: ["0"], Capabilities: null }],
+    });
+    expect(a.status).toBe("ok");
+    expect(a.container).toBe("gpu");
+  });
+
+  it("adapts the fix text when hindsight.gpu is already pinned true", () => {
+    const a = assessHindsightGpuDrift({
+      probe: probe(),
+      capsRead: capsRead(),
+      deviceRequests: [],
+      gpuPinned: true,
+    });
+    expect(a.status).toBe("fail");
+    // A pinned-true host that is still CPU-only needs a recreate, and the text
+    // should say the pin is already set.
+    expect(a.fix).toContain("already set");
+    expect(a.fix).toContain("--recreate");
+  });
+});
+
+describe("runHindsightGpuDriftAssessment — wires the injected probes", () => {
+  it("routes injected deps through the pure assessment (proven GPU + CPU container ⇒ FAIL)", () => {
+    const a = runHindsightGpuDriftAssessment({
+      deps: {
+        probe: () => probe(),
+        capsRead: () => capsRead(),
+        deviceRequests: () => [],
+      },
+    });
+    expect(a.status).toBe("fail");
+  });
+
+  it("degrades to OK when the container probe returns null (docker unavailable)", () => {
+    const a = runHindsightGpuDriftAssessment({
+      deps: {
+        probe: () => probe(),
+        capsRead: () => capsRead(),
+        deviceRequests: () => null,
+      },
+    });
+    expect(a.status).toBe("ok");
+    expect(a.container).toBe("unknown");
+  });
+});

--- a/src/setup/hindsight-gpu-drift.ts
+++ b/src/setup/hindsight-gpu-drift.ts
@@ -1,0 +1,258 @@
+/**
+ * Live-state GPU drift assessment for the hindsight container.
+ *
+ * The gap this closes (issue #4459, incident 2026-07-28..08-06): the
+ * `switchroom-hindsight` container ran CPU-only (`HostConfig.DeviceRequests:
+ * null`) on a host with a working RTX 3070 + nvidia-container-toolkit. The
+ * reranker and the local embedding model fell to CPU on the interactive recall
+ * path — recalls climbed to 5-9s and hit the deadline — and NOTHING detected
+ * it. `switchroom doctor` was green throughout, because its only GPU-related
+ * check (`checkHostCapabilitiesReadable`) inspects the caps FILE — what a
+ * FUTURE recreate would decide — and never the LIVE container's actual device
+ * state. Its "GPU not proven" branch returns `ok`, not a warning.
+ *
+ * The building blocks already existed but were only wired into the
+ * recreate-time drop guard (`hindsight-gpu-guard.ts`), never into a standing
+ * health check:
+ *   - {@link getHindsightDeviceRequests} / {@link deviceRequestsHaveGpu} read
+ *     and interpret the live container's `HostConfig.DeviceRequests`;
+ *   - {@link detectGpuCapabilities} probes the host (nvidia-smi + the nvidia
+ *     container runtime);
+ *   - {@link readHostCapabilities} corroborates with the persisted verdict,
+ *     keeping the "no GPU" vs "could not tell" distinction it was built for.
+ *
+ * This module is the cause-AGNOSTIC alarm: it compares what the host can
+ * actually do against what the running container actually has, and reports
+ * loudly when a usable GPU sits idle while hindsight serves CPU-only recalls —
+ * regardless of HOW the container ended up CPU-only (a stale hand `docker run`,
+ * an on-disk recreate script that dropped `--gpus all`, a slipped `--no-gpu`).
+ * It is consumed by both `switchroom doctor` (`doctor-hindsight-gpu.ts`) and
+ * the nightly fleet-health scan (`fleet-health/hindsight-gpu-drift-sensor.ts`).
+ */
+
+import { detectGpuCapabilities, type GpuCapabilities } from "./gpu-detect.js";
+import {
+  readHostCapabilities,
+  type HostCapabilitiesRead,
+} from "./host-capabilities.js";
+import {
+  deviceRequestsHaveGpu,
+  getHindsightDeviceRequests,
+  type HindsightDeviceRequest,
+} from "./hindsight.js";
+
+/** The default container name the drift check inspects. */
+export const HINDSIGHT_CONTAINER = "switchroom-hindsight";
+
+/** Severity of the drift verdict. Mirrors the doctor `CheckStatus` subset this
+ *  check can emit (it never `skip`s — a "could not tell" is a benign `ok`). */
+export type HindsightGpuDriftStatus = "ok" | "warn" | "fail";
+
+/**
+ * How confidently the host is known to offer USABLE GPU passthrough.
+ *
+ *   - `proven`    — the live probe confirmed BOTH an NVIDIA GPU (`nvidia-smi`)
+ *                   AND the nvidia container runtime (Docker can pass it in).
+ *                   This is the strong signal: a CPU-only container here is a
+ *                   provable degradation → FAIL.
+ *   - `suspected` — the live probe could NOT confirm usability this run, but
+ *                   the persisted capabilities verdict records a usable GPU
+ *                   (`gpuPresent && containerToolkit`). Either the GPU is
+ *                   genuinely unavailable now, or the probe cannot see it from
+ *                   this process (e.g. `nvidia-smi` off a non-login `$PATH`).
+ *                   A CPU-only container here is worth surfacing → WARN.
+ *   - `unproven`  — no positive evidence of a usable GPU from either source: a
+ *                   genuine no-GPU host, or one we simply cannot tell about. A
+ *                   CPU-only container here is expected → no alarm.
+ */
+export type HostGpuUsability = "proven" | "suspected" | "unproven";
+
+/**
+ * The live container's device state.
+ *
+ *   - `gpu`     — `HostConfig.DeviceRequests` carries an NVIDIA GPU.
+ *   - `cpu`     — the container exists and requests no devices (`[]`).
+ *   - `unknown` — could not tell: no container, docker unavailable, or an
+ *                 unparseable inspect ({@link getHindsightDeviceRequests}
+ *                 returned `null`). NEVER produces an alarm — a false positive
+ *                 here would cry wolf every time the container is down.
+ */
+export type LiveContainerGpu = "gpu" | "cpu" | "unknown";
+
+export interface HindsightGpuDriftAssessment {
+  status: HindsightGpuDriftStatus;
+  hostGpu: HostGpuUsability;
+  container: LiveContainerGpu;
+  /** One-line human explanation, operator-facing. */
+  detail: string;
+  /** How to fix it — present only for `warn`/`fail`. */
+  fix?: string;
+}
+
+/**
+ * The pure decision. All I/O (the host probe, the caps read, the docker
+ * inspect) is done by the caller and passed in, so this is fully hermetic and
+ * every cell of the decision table is unit-testable without a real GPU, a real
+ * container, or a real filesystem.
+ *
+ * Decision table (rows = host GPU usability, cols = live container state):
+ *
+ *   host \ container | gpu        | cpu            | unknown
+ *   -----------------+------------+----------------+-------------
+ *   proven           | ok (agree) | FAIL           | ok (degrade)
+ *   suspected        | ok (agree) | WARN           | ok (degrade)
+ *   unproven         | ok         | ok (expected)  | ok (degrade)
+ *
+ * The `unknown` column is always `ok`: a "could not tell" about the container
+ * must not manufacture a false alarm. The `gpu` column is always `ok`: the
+ * container has what the host can give. Only a provably/suspectedly usable GPU
+ * paired with a provably CPU-only container is loud.
+ */
+export function assessHindsightGpuDrift(args: {
+  probe: GpuCapabilities;
+  capsRead: HostCapabilitiesRead;
+  deviceRequests: HindsightDeviceRequest[] | null;
+  /** `hindsight.gpu` pin from switchroom.yaml, if the operator set one. Shapes
+   *  the fix text: a pinned-true host that is still CPU-only needs a recreate,
+   *  not a config edit. */
+  gpuPinned?: boolean;
+}): HindsightGpuDriftAssessment {
+  const { probe, capsRead, deviceRequests, gpuPinned } = args;
+
+  const probeUsable = probe.gpuPresent === true && probe.containerToolkit === true;
+  const voice = capsRead.status === "ok" ? capsRead.caps?.voice : undefined;
+  const capsUsable = voice?.gpuPresent === true && voice?.containerToolkit === true;
+
+  const hostGpu: HostGpuUsability = probeUsable
+    ? "proven"
+    : capsUsable
+      ? "suspected"
+      : "unproven";
+
+  const container: LiveContainerGpu =
+    deviceRequests === null
+      ? "unknown"
+      : deviceRequestsHaveGpu(deviceRequests)
+        ? "gpu"
+        : "cpu";
+
+  const probeNote = `host probe: ${probe.reason}`;
+  const capsNote =
+    capsRead.status === "ok"
+      ? `verdict: gpuPresent=${JSON.stringify(voice?.gpuPresent)}, ` +
+        `containerToolkit=${JSON.stringify(voice?.containerToolkit)}`
+      : `verdict: ${capsRead.status} (${capsRead.path})`;
+
+  // --- The `unknown` container column: could not tell. Never alarm. ---
+  if (container === "unknown") {
+    return {
+      status: "ok",
+      hostGpu,
+      container,
+      detail:
+        `could not read the live ${HINDSIGHT_CONTAINER} device state ` +
+        "(container absent, or docker unavailable) — GPU/CPU drift not evaluated. " +
+        probeNote,
+    };
+  }
+
+  // --- The `gpu` container column: the container has GPU. Agreement. ---
+  if (container === "gpu") {
+    return {
+      status: "ok",
+      hostGpu,
+      container,
+      detail:
+        `${HINDSIGHT_CONTAINER} is running WITH GPU passthrough ` +
+        "(HostConfig.DeviceRequests carries an NVIDIA GPU). " +
+        probeNote,
+    };
+  }
+
+  // --- The `cpu` container column: the container requests no devices. ---
+  if (hostGpu === "proven") {
+    return {
+      status: "fail",
+      hostGpu,
+      container,
+      detail:
+        `this host has a USABLE GPU (${probe.reason}) but ${HINDSIGHT_CONTAINER} ` +
+        "is running CPU-only (HostConfig.DeviceRequests is empty). The reranker and " +
+        "the local embedding model are on CPU on the interactive recall path — the " +
+        "exact degradation from the 2026-07-28 incident (recalls 5-9s, deadline hits).",
+      fix: driftFix(gpuPinned),
+    };
+  }
+
+  if (hostGpu === "suspected") {
+    return {
+      status: "warn",
+      hostGpu,
+      container,
+      detail:
+        `${HINDSIGHT_CONTAINER} is running CPU-only (HostConfig.DeviceRequests is ` +
+        "empty) and the persisted capabilities verdict records a usable GPU, but the " +
+        `live probe could not confirm it this run (${probe.reason}). Either the GPU is ` +
+        "genuinely unavailable now, or the probe cannot see it — confirm so recalls " +
+        `aren't silently on CPU. ${capsNote}.`,
+      fix: driftFix(gpuPinned),
+    };
+  }
+
+  // hostGpu === "unproven": no usable GPU proven anywhere. CPU is expected.
+  return {
+    status: "ok",
+    hostGpu,
+    container,
+    detail:
+      `${HINDSIGHT_CONTAINER} is CPU-only and no usable GPU is proven on this host ` +
+      `(${probe.reason}; ${capsNote}) — a CPU-only container is expected here.`,
+  };
+}
+
+/** The remediation line, shared by the WARN and FAIL cases. */
+function driftFix(gpuPinned?: boolean): string {
+  if (gpuPinned) {
+    return (
+      "`hindsight.gpu: true` is already set, so recreate the container to apply it: " +
+      "`switchroom memory setup --recreate` (the recreate emits `--gpus all`). If it " +
+      "keeps coming back CPU-only, a stale hand `docker run` or an on-disk recreate " +
+      "script is bypassing the GPU gate."
+    );
+  }
+  return (
+    "Recreate the container on GPU: set `hindsight.gpu: true` in switchroom.yaml, then " +
+    "`switchroom memory setup --recreate` (the recreate emits `--gpus all`)."
+  );
+}
+
+/** I/O seams for {@link runHindsightGpuDriftAssessment}. Each defaults to the
+ *  real probe; tests inject stubs so the suite never depends on a real GPU,
+ *  container, or capabilities file. */
+export interface HindsightGpuDriftDeps {
+  probe?: () => GpuCapabilities;
+  capsRead?: () => HostCapabilitiesRead;
+  deviceRequests?: () => HindsightDeviceRequest[] | null;
+}
+
+/**
+ * Wire the real probes and run {@link assessHindsightGpuDrift}. This is the
+ * single entry point both consumers (doctor + fleet-health) call, so the live
+ * behaviour cannot drift between them.
+ */
+export function runHindsightGpuDriftAssessment(
+  opts: { gpuPinned?: boolean; deps?: HindsightGpuDriftDeps } = {},
+): HindsightGpuDriftAssessment {
+  const deps = opts.deps ?? {};
+  const probe = (deps.probe ?? (() => detectGpuCapabilities()))();
+  const capsRead = (deps.capsRead ?? readHostCapabilities)();
+  const deviceRequests = (
+    deps.deviceRequests ?? (() => getHindsightDeviceRequests(HINDSIGHT_CONTAINER))
+  )();
+  return assessHindsightGpuDrift({
+    probe,
+    capsRead,
+    deviceRequests,
+    gpuPinned: opts.gpuPinned,
+  });
+}


### PR DESCRIPTION
## Summary

`switchroom doctor`'s only GPU-related check (`checkHostCapabilitiesReadable`) inspects the caps **file** — what a *future recreate* would decide — and never the **live** container's device state; its "GPU not proven" branch returns `ok`, not `warn`. So a genuinely CPU-only `switchroom-hindsight` on a GPU host reads **green**, exactly as it did in the 2026-07-28..08-06 incident: `HostConfig.DeviceRequests: null` on a host with a working RTX 3070 + nvidia-container-toolkit, reranker + local embeddings on CPU on the interactive recall path, recalls 5-9s hitting the deadline, nothing detecting it.

This adds a **cause-agnostic, live-state** alarm and wires it into BOTH `switchroom doctor` and the nightly `fleet-health` scan. It compares an independent host-GPU determination against the running container's actual `HostConfig.DeviceRequests`, reusing the building blocks that previously only fed the recreate-time drop guard (`getHindsightDeviceRequests` / `deviceRequestsHaveGpu`, `detectGpuCapabilities`, `readHostCapabilities`).

## Why

Cites job spec `reference/jobs/fleet-stays-healthy.md` — a live degradation of the whole memory layer that ran undetected through a green doctor is exactly the drift the fleet-health sensors exist to surface. Advances the "always available / gets better the longer they run" vision outcomes (fast recall is the memory layer working).

## Before → after doctor behavior

| Host GPU | Live container | Before (`checkHostCapabilitiesReadable` only) | After (new `hindsight GPU (live container)` row) |
|---|---|---|---|
| Provably usable (probe: nvidia-smi + nvidia runtime) | CPU-only (`DeviceRequests` empty) | **ok** (verdict "GPU proven") — the blind spot | **FAIL**, names the fix (recreate / `hindsight.gpu: true`) |
| Verdict records GPU, live probe can't confirm | CPU-only | ok | **WARN** (unconfirmable — probe false-negative vs GPU genuinely gone) |
| Usable GPU | GPU passthrough present | ok | **ok** (agreement) |
| Genuine no-GPU host | CPU-only | ok | **ok** (expected) |
| Any | container absent / docker down (`DeviceRequests` null) | ok | **ok** — a could-not-tell never false-alarms |

## Decision table (the shared assessment)

`assessHindsightGpuDrift` in `src/setup/hindsight-gpu-drift.ts` (rows = host GPU usability, cols = live container state):

```
host \ container | gpu        | cpu           | unknown
-----------------+------------+---------------+-------------
proven           | ok         | FAIL          | ok (degrade)
suspected        | ok         | WARN          | ok (degrade)
unproven         | ok         | ok (expected) | ok (degrade)
```

- **proven** = live probe confirms GPU **and** the nvidia container runtime.
- **suspected** = probe can't confirm, but the caps verdict records `gpuPresent && containerToolkit` (a degraded/unreadable verdict is NOT "suspected" — it's "could not tell", so it never alarms; that file has its own loud doctor row).
- **unknown container** (`getHindsightDeviceRequests` → `null`) is always `ok`.

Only the **FAIL** case escalates into the fleet-health ledger (→ GitHub issue). The **WARN** case is deliberately doctor-only: opening a sev-3 nightly issue on an unconfirmable probe conflict would cry wolf.

## Files changed

- `src/setup/hindsight-gpu-drift.ts` — new. The pure, hermetic assessment + a `runHindsightGpuDriftAssessment` wrapper that wires the real probes (the single entry point both consumers call, so they can't drift).
- `src/cli/doctor-hindsight-gpu.ts` — new. Doctor `CheckResult` adapter.
- `src/cli/doctor.ts` — register the row right after `checkHostCapabilitiesReadable` in `checkHindsight` (before the URL-parse / reachability early-returns).
- `src/fleet-health/hindsight-gpu-drift-sensor.ts` — new. Standalone live-state sensor emitting a `Finding` on the FAIL case.
- `src/fleet-health/detect.ts` — add the `hindsight-gpu-cpu-on-gpu-host` `SensorSignal`.
- `src/fleet-health/mapping.ts` — its `SIGNAL_MAP` entry (`drift`, severity 3, `fleet-stays-healthy`).
- `src/fleet-health/scan.ts` — run the sensor in `runScan` (with an injectable `hindsightGpuDeps` seam, matching the litellm sensor pattern).
- Tests: `hindsight-gpu-drift.test.ts` (12 — full decision table), `doctor-hindsight-gpu.test.ts` (4 — adapter), `hindsight-gpu-drift-sensor.test.ts` (5 — Finding emission), plus hermeticity stubs added to the two existing `runScan` tests (`ledger.test.ts`, `test-agents.test.ts`) so the new live probe can't make them host-dependent.

## Test plan / verification

- Scoped vitest, new + adjacent suites: **133 passed** (21 new). Each load-bearing outcome is asserted, not just exercised: proven-GPU + CPU-container ⇒ FAIL; container-null ⇒ stays ok (no false alarm); caps-claims-GPU + probe-can't-confirm ⇒ WARN not FAIL; degraded caps read ⇒ no alarm.
- `tsc --noEmit`: clean.
- `npm run lint`: clean (all guard scripts pass, incl. attribution + test-runner-coverage; `check-test-runner-coverage` sees the new vitest files as covered).
- Commit carries `Switchroom-Agent: klanker` / `Switchroom-Model: claude-opus-4-8`.

## Risk

Low. The doctor row and the sensor both degrade to a benign `ok`/no-op when docker or nvidia-smi are unavailable, so nothing new can fail off-host. The doctor row only runs when hindsight is enabled (inside `checkHindsight`). The probe adds two short `spawnSync`s (nvidia-smi, docker info, each 8s-capped) + one `docker inspect` to a doctor run.

## Deferred follow-up

- **Belt-and-suspenders CUDA-load confirmation** (issue #4459 item 4): even when `DeviceRequests` carries a GPU, torch can still have fallen back to CPU — the container's startup log emits `CrossEncoder ... device: cuda:0` / `Embeddings ... device: cuda`. Reading container logs from a doctor check is materially heavier (another `docker logs` shell-out + log parsing + a mock seam) and is a distinct concern from the `DeviceRequests` alarm, which catches the actual incident. Deferring to keep this PR single-concern; the assessment function is structured so a `cudaConfirmed` field can be layered on without changing the decision table. Tracked as a tight follow-up.

Closes #4459

🤖 Generated with [Claude Code](https://claude.com/claude-code)
