### PR TITLE
ci(docker-images): retag unchanged images at a release tag instead of rebuilding

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -51,14 +51,14 @@ name: docker-images
 # large share of every warm build's wall time, and the verification
 # story (`switchroom update` pull-side checks) targets release images.
 #
-# This workflow is staged at docs/proposed/docker-images.yml because the
-# OAuth token used to land code changes here lacks the `workflow` scope
-# GitHub requires for writes under `.github/workflows/`. To activate it,
-# an operator with a workflow-scoped token must:
-#
-#   git mv docs/proposed/docker-images.yml .github/workflows/docker-images.yml
-#   git commit -m "ci: enable docker-images workflow"
-#   git push
+# Rebuild avoidance:
+#   - main pushes: `retag-unchanged` re-points `:sha-<short>` at the
+#     existing `:latest` for path-skipped hindsight / voice.
+#   - RELEASE TAGS: `tag-retag-plan` diffs this tag against the previous
+#     release tag over each image's declared filter inputs, and
+#     `retag-release` re-points the previous release's manifest at
+#     `:vX.Y.Z` for any image whose inputs are provably identical.
+#     Both verdicts are fail-safe: anything short of proof means BUILD.
 
 on:
   push:
@@ -135,8 +135,12 @@ jobs:
   #     their FULL build input set, so an unchanged filter provably
   #     means an identical image. When skipped on a main push, the
   #     retag-unchanged job re-points `:sha-<short>` at the existing
-  #     `:latest` manifest instead of re-building/re-exporting. Tags +
-  #     dispatch still always build them.
+  #     `:latest` manifest instead of re-building/re-exporting.
+  #     workflow_dispatch still always builds them. RELEASE TAGS are
+  #     handled by tag-retag-plan / retag-release below, which diff
+  #     against the PREVIOUS RELEASE TAG (dorny has no diff base on a
+  #     tag push, so the plan job does the diff itself) — an image with
+  #     no input change since the last release is retagged, not rebuilt.
   #
   # This job itself skips on tag pushes / workflow_dispatch (dorny has
   # no diff base there); downstream `if:`s use `!cancelled()` so a
@@ -170,6 +174,160 @@ jobs:
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         with:
           filters: .github/path-filters.yml
+
+  # ─── Release-tag change filter (the tag-path analogue of `changes`) ─
+  # `changes` cannot run on a tag push — dorny has no diff base there —
+  # so historically EVERY image was rebuilt from scratch at every
+  # release tag, including the ones whose build inputs had not moved a
+  # byte since the previous release. This job supplies the missing diff
+  # base: the PREVIOUS release tag reachable from this one.
+  #
+  # It emits, per image, exactly one of two verdicts:
+  #   `unchanged` — PROVEN identical: the image's full declared input
+  #                 set (its key in .github/path-filters.yml) has no
+  #                 diff between the previous release tag and this one,
+  #                 AND the previous release's manifest is present in
+  #                 the registry so `retag-release` has something to
+  #                 point at.
+  #   `changed`   — everything else.
+  #
+  # FAIL-SAFE BY CONSTRUCTION. Both verdicts start at `changed` and are
+  # only ever promoted to `unchanged` by a positive proof. No previous
+  # tag, an unreadable / restructured filter file, a missing `yq`, a git
+  # error, a registry hiccup, a skipped or failed instance of THIS job —
+  # every one of those leaves the consumer reading something that is not
+  # the literal string `unchanged`, and the build gates below are written
+  # as `!= 'unchanged'`, so the fallback is always BUILD. Publishing a
+  # stale image under a release tag is unrecoverable; a redundant rebuild
+  # merely costs minutes.
+  #
+  # Manifest-only (imagetools inspect, no build) — deliberately NO
+  # setup-buildx; see merge-base. Enforced by
+  # tests/docker/manifest-jobs-no-buildx.test.ts.
+  tag-retag-plan:
+    # `github.event_name == 'push'` is not redundant with the ref test:
+    # it makes this gate a positive EVENT ALLOWLIST, which is the shape
+    # tests/ci-merge-queue-triggers.test.ts uses to prove the GHCR-login
+    # step below is unreachable from a queue ref. It also keeps a
+    # workflow_dispatch aimed at a tag ref out of here — dispatch always
+    # builds, by design.
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      prev_tag: ${{ steps.plan.outputs.prev_tag }}
+      hindsight: ${{ steps.plan.outputs.hindsight }}
+      voice: ${{ steps.plan.outputs.voice }}
+    steps:
+      - name: Checkout (full history + tags — the plan diffs two releases)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          # fetch-depth: 0 is required, not defensive: the plan resolves
+          # the previous release tag and diffs against it. The default
+          # shallow single-commit checkout has neither the tags nor the
+          # ancestry to answer that, and every failure there degrades to
+          # `changed` — i.e. a silent loss of the whole optimisation.
+          fetch-depth: 0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Plan per-image release retags
+        id: plan
+        run: |
+          # NOTE: deliberately no `set -e`. Every probe below is allowed
+          # to fail; a failure means "cannot prove identical" and leaves
+          # the verdict at its `changed` default. `set -e` would turn a
+          # transient registry blip into a red release instead.
+          set -uo pipefail
+
+          TAG="${GITHUB_REF#refs/tags/}"
+          HINDSIGHT_VERDICT=changed
+          VOICE_VERDICT=changed
+
+          # Previous release tag reachable from this commit. `--merged`
+          # keeps it to ancestors (a tag on an unrelated branch is not a
+          # valid diff base); version sort picks the highest such tag
+          # that is not this one.
+          PREV=$(git tag --list 'v*' --sort=-version:refname --merged "${GITHUB_SHA}" \
+                   | grep -vFx "$TAG" | head -n1)
+          PREV="${PREV:-}"
+
+          # $1 = path-filters.yml key, $2 = the image's own Dockerfile
+          # (sanity anchor), $3 = GHCR image short name.
+          # Returns 0 ONLY when the image is proven identical.
+          plan_image() {
+            local key="$1" anchor="$2" name="$3"
+            local IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-${name}"
+            local specs=() line out changed
+
+            while IFS= read -r line; do
+              [ -n "$line" ] && specs+=("$line")
+            done < <(yq eval ".${key}[]" .github/path-filters.yml 2>/dev/null)
+
+            if [ "${#specs[@]}" -eq 0 ]; then
+              echo "::warning title=tag-retag-plan::could not read the '${key}' filter from .github/path-filters.yml — ${name} will be BUILT."
+              return 1
+            fi
+            # The verdict is only sound if the filter key really is the
+            # image's FULL input set. Anchor on two entries that must be
+            # there: the image's own Dockerfile, and this filter file
+            # (a filter edit is itself an input change). If a refactor
+            # moves either out of the key, stop trusting the list.
+            local spec_list
+            spec_list=$(printf '%s\n' "${specs[@]}")
+            if ! printf '%s\n' "$spec_list" | grep -qFx "$anchor"; then
+              echo "::warning title=tag-retag-plan::filter key '${key}' no longer lists ${anchor} — refusing to trust it; ${name} will be BUILT."
+              return 1
+            fi
+            if ! printf '%s\n' "$spec_list" | grep -qFx '.github/path-filters.yml'; then
+              echo "::warning title=tag-retag-plan::filter key '${key}' no longer lists .github/path-filters.yml — refusing to trust it; ${name} will be BUILT."
+              return 1
+            fi
+
+            changed=$(git diff --name-only "$PREV" "$GITHUB_SHA" -- "${specs[@]}")
+            if [ $? -ne 0 ]; then
+              echo "::warning title=tag-retag-plan::git diff ${PREV}..${TAG} failed for '${key}' — ${name} will be BUILT."
+              return 1
+            fi
+            if [ -n "$changed" ]; then
+              echo "${name}: inputs changed since ${PREV} — BUILD:"
+              printf '  %s\n' $changed
+              return 1
+            fi
+
+            # Inputs identical. The retag still needs the previous
+            # release's manifest to exist — if it does not (fresh
+            # namespace, pruned tag), there is nothing to point at, so
+            # build rather than publish a release with a missing image.
+            if ! out=$(docker buildx imagetools inspect "${IMAGE}:${PREV}" 2>&1); then
+              echo "::notice title=tag-retag-plan::${IMAGE}:${PREV} is not inspectable — nothing to retag from; ${name} will be BUILT."
+              printf '%s\n' "$out"
+              return 1
+            fi
+
+            echo "${name}: inputs identical to ${PREV} and ${IMAGE}:${PREV} exists — RETAG."
+            return 0
+          }
+
+          if [ -z "$PREV" ]; then
+            echo "::notice title=tag-retag-plan::no previous release tag reachable from ${TAG} — every image will be BUILT."
+          else
+            echo "planning ${TAG} against previous release ${PREV}"
+            if plan_image hindsight docker/Dockerfile.hindsight hindsight; then HINDSIGHT_VERDICT=unchanged; fi
+            if plan_image voice     docker/Dockerfile.voice     voice;     then VOICE_VERDICT=unchanged; fi
+          fi
+
+          {
+            echo "prev_tag=${PREV}"
+            echo "hindsight=${HINDSIGHT_VERDICT}"
+            echo "voice=${VOICE_VERDICT}"
+          } >> "$GITHUB_OUTPUT"
+          echo "verdicts: hindsight=${HINDSIGHT_VERDICT} voice=${VOICE_VERDICT} prev_tag=${PREV:-<none>}"
 
   # ─── Build dist/ once, share with the dependent image legs ────────
   # The dependent images (agent/broker/kernel/hostd/auth-broker/web)
