### PR TITLE
fix(self-improve): label review-turn messages and stop raw-reasoning leaks to operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Self-improvement
+
+- **Label review-turn messages, stop raw-reasoning leaks to the operator** — a silent self-improvement review turn's mid-turn reasoning could be captured by the outbox backstop and delivered into the operator's DM as a raw, unlabelled message. A review turn now has exactly one sanctioned operator-facing output: a well-formed self-improvement card (a message opening with `🔧 **Self-improvement**`). The backstop delivers a review-originated record only when its text is that card; all other trailing prose classifies `internal` and is suppressed. Detection is deterministic on the synthesized inbound's `source="self_improve_review"` tag plus an exact card-title prefix, never a prose-shape heuristic. A residual title-framing layer (behind `SWITCHROOM_TG_OUTBOX_SELF_IMPROVE_FRAMING`) prepends the title if a non-card review record ever reaches delivery with the audience gate off, so review reasoning can never appear unlabelled. The review prompt now locks the exact card shape (Signal / Suggestion / Status) and instructs silence on a no-op turn.
+
 ## v0.20.12 — native WebSearch fleet-wide, faster sub-agent cards, Hindsight recall speedups, and token-aware LiteLLM pacing
 
 ### Web tooling

--- a/src/self-improve/review-prompt.ts
+++ b/src/self-improve/review-prompt.ts
@@ -30,6 +30,18 @@ import { resolveSelfImproveConfig } from "./config.js";
 export const REVIEW_SOURCE = "self_improve_review";
 
 /**
+ * The leading title line of a self-improvement CARD — the ONE sanctioned
+ * operator-facing output of a review turn. MUST stay byte-identical to
+ * `SELF_IMPROVEMENT_TITLE` in
+ * `telegram-plugin/hooks/audience-classify.mjs`: the review turn emits a message
+ * opening with this line, and the backstop's card gate (`isSelfImprovementCard`)
+ * delivers it ONLY because it opens with exactly this string. A drift would make
+ * every surfacing card fall through the gate and be suppressed as raw reasoning.
+ * `tests/self-improve-review-audience.test.ts` pins the equality.
+ */
+export const SELF_IMPROVEMENT_CARD_TITLE = "🔧 **Self-improvement**";
+
+/**
  * The banner that opens every review prompt. Single source of truth so the
  * builder (below) and the review-turn DETECTOR (`isReviewTurn`) can never
  * drift apart — a drift there is exactly what let the re-fire loop through
@@ -80,8 +92,7 @@ export function buildReviewPrompt(signals: LearningSignal[]): string {
       "Run a focused, forked review. Use ONLY memory tools (recall/retain/" +
       "directives) and skill read/write tools (Read/Write/Edit under your " +
       "own .claude/skills/, skill_* / skill-personal). Do NOT touch " +
-      "anything else, do NOT reply to the operator, and end the turn when " +
-      "done.",
+      "anything else, and do NOT reply to the operator with tools.",
   );
   lines.push("");
   lines.push("Signals detected this turn:");
@@ -132,6 +143,44 @@ export function buildReviewPrompt(signals: LearningSignal[]): string {
     `Rate limits in effect: <= ${cfg.maxAutoAppliesPerDay} auto-applies/day, ` +
       `<= ${cfg.maxOutstandingPending} outstanding pending suggestions. If a ` +
       "limit is reached, stop and leave a note rather than forcing the change.",
+  );
+
+  // ── The operator-facing output contract (Ken, 2026-08-07) ────────────────
+  // A review turn is OFF the operator reply path (its inbound targets a
+  // placeholder chat). Its ONE operator-facing output is the final text of this
+  // turn, and the backstop only lets it through when it is a well-formed card
+  // (leading `SELF_IMPROVEMENT_CARD_TITLE` — see `isSelfImprovementCard`). Raw
+  // reasoning as trailing text is SUPPRESSED, so it can never leak again. Lock
+  // the exact shape here so the model emits what the gate expects.
+  lines.push("");
+  lines.push(
+    "OPERATOR OUTPUT — READ CAREFULLY. You have exactly ONE operator-facing " +
+      "message this turn, and it is the FINAL TEXT you write (not a tool call).",
+  );
+  lines.push(
+    "  - If you actioned NOTHING this turn (deduped, no-op, already handled, or " +
+      "nothing worth the operator's attention), write NO final text at all — " +
+      "end the turn SILENTLY. Do NOT narrate your reasoning; trailing reasoning " +
+      "prose is suppressed and never reaches the operator.",
+  );
+  lines.push(
+    "  - If you surfaced a REAL outcome (logged a pending suggestion, applied a " +
+      "T1, or proposed an eval case), end the turn with a SINGLE message in " +
+      "EXACTLY this format and nothing else:",
+  );
+  lines.push("");
+  lines.push(`${SELF_IMPROVEMENT_CARD_TITLE} — <one-line outcome>`);
+  lines.push("- **Signal:** <what tripped the gate>");
+  lines.push("- **Suggestion:** <the proposed change>");
+  lines.push(
+    "- **Status:** <tier + whether anything auto-applied, e.g. " +
+      '"T2, logged for your review, nothing auto-applied">',
+  );
+  lines.push("");
+  lines.push(
+    `The leading "${SELF_IMPROVEMENT_CARD_TITLE}" line is REQUIRED verbatim — it ` +
+      "is what marks the message as a self-improvement card. Anything not " +
+      "starting with it is treated as raw reasoning and dropped.",
   );
 
   return lines.join("\n");

--- a/telegram-plugin/gateway/outbox-sweep.ts
+++ b/telegram-plugin/gateway/outbox-sweep.ts
@@ -47,6 +47,7 @@ import {
   AUDIENCE_INTERNAL,
   formatInternalSuppression,
   formatReplyThrowFraming,
+  formatSelfImprovementFraming,
   resolveRecordAudience,
   shouldSuppressForAudience,
 } from '../hooks/audience-classify.mjs'
@@ -162,6 +163,19 @@ export interface OutboxSweepDeps {
    * Defaults to `log`.
    */
   logProvenanceFraming?: (line: string) => void
