### PR TITLE
fix(telegram-plugin): stop history.js module-mock leak causing #4488 flake

### DIFF
--- a/scripts/check-bun-module-mock-scope.mjs
+++ b/scripts/check-bun-module-mock-scope.mjs
@@ -42,15 +42,29 @@
  * through a dependency seam instead of touching the module registry. A DI fake
  * exists only inside the instance the test constructs and cannot leak.
  *
- * What this does NOT catch (deliberate, documented residual)
- * ----------------------------------------------------------
- * An intra-`telegram-plugin/` module mock leaks just as globally. Two of those
- * exist today (`../history.js`, `../gateway/auth-broker-client.js`) and are
- * benign only because no sibling suite exercises the real module. Banning them
- * outright would be a retrofit beyond this gate's evidence; the cross-package
- * boundary is where the demonstrated breakage occurred, and it is the boundary
- * a new mock is most likely to cross. If an intra-plugin mock ever collides,
- * tighten this to a total ban rather than adding an exception.
+ * An intra-`telegram-plugin/` module mock leaks just as globally — this WAS
+ * theoretical, and is no longer. #4488/#4491: `tests/captured-answer-resume.test.ts`
+ * module-mocked `../history.js` (assumed "benign" here because "no sibling
+ * suite exercises the real module" — that assumption was simply wrong:
+ * `tests/history.test.ts` imports and calls the real `hasOutboundWithText`
+ * directly). Under `bun test`'s process-global `mock.module`, the mock's
+ * default stub (`() => false`) retroactively answered `history.test.ts`'s
+ * calls too, producing false `hasOutboundWithText` misses against a database
+ * that in fact held the row — the exact "Expected: true / Received: false"
+ * signature from #4488/#4491, intermittent because it depends on bun's file
+ * discovery/module-resolution ordering within the sweep. Fixed by injecting
+ * the oracle through `CapturedResumePorts.hasOutboundWithText` instead (see
+ * `gateway/captured-answer-resume.ts`) and removing that mock.
+ *
+ * Per this gate's own prior guidance ("if an intra-plugin mock ever
+ * collides, tighten this to a total ban"): `../history.js` is now banned
+ * outright below, not just discouraged in a comment. It is still exercised
+ * for real by other swept suites, so any future re-introduction of a
+ * `../history.js` module-mock in this sweep is exactly as dangerous as the
+ * one that just broke `bun-test-run`.
+ * `../gateway/auth-broker-client.js` remains an untightened, still-documented
+ * residual risk (no proven collision yet) — out of scope for this change;
+ * tighten it the same way if it ever collides.
  *
  * Run: `npm run lint:bun-module-mock-scope` (also part of `npm run lint`).
  */
