### PR TITLE
fix(litellm): detect a stale versioned site-packages passthrough mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,21 @@ now an anomaly worth investigating, not the norm.
   (`src/litellm/callback-mount-guard.ts`), and `docker/litellm-pacer/README.md`
   documents the database as the only durable place to put the mount.
 
+- **fleet health: a stale versioned passthrough patch mount is now caught
+  before it silently drops the patch.** The pacer's
+  `anthropic_passthrough_logging_handler.py` patch mount shadows a file at a
+  hard-coded CPython minor version
+  (`/app/.venv/lib/python3.13/site-packages/…`). A future image built on python
+  3.14 moves site-packages, so the 3.13 target lands at an inert path and the
+  patch is SILENTLY dropped — no crash (unlike the callback case above), the
+  proxy comes up "healthy" on unpatched code, so nothing but a standing sensor
+  would surface it. The fleet-health LiteLLM sensor now validates every
+  versioned `pythonX.Y` site-packages shadow mount against the live image's
+  actual CPython version (resolved from the live container) and raises
+  `litellm-passthrough-mount-stale` into the priority ledger
+  (`src/litellm/passthrough-mount-guard.ts`) — closing the residual hazard the
+  callback-mount guard left open.
+
 - **hindsight: recall-pool split follow-ups — first-boot health headroom, an
   audible `hindsight.env` conflict, and convergence on a disabled split.** Three
   low-severity gaps left open when the recall/background worker split landed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,10 @@ now an anomaly worth investigating, not the norm.
   versioned `pythonX.Y` site-packages shadow mount against the live image's
   actual CPython version (resolved from the live container) and raises
   `litellm-passthrough-mount-stale` into the priority ledger
-  (`src/litellm/passthrough-mount-guard.ts`) — closing the residual hazard the
-  callback-mount guard left open.
+  (`src/litellm/passthrough-mount-guard.ts`). Scope: this catches a mount pinned
+  to the WRONG python version, not a mount that was removed from the compose
+  entirely — a removed passthrough mount has no config anchor to test against
+  and stays uncovered (tracked separately in #4558).
 
 - **hindsight: recall-pool split follow-ups — first-boot health headroom, an
   audible `hindsight.env` conflict, and convergence on a disabled split.** Three

--- a/src/fleet-health/detect.ts
+++ b/src/fleet-health/detect.ts
@@ -110,6 +110,12 @@ export type SensorSignal =
   // that the live compose does not bind-mount. LiteLLM imports callbacks during
   // startup, so this is a hard crash-loop with no degraded mode.
   | "litellm-callback-mount-missing"
+  // The live compose declares a passthrough/patch bind mount whose target
+  // hard-codes a CPython minor version (`.../python3.13/site-packages/...`) that
+  // no longer matches the live image. The mount lands at an inert path and the
+  // patch is SILENTLY dropped — no crash, unlike the callback case; the proxy
+  // comes up "healthy" on unpatched code. See `passthrough-mount-guard.ts`.
+  | "litellm-passthrough-mount-stale"
   // The live `switchroom-hindsight` container is running CPU-only
   // (`HostConfig.DeviceRequests` empty) while the host has a PROVABLY usable
   // GPU (nvidia-smi + the nvidia container runtime). Reranker + local

--- a/src/fleet-health/litellm-config-sensor.test.ts
+++ b/src/fleet-health/litellm-config-sensor.test.ts
@@ -506,4 +506,33 @@ services:
     const { res } = scan(compose, "3.14");
     expect(res.findings.some((f) => f.signal === "litellm-passthrough-mount-stale")).toBe(false);
   });
+
+  it("skips the python-version resolve (no docker, no SKIP/OK log) when there is no versioned mount to check", () => {
+    // Gating fix: resolving the live image's python version costs two
+    // `docker exec`s, so it must not run — and must not emit a misleading
+    // "could not resolve" SKIP — on a compose that has zero versioned mounts.
+    const compose = `
+services:
+  litellm:
+    volumes:
+      - '/svc/p/custom_pacing.py:/app/custom_pacing.py'
+`;
+    let pythonVersionCalls = 0;
+    const logs: string[] = [];
+    const res = scanLitellmConfig({
+      path: CONFIG_PATH,
+      existsFn: (p) => (p === COMPOSE_PATH ? true : true),
+      readFn: (p) => (p === COMPOSE_PATH ? compose : PACER_CONFIG),
+      pythonVersionFn: () => {
+        pythonVersionCalls += 1;
+        return "3.14";
+      },
+      log: (m) => logs.push(m),
+      nowIso: "2026-08-09T00:00:00.000Z",
+    });
+    expect(pythonVersionCalls).toBe(0);
+    expect(res.findings.some((f) => f.signal === "litellm-passthrough-mount-stale")).toBe(false);
+    expect(logs.some((l) => /passthrough-mount check SKIPPED/.test(l))).toBe(false);
+    expect(logs.some((l) => /every versioned site-packages shadow/.test(l))).toBe(false);
+  });
 });

