### PR TITLE
chore(hindsight-gate): record the epic owner's ACCEPT on the temporal-relative shift

### DIFF
--- a/scripts/hindsight-rollout-gate/README.md
+++ b/scripts/hindsight-rollout-gate/README.md
@@ -131,10 +131,20 @@ between a live pre-capture and a live post-capture minutes later. It is
 deliberately not widened to cover WP6's comparison-B artefact range (0.36–0.75):
 the low end must stay a failure.
 
-**This entry needs the epic owner's explicit sign-off** before the WP7 window —
-WP6 and the stage-4 validator both flagged that Jaccard cannot say whether the
-shift is better or worse, only that it is real, bounded, deterministic,
-count-neutral and latency-neutral.
+**This entry is signed off.** WP6 and the stage-4 validator both flagged that
+Jaccard cannot say whether the shift is better or worse, only that it is real,
+bounded, deterministic, count-neutral and latency-neutral — so the call was the
+epic owner's to make. Ken Thompson (@mekenthompson) made it on **2026-08-08:
+ACCEPT**. Rollout proceeds on that basis.
+
+Accepting the band is a decision about blast radius, not a claim that the
+ranking is correct. The underlying defect — `_select_with_temporal_coverage`
+(0.9.0 `retrieval.py:428`) has no deterministic tiebreaker, so equal-similarity
+ties inherit SQL row order — is tracked in **switchroom#4544** (`follow_up` on
+the declaration). When it is fixed, `temporal-relative` should return to ~1.000
+on byte-identical data and this declaration should be deleted; the comparator's
+`expected-shift-not-observed` verdict is the mechanism that will surface the
+stale declaration if it is not.
 
 ## Soak measurement
 

--- a/scripts/hindsight-rollout-gate/expected_shifts.json
+++ b/scripts/hindsight-rollout-gate/expected_shifts.json
@@ -26,7 +26,13 @@
     "  jaccard_max     inclusive upper bound; above this the shift did NOT",
     "                  occur and is reported as such",
     "  from_api_version / to_api_version   version scope, or null for 'any'",
-    "  reason / evidence / signed_off_by   why this is not a defect"
+    "  reason / evidence / signed_off_by   why this is not a defect",
+    "  band_derivation how the min/max bounds were chosen (optional)",
+    "  issue           the investigation this declaration came out of (optional)",
+    "  follow_up       the issue tracking the UNDERLYING defect, for a",
+    "                  declaration that accepts a real defect rather than a",
+    "                  benign behavioural difference. Accepting a shift must",
+    "                  never become the way the bug gets lost (optional)."
   ],
   "shifts": [
     {
@@ -36,11 +42,12 @@
       "jaccard_max": 0.85,
       "from_api_version": "0.8.6",
       "to_api_version": "0.9.0",
-      "reason": "Deterministic tie-break reshuffle, not a retrieval defect. _select_with_temporal_coverage (0.9.0 retrieval.py:428) ranks its pool with a stable sort on similarity and NO deterministic tiebreaker, then buckets in ranked order, so equal-similarity ties inherit SQL row order. Any change to plans, physical order or pool composition reshuffles the temporal arm's entry points and everything downstream (graph spreading, rerank) follows. The function itself is byte-identical between 0.8.6 and 0.9.0.",
+      "reason": "Deterministic tie-break reshuffle, not a retrieval defect. _select_with_temporal_coverage (0.9.0 retrieval.py:428) ranks its pool with a stable sort on similarity and NO deterministic tiebreaker, then buckets in ranked order, so equal-similarity ties inherit SQL row order. Any change to plans, physical order or pool composition reshuffles the temporal arm's entry points and everything downstream (graph spreading, rerank) follows. The function itself is byte-identical between 0.8.6 and 0.9.0. The missing tiebreaker is itself a real defect and is tracked in switchroom#4544: accepting this band is a rollout decision about blast radius, not a claim that the ranking is correct.",
       "evidence": "WP6 (switchroom#4533) comparison C, byte-identical data, 0.8.6 image vs 0.9.0 image on the same restored copy: overlord 0.793, klanker 0.688, finn 0.782. Counts -1%/+9%/+1%, latency unchanged. Reproduced exactly across a container restart and a full downgrade -> re-upgrade cycle (Jaccard 1.000 against itself). 27/30 other cells passed, 25 of them at 1.000, including entity-person at 1.000 on all three banks. Stage-4 independent validation (switchroom#4525) confirmed the attribution in 0.9.0 source.",
       "band_derivation": "WP6 measured 0.688-0.793 on byte-identical data. The band is widened to 0.60-0.85 to absorb the organic ingest that accrues between a live pre-capture and a live post-capture minutes later. It is deliberately NOT widened further: below 0.60 is outside anything WP6 observed and should stop the rollout.",
-      "signed_off_by": "epic owner sign-off required before the WP7 window - see switchroom#4525 'the epic owner still owes the explicit better/worse/accept call'",
-      "issue": "switchroom#4533"
+      "signed_off_by": "ACCEPTED by the epic owner (Ken Thompson / @mekenthompson) on 2026-08-08: the shift is real, but it is bounded to 1 of 10 query shapes, deterministic, and count- and latency-neutral. Rollout proceeds; the missing tiebreaker in _select_with_temporal_coverage is tracked for later tuning (switchroom#4544) rather than blocking the WP7 window. See switchroom#4533.",
+      "issue": "switchroom#4533",
+      "follow_up": "switchroom#4544"
     }
   ]
 }