+  /**
+   * Ken 2026-08-07 kill switch for the self-improvement title header. Defaults
+   * to `SWITCHROOM_TG_OUTBOX_SELF_IMPROVE_FRAMING !== '0'` (ON). Same
+   * injected-seam reasoning as {@link provenanceFramingEnabled}: a module-scope
+   * env read would be captured at import and a revert-check could not run.
+   */
+  selfImprovementFramingEnabled?: () => boolean
+  /**
+   * Ken 2026-08-07 telemetry sink for a self-improvement-framed delivery.
+   * Separate from {@link logProvenanceFraming} so the two framings are greppable
+   * apart. Defaults to `log`.
+   */
+  logSelfImprovementFraming?: (line: string) => void
 }
 
 export interface OutboxSweepSummary {
@@ -190,6 +204,12 @@ export interface OutboxSweepSummary {
    * delivery, not a skip.
    */
   provenanceFramed?: number
+  /**
+   * Ken 2026-08-07: deliveries this sweep that carried the self-improvement
+   * title header. These ARE counted in `delivered` — framing is a delivery, not
+   * a skip.
+   */
+  selfImprovementFramed?: number
 }
 
 /**
@@ -246,6 +266,9 @@ export async function sweepOutbox(deps: OutboxSweepDeps): Promise<OutboxSweepSum
   const provenanceFramingEnabled = deps.provenanceFramingEnabled?.() ??
     process.env.SWITCHROOM_TG_OUTBOX_PROVENANCE_FRAMING !== '0'
   const logProvenanceFraming = deps.logProvenanceFraming ?? log
+  const selfImprovementFramingEnabled = deps.selfImprovementFramingEnabled?.() ??
+    process.env.SWITCHROOM_TG_OUTBOX_SELF_IMPROVE_FRAMING !== '0'
+  const logSelfImprovementFraming = deps.logSelfImprovementFraming ?? log
 
   for (const record of records) {
     summary.scanned++
@@ -341,6 +364,11 @@ export async function sweepOutbox(deps: OutboxSweepDeps): Promise<OutboxSweepSum
       // exists to prevent. So we state the provenance instead, and the human
       // (who can tell the difference, unlike any classifier here) decides.
       provenanceFraming: provenanceFramingEnabled,
+      // Ken 2026-08-07: label any review-originated record that reaches delivery
+      // (the audience gate's default suppression already withheld it above; this
+      // covers the gate-off / `user`-route residual) with the self-improvement
+      // title, so review reasoning can never appear as raw, unlabelled prose.
+      selfImprovementFraming: selfImprovementFramingEnabled,
     })
 
     if (decision.action !== 'send' && decision.action !== 'send-delayed') {
@@ -423,6 +451,11 @@ export async function sweepOutbox(deps: OutboxSweepDeps): Promise<OutboxSweepSum
           ...(decision.framedProvenance != null
             ? { framedProvenance: decision.framedProvenance }
             : {}),
+          // Ken 2026-08-07: durable terminal stamp for a self-improvement-framed
+          // delivery — same reasoning as `framedProvenance`.
+          ...(decision.framedSelfImprovement != null
+            ? { framedSelfImprovement: decision.framedSelfImprovement }
+            : {}),
         },
         deps.stateDir,
       )
@@ -430,6 +463,18 @@ export async function sweepOutbox(deps: OutboxSweepDeps): Promise<OutboxSweepSum
         summary.provenanceFramed = (summary.provenanceFramed ?? 0) + 1
         logProvenanceFraming(
           formatReplyThrowFraming({
+            turnNonce: record.turnNonce,
+            turnId: turnIdFromNonce(record.turnNonce),
+            chatId: resolvedChat.chatId,
+            textSha256: record.textSha256,
+            source: record.source,
+          }),
+        )
+      }
+      if (decision.framedSelfImprovement != null) {
+        summary.selfImprovementFramed = (summary.selfImprovementFramed ?? 0) + 1
+        logSelfImprovementFraming(
+          formatSelfImprovementFraming({
             turnNonce: record.turnNonce,
             turnId: turnIdFromNonce(record.turnNonce),
             chatId: resolvedChat.chatId,

--- a/telegram-plugin/hooks/audience-classify.d.mts
+++ b/telegram-plugin/hooks/audience-classify.d.mts
@@ -3,9 +3,16 @@ export type Audience = 'user' | 'internal'
 export const AUDIENCE_USER: 'user'
 export const AUDIENCE_INTERNAL: 'internal'
 
+/** Mirror of `REVIEW_SOURCE` in `src/self-improve/review-prompt.ts`. */
+export const REVIEW_SOURCE: 'self_improve_review'
+
+export function isReviewOriginatedSource(source: string | null | undefined): boolean
+
 export function decideCaptureAudience(signals: {
   replyToolThrewThisTurn?: boolean
   openInboundObligation?: true | false | 'unknown'
+  reviewOriginated?: boolean
+  reviewTextIsCard?: boolean
 }): Audience
 
 export function resolveOpenObligation(args: {
@@ -32,6 +39,25 @@ export function shouldFrameReplyThrow(
 export function applyReplyThrowFraming(text: string): string
 
 export function formatReplyThrowFraming(s: {
+  turnNonce: string
+  turnId?: string | null
+  chatId?: string | null
+  textSha256?: string
+  source?: string
+}): string
+
+export const SELF_IMPROVEMENT_TITLE: string
+
+export function isSelfImprovementCard(text: string | null | undefined): boolean
+
+export function shouldFrameSelfImprovement(
+  record: { reviewOriginated?: unknown },
+  opts?: { frameEnabled?: boolean },
+): boolean
+
+export function applySelfImprovementFraming(text: string): string
+
+export function formatSelfImprovementFraming(s: {
   turnNonce: string
   turnId?: string | null
   chatId?: string | null

--- a/telegram-plugin/hooks/audience-classify.mjs
+++ b/telegram-plugin/hooks/audience-classify.mjs
@@ -36,6 +36,39 @@ export const AUDIENCE_USER = 'user'
 export const AUDIENCE_INTERNAL = 'internal'
 
 /**
+ * The `meta.source` a self-improvement review turn's synthesized inbound
+ * carries. MUST stay byte-identical to `REVIEW_SOURCE` in
+ * `src/self-improve/review-prompt.ts` — this unbundled `.mjs` cannot import the
+ * TS module, so the constant is mirrored here (same discipline as `MAX_RETRIES`
+ * / `isTurnFlushSafetyEnabledEnv`). `tests/self-improve-review-audience.test.ts`
+ * pins the equality so a rename on either side reds CI.
+ *
+ * WHY IT LIVES IN THE AUDIENCE MODULE. A self-improvement review turn is
+ * injected with an explicit contract (`buildReviewPrompt`): "act SILENTLY, do
+ * NOT reply to the operator, end the turn when done." Its trailing transcript
+ * prose is therefore the agent reasoning to ITSELF — an `internal` audience by
+ * construction, exactly the vocabulary this module owns. Ken hit the leak this
+ * closes: a silent review turn's mid-turn reasoning ("I own personal-garmin,
+ * but the script I hand-rolled…") was captured by the outbox backstop and
+ * delivered into his DM as a raw, unlabelled message.
+ */
+export const REVIEW_SOURCE = 'self_improve_review'
+
+/**
+ * Did the turn that produced this capture originate from a self-improvement
+ * review inbound? Deterministic: it keys ONLY on the enqueue envelope's
+ * `source="…"` attribute (parsed upstream by `parseChannelEnvelope`), never on
+ * prose shape or a wording heuristic — the same source tag the rest of the
+ * self-improve machinery already routes on.
+ *
+ * @param {string | null | undefined} source The capture/record `source` field.
+ * @returns {boolean}
+ */
+export function isReviewOriginatedSource(source) {
+  return source === REVIEW_SOURCE
+}
+
+/**
  * Obligation state for the resolved chat, as seen at capture time.
  *
  * `'unknown'` is a first-class value and is NOT the same as `false`: an
@@ -72,13 +105,46 @@ export const AUDIENCE_INTERNAL = 'internal'
  * would let a heuristic prose-shape match silently swallow a real answer —
  * exactly the severity-3 error this function is built to avoid.
  *
+ * `reviewOriginated` is the ONE other positive signal, and it is deterministic
+ * rather than heuristic. A self-improvement review turn is injected with a
+ * SYNTHESIZED inbound (`source="self_improve_review"`); no operator is waiting on
+ * an answer to it. Its contract (`buildReviewPrompt`) gives it exactly ONE
+ * operator-facing output: a well-formed self-improvement CARD (leading
+ * `SELF_IMPROVEMENT_TITLE` line) when — and only when — it surfaces a real
+ * outcome; otherwise it stays silent. So the review branch is checked FIRST and
+ * routes on card-shape:
+ *
+ *   - review + text IS a card (`reviewTextIsCard === true`) ⇒ `user`. The card
+ *     is the sanctioned surfacing message; deliver it. It is self-labelled by
+ *     construction (it opens with the title), so it can never appear as raw,
+ *     unlabelled reasoning.
+ *   - review + text is NOT a card ⇒ `internal`. This is the leak Ken hit — a
+ *     review turn's mid-turn reasoning captured by the backstop — and it is
+ *     SUPPRESSED. Deterministic: the gate is an EXACT title-line prefix, not a
+ *     fuzzy prose-shape guess, and the failure direction is SAFE (a mis-typed
+ *     card is withheld, never a real answer swallowed — a review inbound has no
+ *     waiting question to swallow, so this never manufactures the severity-3
+ *     silent no-op the asymmetry above guards against).
+ *
+ * `reviewTextIsCard` is scoped to review turns ONLY; it can never affect a
+ * normal user turn's classification, so the "no prose-shape heuristic on user
+ * text" rule above is intact.
+ *
  * @param {{
  *   replyToolThrewThisTurn?: boolean,
  *   openInboundObligation?: true | false | 'unknown',
+ *   reviewOriginated?: boolean,
+ *   reviewTextIsCard?: boolean,
  * }} signals
  * @returns {'user' | 'internal'}
  */
 export function decideCaptureAudience(signals) {
+  // Self-improvement review turns (see the header note): the sanctioned card
+  // delivers (`user`); any other trailing prose is the leak and is suppressed
+  // (`internal`). Deterministic, independent of the reply-throw path below.
+  if (signals?.reviewOriginated === true) {
+    return signals?.reviewTextIsCard === true ? AUDIENCE_USER : AUDIENCE_INTERNAL
+  }
   const threw = signals?.replyToolThrewThisTurn === true
   if (!threw) return AUDIENCE_USER
   // Only a POSITIVE, known-empty obligation state clears the second gate.
@@ -327,6 +393,133 @@ export function formatReplyThrowFraming(s) {
     `sha=${(s.textSha256 ?? '').slice(0, 12)} source=${s.source ?? 'unknown'} ` +
     `audience=user replyToolThrew=true — captured prose delivered with its ` +
     `provenance stated, not suppressed\n`
+  )
+}
+
+/**
+ * ── Self-improvement review labelling (Ken, 2026-08-07) ──────────────────────
+ *
+ * TWO layers, both in this one shared module so the hook (which classifies +
+ * stamps) and the sweep (which delivers) run identical rules:
+ *
+ *   1. CARD GATE (primary, `decideCaptureAudience` above). A review turn's
+ *      trailing backstop text is delivered to the operator ONLY IF it is a
+ *      well-formed self-improvement card — `isSelfImprovementCard`, an EXACT
+ *      leading-`SELF_IMPROVEMENT_TITLE` prefix. Non-card review prose (the raw
+ *      reasoning Ken saw leak) classifies `internal` and is suppressed. This is
+ *      the deterministic "never leak raw reasoning; the card is the only
+ *      operator-facing output" guarantee.
+ *
+ *   2. TITLE FRAMING (residual). The card gate delivers only text that is
+ *      ALREADY self-titled, so in the default config the delivered body needs no
+ *      relabelling. This block is the belt-and-braces for the degraded config:
+ *      if the audience gate is turned OFF (`SWITCHROOM_TG_OUTBOX_AUDIENCE_GATE=0`)
+ *      so a NON-card review record reaches delivery, the title is prepended so it
+ *      can still never appear as raw, unlabelled reasoning. Idempotent: text that
+ *      already opens with the title is left untouched (no double title on a real
+ *      card). Mirrors the reply-throw framing above — pure predicate + pure body
+ *      transform + telemetry — and is additive only, so it can never manufacture
+ *      silence.
+ */
+
+/**
+ * The title line every self-improvement card opens with, and the label the
+ * residual framing prepends. `🔧 **Self-improvement**` — a leading glyph + bold
+ * so the operator sees at a glance this is a review note, not a normal reply.
+ * The card contract (`buildReviewPrompt`) continues the same line with
+ * ` — <one-line outcome>`, so this is a PREFIX of a real card, which is exactly
+ * what `isSelfImprovementCard` keys on.
+ */
+export const SELF_IMPROVEMENT_TITLE = '🔧 **Self-improvement**'
+
+/**
+ * Is `text` a well-formed self-improvement card — i.e. does it open with the
+ * `SELF_IMPROVEMENT_TITLE` line? This is the deterministic gate that separates
+ * the sanctioned surfacing card (deliver) from raw review reasoning (suppress).
+ *
+ * EXACT structural prefix, not a fuzzy prose-shape match: the model is
+ * instructed to emit the title verbatim as the first line of its one surfacing
+ * message, and the failure direction is SAFE — a mis-formatted card is withheld
+ * (silence), never a real answer delivered. Leading whitespace is tolerated so a
+ * stray newline before the title does not defeat the gate.
+ *
+ * @param {string | null | undefined} text
+ * @returns {boolean}
+ */
+export function isSelfImprovementCard(text) {
+  if (typeof text !== 'string') return false
+  return text.trimStart().startsWith(SELF_IMPROVEMENT_TITLE)
+}
+
+/**
+ * Should this record's delivered text carry the residual title header?
+ *
+ * POSITIVE evidence only: an exact `true` on the record's persisted
+ * `reviewOriginated`. Missing / `undefined` / `'true'` / `1` — anything that is
+ * not the boolean — changes nothing, so a non-review record (every normal turn)
+ * delivers byte-for-byte as it does today. Text that is already a card is a
+ * no-op at `applySelfImprovementFraming` (idempotent), so this predicate stays
+ * simple: "is this a review record".
+ *
+ * `frameEnabled === false` is the kill switch, and it is the seam a revert-check
+ * flips.
+ *
+ * @param {{ reviewOriginated?: unknown }} record
+ * @param {{ frameEnabled?: boolean }} [opts]
+ * @returns {boolean}
+ */
+export function shouldFrameSelfImprovement(record, opts) {
+  if (opts?.frameEnabled === false) return false
+  return record?.reviewOriginated === true
+}
+
+/**
+ * Compose the title header onto the delivered body. Pure; the caller owns the
+ * `(delayed) ` / `(from background task) ` delivery prefixes, which stay OUTSIDE
+ * (they describe the delivery, this describes the text). The title is the
+ * OUTERMOST content line so it always reads first, even when the reply-throw
+ * banner is also present.
+ *
+ * IDEMPOTENT: text that already opens with the title (a real card) is returned
+ * unchanged, so a delivered card never carries a duplicated title.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function applySelfImprovementFraming(text) {
+  const body = typeof text === 'string' ? text : ''
+  // Empty body: the sweep's send adapter early-returns on empty text, and a
+  // title over nothing would be a message about nothing. Leave it.
+  if (body.trim().length === 0) return body
+  // Already a card — do not prepend a second title.
+  if (isSelfImprovementCard(body)) return body
+  return `${SELF_IMPROVEMENT_TITLE}\n\n${body}`
+}
+
+/**
+ * Structured telemetry for a self-improvement-framed delivery — the
+ * observability half of the rule, mirroring {@link formatReplyThrowFraming}.
+ * Framing changes what a human sees, so it must never be inferable only from the
+ * absence of a log line. Worded to match NONE of `GATEWAY_SIGNATURES` in
+ * `src/fleet-health/detect.ts`: a framed delivery IS a delivery, and must not
+ * page anyone.
+ *
+ * @param {{
+ *   turnNonce: string,
+ *   turnId?: string | null,
+ *   chatId?: string | null,
+ *   textSha256?: string,
+ *   source?: string,
+ * }} s
+ * @returns {string}
+ */
+export function formatSelfImprovementFraming(s) {
+  return (
+    `telegram gateway: outbox self-improvement framing nonce=${s.turnNonce} ` +
+    `turnId=${s.turnId ?? 'unknown'} chatId=${s.chatId ?? 'unresolved'} ` +
+    `sha=${(s.textSha256 ?? '').slice(0, 12)} source=${s.source ?? 'unknown'} ` +
+    `reviewOriginated=true — review-turn prose delivered with its self-improvement ` +
+    `title, never as raw unlabelled reasoning\n`
   )
 }
 

--- a/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
+++ b/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
@@ -72,6 +72,8 @@ import {
 import {
   decideCaptureAudience,
   resolveOpenObligation,
+  isReviewOriginatedSource,
+  isSelfImprovementCard,
   AUDIENCE_INTERNAL,
 } from './audience-classify.mjs'
 
@@ -181,7 +183,7 @@ function outboxAlreadyDelivered(outboxDir, nonce) {
  * `'unknown'` → the record delivers exactly as it does today.
  *
  * @param {string} stateDir
- * @param {{ chatId: string|null, originChatId?: string|null, replyToolThrewThisTurn?: boolean }} capture
+ * @param {{ chatId: string|null, originChatId?: string|null, replyToolThrewThisTurn?: boolean, source?: string|null }} capture
  * @returns {'user' | 'internal'}
  */
 function classifyCaptureAudience(stateDir, capture) {
@@ -212,6 +214,14 @@ function classifyCaptureAudience(stateDir, capture) {
     process.env.TELEGRAM_ACCESS_MODE !== 'static'
   return decideCaptureAudience({
     replyToolThrewThisTurn: capture.replyToolThrewThisTurn === true,
+    // A self-improvement review turn has exactly ONE sanctioned operator-facing
+    // output: a well-formed self-improvement CARD. Deterministic on the enqueue
+    // envelope's `source` tag (the same signal the rest of the self-improve
+    // machinery routes on) plus the EXACT card-shape of the captured text. A
+    // card delivers; any other trailing prose (the raw-reasoning leak) is
+    // suppressed. Independent of the reply-throw / obligation state below.
+    reviewOriginated: isReviewOriginatedSource(capture.source),
+    reviewTextIsCard: isSelfImprovementCard(capture.text),
     openInboundObligation: resolveOpenObligation({
       snapshotRaw,
       snapshotTrusted,
@@ -265,6 +275,13 @@ function writeOutboxRecord(stateDir, capture, audience) {
       // not catch (the foreground case). Stamped here because this is the last
       // point in the pipeline that can still see the transcript.
       replyToolThrewThisTurn: capture.replyToolThrewThisTurn === true,
+      // Ken 2026-08-07: did this turn originate from a self-improvement review
+      // inbound? `audience` already consumed it (with the card-shape signal) to
+      // deliver a well-formed card and suppress raw reasoning by default; the
+      // sweep consumes this raw flag again, on its own, to prepend the
+      // self-improvement TITLE to any review record delivered with the audience
+      // gate OFF, so review reasoning can never appear as raw, unlabelled prose.
+      reviewOriginated: isReviewOriginatedSource(capture.source),
     }
     const tmpPath = join(outboxDir, `.${capture.turnNonce}.${process.pid}.tmp`)
     writeFileSync(tmpPath, JSON.stringify(record), 'utf8')

--- a/telegram-plugin/outbox.ts
+++ b/telegram-plugin/outbox.ts
@@ -75,6 +75,8 @@ import type { Audience } from './hooks/audience-classify.mjs'
 import {
   applyReplyThrowFraming,
   shouldFrameReplyThrow,
+  applySelfImprovementFraming,
+  shouldFrameSelfImprovement,
 } from './hooks/audience-classify.mjs'
 
 export type { Audience }
@@ -162,6 +164,25 @@ export interface OutboxRecord {
    * exact boolean `true` changes anything — see `shouldFrameReplyThrow`.
    */
   replyToolThrewThisTurn?: boolean
+  /**
+   * Ken 2026-08-07: did the turn that produced this record originate from a
+   * self-improvement review inbound (`source="self_improve_review"`)? Stamped at
+   * capture by `hooks/silent-end-interrupt-stop.mjs` from the enqueue envelope's
+   * source tag.
+   *
+   * `audience` already consumed it once — a review turn classifies `'internal'`
+   * (`decideCaptureAudience`), so by default it is SUPPRESSED at the sweep's
+   * entry gate and never delivered. The sweep consumes this raw flag again, on
+   * its own, only for the residual: a review record that IS delivered (the
+   * audience gate turned off, or a legacy/`user` route) must carry the
+   * self-improvement TITLE so it can never appear as raw, unlabelled agent
+   * reasoning — the leak this closes.
+   *
+   * OPTIONAL: absent on every pre-change record and on non-review turns, which
+   * deliver unframed. Only an exact boolean `true` changes anything — see
+   * `shouldFrameSelfImprovement`.
+   */
+  reviewOriginated?: boolean
 }
 
 /** One line of the delivered-keys journal (`outbox/delivered.jsonl`). */
@@ -204,6 +225,16 @@ export interface DeliveredEntry {
    * framed delivery is a delivery.
    */
   framedProvenance?: 'reply-throw'
+  /**
+   * Ken 2026-08-07: this delivery carried the self-improvement TITLE header
+   * (`SELF_IMPROVEMENT_TITLE`) in front of a review-originated record's prose.
+   * Durable and terminal, for the same reason `framedProvenance` is: framing
+   * changes what a human sees, so the outcome is recorded as an explicit named
+   * state on the journal line rather than being inferable only from a log line
+   * that may have rotated away. `tgMessageId` IS present on these lines — a
+   * framed delivery is a delivery.
+   */
+  framedSelfImprovement?: 'self-improve'
 }
 
 export function sha256Hex(s: string): string {
@@ -519,6 +550,13 @@ export interface OutboxSweepDecision {
    * the rule.
    */
   framedProvenance?: 'reply-throw'
+  /**
+   * Ken 2026-08-07: `text` carries the self-improvement title header. Surfaced
+   * on the decision (rather than left implicit in a string compare) so the
+   * caller can journal the outcome and emit telemetry without re-deriving the
+   * rule — same shape as `framedProvenance`.
+   */
+  framedSelfImprovement?: 'self-improve'
 }
 
 /**
@@ -538,7 +576,7 @@ export interface OutboxSweepDecision {
 export function decideOutboxSweep(input: {
   record: Pick<
     OutboxRecord,
-    'turnNonce' | 'text' | 'createdAt' | 'replyToolThrewThisTurn'
+    'turnNonce' | 'text' | 'createdAt' | 'replyToolThrewThisTurn' | 'reviewOriginated'
   >
   now: number
   deliveredNonces: Set<string>
@@ -566,6 +604,13 @@ export function decideOutboxSweep(input: {
    * revert-check can flip it in-process.
    */
   provenanceFraming?: boolean
+  /**
+   * Ken 2026-08-07 kill switch for the self-improvement TITLE header. `false`
+   * restores the pre-change body byte-for-byte; the default is ON. Passed in
+   * rather than read from env here so this core stays pure and a revert-check
+   * can flip it in-process.
+   */
+  selfImprovementFraming?: boolean
 }): OutboxSweepDecision {
   const {
     record,
@@ -578,6 +623,7 @@ export function decideOutboxSweep(input: {
     maxAgeMs = OUTBOX_MAX_AGE_MS,
     shownLedgerHit = false,
     provenanceFraming = true,
+    selfImprovementFraming = true,
   } = input
   if (deliveredNonces.has(record.turnNonce)) return { action: 'skip-journaled' }
   if (shownLedgerHit) return { action: 'skip-ephemeral-shown' }
@@ -592,11 +638,22 @@ export function decideOutboxSweep(input: {
   // the banner describes the TEXT. It is additive only: it can never turn a
   // send into a skip, so this branch cannot manufacture silence.
   const framed = shouldFrameReplyThrow(record, { frameEnabled: provenanceFraming })
-  const body = framed ? applyReplyThrowFraming(record.text) : record.text
+  const provenanceBody = framed ? applyReplyThrowFraming(record.text) : record.text
+  // Ken 2026-08-07: the self-improvement title is the OUTERMOST content line, so
+  // it is applied AFTER the reply-throw banner — a review record that somehow
+  // also threw reads "🔧 Self-improvement" first, then the provenance note, then
+  // the prose. Additive only: it can never turn a send into a skip.
+  const selfImproveFramed = shouldFrameSelfImprovement(record, {
+    frameEnabled: selfImprovementFraming,
+  })
+  const body = selfImproveFramed ? applySelfImprovementFraming(provenanceBody) : provenanceBody
   return {
     action: delayed ? 'send-delayed' : 'send',
     text: prefix + body,
-    ...(framed && body !== record.text ? { framedProvenance: 'reply-throw' as const } : {}),
+    ...(framed && provenanceBody !== record.text ? { framedProvenance: 'reply-throw' as const } : {}),
+    ...(selfImproveFramed && body !== provenanceBody
+      ? { framedSelfImprovement: 'self-improve' as const }
+      : {}),
   }
 }
 

--- a/telegram-plugin/tests/outbox-self-improve-review.test.ts
+++ b/telegram-plugin/tests/outbox-self-improve-review.test.ts
@@ -1,0 +1,309 @@
+/**
+ * outbox-self-improve-review.test.ts — the self-improvement review labelling
+ * rule, end to end through the REAL Stop hook and the REAL outbox sweep (Ken,
+ * 2026-08-07).
+ *
+ * THE LEAK THIS CLOSES
+ * --------------------
+ * A self-improvement review turn is a SYNTHESIZED inbound
+ * (`source="self_improve_review"`) injected off the operator reply path. Its
+ * trailing transcript prose is the agent's own reasoning. The outbox backstop
+ * captured that prose and the sweep delivered it into the operator's DM as a
+ * RAW, UNLABELLED message — the bug.
+ *
+ * THE RULE UNDER TEST
+ * -------------------
+ * A review-originated backstop record is delivered to the operator ONLY IF its
+ * text is a well-formed self-improvement CARD (opens with the title line).
+ * Everything else — the raw reasoning — is suppressed as `internal`.
+ *
+ *   (a) SURFACING: a review turn whose final text is a card ⇒ the card is
+ *       delivered, self-labelled, journaled as a real delivery.
+ *   (b) NO-OP: a review turn whose final text is raw reasoning ⇒ suppressed,
+ *       zero chat sends, journaled as an internal suppression.
+ *   (c) NORMAL: a non-review turn is delivered byte-for-byte unchanged.
+ *
+ * Every assertion drives REAL machinery: the REAL Stop hook spawned as a
+ * subprocess against a REAL transcript, and the REAL `sweepOutbox` with the
+ * REAL `createOutboxSend` adapter against a RECORDING fake Bot API.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readdirSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { sweepOutbox, createOutboxSend } from "../gateway/outbox-sweep.js";
+import { sha256Hex } from "../outbox.js";
+import { SELF_IMPROVEMENT_TITLE } from "../hooks/audience-classify.mjs";
+
+const HOOK = resolve(__dirname, "..", "hooks", "silent-end-interrupt-stop.mjs");
+
+// Synthetic ids only (check-no-pii-secrets forbids real chat/user ids).
+const DM_CHAT = "5550001";
+const INBOUND_MSG_ID = 8420;
+
+/** Raw review reasoning — the text that must never reach the operator. */
+const REVIEW_REASONING = [
+  "I own personal-garmin, but the script I hand-rolled against this turn was the",
+  "shared garmin skill's garmin-history-pull, which only samples every 3rd day.",
+  "The durable fix is a first-class hrv-trend subcommand; that is a T2 change so",
+  "I logged it as a pending suggestion rather than auto-applying it here.",
+].join(" ");
+
+/** A well-formed card, exactly as `buildReviewPrompt` instructs the model. */
+const REVIEW_CARD = [
+  `${SELF_IMPROVEMENT_TITLE} — pending suggestion logged`,
+  "- **Signal:** had to hand-roll python twice to pull daily HRV",
+  "- **Suggestion:** add an `hrv-trend` command to the garmin skill",
+  "- **Status:** T2, logged for your review, nothing auto-applied",
+].join("\n");
+
+/** A normal operator answer on a normal (non-review) turn. No markdown-special
+ *  characters, so the rich-send path delivers it byte-for-byte (letting the
+ *  "unchanged" assertion be exact equality rather than a substring). */
+const NORMAL_ANSWER = "Your HRV trended up this week, sitting around thirty against last week.";
+
+function makeStateDir(): string {
+  // NEVER ~/.switchroom — a test that writes there corrupts production state.
+  return mkdtempSync(join(tmpdir(), "self-improve-review-"));
+}
+
+function writeTranscript(dir: string, lines: object[]): string {
+  const p = join(dir, "transcript.jsonl");
+  writeFileSync(p, lines.map((l) => JSON.stringify(l)).join("\n"), "utf8");
+  return p;
+}
+
+function runHook(transcriptPath: string, stateDir: string, extraEnv: Record<string, string> = {}) {
+  return spawnSync("node", [HOOK], {
+    input: JSON.stringify({ session_id: "s", transcript_path: transcriptPath }),
+    encoding: "utf8",
+    timeout: 10_000,
+    env: { ...process.env, TELEGRAM_STATE_DIR: stateDir, ...extraEnv },
+  });
+}
+
+interface RecordShape {
+  turnNonce: string;
+  text: string;
+  audience?: string;
+  reviewOriginated?: unknown;
+  chatId: string | null;
+  source: string;
+}
+
+function outboxRecords(dir: string): RecordShape[] {
+  const outbox = join(dir, "outbox");
+  if (!existsSync(outbox)) return [];
+  return readdirSync(outbox)
+    .filter((f) => f.endsWith(".json") && f !== "delivered.jsonl")
+    .map((f) => JSON.parse(readFileSync(join(outbox, f), "utf8")) as RecordShape);
+}
+
+function journalLines(dir: string): Array<Record<string, unknown>> {
+  const p = join(dir, "outbox", "delivered.jsonl");
+  if (!existsSync(p)) return [];
+  return readFileSync(p, "utf8")
+    .split("\n")
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+/** A RECORDING fake Bot API — every chat-visible method is counted. */
+function recordingBot() {
+  const calls: Array<{ method: string; chatId: string; text: string }> = [];
+  let nextId = 900;
+  return {
+    chatCalls: () => calls,
+    api: {
+      sendRichMessage: async (chatId: string, body: { markdown: string }) => {
+        calls.push({ method: "sendRichMessage", chatId, text: body.markdown });
+        return { message_id: nextId++ };
+      },
+      sendMessage: async (chatId: string, text: string) => {
+        calls.push({ method: "sendMessage", chatId, text });
+        return { message_id: nextId++ };
+      },
+      editMessageText: async (chatId: string, _mid: number, text: string) => {
+        calls.push({ method: "editMessageText", chatId, text });
+        return { message_id: nextId++ };
+      },
+    },
+  };
+}
+
+const passthroughRetry = <U>(fn: () => Promise<U>): Promise<U> => fn();
+
+/** Drive ONE real sweep tick against the recording bot. */
+async function realSweep(
+  stateDir: string,
+  bot: ReturnType<typeof recordingBot>,
+  opts: { audienceGateEnabled?: boolean } = {},
+) {
+  const framingLines: string[] = [];
+  const escalations: string[] = [];
+  const summary = await sweepOutbox({
+    send: createOutboxSend({ getBot: () => bot, retry: passthroughRetry }),
+    textAlreadyDelivered: () => false,
+    stateDir,
+    now: () => Date.now() + 60_000,
+    quietMs: 0,
+    log: () => {},
+    ...(opts.audienceGateEnabled === undefined
+      ? {}
+      : { audienceGateEnabled: () => opts.audienceGateEnabled! }),
+    logSelfImprovementFraming: (l) => framingLines.push(l),
+    escalateInternalSuppression: (l) => escalations.push(l),
+  });
+  return { summary, framingLines, escalations };
+}
+
+/**
+ * The REAL review-turn shape: the synthesized review inbound (channel-wrapped,
+ * carrying `source="self_improve_review"` and the real operator chat the gateway
+ * fell back to), then the agent's trailing final text.
+ */
+function reviewTranscript(dir: string, trailing: string): string {
+  return writeTranscript(dir, [
+    {
+      type: "queue-operation",
+      operation: "enqueue",
+      content:
+        `<channel source="self_improve_review" chat_id="${DM_CHAT}" ` +
+        `message_id="${INBOUND_MSG_ID}">[self-improvement review] The turn-end gate ` +
+        `detected a learning signal. Run a focused, forked review.</channel>`,
+      timestamp: 1000,
+    },
+    { type: "assistant", message: { content: [{ type: "text", text: trailing }] } },
+  ]);
+}
+
+describe("self-improvement review — the card gate, end to end", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = makeStateDir();
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("(a) SURFACING: a review turn ending in a CARD delivers it, self-labelled", async () => {
+    const t = reviewTranscript(dir, REVIEW_CARD);
+    expect(runHook(t, dir).status).toBe(0);
+
+    const records = outboxRecords(dir);
+    expect(records).toHaveLength(1);
+    // Detected as review-originated, and the card routes to the operator.
+    expect(records[0].reviewOriginated).toBe(true);
+    expect(records[0].audience).toBe("user");
+
+    const bot = recordingBot();
+    const run = await realSweep(dir, bot);
+
+    // Delivered exactly once, carrying the card verbatim (title first).
+    expect(bot.chatCalls()).toHaveLength(1);
+    expect(run.summary.delivered).toBe(1);
+    expect(run.summary.audienceSuppressed).toBeUndefined();
+    const sent = bot.chatCalls()[0].text;
+    expect(sent).toContain(SELF_IMPROVEMENT_TITLE);
+    expect(sent).toContain("add an `hrv-trend` command");
+    expect(sent.startsWith(SELF_IMPROVEMENT_TITLE)).toBe(true);
+    expect(bot.chatCalls()[0].chatId).toBe(DM_CHAT);
+
+    // Journaled as a real delivery (carries a message id, not a suppression).
+    const journal = journalLines(dir);
+    expect(journal).toHaveLength(1);
+    expect(journal[0].tgMessageId).toBeDefined();
+    expect(journal[0].suppressedAudience).toBeUndefined();
+  });
+
+  it("(b) NO-OP: a review turn ending in RAW REASONING is suppressed — zero sends", async () => {
+    const t = reviewTranscript(dir, REVIEW_REASONING);
+    expect(runHook(t, dir).status).toBe(0);
+
+    const records = outboxRecords(dir);
+    expect(records).toHaveLength(1);
+    expect(records[0].reviewOriginated).toBe(true);
+    // The leak text classifies internal by construction.
+    expect(records[0].audience).toBe("internal");
+
+    const bot = recordingBot();
+    const run = await realSweep(dir, bot);
+
+    // The bug, closed: nothing reaches the operator.
+    expect(bot.chatCalls()).toEqual([]);
+    expect(run.summary.delivered ?? 0).toBe(0);
+    expect(run.summary.audienceSuppressed).toBe(1);
+    expect(journalLines(dir)[0].suppressedAudience).toBe("internal");
+  });
+
+  it("(b') REVERT CHECK: with the audience gate OFF the leak reproduces — but TITLED", async () => {
+    // Same raw reasoning; only the gate differs. This proves (b) is load-bearing
+    // AND that the residual framing labels the gate-off delivery so it is never
+    // raw/unlabelled — the task's minimum guarantee.
+    const t = reviewTranscript(dir, REVIEW_REASONING);
+    expect(runHook(t, dir).status).toBe(0);
+
+    const bot = recordingBot();
+    const run = await realSweep(dir, bot, { audienceGateEnabled: false });
+
+    expect(bot.chatCalls()).toHaveLength(1);
+    const sent = bot.chatCalls()[0].text;
+    // The raw reasoning is present (the pre-change leak) BUT now titled.
+    expect(sent).toContain(REVIEW_REASONING);
+    expect(sent.startsWith(SELF_IMPROVEMENT_TITLE)).toBe(true);
+    expect(run.summary.selfImprovementFramed).toBe(1);
+    expect(run.framingLines).toHaveLength(1);
+    expect(journalLines(dir)[0].framedSelfImprovement).toBe("self-improve");
+  });
+
+  it("(c) NORMAL: a non-review record is delivered byte-for-byte, no review handling", async () => {
+    // A normal foreground turn is delivered LIVE by the turn-flush path and
+    // writes no outbox record at all (verified: the real hook elects
+    // `flush-will-deliver` for a `source="telegram"` turn). The invariant this
+    // case guards is the sweep side: a non-review outbox record — the shape the
+    // sweep DOES handle, e.g. a background handback or a flood-queued reply — is
+    // untouched by any of the self-improvement machinery. Constructed directly
+    // on disk (mirrors the LEGACY pattern in outbox-provenance-4141.test.ts) so
+    // "byte-for-byte unchanged" can be asserted as exact equality.
+    const outbox = join(dir, "outbox");
+    mkdirSync(outbox, { recursive: true });
+    const nonce = `${DM_CHAT}:_#7788`;
+    const normal = {
+      turnNonce: nonce,
+      chatId: DM_CHAT,
+      threadId: null,
+      text: NORMAL_ANSWER,
+      textSha256: sha256Hex(NORMAL_ANSWER),
+      // Inside the max-age window ⇒ no delivery prefix, so exact equality holds.
+      createdAt: Date.now(),
+      source: "task-notification",
+      audience: "user",
+    };
+    // The review fields simply do not exist on a normal record.
+    expect(Object.keys(normal)).not.toContain("reviewOriginated");
+    writeFileSync(join(outbox, `${nonce}.json`), JSON.stringify(normal), "utf8");
+
+    const bot = recordingBot();
+    const run = await realSweep(dir, bot);
+
+    // Delivered, verbatim, with no self-improvement title anywhere.
+    expect(bot.chatCalls()).toHaveLength(1);
+    expect(run.summary.delivered).toBe(1);
+    expect(bot.chatCalls()[0].text).toBe(NORMAL_ANSWER);
+    expect(bot.chatCalls()[0].text).not.toContain(SELF_IMPROVEMENT_TITLE);
+    expect(run.summary.selfImprovementFramed).toBeUndefined();
+    expect(run.summary.audienceSuppressed).toBeUndefined();
+    // Journal parity: a plain delivery, keyed on the raw text, unframed.
+    expect(journalLines(dir)[0].textSha256).toBe(sha256Hex(NORMAL_ANSWER));
+    expect(journalLines(dir)[0].framedSelfImprovement).toBeUndefined();
+  });
+});

--- a/tests/self-improve-review-audience.test.ts
+++ b/tests/self-improve-review-audience.test.ts
@@ -1,0 +1,220 @@
+/**
+ * self-improve-review-audience.test.ts — the self-improvement review labelling
+ * rule (Ken, 2026-08-07).
+ *
+ * THE BUG THIS GUARDS
+ * -------------------
+ * A self-improvement review turn is injected with an explicit contract
+ * (`buildReviewPrompt`): act on the signal, do NOT reply with tools, end when
+ * done. It is OFF the operator reply path — its inbound targets a placeholder
+ * chat. Its trailing transcript prose is the agent reasoning to ITSELF. But the
+ * outbox backstop captured that prose and delivered it into the operator's DM
+ * as a RAW, UNLABELLED message — Ken saw the agent musing to itself ("I own
+ * personal-garmin, but the script I hand-rolled…") with nothing to say it was a
+ * self-improvement note.
+ *
+ * THE DESIGN UNDER TEST — CARD GATE, SUPPRESS THE REST
+ * ---------------------------------------------------
+ * A review turn's ONE sanctioned operator-facing output is a well-formed CARD
+ * (a message opening with `SELF_IMPROVEMENT_TITLE`). The backstop delivers a
+ * review-originated record ONLY IF its text is such a card; everything else —
+ * the raw reasoning — classifies `internal` and is suppressed. Deterministic:
+ * the gate is an EXACT title-line prefix, and the failure direction is SAFE (a
+ * mis-typed card is withheld, never a real answer swallowed; a review inbound
+ * has no waiting question to swallow).
+ *
+ *   - surfacing review turn (emits the card)  ⇒ delivered, self-labelled
+ *   - no-op review turn (silent / raw prose)  ⇒ suppressed
+ *   - normal non-review turn                  ⇒ untouched
+ *
+ * PARITY. The `.mjs` hook (unbundled) and the TS self-improve machinery cannot
+ * share a module, so `REVIEW_SOURCE` and the card title are mirrored. This file
+ * PINS both equalities — a rename on either side reds CI here rather than
+ * silently splitting the copies and making the feature inert.
+ */
+
+import { describe, it, expect } from "vitest";
+
+// The TS source of truth for the review source tag + the card title, and the
+// prompt builder that carries the operator-output contract.
+import {
+  REVIEW_SOURCE as REVIEW_SOURCE_TS,
+  SELF_IMPROVEMENT_CARD_TITLE,
+  buildReviewPrompt,
+} from "../src/self-improve/review-prompt.js";
+import type { LearningSignal } from "../src/self-improve/types.js";
+
+// The unbundled `.mjs` mirror that the Stop hook + the sweep actually run.
+import {
+  REVIEW_SOURCE as REVIEW_SOURCE_MJS,
+  AUDIENCE_INTERNAL,
+  AUDIENCE_USER,
+  isReviewOriginatedSource,
+  isSelfImprovementCard,
+  decideCaptureAudience,
+  shouldFrameSelfImprovement,
+  applySelfImprovementFraming,
+  formatSelfImprovementFraming,
+  SELF_IMPROVEMENT_TITLE,
+} from "../telegram-plugin/hooks/audience-classify.mjs";
+
+import { GATEWAY_SIGNATURES } from "../src/fleet-health/detect.js";
+
+const REVIEW_PROSE = [
+  "I own personal-garmin, but the script I hand-rolled against this turn was the",
+  "shared garmin skill's garmin-history-pull, which only samples every 3rd day.",
+  "The durable fix is a first-class hrv-trend subcommand; I logged it as a",
+  "pending suggestion rather than auto-applying.",
+].join(" ");
+
+/** A well-formed card, exactly as the prompt instructs the model to emit it. */
+const REVIEW_CARD = [
+  `${SELF_IMPROVEMENT_TITLE} — pending suggestion logged`,
+  "- **Signal:** had to hand-roll python twice to pull daily HRV",
+  "- **Suggestion:** add an `hrv-trend` command to the garmin skill",
+  "- **Status:** T2, logged for your review, nothing auto-applied",
+].join("\n");
+
+describe("parity — the mirrored constants cannot silently drift", () => {
+  it("REVIEW_SOURCE: the .mjs mirror equals the TS source of truth", () => {
+    expect(REVIEW_SOURCE_MJS).toBe(REVIEW_SOURCE_TS);
+    expect(REVIEW_SOURCE_MJS).toBe("self_improve_review");
+  });
+
+  it("the card title: the TS prompt constant equals the .mjs gate title", () => {
+    // If these split, the model emits one string and the backstop gate keys on
+    // another — every surfacing card falls through and is suppressed.
+    expect(SELF_IMPROVEMENT_CARD_TITLE).toBe(SELF_IMPROVEMENT_TITLE);
+    expect(SELF_IMPROVEMENT_CARD_TITLE).toBe("🔧 **Self-improvement**");
+  });
+
+  it("isReviewOriginatedSource keys ONLY on the exact source tag", () => {
+    expect(isReviewOriginatedSource(REVIEW_SOURCE_TS)).toBe(true);
+    for (const v of [undefined, null, "", "telegram", "cron", "channel", "SELF_IMPROVE_REVIEW"]) {
+      expect(isReviewOriginatedSource(v as string)).toBe(false);
+    }
+  });
+});
+
+describe("card gate — an EXACT title-line prefix, safe failure direction", () => {
+  it("recognises a well-formed card, tolerating leading whitespace", () => {
+    expect(isSelfImprovementCard(REVIEW_CARD)).toBe(true);
+    expect(isSelfImprovementCard(`\n\n${REVIEW_CARD}`)).toBe(true);
+    // Bare title line (outcome on the same line after ` — `) still qualifies.
+    expect(isSelfImprovementCard(`${SELF_IMPROVEMENT_TITLE} — done`)).toBe(true);
+  });
+
+  it("rejects raw reasoning and anything not opening with the title", () => {
+    for (const v of [REVIEW_PROSE, "", "   ", undefined, null, 1, {}, "Self-improvement: x"]) {
+      expect(isSelfImprovementCard(v as string)).toBe(false);
+    }
+  });
+});
+
+describe("audience — the card delivers, the reasoning is suppressed", () => {
+  it("review + card ⇒ user; review + non-card ⇒ internal", () => {
+    expect(decideCaptureAudience({ reviewOriginated: true, reviewTextIsCard: true })).toBe(
+      AUDIENCE_USER,
+    );
+    expect(decideCaptureAudience({ reviewOriginated: true, reviewTextIsCard: false })).toBe(
+      AUDIENCE_INTERNAL,
+    );
+    // Missing card flag defaults to "not a card" ⇒ suppressed (safe direction).
+    expect(decideCaptureAudience({ reviewOriginated: true })).toBe(AUDIENCE_INTERNAL);
+  });
+
+  it("the review branch is checked FIRST, independent of reply-throw/obligation", () => {
+    // A card delivers even with signals that would otherwise route `user`, and
+    // raw reasoning is suppressed even though a review inbound never opens an
+    // obligation — the branch does not consult those at all.
+    expect(
+      decideCaptureAudience({
+        reviewOriginated: true,
+        reviewTextIsCard: false,
+        replyToolThrewThisTurn: false,
+        openInboundObligation: true,
+      }),
+    ).toBe(AUDIENCE_INTERNAL);
+  });
+
+  it("positive-evidence-only: a non-review turn is completely unaffected", () => {
+    // reviewOriginated anything-but-true ⇒ the rest of the classifier decides.
+    for (const v of [undefined, null, false, "true", 1, {}]) {
+      expect(decideCaptureAudience({ reviewOriginated: v as boolean })).toBe(AUDIENCE_USER);
+    }
+    // And the pre-existing throw/obligation asymmetry is untouched.
+    expect(
+      decideCaptureAudience({ replyToolThrewThisTurn: true, openInboundObligation: false }),
+    ).toBe(AUDIENCE_INTERNAL);
+    // The card flag alone (no reviewOriginated) never changes a normal turn.
+    expect(decideCaptureAudience({ reviewTextIsCard: true })).toBe(AUDIENCE_USER);
+  });
+});
+
+describe("residual title framing — the gate-off belt-and-braces", () => {
+  it("frames ONLY on an exact boolean true, with a kill switch", () => {
+    expect(shouldFrameSelfImprovement({ reviewOriginated: true })).toBe(true);
+    for (const v of [undefined, null, false, "true", 1, {}, []]) {
+      expect(shouldFrameSelfImprovement({ reviewOriginated: v })).toBe(false);
+    }
+    expect(shouldFrameSelfImprovement({ reviewOriginated: true }, { frameEnabled: false })).toBe(
+      false,
+    );
+  });
+
+  it("labels raw prose additively (title first, prose verbatim)", () => {
+    const framed = applySelfImprovementFraming(REVIEW_PROSE);
+    expect(framed).toContain(REVIEW_PROSE);
+    expect(framed.startsWith(SELF_IMPROVEMENT_TITLE)).toBe(true);
+    expect(framed.indexOf(SELF_IMPROVEMENT_TITLE)).toBeLessThan(framed.indexOf("I own"));
+  });
+
+  it("is IDEMPOTENT: a real card is not double-titled", () => {
+    expect(applySelfImprovementFraming(REVIEW_CARD)).toBe(REVIEW_CARD);
+  });
+
+  it("an empty body is left alone — a title about nothing is not a message", () => {
+    expect(applySelfImprovementFraming("")).toBe("");
+    expect(applySelfImprovementFraming("   \n ")).toBe("   \n ");
+  });
+});
+
+describe("the review prompt locks the operator-output contract", () => {
+  const signals: LearningSignal[] = [
+    { kind: "repeated-fix", reason: "hand-rolled the same HRV pull twice", evidence: "two turns" },
+  ];
+
+  it("carries the EXACT card format the gate expects", () => {
+    const p = buildReviewPrompt(signals);
+    // The title line the gate keys on, verbatim.
+    expect(p).toContain(SELF_IMPROVEMENT_CARD_TITLE);
+    // The three structured fields, in the operator-approved shape.
+    expect(p).toContain("- **Signal:**");
+    expect(p).toContain("- **Suggestion:**");
+    expect(p).toContain("- **Status:**");
+    // A well-formed card built to the prompt's spec passes the runtime gate.
+    expect(isSelfImprovementCard(`${SELF_IMPROVEMENT_CARD_TITLE} — outcome`)).toBe(true);
+  });
+
+  it("instructs silence on a no-op and forbids trailing reasoning", () => {
+    const p = buildReviewPrompt(signals);
+    expect(p.toLowerCase()).toContain("silent");
+    // The no-raw-reasoning rule is stated, not just implied.
+    expect(p.toLowerCase()).toContain("reasoning");
+  });
+});
+
+describe("telemetry — a framed delivery is a delivery, not an alarm", () => {
+  it("the framing line matches NO gateway alarm signature", () => {
+    const line = formatSelfImprovementFraming({
+      turnNonce: "5550001:_#7311",
+      turnId: "5550001:_#7311",
+      chatId: "5550001",
+      textSha256: "abcdef012345",
+      source: REVIEW_SOURCE_TS,
+    });
+    for (const [name, re] of Object.entries(GATEWAY_SIGNATURES)) {
+      expect(re.test(line), `${name} must not match a by-design framed delivery`).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

A silent self-improvement review turn (a synthesized inbound with `source="self_improve_review"`, banner `[self-improvement review]`, instructed to act silently and end with `NO_REPLY`) could have its mid-turn reasoning captured by the outbox backstop and delivered into the operator's DM as a **raw, unlabelled** message. The operator saw the agent musing to itself with nothing to mark it as a self-improvement note.

This locks the review turn's operator-facing contract to exactly **one** sanctioned output — a well-formed self-improvement card — and suppresses everything else deterministically.

## Why

- A review turn is **off the operator reply path** (its inbound targets a placeholder chat); genuine operator surfacing is an RFC-deferred slice. Its trailing transcript prose is the agent reasoning to itself — `internal` by construction.
- The only operator channel a review turn currently has is the outbox backstop, and that path had no notion of review provenance, so raw reasoning leaked through unlabelled.

## What changed

A review turn's ONE operator-facing output is a **card** opening with the exact title line `🔧 **Self-improvement**`. The backstop delivers a review-originated record **only** when its text is such a card; all other trailing prose classifies `internal` and is suppressed.

- **Deterministic detection**, never a prose-shape heuristic: keyed on the synthesized inbound's `source="self_improve_review"` tag plus an exact card-title prefix (`isSelfImprovementCard`). Safe failure direction — a mis-typed card is withheld (silence), never a real answer swallowed, because a review inbound has no waiting question.
- **Three outcomes:** surfacing review turn (emits the card) → delivered, self-labelled; no-op review turn (silent / raw prose) → suppressed; normal non-review turn → completely untouched.
- **Residual title-framing** (belt-and-braces, behind the `SWITCHROOM_TG_OUTBOX_SELF_IMPROVE_FRAMING` kill switch): if the audience gate is turned off and a non-card review record ever reaches delivery, the title is prepended so review reasoning can never appear unlabelled. Idempotent (a real card is not double-titled), additive only (can never manufacture silence).
- **The review prompt** now locks the exact card shape (Signal / Suggestion / Status bullets) and instructs the model to stay silent on a no-op turn and never narrate trailing reasoning.

The `.mjs` hook (unbundled, run by the Stop hook + sweep) and the TS self-improve machinery cannot share a module, so `REVIEW_SOURCE` and the card title are mirrored with sync comments and a parity test pins the equalities.

## Files

- `telegram-plugin/hooks/audience-classify.mjs` — the shared pure classifier. Adds `REVIEW_SOURCE`, `isReviewOriginatedSource`, `SELF_IMPROVEMENT_TITLE`, `isSelfImprovementCard`; makes `decideCaptureAudience` card-aware (review branch checked first); adds the residual framing predicate/transform/telemetry.
- `telegram-plugin/hooks/audience-classify.d.mts` — type surface for the new exports.
- `telegram-plugin/hooks/silent-end-interrupt-stop.mjs` — the Stop hook passes `reviewOriginated` + `reviewTextIsCard` into classification and stamps `reviewOriginated` on the outbox record.
- `telegram-plugin/outbox.ts` — `reviewOriginated` on `OutboxRecord`, `framedSelfImprovement` on `DeliveredEntry`/`OutboxSweepDecision`; `decideOutboxSweep` applies the title framing after provenance framing.
- `telegram-plugin/gateway/outbox-sweep.ts` — wires the kill switch + telemetry sink, counts framed deliveries, journals the terminal `framedSelfImprovement` stamp.
- `src/self-improve/review-prompt.ts` — `SELF_IMPROVEMENT_CARD_TITLE` (byte-identical to the mjs), and the operator-output contract section locking the card shape + silence-on-no-op.
- `tests/self-improve-review-audience.test.ts` — 15 unit tests (parity, card gate, audience routing, residual framing, prompt contract, telemetry no-alarm).
- `telegram-plugin/tests/outbox-self-improve-review.test.ts` — 4 e2e tests (real Stop hook + real sweep + recording fake Bot API): surfacing card delivered self-labelled, no-op raw reasoning suppressed to zero sends, gate-off revert-check (leak reproduces but titled), normal non-review record delivered byte-for-byte.

## Test plan

```
./node_modules/.bin/vitest run \
  tests/self-improve-review-audience.test.ts \
  telegram-plugin/tests/outbox-self-improve-review.test.ts \
  telegram-plugin/tests/outbox-provenance-4141.test.ts \
  telegram-plugin/tests/outbox-audience-3865.test.ts \
  telegram-plugin/tests/outbox-delivery.test.ts \
  telegram-plugin/tests/outbox-capture-scan.test.ts \
  telegram-plugin/tests/outbox-hook-capture.test.ts \
  src/self-improve/
```

Result: **147 passing** across 11 files (19 new + 128 sibling regression). `tsc --noEmit` clean; `npm run lint` fully green (all 24 guards).

## Risk

- Scoped to the review-originated backstop path; a normal turn's classification is positive-evidence-gated on an exact boolean `reviewOriginated === true`, so non-review delivery is byte-for-byte unchanged (asserted by the e2e normal-turn case).
- The card-gate false-negative (a real card mis-typed by the model) fails safe: the note is withheld, not delivered raw — no operator question is dropped because a review inbound has none.

## Note for the operator

Genuine first-class operator card **delivery** with one-tap actions is the RFC's deferred surfacing slice. This PR locks the card contract in the prompt and kills the raw-reasoning leak deterministically via the backstop; the card currently rides the backstop because that is the only operator channel a review turn has today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)