### PR TITLE
fix(docker): drop the 230.8MB duplicate chown layer from Dockerfile.hindsight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,27 @@ now an anomaly worth investigating, not the norm.
   mean BUILD, never skip — publishing a stale image under a release tag is
   unrecoverable, while a redundant rebuild only costs minutes.
 
+### Docker: drop a 230.8MB pure-duplicate layer from `switchroom-hindsight`
+
+- **`Dockerfile.hindsight` merged the HuggingFace ONNX download and its
+  ownership fixup into one `RUN`, and narrowed the fixup from `chown -R` to a
+  scoped `find`, cutting 230.8MB compressed (360MB uncompressed) off the
+  image.** `chown(2)` triggers an overlayfs copy-up even when the ownership is
+  *unchanged*, so the old standalone
+  `RUN chown -R hindsight:hindsight /home/hindsight/.cache/huggingface`
+  copied the entire 344MB cache into a second layer — of which only the 133MB
+  ONNX graph this stage actually downloads was ever root-owned. Everything else
+  (upstream's baked bge safetensors and the ms-marco reranker) was already set
+  to the runtime UID by the UID-11000 remap earlier in the file, so re-chowning
+  it bought nothing and duplicated the graph on top. Both halves of the fix are
+  load-bearing and `tests/docker/dockerfile-hindsight-bakes.test.ts` pins both:
+  scoping alone would still copy the graph up a second time in its own layer,
+  and merging alone would still copy up the whole cache. The EACCES guarantee
+  is unchanged — every file not owned by `hindsight` is still chowned — and is
+  now *asserted* rather than assumed: the build fails loudly if any file under
+  the cache is left non-`hindsight`-owned, alongside the retained `test -f`
+  check on the pinned export. Runtime UID 11000 is untouched.
+
 ## v0.20.20 — docker-images builds `dist/` once and shares it with the dependent image legs
 
 ### CI: `dist/` is built once and shared with the dependent image legs

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -5958,7 +5958,7 @@ RUN OLD_UID=$(id -u hindsight) && NEW_UID=11000 \
 # is absent or truncated, so we never ship a half-baked image.
 #
 # ONE `RUN`, and the ownership fixup is a SCOPED `find`, not `chown -R` —
-# both halves matter and neither alone is sufficient (#4571):
+# both halves matter and neither alone is sufficient (#4566):
 #
 #   * SCOPED. `chown(2)` triggers an overlayfs copy-up even when the
 #     ownership is UNCHANGED, so `chown -R` over the whole cache copied up

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -5956,9 +5956,34 @@ RUN OLD_UID=$(id -u hindsight) && NEW_UID=11000 \
 # (11000, post-remap above) — a root-owned cache file would EACCES the
 # non-root API at boot. Self-verifying: the build FAILS LOUDLY if the export
 # is absent or truncated, so we never ship a half-baked image.
-RUN set -eu; \
-    HF_HOME=/home/hindsight/.cache/huggingface \
-    /app/api/.venv/bin/python - <<'PYEOF'
+#
+# ONE `RUN`, and the ownership fixup is a SCOPED `find`, not `chown -R` —
+# both halves matter and neither alone is sufficient (#4571):
+#
+#   * SCOPED. `chown(2)` triggers an overlayfs copy-up even when the
+#     ownership is UNCHANGED, so `chown -R` over the whole cache copied up
+#     all 344MB of it. Only the blob this stage just downloaded is
+#     root-owned; the upstream-baked bge safetensors + ms-marco reranker
+#     were already set to the runtime uid by the `find … -exec chown` remap
+#     above. The `! -user / ! -group` predicate narrows the set of files
+#     TOUCHED to exactly those that actually need it — same guarantee, and
+#     it stays idempotent on re-runs. (Same reasoning as the #2807 `-xdev`
+#     scoping above: chown only what is genuinely wrong, never a blanket
+#     sweep, because every needless chown is a copy-up.)
+#   * ONE LAYER. A scoped chown in a SEPARATE `RUN` would still copy the
+#     freshly-downloaded 133MB graph up a second time — the download layer
+#     and a chown layer would each carry a full copy. Merging makes the
+#     fixup free: the files are created and corrected in the same layer.
+#
+# Together these drop a 360MB (230.8MB compressed) pure-duplicate layer.
+# The EACCES guarantee is unchanged — every file not owned by hindsight is
+# still chowned, and a post-condition check below now proves it — and the
+# `test -f` assertion is retained, so the build still fails loudly if the
+# pinned export is missing.
+RUN <<'SHEOF'
+set -eu
+HF_HOME=/home/hindsight/.cache/huggingface \
+/app/api/.venv/bin/python - <<'PYEOF'
 import os
 from huggingface_hub import snapshot_download
 
@@ -5975,9 +6000,19 @@ sz = os.path.getsize(p)
 assert sz > 100_000_000, f"switchroom: bge onnx export suspiciously small ({sz} bytes) — download truncated?"
 print(f"switchroom: baked {REPO}@{REV[:7]} onnx export -> {p} ({sz} bytes)")
 PYEOF
-RUN chown -R hindsight:hindsight /home/hindsight/.cache/huggingface \
- && test -f /home/hindsight/.cache/huggingface/hub/models--BAAI--bge-small-en-v1.5/snapshots/5c38ec7c405ec4b44b94cc5a9bb96e735b38267a/onnx/model.onnx \
- && echo "switchroom: bge onnx export owned by hindsight and present at pinned revision" >&2
+find /home/hindsight/.cache/huggingface -xdev \( ! -user hindsight -o ! -group hindsight \) \
+     -exec chown -h hindsight:hindsight {} +
+test -f /home/hindsight/.cache/huggingface/hub/models--BAAI--bge-small-en-v1.5/snapshots/5c38ec7c405ec4b44b94cc5a9bb96e735b38267a/onnx/model.onnx
+# Assert the EACCES guarantee rather than trusting the chown above: nothing
+# under the cache may be left owned by anyone but hindsight. A leftover here
+# would otherwise surface as a runtime EACCES on a non-root boot.
+STRAY=$(find /home/hindsight/.cache/huggingface -xdev \( ! -user hindsight -o ! -group hindsight \) -print -quit)
+if [ -n "$STRAY" ]; then
+  echo "switchroom: FATAL — HF cache still has non-hindsight-owned files (e.g. $STRAY)" >&2
+  exit 1
+fi
+echo "switchroom: bge onnx export owned by hindsight and present at pinned revision" >&2
+SHEOF
 
 # HF_HUB_OFFLINE=1: hard boot-offline guarantee. With the bge safetensors +
 # bge onnx export + the ms-marco reranker ALL baked into the image cache

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -589,6 +589,54 @@ describe("Dockerfile.hindsight shape", () => {
     expect(userIdx).toBeGreaterThan(chownIdx); // chown runs as root, before the USER switch
   });
 
+  it("fixes HF-cache ownership with a scoped find in the SAME RUN as the download (no `chown -R` copy-up layer)", () => {
+    // Regression guard for #4571. `chown(2)` copy-ups a file on overlayfs
+    // even when the ownership is UNCHANGED, so the old shape —
+    //
+    //   RUN … snapshot_download …            <- 133MB layer (the onnx graph)
+    //   RUN chown -R hindsight:hindsight /home/hindsight/.cache/huggingface
+    //
+    // — emitted a SECOND 360MB layer (230.8MB compressed) that was pure
+    // duplicate: the whole 344MB cache copied up, of which only the 133MB
+    // graph was actually root-owned (the upstream-baked bge safetensors +
+    // ms-marco reranker were already set to the runtime uid by the UID-remap
+    // `find` earlier in the file). Measured on v0.20.18 via `docker history`.
+    //
+    // Both halves of the fix are load-bearing, so both are pinned here:
+    //   * no blanket `chown -R` over the cache root (scope), and
+    //   * the fixup lives in the same RUN as the download (one layer),
+    //     otherwise the 133MB graph is copied up a second time anyway.
+    const cacheRoot = "/home/hindsight/.cache/huggingface";
+
+    // (a) The blanket recursive chown over the cache root must not come back.
+    expect(dockerfile).not.toMatch(
+      new RegExp(`chown\\s+-R\\s+\\S+\\s+${cacheRoot}`, "m"),
+    );
+
+    // (b) The download and the ownership fixup must live in ONE RUN. Slice
+    //     from the snapshot_download call to the next top-level instruction
+    //     and require the chown inside that slice.
+    const dlIdx = dockerfile.search(/from huggingface_hub import snapshot_download/);
+    expect(dlIdx).toBeGreaterThanOrEqual(0);
+    const rest = dockerfile.slice(dlIdx);
+    const nextInstr = rest.search(/^(RUN|ENV|COPY|USER|ENTRYPOINT|CMD)\s/m);
+    const runBody = nextInstr === -1 ? rest : rest.slice(0, nextInstr);
+    expect(runBody).toMatch(/chown -h hindsight:hindsight/);
+
+    // (c) …and that chown must be scoped by an ownership predicate, so it
+    //     touches only files that are genuinely mis-owned.
+    expect(runBody).toMatch(/! -user hindsight -o ! -group hindsight/);
+
+    // (d) The self-verifying assertions survive: the pinned export is still
+    //     required to exist, and nothing may be left non-hindsight-owned.
+    expect(runBody).toContain(
+      `test -f ${cacheRoot}/hub/models--BAAI--bge-small-en-v1.5/snapshots/` +
+        `5c38ec7c405ec4b44b94cc5a9bb96e735b38267a/onnx/model.onnx`,
+    );
+    expect(runBody).toMatch(/STRAY=\$\(find/);
+    expect(runBody).toMatch(/exit 1/);
+  });
+
   it("ends as USER hindsight (so the entrypoint runs as UID 11000)", () => {
     expect(dockerfile).toMatch(/^USER\s+hindsight\b/m);
   });

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -590,7 +590,7 @@ describe("Dockerfile.hindsight shape", () => {
   });
 
   it("fixes HF-cache ownership with a scoped find in the SAME RUN as the download (no `chown -R` copy-up layer)", () => {
-    // Regression guard for #4571. `chown(2)` copy-ups a file on overlayfs
+    // Regression guard for #4566. `chown(2)` copy-ups a file on overlayfs
     // even when the ownership is UNCHANGED, so the old shape —
     //
     //   RUN … snapshot_download …            <- 133MB layer (the onnx graph)


### PR DESCRIPTION
## What

`switchroom-hindsight` ships a 230.8MB-compressed (360MB uncompressed) layer that is pure duplicate. This removes it.

## Evidence

`chown(2)` triggers an overlayfs copy-up **even when the ownership is unchanged**. The HF ONNX bake was two layers — measured on `ghcr.io/switchroom/switchroom-hindsight:v0.20.18` with `docker history`:

```
133MB  RUN set -eu; HF_HOME=… /app/api/.venv/bin/python - <<'PYEOF'   # snapshot_download
360MB  RUN chown -R hindsight:hindsight /home/hindsight/.cache/huggingface && test -f …
```

The 360MB layer buys nothing:

- The cache is **344MB total** (`du -sh` inside the image: 256MB `models--BAAI--bge-small-en-v1.5` + 88MB `models--cross-encoder--ms-marco-MiniLM-L-6-v2`), so the chown layer is the *entire tree* copied up.
- The **only** root-owned file in it is the 133MB graph this stage just downloaded — blob `828e1496…`, mtime Aug 8, vs every other blob at mtime Aug 7 (upstream-baked).
- Everything else was already UID 11000, set by the remap `find` earlier in the file. Confirmed by `docker export` + `tar -tv`: **all 91 cache entries are `11000/11000`**.

So 360MB is written to duplicate 133MB of new content plus 211MB of files that were already correct.

## Fix

Both halves, and **neither alone is sufficient**:

- **Scope** the fixup to files that are genuinely mis-owned (`! -user hindsight -o ! -group hindsight`) — same reasoning as the `#2807` `-xdev` scoping directly above it, which the surrounding comments explain and this change extends rather than undoes.
- **Merge** it into the same `RUN` as the download. A scoped chown in a *separate* `RUN` would still copy the freshly-created 133MB graph up a second time.

## Guarantees

Preserved and strengthened, not traded away:

- Every non-`hindsight`-owned file is still chowned — the EACCES guarantee is unchanged; only the *set of files touched* narrows.
- The `test -f` assertion on the pinned export (`5c38ec7…/onnx/model.onnx`) is retained.
- **New**: a post-condition check fails the build loudly if anything under the cache is left non-`hindsight`-owned, instead of deferring that to a runtime EACCES on a non-root boot.
- **Runtime UID 11000 is untouched.** It is load-bearing for the auth-broker per-consumer UDS (`docs/auth.md:85,497,514`), the claude-creds tmpfs (`docs/operators/claude-cli-updates.md:108-109`), `src/cli/doctor.ts:1355`, and deployed fleets' 11000-owned pgdata volumes.

## Testing

- `tests/docker/dockerfile-hindsight-bakes.test.ts` gains a regression test pinning **both** halves plus the retained assertions.
- Verified it is a real outcome assertion: it **fails** when run against the pre-fix `origin/main` Dockerfile, and passes after — `44/44` green.
- `docker build --check -f docker/Dockerfile.hindsight .` → `Check complete, no warnings found.`
- The nested-heredoc form (`RUN <<'SHEOF'` wrapping the existing `python - <<'PYEOF'`) was validated with a standalone BuildKit build before adopting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)