### PR TITLE
fix(hindsight): drop the dead CREATE EXTENSION fallback and pin the production migration shape (#4507 review)

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -599,7 +599,7 @@ jobs:
       - name: Label-scoped teardown
         if: always()
         run: |
-          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-mm-refresh-debounce-patch hindsight-pg-search-tokenizer-drift-patch hindsight-text-search-migration-patch hindsight-graph-seed-retirement hindsight-maxitems-grammar-patch hindsight-reflect-directives-patch hindsight-recall-budget-reflect-grounding hindsight-reranker-priority-patch hindsight-temporal-language-patch hindsight-temporal-offload-patch hindsight-pg-fsync-probe; do
+          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-mm-refresh-debounce-patch hindsight-pg-search-tokenizer-drift-patch hindsight-pg-search-filter-pushdown-patch hindsight-text-search-migration-patch hindsight-graph-seed-retirement hindsight-maxitems-grammar-patch hindsight-reflect-directives-patch hindsight-recall-budget-reflect-grounding hindsight-reranker-priority-patch hindsight-temporal-language-patch hindsight-temporal-offload-patch hindsight-pg-fsync-probe; do
             ids=$(docker ps -aq --filter "label=switchroom.test=$phase" 2>/dev/null || true)
             if [ -n "$ids" ]; then docker rm -f $ids 2>/dev/null || true; fi
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,29 @@ now an anomaly worth investigating, not the norm.
   a throwaway container and asserts it is RED unpatched and GREEN patched across
   six scenarios, including the two that must keep failing. Wired into the
   `hindsight-probe` CI job, which hard-fails rather than skipping. (#4506)
+- **A failed `CREATE EXTENSION pg_search` now reports why.** The migration
+  mirrored upstream's `pgroonga` branch verbatim, including an "already exists /
+  no permission" fallback that re-probed `pg_extension` in the `except` arm.
+  With `IF NOT EXISTS` that probe can never suppress anything, and because the
+  whole reconcile runs in ONE transaction it fired on an already-aborted one —
+  so the operator got `current transaction is aborted` instead of the real
+  ParadeDB error. That is precisely the wrong trade here: `prestart_pg0` is
+  best-effort, so an ineffective `shared_preload_libraries=pg_search` is the
+  most likely real-world failure of this migration, and it was exactly the
+  diagnostic being destroyed. The fallback is gone; the statement raises
+  directly. (#4507)
+- **The probe now covers the migration operators actually run.** The six
+  original scenarios each isolate one defect, but none was a populated
+  `memory_units` carrying a `tsvector` under a live GIN index flipped to
+  `pg_search` — the shape the runbook produces. A seventh covers it at the real
+  row count and pins the ORDER of the repair (stale index before its column;
+  `CREATE EXTENSION` before the BM25 build that needs the `pdb` schema), plus
+  that the rebuilt index keeps the #4478 `bank_id`/`fact_type` `pdb.literal`
+  pushdown fast fields — previously asserted nowhere, despite riding on an
+  optional argument a refactor could drop in silence. (#4507)
+- **CI no longer leaks the filter-pushdown probe's containers.** The
+  `hindsight-probe` job's label-scoped teardown loop omitted
+  `hindsight-pg-search-filter-pushdown-patch`. (#4507)
 
 ## v0.20.14 — BM25 filter-field pushdown for Hindsight keyword recall, and a phase-attribution ceiling for database-side proposals
 

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -2091,14 +2091,27 @@ patch(
                 # died with `InvalidSchemaName: schema "pdb" does not exist`
                 # because the pdb schema only exists once the extension is
                 # installed. The pgroonga branch above already does exactly this;
-                # mirror it, including the "already exists / no permission"
-                # verification fallback.
-                try:
-                    conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_search CASCADE"))
-                except Exception:
-                    has_ext = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'pg_search'")).fetchone()
-                    if not has_ext:
-                        raise
+                # mirror its CREATE EXTENSION — but deliberately NOT its
+                # try/except fallback (#4507 review):
+                #
+                #   1. `IF NOT EXISTS` already makes the fallback's "already
+                #      exists" case unreachable, so the probe can never return a
+                #      row that suppresses the raise. It is dead code.
+                #   2. Worse than dead: the whole reconcile runs in ONE implicit
+                #      transaction (this connection is opened once and committed
+                #      only at the end of ensure_text_search_extension), so by the
+                #      time CREATE EXTENSION raises the transaction is already
+                #      aborted and the fallback SELECT raises
+                #      InFailedSqlTransactionError on top of it. The operator sees
+                #      "current transaction is aborted" instead of the real
+                #      ParadeDB error.
+                #
+                # That matters precisely here: prestart_pg0 is best-effort
+                # (`|| true`), so an ineffective `shared_preload_libraries=pg_search`
+                # is the single most likely real-world failure of this migration —
+                # and it is exactly the case whose diagnostic the fallback
+                # destroyed. Let it raise.
+                conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_search CASCADE"))
 
                 logger.info(f"Creating TEXT column on {table_name}")
 ''',
@@ -2134,6 +2147,16 @@ assert m.count("ADD COLUMN IF NOT EXISTS search_vector") == 5, (
 )
 assert 'CREATE EXTENSION IF NOT EXISTS pg_search CASCADE' in m, (
     f"switchroom hindsight {NAME}: the pg_search branch still never creates the extension"
+)
+# …and it must NOT be wrapped in upstream's pgroonga-style verification fallback.
+# `IF NOT EXISTS` makes that probe unreachable as a suppressor, and the whole
+# reconcile is ONE implicit transaction, so on a real failure the probe runs on
+# an already-aborted transaction and reports "current transaction is aborted"
+# over the top of the actual ParadeDB error. See the D2 block for the argument.
+assert "SELECT 1 FROM pg_extension WHERE extname = 'pg_search'" not in m, (
+    f"switchroom hindsight {NAME}: the dead CREATE EXTENSION fallback is back — it cannot "
+    "suppress anything and it destroys the diagnostic for the most likely real-world failure "
+    "of this migration (an ineffective shared_preload_libraries=pg_search)"
 )
 # The CREATE EXTENSION must come BEFORE the CREATE INDEX in that branch, or the
 # pdb schema still does not exist when the index is built.

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -546,6 +546,20 @@ describe("Dockerfile.hindsight shape", () => {
     expect(dockerfile).toMatch(
       /assert _branch\.index\("CREATE EXTENSION IF NOT EXISTS pg_search"\) < _branch\.index\("USING bm25"\)/,
     );
+    // D2b. …and it is NOT wrapped in upstream's pgroonga-style "already exists /
+    //      no permission" fallback. `IF NOT EXISTS` makes that probe unreachable
+    //      as a suppressor, and the reconcile runs in ONE implicit transaction —
+    //      so on a real failure the probe fires on an already-aborted
+    //      transaction and buries the actual ParadeDB error under "current
+    //      transaction is aborted". That is exactly the diagnostic an operator
+    //      needs when prestart_pg0 (best-effort, `|| true`) left
+    //      shared_preload_libraries=pg_search ineffective.
+    expect(dockerfile).not.toMatch(
+      /except Exception:\s*\n\s*has_ext = conn\.execute\(text\("SELECT 1 FROM pg_extension WHERE extname = 'pg_search'"\)\)/,
+    );
+    expect(dockerfile).toMatch(
+      /assert "SELECT 1 FROM pg_extension WHERE extname = 'pg_search'" not in m, \(/,
+    );
 
     // D3. the second memory table is reconciled under the name it actually has
     //     (alembic t5o6p7q8r9s0 renamed reflections -> mental_models), and the

--- a/tests/docker/hindsight-text-search-migration-patch.test.ts
+++ b/tests/docker/hindsight-text-search-migration-patch.test.ts
@@ -44,6 +44,16 @@
  *  6. AN INDEX-ONLY REBUILD MUST NOT DISCARD A POPULATED COLUMN. Upstream's
  *     reconcile loop drops `search_vector` unconditionally, which is safe only
  *     while (1) makes an index-only rebuild unreachable.
+ *  7. THE PRODUCTION SHAPE ITSELF. (1)-(6) each isolate one defect; none of
+ *     them is the migration the operator procedure actually performs — a
+ *     populated `memory_units` carrying a tsvector column under a live GIN
+ *     index, flipped to pg_search. (2) is that shape at zero rows and (3) is
+ *     it on the 43-row `mental_models`, so the row-count arm of the guard was
+ *     never exercised on the real table. S7 covers it end to end at the
+ *     fleet's actual row count, and pins the ORDER of the repair — stale index
+ *     before its column, CREATE EXTENSION before the BM25 build that needs the
+ *     `pdb` schema — plus the #4478 filter-pushdown fast fields on the
+ *     rebuilt index.
  *
  * The probe drives the REAL shipping `ensure_text_search_extension` with a
  * fake ONLY at the SQLAlchemy boundary (`create_engine` / `to_libpq_url`): the
@@ -130,13 +140,14 @@ function patchBlocks(): string[] {
 }
 
 /**
- * The Python probe. Exits 0 only when all six properties above hold, and
+ * The Python probe. Exits 0 only when all seven properties above hold, and
  * prints the offending assertions otherwise. It asserts OUTCOMES: it runs the
  * real `ensure_text_search_extension` and reads back the DDL it emitted and
  * the exceptions it raised.
  */
 const PROBE = String.raw`
 import json
+import re
 import sys
 
 import hindsight_api.migrations as M
@@ -264,6 +275,37 @@ else:
         fail("S1: the missing BM25 index was not rebuilt: %s" % ddl(conn))
     if "DROP COLUMN" in ddl(conn):
         fail("S1: an index-only rebuild dropped the search_vector column: %s" % ddl(conn))
+    # The rebuild must come back with the #4478 filter-pushdown fast fields.
+    # "USING bm25" alone would still pass with the pushdown columns silently
+    # dropped, which is exactly the regression pg_search_rebuild_bm25_columns
+    # exists to prevent: it re-emits pg_search_filter_fields(table) on EVERY
+    # branch because they encode the recall arm's WHERE shape, not a tokenizer
+    # choice. Structural match, not an exact string: postgres RENDERS the stored
+    # indexdef as ((bank_id)::pdb.literal) while the emitted DDL is
+    # (bank_id::pdb.literal), and the whitespace here is the f-string's.
+    _s1 = ddl(conn)
+    for _col in ("bank_id", "fact_type"):
+        if not re.search(r"\(+%s\)?::pdb\.literal" % _col, _s1):
+            fail(
+                "PUSHDOWN LOST: the rebuilt memory_units BM25 index omits the #4478 "
+                "%s::pdb.literal filter fast field, so the recall arm's = predicate "
+                "falls back to a post-scoring heap_filter -> %s" % (_col, _s1)
+            )
+    if not re.search(r"key_field='?id'?", _s1):
+        fail("S1: the rebuilt BM25 index has no key_field=id reloption -> %s" % _s1)
+    # …and the whole column list, in order. FakeConn already collapsed the
+    # f-string's newlines, so this is order-sensitive without being
+    # whitespace-brittle.
+    if not re.search(
+        r"CREATE INDEX idx_memory_units_text_search ON public\.memory_units USING bm25 "
+        r"\( *id, *text, *context, *text_signals, *\(+bank_id\)?::pdb\.literal\), *"
+        r"\(+fact_type\)?::pdb\.literal\) *\)",
+        _s1,
+    ):
+        fail(
+            "S1: the rebuilt memory_units index is not the known-good BM25 shape "
+            "(id, text, context, text_signals, bank_id::pdb.literal, fact_type::pdb.literal) -> %s" % _s1
+        )
 
 # --- S2. NOBODY CREATES THE EXTENSION -----------------------------------------
 # Empty table so upstream reaches the pg_search branch: it emits CREATE INDEX
@@ -353,6 +395,52 @@ else:
         fail("DATA LOSS: the populated tsvector column is dropped and recreated empty on an index-only rebuild -> %s" % d)
     if "USING gin" not in d:
         fail("S6: the GIN index was not rebuilt -> %s" % d)
+
+# --- S7. THE PRODUCTION SHAPE: native -> pg_search on a POPULATED table ---------
+# This is the migration the operator procedure actually performs, and until now
+# no scenario covered it. S2 is this shape at rows=0 (so the guard is trivially
+# satisfied) and S3 is it on mental_models at 43 rows; neither exercises the
+# real one — memory_units carrying a populated tsvector under a live GIN index,
+# at the fleet's actual row count. The guard must NOT fire (pg_search keeps
+# search_vector as a dummy, so recreating it loses nothing), and the full repair
+# sequence must be emitted in the only order that works.
+err, conn = run(
+    {"memory_units": {"udt_name": "tsvector", "am": "gin", "indexdef": IDX_GIN, "rows": BIG}},
+    "pg_search",
+)
+print("S7_ERR", repr(err))
+print("S7_DDL", ddl(conn))
+if err is not None:
+    fail(
+        "S7: the real native -> pg_search migration on %d rows RAISED instead of migrating -> %r"
+        % (BIG, err)
+    )
+else:
+    d = ddl(conn)
+    # Order is load-bearing end to end: the stale GIN index must go before its
+    # column; the tsvector column must go before the TEXT one replaces it; and
+    # CREATE EXTENSION must precede the BM25 build or the pdb schema the
+    # ParadeDB casts live in does not exist yet.
+    _seq = [
+        ("DROP INDEX IF EXISTS public.idx_memory_units_text_search", "drop the stale GIN index"),
+        ("ALTER TABLE public.memory_units DROP COLUMN IF EXISTS search_vector", "drop the tsvector column"),
+        ("CREATE EXTENSION IF NOT EXISTS pg_search CASCADE", "install pg_search"),
+        ("ALTER TABLE public.memory_units ADD COLUMN IF NOT EXISTS search_vector TEXT", "add the dummy TEXT column"),
+        ("USING bm25", "build the BM25 index"),
+    ]
+    _at = -1
+    for _needle, _what in _seq:
+        _i = d.find(_needle)
+        if _i < 0:
+            fail("S7: the migration never emitted the step to %s -> %s" % (_what, d))
+            break
+        if _i < _at:
+            fail("S7: the step to %s is emitted out of order -> %s" % (_what, d))
+            break
+        _at = _i
+    else:
+        if not re.search(r"\(+bank_id\)?::pdb\.literal", d):
+            fail("S7: the production migration builds a BM25 index without the #4478 pushdown fields -> %s" % d)
 
 print("FAILURES", json.dumps(failures))
 print("PROBE_EXECUTED")
@@ -529,9 +617,16 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toMatch(
         /S6_ERR .*Cannot change text search extension from native to native/,
       );
+      // 7. and the migration the operator procedure actually performs — a
+      //    populated native memory_units to pg_search — is fatal too, which is
+      //    the whole reason the documented runbook could not work.
+      expect(stdout).toMatch(
+        /S7_ERR .*Cannot change text search extension from native to pg_search/,
+      );
+      expect(stdout).toMatch(/^S7_DDL\s*$/m); // no repair DDL at all
     }, 300_000);
 
-    it("upstream + the baked patch block is GREEN on all six properties", () => {
+    it("upstream + the baked patch block is GREEN on all seven properties", () => {
       const { status, stdout } = runProbe(true);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
@@ -563,6 +658,18 @@ describe.skipIf(!dockerOk || !imageOk)(
       // 6. an index-only rebuild keeps the populated tsvector column.
       expect(stdout).toMatch(/S6_DDL .*USING gin/);
       expect(stdout).not.toMatch(/S6_DDL .*DROP COLUMN/);
+      // 7. the production migration — populated native memory_units to
+      //    pg_search — completes, in the only order that works.
+      expect(stdout).toMatch(/S7_ERR None/);
+      expect(stdout).toMatch(
+        /S7_DDL .*DROP INDEX IF EXISTS public\.idx_memory_units_text_search.*DROP COLUMN IF EXISTS search_vector.*CREATE EXTENSION IF NOT EXISTS pg_search CASCADE.*ADD COLUMN IF NOT EXISTS search_vector TEXT.*USING bm25/,
+      );
+      // …and the rebuilt index keeps the #4478 filter-pushdown fast fields, on
+      // BOTH the in-place rebuild (S1) and the full production migration (S7).
+      expect(stdout).toMatch(/S1_DDL .*bank_id\)?::pdb\.literal/);
+      expect(stdout).toMatch(/S1_DDL .*fact_type\)?::pdb\.literal/);
+      expect(stdout).toMatch(/S1_DDL .*key_field='id'/);
+      expect(stdout).toMatch(/S7_DDL .*bank_id\)?::pdb\.literal/);
     }, 300_000);
   },
 );


### PR DESCRIPTION
Adversarial-review follow-ups on #4507. That PR merged as `fb0519cd` **before** these landed, so they ship as a separate single-concern PR rather than as commits on the (now closed) branch. All four defects are present in `main` today.

None of this changes the merged engineering — the guard re-key, the conditional `DROP COLUMN`, the `mental_models` rename decision and the JSDoc-only `hindsight-perf-defaults.ts` diff were all reviewed and verified sound, and are untouched here.

## 1. The dead `CREATE EXTENSION` fallback destroyed the diagnostic

`docker/Dockerfile.hindsight`, D2 block. It mirrored upstream's pgroonga branch verbatim, fallback included:

```python
try:
    conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_search CASCADE"))
except Exception:
    has_ext = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'pg_search'")).fetchone()
    if not has_ext:
        raise
```

Wrong twice over:

1. **Dead.** `IF NOT EXISTS` already makes the "already exists" case the fallback was written for unreachable, so the probe can never return a row that suppresses the raise.
2. **Worse than dead.** The whole reconcile is ONE implicit transaction — `ensure_text_search_extension` opens its connection at `migrations.py:854` and the next `conn.commit()` is `:1089` (verified against the pinned digest, `/app/api/hindsight_api/migrations.py`). So when `CREATE EXTENSION` raises, the transaction is already aborted and the fallback `SELECT` raises `InFailedSqlTransactionError` on top of it. The operator sees "current transaction is aborted", not the real ParadeDB error.

That matters precisely here: `prestart_pg0` is best-effort (`|| true`), which makes an ineffective `shared_preload_libraries=pg_search` the single most likely real-world failure of this migration — and it is exactly the case whose diagnostic the fallback replaced with noise.

**Call: delete it, not `conn.rollback()` + retry the probe.** With `IF NOT EXISTS` there is nothing left for the probe to suppress, so rolling back would preserve a branch that can only ever re-raise the same exception with extra steps — and a rollback mid-reconcile silently discards the DDL already emitted for earlier tables in the loop, converting a clean abort into a partial migration. The correct code is the bare statement. Being a faithful mirror of an upstream wart is *why* it is wrong here, not a defence.

Pinned by a new assert in the block's verification footer **and** a negative shape guard in `dockerfile-hindsight-bakes.test.ts`, so it cannot come back.

## 2. No probe scenario in the production shape (new S7)

S1–S6 each isolate one defect; none of them was the migration the operator procedure actually performs — a populated `memory_units` carrying a tsvector column under a live GIN index, flipped to `pg_search`. S2 is that shape at `rows=0` (so the row-count arm of the guard is never reached at all) and S3 is it on the 43-row `mental_models`.

**S7** covers it end to end at the fleet's real row count (801,792) and asserts it does not raise, plus the ORDER of the emitted repair — load-bearing at every step: the stale index must go before its column, and `CREATE EXTENSION` before the BM25 build that needs the `pdb` schema.

```
S7_DDL DROP INDEX IF EXISTS public.idx_memory_units_text_search
    || ALTER TABLE public.memory_units DROP COLUMN IF EXISTS search_vector
    || CREATE EXTENSION IF NOT EXISTS pg_search CASCADE
    || ALTER TABLE public.memory_units ADD COLUMN IF NOT EXISTS search_vector TEXT
    || CREATE INDEX idx_memory_units_text_search ON public.memory_units USING bm25
       (id, text, context, text_signals, (bank_id::pdb.literal), (fact_type::pdb.literal))
       WITH (key_field='id')
```

Note `CREATE EXTENSION` precedes `ADD COLUMN`, not the reverse: the assertion pins the sequence **actually emitted**, established by dumping the probe's real `S7_DDL`, not an assumed one.

## 3. Nothing pinned the resulting indexdef

S1's assertions were only `/USING bm25/` and `not /DROP COLUMN/`. #4507's body claims the in-place rebuild also repairs the #4478 filter-field gap, and nothing held it — while `pg_search_bm25_columns`' pushdown argument is *optional* (`filter_fields: Sequence[str] = ()`), i.e. exactly the kind of thing a refactor drops in silence. It only survives because `pg_search_rebuild_bm25_columns` re-appends `pg_search_filter_fields(table)` on every branch.

S1 and S7 now assert the known-good shape, matched **structurally** — postgres RENDERS the stored indexdef as `((bank_id)::pdb.literal)` while the emitted DDL is `(bank_id::pdb.literal)`.

**Verified load-bearing by mutation:** dropping `filter_fields` from `pg_search_rebuild_bm25_columns` turns the GREEN test red with `PUSHDOWN LOST:`; restoring it turns it green.

## 4. CI teardown leak

`docker-e2e.yml`'s label-scoped teardown loop omitted `hindsight-pg-search-filter-pushdown-patch`, leaking that phase's containers on every run. Pre-existing; added while here.

## Evidence

- Probe against the pinned upstream digest: **RED unpatched, GREEN patched, all seven properties.**
- The four affected docker tests together: **58 passed** (`dockerfile-hindsight-bakes`, `hindsight-text-search-migration-patch`, `hindsight-pg-search-filter-pushdown-patch`, `hindsight-pg-search-tokenizer-drift-patch`).
- `tsc --noEmit` clean apart from the pre-existing `Cannot find module 'nostr-tools'` artefact in `src/buzz-gateway/**` (borrowed `node_modules`, files untouched here).
- The live `switchroom-hindsight` container was never touched, nothing restarted, no env flipped; `switchroom.yaml`'s `native` pin is untouched. Upstream source was read with a read-only `docker create` + `docker cp`.

## Follow-up filed, deliberately not fixed here

#4510 — `ensure_vector_extension` has the **identical** dead-table bug #4507 fixed elsewhere: `migrations.py:598` still lists `("pinned_reflections", "idx_pinned_reflections_embedding")` and `:708` still advises `DELETE FROM {schema}.pinned_reflections`, a name renamed twice away (`pinned_reflections` → `reflections` → `mental_models`). So `mental_models`' vector index is never reconciled, and the error hands the operator destructive DDL against a table that does not exist.

## Not verified

- Nothing run against live data.
- The probe's `801792` is a faked row count at the SQLAlchemy boundary, as in every other scenario — it costs nothing and buys the row-count arm of the guard.

Refs #4506, #4507, #4510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
