### PR TITLE
chore: release v0.20.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+## v0.20.18 — Hindsight's pinned server moves to 0.9.0, plus the env plumbing, alarm and guidance fixes around it
+
 ### Hindsight: allow the ONNX embeddings env overrides through `memory.env`
 
 - **`resolveHindsightPerfOverrides()` now forwards the five ONNX-embeddings


### PR DESCRIPTION
Release commit for **v0.20.18** (patch bump from v0.20.17, matching this repo's established precedent).

CHANGELOG-only, per `skills/switchroom-release/SKILL.md` step 1:

- `## Unreleased` renamed to `## v0.20.18 — Hindsight's pinned server moves to 0.9.0, plus the env plumbing, alarm and guidance fixes around it`
- a fresh empty `## Unreleased` block (header + convention comment) re-seeded under `# Changelog` so the staging area exists for the next cycle and `scripts/check-changelog-entry.mjs` keeps enforcing it
- `package.json` `version` deliberately untouched (placeholder discipline, #2733)

Diff is +2 lines. Nothing else changes.

## What's in it

Six staged sections, from the PRs that landed since v0.20.17:

- Hindsight pinned server **0.8.6 → 0.9.0** (#4525, #4529, #4530)
- ONNX embeddings env overrides through `memory.env` (#4523)
- the `pg_search` filter-field drift false alarm (#4526)
- `/private` + `/public` in the Telegram slash-command menu (#4445)
- three corrected Hindsight claims in the profile templates
- dead-fork hardening (fleet guidance + worktree GC)

## Pre-flight

- `main` tip at branch time: `4fa318fc` — 75 successful / 0 failed check runs on its parent `29e74ddf`, and `4fa318fc` (#4545) itself merged green through the queue.
- No other open PR intended for this release.
- `node scripts/check-changelog-entry.mjs` → `OK — no shippable code changed`, hence `[skip changelog]`.

[skip changelog]

🤖 Generated with [Claude Code](https://claude.com/claude-code)