### PR TITLE
fix(hindsight): measure consolidation per-fact tokens, 32k batch 6 to 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+### Bug fixes
+
+- **hindsight: measure consolidation per-fact tokens, 32k batch 6 to 3**
+
 ### Build: `npm ci` works again on a clean clone
 
 - **`package-lock.json` is resynced with `package.json`.** #4208 added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,21 @@ now an anomaly worth investigating, not the norm.
 
 ### Bug fixes
 
-- **hindsight: measure consolidation per-fact tokens, 32k batch 6 to 3**
+- **hindsight: measure consolidation per-fact tokens, 32k batch 6 to 3.** The
+  marginal prompt cost of a fact in a consolidation batch was 2,500 tokens,
+  back-derived as `30,000 / 12` from a whole-prompt p90 at batch 12 — a
+  derivation that charges the entire prompt, fixed overhead included, to the
+  marginal term. Measured directly against 24h of production consolidation
+  logs, unsplit batches of 6 (n=450) run to a p90 of 28,882 and a max of 31,903
+  input tokens, so the real marginal cost is ~4,939/fact and the constant was
+  low by ~1.8x. It is now 5,000. Effect: a 32,768-token backend derives batch
+  **3** instead of 6, which is the size that never failed in production (9
+  truncate-and-split events at batch 6, zero below it) — batch 6's real prompts
+  plus the 8,192-token completion overflowed the window, and llama.cpp answers
+  an overflow with HTTP 200 and conversational text rather than an error. A
+  131k or 200k window still derives the historical batch 12, so a big-window
+  operator is unaffected. The trade on a 32k backend is throughput for
+  correctness: roughly twice as many consolidation LLM calls.
 
 ### Build: `npm ci` works again on a clean clone
 

