### PR TITLE
fix(telegraph): render `**>` expandable blockquotes in Instant View pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ now an anomaly worth investigating, not the norm.
 
 ### Bug fixes
 
+- **telegraph: `**>` expandable blockquotes render correctly in Instant View
+  pages.** `markdownToTelegraphNodes` — the Telegra.ph node builder used when a
+  telegraph-enabled agent's reply exceeds the ~3000-char threshold — matched
+  blockquote lines with `/^>\s?/` only, so the documented expandable-quote
+  syntax (`**> summary` opener plus `> body` continuation lines) fell through to
+  paragraph handling: the unterminated `**` leaked as a literal `**>` paragraph
+  and the `>` lines split off into a second, detached blockquote. The live
+  outbound entity path (`render/parse.ts`, `render/render.ts`) already handled
+  `**>`; only this Instant View builder disagreed. It now recognises the
+  `**>`-opener group, strips the markers, and folds opener plus continuations
+  into a single `<blockquote>` — Telegra.ph's tag set has no collapsible-quote
+  tag, so an expandable quote degrades faithfully to a normal one. `isBlockStart`
+  treats `**>` as a block start too, so a preceding paragraph no longer absorbs
+  it. Plain `>` quotes are unchanged.
+
 - **hindsight: measure consolidation per-fact tokens, 32k batch 6 to 3.** The
   marginal prompt cost of a fact in a consolidation batch was 2,500 tokens,
   back-derived as `30,000 / 12` from a whole-prompt p90 at batch 12 — a

