### PR TITLE
fix(hindsight): make the 0.9.0 rollout gate correct by construction

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -160,6 +160,10 @@ jobs:
       - name: Run litellm-pacer unittests
         working-directory: docker/litellm-pacer
         run: python3 -m unittest discover -s . -p 'test_*.py'
+      # Mirrors ci-tests-python.yml — hindsight server-bump rollout gate.
+      - name: Run hindsight-rollout-gate unittests
+        working-directory: scripts/hindsight-rollout-gate
+        run: python3 -m unittest discover -s tests -t .
 
   # ─── Docker e2e, forced COLD path (mirrors docker-e2e.yml e2e) ────
   # Deliberately no actions/cache restore: the nightly job exists to

--- a/.github/workflows/ci-tests-python.yml
+++ b/.github/workflows/ci-tests-python.yml
@@ -73,6 +73,8 @@ jobs:
               - 'vendor/hindsight-memory/hooks/**'
               - 'docker/voice-sidecar/**'
               - 'docker/litellm-pacer/**'
+              # Hindsight server-bump rollout gate (scripts + its self-test).
+              - 'scripts/hindsight-rollout-gate/**'
               - '.github/workflows/ci-tests-python.yml'
 
   unittest:
@@ -123,6 +125,15 @@ jobs:
       - name: Run litellm-pacer unittests
         working-directory: docker/litellm-pacer
         run: python3 -m unittest discover -s . -p 'test_*.py'
+
+      # Hindsight server-bump rollout gate. Stdlib-only, no network. This
+      # suite exists because the gate's first version would have reported a
+      # fully-red board on healthy data at rollout time (switchroom#4533
+      # comparison B: same code, restored copy, 30/30 cells flagged) and had
+      # never been run against a known-good or known-bad input.
+      - name: Run hindsight-rollout-gate unittests
+        working-directory: scripts/hindsight-rollout-gate
+        run: python3 -m unittest discover -s tests -t .
 
   # ─── Sentinel ─────────────────────────────────────────────────────
   # Branch-protection-required context (see ci-lint.yml header for the

