### PR TITLE
fix(build): resync package-lock.json with package.json — npm ci is broken on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+### Build: `npm ci` works again on a clean clone
+
+- **`package-lock.json` is resynced with `package.json`.** #4208 added
+  `nostr-tools@^2.24.1` as a dependency but never regenerated the lockfile, so
+  `origin/main` carried a `package.json` declaring the dep against a lock with
+  zero `node_modules/nostr-tools` entries. Every fresh clone or worktree failed
+  at `npm ci` with `Missing: nostr-tools@2.24.1 from lock file` (plus its
+  `nostr-wasm` / `@noble/*` / `@scure/*` transitives), which is why recent work
+  had to symlink `node_modules` in from another checkout to run tests at all.
+  Regenerating is purely additive — eight new package entries, no version bumps,
+  no integrity or `lockfileVersion` churn — apart from `typescript` moving
+  `dev` → `devOptional`, which is npm correctly recording nostr-tools' optional
+  `typescript` peer.
+
 ### Hindsight: an agent can finally read its own knowledge pages
 
 - **The MCP shim now synthesizes three GET-only knowledge-page tools —

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "commander": "^13.1.0",
         "grammy": "^1.44",
         "handlebars": "^4.7.8",
+        "nostr-tools": "^2.24.1",
         "posthog-node": "^5.29.2",
         "yaml": "^2.7.0",
         "zod": "^3.24.0"
@@ -1198,6 +1199,45 @@
       "integrity": "sha512-HYd1spcP10xUfECmFlvCJXcxMbZ89dq+FNtgHOBqYM1w0Udncg4hY8/bE+pWFwowD2QjnHDzvKrwokW/IsZURQ==",
       "license": "MIT"
     },
+    "node_modules/@noble/ciphers": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.1.1.tgz",
+      "integrity": "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1610,6 +1650,42 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@scure/base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
+      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.0.1.tgz",
+      "integrity": "sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "2.0.1",
+        "@noble/hashes": "2.0.1",
+        "@scure/base": "2.0.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.0.1.tgz",
+      "integrity": "sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1",
+        "@scure/base": "2.0.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@secretlint/core": {
       "version": "12.3.1",
@@ -4802,6 +4878,35 @@
         }
       }
     },
+    "node_modules/nostr-tools": {
+      "version": "2.24.1",
+      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.24.1.tgz",
+      "integrity": "sha512-KdrKjC74n/rr6J3eCSfZj8dcbZFvolHYe4S22SefNZ5YWbhHiB0KL/mmJjEZ0u6B9mZK0YcQtl+WQ46KzwapeQ==",
+      "license": "Unlicense",
+      "dependencies": {
+        "@noble/ciphers": "2.1.1",
+        "@noble/curves": "2.0.1",
+        "@noble/hashes": "2.0.1",
+        "@scure/base": "2.0.0",
+        "@scure/bip32": "2.0.1",
+        "@scure/bip39": "2.0.1",
+        "nostr-wasm": "0.1.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nostr-wasm": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/nostr-wasm/-/nostr-wasm-0.1.0.tgz",
+      "integrity": "sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6139,7 +6244,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",


### PR DESCRIPTION
## Symptom

`npm ci` fails on a fresh clone or worktree of `main`:

```
npm error Missing: nostr-wasm@0.1.0 from lock file
npm error Missing: nostr-tools@2.24.1 from lock file
```

Recent work had to symlink `node_modules` in from another checkout just to run tests.

## Verification of the desync (on `origin/main`, pre-fix)

```
$ git show origin/main:package.json | grep -c nostr-tools
1
$ git show origin/main:package-lock.json | grep -c '"node_modules/nostr-tools"'
0
$ npm ci
npm error Missing: nostr-wasm@0.1.0 from lock file
```

## Root cause

`git log -S nostr-tools -- package.json` returns exactly one commit: **65d9c13b** — *feat(buzz): Phase 1 — inbound fan-in sidecar + auth gate + config schema (default off) (#4208)*, merged 2026-08-02.

`git show --stat 65d9c13b` touches `package.json` only; `package-lock.json` is not in that commit's tree, and `git log -S nostr-tools -- package-lock.json` returns nothing at all. So the dep was added to `package.json` without regenerating the lock, and `main` has shipped a broken clean install for six days. No workspace or optional-dep subtlety involved — it is the plain "added a dep, didn't regenerate" case.

## What regenerating changed

`npm install` in a fresh worktree off `origin/main` (`package.json` untouched — `git status` shows only `package-lock.json` modified). Diff is **+106 / −1**, entirely additive:

- `nostr-tools` 2.24.1
- `nostr-wasm` 0.1.0
- `@noble/ciphers` 2.1.1, `@noble/curves` 2.0.1, `@noble/hashes` 2.0.1
- `@scure/base` 2.0.0, `@scure/bip32` 2.0.1, `@scure/bip39` 2.0.1
- the `nostr-tools` line in the root `""` packages block

All eight transitives are **exact pins taken straight from nostr-tools 2.24.1's own `dependencies`**, so there is no resolution latitude here.

Explicitly *not* churned: no version bumps of existing packages, no integrity-hash rewrites, no `lockfileVersion` change (stays 3), no registry-URL changes.

The single removed line is `typescript`'s `"dev": true` becoming `"devOptional": true` — npm correctly recording that `nostr-tools` declares an optional `typescript` peerDependency, which promotes the already-present dev-only `typescript` to dev-or-optional. Same version, same integrity, no install-graph change for anyone.

## Verification of the fix

- `rm -rf node_modules && npm ci` → **`added 450 packages, and audited 452 packages`**, exit 0. This is the acceptance test.
- `npm ci` leaves the lockfile unmodified (`git status` clean apart from the staged change), i.e. it is genuinely in sync now.
- `npm run lint` → **fully green**, all 25+ gates including `check-changelog-entry` and `check-agent-attribution-trailers`.
- `npx vitest run src/buzz-gateway src/config/schema.test.ts` → **318 pass / 15 files**. These are the actual `nostr-tools` consumers, so they exercise the newly-locked versions rather than just the lockfile text.
- `bun build src/buzz-gateway/index.ts --target node` → bundles clean (49 modules).

## Changelog

`check-changelog-entry` reports *"no shippable code changed"* — `package-lock.json` is not under a `SHIPPABLE_ROOTS` prefix, so no entry is strictly required. One is staged under `## Unreleased` anyway, because a broken clean install is a real user-visible defect worth naming in the release notes.

## Context

Found while working on #4548 (Hindsight knowledge-page tools). **Unrelated to that change** — it just happens to be what blocked setting up a clean worktree for it.