### PR TITLE
ci: parallelize e2e (3-way shard) + core tests (4→8 shards) — free-runner only

### DIFF
--- a/.github/workflows/ci-tests-core.yml
+++ b/.github/workflows/ci-tests-core.yml
@@ -16,9 +16,12 @@ name: ci-tests-core
 #      ci-tests-core from ~1m10s to ~20-30s on the common case.
 #      Push to main runs the full suite — we don't gamble on main.
 #
-#   3. 4-way matrix sharding (carryover from #1320). With --changed
-#      the per-shard surface drops to a handful of files; shards still
-#      run in parallel for the few cases where many tests are affected.
+#   3. 8-way matrix sharding (raised from 4-way; carryover origin
+#      #1320). With --changed the per-shard surface drops to a handful
+#      of files; shards still run in parallel for the few cases where
+#      many tests are affected (push-to-main / merge_group full suite),
+#      where 8 free parallel runners roughly halve the wall-clock of the
+#      old 4-way split at zero extra cost.
 #
 # Sharding determinism: `vitest --shard X/Y` hashes test file paths so
 # a given file always lands in the same shard for a given Y. The
@@ -26,7 +29,7 @@ name: ci-tests-core
 #
 # Fork-pool tuning: VITEST_MAX_FORKS=2 honored by vitest.config.ts.
 # On a 2-vCPU runner that's 2 concurrent workers per shard, with all
-# 4 shards running on separate runners (matrix-parallel, not
+# 8 shards running on separate runners (matrix-parallel, not
 # co-located). Net: comfortable, not oversubscribed.
 
 on:
@@ -62,7 +65,7 @@ jobs:
   # below — it ALWAYS runs and aggregates the shards, so a docs-only
   # PR (shards skipped) still reports pass instead of blocking (#1343).
   # NOTE: branch protection must require `vitest` (the sentinel), NOT
-  # the old `vitest (1..4)` matrix contexts — see the PR description
+  # the old `vitest (1..8)` matrix contexts — see the PR description
   # for the one-time required-status-checks retune.
   changes:
     runs-on: ubuntu-latest
@@ -117,7 +120,7 @@ jobs:
   # ─── Sharded vitest run ───────────────────────────────────────────
   # Renamed vitest → vitest-shard so the required context is the
   # always-running `vitest` sentinel, not the path-skippable matrix
-  # contexts `vitest (1..4)` (those blocked docs-only PRs, #1343).
+  # contexts `vitest (1..8)` (those blocked docs-only PRs, #1343).
   vitest-shard:
     needs: [changes, build-dist]
     # push / merge_group: always run — both are (candidate) main.
@@ -127,7 +130,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     env:
       TELEGRAM_BOT_TOKEN: "123456:stub-for-tests"
       VITEST_MAX_FORKS: "2"
