### PR TITLE
feat(telegram): add /private /public to the command menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ now an anomaly worth investigating, not the norm.
   healthy BM25 index — a false positive; no index rebuild is warranted. The
   alarm still fires when a filter field is genuinely absent. (#4526)
 
+### Telegram: surface `/private` and `/public` in the slash-command menu
+
+- **`/private` and `/public` now appear in the Telegram autocomplete menu**
+  (`setMyCommands`). The handlers already shipped (#4445) — `/private` pauses
+  Hindsight auto-retain for the session, `/public` resumes it, and
+  session-start resets to public — but the two commands were never registered
+  in `TELEGRAM_MENU_COMMANDS`, so they didn't autocomplete when a user typed
+  `/`. Added both to the session-controls group of the menu (right after
+  `/clear`) and to the `/commands` help text. Autocomplete-only change; no
+  handler or retain-side logic touched.
+
 ## v0.20.17 — Hindsight bakes the bge ONNX export into the image and boots HF-offline
 
 ### Hindsight: bake the bge ONNX export into the image and go HF-offline at boot

--- a/telegram-plugin/tests/welcome-text.test.ts
+++ b/telegram-plugin/tests/welcome-text.test.ts
@@ -533,11 +533,12 @@ describe("TELEGRAM_MENU_COMMANDS (slash-menu shape)", () => {
     ).not.toMatch(/`\/reauth\b/);
   });
 
-  it("menu is short enough for a mobile keyboard (<= 21 entries)", () => {
+  it("menu is short enough for a mobile keyboard (<= 23 entries)", () => {
     // Hard cap: Telegram autocomplete on mobile shows ~8-10 commands
-    // without scrolling. 21 is a generous upper bound (well under
-    // Telegram's own 100-command limit). /whoami brought it to 21.
-    expect(TELEGRAM_MENU_COMMANDS.length).toBeLessThanOrEqual(21);
+    // without scrolling. 23 is a generous upper bound (well under
+    // Telegram's own 100-command limit). /whoami brought it to 21;
+    // /private + /public (autocomplete for the shipped handlers) → 23.
+    expect(TELEGRAM_MENU_COMMANDS.length).toBeLessThanOrEqual(23);
   });
 
   it("menu includes /whoami (sandbox introspection)", () => {

--- a/telegram-plugin/welcome-text.ts
+++ b/telegram-plugin/welcome-text.ts
@@ -356,6 +356,11 @@ export const TELEGRAM_MENU_COMMANDS = [
   { command: "new", description: "Fresh session (flush handoff, restart)" },
   { command: "compact", description: "Compact context (summarize, keep the thread)" },
   { command: "clear", description: "Clear context (fresh slate; memory in Hindsight)" },
+  // Privacy — pause/resume Hindsight auto-retain for this session
+  // (session-start resets to public). Handlers shipped in #4445;
+  // these entries only add them to the autocomplete menu.
+  { command: "private", description: "Pause saving this session to memory" },
+  { command: "public", description: "Resume saving this session to memory" },
   // Inline approvals
   { command: "approve", description: "Approve pending tool permission" },
   { command: "deny", description: "Deny pending tool permission" },
@@ -418,6 +423,8 @@ export function switchroomHelpText(agentName: string): string {
     `\`/new\` — fresh session (flush handoff, restart)`,
     `\`/compact\` — compact context (summarize, keep the thread)`,
     `\`/clear\` — clear context (fresh slate; memory in Hindsight)`,
+    `\`/private\` — pause saving this session to memory`,
+    `\`/public\` — resume saving this session to memory`,
     `\`/approve [id]\` — approve pending tool permission`,
     `\`/deny [id]\` — deny pending tool permission`,
     `\`/pending\` — list pending permission prompts`,


### PR DESCRIPTION
## What

Adds `/private` and `/public` to the Telegram bot's slash-command
autocomplete menu (`setMyCommands`).

**Autocomplete-only change.** The two commands already ship end-to-end —
handlers landed in #4445 (#4444/#4446): `/private` pauses Hindsight
auto-retain for the session, `/public` resumes it, and session-start
resets to public. They are gateway-intercepted and per-sender-auth-gated
(like `/clear`) and deliberately NOT in `ADMIN_COMMAND_NAMES`. The only
gap was that they were never registered in `TELEGRAM_MENU_COMMANDS`, so
they did not appear when a user typed `/`. This PR closes only that gap —
no command handler or retain-side logic is touched.

## Changes

- `telegram-plugin/welcome-text.ts`
  - Added `{ command: "private", ... }` and `{ command: "public", ... }`
    to `TELEGRAM_MENU_COMMANDS`, in the session-controls group right after
    `/clear`. Both land at index > 3, so they stay inside
    `TELEGRAM_SWITCHROOM_COMMANDS` (`slice(3)`); base/switchroom slice
    boundaries are unchanged and still recompose to the full list.
  - Added `/private` and `/public` lines to the `switchroomHelpText`
    session section — required by the existing "every menu command is
    documented in switchroomHelpText" test, and keeps the `/commands`
    output consistent with the menu.

## Tests updated

- `telegram-plugin/tests/welcome-text.test.ts` — bumped the mobile-keyboard
  cap assertion from `<= 21` to `<= 23` (the two new entries take the menu
  from 21 to 23). No assertion weakened; the expected upper bound was raised
  to the intended new menu length, and the comment updated to explain why.

Nothing else needed updating:
- `gateway-handler-registration-wiring.test.ts` already lists
  `command:private` / `command:public` in its golden registration order
  (handlers shipped in #4445) — unchanged and green.
- The "every menu command documented" test passes because the two help-text
  lines were added.

## Verify

- Build: `node telegram-plugin/scripts/build.mjs` → green (produces
  `dist/gateway/gateway.js`).
- Type check: `tsc --noEmit` in `telegram-plugin/` → clean.
- Scoped tests: `welcome-text.test.ts` (67) + `gateway-handler-registration-wiring.test.ts` (7) → 74 passed.
- Lint guards: `check-changelog-entry` OK (Unreleased grew),
  `check-agent-attribution-trailers` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
