### PR TITLE
fix(hindsight): pg_search drift checker misreads normalised pdb casts (#4526)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+### Hindsight: the pg_search filter-field drift alarm no longer cries wolf
+
+- Fixed `parse_pg_search_index_casts()`, which could not read the
+  `((bank_id)::pdb.literal)` spelling `pg_get_indexdef` emits after PostgreSQL
+  normalises the DDL. Every boot logged
+  `pg_search_filter_field_drift ... missing=['bank_id', 'fact_type']` against a
+  healthy BM25 index — a false positive; no index rebuild is warranted. The
+  alarm still fires when a filter field is genuinely absent. (#4526)
+
 ## v0.20.17 — Hindsight bakes the bge ONNX export into the image and boots HF-offline
 
 ### Hindsight: bake the bge ONNX export into the image and go HF-offline at boot

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -1050,9 +1050,21 @@ _LAST_FILTER_FIELD_DRIFT: dict[str, dict[str, object]] = {}
 
 _INDEX_COLUMNS_RE = re.compile(r"\busing\s+(?:bm25|paradedb)\s*\(", re.IGNORECASE)
 
+# Two field spellings, because pg_get_indexdef does NOT echo back the DDL we
+# wrote. We emit `(bank_id::pdb.literal)`; after PostgreSQL normalises the
+# expression the catalog reports `((bank_id)::pdb.literal)` — the cast operand
+# wrapped in its own parens. `_strip_outer_parens` removes the WHOLE-item pair
+# and stops there (the remaining `(bank_id)` is not a whole-string pair), so a
+# field-anchored-at-^ pattern misses every normalised column and the drift
+# checker reports healthy filter fields as missing (switchroom #4526).
+# The paren-wrapped alternative is matched as a balanced pair rather than with
+# optional `\(?`/`\)?` so a malformed `(bank_id::pdb.literal` cannot parse.
 _FIELD_CAST_RE = re.compile(
-    r"^\"?(?P<field>[A-Za-z_][A-Za-z0-9_$]*)\"?\s*::\s*pdb\.(?P<cast>\S.*)$",
-    re.IGNORECASE | re.DOTALL,
+    r"""^(?:
+            \(\s*"?(?P<paren_field>[A-Za-z_][A-Za-z0-9_$]*)"?\s*\)
+          | "?(?P<field>[A-Za-z_][A-Za-z0-9_$]*)"?
+        )\s*::\s*pdb\.(?P<cast>\S.*)$""",
+    re.IGNORECASE | re.DOTALL | re.VERBOSE,
 )
 
 # Conservative whitelist for a cast we are willing to re-emit into DDL. The text
@@ -1168,7 +1180,8 @@ def parse_pg_search_index_casts(indexdef: str | None) -> dict[str, str] | None:
         bare = _strip_outer_parens(item)
         cast_match = _FIELD_CAST_RE.match(bare)
         if cast_match:
-            casts[cast_match.group("field").lower()] = cast_match.group("cast").strip()
+            field = cast_match.group("paren_field") or cast_match.group("field")
+            casts[field.lower()] = cast_match.group("cast").strip()
             continue
         ident = bare.strip('"').strip()
         if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_$]*", ident):

--- a/tests/docker/hindsight-pg-search-cast-parser.test.ts
+++ b/tests/docker/hindsight-pg-search-cast-parser.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Regression proof for `parse_pg_search_index_casts()` — the cast parser the
+ * pg_search drift checkers run on every boot (switchroom #4526, WP-pre of the
+ * Hindsight 0.9.0 epic #4525).
+ *
+ * THE DEFECT. `_FIELD_CAST_RE` anchored the field name at `^`:
+ *
+ *     r"^\"?(?P<field>[A-Za-z_][A-Za-z0-9_$]*)\"?\s*::\s*pdb\.(?P<cast>\S.*)$"
+ *
+ * That matches the DDL switchroom WRITES — `(bank_id::pdb.literal)` — but not
+ * the DDL PostgreSQL REPORTS. `pg_get_indexdef` (and therefore
+ * `pg_indexes.indexdef`) re-renders the normalised expression tree, which puts
+ * the cast operand in its own parens: `((bank_id)::pdb.literal)`.
+ * `_strip_outer_parens` removes only the whole-item pair, leaving
+ * `(bank_id)::pdb.literal`, which the `^`-anchored pattern cannot match. The
+ * parser therefore dropped every filter column, and
+ * `check_pg_search_filter_field_drift` logged
+ *
+ *     pg_search_filter_field_drift ... missing=['bank_id', 'fact_type']
+ *
+ * on a perfectly healthy production index — a pure false positive
+ * (`paradedb.schema()` lists both fields and `EXPLAIN` shows both predicates
+ * pushed inside the ParadeDB scan; nothing was wrong with the index).
+ *
+ * WHY THE FIXTURE IS REAL CATALOG OUTPUT AND NOT HAND-WRITTEN DDL. The whole
+ * bug is that hand-written DDL and catalog-normalised DDL differ. Every
+ * existing probe in this directory feeds the parser DDL written by hand in the
+ * test, which is why none of them caught this. `tests/fixtures/
+ * pg-search-live-indexdef.txt` is therefore verbatim `psql -tA` output,
+ * captured read-only from the live fleet on 2026-08-08:
+ *
+ *     SELECT indexdef FROM pg_indexes
+ *      WHERE indexname = 'idx_memory_units_text_search';
+ *
+ * `guards the fixture against being "fixed"` below fails if anyone rewrites it
+ * into the un-normalised form, which would make this whole file vacuous.
+ *
+ * WHY THIS RUNS EVERYWHERE (no docker, no 6.4GB image). The parser is pure
+ * Python with no hindsight imports, so the shipping source is extracted from
+ * the Dockerfile's own patch heredocs (never duplicated here) and executed on
+ * the host interpreter. The heavier behavioural probes in
+ * `hindsight-pg-search-{tokenizer-drift,filter-pushdown}-patch.test.ts` still
+ * own the docker-bound end-to-end properties.
+ */
+
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const LIVE_INDEXDEF = readFileSync(
+  resolve(root, "tests/fixtures/pg-search-live-indexdef.txt"),
+  "utf8",
+).trim();
+
+/**
+ * Driver: lift the shipping parser out of the Dockerfile and exercise it.
+ *
+ * Both blocks are needed. The tokenizer-drift block carries the parser and the
+ * drift checkers in a `GUARD` string; the filter-pushdown block carries
+ * `pg_search_filter_fields`, which `check_pg_search_filter_field_drift` calls
+ * to learn which columns `memory_units` must index. Both are located by their
+ * unique in-block patch names and pulled out with `ast`, so this test executes
+ * the exact bytes that get baked into the image.
+ */
+const DRIVER = String.raw`
+import ast
+import json
+import re
+import sys
+
+dockerfile = open(sys.argv[1]).read()
+indexdef = open(sys.argv[2]).read().strip()
+
+blocks = re.findall(r"^RUN python3 - <<'PYEOF'\n([\s\S]*?)^PYEOF$", dockerfile, re.M)
+
+
+def block(name):
+    hits = [b for b in blocks if name in b]
+    assert len(hits) == 1, "%d %r blocks (expected 1)" % (len(hits), name)
+    return hits[0]
+
+
+def guard_string(src, var):
+    for node in ast.parse(src).body:
+        if isinstance(node, ast.Assign) and getattr(node.targets[0], "id", "") == var:
+            return node.value.value
+    raise AssertionError("no %s assignment in patch block" % var)
+
+
+def patch_replacement(src, rel):
+    """The third (replacement) argument of the first patch(rel, ...) call."""
+    for node in ast.walk(ast.parse(src)):
+        if (
+            isinstance(node, ast.Call)
+            and getattr(node.func, "id", "") == "patch"
+            and node.args
+            and getattr(node.args[0], "value", None) == rel
+        ):
+            return node.args[2].value
+    raise AssertionError("no patch(%r, ...) call in patch block" % rel)
+
+
+pushdown = patch_replacement(block("pg_search filter-field pushdown"), "_pg_search.py")
+guard = guard_string(block("pg_search tokenizer-drift guard"), "GUARD")
+
+# The three names _pg_search.py already imports at module scope (the drift patch
+# adds "logging" itself); everything else the guard needs it defines.
+ns = {}
+exec(
+    compile(
+        "import logging\nimport re\nfrom collections.abc import Sequence\n"
+        + pushdown
+        + "\n"
+        + guard,
+        "<Dockerfile.hindsight pg_search source>",
+        "exec",
+    ),
+    ns,
+)
+
+parse = ns["parse_pg_search_index_casts"]
+drift = ns["check_pg_search_filter_field_drift"]
+
+out = {"casts": parse(indexdef)}
+
+out["drift_live"] = drift(
+    indexdef, "memory_units", index_name="idx_memory_units_text_search"
+)
+
+# A genuinely degraded index — same normalised spelling, fact_type absent — must
+# still be reported, so the fix cannot be "make the checker never fire".
+degraded = indexdef.replace(", ((fact_type)::pdb.literal)", "")
+record = drift(degraded, "memory_units", index_name="idx_memory_units_text_search")
+out["drift_degraded"] = None if record is None else {
+    k: v for k, v in record.items() if k in ("missing_filter_fields", "index")
+}
+
+# The hand-written spelling (what switchroom's own DDL emits, pre-normalisation)
+# must keep parsing — this is a widening, not a swap.
+out["casts_handwritten"] = parse(
+    "CREATE INDEX i ON public.memory_units USING bm25 "
+    "(id, (text::pdb.simple('stemmer=english')), (bank_id::pdb.literal)) "
+    "WITH (key_field=id)"
+)
+
+# It runs on the every-boot path: malformed input returns, never raises. The
+# unbalanced entries also prove the paren-wrapped alternative is matched as a
+# real pair rather than with optional parens.
+hostile = [
+    None,
+    "",
+    "not an index definition at all",
+    "CREATE INDEX i ON t USING gin (search_vector)",
+    "CREATE INDEX i ON t USING bm25 (id, ((text)::pdb.simple('unterminated",
+    "CREATE INDEX i ON t USING bm25 (id, ((bank_id::pdb.literal)) WITH (key_field=id)",
+    "CREATE INDEX i ON t USING bm25 (id, (bank_id)::pdb.literal) WITH (key_field=id)",
+]
+out["hostile"] = []
+for item in hostile:
+    try:
+        out["hostile"].append({"ok": True, "casts": parse(item)})
+    except Exception as exc:
+        out["hostile"].append({"ok": False, "error": repr(exc)})
+
+print(json.dumps(out, default=str))
+`;
+
+interface DriverOutput {
+  casts: Record<string, string> | null;
+  drift_live: unknown;
+  drift_degraded: { missing_filter_fields?: string[]; index?: string } | null;
+  casts_handwritten: Record<string, string> | null;
+  hostile: { ok: boolean; casts?: unknown; error?: string }[];
+}
+
+const result: DriverOutput = (() => {
+  const stdout = execFileSync(
+    "python3",
+    [
+      "-",
+      resolve(root, "docker/Dockerfile.hindsight"),
+      resolve(root, "tests/fixtures/pg-search-live-indexdef.txt"),
+    ],
+    { input: DRIVER, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+  );
+  return JSON.parse(stdout) as DriverOutput;
+})();
+
+describe("pg_search cast parser against REAL pg_get_indexdef output (#4526)", () => {
+  it("guards the fixture against being 'fixed' into hand-written DDL", () => {
+    // The catalog's normalised spelling — parens around the cast operand — is
+    // the entire subject of this file. Rewriting the fixture to
+    // `(bank_id::pdb.literal)` would make every assertion below pass against
+    // the buggy parser.
+    expect(LIVE_INDEXDEF).toContain("((bank_id)::pdb.literal)");
+    expect(LIVE_INDEXDEF).toContain("((fact_type)::pdb.literal)");
+    expect(LIVE_INDEXDEF).toMatch(/USING bm25 \(/);
+  });
+
+  it("parses every indexed field, including the paren-wrapped filter columns", () => {
+    // Before the fix this returned only the four un-cast columns; bank_id and
+    // fact_type were silently dropped.
+    expect(result.casts).toEqual({
+      id: "",
+      text: "",
+      context: "",
+      text_signals: "",
+      bank_id: "literal",
+      fact_type: "literal",
+    });
+  });
+
+  it("reports NO filter-field drift for the healthy live index", () => {
+    // This is the false positive: `pg_search_filter_field_drift
+    // idx_memory_units_text_search missing=['bank_id', 'fact_type']` logged on
+    // an index that carries both.
+    expect(result.drift_live).toBeNull();
+  });
+
+  it("still reports drift when a filter field is genuinely absent", () => {
+    expect(result.drift_degraded).not.toBeNull();
+    expect(result.drift_degraded?.missing_filter_fields).toEqual(["fact_type"]);
+  });
+
+  it("keeps parsing the un-normalised spelling switchroom's own DDL emits", () => {
+    expect(result.casts_handwritten).toEqual({
+      id: "",
+      text: "simple('stemmer=english')",
+      bank_id: "literal",
+    });
+  });
+
+  it("never raises on malformed or unbalanced index definitions", () => {
+    for (const outcome of result.hostile) {
+      expect(outcome.error ?? null, `parser raised: ${outcome.error}`).toBeNull();
+      expect(outcome.ok).toBe(true);
+    }
+  });
+});

--- a/tests/fixtures/pg-search-live-indexdef.txt
+++ b/tests/fixtures/pg-search-live-indexdef.txt
@@ -1,0 +1,1 @@
+CREATE INDEX idx_memory_units_text_search ON public.memory_units USING bm25 (id, text, context, text_signals, ((bank_id)::pdb.literal), ((fact_type)::pdb.literal)) WITH (key_field=id)


### PR DESCRIPTION
Closes #4526. WP-pre of epic #4525 (Hindsight 0.8.6 -> 0.9.0), and go/no-go gate item 7.

## The bug

`parse_pg_search_index_casts()` — the parser both pg_search drift checkers run on every boot — anchored the field name at `^`:

```python
r"^\"?(?P<field>[A-Za-z_][A-Za-z0-9_$]*)\"?\s*::\s*pdb\.(?P<cast>\S.*)$"
```

That matches the DDL switchroom **writes** (`(bank_id::pdb.literal)`), but not the DDL PostgreSQL **reports**. `pg_get_indexdef` re-renders the normalised expression tree and wraps the cast operand in its own parens — `((bank_id)::pdb.literal)` — and `_strip_outer_parens` only removes the whole-item pair, leaving `(bank_id)::pdb.literal` unmatched.

So every filter column was dropped from the parse and `check_pg_search_filter_field_drift` logged, on every boot, against a healthy production index:

```
pg_search_filter_field_drift idx_memory_units_text_search missing=['bank_id', 'fact_type']
```

That is a false positive. Three independent live signals show the index carries both fields: `pg_indexes` (the indexdef below), `paradedb.schema()`, and `EXPLAIN` showing both predicates pushed inside the ParadeDB/Tantivy scan rather than applied as a heap filter. **No index rebuild is warranted** — a rebuild would produce the identical indexdef text and therefore reproduce the identical false positive, while opening an avoidable `XX000` window on a populated table.

## Before / after, against real catalog output

Real `pg_indexes.indexdef` from the live fleet (read-only `SELECT`, nothing in the container or database was modified):

```
CREATE INDEX idx_memory_units_text_search ON public.memory_units USING bm25 (id, text, context, text_signals, ((bank_id)::pdb.literal), ((fact_type)::pdb.literal)) WITH (key_field=id)
```

`parse_pg_search_index_casts()` on that string, executed in the deployed image (`/app/api/hindsight_api/_pg_search.py`) — **before**:

```
{'id': '', 'text': '', 'context': '', 'text_signals': ''}
```

Same input, patched parser — **after**:

```
{'id': '', 'text': '', 'context': '', 'text_signals': '', 'bank_id': 'literal', 'fact_type': 'literal'}
```

and `check_pg_search_filter_field_drift(...)` returns `None` — the log line goes away because the checker is fixed, not because anything about the index changed.

## The fix

`_FIELD_CAST_RE` now accepts both spellings. The paren-wrapped alternative is matched as a **balanced pair** rather than with optional `\(?`/`\)?`, so a malformed `(bank_id::pdb.literal` still fails to parse.

## The regression test

`tests/docker/hindsight-pg-search-cast-parser.test.ts`, fed with **real `pg_get_indexdef` output** stored verbatim at `tests/fixtures/pg-search-live-indexdef.txt`. This matters: the whole bug is that hand-written DDL and catalog-normalised DDL differ, and every existing probe in that directory feeds the parser DDL written by hand in the test — which is exactly why none of them caught it. One test guards the fixture against being "corrected" into the un-normalised spelling, which would make the file vacuous.

It extracts the shipping parser from the Dockerfile's own patch heredocs (never duplicated) and runs it on the host interpreter, so it needs no docker and no 6.4GB image. Six cases: the real parse, no drift on the healthy index, drift **still reported** when a filter field is genuinely absent (the fix cannot be "make the checker never fire"), the un-normalised spelling still parses, and never-raises on malformed/unbalanced input (it runs on the every-boot path).

Against the pre-fix parser 3 of the 6 fail; after the fix all 6 pass.

## Verification

- `vitest run tests/docker/hindsight-pg-search-cast-parser.test.ts` — 6 passed; 3 failed when the Dockerfile change is stashed.
- `vitest run tests/docker/dockerfile-hindsight-bakes.test.ts tests/docker/hindsight-pg-search-filter-pushdown-patch.test.ts tests/docker/hindsight-pg-search-tokenizer-drift-patch.test.ts` — 53 passed. The two behavioural probes really executed against the pinned upstream image (docker was available locally), so the edited patch block still applies to upstream cleanly and all six properties of each still hold.
- `npm run lint` — clean.

## Out of scope

Rebuilding, reindexing or recreating `idx_memory_units_text_search` in production. The index is healthy; only the checker was broken (epic §6a, review correction B1).

## Rollback

Checker-only change, no data impact: revert the commit. The false-positive log line returns; nothing else changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)