### PR TITLE
feat(litellm-pacer): token-aware pacing (PACE_MAX_TPM)

### DIFF
--- a/docker/litellm-pacer/README.md
+++ b/docker/litellm-pacer/README.md
@@ -55,12 +55,12 @@ preserved here unchanged:
 
 | Knob                   | Code default | Live deployment override (`docker-compose.yml`) |
 |------------------------|:------------:|:-----------------------------------------------:|
-| `PACE_MAX_CONCURRENCY` |      8       |                       16                        |
+| `PACE_MAX_CONCURRENCY` |      8       |                       64                        |
 | `PACE_MAX_RPM`         |      60      |                       90                        |
 | `PACE_MAX_RPS`         |      4       |                        6                        |
 | `PACE_MAX_WAIT_S`      |      20      |                       12                        |
 | `PACE_MAX_COOLDOWN_S`  |      60      |                       60                        |
-| `PACE_LEASE_TTL_S`     |     300      |                       300                       |
+| `PACE_LEASE_TTL_S`     |     300      |                       60                        |
 
 **Tuning the running fleet is the deployment's job, via env** — set/adjust the
 `PACE_*` vars in `docker-compose.yml` (or live via the same Redis keys). Do NOT
@@ -112,6 +112,69 @@ separate from this repo change):
 
 Until `PACE_COOLDOWN_HOLD=true` is set, the only active change vs. today is the
 absolute cap, which can only ever shorten a pathological (roughly >45s) wait.
+
+## Token-aware pacing (`PACE_MAX_TPM`)
+
+A **4th admission predicate**: a fleet-wide rolling ~60s **token** budget layered
+on top of the concurrency/RPM/RPS gates. Anthropic's per-minute burst ceiling is
+a token ceiling as much as a request ceiling — a handful of huge-context turns
+can 429 an account that the RPM gate would happily admit. `PACE_MAX_TPM` smooths
+that.
+
+**Disabled by default (`0`).** With `PACE_MAX_TPM=0` every bit of token logic is
+inert: the Lua predicate short-circuits, the estimator is never called, and the
+`litellm_pace:tokens` key is never written — so merging + redeploy is
+behaviour-neutral until the env is set at rollout. Production sets `1200000`.
+
+How it works:
+
+- **Admit-time estimate.** A cheap, dependency-free char-count estimator
+  (`_estimate_tokens`) reserves budget: input chars across messages / system /
+  tools divided by `PACE_TPM_CHARS_PER_TOKEN`, plus a bounded output reservation
+  (`min(max_tokens, PACE_TPM_OUTPUT_RESERVE)`), all scaled by `PACE_TPM_EST_MULT`.
+  It deliberately does NOT call `litellm.token_counter` (too slow on the hot
+  path) and NEVER raises — any error estimates 0.
+- **Rolling budget in Redis.** A HASH `litellm_pace:tokens` keyed by 10s bucket
+  (`floor(now/10)*10`); the rolling sum is the buckets newer than `now-60` (~7
+  live buckets). The admit Lua sums them, HDELs stale buckets as it walks, and
+  denies when `sum + est > PACE_MAX_TPM`. The predicate runs AFTER the RPS check
+  and BEFORE the lease/rate writes, so a token denial takes no slot.
+- **Single-oversized-request bypass.** A request whose own estimate already
+  meets/exceeds the whole budget could never satisfy `sum+est<=maxtpm` and would
+  burn the full wait ceiling every attempt — so it is admitted on its first
+  attempt (still recording its tokens) rather than being starved.
+- **Best-effort reconciliation.** Once real usage is known, the non-streaming
+  passthrough success handler and the router success hook HINCRBY the delta
+  (`actual - est`, may be negative; the Lua clamps the rolling sum at ≥0) into
+  the current bucket so the budget converges on real spend. **Streaming requests
+  keep their estimate** — the streaming wrapper is left byte-transparent
+  (no SSE parsing), an accepted, bounded imprecision.
+- **Observability.** `litellm_pace:tpm_denied` is INCR'd inside the Lua on a
+  token-caused denial ONLY (not concurrency/RPM/RPS/cooldown denials), so
+  operators can see whether the token gate is the thing throttling the fleet.
+
+Everything still **fails open**: a token gate that can't reach Redis, or a
+request that waits past the ceiling, proceeds unpaced (and its estimate is
+best-effort booked so the budget stays honest).
+
+| Knob                       | Code default | Rollout value | Meaning |
+|----------------------------|:------------:|:-------------:|---------|
+| `PACE_MAX_TPM`             |      0       |    1200000    | Rolling ~60s fleet-wide token budget. `0` disables the whole predicate (inert). `max(0, …)` so a negative can't invert the gate. |
+| `PACE_TPM_OUTPUT_RESERVE`  |     2048     |     2048      | Output tokens reserved per request in the estimate, and the CAP on a caller's `max_tokens` so one request can't reserve an unbounded slice. |
+| `PACE_TPM_CHARS_PER_TOKEN` |     4.0      |      4.0      | Char/token ratio for the input estimator. |
+| `PACE_TPM_EST_MULT`        |     1.0      |      1.0      | Safety multiplier on the whole per-request estimate. |
+| `PACE_TPM_CACHE_READ_WEIGHT`|    1.0      |      1.0      | Weight applied to cache-READ tokens during reconciliation (a value < 1 discounts them; 1.0 counts at par). |
+
+**Rollout env** (set alongside the existing live overrides in the deployed
+`docker-compose.yml`, then redeploy litellm — a gated ROLLOUT step, separate from
+this repo change):
+
+```yaml
+- 'PACE_MAX_TPM=1200000'
+```
+
+Until `PACE_MAX_TPM` is set to a positive value, the token predicate is fully
+inert and behaviour is identical to today.
 
 ## Sync / redeploy step
 

--- a/docker/litellm-pacer/custom_pacing.py
+++ b/docker/litellm-pacer/custom_pacing.py
@@ -35,6 +35,13 @@ LiteLLM v3's per-key reject-based limiter):
     PACE_LEASE_TTL_S — no leaked permanent slots).
   * Bounded global RATE: rolling 60s cap (PACE_MAX_RPM) + rolling 1s burst
     smoother (PACE_MAX_RPS).
+  * Bounded global TOKENS (PACE_MAX_TPM): a rolling ~60s fleet-wide token
+    budget as a 4th admission predicate, because Anthropic's per-minute burst
+    ceiling is a token ceiling as much as a request ceiling — a few huge-context
+    turns can 429 an account the RPM gate would admit. A cheap char-count
+    estimate reserves budget at admit; the non-streaming + router terminal paths
+    reconcile it to real usage. DISABLED by default (0) — fully inert until the
+    env is set at rollout, so the token logic is behaviour-neutral until then.
   * EXPLICIT LEASE RELEASE on the passthrough path. litellm exposes no
     callback that fires on a passthrough stream, and the one
     post_call_success_hook call site on the non-streaming passthrough path is
@@ -227,6 +234,33 @@ class _Cfg:
         "PACE_MODEL_GROUPS_EXCLUDE", "*-openrouter"
     )
 
