### PR TITLE
feat(hindsight): default new installs to ParadeDB pg_search BM25 backend

### DIFF
--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -4454,6 +4454,72 @@ COPY --chmod=0755 docker/hindsight-maintenance.sh /usr/local/lib/switchroom/hind
 # regconfig that consumes it is created idempotently by the entrypoint.
 COPY --chmod=0644 docker/hindsight-extra.stop /usr/local/lib/switchroom/hindsight_extra.stop
 
+# ParadeDB pg_search — durable BM25 text-search backend for hindsight recall.
+#
+# The native tsvector/ts_rank arm degenerated to full seq-scans on the highest-
+# frequency lexemes (claude/code/agent, folded into ~80% of rows via the
+# `context` tag). pg_search replaces it with a Tantivy-backed BM25 index. It is
+# now the default text-search backend for NEW installs (see
+# HINDSIGHT_DEFAULT_TEXT_SEARCH_EXTENSION in src/setup/hindsight-perf-defaults.ts).
+#
+# libopenblas0 is a HARD dependency: pg_search.so carries a DT_NEEDED on
+# libopenblas.so.0 (verified with readelf -d), so the embedded-pg postmaster
+# fails to load the preload library at boot without it. --no-install-recommends
+# still pulls libgfortran5 and libopenblas0-pthread transitively (both real
+# Depends of libopenblas0), which the .so also needs. Kept as its own layer:
+# it is stable and must NOT be invalidated by a pg_search version bump.
+RUN set -eu; \
+    export DEBIAN_FRONTEND=noninteractive; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends libopenblas0; \
+    rm -rf /var/lib/apt/lists/*; \
+    ldconfig; \
+    ldconfig -p | grep -q 'libopenblas\.so\.0' \
+      || { echo 'pg_search prereq FAILED: libopenblas.so.0 not on the loader path after install' >&2; exit 1; }; \
+    echo 'pg_search prereq ok: libopenblas.so.0 present' >&2
+
+# Stage the pg_search extension artifacts (.so + control + version SQL) at a
+# STABLE, embedded-pg-version-independent path. The entrypoint's
+# provision_pg_search() re-materializes them into the CURRENT pg0 install's
+# lib/ + share/extension/ on every boot (the pg0 data dir is a mounted volume,
+# so nothing baked under it survives) and adds pg_search to
+# shared_preload_libraries. Baking under a MAJOR-versioned subdir (18) lets the
+# entrypoint refuse to copy an ABI-mismatched .so if pg0's major ever bumps
+# ahead of this deb — see the per-PG-bump maintenance note in the entrypoint.
+#
+# Pins are DELIBERATE, no floating `latest`: the .so is loaded into the
+# postmaster via shared_preload_libraries, so a silent upstream rebuild must
+# never slip in. sha256s are the PG18/trixie release debs for both arches.
+ARG PG_SEARCH_VERSION=0.25.1
+ARG PG_SEARCH_PG_MAJOR=18
+ARG PG_SEARCH_SHA256_AMD64=7596bc87ea6e8b40df4d42ec4a98669783b7c07684a82cf18dbcfa246dd6460e
+ARG PG_SEARCH_SHA256_ARM64=ee97119251f1e47e4784334374a2bbd7d12e41a7ecb830ce813ca2f21c249d1c
+RUN set -eu; \
+    : "${TARGETARCH:=amd64}"; \
+    case "${TARGETARCH}" in \
+      amd64) _arch=amd64; _sha="${PG_SEARCH_SHA256_AMD64}";; \
+      arm64) _arch=arm64; _sha="${PG_SEARCH_SHA256_ARM64}";; \
+      *) echo "pg_search: artifact not available for TARGETARCH='${TARGETARCH}'; switchroom ships pg_search for amd64/arm64 only. The runtime default text-search backend is pg_search, so a build with no baked deb would crash-loop on CREATE EXTENSION at first boot — failing the build instead." >&2; exit 1;; \
+    esac; \
+    _deb="postgresql-${PG_SEARCH_PG_MAJOR}-pg-search_${PG_SEARCH_VERSION}-1PARADEDB-trixie_${_arch}.deb"; \
+    _url="https://github.com/paradedb/paradedb/releases/download/v${PG_SEARCH_VERSION}/${_deb}"; \
+    _tmp="$(mktemp -d)"; \
+    curl -fsSL --retry 3 -o "${_tmp}/pg_search.deb" "${_url}"; \
+    echo "${_sha}  ${_tmp}/pg_search.deb" | sha256sum -c -; \
+    dpkg-deb -x "${_tmp}/pg_search.deb" "${_tmp}/x"; \
+    _dest="/usr/local/lib/switchroom/pg_search/${PG_SEARCH_PG_MAJOR}"; \
+    mkdir -p "${_dest}/lib" "${_dest}/extension"; \
+    cp -a "${_tmp}/x/usr/lib/postgresql/${PG_SEARCH_PG_MAJOR}/lib/pg_search.so" "${_dest}/lib/"; \
+    cp -a "${_tmp}/x/usr/share/postgresql/${PG_SEARCH_PG_MAJOR}/extension/pg_search"*.control "${_dest}/extension/"; \
+    cp -a "${_tmp}/x/usr/share/postgresql/${PG_SEARCH_PG_MAJOR}/extension/pg_search"*.sql "${_dest}/extension/"; \
+    rm -rf "${_tmp}"; \
+    chmod -R a+rX /usr/local/lib/switchroom/pg_search; \
+    test -f "${_dest}/lib/pg_search.so"; \
+    test -f "${_dest}/extension/pg_search.control"; \
+    test -f "${_dest}/extension/pg_search--${PG_SEARCH_VERSION}.sql"; \
+    grep -q "default_version = '${PG_SEARCH_VERSION}'" "${_dest}/extension/pg_search.control"; \
+    echo "pg_search bake ok: ${_deb} -> ${_dest} (default_version ${PG_SEARCH_VERSION})" >&2
+
 # Backup mount point, owned by the hindsight user (UID 11000). The
 # maintenance script writes rotated pg_dumps to /backups via a named
 # volume (compose `switchroom-hindsight-backups:/backups`). A fresh named

--- a/docker/hindsight-entrypoint.sh
+++ b/docker/hindsight-entrypoint.sh
@@ -135,8 +135,79 @@ TS_STOP_DEST_GLOB="${SWITCHROOM_HINDSIGHT_TS_STOP_DEST_GLOB:-/home/hindsight/.pg
 # until the server accepts, so the first psql normally succeeds; this only
 # insures a slow-recovery edge. One `sleep 1` between tries.
 TS_PROVISION_TRIES="${SWITCHROOM_HINDSIGHT_TS_PROVISION_TRIES:-30}"
+# --- ParadeDB pg_search provisioning (durable BM25 backend) ------------------
+# Baked extension artifacts. docker/Dockerfile.hindsight stages pg_search.so +
+# the control + version SQL under a PG-MAJOR subdir here (…/pg_search/18/{lib,
+# extension}). Empty/missing DISABLES pg_search provisioning entirely, so an
+# older image without the bake boots exactly as before. Overridable for tests.
+PG_SEARCH_SRC_ROOT="${SWITCHROOM_HINDSIGHT_PG_SEARCH_SRC_ROOT:-/usr/local/lib/switchroom/pg_search}"
+# Glob of the embedded-pg install dir(s) to provision into. pg0 extracts a
+# fresh, version-scoped install dir on every embedded-pg bump; the .so + control
+# + SQL are re-materialized into each MAJOR-matched match on every boot (the pg0
+# data dir is a mounted volume, so nothing baked into the image survives there).
+# Overridable for host tests.
+PG_SEARCH_INSTALL_GLOB="${SWITCHROOM_HINDSIGHT_PG_SEARCH_INSTALL_GLOB:-/home/hindsight/.pg0/installation/*}"
+# The resolved text-search backend selector, read from the same env switchroom
+# emits (src/setup/hindsight-perf-defaults.ts) and hindsight_api itself reads.
+# pg_search provisioning AND the shared_preload_libraries flag are applied ONLY
+# when this is exactly `pg_search`; any other value — empty (an older switchroom
+# that does not emit it), or an operator pin of `native` on a not-yet-migrated
+# fleet — leaves the box on the native backend, byte-identical to before.
+TEXT_SEARCH_EXTENSION="${HINDSIGHT_API_TEXT_SEARCH_EXTENSION:-}"
 
 log() { echo "switchroom-hindsight-entrypoint: $*" >&2; }
+
+# Echoes the BAKED pg_search MAJOR (e.g. "18") when pg_search is the selected
+# backend AND the extension artifacts are baked into the image; empty otherwise.
+# This is the SOURCE side: provision_pg_search() uses it to locate the artifacts
+# to stage into the embedded-pg install dir. It says nothing about whether the
+# stage SUCCEEDED — see pg_search_landed_major() for the preload gate.
+pg_search_baked_major() {
+  [ "${TEXT_SEARCH_EXTENSION}" = "pg_search" ] || return 0
+  for _sofile in ${PG_SEARCH_SRC_ROOT}/*/lib/pg_search.so; do
+    [ -r "${_sofile}" ] || continue
+    _m="${_sofile%/lib/pg_search.so}"
+    _m="${_m##*/}"
+    printf '%s\n' "${_m}"
+    return 0
+  done
+  return 0
+}
+
+# Echoes the LANDED pg_search MAJOR when pg_search is the selected backend AND
+# pg_search.so has actually been COPIED into a version-scoped embedded-pg install
+# dir whose major matches the baked deb; empty otherwise. This is the DESTINATION
+# side, and it is what prestart_pg0() gates the shared_preload_libraries=pg_search
+# flag on — NOT the bake.
+#
+# WHY NOT the bake (pg_search_baked_major). The two CAN disagree: on a future pg
+# MAJOR bump that lands a new install dir AHEAD of the baked deb,
+# provision_pg_search() correctly SKIPS the copy (ABI mismatch), so the install
+# dir has no .so even though the bake still exists under PG_SEARCH_SRC_ROOT. A
+# postmaster told to preload a library that is not in its install dir REFUSES to
+# start, so gating the preload on the bake would turn that graceful copy-skip
+# into a boot crash-loop — the exact opposite of the "ABI mismatch refused
+# gracefully" contract. Gating on the landed .so degrades a skipped/failed stage
+# to "no preload -> pg0 starts plain -> hindsight_api's CREATE EXTENSION pg_search
+# surfaces the missing library loudly" — the correct, recoverable failure mode.
+#
+# The baked-major match also ignores a STALE .so left in an OLD install dir by a
+# prior boot: only a dir whose major equals the currently-baked deb can have been
+# staged with an ABI-compatible library, so that is the only major we preload.
+pg_search_landed_major() {
+  [ "${TEXT_SEARCH_EXTENSION}" = "pg_search" ] || return 0
+  _baked="$(pg_search_baked_major)"
+  [ -n "${_baked}" ] || return 0
+  for _sofile in ${PG_SEARCH_INSTALL_GLOB}/lib/pg_search.so; do
+    [ -r "${_sofile}" ] || continue
+    _d="${_sofile%/lib/pg_search.so}"
+    _ver="${_d##*/}"
+    case "${_ver%%.*}" in
+      "${_baked}") printf '%s\n' "${_baked}"; return 0 ;;
+    esac
+  done
+  return 0
+}
 
 # Stable worker identity (fix A above). `:=` only sets it when the
 # operator/compose hasn't already pinned HINDSIGHT_API_WORKER_ID, so an
