### PR TITLE
fix(hindsight): degrade to semantic-only when pg_search BM25 index is absent (follow-up to #4470)

### DIFF
--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -587,7 +587,8 @@ assert '        return " | ".join(tokens)' in pg, "switchroom hindsight BM25 com
 print("switchroom hindsight BM25 compound-token patch: intact compound tokens appended (strict superset of upstream tokens); native tsquery left as a plain OR join")
 PYEOF
 
-# PG text-search regconfig / stopword-file recall fallback.
+# PG text-search recall fallback: missing regconfig / stopword-file (native)
+# AND absent pg_search BM25 index (ParadeDB) — follow-up to #4470.
 #
 # switchroom runs the native (Postgres) BM25 arms through a CUSTOM text-search
 # regconfig — HINDSIGHT_API_TEXT_SEARCH_EXTENSION_NATIVE_LANGUAGE, set to
@@ -602,10 +603,20 @@ PYEOF
 # only caught Oracle's DRG-10599/ORA-30600/ORA-29902 and re-`raise`d everything
 # else, EVERY recall 500s — a total recall outage, not a degraded one.
 #
+# #4470 made pg_search (ParadeDB BM25) the default text-search backend for new
+# installs. It has the same failure mode on a different signature: whenever the
+# `USING bm25` index is absent — the initial build window, or any REINDEX — the
+# recall query's @@@ / paradedb.score arm raises SQLSTATE XX000 with
+# "<table> does not contain a USING bm25 index". The 42704/stopword predicate
+# below did not recognise that, so pg_search recall still failed CLOSED (500)
+# for the whole build/rebuild window while native degraded gracefully. A dry-run
+# on a full 772k-row clone caught it as a BLOCKER.
+#
 # This widens the existing semantic-only fallback (which the Oracle branch
-# already built, dialect-agnostically) to also trigger on the PG signatures,
-# reusing the very same rebuild. Recall degrades to semantic-only — lossy but
-# serving — until provisioning catches up, instead of failing closed. The
+# already built, dialect-agnostically) to also trigger on the native PG
+# signatures AND the pg_search "no bm25 index" signature, reusing the very same
+# rebuild. Recall degrades to semantic-only — lossy but serving — until
+# provisioning / the index build catches up, instead of failing closed. The
 # index-write path and the backfill migration are NOT touched here (they own
 # their own provisioning contract via the entrypoint); this covers the READ
 # path only, which is where a user-visible 500 would otherwise land.
@@ -633,9 +644,25 @@ NEW = '''        # switchroom: Postgres native BM25 arms run to_tsvector/to_tsqu
         # gap (fresh volume before the entrypoint provisioned the config, or an
         # embedded-pg version bump that orphaned the version-scoped stopfile),
         # never on a normal query.
+        #
+        # The pg_search (ParadeDB BM25) backend has the SAME failure shape on a
+        # DIFFERENT signature: when the `USING bm25` index is absent — the initial
+        # index-build window on a fresh/large volume, or any REINDEX/rebuild — a
+        # recall query that hits the @@@ / paradedb.score arm raises SQLSTATE
+        # XX000 with "<table> does not contain a USING bm25 index" (the table
+        # varies: memory_units, reflections, …). Native degrades gracefully here;
+        # pg_search did not, so recall failed CLOSED (HTTP 500) for the whole
+        # build/rebuild window (found by a dry-run on a full 772k-row clone).
+        # Match XX000 AND the stable, table-name-agnostic
+        # "does not contain a using bm25 index" substring (case-insensitive) —
+        # NOT XX000 alone, which is Postgres internal_error, a catch-all that
+        # would swallow unrelated internal errors and mask real bugs.
         _pg_text_search_unavailable = getattr(e, "sqlstate", None) == "42704" or (
             "could not open stop-word file" in err_str
-        ) or ("text search configuration" in err_str.lower() and "does not exist" in err_str.lower())
+        ) or ("text search configuration" in err_str.lower() and "does not exist" in err_str.lower()) or (
+            getattr(e, "sqlstate", None) == "XX000"
+            and "does not contain a using bm25 index" in err_str.lower()
+        )
         if _include_bm25 and ("DRG-10599" in err_str or "ORA-30600" in err_str or "ORA-29902" in err_str or _pg_text_search_unavailable):
             if _pg_text_search_unavailable:
                 logger.warning("Postgres text-search config unavailable (%s); falling back to semantic-only search", err_str[:160])
@@ -656,10 +683,12 @@ t = f.read_text()
 assert "_pg_text_search_unavailable" in t, "switchroom PG text-search recall-fallback patch: sentinel missing after patch"
 assert 'getattr(e, "sqlstate", None) == "42704"' in t, "switchroom PG text-search recall-fallback patch: 42704 guard missing after patch"
 assert "could not open stop-word file" in t, "switchroom PG text-search recall-fallback patch: stopword-file guard missing after patch"
+assert 'getattr(e, "sqlstate", None) == "XX000"' in t, "switchroom PG text-search recall-fallback patch: pg_search XX000 guard missing after patch"
+assert "does not contain a using bm25 index" in t, "switchroom PG text-search recall-fallback patch: pg_search bm25-index substring missing after patch"
 # The dialect-agnostic semantic-only rebuild the Oracle branch already had must
 # stay the SINGLE fallback path both branches reach — we only widened its trigger.
 assert t.count("rows = await conn.fetch(fb_query, *fb_params)") == 1, "switchroom PG text-search recall-fallback patch: shared semantic-only rebuild changed shape"
-print("switchroom hindsight PG text-search recall-fallback patch: recall degrades to semantic-only on missing regconfig / stopword file (SQLSTATE 42704)")
+print("switchroom hindsight PG text-search recall-fallback patch: recall degrades to semantic-only on missing regconfig / stopword file (SQLSTATE 42704) and on absent pg_search BM25 index (SQLSTATE XX000)")
 PYEOF
 
 # Empty-TimeoutError-message fix: both retry loops in

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -313,6 +313,12 @@ describe("Dockerfile.hindsight shape", () => {
     expect(dockerfile).toMatch(
       /"text search configuration" in err_str\.lower\(\) and "does not exist" in err_str\.lower\(\)/,
     );
+    // The pg_search (ParadeDB BM25) "no bm25 index" signature (follow-up to
+    // #4470): SQLSTATE XX000 AND the stable, table-name-agnostic substring —
+    // never XX000 alone (Postgres internal_error is a catch-all).
+    expect(dockerfile).toMatch(
+      /getattr\(e, "sqlstate", None\) == "XX000"\s*\n\s*and "does not contain a using bm25 index" in err_str\.lower\(\)/,
+    );
     // The widened condition must be an OR onto the EXISTING Oracle guard — a
     // separate `if` could double-run the rebuild or diverge. Pin that the
     // Oracle codes and the new sentinel share one branch.
@@ -331,6 +337,12 @@ describe("Dockerfile.hindsight shape", () => {
     );
     expect(dockerfile).toMatch(
       /assert "could not open stop-word file" in t,/,
+    );
+    expect(dockerfile).toMatch(
+      /assert 'getattr\(e, "sqlstate", None\) == "XX000"' in t,/,
+    );
+    expect(dockerfile).toMatch(
+      /assert "does not contain a using bm25 index" in t,/,
     );
     expect(dockerfile).toMatch(
       /assert t\.count\("rows = await conn\.fetch\(fb_query, \*fb_params\)"\) == 1,/,

--- a/tests/docker/hindsight-search-patches.test.ts
+++ b/tests/docker/hindsight-search-patches.test.ts
@@ -565,6 +565,18 @@ _run_fallback("sqlstate_42704", _mk_pgerr('text search configuration "hindsight_
 _run_fallback("stopword_file", _mk_pgerr('could not open stop-word file "/x/hindsight_extra.stop": No such file or directory'), True)
 _run_fallback("config_msg", _mk_pgerr('text search configuration "public.hindsight_english" does not exist'), True)
 _run_fallback("unrelated_error", _mk_pgerr('relation "memory_units" does not exist', sqlstate="42P01"), False)
+# pg_search (ParadeDB BM25) index absent during the initial build window or a
+# REINDEX: XX000 + "<table> does not contain a USING bm25 index". Degrades.
+# Table-name-agnostic: reflections also uses a bm25 index, so match the stable
+# fragment, not the table name.
+_run_fallback("pg_search_no_bm25_index", _mk_pgerr('memory_units does not contain a USING bm25 index', sqlstate="XX000"), True)
+_run_fallback("pg_search_no_bm25_index_reflections", _mk_pgerr('reflections does not contain a USING bm25 index', sqlstate="XX000"), True)
+# The XX000 arm is gated on the SPECIFIC substring, not on XX000 alone (which is
+# Postgres internal_error, a catch-all). An unrelated XX000 must still propagate.
+_run_fallback("xx000_unrelated", _mk_pgerr('some other internal error', sqlstate="XX000"), False)
+# And the bm25 substring alone, under a different sqlstate, must still propagate:
+# the guard requires BOTH XX000 AND the substring.
+_run_fallback("bm25_msg_wrong_sqlstate", _mk_pgerr('memory_units does not contain a USING bm25 index', sqlstate="42P01"), False)
 
 _retr.RetrievalResult.from_db_row = _orig_from_db_row
 
@@ -786,6 +798,12 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toContain(
         "sqlstate_42704: recall raised Exception instead of degrading to semantic-only"
       );
+      // The pg_search "no bm25 index" signature (SQLSTATE XX000) also RAISES on
+      // unpatched upstream — this is the fail-CLOSED blocker this PR fixes.
+      expect(stdout).toMatch(/PGFALLBACK pg_search_no_bm25_index RAISED /);
+      expect(stdout).toContain(
+        "pg_search_no_bm25_index: recall raised Exception instead of degrading to semantic-only"
+      );
       // …but an unrelated error already propagates on upstream too (so the
       // patched behaviour for it is unchanged, not a new regression).
       expect(stdout).toMatch(/PGFALLBACK unrelated_error RAISED Exception '42P01'/);
@@ -875,9 +893,27 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toContain("PGFALLBACK sqlstate_42704 RETURNED 2 ['sem-1']");
       expect(stdout).toContain("PGFALLBACK stopword_file RETURNED 2 ['sem-1']");
       expect(stdout).toContain("PGFALLBACK config_msg RETURNED 2 ['sem-1']");
+      // … including the pg_search "no bm25 index" signature (XX000), which now
+      // degrades to semantic-only during the initial build window / any REINDEX
+      // instead of 500ing every recall. Table-name-agnostic: memory_units AND
+      // reflections both degrade off the stable substring.
+      expect(stdout).toContain(
+        "PGFALLBACK pg_search_no_bm25_index RETURNED 2 ['sem-1']"
+      );
+      expect(stdout).toContain(
+        "PGFALLBACK pg_search_no_bm25_index_reflections RETURNED 2 ['sem-1']"
+      );
       // … while an UNRELATED error (undefined_table) still propagates, proving
       // the widened fallback is not a catch-all.
       expect(stdout).toMatch(/PGFALLBACK unrelated_error RAISED Exception '42P01'/);
+      // … and the XX000 arm is gated on the SPECIFIC substring, not XX000 alone
+      // (internal_error is a catch-all): an unrelated XX000 still propagates, and
+      // the bm25 substring under a different sqlstate still propagates — the
+      // guard requires BOTH to hold.
+      expect(stdout).toMatch(/PGFALLBACK xx000_unrelated RAISED Exception 'XX000'/);
+      expect(stdout).toMatch(
+        /PGFALLBACK bm25_msg_wrong_sqlstate RAISED Exception '42P01'/
+      );
     }, 240_000);
   }
 );


### PR DESCRIPTION
## Summary

Recall **fails closed (HTTP 500)** whenever the pg_search BM25 index is absent — the initial build window on a fresh/large volume, or any `REINDEX`/rebuild. #4470 made pg_search (ParadeDB BM25) the default text-search backend for new installs; this closes the graceful-degradation gap it left on the read path.

switchroom patches the upstream Hindsight engine at Docker build time (`docker/Dockerfile.hindsight`). The existing **"PG text-search recall-fallback"** patch already widens recall's Oracle-only semantic fallback to the *native* Postgres failure signatures (SQLSTATE `42704` "text search configuration ... does not exist" and "could not open stop-word file"). It did **not** recognise pg_search's failure mode, so pg_search recall re-raised and 500'd.

## The fail-closed blocker

A dry-run on a full **772k-row clone** caught it: when the `USING bm25` index is missing, a recall query hitting the `@@@` / `paradedb.score` arm raises:

```
ERROR: XX000: memory_units does not contain a USING bm25 index
```

`retrieve_semantic_bm25_combined`'s `_pg_text_search_unavailable` predicate only matched the native tsvector signatures, so it re-`raise`d — **every recall 500'd for the whole build/rebuild window.** Native degraded gracefully; pg_search did not.

## The fix

One **additive OR branch** on the existing `_pg_text_search_unavailable` predicate (the switchroom build-time patch, anchored verbatim against the pinned **v0.8.6** base image), keeping the native predicates intact:

```python
... or (
    getattr(e, "sqlstate", None) == "XX000"
    and "does not contain a using bm25 index" in err_str.lower()
)
```

Recall degrades to semantic-only — lossy but serving — instead of failing closed.

**Why not match `XX000` alone:** `XX000` is Postgres `internal_error`, a catch-all. A broad match would swallow unrelated internal errors and mask real bugs. The branch requires **both** `XX000` **and** the case-insensitive, **table-name-agnostic** substring `does not contain a using bm25 index` (matched by the stable fragment, not the literal table name — `reflections` also uses a bm25 index).

**Why extend the existing predicate** rather than add a second patch block: a new block would have to anchor on switchroom's *own* prior patch output. Extending the existing one keeps a single owner for the predicate and a deterministic upstream anchor (the still-verbatim Oracle-only `OLD` anchor in v0.8.6).

The error string was confirmed against the captured live dry-run error (authoritative per the brief) and ParadeDB's documented "no bm25 index" error family (paradedb/paradedb #1407, #713, #2211).

## Test plan

Behavioural, driven against the **pinned upstream image**, not a grep:

- `tests/docker/hindsight-search-patches.test.ts` — the probe applies the real Dockerfile patch blocks to the pinned base and drives the real `retrieve_semantic_bm25_combined` with a pg_search `XX000` error, asserting it **degrades to semantic-only** (2nd rebuild fetch returns the semantic rows) for both `memory_units` and `reflections`. Proves the guard is **not a catch-all**: an unrelated `XX000` and the bm25 substring under a different sqlstate both still propagate.
- `tests/docker/dockerfile-hindsight-bakes.test.ts` — structural assertions for the new `XX000` trigger and its post-build re-assertions.

**Non-vacuous (verified both directions):** reverting the OR branch turns the behavioural GREEN probe RED (patched image raises on the pg_search signature instead of degrading) and reds the structural bakes assertions; restoring it passes. Local: `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 vitest run` on both files → **45/45 green**; `npm run lint` clean; `tsc --noEmit` clean.

This touches `docker/`, so CI's hindsight image build validates the patch applies cleanly against v0.8.6 and the image boots (`e2e-ok` / hindsight-probe).

## Risk

Read-path only; the index-write path and backfill migration are untouched (they own their provisioning contract via the entrypoint). The branch trips only on a genuine index-absent window, degrading a total outage to a lossy-but-serving recall.

Job spec: `reference/jobs/` — memory recall availability (the "always available" vision outcome); a recall outage during a routine `REINDEX` is exactly the fail-closed behaviour this removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)