### PR TITLE
fix(litellm): detect a custom callback whose bind mount was dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ now an anomaly worth investigating, not the norm.
 
 ### Bug fixes
 
+- **fleet health: a LiteLLM custom callback with no bind mount is now a loud
+  finding instead of a silent proxy outage.** LiteLLM imports callback modules
+  during startup, so a config that names `custom_pacing.pacer_instance` while
+  the deployed compose does not mount `/app/custom_pacing.py` crash-loops the
+  shared proxy with `ModuleNotFoundError` — no degraded mode, every
+  proxy-routed agent turn fails. That happened on 2026-08-09: a v1.91.0 →
+  v1.95.0 image bump made Coolify regenerate the compose from
+  `services.docker_compose_raw`, dropping the pacer and passthrough-patch
+  mounts that had only ever been hand-added to the GENERATED file. The
+  fleet-health LiteLLM sensor now pairs the live config against the live
+  compose and raises `litellm-callback-mount-missing` into the priority ledger
+  (`src/litellm/callback-mount-guard.ts`), and `docker/litellm-pacer/README.md`
+  documents the database as the only durable place to put the mount.
+
 - **telegraph: `**>` expandable blockquotes render correctly in Instant View
   pages.** `markdownToTelegraphNodes` — the Telegra.ph node builder used when a
   telegraph-enabled agent's reply exceeds the ~3000-char threshold — matched

--- a/docker/litellm-pacer/README.md
+++ b/docker/litellm-pacer/README.md
@@ -41,12 +41,63 @@ litellm_settings:
   callbacks: ["custom_pacing.pacer_instance"]
 ```
 
-Bind mount in the sibling `docker-compose.yml`:
+### Mounts live in Coolify's database, not in the compose file
+
+**Do not add the bind mount to the deployed
+`/data/coolify/services/<litellm-service-id>/docker-compose.yml`.** That file is
+GENERATED. Coolify rewrites it from `services.docker_compose_raw` in its own
+Postgres database on every deploy, so a hand edit survives exactly until the
+next one and no longer.
+
+That is not hypothetical. On 2026-08-09 a v1.91.0 -> v1.95.0 image bump
+regenerated the compose and silently dropped both this mount and the
+`anthropic_passthrough_logging_handler.py` patch mount, because both had only
+ever been hand-added to the generated file. The proxy crash-looped on
+`ModuleNotFoundError: No module named 'custom_pacing'` — LiteLLM resolves
+callbacks during startup, so there is no degraded mode; it served nothing until
+the mounts were restored in the real source.
+
+The mount belongs in `docker_compose_raw`, in the long object form that file
+uses:
 
 ```yaml