### PR DESCRIPTION
## What

Records the epic owner's decision on the `temporal-relative` expected-shift
declaration in the Hindsight 0.9.0 rollout gate, and files the underlying defect
so the acceptance does not swallow it.

`scripts/hindsight-rollout-gate/expected_shifts.json` carried a placeholder:

```
"signed_off_by": "epic owner sign-off required before the WP7 window - see
switchroom#4525 'the epic owner still owes the explicit better/worse/accept call'"
```

Ken Thompson (@mekenthompson) made that call on **2026-08-08: ACCEPT**. The
field now records the decision, the decider, the date, and the reasoning.

## Why accept

WP6 (#4533) and the stage-4 validation (#4525) established that Jaccard cannot
say whether the shift is *better* or *worse* — only that it is:

- **real** — 0.688–0.793 across three banks on byte-identical data;
- **bounded** — 1 of 10 canned query shapes; 27/30 other cells passed, 25 at 1.000;
- **deterministic** — reproduced exactly across a container restart and a full
  downgrade → re-upgrade cycle (Jaccard 1.000 against itself);
- **count- and latency-neutral** — counts −1%/+9%/+1%, latency unchanged.

That is a rollout decision, not a measurement question, and it was the epic
owner's to make.

## The defect is now tracked, not absorbed

Accepting the band is a decision about blast radius, **not** a claim that the
ranking is correct. So this PR also:

- files #4544 for the real defect — `_select_with_temporal_coverage`
  (0.9.0 `retrieval.py:428`) sorts its pool on similarity alone with no
  deterministic tiebreaker, so equal-similarity ties inherit SQL row order;
- adds an optional **`follow_up`** field to the declaration pointing at it, and
  documents `follow_up` (plus the already-in-use `band_derivation` and `issue`)
  in the `_doc` field list, which had drifted;
- says so in `reason` and in the README, so a reader of the declaration cannot
  come away thinking the ranking was found correct.

The declaration remains version-scoped (0.8.6 → 0.9.0), so it self-retires once
the fleet moves past 0.9.0, and the comparator's `expected-shift-not-observed`
verdict will surface it as stale once #4544 is fixed.

## Scope

Metadata + docs only. No runtime code, no shippable path
(`scripts/**` is outside `SHIPPABLE_ROOTS`).

`node scripts/check-changelog-entry.mjs` locally:
`OK — no shippable code changed (origin/main...HEAD)` — hence
`[skip changelog]`.

`scripts/hindsight-rollout-gate/tests/` — 17 passed.

Refs #4533, #4525. Closes nothing; #4544 stays open as the tracked follow-up.

[skip changelog]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
