### PR TITLE
chore: release v0.20.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+## v0.20.21 — recall slot floors scale with the `max_memories` cap, and release tags retag unchanged images instead of rebuilding them
+
 ### Fixed: recall slot floors now scale with the `max_memories` cap (own/additional bank crowd-out)
 
 - **The per-turn recall slot floors that reserve a minimum for the agent's OWN


### PR DESCRIPTION
Cut v0.20.21 from the three commits that landed since v0.20.20:

- `5b6ea947` fix(recall): scale own/additional bank slot floors with `max_memories` cap (#4565)
- `d84159be` ci(docker-images): retag unchanged images at a release tag instead of rebuilding (#4567)
- `81030a8e` fix(docker): drop the 230.8MB duplicate chown layer from `Dockerfile.hindsight` (#4566)

All three staged their own `## Unreleased` sections as they merged, so this is the rename+tidy of `skills/switchroom-release/SKILL.md` step 1, not authorship: `## Unreleased` becomes `## v0.20.21 — <summary>`, inserted directly below the convention comment — the same anchor v0.20.20, v0.20.19 and v0.20.18 used (see `f444ea4a`, `552a2d21`, `7b49b13d`). The empty `## Unreleased` staging block (header + convention comment) stays in place for the next cycle. No entry text was edited; the diff is two added lines.

CHANGELOG-only. `package.json` version is deliberately untouched — the tag is the version source of truth (`scripts/build.mjs:resolveVersion()`), the manifest field is a placeholder and `npm-publish.yml` does the uncommitted pack-time bump.

Note: this is the first release tag since #4567, so it is the first live execution of the new `tag-retag-plan` / `retag-release` jobs in `docker-images.yml`.

[skip changelog]