@@ -346,9 +417,20 @@ prestart_pg0() {
     on) PG_FSYNC="on" ;;
     *) PG_FSYNC="" ;;
   esac
+  # pg_search preload. When pg_search is the selected backend and its .so has
+  # actually LANDED in the install dir, THIS start is the authoritative one that
+  # must set shared_preload_libraries=pg_search — a PGC_POSTMASTER GUC that only
+  # applies at server start. provision_pg_search() ran just before us, staged the
+  # .so into the install dir, and left pg0 STOPPED precisely so this start applies
+  # the preload. We gate on pg_search_landed_major() (the COPIED .so whose major
+  # matches the baked deb), not the bake: if provisioning could not stage the
+  # library — e.g. a future pg-major bump moved the install dir ahead of the
+  # baked deb and the ABI-mismatched copy was skipped — this returns empty, we do
+  # NOT preload, pg0 starts plain, and hindsight_api surfaces any real miss loudly.
+  _pg_preload_major="$(pg_search_landed_major)"
   # Nothing to apply ⇒ do not touch pg0 at all (pre-#3706 behaviour).
   [ -n "${PG_EFFECTIVE_CACHE_SIZE}" ] || [ -n "${PG_SHARED_BUFFERS}" ] ||
-    [ -n "${PG_FSYNC}" ] || return 0
+    [ -n "${PG_FSYNC}" ] || [ -n "${_pg_preload_major}" ] || return 0
 
   # Only the embedded-pg0 database is ours to pre-start. An operator pointing
   # hindsight at an external postgres (or a differently-named/ported pg0
@@ -400,16 +482,55 @@ EOF
   if [ -n "${PG_FSYNC}" ]; then
     set -- "$@" -c "fsync=${PG_FSYNC}"
   fi
+  if [ -n "${_pg_preload_major}" ]; then
+    # NOTE: this SETS shared_preload_libraries rather than appending. pg0 does
+    # not set the GUC itself, so `pg_search` is the only preloaded library. If a
+    # second preload-requiring extension is ever added, make this a
+    # comma-joined value — a second `-c shared_preload_libraries=` would NOT
+    # merge, the last one wins.
+    set -- "$@" -c "shared_preload_libraries=pg_search"
+  fi
 
   if _out="$("${_pg0}" "$@" 2>&1)"; then
-    log "pg0 pre-start ok: name=${PG0_NAME} effective_cache_size=${PG_EFFECTIVE_CACHE_SIZE:-<pg0-default>} shared_buffers=${PG_SHARED_BUFFERS:-<pg0-default>} fsync=${PG_FSYNC:-<pg0-default:off>}"
+    log "pg0 pre-start ok: name=${PG0_NAME} effective_cache_size=${PG_EFFECTIVE_CACHE_SIZE:-<pg0-default>} shared_buffers=${PG_SHARED_BUFFERS:-<pg0-default>} fsync=${PG_FSYNC:-<pg0-default:off>} shared_preload_libraries=$([ -n "${_pg_preload_major}" ] && echo pg_search || echo '<none>')"
     return 0
   fi
 