@@ -167,7 +170,7 @@ jobs:
           chmod +x dist/cli/*.js dist/cli/*.mjs 2>/dev/null || true
           ls -l dist/cli/
 
-      - name: Vitest shard ${{ matrix.shard }}/4 (PR — changed-files only)
+      - name: Vitest shard ${{ matrix.shard }}/8 (PR — changed-files only)
         if: github.event_name == 'pull_request'
         # --changed traces the import graph from files changed against
         # the PR base; vitest runs every test that transitively depends
@@ -176,7 +179,7 @@ jobs:
         # default behaviour is exit 1.
         run: |
           bunx vitest run \
-            --shard ${{ matrix.shard }}/4 \
+            --shard ${{ matrix.shard }}/8 \
             --changed origin/${{ github.base_ref }} \
             --passWithNoTests
 
@@ -188,9 +191,9 @@ jobs:
       # `github.base_ref`, which a queue ref does not have), so without
       # this the queue would "pass" vitest without executing a test.
       # Guarded by tests/ci-merge-queue-triggers.test.ts.
-      - name: Vitest shard ${{ matrix.shard }}/4 (push to main / merge queue — full suite)
+      - name: Vitest shard ${{ matrix.shard }}/8 (push to main / merge queue — full suite)
         if: github.event_name == 'push' || github.event_name == 'merge_group'
-        run: bunx vitest run --shard ${{ matrix.shard }}/4
+        run: bunx vitest run --shard ${{ matrix.shard }}/8
 
       - name: Upload coverage (if produced)
         if: always()
@@ -203,10 +206,10 @@ jobs:
 
   # ─── Sentinel ─────────────────────────────────────────────────────
   # Branch-protection-required context. ALWAYS runs and aggregates the
-  # 4 shards. `needs.vitest-shard.result` is success only if every
+  # 8 shards. `needs.vitest-shard.result` is success only if every
   # matrix shard succeeded, failure if any failed, skipped if the whole
   # matrix was path-skipped (irrelevant PR → pass). Branch protection
-  # must require `vitest` (this job), NOT `vitest (1..4)`.
+  # must require `vitest` (this job), NOT `vitest (1..8)`.
   vitest:
     needs: [changes, vitest-shard]
     if: always()

--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -61,13 +61,13 @@ concurrency:
 
 jobs:
   # ─── Path-change filter (sentinel pattern; see ci-lint.yml header) ─
-  # This filter job always runs; the real work jobs (`e2e`,
+  # This filter job always runs; the real work jobs (`e2e-shard`,
   # `hindsight-probe`) are `if:`-gated on its outputs and report
   # `skipped` on PRs that don't touch the paths they cover.
   #
   # A `skipped` check is NOT success for branch protection — it BLOCKS
   # (proven by #1343, a docs-only PR hard-blocked; same deadlock as
-  # #2237). So neither `e2e` nor `hindsight-probe` can be a required
+  # #2237). So neither `e2e-shard` nor `hindsight-probe` can be a required
   # context, and in fact neither has ever been in ruleset 16470166.
   # The `e2e-ok` sentinel at the bottom of this file exists for exactly
   # that reason: it ALWAYS runs, so it is the one context here that can
@@ -149,7 +149,27 @@ jobs:
               - 'tests/docker/dockerfile-hindsight-bakes.test.ts'
               - '.github/workflows/docker-e2e.yml'
 
-  e2e:
+  # ─── Sharded docker e2e run ───────────────────────────────────────
+  # The tests/docker suite is split across a 3-way matrix so it runs on
+  # three free parallel runners instead of one (~8 min of test execution
+  # → ~3 min wall clock). Mirrors the ci-tests-core.yml vitest-shard
+  # pattern: a matrix job whose contexts (`e2e-shard (1..3)`) are NOT
+  # branch-protection-required, aggregated by the always-running `e2e-ok`
+  # sentinel below.
+  #
+  # Isolation across shards is already guaranteed by the suite itself:
+  # every test container carries a `switchroom.test=phase*` label and
+  # runs under its own compose project, so three shards on three separate
+  # runners never collide. Each shard leg does the SAME image
+  # build/cache setup the single job did — the warm-tarball cache is
+  # keyed on file hashes, so all three shards share one key (first cold
+  # build populates it; the rest hit it warm or cold-build in parallel,
+  # all free).
+  #
+  # Sharding is threaded into scripts/ci/docker-snapshot-gate.sh via the
+  # VITEST_SHARD env var (e.g. "2/3"); unset, the gate runs the whole
+  # suite (the original single-runner path, preserved for other callers).
+  e2e-shard:
     needs: changes
     # push / merge_group: always run — both are (candidate) main. On the
     # queue ref this is the job that actually catches a semantic conflict
@@ -157,6 +177,10 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'merge_group' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -252,6 +276,12 @@ jobs:
         #      compose-project pattern `phase<digit><letter>-...` used
         #      by broker-ipc-race + per-agent-isolation. Filter now
         #      covers both shapes.
+        #
+        # VITEST_SHARD threads this matrix leg's shard into the gate's
+        # `vitest run` so each of the 3 runners executes a third of the
+        # tests/docker suite.
+        env:
+          VITEST_SHARD: ${{ matrix.shard }}/3
         run: bash scripts/ci/docker-snapshot-gate.sh
 
       - name: Capture broker / kernel logs on failure
@@ -293,7 +323,7 @@ jobs:
   # This job pulls the digest-pinned upstream image and sets
   # SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1, under which the suite treats an
   # unavailable docker/image as a HARD FAILURE. It is a separate job from
-  # `e2e` because the pull is large and unrelated to the phase1b image set,
+  # `e2e-shard` because the pull is large and unrelated to the phase1b image set,
   # and because it must not share that job's disk budget.
   hindsight-probe:
     needs: changes
@@ -363,11 +393,11 @@ jobs:
         # only correct base is the fully-patched source tree, which the shipping
         # image IS. We build it here rather than pull it: build-hindsight (in
         # docker-images.yml) does not push on PRs, and cross-workflow image
-        # hand-off is fragile — so, mirroring how the `e2e` job builds its own
+        # hand-off is fragile — so, mirroring how the `e2e-shard` job builds its own
         # image set in-job, this job builds the image it needs.
         #
         # `driver: docker` builds straight into the daemon's image store (same
-        # rationale as the `e2e` job) so the just-pulled FROM digest resolves
+        # rationale as the `e2e-shard` job) so the just-pulled FROM digest resolves
         # locally and the built tag is immediately runnable by `docker run`.
         # BuildKit (via buildx) is REQUIRED for Dockerfile.hindsight: its patch
         # steps are `RUN python3 - <<'PYEOF'` heredocs, which the legacy builder
@@ -640,14 +670,17 @@ jobs:
   # fail when any failed/was cancelled, or when the `changes` filter
   # job itself broke (can't trust a skip produced by broken infra).
   # Ruleset 16470166 should require `e2e-ok` as THE single required
-  # context for this workflow — `e2e` and `hindsight-probe` themselves
-  # cannot be required (they legitimately skip, and a skipped required
-  # check hard-blocks: #1343 / #2237). hindsight-probe in particular
-  # exists so the behavioural patch probe can never silently skip; it
-  # only actually gates via this sentinel. Keep this `needs` list
-  # complete when adding jobs.
+  # context for this workflow — the `e2e-shard` matrix legs and
+  # `hindsight-probe` themselves cannot be required (they legitimately
+  # skip, and a skipped required check hard-blocks: #1343 / #2237, and a
+  # matrix leg's context is `e2e-shard (N)`, not a stable name). A single
+  # `needs: e2e-shard` here aggregates ALL matrix legs: it is `success`
+  # only if every shard succeeded, `failure`/`cancelled` if any did.
+  # hindsight-probe in particular exists so the behavioural patch probe
+  # can never silently skip; it only actually gates via this sentinel.
+  # Keep this `needs` list complete when adding jobs.
   e2e-ok:
-    needs: [changes, e2e, hindsight-probe]
+    needs: [changes, e2e-shard, hindsight-probe]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 1
@@ -661,7 +694,7 @@ jobs:
           fi
           fail=0
           for pair in \
-            "e2e=${{ needs.e2e.result }}" \
+            "e2e-shard=${{ needs.e2e-shard.result }}" \
             "hindsight-probe=${{ needs.hindsight-probe.result }}"; do
             job="${pair%%=*}"; r="${pair#*=}"
             if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+### CI: more free-runner test parallelism (docker-e2e sharded 3-way, ci-tests-core 8-way)
+
+- **docker-e2e's `e2e` job is now a 3-way `--shard` matrix (`e2e-shard`) and
+  ci-tests-core's vitest matrix goes 4 → 8 shards**, both fanning across
+  additional free GitHub-hosted runners at zero extra cost (no runner-tier
+  change). The `tests/docker` suite (~8 min of execution) is threaded through
+  `scripts/ci/docker-snapshot-gate.sh` via a new `VITEST_SHARD` env var so each
+  leg runs `--shard i/3`, trimming ~4-5 min of wall clock; the core suite's
+  full-suite runs on push/merge_group split ~1 min further. The required
+  merge-queue sentinels are unchanged — `e2e-ok` still aggregates every e2e
+  shard + `hindsight-probe`, and `vitest` still aggregates all 8 core shards;
+  the individual shard contexts are NOT branch-protection-required.
+
 ### CI: `build-dependents` no longer serialized behind `build-base` on PR / merge_group
 
 - **docker-images: dependent image builds now run in parallel with `build-base`

--- a/scripts/ci/docker-snapshot-gate.sh
+++ b/scripts/ci/docker-snapshot-gate.sh
@@ -89,8 +89,19 @@ echo "captured pre-snapshot: $(wc -l <"$PRE_FILE") containers"
 
 # Run the docker test slice. Any failure is captured but does NOT skip
 # the post-snapshot — we MUST always compare.
+#
+# VITEST_SHARD (e.g. "2/3") fans the suite across parallel CI runners:
+# docker-e2e.yml's e2e-shard matrix sets it per leg so each runner
+# executes a `--shard i/N` slice. Unset, we run the whole suite — the
+# original single-runner path, preserved for any other caller. When
+# sharding, --passWithNoTests guards the (unlikely) empty-slice case so
+# a shard with zero selected files does not exit 1 and red the gate.
 set +e
-bunx vitest run tests/docker
+if [ -n "${VITEST_SHARD:-}" ]; then
+  bunx vitest run tests/docker --shard "${VITEST_SHARD}" --passWithNoTests
+else
+  bunx vitest run tests/docker
+fi
 VITEST_EXIT=$?
 set -e
 

--- a/tests/ci-merge-queue-triggers.test.ts
+++ b/tests/ci-merge-queue-triggers.test.ts
@@ -533,3 +533,75 @@ describe('docker-images — build-dependents is decoupled from build-base on PR/
     )
   })
 })
+
+describe('CI parallelism — docker-e2e sharded 3-way, ci-tests-core 8-way', () => {
+  // Guards the free-runner parallelism split. Each assertion fails on the
+  // exact regression it protects: a shard count reverted, the required
+  // sentinel losing a shard's coverage, or the shard parameter never
+  // reaching the test runner (which would run the whole suite N times over
+  // — no speedup and wasted runners). None of this is observable on a
+  // green run; only a shape test pins it.
+
+  const shardsOf = (job: Job | undefined): unknown[] => {
+    const matrix = (job?.strategy as { matrix?: { shard?: unknown[] } } | undefined)?.matrix?.shard
+    return Array.isArray(matrix) ? matrix : []
+  }
+  const needsOf = (job: Job | undefined): string[] => {
+    const n = job?.needs
+    return Array.isArray(n) ? n : n ? [String(n)] : []
+  }
+
+  it('docker-e2e: e2e-shard is a 3-way matrix', () => {
+    const job = (load('docker-e2e.yml').jobs ?? {})['e2e-shard']
+    expect(job, 'docker-e2e.yml must define the sharded e2e-shard job').toBeTruthy()
+    expect(shardsOf(job)).toEqual([1, 2, 3])
+  })
+
+  it('docker-e2e: every e2e shard threads its shard index into the snapshot gate', () => {
+    const job = (load('docker-e2e.yml').jobs ?? {})['e2e-shard']
+    const gateStep = stepsOf(job).find((s) => (s.run ?? '').includes('docker-snapshot-gate.sh')) as
+      | (Step & { env?: Record<string, string> })
+      | undefined
+    expect(gateStep, 'the e2e-shard job must still run docker-snapshot-gate.sh').toBeTruthy()
+    // The gate slices tests/docker by VITEST_SHARD; without this env each
+    // leg runs the WHOLE suite, three times over — the exact anti-speedup.
+    expect(gateStep!.env?.VITEST_SHARD, 'VITEST_SHARD must pin this leg to /3').toBe(
+      '${{ matrix.shard }}/3',
+    )
+  })
+
+  it('docker-e2e: the e2e-ok sentinel aggregates every e2e shard + hindsight-probe', () => {
+    const sentinel = (load('docker-e2e.yml').jobs ?? {})['e2e-ok']
+    const needs = needsOf(sentinel)
+    // `needs: e2e-shard` aggregates ALL matrix legs — success only if
+    // every shard passed; failure/cancel if any did. Dropping it (or a
+    // stale `needs: e2e`) would let a failing shard slip past the one
+    // required context for this workflow.
+    expect(needs, 'e2e-ok must need the sharded e2e job').toContain('e2e-shard')
+    expect(needs, 'e2e-ok must still need hindsight-probe').toContain('hindsight-probe')
+    expect(needs, 'e2e-ok must not reference the pre-shard job name').not.toContain('e2e')
+    const verdict = JSON.stringify(sentinel?.steps ?? [])
+    expect(verdict, 'the verdict must fail the sentinel on a shard failure').toContain(
+      'needs.e2e-shard.result',
+    )
+    expect(verdict, 'the verdict must not read the stale e2e.result').not.toContain(
+      'needs.e2e.result',
+    )
+  })
+
+  it('ci-tests-core: vitest-shard is an 8-way matrix and both arms shard /8', () => {
+    const job = (load('ci-tests-core.yml').jobs ?? {})['vitest-shard']
+    expect(shardsOf(job)).toEqual([1, 2, 3, 4, 5, 6, 7, 8])
+    const shardCmds = stepsOf(job)
+      .map((s) => s.run ?? '')
+      .filter((r) => r.includes('vitest run'))
+    expect(
+      shardCmds.length,
+      'expected both vitest arms (PR --changed + full suite)',
+    ).toBeGreaterThanOrEqual(2)
+    for (const cmd of shardCmds) {
+      expect(cmd, 'every vitest arm must shard /8, not a stale /4').toContain('${{ matrix.shard }}/8')
+      expect(cmd, 'no stale /4 denominator may remain').not.toContain('/4')
+    }
+  })
+})


### PR DESCRIPTION
## What & why

Two zero-cost CI speedups that use **more free GitHub-hosted runners in parallel** — no runner-tier change, no `runs-on:` touched. Both are the same concern: increase test parallelism.

### 1. `docker-e2e.yml` — shard the e2e suite 3 ways (the big win)

The single `e2e` job ran `bunx vitest run tests/docker` (~8 min of test execution) on one runner. It's now a **3-way `--shard` matrix** (`e2e-shard`, `shard: [1, 2, 3]`), mirroring the proven `vitest-shard` pattern in `ci-tests-core.yml`.

- Sharding is threaded cleanly into `scripts/ci/docker-snapshot-gate.sh` via a new `VITEST_SHARD` env var (e.g. `2/3`). Unset → the gate runs the whole suite exactly as before (preserved for any other caller). The pre/post `docker ps` snapshot gate still wraps every leg.
- Each matrix leg keeps the **full image build/cache setup** (warm-tarball `actions/cache`, cold buildx build, phase2a/2b retag). The cache key is file-hash-based, so all three legs share one key.
- Isolation is already guaranteed by the suite: every test container carries a `switchroom.test=phase*` label and runs under its own compose project, so three shards on three separate runners never collide.
- `hindsight-probe` stays its own job (not folded into the matrix).

**Expected saving: ~4-5 min off e2e wall clock.**

### 2. `ci-tests-core.yml` — raise vitest shards 4 → 8

Matrix `shard: [1..8]` and the `--shard i/8` denominator in both arms (the `--changed`-on-PR arm and the full-suite push/merge_group arm). `build-dist`/artifact-share and `--changed` logic are unchanged and work across 8 shards.

**Expected saving: ~1 min off the full-suite core run.**

## Branch-protection safety (merge queue)

The required contexts are unchanged. `e2e-ok` is still `if: always()`, still the sole required context for `docker-e2e.yml`, and now `needs: [changes, e2e-shard, hindsight-probe]` — a single `needs: e2e-shard` aggregates **all** matrix legs (success only if every shard passed; fails on any shard failure/cancel). `vitest` remains the required sentinel for `ci-tests-core.yml`, aggregating all 8 shards. The individual shard contexts (`e2e-shard (N)`, `vitest (N)`) are **not** added to the required set.

## Reviewer verification map

- e2e matrix: `.github/workflows/docker-e2e.yml` — `e2e-shard:` job header + `strategy.matrix.shard: [1, 2, 3]` (~line 170); `VITEST_SHARD: ${{ matrix.shard }}/3` on the snapshot-gate step (~line 250).
- shard threading: `scripts/ci/docker-snapshot-gate.sh` — the `if [ -n "${VITEST_SHARD:-}" ]` branch around the `bunx vitest run tests/docker` call (~line 92).
- sentinel: `.github/workflows/docker-e2e.yml` — `e2e-ok` `needs: [changes, e2e-shard, hindsight-probe]` + verdict loop reads `needs.e2e-shard.result` (~line 660).
- core bump: `.github/workflows/ci-tests-core.yml` — matrix `[1..8]` + both `--shard ${{ matrix.shard }}/8` arms.
- shape tests: `tests/ci-merge-queue-triggers.test.ts` — new "CI parallelism" describe block asserting the 3-way/8-way matrices, `VITEST_SHARD` threading, and `e2e-ok` aggregation.

## Validation done locally

- `vitest run tests/ci-merge-queue-triggers.test.ts` → 62 passed (includes the new assertions).
- `ci-buildx-warm-pull` / `ci-infra-watchdog` / `ci-python-path-filter` shape tests → green.
- Both workflows parse (yaml); `bash -n` on the gate script; `check-changelog-entry` OK.

## Zero cost

Both changes only fan work across additional free GitHub-hosted runners running concurrently — no paid tier, no larger runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)