### PR TITLE
chore: release v0.20.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+## v0.20.19 — a 32k backend now consolidates in batches of 3, plus the first-class recall/background split and two LiteLLM mount guards
+
 ### CI: more free-runner test parallelism (docker-e2e sharded 3-way, ci-tests-core 8-way)
 
 - **docker-e2e's `e2e` job is now a 3-way `--shard` matrix (`e2e-shard`) and


### PR DESCRIPTION
Rename `## Unreleased` to `## v0.20.19 — a 32k backend now consolidates in batches of 3, plus the first-class recall/background split and two LiteLLM mount guards`, leaving the fresh empty `## Unreleased` staging block (header + convention comment) in place under `# Changelog` for the next cycle.

CHANGELOG-only, per `skills/switchroom-release/SKILL.md` step 1 — a +2-line diff, the same shape as #4546. `package.json` version is deliberately untouched: the tag is the version source of truth (`scripts/build.mjs:resolveVersion()`), the manifest field is a placeholder, and `npm-publish.yml` does the uncommitted pack-time bump.

**Why now:** `git tag --contains 29993839` is empty — the consolidation batch-size fix (#4551) is in no tag. Without it a 32k-window host derives batch 6, whose real prompts plus the 8,192-token completion overflow the window, and llama.cpp answers an overflow with HTTP 200 and conversational text rather than an error — facts get silently truncated out of the consolidation prompt.

Contents of the release, as staged by the PRs that landed since v0.20.18 (9 commits):

- **#4551** — measure consolidation per-fact tokens, 32k batch 6 → 3 (the load-bearing fix)
- **#4550** — first-class opt-in recall/background worker split topology, and **#4559** — its follow-ups (boot headroom, `hindsight.env` conflict, stale-pool convergence)
- **#4553** / **#4556** — two LiteLLM mount-integrity guards (dropped custom-callback mount; stale versioned site-packages passthrough mount)
- **#4552** — Telegraph `**>` expandable blockquotes render in Instant View pages
- **#4548** — GET-only MCP knowledge-page read tools
- **#4549** — `package-lock.json` resync, so `npm ci` works on a clean clone
- **#4560** — docker-images `build-dependents` decoupled from `build-base` on PR/merge_group

[skip changelog]

Switchroom-Agent: overlord
Switchroom-Model: opus

🤖 Generated with [Claude Code](https://claude.com/claude-code)