### PR TITLE
feat(hindsight): configurable container memory cap + shared_buffers safety check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,10 @@ now an anomaly worth investigating, not the norm.
   changes to expect: the **ultraplan** feature is gone, and `/review` is now an
   alias for `/code-review`.
 
+### Hindsight
+
+- **`hindsight.mem_limit` — the container's memory cap is configurable, and a cap that cannot hold `shared_buffers` now says so** — the cap was a hard-coded `16g` with no config path, while `shared_buffers` (a managed `hindsight.env` key) was configurable. An operator who raised the live container to 24 GiB by hand to fit a 12 GiB buffer pool had it silently reverted to 16 GiB by the next `switchroom memory setup --recreate`, with the 12 GiB `shared_buffers` left standing inside it — Postgres pinning most of its own cgroup as unreclaimable shared memory, warned about nowhere. `hindsight.mem_limit` (a docker size string; absent → the unchanged `16g` default) now reaches docker `--memory` and the compose `mem_limit:` from one resolver, so the two launch paths cannot disagree, and it is honoured on first-run `switchroom setup` as well as on `memory setup`. It is a first-class field rather than an `env:` key because it is a docker `HostConfig.Memory` flag, not a variable emitted into the container. On top of the knob, every launch now checks the resolved cap against the resolved `shared_buffers` and warns — naming both numbers and both keys — when the cap does not clear the buffer pool by the app working set plus the page-cache floor (4608 MiB). Warning, not refusal: the dangerous state is a default re-asserting itself, and hard-failing there would leave the fleet with no memory container at all. A malformed size string is still rejected outright, at `switchroom apply` by the schema and at launch rather than silently falling back to the default.
+
 ## v0.20.12 — native WebSearch fleet-wide, faster sub-agent cards, Hindsight recall speedups, and token-aware LiteLLM pacing
 
 ### Web tooling

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -756,6 +756,35 @@ hindsight:
 
 If you run your own Hindsight container outside `switchroom memory --start` (e.g. you point `memory.config.url` at an external server), switchroom doesn't manage that container's env — set the cap on your own image.
 
