### PR TITLE
feat(hindsight): bake bge ONNX export into image + go HF-offline at boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+### Hindsight: bake the bge ONNX export into the image and go HF-offline at boot
+
+- **`docker/Dockerfile.hindsight` now bakes the `BAAI/bge-small-en-v1.5`
+  `onnx/model.onnx` export into the HF cache and sets `HF_HUB_OFFLINE=1`.**
+  The base image already bakes the bge *safetensors* weights and the
+  `cross-encoder/ms-marco-MiniLM-L-6-v2` reranker, but the ONNX graph the
+  `onnx` embeddings provider needs was fetched at runtime into the container's
+  ephemeral writable layer — so a `docker rm`/recreate wiped it and boot
+  re-downloaded 133MB from HuggingFace, taking recall down for every agent
+  when HF was slow or unreachable. Baking the graph (pinned to the same
+  `5c38ec7` snapshot as the tokenizer/config) and forcing HF offline makes
+  hindsight boot fully self-contained. The paired provider override block
+  (`HINDSIGHT_API_EMBEDDINGS_PROVIDER=onnx` + bge/CLS/no-prefix settings)
+  lands separately in `switchroom.yaml` after this image ships.
+
 ## v0.20.16 — the release CHANGELOG entry is staged author-side, and image builds got faster
 
 ### CI: faster hindsight image build and e2e probe

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -5938,6 +5938,68 @@ RUN OLD_UID=$(id -u hindsight) && NEW_UID=11000 \
     fi \
  && id hindsight >&2
 
+# ── Bake the BAAI/bge-small-en-v1.5 ONNX export + go HF-offline ───────────
+# DURABILITY, not a feature. The upstream base image already bakes the bge
+# *safetensors* weights + the cross-encoder/ms-marco-MiniLM-L-6-v2 reranker
+# into the HF hub cache (/home/hindsight/.cache/huggingface/hub), so the
+# default `local` sentence-transformers embeddings provider and the reranker
+# both already run offline. The ONE artifact missing for the `onnx`
+# embeddings provider (HINDSIGHT_API_EMBEDDINGS_PROVIDER=onnx) is the ONNX
+# graph itself — `onnx/model.onnx`, ~133MB. Upstream ships it only on demand:
+# OnnxEmbeddings.initialize() calls huggingface_hub.snapshot_download() at
+# RUNTIME, landing the graph in the container's EPHEMERAL writable layer (that
+# cache dir is on NO volume). A `docker rm` / recreate wipes it, and boot then
+# re-downloads 133MB from HuggingFace — on a shared memory service, a slow or
+# down HF at boot means every agent loses recall until the pull completes (or
+# hangs up to HF_HUB_DOWNLOAD_TIMEOUT=600s). Bake it into the image instead.
+#
+# Pinned to the SAME snapshot revision the base image pins for the bge
+# tokenizer/config (5c38ec7…) so the onnx graph and the tokenizer it rides
+# come from one consistent revision — required for byte-identical parity with
+# the 826k stored bge vectors. The onnx provider's AutoTokenizer + snapshot
+# resolve against this same cached revision. No `*_data` sidecar exists for
+# this export (single-file graph, unlike bge-m3), so we fetch model.onnx only.
+#
+# Runs as root (this stage is USER root until the tail), so HF_HOME is pinned
+# to the hindsight cache dir and the tree is chowned back to the runtime uid
+# (11000, post-remap above) — a root-owned cache file would EACCES the
+# non-root API at boot. Self-verifying: the build FAILS LOUDLY if the export
+# is absent or truncated, so we never ship a half-baked image.
+RUN set -eu; \
+    HF_HOME=/home/hindsight/.cache/huggingface \
+    /app/api/.venv/bin/python - <<'PYEOF'
+import os
+from huggingface_hub import snapshot_download
+
+REPO = "BAAI/bge-small-en-v1.5"
+REV = "5c38ec7c405ec4b44b94cc5a9bb96e735b38267a"
+d = snapshot_download(
+    repo_id=REPO,
+    revision=REV,
+    allow_patterns=["onnx/model.onnx", "onnx/model.onnx_data"],
+)
+p = os.path.join(d, "onnx", "model.onnx")
+assert os.path.exists(p), f"switchroom: bge onnx export missing after download at {p}"
+sz = os.path.getsize(p)
+assert sz > 100_000_000, f"switchroom: bge onnx export suspiciously small ({sz} bytes) — download truncated?"
+print(f"switchroom: baked {REPO}@{REV[:7]} onnx export -> {p} ({sz} bytes)")
+PYEOF
+RUN chown -R hindsight:hindsight /home/hindsight/.cache/huggingface \
+ && test -f /home/hindsight/.cache/huggingface/hub/models--BAAI--bge-small-en-v1.5/snapshots/5c38ec7c405ec4b44b94cc5a9bb96e735b38267a/onnx/model.onnx \
+ && echo "switchroom: bge onnx export owned by hindsight and present at pinned revision" >&2
+
+# HF_HUB_OFFLINE=1: hard boot-offline guarantee. With the bge safetensors +
+# bge onnx export + the ms-marco reranker ALL baked into the image cache
+# above, nothing hindsight loads at boot needs the network — so forbid HF
+# network calls entirely rather than leaving snapshot_download free to hang on
+# a slow/down HuggingFace at boot. This protects BOTH the current `local`
+# provider (unchanged) and the `onnx` cutover. TRADE-OFF, stated honestly:
+# any future embeddings/reranker model that is NOT baked here will hard-fail
+# fast at boot instead of silently downloading — which is the correct failure
+# mode for a shared memory service, but means a new model must be baked into
+# this Dockerfile (not just configured) before it can be used.
+ENV HF_HUB_OFFLINE=1
+
 # Credential fetcher — small Node program reused by both the boot
 # fetch and the background refresh loop. Pulled out of the entrypoint
 # so both code paths exercise the exact same wire shape.