-  # `already running` is not a failure — some other path won the race and the
-  # instance is up; hindsight_api adopts it either way.
+  # `already running` — some path won the race and the instance is up. When NO
+  # preload is required, adopting it is fine (hindsight_api would too). But when
+  # the pg_search preload IS required (_pg_preload_major set), a postmaster that
+  # came up WITHOUT shared_preload_libraries=pg_search can never CREATE EXTENSION
+  # pg_search (PGC_POSTMASTER — the GUC only applies at start), so adopting it
+  # silently would strand the box on a boot loop or a broken text-search backend.
+  # Verify via SHOW; if the preload is absent, STOP and restart WITH it rather
+  # than adopt a preload-less postmaster (MAJOR-2). This matters when
+  # provision_pg_search()'s own `pg0 stop` failed and left a plain server up.
   if printf '%s' "${_out}" | grep -qi 'already running'; then
-    log "pg0 pre-start: instance ${PG0_NAME} already running; leaving it alone"
+    if [ -z "${_pg_preload_major}" ]; then
+      log "pg0 pre-start: instance ${PG0_NAME} already running; leaving it alone"
+      return 0
+    fi
+    _cur_preload=""
+    _psqlx="$(command -v psql 2>/dev/null || ls /home/hindsight/.pg0/installation/*/bin/psql 2>/dev/null | head -1)"
+    if [ -n "${_psqlx}" ] && [ -x "${_psqlx}" ] && [ -n "${_pport}" ]; then
+      _cur_preload="$(PGPASSWORD="${_pp}" "${_psqlx}" -U "${_pu}" -h /tmp -p "${_pport}" -d "${_pd}" -tAc 'SHOW shared_preload_libraries' 2>/dev/null || true)"
+    fi
+    case "${_cur_preload}" in
+      *pg_search*)
+        log "pg0 pre-start: instance ${PG0_NAME} already running WITH pg_search preload; adopting"
+        return 0
+        ;;
+    esac
+    log "WARNING: pg0 pre-start: instance ${PG0_NAME} already running WITHOUT pg_search preload; stopping to restart with shared_preload_libraries=pg_search"
+    if _stout="$("${_pg0}" stop --name "${PG0_NAME}" 2>&1)"; then
+      if _out2="$("${_pg0}" "$@" 2>&1)"; then
+        log "pg0 pre-start ok (restarted to apply pg_search preload): name=${PG0_NAME} shared_preload_libraries=pg_search"
+        return 0
+      fi
+      log "WARNING: pg0 pre-start: restart-with-preload failed; hindsight_api's CREATE EXTENSION pg_search will surface it. detail: $(printf '%s' "${_out2}" | tr '\n' ' ' | cut -c1-300)"
+      return 0
+    fi
+    log "WARNING: pg0 pre-start: could not stop the already-running instance to apply the pg_search preload; adopting the preload-less postmaster (CREATE EXTENSION pg_search will fail loudly). detail: $(printf '%s' "${_stout}" | tr '\n' ' ' | cut -c1-300)"
     return 0
   fi
 
@@ -592,6 +713,186 @@ EOF
   return 0
 }
 
