### PR TITLE
feat(hindsight): synthesize GET-only knowledge-page read tools in the MCP shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,36 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
-### Features
+### Hindsight: an agent can finally read its own knowledge pages
 
-- **hindsight: synthesize GET-only knowledge-page read tools in the MCP shim**
+- **The MCP shim now synthesizes three GET-only knowledge-page tools —
+  `search_knowledge_pages`, `get_knowledge_page` and `get_knowledge_tree`.**
+  Hindsight 0.9.0 serves a full Knowledge Base REST surface
+  (`/v1/default/banks/{bank}/knowledge-base/...`) but registers ZERO knowledge
+  tools on its MCP surface, so an agent's own curated pages — the synthesized
+  standing answer, where recall returns fragments — were unreachable from a
+  tool call. The shim answers all three locally over REST, the same way it
+  already synthesizes `deactivate_directive` / `reactivate_directive`, so they
+  work on every path: cold boot, cached manifest, or live.
+- **Read-only by construction, not by convention.** The backing
+  `KnowledgeAdmin` has exactly three methods and one network primitive that
+  hard-codes `method: "GET"` with no parameter to override it, so
+  `POST .../pages`, `PATCH .../nodes/{id}` and `DELETE .../nodes/{id}` are
+  unreachable — a page delete would remove the page AND its backing mental
+  model with no undo. Page authorship stays on the operator-approved
+  `mental_model_propose` card. The bank is pinned from `HINDSIGHT_BANK_ID` and
+  no schema exposes a `bank_id`, so a tool call cannot name another agent's
+  bank. (#4548)
+- **Known upstream defect:** `search_knowledge_pages` currently returns
+  HTTP 500 against the deployed Hindsight 0.9.0 backend. Upstream's
+  `search_knowledge_pages` hard-codes `ts_rank_cd`/tsvector and 500s on every
+  non-native text-search backend
+  (https://github.com/vectorize-io/hindsight/issues/3268); the deployed schema
+  has `mental_models.search_vector` as `text`, so the query raises
+  `asyncpg UndefinedFunctionError: function ts_rank_cd(text, tsquery) does not
+  exist`. The shim surfaces it as an honest `HTTP 500` isError result rather
+  than an empty one. `get_knowledge_page` and `get_knowledge_tree` are
+  unaffected. (#4548)
 
 ## v0.20.18 — Hindsight's pinned server moves to 0.9.0, plus the env plumbing, alarm and guidance fixes around it
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+### Features
+
+- **hindsight: synthesize GET-only knowledge-page read tools in the MCP shim**
+
 ## v0.20.18 — Hindsight's pinned server moves to 0.9.0, plus the env plumbing, alarm and guidance fixes around it
 
 ### Hindsight: allow the ONNX embeddings env overrides through `memory.env`

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1287,6 +1287,17 @@ export const HINDSIGHT_MCP_TOOLS = [
   // Mental models — READ ONLY (writes go through the propose card).
   "mcp__hindsight__get_mental_model",
   "mcp__hindsight__list_mental_models",
+  // Knowledge pages — READ ONLY, and SHIM-SYNTHESIZED
+  // (src/cli/hindsight-mcp-shim.ts, backed by KnowledgeAdmin). Hindsight
+  // serves a full Knowledge Base REST surface but registers no knowledge MCP
+  // tools, so these three are answered locally as plain GETs with the bank
+  // pinned to HINDSIGHT_BANK_ID. They are pre-approved for the same reason the
+  // read/list surface above is: they read the agent's own bank and change
+  // nothing. Page authorship and deletion are deliberately NOT synthesized, so
+  // there is no write counterpart to gate.
+  "mcp__hindsight__search_knowledge_pages",
+  "mcp__hindsight__get_knowledge_page",
+  "mcp__hindsight__get_knowledge_tree",
   // Tags.
   "mcp__hindsight__list_tags",
   // Operations.

--- a/src/cli/hindsight-mcp-shim.ts
+++ b/src/cli/hindsight-mcp-shim.ts
@@ -90,6 +90,7 @@ import {
   KNOWLEDGE_SEARCH_LIMIT_DEFAULT,
   KNOWLEDGE_SEARCH_LIMIT_MAX,
   KNOWLEDGE_SEARCH_LIMIT_MIN,
+  type KnowledgeNode,
 } from "../memory/hindsight-knowledge-admin.js";
 import { redact } from "../secret-detect/redact.js";
 import { HINDSIGHT_DEFAULT_MCP_URL } from "../setup/hindsight.js";
@@ -358,6 +359,18 @@ export const SYNTHESIZED_TOOL_TABLE: Record<
 export const SYNTHESIZED_TOOL_NAMES = Object.keys(SYNTHESIZED_TOOL_TABLE);
 
 /**
+ * The ONLY string spelling of an integer `coerceSynthesizedArg` accepts.
+ *
+ * Deliberately narrower than `/^-?\d+$/` over a trimmed value, which took
+ * `"01"`, `" 5 "` and `"50\n"`. Those are not what an MCP client's number
+ * stringification produces; accepting them means accepting a value the caller
+ * did not mean to send in that form, and `"01"` in particular is the shape a
+ * truncated or hand-mangled argument arrives in. No surrounding whitespace, no
+ * leading zeros, `0` itself allowed.
+ */
+const INTEGER_STRING_PATTERN = /^-?(?:0|[1-9]\d*)$/;
+
+/**
  * Validate + coerce ONE synthesized-tool argument against its declared schema.
  *
  * Per-property, deliberately. The original rule was "every argument must be a
@@ -405,15 +418,15 @@ export function coerceSynthesizedArg(
   let n: number;
   if (typeof value === "number") {
     n = value;
-  } else if (typeof value === "string" && /^-?\d+$/.test(value.trim())) {
-    n = Number(value.trim());
+  } else if (typeof value === "string" && INTEGER_STRING_PATTERN.test(value)) {
+    n = Number(value);
   } else {
     return {
       ok: false,
       text: `${toolName}: '${key}' must be an integer${range}.`,
     };
   }
-  if (!Number.isInteger(n)) {
+  if (!Number.isSafeInteger(n)) {
     return {
       ok: false,
       text: `${toolName}: '${key}' must be an integer${range}.`,
@@ -618,6 +631,122 @@ export const DEFAULT_REFLECT_MAX_TOKENS = 1024;
  */
 export const DEFAULT_RECALL_BUDGET = "low";
 export const DEFAULT_REFLECT_BUDGET = "mid";
+
+// ─── Synthesized knowledge-read response caps ─────────────────────────────
+
+/**
+ * Char ceiling on ONE synthesized knowledge response.
+ *
+ * The forwarded reads are token-budgeted ({@link DEFAULT_RECALL_MAX_TOKENS} =
+ * 1024) precisely because an unbounded payload silently overruns the MCP
+ * output cap and never lands in the agent's context. The knowledge reads had
+ * no equivalent ceiling: a big tree or a long page went back verbatim.
+ *
+ * 16384 = 4096 tokens × ~4 chars/token, i.e. exactly the budget upstream
+ * generates a page against (`KNOWLEDGE_PAGE_DEFAULT_MAX_TOKENS = 4096`,
+ * hindsight 0.9.0 `engine/memory_engine.py:13347`), so a normally-sized page
+ * is never touched and only a genuinely oversized payload is cut.
+ */
+export const KNOWLEDGE_RESPONSE_MAX_CHARS = 16_384;
+
+/**
+ * Chars held back from the tree's budget for the omission marker, so the
+ * capped render (JSON + marker) still fits {@link KNOWLEDGE_RESPONSE_MAX_CHARS}
+ * rather than overshooting it by the length of its own footnote.
+ *
+ * Deliberately NOT paired with a node-count constant. A minimal node
+ * serializes to ~35 chars, so any node ceiling low enough to bind before the
+ * char budget would have to be under ~460 — i.e. a second threshold that
+ * either never fires (dead config, which is what a 500-node cap turned out to
+ * be) or silently overrides the one that matters. One budget, in the unit the
+ * MCP output cap is actually denominated in.
+ */
+const KNOWLEDGE_TREE_MARKER_RESERVE = 256;
+
+/**
+ * Cut an oversized synthesized payload, SAYING SO.
+ *
+ * The marker is the whole point: a silently-truncated page reads to the model
+ * as a complete page that simply ends, and it will act on the missing half as
+ * if it did not exist. An explicit tail makes the gap something the model can
+ * see and route around.
+ */
+export function capKnowledgeResponse(text: string): string {
+  if (text.length <= KNOWLEDGE_RESPONSE_MAX_CHARS) return text;
+  const omitted = text.length - KNOWLEDGE_RESPONSE_MAX_CHARS;
+  return (
+    text.slice(0, KNOWLEDGE_RESPONSE_MAX_CHARS) +
+    `\n\n…truncated at ${KNOWLEDGE_RESPONSE_MAX_CHARS} chars — ${omitted} ` +
+    `chars omitted. This is a PARTIAL read; narrow it with ` +
+    `search_knowledge_pages rather than treating the above as the whole.`
+  );
+}
+
+/** Total nodes in a knowledge forest, children included. */
+function countKnowledgeNodes(nodes: KnowledgeNode[]): number {
+  let n = 0;
+  for (const node of nodes) n += 1 + countKnowledgeNodes(node.children ?? []);
+  return n;
+}
+
+/** Depth-first prefix of a forest holding at most `budget` nodes. */
+function takeKnowledgeNodes(
+  nodes: KnowledgeNode[],
+  budget: { left: number },
+): KnowledgeNode[] {
+  const out: KnowledgeNode[] = [];
+  for (const node of nodes) {
+    if (budget.left <= 0) break;
+    budget.left -= 1;
+    out.push(
+      node.children === undefined
+        ? node
+        : { ...node, children: takeKnowledgeNodes(node.children, budget) },
+    );
+  }
+  return out;
+}
+
+/**
+ * Render the tree inside {@link KNOWLEDGE_RESPONSE_MAX_CHARS}.
+ *
+ * `capKnowledgeResponse` is deliberately NOT used here: a char-level cut of
+ * JSON leaves an unparseable document, which is worse than no answer. The
+ * NODE budget is shrunk proportionally until the serialized form fits
+ * instead, so the JSON is well-formed at every size.
+ *
+ * Depth-first prune so the retained part is a valid subtree (a folder is never
+ * emitted without its own record), compact JSON so the budget buys nodes
+ * rather than indentation, and an explicit `N of M nodes omitted` tail
+ * whenever anything was dropped.
+ */
+export function renderKnowledgeTree(roots: KnowledgeNode[]): string {
+  const total = countKnowledgeNodes(roots);
+  const whole = JSON.stringify(roots);
+  if (whole.length <= KNOWLEDGE_RESPONSE_MAX_CHARS) return whole;
+  const charBudget = KNOWLEDGE_RESPONSE_MAX_CHARS - KNOWLEDGE_TREE_MARKER_RESERVE;
+  let allowed = total;
+  let kept = takeKnowledgeNodes(roots, { left: allowed });
+  let json = JSON.stringify(kept);
+  // Proportional shrink, guaranteed to make progress (the -1 floor), so this
+  // terminates even on pathologically large single nodes.
+  while (json.length > charBudget && allowed > 0) {
+    allowed = Math.max(
+      0,
+      Math.min(allowed - 1, Math.floor(allowed * (charBudget / json.length))),
+    );
+    kept = takeKnowledgeNodes(roots, { left: allowed });
+    json = JSON.stringify(kept);
+  }
+  const shown = countKnowledgeNodes(kept);
+  if (shown === total) return json;
+  return (
+    json +
+    `\n…${total - shown} of ${total} nodes omitted — the knowledge tree was ` +
+    `truncated to fit the response budget. This is a PARTIAL listing; use ` +
+    `search_knowledge_pages to find a specific page.`
+  );
+}
 
 const VALID_BUDGETS = new Set(["low", "mid", "high"]);
 
@@ -1200,10 +1329,13 @@ export class HindsightShim {
       );
       this.staleManifestServed = true;
       const cached = this.readCache();
-      // The synthesized directive tools do not depend on the backend at all,
-      // so they are advertised identically on every path — cold boot, cached,
-      // or live. An agent must never lose the retirement path just because
-      // memory is briefly down.
+      // The synthesized tools — the two directive-retirement tools AND the
+      // three knowledge-page reads — do not depend on the backend's MCP
+      // surface at all, so they are advertised identically on every path:
+      // cold boot, cached, or live. An agent must never lose the retirement
+      // path, or sight of its own knowledge pages, just because the MCP
+      // session is briefly down. (Their REST calls can still fail; that
+      // surfaces as an honest isError at call time, not as a missing tool.)
       return cached ? withSynthesizedTools(cached) : buildFallbackToolsList();
     }
   }
@@ -1345,13 +1477,18 @@ export class HindsightShim {
             "exists."
           );
         }
-        return JSON.stringify(res.results, null, 2);
+        // `total` rides along deliberately: with `results` alone the model
+        // cannot tell a complete set from one the `limit` cut short, and would
+        // read 10 of 200 hits as "there are 10".
+        return capKnowledgeResponse(
+          JSON.stringify({ total: res.total, results: res.results }, null, 2),
+        );
       }
       case "get_knowledge_page": {
         const page = await this.knowledgeAdmin.getPage({
           page_id: args.page_id as string,
         });
-        return page.markdown;
+        return capKnowledgeResponse(page.markdown);
       }
       case "get_knowledge_tree": {
         const tree = await this.knowledgeAdmin.tree();
@@ -1361,7 +1498,7 @@ export class HindsightShim {
             "mental models — propose one to start it."
           );
         }