### PR DESCRIPTION
## Summary

Makes the Hindsight ONNX-embeddings cutover **durable**. Adds a build layer to `docker/Dockerfile.hindsight` that bakes the `BAAI/bge-small-en-v1.5` `onnx/model.onnx` export (~133MB) into the image HF cache, then sets `HF_HUB_OFFLINE=1` so hindsight boots fully self-contained.

This is the **image half** of the cutover. The paired **config half** (the provider override block) lands separately in `switchroom.yaml` **after** this image ships — see checklist.

## Why (durability)

We want to switch the embeddings provider from `local` (torch/sentence-transformers, ~131ms/query) to `onnx` (~6-12ms/query, byte-identical vectors, cosine≈1.0 parity already proven). The only blocker was durability:

- The upstream base image (`ghcr.io/vectorize-io/hindsight`) **already bakes** the bge *safetensors* weights (for the default `local` provider) and the `cross-encoder/ms-marco-MiniLM-L-6-v2` reranker into the HF cache.
- It does **not** bake the ONNX graph. `OnnxEmbeddings.initialize()` calls `huggingface_hub.snapshot_download()` at **runtime**, landing `onnx/model.onnx` in the container's **ephemeral writable layer** — the HF cache dir (`/home/hindsight/.cache/huggingface`) is on **no volume**.

Evidence, gathered live against the running `v0.20.16` container:
- Pristine image (fresh container, empty writable layer): bge snapshot has **no** `onnx/` dir; the reranker + bge safetensors **are** present.
- Running container: `onnx/model.onnx` exists but dated at the parity-test run, i.e. written into the writable layer, **not** the image.

So a `docker rm`/recreate wipes the ONNX graph and boot re-downloads 133MB from HuggingFace. On a shared memory service, a slow/down HF at boot (up to `HF_HUB_DOWNLOAD_TIMEOUT=600`s per file) takes **recall down for every agent**.

## What changed

One new layer in `docker/Dockerfile.hindsight`, placed after the uid-remap (so it can chown to the runtime uid 11000):

1. **`RUN` bge ONNX export download** via the venv's `huggingface_hub.snapshot_download`, pinned to `revision=5c38ec7c405ec4b44b94cc5a9bb96e735b38267a` — the **same** snapshot the base pins for the bge tokenizer/config, so the graph and the tokenizer it rides come from one consistent revision (required for byte-identical parity with the ~826k stored bge vectors). `allow_patterns=["onnx/model.onnx","onnx/model.onnx_data"]` matches the exact runtime code path; there is no `*_data` sidecar for this single-file export. Fails loud if the file is absent or truncated.
2. **`RUN chown`** the cache tree back to `hindsight:hindsight` (root-owned cache would EACCES the non-root API at boot) + presence assertion.
3. **`ENV HF_HUB_OFFLINE=1`** — set *after* the download so the build itself can still fetch.