@@ -847,8 +1005,9 @@ jobs:
     # Path-gated on PRs AND main pushes (see `changes` header): the
     # hindsight context rarely changes; when it's unchanged on a main
     # push this job skips and retag-unchanged re-points :sha-<short>
-    # at the existing :latest manifest. Tags + workflow_dispatch always
-    # build.
+    # at the existing :latest manifest. On a RELEASE TAG the equivalent
+    # gate is tag-retag-plan's verdict (retag-release does the retag);
+    # workflow_dispatch always builds.
     #
     # Split per-arch on NATIVE runners (amd64 on ubuntu-latest, arm64 on
     # ubuntu-24.04-arm), exactly like build-base / build-dependents — no
@@ -865,8 +1024,19 @@ jobs:
     # the push to main straight after the merge. Forcing the 6.4GB
     # build onto every queue entry would push the queue past its 60-min
     # check_response_timeout for no added signal.
-    needs: changes
-    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || needs.changes.outputs.hindsight == 'true') }}
+    #
+    # TAG BRANCH: no longer an unconditional build. It is CONJOINED with
+    # tag-retag-plan's verdict — `startsWith(refs/tags/) && plan !=
+    # 'unchanged'`. The polarity is deliberate and is the highest-risk
+    # line in this file: the test is `!= 'unchanged'`, NOT `== 'changed'`,
+    # so every value the output can take other than the literal
+    # `unchanged` — the empty string from a skipped or failed
+    # tag-retag-plan included — BUILDS. Inverting this to `== 'changed'`
+    # would make a missing plan silently skip the build and ship the
+    # previous release's image under a new version tag.
+    # Guarded by tests/docker/ci-tag-retag-unchanged.test.ts.
+    needs: [changes, tag-retag-plan]
+    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/') && needs.tag-retag-plan.outputs.hindsight != 'unchanged') || needs.changes.outputs.hindsight == 'true') }}
     strategy:
       fail-fast: false
       matrix:
@@ -1023,14 +1193,21 @@ jobs:
     # Path-gated on PRs AND main pushes like build-hindsight (see the
     # `changes` header): the CUDA layers make voice the heaviest build
     # and its context almost never changes; retag-unchanged covers the
-    # skipped-on-main-push case. Tags + dispatch always build.
+    # skipped-on-main-push case, and tag-retag-plan / retag-release the
+    # release-tag case. workflow_dispatch always builds.
     #
     # Skips on merge_group for the same reason as build-hindsight — this
     # is the single heaviest build in the repo and running it per queue
     # entry would blow the queue's 60-min check_response_timeout. The
     # build + publish still runs on the push to main after the merge.
-    needs: changes
-    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || needs.changes.outputs.voice == 'true') }}
+    #
+    # TAG BRANCH: conjoined with tag-retag-plan's verdict, same shape and
+    # same fail-safe polarity as build-hindsight — `!= 'unchanged'`, so a
+    # skipped / failed / absent plan BUILDS. See build-hindsight for the
+    # full rationale. Guarded by
+    # tests/docker/ci-tag-retag-unchanged.test.ts.
+    needs: [changes, tag-retag-plan]
+    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/') && needs.tag-retag-plan.outputs.voice != 'unchanged') || needs.changes.outputs.voice == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -1179,6 +1356,89 @@ jobs:
           }
           if [ "$HINDSIGHT_CHANGED" != "true" ]; then retag hindsight; fi
           if [ "$VOICE_CHANGED" != "true" ]; then retag voice; fi