--- a/src/fleet-health/litellm-config-sensor.test.ts
+++ b/src/fleet-health/litellm-config-sensor.test.ts
@@ -428,3 +428,82 @@ services:
     expect(logs.some((l) => /every custom callback module is/.test(l))).toBe(false);
   });
 });
+
+describe("scanLitellmConfig — passthrough shadow-mount version coherence", () => {
+  const CONFIG_PATH = "/svc/p/litellm-config.yaml";
+  const COMPOSE_PATH = "/svc/p/docker-compose.yml";
+  const PACER_CONFIG = `
+litellm_settings:
+  callbacks: ["custom_pacing.pacer_instance"]
+`;
+  const PASSTHROUGH_TARGET =
+    "/app/.venv/lib/python3.13/site-packages/litellm/proxy/pass_through_endpoints/" +
+    "llm_provider_handlers/anthropic_passthrough_logging_handler.py";
+
+  /** Compose with both mounts present and correct for a python3.13 image. */
+  const COMPOSE_313 = `
+services:
+  litellm:
+    volumes:
+      - '/svc/p/custom_pacing.py:/app/custom_pacing.py'
+      - '/svc/p/anthropic_passthrough_logging_handler.py:${PASSTHROUGH_TARGET}'
+`;
+
+  /** Inject the live image's python version so the suite never touches docker. */
+  function scan(compose: string | null, pyVersion: string | null, logs: string[] = []) {
+    const res = scanLitellmConfig({
+      path: CONFIG_PATH,
+      existsFn: (p) => (p === COMPOSE_PATH ? compose !== null : true),
+      readFn: (p) => {
+        if (p === COMPOSE_PATH) {
+          if (compose === null) throw new Error("ENOENT");
+          return compose;
+        }
+        return PACER_CONFIG;
+      },
+      pythonVersionFn: () => pyVersion,
+      log: (m) => logs.push(m),
+      nowIso: "2026-08-09T00:00:00.000Z",
+    });
+    return { res, logs };
+  }
+
+  it("raises a ledger finding when a 3.13 shadow mount runs on a 3.14 image", () => {
+    // The bug: an image bumped to python 3.14 moves site-packages, the 3.13
+    // mount lands at an inert path, and the passthrough patch silently drops.
+    const { res } = scan(COMPOSE_313, "3.14");
+    expect(res.status).toBe("violation");
+    const f = res.findings.find((x) => x.signal === "litellm-passthrough-mount-stale");
+    expect(f).toBeDefined();
+    expect(f!.agent).toBe(LITELLM_PROXY_PSEUDO_AGENT);
+    expect(f!.turn_id).toBe("litellm-passthrough-mount:3.13->3.14");
+    expect(f!.log_pointer).toContain(COMPOSE_PATH);
+    expect(f!.log_pointer).toContain("docker_compose_raw");
+    expect(f!.log_pointer).toContain("SILENTLY dropped");
+    // and it must be a signal the ledger can actually classify
+    expect(mapSignal(f!.signal)).toBeDefined();
+  });
+
+  it("passes when the shadow mount matches the live image's python version", () => {
+    const { res } = scan(COMPOSE_313, "3.13");
+    expect(res.findings.some((f) => f.signal === "litellm-passthrough-mount-stale")).toBe(false);
+  });
+
+  it("SKIPS visibly, never claims OK, when the image python version is unresolvable", () => {
+    const { res, logs } = scan(COMPOSE_313, null);
+    expect(res.findings.some((f) => f.signal === "litellm-passthrough-mount-stale")).toBe(false);
+    expect(logs.some((l) => /passthrough-mount check SKIPPED/.test(l))).toBe(true);
+    expect(logs.some((l) => /every versioned site-packages shadow/.test(l))).toBe(false);
+  });
+
+  it("does not flag a compose with no versioned shadow mounts", () => {
+    const compose = `
+services:
+  litellm:
+    volumes:
+      - '/svc/p/custom_pacing.py:/app/custom_pacing.py'
+`;
+    const { res } = scan(compose, "3.14");
+    expect(res.findings.some((f) => f.signal === "litellm-passthrough-mount-stale")).toBe(false);
+  });
+});

