### PR TITLE
fix(hindsight): recall-pool split follow-ups — boot headroom, env conflict, stale-pool convergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,40 @@ now an anomaly worth investigating, not the norm.
   (`src/litellm/callback-mount-guard.ts`), and `docker/litellm-pacer/README.md`
   documents the database as the only durable place to put the mount.
 
+- **hindsight: recall-pool split follow-ups — first-boot health headroom, an
+  audible `hindsight.env` conflict, and convergence on a disabled split.** Three
+  low-severity gaps left open when the recall/background worker split landed.
+  (1) The health gate used one flat 150s deadline for every wait, but with the
+  split on a fresh host the AUTHORITY container answers `/health` only after pg0
+  `initdb`, extension creation, and the whole first-boot migration chain — a
+  boot that outran the deadline was read as `authority-unhealthy` and failed the
+  launch, self-healing only because a re-run took the repair branch. The
+  deadline is now composed from the phases each container actually runs
+  (`hindsightHealthTimeoutMs`): 240s for the pg0 owner, an api-startup budget
+  plus per-worker model-load time for the pool, and never below the 150s the
+  flat default used, so no path gets a tighter deadline than before.
+  (2) A `hindsight.env` entry for `HINDSIGHT_API_DB_POOL_MAX_SIZE` /
+  `HINDSIGHT_API_READ_DB_POOL_MAX_SIZE` used to win on the authority container
+  and lose on the pool — the same key, two opposite silent outcomes, and the
+  winning half quietly falsified the 60-connection background reserve that the
+  connection-budget assertion proves `≤ 240` against (an operator's 100 would
+  have taken the split to 300 against pg0's 250, i.e. the `FATAL: too many
+  clients` the budget exists to prevent, reached by a path the budget never
+  saw). Both containers now take the split's computed cap, and every superseded
+  key is named in a warning that points at `hindsight.recall_pool.db_pool_max_size`
+  — the knob that IS budget-checked. Only these two keys are managed; the rest
+  of `hindsight.env` is untouched, and with the split off nothing changes.
+  (3) With `hindsight.recall_pool.enabled` false but a pool container still
+  running, `switchroom setup` and `switchroom memory setup` reported "already
+  running" and left the orphan up, contradicting declared config and surviving
+  reboots on `--restart always`. They now converge: the pool is dropped outright
+  when the authority already serves the public port, and when the pool HOLDS the
+  public port the authority is relaunched onto it as one step and the port is
+  health-gated before success is reported — never left unbound, which is the
+  outage the split's `publicPortIsUnserved` guard exists to refuse. With no
+  declared public port or an unreadable authority port there is no positive
+  evidence to act on, so nothing is touched.
+
 - **telegraph: `**>` expandable blockquotes render correctly in Instant View
   pages.** `markdownToTelegraphNodes` — the Telegra.ph node builder used when a
   telegraph-enabled agent's reply exceeds the ~3000-char threshold — matched

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -56,10 +56,15 @@ import {
   stopHindsightRecallPool,
   isHindsightRecallPoolRunning,
   publicPortIsUnserved,
+  planStaleRecallPoolConvergence,
+  convergeStaleRecallPool,
   waitForHindsightHealthy,
   launchRecallPoolHealthGated,
-  backgroundContainerPoolEnv,
+  splitContainerPerfEnv,
+  splitDbPoolEnvConflicts,
+  splitDbPoolEnvConflictWarning,
   HINDSIGHT_RECALL_POOL_CONTAINER,
+  type HindsightHealthRole,
   type RecallPoolConfig,
 } from "../setup/hindsight-recall-pool.js";
 import { assessHindsightGpuDrop } from "../setup/hindsight-gpu-guard.js";
@@ -852,15 +857,26 @@ export function registerMemoryCommand(program: Command): void {
             const { litellm: repairLitellm } = await resolveLiteLLMForHindsight(repairConfig);
             const repairLlm = await getResolvedLlm();
             const repairCpAccessKey = await resolveHindsightCpAccessKey(repairConfig);
-            const repairAuthorityEnv = {
-              ...backgroundContainerPoolEnv(),
-              ...(repairConfig.hindsight?.env ?? {}),
-            };
+            // The two split-managed DB-pool caps WIN over `hindsight.env` —
+            // the connection budget asserted at resolve time is only a proof if
+            // the containers launch with the asserted numbers. Say so rather
+            // than dropping the operator's declared value in silence.
+            for (const conflict of splitDbPoolEnvConflicts(
+              repairConfig.hindsight?.env,
+              noRecreatePoolCfg,
+            )) {
+              console.log(chalk.yellow(`  ! ${splitDbPoolEnvConflictWarning(conflict)}`));
+            }
+            const repairAuthorityEnv = splitContainerPerfEnv(repairConfig.hindsight?.env);
             const repairResult = await launchRecallPoolHealthGated({
               publicApiPort: repairPublicPort,
               authorityApiPort: repairBasePorts.apiPort,
               workers: noRecreatePoolCfg.workers,
-              waitForHealthy: (p) => waitForHindsightHealthy(p),
+              // Role-aware deadline: the authority's first boot pays pg0
+              // initdb + the migration chain and needs far more headroom than
+              // the pool, which runs neither.
+              waitForHealthy: (p, role) =>
+                waitForHindsightHealthy(p, { role, workers: noRecreatePoolCfg!.workers }),
               stopPool: () => stopHindsightRecallPool(),
               startPool: () =>
                 startHindsightRecallPool({
@@ -967,7 +983,8 @@ export function registerMemoryCommand(program: Command): void {
         // fleet's memory endpoint refuses — the half-built topology a
         // split→single toggle (or a removed pool) leaves behind, durable across
         // reboots via `--restart always`. Refuse to report success over it.
-        const liveApiPort = getRunningHindsightPorts()?.apiPort;
+        const livePorts = getRunningHindsightPorts();
+        const liveApiPort = livePorts?.apiPort;
         const liveConfigUrlPort = ((): number | undefined => {
           try {
             const p = Number(new URL(getConfig(program).memory?.config?.url ?? "").port);
@@ -976,6 +993,102 @@ export function registerMemoryCommand(program: Command): void {
             return undefined;
           }
         })();
+        // MIRROR IMAGE of the pool-repair branch above: the split is DECLARED
+        // OFF but a pool container is still running. `publicPortIsUnserved`
+        // deliberately says "fine" (the pool IS serving the public port), which
+        // used to mean this printed "already running" and left an orphan
+        // container standing against declared config — durable across reboots
+        // via `--restart always`. Converge on the declared topology instead.
+        const stalePlan = planStaleRecallPoolConvergence({
+          recallEnabled: noRecreatePoolCfg !== null,
+          poolRunning: isHindsightRecallPoolRunning(),
+          authorityApiPort: liveApiPort,
+          configUrlPort: liveConfigUrlPort,
+        });
+        if (stalePlan.action !== "none") {
+          const staleConfig = getConfig(program);
+          const staleGpu = hindsightGpuDecision(
+            resolveHindsightGpuOverride({ flag: opts.gpu, config: staleConfig.hindsight?.gpu }),
+          );
+          try {
+            // Only the relaunch action launches a container, so only it needs
+            // secrets — removing an orphan must not spend broker round-trips.
+            const needsSecrets = stalePlan.action === "relaunch-single-on-public";
+            const staleLitellm = needsSecrets
+              ? (await resolveLiteLLMForHindsight(staleConfig)).litellm
+              : undefined;
+            const staleLlm = needsSecrets ? await getResolvedLlm() : undefined;
+            const staleCpAccessKey = needsSecrets
+              ? await resolveHindsightCpAccessKey(staleConfig)
+              : undefined;
+            const staleResult = await convergeStaleRecallPool({
+              plan: stalePlan,
+              stopPool: () => stopHindsightRecallPool(),
+              relaunchSingleOnPublic: (publicApiPort) => {
+                // ONE step: drop the pool holding the public port and the
+                // parked authority, then bring a sole container up ON the
+                // public port. convergeStaleRecallPool health-gates it before
+                // this is reported as success.
+                stopHindsightRecallPool();
+                stopHindsight();
+                startHindsight(
+                  { apiPort: publicApiPort, uiPort: livePorts?.uiPort ?? HINDSIGHT_DEFAULT_UI_PORT },
+                  staleLitellm,
+                  effectiveTag,
+                  staleLlm,
+                  hindsightConsumerMirrorDir(staleConfig),
+                  staleGpu.enabled,
+                  // Single-container env: no split DB-pool caps, so
+                  // `hindsight.env` is authoritative again — exactly what the
+                  // declared topology says.
+                  { env: staleConfig.hindsight?.env, memLimit: staleConfig.hindsight?.mem_limit },
+                  staleCpAccessKey,
+                );
+              },
+              waitForHealthy: (p, role) => waitForHindsightHealthy(p, { role }),
+              log: (m) => console.log(chalk.gray(m)),
+            });
+            switch (staleResult.outcome) {
+              case "pool-stopped":
+                console.log(
+                  chalk.green(
+                    "\n  Removed the orphan recall pool (hindsight.recall_pool is disabled).\n",
+                  ),
+                );
+                break;
+              case "relaunched-single":
+                console.log(
+                  chalk.green(
+                    `\n  Converged to the declared single-container topology on ` +
+                      `${staleResult.publicApiPort}.\n`,
+                  ),
+                );
+                break;
+              case "relaunch-failed":
+                console.error(
+                  chalk.red(
+                    `\n  hindsight.recall_pool is disabled, but the single container relaunched ` +
+                      `on the public port ${staleResult.publicApiPort} did not become healthy — ` +
+                      `nothing is serving fleet memory. Inspect \`docker logs ` +
+                      `switchroom-hindsight --tail 50\`, then re-run \`switchroom memory setup ` +
+                      `--recreate\`.\n`,
+                  ),
+                );
+                process.exit(1);
+                break;
+              case "nothing-to-do":
+                break;
+            }
+          } catch (err) {
+            console.error(
+              chalk.red(
+                `\n  Failed to converge the stale recall pool: ${(err as Error).message}\n`,
+              ),
+            );
+            process.exit(1);
+          }
+          return;
+        }
         if (
           publicPortIsUnserved({
             configUrlPort: liveConfigUrlPort,
@@ -1351,9 +1464,21 @@ export function registerMemoryCommand(program: Command): void {
         // When the split is on, the authority container caps its own DB pools
         // (write 40 / read 20) to free connection headroom for the pool's N
         // workers. These ride the operator-override path (the keys are in
-        // HINDSIGHT_PERF_ENV_KEYS); an explicit `hindsight.env` still wins.
+        // HINDSIGHT_PERF_ENV_KEYS) but they are MANAGED: they win over
+        // `hindsight.env`, because the connection budget asserted at resolve
+        // time is only a proof if the containers launch with the asserted
+        // numbers. A superseded operator value is warned about, not dropped
+        // silently.
+        if (recallPoolCfg) {
+          for (const conflict of splitDbPoolEnvConflicts(
+            hindsightConfig.hindsight?.env,
+            recallPoolCfg,
+          )) {
+            console.log(chalk.yellow(`  ! ${splitDbPoolEnvConflictWarning(conflict)}`));
+          }
+        }
         const authorityEnv = recallPoolCfg
-          ? { ...backgroundContainerPoolEnv(), ...(hindsightConfig.hindsight?.env ?? {}) }
+          ? splitContainerPerfEnv(hindsightConfig.hindsight?.env)
           : hindsightConfig.hindsight?.env;
         startHindsight(
           basePorts,
@@ -1399,7 +1524,11 @@ export function registerMemoryCommand(program: Command): void {
             publicApiPort,
             authorityApiPort: basePorts.apiPort,
             workers: recallPoolCfg.workers,
-            waitForHealthy: (p) => waitForHindsightHealthy(p),
+            // Role-aware deadline: the authority's first boot pays pg0 initdb
+            // + the migration chain, which the 150s flat default could expire
+            // mid-way through on a fresh host.
+            waitForHealthy: (p, role) =>
+              waitForHindsightHealthy(p, { role, workers: recallPoolCfg!.workers }),
             stopPool: () => stopHindsightRecallPool(),
             startPool: () =>
               startHindsightRecallPool({

--- a/src/cli/setup-memory-backend.ts
+++ b/src/cli/setup-memory-backend.ts
@@ -33,10 +33,15 @@ import {
   stopHindsightRecallPool,
   isHindsightRecallPoolRunning,
   publicPortIsUnserved,
-  backgroundContainerPoolEnv,
+  planStaleRecallPoolConvergence,
+  convergeStaleRecallPool,
+  splitContainerPerfEnv,
+  splitDbPoolEnvConflicts,
+  splitDbPoolEnvConflictWarning,
   waitForHindsightHealthy,
   launchRecallPoolHealthGated,
   HINDSIGHT_RECALL_POOL_CONTAINER,
+  type HindsightHealthRole,
   type RecallPoolConfig,
 } from "../setup/hindsight-recall-pool.js";
 import type { getViaBrokerStructured } from "../vault/broker/client.js";
@@ -337,8 +342,24 @@ export async function stepMemoryBackend(
     recallPoolCfg = null;
   }
 
+  // A `hindsight.env` line for one of the split-managed DB-pool caps cannot
+  // reach either container while the split is on (the split computes both, and
+  // the connection budget is only provable if it does). Say so — silently
+  // dropping an operator's declared value is the defect.
+  if (recallPoolCfg) {
+    for (const conflict of splitDbPoolEnvConflicts(config.hindsight?.env, recallPoolCfg)) {
+      console.log(chalk.yellow(`  ! ${splitDbPoolEnvConflictWarning(conflict)}`));
+    }
+  }
+
   const startPool = deps.startRecallPool ?? startHindsightRecallPool;
   const waitHealthy = deps.waitForHealthy ?? waitForHindsightHealthy;
+  /**
+   * Role-aware health gate: the authority's first boot pays pg0 initdb + the
+   * migration chain, so it gets a much longer deadline than the pool.
+   */
+  const waitHealthyFor = (port: number, role: HindsightHealthRole) =>
+    waitHealthy(port, { role, workers: recallPoolCfg?.workers });
   const poolIsRunning = deps.recallPoolRunningProbe ?? isHindsightRecallPoolRunning;
   const stopPool = deps.stopRecallPool ?? stopHindsightRecallPool;
 
@@ -399,7 +420,7 @@ export async function stepMemoryBackend(
       publicApiPort,
       authorityApiPort,
       workers: cfg.workers,
-      waitForHealthy: (p) => waitHealthy(p),
+      waitForHealthy: waitHealthyFor,
       stopPool,
       startPool: () =>
         startPool({
@@ -408,9 +429,11 @@ export async function stepMemoryBackend(
           litellm: secrets.litellmCfg,
           llm: secrets.resolvedLlm,
           // The authority caps its own DB pools when the split is on; the pool
-          // container inherits the same env base plus its own overrides.
+          // container inherits the same env base plus its own overrides. The
+          // managed caps win over `hindsight.env` (warned about above) so the
+          // connection budget the launch asserted is the one that ships.
           perf: {
-            env: { ...backgroundContainerPoolEnv(), ...(config.hindsight?.env ?? {}) },
+            env: splitContainerPerfEnv(config.hindsight?.env),
             memLimit: config.hindsight?.mem_limit,
           },
           cpAccessKey: secrets.cpAccessKey,
@@ -512,6 +535,84 @@ export async function stepMemoryBackend(
       }
       return { hindsightExpected: true, optedOut: false };
     }
+    // MIRROR IMAGE of the branch above: the split is DECLARED OFF but a pool
+    // container is still running. `publicPortIsUnserved` deliberately says
+    // "fine" here (the pool IS serving the public port), which used to mean the
+    // step printed "already running" and left an orphan container standing
+    // against declared config — durable across reboots via `--restart always`.
+    // Converge instead.
+    const staleRunningPorts = (deps.runningPortsProbe ?? getRunningHindsightPorts)();
+    const stalePlan = planStaleRecallPoolConvergence({
+      recallEnabled: recallPoolCfg !== null,
+      poolRunning: poolIsRunning(deps.dockerProbe),
+      authorityApiPort: staleRunningPorts?.apiPort,
+      configUrlPort: parseUrlPort(config.memory?.config?.url),
+    });
+    if (stalePlan.action !== "none") {
+      // Only the relaunch action launches a container, so only it needs
+      // secrets — `stop-pool` must not spend broker round-trips to remove an
+      // orphan.
+      const staleSecrets =
+        stalePlan.action === "relaunch-single-on-public"
+          ? await resolveLaunchSecrets()
+          : undefined;
+      const startContainer = deps.startContainer ?? startHindsight;
+      const staleResult = await convergeStaleRecallPool({
+        plan: stalePlan,
+        stopPool,
+        relaunchSingleOnPublic: (publicApiPort) => {
+          // ONE step: drop the pool that holds the public port and the parked
+          // authority, then bring a sole container up ON the public port. The
+          // health gate inside convergeStaleRecallPool is what makes this safe
+          // to report on.
+          stopPool();
+          (deps.stopContainer ?? stopHindsight)();
+          startContainer(
+            {
+              apiPort: publicApiPort,
+              uiPort: staleRunningPorts?.uiPort ?? HINDSIGHT_DEFAULT_UI_PORT,
+            },
+            staleSecrets!.litellmCfg,
+            undefined,
+            staleSecrets!.resolvedLlm,
+            hindsightConsumerMirrorDir(config),
+            undefined,
+            // Single-container env: NO split DB-pool caps, so `hindsight.env`
+            // is authoritative again, exactly as the declared topology says.
+            { env: config.hindsight?.env, memLimit: config.hindsight?.mem_limit },
+            staleSecrets!.cpAccessKey,
+          );
+        },
+        waitForHealthy: waitHealthyFor,
+        log: (m) => console.log(chalk.gray(m)),
+      });
+      if (staleResult.outcome === "relaunch-failed") {
+        const msg =
+          `hindsight.recall_pool is disabled, but the single container relaunched on the ` +
+          `public port ${staleResult.publicApiPort} did not become healthy — nothing is ` +
+          `serving fleet memory.`;
+        console.log(chalk.red(`  x ${msg}`));
+        throw new Error(
+          `Memory backend setup failed: ${msg} Inspect \`docker logs switchroom-hindsight ` +
+            `--tail 50\`, then re-run \`switchroom setup\`.`,
+        );
+      }
+      if (staleResult.outcome === "pool-stopped") {
+        console.log(
+          chalk.green(
+            `  ${STEP_DONE} Removed the orphan recall pool (hindsight.recall_pool is disabled)`,
+          ),
+        );
+      } else if (staleResult.outcome === "relaunched-single") {
+        console.log(
+          chalk.green(
+            `  ${STEP_DONE} Converged to the declared single-container topology on ` +
+              `${staleResult.publicApiPort}`,
+          ),
+        );
+      }
+      return { hindsightExpected: true, optedOut: false };
+    }
     // "The authority container is running" is NOT the same as "memory works".
     // If it is parked on a port that is not the one `memory.config.url`
     // declares, and no pool is bound there, NOTHING serves the fleet's memory
@@ -519,7 +620,7 @@ export async function stepMemoryBackend(
     // pool) leaves behind, durable across reboots via `--restart always`.
     // Reporting "already running" over that is exactly the silent-success-over-
     // an-outage class review H2 closed for the other paths in this step.
-    const runningPorts = (deps.runningPortsProbe ?? getRunningHindsightPorts)();
+    const runningPorts = staleRunningPorts;
     if (
       publicPortIsUnserved({
         configUrlPort: parseUrlPort(config.memory?.config?.url),
@@ -663,9 +764,12 @@ export async function stepMemoryBackend(
     launchSecrets = await resolveLaunchSecrets();
     // When the split is on the authority caps its own DB pools to free
     // connection headroom for the pool's N workers (the keys ride the
-    // HINDSIGHT_PERF_ENV_KEYS allowlist); an explicit `hindsight.env` still wins.
+    // HINDSIGHT_PERF_ENV_KEYS allowlist). Those two caps are MANAGED: they win
+    // over `hindsight.env`, because the connection budget asserted at resolve
+    // time is only a proof if the containers launch with the asserted numbers.
+    // A superseded `hindsight.env` value was warned about above.
     const authorityEnv = recallPoolCfg
-      ? { ...backgroundContainerPoolEnv(), ...(config.hindsight?.env ?? {}) }
+      ? splitContainerPerfEnv(config.hindsight?.env)
       : config.hindsight?.env;
     const startContainer = deps.startContainer ?? startHindsight;
     startContainer(

--- a/src/cli/setup-recall-pool-provision.test.ts
+++ b/src/cli/setup-recall-pool-provision.test.ts
@@ -208,6 +208,134 @@ describe("stepMemoryBackend — recall-pool provisioning wiring", () => {
     expect(waitForHealthy.mock.calls.map((c) => c[0])).toEqual([18889, 18888, 18888]);
   });
 
+  it("CONVERGES a stale pool that still holds the public port when the split is disabled", async () => {
+    // The declared topology is single-container, but a pool container from a
+    // previous split is still bound to 18888 with the authority parked on
+    // 18889. `publicPortIsUnserved` correctly says this is not an outage (the
+    // pool IS serving 18888), which is exactly why this used to print "already
+    // running" and walk away, leaving an orphan container contradicting config
+    // and surviving reboots on `--restart always`.
+    const startContainer = vi.fn();
+    const stopContainer = vi.fn();
+    const stopRecallPool = vi.fn();
+    const waitForHealthy = vi.fn((_port: number) => Promise.resolve(true));
+
+    const splitDisabled = {
+      memory: { config: { url: "http://127.0.0.1:18888/mcp/" } },
+    } as unknown as SwitchroomConfig;
+
+    const outcome = await stepMemoryBackend(splitDisabled, true, tempConfigPath(), {
+      dockerProbe: makeDockerProbe({ authorityUp: true }),
+      recallPoolRunningProbe: () => true, // the stale pool is UP on 18888
+      runningPortsProbe: () => ({ apiPort: 18889, uiPort: 19999 }),
+      startContainer,
+      stopContainer,
+      stopRecallPool,
+      waitForHealthy,
+    });
+
+    expect(outcome).toEqual({ hindsightExpected: true, optedOut: false });
+    // The orphan is gone...
+    expect(stopRecallPool).toHaveBeenCalled();
+    // ...and the public port is SERVED by the declared single container, not
+    // left unbound. Stopping the pool alone would have been the outage.
+    expect(startContainer).toHaveBeenCalledTimes(1);
+    expect(startContainer.mock.calls[0][0]).toEqual(expect.objectContaining({ apiPort: 18888 }));
+    expect(stopContainer).toHaveBeenCalledTimes(1);
+    // And it is proven served before the step reports success.
+    expect(waitForHealthy).toHaveBeenCalledWith(18888, expect.anything());
+  });
+
+  it("fails loud when the converged single container never binds the public port", async () => {
+    const startContainer = vi.fn();
+    const splitDisabled = {
+      memory: { config: { url: "http://127.0.0.1:18888/mcp/" } },
+    } as unknown as SwitchroomConfig;
+
+    await expect(
+      stepMemoryBackend(splitDisabled, true, tempConfigPath(), {
+        dockerProbe: makeDockerProbe({ authorityUp: true }),
+        recallPoolRunningProbe: () => true,
+        runningPortsProbe: () => ({ apiPort: 18889, uiPort: 19999 }),
+        startContainer,
+        stopContainer: vi.fn(),
+        stopRecallPool: vi.fn(),
+        waitForHealthy: vi.fn(() => Promise.resolve(false)),
+      }),
+    ).rejects.toThrow(/Memory backend setup failed:.*did not become healthy/s);
+  });
+
+  it("drops the orphan pool WITHOUT bouncing an authority that already serves the public port", async () => {
+    // Same stale-pool state, but the authority is already on 18888. There is
+    // nothing to hand over, so the convergence must not restart anything — a
+    // gratuitous relaunch here is a memory blip for the whole fleet.
+    const startContainer = vi.fn();
+    const stopContainer = vi.fn();
+    const stopRecallPool = vi.fn();
+
+    const splitDisabled = {
+      memory: { config: { url: "http://127.0.0.1:18888/mcp/" } },
+    } as unknown as SwitchroomConfig;
+
+    const outcome = await stepMemoryBackend(splitDisabled, true, tempConfigPath(), {
+      dockerProbe: makeDockerProbe({ authorityUp: true }),
+      recallPoolRunningProbe: () => true,
+      runningPortsProbe: () => ({ apiPort: 18888, uiPort: 19999 }),
+      startContainer,
+      stopContainer,
+      stopRecallPool,
+      waitForHealthy: vi.fn(() => Promise.resolve(true)),
+    });
+
+    expect(outcome).toEqual({ hindsightExpected: true, optedOut: false });
+    expect(stopRecallPool).toHaveBeenCalled();
+    expect(startContainer).not.toHaveBeenCalled();
+    expect(stopContainer).not.toHaveBeenCalled();
+  });
+
+  it("ships the MANAGED db-pool caps and says so when hindsight.env conflicts", async () => {
+    // The operator pins a 100-connection write pool in `hindsight.env`. Honour
+    // it on the authority and the connection budget the launch asserted
+    // (background 60) is a fiction — 100 + 20 + 4x45 = 300 against pg0's 250.
+    // The managed value must ship, and the operator must be TOLD, not left to
+    // discover it in `docker inspect`.
+    const logs: string[] = [];
+    const logSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation((...args: unknown[]) => void logs.push(args.join(" ")));
+    const startRecallPool = vi.fn();
+    try {
+      const config = {
+        hindsight: {
+          recall_pool: { enabled: true, workers: 4 },
+          env: { HINDSIGHT_API_DB_POOL_MAX_SIZE: "100" },
+        },
+        memory: { config: { url: "http://127.0.0.1:18888/mcp/" } },
+      } as unknown as SwitchroomConfig;
+
+      await stepMemoryBackend(config, true, tempConfigPath(), {
+        dockerProbe: makeDockerProbe({ authorityUp: true }),
+        recallPoolRunningProbe: () => false,
+        startContainer: vi.fn(),
+        startRecallPool,
+        waitForHealthy: vi.fn(() => Promise.resolve(true)),
+        stopRecallPool: vi.fn(),
+      });
+    } finally {
+      logSpy.mockRestore();
+    }
+
+    expect(startRecallPool).toHaveBeenCalledTimes(1);
+    // 40 is the split's background cap; 100 is the operator's, which cannot be
+    // honoured without overflowing pg0.
+    expect(startRecallPool.mock.calls[0][0].perf.env.HINDSIGHT_API_DB_POOL_MAX_SIZE).toBe("40");
+    expect(
+      logs.some(
+        (l) => l.includes("HINDSIGHT_API_DB_POOL_MAX_SIZE") && l.includes("IGNORED"),
+      ),
+    ).toBe(true);
+  });
+
   it("REFUSES success when the authority is parked off the public port with no pool", async () => {
     // The production outage shape: the split was turned on (authority moved to
     // 18889), then the pool was removed / `enabled` set back to false WITHOUT

--- a/src/setup/hindsight-recall-pool.test.ts
+++ b/src/setup/hindsight-recall-pool.test.ts
@@ -53,6 +53,14 @@ import {
   startHindsightRecallPool,
   stopHindsightRecallPool,
   waitForHindsightHealthy,
+  hindsightHealthTimeoutMs,
+  HINDSIGHT_HEALTH_MIN_TIMEOUT_MS,
+  HINDSIGHT_HEALTH_PHASE_BUDGET_MS,
+  splitContainerPerfEnv,
+  splitDbPoolEnvConflicts,
+  splitDbPoolEnvConflictWarning,
+  planStaleRecallPoolConvergence,
+  convergeStaleRecallPool,
 } from "./hindsight-recall-pool.js";
 
 /** Turn a flat `["run","-d",...]` docker argv into a lookup for -e KEY=VAL. */
@@ -604,5 +612,236 @@ describe("publicPortIsUnserved — the half-built-topology outage guard", () => 
         poolRunning: false,
       }),
     ).toBe(false);
+  });
+});
+
+/**
+ * A `waitForHindsightHealthy` driven by a fake clock: `/health` starts
+ * answering only once the clock passes `healthyAtMs`. This is the whole point
+ * of the test — it measures whether the DEADLINE is long enough to still be
+ * polling when the container finally answers, which is exactly the fresh-host
+ * first-boot question, and it does it without sleeping in real time.
+ */
+async function healthyAfter(
+  healthyAtMs: number,
+  opts: Parameters<typeof waitForHindsightHealthy>[1],
+): Promise<boolean> {
+  let t = 0;
+  const intervalMs = 3_000;
+  return waitForHindsightHealthy(18888, {
+    ...opts,
+    intervalMs,
+    now: () => t,
+    sleep: async () => {
+      t += intervalMs;
+    },
+    fetchImpl: (async () => ({ ok: t >= healthyAtMs })) as unknown as typeof fetch,
+  });
+}
+
+describe("health deadlines are derived from the work each container does", () => {
+  it("the authority survives a fresh-host boot that the old flat 150s deadline cut short", async () => {
+    // A first boot that answers /health at 200s: pg0 initdb + the migration
+    // chain + API startup. Under the pre-existing flat default this was read as
+    // "authority unhealthy" and the split launch failed, self-healing only
+    // because a re-run took the repair branch.
+    await expect(healthyAfter(200_000, { role: "authority" })).resolves.toBe(true);
+    // Same boot, the deadline this replaced: still a timeout. This is the
+    // control that proves the assertion above is about the deadline and not
+    // about the fake clock.
+    await expect(
+      healthyAfter(200_000, { timeoutMs: HINDSIGHT_HEALTH_MIN_TIMEOUT_MS }),
+    ).resolves.toBe(false);
+  });
+
+  it("the authority budget covers pg0 initdb AND migrations AND api startup", () => {
+    const p = HINDSIGHT_HEALTH_PHASE_BUDGET_MS;
+    expect(hindsightHealthTimeoutMs({ role: "authority" })).toBeGreaterThanOrEqual(
+      p.pgFirstBoot + p.migrations + p.apiStartup,
+    );
+    // The pool runs NEITHER pg0 nor migrations, so it must not be granted the
+    // authority's budget — a deadline that long would stall a genuinely broken
+    // pool for minutes before the degrade fires.
+    expect(hindsightHealthTimeoutMs({ role: "recall-pool", workers: 4 })).toBeLessThan(
+      hindsightHealthTimeoutMs({ role: "authority" }),
+    );
+  });
+
+  it("no role is ever granted a TIGHTER deadline than the flat default it replaced", () => {
+    for (const role of ["authority", "recall-pool", "single-container"] as const) {
+      for (const workers of [1, 4, 8]) {
+        expect(hindsightHealthTimeoutMs({ role, workers })).toBeGreaterThanOrEqual(
+          HINDSIGHT_HEALTH_MIN_TIMEOUT_MS,
+        );
+      }
+    }
+    // And with no role at all — the pre-role call shape — the behaviour is
+    // byte-identical to the old default.
+    expect(hindsightHealthTimeoutMs({ role: "recall-pool" })).toBe(
+      HINDSIGHT_HEALTH_MIN_TIMEOUT_MS,
+    );
+  });
+
+  it("a bigger pool gets proportionally longer to load its per-worker rerankers", () => {
+    const many = hindsightHealthTimeoutMs({ role: "recall-pool", workers: 16 });
+    const few = hindsightHealthTimeoutMs({ role: "recall-pool", workers: 4 });
+    expect(many).toBeGreaterThan(few);
+  });
+});
+
+describe("hindsight.env vs the split's managed DB-pool caps", () => {
+  const cfg = resolveRecallPoolConfig({ enabled: true, workers: 4 })!;
+
+  it("the managed cap WINS, so the asserted connection budget is the one that ships", () => {
+    // The operator asks for a 100-connection write pool. Honoured on the
+    // authority, that alone is 100 + 20 read + 4x45 pool = 300 connections
+    // against pg0's 250 ceiling — the `FATAL: too many clients` the budget
+    // assertion exists to prevent, arrived at by a path the assertion never
+    // saw.
+    const env = splitContainerPerfEnv({ HINDSIGHT_API_DB_POOL_MAX_SIZE: "100" });
+    expect(env.HINDSIGHT_API_DB_POOL_MAX_SIZE).toBe(
+      String(HINDSIGHT_BACKGROUND_DB_POOL_MAX_SIZE),
+    );
+    expect(env.HINDSIGHT_API_READ_DB_POOL_MAX_SIZE).toBe(
+      String(HINDSIGHT_BACKGROUND_READ_DB_POOL_MAX_SIZE),
+    );
+  });
+
+  it("supersession is REPORTED, naming the key, both values, and the right knob", () => {
+    const conflicts = splitDbPoolEnvConflicts(
+      { HINDSIGHT_API_DB_POOL_MAX_SIZE: "100", HINDSIGHT_API_RERANKER_BATCH_SIZE: "8" },
+      cfg,
+    );
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toEqual({
+      key: "HINDSIGHT_API_DB_POOL_MAX_SIZE",
+      operatorValue: "100",
+      authorityValue: String(HINDSIGHT_BACKGROUND_DB_POOL_MAX_SIZE),
+      poolValue: String(cfg.dbPoolMaxSize),
+    });
+    const warning = splitDbPoolEnvConflictWarning(conflicts[0]);
+    expect(warning).toContain("HINDSIGHT_API_DB_POOL_MAX_SIZE");
+    expect(warning).toContain("100");
+    // It must point at the knob that IS budget-checked, not leave the operator
+    // guessing why their value vanished.
+    expect(warning).toContain("hindsight.recall_pool.db_pool_max_size");
+  });
+
+  it("says nothing when the operator set no managed key (no warning spam)", () => {
+    expect(splitDbPoolEnvConflicts(undefined, cfg)).toEqual([]);
+    expect(splitDbPoolEnvConflicts({ HINDSIGHT_API_RERANKER_BATCH_SIZE: "8" }, cfg)).toEqual([]);
+  });
+
+  it("passes every OTHER hindsight.env key through untouched", () => {
+    const env = splitContainerPerfEnv({
+      HINDSIGHT_API_RERANKER_BATCH_SIZE: "8",
+      HINDSIGHT_API_DB_POOL_MAX_SIZE: "100",
+    });
+    expect(env.HINDSIGHT_API_RERANKER_BATCH_SIZE).toBe("8");
+  });
+});
+
+describe("converging a stale recall pool when the split is DECLARED off", () => {
+  it("relaunches a single container on the public port when the pool holds it", async () => {
+    // Split disabled in config, but the pool is still bound to 18888 and the
+    // authority is parked on 18889. Merely stopping the pool would leave 18888
+    // unbound — the fleet-memory outage. The plan must be the full relaunch.
+    const plan = planStaleRecallPoolConvergence({
+      recallEnabled: false,
+      poolRunning: true,
+      authorityApiPort: 18889,
+      configUrlPort: 18888,
+    });
+    expect(plan).toEqual({ action: "relaunch-single-on-public", publicApiPort: 18888 });
+
+    const stopPool = vi.fn();
+    const relaunchSingleOnPublic = vi.fn();
+    const waitForHealthy = vi.fn(() => Promise.resolve(true));
+    const result = await convergeStaleRecallPool({
+      plan,
+      stopPool,
+      relaunchSingleOnPublic,
+      waitForHealthy,
+    });
+    expect(result).toEqual({ outcome: "relaunched-single", publicApiPort: 18888 });
+    expect(relaunchSingleOnPublic).toHaveBeenCalledWith(18888);
+    // The PUBLIC port is health-gated before this is called success — the
+    // convergence must never hand back a topology it has not proven serves it.
+    expect(waitForHealthy).toHaveBeenCalledWith(18888, "single-container");
+  });
+
+  it("reports relaunch-failed rather than success over an unbound public port", async () => {
+    const result = await convergeStaleRecallPool({
+      plan: { action: "relaunch-single-on-public", publicApiPort: 18888 },
+      stopPool: vi.fn(),
+      relaunchSingleOnPublic: vi.fn(),
+      waitForHealthy: () => Promise.resolve(false),
+    });
+    expect(result).toEqual({ outcome: "relaunch-failed", publicApiPort: 18888 });
+  });
+
+  it("just drops the orphan when the authority ALREADY serves the public port", async () => {
+    const plan = planStaleRecallPoolConvergence({
+      recallEnabled: false,
+      poolRunning: true,
+      authorityApiPort: 18888,
+      configUrlPort: 18888,
+    });
+    expect(plan).toEqual({ action: "stop-pool" });
+
+    const stopPool = vi.fn();
+    const relaunchSingleOnPublic = vi.fn();
+    const result = await convergeStaleRecallPool({
+      plan,
+      stopPool,
+      relaunchSingleOnPublic,
+      waitForHealthy: () => Promise.resolve(true),
+    });
+    expect(result).toEqual({ outcome: "pool-stopped" });
+    expect(stopPool).toHaveBeenCalledTimes(1);
+    // No restart: the public port was served the whole time and must stay that
+    // way. Bouncing the authority here would be a gratuitous memory blip.
+    expect(relaunchSingleOnPublic).not.toHaveBeenCalled();
+  });
+
+  it("leaves a DECLARED pool alone", () => {
+    expect(
+      planStaleRecallPoolConvergence({
+        recallEnabled: true,
+        poolRunning: true,
+        authorityApiPort: 18889,
+        configUrlPort: 18888,
+      }),
+    ).toEqual({ action: "none" });
+  });
+
+  it("does nothing without positive evidence of where things are bound", () => {
+    // No declared public port, or an unreadable authority port: acting here
+    // could CAUSE the outage it is meant to prevent, so it must not guess.
+    expect(
+      planStaleRecallPoolConvergence({
+        recallEnabled: false,
+        poolRunning: true,
+        authorityApiPort: 18889,
+        configUrlPort: undefined,
+      }),
+    ).toEqual({ action: "none" });
+    expect(
+      planStaleRecallPoolConvergence({
+        recallEnabled: false,
+        poolRunning: true,
+        authorityApiPort: undefined,
+        configUrlPort: 18888,
+      }),
+    ).toEqual({ action: "none" });
+    // And no pool running at all is trivially nothing to do.
+    expect(
+      planStaleRecallPoolConvergence({
+        recallEnabled: false,
+        poolRunning: false,
+        authorityApiPort: 18889,
+        configUrlPort: 18888,
+      }),
+    ).toEqual({ action: "none" });
   });
 });

--- a/src/setup/hindsight-recall-pool.ts
+++ b/src/setup/hindsight-recall-pool.ts
@@ -274,6 +274,65 @@ export function publicPortIsUnserved(input: {
   return input.authorityApiPort !== input.configUrlPort;
 }
 
+/**
+ * What a "split is DECLARED OFF but a recall pool is still running" state has
+ * to do to converge on the declared single-container topology.
+ *
+ *   - `none`                     — nothing to converge (no stale pool, or not
+ *                                  enough positive evidence to act safely).
+ *   - `stop-pool`                — the authority ALREADY serves the public
+ *                                  port, so the pool is a pure orphan. Stopping
+ *                                  it cannot unserve anything.
+ *   - `relaunch-single-on-public`— the pool HOLDS the public port and the
+ *                                  authority is parked elsewhere (public+1).
+ *                                  Just stopping the pool would leave the
+ *                                  public port unbound — the exact outage
+ *                                  {@link publicPortIsUnserved} exists to
+ *                                  catch. The pool may only be stopped as part
+ *                                  of relaunching a sole container ON the
+ *                                  public port, health-gated.
+ */
+export type StaleRecallPoolConvergence =
+  | { action: "none" }
+  | { action: "stop-pool" }
+  | { action: "relaunch-single-on-public"; publicApiPort: number };
+
+/**
+ * Plan the convergence for a stale recall pool.
+ *
+ * The defect this closes: with `hindsight.recall_pool.enabled` absent/false but
+ * a pool container still running, the no-recreate "is it already running?"
+ * branch in both launch paths printed "already running" and returned success.
+ * {@link publicPortIsUnserved} deliberately returns false there (the pool IS
+ * serving the public port, so it is not an outage), which left an orphan
+ * container contradicting declared config — durable across reboots via
+ * `--restart always`, and carrying the pool's own DB-pool caps against a
+ * background container that is no longer capped for a split.
+ *
+ * Positive-evidence-only, like {@link publicPortIsUnserved}: with no declared
+ * public port (`configUrlPort` absent) or no readable authority port, there is
+ * no way to tell whether stopping the pool would strand the public port, so the
+ * plan is `none` rather than a guess that could cause the outage it is
+ * preventing.
+ */
+export function planStaleRecallPoolConvergence(input: {
+  /** `hindsight.recall_pool.enabled` — a DECLARED pool is never stale. */
+  recallEnabled: boolean;
+  poolRunning: boolean;
+  /** Port the authority container currently publishes, if readable. */
+  authorityApiPort: number | undefined;
+  /** Port `memory.config.url` declares, if any. */
+  configUrlPort: number | undefined;
+}): StaleRecallPoolConvergence {
+  if (input.recallEnabled) return { action: "none" };
+  if (!input.poolRunning) return { action: "none" };
+  if (input.configUrlPort == null || input.authorityApiPort == null) {
+    return { action: "none" };
+  }
+  if (input.authorityApiPort === input.configUrlPort) return { action: "stop-pool" };
+  return { action: "relaunch-single-on-public", publicApiPort: input.configUrlPort };
+}
+
 /** Resolved recall-pool settings, or `null` when the feature is off. */
 export interface RecallPoolConfig {
   /** Number of uvicorn workers the pool runs (`--workers`). */
@@ -395,6 +454,102 @@ export function backgroundContainerPoolEnv(): Record<string, string> {
     HINDSIGHT_API_DB_POOL_MAX_SIZE: String(HINDSIGHT_BACKGROUND_DB_POOL_MAX_SIZE),
     HINDSIGHT_API_READ_DB_POOL_MAX_SIZE: String(HINDSIGHT_BACKGROUND_READ_DB_POOL_MAX_SIZE),
   };
+}
+
+/**
+ * The two env keys the split COMPUTES for itself, in both containers, and
+ * therefore cannot honour from `hindsight.env`. They are the DB-pool caps, and
+ * they are the load-bearing inputs to
+ * {@link assertRecallPoolConnectionBudget}: the assertion proves
+ * `pool + {@link HINDSIGHT_BACKGROUND_CONNECTION_BUDGET} ≤ 240`, which is only
+ * a proof if BOTH sides are the values the containers actually launch with.
+ */
+/** The operator's `hindsight.env` block, as switchroom.yaml types it. */
+export type HindsightEnvBlock = Record<string, string | number | boolean>;
+
+export const HINDSIGHT_SPLIT_MANAGED_DB_POOL_KEYS = [
+  "HINDSIGHT_API_DB_POOL_MAX_SIZE",
+  "HINDSIGHT_API_READ_DB_POOL_MAX_SIZE",
+] as const;
+
+/** One operator `hindsight.env` key the split had to override, and with what. */
+export interface SplitDbPoolEnvConflict {
+  key: string;
+  /** What the operator wrote in `hindsight.env`. */
+  operatorValue: string;
+  /** What the AUTHORITY container launches with instead. */
+  authorityValue: string;
+  /** What the RECALL POOL container launches with instead. */
+  poolValue: string;
+}
+
+/**
+ * Which of {@link HINDSIGHT_SPLIT_MANAGED_DB_POOL_KEYS} the operator set in
+ * `hindsight.env` while the split is on — i.e. every value that will NOT reach
+ * either container. Empty when the operator set none (the overwhelmingly
+ * common case), so the caller warns about nothing.
+ */
+export function splitDbPoolEnvConflicts(
+  operatorEnv: HindsightEnvBlock | undefined,
+  cfg: RecallPoolConfig,
+): SplitDbPoolEnvConflict[] {
+  if (!operatorEnv) return [];
+  const authority = backgroundContainerPoolEnv();
+  const pool: Record<string, string> = {
+    HINDSIGHT_API_DB_POOL_MAX_SIZE: String(cfg.dbPoolMaxSize),
+    HINDSIGHT_API_READ_DB_POOL_MAX_SIZE: String(cfg.readDbPoolMaxSize),
+  };
+  const out: SplitDbPoolEnvConflict[] = [];
+  for (const key of HINDSIGHT_SPLIT_MANAGED_DB_POOL_KEYS) {
+    const operatorValue = operatorEnv[key];
+    if (operatorValue === undefined) continue;
+    out.push({
+      key,
+      operatorValue: String(operatorValue),
+      authorityValue: authority[key]!,
+      poolValue: pool[key]!,
+    });
+  }
+  return out;
+}
+
+/** Operator-facing text for one {@link splitDbPoolEnvConflicts} entry. */
+export function splitDbPoolEnvConflictWarning(c: SplitDbPoolEnvConflict): string {
+  const knob =
+    c.key === "HINDSIGHT_API_DB_POOL_MAX_SIZE"
+      ? "hindsight.recall_pool.db_pool_max_size"
+      : "hindsight.recall_pool.read_db_pool_max_size";
+  return (
+    `hindsight.env.${c.key}=${c.operatorValue} is IGNORED while ` +
+    `hindsight.recall_pool.enabled is true: the split computes this cap for both ` +
+    `containers (authority ${c.authorityValue}, recall pool ${c.poolValue}) so the ` +
+    `pg0 connection budget stays provable. Set \`${knob}\` instead — it is budget-checked — ` +
+    `or set hindsight.recall_pool.enabled: false to have hindsight.env win again.`
+  );
+}
+
+/**
+ * The `hindsight.env`-shaped perf overrides a SPLIT launch passes to both
+ * containers: the operator's `hindsight.env` with the split's own DB-pool caps
+ * layered LAST, so the managed keys win.
+ *
+ * The precedence is the fix, not an accident. Before this, the composition was
+ * `{...backgroundContainerPoolEnv(), ...hindsight.env}` — the operator's value
+ * won on the AUTHORITY (silently making the 60-connection background reserve
+ * that {@link assertRecallPoolConnectionBudget} asserts against a fiction, so a
+ * large value overflows pg0's ceiling into `FATAL: too many clients` at load)
+ * while still LOSING on the pool, where {@link applyRecallPoolEnvOverrides}
+ * replaces it. Same key, two opposite silent outcomes. Now the managed value
+ * wins in both containers and {@link splitDbPoolEnvConflicts} makes it audible.
+ *
+ * Only the two managed keys are touched; every other `hindsight.env` entry is
+ * passed through untouched, and when the split is OFF this function is not
+ * called at all.
+ */
+export function splitContainerPerfEnv(
+  operatorEnv: HindsightEnvBlock | undefined,
+): HindsightEnvBlock {
+  return { ...(operatorEnv ?? {}), ...backgroundContainerPoolEnv() };
 }
 
 /**
@@ -625,6 +780,98 @@ export function isHindsightRecallPoolRunning(
 }
 
 /**
+ * Which container a health wait is gating. The three roles do MEASURABLY
+ * different amounts of work before they can answer `/health`, which is what
+ * {@link hindsightHealthTimeoutMs} turns into a deadline:
+ *
+ *   - `authority`        — owns pg0. On a fresh host that means initdb on a
+ *                          cold data volume, extension creation, and the full
+ *                          schema migration chain
+ *                          (`HINDSIGHT_API_RUN_MIGRATIONS_ON_STARTUP`), THEN
+ *                          the API startup. The slowest role by far.
+ *   - `recall-pool`      — no pg0, no initdb, migrations explicitly OFF (see
+ *                          {@link recallPoolEnvOverrides}). It only boots N
+ *                          uvicorn workers, each loading its own reranker.
+ *   - `single-container` — the degrade/fallback relaunch. pg0 again, but over
+ *                          an EXISTING data volume, so no initdb; migrations
+ *                          may still run. Budgeted like the authority because
+ *                          the difference is not knowable from here.
+ */
+export type HindsightHealthRole = "authority" | "recall-pool" | "single-container";
+
+/**
+ * The floor every health deadline is raised to: the single default this
+ * function replaced. Keeping it as an explicit floor means the role-derived
+ * budgets below can only ever ADD headroom — no role silently gets a TIGHTER
+ * deadline than the code had before, so no path can start false-degrading.
+ */
+export const HINDSIGHT_HEALTH_MIN_TIMEOUT_MS = 150_000;
+
+/**
+ * Per-phase budgets a health deadline is composed from. These are deliberately
+ * generous UPPER BOUNDS, not measurements, and the asymmetry is why: the poll
+ * returns the instant `/health` answers 200, so a generous budget costs
+ * NOTHING on the happy path and is only ever spent when the boot is already
+ * failing. A budget that is too TIGHT, by contrast, converts a slow-but-fine
+ * first boot into a spurious "unhealthy" verdict and a topology change.
+ *
+ *   - `apiStartup` — uvicorn boot + app import + model load for the first
+ *     worker. Anchored on the image's own `--health-start-period` (60s, see
+ *     the `docker run` flags in this module and in hindsight.ts), which is
+ *     upstream's estimate of warm-start-to-serving.
+ *   - `pgFirstBoot` — pg0 `initdb` on a cold data volume plus extension
+ *     creation. Paid ONCE, on a fresh host, by whichever container owns pg0.
+ *   - `migrations` — the schema migration chain the pg0 owner runs at startup.
+ *     Longest on a first boot, when every migration applies.
+ *   - `perExtraWorker` — each ADDITIONAL uvicorn worker in the pool loads its
+ *     own cross-encoder onto the single GPU, and they serialize on VRAM, so
+ *     worker count extends the pool's startup roughly linearly.
+ */
+export const HINDSIGHT_HEALTH_PHASE_BUDGET_MS = {
+  apiStartup: 60_000,
+  pgFirstBoot: 90_000,
+  migrations: 90_000,
+  perExtraWorker: 15_000,
+} as const;
+
+/**
+ * The health deadline for a role, derived from the work that role actually
+ * does rather than from one flat number.
+ *
+ * The concrete defect this fixes: with the split ON, a fresh-host first boot
+ * runs pg0 initdb + the full migration chain + API startup in the AUTHORITY
+ * container before anything answers `/health`, and the single 150s deadline
+ * could expire mid-migration. {@link launchRecallPoolHealthGated} would then
+ * read that as `authority-unhealthy` and fail the launch — self-healing only
+ * because a re-run finds the authority already up and takes the repair branch.
+ * The authority now gets 60 + 90 + 90 = 240s.
+ *
+ * The pool is budgeted DOWN-ward by the same logic (no pg0, no migrations) but
+ * never below {@link HINDSIGHT_HEALTH_MIN_TIMEOUT_MS}, so the default 4-worker
+ * pool keeps exactly the deadline it has today.
+ */
+export function hindsightHealthTimeoutMs(input: {
+  role: HindsightHealthRole;
+  /** Pool worker count; only meaningful for `recall-pool`. */
+  workers?: number;
+}): number {
+  const p = HINDSIGHT_HEALTH_PHASE_BUDGET_MS;
+  let budget: number;
+  switch (input.role) {
+    case "authority":
+    case "single-container":
+      budget = p.apiStartup + p.pgFirstBoot + p.migrations;
+      break;
+    case "recall-pool": {
+      const workers = input.workers && input.workers > 0 ? input.workers : 1;
+      budget = p.apiStartup + (workers - 1) * p.perExtraWorker;
+      break;
+    }
+  }
+  return Math.max(HINDSIGHT_HEALTH_MIN_TIMEOUT_MS, budget);
+}
+
+/**
  * Poll `http://127.0.0.1:<port>/health` until it returns 200 or the deadline
  * passes. Returns true on healthy, false on timeout. Injectable `fetchImpl` +
  * `sleep` keep it deterministic under test.
@@ -634,11 +881,20 @@ export function isHindsightRecallPoolRunning(
  * connection-refused), and the pool must bind its port before
  * `memory.config.url` is declared live. Mirrors the health gate the
  * hand-applied `hindsight-recallsplit-swap.sh` used between steps.
+ *
+ * The deadline comes from {@link hindsightHealthTimeoutMs} for the given
+ * `role` (an explicit `timeoutMs` still wins). With no `role` the budget is the
+ * {@link HINDSIGHT_HEALTH_MIN_TIMEOUT_MS} floor, which is the value this
+ * defaulted to before roles existed.
  */
 export async function waitForHindsightHealthy(
   port: number,
   opts: {
     timeoutMs?: number;
+    /** The container being waited on; picks the phase-derived budget. */
+    role?: HindsightHealthRole;
+    /** Pool worker count, for the `recall-pool` role's budget. */
+    workers?: number;
     intervalMs?: number;
     fetchImpl?: typeof fetch;
     sleep?: (ms: number) => Promise<void>;
@@ -646,7 +902,10 @@ export async function waitForHindsightHealthy(
   } = {},
 ): Promise<boolean> {
   const {
-    timeoutMs = 150_000,
+    // No role ⇒ the pre-role flat default, exactly. A role ⇒ its phase budget.
+    timeoutMs = opts.role
+      ? hindsightHealthTimeoutMs({ role: opts.role, workers: opts.workers })
+      : HINDSIGHT_HEALTH_MIN_TIMEOUT_MS,
     intervalMs = 3_000,
     fetchImpl = fetch,
     sleep = (ms: number) => new Promise((r) => setTimeout(r, ms)),
@@ -724,7 +983,13 @@ export async function launchRecallPoolHealthGated(opts: {
   publicApiPort: number;
   authorityApiPort: number;
   workers: number;
-  waitForHealthy: (port: number) => Promise<boolean>;
+  /**
+   * Health gate. The `role` says WHICH container is being waited on so the
+   * caller can pick the phase-derived deadline
+   * ({@link hindsightHealthTimeoutMs}) — the authority's first boot pays pg0
+   * initdb + migrations and needs far more headroom than the pool.
+   */
+  waitForHealthy: (port: number, role: HindsightHealthRole) => Promise<boolean>;
   /** Clear a stale recall-pool sibling before (re)launch. */
   stopPool: () => void;
   /** Start the recall pool on the public port. */
@@ -741,14 +1006,14 @@ export async function launchRecallPoolHealthGated(opts: {
     `  Waiting for the authority container to become healthy on ` +
       `${opts.authorityApiPort} (pg0 startup)...`,
   );
-  if (!(await opts.waitForHealthy(opts.authorityApiPort))) {
+  if (!(await opts.waitForHealthy(opts.authorityApiPort, "authority"))) {
     return { outcome: "authority-unhealthy" };
   }
   // Clear any stale sibling so `docker run --name` cannot hit a name conflict.
   opts.stopPool();
   log(`  Starting recall pool (${opts.workers} workers) on ${opts.publicApiPort}...`);
   opts.startPool();
-  if (await opts.waitForHealthy(opts.publicApiPort)) {
+  if (await opts.waitForHealthy(opts.publicApiPort, "recall-pool")) {
     return { outcome: "split" };
   }
   const reason = `the recall pool did not become healthy on ${opts.publicApiPort}`;
@@ -757,8 +1022,77 @@ export async function launchRecallPoolHealthGated(opts: {
       `container on the public port so memory.config.url stays served...`,
   );
   opts.degradeToSingleContainer();
-  if (await opts.waitForHealthy(opts.publicApiPort)) {
+  if (await opts.waitForHealthy(opts.publicApiPort, "single-container")) {
     return { outcome: "degraded-single-container", reason };
   }
   return { outcome: "degrade-failed", reason };
+}
+
+/** What {@link convergeStaleRecallPool} actually did. */
+export type StaleRecallPoolConvergenceResult =
+  | { outcome: "nothing-to-do" }
+  | { outcome: "pool-stopped" }
+  | { outcome: "relaunched-single"; publicApiPort: number }
+  | { outcome: "relaunch-failed"; publicApiPort: number };
+
+/**
+ * Execute a {@link planStaleRecallPoolConvergence} plan. Shared by both
+ * no-recreate launch paths (`switchroom memory setup` and first-run
+ * `switchroom setup`) so they cannot diverge on the ordering, which is the
+ * whole difficulty here.
+ *
+ * ## The ordering, and why it is the way it is
+ *
+ * A TCP port is exclusive: while the stale pool holds the public port the
+ * authority physically cannot bind it, so "converge without ever unbinding the
+ * public port" is not achievable — the handover has a gap by construction. What
+ * IS achievable, and what this enforces, is that the gap is bounded by a single
+ * relaunch and never LEFT open:
+ *
+ *   - `stop-pool` is only ever planned when the authority already serves the
+ *     public port, so that path has no gap at all.
+ *   - `relaunch-single-on-public` stops the pool and relaunches the sole
+ *     container on the public port as ONE step, then HEALTH-GATES the public
+ *     port before reporting success. A relaunch that does not come back is
+ *     reported as `relaunch-failed` for the caller to fail loud on — never as
+ *     silent success over an unbound public port, which is precisely the
+ *     half-built topology {@link publicPortIsUnserved} exists to refuse.
+ */
+export async function convergeStaleRecallPool(opts: {
+  plan: StaleRecallPoolConvergence;
+  /** Stop + remove the stale pool container. */
+  stopPool: () => void;
+  /**
+   * Stop the pool AND the parked authority, then relaunch a SOLE container on
+   * the public port with single-container env (no split DB-pool caps).
+   */
+  relaunchSingleOnPublic: (publicApiPort: number) => void;
+  waitForHealthy: (port: number, role: HindsightHealthRole) => Promise<boolean>;
+  log?: (msg: string) => void;
+}): Promise<StaleRecallPoolConvergenceResult> {
+  const log = opts.log ?? (() => {});
+  switch (opts.plan.action) {
+    case "none":
+      return { outcome: "nothing-to-do" };
+    case "stop-pool":
+      log(
+        "  hindsight.recall_pool is disabled but a recall pool container is running; " +
+          "the authority already serves the public port, so removing the orphan pool...",
+      );
+      opts.stopPool();
+      return { outcome: "pool-stopped" };
+    case "relaunch-single-on-public": {
+      const publicApiPort = opts.plan.publicApiPort;
+      log(
+        `  hindsight.recall_pool is disabled but a recall pool container still holds the ` +
+          `public port ${publicApiPort}; relaunching a single container on it to match the ` +
+          `declared topology...`,
+      );
+      opts.relaunchSingleOnPublic(publicApiPort);
+      if (await opts.waitForHealthy(publicApiPort, "single-container")) {
+        return { outcome: "relaunched-single", publicApiPort };
+      }
+      return { outcome: "relaunch-failed", publicApiPort };
+    }
+  }
 }


### PR DESCRIPTION
Follow-up polish on the recall/background worker split (#4550). Three
low-severity items that PR's review considered, documented, and consciously
left. Each was verified as still real in source at `af38b83` before being
changed.

## 1. Flat 150s health deadline vs a fresh-host first boot

`waitForHindsightHealthy` defaulted to one 150s deadline for every wait
(`src/setup/hindsight-recall-pool.ts`). It is only reached on the split path,
and there the AUTHORITY container answers `/health` only after pg0 `initdb`,
extension creation, and the first-boot migration chain. A boot that outran the
deadline was read as `authority-unhealthy` and failed the launch, self-healing
only because a re-run finds the authority up and takes the repair branch.

The deadline is now composed from the phases each role actually runs
(`hindsightHealthTimeoutMs` + `HINDSIGHT_HEALTH_PHASE_BUDGET_MS`):

| role | budget | why |
|---|---|---|
| `authority` / `single-container` | 60 + 90 + 90 = **240s** | api startup + pg0 first boot + migrations |
| `recall-pool` | 60s + 15s per extra worker, floored | no pg0, migrations OFF; per-worker reranker load |

Everything is floored at `HINDSIGHT_HEALTH_MIN_TIMEOUT_MS` (150s, the old
default), so **no role gets a tighter deadline than before**. The numbers are
generous upper bounds by design: the poll returns the instant `/health`
answers, so headroom costs nothing on the happy path and is only spent when the
boot is already failing.

## 2. Silent `hindsight.env` supersession of the managed DB-pool caps

`HINDSIGHT_API_DB_POOL_MAX_SIZE` / `..._READ_...` were composed as
`{...backgroundContainerPoolEnv(), ...hindsight.env}`, so an operator value
**won on the authority** and **lost on the pool** (`applyRecallPoolEnvOverrides`
replaces it) — the same key, two opposite silent outcomes.

The winning half is the worse bug: it falsifies the 60-connection background
reserve that `assertRecallPoolConnectionBudget` proves `≤ 240` against. An
operator's `100` takes the split to `100 + 20 + 4×45 = 300` against pg0's 250 —
the `FATAL: too many clients` the budget exists to prevent, reached by a path
the budget never sees.

Fix: the managed cap wins in **both** containers (`splitContainerPerfEnv`), and
every superseded key is named in a warning that points at
`hindsight.recall_pool.db_pool_max_size` — the knob that *is* budget-checked.
A hard error would be too aggressive for something that currently boots, and
letting the operator win is what breaks the invariant; a warning plus a
deterministic managed value is the pair that makes it both audible and
provable. Only those two keys are managed; the rest of `hindsight.env` passes
through, and with the split off nothing changes (no existing deployment can be
relying on this — `recall_pool` shipped in #4550).

## 3. Split disabled, pool still running

`publicPortIsUnserved` correctly returns false here (the pool *is* serving the
public port), so the no-recreate "already running" branch in both launch paths
printed success and left an orphan container contradicting declared config,
durable across reboots on `--restart always`.

`planStaleRecallPoolConvergence` + `convergeStaleRecallPool` now converge, and
the ordering is the careful part:

- authority **already on** the public port → `stop-pool`. No gap at all.
- pool **holds** the public port → `relaunch-single-on-public`: the pool and the
  parked authority are dropped and a sole container is brought up **on the
  public port as one step**, then the port is **health-gated** before success is
  reported. A relaunch that never comes back is `relaunch-failed` and the caller
  fails loud — never silent success over an unbound port, which is the exact
  outage #4550's guard exists to refuse. (A TCP port is exclusive, so the
  handover has a gap by construction; what this guarantees is that it is bounded
  by one relaunch and never *left* open.)
- no declared public port, or an unreadable authority port → `none`. Same
  positive-evidence-only discipline as `publicPortIsUnserved`; guessing here
  could cause the outage it prevents.

## Tests

15 new tests, all outcome-asserting. Every one was mutation-tested — the
guarded behaviour was broken, the failure confirmed, then restored:

| mutation | tests that failed |
|---|---|
| authority budget reverted to the flat floor | 2 (incl. the fake-clock boot that answers at 200s) |
| `splitContainerPerfEnv` precedence reverted to operator-wins | 2 |
| `splitDbPoolEnvConflicts` returns `[]` (silent again) | 2 |
| `planStaleRecallPoolConvergence` always `none` (pre-fix) | 5 |
| naive fix: `stop-pool` when the pool holds the public port | 3 |
| convergence reports success without health-gating | 4 |

`npm run lint` clean. Scoped suites: 25 files / 627 tests passing
(`src/setup/hindsight*`, `src/cli/setup*`, `src/cli/memory*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)