### PR TITLE
feat(scaffold): pre-approve native WebSearch fleet-wide

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1525,6 +1525,37 @@ const DEFAULT_READ_ONLY_PREAPPROVED_TOOLS = [
 ];
 
 /**
+ * Native `WebSearch`, pre-approved fleet-wide (operator decision, 2026-08).
+ *
+ * Unlike the other native network-egress tools, WebSearch does NOT go through
+ * the standard permission prompt: it is pre-approved for EVERY agent so a
+ * search lands seamlessly on the first call. The risk profile is the same as
+ * the already-pre-approved `mcp__webkite__webkite_search` (see
+ * WEBKITE_MCP_TOOLS) — read-only egress whose results are untrusted DATA
+ * either way — so gating native WebSearch while pre-approving webkite_search
+ * bought no safety, only a first-use prompt whenever the model reached for the
+ * native tool instead of webkite.
+ *
+ * `WebFetch` is deliberately NOT here — page fetches still route through
+ * webkite (WEBKITE_FLEET_DENY_TOOLS keeps native WebFetch denied), so this is
+ * a WebSearch-only grant.
+ *
+ * This is an UNCONDITIONAL spread in the allow-list assembly (like
+ * WEBKITE_MCP_TOOLS), not a member of DEFAULT_READ_ONLY_PREAPPROVED_TOOLS:
+ * every agent gets it regardless of an explicit `tools.allow` or
+ * `dangerous_mode`, so acceptEdits-mode / explicit-allow agents (which skip
+ * the read-only defaults) are covered uniformly. An agent that must NOT have
+ * WebSearch pre-approved sets `tools.deny: ["WebSearch"]` — deny wins in
+ * Claude Code.
+ *
+ * NOTE — while WebSearch remains in WEBKITE_FLEET_DENY_TOOLS, deny wins and
+ * this allow entry is inert for webkite-enabled agents; it becomes live once
+ * WebSearch is removed from the fleet deny (PR #4465). For webkite-opted-out
+ * agents (no fleet deny) it takes effect immediately.
+ */
+const NATIVE_WEBSEARCH_PREAPPROVED_TOOLS = ["WebSearch"];
+
+/**
  * Fleet-baseline deny list seeded into every agent's settings.json
  * `permissions.deny` unless the agent has opted out of webkite. The
  * model still has full web-fetch capability — via the webkite_*
@@ -5131,6 +5162,12 @@ export function computeDesiredPermissionAllow(
     // (daemon-side gates remain the real security boundary).
     ...AGENT_CONFIG_MCP_TOOLS,
     ...HOSTD_MCP_TOOLS,
+    // Native WebSearch is pre-approved fleet-wide (see
+    // NATIVE_WEBSEARCH_PREAPPROVED_TOOLS). Unconditional — every agent,
+    // regardless of explicit tools.allow / dangerous_mode — so it matches
+    // the webkite_search pre-approval and the model can search seamlessly.
+    // WebFetch stays gated (page fetches route through webkite).
+    ...NATIVE_WEBSEARCH_PREAPPROVED_TOOLS,
     // Webkite is fleet-default (resolveWebkiteMcpEntry) unless the agent
     // opts out. Pre-approve its tools so the first web fetch doesn't
     // wedge on a permission prompt — webkite IS the web-fetch path now
@@ -5554,6 +5591,12 @@ export function scaffoldAgent(
         ...HOSTD_MCP_TOOLS,
         ...webkiteAllowTools,
         ...context7AllowTools,
+        // Existing-agent twin of the permissionAllow WebSearch spread —
+        // writeIfMissing skips the settings.json template for deployed
+        // agents, so `switchroom apply` re-seeds native WebSearch here.
+        // Unconditional (not gated on any opt-out), matching the fresh /
+        // reconcile path.
+        ...NATIVE_WEBSEARCH_PREAPPROVED_TOOLS,
       ]) {
         if (!allow.includes(t)) allow.push(t);
       }

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -796,6 +796,74 @@ describe("scaffoldAgent", () => {
     expect(s2.permissions.allow).toContain("mcp__webkite__*");
   });
 
+  it("pre-approves native WebSearch fleet-wide even for an explicit-allow (acceptEdits) agent", () => {
+    // The uniformity gap this guards: an agent with an explicit `tools.allow`
+    // (acceptEdits-mode agents like kdogg/marko) SKIPS
+    // DEFAULT_READ_ONLY_PREAPPROVED_TOOLS, so a WebSearch pre-approval seeded
+    // only via the read-only defaults would never reach them. WebSearch is
+    // pre-approved as an UNCONDITIONAL spread instead, so every agent —
+    // explicit-allow or not — gets it. WebFetch stays gated (webkite path).
+    const config = makeAgentConfig({
+      tools: { allow: ["calendar", "notion"], deny: ["bash"] },
+    });
+    const result = scaffoldAgent("websearch-explicit", config, tmpDir, telegramConfig);
+    const settings = JSON.parse(
+      readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
+    );
+    // The explicit tools survive AND WebSearch is pre-approved alongside them.
+    expect(settings.permissions.allow).toContain("calendar");
+    expect(settings.permissions.allow).toContain("WebSearch");
+    // WebFetch is NOT pre-approved — page fetches still route through webkite.
+    expect(settings.permissions.allow).not.toContain("WebFetch");
+  });
+
+  it("reconcile pre-approves native WebSearch in permissions.allow", () => {
+    // The live `switchroom apply` path reconciles EXISTING agents
+    // (reconcileAgent) and assigns computeDesiredPermissionAllow's output
+    // wholesale — pin that native WebSearch rides that path too.
+    const config = makeAgentConfig({});
+    const switchroomConfig: SwitchroomConfig = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      agents: { "websearch-reconcile": config },
+    } as SwitchroomConfig;
+    scaffoldAgent("websearch-reconcile", config, tmpDir, telegramConfig, switchroomConfig);
+    reconcileAgent("websearch-reconcile", config, tmpDir, telegramConfig, switchroomConfig);
+    const settings = JSON.parse(
+      readFileSync(join(tmpDir, "websearch-reconcile", ".claude", "settings.json"), "utf-8"),
+    );
+    expect(settings.permissions.allow).toContain("WebSearch");
+    expect(settings.permissions.allow).not.toContain("WebFetch");
+  });
+
+  it("re-seeds native WebSearch into an EXISTING agent's allow (merge path)", () => {
+    // Twin of the webkite existing-agent merge test: `switchroom apply` on a
+    // deployed agent hits writeIfMissing (skips the settings.json template),
+    // so the additive MCP-merge block must re-seed native WebSearch or a
+    // pre-WebSearch deployed agent never picks it up until it next reconciles.
+    const config = makeAgentConfig({});
+    const result = scaffoldAgent("ws-existing", config, tmpDir, telegramConfig, {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      agents: { "ws-existing": config },
+    } as SwitchroomConfig);
+    const settingsPath = join(result.agentDir, ".claude", "settings.json");
+    // Simulate a PRE-WebSearch deployed agent: strip WebSearch from allow.
+    const s1 = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    s1.permissions.allow = s1.permissions.allow.filter((x: string) => x !== "WebSearch");
+    writeFileSync(settingsPath, JSON.stringify(s1, null, 2));
+    expect(JSON.parse(readFileSync(settingsPath, "utf-8")).permissions.allow)
+      .not.toContain("WebSearch");
+    // Re-scaffold (existing-agent merge path) must re-seed WebSearch.
+    scaffoldAgent("ws-existing", config, tmpDir, telegramConfig, {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      agents: { "ws-existing": config },
+    } as SwitchroomConfig);
+    const s2 = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    expect(s2.permissions.allow).toContain("WebSearch");
+  });
+
   it("context7 MCP entry is wired into .mcp.json by default (remote HTTP)", () => {
     // Fleet-default capability, no opt-in gate. Asserts the OUTCOME the
     // operator cares about — the server is reachable from the agent's


### PR DESCRIPTION
## Intent

Per operator decision, make native **`WebSearch`** pre-approved (no permission prompt) for **every agent, fleet-wide**, so a web search lands seamlessly on the first call. **`WebFetch` stays gated/denied — unchanged**: page fetches still route through webkite.

Follow-up to **#4465** (which removes `WebSearch` from `WEBKITE_FLEET_DENY_TOOLS`). This PR is the ALLOW side; #4465 is the DENY side. They compose: while `WebSearch` remains fleet-denied, deny wins in Claude Code and this allow entry is **inert** for webkite-enabled agents — it goes live the moment #4465 lands. For webkite-opted-out agents (no fleet deny) it takes effect immediately, which is also desired.

## Mechanism changed

An agent's `settings.json` `permissions.allow` is produced by `computeDesiredPermissionAllow` (`src/agents/scaffold.ts`). Entries come in two flavours:

- **Conditional** — `DEFAULT_READ_ONLY_PREAPPROVED_TOOLS` is seeded **only when** `!dangerousMode && !hadExplicitAllow`. Agents with an explicit `tools.allow` (e.g. the acceptEdits-mode agents `kdogg`/`marko`) **skip** it. This is exactly why per-agent WebSearch coverage had drifted (~10 agents had it via one-off "Always allow" taps, others didn't).
- **Unconditional** — `AGENT_CONFIG_MCP_TOOLS`, `HOSTD_MCP_TOOLS`, `WEBKITE_MCP_TOOLS` are spread in regardless of explicit allow / dangerous_mode.

To make WebSearch **uniform for every agent**, it is added as a new **unconditional** spread (`NATIVE_WEBSEARCH_PREAPPROVED_TOOLS = ["WebSearch"]`), mirroring the webkite pattern, in **both** write paths that reach a deployed agent's `settings.json`:

1. `computeDesiredPermissionAllow` — used by fresh scaffold and by **`reconcileAgent`** (the production restart-reconcile rollout, which assigns the output wholesale).
2. The existing-agent additive merge loop in `scaffoldAgent` — the `switchroom apply` path, which skips the settings.json template (`writeIfMissing`) and re-seeds allow tokens additively.

An agent that must NOT have WebSearch pre-approved sets `tools.deny: ["WebSearch"]` (deny wins).

## Why WebSearch-only

`mcp__webkite__webkite_search` is **already** pre-approved (`WEBKITE_MCP_TOOLS`). Native `WebSearch` is equivalent read-only egress whose results are **untrusted data either way** — so gating native WebSearch while pre-approving `webkite_search` bought no safety, only a first-use permission prompt whenever the model reached for the native tool. `WebFetch` is different (arbitrary page fetch) and stays on the webkite path — it is deliberately excluded here and untouched in the deny list.

## Scope guardrails

- Does **not** touch `WEBKITE_FLEET_DENY_TOOLS` or the deny list (that's #4465).
- Does **not** reword any agent-facing guidance.
- Single concern: add `WebSearch` to the pre-approved/allow set.

## Tests

Added 3 tests in `tests/scaffold.test.ts`, each verified to **FAIL without the source change** (non-vacuous):
- fresh scaffold of an **explicit-allow (acceptEdits-gap)** agent → `WebSearch` in allow, `WebFetch` not;
- **`reconcileAgent`** → `WebSearch` in allow;
- **existing-agent merge path** (`switchroom apply`) re-seeds `WebSearch`.

`vitest run tests/scaffold.test.ts` → 247 passed. `tsc --noEmit` → 0 errors. Full `bun run lint` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)