### PR TITLE
Enable native WebSearch fleet-wide (keep WebFetch denied → webkite)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -337,7 +337,7 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
 
 /**
  * The web-fetch contract. One of the fleet invariant blocks. The
- * native WebFetch / WebSearch tools are disabled at the cascade
+ * native WebFetch tool is disabled at the cascade
  * level (`scaffold.ts:WEBKITE_FLEET_DENY_TOOLS`); webkite is wired
  * in via `.mcp.json` and runs as a stdio MCP server with 12 tools.
  *
@@ -348,9 +348,11 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
  */
 const WEB_FETCH_GUIDANCE = `## Fetching from the web
 
-The native \`WebFetch\` and \`WebSearch\` tools are disabled in this
-fleet. Use the \`webkite_*\` MCP tools instead — they're already
-wired up and authenticated.
+The native \`WebFetch\` tool is disabled in this fleet — fetch pages
+with the \`webkite_*\` MCP tools instead (they're wired up and
+authenticated). Native \`WebSearch\` IS available; prefer it for quick
+web search, and reach for \`webkite_search\` when you then need to
+fetch a result's page content.
 
 The 12 tools webkite exposes cover what you actually need:
 
@@ -1528,7 +1530,7 @@ const DEFAULT_READ_ONLY_PREAPPROVED_TOOLS = [
  * Fleet-baseline deny list seeded into every agent's settings.json
  * `permissions.deny` unless the agent has opted out of webkite. The
  * model still has full web-fetch capability — via the webkite_*
- * MCP tools — but the native WebFetch / WebSearch tools are off so
+ * MCP tools — but the native WebFetch tool is off so
  * the model reaches for webkite by default. Webkite is operator-
  * mounted (private beta binary) and pre-credentialed via the vault-
  * broker; the model doesn't need to know about any of that.
@@ -1537,7 +1539,7 @@ const DEFAULT_READ_ONLY_PREAPPROVED_TOOLS = [
  * — the agent gets native WebFetch back. (Documented behavior — if
  * you turn off webkite, you keep WebFetch.)
  */
-const WEBKITE_FLEET_DENY_TOOLS = ["WebFetch", "WebSearch"];
+const WEBKITE_FLEET_DENY_TOOLS = ["WebFetch"];
 
 /**
  * Fleet-baseline deny for blocking interactive TUI tools.

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -725,7 +725,7 @@ describe("scaffoldAgent", () => {
       // pre-approved (the underlying server is removed).
       expect(settings.permissions.allow).not.toContain("mcp__switchroom__*");
       // Webkite is fleet-default (scaffold.ts:WEBKITE_FLEET_DENY_TOOLS) —
-      // the native WebFetch / WebSearch tools are denied so the model
+      // the native WebFetch tool is denied (native WebSearch stays available) so the model
       // reaches for the webkite_* MCP tools instead. Per-agent
       // `mcp_servers.webkite: false` opts both webkite AND this deny
       // out together.
@@ -735,7 +735,6 @@ describe("scaffoldAgent", () => {
       expect(settings.permissions.deny).toEqual([
         "bash",
         "WebFetch",
-        "WebSearch",
         "AskUserQuestion",
       ]);
       // acceptEdits is now the switchroom built-in default for EVERY agent


### PR DESCRIPTION
## What

Removes `WebSearch` from the webkite fleet deny-list so every agent's main loop gets native `WebSearch` back. One-line constant change:

```diff
-const WEBKITE_FLEET_DENY_TOOLS = ["WebFetch", "WebSearch"];
+const WEBKITE_FLEET_DENY_TOOLS = ["WebFetch"];
```

`WebFetch` **stays denied** — page fetching continues to route through the `webkite_*` MCP tools (wired via `.mcp.json`, vault-credentialed). We're only un-denying search, not fetch.

## Why

- **Parity with sub-agents** — sub-agents already have native WebSearch; this brings the main loop in line.
- **Free in-model search** — native WebSearch is cheap/quick for lookups; agents should prefer it and reach for `webkite_search` only when they then need to fetch a result's page content.
- **Operator-approved.**

## Changes

- `src/agents/scaffold.ts` — drop `WebSearch` from `WEBKITE_FLEET_DENY_TOOLS`; reword the `WEB_FETCH_GUIDANCE` agent-facing prompt to say WebFetch is disabled (use webkite) while native WebSearch IS available and preferred for quick search; update the two doc comments (`WEB_FETCH_GUIDANCE` header ~L339 and the constant ~L1531) from "WebFetch / WebSearch" to "WebFetch".
- `tests/scaffold.test.ts` — drop `"WebSearch"` from the expected `permissions.deny` array (now `["bash", "WebFetch", "AskUserQuestion"]`) and update the preceding comment.

Nothing else touched: the webkite-absent fail-safe test, the `tools:["all"]` allow-expansion test (WebSearch still in allow), the disallowed_tools passthrough test, and the built-in tools list all stay as-is — WebSearch remains a valid allowable tool, it's just no longer denied by default.

## Verification

- `npx vitest run tests/scaffold.test.ts` → **244 passed**.
- `tsc --noEmit`, `check-stale-tool-descriptions`, `check-web-subscription-honest` → all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)