### PR TITLE
fix(telegram): first-paint sub-agent card at 4s (was 8s), env-tunable

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -23827,6 +23827,14 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
               const raw = Number(process.env.SWITCHROOM_TG_WORKER_FEED_MAX_ROWS)
               return Number.isInteger(raw) && raw > 0 ? raw : undefined
             })()
+            // First-paint hold for a prose-silent sub-agent card. Unset /
+            // non-positive → the feed's built-in default (4000ms). Operator
+            // override (SWITCHROOM_TG_WORKER_FEED_FIRST_PAINT_MS) lets first
+            // paint be retuned/reverted (e.g. back to 8000) without a redeploy.
+            const workerFeedFirstPaintMs = (() => {
+              const raw = Number(process.env.SWITCHROOM_TG_WORKER_FEED_FIRST_PAINT_MS)
+              return Number.isInteger(raw) && raw > 0 ? raw : undefined
+            })()
             // Model A — foreground sub-agent nesting in the parent's live
             // activity draft. ON by default; this edits the SAME activity-
             // summary message the tool_label feed already owns (not the
@@ -23900,6 +23908,10 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
               // channels.telegram.worker_feed.max_rows via the config cascade
               // (scaffold emits SWITCHROOM_TG_WORKER_FEED_MAX_ROWS); unset → 8.
               maxRows: workerFeedMaxRows,
+              // First-paint hold for a prose-silent worker's initial card.
+              // Unset → the feed's built-in default (4000ms); the operator
+              // override SWITCHROOM_TG_WORKER_FEED_FIRST_PAINT_MS retunes it.
+              firstPaintMinMs: workerFeedFirstPaintMs,
               // Backstop TTL for the feed's stale-row reaper, DERIVED in code
               // from the watcher's effective in-flight terminal cap (same env /
               // default the watcher itself resolves) plus a margin — NOT a

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -304,6 +304,45 @@ describe('createWorkerActivityFeed', () => {
     expect(feed.has('w1')).toBe(true)
   })
 
