### PR TITLE
ci(docker-images): build dist/ once, share with dependent image legs

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -13,9 +13,10 @@ name: docker-images
 #   - pull_request: build only (no push) to validate Dockerfile changes.
 #
 # Pipelines (perf rework, follows #2807):
-#   - build-dist builds dist/ ONCE and uploads it as the `dist-built`
+#   - build-dist runs `npm run build` ONCE and uploads BOTH build-output
+#     trees — `dist/` and `telegram-plugin/dist/` — as the `dist-built`
 #     artifact; the dependent image legs download it instead of each
-#     rebuilding dist/ (an Actions-minutes saving — legs run in parallel
+#     rebuilding them (an Actions-minutes saving — legs run in parallel
 #     so wall-clock is ~neutral). build-base does NOT consume dist/
 #     (Dockerfile.base COPYs nothing from the context), so it builds no
 #     dist.
@@ -224,7 +225,25 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: dist-built
-          path: dist/
+          # BOTH build-output trees, not just dist/. `npm run build` emits
+          # dist/ AND telegram-plugin/dist/ (scripts/build.mjs shells
+          # telegram-plugin/scripts/build.mjs to bundle the plugin's
+          # server/gateway/bridge entry points), and Dockerfile.agent COPYs
+          # `telegram-plugin/dist`. Both are gitignored (.gitignore's bare
+          # `dist/` matches at any depth), so neither is in the leg's
+          # checkout — shipping only dist/ makes the agent leg fail with a
+          # bare `"/telegram-plugin/dist": not found` from buildx. Any
+          # gitignored path a dependent Dockerfile COPYs from MUST be listed
+          # here; tests/docker/ci-build-dist-shared.test.ts derives that set
+          # from the Dockerfiles and fails if one is missing.
+          #
+          # Two paths make upload-artifact root the archive at their least
+          # common ancestor — the workspace — so entries are `dist/...` and
+          # `telegram-plugin/dist/...`. The consumers download with
+          # `path: .` to restore that layout verbatim.
+          path: |
+            dist/
+            telegram-plugin/dist/
           # 1-day retention: the artifact is consumed by the image legs
           # that fire within minutes of this job.
           retention-days: 1
@@ -493,13 +512,34 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Download dist artifact
-        # Built once by build-dist; each Dockerfile COPYs a slice of
-        # dist/ into its image. `context: .` in the build step below
-        # picks it up from the working directory.
+        # Built once by build-dist; each Dockerfile COPYs a slice of the
+        # build output into its image. `path: .` (NOT `dist/`) because the
+        # artifact is rooted at the workspace and carries BOTH build-output
+        # trees — `dist/` and `telegram-plugin/dist/`. Unpacking at `.`
+        # restores each at its original path, which is where the
+        # Dockerfiles' COPY sources resolve under `context: .` below.
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: dist-built
-          path: dist/
+          path: .
+
+      - name: Verify build outputs landed
+        # Fail HERE, with a readable message, rather than 200 lines later
+        # inside buildx. A missing tree surfaces from docker build as a bare
+        # `failed to compute cache key: "/telegram-plugin/dist": not found`,
+        # which says nothing about the artifact being the culprit — that is
+        # exactly how the telegram-plugin/dist omission presented. Keep this
+        # list in sync with the upload paths in build-dist.
+        run: |
+          set -euo pipefail
+          missing=0
+          for d in dist telegram-plugin/dist; do
+            if [ ! -d "$d" ] || [ -z "$(ls -A "$d" 2>/dev/null)" ]; then
+              echo "::error::build output '$d' is missing or empty after downloading the dist-built artifact — check the upload paths in the build-dist job"
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ]
 
       - name: Restore exec bits on bundled CLIs
         # upload-artifact stores a zip and strips POSIX exec bits on
@@ -626,13 +666,34 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Download dist artifact
-        # Built once by build-dist; each Dockerfile COPYs a slice of
-        # dist/ into its image. `context: .` in the build step below
-        # picks it up from the working directory.
+        # Built once by build-dist; each Dockerfile COPYs a slice of the
+        # build output into its image. `path: .` (NOT `dist/`) because the
+        # artifact is rooted at the workspace and carries BOTH build-output
+        # trees — `dist/` and `telegram-plugin/dist/`. Unpacking at `.`
+        # restores each at its original path, which is where the
+        # Dockerfiles' COPY sources resolve under `context: .` below.
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: dist-built
-          path: dist/
+          path: .
+
+      - name: Verify build outputs landed
+        # Fail HERE, with a readable message, rather than 200 lines later
+        # inside buildx. A missing tree surfaces from docker build as a bare
+        # `failed to compute cache key: "/telegram-plugin/dist": not found`,
+        # which says nothing about the artifact being the culprit — that is
+        # exactly how the telegram-plugin/dist omission presented. Keep this
+        # list in sync with the upload paths in build-dist.
+        run: |
+          set -euo pipefail
+          missing=0
+          for d in dist telegram-plugin/dist; do
+            if [ ! -d "$d" ] || [ -z "$(ls -A "$d" 2>/dev/null)" ]; then
+              echo "::error::build output '$d' is missing or empty after downloading the dist-built artifact — check the upload paths in the build-dist job"
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ]
 
       - name: Restore exec bits on bundled CLIs
         # upload-artifact stores a zip and strips POSIX exec bits on

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -13,6 +13,12 @@ name: docker-images
 #   - pull_request: build only (no push) to validate Dockerfile changes.
 #
 # Pipelines (perf rework, follows #2807):