-        return JSON.stringify(tree.roots, null, 2);
+        return renderKnowledgeTree(tree.roots);
       }
       default:
         throw new Error(

--- a/src/cli/hindsight-mcp-shim.ts
+++ b/src/cli/hindsight-mcp-shim.ts
@@ -33,14 +33,20 @@
  *
  * ## The one place the shim is not a pure proxy (#directive-retirement)
  *
- * It also SYNTHESIZES two tools that no backend version registers —
- * `deactivate_directive` and `reactivate_directive` (see
- * {@link SYNTHESIZED_TOOL_TABLE}). Hindsight's MCP surface can create, list
- * and delete a directive but cannot flip `is_active`; only the REST API can,
- * so without this the only retirement path was hand-rolled curl. These two are
- * answered locally by {@link DirectiveAdmin} against the REST base derived
- * from `HINDSIGHT_MCP_URL`, with the bank pinned to `HINDSIGHT_BANK_ID`, and
- * are never forwarded upstream.
+ * It also SYNTHESIZES tools that no backend version registers (see
+ * {@link SYNTHESIZED_TOOL_TABLE}), answered locally over REST against the base
+ * derived from `HINDSIGHT_MCP_URL`, with the bank pinned to
+ * `HINDSIGHT_BANK_ID`, and never forwarded upstream:
+ *
+ *   - `deactivate_directive` / `reactivate_directive` — hindsight's MCP
+ *     surface can create, list and delete a directive but cannot flip
+ *     `is_active`; only the REST API can, so without this the only retirement
+ *     path was hand-rolled curl. Backed by {@link DirectiveAdmin}.
+ *   - `search_knowledge_pages` / `get_knowledge_page` / `get_knowledge_tree` —
+ *     hindsight 0.9.0 serves a full Knowledge Base REST surface and registers
+ *     no knowledge MCP tools at all, so an agent's own curated pages were
+ *     unreachable from a tool call. Backed by {@link KnowledgeAdmin}, which is
+ *     GET-only: page authorship and deletion stay off this surface entirely.
  *
  * That pin is a usability and provenance boundary, NOT a security one — the
  * REST API is unauthenticated and raw curl bypasses the shim entirely. See the
@@ -79,6 +85,12 @@ import {
   DirectiveAdmin,
   DirectivePairInconsistentError,
 } from "../memory/hindsight-directive-admin.js";
+import {
+  KnowledgeAdmin,
+  KNOWLEDGE_SEARCH_LIMIT_DEFAULT,
+  KNOWLEDGE_SEARCH_LIMIT_MAX,
+  KNOWLEDGE_SEARCH_LIMIT_MIN,
+} from "../memory/hindsight-knowledge-admin.js";
 import { redact } from "../secret-detect/redact.js";
 import { HINDSIGHT_DEFAULT_MCP_URL } from "../setup/hindsight.js";
 
@@ -222,7 +234,7 @@ export const FALLBACK_TOOL_TABLE: Record<string, [string[], string[]]> = {
  * filter applied when it did not. The harm is entirely a property of tools
  * whose calls are FORWARDED to the backend.
  *
- * These two are not. `toolsCall()` intercepts them by name before any upstream
+ * These are not. `toolsCall()` intercepts them by name before any upstream
  * request exists and answers them locally over REST, so there is no server to
  * mis-describe and no argument that can be silently dropped: an unknown
  * argument here is rejected loudly by {@link HindsightShim.synthesizedCall}.
@@ -235,8 +247,13 @@ export const FALLBACK_TOOL_TABLE: Record<string, [string[], string[]]> = {
  * `tests/memory.hindsight-contract.fixture.test.ts` still asserts
  * `FALLBACK_TOOL_TABLE` ≡ the snapshot, plus a new assertion that these names
  * do NOT appear in the snapshot — so if a future image bump registers real
- * `deactivate_directive` / `reactivate_directive` tools, the test reds and the
- * synthesis gets retired rather than silently shadowing them.
+ * `deactivate_directive` / `search_knowledge_pages` / … tools, the test reds
+ * and the synthesis gets retired rather than silently shadowing them.
+ *
+ * The knowledge tools additionally carry `type: "integer"` props. See
+ * {@link coerceSynthesizedArg}: an integer prop is range-checked against its
+ * own `minimum`/`maximum` here rather than forwarded, because the upstream
+ * endpoint answers a 422 the calling model cannot act on.
  *
  * NOTE the deliberate absence of a `bank_id` property. The bank is pinned from
  * `HINDSIGHT_BANK_ID`; a caller cannot name one. That is a usability and
@@ -283,10 +300,135 @@ export const SYNTHESIZED_TOOL_TABLE: Record<
       },
     },
   },
+  search_knowledge_pages: {
+    description:
+      "Search YOUR OWN knowledge pages — the curated, continuously-refreshed " +
+      "summaries of what this bank knows — with hybrid full-text + semantic " +
+      "search. Reach for this before re-deriving a standing answer from raw " +
+      "recall: a page is already synthesized, where recall returns fragments. " +
+      "Returns ranked hits with a relevance snippet and a page id; read the " +
+      "whole page with get_knowledge_page. Read-only, and only ever your own " +
+      "memory bank. An empty knowledge base returns no results, not an error.",
+    required: ["query"],
+    props: {
+      query: {
+        type: "string",
+        description: "What to look for, in natural language.",
+      },
+      limit: {
+        type: "integer",
+        minimum: KNOWLEDGE_SEARCH_LIMIT_MIN,
+        maximum: KNOWLEDGE_SEARCH_LIMIT_MAX,
+        description:
+          `Maximum hits to return (${KNOWLEDGE_SEARCH_LIMIT_MIN}-` +
+          `${KNOWLEDGE_SEARCH_LIMIT_MAX}, default ${KNOWLEDGE_SEARCH_LIMIT_DEFAULT}).`,
+      },
+    },
+  },
+  get_knowledge_page: {
+    description:
+      "Read one of YOUR OWN knowledge pages in full, by the page id returned " +
+      "by search_knowledge_pages or get_knowledge_tree. Returns the complete " +
+      "markdown document (YAML frontmatter + synthesized body). Prefer this " +
+      "over rebuilding the same understanding from scratch. Read-only: it " +
+      "returns the page as it currently stands and never triggers a refresh.",
+    required: ["page_id"],
+    props: {
+      page_id: {
+        type: "string",
+        description:
+          "Id of the page to read, from search_knowledge_pages or " +
+          "get_knowledge_tree.",
+      },
+    },
+  },
+  get_knowledge_tree: {
+    description:
+      "List YOUR OWN knowledge base as a folder/page tree — every page's id, " +
+      "name, source query, tags and staleness flag. Call this to see what " +
+      "this bank already knows before reading anything else; is_stale=true " +
+      "means the page MAY be behind newer memories, not that it is wrong. " +
+      "Read-only, and only ever your own memory bank.",
+    required: [],
+    props: {},
+  },
 };
 
 /** Names of the shim-synthesized tools (never forwarded upstream). */
 export const SYNTHESIZED_TOOL_NAMES = Object.keys(SYNTHESIZED_TOOL_TABLE);