--- a/telegram-plugin/telegraph.ts
+++ b/telegram-plugin/telegraph.ts
@@ -193,6 +193,18 @@ export async function createTelegraphPage(
 }
 
 /**
+ * A blockquote line: a plain `> ` marker OR the expandable-blockquote opener
+ * `**> ` (Bot API 10.1 syntax the switchroom render path emits on the first
+ * line of an expandable quote — see `render/render.ts` and
+ * `reference/telegram-formatting-guide.md`). Telegra.ph has no collapsible
+ * blockquote tag, so an expandable quote degrades to a normal `<blockquote>`;
+ * the `**` prefix must still be recognised and stripped here, else the
+ * unterminated `**` renders as literal `**>` text and the `>` continuation
+ * lines split off into a second, detached quote.
+ */
+const TELEGRAPH_QUOTE_LINE = /^(?:\*\*)?>\s?/
+
+/**
  * Convert reply text (markdown-ish) into Telegraph node structure.
  *
  * Lives between the two extremes of "raw text in one paragraph"
@@ -278,11 +290,15 @@ export function markdownToTelegraphNodes(text: string): TelegraphNode[] {
       continue
     }
 
-    // Blockquote.
-    if (/^>\s?/.test(line)) {
+    // Blockquote — plain `> …` OR an expandable `**> …` opener followed by
+    // `> …` continuation lines. Both collapse into one <blockquote> with the
+    // markers stripped (Telegra.ph has no expandable-blockquote tag, so the
+    // expandable quote degrades faithfully to a normal one; the `**>` marker is
+    // stripped so no literal `**>` leaks and the summary stays with its body).
+    if (TELEGRAPH_QUOTE_LINE.test(line)) {
       const quoted: string[] = []
-      while (i < lines.length && /^>\s?/.test(lines[i])) {
-        quoted.push(lines[i].replace(/^>\s?/, ''))
+      while (i < lines.length && TELEGRAPH_QUOTE_LINE.test(lines[i])) {
+        quoted.push(lines[i].replace(TELEGRAPH_QUOTE_LINE, ''))
         i++
       }
       nodes.push({ tag: 'blockquote', children: parseInline(quoted.join(' ')) })
@@ -310,7 +326,9 @@ function isBlockStart(line: string): boolean {
     /^[-*]\s+/.test(line) ||
     /^\d+\.\s+/.test(line) ||
     line.trim().startsWith('```') ||
-    /^>\s?/.test(line)
+    // A `**>` expandable-quote opener is a block start too, so a preceding
+    // paragraph does not absorb it (which is what left the `**>` literal).
+    TELEGRAPH_QUOTE_LINE.test(line)
   )
 }
 

--- a/telegram-plugin/tests/telegraph.test.ts
+++ b/telegram-plugin/tests/telegraph.test.ts
@@ -164,6 +164,40 @@ describe('markdownToTelegraphNodes — block elements', () => {
     expect(r[0].tag).toBe('blockquote')
   })
 
+  it('folds an expandable `**>` quote into one blockquote, marker stripped', () => {
+    // The Bot API 10.1 expandable-blockquote syntax: `**>` opener on the first
+    // line, `>` continuation lines. Telegra.ph has no collapsible-blockquote
+    // tag, so it degrades to a normal blockquote — but the `**>` marker MUST be
+    // recognised. Before the fix the `**>` line became a paragraph with literal
+    // `**>` text and the `>` lines split into a detached second quote.
+    const r = markdownToTelegraphNodes('**> summary of the thing\n> body one\n> body two')
+    expect(r).toHaveLength(1)
+    expect(r[0].tag).toBe('blockquote')
+    // Summary and body are joined in the single quote, no literal `**>` leaks.
+    const flat = JSON.stringify(r)
+    expect(flat).not.toContain('**>')
+    expect(flat).not.toContain('*') // no stray bold delimiter survives
+    expect(flat).toContain('summary of the thing')
+    expect(flat).toContain('body one')
+    expect(flat).toContain('body two')
+  })
+
+  it('does not let a paragraph absorb a following `**>` opener', () => {
+    // isBlockStart must treat `**>` as a block start so the preceding line ends
+    // the paragraph instead of swallowing the quote (which left the `**>`
+    // literal glued into prose).
+    const r = markdownToTelegraphNodes('Intro line\n**> quoted summary')
+    expect(r.map((n) => n.tag)).toEqual(['p', 'blockquote'])
+    expect(r[0].children).toEqual(['Intro line'])
+  })
+
+  it('does not misread a line that merely opens with bold text', () => {
+    // `**` is only a quote marker when `>` follows it immediately. A line
+    // starting with real bold must stay a paragraph, not become a blockquote.
+    const r = markdownToTelegraphNodes('**bold** > x')
+    expect(r.map((n) => n.tag)).toEqual(['p'])
+  })
+
   it('handles a mixed document end-to-end', () => {
     const md = '# Title\n\nIntro paragraph.\n\n## Steps\n\n- one\n- two\n\nFinal note.'
     const r = markdownToTelegraphNodes(md)


### PR DESCRIPTION
## Summary

A telegraph-enabled agent whose reply exceeds the ~3000-char threshold gets published to a Telegra.ph Instant View page. On that path, the documented expandable-blockquote syntax — `**> summary` opener plus `> body` continuation lines — rendered as a **literal `**>` paragraph followed by a detached plain blockquote**: the `**` leaked as text and the summary was divorced from its body.

Normal-length replies were never affected.

## Root cause

`telegram-plugin/telegraph.ts`, `markdownToTelegraphNodes`: the blockquote branch matched only `/^>\s?/`, so a `**>` opener fell through to paragraph handling (the unterminated `**` becomes literal text) and the following `>` lines were collected as a *separate* quote. `isBlockStart` in the same file only knew `/^>\s?/` too, so a preceding paragraph could absorb a following `**>` line.

The live outbound entity path (`render/parse.ts`, `render/render.ts`) already handles `**>` correctly — only this Instant View node builder ever disagreed. That path is untouched here.

## Fix

- Hoist `const TELEGRAPH_QUOTE_LINE = /^(?:\*\*)?>\s?/` and use it in both the blockquote branch and `isBlockStart`.
- In the group loop, strip the marker with `.replace(TELEGRAPH_QUOTE_LINE, '')` so a `**>` opener plus its `>` continuations fold into a **single** `blockquote` node with no literal `**>`.
- Telegra.ph's allowed-tag set (docblock at `telegraph.ts:23-30`) has **no** `expandable_blockquote` tag — Telegra.ph has no collapsible quote — so the faithful degradation is a normal `<blockquote>` with markers stripped. No `expandable_blockquote` node is emitted.

## Test plan

Three cases added to `telegram-plugin/tests/telegraph.test.ts`:

1. `**> summary` + `> body one` + `> body two` folds to exactly one `blockquote`, no literal `**>` and no stray `*`.
2. A paragraph directly above a `**>` line splits into `['p', 'blockquote']` (the `isBlockStart` half).
3. `**bold** > x` stays a paragraph — `**` is only a quote marker when `>` follows immediately.

Mutation-tested: reverting `TELEGRAPH_QUOTE_LINE` to `/^>\s?/` fails cases 1 and 2 (`Received length: 2` and a missing `blockquote` tag) and passes everything else. The tests fail on the bug they guard.

```
$ bun test telegram-plugin/tests/telegraph.test.ts
 33 pass
 0 fail
 54 expect() calls

$ node node_modules/typescript/bin/tsc --noEmit --skipLibCheck
(exit 0, no output)
```

## Risk

Low. Isolated pure function, no I/O, single file plus its test. Plain `>` quotes are unchanged (the `(?:\*\*)?` group is optional), and the regex stays `^`-anchored so mid-line bold is not misread. The outbound entity render path is not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
