### PR TITLE
chore: release v0.20.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+## v0.20.15 — migrating a populated Hindsight bank to ParadeDB `pg_search` is a plain env flip, not a trapdoor
+
 ### Hindsight: a populated bank can migrate to `pg_search` by flipping the env, not by hand
 
 - **`native` → `pg_search` on a POPULATED bank is now a plain env flip +


### PR DESCRIPTION
Step 1 of `skills/switchroom-release`: consolidate the continuously-staged `## Unreleased` section into a released `## v0.20.15` section.

**Headline:** migrating a populated Hindsight bank from the `native` tsvector backend to ParadeDB `pg_search` is now a plain env flip plus a restart. Previously the documented procedure was a trapdoor that left hindsight unbootable on *both* backends.

Contents (three PRs merged since `v0.20.14` / `acb44b7f`):

| SHA | PR | What |
|---|---|---|
| `fb0519cd` | #4507 | make the pg_search text-search migration a plain env flip (closes #4506) |
| `98ae8910` | #4509 | make `HINDSIGHT_API_BM25_MAX_QUERY_TERMS` actually reach the container |
| `f81de350` | #4511 | drop the dead CREATE EXTENSION fallback and pin the production migration shape |

CHANGELOG.md only — `package.json` `version` stays the deliberate stale placeholder; the tag is the version source of truth.

The edit is grouping only, not authorship: the sole change is the inserted `## v0.20.15` heading (2 added lines). The sorted set of `- **` bullet lines is byte-identical to `HEAD`, and the two `###` subheads keep their staged order.

[skip changelog]