### PR TITLE
fix(memory): gate resolved-secret emission behind --resolve-secrets, pin --recreate vault wiring (#4486, #4487)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ now an anomaly worth investigating, not the norm.
   trivial rename of this header instead of reconstructing the whole section
   from `git log` at release time (as v0.20.12 had to).
 
+### Memory CLI secret hygiene
+
+- **`memory docker-compose` no longer prints live secrets to stdout by default (#4487)** — the compose snippet now emits `vault:` refs unresolved, plus a note, unless the new `--resolve-secrets` flag is passed; `cp_access_key` follows the same rule. Closes the follow-up from #4471, which correctly wired `vault:` resolution into the snippet emit site but changed the command to print a live `sk-…` key on an operator-invoked command whose stdout is routinely pasted around.
+- **`memory setup --recreate` vault-ref wiring now has a direct test (#4486)** — adds the first `registerMemoryCommand` test harness and a wiring assertion pinning that the `--recreate` launch path (the one that caused the 2026-08-06 outage) resolves `hindsight.llm` `vault:` refs before they reach `startHindsight`.
+
 ### Hindsight keyword recall moves to ParadeDB pg_search (BM25)
 
 - **New installs default to the `pg_search` BM25 backend (#4470)** — the keyword

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ now an anomaly worth investigating, not the norm.
 
 - **`memory docker-compose` no longer prints live secrets to stdout by default (#4487)** — the compose snippet now emits `vault:` refs unresolved, plus a note, unless the new `--resolve-secrets` flag is passed; `cp_access_key` follows the same rule. Closes the follow-up from #4471, which correctly wired `vault:` resolution into the snippet emit site but changed the command to print a live `sk-…` key on an operator-invoked command whose stdout is routinely pasted around.
 - **`memory setup --recreate` vault-ref wiring now has a direct test (#4486)** — adds the first `registerMemoryCommand` test harness and a wiring assertion pinning that the `--recreate` launch path (the one that caused the 2026-08-06 outage) resolves `hindsight.llm` `vault:` refs before they reach `startHindsight`.
+- **The cleartext-secrets warning now fires on every path that actually emits one** — it is decided ONCE, from the values about to be printed rather than from the flag, so `--resolve-secrets` (the only path that emits a live `sk-…` key) can never warn LESS than the safe default does; a PLAINTEXT api_key written straight into `switchroom.yaml`, which no `vault:` gate ever applied to, is warned about too; and a snippet carrying only unresolved `vault:` refs stays quiet, since a `vault:…` string is not a secret and crying wolf there would devalue the warning where it matters.
 
 ### Hindsight keyword recall moves to ParadeDB pg_search (BM25)
 

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -62,6 +62,7 @@ import {
   HINDSIGHT_CONTAINER_NAME,
   REPAIR_FAILED_EXIT,
 } from "../memory/hindsight-repair.js";
+import { isVaultReference } from "../vault/resolver.js";
 import { spawn } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { writeConfigFileSync } from "../util/atomic.js";
@@ -158,6 +159,28 @@ export function resolveMemorySetupTag(input: {
   const pin = normalizeHindsightVersionTag(input.releasePin);
   if (pin) return { tag: pin, reason: "pin" };
   return { tag: undefined, reason: "latest" };
+}
+
+/**
+ * Whether `memory docker-compose`'s unresolved-by-default snippet (#4487)
+ * actually carries a `vault:` ref anywhere the emit path reads a secret from
+ * — the global/per-op LLM `api_key` fields and `cp_access_key`. Used only to
+ * decide whether the "these refs are unresolved" note is accurate; the
+ * refs themselves are never touched here (that's `resolveHindsightLlmSecrets`
+ * / `resolveHindsightCpAccessKey`, gated behind `--resolve-secrets`).
+ */
+function hasUnresolvedHindsightVaultRef(config: SwitchroomConfig): boolean {
+  const hindsight = (config as { hindsight?: { cp_access_key?: string; llm?: HindsightLlmConfig } })
+    .hindsight;
+  const isRef = (v?: string) => typeof v === "string" && isVaultReference(v);
+  if (isRef(hindsight?.cp_access_key)) return true;
+  const llm = hindsight?.llm;
+  if (!llm) return false;
+  if (isRef(llm.api_key)) return true;
+  for (const op of ["retain", "reflect", "consolidation"] as const) {
+    if (isRef(llm[op]?.api_key)) return true;
+  }
+  return false;
 }
 
 /**
@@ -1126,19 +1149,21 @@ export function registerMemoryCommand(program: Command): void {
           snippetLlm = await resolveHindsightLlmSecrets(snippetConfig.hindsight?.llm);
         } else {
           // DEFAULT: emit the `vault:` refs unresolved. This snippet is not
-          // runnable as-is — that's the point (#4487). Pass --resolve-secrets
-          // for a runnable file with live secret values.
+          // runnable as-is when it carries one — that's the point (#4487).
+          // Pass --resolve-secrets for a runnable file with live secret values.
           cpAccessKey = snippetConfig.hindsight?.cp_access_key;
           snippetLlm = snippetConfig.hindsight?.llm;
-          console.log(
-            chalk.yellow(
-              "# NOTE: `vault:` references below are left UNRESOLVED (default) — this\n" +
-                "#       snippet is not runnable as-is. Resolve them yourself before use, or\n" +
-                "#       re-run with --resolve-secrets to print the live secret values\n" +
-                "#       instead. If you do, treat this command's output as a secret: don't\n" +
-                "#       paste it into chat, logs, or an unencrypted file.\n",
-            ),
-          );
+          if (hasUnresolvedHindsightVaultRef(snippetConfig)) {
+            console.log(
+              chalk.yellow(
+                "# NOTE: `vault:` references below are left UNRESOLVED (default) — this\n" +
+                  "#       snippet is not runnable as-is. Resolve them yourself before use, or\n" +
+                  "#       re-run with --resolve-secrets to print the live secret values\n" +
+                  "#       instead. If you do, treat this command's output as a secret: don't\n" +
+                  "#       paste it into chat, logs, or an unencrypted file.\n",
+              ),
+            );
+          }
         }
         // The docker-run path warns from inside startHindsight(); the compose
         // generator is a pure string builder, so its wrapper carries the same

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -162,26 +162,80 @@ export function resolveMemorySetupTag(input: {
 }
 
 /**
+ * Every secret-bearing value `memory docker-compose` can emit: the global and
+ * per-op LLM `api_key` fields plus `cp_access_key`. Blank/absent entries are
+ * dropped, so callers can treat the result as "the secrets in play".
+ *
+ * One enumerator so the two questions asked below — "is there a `vault:` ref
+ * to warn is unresolved?" and "will this snippet carry a live secret?" — can
+ * never disagree about WHICH fields carry a secret.
+ */
+function hindsightSecretValues(input: {
+  llm?: HindsightLlmConfig;
+  cpAccessKey?: string;
+}): string[] {
+  const out: string[] = [];
+  const push = (v?: string) => {
+    if (typeof v === "string" && v.trim().length > 0) out.push(v.trim());
+  };
+  push(input.cpAccessKey);
+  push(input.llm?.api_key);
+  for (const op of ["retain", "reflect", "consolidation"] as const) {
+    push(input.llm?.[op]?.api_key);
+  }
+  return out;
+}
+
+/**
  * Whether `memory docker-compose`'s unresolved-by-default snippet (#4487)
- * actually carries a `vault:` ref anywhere the emit path reads a secret from
- * — the global/per-op LLM `api_key` fields and `cp_access_key`. Used only to
- * decide whether the "these refs are unresolved" note is accurate; the
- * refs themselves are never touched here (that's `resolveHindsightLlmSecrets`
- * / `resolveHindsightCpAccessKey`, gated behind `--resolve-secrets`).
+ * actually carries a `vault:` ref anywhere the emit path reads a secret from.
+ * Used only to decide whether the "these refs are unresolved" note is
+ * accurate; the refs themselves are never touched here (that's
+ * `resolveHindsightLlmSecrets` / `resolveHindsightCpAccessKey`, gated behind
+ * `--resolve-secrets`).
  */
 function hasUnresolvedHindsightVaultRef(config: SwitchroomConfig): boolean {
   const hindsight = (config as { hindsight?: { cp_access_key?: string; llm?: HindsightLlmConfig } })
     .hindsight;
-  const isRef = (v?: string) => typeof v === "string" && isVaultReference(v);
-  if (isRef(hindsight?.cp_access_key)) return true;
-  const llm = hindsight?.llm;
-  if (!llm) return false;
-  if (isRef(llm.api_key)) return true;
-  for (const op of ["retain", "reflect", "consolidation"] as const) {
-    if (isRef(llm[op]?.api_key)) return true;
-  }
-  return false;
+  return hindsightSecretValues({
+    llm: hindsight?.llm,
+    cpAccessKey: hindsight?.cp_access_key,
+  }).some((v) => isVaultReference(v));
 }
+
+/**
+ * Whether the snippet about to be printed carries a secret in CLEARTEXT.
+ *
+ * Asked of the values that will actually be emitted, NOT of the flag, so one
+ * predicate covers both branches and neither can drift:
+ *
+ *   - `--resolve-secrets`: the `vault:` refs have already been swapped for
+ *     live `sk-…` values by here, so they read as cleartext ⇒ warn. A ref the
+ *     broker DENIED resolves to nothing and is correctly not warned about —
+ *     nothing cleartext reaches stdout in that case.
+ *   - default: refs are emitted literally (a `vault:…` string is not a
+ *     secret), but a PLAINTEXT key written straight into switchroom.yaml is
+ *     still copied verbatim into the snippet ⇒ warn. The `--resolve-secrets`
+ *     gate never applied to those, so they must not lose the warning `main`
+ *     always printed.
+ */
+function emitsCleartextHindsightSecret(input: {
+  llm?: HindsightLlmConfig;
+  cpAccessKey?: string;
+}): boolean {
+  return hindsightSecretValues(input).some((v) => !isVaultReference(v));
+}
+
+/**
+ * The one cleartext-secrets warning for `memory docker-compose`. Kept next to
+ * the predicate above so the message and the condition that fires it stay in
+ * one place. Emitted to stderr with a `#` prefix by every caller, so a
+ * piped/redirected stdout stays a valid compose file even under `2>&1`.
+ */
+export const HINDSIGHT_COMPOSE_CLEARTEXT_SECRETS_WARNING =
+  "This snippet embeds secrets in CLEARTEXT (LLM api_key and/or cp_access_key)." +
+  " Treat the output as sensitive — do not paste it into shared channels or" +
+  " commit it unredacted.";
 
 /**
  * Resolve LiteLLM routing config for the hindsight container, plus the
@@ -1177,6 +1231,14 @@ export function registerMemoryCommand(program: Command): void {
             memLimit: snippetConfig.hindsight?.mem_limit,
           });
           if (memWarning) console.error(chalk.yellow(`# ! ${memWarning}`));
+        }
+        // Warn ONCE, from ONE site covering BOTH branches, whenever the
+        // snippet about to print actually carries a cleartext secret — the
+        // warning `main` printed unconditionally before `--resolve-secrets`
+        // existed. The dangerous path (`--resolve-secrets`, which emits live
+        // `sk-…` keys) must never warn LESS than the safe default does.
+        if (emitsCleartextHindsightSecret({ llm: snippetLlm, cpAccessKey })) {
+          console.error(chalk.yellow(`# ! ${HINDSIGHT_COMPOSE_CLEARTEXT_SECRETS_WARNING}`));
         }
         console.log(
           generateHindsightComposeSnippet(

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -46,6 +46,7 @@ import {
   resolveHindsightLiteLlm,
   hindsightLiteLlmDroppedKeyWarning,
   type HindsightLiteLlmResolution,
+  type HindsightLlmConfig,
 } from "../setup/hindsight.js";
 import { assessHindsightGpuDrop } from "../setup/hindsight-gpu-guard.js";
 import {
@@ -1091,24 +1092,60 @@ export function registerMemoryCommand(program: Command): void {
   memory
     .command("docker-compose")
     .description("Output a docker-compose snippet for Hindsight (broker-fed mode)")
+    .option(
+      "--resolve-secrets",
+      "Resolve `vault:` refs (the LLM api_key fields and cp_access_key) to their " +
+        "live secret values before printing the snippet. Without this flag (the " +
+        "default) the `vault:` refs are printed literally — this is an " +
+        "operator-invoked command whose stdout routinely ends up pasted into " +
+        "terminals, files, and chat, and a live `sk-…` key has no business " +
+        "landing there by accident (#4487). Pass this when you genuinely want a " +
+        "runnable compose file, and treat the output as a secret once you do.",
+    )
     // Async now that the CP access key is resolved through the vault broker;
     // withConfigError keeps a bad switchroom.yaml a friendly message rather
     // than an unhandled rejection (the sibling `memory` subcommands' shape).
-    .action(withConfigError(async () => {
+    .action(withConfigError(async (opts: { resolveSecrets?: boolean }) => {
       console.log(chalk.bold("\n# Add this to your docker-compose.yml:\n"));
       {
         const snippetConfig = getConfig(program);
-        // Same resolve + same warning as the docker-run path: a compose
-        // deployment must not be the one that quietly serves an open dashboard.
-        const cpAccessKey = await resolveHindsightCpAccessKey(snippetConfig);
-        if (!cpAccessKey) {
-          console.error(chalk.yellow(`# ! ${HINDSIGHT_CP_NO_ACCESS_KEY_WARNING}`));
+        const resolveSecrets = opts.resolveSecrets === true;
+        let cpAccessKey: string | undefined;
+        let snippetLlm: HindsightLlmConfig | undefined;
+        if (resolveSecrets) {
+          // Same resolve + same warning as the docker-run path: a compose
+          // deployment must not be the one that quietly serves an open dashboard.
+          cpAccessKey = await resolveHindsightCpAccessKey(snippetConfig);
+          if (!cpAccessKey) {
+            console.error(chalk.yellow(`# ! ${HINDSIGHT_CP_NO_ACCESS_KEY_WARNING}`));
+          }
+          // Resolve `vault:` api_key refs so the emitted compose file carries the
+          // real credential — the same reason the docker-run path resolves them,
+          // and the same shape the cp_access_key above already takes. An emitted
+          // literal `vault:…` would break every retain exactly like the recreate bug.
+          snippetLlm = await resolveHindsightLlmSecrets(snippetConfig.hindsight?.llm);
+        } else {
+          // DEFAULT: emit the `vault:` refs unresolved. This snippet is not
+          // runnable as-is — that's the point (#4487). Pass --resolve-secrets
+          // for a runnable file with live secret values.
+          cpAccessKey = snippetConfig.hindsight?.cp_access_key;
+          snippetLlm = snippetConfig.hindsight?.llm;
+          console.log(
+            chalk.yellow(
+              "# NOTE: `vault:` references below are left UNRESOLVED (default) — this\n" +
+                "#       snippet is not runnable as-is. Resolve them yourself before use, or\n" +
+                "#       re-run with --resolve-secrets to print the live secret values\n" +
+                "#       instead. If you do, treat this command's output as a secret: don't\n" +
+                "#       paste it into chat, logs, or an unencrypted file.\n",
+            ),
+          );
         }
         // The docker-run path warns from inside startHindsight(); the compose
         // generator is a pure string builder, so its wrapper carries the same
         // check. To stderr with a `#` prefix so a redirected stdout stays a
-        // valid compose file even under `2>&1` (same discipline as the
-        // secrets notice below).
+        // valid compose file even under `2>&1`. Independent of
+        // --resolve-secrets: the memory budget is a property of the config,
+        // not of whether secrets got resolved.
         {
           const memWarning = hindsightMemBudgetWarningFor({
             env: snippetConfig.hindsight?.env,
@@ -1116,24 +1153,6 @@ export function registerMemoryCommand(program: Command): void {
           });
           if (memWarning) console.error(chalk.yellow(`# ! ${memWarning}`));
         }
-        // Resolve `vault:` api_key refs so the emitted compose file carries the
-        // real credential — the same reason the docker-run path resolves them,
-        // and the same shape the cp_access_key above already takes. An emitted
-        // literal `vault:…` would break every retain exactly like the recreate bug.
-        const snippetLlm = await resolveHindsightLlmSecrets(snippetConfig.hindsight?.llm);
-        // The emitted snippet carries REAL resolved credentials in cleartext —
-        // the LLM `sk-` api_key(s) and any `cp_access_key` — because a
-        // paste-ready compose file must. Warn ONCE, to stderr with a `#` prefix,
-        // so a piped/redirected stdout is still a valid compose file (the notice
-        // stays a YAML comment even under `2>&1`) while an interactive operator
-        // is told to handle the output as a secret.
-        console.error(
-          chalk.yellow(
-            "# ! This snippet embeds resolved secrets in cleartext (LLM api_key" +
-              " and cp_access_key). Treat the output as sensitive — do not paste" +
-              " it into shared channels or commit it unredacted.",
-          ),
-        );
         console.log(
           generateHindsightComposeSnippet(
             snippetLlm,

--- a/tests/cli.memory-secrets-wiring.test.ts
+++ b/tests/cli.memory-secrets-wiring.test.ts
@@ -211,6 +211,32 @@ describe("registerMemoryCommand wiring (#4486, #4487)", () => {
     expect(mocks.getViaBrokerStructured).toHaveBeenCalledWith("litellm/gpt-oss-key", {});
   });
 
+  it("`memory docker-compose` (no flag) omits the unresolved note when there is no `vault:` ref to resolve", async () => {
+    writeFileSync(
+      configPath,
+      [
+        "switchroom:",
+        "  version: 1",
+        `  agents_dir: ${join(tmpDir, "agents")}`,
+        "telegram:",
+        '  bot_token: "test:token"',
+        '  forum_chat_id: "0"',
+        "agents:",
+        "  alpha:",
+        "    topic_name: alpha",
+        "",
+      ].join("\n"),
+    );
+
+    await buildProgram(configPath).parseAsync(["memory", "docker-compose"], {
+      from: "user",
+    });
+
+    const out = logs.join("\n");
+    expect(out).not.toMatch(/unresolved/i);
+    expect(mocks.getViaBrokerStructured).not.toHaveBeenCalled();
+  });
+
   it("`cp_access_key` follows the SAME default-unresolved rule as the LLM api_key", async () => {
     writeFileSync(
       configPath,

--- a/tests/cli.memory-secrets-wiring.test.ts
+++ b/tests/cli.memory-secrets-wiring.test.ts
@@ -1,0 +1,252 @@
+/**
+ * `registerMemoryCommand` wiring tests — the first harness that drives the
+ * command through commander end to end (no test file referenced
+ * `registerMemoryCommand` before this; see #4486).
+ *
+ * Two things pinned here, both follow-ups from the review of #4471
+ * (`fix(hindsight): resolve vault: LLM api_key refs on the
+ * recreate/rollout launch path`):
+ *
+ *   #4486 — `tests/setup-verification.test.ts` only pins the vault-ref
+ *   resolution wiring on `stepMemoryBackend` (the first-run setup path).
+ *   `switchroom memory setup --recreate` (src/cli/memory.ts, reached from
+ *   `switchroom rollout` via hostd's refresh step — the actual path that
+ *   caused the 2026-08-06 outage) was asserted only indirectly, through a
+ *   unit test of the resolver helper. This file adds the direct wiring
+ *   assertion.
+ *
+ *   #4487 — `memory docker-compose` resolves `vault:` refs to their live
+ *   secret and prints the result to stdout. That is correct when the
+ *   operator explicitly wants a runnable snippet, but by DEFAULT a live
+ *   `sk-…` key must never land on an operator's scrollback. This pins the
+ *   new `--resolve-secrets` opt-in: unresolved `vault:` refs (plus a note)
+ *   by default, the live secret only behind the flag — for both the LLM
+ *   `api_key` and `cp_access_key`, so the command has one rule, not two.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const mocks = vi.hoisted(() => ({
+  startHindsight: vi.fn(),
+  getViaBrokerStructured: vi.fn(),
+}));
+
+// `memory setup --recreate` and `memory docker-compose` both shell out to
+// docker for container/port bookkeeping unrelated to the vault-ref wiring
+// under test here. Stub the docker-touching surface only; keep every pure
+// resolver (resolveHindsightLlmSecrets, resolveHindsightCpAccessKey,
+// hindsightGpuDecision, generateHindsightComposeSnippet, ...) real, so the
+// actual resolution + emit code is what gets exercised.
+vi.mock("../src/setup/hindsight.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/setup/hindsight.js")>();
+  return {
+    ...actual,
+    startHindsight: mocks.startHindsight,
+    isDockerAvailable: () => true,
+    isHindsightRunning: () => false,
+    isHindsightContainerExists: () => false,
+    getRunningHindsightPorts: () => null,
+    pickHindsightPorts: async () => ({ apiPort: 18888, uiPort: 19999 }),
+    preflightHindsightPorts: async () => null,
+    pullHindsightImage: () => {},
+    stopHindsight: () => {},
+    getHindsightDeviceRequests: () => null,
+    // Deterministic regardless of what this box's real
+    // ~/.switchroom/host-capabilities.json says — irrelevant to the vault
+    // wiring under test, and reading it here would make the test's outcome
+    // depend on the runner's host state.
+    hindsightGpuDecision: () => ({
+      enabled: false,
+      source: "autodetect" as const,
+      degraded: false,
+      capabilities: { status: "absent" as const, path: "/dev/null", caps: null, detail: "" },
+      reason: "stubbed for test",
+    }),
+    resolveHindsightGpuOverride: () => null,
+  };
+});
+
+// `resolveHindsightLlmSecrets` / `resolveHindsightCpAccessKey` dynamic-import
+// this module to reach the broker (see src/setup/hindsight.ts
+// resolveHindsightVaultString) — mock it here so both the direct import in
+// src/cli/memory.ts and that dynamic import see the same stub.
+vi.mock("../src/vault/broker/client.js", () => ({
+  getViaBrokerStructured: mocks.getViaBrokerStructured,
+  readVaultTokenFile: () => null,
+}));
+
+vi.mock("../src/analytics/posthog.js", () => ({
+  captureEvent: vi.fn(),
+  installGlobalErrorHandlers: vi.fn(),
+}));
+
+import { Command } from "commander";
+import { registerMemoryCommand } from "../src/cli/memory.js";
+
+function buildProgram(configPath: string): Command {
+  const program = new Command()
+    .name("switchroom")
+    .option("-c, --config <path>", "Path to switchroom.yaml");
+  registerMemoryCommand(program);
+  program.setOptionValue("config", configPath);
+  return program;
+}
+
+const VAULT_REF = "vault:litellm/gpt-oss-key";
+const REAL_KEY = "sk-" + "test-fake-resolved-key-000";
+
+describe("registerMemoryCommand wiring (#4486, #4487)", () => {
+  let tmpDir: string;
+  let configPath: string;
+  let logs: string[];
+  let errs: string[];
+  let priorExitCode: number | string | undefined;
+  let savedAgentName: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "sr-memory-secrets-"));
+    configPath = join(tmpDir, "switchroom.yaml");
+    writeFileSync(
+      configPath,
+      [
+        "switchroom:",
+        "  version: 1",
+        `  agents_dir: ${join(tmpDir, "agents")}`,
+        "telegram:",
+        '  bot_token: "test:token"',
+        '  forum_chat_id: "0"',
+        "agents:",
+        "  alpha:",
+        "    topic_name: alpha",
+        "hindsight:",
+        "  llm:",
+        "    provider: openai",
+        `    api_key: "${VAULT_REF}"`,
+        "",
+      ].join("\n"),
+    );
+    logs = [];
+    errs = [];
+    priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    vi.spyOn(console, "log").mockImplementation((...args) => {
+      logs.push(args.join(" "));
+    });
+    vi.spyOn(console, "error").mockImplementation((...args) => {
+      errs.push(args.join(" "));
+    });
+    mocks.startHindsight.mockReset();
+    mocks.getViaBrokerStructured.mockReset();
+    mocks.getViaBrokerStructured.mockResolvedValue({
+      kind: "ok",
+      entry: { kind: "string", value: REAL_KEY },
+    });
+    // Keep the broker call token-free, matching the sibling stepMemoryBackend
+    // wiring test in tests/setup-verification.test.ts.
+    savedAgentName = process.env.SWITCHROOM_AGENT_NAME;
+    delete process.env.SWITCHROOM_AGENT_NAME;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = priorExitCode;
+    rmSync(tmpDir, { recursive: true, force: true });
+    if (savedAgentName === undefined) delete process.env.SWITCHROOM_AGENT_NAME;
+    else process.env.SWITCHROOM_AGENT_NAME = savedAgentName;
+  });
+
+  // ─── #4486: memory setup --recreate ────────────────────────────────────
+
+  it("resolves a `vault:` LLM api_key BEFORE it reaches startHindsight on `memory setup --recreate` (2026-08-06 wiring)", async () => {
+    // The regression this pins: the recreate/rollout launch path
+    // (src/cli/memory.ts:991, reached from src/cli/rollout.ts:1412 via
+    // hostd's refresh step) is the one that actually shipped the fleet-wide
+    // outage — stepMemoryBackend (first-run setup) is a DIFFERENT code
+    // path and does not exercise this call site. Unwire the resolver here
+    // (pass hindsightConfig.hindsight?.llm verbatim to startHindsight) and
+    // this fails: the spy would see the `vault:` literal instead of the
+    // resolved `sk-` key.
+    await buildProgram(configPath).parseAsync(["memory", "setup", "--recreate"], {
+      from: "user",
+    });
+
+    expect(mocks.startHindsight).toHaveBeenCalledTimes(1);
+    // startHindsight(ports, litellm, tag, llm, mirrorDir, gpu, perf, cpKey):
+    // the resolved LLM config is the 4th positional arg (src/setup/hindsight.ts).
+    const llmArg = mocks.startHindsight.mock.calls[0][3] as { api_key?: string } | undefined;
+    expect(llmArg?.api_key).toBe(REAL_KEY);
+    expect(llmArg?.api_key).not.toContain("vault:");
+    expect(mocks.getViaBrokerStructured).toHaveBeenCalledWith("litellm/gpt-oss-key", {});
+    expect(process.exitCode ?? 0).toBe(0);
+  });
+
+  // ─── #4487: memory docker-compose --resolve-secrets ────────────────────
+
+  it("`memory docker-compose` (no flag) emits the `vault:` ref UNRESOLVED, with a note, and never touches the broker", async () => {
+    await buildProgram(configPath).parseAsync(["memory", "docker-compose"], {
+      from: "user",
+    });
+
+    const out = logs.join("\n");
+    // The guard: a live secret must NEVER reach stdout without explicit
+    // opt-in. This is what closes #4487 — assert the OUTCOME (what actually
+    // printed), not that some resolver function was or wasn't called.
+    expect(out).not.toContain(REAL_KEY);
+    expect(out).toContain(VAULT_REF);
+    expect(out).toMatch(/unresolved|resolve them|--resolve-secrets/i);
+    expect(mocks.getViaBrokerStructured).not.toHaveBeenCalled();
+  });
+
+  it("`memory docker-compose --resolve-secrets` emits the LIVE key (explicit opt-in)", async () => {
+    await buildProgram(configPath).parseAsync(
+      ["memory", "docker-compose", "--resolve-secrets"],
+      { from: "user" },
+    );
+
+    const out = logs.join("\n");
+    expect(out).toContain(REAL_KEY);
+    expect(out).not.toContain(VAULT_REF);
+    expect(mocks.getViaBrokerStructured).toHaveBeenCalledWith("litellm/gpt-oss-key", {});
+  });
+
+  it("`cp_access_key` follows the SAME default-unresolved rule as the LLM api_key", async () => {
+    writeFileSync(
+      configPath,
+      [
+        "switchroom:",
+        "  version: 1",
+        `  agents_dir: ${join(tmpDir, "agents")}`,
+        "telegram:",
+        '  bot_token: "test:token"',
+        '  forum_chat_id: "0"',
+        "agents:",
+        "  alpha:",
+        "    topic_name: alpha",
+        "hindsight:",
+        '  cp_access_key: "vault:hindsight/cp-key"',
+        "",
+      ].join("\n"),
+    );
+    mocks.getViaBrokerStructured.mockResolvedValue({
+      kind: "ok",
+      entry: { kind: "string", value: "cp-test-fake-live-key" },
+    });
+
+    await buildProgram(configPath).parseAsync(["memory", "docker-compose"], {
+      from: "user",
+    });
+    let out = logs.join("\n");
+    expect(out).not.toContain("cp-test-fake-live-key");
+    expect(out).toContain("vault:hindsight/cp-key");
+
+    logs = [];
+    await buildProgram(configPath).parseAsync(
+      ["memory", "docker-compose", "--resolve-secrets"],
+      { from: "user" },
+    );
+    out = logs.join("\n");
+    expect(out).toContain("cp-test-fake-live-key");
+  });
+});

--- a/tests/cli.memory-secrets-wiring.test.ts
+++ b/tests/cli.memory-secrets-wiring.test.ts
@@ -236,6 +236,77 @@ describe("registerMemoryCommand wiring (#4486, #4487)", () => {
     expect(mocks.getViaBrokerStructured).toHaveBeenCalledWith("litellm/gpt-oss-key", {});
   });
 
+  // The dangerous branch must not warn LESS than the safe one. Before this
+  // guard, `--resolve-secrets` — the ONLY path that emits a live `sk-…` key —
+  // printed no cleartext warning at all, having dropped the unconditional one
+  // `main` carried (src/cli/memory.ts, pre-#4487), while the safe default
+  // branch got a five-line NOTE.
+  it("`memory docker-compose --resolve-secrets` WARNS that the snippet embeds cleartext secrets", async () => {
+    await buildProgram(configPath).parseAsync(
+      ["memory", "docker-compose", "--resolve-secrets"],
+      { from: "user" },
+    );
+
+    // Assert the OUTCOME: the warning text actually reached the operator, on
+    // stderr, `#`-prefixed so a redirected stdout stays a valid compose file.
+    const err = errs.join("\n");
+    expect(err).toMatch(/cleartext/i);
+    expect(err).toMatch(/do not paste it into shared channels/i);
+    expect(err).toMatch(/^# ! /m);
+    // And the thing it is warning about really is in the output.
+    expect(logs.join("\n")).toContain(REAL_KEY);
+  });
+
+  it("warns about a PLAINTEXT api_key in config even without --resolve-secrets (nothing gates it)", async () => {
+    // A key written straight into switchroom.yaml is never a `vault:` ref, so
+    // the unresolved-refs NOTE does not fire for it and `--resolve-secrets`
+    // does not apply to it — yet it is copied verbatim into the snippet. On
+    // `main` this printed the unconditional cleartext warning; it must not
+    // have become the one case that prints a live key silently.
+    const PLAINTEXT_KEY = "sk-" + "test-fake-plaintext-key-111";
+    writeFileSync(
+      configPath,
+      [
+        "switchroom:",
+        "  version: 1",
+        `  agents_dir: ${join(tmpDir, "agents")}`,
+        "telegram:",
+        '  bot_token: "test:token"',
+        '  forum_chat_id: "0"',
+        "agents:",
+        "  alpha:",
+        "    topic_name: alpha",
+        "hindsight:",
+        "  llm:",
+        "    provider: openai",
+        `    api_key: "${PLAINTEXT_KEY}"`,
+        "",
+      ].join("\n"),
+    );
+
+    await buildProgram(configPath).parseAsync(["memory", "docker-compose"], {
+      from: "user",
+    });
+
+    expect(logs.join("\n")).toContain(PLAINTEXT_KEY);
+    const err = errs.join("\n");
+    expect(err).toMatch(/cleartext/i);
+    expect(err).toMatch(/do not paste it into shared channels/i);
+  });
+
+  it("stays QUIET about cleartext when the snippet carries only unresolved `vault:` refs", async () => {
+    // The complement of the two guards above: a `vault:…` string is not a
+    // secret, so the default branch must not cry wolf — otherwise the warning
+    // becomes noise on the safe path and stops meaning anything on the
+    // dangerous one.
+    await buildProgram(configPath).parseAsync(["memory", "docker-compose"], {
+      from: "user",
+    });
+
+    expect(logs.join("\n")).toContain(VAULT_REF);
+    expect(errs.join("\n")).not.toMatch(/cleartext/i);
+  });
+
   it("`memory docker-compose` (no flag) omits the unresolved note when there is no `vault:` ref to resolve", async () => {
     writeFileSync(
       configPath,

--- a/tests/cli.memory-secrets-wiring.test.ts
+++ b/tests/cli.memory-secrets-wiring.test.ts
@@ -182,6 +182,31 @@ describe("registerMemoryCommand wiring (#4486, #4487)", () => {
     expect(process.exitCode ?? 0).toBe(0);
   });
 
+  it("warns when a `vault:` LLM api_key ref is DROPPED on `memory setup --recreate` (#4473, preserved through the #4487 reconcile)", async () => {
+    // #4473 landed independently of #4486/#4487 and wired
+    // diffDroppedHindsightLlmVaultKeys into this same action for a DIFFERENT
+    // failure mode (a `vault:` ref that fails to resolve is silently dropped,
+    // not a resolved secret reaching stdout). The #4487 rebase touched the
+    // docker-compose action only — this pins that the --recreate warning
+    // wiring survived the reconcile untouched.
+    mocks.getViaBrokerStructured.mockResolvedValue({
+      kind: "denied",
+      code: "VAULT-BROKER-DENIED",
+      msg: "no grant for this key",
+    });
+
+    await buildProgram(configPath).parseAsync(["memory", "setup", "--recreate"], {
+      from: "user",
+    });
+
+    const out = logs.join("\n");
+    expect(out).toMatch(/dropped|vault:litellm\/gpt-oss-key/i);
+    const llmArg = mocks.startHindsight.mock.calls[0]?.[3] as { api_key?: string } | undefined;
+    // The fail-safe: a ref that can't be resolved must not be baked in
+    // literally either — it's dropped (undefined), not passed through raw.
+    expect(llmArg?.api_key).toBeUndefined();
+  });
+
   // ─── #4487: memory docker-compose --resolve-secrets ────────────────────
 
   it("`memory docker-compose` (no flag) emits the `vault:` ref UNRESOLVED, with a note, and never touches the broker", async () => {


### PR DESCRIPTION
## Summary

Both follow-ups from the review of #4471 (`fix(hindsight): resolve vault: LLM api_key refs on the recreate/rollout launch path`), fixed together since both live in `src/cli/memory.ts`.

### #4487 — `memory docker-compose` no longer prints live secrets to stdout by default

#4471 wired `vault:` resolution into the compose-snippet emit site (`src/cli/memory.ts:1058` at the time) — functionally required (a compose file with a literal `vault:` ref is broken) and consistent with what `cp_access_key` already did, so not a careless regression. But it changed what the command emits to stdout: a live `sk-…` key, from an operator-invoked command whose output routinely gets pasted into terminals, files, and chat.

**Implemented the design from the issue** (did not substitute my own):
- Default: emit `vault:` refs unresolved, plus a note that the snippet needs resolving before use.
- New `--resolve-secrets` opt-in flag restores the resolved-key behaviour.
- `cp_access_key` follows the same rule (previously always resolved) — one consistent default for the command instead of two.

I considered the alternatives the issue raises (emit to a `0600` file; keep resolution on but redact on a TTY):
- **0600 file** is a bigger behavioural change (a `docker-compose` verb that writes to disk instead of stdout) for a command whose whole contract today is "print a snippet to paste"; it also doesn't help the common case of piping into a file the operator names themselves (`> compose.yml`), which would still be an unencrypted live-key file.
- **Redact-on-TTY, resolve-when-piped** is TTY-detection-dependent (model-dependent-ish, and every agent/CI/hook invocation is non-TTY, i.e. *always* piped) — it would resolve secrets by default in exactly the automated contexts where an accidental `docker-compose > some-log-capturing-place.txt` is most likely, which is the opposite of what we want.

`--resolve-secrets` is the simplest mechanism that is deterministic regardless of TTY/pipe context and matches the issue's own proposal, so I went with it as specified.

### #4486 — wiring regression test for `memory setup --recreate`

No test file referenced `registerMemoryCommand` at all, so there was no harness to hang a direct assertion on the `--recreate` launch path (`src/cli/memory.ts:991` at review time) — the path that actually caused the 2026-08-06 outage (reached from `src/cli/rollout.ts:1412` via hostd's refresh step). The existing regression test (`tests/setup-verification.test.ts:578`) only covers `stepMemoryBackend`, a different first-run-setup code path.

Added `tests/cli.memory-secrets-wiring.test.ts`: the first `registerMemoryCommand` harness (`new Command()` + `registerMemoryCommand(program)` + `parseAsync`, mirroring the shape of `tests/cli.agent-start-exit-code.test.ts`). It mocks only the docker-touching surface of `src/setup/hindsight.js` (container probes, port allocation, pull/stop) and the vault broker client, keeping every resolver (`resolveHindsightLlmSecrets`, `resolveHindsightCpAccessKey`, `hindsightGpuDecision`, `generateHindsightComposeSnippet`, ...) real. On top of that harness:

- a wiring assertion for `--recreate`, in the same shape as the existing `stepMemoryBackend` test (spies `startHindsight`, asserts the resolved `sk-…` key reaches the 4th positional arg and no `vault:` literal does)
- coverage for the new `--resolve-secrets` flag (default unresolved + note, `--resolve-secrets` resolved, `cp_access_key` follows the same rule)

Both new guards were verified to FAIL when the fix they pin is reverted (a live `sk-…` key reaching stdout without `--resolve-secrets`, and the `--recreate` launch path handed the raw `vault:` config instead of the resolved one) — pasted into the PR description's test plan below.

## Test plan

- [x] `npx vitest run tests/cli.memory-secrets-wiring.test.ts tests/setup-verification.test.ts` — 56/56 pass
- [x] Confirmed the #4486 guard fails when `--recreate`'s `startHindsight` call is reverted to pass the raw (unresolved) `hindsight.llm` config
- [x] Confirmed the #4487 guard fails when `--resolve-secrets` is forced on unconditionally (simulating the pre-fix always-resolve behaviour)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (full check suite; no full test suite run locally per instructions)
- [x] CHANGELOG `## Unreleased` entry added under a new `### Hindsight` section (rebased cleanly, no conflict)

Not run locally (CI is the full-suite authority): the full `vitest` suite.