### PR TITLE
fix(hindsight): guard pg_search index rebuilds against silent tokenizer downgrade (#4474 C1)

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -134,6 +134,7 @@ jobs:
               - 'tests/docker/hindsight-recall-isolation-patches.test.ts'
               - 'tests/docker/hindsight-retry-perturbation-patches.test.ts'
               - 'tests/docker/hindsight-mm-refresh-debounce-patch.test.ts'
+              - 'tests/docker/hindsight-pg-search-tokenizer-drift-patch.test.ts'
               - 'tests/docker/hindsight-graph-seed-retirement.test.ts'
               - 'tests/docker/hindsight-maxitems-grammar-patch.test.ts'
               - 'src/setup/hindsight-perf-defaults.ts'
@@ -408,6 +409,18 @@ jobs:
           SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
         run: npx vitest run tests/docker/hindsight-mm-refresh-debounce-patch.test.ts
 
+      - name: Run the hindsight pg_search tokenizer-drift probe (RED/GREEN, must not skip)
+        # Epic #4474 finding C1. The bakes test can only see that the patch TEXT
+        # is present; it cannot see the outcome that matters — that the shipping
+        # text_signals migration, handed a live STEMMED ParadeDB index, emits a
+        # CREATE INDEX that still carries `stemmer=english`. Upstream emits
+        # `(id, text, context, text_signals)` there, silently unstemmed, on a
+        # POPULATED table, with no error and no log line. Only running the real
+        # `_pg_upgrade()` and reading back the DDL it emits catches that.
+        env:
+          SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
+        run: npx vitest run tests/docker/hindsight-pg-search-tokenizer-drift-patch.test.ts
+
       - name: Run the hindsight graph-seed RETIREMENT probe (RED/GREEN, must not skip)
         # The v0.8.5 upstream #2968 carry was retired in the v0.8.6 base bump —
         # upstream ships the behaviour natively and exposes
@@ -551,7 +564,7 @@ jobs:
       - name: Label-scoped teardown
         if: always()
         run: |
-          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-mm-refresh-debounce-patch hindsight-graph-seed-retirement hindsight-maxitems-grammar-patch hindsight-reflect-directives-patch hindsight-recall-budget-reflect-grounding hindsight-reranker-priority-patch hindsight-temporal-language-patch hindsight-temporal-offload-patch hindsight-pg-fsync-probe; do
+          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-mm-refresh-debounce-patch hindsight-pg-search-tokenizer-drift-patch hindsight-graph-seed-retirement hindsight-maxitems-grammar-patch hindsight-reflect-directives-patch hindsight-recall-budget-reflect-grounding hindsight-reranker-priority-patch hindsight-temporal-language-patch hindsight-temporal-offload-patch hindsight-pg-fsync-probe; do
             ids=$(docker ps -aq --filter "label=switchroom.test=$phase" 2>/dev/null || true)
             if [ -n "$ids" ]; then docker rm -f $ids 2>/dev/null || true; fi
           done

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -662,6 +662,683 @@ assert t.count("rows = await conn.fetch(fb_query, *fb_params)") == 1, "switchroo
 print("switchroom hindsight PG text-search recall-fallback patch: recall degrades to semantic-only on missing regconfig / stopword file (SQLSTATE 42704)")
 PYEOF
 
+# pg_search tokenizer-drift guard (switchroom epic #4474, finding C1).
+#
+# THE DEFECT, in the real shipping source at tag v0.8.6.
+#
+# The stemmed/stopworded ParadeDB variant the fleet needs for recall quality
+# ("Variant B": `stemmer=english` + `stopwords_language=english`) is NOT
+# expressible through HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER.
+# `_pg_search.py:32-85` accepts only a bare tokenizer NAME from a fixed set and
+# emits an UNSTEMMED `(field::pdb.<tok>)` cast — there is no stemmer or stopword
+# parameter anywhere in that module. So Variant B can only ever exist as
+# hand-built DDL.
+#
+# Meanwhile every place that decides "does the live index match the config"
+# keys on the `key_field` reloption alone (`migrations.py:887`) and never looks
+# at the tokenizer cast. A hand-built stemmed index is therefore silently
+# ADOPTED as correct — and any code path that rebuilds it emits the config's
+# unstemmed column list instead. The rebuild is real, not hypothetical:
+# `alembic/versions/a2b3c4d5e6f7_add_text_signals_column.py:75-83` does an
+# unconditional DROP INDEX + CREATE INDEX on a POPULATED memory_units, and
+# `migrations.py:1042-1070` rebuilds on the empty-table path. Both take their
+# column list from the config knob. Result: stemming silently disappears, with
+# no error, no log line, and nothing to notice it by until someone measures
+# recall quality.
+#
+# THE GUARD.
+#
+#  * `_pg_search.py` gains a parser for an existing ParadeDB indexdef, an
+#    "can the config knob even express this cast?" predicate (implemented by
+#    round-tripping through `normalize_pg_search_tokenizer`, so it can never
+#    drift from what config actually emits), a drift checker, and a
+#    rebuild-aware column builder.
+#  * `migrations.py` boot path: when column type / access method / key_field
+#    all agree, the tokenizer casts are compared too and a mismatch is logged
+#    at ERROR with the stable marker `pg_search_tokenizer_drift`.
+#  * Rebuild paths (`migrations.py` + the text_signals migration) read the
+#    PRE-EXISTING indexdef before dropping, and when the live tokenizer is one
+#    the knob cannot express they PRESERVE it instead of silently downgrading.
+#    A drift the knob CAN express is a deliberate config change and config
+#    still wins (logged at WARN).
+#
+# WHY THIS CANNOT CRASH-LOOP THE FLEET. `ensure_text_search_extension` runs on
+# EVERY boot and already raises RuntimeError on a schema mismatch with data
+# present (`migrations.py:768 -> :922 -> :940`); a guard that raised here would
+# take out the SEMANTIC arm too, i.e. a full memory outage — strictly worse
+# than the silent quality degradation it fixes. So this guard NEVER raises and
+# NEVER changes `index_matches`: every new code path is wrapped so that any
+# parse or comparison failure degrades to exactly upstream's behaviour with a
+# warning. The signal is a loud, repeated-every-boot structured log plus the
+# in-process `pg_search_tokenizer_drift_state()` accessor.
+#
+# NOT PATCHED, deliberately: `5a366d414dce_initial_schema.py` and
+# `n9i0j1k2l3m4_learnings_and_pinned_reflections.py` CREATE their tables in the
+# same migration, so no pre-existing index can be downgraded there.
+#
+# The cast syntax preserved here is ParadeDB's documented form —
+# `(description::pdb.simple('stemmer=english', 'stopwords_language=english'))`,
+# single-quoted `key=value` arguments (docs.paradedb.com, Create an Index /
+# Token Filters / Stemmer). The parser is deliberately syntax-agnostic: it
+# round-trips whatever cast text the catalog reports rather than assuming a
+# form, so an unquoted variant is preserved just as faithfully.
+#
+# Self-verifying at build time; behaviourally guarded by
+# tests/docker/hindsight-pg-search-tokenizer-drift-patch.test.ts and statically
+# by tests/docker/dockerfile-hindsight-bakes.test.ts.
+RUN python3 - <<'PYEOF'
+import pathlib
+
+NAME = "pg_search tokenizer-drift guard"
+ROOT = pathlib.Path("/app/api/hindsight_api")
+
+
+def patch(rel, old, new, *, count=1):
+    f = ROOT / rel
+    s = f.read_text()
+    n = s.count(old)
+    assert n == count, (
+        f"switchroom hindsight {NAME}: anchor found {n}x (expected {count}) in {rel} — "
+        "upstream reformatted; re-author this patch in docker/Dockerfile.hindsight. "
+        f"Anchor head: {old.strip().splitlines()[0]!r}"
+    )
+    f.write_text(s.replace(old, new, count))
+
+
+# ---------------------------------------------------------------- _pg_search.py
+patch(
+    "_pg_search.py",
+    r'''import re
+from collections.abc import Sequence
+''',
+    r'''import logging
+import re
+from collections.abc import Sequence
+''',
+)
+
+GUARD = r'''
+
+# --- switchroom: pg_search tokenizer-drift guard (epic #4474, C1) -------------
+#
+# The config knob above can only ever emit a BARE tokenizer name, so a
+# stemmed / stopworded ParadeDB index can only exist as hand-built DDL — and
+# nothing upstream compares tokenizers when it decides to rebuild. Everything
+# below exists so a rebuild cannot silently change retrieval semantics. None of
+# it raises: it runs on the every-boot migration path.
+
+PG_SEARCH_TOKENIZER_DRIFT_MARKER = "pg_search_tokenizer_drift"
+
+_DRIFT_LOG = logging.getLogger(__name__)
+
+_LAST_TOKENIZER_DRIFT: dict[str, dict[str, object]] = {}
+
+_INDEX_COLUMNS_RE = re.compile(r"\busing\s+(?:bm25|paradedb)\s*\(", re.IGNORECASE)
+
+_FIELD_CAST_RE = re.compile(
+    r"^\"?(?P<field>[A-Za-z_][A-Za-z0-9_$]*)\"?\s*::\s*pdb\.(?P<cast>\S.*)$",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# Conservative whitelist for a cast we are willing to re-emit into DDL. The text
+# comes from pg_get_indexdef (already-executed DDL, not user input), but we still
+# never splice anything into CREATE INDEX that is not a bare tokenizer name
+# optionally followed by simple identifier args or single-quoted key=value opts.
+_SAFE_CAST_RE = re.compile(
+    r"""^[a-z_][a-z0-9_]*
+        (\(\s*
+            (?:
+                '[A-Za-z0-9_=\-. ]*'(?:\s*,\s*'[A-Za-z0-9_=\-. ]*')*
+              | [A-Za-z0-9_]+(?:\s*,\s*[A-Za-z0-9_]+)*
+            )?
+        \s*\))?$""",
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def _strip_outer_parens(item: str) -> str:
+    item = item.strip()
+    while item.startswith("("):
+        depth = 0
+        quoted = False
+        end = -1
+        for i, ch in enumerate(item):
+            if quoted:
+                if ch == "'":
+                    quoted = False
+                continue
+            if ch == "'":
+                quoted = True
+            elif ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0:
+                    end = i
+                    break
+        if end != len(item) - 1:
+            break
+        item = item[1:-1].strip()
+    return item
+
+
+def _split_top_level(columns: str) -> list[str]:
+    parts: list[str] = []
+    buf: list[str] = []
+    depth = 0
+    quoted = False
+    for ch in columns:
+        if quoted:
+            buf.append(ch)
+            if ch == "'":
+                quoted = False
+            continue
+        if ch == "'":
+            quoted = True
+            buf.append(ch)
+        elif ch == "(":
+            depth += 1
+            buf.append(ch)
+        elif ch == ")":
+            depth -= 1
+            buf.append(ch)
+        elif ch == "," and depth == 0:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(ch)
+    parts.append("".join(buf))
+    return [p.strip() for p in parts if p.strip()]
+
+
+def parse_pg_search_index_casts(indexdef: str | None) -> dict[str, str] | None:
+    """Map indexed field -> tokenizer cast text, parsed from a ParadeDB indexdef.
+
+    The cast is whatever follows ``pdb.`` (e.g. ``simple('stemmer=english')``);
+    an uncast field maps to ``""``. Returns ``None`` when ``indexdef`` is absent
+    or is not a parseable ParadeDB / BM25 index definition — callers must treat
+    that as "nothing known", never as "no drift proven".
+    """
+
+    if not indexdef:
+        return None
+    match = _INDEX_COLUMNS_RE.search(indexdef)
+    if not match:
+        return None
+
+    open_at = match.end() - 1
+    depth = 0
+    quoted = False
+    close_at = -1
+    for i in range(open_at, len(indexdef)):
+        ch = indexdef[i]
+        if quoted:
+            if ch == "'":
+                quoted = False
+            continue
+        if ch == "'":
+            quoted = True
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                close_at = i
+                break
+    if close_at < 0:
+        return None
+
+    casts: dict[str, str] = {}
+    for item in _split_top_level(indexdef[open_at + 1 : close_at]):
+        bare = _strip_outer_parens(item)
+        cast_match = _FIELD_CAST_RE.match(bare)
+        if cast_match:
+            casts[cast_match.group("field").lower()] = cast_match.group("cast").strip()
+            continue
+        ident = bare.strip('"').strip()
+        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_$]*", ident):
+            casts[ident.lower()] = ""
+    return casts or None
+
+
+def pg_search_tokenizer_is_expressible(cast: str) -> bool:
+    """True when the configured tokenizer knob can reproduce ``cast`` verbatim.
+
+    This is the C1 test. ``normalize_pg_search_tokenizer`` is the ONLY thing
+    that ever writes a cast from config, so a cast it cannot round-trip (e.g.
+    ``simple('stemmer=english')``) can only have come from hand-built DDL, and a
+    config-driven rebuild would silently destroy it. Defining the predicate as a
+    round-trip means it can never drift from what config actually emits.
+    """
+
+    if not cast:
+        return True
+    try:
+        return normalize_pg_search_tokenizer(cast) == cast.strip().lower()
+    except ValueError:
+        return False
+
+
+def _observed_cast(casts: dict[str, str], text_fields: Sequence[str]) -> tuple[str, bool]:
+    """The tokenizer cast the existing index applies to the fields being rebuilt.
+
+    Returns ``(cast, consistent)``. ``consistent`` is False when the index
+    applies more than one distinct cast across those fields; the first one wins
+    and the caller reports it.
+    """
+
+    seen: list[str] = []
+    for field in text_fields:
+        if field.lower() in casts:
+            value = casts[field.lower()]
+            if value not in seen:
+                seen.append(value)
+    if not seen:
+        return "", True
+    return seen[0], len(seen) == 1
+
+
+def pg_search_tokenizer_drift_state() -> dict[str, dict[str, object]]:
+    """Last recorded drift per index — for status surfaces and tests."""
+
+    return {key: dict(value) for key, value in _LAST_TOKENIZER_DRIFT.items()}
+
+
+def check_pg_search_tokenizer_drift(
+    indexdef: str | None,
+    text_fields: Sequence[str],
+    tokenizer: str | None,
+    *,
+    table: str = "",
+    index_name: str = "",
+    log=None,
+) -> dict[str, object] | None:
+    """Compare a live ParadeDB index's tokenizer against the configured one.
+
+    Returns a drift record, or ``None`` when there is no drift (or nothing
+    parseable to compare). NEVER raises and NEVER mutates the database: this
+    runs on the boot path, where an exception would take out the semantic arm
+    alongside the keyword one.
+    """
+
+    emit = log if log is not None else _DRIFT_LOG
+    try:
+        casts = parse_pg_search_index_casts(indexdef)
+        if casts is None:
+            return None
+        configured = normalize_pg_search_tokenizer(tokenizer)
+        observed, consistent = _observed_cast(casts, text_fields)
+        if observed == configured and consistent:
+            return None
+        expressible = pg_search_tokenizer_is_expressible(observed)
+        record: dict[str, object] = {
+            "table": table,
+            "index": index_name,
+            "observed_tokenizer": observed,
+            "configured_tokenizer": configured,
+            "config_expressible": expressible,
+            "consistent_across_fields": consistent,
+            "observed_casts": dict(casts),
+        }
+        _LAST_TOKENIZER_DRIFT[f"{table}.{index_name}"] = record
+        emit.error(
+            "%s table=%s index=%s observed=%r configured=%r config_expressible=%s "
+            "consistent_across_fields=%s - the live ParadeDB index does not tokenize the "
+            "way %s would build it, so keyword recall quality is NOT what the config "
+            "describes. See switchroom epic #4474 (C1).",
+            PG_SEARCH_TOKENIZER_DRIFT_MARKER,
+            table or "?",
+            index_name or "?",
+            observed,
+            configured,
+            expressible,
+            consistent,
+            PG_SEARCH_TOKENIZER_ENV,
+        )
+        return record
+    except Exception as exc:  # never raise on the boot path
+        emit.warning(
+            "%s check failed on table=%s index=%s: %s",
+            PG_SEARCH_TOKENIZER_DRIFT_MARKER,
+            table,
+            index_name,
+            exc,
+        )
+        return None
+
+
+def pg_search_rebuild_bm25_columns(
+    indexdef: str | None,
+    key_field: str,
+    text_fields: Sequence[str],
+    tokenizer: str | None,
+    *,
+    table: str = "",
+    index_name: str = "",
+    log=None,
+) -> str:
+    """Column list for REBUILDING a ParadeDB index that may already exist.
+
+    Identical to :func:`pg_search_bm25_columns` for a fresh build. When an index
+    already exists, its tokenizer is compared against the configured one:
+
+    * no drift -> the configured column list, unchanged;
+    * drift the tokenizer knob CAN express -> configured wins (a deliberate
+      config change), logged at WARN;
+    * drift the knob CANNOT express (the C1 hazard: a hand-built stemmed /
+      stopworded index) -> the observed cast is PRESERVED, so the rebuild cannot
+      silently downgrade a stemmed index to an unstemmed one.
+
+    Never raises: any parse or safety failure falls back to the configured
+    column list with a log line, i.e. exactly upstream's behaviour.
+    """
+
+    emit = log if log is not None else _DRIFT_LOG
+    configured_columns = pg_search_bm25_columns(key_field, text_fields, tokenizer)
+    drift = check_pg_search_tokenizer_drift(
+        indexdef, text_fields, tokenizer, table=table, index_name=index_name, log=emit
+    )
+    if drift is None:
+        return configured_columns
+    if drift["config_expressible"]:
+        emit.warning(
+            "%s rebuild=honour-config table=%s index=%s observed=%r configured=%r - the "
+            "configured tokenizer can express the live one, so the rebuild applies config.",
+            PG_SEARCH_TOKENIZER_DRIFT_MARKER,
+            table or "?",
+            index_name or "?",
+            drift["observed_tokenizer"],
+            drift["configured_tokenizer"],
+        )
+        return configured_columns
+
+    observed = str(drift["observed_tokenizer"])
+    if not _SAFE_CAST_RE.match(observed):
+        emit.error(
+            "%s rebuild=downgrade-unavoidable table=%s index=%s observed=%r - the live "
+            "tokenizer cast is not in a re-emittable form, so the rebuild CANNOT preserve "
+            "it. The rebuilt index will tokenize as %r; re-apply the hand-built DDL.",
+            PG_SEARCH_TOKENIZER_DRIFT_MARKER,
+            table or "?",
+            index_name or "?",
+            observed,
+            drift["configured_tokenizer"],
+        )
+        return configured_columns
+
+    emit.error(
+        "%s rebuild=preserve-observed table=%s index=%s observed=%r configured=%r - %s "
+        "cannot express the live tokenizer, so the rebuild PRESERVES it rather than "
+        "silently reverting to the configured (unstemmed) form. See epic #4474 (C1).",
+        PG_SEARCH_TOKENIZER_DRIFT_MARKER,
+        table or "?",
+        index_name or "?",
+        observed,
+        drift["configured_tokenizer"],
+        PG_SEARCH_TOKENIZER_ENV,
+    )
+    return ", ".join([key_field, *(f"({field}::pdb.{observed})" for field in text_fields)])
+'''
+
+_pg = ROOT / "_pg_search.py"
+_src = _pg.read_text()
+assert "pg_search_rebuild_bm25_columns" not in _src, (
+    f"switchroom hindsight {NAME}: upstream now ships a rebuild-aware column builder — "
+    "retire this patch in docker/Dockerfile.hindsight"
+)
+_pg.write_text(_src.rstrip("\n") + "\n" + GUARD)
+
+# ---------------------------------------------------------------- migrations.py
+patch(
+    "migrations.py",
+    r'''from ._pg_search import normalize_pg_search_tokenizer, pg_search_bm25_columns
+''',
+    r'''from ._pg_search import (
+    check_pg_search_tokenizer_drift,
+    normalize_pg_search_tokenizer,
+    pg_search_rebuild_bm25_columns,
+)
+''',
+)
+
+# Boot path: column type, access method and key_field can all agree while the
+# index tokenizes completely differently. Compare the casts too — LOG ONLY.
+patch(
+    "migrations.py",
+    r'''            else:
+                logger.debug(f"Text search OK for {table_name}: {current_column_type}/{current_index_type}")
+''',
+    r'''            else:
+                # switchroom (epic #4474, C1): everything upstream checks — column
+                # type, access method, key_field — can agree while the live index
+                # tokenizes completely differently, because the tokenizer cast is
+                # never inspected. Compare it and say so LOUDLY. Deliberately log
+                # only: this is the every-boot path and the mismatch branch below
+                # raises RuntimeError when data is present, which would take the
+                # SEMANTIC arm down too. A quality regression must not become an
+                # availability outage.
+                if want_pg_search and current_is_pg_search:
+                    check_pg_search_tokenizer_drift(
+                        current_index_def,
+                        ("text", "context", "text_signals")
+                        if table_name == "memory_units"
+                        else ("name", "content"),
+                        pg_search_tokenizer,
+                        table=table_name,
+                        index_name=f"idx_{table_name.replace('.', '_')}_text_search",
+                        log=logger,
+                    )
+                logger.debug(f"Text search OK for {table_name}: {current_column_type}/{current_index_type}")
+''',
+)
+
+# Rebuild path: capture the pre-existing definition BEFORE the DROP.
+patch(
+    "migrations.py",
+    r'''        for table_name, current_col_type, current_idx_type, _was_pg_search in mismatched_tables:
+            # Drop existing index if it exists
+''',
+    r'''        for table_name, current_col_type, current_idx_type, _was_pg_search in mismatched_tables:
+            # switchroom (epic #4474, C1): read the existing index definition
+            # BEFORE dropping it, so the rebuild below can tell whether it is
+            # about to silently change tokenizer semantics.
+            _prior_index_name = f"idx_{table_name.replace('.', '_')}_text_search"
+            try:
+                prior_indexdef = conn.execute(
+                    text(
+                        "SELECT indexdef FROM pg_indexes "
+                        "WHERE schemaname = :schema AND indexname = :index_name"
+                    ),
+                    {"schema": schema_name, "index_name": _prior_index_name},
+                ).scalar()
+            except Exception as exc:  # never block the rebuild on the guard
+                logger.warning("Could not read prior indexdef for %s: %s", _prior_index_name, exc)
+                prior_indexdef = None
+
+            # Drop existing index if it exists
+''',
+)
+
+patch(
+    "migrations.py",
+    r'''                if table_name == "memory_units":
+                    bm25_cols = pg_search_bm25_columns(
+                        "id",
+                        ("text", "context", "text_signals"),
+                        pg_search_tokenizer,
+                    )
+                else:  # reflections
+                    bm25_cols = pg_search_bm25_columns(
+                        "id",
+                        ("name", "content"),
+                        pg_search_tokenizer,
+                    )
+''',
+    r'''                # switchroom (epic #4474, C1): rebuild-aware — preserves a live
+                # tokenizer the config knob cannot express instead of silently
+                # reverting the index to unstemmed.
+                if table_name == "memory_units":
+                    bm25_cols = pg_search_rebuild_bm25_columns(
+                        prior_indexdef,
+                        "id",
+                        ("text", "context", "text_signals"),
+                        pg_search_tokenizer,
+                        table=table_name,
+                        index_name=_prior_index_name,
+                        log=logger,
+                    )
+                else:  # reflections
+                    bm25_cols = pg_search_rebuild_bm25_columns(
+                        prior_indexdef,
+                        "id",
+                        ("name", "content"),
+                        pg_search_tokenizer,
+                        table=table_name,
+                        index_name=_prior_index_name,
+                        log=logger,
+                    )
+''',
+)
+
+# ------------------------------------------- a2b3c4d5e6f7_add_text_signals_column
+# The one rebuild that runs DROP INDEX + CREATE INDEX against a POPULATED
+# memory_units. Upstream takes the new column list straight from the config
+# knob, which is exactly how a hand-built stemmed index disappears.
+MIG = "alembic/versions/a2b3c4d5e6f7_add_text_signals_column.py"
+
+patch(
+    MIG,
+    r'''from hindsight_api._pg_search import (
+    PG_SEARCH_TOKENIZER_ENV,
+    normalize_pg_search_tokenizer,
+    pg_search_bm25_columns,
+)
+''',
+    r'''from hindsight_api._pg_search import (
+    PG_SEARCH_TOKENIZER_ENV,
+    normalize_pg_search_tokenizer,
+    pg_search_rebuild_bm25_columns,
+)
+''',
+)
+
+patch(
+    MIG,
+    r'''def _pg_search_tokenizer() -> str:
+    return normalize_pg_search_tokenizer(os.getenv(PG_SEARCH_TOKENIZER_ENV))
+''',
+    r'''def _pg_search_tokenizer() -> str:
+    return normalize_pg_search_tokenizer(os.getenv(PG_SEARCH_TOKENIZER_ENV))
+
+
+def _prior_indexdef(index_name: str) -> str | None:
+    """The live definition of ``index_name``, read BEFORE it is dropped.
+
+    switchroom (epic #4474, C1): the rebuild below takes its column list from
+    the tokenizer config knob, which cannot express a stemmed / stopworded
+    ParadeDB index. Without this read, a hand-built stemmed index is silently
+    replaced by an unstemmed one on a populated table. Returns None on any
+    failure — the guard must never break the migration.
+
+    Honest caveat: this SELECT runs inside the migration's transaction, so a
+    failure would abort that transaction and the DDL after it would fail too,
+    swallowed exception or not. That is accepted rather than papered over —
+    the query is a parameterised read of a core catalog view, so the only
+    realistic failure mode is a dead connection, which fails the migration
+    regardless.
+    """
+
+    from sqlalchemy import text as _sa_text
+
+    schema = context.config.get_main_option("target_schema") or "public"
+    try:
+        return (
+            op.get_bind()
+            .execute(
+                _sa_text(
+                    "SELECT indexdef FROM pg_indexes "
+                    "WHERE schemaname = :schema AND indexname = :index_name"
+                ),
+                {"schema": schema, "index_name": index_name},
+            )
+            .scalar()
+        )
+    except Exception:
+        return None
+''',
+)
+
+patch(
+    MIG,
+    r'''        bm25_cols = pg_search_bm25_columns("id", ("text", "context", "text_signals"), _pg_search_tokenizer())
+        op.execute(f"DROP INDEX IF EXISTS {schema}idx_memory_units_text_search")
+''',
+    r'''        bm25_cols = pg_search_rebuild_bm25_columns(
+            _prior_indexdef("idx_memory_units_text_search"),
+            "id",
+            ("text", "context", "text_signals"),
+            _pg_search_tokenizer(),
+            table="memory_units",
+            index_name="idx_memory_units_text_search",
+        )
+        op.execute(f"DROP INDEX IF EXISTS {schema}idx_memory_units_text_search")
+''',
+)
+
+patch(
+    MIG,
+    r'''        bm25_cols = pg_search_bm25_columns("id", ("text", "context"), _pg_search_tokenizer())
+        op.execute(f"DROP INDEX IF EXISTS {schema}idx_memory_units_text_search")
+''',
+    r'''        bm25_cols = pg_search_rebuild_bm25_columns(
+            _prior_indexdef("idx_memory_units_text_search"),
+            "id",
+            ("text", "context"),
+            _pg_search_tokenizer(),
+            table="memory_units",
+            index_name="idx_memory_units_text_search",
+        )
+        op.execute(f"DROP INDEX IF EXISTS {schema}idx_memory_units_text_search")
+''',
+)
+
+# ----------------------------------------------------------------- verification
+import py_compile
+
+for rel in ("_pg_search.py", "migrations.py", MIG):
+    py_compile.compile(str(ROOT / rel), doraise=True)
+
+t = (ROOT / "_pg_search.py").read_text()
+assert "def parse_pg_search_index_casts(" in t, f"switchroom hindsight {NAME}: parser missing after patch"
+assert "def pg_search_tokenizer_is_expressible(" in t, f"switchroom hindsight {NAME}: expressibility predicate missing after patch"
+assert "def pg_search_rebuild_bm25_columns(" in t, f"switchroom hindsight {NAME}: rebuild builder missing after patch"
+assert "def pg_search_tokenizer_drift_state(" in t, f"switchroom hindsight {NAME}: drift-state accessor missing after patch"
+assert 'PG_SEARCH_TOKENIZER_DRIFT_MARKER = "pg_search_tokenizer_drift"' in t, f"switchroom hindsight {NAME}: log marker missing after patch"
+# The guard body must contain no `raise` statement at all: it runs on the
+# every-boot path, where an exception is an availability outage.
+_guard_body = t.split("# --- switchroom: pg_search tokenizer-drift guard")[1]
+_raises = [ln for ln in _guard_body.splitlines() if ln.strip().startswith(("raise ", "raise\t", "raise\n")) or ln.strip() == "raise"]
+assert not _raises, f"switchroom hindsight {NAME}: guard body contains a raise statement ({_raises!r}) — it runs on the every-boot path"
+
+m = (ROOT / "migrations.py").read_text()
+assert "check_pg_search_tokenizer_drift(" in m, f"switchroom hindsight {NAME}: boot-path drift check missing after patch"
+assert m.count("pg_search_rebuild_bm25_columns(") == 2, f"switchroom hindsight {NAME}: expected 2 rebuild call sites in migrations.py"
+assert m.count("pg_search_bm25_columns(") == 0, f"switchroom hindsight {NAME}: a config-only pg_search rebuild call site survived in migrations.py"
+assert "prior_indexdef" in m, f"switchroom hindsight {NAME}: pre-drop indexdef capture missing after patch"
+# The boot detector must NOT have become a new failure mode.
+assert m.count("raise RuntimeError(") == 9, (
+    f"switchroom hindsight {NAME}: migrations.py RuntimeError count changed — the guard must "
+    "add no new raise on the every-boot text-search path"
+)
+
+a = (ROOT / MIG).read_text()
+assert a.count("pg_search_rebuild_bm25_columns(") == 2, f"switchroom hindsight {NAME}: expected 2 call sites in the text_signals migration"
+assert a.count("pg_search_bm25_columns(") == 0, f"switchroom hindsight {NAME}: a config-only rebuild call site survived in the text_signals migration"
+assert "def _prior_indexdef(" in a, f"switchroom hindsight {NAME}: pre-drop indexdef read missing from the text_signals migration"
+
+print("switchroom hindsight pg_search tokenizer-drift guard: rebuilds preserve an inexpressible tokenizer and drift is logged as pg_search_tokenizer_drift; no new raise on the boot path")
+PYEOF
+
 # Empty-TimeoutError-message fix: both retry loops in
 # engine/providers/litellm_llm.py end their timeout handler with a bare
 # `raise`, which re-raises the asyncio.TimeoutError produced by

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -340,6 +340,76 @@ describe("Dockerfile.hindsight shape", () => {
     );
   });
 