--- a/docs/operators/hindsight-memory.md
+++ b/docs/operators/hindsight-memory.md
@@ -72,6 +72,82 @@ switchroom agent restart test-harness --wait --force   # or: docker restart swit
 switchroom memory repair --all
 ```
 
+## Rolling the base image FORWARD: the rollout gate
+
+`scripts/hindsight-rollout-gate/` decides go/no-go for a Hindsight **server**
+bump by measuring whether recall result sets and latency changed across the
+restart. Read its `README.md` before the window; the essentials are here.
+
+### Capture the baseline LIVE, minutes before the window
+
+```sh
+cd scripts/hindsight-rollout-gate
+export HINDSIGHT_API_URL=http://127.0.0.1:18888
+
+./rollout_gate.sh pre        # MINUTES before the maintenance window
+# ... perform the upgrade ...
+./rollout_gate.sh post       # captures, compares, prints the verdict
+```
+
+`post` reuses the run directory, API URL and pinned recency anchor recorded by
+`pre`, so they cannot drift between the two halves.
+
+> **Do not gate on an old frozen baseline.** The result-set comparison is
+> meaningful in exactly one configuration: live-before vs live-after, same
+> running instance, baseline captured minutes beforehand. WP6
+> (switchroom#4533) proved the alternative empirically — comparing a captured
+> baseline against **the same code** on a fresh restore of that instance's own
+> dump flagged **30/30 cells at Jaccard 0.36–0.75** on completely healthy data.
+> The number is dominated by physical row order (ties in `LIMIT`-ed retrieval
+> arms have no deterministic tiebreaker), not by the code under test.
+>
+> The gate now enforces this rather than trusting it: each capture records the
+> Postgres cluster identity (`pg_controldata`, read-only) and its capture time,
+> and the comparator **refuses** a cross-instance or stale (>4h) baseline.
+
+### Reading the verdict
+
+| exit | meaning | what to do |
+|---|---|---|
+| `0` | **GATE PASS** | proceed; declared expected shifts are listed, check them |
+| `1` | **GATE FAIL** | a verdict about the upgrade — investigate / roll back |
+| `2` | **GATE MISUSE** | *not* a verdict. The two captures are not comparable (different instance, stale baseline, mismatched recency anchor). Fix the inputs and re-run. |
+
+Exit 2 is deliberately distinct from exit 1. A red board that turns out to mean
+"you used the gate wrong" trains you to ignore red.
+
+`--allow-cross-instance` / `--allow-stale-baseline` downgrade those refusals to
+warnings and stamp the report **ADVISORY ONLY**. They are for post-hoc
+investigation, never for a rollout decision.
+
+### Expected shifts
+
+`expected_shifts.json` pre-declares cells known to move for an understood,
+non-defect reason. A declared cell reports as `expected-shift` instead of
+failing — but it is still printed with its measured Jaccard, in its own report
+section, and it still FAILS if it drops below the declared band or if its
+result count moves. If the declared shift does **not** occur, that is reported
+too (`expected-shift-not-observed`): a declaration that has stopped matching
+reality is stale and must be visible.
+
+For 0.8.6 → 0.9.0 there is exactly one: **`temporal-relative`, band 0.60–0.85**.
+`_select_with_temporal_coverage` (0.9.0 `retrieval.py:428`) stable-sorts on
+similarity with no tiebreaker, so equal-similarity ties inherit SQL row order
+and the temporal arm's entry points reshuffle. WP6 measured 0.688–0.793 on
+byte-identical data, reproducible across restarts and a full
+downgrade/re-upgrade cycle, count-neutral and latency-neutral. Declarations are
+version-scoped, so this one retires itself once the fleet is past 0.9.0.
+
+### Soak numbers
+
+Latency medians/p90 are robust to organic ingest, so they still come from the
+WP0 frozen window rather than a fresh capture:
+
+```sh
+./soak_measure.py --json soak-metrics-<date>.json           # pre
+./soak_measure.py --since <rollout ts> --json <out>.json    # post-flight
+```
+
 ## Rolling the base image BACK (schema first, then the digest)
 
 `docker/Dockerfile.hindsight` pins upstream Hindsight by digest, and a bump

--- a/scripts/hindsight-rollout-gate/README.md
+++ b/scripts/hindsight-rollout-gate/README.md
@@ -1,0 +1,160 @@
+# Hindsight server-bump rollout gate
+
+Operational tooling that decides go/no-go for a Hindsight **server** upgrade
+(the `switchroom-hindsight` image), by measuring whether recall results and
+recall latency changed across the restart.
+
+Originally written for the 0.8.6 → 0.9.0 bump (epic switchroom#4525, WP0
+switchroom#4527) and kept outside the repo. It is in the repo now because a
+runbook depends on it and because it was proven to need tests — see below.
+
+| file | what |
+|---|---|
+| `rollout_gate.sh` | the driver. `pre` then `post`. Use this, not the pieces. |
+| `canned_recall.py` | captures 10 fixed queries × N banks: `result_count`, ordered `memory_ids`, latency, **plus instance identity and capture time** |
+| `compare_baseline.py` | the comparator that produces the verdict |
+| `expected_shifts.json` | declared, version-scoped expected-shift cells |
+| `soak_measure.py` | per-agent cache-miss recall count / median / p90 from `recall_log.jsonl` |
+| `tests/` | the self-test (`python3 -m unittest discover -s tests -t .`) |
+
+## Why this is shaped like this
+
+The first version of these scripts would have produced a **fully-red board at
+rollout time on completely healthy data**.
+
+WP6 (switchroom#4533) ran the control experiment that proved it: it compared a
+captured baseline against **the same code (0.8.6) on a fresh restore of that
+instance's own dump**. Identical code, identical data — **30/30 cells flagged
+at Jaccard 0.36–0.75**. Independently confirmed by the stage-4 validator on
+switchroom#4525.
+
+The Jaccard number is not measuring the code. It is dominated by physical row
+order: `_select_with_temporal_coverage` and friends stable-sort on similarity
+with no deterministic tiebreaker, so ties inherit SQL row order, and anything
+that changes plans — a `pg_restore` rebuilding every index with fresh
+statistics, hours of organic ingest — reshuffles `LIMIT`-ed retrieval arms.
+
+So the 0.8 floor is meaningful in **exactly one** configuration:
+
+> **live-before vs live-after, on the same running instance, with the baseline
+> captured minutes beforehand.**
+
+The old scripts could not tell that configuration apart from any other, because
+the artifact recorded neither which instance it came from nor how stale it was.
+Everything below exists to close that.
+
+## The workflow
+
+```sh
+export HINDSIGHT_API_URL=http://127.0.0.1:18888
+
+# 1. MINUTES before the maintenance window, against LIVE production:
+./rollout_gate.sh pre
+
+# 2. ... perform the upgrade ...
+
+# 3. Immediately after, same instance:
+./rollout_gate.sh post        # captures, then compares, then prints the verdict
+```
+
+`post` reuses the run directory, the API URL and the pinned recency anchor that
+`pre` recorded, so those cannot drift between the two halves by accident.
+
+Exit codes from the comparator:
+
+| code | meaning |
+|---|---|
+| `0` | **GATE PASS** — no failing cells. Declared expected shifts may be present and are always listed. |
+| `1` | **GATE FAIL** — at least one failing cell. This is a verdict about the upgrade. |
+| `2` | **GATE MISUSE** — the two captures are not validly comparable. This is *not* a verdict about the upgrade; fix the inputs and re-run. |
+
+Distinguishing 2 from 1 is the point. A runbook that cannot tell "the gate says
+no" from "you used the gate wrong" trains the operator to ignore red.
+
+## Instance identity
+
+Every capture records an `instance` block. The comparator refuses (exit 2) when
+any of these disagree between the two captures:
+
+| field | why it is identity |
+|---|---|
+| `db_system_identifier` | the Postgres cluster identity, read read-only via `pg_controldata`. **The strong one**: invariant across an application-image upgrade (same data directory), different on any `pg_restore` into a fresh cluster. Exactly the signal that would have caught WP6's comparison B. |
+| `api_url` | catches "baseline came from the staging container" |
+| `instance_id` | optional operator label |
+
+Recorded but deliberately **not** identity: `api_version` (it is *supposed* to
+change across the upgrade) and `banks_fingerprint` (a bank added mid-window is
+a comparability note, not a different instance — it warns).
+
+If the cluster-identity probe cannot run, the capture and every report say so
+loudly: identity was then only checked `api_url`-deep, which does not catch a
+repoint to different data. Override the probe with `--db-identity-cmd` (any
+read-only command printing one stable token) for a different topology.
+
+## Freshness
+
+The comparator refuses (exit 2) a baseline more than `--max-baseline-age-hours`
+(default **4h**) older than the post run — "minutes, not days". A baseline
+frozen days earlier absorbs hours of organic ingest and partially false-alarms
+on its own, with no code change involved.
+
+`--allow-stale-baseline` and `--allow-cross-instance` downgrade these to
+warnings, but stamp the whole report **ADVISORY ONLY — not a valid gate**. They
+exist for post-hoc investigation, not for rollout decisions.
+
+## Declared expected shifts
+
+`expected_shifts.json` declares cells that are *known* to move for a understood,
+non-defect reason. A declaration:
+
+* **reclassifies** a cell from `FAIL` to `expected-shift` — only while its
+  measured Jaccard is inside the declared band;
+* **never silences it** — every declared cell is printed inline *and* again in
+  a dedicated "Declared expected-shift cells (reported, never silenced)"
+  section, with its measured value and the reason;
+* **still fails below the band** (`jaccard < jaccard_min`) — the declaration is
+  a band, not a floor removal;
+* **still fails on a count swing** — the declared 0.9.0 shift is count-neutral,
+  so a count move means it is not the declared shift;
+* **reports `expected-shift-not-observed`** when the measurement is *above* the
+  band. A declaration that stops matching reality is a stale declaration, and
+  it must be visible rather than quietly satisfied;
+* **is version-scoped** via `from_api_version` / `to_api_version`, so it retires
+  itself once the fleet moves past the versions it was reasoned about, instead
+  of excusing the same cell forever. A declaration that matched no cell is
+  reported as such.
+
+The one shipped declaration is `temporal-relative` for 0.8.6 → 0.9.0. Band
+0.60–0.85, derived from WP6's byte-identical-data measurements (overlord 0.793,
+klanker 0.688, finn 0.782) widened only enough to absorb the ingest that accrues
+between a live pre-capture and a live post-capture minutes later. It is
+deliberately not widened to cover WP6's comparison-B artefact range (0.36–0.75):
+the low end must stay a failure.
+
+**This entry needs the epic owner's explicit sign-off** before the WP7 window —
+WP6 and the stage-4 validator both flagged that Jaccard cannot say whether the
+shift is better or worse, only that it is real, bounded, deterministic,
+count-neutral and latency-neutral.
+
+## Soak measurement
+
+`soak_measure.py` is unchanged and keeps using the WP0 frozen window. Latency
+medians/p90 are robust to organic ingest, so they do **not** need the
+live-before/live-after treatment — only the result-set comparison does.
+
+```sh
+./soak_measure.py --json soak-metrics-<date>.json          # pre
+./soak_measure.py --since <0.9.0 rollout ts> --json ...    # post-flight
+```
+
+## Self-test
+
+```sh
+python3 -m unittest discover -s tests -t .
+```
+
+Stdlib only, no network. It drives the real comparator against known-good and
+known-bad inputs, including the actual WP6 measurements, and asserts the verdict
+and exit code — because the failure this whole rework exists for was a gate that
+reported red on healthy data and had never been run against either kind of
+input. Runs in CI via `.github/workflows/ci-tests-python.yml`.

--- a/scripts/hindsight-rollout-gate/canned_recall.py
+++ b/scripts/hindsight-rollout-gate/canned_recall.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Hindsight rollout gate — canned recall result-set capture.
+
+Runs a FIXED set of recall queries against a FIXED set of banks through the
+Hindsight HTTP API and records, per (bank, query): result_count, the ordered
+memory_ids, and server round-trip latency.
+
+Originally WP0 (switchroom#4527) of the Hindsight 0.8.6 -> 0.9.0 bump. Reworked
+after WP6 (switchroom#4533) proved the original capture/compare pair produced a
+fully-red board on healthy data — see README.md "Why this is shaped like this".
+
+WHAT CHANGED, AND WHY IT MATTERS
+--------------------------------
+The capture now records an INSTANCE IDENTITY block and a capture timestamp, so
+`compare_baseline.py` can *check* rather than *assume* that the two runs it is
+handed came from the same live instance minutes apart. WP6's control experiment
+compared a live instance against a fresh restore of that instance's own dump,
+with byte-identical code on both sides, and scored 0.36-0.75 Jaccard on 30/30
+cells. Nothing was wrong with the data; the comparison was simply not a valid
+one, and nothing in the artifact recorded enough to notice.
+
+The identity components, and what each is for:
+
+  * ``api_url``           - normalised endpoint. Catches "baseline came from the
+                            staging container, post came from prod".
+  * ``db_system_identifier`` - Postgres cluster identity, read read-only from
+                            ``pg_controldata``. This is the strong one: it is
+                            INVARIANT across an application-image upgrade (same
+                            data directory) and DIFFERENT on any ``pg_restore``
+                            into a fresh cluster. It is exactly the signal that
+                            would have caught WP6's comparison B.
+  * ``instance_id``       - optional operator label, for deployments where the
+                            two above are not enough.
+
+Recorded but deliberately NOT part of identity: ``api_version`` (it is supposed
+to change across the upgrade - that is the point) and the bank fingerprint
+(a bank added between capture and compare is a comparability note, not a
+different instance).
+
+Determinism notes (why the knobs below are pinned):
+  * query_timestamp is PINNED. Recall's recency scoring and relative temporal
+    parsing anchor on it; leaving it to "now" would make the two runs
+    incomparable by construction. Both runs of a gate MUST use the same anchor;
+    the comparator hard-refuses if they differ.
+  * budget / max_tokens / types / tags are pinned to the recall hook's
+    effective production shape so the captured sets exercise the same
+    retrieval stages the fleet actually uses.
+  * Residual, unavoidable: the banks keep ingesting between the two captures,
+    so some drift is organic, not a regression. That residual is bounded by
+    keeping the two captures MINUTES apart, not days - which is why
+    ``compare_baseline.py`` enforces a freshness bound.
+
+Read-only: recall does not mutate memories, and the db-identity probe is
+``pg_controldata``, which only reads the control file.
+
+Usage:
+  canned_recall.py --out pre.json --phase pre  [--api-url URL]
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import shlex
+import subprocess
+import time
+import urllib.request
+from datetime import datetime, timezone
+
+# Pinned query-time anchor. Both captures of a single gate run MUST share it.
+# The driver (`rollout_gate.sh`) passes the pre-capture's anchor through to the
+# post-capture so this cannot drift by accident.
+QUERY_TIMESTAMP = "2026-08-08T00:00:00"
+
+# The busy banks the soak measures (plan Sec.10 WP0: overlord, klanker, finn).
+# switchroom-dev was rejected as a bank: 13 nodes, not representative of a
+# production retrieval path.
+BANKS = ["overlord", "klanker", "finn"]
+
+# Ten canned queries, chosen to cover every retrieval stage the bump can
+# plausibly perturb (patch blocks 520/616 BM25, 2999 rerank, 4109 temporal,
+# entity resolution) rather than ten variations of one stage.
+QUERIES = [
+    # 1-3: BM25 / compound-token path (patch 520 keeps compound tokens
+    # intact; 616 is the regconfig fallback). Identifier-shaped queries are
+    # the ones that go wrong first if tokenization drifts.
+    ("bm25-config-key", "HINDSIGHT_API_TEXT_SEARCH_EXTENSION pg_search"),
+    ("bm25-identifier", "recall_log.jsonl cache_hit total_elapsed_ms"),
+    ("bm25-errorcode", "SQLSTATE 42704 regconfig fallback"),
+    # 4-5: semantic / natural-language path (no rare literals to latch onto).
+    ("semantic-decision", "what did we decide about upgrading the memory server"),
+    ("semantic-howto", "how do I restart a container and check that it came back healthy"),
+    # 6: temporal expression - exercises the query analyzer / temporal
+    # extraction path touched by patch 4109 and env R3. THIS IS THE DECLARED
+    # EXPECTED-SHIFT CELL for 0.8.6 -> 0.9.0; see expected_shifts.json.
+    ("temporal-relative", "what did we work on last week"),
+    # 7: entity-resolution path (proper nouns -> entities trgm).
+    ("entity-person", "Ken Thompson preference"),
+    # 8: mixed rare-token + prose, the common real shape.
+    ("mixed-paradedb", "ParadeDB BM25 index on memory_units text search"),
+    # 9: identity/persona - hits each bank's densest own-content region.
+    ("persona-role", "who am I and what is my role here"),
+    # 10: operational prose, long-tail recall.
+    ("ops-procedure", "rollout procedure and what to check before deploying"),
+]
+
+BUDGET = "mid"
+MAX_TOKENS = 4096
+TYPES = None  # server default: world + experience
+
+# Read-only probe for the Postgres cluster identity behind the API. Hindsight
+# embeds its own pg0 instance in the API container, so this reaches it through
+# the docker socket. Override with --db-identity-cmd for any other topology;
+# whatever it is, it MUST be read-only and print a single stable token.
+DEFAULT_DB_IDENTITY_CMD = (
+    "docker exec switchroom-hindsight sh -c "
+    "'/home/hindsight/.pg0/installation/*/bin/pg_controldata "
+    "-D /home/hindsight/.pg0/instances/hindsight/data' "
+    "| sed -n 's/^Database system identifier: *//p'"
+)
+
+
+def _get_json(url, timeout=15):
+    req = urllib.request.Request(url, method="GET")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.load(resp)
+
+
+def normalise_api_url(url):
+    """Strip trailing slash so 'http://h:1/' and 'http://h:1' are one instance."""
+    return url.rstrip("/")
+
+
+def probe_db_identity(cmd, timeout=30):
+    """Run the read-only cluster-identity probe. Returns (value, error)."""
+    if not cmd:
+        return None, "disabled"
+    try:
+        p = subprocess.run(
+            cmd, shell=True, capture_output=True, text=True, timeout=timeout
+        )
+    except subprocess.TimeoutExpired:
+        return None, "timeout"
+    if p.returncode != 0:
+        return None, f"exit {p.returncode}: {(p.stderr or '').strip()[:200]}"
+    val = (p.stdout or "").strip()
+    if not val:
+        return None, "probe produced no output"
+    # Guard against a probe that accidentally prints a whole file.
+    if len(val) > 200 or "\n" in val:
+        return None, "probe output is not a single token"
+    return val, None
+
+
+def capture_instance(api_url, instance_id, db_identity_cmd):
+    """Everything needed to decide, later, WHETHER two captures are comparable."""
+    inst = {
+        "api_url": normalise_api_url(api_url),
+        "instance_id": instance_id,
+        "db_system_identifier": None,
+        "db_identity_error": None,
+        # Recorded for the report, NOT identity - api_version is expected to
+        # change across the very upgrade this gate measures.
+        "api_version": None,
+        "features": None,
+        "health": None,
+        "banks_fingerprint": None,
+        "banks_seen": None,
+    }
+    inst["db_system_identifier"], inst["db_identity_error"] = probe_db_identity(
+        db_identity_cmd
+    )
+    base = normalise_api_url(api_url)
+    try:
+        v = _get_json(f"{base}/version")
+        inst["api_version"] = v.get("api_version")
+        inst["features"] = v.get("features")
+    except Exception as e:  # noqa: BLE001 - best effort, recorded not raised
+        inst["api_version"] = f"ERROR {type(e).__name__}"
+    try:
+        inst["health"] = _get_json(f"{base}/health").get("status")
+    except Exception as e:  # noqa: BLE001
+        inst["health"] = f"ERROR {type(e).__name__}"
+    try:
+        banks = sorted(
+            b.get("bank_id") for b in _get_json(f"{base}/v1/default/banks")["banks"]
+        )
+        inst["banks_seen"] = banks
+        inst["banks_fingerprint"] = hashlib.sha256(
+            "\n".join(banks).encode()
+        ).hexdigest()[:16]
+    except Exception as e:  # noqa: BLE001
+        inst["banks_fingerprint"] = f"ERROR {type(e).__name__}"
+    return inst
+
+
+def recall(api_url, bank, query, query_timestamp, timeout=60):
+    url = f"{normalise_api_url(api_url)}/v1/default/banks/{bank}/memories/recall"
+    body = {
+        "query": query,
+        "budget": BUDGET,
+        "max_tokens": MAX_TOKENS,
+        "query_timestamp": query_timestamp,
+    }
+    if TYPES:
+        body["types"] = TYPES
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    t0 = time.monotonic()
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        payload = json.load(resp)
+    elapsed_ms = int((time.monotonic() - t0) * 1000)
+    mems = payload.get("memories") or payload.get("results") or []
+    ids = [m.get("id") or m.get("memory_id") for m in mems]
+    return {
+        "result_count": len(ids),
+        "memory_ids": ids,
+        "elapsed_ms": elapsed_ms,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--api-url", default=os.environ.get("HINDSIGHT_API_URL"))
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--banks", default=",".join(BANKS))
+    ap.add_argument(
+        "--phase",
+        choices=["pre", "post"],
+        required=True,
+        help="pre = baseline captured immediately BEFORE the maintenance "
+        "window; post = the run captured after it. Recorded in the artifact "
+        "so the comparator can refuse a pre/pre or post/pre mix-up.",
+    )
+    ap.add_argument(
+        "--query-timestamp",
+        default=QUERY_TIMESTAMP,
+        help="Pinned recency anchor. Both captures of a gate run must match.",
+    )
+    ap.add_argument(
+        "--instance-id",
+        default=os.environ.get("HINDSIGHT_INSTANCE_ID"),
+        help="Optional operator label for this instance (e.g. 'prod').",
+    )
+    ap.add_argument(
+        "--db-identity-cmd",
+        default=os.environ.get("HINDSIGHT_DB_IDENTITY_CMD", DEFAULT_DB_IDENTITY_CMD),
+        help="Read-only shell command printing a stable cluster identity.",
+    )
+    ap.add_argument(
+        "--no-db-identity",
+        action="store_true",
+        help="Skip the cluster-identity probe. The comparator will then only "
+        "be able to check identity URL-deep, and says so loudly.",
+    )
+    args = ap.parse_args()
+    if not args.api_url:
+        raise SystemExit("HINDSIGHT_API_URL not set and --api-url not given")
+
+    banks = [b.strip() for b in args.banks.split(",") if b.strip()]
+    instance = capture_instance(
+        args.api_url,
+        args.instance_id,
+        None if args.no_db_identity else args.db_identity_cmd,
+    )
+    if instance["db_system_identifier"] is None:
+        print(
+            "WARNING: cluster identity unavailable "
+            f"({instance['db_identity_error']}). This capture can only be "
+            "identity-checked by api_url. See README 'Instance identity'.",
+            flush=True,
+        )
+    else:
+        print(
+            f"instance: {instance['api_url']} "
+            f"db={instance['db_system_identifier']} "
+            f"api_version={instance['api_version']}",
+            flush=True,
+        )
+
+    out = {
+        "schema_version": 2,
+        "phase": args.phase,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "query_timestamp_anchor": args.query_timestamp,
+        "budget": BUDGET,
+        "max_tokens": MAX_TOKENS,
+        "instance": instance,
+        "banks": banks,
+        "queries": [{"id": qid, "query": q} for qid, q in QUERIES],
+        "results": {},
+    }
+    for bank in banks:
+        out["results"][bank] = {}
+        for qid, q in QUERIES:
+            try:
+                r = recall(args.api_url, bank, q, args.query_timestamp)
+            except Exception as e:  # capture, don't abort the sweep
+                r = {"error": f"{type(e).__name__}: {str(e)[:200]}"}
+            r["query"] = q
+            out["results"][bank][qid] = r
+            n = r.get("result_count", "ERR")
+            print(f"{bank:16} {qid:20} n={n} {r.get('elapsed_ms','')}ms", flush=True)
+
+    with open(args.out, "w") as fh:
+        fh.write(json.dumps(out, indent=2) + "\n")
+    print(f"\nwrote {args.out} (phase={args.phase})")
+    if args.phase == "pre":
+        print(
+            "\nNEXT: perform the upgrade, then within the freshness bound run\n"
+            f"  {os.path.basename(__file__)} --phase post --out post.json "
+            f"--query-timestamp {shlex.quote(args.query_timestamp)}\n"
+            "  compare_baseline.py --baseline "
+            f"{shlex.quote(args.out)} --post post.json"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hindsight-rollout-gate/compare_baseline.py
+++ b/scripts/hindsight-rollout-gate/compare_baseline.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""Hindsight rollout gate — live-before vs live-after comparator.
+
+Diffs a post-upgrade `canned_recall.py` capture against a pre-upgrade capture,
+per (bank, query): Jaccard over memory_ids, result_count delta, latency delta.
+
+WHY THIS IS NOT THE ORIGINAL SCRIPT
+-----------------------------------
+The original compared "the frozen WP0 baseline" against whatever it was handed
+and flagged Jaccard < 0.8. WP6 (switchroom#4533) ran the control that decides
+whether that number means anything: the SAME code (0.8.6) against a fresh
+restore of the live instance's own dump. Result: 30/30 cells flagged at
+0.36-0.75. Identical code, healthy data, fully red board.
+
+So the 0.8 floor is only meaningful **live-before vs live-after on the same
+running instance, with the pre-capture taken minutes beforehand**. Everything
+else it measures is physical/statistics drift. The original script could not
+tell the two situations apart because the artifact recorded neither which
+instance it came from nor how stale it was.
+
+This version therefore does three things the original did not:
+
+1. **Refuses a comparison it cannot justify.** Instance identity and capture
+   freshness are checked, not assumed, and a violation exits 2 (GATE MISUSE) -
+   a distinct code from 1 (cells failed), so a runbook can tell "the gate says
+   no" apart from "you used the gate wrong".
+
+2. **Classifies declared expected shifts** from `expected_shifts.json` instead
+   of failing them - while still PRINTING every one with its measured value in
+   its own report section, and reporting when a declared shift did not occur.
+   An expected shift that silently disappears from the output is how a real
+   regression hides.
+
+3. **Is testable.** `evaluate()` is a pure function over two capture dicts;
+   `tests/test_compare_baseline.py` drives it against known-good and known-bad
+   inputs. A gate nobody has tested against a known-bad input is not a gate.
+
+Exit codes:
+  0  gate PASS   (no failures; expected shifts may be present and are listed)
+  1  gate FAIL   (at least one failing cell)
+  2  GATE MISUSE (the two captures are not validly comparable - not a verdict
+                  about the upgrade)
+
+Usage:
+  compare_baseline.py --baseline pre.json --post post.json
+  compare_baseline.py --baseline pre.json --post post.json --json report.json
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+JACCARD_FLOOR = 0.8
+COUNT_TOLERANCE = 0.25
+# "Minutes, not days" (stage-4 validation, switchroom#4525). Four hours is a
+# generous maintenance window, not a licence to reuse yesterday's capture.
+DEFAULT_MAX_BASELINE_AGE_HOURS = 4.0
+
+DEFAULT_SHIFTS_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "expected_shifts.json"
+)
+
+OK = "ok"
+EXPECTED_SHIFT = "expected-shift"
+SHIFT_NOT_OBSERVED = "expected-shift-not-observed"
+FAIL = "FAIL"
+
+
+def parse_ts(s):
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(str(s).replace("Z", "+00:00")).astimezone(
+            timezone.utc
+        )
+    except ValueError:
+        return None
+
+
+def load_shifts(path):
+    if not path:
+        return []
+    with open(path) as fh:
+        return json.load(fh).get("shifts", [])
+
+
+def _shift_applies(shift, bank, qid, base_ver, post_ver):
+    if shift.get("query_id") != qid:
+        return False
+    banks = shift.get("banks", "*")
+    if banks != "*" and bank not in banks:
+        return False
+    fv, tv = shift.get("from_api_version"), shift.get("to_api_version")
+    if fv is not None and base_ver != fv:
+        return False
+    if tv is not None and post_ver != tv:
+        return False
+    return True
+
+
+def check_comparability(base, post, max_age_hours, allow_cross_instance, allow_stale):
+    """Return (errors, warnings, baseline_age_hours).
+
+    A non-empty ``errors`` means: refuse to render a verdict at all. These are
+    statements about the INPUTS, not about the upgrade.
+    """
+    errors, warnings = [], []
+
+    bi = base.get("instance") or {}
+    pi = post.get("instance") or {}
+
+    # --- phase ordering -----------------------------------------------------
+    bp, pp = base.get("phase"), post.get("phase")
+    if bp is not None and bp != "pre":
+        errors.append(f"--baseline is a '{bp}' capture, expected 'pre'")
+    if pp is not None and pp != "post":
+        errors.append(f"--post is a '{pp}' capture, expected 'post'")
+    if bp is None or pp is None:
+        warnings.append(
+            "one or both captures predate schema_version 2 and carry no phase "
+            "marker; pre/post ordering could not be checked"
+        )
+
+    # --- pinned recency anchor ---------------------------------------------
+    ba, pa = base.get("query_timestamp_anchor"), post.get("query_timestamp_anchor")
+    if ba != pa:
+        errors.append(
+            f"query_timestamp anchors differ ({ba} vs {pa}) - recency scoring "
+            "keys off this, so the two runs are not comparable at all"
+        )
+
+    # --- instance identity --------------------------------------------------
+    bdb, pdb = bi.get("db_system_identifier"), pi.get("db_system_identifier")
+    burl, purl = bi.get("api_url"), pi.get("api_url")
+    bid, pid = bi.get("instance_id"), pi.get("instance_id")
+
+    identity_msgs = []
+    if bdb and pdb and bdb != pdb:
+        identity_msgs.append(
+            f"database cluster identity differs ({bdb} vs {pdb}) - these are "
+            "DIFFERENT instances (e.g. one is a restore of the other's dump). "
+            "This is exactly the comparison WP6 proved meaningless."
+        )
+    if burl and purl and burl != purl:
+        identity_msgs.append(f"api_url differs ({burl} vs {purl})")
+    if bid and pid and bid != pid:
+        identity_msgs.append(f"instance_id differs ({bid} vs {pid})")
+
+    if identity_msgs:
+        if allow_cross_instance:
+            warnings.extend("OVERRIDDEN: " + m for m in identity_msgs)
+            warnings.append(
+                "--allow-cross-instance was passed: the Jaccard numbers below "
+                "are ADVISORY ONLY and must not be used as a rollout gate."
+            )
+        else:
+            errors.extend(identity_msgs)
+
+    if not (bdb and pdb):
+        warnings.append(
+            "cluster identity missing on at least one capture "
+            f"(baseline={bdb!r}, post={pdb!r}); identity was only checked "
+            "api_url-deep, which does NOT catch a repoint to different data"
+        )
+
+    if bi.get("banks_fingerprint") != pi.get("banks_fingerprint"):
+        warnings.append(
+            "bank inventory changed between captures "
+            f"({bi.get('banks_fingerprint')} vs {pi.get('banks_fingerprint')})"
+        )
+
+    # --- freshness ----------------------------------------------------------
+    bt, pt = parse_ts(base.get("generated_at")), parse_ts(post.get("generated_at"))
+    age_hours = None
+    if bt and pt:
+        age_hours = (pt - bt).total_seconds() / 3600.0
+        if age_hours < 0:
+            errors.append(
+                f"baseline was captured AFTER the post run ({bt} > {pt}) - "
+                "the two files are the wrong way round"
+            )
+        elif age_hours > max_age_hours:
+            msg = (
+                f"baseline is {age_hours:.1f}h older than the post run "
+                f"(bound {max_age_hours:.1f}h). A stale baseline absorbs hours "
+                "of organic ingest and false-alarms on its own. Re-capture the "
+                "baseline immediately before the window."
+            )
+            if allow_stale:
+                warnings.append("OVERRIDDEN: " + msg)
+                warnings.append(
+                    "--allow-stale-baseline was passed: results are ADVISORY "
+                    "ONLY and must not be used as a rollout gate."
+                )
+            else:
+                errors.append(msg)
+    else:
+        warnings.append("capture timestamps missing; freshness not checked")
+
+    return errors, warnings, age_hours
+
+
+def evaluate(base, post, shifts, jaccard_floor=JACCARD_FLOOR,
+             count_tolerance=COUNT_TOLERANCE):
+    """Pure: classify every cell. No I/O, no exits - this is what the tests drive."""
+    base_ver = (base.get("instance") or {}).get("api_version")
+    post_ver = (post.get("instance") or {}).get("api_version")
+
+    cells = []
+    matched_shifts = set()
+    for bank, qmap in sorted(base.get("results", {}).items()):
+        for qid, b in sorted(qmap.items()):
+            cell = {"bank": bank, "query_id": qid}
+            p = post.get("results", {}).get(bank, {}).get(qid)
+            if p is None:
+                cell.update(status=FAIL, detail="missing from post capture")
+                cells.append(cell)
+                continue
+            if b.get("error") or p.get("error"):
+                cell.update(
+                    status=FAIL,
+                    detail=f"error base={b.get('error')} post={p.get('error')}",
+                )
+                cells.append(cell)
+                continue
+
+            a, c = set(b.get("memory_ids") or []), set(p.get("memory_ids") or [])
+            j = len(a & c) / len(a | c) if (a | c) else 1.0
+            nb, np_ = b.get("result_count", 0), p.get("result_count", 0)
+            dn = (np_ - nb) / nb if nb else 0.0
+            cell.update(
+                jaccard=round(j, 3),
+                count_base=nb,
+                count_post=np_,
+                count_delta=round(dn, 4),
+                latency_base_ms=b.get("elapsed_ms"),
+                latency_post_ms=p.get("elapsed_ms"),
+            )
+
+            count_bad = abs(dn) > count_tolerance
+            shift = next(
+                (s for s in shifts if _shift_applies(s, bank, qid, base_ver, post_ver)),
+                None,
+            )
+            if shift is not None:
+                matched_shifts.add(id(shift))
+                lo, hi = shift.get("jaccard_min", 0.0), shift.get("jaccard_max", 1.0)
+                cell["declared_shift"] = {
+                    "band": [lo, hi],
+                    "reason": shift.get("reason"),
+                    "issue": shift.get("issue"),
+                }
+                if j > hi:
+                    # The declared shift did NOT happen. Not a failure, but it
+                    # must be visible: a declaration that stops matching
+                    # reality is a stale declaration.
+                    cell["status"] = SHIFT_NOT_OBSERVED
+                    cell["detail"] = (
+                        f"jaccard {j:.3f} is ABOVE the declared band "
+                        f"[{lo}, {hi}] - the expected shift did not occur"
+                    )
+                elif j < lo:
+                    cell["status"] = FAIL
+                    cell["detail"] = (
+                        f"jaccard {j:.3f} is BELOW the declared band "
+                        f"[{lo}, {hi}] - worse than the declared expectation"
+                    )
+                elif count_bad:
+                    cell["status"] = FAIL
+                    cell["detail"] = (
+                        f"jaccard within declared band but result_count moved "
+                        f"{dn:+.0%} (>{count_tolerance:.0%}); the declared "
+                        "shift is count-neutral, so this is not it"
+                    )
+                else:
+                    cell["status"] = EXPECTED_SHIFT
+                    cell["detail"] = f"within declared band [{lo}, {hi}]"
+            else:
+                bad = j < jaccard_floor or count_bad
+                cell["status"] = FAIL if bad else OK
+                if bad:
+                    why = []
+                    if j < jaccard_floor:
+                        why.append(f"jaccard {j:.3f} < {jaccard_floor}")
+                    if count_bad:
+                        why.append(f"result_count {dn:+.0%} > {count_tolerance:.0%}")
+                    cell["detail"] = "; ".join(why)
+            cells.append(cell)
+
+    # Cells present in post but absent from baseline - a silently added query
+    # would otherwise never be looked at.
+    for bank, qmap in sorted(post.get("results", {}).items()):
+        for qid in sorted(qmap):
+            if qid not in base.get("results", {}).get(bank, {}):
+                cells.append(
+                    {
+                        "bank": bank,
+                        "query_id": qid,
+                        "status": FAIL,
+                        "detail": "present in post capture but missing from baseline",
+                    }
+                )
+
+    unmatched = [
+        {
+            "query_id": s.get("query_id"),
+            "from_api_version": s.get("from_api_version"),
+            "to_api_version": s.get("to_api_version"),
+        }
+        for s in shifts
+        if id(s) not in matched_shifts
+    ]
+
+    counts = {
+        OK: sum(1 for c in cells if c["status"] == OK),
+        EXPECTED_SHIFT: sum(1 for c in cells if c["status"] == EXPECTED_SHIFT),
+        SHIFT_NOT_OBSERVED: sum(1 for c in cells if c["status"] == SHIFT_NOT_OBSERVED),
+        FAIL: sum(1 for c in cells if c["status"] == FAIL),
+    }
+    return {
+        "cells": cells,
+        "counts": counts,
+        "total_cells": len(cells),
+        "unmatched_declarations": unmatched,
+        "base_api_version": base_ver,
+        "post_api_version": post_ver,
+        "passed": counts[FAIL] == 0,
+    }
+
+
+def render(report, errors, warnings, age_hours, advisory):
+    out = []
+    if errors:
+        out.append("GATE MISUSE - refusing to render a verdict:")
+        out.extend(f"  ERROR  {e}" for e in errors)
+        out.append("")
+        out.append(
+            "  These are not findings about the upgrade. Fix the inputs "
+            "(re-capture the baseline live against the same instance, "
+            "immediately before the window) and re-run."
+        )
+        return "\n".join(out)
+
+    for w in warnings:
+        out.append(f"WARNING  {w}")
+    if warnings:
+        out.append("")
+
+    out.append(
+        f"api_version {report['base_api_version']} -> {report['post_api_version']}"
+        + (f"   baseline age {age_hours:.2f}h" if age_hours is not None else "")
+    )
+    out.append("")
+    for c in report["cells"]:
+        if "jaccard" in c:
+            line = (
+                f"{c['status']:28} {c['bank']:16} {c['query_id']:20} "
+                f"jaccard={c['jaccard']:.3f} "
+                f"n {c['count_base']}->{c['count_post']} "
+                f"({c['count_delta']:+.0%}) "
+                f"lat {c['latency_base_ms']}->{c['latency_post_ms']}ms"
+            )
+        else:
+            line = f"{c['status']:28} {c['bank']:16} {c['query_id']:20}"
+        if c.get("detail") and c["status"] != OK:
+            line += f"   [{c['detail']}]"
+        out.append(line)
+
+    # Declared shifts ALWAYS get their own section, with their measured value.
+    declared = [c for c in report["cells"] if "declared_shift" in c]
+    out.append("")
+    if declared:
+        out.append("Declared expected-shift cells (reported, never silenced):")
+        for c in declared:
+            lo, hi = c["declared_shift"]["band"]
+            out.append(
+                f"  {c['bank']:16} {c['query_id']:20} measured={c['jaccard']:.3f} "
+                f"declared=[{lo}, {hi}] -> {c['status']}"
+            )
+            out.append(f"      {c['declared_shift']['issue']}: "
+                       f"{(c['declared_shift']['reason'] or '')[:140]}")
+    else:
+        out.append("Declared expected-shift cells: none applied to this comparison.")
+
+    if report["unmatched_declarations"]:
+        out.append("")
+        out.append(
+            "NOTE: declarations that matched no cell in this comparison "
+            "(stale, or out of version scope):"
+        )
+        for u in report["unmatched_declarations"]:
+            out.append(
+                f"  {u['query_id']} ({u['from_api_version']} -> "
+                f"{u['to_api_version']})"
+            )
+
+    ct = report["counts"]
+    out.append("")
+    out.append(
+        f"{report['total_cells']} cells: {ct[OK]} ok, "
+        f"{ct[EXPECTED_SHIFT]} expected-shift, "
+        f"{ct[SHIFT_NOT_OBSERVED]} expected-shift-not-observed, "
+        f"{ct[FAIL]} FAIL"
+    )
+    verdict = "PASS" if report["passed"] else "FAIL"
+    if advisory:
+        verdict += " (ADVISORY ONLY - overrides in effect, not a valid gate)"
+    out.append(f"GATE {verdict}")
+    return "\n".join(out)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--baseline", required=True, help="the 'pre' capture")
+    ap.add_argument("--post", required=True, help="the 'post' capture")
+    ap.add_argument("--expected-shifts", default=DEFAULT_SHIFTS_PATH)
+    ap.add_argument("--no-expected-shifts", action="store_true")
+    ap.add_argument("--jaccard-floor", type=float, default=JACCARD_FLOOR)
+    ap.add_argument("--count-tolerance", type=float, default=COUNT_TOLERANCE)
+    ap.add_argument(
+        "--max-baseline-age-hours", type=float, default=DEFAULT_MAX_BASELINE_AGE_HOURS
+    )
+    ap.add_argument(
+        "--allow-cross-instance",
+        action="store_true",
+        help="Downgrade an instance-identity mismatch to a warning. Output "
+        "becomes advisory and is NOT a valid gate.",
+    )
+    ap.add_argument(
+        "--allow-stale-baseline",
+        action="store_true",
+        help="Downgrade a stale baseline to a warning. Output becomes "
+        "advisory and is NOT a valid gate.",
+    )
+    ap.add_argument("--json", dest="json_out", default=None)
+    args = ap.parse_args(argv)
+
+    with open(args.baseline) as fh:
+        base = json.load(fh)
+    with open(args.post) as fh:
+        post = json.load(fh)
+
+    shifts = [] if args.no_expected_shifts else load_shifts(args.expected_shifts)
+
+    errors, warnings, age_hours = check_comparability(
+        base,
+        post,
+        args.max_baseline_age_hours,
+        args.allow_cross_instance,
+        args.allow_stale_baseline,
+    )
+    advisory = args.allow_cross_instance or args.allow_stale_baseline
+
+    if errors:
+        print(render({}, errors, warnings, age_hours, advisory))
+        return 2
+
+    report = evaluate(
+        base, post, shifts, args.jaccard_floor, args.count_tolerance
+    )
+    print(render(report, [], warnings, age_hours, advisory))
+
+    if args.json_out:
+        payload = dict(report)
+        payload["warnings"] = warnings
+        payload["baseline_age_hours"] = age_hours
+        payload["advisory_only"] = advisory
+        with open(args.json_out, "w") as fh:
+            fh.write(json.dumps(payload, indent=2) + "\n")
+
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hindsight-rollout-gate/expected_shifts.json
+++ b/scripts/hindsight-rollout-gate/expected_shifts.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": 1,
+  "_doc": [
+    "Declared expected-shift cells for the Hindsight rollout gate.",
+    "",
+    "An entry here does NOT silence a cell. It reclassifies it from FAIL to",
+    "EXPECTED-SHIFT, and compare_baseline.py still prints its measured Jaccard",
+    "in a dedicated section of every report. A declared shift that vanishes",
+    "from the output is how a real regression hides, so the comparator also",
+    "reports when a declared shift did NOT occur (jaccard above the band) and",
+    "when a declaration matched no cell at all (stale declaration).",
+    "",
+    "A measurement BELOW jaccard_min is still a FAIL: the declaration is a",
+    "band, not a floor removal.",
+    "",
+    "Entries are version-scoped. A declaration applies only when the baseline",
+    "capture's api_version matches from_api_version AND the post capture's",
+    "matches to_api_version. That makes the list self-retiring: once the fleet",
+    "is past 0.9.0, the entry below stops applying on its own instead of",
+    "quietly excusing the same cell forever.",
+    "",
+    "Fields:",
+    "  query_id        query id from canned_recall.py QUERIES",
+    "  banks           '*' or an explicit list of bank ids",
+    "  jaccard_min     inclusive lower bound of the accepted shift band",
+    "  jaccard_max     inclusive upper bound; above this the shift did NOT",
+    "                  occur and is reported as such",
+    "  from_api_version / to_api_version   version scope, or null for 'any'",
+    "  reason / evidence / signed_off_by   why this is not a defect"
+  ],
+  "shifts": [
+    {
+      "query_id": "temporal-relative",
+      "banks": "*",
+      "jaccard_min": 0.6,
+      "jaccard_max": 0.85,
+      "from_api_version": "0.8.6",
+      "to_api_version": "0.9.0",
+      "reason": "Deterministic tie-break reshuffle, not a retrieval defect. _select_with_temporal_coverage (0.9.0 retrieval.py:428) ranks its pool with a stable sort on similarity and NO deterministic tiebreaker, then buckets in ranked order, so equal-similarity ties inherit SQL row order. Any change to plans, physical order or pool composition reshuffles the temporal arm's entry points and everything downstream (graph spreading, rerank) follows. The function itself is byte-identical between 0.8.6 and 0.9.0.",
+      "evidence": "WP6 (switchroom#4533) comparison C, byte-identical data, 0.8.6 image vs 0.9.0 image on the same restored copy: overlord 0.793, klanker 0.688, finn 0.782. Counts -1%/+9%/+1%, latency unchanged. Reproduced exactly across a container restart and a full downgrade -> re-upgrade cycle (Jaccard 1.000 against itself). 27/30 other cells passed, 25 of them at 1.000, including entity-person at 1.000 on all three banks. Stage-4 independent validation (switchroom#4525) confirmed the attribution in 0.9.0 source.",
+      "band_derivation": "WP6 measured 0.688-0.793 on byte-identical data. The band is widened to 0.60-0.85 to absorb the organic ingest that accrues between a live pre-capture and a live post-capture minutes later. It is deliberately NOT widened further: below 0.60 is outside anything WP6 observed and should stop the rollout.",
+      "signed_off_by": "epic owner sign-off required before the WP7 window - see switchroom#4525 'the epic owner still owes the explicit better/worse/accept call'",
+      "issue": "switchroom#4533"
+    }
+  ]
+}

--- a/scripts/hindsight-rollout-gate/rollout_gate.sh
+++ b/scripts/hindsight-rollout-gate/rollout_gate.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Hindsight rollout gate driver — capture-then-compare, correct by construction.
+#
+# The defect this exists to prevent (WP6, switchroom#4533): comparing a
+# post-upgrade run against a baseline that came from a different instance or a
+# different day produces a fully-red board on completely healthy data. The
+# comparator now refuses those inputs, but the better fix is to make the
+# CORRECT workflow the easiest thing to run.
+#
+#   ./rollout_gate.sh pre          # minutes BEFORE the maintenance window
+#   ... perform the upgrade ...
+#   ./rollout_gate.sh post         # captures, then compares against that pre
+#
+# `post` reuses the run directory, the api-url and the pinned recency anchor
+# recorded by `pre`, so those cannot drift between the two halves by accident.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_DIR="${HINDSIGHT_GATE_RUN_DIR:-${HERE}/.gate-run}"
+PRE="${RUN_DIR}/pre.json"
+POST="${RUN_DIR}/post.json"
+META="${RUN_DIR}/run.env"
+
+usage() {
+  cat <<'EOF'
+usage: rollout_gate.sh <pre|post|compare> [extra args passed through]
+
+  pre       capture the live baseline (run MINUTES before the window)
+  post      capture the live post-upgrade run and compare against pre
+  compare   re-run only the comparison over an existing run directory
+
+env:
+  HINDSIGHT_API_URL       required for `pre`
+  HINDSIGHT_GATE_RUN_DIR  where the run artifacts live (default ./.gate-run)
+EOF
+}
+
+cmd="${1:-}"; shift || true
+
+case "$cmd" in
+  pre)
+    : "${HINDSIGHT_API_URL:?HINDSIGHT_API_URL must be set}"
+    mkdir -p "$RUN_DIR"
+    if [ -f "$PRE" ]; then
+      echo "refusing to overwrite an existing baseline at $PRE" >&2
+      echo "move or delete the run directory to start a new gate run" >&2
+      exit 2
+    fi
+    "${HERE}/canned_recall.py" --phase pre --out "$PRE" "$@"
+    anchor="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["query_timestamp_anchor"])' "$PRE")"
+    {
+      printf 'HINDSIGHT_API_URL=%s\n' "$HINDSIGHT_API_URL"
+      printf 'GATE_ANCHOR=%s\n' "$anchor"
+    } >"$META"
+    echo
+    echo "Baseline captured. Do the upgrade, then run \`rollout_gate.sh post\`"
+    echo "WITHIN THE FRESHNESS BOUND (default 4h) — a stale baseline is the"
+    echo "exact failure mode this gate was rebuilt to prevent."
+    ;;
+  post)
+    [ -f "$PRE" ] || { echo "no baseline at $PRE — run \`rollout_gate.sh pre\` first" >&2; exit 2; }
+    # shellcheck disable=SC1090
+    . "$META"
+    export HINDSIGHT_API_URL
+    "${HERE}/canned_recall.py" --phase post --out "$POST" \
+      --query-timestamp "$GATE_ANCHOR" "$@"
+    echo
+    exec "${HERE}/compare_baseline.py" --baseline "$PRE" --post "$POST" \
+      --json "${RUN_DIR}/report.json"
+    ;;
+  compare)
+    exec "${HERE}/compare_baseline.py" --baseline "$PRE" --post "$POST" \
+      --json "${RUN_DIR}/report.json" "$@"
+    ;;
+  *)
+    usage; exit 2 ;;
+esac

--- a/scripts/hindsight-rollout-gate/soak_measure.py
+++ b/scripts/hindsight-rollout-gate/soak_measure.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""WP0 (issue #4527) — Hindsight 0.8.6 -> 0.9.0 soak measurement.
+
+Counts cache-miss recalls and computes median / p90 latency per busy agent
+from each agent's recall_log.jsonl, over a window that starts at the
+2026-08-07 pg_search cutover.
+
+Re-run this VERBATIM post-flight (with --since set to the 0.9.0 rollout
+timestamp) so the post-bump number is produced by the same code path as the
+frozen baseline rather than a hand-rolled approximation.
+
+Usage:
+  soak_measure.py [--since ISO8601Z] [--until ISO8601Z]
+                  [--agents overlord,klanker,finn] [--json OUT.json]
+
+Read-only. Touches nothing but the log files.
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+# 2026-08-07 pg_search cutover. Corroborated by
+# /host-home/.switchroom/backups/switchroom.yaml.bak-pg_search-20260807T205206
+# (local AEST = UTC+10 -> 2026-08-07T10:52:06Z).
+CUTOVER = "2026-08-07T10:52:06Z"
+
+# Default is the host path as seen from the root-tier debugging agent's
+# container. Override with --agents-dir / HINDSIGHT_AGENTS_DIR when running
+# from the host itself (~/.switchroom/agents) or any other layout.
+AGENTS_DIR = os.environ.get("HINDSIGHT_AGENTS_DIR", "/host-home/.switchroom/agents")
+LOG_REL = ".claude/plugins/data/hindsight-memory-inline/state/recall_log.jsonl"
+
+
+def parse_ts(s):
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def pct(sorted_vals, q):
+    """Nearest-rank percentile (deterministic, no interpolation)."""
+    if not sorted_vals:
+        return None
+    k = max(0, min(len(sorted_vals) - 1, int(round(q * (len(sorted_vals) - 1)))))
+    return sorted_vals[k]
+
+
+def median(sorted_vals):
+    n = len(sorted_vals)
+    if n == 0:
+        return None
+    if n % 2:
+        return float(sorted_vals[n // 2])
+    return (sorted_vals[n // 2 - 1] + sorted_vals[n // 2]) / 2.0
+
+
+def measure(agent, since, until, log_path=None, agents_dir=None):
+    path = log_path or os.path.join(agents_dir or AGENTS_DIR, agent, LOG_REL)
+    out = {
+        "agent": agent,
+        "log_path": path,
+        "rows_total": 0,
+        "rows_in_window": 0,
+        "cache_miss": 0,
+        "cache_hit": 0,
+        "errored": 0,
+        "malformed": 0,
+        "days_covered": [],
+        "first_ts": None,
+        "last_ts": None,
+    }
+    if not os.path.exists(path):
+        out["error"] = "log not found"
+        return out
+
+    total_ms, dur_ms, res_counts = [], [], []
+    days = set()
+    with open(path, "r", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            out["rows_total"] += 1
+            try:
+                r = json.loads(line)
+            except Exception:
+                out["malformed"] += 1
+                continue
+            ts = parse_ts(r.get("ts"))
+            if ts is None or ts < since or ts > until:
+                continue
+            out["rows_in_window"] += 1
+            if out["first_ts"] is None:
+                out["first_ts"] = r.get("ts")
+            out["last_ts"] = r.get("ts")
+            if r.get("cache_hit"):
+                out["cache_hit"] += 1
+                continue
+            out["cache_miss"] += 1
+            days.add(ts.date().isoformat())
+            if r.get("error"):
+                out["errored"] += 1
+            t = r.get("total_elapsed_ms")
+            if isinstance(t, (int, float)):
+                total_ms.append(t)
+            d = r.get("duration_ms")
+            if isinstance(d, (int, float)):
+                dur_ms.append(d)
+            c = r.get("result_count")
+            if isinstance(c, (int, float)):
+                res_counts.append(c)
+
+    total_ms.sort()
+    dur_ms.sort()
+    res_counts.sort()
+    out["days_covered"] = sorted(days)
+    out["total_elapsed_ms"] = {
+        "n": len(total_ms),
+        "median": median(total_ms),
+        "p90": pct(total_ms, 0.90),
+        "p95": pct(total_ms, 0.95),
+        "min": total_ms[0] if total_ms else None,
+        "max": total_ms[-1] if total_ms else None,
+    }
+    out["duration_ms"] = {
+        "n": len(dur_ms),
+        "median": median(dur_ms),
+        "p90": pct(dur_ms, 0.90),
+    }
+    out["result_count"] = {
+        "n": len(res_counts),
+        "median": median(res_counts),
+    }
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--since", default=CUTOVER)
+    ap.add_argument("--until", default=None)
+    ap.add_argument("--agents", default="overlord,klanker,finn")
+    ap.add_argument("--threshold", type=int, default=300)
+    ap.add_argument("--agents-dir", default=AGENTS_DIR)
+    ap.add_argument("--json", dest="json_out", default=None)
+    args = ap.parse_args()
+
+    since = parse_ts(args.since)
+    until = parse_ts(args.until) if args.until else datetime.now(timezone.utc)
+    if since is None:
+        sys.exit("bad --since")
+
+    agents = [a.strip() for a in args.agents.split(",") if a.strip()]
+    report = {
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "window_since": since.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "window_until": until.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "threshold_cache_miss_recalls": args.threshold,
+        "agents": [measure(a, since, until, agents_dir=args.agents_dir) for a in agents],
+    }
+    report["threshold_met_all"] = all(
+        a["cache_miss"] >= args.threshold for a in report["agents"]
+    )
+
+    w = 3600.0 * 24
+    for a in report["agents"]:
+        f, l = parse_ts(a.get("first_ts")), parse_ts(a.get("last_ts"))
+        elapsed_days = (until - since).total_seconds() / w
+        a["rate_cache_miss_per_day"] = (
+            round(a["cache_miss"] / elapsed_days, 1) if elapsed_days > 0 else None
+        )
+        a["threshold_met"] = a["cache_miss"] >= args.threshold
+        a["active_span_hours"] = (
+            round((l - f).total_seconds() / 3600.0, 1) if f and l else None
+        )
+
+    txt = json.dumps(report, indent=2)
+    print(txt)
+    if args.json_out:
+        with open(args.json_out, "w") as fh:
+            fh.write(txt + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hindsight-rollout-gate/tests/test_compare_baseline.py
+++ b/scripts/hindsight-rollout-gate/tests/test_compare_baseline.py
@@ -1,0 +1,383 @@
+"""Self-test for the Hindsight rollout gate comparator.
+
+The failure this suite exists for: the previous gate reported RED on healthy
+data (WP6, switchroom#4533 — same code, same data, 30/30 cells flagged at
+0.36-0.75), and nobody noticed because the gate had never been run against a
+known-good or a known-bad input. A gate that has not been shown to distinguish
+the two is not a gate.
+
+Every test drives the REAL `evaluate()` / `check_comparability()` / `main()` —
+no mocks of the logic under test — and asserts OUTCOMES (verdict, exit code,
+what appears in the rendered report), not that a code path ran.
+
+Stdlib only: `python3 -m unittest discover -s tests -t .` from this script's
+parent directory.
+"""
+
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import compare_baseline as cb  # noqa: E402
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SHIFTS_PATH = os.path.join(os.path.dirname(HERE), "expected_shifts.json")
+
+BANKS = ["overlord", "klanker", "finn"]
+QIDS = [
+    "bm25-config-key",
+    "bm25-identifier",
+    "bm25-errorcode",
+    "semantic-decision",
+    "semantic-howto",
+    "temporal-relative",
+    "entity-person",
+    "mixed-paradedb",
+    "persona-role",
+    "ops-procedure",
+]
+
+PROD_DB_ID = "7627286907797205078"
+RESTORED_COPY_DB_ID = "7627286907799999999"
+
+
+def ts(offset_hours=0.0):
+    return (
+        datetime(2026, 8, 11, 12, 0, 0, tzinfo=timezone.utc)
+        + timedelta(hours=offset_hours)
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def ids(bank, qid, n=80, start=0):
+    return [f"{bank}-{qid}-{i}" for i in range(start, start + n)]
+
+
+def capture(
+    phase,
+    generated_at,
+    api_version,
+    db_id=PROD_DB_ID,
+    api_url="http://127.0.0.1:18888",
+    overrides=None,
+    anchor="2026-08-08T00:00:00",
+):
+    """A full 30-cell capture. `overrides` maps (bank, qid) -> cell dict patch."""
+    overrides = overrides or {}
+    results = {}
+    for bank in BANKS:
+        results[bank] = {}
+        for qid in QIDS:
+            cell = {
+                "result_count": 80,
+                "memory_ids": ids(bank, qid),
+                "elapsed_ms": 1800,
+                "query": qid,
+            }
+            cell.update(overrides.get((bank, qid), {}))
+            results[bank][qid] = cell
+    return {
+        "schema_version": 2,
+        "phase": phase,
+        "generated_at": generated_at,
+        "query_timestamp_anchor": anchor,
+        "instance": {
+            "api_url": api_url,
+            "instance_id": "prod",
+            "db_system_identifier": db_id,
+            "api_version": api_version,
+            "banks_fingerprint": "abc123",
+        },
+        "banks": BANKS,
+        "results": results,
+    }
+
+
+def jaccard_shifted(bank, qid, target, n=80):
+    """A post-run id list whose Jaccard against the baseline is ~= target.
+
+    |A n B| = n - k, |A u B| = n + k  ->  J = (n-k)/(n+k).
+    """
+    k = round(n * (1 - target) / (1 + target))
+    return ids(bank, qid, n=n - k) + ids(bank, qid, n=k, start=1000)
+
+
+def run_main(base, post, extra=None):
+    """Drive the real CLI end to end. Returns (exit_code, stdout)."""
+    with tempfile.TemporaryDirectory() as d:
+        bp, pp = os.path.join(d, "pre.json"), os.path.join(d, "post.json")
+        with open(bp, "w") as fh:
+            json.dump(base, fh)
+        with open(pp, "w") as fh:
+            json.dump(post, fh)
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            code = cb.main(
+                ["--baseline", bp, "--post", pp, "--expected-shifts", SHIFTS_PATH]
+                + (extra or [])
+            )
+        return code, buf.getvalue()
+
+
+class TestKnownGood(unittest.TestCase):
+    """A healthy 0.8.6 -> 0.9.0 rollout must come back GREEN."""
+
+    def test_healthy_rollout_passes_with_zero_failures(self):
+        """The whole board healthy, temporal shifting exactly as declared."""
+        base = capture("pre", ts(0), "0.8.6")
+        post = capture(
+            "post",
+            ts(0.5),
+            "0.9.0",
+            overrides={
+                (b, "temporal-relative"): {
+                    "memory_ids": jaccard_shifted(b, "temporal-relative", 0.75)
+                }
+                for b in BANKS
+            },
+        )
+        code, out = run_main(base, post)
+        self.assertEqual(code, 0, out)
+        self.assertIn("GATE PASS", out)
+        self.assertIn("27 ok, 3 expected-shift", out)
+        self.assertIn("0 FAIL", out)
+
+    def test_wp6_measured_reality_passes(self):
+        """The real WP6 comparison-C numbers, live-before vs live-after.
+
+        27/30 clean (two of them at 0.929/0.933, i.e. under organic drift but
+        over the floor) and temporal-relative at overlord 0.793 / klanker 0.688
+        / finn 0.782. This is the shape the WP7 window is expected to produce,
+        and it must read as PASS with three declared expected shifts — not as
+        a three-cell failure.
+        """
+        base = capture("pre", ts(0), "0.8.6")
+        measured = {
+            ("overlord", "temporal-relative"): 0.793,
+            ("klanker", "temporal-relative"): 0.688,
+            ("finn", "temporal-relative"): 0.782,
+            ("overlord", "bm25-errorcode"): 0.933,
+            ("klanker", "semantic-howto"): 0.929,
+        }
+        overrides = {
+            (bank, qid): {"memory_ids": jaccard_shifted(bank, qid, j)}
+            for (bank, qid), j in measured.items()
+        }
+        post = capture("post", ts(0.5), "0.9.0", overrides=overrides)
+        code, out = run_main(base, post)
+        self.assertEqual(code, 0, out)
+        self.assertIn("GATE PASS", out)
+        self.assertIn("27 ok, 3 expected-shift", out)
+        self.assertIn("0 FAIL", out)
+        # the two sub-floor-but-passing cells stay plain `ok`, not excused
+        self.assertRegex(out, r"ok\s+overlord\s+bm25-errorcode\s+jaccard=0\.9")
+
+    def test_declared_shift_is_always_reported_with_its_value(self):
+        """An expected shift that vanishes from the output is how a regression hides."""
+        base = capture("pre", ts(0), "0.8.6")
+        overrides = {
+            (b, "temporal-relative"): {"memory_ids": jaccard_shifted(b, "temporal-relative", 0.70)}
+            for b in BANKS
+        }
+        post = capture("post", ts(0.5), "0.9.0", overrides=overrides)
+        code, out = run_main(base, post)
+        self.assertEqual(code, 0, out)
+        self.assertIn("Declared expected-shift cells (reported, never silenced)", out)
+        for bank in BANKS:
+            self.assertRegex(out, rf"{bank}\s+temporal-relative\s+measured=0\.7")
+        self.assertIn("switchroom#4533", out)
+
+
+class TestKnownBad(unittest.TestCase):
+    """Real regressions must come back RED."""
+
+    def test_single_collapsed_cell_fails(self):
+        base = capture("pre", ts(0), "0.8.6")
+        post = capture(
+            "post",
+            ts(0.5),
+            "0.9.0",
+            overrides={
+                ("klanker", "entity-person"): {
+                    "memory_ids": jaccard_shifted("klanker", "entity-person", 0.40)
+                }
+            },
+        )
+        code, out = run_main(base, post)
+        self.assertEqual(code, 1, out)
+        self.assertIn("GATE FAIL", out)
+        self.assertRegex(out, r"FAIL\s+klanker\s+entity-person")
+
+    def test_result_count_collapse_fails_even_at_high_jaccard(self):
+        base = capture("pre", ts(0), "0.8.6")
+        post = capture(
+            "post",
+            ts(0.5),
+            "0.9.0",
+            overrides={
+                ("finn", "bm25-config-key"): {
+                    "memory_ids": ids("finn", "bm25-config-key", n=40),
+                    "result_count": 40,
+                }
+            },
+        )
+        code, out = run_main(base, post)
+        self.assertEqual(code, 1, out)
+        self.assertRegex(out, r"FAIL\s+finn\s+bm25-config-key")
+
+    def test_error_in_post_capture_fails(self):
+        base = capture("pre", ts(0), "0.8.6")
+        post = capture(
+            "post",
+            ts(0.5),
+            "0.9.0",
+            overrides={("overlord", "persona-role"): {"error": "TimeoutError"}},
+        )
+        code, out = run_main(base, post)
+        self.assertEqual(code, 1, out)
+        self.assertIn("TimeoutError", out)
+
+    def test_declared_cell_below_its_band_still_fails(self):
+        """The declaration is a BAND, not a licence to ignore the cell."""
+        base = capture("pre", ts(0), "0.8.6")
+        post = capture(
+            "post",
+            ts(0.5),
+            "0.9.0",
+            overrides={
+                ("overlord", "temporal-relative"): {
+                    "memory_ids": jaccard_shifted("overlord", "temporal-relative", 0.30)
+                }
+            },
+        )
+        code, out = run_main(base, post)
+        self.assertEqual(code, 1, out)
+        self.assertIn("BELOW the declared band", out)
+
+    def test_declared_shift_not_observed_is_reported_but_passes(self):
+        """0.9.0 without the known temporal reshuffle is suspicious, not fatal."""
+        base = capture("pre", ts(0), "0.8.6")
+        post = capture("post", ts(0.5), "0.9.0")  # all cells identical
+        code, out = run_main(base, post)
+        self.assertEqual(code, 0, out)
+        self.assertIn("expected-shift-not-observed", out)
+        self.assertIn("the expected shift did not occur", out)
+
+    def test_declaration_does_not_apply_outside_its_version_scope(self):
+        """Self-retiring: past 0.9.0 the temporal cell is a plain cell again."""
+        base = capture("pre", ts(0), "0.9.0")
+        post = capture(
+            "post",
+            ts(0.5),
+            "0.10.0",
+            overrides={
+                (b, "temporal-relative"): {
+                    "memory_ids": jaccard_shifted(b, "temporal-relative", 0.70)
+                }
+                for b in BANKS
+            },
+        )
+        code, out = run_main(base, post)
+        self.assertEqual(code, 1, out)
+        self.assertIn("matched no cell", out)
+
+
+class TestGateMisuse(unittest.TestCase):
+    """The WP6 finding, encoded: an invalid comparison must not render a verdict."""
+
+    def test_cross_instance_baseline_is_refused(self):
+        """WP6 comparison B: live instance vs a fresh restore of its own dump.
+
+        Same code, healthy data, 30/30 cells at 0.36-0.75. The old gate called
+        that a failing upgrade. This one must call it what it is: not a valid
+        comparison. Exit 2, not 1.
+        """
+        base = capture("pre", ts(0), "0.8.6", db_id=PROD_DB_ID)
+        overrides = {
+            (b, q): {"memory_ids": jaccard_shifted(b, q, 0.5)} for b in BANKS for q in QIDS
+        }
+        post = capture(
+            "post",
+            ts(0.5),
+            "0.8.6",
+            db_id=RESTORED_COPY_DB_ID,
+            api_url="http://127.0.0.1:19999",
+            overrides=overrides,
+        )
+        code, out = run_main(base, post)
+        self.assertEqual(code, 2, out)
+        self.assertIn("GATE MISUSE", out)
+        self.assertIn("DIFFERENT instances", out)
+        self.assertNotIn("GATE FAIL", out)
+
+    def test_stale_baseline_is_refused(self):
+        base = capture("pre", ts(-72), "0.8.6")
+        post = capture("post", ts(0), "0.9.0")
+        code, out = run_main(base, post)
+        self.assertEqual(code, 2, out)
+        self.assertIn("GATE MISUSE", out)
+        self.assertIn("Re-capture the baseline", out)
+
+    def test_stale_override_is_loud_and_marked_advisory(self):
+        base = capture("pre", ts(-72), "0.8.6")
+        post = capture("post", ts(0), "0.9.0")
+        code, out = run_main(base, post, ["--allow-stale-baseline"])
+        self.assertEqual(code, 0, out)
+        self.assertIn("ADVISORY ONLY", out)
+
+    def test_anchor_drift_is_refused(self):
+        base = capture("pre", ts(0), "0.8.6", anchor="2026-08-08T00:00:00")
+        post = capture("post", ts(0.5), "0.9.0", anchor="2026-08-11T00:00:00")
+        code, out = run_main(base, post)
+        self.assertEqual(code, 2, out)
+        self.assertIn("anchors differ", out)
+
+    def test_captures_the_wrong_way_round_are_refused(self):
+        base = capture("post", ts(0), "0.9.0")
+        post = capture("pre", ts(0.5), "0.8.6")
+        code, out = run_main(base, post)
+        self.assertEqual(code, 2, out)
+        self.assertIn("expected 'pre'", out)
+
+    def test_missing_cluster_identity_warns_but_proceeds(self):
+        base = capture("pre", ts(0), "0.8.6", db_id=None)
+        post = capture("post", ts(0.5), "0.9.0", db_id=None)
+        code, out = run_main(base, post)
+        self.assertEqual(code, 0, out)
+        self.assertIn("cluster identity missing", out)
+        self.assertIn("api_url-deep", out)
+
+
+class TestExpectedShiftsFile(unittest.TestCase):
+    def test_shipped_declarations_are_well_formed(self):
+        shifts = cb.load_shifts(SHIFTS_PATH)
+        self.assertTrue(shifts)
+        for s in shifts:
+            self.assertIn(s["query_id"], QIDS)
+            self.assertLess(s["jaccard_min"], s["jaccard_max"])
+            self.assertGreaterEqual(s["jaccard_min"], 0.0)
+            self.assertLessEqual(s["jaccard_max"], 1.0)
+            for field in ("reason", "evidence", "issue"):
+                self.assertTrue(s.get(field), f"{s['query_id']} missing {field}")
+
+    def test_temporal_band_covers_every_wp6_measurement(self):
+        """The band must actually contain what WP6 measured: 0.688-0.793."""
+        shift = next(
+            s for s in cb.load_shifts(SHIFTS_PATH) if s["query_id"] == "temporal-relative"
+        )
+        for measured in (0.688, 0.716, 0.782, 0.793):
+            self.assertGreaterEqual(measured, shift["jaccard_min"])
+            self.assertLessEqual(measured, shift["jaccard_max"])
+        # ...and must NOT be so wide it swallows the WP6 comparison-B artefact
+        # range (0.36-0.75 was same-code drift; the low end must stay a FAIL).
+        self.assertGreater(shift["jaccard_min"], 0.36)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the go/no-go gate for the Hindsight 0.8.6 → 0.9.0 rollout (epic #4525, rollout WP #4534). **As written it would have produced a fully-red board at rollout time on completely healthy data.**

[skip changelog]

## The defect

WP6 (#4533) ran the control experiment: it compared a captured baseline against **the same code (0.8.6) on a fresh restore of that instance's own dump**. Identical code, identical data — **30/30 cells flagged at Jaccard 0.36–0.75**.

The 0.8 Jaccard floor does not measure the code. `_select_with_temporal_coverage` (0.9.0 `retrieval.py:428`) stable-sorts on similarity with **no deterministic tiebreaker**, so equal-similarity ties inherit SQL row order — and anything that changes plans (a `pg_restore` rebuilding every index with fresh statistics; hours of organic ingest) reshuffles `LIMIT`-ed retrieval arms. The floor is meaningful in exactly one configuration:

> live-before vs live-after, on the same running instance, with the baseline captured **minutes** beforehand.

The old artifact recorded neither which instance it came from nor how stale it was, so nothing could tell that configuration apart from any other. Confirmed independently by the stage-4 validator on #4525, which asked for exactly the three fixes below.

## 1. Capture-then-compare, checked rather than assumed

Each capture now records an **instance identity block** and its capture time. The strong identity component is the Postgres cluster `system_identifier`, read read-only via `pg_controldata`: it is **invariant across an application-image upgrade** (same data directory) and **different on any `pg_restore` into a fresh cluster** — precisely the signal that would have caught WP6's comparison B. Verified live against production: `7627286907797205078`.

The comparator **refuses** (rather than mis-verdicts) a cross-instance or >4h-stale baseline, with a **distinct exit code 2 (GATE MISUSE)** separate from 1 (GATE FAIL), so the runbook can tell "the gate says no" from "you used the gate wrong". Overrides exist but stamp the report **ADVISORY ONLY**.

`rollout_gate.sh pre` / `post` makes the correct workflow the easiest one to run, threading the API URL and the pinned recency anchor from `pre` into `post` so they cannot drift.

Deliberately **not** identity: `api_version` (it is supposed to change across this very upgrade) and the bank fingerprint (warns instead).

## 2. Declared expected shifts — a general mechanism

`expected_shifts.json` declares cells known to move for an understood, non-defect reason, each with a band, reason, evidence, issue link and **version scope**. A declaration:

- reclassifies `FAIL` → `expected-shift` **only inside its band**;
- **never silences** — every declared cell is printed inline *and* again in a dedicated "Declared expected-shift cells (reported, never silenced)" section with its measured value;
- still **FAILS below** the band, and still fails on a result-count swing (the declared 0.9.0 shift is count-neutral, so a count move means it is not the declared shift);
- reports **`expected-shift-not-observed`** when the measurement is above the band — a declaration that stopped matching reality is stale and must be visible;
- is **version-scoped**, so it retires itself once the fleet is past 0.9.0 instead of excusing the same cell forever. Unmatched declarations are reported.

One entry ships: `temporal-relative`, band **0.60–0.85**, derived from WP6's byte-identical-data measurements (overlord 0.793, klanker 0.688, finn 0.782), widened only enough to absorb minutes of live ingest and deliberately **not** widened into WP6's comparison-B artefact range (0.36–0.75). **It still needs the epic owner's explicit better/worse/accept sign-off** before the WP7 window, as WP6 and stage-4 both asked.

## 3. A self-test that proves the gate works

17 stdlib tests drive the real comparator and assert verdicts + exit codes.

```
Ran 17 tests in 0.053s
OK
```

Old gate vs new gate on the same inputs:

| scenario | old gate | new gate |
|---|---|---|
| **Healthy** live-before/after with WP6's comparison-C numbers | `3 flagged cell(s) out of 30`, **exit 1** | `27 ok, 3 expected-shift, 0 FAIL` → **GATE PASS**, exit 0 |
| **Invalid** comparison (WP6 comparison B: restored copy, healthy data, same code) | `30 flagged cell(s) out of 30`, **exit 1** | **GATE MISUSE**, exit 2 — *"database cluster identity differs … these are DIFFERENT instances"* |
| **Genuine regression** (`entity-person` collapses to 0.40 on all 3 banks) | exit 1 | `24 ok, 3 FAIL` → **GATE FAIL**, exit 1 |

The middle row is the whole point: the old gate called healthy data a failing upgrade, and the new one refuses to render a verdict on a comparison that cannot support one. The bottom row proves the refusal did not cost it the ability to fail.

Known-bad cases covered: collapsed cell, count collapse, capture error, a **declared** cell below its band, a declaration outside its version scope, stale baseline, anchor drift, swapped pre/post captures, missing cluster identity (warns, proceeds).

## Why these move into the repo

They are operational tooling a runbook depends on, and they were just proven to need tests — an untested gate outside version control is what produced this defect. `docs/operators/hindsight-memory.md` gains a "Rolling the base image FORWARD: the rollout gate" section matching the new workflow. CI runs the suite via `ci-tests-python.yml` (path-filtered) and `ci-full.yml`.

`soak_measure.py` is functionally unchanged — latency medians/p90 are robust to organic ingest, so only the result-set comparison needed the live-before/after treatment. Its hardcoded agents dir became `--agents-dir` / `HINDSIGHT_AGENTS_DIR` now that it lives in the repo.

## Verification

- Self-test 17/17 green; `lint:no-pii`, `lint:test-runner-coverage`, `lint:agent-attribution-trailers`, `lint:plugin-references`, `lint:hindsight-bank-hermeticity` clean. `bash -n` clean (`shellcheck` not installed locally — CI is the authority).
- Live read-only smoke against production `switchroom-hindsight`: identity capture returned the real cluster id, `api_version 0.8.6`, `health healthy`; one recall returned n=80 in 894 ms. **Production was never stopped, restarted, migrated or repointed.**
- **Not verified:** the gate has not been run through a real pre→upgrade→post cycle on production — that is WP7 itself. The `temporal-relative` band is calibrated from WP6's restored-copy measurements; live-vs-live may land slightly differently within it.

Refs #4525, #4533, #4534. Nothing merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