+
+  # ─── Skip re-export of unchanged images (RELEASE TAGS) ────────────
+  # The tag-path twin of retag-unchanged. For any image tag-retag-plan
+  # proved identical to the previous release, re-point that release's
+  # manifest at `:vX.Y.Z` with `docker buildx imagetools create` instead
+  # of rebuilding it — same manifest-only, no-rebuild, no-re-export
+  # pattern as merge-* / retag-unchanged / promote-to-dev.
+  #
+  # Two independent conditions must BOTH hold per image before anything
+  # is retagged, and they are checked again inside the step (not only in
+  # the job `if:`) so the per-image decision is never inferred from the
+  # job-level OR:
+  #   1. tag-retag-plan's verdict for that image is exactly `unchanged`.
+  #   2. that image's build job actually SKIPPED. If it ran for any
+  #      reason it owns `:vX.Y.Z`, and retagging the previous release
+  #      over it would REGRESS the release. We warn and leave it alone.
+  #
+  # `imagetools create` here is a hard requirement, not best-effort: the
+  # plan already verified the source manifest exists, so a failure now is
+  # a real failure and must red the run — a release tag with a missing
+  # image is worse than a red workflow.
+  #
+  # Attestations: a retagged index carries the PREVIOUS release's
+  # provenance/SBOM manifests (WS9-F3 attests tag builds). That is
+  # accurate rather than stale — the bits genuinely were produced by that
+  # build — and nothing on the pull side verifies image provenance today
+  # (`switchroom update` does no cosign/SLSA check). If that ever
+  # changes, this job is the place that has to grow an attestation
+  # re-attach step, or hindsight/voice have to drop out of the plan.
+  #
+  # Manifest-only — deliberately NO setup-buildx; see merge-base.
+  # Enforced by tests/docker/manifest-jobs-no-buildx.test.ts.
+  retag-release:
+    needs: [tag-retag-plan, build-hindsight, build-voice]
+    if: >-
+      !cancelled() &&
+      github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') &&
+      needs.tag-retag-plan.result == 'success' &&
+      ((needs.tag-retag-plan.outputs.hindsight == 'unchanged' && needs.build-hindsight.result == 'skipped') ||
+       (needs.tag-retag-plan.outputs.voice == 'unchanged' && needs.build-voice.result == 'skipped'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # NO `docker/setup-buildx-action` here, deliberately — manifest-only
+      # job; see the full rationale on merge-base above. Enforced by
+      # tests/docker/manifest-jobs-no-buildx.test.ts.
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Retag previous release manifest as :<tag> for unchanged images
+        env:
+          PREV_TAG: ${{ needs.tag-retag-plan.outputs.prev_tag }}
+          HINDSIGHT_VERDICT: ${{ needs.tag-retag-plan.outputs.hindsight }}
+          VOICE_VERDICT: ${{ needs.tag-retag-plan.outputs.voice }}
+          HINDSIGHT_BUILD: ${{ needs.build-hindsight.result }}
+          VOICE_BUILD: ${{ needs.build-voice.result }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          if [ -z "$PREV_TAG" ]; then
+            echo "::error title=retag-release::reached with an empty prev_tag — refusing to guess a source manifest."
+            exit 1
+          fi
+          retag() {
+            local name="$1" verdict="$2" build="$3"
+            local IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-${name}"
+            if [ "$verdict" != "unchanged" ]; then
+              echo "${name}: plan verdict '${verdict}' — built for this release; nothing to retag."
+              return 0
+            fi
+            if [ "$build" != "skipped" ]; then
+              echo "::warning title=retag-release::${name} planned as unchanged but build-${name} result is '${build}' — that job owns ${IMAGE}:${TAG}; NOT overwriting it."
+              return 0
+            fi
+            docker buildx imagetools create -t "${IMAGE}:${TAG}" "${IMAGE}:${PREV_TAG}"
+            echo "retagged ${IMAGE}:${PREV_TAG} -> ${IMAGE}:${TAG} (inputs identical since ${PREV_TAG})"
+          }
+          retag hindsight "$HINDSIGHT_VERDICT" "$HINDSIGHT_BUILD"
+          retag voice "$VOICE_VERDICT" "$VOICE_BUILD"
 
   # PR C: smoke test the freshly-pushed :sha-<7> agent image — runs the
   # MCP tools/list harness inside a throwaway container with the
@@ -1346,6 +1606,13 @@ jobs:
       - merge-hindsight
       - build-voice
       - retag-unchanged
+      # Release-tag retag path. Both must be aggregated here or a
+      # failure in them is invisible: neither runs on a PR, and
+      # `retag-release` is the job that actually publishes hindsight /
+      # voice `:vX.Y.Z` when their builds were short-circuited — a
+      # silent failure there means a release tag with a missing image.
+      - tag-retag-plan
+      - retag-release
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 1
@@ -1371,7 +1638,9 @@ jobs:
             "build-hindsight=${{ needs.build-hindsight.result }}" \
             "merge-hindsight=${{ needs.merge-hindsight.result }}" \
             "build-voice=${{ needs.build-voice.result }}" \
-            "retag-unchanged=${{ needs.retag-unchanged.result }}"; do
+            "retag-unchanged=${{ needs.retag-unchanged.result }}" \
+            "tag-retag-plan=${{ needs.tag-retag-plan.result }}" \
+            "retag-release=${{ needs.retag-release.result }}"; do
             job="${pair%%=*}"; r="${pair#*=}"
             if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
               echo "::error::${job}=${r} — real build failure, blocking"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,20 @@ now an anomaly worth investigating, not the norm.
   high=1000), with the local cross-encoder reranker running at every tier and
   no LLM in the recall ranking path.
 
+### CI: release tags retag unchanged images instead of rebuilding them
+
+- **docker-images: a new `tag-retag-plan` job diffs a release tag against the
+  previous release tag over each image's declared build inputs, and a new
+  `retag-release` job re-points the previous release's manifest at `:vX.Y.Z` for
+  any image whose inputs are provably identical.** `hindsight` and `voice` were
+  rebuilt from scratch at every release even when their build context had not
+  moved a byte — the main-push path already had this short-circuit
+  (`retag-unchanged`), the tag path did not, because `dorny/paths-filter` has no
+  diff base on a tag push. Both verdicts are fail-safe: no previous tag, an
+  unreadable filter file, a registry hiccup, or a skipped/failed plan job all
+  mean BUILD, never skip — publishing a stale image under a release tag is
+  unrecoverable, while a redundant rebuild only costs minutes.
+
 ## v0.20.20 — docker-images builds `dist/` once and shares it with the dependent image legs
 
 ### CI: `dist/` is built once and shared with the dependent image legs

--- a/tests/ci-merge-queue-triggers.test.ts
+++ b/tests/ci-merge-queue-triggers.test.ts
@@ -327,15 +327,25 @@ describe('merge queue — docker-images never publishes from an unmerged ref', (
 
   it('no manifest job moves a user-facing tag on merge_group', () => {
     // merge-base / merge-dependents / merge-hindsight / promote-to-dev /
-    // retag-unchanged assign :latest / :sha-<short> / :dev with
-    // `imagetools create`.
+    // retag-unchanged / retag-release assign :latest / :sha-<short> /
+    // :dev / :vX.Y.Z with `imagetools create`.
     const manifestJobs = jobs.filter(([, job]) =>
       stepsOf(job).some((s) => (s.run ?? '').includes('imagetools create')),
     )
     expect(
       manifestJobs.map(([n]) => n).sort(),
       'the rule must still match the publishing jobs it guards',
-    ).toEqual(['merge-base', 'merge-dependents', 'merge-hindsight', 'promote-to-dev', 'retag-unchanged'])
+    ).toEqual([
+      'merge-base',
+      'merge-dependents',
+      'merge-hindsight',
+      'promote-to-dev',
+      // Release-tag twin of retag-unchanged: assigns :vX.Y.Z from the
+      // previous release's manifest when tag-retag-plan proved the
+      // image's inputs identical to that release.
+      'retag-release',
+      'retag-unchanged',
+    ])
 
     const offenders = manifestJobs.filter(([, job]) => !excludesMergeGroup(job.if)).map(([n]) => n)
 

--- a/tests/docker/ci-tag-retag-unchanged.test.ts
+++ b/tests/docker/ci-tag-retag-unchanged.test.ts
@@ -1,0 +1,567 @@
+/**
+ * Guard: the RELEASE-TAG retag short-circuit in docker-images.yml.
+ *
+ * Background. At a release tag `changes` (dorny/paths-filter) cannot run
+ * — a tag push has no diff base — so every image was rebuilt from
+ * scratch at every release, including images whose build inputs had not
+ * moved since the previous release. `tag-retag-plan` supplies the
+ * missing diff base (the previous release tag) and `retag-release`
+ * re-points the previous release's manifest at `:vX.Y.Z` for any image
+ * proven identical.
+ *
+ * Why these tests exist. NONE of this runs on a pull request: the plan,
+ * the retag, and the tag branch of the build gates are all reachable
+ * only from `refs/tags/v*`. A polarity slip in a build gate is therefore
+ * invisible until a release silently ships the PREVIOUS release's image
+ * under a new version tag — an unrecoverable, unnoticeable failure. A
+ * test is the only deterministic thing standing between an edit and that
+ * outcome.
+ *
+ * These assert OUTCOMES, not shapes: the job `if:` expressions are
+ * parsed and EVALUATED against simulated GitHub contexts, so a test
+ * fails when the *decision* changes, not merely when the text does.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { parse } from 'yaml'
+
+const REPO = resolve(import.meta.dirname, '../..')
+const WORKFLOW = '.github/workflows/docker-images.yml'
+
+interface Step {
+  uses?: string
+  with?: Record<string, unknown>
+  run?: string
+  name?: string
+}
+interface Job {
+  if?: string | boolean
+  needs?: string | string[]
+  steps?: Step[]
+}
+
+const raw = readFileSync(join(REPO, WORKFLOW), 'utf8')
+const doc = parse(raw) as { jobs: Record<string, Job> }
+const jobs = doc.jobs
+
+function job(name: string): Job {
+  const j = jobs[name]
+  expect(j, `${WORKFLOW} has no job \`${name}\``).toBeDefined()
+  return j
+}
+
+function needsOf(name: string): string[] {
+  const n = job(name).needs
+  if (!n) return []
+  return Array.isArray(n) ? n : [n]
+}
+
+function stepsOf(name: string): Step[] {
+  const s = job(name).steps
+  return Array.isArray(s) ? s : []
+}
+
+// ───────────────────────── GitHub expression evaluator ────────────────
+// A deliberately small recursive-descent evaluator for the subset of the
+// GitHub expression language these gates use: string/boolean literals,
+// `!`, `&&`, `||`, `==`, `!=`, parentheses, dotted context lookups, and
+// the `cancelled()` / `always()` / `success()` / `failure()` /
+// `startsWith()` / `contains()` functions. An unknown token throws
+// rather than silently evaluating to something convenient — a test that
+// cannot parse the gate must fail loudly, not pass vacuously.
+
+type Ctx = {
+  event_name: string
+  ref: string
+  needs: Record<string, { result?: string; outputs?: Record<string, string> }>
+  cancelled?: boolean
+}
+
+type Tok = { t: 'op' | 'str' | 'id'; v: string }
+
+function tokenize(src: string): Tok[] {
+  const out: Tok[] = []
+  let i = 0
+  while (i < src.length) {
+    const c = src[i]
+    if (/\s/.test(c)) {
+      i++
+      continue
+    }
+    if (c === "'") {
+      let j = i + 1
+      let s = ''
+      while (j < src.length) {
+        if (src[j] === "'" && src[j + 1] === "'") {
+          s += "'"
+          j += 2
+          continue
+        }
+        if (src[j] === "'") break
+        s += src[j++]
+      }
+      out.push({ t: 'str', v: s })
+      i = j + 1
+      continue
+    }
+    const two = src.slice(i, i + 2)
+    if (two === '&&' || two === '||' || two === '==' || two === '!=') {
+      out.push({ t: 'op', v: two })
+      i += 2
+      continue
+    }
+    if ('()!,'.includes(c)) {
+      out.push({ t: 'op', v: c })
+      i++
+      continue
+    }
+    const m = /^[A-Za-z_][A-Za-z0-9_.\-]*/.exec(src.slice(i))
+    if (m) {
+      out.push({ t: 'id', v: m[0] })
+      i += m[0].length
+      continue
+    }
+    throw new Error(`unexpected character '${c}' at ${i} in: ${src}`)
+  }
+  return out
+}
+
+function lookup(path: string, ctx: Ctx): unknown {
+  const parts = path.split('.')
+  if (parts[0] === 'github') {
+    if (parts[1] === 'event_name') return ctx.event_name
+    if (parts[1] === 'ref') return ctx.ref
+    throw new Error(`unsupported github context: ${path}`)
+  }
+  if (parts[0] === 'needs') {
+    // Missing job / missing output is '' — exactly what GitHub hands a
+    // consumer when the producing job skipped or failed. The fail-safe
+    // tests below depend on this being modelled, not special-cased.
+    const n = ctx.needs[parts[1]]
+    if (!n) return ''
+    if (parts[2] === 'result') return n.result ?? ''
+    if (parts[2] === 'outputs') return n.outputs?.[parts[3]] ?? ''
+    throw new Error(`unsupported needs context: ${path}`)
+  }
+  throw new Error(`unsupported context: ${path}`)
+}
+
+function truthy(v: unknown): boolean {
+  if (typeof v === 'boolean') return v
+  if (typeof v === 'string') return v !== ''
+  return Boolean(v)
+}
+
+function evaluate(expr: string, ctx: Ctx): boolean {
+  const toks = tokenize(expr)
+  let p = 0
+  const peek = () => toks[p]
+  const eat = (v: string) => {
+    if (!toks[p] || toks[p].v !== v) {
+      throw new Error(`expected '${v}' at token ${p} in: ${expr}`)
+    }
+    p++
+  }
+
+  function primary(): unknown {
+    const tk = toks[p]
+    if (!tk) throw new Error(`unexpected end of expression: ${expr}`)
+    if (tk.v === '!') {
+      p++
+      return !truthy(primary())
+    }
+    if (tk.v === '(') {
+      p++
+      const v = or()
+      eat(')')
+      return v
+    }
+    if (tk.t === 'str') {
+      p++
+      return tk.v
+    }
+    if (tk.t === 'id') {
+      p++
+      // Function call?
+      if (peek() && peek()!.v === '(') {
+        p++
+        const args: unknown[] = []
+        while (peek() && peek()!.v !== ')') {
+          args.push(or())
+          if (peek() && peek()!.v === ',') p++
+        }
+        eat(')')
+        switch (tk.v) {
+          case 'cancelled':
+            return ctx.cancelled === true
+          case 'always':
+            return true
+          case 'success':
+            return Object.values(ctx.needs).every((n) => (n.result ?? 'success') === 'success')
+          case 'failure':
+            return Object.values(ctx.needs).some((n) => n.result === 'failure')
+          case 'startsWith':
+            return String(args[0]).startsWith(String(args[1]))
+          case 'contains':
+            return String(args[0]).includes(String(args[1]))
+          default:
+            throw new Error(`unsupported function ${tk.v}() in: ${expr}`)
+        }
+      }
+      if (tk.v === 'true') return true
+      if (tk.v === 'false') return false
+      return lookup(tk.v, ctx)
+    }
+    throw new Error(`unexpected token '${tk.v}' in: ${expr}`)
+  }
+
+  function cmp(): unknown {
+    let l = primary()
+    while (peek() && (peek()!.v === '==' || peek()!.v === '!=')) {
+      const op = toks[p++].v
+      const r = primary()
+      l = op === '==' ? l === r : l !== r
+    }
+    return l
+  }
+
+  function and(): unknown {
+    let l = cmp()
+    while (peek() && peek()!.v === '&&') {
+      p++
+      const r = cmp()
+      l = truthy(l) ? r : l
+    }
+    return l
+  }
+
+  function or(): unknown {
+    let l = and()
+    while (peek() && peek()!.v === '||') {
+      p++
+      const r = and()
+      l = truthy(l) ? l : r
+    }
+    return l
+  }
+
+  const v = or()
+  if (p !== toks.length) throw new Error(`trailing tokens at ${p} in: ${expr}`)
+  return truthy(v)
+}
+
+/** Evaluate a job's `if:` under a simulated context. */
+function jobRuns(name: string, ctx: Ctx): boolean {
+  const cond = job(name).if
+  if (cond === undefined) return true
+  if (typeof cond === 'boolean') return cond
+  const expr = cond.trim().replace(/^\$\{\{/, '').replace(/\}\}$/, '').trim()
+  return evaluate(expr, ctx)
+}
+
+// ── Context builders ──────────────────────────────────────────────────
+
+/** A release-tag push. `plan` is what tag-retag-plan reported. */
+function tagCtx(opts: {
+  hindsight?: string
+  voice?: string
+  planResult?: string
+  buildHindsight?: string
+  buildVoice?: string
+  /** omit tag-retag-plan from `needs` entirely (job never ran/defined) */
+  noPlan?: boolean
+}): Ctx {
+  const needs: Ctx['needs'] = {
+    changes: { result: 'skipped', outputs: {} },
+    'build-hindsight': { result: opts.buildHindsight ?? 'success' },
+    'build-voice': { result: opts.buildVoice ?? 'success' },
+  }
+  if (!opts.noPlan) {
+    needs['tag-retag-plan'] = {
+      result: opts.planResult ?? 'success',
+      outputs: {
+        prev_tag: 'v0.20.19',
+        ...(opts.hindsight !== undefined ? { hindsight: opts.hindsight } : {}),
+        ...(opts.voice !== undefined ? { voice: opts.voice } : {}),
+      },
+    }
+  }
+  return { event_name: 'push', ref: 'refs/tags/v0.20.20', needs }
+}
+
+function mainPushCtx(changed: Record<string, string>): Ctx {
+  return {
+    event_name: 'push',
+    ref: 'refs/heads/main',
+    needs: {
+      changes: { result: 'success', outputs: changed },
+      'tag-retag-plan': { result: 'skipped', outputs: {} },
+      'build-hindsight': { result: 'success' },
+      'build-voice': { result: 'success' },
+    },
+  }
+}
+
+// ──────────────────────────────── Tests ──────────────────────────────
+
+describe('docker-images.yml — release-tag retag short-circuit', () => {
+  describe('the tag branch of each build gate is conjoined with the plan verdict', () => {
+    it.each([
+      ['build-hindsight', 'hindsight'],
+      ['build-voice', 'voice'],
+    ])('%s does NOT build at a tag when the plan proved the image unchanged', (jobName, key) => {
+      expect(
+        jobRuns(jobName, tagCtx({ [key]: 'unchanged' })),
+        `${jobName} still builds on a release tag even though tag-retag-plan reported ` +
+          `${key}=unchanged. The tag branch of its \`if:\` must be CONJOINED with ` +
+          `needs.tag-retag-plan.outputs.${key} != 'unchanged'; an unconditional ` +
+          `startsWith(github.ref, 'refs/tags/') disjunct makes retag-release dead code and ` +
+          `rebuilds a byte-identical image on every release.`,
+      ).toBe(false)
+    })
+
+    it.each([
+      ['build-hindsight', 'hindsight'],
+      ['build-voice', 'voice'],
+    ])('%s DOES build at a tag when the plan says the image changed', (jobName, key) => {
+      expect(jobRuns(jobName, tagCtx({ [key]: 'changed' })), `${jobName} must build`).toBe(true)
+    })
+  })
+
+  describe('fail-safe: anything short of a proven `unchanged` verdict BUILDS', () => {
+    // The polarity here is the highest-risk line in the workflow. The
+    // gate must read `!= 'unchanged'`, never `== 'changed'`: every one
+    // of the states below yields an empty string, and only `!=` treats
+    // that as "build".
+    const degraded: Array<[string, Partial<Parameters<typeof tagCtx>[0]>]> = [
+      ['tag-retag-plan produced no output at all', { hindsight: undefined, voice: undefined }],
+      ['tag-retag-plan output is the empty string', { hindsight: '', voice: '' }],
+      ['tag-retag-plan FAILED', { planResult: 'failure' }],
+      ['tag-retag-plan was SKIPPED', { planResult: 'skipped' }],
+      ['tag-retag-plan is absent from needs', { noPlan: true }],
+      ['verdict is an unrecognised string', { hindsight: 'maybe', voice: 'maybe' }],
+    ]
+
+    it.each(degraded)('build-hindsight builds when %s', (_label, opts) => {
+      expect(
+        jobRuns('build-hindsight', tagCtx(opts)),
+        'build-hindsight SKIPPED on a degraded plan. Fail-safe is violated: the release ' +
+          'would publish the previous release\'s hindsight image under a new version tag.',
+      ).toBe(true)
+    })
+
+    it.each(degraded)('build-voice builds when %s', (_label, opts) => {
+      expect(
+        jobRuns('build-voice', tagCtx(opts)),
+        'build-voice SKIPPED on a degraded plan. Fail-safe is violated.',
+      ).toBe(true)
+    })
+
+    it('retag-release does NOT run on a degraded plan', () => {
+      for (const [label, opts] of degraded) {
+        expect(jobRuns('retag-release', tagCtx(opts)), `retag-release ran when ${label}`).toBe(
+          false,
+        )
+      }
+    })
+  })
+
+  describe('the main-push and dispatch paths are unchanged', () => {
+    it('build-hindsight/build-voice still follow the `changes` filter on a main push', () => {
+      expect(jobRuns('build-hindsight', mainPushCtx({ hindsight: 'true' }))).toBe(true)
+      expect(jobRuns('build-hindsight', mainPushCtx({ hindsight: 'false' }))).toBe(false)
+      expect(jobRuns('build-voice', mainPushCtx({ voice: 'true' }))).toBe(true)
+      expect(jobRuns('build-voice', mainPushCtx({ voice: 'false' }))).toBe(false)
+    })
+
+    it('workflow_dispatch still forces a build regardless of any plan verdict', () => {
+      const ctx: Ctx = {
+        event_name: 'workflow_dispatch',
+        ref: 'refs/heads/main',
+        needs: {
+          changes: { result: 'skipped', outputs: {} },
+          'tag-retag-plan': { result: 'skipped', outputs: { hindsight: 'unchanged', voice: 'unchanged' } },
+        },
+      }
+      expect(jobRuns('build-hindsight', ctx)).toBe(true)
+      expect(jobRuns('build-voice', ctx)).toBe(true)
+    })
+
+    it('retag-release never runs outside a release tag', () => {
+      expect(jobRuns('retag-release', mainPushCtx({ hindsight: 'false', voice: 'false' }))).toBe(
+        false,
+      )
+      expect(
+        jobRuns('retag-release', {
+          event_name: 'pull_request',
+          ref: 'refs/pull/1/merge',
+          needs: {},
+        }),
+      ).toBe(false)
+    })
+  })
+
+  describe('retag-release only retags what was genuinely short-circuited', () => {
+    it('runs when the plan proved an image unchanged and its build skipped', () => {
+      expect(
+        jobRuns(
+          'retag-release',
+          tagCtx({ hindsight: 'unchanged', voice: 'changed', buildHindsight: 'skipped' }),
+        ),
+      ).toBe(true)
+      expect(
+        jobRuns(
+          'retag-release',
+          tagCtx({ hindsight: 'changed', voice: 'unchanged', buildVoice: 'skipped' }),
+        ),
+      ).toBe(true)
+    })
+
+    it('does NOT run when every image was built', () => {
+      expect(jobRuns('retag-release', tagCtx({ hindsight: 'changed', voice: 'changed' }))).toBe(
+        false,
+      )
+    })
+
+    it('does NOT run when a build actually ran despite an `unchanged` verdict', () => {
+      // If build-hindsight ran it owns :vX.Y.Z. Retagging the previous
+      // release over it would REGRESS the release.
+      expect(
+        jobRuns(
+          'retag-release',
+          tagCtx({ hindsight: 'unchanged', voice: 'changed', buildHindsight: 'success' }),
+        ),
+      ).toBe(false)
+    })
+
+    it('re-checks both conditions per image inside the step, not just in the job `if:`', () => {
+      // The job-level `if:` is an OR across images, so a job that ran
+      // for voice must not blindly retag hindsight.
+      const body = stepsOf('retag-release')
+        .map((s) => s.run ?? '')
+        .join('\n')
+      expect(body).toContain('imagetools create')
+      expect(body).toMatch(/!=\s*"unchanged"/)
+      expect(body).toMatch(/!=\s*"skipped"/)
+    })
+  })
+
+  describe('the new jobs are manifest-only (no Docker Hub buildkit pull)', () => {
+    it.each(['retag-release', 'tag-retag-plan'])('%s sets up no buildx and builds nothing', (name) => {
+      const steps = stepsOf(name)
+      const offenders = steps
+        .map((s) => s.uses ?? '')
+        .filter(
+          (u) =>
+            u.includes('docker/setup-buildx-action') ||
+            u === './.github/actions/setup-buildx' ||
+            u.includes('docker/build-push-action'),
+        )
+      expect(
+        offenders,
+        `${name} is manifest-only (imagetools inspect/create are pure registry ops). ` +
+          `setup-buildx-action's docker-container driver pulls moby/buildkit from Docker Hub — ` +
+          `an unauthenticated, rate-limited docker.io dependency this job never uses.`,
+      ).toEqual([])
+    })
+  })
+
+  describe('tag-retag-plan', () => {
+    it('only runs on a release tag', () => {
+      expect(jobRuns('tag-retag-plan', tagCtx({}))).toBe(true)
+      expect(jobRuns('tag-retag-plan', mainPushCtx({}))).toBe(false)
+      expect(
+        jobRuns('tag-retag-plan', {
+          event_name: 'pull_request',
+          ref: 'refs/pull/1/merge',
+          needs: {},
+        }),
+      ).toBe(false)
+    })
+
+    it('checks out full history — a shallow clone cannot resolve the previous release tag', () => {
+      const checkout = stepsOf('tag-retag-plan').find((s) => (s.uses ?? '').includes('actions/checkout'))
+      expect(checkout, 'tag-retag-plan must check out the repo to diff two releases').toBeDefined()
+      expect(
+        checkout!.with?.['fetch-depth'],
+        'tag-retag-plan needs `fetch-depth: 0`: the default single-commit checkout has ' +
+          'neither the tags nor the ancestry to diff against the previous release, so every ' +
+          'verdict degrades to `changed` and the optimisation silently never fires.',
+      ).toBe(0)
+    })
+
+    it('defaults both verdicts to `changed` before any probe can promote them', () => {
+      const body = stepsOf('tag-retag-plan')
+        .map((s) => s.run ?? '')
+        .join('\n')
+      expect(body).toMatch(/HINDSIGHT_VERDICT=changed/)
+      expect(body).toMatch(/VOICE_VERDICT=changed/)
+      // The verdict may only be promoted, never assigned from a probe's
+      // raw output — `=unchanged` must appear exactly where a proof
+      // succeeded.
+      const promotions = body.match(/_VERDICT=unchanged/g) ?? []
+      expect(promotions.length).toBe(2)
+    })
+
+    it('anchors the filter list it trusts, so a path-filters refactor degrades to `changed`', () => {
+      const body = stepsOf('tag-retag-plan')
+        .map((s) => s.run ?? '')
+        .join('\n')
+      expect(body).toContain('docker/Dockerfile.hindsight')
+      expect(body).toContain('docker/Dockerfile.voice')
+      expect(body).toContain('.github/path-filters.yml')
+    })
+  })
+
+  describe('images-ok cannot mask a failure in the new jobs', () => {
+    it('needs both tag-retag-plan and retag-release', () => {
+      const needs = needsOf('images-ok')
+      for (const n of ['tag-retag-plan', 'retag-release']) {
+        expect(
+          needs,
+          `images-ok must \`needs: ${n}\`. It is the single required context for this ` +
+            `workflow; a job missing from the list can fail a release with nobody noticing.`,
+        ).toContain(n)
+      }
+    })
+
+    it('aggregates both results in its verdict loop', () => {
+      // Being in `needs` alone is not enough — images-ok's verdict is a
+      // hand-written loop over `needs.<job>.result` pairs, and a job in
+      // `needs` but absent from the loop is still masked.
+      const body = stepsOf('images-ok')
+        .map((s) => s.run ?? '')
+        .join('\n')
+      for (const n of ['tag-retag-plan', 'retag-release']) {
+        expect(
+          body,
+          `images-ok's verdict loop must inspect needs.${n}.result, not just list it in needs.`,
+        ).toContain(`needs.${n}.result`)
+      }
+    })
+  })
+
+  describe('pre-existing invariants this rework must not break', () => {
+    it('promote-to-dev still gates on build-hindsight (its hindsight leg retags :sha-<short>)', () => {
+      expect(needsOf('promote-to-dev')).toContain('build-hindsight')
+    })
+
+    it('retag-unchanged is still the main-push-only path', () => {
+      expect(jobRuns('retag-unchanged', mainPushCtx({ hindsight: 'false', voice: 'true' }))).toBe(
+        true,
+      )
+      expect(jobRuns('retag-unchanged', tagCtx({ hindsight: 'unchanged' }))).toBe(false)
+    })
+  })
+
+  describe('the workflow header describes reality', () => {
+    it('no longer claims the workflow is staged at docs/proposed/', () => {
+      // The file IS at .github/workflows/docker-images.yml; the staging
+      // instructions were completed long ago and misdirect any reader
+      // trying to work out where to edit it.
+      expect(raw).not.toContain('docs/proposed/docker-images.yml')
+    })
+  })
+})

--- a/tests/docker/manifest-jobs-no-buildx.test.ts
+++ b/tests/docker/manifest-jobs-no-buildx.test.ts
@@ -92,7 +92,9 @@ describe('manifest-only workflow jobs never set up buildx (no docker.io dependen
       'docker-images.yml:merge-dependents',
       'docker-images.yml:merge-hindsight',
       'docker-images.yml:promote-to-dev',
+      'docker-images.yml:retag-release',
       'docker-images.yml:retag-unchanged',
+      'docker-images.yml:tag-retag-plan',
       'promote.yml:promote',
     ])
   })