--- a/src/fleet-health/litellm-config-sensor.ts
+++ b/src/fleet-health/litellm-config-sensor.ts
@@ -20,6 +20,7 @@
  * a structured finding. No LLM, no network.
  */
 
+import { execFileSync } from "node:child_process";
 import { readFileSync, existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 
@@ -40,6 +41,7 @@ import {
   canReadComposeMounts,
   detectMissingCallbackMounts,
 } from "../litellm/callback-mount-guard.js";
+import { detectStalePassthroughMounts } from "../litellm/passthrough-mount-guard.js";
 
 /** The pseudo-agent the litellm misconfig finding is attributed to. It is not a
  *  real switchroom agent — it names the shared LiteLLM proxy so the ledger's
@@ -58,6 +60,11 @@ export interface LitellmSensorOptions {
   /** Live-config discovery, injectable so tests never depend on the host's
    *  real `/data/coolify/services` tree (see `DiscoverFn`). */
   discoverFn?: DiscoverFn;
+  /** Resolve the CPython minor version the LIVE litellm image actually ships
+   *  (e.g. `"3.13"`), or null when it cannot be determined (docker down, no
+   *  container, off-host CI/dev). Injectable so the suite never depends on a
+   *  real container. Defaults to `resolveLiveLitellmPythonVersion`. */
+  pythonVersionFn?: PythonVersionFn;
   log?: (msg: string) => void;
   /** Timestamp for the finding (ISO). Defaults to now. */
   nowIso?: string;
@@ -79,6 +86,55 @@ export interface LitellmSensorResult {
  * exists — a host-dependent test is a real defect, fixed by injecting here.
  */
 export type DiscoverFn = () => LiveConfigDiscovery;
+
+/**
+ * Resolve-the-live-image-python-version seam. Defaults to a `docker exec` of the
+ * live litellm container (same `docker inspect`-the-live-container division of
+ * labour the image pin and the GPU-drift sensor use). Tests inject a stub so
+ * they assert the version-coherence LOGIC instead of reaching for a real
+ * container. Returns null for "cannot tell" — docker down, no container,
+ * off-host CI/dev — which the passthrough check treats as a visible skip.
+ */
+export type PythonVersionFn = () => string | null;
+
+/**
+ * Default live resolver: find the litellm container and read the CPython minor
+ * version its interpreter actually ships, straight from the venv site-packages
+ * layout (`/app/.venv/lib/pythonX.Y/`). That layout IS the ground truth a
+ * versioned shadow mount must match, so reading it — rather than guessing from
+ * the image tag, which does not encode python — is what makes the check
+ * substantiated. Any failure (no docker, no container, unexpected layout)
+ * returns null so the sensor skips instead of fabricating a version.
+ *
+ * Model-free: two docker calls, no LLM, no network. Not exercised by the unit
+ * suite (which injects `pythonVersionFn`); it runs only on-host where the scan
+ * runs and a real container exists.
+ */
+export function resolveLiveLitellmPythonVersion(): string | null {
+  try {
+    const ps = execFileSync("docker", ["ps", "--format", "{{.Names}}\t{{.Image}}"], {
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const line = ps
+      .split("\n")
+      .find((l) => /litellm-database|(^|\s)litellm/i.test(l) && l.trim().length > 0);
+    if (!line) return null;
+    const name = line.split("\t")[0]?.trim();
+    if (!name) return null;
+
+    const lsOut = execFileSync(
+      "docker",
+      ["exec", name, "sh", "-c", "ls -d /app/.venv/lib/python*/ 2>/dev/null"],
+      { encoding: "utf-8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"] },
+    );
+    const m = lsOut.match(/python(\d+\.\d+)/);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Resolve the live config path: explicit arg → `LITELLM_CONFIG_PATH` env →
@@ -226,6 +282,40 @@ export function scanLitellmConfig(
       agent: LITELLM_PROXY_PSEUDO_AGENT,
       turn_id: `litellm-callback-mount:${m.module}`,
       log_pointer: `${composePath}: ${m.detail}`,
+      ts: nowIso,
+    });
+  }
+
+  // Passthrough / shadow-mount version coherence: a patch mount whose target
+  // hard-codes a CPython minor version the live image no longer ships lands at
+  // an inert path and SILENTLY drops the patch — no crash, unlike the callback
+  // case above, so nothing but this check would surface it. It is the residual
+  // hazard #4553's callback guard left open. Resolving the image's real python
+  // version needs the live container, so it goes through an injectable seam; a
+  // null result (docker down, no container, off-host CI/dev) is a visible skip,
+  // never a fabricated finding.
+  const pythonVersionFn = opts.pythonVersionFn ?? resolveLiveLitellmPythonVersion;
+  const actualPythonVersion = composeText !== null ? pythonVersionFn() : null;
+  if (composeText !== null && canReadComposeMounts(composeText) && actualPythonVersion === null) {
+    log(
+      `fleet-health: litellm-config sensor — passthrough-mount check SKIPPED, ` +
+        `could not resolve the live litellm image's CPython version (docker down, no ` +
+        `container, or off-host CI/dev)`,
+    );
+  }
+  const staleMounts = detectStalePassthroughMounts(composeText, actualPythonVersion);
+  if (composeText !== null && actualPythonVersion !== null && staleMounts.length === 0) {
+    log(
+      `fleet-health: litellm-config sensor OK — every versioned site-packages shadow ` +
+        `mount in ${composePath} matches the live image's CPython ${actualPythonVersion}`,
+    );
+  }
+  for (const s of staleMounts) {
+    findings.push({
+      signal: "litellm-passthrough-mount-stale",
+      agent: LITELLM_PROXY_PSEUDO_AGENT,
+      turn_id: `litellm-passthrough-mount:${s.declaredPythonVersion}->${s.actualPythonVersion}`,
+      log_pointer: `${composePath}: ${s.detail}`,
       ts: nowIso,
     });
   }

--- a/src/fleet-health/litellm-config-sensor.ts
+++ b/src/fleet-health/litellm-config-sensor.ts
@@ -41,7 +41,10 @@ import {
   canReadComposeMounts,
   detectMissingCallbackMounts,
 } from "../litellm/callback-mount-guard.js";
-import { detectStalePassthroughMounts } from "../litellm/passthrough-mount-guard.js";
+import {
+  detectStalePassthroughMounts,
+  extractVersionedSitePackagesMounts,
+} from "../litellm/passthrough-mount-guard.js";
 
 /** The pseudo-agent the litellm misconfig finding is attributed to. It is not a
  *  real switchroom agent — it names the shared LiteLLM proxy so the ledger's
@@ -286,17 +289,23 @@ export function scanLitellmConfig(
     });
   }
 
-  // Passthrough / shadow-mount version coherence: a patch mount whose target
+  // Passthrough / shadow-mount version STALENESS: a patch mount whose target
   // hard-codes a CPython minor version the live image no longer ships lands at
   // an inert path and SILENTLY drops the patch — no crash, unlike the callback
-  // case above, so nothing but this check would surface it. It is the residual
-  // hazard #4553's callback guard left open. Resolving the image's real python
-  // version needs the live container, so it goes through an injectable seam; a
-  // null result (docker down, no container, off-host CI/dev) is a visible skip,
-  // never a fabricated finding.
+  // case above, so nothing but this check would surface it. Scope note: this
+  // detects a mount pinned to the WRONG python version, not a mount that was
+  // removed entirely — removal has no config anchor to test against and stays
+  // uncovered (tracked in #4558). Resolving the image's real python version
+  // costs two `docker exec`s, so gate it behind "there is actually a versioned
+  // mount to validate": on a compose with zero versioned mounts there is
+  // nothing to check, so skip the resolve (and its log) entirely rather than
+  // paying ~10s and emitting a misleading "could not resolve" line every scan.
+  const versionedMounts =
+    composeText !== null ? extractVersionedSitePackagesMounts(composeText) : null;
+  const hasVersionedMounts = versionedMounts !== null && versionedMounts.length > 0;
   const pythonVersionFn = opts.pythonVersionFn ?? resolveLiveLitellmPythonVersion;
-  const actualPythonVersion = composeText !== null ? pythonVersionFn() : null;
-  if (composeText !== null && canReadComposeMounts(composeText) && actualPythonVersion === null) {
+  const actualPythonVersion = hasVersionedMounts ? pythonVersionFn() : null;
+  if (hasVersionedMounts && actualPythonVersion === null) {
     log(
       `fleet-health: litellm-config sensor — passthrough-mount check SKIPPED, ` +
         `could not resolve the live litellm image's CPython version (docker down, no ` +
@@ -304,7 +313,7 @@ export function scanLitellmConfig(
     );
   }
   const staleMounts = detectStalePassthroughMounts(composeText, actualPythonVersion);
-  if (composeText !== null && actualPythonVersion !== null && staleMounts.length === 0) {
+  if (hasVersionedMounts && actualPythonVersion !== null && staleMounts.length === 0) {
     log(
       `fleet-health: litellm-config sensor OK — every versioned site-packages shadow ` +
         `mount in ${composePath} matches the live image's CPython ${actualPythonVersion}`,

--- a/src/fleet-health/mapping.ts
+++ b/src/fleet-health/mapping.ts
@@ -135,6 +135,22 @@ export const SIGNAL_MAP: Record<L0Signal, SignalMapping> = {
     job_spec: "fleet-stays-healthy",
     signature: "litellm-callback-mount:missing-bind",
   },
+  "litellm-passthrough-mount-stale": {
+    // The live compose declares a passthrough/patch shadow mount whose target
+    // hard-codes a CPython minor version the live image no longer ships, so the
+    // mount lands at an inert path and the patch is silently dropped. Unlike the
+    // callback case this does NOT crash the proxy — it comes up "healthy" while
+    // running unpatched code, which is why it needs a standing sensor rather than
+    // an outage to surface it. `constraint-violation`: the deploy has quietly
+    // broken the mount-version invariant the pacer's passthrough metering
+    // depends on. severity 3 — a silent correctness defect on the shared proxy
+    // that no health check would otherwise catch, and the exact residual hazard
+    // left open by the callback-mount guard (#4553).
+    failure_mode: "constraint-violation",
+    severity: 3,
+    job_spec: "fleet-stays-healthy",
+    signature: "litellm-passthrough-mount:stale-python-version",
+  },
   "litellm-timeout-budget-drift": {
     // A per-deployment `timeout` in the live LiteLLM config no longer matches
     // the tier switchroom derived its client budgets from

--- a/src/fleet-health/mapping.ts
+++ b/src/fleet-health/mapping.ts
@@ -144,8 +144,10 @@ export const SIGNAL_MAP: Record<L0Signal, SignalMapping> = {
     // an outage to surface it. `constraint-violation`: the deploy has quietly
     // broken the mount-version invariant the pacer's passthrough metering
     // depends on. severity 3 — a silent correctness defect on the shared proxy
-    // that no health check would otherwise catch, and the exact residual hazard
-    // left open by the callback-mount guard (#4553).
+    // that no health check would otherwise catch. Scope: this covers a mount
+    // pinned to the WRONG python version, NOT a passthrough mount removed from
+    // the compose entirely — removal has no config anchor to test against and
+    // stays uncovered (tracked separately in #4558).
     failure_mode: "constraint-violation",
     severity: 3,
     job_spec: "fleet-stays-healthy",

--- a/src/litellm/passthrough-mount-guard.test.ts
+++ b/src/litellm/passthrough-mount-guard.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  detectStalePassthroughMounts,
+  extractVersionedSitePackagesMounts,
+} from "./passthrough-mount-guard.js";
+
+/** The passthrough patch mount as it exists today: a shadow of the real file
+ *  inside the interpreter's site-packages, hard-coding `python3.13`. */
+const PASSTHROUGH_TARGET =
+  "/app/.venv/lib/python3.13/site-packages/litellm/proxy/pass_through_endpoints/" +
+  "llm_provider_handlers/anthropic_passthrough_logging_handler.py";
+
+/** Coolify's `docker_compose_raw` long object form — the shape the mount is
+ *  actually declared in, and therefore the shape the guard has to read. */
+const COMPOSE_WITH_313_PATCH = `
+services:
+  litellm:
+    image: 'ghcr.io/berriai/litellm-database:v1.95.0'
+    volumes:
+      -
+        type: bind
+        source: ./custom_pacing.py
+        target: /app/custom_pacing.py
+      -
+        type: bind
+        source: ./anthropic_passthrough_logging_handler.py
+        target: ${PASSTHROUGH_TARGET}
+`;
+
+/** The same patch mount in Coolify's generated short-string form. */
+const COMPOSE_SHORT_FORM = `
+services:
+  litellm:
+    volumes:
+      - '/data/coolify/services/svc/anthropic_passthrough_logging_handler.py:${PASSTHROUGH_TARGET}'
+`;
+
+describe("extractVersionedSitePackagesMounts", () => {
+  it("pulls the versioned shadow mount and its hard-coded python version", () => {
+    const mounts = extractVersionedSitePackagesMounts(COMPOSE_WITH_313_PATCH);
+    expect(mounts).toEqual([
+      { target: PASSTHROUGH_TARGET, declaredPythonVersion: "3.13" },
+    ]);
+  });
+
+  it("reads the short string form too", () => {
+    const mounts = extractVersionedSitePackagesMounts(COMPOSE_SHORT_FORM);
+    expect(mounts).toEqual([
+      { target: PASSTHROUGH_TARGET, declaredPythonVersion: "3.13" },
+    ]);
+  });
+
+  it("ignores the bare-module callback mount, which carries no version", () => {
+    const mounts = extractVersionedSitePackagesMounts(`
+services:
+  litellm:
+    volumes:
+      - '/host/custom_pacing.py:/app/custom_pacing.py'
+`);
+    expect(mounts).toEqual([]);
+  });
+
+  it("ignores an UNversioned site-packages path (no pythonX.Y to validate)", () => {
+    const mounts = extractVersionedSitePackagesMounts(`
+services:
+  litellm:
+    volumes:
+      - '/host/patch.py:/usr/local/lib/site-packages/litellm/patch.py'
+`);
+    expect(mounts).toEqual([]);
+  });
+
+  it("returns null on 'cannot tell' (no services mapping), never an empty pass", () => {
+    expect(extractVersionedSitePackagesMounts("model_list: []")).toBeNull();
+    expect(extractVersionedSitePackagesMounts("\tnot: [valid")).toBeNull();
+  });
+});
+
+describe("detectStalePassthroughMounts", () => {
+  it("ALARMS: a python3.13 shadow mount on an image that actually ships 3.14", () => {
+    // This is the exact bug the guard exists to catch — a minor-version image
+    // bump moves site-packages to python3.14/ while the mount still targets
+    // python3.13/, so the patch lands at an inert path and silently drops.
+    const violations = detectStalePassthroughMounts(COMPOSE_WITH_313_PATCH, "3.14");
+    expect(violations).toHaveLength(1);
+    expect(violations[0].target).toBe(PASSTHROUGH_TARGET);
+    expect(violations[0].declaredPythonVersion).toBe("3.13");
+    expect(violations[0].actualPythonVersion).toBe("3.14");
+    // The finding must point at the real fix site, not the generated file, and
+    // name the silent-drop nature so the operator understands the stakes.
+    expect(violations[0].detail).toContain("docker_compose_raw");
+    expect(violations[0].detail).toContain("SILENTLY dropped");
+    expect(violations[0].detail).toContain("python3.14/");
+  });
+
+  it("passes when the mount's version matches the live image", () => {
+    expect(detectStalePassthroughMounts(COMPOSE_WITH_313_PATCH, "3.13")).toEqual([]);
+  });
+
+  it("alarms on the short-string form too", () => {
+    const violations = detectStalePassthroughMounts(COMPOSE_SHORT_FORM, "3.14");
+    expect(violations).toHaveLength(1);
+    expect(violations[0].declaredPythonVersion).toBe("3.13");
+  });
+
+  it("stays quiet when the image's actual python version cannot be resolved", () => {
+    // No fabricated violation: a stale shadow mount is a silent-drop hazard, so
+    // guessing the image version would defeat the point.
+    expect(detectStalePassthroughMounts(COMPOSE_WITH_313_PATCH, null)).toEqual([]);
+  });
+
+  it("stays quiet when the compose is unavailable or unreadable", () => {
+    expect(detectStalePassthroughMounts(null, "3.14")).toEqual([]);
+    expect(detectStalePassthroughMounts("\tnot: [valid", "3.14")).toEqual([]);
+    expect(detectStalePassthroughMounts("model_list: []", "3.14")).toEqual([]);
+  });
+
+  it("does not flag a config whose only mounts are unversioned", () => {
+    const compose = `
+services:
+  litellm:
+    volumes:
+      - '/host/custom_pacing.py:/app/custom_pacing.py'
+`;
+    expect(detectStalePassthroughMounts(compose, "3.14")).toEqual([]);
+  });
+});

--- a/src/litellm/passthrough-mount-guard.ts
+++ b/src/litellm/passthrough-mount-guard.ts
@@ -1,0 +1,133 @@
+/**
+ * LiteLLM passthrough / shadow-mount version coherence.
+ *
+ * The pacer ships a SECOND kind of bind mount alongside the `custom_pacing.py`
+ * callback module: a *patch* mount that shadows a file already inside the image,
+ * `anthropic_passthrough_logging_handler.py`, so the Anthropic passthrough path
+ * emits the token-usage the pacer meters. Unlike the callback module (imported
+ * as a bare `<module>` off `/app` on `sys.path`), the patch has to land at the
+ * EXACT path the real file occupies inside the interpreter's site-packages tree:
+ *
+ *   /app/.venv/lib/python3.13/site-packages/litellm/proxy/pass_through_endpoints/
+ *     llm_provider_handlers/anthropic_passthrough_logging_handler.py
+ *
+ * That target hard-codes the CPython minor version (`python3.13`). It is the
+ * fragile part: the segment is baked into the image and MOVES on a minor-version
+ * bump. A future image built on python 3.14 puts its site-packages under
+ * `python3.14/`, so a mount still targeting `python3.13/` lands at an inert path
+ * — the directory does not exist, the real file at 3.14 is never shadowed, and
+ * the patch SILENTLY drops. There is no crash and no log: the proxy comes up
+ * "healthy" while the pacer's usage accounting quietly runs on unpatched code.
+ *
+ * That silence is the whole hazard. The 2026-08-09 outage was LOUD (callbacks
+ * abort startup); this failure mode is the opposite — a green deploy that has
+ * quietly lost a patch — which is exactly the class a standing sensor exists to
+ * catch. `callback-mount-guard.ts` does NOT cover it: that guard checks a
+ * config-declared callback has SOME mount at `/app/<module>.py`; it says nothing
+ * about a versioned site-packages shadow whose target has gone stale against the
+ * image it is mounted into.
+ *
+ * This module is the pure detection core for that invariant:
+ *
+ *   a bind mount shadowing pythonX.Y/site-packages  ⇒  X.Y == the image's
+ *   actual CPython minor version
+ *
+ * The image's actual version cannot be read from text — it lives in the running
+ * container — so it is passed IN. The sensor resolves it from the live image via
+ * an injectable seam (default: `docker exec` the litellm container), exactly the
+ * `docker inspect`-the-live-container division of labour the image pin and the
+ * GPU-drift sensor already use. `null` means "cannot tell" and the core stays
+ * silent — a fabricated violation is worse than none.
+ *
+ * STRICTLY PURE: compose text + a resolved version string in, violations out. No
+ * fs, no network, no docker. The IO lives in the sensor seam.
+ */
+
+import { extractComposeBindTargets } from "./callback-mount-guard.js";
+
+/**
+ * A bind-mount target that shadows a file inside a VERSIONED CPython
+ * site-packages tree: `/.../pythonX.Y/site-packages/...`. The `X.Y` capture is
+ * the interpreter minor version baked into the target — the part that goes stale
+ * when the image's python moves. Only `pythonX.Y` (two numeric segments) is
+ * matched: an unversioned `site-packages` path carries no version to validate.
+ */
+const VERSIONED_SITE_PACKAGES_RE = /\/python(\d+\.\d+)\/site-packages\//;
+
+export interface StalePassthroughMount {
+  /** The container path the mount targets. */
+  target: string;
+  /** The CPython minor version the target hard-codes (e.g. `3.13`). */
+  declaredPythonVersion: string;
+  /** The CPython minor version the live image actually ships (e.g. `3.14`). */
+  actualPythonVersion: string;
+  /** Human-readable explanation for the ledger finding. */
+  detail: string;
+}
+
+/**
+ * Extract every bind-mount target that shadows a versioned site-packages path,
+ * with the CPython minor version each one hard-codes.
+ *
+ * Returns `null` for "cannot tell" (compose absent/unparseable, or no `services`
+ * mapping) — propagated straight from `extractComposeBindTargets`, whose null vs
+ * empty-set distinction the callback guard relies on and this one inherits. An
+ * empty array means "parsed fine, no versioned shadow mounts here" — a real and
+ * quiet pass, not an unknown.
+ */
+export function extractVersionedSitePackagesMounts(
+  composeText: string,
+): { target: string; declaredPythonVersion: string }[] | null {
+  const targets = extractComposeBindTargets(composeText);
+  if (targets === null) return null;
+
+  const out: { target: string; declaredPythonVersion: string }[] = [];
+  for (const target of targets) {
+    const m = VERSIONED_SITE_PACKAGES_RE.exec(target);
+    if (m) out.push({ target, declaredPythonVersion: m[1] });
+  }
+  return out;
+}
+
+/**
+ * The invariant: every versioned site-packages shadow mount targets the CPython
+ * minor version the live image actually ships.
+ *
+ * Yields no violations when the compose is absent/unreadable OR the image's
+ * actual version could not be resolved (`actualPythonVersion == null`) — a
+ * violation we cannot substantiate is worse than staying quiet, and a stale
+ * shadow mount is a silent-drop hazard, so guessing here would defeat the point.
+ * The caller logs a visible SKIP for the "cannot tell" case, the same way the
+ * callback guard does.
+ *
+ * A compose that resolves the version but whose shadow mount names a DIFFERENT
+ * minor version is the bug: the mount lands at an inert path and the patch is
+ * silently dropped.
+ */
+export function detectStalePassthroughMounts(
+  composeText: string | null,
+  actualPythonVersion: string | null,
+): StalePassthroughMount[] {
+  if (composeText == null || actualPythonVersion == null) return [];
+
+  const mounts = extractVersionedSitePackagesMounts(composeText);
+  if (mounts === null) return [];
+
+  const violations: StalePassthroughMount[] = [];
+  for (const { target, declaredPythonVersion } of mounts) {
+    if (declaredPythonVersion === actualPythonVersion) continue;
+    violations.push({
+      target,
+      declaredPythonVersion,
+      actualPythonVersion,
+      detail:
+        `bind mount targets ${target}, hard-coding CPython ${declaredPythonVersion}, but the live ` +
+        `litellm image ships CPython ${actualPythonVersion} — its site-packages live under ` +
+        `python${actualPythonVersion}/, so this mount lands at an inert path and the patch is ` +
+        `SILENTLY dropped (no crash, no log; the proxy comes up "healthy" on unpatched code). ` +
+        `Update the mount target to python${actualPythonVersion}/ in services.docker_compose_raw ` +
+        `(a hand edit to the generated compose is wiped on the next Coolify deploy), then redeploy.`,
+    });
+  }
+  return violations;
+}


### PR DESCRIPTION
## Summary
Extends #4553's LiteLLM mount-durability guard to cover a shape it does not: a
passthrough/patch bind mount whose target hard-codes a CPython minor version.
Adds a pure detection core (`src/litellm/passthrough-mount-guard.ts`) and wires
it into the fleet-health LiteLLM sensor, raising a new ledger code
`litellm-passthrough-mount-stale`.

**Stacked on #4553** (`fix/litellm-mount-durability`) — base this PR there so
the reviewer sees one coherent guard. Only two commits are mine; retarget to
`main` after #4553 merges.

## Why
The pacer's `anthropic_passthrough_logging_handler.py` patch mount shadows a
file at a hard-coded path:

```
/app/.venv/lib/python3.13/site-packages/litellm/proxy/pass_through_endpoints/
  llm_provider_handlers/anthropic_passthrough_logging_handler.py
```

A future image built on python 3.14 moves site-packages to `python3.14/`, so a
mount still targeting `python3.13/` lands at an inert path and the patch is
**silently dropped** — no crash (unlike the callback case in #4553), the proxy
comes up "healthy" on unpatched code. The callback-mount guard only checks that
a config-declared callback has *some* mount at `/app/<module>.py`; it says
nothing about a versioned site-packages shadow whose target has gone stale
against the image. This is the residual hazard that guard left open.

## What
- `src/litellm/passthrough-mount-guard.ts` — STRICTLY PURE core: compose text +
  the live image's resolved CPython version in, violations out. Reuses
  `extractComposeBindTargets` from the callback guard for parsing.
- `src/fleet-health/litellm-config-sensor.ts` — wires it in behind an
  injectable `pythonVersionFn` seam (default: `docker exec` the live litellm
  container and read `/app/.venv/lib/pythonX.Y/` — the ground truth a versioned
  shadow mount must match). `null` (docker down / no container / off-host
  CI/dev) is a visible SKIP, never a fabricated finding — same discipline as the
  callback and GPU-drift sensors.
- `src/fleet-health/detect.ts`, `mapping.ts` — register
  `litellm-passthrough-mount-stale` (constraint-violation, severity 3,
  `fleet-stays-healthy`).

## Test plan
- `vitest run src/litellm/passthrough-mount-guard.test.ts
  src/fleet-health/{litellm-config-sensor,mapping,detect}.test.ts` — 89 passed.
- **Fails on the bug:** the alarm test (`COMPOSE_313` mount + injected image
  version `"3.14"`) expects one `litellm-passthrough-mount-stale` finding.
  Mutation-verified: forcing the guard to never alarm reds 3 tests.
- `tsc --noEmit` clean on all touched files (pre-existing unrelated
  `nostr-tools` missing-module errors in `src/buzz-gateway/*` are an env
  artifact of the borrowed `node_modules`, not this change).
- Lint: `check-no-pii-secrets`, `check-stale-tool-descriptions`,
  `check-litellm-config-guard`, `check-changelog-entry` all pass.

## Risk
Low. The new check is purely additive and defaults to a visible skip whenever
the live image version can't be resolved, so it cannot produce a false finding
in CI/dev or on any host where docker isn't reachable. No runtime/deploy change.

Job spec: `reference/jobs/fleet-stays-healthy.md`.

Follow-up: python-hardcoded-path risk tracked in the issue linked from this PR;
pacer deploy of #4461/#4462 tracked separately.