+  it("keeps the pg_search tokenizer-drift guard (assert-guarded, fail-loud)", () => {
+    // Epic #4474, finding C1. The stemmed/stopworded ParadeDB variant the fleet
+    // needs for recall quality cannot be expressed through
+    // HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER (_pg_search.py
+    // takes a bare tokenizer NAME and emits an UNSTEMMED cast), so it can only
+    // exist as hand-built DDL — and nothing upstream defends it: every
+    // "does the index match the config" decision keys on the `key_field`
+    // reloption alone (migrations.py:887) and never inspects the tokenizer.
+    // The text_signals migration then DROPs and re-CREATEs the index on a
+    // POPULATED memory_units from the config knob, silently reverting it to
+    // unstemmed. Behaviour is proven against the pinned upstream image in
+    // tests/docker/hindsight-pg-search-tokenizer-drift-patch.test.ts.
+
+    // The exact-once anchor guard (fail-loud on upstream drift), naming the
+    // file and the re-author path.
+    expect(dockerfile).toMatch(
+      /switchroom hindsight \{NAME\}: anchor found \{n\}x \(expected \{count\}\) in \{rel\}/,
+    );
+
+    // The three mechanisms, all load-bearing.
+    // 1. expressibility is defined as a ROUND-TRIP through the same normalizer
+    //    config uses, so the predicate can never drift from what config emits.
+    expect(dockerfile).toMatch(
+      /return normalize_pg_search_tokenizer\(cast\) == cast\.strip\(\)\.lower\(\)/,
+    );
+    // 2. the boot path compares tokenizers, not just key_field…
+    expect(dockerfile).toMatch(/check_pg_search_tokenizer_drift\(/);
+    // 3. …and every rebuild reads the PRE-EXISTING definition before dropping.
+    expect(dockerfile).toMatch(/SELECT indexdef FROM pg_indexes /);
+    expect(dockerfile).toMatch(/def pg_search_rebuild_bm25_columns\(/);
+
+    // The stable, greppable operator signal.
+    expect(dockerfile).toMatch(
+      /PG_SEARCH_TOKENIZER_DRIFT_MARKER = "pg_search_tokenizer_drift"/,
+    );
+
+    // THE CRASH-LOOP CONSTRAINT, pinned. ensure_text_search_extension runs on
+    // EVERY boot and already raises RuntimeError on a schema mismatch with data
+    // present (migrations.py:768 → :922 → :940); a guard that raised there
+    // would take the SEMANTIC arm down alongside the keyword one — a full
+    // memory outage, strictly worse than the silent degradation being fixed.
+    // Both halves are pinned: the guard body carries no `raise` statement, and
+    // migrations.py's RuntimeError count is unchanged by the patch.
+    expect(dockerfile).toMatch(
+      /assert not _raises, f"switchroom hindsight \{NAME\}: guard body contains a raise statement/,
+    );
+    expect(dockerfile).toMatch(
+      /assert m\.count\("raise RuntimeError\("\) == 9,/,
+    );
+
+    // Post-replace re-assertions (verification-on-build): both rebuild call
+    // sites in each patched file must be the rebuild-aware builder, with no
+    // config-only call site left behind.
+    expect(dockerfile).toMatch(
+      /assert m\.count\("pg_search_rebuild_bm25_columns\("\) == 2,/,
+    );
+    expect(dockerfile).toMatch(
+      /assert m\.count\("pg_search_bm25_columns\("\) == 0,/,
+    );
+    expect(dockerfile).toMatch(
+      /assert a\.count\("pg_search_rebuild_bm25_columns\("\) == 2,/,
+    );
+    expect(dockerfile).toMatch(
+      /assert a\.count\("pg_search_bm25_columns\("\) == 0,/,
+    );
+    expect(dockerfile).toMatch(
+      /switchroom hindsight pg_search tokenizer-drift guard: rebuilds preserve an inexpressible tokenizer/,
+    );
+  });
+
   it("creates /backups owned by hindsight BEFORE `USER hindsight` (so the named volume is writable)", () => {
     // A root-owned /backups mount point makes the fresh named volume
     // root-owned → the non-root hindsight process EACCESes on pg_dump and

--- a/tests/docker/hindsight-pg-search-tokenizer-drift-patch.test.ts
+++ b/tests/docker/hindsight-pg-search-tokenizer-drift-patch.test.ts
@@ -1,0 +1,496 @@
+/**
+ * Behavioural proof for the pg_search tokenizer-drift guard (epic #4474, C1)
+ * that `docker/Dockerfile.hindsight` bakes into the pinned upstream Hindsight
+ * image.
+ *
+ * `dockerfile-hindsight-bakes.test.ts` pins the *shape* of that patch block
+ * (grep-on-file, runs everywhere). This file proves the *outcome*: it runs the
+ * same probe against unpatched upstream (must be RED — the rebuild silently
+ * drops stemming) and against upstream + the patch block applied (must be
+ * GREEN on every property).
+ *
+ * THE DEFECT, in the real shipping source at tag v0.8.6.
+ *
+ * The stemmed/stopworded ParadeDB variant the fleet needs for recall quality
+ * (`stemmer=english` + `stopwords_language=english`) cannot be expressed
+ * through `HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER`:
+ * `_pg_search.py:32-85` takes a bare tokenizer NAME from a fixed set and emits
+ * an unstemmed `(field::pdb.<tok>)` cast. So it can only ever exist as
+ * hand-built DDL. Nothing then defends it — every "does the index match the
+ * config" decision keys on the `key_field` reloption alone
+ * (`migrations.py:887`) and never looks at the tokenizer cast.
+ *
+ * The probe drives the single most dangerous consequence: the REBUILD in
+ * `alembic/versions/a2b3c4d5e6f7_add_text_signals_column.py:75-83`, which does
+ * an unconditional `DROP INDEX` + `CREATE INDEX` against a POPULATED
+ * `memory_units` and takes its column list straight from the config knob. Given
+ * a live stemmed index, unpatched upstream emits `(id, text, context,
+ * text_signals)` — unstemmed. No error, no log line, recall quality quietly
+ * degraded fleet-wide.
+ *
+ * The properties this probe drives, none of which the patch TEXT can show:
+ *
+ *  1. THE REBUILD PRESERVES STEMMING — the real `_pg_upgrade()` from the
+ *     shipping migration, given a live stemmed index, emits a `CREATE INDEX`
+ *     that still carries `stemmer=english` / `stopwords_language=english`.
+ *     This is the property that is RED on upstream.
+ *  2. THE MIGRATION STILL DOES ITS JOB — the rebuilt index gains
+ *     `text_signals` and keeps `key_field='id'`. Preserving semantics must not
+ *     silently neuter the migration.
+ *  3. THE BOOT PATH SURFACES THE DRIFT — a drift record is produced, naming the
+ *     observed cast, the configured one, and that config cannot express it.
+ *  4. NO FALSE ALARM — an index whose tokenizer already matches config yields
+ *     no drift, so the ERROR line means something when it appears.
+ *  5. CONFIG STILL WINS WHEN IT CAN — a drift the knob CAN express (e.g. a live
+ *     `pdb.icu` against an unset knob) is a deliberate config change and the
+ *     rebuild applies config. The guard preserves what config cannot express,
+ *     it does not freeze the index.
+ *  6. IT NEVER RAISES — the guard runs inside `ensure_text_search_extension`,
+ *     which executes on EVERY boot and already raises `RuntimeError` on a
+ *     schema mismatch with data present (`migrations.py:768 -> :922 -> :940`).
+ *     A guard that raised would take the SEMANTIC arm down with the keyword
+ *     one — a full memory outage, strictly worse than the silent degradation
+ *     it fixes. The probe feeds it malformed, truncated and hostile index
+ *     definitions and asserts it returns instead of raising.
+ *
+ * The probe drives the REAL shipping migration with fakes ONLY at the alembic
+ * boundary (`op` / `context`), capturing the DDL it actually emits, rather than
+ * re-implementing the rebuild here. Nothing in it greps the patched source.
+ *
+ * The patch block is extracted from the Dockerfile itself rather than
+ * duplicated here, so this test cannot drift from what actually ships. It
+ * applies it by `docker exec` (not `docker build`) so it runs on daemons
+ * without buildx, and it never touches the production `switchroom-hindsight`
+ * container. No database is required: the rebuild is observed as emitted SQL.
+ *
+ * SKIP DISCIPLINE: identical to `hindsight-mm-refresh-debounce-patch.test.ts`.
+ * Locally, with no docker or no cached image, this skips (never pull a 6.4GB
+ * third-party image onto a dev box). In CI the `hindsight-probe` job pulls the
+ * pinned digest and sets SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1, under which an
+ * unavailable docker/image is a HARD FAILURE, never a green skip. Both runs
+ * assert a `PROBE_EXECUTED` sentinel so a probe that dies early can never be
+ * mistaken for a pass.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { execFileSync, execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const dockerfile = readFileSync(
+  resolve(root, "docker/Dockerfile.hindsight"),
+  "utf8",
+);
+
+const RUN_ID = randomUUID();
+const TEST_PHASE = "hindsight-pg-search-tokenizer-drift-patch";
+
+/** The pinned upstream image, read from the Dockerfile so it can never drift. */
+const UPSTREAM_IMAGE = (() => {
+  const m = dockerfile.match(/^FROM\s+(\S+)/m);
+  if (!m) throw new Error("Dockerfile.hindsight has no FROM line");
+  return m[1];
+})();
+
+/** The patch this file proves, named by its unique in-block marker. */
+const PATCH_NAME = "pg_search tokenizer-drift guard";
+
+/**
+ * The patch block under test, pulled out of the Dockerfile's
+ * `RUN python3 - <<'PYEOF' ... PYEOF` heredocs by its unique patch name.
+ */
+function patchBlocks(): string[] {
+  const blocks = [
+    ...dockerfile.matchAll(/^RUN python3 - <<'PYEOF'\n([\s\S]*?)^PYEOF$/gm),
+  ].map((m) => m[1]);
+  const hits = blocks.filter((b) => b.includes(PATCH_NAME));
+  if (hits.length !== 1) {
+    throw new Error(
+      `Dockerfile.hindsight contains ${hits.length} "${PATCH_NAME}" RUN blocks ` +
+        `(expected exactly 1) — if the patch was deliberately removed, delete ` +
+        `this test with it.`,
+    );
+  }
+  return hits;
+}
+
+/**
+ * Python probe. Exits 0 only when all six properties above hold; prints the
+ * offending assertions otherwise.
+ *
+ * Deliberately asserts OUTCOMES: it runs the real `_pg_upgrade()` from the
+ * shipping text_signals migration against a fake alembic boundary and reads
+ * back the DDL it emits.
+ */
+const PROBE = String.raw`
+import importlib.util
+import json
+import os
+import sys
+
+failures = []
+
+
+def fail(msg):
+    failures.append(msg)
+
+
+STEM = "simple('stemmer=english', 'stopwords_language=english')"
+
+# What a hand-built "Variant B" index looks like in pg_indexes.indexdef. Only
+# (id, text, context) — this is the pre-text_signals shape the migration below
+# is about to rebuild.
+LIVE_STEMMED = (
+    "CREATE INDEX idx_memory_units_text_search ON public.memory_units USING bm25 "
+    "(id, (text::pdb.%s), (context::pdb.%s)) WITH (key_field='id')" % (STEM, STEM)
+)
+LIVE_PLAIN = (
+    "CREATE INDEX idx_memory_units_text_search ON public.memory_units USING bm25 "
+    "(id, text, context) WITH (key_field='id')"
+)
+LIVE_ICU = (
+    "CREATE INDEX idx_memory_units_text_search ON public.memory_units USING bm25 "
+    "(id, (text::pdb.icu), (context::pdb.icu)) WITH (key_field='id')"
+)
+
+os.environ["HINDSIGHT_API_TEXT_SEARCH_EXTENSION"] = "pg_search"
+os.environ.pop("HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER", None)
+
+MIG_PATH = "/app/api/hindsight_api/alembic/versions/a2b3c4d5e6f7_add_text_signals_column.py"
+
+
+# --- fakes at the alembic boundary ONLY ---------------------------------------
+class _Result:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar(self):
+        return self._value
+
+
+class _Bind:
+    def __init__(self, indexdef):
+        self.indexdef = indexdef
+
+    def execute(self, statement, params=None):
+        return _Result(self.indexdef)
+
+    def exec_driver_sql(self, statement, params=None):
+        return _Result(self.indexdef)
+
+
+class FakeOp:
+    def __init__(self, indexdef):
+        self.sql = []
+        self._bind = _Bind(indexdef)
+
+    def execute(self, statement):
+        self.sql.append(" ".join(str(statement).split()))
+
+    def get_bind(self):
+        return self._bind
+
+
+class _FakeConfig:
+    def get_main_option(self, name, default=None):
+        return None
+
+
+class FakeContext:
+    config = _FakeConfig()
+
+
+def load_migration():
+    spec = importlib.util.spec_from_file_location("sr_probe_text_signals", MIG_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def rebuild_ddl(live_indexdef):
+    """Run the REAL migration upgrade and return the CREATE INDEX it emits."""
+    mod = load_migration()
+    fake = FakeOp(live_indexdef)
+    mod.op = fake
+    mod.context = FakeContext()
+    mod._pg_upgrade()
+    created = [s for s in fake.sql if s.upper().startswith("CREATE INDEX")]
+    if len(created) != 1:
+        fail("migration emitted %d CREATE INDEX statements (expected 1): %s" % (len(created), fake.sql))
+        return ""
+    return created[0]
+
+
+# --- 1 + 2. the rebuild preserves stemming and still adds text_signals ---------
+ddl = rebuild_ddl(LIVE_STEMMED)
+print("REBUILD_DDL", ddl)
+if "stemmer=english" not in ddl:
+    fail("REBUILD DROPPED THE STEMMER: the rebuilt index is unstemmed -> " + ddl)
+if "stopwords_language=english" not in ddl:
+    fail("REBUILD DROPPED THE STOPWORD FILTER: " + ddl)
+if "text_signals" not in ddl:
+    fail("rebuild lost text_signals — the migration's own purpose: " + ddl)
+if "key_field='id'" not in ddl:
+    fail("rebuild lost key_field='id': " + ddl)
+
+# --- 3. the boot path surfaces the drift ---------------------------------------
+try:
+    import hindsight_api._pg_search as pgs
+except Exception as exc:  # pragma: no cover - import cannot fail in the image
+    pgs = None
+    fail("could not import hindsight_api._pg_search: %r" % (exc,))
+
+check = getattr(pgs, "check_pg_search_tokenizer_drift", None) if pgs else None
+if check is None:
+    fail(
+        "NO TOKENIZER DRIFT DETECTOR: a hand-built stemmed index is adopted as valid "
+        "and nothing reports that the live index no longer tokenizes the way config says"
+    )
+else:
+    record = check(LIVE_STEMMED, ("text", "context", "text_signals"), "", table="memory_units", index_name="idx")
+    if not record:
+        fail("drift detector returned nothing for a stemmed index against an unset tokenizer knob")
+    else:
+        print("DRIFT_RECORD", json.dumps({k: record[k] for k in sorted(record) if k != "observed_casts"}, default=str))
+        if record.get("config_expressible") is not False:
+            fail("drift detector claims the config knob can express %r" % (record.get("observed_tokenizer"),))
+        if "stemmer=english" not in str(record.get("observed_tokenizer")):
+            fail("drift record does not name the observed stemmed tokenizer: %r" % (record,))
+
+    # --- 4. no false alarm -----------------------------------------------------
+    if check(LIVE_PLAIN, ("text", "context"), "", table="t", index_name="i") is not None:
+        fail("drift reported for an index that already matches the configured tokenizer")
+    if check(LIVE_ICU, ("text", "context"), "icu", table="t", index_name="i") is not None:
+        fail("drift reported for an icu index against an icu-configured knob")
+
+rebuild_cols = getattr(pgs, "pg_search_rebuild_bm25_columns", None) if pgs else None
+if rebuild_cols is None:
+    fail("no rebuild-aware column builder: every rebuild takes its columns from config alone")
+else:
+    # --- 5. config still wins when it CAN express the difference ---------------
+    cols = rebuild_cols(LIVE_ICU, "id", ("text", "context"), "", table="t", index_name="i")
+    print("EXPRESSIBLE_DRIFT_COLS", cols)
+    if cols != "id, text, context":
+        fail("an expressible tokenizer drift was not resolved in favour of config: %r" % (cols,))
+
+    # A fresh build (no pre-existing index) must be byte-identical to upstream.
+    fresh = rebuild_cols(None, "id", ("text", "context"), "icu", table="t", index_name="i")
+    upstream_fresh = pgs.pg_search_bm25_columns("id", ("text", "context"), "icu")
+    if fresh != upstream_fresh:
+        fail("fresh build diverged from upstream: %r != %r" % (fresh, upstream_fresh))
+
+# --- 6. it never raises --------------------------------------------------------
+HOSTILE = [
+    None,
+    "",
+    "not an index definition at all",
+    "CREATE INDEX i ON t USING gin (search_vector)",
+    "CREATE INDEX i ON t USING bm25 (id, (text::pdb.simple('unterminated",
+    "CREATE INDEX i ON t USING bm25 (",
+    "CREATE INDEX i ON t USING bm25 (id, (text::pdb.simple('a'); DROP TABLE x --')) WITH (key_field='id')",
+]
+if check is not None and rebuild_cols is not None:
+    for hostile in HOSTILE:
+        try:
+            check(hostile, ("text", "context"), "", table="t", index_name="i")
+        except Exception as exc:
+            fail("drift detector RAISED on %r: %r — this runs on the every-boot path" % (hostile, exc))
+        try:
+            out = rebuild_cols(hostile, "id", ("text", "context"), "", table="t", index_name="i")
+        except Exception as exc:
+            fail("rebuild builder RAISED on %r: %r — this runs on the every-boot path" % (hostile, exc))
+        else:
+            if ";" in out or "--" in out:
+                fail("rebuild builder re-emitted an unsafe cast from %r: %r" % (hostile, out))
+
+print("FAILURES", json.dumps(failures))
+print("PROBE_EXECUTED")
+sys.exit(1 if failures else 0)
+`;
+
+function hasDocker(): boolean {
+  try {
+    execSync("docker version --format '{{.Server.Version}}'", {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasImage(ref: string): boolean {
+  try {
+    execSync(`docker image inspect ${ref}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * CI marker. When set, this suite MUST really execute — an absent docker or
+ * an absent upstream image becomes a hard failure instead of a green skip.
+ * `.github/workflows/docker-e2e.yml` sets it after pulling the pinned digest.
+ */
+const REQUIRED = process.env.SWITCHROOM_REQUIRE_HINDSIGHT_PROBE === "1";
+
+const dockerOk = hasDocker();
+const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
+
+type ProbeResult = { status: number; stdout: string };
+
+/** Run the probe in a throwaway container, optionally patching first. */
+function runProbe(patched: boolean): ProbeResult {
+  const name = `sr-hs-pgstok-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
+    0,
+    8,
+  )}`;
+  try {
+    execFileSync(
+      "docker",
+      [
+        "run",
+        "-d",
+        "--name",
+        name,
+        "--label",
+        `switchroom.test=${TEST_PHASE}`,
+        "--label",
+        `switchroom.test.run=${RUN_ID}`,
+        "--user",
+        "root",
+        "--network",
+        "none",
+        UPSTREAM_IMAGE,
+        "sleep",
+        "300",
+      ],
+      { stdio: ["ignore", "ignore", "pipe"] },
+    );
+
+    if (patched) {
+      for (const block of patchBlocks()) {
+        // The block is self-verifying: it asserts its upstream anchors exist
+        // exactly once each and re-asserts the result, so a non-zero exit here
+        // means upstream drifted and the patch must be re-authored.
+        execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
+          input: block,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      }
+    }
+
+    const res = execFileSync(
+      "docker",
+      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
+      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
+    );
+    return { status: 0, stdout: res };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: Buffer | string };
+    return {
+      status: err.status ?? -1,
+      stdout: (err.stdout ?? "").toString(),
+    };
+  } finally {
+    try {
+      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+describe("Dockerfile.hindsight pg_search tokenizer-drift probe is real, not a silent skip", () => {
+  it("pins the upstream image by digest so the probe tests the exact shipping bytes", () => {
+    expect(UPSTREAM_IMAGE).toMatch(/@sha256:[0-9a-f]{64}$/);
+  });
+
+  it("extracts exactly the one patch block it claims to prove", () => {
+    expect(patchBlocks()).toHaveLength(1);
+  });
+
+  it("hard-fails rather than skipping when CI demands a real run", () => {
+    if (!REQUIRED) {
+      // Local/dev path: skipping is legitimate (never pull a 6.4GB image onto
+      // a dev box), but it must be visible rather than silent.
+      expect(
+        REQUIRED,
+        "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE is unset — the behavioural probe " +
+          "is advisory here. CI's hindsight-probe job sets it after pulling " +
+          `${UPSTREAM_IMAGE}.`,
+      ).toBe(false);
+      return;
+    }
+    expect(
+      dockerOk,
+      "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but the docker daemon is unreachable",
+    ).toBe(true);
+    expect(
+      imageOk,
+      `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but ${UPSTREAM_IMAGE} is not present ` +
+        "locally — the workflow must pull the pinned digest before running this suite",
+    ).toBe(true);
+  });
+});
+
+describe.skipIf(!dockerOk || !imageOk)(
+  "Dockerfile.hindsight pg_search tokenizer-drift patch changes real behaviour",
+  () => {
+    afterAll(() => {
+      // Label-scoped teardown belt (never an unlabelled bulk removal).
+      try {
+        const ids = execSync(
+          `docker ps -aq --filter label=switchroom.test.run=${RUN_ID}`,
+          { encoding: "utf8" },
+        )
+          .split("\n")
+          .filter(Boolean);
+        if (ids.length) {
+          execFileSync("docker", ["rm", "-f", ...ids], { stdio: "ignore" });
+        }
+      } catch {
+        /* nothing to clean */
+      }
+    });
+
+    it("unpatched upstream is RED — the rebuild silently drops stemming", () => {
+      const { status, stdout } = runProbe(false);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED",
+      );
+      expect(status, `probe unexpectedly passed:\n${stdout}`).not.toBe(0);
+
+      // The defect, driven: the shipping migration rebuilds a live STEMMED
+      // index as a plain unstemmed one, on a populated table, with no error.
+      expect(stdout).toMatch(
+        /REBUILD_DDL .*USING bm25 \(id, text, context, text_signals\)/,
+      );
+      expect(stdout).toContain("REBUILD DROPPED THE STEMMER");
+      expect(stdout).toContain("NO TOKENIZER DRIFT DETECTOR");
+    }, 240_000);
+
+    it("upstream + the baked patch block is GREEN on all six properties", () => {
+      const { status, stdout } = runProbe(true);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED",
+      );
+      expect(status, `probe failed:\n${stdout}`).toBe(0);
+      expect(stdout).toContain("FAILURES []");
+
+      // 1 + 2. the rebuild carries the hand-built semantics forward AND still
+      // does what the migration exists to do.
+      expect(stdout).toContain("stemmer=english");
+      expect(stdout).toContain("stopwords_language=english");
+      expect(stdout).toMatch(/REBUILD_DDL .*text_signals::pdb\.simple/);
+      // 3. the drift is named, not merely repaired.
+      expect(stdout).toContain('"config_expressible": false');
+      // 5. an expressible drift still resolves in favour of config.
+      expect(stdout).toContain("EXPRESSIBLE_DRIFT_COLS id, text, context");
+    }, 240_000);
+  },
+);


### PR DESCRIPTION
Implements the **C1 guard** from epic #4474 (`EPIC: Consistent recall latency at any bank size and under contention (Hindsight) — pg_search re-scoped`). Single concern; **do not merge without review**.

## The hazard, root-caused in real source at tag `v0.8.6`

The stemmed/stopworded ParadeDB variant needed for recall quality (`stemmer=english` + `stopwords_language=english`) is **not expressible** through `HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER`. `_pg_search.py:32-85` takes a bare tokenizer *name* from a fixed set and emits an unstemmed `(field::pdb.<tok>)` cast — no stemmer or stopword parameter exists. So it can only ever be hand-built DDL.

Nothing defends it. Every "does the live index match the config" decision keys on the `key_field` reloption alone (`migrations.py:887`) and never inspects the tokenizer cast.

**The silent-rebuild path is real, and worse than the epic recorded.** It is not only the empty-table rebuild in `migrations.py:1042-1070`: `alembic/versions/a2b3c4d5e6f7_add_text_signals_column.py:75-83` does an unconditional `DROP INDEX` + `CREATE INDEX` against a **populated** `memory_units`, taking its column list straight from the config knob. A hand-built stemmed index is destroyed by an ordinary engine upgrade — no error, no log line.

## The guard

Baked as a build-time patch in `docker/Dockerfile.hindsight` (hindsight fixes are switchroom-side only).

- `_pg_search.py`: an indexdef parser, an **expressibility predicate defined as a round-trip through the same `normalize_pg_search_tokenizer` that config uses** (so the predicate can never drift from what config emits), a drift checker, and a rebuild-aware column builder.
- **Boot path** (`migrations.py`): when column type, access method and `key_field` all agree, tokenizer casts are compared too; a mismatch logs at ERROR under the stable marker `pg_search_tokenizer_drift`, plus an in-process `pg_search_tokenizer_drift_state()` accessor.
- **Rebuild paths** (`migrations.py` + the text_signals migration, upgrade and downgrade): read the pre-existing indexdef *before* dropping. A drift the knob **cannot** express is **preserved**; a drift it **can** express is a deliberate config change and config still wins (WARN). Re-emitted casts pass a conservative whitelist first.

Deliberately **not** patched: `5a366d414dce_initial_schema.py` and `n9i0j1k2l3m4_learnings_and_pinned_reflections.py` create their tables in the same migration, so no pre-existing index can be downgraded there.

## Why this cannot crash-loop the fleet

`ensure_text_search_extension` runs on **every boot** and already raises `RuntimeError` on a schema mismatch with data present (`migrations.py:768 → :922 → :940`). A guard that raised there would take the **semantic** arm down alongside the keyword one — a full memory outage, strictly worse than the silent degradation being fixed.

So the guard **never raises** and **never changes `index_matches`**. Two build-time asserts pin it: the guard body contains no `raise` statement, and `migrations.py`'s `raise RuntimeError(` count is unchanged (9). The probe additionally feeds malformed, truncated and injection-shaped index definitions and asserts it returns rather than raising.

## Tests — outcome, not code path

`tests/docker/hindsight-pg-search-tokenizer-drift-patch.test.ts` drives the **real** `_pg_upgrade()` from the shipping text_signals migration against a fake alembic boundary (no database) and reads back the DDL it actually emits.

- **RED on unpatched upstream**, verified: given a live stemmed index it emits `USING bm25 (id, text, context, text_signals)` — unstemmed — and there is no drift detector at all.
- **GREEN patched**, verified: the emitted `CREATE INDEX` still carries `stemmer=english` / `stopwords_language=english`, still adds `text_signals`, still keeps `key_field='id'`; drift is reported with `config_expressible: false`; an expressible drift resolves to config; hostile inputs return instead of raising.

Wired into `docker-e2e.yml`'s `hindsight-probe` job (path filter, run step, label-scoped teardown) so it cannot silently skip in CI. Static shape pinned in `dockerfile-hindsight-bakes.test.ts`.

## C3 — tokenizer syntax, resolved

Verified against current ParadeDB documentation (`docs.paradedb.com`, *Create an Index* → Token Filters, and *Stemmer*): the canonical form is **single-quoted `key=value` arguments** —

    CREATE INDEX search_idx ON mock_items
    USING paradedb (id, (description::pdb.simple('stemmer=english', 'stopwords_language=english')))
    WITH (key_field='id');

i.e. the **quoted** form, not the unquoted one the dry-run used. The guard does not depend on this: the parser round-trips whatever cast text the catalog reports rather than assuming a form, so an unquoted variant is preserved just as faithfully. C3's behavioural assertion (does stemming actually take effect) is still P5's, unchanged.

## Adjacent finding for the epic — not fixed here

The same docs note that in ParadeDB **0.25.0 the access method was renamed to `paradedb`**, with `USING bm25` kept as a backwards-compatible alias. `migrations.py:876` compares `pg_am.amname` against the literal `"bm25"`. If a hand-built index registers under `paradedb`, upstream reads that as a schema mismatch and, with data present, **raises** — the BOOT-CRASH-LOOP risk, not C1. This PR's parser accepts both spellings, but the `amname` comparison is untouched: fixing it means touching the raise path and belongs with P5's crash-loop mitigation.

Refs #4474