+# ---------------------------------------------------------------------------
+# ParadeDB pg_search provisioning (durable BM25 backend).
+#
+# pg_search is a Postgres extension whose LIBRARY (pg_search.so, ~180MB) is
+# loaded into the postmaster via shared_preload_libraries and whose control+SQL
+# live in the embedded-pg install's share/extension. Both are baked into the
+# image at a STABLE path (docker/Dockerfile.hindsight) but must be re-copied
+# into pg0's version-scoped install dir on every boot, because that dir lives on
+# a mounted volume the image content cannot reach — the same durability problem
+# provision_text_search() solves for the stopword file, and the same fix.
+#
+# THE ORDERING PROBLEM this function exists to solve. shared_preload_libraries
+# is PGC_POSTMASTER: it only takes effect at server start, and a server told to
+# preload a library that is not present FAILS to start. On a FRESH volume the
+# install dir does not exist until pg0 first extracts it, so we cannot copy the
+# .so before pg0 has run at least once — but we must not hand the very first
+# start a preload it cannot satisfy. So:
+#   (1) start pg0 PLAIN (no preload) — this extracts the install dir and can
+#       never fail on the not-yet-copied library;
+#   (2) copy the .so + control + SQL into every MAJOR-matched install dir;
+#   (3) STOP pg0, so the NEXT start — prestart_pg0(), which runs immediately
+#       after us — is the authoritative one that sets
+#       shared_preload_libraries=pg_search against a now-present library.
+# On a reboot the install dir already exists, so step (1) is skipped and this is
+# just an idempotent re-copy + a stop of a server that was not running.
+#
+# BEST-EFFORT BY CONSTRUCTION. Every failure path returns 0. Gated entirely on
+# pg_search_baked_major() — a stock native fleet (selector != pg_search, or an
+# older image with no bake) never enters here and is byte-identical to before.
+#
+# ── EXISTING-INSTALL MIGRATION BOUNDARY (read before assuming this migrates) ──
+# This function makes a NEW (empty) database come up on pg_search. It does NOT,
+# and MUST NOT, migrate a POPULATED database from the native tsvector backend:
+# hindsight_api HARD-REFUSES a text-search backend switch on non-empty memory
+# tables (the BM25 index must be rebuilt under a different operator class, which
+# upstream will not silently do under live data). The data migration is a
+# DELIBERATE operator-run step (pg_dump backup → drop the native search index →
+# flip HINDSIGHT_API_TEXT_SEARCH_EXTENSION → restart so this provisioning +
+# prestart_pg0 preload run → let hindsight_api rebuild the BM25 index). An
+# operator not ready to migrate pins `native` in hindsight.env; that pin
+# survives `switchroom apply` (the key is on HINDSIGHT_PERF_ENV_KEYS) and this
+# function no-ops. Nothing here touches operator data.
+provision_pg_search() {
+  _psm="$(pg_search_baked_major)"
+  [ -n "${_psm}" ] || return 0
+
+  # Only the embedded pg0 database is ours to provision — never an operator's
+  # external postgres.
+  case "${HINDSIGHT_API_DB_URL:-pg0}" in
+    pg0 | "pg0://${PG0_NAME}") : ;;
+    *)
+      log "pg_search provisioning skipped: HINDSIGHT_API_DB_URL=${HINDSIGHT_API_DB_URL:-} is not the default embedded instance"
+      return 0
+      ;;
+  esac
+
+  _src_lib="${PG_SEARCH_SRC_ROOT}/${_psm}/lib/pg_search.so"
+  _src_ext="${PG_SEARCH_SRC_ROOT}/${_psm}/extension"
+  if [ ! -r "${_src_lib}" ] || [ ! -d "${_src_ext}" ]; then
+    log "WARNING: pg_search provisioning: baked artifacts missing (${_src_lib}); skipping"
+    return 0
+  fi
+
+  _pg0="${PG0_BIN}"
+  if [ -z "${_pg0}" ]; then
+    _pg0="$(command -v pg0 2>/dev/null || ls /app/api/.venv/lib/python3.*/site-packages/pg0/bin/pg0 2>/dev/null | head -1)"
+  fi
+  if [ -z "${_pg0}" ] || [ ! -x "${_pg0}" ]; then
+    log "WARNING: pg_search provisioning: pg0 binary not found; skipping (CREATE EXTENSION pg_search will fail if the .so is absent)"
+    return 0
+  fi
+
+  # (1) On a FRESH volume the install dir does not exist until pg0 extracts it.
+  # Start pg0 PLAIN so the extraction can never fail on the not-yet-copied
+  # library. Reuse the descriptor's identity when present (never rewrite creds);
+  # on first boot use hindsight_api's own defaults + pg0 auto-port, exactly like
+  # prestart_pg0 / provision_text_search.
+  _have_install=0
+  for _id in ${PG_SEARCH_INSTALL_GLOB}; do
+    [ -d "${_id}/lib" ] || continue
+    _have_install=1
+    break
+  done
+  if [ "${_have_install}" != 1 ]; then
+    _pu="hindsight"; _pp="hindsight"; _pd="hindsight"; _pport=""
+    if [ -r "${PG0_INSTANCE}" ]; then
+      if { read -r _v_u; read -r _v_d; read -r _v_p; read -r _v_pw; } <<EOF
+$(python3 -c 'import json,sys;d=json.load(open(sys.argv[1]));print(d.get("username","hindsight"));print(d.get("database","hindsight"));print(d.get("port",""));print(d.get("password","hindsight"))' "${PG0_INSTANCE}" 2>/dev/null)
+EOF
+      then
+        if [ -n "${_v_u}" ]; then _pu="${_v_u}"; fi
+        if [ -n "${_v_d}" ]; then _pd="${_v_d}"; fi
+        if [ -n "${_v_pw}" ]; then _pp="${_v_pw}"; fi
+        if [ -n "${_v_p}" ]; then _pport="${_v_p}"; fi
+      fi
+    fi
+    set -- start --name "${PG0_NAME}" --username "${_pu}" --password "${_pp}" --database "${_pd}"
+    if [ -n "${_pport}" ]; then set -- "$@" --port "${_pport}"; fi
+    if _sout="$("${_pg0}" "$@" 2>&1)"; then
+      :
+    elif printf '%s' "${_sout}" | grep -qi 'already running'; then
+      :
+    else
+      log "WARNING: pg_search provisioning: initial pg0 start failed; skipping copy (CREATE EXTENSION pg_search will fail). detail: $(printf '%s' "${_sout}" | tr '\n' ' ' | cut -c1-200)"
+      return 0
+    fi
+  fi
+
+  # (2) Re-materialize the extension into every MAJOR-matched install dir. A
+  # version bump that lands a NEW major ahead of the baked deb is skipped with a
+  # loud warning rather than copying an ABI-mismatched .so (which would crash the
+  # postmaster on preload) — bump PG_SEARCH_* in the Dockerfile to match.
+  _placed=0
+  for _id in ${PG_SEARCH_INSTALL_GLOB}; do
+    [ -d "${_id}/lib" ] || continue
+    _ver="${_id##*/}"
+    case "${_ver}" in
+      "${_psm}" | "${_psm}".*) : ;;
+      *)
+        log "WARNING: pg_search provisioning: install ${_ver} major != baked ${_psm}; NOT copying (ABI mismatch — bump the baked pg_search deb)"
+        continue
+        ;;
+    esac
+    [ -d "${_id}/share/extension" ] || mkdir -p "${_id}/share/extension" 2>/dev/null || true
+    if cp -f "${_src_lib}" "${_id}/lib/pg_search.so" 2>/dev/null &&
+      cp -f "${_src_ext}/"pg_search*.control "${_id}/share/extension/" 2>/dev/null &&
+      cp -f "${_src_ext}/"pg_search*.sql "${_id}/share/extension/" 2>/dev/null; then
+      _placed=1
+    else
+      log "WARNING: pg_search provisioning: copy into ${_id} failed"
+    fi
+  done
+  if [ "${_placed}" != 1 ]; then
+    log "WARNING: pg_search provisioning: no major-matched install dir under ${PG_SEARCH_INSTALL_GLOB}; extension NOT staged (CREATE EXTENSION pg_search will fail)"
+  else
+    log "pg_search provisioning ok: staged pg_search.so + control + sql (major ${_psm}) into embedded-pg install"
+  fi
+
+  # (3) Stop pg0 so prestart_pg0 can (re)start it with
+  # shared_preload_libraries=pg_search — a PGC_POSTMASTER GUC that only applies
+  # at server start. `pg0 stop` blocks until the postmaster has fully exited, so
+  # on success the instance is confirmed DOWN and prestart_pg0's start cannot
+  # race it. But this stop MUST actually take effect: if an up-but-preload-less
+  # postmaster survives here and prestart_pg0 then sees "already running", the
+  # preload never gets applied and CREATE EXTENSION pg_search crash-loops. So on
+  # a non-"already-down" stop failure we do NOT silently proceed — we re-verify
+  # with a bounded, idempotent second stop (a down server reports "not running")
+  # and loud-warn if the instance is still up, leaving prestart_pg0's own
+  # SHOW-verify branch as the backstop rather than a silent adopt.
+  if _stout="$("${_pg0}" stop --name "${PG0_NAME}" 2>&1)"; then
+    :
+  else
+    case "${_stout}" in
+      *"not running"* | *"no server"* | *"not found"* | *"No such"*) : ;;
+      *)
+        log "pg_search provisioning: pg0 stop returned: $(printf '%s' "${_stout}" | tr '\n' ' ' | cut -c1-200)"
+        # Confirm the postmaster is actually down before returning. Re-issue stop
+        # up to a few times; a down instance reports the not-running family.
+        _down=0
+        _try=0
+        while [ "${_try}" -lt 5 ]; do
+          _try=$((_try + 1))
+          if _vout="$("${_pg0}" stop --name "${PG0_NAME}" 2>&1)"; then
+            _down=1
+            break
+          fi
+          case "${_vout}" in
+            *"not running"* | *"no server"* | *"not found"* | *"No such"*) _down=1; break ;;
+          esac
+          sleep 1
+        done
+        if [ "${_down}" != 1 ]; then
+          log "WARNING: pg_search provisioning: pg0 instance ${PG0_NAME} still running after stop; prestart_pg0 will SHOW-verify the preload and restart or fail loudly rather than adopt it"
+        fi
+        ;;
+    esac
+  fi
+  return 0
+}
+
 # 1. Wait for the broker socket. The broker may still be starting on
 # the host when this container boots (no cross-project depends_on).
 i=0
@@ -650,11 +951,21 @@ export CLAUDE_CONFIG_DIR="${CRED_DIR}"
 # 4b. Boot-deferred stale-claim reaper (does not block boot; see fn header).
 reap_stale_processing_when_ready || true
 
+# 4b2. pg_search staging (durable BM25 backend). MUST run before prestart_pg0:
+# it stages the extension .so into pg0's install dir and leaves pg0 STOPPED so
+# prestart_pg0's start is the one that sets shared_preload_libraries=pg_search
+# (a PGC_POSTMASTER GUC). No-op unless pg_search is the selected backend AND the
+# artifacts are baked in. Synchronous + best-effort — see provision_pg_search().
+provision_pg_search || true
+
 # 4c. pg0 sizing pre-start (#3706). MUST run before the exec: hindsight_api's
 # ensure_running() adopts an already-running instance without re-applying
 # config, which is the only reason we can set these at all. Synchronous by
 # necessity (a background race would let hindsight_api win and start pg0
 # untuned); bounded by pg0's own start, and best-effort — see prestart_pg0().
+# When pg_search is the selected backend this is also the start that applies
+# shared_preload_libraries=pg_search against the library provision_pg_search
+# just staged (which is why that ran first and left pg0 stopped).
 prestart_pg0 || true
 
 # 4d. Text-search provisioning (durable stopword config). MUST run before the

