### PR TITLE
chore: release v0.20.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+## v0.20.17 — Hindsight bakes the bge ONNX export into the image and boots HF-offline
+
 ### Hindsight: bake the bge ONNX export into the image and go HF-offline at boot
 
 - **`docker/Dockerfile.hindsight` now bakes the `BAAI/bge-small-en-v1.5`


### PR DESCRIPTION
## Summary
Consolidate the CHANGELOG for **v0.20.17**: rename `## Unreleased` to `## v0.20.17 — Hindsight bakes the bge ONNX export into the image and boots HF-offline` and re-seed a fresh empty `## Unreleased` staging block.

The single shipped change is #4521: `docker/Dockerfile.hindsight` now bakes the `BAAI/bge-small-en-v1.5` ONNX export into the HF cache and sets `HF_HUB_OFFLINE=1`, so hindsight boots fully self-contained instead of re-downloading 133MB from HuggingFace after a container recreate.

## Why
Release cut per `skills/switchroom-release/SKILL.md` Step 1 — the release commit is CHANGELOG-only (`package.json` version is a placeholder by design; the git tag is the source of truth).

## Test plan
CHANGELOG-only; `check-changelog-entry.mjs` and `tsc --noEmit` run in CI lint. No code paths touched.

## Risk
None — documentation/changelog only.

Job spec: release process (`skills/switchroom-release/SKILL.md`).