--- a/src/setup/hindsight-context-budget.ts
+++ b/src/setup/hindsight-context-budget.ts
@@ -104,21 +104,76 @@ export const HINDSIGHT_CONTEXT_SAFETY_FRACTION = 0.2;
 
 /**
  * Fixed prompt cost of ONE consolidation call, independent of batch size:
- * system prompt + JSON schema + recall context. Back-derived from the
- * measured p90 (32,270 prompt tokens at batch size 12) split as
- * `overhead + batch × per-fact` — see {@link HINDSIGHT_CONSOLIDATION_TOKENS_PER_FACT}.
+ * system prompt + JSON schema + recall context. Held at its original value and
+ * treated as the KNOWN term when the marginal per-fact cost was re-measured
+ * against production in 2026-08 — the measurement solves
+ * `input = overhead + batch × per-fact` for the per-fact term with this
+ * overhead fixed, so an error here lands entirely in
+ * {@link HINDSIGHT_CONSOLIDATION_TOKENS_PER_FACT}, which is the conservative
+ * place for it (the per-fact term is what shrinks the batch). Re-measuring the
+ * intercept needs a spread of batch sizes the production log does not supply:
+ * outside batch 6, every sample is a post-split remainder.
  */
 export const HINDSIGHT_CONSOLIDATION_PROMPT_OVERHEAD_TOKENS = 2_270;
 
 /**
  * Marginal prompt cost of each additional fact in a consolidation batch.
- * 30,000 / 12 from the same measured p90 decomposition. This is the number
- * that makes batch size a TOKEN decision rather than a throughput one — the
- * comment this fix replaced claimed batch size was "tokens-per-call, not
- * concurrency, so it doesn't affect the ceiling", which was true of the
- * *quota* ceiling and dead wrong about the *context* ceiling.
+ *
+ * This is the number that makes batch size a TOKEN decision rather than a
+ * throughput one — the comment the original fix replaced claimed batch size
+ * was "tokens-per-call, not concurrency, so it doesn't affect the ceiling",
+ * which was true of the *quota* ceiling and dead wrong about the *context*
+ * ceiling.
+ *
+ * **Measured, not back-derived (2026-08-09).** This constant was 2,500,
+ * justified as `30,000 / 12`: the whole of a measured p90 prompt at batch 12
+ * divided by the batch. That derivation is unsound twice over — it attributes
+ * the ENTIRE prompt (fixed overhead included) to the marginal per-fact cost,
+ * and it reads one p90 sample at one batch size as the marginal cost at
+ * another. The old docstring's own record of a batch-8 experiment on
+ * 2026-07-28 hitting 15.5% `OutputTooLongError` against a 32,768-token window
+ * was the first symptom of the constant being too small.
+ *
+ * The replacement is measured directly off production. 24h of
+ * `switchroom-hindsight` logs were joined per batch: each
+ * `[CONSOLIDATION] … llm_batch #N (K memories, 1 llm calls)` summary line
+ * gives the batch size, and the `slow llm call: scope=consolidation …
+ * input_tokens=` line for that same call gives the backend's OWN tokenizer
+ * count of the prompt. (The summary line's `input_tokens=~` field is only an
+ * internal estimate and under-reports the real count by ~20%, which is part of
+ * why this went unnoticed.) Restricted to unsplit, single-call batches of 6 —
+ * n = 450, banks `overlord` and `klanker`:
+ *
+ * ```
+ *   p50 25,585   p90 28,882   p95 29,738   p99 31,391   max 31,903
+ * ```
+ *
+ * Solving `input = OVERHEAD + 6 × PER_FACT` across that tail gives 4,435 (p90)
+ * / 4,578 (p95) / 4,854 (p99) / 4,939 (max) tokens per fact: the old 2,500 was
+ * low by ~1.8×. This constant feeds a safety preflight, so it must bound the
+ * tail rather than the average — it takes the observed **maximum**, rounded up
+ * to 5,000. (Batch 3 holds for any value in 3,939…5,251, so the rounding is
+ * slack, not a cliff.)
+ *
+ * Production evidence that the resulting batch size of 3 is the right answer,
+ * from the same 24h window: **9 `LLM failed for sub-batch of 6, splitting into
+ * 3/3` events, and zero failures at any smaller sub-batch size.** Every 6 → 3/3
+ * split then succeeded. Under the old constant a 32,768-token window derived
+ * batch 6 with an estimated worst case of 25,462 tokens, which "fit" the 26,215
+ * usable band and passed preflight — while real prompts reached 31,707, so
+ * `prompt + 8,192 requested completion` blew straight through the window, the
+ * backend truncated, and hindsight logged `LiteLLM response was truncated due
+ * to token limit`, retried three times uselessly (LiteLLM's redis cache returns
+ * the identical truncated response), then split the batch.
+ *
+ * The trade is throughput for correctness: on a 32k backend batch 6 → 3 roughly
+ * doubles the consolidation LLM call count, and the LLM is already the
+ * bottleneck. That is the intended direction — under-declaring costs
+ * throughput, over-declaring corrupts memory. A 131k or 200k window still
+ * derives the historical batch 12 under this constant, so a big-window operator
+ * is unaffected.
  */