+#   - build-dist builds dist/ ONCE and uploads it as the `dist-built`
+#     artifact; the dependent image legs download it instead of each
+#     rebuilding dist/ (an Actions-minutes saving — legs run in parallel
+#     so wall-clock is ~neutral). build-base does NOT consume dist/
+#     (Dockerfile.base COPYs nothing from the context), so it builds no
+#     dist.
 #   - build-base + build-dependents run as a PER-ARCH matrix on NATIVE
 #     runners (amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm) — no
 #     QEMU emulation. On PR / merge_group, build-dependents builds FROM
@@ -164,6 +170,66 @@ jobs:
         with:
           filters: .github/path-filters.yml
 
+  # ─── Build dist/ once, share with the dependent image legs ────────
+  # The dependent images (agent/broker/kernel/hostd/auth-broker/web)
+  # each COPY a slice of dist/ into their image. Before this job every
+  # matrix leg rebuilt dist/ from scratch (setup-node + frozen bun
+  # install + `npm run build`) — identical work, once per leg per arch.
+  # Build it ONCE here and hand it to the legs as the `dist-built`
+  # artifact. This is an Actions-MINUTES saving, not a wall-clock one:
+  # the legs already run in parallel, so the critical path is roughly
+  # unchanged, but the redundant per-leg build work collapses into a
+  # single job. build-base is deliberately NOT a consumer — its
+  # Dockerfile.base COPYs nothing from the context (pure FROM
+  # node:22 + apt/npm), so its dist build was dead work and is dropped.
+  # Mirrors the build-dist -> dist-built pattern in ci-tests-core.yml.
+  build-dist:
+    needs: changes
+    # Runs whenever any dependent leg will: every non-PR event (push /
+    # tag / dispatch / merge_group) plus PRs that touched image inputs.
+    # Skipped only on a PR with no image changes — where no leg runs.
+    # `!cancelled()` for the SAME reason build-base has it: `changes` is
+    # skipped on tag / dispatch / merge_group (no diff base), and without
+    # a status expression that skip would propagate and skip build-dist —
+    # which would skip the merge_group validation legs AND, on a tag,
+    # skip the publish path entirely.
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.images == 'true') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up Node (for dist/ bundling)
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: "22"
+
+      - name: Set up workspace (pinned bun + warm cache + frozen lockfile)
+        # Composite action: pinned bun (not `latest` — an unpinned bun
+        # release changing under a release build is a flake vector), bun
+        # package cache restore, and `bun install --frozen-lockfile`
+        # (a bare `bun install` can silently drift from bun.lock).
+        uses: ./.github/actions/setup-switchroom
+
+      - name: Build dist/
+        env:
+          # Arms the mis-stamp guard in scripts/build.mjs: on a tag build this is
+          # the tag (e.g. v0.15.56); on non-tag builds it is empty so the guard
+          # stays silent and dev builds fall back to package.json.
+          TAG_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
+        run: npm run build
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: dist-built
+          path: dist/
+          # 1-day retention: the artifact is consumed by the image legs
+          # that fire within minutes of this job.
+          retention-days: 1
+          if-no-files-found: error
+
   build-base:
     needs: changes
     # Non-PR events (main push / tag / dispatch / merge_group): always
@@ -192,26 +258,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
-      - name: Set up Node (for dist/ bundling)
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
-        with:
-          node-version: "22"
-
-      - name: Set up workspace (pinned bun + warm cache + frozen lockfile)
-        # Composite action: pinned bun (not `latest` — an unpinned bun
-        # release changing under a release build is a flake vector), bun
-        # package cache restore, and `bun install --frozen-lockfile`
-        # (a bare `bun install` can silently drift from bun.lock).
-        uses: ./.github/actions/setup-switchroom
-
-      - name: Build dist/
-        env:
-          # Arms the mis-stamp guard in scripts/build.mjs: on a tag build this is
-          # the tag (e.g. v0.15.56); on non-tag builds it is empty so the guard
-          # stays silent and dev builds fall back to package.json.
-          TAG_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
-        run: npm run build
 
       - name: Set up Docker Buildx
         # Composite action, NOT docker/setup-buildx-action directly (#3815).