+    # --- Token-aware pacing (PACE_MAX_TPM) -----------------------------------
+    # A 4th admission predicate: a fleet-wide rolling ~60s TOKEN budget, layered
+    # on top of the concurrency/RPM/RPS gates. Anthropic's per-minute burst
+    # ceiling is a token ceiling as much as a request ceiling — a handful of
+    # huge-context turns can 429 an account the RPM gate would happily admit.
+    # DISABLED BY DEFAULT (0): with MAX_TPM==0 every bit of token logic below is
+    # inert — the Lua predicate short-circuits, the estimator is never called,
+    # and the `litellm_pace:tokens` key is never written — so merging + redeploy
+    # is behaviour-neutral until the env is set at rollout (prod sets 1200000).
+    # max(0, …) so a negative env can't invert the gate.
+    MAX_TPM = max(0, _int_env("PACE_MAX_TPM", 0))
+    # Output tokens reserved per request in the estimate (the response is not yet
+    # known at admit time). Also the CAP on a caller-supplied max_tokens, so one
+    # request can never reserve an unbounded slice of the budget.
+    TPM_OUTPUT_RESERVE = _int_env("PACE_TPM_OUTPUT_RESERVE", 2048)
+    # Char/token ratio for the cheap, dependency-free input estimator. ~4 chars
+    # per token is the standard rough English ratio; conservative is fine because
+    # the estimate reconciles to real usage post-call.
+    TPM_CHARS_PER_TOKEN = _float_env("PACE_TPM_CHARS_PER_TOKEN", 4.0)
+    # Multiplier applied to the whole per-request estimate — safety headroom for
+    # the heuristic's under-count. 1.0 = trust the estimate as-is.
+    TPM_EST_MULT = _float_env("PACE_TPM_EST_MULT", 1.0)
+    # Weight applied to cache-READ tokens when reconciling to actual usage.
+    # Cache reads are far cheaper against the burst ceiling than fresh input; a
+    # weight < 1 discounts them. Default 1.0 = count them at par (conservative).
+    TPM_CACHE_READ_WEIGHT = _float_env("PACE_TPM_CACHE_READ_WEIGHT", 1.0)
+
     REDIS_HOST = os.getenv("REDIS_HOST", "redis")
     REDIS_PORT = _int_env("REDIS_PORT", 6379)
     REDIS_PASSWORD = os.getenv("REDIS_PASSWORD") or None
@@ -236,6 +270,15 @@ class _Cfg:
 _INFLIGHT_KEY = f"{_Cfg.KEY_PREFIX}:inflight"      # ZSET member=pace_id score=deadline
 _RECENT_KEY = f"{_Cfg.KEY_PREFIX}:recent"          # ZSET member=uuid score=ts (rolling window)
 _COOLDOWN_KEY = f"{_Cfg.KEY_PREFIX}:cooldown_until"  # STRING epoch seconds
+# HASH field=10s-bucket-start (floor(now/10)*10 as str) value=int tokens. The
+# rolling ~60s token sum is the fields whose bucket > now-60 (~7 live buckets);
+# the admit Lua HDELs older fields as it walks them and EXPIREs the key 120s so
+# a fully idle fleet drops the key entirely.
+_TOKENS_KEY = f"{_Cfg.KEY_PREFIX}:tokens"
+# Cheap observability counter: INCR'd inside the admit Lua on a token-caused
+# denial only (not concurrency/RPM/RPS/cooldown denials), so operators can see
+# whether the TOKEN gate is the thing throttling the fleet.
+_TPM_DENIED_KEY = f"{_Cfg.KEY_PREFIX}:tpm_denied"
 
 # Atomic admission. Redis runs a script to completion single-threaded, so the
 # trim -> count -> conditional-add sequence is race-free across all 8 proxy
@@ -245,6 +288,8 @@ _ADMIT_LUA = """
 local inflight = KEYS[1]
 local recent = KEYS[2]
 local cd = KEYS[3]
+local tokens = KEYS[4]
+local tpm_denied = KEYS[5]
 local now = tonumber(ARGV[1])
 local maxc = tonumber(ARGV[2])
 local maxrpm = tonumber(ARGV[3])
@@ -252,6 +297,8 @@ local maxrps = tonumber(ARGV[4])
 local lease = tonumber(ARGV[5])
 local pid = ARGV[6]
 local ruid = ARGV[7]
+local maxtpm = tonumber(ARGV[8])
+local est = tonumber(ARGV[9])
 local until_ = redis.call('GET', cd)
 if until_ and tonumber(until_) > now then return 0 end
 redis.call('ZREMRANGEBYSCORE', inflight, '-inf', now)
@@ -259,18 +306,165 @@ if redis.call('ZCARD', inflight) >= maxc then return 0 end
 redis.call('ZREMRANGEBYSCORE', recent, '-inf', now - 60)
 if redis.call('ZCARD', recent) >= maxrpm then return 0 end
 if tonumber(redis.call('ZCOUNT', recent, now - 1, '+inf')) >= maxrps then return 0 end
+-- (4th predicate) rolling ~60s TOKEN budget. Fully inert when maxtpm<=0.
+-- Placed AFTER the RPS check and BEFORE the ZADD writes so a token denial
+-- takes no concurrency/rate slot. Walks the bucket hash once: HDELs fields at
+-- or below now-60 (stale) and sums the rest.
+local cur_bucket = math.floor(now / 10) * 10
+if maxtpm > 0 then
+  local cutoff = now - 60
+  local sum = 0
+  local fields = redis.call('HGETALL', tokens)
+  for i = 1, #fields, 2 do
+    local b = tonumber(fields[i])
+    local v = tonumber(fields[i + 1])
+    if (b == nil) or (b <= cutoff) then
+      redis.call('HDEL', tokens, fields[i])
+    elseif v then
+      sum = sum + v
+    end
+  end
+  if sum < 0 then sum = 0 end
+  -- SINGLE-OVERSIZED-REQUEST BYPASS: a request whose OWN estimate already
+  -- meets/exceeds the whole budget can never satisfy sum+est<=maxtpm and would
+  -- burn the full wait ceiling on every attempt. Skip the sum check for it (it
+  -- still records its tokens + admits) so it is not permanently starved; the
+  -- budget check only gates requests that could plausibly fit.
+  if est < maxtpm then
+    if sum + est > maxtpm then
+      redis.call('INCR', tpm_denied)
+      return 0
+    end
+  end
+end
 redis.call('ZADD', inflight, now + lease, pid)
 redis.call('EXPIRE', inflight, lease + 60)
 redis.call('ZADD', recent, now, ruid)
 redis.call('EXPIRE', recent, 120)
+if maxtpm > 0 then
+  redis.call('HINCRBY', tokens, tostring(cur_bucket), est)
+  redis.call('EXPIRE', tokens, 120)
+end
 return 1
 """
