### PR TITLE
ci(docker-images): decouple build-dependents from build-base on PR/merge_group

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -15,7 +15,12 @@ name: docker-images
 # Pipelines (perf rework, follows #2807):
 #   - build-base + build-dependents run as a PER-ARCH matrix on NATIVE
 #     runners (amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm) — no
-#     QEMU emulation. Each arch leg pushes a temporary
+#     QEMU emulation. On PR / merge_group, build-dependents builds FROM
+#     the published switchroom-base:latest and does NOT wait on build-base
+#     (no data dependency — takes build-base off the PR critical path);
+#     the push/tag/dispatch build-dependents-push leg keeps the base
+#     dependency because it consumes the freshly-built scratch base tag.
+#     Each arch leg pushes a temporary
 #     `:sha-<short>-<arch>` tag; the merge-base / merge-dependents jobs
 #     then stitch the two arch images into the final multi-arch
 #     manifest (`:latest` / `:sha-<short>` / `:vX.Y.Z`) with
@@ -397,14 +402,158 @@ jobs:
             "${IMAGE}:sha-${SHA_SHORT}-arm64"
 
   build-dependents:
-    # Per-arch dependents FROM the per-arch base scratch tag pushed by
-    # build-base — no wait on merge-base (it runs in parallel).
+    # PR / merge_group VALIDATION leg. Each dependent builds FROM the
+    # PUBLISHED switchroom-base:latest (see the tags step) — NOT a base
+    # built earlier in THIS run — so there is NO data dependency on
+    # build-base, and this job deliberately does NOT `needs:` it. That
+    # takes build-base's ~31s off the PR / merge-queue critical path:
+    # the two now run in parallel instead of serialised. build-base
+    # still runs (and is still aggregated by images-ok), so a base
+    # Dockerfile regression is still caught here. The push/tag/dispatch
+    # leg that DOES consume the freshly-built per-arch scratch base tag
+    # is build-dependents-push below — GitHub Actions has no
+    # event-conditional `needs:`, so the push-path data dependency is
+    # expressed as a separate job rather than a conditional edge.
+    needs: changes
+    # PR: only when image inputs changed. merge_group: always — a queue
+    # entry that compiled no dependents would make images-ok a rubber
+    # stamp. Never push/tag/dispatch — that is build-dependents-push.
+    if: ${{ !cancelled() && ((github.event_name == 'pull_request' && needs.changes.outputs.images == 'true') || github.event_name == 'merge_group') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # merge_group is amd64-only for the same reason PRs are: the
+        # queue validates buildability and pushes nothing, and the arm64
+        # artifact is only ever consumed from a main/tag push.
+        arch: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && fromJSON('["amd64"]') || fromJSON('["amd64","arm64"]') }}
+        image:
+          - { name: agent,        file: docker/Dockerfile.agent }
+          - { name: broker,       file: docker/Dockerfile.broker }
+          - { name: kernel,       file: docker/Dockerfile.kernel }
+          - { name: hostd,        file: docker/Dockerfile.hostd }
+          - { name: auth-broker,  file: docker/Dockerfile.auth-broker }
+          - { name: web,          file: docker/Dockerfile.web }
+          # hindsight is NOT here — it has its own `build-hindsight`
+          # job (PR #1310) that runs in parallel with build-base
+          # because Dockerfile.hindsight extends upstream
+          # `vectorize-io/hindsight:latest`, not switchroom-base.
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up Node (for dist/ bundling)
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: "22"
+
+      - name: Set up workspace (pinned bun + warm cache + frozen lockfile)
+        # Composite action: pinned bun (not `latest` — an unpinned bun
+        # release changing under a release build is a flake vector), bun
+        # package cache restore, and `bun install --frozen-lockfile`
+        # (a bare `bun install` can silently drift from bun.lock).
+        uses: ./.github/actions/setup-switchroom
+
+      - name: Build dist/
+        env:
+          # Arms the mis-stamp guard in scripts/build.mjs: on a tag build this is
+          # the tag (e.g. v0.15.56); on non-tag builds it is empty so the guard
+          # stays silent and dev builds fall back to package.json.
+          TAG_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
+        run: npm run build
+
+      - name: Set up Docker Buildx
+        # Composite action, NOT docker/setup-buildx-action directly (#3815).
+        # The docker-container driver boots BuildKit by pulling
+        # `moby/buildkit:buildx-stable-1` from DOCKER HUB — unauthenticated,
+        # un-retried, and before the GHCR login step below ever runs. 19 of
+        # the 21 failed image jobs between 2026-07-16 and 2026-07-27 died
+        # exactly there, reddening the required `images-ok` sentinel and
+        # ejecting four PRs from the merge queue. The composite warms that
+        # image into the runner's local image store behind a bounded,
+        # transient-only retry first, which also arms buildx's own
+        # "pulling failed, using local image" fallback.
+        # Enforced by tests/ci-buildx-warm-pull.test.ts.
+        uses: ./.github/actions/setup-buildx
+
+      - name: Log in to GHCR (push only on main / tags)
+        # merge_group excluded: a queue run is validation-only and pushes
+        # nothing, so it needs no registry credential.
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags + base ref
+        id: tags
+        run: |
+          IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-${{ matrix.image.name }}"
+          BASE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-base"
+          SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            # Merge-queue validation — see build-base for why the PR
+            # number can't be used here. Like a PR, the queue's base
+            # build pushed no scratch tag, so build FROM published
+            # :latest.
+            echo "tags=${IMAGE}:mq-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
+            echo "base=${BASE}:latest" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "tags=${IMAGE}:pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            # On PRs the base wasn't pushed, so depend on the published
+            # :latest (multi-arch; buildx resolves the amd64 leg).
+            echo "base=${BASE}:latest" >> "$GITHUB_OUTPUT"
+          else
+            # Per-arch scratch tag; merge-dependents assigns the real
+            # tags from the merged manifest (see build-base comment).
+            echo "tags=${IMAGE}:sha-${SHA_SHORT}-${{ matrix.arch }}" >> "$GITHUB_OUTPUT"
+            echo "base=${BASE}:sha-${SHA_SHORT}-${{ matrix.arch }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build (and push on main/tag) ${{ matrix.image.name }} ${{ matrix.arch }}
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: .
+          file: ${{ matrix.image.file }}
+          platforms: linux/${{ matrix.arch }}
+          tags: ${{ steps.tags.outputs.tags }}
+          push: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
+          build-args: |
+            BASE_IMAGE=${{ steps.tags.outputs.base }}
+          # GHCR registry cache, not type=gha — #1965. `agent` (Chromium/
+          # webkite/playwright, 143MB layers) is the worst hit: its layers
+          # outran the GHA Azure-blob SAS token / stalled mid-restore and
+          # hard-failed the build, blocking releases. Registry cache has no
+          # SAS expiry; a miss degrades to a cold build. cache-to gated to
+          # non-PR (fork PRs can't write GHCR; export failure would break
+          # the required check). Per-image, per-arch :buildcache-<arch>
+          # tag, mode=max; legacy :buildcache kept as read-only fallback
+          # for the first post-split run.
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-${{ matrix.image.name }}:buildcache-${{ matrix.arch }}
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-${{ matrix.image.name }}:buildcache
+          cache-to: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' && format('type=registry,ref=ghcr.io/{0}/switchroom-{1}:buildcache-{2},mode=max,image-manifest=true,oci-mediatypes=true', github.repository_owner, matrix.image.name, matrix.arch) || '' }}
+          # sec WS9-F3 (#1418, relaxed per header): attestation on tag
+          # pushes only.
+          provenance: ${{ startsWith(github.ref, 'refs/tags/v') && 'mode=max' || 'false' }}
+          sbom: ${{ startsWith(github.ref, 'refs/tags/v') }}
+
+  build-dependents-push:
+    # push / tag / dispatch leg. Byte-identical build to
+    # build-dependents above EXCEPT for gating: this leg DOES consume
+    # the freshly-built per-arch scratch base tag
+    # (switchroom-base:sha-<short>-<arch>) that build-base pushes, so
+    # it MUST wait on build-base — hence `needs: [changes, build-base]`
+    # and the explicit base-success check (the push-path data
+    # dependency the PR/merge_group leg deliberately drops). Keep the
+    # strategy + steps below IN SYNC with build-dependents.
     needs: [changes, build-base]
