### PR TITLE
fix(recall): scale own/additional bank slot floors with max_memories cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,38 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+### Fixed: recall slot floors now scale with the `max_memories` cap (own/additional bank crowd-out)
+
+- **The per-turn recall slot floors that reserve a minimum for the agent's OWN
+  bank vs the additional/profile banks are now DERIVED from the effective
+  `max_memories` cap instead of being hardcoded literals.** They were fixed at
+  `own=2 / additional=1`, sized for the cap of 6 the fleet ran when they landed
+  (#3755, `4f469b1d`, "sized to the cap the fleet actually deploys"). When the
+  fleet cap was raised 6→16 (`switchroom.yaml`) the literals silently kept
+  reserving 2/1 — ~19% of a 16-slot budget for the agent's own bank instead of
+  the ~50% the design intended — so a dense additional/profile bank could crowd
+  out the agent's own recent context (a live regression for agents using
+  `additional_banks`). The defaults now compute as `own ≈ ⅓` and
+  `additional ≈ ⅙` of the cap (rounded, floored at 1), which preserves the
+  historical 2/1 at cap 6, yields 3/1 at the resolver default of 8, and 5/3 at
+  the live cap of 16 — and since ⅓ + ⅙ = ½ they sit exactly at recall.py's
+  half-cap reservation budget and never overflow it. An explicit per-agent
+  `memory.recall.own_bank_min_slots` / `.additional_bank_min_slots` override
+  still wins (via the authoritative start.sh env export). Regression tests in
+  `tests/scaffold.recall-observations.test.ts` and `tests/scaffold.test.ts`
+  parameterise over the cap and fail if the floors ever stop tracking it.
+- **Docs/comment accuracy (no runtime change):** the
+  `memory.recall.max_memories`, `own_bank_min_slots`, and
+  `additional_bank_min_slots` schema docstrings and `docs/configuration.md`
+  cited stale numbers (plugin default 12, "fleet cap of 6"); they now state the
+  resolver default of 8, the live fleet default, and the cap-proportional
+  derivation, phrased against the mechanism so they will not re-stale. The
+  `memory.recall.budget` enum docstring was factually wrong — it claimed `mid`
+  "adds the LLM rerank pass"; corrected to describe what `budget` actually
+  tunes: the retrieval/rerank candidate-pool depth (low=100 / mid=300 /
+  high=1000), with the local cross-encoder reranker running at every tier and
+  no LLM in the recall ranking path.
+
 ## v0.20.20 — docker-images builds `dist/` once and shares it with the dependent image legs
 
 ### CI: `dist/` is built once and shared with the dependent image legs

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -174,7 +174,7 @@ Hindsight's auto-recall hook injects relevant memories into every inbound prompt
 defaults:
   memory:
     recall:
