### PR TITLE
fix(hindsight): warn on dropped vault: LLM api_key; flag secret-bearing compose output (#4471 follow-up)

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -37,6 +37,8 @@ import {
   resolveHindsightGpuOverride,
   resolveHindsightCpAccessKey,
   resolveHindsightLlmSecrets,
+  diffDroppedHindsightLlmVaultKeys,
+  hindsightLlmDroppedKeyWarning,
   HINDSIGHT_CP_NO_ACCESS_KEY_WARNING,
   HINDSIGHT_DEFAULT_API_PORT,
   HINDSIGHT_DEFAULT_MCP_URL,
@@ -1018,6 +1020,17 @@ export function registerMemoryCommand(program: Command): void {
         // path. Memoized (getResolvedLlm) so this reuses the env-drift compare's
         // resolution rather than firing the broker round-trips a second time.
         const resolvedLlm = await getResolvedLlm();
+        // Symmetric to the cp_access_key warning above and to the first-run
+        // path in `switchroom setup`: a dropped `vault:` LLM api_key ref is
+        // otherwise silent here. The env-drift report only fires when the key
+        // was previously baked and only names the env var; this names the lane
+        // and the unresolved reference so the operator can fix the grant.
+        for (const drop of await diffDroppedHindsightLlmVaultKeys(
+          hindsightConfig.hindsight?.llm,
+          resolvedLlm,
+        )) {
+          console.log(chalk.yellow(`  ! ${hindsightLlmDroppedKeyWarning(drop)}`));
+        }
         startHindsight(
           ports,
           litellmCfg,
@@ -1088,6 +1101,19 @@ export function registerMemoryCommand(program: Command): void {
         // and the same shape the cp_access_key above already takes. An emitted
         // literal `vault:…` would break every retain exactly like the recreate bug.
         const snippetLlm = await resolveHindsightLlmSecrets(snippetConfig.hindsight?.llm);
+        // The emitted snippet carries REAL resolved credentials in cleartext —
+        // the LLM `sk-` api_key(s) and any `cp_access_key` — because a
+        // paste-ready compose file must. Warn ONCE, to stderr with a `#` prefix,
+        // so a piped/redirected stdout is still a valid compose file (the notice
+        // stays a YAML comment even under `2>&1`) while an interactive operator
+        // is told to handle the output as a secret.
+        console.error(
+          chalk.yellow(
+            "# ! This snippet embeds resolved secrets in cleartext (LLM api_key" +
+              " and cp_access_key). Treat the output as sensitive — do not paste" +
+              " it into shared channels or commit it unredacted.",
+          ),
+        );
         console.log(
           generateHindsightComposeSnippet(
             snippetLlm,

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -41,6 +41,8 @@ import {
   ensureHindsightConsumer,
   resolveHindsightCpAccessKey,
   resolveHindsightLlmSecrets,
+  diffDroppedHindsightLlmVaultKeys,
+  hindsightLlmDroppedKeyWarning,
   HINDSIGHT_CONSUMER_NAME,
   HINDSIGHT_CP_NO_ACCESS_KEY_WARNING,
   HINDSIGHT_DEFAULT_API_PORT,
@@ -1331,6 +1333,12 @@ export async function stepMemoryBackend(
       config.hindsight?.llm,
       deps.getViaBrokerStructured ? { getViaBrokerStructured: deps.getViaBrokerStructured } : {},
     );
+    // Symmetric to the cp_access_key warning above: a `vault:` LLM api_key ref
+    // that fails to resolve is dropped and the lane silently falls back to the
+    // provider default, so name every drop rather than launch on it quietly.
+    for (const drop of await diffDroppedHindsightLlmVaultKeys(config.hindsight?.llm, resolvedLlm)) {
+      console.log(chalk.yellow(`  ! ${hindsightLlmDroppedKeyWarning(drop)}`));
+    }
     const startContainer = deps.startContainer ?? startHindsight;
     startContainer(
       ports,

--- a/src/setup/hindsight-llm-vault-resolve.test.ts
+++ b/src/setup/hindsight-llm-vault-resolve.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import {
   resolveHindsightLlmSecrets,
+  diffDroppedHindsightLlmVaultKeys,
+  hindsightLlmDroppedKeyWarning,
   hindsightContainerEnvPairs,
   type HindsightLlmConfig,
 } from "./hindsight.js";
@@ -164,5 +166,85 @@ describe("resolveHindsightLlmSecrets", () => {
     for (const value of env.values()) {
       expect(value).not.toContain("vault:");
     }
+  });
+});
+
+/**
+ * Minor-1 (follow-up to the 2026-08-06 outage PR): a `vault:` LLM api_key that
+ * fails to resolve is DROPPED — correct fail-safe, but silent. The launch paths
+ * warn on the drop, symmetric to the cp_access_key warning. These assert the
+ * diff finds the drops and the message names the lane + ref without a secret.
+ */
+describe("diffDroppedHindsightLlmVaultKeys", () => {
+  const VAULT_REF = "vault:litellm/gpt-oss-key";
+  const REAL_KEY = "sk-" + "resolved-oss-key-abc123";
+
+  it("returns no drops when there is no config", async () => {
+    await expect(diffDroppedHindsightLlmVaultKeys(undefined, undefined)).resolves.toEqual([]);
+  });
+
+  it("reports a dropped global `vault:` ref (input ref, output undefined)", async () => {
+    const drops = await diffDroppedHindsightLlmVaultKeys(
+      { api_key: VAULT_REF },
+      { api_key: undefined },
+    );
+    expect(drops).toEqual([{ lane: "global", ref: VAULT_REF }]);
+  });
+
+  it("reports each dropped per-op lane by name", async () => {
+    const drops = await diffDroppedHindsightLlmVaultKeys(
+      {
+        retain: { api_key: VAULT_REF },
+        reflect: { api_key: "vault:litellm/reflect-key" },
+        consolidation: { api_key: VAULT_REF },
+      },
+      {
+        retain: { api_key: undefined },
+        reflect: { api_key: undefined },
+        consolidation: { api_key: undefined },
+      },
+    );
+    expect(drops.map((d) => d.lane).sort()).toEqual(["consolidation", "reflect", "retain"]);
+  });
+
+  it("does NOT report a `vault:` ref that resolved (output has the key)", async () => {
+    const drops = await diffDroppedHindsightLlmVaultKeys(
+      { api_key: VAULT_REF },
+      { api_key: REAL_KEY },
+    );
+    expect(drops).toEqual([]);
+  });
+
+  it("does NOT report a non-`vault:` literal that came back empty", async () => {
+    // A plain literal is never a broker drop — only `vault:` refs are reported.
+    const drops = await diffDroppedHindsightLlmVaultKeys(
+      { api_key: REAL_KEY },
+      { api_key: undefined },
+    );
+    expect(drops).toEqual([]);
+  });
+
+  it("does NOT report an unset field", async () => {
+    const drops = await diffDroppedHindsightLlmVaultKeys({ provider: "openai" }, { provider: "openai" });
+    expect(drops).toEqual([]);
+  });
+});
+
+describe("hindsightLlmDroppedKeyWarning", () => {
+  const VAULT_REF = "vault:litellm/gpt-oss-key";
+
+  it("names the global lane and the `vault:` ref, never a secret", () => {
+    const msg = hindsightLlmDroppedKeyWarning({ lane: "global", ref: VAULT_REF });
+    expect(msg).toContain("global LLM lane");
+    expect(msg).toContain(VAULT_REF);
+    expect(msg).toMatch(/did not resolve/);
+    expect(msg).not.toContain("sk-");
+  });
+
+  it("names a per-op lane", () => {
+    const msg = hindsightLlmDroppedKeyWarning({ lane: "retain", ref: VAULT_REF });
+    expect(msg).toContain("`retain` LLM op");
+    expect(msg).toContain(VAULT_REF);
+    expect(msg).not.toContain("sk-");
   });
 });

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -1620,6 +1620,77 @@ export async function resolveHindsightLlmSecrets(
 }
 
 /**
+ * A hindsight LLM api_key `vault:` reference that FAILED to resolve and was
+ * dropped by {@link resolveHindsightLlmSecrets}. Carries the lane it belonged
+ * to and the reference string ONLY — never the resolved `sk-` secret.
+ */
+export interface DroppedHindsightLlmVaultKey {
+  /** `"global"`, or a per-op name: `retain` / `reflect` / `consolidation`. */
+  lane: string;
+  /** The `vault:<key>` reference that could not be resolved. NEVER a secret. */
+  ref: string;
+}
+
+/**
+ * Diff an LLM config against its {@link resolveHindsightLlmSecrets} output to
+ * find every api_key `vault:` reference that failed to resolve and was dropped.
+ *
+ * A drop means that lane silently falls back to the inherited / provider-default
+ * credential instead of the operator's configured key — invisible otherwise.
+ * The launch paths warn on it exactly as {@link HINDSIGHT_CP_NO_ACCESS_KEY_WARNING}
+ * warns on a dropped CP key (see {@link hindsightLlmDroppedKeyWarning}).
+ *
+ * Only `vault:` references are reported: a literal that resolves to itself is
+ * never "dropped", and an absent field was never configured. The returned `ref`
+ * is the `vault:<key>` reference string only — the whole point of resolving
+ * before launch is that the `sk-` value NEVER reaches an operator-facing surface.
+ */
+export async function diffDroppedHindsightLlmVaultKeys(
+  original: HindsightLlmConfig | undefined,
+  resolved: HindsightLlmConfig | undefined,
+): Promise<DroppedHindsightLlmVaultKey[]> {
+  if (!original) return [];
+  const { isVaultReference } = await import("../vault/resolver.js");
+  const drops: DroppedHindsightLlmVaultKey[] = [];
+  const check = (lane: string, origKey: string | undefined, resolvedKey: string | undefined) => {
+    const ref = origKey?.trim();
+    // A vault ref present in the input but absent from the output is a drop; a
+    // literal (resolves to itself) or an unset field is not.
+    if (ref && isVaultReference(ref) && !resolvedKey) drops.push({ lane, ref });
+  };
+  check("global", original.api_key, resolved?.api_key);
+  for (const op of HINDSIGHT_LLM_OPS) {
+    check(
+      op,
+      original[op as HindsightLlmOp]?.api_key,
+      resolved?.[op as HindsightLlmOp]?.api_key,
+    );
+  }
+  return drops;
+}
+
+/**
+ * Operator-facing warning the launch paths emit when a hindsight LLM api_key
+ * `vault:` reference could not be resolved and was dropped. The symmetric
+ * counterpart to {@link HINDSIGHT_CP_NO_ACCESS_KEY_WARNING}: a dropped LLM key
+ * is otherwise silent, and the lane quietly runs on the inherited / provider
+ * default credential — so fact extraction on that lane can fail with no trace.
+ * Names the lane and the `vault:` reference; NEVER the resolved secret.
+ */
+export function hindsightLlmDroppedKeyWarning(drop: DroppedHindsightLlmVaultKey): string {
+  const where =
+    drop.lane === "global" ? "the global LLM lane" : `the \`${drop.lane}\` LLM op`;
+  const fallback =
+    drop.lane === "global" ? "every op inherits" : "the op inherits";
+  return (
+    `hindsight: ${where} api_key \`${drop.ref}\` did not resolve through the ` +
+    "vault broker (denied, missing, or broker down) — the key was DROPPED, so " +
+    `${fallback} the provider-default credential and fact extraction on that ` +
+    "lane may fail. Check the broker grant for the reference above, then re-run."
+  );
+}
+
+/**
  * Whether hindsight's LLM traffic terminates on a self-hosted endpoint.
  *
  * The capability gate for the LLM concurrency caps (see

--- a/tests/setup-verification.test.ts
+++ b/tests/setup-verification.test.ts
@@ -630,6 +630,57 @@ describe("stepMemoryBackend (Docker absent)", () => {
       else process.env.SWITCHROOM_AGENT_NAME = savedName;
     }
   });
+
+  it("WARNS (naming the lane + ref, no secret) when a `vault:` LLM api_key drops", async () => {
+    // Minor-1 outcome guard: when the broker cannot resolve the `vault:` ref,
+    // the key is dropped and the lane silently inherits the provider default.
+    // The launch path must SAY so — symmetric to the cp_access_key warning —
+    // rather than launch quietly. This asserts the warning fires, names the
+    // lane and the `vault:` reference, and never prints a resolved `sk-` value.
+    const VAULT_REF = "vault:litellm/gpt-oss-key";
+    const savedName = process.env.SWITCHROOM_AGENT_NAME;
+    delete process.env.SWITCHROOM_AGENT_NAME;
+
+    const config = {
+      agents: { alpha: { topic_name: "alpha-topic" } },
+      hindsight: { llm: { provider: "openai", api_key: VAULT_REF } },
+    } as unknown as SwitchroomConfig;
+
+    const probe = (args: string[]) => {
+      if (args[0] === "--version") return "Docker version 27.0.0\n";
+      return "";
+    };
+    const startContainer = vi.fn();
+    // Broker denies the grant → the ref cannot resolve → the key is dropped.
+    const getViaBrokerStructured = vi.fn().mockResolvedValue({ kind: "denied" });
+
+    try {
+      await expect(
+        stepMemoryBackend(config, true, cfgPath, {
+          dockerProbe: probe,
+          startContainer: startContainer as never,
+          getViaBrokerStructured: getViaBrokerStructured as never,
+          sleep: async () => {},
+          readyRetries: 1,
+        }),
+      ).rejects.toThrow(/did not stay running/);
+
+      // The dropped key reached startContainer as undefined (fail-safe), and the
+      // operator was warned about it.
+      const llmArg = startContainer.mock.calls[0][3] as { api_key?: string } | undefined;
+      expect(llmArg?.api_key).toBeUndefined();
+
+      const text = logs.join("\n");
+      expect(text).toMatch(/did not resolve through the/);
+      expect(text).toMatch(/global LLM lane/);
+      expect(text).toContain(VAULT_REF);
+      // Secret hygiene: no resolved `sk-` value on any operator-facing line.
+      expect(text).not.toContain("sk-");
+    } finally {
+      if (savedName === undefined) delete process.env.SWITCHROOM_AGENT_NAME;
+      else process.env.SWITCHROOM_AGENT_NAME = savedName;
+    }
+  });
 });
 
 // ─── review M4: a FAIL verdict is sampled, like the OK verdict ───────────────


### PR DESCRIPTION
Two non-blocking minors from the pre-merge review of #4471 (hindsight `vault:` LLM api_key resolution on the recreate/rollout/first-run launch paths).

**Stacks on #4471 — merge after it lands.** Branched off #4471's head (`e909a626`) so the resolve helpers are present to extend. Once #4471 merges, this branch will be rebased onto `origin/main` to drop the now-duplicate resolve commits before it can merge.

## Minor-1 (real fix)
On the first-run (`switchroom setup`) and recreate (`memory setup --recreate`) launch paths, a `vault:` LLM api_key ref that fails to resolve through the broker (denied / missing / broker down) is **dropped** — the correct fail-safe, but silent. The lane then runs on the inherited / provider-default credential and fact extraction can fail with no trace. The `cp_access_key` path already warns in the mirror case (`HINDSIGHT_CP_NO_ACCESS_KEY_WARNING`); this adds the symmetric warning.

- `diffDroppedHindsightLlmVaultKeys(original, resolved)` diffs the pre/post-resolve LLM config to find every dropped `vault:` ref.
- `hindsightLlmDroppedKeyWarning(drop)` renders the operator line — naming the lane (global / retain / reflect / consolidation) and the `vault:` reference **only, never the resolved `sk-`**.
- Both launch call sites emit it (`src/cli/setup.ts`, `src/cli/memory.ts`), symmetric to the `cp_access_key` warning they already print.
- The recreate path keeps its env-drift report too; that report is env-var level ("this var will be dropped") and only fires when the key was previously baked, whereas this warning is vault-resolution level and actionable ("check the grant for `<ref>`"). Both signals are complementary, so both paths are observable.

## Minor-2 (conservative fix — applied)
`switchroom memory docker-compose` emits real resolved secrets in cleartext (LLM `sk-` api_key, `cp_access_key`) because a paste-ready compose file must carry them. The reviewer judged the cleartext acceptable (consistent with `cp_access_key`, and the command's purpose is a paste-ready file). Fix keeps stdout intact and adds a one-line **stderr** `#`-comment warning that the output is secret-bearing — so a piped/redirected stdout stays a valid compose file (the notice is a YAML comment even under `2>&1`) while an interactive operator is warned. Decision: **applied** the stderr warning (not left as-is); it's non-destructive and covers the LLM key under one notice alongside the existing (separate-concern) open-dashboard cp warning.

## Tests
- `tests/setup-verification.test.ts` — launch-path harness: asserts the warning fires on a broker-denied drop, names the lane + `vault:` ref, drops the key to `undefined`, and prints no `sk-`.
- `src/setup/hindsight-llm-vault-resolve.test.ts` — unit coverage for `diffDroppedHindsightLlmVaultKeys` (global + per-op drops, resolved refs / literals / unset fields not reported) and `hindsightLlmDroppedKeyWarning` (lane naming, no secret).

Scoped: `npx vitest run src/setup/hindsight-llm-vault-resolve.test.ts tests/setup-verification.test.ts` → 68 passed. `bun run lint` → clean.

Secret hygiene: no test or warning prints a resolved `sk-` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)