+
+
+# --- Token estimation + accounting helpers (pure, module-level) ------------
+# All three NEVER raise: on ANY error they return 0 / None. They run on the hot
+# admit path, so they are deliberately dependency-free — no litellm.token_counter
+# (which imports a tokenizer and is far too slow here). A char/token heuristic is
+# good enough for a rolling admission budget that reconciles to real usage.
+
+
+def _token_bucket(now: float) -> int:
+    """The 10s bucket start for a timestamp: floor(now/10)*10. Never raises."""
+    try:
+        return int(now // 10) * 10
+    except Exception:
+        return 0
+
+
+def _estimate_tokens(data: Any) -> int:
+    """Cheap per-request token estimate for the admit budget. NEVER raises — any
+    error returns 0 (which simply doesn't contribute to the fleet budget).
+
+    Counts characters across messages (plain-string content AND content-block
+    lists), the system prompt, and the tools spec, divides by CHARS_PER_TOKEN
+    for the input estimate, adds a bounded output reservation, and scales by
+    EST_MULT. Content blocks: text blocks count their `text` length; an image
+    block counts a flat ~1600; any other block counts len(str(block))//4."""
+    try:
+        if not isinstance(data, dict):
+            return 0
+
+        def _block_chars(block: Any) -> int:
+            if isinstance(block, dict):
+                t = block.get("text")
+                if isinstance(t, str):
+                    return len(t)
+                if block.get("type") in ("image", "image_url"):
+                    return 1600
+                return len(str(block)) // 4
+            return len(str(block)) // 4
+
+        def _content_chars(content: Any) -> int:
+            if content is None:
+                return 0
+            if isinstance(content, str):
+                return len(content)
+            if isinstance(content, list):
+                return sum(_block_chars(b) for b in content)
+            return len(str(content))
+
+        chars = 0
+        messages = data.get("messages")
+        if isinstance(messages, list):
+            for msg in messages:
+                if isinstance(msg, dict):
+                    chars += _content_chars(msg.get("content"))
+                elif isinstance(msg, str):
+                    chars += len(msg)
+
+        system = data.get("system")
+        if system is not None:
+            chars += _content_chars(system)
+
+        tools = data.get("tools")
+        if tools:
+            chars += len(str(tools))
+
+        cpt = _Cfg.TPM_CHARS_PER_TOKEN or 4.0
+        est_in = int(chars / cpt)
+        reserve = _Cfg.TPM_OUTPUT_RESERVE
+        est_out = min(int(data.get("max_tokens") or reserve), reserve)
+        total = int((est_in + est_out) * _Cfg.TPM_EST_MULT)
+        return total if total > 0 else 0
+    except Exception:
+        return 0
+
+
+def _usage_actual_tokens(usage: dict) -> Optional[int]:
+    """Actual token count from an Anthropic/OpenAI-style usage dict:
+    input + cache_creation + output + cache_read*CACHE_READ_WEIGHT. Missing
+    fields contribute 0; a usage carrying NO recognised field returns None (so
+    reconciliation is skipped rather than adjusting by a bogus 0). NEVER raises."""
+    try:
+        if not isinstance(usage, dict):
+            return None
+        seen = False
+        total = 0.0
+
+        def _num(*keys: str) -> float:
+            nonlocal seen
+            for k in keys:
+                v = usage.get(k)
+                if isinstance(v, (int, float)) and not isinstance(v, bool):
+                    seen = True
+                    return float(v)
+            return 0.0
+
+        total += _num("input_tokens", "prompt_tokens")
+        total += _num("cache_creation_input_tokens", "cache_creation_tokens")
+        total += _num("output_tokens", "completion_tokens")
+        total += (
+            _num("cache_read_input_tokens", "cache_read_tokens")
+            * _Cfg.TPM_CACHE_READ_WEIGHT
+        )
+        if not seen:
+            return None
+        return int(total)
+    except Exception:
+        return None
 
 
 # Attribute/key name the lease id is pinned under, on every carrier that can
 # survive to a terminal path (request metadata, litellm_params.metadata, and
 # the per-request LiteLLMLoggingObj).
 _PACE_ATTR = "_pace_id"
+# Sibling attribute carrying the admit-time token ESTIMATE alongside the lease
+# id on the same carriers, so a terminal path can reconcile the budget against
+# the request's real usage.
+_PACE_TOK_ATTR = "_pace_tok_est"
 # Bound on the per-worker already-released LRU. Purely a Redis-round-trip
 # saver — ZREM is idempotent on its own — so any bound works; this one keeps
 # the dict trivially small for a long-lived proxy worker.
@@ -352,19 +546,23 @@ class FleetPacer(CustomLogger):
             base += random.uniform(0.0, _Cfg.RELEASE_JITTER_S)
         return base
 
-    async def _try_admit(self, r, pace_id: str) -> bool:
+    async def _try_admit(self, r, pace_id: str, est_tokens: int = 0) -> bool:
         """One ATOMIC admission attempt via Lua. Returns True if a
-        concurrency slot + rate window was granted (and the request
-        recorded). Never raises — on any Redis error it fails OPEN
-        (returns True) so the pacer can never wedge the fleet."""
+        concurrency slot + rate window + token budget was granted (and the
+        request recorded). `est_tokens` is the admit-time token estimate; it is
+        only consulted when PACE_MAX_TPM>0 (else the Lua predicate is inert).
+        Never raises — on any Redis error it fails OPEN (returns True) so the
+        pacer can never wedge the fleet."""
         now = time.time()
         try:
             result = await r.eval(
                 _ADMIT_LUA,
-                3,
+                5,
                 _INFLIGHT_KEY,
                 _RECENT_KEY,
                 _COOLDOWN_KEY,
+                _TOKENS_KEY,
+                _TPM_DENIED_KEY,
                 repr(now),
                 str(_Cfg.MAX_CONCURRENCY),
                 str(_Cfg.MAX_RPM),
@@ -372,12 +570,31 @@ class FleetPacer(CustomLogger):
                 str(_Cfg.LEASE_TTL_S),
                 pace_id,
                 uuid.uuid4().hex,
+                str(_Cfg.MAX_TPM),
+                str(int(est_tokens or 0)),
             )
             return int(result) == 1
         except Exception as e:
             verbose_proxy_logger.debug("custom_pacing: admit check error (fail open): %s", e)
             # On redis error, fail open by claiming admission.
             return True
+
+    async def _record_est_fail_open(self, r, est: int) -> None:
+        """When a request FAILS OPEN past the wait ceiling it was never recorded
+        in the token budget by the admit Lua (which only records on admit). Book
+        its estimate into the current bucket here so the fleet budget still
+        accounts for the tokens it is about to spend. Best-effort only: guarded
+        on MAX_TPM>0 and a positive estimate, and swallows every error."""
+        if not (_Cfg.MAX_TPM > 0 and est > 0):
+            return
+        try:
+            bucket = _token_bucket(time.time())
+            await r.hincrby(_TOKENS_KEY, str(bucket), int(est))
+            await r.expire(_TOKENS_KEY, 120)
+        except Exception as e:
+            verbose_proxy_logger.debug(
+                "custom_pacing: fail-open token record failed (non-load-bearing): %s", e
+            )
 
     async def _release(self, pace_id: Optional[str]) -> None:
         """Release a concurrency lease. IDEMPOTENT: ZREM of an absent member
@@ -464,6 +681,9 @@ class FleetPacer(CustomLogger):
             return data  # fail open
 
         pace_id = uuid.uuid4().hex
+        # Admit-time token estimate, computed ONCE before the wait loop. Fully
+        # skipped (and the estimator never consulted) when token pacing is off.
+        est = _estimate_tokens(data) if _Cfg.MAX_TPM > 0 else 0
         # Loop deadline math uses a MONOTONIC clock so a backward wall-clock/NTP
         # step can never extend a hold. (Redis cooldown_until stays wall-clock —
         # see _cooldown_remaining — and is never compared against these values.)
@@ -477,7 +697,7 @@ class FleetPacer(CustomLogger):
         admitted = False
         try:
             while True:
-                if await self._try_admit(r, pace_id):
+                if await self._try_admit(r, pace_id, est):
                     admitted = True
                     break
                 now = time.monotonic()
@@ -490,6 +710,9 @@ class FleetPacer(CustomLogger):
                         "custom_pacing: HARD wait cap %.1fs hit, admitting unpaced (fail open)",
                         _Cfg.HARD_MAX_WAIT_S,
                     )
+                    # Book the estimate: this request proceeds unpaced, so the
+                    # admit Lua never recorded it (best-effort, guarded inside).
+                    await self._record_est_fail_open(r, est)
                     break
                 # (2) Pick this iteration's regime ceiling:
                 #   * burst-smoothing (no active cooldown): the short MAX_WAIT_S
@@ -514,6 +737,9 @@ class FleetPacer(CustomLogger):
                         "cooldown-hold" if holding else "burst",
                         ceiling,
                     )
+                    # Book the estimate: this request proceeds unpaced, so the
+                    # admit Lua never recorded it (best-effort, guarded inside).
+                    await self._record_est_fail_open(r, est)
                     break
                 # (3) Bounded jittered backoff; jitter de-synchronizes the fleet
                 # so releases don't thunder (extra release jitter while holding).
@@ -522,13 +748,14 @@ class FleetPacer(CustomLogger):
             verbose_proxy_logger.debug("custom_pacing: pre_call error (fail open): %s", e)
 
         # Stash id so terminal paths can release the concurrency lease. Even
-        # if every carrier is lost, the lease self-heals via LEASE_TTL_S.
+        # if every carrier is lost, the lease self-heals via LEASE_TTL_S. The
+        # token estimate rides along on the same carriers for reconciliation.
         if admitted:
-            self._stash_pace_id(data, pace_id)
+            self._stash_pace_id(data, pace_id, est)
         return data
 
     @staticmethod