Plus a `## Unreleased` CHANGELOG entry.

## Offline-safety finding

**`HF_HUB_OFFLINE=1` is safe once this layer bakes the ONNX export.** Everything hindsight loads at boot is cached in the image:

| Model | Purpose | Baked by |
|---|---|---|
| `BAAI/bge-small-en-v1.5` safetensors + tokenizer/config | `local` embeddings provider | base image |
| `BAAI/bge-small-en-v1.5` `onnx/model.onnx` | `onnx` embeddings provider | **this PR** |
| `cross-encoder/ms-marco-MiniLM-L-6-v2` | recall reranker | base image |

Proven live with `HF_HUB_OFFLINE=1` against the running container's cache:
- `snapshot_download(...)` (the exact `OnnxEmbeddings` path) resolves `onnx/model.onnx` at the pinned revision.
- `AutoTokenizer.from_pretrained("BAAI/bge-small-en-v1.5")` loads (BertTokenizer, vocab 30522).
- `snapshot_download("cross-encoder/ms-marco-MiniLM-L-6-v2")` resolves (safetensors + config + tokenizer present).

`HF_HUB_OFFLINE=1` protects **both** the current `local` provider and the `onnx` cutover. Trade-off, stated honestly: any future embeddings/reranker model that is **not** baked here will hard-fail fast at boot instead of silently downloading — the correct failure mode for a shared memory service, but it means a new model must be baked into this Dockerfile before use.

## Test plan

- [x] Extracted the exact ONNX env-var surface from the installed package (`config.py` / `embeddings.py`) — see override block below.
- [x] `onnx/model.onnx` at `5c38ec7…` confirmed on HF: **133093490 bytes, etag `828e1496…`** — byte-identical to the parity-tested ephemeral copy. No `_data` sidecar.
- [x] Offline resolution proven for the onnx graph, the bge tokenizer, and the reranker against the baked cache.
- [ ] Full image build not run here (heavy: cu130 torch wheels). The added `snapshot_download` step is proven equivalent to the runtime path that already succeeds; CI `build-hindsight` + the `hindsight-probe` e2e gate exercise the real build.

## Paired config change (lands SEPARATELY, after this image ships)

The `onnx` provider **defaults are wrong for us** (`intfloat/multilingual-e5-small` + mean pooling + `query: `/`passage: ` prefixes). The override block for `switchroom.yaml`'s hindsight service env, to load bge with CLS pooling and no prefixes (matching the stored vectors):

```
HINDSIGHT_API_EMBEDDINGS_PROVIDER=onnx
HINDSIGHT_API_EMBEDDINGS_ONNX_MODEL_ID=BAAI/bge-small-en-v1.5
HINDSIGHT_API_EMBEDDINGS_ONNX_POOLING=cls
HINDSIGHT_API_EMBEDDINGS_ONNX_QUERY_PREFIX=""      # override default "query: "
HINDSIGHT_API_EMBEDDINGS_ONNX_PASSAGE_PREFIX=""    # override default "passage: "
# defaults already correct, set explicitly for clarity:
# HINDSIGHT_API_EMBEDDINGS_ONNX_FILE=onnx/model.onnx
# HINDSIGHT_API_EMBEDDINGS_ONNX_NORMALIZE=True
# HINDSIGHT_API_EMBEDDINGS_ONNX_MAX_TOKENS=512
```

Checklist:
- [ ] Merge + ship this image first (bakes the graph + `HF_HUB_OFFLINE=1`).
- [ ] THEN apply the provider override block to `switchroom.yaml` and restart hindsight.
- [ ] Do NOT flip the provider before the image ships, or `HF_HUB_OFFLINE=1` would have nothing to fall back to for the onnx graph (well — it isn't set until this image; but ordering keeps parity clean).

## Risk / assumptions

- Assumes the base image continues to bake bge safetensors + tokenizer + the reranker at revision `5c38ec7…` / `c5ee24cb…`. If a future base bump drops or moves them, `HF_HUB_OFFLINE=1` would surface as a loud boot failure (the desired fail-fast), not silent corruption.
- Assumes `BAAI/bge-small-en-v1.5`'s ONNX graph stays a single-file export (no `*_data` sidecar) at the pinned revision — confirmed via HF metadata HEAD.
- Full multi-arch image build deferred to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)