--- a/src/setup/hindsight-perf-defaults.test.ts
+++ b/src/setup/hindsight-perf-defaults.test.ts
@@ -192,6 +192,7 @@ describe("hindsightPerfEnv — capability gating", () => {
       "HINDSIGHT_API_RECENCY_DECAY_FUNCTION",
       "HINDSIGHT_API_RECENCY_DECAY_HALFLIFE_DAYS",
       "HINDSIGHT_API_GRAPH_SEED_MIN_SIMILARITY",
+      "HINDSIGHT_API_TEXT_SEARCH_EXTENSION",
     ];
     expect(HINDSIGHT_PERF_DEFAULTS_UNGATED.map(([k]) => k)).toEqual(UNGATED);
     for (const caps of [
@@ -351,7 +352,7 @@ describe("operator override wins", () => {
     expect(got.size).toBe(0);
   });
 
-  it("is overridable on exactly these forty-nine keys, by name", () => {
+  it("is overridable on exactly these fifty keys, by name", () => {
     // Spelled out, NOT derived from the three group arrays. HINDSIGHT_PERF_ENV_KEYS
     // is DEFINED as the union of those arrays, so asserting it equals that union
     // is a tautology — it passes no matter which keys are in the arrays. The
@@ -389,6 +390,7 @@ describe("operator override wins", () => {
       "HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY",
       "HINDSIGHT_API_TEMPORAL_LANGUAGES",
       "HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS",
+      "HINDSIGHT_API_TEXT_SEARCH_EXTENSION",
       "HINDSIGHT_API_TEXT_SEARCH_EXTENSION_NATIVE_LANGUAGE",
       "HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY",
       // Both spellings of every per-type slot reservation are ACCEPTED as

--- a/src/setup/hindsight-perf-defaults.ts
+++ b/src/setup/hindsight-perf-defaults.ts
@@ -866,6 +866,52 @@ export const HINDSIGHT_DEFAULT_RECENCY_DECAY_HALFLIFE_DAYS = 30;
  * instead (already on by default; see vendor/hindsight-memory/scripts/recall.py).
  */
 
+/**
+ * The text-search backend hindsight_api uses for the BM25 recall arm.
+ *
+ * switchroom defaults NEW installs to ParadeDB `pg_search` — a Tantivy-backed
+ * BM25 index that replaces the native `tsvector`/`ts_rank` arm, which on this
+ * fleet degenerated to full seq-scans on the highest-frequency lexemes
+ * (`claude`/`code`/`agent`, folded into ~80% of rows via the `context` tag).
+ * The value is one of the strings hindsight_api validates at boot
+ * (`config.py`: `("native", "vchord", "pg_textsearch", "pgroonga",
+ * "pg_search")`); anything else is a hard `ValueError`. The extension itself is
+ * provisioned durably by the image — the baked `.so` + control/sql are copied
+ * into the embedded-pg install and `pg_search` is added to
+ * `shared_preload_libraries` at boot (`docker/hindsight-entrypoint.sh`,
+ * `provision_pg_search()` + `prestart_pg0()`), so a fresh volume comes up with a
+ * working BM25 index and no operator step.
+ *
+ * ## Migration boundary — READ THIS before assuming a live fleet flips
+ *
+ * This default is safe **only for a NEW install (empty memory tables).**
+ * hindsight_api HARD-REFUSES to switch the text-search backend on a non-empty
+ * database: swapping `native` → `pg_search` requires the BM25 index to be
+ * rebuilt with a different operator class, and upstream will not silently drop
+ * and recreate it under live data. So this key going to `pg_search` does NOT
+ * migrate an existing bank on the next `switchroom apply` — the container would
+ * refuse to start against populated tables.
+ *
+ * The data migration is a DELIBERATE, operator-run manual step, NOT encoded
+ * here. An operator on a populated fleet who is not ready to migrate must pin
+ * the prior backend in `hindsight.env`:
+ *
+ * ```yaml
+ * hindsight:
+ *   env:
+ *     HINDSIGHT_API_TEXT_SEARCH_EXTENSION: "native"   # stay on tsvector until migrated
+ * ```
+ *
+ * That pin SURVIVES `switchroom apply` precisely because adding the key to
+ * {@link HINDSIGHT_PERF_DEFAULTS_UNGATED} below also places it in
+ * {@link HINDSIGHT_PERF_ENV_KEYS} (the allowlist is the union of the default
+ * groups) and {@link resolveHindsightPerfOverrides} then lets the operator
+ * value replace the emitted default. Absent that allowlist membership the pin
+ * would be silently discarded and the fleet would try to boot on `pg_search`
+ * against live data — which is exactly the trap this pairing avoids.
+ */
+export const HINDSIGHT_DEFAULT_TEXT_SEARCH_EXTENSION = "pg_search";
+
 /** Emitted on every host — bounded work, no hardware assumption. */
 export const HINDSIGHT_PERF_DEFAULTS_UNGATED: ReadonlyArray<readonly [string, string]> = [
   [
@@ -933,6 +979,10 @@ export const HINDSIGHT_PERF_DEFAULTS_UNGATED: ReadonlyArray<readonly [string, st
     "HINDSIGHT_API_GRAPH_SEED_MIN_SIMILARITY",
     String(HINDSIGHT_DEFAULT_GRAPH_SEED_MIN_SIMILARITY),
   ],
+  // NEW-install default only; a populated fleet migrates by hand or pins
+  // `native`. See HINDSIGHT_DEFAULT_TEXT_SEARCH_EXTENSION's migration-boundary
+  // note above for why this pairing (default + allowlist membership) is load-bearing.
+  ["HINDSIGHT_API_TEXT_SEARCH_EXTENSION", HINDSIGHT_DEFAULT_TEXT_SEARCH_EXTENSION],
 ];
 
 /** Emitted only when the container can reach a GPU. */

--- a/tests/docker/hindsight-entrypoint.test.ts
+++ b/tests/docker/hindsight-entrypoint.test.ts
@@ -1179,6 +1179,351 @@ exit 0
     expect(r.stderr).toMatch(/text-search provisioning skipped/);
   }, 20_000);
 
+  // provision_pg_search() runs BEFORE prestart_pg0(): it stages the pg_search
+  // extension (.so + control + SQL) into the embedded-pg install dir and leaves
+  // pg0 STOPPED so prestart_pg0's start is the one that sets
+  // shared_preload_libraries=pg_search (a PGC_POSTMASTER GUC). These tests drive
+  // it with a baked-artifact tree + a fake pg0 and assert the OUTCOME.
+
+  /** Stage a fake baked pg_search artifact tree (.so + control + version SQL). */
+  function installFakePgSearchBake(root: string, major = "18"): void {
+    const lib = join(root, major, "lib");
+    const ext = join(root, major, "extension");
+    mkdirSync(lib, { recursive: true });
+    mkdirSync(ext, { recursive: true });
+    writeFileSync(join(lib, "pg_search.so"), "\x7fELF fake pg_search .so");
+    writeFileSync(join(ext, "pg_search.control"), "default_version = '0.25.1'\n");
+    writeFileSync(join(ext, "pg_search--0.25.1.sql"), "-- fake base sql\n");
+    writeFileSync(join(ext, "pg_search--0.24.0--0.25.1.sql"), "-- fake upgrade sql\n");
+  }
+
+  it("stages pg_search into the install dir and preloads it via prestart_pg0", async () => {
+    // The core happy path (reboot: the version-scoped install dir already
+    // exists). The .so + control + SQL are copied in, pg0 is STOPPED, and the
+    // authoritative prestart start carries shared_preload_libraries=pg_search.
+    stopBroker = await startFakeBroker(socketPath);
+    const pg0log = join(dir, "pgs-pg0.log");
+    const bakeRoot = join(dir, "bake");
+    installFakePgSearchBake(bakeRoot);
+    const installLib = join(dir, "inst", "18.1.0", "lib");
+    const installExt = join(dir, "inst", "18.1.0", "share", "extension");
+    mkdirSync(installLib, { recursive: true });
+    mkdirSync(installExt, { recursive: true });
+    const marker = join(dir, "pgs-cmd-ran");
+
+    const r = await runWithEnv(
+      {
+        SWITCHROOM_HINDSIGHT_PG0_BIN: installFakePg0(pg0log),
+        SWITCHROOM_HINDSIGHT_REAP_STALE_S: "0",
+        SWITCHROOM_HINDSIGHT_PG_SEARCH_SRC_ROOT: bakeRoot,
+        SWITCHROOM_HINDSIGHT_PG_SEARCH_INSTALL_GLOB: join(dir, "inst", "*"),
+        HINDSIGHT_API_TEXT_SEARCH_EXTENSION: "pg_search",
+      },
+      ["sh", "-c", `touch ${marker}`],
+    );
+    expect(r.status).toBe(0);
+    expect(existsSync(marker)).toBe(true);
+
+    // The extension artifacts were materialized into the current install dir.
+    expect(existsSync(join(installLib, "pg_search.so"))).toBe(true);
+    expect(existsSync(join(installExt, "pg_search.control"))).toBe(true);
+    expect(existsSync(join(installExt, "pg_search--0.25.1.sql"))).toBe(true);
+
+    const argv = argvOf(pg0log);
+    // provision_pg_search stops pg0 so the preload can be applied at next start.
+    expect(argv).toContain("stop");
+    // prestart_pg0's authoritative start carries the preload GUC.
+    expect(argv).toContain("shared_preload_libraries=pg_search");
+    expect(r.stderr).toMatch(/pg_search provisioning ok/);
+    expect(r.stderr).toMatch(/pg0 pre-start ok/);
+  }, 20_000);
+
+  it("starts pg0 PLAIN first to extract a fresh-volume install dir, then copies", async () => {
+    // First boot on an empty volume: the install dir does not exist until pg0
+    // extracts it. provision_pg_search must start pg0 WITHOUT a preload it
+    // cannot yet satisfy, let the dir appear, then copy — never hand the very
+    // first start a missing library.
+    stopBroker = await startFakeBroker(socketPath);
+    const pg0log = join(dir, "pgs-fresh-pg0.log");
+    const bakeRoot = join(dir, "bake");
+    installFakePgSearchBake(bakeRoot);
+    const installBase = join(dir, "inst", "18.1.0");
+    // A fake pg0 that materializes the version-scoped install dir on `start`,
+    // exactly as the real pg0 extracts it on first run.
+    const binDir = execTmpDir("swr-fakepg0-mkinstall-");
+    const pg0 = join(binDir, "pg0");
+    writeFileSync(
+      pg0,
+      `#!/bin/sh
+for a in "$@"; do printf '%s\\n' "$a" >> "${pg0log}"; done
+if [ "$1" = start ]; then mkdir -p "${join(installBase, "lib")}" "${join(installBase, "share", "extension")}"; fi
+exit 0
+`,
+      { mode: 0o755 },
+    );
+
+    const r = await runWithEnv({
+      SWITCHROOM_HINDSIGHT_PG0_BIN: pg0,
+      SWITCHROOM_HINDSIGHT_REAP_STALE_S: "0",
+      SWITCHROOM_HINDSIGHT_PG_SEARCH_SRC_ROOT: bakeRoot,
+      SWITCHROOM_HINDSIGHT_PG_SEARCH_INSTALL_GLOB: join(dir, "inst", "*"),
+      HINDSIGHT_API_TEXT_SEARCH_EXTENSION: "pg_search",
+    });
+    expect(r.status).toBe(0);
+    // The plain extraction start ran (a `start` appears in the log) …
+    expect(argvOf(pg0log)).toContain("start");
+    // … and the copy landed after the dir appeared.
+    expect(existsSync(join(installBase, "lib", "pg_search.so"))).toBe(true);
+    expect(existsSync(join(installBase, "share", "extension", "pg_search.control"))).toBe(true);
+    expect(r.stderr).toMatch(/pg_search provisioning ok/);
+  }, 20_000);
+
+  it("is a clean no-op (no copy, no preload) when the backend is not pg_search", async () => {
+    // The byte-identical-to-before guarantee: a native-pinned fleet (or an older
+    // switchroom that never emits the selector) must not stage the extension nor
+    // preload it. This is the safety valve for a not-yet-migrated populated DB.
+    stopBroker = await startFakeBroker(socketPath);
+    const pg0log = join(dir, "pgs-native-pg0.log");
+    const bakeRoot = join(dir, "bake");
+    installFakePgSearchBake(bakeRoot);
+    const installLib = join(dir, "inst", "18.1.0", "lib");
+    mkdirSync(installLib, { recursive: true });
+
+    const r = await runWithEnv({
+      SWITCHROOM_HINDSIGHT_PG0_BIN: installFakePg0(pg0log),
+      SWITCHROOM_HINDSIGHT_REAP_STALE_S: "0",
+      SWITCHROOM_HINDSIGHT_PG_SEARCH_SRC_ROOT: bakeRoot,
+      SWITCHROOM_HINDSIGHT_PG_SEARCH_INSTALL_GLOB: join(dir, "inst", "*"),
+      HINDSIGHT_API_TEXT_SEARCH_EXTENSION: "native",
+    });
+    expect(r.status).toBe(0);
+    // Not staged …
+    expect(existsSync(join(installLib, "pg_search.so"))).toBe(false);
+    // … and never preloaded.
+    expect(argvOf(pg0log)).not.toContain("shared_preload_libraries=pg_search");
+    expect(r.stderr).not.toMatch(/pg_search provisioning ok/);
+  }, 20_000);
+
+  it("refuses to copy an ABI-mismatched .so when the install major moves ahead of the baked deb", async () => {
+    // A pg0 embedded-pg bump that lands a NEW major before the baked deb is
+    // updated must NOT copy the wrong-major .so (which would crash the postmaster
+    // on preload). It is skipped with a loud warning; bump PG_SEARCH_* to fix.
+    stopBroker = await startFakeBroker(socketPath);
+    const pg0log = join(dir, "pgs-mismatch-pg0.log");
+    const bakeRoot = join(dir, "bake");
+    installFakePgSearchBake(bakeRoot, "18");
+    // The live install is major 19 — ahead of the baked 18.
+    const installLib = join(dir, "inst", "19.0.0", "lib");
+    mkdirSync(installLib, { recursive: true });
+
+    const r = await runWithEnv({
+      SWITCHROOM_HINDSIGHT_PG0_BIN: installFakePg0(pg0log),
+      SWITCHROOM_HINDSIGHT_REAP_STALE_S: "0",
+      SWITCHROOM_HINDSIGHT_PG_SEARCH_SRC_ROOT: bakeRoot,
+      SWITCHROOM_HINDSIGHT_PG_SEARCH_INSTALL_GLOB: join(dir, "inst", "*"),
+      HINDSIGHT_API_TEXT_SEARCH_EXTENSION: "pg_search",
+    });
+    expect(r.status).toBe(0);
+    expect(existsSync(join(installLib, "pg_search.so"))).toBe(false);
+    expect(r.stderr).toMatch(/major != baked/);
+    // The load-bearing half: because the copy was SKIPPED, no .so landed in the
+    // version-matched install dir, so prestart_pg0 must NOT hand the postmaster
+    // shared_preload_libraries=pg_search — that would tell pg0 to preload a
+    // library that isn't there and turn a graceful ABI-skip into a boot
+    // crash-loop. The preload gate keys off the LANDED artifact, not the bake.
+    expect(argvOf(pg0log)).not.toContain("shared_preload_libraries=pg_search");
+  }, 20_000);
+
+  it("does NOT adopt an already-running preload-less postmaster: SHOW-verifies, stops, restarts WITH the preload (MAJOR-2)", async () => {
+    // The dangerous adopt path: provision_pg_search()'s best-effort stop left a
+    // plain (preload-less) postmaster up, and prestart_pg0's `start` loses the
+    // race and gets "already running". A naive adopt would strand the box —
+    // shared_preload_libraries is PGC_POSTMASTER, so CREATE EXTENSION pg_search
+    // can never succeed against a server that came up without the preload. The
+    // entrypoint must SHOW-verify the preload, and finding it absent, STOP and
+    // restart WITH shared_preload_libraries=pg_search rather than adopt.
+    stopBroker = await startFakeBroker(socketPath);
+    const pg0log = join(dir, "pgs-adopt-pg0.log");
+    const bakeRoot = join(dir, "bake");
+    installFakePgSearchBake(bakeRoot, "18");
+    // Reboot path: a version-matched install dir already exists, so the .so
+    // lands there and the preload IS intended (landed major 18 == baked 18).
+    mkdirSync(join(dir, "inst", "18.1.0", "lib"), { recursive: true });
+    mkdirSync(join(dir, "inst", "18.1.0", "share", "extension"), { recursive: true });
+
+    // A stateful fake pg0: the FIRST `start` reports "already running" (the
+    // preload-less postmaster provisioning left up); after a `stop`, the next
+    // `start` succeeds — modelling a real stop+restart that applies the preload.
+    // Each invocation is also logged as ONE space-joined line to invLog so the
+    // test can count how many `start`s carried shared_preload_libraries=pg_search
+    // (a later native provision_text_search start carries none, so a raw token
+    // count would be ambiguous — the preload flag is the load-bearing signal).
+    const binDir = execTmpDir("swr-fakepg0-adopt-");
+    const pg0 = join(binDir, "pg0");
+    const startCtr = join(dir, "adopt-startctr");
+    const invLog = join(dir, "adopt-inv.log");
+    writeFileSync(
+      pg0,
+      `#!/bin/sh
+for a in "$@"; do printf '%s\\n' "$a" >> "${pg0log}"; done
+printf '%s\\n' "$*" >> "${invLog}"
+if [ "$1" = start ]; then
+  n=$(cat "${startCtr}" 2>/dev/null || echo 0); n=$((n + 1)); echo "$n" > "${startCtr}"
+  if [ "$n" = 1 ]; then echo "fake pg0: FATAL: instance is already running" >&2; exit 1; fi
+fi
+exit 0
+`,
+      { mode: 0o755 },
+    );
+
+    const stateDir = join(dir, "adopt-fakestate");
+    const psqlBin = installFakePsql(stateDir); // SHOW ... -> empty (preload-less)
+    const psqlLog = join(dir, "adopt-psql.log");
+    const pgInstance = join(dir, "adopt-instance.json");
+    writePgInstance(pgInstance);
+
+    const r = await runWithEnv({
+      SWITCHROOM_HINDSIGHT_PG0_BIN: pg0,
+      PATH: `${psqlBin}:${process.env.PATH}`,
+      FAKE_PSQL_LOG: psqlLog,
+      SWITCHROOM_HINDSIGHT_PG0_INSTANCE: pgInstance,
+      SWITCHROOM_HINDSIGHT_REAP_STALE_S: "0",
+      SWITCHROOM_HINDSIGHT_PG_SEARCH_SRC_ROOT: bakeRoot,
+      SWITCHROOM_HINDSIGHT_PG_SEARCH_INSTALL_GLOB: join(dir, "inst", "*"),
+      HINDSIGHT_API_TEXT_SEARCH_EXTENSION: "pg_search",
+    });
+    expect(r.status).toBe(0);
+    // The preload was SHOW-verified against the running postmaster.
+    expect(argvOf(psqlLog)).toContain("SHOW shared_preload_libraries");
+    // It did NOT silently adopt: the preload-less server was stopped and a
+    // SECOND preload-carrying start ran. A silent adopt would show exactly ONE
+    // start carrying shared_preload_libraries=pg_search (the failed first try).
+    const preloadStarts = argvOf(invLog).filter(
+      (l) => l.startsWith("start") && l.includes("shared_preload_libraries=pg_search"),
+    ).length;
+    expect(preloadStarts).toBe(2);
+    expect(argvOf(pg0log)).toContain("stop");
+    expect(r.stderr).toMatch(/already running WITHOUT pg_search preload/);
+    expect(r.stderr).toMatch(/restarted to apply pg_search preload/);
+    // And it did NOT take the silent-adopt branch.
+    expect(r.stderr).not.toMatch(/already running WITH pg_search preload; adopting/);
+  }, 20_000);
+
+  it("loud-fails rather than silently adopting when the preload-less postmaster cannot be stopped (MAJOR-2)", async () => {
+    // The unstoppable variant: prestart_pg0 SHOW-verifies the missing preload but
+    // its stop fails. It must NOT pretend success — it adopts only as a last
+    // resort with a LOUD warning that CREATE EXTENSION pg_search will fail, never
+    // logging the "restarted with preload" success line.
+    stopBroker = await startFakeBroker(socketPath);
+    const pg0log = join(dir, "pgs-unstoppable-pg0.log");
+    const bakeRoot = join(dir, "bake");
+    installFakePgSearchBake(bakeRoot, "18");
+    mkdirSync(join(dir, "inst", "18.1.0", "lib"), { recursive: true });
+    mkdirSync(join(dir, "inst", "18.1.0", "share", "extension"), { recursive: true });
+
+    // Fake pg0: `start` always reports "already running"; the FIRST `stop`
+    // (provision's) succeeds so provisioning stays fast, but the SECOND `stop`
+    // (prestart's) fails — the postmaster cannot be brought down.
+    const binDir = execTmpDir("swr-fakepg0-unstoppable-");
+    const pg0 = join(binDir, "pg0");
+    const stopCtr = join(dir, "unstoppable-stopctr");
+    const invLog = join(dir, "unstoppable-inv.log");
+    writeFileSync(
+      pg0,
+      `#!/bin/sh
+for a in "$@"; do printf '%s\\n' "$a" >> "${pg0log}"; done
+printf '%s\\n' "$*" >> "${invLog}"
+if [ "$1" = stop ]; then
+  n=$(cat "${stopCtr}" 2>/dev/null || echo 0); n=$((n + 1)); echo "$n" > "${stopCtr}"
+  if [ "$n" = 1 ]; then exit 0; fi
+  echo "fake pg0: stop failed: could not remove postmaster.pid" >&2; exit 1
+fi
+if [ "$1" = start ]; then echo "fake pg0: FATAL: instance is already running" >&2; exit 1; fi
+exit 0
+`,
+      { mode: 0o755 },
+    );
+
+    const stateDir = join(dir, "unstoppable-fakestate");
+    const psqlBin = installFakePsql(stateDir);
+    const pgInstance = join(dir, "unstoppable-instance.json");
+    writePgInstance(pgInstance);
+
+    const r = await runWithEnv({
+      SWITCHROOM_HINDSIGHT_PG0_BIN: pg0,
+      PATH: `${psqlBin}:${process.env.PATH}`,
+      SWITCHROOM_HINDSIGHT_PG0_INSTANCE: pgInstance,
+      SWITCHROOM_HINDSIGHT_REAP_STALE_S: "0",
+      SWITCHROOM_HINDSIGHT_PG_SEARCH_SRC_ROOT: bakeRoot,
+      SWITCHROOM_HINDSIGHT_PG_SEARCH_INSTALL_GLOB: join(dir, "inst", "*"),
+      HINDSIGHT_API_TEXT_SEARCH_EXTENSION: "pg_search",
+    });
+    // Boot still proceeds (best-effort), but the failure is LOUD, not silent.
+    expect(r.status).toBe(0);
+    expect(r.stderr).toMatch(/could not stop the already-running instance/);
+    expect(r.stderr).toMatch(/adopting the preload-less postmaster/);
+    // No successful restart happened: only the one (failed) preload-carrying start.
+    const preloadStarts = argvOf(invLog).filter(
+      (l) => l.startsWith("start") && l.includes("shared_preload_libraries=pg_search"),
+    ).length;
+    expect(preloadStarts).toBe(1);
+    expect(r.stderr).not.toMatch(/restarted to apply pg_search preload/);
+  }, 20_000);
+
+  it("skips pg_search provisioning for an external (non-embedded) database", async () => {
+    // Never reach into an operator's external postgres to stage our extension.
+    stopBroker = await startFakeBroker(socketPath);
+    const pg0log = join(dir, "pgs-extdb-pg0.log");
+    const bakeRoot = join(dir, "bake");
+    installFakePgSearchBake(bakeRoot);
+    const installLib = join(dir, "inst", "18.1.0", "lib");
+    mkdirSync(installLib, { recursive: true });
+
+    const r = await runWithEnv({
+      SWITCHROOM_HINDSIGHT_PG0_BIN: installFakePg0(pg0log),
+      SWITCHROOM_HINDSIGHT_REAP_STALE_S: "0",
+      SWITCHROOM_HINDSIGHT_PG_SEARCH_SRC_ROOT: bakeRoot,
+      SWITCHROOM_HINDSIGHT_PG_SEARCH_INSTALL_GLOB: join(dir, "inst", "*"),
+      HINDSIGHT_API_TEXT_SEARCH_EXTENSION: "pg_search",
+      HINDSIGHT_API_DB_URL: "postgresql://user:pw@db.example.com:5432/hindsight",
+    });
+    expect(r.status).toBe(0);
+    expect(existsSync(join(installLib, "pg_search.so"))).toBe(false);
+    expect(r.stderr).toMatch(/pg_search provisioning skipped/);
+  }, 20_000);
+
+  it("bakes the pinned pg_search deb + libopenblas0 into the Dockerfile", () => {
+    // The entrypoint re-materializes what the image bakes; assert the bake is
+    // present, pinned (no floating latest), and provides the runtime prereq.
+    const dockerfilePath = resolve(__dirname, "..", "..", "docker", "Dockerfile.hindsight");
+    const raw = readFileSync(dockerfilePath, "utf-8");
+    // libopenblas0 is a hard DT_NEEDED of pg_search.so.
+    expect(raw).toMatch(/apt-get install -y --no-install-recommends libopenblas0/);
+    // Version + checksums are pinned, not floating.
+    expect(raw).toMatch(/ARG PG_SEARCH_VERSION=0\.25\.1/);
+    expect(raw).toMatch(/ARG PG_SEARCH_SHA256_AMD64=[0-9a-f]{64}/);
+    expect(raw).toMatch(/ARG PG_SEARCH_SHA256_ARM64=[0-9a-f]{64}/);
+    expect(raw).toMatch(/sha256sum -c -/);
+    // Staged at the STABLE path the entrypoint's PG_SEARCH_SRC_ROOT defaults to.
+    expect(raw).toMatch(/\/usr\/local\/lib\/switchroom\/pg_search/);
+    // amd64 + arm64 ARE the shipped arches: each maps to a checksum, not the
+    // fail branch.
+    expect(raw).toMatch(/amd64\) _arch=amd64; _sha="\$\{PG_SEARCH_SHA256_AMD64\}";;/);
+    expect(raw).toMatch(/arm64\) _arch=arm64; _sha="\$\{PG_SEARCH_SHA256_ARM64\}";;/);
+    // The default text-search backend is pg_search, so a build with NO baked deb
+    // would crash-loop on CREATE EXTENSION at first boot. The unsupported-arch
+    // branch must FAIL the build (exit 1), never silently `exit 0` — and must not
+    // carry the old false "installs fall back to native text search" comment,
+    // which no longer holds now that pg_search is the emitted default.
+    const archCase = raw
+      .split("\n")
+      .find((l) => l.includes("no prebuilt deb") || l.includes("artifact not available for TARGETARCH"));
+    expect(archCase, "unsupported-arch case arm not found in Dockerfile").toBeDefined();
+    expect(archCase).toMatch(/exit 1;;/);
+    expect(archCase).not.toMatch(/exit 0/);
+    expect(raw).not.toMatch(/fall back to native text search/);
+  });
+
   it("Dockerfile pins UID 11000 to match HINDSIGHT_DEFAULT_UID", () => {
     // The broker chowns the per-consumer socket to consumer.uid (mode 0600).
     // If the runtime UID inside hindsight didn't match what the operator


### PR DESCRIPTION
## What

Makes ParadeDB **pg_search** the durable-default full-text backend for Hindsight, replacing native Postgres `tsvector`. Native ranks by bitmap-heap-scanning every matching row (~415ms on large banks); pg_search returns index-driven top-N (spike: **1.6ms** on real 86k-row bank data, 18MB index built in 555ms).

## How (single coherent change, mirrors the #4463 stopword-provisioning pattern)

- **`docker/Dockerfile.hindsight`**: install `libopenblas0` (pg_search.so has a hard `DT_NEEDED` on `libopenblas.so.0`); pinned fetch + sha256-verify + stage the ParadeDB PG18 deb artifacts to a stable baked path. Build fails loudly on missing/mismatched artifact.
- **`docker/hindsight-entrypoint.sh`**: `provision_pg_search()` copies the baked `.so`/control/sql into pg0's version-scoped install dir before start (bump-durable), then `prestart_pg0()` starts with `-c shared_preload_libraries=pg_search`. Major-version mismatch is refused with a loud warning, never a crashed postmaster.
- **`src/setup/hindsight-perf-defaults.ts`**: default selector `HINDSIGHT_API_TEXT_SEARCH_EXTENSION=pg_search`, added to the ungated group so it lands on the allowlist (avoids the silent-drop trap) and an operator `native` pin survives `apply`.

## ⚠️ Migration boundary (operational)

New/empty installs provision pg_search cleanly. **Existing populated banks require a manual migration** — hindsight_api hard-refuses a backend switch on non-empty tables, so an `apply` that flips the default without migrating first would crash-loop. Pin `native` on populated banks, migrate on schedule, then unpin. Runbook lives with the live-fleet rollout, not this PR.

## Verification

- Feasibility spike (throwaway cluster on pg0 PG18.1): ABI-compatible, `CREATE EXTENSION` works, BM25 top-N query confirmed via EXPLAIN, validated on real bank data. Live DB untouched.
- `tsc --noEmit` clean; full `npm run lint` green; scoped vitest green (perf-defaults 216, entrypoint 39, dockerfile-bakes 40, env 58).

🤖 Generated with [Claude Code](https://claude.com/claude-code)