@@ -414,11 +460,15 @@ jobs:
     # is build-dependents-push below — GitHub Actions has no
     # event-conditional `needs:`, so the push-path data dependency is
     # expressed as a separate job rather than a conditional edge.
-    needs: changes
+    needs: [changes, build-dist]
     # PR: only when image inputs changed. merge_group: always — a queue
     # entry that compiled no dependents would make images-ok a rubber
     # stamp. Never push/tag/dispatch — that is build-dependents-push.
-    if: ${{ !cancelled() && ((github.event_name == 'pull_request' && needs.changes.outputs.images == 'true') || github.event_name == 'merge_group') }}
+    # `needs.build-dist.result == 'success'` gates on the shared dist
+    # artifact — with `!cancelled()` replacing the default
+    # all-needs-succeeded, a failed build-dist would otherwise let this
+    # leg run and fail confusingly at `COPY dist/`.
+    if: ${{ !cancelled() && needs.build-dist.result == 'success' && ((github.event_name == 'pull_request' && needs.changes.outputs.images == 'true') || github.event_name == 'merge_group') }}
     strategy:
       fail-fast: false
       matrix:
@@ -442,25 +492,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - name: Set up Node (for dist/ bundling)
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+      - name: Download dist artifact
+        # Built once by build-dist; each Dockerfile COPYs a slice of
+        # dist/ into its image. `context: .` in the build step below
+        # picks it up from the working directory.
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          node-version: "22"
+          name: dist-built
+          path: dist/
 
