### PR TITLE
fix(hindsight): make HINDSIGHT_API_BM25_MAX_QUERY_TERMS actually reach the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,22 @@ now an anomaly worth investigating, not the norm.
   six scenarios, including the two that must keep failing. Wired into the
   `hindsight-probe` CI job, which hard-fails rather than skipping. (#4506)
 
+### Hindsight: `HINDSIGHT_API_BM25_MAX_QUERY_TERMS` is no longer silently discarded
+
+- **The key was inert no matter what an operator wrote.** Upstream parses
+  `HINDSIGHT_API_BM25_MAX_QUERY_TERMS` (`config.py:764`, `:2946`) and threads it
+  to `retrieval.py:240` -> `engine/sql/postgresql.py:258`, where it truncates the
+  token list before the BM25 query is built — the direct lever on a multi-KB
+  consolidation query becoming a disjunction over hundreds of terms. But it was
+  not a member of `HINDSIGHT_PERF_ENV_KEYS`, and `resolveHindsightPerfOverrides`
+  skips every key outside the managed set, so a `hindsight.env` line for it was
+  dropped with no error and never reached the container on either launch path.
+  Added to `HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS` and documented on the
+  `hindsight.env` schema description. Override-only on purpose: switchroom emits
+  no default, so a stock fleet keeps upstream's unbounded `0` — a cap chosen
+  without a measurement silently drops the tail of a long query and degrades
+  recall quality with nothing to notice. (#4506)
+
 ## v0.20.14 — BM25 filter-field pushdown for Hindsight keyword recall, and a phase-attribution ceiling for database-side proposals
 
 ### Hindsight keyword recall: BM25 filter-field pushdown

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -3014,7 +3014,12 @@ export const HindsightConfigSchema = z.object({
       "always-safe `english`, set `hindsight_english` to use switchroom's " +
       "junk-stopping config (dict + stopword file provisioned durably by the " +
       "image entrypoint, recall degrading to semantic-only if it is ever " +
-      "missing); plus the " +
+      "missing); and " +
+      "HINDSIGHT_API_BM25_MAX_QUERY_TERMS \u2014 the max number of query tokens the " +
+      "keyword (BM25) recall arm searches for; unset means upstream's 0 = " +
+      "unbounded, which makes a multi-KB consolidation query a disjunction " +
+      "over hundreds of terms; set e.g. 64 to cap it, at the cost of " +
+      "silently dropping the tail of a long query; plus the " +
       "embedded-PostgreSQL (pg0) sizing keys switchroom manages in " +
       "src/setup/hindsight-pg-defaults.ts (`HINDSIGHT_PG_ENV_KEYS`: " +
       "SWITCHROOM_HINDSIGHT_PG_EFFECTIVE_CACHE_SIZE, " +

--- a/src/setup/hindsight-perf-defaults.test.ts
+++ b/src/setup/hindsight-perf-defaults.test.ts
@@ -352,7 +352,7 @@ describe("operator override wins", () => {
     expect(got.size).toBe(0);
   });
 
-  it("is overridable on exactly these fifty keys, by name", () => {
+  it("is overridable on exactly these fifty-one keys, by name", () => {
     // Spelled out, NOT derived from the three group arrays. HINDSIGHT_PERF_ENV_KEYS
     // is DEFINED as the union of those arrays, so asserting it equals that union
     // is a tautology — it passes no matter which keys are in the arrays. The
@@ -360,6 +360,7 @@ describe("operator override wins", () => {
     // `hindsight.env` description names these keys), so pin the literal list:
     // adding or dropping a managed key must fail here and force the doc update.
     expect([...HINDSIGHT_PERF_ENV_KEYS].sort()).toEqual([
+      "HINDSIGHT_API_BM25_MAX_QUERY_TERMS",
       "HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT",
       "HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM",
       "HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND",
@@ -623,6 +624,66 @@ describe("HINDSIGHT_API_TEXT_SEARCH_EXTENSION_NATIVE_LANGUAGE (override-only)", 
     );
     // Both paths, or the value dies on whichever recreate the operator uses —
     // exactly the live-vs-durable gap this whole change closes.
+    expect(fromRun.get(KEY)).toEqual([VALUE]);
+    expect(fromCompose.get(KEY)).toEqual([VALUE]);
+  });
+
+  it("still reaches the container on a host with NO gated capability", () => {
+    const perf = { env: { [KEY]: VALUE }, processEnv: {} };
+    startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, false, perf);
+    expect(runEnv(runArgs()).get(KEY)).toEqual([VALUE]);
+  });
+});
+
+describe("HINDSIGHT_API_BM25_MAX_QUERY_TERMS (override-only)", () => {
+  // Upstream parses this at config.py:2946 from ENV_BM25_MAX_QUERY_TERMS
+  // (config.py:764), defaults it to 0 = unbounded, and threads it to
+  // retrieval.py:240 -> engine/sql/postgresql.py:258, which truncates the token
+  // list before the BM25 query is built. Before this key joined the managed
+  // set it was INERT: resolveHindsightPerfOverrides skips anything outside
+  // HINDSIGHT_PERF_ENV_KEYS, so an operator's hindsight.env line was discarded
+  // with no error and never reached the container on EITHER launch path. That
+  // is the regression these cases guard — the value must survive `switchroom
+  // apply` and arrive intact.
+  const KEY = "HINDSIGHT_API_BM25_MAX_QUERY_TERMS";
+  const VALUE = "64";
+  const CAPS = [
+    { gpu: false, localLlm: false },
+    { gpu: true, localLlm: false },
+    { gpu: false, localLlm: true },
+    { gpu: true, localLlm: true },
+  ];
+
+  it("is in the managed set but in NO defaults group (no emitted default)", () => {
+    expect(HINDSIGHT_PERF_ENV_KEYS.has(KEY)).toBe(true);
+    expect(HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS.has(KEY)).toBe(true);
+    for (const group of [
+      HINDSIGHT_PERF_DEFAULTS_UNGATED,
+      HINDSIGHT_PERF_DEFAULTS_GPU,
+      HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM,
+    ]) {
+      expect(group.map(([k]) => k)).not.toContain(KEY);
+    }
+  });
+
+  it.each(CAPS)(
+    "is NOT emitted when unset (gpu=$gpu localLlm=$localLlm) — upstream's unbounded 0 stands",
+    (caps) => {
+      // A cap picked without a measurement would silently drop the tail of a
+      // long query and degrade recall QUALITY with no error to notice, so a
+      // stock fleet must stay on upstream's 0.
+      expect(hindsightPerfEnv(caps).map(([k]) => k)).not.toContain(KEY);
+    },
+  );
+
+  it("reaches BOTH launch paths, with the operator's value, when set in hindsight.env", () => {
+    const perf = { env: { [KEY]: VALUE }, processEnv: {} };
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, false, perf);
+    const fromRun = runEnv(runArgs());
+    const fromCompose = composeEnv(
+      generateHindsightComposeSnippet(undefined, undefined, LOOPBACK_LITELLM, false, perf),
+    );
+    // Both paths, or the value dies on whichever recreate the operator uses.
     expect(fromRun.get(KEY)).toEqual([VALUE]);
     expect(fromCompose.get(KEY)).toEqual([VALUE]);
   });

--- a/src/setup/hindsight-perf-defaults.ts
+++ b/src/setup/hindsight-perf-defaults.ts
@@ -1479,6 +1479,38 @@ export const HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM: ReadonlyArray<readonly [string, 
  *     HINDSIGHT_API_TEXT_SEARCH_EXTENSION_NATIVE_LANGUAGE: "hindsight_english"
  * ```
  *
+ * ### `HINDSIGHT_API_BM25_MAX_QUERY_TERMS` (override-only)
+ *
+ * A cap on how many tokens of a query the keyword arm actually searches for.
+ * Upstream parses it at `config.py:2946` from `ENV_BM25_MAX_QUERY_TERMS`
+ * (`config.py:764`), defaults it to `0` = unbounded (`DEFAULT_BM25_MAX_QUERY_TERMS`,
+ * `config.py:935`), and threads it to `retrieval.py:240` ->
+ * `engine/sql/postgresql.py:258`, which truncates the token list before the
+ * BM25 query is built. It is the direct lever on the pathological case: a
+ * multi-KB consolidation query becomes a BM25 disjunction over hundreds of
+ * terms, and the cost of that scan is linear in the term count.
+ *
+ * Until now the key was INERT no matter what an operator wrote. It is not a
+ * member of {@link HINDSIGHT_PERF_ENV_KEYS} (of which this set is one of the
+ * three constituents), and {@link resolveHindsightPerfOverrides} skips every
+ * key outside the managed set — so a `hindsight.env` line for it was discarded
+ * with no error and no warning, and the value never reached the container on
+ * either launch path. That is the same silent-drop defect recorded above for
+ * the reranker keys; this entry closes it for this one.
+ *
+ * OVERRIDE-ONLY, deliberately: switchroom emits no default, so a stock fleet
+ * keeps upstream's unbounded `0`. Choosing a cap here would be an
+ * unfalsifiable opinion — the right ceiling depends on a fleet's query shape,
+ * and a too-low value silently drops query terms and degrades recall QUALITY
+ * with no error to notice. Promote it to an emitted default only behind a
+ * measurement.
+ *
+ * ```yaml
+ * hindsight:
+ *   env:
+ *     HINDSIGHT_API_BM25_MAX_QUERY_TERMS: "64"
+ * ```
+ *
  * ### DELIBERATELY NOT ADOPTED from v0.8.6
  *
  * - `HINDSIGHT_API_LOOP_WATCHDOG_ENABLED` / `..._STALL_THRESHOLD_MS` /
@@ -1508,6 +1540,7 @@ export const HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS: ReadonlySet<string> = new Set([
   "HINDSIGHT_API_TEMPORAL_LANGUAGES",
   "HINDSIGHT_API_TEMPORAL_MAX_QUERY_CHARS",
   "HINDSIGHT_API_TEXT_SEARCH_EXTENSION_NATIVE_LANGUAGE",
+  "HINDSIGHT_API_BM25_MAX_QUERY_TERMS",
 ]);
 
 /**


### PR DESCRIPTION
## The bug

`HINDSIGHT_API_BM25_MAX_QUERY_TERMS` was inert. An operator could set it in
`hindsight.env` and it would be silently discarded — no warning, no error, and
nothing in the container's environment.

The key is real upstream and load-bearing:

- parsed at `config.py:764` (`ENV_BM25_MAX_QUERY_TERMS`), `config.py:935`, `config.py:2946`, default `0` = unbounded
- threaded to `retrieval.py:240`
- consumed at `engine/sql/postgresql.py:254-259`, where it truncates the token list before the BM25 query is built

That makes it the direct lever on the failure mode where a multi-KB
consolidation query degenerates into a BM25 disjunction over hundreds of terms.

## Why it was inert

`resolveHindsightPerfOverrides` skips any key outside `HINDSIGHT_PERF_ENV_KEYS`
— the union of the three defaults groups plus `HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS`.
The key was in none of them. Verified: it has **zero** references anywhere in
this repo before this PR.

## The change

Follows the file's existing convention for an override-only key (the
`HINDSIGHT_API_TEXT_SEARCH_EXTENSION_NATIVE_LANGUAGE` precedent):

1. `src/setup/hindsight-perf-defaults.ts` — TSDoc block citing the upstream call chain and explaining why it stays override-only, plus the `HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS` entry.
2. `src/config/schema.ts` — documented on the `hindsight.env` description so it is discoverable from config help.
3. `src/setup/hindsight-perf-defaults.test.ts` — roster entry (`fifty` -> `fifty-one`) and a four-case `describe` block.

**Override-only on purpose.** Switchroom emits no default, so a stock fleet
keeps upstream's unbounded `0`. A cap chosen without a measurement silently
drops the tail of a long query and degrades recall *quality* with nothing to
notice — a worse failure mode than a slow query. The operator opts in.

## Tests assert the outcome

Removing **only** the set entry (leaving the tests and docs) fails four cases:

```
 ❯ src/setup/hindsight-perf-defaults.test.ts (223 tests | 4 failed)
   × is overridable on exactly these fifty-one keys, by name
   × HINDSIGHT_API_BM25_MAX_QUERY_TERMS (override-only) > is in the managed set but in NO defaults group
   × HINDSIGHT_API_BM25_MAX_QUERY_TERMS (override-only) > reaches BOTH launch paths, with the operator's value, when set in hindsight.env
   × HINDSIGHT_API_BM25_MAX_QUERY_TERMS (override-only) > still reaches the container on a host with NO gated capability
```

The two launch-path cases are the real guard: they assert the operator's value
`64` arrives in both the `docker run` argv and the compose snippet, so the key
cannot die on whichever recreate path the operator happens to use. With the
entry restored, 223 pass.

The "not emitted when unset" case runs across all four gated-capability
combinations, pinning that a stock fleet stays on upstream's `0`.

## Notes

- Minor drift from the ticket: `HINDSIGHT_PERF_OVERRIDE_ONLY_KEYS` is at ~line 1496, not 1479.
- `npm run lint` fails locally on 14 pre-existing `TS2307: Cannot find module 'nostr-tools'` errors in `src/buzz-gateway/**` — an environment artefact (borrowed `node_modules` predates `package.json:70`) in files this PR does not touch. The remaining guard scripts were run individually and pass, including `check-changelog-entry`. CI is the authority.
- Split out of #4507 (the pg_search migration-path fix) as the ticket asked; no shared files, no dependency.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