### PR DESCRIPTION
## Problem

At a release tag, `changes` (dorny/paths-filter) **cannot run** — a tag push has no diff base — so `docker-images.yml` rebuilt **every** image from scratch at every release, including images whose build inputs had not moved a byte since the previous release.

The main-push path already has this short-circuit (`retag-unchanged`, which re-points `:sha-<short>` at the existing `:latest` for path-skipped hindsight/voice). The **tag path had no equivalent**.

v0.20.20 is the motivating case: `switchroom-base`, `switchroom-hindsight` and `switchroom-voice` were byte-identical in per-platform content to v0.20.19 (only the attestation manifests differed), yet all three were fully rebuilt. Only `switchroom-agent` genuinely changed.

### ⚠️ One correction to that framing, from the repo

**This PR would NOT have short-circuited v0.20.20 itself.** `git diff --name-only v0.20.19..v0.20.20` is:

```
.github/workflows/docker-images.yml
CHANGELOG.md
tests/ci-merge-queue-triggers.test.ts
tests/docker/ci-build-dist-shared.test.ts
```

`.github/workflows/docker-images.yml` is a **declared input** of both the `hindsight` and the `voice` keys in `.github/path-filters.yml` (it is, correctly — the workflow determines the build invocation). So the plan verdict for v0.20.20 is `changed` for both, and both build. That is the fail-safe answer, and this PR deliberately does not narrow the filter to manufacture a `unchanged` verdict there — the whole soundness argument for `retag-unchanged` is "the filter key enumerates the image's FULL input set", and quietly deleting an entry from that set to win one release would break it.

