### PR TITLE
fix(hindsight): make the pg_search text-search migration a plain env flip (#4506)

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -136,6 +136,7 @@ jobs:
               - 'tests/docker/hindsight-mm-refresh-debounce-patch.test.ts'
               - 'tests/docker/hindsight-pg-search-tokenizer-drift-patch.test.ts'
               - 'tests/docker/hindsight-pg-search-filter-pushdown-patch.test.ts'
+              - 'tests/docker/hindsight-text-search-migration-patch.test.ts'
               - 'tests/docker/hindsight-graph-seed-retirement.test.ts'
               - 'tests/docker/hindsight-maxitems-grammar-patch.test.ts'
               - 'src/setup/hindsight-perf-defaults.ts'
@@ -438,6 +439,23 @@ jobs:
           SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
         run: npx vitest run tests/docker/hindsight-pg-search-filter-pushdown-patch.test.ts
 
+      - name: Run the hindsight text-search migration-path probe (RED/GREEN, must not skip)
+        # #4506. The bakes test can only see that the new guard conditions are
+        # PRESENT in the patched source; it cannot see the outcome that matters
+        # — that the real shipping `ensure_text_search_extension`, handed a
+        # populated table whose text-search INDEX was dropped while
+        # `search_vector` survived, REPAIRS it instead of raising. Upstream
+        # raises there on every backend including the one already configured
+        # ("from pg_textsearch to pg_search" on 801,792 rows, observed), so the
+        # database comes up on none of them. The same probe pins the other half:
+        # a genuinely lossy pg_search → native switch on populated tables must
+        # STILL be refused, and an index-only rebuild must not drop a populated
+        # tsvector column. Only running the real function and reading back the
+        # DDL it emits can tell those four states apart.
+        env:
+          SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
+        run: npx vitest run tests/docker/hindsight-text-search-migration-patch.test.ts
+
       - name: Run the hindsight graph-seed RETIREMENT probe (RED/GREEN, must not skip)
         # The v0.8.5 upstream #2968 carry was retired in the v0.8.6 base bump —
         # upstream ships the behaviour natively and exposes
@@ -581,7 +599,7 @@ jobs:
       - name: Label-scoped teardown
         if: always()
         run: |
-          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-mm-refresh-debounce-patch hindsight-pg-search-tokenizer-drift-patch hindsight-graph-seed-retirement hindsight-maxitems-grammar-patch hindsight-reflect-directives-patch hindsight-recall-budget-reflect-grounding hindsight-reranker-priority-patch hindsight-temporal-language-patch hindsight-temporal-offload-patch hindsight-pg-fsync-probe; do
+          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-mm-refresh-debounce-patch hindsight-pg-search-tokenizer-drift-patch hindsight-text-search-migration-patch hindsight-graph-seed-retirement hindsight-maxitems-grammar-patch hindsight-reflect-directives-patch hindsight-recall-budget-reflect-grounding hindsight-reranker-priority-patch hindsight-temporal-language-patch hindsight-temporal-offload-patch hindsight-pg-fsync-probe; do
             ids=$(docker ps -aq --filter "label=switchroom.test=$phase" 2>/dev/null || true)
             if [ -n "$ids" ]; then docker rm -f $ids 2>/dev/null || true; fi
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,61 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+### Hindsight: a populated bank can migrate to `pg_search` by flipping the env, not by hand
+
+- **`native` → `pg_search` on a POPULATED bank is now a plain env flip +
+  restart.** v0.20.13 shipped `pg_search` as the default for new installs but
+  said an existing bank had to be migrated by a manual operator procedure. That
+  procedure did not work. Following it (drop the native search index, flip
+  `HINDSIGHT_API_TEXT_SEARCH_EXTENSION`, restart) produced a
+  column-without-index state that `ensure_text_search_extension` classified as a
+  backend CHANGE and refused — on **every** backend, including the one already
+  configured. Held constant at `pg_search`, a 801,792-row `memory_units` gave
+  `RuntimeError: Cannot change text search extension from pg_textsearch to
+  pg_search: the following tables contain data: memory_units(801792 rows)`, and
+  the error's own "put it back" advice could not work either. The bank came up
+  on nothing. `docker/Dockerfile.hindsight` now bakes a fix so the guard fires
+  only on a genuinely lossy column recreate; a stale or absent index is rebuilt
+  in place. Measured on that bank: `CREATE EXTENSION` 0.06s, BM25 build 12.7s,
+  34s total unavailable. (#4506)
+- **The `pg_search` migration branch now creates its own extension.**
+  `provision_pg_search()` stages the `.so` and control/SQL but deliberately
+  never touches the database, and nothing else ran `CREATE EXTENSION pg_search`
+  — so the branch went straight to `CREATE INDEX ... USING bm25` and died with
+  `InvalidSchemaName: schema "pdb" does not exist`. It now creates the extension
+  first, mirroring what the `pgroonga` branch already did. (#4506)
+- **The second memory table is reconciled again.** `tables_to_check` still named
+  `reflections`, renamed to `mental_models` by alembic `t5o6p7q8r9s0`, so that
+  table matched nothing and silently kept whatever index it had under any
+  backend. (#4506)
+- **The refusal message no longer guesses a backend or names a dead table.** A
+  `TEXT` `search_vector` with no index carries nothing to identify the live
+  backend from, yet the error asserted `pg_textsearch` and told the operator to
+  `DELETE FROM public.reflections`. It now reports
+  `indeterminate (TEXT search_vector, no text-search index)` in that case, names
+  the tables that actually exist, and only offers the "stay on your current
+  backend" remedy when it could genuinely read what that backend is. (#4506)
+- **The reverse direction is still refused, and an index-only rebuild no longer
+  discards data.** `pg_search` → `native`/`vchord` on non-empty tables stays
+  fatal: those backends store the indexed content IN `search_vector` and only
+  write it on INSERT, so every existing row would go unsearchable. Relatedly,
+  the reconcile loop's unconditional `DROP COLUMN` is now conditional on the
+  column type actually changing, so rebuilding a missing GIN index no longer
+  drops and recreates a populated `tsvector` empty. (#4506)
+- **`docker/hindsight-entrypoint.sh` and
+  `src/setup/hindsight-perf-defaults.ts` documented the old hard refusal as a
+  guarantee.** Both are rewritten: the flip now migrates, so the pin
+  (`HINDSIGHT_API_TEXT_SEARCH_EXTENSION: "native"` under `hindsight.env`) is
+  what an operator who is *not* ready to migrate must set, and the
+  `HINDSIGHT_API_STARTUP_WAIT_SECONDS` ceiling (default 300s) is called out for
+  banks much larger than this one. (#4506)
+- **Regression-pinned behaviourally, not structurally.**
+  `tests/docker/hindsight-text-search-migration-patch.test.ts` runs the real
+  shipping `ensure_text_search_extension` against the pinned upstream digest in
+  a throwaway container and asserts it is RED unpatched and GREEN patched across
+  six scenarios, including the two that must keep failing. Wired into the
+  `hindsight-probe` CI job, which hard-fails rather than skipping. (#4506)
+
 ## v0.20.14 — BM25 filter-field pushdown for Hindsight keyword recall, and a phase-attribution ceiling for database-side proposals
 
 ### Hindsight keyword recall: BM25 filter-field pushdown

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -1736,6 +1736,428 @@ assert "def _prior_indexdef(" in a, f"switchroom hindsight {NAME}: pre-drop inde
 print("switchroom hindsight pg_search tokenizer-drift guard: rebuilds preserve an inexpressible tokenizer and drift is logged as pg_search_tokenizer_drift; no new raise on the boot path")
 PYEOF
 
+# Text-search backend migration path (switchroom #4506).
+#
+# THE DEFECTS, in the real shipping source at the pinned digest. All five were
+# OBSERVED in a rehearsal against a clone of this fleet's 801,792-row
+# `memory_units`, following the operator runbook that
+# `docker/hindsight-entrypoint.sh` documented at the time.
+#
+# D1 — DROPPED-INDEX-WITH-SURVIVING-COLUMN IS A ONE-WAY TRAPDOOR.
+# `migrations.py::ensure_text_search_extension` decides "does the schema match
+# the configured backend" on the (column, index) PAIR, then raises whenever a
+# mismatched table has rows. So a database whose text-search INDEX had been
+# dropped while `search_vector` survived hit the row-count check and raised —
+# regardless of the target backend. With the backend held CONSTANT
+# (pg_search -> pg_search) the rehearsal got, verbatim:
+#     RuntimeError: Cannot change text search extension from pg_textsearch to
+#     pg_search: the following tables contain data: memory_units(801792 rows).
+# The database then booted on NEITHER backend, and the error's own "set it
+# back" advice could not work — the same pair still mismatched. That is exactly
+# the state the old runbook told operators to create ("drop the native search
+# index"), so the documented migration was a trapdoor.
+#
+# What is actually at risk is never the index — an index is rebuilt from the
+# heap — but the COLUMN: a recreated `search_vector` comes back EMPTY and is
+# only ever populated on INSERT (`ops_postgresql.insert_facts_batch`), with no
+# backfill anywhere. And that only matters for the backends that store the
+# indexed content IN the column (native `tsvector`, vchord `bm25vector`).
+# pg_textsearch, pgroonga and pg_search keep `search_vector` purely for schema
+# symmetry and index the BASE columns directly, so recreating it under live
+# data loses precisely nothing. The guard is therefore re-keyed onto
+# "the column type must genuinely change AND the target backend reads the
+# column" — a real lossy switch (pg_search -> native on populated tables) is
+# still refused, while a stale/absent index over a correctly typed column is
+# rebuilt in place. The rebuild loop's unconditional `DROP COLUMN` is narrowed
+# to match, because dropping a correctly typed, POPULATED tsvector and
+# recreating it empty was silent data loss in its own right.
+#
+# D2 — NOTHING EVER RAN `CREATE EXTENSION pg_search`. The entrypoint's
+# `provision_pg_search()` stages the `.so` + control/sql into the embedded-pg
+# install and deliberately does not touch the database; the migration's
+# pg_search branch went straight to `CREATE INDEX ... USING bm25` and died with
+# `psycopg2.errors.InvalidSchemaName: schema "pdb" does not exist` (the pdb
+# schema is created BY the extension). The extension was available the whole
+# time — `default_version` 0.25.1, `installed_version` None. The pgroonga
+# branch a few lines above already does the right thing; this mirrors it,
+# including the "already exists / no permission" verification fallback.
+#
+# D3 — `tables_to_check` NAMED A TABLE THAT DOES NOT EXIST. Alembic revision
+# `t5o6p7q8r9s0_rename_mental_models_to_observations.py:70,76` renamed
+# `reflections` -> `mental_models` and `idx_reflections_text_search` ->
+# `idx_mental_models_text_search`. The old name matched nothing, so this loop
+# reconciled `memory_units` ALONE: `mental_models` kept a native tsvector
+# column + GIN index under a pg_search backend (an orphan — harmless today only
+# because the BM25 arm in `engine/sql/postgresql.py:185-247` is memory_units
+# only), and the RuntimeError advised `DELETE FROM public.reflections`.
+# Renaming the entry rather than deleting it keeps upstream's evident intent —
+# both memory tables tracking the configured backend — costs one BM25 index
+# over 43 rows on this fleet, and leaves nothing orphaned for a future arm to
+# trip over.
+#
+# D4 — THE ERROR MISREPORTED THE LIVE BACKEND. With `column=text, index=None`
+# there is no `key_field` reloption to read and pg_textsearch / pgroonga /
+# pg_search are indistinguishable, yet the detector reported `pg_textsearch`
+# and told the operator to pin it. It now says the backend is indeterminate and
+# how to read it off the schema. It also describes a table that actually
+# TRIPPED the guard (upstream read `mismatched_tables[0]`, which need not be
+# one of them) and names real tables in the remedy.
+#
+# CONSEQUENCE, which is the point of the ticket. `CREATE EXTENSION pg_search`
+# needs `shared_preload_libraries=pg_search`, which only `prestart_pg0()` sets
+# and which only applies at postmaster start — but booting the API on pg_search
+# tripped D1, so the rehearsal could only get through with a manual
+# `HINDSIGHT_ENABLE_API=false` boot. With D1 and D2 fixed the entrypoint's
+# existing order (provision_pg_search -> prestart_pg0 -> exec start-all.sh)
+# already satisfies the dependency, and a populated fleet migrates on a plain
+# env flip + restart in ONE boot. No entrypoint ordering change was needed; the
+# runbook comment in `docker/hindsight-entrypoint.sh` is rewritten to match.
+#
+# Self-verifying at build time; behaviourally guarded by
+# tests/docker/hindsight-text-search-migration-patch.test.ts (RED on unpatched
+# upstream, GREEN here) and statically by
+# tests/docker/dockerfile-hindsight-bakes.test.ts.
+RUN python3 - <<'PYEOF'
+import pathlib
+
+NAME = "text-search backend migration path"
+ROOT = pathlib.Path("/app/api/hindsight_api")
+
+
+def patch(rel, old, new, *, count=1):
+    f = ROOT / rel
+    s = f.read_text()
+    n = s.count(old)
+    assert n == count, (
+        f"switchroom hindsight {NAME}: anchor found {n}x (expected {count}) in {rel} — "
+        "upstream reformatted; re-author this patch in docker/Dockerfile.hindsight. "
+        f"Anchor head: {old.strip().splitlines()[0]!r}"
+    )
+    f.write_text(s.replace(old, new, count))
+
+
+# ------------------------------------------------- D3: the table list is stale
+patch(
+    "migrations.py",
+    r'''        tables_to_check = [
+            "memory_units",
+            "reflections",  # Renamed from pinned_reflections in p1k2l3m4n5o6 migration
+        ]
+''',
+    r'''        # switchroom (#4506, D3): `reflections` was renamed to `mental_models` by
+        # alembic revision t5o6p7q8r9s0 (which also renamed
+        # idx_reflections_text_search -> idx_mental_models_text_search). The old
+        # name matched no table, so this loop silently reconciled memory_units
+        # ALONE: mental_models kept a native tsvector column + GIN index under a
+        # pg_search backend, and the RuntimeError below advised deleting a table
+        # that does not exist.
+        tables_to_check = [
+            "memory_units",
+            "mental_models",  # renamed from `reflections` by alembic t5o6p7q8r9s0
+        ]
+''',
+)
+
+# The three `else:` arms below select the mental_models column list; their
+# comments still said `reflections`.
+patch(
+    "migrations.py",
+    "                else:  # reflections\n",
+    "                else:  # mental_models\n",
+    count=3,
+)
+
+# ------------------------- D1: classify the target backend's search_vector role
+patch(
+    "migrations.py",
+    r'''        else:  # native
+            target_column_type = "tsvector"
+            target_index_type = "gin"
+
+        mismatched_tables = []
+        tables_with_data = []
+''',
+    r'''        else:  # native
+            target_column_type = "tsvector"
+            target_index_type = "gin"
+
+        # switchroom (#4506, D1): does the TARGET backend store the indexed
+        # content IN `search_vector`, or is the column a dummy?
+        #
+        #   native  -> tsvector, written by ops_postgresql.insert_facts_batch
+        #   vchord  -> bm25vector, tokenized on INSERT
+        #   pg_textsearch / pgroonga / pg_search -> a DUMMY column kept only for
+        #       schema symmetry; those index the BASE columns (text, context,
+        #       text_signals / name, content) directly.
+        #
+        # This is the whole basis of the data guard further down: a recreated
+        # `search_vector` comes back EMPTY and is only ever populated on INSERT,
+        # so recreating it under live rows is lossy for the first group and
+        # completely inert for the second. Expressed as a NEGATIVE test so an
+        # unrecognised future backend is treated as content-bearing (guarded),
+        # never as safe-to-recreate.
+        target_search_vector_is_content = text_search_extension not in (
+            "pg_textsearch",
+            "pgroonga",
+            "pg_search",
+        )
+
+        mismatched_tables = []
+        tables_with_data = []
+''',
+)
+
+# ------------------- D1: guard only a genuinely lossy COLUMN recreate, not any
+#                     (column, index) pair mismatch.
+patch(
+    "migrations.py",
+    r'''                mismatched_tables.append((table_name, current_column_type, current_index_type, current_is_pg_search))
+
+                # Check if table has data
+                row_count = conn.execute(text(f"SELECT COUNT(*) FROM {schema_name}.{table_name}")).scalar()
+
+                if row_count > 0:
+                    tables_with_data.append((table_name, row_count))
+''',
+    r'''                mismatched_tables.append((table_name, current_column_type, current_index_type, current_is_pg_search))
+
+                # switchroom (#4506, D1): the data guard must fire ONLY for a
+                # genuinely lossy backend change.
+                #
+                # Upstream keyed it on the (column, index) PAIR: ANY mismatch on
+                # a populated table raised. So a database whose text-search INDEX
+                # had been dropped while the column survived became a one-way
+                # trapdoor — it booted on NEITHER backend (the pair still
+                # mismatched whatever you set the env var back to), and the
+                # error's own "set it back" advice therefore could not work. That
+                # is exactly the state the documented native->pg_search runbook
+                # asked operators to create.
+                #
+                # What is actually at risk is the COLUMN, never the index: an
+                # index is rebuilt from the heap, a recreated `search_vector`
+                # comes back empty and nothing backfills it. So guard when, and
+                # only when, (a) the column type must genuinely change AND (b) the
+                # target backend reads the column's contents. Everything else — a
+                # stale/absent index over a correctly typed column, or a swap
+                # between two dummy-column backends — is repaired in place.
+                column_recreate_needed = current_column_type != target_column_type
+                if column_recreate_needed and target_search_vector_is_content:
+                    row_count = conn.execute(text(f"SELECT COUNT(*) FROM {schema_name}.{table_name}")).scalar()
+                    if row_count > 0:
+                        tables_with_data.append((table_name, row_count))
+                elif column_recreate_needed:
+                    logger.info(
+                        f"{table_name}: search_vector is a dummy column under "
+                        f"'{text_search_extension}' (the base columns are indexed directly), "
+                        f"so it is recreated in place — no row data is at risk"
+                    )
+                else:
+                    logger.info(
+                        f"{table_name}: search_vector column already has the type "
+                        f"'{text_search_extension}' requires; rebuilding the text-search "
+                        f"index in place"
+                    )
+'''
+    ,
+)
+
+# ---------------------------------------- D3 + D4: an accurate, actionable error
+patch(
+    "migrations.py",
+    r'''            current_col_type = mismatched_tables[0][1]
+            current_idx_type = mismatched_tables[0][2]
+            first_is_pg_search = mismatched_tables[0][3]
+            if current_col_type == "tsvector":
+                current_ext = "native"
+            elif current_col_type == "bm25vector":
+                current_ext = "vchord"
+            elif current_col_type == "text" and current_idx_type == "pgroonga":
+                current_ext = "pgroonga"
+            elif current_col_type == "text":
+                current_ext = "pg_search" if first_is_pg_search else "pg_textsearch"
+            else:
+                current_ext = "unknown"
+            raise RuntimeError(
+                f"Cannot change text search extension from {current_ext} to {text_search_extension}: "
+                f"the following tables contain data: {table_list}. "
+                f"To change text search extension, you must either:\n"
+                f"  1. Clear all data: DELETE FROM {schema_name}.memory_units; "
+                f"DELETE FROM {schema_name}.reflections; then restart\n"
+                f"  2. Use the current text search extension (set HINDSIGHT_API_TEXT_SEARCH_EXTENSION='{current_ext}')"
+            )
+''',
+    r'''            # switchroom (#4506, D4): describe the table that actually TRIPPED
+            # the guard. Upstream read mismatched_tables[0], which need not be one
+            # of the blocked tables at all.
+            _blocked = {t for t, _n in tables_with_data}
+            _row = next((m for m in mismatched_tables if m[0] in _blocked), mismatched_tables[0])
+            current_col_type = _row[1]
+            current_idx_type = _row[2]
+            first_is_pg_search = _row[3]
+            if current_col_type == "tsvector":
+                current_ext = "native"
+            elif current_col_type == "bm25vector":
+                current_ext = "vchord"
+            elif current_col_type == "text" and current_idx_type == "pgroonga":
+                current_ext = "pgroonga"
+            elif current_col_type == "text" and current_idx_type is None:
+                # switchroom (#4506, D4): with no index there is no `key_field`
+                # reloption to read, and pg_textsearch / pgroonga / pg_search all
+                # sit on a plain TEXT column — the live backend is genuinely
+                # undetermined. Upstream reported `pg_textsearch` here, which was
+                # a guess presented as a reading, and it sent operators to set an
+                # env value that did not describe their database.
+                current_ext = "indeterminate (TEXT search_vector, no text-search index)"
+            elif current_col_type == "text":
+                current_ext = "pg_search" if first_is_pg_search else "pg_textsearch"
+            elif current_col_type is None:
+                current_ext = "none (no search_vector column)"
+            else:
+                current_ext = f"unknown (search_vector is {current_col_type})"
+
+            # switchroom (#4506, D3): name tables that EXIST. Upstream hard-coded
+            # `reflections`, renamed to `mental_models` by alembic t5o6p7q8r9s0,
+            # so remedy 1 could not be run as written.
+            _clear = " ".join(f"DELETE FROM {schema_name}.{table};" for table, _n in tables_with_data)
+            if current_ext in ("native", "vchord", "pgroonga", "pg_textsearch", "pg_search"):
+                _keep = (
+                    f"  2. Stay on the current backend "
+                    f"(set HINDSIGHT_API_TEXT_SEARCH_EXTENSION='{current_ext}') and restart"
+                )
+            else:
+                _keep = (
+                    "  2. Identify the live backend from the schema "
+                    "(\\d+ on the table, then \\di+ on its *_text_search index) and pin that value "
+                    "in HINDSIGHT_API_TEXT_SEARCH_EXTENSION"
+                )
+            raise RuntimeError(
+                f"Cannot change text search extension from {current_ext} to {text_search_extension}: "
+                f"the following tables contain data: {table_list}. "
+                f"'{text_search_extension}' stores the indexed content IN the search_vector column and "
+                f"only populates it on INSERT, so recreating that column here would leave every "
+                f"existing row unsearchable. To change text search extension, you must either:\n"
+                f"  1. Clear all data: {_clear} then restart\n"
+                f"{_keep}"
+            )
+'''
+    ,
+)
+
+# ------------------------- D1: an index-only rebuild must not drop the column
+patch(
+    "migrations.py",
+    r'''            # Drop existing column if it exists
+            if current_col_type:
+                logger.info(f"Dropping {current_col_type} column on {table_name}")
+                conn.execute(text(f"ALTER TABLE {schema_name}.{table_name} DROP COLUMN IF EXISTS search_vector"))
+''',
+    r'''            # switchroom (#4506, D1): drop the column ONLY when its type is
+            # genuinely wrong. Upstream dropped unconditionally, which turned an
+            # index-only rebuild (correct column, stale/absent index) into silent
+            # data loss: the populated native tsvector would be discarded and
+            # recreated empty, and nothing ever backfills it.
+            if current_col_type and current_col_type != target_column_type:
+                logger.info(f"Dropping {current_col_type} column on {table_name}")
+                conn.execute(text(f"ALTER TABLE {schema_name}.{table_name} DROP COLUMN IF EXISTS search_vector"))
+            elif current_col_type:
+                logger.info(
+                    f"Keeping the existing {current_col_type} search_vector column on {table_name}; "
+                    f"rebuilding the {target_index_type} index only"
+                )
+''',
+)
+
+# The five ADD COLUMN sites become idempotent so the preserved-column path above
+# is a no-op rather than a duplicate-column error.
+patch(
+    "migrations.py",
+    "ADD COLUMN search_vector",
+    "ADD COLUMN IF NOT EXISTS search_vector",
+    count=5,
+)
+
+# ---------------------------------------------- D2: nobody creates the extension
+patch(
+    "migrations.py",
+    r'''            elif text_search_extension == "pg_search":
+                logger.info(f"Creating TEXT column on {table_name}")
+''',
+    r'''            elif text_search_extension == "pg_search":
+                # switchroom (#4506, D2): NOTHING in the boot path ever ran
+                # `CREATE EXTENSION pg_search`. The entrypoint's
+                # provision_pg_search() stages the .so + control/sql into the
+                # embedded-pg install and deliberately does not touch the
+                # database, and this branch went straight to CREATE INDEX — which
+                # died with `InvalidSchemaName: schema "pdb" does not exist`
+                # because the pdb schema only exists once the extension is
+                # installed. The pgroonga branch above already does exactly this;
+                # mirror it, including the "already exists / no permission"
+                # verification fallback.
+                try:
+                    conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_search CASCADE"))
+                except Exception:
+                    has_ext = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'pg_search'")).fetchone()
+                    if not has_ext:
+                        raise
+
+                logger.info(f"Creating TEXT column on {table_name}")
+''',
+)
+
+# ----------------------------------------------------------------- verification
+import py_compile
+
+py_compile.compile(str(ROOT / "migrations.py"), doraise=True)
+
+m = (ROOT / "migrations.py").read_text()
+assert '"mental_models",  # renamed from `reflections` by alembic t5o6p7q8r9s0' in m, (
+    f"switchroom hindsight {NAME}: tables_to_check still does not name mental_models"
+)
+assert '"reflections",' not in m, (
+    f"switchroom hindsight {NAME}: the dead `reflections` table name survived the patch"
+)
+assert "DELETE FROM {schema_name}.reflections" not in m, (
+    f"switchroom hindsight {NAME}: the error message still advises deleting a table that does not exist"
+)
+assert "target_search_vector_is_content = text_search_extension not in (" in m, (
+    f"switchroom hindsight {NAME}: the content-vs-dummy classification is missing"
+)
+assert "if column_recreate_needed and target_search_vector_is_content:" in m, (
+    f"switchroom hindsight {NAME}: the data guard is not narrowed to a lossy column recreate"
+)
+assert "if current_col_type and current_col_type != target_column_type:" in m, (
+    f"switchroom hindsight {NAME}: the rebuild path still drops the column unconditionally"
+)
+assert m.count("ADD COLUMN IF NOT EXISTS search_vector") == 5, (
+    f"switchroom hindsight {NAME}: expected 5 idempotent ADD COLUMN sites, found "
+    f"{m.count('ADD COLUMN IF NOT EXISTS search_vector')}"
+)
+assert 'CREATE EXTENSION IF NOT EXISTS pg_search CASCADE' in m, (
+    f"switchroom hindsight {NAME}: the pg_search branch still never creates the extension"
+)
+# The CREATE EXTENSION must come BEFORE the CREATE INDEX in that branch, or the
+# pdb schema still does not exist when the index is built.
+# NB: `elif text_search_extension == "pg_search":` also appears in the
+# target-type selection at the top of the function — take the DDL branch.
+_branch = m.split('elif text_search_extension == "pg_search":\n                # switchroom (#4506, D2)', 1)[
+    1
+].split("else:  # native", 1)[0]
+assert _branch.index("CREATE EXTENSION IF NOT EXISTS pg_search") < _branch.index("USING bm25"), (
+    f"switchroom hindsight {NAME}: CREATE EXTENSION pg_search must precede the BM25 CREATE INDEX"
+)
+assert "indeterminate (TEXT search_vector, no text-search index)" in m, (
+    f"switchroom hindsight {NAME}: the detector still guesses a backend it cannot read"
+)
+
+print(
+    "switchroom hindsight text-search backend migration path: reconciles mental_models (not the "
+    "renamed-away `reflections`); the data guard now fires only on a genuinely lossy column "
+    "recreate, so a stale/absent index is rebuilt in place instead of being a one-way trapdoor; "
+    "the pg_search branch creates its extension before building the BM25 index; the mismatch "
+    "error names real tables and never guesses a backend it cannot read"
+)
+PYEOF
+
 # Empty-TimeoutError-message fix: both retry loops in
 # engine/providers/litellm_llm.py end their timeout handler with a bare
 # `raise`, which re-raises the asyncio.TimeoutError produced by

--- a/docker/hindsight-entrypoint.sh
+++ b/docker/hindsight-entrypoint.sh
@@ -743,18 +743,42 @@ EOF
 # pg_search_baked_major() — a stock native fleet (selector != pg_search, or an
 # older image with no bake) never enters here and is byte-identical to before.
 #
-# ── EXISTING-INSTALL MIGRATION BOUNDARY (read before assuming this migrates) ──
-# This function makes a NEW (empty) database come up on pg_search. It does NOT,
-# and MUST NOT, migrate a POPULATED database from the native tsvector backend:
-# hindsight_api HARD-REFUSES a text-search backend switch on non-empty memory
-# tables (the BM25 index must be rebuilt under a different operator class, which
-# upstream will not silently do under live data). The data migration is a
-# DELIBERATE operator-run step (pg_dump backup → drop the native search index →
-# flip HINDSIGHT_API_TEXT_SEARCH_EXTENSION → restart so this provisioning +
-# prestart_pg0 preload run → let hindsight_api rebuild the BM25 index). An
-# operator not ready to migrate pins `native` in hindsight.env; that pin
+# ── EXISTING-INSTALL MIGRATION BOUNDARY (what this function does and does not) ─
+# This function only stages the LIBRARY. It never touches operator data and it
+# never runs DDL: `CREATE EXTENSION pg_search` and the BM25 index are
+# hindsight_api's job, inside the migration that runs after us (see the
+# "text-search backend migration path" patch block in docker/Dockerfile.hindsight).
+#
+# THE MIGRATION IS A PLAIN ENV FLIP + RESTART. Since #4506 an operator moving a
+# POPULATED database from `native` to `pg_search` sets
+# HINDSIGHT_API_TEXT_SEARCH_EXTENSION=pg_search and restarts the container. The
+# ordering below (provision_pg_search → prestart_pg0 → start-all.sh) is what
+# makes that one-shot: we stage the .so and stop pg0, prestart_pg0 brings it up
+# with shared_preload_libraries=pg_search, and only then does hindsight_api
+# create the extension and build the index. NO manual DDL is required — in
+# particular, do NOT "drop the native search index first". That advice used to
+# live here and was wrong: it produced a column-without-index state that the
+# migration guard treated as a backend CHANGE and refused on BOTH backends, so
+# the database came up on neither (fixed in #4506; regression-pinned by
+# tests/docker/hindsight-text-search-migration-patch.test.ts).
+#
+# WHAT IS STILL REFUSED. Recreating `search_vector` under a backend that stores
+# the indexed content IN that column (`native`, `vchord`) is lossy: nothing
+# backfills it, so every existing row would go unsearchable. hindsight_api
+# therefore still hard-refuses pg_search → native on non-empty memory tables and
+# tells the operator to either clear the data or stay put. Migrating FORWARD to
+# pg_search is safe because pg_search indexes the base columns and keeps
+# `search_vector` as an unread dummy.
+#
+# COST, measured on this fleet's 801,792-row memory_units: CREATE EXTENSION
+# 0.06s, BM25 build 12.7s, total container-unavailable window 34s — well under
+# HINDSIGHT_API_STARTUP_WAIT_SECONDS (default 300), which start-all.sh enforces
+# by killing the container. A very large table should raise that ceiling first.
+# Take a pg_dump backup before any backend flip regardless.
+#
+# An operator not ready to migrate pins `native` in hindsight.env; that pin
 # survives `switchroom apply` (the key is on HINDSIGHT_PERF_ENV_KEYS) and this
-# function no-ops. Nothing here touches operator data.
+# function no-ops.
 provision_pg_search() {
   _psm="$(pg_search_baked_major)"
   [ -n "${_psm}" ] || return 0

--- a/src/setup/hindsight-perf-defaults.ts
+++ b/src/setup/hindsight-perf-defaults.ts
@@ -884,17 +884,33 @@ export const HINDSIGHT_DEFAULT_RECENCY_DECAY_HALFLIFE_DAYS = 30;
  *
  * ## Migration boundary — READ THIS before assuming a live fleet flips
  *
- * This default is safe **only for a NEW install (empty memory tables).**
- * hindsight_api HARD-REFUSES to switch the text-search backend on a non-empty
- * database: swapping `native` → `pg_search` requires the BM25 index to be
- * rebuilt with a different operator class, and upstream will not silently drop
- * and recreate it under live data. So this key going to `pg_search` does NOT
- * migrate an existing bank on the next `switchroom apply` — the container would
- * refuse to start against populated tables.
+ * Since #4506 a POPULATED fleet DOES migrate `native` → `pg_search` on the next
+ * restart after this key changes. That is deliberate and it is a behaviour
+ * change: previously hindsight_api refused the switch outright and the
+ * container would not start against populated tables. The direction is safe
+ * because `pg_search` indexes the base columns and keeps `search_vector` as an
+ * unread dummy, so nothing is lost by recreating it; the image's baked patch
+ * creates the extension and rebuilds the index in one boot with no operator DDL
+ * (`docker/Dockerfile.hindsight`, patch block "text-search backend migration
+ * path"; behaviour pinned by
+ * `tests/docker/hindsight-text-search-migration-patch.test.ts`).
  *
- * The data migration is a DELIBERATE, operator-run manual step, NOT encoded
- * here. An operator on a populated fleet who is not ready to migrate must pin
- * the prior backend in `hindsight.env`:
+ * The REVERSE direction is still hard-refused on non-empty tables: `native` and
+ * `vchord` store the indexed content IN `search_vector` and only ever write it
+ * on INSERT, so recreating that column would leave every existing row
+ * unsearchable with no backfill anywhere. hindsight_api raises and tells the
+ * operator to clear the data or stay put.
+ *
+ * COST of the forward migration, measured on this fleet's 801,792-row
+ * `memory_units`: `CREATE EXTENSION` 0.06s, BM25 build 12.7s, total
+ * container-unavailable window 34s. `start-all.sh` kills the container if the
+ * API is not healthy within `HINDSIGHT_API_STARTUP_WAIT_SECONDS` (default 300),
+ * so a substantially larger table should raise that ceiling before flipping.
+ * Take a `pg_dump` backup first regardless: the flip is reversible only by
+ * restore, since the reverse direction is refused.
+ *
+ * An operator who does not want that migration to happen on their next
+ * `switchroom apply` + restart must pin the prior backend in `hindsight.env`:
  *
  * ```yaml
  * hindsight:
@@ -907,8 +923,9 @@ export const HINDSIGHT_DEFAULT_RECENCY_DECAY_HALFLIFE_DAYS = 30;
  * {@link HINDSIGHT_PERF_ENV_KEYS} (the allowlist is the union of the default
  * groups) and {@link resolveHindsightPerfOverrides} then lets the operator
  * value replace the emitted default. Absent that allowlist membership the pin
- * would be silently discarded and the fleet would try to boot on `pg_search`
- * against live data — which is exactly the trap this pairing avoids.
+ * would be silently discarded and a populated fleet would migrate itself to
+ * `pg_search` on the next restart without the operator ever having chosen it —
+ * which is exactly the trap this pairing avoids.
  */
 export const HINDSIGHT_DEFAULT_TEXT_SEARCH_EXTENSION = "pg_search";
 

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -508,6 +508,62 @@ describe("Dockerfile.hindsight shape", () => {
     );
   });
 
+  it("keeps the text-search backend migration-path fix (assert-guarded, fail-loud)", () => {
+    // #4506. Five defects in `ensure_text_search_extension`, all OBSERVED in a
+    // rehearsal against a clone of the live 801,792-row memory_units.
+    // Behaviour is proven against the pinned upstream image in
+    // tests/docker/hindsight-text-search-migration-patch.test.ts; this pins the
+    // shape so a silent removal cannot ship.
+
+    // D1a. THE LOAD-BEARING CONSTRAINT: the data guard fires only when the
+    //      column type must genuinely change AND the target backend reads the
+    //      column's contents. Keyed on the (column, index) PAIR — as upstream
+    //      did — a merely-dropped index over a surviving column is fatal on
+    //      EVERY backend, including the one already in use, and the error's own
+    //      "set it back" advice cannot work. That was a one-way trapdoor.
+    expect(dockerfile).toMatch(
+      /target_search_vector_is_content = text_search_extension not in \(/,
+    );
+    expect(dockerfile).toMatch(
+      /if column_recreate_needed and target_search_vector_is_content:/,
+    );
+
+    // D1b. …and the rebuild path must not drop a correctly typed, POPULATED
+    //      column. `search_vector` is recreated EMPTY and only ever written on
+    //      INSERT, so an unconditional DROP on an index-only rebuild is silent
+    //      data loss in its own right.
+    expect(dockerfile).toMatch(
+      /if current_col_type and current_col_type != target_column_type:/,
+    );
+
+    // D2. the pg_search branch installs its own extension. Without this the
+    //     BM25 CREATE INDEX dies on `schema "pdb" does not exist`, because
+    //     nothing else in the boot path ever creates it (the entrypoint stages
+    //     the .so only, by design).
+    expect(dockerfile).toMatch(
+      /CREATE EXTENSION IF NOT EXISTS pg_search CASCADE/,
+    );
+    expect(dockerfile).toMatch(
+      /assert _branch\.index\("CREATE EXTENSION IF NOT EXISTS pg_search"\) < _branch\.index\("USING bm25"\)/,
+    );
+
+    // D3. the second memory table is reconciled under the name it actually has
+    //     (alembic t5o6p7q8r9s0 renamed reflections -> mental_models), and the
+    //     dead name is gone from the source entirely.
+    expect(dockerfile).toMatch(/"mental_models",\s+# renamed from `reflections`/);
+    expect(dockerfile).toMatch(/assert '"reflections",' not in m, \(/);
+
+    // D4. the detector never reports a backend it cannot read.
+    expect(dockerfile).toMatch(
+      /indeterminate \(TEXT search_vector, no text-search index\)/,
+    );
+
+    // the stable operator signal.
+    expect(dockerfile).toMatch(
+      /switchroom hindsight text-search backend migration path: reconciles mental_models/,
+    );
+  });
+
   it("creates /backups owned by hindsight BEFORE `USER hindsight` (so the named volume is writable)", () => {
     // A root-owned /backups mount point makes the fresh named volume
     // root-owned → the non-root hindsight process EACCESes on pg_dump and

--- a/tests/docker/hindsight-text-search-migration-patch.test.ts
+++ b/tests/docker/hindsight-text-search-migration-patch.test.ts
@@ -1,0 +1,568 @@
+/**
+ * Behavioural proof for the text-search backend migration-path fix (#4506)
+ * that `docker/Dockerfile.hindsight` bakes into the pinned upstream Hindsight
+ * image.
+ *
+ * `dockerfile-hindsight-bakes.test.ts` pins the *shape* of that patch block
+ * (grep-on-file, runs everywhere). This file proves the *outcome*: it runs the
+ * same probe against unpatched upstream (which must be RED) and against
+ * upstream + the patch block applied (which must be GREEN on every property).
+ *
+ * THE DEFECTS, all OBSERVED in a rehearsal against a clone of this fleet's
+ * 801,792-row `memory_units` (switchroom-hindsight v0.20.14), following the
+ * operator runbook that `docker/hindsight-entrypoint.sh` documented at the
+ * time:
+ *
+ *  1. THE TRAPDOOR. `ensure_text_search_extension` decides "does the schema
+ *     match the configured backend" on the (column, index) PAIR, then raises
+ *     whenever a mismatched table has rows. A database whose text-search INDEX
+ *     had been dropped while `search_vector` survived therefore raised on
+ *     EVERY backend — including the one already in use. Held CONSTANT at
+ *     pg_search, the rehearsal got, verbatim:
+ *       RuntimeError: Cannot change text search extension from pg_textsearch
+ *       to pg_search: the following tables contain data:
+ *       memory_units(801792 rows).
+ *     The database booted on no backend at all, and the error's own "set it
+ *     back" advice could not work. The old runbook told operators to create
+ *     exactly that state.
+ *  2. NOBODY CREATES THE EXTENSION. `provision_pg_search()` stages the .so +
+ *     control/sql files and deliberately does not touch the DB; the pg_search
+ *     branch of the migration went straight to CREATE INDEX and died with
+ *     `InvalidSchemaName: schema "pdb" does not exist`. The pgroonga branch
+ *     already did the right thing.
+ *  3. THE SECOND TABLE IS NEVER RECONCILED. `tables_to_check` names
+ *     `reflections`, renamed to `mental_models` by alembic `t5o6p7q8r9s0`, so
+ *     it matches nothing and that table keeps whatever index it had.
+ *  4. THE ERROR MISREPORTS THE BACKEND. With `column=text, index=None` there
+ *     is no index to read, yet it asserted `pg_textsearch` — and told the
+ *     operator to DELETE FROM a table that does not exist.
+ *  5. THE GUARD MUST STILL PROTECT A REAL LOSSY SWITCH. pg_search -> native on
+ *     populated tables recreates `search_vector` EMPTY, and nothing backfills
+ *     it (it is written only on INSERT), so that must still be refused. A
+ *     "fix" that merely deleted the guard would pass 1-4 while silently making
+ *     every existing row unsearchable.
+ *  6. AN INDEX-ONLY REBUILD MUST NOT DISCARD A POPULATED COLUMN. Upstream's
+ *     reconcile loop drops `search_vector` unconditionally, which is safe only
+ *     while (1) makes an index-only rebuild unreachable.
+ *
+ * The probe drives the REAL shipping `ensure_text_search_extension` with a
+ * fake ONLY at the SQLAlchemy boundary (`create_engine` / `to_libpq_url`): the
+ * fake connection answers the introspection reads and records the DDL the
+ * function actually emits. Nothing in it greps the patched source, and no
+ * database is required.
+ *
+ * The patch block is extracted from the Dockerfile itself rather than
+ * duplicated here, so this test cannot drift from what ships. It applies it by
+ * `docker exec` (not `docker build`) so it runs on daemons without buildx, and
+ * it never touches the production `switchroom-hindsight` container.
+ *
+ * SKIP DISCIPLINE: identical to
+ * `hindsight-pg-search-tokenizer-drift-patch.test.ts`. Locally, with no docker
+ * or no cached image, this skips (never pull a multi-GB third-party image onto
+ * a dev box). In CI the probe job pulls the pinned digest and sets
+ * SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1, under which an unavailable docker or
+ * image is a HARD FAILURE, never a green skip. Both runs assert a
+ * `PROBE_EXECUTED` sentinel so a probe that dies early can never be mistaken
+ * for a pass.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { execFileSync, execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const dockerfile = readFileSync(
+  resolve(root, "docker/Dockerfile.hindsight"),
+  "utf8",
+);
+
+const RUN_ID = randomUUID();
+const TEST_PHASE = "hindsight-text-search-migration-patch";
+
+/** The pinned upstream image, read from the Dockerfile so it cannot drift. */
+const UPSTREAM_IMAGE = (() => {
+  const m = dockerfile.match(/^FROM\s+(\S+)/m);
+  if (!m) throw new Error("Dockerfile.hindsight has no FROM line");
+  return m[1];
+})();
+
+/** The patch this file proves, named by its unique in-block marker. */
+const PATCH_NAME = "text-search backend migration path";
+
+/**
+ * PREREQUISITES, applied first, in Dockerfile order. Both earlier blocks edit
+ * `migrations.py` and this block's anchors are written against their output —
+ * a real ordering dependency in the Dockerfile, so the probe reproduces it
+ * rather than pretending the block is standalone. Their own assertions live in
+ * `hindsight-pg-search-filter-pushdown-patch.test.ts` and
+ * `hindsight-pg-search-tokenizer-drift-patch.test.ts`.
+ */
+const PREREQ_PATCH_NAMES = [
+  "pg_search filter-field pushdown",
+  "pg_search tokenizer-drift guard",
+];
+
+/**
+ * The patch block under test plus its prerequisites, pulled out of the
+ * Dockerfile's `RUN python3 - <<'PYEOF' ... PYEOF` heredocs by their unique
+ * patch names and returned in Dockerfile (application) order.
+ */
+function patchBlocks(): string[] {
+  const blocks = [
+    ...dockerfile.matchAll(/^RUN python3 - <<'PYEOF'\n([\s\S]*?)^PYEOF$/gm),
+  ].map((m) => m[1]);
+  const picked: string[] = [];
+  for (const name of [...PREREQ_PATCH_NAMES, PATCH_NAME]) {
+    const hits = blocks.filter((b) => b.includes(name));
+    if (hits.length !== 1) {
+      throw new Error(
+        `Dockerfile.hindsight contains ${hits.length} "${name}" RUN blocks ` +
+          `(expected exactly 1) — if the patch was deliberately removed, delete ` +
+          `this test with it.`,
+      );
+    }
+    picked.push(hits[0]);
+  }
+  return blocks.filter((b) => picked.includes(b));
+}
+
+/**
+ * The Python probe. Exits 0 only when all six properties above hold, and
+ * prints the offending assertions otherwise. It asserts OUTCOMES: it runs the
+ * real `ensure_text_search_extension` and reads back the DDL it emitted and
+ * the exceptions it raised.
+ */
+const PROBE = String.raw`
+import json
+import sys
+
+import hindsight_api.migrations as M
+
+failures = []
+
+
+def fail(msg):
+    failures.append(msg)
+
+
+IDX_BM25_PG_SEARCH = (
+    "CREATE INDEX idx_memory_units_text_search ON public.memory_units USING bm25 "
+    "(id, text, context, text_signals) WITH (key_field='id')"
+)
+IDX_GIN = "CREATE INDEX idx_memory_units_text_search ON public.memory_units USING gin (search_vector)"
+
+
+class _Res:
+    def __init__(self, value=None, row=None):
+        self._v = value
+        self._r = row
+
+    def scalar(self):
+        return self._v
+
+    def fetchone(self):
+        return self._r
+
+
+class FakeConn:
+    """Answers ONLY the introspection reads; records every DDL statement."""
+
+    def __init__(self, tables):
+        # tables: name -> dict(udt_name=..., am=..., indexdef=..., rows=int)
+        self.tables = tables
+        self.sql = []
+        self.committed = False
+
+    def execute(self, statement, params=None):
+        s = " ".join(str(statement).split())
+        p = params or {}
+        if "FROM information_schema.tables" in s:
+            return _Res(value=p.get("table_name") in self.tables)
+        if "FROM information_schema.columns" in s:
+            t = self.tables.get(p.get("table_name"), {})
+            udt = t.get("udt_name")
+            if udt is None:
+                return _Res(row=None)
+            data_type = {"tsvector": "tsvector", "text": "text"}.get(udt, "USER-DEFINED")
+            return _Res(row=(data_type, udt))
+        if "FROM pg_indexes pi" in s:
+            t = self.tables.get(p.get("table_name"), {})
+            if not t.get("am"):
+                return _Res(row=None)
+            return _Res(row=(t["am"], t.get("indexdef")))
+        if s.startswith("SELECT indexdef FROM pg_indexes"):
+            name = (p or {}).get("index_name", "")
+            for tn, t in self.tables.items():
+                if name == "idx_%s_text_search" % tn:
+                    return _Res(value=t.get("indexdef"))
+            return _Res(value=None)
+        if s.startswith("SELECT COUNT(*)"):
+            for tn, t in self.tables.items():
+                if s.endswith("public.%s" % tn):
+                    return _Res(value=t.get("rows", 0))
+            return _Res(value=0)
+        if "FROM pg_extension" in s:
+            return _Res(row=None)
+        self.sql.append(s)
+        return _Res()
+
+    def commit(self):
+        self.committed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+class FakeEngine:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def connect(self):
+        return self._conn
+
+
+def run(tables, backend):
+    """Drive the REAL ensure_text_search_extension; return (error, conn)."""
+    conn = FakeConn(tables)
+    orig_ce, orig_url = M.create_engine, M.to_libpq_url
+    M.create_engine = lambda *a, **k: FakeEngine(conn)
+    M.to_libpq_url = lambda u: u
+    try:
+        M.ensure_text_search_extension("postgresql://x/y", text_search_extension=backend)
+        return None, conn
+    except Exception as exc:  # noqa: BLE001 - the outcome under test
+        return exc, conn
+    finally:
+        M.create_engine, M.to_libpq_url = orig_ce, orig_url
+
+
+def ddl(conn):
+    return " || ".join(conn.sql)
+
+
+BIG = 801792
+
+# --- S1. THE TRAPDOOR: index dropped, column survives, backend UNCHANGED ------
+# pg_search -> pg_search on a populated table. Nothing about the backend is
+# changing; only the index is missing. This must be repaired, not fatal.
+err, conn = run(
+    {"memory_units": {"udt_name": "text", "am": None, "indexdef": None, "rows": BIG}},
+    "pg_search",
+)
+print("S1_ERR", repr(err))
+print("S1_DDL", ddl(conn))
+if err is not None:
+    fail("TRAPDOOR: a dropped index over a surviving TEXT column is FATAL under an UNCHANGED pg_search backend -> %r" % (err,))
+else:
+    if "USING bm25" not in ddl(conn):
+        fail("S1: the missing BM25 index was not rebuilt: %s" % ddl(conn))
+    if "DROP COLUMN" in ddl(conn):
+        fail("S1: an index-only rebuild dropped the search_vector column: %s" % ddl(conn))
+
+# --- S2. NOBODY CREATES THE EXTENSION -----------------------------------------
+# Empty table so upstream reaches the pg_search branch: it emits CREATE INDEX
+# USING bm25 without ever installing the extension, so the pdb schema the
+# ParadeDB casts live in does not exist and the index build dies.
+err, conn = run(
+    {"memory_units": {"udt_name": "tsvector", "am": "gin", "indexdef": IDX_GIN, "rows": 0}},
+    "pg_search",
+)
+print("S2_ERR", repr(err))
+print("S2_DDL", ddl(conn))
+if err is not None:
+    fail("S2: migrating an EMPTY table to pg_search raised: %r" % (err,))
+else:
+    d = ddl(conn)
+    if "CREATE EXTENSION IF NOT EXISTS pg_search" not in d:
+        fail("NO CREATE EXTENSION: the pg_search branch builds a BM25 index without installing pg_search -> %s" % d)
+    elif d.index("CREATE EXTENSION IF NOT EXISTS pg_search") > d.index("USING bm25"):
+        fail("S2: CREATE EXTENSION pg_search runs AFTER the BM25 CREATE INDEX")
+
+# --- S3. THE SECOND TABLE IS NEVER RECONCILED ---------------------------------
+# 'reflections' was renamed to 'mental_models'; the old name matches nothing.
+err, conn = run(
+    {
+        "memory_units": {"udt_name": "text", "am": "bm25", "indexdef": IDX_BM25_PG_SEARCH, "rows": BIG},
+        "mental_models": {"udt_name": "tsvector", "am": "gin", "indexdef": IDX_GIN, "rows": 43},
+    },
+    "pg_search",
+)
+print("S3_ERR", repr(err))
+print("S3_DDL", ddl(conn))
+if err is not None:
+    fail("S3: reconciling mental_models raised: %r" % (err,))
+elif "mental_models" not in ddl(conn):
+    fail(
+        "ORPHANED TABLE: mental_models keeps a native tsvector GIN under a pg_search backend and is "
+        "never reconciled -> %s" % (ddl(conn) or "<no DDL at all>")
+    )
+
+# --- S4. THE ERROR TEXT ---------------------------------------------------------
+# TEXT column, no index -> nothing can disambiguate pg_textsearch/pgroonga/
+# pg_search, and the remedy must name tables that exist.
+err, _c = run(
+    {
+        "memory_units": {"udt_name": "text", "am": None, "indexdef": None, "rows": BIG},
+        "mental_models": {"udt_name": "text", "am": None, "indexdef": None, "rows": 43},
+    },
+    "native",
+)
+print("S4_ERR", str(err))
+if err is None:
+    fail("S4: pg_search -> native on populated tables did NOT raise — the real data guard is gone")
+else:
+    msg = str(err)
+    if "from pg_textsearch" in msg:
+        fail("MISDETECTED BACKEND: reports 'pg_textsearch' from a TEXT column with no index to read -> %s" % msg)
+    if "reflections" in msg:
+        fail("DEAD TABLE IN ERROR TEXT: advises operating on 'reflections', renamed away by t5o6p7q8r9s0 -> %s" % msg)
+    if "mental_models" not in msg:
+        fail("S4: the remedy does not name mental_models -> %s" % msg)
+
+# --- S5. THE GUARD STILL PROTECTS A REAL LOSSY SWITCH ---------------------------
+# pg_search -> native with data: the tsvector column comes back EMPTY and is
+# only ever written on INSERT, so this must STILL be refused.
+err, _c = run(
+    {"memory_units": {"udt_name": "text", "am": "bm25", "indexdef": IDX_BM25_PG_SEARCH, "rows": BIG}},
+    "native",
+)
+print("S5_ERR", str(err))
+if err is None:
+    fail("REGRESSION: pg_search -> native on 801792 rows was ALLOWED; every existing row would become unsearchable")
+elif "from pg_search to native" not in str(err):
+    fail("S5: the refusal does not name the real direction -> %s" % err)
+
+# --- S6. AN INDEX-ONLY REBUILD MUST NOT DISCARD A POPULATED tsvector -------------
+err, conn = run(
+    {"memory_units": {"udt_name": "tsvector", "am": None, "indexdef": None, "rows": BIG}},
+    "native",
+)
+print("S6_ERR", repr(err))
+print("S6_DDL", ddl(conn))
+if err is not None:
+    fail("S6: a native backend with a dropped GIN index is FATAL instead of rebuilding the index -> %r" % (err,))
+else:
+    d = ddl(conn)
+    if "DROP COLUMN" in d:
+        fail("DATA LOSS: the populated tsvector column is dropped and recreated empty on an index-only rebuild -> %s" % d)
+    if "USING gin" not in d:
+        fail("S6: the GIN index was not rebuilt -> %s" % d)
+
+print("FAILURES", json.dumps(failures))
+print("PROBE_EXECUTED")
+sys.exit(1 if failures else 0)
+`;
+
+function hasDocker(): boolean {
+  try {
+    execSync("docker version --format '{{.Server.Version}}'", {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasImage(ref: string): boolean {
+  try {
+    execSync(`docker image inspect ${ref}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * CI marker. When set, this suite MUST really execute — an absent docker or an
+ * absent upstream image becomes a hard failure instead of a green skip.
+ */
+const REQUIRED = process.env.SWITCHROOM_REQUIRE_HINDSIGHT_PROBE === "1";
+
+const dockerOk = hasDocker();
+const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
+
+type ProbeResult = { status: number; stdout: string };
+
+/** Run the probe in a throwaway container, optionally patching it first. */
+function runProbe(patched: boolean): ProbeResult {
+  const name = `sr-hs-tsmig-${patched ? "patched" : "upstream"}-${RUN_ID.slice(0, 8)}`;
+  try {
+    execFileSync(
+      "docker",
+      [
+        "run",
+        "-d",
+        "--name",
+        name,
+        "--label",
+        `switchroom.test=${TEST_PHASE}`,
+        "--label",
+        `switchroom.test.run=${RUN_ID}`,
+        "--user",
+        "root",
+        "--network",
+        "none",
+        UPSTREAM_IMAGE,
+        "sleep",
+        "600",
+      ],
+      { stdio: ["ignore", "ignore", "pipe"] },
+    );
+
+    if (patched) {
+      for (const block of patchBlocks()) {
+        // Each block is self-verifying: it asserts its upstream anchors exist
+        // exactly the expected number of times and re-asserts the result, so a
+        // non-zero exit here means upstream drifted and the patch must be
+        // re-authored in docker/Dockerfile.hindsight.
+        execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
+          input: block,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      }
+    }
+
+    const res = execFileSync(
+      "docker",
+      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
+      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
+    );
+    return { status: 0, stdout: res };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: Buffer | string };
+    return { status: err.status ?? -1, stdout: (err.stdout ?? "").toString() };
+  } finally {
+    try {
+      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+describe("Dockerfile.hindsight text-search migration probe is real, not a silent skip", () => {
+  it("pins the upstream image by digest so the probe tests the exact shipping bytes", () => {
+    expect(UPSTREAM_IMAGE).toMatch(/@sha256:[0-9a-f]{64}$/);
+  });
+
+  it("extracts the patch block it claims to prove, plus its prerequisites, in order", () => {
+    const picked = patchBlocks();
+    expect(picked).toHaveLength(3);
+    expect(picked[0]).toContain(PREREQ_PATCH_NAMES[0]);
+    expect(picked[1]).toContain(PREREQ_PATCH_NAMES[1]);
+    expect(picked[2]).toContain(PATCH_NAME);
+  });
+
+  it("hard-fails rather than skipping when CI demands a real run", () => {
+    if (!REQUIRED) {
+      // Local/dev path: skipping is legitimate, but it must be visible rather
+      // than silent.
+      expect(
+        REQUIRED,
+        "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE is unset — the behavioural probe " +
+          "is advisory here.",
+      ).toBe(false);
+      return;
+    }
+    expect(
+      dockerOk,
+      "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but the docker daemon is unreachable",
+    ).toBe(true);
+    expect(
+      imageOk,
+      `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but ${UPSTREAM_IMAGE} is not present ` +
+        "locally — the workflow must pull the pinned digest before this suite runs",
+    ).toBe(true);
+  });
+});
+
+describe.skipIf(!dockerOk || !imageOk)(
+  "Dockerfile.hindsight text-search migration patch changes real behaviour",
+  () => {
+    afterAll(() => {
+      // Label-scoped teardown belt — never an unlabelled bulk removal.
+      try {
+        const ids = execSync(
+          `docker ps -aq --filter label=switchroom.test.run=${RUN_ID}`,
+          { encoding: "utf8" },
+        )
+          .split("\n")
+          .filter(Boolean);
+        if (ids.length) {
+          execFileSync("docker", ["rm", "-f", ...ids], { stdio: "ignore" });
+        }
+      } catch {
+        /* nothing to clean */
+      }
+    });
+
+    it("unpatched upstream is RED — the trapdoor, the missing extension, the dead table", () => {
+      const { status, stdout } = runProbe(false);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED",
+      );
+      expect(status, `probe unexpectedly passed:\n${stdout}`).not.toBe(0);
+
+      // 1. the trapdoor, reproduced verbatim: the backend is UNCHANGED and the
+      //    only thing wrong is a missing index, yet it is fatal.
+      expect(stdout).toContain("TRAPDOOR:");
+      expect(stdout).toMatch(
+        /S1_ERR .*Cannot change text search extension from pg_textsearch to pg_search/,
+      );
+      expect(stdout).toMatch(/^S1_DDL\s*$/m); // and it emitted no repair DDL at all
+      // 2. the BM25 index is built without the extension owning the pdb schema.
+      expect(stdout).toContain("NO CREATE EXTENSION:");
+      // 3. mental_models is never reconciled.
+      expect(stdout).toContain("ORPHANED TABLE:");
+      // 4. the message guesses a backend, and names a table that does not exist.
+      expect(stdout).toContain("MISDETECTED BACKEND:");
+      expect(stdout).toContain("DEAD TABLE IN ERROR TEXT:");
+      // 6. a native fleet that merely lost its GIN index is equally stuck —
+      //    "from native to native".
+      expect(stdout).toMatch(
+        /S6_ERR .*Cannot change text search extension from native to native/,
+      );
+    }, 300_000);
+
+    it("upstream + the baked patch block is GREEN on all six properties", () => {
+      const { status, stdout } = runProbe(true);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED",
+      );
+      expect(status, `probe failed:\n${stdout}`).toBe(0);
+      expect(stdout).toContain("FAILURES []");
+
+      // 1. the trapdoor is repaired in place: the index is rebuilt and the
+      //    surviving column is NOT dropped.
+      expect(stdout).toMatch(/S1_ERR None/);
+      expect(stdout).toMatch(/S1_DDL .*USING bm25/);
+      expect(stdout).not.toMatch(/S1_DDL .*DROP COLUMN/);
+      // 2. the extension is installed before the index that needs it.
+      expect(stdout).toMatch(
+        /S2_DDL .*CREATE EXTENSION IF NOT EXISTS pg_search CASCADE .*USING bm25/,
+      );
+      // 3. mental_models is reconciled under the name it actually has.
+      expect(stdout).toMatch(/S3_DDL .*idx_mental_models_text_search/);
+      // 4. the message reads the schema instead of guessing, and names real
+      //    tables in its remedy.
+      expect(stdout).toContain(
+        "indeterminate (TEXT search_vector, no text-search index)",
+      );
+      expect(stdout).toContain("DELETE FROM public.mental_models;");
+      // 5. the genuinely lossy switch is STILL refused.
+      expect(stdout).toMatch(
+        /S5_ERR Cannot change text search extension from pg_search to native/,
+      );
+      // 6. an index-only rebuild keeps the populated tsvector column.
+      expect(stdout).toMatch(/S6_DDL .*USING gin/);
+      expect(stdout).not.toMatch(/S6_DDL .*DROP COLUMN/);
+    }, 300_000);
+  },
+);


### PR DESCRIPTION
Closes #4506.

v0.20.13 shipped `pg_search` as the default text-search backend for new installs and documented a manual operator procedure for migrating an existing bank. **That procedure does not work**, and the code behind it had five separate defects. All five are fixed by a new patch block in `docker/Dockerfile.hindsight` (the only place switchroom can change upstream `hindsight_api`).

Every defect below was verified against the real shipping source at the pinned digest — not from the ticket — and every claim in this PR is backed by the probe output at the bottom.

## D1 — dropped-index-with-surviving-column was a one-way trapdoor

`ensure_text_search_extension` decided "does the schema match the configured backend" on the **(column, index) PAIR**, then raised whenever a mismatched table had rows. So a database whose text-search INDEX had been dropped while `search_vector` survived — *the exact state the old runbook asked operators to create* — raised on **every** backend, including the one already configured. Held constant at pg_search:

```
RuntimeError: Cannot change text search extension from pg_textsearch to pg_search:
  the following tables contain data: memory_units(801792 rows).
```

The bank came up on nothing, and the error's own "set it back" advice could not work because the same pair still mismatched.

**The insight.** What is at risk is never the index — an index is rebuilt from the heap — but the **column**. A recreated `search_vector` comes back EMPTY and is only ever written on INSERT (`ops_postgresql.insert_facts_batch`); nothing backfills it. And that only matters for the backends that store the indexed content IN the column: `native` (tsvector) and `vchord` (bm25vector). `pg_textsearch`, `pgroonga` and `pg_search` index the BASE columns and keep `search_vector` as a dummy for schema symmetry.

So the guard is re-keyed onto **"the column type must genuinely change AND the target backend reads the column's contents"**, written as a negative test so an unrecognised future backend is treated as content-bearing (guarded), never as safe-to-recreate. A real lossy switch is still refused; a stale or absent index over a correctly typed column is rebuilt in place.

**Second-order fix, caught in self-review before writing the code:** with the guard relaxed, the reconcile loop's *unconditional* `DROP COLUMN` would newly become reachable on a native→native index-only rebuild — discarding a populated tsvector and recreating it empty. That would have turned a fixed trapdoor into silent data loss. `DROP COLUMN` is now conditional on the column type actually changing, and the five `ADD COLUMN` sites are idempotent. Probe scenario S6 pins it.

## D2 — nothing ever ran `CREATE EXTENSION pg_search`

`provision_pg_search()` stages the `.so` + control/sql into the embedded-pg install and deliberately does not touch the database. The migration's pg_search branch then went straight to `CREATE INDEX ... USING bm25` and died with `InvalidSchemaName: schema "pdb" does not exist` — the `pdb` schema is created *by* the extension. It was available the whole time (`default_version` 0.25.1, `installed_version` None). The pgroonga branch a few lines above already did the right thing; this mirrors it, "already exists / no permission" fallback included.

## D3 — `tables_to_check` named a table that does not exist

`reflections` was renamed to `mental_models` by alembic `t5o6p7q8r9s0` (which also renamed `idx_reflections_text_search`). The old name matched nothing, so the loop reconciled `memory_units` **alone**, and the RuntimeError advised `DELETE FROM public.reflections`.

**Decision: renamed, not deleted.** The ticket left this open. Rationale: nothing reads `mental_models.search_vector` today (the BM25 arm in `engine/sql/postgresql.py:185-247` is memory_units-only), so it is inert either way; the existing `else:` arm already expects `mental_models`' `name`/`content` columns and works unmodified; renaming preserves upstream's evident intent that both memory tables track the configured backend, costs one BM25 index over 43 rows on this fleet, and leaves nothing orphaned for a future recall arm to trip over. The alternative (drop the entry and clean up the orphan) means destructive boot-time DDL on a table upstream may later use.

## D4 — the error misreported the live backend

With `column=text, index=None` there is no `key_field` reloption to read, and pg_textsearch / pgroonga / pg_search all sit on a plain TEXT column — the live backend is genuinely undetermined. Upstream asserted `pg_textsearch` and told the operator to pin it. It now reports `indeterminate (TEXT search_vector, no text-search index)` and how to read the backend off the schema, describes a table that actually **tripped** the guard (upstream read `mismatched_tables[0]`, which need not be one of them), and names real tables in remedy 1.

## D5 — the chicken-and-egg: **no entrypoint change was needed**

`CREATE EXTENSION pg_search` needs `shared_preload_libraries=pg_search`, a PGC_POSTMASTER GUC only `prestart_pg0()` sets and only applied at postmaster start — but booting the API tripped D1, so the rehearsal could only get through with a manual `HINDSIGHT_ENABLE_API=false` boot. With D1 and D2 fixed, the entrypoint's existing order already satisfies the dependency:

`provision_pg_search` (stages .so, stops pg0) → `prestart_pg0` (starts with the preload) → `provision_text_search` → `exec start-all.sh` (migrations)

Verified at `docker/hindsight-entrypoint.sh:952-981`. A populated fleet now migrates on a plain env flip + restart, in one boot.

## Tests assert outcomes, not shape

`tests/docker/hindsight-text-search-migration-patch.test.ts` drives the **real shipping** `ensure_text_search_extension` inside a throwaway container from the pinned upstream digest, faking only the SQLAlchemy boundary (`create_engine` / `to_libpq_url`), and reads back the DDL it emits and the exceptions it raises. It extracts the patch block from the Dockerfile itself (so it cannot drift from what ships) and applies it by `docker exec`, never `docker build`.

**RED on unpatched upstream** (exit 1, `PROBE_EXECUTED`) — all seven failure strings fire, including the rehearsal's error reproduced verbatim:

```
S1_ERR RuntimeError("Cannot change text search extension from pg_textsearch to pg_search:
  the following tables contain data: memory_units(801792 rows). ... DELETE FROM public.reflections; ...")
TRAPDOOR: / NO CREATE EXTENSION: / ORPHANED TABLE: <no DDL at all> /
MISDETECTED BACKEND: / DEAD TABLE IN ERROR TEXT: /
S6_ERR "Cannot change text search extension from native to native"   ← the trapdoor at its purest
```

**GREEN patched** (exit 0, `FAILURES []`):

```
S1_DDL CREATE EXTENSION IF NOT EXISTS pg_search CASCADE || ALTER TABLE public.memory_units ADD COLUMN IF NOT EXISTS search_vector TEXT || CREATE INDEX idx_memory_units_text_search ON public.memory_units USING bm25 (id, text, context, text_signals, (bank_id::pdb.literal), (fact_type::pdb.literal)) WITH (key_field='id')
S3_DDL ... CREATE INDEX idx_mental_models_text_search ON public.mental_models USING bm25 (id, name, content) WITH (key_field='id')
S4_ERR Cannot change text search extension from indeterminate (TEXT search_vector, no text-search index) to native: ... DELETE FROM public.memory_units; DELETE FROM public.mental_models; ...
S5_ERR Cannot change text search extension from pg_search to native: ... Stay on the current backend (set HINDSIGHT_API_TEXT_SEARCH_EXTENSION='pg_search')
S6_DDL ALTER TABLE public.memory_units ADD COLUMN IF NOT EXISTS search_vector tsvector || CREATE INDEX ... USING gin(search_vector)
FAILURES []
```

**Two of the six scenarios exist to pin what must NOT change** — S5 (pg_search → native on 801,792 rows must still be refused) and S6 (an index-only rebuild must not drop a populated tsvector). A fix that merely deleted the guard would pass D1–D4 and silently make every existing row unsearchable; those two are what make that impossible.

Wired into the `hindsight-probe` CI job, which hard-fails rather than skipping (`SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1`), plus a static shape guard in `dockerfile-hindsight-bakes.test.ts` so a silent removal cannot ship.

**Bonus:** because the S1 in-place rebuild goes through the current DDL path, it also picks up the #4478 pushdown columns `(bank_id::pdb.literal), (fact_type::pdb.literal)` — a rebuild repairs the filter-field gap too.

## Contradictions with the ticket, reported rather than force-fitted

1. **There is no `switchroom/hindsight` repo.** The code is upstream `vectorize-io/hindsight`, patched at image-build time from `docker/Dockerfile.hindsight` in this repo. Upstream source was read out of the pinned base image with a read-only `docker create` + `docker cp`; the live `switchroom-hindsight` container was never touched.
2. **`pg_textsearch` IS a legitimate configured value upstream** (validated in `config.py`'s tuple; docstring `migrations.py:786`, branch `:810`) — it is simply not what this deployment uses. The real D4 bug is mis-attribution when the index is absent, not an invented value.
3. **D5 needed no entrypoint fix** (see above).

## Judgement call, surfaced rather than decided silently

Relaxing the D1 guard means a populated fleet that flips this key **auto-migrates at boot** (~13 s index build) instead of hard-refusing. That is exactly what D5 asked for, but it removes a safety net. Both doc blocks are rewritten to say so honestly, and to call out the `HINDSIGHT_API_STARTUP_WAIT_SECONDS` ceiling (default 300 s; `start-all.sh` kills the container past it) against the measured 12.7 s. **Recommendation: keep the auto-migration** — it is the requirement, the direction is provably non-lossy, and the reverse direction is still refused.

## Operator procedure that is valid AFTER this ships

1. `pg_dump` backup (the flip is reversible only by restore — the reverse direction is still refused by design).
2. Set `HINDSIGHT_API_TEXT_SEARCH_EXTENSION: "pg_search"` under `hindsight.env` (or simply remove a `native` pin to take the default).
3. `switchroom apply` + restart the hindsight container.
4. Done. **No manual DDL.** In particular do NOT drop the native search index first — that is what created the trapdoor. Measured on 801,792 rows: `CREATE EXTENSION` 0.06 s, BM25 build 12.7 s, 34 s total container-unavailable.

For a bank substantially larger than this one, raise `HINDSIGHT_API_STARTUP_WAIT_SECONDS` above its 300 s default first.

## Not verified

- Nothing here was run against live data. The rehearsal numbers quoted are from the prior, separately-authorised exercise on a cloned volume; this PR's own proof is the container probe against the pinned digest.
- Local `tsc` reports pre-existing `Cannot find module 'nostr-tools'` errors in `src/buzz-gateway/**` — an environment artefact of a borrowed `node_modules` predating that dependency, in files this PR does not touch. Every other lint guard passes locally; CI is the authority.

## Follow-up filed separately

`ensure_vector_extension` has the **identical** dead-table bug at `migrations.py:594-598` and `:708`, naming `pinned_reflections` (renamed twice away: `pinned_reflections` → `reflections` → `mental_models`). So `mental_models`' vector index is never reconciled either, and that error also advises deleting a nonexistent table. Deliberately out of scope here to keep this PR single-concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
