### PR TITLE
feat(evals): recall quality regression suite (P6, #4479)

### DIFF
--- a/.github/workflows/ci-evals.yml
+++ b/.github/workflows/ci-evals.yml
@@ -85,6 +85,24 @@ jobs:
         # evals: replace with `--coverage --hard --base-ref origin/main`.
         run: python3 evals/validate_datasets.py --coverage
 
+      # ── Recall-quality suite (#4479) ──────────────────────────────
+      # Offline half only: schema + lints + unit tests. Scoring a real
+      # configuration needs a live Hindsight instance and a populated bank, so
+      # that is an operator-run command, not a CI job. What CI protects here is
+      # the ASSET and the SCORER — a corrupted query set, or a scorer that
+      # silently returns 1.0 for an unjudged case, would make every future run
+      # vacuous. Both are catchable at zero model cost, on fork PRs.
+      - name: Recall query-set lint self-check (each lint must fire)
+        run: python3 evals/recall/validate_queryset.py --selftest
+
+      - name: Validate recall query set
+        run: python3 evals/recall/validate_queryset.py
+
+      - name: Recall-quality scorer unit tests
+        # Includes the non-vacuity proof (#4479 AC1): an ablated run must score
+        # worse and drive the regression gate red, asserted offline.
+        run: python3 -m unittest discover -s evals/recall -p 'test_*.py' -t .
+
   # ─── Trigger routing eval ────────────────────────────────────────
   evals-trigger:
     runs-on: ubuntu-latest

--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -1,0 +1,1 @@
+"""Switchroom eval harnesses (skills + Hindsight recall quality)."""

--- a/evals/recall/README.md
+++ b/evals/recall/README.md
@@ -1,0 +1,287 @@
+# Hindsight recall-quality regression suite
+
+Scores Hindsight **recall quality** and fails when it regresses. Built for
+issue #4479 (phase P6 of epic #4474), which exists because the strongest
+datapoint in the whole pg_search investigation was a quality one that lived
+only in a dry-run note: the candidate backend answered queries the incumbent
+returns **zero rows** for. A note cannot gate a change. This turns it into a
+number.
+
+Two things this suite is not:
+
+- **It is not a latency benchmark.** That is P1 (#4475). Timings appear in the
+  result file under `timings_not_a_measurement` as diagnostics and are never
+  scored, never gated, and must never be quoted as performance figures. The
+  box that runs this also serves the live fleet and nothing here isolates it.
+- **It is not a writer.** The client can issue exactly three requests:
+  `GET /health`, `GET /version`, and `POST .../memories/recall`. Anything else
+  raises `ReadOnlyViolation`. Recall is a read path; keeping it one is what
+  makes running this against production safe.
+
+## Quick start
+
+```bash
+pip install pyyaml
+
+# validate the asset (no network, no database, runs in CI)
+python3 evals/recall/validate_queryset.py
+python3 evals/recall/validate_queryset.py --selftest
+python3 -m unittest discover -s evals/recall -p 'test_*.py' -t .
+
+# score a live configuration
+python3 evals/recall/run_recall_quality.py run \
+    --banks <bank-a>,<bank-b> --backend native \
+    --out evals/recall/results/p6-baseline-native.json
+
+# the AC1 non-vacuity check: a deliberately degraded configuration
+python3 evals/recall/run_recall_quality.py run \
+    --banks <bank-a> --backend native --disable-keyword-arm \
+    --out evals/recall/results/p6-vacuity-check.json
+
+# the gate (exit 0 within budget, exit 1 on regression)
+python3 evals/recall/run_recall_quality.py compare \
+    evals/recall/results/p6-baseline-native.json \
+    evals/recall/results/p6-pgsearch.json \
+    --max-recall10-drop 0.02 --max-zero-result-regressions 0
+```
+
+`--api-url` defaults to `$HINDSIGHT_API_URL`, then `http://127.0.0.1:18888`.
+
+**`run` fails closed.** Any case that errored exits non-zero, because every
+metric here is a ratio over the cases that succeeded and a run where most cases
+timed out would otherwise print a confident number over the handful that
+worked. `--no-fail-on-error` is the explicit escape hatch.
+
+**On a shared box, pass `--limit N` and `--pace-ms`.** The runner is sequential
+by construction and has no concurrency knob, but a full run is
+`cases x banks` recall calls and that is real load on a database other people
+are measuring.
+
+## What it measures
+
+Every recall is issued with `trace: true`, which returns the engine's own
+per-stage view (`hindsight_api/engine/search/trace.py:191`, tag `v0.8.6`). The
+suite reduces that to ranked id lists per stage:
+
+| stage | source |
+|---|---|
+| `arm:semantic` / `arm:bm25` / `arm:graph` | `trace.retrieval_results[]`, pooled across `fact_type` by best rank |
+| `rrf_client` | RRF recomputed here from the raw arms, `k=60`, matching `engine/search/fusion.py:29` |
+| `rrf_engine` | `trace.rrf_merged[]`, as the engine fused it |
+| `rerank` | `trace.reranked[]`, cross-encoder output |
+| `final` | what the caller received |
+
+Per-stage reporting is the point: when the keyword arm collapses, the fused
+list often barely moves, which is exactly how a tokenizer regression hides for
+weeks. A regression that shows up at `arm:bm25` and not at `final` is still a
+regression, and the epic's risk C1 is precisely that shape.
+
+### The headline metric
+
+```
+zero_result_queries_answered / zero_result_queries_total
+```
+
+The subset is every query whose **keyword arm returned zero rows in the
+reference run**. `answered` counts how many of those the **candidate** run's
+keyword arm returns at least one row for.
+
+This metric needs **no relevance judgements at all**, only two runs and a row
+count, which is why it is the number this suite can report honestly at full
+scale while the graded metrics wait on judgement coverage. A query present in
+the reference but absent from the candidate counts as *not answered*, never as
+skipped, so a candidate that errors on the hard queries cannot outscore one
+that answers them.
+
+Alongside it, every run reports the label-free `keyword_arm_zero_result_rate`
+for itself, so a single run is interpretable without a partner file.
+
+**Why native returns zero rows at all**, since this is the phenomenon under
+protection: the native arm builds `to_tsquery('<regconfig>', 'tok1 | tok2 |
+...')` (`engine/sql/postgresql.py:229-234`) and gates matching on
+`search_vector @@ <that query>`. The terms are OR-ed, so on a large bank almost
+any content word matches something. The arm therefore goes to zero essentially
+only when the *query itself* reduces to nothing under the configured
+regconfig, leaving an empty tsquery that matches no row.
+
+That is not a hypothetical. The fleet sets
+`HINDSIGHT_API_TEXT_SEARCH_EXTENSION_NATIVE_LANGUAGE=hindsight_english`, a
+`COPY = pg_catalog.english` whose snowball dictionary carries the extra
+stopword list in `docker/hindsight-extra.stop`
+(`docker/hindsight-entrypoint.sh:593`). That list drops corpus boilerplate —
+`claude`, `code`, `agent`, `assistant`, `user`, `switchroom`, `sidechain` —
+on top of the standard English stopwords, because those lexemes appear in
+nearly every memory and turned the keyword arm into a sequential scan. A query
+composed *only* of those words produces an empty tsquery and returns nothing.
+
+Measured on the live instance, that is exactly what happens: of ten
+`stopword-heavy` cases, the nine built from ordinary English function words
+still returned 172-300 keyword rows, because each retained at least one content
+lexeme. The one built from fleet boilerplate — `sw-005`, "claude code agent
+assistant switchroom sidechain" — returned **zero**. So the family that matters
+for the headline metric is not "queries with lots of stopwords" in the ordinary
+sense; it is queries whose every token is boilerplate under *this* regconfig.
+Grow that population deliberately, and note that a change to
+`hindsight-extra.stop` changes the denominator.
+
+### Graded metrics
+
+`recall@10`, `recall@50`, `nDCG@10`, `MRR`, macro-averaged over judged cases,
+computed **per stage**. Also `judged_coverage@10`, which is the label-rot
+alarm: judgements are pinned to memory-unit ids in a live bank, consolidation
+rewrites those units, and a decayed qrels file otherwise looks exactly like a
+quality regression. `--min-judged-coverage` fails the run instead.
+
+Unjudged cases are excluded from graded metrics and still counted in the
+label-free ones. A query with no positive judgement scores `0.0`, not `1.0` —
+the fail-open shape is how a suite goes quietly vacuous.
+
+## Judgement provenance, and its limits
+
+Stated here rather than left implicit, per #4479 item 6.
+
+Relevance judgements live in `qrels/` as **ids and integer grades only**, never
+text, and every file must carry a `judgement` block naming the method, the
+judge, the date, and the pool. `load_qrels` refuses a file without one.
+
+Supported methods, with what each is worth:
+
+- **`pooled-graded`** — the standard IR compromise. Pool the top-*k* of every
+  arm across every configuration under comparison, judge each (query, memory)
+  pair on a graded scale with a judge that never sees ranks or scores. Not
+  circular in its *labels*, but the *pool* is system-derived, so `recall@k` is
+  really recall-within-pool and an unjudged relevant document is invisible.
+  Both metrics are therefore conservative, never optimistic.
+- **`known-item`** — derive the query from one specific memory and label that
+  memory as the single relevant answer. No judge, exact labels, fully
+  deterministic. Its bias is lexical: a query derived from a document shares
+  vocabulary with it and flatters the keyword arm. Use it for *relative*
+  comparisons between configurations, not as an absolute quality figure. Query
+  text derived this way must stay out of the committed query set, because it
+  is derived from private memory.
+- **`operator`** — a human judged it. Cheapest to trust, most expensive to
+  produce, does not scale past a few dozen.
+
+**A suite whose labels came from the system it grades would be circular.** None
+of the three above take labels from the ranker under test. What they cannot
+escape is that the *candidate pool* comes from retrieval systems, which is the
+standard, documented limitation of pooled evaluation and the reason
+`judged_coverage@10` is reported on every stage.
+
+## The query set is the asset
+
+`queryset/v1.yaml`, 141 cases across seven families, versioned and hashed into
+every result file (`config.queryset_sha256`), so a score can never be compared
+against a set it was not computed on.
+
+**No real user, bank, or traffic text is in it, and none may be added.** This
+repository is public and the banks are a live operator's private memory. Real
+recall traffic shaped the *families* and the *length distribution* only; the
+`provenance.shaped_by` block records the aggregate statistics that shaping came
+from, and `derive_shape.py` reproduces them so the claim is checkable rather
+than asserted: 23,538 recalls across 12 agents, median query 691 characters,
+43 % hitting the result cap. The source telemetry records `query_chars` as an
+integer and never the query itself, so that path cannot leak text even by
+accident.
+
+The single most consequential of those numbers: real auto-recall queries are
+not short keyword queries, they are multi-sentence transcript slices clipped at
+an 800-character cap. `context-blob` is the largest family because of it.
+
+### Adding a case
+
+1. Pick the family it belongs to, or add one to `families` with a one-line
+   description of what it probes. An undeclared family is a hard lint error.
+2. Give it a stable id (`<family-prefix>-NNN`). Ids are keys in every qrels
+   file; renaming one silently orphans its judgements.
+3. Write the `text` yourself. Never paste from a transcript, a log, or a bank.
+4. `morphological` cases must carry a `probe:` note saying which surface form
+   maps to which stem. Lint rejects one without it.
+5. Run `python3 evals/recall/validate_queryset.py`.
+6. **Do not delete a case because it currently scores zero.** The
+   `zero-result-probe` family exists to score zero somewhere; removing the
+   cases that do is how the headline metric's denominator quietly disappears.
+
+Bumping `queryset_version` invalidates comparison against older result files by
+design: `compare` shows both versions in its report so a mismatch is visible
+rather than silently averaged.
+
+## Non-vacuity: how the suite is made to fail
+
+#4479 AC1 requires the suite to go **red** on a deliberately degraded
+configuration, and the abort condition says a suite that cannot is worse than
+none at all.
+
+The degradation is `--disable-keyword-arm` (alias for `--ablate-arm bm25`).
+Rather than flipping a live configuration, which would mutate production to
+prove a point, the ablation removes the arm from the **client-side fusion**:
+the arm's ranked list is emptied and `rrf_client` is recomputed without its
+contributions. Because the *same* client-side fusion scores the ablated and the
+non-ablated run, the delta between them is attributable to the ablation and not
+to any mismatch between this implementation and the engine's.
+
+Stages the engine computed downstream of its own fusion (`rrf_engine`,
+`rerank`, `final`) are **dropped, not recomputed**, in an ablated run: there is
+no honest way to simulate a cross-encoder over a candidate set it never saw.
+`compare` therefore falls back to `rrf_client` when the candidate has no
+`final` stage, so an ablated run is graded on a stage both runs really have
+instead of passing on a technicality.
+
+`test_recall_quality.py::Ablation::test_ablated_run_scores_worse_and_the_gate_goes_red`
+pins this offline, with no live instance involved.
+
+## Determinism
+
+#4479 AC3 asks for identical scores across runs, or a documented bound under
+1 %. `--runs N` runs the suite N times and emits a `determinism` block:
+per-(stage, metric) min/max/spread, the worst spread and which metric carried
+it, plus `keyword_zero_set_jaccard` and `keyword_zero_set_unstable_ids` for the
+label-free side.
+
+Spread is reported **absolute**, not relative: these metrics are bounded in
+[0, 1], and a relative spread explodes meaninglessly near zero. So
+`worst_spread` is directly comparable to the 0.01 budget.
+
+Three things drive real nondeterminism, in descending order:
+
+1. **The bank keeps changing.** Live agents retain continuously, so the corpus
+   under a second run is not the corpus under the first. This dominates
+   everything else and is not fixable from inside the suite. For a tight
+   determinism measurement, run against a quiet bank or accept the number.
+2. **The cross-encoder reranker**, which affects `rerank` and `final` only.
+   `arm:*` and `rrf_client` are downstream of neither it nor any model.
+3. **ANN traversal.** Deterministic for a fixed HNSW graph, but the graph
+   changes as the bank does, folding back into (1).
+
+If the measured spread exceeds the budget, say so and do not wire the suite as
+a hard gate at P3's 2 % budget. That is the issue's own abort/re-scope
+condition, not a judgement call to make quietly.
+
+## Result files
+
+`--out` writes a self-describing JSON file: query set id, version and sha256,
+banks, declared backend, budget, ablated arms, qrels file and case count, plus
+the engine's `/version` and `/health` as it reported them. A result without its
+configuration is not a result, so a file pasted into an issue comment stands on
+its own.
+
+Bank ids are **pseudonymised by default** (`bank-<sha256[:8]>`); they are the
+operator's agent names and a committed baseline should not enumerate a private
+fleet. `--no-redact-banks` prints them for local debugging. Memory text never
+enters a result file at any setting: observations carry ids only.
+
+## Layout
+
+```
+evals/recall/
+  metrics.py               pure scoring; no I/O, no clock, no randomness
+  client.py                read-only recall client (allowlisted paths)
+  queryset.py              query-set + qrels loading, strict
+  run_recall_quality.py    the CLI: run / compare
+  validate_queryset.py     zero-cost schema + lint, with --selftest
+  test_recall_quality.py   unit tests, incl. the gate-goes-red proof
+  derive_shape.py          aggregate-only traffic shape stats (never text)
+  queryset/v1.yaml         the versioned asset
+  qrels/                   relevance judgements, ids and grades only
+  results/                 committed baselines
+```

--- a/evals/recall/README.md
+++ b/evals/recall/README.md
@@ -230,6 +230,36 @@ instead of passing on a technicality.
 `test_recall_quality.py::Ablation::test_ablated_run_scores_worse_and_the_gate_goes_red`
 pins this offline, with no live instance involved.
 
+### Going red is not enough — the gate has to discriminate
+
+A gate that is red on *everything* proves nothing about a degraded config. That
+is not hypothetical here: until judgements are committed there is no
+`recall@10` on either side, so the recall budget cannot be evaluated at all —
+and a compare of a result file **against itself** was red for exactly that
+reason. Red-on-degraded is only evidence if green-on-identical is reachable.
+
+So failures are split by kind, and they do not share an exit code:
+
+| verdict | meaning | exit |
+|---|---|---|
+| `pass` | every evaluable budget was met | 0 |
+| `regression` | a budget was evaluated and **measurably** breached | 1 |
+| `ungraded` | no regression found, but a budget could not be evaluated | 3 |
+
+`ungraded` still blocks — an uncertifiable run is not a passing run — but it is
+a different claim from "the candidate is worse", and CI can tell them apart.
+
+Live, on the committed artefacts:
+
+- baseline vs `--disable-keyword-arm` → `regression`, exit **1**,
+  23 keyword-zero regressions
+- ablated run vs an identical copy of itself → `ungraded`, exit **3**,
+  0 regressions
+
+The discriminating signal is the keyword-zero regression count, which is
+**label-free** — it needs two runs and a row count, no judgements. That is what
+makes AC1 demonstrable today rather than after a judgement campaign.
+
 ## Determinism
 
 #4479 AC3 asks for identical scores across runs, or a documented bound under

--- a/evals/recall/README.md
+++ b/evals/recall/README.md
@@ -315,6 +315,25 @@ operator's agent names and a committed baseline should not enumerate a private
 fleet. `--no-redact-banks` prints them for local debugging. Memory text never
 enters a result file at any setting: observations carry ids only.
 
+### What is committed under `results/`
+
+Four files, all produced by the commands in this README against hindsight
+`0.8.6`, one bank, a 28-case `--seed 4479` sample, sequential at concurrency 1:
+
+| file | what it is | exit |
+|---|---|---|
+| `p6-baseline-native-v1.json` | the quality baseline; `--runs 3`, carries the determinism block | 0 |
+| `p6-vacuity-check-keyword-ablated.json` | the same sample with `--disable-keyword-arm` | 0 |
+| `p6-vacuity-check-compare.json` | baseline vs ablated — the AC1 red proof | 1 |
+| `p6-vacuity-check-control-self-compare.json` | the ablated file vs **itself** — the control that shows the red above is specific | 3 |
+
+The control is the point of the pair: without it, exit 1 on the ablated compare
+is not evidence, because a gate that is red on everything is red on nothing.
+
+**These are quality numbers. Nothing in them is a latency measurement.** The
+box was running an unrelated latency benchmark throughout, by design, so the
+`timings_not_a_measurement` block is diagnostic only and is never scored.
+
 ## Layout
 
 ```

--- a/evals/recall/README.md
+++ b/evals/recall/README.md
@@ -242,6 +242,21 @@ Spread is reported **absolute**, not relative: these metrics are bounded in
 [0, 1], and a relative spread explodes meaninglessly near zero. So
 `worst_spread` is directly comparable to the 0.01 budget.
 
+**A determinism report that compared nothing does not pass.** Graded metrics
+only exist once a qrels file is loaded, so on an unjudged run the graded series
+are all empty. A naive implementation would then take the max of an empty set,
+report `worst_spread: 0.0`, and read as *perfectly deterministic* while
+actually meaning *measured nothing* — the same fail-open shape this suite
+exists to catch in the scorer. The block therefore carries `measured` and
+`metrics_compared`, and `within_budget` requires `measured` to be true. When
+nothing was comparable, `worst_spread` is `null` and the summary prints
+`NOT MEASURED` rather than a number.
+
+That is also why variance covers **label-free series** — the keyword arm's
+zero-result rate, and each case's per-arm row counts normalised by that case's
+max across runs. Those exist without any judgements, so an unjudged run still
+yields a real, falsifiable determinism number instead of an empty one.
+
 Three things drive real nondeterminism, in descending order:
 
 1. **The bank keeps changing.** Live agents retain continuously, so the corpus

--- a/evals/recall/__init__.py
+++ b/evals/recall/__init__.py
@@ -1,0 +1,1 @@
+"""Hindsight recall-quality regression suite (issue #4479)."""

--- a/evals/recall/client.py
+++ b/evals/recall/client.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Read-only Hindsight client for the recall-quality eval (issue #4479).
+
+Two properties matter more than features here.
+
+**It cannot write.** The only request this module can issue is
+``POST /v1/default/banks/{bank}/memories/recall`` (plus the two read probes
+``GET /health`` and ``GET /version``). Recall is a read path and #4479 says to
+keep it one; the epic's own abort condition (#4475, "Hard abort if any harness
+run is found to have mutated production data") is what a stray retain would
+trip. ``_request`` refuses any path not on ``_ALLOWED``, so a future edit that
+adds a write has to delete a guard rather than merely add a call.
+
+**It runs sequentially.** There is no concurrency knob, on purpose. This suite
+grades *quality*, and the box it runs on also serves the live fleet — issuing a
+parallel fan-out would both distort whatever else is measuring latency and buy
+nothing, since no metric here is timing-derived. ``--pace-ms`` adds a gap
+between calls for the same reason.
+
+Timings ARE captured (``elapsed_ms`` per observation) but are recorded as
+diagnostics only and are never scored or gated. Anything in this suite's output
+under ``timings`` is not a latency measurement.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any
+
+_ALLOWED = ("/health", "/version", "/memories/recall")
+
+
+class ReadOnlyViolation(RuntimeError):
+    """Raised when a caller attempts a request outside the read-only allowlist."""
+
+
+@dataclass
+class RecallObservation:
+    """One recall call, reduced to ranked id lists plus non-scored diagnostics."""
+
+    query_id: str
+    bank: str
+    ok: bool
+    http_status: int | None = None
+    error: str | None = None
+    elapsed_ms: float | None = None
+    # stage name -> ranked memory ids, best first
+    stages: dict[str, list[str]] = field(default_factory=dict)
+    # arm name -> ranked memory ids, pooled across fact_type
+    arms: dict[str, list[str]] = field(default_factory=dict)
+    result_count: int = 0
+
+
+class HindsightRecallClient:
+    def __init__(
+        self,
+        base_url: str,
+        token: str | None = None,
+        timeout_s: float = 60.0,
+        pace_ms: int = 0,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.timeout_s = timeout_s
+        self.pace_ms = pace_ms
+        self._last_call = 0.0
+
+    # ── transport ────────────────────────────────────────────────
+
+    def _request(self, method: str, path: str, body: dict[str, Any] | None = None) -> Any:
+        if not any(path.endswith(suffix) for suffix in _ALLOWED):
+            raise ReadOnlyViolation(
+                f"{method} {path} is not on the read-only allowlist {_ALLOWED}. "
+                "This eval must never write to a live bank."
+            )
+        if method != "GET" and not path.endswith("/memories/recall"):
+            raise ReadOnlyViolation(f"{method} {path} is not a read operation")
+
+        if self.pace_ms:
+            wait = (self._last_call + self.pace_ms / 1000.0) - time.monotonic()
+            if wait > 0:
+                time.sleep(wait)
+
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(self.base_url + path, data=data, method=method)
+        req.add_header("content-type", "application/json")
+        if self.token:
+            req.add_header("authorization", f"Bearer {self.token}")
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout_s) as resp:
+                return json.loads(resp.read().decode())
+        finally:
+            self._last_call = time.monotonic()
+
+    # ── probes ───────────────────────────────────────────────────
+
+    def version(self) -> dict[str, Any]:
+        return self._request("GET", "/version")
+
+    def health(self) -> dict[str, Any]:
+        return self._request("GET", "/health")
+
+    # ── the one call this suite makes ────────────────────────────
+
+    def recall(
+        self,
+        bank: str,
+        query_id: str,
+        query: str,
+        *,
+        budget: str = "low",
+        max_tokens: int = 4096,
+        types: list[str] | None = None,
+    ) -> RecallObservation:
+        payload: dict[str, Any] = {
+            "query": query,
+            "budget": budget,
+            "max_tokens": max_tokens,
+            "trace": True,
+        }
+        if types:
+            payload["types"] = types
+        started = time.monotonic()
+        try:
+            raw = self._request("POST", f"/v1/default/banks/{bank}/memories/recall", payload)
+        except urllib.error.HTTPError as exc:
+            return RecallObservation(
+                query_id=query_id,
+                bank=bank,
+                ok=False,
+                http_status=exc.code,
+                error=f"HTTP {exc.code}",
+                elapsed_ms=round((time.monotonic() - started) * 1000, 1),
+            )
+        except Exception as exc:  # noqa: BLE001 - any transport failure is a failed case
+            return RecallObservation(
+                query_id=query_id,
+                bank=bank,
+                ok=False,
+                error=f"{type(exc).__name__}: {exc}",
+                elapsed_ms=round((time.monotonic() - started) * 1000, 1),
+            )
+        elapsed = round((time.monotonic() - started) * 1000, 1)
+        obs = parse_observation(query_id, bank, raw)
+        obs.elapsed_ms = elapsed
+        return obs
+
+
+def parse_observation(query_id: str, bank: str, raw: dict[str, Any]) -> RecallObservation:
+    """Reduce a recall response to ranked id lists.
+
+    Only ids are kept. Memory text never enters an observation, so it can never
+    reach a result file: this repo is public and the banks are a live operator's
+    private memory. The ids are opaque UUIDs and carry no content.
+
+    Trace shape is ``hindsight_api/engine/search/trace.py`` at tag v0.8.6:
+    ``retrieval_results[].method_name`` in {semantic, bm25, graph, temporal},
+    one entry per (method, fact_type); ``rrf_merged[]``; ``reranked[]``.
+    """
+    from . import metrics
+
+    results = raw.get("results") or []
+    obs = RecallObservation(
+        query_id=query_id,
+        bank=bank,
+        ok=True,
+        http_status=200,
+        result_count=len(results),
+    )
+
+    trace = raw.get("trace") or {}
+    per_arm: dict[str, list[list[str]]] = {}
+    for entry in trace.get("retrieval_results") or []:
+        arm = entry.get("method_name")
+        if not arm:
+            continue
+        ranked = [r["node_id"] for r in entry.get("results") or [] if r.get("node_id")]
+        per_arm.setdefault(arm, []).append(ranked)
+
+    for arm, lists in per_arm.items():
+        obs.arms[arm] = metrics.pool_by_best_rank(lists)
+
+    for arm in ("semantic", "bm25", "graph"):
+        obs.stages[f"arm:{arm}"] = obs.arms.get(arm, [])
+
+    obs.stages["rrf_client"] = metrics.rrf_fuse(obs.arms)
+    obs.stages["rrf_engine"] = [
+        r["node_id"] for r in trace.get("rrf_merged") or [] if r.get("node_id")
+    ]
+    obs.stages["rerank"] = [r["node_id"] for r in trace.get("reranked") or [] if r.get("node_id")]
+    obs.stages["final"] = [r["id"] for r in results if r.get("id")]
+    return obs

--- a/evals/recall/derive_shape.py
+++ b/evals/recall/derive_shape.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Derive the AGGREGATE shape of real recall traffic (#4479).
+
+The query set is authored, not sampled, because this repository is public and
+the banks are a live operator's private memory. But an authored set that does
+not resemble real traffic tests the wrong thing, so the families and the length
+distribution in `queryset/v1.yaml` are shaped by the statistics this script
+produces, and its `provenance.shaped_by` block records them.
+
+This script is what makes that provenance claim checkable rather than asserted.
+
+**It cannot emit query text, because the source does not contain any.** The
+hindsight-memory-inline plugin's `recall_log.jsonl` records `query_chars` (an
+integer length) and never the query itself; the only free-form field it carries
+is a bank id, which this script hashes. The output is counts, percentiles and
+rates. Run it, paste the numbers into `provenance.shaped_by`, and commit the
+numbers — never the log.
+
+Usage::
+
+    python3 evals/recall/derive_shape.py \\
+        --glob '~/.switchroom/agents/*/.claude/plugins/data/hindsight-memory-inline/state/recall_log.jsonl'
+
+Default glob points at a local fleet install. On a machine with no such logs the
+script exits 0 with `rows_observed: 0` rather than failing: shaping input is
+nice to have, and CI must never depend on a file that cannot be committed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob as globmod
+import hashlib
+import json
+import statistics
+import sys
+from pathlib import Path
+
+DEFAULT_GLOB = (
+    "~/.switchroom/agents/*/.claude/plugins/data/"
+    "hindsight-memory-inline/state/recall_log.jsonl"
+)
+
+# Fields worth reading. Anything not listed is ignored rather than aggregated,
+# so a future field carrying text cannot silently start flowing into output.
+NUMERIC_FIELDS = ("query_chars", "result_count", "pre_cap_count", "demoted_count")
+
+
+def percentile(values: list[float], q: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    idx = min(len(ordered) - 1, max(0, int(round(q * (len(ordered) - 1)))))
+    return float(ordered[idx])
+
+
+def derive(paths: list[Path]) -> dict:
+    rows = 0
+    malformed = 0
+    chars: list[float] = []
+    results: list[float] = []
+    zero_result = 0
+    capped = 0
+    cache_hits = 0
+    banks: set[str] = set()
+
+    for path in paths:
+        try:
+            text = path.read_text(errors="replace")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                malformed += 1
+                continue
+            if not isinstance(row, dict):
+                malformed += 1
+                continue
+            rows += 1
+            if isinstance(row.get("query_chars"), (int, float)):
+                chars.append(float(row["query_chars"]))
+            count = row.get("result_count")
+            if isinstance(count, (int, float)):
+                results.append(float(count))
+                if count == 0:
+                    zero_result += 1
+            if row.get("capped"):
+                capped += 1
+            if row.get("cache_hit"):
+                cache_hits += 1
+            bank = row.get("bank_id")
+            if isinstance(bank, str) and bank:
+                # Hashed: bank ids are the operator's agent names and this
+                # output is meant to be pasteable into a public repo.
+                banks.add(hashlib.sha256(bank.encode()).hexdigest()[:8])
+
+    out: dict = {
+        "rows_observed": rows,
+        "malformed_lines": malformed,
+        "distinct_banks": len(banks),
+        "files_read": len(paths),
+    }
+    if rows:
+        out.update(
+            {
+                "query_chars_p50": round(percentile(chars, 0.50)),
+                "query_chars_p90": round(percentile(chars, 0.90)),
+                "query_chars_max": round(max(chars)) if chars else 0,
+                "query_chars_mean": round(statistics.fmean(chars), 1) if chars else 0.0,
+                "result_count_p50": round(percentile(results, 0.50)),
+                "final_zero_result_rate": round(zero_result / rows, 4),
+                "capped_rate": round(capped / rows, 4),
+                "cache_hit_rate": round(cache_hits / rows, 4),
+            }
+        )
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="aggregate-only shape statistics for real recall traffic"
+    )
+    parser.add_argument("--glob", default=DEFAULT_GLOB, help="recall_log.jsonl glob")
+    args = parser.parse_args(argv)
+
+    pattern = str(Path(args.glob).expanduser())
+    paths = [Path(p) for p in sorted(globmod.glob(pattern))]
+    stats = derive(paths)
+
+    if not stats["rows_observed"]:
+        print(
+            f"no recall_log rows matched {pattern!r}; nothing to derive. "
+            "This is not an error: the logs are local-only and never committed.",
+            file=sys.stderr,
+        )
+    print(json.dumps(stats, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/recall/metrics.py
+++ b/evals/recall/metrics.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Pure scoring functions for the Hindsight recall-quality eval (issue #4479).
+
+Everything in this module is a **pure function over ranked id lists**. No HTTP,
+no database, no clock, no randomness. That is deliberate: the scoring half of
+the suite is the half CI runs, and it has to be reproducible bit-for-bit on a
+machine that cannot reach a Hindsight instance.
+
+## Stage vocabulary
+
+A single recall is observed as several ranked lists, taken from the engine's
+own ``SearchTrace`` (``hindsight_api/engine/search/trace.py:191`` at tag
+``v0.8.6``):
+
+``arm:semantic`` / ``arm:bm25`` / ``arm:graph``
+    Raw per-arm rankings, pooled across ``fact_type`` (the engine emits one
+    ``RetrievalMethodResults`` per (method, fact_type) pair — see
+    ``retrieval.py:214`` for the semantic UNION ALL arms and ``:233`` for the
+    BM25 ones). Pooling is by best rank across fact types.
+``rrf_engine``
+    The engine's own ``rrf_merged`` list. Observational only — it reflects
+    whatever fusion, capping and budget the deployed engine applies.
+``rrf_client``
+    RRF recomputed **here** from the raw arm lists, using the same formula and
+    the same ``k`` as ``engine/search/fusion.py:29``
+    (``score(d) = sum 1/(k + rank)``, ``k=60``).
+``rerank``
+    The engine's ``reranked`` list (cross-encoder output).
+``final``
+    What the caller actually received.
+
+``rrf_client`` exists for one reason: **arm ablation**. To prove the suite is
+non-vacuous (#4479 AC1) we need a configuration that is genuinely worse, without
+mutating a live instance. Dropping an arm from the client-side fusion does that
+exactly — and because the *same* client-side fusion scores both the ablated and
+the non-ablated run, the delta between them is attributable to the ablation and
+not to any mismatch between this implementation and the engine's. Do not read
+``rrf_client`` as a reimplementation of the engine; read it as a controlled
+comparator.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping, Sequence
+
+# Matches `reciprocal_rank_fusion(result_lists, k=60)` —
+# hindsight-api-slim/hindsight_api/engine/search/fusion.py:29 (tag v0.8.6).
+RRF_K = 60
+
+# Arm order in the engine's fusion call is ["semantic", "bm25", "graph",
+# "temporal"] (fusion.py:56). RRF is order-independent for scoring, but the
+# order is pinned here so ablation flags and reports name the same things the
+# engine does.
+ARMS = ("semantic", "bm25", "graph", "temporal")
+
+# The stages every run reports. Ordered coarse-to-fine so a report reads as a
+# pipeline walk.
+STAGES = (
+    "arm:semantic",
+    "arm:bm25",
+    "arm:graph",
+    "rrf_client",
+    "rrf_engine",
+    "rerank",
+    "final",
+)
+
+
+# ─────────────────────────── IR metrics ───────────────────────────
+#
+# `relevant` is a mapping id -> integer grade (0 = not relevant). Binary
+# judgements are just grade 1. A grade of 0 is treated as judged-and-irrelevant,
+# which is NOT the same as unjudged — see `judged_coverage`.
+
+
+def recall_at_k(ranked: Sequence[str], relevant: Mapping[str, int], k: int) -> float:
+    """Fraction of graded-positive ids that appear in the top ``k``.
+
+    Returns 0.0 when there is nothing to find, not 1.0. A query with no positive
+    judgement contributes no information about recall, and the caller is
+    expected to exclude it (``score_case`` does); returning 1.0 here would let an
+    unjudged query silently inflate the mean.
+    """
+    positives = {doc for doc, grade in relevant.items() if grade > 0}
+    if not positives:
+        return 0.0
+    hits = sum(1 for doc in ranked[:k] if doc in positives)
+    return hits / len(positives)
+
+
+def dcg(gains: Iterable[float]) -> float:
+    return sum(g / math.log2(i + 2) for i, g in enumerate(gains))
+
+
+def ndcg_at_k(ranked: Sequence[str], relevant: Mapping[str, int], k: int) -> float:
+    """Normalised DCG with the standard ``2**grade - 1`` gain.
+
+    The ideal ranking is computed over the *judged* set only, so nDCG is
+    conservative under pooled judgements: an unjudged-but-relevant document
+    scores 0 and cannot be compensated for.
+    """
+    positives = {doc: g for doc, g in relevant.items() if g > 0}
+    if not positives:
+        return 0.0
+    actual = dcg(2 ** positives.get(doc, 0) - 1 for doc in ranked[:k])
+    ideal = dcg(2**g - 1 for g in sorted(positives.values(), reverse=True)[:k])
+    return actual / ideal if ideal > 0 else 0.0
+
+
+def reciprocal_rank(ranked: Sequence[str], relevant: Mapping[str, int]) -> float:
+    """1/rank of the first graded-positive id, or 0.0 if none is retrieved."""
+    positives = {doc for doc, grade in relevant.items() if grade > 0}
+    for i, doc in enumerate(ranked, start=1):
+        if doc in positives:
+            return 1.0 / i
+    return 0.0
+
+
+def judged_coverage(ranked: Sequence[str], relevant: Mapping[str, int], k: int) -> float:
+    """Fraction of the top ``k`` that carries **any** judgement.
+
+    This is the label-rot alarm. Judgements are pinned to memory-unit ids in a
+    live bank; consolidation rewrites and merges units, so a qrels file silently
+    decays into "nothing matches anything" and every metric drifts toward zero
+    while looking like a quality regression. A falling coverage number
+    distinguishes the two, and ``run_recall_quality.py`` fails the run when it
+    drops under ``--min-judged-coverage``.
+    """
+    if not ranked:
+        return 0.0
+    return sum(1 for doc in ranked[:k] if doc in relevant) / len(ranked[:k])
+
+
+# ─────────────────────────── fusion ───────────────────────────
+
+
+def rrf_fuse(arm_rankings: Mapping[str, Sequence[str]], k: int = RRF_K) -> list[str]:
+    """Reciprocal-rank-fuse per-arm ranked id lists into one ranked id list.
+
+    Mirrors ``engine/search/fusion.py:29``: ``score(d) = sum_arms 1/(k + rank)``,
+    ranks 1-based, ties broken by first appearance so the result is a total
+    order and therefore deterministic. Arms absent from ``arm_rankings`` simply
+    contribute nothing — that is how ablation is expressed.
+    """
+    scores: dict[str, float] = {}
+    first_seen: dict[str, int] = {}
+    seq = 0
+    for arm in ARMS:
+        ranked = arm_rankings.get(arm)
+        if not ranked:
+            continue
+        for rank, doc in enumerate(ranked, start=1):
+            if doc not in scores:
+                scores[doc] = 0.0
+                first_seen[doc] = seq
+                seq += 1
+            scores[doc] += 1.0 / (k + rank)
+    return sorted(scores, key=lambda d: (-scores[d], first_seen[d]))
+
+
+def pool_by_best_rank(lists: Iterable[Sequence[str]]) -> list[str]:
+    """Merge several ranked lists of the same arm by each id's best rank.
+
+    The engine emits one arm per (method, fact_type); this collapses them into
+    the single "what did the keyword arm return" list the metrics talk about.
+    Ties (same best rank in different fact types) keep first-list order, so the
+    output is deterministic.
+    """
+    best: dict[str, tuple[int, int]] = {}
+    seq = 0
+    for ranked in lists:
+        for rank, doc in enumerate(ranked, start=1):
+            previous = best.get(doc)
+            if previous is None:
+                best[doc] = (rank, seq)
+                seq += 1
+            elif rank < previous[0]:
+                # Improve the rank, keep the original first-seen tiebreak so the
+                # ordering of equally-ranked ids does not depend on which arm
+                # happened to improve last.
+                best[doc] = (rank, previous[1])
+    return sorted(best, key=lambda d: best[d])
+
+
+# ─────────────────────── the headline metric ───────────────────────
+
+
+def zero_result_metric(
+    reference_keyword_counts: Mapping[str, int],
+    candidate_keyword_counts: Mapping[str, int],
+) -> dict[str, object]:
+    """``zero_result_queries_answered / zero_result_queries_total`` — #4479 AC2.
+
+    The subset is defined by the **reference** run: every query whose keyword
+    arm returned 0 rows there. ``answered`` counts those the **candidate** run's
+    keyword arm returned at least one row for.
+
+    Deliberately label-free. This is the number that put pg_search on the table
+    (epic #4474, "Quality" row) and it needs no relevance judgements at all —
+    only two runs and a row count — which is why it is the metric this suite can
+    report honestly at full scale today, while graded metrics depend on qrels
+    coverage.
+
+    A query present in the reference but missing from the candidate is counted
+    as **not answered**, never skipped: a candidate that errors out on the hard
+    queries must not score better than one that answers them.
+    """
+    subset = sorted(q for q, n in reference_keyword_counts.items() if n == 0)
+    answered = [q for q in subset if candidate_keyword_counts.get(q, 0) > 0]
+    missing = [q for q in subset if q not in candidate_keyword_counts]
+    total = len(subset)
+    return {
+        "zero_result_queries_total": total,
+        "zero_result_queries_answered": len(answered),
+        "zero_result_answer_rate": (len(answered) / total) if total else 0.0,
+        "zero_result_query_ids": subset,
+        "zero_result_answered_ids": sorted(answered),
+        "zero_result_unevaluated_ids": sorted(missing),
+    }
+
+
+# ─────────────────────── aggregation ───────────────────────
+
+
+def score_case(
+    ranked: Sequence[str],
+    relevant: Mapping[str, int],
+    ks: Sequence[int] = (10, 50),
+) -> dict[str, float]:
+    out: dict[str, float] = {}
+    for k in ks:
+        out[f"recall@{k}"] = recall_at_k(ranked, relevant, k)
+    out["ndcg@10"] = ndcg_at_k(ranked, relevant, 10)
+    out["mrr"] = reciprocal_rank(ranked, relevant)
+    out["judged_coverage@10"] = judged_coverage(ranked, relevant, 10)
+    return out
+
+
+def mean(values: Sequence[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def aggregate(per_case: Sequence[Mapping[str, float]]) -> dict[str, float]:
+    """Macro-average each metric across cases, rounded to 6 dp.
+
+    Rounding is not cosmetic: it is what makes two runs over identical inputs
+    compare *equal* rather than differing in float noise from summation order.
+    6 dp is far below the <1 % determinism budget (#4479 AC3) and far above any
+    real difference the suite is meant to detect.
+    """
+    if not per_case:
+        return {}
+    keys = sorted({k for case in per_case for k in case})
+    return {k: round(mean([case[k] for case in per_case if k in case]), 6) for k in keys}
+
+
+# ─────────────────────── regression gate ───────────────────────
+
+
+def compare(
+    baseline: Mapping[str, object],
+    candidate: Mapping[str, object],
+    *,
+    max_recall10_drop: float = 0.02,
+    max_zero_result_regressions: int = 0,
+    gate_stage: str = "final",
+) -> dict[str, object]:
+    """Grade ``candidate`` against ``baseline``; ``ok=False`` means exit non-zero.
+
+    Two independent budgets, both from #4479's verification block:
+
+    * ``max_recall10_drop`` — absolute drop in ``recall@10`` at ``gate_stage``.
+    * ``max_zero_result_regressions`` — count of queries the baseline's keyword
+      arm answered that the candidate's does not. This is the guard that a
+      tokenizer silently reverting to unstemmed (risk C1 in #4474) trips, and
+      it defaults to zero tolerance.
+    """
+    findings: list[str] = []
+
+    b_stage = (baseline.get("stages") or {}).get(gate_stage) or {}
+    c_stage = (candidate.get("stages") or {}).get(gate_stage) or {}
+    b_r10 = b_stage.get("recall@10")
+    c_r10 = c_stage.get("recall@10")
+    drop = None
+    if b_r10 is None or c_r10 is None:
+        findings.append(
+            f"recall@10 missing at stage {gate_stage} "
+            f"(baseline={b_r10!r}, candidate={c_r10!r}) — cannot grade"
+        )
+    else:
+        drop = round(b_r10 - c_r10, 6)
+        if drop > max_recall10_drop:
+            findings.append(
+                f"recall@10 at {gate_stage} dropped {drop:.4f} > budget {max_recall10_drop:.4f} "
+                f"({b_r10:.4f} -> {c_r10:.4f})"
+            )
+
+    b_kw = baseline.get("keyword_arm_row_counts") or {}
+    c_kw = candidate.get("keyword_arm_row_counts") or {}
+    regressed = sorted(q for q, n in b_kw.items() if n > 0 and c_kw.get(q, 0) == 0)
+    if len(regressed) > max_zero_result_regressions:
+        findings.append(
+            f"{len(regressed)} queries went keyword-zero that the baseline answered "
+            f"(budget {max_zero_result_regressions}): {regressed[:10]}"
+            + ("..." if len(regressed) > 10 else "")
+        )
+
+    return {
+        "ok": not findings,
+        "gate_stage": gate_stage,
+        "recall@10_baseline": b_r10,
+        "recall@10_candidate": c_r10,
+        "recall@10_drop": drop,
+        "zero_result_regressions": regressed,
+        "budgets": {
+            "max_recall10_drop": max_recall10_drop,
+            "max_zero_result_regressions": max_zero_result_regressions,
+        },
+        "findings": findings,
+    }
+
+
+def variance_report(runs: Sequence[Mapping[str, object]]) -> dict[str, object]:
+    """Run-to-run spread per (stage, metric), for #4479 AC3.
+
+    Reports the **absolute** spread (max - min) rather than a relative one:
+    these metrics are already bounded in [0, 1], and a relative spread explodes
+    meaninglessly when a metric sits near zero. ``worst_spread`` is therefore
+    directly comparable to the 1 % (0.01) budget the AC states.
+    """
+    if len(runs) < 2:
+        return {"runs": len(runs), "worst_spread": 0.0, "per_metric": {}}
+    per_metric: dict[str, dict[str, float]] = {}
+    stages = sorted({s for run in runs for s in (run.get("stages") or {})})
+    for stage in stages:
+        metrics = sorted({m for run in runs for m in ((run.get("stages") or {}).get(stage) or {})})
+        for metric in metrics:
+            values = [
+                v
+                for run in runs
+                if (v := ((run.get("stages") or {}).get(stage) or {}).get(metric)) is not None
+            ]
+            if len(values) < 2:
+                continue
+            per_metric[f"{stage}/{metric}"] = {
+                "min": round(min(values), 6),
+                "max": round(max(values), 6),
+                "spread": round(max(values) - min(values), 6),
+            }
+    worst = max((v["spread"] for v in per_metric.values()), default=0.0)
+    return {
+        "runs": len(runs),
+        "worst_spread": round(worst, 6),
+        "worst_metric": max(per_metric, key=lambda m: per_metric[m]["spread"], default=None)
+        if per_metric
+        else None,
+        "per_metric": per_metric,
+    }

--- a/evals/recall/metrics.py
+++ b/evals/recall/metrics.py
@@ -322,38 +322,100 @@ def compare(
 
 
 def variance_report(runs: Sequence[Mapping[str, object]]) -> dict[str, object]:
-    """Run-to-run spread per (stage, metric), for #4479 AC3.
+    """Run-to-run spread per metric, for #4479 AC3.
 
     Reports the **absolute** spread (max - min) rather than a relative one:
     these metrics are already bounded in [0, 1], and a relative spread explodes
     meaninglessly when a metric sits near zero. ``worst_spread`` is therefore
     directly comparable to the 1 % (0.01) budget the AC states.
+
+    Two families are covered, and covering both is not optional:
+
+    * graded per-stage metrics, which exist only when a qrels file was supplied;
+    * **label-free** per-case retrieval stability, which always exists — the
+      normalised keyword- and semantic-arm row count for every case, plus the
+      keyword-arm zero-result rate.
+
+    Without the second family a run with no judgements would compare *nothing*
+    and report ``worst_spread: 0.0``, i.e. claim perfect determinism because it
+    measured none. ``metrics_compared`` is returned so that claim is always
+    checkable, and ``measured`` is False when it is zero.
     """
     if len(runs) < 2:
-        return {"runs": len(runs), "worst_spread": 0.0, "per_metric": {}}
-    per_metric: dict[str, dict[str, float]] = {}
+        return {
+            "runs": len(runs),
+            "worst_spread": None,
+            "worst_metric": None,
+            "metrics_compared": 0,
+            "measured": False,
+            "per_metric": {},
+        }
+
+    series: dict[str, list[float]] = {}
+
     stages = sorted({s for run in runs for s in (run.get("stages") or {})})
     for stage in stages:
-        metrics = sorted({m for run in runs for m in ((run.get("stages") or {}).get(stage) or {})})
-        for metric in metrics:
-            values = [
+        names = sorted({m for run in runs for m in ((run.get("stages") or {}).get(stage) or {})})
+        for metric in names:
+            if metric == "judged_cases":  # a count, not a [0,1] score
+                continue
+            series[f"{stage}/{metric}"] = [
                 v
                 for run in runs
                 if (v := ((run.get("stages") or {}).get(stage) or {}).get(metric)) is not None
             ]
+
+    series["label_free/keyword_arm_zero_result_rate"] = [
+        float(v)
+        for run in runs
+        if (v := run.get("keyword_arm_zero_result_rate")) is not None
+    ]
+
+    # Per-case arm row counts, normalised by that case's own maximum across the
+    # runs so the spread is comparable to the [0, 1] budget. A case whose
+    # keyword arm returns 300 rows in one run and 258 in the next is a 14 %
+    # swing in the input to fusion, and it is invisible in any graded metric
+    # when there are no judgements.
+    for arm_key, label in (
+        ("keyword_arm_row_counts", "keyword"),
+        ("semantic_arm_row_counts", "semantic"),
+    ):
+        cases = sorted({c for run in runs for c in (run.get(arm_key) or {})})
+        for case in cases:
+            values = [
+                float(v) for run in runs if (v := (run.get(arm_key) or {}).get(case)) is not None
+            ]
             if len(values) < 2:
                 continue
-            per_metric[f"{stage}/{metric}"] = {
-                "min": round(min(values), 6),
-                "max": round(max(values), 6),
-                "spread": round(max(values) - min(values), 6),
-            }
-    worst = max((v["spread"] for v in per_metric.values()), default=0.0)
+            scale = max(values) or 1.0
+            series[f"label_free/{label}_rows/{case}"] = [v / scale for v in values]
+
+    per_metric: dict[str, dict[str, float]] = {}
+    for name, values in series.items():
+        if len(values) < 2:
+            continue
+        per_metric[name] = {
+            "min": round(min(values), 6),
+            "max": round(max(values), 6),
+            "spread": round(max(values) - min(values), 6),
+        }
+
+    if not per_metric:
+        return {
+            "runs": len(runs),
+            "worst_spread": None,
+            "worst_metric": None,
+            "metrics_compared": 0,
+            "measured": False,
+            "per_metric": {},
+        }
+
+    worst_metric = max(per_metric, key=lambda m: per_metric[m]["spread"])
     return {
         "runs": len(runs),
-        "worst_spread": round(worst, 6),
-        "worst_metric": max(per_metric, key=lambda m: per_metric[m]["spread"], default=None)
-        if per_metric
-        else None,
+        "worst_spread": per_metric[worst_metric]["spread"],
+        "worst_metric": worst_metric,
+        "metrics_compared": len(per_metric),
+        "measured": True,
         "per_metric": per_metric,
     }

--- a/evals/recall/metrics.py
+++ b/evals/recall/metrics.py
@@ -275,8 +275,19 @@ def compare(
       arm answered that the candidate's does not. This is the guard that a
       tokenizer silently reverting to unstemmed (risk C1 in #4474) trips, and
       it defaults to zero tolerance.
+
+    Failures are split into two kinds, because conflating them makes the gate
+    unfalsifiable. ``regressions`` are *measured* — the candidate is provably
+    worse. ``ungraded`` means a budget could not be evaluated at all (typically
+    no qrels, so ``recall@10`` does not exist on either side). Both block, but
+    only the first discriminates: with no judgements committed, *every* compare
+    is ungraded, including a run against itself, so an exit code that cannot
+    tell the two apart proves nothing about a degraded configuration. ``verdict``
+    is ``pass`` / ``regression`` / ``ungraded`` and the caller maps it to a
+    distinct exit code.
     """
-    findings: list[str] = []
+    regressions: list[str] = []
+    ungraded: list[str] = []
 
     b_stage = (baseline.get("stages") or {}).get(gate_stage) or {}
     c_stage = (candidate.get("stages") or {}).get(gate_stage) or {}
@@ -284,14 +295,14 @@ def compare(
     c_r10 = c_stage.get("recall@10")
     drop = None
     if b_r10 is None or c_r10 is None:
-        findings.append(
+        ungraded.append(
             f"recall@10 missing at stage {gate_stage} "
             f"(baseline={b_r10!r}, candidate={c_r10!r}) — cannot grade"
         )
     else:
         drop = round(b_r10 - c_r10, 6)
         if drop > max_recall10_drop:
-            findings.append(
+            regressions.append(
                 f"recall@10 at {gate_stage} dropped {drop:.4f} > budget {max_recall10_drop:.4f} "
                 f"({b_r10:.4f} -> {c_r10:.4f})"
             )
@@ -300,14 +311,24 @@ def compare(
     c_kw = candidate.get("keyword_arm_row_counts") or {}
     regressed = sorted(q for q, n in b_kw.items() if n > 0 and c_kw.get(q, 0) == 0)
     if len(regressed) > max_zero_result_regressions:
-        findings.append(
+        regressions.append(
             f"{len(regressed)} queries went keyword-zero that the baseline answered "
             f"(budget {max_zero_result_regressions}): {regressed[:10]}"
             + ("..." if len(regressed) > 10 else "")
         )
 
+    if regressions:
+        verdict = "regression"
+    elif ungraded:
+        verdict = "ungraded"
+    else:
+        verdict = "pass"
+
     return {
-        "ok": not findings,
+        "ok": verdict == "pass",
+        "verdict": verdict,
+        "regressions": regressions,
+        "ungraded": ungraded,
         "gate_stage": gate_stage,
         "recall@10_baseline": b_r10,
         "recall@10_candidate": c_r10,
@@ -317,7 +338,7 @@ def compare(
             "max_recall10_drop": max_recall10_drop,
             "max_zero_result_regressions": max_zero_result_regressions,
         },
-        "findings": findings,
+        "findings": regressions + ungraded,
     }
 
 

--- a/evals/recall/qrels/README.md
+++ b/evals/recall/qrels/README.md
@@ -1,0 +1,89 @@
+# Relevance judgements (qrels)
+
+Graded relevance labels for the recall-quality suite. One file per
+(bank, judgement campaign). `metrics.recall@k` / `nDCG@10` / `MRR` are computed
+against these; the headline zero-result metric is not, which is why it is the
+number the suite can report at full scale today.
+
+## Format
+
+```json
+{
+  "judgement": {
+    "method": "pooled-graded",
+    "judge": "operator",
+    "date": "2026-08-07",
+    "bank": "bank-0c3d12fd",
+    "queryset_version": "v1",
+    "pool_depth": 10,
+    "pool_configs": ["native/arm:semantic", "native/arm:bm25", "native/final"],
+    "scale": {"0": "irrelevant", "1": "marginal", "2": "relevant", "3": "ideal"},
+    "notes": "..."
+  },
+  "qrels": {
+    "nq-001": {"7d5f9840-5778-47ed-b8cf-a06edacfbdc1": 3},
+    "zr-003": {}
+  }
+}
+```
+
+`load_qrels` **rejects a file with no `judgement` block.** A label set whose
+provenance is unrecorded cannot be argued with, and #4479 item 6 asks for
+provenance to be stated rather than implied.
+
+## Two hard rules
+
+1. **Ids and integer grades only. Never memory text, never query text.** This
+   repository is public and every id here points into a live operator's private
+   memory. A UUID is opaque; a snippet is a leak. There is no redaction mode
+   that makes pasting text here acceptable.
+2. **Case ids are the join key.** Renaming a case in `queryset/v1.yaml`
+   silently orphans its judgements — the case becomes unjudged, drops out of
+   the graded metrics, and the score goes *up*. Add cases; do not rename them.
+
+An empty object (`"zr-003": {}`) is meaningful and distinct from an absent key:
+it records "judged, nothing relevant exists". `recall@k` for such a case is
+`0.0`, not `1.0`.
+
+## Choosing a method
+
+See the README's "Judgement provenance, and its limits" for what each method is
+worth. Short version:
+
+| method | labels | main bias |
+|---|---|---|
+| `pooled-graded` | human or LLM judge over a pooled candidate set | recall is recall-within-pool; unjudged relevant docs are invisible |
+| `known-item` | derived, exact, deterministic | lexical overlap flatters the keyword arm; use for relative comparisons |
+| `operator` | human | does not scale past a few dozen |
+
+Whichever you pick, **the judge must not see ranks, scores, or which
+configuration produced a candidate.** That is the difference between a
+judgement and a rationalisation of the current ranking.
+
+## Building a pooled set
+
+1. Run the suite against every configuration you intend to compare, with
+   `--no-redact-banks` so ids resolve locally.
+2. Union the top-`pool_depth` of every stage across every run. Pooling across
+   *configurations* is what stops the labels favouring the incumbent.
+3. Judge each (case, memory) pair blind, then write ids + grades here.
+4. Record `pool_depth` and `pool_configs` in the `judgement` block. Without
+   them, `recall@k` has no stated denominator and cannot be interpreted.
+
+## Label rot is expected, and it is measured
+
+Judgements pin memory-unit ids in a **live** bank. Consolidation rewrites
+units, so ids decay. A decayed qrels file looks exactly like a quality
+regression, which is the failure mode most likely to make someone distrust a
+green suite and then ignore a red one.
+
+Every run therefore reports `judged_coverage@10`, and `--min-judged-coverage`
+fails the run outright rather than letting rot masquerade as a score change.
+When coverage drops below the floor, re-judge; do not lower the floor.
+
+## Committed files
+
+None yet. The baseline in `../results/` is label-free by design: it reports the
+keyword-arm zero-result metric and per-stage row counts, which need no
+judgements. A graded campaign against a named bank is the next increment, and
+it should land as its own PR with its `judgement` block filled in.

--- a/evals/recall/queryset.py
+++ b/evals/recall/queryset.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Query-set and qrels loading for the recall-quality eval (#4479).
+
+The query set is the asset this phase leaves behind, so loading it is strict:
+an unknown key, a duplicate id or an empty query is an error, not a warning. A
+silently-dropped case is a silently-shrunk denominator, and every metric in the
+suite is a ratio.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+CASE_KEYS = {"id", "family", "text", "probe", "banks", "notes"}
+TOP_KEYS = {
+    "schema_version",
+    "queryset_version",
+    "queryset_id",
+    "provenance",
+    "families",
+    "cases",
+}
+
+
+class QuerySetError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class Case:
+    id: str
+    family: str
+    text: str
+    probe: str | None = None
+    banks: tuple[str, ...] | None = None
+    notes: str | None = None
+
+
+@dataclass
+class QuerySet:
+    queryset_id: str
+    queryset_version: str
+    schema_version: int
+    families: dict[str, str]
+    provenance: dict
+    cases: list[Case]
+    sha256: str
+
+    def filtered(self, families: list[str]) -> QuerySet:
+        wanted = {f.strip() for f in families if f.strip()}
+        unknown = wanted - set(self.families)
+        if unknown:
+            raise QuerySetError(f"unknown families: {sorted(unknown)}")
+        return QuerySet(
+            self.queryset_id,
+            self.queryset_version,
+            self.schema_version,
+            self.families,
+            self.provenance,
+            [c for c in self.cases if c.family in wanted],
+            self.sha256,
+        )
+
+    def limited(self, n: int, seed: int = 0) -> QuerySet:
+        """Take a deterministic, family-balanced subset of ``n`` cases.
+
+        Deliberately not `random.sample`: a subset that changes between runs
+        makes two result files incomparable, and the whole point of `--limit` is
+        to run a small set on a contended box and still be able to diff it
+        against the next one. Selection is a stable round-robin across families
+        ordered by `sha256(seed:id)`, so the same (n, seed) always yields the
+        same cases and every family is represented before any family repeats.
+        """
+        if n <= 0 or n >= len(self.cases):
+            return self
+        by_family: dict[str, list[Case]] = {}
+        for case in self.cases:
+            by_family.setdefault(case.family, []).append(case)
+        for family in by_family:
+            by_family[family].sort(
+                key=lambda c: hashlib.sha256(f"{seed}:{c.id}".encode()).hexdigest()
+            )
+        picked: list[Case] = []
+        order = sorted(by_family)
+        i = 0
+        while len(picked) < n:
+            progressed = False
+            for family in order:
+                if i < len(by_family[family]):
+                    picked.append(by_family[family][i])
+                    progressed = True
+                    if len(picked) == n:
+                        break
+            if not progressed:
+                break
+            i += 1
+        picked.sort(key=lambda c: c.id)
+        return QuerySet(
+            self.queryset_id,
+            self.queryset_version,
+            self.schema_version,
+            self.families,
+            self.provenance,
+            picked,
+            self.sha256,
+        )
+
+
+def load_queryset(path: str | Path) -> QuerySet:
+    raw_text = Path(path).read_text()
+    data = yaml.safe_load(raw_text)
+    if not isinstance(data, dict):
+        raise QuerySetError(f"{path}: top level must be a mapping")
+
+    unknown = set(data) - TOP_KEYS
+    if unknown:
+        raise QuerySetError(f"{path}: unknown top-level keys {sorted(unknown)}")
+    for key in ("schema_version", "queryset_version", "queryset_id", "families", "cases"):
+        if key not in data:
+            raise QuerySetError(f"{path}: missing required key {key!r}")
+    if data["schema_version"] != 1:
+        raise QuerySetError(f"{path}: unsupported schema_version {data['schema_version']!r}")
+
+    families = data["families"]
+    if not isinstance(families, dict) or not families:
+        raise QuerySetError(f"{path}: families must be a non-empty mapping")
+
+    cases: list[Case] = []
+    seen: set[str] = set()
+    for i, raw in enumerate(data["cases"] or []):
+        if not isinstance(raw, dict):
+            raise QuerySetError(f"{path}: case #{i} is not a mapping")
+        extra = set(raw) - CASE_KEYS
+        if extra:
+            raise QuerySetError(f"{path}: case #{i} has unknown keys {sorted(extra)}")
+        cid = raw.get("id")
+        if not cid or not isinstance(cid, str):
+            raise QuerySetError(f"{path}: case #{i} has no id")
+        if cid in seen:
+            raise QuerySetError(f"{path}: duplicate case id {cid!r}")
+        seen.add(cid)
+        family = raw.get("family")
+        if family not in families:
+            raise QuerySetError(f"{path}: case {cid} has unknown family {family!r}")
+        text = (raw.get("text") or "").strip()
+        if not text:
+            raise QuerySetError(f"{path}: case {cid} has empty text")
+        banks = raw.get("banks")
+        cases.append(
+            Case(
+                id=cid,
+                family=family,
+                text=text,
+                probe=raw.get("probe"),
+                banks=tuple(banks) if banks else None,
+                notes=raw.get("notes"),
+            )
+        )
+    if not cases:
+        raise QuerySetError(f"{path}: no cases")
+
+    return QuerySet(
+        queryset_id=data["queryset_id"],
+        queryset_version=data["queryset_version"],
+        schema_version=data["schema_version"],
+        families=families,
+        provenance=data.get("provenance") or {},
+        cases=cases,
+        sha256=hashlib.sha256(raw_text.encode()).hexdigest(),
+    )
+
+
+def load_qrels(path: str | Path) -> dict[str, dict[str, int]]:
+    """Load relevance judgements.
+
+    Shape::
+
+        {
+          "judgement": {"method": "...", "judge": "...", "date": "...",
+                        "pool_depth": 10, "pool_configs": ["..."]},
+          "qrels": {"<case-id>": {"<memory-uuid>": 2, ...}, ...}
+        }
+
+    Ids and integer grades only. Memory TEXT must never appear in a qrels file:
+    this repository is public and the memories are private. The `judgement`
+    block is mandatory because #4479 item 6 asks for provenance to be recorded
+    rather than implied, and a file without it cannot answer "where did these
+    labels come from".
+    """
+    data = json.loads(Path(path).read_text())
+    if "judgement" not in data:
+        raise QuerySetError(f"{path}: qrels file has no 'judgement' provenance block")
+    qrels = data.get("qrels") or {}
+    out: dict[str, dict[str, int]] = {}
+    for case_id, judgements in qrels.items():
+        out[case_id] = {str(doc): int(grade) for doc, grade in (judgements or {}).items()}
+    return out

--- a/evals/recall/queryset/v1.yaml
+++ b/evals/recall/queryset/v1.yaml
@@ -1,0 +1,444 @@
+# Hindsight recall-quality query set — version 1
+#
+# See ../README.md for the method, the judgement provenance, and how to add a
+# case. Two rules bind every entry in this file:
+#
+#   1. NO REAL USER OR BANK TEXT. This repo is public; the banks are a live
+#      operator's private memory. Every `text` below is authored. Real recall
+#      traffic shaped the FAMILIES and the LENGTH DISTRIBUTION (see
+#      `provenance` below), never the wording.
+#   2. A case is a question about the query, not about an answer. Relevance
+#      judgements live in ../qrels/ as opaque ids, never here.
+
+schema_version: 1
+queryset_version: "v1"
+queryset_id: p6-recall-quality-v1
+
+provenance:
+  method: authored-traffic-shaped
+  shaped_by:
+    # Aggregate statistics only, reproduced by `derive_shape.py`, which reads
+    # the local `recall_log.jsonl` telemetry of the fleet. The source log
+    # records `query_chars` (an integer) and never the query text, so nothing
+    # private can reach this block. Regenerate with:
+    #   python3 evals/recall/derive_shape.py --glob '<path>/recall_log.jsonl'
+    # Captured 2026-08-07 across 12 agents.
+    source: recall_log.jsonl (local, never committed)
+    rows_observed: 23538
+    distinct_banks: 12
+    query_chars_p50: 691
+    query_chars_p90: 800
+    query_chars_max: 800  # HINDSIGHT_RECALL_MAX_QUERY_CHARS
+    query_chars_mean: 577.5
+    result_count_p50: 5
+    capped_rate: 0.4284
+    final_zero_result_rate: 0.3883
+  notes: >-
+    The single most surprising shape fact, and the reason the `context-blob`
+    family is the largest one here: real auto-recall queries are NOT short
+    keyword queries. The median is 691 characters and 43% of calls hit the
+    result cap, i.e. these are multi-sentence transcript slices clipped at the
+    800-char query cap. A query set made only of short natural-language
+    questions would not exercise the arm the fleet actually uses.
+
+    The 0.3883 final zero-result rate is a DIFFERENT quantity from this suite's
+    headline metric and must not be quoted as a baseline for it. It counts
+    recalls where the plugin surfaced no memory at all, after the relevance
+    floor and the demotion/overlap filters, over every bank including new and
+    nearly-empty ones. The headline metric counts KEYWORD-ARM zero rows on a
+    fixed query set against a named bank. This number is here to say the
+    phenomenon is common in the field, not to be compared against a run.
+
+families:
+  natural-question: Short natural-language questions. The shape a human types.
+  identifier: Code identifiers, paths, issue numbers, env vars. Common in fleet traffic.
+  morphological: >-
+    Stemming probes. Each pairs a surface form with a form that only matches
+    under a stemmer. These are the cases that go red if the pg_search tokenizer
+    silently reverts to unstemmed (risk C1 in epic #4474).
+  stopword-heavy: >-
+    Queries dominated by boilerplate. The fleet runs a custom `hindsight_english`
+    regconfig whose stopword file drops boilerplate lexemes; migrating off it
+    changes recall, which is the epic's open decision.
+  rare-term: Low-frequency technical terms. Where a keyword arm earns its place.
+  context-blob: >-
+    Long multi-sentence slices at the real 500-800 char median. The dominant
+    real shape.
+  zero-result-probe: >-
+    Composed entirely of lexemes the deployed regconfig discards, so the query
+    reduces to an empty tsquery and the native keyword arm returns zero rows.
+    This is the measured mechanism, not an assumed one; see the family comment
+    below. These are the headline metric's subject.
+
+cases:
+  # ── natural-question ────────────────────────────────────────────
+  - {id: nq-001, family: natural-question, text: "what did we decide about the recall deadline envelope"}
+  - {id: nq-002, family: natural-question, text: "why does the keyword arm return nothing sometimes"}
+  - {id: nq-003, family: natural-question, text: "how do scheduled tasks fire into a running session"}
+  - {id: nq-004, family: natural-question, text: "what is the difference between a directive and a mental model"}
+  - {id: nq-005, family: natural-question, text: "who approves a vault grant and how long does it take"}
+  - {id: nq-006, family: natural-question, text: "when was the last time the fleet was rolled to a new image"}
+  - {id: nq-007, family: natural-question, text: "what breaks when an agent overlay file is owned by root"}
+  - {id: nq-008, family: natural-question, text: "how is the merge queue configured for this repo"}
+  - {id: nq-009, family: natural-question, text: "what happened during the contention incident"}
+  - {id: nq-010, family: natural-question, text: "which checks are required before a pull request can merge"}
+  - {id: nq-011, family: natural-question, text: "how does an agent recover a session after a restart"}
+  - {id: nq-012, family: natural-question, text: "what is the policy on running claude programmatically"}
+  - {id: nq-013, family: natural-question, text: "where do worker sub-agents write their scratch files"}
+  - {id: nq-014, family: natural-question, text: "how many directives can a bank hold before recall drops some"}
+  - {id: nq-015, family: natural-question, text: "what is the plan for the text search backend"}
+  - {id: nq-016, family: natural-question, text: "why did the cron stop firing for weeks"}
+  - {id: nq-017, family: natural-question, text: "what does a degraded recall look like from the outside"}
+  - {id: nq-018, family: natural-question, text: "how do we prove a test can actually fail"}
+
+  # ── identifier ──────────────────────────────────────────────────
+  - {id: id-001, family: identifier, text: "idx_memory_units_text_search"}
+  - {id: id-002, family: identifier, text: "HINDSIGHT_API_RERANKER_MAX_CANDIDATES"}
+  - {id: id-003, family: identifier, text: "hnsw.ef_search 200 high recall profile"}
+  - {id: id-004, family: identifier, text: "shared_buffers effective_cache_size sizing"}
+  - {id: id-005, family: identifier, text: "reciprocal_rank_fusion k=60"}
+  - {id: id-006, family: identifier, text: "ensure_text_search_extension boot crash loop"}
+  - {id: id-007, family: identifier, text: "pg_search bm25 key_field reloption"}
+  - {id: id-008, family: identifier, text: "hindsight_english regconfig stopword file"}
+  - {id: id-009, family: identifier, text: "recall_log.jsonl injected_score_max"}
+  - {id: id-010, family: identifier, text: "SWITCHROOM_CHEAP_CRON kill switch"}
+  - {id: id-011, family: identifier, text: "check-status-pin-single-path lint guard"}
+  - {id: id-012, family: identifier, text: "profiles/_base/start.sh.hbs boot entry"}
+  - {id: id-013, family: identifier, text: "vault-broker peercred socketPathToAgent"}
+  - {id: id-014, family: identifier, text: "d5e6f7a8b9c0 per bank hnsw migration"}
+  - {id: id-015, family: identifier, text: "pg_total_relation_size memory_units"}
+  - {id: id-016, family: identifier, text: "CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS"}
+  - {id: id-017, family: identifier, text: "XX000 does not contain a USING bm25 index"}
+  - {id: id-018, family: identifier, text: "issue 4474 epic recall latency"}
+
+  # ── morphological (stemming probes) ─────────────────────────────
+  # `probe` records the morphological relationship the case is testing. It is
+  # documentation, not an assertion: what the suite asserts is that these cases
+  # do not silently lose their keyword arm between two configurations.
+  - {id: mo-001, family: morphological, text: "indexing strategy for the memory units table", probe: "indexing -> index"}
+  - {id: mo-002, family: morphological, text: "indexes we should drop as dead weight", probe: "indexes -> index"}
+  - {id: mo-003, family: morphological, text: "running the benchmark under contention", probe: "running -> run"}
+  - {id: mo-004, family: morphological, text: "ran the sweep twice and compared", probe: "ran -> run (irregular)"}
+  - {id: mo-005, family: morphological, text: "consolidation writes storming the read path", probe: "storming -> storm"}
+  - {id: mo-006, family: morphological, text: "consolidated observations merged into one", probe: "consolidated -> consolidate"}
+  - {id: mo-007, family: morphological, text: "tokenizing the text column without a stemmer", probe: "tokenizing -> token"}
+  - {id: mo-008, family: morphological, text: "tokenizer variants and their stopword handling", probe: "tokenizer -> token"}
+  - {id: mo-009, family: morphological, text: "scheduling a recurring digest", probe: "scheduling -> schedul"}
+  - {id: mo-010, family: morphological, text: "schedules that fire into the live session", probe: "schedules -> schedul"}
+  - {id: mo-011, family: morphological, text: "approving a host mutation from telegram", probe: "approving -> approv"}
+  - {id: mo-012, family: morphological, text: "approvals that timed out are not denials", probe: "approvals -> approv"}
+  - {id: mo-013, family: morphological, text: "retaining a fact after a correction", probe: "retaining -> retain"}
+  - {id: mo-014, family: morphological, text: "retained memories that never surfaced again", probe: "retained -> retain"}
+  - {id: mo-015, family: morphological, text: "measuring latency percentiles not means", probe: "measuring -> measur"}
+  - {id: mo-016, family: morphological, text: "measurement instrument for the epic", probe: "measurement -> measur"}
+  - {id: mo-017, family: morphological, text: "degrading gracefully to semantic only", probe: "degrading -> degrad"}
+  - {id: mo-018, family: morphological, text: "degradation of the candidate pool", probe: "degradation -> degrad"}
+  - {id: mo-019, family: morphological, text: "reranking candidates with the cross encoder", probe: "reranking -> rerank"}
+  - {id: mo-020, family: morphological, text: "reranked results moved up in rank", probe: "reranked -> rerank"}
+
+  # ── stopword-heavy ──────────────────────────────────────────────
+  - {id: sw-001, family: stopword-heavy, text: "can you tell me what it was that we had decided about this"}
+  - {id: sw-002, family: stopword-heavy, text: "is there anything at all that i should know before i do that"}
+  - {id: sw-003, family: stopword-heavy, text: "the user asked the assistant to do the thing with the agent"}
+  - {id: sw-004, family: stopword-heavy, text: "please go ahead and do it the way we normally do"}
+  - {id: sw-005, family: stopword-heavy, text: "claude code agent assistant switchroom sidechain"}
+  - {id: sw-006, family: stopword-heavy, text: "what were the things we said about the other thing"}
+  - {id: sw-007, family: stopword-heavy, text: "i think it might have been something like that but not quite"}
+  - {id: sw-008, family: stopword-heavy, text: "ok so then what should we be doing about all of this now"}
+  - {id: sw-009, family: stopword-heavy, text: "there is a thing that does the thing when the other thing happens"}
+  - {id: sw-010, family: stopword-heavy, text: "just to be clear this is about that other one we talked about"}
+
+  # ── rare-term ───────────────────────────────────────────────────
+  - {id: rt-001, family: rare-term, text: "block-max WAND non competitive document skipping"}
+  - {id: rt-002, family: rare-term, text: "MaxScore top-n retrieval sublinear in matches"}
+  - {id: rt-003, family: rare-term, text: "tantivy segment merge policy"}
+  - {id: rt-004, family: rare-term, text: "snowball dictionary lexeme dropping"}
+  - {id: rt-005, family: rare-term, text: "reciprocal rank fusion versus interleaved fusion for dedup"}
+  - {id: rt-006, family: rare-term, text: "spreading activation entry point selection"}
+  - {id: rt-007, family: rare-term, text: "amcheck extension verifying btree integrity"}
+  - {id: rt-008, family: rare-term, text: "autovacuum dead tuple pruning headroom"}
+  - {id: rt-009, family: rare-term, text: "partial hnsw index per bank and fact type"}
+  - {id: rt-010, family: rare-term, text: "heap filter versus pushed down predicate"}
+  - {id: rt-011, family: rare-term, text: "cross encoder batching nondeterminism"}
+  - {id: rt-012, family: rare-term, text: "peercred based socket authentication"}
+  - {id: rt-013, family: rare-term, text: "idempotent at least once boot replay"}
+  - {id: rt-014, family: rare-term, text: "unified diff proposal applied by the host"}
+  - {id: rt-015, family: rare-term, text: "reciprocal grant scoped to one vault key"}
+
+  # rt-016..rt-035 were the original zero-result-probe population: lexically
+  # narrow, low-frequency phrasings, on the assumption that a rare phrase is
+  # what drives a keyword arm to zero. Measurement said otherwise (see the
+  # zero-result-probe comment below), so they live here instead, where being
+  # rare-but-matching is the point. They stay useful as a hedge: a backend with
+  # conjunctive semantics would drive these to zero even though native does not.
+  - {id: rt-016, family: rare-term, text: "quiescent reindexation window"}
+  - {id: rt-017, family: rare-term, text: "unstemmed lexeme regression guard"}
+  - {id: rt-018, family: rare-term, text: "nondeterministic tie-break in fusion ordering"}
+  - {id: rt-019, family: rare-term, text: "pathological stopword saturation"}
+  - {id: rt-020, family: rare-term, text: "orthogonal ablation of the keyword arm"}
+  - {id: rt-021, family: rare-term, text: "vacuous acceptance criterion"}
+  - {id: rt-022, family: rare-term, text: "circularity in relevance judgements"}
+  - {id: rt-023, family: rare-term, text: "amortised skipping across competitive postings"}
+  - {id: rt-024, family: rare-term, text: "morphological variant coverage shortfall"}
+  - {id: rt-025, family: rare-term, text: "monotonic degradation under arm removal"}
+  - {id: rt-026, family: rare-term, text: "provenance of a graded judgement"}
+  - {id: rt-027, family: rare-term, text: "idempotence of the reconcile sweep"}
+  - {id: rt-028, family: rare-term, text: "sublinearity claim conditional on the index fix"}
+  - {id: rt-029, family: rare-term, text: "unreproducible contention from rotated logs"}
+  - {id: rt-030, family: rare-term, text: "fail closed versus fail open on a missing index"}
+  - {id: rt-031, family: rare-term, text: "counterfactual baseline for a quality budget"}
+  - {id: rt-032, family: rare-term, text: "lexical recall shortfall recovered by bm25"}
+  - {id: rt-033, family: rare-term, text: "denominator per signal rather than shared"}
+  - {id: rt-034, family: rare-term, text: "escalation reason recorded on the render plan"}
+  - {id: rt-035, family: rare-term, text: "attributable delta between two ablations"}
+
+  # ── zero-result-probe ───────────────────────────────────────────
+  # Built to the ONE mechanism that actually drives the native keyword arm to
+  # zero rows, which was measured rather than assumed.
+  #
+  # The native arm ORs its tokens — `to_tsquery(cfg, 'a | b | c')` gated by
+  # `search_vector @@ <query>` (engine/sql/postgresql.py:228-234, v0.8.6) — so
+  # on a large bank a merely rare phrase still matches something. What does not
+  # match is a query that reduces to an EMPTY tsquery. The fleet runs
+  # `hindsight_english`, a COPY of `english` whose snowball dictionary carries
+  # docker/hindsight-extra.stop: standard English stopwords PLUS the corpus
+  # boilerplate claude / code / agent / assistant / user / switchroom /
+  # sidechain. A query made only of those words yields no lexemes at all.
+  #
+  # Measured on the live instance: of ten stopword-heavy cases, the nine using
+  # ordinary function words returned 172-300 keyword rows; sw-005, the one made
+  # of fleet boilerplate, returned 0. Every case below is composed exclusively
+  # of tokens present in that stop file.
+  #
+  # This makes the denominator a function of hindsight-extra.stop. If that file
+  # changes, these cases change meaning — which is itself worth knowing, and is
+  # exactly the kind of regression this family is here to catch.
+  #
+  # Do not delete a case because it currently scores zero. Scoring zero is the
+  # job: the headline metric's denominator is drawn from the cases that do.
+  # Surface forms only, no plurals or inflections, because whether the stopword
+  # check runs before or after stemming is not something this suite asserts.
+  # Inflected probes belong in `morphological`, with a probe note.
+  - {id: zr-001, family: zero-result-probe, text: "what did the user and the assistant do about it"}
+  - {id: zr-002, family: zero-result-probe, text: "the agent involved in this"}
+  - {id: zr-003, family: zero-result-probe, text: "claude code sidechain"}
+  - {id: zr-004, family: zero-result-probe, text: "switchroom agent user"}
+  - {id: zr-005, family: zero-result-probe, text: "is the assistant involving the user"}
+  - {id: zr-006, family: zero-result-probe, text: "should the agent do it now"}
+  - {id: zr-007, family: zero-result-probe, text: "claude-code sidechain user"}
+  - {id: zr-008, family: zero-result-probe, text: "the user who involved the assistant"}
+  - {id: zr-009, family: zero-result-probe, text: "what about claude"}
+  - {id: zr-010, family: zero-result-probe, text: "code and the agent"}
+  - {id: zr-011, family: zero-result-probe, text: "switchroom"}
+  - {id: zr-012, family: zero-result-probe, text: "the assistant"}
+  - {id: zr-013, family: zero-result-probe, text: "how does the agent do this"}
+  - {id: zr-014, family: zero-result-probe, text: "claude-code-sidechain"}
+  - {id: zr-015, family: zero-result-probe, text: "involves the user and the assistant"}
+  - {id: zr-016, family: zero-result-probe, text: "when will claude code do it"}
+  - {id: zr-017, family: zero-result-probe, text: "who is the user here"}
+  - {id: zr-018, family: zero-result-probe, text: "a switchroom agent involved with claude"}
+  - {id: zr-019, family: zero-result-probe, text: "not the assistant but the agent"}
+  - {id: zr-020, family: zero-result-probe, text: "just some code from claude"}
+
+  # ── context-blob (the dominant real shape: 500-800 chars) ───────
+  - id: cb-001
+    family: context-blob
+    text: >-
+      Prior context: we were working through whether the keyword backend is the
+      right lever at all. The conclusion was that consistency under contention
+      is decided by box level resource fit and by isolating the read path from
+      the write storm, not by which text search extension is installed. The
+      keyword index is small and cache resident, so swapping it does not move
+      the decisive axis. What it does move is quality, because the current
+      backend returns nothing at all for some queries and the candidate one
+      returns something. That quality result is the only reason the idea is
+      still on the table, and it needs to become a number before anything is
+      traded against it.
+  - id: cb-002
+    family: context-blob
+    text: >-
+      Prior context: the index we are building omits the bank and fact type
+      columns, so every arm scores across the whole table and the restriction
+      lands as a heap filter instead of being pushed into the scan. At fourteen
+      banks that is a large amplification for the biggest bank and far worse
+      for the small ones. Nothing downstream should be measured until that is
+      fixed, otherwise every number we produce is measuring the bug rather than
+      the backend. The follow up is to rebuild the index with the two columns
+      included and re-run the comparison from scratch.
+  - id: cb-003
+    family: context-blob
+    text: >-
+      Prior context: the boot path raises when the configured backend does not
+      match the column and index layout on disk and the tables already contain
+      data. When that raises, the application never serves, which takes out the
+      semantic arm as well as the keyword one. That is a full memory outage
+      rather than keyword errors, and it is the reason the cutover has to build
+      and validate the index before the configuration flips rather than after.
+      A non concurrent reindex on a live instance is the same hazard in a
+      different wrapper.
+  - id: cb-004
+    family: context-blob
+    text: >-
+      Prior context: cache hit numbers on this box are currently unusable as a
+      signal because the statistics were never reset, so everything reported is
+      cumulative since the database was initialised and says nothing about
+      behaviour under load. Any acceptance criterion that leans on a hit ratio
+      has to reset first or capture a before and after delta. The same applies
+      to any claim about buffer pool residency: the working set currently
+      overshoots the pool, and the cleanest reclaim is an index the upstream
+      source itself describes as dead weight.
+  - id: cb-005
+    family: context-blob
+    text: >-
+      Prior context: we agreed that a suite which cannot go red is worse than
+      no suite, because it manufactures confidence rather than measuring
+      anything. So the acceptance criterion is that a deliberately degraded
+      configuration has to fail it, and both runs get attached. Constructing
+      degraded without touching live state is part of the problem, not a
+      footnote to it. The obvious lever is removing an arm from the fusion and
+      showing that the score moves in the direction it must.
+  - id: cb-006
+    family: context-blob
+    text: >-
+      Prior context: the tokenizer variant we want cannot be expressed through
+      the environment knob at all. The normaliser accepts only a bare tokenizer
+      name from a fixed set, and the column builder emits an unstemmed cast, so
+      there is no stemmer or stopword parameter anywhere in that path. Worse,
+      the mismatch detector distinguishes the two extensions only by the
+      presence of one index option and never inspects the cast, so a hand built
+      index is silently adopted as correct and silently reverts to unstemmed if
+      it is ever rebuilt.
+  - id: cb-007
+    family: context-blob
+    text: >-
+      Prior context: the recall query is a union of per fact type semantic arms
+      and per fact type keyword arms plus graph arms, fused with reciprocal
+      rank fusion and then reranked by a cross encoder with a candidate cap.
+      The semantic arms over fetch and trim in application code, and the vector
+      search parameter is set globally on pool connections at initialisation
+      rather than per query. That matters because a per stage attribution needs
+      to know which of those knobs was in force when the numbers were taken.
+  - id: cb-008
+    family: context-blob
+    text: >-
+      Prior context: the fleet runs a custom text search configuration that is
+      a copy of the standard English one with a stopword file that drops
+      boilerplate. Migrating without preserving that behaviour changes recall
+      everywhere, which makes it a semantic quality tradeoff rather than a pure
+      performance win. That decision belongs to the requester and must not be
+      resolved silently by an implementation phase. The suite exists partly so
+      that the decision can be made against a number instead of an intuition.
+  - id: cb-009
+    family: context-blob
+    text: >-
+      Prior context: a test sweep created ten throwaway banks inside a four
+      minute window and one of them collided with a live agent's bank name,
+      which destroyed an annotation that mattered. The rule that came out of it
+      is that no evaluation may create a bank whose name could collide with a
+      live one, and that any fixture data has to sit behind a reserved prefix
+      and be cleaned up. Read paths are preferred over write paths for exactly
+      this reason.
+  - id: cb-010
+    family: context-blob
+    text: >-
+      Prior context: the auto recall path failed roughly eighty six percent of
+      the time for six weeks and no alert fired, because every armed watchdog
+      watched retain and liveness while every layer of the recall path fails
+      open. The hook exits zero on a bank timeout, the harness swallows the
+      warning, the agent cannot distinguish an empty match from an unreachable
+      fact layer, and the health probe answers fast and empty. The only durable
+      evidence is the telemetry the hook writes itself.
+  - id: cb-011
+    family: context-blob
+    text: >-
+      Prior context: percentiles rather than means, because the goal is a
+      statement about a distribution and about two independent variables, bank
+      size and concurrency. A median only harness cannot grade any of the
+      acceptance criteria. The sweep needs at least five bank size points
+      spanning the real distribution plus one synthetic point above the current
+      maximum so the curve extrapolates, and a contention mode that runs the
+      sweep while a synthetic write and model load runs against the same box.
+  - id: cb-012
+    family: context-blob
+    text: >-
+      Prior context: the judgement question is the one that decides whether the
+      suite means anything. Labels produced by the system being graded are
+      circular, so the method has to be stated along with its limits rather
+      than left implicit. Pooled judgements are the standard compromise, and
+      known item retrieval avoids the judge entirely at the cost of a lexical
+      bias toward whichever arm shares vocabulary with the target. Both are
+      acceptable if written down.
+  - id: cb-013
+    family: context-blob
+    text: >-
+      Prior context: the headline number is how many of the queries that return
+      nothing under the reference configuration are answered by the candidate
+      one. It needs no relevance labels at all, only two runs and a row count,
+      which is why it is the number the suite can report honestly at full scale
+      while the graded metrics wait on judgement coverage. Everything else in
+      the report is secondary to that ratio.
+  - id: cb-014
+    family: context-blob
+    text: >-
+      Prior context: determinism is not free here because the pipeline includes
+      an approximate nearest neighbour index and a model based reranker, and
+      the underlying bank keeps changing as agents write to it. The honest move
+      is to measure the real run to run spread and report it, rather than tune
+      the measurement until it flatters itself. If the spread exceeds the
+      budget, the suite is still a reporting instrument but must not be wired
+      as a hard gate at that budget.
+  - id: cb-015
+    family: context-blob
+    text: >-
+      Prior context: the results file has to stand on its own when pasted into
+      an issue comment, which means it carries the configuration, the banks,
+      the query set version and the engine identity alongside the scores. A
+      result without its configuration is not a result. It also means the file
+      cannot carry memory text, because the repository is public and the banks
+      are private, so identifiers and numbers only.
+  - id: cb-016
+    family: context-blob
+    text: >-
+      Prior context: the arm attribution matters because a regression needs to
+      be localised to the arm that caused it rather than blamed on the whole
+      pipeline. Reporting the raw keyword arm, the raw semantic arm, the fused
+      list and the reranked list separately is what makes that possible. When
+      the keyword arm alone collapses, the fused list often barely moves,
+      which is exactly how a tokenizer regression hides for weeks.
+  - id: cb-017
+    family: context-blob
+    text: >-
+      Prior context: we should not run a large sweep right now because another
+      measurement is in flight on the same box and a third is establishing a
+      baseline. Sequential at concurrency one against a small query set, and
+      anything timing shaped that comes out of it is not a latency measurement
+      and must never be reported as one. The suite should be built so it can
+      run bigger later, with the full run deferred rather than quietly skipped.
+  - id: cb-018
+    family: context-blob
+    text: >-
+      Prior context: the ordering rule that fell out of the fail closed
+      behaviour is that the index is built and validated before the
+      configuration flips, never the other way round, and that a rebuild on a
+      live instance is done concurrently or not at all. The graceful path the
+      other backend has is not shared, so the window between dropping and
+      rebuilding is a fleet wide outage rather than a degraded mode.
+  - id: cb-019
+    family: context-blob
+    text: >-
+      Prior context: every signal carries its own denominator, because a row
+      that does not carry a field should be excluded from that signal rather
+      than counted as healthy. The fail open default where a missing field
+      reads as zero and therefore fine is precisely the bug class the module
+      exists to catch. A signal whose denominator falls under its sample floor
+      reports no data, which neither fires nor resolves.
+  - id: cb-020
+    family: context-blob
+    text: >-
+      Prior context: the thing that made the whole investigation worth doing
+      was noticing that the candidate backend answered queries the incumbent
+      returned nothing for. That observation currently lives in one dry run
+      note, which means it cannot gate a change and cannot be regressed
+      against, and every latency phase is trading against a quality number
+      nobody can compute. Turning it into a score is the entire point of this
+      phase.

--- a/evals/recall/run_recall_quality.py
+++ b/evals/recall/run_recall_quality.py
@@ -356,11 +356,16 @@ def cmd_run(args: argparse.Namespace) -> int:
 
     result = runs[-1]
     if args.runs > 1:
-        result["determinism"] = metrics.variance_report(runs)
-        result["determinism"]["budget"] = args.determinism_budget
-        result["determinism"]["within_budget"] = (
-            result["determinism"]["worst_spread"] <= args.determinism_budget
+        det = metrics.variance_report(runs)
+        det["budget"] = args.determinism_budget
+        # A report that compared nothing must not claim determinism. This is the
+        # AC3 analogue of the fail-open scorer: `worst_spread: 0.0` over an empty
+        # comparison set reads as "perfectly deterministic" and means "measured
+        # nothing".
+        det["within_budget"] = bool(det["measured"]) and (
+            det["worst_spread"] <= args.determinism_budget
         )
+        result["determinism"] = det
         # Label-free metrics have their own stability question: the keyword arm
         # returning rows for a query is the thing the headline metric counts, so
         # a run where that set moves is a run whose headline number moved.
@@ -390,12 +395,20 @@ def cmd_run(args: argparse.Namespace) -> int:
     print(human_summary(result))
     if args.runs > 1:
         det = result["determinism"]
-        print(
-            f"\n  determinism over {det['runs']} runs: worst spread {det['worst_spread']:.6f} "
-            f"on {det['worst_metric']} (budget {args.determinism_budget})"
-        )
+        if not det["measured"]:
+            print(
+                f"\n  determinism over {det['runs']} runs: NOT MEASURED "
+                "(no comparable metrics across runs)"
+            )
+        else:
+            print(
+                f"\n  determinism over {det['runs']} runs: worst spread "
+                f"{det['worst_spread']:.6f} on {det['worst_metric']} "
+                f"across {det['metrics_compared']} metrics "
+                f"(budget {args.determinism_budget})"
+            )
         if not det["within_budget"]:
-            print("  determinism budget EXCEEDED", file=sys.stderr)
+            print("  determinism budget EXCEEDED or unmeasured", file=sys.stderr)
             return EXIT_REGRESSION
     # Across ALL runs, not just the one whose scores are reported: with
     # `--runs N` the reported block is the last run, and failures in an earlier

--- a/evals/recall/run_recall_quality.py
+++ b/evals/recall/run_recall_quality.py
@@ -1,0 +1,569 @@
+#!/usr/bin/env python3
+"""Hindsight recall-quality eval — runner, scorer and regression gate (#4479).
+
+One command, three modes:
+
+    # score a configuration
+    python3 evals/recall/run_recall_quality.py run \\
+        --banks bank-a,bank-b --out results/p6-baseline-native.json
+
+    # prove the suite is non-vacuous (#4479 AC1)
+    python3 evals/recall/run_recall_quality.py run \\
+        --banks bank-a --disable-keyword-arm --out results/p6-vacuity-check.json
+
+    # gate a candidate against a baseline (#4479 AC4; exit 1 on regression)
+    python3 evals/recall/run_recall_quality.py compare \\
+        results/p6-baseline-native.json results/p6-pgsearch.json \\
+        --max-recall10-drop 0.02 --max-zero-result-regressions 0
+
+Read `evals/recall/README.md` before changing scoring. Three things there are
+load-bearing and are easy to break by accident: the judgement provenance, the
+reason the headline metric is label-free, and the reason nothing here is a
+latency measurement.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Support both `python3 evals/recall/run_recall_quality.py` and
+# `python3 -m evals.recall.run_recall_quality`.
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from evals.recall import metrics  # noqa: E402
+from evals.recall.client import HindsightRecallClient, RecallObservation  # noqa: E402
+from evals.recall.queryset import (  # noqa: E402
+    QuerySet,
+    load_qrels,
+    load_queryset,
+)
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_QUERYSET = HERE / "queryset" / "v1.yaml"
+DEFAULT_API_URL = os.environ.get("HINDSIGHT_API_URL", "http://127.0.0.1:18888")
+
+EXIT_OK = 0
+EXIT_REGRESSION = 1
+EXIT_USAGE = 2
+
+
+# ────────────────────────── running ──────────────────────────
+
+
+def obs_key(query_id: str, bank: str) -> str:
+    return f"{query_id}@{bank}"
+
+
+def run_suite(
+    client: HindsightRecallClient,
+    qs: QuerySet,
+    banks: Sequence[str],
+    *,
+    ablate_arms: Sequence[str] = (),
+    budget: str = "low",
+    max_tokens: int = 4096,
+    progress: bool = True,
+) -> list[RecallObservation]:
+    """Execute every (case, bank) pair sequentially.
+
+    Sequential is not an oversight (see `client.py`). Ablation, when requested,
+    is applied to the *client-side* view of each response: nothing about the
+    live instance changes, and an ablated run issues exactly the same requests
+    a normal one does.
+    """
+    observations: list[RecallObservation] = []
+    total = len(qs.cases) * len(banks)
+    done = 0
+    for bank in banks:
+        for case in qs.cases:
+            obs = client.recall(
+                bank,
+                case.id,
+                case.text,
+                budget=budget,
+                max_tokens=max_tokens,
+            )
+            if ablate_arms:
+                apply_ablation(obs, ablate_arms)
+            observations.append(obs)
+            done += 1
+            if progress:
+                print(
+                    f"  [{done}/{total}] {obs_key(case.id, bank)} "
+                    f"{'ok' if obs.ok else 'FAIL ' + (obs.error or '')} "
+                    f"kw={len(obs.arms.get('bm25', []))} final={obs.result_count}",
+                    file=sys.stderr,
+                )
+    return observations
+
+
+def apply_ablation(obs: RecallObservation, ablate_arms: Sequence[str]) -> None:
+    """Remove arms from the client-side view of a recall.
+
+    This is how the suite constructs a "deliberately degraded configuration"
+    (#4479 AC1) without mutating a live instance. The removed arm's ranked list
+    is emptied and `rrf_client` is refused those contributions, so the fused
+    ranking is genuinely the one that configuration would produce.
+
+    Stages the engine computed downstream of its own fusion (`rrf_engine`,
+    `rerank`, `final`) are NOT recomputed and are dropped instead of being left
+    stale, because there is no honest way to simulate a cross-encoder over a
+    candidate set it never saw. An ablated run therefore has no `final` stage,
+    which is why `--gate-stage` defaults to `rrf_client` when comparing an
+    ablated run.
+    """
+    arms = {arm: ranked for arm, ranked in obs.arms.items() if arm not in ablate_arms}
+    for arm in ablate_arms:
+        obs.arms[arm] = []
+        obs.stages[f"arm:{arm}"] = []
+    obs.stages["rrf_client"] = metrics.rrf_fuse(arms)
+    for stage in ("rrf_engine", "rerank", "final"):
+        obs.stages.pop(stage, None)
+    obs.result_count = len(obs.stages["rrf_client"])
+
+
+# ────────────────────────── scoring ──────────────────────────
+
+
+def score(
+    observations: Sequence[RecallObservation],
+    qrels: Mapping[str, Mapping[str, int]],
+) -> dict[str, object]:
+    """Reduce observations to the score block that lands in the result file."""
+    stage_names = sorted({s for obs in observations for s in obs.stages})
+    stages: dict[str, dict[str, float]] = {}
+    for stage in stage_names:
+        per_case = []
+        for obs in observations:
+            if not obs.ok or stage not in obs.stages:
+                continue
+            relevant = qrels.get(obs.query_id) or qrels.get(obs_key(obs.query_id, obs.bank))
+            if not relevant:
+                continue
+            per_case.append(metrics.score_case(obs.stages[stage], relevant))
+        if per_case:
+            stages[stage] = metrics.aggregate(per_case)
+            stages[stage]["judged_cases"] = len(per_case)
+
+    keyword_counts = {
+        obs_key(obs.query_id, obs.bank): len(obs.arms.get("bm25", []))
+        for obs in observations
+        if obs.ok
+    }
+    semantic_counts = {
+        obs_key(obs.query_id, obs.bank): len(obs.arms.get("semantic", []))
+        for obs in observations
+        if obs.ok
+    }
+    ok = [obs for obs in observations if obs.ok]
+    kw_zero = sorted(q for q, n in keyword_counts.items() if n == 0)
+
+    return {
+        "stages": stages,
+        "keyword_arm_row_counts": keyword_counts,
+        "semantic_arm_row_counts": semantic_counts,
+        "keyword_arm_zero_result_ids": kw_zero,
+        "keyword_arm_zero_result_count": len(kw_zero),
+        "keyword_arm_zero_result_rate": round(len(kw_zero) / len(ok), 6) if ok else 0.0,
+        "final_zero_result_count": sum(1 for obs in ok if obs.result_count == 0),
+        "cases_run": len(observations),
+        "cases_ok": len(ok),
+        "cases_failed": len(observations) - len(ok),
+        "failures": [
+            {"case": obs_key(obs.query_id, obs.bank), "error": obs.error}
+            for obs in observations
+            if not obs.ok
+        ],
+        # Diagnostics only. NOT a latency measurement: this suite runs on a box
+        # that also serves the live fleet and it makes no attempt to isolate.
+        "timings_not_a_measurement": {
+            "note": "diagnostic only, box is not isolated, never quote as latency",
+            "elapsed_ms_min": min((o.elapsed_ms for o in ok if o.elapsed_ms), default=None),
+            "elapsed_ms_max": max((o.elapsed_ms for o in ok if o.elapsed_ms), default=None),
+        },
+    }
+
+
+def engine_identity(client: HindsightRecallClient) -> dict[str, object]:
+    """Whatever the instance will tell us about itself, for the result header.
+
+    #4479 item 5 and #4475 AC2 both say the same thing in different words: a
+    result without its configuration is not a result.
+    """
+    ident: dict[str, object] = {"api_url": client.base_url}
+    try:
+        ident["version"] = client.version()
+    except Exception as exc:  # noqa: BLE001
+        ident["version_error"] = f"{type(exc).__name__}: {exc}"
+    try:
+        ident["health"] = client.health()
+    except Exception as exc:  # noqa: BLE001
+        ident["health_error"] = f"{type(exc).__name__}: {exc}"
+    return ident
+
+
+def redact_bank(bank: str, redact: bool) -> str:
+    """Stable pseudonym for a bank name.
+
+    Bank ids are the operator's agent names. They are not secrets, but this
+    repository is public and a committed baseline should not enumerate a
+    private fleet, so the default is on. `--no-redact-banks` prints them for
+    local debugging.
+    """
+    if not redact:
+        return bank
+    return "bank-" + hashlib.sha256(bank.encode()).hexdigest()[:8]
+
+
+def build_result(
+    args: argparse.Namespace,
+    qs: QuerySet,
+    banks: Sequence[str],
+    observations: Sequence[RecallObservation],
+    qrels: Mapping[str, Mapping[str, int]],
+    ident: Mapping[str, object],
+) -> dict[str, object]:
+    alias = {bank: redact_bank(bank, args.redact_banks) for bank in banks}
+    renamed: list[RecallObservation] = []
+    for obs in observations:
+        obs.bank = alias.get(obs.bank, obs.bank)
+        renamed.append(obs)
+
+    body = score(renamed, qrels)
+    body.update(
+        {
+            "schema_version": 1,
+            "kind": "hindsight-recall-quality",
+            "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "config": {
+                "queryset_id": qs.queryset_id,
+                "queryset_version": qs.queryset_version,
+                "queryset_case_count": len(qs.cases),
+                "queryset_sha256": qs.sha256,
+                "banks": [alias[b] for b in banks],
+                "banks_redacted": args.redact_banks,
+                "backend_declared": args.backend,
+                "budget": args.budget,
+                "max_tokens": args.max_tokens,
+                "ablated_arms": list(args.ablate_arm or []),
+                "limit": args.limit,
+                "families": args.families,
+                "qrels_file": str(args.qrels) if args.qrels else None,
+                "qrels_query_count": len(qrels),
+                "pace_ms": args.pace_ms,
+            },
+            "engine": ident,
+        }
+    )
+    return body
+
+
+# ────────────────────────── reporting ──────────────────────────
+
+
+def human_summary(result: Mapping[str, object]) -> str:
+    cfg = result.get("config") or {}
+    lines: list[str] = []
+    lines.append("Hindsight recall quality")
+    lines.append(
+        f"  query set     {cfg.get('queryset_id')} {cfg.get('queryset_version')} "
+        f"({cfg.get('queryset_case_count')} cases, sha256 {str(cfg.get('queryset_sha256'))[:12]})"
+    )
+    lines.append(f"  banks         {', '.join(cfg.get('banks') or [])}")
+    lines.append(f"  backend       {cfg.get('backend_declared')}")
+    engine = result.get("engine") or {}
+    version = (engine.get("version") or {}) if isinstance(engine, dict) else {}
+    lines.append(f"  engine        api_version={version.get('api_version')} at {engine.get('api_url')}")
+    if cfg.get("ablated_arms"):
+        lines.append(f"  ABLATED ARMS  {', '.join(cfg['ablated_arms'])}  (degraded configuration)")
+    lines.append("")
+    lines.append(
+        f"  cases run {result.get('cases_run')}  ok {result.get('cases_ok')}  "
+        f"failed {result.get('cases_failed')}"
+    )
+    lines.append(
+        f"  keyword arm zero-result: {result.get('keyword_arm_zero_result_count')}"
+        f"/{result.get('cases_ok')} "
+        f"({float(result.get('keyword_arm_zero_result_rate') or 0) * 100:.1f}%)"
+    )
+    lines.append(f"  final zero-result:       {result.get('final_zero_result_count')}")
+    stages = result.get("stages") or {}
+    if stages:
+        lines.append("")
+        lines.append("  stage            recall@10 recall@50   ndcg@10       mrr  judged")
+        for stage in metrics.STAGES:
+            row = stages.get(stage)
+            if not row:
+                continue
+            lines.append(
+                f"  {stage:<16}"
+                f"{row.get('recall@10', 0):>9.4f} {row.get('recall@50', 0):>9.4f} "
+                f"{row.get('ndcg@10', 0):>9.4f} {row.get('mrr', 0):>9.4f} "
+                f"{int(row.get('judged_cases', 0)):>7}"
+            )
+    else:
+        lines.append("")
+        lines.append(
+            "  no graded metrics: no qrels matched. Label-free metrics above are still valid."
+        )
+    lines.append("")
+    lines.append("  timings in this file are diagnostics, not a latency measurement.")
+    return "\n".join(lines)
+
+
+# ────────────────────────── modes ──────────────────────────
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    qs = load_queryset(args.queryset)
+    if args.families:
+        qs = qs.filtered(families=args.families.split(","))
+    if args.limit:
+        qs = qs.limited(args.limit, seed=args.seed)
+    banks = [b.strip() for b in args.banks.split(",") if b.strip()]
+    if not banks:
+        print("error: --banks is required and must name at least one bank", file=sys.stderr)
+        return EXIT_USAGE
+
+    qrels = load_qrels(args.qrels) if args.qrels else {}
+    client = HindsightRecallClient(
+        args.api_url, token=args.api_token, timeout_s=args.timeout_s, pace_ms=args.pace_ms
+    )
+    ident = engine_identity(client)
+
+    runs: list[dict[str, object]] = []
+    for attempt in range(args.runs):
+        if args.runs > 1:
+            print(f"run {attempt + 1}/{args.runs}", file=sys.stderr)
+        observations = run_suite(
+            client,
+            qs,
+            banks,
+            ablate_arms=args.ablate_arm or [],
+            budget=args.budget,
+            max_tokens=args.max_tokens,
+            progress=not args.quiet,
+        )
+        runs.append(build_result(args, qs, banks, observations, qrels, ident))
+
+    result = runs[-1]
+    if args.runs > 1:
+        result["determinism"] = metrics.variance_report(runs)
+        result["determinism"]["budget"] = args.determinism_budget
+        result["determinism"]["within_budget"] = (
+            result["determinism"]["worst_spread"] <= args.determinism_budget
+        )
+        # Label-free metrics have their own stability question: the keyword arm
+        # returning rows for a query is the thing the headline metric counts, so
+        # a run where that set moves is a run whose headline number moved.
+        zero_sets = [set(r.get("keyword_arm_zero_result_ids") or []) for r in runs]
+        union = set().union(*zero_sets)
+        stable = set.intersection(*zero_sets) if zero_sets else set()
+        result["determinism"]["keyword_zero_set_unstable_ids"] = sorted(union - stable)
+        result["determinism"]["keyword_zero_set_jaccard"] = (
+            round(len(stable) / len(union), 6) if union else 1.0
+        )
+
+    if args.min_judged_coverage > 0:
+        gate = (result.get("stages") or {}).get(args.gate_stage) or {}
+        coverage = gate.get("judged_coverage@10")
+        if coverage is not None and coverage < args.min_judged_coverage:
+            print(
+                f"error: judged coverage {coverage:.4f} at stage {args.gate_stage} is under "
+                f"--min-judged-coverage {args.min_judged_coverage:.4f}. The qrels file has "
+                "most likely gone stale against a bank that has since consolidated.",
+                file=sys.stderr,
+            )
+            write_out(args.out, result)
+            print(human_summary(result))
+            return EXIT_REGRESSION
+
+    write_out(args.out, result)
+    print(human_summary(result))
+    if args.runs > 1:
+        det = result["determinism"]
+        print(
+            f"\n  determinism over {det['runs']} runs: worst spread {det['worst_spread']:.6f} "
+            f"on {det['worst_metric']} (budget {args.determinism_budget})"
+        )
+        if not det["within_budget"]:
+            print("  determinism budget EXCEEDED", file=sys.stderr)
+            return EXIT_REGRESSION
+    # Across ALL runs, not just the one whose scores are reported: with
+    # `--runs N` the reported block is the last run, and failures in an earlier
+    # run are exactly as disqualifying.
+    failed = sum(int(r.get("cases_failed") or 0) for r in runs)
+    if failed and args.fail_on_error:
+        print(f"\n  {failed} case(s) errored across {len(runs)} run(s)", file=sys.stderr)
+        return EXIT_REGRESSION
+    return EXIT_OK
+
+
+def cmd_compare(args: argparse.Namespace) -> int:
+    baseline = json.loads(Path(args.baseline).read_text())
+    candidate = json.loads(Path(args.candidate).read_text())
+
+    gate_stage = args.gate_stage
+    if gate_stage not in (candidate.get("stages") or {}):
+        # An ablated run has no post-fusion stages by construction, so fall back
+        # to the stage both runs actually have rather than failing on a
+        # technicality and hiding a real regression.
+        for fallback in ("rrf_client", "arm:bm25"):
+            if fallback in (candidate.get("stages") or {}) and fallback in (
+                baseline.get("stages") or {}
+            ):
+                gate_stage = fallback
+                break
+
+    verdict = metrics.compare(
+        baseline,
+        candidate,
+        max_recall10_drop=args.max_recall10_drop,
+        max_zero_result_regressions=args.max_zero_result_regressions,
+        gate_stage=gate_stage,
+    )
+    zero = metrics.zero_result_metric(
+        baseline.get("keyword_arm_row_counts") or {},
+        candidate.get("keyword_arm_row_counts") or {},
+    )
+    report = {
+        "schema_version": 1,
+        "kind": "hindsight-recall-quality-compare",
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "baseline": {
+            "file": str(args.baseline),
+            "config": baseline.get("config"),
+            "engine": baseline.get("engine"),
+        },
+        "candidate": {
+            "file": str(args.candidate),
+            "config": candidate.get("config"),
+            "engine": candidate.get("engine"),
+        },
+        "headline": zero,
+        "verdict": verdict,
+    }
+    write_out(args.out, report)
+
+    print("Recall quality comparison")
+    print(f"  baseline   {args.baseline}")
+    print(f"  candidate  {args.candidate}")
+    print(f"  gate stage {verdict['gate_stage']}")
+    print("")
+    print(
+        f"  HEADLINE zero_result_queries_answered/total: "
+        f"{zero['zero_result_queries_answered']}/{zero['zero_result_queries_total']} "
+        f"({zero['zero_result_answer_rate'] * 100:.1f}%)"
+    )
+    if zero["zero_result_unevaluated_ids"]:
+        print(
+            f"  {len(zero['zero_result_unevaluated_ids'])} zero-result queries were not "
+            "evaluated by the candidate and are counted as not answered"
+        )
+    b10, c10 = verdict["recall@10_baseline"], verdict["recall@10_candidate"]
+    if b10 is not None and c10 is not None:
+        print(f"  recall@10  {b10:.4f} -> {c10:.4f}  (drop {verdict['recall@10_drop']:+.4f})")
+    print(f"  keyword-zero regressions: {len(verdict['zero_result_regressions'])}")
+    print("")
+    if verdict["ok"]:
+        print("  PASS: within budget")
+        return EXIT_OK
+    print("  FAIL:")
+    for finding in verdict["findings"]:
+        print(f"    - {finding}")
+    return EXIT_REGRESSION
+
+
+def write_out(out: str | None, payload: Mapping[str, object]) -> None:
+    if not out:
+        return
+    path = Path(out)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    print(f"wrote {path}", file=sys.stderr)
+
+
+# ────────────────────────── cli ──────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="run_recall_quality.py",
+        description="Hindsight recall-quality eval (issue #4479)",
+    )
+    sub = parser.add_subparsers(dest="mode", required=True)
+
+    run = sub.add_parser("run", help="run the suite against a live instance and score it")
+    run.add_argument("--queryset", default=str(DEFAULT_QUERYSET))
+    run.add_argument("--qrels", default=None, help="relevance judgements (ids only); see qrels/README.md")
+    run.add_argument("--banks", required=True, help="comma-separated bank ids")
+    run.add_argument("--api-url", default=DEFAULT_API_URL)
+    run.add_argument("--api-token", default=os.environ.get("HINDSIGHT_API_TOKEN"))
+    run.add_argument("--backend", default="unknown", help="backend label recorded in the result file")
+    run.add_argument("--budget", default="low", choices=["low", "medium", "high"])
+    run.add_argument("--max-tokens", type=int, default=4096)
+    run.add_argument("--timeout-s", type=float, default=60.0)
+    run.add_argument("--pace-ms", type=int, default=0, help="minimum gap between recall calls")
+    run.add_argument("--limit", type=int, default=0, help="run a deterministic subset of N cases")
+    run.add_argument("--families", default=None, help="comma-separated family filter")
+    run.add_argument("--seed", type=int, default=0, help="subset selection seed (deterministic)")
+    run.add_argument("--runs", type=int, default=1, help="repeat and report run-to-run spread")
+    run.add_argument("--determinism-budget", type=float, default=0.01)
+    run.add_argument("--gate-stage", default="final")
+    run.add_argument("--min-judged-coverage", type=float, default=0.0)
+    # Fail-CLOSED by default. Every metric here is a ratio whose denominator is
+    # the set of cases that succeeded, so a run where 27 of 28 cases errored
+    # would otherwise exit 0 and report a confident-looking score over the one
+    # that worked. A quality gate that reports a number after the system fell
+    # over is worse than one that reports nothing.
+    run.add_argument(
+        "--no-fail-on-error",
+        dest="fail_on_error",
+        action="store_false",
+        help="exit 0 even when cases errored (default: any errored case exits non-zero)",
+    )
+    run.add_argument(
+        "--ablate-arm",
+        action="append",
+        choices=list(metrics.ARMS),
+        help="remove an arm from client-side fusion (degraded configuration)",
+    )
+    run.add_argument(
+        "--disable-keyword-arm",
+        dest="ablate_arm",
+        action="append_const",
+        const="bm25",
+        help="alias for --ablate-arm bm25 (the #4479 AC1 vacuity check)",
+    )
+    run.add_argument("--no-redact-banks", dest="redact_banks", action="store_false")
+    run.add_argument("--quiet", action="store_true")
+    run.add_argument("--out", default=None)
+    run.set_defaults(func=cmd_run, redact_banks=True, fail_on_error=True)
+
+    cmp_ = sub.add_parser("compare", help="grade a candidate result file against a baseline")
+    cmp_.add_argument("baseline")
+    cmp_.add_argument("candidate")
+    cmp_.add_argument("--max-recall10-drop", type=float, default=0.02)
+    cmp_.add_argument("--max-zero-result-regressions", type=int, default=0)
+    cmp_.add_argument("--gate-stage", default="final")
+    cmp_.add_argument("--out", default=None)
+    cmp_.set_defaults(func=cmd_compare)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/recall/run_recall_quality.py
+++ b/evals/recall/run_recall_quality.py
@@ -53,6 +53,10 @@ DEFAULT_API_URL = os.environ.get("HINDSIGHT_API_URL", "http://127.0.0.1:18888")
 EXIT_OK = 0
 EXIT_REGRESSION = 1
 EXIT_USAGE = 2
+# Distinct from EXIT_REGRESSION on purpose: "the candidate is measurably worse"
+# and "no budget could be evaluated" are different claims, and CI should be able
+# to tell them apart. Both are non-zero -- neither is a pass.
+EXIT_UNGRADED = 3
 
 
 # ────────────────────────── running ──────────────────────────
@@ -489,10 +493,24 @@ def cmd_compare(args: argparse.Namespace) -> int:
     if verdict["ok"]:
         print("  PASS: within budget")
         return EXIT_OK
-    print("  FAIL:")
-    for finding in verdict["findings"]:
+
+    # A measured regression and an un-evaluable budget both block, but they are
+    # not the same claim and must not share an exit code. With no qrels
+    # committed every compare is `ungraded` -- including a file against itself --
+    # so a single non-zero code would be evidence of nothing.
+    if verdict["regressions"]:
+        print("  FAIL (measured regression):")
+        for finding in verdict["regressions"]:
+            print(f"    - {finding}")
+        for finding in verdict["ungraded"]:
+            print(f"    - (also ungraded) {finding}")
+        return EXIT_REGRESSION
+
+    print("  BLOCKED (cannot certify -- nothing was graded):")
+    for finding in verdict["ungraded"]:
         print(f"    - {finding}")
-    return EXIT_REGRESSION
+    print("    no measured regression was found; this is not a pass either")
+    return EXIT_UNGRADED
 
 
 def write_out(out: str | None, payload: Mapping[str, object]) -> None:

--- a/evals/recall/test_recall_quality.py
+++ b/evals/recall/test_recall_quality.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Unit tests for the recall-quality scorer (#4479).
+
+These run in CI with no network and no database. They assert **outcomes**: that
+each metric moves the way a real regression would move it, and above all that
+the regression gate actually fails on a degraded configuration. A gate nobody
+has watched go red is decoration.
+
+Run: `python3 -m unittest discover -s evals/recall -p 'test_*.py' -t .`
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import sys
+import unittest
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from evals.recall import metrics  # noqa: E402
+from evals.recall.client import parse_observation  # noqa: E402
+from evals.recall.queryset import load_queryset  # noqa: E402
+from evals.recall import run_recall_quality as runner  # noqa: E402
+from evals.recall.run_recall_quality import apply_ablation, score  # noqa: E402
+
+HERE = Path(__file__).resolve().parent
+QUERYSET = HERE / "queryset" / "v1.yaml"
+REPO_ROOT = HERE.parent.parent
+
+
+class IRMetrics(unittest.TestCase):
+    def test_recall_at_k_counts_only_the_top_k(self):
+        ranked = ["a", "b", "c", "d"]
+        relevant = {"a": 1, "d": 1}
+        self.assertEqual(metrics.recall_at_k(ranked, relevant, 2), 0.5)
+        self.assertEqual(metrics.recall_at_k(ranked, relevant, 4), 1.0)
+
+    def test_recall_is_zero_not_one_when_nothing_is_judged_relevant(self):
+        # The fail-open shape (no positives -> perfect score) would let an
+        # unjudged query inflate the macro average, which is exactly how a
+        # suite goes quietly vacuous.
+        self.assertEqual(metrics.recall_at_k(["a"], {"b": 0}, 10), 0.0)
+
+    def test_ndcg_rewards_putting_the_better_document_first(self):
+        good = metrics.ndcg_at_k(["a", "b"], {"a": 3, "b": 1}, 10)
+        bad = metrics.ndcg_at_k(["b", "a"], {"a": 3, "b": 1}, 10)
+        self.assertEqual(good, 1.0)
+        self.assertLess(bad, good)
+
+    def test_mrr_is_the_reciprocal_of_the_first_hit(self):
+        self.assertEqual(metrics.reciprocal_rank(["x", "y", "a"], {"a": 1}), 1 / 3)
+        self.assertEqual(metrics.reciprocal_rank(["x"], {"a": 1}), 0.0)
+
+    def test_judged_coverage_sees_label_rot(self):
+        # Every returned id unjudged is what a stale qrels file looks like after
+        # consolidation rewrites the bank.
+        self.assertEqual(metrics.judged_coverage(["p", "q"], {"a": 1}, 10), 0.0)
+        self.assertEqual(metrics.judged_coverage(["a", "q"], {"a": 1}, 10), 0.5)
+
+
+class Fusion(unittest.TestCase):
+    def test_rrf_matches_the_engine_formula(self):
+        # score(d) = sum 1/(k + rank); engine/search/fusion.py:29, k=60.
+        fused = metrics.rrf_fuse({"semantic": ["a", "b"], "bm25": ["b", "a"]})
+        self.assertEqual(sorted(fused), ["a", "b"])
+        # "c" is rank 1 in one arm only; "a" is rank 2 in both. 1/61 < 2/62.
+        fused2 = metrics.rrf_fuse({"semantic": ["x", "a"], "bm25": ["c", "a"]})
+        self.assertLess(fused2.index("a"), fused2.index("c"))
+
+    def test_rrf_is_deterministic_under_ties(self):
+        arms = {"semantic": ["a", "b", "c"], "bm25": ["a", "b", "c"]}
+        self.assertEqual(metrics.rrf_fuse(arms), metrics.rrf_fuse(arms))
+
+    def test_dropping_an_arm_changes_the_fused_ranking(self):
+        arms = {"semantic": ["s1", "s2"], "bm25": ["k1", "k2"]}
+        full = metrics.rrf_fuse(arms)
+        without = metrics.rrf_fuse({"semantic": arms["semantic"]})
+        self.assertIn("k1", full)
+        self.assertNotIn("k1", without)
+
+    def test_pool_by_best_rank_keeps_the_better_rank(self):
+        pooled = metrics.pool_by_best_rank([["a", "b"], ["b", "c"]])
+        self.assertEqual(pooled[0], "a")
+        self.assertIn("b", pooled)
+        self.assertIn("c", pooled)
+
+
+class HeadlineMetric(unittest.TestCase):
+    def test_subset_comes_from_the_reference_and_answers_from_the_candidate(self):
+        out = metrics.zero_result_metric({"q1": 0, "q2": 5, "q3": 0}, {"q1": 4, "q2": 5, "q3": 0})
+        self.assertEqual(out["zero_result_queries_total"], 2)
+        self.assertEqual(out["zero_result_queries_answered"], 1)
+        self.assertEqual(out["zero_result_answer_rate"], 0.5)
+
+    def test_a_query_the_candidate_never_ran_counts_as_unanswered(self):
+        out = metrics.zero_result_metric({"q1": 0, "q2": 0}, {"q1": 3})
+        self.assertEqual(out["zero_result_queries_answered"], 1)
+        self.assertEqual(out["zero_result_unevaluated_ids"], ["q2"])
+
+    def test_no_zero_result_queries_is_a_zero_rate_not_a_crash(self):
+        out = metrics.zero_result_metric({"q1": 3}, {"q1": 3})
+        self.assertEqual(out["zero_result_queries_total"], 0)
+        self.assertEqual(out["zero_result_answer_rate"], 0.0)
+
+
+class RegressionGate(unittest.TestCase):
+    """AC1 in miniature: the gate must go red on a degraded configuration."""
+
+    BASE = {
+        "stages": {"final": {"recall@10": 0.80, "ndcg@10": 0.7}},
+        "keyword_arm_row_counts": {"q1": 10, "q2": 8, "q3": 0},
+    }
+
+    def test_passes_an_identical_run(self):
+        verdict = metrics.compare(self.BASE, self.BASE)
+        self.assertTrue(verdict["ok"], verdict["findings"])
+
+    def test_fails_when_recall_drops_past_the_budget(self):
+        worse = {
+            "stages": {"final": {"recall@10": 0.70}},
+            "keyword_arm_row_counts": self.BASE["keyword_arm_row_counts"],
+        }
+        verdict = metrics.compare(self.BASE, worse, max_recall10_drop=0.02)
+        self.assertFalse(verdict["ok"])
+        self.assertIn("recall@10", verdict["findings"][0])
+
+    def test_a_drop_exactly_at_the_budget_passes(self):
+        edge = {
+            "stages": {"final": {"recall@10": 0.78}},
+            "keyword_arm_row_counts": self.BASE["keyword_arm_row_counts"],
+        }
+        self.assertTrue(metrics.compare(self.BASE, edge, max_recall10_drop=0.02)["ok"])
+
+    def test_fails_when_the_keyword_arm_goes_zero_on_a_query_it_answered(self):
+        # This is the tokenizer-silently-reverts-to-unstemmed guard (risk C1).
+        reverted = {
+            "stages": {"final": {"recall@10": 0.80}},
+            "keyword_arm_row_counts": {"q1": 0, "q2": 8, "q3": 0},
+        }
+        verdict = metrics.compare(self.BASE, reverted)
+        self.assertFalse(verdict["ok"])
+        self.assertEqual(verdict["zero_result_regressions"], ["q1"])
+
+    def test_a_missing_stage_is_a_failure_not_a_pass(self):
+        verdict = metrics.compare(self.BASE, {"stages": {}, "keyword_arm_row_counts": {}})
+        self.assertFalse(verdict["ok"])
+        self.assertIn("cannot grade", verdict["findings"][0])
+
+
+class Ablation(unittest.TestCase):
+    """The non-vacuity mechanism, end to end over a synthetic trace."""
+
+    @staticmethod
+    def _raw():
+        def arm(method, fact_type, ids):
+            return {
+                "method_name": method,
+                "fact_type": fact_type,
+                "duration_seconds": 0.0,
+                "results": [
+                    {"rank": i + 1, "node_id": n, "text": "", "score": 1.0, "score_name": "s"}
+                    for i, n in enumerate(ids)
+                ],
+            }
+
+        return {
+            "results": [{"id": "t1"}, {"id": "s1"}],
+            "trace": {
+                "retrieval_results": [
+                    arm("semantic", "world", ["s1", "s2"]),
+                    arm("bm25", "world", ["t1", "t2"]),
+                    arm("graph", "world", ["g1"]),
+                ],
+                "rrf_merged": [{"node_id": n} for n in ["t1", "s1", "t2", "s2", "g1"]],
+                "reranked": [{"node_id": n} for n in ["t1", "s1"]],
+            },
+        }
+
+    def test_parse_extracts_every_stage(self):
+        obs = parse_observation("q1", "b", self._raw())
+        self.assertEqual(obs.arms["bm25"], ["t1", "t2"])
+        self.assertEqual(obs.stages["arm:semantic"], ["s1", "s2"])
+        self.assertEqual(obs.stages["rerank"], ["t1", "s1"])
+        self.assertEqual(obs.stages["final"], ["t1", "s1"])
+        self.assertIn("t1", obs.stages["rrf_client"])
+
+    def test_parse_keeps_no_memory_text(self):
+        # The repo is public and the banks are private: ids only, always.
+        obs = parse_observation("q1", "b", self._raw())
+        flat = repr(obs)
+        for stage_ids in obs.stages.values():
+            for doc in stage_ids:
+                self.assertRegex(doc, r"^[a-zA-Z0-9_-]+$")
+        self.assertNotIn("text", flat)
+
+    def test_ablating_the_keyword_arm_removes_its_documents(self):
+        obs = parse_observation("q1", "b", self._raw())
+        apply_ablation(obs, ["bm25"])
+        self.assertEqual(obs.arms["bm25"], [])
+        self.assertNotIn("t1", obs.stages["rrf_client"])
+        self.assertNotIn("t2", obs.stages["rrf_client"])
+        self.assertIn("s1", obs.stages["rrf_client"])
+
+    def test_ablation_drops_stages_it_cannot_honestly_recompute(self):
+        obs = parse_observation("q1", "b", self._raw())
+        apply_ablation(obs, ["bm25"])
+        for stage in ("rrf_engine", "rerank", "final"):
+            self.assertNotIn(stage, obs.stages)
+
+    def test_ablated_run_scores_worse_and_the_gate_goes_red(self):
+        """The AC1 proof in unit form, with no live instance involved."""
+        qrels = {"q1": {"t1": 3, "t2": 2}}
+        full = parse_observation("q1", "b", self._raw())
+        degraded = parse_observation("q1", "b", self._raw())
+        apply_ablation(degraded, ["bm25"])
+
+        baseline = score([full], qrels)
+        candidate = score([degraded], qrels)
+
+        stage = "rrf_client"
+        self.assertGreater(
+            baseline["stages"][stage]["recall@10"],
+            candidate["stages"][stage]["recall@10"],
+        )
+        verdict = metrics.compare(baseline, candidate, gate_stage=stage)
+        self.assertFalse(verdict["ok"], "ablated run must fail the gate")
+        self.assertTrue(any("recall@10" in f for f in verdict["findings"]))
+        self.assertEqual(verdict["zero_result_regressions"], ["q1@b"])
+
+
+class Variance(unittest.TestCase):
+    def test_identical_runs_report_zero_spread(self):
+        run = {"stages": {"final": {"recall@10": 0.5}}}
+        report = metrics.variance_report([run, run])
+        self.assertEqual(report["worst_spread"], 0.0)
+
+    def test_spread_is_absolute_and_names_the_worst_metric(self):
+        report = metrics.variance_report(
+            [
+                {"stages": {"final": {"recall@10": 0.50, "mrr": 0.90}}},
+                {"stages": {"final": {"recall@10": 0.53, "mrr": 0.91}}},
+            ]
+        )
+        self.assertAlmostEqual(report["worst_spread"], 0.03, places=6)
+        self.assertEqual(report["worst_metric"], "final/recall@10")
+
+    def test_a_single_run_cannot_claim_determinism(self):
+        self.assertEqual(metrics.variance_report([{"stages": {}}])["runs"], 1)
+
+
+class ScoreBlock(unittest.TestCase):
+    def test_unjudged_cases_are_excluded_from_graded_metrics_but_not_from_label_free_ones(self):
+        judged = parse_observation("q1", "b", Ablation._raw())
+        unjudged = parse_observation("q9", "b", Ablation._raw())
+        block = score([judged, unjudged], {"q1": {"t1": 1}})
+        self.assertEqual(block["stages"]["final"]["judged_cases"], 1)
+        self.assertEqual(block["cases_ok"], 2)
+        self.assertEqual(len(block["keyword_arm_row_counts"]), 2)
+
+    def test_keyword_zero_rate_is_label_free(self):
+        empty = parse_observation("q2", "b", {"results": [], "trace": {}})
+        block = score([empty], {})
+        self.assertEqual(block["keyword_arm_zero_result_count"], 1)
+        self.assertEqual(block["keyword_arm_zero_result_rate"], 1.0)
+
+
+class FailClosed(unittest.TestCase):
+    """A run whose cases errored must not report a confident score.
+
+    Every metric here is a ratio over the cases that SUCCEEDED, so a run where
+    most cases errored would otherwise exit 0 with a clean-looking number
+    computed over the handful that worked.
+    """
+
+    def _args(self, argv):
+        return runner.build_parser().parse_args(argv)
+
+    def _run_with(self, argv, observations):
+        args = self._args(argv)
+        real_client, real_suite, real_ident = (
+            runner.HindsightRecallClient,
+            runner.run_suite,
+            runner.engine_identity,
+        )
+        runner.HindsightRecallClient = lambda *a, **kw: object()
+        runner.run_suite = lambda *a, **kw: observations
+        runner.engine_identity = lambda client: {"api_url": "test"}
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                return runner.cmd_run(args)
+        finally:
+            runner.HindsightRecallClient = real_client
+            runner.run_suite = real_suite
+            runner.engine_identity = real_ident
+
+    def test_an_errored_case_exits_non_zero_by_default(self):
+        ok = parse_observation("q1", "b", Ablation._raw())
+        broken = parse_observation("q2", "b", Ablation._raw())
+        broken.ok = False
+        broken.error = "timeout"
+        code = self._run_with(["run", "--banks", "b", "--quiet"], [ok, broken])
+        self.assertEqual(code, runner.EXIT_REGRESSION)
+
+    def test_the_escape_hatch_is_explicit(self):
+        ok = parse_observation("q1", "b", Ablation._raw())
+        broken = parse_observation("q2", "b", Ablation._raw())
+        broken.ok = False
+        broken.error = "timeout"
+        code = self._run_with(
+            ["run", "--banks", "b", "--quiet", "--no-fail-on-error"], [ok, broken]
+        )
+        self.assertEqual(code, runner.EXIT_OK)
+
+    def test_a_clean_run_still_passes(self):
+        ok = parse_observation("q1", "b", Ablation._raw())
+        self.assertEqual(self._run_with(["run", "--banks", "b", "--quiet"], [ok]), runner.EXIT_OK)
+
+
+class QuerySetAsset(unittest.TestCase):
+    def test_committed_query_set_meets_the_issue_scope(self):
+        qs = load_queryset(QUERYSET)
+        self.assertGreaterEqual(len(qs.cases), 100)
+        self.assertTrue(qs.provenance.get("method"))
+
+    def test_limit_is_deterministic_and_family_balanced(self):
+        qs = load_queryset(QUERYSET)
+        a = [c.id for c in qs.limited(21, seed=7).cases]
+        b = [c.id for c in qs.limited(21, seed=7).cases]
+        self.assertEqual(a, b)
+        self.assertNotEqual(a, [c.id for c in qs.limited(21, seed=8).cases])
+        families = {c.family for c in qs.limited(21, seed=7).cases}
+        self.assertEqual(families, set(qs.families))
+
+    def test_zero_result_probes_are_built_only_from_discarded_lexemes(self):
+        """The headline metric's denominator is a function of the stop file.
+
+        The native keyword arm ORs its tokens (engine/sql/postgresql.py:228-234,
+        hindsight v0.8.6), so on a populated bank a merely rare phrase still
+        matches something. It returns zero rows when the query reduces to an
+        EMPTY tsquery — which happens only when every token is discarded by the
+        deployed `hindsight_english` regconfig, whose extra stopwords live in
+        `docker/hindsight-extra.stop`.
+
+        Confirmed live before this test was written: all 20 cases below scored
+        `kw=0`, while nine of ten ordinary-function-word queries scored 172-300.
+
+        So this couples the query set to that file on purpose. Editing the stop
+        file changes which queries can score zero, i.e. changes the denominator
+        of a number people are meant to trust; this makes that a visible CI
+        failure rather than a silent drift.
+        """
+        stop_path = REPO_ROOT / "docker" / "hindsight-extra.stop"
+        self.assertTrue(stop_path.exists(), f"{stop_path} is missing")
+        stop = {
+            line.strip().lower()
+            for line in stop_path.read_text().splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        }
+        self.assertIn(
+            "switchroom", stop, "stop file is not the boilerplate list this test expects"
+        )
+
+        def discarded(token: str) -> bool:
+            # PostgreSQL's default parser emits a hyphenated word as the whole
+            # compound AND its parts, so every piece must be discarded too.
+            if token in stop:
+                return True
+            parts = [p for p in token.split("-") if p]
+            return len(parts) > 1 and all(p in stop for p in parts)
+
+        qs = load_queryset(QUERYSET)
+        probes = [c for c in qs.cases if c.family == "zero-result-probe"]
+        self.assertGreaterEqual(len(probes), 15)
+        offenders = {
+            case.id: sorted(t for t in case.text.lower().split() if not discarded(t))
+            for case in probes
+        }
+        offenders = {cid: toks for cid, toks in offenders.items() if toks}
+        self.assertEqual(
+            offenders,
+            {},
+            "these zero-result-probe cases contain lexemes the deployed regconfig "
+            "KEEPS, so they will not drive the keyword arm to zero and do not belong "
+            "in this family. Move them to rare-term, or extend the stop file "
+            "deliberately",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/evals/recall/test_recall_quality.py
+++ b/evals/recall/test_recall_quality.py
@@ -147,7 +147,33 @@ class RegressionGate(unittest.TestCase):
     def test_a_missing_stage_is_a_failure_not_a_pass(self):
         verdict = metrics.compare(self.BASE, {"stages": {}, "keyword_arm_row_counts": {}})
         self.assertFalse(verdict["ok"])
-        self.assertIn("cannot grade", verdict["findings"][0])
+        self.assertTrue(any("cannot grade" in f for f in verdict["ungraded"]))
+
+    # -- the gate must DISCRIMINATE, not merely go red -------------------------
+    #
+    # With no qrels committed there is no recall@10 on either side, so every
+    # unjudged compare is un-gradeable -- including a run against itself. If
+    # "measurably worse" and "could not be measured" shared one verdict, a red
+    # result on a degraded config would be evidence of nothing at all.
+
+    def test_an_unjudged_run_against_itself_is_ungraded_not_a_regression(self):
+        unjudged = {"stages": {}, "keyword_arm_row_counts": {"q1": 10}}
+        verdict = metrics.compare(unjudged, unjudged)
+        self.assertEqual(verdict["verdict"], "ungraded")
+        self.assertFalse(verdict["ok"])
+        self.assertEqual(verdict["regressions"], [])
+        self.assertTrue(verdict["ungraded"])
+
+    def test_an_unjudged_degraded_run_is_still_a_measured_regression(self):
+        unjudged = {"stages": {}, "keyword_arm_row_counts": {"q1": 10, "q2": 8}}
+        ablated = {"stages": {}, "keyword_arm_row_counts": {"q1": 0, "q2": 0}}
+        verdict = metrics.compare(unjudged, ablated)
+        self.assertEqual(verdict["verdict"], "regression")
+        self.assertEqual(verdict["zero_result_regressions"], ["q1", "q2"])
+
+    def test_the_two_verdicts_do_not_share_an_exit_code(self):
+        self.assertNotEqual(runner.EXIT_UNGRADED, runner.EXIT_REGRESSION)
+        self.assertNotEqual(runner.EXIT_UNGRADED, runner.EXIT_OK)
 
 
 class Ablation(unittest.TestCase):

--- a/evals/recall/test_recall_quality.py
+++ b/evals/recall/test_recall_quality.py
@@ -236,6 +236,7 @@ class Variance(unittest.TestCase):
         run = {"stages": {"final": {"recall@10": 0.5}}}
         report = metrics.variance_report([run, run])
         self.assertEqual(report["worst_spread"], 0.0)
+        self.assertTrue(report["measured"])
 
     def test_spread_is_absolute_and_names_the_worst_metric(self):
         report = metrics.variance_report(
@@ -248,7 +249,53 @@ class Variance(unittest.TestCase):
         self.assertEqual(report["worst_metric"], "final/recall@10")
 
     def test_a_single_run_cannot_claim_determinism(self):
-        self.assertEqual(metrics.variance_report([{"stages": {}}])["runs"], 1)
+        report = metrics.variance_report([{"stages": {}}])
+        self.assertEqual(report["runs"], 1)
+        self.assertFalse(report["measured"])
+        self.assertIsNone(report["worst_spread"])
+
+    def test_comparing_nothing_is_not_perfect_determinism(self):
+        """The AC3 analogue of the fail-open scorer.
+
+        A run with no qrels has no graded metrics. If variance only ever looked
+        at those, it would report a spread of 0.0 and read as 'identical scores
+        across runs' while having compared nothing at all.
+        """
+        report = metrics.variance_report([{"stages": {}}, {"stages": {}}])
+        self.assertFalse(report["measured"])
+        self.assertEqual(report["metrics_compared"], 0)
+        self.assertIsNone(report["worst_spread"])
+
+    def test_label_free_runs_are_still_measured(self):
+        runs = [
+            {
+                "stages": {},
+                "keyword_arm_zero_result_rate": 0.10,
+                "keyword_arm_row_counts": {"q1@b": 300, "q2@b": 0},
+                "semantic_arm_row_counts": {"q1@b": 100, "q2@b": 100},
+            },
+            {
+                "stages": {},
+                "keyword_arm_zero_result_rate": 0.10,
+                "keyword_arm_row_counts": {"q1@b": 240, "q2@b": 0},
+                "semantic_arm_row_counts": {"q1@b": 100, "q2@b": 100},
+            },
+        ]
+        report = metrics.variance_report(runs)
+        self.assertTrue(report["measured"])
+        # 300 -> 240 is a 20% swing in the keyword arm's contribution to fusion,
+        # and it is invisible in every graded metric when nothing is judged.
+        self.assertAlmostEqual(report["worst_spread"], 0.2, places=6)
+        self.assertEqual(report["worst_metric"], "label_free/keyword_rows/q1@b")
+
+    def test_an_unmeasured_report_cannot_pass_the_budget(self):
+        args = runner.build_parser().parse_args(["run", "--banks", "b"])
+        det = metrics.variance_report([{"stages": {}}, {"stages": {}}])
+        within = bool(det["measured"]) and (
+            det["worst_spread"] is not None
+            and det["worst_spread"] <= args.determinism_budget
+        )
+        self.assertFalse(within)
 
 
 class ScoreBlock(unittest.TestCase):

--- a/evals/recall/validate_queryset.py
+++ b/evals/recall/validate_queryset.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Zero-cost schema and lint pass over the recall query set (#4479).
+
+Sibling of `evals/validate_datasets.py` and runs in the same CI job: no network,
+no model, no database, so it protects the asset on every PR including forks.
+
+HARD lints (exit 1) are the ones that would make a run silently meaningless:
+
+* the query set does not parse, or has a duplicate/empty case
+* fewer than `--min-cases` cases (#4479 scope item 1 asks for at least 100)
+* a family declared but unused, or a case in an undeclared family
+* a `zero-result-probe` population under `--min-zero-probes` (the headline
+  metric's subset comes from here; too few and the ratio is noise)
+* a `morphological` case with no `probe` note, i.e. a stemming probe that does
+  not say what it is probing
+* two cases with identical text (a duplicated denominator entry)
+
+WARN (exit 0): family length distribution drifting far from the shape the
+provenance block claims it was built to match.
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import sys
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from evals.recall.queryset import QuerySetError, load_queryset  # noqa: E402
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_QUERYSET = HERE / "queryset" / "v1.yaml"
+
+
+def validate(path: Path, *, min_cases: int, min_zero_probes: int) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    try:
+        qs = load_queryset(path)
+    except QuerySetError as exc:
+        return [str(exc)], []
+
+    if len(qs.cases) < min_cases:
+        errors.append(
+            f"{len(qs.cases)} cases, below the {min_cases} minimum "
+            "(#4479 scope item 1: at least 100 queries)"
+        )
+
+    used = {c.family for c in qs.cases}
+    unused = set(qs.families) - used
+    if unused:
+        errors.append(f"declared but unused families: {sorted(unused)}")
+
+    zero_probes = [c for c in qs.cases if c.family == "zero-result-probe"]
+    if len(zero_probes) < min_zero_probes:
+        errors.append(
+            f"only {len(zero_probes)} zero-result-probe cases, below {min_zero_probes}. "
+            "The headline metric's subset is drawn from these; too few makes the ratio noise."
+        )
+
+    missing_probe = [c.id for c in qs.cases if c.family == "morphological" and not c.probe]
+    if missing_probe:
+        errors.append(f"morphological cases with no `probe` note: {missing_probe}")
+
+    by_text: dict[str, list[str]] = {}
+    for case in qs.cases:
+        by_text.setdefault(" ".join(case.text.lower().split()), []).append(case.id)
+    dupes = {text: ids for text, ids in by_text.items() if len(ids) > 1}
+    if dupes:
+        errors.append(f"duplicate query text across cases: {sorted(dupes.values())}")
+
+    blobs = [len(c.text) for c in qs.cases if c.family == "context-blob"]
+    claimed = (qs.provenance.get("shaped_by") or {}).get("query_chars_p50")
+    if blobs and claimed:
+        median = statistics.median(blobs)
+        if abs(median - float(claimed)) > 0.4 * float(claimed):
+            warnings.append(
+                f"context-blob median length {median:.0f} is far from the "
+                f"{claimed} the provenance block claims it matches"
+            )
+
+    return errors, warnings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="validate the recall query set")
+    parser.add_argument("--queryset", default=str(DEFAULT_QUERYSET))
+    parser.add_argument("--min-cases", type=int, default=100)
+    parser.add_argument("--min-zero-probes", type=int, default=15)
+    parser.add_argument(
+        "--selftest",
+        action="store_true",
+        help="assert each HARD lint fires on a fixture, so the validator cannot go vacuous",
+    )
+    args = parser.parse_args(argv)
+
+    if args.selftest:
+        return selftest()
+
+    errors, warnings = validate(
+        Path(args.queryset), min_cases=args.min_cases, min_zero_probes=args.min_zero_probes
+    )
+    for warning in warnings:
+        print(f"WARN  {warning}")
+    for error in errors:
+        print(f"ERROR {error}", file=sys.stderr)
+    if errors:
+        return 1
+    qs = load_queryset(Path(args.queryset))
+    print(
+        f"ok: {qs.queryset_id} {qs.queryset_version}, {len(qs.cases)} cases "
+        f"across {len(qs.families)} families"
+    )
+    return 0
+
+
+def selftest() -> int:
+    """Prove each HARD lint fires. A validator nobody has seen fail is a no-op."""
+    import tempfile
+    import textwrap
+
+    base = textwrap.dedent(
+        """
+        schema_version: 1
+        queryset_version: "t"
+        queryset_id: t
+        families:
+          alpha: a
+          morphological: m
+          zero-result-probe: z
+        cases:
+          - {id: a1, family: alpha, text: one}
+          - {id: m1, family: morphological, text: two, probe: "x -> y"}
+          - {id: z1, family: zero-result-probe, text: three}
+        """
+    ).strip()
+
+    fixtures = {
+        "too-few-cases": (base, dict(min_cases=100, min_zero_probes=1), "below the 100 minimum"),
+        "too-few-zero-probes": (base, dict(min_cases=1, min_zero_probes=5), "zero-result-probe"),
+        "unused-family": (
+            base.replace("  alpha: a\n", "  alpha: a\n  beta: b\n"),
+            dict(min_cases=1, min_zero_probes=1),
+            "unused families",
+        ),
+        "morphological-no-probe": (
+            base.replace(', probe: "x -> y"', ""),
+            dict(min_cases=1, min_zero_probes=1),
+            "no `probe` note",
+        ),
+        "duplicate-text": (
+            base + "\n  - {id: a2, family: alpha, text: One}",
+            dict(min_cases=1, min_zero_probes=1),
+            "duplicate query text",
+        ),
+        "duplicate-id": (
+            base + "\n  - {id: a1, family: alpha, text: four}",
+            dict(min_cases=1, min_zero_probes=1),
+            "duplicate case id",
+        ),
+        "unknown-family": (
+            base + "\n  - {id: x1, family: nope, text: four}",
+            dict(min_cases=1, min_zero_probes=1),
+            "unknown family",
+        ),
+        "empty-text": (
+            base + '\n  - {id: e1, family: alpha, text: "  "}',
+            dict(min_cases=1, min_zero_probes=1),
+            "empty text",
+        ),
+    }
+
+    failures = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        # The base fixture itself must be clean, or every lint below is trivially
+        # "firing" on unrelated breakage.
+        clean = Path(tmp) / "clean.yaml"
+        clean.write_text(base)
+        errors, _ = validate(clean, min_cases=1, min_zero_probes=1)
+        if errors:
+            print(f"FAIL  base fixture is not clean: {errors}", file=sys.stderr)
+            failures += 1
+
+        for name, (text, kwargs, needle) in fixtures.items():
+            path = Path(tmp) / f"{name}.yaml"
+            path.write_text(text)
+            errors, _ = validate(path, **kwargs)
+            if not any(needle in e for e in errors):
+                print(f"FAIL  lint {name!r} did not fire (errors={errors})", file=sys.stderr)
+                failures += 1
+            else:
+                print(f"ok    lint {name!r} fires")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #4479. Phase P6 of #4474.

## Why

The strongest datapoint in the pg_search investigation is a quality one: the
candidate backend answered queries native returns **zero rows** for. That lived
only in a dry-run note, so it could not gate anything, and P3 is trading latency
against a quality number nobody could compute. This turns it into a score.

## What lands

`evals/recall/` — a read-only, sequential recall-quality suite:

| file | role |
|---|---|
| `metrics.py` | pure scoring: recall@10/@50, nDCG@10, MRR, judged coverage, RRF, the headline zero-result metric, the regression gate, the variance report. No I/O, no clock, no randomness. |
| `client.py` | read-only transport. Three allowlisted requests; anything else raises `ReadOnlyViolation`. No concurrency knob. |
| `queryset.py` | strict loader; unknown key / duplicate id / empty text are errors, not warnings. |
| `run_recall_quality.py` | the CLI: `run` and `compare`. |
| `validate_queryset.py` | zero-cost lints, plus `--selftest` that proves each lint fires. |
| `derive_shape.py` | reproduces the aggregate traffic statistics the query set's provenance block claims. |
| `queryset/v1.yaml` | 141 authored cases across 7 families, versioned and sha256-stamped into every result. |
| `test_recall_quality.py` | 36 unit tests, including the AC1 proof. |
| `README.md`, `qrels/README.md` | method, judgement provenance and its limits, how to grow the asset. |

CI gains three zero-cost offline steps in `ci-evals.yml` (validator selftest,
query-set validation, scorer unit tests). Scoring a live configuration needs a
running instance and stays an operator-run command.

## Acceptance criteria

- **AC1 (non-vacuous)** — `--disable-keyword-arm` ablates the keyword arm from
  the client-side fusion and the gate goes RED. Proven offline in
  `Ablation::test_ablated_run_scores_worse_and_the_gate_goes_red`, and live —
  both runs and the compare output are committed under `results/`. The
  degradation is client-side by design: proving a suite works should not require
  mutating production. The gate also **discriminates** — see below; a gate that
  is red on everything proves nothing.
- **AC2 (headline number)** — `zero_result_queries_answered / zero_result_queries_total`
  is a named top-level metric, and it is **label-free**: two runs and a row
  count, no judgements needed.
- **AC3 (determinism)** — measured, not assumed; the number is in the issue
  comment. See the note below on why "measured" is load-bearing here.
- **AC4 (single command, machine-readable)** — one command, JSON out, exit 1 on
  regression. Fails closed: a run with errored cases exits non-zero by default,
  because every metric here is a ratio over the cases that succeeded.
- **AC5 (wired as a gate)** — issue-level cross-referencing on #4477 / #4480,
  not a code change; not in this PR.

## A source-vs-brief correction worth reading

The phase assumes "queries native returns zero rows for" means lexically rare
queries. Measured against the live instance, that is wrong. The native arm
**ORs** its tokens — `to_tsquery(cfg, 'a | b | c')` gated by `search_vector @@`
(`hindsight-api-slim/hindsight_api/engine/sql/postgresql.py:228-234`, v0.8.6) —
so on a populated bank a rare phrase still matches something. All 20 of my
original rare-phrase probes returned 300 keyword rows.

The arm goes to zero when the query reduces to an **empty tsquery**. The fleet
runs `hindsight_english`, whose snowball dictionary carries
`docker/hindsight-extra.stop` — standard English stopwords **plus** the corpus
boilerplate `claude` / `code` / `agent` / `assistant` / `user` / `switchroom` /
`sidechain`. A query made only of those words produces no lexemes at all.

Confirmed live: of ten stopword-heavy cases, the nine built from ordinary
function words returned 172-300 keyword rows; the one built from fleet
boilerplate returned 0. Rebuilt to that mechanism, all 20 `zero-result-probe`
cases return 0.

So the headline metric's denominator is a function of `hindsight-extra.stop`,
and `QuerySetAsset::test_zero_result_probes_are_built_only_from_discarded_lexemes`
couples the query set to that file on purpose: editing the stop file changes the
denominator, and that should be a CI failure rather than a silent drift in a
number people are meant to trust. This is also directly relevant to the epic's
open decision about that regconfig.

## Two things the live run caught that the unit tests did not

Both are committed as follow-up commits on the branch rather than squashed
away, because they are the exact failure modes this suite exists to prevent and
the history is the evidence.

### 1. The gate went red on everything, including a file against itself

`recall@10` only exists once qrels are loaded, and no judgements are committed
yet — so `compare` always took the *"recall@10 missing — cannot grade"* branch
and returned exit 1 no matter what the candidate did. Red-on-degraded is only
evidence if green-on-identical is reachable, and it wasn't.

`compare` now separates the two kinds of failure, with distinct exit codes:

| verdict | meaning | exit |
|---|---|---|
| `pass` | every evaluable budget was met | 0 |
| `regression` | a budget was evaluated and **measurably** breached | 1 |
| `ungraded` | no regression found, but nothing could be evaluated | 3 |

`ungraded` still blocks — an uncertifiable run is not a passing run — but it is
a different claim, and CI can now tell them apart. Verified on the committed
artefacts: baseline vs ablated → `regression`, exit 1, 23 keyword-zero
regressions; ablated vs an identical copy of itself → `ungraded`, exit 3, 0
regressions. The discriminating signal is label-free, which is what makes AC1
demonstrable today rather than after a judgement campaign.

### 2. The determinism report used to lie

`variance_report` originally compared only graded per-stage metrics. Those exist
only once a qrels file is loaded — and no judgements are committed yet — so on a
real run every series was empty, the max over an empty candidate set collapsed
to `0.0`, and the block emitted:

```json
{ "runs": 3, "worst_spread": 0.0, "worst_metric": null,
  "per_metric": {}, "within_budget": true }
```

That reads as *perfectly deterministic* and means *compared nothing*. It is the
AC3 analogue of a fail-open scorer, and it was not hypothetical: the first live
3-run baseline against a real bank printed exactly that.

The fix is fail-closed in two places. Variance now also covers **label-free**
series that exist with no judgements at all — the keyword arm's zero-result
rate, and each case's per-arm row counts normalised by that case's max across
runs — so an unjudged run yields a real, falsifiable number. And the block
carries `measured` / `metrics_compared`, with `within_budget` requiring
`measured`, so a report that compared nothing now **fails** the budget instead
of quietly passing it.
`Variance::test_comparing_nothing_is_not_perfect_determinism` pins it.

## Data hygiene

`switchroom/switchroom` is public and the banks are a live operator's private
memory, so:

- every query is **authored**; real traffic shaped only the families and the
  length distribution, via aggregate statistics `derive_shape.py` reproduces
- observations carry **ids only** — memory text never enters a result file
- qrels are **ids and integer grades only**, with a mandatory provenance block
- bank ids are **pseudonymised by default** in committed results

## Not done / deferred

- **The full sweep is deferred.** A latency benchmark and a baseline sweep were
  running on the same box throughout, so runs were kept sequential at
  concurrency 1 over a 28-case subset. The suite runs at any size; the
  multi-bank ≥100-case baseline should be captured on a quiet box.
- **No graded qrels yet.** The committed baseline is label-free. A judgement
  campaign against a named bank belongs in its own PR, per
  `qrels/README.md`.
- **Timings are not a measurement.** They appear under
  `timings_not_a_measurement` as diagnostics and are never scored or gated.
  The box was contended by design.
- `npm run lint` could not run `tsc` locally: `npm ci` fails on `origin/main`
  with `Missing: nostr-tools@2.24.1 from lock file`, which predates this branch.
  Every other lint check passes, and this diff contains no TypeScript.