Measured over the last 15 release intervals (v0.20.5 → v0.20.20), the images' *real* inputs (`docker/Dockerfile.{hindsight,voice}`, `docker/hindsight-*`, `docker/voice-sidecar/**`, `vendor/hindsight-memory/**`) were untouched in **5** intervals, of which **3** also had no workflow/filter change — so this fires on roughly **1 release in 5** as written, skipping the two heaviest images in the repo (voice is CUDA; hindsight is ~6.4GB) across two arches. Tightening the workflow-file input to "did the build job's own definition change" is a plausible follow-up, deliberately out of scope here.

## What it does

**`tag-retag-plan`** (new, tag-push only, manifest-only)
- Resolves the previous release tag reachable from this one: `git tag --list 'v*' --sort=-version:refname --merged $GITHUB_SHA`, minus the current tag. Needs `fetch-depth: 0`.
- Reads each image's full declared input set from its `.github/path-filters.yml` key with `yq` (single source of truth — no second copy of the path list to drift), and diffs the two release commits over exactly those git pathspecs.
- Verifies the previous release's manifest actually exists in GHCR (`imagetools inspect`), so `retag-release` provably has something to point at.
- Emits `hindsight` / `voice` / `prev_tag` outputs.

**`build-hindsight` / `build-voice`** — the **tag branch** of each gate is now *conjoined* with the plan verdict instead of being an unconditional `startsWith(github.ref, 'refs/tags/')`.