+
+/**
+ * Validate + coerce ONE synthesized-tool argument against its declared schema.
+ *
+ * Per-property, deliberately. The original rule was "every argument must be a
+ * non-empty string", which was true while every declared prop was a string and
+ * became a latent bug the moment one was not: a well-formed `limit: 5` would
+ * have been rejected with "'limit' must be a non-empty string", and the model
+ * would have had no way to satisfy the schema it was shown.
+ *
+ * The strictness is preserved, not relaxed:
+ *   • a string prop still rejects a non-string and an empty string — silently
+ *     treating `superseded_by: ""` as "no supersession" would drop provenance
+ *     the caller asked for without saying so;
+ *   • an integer prop rejects anything that is not an integer (or the exact
+ *     decimal string of one — MCP clients routinely stringify numbers) and
+ *     rejects out-of-range rather than clamping, because the bound is in the
+ *     schema the model was shown and a silently-clamped `limit: 500` reads as
+ *     "you got 500 hits" when it got 50.
+ *
+ * Exported for direct test coverage of the table's contract.
+ */
+export function coerceSynthesizedArg(
+  toolName: string,
+  key: string,
+  propSchema: unknown,
+  value: unknown,
+): { ok: true; value: string | number } | { ok: false; text: string } {
+  const schema = (propSchema ?? {}) as {
+    type?: string;
+    minimum?: number;
+    maximum?: number;
+  };
+  if (schema.type !== "integer") {
+    if (typeof value !== "string" || value.length === 0) {
+      return {
+        ok: false,
+        text: `${toolName}: '${key}' must be a non-empty string.`,
+      };
+    }
+    return { ok: true, value };
+  }
+  const min = schema.minimum;
+  const max = schema.maximum;
+  const range =
+    min !== undefined && max !== undefined ? ` between ${min} and ${max}` : "";
+  let n: number;
+  if (typeof value === "number") {
+    n = value;
+  } else if (typeof value === "string" && /^-?\d+$/.test(value.trim())) {
+    n = Number(value.trim());
+  } else {
+    return {
+      ok: false,
+      text: `${toolName}: '${key}' must be an integer${range}.`,
+    };
+  }
+  if (!Number.isInteger(n)) {
+    return {
+      ok: false,
+      text: `${toolName}: '${key}' must be an integer${range}.`,
+    };
+  }
+  if ((min !== undefined && n < min) || (max !== undefined && n > max)) {
+    return {
+      ok: false,
+      text:
+        `${toolName}: '${key}' must be an integer${range} — got ${n}. ` +
+        `Re-issue the call with a value in range.`,
+    };
+  }
+  return { ok: true, value: n };
+}
 
 /** Materialize the synthesized tools in MCP tools/list shape. */
 export function buildSynthesizedToolsList(): ToolDef[] {
@@ -1082,6 +1224,22 @@ export class HindsightShim {
     return this.directiveAdminCache;
   }
 
+  /** Lazily built REST client for the synthesized knowledge-page reads. */
+  private knowledgeAdminCache: KnowledgeAdmin | null = null;
+
+  private get knowledgeAdmin(): KnowledgeAdmin {
+    if (!this.knowledgeAdminCache) {
+      this.knowledgeAdminCache = new KnowledgeAdmin({
+        apiBaseUrl:
+          this.opts.apiBaseUrl ?? this.opts.url.replace(/\/mcp\/?$/, ""),
+        // PINNED. There is no parameter path from a tool call to this value.
+        bankId: this.opts.bankId,
+        ...(this.opts.fetchImpl ? { fetchImpl: this.opts.fetchImpl } : {}),
+      });
+    }
+    return this.knowledgeAdminCache;
+  }
+
   /**
    * Answer a shim-synthesized tool locally. Never touches the upstream MCP
    * session.
@@ -1114,38 +1272,28 @@ export class HindsightShim {
             : ""),
       );
     }
-    // Every declared arg is a string; an empty one is rejected rather than
-    // coerced away — silently treating `superseded_by: ""` as "no
-    // supersession" would drop the provenance the caller asked for without
-    // saying so.
+    // Each declared arg is validated against ITS OWN schema entry — see
+    // coerceSynthesizedArg for why this is per-property rather than the flat
+    // "must be a non-empty string" rule it replaced.
+    const clean: Record<string, string | number> = {};
     for (const key of Object.keys(args)) {
-      if (typeof args[key] !== "string" || (args[key] as string).length === 0) {
-        return fail(`${name}: '${key}' must be a non-empty string.`);
-      }
+      const coerced = coerceSynthesizedArg(name, key, spec.props[key], args[key]);
+      if (!coerced.ok) return fail(coerced.text);
+      clean[key] = coerced.value;
     }
     for (const req of spec.required) {
-      if (args[req] === undefined) {
+      if (clean[req] === undefined) {
         return fail(`${name} requires '${req}'.`);
       }
     }
     if (!this.opts.bankId) {
       return fail(
         `${name} is unavailable: this agent has no HINDSIGHT_BANK_ID, so ` +
-          "there is no bank to pin the change to.",
+          "there is no bank to pin it to.",
       );
     }
     try {
-      const text =
-        name === "deactivate_directive"
-          ? await this.directiveAdmin.deactivate({
-              name: args.name as string,
-              ...(typeof args.superseded_by === "string"
-                ? { supersededBy: args.superseded_by }
-                : {}),
-            })
-          : await this.directiveAdmin.reactivate({
-              name: args.name as string,
-            });
+      const text = await this.runSynthesized(name, clean);
       return { content: [{ type: "text", text }], isError: false };
     } catch (err) {
       if (err instanceof DirectivePairInconsistentError) {
@@ -1155,11 +1303,78 @@ export class HindsightShim {
     }
   }
 
+  /**
+   * Dispatch one validated synthesized call to its REST backing and render
+   * the agent-facing text.
+   *
+   * A name switch rather than a ternary chain: the directive pair was
+   * expressible as `name === "deactivate_directive" ? … : …` only while there
+   * were exactly two, and that shape silently routes any unrecognised name to
+   * the else branch. The `default` throw makes a table entry added without a
+   * dispatch arm a loud failure instead of a wrong tool running.
+   *
+   * Rendering differs by tool on purpose: a page IS a markdown document, so it
+   * is returned verbatim; search hits and the tree are structured data with no
+   * canonical prose form, so they are JSON.
+   */
+  private async runSynthesized(
+    name: string,
+    args: Record<string, string | number>,
+  ): Promise<string> {
+    switch (name) {
+      case "deactivate_directive":
+        return this.directiveAdmin.deactivate({
+          name: args.name as string,
+          ...(typeof args.superseded_by === "string"
+            ? { supersededBy: args.superseded_by }
+            : {}),
+        });
+      case "reactivate_directive":
+        return this.directiveAdmin.reactivate({ name: args.name as string });
+      case "search_knowledge_pages": {
+        const res = await this.knowledgeAdmin.search({
+          query: args.query as string,
+          ...(typeof args.limit === "number" ? { limit: args.limit } : {}),
+        });
+        if (res.results.length === 0) {
+          // An empty bank is a normal answer, not a failure — say so in words
+          // so the model does not read `[]` as a broken tool and retry.
+          return (
+            "No knowledge pages matched that query in your memory bank. " +
+            "The bank may have no pages yet — get_knowledge_tree lists what " +
+            "exists."
+          );
+        }
+        return JSON.stringify(res.results, null, 2);
+      }
+      case "get_knowledge_page": {
+        const page = await this.knowledgeAdmin.getPage({
+          page_id: args.page_id as string,
+        });
+        return page.markdown;
+      }
+      case "get_knowledge_tree": {
+        const tree = await this.knowledgeAdmin.tree();
+        if (tree.roots.length === 0) {
+          return (
+            "Your knowledge base has no pages yet. Pages are synthesized from " +
+            "mental models — propose one to start it."
+          );
+        }
+        return JSON.stringify(tree.roots, null, 2);
+      }
+      default:
+        throw new Error(
+          `${name} is advertised as a synthesized tool but has no dispatch arm`,
+        );
+    }
+  }
+
   /** tools/call: lazy connect + bounded timeout + one retry; isError on down. */
   private async toolsCall(params: unknown): Promise<unknown> {
     const called = (params as { name?: string; arguments?: unknown } | undefined);
     // Synthesized tools are answered here and NEVER forwarded — the upstream
-    // MCP surface has no directive-update tool to forward them to.
+    // MCP surface has no directive-update or knowledge tool to forward them to.
     if (called?.name && SYNTHESIZED_TOOL_NAMES.includes(called.name)) {
       return this.synthesizedCall(called.name, called.arguments);
     }

--- a/src/memory/hindsight-knowledge-admin.ts
+++ b/src/memory/hindsight-knowledge-admin.ts
@@ -1,0 +1,275 @@
+/**
+ * Knowledge-page READS over the Hindsight REST API — the implementation
+ * behind the shim-synthesized `search_knowledge_pages` /
+ * `get_knowledge_page` / `get_knowledge_tree` MCP tools.
+ *
+ * ## Why REST and not MCP
+ *
+ * Hindsight 0.9.0 ships a complete Knowledge Base REST surface
+ * (`/v1/default/banks/{bank_id}/knowledge-base/...`) and registers ZERO
+ * knowledge tools on its MCP surface — verified against the running image's
+ * `hindsight_api/mcp_tools.py`, and pinned by
+ * `tests/fixtures/hindsight-tools-list.snapshot.json`, which contains no
+ * `*_knowledge_*` entry. So an agent's curated pages — the thing the bank is
+ * for once memories have been consolidated — are simply not reachable from a
+ * tool call. This module is the narrow, named alternative, exactly as
+ * `hindsight-directive-admin.ts` is for directive retirement.
+ *
+ * Upstream's own answer is a SEPARATE npm MCP sidecar
+ * (`hindsight-integrations/coding-agents`, `src/core/knowledge-tools.ts`).
+ * Deliberately not adopted: it is a second MCP server per agent (a second
+ * startup dependency the shim exists to remove), it resolves its own bank
+ * rather than honouring `HINDSIGHT_BANK_ID`, it needs an npm dependency in
+ * every container, and it drags ungated WRITE tools (`capture_initiative`,
+ * `ingest_document`) along with the reads. We take the three reads only.
+ *
+ * ## Read-only is enforced by construction, not by convention
+ *
+ * The REST surface underneath also offers `POST .../pages`,
+ * `POST .../folders`, `PATCH .../nodes/{id}` and `DELETE .../nodes/{id}` —
+ * page authorship and deletion. None of them is reachable from here: this
+ * class has exactly three methods, all of them reads, and its ONLY network
+ * primitive ({@link KnowledgeAdmin.get}) hard-codes `method: "GET"` with no
+ * parameter to override it. Adding a write would mean adding a method AND a
+ * second primitive, both of which red
+ * `tests/hindsight-knowledge-admin.test.ts`'s prototype inventory.
+ *
+ * That matters because page CRUD is destructive with no undo — `DELETE
+ * .../nodes/{id}` removes a page and, upstream, its backing mental model.
+ * Page authorship stays where it already is: the operator-approved
+ * `mental_model_propose` card.
+ *
+ * ## The bank pin is a USABILITY AND PROVENANCE boundary, NOT A SECURITY ONE
+ *
+ * `bankId` is pinned here from the agent's own `HINDSIGHT_BANK_ID` and the
+ * tool schemas expose no `bank_id` property, so a *tool call* physically
+ * cannot read another agent's pages. That is the entire extent of the
+ * guarantee — the REST transport is unauthenticated, so raw curl from an
+ * agent's Bash bypasses this module entirely. The full statement is in the
+ * header of `src/memory/hindsight-directive-admin.ts`; nothing here changes
+ * it, and these being READS makes the residual exposure strictly smaller than
+ * the directive path's.
+ */
+
+/** One hybrid-search hit (`KnowledgePageSearchResult` upstream). */
+export interface KnowledgePageSearchResult {
+  id: string;
+  name: string;
+  mental_model_id?: string | null;
+  snippet: string;
+  score: number;
+  updated_at?: string | null;
+}
+
+/** `GET .../knowledge-base/search` response. */
+export interface KnowledgePageSearchResponse {
+  results: KnowledgePageSearchResult[];
+  total: number;
+}
+
+/** `GET .../knowledge-base/pages/{id}` response (`KnowledgePageResponse`). */
+export interface KnowledgePage {
+  id: string;
+  name: string;
+  type: string;
+  description?: string | null;
+  tags?: string[];
+  timestamp?: string | null;
+  body?: string | null;
+  /** The full markdown document: YAML frontmatter + markdown body. */
+  markdown: string;
+}
+
+/** One node of the knowledge tree (`KnowledgeNode` upstream). */
+export interface KnowledgeNode {
+  id: string;
+  kind: "folder" | "page";
+  name: string;
+  parent_id?: string | null;
+  mental_model_id?: string | null;
+  managed?: boolean;
+  description?: string | null;
+  tags?: string[];
+  timestamp?: string | null;
+  /** Pages only, populated by the tree endpoint. */
+  is_stale?: boolean | null;
+  children?: KnowledgeNode[];
+}
+
+/** `GET .../knowledge-base/tree` response. */
+export interface KnowledgeTree {
+  roots: KnowledgeNode[];
+}
+
+/**
+ * Search limit bounds, mirroring the upstream Query declaration
+ * (`limit: int = Query(10, ge=1, le=50)`). Out-of-range is a 422 upstream, so
+ * the value is clamped here rather than forwarded — a caller asking for 200
+ * results gets the 50 the server can give, not a validation error it cannot
+ * act on.
+ */
+export const KNOWLEDGE_SEARCH_LIMIT_MIN = 1;
+export const KNOWLEDGE_SEARCH_LIMIT_MAX = 50;
+export const KNOWLEDGE_SEARCH_LIMIT_DEFAULT = 10;
+
+/** Clamp to the server's accepted range. Exported so a test can pin it. */
+export function clampKnowledgeSearchLimit(limit?: number): number {
+  if (limit === undefined || !Number.isFinite(limit)) {
+    return KNOWLEDGE_SEARCH_LIMIT_DEFAULT;
+  }
+  return Math.min(
+    KNOWLEDGE_SEARCH_LIMIT_MAX,
+    Math.max(KNOWLEDGE_SEARCH_LIMIT_MIN, Math.trunc(limit)),
+  );
+}
+
+export interface KnowledgeAdminOptions {
+  /** REST base, e.g. `http://127.0.0.1:18888` (no trailing slash). */
+  apiBaseUrl: string;
+  /**
+   * The agent's OWN bank. Pinned: every request path this module builds
+   * embeds this value, and no caller-supplied input can reach it.
+   */
+  bankId: string;
+  /** Injectable fetch (tests). Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Per-request timeout. */
+  timeoutMs?: number;
+}
+
+export const KNOWLEDGE_ADMIN_TIMEOUT_MS = 15_000;
+
+/**
+ * Read-only client for one bank's knowledge base.
+ *
+ * Three methods, all GET. See the header for why that is a construction-time
+ * property rather than a convention.
+ */
+export class KnowledgeAdmin {
+  constructor(private readonly opts: KnowledgeAdminOptions) {}
+
+  private get fetchImpl(): typeof fetch {
+    return this.opts.fetchImpl ?? fetch;
+  }
+
+  /**
+   * Base path for THIS agent's knowledge base. The bank segment comes from
+   * `opts.bankId` only — there is no parameter, so no caller can redirect it.
+   */
+  private knowledgeBasePath(): string {
+    const base = this.opts.apiBaseUrl.replace(/\/+$/, "");
+    return `${base}/v1/default/banks/${encodeURIComponent(this.opts.bankId)}/knowledge-base`;
+  }
+
+  /**
+   * The ONLY network primitive in this class, and it takes no method
+   * parameter. A write would need a second primitive alongside it, which is
+   * the reviewable act.
+   */
+  private async get(url: string): Promise<Response> {
+    const ctl = new AbortController();
+    const timer = setTimeout(
+      () => ctl.abort(),
+      this.opts.timeoutMs ?? KNOWLEDGE_ADMIN_TIMEOUT_MS,
+    );
+    try {
+      return await this.fetchImpl(url, {
+        method: "GET",
+        headers: {
+          accept: "application/json",
+          // Advisory only — the REST layer ignores it. Sent for parity with
+          // the shim's MCP path and so request logs carry the intent.
+          ...(this.opts.bankId ? { "X-Bank-Id": this.opts.bankId } : {}),
+        },
+        signal: ctl.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Hybrid (BM25 + vector) search over the pinned bank's knowledge pages.
+   *
+   * An empty bank answers `{results: [], total: 0}` with HTTP 200 — an empty
+   * result, never an error, so a fresh agent asking about its own knowledge
+   * gets "nothing yet" rather than a failure it has to interpret.
+   */
+  async search(args: {
+    query: string;
+    limit?: number;
+  }): Promise<KnowledgePageSearchResponse> {
+    const params = new URLSearchParams({
+      q: args.query,
+      limit: String(clampKnowledgeSearchLimit(args.limit)),
+    });
+    const res = await this.get(`${this.knowledgeBasePath()}/search?${params}`);
+    if (!res.ok) {
+      throw new Error(
+        `searching knowledge pages in bank '${this.opts.bankId}' failed: HTTP ${res.status}`,
+      );
+    }
+    const parsed = (await res.json()) as Partial<KnowledgePageSearchResponse>;
+    const results = parsed.results ?? [];
+    return { results, total: parsed.total ?? results.length };
+  }
+
+  /**
+   * One page as a markdown document (YAML frontmatter + body).
+   *
+   * A pure read: upstream's handler resolves the page and renders it, with no
+   * lazy-refresh side effect, so reading a stale page never triggers a
+   * consolidation run. Staleness is reported by {@link KnowledgeAdmin.tree}
+   * instead.
+   */
+  async getPage(args: { page_id: string }): Promise<KnowledgePage> {
+    const res = await this.get(
+      `${this.knowledgeBasePath()}/pages/${encodeURIComponent(args.page_id)}`,
+    );
+    if (res.status === 404) {
+      throw new Error(
+        `no knowledge page '${args.page_id}' in bank '${this.opts.bankId}'. ` +
+          `Page ids come from search_knowledge_pages or get_knowledge_tree.`,
+      );
+    }
+    if (!res.ok) {
+      throw new Error(
+        `reading knowledge page '${args.page_id}' in bank ` +
+          `'${this.opts.bankId}' failed: HTTP ${res.status}`,
+      );
+    }
+    return (await res.json()) as KnowledgePage;
+  }
+
+  /** The pinned bank's folder/page tree, including per-page `is_stale`. */
+  async tree(): Promise<KnowledgeTree> {
+    const res = await this.get(`${this.knowledgeBasePath()}/tree`);
+    if (!res.ok) {
+      throw new Error(
+        `listing the knowledge tree in bank '${this.opts.bankId}' failed: HTTP ${res.status}`,
+      );
+    }
+    const parsed = (await res.json()) as Partial<KnowledgeTree>;
+    return { roots: parsed.roots ?? [] };
+  }
+}
+
+/**
+ * The COMPLETE inventory of `KnowledgeAdmin.prototype`'s own properties.
+ *
+ * Exported so the test can assert the member set directly rather than
+ * inferring read-only-ness from behaviour — the same mechanism-not-comment
+ * move as `buildDirectivePatchBody`'s key-set assertion. TypeScript's
+ * `private` is erased at runtime, so a `createPage` added anywhere in the
+ * class body appears here and reds the test, whether or not it is exported
+ * API.
+ */
+export const KNOWLEDGE_ADMIN_MEMBERS = [
+  "constructor",
+  "fetchImpl",
+  "get",
+  "getPage",
+  "knowledgeBasePath",
+  "search",
+  "tree",
+];

--- a/src/memory/hindsight-knowledge-admin.ts
+++ b/src/memory/hindsight-knowledge-admin.ts
@@ -103,10 +103,17 @@ export interface KnowledgeTree {
 
 /**
  * Search limit bounds, mirroring the upstream Query declaration
- * (`limit: int = Query(10, ge=1, le=50)`). Out-of-range is a 422 upstream, so
- * the value is clamped here rather than forwarded — a caller asking for 200
- * results gets the 50 the server can give, not a validation error it cannot
- * act on.
+ * (`limit: int = Query(10, ge=1, le=50)`).
+ *
+ * The clamp below is a LOWER-LAYER BACKSTOP, not the policy an agent sees.
+ * Out-of-range is a 422 upstream, so a non-shim caller of this module (a
+ * script, a future CLI subcommand) that asks for 200 gets the 50 the server
+ * can give rather than a validation error it cannot act on. The MCP shim layer
+ * does NOT rely on it: `coerceSynthesizedArg`
+ * (`src/cli/hindsight-mcp-shim.ts`) REJECTS an out-of-range `limit` before the
+ * call ever reaches here, because the bound is in the schema the model was
+ * shown and a silently-clamped `limit: 500` reads to the model as "you got 500
+ * hits" when it got 50. Two layers, two different right answers.
  */
 export const KNOWLEDGE_SEARCH_LIMIT_MIN = 1;
 export const KNOWLEDGE_SEARCH_LIMIT_MAX = 50;
@@ -138,6 +145,26 @@ export interface KnowledgeAdminOptions {
 }
 
 export const KNOWLEDGE_ADMIN_TIMEOUT_MS = 15_000;
+
+/**
+ * Accepted shape of a knowledge-node id.
+ *
+ * Matches what upstream actually mints: `create_knowledge_page` builds
+ * `f"kp-{uuid.uuid4().hex}"` and `create_knowledge_folder` the `kf-` twin
+ * (hindsight 0.9.0, `hindsight_api/engine/memory_engine.py:13477`), so
+ * `[A-Za-z0-9_-]+` covers every real id with room for a future uuid spelling
+ * that carries dashes.
+ *
+ * The reason it is enforced rather than merely documented is `.` and `..`:
+ * `encodeURIComponent("..")` is `..` verbatim, and the URL parser then
+ * collapses the segment, so `page_id: ".."` turns
+ * `.../knowledge-base/pages/..` into a GET of `.../knowledge-base/` — a
+ * different endpoint whose body would then be cast to `KnowledgePage` and
+ * handed to the agent as if it were a page. Not a bank-escape (single level,
+ * GET, own bank only), but an unintended endpoint is not something a page read
+ * should be able to reach.
+ */
+export const KNOWLEDGE_PAGE_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 
 /**
  * Read-only client for one bank's knowledge base.
@@ -210,8 +237,15 @@ export class KnowledgeAdmin {
       );
     }
     const parsed = (await res.json()) as Partial<KnowledgePageSearchResponse>;
-    const results = parsed.results ?? [];
-    return { results, total: parsed.total ?? results.length };
+    // `Array.isArray`, not `?? []`. A malformed `{"results": "stringy"}` has a
+    // truthy `.length`, so a nullish-coalesce alone would sail past the
+    // empty-result check and the shim would stringify a STRING as if it were
+    // the hit list — an isError:false answer that is not hits.
+    const results = Array.isArray(parsed.results) ? parsed.results : [];
+    return {
+      results,
+      total: typeof parsed.total === "number" ? parsed.total : results.length,
+    };
   }
 
   /**
@@ -223,6 +257,13 @@ export class KnowledgeAdmin {
    * instead.
    */
   async getPage(args: { page_id: string }): Promise<KnowledgePage> {
+    if (!KNOWLEDGE_PAGE_ID_PATTERN.test(args.page_id)) {
+      throw new Error(
+        `'${args.page_id}' is not a knowledge page id. Ids look like ` +
+          `'kp-<hex>' (letters, digits, '-' and '_' only) and come from ` +
+          `search_knowledge_pages or get_knowledge_tree.`,
+      );
+    }
     const res = await this.get(
       `${this.knowledgeBasePath()}/pages/${encodeURIComponent(args.page_id)}`,
     );
@@ -238,7 +279,20 @@ export class KnowledgeAdmin {
           `'${this.opts.bankId}' failed: HTTP ${res.status}`,
       );
     }
-    return (await res.json()) as KnowledgePage;
+    const page = (await res.json()) as Partial<KnowledgePage>;
+    // The ONLY field the caller actually renders. Unvalidated, a response that
+    // omits it (field rename on an image bump, or an explicit `markdown: null`)
+    // makes the shim emit `{"type":"text"}` with no `text` key — a content
+    // block that fails MCP client schema validation while `isError` is false,
+    // i.e. a read that silently failed. Fail loudly and name the page instead.
+    if (typeof page.markdown !== "string") {
+      throw new Error(
+        `knowledge page '${args.page_id}' in bank '${this.opts.bankId}' came ` +
+          `back with no markdown body — the response had no string 'markdown' ` +
+          `field, so there is nothing to read.`,
+      );
+    }
+    return page as KnowledgePage;
   }
 
   /** The pinned bank's folder/page tree, including per-page `is_stale`. */
@@ -250,7 +304,9 @@ export class KnowledgeAdmin {
       );
     }
     const parsed = (await res.json()) as Partial<KnowledgeTree>;
-    return { roots: parsed.roots ?? [] };
+    // Same hole as `search()`: a non-array `roots` must read as "no tree", not
+    // as a tree, or the shim renders a scalar as the agent's knowledge base.
+    return { roots: Array.isArray(parsed.roots) ? parsed.roots : [] };
   }
 }
 
@@ -259,10 +315,23 @@ export class KnowledgeAdmin {
  *
  * Exported so the test can assert the member set directly rather than
  * inferring read-only-ness from behaviour — the same mechanism-not-comment
- * move as `buildDirectivePatchBody`'s key-set assertion. TypeScript's
- * `private` is erased at runtime, so a `createPage` added anywhere in the
- * class body appears here and reds the test, whether or not it is exported
- * API.
+ * move as `buildDirectivePatchBody`'s key-set assertion.
+ *
+ * WHAT THIS COVERS, exactly: prototype members. TypeScript's `private` is
+ * erased at runtime, so a `createPage()` declared as a normal (or `private`)
+ * METHOD lands on the prototype, appears here, and reds
+ * `tests/hindsight-knowledge-admin.test.ts`.
+ *
+ * WHAT IT DOES NOT COVER, and why the test pairs it with two more assertions:
+ *   • a write installed as a class FIELD (`createPage = async () => …`) is an
+ *     INSTANCE own-property, not a prototype one — the test therefore also
+ *     asserts a constructed instance has no function-valued own key;
+ *   • a `static` method, and a plain exported module-level function, are on
+ *     neither — nothing here sees those. The backstop for both is the
+ *     behavioural assertion that no non-GET request ever reaches the mock API,
+ *     plus review of this file's diff.
+ * Neither this list nor the instance check is a substitute for reading the
+ * diff; they are the two cheap mechanical tripwires.
  */
 export const KNOWLEDGE_ADMIN_MEMBERS = [
   "constructor",

--- a/tests/hindsight-knowledge-admin.test.ts
+++ b/tests/hindsight-knowledge-admin.test.ts
@@ -30,7 +30,10 @@ import {
   type KnowledgePage,
   type KnowledgePageSearchResult,
 } from "../src/memory/hindsight-knowledge-admin.js";
-import { HindsightShim } from "../src/cli/hindsight-mcp-shim.js";
+import {
+  HindsightShim,
+  KNOWLEDGE_RESPONSE_MAX_CHARS,
+} from "../src/cli/hindsight-mcp-shim.js";
 
 // ─── stateful mock of the hindsight REST knowledge-base API ───────────────
 
@@ -52,6 +55,14 @@ interface MockApi {
   seen: SeenRequest[];
   /** Force the next N responses for a sub-path to this status. */
   failStatus: (subPath: string) => number | null;
+  /**
+   * Replace the 200 body for a sub-path with an arbitrary payload.
+   *
+   * Exists to reproduce a MALFORMED-but-successful response — the field a
+   * future image bump renames, the `null` where a string was promised. Those
+   * are the responses a client that only checks `res.ok` mis-handles.
+   */
+  bodyOverride: (subPath: string) => unknown | undefined;
   close: () => Promise<void>;
 }
 
@@ -64,6 +75,7 @@ async function startMockApi(
     banks,
     seen: [],
     failStatus: () => null,
+    bodyOverride: () => undefined,
     close: async () => undefined,
   };
 
@@ -87,6 +99,8 @@ async function startMockApi(
       const sub = m[2].startsWith("pages/") ? "pages" : m[2];
       const injected = state.failStatus(sub);
       if (injected !== null) return send(injected, { detail: "injected" });
+      const overridden = state.bodyOverride(sub);
+      if (overridden !== undefined) return send(200, overridden);
       const kb = state.banks[bank];
       if (!kb) return send(404, { detail: "no such bank" });
       // The real API accepts GET on all three. Anything else is a 405 here so
@@ -233,8 +247,8 @@ describe("GET-only — no write verb is reachable", () => {
   it("KnowledgeAdmin's prototype has exactly the read members, no more", () => {
     // Asserted as a key set rather than inferred from behaviour, the same way
     // buildDirectivePatchBody's whitelist is. TypeScript `private` is erased
-    // at runtime, so a `createPage` added anywhere in the class body appears
-    // here — exported or not.
+    // at runtime, so a `createPage` declared as a METHOD (private or not)
+    // lands on the prototype and shows up here.
     expect(Object.getOwnPropertyNames(KnowledgeAdmin.prototype).sort()).toEqual(
       [...KNOWLEDGE_ADMIN_MEMBERS].sort(),
     );
@@ -244,6 +258,31 @@ describe("GET-only — no write verb is reachable", () => {
         `${write} would make page authorship/deletion reachable from a tool call`,
       ).not.toContain(write);
     }
+  });
+
+  /**
+   * The prototype inventory alone is NOT the whole guard, and the header
+   * comment used to claim it was. A write installed as a class FIELD —
+   * `createPage = async () => fetch(url, {method: "POST"})` — is an INSTANCE
+   * own-property, so `KnowledgeAdmin.prototype` never sees it and the test
+   * above stays green while page authorship is fully reachable. This closes
+   * that half; `static` methods and module-level functions are covered by
+   * neither and are left to the no-mutating-request assertion plus review, as
+   * the corrected header now says.
+   */
+  it("a constructed KnowledgeAdmin carries no function-valued own property", () => {
+    const instance = new KnowledgeAdmin({
+      apiBaseUrl: api.baseUrl,
+      bankId: OWN_BANK,
+    }) as unknown as Record<string, unknown>;
+    const callable = Object.getOwnPropertyNames(instance).filter(
+      (k) => typeof instance[k] === "function",
+    );
+    expect(
+      callable,
+      `${callable.join(", ")} is a class FIELD holding a function — a write ` +
+        `installed this way is invisible to the prototype inventory`,
+    ).toEqual([]);
   });
 
   it("every public method issues GET and nothing else", async () => {
@@ -287,23 +326,47 @@ describe("bank pinning — every path embeds the agent's own bank", () => {
   });
 
   it("a page_id cannot path-traverse into a peer bank", async () => {
-    // encodeURIComponent means the traversal survives only as an inert,
-    // percent-encoded LEAF segment under our own bank — the separators never
-    // reach the router, so it 404s here instead of resolving the peer's page.
+    // Rejected by shape before a socket is opened — and even if the id regex
+    // were removed, encodeURIComponent would leave the traversal an inert,
+    // percent-encoded LEAF segment under our own bank.
     await expect(
       admin().getPage({ page_id: `../../${PEER_BANK}/knowledge-base/pages/pg-secret` }),
+    ).rejects.toThrow(/is not a knowledge page id/);
+    expect(api.seen).toHaveLength(0);
+  });
+
+  /**
+   * The defect: `encodeURIComponent("..")` is `..` VERBATIM (it is an
+   * unreserved-set string), so the URL parser collapses the segment and
+   * `.../knowledge-base/pages/..` becomes a GET of `.../knowledge-base/` — a
+   * different endpoint whose body was then cast to `KnowledgePage`. Not a
+   * bank escape, but a page read must not be able to retarget the request.
+   */
+  it("a dot-segment page_id is refused instead of retargeting the request", async () => {
+    for (const bad of ["..", ".", "../", "a/b", "pg conventions", ""]) {
+      await expect(
+        admin().getPage({ page_id: bad }),
+        `page_id ${JSON.stringify(bad)} must be refused by shape`,
+      ).rejects.toThrow(/is not a knowledge page id/);
+    }
+    // Not one of them reached the network.
+    expect(api.seen).toHaveLength(0);
+
+    // ...and the real id spelling upstream mints (`kp-<uuid4 hex>`,
+    // memory_engine.py:13477) still passes the gate and is routed as a page.
+    await expect(
+      admin().getPage({ page_id: "kp-0123456789abcdef0123456789abcdef" }),
     ).rejects.toThrow(/no knowledge page/);
     expect(api.seen).toHaveLength(1);
-    const [prefix, id] = [
-      api.seen[0].path.slice(0, api.seen[0].path.lastIndexOf("/")),
-      api.seen[0].path.slice(api.seen[0].path.lastIndexOf("/") + 1),
-    ];
-    // The routed part of the URL is entirely ours.
-    expect(prefix).toBe(`/v1/default/banks/${OWN_BANK}/knowledge-base/pages`);
-    expect(prefix).not.toContain(PEER_BANK);
-    // ...and the peer's name only ever appears escaped inside the id.
-    expect(id).not.toContain("/");
-    expect(id).toContain(encodeURIComponent(`../../${PEER_BANK}/`));
+    expect(api.seen[0].path).toBe(
+      `/v1/default/banks/${OWN_BANK}/knowledge-base/pages/kp-0123456789abcdef0123456789abcdef`,
+    );
+
+    await withShim(OWN_BANK, async (shim) => {
+      const res = await callTool(shim, "get_knowledge_page", { page_id: ".." });
+      expect(res.isError).toBe(true);
+      expect(res.text).toMatch(/is not a knowledge page id/);
+    });
   });
 
   it("the tool schemas expose no bank_id, and a bank_id argument is REJECTED", async () => {
@@ -451,5 +514,230 @@ describe("results and failure text", () => {
     await expect(admin().getPage({ page_id: "pg-conventions" })).rejects.toThrow(
       /HTTP 503/,
     );
+  });
+
+  it("search reports the TOTAL alongside the hits, not the hits alone", async () => {
+    // With `results` alone the model cannot tell a complete set from one the
+    // limit cut short — 10 of 200 hits reads as "there are 10".
+    await withShim(OWN_BANK, async (shim) => {
+      const res = await callTool(shim, "search_knowledge_pages", {
+        query: "Use",
+      });
+      expect(res.isError).toBe(false);
+      const parsed = JSON.parse(res.text) as {
+        total: number;
+        results: { id: string }[];
+      };
+      expect(parsed.total).toBe(1);
+      expect(parsed.results.map((r) => r.id)).toEqual(["pg-conventions"]);
+    });
+  });
+});
+
+// ─── 5. malformed-but-successful responses ────────────────────────────────
+
+/**
+ * HTTP 200 is not a promise about the BODY. A field rename on an image bump,
+ * or an explicit `null`, yields a successful response whose payload is not the
+ * shape the caller casts it to — and a cast is not a check. Each test here
+ * pins the failure mode that response used to produce.
+ */
+describe("a 200 with the wrong body shape", () => {
+  it("a page with no markdown is a loud failure, not a text-less content block", async () => {
+    api.bodyOverride = (sub) =>
+      sub === "pages"
+        ? {
+            id: "pg-conventions",
+            name: "Conventions",
+            type: "knowledge-page",
+            body: "Use tabs.",
+            // `markdown` renamed away upstream — the field the shim renders.
+          }
+        : undefined;
+    await expect(
+      admin().getPage({ page_id: "pg-conventions" }),
+    ).rejects.toThrow(/no markdown body/);
+
+    await withShim(OWN_BANK, async (shim) => {
+      const res = (await shim.handle({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "get_knowledge_page",
+          arguments: { page_id: "pg-conventions" },
+        },
+      })) as {
+        result: { isError: boolean; content: { type: string; text?: string }[] };
+      };
+      // Unfixed, this returned `{type:"text"}` with NO text key and
+      // isError:false — a block that fails MCP client schema validation while
+      // claiming success, i.e. a read that silently failed.
+      expect(res.result.isError).toBe(true);
+      expect(typeof res.result.content[0].text).toBe("string");
+      expect(res.result.content[0].text).toContain("pg-conventions");
+    });
+  });
+
+  it("a null markdown is refused the same way", async () => {
+    api.bodyOverride = (sub) =>
+      sub === "pages"
+        ? { id: "pg-conventions", name: "Conventions", markdown: null }
+        : undefined;
+    await expect(
+      admin().getPage({ page_id: "pg-conventions" }),
+    ).rejects.toThrow(/no markdown body/);
+  });
+
+  it("a non-array `results` is no results, never echoed as if it were hits", async () => {
+    // `"stringy".length` is truthy, so a `?? []` fallback sailed past the
+    // empty check and the shim stringified a STRING as the hit list.
+    api.bodyOverride = (sub) =>
+      sub === "search" ? { results: "stringy", total: 7 } : undefined;
+    const res = await admin().search({ query: "Use" });
+    expect(res.results).toEqual([]);
+
+    await withShim(OWN_BANK, async (shim) => {
+      const out = await callTool(shim, "search_knowledge_pages", {
+        query: "Use",
+      });
+      expect(out.isError).toBe(false);
+      expect(out.text).toMatch(/no knowledge pages/i);
+      expect(out.text).not.toContain("stringy");
+    });
+  });
+
+  it("a non-array `roots` is an empty tree, never rendered as a tree", async () => {
+    api.bodyOverride = (sub) => (sub === "tree" ? { roots: "stringy" } : undefined);
+    expect((await admin().tree()).roots).toEqual([]);
+
+    await withShim(OWN_BANK, async (shim) => {
+      const out = await callTool(shim, "get_knowledge_tree", {});
+      expect(out.isError).toBe(false);
+      expect(out.text).toMatch(/no pages yet/i);
+      expect(out.text).not.toContain("stringy");
+    });
+  });
+});
+
+// ─── 6. response size caps ────────────────────────────────────────────────
+
+/**
+ * The forwarded reads are token-budgeted (`DEFAULT_RECALL_MAX_TOKENS`) because
+ * an unbounded payload silently overruns the MCP output cap and never lands in
+ * the agent's context. The knowledge reads had no equivalent ceiling.
+ *
+ * The marker is as load-bearing as the cut: a silently-truncated page reads to
+ * the model as a complete page that simply ends.
+ */
+describe("oversized responses are capped, and say so", () => {
+  it("a page longer than the char budget is cut with an explicit marker", async () => {
+    const huge = "x".repeat(KNOWLEDGE_RESPONSE_MAX_CHARS + 5_000);
+    api.bodyOverride = (sub) =>
+      sub === "pages"
+        ? { id: "pg-conventions", name: "Conventions", markdown: huge }
+        : undefined;
+
+    // The REST layer still returns the whole document — the cap is the shim's
+    // rendering decision, not a lie told to every caller of KnowledgeAdmin.
+    expect((await admin().getPage({ page_id: "pg-conventions" })).markdown)
+      .toHaveLength(huge.length);
+
+    await withShim(OWN_BANK, async (shim) => {
+      const res = await callTool(shim, "get_knowledge_page", {
+        page_id: "pg-conventions",
+      });
+      expect(res.isError).toBe(false);
+      expect(res.text.length).toBeLessThan(huge.length);
+      expect(res.text).toMatch(/truncated at \d+ chars/);
+      expect(res.text).toContain("PARTIAL");
+      expect(res.text).toContain("5000 chars omitted");
+    });
+  });
+
+  it("a page inside the budget is returned byte-for-byte", async () => {
+    await withShim(OWN_BANK, async (shim) => {
+      const res = await callTool(shim, "get_knowledge_page", {
+        page_id: "pg-conventions",
+      });
+      expect(res.text).toBe("---\nname: Conventions\n---\n\nUse tabs.\n");
+      expect(res.text).not.toContain("truncated");
+    });
+  });
+
+  it("an oversized tree is capped, stays parseable JSON, and states the omission", async () => {
+    const total = 700;
+    const roots: KnowledgeNode[] = Array.from({ length: total }, (_, i) => ({
+      id: `kp-${i}`,
+      kind: "page" as const,
+      name: `Page ${i}`,
+      is_stale: false,
+    }));
+    api.bodyOverride = (sub) => (sub === "tree" ? { roots } : undefined);
+
+    await withShim(OWN_BANK, async (shim) => {
+      const res = await callTool(shim, "get_knowledge_tree", {});
+      expect(res.isError).toBe(false);
+      expect(res.text).toMatch(
+        new RegExp(`…\\d+ of ${total} nodes omitted`),
+      );
+      expect(res.text).toContain("PARTIAL");
+      // The whole render — JSON plus its own footnote — fits the budget.
+      expect(res.text.length).toBeLessThanOrEqual(KNOWLEDGE_RESPONSE_MAX_CHARS);
+      // A char-level cut of JSON would leave an unparseable document — worse
+      // than no answer. The prune is by node, so this always parses.
+      const json = res.text.slice(0, res.text.indexOf("\n…"));
+      const parsed = JSON.parse(json) as KnowledgeNode[];
+      expect(parsed.length).toBeGreaterThan(0);
+      expect(parsed.length).toBeLessThan(total);
+      expect(parsed[0].id).toBe("kp-0");
+      // The stated count is the truth, not an estimate.
+      const omitted = Number(
+        /…(\d+) of \d+ nodes omitted/.exec(res.text)![1],
+      );
+      expect(parsed.length + omitted).toBe(total);
+    });
+  });
+
+  it("a nested tree is pruned depth-first, never leaving an orphan child", async () => {
+    // A folder must never be dropped while its children survive: the ids
+    // would be unreachable and the shape a lie about the bank's layout.
+    const roots: KnowledgeNode[] = Array.from({ length: 60 }, (_, i) => ({
+      id: `kf-${i}`,
+      kind: "folder" as const,
+      name: `Folder ${i} ${"pad".repeat(30)}`,
+      children: Array.from({ length: 20 }, (_, j) => ({
+        id: `kp-${i}-${j}`,
+        kind: "page" as const,
+        name: `Page ${i}/${j} ${"pad".repeat(30)}`,
+      })),
+    }));
+    api.bodyOverride = (sub) => (sub === "tree" ? { roots } : undefined);
+    await withShim(OWN_BANK, async (shim) => {
+      const res = await callTool(shim, "get_knowledge_tree", {});
+      expect(res.text.length).toBeLessThanOrEqual(KNOWLEDGE_RESPONSE_MAX_CHARS);
+      const parsed = JSON.parse(
+        res.text.slice(0, res.text.indexOf("\n…")),
+      ) as KnowledgeNode[];
+      expect(parsed.length).toBeGreaterThan(0);
+      expect(parsed.length).toBeLessThan(roots.length);
+      // Every retained child sits under a retained folder, by construction.
+      for (const folder of parsed) {
+        expect(folder.kind).toBe("folder");
+        for (const child of folder.children ?? []) {
+          expect(child.id.startsWith(`${folder.id.replace("kf-", "kp-")}-`)).toBe(
+            true,
+          );
+        }
+      }
+    });
+  });
+
+  it("a small tree is rendered whole, with no omission marker", async () => {
+    await withShim(OWN_BANK, async (shim) => {
+      const res = await callTool(shim, "get_knowledge_tree", {});
+      expect(res.text).not.toContain("omitted");
+      expect(JSON.parse(res.text)).toHaveLength(1);
+    });
   });
 });

--- a/tests/hindsight-knowledge-admin.test.ts
+++ b/tests/hindsight-knowledge-admin.test.ts
@@ -1,0 +1,455 @@
+/**
+ * Outcome tests for the knowledge-page READ path — `KnowledgeAdmin`
+ * (src/memory/hindsight-knowledge-admin.ts) and the three shim-synthesized MCP
+ * tools that wrap it (src/cli/hindsight-mcp-shim.ts).
+ *
+ * These drive the real modules against a stateful mock of the hindsight REST
+ * knowledge-base API and assert the REQUESTS THAT ACTUALLY REACHED IT plus the
+ * text the agent ends up seeing — not that a code path ran. Each guard fails
+ * on the specific defect it exists for:
+ *
+ *   • GET-only        — add any write and either the prototype inventory or
+ *                       the "no non-GET verb was ever sent" assertion reds
+ *   • bank pinning    — remove the pin and the request lands on a peer bank
+ *   • limit clamping  — forward an out-of-range limit and the server 422s
+ *   • honest failure  — a 404/500 surfaces as an isError result naming the id
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServer, type Server } from "node:http";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  KnowledgeAdmin,
+  KNOWLEDGE_ADMIN_MEMBERS,
+  KNOWLEDGE_SEARCH_LIMIT_DEFAULT,
+  KNOWLEDGE_SEARCH_LIMIT_MAX,
+  clampKnowledgeSearchLimit,
+  type KnowledgeNode,
+  type KnowledgePage,
+  type KnowledgePageSearchResult,
+} from "../src/memory/hindsight-knowledge-admin.js";
+import { HindsightShim } from "../src/cli/hindsight-mcp-shim.js";
+
+// ─── stateful mock of the hindsight REST knowledge-base API ───────────────
+
+interface SeenRequest {
+  method: string;
+  path: string;
+}
+
+interface BankKnowledge {
+  pages: Record<string, KnowledgePage>;
+  hits: KnowledgePageSearchResult[];
+  roots: KnowledgeNode[];
+}
+
+interface MockApi {
+  baseUrl: string;
+  server: Server;
+  banks: Record<string, BankKnowledge>;
+  seen: SeenRequest[];
+  /** Force the next N responses for a sub-path to this status. */
+  failStatus: (subPath: string) => number | null;
+  close: () => Promise<void>;
+}
+
+async function startMockApi(
+  banks: Record<string, BankKnowledge>,
+): Promise<MockApi> {
+  const state: MockApi = {
+    baseUrl: "",
+    server: undefined as unknown as Server,
+    banks,
+    seen: [],
+    failStatus: () => null,
+    close: async () => undefined,
+  };
+
+  const server = createServer((req, res) => {
+    req.on("data", () => undefined);
+    req.on("end", () => {
+      const path = req.url ?? "";
+      state.seen.push({ method: req.method ?? "", path });
+      const send = (status: number, payload: unknown) => {
+        res.writeHead(status, { "content-type": "application/json" });
+        res.end(JSON.stringify(payload));
+      };
+      const [rawPath, rawQuery] = path.split("?");
+      const query = new URLSearchParams(rawQuery ?? "");
+      const m =
+        /^\/v1\/default\/banks\/([^/]+)\/knowledge-base\/(tree|search|pages\/([^/]+))$/.exec(
+          rawPath,
+        );
+      if (!m) return send(404, { detail: "not found" });
+      const bank = decodeURIComponent(m[1]);
+      const sub = m[2].startsWith("pages/") ? "pages" : m[2];
+      const injected = state.failStatus(sub);
+      if (injected !== null) return send(injected, { detail: "injected" });
+      const kb = state.banks[bank];
+      if (!kb) return send(404, { detail: "no such bank" });
+      // The real API accepts GET on all three. Anything else is a 405 here so
+      // an accidental write shows up as a failure, not as a silent success.
+      if (req.method !== "GET") return send(405, { detail: "method not allowed" });
+
+      if (sub === "tree") return send(200, { roots: kb.roots });
+      if (sub === "search") {
+        // Mirror the REAL upstream Query constraints — ge=1, le=50 — because
+        // those are exactly what an unclamped forward would trip.
+        const q = query.get("q") ?? "";
+        if (q.length === 0) return send(422, { detail: "q too short" });
+        const limit = Number(query.get("limit") ?? "10");
+        if (!Number.isInteger(limit) || limit < 1 || limit > 50) {
+          return send(422, { detail: "limit out of range" });
+        }
+        const results = kb.hits
+          .filter((h) => h.name.includes(q) || h.snippet.includes(q))
+          .slice(0, limit);
+        return send(200, { results, total: results.length });
+      }
+      const pageId = decodeURIComponent(m[3]);
+      const page = kb.pages[pageId];
+      if (!page) return send(404, { detail: `Knowledge page '${pageId}' not found` });
+      return send(200, page);
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const port = (server.address() as { port: number }).port;
+  state.baseUrl = `http://127.0.0.1:${port}`;
+  state.server = server;
+  state.close = () => new Promise((r) => server.close(() => r()));
+  return state;
+}
+
+const OWN_BANK = "agent-own-bank";
+const PEER_BANK = "peer-bank";
+
+function fixtureBanks(): Record<string, BankKnowledge> {
+  return {
+    [OWN_BANK]: {
+      pages: {
+        "pg-conventions": {
+          id: "pg-conventions",
+          name: "Conventions",
+          type: "knowledge-page",
+          description: "How this project writes code",
+          tags: ["arch"],
+          timestamp: "2026-08-01T00:00:00Z",
+          body: "Use tabs.",
+          markdown: "---\nname: Conventions\n---\n\nUse tabs.\n",
+        },
+      },
+      hits: [
+        {
+          id: "pg-conventions",
+          name: "Conventions",
+          mental_model_id: "mm-1",
+          snippet: "Use tabs.",
+          score: 0.91,
+          updated_at: "2026-08-01T00:00:00Z",
+        },
+      ],
+      roots: [
+        {
+          id: "pg-conventions",
+          kind: "page",
+          name: "Conventions",
+          is_stale: false,
+          children: [],
+        },
+      ],
+    },
+    [PEER_BANK]: {
+      pages: {
+        "pg-secret": {
+          id: "pg-secret",
+          name: "Peer secrets",
+          type: "knowledge-page",
+          markdown: "PEER ONLY",
+        },
+      },
+      hits: [
+        { id: "pg-secret", name: "Peer secrets", snippet: "PEER ONLY", score: 1 },
+      ],
+      roots: [{ id: "pg-secret", kind: "page", name: "Peer secrets" }],
+    },
+    // An agent whose bank has never been consolidated into pages.
+    "empty-bank": { pages: {}, hits: [], roots: [] },
+  };
+}
+
+let api: MockApi;
+beforeEach(async () => {
+  api = await startMockApi(fixtureBanks());
+});
+afterEach(async () => {
+  await api.close();
+});
+
+function admin(bankId = OWN_BANK): KnowledgeAdmin {
+  return new KnowledgeAdmin({ apiBaseUrl: api.baseUrl, bankId, timeoutMs: 5_000 });
+}
+
+async function withShim<T>(
+  bankId: string,
+  fn: (shim: HindsightShim) => Promise<T>,
+): Promise<T> {
+  const cacheDir = mkdtempSync(join(tmpdir(), "shim-knowledge-test-"));
+  try {
+    return await fn(
+      new HindsightShim({
+        // /mcp/ on the mock answers 404 — proving a synthesized call never
+        // touches the MCP transport, only the REST endpoints.
+        url: `${api.baseUrl}/mcp/`,
+        bankId,
+        cacheDir,
+        toolsListTimeoutMs: 500,
+        logger: () => undefined,
+      }),
+    );
+  } finally {
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+}
+
+async function callTool(
+  shim: HindsightShim,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ isError: boolean; text: string }> {
+  const res = (await shim.handle({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name, arguments: args },
+  })) as { result: { isError: boolean; content: { text: string }[] } };
+  return { isError: res.result.isError, text: res.result.content[0].text };
+}
+
+// ─── 1. read-only by construction ─────────────────────────────────────────
+
+describe("GET-only — no write verb is reachable", () => {
+  it("KnowledgeAdmin's prototype has exactly the read members, no more", () => {
+    // Asserted as a key set rather than inferred from behaviour, the same way
+    // buildDirectivePatchBody's whitelist is. TypeScript `private` is erased
+    // at runtime, so a `createPage` added anywhere in the class body appears
+    // here — exported or not.
+    expect(Object.getOwnPropertyNames(KnowledgeAdmin.prototype).sort()).toEqual(
+      [...KNOWLEDGE_ADMIN_MEMBERS].sort(),
+    );
+    for (const write of ["createPage", "createFolder", "patch", "delete", "send"]) {
+      expect(
+        Object.getOwnPropertyNames(KnowledgeAdmin.prototype),
+        `${write} would make page authorship/deletion reachable from a tool call`,
+      ).not.toContain(write);
+    }
+  });
+
+  it("every public method issues GET and nothing else", async () => {
+    await admin().search({ query: "Use" });
+    await admin().getPage({ page_id: "pg-conventions" });
+    await admin().tree();
+    expect(api.seen.length).toBe(3);
+    expect(api.seen.map((r) => r.method)).toEqual(["GET", "GET", "GET"]);
+  });
+
+  it("the whole synthesized knowledge surface sends no mutating request", async () => {
+    await withShim(OWN_BANK, async (shim) => {
+      await callTool(shim, "search_knowledge_pages", { query: "Use" });
+      await callTool(shim, "get_knowledge_page", { page_id: "pg-conventions" });
+      await callTool(shim, "get_knowledge_tree", {});
+    });
+    expect(api.seen.length).toBeGreaterThan(0);
+    for (const r of api.seen) {
+      expect(
+        r.method,
+        `a knowledge tool sent ${r.method} ${r.path} — this surface is reads only`,
+      ).toBe("GET");
+    }
+    // ...and none of it went through the MCP transport.
+    expect(api.seen.some((r) => r.path.startsWith("/mcp"))).toBe(false);
+  });
+});
+
+// ─── 2. the bank pin ──────────────────────────────────────────────────────
+
+describe("bank pinning — every path embeds the agent's own bank", () => {
+  it("builds all three URLs under the pinned bank", async () => {
+    await admin().search({ query: "Use" });
+    await admin().getPage({ page_id: "pg-conventions" });
+    await admin().tree();
+    expect(api.seen.map((r) => r.path.split("?")[0])).toEqual([
+      `/v1/default/banks/${OWN_BANK}/knowledge-base/search`,
+      `/v1/default/banks/${OWN_BANK}/knowledge-base/pages/pg-conventions`,
+      `/v1/default/banks/${OWN_BANK}/knowledge-base/tree`,
+    ]);
+  });
+
+  it("a page_id cannot path-traverse into a peer bank", async () => {
+    // encodeURIComponent means the traversal survives only as an inert,
+    // percent-encoded LEAF segment under our own bank — the separators never
+    // reach the router, so it 404s here instead of resolving the peer's page.
+    await expect(
+      admin().getPage({ page_id: `../../${PEER_BANK}/knowledge-base/pages/pg-secret` }),
+    ).rejects.toThrow(/no knowledge page/);
+    expect(api.seen).toHaveLength(1);
+    const [prefix, id] = [
+      api.seen[0].path.slice(0, api.seen[0].path.lastIndexOf("/")),
+      api.seen[0].path.slice(api.seen[0].path.lastIndexOf("/") + 1),
+    ];
+    // The routed part of the URL is entirely ours.
+    expect(prefix).toBe(`/v1/default/banks/${OWN_BANK}/knowledge-base/pages`);
+    expect(prefix).not.toContain(PEER_BANK);
+    // ...and the peer's name only ever appears escaped inside the id.
+    expect(id).not.toContain("/");
+    expect(id).toContain(encodeURIComponent(`../../${PEER_BANK}/`));
+  });
+
+  it("the tool schemas expose no bank_id, and a bank_id argument is REJECTED", async () => {
+    await withShim(OWN_BANK, async (shim) => {
+      const list = (await shim.handle({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+      })) as { result: { tools: { name: string; inputSchema: unknown }[] } };
+      for (const name of [
+        "search_knowledge_pages",
+        "get_knowledge_page",
+        "get_knowledge_tree",
+      ]) {
+        const tool = list.result.tools.find((t) => t.name === name)!;
+        expect(tool, `${name} is not advertised`).toBeDefined();
+        expect(
+          Object.keys(
+            (tool.inputSchema as { properties: Record<string, unknown> })
+              .properties,
+          ),
+        ).not.toContain("bank_id");
+      }
+
+      const mark = api.seen.length;
+      const res = await callTool(shim, "search_knowledge_pages", {
+        query: "Peer",
+        bank_id: PEER_BANK,
+      });
+      expect(res.isError).toBe(true);
+      expect(res.text).toContain("bank_id");
+      expect(res.text).toContain("your own memory bank");
+      // Nothing was read from anywhere.
+      expect(api.seen.slice(mark)).toEqual([]);
+    });
+  });
+
+  it("refuses to act when the agent has no pinned bank", async () => {
+    await withShim("", async (shim) => {
+      const res = await callTool(shim, "get_knowledge_tree", {});
+      expect(res.isError).toBe(true);
+      expect(res.text).toContain("HINDSIGHT_BANK_ID");
+    });
+  });
+});
+
+// ─── 3. limit handling ────────────────────────────────────────────────────
+
+describe("search limit", () => {
+  it("clamps to the server's accepted range instead of 422ing", () => {
+    expect(clampKnowledgeSearchLimit(undefined)).toBe(
+      KNOWLEDGE_SEARCH_LIMIT_DEFAULT,
+    );
+    expect(clampKnowledgeSearchLimit(0)).toBe(1);
+    expect(clampKnowledgeSearchLimit(-5)).toBe(1);
+    expect(clampKnowledgeSearchLimit(999)).toBe(KNOWLEDGE_SEARCH_LIMIT_MAX);
+    expect(clampKnowledgeSearchLimit(7)).toBe(7);
+    expect(clampKnowledgeSearchLimit(7.9)).toBe(7);
+    expect(clampKnowledgeSearchLimit(Number.NaN)).toBe(
+      KNOWLEDGE_SEARCH_LIMIT_DEFAULT,
+    );
+  });
+
+  it("an out-of-range limit reaches the server clamped, and still returns hits", async () => {
+    // The mock 422s on a limit outside 1..50 exactly as upstream does, so an
+    // unclamped forward fails this test rather than merely looking untidy.
+    const res = await admin().search({ query: "Use", limit: 5_000 });
+    expect(res.results).toHaveLength(1);
+    expect(api.seen[0].path).toContain(`limit=${KNOWLEDGE_SEARCH_LIMIT_MAX}`);
+  });
+
+  it("omitting limit sends the documented default", async () => {
+    await admin().search({ query: "Use" });
+    expect(api.seen[0].path).toContain(
+      `limit=${KNOWLEDGE_SEARCH_LIMIT_DEFAULT}`,
+    );
+  });
+});
+
+// ─── 4. results, empties and failures ─────────────────────────────────────
+
+describe("results and failure text", () => {
+  it("returns the hit fields the agent needs to follow up", async () => {
+    const res = await admin().search({ query: "Use" });
+    expect(res.total).toBe(1);
+    expect(res.results[0].id).toBe("pg-conventions");
+    expect(res.results[0].score).toBeCloseTo(0.91);
+  });
+
+  it("a page read returns the full markdown document", async () => {
+    const page = await admin().getPage({ page_id: "pg-conventions" });
+    expect(page.markdown).toContain("Use tabs.");
+    await withShim(OWN_BANK, async (shim) => {
+      const res = await callTool(shim, "get_knowledge_page", {
+        page_id: "pg-conventions",
+      });
+      expect(res.isError).toBe(false);
+      // The page IS a markdown document — returned verbatim, not re-wrapped.
+      expect(res.text).toBe(page.markdown);
+    });
+  });
+
+  it("an EMPTY knowledge base is an empty result, never an error", async () => {
+    const search = await admin("empty-bank").search({ query: "anything" });
+    expect(search.results).toEqual([]);
+    expect(search.total).toBe(0);
+    expect((await admin("empty-bank").tree()).roots).toEqual([]);
+
+    await withShim("empty-bank", async (shim) => {
+      const s = await callTool(shim, "search_knowledge_pages", { query: "x" });
+      expect(s.isError).toBe(false);
+      expect(s.text).toMatch(/no knowledge pages/i);
+      const t = await callTool(shim, "get_knowledge_tree", {});
+      expect(t.isError).toBe(false);
+      expect(t.text).toMatch(/no pages yet/i);
+    });
+  });
+
+  it("a 404 page names the id and where ids come from", async () => {
+    await expect(admin().getPage({ page_id: "pg-nope" })).rejects.toThrow(
+      /no knowledge page 'pg-nope'/,
+    );
+    await withShim(OWN_BANK, async (shim) => {
+      const res = await callTool(shim, "get_knowledge_page", {
+        page_id: "pg-nope",
+      });
+      expect(res.isError).toBe(true);
+      expect(res.text).toContain("pg-nope");
+      expect(res.text).toContain("get_knowledge_tree");
+    });
+  });
+
+  it("a 500 surfaces as an isError result naming the status, not a crash", async () => {
+    api.failStatus = (sub) => (sub === "search" ? 500 : null);
+    await expect(admin().search({ query: "Use" })).rejects.toThrow(/HTTP 500/);
+    await withShim(OWN_BANK, async (shim) => {
+      const res = await callTool(shim, "search_knowledge_pages", { query: "Use" });
+      expect(res.isError).toBe(true);
+      expect(res.text).toContain("HTTP 500");
+    });
+
+    api.failStatus = (sub) => (sub === "tree" ? 500 : null);
+    await expect(admin().tree()).rejects.toThrow(/HTTP 500/);
+    api.failStatus = (sub) => (sub === "pages" ? 503 : null);
+    await expect(admin().getPage({ page_id: "pg-conventions" })).rejects.toThrow(
+      /HTTP 503/,
+    );
+  });
+});

--- a/tests/hindsight-mcp-shim.test.ts
+++ b/tests/hindsight-mcp-shim.test.ts
@@ -1073,10 +1073,27 @@ describe("synthesized knowledge-page tools", () => {
       coerceSynthesizedArg("search_knowledge_pages", "limit", spec.props.limit, v);
     expect(arg(5)).toEqual({ ok: true, value: 5 });
     expect(arg("5")).toEqual({ ok: true, value: 5 });
-    expect(arg(" 5 ")).toEqual({ ok: true, value: 5 });
     expect(arg(1)).toEqual({ ok: true, value: 1 });
     expect(arg(50)).toEqual({ ok: true, value: 50 });
-    for (const bad of [0, 51, -1, 2.5, "abc", "", true, null, {}]) {
+    // The accepted STRING spelling is exact: no surrounding whitespace, no
+    // leading zeros. `" 5 "`, `"01"` and `"50\n"` are not what an MCP client's
+    // number stringification emits, so taking them means silently accepting a
+    // mangled argument as though the caller had meant it that way.
+    for (const bad of [
+      0,
+      51,
+      -1,
+      2.5,
+      "abc",
+      "",
+      " 5 ",
+      "01",
+      "50\n",
+      Number.MAX_SAFE_INTEGER + 2,
+      true,
+      null,
+      {},
+    ]) {
       const r = arg(bad);
       expect(r.ok, `${JSON.stringify(bad)} must not be an accepted limit`).toBe(
         false,

--- a/tests/hindsight-mcp-shim.test.ts
+++ b/tests/hindsight-mcp-shim.test.ts
@@ -25,6 +25,8 @@ import {
   TOOLS_CACHE_FILENAME,
   SHIM_SUPPORTED_PROTOCOL_VERSIONS,
   SYNTHESIZED_TOOL_NAMES,
+  SYNTHESIZED_TOOL_TABLE,
+  coerceSynthesizedArg,
   guardAndClampToolCall,
   DEFAULT_RECALL_MAX_TOKENS,
   DEFAULT_RECALL_BUDGET,
@@ -989,5 +991,170 @@ describe("reflect re-roll through the live shim", () => {
     );
     expect(n).toBe(1);
     await backend.close();
+  });
+});
+
+// ─── 8. the synthesized knowledge-page reads ──────────────────────────────
+
+/**
+ * The knowledge tools are shim-local, so their contract must hold with the
+ * backend DOWN — that is the whole reason they are synthesized rather than
+ * forwarded. The REST-backed behaviour lives in
+ * tests/hindsight-knowledge-admin.test.ts; what is pinned here is the shim
+ * half: advertisement, argument validation, and that validation happens
+ * before any network I/O.
+ */
+describe("synthesized knowledge-page tools", () => {
+  it("are advertised with the backend dead, schemas intact", async () => {
+    const shim = makeShim({ url: await deadUrl(), cacheDir });
+    const res = await shim.handle(rpc(1, "tools/list") as never);
+    const { tools } = res?.result as {
+      tools: { name: string; inputSchema: { properties: Record<string, unknown>; required: string[] } }[];
+    };
+    const byName = new Map(tools.map((t) => [t.name, t]));
+    for (const n of [
+      "search_knowledge_pages",
+      "get_knowledge_page",
+      "get_knowledge_tree",
+    ]) {
+      expect(SYNTHESIZED_TOOL_NAMES).toContain(n);
+      expect(byName.has(n), `${n} missing from the served manifest`).toBe(true);
+    }
+    expect(byName.get("search_knowledge_pages")!.inputSchema.required).toEqual([
+      "query",
+    ]);
+    expect(
+      byName.get("search_knowledge_pages")!.inputSchema.properties.limit,
+    ).toMatchObject({ type: "integer", minimum: 1, maximum: 50 });
+    expect(byName.get("get_knowledge_page")!.inputSchema.required).toEqual([
+      "page_id",
+    ]);
+    expect(byName.get("get_knowledge_tree")!.inputSchema.required).toEqual([]);
+  });
+
+  it("rejects an unknown argument locally, naming bank_id explicitly", async () => {
+    const shim = makeShim({ url: await deadUrl(), cacheDir });
+    const res = await shim.handle(
+      rpc(2, "tools/call", {
+        name: "get_knowledge_tree",
+        arguments: { bank_id: "someone-elses-bank" },
+      }) as never,
+    );
+    const result = res?.result as { isError: boolean; content: { text: string }[] };
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("bank_id");
+    expect(result.content[0].text).toContain("your own memory bank");
+    // NOT the forwarded "memory is temporarily unavailable" path: the backend
+    // is dead and the answer still came from the shim.
+    expect(result.content[0].text).not.toMatch(/temporarily unavailable/i);
+  });
+
+  it("requires the declared required argument", async () => {
+    const shim = makeShim({ url: await deadUrl(), cacheDir });
+    const res = await shim.handle(
+      rpc(3, "tools/call", {
+        name: "search_knowledge_pages",
+        arguments: {},
+      }) as never,
+    );
+    const result = res?.result as { isError: boolean; content: { text: string }[] };
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe("search_knowledge_pages requires 'query'.");
+  });
+
+  /**
+   * The regression this exists for: the validator used to require EVERY
+   * argument to be a non-empty string, so a schema-legal `limit: 5` was
+   * rejected with an error the model could not act on.
+   */
+  it("accepts an integer limit and a numeric string, rejects the rest", () => {
+    const spec = SYNTHESIZED_TOOL_TABLE.search_knowledge_pages;
+    const arg = (v: unknown) =>
+      coerceSynthesizedArg("search_knowledge_pages", "limit", spec.props.limit, v);
+    expect(arg(5)).toEqual({ ok: true, value: 5 });
+    expect(arg("5")).toEqual({ ok: true, value: 5 });
+    expect(arg(" 5 ")).toEqual({ ok: true, value: 5 });
+    expect(arg(1)).toEqual({ ok: true, value: 1 });
+    expect(arg(50)).toEqual({ ok: true, value: 50 });
+    for (const bad of [0, 51, -1, 2.5, "abc", "", true, null, {}]) {
+      const r = arg(bad);
+      expect(r.ok, `${JSON.stringify(bad)} must not be an accepted limit`).toBe(
+        false,
+      );
+      if (!r.ok) expect(r.text).toContain("integer");
+    }
+    // Out-of-range says the range rather than silently clamping — a clamped
+    // 500 reads to the model as "you got 500 hits".
+    const over = arg(500);
+    expect(over.ok).toBe(false);
+    if (!over.ok) {
+      expect(over.text).toContain("between 1 and 50");
+      expect(over.text).toContain("500");
+    }
+  });
+
+  it("still rejects an empty STRING argument (the old rule is intact)", () => {
+    const spec = SYNTHESIZED_TOOL_TABLE.search_knowledge_pages;
+    const r = coerceSynthesizedArg(
+      "search_knowledge_pages",
+      "query",
+      spec.props.query,
+      "",
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.text).toContain("non-empty string");
+    expect(
+      coerceSynthesizedArg(
+        "deactivate_directive",
+        "superseded_by",
+        SYNTHESIZED_TOOL_TABLE.deactivate_directive.props.superseded_by,
+        "",
+      ).ok,
+    ).toBe(false);
+  });
+
+  it("an out-of-range limit is refused before any network I/O", async () => {
+    const shim = makeShim({ url: await deadUrl(), cacheDir });
+    const res = await shim.handle(
+      rpc(4, "tools/call", {
+        name: "search_knowledge_pages",
+        arguments: { query: "x", limit: 500 },
+      }) as never,
+    );
+    const result = res?.result as { isError: boolean; content: { text: string }[] };
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("between 1 and 50");
+  });
+
+  it("every advertised synthesized tool has a dispatch arm", async () => {
+    // The name switch throws on an unmatched name, so a table entry added
+    // without an arm surfaces here as "no dispatch arm" instead of silently
+    // running whichever tool the old ternary's else branch happened to be.
+    // Each call gets SCHEMA-VALID required args so it clears validation and
+    // actually reaches the switch; the backend is dead, so a wired arm fails
+    // at the network with "<name> failed:".
+    const shim = makeShim({ url: await deadUrl(), cacheDir });
+    for (const name of SYNTHESIZED_TOOL_NAMES) {
+      const spec = SYNTHESIZED_TOOL_TABLE[name];
+      const args = Object.fromEntries(
+        spec.required.map((k) => [
+          k,
+          (spec.props[k] as { type?: string })?.type === "integer" ? 1 : "x",
+        ]),
+      );
+      const res = await shim.handle(
+        rpc(5, "tools/call", { name, arguments: args }) as never,
+      );
+      const result = res?.result as {
+        isError: boolean;
+        content: { text: string }[];
+      };
+      expect(result.isError, `${name} unexpectedly succeeded`).toBe(true);
+      expect(
+        result.content[0].text,
+        `${name} is advertised but the dispatch switch has no arm for it`,
+      ).not.toContain("no dispatch arm");
+      expect(result.content[0].text).toContain(`${name} failed:`);
+    }
   });
 });

--- a/tests/hindsight-permission-surface.test.ts
+++ b/tests/hindsight-permission-surface.test.ts
@@ -44,6 +44,8 @@ describe("Hindsight pre-approved permission surface (Fix 1.2, #2903)", () => {
       "mcp__hindsight__get_bank",
       "mcp__hindsight__get_bank_stats",
       "mcp__hindsight__get_document",
+      "mcp__hindsight__get_knowledge_page",
+      "mcp__hindsight__get_knowledge_tree",
       "mcp__hindsight__get_memory",
       "mcp__hindsight__get_mental_model",
       "mcp__hindsight__get_operation",
@@ -59,6 +61,7 @@ describe("Hindsight pre-approved permission surface (Fix 1.2, #2903)", () => {
       "mcp__hindsight__recall",
       "mcp__hindsight__reflect",
       "mcp__hindsight__retain",
+      "mcp__hindsight__search_knowledge_pages",
       "mcp__hindsight__sync_retain",
       "mcp__hindsight__update_bank",
       "mcp__hindsight__update_memory",
@@ -156,6 +159,40 @@ describe("Hindsight pre-approved permission surface (Fix 1.2, #2903)", () => {
         "history table upstream) — it must keep its per-call approval card. " +
         "Deactivation being pre-approved is not a precedent for deletion.",
     ).not.toContain("mcp__hindsight__delete_directive");
+  });
+
+  /**
+   * The knowledge-page surface is READS ONLY, asserted in both directions.
+   *
+   * The three reads are pre-approved; no page-authoring name may appear here,
+   * and none is synthesized at all (KnowledgeAdmin has no write method). Page
+   * DELETE upstream removes the page and its backing mental model with no
+   * undo, so a "while we're here" write addition must fail loudly rather than
+   * inherit the reads' pre-approval.
+   */
+  it("knowledge-page READS are pre-approved and no page WRITE is", () => {
+    for (const read of [
+      "mcp__hindsight__search_knowledge_pages",
+      "mcp__hindsight__get_knowledge_page",
+      "mcp__hindsight__get_knowledge_tree",
+    ]) {
+      expect(HINDSIGHT_MCP_TOOLS).toContain(read);
+    }
+    for (const write of [
+      "mcp__hindsight__create_knowledge_page",
+      "mcp__hindsight__create_knowledge_folder",
+      "mcp__hindsight__update_knowledge_node",
+      "mcp__hindsight__delete_knowledge_node",
+    ]) {
+      expect(
+        HINDSIGHT_MCP_TOOLS,
+        `${write} would pre-approve knowledge-page authorship/deletion — the ` +
+          `shim deliberately synthesizes reads only (KnowledgeAdmin is GET-only)`,
+      ).not.toContain(write);
+      expect(SYNTHESIZED_TOOL_NAMES).not.toContain(
+        write.replace("mcp__hindsight__", ""),
+      );
+    }
   });
 
   it("read-only mental-model tools ARE pre-approved (get/list), writes are not", () => {

--- a/tests/memory.hindsight-contract.fixture.test.ts
+++ b/tests/memory.hindsight-contract.fixture.test.ts
@@ -213,20 +213,24 @@ describe("hindsight contract — the shim fallback manifest mirrors the snapshot
    * The shim-synthesized carve-out, asserted rather than asserted-away.
    *
    * `FALLBACK_TOOL_TABLE` remains a byte-faithful description of the pinned
-   * image (test above) — the synthesized directive tools deliberately are NOT
-   * in it. What they DO ride in on is the served manifest, so these two
-   * assertions pin the boundary:
+   * image (test above) — the synthesized tools deliberately are NOT in it.
+   * That set is FIVE, not two: the two directive-retirement tools plus the
+   * three knowledge-page reads. The loop below iterates
+   * `SYNTHESIZED_TOOL_NAMES` rather than a hard-coded pair, so it covers
+   * whatever the table holds. What they DO ride in on is the served manifest,
+   * so the two tests here pin the boundary:
    *
-   *  1. the synthesized names must not exist upstream. If an image bump
-   *     registers a real `deactivate_directive`, this reds and the synthesis
-   *     gets retired instead of silently shadowing the backend's version
-   *     (which would accept a `bank_id` the shim's deliberately does not).
+   *  1. no synthesized name may exist upstream. If an image bump registers a
+   *     real `deactivate_directive` or `search_knowledge_pages`, this reds and
+   *     the synthesis gets retired instead of silently shadowing the backend's
+   *     version (which would accept a `bank_id` the shim's deliberately does
+   *     not).
    *  2. the served manifest must be exactly snapshot ∪ synthesized. A tool
    *     added to either table without review changes that set and reds here,
    *     which is what stops "over-reporting" creeping back in under the
    *     synthesis banner.
    */
-  it("the synthesized directive tools are NOT tools the pinned image registers", () => {
+  it("no shim-synthesized tool is one the pinned image registers", () => {
     for (const name of SYNTHESIZED_TOOL_NAMES) {
       expect(
         Object.keys(snapshot.tools),


### PR DESCRIPTION
## What

Hindsight 0.9.0 ships a full REST surface for Knowledge Pages but exposes **no MCP tools** for it (verified: zero knowledge tools in `mcp_tools.py` on the live 0.9.0 image). Agents therefore cannot reach knowledge pages at all.

This adds three **GET-only** shim-synthesized read tools, following the existing `deactivate_directive` / `reactivate_directive` precedent:

- `search_knowledge_pages(query, limit?)`
- `get_knowledge_page(page_id)`
- `get_knowledge_tree()`

Served tool count goes 34 → 37 (32 backend + 5 synthesized).

## Read-only by construction

`KnowledgeAdmin` has a single network primitive that hard-codes `method: "GET"` with no parameter to override it, so the page/folder/node write endpoints are unreachable rather than merely un-called. The bank segment comes from config only, never from a caller argument. Tests assert the prototype inventory and that no non-GET verb is ever sent across the whole synthesized surface.

Write tools are deliberately **not** added: a knowledge page is a mental model, and this fleet operator-gates all mental-model writes through an approval card. Ungated page creation would bypass that policy. A gated write path is possible later, but it is larger than it first appears (approval appends to config and reconcile creates the model via MCP `create_mental_model`, which cannot create a tree node).

## Considered and rejected

Upstream's new `@vectorize-io/hindsight-coding-agents` plugin ships a TS stdio MCP server wrapping these same endpoints. Not adopted: it would add a second MCP surface and an npm dependency, loses bank pinning and offline resilience, and drags ungated write tools (`capture_initiative`, `ingest_document`) along. Schemas and param naming were cribbed from it.

## Also

`synthesizedCall` previously required every argument to be a non-empty string, which would have rejected a numeric `limit`. Validation is now per-property: integer-typed properties accept an integer (or numeric string, coerced) within range; the non-empty-string rule still applies to string properties. The directive-specific dispatch ternary is refactored into a name switch whose `default` throws.

`READ_ONLY_TOOL_NAMES` is intentionally untouched — it is the secret-redaction skip-list for *forwarded* calls, and synthesized calls are intercepted before redaction runs, so adding names there would be a no-op that reads like a security change.

## Testing

146 tests pass across 5 files (15 new in `hindsight-knowledge-admin.test.ts`, 7 added to the shim suite, permission-surface enumerated set updated plus a both-directions assertion that no knowledge write name is pre-approved or synthesized). Lint green on all 27 gates.

Live smoke against a running 0.9.0 backend: `tools/list` returns 37; `get_knowledge_tree` and `get_knowledge_page` verified end-to-end against a real page (created and deleted for the test); cross-bank `bank_id` rejected with zero requests sent; `limit: 500` rejected pre-network.

## Known upstream defect (not introduced here)

`search_knowledge_pages` currently fails against the deployed 0.9.0 image for every bank, empty or not:

```
UndefinedFunctionError: function ts_rank_cd(text, tsquery) does not exist
  memory_engine.py:13638 in search_knowledge_pages
```

`mental_models.search_vector` is a `text` column where the RRF query expects `tsvector`; the BM25-only fallback branch makes the same call and fails identically. The shim surfaces this honestly as an error rather than faking an empty result. The empty-result-not-error contract is pinned in unit tests, so the tool will start working once the backend is fixed. Tree and page-read are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