-    def _stash_pace_id(data: Any, pace_id: str) -> None:
+    def _stash_pace_id(data: Any, pace_id: str, est_tokens: int = 0) -> None:
         """Pin the lease id on every carrier that can survive to a terminal
         path.
 
@@ -548,15 +775,21 @@ class FleetPacer(CustomLogger):
             meta = data.setdefault("metadata", {})
             if isinstance(meta, dict):
                 meta[_PACE_ATTR] = pace_id
+                if est_tokens:
+                    meta[_PACE_TOK_ATTR] = int(est_tokens)
         except Exception:
             pass
         try:
             lobj = data.get("litellm_logging_obj")
             if lobj is not None:
                 setattr(lobj, _PACE_ATTR, pace_id)
+                if est_tokens:
+                    setattr(lobj, _PACE_TOK_ATTR, int(est_tokens))
                 mcd = getattr(lobj, "model_call_details", None)
                 if isinstance(mcd, dict):
                     mcd[_PACE_ATTR] = pace_id
+                    if est_tokens:
+                        mcd[_PACE_TOK_ATTR] = int(est_tokens)
         except Exception:
             pass
 
@@ -596,8 +829,146 @@ class FleetPacer(CustomLogger):
             pass
         return None
 
+    # ----- token reconciliation (best-effort, never load-bearing) ------
+    @staticmethod
+    def _tok_est_from_logging_obj(lobj: Any) -> Optional[int]:
+        """Sibling of _pace_id_from_logging_obj: recover the admit-time token
+        estimate pinned on the logging object / its model_call_details."""
+        if lobj is None:
+            return None
+        try:
+            v = getattr(lobj, _PACE_TOK_ATTR, None)
+            if isinstance(v, int) and not isinstance(v, bool):
+                return v
+            mcd = getattr(lobj, "model_call_details", None)
+            if isinstance(mcd, dict):
+                v = mcd.get(_PACE_TOK_ATTR)
+                if isinstance(v, int) and not isinstance(v, bool):
+                    return v
+        except Exception:
+            pass
+        return None
+
+    def _extract_tok_est(self, data: Any) -> Optional[int]:
+        """Sibling of _extract_pace_id: recover the admit-time token estimate
+        from whatever payload shape a terminal hook hands us. Never raises."""
+        try:
+            if not isinstance(data, dict):
+                return None
+            meta = data.get("metadata")
+            if isinstance(meta, dict):
+                v = meta.get(_PACE_TOK_ATTR)
+                if isinstance(v, int) and not isinstance(v, bool):
+                    return v
+            lp = data.get("litellm_params")
+            if isinstance(lp, dict):
+                lp_meta = lp.get("metadata")
+                if isinstance(lp_meta, dict):
+                    v = lp_meta.get(_PACE_TOK_ATTR)
+                    if isinstance(v, int) and not isinstance(v, bool):
+                        return v
+            return self._tok_est_from_logging_obj(data.get("litellm_logging_obj"))
+        except Exception:
+            return None
+
+    @staticmethod
+    def _usage_to_dict(usage: Any) -> dict:
+        """Coerce a usage object (dict, pydantic model, or plain attr-carrier)
+        into a flat dict _usage_actual_tokens can read. Never raises."""
+        try:
+            if isinstance(usage, dict):
+                return usage
+            for meth in ("model_dump", "dict"):
+                fn = getattr(usage, meth, None)
+                if callable(fn):
+                    try:
+                        d = fn()
+                        if isinstance(d, dict):
+                            return d
+                    except Exception:
+                        pass
+            d = getattr(usage, "__dict__", None)
+            if isinstance(d, dict) and d:
+                return d
+            out: dict = {}
+            for k in (
+                "input_tokens",
+                "output_tokens",
+                "prompt_tokens",
+                "completion_tokens",
+                "cache_creation_input_tokens",
+                "cache_read_input_tokens",
+            ):
+                v = getattr(usage, k, None)
+                if v is not None:
+                    out[k] = v
+            return out
+        except Exception:
+            return {}
+
+    def _actual_tokens_from_response(self, response: Any, data: Any = None) -> Optional[int]:
+        """Best-effort actual token count for the ROUTER success path: reads
+        response.usage, else a dict response's 'usage', else the logging
+        object's model_call_details['usage']. Never raises."""
+        try:
+            usage = getattr(response, "usage", None)
+            if usage is None and isinstance(response, dict):
+                usage = response.get("usage")
+            if usage is None and isinstance(data, dict):
+                lobj = data.get("litellm_logging_obj")
+                mcd = getattr(lobj, "model_call_details", None) if lobj is not None else None
+                if isinstance(mcd, dict):
+                    usage = mcd.get("usage")
+            if usage is None:
+                return None
+            return _usage_actual_tokens(self._usage_to_dict(usage))
+        except Exception:
+            return None
+
+    def _actual_tokens_from_response_body(self, response_body: Any) -> Optional[int]:
+        """Best-effort actual token count for the non-streaming PASSTHROUGH path:
+        the anthropic response_body dict carries `usage`. Never raises."""
+        try:
+            if isinstance(response_body, dict):
+                return _usage_actual_tokens(self._usage_to_dict(response_body.get("usage")))
+            return None
+        except Exception:
+            return None
+
+    async def _reconcile_tokens(self, est: Optional[int], actual: Optional[int]) -> None:
+        """Best-effort convergence of the rolling budget from admit-time ESTIMATE
+        to real USAGE: HINCRBY (actual - est) into the CURRENT bucket once usage
+        is known. NEVER load-bearing — a no-op when token pacing is off or either
+        value is missing, and it swallows every error. The delta may be negative
+        (estimate over-counted); the admit Lua clamps the rolling sum at >= 0."""
+        if _Cfg.MAX_TPM <= 0 or est is None or actual is None:
+            return
+        delta = int(actual) - int(est)
+        if delta == 0:
+            return
+        try:
+            r = await self._get_redis()
+            if r is None:
+                return
+            bucket = _token_bucket(time.time())
+            await r.hincrby(_TOKENS_KEY, str(bucket), delta)
+            await r.expire(_TOKENS_KEY, 120)
+        except Exception as e:
+            verbose_proxy_logger.debug(
+                "custom_pacing: token reconcile failed (non-load-bearing): %s", e
+            )
+
     async def async_post_call_success_hook(self, data, user_api_key_dict, response):
         await self._release(self._extract_pace_id(data))