**`retag-release`** (new, inserted after `retag-unchanged`, manifest-only) — `docker buildx imagetools create -t $IMAGE:vX.Y.Z $IMAGE:$PREV_TAG`.

**`images-ok`** — both new jobs added to `needs:` **and** to its hand-written verdict loop (a job in `needs` but absent from the loop is still masked).

**Header** — dropped the long-completed `docs/proposed/docker-images.yml` staging instructions (that path does not exist in the repo), and corrected three now-wrong "tags always build" comments.

## Fail-safe reasoning

Publishing a **stale image under a release tag** is unrecoverable and unnoticeable. A redundant rebuild costs minutes. So the asymmetry is baked in structurally, not left to reviewer discipline:

1. Both verdicts **initialise to `changed`** and are only ever promoted by a positive proof. The plan runs `set -uo pipefail` **without `-e`** on purpose — every probe is allowed to fail, and a failure leaves the verdict at its default rather than reddening a release.
2. The gates test **`!= 'unchanged'`, not `== 'changed'`**. No previous tag, an unreadable/restructured filter file, a missing `yq`, a git error, a registry hiccup, or a skipped/failed/absent `tag-retag-plan` all surface as the **empty string** — which is not the literal `unchanged`, so the fallback is always BUILD. Inverting this to `== 'changed'` still behaves correctly on the happy path and silently ships stale images on every degraded one; that is why it has six dedicated tests.
3. `retag-release` additionally requires the image's build job to have **actually SKIPPED**. If it ran, it owns `:vX.Y.Z` and retagging the previous release over it would *regress* the release. Both conditions are re-checked **per image inside the step**, because the job-level `if:` is an OR across images.
4. The plan **anchors** the filter list it trusts: the key must still contain the image's own Dockerfile and `.github/path-filters.yml`, or the list is no longer the full input set and the verdict degrades to `changed`.
5. `imagetools create` in `retag-release` is a **hard** requirement (`set -euo pipefail`): the plan already verified the source manifest, so a failure there is real. A release tag with a missing image is worse than a red workflow.

