### PR TITLE
chore: release v0.20.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+## v0.20.16 — the release CHANGELOG entry is staged author-side, and image builds got faster
+
 ### CI: faster hindsight image build and e2e probe
 
 - **The `build-hindsight` job builds arm64 natively and the hindsight-probe


### PR DESCRIPTION
Consolidates the staged `## Unreleased` CHANGELOG entries under
`## v0.20.16 — the release CHANGELOG entry is staged author-side, and image builds got faster`
and re-seeds an empty `## Unreleased` staging block for the next cycle.

CHANGELOG-only, per `skills/switchroom-release/SKILL.md` Step 1 — `package.json`
`version` stays a placeholder; the tag is the version source of truth.

Commits released since v0.20.15:

- `a1b86a9b` feat(release): auto-stage the CHANGELOG Unreleased entry author-side (#4501)
- `ba06cf91` ci: speed up hindsight image build and e2e probe (#4513)

Both already had staged entries under `## Unreleased`; this PR only renames the
header and re-seeds the staging area.

[skip changelog]