### PR TITLE
fix(hindsight): resolve vault: LLM api_key refs on the recreate/rollout launch path

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -646,6 +646,21 @@ export function registerMemoryCommand(program: Command): void {
 
       const recreate = opts.recreate === true;
 
+      // Resolve the hindsight LLM config's `vault:` api_key refs ONCE for this
+      // invocation, memoized, so both the env-drift compare and the launch
+      // below reuse the SAME resolved value instead of each firing its own
+      // (up to 4) broker round-trips. Resolution happens through the broker —
+      // apply's passphrase resolver never runs on the recreate path, so an
+      // unresolved literal `vault:…` would bake into the container env and fail
+      // every retain (2026-08-06 outage).
+      let resolvedLlmPromise: ReturnType<typeof resolveHindsightLlmSecrets> | undefined;
+      const getResolvedLlm = () => {
+        if (!resolvedLlmPromise) {
+          resolvedLlmPromise = resolveHindsightLlmSecrets(getConfig(program).hindsight?.llm);
+        }
+        return resolvedLlmPromise;
+      };
+
       // Resolve which image tag to pull + run. Without an explicit --tag,
       // default to the persisted release.pin when the fleet is pinned, so a
       // manual `memory setup --recreate` on a pinned fleet doesn't silently
@@ -790,8 +805,9 @@ export function registerMemoryCommand(program: Command): void {
             // Resolve `vault:` api_key refs the SAME way the launch below does,
             // so the drift compare is against the env we will ACTUALLY bake —
             // otherwise a resolved live key vs a literal `vault:…` next value
-            // reads as spurious drift on every recreate.
-            const driftLlm = await resolveHindsightLlmSecrets(driftConfig.hindsight?.llm);
+            // reads as spurious drift on every recreate. Shared (memoized) with
+            // the launch so the broker is hit once per invocation.
+            const driftLlm = await getResolvedLlm();
             const nextEnv = hindsightContainerEnvPairs({
               // The recreate rebinds the port it is already on (reusePorts);
               // fall back to the default only when it could not be read.
@@ -998,8 +1014,10 @@ export function registerMemoryCommand(program: Command): void {
         // broker BEFORE the container is launched. Without this the literal
         // `vault:…` string is baked into HINDSIGHT_API_*_LLM_API_KEY and every
         // retain fails auth (2026-08-06 fleet outage) — `switchroom apply`'s
-        // passphrase resolver never runs on the recreate / refresh-hindsight path.
-        const resolvedLlm = await resolveHindsightLlmSecrets(hindsightConfig.hindsight?.llm);
+        // passphrase resolver never runs on the recreate / refresh-hindsight
+        // path. Memoized (getResolvedLlm) so this reuses the env-drift compare's
+        // resolution rather than firing the broker round-trips a second time.
+        const resolvedLlm = await getResolvedLlm();
         startHindsight(
           ports,
           litellmCfg,

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -36,6 +36,7 @@ import {
   hindsightGpuDecision,
   resolveHindsightGpuOverride,
   resolveHindsightCpAccessKey,
+  resolveHindsightLlmSecrets,
   HINDSIGHT_CP_NO_ACCESS_KEY_WARNING,
   HINDSIGHT_DEFAULT_API_PORT,
   HINDSIGHT_DEFAULT_MCP_URL,
@@ -786,12 +787,17 @@ export function registerMemoryCommand(program: Command): void {
             const driftConfig = getConfig(program);
             const driftLitellm = await resolveLiteLLMForHindsight(driftConfig);
             const driftPerf = { env: driftConfig.hindsight?.env };
+            // Resolve `vault:` api_key refs the SAME way the launch below does,
+            // so the drift compare is against the env we will ACTUALLY bake —
+            // otherwise a resolved live key vs a literal `vault:…` next value
+            // reads as spurious drift on every recreate.
+            const driftLlm = await resolveHindsightLlmSecrets(driftConfig.hindsight?.llm);
             const nextEnv = hindsightContainerEnvPairs({
               // The recreate rebinds the port it is already on (reusePorts);
               // fall back to the default only when it could not be read.
               apiPort: reusePorts?.apiPort ?? HINDSIGHT_DEFAULT_API_PORT,
               litellm: driftLitellm,
-              llm: driftConfig.hindsight?.llm,
+              llm: driftLlm,
               // The SAME GPU answer the launch will use, passed as a value.
               gpu: gpuDecision.enabled,
               perf: driftPerf,
@@ -808,7 +814,7 @@ export function registerMemoryCommand(program: Command): void {
             envDriftLines = formatDroppedHindsightEnvReport(
               dropped,
               hindsightResolvedCapabilities(
-                driftConfig.hindsight?.llm,
+                driftLlm,
                 driftLitellm,
                 gpuDecision.enabled,
                 driftPerf,
@@ -988,11 +994,17 @@ export function registerMemoryCommand(program: Command): void {
         const litellmCfg = await resolveLiteLLMForHindsight(hindsightConfig);
         const cpAccessKey = await resolveHindsightCpAccessKey(hindsightConfig);
         if (!cpAccessKey) console.log(chalk.yellow(`  ! ${HINDSIGHT_CP_NO_ACCESS_KEY_WARNING}`));
+        // Resolve any `vault:` refs in the LLM api_key fields through the
+        // broker BEFORE the container is launched. Without this the literal
+        // `vault:…` string is baked into HINDSIGHT_API_*_LLM_API_KEY and every
+        // retain fails auth (2026-08-06 fleet outage) — `switchroom apply`'s
+        // passphrase resolver never runs on the recreate / refresh-hindsight path.
+        const resolvedLlm = await resolveHindsightLlmSecrets(hindsightConfig.hindsight?.llm);
         startHindsight(
           ports,
           litellmCfg,
           effectiveTag,
-          hindsightConfig.hindsight?.llm,
+          resolvedLlm,
           hindsightConsumerMirrorDir(hindsightConfig),
           // The SAME answer that was printed and drop-guarded above, passed as
           // a value rather than re-derived. Re-deriving would let the launch
@@ -1053,9 +1065,14 @@ export function registerMemoryCommand(program: Command): void {
         if (!cpAccessKey) {
           console.error(chalk.yellow(`# ! ${HINDSIGHT_CP_NO_ACCESS_KEY_WARNING}`));
         }
+        // Resolve `vault:` api_key refs so the emitted compose file carries the
+        // real credential — the same reason the docker-run path resolves them,
+        // and the same shape the cp_access_key above already takes. An emitted
+        // literal `vault:…` would break every retain exactly like the recreate bug.
+        const snippetLlm = await resolveHindsightLlmSecrets(snippetConfig.hindsight?.llm);
         console.log(
           generateHindsightComposeSnippet(
-            snippetConfig.hindsight?.llm,
+            snippetLlm,
             hindsightConsumerMirrorDir(snippetConfig),
             // litellm: omitted ⇒ same default the docker-run path uses.
             undefined,

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1064,6 +1064,13 @@ export interface MemoryBackendDeps {
    * without docker.
    */
   startContainer?: typeof startHindsight;
+  /**
+   * Broker seam for `resolveHindsightLlmSecrets`. Injected so tests can assert
+   * the WIRING outcome — that a `vault:` LLM api_key is resolved BEFORE it
+   * reaches {@link startContainer}, the exact gap that caused the 2026-08-06
+   * outage. Production leaves it undefined ⇒ the real auto-unlocked broker.
+   */
+  getViaBrokerStructured?: typeof import("../vault/broker/client.js").getViaBrokerStructured;
 }
 
 /**
@@ -1320,7 +1327,10 @@ export async function stepMemoryBackend(
     // container bakes the real `sk-` key rather than the literal `vault:…`
     // string (the recreate/refresh-hindsight outage class; apply's passphrase
     // resolver does not run on this path).
-    const resolvedLlm = await resolveHindsightLlmSecrets(config.hindsight?.llm);
+    const resolvedLlm = await resolveHindsightLlmSecrets(
+      config.hindsight?.llm,
+      deps.getViaBrokerStructured ? { getViaBrokerStructured: deps.getViaBrokerStructured } : {},
+    );
     const startContainer = deps.startContainer ?? startHindsight;
     startContainer(
       ports,

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -40,6 +40,7 @@ import {
   stopHindsight,
   ensureHindsightConsumer,
   resolveHindsightCpAccessKey,
+  resolveHindsightLlmSecrets,
   HINDSIGHT_CONSUMER_NAME,
   HINDSIGHT_CP_NO_ACCESS_KEY_WARNING,
   HINDSIGHT_DEFAULT_API_PORT,
@@ -1315,12 +1316,17 @@ export async function stepMemoryBackend(
     if (!cpAccessKey) {
       console.log(chalk.yellow(`  ! ${HINDSIGHT_CP_NO_ACCESS_KEY_WARNING}`));
     }
+    // Resolve `vault:` api_key refs through the broker before launch, so the
+    // container bakes the real `sk-` key rather than the literal `vault:…`
+    // string (the recreate/refresh-hindsight outage class; apply's passphrase
+    // resolver does not run on this path).
+    const resolvedLlm = await resolveHindsightLlmSecrets(config.hindsight?.llm);
     const startContainer = deps.startContainer ?? startHindsight;
     startContainer(
       ports,
       litellmCfg,
       undefined,
-      config.hindsight?.llm,
+      resolvedLlm,
       hindsightConsumerMirrorDir(config),
       // gpu: omitted ⇒ hindsightGpuEnabled() reads the persisted verdict.
       undefined,

--- a/src/setup/hindsight-llm-vault-resolve.test.ts
+++ b/src/setup/hindsight-llm-vault-resolve.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  resolveHindsightLlmSecrets,
+  hindsightContainerEnvPairs,
+  type HindsightLlmConfig,
+} from "./hindsight.js";
+
+/**
+ * Regression guard for the 2026-08-06 fleet-wide retain outage.
+ *
+ * `hindsight.llm.<op>.api_key` in switchroom.yaml is a `vault:` virtual-key
+ * reference. Vault-ref resolution for it used to happen ONLY in `switchroom
+ * apply` (behind the operator passphrase). The `memory setup --recreate` launch
+ * and hostd's `refresh-hindsight` rollout step run WITHOUT that resolver, so
+ * they baked the LITERAL string `vault:litellm/gpt-oss-key` into the container's
+ * HINDSIGHT_API_*_LLM_API_KEY env. LiteLLM rejected it ("Virtual Key
+ * expected … start with 'sk-'") and every fact extraction failed.
+ *
+ * `resolveHindsightLlmSecrets` closes the gap by resolving those refs through
+ * the auto-unlocked broker before the emit path ever sees them. These tests
+ * assert the api_key is RESOLVED, never passed verbatim — they FAIL against the
+ * pre-fix code path, which handed the literal straight to the emitter.
+ */
+describe("resolveHindsightLlmSecrets", () => {
+  // Token-shaped literals built by runtime concat so GitHub Push Protection
+  // does not flag the fixtures (see CLAUDE.md § Secrets in tests).
+  const VAULT_REF = "vault:litellm/gpt-oss-key";
+  const REAL_KEY = "sk-" + "resolved-oss-key-abc123";
+  const OTHER_KEY = "sk-" + "reflect-key-def456";
+
+  const brokerOk = (value: string) =>
+    vi.fn().mockResolvedValue({ kind: "ok", entry: { kind: "string", value } });
+
+  // The resolver forwards the agent capability token when SWITCHROOM_AGENT_NAME
+  // is set; the harness may itself run inside an agent container, so pin the
+  // env off for determinism and restore afterwards (mirrors the cp-access-key
+  // test's boilerplate).
+  let savedName: string | undefined;
+  let savedDir: string | undefined;
+  beforeEach(() => {
+    savedName = process.env.SWITCHROOM_AGENT_NAME;
+    savedDir = process.env.SWITCHROOM_AGENTS_DIR;
+    delete process.env.SWITCHROOM_AGENT_NAME;
+    delete process.env.SWITCHROOM_AGENTS_DIR;
+  });
+  afterEach(() => {
+    if (savedName === undefined) delete process.env.SWITCHROOM_AGENT_NAME;
+    else process.env.SWITCHROOM_AGENT_NAME = savedName;
+    if (savedDir === undefined) delete process.env.SWITCHROOM_AGENTS_DIR;
+    else process.env.SWITCHROOM_AGENTS_DIR = savedDir;
+  });
+
+  it("returns undefined when there is no llm config", async () => {
+    await expect(resolveHindsightLlmSecrets(undefined)).resolves.toBeUndefined();
+  });
+
+  it("resolves a `vault:` global api_key through the broker", async () => {
+    const get = brokerOk(REAL_KEY);
+    const out = await resolveHindsightLlmSecrets(
+      { provider: "openai", model: "gpt-oss-20b", api_key: VAULT_REF },
+      { getViaBrokerStructured: get as never },
+    );
+    expect(out?.api_key).toBe(REAL_KEY);
+    // Bare-key call, no token (SWITCHROOM_AGENT_NAME unset) — wire-identical to
+    // the host-operator peercred path.
+    expect(get).toHaveBeenCalledWith("litellm/gpt-oss-key", {});
+    // Non-secret fields survive untouched.
+    expect(out?.provider).toBe("openai");
+    expect(out?.model).toBe("gpt-oss-20b");
+  });
+
+  it("resolves per-op `vault:` api_keys (retain / reflect / consolidation)", async () => {
+    const get = vi.fn(async (key: string) => ({
+      kind: "ok" as const,
+      entry: {
+        kind: "string" as const,
+        value: key.includes("reflect") ? OTHER_KEY : REAL_KEY,
+      },
+    }));
+    const out = await resolveHindsightLlmSecrets(
+      {
+        retain: { model: "gpt-oss-20b", api_key: VAULT_REF },
+        reflect: { model: "gpt-oss-20b", api_key: "vault:litellm/reflect-key" },
+        consolidation: { model: "gpt-oss-20b", api_key: VAULT_REF },
+      },
+      { getViaBrokerStructured: get as never },
+    );
+    expect(out?.retain?.api_key).toBe(REAL_KEY);
+    expect(out?.reflect?.api_key).toBe(OTHER_KEY);
+    expect(out?.consolidation?.api_key).toBe(REAL_KEY);
+    // Per-op non-secret fields preserved.
+    expect(out?.retain?.model).toBe("gpt-oss-20b");
+  });
+
+  it("passes a non-`vault:` literal api_key through without touching the broker", async () => {
+    const get = brokerOk("unused");
+    const out = await resolveHindsightLlmSecrets(
+      { api_key: REAL_KEY },
+      { getViaBrokerStructured: get as never },
+    );
+    expect(out?.api_key).toBe(REAL_KEY);
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it("DROPS an unresolvable `vault:` api_key rather than baking the literal", async () => {
+    // Fail-safe: a denied / missing / non-string / broker-down ref must never
+    // leave the literal `vault:…` string in place. Dropping it makes the op
+    // inherit the global / provider default instead of a guaranteed-invalid key.
+    for (const get of [
+      vi.fn().mockResolvedValue({ kind: "denied" }),
+      vi.fn().mockResolvedValue({ kind: "ok", entry: { kind: "json", value: {} } }),
+      vi.fn().mockRejectedValue(new Error("broker down")),
+    ]) {
+      const out = await resolveHindsightLlmSecrets(
+        { api_key: VAULT_REF, retain: { api_key: VAULT_REF } },
+        { getViaBrokerStructured: get as never },
+      );
+      expect(out?.api_key).toBeUndefined();
+      expect(out?.retain?.api_key).toBeUndefined();
+    }
+  });
+
+  it("does not mutate the caller's config object", async () => {
+    const get = brokerOk(REAL_KEY);
+    const input: HindsightLlmConfig = {
+      api_key: VAULT_REF,
+      retain: { api_key: VAULT_REF },
+    };
+    await resolveHindsightLlmSecrets(input, { getViaBrokerStructured: get as never });
+    // The original still holds the vault ref — the resolver returned a clone.
+    expect(input.api_key).toBe(VAULT_REF);
+    expect(input.retain?.api_key).toBe(VAULT_REF);
+  });
+
+  it("bakes the RESOLVED key into the emit path, never the literal (the bug)", async () => {
+    // End-to-end: resolve then emit exactly as the launch path does. On today's
+    // bug the config is handed to hindsightContainerEnvPairs VERBATIM, so the
+    // emitted env carries the literal `vault:…` string. This asserts the fixed
+    // wiring bakes the real `sk-` key into every LLM api_key var.
+    const get = brokerOk(REAL_KEY);
+    const resolved = await resolveHindsightLlmSecrets(
+      {
+        provider: "openai",
+        api_key: VAULT_REF,
+        retain: { api_key: VAULT_REF },
+        consolidation: { api_key: VAULT_REF },
+      },
+      { getViaBrokerStructured: get as never },
+    );
+    const env = new Map(
+      hindsightContainerEnvPairs({ apiPort: 18888, llm: resolved, gpu: false }),
+    );
+    const apiKeyVars = [
+      "HINDSIGHT_API_LLM_API_KEY",
+      "HINDSIGHT_API_RETAIN_LLM_API_KEY",
+      "HINDSIGHT_API_CONSOLIDATION_LLM_API_KEY",
+    ];
+    for (const v of apiKeyVars) {
+      expect(env.get(v)).toBe(REAL_KEY);
+      expect(env.get(v)).not.toContain("vault:");
+    }
+    // Sanity: no other emitted value smuggled the literal ref through either.
+    for (const value of env.values()) {
+      expect(value).not.toContain("vault:");
+    }
+  });
+});

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -1515,25 +1515,52 @@ export function hindsightCpAuthEnvPairs(opts: {
  */
 export async function resolveHindsightCpAccessKey(
   config: { hindsight?: { cp_access_key?: string } } | undefined,
-  deps: {
-    getViaBrokerStructured?: typeof import("../vault/broker/client.js").getViaBrokerStructured;
-  } = {},
+  deps: HindsightVaultResolveDeps = {},
 ): Promise<string | undefined> {
-  const ref = config?.hindsight?.cp_access_key?.trim();
-  if (!ref) return undefined;
+  return resolveHindsightVaultString(config?.hindsight?.cp_access_key, deps);
+}
+
+/** Injection seam shared by the module's `vault:`-ref resolvers. */
+type HindsightVaultResolveDeps = {
+  getViaBrokerStructured?: typeof import("../vault/broker/client.js").getViaBrokerStructured;
+};
+
+/**
+ * Resolve a single config value that may be a `vault:<key>` reference to its
+ * string secret, through the auto-unlocked broker. THE non-interactive vault
+ * path this module depends on — no operator passphrase, so it works from the
+ * `memory setup --recreate` launch and hostd's `refresh-hindsight` rollout step
+ * where `switchroom apply`'s passphrase resolver (`resolveConfigSecret`,
+ * src/cli/apply.ts) is unavailable.
+ *
+ * A non-`vault:` literal is returned trimmed as-is (the broker is never
+ * touched). A `vault:` reference that cannot be resolved — denied, missing,
+ * non-string, blank, or broker down — returns `undefined`. That is the
+ * fail-safe every caller here wants: NEVER return the literal `vault:…` string,
+ * which the container would otherwise bake into its env verbatim (LiteLLM then
+ * rejects it: "Virtual Key expected … start with 'sk-'", the 2026-08-06
+ * fleet-wide retain outage).
+ */
+async function resolveHindsightVaultString(
+  ref: string | undefined,
+  deps: HindsightVaultResolveDeps = {},
+): Promise<string | undefined> {
+  const trimmed = ref?.trim();
+  if (!trimmed) return undefined;
   const { isVaultReference, parseVaultReference } = await import("../vault/resolver.js");
-  if (!isVaultReference(ref)) return ref;
+  if (!isVaultReference(trimmed)) return trimmed;
   const brokerClient = await import("../vault/broker/client.js");
   const get = deps.getViaBrokerStructured ?? brokerClient.getViaBrokerStructured;
   // Issue #1053: forward the agent's capability token so the broker's grant
   // path bypasses the peercred ACL. Without it a freshly-minted grant is
-  // ignored and the `.catch(() => null)` silently swallows the DENIED,
-  // leaving HINDSIGHT_CP_ACCESS_KEY underived. Mirrors the working `vault get`
-  // path in src/cli/vault.ts. Token stays undefined when SWITCHROOM_AGENT_NAME
-  // is unset — identical to prior host-operator peercred behavior.
+  // ignored and the `.catch(() => null)` silently swallows the DENIED, leaving
+  // the secret underived under `memory setup --recreate`. Mirrors the working
+  // `vault get` path in src/cli/vault.ts. Token stays undefined when
+  // SWITCHROOM_AGENT_NAME is unset — identical to prior host-operator peercred
+  // behavior.
   const agentSlug = process.env.SWITCHROOM_AGENT_NAME;
   const token = agentSlug ? brokerClient.readVaultTokenFile(agentSlug) ?? undefined : undefined;
-  const resolved = await get(parseVaultReference(ref), {
+  const resolved = await get(parseVaultReference(trimmed), {
     ...(token ? { token } : {}),
   }).catch(() => null);
   if (!resolved || resolved.kind !== "ok" || resolved.entry.kind !== "string") {
@@ -1541,6 +1568,55 @@ export async function resolveHindsightCpAccessKey(
   }
   const value = resolved.entry.value.trim();
   return value.length > 0 ? value : undefined;
+}
+
+/**
+ * Resolve every `vault:<key>` reference in a hindsight LLM config's API-key
+ * fields to its real secret, through the auto-unlocked broker — the SAME
+ * non-interactive path {@link resolveHindsightCpAccessKey} uses.
+ *
+ * WHY this exists (fleet outage 2026-08-06): vault-ref resolution for the
+ * global `hindsight.llm.api_key` and the per-op `hindsight.llm.<op>.api_key`
+ * used to happen ONLY inside `switchroom apply` (`resolveConfigSecret`,
+ * src/cli/apply.ts), behind the operator passphrase. The
+ * `memory setup --recreate` launch path ({@link startHindsight}) and hostd's
+ * `refresh-hindsight` rollout step run WITHOUT that resolver, so they passed the
+ * literal `vault:…` string straight into the container env via the emit paths
+ * ({@link resolveHindsightGlobalLlmExtras} / {@link resolveHindsightPerOpLlm}).
+ * LiteLLM rejected it and ALL fact extraction failed fleet-wide. Resolving here
+ * — before either emit path sees the value — bakes the real `sk-` key instead.
+ *
+ * Returns a shallow clone with only the api_key fields rewritten; every other
+ * field (model / provider / base_url / context_window, and the rest of each
+ * per-op block) is preserved untouched. A non-`vault:` literal passes through.
+ * An unresolvable ref DROPS that api_key (the field is omitted, so the emit path
+ * skips it) — the op then inherits the global / provider default rather than
+ * baking a guaranteed-invalid literal, the same fail-safe shape the CP key
+ * takes. `undefined` in ⇒ `undefined` out (no config, nothing to do).
+ */
+export async function resolveHindsightLlmSecrets(
+  llm: HindsightLlmConfig | undefined,
+  deps: HindsightVaultResolveDeps = {},
+): Promise<HindsightLlmConfig | undefined> {
+  if (!llm) return llm;
+  const out: HindsightLlmConfig = { ...llm };
+  // Global api_key. `api_key` set-but-unresolvable collapses to undefined, which
+  // the emit path treats identically to "absent" (it skips empty values).
+  if (llm.api_key !== undefined) {
+    out.api_key = await resolveHindsightVaultString(llm.api_key, deps);
+  }
+  // Per-op api_keys (retain / reflect / consolidation). Clone each present block
+  // so we never mutate the caller's config object in place.
+  for (const op of HINDSIGHT_LLM_OPS) {
+    const cfg = llm[op as HindsightLlmOp];
+    if (cfg?.api_key !== undefined) {
+      out[op as HindsightLlmOp] = {
+        ...cfg,
+        api_key: await resolveHindsightVaultString(cfg.api_key, deps),
+      };
+    }
+  }
+  return out;
 }
 
 /**

--- a/tests/setup-verification.test.ts
+++ b/tests/setup-verification.test.ts
@@ -575,6 +575,61 @@ describe("stepMemoryBackend (Docker absent)", () => {
     expect(startContainer).toHaveBeenCalled();
     expect(logs.join("\n")).not.toMatch(/may still be initializing/);
   });
+
+  it("resolves a `vault:` LLM api_key BEFORE it reaches startContainer (2026-08-06 wiring)", async () => {
+    // The regression guard: the bug was NOT that resolveHindsightLlmSecrets
+    // couldn't resolve — it's that the launch caller never CALLED it, handing
+    // the literal `vault:…` ref straight to the container. This asserts the
+    // wiring outcome: the config reaching startContainer carries the RESOLVED
+    // `sk-` key. Unwire the resolver (pass config.hindsight?.llm verbatim) and
+    // this fails — the spy would see the `vault:` literal.
+    const VAULT_REF = "vault:litellm/gpt-oss-key";
+    const REAL_KEY = "sk-" + "resolved-oss-key-xyz789";
+    const savedName = process.env.SWITCHROOM_AGENT_NAME;
+    delete process.env.SWITCHROOM_AGENT_NAME; // keep the broker call token-free
+
+    const config = {
+      agents: { alpha: { topic_name: "alpha-topic" } },
+      hindsight: { llm: { provider: "openai", api_key: VAULT_REF } },
+    } as unknown as SwitchroomConfig;
+
+    // Probe: docker present, hindsight NOT already running / existing, so the
+    // step proceeds to launch (identical shape to the H2 probe above).
+    const probe = (args: string[]) => {
+      if (args[0] === "--version") return "Docker version 27.0.0\n";
+      return "";
+    };
+    const startContainer = vi.fn();
+    const getViaBrokerStructured = vi
+      .fn()
+      .mockResolvedValue({ kind: "ok", entry: { kind: "string", value: REAL_KEY } });
+
+    try {
+      // Rejects on the post-start "did not stay running" check — irrelevant
+      // here: startContainer was already called with the resolved config.
+      await expect(
+        stepMemoryBackend(config, true, cfgPath, {
+          dockerProbe: probe,
+          startContainer: startContainer as never,
+          getViaBrokerStructured: getViaBrokerStructured as never,
+          sleep: async () => {},
+          readyRetries: 1,
+        }),
+      ).rejects.toThrow(/did not stay running/);
+
+      expect(startContainer).toHaveBeenCalledTimes(1);
+      // startHindsight(ports, litellm, tag, llm, mirrorDir, gpu, perf, cpKey):
+      // the resolved LLM config is the 4th positional arg.
+      const llmArg = startContainer.mock.calls[0][3] as { api_key?: string } | undefined;
+      expect(llmArg?.api_key).toBe(REAL_KEY);
+      expect(llmArg?.api_key).not.toContain("vault:");
+      // The broker WAS consulted, by the bare vault key.
+      expect(getViaBrokerStructured).toHaveBeenCalledWith("litellm/gpt-oss-key", {});
+    } finally {
+      if (savedName === undefined) delete process.env.SWITCHROOM_AGENT_NAME;
+      else process.env.SWITCHROOM_AGENT_NAME = savedName;
+    }
+  });
 });
 
 // ─── review M4: a FAIL verdict is sampled, like the OK verdict ───────────────


### PR DESCRIPTION
## Summary

`hindsight.llm.api_key` and `hindsight.llm.<op>.api_key` in switchroom.yaml are `vault:` virtual-key references (e.g. `vault:litellm/gpt-oss-key`). Vault-ref resolution for them ran **only** in the `switchroom apply` path (`resolveConfigSecret`, src/cli/apply.ts), behind the operator passphrase. `resolveHindsightPerOpLlm` / `resolveHindsightGlobalLlmExtras` (src/setup/hindsight.ts) emit `HINDSIGHT_API_*_LLM_API_KEY` from `cfg.api_key` **verbatim**.

So standalone `switchroom memory setup --recreate` **and** hostd's `refresh-hindsight` rollout step (rollout.ts spawns `memory setup --recreate`) — both of which run WITHOUT the apply-time resolver / operator passphrase — baked the **literal** string `vault:litellm/gpt-oss-key` into hindsight's container env. LiteLLM rejected it (`AuthenticationError: LiteLLM Virtual Key expected. Received=vaul****-key, expected to start with 'sk-'`) and **all fact extraction failed fleet-wide** (2026-08-06 outage, manually patched via the broker that night).

## Why this fix

The vault **broker / auto-unlock** resolves these keys non-interactively — that is how the outage was patched by hand. There is already an in-module precedent: `resolveHindsightCpAccessKey` resolves `hindsight.cp_access_key`'s `vault:` ref through the broker (token-forwarding, #1053) on this exact passphrase-less path.

This PR:
- Factors the shared broker string-resolve into `resolveHindsightVaultString` (literal → passthrough; `vault:` ref → broker; unresolvable → `undefined`, never the literal). `resolveHindsightCpAccessKey` now delegates to it (behaviour unchanged, 56 existing tests green).
- Adds `resolveHindsightLlmSecrets(llm, deps)`: returns a shallow clone with the global + per-op `api_key` fields resolved, every other field preserved, input never mutated. An **unresolvable** ref DROPS that key (fail-safe: the op inherits the global / provider default rather than baking a guaranteed-invalid literal).
- Wires it into every launch/emit site that lacked the apply-time resolver: `memory setup` launch **and** its env-drift compare, `memory docker-compose`, and first-run `setup`.

Provider stays `gpt-oss-20b` / the operator's config — this is a pure secret-resolution fix, no routing change.

### Scope note — `litellm.admin_key`
Does **not** share the gap. It never flows into the hindsight container env: the container's proxy key is `litellm/hindsight/api-key`, already broker-resolved in `resolveLiteLLMForHindsight`. `admin_key` is used only for LiteLLM key provisioning in the apply path, which has the resolver. Left untouched.

## Test plan

- `src/setup/hindsight-llm-vault-resolve.test.ts` (new, 7 cases): resolves global + per-op `vault:` refs via a fake broker; literal passthrough; unresolvable → dropped; no input mutation; and an **end-to-end emit assertion** — `hindsightContainerEnvPairs(resolveHindsightLlmSecrets(...))` bakes the real `sk-` key into every `*_LLM_API_KEY` and **no** emitted value contains `vault:`. This fails against the pre-fix verbatim path.
- Fakes only at the broker boundary (`resolveSecret`-style), per repo test discipline; token literals built by runtime concat.
- Local: `tsc --noEmit` clean; `npm run lint` clean (all guards incl. attribution); scoped vitest green — new suite + `hindsight-cp-access-key` (63), `hindsight-env-drift` / `-recreate-env-survival` / `-loopback-bind` (52), `tests/setup.test.ts` + perf/mirror (269).

## Risk

- Launch path now makes up to 4 broker UDS calls (global + 3 per-op); fast, and the drift-compare call is inside the existing non-fatal try/catch.
- `memory docker-compose` now prints the resolved LLM key into the emitted snippet — consistent with the existing `cp_access_key` behaviour in that same command (operator-invoked config emission).
- Fail-safe on unresolvable ref is "drop the key" → op falls back to global/provider default (subscription OAuth), never a hard bake of an invalid literal.

Job: `reference/jobs/remember-across-sessions.md` — fleet memory must survive an update/rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)