@@ -77,6 +91,15 @@ export const SWEPT_DIRS = [
 
 /** The package boundary a swept file's module mocks must stay inside. */
 export const MOCK_BOUNDARY = 'telegram-plugin'
+
+/**
+ * Intra-plugin specifiers that are banned outright for swept files, even
+ * though they resolve inside `MOCK_BOUNDARY`. `../history.js` (any relative
+ * depth) was the #4488/#4491 collision: proven to leak into a sibling suite
+ * that exercises the real module. Matched by resolved path suffix so it
+ * catches every file's relative spelling of the same module.
+ */
+export const BANNED_INTRA_PLUGIN_MOCKS = ['telegram-plugin/history.ts', 'telegram-plugin/history.js']
 
 /**
  * Strip `//` line comments and block comments so a file that merely
@@ -147,6 +170,10 @@ export function findModuleMocks(src) {
 export function evaluateMock(file, spec, line) {
   if (!spec.startsWith('.')) return null
   const resolved = relative(repoRoot, resolve(dirname(join(repoRoot, file)), spec))
+  const resolvedAsTs = resolved.replace(/\.js$/, '.ts')
+  if (BANNED_INTRA_PLUGIN_MOCKS.includes(resolved) || BANNED_INTRA_PLUGIN_MOCKS.includes(resolvedAsTs)) {
+    return { file, line, spec, resolved, banned: true }
+  }
   if (resolved.startsWith(MOCK_BOUNDARY + sep)) return null
   return { file, line, spec, resolved }
 }
@@ -186,6 +213,16 @@ function main() {
     return
   }
   for (const v of violations) {
+    if (v.banned) {
+      console.error(
+        `${v.file}:${v.line}: module-mocks '${v.spec}' → ${v.resolved}, which is banned outright ` +
+        `(the #4488/#4491 collision — see this script's docblock).\n` +
+        `  Under 'bun test' this replaces that module for EVERY test file in the run, including\n` +
+        `  suites that exercise the real module. Inject a fake through a dependency seam instead\n` +
+        `  (see gateway/captured-answer-resume.ts's CapturedResumePorts.hasOutboundWithText).`,
+      )
+      continue
+    }
     console.error(
       `${v.file}:${v.line}: module-mocks '${v.spec}' → ${v.resolved}, outside ${MOCK_BOUNDARY}/.\n` +
       `  Under 'bun test' this replaces that module for EVERY test file in the run.\n` +

--- a/telegram-plugin/gateway/captured-answer-resume.ts
+++ b/telegram-plugin/gateway/captured-answer-resume.ts
@@ -68,7 +68,7 @@
  * `deliver` (via `deliverAnswer`), the durable oracle, and the obligation I/O.
  */
 
-import { hasOutboundWithText } from '../history.js'
+import { hasOutboundWithText as realHasOutboundWithText } from '../history.js'
 import type { BackstopDeliveryLedger } from './backstop-delivery.js'
 import type { CapturedDeliverySnapshot, Obligation } from './obligation-ledger.js'
 
@@ -168,6 +168,27 @@ export interface CapturedResumePorts {
   /** True when history is queryable (else the durable-text oracle reconcile that
    *  gives crash-idempotency — §2.3/A5 — is skipped). */
   historyEnabled: boolean
+  /**
+   * The durable outbound-text oracle. Defaults to the real `history.js`
+   * implementation; tests inject a fake here instead of module-mocking
+   * `../history.js`. A `vi.mock('../history.js', ...)` looks file-scoped
+   * under vitest but is NOT under bun's vitest-compat layer (`bun test`
+   * maps `vi.mock` onto the PROCESS-GLOBAL `mock.module`, which retroactively
+   * rebinds every other file's import of the same specifier in the same
+   * `bun-test-run` sweep — see check-bun-module-mock-scope.mjs). That leak
+   * was the actual root cause of #4488/#4491: a mocked `hasOutboundWithText`
+   * from this module's own test file silently answered
+   * `telegram-plugin/tests/history.test.ts`'s calls to the REAL function
+   * elsewhere in the same 651-file sweep, so a row `history.test.ts` had
+   * genuinely just written was reported as not found. Injecting via this
+   * port keeps the fake scoped to the dispatcher instance that receives it.
+   */
+  hasOutboundWithText?: (
+    chatId: string,
+    text: string,
+    threadId: number | null,
+    sinceMs?: number,
+  ) => boolean
   stderr?: (s: string) => void
 }
 
@@ -198,6 +219,7 @@ export interface CapturedResumeDispatcher {
  */
 export function createCapturedResumeDispatcher(ports: CapturedResumePorts): CapturedResumeDispatcher {
   const stderr = ports.stderr ?? (() => {})
+  const hasOutboundWithText = ports.hasOutboundWithText ?? realHasOutboundWithText
   const inFlight = new Set<string>()
 
   /** Re-deliver the UNSENT tail of `o`'s captured answer, byte-identical,

--- a/telegram-plugin/tests/captured-answer-resume.test.ts
+++ b/telegram-plugin/tests/captured-answer-resume.test.ts
@@ -1,14 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
-
-// The dispatcher's resume closure reaches for the durable outbound-text oracle
-// (history.hasOutboundWithText) to reconcile crash-idempotency. Mock it so these
-// stay pure vitest unit tests (no bun:sqlite / real DB) and we can control the
-// "did this chunk's text land durably?" answer per scenario.
-let mockOracle: (chatId: string, text: string, threadId: number | null, since: number) => boolean = () => false
-vi.mock('../history.js', () => ({
-  hasOutboundWithText: (chatId: string, text: string, threadId: number | null, since: number) =>
-    mockOracle(chatId, text, threadId, since),
-}))
+import { describe, expect, it, beforeEach } from 'vitest'
 
 import {
   BackstopDeliveryLedger,
@@ -36,7 +26,24 @@ import {
  *   (c) a fully-landed answer's represent sends NOTHING.
  * A test that would still pass if the resume re-sent a confirmed chunk is not a
  * test — every scenario asserts the exact `sendChunk` index set.
+ *
+ * The dispatcher's resume closure reaches for the durable outbound-text oracle
+ * (history.hasOutboundWithText) to reconcile crash-idempotency. `mockOracle`
+ * below is injected per-scenario via `createCapturedResumeDispatcher`'s
+ * `hasOutboundWithText` port (see `gateway/captured-answer-resume.ts`) — NOT
+ * via `vi.mock('../history.js', ...)`. That used to module-mock `history.js`,
+ * which looks file-scoped under vitest but under bun's vitest-compat layer
+ * `vi.mock` maps onto the process-global `mock.module`: `bun test` runs the
+ * whole `telegram-plugin/` surface in one process
+ * (`telegram-plugin/scripts/bun-test-ci.sh`), so the mock retroactively
+ * rebound `hasOutboundWithText` for every OTHER file in the same sweep —
+ * including `tests/history.test.ts`'s calls to the REAL implementation. That
+ * was the actual root cause of #4488/#4491: a row `history.test.ts` had
+ * genuinely just written to its own real bun:sqlite DB was reported "not
+ * found" because its `hasOutboundWithText` import had been silently rebound
+ * to this file's `() => false` default. See check-bun-module-mock-scope.mjs.
  */
+let mockOracle: (chatId: string, text: string, threadId: number | null, since: number) => boolean = () => false
 
 beforeEach(() => {
   mockOracle = () => false
@@ -192,6 +199,7 @@ describe('#3282 createCapturedResumeDispatcher — the represent RESUME outcome'
     oblLedger.noteCapturedDelivery('#t1', snapshot)
 
     const dispatcher = createCapturedResumeDispatcher({
+      hasOutboundWithText: mockOracle,
       deliverAnswer: makeResumeDeliverAnswer(resumeLedger, sentIdx),
       obligationLedger: oblLedger,
       backstopDeliveryLedger: resumeLedger,
@@ -228,6 +236,7 @@ describe('#3282 createCapturedResumeDispatcher — the represent RESUME outcome'
     mockOracle = (_c, txt) => txt === 'c0'
 
     const dispatcher = createCapturedResumeDispatcher({
+      hasOutboundWithText: mockOracle,
       deliverAnswer: makeResumeDeliverAnswer(resumeLedger, sentIdx),
       obligationLedger: oblLedger,
       backstopDeliveryLedger: resumeLedger,
@@ -258,6 +267,7 @@ describe('#3282 createCapturedResumeDispatcher — the represent RESUME outcome'
     oblLedger.noteCapturedDelivery('#t1', snapshot)
 
     const dispatcher = createCapturedResumeDispatcher({
+      hasOutboundWithText: mockOracle,
       deliverAnswer: makeResumeDeliverAnswer(resumeLedger, sentIdx),
       obligationLedger: oblLedger,
       backstopDeliveryLedger: resumeLedger,
@@ -302,6 +312,7 @@ describe('#3282 createCapturedResumeDispatcher — the represent RESUME outcome'
 
     const lines: string[] = []
     const dispatcher = createCapturedResumeDispatcher({
+      hasOutboundWithText: mockOracle,
       deliverAnswer: async (a) => {
         a.resume.hydrate(resumeLedger, a.turnId)
         const res = await runBackstopDelivery(
@@ -351,6 +362,7 @@ describe('#3282 createCapturedResumeDispatcher — the represent RESUME outcome'
 
     let probes = 0
     const dispatcher = createCapturedResumeDispatcher({
+      hasOutboundWithText: mockOracle,
       deliverAnswer: async (a) => {
         a.resume.hydrate(resumeLedger, a.turnId)
         const res = await runBackstopDelivery(
@@ -388,6 +400,7 @@ describe('#3282 createCapturedResumeDispatcher — the represent RESUME outcome'
 
     // A resume whose tail send keeps throwing ⇒ not delivered ⇒ obligation stays OPEN.
     const dispatcher = createCapturedResumeDispatcher({
+      hasOutboundWithText: mockOracle,
       deliverAnswer: async (a) => {
         a.resume.hydrate(resumeLedger, a.turnId)
         const res = await runBackstopDelivery(
@@ -423,6 +436,7 @@ describe('#3282 createCapturedResumeDispatcher — the represent RESUME outcome'
     oblLedger.noteCapturedDelivery('#t1', snapshot)
 
     const dispatcher = createCapturedResumeDispatcher({
+      hasOutboundWithText: mockOracle,
       deliverAnswer: async (a) => {
         deliverCalls++
         a.resume.hydrate(resumeLedger, a.turnId)
@@ -448,6 +462,7 @@ describe('#3282 createCapturedResumeDispatcher — the represent RESUME outcome'
   it('no captured snapshot ⇒ dispatch is a no-op (caller falls through to fresh generation)', async () => {
     let delivered = false
     const dispatcher = createCapturedResumeDispatcher({
+      hasOutboundWithText: mockOracle,
       deliverAnswer: async () => { delivered = true; return { delivered: true, sentIds: [] } },
       obligationLedger: new ObligationLedger(2),
       backstopDeliveryLedger: new BackstopDeliveryLedger(),

--- a/tests/check-bun-module-mock-scope.test.ts
+++ b/tests/check-bun-module-mock-scope.test.ts
@@ -58,10 +58,24 @@ describe('evaluateMock', () => {
     expect(v.line).toBe(41)
   })
 
-  it('allows a mock that stays inside telegram-plugin/', () => {
-    // The two in-tree precedents.
-    expect(evaluateMock(SWEPT, '../history.js', 8)).toBeNull()
+  it('allows a mock that stays inside telegram-plugin/ and is not separately banned', () => {
     expect(evaluateMock(SWEPT, '../gateway/auth-broker-client.js', 58)).toBeNull()
+  })
+
+  it('REJECTS a module-mock of history.js — the #4488/#4491 collision', () => {
+    // `tests/captured-answer-resume.test.ts` used to `vi.mock('../history.js', ...)`
+    // with a default stub that always returned false. Under bun's process-global
+    // `mock.module`, that leaked into `tests/history.test.ts`'s calls to the REAL
+    // `hasOutboundWithText`, producing the exact "Expected: true / Received: false"
+    // signature CI saw intermittently. This gate must reject that mock outright,
+    // not merely allow it because the specifier resolves inside telegram-plugin/.
+    const v = evaluateMock(SWEPT, '../history.js', 8)
+    expect(v).not.toBeNull()
+    expect(v.banned).toBe(true)
+    expect(v.resolved).toBe('telegram-plugin/history.js')
+
+    // Any relative depth / .ts spelling of the same module is caught too.
+    expect(evaluateMock('telegram-plugin/gateway/sub/x.test.ts', '../../history.ts', 1)?.banned).toBe(true)
   })
 
   it('allows a bare package specifier (not a first-party module)', () => {


### PR DESCRIPTION
## Root cause

`tests/captured-answer-resume.test.ts` module-mocked `../history.js`:

```ts
vi.mock('../history.js', () => ({
  hasOutboundWithText: (chatId, text, threadId, since) => mockOracle(chatId, text, threadId, since),
}))
```

with `mockOracle` defaulting to `() => false` (reset every `beforeEach`). Under vitest this mock is file-scoped. Under `bun test` — the `bun-test-run` CI job, which runs the *entire* `telegram-plugin/` surface (651 files) in **one shared process** (`telegram-plugin/scripts/bun-test-ci.sh`) — `vi.mock` maps onto bun's vitest-compat `mock.module`, which is **process-global** and retroactively rebinds every other file's import of the same specifier for the rest of the sweep, regardless of file order.

`tests/history.test.ts` imports and calls the *real* `hasOutboundWithText` directly. Once the mock landed (in either file order — the rebind is retroactive), it silently answered `history.test.ts`'s own calls too: a row `history.test.ts` had genuinely just written moments earlier was reported as not found — the exact intermittent `Expected: true / Received: false` signature reported in #4488/#4491, six assertions in `hasOutboundWithText (durable text-identity oracle)`. Whether it manifests in a given run depends on bun's file discovery/module-resolution ordering, matching both issues' own note that it "reproduces intermittently... on identical commits."

`scripts/check-bun-module-mock-scope.mjs` already documents this exact class of hazard (previously proven by PR #3632/#3627) and had explicitly carved out `../history.js` as an exception, reasoning it was *"benign... because no sibling suite exercises the real module."* That assumption was simply false — `history.test.ts` is exactly such a sibling suite.

## Fix

- Inject the durable-text oracle through a dependency seam instead of module-mocking, per the repo's own documented bun-safe convention (already used by `tests/session-tail-sidecar-reap.test.ts`). Added an optional `hasOutboundWithText` port to `CapturedResumePorts` in `gateway/captured-answer-resume.ts` (defaults to the real `history.js` export), removed the `vi.mock`, and injected the test's mock oracle directly at each `createCapturedResumeDispatcher(...)` construction site in the test file.
- Tightened `scripts/check-bun-module-mock-scope.mjs` to **ban** `../history.js` module-mocks outright for bun-swept files, per the gate's own prior guidance ("if an intra-plugin mock ever collides, tighten this to a total ban rather than adding an exception"). Extended `tests/check-bun-module-mock-scope.test.ts`: the new case asserts the gate rejects the exact mock the old test file used, at any relative depth/`.ts` spelling.

## Verification

- `node scripts/check-bun-module-mock-scope.mjs` — exits 1 (correctly flags the violation) against the reverted pre-fix files, exits 0 against the committed fix. This is the regression test: it would have failed on the actual bug's enabling condition, not just a symptom.
- `npx vitest run tests/check-bun-module-mock-scope.test.ts telegram-plugin/tests/captured-answer-resume.test.ts` — 24/24 pass.
- `npm run lint` — clean (full composite gate, including the tightened check-bun-module-mock-scope).
- Full `telegram-plugin` bun sweep (permitted for this task): `10820 pass, 4 skip, 54 fail` across 651 files / 10878 tests. The 54 failures are the pre-existing, unrelated set (gateway reply-pipeline timing suites — `sendReply golden harness`, `#3429/#4172/#4176 handback/supersede`, etc. — none touch `history.js`/`hasOutboundWithText`), identical before and after this change. Zero occurrences of `hasOutboundWithText` in the failure log.

## Scope note

An earlier hypothesis (a leaked `initHistory()` handle serving the wrong stateDir, shadowed by `hasOutboundWithText`'s `ORDER BY ts DESC LIMIT 500` window) is a real, independently-reproducible latent defect in `history.ts`, but a CI-side instrumented diagnostic run by another investigator showed the DB file and row content were correct at failure time — ruling it out as the cause of *this* flake. It is not included in this PR; happy to file it separately if desired.

Closes #4488. #4491 was triaged as a duplicate and closed (`not planned`, referencing #4488) before this change.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>