-    # Same gate as build-base, plus an explicit success check on the
-    # base build — `!cancelled()` alone would let dependents run past
-    # a FAILED base (unlike the default all-needs-succeeded semantics
-    # it replaces). merge_group builds here too; see build-base.
-    if: ${{ !cancelled() && needs.build-base.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.images == 'true') }}
+    # `!cancelled() && base succeeded` (not the default
+    # all-needs-succeeded, so a FAILED base blocks rather than
+    # silently skips), restricted to the publishing events. Never PR
+    # or merge_group — those are build-dependents' job.
+    if: ${{ !cancelled() && needs.build-base.result == 'success' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
     strategy:
       fail-fast: false
       matrix:
@@ -528,10 +677,15 @@ jobs:
   # Stitch the per-arch dependent images into their final multi-arch
   # manifests. Same pattern as merge-base.
   merge-dependents:
-    needs: build-dependents
+    # build-dependents-push (NOT the PR/merge_group build-dependents leg)
+    # is what pushes the per-arch scratch tags on a real push, so this
+    # publishing job needs THAT leg. On a push the PR/merge_group leg is
+    # skipped; needing it here would leave merge-dependents skipped and
+    # nothing would ever publish.
+    needs: build-dependents-push
     # merge_group excluded — see merge-base. Publication is a push-to-main
     # concern, never a queue-validation concern.
-    if: ${{ !cancelled() && github.event_name != 'pull_request' && github.event_name != 'merge_group' && needs.build-dependents.result == 'success' }}
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && github.event_name != 'merge_group' && needs.build-dependents-push.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
@@ -1078,6 +1232,7 @@ jobs:
       - build-base
       - merge-base
       - build-dependents
+      - build-dependents-push
       - merge-dependents
       - build-hindsight
       - merge-hindsight
@@ -1102,6 +1257,7 @@ jobs:
             "build-base=${{ needs.build-base.result }}" \
             "merge-base=${{ needs.merge-base.result }}" \
             "build-dependents=${{ needs.build-dependents.result }}" \
+            "build-dependents-push=${{ needs.build-dependents-push.result }}" \
             "merge-dependents=${{ needs.merge-dependents.result }}" \
             "build-hindsight=${{ needs.build-hindsight.result }}" \
             "merge-hindsight=${{ needs.merge-hindsight.result }}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+### CI: `build-dependents` no longer serialized behind `build-base` on PR / merge_group
+
+- **docker-images: dependent image builds now run in parallel with `build-base`
+  on PRs and the merge queue** instead of waiting ~31s for it. On
+  `pull_request` / `merge_group` the dependents build FROM the published
+  `switchroom-base:latest` — no data dependency on the base built in the same
+  run — so the job is split into `build-dependents` (validation, no base
+  dependency) and `build-dependents-push` (the publish leg that still consumes
+  the freshly-built per-arch scratch base tag). `build-base` still runs and is
+  still aggregated by `images-ok`, so base-Dockerfile regressions are still
+  caught; this only takes it off the PR critical path.
+
 ### Bug fixes
 
 - **fleet health: a LiteLLM custom callback with no bind mount is now a loud

--- a/tests/ci-buildx-warm-pull.test.ts
+++ b/tests/ci-buildx-warm-pull.test.ts
@@ -120,6 +120,10 @@ describe('buildx warm-pull guard (#3815)', () => {
       'ci-full.yml:docker-images-build',
       'docker-images.yml:build-base',
       'docker-images.yml:build-dependents',
+      // PR/merge_group and push legs of the dependents build are separate
+      // jobs (GHA has no event-conditional `needs:`); both build images
+      // and so both go through the warm-pull action.
+      'docker-images.yml:build-dependents-push',
       'docker-images.yml:build-hindsight',
       'docker-images.yml:build-voice',
     ])

--- a/tests/ci-merge-queue-triggers.test.ts
+++ b/tests/ci-merge-queue-triggers.test.ts
@@ -354,17 +354,26 @@ describe('merge queue — docker-images never publishes from an unmerged ref', (
     // uses `github.event_name != 'pull_request'` as shorthand for "this
     // is a publishing event" — a shorthand that is silently WRONG on a
     // queue ref. Every occurrence must therefore also exclude
-    // merge_group, except the two deliberate JOB-LEVEL gates below,
-    // which mean "actually compile the images" and MUST run on
+    // merge_group, except the deliberate JOB-LEVEL gate below, which
+    // means "actually compile the base image" and MUST run on
     // merge_group or `images-ok` becomes a rubber stamp.
     //
     // The exemption is deliberately narrow: it is keyed on the job-level
-    // `if:` (4-space indent) and NOT on the job as a whole, because both
-    // exempt jobs also contain `push:` / `cache-to:` / step-level `if:`
+    // `if:` (4-space indent) and NOT on the job as a whole, because the
+    // exempt job also contains `push:` / `cache-to:` / step-level `if:`
     // occurrences of the same shorthand that must still be caught. A
     // job-wide exemption would wave those through — which is exactly the
     // bug this file exists to prevent.
-    const ALLOWED_JOB_LEVEL_GATES = ['build-base', 'build-dependents']
+    //
+    // Only `build-base` remains here. `build-dependents` used to be exempt
+    // too (its old bare `!= 'pull_request'` gate also meant "compile on
+    // merge_group"), but the build-base decoupling split the dependents
+    // build into two jobs: the PR/merge_group leg (`build-dependents`) now
+    // uses a POSITIVE event allowlist with no `!= 'pull_request'`
+    // shorthand, and the push leg (`build-dependents-push`) spells out
+    // `&& github.event_name != 'merge_group'` — so neither needs the
+    // exemption. See the "build-base decoupling" describe block below.
+    const ALLOWED_JOB_LEVEL_GATES = ['build-base']
 
     const lines = readFileSync(join(REPO, '.github/workflows/docker-images.yml'), 'utf8').split('\n')
     let job = '<workflow-level>'
@@ -385,7 +394,7 @@ describe('merge queue — docker-images never publishes from an unmerged ref', (
 
     expect(
       seenAllowed,
-      'expected the two deliberate build gates to still be present — if this drops to 0 the ' +
+      'expected the deliberate build-base gate to still be present — if this drops to 0 the ' +
         'rule below is passing vacuously and no longer guards anything',
     ).toBe(ALLOWED_JOB_LEVEL_GATES.length)
 
@@ -413,5 +422,114 @@ describe('merge queue — docker-images never publishes from an unmerged ref', (
           `only ever consumed from a main/tag push.`,
       ).toContain('merge_group')
     }
+  })
+})
+
+describe('docker-images — build-dependents is decoupled from build-base on PR/merge_group', () => {
+  // The dependents build was split into two jobs because GitHub Actions
+  // has no event-conditional `needs:` (a job always waits for every job
+  // it needs, even skipped ones, before its own `if` is evaluated):
+  //
+  //   - `build-dependents`      — PR / merge_group VALIDATION leg. Builds
+  //     FROM the PUBLISHED switchroom-base:latest, so it has NO data
+  //     dependency on build-base and must NOT `needs:` it — that is the
+  //     whole point (build-base's ~31s comes off the PR critical path).
+  //   - `build-dependents-push` — push / tag / dispatch leg. Consumes the
+  //     freshly-built per-arch scratch base tag, so it MUST wait on
+  //     build-base.
+  //
+  // Every assertion here is invisible on a PR run (the push leg never
+  // executes there), so a test is the only thing that stops a future edit
+  // from re-coupling the PR path — reintroducing the serialisation this
+  // change removed — or, worse, from dropping the push-path base
+  // dependency and racing build-base (a `FROM …:sha-<short>-<arch>` pull
+  // of a tag that does not exist yet).
+  const wf = load('docker-images.yml')
+  const jobs = wf.jobs ?? {}
+  const needsOf = (j?: Job): string[] => {
+    const n = j?.needs
+    return Array.isArray(n) ? n : n ? [String(n)] : []
+  }
+
+  it('both dependent legs exist', () => {
+    expect(Object.keys(jobs)).toEqual(
+      expect.arrayContaining(['build-dependents', 'build-dependents-push']),
+    )
+  })
+
+  it('the PR/merge_group leg does NOT depend on build-base', () => {
+    expect(
+      needsOf(jobs['build-dependents']),
+      'build-dependents must not `needs: build-base` — that edge would serialise the ' +
+        'base build ahead of dependents on every PR, which is exactly the wait this split ' +
+        'removes. It builds FROM the published :latest and has no data dependency on the run.',
+    ).not.toContain('build-base')
+  })
+
+  it('the push leg DOES depend on build-base (keeps the scratch-tag dependency)', () => {
+    expect(
+      needsOf(jobs['build-dependents-push']),
+      'build-dependents-push consumes switchroom-base:sha-<short>-<arch>, which build-base ' +
+        'pushes — without `needs: build-base` it would race the base build and fail the FROM.',
+    ).toContain('build-base')
+  })
+
+  it('the PR/merge_group leg runs on merge_group and never on push', () => {
+    const gate = String(jobs['build-dependents']?.if ?? '')
+    expect(gate, 'build-dependents must still compile on the queue ref (images-ok signal)').toContain(
+      'merge_group',
+    )
+    // Positive allowlist form — must not carry the `!= 'pull_request'`
+    // "this is a publish" shorthand (that is the push leg's spelling).
+    expect(
+      gate,
+      "the PR/merge_group leg must use a positive event allowlist, not the `!= 'pull_request'` " +
+        'publish shorthand',
+    ).not.toContain("!= 'pull_request'")
+  })
+
+  it('the push leg is fenced off PR and merge_group', () => {
+    const gate = String(jobs['build-dependents-push']?.if ?? '')
+    expect(gate).toContain("github.event_name != 'pull_request'")
+    expect(gate).toContain("github.event_name != 'merge_group'")
+    expect(
+      gate,
+      'the push leg must not publish past a failed base — keep the explicit success check ' +
+        'that replaces the default all-needs-succeeded semantics `!cancelled()` discards.',
+    ).toContain("needs.build-base.result == 'success'")
+  })
+
+  it('merge-dependents publishes from the PUSH leg, not the PR/merge_group leg', () => {
+    // On a real push the PR/merge_group leg is skipped; if merge-dependents
+    // needed it, the publish job would be skipped and NOTHING would land in
+    // GHCR. It must consume the push leg's per-arch scratch tags.
+    expect(needsOf(jobs['merge-dependents'])).toContain('build-dependents-push')
+    expect(needsOf(jobs['merge-dependents'])).not.toContain('build-dependents')
+    expect(String(jobs['merge-dependents']?.if ?? '')).toContain(
+      "needs.build-dependents-push.result == 'success'",
+    )
+  })
+
+  it('images-ok aggregates BOTH dependent legs', () => {
+    // A failure of either leg (PR-leg on a PR, push-leg on a push) must
+    // block the required sentinel — neither may drop out of coverage.
+    const needs = needsOf(jobs['images-ok'])
+    expect(needs).toContain('build-dependents')
+    expect(needs).toContain('build-dependents-push')
+    const verdict = JSON.stringify(jobs['images-ok']?.steps ?? [])
+    expect(verdict).toContain('build-dependents=')
+    expect(verdict).toContain('build-dependents-push=')
+  })
+
+  it('the two legs build the identical image set (drift guard)', () => {
+    // The legs are byte-identical except for `needs`/`if`. If a future
+    // edit adds an image to one matrix and forgets the other, PR
+    // validation and the published set would silently diverge.
+    expect(JSON.stringify(jobs['build-dependents']?.strategy)).toEqual(
+      JSON.stringify(jobs['build-dependents-push']?.strategy),
+    )
+    expect(JSON.stringify(jobs['build-dependents']?.steps)).toEqual(
+      JSON.stringify(jobs['build-dependents-push']?.steps),
+    )
   })
 })


### PR DESCRIPTION
## What

On `pull_request` and `merge_group`, dependent images build FROM the published `switchroom-base:latest` — not a base built earlier in the same run — so there is **no data dependency** on `build-base`. Yet `build-dependents` still `needs:` it and serialises behind its **~31s**, on the long pole of the PR critical path (`docker-images`).

GitHub Actions has no event-conditional `needs:` (a `needs:` edge is static and always serialises, even when the upstream is skipped), so the fix is a two-job split:

- **`build-dependents`** — PR / merge_group **validation** leg. `needs: changes` only; builds FROM `:latest`. Runs in parallel with `build-base` instead of behind it → takes build-base off the PR critical path.
- **`build-dependents-push`** — push / tag / dispatch leg. **Byte-identical** build, but keeps `needs: [changes, build-base]` and the explicit base-success check because it genuinely consumes the freshly-built per-arch scratch base tag (`switchroom-base:sha-<short>-<arch>`).

## Correctness

- `build-base` still runs on **every** event and is still aggregated by `images-ok`, so a base-Dockerfile regression is still caught on PRs.
- `merge-dependents` now needs `build-dependents-push` (the leg that actually pushes the per-arch scratch tags on a real push; the PR/merge_group leg is skipped on push, so needing it would leave merge-dependents skipped and nothing would publish).
- `images-ok` (the branch-protection sentinel) aggregates **both** legs in `needs:` and its verdict loop.

## Tests

- `tests/ci-merge-queue-triggers.test.ts` — locks in the new needs-graph: PR leg does NOT need build-base, push leg DOES, both legs' `strategy`+`steps` stay in sync (drift guard), merge-dependents needs the push leg, images-ok aggregates both. `ALLOWED_JOB_LEVEL_GATES` narrowed to `['build-base']` (only it keeps the bare `!= 'pull_request'` shorthand).
- `tests/ci-buildx-warm-pull.test.ts` — adds `build-dependents-push` to the pinned setup-buildx-composite allowlist.

79/79 scoped workflow-shape tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)