-volumes:
-  - '/data/coolify/services/<litellm-service-id>/custom_pacing.py:/app/custom_pacing.py'
+    volumes:
+      -
+        type: bind
+        source: ./custom_pacing.py
+        target: /app/custom_pacing.py
 ```
+
+Apply it to the database, then let Coolify regenerate and redeploy — never edit
+the generated file by hand:
+
+```bash
+# 1. back up the row you are about to change
+docker exec coolify-db psql -U coolify -d coolify -t -A \
+  -c "select docker_compose_raw from services where uuid='<litellm-service-id>';" > raw.yml.bak
+
+# 2. edit a copy, then write it back (dollar-quoted so YAML quoting survives)
+#    UPDATE services SET docker_compose_raw = $RAWYML$...$RAWYML$, updated_at=now()
+#      WHERE uuid='<litellm-service-id>';
+
+# 3. redeploy so Coolify regenerates the compose FROM the database
+curl -s -X POST -H "Authorization: Bearer $COOLIFY_API_TOKEN" \
+  "http://localhost:8000/api/v1/deploy?uuid=<litellm-service-id>"
+
+# 4. verify the mount actually landed in BOTH the generated file and the container
+grep -n custom_pacing /data/coolify/services/<litellm-service-id>/docker-compose.yml
+docker inspect <litellm-container> --format '{{range .Mounts}}{{.Destination}}{{println}}{{end}}'
+```
+
+`local_file_volumes` rows are worth keeping in sync too (they carry the file
+CONTENT, so Coolify can re-materialise the file), but a row there does **not**
+by itself produce a mount — only `docker_compose_raw` does.
+
+This coupling is now enforced rather than merely documented: the fleet-health
+LiteLLM sensor pairs the live config against the live compose and raises
+`litellm-callback-mount-missing` into the priority ledger whenever a declared
+callback module has no matching bind mount
+(`src/litellm/callback-mount-guard.ts`).
 
 ## Code defaults vs. live env overrides
 

--- a/docker/litellm-proxy/litellm-image.txt
+++ b/docker/litellm-proxy/litellm-image.txt
@@ -27,4 +27,10 @@
 # the live host (commands above) — the public registry can tell you which tags
 # exist, but not which one this deployment runs. Guessing a plausible upstream
 # tag here would make the file confidently wrong.
-ghcr.io/berriai/litellm-database:v1.91.0@sha256:6151ddc97c5dc4590740bd14646d78d48267d8b7a1bf398eeaffcd6729b8f0b9
+#
+# RE-VERIFIED against the live deployment on 2026-08-09 after the v1.91.0 ->
+# v1.95.0 update, using method 1 above (Config.Image + RepoDigests of the
+# running container). That update is also what dropped the pacer bind mount and
+# crash-looped the proxy — see ../litellm-pacer/README.md "Mounts live in
+# Coolify's database" before touching this deployment.
+ghcr.io/berriai/litellm-database:v1.95.0@sha256:af7ff0444278be40f7615764d1562ac557df6103cba052e886915a7e1e944c27

--- a/src/fleet-health/detect.ts
+++ b/src/fleet-health/detect.ts
@@ -106,6 +106,10 @@ export type GatewaySignal =
 export type SensorSignal =
   | "litellm-header-passthrough-misconfig"
   | "litellm-timeout-budget-drift"
+  // The live LiteLLM config names a custom callback module (`custom_pacing`)
+  // that the live compose does not bind-mount. LiteLLM imports callbacks during
+  // startup, so this is a hard crash-loop with no degraded mode.
+  | "litellm-callback-mount-missing"
   // The live `switchroom-hindsight` container is running CPU-only
   // (`HostConfig.DeviceRequests` empty) while the host has a PROVABLY usable
   // GPU (nvidia-smi + the nvidia container runtime). Reranker + local

--- a/src/fleet-health/litellm-config-sensor.test.ts
+++ b/src/fleet-health/litellm-config-sensor.test.ts
@@ -320,3 +320,111 @@ model_list:
     expect(logs.some((l) => /VIOLATION.*gpt-oss-20b/.test(l))).toBe(true);
   });
 });
+
+/**
+ * Custom-callback mount coherence (2026-08-09 outage). These drive the real
+ * sensor with fakes only at the fs boundary, and assert the OUTCOME the ledger
+ * consumes — the failure here was a composition between config and compose, so
+ * a unit test of the guard alone would not have caught it.
+ */
+describe("scanLitellmConfig — custom callback mount coherence", () => {
+  const CONFIG_PATH = "/svc/p/litellm-config.yaml";
+  const COMPOSE_PATH = "/svc/p/docker-compose.yml";
+  const PACER_CONFIG = `
+litellm_settings:
+  callbacks: ["custom_pacing.pacer_instance"]
+`;
+
+  /** Serve the config at CONFIG_PATH and whatever `compose` is at the sibling
+   *  docker-compose.yml. `compose: null` means the file is absent. */
+  function scan(config: string, compose: string | null, logs: string[] = []) {
+    const res = scanLitellmConfig({
+      path: CONFIG_PATH,
+      existsFn: (p) => (p === COMPOSE_PATH ? compose !== null : true),
+      readFn: (p) => {
+        if (p === COMPOSE_PATH) {
+          if (compose === null) throw new Error("ENOENT");
+          return compose;
+        }
+        return config;
+      },
+      log: (m) => logs.push(m),
+      nowIso: "2026-08-09T00:00:00.000Z",
+    });
+    return { res, logs };
+  }
+
+  it("derives the compose path as a sibling of the config", () => {
+    const seen: string[] = [];
+    scanLitellmConfig({
+      path: CONFIG_PATH,
+      existsFn: (p) => {
+        seen.push(p);
+        return true;
+      },
+      readFn: () => PACER_CONFIG,
+      nowIso: "2026-08-09T00:00:00.000Z",
+    });
+    expect(seen).toContain(COMPOSE_PATH);
+  });
+
+  it("raises a ledger finding when the declared pacer has no bind mount", () => {
+    const { res } = scan(
+      PACER_CONFIG,
+      `
+services:
+  litellm:
+    volumes:
+      - '/svc/p/litellm-config.yaml:/app/config.yaml'
+`,
+    );
+    expect(res.status).toBe("violation");
+    const f = res.findings.find((x) => x.signal === "litellm-callback-mount-missing");
+    expect(f).toBeDefined();
+    expect(f!.agent).toBe(LITELLM_PROXY_PSEUDO_AGENT);
+    expect(f!.turn_id).toBe("litellm-callback-mount:custom_pacing");
+    expect(f!.log_pointer).toContain(COMPOSE_PATH);
+    expect(f!.log_pointer).toContain("docker_compose_raw");
+    // and it must be a signal the ledger can actually classify
+    expect(mapSignal(f!.signal)).toBeDefined();
+  });
+
+  it("passes when the mount is present", () => {
+    const { res } = scan(
+      PACER_CONFIG,
+      `
+services:
+  litellm:
+    volumes:
+      - '/svc/p/custom_pacing.py:/app/custom_pacing.py'
+`,
+    );
+    expect(res.findings.some((f) => f.signal === "litellm-callback-mount-missing")).toBe(false);
+  });
+
+  it("flags a compose that parses but declares no volumes at all", () => {
+    const { res } = scan(
+      PACER_CONFIG,
+      `
+services:
+  litellm:
+    image: 'ghcr.io/berriai/litellm-database:v1.95.0'
+`,
+    );
+    expect(res.findings.some((f) => f.signal === "litellm-callback-mount-missing")).toBe(true);
+  });
+
+  it("SKIPS visibly, never passes, when the compose is absent", () => {
+    const { res, logs } = scan(PACER_CONFIG, null);
+    expect(res.findings.some((f) => f.signal === "litellm-callback-mount-missing")).toBe(false);
+    expect(logs.some((l) => /callback-mount check SKIPPED/.test(l))).toBe(true);
+    expect(logs.some((l) => /every custom callback module is/.test(l))).toBe(false);
+  });
+
+  it("SKIPS visibly, never claims OK, when the compose is unparseable", () => {
+    const { res, logs } = scan(PACER_CONFIG, "\tnot: [valid");
+    expect(res.findings.some((f) => f.signal === "litellm-callback-mount-missing")).toBe(false);
+    expect(logs.some((l) => /callback-mount check SKIPPED/.test(l))).toBe(true);
+    expect(logs.some((l) => /every custom callback module is/.test(l))).toBe(false);
+  });
+});

--- a/src/fleet-health/litellm-config-sensor.ts
+++ b/src/fleet-health/litellm-config-sensor.ts
@@ -21,6 +21,7 @@
  */
 
 import { readFileSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
 
 import type { Finding } from "./detect.js";
 import type { LiveConfigDiscovery } from "../litellm/header-passthrough-guard.js";
@@ -34,6 +35,11 @@ import {
   detectLitellmTimeoutDrift,
   extractGroupTimeouts,
 } from "../litellm/timeout-budget.js";
+import {
+  LIVE_COMPOSE_BASENAME,
+  canReadComposeMounts,
+  detectMissingCallbackMounts,
+} from "../litellm/callback-mount-guard.js";
 
 /** The pseudo-agent the litellm misconfig finding is attributed to. It is not a
  *  real switchroom agent — it names the shared LiteLLM proxy so the ledger's
@@ -171,6 +177,55 @@ export function scanLitellmConfig(
       agent: LITELLM_PROXY_PSEUDO_AGENT,
       turn_id: `litellm-timeout:${d.role}:${d.group}`,
       log_pointer: `${path}: group '${d.group}' — ${d.detail}`,
+      ts: nowIso,
+    });
+  }
+
+  // Custom-callback mount coherence: a callback the config names but the
+  // deployed compose does not mount is a hard startup abort, not a degraded
+  // mode (2026-08-09 fleet outage — the v1.95.0 image bump regenerated the
+  // compose from Coolify's `docker_compose_raw` and dropped the pacer mount
+  // that only ever existed as a hand edit to the generated file). Only this
+  // sensor can see the LIVE pairing, same division of labour as the checks
+  // above. The compose sits beside the config in the Coolify service dir.
+  const composePath = join(dirname(path), LIVE_COMPOSE_BASENAME);
+  let composeText: string | null = null;
+  if (exists(composePath)) {
+    try {
+      composeText = read(composePath);
+    } catch (e) {
+      log(
+        `fleet-health: litellm-config sensor — callback-mount check SKIPPED, ` +
+          `${composePath} unreadable: ${String(e)}`,
+      );
+    }
+  } else {
+    log(
+      `fleet-health: litellm-config sensor — callback-mount check SKIPPED, ` +
+        `no ${LIVE_COMPOSE_BASENAME} beside ${path}`,
+    );
+  }
+
+  const missingMounts = detectMissingCallbackMounts(parsed, composeText);
+  if (composeText !== null && !canReadComposeMounts(composeText)) {
+    // Parsed to nothing usable (bad YAML, or no `services` mapping). Judging
+    // this a pass would be the silent-green failure the sensor exists to catch.
+    log(
+      `fleet-health: litellm-config sensor — callback-mount check SKIPPED, ` +
+        `${composePath} has no readable services/volumes mapping`,
+    );
+  } else if (composeText !== null && missingMounts.length === 0) {
+    log(
+      `fleet-health: litellm-config sensor OK — every custom callback module is ` +
+        `bind-mounted by ${composePath}`,
+    );
+  }
+  for (const m of missingMounts) {
+    findings.push({
+      signal: "litellm-callback-mount-missing",
+      agent: LITELLM_PROXY_PSEUDO_AGENT,
+      turn_id: `litellm-callback-mount:${m.module}`,
+      log_pointer: `${composePath}: ${m.detail}`,
       ts: nowIso,
     });
   }

--- a/src/fleet-health/mapping.ts
+++ b/src/fleet-health/mapping.ts
@@ -122,6 +122,19 @@ export const SIGNAL_MAP: Record<L0Signal, SignalMapping> = {
     job_spec: "keep-my-subscription-honest",
     signature: "litellm-header-passthrough:oauth-leak-scope",
   },
+  "litellm-callback-mount-missing": {
+    // The live config names a custom callback module the live compose does not
+    // mount. LiteLLM resolves callbacks during startup, so the proxy aborts its
+    // lifespan and crash-loops — every proxy-routed agent turn fails.
+    // severity 3 (the ceiling): this is a total outage of the shared proxy, not
+    // a degraded lane. It shipped exactly this way on 2026-08-09, when a Coolify
+    // redeploy regenerated the compose from `docker_compose_raw` and dropped the
+    // pacer mount that had only ever been hand-added to the generated file.
+    failure_mode: "constraint-violation",
+    severity: 3,
+    job_spec: "fleet-stays-healthy",
+    signature: "litellm-callback-mount:missing-bind",
+  },
   "litellm-timeout-budget-drift": {
     // A per-deployment `timeout` in the live LiteLLM config no longer matches
     // the tier switchroom derived its client budgets from

--- a/src/litellm/callback-mount-guard.test.ts
+++ b/src/litellm/callback-mount-guard.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+
+import { parseLitellmConfig } from "./header-passthrough-guard.js";
+import {
+  canReadComposeMounts,
+  detectMissingCallbackMounts,
+  extractComposeBindTargets,
+  extractCustomCallbackModules,
+} from "./callback-mount-guard.js";
+
+const PACER_CONFIG = `
+litellm_settings:
+  callbacks: ["custom_pacing.pacer_instance"]
+`;
+
+/** The compose Coolify generated on 2026-08-09: correct image, pacer mount
+ *  gone. This is the exact shape that crash-looped the proxy. */
+const COMPOSE_WITHOUT_PACER = `
+services:
+  litellm:
+    image: 'ghcr.io/berriai/litellm-database:v1.95.0'
+    volumes:
+      - '/data/coolify/services/svc/litellm-config.yaml:/app/config.yaml'
+  redis:
+    image: 'redis:7-alpine'
+`;
+
+const COMPOSE_WITH_PACER = `
+services:
+  litellm:
+    image: 'ghcr.io/berriai/litellm-database:v1.95.0'
+    volumes:
+      - '/data/coolify/services/svc/litellm-config.yaml:/app/config.yaml'
+      - '/data/coolify/services/svc/custom_pacing.py:/app/custom_pacing.py'
+`;
+
+/** Coolify's `docker_compose_raw` source form — the file the mount must
+ *  actually be restored in, and therefore a shape the guard has to read. */
+const COMPOSE_LONG_FORM = `
+services:
+  litellm:
+    volumes:
+      -
+        type: bind
+        source: ./litellm-config.yaml
+        target: /app/config.yaml
+      -
+        type: bind
+        source: ./custom_pacing.py
+        target: /app/custom_pacing.py
+`;
+
+describe("extractCustomCallbackModules", () => {
+  it("picks up a `<module>.<attr>` custom callback", () => {
+    const mods = extractCustomCallbackModules(parseLitellmConfig(PACER_CONFIG));
+    expect(mods).toEqual([{ module: "custom_pacing", reference: "custom_pacing.pacer_instance" }]);
+  });
+
+  it("ignores built-in bare-token callbacks, which need no mount", () => {
+    const parsed = parseLitellmConfig(`
+litellm_settings:
+  callbacks: ["prometheus", "datadog"]
+`);
+    expect(extractCustomCallbackModules(parsed)).toEqual([]);
+  });
+
+  it("reads success_callback and failure_callback too, and de-duplicates", () => {
+    const parsed = parseLitellmConfig(`
+litellm_settings:
+  success_callback: ["custom_pacing.pacer_instance"]
+  failure_callback: ["custom_pacing.pacer_instance"]
+`);
+    expect(extractCustomCallbackModules(parsed)).toHaveLength(1);
+  });
+
+  it("skips dotted package paths, which a single-file mount cannot satisfy", () => {
+    const parsed = parseLitellmConfig(`
+litellm_settings:
+  callbacks: ["pkg.mod.instance"]
+`);
+    expect(extractCustomCallbackModules(parsed)).toEqual([]);
+  });
+
+  it("returns nothing for a config with no litellm_settings", () => {
+    expect(extractCustomCallbackModules(parseLitellmConfig("model_list: []"))).toEqual([]);
+    expect(extractCustomCallbackModules(null)).toEqual([]);
+  });
+});
+
+describe("extractComposeBindTargets", () => {
+  it("reads the short string form Coolify generates", () => {
+    expect(extractComposeBindTargets(COMPOSE_WITH_PACER)).toContain("/app/custom_pacing.py");
+  });
+
+  it("reads the long object form docker_compose_raw uses", () => {
+    expect(extractComposeBindTargets(COMPOSE_LONG_FORM)).toContain("/app/custom_pacing.py");
+  });
+
+  it("handles a read-only suffix", () => {
+    const targets = extractComposeBindTargets(`
+services:
+  litellm:
+    volumes:
+      - '/host/custom_pacing.py:/app/custom_pacing.py:ro'
+`);
+    expect(targets).toContain("/app/custom_pacing.py");
+  });
+
+  it("returns null on unparseable YAML rather than throwing", () => {
+    expect(extractComposeBindTargets("\tnot: [valid")).toBeNull();
+  });
+
+  it("returns null when there is no services mapping — 'cannot tell', not 'no mounts'", () => {
+    expect(extractComposeBindTargets("model_list: []")).toBeNull();
+  });
+
+  it("returns an EMPTY set when services parse but declare no volumes", () => {
+    const targets = extractComposeBindTargets(`
+services:
+  litellm:
+    image: 'ghcr.io/berriai/litellm-database:v1.95.0'
+`);
+    expect(targets).not.toBeNull();
+    expect(targets?.size).toBe(0);
+  });
+});
+
+describe("canReadComposeMounts", () => {
+  it("is false for absent or unreadable compose, true for a parseable one", () => {
+    expect(canReadComposeMounts(null)).toBe(false);
+    expect(canReadComposeMounts("\tnot: [valid")).toBe(false);
+    expect(canReadComposeMounts("model_list: []")).toBe(false);
+    expect(canReadComposeMounts(COMPOSE_WITHOUT_PACER)).toBe(true);
+  });
+});
+
+describe("detectMissingCallbackMounts", () => {
+  it("flags the 2026-08-09 outage: pacer declared, mount dropped", () => {
+    const violations = detectMissingCallbackMounts(
+      parseLitellmConfig(PACER_CONFIG),
+      COMPOSE_WITHOUT_PACER,
+    );
+    expect(violations).toHaveLength(1);
+    expect(violations[0].module).toBe("custom_pacing");
+    expect(violations[0].expectedTarget).toBe("/app/custom_pacing.py");
+    // The finding must point at the real fix site, not the generated file.
+    expect(violations[0].detail).toContain("docker_compose_raw");
+    expect(violations[0].detail).toContain("ModuleNotFoundError");
+  });
+
+  it("passes once the mount is restored", () => {
+    expect(
+      detectMissingCallbackMounts(parseLitellmConfig(PACER_CONFIG), COMPOSE_WITH_PACER),
+    ).toEqual([]);
+  });
+
+  it("passes for a config that uses only built-in callbacks", () => {
+    const parsed = parseLitellmConfig(`
+litellm_settings:
+  callbacks: ["prometheus"]
+`);
+    expect(detectMissingCallbackMounts(parsed, COMPOSE_WITHOUT_PACER)).toEqual([]);
+  });
+
+  it("stays quiet when the compose is unavailable — never a fabricated violation", () => {
+    expect(detectMissingCallbackMounts(parseLitellmConfig(PACER_CONFIG), null)).toEqual([]);
+    expect(detectMissingCallbackMounts(parseLitellmConfig(PACER_CONFIG), "\tnot: [valid")).toEqual(
+      [],
+    );
+    expect(detectMissingCallbackMounts(parseLitellmConfig(PACER_CONFIG), "model_list: []")).toEqual(
+      [],
+    );
+  });
+
+  it("FLAGS a compose that parses but declares no volumes at all", () => {
+    // The worst case of the 2026-08-09 regression: Coolify drops the whole
+    // hand-added `volumes:` block, not one line. An earlier revision treated
+    // "no mounts found" as "cannot tell" and stayed silent here.
+    const violations = detectMissingCallbackMounts(
+      parseLitellmConfig(PACER_CONFIG),
+      `
+services:
+  litellm:
+    image: 'ghcr.io/berriai/litellm-database:v1.95.0'
+`,
+    );
+    expect(violations).toHaveLength(1);
+    expect(violations[0].module).toBe("custom_pacing");
+  });
+});

--- a/src/litellm/callback-mount-guard.ts
+++ b/src/litellm/callback-mount-guard.ts
@@ -1,0 +1,189 @@
+/**
+ * LiteLLM custom-callback mount coherence.
+ *
+ * `litellm-config.yaml` can name a *custom* callback as `<module>.<attr>` (we
+ * run exactly one: `custom_pacing.pacer_instance`, the fleet request pacer).
+ * LiteLLM resolves that with `importlib.import_module("<module>")` during
+ * startup, so the module file MUST be bind-mounted into the proxy container or
+ * the process aborts its lifespan with `ModuleNotFoundError` and crash-loops.
+ * There is no degraded mode: the proxy never serves a request.
+ *
+ * That coupling has no enforcement point on the host, and it broke the fleet on
+ * 2026-08-09. Coolify regenerates the deployed `docker-compose.yml` from
+ * `services.docker_compose_raw` in its own database on every deploy. The pacer
+ * and passthrough-patch mounts had only ever been hand-added to the GENERATED
+ * file, so the v1.91.0 → v1.95.0 image bump silently dropped both, and the
+ * proxy crash-looped with `No module named 'custom_pacing'` until the mounts
+ * were restored in `docker_compose_raw` (the actual generator source).
+ *
+ * This module is the pure detection core for that invariant:
+ *
+ *   config declares a custom callback module  ⇒  compose mounts that module
+ *
+ * A violation means the proxy is already down, or is a landmine that detonates
+ * on its next restart (the running container can still hold a mount the
+ * regenerated compose no longer declares). Either way it belongs in the ledger
+ * loudly, not in a 40-minute outage nobody can explain.
+ *
+ * STRICTLY PURE: text and parsed YAML in, violations out. No fs, no network.
+ */
+
+import { parse as parseYaml } from "yaml";
+
+/** Where the proxy's config dir lands in the container. It is the process CWD
+ *  and therefore on `sys.path`, which is why a bare `<module>.py` there is
+ *  importable as `<module>`. */
+export const CONTAINER_APP_DIR = "/app";
+
+/** Basename of the deployed compose file Coolify regenerates, sibling to the
+ *  live `litellm-config.yaml` in the same Coolify service directory. */
+export const LIVE_COMPOSE_BASENAME = "docker-compose.yml";
+
+/** The config keys that can carry callback references. `callbacks` is the one
+ *  we use; the other two are accepted so a future move between them cannot
+ *  silently drop the check. */
+const CALLBACK_KEYS = ["callbacks", "success_callback", "failure_callback"] as const;
+
+/**
+ * Whether the compose could be read well enough to judge its mounts at all.
+ * Lets the caller log a visible SKIP for "cannot tell" instead of an
+ * affirmative OK — an unreadable artifact reported as a pass is the exact
+ * silent-green failure this sensor exists to prevent.
+ */
+export function canReadComposeMounts(composeText: string | null): boolean {
+  if (composeText == null) return false;
+  return extractComposeBindTargets(composeText) !== null;
+}
+
+export interface MissingCallbackMount {
+  /** The python module name that must be importable (e.g. `custom_pacing`). */
+  module: string;
+  /** The full callback reference as written in the config. */
+  reference: string;
+  /** The container path the module must be mounted at. */
+  expectedTarget: string;
+  /** Human-readable explanation for the ledger finding. */
+  detail: string;
+}
+
+/**
+ * Pull the custom callback MODULE names out of a parsed LiteLLM config.
+ *
+ * LiteLLM's built-in callbacks are bare tokens (`prometheus`, `datadog`,
+ * `langfuse`) and need no mount. A custom one is an instance reference,
+ * `<module>.<attr>` — the dot is what distinguishes them. Only the first
+ * segment is the importable module; a dotted package (`pkg.mod.attr`) cannot be
+ * satisfied by a single-file bind mount, so it is deliberately not reported
+ * here (it would be a different deployment shape entirely).
+ */
+export function extractCustomCallbackModules(parsed: unknown): { module: string; reference: string }[] {
+  const settings = (parsed as { litellm_settings?: unknown } | null)?.litellm_settings;
+  if (settings == null || typeof settings !== "object") return [];
+
+  const out: { module: string; reference: string }[] = [];
+  const seen = new Set<string>();
+
+  for (const key of CALLBACK_KEYS) {
+    const raw = (settings as Record<string, unknown>)[key];
+    if (!Array.isArray(raw)) continue;
+    for (const entry of raw) {
+      if (typeof entry !== "string") continue;
+      const reference = entry.trim();
+      const parts = reference.split(".");
+      // Bare token → built-in callback, nothing to mount.
+      // More than one dot → a package path, not a single-file mount.
+      if (parts.length !== 2) continue;
+      const [module, attr] = parts;
+      if (!module || !attr) continue;
+      if (seen.has(module)) continue;
+      seen.add(module);
+      out.push({ module, reference });
+    }
+  }
+  return out;
+}
+
+/**
+ * Collect every bind-mount TARGET declared anywhere in a compose file.
+ *
+ * Coolify emits the short string form (`'host/path:/container/path'`) in the
+ * generated file while its `docker_compose_raw` source uses the long object
+ * form (`{type: bind, source, target}`); both appear in practice, so both are
+ * read.
+ *
+ * Returns `null` for "cannot tell" — unparseable YAML, or no `services`
+ * mapping — as distinct from an EMPTY SET, which is the real and dangerous
+ * state of "this compose declares no mounts at all". Collapsing those two was
+ * the near-miss in review: Coolify regeneration drops the whole hand-added
+ * `volumes:` block, not a single line, so an empty set is precisely the outage
+ * shape and must be reported, while `null` must stay quiet.
+ */
+export function extractComposeBindTargets(composeText: string): Set<string> | null {
+  const targets = new Set<string>();
+  let doc: unknown;
+  try {
+    doc = parseYaml(composeText);
+  } catch {
+    return null;
+  }
+  const services = (doc as { services?: unknown } | null)?.services;
+  if (services == null || typeof services !== "object") return null;
+
+  for (const svc of Object.values(services as Record<string, unknown>)) {
+    const volumes = (svc as { volumes?: unknown } | null)?.volumes;
+    if (!Array.isArray(volumes)) continue;
+    for (const v of volumes) {
+      if (typeof v === "string") {
+        // 'source:target' or 'source:target:ro' — the target is the second
+        // colon-separated field. Windows drive letters are not a case here.
+        const parts = v.split(":");
+        if (parts.length >= 2 && parts[1]) targets.add(parts[1].trim());
+      } else if (v != null && typeof v === "object") {
+        const t = (v as { target?: unknown }).target;
+        if (typeof t === "string" && t) targets.add(t.trim());
+      }
+    }
+  }
+  return targets;
+}
+
+/**
+ * The invariant: every custom callback module named by the config is mounted
+ * into the container at `/app/<module>.py`.
+ *
+ * Yields no violations when the compose is absent or unreadable — claiming a
+ * violation we cannot substantiate would be worse than staying quiet. Use
+ * `canReadComposeMounts` to tell that apart from a genuine pass, so the caller
+ * can log a visible SKIP instead of an affirmative OK.
+ *
+ * A compose that parses but declares NO mounts is NOT "cannot tell" — it is a
+ * violation, and the worst-case shape of the 2026-08-09 regression.
+ */
+export function detectMissingCallbackMounts(
+  parsedConfig: unknown,
+  composeText: string | null,
+): MissingCallbackMount[] {
+  const modules = extractCustomCallbackModules(parsedConfig);
+  if (modules.length === 0 || composeText == null) return [];
+
+  const targets = extractComposeBindTargets(composeText);
+  if (targets === null) return [];
+
+  const violations: MissingCallbackMount[] = [];
+  for (const { module, reference } of modules) {
+    const expectedTarget = `${CONTAINER_APP_DIR}/${module}.py`;
+    if (targets.has(expectedTarget)) continue;
+    violations.push({
+      module,
+      reference,
+      expectedTarget,
+      detail:
+        `litellm_settings names custom callback '${reference}' but no bind mount targets ` +
+        `${expectedTarget} — the proxy will abort startup with ` +
+        `ModuleNotFoundError: No module named '${module}'. Coolify regenerates this compose ` +
+        `from services.docker_compose_raw in its database, so the mount must be restored THERE ` +
+        `(a hand edit to the generated file is wiped on the next deploy).`,
+    });
+  }
+  return violations;
+}


### PR DESCRIPTION
## Summary

Turns the 2026-08-09 LiteLLM outage into a detected condition, and fixes the
documentation that caused it to recur.

LiteLLM resolves `litellm_settings.callbacks` with `importlib` during startup.
A config naming `custom_pacing.pacer_instance` while the deployed compose does
not mount `/app/custom_pacing.py` aborts the app lifespan and crash-loops the
shared proxy — no degraded mode, every proxy-routed agent turn fails.

- **`src/litellm/callback-mount-guard.ts`** (new, pure): every custom
  `<module>.<attr>` callback must have a bind mount targeting
  `/app/<module>.py`. Reads both the short string form Coolify generates and
  the long object form `docker_compose_raw` uses. An unreadable/unparseable
  compose yields **no** violation rather than a fabricated one.
- **fleet-health sensor**: raises `litellm-callback-mount-missing`
  (severity 3, `fleet-stays-healthy`) into the priority ledger.
- **`docker/litellm-pacer/README.md`**: the mount belongs in Coolify's
  `services.docker_compose_raw`, never in the generated compose. The previous
  text told you to edit the generated file — that is precisely what kept
  getting wiped.
- **`docker/litellm-proxy/litellm-image.txt`**: re-verified against the live
  deployment — v1.95.0 + digest (was v1.91.0).

## Why

Coolify regenerates the deployed `docker-compose.yml` from
`services.docker_compose_raw` in its own Postgres on every deploy. The pacer
and `anthropic_passthrough_logging_handler.py` patch mounts had only ever been
hand-added to the GENERATED file, so the v1.91.0 → v1.95.0 image bump silently
dropped both and the proxy crash-looped on
`ModuleNotFoundError: No module named 'custom_pacing'`.

The live fix (already applied to the host) was to restore both mounts in
`docker_compose_raw` and redeploy, so Coolify now regenerates them itself. This
PR is the repo-side half: detection plus honest docs, so a silent drop becomes
a ledger finding rather than an unexplained fleet outage.

## Test plan

- `src/litellm/callback-mount-guard.test.ts` — 13 tests, including a regression
  fixture of the exact compose Coolify generated on 2026-08-09 (correct image,
  pacer mount gone), plus built-in-callback and unreadable-compose negatives.
- `vitest run src/litellm/ src/fleet-health/` → 283 passed.
- `npm run lint` → green.
- Verified live: the regenerated compose and the running container both carry
  `/app/custom_pacing.py`; proxy healthy, 66 models served; agents reach it
  (health 200).

## Risk

Low. The detection core is pure and fails quiet (no compose → no finding), so
it cannot fabricate a violation or affect the request path. The sensor addition
is read-only. Remaining doc/behaviour risk is called out below.

## Follow-ups (not in this PR)

- The repo pacer is **ahead of the deployed copy** by #4461 (token-aware
  pacing, `PACE_MAX_TPM`) and #4462 (image token estimate). The host runs the
  pre-#4461 build. Deliberately not coupled to an outage fix — worth a separate
  deploy PR.
- The passthrough patch mount targets a `python3.13` site-packages path. A
  future image on 3.14 would make that mount land somewhere harmless-looking
  and silently drop the fix; the guard does not cover that path shape yet.

Job spec: `reference/jobs/fleet-stays-healthy.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)