### PR TITLE
fix(litellm-pacer): count each image as ~1600 tokens in admit estimate

### DIFF
--- a/docker/litellm-pacer/custom_pacing.py
+++ b/docker/litellm-pacer/custom_pacing.py
@@ -372,7 +372,7 @@ def _estimate_tokens(data: Any) -> int:
     lists), the system prompt, and the tools spec, divides by CHARS_PER_TOKEN
     for the input estimate, adds a bounded output reservation, and scales by
     EST_MULT. Content blocks: text blocks count their `text` length; an image
-    block counts a flat ~1600; any other block counts len(str(block))//4."""
+    block counts a flat ~1600 tokens; any other block counts len(str(block))//4."""
     try:
         if not isinstance(data, dict):
             return 0
@@ -383,7 +383,9 @@ def _estimate_tokens(data: Any) -> int:
                 if isinstance(t, str):
                     return len(t)
                 if block.get("type") in ("image", "image_url"):
-                    return 1600
+                    # A real Anthropic image is ~1600 TOKENS; scale to chars so
+                    # dividing by CHARS_PER_TOKEN lands at ~1600 tokens.
+                    return int(1600 * _Cfg.TPM_CHARS_PER_TOKEN)
                 return len(str(block)) // 4
             return len(str(block)) // 4
 

--- a/docker/litellm-pacer/test_custom_pacing.py
+++ b/docker/litellm-pacer/test_custom_pacing.py
@@ -1239,7 +1239,8 @@ class EstimateTokensTests(_TpmCfgMixin, unittest.TestCase):
 
     def test_block_content_text_and_image(self):
         # text block counts its text length (40); an image block counts a flat
-        # 1600 chars. (40 + 1600) / 4 = 410 input tokens; +2048.
+        # ~1600 tokens -> int(1600 * 4) = 6400 chars. (40 + 6400) / 4 = 1610
+        # input tokens; +2048 output reserve.
         data = {
             "messages": [
                 {
@@ -1251,7 +1252,10 @@ class EstimateTokensTests(_TpmCfgMixin, unittest.TestCase):
                 }
             ]
         }
-        self.assertEqual(self._est(data), (40 + 1600) // 4 + 2048)
+        img_chars = int(1600 * 4)
+        self.assertEqual(self._est(data), (40 + img_chars) // 4 + 2048)
+        # Guard: the image alone must contribute ~1600 tokens, not the old ~400.
+        self.assertGreater(self._est(data), (40 // 4) + 1500 + 2048)
 
     def test_system_and_tools_add_to_estimate(self):
         base = {"messages": [{"role": "user", "content": "x" * 40}]}


### PR DESCRIPTION
## What

In `_estimate_tokens()` (`docker/litellm-pacer/custom_pacing.py`), an image content block returned a flat `1600` chars. The estimator does `est_in = int(chars / cpt)` with `cpt = _Cfg.TPM_CHARS_PER_TOKEN` (default `4.0`), so a flat 1600 chars became only **~400 tokens** per image.

A real Anthropic image is **~1600 tokens**, so the admit estimate undercounted each image by **4x**.

## Fix

Return `int(1600 * _Cfg.TPM_CHARS_PER_TOKEN)` chars so that after `÷ cpt` it lands at ~1600 tokens, and scales consistently if `cpt` is retuned. The `_estimate_tokens` docstring is updated to say "~1600 tokens" instead of "~1600".

## Why it matters

The undercount matters most on the **streaming path**, whose admit estimate is never reconciled to actuals — so the error persists into the fleet budget rather than being corrected. The feature is still inert (`PACE_MAX_TPM=0`); this is a fast-follow before rollout.

## Tests

`test_block_content_text_and_image` in `docker/litellm-pacer/test_custom_pacing.py` updated to expect ~1600 tokens per image (`int(1600*4)=6400` chars), plus an added guard asserting the estimate exceeds the old ~400-token value so the test genuinely fails on the pre-fix behaviour. Estimator tests pass locally (`EstimateTokensTests`: 7 passed); full module 116 passed, 4 RealRedis tests skipped (need `PACE_TEST_REDIS_URL`).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)