### PR TITLE
chore(gdrive-mcp): bump pinned google_workspace_mcp v1.20.4 -> v1.23.1

### DIFF
--- a/examples/personal-google-workspace-mcp/compose.yaml
+++ b/examples/personal-google-workspace-mcp/compose.yaml
@@ -38,7 +38,7 @@ services:
       # Pinned: bumping is a deliberate operator decision, not a silent
       # surprise. Bump in lockstep with retesting the OAuth flow.
       - --from
-      - workspace-mcp==1.20.4
+      - workspace-mcp==1.23.1
       - workspace-mcp
       # streamable-http (not stdio) is required for OAuth 2.1 PKCE per
       # upstream README.

--- a/reference/rfcs/gdrive-mcp.md
+++ b/reference/rfcs/gdrive-mcp.md
@@ -27,7 +27,7 @@ Add a Google Drive MCP server so agents can read and (with explicit approval) wr
 
 ## 2. MCP server choice
 
-**Pinned:** [`taylorwilsdon/google_workspace_mcp`](https://github.com/taylorwilsdon/google_workspace_mcp), MIT-licensed, pinned to an explicit upstream **commit SHA** (a tag's deref'd commit, not a floating ref, so upstream history rewrites can't change what we run). The RFC originally targeted `v0.5.x`, but no such tag exists upstream. The live pin is single-sourced in code as `GOOGLE_WORKSPACE_MCP_PINNED_SHA` (`src/memory/scaffold-integration.ts`). That constant, with its doc comment, is the source of truth (currently the `v1.20.4` commit); do not duplicate the literal here, it only rots. Bump deliberately per the procedure in that comment + the `tests/docker/drive-mcp-pin-smoke.test.ts` guard.
+**Pinned:** [`taylorwilsdon/google_workspace_mcp`](https://github.com/taylorwilsdon/google_workspace_mcp), MIT-licensed, pinned to an explicit upstream **commit SHA** (a tag's deref'd commit, not a floating ref, so upstream history rewrites can't change what we run). The RFC originally targeted `v0.5.x`, but no such tag exists upstream. The live pin is single-sourced in code as `GOOGLE_WORKSPACE_MCP_PINNED_SHA` (`src/memory/scaffold-integration.ts`). That constant, with its doc comment, is the source of truth (currently the `v1.23.1` commit); do not duplicate the literal here, it only rots. Bump deliberately per the procedure in that comment + the `tests/docker/drive-mcp-pin-smoke.test.ts` guard.
 
 - **Runtime:** Python 3.11+, run via `uvx` so no system-wide install is required. Switchroom's existing MCP-subprocess machinery already supports `uvx`-launched servers.
 - **License:** MIT.

--- a/src/memory/scaffold-integration.ts
+++ b/src/memory/scaffold-integration.ts
@@ -92,25 +92,35 @@ export type GdriveMcpTier = "core" | "extended" | "complete";
  * Specific commit SHA — bump deliberately. Pinning to a 40-char commit
  * SHA (not the moving tag ref) means upstream history rewrites can't
  * change what we run, while still tracking a tagged release. This SHA
- * is the commit annotated tag `v1.20.4` dereferences to
- * (`gh api repos/taylorwilsdon/google_workspace_mcp/git/refs/tags/v1.20.4`
- * → tag obj → `.object.sha`). v1.20.4 (2026-05-07) supersedes the prior
- * pin v1.20.3 (`f3c7dc5…`): it hardens the `--single-user` stdio OAuth
- * callback path switchroom depends on (upstream PR #762, "missing state
- * parameter fallback for single-user stdio OAuth callbacks"). The
- * `workspace-mcp` entrypoint is unchanged at this tag (pyproject
- * `[project.scripts]` still defines `workspace-mcp = "main:main"` —
- * the bug-6 guard). Validated end-to-end in a real agent container at
- * this SHA: MCP starts and a real Drive call authenticates the seeded
- * single-user account. When bumping: re-deref a NEW tag to its commit
- * SHA, confirm the entrypoint, and re-run the docker pin-smoke test.
+ * is the commit annotated tag `v1.23.1` dereferences to
+ * (`gh api repos/taylorwilsdon/google_workspace_mcp/git/refs/tags/v1.23.1`
+ * → tag obj → `.object.sha`, i.e. the `v1.23.1^{}` peel). v1.23.1
+ * (2026-08-02) supersedes the prior pin v1.20.4 (`9d69115…`): it carries
+ * an auth/server refactor (request-scoped auth upstream #992, late-bind
+ * port fallback #768 via the new `auth/port_resolver.py`) plus docs/
+ * sheets/forms bug fixes and new import tools. The `--single-user`
+ * seeded-credentials refresh branch switchroom depends on is unchanged
+ * (upstream still reads `WORKSPACE_MCP_CREDENTIALS_DIR`, preferred, in
+ * `auth/google_auth.py`, and takes the refresh path on a `token:null`
+ * seed — no browser), and the new `--permissions` flag is additive and
+ * mutually exclusive only with `--read-only`/`--tools`, which the
+ * launcher never combines with it. The `workspace-mcp` entrypoint is
+ * unchanged at this tag (pyproject `[project.scripts]` still defines
+ * `workspace-mcp = "main:main"` — the bug-6 guard) and `WORKSPACE_MCP_PORT`
+ * is still honored. Validated at this SHA via the stdio JSON-RPC smoke
+ * test: `initialize` completes and `tools/list` registers the complete
+ * tier (incl. `insert_doc_image` / `batch_update_doc` /
+ * `inspect_doc_structure`); the four launcher flags `--single-user /
+ * --tools / --tool-tier / --read-only` all still parse in `main.py`.
+ * When bumping: re-deref a NEW tag to its commit SHA, confirm the
+ * entrypoint, and re-run the docker pin-smoke test.
  *
  * Exported as the single source of truth: the scaffold MCP entry and
  * the in-container `drive-mcp-launcher` both reference this constant so
  * the spawned upstream revision is identical on both code paths.
  */
 export const GOOGLE_WORKSPACE_MCP_PINNED_SHA =
-  "9d69115b63e6bc2ef0d4b5d7a3b962396382b44c";
+  "db6212992738d4380a94fb6940140bcebf5d861d";
 
 /**
  * Pinned softeria/ms-365-mcp-server version — RFC #1873 PR 3.


### PR DESCRIPTION
## What

Bump the single-sourced `GOOGLE_WORKSPACE_MCP_PINNED_SHA` for upstream
[`taylorwilsdon/google_workspace_mcp`](https://github.com/taylorwilsdon/google_workspace_mcp)
from the **v1.20.4** commit (`9d69115`) to the **v1.23.1** commit
(`db6212992738d4380a94fb6940140bcebf5d861d` — the `v1.23.1^{}` peel of the
annotated tag, 2026-08-02, the latest stable upstream release).

### Files changed
- `src/memory/scaffold-integration.ts` — the pinned SHA constant + its doc comment (the source of truth both the scaffold MCP entry and the in-container `drive-mcp-launcher` consume).
- `reference/rfcs/gdrive-mcp.md` — the "currently the `v1.20.4` commit" note → `v1.23.1`.
- `examples/personal-google-workspace-mcp/compose.yaml` — the standalone personal-use pip pin `workspace-mcp==1.20.4` → `==1.23.1`.

## Smoke-test evidence (new SHA, real launch)

Ran the launcher's exact `uvx` invocation over stdio JSON-RPC:

```
uvx --from git+https://github.com/taylorwilsdon/google_workspace_mcp.git@db6212992738d4380a94fb6940140bcebf5d861d \
    --refresh-package aiofile --with aiofile==3.10.2 \
    workspace-mcp --single-user --tool-tier complete
```

- **`initialize` completes** — `serverInfo = {"name":"google_workspace","version":"3.4.6"}`.
- **`tools/list` returns the full complete tier — 121 tools**, including the docs complete-tier tools the task calls out: `insert_doc_image` ✓, `batch_update_doc` ✓, `inspect_doc_structure` ✓.
- **All four launcher flags parse** at v1.23.1 (`main.py` argparse): `--single-user`, `--tools`, `--tool-tier`, `--read-only`. `--single-user --tool-tier complete` verified at runtime; all four confirmed present in the arg parser.
- **New port fallback (#768) fired live**: `Port resolver: preferred port 8631 unavailable; falling back to 8632` — graceful, non-fatal.
- Scoped unit test `src/memory/scaffold-integration.test.ts` — **7/7 pass**.

Auth/network calls are not exercised (no real Google creds needed) — this validates the server boots, registers tools, and honors the flags switchroom depends on.

## Breaking-risk verdict: single-user seeded-cred path is SAFE

The v1.20.4→v1.23.x range includes an auth/server refactor (request-scoped auth #992, late-bind port fallback #768 via new `auth/port_resolver.py`), so I verified the launcher's assumptions against v1.23.1 source:

- **Seeded-credentials refresh branch unchanged.** `auth/google_auth.py` still resolves `WORKSPACE_MCP_CREDENTIALS_DIR` (preferred) and takes the refresh path on a `token:null` seed — no browser. The `drive-mcp-launcher.ts` seeding contract (`token`/`expiry` null → refresh branch) holds.
- **Entrypoint unchanged.** `pyproject.toml [project.scripts]` still defines `workspace-mcp = "main:main"` (the bug-6 guard).
- **Port env unchanged.** `WORKSPACE_MCP_PORT` is still honored (`auth/oauth_config.py`, `auth/port_resolver.py`).
- **New `--permissions` flag is additive** and mutually exclusive only with `--read-only`/`--tools` — the launcher never combines it with `--permissions`, so no conflict. The read-only default is env-gated (`WORKSPACE_MCP_READ_ONLY`) only; it does **not** auto-enable, so our read-write path is unaffected.
- **No tool renames/removals affecting us.** All 10 upstream tool names switchroom references in code (`GATED_DRIVE_WRITE_TOOLS` et al. — `batch_update_doc`, `create_doc`, `find_and_replace_doc`, `insert_doc_elements`, `insert_doc_image`, `manage_drive_access`, `modify_doc_text`, `update_doc_headers_footers`, `update_drive_file`, `update_paragraph_style`) still exist in the v1.23.1 surface.

## Benefits catalogue (changelog-grounded)

**Real benefit to our usage:**
- **Docs structure fix** — `inspect_doc_structure` now inspects the first tab body (upstream `ff59acc` / #976 "fix inspect first tab body in docs structure"). We expose this tool in complete tier.
- **Sheets read clamp** — `read_sheet_values` clamps A1 ranges to 1000 rows (`bbe3325` / #986), preventing oversized reads; documented in `826c049`.
- **Sheets input validation** — `_column_to_index` rejects non-letter inputs (`dc0c7d6` / #964) — fewer opaque 400s on bad column args.
- **Drive search correctness** — `search_drive_files` now excludes trashed files by default and ignores quoted literals when detecting a trashed clause (`25cc8fb`/`42a4675` / #978).
- **Apps Script safety** — `update_script_content` defaults to safe merge mode (`ce3f4c9` / #982) — avoids clobbering script content.
- **Calendar metadata** — `get_events` exposes colorId + series metadata and emits consistent metadata from both branches (`220431a`/`909d238` / #980).
- **New tools** — `import_to_google_sheets` and `import_to_google_slides` (both **new** since v1.20.4; `import_to_google_doc` already existed). Broadens the import surface in complete tier.
- **Auth robustness** — request-scoped `AuthInfoMiddleware` identity (#992) and late-bind port fallback (#768, seen live in the smoke test) harden startup/concurrency.

**Present but irrelevant to our usage:**
- **OpenTelemetry tracing (#938) + opt-in `user.email` span attribute (#992/d64764a)** — **off by default**: `configure_telemetry()` returns `False` unless an OTLP endpoint is configured, and the email attribute is gated behind an env var. No PII leaves us unless explicitly enabled.
- Gateway/OAuth-2.1 hardening (principal validation, consent binding) — relevant only to the streamable-http gateway mode; our launcher runs `--single-user` stdio.
- CLI quoted-value parsing fix (#983) — affects `workspace-cli`, which we don't invoke.

## Notes / caveats
- The `tests/docker/drive-mcp-pin-smoke.test.ts` guard requires the `switchroom/agent` image + Docker, unavailable in my sandbox — CI's `e2e` job runs it. I reproduced its exact invocation via `uvx` directly instead (evidence above); it reached the same `Starting MCP server` marker plus a full `tools/list`.
- A full local `tsc` run was not achievable (sandbox filesystem is `noexec`, so a clean native-dependency install couldn't complete); the change is a string-constant + comment + version-string edit touching no types, and the scoped `scaffold-integration` test passes. CI is the full-suite authority.

Do **not** merge without CI green.