Attestations: a retagged index carries the previous release's provenance/SBOM manifests. That is accurate rather than stale — those bits genuinely were produced by that build — and nothing on the pull side verifies image provenance today (`switchroom update` does no cosign/SLSA check). Noted in a comment so the constraint is visible if that ever changes.

## Constraints honoured

- **Manifest-only jobs never set up buildx.** Both new jobs run only `imagetools inspect|create` (pure registry ops) and reference neither `docker/setup-buildx-action` nor `./.github/actions/setup-buildx`. Added to the pinned allowlist in `tests/docker/manifest-jobs-no-buildx.test.ts` and asserted independently in the new test file.
- **`promote-to-dev`'s `build-hindsight` dependency is untouched** — its hindsight leg retags hindsight's `:sha-<short>`. Pinned by a regression test.
- `tests/ci-merge-queue-triggers.test.ts`: `retag-release` added to the pinned manifest-job list, and both new jobs carry `github.event_name == 'push'` so their `if:` is a positive event allowlist — that is the shape the merge-queue guard uses to prove a GHCR-login step is unreachable from a queue ref.

## Tests

`tests/docker/ci-tag-retag-unchanged.test.ts` — **35 tests**. They assert **outcomes, not shapes**: the file contains a small recursive-descent evaluator for the GitHub expression subset these gates use, and each job's `if:` is *parsed and evaluated* against simulated contexts (release tag / main push / dispatch / PR × plan verdict × build result). A test fails when the **decision** changes, not merely when the text does. An unparsable gate throws rather than passing vacuously.