+### Memory cap for the Hindsight container (`hindsight.mem_limit`)
+
+The Hindsight container is created with a hard memory cap — docker `--memory` on the `switchroom memory setup` path, `mem_limit:` in the `switchroom memory docker-compose` snippet. The default is **16g**, and until this key existed that was also the *only* value: there was no config path at all.
+
+```yaml
+hindsight:
+  mem_limit: 24g          # a docker size string: 24g, 16384m, …
+  env:
+    SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS: 12288MB
+```
+
+It is a first-class field rather than a `hindsight.env` key on purpose: `env` is the map of variables switchroom **emits into** the container, and the memory cap is a docker `HostConfig.Memory` flag consumed by the daemon — no process inside the container ever sees it.
+
+**Move it together with `shared_buffers`.** They are one decision, not two knobs. Hindsight's embedded PostgreSQL runs with `shared_memory_type=mmap`, so `shared_buffers` is charged to the container's cgroup as **unreclaimable** anonymous memory: whatever you give the buffer pool is subtracted from the cap before anything else in the container gets a byte. The container still has to hold its ~2.5 GiB app working set (API process, embedder, cross-encoder, next-server) plus a page-cache floor on top of that.
+
+The failure this key removes is the asymmetry, not the number. `shared_buffers` was configurable (a managed `hindsight.env` key); the cap was not. So an operator who raised the live container's cap by hand to fit a larger buffer pool had it silently reverted to 16g by the **next `switchroom memory setup --recreate`**, while their `shared_buffers` stayed exactly where they had put it — leaving Postgres pinning most of its own cgroup, with no warning anywhere. Setting `hindsight.mem_limit` makes the cap survive a recreate like every other configured value.
+
+Switchroom now also **warns** when the resolved cap does not clear the resolved `shared_buffers` by at least the app working set plus the page-cache floor (4608 MiB — the same arithmetic the shipped defaults are derived from). The warning names both numbers and both keys, and fires on the launch path itself, so a `--recreate` that puts the container into that state says so:
+
+```
+! hindsight: container memory cap 16g (16 GiB) leaves only 4 GiB above shared_buffers
+  12288MB (12 GiB) — … Raise `hindsight.mem_limit` to at least 17 GiB, or lower
+  `hindsight.env.SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS`.
+```
+
+It is a **warning, not a refusal**, deliberately: the dangerous state is reached by a default re-asserting itself, so hard-failing there would turn "the memory container is badly sized" into "the fleet has no memory container at all". Two things *are* rejected outright: a malformed size string (by the schema at `switchroom apply`, and again at launch rather than silently falling back to the default), and a cap below the container's 4g memory *reservation* — docker will not create such a container, and its own rejection is late and opaque.
+
+Both launch paths resolve the cap from one place, so the `docker run` and `--compose` outputs cannot disagree. Changing it takes effect on the next container recreate (`switchroom memory setup --recreate`), not live.
+
 ### Logging in to the Hindsight dashboard (`hindsight.cp_access_key`)
 
 The Hindsight container also serves a **control-plane dashboard** (Next.js, host port 9999) alongside the memory API. That dashboard's login is armed by exactly one thing — upstream's `HINDSIGHT_CP_ACCESS_KEY`. When the variable is unset the access-key middleware short-circuits and lets every request through: the dashboard is not weakly protected, it has **no authentication at all**.

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -30,6 +30,7 @@ import {
   getHindsightContainerEnv,
   getHindsightImageEnv,
   hindsightContainerEnvPairs,
+  hindsightMemBudgetWarningFor,
   hindsightResolvedCapabilities,
   preflightHindsightPorts,
   getHindsightDeviceRequests,
@@ -1042,8 +1043,15 @@ export function registerMemoryCommand(program: Command): void {
           // disagree with the guard that just cleared it — the exact class of
           // silent divergence this PR exists to close.
           gpuDecision.enabled,
-          // Operator overrides for the capability-gated performance defaults.
-          { env: hindsightConfig.hindsight?.env },
+          // Operator overrides for the capability-gated performance defaults,
+          // plus the container's memory cap (`hindsight.mem_limit`). Without
+          // that last one every `--recreate` silently reset the cap to the
+          // hard-coded default while leaving the operator's `shared_buffers`
+          // standing — see resolveHindsightMemLimit.
+          {
+            env: hindsightConfig.hindsight?.env,
+            memLimit: hindsightConfig.hindsight?.mem_limit,
+          },
           // Resolved `hindsight.cp_access_key`. Absent ⇒ the CP dashboard has
           // no login, so hindsightCpAuthEnvPairs pins it to loopback.
           cpAccessKey,
@@ -1096,6 +1104,18 @@ export function registerMemoryCommand(program: Command): void {
         if (!cpAccessKey) {
           console.error(chalk.yellow(`# ! ${HINDSIGHT_CP_NO_ACCESS_KEY_WARNING}`));
         }
+        // The docker-run path warns from inside startHindsight(); the compose
+        // generator is a pure string builder, so its wrapper carries the same
+        // check. To stderr with a `#` prefix so a redirected stdout stays a
+        // valid compose file even under `2>&1` (same discipline as the
+        // secrets notice below).
+        {
+          const memWarning = hindsightMemBudgetWarningFor({
+            env: snippetConfig.hindsight?.env,
+            memLimit: snippetConfig.hindsight?.mem_limit,
+          });
+          if (memWarning) console.error(chalk.yellow(`# ! ${memWarning}`));
+        }
         // Resolve `vault:` api_key refs so the emitted compose file carries the
         // real credential — the same reason the docker-run path resolves them,
         // and the same shape the cp_access_key above already takes. An emitted
@@ -1125,7 +1145,12 @@ export function registerMemoryCommand(program: Command): void {
             hindsightGpuDecision(
               resolveHindsightGpuOverride({ config: snippetConfig.hindsight?.gpu }),
             ).enabled,
-            { env: snippetConfig.hindsight?.env },
+            // Same options object the docker-run path builds, so the emitted
+            // compose file caps the container exactly as `memory setup` would.
+            {
+              env: snippetConfig.hindsight?.env,
+              memLimit: snippetConfig.hindsight?.mem_limit,
+            },
             cpAccessKey,
           ),
         );

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1348,8 +1348,13 @@ export async function stepMemoryBackend(
       hindsightConsumerMirrorDir(config),
       // gpu: omitted ⇒ hindsightGpuEnabled() reads the persisted verdict.
       undefined,
-      // perf: omitted ⇒ the managed defaults, same as before.
-      undefined,
+      // The container's memory cap (`hindsight.mem_limit`, absent ⇒
+      // HINDSIGHT_DEFAULT_MEM_LIMIT) plus the `hindsight.env` overrides the
+      // cap is checked against — the shared_buffers-vs-cap warning is only
+      // honest when it can see the operator's shared_buffers override, and a
+      // knob honoured on `memory setup` but ignored on first-run `switchroom
+      // setup` would be the same silent divergence again.
+      { env: config.hindsight?.env, memLimit: config.hindsight?.mem_limit },
       // Resolved `hindsight.cp_access_key` — absent ⇒ loginless dashboard,
       // pinned to loopback by hindsightCpAuthEnvPairs.
       cpAccessKey,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2796,6 +2796,28 @@ export const HindsightConfigSchema = z.object({
       "turn a GPU container into a CPU one). `--gpu`/`--no-gpu` on `memory " +
       "setup` override this for a single run.",
     ),
+  mem_limit: z
+    .string()
+    .regex(
+      /^\d+(\.\d+)?\s*[bkmgt]?b?$/i,
+      "hindsight.mem_limit must be a docker memory size, e.g. `24g` or `16384m`",
+    )
+    .optional()
+    .describe(
+      "Hard memory cap for the hindsight container — docker `--memory` on the " +
+      "`memory setup` path and `mem_limit:` in the emitted compose snippet. A " +
+      "docker size string (`24g`, `16384m`). Absent → switchroom's default " +
+      "(`HINDSIGHT_DEFAULT_MEM_LIMIT`, 16g). This is a docker HostConfig flag, " +
+      "not a container env var, which is why it is a first-class field here " +
+      "rather than an `env:` key. **Move it together with " +
+      "`env.SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS`**: Postgres pins the " +
+      "buffer pool as unreclaimable shared memory inside this cap, so a cap " +
+      "that does not clear `shared_buffers` by the container's app working " +
+      "set plus its page-cache floor puts Postgres in a near-OOM " +
+      "configuration. switchroom warns, naming both numbers, when it does " +
+      "not. A value below the container's memory RESERVATION (4g) is " +
+      "rejected outright — docker will not create such a container.",
+    ),
   cp_access_key: z
     .string()
     .min(1)

--- a/src/setup/hindsight-mem-limit.test.ts
+++ b/src/setup/hindsight-mem-limit.test.ts
@@ -1,0 +1,322 @@
+/**
+ * `hindsight.mem_limit` — the container's docker memory cap.
+ *
+ * ## The bug these tests exist for
+ *
+ * The cap was a hard-coded `16g` with no config path. An operator raised the
+ * live container to 24 GiB by hand so a 12 GiB `shared_buffers` would fit; the
+ * next `switchroom memory setup --recreate` put the cap silently back to 16 GiB
+ * and left the 12 GiB buffer pool configured inside it — Postgres pinning 75%
+ * of its own cgroup as unreclaimable shared memory, with no warning anywhere.
+ *
+ * So, in order of how badly a regression would hurt:
+ *
+ *   1. **A configured cap actually reaches docker — on BOTH launch paths.** A
+ *      knob that lands in the docker-run argv but not the compose snippet
+ *      re-creates the divergence rather than fixing it.
+ *   2. **The default is untouched when nothing is configured.** This change
+ *      must be invisible to every existing install.
+ *   3. **The dangerous combination is named out loud.** The config knob alone
+ *      only moves the foot-gun; the warning is what stops it recurring. It
+ *      must fire on cap 16 GiB + shared_buffers 12 GiB and stay quiet on the
+ *      shipped defaults.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { execFileSyncMock } = vi.hoisted(() => ({ execFileSyncMock: vi.fn() }));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, execFileSync: execFileSyncMock };
+});
+
+import {
+  HINDSIGHT_PG_APP_ANON_MIB,
+  HINDSIGHT_PG_DEFAULT_SHARED_BUFFERS_MIB,
+  HINDSIGHT_PG_MIN_NON_BUFFER_MIB,
+  HINDSIGHT_PG_PAGE_CACHE_FLOOR_MIB,
+  HINDSIGHT_PG_SHARED_BUFFERS_ENV,
+  hindsightMemBudgetWarning,
+  parseDockerSizeToMib,
+  parsePgSizeToMib,
+  pgMib,
+} from "./hindsight-pg-defaults.js";
+import {
+  HINDSIGHT_DEFAULT_MEM_LIMIT,
+  generateHindsightComposeSnippet,
+  hindsightMemBudgetWarningFor,
+  resolveHindsightMemLimit,
+  startHindsight,
+} from "./hindsight.js";
+
+beforeEach(() => {
+  execFileSyncMock.mockReset();
+  execFileSyncMock.mockReturnValue(Buffer.from(""));
+});
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+/** The `docker run` argv for the hindsight container itself. */
+function runArgs(): string[] {
+  const call = execFileSyncMock.mock.calls.find(
+    (c) =>
+      c[0] === "docker" &&
+      Array.isArray(c[1]) &&
+      (c[1] as string[])[0] === "run" &&
+      (c[1] as string[]).includes("switchroom-hindsight"),
+  );
+  expect(call, "startHindsight must have issued a `docker run`").toBeDefined();
+  return call![1] as string[];
+}
+
+/** `--memory=…` flags in a docker-run argv. */
+function memoryFlags(args: string[]): string[] {
+  return args.filter((a) => a.startsWith("--memory="));
+}
+
+/** `mem_limit: …` lines in a compose snippet. */
+function composeMemLimits(snippet: string): string[] {
+  return snippet
+    .split("\n")
+    .filter((l) => /^ {4}mem_limit:/.test(l))
+    .map((l) => l.replace(/^ {4}mem_limit:\s*/, ""));
+}
+
+// ── 1. an explicit cap reaches BOTH launch paths ──────────────────────────
+describe("hindsight.mem_limit reaches docker", () => {
+  it("puts the configured cap in the docker-run argv, exactly once", () => {
+    startHindsight(undefined, undefined, undefined, undefined, undefined, false, {
+      memLimit: "24g",
+    });
+    // The bug: this used to be `16g` no matter what the operator configured.
+    expect(memoryFlags(runArgs())).toEqual(["--memory=24g"]);
+  });
+
+  it("puts the SAME configured cap in the compose snippet", () => {
+    const snippet = generateHindsightComposeSnippet(
+      undefined,
+      undefined,
+      undefined,
+      false,
+      { memLimit: "24g" },
+    );
+    expect(composeMemLimits(snippet)).toEqual(["24g"]);
+  });
+
+  it("keeps the two launch paths on the same cap for the same input", () => {
+    for (const memLimit of [undefined, "24g", "32768m"]) {
+      execFileSyncMock.mockReset();
+      execFileSyncMock.mockReturnValue(Buffer.from(""));
+      startHindsight(undefined, undefined, undefined, undefined, undefined, false, {
+        memLimit,
+      });
+      const fromRun = memoryFlags(runArgs())[0].replace("--memory=", "");
+      const fromCompose = composeMemLimits(
+        generateHindsightComposeSnippet(undefined, undefined, undefined, false, {
+          memLimit,
+        }),
+      )[0];
+      expect(fromCompose, `mem_limit=${String(memLimit)}`).toBe(fromRun);
+    }
+  });
+
+  it("still emits NO --memory-swap alongside a configured cap", () => {
+    // The pre-existing invariant (see HINDSIGHT_DEFAULT_MEM_LIMIT's comment):
+    // memory-swap == memory disables swap and converts graceful degradation
+    // into a hard OOM kill. A new knob must not smuggle one in.
+    startHindsight(undefined, undefined, undefined, undefined, undefined, false, {
+      memLimit: "24g",
+    });
+    expect(runArgs().some((a) => a.startsWith("--memory-swap"))).toBe(false);
+  });
+
+  it("rejects a value docker could not parse instead of silently defaulting", () => {
+    // Silently substituting the default for a typo would be the SAME failure
+    // this change removes: the operator asks for a cap and gets 16g anyway.
+    expect(() => resolveHindsightMemLimit({ memLimit: "24 gigs" })).toThrow(
+      /not a docker memory size/,
+    );
+  });
+
+  it("rejects a cap under the container's own memory reservation", () => {
+    // `--memory-reservation` is emitted unconditionally, and docker refuses to
+    // create a container whose limit is under its reservation. That state was
+    // unreachable while the cap was a constant; this knob makes it reachable,
+    // so it fails here with both numbers rather than opaquely in docker.
+    expect(() => resolveHindsightMemLimit({ memLimit: "2g" })).toThrow(
+      /below the container's memory reservation \(4g\)/,
+    );
+    expect(resolveHindsightMemLimit({ memLimit: "4g" })).toBe("4g");
+  });
+});
+
+// ── 2. no behaviour change for existing installs ──────────────────────────
+describe("hindsight.mem_limit default", () => {
+  it("is unchanged at 16g", () => {
+    expect(HINDSIGHT_DEFAULT_MEM_LIMIT).toBe("16g");
+  });
+
+  it("emits the default when nothing is configured, on both paths", () => {
+    startHindsight();
+    expect(memoryFlags(runArgs())).toEqual([`--memory=${HINDSIGHT_DEFAULT_MEM_LIMIT}`]);
+    expect(composeMemLimits(generateHindsightComposeSnippet())).toEqual([
+      HINDSIGHT_DEFAULT_MEM_LIMIT,
+    ]);
+  });
+
+  it("treats a blank / whitespace value as unset, not as an error", () => {
+    for (const blank of ["", "   "]) {
+      expect(resolveHindsightMemLimit({ memLimit: blank })).toBe(HINDSIGHT_DEFAULT_MEM_LIMIT);
+    }
+    expect(resolveHindsightMemLimit(undefined)).toBe(HINDSIGHT_DEFAULT_MEM_LIMIT);
+    expect(resolveHindsightMemLimit({})).toBe(HINDSIGHT_DEFAULT_MEM_LIMIT);
+  });
+});
+
+// ── 3. the safety check ───────────────────────────────────────────────────
+describe("shared_buffers-vs-cap safety check", () => {
+  it("is the same arithmetic the compile-time budget reserves", () => {
+    expect(HINDSIGHT_PG_MIN_NON_BUFFER_MIB).toBe(
+      HINDSIGHT_PG_APP_ANON_MIB + HINDSIGHT_PG_PAGE_CACHE_FLOOR_MIB,
+    );
+  });
+
+  it("fires on the observed dangerous state: 16 GiB cap, 12 GiB shared_buffers", () => {
+    const warning = hindsightMemBudgetWarning({
+      memLimit: "16g",
+      sharedBuffers: "12288MB",
+    });
+    expect(warning).not.toBeNull();
+    // A warning that does not name both numbers and the key to change is not
+    // actionable — that was the whole defect.
+    expect(warning).toContain("16g");
+    expect(warning).toContain("12288MB");
+    expect(warning).toContain("hindsight.mem_limit");
+    expect(warning).toContain("SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS");
+  });
+
+  it("stays quiet on the shipped defaults", () => {
+    expect(
+      hindsightMemBudgetWarning({
+        memLimit: HINDSIGHT_DEFAULT_MEM_LIMIT,
+        sharedBuffers: pgMib(HINDSIGHT_PG_DEFAULT_SHARED_BUFFERS_MIB),
+      }),
+    ).toBeNull();
+  });
+
+  it("stays quiet on the operator's fix (24 GiB cap, 12 GiB shared_buffers)", () => {
+    expect(
+      hindsightMemBudgetWarning({ memLimit: "24g", sharedBuffers: "12288MB" }),
+    ).toBeNull();
+  });
+
+  it("sits exactly on the boundary, not near it", () => {
+    const bufMib = 8192;
+    const exact = bufMib + HINDSIGHT_PG_MIN_NON_BUFFER_MIB;
+    expect(
+      hindsightMemBudgetWarning({
+        memLimit: `${exact}m`,
+        sharedBuffers: pgMib(bufMib),
+      }),
+      "a cap exactly equal to buffers + reserved headroom is acceptable",
+    ).toBeNull();
+    expect(
+      hindsightMemBudgetWarning({
+        memLimit: `${exact - 1}m`,
+        sharedBuffers: pgMib(bufMib),
+      }),
+      "one MiB under is not",
+    ).not.toBeNull();
+  });
+
+  it("says nothing rather than assert a wrong number on an unparseable input", () => {
+    expect(
+      hindsightMemBudgetWarning({ memLimit: "lots", sharedBuffers: "12288MB" }),
+    ).toBeNull();
+    expect(
+      hindsightMemBudgetWarning({ memLimit: "16g", sharedBuffers: "plenty" }),
+    ).toBeNull();
+  });
+
+  it("honours the `off` sentinel — pg0's own 256MB clears any sane cap", () => {
+    expect(hindsightMemBudgetWarning({ memLimit: "16g", sharedBuffers: "off" })).toBeNull();
+  });
+});
+
+describe("safety check against the config that will actually launch", () => {
+  it("fires when the DEFAULT cap meets an operator-raised shared_buffers", () => {
+    // This is the exact recurrence path: `hindsight.env` raised
+    // shared_buffers, `hindsight.mem_limit` left unset, so the hard-coded
+    // default cap comes back under it.
+    const warning = hindsightMemBudgetWarningFor({
+      env: { [HINDSIGHT_PG_SHARED_BUFFERS_ENV]: "12288MB" },
+    });
+    expect(warning).not.toBeNull();
+    expect(warning).toContain(HINDSIGHT_DEFAULT_MEM_LIMIT);
+    expect(warning).toContain("12288MB");
+  });
+
+  it("goes quiet once the operator also raises the cap", () => {
+    expect(
+      hindsightMemBudgetWarningFor({
+        env: { [HINDSIGHT_PG_SHARED_BUFFERS_ENV]: "12288MB" },
+        memLimit: "24g",
+      }),
+    ).toBeNull();
+  });
+
+  it("is silent for a stock install", () => {
+    expect(hindsightMemBudgetWarningFor()).toBeNull();
+    expect(hindsightMemBudgetWarningFor({ env: {} })).toBeNull();
+  });
+
+  it("warns on the launch path itself, not only in the CLI wrapper", () => {
+    // `switchroom memory setup --recreate` is what did the reverting, so the
+    // warning has to be attached to the launcher. A CLI-only warning would be
+    // skipped by every other caller of startHindsight().
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    startHindsight(undefined, undefined, undefined, undefined, undefined, false, {
+      env: { [HINDSIGHT_PG_SHARED_BUFFERS_ENV]: "12288MB" },
+    });
+    const said = warn.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(said).toContain("shared_buffers");
+    expect(said).toContain("12288MB");
+    expect(said).toContain("hindsight.mem_limit");
+  });
+
+  it("does not warn on a stock launch", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    startHindsight();
+    const said = warn.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(said).not.toContain("shared_buffers");
+  });
+});
+
+// ── size parsing ──────────────────────────────────────────────────────────
+describe("size parsing", () => {
+  it("parses docker sizes base-1024, with a bare number meaning BYTES", () => {
+    expect(parseDockerSizeToMib("16g")).toBe(16384);
+    expect(parseDockerSizeToMib("24G")).toBe(24576);
+    expect(parseDockerSizeToMib("2gb")).toBe(2048);
+    expect(parseDockerSizeToMib("512m")).toBe(512);
+    expect(parseDockerSizeToMib("1024k")).toBe(1);
+    expect(parseDockerSizeToMib("1048576")).toBe(1);
+    expect(parseDockerSizeToMib("plenty")).toBeNull();
+    expect(parseDockerSizeToMib("")).toBeNull();
+  });
+
+  it("parses postgres sizes, with a bare number meaning 8 kB BLOCKS", () => {
+    // Not the same grammar as docker's, and getting it wrong here would
+    // silence or misfire the check by a factor of 8192.
+    expect(parsePgSizeToMib("12288MB")).toBe(12288);
+    expect(parsePgSizeToMib("4GB")).toBe(4096);
+    expect(parsePgSizeToMib("2048kB")).toBe(2);
+    expect(parsePgSizeToMib("131072")).toBe(1024);
+    expect(parsePgSizeToMib("off")).toBe(256);
+    expect(parsePgSizeToMib("OFF")).toBe(256);
+    expect(parsePgSizeToMib("some")).toBeNull();
+  });
+});

--- a/src/setup/hindsight-pg-defaults.ts
+++ b/src/setup/hindsight-pg-defaults.ts
@@ -219,6 +219,151 @@ export function pgMib(mib: number): string {
 }
 
 /**
+ * `shared_buffers` pg0 itself starts with when switchroom's `-c` flag is
+ * omitted — the sentinel `off` case. Read off the live argv quoted in the
+ * module header (`-c shared_buffers=256MB`).
+ */
+export const HINDSIGHT_PG0_FALLBACK_SHARED_BUFFERS_MIB = 256;
+
+/**
+ * Parse a **docker** size string (`16g`, `512m`, `2G`, `1024`, `2gb`) to MiB.
+ *
+ * Docker's own parser is base-1024 and treats a bare number as BYTES; a bare
+ * number is almost always an operator mistake at this scale, so it is parsed
+ * faithfully rather than being second-guessed. Returns `null` for anything
+ * unparseable so callers can degrade instead of asserting a wrong number.
+ */
+export function parseDockerSizeToMib(size: string): number | null {
+  const m = size.trim().match(/^(\d+(?:\.\d+)?)\s*([bkmgt])?b?$/i);
+  if (!m) return null;
+  const n = Number(m[1]);
+  if (!Number.isFinite(n)) return null;
+  switch ((m[2] ?? "b").toLowerCase()) {
+    case "b":
+      return n / (1024 * 1024);
+    case "k":
+      return n / 1024;
+    case "m":
+      return n;
+    case "g":
+      return n * 1024;
+    case "t":
+      return n * 1024 * 1024;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Parse a **PostgreSQL** memory-parameter value (`6144MB`, `4GB`, `256MB`,
+ * `off`, or a bare block count) to MiB.
+ *
+ * Two shapes that are NOT docker's:
+ *  - a bare integer is a count of 8 kB blocks (postgres' `BLCKSZ`), not bytes;
+ *  - the sentinel `off` means switchroom omits the `-c` flag entirely, so the
+ *    effective value is pg0's own {@link HINDSIGHT_PG0_FALLBACK_SHARED_BUFFERS_MIB}.
+ *
+ * Returns `null` when the string is not a size switchroom can reason about.
+ */
+export function parsePgSizeToMib(value: string): number | null {
+  const raw = value.trim();
+  if (raw.toLowerCase() === "off") return HINDSIGHT_PG0_FALLBACK_SHARED_BUFFERS_MIB;
+  const m = raw.match(/^(\d+(?:\.\d+)?)\s*(kB|MB|GB|TB)?$/i);
+  if (!m) return null;
+  const n = Number(m[1]);
+  if (!Number.isFinite(n)) return null;
+  switch ((m[2] ?? "").toUpperCase()) {
+    case "":
+      // Bare number = 8 kB blocks.
+      return (n * 8) / 1024;
+    case "KB":
+      return n / 1024;
+    case "MB":
+      return n;
+    case "GB":
+      return n * 1024;
+    case "TB":
+      return n * 1024 * 1024;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Non-`shared_buffers` memory the container must still be left, in MiB.
+ *
+ * Not a new number: it is exactly the two reservations the budget derivation
+ * above already subtracts out of the ceiling — the app's anonymous working set
+ * and the page-cache floor. Stating it as its own constant lets the runtime
+ * check use the SAME arithmetic the compile-time budget uses, so the two can
+ * never disagree about what "comfortably larger" means.
+ */
+export const HINDSIGHT_PG_MIN_NON_BUFFER_MIB =
+  HINDSIGHT_PG_APP_ANON_MIB + HINDSIGHT_PG_PAGE_CACHE_FLOOR_MIB;
+
+/** Render a MiB figure the way an operator reads a docker cap. */
+function mib(n: number): string {
+  return n >= 1024 && n % 1024 === 0 ? `${n / 1024} GiB` : `${Math.round(n)} MiB`;
+}
+
+/**
+ * Is this container cap comfortably larger than the `shared_buffers` it is
+ * configured to pin? Returns a ready-to-print warning, or `null` when safe.
+ *
+ * ## Why this check exists
+ *
+ * {@link HINDSIGHT_PG_SHARED_BUFFERS_BUDGET_MIB} is a COMPILE-TIME budget: it
+ * is derived from a literal 16 GiB ceiling and pinned by a test. That protects
+ * the pair of numbers checked into this repo, and nothing else. Once the cap
+ * and `shared_buffers` are both operator-configurable they can be moved
+ * independently, at different times, by different mechanisms — and the
+ * observed failure is exactly that: an operator raised the live container to
+ * 24 GiB to fit a 12 GiB `shared_buffers`, and the next
+ * `switchroom memory setup --recreate` put the cap back to the hard-coded
+ * 16 GiB default while leaving the 12 GiB buffer pool configured inside the
+ * container. Postgres came back up pinning 75% of its cgroup as unreclaimable
+ * shared memory, with no warning anywhere.
+ *
+ * **Warn, do not fail.** Two reasons, and they point the same way:
+ *  1. The dangerous state is reached by a DEFAULT re-asserting itself, not by
+ *     a bad operator edit. Hard-failing there turns "the memory container is
+ *     badly sized" into "the fleet has no memory container at all", which is
+ *     strictly worse for every agent on the host.
+ *  2. The headroom figure is a heuristic (a measured anon working set plus a
+ *     page-cache floor), not a hard kernel limit. A heuristic should not be
+ *     able to brick `switchroom setup` on a host whose workload the heuristic
+ *     was not measured against.
+ *
+ * The warning names both numbers and the key to change, which is the whole
+ * point: the previous behaviour named neither.
+ */
+export function hindsightMemBudgetWarning(input: {
+  /** Resolved docker memory cap, as it will be handed to docker (`16g`). */
+  memLimit: string;
+  /** Resolved `shared_buffers`, as it will be handed to pg0 (`12288MB`). */
+  sharedBuffers: string;
+}): string | null {
+  const capMib = parseDockerSizeToMib(input.memLimit);
+  const bufMib = parsePgSizeToMib(input.sharedBuffers);
+  // Unparseable on either side: say nothing rather than assert a wrong number.
+  // The schema regex is what rejects a malformed `hindsight.mem_limit`.
+  if (capMib === null || bufMib === null) return null;
+  const headroom = capMib - bufMib;
+  if (headroom >= HINDSIGHT_PG_MIN_NON_BUFFER_MIB) return null;
+  return (
+    `hindsight: container memory cap ${input.memLimit} (${mib(capMib)}) leaves only ` +
+    `${mib(Math.max(headroom, 0))} above shared_buffers ${input.sharedBuffers} ` +
+    `(${mib(bufMib)}) — Postgres pins that buffer pool as unreclaimable shared ` +
+    `memory, so the container needs at least ${mib(HINDSIGHT_PG_MIN_NON_BUFFER_MIB)} ` +
+    `beyond it (${mib(HINDSIGHT_PG_APP_ANON_MIB)} app working set + ` +
+    `${mib(HINDSIGHT_PG_PAGE_CACHE_FLOOR_MIB)} page-cache floor). Raise ` +
+    `\`hindsight.mem_limit\` to at least ` +
+    `${mib(Math.ceil((bufMib + HINDSIGHT_PG_MIN_NON_BUFFER_MIB) / 1024) * 1024)}, or lower ` +
+    "`hindsight.env.SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS`."
+  );
+}
+
+/**
  * Env var carrying the `effective_cache_size` the entrypoint should pass to
  * `pg0 start`. Empty / unset ⇒ the entrypoint skips that flag.
  */

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -18,7 +18,10 @@ import {
   resolveHindsightPerfOverrides,
 } from "./hindsight-perf-defaults.js";
 import {
+  HINDSIGHT_PG_SHARED_BUFFERS_ENV,
+  hindsightMemBudgetWarning,
   hindsightPgEnv,
+  parseDockerSizeToMib,
   resolveHindsightPgOverrides,
 } from "./hindsight-pg-defaults.js";
 import {
@@ -879,6 +882,16 @@ export { HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM } from "./hindsight-per
 // OOM kill that takes memory down for the whole fleet. Never emit a
 // memory-swap equal to the memory limit — `tests/setup/hindsight.test.ts`
 // asserts the invariant on BOTH the run-args and compose paths.
+//
+// **This is the DEFAULT, not the value.** It was the value until this knob landed: with
+// no config path, an operator who raised the live container's cap by hand had
+// it silently reverted to 16g by the next `switchroom memory setup --recreate`
+// — while `shared_buffers` (which IS configurable, via `hindsight.env`) stayed
+// where they had put it. That is how a 16 GiB cap ended up carrying a 12 GiB
+// buffer pool on the live fleet. Override with `hindsight.mem_limit`; see
+// {@link resolveHindsightMemLimit} for the resolution and
+// {@link import("./hindsight-pg-defaults.js").hindsightMemBudgetWarning} for
+// the check that now names the dangerous combination out loud.
 export const HINDSIGHT_DEFAULT_MEM_LIMIT = "16g";
 export const HINDSIGHT_DEFAULT_MEM_RESERVATION = "4g";
 export const HINDSIGHT_DEFAULT_PIDS_LIMIT = 1000;
@@ -2020,8 +2033,91 @@ export interface HindsightPerfOptions {
    * URLs. Tests pass an explicit boolean.
    */
   localLlm?: boolean;
+  /**
+   * The operator's `hindsight.mem_limit` — the container's docker memory cap.
+   * Absent / blank ⇒ {@link HINDSIGHT_DEFAULT_MEM_LIMIT}.
+   *
+   * This rides the options object rather than `env` on purpose. `env` is a map
+   * of vars switchroom EMITS INTO the container (`-e K=V` /
+   * `environment: - K=V`); the memory cap is a docker `HostConfig.Memory`
+   * flag, consumed by the daemon and never seen by any process inside the
+   * container. Putting it in `env` would either emit a var nothing reads or
+   * break that map's one invariant. It rides the options object rather than a
+   * new positional for the reason this object exists at all (see the interface
+   * doc): a 9th positional is a silent argument-order mismatch waiting to
+   * happen between the two launch paths.
+   *
+   * @see resolveHindsightMemLimit
+   */
+  memLimit?: string;
   /** Process-environment seam for tests; defaults to `process.env`. */
   processEnv?: NodeJS.ProcessEnv;
+}
+
+/**
+ * The docker memory cap the hindsight container is actually created with.
+ *
+ * ONE derivation, called by both {@link startHindsight} and
+ * {@link generateHindsightComposeSnippet}, for the same anti-drift reason as
+ * {@link hindsightPerfEnvPairs}: a cap that differs between the docker-run and
+ * compose paths is exactly the class of divergence that produced the bug this
+ * knob exists to fix.
+ *
+ * A blank / whitespace-only value is an accident rather than an override
+ * (same discipline as `resolveHindsightPgOverrides`) and falls back to the
+ * default. A non-blank value that docker could not parse THROWS: the schema
+ * regex is the first line of defence, and silently substituting the default
+ * for a typo'd cap would reproduce the very "silently reverted to 16g"
+ * behaviour this change removes.
+ *
+ * It also throws below {@link HINDSIGHT_DEFAULT_MEM_RESERVATION}. The soft
+ * reservation is emitted unconditionally on both launch paths, and docker
+ * refuses to create a container whose memory limit is under its reservation —
+ * a previously unreachable state (the cap was a constant `16g`) that this knob
+ * makes reachable. Docker's own rejection is late and opaque; this one names
+ * both numbers.
+ */
+export function resolveHindsightMemLimit(perf?: HindsightPerfOptions): string {
+  const raw = perf?.memLimit?.trim();
+  if (!raw) return HINDSIGHT_DEFAULT_MEM_LIMIT;
+  const capMib = parseDockerSizeToMib(raw);
+  if (capMib === null) {
+    throw new Error(
+      `hindsight.mem_limit: \`${raw}\` is not a docker memory size. Use a ` +
+        "number with an optional b/k/m/g suffix, e.g. `24g` or `16384m`.",
+    );
+  }
+  const reservationMib = parseDockerSizeToMib(HINDSIGHT_DEFAULT_MEM_RESERVATION);
+  if (reservationMib !== null && capMib < reservationMib) {
+    throw new Error(
+      `hindsight.mem_limit: \`${raw}\` is below the container's memory ` +
+        `reservation (${HINDSIGHT_DEFAULT_MEM_RESERVATION}) — docker refuses ` +
+        "to create a container whose memory limit is under its reservation.",
+    );
+  }
+  return raw;
+}
+
+/**
+ * The memory-budget warning for the config this container will launch with, or
+ * `null` when the cap comfortably clears the configured `shared_buffers`.
+ *
+ * Resolves BOTH sides from the same helpers the launch paths use — the cap
+ * from {@link resolveHindsightMemLimit}, `shared_buffers` from
+ * {@link hindsightPgEnvPairs} — so the check can never be evaluated against a
+ * different pair of numbers than the container gets.
+ */
+export function hindsightMemBudgetWarningFor(
+  perf?: HindsightPerfOptions,
+): string | null {
+  const sharedBuffers = hindsightPgEnvPairs(perf).find(
+    ([k]) => k === HINDSIGHT_PG_SHARED_BUFFERS_ENV,
+  )?.[1];
+  if (!sharedBuffers) return null;
+  return hindsightMemBudgetWarning({
+    memLimit: resolveHindsightMemLimit(perf),
+    sharedBuffers,
+  });
 }
 
 /**
@@ -2268,14 +2364,22 @@ export function startHindsight(
     perf,
   }).flatMap(([k, v]) => ["-e", `${k}=${v}`]);
 
+  // Loud on the launch path itself, not only in the CLI wrappers: `switchroom
+  // memory setup --recreate` is what silently reverted the cap, so the warning
+  // has to be attached to the thing that does the reverting.
+  const memBudgetWarning = hindsightMemBudgetWarningFor(perf);
+  if (memBudgetWarning) console.warn(`  ! ${memBudgetWarning}`);
+
   const args = [
     "run", "-d",
     "--name", "switchroom-hindsight",
     "--restart", "always",
     // Container resource caps (memory + pids only; CPU uncapped —
     // see HINDSIGHT_DEFAULT_MEM_LIMIT constant for the v0.13.22 → v0.13.23
-    // unwind rationale).
-    `--memory=${HINDSIGHT_DEFAULT_MEM_LIMIT}`,
+    // unwind rationale). The cap itself is `hindsight.mem_limit` (default
+    // HINDSIGHT_DEFAULT_MEM_LIMIT), resolved through the SAME helper the
+    // compose path uses.
+    `--memory=${resolveHindsightMemLimit(perf)}`,
     `--memory-reservation=${HINDSIGHT_DEFAULT_MEM_RESERVATION}`,
     `--pids-limit=${HINDSIGHT_DEFAULT_PIDS_LIMIT}`,
     // PostgreSQL needs far more than Docker's 64MB default shm (see
@@ -2872,7 +2976,10 @@ export function generateHindsightComposeSnippet(
     // paths (see HINDSIGHT_DEFAULT_REQUEUE_DEAD_LETTERS / _MAX, #3795 / #3797).
     `      - SWITCHROOM_HINDSIGHT_REQUEUE_DEAD_LETTERS=${HINDSIGHT_DEFAULT_REQUEUE_DEAD_LETTERS}`,
     `      - SWITCHROOM_HINDSIGHT_REQUEUE_MAX=${HINDSIGHT_DEFAULT_REQUEUE_MAX}`,
-    `    mem_limit: ${HINDSIGHT_DEFAULT_MEM_LIMIT}`,
+    // Operator's `hindsight.mem_limit` (default HINDSIGHT_DEFAULT_MEM_LIMIT),
+    // from the SAME resolver the docker-run path uses so an emitted compose
+    // file cannot cap the container differently than `memory setup` would.
+    `    mem_limit: ${resolveHindsightMemLimit(perf)}`,
     `    mem_reservation: ${HINDSIGHT_DEFAULT_MEM_RESERVATION}`,
     `    pids_limit: ${HINDSIGHT_DEFAULT_PIDS_LIMIT}`,
     // PostgreSQL shm — see HINDSIGHT_DEFAULT_SHM_SIZE. Without this the


### PR DESCRIPTION
## The bug

`HINDSIGHT_DEFAULT_MEM_LIMIT = "16g"` was hard-coded at `src/setup/hindsight.ts:882` with no config path, and it reached docker on both launch paths as a constant — `--memory=${HINDSIGHT_DEFAULT_MEM_LIMIT}` (`hindsight.ts:2278`) and `mem_limit: ${HINDSIGHT_DEFAULT_MEM_LIMIT}` (`hindsight.ts:2875`).

Meanwhile `shared_buffers` — the thing that cap has to hold — **has** been operator-configurable since the pg0 work: `SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS` is a managed key (`hindsight-pg-defaults.ts:229`, in `HINDSIGHT_PG_ENV_KEYS` at `:309`), resolved by `resolveHindsightPgOverrides()` (`:326`) from the operator's `hindsight.env` block.

**That asymmetry is the defect.** An operator raised the live container to 24 GiB by hand so a 12 GiB buffer pool would fit. The next `switchroom memory setup --recreate` put the cap silently back to 16 GiB and left the 12 GiB `shared_buffers` standing inside it. pg0 runs Postgres with `shared_memory_type=mmap` (`hindsight-pg-defaults.ts:110-117`), so the buffer pool is charged to the cgroup as **unreclaimable** anonymous memory — the container came back pinning three quarters of its own ceiling, with no warning anywhere. It already happened once this week, and nothing in the codebase would have stopped it happening again.

## Plumbing-path decision — first-class field, NOT the `HINDSIGHT_PG_ENV_KEYS` channel

**Requested justification.** I did not put it on the `hindsight.env` channel, and the reason is mechanical rather than stylistic.

`hindsight.env` is the map of variables switchroom **emits into the container**. Every managed key travels one route and only one: `hindsightPgEnvPairs()` (`hindsight.ts:1914` pre-change) → `.flatMap(([k, v]) => ["-e", ...])` in the docker-run argv (`:2013`) and `.map(([k, v]) => "      - K=V")` in the compose `environment:` block (`:2722`). Those pairs are read by `docker/hindsight-entrypoint.sh` inside the container.

The memory cap is a docker `HostConfig.Memory` flag. The daemon consumes it; no process inside the container ever sees it. Routing it through that channel gives two bad options — emit `-e SWITCHROOM_HINDSIGHT_MEM_LIMIT=24g` into a container where nothing reads it (a lie in `docker inspect`), or put a key in the `env` map that is deliberately *not* emitted (breaking that map's one invariant, so `docker inspect`'s env no longer matches the config). The task said not to force-fit it; I didn't.

The repo already decided this category once. `hindsight.gpu` (`schema.ts:2782`) is the other non-env container-shape knob — `--gpus all` / the compose `deploy.resources.reservations.devices` stanza — and it is a **first-class field on `HindsightConfigSchema`**, not an `env` key. `hindsight.mem_limit` follows that precedent exactly.

**Threading:** on the existing trailing `HindsightPerfOptions` object, not a new positional. That object's own doc (`hindsight.ts:2004-2009`) states the rationale — "the positional-parameter list is already long enough to make a silent argument-order mismatch between them plausible" — and a 9th positional across two generators with *different* parameter orders is precisely that hazard. Both paths resolve through one `resolveHindsightMemLimit()`, so they cannot drift; a test asserts the outcome of both generators for the same inputs rather than that both call it.

## The safety check — warn, and why not fail

`HINDSIGHT_PG_SHARED_BUFFERS_BUDGET_MIB` is a **compile-time** budget derived from a literal 16 GiB, pinned by a test. It protects the pair of numbers in this repo and nothing else. Once both sides are operator-configurable they move independently, at different times, by different mechanisms — which is the observed failure.

So: every launch now compares the *resolved* cap against the *resolved* `shared_buffers` and warns when the cap does not clear the pool by `HINDSIGHT_PG_APP_ANON_MIB + HINDSIGHT_PG_PAGE_CACHE_FLOOR_MIB` (4608 MiB) — the **same arithmetic** the shipped budget subtracts, exported as one constant so the two cannot disagree about what "comfortably larger" means.

```
! hindsight: container memory cap 16g (16 GiB) leaves only 4 GiB above shared_buffers
  12288MB (12 GiB) — Postgres pins that buffer pool as unreclaimable shared memory, so
  the container needs at least 4608 MiB beyond it (2560 MiB app working set + 2 GiB
  page-cache floor). Raise `hindsight.mem_limit` to at least 17 GiB, or lower
  `hindsight.env.SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS`.
```

It fires from **`startHindsight()` itself**, not only the CLI wrapper, because `switchroom memory setup --recreate` is the thing that did the reverting — a CLI-only warning would be skipped by every other caller.

**Warn, not fail** — argued, per the request:

1. The dangerous state is reached by a **default re-asserting itself**, not by a bad operator edit. Hard-failing there converts "the memory container is badly sized" into "the fleet has no memory container at all", which is strictly worse for every agent on the host.
2. The headroom figure is a measured heuristic (an anon working set plus a page-cache floor), not a hard kernel limit. A heuristic must not be able to brick `switchroom setup` on a host whose workload it was never measured against.

Two things **are** hard rejections, because they are unambiguous rather than heuristic: a malformed size string (schema regex at `apply`, and again at launch rather than silently substituting the default — silently defaulting would reproduce the exact "reverted to 16g" behaviour this removes), and a cap **below the container's 4g `--memory-reservation`**. That last one is an adversarial finding on my own diff: the reservation is emitted unconditionally, docker refuses to create a container whose limit is under its reservation, and the constant made that unreachable while this knob makes it reachable. Docker's own rejection is late and opaque; this one names both numbers.

## Tests — `src/setup/hindsight-mem-limit.test.ts` (23)

Each would go red on the original code, not just exercise a path:

- **(a) explicit value reaches both emitters.** `--memory=24g` in the docker-run argv (asserted as the *exact* set of `--memory=` flags, so a duplicate would also fail) and `mem_limit: 24g` in the compose snippet. On `main` both are `16g` regardless. Plus a parity loop asserting run ⇄ compose agree for `undefined` / `24g` / `32768m`, and that the pre-existing `--memory-swap` invariant still holds alongside a configured cap.
- **(b) default unchanged.** `HINDSIGHT_DEFAULT_MEM_LIMIT` is still `16g`; an unconfigured `startHindsight()` / `generateHindsightComposeSnippet()` emits exactly that on both paths; blank/whitespace/absent all resolve to the default rather than erroring.
- **(c) the check fires on the dangerous combination and stays quiet on safe ones.** Red on cap `16g` + `shared_buffers` `12288MB` — asserting the message names both numbers *and* both keys, since a warning that names neither was the original defect. Quiet on the shipped defaults, quiet on the operator's actual fix (24 GiB + 12 GiB). Boundary asserted exactly (cap == buffers + headroom passes; one MiB under does not). The end-to-end shape too: `hindsightMemBudgetWarningFor({ env: { SWITCHROOM_HINDSIGHT_PG_SHARED_BUFFERS: "12288MB" } })` — the default cap meeting an operator-raised pool, i.e. the recurrence path — warns, and goes quiet once `mem_limit` is also raised. And that `startHindsight()` itself warns on that config and does not on a stock launch.
- Size parsing is asserted in both grammars, because they differ and getting it wrong would misfire the check by a factor of 8192: docker's bare number is **bytes**, Postgres' bare number is **8 kB blocks**, plus the `off` sentinel resolving to pg0's own 256MB.

Unparseable input on either side returns `null` (say nothing rather than assert a wrong number) — asserted.

## Also

- Wired on **first-run `switchroom setup`** too (`src/cli/setup.ts`), which previously passed `perf: undefined`. A knob honoured on `memory setup` but ignored on `setup` would be the same silent divergence again. That call site now also forwards `hindsight.env` — necessary, not incidental: the check cannot honestly compare against `shared_buffers` it cannot see.
- Docs: new `### Memory cap for the Hindsight container (hindsight.mem_limit)` section in `docs/configuration.md`, alongside the other `hindsight.*` keys.
- `CHANGELOG.md` `## Unreleased` (the one at the top).

## Verification

- `npm run lint` — clean (tsc + all 23 guards).
- `vitest run src/setup/ src/config/` — 41 files, 1002 passed.
- `src/cli/apply.test.ts` fails 10 identically on unmodified `origin/main` in this environment (needs a built `dist/`); pre-existing, not from this change.
- **No container was touched.** Code only.

## Considered and not done

A recreate-time *drop guard* for the cap, mirroring the GPU drop guard (`memory setup --recreate` refusing to silently shrink a running container's cap). The warning covers the dangerous end state, and the guard is a separate concern with its own inspect-path surface — deliberately out of scope for a single-concern PR rather than forgotten.