-      - name: Set up workspace (pinned bun + warm cache + frozen lockfile)
-        # Composite action: pinned bun (not `latest` — an unpinned bun
-        # release changing under a release build is a flake vector), bun
-        # package cache restore, and `bun install --frozen-lockfile`
-        # (a bare `bun install` can silently drift from bun.lock).
-        uses: ./.github/actions/setup-switchroom
-
-      - name: Build dist/
-        env:
-          # Arms the mis-stamp guard in scripts/build.mjs: on a tag build this is
-          # the tag (e.g. v0.15.56); on non-tag builds it is empty so the guard
-          # stays silent and dev builds fall back to package.json.
-          TAG_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
-        run: npm run build
+      - name: Restore exec bits on bundled CLIs
+        # upload-artifact stores a zip and strips POSIX exec bits on
+        # download; scripts/build.mjs chmods every entry-point bundle
+        # 0o755 because the runtime invokes them directly, and a
+        # Dockerfile COPY preserves the (now-stripped) source mode. Mirrors
+        # ci-tests-core.yml's dist-built consumers.
+        run: |
+          chmod +x dist/cli/*.js dist/cli/*.mjs 2>/dev/null || true
 
       - name: Set up Docker Buildx
         # Composite action, NOT docker/setup-buildx-action directly (#3815).
@@ -548,12 +596,12 @@ jobs:
     # and the explicit base-success check (the push-path data
     # dependency the PR/merge_group leg deliberately drops). Keep the
     # strategy + steps below IN SYNC with build-dependents.
-    needs: [changes, build-base]
-    # `!cancelled() && base succeeded` (not the default
-    # all-needs-succeeded, so a FAILED base blocks rather than
+    needs: [changes, build-base, build-dist]
+    # `!cancelled() && base succeeded && dist built` (not the default
+    # all-needs-succeeded, so a FAILED base or dist blocks rather than
     # silently skips), restricted to the publishing events. Never PR
     # or merge_group — those are build-dependents' job.
-    if: ${{ !cancelled() && needs.build-base.result == 'success' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
+    if: ${{ !cancelled() && needs.build-base.result == 'success' && needs.build-dist.result == 'success' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
     strategy:
       fail-fast: false
       matrix:
@@ -577,25 +625,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - name: Set up Node (for dist/ bundling)
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+      - name: Download dist artifact
+        # Built once by build-dist; each Dockerfile COPYs a slice of
+        # dist/ into its image. `context: .` in the build step below
+        # picks it up from the working directory.
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          node-version: "22"
+          name: dist-built
+          path: dist/
 
-      - name: Set up workspace (pinned bun + warm cache + frozen lockfile)
-        # Composite action: pinned bun (not `latest` — an unpinned bun
-        # release changing under a release build is a flake vector), bun
-        # package cache restore, and `bun install --frozen-lockfile`
-        # (a bare `bun install` can silently drift from bun.lock).
-        uses: ./.github/actions/setup-switchroom
-
-      - name: Build dist/
-        env:
-          # Arms the mis-stamp guard in scripts/build.mjs: on a tag build this is
-          # the tag (e.g. v0.15.56); on non-tag builds it is empty so the guard
-          # stays silent and dev builds fall back to package.json.
-          TAG_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
-        run: npm run build
+      - name: Restore exec bits on bundled CLIs
+        # upload-artifact stores a zip and strips POSIX exec bits on
+        # download; scripts/build.mjs chmods every entry-point bundle
+        # 0o755 because the runtime invokes them directly, and a
+        # Dockerfile COPY preserves the (now-stripped) source mode. Mirrors
+        # ci-tests-core.yml's dist-built consumers.
+        run: |
+          chmod +x dist/cli/*.js dist/cli/*.mjs 2>/dev/null || true
 
       - name: Set up Docker Buildx
         # Composite action, NOT docker/setup-buildx-action directly (#3815).
@@ -1229,6 +1275,7 @@ jobs:
   images-ok:
     needs:
       - changes
+      - build-dist
       - build-base
       - merge-base
       - build-dependents
@@ -1254,6 +1301,7 @@ jobs:
           fi
           fail=0
           for pair in \
+            "build-dist=${{ needs.build-dist.result }}" \
             "build-base=${{ needs.build-base.result }}" \
             "merge-base=${{ needs.merge-base.result }}" \
             "build-dependents=${{ needs.build-dependents.result }}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ now an anomaly worth investigating, not the norm.
   shard + `hindsight-probe`, and `vitest` still aggregates all 8 core shards;
   the individual shard contexts are NOT branch-protection-required.
 
+### CI: `dist/` is built once and shared with the dependent image legs
+
+- **docker-images: a single `build-dist` job bundles `dist/` once and uploads
+  it as the `dist-built` artifact; the dependent image legs download it instead
+  of each rebuilding `dist/`.** An Actions-minutes saving (one build instead of
+  one per leg per arch), not a wall-clock one — the legs already run in
+  parallel. `build-base` builds no `dist/` at all now: `Dockerfile.base` copies
+  nothing from the build context, so its dist build was dead work and is
+  removed.
+
 ### CI: `build-dependents` no longer serialized behind `build-base` on PR / merge_group
 
 - **docker-images: dependent image builds now run in parallel with `build-base`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,13 +30,19 @@ now an anomaly worth investigating, not the norm.
 
 ### CI: `dist/` is built once and shared with the dependent image legs
 
-- **docker-images: a single `build-dist` job bundles `dist/` once and uploads
-  it as the `dist-built` artifact; the dependent image legs download it instead
-  of each rebuilding `dist/`.** An Actions-minutes saving (one build instead of
-  one per leg per arch), not a wall-clock one — the legs already run in
-  parallel. `build-base` builds no `dist/` at all now: `Dockerfile.base` copies
-  nothing from the build context, so its dist build was dead work and is
-  removed.
+- **docker-images: a single `build-dist` job runs `npm run build` once and
+  uploads both build-output trees — `dist/` and `telegram-plugin/dist/` — as the
+  `dist-built` artifact; the dependent image legs download it instead of each
+  rebuilding them.** An Actions-minutes saving (one build instead of one per leg
+  per arch), not a wall-clock one — the legs already run in parallel.
+  `build-base` builds no `dist/` at all now: `Dockerfile.base` copies nothing
+  from the build context, so its dist build was dead work and is removed.
+  `telegram-plugin/dist/` is easy to overlook because `.gitignore`'s bare
+  `dist/` matches it at any depth, yet only `Dockerfile.agent` copies it — so
+  `tests/docker/ci-build-dist-shared.test.ts` now derives the required artifact
+  contents from the dependent Dockerfiles' `COPY` sources rather than
+  hardcoding them, and each leg verifies both trees landed before invoking
+  buildx.
 
 ### CI: `build-dependents` no longer serialized behind `build-base` on PR / merge_group
 

--- a/tests/ci-merge-queue-triggers.test.ts
+++ b/tests/ci-merge-queue-triggers.test.ts
@@ -365,15 +365,24 @@ describe('merge queue — docker-images never publishes from an unmerged ref', (
     // job-wide exemption would wave those through — which is exactly the
     // bug this file exists to prevent.
     //
-    // Only `build-base` remains here. `build-dependents` used to be exempt
-    // too (its old bare `!= 'pull_request'` gate also meant "compile on
-    // merge_group"), but the build-base decoupling split the dependents
-    // build into two jobs: the PR/merge_group leg (`build-dependents`) now
-    // uses a POSITIVE event allowlist with no `!= 'pull_request'`
-    // shorthand, and the push leg (`build-dependents-push`) spells out
-    // `&& github.event_name != 'merge_group'` — so neither needs the
-    // exemption. See the "build-base decoupling" describe block below.
-    const ALLOWED_JOB_LEVEL_GATES = ['build-base']
+    // Two jobs are exempt: `build-base` and `build-dist`. Both mean
+    // "actually produce the build input" — build-base compiles the base
+    // image, build-dist bundles dist/ once for the dependent legs — and
+    // both MUST run on merge_group so the validation legs have something
+    // to build (else `images-ok` is a rubber stamp). Crucially, NEITHER
+    // pushes anything: build-base's push/cache-to are step-level and gated
+    // separately, and build-dist only uploads an in-run artifact. So the
+    // bare `!= 'pull_request'` job gate is safe on the queue ref for both.
+    //
+    // `build-dependents` used to be exempt too (its old bare
+    // `!= 'pull_request'` gate also meant "compile on merge_group"), but
+    // the build-base decoupling split the dependents build into two jobs:
+    // the PR/merge_group leg (`build-dependents`) now uses a POSITIVE event
+    // allowlist with no `!= 'pull_request'` shorthand, and the push leg
+    // (`build-dependents-push`) spells out `&& github.event_name !=
+    // 'merge_group'` — so neither needs the exemption. See the "build-base
+    // decoupling" describe block below.
+    const ALLOWED_JOB_LEVEL_GATES = ['build-base', 'build-dist']
 
     const lines = readFileSync(join(REPO, '.github/workflows/docker-images.yml'), 'utf8').split('\n')
     let job = '<workflow-level>'

--- a/tests/docker/ci-build-dist-shared.test.ts
+++ b/tests/docker/ci-build-dist-shared.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Guard: dist/ is built ONCE (in build-dist) and shared with the
+ * dependent image legs as the `dist-built` artifact — no leg rebuilds
+ * it, and build-base (which COPYs nothing from the context) builds no
+ * dist at all.
+ *
+ * Why this test exists: the whole point of the build-dist job is to
+ * collapse N identical `npm run build` invocations into one. A future
+ * edit that re-adds a `Build dist/` step to a matrix leg (or drops the
+ * `download-artifact` step so the leg's `COPY dist/` picks up a stale or
+ * empty tree) would silently undo the saving OR — worse — produce an
+ * image built from no dist. Both are invisible on a green run: the
+ * former just wastes minutes, the latter only fails at docker-build
+ * time on a push. Assert the shape directly.
+ *
+ * Companion to tests/ci-buildx-warm-pull.test.ts and
+ * tests/ci-merge-queue-triggers.test.ts, which guard other structural
+ * invariants of the same workflow.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse } from "yaml";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+interface Step {
+  name?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, unknown>;
+}
+interface Job {
+  needs?: string | string[];
+  if?: unknown;
+  steps?: Step[];
+}
+
+const wf = parse(
+  readFileSync(resolve(root, ".github/workflows/docker-images.yml"), "utf8"),
+) as { jobs: Record<string, Job> };
+const jobs = wf.jobs;
+
+function needsOf(job: Job): string[] {
+  if (!job.needs) return [];
+  return Array.isArray(job.needs) ? job.needs : [job.needs];
+}
+function steps(name: string): Step[] {
+  const j = jobs[name];
+  expect(j, `job ${name} must exist`).toBeTruthy();
+  return j.steps ?? [];
+}
+function runsNpmBuild(job: Job): boolean {
+  return (job.steps ?? []).some((s) => /\bnpm run build\b/.test(s.run ?? ""));
+}
+function downloadsDist(job: Job): boolean {
+  return (job.steps ?? []).some(
+    (s) =>
+      typeof s.uses === "string" &&
+      s.uses.includes("actions/download-artifact") &&
+      s.with?.name === "dist-built",
+  );
+}
+
+const DEPENDENT_LEGS = ["build-dependents", "build-dependents-push"];
+
+describe("docker-images — dist/ is built once and shared", () => {
+  it("build-dist exists, builds dist/, and uploads the dist-built artifact", () => {
+    const j = jobs["build-dist"];
+    expect(j, "build-dist job must exist").toBeTruthy();
+    expect(runsNpmBuild(j)).toBe(true);
+    const upload = (j.steps ?? []).find(
+      (s) =>
+        typeof s.uses === "string" &&
+        s.uses.includes("actions/upload-artifact"),
+    );
+    expect(upload, "build-dist must upload an artifact").toBeTruthy();
+    expect(upload!.with?.name).toBe("dist-built");
+    expect(upload!.with?.path).toBe("dist/");
+    // if-no-files-found: error — a build that emitted nothing must fail
+    // the job loudly, not hand an empty artifact to the image legs.
+    expect(upload!.with?.["if-no-files-found"]).toBe("error");
+  });
+
+  it("EXACTLY one job runs `npm run build` — dist is not rebuilt anywhere else", () => {
+    const builders = Object.keys(jobs).filter((n) => runsNpmBuild(jobs[n]));
+    expect(builders).toEqual(["build-dist"]);
+  });
+
+  for (const leg of DEPENDENT_LEGS) {
+    it(`${leg} downloads dist-built and does NOT rebuild dist/`, () => {
+      const j = jobs[leg];
+      expect(j, `${leg} must exist`).toBeTruthy();
+      expect(downloadsDist(j)).toBe(true);
+      expect(runsNpmBuild(j)).toBe(false);
+    });
+
+    it(`${leg} needs build-dist`, () => {
+      expect(needsOf(jobs[leg])).toContain("build-dist");
+    });
+
+    it(`${leg} restores exec bits on the downloaded bundles`, () => {
+      // upload-artifact zips and strips POSIX exec bits; the runtime
+      // execs the bundled CLIs and a Dockerfile COPY preserves the
+      // stripped mode, so the leg MUST chmod them back before building.
+      const chmod = steps(leg).some((s) =>
+        /chmod \+x dist\/cli/.test(s.run ?? ""),
+      );
+      expect(chmod).toBe(true);
+    });
+  }
+
+  it("build-base builds NO dist and does not consume the artifact (Dockerfile.base COPYs nothing)", () => {
+    const j = jobs["build-base"];
+    expect(runsNpmBuild(j)).toBe(false);
+    expect(downloadsDist(j)).toBe(false);
+    expect(needsOf(j)).not.toContain("build-dist");
+  });
+
+  it("images-ok aggregates build-dist so a dist-build failure blocks the sentinel", () => {
+    expect(needsOf(jobs["images-ok"])).toContain("build-dist");
+  });
+
+  it("build-dist runs on every event except a PR with no image changes", () => {
+    // The union of the two dependent legs' gates: skip only when it's a
+    // PR that touched no image inputs (where no leg runs).
+    const cond = String(jobs["build-dist"].if);
+    expect(cond).toContain("github.event_name != 'pull_request'");
+    expect(cond).toContain("needs.changes.outputs.images == 'true'");
+  });
+
+  it("build-dist's if is a status expression (!cancelled) so a skipped `changes` doesn't skip it", () => {
+    // `changes` is skipped on tag / dispatch / merge_group (no diff
+    // base). Without a status function in the if, that skip PROPAGATES
+    // through `needs: changes` and skips build-dist — which would skip
+    // the merge_group validation legs and, on a TAG push, skip the whole
+    // publish path (merge-dependents needs build-dependents-push needs
+    // build-dist). build-base carries `!cancelled()` for exactly this
+    // reason; build-dist must too. Regression is invisible on PRs.
+    expect(String(jobs["build-dist"].if)).toContain("!cancelled()");
+  });
+});

--- a/tests/docker/ci-build-dist-shared.test.ts
+++ b/tests/docker/ci-build-dist-shared.test.ts
@@ -20,6 +20,7 @@
 
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse } from "yaml";
@@ -64,6 +65,89 @@ function downloadsDist(job: Job): boolean {
   );
 }
 
+/** The `path:` of build-dist's upload, normalised to a list (it is multi-line). */
+function uploadPaths(): string[] {
+  const upload = (jobs["build-dist"].steps ?? []).find(
+    (s) =>
+      typeof s.uses === "string" && s.uses.includes("actions/upload-artifact"),
+  );
+  return String(upload?.with?.path ?? "")
+    .split("\n")
+    .map((p) => p.trim())
+    .filter(Boolean);
+}
+
+/**
+ * The Dockerfiles the dependent legs build, read off the job matrix rather
+ * than hardcoded — a leg added to the matrix is covered automatically.
+ */
+function dependentDockerfiles(): string[] {
+  const out = new Set<string>();
+  for (const leg of DEPENDENT_LEGS) {
+    const images = (
+      jobs[leg] as {
+        strategy?: { matrix?: { image?: { name?: string; file?: string }[] } };
+      }
+    ).strategy?.matrix?.image;
+    for (const entry of images ?? []) {
+      if (entry.file) out.add(entry.file);
+    }
+  }
+  expect(
+    out.size,
+    "expected to discover dependent Dockerfiles from the build-dependents matrix",
+  ).toBeGreaterThan(0);
+  return [...out];
+}
+
+/** Every COPY source path in a Dockerfile (skipping `COPY --from=` stage/image copies). */
+function copySources(dockerfile: string): string[] {
+  const text = readFileSync(resolve(root, dockerfile), "utf8");
+  const srcs: string[] = [];
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!/^COPY\s/i.test(line)) continue;
+    const tokens = line.split(/\s+/).slice(1);
+    // `--from=` copies pull from another stage or image, not the build
+    // context, so the artifact is irrelevant to them.
+    if (tokens.some((t) => t.startsWith("--from="))) continue;
+    const args = tokens.filter((t) => !t.startsWith("--"));
+    // Last arg is the destination; everything before it is a source.
+    srcs.push(...args.slice(0, -1));
+  }
+  return srcs;
+}
+
+/**
+ * True when git ignores the path — i.e. it is a build output absent from a
+ * fresh checkout, so it can only reach the build context via the artifact.
+ * Uses git itself rather than a hand-maintained pattern list: `.gitignore`'s
+ * bare `dist/` matches at ANY depth, which is precisely why
+ * `telegram-plugin/dist` is in the same boat as `dist` and easy to miss.
+ */
+function isGitIgnored(p: string): boolean {
+  const check = (probe: string): boolean => {
+    const r = spawnSync("git", ["check-ignore", "-q", "--no-index", probe], {
+      cwd: root,
+    });
+    if (r.error) throw r.error;
+    // 0 = ignored, 1 = not ignored, anything else = git failed.
+    if (r.status !== 0 && r.status !== 1) {
+      throw new Error(
+        `git check-ignore failed for ${probe} (status ${r.status})`,
+      );
+    }
+    return r.status === 0;
+  };
+  // Probe the bare path AND the directory form. A directory-only pattern
+  // (`dist/`, with the trailing slash) does NOT match the bare string
+  // `telegram-plugin/dist` when that directory is absent from disk — which
+  // it always is in CI, since it is a build output. Without the trailing-
+  // slash probe this helper silently reports every such COPY source as
+  // "tracked" and the coverage assertion below becomes a no-op.
+  return check(p) || check(p.endsWith("/") ? p : `${p}/`);
+}
+
 const DEPENDENT_LEGS = ["build-dependents", "build-dependents-push"];
 
 describe("docker-images — dist/ is built once and shared", () => {
@@ -78,10 +162,88 @@ describe("docker-images — dist/ is built once and shared", () => {
     );
     expect(upload, "build-dist must upload an artifact").toBeTruthy();
     expect(upload!.with?.name).toBe("dist-built");
-    expect(upload!.with?.path).toBe("dist/");
+    expect(uploadPaths()).toContain("dist/");
     // if-no-files-found: error — a build that emitted nothing must fail
     // the job loudly, not hand an empty artifact to the image legs.
     expect(upload!.with?.["if-no-files-found"]).toBe("error");
+  });
+
+  // The bug this assertion exists for: the artifact originally shipped
+  // ONLY `dist/`, but `npm run build` also emits `telegram-plugin/dist/`
+  // (scripts/build.mjs shells telegram-plugin/scripts/build.mjs) and
+  // Dockerfile.agent COPYs it. Both trees are gitignored, so neither is in
+  // the leg's checkout — the agent leg died with a bare
+  // `failed to compute cache key: "/telegram-plugin/dist": not found`.
+  //
+  // Rather than hardcode the two known trees, DERIVE the requirement from
+  // the Dockerfiles: every COPY source that git ignores is, by definition,
+  // absent from the checkout and must therefore arrive via the artifact.
+  // That catches the next build output someone adds a COPY for, not just
+  // this one.
+  it("the dist-built artifact covers every gitignored path the dependent Dockerfiles COPY from", () => {
+    // Compare slash-normalised: an artifact path is written `dist/` but the
+    // Dockerfile COPYs `telegram-plugin/dist` (no trailing slash), and the
+    // two spellings denote the same tree.
+    const trim = (s: string) => s.replace(/\/+$/, "");
+    const paths = uploadPaths();
+    const roots = paths.map(trim);
+    const uncovered: string[] = [];
+
+    for (const dockerfile of dependentDockerfiles()) {
+      for (const src of copySources(dockerfile)) {
+        if (!isGitIgnored(src)) continue; // in the checkout already
+        const s = trim(src);
+        const covered = roots.some((r) => s === r || s.startsWith(`${r}/`));
+        if (!covered) uncovered.push(`${dockerfile}: COPY ${src}`);
+      }
+    }
+
+    expect(
+      uncovered,
+      `these Dockerfile COPY sources are build outputs (gitignored) but are not in the ` +
+        `dist-built artifact, so the build leg will fail with "not found":\n  ` +
+        `${uncovered.join("\n  ")}\nArtifact paths: ${JSON.stringify(paths)}`,
+    ).toEqual([]);
+  });
+
+  it("the dependent legs unpack the artifact at the workspace root", () => {
+    // The artifact spans two trees, so upload-artifact roots it at their
+    // least common ancestor (the workspace). Downloading into `dist/`
+    // would nest it as `dist/dist/...` + `dist/telegram-plugin/dist/...`
+    // and every COPY would miss.
+    for (const leg of DEPENDENT_LEGS) {
+      const dl = steps(leg).find(
+        (s) =>
+          typeof s.uses === "string" &&
+          s.uses.includes("actions/download-artifact") &&
+          s.with?.name === "dist-built",
+      );
+      expect(dl, `${leg} must download dist-built`).toBeTruthy();
+      expect(dl!.with?.path, `${leg} must unpack at the workspace root`).toBe(
+        ".",
+      );
+    }
+  });
+
+  it("each leg's post-download verify step checks exactly the uploaded trees", () => {
+    // The verify step exists so a missing tree fails with a readable error
+    // instead of a cryptic buildx `not found`. That only holds if its list
+    // tracks the upload paths — a tree added to the artifact but not to the
+    // verify loop is unguarded, and one dropped from the artifact but left
+    // in the loop makes the step fail spuriously. Pin them together.
+    const expected = uploadPaths()
+      .map((p) => p.replace(/\/+$/, ""))
+      .sort();
+    for (const leg of DEPENDENT_LEGS) {
+      const verify = steps(leg).find((s) =>
+        /Verify build outputs/i.test(s.name ?? ""),
+      );
+      expect(verify, `${leg} must verify the download landed`).toBeTruthy();
+      const loop = /for d in ([^;\n]+); do/.exec(verify!.run ?? "");
+      expect(loop, `${leg}'s verify step must iterate the expected trees`)
+        .toBeTruthy();
+      expect(loop![1].trim().split(/\s+/).sort()).toEqual(expected);
+    }
   });
 
   it("EXACTLY one job runs `npm run build` — dist is not rebuilt anywhere else", () => {


### PR DESCRIPTION
> **Stacked on #4560** (`ci/decouple-dependents-from-base`). Base is that branch, not `main`, because both PRs edit the same `build-dependents` / `build-dependents-push` regions of `docker-images.yml` and would otherwise conflict. Rebase onto `main` after #4560 merges.

## What

Every dependent image leg (agent/broker/kernel/hostd/auth-broker/web) rebuilt `dist/` from scratch — `setup-node` + frozen `bun install` + `npm run build` — identical work, once per leg per arch. Add a single **`build-dist`** job that bundles `dist/` once and uploads it as the `dist-built` artifact; each leg **downloads** it (and restores the exec bits `upload-artifact` strips) instead of rebuilding. Mirrors the pattern `ci-tests-core.yml` already uses for the vitest shards.

**Honest framing:** this is an **Actions-minutes** saving, *not* a wall-clock one. The legs already run in parallel, so the critical path is roughly unchanged; what shrinks is the redundant per-leg build work (one build instead of ~6–10).

## build-base contradiction (reported, not force-fitted)

The task framed this as "docker matrix legs download dist instead of building it." But `docker/Dockerfile.base` **COPYs nothing** from the build context (it is a pure `FROM node:22` + apt/npm image), so build-base's `Set up Node` / `Set up workspace` / `Build dist/` steps were **dead work** — building a dist/ the base image never consumes. Rather than wire build-base to download an artifact it wouldn't use, those three steps are **removed outright**. build-base is not a consumer of `dist-built`.

## Correctness

- `dist/` is arch-independent JS bundles, so the amd64-built artifact feeds the native **arm64** legs unchanged.
- `build-dist` carries `!cancelled()` like build-base: `changes` is skipped on tag/dispatch/merge_group, and without a status expression that skip would propagate and skip build-dist — which would skip the merge_group validation legs and, **on a tag, skip the whole publish path**. Guarded by a test.
- the dependent legs gate on `needs.build-dist.result == 'success'` so a failed dist build blocks rather than failing confusingly at `COPY dist/`.
- `images-ok` aggregates `build-dist` so a dist-build failure reddens the required sentinel.
- exactly **one** job runs `npm run build` now (asserted) — no leg silently rebuilds dist.

## Tests

- `tests/docker/ci-build-dist-shared.test.ts` (new, 12 assertions): exactly one `npm run build`; both legs download `dist-built` + restore exec bits + `needs: build-dist`; build-base builds no dist and doesn't need it; images-ok aggregates build-dist; build-dist's `if` is a status expression (`!cancelled()`).
- `tests/ci-merge-queue-triggers.test.ts`: adds `build-dist` to the narrow job-level `!= 'pull_request'` gate allowlist (it must run on merge_group to feed the validation legs, and pushes nothing).

90/90 scoped workflow-shape tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)