### PR TITLE
chore: release v0.20.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,34 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+## v0.20.14 — BM25 filter-field pushdown for Hindsight keyword recall, and a phase-attribution ceiling for database-side proposals
+
+### Hindsight keyword recall: BM25 filter-field pushdown
+
+- **The pg_search BM25 index now indexes `bank_id` and `fact_type` as
+  `pdb.literal` fast fields (#4478)** — every recall keyword arm filters on
+  `bank_id = $n AND fact_type = '<literal>'`, but those columns were outside the
+  BM25 index, so ParadeDB could not push the equalities into the Tantivy scan and
+  degraded them to a post-scoring `heap_filter`: the arm scored the WHOLE table
+  and then discarded everything outside the caller's bank. Measured on an
+  isolated 797,893-row corpus with the real arm shape: `Buffers: shared hit`
+  171,517 → 405 (423x) and 231.4ms → 7.8ms execution for a byte-identical result
+  set (120 queries / 4,362 rows: 0 rows added, 0 dropped, 0 score or rank
+  changes). Corrected, pg_search is 4-6x faster than native at every measured
+  concurrency and its p95 is flat across bank size (largest/smallest ratio 0.97 /
+  1.04 / 1.06 at concurrency 1 / 8 / 16, versus native's 1.11 / 1.17 / 1.20) —
+  which also explains away the recorded "pg_search is a 124-138ms regression"
+  claim: those numbers measured the missing fast fields, not the backend. The
+  filter cast is hard-coded to `literal` and never follows
+  `HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER`, because a stemmed or
+  ngram cast on a filter column would stop the equality matching at all. Index
+  cost is +0.7%. Fresh databases get the corrected index from the initial-schema
+  migration; an EXISTING index is reported loudly on every boot
+  (`pg_search_filter_field_drift`) and never rebuilt implicitly, because a
+  boot-path `DROP INDEX`/`CREATE INDEX` on a populated table is the fail-closed
+  window from #4472. Evidence and the deliberate rebuild procedure:
+  `docs/baselines/hindsight-pg-search-pushdown-2026-08-07/`.
+
 ### `hindsight-bench --phases`: a refutation number for database-side proposals
 
 - **`switchroom hindsight-bench --phases [n]` attributes recall latency to
@@ -49,32 +77,6 @@ now an anomaly worth investigating, not the norm.
   cosmetic one. The new `readStatsEpoch` re-reads both immediately after the
   reset. Baselines captured before this fix are annotated in
   `docs/hindsight-bench-p2-residency.md` rather than hand-edited.
-
-### Hindsight keyword recall
-
-- **The pg_search BM25 index now indexes `bank_id` and `fact_type` as
-  `pdb.literal` fast fields (#4478)** — every recall keyword arm filters on
-  `bank_id = $n AND fact_type = '<literal>'`, but those columns were outside the
-  BM25 index, so ParadeDB could not push the equalities into the Tantivy scan and
-  degraded them to a post-scoring `heap_filter`: the arm scored the WHOLE table
-  and then discarded everything outside the caller's bank. Measured on an
-  isolated 797,893-row corpus with the real arm shape: `Buffers: shared hit`
-  171,517 → 405 (423x) and 231.4ms → 7.8ms execution for a byte-identical result
-  set (120 queries / 4,362 rows: 0 rows added, 0 dropped, 0 score or rank
-  changes). Corrected, pg_search is 4-6x faster than native at every measured
-  concurrency and its p95 is flat across bank size (largest/smallest ratio 0.97 /
-  1.04 / 1.06 at concurrency 1 / 8 / 16, versus native's 1.11 / 1.17 / 1.20) —
-  which also explains away the recorded "pg_search is a 124-138ms regression"
-  claim: those numbers measured the missing fast fields, not the backend. The
-  filter cast is hard-coded to `literal` and never follows
-  `HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER`, because a stemmed or
-  ngram cast on a filter column would stop the equality matching at all. Index
-  cost is +0.7%. Fresh databases get the corrected index from the initial-schema
-  migration; an EXISTING index is reported loudly on every boot
-  (`pg_search_filter_field_drift`) and never rebuilt implicitly, because a
-  boot-path `DROP INDEX`/`CREATE INDEX` on a populated table is the fail-closed
-  window from #4472. Evidence and the deliberate rebuild procedure:
-  `docs/baselines/hindsight-pg-search-pushdown-2026-08-07/`.
 
 ## v0.20.13 — ParadeDB pg_search BM25 keyword recall, `vault:` secrets resolved off the apply path, and recall quality as a gating number
 


### PR DESCRIPTION
Step 1 of `skills/switchroom-release`: consolidate the continuously-staged `## Unreleased` section into a released `## v0.20.14` section and re-seed an empty `## Unreleased` staging area.

`CHANGELOG.md` only — `package.json` `version` stays the deliberate stale placeholder; the tag is the version source of truth.

**What is in this release** — two commits since `v0.20.13` (`a73b0fd2`), both merge-queue green on `947277c5`:

- `947277c5` fix(hindsight): index `bank_id`/`fact_type` as BM25 filter fast fields (#4504)
- `dcf6d706` feat(hindsight-bench): `--phases` attribution and the P2 residency measurement (#4476) (#4503)

**Why it needs a tag rather than sitting on `main`:** #4504 is a build-time patch to `docker/Dockerfile.hindsight`, so it only takes effect in an image built from a tag (`git tag --contains 947277c5` is empty; `v0.20.13`'s `Dockerfile.hindsight` has 0 occurrences of `pdb.literal`, `main` has 3). Until it ships in an image, the pg_search backend would build the uncorrected BM25 index, measured at 2-10x slower than native at saturation.

**Editing was grouping only, not authorship.** The set of `- **` bullet lines is byte-identical to what the two PRs staged (verified by a sorted diff of that set). Two structural changes: the subheads were reordered so the pushdown fix leads and the `hindsight-bench --phases` work follows, and `### Hindsight keyword recall` was narrowed to `### Hindsight keyword recall: BM25 filter-field pushdown` so it does not read identically to the v0.20.13 section directly below it.

[skip changelog]