-      max_memories: 12   # workspace default (also the plugin default)
+      max_memories: 16   # fleet default (switchroom's resolver default is 8 when unset; the vendor plugin ships 12)
 
 agents:
   coach:

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -818,6 +818,7 @@ import {
   resolveHindsightRecallTunables,
   resolveHindsightRecallCaps,
   renderHindsightHooksOverrides,
+  DEFAULT_RECALL_MAX_MEMORIES,
   type HindsightRecallTunables,
   type HindsightRecallCaps,
   type RecallTunableInput,
@@ -3710,24 +3711,68 @@ function applyHindsightHooksOverrides(
 }
 
 /**
- * Per-bank recall slot floors, switchroom's shipped defaults.
+ * Per-bank recall slot floors, switchroom's shipped defaults — CAP-PROPORTIONAL.
  *
  * These are FLOORS inside `recallMaxMemories`, not fixed quotas. The effective
  * cap is whatever the operator sets in `memory.recall.max_memories` (cascaded to
  * both HINDSIGHT_RECALL_MAX_MEMORIES and the settings.json stamp — see
- * resolveHindsightRecallCaps; switchroom's own default is 8, the vendor ships
- * 12). recall.py bounds the two floors to HALF the cap between them
- * (`_reservable_slots`), so 2 + 1 stays comfortably within a floor at any cap
- * the fleet realistically runs (e.g. at cap 8 it reserves 3 of 8 and leaves 5 to
- * pure global relevance; larger caps only widen that margin). Floors that summed
- * to the cap would stop being floors and become a fixed quota.
+ * resolveHindsightRecallCaps; switchroom's own resolver default is 8, the vendor
+ * ships 12, the live fleet runs the `defaults.memory.recall.max_memories` in
+ * switchroom.yaml). recall.py bounds the SUM of the two floors to HALF the cap
+ * (`_reservable_slots`), so floors that summed to the cap would stop being
+ * floors and become a fixed quota.
+ *
+ * The defaults are DERIVED from the effective cap rather than hardcoded, so they
+ * track the cap and never go stale when the fleet raises it. History: these were
+ * literals `2 / 1`, sized to the cap-of-6 the fleet ran in 2026-07 (#3755,
+ * 4f469b1d, "sized to the cap the fleet actually deploys"). When the fleet cap
+ * was raised 6→16 (switchroom.yaml, 2026-08-03) the literals silently kept
+ * reserving 2/1 — ~19% of a 16-slot budget for the agent's OWN bank instead of
+ * the ~50% the design intended — so a dense additional/profile bank could crowd
+ * out the agent's own recent context (a live regression for agents using
+ * `additional_banks`). Deriving from the cap restores the original ratio at
+ * every cap: own ≈ ⅓, additional ≈ ⅙ (rounded, never below 1). Since ⅓ + ⅙ = ½,
+ * the derived pair sits exactly at recall.py's half-cap reservation budget and
+ * never overflows it:
+ *
+ *   cap 6  → own 2, additional 1   (preserves the historical 2/1)
+ *   cap 8  → own 3, additional 1   (resolver default)
+ *   cap 16 → own 5, additional 3   (live fleet)
+ *
+ * A per-agent `memory.recall.own_bank_min_slots` / `.additional_bank_min_slots`
+ * override still WINS over these computed defaults — see the `?? default(...)`
+ * call sites in the settings stamp and the start.sh env exports.
  *
  * These are also the values exported to the environment unconditionally (see
  * `start.sh.hbs`) so a stale `~/.hindsight/claude-code.json` — which loads
  * AFTER the plugin's settings.json — cannot shadow them (#3774).
  */
-const HINDSIGHT_OWN_BANK_MIN_SLOTS_DEFAULT = 2;
-const HINDSIGHT_ADDITIONAL_BANK_MIN_SLOTS_DEFAULT = 1;
+const RECALL_OWN_BANK_SLOT_DIVISOR = 3; // own ≈ ⅓ of the cap
+const RECALL_ADDITIONAL_BANK_SLOT_DIVISOR = 6; // additional ≈ ⅙ of the cap
+
+function recallSlotFloorFromCap(maxMemories: number, divisor: number): number {
+  // A cap of 0 means "no count cap" (unlimited injection); reservation is moot
+  // because recall.py bounds floors to HALF the cap. Fall back to the resolver
+  // default so an unlimited/garbage cap still yields a sensible, non-zero floor.
+  const cap =
+    Number.isFinite(maxMemories) && maxMemories > 0
+      ? maxMemories
+      : DEFAULT_RECALL_MAX_MEMORIES;
+  // Round to nearest, floored at 1: even the smallest cap keeps a non-zero
+  // own-bank reservation, or one bank's score distribution could take every
+  // slot (the crowd-out this floor exists to prevent).
+  return Math.max(1, Math.round(cap / divisor));
+}
+
+/** Cap-proportional default floor for the agent's OWN bank (≈ ⅓ of the cap). */
+export function defaultRecallOwnBankMinSlots(maxMemories: number): number {
+  return recallSlotFloorFromCap(maxMemories, RECALL_OWN_BANK_SLOT_DIVISOR);
+}
+
+/** Cap-proportional default floor for the additional banks (≈ ⅙ of the cap). */
+export function defaultRecallAdditionalBankMinSlots(maxMemories: number): number {
+  return recallSlotFloorFromCap(maxMemories, RECALL_ADDITIONAL_BANK_SLOT_DIVISOR);
+}
 
 /**
  * Absolute relevance floor for injected memories (#3837), switchroom's shipped
@@ -3759,10 +3804,12 @@ const HINDSIGHT_RECALL_MIN_SCORE_SCOPE_DEFAULT = "degraded";
  *   - `retainMode`: full-session → chunked (Phase 6b: window, not whole
  *     transcript, re-consolidated per fire; paired with the vendor
  *     retain.py divergence)
- *   - `recallMaxMemories`: 12 → cascade (default 8; `memory.recall.max_memories`)
+ *   - `recallMaxMemories`: vendor 12 → cascade (resolver default 8;
+ *     `memory.recall.max_memories`)
  *   - `recallMaxTokens`: cascade (default 1024; `memory.recall.max_tokens`)
- *   - `recallOwnBankMinSlots` / `recallAdditionalBankMinSlots`: 0/0 → 2/1
- *     (FLOORS inside recallMaxMemories, bounded to half the cap by recall.py)
+ *   - `recallOwnBankMinSlots` / `recallAdditionalBankMinSlots`: 0/0 →
+ *     cap-proportional (own ≈ ⅓, additional ≈ ⅙ of recallMaxMemories; FLOORS
+ *     bounded to half the cap by recall.py)
  *
  * Future overrides go here, NOT in the vendor file. The vendor is
  * third-party code and must remain untouched for clean upstream
@@ -3931,22 +3978,28 @@ function renderHindsightSettingsOverrides(
   // field that would have caught the own-bank outage, since a fully timed-out
   // own bank still logs a full `result_count`.
   //
-  // 2/1 against recallMaxMemories, whatever the operator set it to
+  // Slot floors DERIVED from recallMaxMemories, whatever the operator set it to
   // (`memory.recall.max_memories` cascades to both HINDSIGHT_RECALL_MAX_MEMORIES
-  // and the settings.json stamp above — the two now carry the same value, so the
-  // floors bind against the same cap on every invocation, env-inheriting or not).
+  // and the settings.json stamp above — the two carry the same value, and both
+  // the stamp here and the start.sh env export derive the floors from that same
+  // cap, so they bind identically on every invocation, env-inheriting or not).
   // FLOORS, not quotas, and enforced as such: recall.py bounds the two floors to
   // HALF the cap between them (`_reservable_slots`), so at least half the slots
   // are always won on pure relevance and composition still moves with the
-  // scores (at the default cap of 8, that reserves 3 and leaves 5). Floors that
-  // summed to the cap would be a fixed quota with
-  // no score influence at all. Each side also gets its floor only if it returned
-  // that many, so a silent bank wastes nothing. Operators re-tune via
+  // scores. own ≈ ⅓ + additional ≈ ⅙ = ½ of the cap, exactly the reservation
+  // budget (cap 6 → 2/1, cap 8 → 3/1, cap 16 → 5/3). Deriving from the cap is
+  // what stops the floors going stale when the fleet raises max_memories — the
+  // #3755 literals (2/1, sized for the old cap of 6) reserved only ~19% of a
+  // 16-slot cap once it was raised. Each side also gets its floor only if it
+  // returned that many, so a silent bank wastes nothing. Operators re-tune via
   // memory.recall.own_bank_min_slots / .additional_bank_min_slots in
-  // switchroom.yaml (0/0 = the pre-fix head-slice). Vendor default is 0/0; this
-  // is the switchroom opt-in.
-  settings.recallOwnBankMinSlots = HINDSIGHT_OWN_BANK_MIN_SLOTS_DEFAULT;
-  settings.recallAdditionalBankMinSlots = HINDSIGHT_ADDITIONAL_BANK_MIN_SLOTS_DEFAULT;
+  // switchroom.yaml (0/0 = the pre-fix head-slice), and an explicit override
+  // still wins over the derived default. Vendor default is 0/0; this is the
+  // switchroom opt-in.
+  settings.recallOwnBankMinSlots = defaultRecallOwnBankMinSlots(recallCaps.maxMemories);
+  settings.recallAdditionalBankMinSlots = defaultRecallAdditionalBankMinSlots(
+    recallCaps.maxMemories,
+  );
   // Phase 6a: on top of the ack-skip, skip recall on plausibly-stateless
   // trivial turns (time/date/day, bare greetings) — saves the ~1-2s
   // recall arm + up to ~1024 injected tokens on turns that never need
@@ -5335,11 +5388,19 @@ export function scaffoldAgent(
   // and loads AFTER the plugin's settings.json, so a conditional export lets a
   // stale hand-edited value there shadow what switchroom stamps — silently, and
   // permanently. Exporting the resolved effective value makes env authoritative.
+  // Default floors DERIVE from the effective count cap (resolved the same way
+  // the settings.json stamp resolves it) so the env export and the stamp agree,
+  // and so the floors track the cap instead of going stale when it is raised.
+  // An explicit per-agent override still wins over the derived default.
+  const hindsightRecallEffectiveMaxMemories = resolveHindsightRecallCaps(
+    agentConfig.memory?.recall as RecallCapInput | undefined,
+  ).maxMemories;
   const hindsightRecallOwnBankMinSlots =
-    agentConfig.memory?.recall?.own_bank_min_slots ?? HINDSIGHT_OWN_BANK_MIN_SLOTS_DEFAULT;
+    agentConfig.memory?.recall?.own_bank_min_slots ??
+    defaultRecallOwnBankMinSlots(hindsightRecallEffectiveMaxMemories);
   const hindsightRecallAdditionalBankMinSlots =
     agentConfig.memory?.recall?.additional_bank_min_slots ??
-    HINDSIGHT_ADDITIONAL_BANK_MIN_SLOTS_DEFAULT;
+    defaultRecallAdditionalBankMinSlots(hindsightRecallEffectiveMaxMemories);
   // #3837 score floor. Same unconditional-export treatment as the slot floors
   // (#3774): a conditional export would let a stale hand-edited
   // `~/.hindsight/claude-code.json` silently turn a filter ON that switchroom
@@ -7946,11 +8007,19 @@ function reconcileAgentInner(
   // and loads AFTER the plugin's settings.json, so a conditional export lets a
   // stale hand-edited value there shadow what switchroom stamps — silently, and
   // permanently. Exporting the resolved effective value makes env authoritative.
+  // Default floors DERIVE from the effective count cap (resolved the same way
+  // the settings.json stamp resolves it) so the env export and the stamp agree,
+  // and so the floors track the cap instead of going stale when it is raised.
+  // An explicit per-agent override still wins over the derived default.
+  const hindsightRecallEffectiveMaxMemories = resolveHindsightRecallCaps(
+    agentConfig.memory?.recall as RecallCapInput | undefined,
+  ).maxMemories;
   const hindsightRecallOwnBankMinSlots =
-    agentConfig.memory?.recall?.own_bank_min_slots ?? HINDSIGHT_OWN_BANK_MIN_SLOTS_DEFAULT;
+    agentConfig.memory?.recall?.own_bank_min_slots ??
+    defaultRecallOwnBankMinSlots(hindsightRecallEffectiveMaxMemories);
   const hindsightRecallAdditionalBankMinSlots =
     agentConfig.memory?.recall?.additional_bank_min_slots ??
-    HINDSIGHT_ADDITIONAL_BANK_MIN_SLOTS_DEFAULT;
+    defaultRecallAdditionalBankMinSlots(hindsightRecallEffectiveMaxMemories);
   // #3837 score floor. Same unconditional-export treatment as the slot floors
   // (#3774): a conditional export would let a stale hand-edited
   // `~/.hindsight/claude-code.json` silently turn a filter ON that switchroom

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -677,7 +677,9 @@ export const AgentMemorySchema = z
           .optional()
           .describe(
             "Cap on the number of memories injected into the prompt by " +
-            "auto-recall, regardless of token budget. Plugin default is 12. " +
+            "auto-recall, regardless of token budget. The vendor plugin ships " +
+            "12; switchroom's resolver default is 8 when this is unset, and the " +
+            "live fleet raises it via `defaults.memory.recall.max_memories`. " +
             "0 disables the cap (all memories Hindsight returns are injected).",
           ),
         cache_ttl_secs: z
@@ -799,8 +801,11 @@ export const AgentMemorySchema = z
             "— the rest is always won on pure relevance, so composition still " +
             "moves with the scores. Fixes score-based crowd-out only; a " +
             "timed-out bank returns no candidates and reservation is a no-op " +
-            "there. 0 disables (default). Switchroom-managed agents use 2 " +
-            "against the fleet-deployed cap of 6.",
+            "there. 0 disables (default). Switchroom-managed agents DERIVE this " +
+            "default from the count cap (≈ ⅓ of the effective `max_memories`, " +
+            "floored at 1) so it tracks the cap instead of going stale when the " +
+            "fleet raises it; an explicit value set here still wins over that " +
+            "derived default.",
           ),
         additional_bank_min_slots: z
           .number()
@@ -813,8 +818,10 @@ export const AgentMemorySchema = z
             "`own_bank_min_slots` — same floor-not-quota semantics, and the " +
             "two share the same half-of-cap reservation budget. When they sum " +
             "above that budget the own-bank floor is honoured first. 0 " +
-            "disables (default). Switchroom-managed agents use 1 against the " +
-            "fleet-deployed cap of 6. Observe `injected_own_bank_count` / " +
+            "disables (default). Switchroom-managed agents DERIVE this default " +
+            "from the count cap (≈ ⅙ of the effective `max_memories`, floored " +
+            "at 1) so it tracks the cap instead of going stale; an explicit " +
+            "value set here still wins. Observe `injected_own_bank_count` / " +
             "`injected_additional_bank_count` via " +
             "`switchroom memory recall-log`.",
           ),
@@ -912,13 +919,18 @@ export const AgentMemorySchema = z
           .enum(["low", "mid", "high"])
           .optional()
           .describe(
-            "How hard Hindsight searches. \"low\" (switchroom default) = " +
-            "vector retrieval only, ~1-2s. \"mid\" adds the LLM rerank pass " +
-            "and measured ~5s of hook latency on real fleet turns — the " +
-            "second-largest contributor to perceived dead air after model " +
-            "TTFT. \"high\" is thorough and slower still. Raise it for an " +
-            "agent whose recall quality matters more than its reply latency " +
-            "(a research or audit role); leave it at low for chat.",
+            "How deep Hindsight's recall search goes. It tunes the CANDIDATE-" +
+            "POOL depth retrieved before reranking — low (switchroom default) " +
+            "= 100, mid = 300, high = 1000 candidates. The local cross-encoder " +
+            "reranker (ms-marco-MiniLM) runs at EVERY tier; budget does not " +
+            "gate it on or off, and there is no LLM rerank pass in the recall " +
+            "path (the LLM serves reflect/retain/consolidation, not recall " +
+            "ranking). Higher tiers cost more latency purely from the deeper " +
+            "pool: mid measured ~5s of hook latency on real fleet turns (3× " +
+            "the retrieval+rerank pool, not an added model call), the second-" +
+            "largest contributor to perceived dead air after model TTFT. Raise " +
+            "it for an agent whose recall quality matters more than its reply " +
+            "latency (a research or audit role); leave it at low for chat.",
           ),
         max_tokens: z
           .number()

--- a/tests/scaffold.recall-observations.test.ts
+++ b/tests/scaffold.recall-observations.test.ts
@@ -96,28 +96,63 @@ describe("hindsight recall overrides — observations + trivial-skip", () => {
   // banks return more candidates than the cap, one bank's score distribution
   // can fill every slot. These floors are the switchroom opt-in over the
   // vendor's 0/0 (pure head-slice).
-  it("reserves a floor of recall slots for each bank, sized to the DEPLOYED cap", () => {
+  it("reserves a floor of recall slots for each bank, at the resolver-default cap", () => {
+    // No `max_memories` set → resolver default 8 → own ≈ ⅓ = 3, additional ≈ ⅙ = 1.
     const s = settingsAfterInstall();
-    expect(s.recallOwnBankMinSlots).toBe(2);
+    expect(s.recallOwnBankMinSlots).toBe(3);
     expect(s.recallAdditionalBankMinSlots).toBe(1);
-    // The cap this fleet actually runs is 6 — `defaults.memory.recall
-    // .max_memories: 6` in switchroom.yaml cascades to
-    // HINDSIGHT_RECALL_MAX_MEMORIES, and env wins over the 8 stamped into
-    // settings.json. recall.py bounds the two floors to HALF the cap between
-    // them (`_reservable_slots`), so floors summing above 3 would be silently
-    // clamped and the stamped numbers would be a lie. Pinning against 6 rather
-    // than against `s.recallMaxMemories` is deliberate: asserting against the
-    // stamped 8 is exactly the mistake that let floors of 4/2 look safe when
-    // at the deployed cap they consumed the whole of it and `scores.final`
-    // stopped influencing composition at all.
-    const DEPLOYED_CAP = 6;
-    expect(
-      (s.recallOwnBankMinSlots as number) + (s.recallAdditionalBankMinSlots as number),
-    ).toBeLessThanOrEqual(Math.floor(DEPLOYED_CAP / 2));
     // Both floors must be non-zero, or one side can still be zeroed out.
     expect(s.recallOwnBankMinSlots as number).toBeGreaterThan(0);
     expect(s.recallAdditionalBankMinSlots as number).toBeGreaterThan(0);
   });
+
+  // REGRESSION GUARD (recall slot-floor scaling). The floors USED to be
+  // hardcoded literals `2 / 1`, sized to the cap-of-6 the fleet ran in 2026-07
+  // (#3755, 4f469b1d). When the fleet cap was raised 6→16 (switchroom.yaml,
+  // 2026-08-03) the literals silently kept reserving 2/1 — ~19% of a 16-slot
+  // budget for the agent's OWN bank — so a dense additional/profile bank could
+  // crowd out the agent's own recent context. The fix DERIVES the defaults from
+  // the cap (own ≈ ⅓, additional ≈ ⅙). This test parameterises over the cap and
+  // asserts the floors TRACK it: it would FAIL if someone raised the cap again
+  // and the floors stayed put (the exact regression), or reverted the defaults
+  // to fixed literals. `defaults.memory.recall.max_memories` cascades to the
+  // agent, and the SAME cap is stamped into settings.json, so the floors bind
+  // against it.
+  it("default slot floors SCALE with the max_memories cap (never go stale)", () => {
+    // [cap, expectedOwn, expectedAdditional] — own = round(cap/3), additional = round(cap/6).
+    const cases: [number, number, number][] = [
+      [6, 2, 1], // preserves the historical 2/1 the #3755 literals hardcoded
+      [8, 3, 1], // resolver default
+      [12, 4, 2], // vendor cap
+      [16, 5, 3], // the live fleet cap the literals went stale against
+      [24, 8, 4],
+    ];
+    for (const [cap, expectedOwn, expectedAdditional] of cases) {
+      config.defaults = {
+        memory: { recall: { max_memories: cap } },
+      } as SwitchroomConfig["defaults"];
+      const s = settingsAfterInstall();
+      // The stamp derives the floors from the SAME cap it stamps into settings.
+      expect(s.recallMaxMemories).toBe(cap);
+      expect(s.recallOwnBankMinSlots, `own floor at cap ${cap}`).toBe(expectedOwn);
+      expect(
+        s.recallAdditionalBankMinSlots,
+        `additional floor at cap ${cap}`,
+      ).toBe(expectedAdditional);
+      // The two floors must never exceed recall.py's half-cap reservation budget
+      // (`_reservable_slots`), or the stamped numbers would be silently clamped
+      // and the composition would stop moving with the scores. own ≈ ⅓ +
+      // additional ≈ ⅙ = ½, so the derived pair sits exactly at the budget.
+      expect(
+        (s.recallOwnBankMinSlots as number) + (s.recallAdditionalBankMinSlots as number),
+        `sum within half-cap budget at cap ${cap}`,
+      ).toBeLessThanOrEqual(Math.floor(cap / 2));
+      // Non-zero at both ends: even the smallest cap keeps an own-bank floor.
+      expect(s.recallOwnBankMinSlots as number).toBeGreaterThan(0);
+      expect(s.recallAdditionalBankMinSlots as number).toBeGreaterThan(0);
+    }
+  });
+
 
   // #2816 tag-filter port — INTENTIONALLY DORMANT (see the decision comment in
   // renderHindsightSettingsOverrides + reference/rfcs/hindsight-synthesis-

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2901,13 +2901,41 @@ describe("reconcileAgent", () => {
     scaffoldAgent("test-agent", agentConfig, tmpDir, telegramConfig, withMemory);
 
     const startSh = readFileSync(join(tmpDir, "test-agent", "start.sh"), "utf-8");
-    expect(startSh).toContain("export HINDSIGHT_RECALL_OWN_BANK_MIN_SLOTS=2");
+    // No override and no max_memories set → cap resolves to the switchroom
+    // default of 8, and the floors DERIVE from it: own ≈ ⅓ = 3, additional
+    // ≈ ⅙ = 1. (These used to be the hardcoded literals 2/1; they are now
+    // cap-proportional so they track the cap instead of going stale.)
+    expect(startSh).toContain("export HINDSIGHT_RECALL_OWN_BANK_MIN_SLOTS=3");
     expect(startSh).toContain("export HINDSIGHT_RECALL_ADDITIONAL_BANK_MIN_SLOTS=1");
     // And never an empty assignment: `_cast_env("", int)` returns None, the
     // assignment is skipped, and claude-code.json wins again — the exact
     // failure mode this test exists to prevent.
     expect(startSh).not.toContain("export HINDSIGHT_RECALL_OWN_BANK_MIN_SLOTS=\n");
     expect(startSh).not.toContain("export HINDSIGHT_RECALL_ADDITIONAL_BANK_MIN_SLOTS=\n");
+  });
+
+  it("start.sh slot-floor exports SCALE with the max_memories cap (regression: #3755 stale literals)", () => {
+    // REGRESSION GUARD, env-export half. The floors were hardcoded 2/1 for the
+    // old cap of 6 (#3755, 4f469b1d); raising the fleet cap 6→16 left them
+    // reserving ~19% of the budget for the own bank. The defaults now derive
+    // from the cap (own ≈ ⅓, additional ≈ ⅙), so a cap raise carries the floors
+    // with it. This asserts the export tracks the cap — it FAILS if the floors
+    // are reverted to fixed literals while the cap moves.
+    const agentConfig = makeAgentConfig({
+      memory: { collection: "test-agent", recall: { max_memories: 16 } },
+    });
+    const withMemory = buildSwitchroomConfig(agentConfig, {
+      backend: "hindsight",
+      shared_collection: "shared",
+      config: { provider: "openai", docker_service: true, url: "http://127.0.0.1:18888/mcp/" },
+    });
+    scaffoldAgent("test-agent", agentConfig, tmpDir, telegramConfig, withMemory);
+
+    const startSh = readFileSync(join(tmpDir, "test-agent", "start.sh"), "utf-8");
+    expect(startSh).toContain("export HINDSIGHT_RECALL_MAX_MEMORIES=16");
+    // Cap 16 → own = round(16/3) = 5, additional = round(16/6) = 3.
+    expect(startSh).toContain("export HINDSIGHT_RECALL_OWN_BANK_MIN_SLOTS=5");
+    expect(startSh).toContain("export HINDSIGHT_RECALL_ADDITIONAL_BANK_MIN_SLOTS=3");
   });
 
   it("start.sh exports the per-bank slot floors when the operator overrides them", () => {


### PR DESCRIPTION
## The regression

Recall injects up to `max_memories` memories per turn. When it fans out to
more than one bank the merged set is sorted globally by relevance and
head-sliced — winner-take-all across banks — so switchroom reserves per-turn
**slot floors** for the agent's OWN bank vs the additional/profile banks.

Those floors were hardcoded literals `own=2 / additional=1`, sized to the cap
of **6** the fleet ran when they landed (#3755, `4f469b1d`, *"sized to the cap
the fleet actually deploys"*). At cap 6 that reserved ~50% for the own bank.

The fleet cap was later raised **6→16** (`switchroom.yaml`). The literals kept
reserving 2/1 — now only ~19% of a 16-slot budget for the agent's own bank —
so a dense additional/profile bank can crowd out the agent's own recent
context. A live regression for any agent using `additional_banks`.

## The fix (deterministic, won't re-stale)

Derive the default floors from the effective cap instead of hardcoding them:

- `own ≈ ⅓` of the cap, `additional ≈ ⅙` (rounded, floored at 1)
- Since `⅓ + ⅙ = ½`, the pair sits exactly at `recall.py`'s half-cap
  reservation budget (`_reservable_slots`) and never overflows it.

Resulting defaults:

| cap | own | additional | note |
|----:|----:|-----------:|------|
| 6   | 2   | 1          | preserves the historical 2/1 |
| 8   | 3   | 1          | switchroom resolver default |
| 16  | 5   | 3          | live fleet cap |

An explicit per-agent `memory.recall.own_bank_min_slots` /
`.additional_bank_min_slots` override still wins, via the authoritative
start.sh env export (env is applied last: DEFAULTS → settings.json →
claude-code.json → env, per #3774).

Both the settings.json stamp and the start.sh env export now derive the floors
from the same resolved cap, so they bind identically on every invocation.

### Deterministic guard

Regression tests parameterise over the cap and **fail if the floors ever stop
tracking it** (the exact way this bug recurs), or if they are reverted to fixed
literals:

- `tests/scaffold.recall-observations.test.ts` — settings.json stamp path
- `tests/scaffold.test.ts` — start.sh env-export path

## Doc/comment accuracy (no runtime change)

- `memory.recall.max_memories`, `own_bank_min_slots`, `additional_bank_min_slots`
  docstrings + `docs/configuration.md` cited stale numbers (plugin default 12,
  "fleet cap of 6") → now state the resolver default of 8, the live fleet
  default, and the cap-proportional derivation, phrased against the mechanism
  so they won't re-stale.
- The `memory.recall.budget` enum docstring was **factually wrong** — it
  claimed `mid` "adds the LLM rerank pass". Corrected to what `budget` actually
  tunes: retrieval/rerank candidate-pool depth (low=100 / mid=300 / high=1000);
  the local cross-encoder reranker runs at **every** tier, and there is no LLM
  in the recall ranking path (the LLM serves reflect/retain/consolidation).

## Test evidence

`vitest run` scoped to the touched areas — all green:
`tests/scaffold.recall-observations.test.ts` (8), `tests/scaffold.test.ts`
(248), `tests/config.test.ts` (10), `tests/memory*.test.ts`,
`src/config/schema.mirror-parity.test.ts` (13). Changelog + stale-description
gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)