+        # Router-path token reconciliation (best-effort; no-op when MAX_TPM==0).
+        if _Cfg.MAX_TPM > 0:
+            try:
+                await self._reconcile_tokens(
+                    self._extract_tok_est(data),
+                    self._actual_tokens_from_response(response, data),
+                )
+            except Exception:
+                pass
         return response
 
     async def async_post_call_failure_hook(
@@ -690,6 +1061,15 @@ pacer_instance = FleetPacer()
 #
 # The patch is install-once, fails open (any error leaves litellm untouched),
 # and never changes the bytes yielded to the client.
+#
+# TOKEN RECONCILIATION IS DELIBERATELY NOT DONE HERE. The streaming wrapper is
+# left untouched by PACE_MAX_TPM: parsing SSE to recover the terminal usage
+# block would mean buffering/inspecting the client's byte stream, which this
+# wrapper is expressly forbidden from doing (it must be byte-transparent). So a
+# STREAMED request keeps its admit-time ESTIMATE in the budget forever — never
+# reconciled to actuals. That is an accepted, bounded imprecision: the estimate
+# is conservative, the budget is a rolling smoother (not an accountant), and the
+# non-streaming + router paths (which CAN see usage cheaply) do reconcile.
 # ---------------------------------------------------------------------------
 
 _PATCH_FLAG = "_switchroom_pace_patched"
@@ -819,11 +1199,25 @@ def _install_nonstreaming_release_patch() -> bool:
 
     async def _paced_success_handler(self, *args, **kwargs):
         pace_id: Optional[str] = None
+        est: Optional[int] = None
+        actual: Optional[int] = None
         try:
             lobj = kwargs.get("logging_obj")
             pace_id = FleetPacer._pace_id_from_logging_obj(lobj)
             if pace_id is None:
                 pace_id = pacer_instance._extract_pace_id(kwargs.get("request_body"))
+            # Token reconciliation inputs (only when the budget is active). The
+            # non-streaming passthrough success handler is called with keywords
+            # (success_handler.py) but positional is handled defensively, the
+            # same way the streaming wrapper reads its lobj/body.
+            if _Cfg.MAX_TPM > 0:
+                est = FleetPacer._tok_est_from_logging_obj(lobj)
+                if est is None:
+                    est = pacer_instance._extract_tok_est(kwargs.get("request_body"))
+                response_body = kwargs.get("response_body")
+                if response_body is None and len(args) >= 2:
+                    response_body = args[1]
+                actual = pacer_instance._actual_tokens_from_response_body(response_body)
         except Exception as e:
             verbose_proxy_logger.debug(
                 "custom_pacing: non-stream pace_id lookup failed: %s", e
@@ -835,6 +1229,11 @@ def _install_nonstreaming_release_patch() -> bool:
                 await pacer_instance._release(pace_id)
             except Exception:
                 pacer_instance._release_soon(pace_id)
+            if _Cfg.MAX_TPM > 0:
+                try:
+                    await pacer_instance._reconcile_tokens(est, actual)
+                except Exception:
+                    pass
 
     setattr(_paced_success_handler, _PATCH_FLAG, True)
     setattr(_paced_success_handler, "__wrapped__", original)

--- a/docker/litellm-pacer/test_custom_pacing.py
+++ b/docker/litellm-pacer/test_custom_pacing.py
@@ -107,6 +107,9 @@ class FakeRedis:
         self.set_calls: list = []
         self.eval_calls = 0
         self.zrem_calls: list = []
+        # Token-budget round trips (reconciliation + fail-open recording).
+        self.hincrby_calls: list = []
+        self.expire_calls: list = []
 
     async def ping(self):
         return True
@@ -130,6 +133,19 @@ class FakeRedis:
         # assert BOTH that a release happened and that it happened once.
         self.zrem_calls.append(args)
         return 0
+
+    async def hincrby(self, key, field, amount):
+        self.hincrby_calls.append((key, field, int(amount)))
+        h = self.store.get(key)
+        if not isinstance(h, dict):
+            h = {}
+            self.store[key] = h
+        h[str(field)] = int(h.get(str(field), 0)) + int(amount)
+        return h[str(field)]
+
+    async def expire(self, key, ttl):
+        self.expire_calls.append((key, ttl))
+        return True
 
 
 # --- Retry-After parsing (pure static method) --------------------------------
@@ -225,6 +241,23 @@ class CodeDefaultTests(unittest.TestCase):
         self.assertEqual(self._default_of("_float_env", "MAX_WAIT_S"), 20.0)
         self.assertEqual(self._default_of("_float_env", "MAX_COOLDOWN_S"), 60.0)
         self.assertEqual(self._default_of("_int_env", "LEASE_TTL_S"), 300)
+
+    def test_token_pacing_code_defaults(self):
+        # PACE_MAX_TPM ships DISABLED (0) so the whole token predicate is inert
+        # until the deployment sets the env at rollout — behaviour-neutral merge.
+        self.assertEqual(self._default_of("_int_env", "MAX_TPM"), 0)
+        self.assertEqual(self._default_of("_int_env", "TPM_OUTPUT_RESERVE"), 2048)
+        self.assertEqual(self._default_of("_float_env", "TPM_CHARS_PER_TOKEN"), 4.0)
+        self.assertEqual(self._default_of("_float_env", "TPM_EST_MULT"), 1.0)
+        self.assertEqual(self._default_of("_float_env", "TPM_CACHE_READ_WEIGHT"), 1.0)
+
+    def test_max_tpm_clamped_non_negative(self):
+        # max(0, …) guards against a negative env inverting the gate; assert the
+        # source actually wraps the env read in max(0, …).
+        src = os.path.join(os.path.dirname(__file__), "custom_pacing.py")
+        with open(src, "r", encoding="utf-8") as fh:
+            source = fh.read()
+        self.assertIn('max(0, _int_env("PACE_MAX_TPM", 0))', source)
 
     def test_l1_knob_defaults(self):
         # The absolute hard cap ships ACTIVE (45s), but with 45 > MAX_WAIT_S it
@@ -1156,6 +1189,497 @@ class PatchInstallFailOpenTests(unittest.TestCase):
         finally:
             self._restore(saved)
             custom_pacing.verbose_proxy_logger = saved_logger
+
+
+# =============================================================================
+# Token-aware pacing (PACE_MAX_TPM) — estimator, usage accounting, gating,
+# reconciliation, and a real-Redis Lua budget exercise.
+# =============================================================================
+
+
+class _TpmCfgMixin:
+    """Pin the token-estimator knobs to known values (and enable the budget) so
+    the estimate/usage/reconcile tests are deterministic regardless of any PACE_*
+    env set in the runner. Snapshot + restore around each test."""
+
+    _TPM_KNOBS = (
+        "MAX_TPM",
+        "TPM_OUTPUT_RESERVE",
+        "TPM_CHARS_PER_TOKEN",
+        "TPM_EST_MULT",
+        "TPM_CACHE_READ_WEIGHT",
+    )
+
+    def setUp(self):
+        super().setUp()
+        self._saved_tpm = {k: getattr(custom_pacing._Cfg, k) for k in self._TPM_KNOBS}
+        custom_pacing._Cfg.MAX_TPM = 1_200_000
+        custom_pacing._Cfg.TPM_OUTPUT_RESERVE = 2048
+        custom_pacing._Cfg.TPM_CHARS_PER_TOKEN = 4.0
+        custom_pacing._Cfg.TPM_EST_MULT = 1.0
+        custom_pacing._Cfg.TPM_CACHE_READ_WEIGHT = 1.0
+
+    def tearDown(self):
+        for k, v in self._saved_tpm.items():
+            setattr(custom_pacing._Cfg, k, v)
+        super().tearDown()
+
+
+class EstimateTokensTests(_TpmCfgMixin, unittest.TestCase):
+    """Outcome tests for the cheap char-count estimator. With CHARS_PER_TOKEN=4,
+    RESERVE=2048, EST_MULT=1: est = int(chars/4) + min(max_tokens or 2048, 2048)."""
+
+    def _est(self, data):
+        return custom_pacing._estimate_tokens(data)
+
+    def test_string_content(self):
+        # 40 input chars -> 10 input tokens; +2048 output reserve.
+        data = {"messages": [{"role": "user", "content": "x" * 40}]}
+        self.assertEqual(self._est(data), 10 + 2048)
+
+    def test_block_content_text_and_image(self):
+        # text block counts its text length (40); an image block counts a flat
+        # 1600 chars. (40 + 1600) / 4 = 410 input tokens; +2048.
+        data = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "x" * 40},
+                        {"type": "image", "source": {"type": "base64", "data": "zz"}},
+                    ],
+                }
+            ]
+        }
+        self.assertEqual(self._est(data), (40 + 1600) // 4 + 2048)
+
+    def test_system_and_tools_add_to_estimate(self):
+        base = {"messages": [{"role": "user", "content": "x" * 40}]}
+        with_system = {**base, "system": "y" * 400}
+        with_tools = {**base, "tools": [{"name": "t", "description": "d" * 400}]}
+        self.assertGreater(self._est(with_system), self._est(base))
+        self.assertGreater(self._est(with_tools), self._est(base))
+        # System as a block list is also counted.
+        with_system_blocks = {**base, "system": [{"type": "text", "text": "y" * 400}]}
+        self.assertGreater(self._est(with_system_blocks), self._est(base))
+
+    def test_max_tokens_capped_by_reserve(self):
+        small = {"messages": [{"role": "user", "content": "x" * 40}]}
+        # A huge max_tokens is capped at RESERVE (2048), not trusted verbatim.
+        capped = {**small, "max_tokens": 999999}
+        self.assertEqual(self._est(capped), 10 + 2048)
+        # A small max_tokens reserves only that much.
+        tiny = {**small, "max_tokens": 100}
+        self.assertEqual(self._est(tiny), 10 + 100)
+
+    def test_est_mult_scaling(self):
+        data = {"messages": [{"role": "user", "content": "x" * 40}]}
+        base = self._est(data)
+        custom_pacing._Cfg.TPM_EST_MULT = 2.0
+        self.assertEqual(self._est(data), int(base * 2.0))
+
+    def test_garbage_returns_zero_never_raises(self):
+        for junk in (
+            None,
+            42,
+            "not-a-dict",
+            [],
+            {"max_tokens": "abc", "messages": [{"role": "user", "content": "hi"}]},
+        ):
+            self.assertEqual(self._est(junk), 0)
+
+    def test_chars_per_token_zero_does_not_divide_by_zero(self):
+        # A misconfigured 0 ratio must not blow up (would be ZeroDivisionError);
+        # the estimator falls back to 4.0 rather than returning 0/raising.
+        custom_pacing._Cfg.TPM_CHARS_PER_TOKEN = 0.0
+        data = {"messages": [{"role": "user", "content": "x" * 40}]}
+        self.assertEqual(self._est(data), 10 + 2048)
+
+
+class UsageActualTokensTests(_TpmCfgMixin, unittest.TestCase):
+    def _actual(self, usage):
+        return custom_pacing._usage_actual_tokens(usage)
+
+    def test_full_anthropic_usage(self):
+        usage = {
+            "input_tokens": 1000,
+            "output_tokens": 500,
+            "cache_creation_input_tokens": 200,
+            "cache_read_input_tokens": 4000,
+        }
+        # weight 1.0: 1000 + 200 + 500 + 4000 = 5700
+        self.assertEqual(self._actual(usage), 5700)
+
+    def test_cache_read_weight_zero_vs_one(self):
+        usage = {
+            "input_tokens": 1000,
+            "output_tokens": 500,
+            "cache_creation_input_tokens": 200,
+            "cache_read_input_tokens": 4000,
+        }
+        custom_pacing._Cfg.TPM_CACHE_READ_WEIGHT = 1.0
+        weighted = self._actual(usage)
+        custom_pacing._Cfg.TPM_CACHE_READ_WEIGHT = 0.0
+        discounted = self._actual(usage)
+        self.assertEqual(weighted, 5700)
+        self.assertEqual(discounted, 1700)  # cache reads no longer counted
+        self.assertLess(discounted, weighted)
+
+    def test_openai_style_keys(self):
+        self.assertEqual(
+            self._actual({"prompt_tokens": 100, "completion_tokens": 50}), 150
+        )
+
+    def test_missing_fields_partial_not_raise(self):
+        # Only some fields present -> partial sum, never a raise.
+        self.assertEqual(self._actual({"input_tokens": 100}), 100)
+        self.assertEqual(self._actual({"output_tokens": 50}), 50)
+
+    def test_no_recognised_field_returns_none(self):
+        self.assertIsNone(self._actual({}))
+        self.assertIsNone(self._actual({"nonsense": 5}))
+
+    def test_non_dict_and_junk_return_none_never_raise(self):
+        for junk in (None, "x", 7, [], {"input_tokens": "not-a-number"}):
+            self.assertIsNone(self._actual(junk))
+
+
+class TokenBucketTests(unittest.TestCase):
+    def test_bucket_floors_to_10s(self):
+        self.assertEqual(custom_pacing._token_bucket(1700000000.0), 1700000000)
+        self.assertEqual(custom_pacing._token_bucket(1700000009.9), 1700000000)
+        self.assertEqual(custom_pacing._token_bucket(1700000010.0), 1700000010)
+
+    def test_bucket_never_raises(self):
+        # NaN and non-numeric input degrade to 0 rather than raising.
+        self.assertEqual(custom_pacing._token_bucket(float("nan")), 0)
+        self.assertEqual(custom_pacing._token_bucket("junk"), 0)
+
+
+class TokenAdmitSignatureTests(unittest.IsolatedAsyncioTestCase):
+    """The admit Lua now takes 5 keys + maxtpm + est. Assert _try_admit threads
+    them, and that the fail-open + verdict contract is unchanged."""
+
+    def setUp(self):
+        self._saved = custom_pacing._Cfg.MAX_TPM
+
+    def tearDown(self):
+        custom_pacing._Cfg.MAX_TPM = self._saved
+
+    async def test_threads_est_and_maxtpm_and_five_keys(self):
+        captured = {}
+
+        class CapRedis(FakeRedis):
+            async def eval(self, *args, **kwargs):
+                captured["args"] = args
+                return 1
+
+        custom_pacing._Cfg.MAX_TPM = 1234
+        pacer = custom_pacing.FleetPacer()
+        self.assertTrue(await pacer._try_admit(CapRedis(), "pace-1", 777))
+        args = captured["args"]
+        # args[0] = LUA source, args[1] = numkeys.
+        self.assertEqual(args[1], 5)
+        self.assertIn(custom_pacing._TOKENS_KEY, args)
+        self.assertIn(custom_pacing._TPM_DENIED_KEY, args)
+        self.assertIn("1234", args)  # maxtpm ARGV
+        self.assertIn("777", args)  # est ARGV
+
+    async def test_default_est_is_zero_and_still_admits(self):
+        # Called with the default est (0) — the disabled path — still admits on a
+        # granting verdict.
+        pacer = custom_pacing.FleetPacer()
+        self.assertTrue(await pacer._try_admit(FakeRedis(eval_result=1), "p"))
+
+    async def test_fail_open_on_redis_error_with_est(self):
+        pacer = custom_pacing.FleetPacer()
+        r = FakeRedis(eval_raises=RuntimeError("redis down"))
+        self.assertTrue(await pacer._try_admit(r, "p", 5000))
+
+
+class TokenEnvGatingTests(_CfgPatchMixin, unittest.IsolatedAsyncioTestCase):
+    """When PACE_MAX_TPM is disabled the estimator must never be consulted on the
+    admit path, and admission still flows via the stubbed Lua verdict."""
+
+    def setUp(self):
+        super().setUp()
+        self._saved_est = custom_pacing._estimate_tokens
+        self._saved_tpm = custom_pacing._Cfg.MAX_TPM
+        self._est_calls = []
+
+        def _recording_est(data):
+            self._est_calls.append(data)
+            return 4242
+
+        custom_pacing._estimate_tokens = _recording_est
+        custom_pacing._Cfg.MAX_WAIT_S = 0.15
+        custom_pacing._Cfg.HARD_MAX_WAIT_S = 0.2
+        custom_pacing._Cfg.COOLDOWN_HOLD = False
+
+    def tearDown(self):
+        custom_pacing._estimate_tokens = self._saved_est
+        custom_pacing._Cfg.MAX_TPM = self._saved_tpm
+        super().tearDown()
+
+    async def test_estimator_not_consulted_when_disabled(self):
+        custom_pacing._Cfg.MAX_TPM = 0
+        pacer = custom_pacing.FleetPacer()
+        r = FakeRedis(eval_result=1)  # admit immediately
+        pacer._redis = r
+        data = await pacer.async_pre_call_hook(None, None, {}, "pass_through_endpoint")
+        self.assertEqual(self._est_calls, [])  # never called
+        self.assertIsInstance(data, dict)
+        self.assertGreaterEqual(r.eval_calls, 1)  # still admitted via verdict
+
+    async def test_estimator_consulted_when_enabled(self):
+        custom_pacing._Cfg.MAX_TPM = 1_000_000
+        pacer = custom_pacing.FleetPacer()
+        r = FakeRedis(eval_result=1)
+        pacer._redis = r
+        await pacer.async_pre_call_hook(None, None, {"messages": []}, "pass_through_endpoint")
+        self.assertEqual(len(self._est_calls), 1)
+
+
+class RecordEstFailOpenTests(_TpmCfgMixin, unittest.IsolatedAsyncioTestCase):
+    async def test_books_estimate_when_enabled(self):
+        pacer = custom_pacing.FleetPacer()
+        r = FakeRedis()
+        await pacer._record_est_fail_open(r, 500)
+        self.assertEqual(len(r.hincrby_calls), 1)
+        self.assertEqual(r.hincrby_calls[0][0], custom_pacing._TOKENS_KEY)
+        self.assertEqual(r.hincrby_calls[0][2], 500)
+        self.assertEqual(len(r.expire_calls), 1)
+
+    async def test_noop_when_disabled(self):
+        custom_pacing._Cfg.MAX_TPM = 0
+        pacer = custom_pacing.FleetPacer()
+        r = FakeRedis()
+        await pacer._record_est_fail_open(r, 500)
+        self.assertEqual(r.hincrby_calls, [])
+
+    async def test_noop_when_zero_estimate(self):
+        pacer = custom_pacing.FleetPacer()
+        r = FakeRedis()
+        await pacer._record_est_fail_open(r, 0)
+        self.assertEqual(r.hincrby_calls, [])
+
+    async def test_swallows_raising_redis(self):
+        class Boom(FakeRedis):
+            async def hincrby(self, *a, **k):
+                raise RuntimeError("redis down")
+
+        pacer = custom_pacing.FleetPacer()
+        await pacer._record_est_fail_open(Boom(), 500)  # must not raise
+
+
+class ReconcileTokensTests(_TpmCfgMixin, unittest.IsolatedAsyncioTestCase):
+    def _pacer(self, r):
+        pacer = custom_pacing.FleetPacer()
+        pacer._redis = r  # bypass _get_redis
+        return pacer
+
+    async def test_positive_delta_booked_to_current_bucket(self):
+        r = FakeRedis()
+        pacer = self._pacer(r)
+        await pacer._reconcile_tokens(100, 150)
+        self.assertEqual(len(r.hincrby_calls), 1)
+        self.assertEqual(r.hincrby_calls[0][2], 50)  # actual - est
+
+    async def test_negative_delta_allowed(self):
+        r = FakeRedis()
+        pacer = self._pacer(r)
+        await pacer._reconcile_tokens(200, 50)
+        self.assertEqual(r.hincrby_calls[0][2], -150)
+
+    async def test_noop_when_equal(self):
+        r = FakeRedis()
+        pacer = self._pacer(r)
+        await pacer._reconcile_tokens(100, 100)
+        self.assertEqual(r.hincrby_calls, [])
+
+    async def test_noop_when_disabled(self):
+        custom_pacing._Cfg.MAX_TPM = 0
+        r = FakeRedis()
+        pacer = self._pacer(r)
+        await pacer._reconcile_tokens(100, 200)
+        self.assertEqual(r.hincrby_calls, [])
+
+    async def test_noop_when_either_missing(self):
+        r = FakeRedis()
+        pacer = self._pacer(r)
+        await pacer._reconcile_tokens(None, 200)
+        await pacer._reconcile_tokens(100, None)
+        self.assertEqual(r.hincrby_calls, [])
+
+    async def test_swallows_raising_redis(self):
+        class Boom(FakeRedis):
+            async def hincrby(self, *a, **k):
+                raise RuntimeError("redis down")
+
+        pacer = self._pacer(Boom())
+        await pacer._reconcile_tokens(100, 200)  # must not raise
+
+
+class TokenStashExtractTests(_TpmCfgMixin, unittest.TestCase):
+    def test_stash_pins_est_on_all_carriers(self):
+        lobj = _fake_logging_obj()
+        data = {"litellm_logging_obj": lobj}
+        custom_pacing.FleetPacer._stash_pace_id(data, "pace-1", 4242)
+        self.assertEqual(data["metadata"][custom_pacing._PACE_TOK_ATTR], 4242)
+        self.assertEqual(getattr(lobj, custom_pacing._PACE_TOK_ATTR), 4242)
+        self.assertEqual(lobj.model_call_details[custom_pacing._PACE_TOK_ATTR], 4242)
+
+    def test_stash_without_est_pins_no_token_attr(self):
+        # Back-compat: the 2-arg form (est defaults to 0) pins only the lease id.
+        data = {}
+        custom_pacing.FleetPacer._stash_pace_id(data, "pace-1")
+        self.assertNotIn(custom_pacing._PACE_TOK_ATTR, data.get("metadata", {}))
+
+    def test_extract_est_from_metadata(self):
+        pacer = custom_pacing.FleetPacer()
+        data = {"metadata": {custom_pacing._PACE_TOK_ATTR: 999}}
+        self.assertEqual(pacer._extract_tok_est(data), 999)
+
+    def test_extract_est_from_litellm_params(self):
+        pacer = custom_pacing.FleetPacer()
+        data = {"litellm_params": {"metadata": {custom_pacing._PACE_TOK_ATTR: 777}}}
+        self.assertEqual(pacer._extract_tok_est(data), 777)
+
+    def test_extract_est_recovered_after_metadata_popped(self):
+        lobj = _fake_logging_obj()
+        data = {"litellm_logging_obj": lobj}
+        custom_pacing.FleetPacer._stash_pace_id(data, "pace-1", 4242)
+        data.pop("metadata")  # what _init_kwargs_for_pass_through_endpoint does
+        pacer = custom_pacing.FleetPacer()
+        self.assertEqual(pacer._extract_tok_est(data), 4242)
+
+    def test_extract_est_never_raises_on_junk(self):
+        pacer = custom_pacing.FleetPacer()
+        for junk in (None, "", 42, [], {"metadata": "not-a-dict"}):
+            self.assertIsNone(pacer._extract_tok_est(junk))
+
+
+class SuccessHookReconcileTests(_TpmCfgMixin, unittest.IsolatedAsyncioTestCase):
+    """The router success hook reconciles the budget from estimate to actual."""
+
+    async def test_router_success_reconciles(self):
+        pacer = custom_pacing.FleetPacer()
+        r = FakeRedis()
+        pacer._redis = r
+        data = {"metadata": {custom_pacing._PACE_TOK_ATTR: 1000}}
+        response = types.SimpleNamespace(
+            usage={"input_tokens": 1200, "output_tokens": 300}
+        )
+        await pacer.async_post_call_success_hook(data, None, response)
+        # actual = 1500, est = 1000 -> delta +500
+        self.assertEqual(len(r.hincrby_calls), 1)
+        self.assertEqual(r.hincrby_calls[0][2], 500)
+
+    async def test_router_success_noop_when_disabled(self):
+        custom_pacing._Cfg.MAX_TPM = 0
+        pacer = custom_pacing.FleetPacer()
+        r = FakeRedis()
+        pacer._redis = r
+        data = {"metadata": {custom_pacing._PACE_TOK_ATTR: 1000}}
+        response = types.SimpleNamespace(usage={"input_tokens": 1200})
+        await pacer.async_post_call_success_hook(data, None, response)
+        self.assertEqual(r.hincrby_calls, [])
+
+
+# --- Real-Redis Lua budget exercise (gated; CI's pure-stdlib lane skips it) ---
+# The rest of the suite stubs the eval verdict, so it can NOT catch a broken
+# budget script. This class runs the ACTUAL _ADMIT_LUA against a real Redis to
+# prove the token predicate admits/denies correctly. Run locally with a
+# throwaway redis:  docker run --rm -d -p 6379:6379 redis
+#   PACE_TEST_REDIS_URL=redis://127.0.0.1:6379/15 \
+#     python3 -m unittest discover -s docker/litellm-pacer -p 'test_*.py'
+@unittest.skipUnless(
+    os.getenv("PACE_TEST_REDIS_URL"),
+    "set PACE_TEST_REDIS_URL to a THROWAWAY redis to run the real-Lua budget test",
+)
+class RealRedisTokenBudgetTests(unittest.TestCase):
+    BIG = 10**9  # concurrency/RPM/RPS so high only the TOKEN gate can deny
+
+    @classmethod
+    def setUpClass(cls):
+        import redis  # local-only; never imported on the pure-stdlib CI lane
+
+        cls.client = redis.Redis.from_url(
+            os.environ["PACE_TEST_REDIS_URL"], decode_responses=True
+        )
+        cls.client.ping()
+
+    def setUp(self):
+        # Only ever touch OUR keys — never flushdb a shared instance.
+        self._keys = [
+            custom_pacing._INFLIGHT_KEY,
+            custom_pacing._RECENT_KEY,
+            custom_pacing._COOLDOWN_KEY,
+            custom_pacing._TOKENS_KEY,
+            custom_pacing._TPM_DENIED_KEY,
+        ]
+        self.client.delete(*self._keys)
+
+    def tearDown(self):
+        self.client.delete(*self._keys)
+
+    def _admit(self, est, maxtpm, now=None):
+        now = time.time() if now is None else now
+        res = self.client.eval(
+            custom_pacing._ADMIT_LUA,
+            5,
+            custom_pacing._INFLIGHT_KEY,
+            custom_pacing._RECENT_KEY,
+            custom_pacing._COOLDOWN_KEY,
+            custom_pacing._TOKENS_KEY,
+            custom_pacing._TPM_DENIED_KEY,
+            repr(now),
+            str(self.BIG),
+            str(self.BIG),
+            str(self.BIG),
+            "300",
+            "pid-" + str(random.random()),
+            "ruid-" + str(random.random()),
+            str(maxtpm),
+            str(int(est)),
+        )
+        return int(res)
+
+    def _token_sum(self):
+        h = self.client.hgetall(custom_pacing._TOKENS_KEY)
+        return sum(int(v) for v in h.values())
+
+    def test_burst_admitted_until_budget_then_denied(self):
+        # MAX_TPM=1000, E=300: 3 admits (0,300,600 -> sums 300,600,900), 4th
+        # would be 900+300=1200 > 1000 -> denied.
+        now = time.time()
+        verdicts = [self._admit(300, 1000, now=now) for _ in range(4)]
+        self.assertEqual(verdicts, [1, 1, 1, 0])
+        self.assertEqual(self._token_sum(), 900)  # denied req not recorded
+        # The observability counter caught exactly the one token denial.
+        self.assertEqual(int(self.client.get(custom_pacing._TPM_DENIED_KEY)), 1)
+
+    def test_budget_frees_after_buckets_age(self):
+        now = time.time()
+        for _ in range(3):
+            self.assertEqual(self._admit(300, 1000, now=now), 1)
+        self.assertEqual(self._admit(300, 1000, now=now), 0)  # budget full
+        # Advance >60s: the old bucket ages out (HDEL), budget resets -> admit.
+        later = now + 61
+        self.assertEqual(self._admit(300, 1000, now=later), 1)
+
+    def test_disabled_admits_regardless_and_writes_no_tokens_key(self):
+        # MAX_TPM=0: admits any size and never creates the tokens hash.
+        self.assertEqual(self._admit(999999, 0), 1)
+        self.assertEqual(self.client.exists(custom_pacing._TOKENS_KEY), 0)
+
+    def test_single_oversized_request_admitted(self):
+        # est (5000) >= MAX_TPM (1000): the bypass admits it on the first attempt
+        # rather than starving it, and still records its tokens.
+        self.assertEqual(self._admit(5000, 1000), 1)
+        self.assertEqual(self._token_sum(), 5000)
+        # No token denial was counted for the bypass admit.
+        self.assertIsNone(self.client.get(custom_pacing._TPM_DENIED_KEY))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a fleet-wide rolling ~60s **token** budget as a **4th admission predicate** in the litellm pacer (`docker/litellm-pacer/custom_pacing.py`), layered on top of the existing concurrency/RPM/RPS gates. Single concern: token budget + estimate + best-effort reconciliation. Lease/release/TTL paths and the wait-loop structure/ordering are untouched; the module rule (pace, then fail open, never reject) is preserved.

**Disabled by default (`PACE_MAX_TPM=0`)** — the Lua predicate short-circuits, the estimator is never called, and `litellm_pace:tokens` is never written, so merge + redeploy is behaviour-neutral until the env is set at rollout (prod sets `1200000`).

## Why

Anthropic's per-minute burst ceiling is a token ceiling as much as a request ceiling — a handful of huge-context turns can 429 an account the RPM gate would happily admit. This smooths that. Advances the **subscription-honest / always-available** vision outcomes (job: keep the fleet on one OAuth account without self-inflicted 429 storms — the same "never storm, always pace" rule the pacer already serves).

## What changed

- **New `_Cfg` knobs** (env, conservative code defaults): `PACE_MAX_TPM` (`max(0, …)`, default 0), `PACE_TPM_OUTPUT_RESERVE` (2048), `PACE_TPM_CHARS_PER_TOKEN` (4.0), `PACE_TPM_EST_MULT` (1.0), `PACE_TPM_CACHE_READ_WEIGHT` (1.0).
- **Redis**: HASH `litellm_pace:tokens` (10s buckets; rolling sum = buckets newer than `now-60`; Lua HDELs stale + EXPIREs 120s) + `litellm_pace:tpm_denied` INCR counter on token-caused denials only.
- **Pure helpers, never raise**: `_estimate_tokens` (char-count over messages/system/tools + bounded output reserve, no `litellm.token_counter`), `_token_bucket`, `_usage_actual_tokens`.
- **Lua**: `KEYS[4]=tokens`, `KEYS[5]=tpm_denied`, `ARGV maxtpm+est`. Token predicate after the RPS check and before the ZADD writes; HINCRBY+EXPIRE on admit; **single-oversized-request bypass** so a request whose own estimate exceeds the whole budget admits on first attempt instead of burning the wait ceiling forever.
- **`_try_admit`** signature → `(self, r, pace_id, est_tokens=0)`; 5 keys + two new ARGV; fail-open preserved.
- **`async_pre_call_hook`**: estimate computed once (only when `MAX_TPM>0`), threaded into `_try_admit`; on the two fail-open ceiling breaks, best-effort HINCRBY of the estimate (guarded, try/except). Loop/hard-backstop/hold-regime logic untouched.
- **Reconciliation** (best-effort, never load-bearing): estimate stashed on the same carriers as the lease id; sibling extractors; `_reconcile_tokens` HINCRBYs `actual-est` (may be negative; Lua clamps sum ≥0) into the current bucket. Called from the router success hook (`response.usage`) and the non-streaming passthrough success handler (anthropic `response_body.usage`, positional-args defense). **Streaming wrapper left byte-transparent** (no SSE parsing) — streams keep their estimate, documented.
- **README**: documents the budget + knobs; fixes the stale live env table (`MAX_CONCURRENCY` 64, `LEASE_TTL` 60; RPM 90 / RPS 6 / WAIT_S 12 already correct).

## Test plan

- `python3 -m unittest discover -s docker/litellm-pacer -p 'test_*.py'` → **120 tests, OK** (4 real-Redis tests skip on the pure-stdlib CI lane).
- Existing lease/release/cooldown/router-gate tests pass **unmodified** (the new `est_tokens` param defaults to 0, so 2-arg `_try_admit` calls keep working).
- New outcome tests: estimator (string/block/system+tools/max_tokens cap/EST_MULT/garbage→0), usage accounting (full anthropic, cache-read weight 0 vs 1, missing→None, non-dict→None), env gating (estimator not consulted when disabled), reconciliation (positive/negative/zero/disabled/missing/raising-redis swallowed), stash/extract of the estimate.

### Real-Redis Lua budget test (runs the ACTUAL script; CI stdlib lane skips it)

Run locally against a throwaway redis (`docker run --rm -d -p 6379:6379 redis`, `PACE_TEST_REDIS_URL` set):

```
test_budget_frees_after_buckets_age ... ok
test_burst_admitted_until_budget_then_denied ... ok
test_disabled_admits_regardless_and_writes_no_tokens_key ... ok
test_single_oversized_request_admitted ... ok
----------------------------------------------------------------------
Ran 4 tests in 0.057s
OK
```

Asserts: (a) burst of N×E admitted only while `sum+E<=MAX_TPM` then denied (+`tpm_denied` INCR'd once); (b) budget frees after buckets age past 60s; (c) `MAX_TPM=0` admits regardless and leaves `litellm_pace:tokens` absent; (d) `est>MAX_TPM` single request admitted (bypass) and its tokens recorded.

## Risk

Low. Fully inert at the default `PACE_MAX_TPM=0`; every token path fails open (Redis error → admit; wait-ceiling → proceed with best-effort booking). No change to lease/release/TTL or the wait-loop ordering.

## Deploy note — DO NOT DEPLOY from this PR (operator-gated)

**DRIFT WARNING.** The deployed `/app/custom_pacing.py` is **older than `origin/main`**: it has lease-release (#4107) but is **missing** #3211 (cooldown-hold / `HARD_MAX_WAIT_S`) and #3413 (router-path `anthropic_messages` gating). Syncing this file to prod therefore ALSO first-deploys:

- **#3211** — neutral by default (`PACE_COOLDOWN_HOLD` off; the hard cap only ever shortens a >45s pathological wait).
- **#3413** — newly paces the `/v1/messages` router path for `claude-*` / `sonnet` / `fable`.

And this PR's own token budget is inert until `PACE_MAX_TPM` is set. The sync + redeploy is a separate, gated rollout step handled by the operator — container/compose are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)