-export const HINDSIGHT_CONSOLIDATION_TOKENS_PER_FACT = 2_500;
+export const HINDSIGHT_CONSOLIDATION_TOKENS_PER_FACT = 5_000;
 
 /**
  * Worst-case prompt size of one retain (fact-extraction) call: the chunk
@@ -366,10 +421,13 @@ export function resolveLaneContextWindow(
  *   promptBudget    = usable − maxCompletion
  *   batchSize       = clamp(⌊(promptBudget − OVERHEAD) / PER_FACT⌋, 1, 12)
  *
- * For a 32,768-token window that lands on batch 6 / consolidation completion
- * 8,192 / retain completion 6,144 — the values applied by hand to the live
- * container when the incident was diagnosed. For 131k or 200k it lands on
- * the historical batch 12, so a big-window operator loses nothing.
+ * For a 32,768-token window that lands on batch 3 / consolidation completion
+ * 8,192 / retain completion 6,144. Batch 3, not the 6 this originally derived:
+ * the per-fact constant was re-measured against production in 2026-08 and the
+ * old value was low by ~1.8×, so 32k backends were passing preflight at a
+ * batch whose real prompts overflowed the window (see
+ * {@link HINDSIGHT_CONSOLIDATION_TOKENS_PER_FACT}). For 131k or 200k it still
+ * lands on the historical batch 12, so a big-window operator loses nothing.
  *
  * The retain lane has no batch knob and a FIXED prompt estimate, so nothing in
  * its derivation shrinks with the window — `usable` binds it only through the

--- a/src/setup/hindsight-context-budget.ts
+++ b/src/setup/hindsight-context-budget.ts
@@ -158,7 +158,13 @@ export const HINDSIGHT_CONSOLIDATION_PROMPT_OVERHEAD_TOKENS = 2_270;
  * Production evidence that the resulting batch size of 3 is the right answer,
  * from the same 24h window: **9 `LLM failed for sub-batch of 6, splitting into
  * 3/3` events, and zero failures at any smaller sub-batch size.** Every 6 → 3/3
- * split then succeeded. Under the old constant a 32,768-token window derived
+ * split then succeeded. Corroboration from the other direction, same window:
+ * genuine (unsplit, not post-split) batches of 3 measured n = 9, max 17,160
+ * prompt tokens — which the corrected estimate for a batch of 3
+ * (2,270 + 3 × 5,000 = 17,270) bounds, where the old constant's estimate for a
+ * batch of 6 did not bound the batch-6 measurement.
+ *
+ * Under the old constant a 32,768-token window derived
  * batch 6 with an estimated worst case of 25,462 tokens, which "fit" the 26,215
  * usable band and passed preflight — while real prompts reached 31,707, so
  * `prompt + 8,192 requested completion` blew straight through the window, the

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -816,6 +816,15 @@ export function hindsightLlmBudgetEnv(llm?: HindsightLlmConfig): Array<[string, 
  * `hindsight.llm.context_window` and asserted to fit before launch. Picking
  * "better" constants would only relocate the same latent bug to the next
  * backend swap.
+ *
+ * **Caveat on the p90 above (added 2026-08-09).** That 32,270 figure measures
+ * whole prompts at batch 12; it is NOT a per-fact marginal cost, and dividing
+ * it by 12 to get one is the mistake that left
+ * `HINDSIGHT_CONSOLIDATION_TOKENS_PER_FACT` at 2,500 — low by ~1.8×. A
+ * 32,768-token backend therefore passed preflight at batch 6 and then
+ * truncated in production. The marginal cost has since been measured directly
+ * per batch size; see that constant's docstring in
+ * `hindsight-context-budget.ts`.
  */
 // Batch-size CEILING — the value the derivation lands on whenever the declared
 // window is large enough to fit it (131k and 200k both are), so a big-window