+  it('defaults firstPaintMin to 4000ms (no explicit firstPaintMinMs)', async () => {
+    // Guards the module default. A prose-silent worker's first card must paint
+    // once it has run ≥4000ms and NOT before — asserting the actual default so
+    // this fails on the old 8000. #fix/worker-feed-first-paint.
+    const bot = makeFakeBot()
+    let clock = 0
+    const feed = createWorkerActivityFeed({ bot, now: () => clock })
+    // Just below the 4000 default: still held.
+    clock = 3999
+    await feed.update('w1', 'chat', view({ elapsedMs: 3999 }))
+    expect(bot.sent).toHaveLength(0)
+    expect(feed.has('w1')).toBe(false)
+    // At/above 4000: paints. (On the old 8000 default this would still be held
+    // and bot.sent would be empty — so this assertion pins the new value.)
+    clock = 4000
+    await feed.update('w1', 'chat', view({ elapsedMs: 4000 }))
+    expect(bot.sent).toHaveLength(1)
+    expect(feed.has('w1')).toBe(true)
+  })
+
+  it('honors an explicit firstPaintMinMs override (env plumbing shape)', async () => {
+    // The gateway threads SWITCHROOM_TG_WORKER_FEED_FIRST_PAINT_MS through as
+    // firstPaintMinMs; an operator override (e.g. reverting to 8000) must hold
+    // first paint until that value, overriding the 4000 default.
+    const bot = makeFakeBot()
+    let clock = 0
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, firstPaintMinMs: 8000 })
+    // Past the 4000 default but below the override: still held.
+    clock = 5000
+    await feed.update('w1', 'chat', view({ elapsedMs: 5000 }))
+    expect(bot.sent).toHaveLength(0)
+    expect(feed.has('w1')).toBe(false)
+    // At the override threshold: paints.
+    clock = 8000
+    await feed.update('w1', 'chat', view({ elapsedMs: 8000 }))
+    expect(bot.sent).toHaveLength(1)
+    expect(feed.has('w1')).toBe(true)
+  })
+
   it('messageIdOf exposes the posted message id (for status-pin) and is null before paint / after finish', async () => {
     const bot = makeFakeBot()
     let clock = 0
@@ -706,7 +745,7 @@ describe('createWorkerActivityFeed — heartbeat', () => {
       setInterval: () => 1,
       clearInterval: () => {},
     })
-    // First paint at elapsed 0 (firstPaintMin default 8000 — use 9000). The
+    // First paint at elapsed 0 (firstPaintMin default 4000 — use 9000). The
     // narrative line 'pulling data' lands here, so the current step starts now.
     clock = 19_000
     await feed.update('w1', 'chat', view({ elapsedMs: 9000, latestSummary: 'pulling data' }))

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -800,7 +800,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
   const floodWaitRemainingMs = opts.floodWaitRemainingMs ?? (() => 0)
   const minEditInterval = opts.minEditIntervalMs ?? 2500
   const elapsedRefreshMs = Math.max(minEditInterval, Math.floor(opts.elapsedRefreshMs ?? 15000))
-  const firstPaintMin = opts.firstPaintMinMs ?? 8000
+  const firstPaintMin = opts.firstPaintMinMs ?? 4000
   const heartbeatTickMs = opts.heartbeatTickMs ?? 6000
   const maxRows = Math.max(1, Math.floor(opts.maxRows ?? 8))
   const staleWorkerTtlMs = Math.max(1, Math.floor(opts.staleWorkerTtlMs ?? 50 * 60_000))


### PR DESCRIPTION
## What changed

Lowers the worker-activity-feed **first-paint hold** default from **8000ms → 4000ms**, and adds an operator env override to retune it without a redeploy.

- `telegram-plugin/worker-activity-feed.ts` (~L803): `firstPaintMin = opts.firstPaintMinMs ?? 8000` → `?? 4000`.
- `telegram-plugin/gateway/gateway.ts`: new `workerFeedFirstPaintMs` env read (`SWITCHROOM_TG_WORKER_FEED_FIRST_PAINT_MS`), threaded into `createWorkerActivityFeed({ … firstPaintMinMs: workerFeedFirstPaintMs })`. Mirrors the existing `SWITCHROOM_TG_WORKER_FEED_MAX_ROWS` / `workerFeedMaxRows` pattern exactly (integer parse, `> 0` guard, `undefined` when unset/invalid so the module default applies).
- `telegram-plugin/tests/worker-activity-feed.test.ts`: two new tests — one asserts the **4000** default (paints at 4000, held at 3999; fails on the old 8000), one asserts an explicit `firstPaintMinMs: 8000` override is honored (held at 5000, paints at 8000). Fixed a stale `default 8000` comment in an existing test.

## Why it's flood-safe

First paint of the sub-agent card is a **`useful`** send (`priorityClass: 'useful'`), off the cosmetic edit budget — this is a threshold change on *when* that single send fires, **not a new edit on the wire**. Zero added flood risk: at most **+1 send** per short-lived worker (one that finishes between 4s and 8s and would previously never have painted a running card).

## Real-world effect

A quiet (prose-silent) background sub-agent's first visible update lands at **~6s instead of ~12s** — the hold aligns to the 6s heartbeat tick, so 4000 resolves to the 6s tick and 8000 to the 12s tick.

## Env override

`SWITCHROOM_TG_WORKER_FEED_FIRST_PAINT_MS` — set to an integer ms to retune (e.g. `8000` to revert). Unset/invalid → module default (4000).

## Scope

Scoped to the background sub-agent (**worker**) card only — **not** the parent answer stream. Untouched by design (review confirmed changing them only manufactures shed attempts with no visible gain): `elapsedRefreshMs`, `minEditInterval`, `FEED_HEARTBEAT_TICK_MS`/`MIN_STALE_MS`, `cosmeticPerMessageMaxPerWindow`, `ANSWER_STAGE_MS`, `FEED_LIVENESS_OPEN_MS`.

## Verification

`npx vitest run tests/worker-activity-feed.test.ts tests/worker-feed-coalesce.test.ts tests/worker-feed-repeat-steps.test.ts`:

```
 ✓ tests/worker-feed-repeat-steps.test.ts (6 tests) 10ms
 ✓ tests/worker-activity-feed.test.ts (86 tests) 68ms
 ✓ tests/worker-feed-coalesce.test.ts (52 tests) 2104ms

 Test Files  3 passed (3)
      Tests  144 passed (144)
```

Negative control — reverting the default to 8000 makes the new default test fail (real test, asserts the value, not just a code path):

```
 Test Files  1 failed (1)
      Tests  1 failed | 85 skipped (86)
```

- `npx tsc` (scoped, worker-activity-feed.ts): clean.
- `scripts/check-gateway-line-ratchet.mjs`: clean (gateway.ts = 24815 lines, ratchet 24805, slack 50).

🤖 Generated with [Claude Code](https://claude.com/claude-code)