```
 ✓ tests/docker/manifest-jobs-no-buildx.test.ts (4 tests)
 ✓ tests/release-pipeline-gating.test.ts (55 tests)
 ✓ tests/ci-buildx-warm-pull.test.ts (12 tests)
 ✓ tests/ci-merge-queue-triggers.test.ts (62 tests)
 ✓ tests/docker/ci-tag-retag-unchanged.test.ts (35 tests)

 Test Files  5 passed (5)
      Tests  168 passed (168)
```

Full `tests/docker/` suite: **42 passed | 3 skipped (45) files, 587 passed | 35 skipped (622) tests**. `tsc --noEmit` clean. `check-test-runner-coverage`, `check-agent-attribution-trailers`, `check-changelog-entry` all OK.

The plan and retag shell bodies were also **executed locally** against real repo history (with `yq` and `docker` shimmed), confirming: `v0.20.20` → `changed/changed`; `v0.20.9` → `unchanged/unchanged`; `v0.20.10` → `changed/unchanged`; previous-release image absent → `changed/changed`; `yq` missing → `changed/changed`; first-ever tag → `changed/changed`; and `retag-release` retagging only the correct image, warning (not overwriting) when a build ran, and exiting 1 on an empty `prev_tag`.

## Mutation results

Each mutation was applied to the workflow, the suite run, then reverted.

| # | Mutation | Result |
|---|---|---|
| **M1** | make the hindsight tag build unconditional (`startsWith(refs/tags/)` alone) | **FAIL** — 1 failed \| 34 passed. `build-hindsight does NOT build at a tag when the plan proved the image unchanged`: *expected true to be false* |
| **M2** | flip the voice gate polarity (`!= 'unchanged'` → `== 'changed'`) | **FAIL** — 6 failed \| 29 passed. All six `build-voice builds when …` fail-safe cases (no output / empty string / plan FAILED / plan SKIPPED / plan absent from needs / unrecognised verdict) |
| **M3** | drop `retag-release` from `images-ok`'s `needs:` | **FAIL** — 1 failed \| 34 passed. `images-ok … needs both tag-retag-plan and retag-release` |
| M4 *(bonus)* | drop the `build-hindsight.result == 'skipped'` guard from `retag-release` | **FAIL** — 1 failed \| 34 passed. `does NOT run when a build actually ran despite an 'unchanged' verdict` |
| M5 *(bonus)* | remove `fetch-depth: 0` from the plan checkout | **FAIL** — 1 failed \| 34 passed. `checks out full history — a shallow clone cannot resolve the previous release tag` |

Reverted state: **35 passed (35)**.

Note that M2 is the important one — flipping the polarity leaves the happy path *working*, so only the fail-safe cases catch it. That is exactly the bug class this PR is most exposed to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