--- a/tests/setup/hindsight-context-budget.test.ts
+++ b/tests/setup/hindsight-context-budget.test.ts
@@ -15,6 +15,7 @@ import {
   HINDSIGHT_CLAUDE_CONTEXT_WINDOW,
   HINDSIGHT_CONSERVATIVE_CONTEXT_WINDOW,
   HINDSIGHT_CONSOLIDATION_BATCH_SIZE_CEILING,
+  HINDSIGHT_CONSOLIDATION_BATCH_SIZE_FLOOR,
   HINDSIGHT_CONSOLIDATION_PROMPT_OVERHEAD_TOKENS,
   HINDSIGHT_CONSOLIDATION_TOKENS_PER_FACT,
   HINDSIGHT_RETAIN_MAX_COMPLETION_CEILING,
@@ -57,18 +58,51 @@ const LOCAL_SLOT_WINDOW = 32_768;
 const localLlm = { provider: "litellm", context_window: LOCAL_SLOT_WINDOW };
 
 describe("hindsight context budget — derivation (#3716)", () => {
-  it("lands on the hand-applied 32k values: batch 6 / consolidation 8192 / retain 6144", () => {
+  it("lands on the 32k values: batch 3 / consolidation 8192 / retain 6144", () => {
     const b = resolveHindsightContextBudget(localLlm);
-    expect(b.consolidation.batchSize).toBe(6);
+    expect(b.consolidation.batchSize).toBe(3);
     expect(b.consolidation.maxCompletionTokens).toBe(8192);
     expect(b.retain.maxCompletionTokens).toBe(6144);
   });
 
+  it("holds the 32k batch at 3 — the size production never fails at", () => {
+    // Outcome pin for the 2026-08-09 per-fact re-measurement. This test FAILS
+    // on the pre-fix constant: 2,500 tokens/fact derives batch 6, which in 24h
+    // of live logs produced 9 `LLM failed for sub-batch of 6, splitting into
+    // 3/3` truncation events and zero failures at any smaller sub-batch — the
+    // measured batch-6 prompt tail reached 31,903 tokens against a 32,768
+    // window with 8,192 completion requested on top.
+    //
+    // Asserted through the real measurement rather than only through the
+    // derived number, so a future edit to the constant that silently moves the
+    // batch has to confront the production evidence, not just retune a literal.
+    const MEASURED_BATCH6_PROMPT_TOKENS_MAX = 31_903; // n=450, banks overlord+klanker
+    const impliedPerFact =
+      (MEASURED_BATCH6_PROMPT_TOKENS_MAX - HINDSIGHT_CONSOLIDATION_PROMPT_OVERHEAD_TOKENS) / 6;
+    expect(HINDSIGHT_CONSOLIDATION_TOKENS_PER_FACT).toBeGreaterThanOrEqual(impliedPerFact);
+
+    const b = resolveHindsightContextBudget(localLlm);
+    expect(b.consolidation.batchSize).toBe(3);
+
+    // The bug in one line: what the OLD constant claimed a batch of 6 would
+    // cost, versus what a batch of 6 really costs. The estimate has to bound
+    // the measurement, and 2,500/fact did not.
+    const preFixEstimateForSix = HINDSIGHT_CONSOLIDATION_PROMPT_OVERHEAD_TOKENS + 6 * 2_500;
+    expect(preFixEstimateForSix).toBeLessThan(MEASURED_BATCH6_PROMPT_TOKENS_MAX);
+    expect(
+      HINDSIGHT_CONSOLIDATION_PROMPT_OVERHEAD_TOKENS +
+        6 * HINDSIGHT_CONSOLIDATION_TOKENS_PER_FACT +
+        b.consolidation.maxCompletionTokens,
+    ).toBeGreaterThan(LOCAL_SLOT_WINDOW);
+  });
+
   it("keeps worst-case prompt+completion strictly inside a 32k window", () => {
-    // THE regression assertion. On main the emitted batch size was a hard 12,
-    // whose measured p90 prompt was 32,270 tokens against a 32,768 slot — with
-    // an uncapped completion on top, i.e. guaranteed overflow. Recomputing the
-    // pre-fix worst case here proves this test would have failed on the bug.
+    // THE regression assertion for #3716. Before it, the emitted batch size
+    // was a hard 12 with an uncapped completion on top against a 32,768 slot,
+    // i.e. guaranteed overflow. Recomputing the pre-fix worst case here proves
+    // this test would have failed on the bug — and it holds a fortiori under
+    // the 2026-08 per-fact re-measurement, which only made the estimate for a
+    // batch of 12 larger.
     const preFixPrompt =
       HINDSIGHT_CONSOLIDATION_PROMPT_OVERHEAD_TOKENS +
       HINDSIGHT_CONSOLIDATION_BATCH_SIZE_CEILING * HINDSIGHT_CONSOLIDATION_TOKENS_PER_FACT;
@@ -116,7 +150,7 @@ describe("hindsight context budget — derivation (#3716)", () => {
     });
     // An undeclared litellm backend is assumed local-and-small, so it gets the
     // ratcheted budget rather than the pre-fix one.
-    expect(resolveHindsightContextBudget({ provider: "litellm" }).consolidation.batchSize).toBe(6);
+    expect(resolveHindsightContextBudget({ provider: "litellm" }).consolidation.batchSize).toBe(3);
   });
 
   it("resolves per-op window over global over provider default", () => {
@@ -259,9 +293,38 @@ describe("hindsight context budget — the safety band binds the retain lane too
   it("REJECTS the low edge of the band (11,072 — raw check passes exactly)", () => {
     const at = { provider: "litellm", context_window: 11_072 };
     expect(() => resolveCheckedHindsightContextBudget(at)).toThrow(HindsightContextBudgetError);
-    expect(() => resolveCheckedHindsightContextBudget(at)).toThrow(/hindsight retain/);
     // usable = 11072 − ⌊11072 × 0.2⌋ = 8858.
     expect(usableContextTokens(11_072)).toBe(8_858);
+    // Retain trips the band on its own — that is #3721's point, and the `pins
+    // the arithmetic` case above asserts it directly. It is no longer the lane
+    // NAMED in the message: since the 2026-08 per-fact re-measurement,
+    // consolidation at its batch floor of 1 costs 2,270 + 5,000 prompt and is
+    // checked first, so it reports at this window too. Both lanes overflowing
+    // is a stronger rejection, not a weaker one.
+    const b = resolveHindsightContextBudget(at);
+    expect(b.consolidation.batchSize).toBe(HINDSIGHT_CONSOLIDATION_BATCH_SIZE_FLOOR);
+    expect(b.consolidation.worstCaseTotalTokens).toBeGreaterThan(b.consolidation.usableTokens);
+    expect(() => resolveCheckedHindsightContextBudget(at)).toThrow(/hindsight consolidation/);
+  });
+
+  it("leaves the smallest admissible window at 13,839 — retain is still the binding lane", () => {
+    // The corrected per-fact constant raises consolidation's floor-batch cost,
+    // so it is worth pinning that it did NOT move the documented minimum.
+    // Consolidation stops fitting below 13,217, which is under retain's 13,839,
+    // so retain remains what decides the floor and the module docstring's
+    // "smallest declared window switchroom will accept is 13,839" still holds.
+    for (const window of [13_217, 13_838]) {
+      const b = resolveHindsightContextBudget({ provider: "litellm", context_window: window });
+      expect(b.consolidation.worstCaseTotalTokens, `cons@${window}`).toBeLessThanOrEqual(
+        b.consolidation.usableTokens,
+      );
+      expect(b.retain.worstCaseTotalTokens, `retain@${window}`).toBeGreaterThan(
+        b.retain.usableTokens,
+      );
+    }
+    expect(() =>
+      resolveCheckedHindsightContextBudget({ provider: "litellm", context_window: 13_839 }),
+    ).not.toThrow();
   });
 
   it("REJECTS the high edge of the band (13,838 — usable 11,071, one short)", () => {
@@ -418,7 +481,7 @@ describe("hindsight context budget — emit paths stay in sync (#3716)", () => {
     const snippet = generateHindsightComposeSnippet(localLlm);
 
     for (const pair of [
-      "HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE=6",
+      "HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE=3",
       "HINDSIGHT_API_CONSOLIDATION_MAX_COMPLETION_TOKENS=8192",
       "HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS=6144",
       "HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS=20000",

--- a/tests/setup/hindsight-context-budget.test.ts
+++ b/tests/setup/hindsight-context-budget.test.ts
@@ -313,6 +313,13 @@ describe("hindsight context budget — the safety band binds the retain lane too
     // Consolidation stops fitting below 13,217, which is under retain's 13,839,
     // so retain remains what decides the floor and the module docstring's
     // "smallest declared window switchroom will accept is 13,839" still holds.
+    // The 13,216 case asserts that boundary rather than only asserting the
+    // comment — without it a future constant change could push consolidation's
+    // floor ABOVE retain's and this test would still pass.
+    {
+      const b = resolveHindsightContextBudget({ provider: "litellm", context_window: 13_216 });
+      expect(b.consolidation.worstCaseTotalTokens).toBeGreaterThan(b.consolidation.usableTokens);
+    }
     for (const window of [13_217, 13_838]) {
       const b = resolveHindsightContextBudget({ provider: "litellm", context_window: window });
       expect(b.consolidation.worstCaseTotalTokens, `cons@${window}`).toBeLessThanOrEqual(


### PR DESCRIPTION
## Summary

`HINDSIGHT_CONSOLIDATION_TOKENS_PER_FACT` was **2,500**, justified in its docstring as `30,000 / 12` — the whole of a measured p90 prompt at batch size 12, divided by the batch. That derivation is unsound twice over: it attributes the **entire** prompt (fixed overhead included) to the *marginal* per-fact cost, and it reads one p90 sample at one batch size as the marginal cost at another.

Corrected to **5,000**, measured against production. On a 32,768-token window this moves the derived consolidation batch size from **6 to 3**. 131k and 200k windows still derive the historical batch 12, so a big-window operator loses nothing.

## The measurement

24h of `docker logs switchroom-hindsight`, joined per batch:

- `[CONSOLIDATION] bank=… llm_batch #N (K memories, 1 llm calls)` gives the batch size K.
- The `slow llm call: scope=consolidation … input_tokens=` line emitted for that same call gives the **backend's own tokenizer count** of the prompt.

(The summary line's own `input_tokens=~` field is only an internal estimate and under-reports the real count by ~20% — e.g. `~22004` on a call the tokenizer counted at `28374`. That gap is part of why this went unnoticed.)

Restricted to unsplit, single-LLM-call batches of 6 — **n = 450**, banks `overlord` and `klanker`:

| stat | input tokens |
|---|---|
| p50 | 25,585 |
| p90 | 28,882 |
| p95 | 29,738 |
| p99 | 31,391 |
| max | 31,903 |

Solving `input = OVERHEAD(2,270) + 6 × PER_FACT` across that tail:

| from | implied tokens/fact |
|---|---|
| p90 | 4,435 |
| p95 | 4,578 |
| p99 | 4,854 |
| max | 4,939 |

The old 2,500 is low by ~1.8×. This constant feeds a **safety preflight**, so it has to bound the tail rather than the average: the PR takes the observed **maximum**, rounded up to **5,000**. Batch 3 holds for any value in 3,939…5,251, so the round-up is slack, not a cliff.

`HINDSIGHT_CONSOLIDATION_PROMPT_OVERHEAD_TOKENS` (2,270) is deliberately **unchanged** and treated as the known term. Re-measuring the intercept needs a spread of batch sizes the production log does not supply — outside batch 6, every sample is a post-split remainder (n = 8–9 each). Holding the intercept fixed pushes any residual error into the per-fact term, which is the conservative place for it, since that is the term that shrinks the batch. This is stated in the docstring rather than papered over.

## Why batch 3 is the right answer, not just a smaller one

From the same 24h window:

- **9 × `[CONSOLIDATION] bank=… LLM failed for sub-batch of 6, splitting into 3/3`** (5 on `overlord`, 4 on `klanker`).
- **Zero** failures at any smaller sub-batch size. Every 6 → 3/3 split then succeeded.

The failure path: derived batch 6 with an *estimated* worst case of 25,462 tokens "fits" the 26,215 usable band and passes preflight — while real prompts reach 31,707+, so `prompt + 8,192 requested completion` blows straight through the 32,768 window. The backend truncates, hindsight logs `LiteLLM response was truncated due to token limit`, retries 3× uselessly (LiteLLM's redis cache with ttl 600 returns the identical truncated response in ~30ms, so attempts 2 and 3 never re-call the model), then splits.

Independent corroboration already in the tree: the old docstring recorded a batch-8 experiment on 2026-07-28 hitting **15.5% `OutputTooLongError`** against this same window — consistent with the constant being too small.

## Arithmetic check (32,768 window)

```
usable        = 32768 − ⌊32768 × 0.2⌋            = 26,215
maxCompletion = clamp(⌊32768/4⌋, 1024, 16384)    =  8,192
promptBudget  = 26215 − 8192                     = 18,023
batchSize     = clamp(⌊(18023 − 2270)/5000⌋,1,12) =      3   (was 6 at 2,500)
```

Big windows, verified unchanged:

| window | batch @2,500 | batch @5,000 |
|---|---|---|
| 131,072 | 12 | **12** |
| 200,000 | 12 | **12** |

## Throughput tradeoff — stated honestly

Batch 6 → 3 **roughly doubles the consolidation LLM call count** on a 32k backend, and the LLM is already the bottleneck (~18s/call median, tail past 60s). There is a live backlog of ~496 pending consolidations on the `overlord` bank and 116 on `klanker`, and this change makes that backlog drain slower in the nominal case.

That is the correct trade. The current behaviour is not actually 2× faster — ~4% of batch-6 calls burn a full LLM call, three cached-no-op retries, *and* two replacement batch-3 calls before succeeding, so the effective throughput gap is smaller than 2×. More importantly, the failure mode is silent corruption of memory quality, not a visible error: on the local llama.cpp path context-shift discards the system prompt and returns HTTP 200 with conversational text. Under-declaring costs throughput; over-declaring corrupts memory.

## Side effect found and pinned

At an 11,072-token window, consolidation at its batch floor of 1 now costs `2,270 + 5,000` prompt and trips the band before retain does, so the preflight error names `hindsight consolidation` rather than `hindsight retain`. The #3721 test asserting that string is updated to assert both lanes overflow (a stronger rejection, not a weaker one), and a new test pins that the **documented smallest admissible window is still 13,839** — consolidation only stops fitting below 13,217, which is under retain's floor, so retain remains the binding lane.

## Test plan

- `tests/setup/hindsight-context-budget.test.ts`: the 32k derivation pin moves 6 → 3; the emitted-env pin moves `…LLM_BATCH_SIZE=6` → `=3`; the litellm-default pin moves 6 → 3.
- **New outcome test** `holds the 32k batch at 3 — the size production never fails at`: asserts the constant bounds the measured batch-6 maximum (31,903), that the derivation lands on 3, and that a batch of 6 under the corrected constant provably does **not** fit the window. Verified to FAIL on the old 2,500 constant (5 failures total across the file when the constant is reverted) — it is a regression test, not a code-path walk.
- **New test** `leaves the smallest admissible window at 13,839 — retain is still the binding lane`.
- Scoped: `vitest run tests/setup/hindsight-context-budget.test.ts tests/setup/hindsight.test.ts src/setup/` → **701 passed**.
- `npm run lint` → clean.
- CHANGELOG entry staged author-side via `bun run changelog:generate`.

## Risk

Low and bounded. The only behaviour change is a smaller derived consolidation batch on windows below ~65k; every emit path reads the same pure derivation, so the docker-run and compose paths cannot disagree. Rollout requires a `switchroom setup`/hindsight recreate to re-emit `HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE` — until then the live container keeps its current value, so nothing regresses on merge alone.

## Docstrings corrected

The `30,000 / 12` justification is deleted, not softened. `src/setup/hindsight.ts`'s "p90 prompt 32,270 tok" block — the *source* of the bad decomposition — gains an explicit caveat that the figure measures whole prompts at batch 12 and is not a per-fact marginal cost. The module docstring's "For a 32,768-token window that lands on batch 6" prose is corrected to batch 3.

## Verdict rule

- **Advances:** `standing-team` — via `reference/jobs/remember-across-sessions.md`. Silent consolidation truncation is memory-quality loss the user experiences as the agent failing to bring back facts it was told; a preflight that passes a batch production demonstrably fails at is the mechanism that lets it happen.
- **Job spec:** `reference/jobs/remember-across-sessions.md` (outcome: relevant facts brought back without being re-told).
- **Docs test:** the constant now documents a measurement with its method, sample size, date and production evidence — shorter to justify than the arithmetic it replaced.
- **Defaults test:** the shipped default is the safe one; an operator on a large window is unaffected.
- **Consistency test:** same single derivation, same preflight, no new knob.
- **Invariants:** none crossed. Single-tenant untouched; no model/API surface touched.
