### PR TITLE
fix(hindsight): advance watermark on drain of reconcile slices

### DIFF
--- a/vendor/hindsight-memory/scripts/drain_pending.py
+++ b/vendor/hindsight-memory/scripts/drain_pending.py
@@ -171,6 +171,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+from lib import watermark
 from lib.client import HindsightClient
 from lib.config import debug_log, load_config
 from lib.pending import (
@@ -770,6 +771,72 @@ def _record_failure(
     return err_class
 
 
+def _reconcile_index(entries: list[tuple[str, dict]]) -> dict:
+    """``session_id -> set(abs_path)`` for reconcile-sourced queue entries.
+
+    Powers the no-loss sibling guard in ``_commit_reconcile_watermark``. Only
+    entries reconcile stamped (``reconcile_session_id``, switchroom #4571) are
+    indexed; everything else is ignored, so a non-reconcile queue entry for the
+    same session never blocks — its turns are covered by the reconcile slice's
+    own document, not by it.
+    """
+    idx: dict[str, set[str]] = {}
+    for path, entry in entries:
+        sid = entry.get("reconcile_session_id")
+        if sid:
+            idx.setdefault(sid, set()).add(os.path.abspath(path))
+    return idx
+
+
+def _commit_reconcile_watermark(entry: dict, path: str, index: dict) -> None:
+    """Advance the transcript watermark for a just-confirmed reconcile entry.
+
+    switchroom #4571. Called ONLY from a confirmed-durable retire branch — a
+    synchronous (``async_processing=False``) retain 200, or a presence GET that
+    returned True — so reaching here means this entry's content is durable. A
+    no-op for a non-reconcile entry (no ``reconcile_session_id``).
+
+    NO-LOSS GUARD. The watermark is a single "last contiguously-committed entry"
+    pointer, so it may only ever advance to the TRANSCRIPT TAIL, and only once
+    NO other slice of the same session is still queued:
+
+    * ``reconcile_is_tail`` False → an older turn-cap-split remainder that ends
+      mid-transcript; advancing to it would skip the newer turns after it.
+    * a live sibling in ``index`` → an unconfirmed earlier remainder OR a
+      size-split part of this same tail; advancing now could jump the watermark
+      past turns that are not yet durable.
+
+    Either way we leave the watermark and accept a redundant re-enqueue on the
+    next boot. ``watermark.commit`` is monotonic + idempotent and refuses
+    backward/compacted moves, so over-conservatism only ever costs repeat work,
+    never a lost turn — and that is the side to err on.
+    """
+    sid = entry.get("reconcile_session_id")
+    if not sid:
+        return
+    live = index.get(sid)
+    if live is not None:
+        # This entry is now durable + archived; drop it from the live set so a
+        # sibling that drains AFTER it is no longer blocked by it.
+        live.discard(os.path.abspath(path))
+    if not entry.get("reconcile_is_tail"):
+        return
+    last_uuid = entry.get("reconcile_last_uuid")
+    if not last_uuid:
+        return
+    if live:  # an earlier remainder / split part of this session is still queued
+        return
+    try:
+        watermark.commit(
+            sid,
+            last_uuid,
+            entry.get("document_id", ""),
+            ordered_uuids=entry.get("reconcile_ordered_uuids"),
+        )
+    except Exception:  # pragma: no cover - a watermark write must never fail a drain
+        pass
+
+
 def _new_summary() -> dict:
     return {
         "drained": 0,
@@ -892,7 +959,12 @@ def _drain_inhook_impl(config: dict, force: bool = False) -> dict:
     # behind them — see ``_drain_order``. Matters even more here than in the
     # backlog drain: the in-hook budget is ~4s, so a single entry at the head
     # that always burns its clamped timeout consumes the entire run.
-    entries = _park_broken(_drain_order(iter_entries()), summary, force)
+    all_entries = iter_entries()
+    # Built from the FULL queue (before parking): a parked reconcile entry is
+    # still queued and unconfirmed, so it must still block a sibling's watermark
+    # advance (#4571).
+    reconcile_index = _reconcile_index(all_entries)
+    entries = _park_broken(_drain_order(all_entries), summary, force)
     if not entries:
         debug_log(
             config,
@@ -938,6 +1010,7 @@ def _drain_inhook_impl(config: dict, force: bool = False) -> dict:
             if _document_state(entry, timeout=_clamp(timeout, budget, started)) is True:
                 if archive_reconciled(path):
                     summary["reconciled"] += 1
+                    _commit_reconcile_watermark(entry, path, reconcile_index)
                 else:
                     # Archive unwritable: the entry is STILL QUEUED (it is
                     # never deleted), so calling it reconciled would be a lie.
@@ -1003,6 +1076,7 @@ def _drain_inhook_impl(config: dict, force: bool = False) -> dict:
         # horizon costs.
         if archive_reconciled(path):
             summary["drained"] += 1
+            _commit_reconcile_watermark(entry, path, reconcile_index)
         else:
             summary["archive_failed"] += 1
         consecutive_failures = 0
@@ -1056,7 +1130,7 @@ def _phase_failed(summary: dict, phase: str, e: BaseException, cost: str) -> Non
     )
 
 
-def _reconcile_phase(config: dict, summary: dict, dry_run: bool) -> None:
+def _reconcile_phase(config: dict, summary: dict, dry_run: bool, reconcile_index: dict) -> None:
     """PHASE 1 — free pass: drop entries whose document already exists.
 
     This is the phase that makes backlog replay affordable. 70.4% of a
@@ -1082,8 +1156,11 @@ def _reconcile_phase(config: dict, summary: dict, dry_run: bool) -> None:
             continue
         state = _document_state(entry)
         if state is True:
-            if dry_run or archive_reconciled(path):
+            if dry_run:
                 summary["reconciled"] += 1
+            elif archive_reconciled(path):
+                summary["reconciled"] += 1
+                _commit_reconcile_watermark(entry, path, reconcile_index)
             else:
                 summary["archive_failed"] += 1
         elif state is None:
@@ -1264,8 +1341,14 @@ def _drain_backlog_impl(
                 f"archived, not deleted"
             )
 
+    # Built AFTER the pre-drain phases (collapse / re-split may have changed the
+    # queue) and shared across the reconcile pass and phase 2, so a sibling that
+    # phase 1 retires is dropped from the live set before phase 2 evaluates the
+    # tail's watermark advance (#4571).
+    reconcile_index = _reconcile_index(iter_entries())
+
     if phase in ("reconcile", "both"):
-        _reconcile_phase(config, summary, dry_run)
+        _reconcile_phase(config, summary, dry_run, reconcile_index)
     if phase == "reconcile":
         return summary
 
@@ -1356,6 +1439,7 @@ def _drain_backlog_impl(
                 if _document_state(entry) is True:
                     if archive_reconciled(path):
                         summary["drained"] += 1
+                        _commit_reconcile_watermark(entry, path, reconcile_index)
                     else:
                         summary["archive_failed"] += 1
                 else:

--- a/vendor/hindsight-memory/scripts/reconcile_tail.py
+++ b/vendor/hindsight-memory/scripts/reconcile_tail.py
@@ -127,6 +127,36 @@ def _session_id_from_path(path: str) -> str:
     return os.path.splitext(os.path.basename(path))[0]
 
 
+def _annotate_reconcile_payload(payload: dict, session_id: str, built: dict) -> dict:
+    """Stamp watermark-anchoring fields onto a QUEUED reconcile payload.
+
+    switchroom #4571 — the recurring ``pending-retains`` spike. A slice that
+    reconcile enqueues (over-budget / out-of-lookback) or defers (turn-cap
+    split) is later drained by ``drain_pending.py`` on a confirmed 200, but the
+    drain had no way to know WHICH session/uuid the entry anchored, so it never
+    advanced the transcript watermark for these paths. Reconcile's gap detection
+    is watermark-keyed, so on the next boot it re-derives the identical tail and
+    re-enqueues it — a false-alarm queue spike that recurs every boot (no memory
+    is lost: enqueue dedupe + the archive protect it, but the depth trips the
+    memory-queue watchdog). These fields let the drain advance the watermark once
+    the slice is confirmed durable, under the no-loss guard in
+    ``drain_pending._commit_reconcile_watermark``.
+
+    ``reconcile_is_tail`` is the load-bearing one: only a slice whose last uuid
+    is the TRANSCRIPT tail may ever anchor the watermark. An older remainder
+    (turn-cap split) ends mid-transcript, so advancing to it would skip the
+    newer turns that follow it.
+    """
+    ordered = built.get("ordered_uuids") or []
+    last_uuid = built.get("last_uuid")
+    tail_uuid = ordered[-1] if ordered else None
+    payload["reconcile_session_id"] = session_id
+    payload["reconcile_last_uuid"] = last_uuid
+    payload["reconcile_ordered_uuids"] = ordered
+    payload["reconcile_is_tail"] = bool(last_uuid) and last_uuid == tail_uuid
+    return payload
+
+
 def reconcile(config: dict | None = None, hook_input: dict | None = None) -> dict:
     """Diff watermarks vs transcript tails and recover un-committed work.
 
@@ -297,6 +327,11 @@ def _post_inline(
         return "skip"
     payload = built["payload"]
     document_id = built["document_id"]
+    # Stamp the watermark-anchoring fields so that IF this slice falls through
+    # to the pending queue (lock busy / POST failed) the drain can advance the
+    # watermark once it lands, instead of leaving reconcile to re-enqueue it
+    # every boot (switchroom #4571).
+    _annotate_reconcile_payload(payload, session_id, built)
 
     with inflight_lock(blocking=True) as acquired:
         if not acquired:  # pragma: no cover - blocking acquire fails open
@@ -350,6 +385,7 @@ def _enqueue_slice(config, session_id, path, all_messages, slice_messages, bank_
     )
     if built is None:
         return False
+    _annotate_reconcile_payload(built["payload"], session_id, built)
     queued = pending_enqueue(built["payload"], RuntimeError("reconcile deferred (bound/budget)"))
     if queued is None:
         debug_log(config, "reconcile_tail: pending-retains full, could not enqueue remainder")

--- a/vendor/hindsight-memory/scripts/tests/test_reconcile_durability.py
+++ b/vendor/hindsight-memory/scripts/tests/test_reconcile_durability.py
@@ -565,6 +565,119 @@ class TestObservationScopes(DurabilityTestBase):
         self.assertTrue(all(s is None for s in self.daemon.observation_scopes_seen))
 
 
+class TestDrainAdvancesWatermark(DurabilityTestBase):
+    """switchroom #4571 — the drain must advance the transcript watermark for a
+    reconcile-sourced slice it confirms durable, so reconcile stops re-deriving
+    and re-enqueueing the identical tail on every boot (the recurring
+    ``pending-retains`` spike). And it must NOT advance while an earlier sibling
+    of the same session is still queued (the no-loss guard).
+    """
+
+    # -- the fix: an enqueued tail, once drained, advances the watermark --------
+    def test_enqueued_tail_drained_advances_watermark_and_stops_reenqueue(self):
+        # This test FAILS on HEAD: the drain never commits the watermark for an
+        # enqueued reconcile slice, so `watermark.load` stays None after the
+        # drain and the second reconcile re-enqueues the same tail.
+        session = "drainA"
+        tpath = os.path.join(self.transcripts, f"{session}.jsonl")
+        _write_transcript(tpath, 3, session_prefix=session)
+        hook = {"session_id": session, "transcript_path": tpath, "cwd": "/x"}
+
+        # Force the out-of-lookback ENQUEUE path (no inline POST): lookback=0
+        # makes every transcript "too old", so reconcile enqueues the full tail
+        # and defers it to the drain — exactly the path that never committed.
+        with mock.patch.dict(os.environ, {"HINDSIGHT_RECONCILE_LOOKBACK_H": "0"}):
+            s1 = reconcile_tail.reconcile(self._config(), hook_input=hook)
+        self.assertEqual(s1["enqueued"], 1)
+        self.assertEqual(len(self._pending_entries()), 1)
+        # Nothing posted inline, so the watermark is still unset.
+        self.assertIsNone(watermark.load(session))
+
+        # Drain against a healthy daemon: the tail lands durably AND (the fix)
+        # the watermark advances to the transcript tail.
+        from drain_pending import drain
+        drain(self._config())
+        self.assertEqual(len(self._pending_entries()), 0)
+        wm = watermark.load(session)
+        self.assertIsNotNone(
+            wm,
+            "drain must advance the watermark for a confirmed-durable reconcile "
+            "tail (#4571) — without it, reconcile re-enqueues every boot",
+        )
+        self.assertEqual(wm["last_uuid"], f"{session}-a2")
+
+        # Second reconcile pass (still out of lookback) is now skipped_clean:
+        # the tail is watermarked, so it is NOT re-derived or re-enqueued.
+        with mock.patch.dict(os.environ, {"HINDSIGHT_RECONCILE_LOOKBACK_H": "0"}):
+            s2 = reconcile_tail.reconcile(self._config(), hook_input=hook)
+        self.assertEqual(s2["skipped_clean"], 1)
+        self.assertEqual(s2["enqueued"], 0)
+        self.assertEqual(len(self._pending_entries()), 0)
+
+    # -- the no-loss guard: an earlier sibling blocks the tail's advance --------
+    def test_tail_drain_does_not_advance_while_earlier_sibling_queued(self):
+        session = "drainB"
+        ordered = [
+            f"{session}-u0", f"{session}-a0", f"{session}-u1",
+            f"{session}-a1", f"{session}-u2", f"{session}-a2",
+        ]
+        older_doc = f"{session}-r{session}-u0-{session}-a1"
+        tail_doc = f"{session}-r{session}-u0-{session}-a2"
+
+        from lib import pending
+
+        def _payload(doc, content, last_uuid, is_tail):
+            return {
+                "api_url": "http://fake", "api_token": None, "bank_id": "test-bank",
+                "content": content, "document_id": doc, "context": "claude-code",
+                "metadata": {}, "tags": [], "observation_scopes": None,
+                "reconcile_session_id": session,
+                "reconcile_last_uuid": last_uuid,
+                "reconcile_ordered_uuids": ordered,
+                "reconcile_is_tail": is_tail,
+            }
+
+        # The earlier remainder (mid-transcript last_uuid) is enqueued FIRST so
+        # it sorts ahead of the tail in the oldest-first drain order.
+        pending.enqueue(
+            _payload(older_doc, "older remainder turns", f"{session}-a1", False),
+            RuntimeError("reconcile deferred"),
+        )
+        import time as _t
+        _t.sleep(0.002)
+        pending.enqueue(
+            _payload(tail_doc, "tail turns", f"{session}-a2", True),
+            RuntimeError("reconcile deferred"),
+        )
+        self.assertEqual(len(self._pending_entries()), 2)
+
+        # Upstream: the tail commits, but the earlier remainder still fails, so
+        # it stays queued through the whole drain run.
+        posted = []
+
+        def fake_retain(self_c, bank_id=None, content=None,
+                        document_id="conversation", **kw):
+            posted.append(document_id)
+            if document_id == older_doc:
+                raise RuntimeError("earlier remainder still failing upstream")
+            return {"ok": True}
+
+        from drain_pending import drain
+        with mock.patch.object(HindsightClient, "retain", fake_retain):
+            drain(self._config())
+
+        # The tail POST succeeded and its entry was retired ...
+        self.assertIn(tail_doc, posted)
+        remaining = [e["document_id"] for _p, e in self._pending_entries()]
+        self.assertNotIn(tail_doc, remaining)
+        # ... but the watermark did NOT advance: an earlier, still-unconfirmed
+        # sibling of the same session is queued, and advancing past it would
+        # risk silent loss of the remainder (#4571 no-loss guard).
+        self.assertIsNone(watermark.load(session))
+        # The earlier remainder is still queued (its POST failed).
+        self.assertIn(older_doc, remaining)
+
+
 def _stdin(obj):
     import io
     return io.StringIO(json.dumps(obj))


### PR DESCRIPTION
## Problem

The hindsight-memory client-side retain buffer re-enqueues the same transcript tail on **every container boot**, spiking the fleet `pending-retains/` buffer (hit **2292 on 2026-08-09**) and tripping the memory-queue watchdog. No memory is actually lost — enqueue dedupe and the reconciled archive protect it — but the depth is a recurring false alarm.

## Root cause (verified at HEAD)

`reconcile_tail.reconcile()` handles each transcript three ways. The healthy inline path calls `_post_inline(..., advance_watermark=True)` and the next boot is `skipped_clean`. But:

- the **over-budget / out-of-lookback** path (`_enqueue_slice`), and
- the **turn-cap split** path (advances watermark = `not did_split` = `False` by design)

both queue a slice to `pending-retains/` and `continue` **without committing the transcript watermark**.

`drain_pending.py` then drains those files on a confirmed sync 200 and archives them (`archive_reconciled`) but contained **zero `watermark.commit` calls**. So the per-session watermark (`lib/watermark.py`) never advanced for those sessions. Reconcile's gap detection is watermark-keyed and blind to pending/archive state, so it re-derives and re-enqueues the identical tail every boot. Enqueue dedupe (`lib/pending.py`, keyed on `(bank_id, part_position, sha256(content))`) only suppresses while the prior copy is still LIVE in `pending-retains/`; once drained+archived (moved out), the next boot re-enqueues fresh — which is why the spikes recur.

## Fix

`reconcile_tail` now stamps the watermark-anchoring fields onto **every payload it queues**: `reconcile_session_id`, `reconcile_last_uuid`, `reconcile_ordered_uuids`, `reconcile_is_tail`. The drain, at each confirmed-durable retire branch (in-hook reconcile-before-retry presence, in-hook POST 200, backlog phase 1 presence, backlog phase 2 confirmed), calls `watermark.commit(...)` for those entries via `_commit_reconcile_watermark`.

## No-loss guard (the hazard that must not regress)

The current code deliberately never advances on the split path to avoid dropping the older remainder of a multi-part session. The fix must not trade the false alarm for real memory loss. The rule enforced:

> Only commit the watermark for a drained slice whose `last_uuid` is the transcript **TAIL** **and** for which no other slice of the same session remains queued (an unconfirmed earlier remainder, or a size-split part). Otherwise leave the watermark and accept a redundant re-enqueue next boot.

`watermark.commit` is already monotonic + idempotent and refuses backward/compacted moves, so an over-conservative "don't advance yet" only ever costs repeat work, never loss — the side we bias to. Pre-existing queue entries (no `reconcile_*` fields) are a no-op for the new path, so the fleet heals forward with no behaviour change for legacy entries.

## Tests (`tests/test_reconcile_durability.py::TestDrainAdvancesWatermark`)

- `test_enqueued_tail_drained_advances_watermark_and_stops_reenqueue` — a session that took the enqueue path and then drained successfully has its watermark advanced, so a second reconcile pass yields `skipped_clean` with no re-enqueue. **Verified FAILS on HEAD** (`AssertionError: unexpectedly None`), passes with the fix.
- `test_tail_drain_does_not_advance_while_earlier_sibling_queued` — a session with an earlier sibling still queued does **not** advance the watermark (no-loss guard).

Full plugin suite green: `python3 -m unittest discover` → **1054 tests, OK**.

## Risk not fully closed

The `_reconcile_index` sibling scan is `O(N)` in-memory per confirmed reconcile-tail retire (built once per drain run from the loaded entries, not re-read from disk), so a first post-fix drain of a large backlog is `O(N²)` CPU but no extra disk I/O; trivial at realistic per-agent queue sizes and self-limiting as the spike drains down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)