### PR TITLE
fix(rollout): gate the roll on the host CLI, host-CLI-first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+### Bug fixes
+
+- **rollout: the host operator CLI is upgraded FIRST, and the roll refuses to
+  start until it is.** The v0.20.21 roll finished green while the host CLI sat
+  on 0.20.16 — five releases of drift. The one enumerative drift check was
+  measuring the wrong binary (the `cli (host)` row was built from the
+  *checking* process's version, so inside hostd it reported the container
+  image's CLI), and the only other signal was a trailing warning printed after
+  the fleet had already rolled, carrying advice (`sudo npm i -g switchroom@X`)
+  that is wrong for a user-owned npm prefix. Every host-context CLI invocation
+  now stamps `~/.switchroom/host-cli.json`, and `switchroom rollout` refuses
+  before the first mutation when the host CLI is behind the target, printing
+  the install command derived from the observed install.
+  `--allow-stale-host-cli` overrides (host shell only). An absent stamp or an
+  unorderable version never blocks. `switchroom doctor`'s `cli (host)` fix and
+  the rollout terminal card's host-side residual are derived from the same
+  stamp — and the card no longer lists the host CLI at all once it is
+  converged.
+
 ## v0.20.22 — recall budget default moves to `mid`, speaker-aware retain context, and fail-safe recall fact-type filtering
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,14 @@ now an anomaly worth investigating, not the norm.
   before the first mutation when the host CLI is behind the target, printing
   the install command derived from the observed install.
   `--allow-stale-host-cli` overrides (host shell only). An absent stamp or an
-  unorderable version never blocks. `switchroom doctor`'s `cli (host)` fix and
-  the rollout terminal card's host-side residual are derived from the same
-  stamp — and the card no longer lists the host CLI at all once it is
-  converged.
+  unorderable version never blocks. For an npm install the command spells out
+  `--prefix` from the recorded prefix, because npm resolves the global prefix
+  from the invoking user's npmrc — which under `sudo` is root's, not the tree
+  the drifted CLI actually lives in. `switchroom doctor`'s `cli (host)` fix,
+  the rollout terminal card's host-side residual, and the roll's own
+  component-drift warnings are all derived from the same stamp — and the card
+  drops the host CLI line only once the stamp *proves* it converged; an
+  unorderable version keeps the line with a confirm-host-side caveat.
 
 ## v0.20.22 — recall budget default moves to `mid`, speaker-aware retain context, and fail-safe recall fact-type filtering
 

--- a/docs/operators/host-cli-self-heal.md
+++ b/docs/operators/host-cli-self-heal.md
@@ -42,6 +42,40 @@ a cadence, so a behind host CLI is corrected within one interval.
 Deliberate container rolls stay the operator's explicit, un-skipped
 `switchroom update`. This unit's only job is keeping the **host binary** current.
 
+## This timer does NOT heal an `npm i -g` install (#4571)
+
+`self-update-cli` classifies the running CLI first and **returns early for
+anything that is not a `static-binary`** (`src/cli/update.ts`, the
+`detection.kind !== "static-binary"` branch). An `npm i -g switchroom` install —
+including the common nvm-prefix one — is therefore *never* swapped by this
+timer, no matter how often it ticks. It prints `host CLI not self-updated: …`
+and moves on.
+
+That is precisely how the reference host ended up on **0.20.16 while the fleet
+ran 0.20.21**: the host CLI lived in the operator's nvm tree, self-heal skipped
+it every tick, and the only other signal was a trailing rollout warning that
+scrolled past.
+
+Two mechanisms close it, and neither depends on anyone remembering to look:
+
+1. **The host CLI stamps itself.** Every host-context CLI invocation refreshes
+   `~/.switchroom/host-cli.json` with its version, install kind, npm prefix and
+   the uid/user owning the install tree (idempotent — an unchanged stamp is not
+   rewritten). That is the only path by which a container can observe the *host*
+   binary, because hostd mounts `~/.switchroom` and nothing else.
+2. **`switchroom rollout` refuses to roll past a stale host CLI.** The gate
+   reads the stamp before any agent restarts and stops with the exact install
+   command *derived from the stamp* — never a hardcoded `sudo npm i -g`, which
+   is wrong on a user-owned prefix. `--allow-stale-host-cli` overrides it and
+   says so loudly in the roll's warnings.
+
+An npm-installed host CLI is upgraded with `npm i -g switchroom@<version>` **as
+the user who owns the npm prefix**. Running that under `sudo` on a user-owned
+nvm tree either installs into root's prefix (so the operator's `switchroom`
+never moves) or leaves root-owned files in the operator's tree. `switchroom
+doctor`'s `cli (host)` row prints the correct command for the install it
+actually observed.
+
 ## Requirements
 
 - **systemd** on the host.

--- a/skills/switchroom-release/SKILL.md
+++ b/skills/switchroom-release/SKILL.md
@@ -125,7 +125,18 @@ The tag push triggers `docker-images` and `release`. `release` internally waits 
 ### Rehearsing a workflow change without releasing anything
 `gh workflow run release.yml --ref <branch>` — `dry_run` defaults to `true`, so it builds, checksums and verifies the full bundle and attaches it as a workflow artifact, touching no GitHub Release, no npm, and no image tags. This is the only supported way to prove a change to the release pipeline before a real tag.
 
-## Step 4 — Fleet rollout (operator-gated, canary-first)
+## Step 4 — HOST OPERATOR CLI FIRST (#4571)
+
+**The host CLI is upgraded BEFORE the fleet, not after.** It is what runs `switchroom apply`, `vault`, `doctor` and the *next* roll host-side, so a host CLI left behind means every later host-shell command runs retired code. Treating it as a trailing chore is how it silently drifted to **0.20.16 while the fleet ran 0.20.21** — five releases, with every roll exiting green.
+
+This is now **enforced, not advised**: `switchroom rollout` reads `~/.switchroom/host-cli.json` (the stamp every host-context CLI invocation refreshes) and **refuses to start** when the host CLI is observably older than the target — before a single agent restarts. The refusal names the exact install command, derived from how the host CLI was *actually* installed.
+
+- Ask the operator to run the upgrade on the host **before** you fire the roll. Do not hand them `sudo npm i -g switchroom@X` from memory: that is wrong on a user-owned nvm prefix (it installs into a different tree, or root-poisons this one). Take the command from `switchroom doctor`'s `cli (host)` fix line or from the rollout refusal text — both derive it from the stamp.
+- Confirm it landed: `switchroom --version` on the host shell reports the target. Any host-context switchroom command also refreshes the stamp, so the gate sees the new version immediately.
+- `--allow-stale-host-cli` is the escape hatch and must be a deliberate, stated decision — it leaves the host CLI drifted and says so loudly in the roll's warnings.
+- A host CLI predating this feature writes no stamp. The gate then does not block (it cannot know), and the roll's terminal card says so instead of claiming convergence. Confirm host-side.
+
+## Step 5 — Fleet rollout (operator-gated, canary-first)
 
 - Fire the rollout via the hostd rollout path (`mcp__hostd__rollout`), which pops an **approval card**. Do NOT roll without the operator tapping approve.
 - Canary discipline: roll the release-critical canary agent first (the test-harness agent, per CLAUDE.md > Release canary discipline), monitor its logs + a smoke check, then stagger the rest per-agent with a `--version` assertion each (guards the `:latest` pull-race).

--- a/src/cli/component-scope.ts
+++ b/src/cli/component-scope.ts
@@ -43,6 +43,7 @@
  */
 
 import type { ComponentVersion } from "./component-versions.js";
+import { hostCliInstallCommand, type HostCliStamp } from "./host-cli-stamp.js";
 
 /**
  * The mechanism that converges a component onto the release target.
@@ -142,11 +143,22 @@ export function classifyComponent(c: ComponentVersion): ComponentOwner {
  * Shared by the doctor row's `fix:` and the rollout drift gate's failure
  * text so an operator is never given two different answers for the same
  * drifted component.
+ *
+ * `hostCli` (#4571) is the host CLI's own record of how it was installed. When
+ * present, the `cli` remediation is derived from it instead of assuming the
+ * self-updatable static binary: `switchroom update` is a no-op on an npm
+ * install, and `sudo npm i -g` is actively wrong on a user-owned nvm prefix.
  */
-export function remediationFor(owner: ComponentOwner, target: string): string {
+export function remediationFor(
+  owner: ComponentOwner,
+  target: string,
+  hostCli?: HostCliStamp,
+): string {
   switch (owner.kind) {
     case "cli":
-      return `switchroom update  (self-updates the host CLI to ${target} first, then everything else)`;
+      return hostCli
+        ? `${hostCliInstallCommand(hostCli, target)}  (upgrade the host CLI FIRST — everything else is driven by it)`
+        : `switchroom update  (self-updates the host CLI to ${target} first, then everything else)`;
     case "web":
       return `switchroom webd install --tag ${target}  (separate compose project — regenerates + recreates switchroom-web)`;
     case "hostd":

--- a/src/cli/component-versions.ts
+++ b/src/cli/component-versions.ts
@@ -256,25 +256,76 @@ export function detectComponentDrift(
 }
 
 /**
+ * What is known about the HOST operator CLI when the inventory is taken from
+ * inside a container.
+ *
+ * `observedVersion` is what the host CLI recorded about itself in
+ * `~/.switchroom/host-cli.json` (`host-cli-stamp.ts`) — the only way a
+ * container can learn it, since hostd mounts `~/.switchroom` and nothing else.
+ */
+export interface HostCliObservation {
+  /** True when the process taking the inventory runs inside a container. */
+  inContainer: boolean;
+  /** Semver from the stamp (`v`-prefixed or bare), when one exists. */
+  observedVersion?: string;
+}
+
+/**
+ * The `cli (host)` row. Pure, so the honesty rule is unit-asserted (#4571).
+ *
+ * On the host shell the running process IS the host CLI, so its own version
+ * is authoritative. Inside a container it is NOT: `SWITCHROOM_VERSION` there
+ * is the hostd/agent IMAGE's bundled CLI, and reporting that as `cli (host)`
+ * is what let the real host binary drift five releases behind the fleet while
+ * every check said the host CLI was fine. In a container the STAMPED version
+ * wins; with no stamp the row is `unknown` — reported, never guessed.
+ */
+export function hostCliComponent(
+  cliVersion: string,
+  observation: HostCliObservation = { inContainer: false },
+): ComponentVersion {
+  if (observation.inContainer) {
+    const stamped = normalizeSemverTag(observation.observedVersion);
+    if (stamped) {
+      return {
+        name: "cli (host)",
+        kind: "cli",
+        version: stamped,
+        detail: "observed via the host CLI stamp (~/.switchroom/host-cli.json)",
+      };
+    }
+    return {
+      name: "cli (host)",
+      kind: "cli",
+      version: null,
+      detail:
+        "not observable from inside a container and no host-cli.json stamp " +
+        "found — run any switchroom command on the host to record it",
+    };
+  }
+  const version = normalizeSemverTag(cliVersion);
+  return {
+    name: "cli (host)",
+    kind: "cli",
+    version,
+    ...(version ? {} : { detail: `unparseable CLI version "${cliVersion}"` }),
+  };
+}
+
+/**
  * Collect the full inventory: the host CLI plus every running container.
  *
  * `cliVersion` is the running CLI's own version (`SWITCHROOM_VERSION`).
  * It is passed in rather than imported so the caller controls the seam
- * and tests stay hermetic.
+ * and tests stay hermetic. `observation` decides whether that version can
+ * honestly stand in for the HOST CLI — see {@link hostCliComponent}.
  */
 export function collectComponents(
   cliVersion: string,
   exec: ExecFn,
+  observation: HostCliObservation = { inContainer: false },
 ): ComponentVersion[] {
-  const cli: ComponentVersion = {
-    name: "cli (host)",
-    kind: "cli",
-    version: normalizeSemverTag(cliVersion),
-    ...(normalizeSemverTag(cliVersion)
-      ? {}
-      : { detail: `unparseable CLI version "${cliVersion}"` }),
-  };
-  return [cli, ...collectContainerComponents(exec)];
+  return [hostCliComponent(cliVersion, observation), ...collectContainerComponents(exec)];
 }
 
 /**

--- a/src/cli/doctor-component-versions.test.ts
+++ b/src/cli/doctor-component-versions.test.ts
@@ -158,7 +158,9 @@ describe("doctor: the host CLI row must never report the CONTAINER's version", (
     // …and the remediation is derived from how the host is ACTUALLY installed:
     // a user-owned npm prefix, so neither `switchroom update` (a no-op on an
     // npm install) nor `sudo npm i -g` (wrong tree) is correct.
-    expect(hostCli?.fix).toContain("npm i -g switchroom@0.19.28");
+    expect(hostCli?.fix).toContain(
+      "npm i -g --prefix /home/op/.nvm/versions/node/v22 switchroom@0.19.28",
+    );
     expect(hostCli?.fix).toContain("run as op");
     expect(hostCli?.fix).not.toMatch(/(^|[;&|]\s*)sudo\s/);
   });

--- a/src/cli/doctor-component-versions.test.ts
+++ b/src/cli/doctor-component-versions.test.ts
@@ -12,6 +12,15 @@ const ps = (lines: string[]): ExecFn => () => ({
   stdout: lines.join("\n"),
 });
 
+/**
+ * The default seams for the host-shell case: the process running the check IS
+ * the host CLI (so `cliVersion` drives the `cli (host)` row), and no install
+ * stamp exists. Both are pinned EXPLICITLY rather than left to production
+ * detection, which reads `/.dockerenv` and the real switchroom home — a test
+ * that inherited those would pass or fail depending on where it ran.
+ */
+const HOST_SHELL = { hostCli: { inContainer: false }, hostCliStamp: null } as const;
+
 const REFERENCE_HOST = [
   "switchroom-hostd\tghcr.io/switchroom/switchroom-hostd:v0.19.28",
   "switchroom-hindsight-autoheal\tghcr.io/switchroom/switchroom-hostd:v0.19.26",
@@ -24,6 +33,7 @@ describe("doctor: component versions (#3919)", () => {
     const rows = runComponentVersionChecks(config("v0.19.28"), {
       exec: ps(REFERENCE_HOST),
       cliVersion: "0.19.23",
+      ...HOST_SHELL,
     });
     const warns = rows.filter((r) => r.status === "warn");
     // Containers that lag are warn-only (they can trail legitimately
@@ -49,6 +59,7 @@ describe("doctor: component versions (#3919)", () => {
     const rows = runComponentVersionChecks(config("v0.19.28"), {
       exec: ps(REFERENCE_HOST),
       cliVersion: "0.19.23",
+      ...HOST_SHELL,
     });
     const hostCli = rows.find((r) => r.name === "component behind: cli (host)");
     expect(hostCli?.status).toBe("fail");
@@ -62,6 +73,7 @@ describe("doctor: component versions (#3919)", () => {
     const rows = runComponentVersionChecks(config("v0.19.28"), {
       exec: ps(REFERENCE_HOST),
       cliVersion: "0.19.28",
+      ...HOST_SHELL,
     });
     expect(rows.some((r) => r.status === "fail")).toBe(false);
     // The lagging containers are still surfaced, as warnings.
@@ -72,6 +84,7 @@ describe("doctor: component versions (#3919)", () => {
     const rows = runComponentVersionChecks(config("v0.19.28"), {
       exec: ps(REFERENCE_HOST.map((l) => l.replace("v0.19.26", "v0.19.28"))),
       cliVersion: "0.19.28",
+      ...HOST_SHELL,
     });
     expect(rows.filter((r) => r.status === "warn")).toEqual([]);
     expect(rows[0].status).toBe("ok");
@@ -81,6 +94,7 @@ describe("doctor: component versions (#3919)", () => {
     const rows = runComponentVersionChecks(config(), {
       exec: () => ({ status: 1, stdout: "" }),
       cliVersion: "not-a-version",
+      ...HOST_SHELL,
     });
     expect(rows).toHaveLength(1);
     expect(rows[0].status).toBe("skip");
@@ -90,6 +104,7 @@ describe("doctor: component versions (#3919)", () => {
     const rows = runComponentVersionChecks(config("v0.19.26"), {
       exec: ps(REFERENCE_HOST),
       cliVersion: "0.19.26",
+      ...HOST_SHELL,
     });
     const ahead = rows.filter((r) => r.name.startsWith("component ahead:"));
     expect(ahead.map((r) => r.name).sort()).toEqual([
@@ -105,9 +120,62 @@ describe("doctor: component versions (#3919)", () => {
     const rows = runComponentVersionChecks(config("v0.19.26"), {
       exec: ps(REFERENCE_HOST.map((l) => l.replace(/v0\.19\.2[68]/g, "v0.19.26"))),
       cliVersion: "0.19.28",
+      ...HOST_SHELL,
     });
     const hostCli = rows.find((r) => r.name.includes("cli (host)"));
     expect(hostCli?.status).not.toBe("fail");
     expect(rows.some((r) => r.status === "fail")).toBe(false);
+  });
+});
+
+/**
+ * #4571 — the reason the silent drift survived five releases. From inside a
+ * container the running CLI is the CONTAINER's CLI, but the inventory reported
+ * it under the `cli (host)` label, so the one enumerative check that should
+ * have caught a stale host binary was measuring the wrong binary and always
+ * agreed with the target.
+ */
+describe("doctor: the host CLI row must never report the CONTAINER's version", () => {
+  it("uses the STAMPED host version, not the container's, when a stamp exists", () => {
+    const rows = runComponentVersionChecks(config("v0.19.28"), {
+      exec: ps(REFERENCE_HOST),
+      // The container CLI is on target — the pre-fix code reported this and
+      // called the host converged.
+      cliVersion: "0.19.28",
+      hostCli: { inContainer: true, observedVersion: "0.19.23" },
+      hostCliStamp: {
+        version: "0.19.23",
+        installKind: "npm-global",
+        path: "/home/op/.nvm/versions/node/v22/lib/node_modules/switchroom/dist/cli/switchroom.js",
+        npmPrefix: "/home/op/.nvm/versions/node/v22",
+        ownerUid: 1000,
+        ownerUser: "op",
+      },
+    });
+    const hostCli = rows.find((r) => r.name === "component behind: cli (host)");
+    expect(hostCli?.status).toBe("fail");
+    expect(hostCli?.detail).toContain("0.19.23");
+    // …and the remediation is derived from how the host is ACTUALLY installed:
+    // a user-owned npm prefix, so neither `switchroom update` (a no-op on an
+    // npm install) nor `sudo npm i -g` (wrong tree) is correct.
+    expect(hostCli?.fix).toContain("npm i -g switchroom@0.19.28");
+    expect(hostCli?.fix).toContain("run as op");
+    expect(hostCli?.fix).not.toMatch(/(^|[;&|]\s*)sudo\s/);
+  });
+
+  it("reports the host CLI as UNKNOWN in a container with no stamp, never as converged", () => {
+    const rows = runComponentVersionChecks(config("v0.19.28"), {
+      exec: ps(REFERENCE_HOST),
+      cliVersion: "0.19.28",
+      hostCli: { inContainer: true },
+      hostCliStamp: null,
+    });
+    // Not a behind row, not an ok row silently claiming the host is on target:
+    // an explicit "not observable from here".
+    expect(rows.some((r) => r.name.includes("cli (host)") && r.status !== "skip")).toBe(
+      false,
+    );
+    const unknown = rows.find((r) => r.name === "component version unknown: cli (host)");
+    expect(unknown?.status).toBe("skip");
   });
 });

--- a/src/cli/doctor-component-versions.ts
+++ b/src/cli/doctor-component-versions.ts
@@ -31,7 +31,6 @@
  */
 
 import { spawnSync } from "node:child_process";
-
 import type { SwitchroomConfig } from "../config/schema.js";
 import type { CheckResult } from "./doctor.js";
 import { SWITCHROOM_VERSION } from "./resolve-version.js";
@@ -40,14 +39,33 @@ import {
   detectComponentDrift,
   type ComponentVersion,
   type ExecFn,
+  type HostCliObservation,
 } from "./component-versions.js";
 import { classifyComponent, remediationFor } from "./component-scope.js";
+import {
+  observeHostCli,
+  readHostCliStamp,
+  type HostCliStamp,
+} from "./host-cli-stamp.js";
 
 export interface ComponentVersionCheckOpts {
   /** Test seam — replace the `docker ps` shellout. */
   exec?: ExecFn;
   /** Test seam — override the running CLI's version. */
   cliVersion?: string;
+  /**
+   * Test seam — what is known about the HOST CLI. Production derives it:
+   * in a container the running CLI is NOT the host CLI, so the stamp is
+   * consulted instead of `SWITCHROOM_VERSION` (#4571).
+   */
+  hostCli?: HostCliObservation;
+  /**
+   * Test seam — the host CLI's install record, used to render the `cli` row's
+   * `fix:`. `undefined` reads the real stamp (production); `null` means
+   * "explicitly no stamp", which is how a test pins the generic remediation
+   * without depending on whether the machine running it has one.
+   */
+  hostCliStamp?: HostCliStamp | null;
 }
 
 const defaultExec: ExecFn = (cmd, args) => {
@@ -64,8 +82,12 @@ const defaultExec: ExecFn = (cmd, args) => {
  * the duplication that let `switchroom-hindsight-autoheal` sit outside
  * the roll's scope while doctor knew perfectly well how to fix it.
  */
-function fixFor(c: ComponentVersion, target: string): string {
-  return remediationFor(classifyComponent(c), target);
+function fixFor(
+  c: ComponentVersion,
+  target: string,
+  hostCli: HostCliStamp | undefined,
+): string {
+  return remediationFor(classifyComponent(c), target, hostCli);
 }
 
 /**
@@ -85,7 +107,16 @@ export function runComponentVersionChecks(
   opts: ComponentVersionCheckOpts = {},
 ): CheckResult[] {
   const exec = opts.exec ?? defaultExec;
-  const components = collectComponents(opts.cliVersion ?? SWITCHROOM_VERSION, exec);
+  // `null` is the explicit "no stamp" seam; `undefined` means "read the real one".
+  const hostCliStamp =
+    opts.hostCliStamp === undefined
+      ? readHostCliStamp()
+      : (opts.hostCliStamp ?? undefined);
+  const components = collectComponents(
+    opts.cliVersion ?? SWITCHROOM_VERSION,
+    exec,
+    opts.hostCli ?? observeHostCli(),
+  );
   const report = detectComponentDrift(components, config.release?.pin);
 
   if (!report.target) {
@@ -119,9 +150,15 @@ export function runComponentVersionChecks(
       status,
       detail:
         status === "fail"
-          ? `on ${c.version}, expected ${report.target} (${src}) — the host CLI must never trail the fleet; it self-heals in-band via \`switchroom update\``
+          ? // #4571 — this used to promise "self-heals in-band via `switchroom
+            // update`". That is false for an `npm i -g` install:
+            // `self-update-cli` returns early for anything that is not a
+            // static binary, so the self-heal timer skipped this host's CLI
+            // every tick while it drifted five releases. The `fix:` below
+            // carries the command derived from the actual install.
+            `on ${c.version}, expected ${report.target} (${src}) — the host CLI must never trail the fleet: it drives \`apply\`, \`vault\`, \`doctor\` and the next roll`
           : `on ${c.version}, expected ${report.target} (${src})`,
-      fix: fixFor(c, report.target),
+      fix: fixFor(c, report.target, hostCliStamp),
     });
   }
   for (const c of report.ahead) {

--- a/src/cli/host-cli-stamp.test.ts
+++ b/src/cli/host-cli-stamp.test.ts
@@ -1,0 +1,393 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  HOST_CLI_STAMP_FILENAME,
+  buildHostCliStamp,
+  hostCliInstallCommand,
+  hostCliInstallShellCommand,
+  npmPackageRoot,
+  npmPrefixFromScriptPath,
+  readHostCliStamp,
+  refreshHostCliStamp,
+  resolveStampDir,
+  shouldRefuseStaleHostCli,
+  stampHomeCandidates,
+  type HostCliStamp,
+} from "./host-cli-stamp.js";
+
+/**
+ * Scope every existence probe to `<tmpdir>` so the resolver can never fall
+ * through to the real `/host-home/.switchroom` (which is a REAL operator home
+ * on a switchroom host, and a test that writes there corrupts a running
+ * fleet). Not defensive dressing: without it, `resolveStampDir`'s
+ * container-mount fallback resolved to the live home on the first run of this
+ * suite.
+ */
+function scopedIo(home: string) {
+  const root = tmpdir();
+  return {
+    env: {} as NodeJS.ProcessEnv,
+    home,
+    exists: (p: string) => p.startsWith(root) && existsSync(p),
+  };
+}
+
+/** A tmp switchroom home (`<tmp>/.switchroom/switchroom.yaml`). */
+function makeHome(): { home: string; dir: string } {
+  const home = mkdtempSync(join(tmpdir(), "host-cli-stamp-"));
+  const dir = join(home, ".switchroom");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "switchroom.yaml"), "switchroom:\n  version: 1\n", "utf8");
+  return { home, dir };
+}
+
+/** The reference host's shape: nvm prefix, operator-owned, NOT root. */
+const NVM_SCRIPT =
+  "/home/op/.nvm/versions/node/v22.22.2/lib/node_modules/switchroom/dist/cli/switchroom.js";
+
+describe("npm prefix + package root derivation", () => {
+  it("derives the npm prefix from an nvm-installed entrypoint", () => {
+    expect(npmPrefixFromScriptPath(NVM_SCRIPT)).toBe(
+      "/home/op/.nvm/versions/node/v22.22.2",
+    );
+    expect(npmPackageRoot(NVM_SCRIPT)).toBe(
+      "/home/op/.nvm/versions/node/v22.22.2/lib/node_modules/switchroom",
+    );
+  });
+
+  it("derives the prefix from a root /usr/local npm install too", () => {
+    const p = "/usr/local/lib/node_modules/switchroom/dist/cli/switchroom.js";
+    expect(npmPrefixFromScriptPath(p)).toBe("/usr/local");
+  });
+
+  it("returns undefined rather than inventing a prefix for a non-npm path", () => {
+    expect(npmPrefixFromScriptPath("/usr/local/bin/switchroom")).toBeUndefined();
+    expect(npmPackageRoot("/usr/local/bin/switchroom")).toBeUndefined();
+  });
+});
+
+describe("buildHostCliStamp", () => {
+  it("records kind, prefix and OWNER for a user-prefix npm install", () => {
+    const stamp = buildHostCliStamp(
+      {
+        version: "0.20.21",
+        execPath: "/usr/bin/node",
+        scriptPath: NVM_SCRIPT,
+        bundleDir: "/home/op/.nvm/versions/node/v22.22.2/lib/node_modules/switchroom/dist/cli",
+        inContainer: false,
+      },
+      { statUid: () => 1000, userForUid: () => "op" },
+    );
+    expect(stamp).toEqual({
+      version: "0.20.21",
+      installKind: "npm-global",
+      path: NVM_SCRIPT,
+      npmPrefix: "/home/op/.nvm/versions/node/v22.22.2",
+      ownerUid: 1000,
+      ownerUser: "op",
+    } satisfies HostCliStamp);
+  });
+
+  it("records the static-binary path for a compiled install", () => {
+    const stamp = buildHostCliStamp(
+      {
+        version: "v0.20.21",
+        execPath: "/usr/local/bin/switchroom",
+        scriptPath: "/$bunfs/root/switchroom",
+        bundleDir: "/$bunfs/root",
+        inContainer: false,
+      },
+      { statUid: () => 0, userForUid: () => "root" },
+    );
+    expect(stamp?.installKind).toBe("static-binary");
+    expect(stamp?.path).toBe("/usr/local/bin/switchroom");
+    // The leading `v` is stripped so the stored value is a bare semver.
+    expect(stamp?.version).toBe("0.20.21");
+  });
+
+  it("refuses to stamp from inside a container — a container CLI is not the host CLI", () => {
+    expect(
+      buildHostCliStamp({
+        version: "0.20.21",
+        execPath: "/usr/bin/node",
+        scriptPath: "/opt/switchroom/dist/cli/switchroom.js",
+        bundleDir: "/opt/switchroom/dist/cli",
+        inContainer: true,
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("refreshHostCliStamp / readHostCliStamp", () => {
+  it("writes the stamp into the switchroom home and reads it back", () => {
+    const { home, dir } = makeHome();
+    const io = { ...scopedIo(home), statUid: () => 1000, userForUid: () => "op" };
+    const first = refreshHostCliStamp(
+      {
+        version: "0.20.21",
+        execPath: "/usr/bin/node",
+        scriptPath: NVM_SCRIPT,
+        bundleDir: "/x",
+        inContainer: false,
+      },
+      io,
+    );
+    expect(first.status).toBe("written");
+    expect(existsSync(join(dir, HOST_CLI_STAMP_FILENAME))).toBe(true);
+
+    const read = readHostCliStamp(io);
+    expect(read?.version).toBe("0.20.21");
+    expect(read?.installKind).toBe("npm-global");
+    expect(read?.ownerUser).toBe("op");
+  });
+
+  it("is a byte-identical no-op on re-run (idempotent, so it can run on every invocation)", () => {
+    const { home, dir } = makeHome();
+    const io = { ...scopedIo(home), statUid: () => 1000, userForUid: () => "op" };
+    const input = {
+      version: "0.20.21",
+      execPath: "/usr/bin/node",
+      scriptPath: NVM_SCRIPT,
+      bundleDir: "/x",
+      inContainer: false,
+    };
+    refreshHostCliStamp(input, io);
+    const before = readFileSync(join(dir, HOST_CLI_STAMP_FILENAME), "utf8");
+    expect(refreshHostCliStamp(input, io).status).toBe("unchanged");
+    expect(readFileSync(join(dir, HOST_CLI_STAMP_FILENAME), "utf8")).toBe(before);
+  });
+
+  it("skips (never throws) when there is no switchroom home to stamp", () => {
+    const empty = mkdtempSync(join(tmpdir(), "host-cli-nohome-"));
+    const res = refreshHostCliStamp(
+      {
+        version: "0.20.21",
+        execPath: "/usr/bin/node",
+        scriptPath: NVM_SCRIPT,
+        bundleDir: "/x",
+        inContainer: false,
+      },
+      scopedIo(empty),
+    );
+    expect(res.status).toBe("skipped");
+    expect(readHostCliStamp(scopedIo(empty))).toBeUndefined();
+  });
+
+  it("hands a root-written stamp back to the switchroom home's owner", () => {
+    // A `sudo switchroom …` run would otherwise leave a root-owned stamp in a
+    // uid-1000 home; every later unprivileged run's tmp+rename then EACCESes
+    // and the stamp freezes — re-opening the silent-drift hole from the inside.
+    const { home } = makeHome();
+    const chowns: Array<[string, number, number]> = [];
+    refreshHostCliStamp(
+      {
+        version: "0.20.21",
+        execPath: "/usr/bin/node",
+        scriptPath: NVM_SCRIPT,
+        bundleDir: "/x",
+        inContainer: false,
+      },
+      {
+        ...scopedIo(home),
+        statUid: () => 1000,
+        userForUid: () => "op",
+        getuid: () => 0,
+        statOwner: () => ({ uid: 1000, gid: 1000 }),
+        chown: (p, uid, gid) => chowns.push([p, uid, gid]),
+      },
+    );
+    expect(chowns).toEqual([[join(home, ".switchroom", HOST_CLI_STAMP_FILENAME), 1000, 1000]]);
+  });
+
+  it("does not chown when the writer is not root, or when the home is root's own", () => {
+    const { home } = makeHome();
+    const input = {
+      version: "0.20.21",
+      execPath: "/usr/bin/node",
+      scriptPath: NVM_SCRIPT,
+      bundleDir: "/x",
+      inContainer: false,
+    };
+    const chowns: string[] = [];
+    const io = {
+      ...scopedIo(home),
+      statUid: () => 1000,
+      userForUid: () => "op",
+      chown: (p: string) => chowns.push(p),
+    };
+    refreshHostCliStamp(input, { ...io, getuid: () => 1000 });
+    // A genuinely root-owned home needs no handoff.
+    const { home: rootHome } = makeHome();
+    refreshHostCliStamp(input, {
+      ...io,
+      ...scopedIo(rootHome),
+      chown: (p: string) => chowns.push(p),
+      getuid: () => 0,
+      statOwner: () => ({ uid: 0, gid: 0 }),
+    });
+    expect(chowns).toEqual([]);
+  });
+
+  it("returns undefined for a malformed stamp instead of throwing", () => {
+    const { home, dir } = makeHome();
+    writeFileSync(join(dir, HOST_CLI_STAMP_FILENAME), "{not json", "utf8");
+    expect(readHostCliStamp(scopedIo(home))).toBeUndefined();
+  });
+
+  it("prefers SWITCHROOM_HOST_HOME, then the sudo user's home, over the process home", () => {
+    expect(
+      stampHomeCandidates(
+        { SWITCHROOM_HOST_HOME: "/host-h", SUDO_USER: "op" } as NodeJS.ProcessEnv,
+        "/root",
+        () => "/home/op",
+      ),
+    ).toEqual([
+      "/host-h/.switchroom",
+      "/home/op/.switchroom",
+      "/root/.switchroom",
+      "/host-home/.switchroom",
+    ]);
+  });
+
+  it("resolves the container mount point when only /host-home has a switchroom.yaml", () => {
+    const { home } = makeHome();
+    // Simulate the container: process home has no config, SWITCHROOM_HOST_HOME does.
+    const bare = mkdtempSync(join(tmpdir(), "host-cli-container-"));
+    expect(
+      resolveStampDir({
+        ...scopedIo(bare),
+        env: { SWITCHROOM_HOST_HOME: home } as NodeJS.ProcessEnv,
+      }),
+    ).toBe(join(home, ".switchroom"));
+  });
+});
+
+describe("hostCliInstallCommand — the command must match how the host is ACTUALLY installed", () => {
+  const target = "v0.20.21";
+
+  it("does NOT say sudo for a user-owned npm prefix, and names the user + prefix", () => {
+    const cmd = hostCliInstallCommand(
+      {
+        version: "0.20.16",
+        installKind: "npm-global",
+        path: NVM_SCRIPT,
+        npmPrefix: "/home/op/.nvm/versions/node/v22.22.2",
+        ownerUid: 1000,
+        ownerUser: "op",
+      },
+      target,
+    );
+    expect(cmd).toContain("npm i -g switchroom@0.20.21");
+    // The literal command must not be a sudo invocation. (It DOES contain the
+    // word "sudo" inside the explicit "NOT under sudo" caution — that caution
+    // is the point of this test, so match the invocation shape, not the word.)
+    expect(cmd).not.toMatch(/(^|[;&|]\s*)sudo\s/);
+    expect(cmd).toContain("run as op");
+    expect(cmd).toContain("/home/op/.nvm/versions/node/v22.22.2");
+  });
+
+  it("DOES say sudo when the npm tree really is root-owned", () => {
+    const cmd = hostCliInstallCommand(
+      {
+        version: "0.20.16",
+        installKind: "npm-global",
+        path: "/usr/local/lib/node_modules/switchroom/dist/cli/switchroom.js",
+        npmPrefix: "/usr/local",
+        ownerUid: 0,
+        ownerUser: "root",
+      },
+      target,
+    );
+    expect(cmd).toBe("sudo npm i -g switchroom@0.20.21 (npm prefix /usr/local)");
+  });
+
+  it("points a static-binary install at `switchroom update`, not npm", () => {
+    const cmd = hostCliInstallCommand(
+      {
+        version: "0.20.16",
+        installKind: "static-binary",
+        path: "/usr/local/bin/switchroom",
+      },
+      target,
+    );
+    expect(cmd).toContain("switchroom update --pin v0.20.21");
+    expect(cmd).not.toContain("npm i -g");
+  });
+
+  it("degrades to a method-agnostic instruction with no stamp", () => {
+    expect(hostCliInstallCommand(undefined, target)).toContain("0.20.21");
+  });
+});
+
+describe("hostCliInstallShellCommand — pasteable ONLY when the caveat isn't load-bearing", () => {
+  it("returns a runnable command for a root-owned npm tree and a static binary", () => {
+    expect(
+      hostCliInstallShellCommand(
+        {
+          version: "0.20.16",
+          installKind: "npm-global",
+          path: "/usr/local/lib/node_modules/switchroom/dist/cli/switchroom.js",
+          npmPrefix: "/usr/local",
+          ownerUid: 0,
+        },
+        "v0.20.21",
+      ),
+    ).toBe("sudo npm i -g switchroom@0.20.21");
+    expect(
+      hostCliInstallShellCommand(
+        { version: "0.20.16", installKind: "static-binary", path: "/usr/local/bin/switchroom" },
+        "v0.20.21",
+      ),
+    ).toBe("switchroom update --pin v0.20.21");
+  });
+
+  it("returns undefined for a USER-owned npm prefix — the 'run as <user>' caveat cannot be &&-chained", () => {
+    expect(
+      hostCliInstallShellCommand(
+        {
+          version: "0.20.16",
+          installKind: "npm-global",
+          path: NVM_SCRIPT,
+          npmPrefix: "/home/op/.nvm/versions/node/v22.22.2",
+          ownerUid: 1000,
+          ownerUser: "op",
+        },
+        "v0.20.21",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined with no stamp at all", () => {
+    expect(hostCliInstallShellCommand(undefined, "v0.20.21")).toBeUndefined();
+  });
+});
+
+describe("shouldRefuseStaleHostCli", () => {
+  const stamp = (version: string): HostCliStamp => ({
+    version,
+    installKind: "npm-global",
+    path: NVM_SCRIPT,
+  });
+
+  it("refuses when the observed host CLI is strictly older than the target", () => {
+    expect(shouldRefuseStaleHostCli(stamp("0.20.16"), "v0.20.21")).toBe(true);
+    expect(shouldRefuseStaleHostCli(stamp("v0.20.16"), "0.20.21")).toBe(true);
+  });
+
+  it("allows an equal or newer host CLI", () => {
+    expect(shouldRefuseStaleHostCli(stamp("0.20.21"), "v0.20.21")).toBe(false);
+    expect(shouldRefuseStaleHostCli(stamp("0.21.0"), "v0.20.21")).toBe(false);
+  });
+
+  it("never blocks with no stamp — a host CLI predating the stamp writes none", () => {
+    expect(shouldRefuseStaleHostCli(undefined, "v0.20.21")).toBe(false);
+  });
+
+  it("never blocks on an unorderable version", () => {
+    expect(shouldRefuseStaleHostCli(stamp("0.0.0-dev"), "v0.20.21")).toBe(false);
+    expect(shouldRefuseStaleHostCli(stamp("0.20.16"), "nightly")).toBe(false);
+  });
+});

--- a/src/cli/host-cli-stamp.test.ts
+++ b/src/cli/host-cli-stamp.test.ts
@@ -6,6 +6,8 @@ import { join } from "node:path";
 import {
   HOST_CLI_STAMP_FILENAME,
   buildHostCliStamp,
+  compareHostCliToTarget,
+  hostCliConvergedOnTarget,
   hostCliInstallCommand,
   hostCliInstallShellCommand,
   npmPackageRoot,
@@ -280,7 +282,9 @@ describe("hostCliInstallCommand — the command must match how the host is ACTUA
       },
       target,
     );
-    expect(cmd).toContain("npm i -g switchroom@0.20.21");
+    expect(cmd).toContain(
+      "npm i -g --prefix /home/op/.nvm/versions/node/v22.22.2 switchroom@0.20.21",
+    );
     // The literal command must not be a sudo invocation. (It DOES contain the
     // word "sudo" inside the explicit "NOT under sudo" caution — that caution
     // is the point of this test, so match the invocation shape, not the word.)
@@ -301,7 +305,7 @@ describe("hostCliInstallCommand — the command must match how the host is ACTUA
       },
       target,
     );
-    expect(cmd).toBe("sudo npm i -g switchroom@0.20.21 (npm prefix /usr/local)");
+    expect(cmd).toBe("sudo npm i -g --prefix /usr/local switchroom@0.20.21");
   });
 
   it("points a static-binary install at `switchroom update`, not npm", () => {
@@ -335,7 +339,7 @@ describe("hostCliInstallShellCommand — pasteable ONLY when the caveat isn't lo
         },
         "v0.20.21",
       ),
-    ).toBe("sudo npm i -g switchroom@0.20.21");
+    ).toBe("sudo npm i -g --prefix /usr/local switchroom@0.20.21");
     expect(
       hostCliInstallShellCommand(
         { version: "0.20.16", installKind: "static-binary", path: "/usr/local/bin/switchroom" },
@@ -363,6 +367,40 @@ describe("hostCliInstallShellCommand — pasteable ONLY when the caveat isn't lo
   it("returns undefined with no stamp at all", () => {
     expect(hostCliInstallShellCommand(undefined, "v0.20.21")).toBeUndefined();
   });
+
+  // npm resolves the global prefix from the INVOKING user's npmrc, and under
+  // `sudo` that is root's — not necessarily the tree the stamp measured. A
+  // bare `-g` then converges a DIFFERENT install and leaves the observed one
+  // exactly as drifted as before, with the card reporting success.
+  it("carries the OBSERVED prefix, because sudo swaps in root's npmrc prefix", () => {
+    const rootOwnedElsewhere: HostCliStamp = {
+      version: "0.20.16",
+      installKind: "npm-global",
+      path: "/opt/npm-global/lib/node_modules/switchroom/dist/cli/switchroom.js",
+      npmPrefix: "/opt/npm-global",
+      ownerUid: 0,
+    };
+    expect(hostCliInstallShellCommand(rootOwnedElsewhere, "v0.20.21")).toBe(
+      "sudo npm i -g --prefix /opt/npm-global switchroom@0.20.21",
+    );
+    expect(hostCliInstallCommand(rootOwnedElsewhere, "v0.20.21")).toBe(
+      "sudo npm i -g --prefix /opt/npm-global switchroom@0.20.21",
+    );
+  });
+
+  it("omits --prefix when the stamp never recorded one", () => {
+    expect(
+      hostCliInstallShellCommand(
+        {
+          version: "0.20.16",
+          installKind: "npm-global",
+          path: "/some/unusual/switchroom",
+          ownerUid: 0,
+        },
+        "v0.20.21",
+      ),
+    ).toBe("sudo npm i -g switchroom@0.20.21");
+  });
 });
 
 describe("shouldRefuseStaleHostCli", () => {
@@ -389,5 +427,43 @@ describe("shouldRefuseStaleHostCli", () => {
   it("never blocks on an unorderable version", () => {
     expect(shouldRefuseStaleHostCli(stamp("0.0.0-dev"), "v0.20.21")).toBe(false);
     expect(shouldRefuseStaleHostCli(stamp("0.20.16"), "nightly")).toBe(false);
+  });
+});
+
+// The asymmetry that made a false all-clear possible: `shouldRefuseStaleHostCli`
+// returns false for "converged" AND for "cannot be ordered", because the ROLL
+// must not block on the latter. Any surface that instead wants to ASSERT the
+// host CLI is done needs the third state, or it prints "nothing to do" over a
+// host CLI that is five releases behind on an rc build.
+describe("compareHostCliToTarget / hostCliConvergedOnTarget", () => {
+  const stamp = (version: string): HostCliStamp => ({
+    version,
+    installKind: "npm-global",
+    path: NVM_SCRIPT,
+  });
+
+  it("separates behind / current-or-ahead / unknown", () => {
+    expect(compareHostCliToTarget(stamp("0.20.16"), "v0.20.21")).toBe("behind");
+    expect(compareHostCliToTarget(stamp("0.20.21"), "v0.20.21")).toBe("current-or-ahead");
+    expect(compareHostCliToTarget(stamp("0.21.0"), "v0.20.21")).toBe("current-or-ahead");
+    expect(compareHostCliToTarget(stamp("0.20.16-rc.1"), "v0.20.21")).toBe("unknown");
+    expect(compareHostCliToTarget(stamp("sha-abc1234"), "v0.20.21")).toBe("unknown");
+    expect(compareHostCliToTarget(undefined, "v0.20.21")).toBe("unknown");
+  });
+
+  it("treats an UNORDERABLE version as not-converged, unlike the roll gate", () => {
+    for (const v of ["0.20.16-rc.1", "0.20.16-dev", "sha-abc1234"]) {
+      // The gate lets it through…
+      expect(shouldRefuseStaleHostCli(stamp(v), "v0.20.21")).toBe(false);
+      // …and that must NOT be readable as "the host CLI is on target".
+      expect(hostCliConvergedOnTarget(stamp(v), "v0.20.21")).toBe(false);
+    }
+  });
+
+  it("is true only for an observed, orderable, on-or-past version", () => {
+    expect(hostCliConvergedOnTarget(stamp("0.20.21"), "v0.20.21")).toBe(true);
+    expect(hostCliConvergedOnTarget(stamp("0.21.0"), "v0.20.21")).toBe(true);
+    expect(hostCliConvergedOnTarget(stamp("0.20.16"), "v0.20.21")).toBe(false);
+    expect(hostCliConvergedOnTarget(undefined, "v0.20.21")).toBe(false);
   });
 });

--- a/src/cli/host-cli-stamp.ts
+++ b/src/cli/host-cli-stamp.ts
@@ -1,0 +1,485 @@
+/**
+ * The host operator CLI stamp — making the host binary's version OBSERVABLE
+ * from inside a container, so a rollout can order it FIRST instead of
+ * apologising for it LAST (#4571).
+ *
+ * ## The bug this closes
+ *
+ * Switchroom's one enumerative "is everything on the same version?" check
+ * (`component-versions.ts`) reports a `cli (host)` row whose version is
+ * `SWITCHROOM_VERSION` — *the version of the process doing the checking*.
+ * On the host shell that is correct: the process IS the host CLI. On the
+ * agent-invoked path (hostd spawns `switchroom rollout` inside its own
+ * container) it is not: the row reports the hostd IMAGE's bundled CLI and
+ * labels it `(host)`. The host operator's npm/binary install is never
+ * measured by anything, at any point in a roll.
+ *
+ * That is why the host CLI on the reference host sat on 0.20.16 while the
+ * fleet rolled to 0.20.21 — five releases of drift, with every roll exiting
+ * green and emitting a trailing "still on the PRIOR version" warning nobody
+ * actioned. A warning scrolls past once; nothing held a checkable answer.
+ *
+ * ## Why a stamp
+ *
+ * hostd mounts exactly one host path: `~/.switchroom` (src/cli/hostd.ts:332).
+ * It has no view of `/usr/local/bin`, no view of an nvm tree, and no way to
+ * `npm i -g` on the host. So the roll cannot GO AND LOOK at the host CLI, and
+ * it cannot install it either. The only thing that can report the host CLI's
+ * version into the shared directory is the host CLI itself.
+ *
+ * So: every host-context invocation of the CLI refreshes
+ * `~/.switchroom/host-cli.json` with its own version and how it was installed
+ * (idempotent — a byte-identical stamp is not rewritten). An agent-invoked
+ * rollout reads that file through the `/host-home/.switchroom` mount and
+ * REFUSES to roll the fleet past a host CLI that is behind the target
+ * (`shouldRefuseStaleHostCli`, consumed by `rollout.ts`).
+ *
+ * ## Why the install command is derived, never hardcoded
+ *
+ * The pre-existing warning told operators to run `sudo npm i -g switchroom@X`.
+ * On the reference host that advice is actively wrong: the CLI lives in the
+ * operator's nvm tree (`~/.nvm/versions/node/vX/lib/node_modules/switchroom`)
+ * owned by the operator, not root — `sudo npm i -g` there either installs into
+ * a different prefix or root-poisons the tree. The stamp therefore records the
+ * npm prefix and the owning user it OBSERVED, and {@link hostCliInstallCommand}
+ * renders the command from those facts.
+ */
+
+import {
+  chownSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { compareReleaseTags } from "../config/release-resolve.js";
+import type { HostCliObservation } from "./component-versions.js";
+import { detectInstallKind, type InstallKind } from "./self-update.js";
+
+/** File name of the stamp inside the switchroom home. */
+export const HOST_CLI_STAMP_FILENAME = "host-cli.json";
+
+/** Marker that a directory really is a switchroom home. */
+const SWITCHROOM_HOME_MARKER = "switchroom.yaml";
+
+/**
+ * The in-container mount point of the operator's home. hostd pins
+ * `HOME=/host-home` and bind-mounts `~/.switchroom` there (hostd.ts:332), and
+ * the root-tier agent container mounts the same host home at the same path —
+ * so this is where a container-side READ finds the stamp.
+ */
+const CONTAINER_OPERATOR_HOME = "/host-home";
+
+/** What the host CLI records about itself. Serialized as JSON. */
+export interface HostCliStamp {
+  /** Bare semver as the CLI reports it (`0.20.21`), or the raw string. */
+  version: string;
+  /** How the host CLI was installed, per {@link detectInstallKind}. */
+  installKind: InstallKind;
+  /** The entrypoint that was actually executed (script or binary path). */
+  path: string;
+  /** npm global prefix, when `installKind === "npm-global"`. */
+  npmPrefix?: string;
+  /** Login name owning the install tree, when resolvable. */
+  ownerUser?: string;
+  /** uid owning the install tree, when readable. */
+  ownerUid?: number;
+}
+
+export interface StampIo {
+  env?: NodeJS.ProcessEnv;
+  home?: string;
+  exists?: (path: string) => boolean;
+  readFile?: (path: string) => string;
+  writeFile?: (path: string, content: string) => void;
+  statUid?: (path: string) => number | undefined;
+  /** Resolve a login name from a uid. Default reads `/etc/passwd`. */
+  userForUid?: (uid: number) => string | undefined;
+  /** Effective uid of this process. Drives the root-write ownership handoff. */
+  getuid?: () => number | undefined;
+  /** Ownership handoff for a stamp written as root. */
+  chown?: (path: string, uid: number, gid: number) => void;
+  /** uid/gid of an existing directory, for the handoff. */
+  statOwner?: (path: string) => { uid: number; gid: number } | undefined;
+}
+
+function resolveIo(io: StampIo): Required<Omit<StampIo, "env" | "home">> & {
+  env: NodeJS.ProcessEnv;
+  home: string;
+} {
+  return {
+    env: io.env ?? process.env,
+    home: io.home ?? homedir(),
+    exists: io.exists ?? ((p) => existsSync(p)),
+    readFile: io.readFile ?? ((p) => readFileSync(p, "utf8")),
+    writeFile:
+      io.writeFile ??
+      ((p, c) => {
+        // tmp+rename so a reader never sees a half-written stamp.
+        const tmp = `${p}.${process.pid}.tmp`;
+        writeFileSync(tmp, c, { mode: 0o644 });
+        renameSync(tmp, p);
+      }),
+    statUid:
+      io.statUid ??
+      ((p) => {
+        try {
+          return statSync(p).uid;
+        } catch {
+          return undefined;
+        }
+      }),
+    userForUid: io.userForUid ?? userFromPasswd,
+    getuid: io.getuid ?? (() => process.getuid?.()),
+    chown: io.chown ?? ((p, uid, gid) => chownSync(p, uid, gid)),
+    statOwner:
+      io.statOwner ??
+      ((p) => {
+        try {
+          const st = statSync(p);
+          return { uid: st.uid, gid: st.gid };
+        } catch {
+          return undefined;
+        }
+      }),
+  };
+}
+
+/** Best-effort login name for a uid, from `/etc/passwd`. */
+function userFromPasswd(uid: number): string | undefined {
+  try {
+    for (const line of readFileSync("/etc/passwd", "utf8").split("\n")) {
+      const f = line.split(":");
+      if (f[2] !== undefined && parseInt(f[2], 10) === uid && f[0]) return f[0];
+    }
+  } catch {
+    /* no passwd / unreadable */
+  }
+  return undefined;
+}
+
+/** Best-effort home dir for a login name, from `/etc/passwd`. */
+function homeFromPasswd(user: string): string | undefined {
+  try {
+    for (const line of readFileSync("/etc/passwd", "utf8").split("\n")) {
+      const f = line.split(":");
+      if (f[0] === user && f[5]) return f[5];
+    }
+  } catch {
+    /* no passwd / unreadable */
+  }
+  return undefined;
+}
+
+/**
+ * Candidate switchroom homes, in precedence order.
+ *
+ * `SWITCHROOM_HOST_HOME` first (hostd injects the real host home), then the
+ * *invoking* operator's home under sudo (`SUDO_USER`'s passwd entry — under
+ * `sudo switchroom …` the process home is `/root`, which is NOT where the
+ * fleet lives), then the process home, then the container mount point.
+ */
+export function stampHomeCandidates(
+  env: NodeJS.ProcessEnv,
+  home: string | undefined,
+  homeForUser: (user: string) => string | undefined = homeFromPasswd,
+): string[] {
+  const sudoUser = env.SUDO_USER;
+  const roots = [
+    env.SWITCHROOM_HOST_HOME?.trim(),
+    sudoUser && sudoUser !== "root" ? homeForUser(sudoUser) : undefined,
+    home,
+    CONTAINER_OPERATOR_HOME,
+  ];
+  const out: string[] = [];
+  for (const r of roots) {
+    if (!r) continue;
+    const dir = join(r, ".switchroom");
+    if (!out.includes(dir)) out.push(dir);
+  }
+  return out;
+}
+
+/**
+ * The switchroom home to read/write the stamp in: the first candidate that
+ * actually contains a `switchroom.yaml`. Returns undefined when none does —
+ * a dev checkout with no installed fleet, and there is nothing to stamp.
+ */
+export function resolveStampDir(io: StampIo = {}): string | undefined {
+  const { env, home, exists } = resolveIo(io);
+  const homeForUser = (u: string) => homeFromPasswd(u);
+  for (const dir of stampHomeCandidates(env, home, homeForUser)) {
+    if (exists(join(dir, SWITCHROOM_HOME_MARKER))) return dir;
+  }
+  return undefined;
+}
+
+/**
+ * The npm global prefix implied by an npm-installed entrypoint path.
+ *
+ * `<prefix>/lib/node_modules/switchroom/dist/cli/switchroom.js` → `<prefix>`.
+ * Returns undefined for any path that does not carry that shape, so the
+ * renderer degrades to a prefix-free command rather than inventing one.
+ */
+export function npmPrefixFromScriptPath(scriptPath: string): string | undefined {
+  const marker = "/lib/node_modules/switchroom/";
+  const at = scriptPath.indexOf(marker);
+  if (at <= 0) return undefined;
+  return scriptPath.slice(0, at);
+}
+
+/** The install-tree path whose ownership identifies who may `npm i -g`. */
+export function npmPackageRoot(scriptPath: string): string | undefined {
+  const marker = "/lib/node_modules/switchroom/";
+  const at = scriptPath.indexOf(marker);
+  if (at <= 0) return undefined;
+  return scriptPath.slice(0, at + marker.length - 1);
+}
+
+export interface BuildStampInput {
+  version: string;
+  execPath: string;
+  scriptPath: string;
+  bundleDir: string;
+  inContainer: boolean;
+}
+
+/**
+ * Build the stamp for the RUNNING process. Pure apart from the injectable
+ * ownership probe, so the exact recorded bytes are unit-asserted.
+ */
+export function buildHostCliStamp(
+  input: BuildStampInput,
+  io: StampIo = {},
+): HostCliStamp | undefined {
+  if (input.inContainer) return undefined; // a container CLI is not the host CLI
+  const { statUid, userForUid } = resolveIo(io);
+  const detection = detectInstallKind({
+    bundleDir: input.bundleDir,
+    execPath: input.execPath,
+    scriptPath: input.scriptPath,
+    inContainer: false,
+  });
+  const path =
+    detection.kind === "static-binary"
+      ? (detection.binaryPath ?? input.execPath)
+      : input.scriptPath || input.execPath;
+  const stamp: HostCliStamp = {
+    version: input.version.replace(/^v/, ""),
+    installKind: detection.kind,
+    path,
+  };
+  if (detection.kind === "npm-global") {
+    const prefix = npmPrefixFromScriptPath(input.scriptPath);
+    if (prefix) stamp.npmPrefix = prefix;
+  }
+  const ownedPath =
+    detection.kind === "npm-global" ? (npmPackageRoot(input.scriptPath) ?? path) : path;
+  const uid = statUid(ownedPath);
+  if (uid !== undefined && Number.isFinite(uid)) {
+    stamp.ownerUid = uid;
+    const user = userForUid(uid);
+    if (user) stamp.ownerUser = user;
+  }
+  return stamp;
+}
+
+/** Stable serialization so an unchanged stamp is a byte-identical no-op. */
+export function serializeStamp(stamp: HostCliStamp): string {
+  return `${JSON.stringify(stamp, ["version", "installKind", "path", "npmPrefix", "ownerUser", "ownerUid"], 2)}\n`;
+}
+
+/**
+ * Refresh `~/.switchroom/host-cli.json` for the running host CLI.
+ *
+ * Best-effort and total: every failure path returns a reason instead of
+ * throwing, because this runs on EVERY CLI invocation and must never be able
+ * to break a command. Returns what it did, for tests.
+ */
+export function refreshHostCliStamp(
+  input: BuildStampInput,
+  io: StampIo = {},
+): { status: "written" | "unchanged" | "skipped"; reason?: string; path?: string } {
+  try {
+    const stamp = buildHostCliStamp(input, io);
+    if (!stamp) return { status: "skipped", reason: "running in a container" };
+    const dir = resolveStampDir(io);
+    if (!dir) return { status: "skipped", reason: "no switchroom home found" };
+    const { exists, readFile, writeFile, getuid, chown, statOwner } = resolveIo(io);
+    const path = join(dir, HOST_CLI_STAMP_FILENAME);
+    const content = serializeStamp(stamp);
+    if (exists(path)) {
+      try {
+        if (readFile(path) === content) return { status: "unchanged", path };
+      } catch {
+        /* unreadable — rewrite */
+      }
+    }
+    mkdirSync(dir, { recursive: true });
+    writeFile(path, content);
+    // A `sudo switchroom …` run would otherwise leave a ROOT-OWNED stamp in the
+    // operator's home, and every later unprivileged run's tmp+rename would
+    // EACCES — freezing the stamp at whatever root last wrote and re-opening
+    // the exact silent-drift hole this file closes. Hand it back to whoever
+    // owns the switchroom home. Best-effort: a chown failure is not fatal.
+    if (getuid() === 0) {
+      try {
+        const owner = statOwner(dir);
+        if (owner && owner.uid !== 0) chown(path, owner.uid, owner.gid);
+      } catch {
+        /* not fatal — the stamp is still written */
+      }
+    }
+    return { status: "written", path };
+  } catch (err) {
+    return { status: "skipped", reason: (err as Error).message };
+  }
+}
+
+/** True when this process is running inside a container. */
+export function runningInContainer(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.SWITCHROOM_HOSTD_CONTEXT === "1" || existsSync("/.dockerenv");
+}
+
+/**
+ * What the CURRENT process can honestly say about the HOST operator CLI.
+ *
+ * The single production derivation, shared by `doctor` and `update --check` so
+ * the two can't disagree about whose version the `cli (host)` row is showing.
+ */
+export function observeHostCli(
+  io: StampIo = {},
+  inContainer: boolean = runningInContainer(io.env ?? process.env),
+): HostCliObservation {
+  if (!inContainer) return { inContainer: false };
+  const stamp = readHostCliStamp(io);
+  return { inContainer: true, ...(stamp ? { observedVersion: stamp.version } : {}) };
+}
+
+/** Read the stamp, or undefined when absent/unreadable/malformed. */
+export function readHostCliStamp(io: StampIo = {}): HostCliStamp | undefined {
+  try {
+    const dir = resolveStampDir(io);
+    if (!dir) return undefined;
+    const { exists, readFile } = resolveIo(io);
+    const path = join(dir, HOST_CLI_STAMP_FILENAME);
+    if (!exists(path)) return undefined;
+    const parsed = JSON.parse(readFile(path)) as Partial<HostCliStamp>;
+    if (typeof parsed.version !== "string" || parsed.version.length === 0) return undefined;
+    return {
+      version: parsed.version,
+      installKind: (parsed.installKind as InstallKind) ?? "unknown",
+      path: typeof parsed.path === "string" ? parsed.path : "",
+      ...(parsed.npmPrefix ? { npmPrefix: parsed.npmPrefix } : {}),
+      ...(parsed.ownerUser ? { ownerUser: parsed.ownerUser } : {}),
+      ...(typeof parsed.ownerUid === "number" ? { ownerUid: parsed.ownerUid } : {}),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The command that brings the OBSERVED host CLI onto `target`.
+ *
+ * Derived from the stamp, never hardcoded — see the module header for why
+ * `sudo npm i -g` is wrong on an nvm/user-prefix install. `target` may be
+ * `vX.Y.Z` or bare; npm wants it bare.
+ */
+export function hostCliInstallCommand(
+  stamp: HostCliStamp | undefined,
+  target: string,
+): string {
+  const bare = target.replace(/^v/, "");
+  if (!stamp) {
+    return (
+      `upgrade the host operator CLI to ${bare} host-side ` +
+      `(\`switchroom update\` for a static-binary install; ` +
+      `\`npm i -g switchroom@${bare}\` for an npm install — as the user who owns ` +
+      `the npm prefix)`
+    );
+  }
+  switch (stamp.installKind) {
+    case "npm-global": {
+      const prefixNote = stamp.npmPrefix ? ` (npm prefix ${stamp.npmPrefix})` : "";
+      const asRoot = stamp.ownerUid === 0;
+      if (asRoot) return `sudo npm i -g switchroom@${bare}${prefixNote}`;
+      const who = stamp.ownerUser ?? (stamp.ownerUid !== undefined ? `uid ${stamp.ownerUid}` : undefined);
+      const asNote = who
+        ? ` — run as ${who}, NOT under sudo${prefixNote}`
+        : ` — run as the user owning ${stamp.path}, NOT under sudo${prefixNote}`;
+      return `npm i -g switchroom@${bare}${asNote}`;
+    }
+    case "static-binary":
+      return `switchroom update --pin v${bare}  (replaces the static binary at ${stamp.path})`;
+    case "source-checkout":
+      return `git pull && bun install && npm run build  (source checkout at ${stamp.path})`;
+    case "container":
+    case "unknown":
+    default:
+      return (
+        `upgrade the host operator CLI at ${stamp.path} to ${bare} using the ` +
+        `method it was installed with`
+      );
+  }
+}
+
+/**
+ * The host-CLI upgrade as a RUNNABLE shell command, or undefined when there
+ * isn't one that can be safely pasted.
+ *
+ * {@link hostCliInstallCommand} is prose-with-a-command: it carries the "run as
+ * <user>, NOT under sudo" caveat that makes the command correct. That caveat
+ * cannot survive being `&&`-chained into a copy-paste block, so this returns
+ * undefined precisely in the cases where the caveat is load-bearing (a
+ * user-owned npm prefix, an unknown install, no stamp at all). Callers that
+ * want to collapse commands into one line must fall back to two lines then —
+ * which is the point: a wrong copy-paste is worse than a second line.
+ */
+export function hostCliInstallShellCommand(
+  stamp: HostCliStamp | undefined,
+  target: string,
+): string | undefined {
+  if (!stamp) return undefined;
+  const bare = target.replace(/^v/, "");
+  if (stamp.installKind === "static-binary") return `switchroom update --pin v${bare}`;
+  if (stamp.installKind === "npm-global" && stamp.ownerUid === 0) {
+    return `sudo npm i -g switchroom@${bare}`;
+  }
+  return undefined;
+}
+
+/**
+ * `failedStep` label for a roll refused up-front because the HOST operator
+ * CLI is behind the target. Distinct from `preflight-stale-cli` (which is
+ * about the CLI *driving* the roll — inside hostd on the agent path) because
+ * the remediation is a host-side install, not a hostd refresh.
+ */
+export const PREFLIGHT_HOST_CLI_STALE_STEP = "preflight-host-cli-stale";
+
+/**
+ * Pure guard: true when the roll must be refused because the observed host
+ * operator CLI is STRICTLY OLDER than the target.
+ *
+ * Conservative in exactly the same shape as `shouldRefuseStaleCli`: an absent
+ * stamp, or a version on either side that is not a clean `vX.Y.Z`, is
+ * unorderable and never blocks. An absent stamp is the first-upgrade
+ * chicken-and-egg case (a host CLI predating this feature writes no stamp) —
+ * refusing there would brick every roll on every host on the release that
+ * introduces the gate.
+ */
+export function shouldRefuseStaleHostCli(
+  stamp: HostCliStamp | undefined,
+  target: string,
+): boolean {
+  if (!stamp) return false;
+  const cmp = compareReleaseTags(
+    `v${stamp.version.replace(/^v/, "")}`,
+    `v${target.replace(/^v/, "")}`,
+  );
+  return cmp !== null && cmp < 0;
+}

--- a/src/cli/host-cli-stamp.ts
+++ b/src/cli/host-cli-stamp.ts
@@ -405,14 +405,18 @@ export function hostCliInstallCommand(
   }
   switch (stamp.installKind) {
     case "npm-global": {
-      const prefixNote = stamp.npmPrefix ? ` (npm prefix ${stamp.npmPrefix})` : "";
-      const asRoot = stamp.ownerUid === 0;
-      if (asRoot) return `sudo npm i -g switchroom@${bare}${prefixNote}`;
+      // `--prefix` is spelled out whenever the stamp recorded one. npm resolves
+      // the global prefix from the INVOKING user's npmrc, which under `sudo` is
+      // root's, not the one the observed install actually lives in — so a bare
+      // `npm i -g` can quietly converge a different tree and leave the drift
+      // exactly where it was.
+      const npmCmd = `npm i -g${stamp.npmPrefix ? ` --prefix ${stamp.npmPrefix}` : ""} switchroom@${bare}`;
+      if (stamp.ownerUid === 0) return `sudo ${npmCmd}`;
       const who = stamp.ownerUser ?? (stamp.ownerUid !== undefined ? `uid ${stamp.ownerUid}` : undefined);
       const asNote = who
-        ? ` — run as ${who}, NOT under sudo${prefixNote}`
-        : ` — run as the user owning ${stamp.path}, NOT under sudo${prefixNote}`;
-      return `npm i -g switchroom@${bare}${asNote}`;
+        ? ` — run as ${who}, NOT under sudo`
+        : ` — run as the user owning ${stamp.path}, NOT under sudo`;
+      return `${npmCmd}${asNote}`;
     }
     case "static-binary":
       return `switchroom update --pin v${bare}  (replaces the static binary at ${stamp.path})`;
@@ -448,7 +452,10 @@ export function hostCliInstallShellCommand(
   const bare = target.replace(/^v/, "");
   if (stamp.installKind === "static-binary") return `switchroom update --pin v${bare}`;
   if (stamp.installKind === "npm-global" && stamp.ownerUid === 0) {
-    return `sudo npm i -g switchroom@${bare}`;
+    // Carry the observed prefix, for the same reason the prose command does:
+    // `sudo` swaps in root's npmrc prefix, so a bare `-g` can install into a
+    // tree that is not the one this stamp measured.
+    return `sudo npm i -g${stamp.npmPrefix ? ` --prefix ${stamp.npmPrefix}` : ""} switchroom@${bare}`;
   }
   return undefined;
 }
@@ -476,10 +483,44 @@ export function shouldRefuseStaleHostCli(
   stamp: HostCliStamp | undefined,
   target: string,
 ): boolean {
-  if (!stamp) return false;
+  return compareHostCliToTarget(stamp, target) === "behind";
+}
+
+/**
+ * Where the observed host CLI sits relative to `target`. THREE states, not two.
+ *
+ * `unknown` is the one that matters: an absent stamp, or a version that is not
+ * a clean `vX.Y.Z` (a `-rc.N` / `-dev` / `sha-…` build — `switchroom update
+ * --channel rc` produces exactly these), is unorderable. `shouldRefuseStaleHostCli`
+ * folds `unknown` in with `current` deliberately, because the ROLL must not
+ * block on what it cannot order. Nothing may fold it in the other direction and
+ * ASSERT convergence: a card that reads "on 0.20.16-rc.1 — nothing to do" while
+ * the fleet rolls to v0.20.22 is the same silent all-clear this whole file
+ * exists to delete. Use {@link hostCliConvergedOnTarget} for that question.
+ */
+export function compareHostCliToTarget(
+  stamp: HostCliStamp | undefined,
+  target: string,
+): "behind" | "current-or-ahead" | "unknown" {
+  if (!stamp) return "unknown";
   const cmp = compareReleaseTags(
     `v${stamp.version.replace(/^v/, "")}`,
     `v${target.replace(/^v/, "")}`,
   );
-  return cmp !== null && cmp < 0;
+  if (cmp === null) return "unknown";
+  return cmp < 0 ? "behind" : "current-or-ahead";
+}
+
+/**
+ * True ONLY when the host CLI was observed and is provably on-or-past `target`.
+ *
+ * The affirmative counterpart to {@link shouldRefuseStaleHostCli}: anything
+ * unobserved or unorderable is NOT converged, so a surface that reports
+ * outstanding host-side work keeps reporting it rather than guessing.
+ */
+export function hostCliConvergedOnTarget(
+  stamp: HostCliStamp | undefined,
+  target: string,
+): boolean {
+  return compareHostCliToTarget(stamp, target) === "current-or-ahead";
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -54,8 +54,23 @@ import { registerHindsightBenchCommand } from "./hindsight-bench.js";
 import { registerOpenRouterWatchCommand } from "./openrouter-watch.js";
 import { registerConfigRepoCommand } from "./config-repo.js";
 import { captureEvent, installGlobalErrorHandlers } from "../analytics/posthog.js";
+import { refreshHostCliStamp, runningInContainer } from "./host-cli-stamp.js";
 
 installGlobalErrorHandlers();
+
+// Record what the HOST operator CLI is, into the one host directory a
+// container can see (`~/.switchroom`). Without this the host binary's version
+// is unobservable from an agent-invoked rollout — which is how the host CLI
+// sat five releases behind the fleet while every roll exited green (#4571).
+// Runs on every invocation (idempotent: a byte-identical stamp is not
+// rewritten), no-ops inside a container, and is total: it cannot throw.
+refreshHostCliStamp({
+  version: VERSION,
+  execPath: process.execPath,
+  scriptPath: process.argv[1] ?? "",
+  bundleDir: import.meta.dirname,
+  inContainer: runningInContainer(),
+});
 
 // VERSION (aliased from SWITCHROOM_VERSION) resolves at runtime from the
 // shipped package.json, with src/build-info.ts as the fallback — see

--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -64,6 +64,7 @@ import {
   PIN_JOURNAL_MAX_AGE_MS,
 } from "./rollout-pin-journal.js";
 import type { ComponentVersion } from "./component-versions.js";
+import type { HostCliStamp } from "./host-cli-stamp.js";
 import { getReleasePinFromConfig } from "./release-yaml.js";
 import { SCOPED_SWEEP_ENV } from "../agents/agent-owned-tree.js";
 
@@ -267,6 +268,14 @@ function harness(opts: {
    */
   components?: ComponentVersion[];
   /**
+   * The host operator CLI's install record (#4571). Defaults to ABSENT,
+   * which is the pre-stamp behaviour every other test assumes: remediation
+   * for a drifted `cli` component degrades to the generic `switchroom
+   * update` text. A test that cares about the host-specific command (npm
+   * prefix, owning user) injects a stamp.
+   */
+  hostCli?: HostCliStamp;
+  /**
    * Behaviour of the injected `ensureBank` hook (the ensure-banks backstop
    * seam). Defaults to "every bank is present" so pre-existing tests keep
    * their meaning. Tests exercising the backstop inject a per-agent verdict
@@ -308,6 +317,7 @@ function harness(opts: {
     hindsightExists: () => opts.hindsightExists ?? false,
     webImageTag: () => opts.webImageTag ?? null,
     collectComponents: () => opts.components ?? [],
+    ...(opts.hostCli ? { hostCli: opts.hostCli } : {}),
     // Instant fake so the ensure-banks retry backoff is exercised without
     // wall-clock delay; the requested waits are recorded for assertions.
     sleepMs: (ms: number) => {
@@ -1366,6 +1376,40 @@ describe("executeRollout — terminal component-drift gate (#3928)", () => {
     const r = await executeRollout(steps, TARGET, deps);
     expect(r.ok).toBe(true);
     expect(r.warnings.join("\n")).toContain("switchroom-somebody-else");
+  });
+
+  it("quotes the HOST CLI's own install command in the drift warning, not the generic one", async () => {
+    // #4571: `remediationFor` is shared between doctor and the roll so that
+    // "an operator is never given two different answers for the same drifted
+    // component". Doctor passes the stamp; the roll used to call the same
+    // helper two-arg and print `switchroom update`, which on an nvm-prefix
+    // npm install run under sudo converges a DIFFERENT tree and leaves the
+    // drift exactly where it was. This asserts the roll quotes the stamp.
+    const stamp: HostCliStamp = {
+      version: "0.19.26",
+      installKind: "npm-global",
+      path: "/home/op/.nvm/versions/node/v22.22.2/bin/switchroom",
+      npmPrefix: "/home/op/.nvm/versions/node/v22.22.2",
+      ownerUser: "op",
+      ownerUid: 1000,
+    };
+    const steps = planRollout(["klanker"]);
+    const { deps } = harness({
+      versions: { klanker: "0.19.30" },
+      hostCli: stamp,
+      // The host CLI is never in any plan's scope (see `gatedOwners`), so a
+      // behind `cli` row lands in `exempt` — reported, never gating.
+      components: [{ name: "cli (host)", kind: "cli", version: "v0.19.26" }],
+    });
+    const r = await executeRollout(steps, TARGET, deps);
+    expect(r.ok).toBe(true);
+    const warned = r.warnings.join("\n");
+    expect(warned).toContain(
+      "npm i -g --prefix /home/op/.nvm/versions/node/v22.22.2 switchroom@0.19.30",
+    );
+    expect(warned).toContain("run as op");
+    // The generic text is what the pre-fix two-arg call produced.
+    expect(warned).not.toContain("self-updates the host CLI");
   });
 
   it("WARNS LOUDLY rather than passing silently when no collector is wired", async () => {
@@ -3214,7 +3258,9 @@ describe("host-CLI-first gate (#4571)", () => {
     const configPath = makeHost("0.0.0");
     const { err } = await runRollout(configPath);
 
-    expect(err).toContain("npm i -g switchroom@0.0.1");
+    expect(err).toContain(
+      "npm i -g --prefix /home/op/.nvm/versions/node/v22.22.2 switchroom@0.0.1",
+    );
     expect(err).toContain("run as op");
     expect(err).toContain("/home/op/.nvm/versions/node/v22.22.2");
     // `sudo npm i -g` on a user-owned nvm prefix either installs somewhere
@@ -3238,7 +3284,9 @@ describe("host-CLI-first gate (#4571)", () => {
     expect(out).toMatch(/Rollout plan → v0\.0\.1:/);
     expect(out).toMatch(/restart clerk/);
     expect(err).toMatch(/--allow-stale-host-cli/);
-    expect(err).toContain("npm i -g switchroom@0.0.1");
+    expect(err).toContain(
+      "npm i -g --prefix /home/op/.nvm/versions/node/v22.22.2 switchroom@0.0.1",
+    );
   });
 
   it("never blocks when no stamp exists — a host CLI predating the stamp writes none", async () => {

--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -3110,3 +3110,141 @@ describe("rollout CLI — the pre-roll crash net and its --dry-run gate", () => 
     expect(err.join("")).toMatch(/reverted an UNCOMMITTED release\.pin/);
   });
 });
+
+// ── #4571 — HOST-CLI-FIRST gate ────────────────────────────────────────────
+//
+// The outcome under test is ORDERING: with the host operator CLI observably
+// behind the target, a roll must not reach the agent-roll step at all. Before
+// this gate the host CLI was a warning printed AFTER every agent had already
+// been restarted, which is how it drifted five releases (0.20.16 vs a 0.20.21
+// fleet) with every roll exiting green.
+//
+// Driven through the real command so the assertion is on what the verb DOES,
+// not on the pure predicate (which `host-cli-stamp.test.ts` covers). `--dry-run`
+// is the observation point: the plan print sits AFTER the gate, so "did the
+// plan render" is exactly "did the roll get as far as the agent steps", with no
+// docker, no spawn and nothing written.
+describe("host-CLI-first gate (#4571)", () => {
+  const OLD_HOST_HOME = process.env.SWITCHROOM_HOST_HOME;
+
+  afterEach(() => {
+    if (OLD_HOST_HOME === undefined) delete process.env.SWITCHROOM_HOST_HOME;
+    else process.env.SWITCHROOM_HOST_HOME = OLD_HOST_HOME;
+    process.exitCode = 0;
+  });
+
+  /**
+   * A tmp operator home holding a fleet config and a host-CLI stamp at
+   * `hostCliVersion` (omit for "no stamp"). `SWITCHROOM_HOST_HOME` points the
+   * stamp resolver at it — first in precedence, so the real `/host-home` on a
+   * switchroom host is never consulted.
+   */
+  function makeHost(hostCliVersion?: string): string {
+    const home = mkdtempSync(join(tmpdir(), "rollout-hostcli-"));
+    const dir = join(home, ".switchroom");
+    mkdirSync(dir, { recursive: true });
+    const configPath = join(dir, "switchroom.yaml");
+    writeFileSync(
+      configPath,
+      `switchroom:\n  version: 1\ntelegram:\n  bot_token: x\n  forum_chat_id: "1"\n` +
+        `release:\n  pin: v0.0.1\nagents:\n  clerk:\n    topic_name: clerk\n`,
+      "utf8",
+    );
+    if (hostCliVersion) {
+      writeFileSync(
+        join(dir, "host-cli.json"),
+        JSON.stringify({
+          version: hostCliVersion,
+          installKind: "npm-global",
+          path: "/home/op/.nvm/versions/node/v22.22.2/lib/node_modules/switchroom/dist/cli/switchroom.js",
+          npmPrefix: "/home/op/.nvm/versions/node/v22.22.2",
+          ownerUid: 1000,
+          ownerUser: "op",
+        }),
+        "utf8",
+      );
+    }
+    process.env.SWITCHROOM_HOST_HOME = home;
+    return configPath;
+  }
+
+  async function runRollout(configPath: string, extra: string[] = []) {
+    const program = new Command();
+    program.exitOverride();
+    program.option("-c, --config <path>", "Path to switchroom.yaml config file");
+    registerRolloutCommand(program);
+    const out: string[] = [];
+    const err: string[] = [];
+    const writeOut = process.stdout.write.bind(process.stdout);
+    const writeErr = process.stderr.write.bind(process.stderr);
+    process.stdout.write = ((s: string) => {
+      out.push(String(s));
+      return true;
+    }) as typeof process.stdout.write;
+    process.stderr.write = ((s: string) => {
+      err.push(String(s));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      // Target v0.0.1: older than the CLI running the tests, so the
+      // stale-DRIVING-cli guard above this one can never be what refuses.
+      await program.parseAsync(
+        ["--config", configPath, "rollout", "--pin", "v0.0.1", "--dry-run", ...extra],
+        { from: "user" },
+      );
+    } finally {
+      process.stdout.write = writeOut;
+      process.stderr.write = writeErr;
+    }
+    return { out: out.join(""), err: err.join("") };
+  }
+
+  it("REFUSES before the agent-roll step when the host CLI is behind the target", async () => {
+    const configPath = makeHost("0.0.0");
+    const { out, err } = await runRollout(configPath);
+
+    expect(process.exitCode).toBe(2);
+    expect(err).toMatch(/HOST operator CLI is v0\.0\.0, OLDER than the target v0\.0\.1/);
+    // The whole point: the roll never got as far as planning agent restarts.
+    expect(out).not.toMatch(/Rollout plan/);
+    expect(out).not.toMatch(/restart clerk/);
+  });
+
+  it("names the CORRECT install command — derived from the recorded prefix + owner, not `sudo npm i -g`", async () => {
+    const configPath = makeHost("0.0.0");
+    const { err } = await runRollout(configPath);
+
+    expect(err).toContain("npm i -g switchroom@0.0.1");
+    expect(err).toContain("run as op");
+    expect(err).toContain("/home/op/.nvm/versions/node/v22.22.2");
+    // `sudo npm i -g` on a user-owned nvm prefix either installs somewhere
+    // else or root-poisons the tree. It must not be what we tell the operator.
+    expect(err).not.toMatch(/(^|[;&|]\s*)sudo\s+npm/m);
+  });
+
+  it("PROCEEDS to the agent-roll step when the host CLI is already on the target", async () => {
+    const configPath = makeHost("0.0.1");
+    const { out } = await runRollout(configPath);
+
+    expect(process.exitCode).not.toBe(2);
+    expect(out).toMatch(/Rollout plan → v0\.0\.1:/);
+    expect(out).toMatch(/restart clerk/);
+  });
+
+  it("PROCEEDS with --allow-stale-host-cli, and says loudly that it is doing so", async () => {
+    const configPath = makeHost("0.0.0");
+    const { out, err } = await runRollout(configPath, ["--allow-stale-host-cli"]);
+
+    expect(out).toMatch(/Rollout plan → v0\.0\.1:/);
+    expect(out).toMatch(/restart clerk/);
+    expect(err).toMatch(/--allow-stale-host-cli/);
+    expect(err).toContain("npm i -g switchroom@0.0.1");
+  });
+
+  it("never blocks when no stamp exists — a host CLI predating the stamp writes none", async () => {
+    const configPath = makeHost(undefined);
+    const { out } = await runRollout(configPath);
+
+    expect(out).toMatch(/Rollout plan → v0\.0\.1:/);
+  });
+});

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -55,6 +55,14 @@ import {
   recoverPinJournal,
 } from "./rollout-pin-journal.js";
 import { resolveOperatorUid } from "./operator-uid.js";
+import {
+  HOST_CLI_STAMP_FILENAME,
+  PREFLIGHT_HOST_CLI_STALE_STEP,
+  hostCliInstallCommand,
+  observeHostCli,
+  readHostCliStamp,
+  shouldRefuseStaleHostCli,
+} from "./host-cli-stamp.js";
 import { resolveSelfInvocation } from "./self-invoke.js";
 import { writeConfigFileSync } from "../util/atomic.js";
 import { compareReleaseTags } from "../config/release-resolve.js";
@@ -2186,7 +2194,12 @@ export function createRolloutDeps(params: {
         if (cmd !== "docker") return { status: 1, stdout: "" };
         const r = dockerRun(args);
         return { status: r.ok ? 0 : 1, stdout: r.stdout };
-      }) satisfies ExecFn),
+      }) satisfies ExecFn,
+      // #4571 — inside hostd, SWITCHROOM_VERSION is the hostd IMAGE's CLI,
+      // not the host operator's. Hand the collector the stamped host version
+      // so the `cli (host)` row stops reporting the container's own version
+      // under a `(host)` label.
+      observeHostCli({}, params.hostdCtx)),
     persistPin: (pin) => {
       const before = readFileSync(configPath, "utf8");
       const after = setReleasePinInConfig(before, pin);
@@ -2279,8 +2292,17 @@ export function registerRolloutCommand(program: Command): void {
         "When set, the downgrade guard is relaxed so --pin may be older than the " +
         "current release.pin. All other safety rails apply unchanged.",
     )
+    .option(
+      "--allow-stale-host-cli",
+      "Roll the fleet even though the HOST operator CLI is observably behind " +
+        "the target. Escape hatch for the host-CLI-first gate: the host CLI is " +
+        "then left drifted and every later host-shell command runs old code. " +
+        "HOST-SHELL ONLY: deliberately not exposed as an `mcp__hostd__rollout` " +
+        "parameter, so an agent cannot roll past the gate on its own — " +
+        "overriding requires the same host shell needed to actually fix it.",
+    )
     .option("--dry-run", "Print the plan and exit without changing anything.")
-    .action(async (opts: { pin?: string; agents?: string; skipWeb?: boolean; allowDowngrade?: boolean; dryRun?: boolean }) => {
+    .action(async (opts: { pin?: string; agents?: string; skipWeb?: boolean; allowDowngrade?: boolean; allowStaleHostCli?: boolean; dryRun?: boolean }) => {
       // Crash recovery (host-shell path). A previous roll that was SIGKILLed
       // between the provisional `release.pin` write and its commit leaves a
       // journal on disk; revert it BEFORE reading the config, so this roll
@@ -2371,6 +2393,68 @@ export function registerRolloutCommand(program: Command): void {
         }
         process.exitCode = 2;
         return;
+      }
+      // #4571 — HOST-CLI-FIRST gate. The host operator CLI must already be on
+      // the target before a single agent moves.
+      //
+      // On the host-shell path the driving CLI IS the host CLI, so the
+      // `shouldRefuseStaleCli` guard above already enforces this. On the
+      // agent/hostd path it does not: the driving CLI is the hostd IMAGE's
+      // bundled CLI, and nothing in the roll ever observed the host binary —
+      // it was named in a trailing warning after every agent had already
+      // moved. That is how the host CLI reached five releases of drift with
+      // every roll exiting green.
+      //
+      // hostd mounts only `~/.switchroom` (hostd.ts:332): it cannot read
+      // `/usr/local/bin`, cannot read an nvm tree, and cannot `npm i -g` on
+      // the host. So the roll CANNOT install the host CLI itself and any step
+      // claiming to would be a lie. What it can do is REFUSE — deterministic,
+      // before the first mutation, with the correct install command derived
+      // from what the host CLI recorded about itself
+      // (`~/.switchroom/host-cli.json`, written by every host-context CLI
+      // invocation). Silence becomes impossible; the ordering becomes real.
+      //
+      // Conservative, like every other guard here: no stamp (a host CLI older
+      // than this feature never wrote one) or an unorderable version never
+      // blocks. `--allow-stale-host-cli` is the explicit override.
+      const hostCliStamp = readHostCliStamp();
+      if (
+        !opts.allowStaleHostCli &&
+        shouldRefuseStaleHostCli(hostCliStamp, target)
+      ) {
+        const observed = hostCliStamp?.version ?? "unknown";
+        const refusal =
+          `rollout refused: the HOST operator CLI is v${observed}, OLDER than ` +
+          `the target ${target}. The host CLI must be upgraded FIRST — it is ` +
+          `what runs \`switchroom apply\`, \`vault\`, \`doctor\` and the next ` +
+          `roll host-side, and leaving it behind is how it silently drifted ` +
+          `five releases. Run this on the host, then re-run the roll: ` +
+          `${hostCliInstallCommand(hostCliStamp, target)}. ` +
+          `(Observed from ${HOST_CLI_STAMP_FILENAME}, refreshed by every ` +
+          `host-context switchroom command — if you already upgraded, run any ` +
+          `switchroom command on the host to refresh it, or pass ` +
+          `--allow-stale-host-cli to roll anyway.) Nothing was changed.`;
+        process.stderr.write(refusal + "\n");
+        if (hostdCtx) {
+          process.stdout.write(
+            encodeRolloutResultLine({
+              ok: false,
+              rolled: [],
+              failedStep: PREFLIGHT_HOST_CLI_STALE_STEP,
+              got: observed,
+              warnings: [refusal],
+            }) + "\n",
+          );
+        }
+        process.exitCode = 2;
+        return;
+      }
+      if (opts.allowStaleHostCli && shouldRefuseStaleHostCli(hostCliStamp, target)) {
+        process.stderr.write(
+          `⚠️  --allow-stale-host-cli: rolling past a HOST operator CLI on ` +
+            `v${hostCliStamp?.version} (target ${target}). Fix it host-side ` +
+            `with: ${hostCliInstallCommand(hostCliStamp, target)}\n`,
+        );
       }
       // #2487 PR2 — downgrade guard: reject a version older than the
       // current release.pin on the hostd path UNLESS --allow-downgrade is
@@ -2505,9 +2589,28 @@ export function registerRolloutCommand(program: Command): void {
                 `full hostd template regen (only needed when a release changes ` +
                 `hostd's mounts/env) is \`switchroom hostd install --tag ${target}\` ` +
                 `host-side. `;
+        // #4571 — the host CLI clause is now derived from what was OBSERVED,
+        // not asserted unconditionally. Reaching here with the host CLI
+        // behind means `--allow-stale-host-cli` was passed (the gate refuses
+        // otherwise), so the three cases are: measured-and-current (say
+        // nothing — the old text claimed drift that no longer exists),
+        // measured-and-behind (name the version AND the command derived from
+        // the recorded install kind/prefix/owner — `sudo npm i -g` is wrong
+        // on a user-prefix nvm install), and unmeasured (say so honestly).
+        const hostCliClause = !hostCliStamp
+          ? `the host operator CLI's version could NOT be observed from here ` +
+            `(no ${HOST_CLI_STAMP_FILENAME} in the switchroom home — it is ` +
+            `written by any host-context switchroom command). Confirm it ` +
+            `host-side with \`switchroom --version\`; if it is behind: ` +
+            `${hostCliInstallCommand(undefined, target)}. `
+          : shouldRefuseStaleHostCli(hostCliStamp, target)
+            ? `still on the PRIOR version after this roll: the host operator ` +
+              `CLI (observed v${hostCliStamp.version}, target ${target}) — ` +
+              `you passed --allow-stale-host-cli. Fix it host-side: ` +
+              `${hostCliInstallCommand(hostCliStamp, target)}. `
+            : "";
         result.warnings.push(
-          `still on the PRIOR version after this roll: the host operator ` +
-            `CLI (\`sudo npm i -g switchroom@${normalizeVersion(target)}\`). ` +
+          hostCliClause +
             regenClause +
             `An agent-invoked rollout cannot recreate its own hostd ` +
             `container mid-roll without killing itself.` +

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -62,6 +62,7 @@ import {
   observeHostCli,
   readHostCliStamp,
   shouldRefuseStaleHostCli,
+  type HostCliStamp,
 } from "./host-cli-stamp.js";
 import { resolveSelfInvocation } from "./self-invoke.js";
 import { writeConfigFileSync } from "../util/atomic.js";
@@ -688,6 +689,18 @@ export interface RolloutDeps {
    * look like a converged one.
    */
   collectComponents?(): ComponentVersion[];
+  /**
+   * The HOST operator CLI's own install record (#4571), when one was readable.
+   *
+   * Threaded through so the executor's drift warnings render the SAME `fix:`
+   * doctor does — `remediationFor`'s contract is that an operator is never
+   * given two different answers for one drifted component, and without this
+   * the roll keeps emitting the generic "`switchroom update` self-updates the
+   * host CLI", which is a no-op on the npm install this issue was opened
+   * about. Optional: absent (no stamp, or a test) degrades to that generic
+   * text, which is the pre-#4571 behaviour.
+   */
+  hostCli?: HostCliStamp;
 }
 
 export interface RolloutResult {
@@ -1610,7 +1623,7 @@ export async function executeRollout(
               `${c.name} is on ${c.version ?? "an unreadable version"}, behind ` +
                 `${target}, but was OUTSIDE this roll's scope (no step in this ` +
                 `plan owns it). Finish it: ` +
-                `${remediationFor(classifyComponent(c), `v${normalizeVersion(target)}`)}`,
+                `${remediationFor(classifyComponent(c), `v${normalizeVersion(target)}`, deps.hostCli)}`,
             );
           }
           break;
@@ -1734,7 +1747,7 @@ export async function executeRollout(
         `${c.name} is STILL on ${c.version ?? "an unreadable version"} after ` +
           `the roll to ${target} — it was in this roll's scope and did not ` +
           `converge. Finish it: ` +
-          `${remediationFor(classifyComponent(c), normalizedTarget)}`,
+          `${remediationFor(classifyComponent(c), normalizedTarget, deps.hostCli)}`,
       );
     }
     deps.log(
@@ -2200,6 +2213,13 @@ export function createRolloutDeps(params: {
       // so the `cli (host)` row stops reporting the container's own version
       // under a `(host)` label.
       observeHostCli({}, params.hostdCtx)),
+    // #4571 — the same stamp, for the drift warnings' `fix:` text. Read once
+    // here rather than per-warning, so one roll cannot quote two different
+    // host CLIs if the operator upgrades mid-roll.
+    ...(() => {
+      const stamp = readHostCliStamp();
+      return stamp ? { hostCli: stamp } : {};
+    })(),
     persistPin: (pin) => {
       const before = readFileSync(configPath, "utf8");
       const after = setReleasePinInConfig(before, pin);

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -52,6 +52,7 @@ import { normalizeHindsightVersionTag } from "../setup/hindsight.js";
 import { getBuiltinDefaultSkillEntries } from "../memory/scaffold-integration.js";
 import { syncBundledSkills } from "./sync-bundled-skills.js";
 import { SWITCHROOM_VERSION } from "./resolve-version.js";
+import { observeHostCli } from "./host-cli-stamp.js";
 import {
   alreadySelfUpdated,
   detectInstallKind,
@@ -1718,7 +1719,10 @@ export function renderDriftPreamble(opts: UpdateOptions): string {
       pin = undefined;
     }
     const report = detectComponentDrift(
-      collectComponents(SWITCHROOM_VERSION, exec),
+      // #4571 — `observeHostCli()` keeps the `cli (host)` row honest when this
+      // runs inside a container (the hostd `update_check` verb): the running
+      // CLI is the IMAGE's, not the host's.
+      collectComponents(SWITCHROOM_VERSION, exec, observeHostCli()),
       pin,
     );
     const body = formatComponentDrift(report);

--- a/src/host-control/render-rollout-status.ts
+++ b/src/host-control/render-rollout-status.ts
@@ -34,9 +34,9 @@ import {
 // #4571 — the host CLI's install record + the DERIVED upgrade command. Pure
 // functions only (no fs from the renderer): the stamp arrives on the state.
 import {
+  compareHostCliToTarget,
   hostCliInstallCommand,
   hostCliInstallShellCommand,
-  shouldRefuseStaleHostCli,
   type HostCliStamp,
 } from "../cli/host-cli-stamp.js";
 
@@ -357,22 +357,33 @@ function deferredLines(
   // against a stale host CLI, so on a completed roll the stamp normally says
   // the host CLI is already on target — printing "still host-side: upgrade the
   // CLI" there is the same false residual #3928 removed for switchroom-web.
-  const hostCliOutstanding = hostCli === undefined || shouldRefuseStaleHostCli(hostCli, target);
-  if (hostCli && !hostCliOutstanding) {
+  //
+  // Dropping the line requires PROOF of convergence, not merely the absence of
+  // proof of drift: an unorderable stamp (`0.20.16-rc.1`, `sha-…`) is exactly
+  // what the gate declines to block on, and reading that silence as "converged"
+  // would print a fresh all-clear over the drift this file exists to expose.
+  const posture = compareHostCliToTarget(hostCli, target);
+  const hostCliOutstanding = posture !== "current-or-ahead";
+  if (posture === "current-or-ahead" && hostCli) {
     head.push(
       `Host operator CLI: **on ${hostCli.version}** (read from \`~/.switchroom/host-cli.json\`) — nothing to do.`,
     );
   }
   const cliCommand = hostCliInstallCommand(hostCli, target);
-  const cliLine = hostCli
-    ? `- host operator CLI — observed **${hostCli.version}**, run: \`${cliCommand}\``
-    : `- host operator CLI (version not observable from here — no \`~/.switchroom/host-cli.json\`) — ${cliCommand}`;
+  const cliLine = !hostCli
+    ? `- host operator CLI (version not observable from here — no \`~/.switchroom/host-cli.json\`) — ${cliCommand}`
+    : posture === "behind"
+      ? `- host operator CLI — observed **${hostCli.version}**, run: \`${cliCommand}\``
+      : `- host operator CLI — observed **${hostCli.version}**, which is not comparable to ${target} (a channel/pre-release build). Confirm host-side with \`switchroom --version\`; if it is behind: ${cliCommand}`;
   const verdict = hostdTemplateRegenVerdict(target, fromVersion);
   // #4269's one-copy-paste block, preserved only where it is still CORRECT:
   // both residuals collapse into one line when the host CLI's upgrade is a
   // pasteable command (see hostCliInstallShellCommand for when it is not).
+  // Only a PROVEN-behind host CLI collapses: the "not comparable, confirm
+  // host-side" caveat cannot survive being &&-chained any more than the
+  // "run as <user>" one can.
   const collapsible =
-    verdict === "required" && hostCliOutstanding
+    verdict === "required" && posture === "behind"
       ? hostCliInstallShellCommand(hostCli, target)
       : undefined;
   if (collapsible) {

--- a/src/host-control/render-rollout-status.ts
+++ b/src/host-control/render-rollout-status.ts
@@ -31,6 +31,14 @@ import {
   HOSTD_TEMPLATE_LAST_CHANGED,
   hostdTemplateRegenVerdict,
 } from "../config/hostd-template-version.js";
+// #4571 — the host CLI's install record + the DERIVED upgrade command. Pure
+// functions only (no fs from the renderer): the stamp arrives on the state.
+import {
+  hostCliInstallCommand,
+  hostCliInstallShellCommand,
+  shouldRefuseStaleHostCli,
+  type HostCliStamp,
+} from "../cli/host-cli-stamp.js";
 
 /** Per-agent progress an accumulator (the narrator) feeds the renderer. */
 export type AgentRollStatus = "pending" | "running" | "done" | "failed";
@@ -112,6 +120,15 @@ export interface RolloutRenderState {
   elapsedMs?: number;
   /** True once the hostd/web refresh was deferred to a host-side run. */
   deferred?: boolean;
+  /**
+   * The HOST operator CLI's own install record (#4571), when hostd could read
+   * `~/.switchroom/host-cli.json`. Two things depend on it, and both used to be
+   * guesses: whether the "still host-side — upgrade the CLI" line belongs on
+   * the card at all (a converged host CLI must not be listed as outstanding),
+   * and what the upgrade command actually is (`sudo npm i -g` is wrong on the
+   * user-owned nvm prefix this fleet actually runs).
+   */
+  hostCli?: HostCliStamp;
   /** Terminal outcome — set only once the roll finished. */
   terminal?: "completed" | "error";
   /** Step that stopped a failed roll. */
@@ -328,33 +345,52 @@ function etaLine(s: RolloutRenderState): string | null {
  * When the regen IS required, both residual commands collapse into one
  * copy-paste line.
  */
-function deferredLines(target: string, fromVersion?: string): string[] {
-  const bare = target.trim().replace(/^v/, "");
+function deferredLines(
+  target: string,
+  fromVersion?: string,
+  hostCli?: HostCliStamp,
+): string[] {
   const head = [
     `**Verified on ${target}** — every component this roll owned passed \`verify-components\`, so this is host convergence, not just the agents. Anything the roll was told to skip is named in its warnings.`,
-    `**Still host-side (nothing in a roll can do these):**`,
   ];
+  // #4571 — the host CLI line is CONDITIONAL now. A roll refuses to start
+  // against a stale host CLI, so on a completed roll the stamp normally says
+  // the host CLI is already on target — printing "still host-side: upgrade the
+  // CLI" there is the same false residual #3928 removed for switchroom-web.
+  const hostCliOutstanding = hostCli === undefined || shouldRefuseStaleHostCli(hostCli, target);
+  if (hostCli && !hostCliOutstanding) {
+    head.push(
+      `Host operator CLI: **on ${hostCli.version}** (read from \`~/.switchroom/host-cli.json\`) — nothing to do.`,
+    );
+  }
+  const cliCommand = hostCliInstallCommand(hostCli, target);
+  const cliLine = hostCli
+    ? `- host operator CLI — observed **${hostCli.version}**, run: \`${cliCommand}\``
+    : `- host operator CLI (version not observable from here — no \`~/.switchroom/host-cli.json\`) — ${cliCommand}`;
   const verdict = hostdTemplateRegenVerdict(target, fromVersion);
-  if (verdict === "required") {
+  // #4269's one-copy-paste block, preserved only where it is still CORRECT:
+  // both residuals collapse into one line when the host CLI's upgrade is a
+  // pasteable command (see hostCliInstallShellCommand for when it is not).
+  const collapsible =
+    verdict === "required" && hostCliOutstanding
+      ? hostCliInstallShellCommand(hostCli, target)
+      : undefined;
+  if (collapsible) {
     return [
       ...head,
+      `**Still host-side (nothing in a roll can do these):**`,
       `- host operator CLI + hostd template regen — regen is **REQUIRED** for this roll (hostd mounts/env changed in ${HOSTD_TEMPLATE_LAST_CHANGED}). One copy-paste:`,
-      `  \`sudo npm i -g switchroom@${bare} && switchroom hostd install --tag ${target}\``,
+      `  \`${collapsible} && switchroom hostd install --tag ${target}\``,
     ];
   }
-  const cliLine = `- host operator CLI — \`sudo npm i -g switchroom@${bare}\``;
-  if (verdict === "not-needed") {
-    return [
-      ...head,
-      cliLine,
-      `- hostd template regen: **not needed** for this release — hostd mounts/env unchanged since ${HOSTD_TEMPLATE_LAST_CHANGED}.`,
-    ];
-  }
-  return [
-    ...head,
-    cliLine,
-    `- hostd template regen (only if the release changed hostd mounts/env) — \`switchroom hostd install --tag ${target}\``,
-  ];
+  const regenLine =
+    verdict === "required"
+      ? `- hostd template regen — **REQUIRED** for this roll (hostd mounts/env changed in ${HOSTD_TEMPLATE_LAST_CHANGED}): \`switchroom hostd install --tag ${target}\``
+      : verdict === "not-needed"
+        ? `- hostd template regen: **not needed** for this release — hostd mounts/env unchanged since ${HOSTD_TEMPLATE_LAST_CHANGED}.`
+        : `- hostd template regen (only if the release changed hostd mounts/env) — \`switchroom hostd install --tag ${target}\``;
+  const outstanding = [...(hostCliOutstanding ? [cliLine] : []), regenLine];
+  return [...head, `**Still host-side (nothing in a roll can do these):**`, ...outstanding];
 }
 
 /**
@@ -412,7 +448,8 @@ function renderWith(s: RolloutRenderState, compact: boolean): string {
     if (checklist.length > 0) parts.push("", ...checklist);
     if (singletons.length > 0) parts.push("", ...singletons);
     if (warnings.length > 0) parts.push("", ...warnings);
-    if (s.deferred !== false) parts.push("", ...deferredLines(s.target, s.fromVersion));
+    if (s.deferred !== false)
+      parts.push("", ...deferredLines(s.target, s.fromVersion, s.hostCli));
     return parts.join("\n");
   }
 

--- a/src/host-control/rollout-observability.test.ts
+++ b/src/host-control/rollout-observability.test.ts
@@ -237,7 +237,7 @@ describe("renderRolloutStatus", () => {
     expect(out).toContain("`test-harness`, `clerk`");
     // What is genuinely still host-side, with its exact command.
     expect(out).toContain("Still host-side");
-    expect(out).toContain("sudo npm i -g switchroom@1.2.3");
+    expect(out).toContain("sudo npm i -g --prefix /usr/local switchroom@1.2.3");
     expect(out).toContain("switchroom hostd install --tag v1.2.3");
   });
 
@@ -281,7 +281,9 @@ describe("renderRolloutStatus", () => {
     expect(out).not.toContain("only if the release changed");
     expect(out).not.toContain("switchroom hostd install");
     // The CLI residual is still named.
-    expect(out).toContain(`sudo npm i -g switchroom@${POST_B.slice(1)}`);
+    expect(out).toContain(
+      `sudo npm i -g --prefix /usr/local switchroom@${POST_B.slice(1)}`,
+    );
   });
 
   it("✅ card says regen REQUIRED, as one copy-paste block, when the roll crosses the template change (#4269)", () => {
@@ -298,7 +300,7 @@ describe("renderRolloutStatus", () => {
     expect(out).not.toContain("only if the release changed");
     // Both residuals collapse into a single copy-paste command line.
     expect(out).toContain(
-      `\`sudo npm i -g switchroom@${POST_A.slice(1)} && switchroom hostd install --tag ${POST_A}\``,
+      `\`sudo npm i -g --prefix /usr/local switchroom@${POST_A.slice(1)} && switchroom hostd install --tag ${POST_A}\``,
     );
   });
 
@@ -326,8 +328,10 @@ describe("renderRolloutStatus", () => {
     });
     // `sudo npm i -g` into a user-owned nvm prefix installs into the WRONG
     // tree (or root-poisons this one) — it must never be emitted as a command.
-    expect(out).not.toContain(`sudo npm i -g switchroom@${POST_A.slice(1)}`);
-    expect(out).toContain(`npm i -g switchroom@${POST_A.slice(1)}`);
+    expect(out).not.toContain(`sudo npm i -g`);
+    expect(out).toContain(
+      `npm i -g --prefix /home/op/.nvm/versions/node/v22.22.2 switchroom@${POST_A.slice(1)}`,
+    );
     expect(out).toContain("run as op");
     expect(out).toContain("/home/op/.nvm/versions/node/v22.22.2");
     // …and the regen command is NOT collapsed onto that line, because the
@@ -354,6 +358,51 @@ describe("renderRolloutStatus", () => {
     expect(out).not.toContain("npm i -g switchroom");
     expect(out).not.toContain("host operator CLI —");
     expect(out).toContain(`Host operator CLI: **on ${POST_A.slice(1)}**`);
+  });
+
+  // The inverse of the test above, and the one that matters. Dropping the
+  // residual requires PROOF of convergence. `shouldRefuseStaleHostCli` is
+  // false for an UNORDERABLE stamp as well as a converged one (deliberately —
+  // the roll must not block on a version it cannot compare), so reusing it to
+  // decide "nothing to do" turns every rc/dev/sha host CLI into a fresh
+  // all-clear over exactly the drift this feature exists to expose.
+  it("✅ card does NOT claim 'nothing to do' for an UNORDERABLE host CLI version", () => {
+    const out = renderRolloutStatus({
+      target: POST_A,
+      fromVersion: POST_A,
+      terminal: "completed",
+      rolled: ["test-harness"],
+      m: 1,
+      // `switchroom update --channel rc` produces exactly this shape.
+      hostCli: userNvmHostCli(`${PRE_TEMPLATE_CHANGE.slice(1)}-rc.1`),
+    });
+    expect(out).not.toContain("nothing to do");
+    // Still listed as outstanding, and honest about WHY it can't be ordered.
+    expect(out).toContain("Still host-side");
+    expect(out).toContain("not comparable");
+    expect(out).toContain("switchroom --version");
+    expect(out).toContain(
+      `npm i -g --prefix /home/op/.nvm/versions/node/v22.22.2 switchroom@${POST_A.slice(1)}`,
+    );
+  });
+
+  it("✅ card never &&-collapses an UNORDERABLE host CLI into one copy-paste", () => {
+    // Regen REQUIRED + a root-owned npm tree is the one shape that collapses.
+    // An unorderable version must still not collapse: the "confirm host-side"
+    // caveat is load-bearing and cannot survive an `&&` chain, exactly like
+    // the "run as <user>" one.
+    const out = renderRolloutStatus({
+      target: POST_A,
+      fromVersion: PRE_TEMPLATE_CHANGE,
+      terminal: "completed",
+      rolled: ["test-harness"],
+      m: 1,
+      hostCli: rootNpmHostCli(`${PRE_TEMPLATE_CHANGE.slice(1)}-rc.1`),
+    });
+    expect(out).toContain("REQUIRED");
+    expect(out).not.toContain("One copy-paste");
+    expect(out).not.toContain(`&& switchroom hostd install --tag ${POST_A}\``);
+    expect(out).toContain("not comparable");
   });
 
   it("renders the ❌ terminal-error summary with the failed step + agent", () => {

--- a/src/host-control/rollout-observability.test.ts
+++ b/src/host-control/rollout-observability.test.ts
@@ -15,6 +15,7 @@ import {
   formatDurationMs,
 } from "./render-rollout-status.js";
 import { HOSTD_TEMPLATE_LAST_CHANGED } from "../config/hostd-template-version.js";
+import type { HostCliStamp } from "../cli/host-cli-stamp.js";
 
 /** Build one JSONL audit row (the shape hostd writes, chain fields elided —
  *  parseAuditLine ignores `_seq`/`_prev`/`_hash`). */
@@ -197,6 +198,30 @@ describe("renderRolloutStatus", () => {
     expect(out).toContain("elapsed 1m 45s");
   });
 
+  /**
+   * #4571 — the host-CLI residual is now DERIVED from the host CLI's own
+   * install stamp rather than hardcoded to `sudo npm i -g`. These fixtures pin
+   * the two install shapes: a root-owned npm tree (where `sudo npm i -g`
+   * genuinely IS the command) and the user-owned nvm prefix this fleet
+   * actually runs (where it is not).
+   */
+  const rootNpmHostCli = (version: string): HostCliStamp => ({
+    version,
+    installKind: "npm-global",
+    path: "/usr/local/lib/node_modules/switchroom/dist/cli/switchroom.js",
+    npmPrefix: "/usr/local",
+    ownerUid: 0,
+    ownerUser: "root",
+  });
+  const userNvmHostCli = (version: string): HostCliStamp => ({
+    version,
+    installKind: "npm-global",
+    path: "/home/op/.nvm/versions/node/v22.22.2/lib/node_modules/switchroom/dist/cli/switchroom.js",
+    npmPrefix: "/home/op/.nvm/versions/node/v22.22.2",
+    ownerUid: 1000,
+    ownerUser: "op",
+  });
+
   it("renders the ✅ terminal summary with rolled list, elapsed total and deferred components", () => {
     const out = renderRolloutStatus({
       target: "v1.2.3",
@@ -204,6 +229,7 @@ describe("renderRolloutStatus", () => {
       rolled: ["test-harness", "clerk"],
       m: 2,
       elapsedMs: 492_000,
+      hostCli: rootNpmHostCli("1.2.0"),
     });
     expect(out.startsWith("✅")).toBe(true);
     expect(out).toContain("Done");
@@ -247,6 +273,7 @@ describe("renderRolloutStatus", () => {
       terminal: "completed",
       rolled: ["test-harness"],
       m: 1,
+      hostCli: rootNpmHostCli(PRE_TEMPLATE_CHANGE.slice(1)),
     });
     expect(out).toContain("not needed");
     expect(out).toContain(`unchanged since ${HOSTD_TEMPLATE_LAST_CHANGED}`);
@@ -264,6 +291,7 @@ describe("renderRolloutStatus", () => {
       terminal: "completed",
       rolled: ["test-harness"],
       m: 1,
+      hostCli: rootNpmHostCli(PRE_TEMPLATE_CHANGE.slice(1)),
     });
     expect(out).toContain("REQUIRED");
     expect(out).toContain(`changed in ${HOSTD_TEMPLATE_LAST_CHANGED}`);
@@ -283,6 +311,49 @@ describe("renderRolloutStatus", () => {
     });
     expect(out).toContain("only if the release changed hostd mounts/env");
     expect(out).toContain(`switchroom hostd install --tag ${POST_A}`);
+  });
+
+  // #4571 — the two regressions the hardcoded `sudo npm i -g` line caused on
+  // the reference host: wrong advice, and advice for work already done.
+  it("✅ card never tells a USER-OWNED npm install to sudo, and names the owner", () => {
+    const out = renderRolloutStatus({
+      target: POST_A,
+      fromVersion: PRE_TEMPLATE_CHANGE,
+      terminal: "completed",
+      rolled: ["test-harness"],
+      m: 1,
+      hostCli: userNvmHostCli(PRE_TEMPLATE_CHANGE.slice(1)),
+    });
+    // `sudo npm i -g` into a user-owned nvm prefix installs into the WRONG
+    // tree (or root-poisons this one) — it must never be emitted as a command.
+    expect(out).not.toContain(`sudo npm i -g switchroom@${POST_A.slice(1)}`);
+    expect(out).toContain(`npm i -g switchroom@${POST_A.slice(1)}`);
+    expect(out).toContain("run as op");
+    expect(out).toContain("/home/op/.nvm/versions/node/v22.22.2");
+    // …and the regen command is NOT collapsed onto that line, because the
+    // "run as op, NOT under sudo" caveat cannot survive an `&&` chain.
+    expect(out).not.toContain(
+      `&& switchroom hostd install --tag ${POST_A}\``,
+    );
+    expect(out).toContain(`switchroom hostd install --tag ${POST_A}`);
+  });
+
+  it("✅ card does NOT list the host CLI as outstanding once it is already on target", () => {
+    // The roll refuses to start against a stale host CLI (#4571 preflight
+    // gate), so on a completed roll the stamp normally reads >= target. Naming
+    // it as "still host-side" then is the same false residual #3928 deleted
+    // for switchroom-web — work the operator would redo for nothing.
+    const out = renderRolloutStatus({
+      target: POST_A,
+      fromVersion: POST_A,
+      terminal: "completed",
+      rolled: ["test-harness"],
+      m: 1,
+      hostCli: userNvmHostCli(POST_A.slice(1)),
+    });
+    expect(out).not.toContain("npm i -g switchroom");
+    expect(out).not.toContain("host operator CLI —");
+    expect(out).toContain(`Host operator CLI: **on ${POST_A.slice(1)}**`);
   });
 
   it("renders the ❌ terminal-error summary with the failed step + agent", () => {

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -107,6 +107,7 @@ import { classifyBlastRadius } from "./config-blast-radius.js";
 import type { ApprovalGateway } from "./approval-gateway.js";
 import type { RolloutRelay } from "./rollout-relay.js";
 import { renderRolloutStatus } from "./render-rollout-status.js";
+import { readHostCliStamp } from "../cli/host-cli-stamp.js";
 import { loadConfig, resolveAgentsDir, findConfigFile } from "../config/loader.js";
 import { getAllAgentStatuses } from "../agents/lifecycle.js";
 import {
@@ -4700,6 +4701,14 @@ export class HostdServer {
         ...(entry.warnings && entry.warnings.length > 0
           ? { warnings: entry.warnings }
           : {}),
+        // #4571 — hostd mounts the operator's `~/.switchroom`, so the host
+        // CLI's own stamp is readable from here. Without it the card printed a
+        // hardcoded `sudo npm i -g` (wrong for a user-owned nvm prefix) and
+        // listed the host CLI as outstanding even once it was converged.
+        ...(() => {
+          const stamp = readHostCliStamp();
+          return stamp ? { hostCli: stamp } : {};
+        })(),
       });
       this.opts.rolloutRelay.postTerminal({
         requestId: entry.request_id,


### PR DESCRIPTION
## Summary

The host operator CLI is now upgraded **first** — and the roll refuses to start until it is.

Today's v0.20.21 fleet rollout finished green while the host operator CLI sat on **0.20.16**: five releases of drift, surfaced only by a trailing warning nobody actioned, whose advice was wrong for this host anyway.

## Why — two independent root causes, both in real source at HEAD

1. **The one enumerative drift check was measuring the wrong binary.** `collectComponents` built the `cli (host)` row from `SWITCHROOM_VERSION` — *the checking process's own version* (`src/cli/component-versions.ts`, the removed `const cli: ComponentVersion = {…}` block). On the host shell that is correct; on the agent-invoked path (hostd spawns `switchroom rollout` inside its own container) it reports the **hostd image's bundled CLI** under a `(host)` label. So the check that exists to catch this always agreed with the target, and the real host binary was never measured by anything, at any point in a roll.

2. **The only other signal was post-hoc and wrong.** `src/cli/rollout.ts:2509-2513` (pre-change) pushed an unconditional warning — after every agent had already rolled — telling the operator to run `sudo npm i -g switchroom@X`. On the reference host the CLI lives in the operator's **user-owned nvm prefix**, where `sudo npm i -g` installs into root's prefix or root-poisons the operator's tree.

Contributing: `self-update-cli` returns early for anything that is not a `static-binary` (`src/cli/update.ts`, `detection.kind !== "static-binary"`), so the `switchroom-self-heal.timer` skipped this host's npm install on **every** tick. The self-heal that was supposed to be the backstop structurally could not fire here.

## Design decision — a hard preflight gate, not a synthetic install step

hostd mounts exactly one host path, `~/.switchroom` (`src/cli/hostd.ts:332`), plus the yaml/skills binds and a docker-socket proxy. It has no view of `/usr/local/bin`, no view of an nvm tree, and no way to `npm i -g` on the host. **A roll cannot install the host CLI, and a step claiming to would be a lie.** No privileged helper was invented — that would be architecturally significant and out of scope here.

What it *can* do is observe and refuse:

- **`~/.switchroom/host-cli.json`** — every host-context CLI invocation stamps its own version, install kind, npm prefix and the uid/user owning the install tree. Idempotent (byte-identical stamp is not rewritten), tmp+rename, totally non-throwing, and **chowned back to the home's owner when written as root** so a `sudo switchroom …` run can't freeze the stamp behind EACCES.
- **`switchroom rollout` refuses** before the first mutation when the stamp is older than the target (`failedStep: preflight-host-cli-stale`, exit 2, structured result line on the hostd path), printing the install command **derived from the observed install**.
- **`--allow-stale-host-cli`** overrides, with a loud warning. Host-shell only — deliberately *not* an `mcp__hostd__rollout` parameter, so an agent cannot roll past the gate on its own; overriding needs the same host shell required to actually fix it.
- **Conservative like its neighbours**: no stamp (a host CLI predating this feature writes none) or an unorderable version never blocks. No host is bricked by the release that introduces the gate.

Everything that prints the install command now derives it from the same stamp: `switchroom doctor`'s `cli (host)` fix, the roll's residual warning, and the Telegram terminal card. The card additionally **drops the host-CLI line entirely once the stamp shows it converged** — the same false-residual fix #3928 applied to `switchroom-web`, which otherwise sends an operator to redo finished work. #4269's one-copy-paste block is preserved only where it stays correct (`hostCliInstallShellCommand` returns undefined exactly when the "run as `<user>`, NOT under sudo" caveat is load-bearing).

## New step order

`preflight: crash-recovery / journal` → `preflight: stale driving CLI` → **`preflight: host-CLI-first` (new — refuses)** → `preflight: downgrade guard` → `persist-pin` → `apply` → `restart-agent` (staggered) → `refresh-web` / `refresh-hostd` / `refresh-hindsight` → `sweep` → `ensure-banks` → `verify-components`.

## Test plan

Tests assert the *outcome*, not the path. Mutation-checked: reverting the gate condition to `false && …` fails 2 of the 5 new rollout tests.

- `src/cli/rollout.test.ts` — "host-CLI-first gate (#4571)" ×5: refuses **before the agent-roll step**; names the correct command and asserts the emitted string is not a `sudo` invocation (`/(^|[;&|]\s*)sudo\s/` — the word appears only inside the "NOT under sudo" caution); proceeds when current; proceeds + warns under the override; never blocks with no stamp.
- `src/cli/host-cli-stamp.test.ts` — 25 tests: prefix/owner derivation, idempotence, malformed-stamp tolerance, home-candidate precedence, root-write chown handoff, and the install-command matrix (root npm vs user nvm vs static binary vs no stamp).
- `src/cli/doctor-component-versions.test.ts` — new: in-container **with** a stamp fails on the *stamped* version (the pre-fix code called the host converged); in-container **without** a stamp yields an `unknown` row rather than the container's version reported as the host's.
- `src/host-control/rollout-observability.test.ts` — new: the card never tells a user-owned npm install to `sudo`, does not collapse the caveat into an `&&` chain, and does not list the host CLI once converged.

Scoped locally: `vitest run src/cli/ src/host-control/ src/config/` → 2619 passed. (`src/cli/apply.test.ts` fails with `EROFS` on `~/.switchroom/fleet/…` in this container — a pre-existing hermeticity gap in that suite, untouched by this diff.) `npm run lint` clean, all guards green.

Job spec: `reference/jobs/idempotent-update-and-restart.md` — "run the update again and nothing bad happens" is only true if the thing driving the update is itself current.

## Risk

- The gate can refuse a roll that previously proceeded. That is the intended behaviour change, it is pre-mutation (nothing is touched), and it degrades to non-blocking whenever the host CLI's version is not observable.
- `refreshHostCliStamp` runs at module load in `src/cli/index.ts` on every CLI invocation. It is a no-op inside containers, byte-identical writes are skipped, and every failure path returns a reason instead of throwing. No test imports `src/cli/index.ts`, so there is no test-time side effect.
- The `cli (host)` row can now be `unknown` on the hostd path. It is reported as a skip, and `"cli"` was already excluded from `gatedOwners`, so `verify-components` gains no new failure mode.

## Notes for the operator (deliberately out of scope)

- **This host has two switchroom CLI installs**: the operator's nvm one and `/usr/local/bin/switchroom`, the latter converged by an out-of-repo `/usr/local/sbin/switchroom-cli-converge.sh` + `switchroom-cli-converge.timer`. The nvm `package.json` already reads 0.20.21 (mtime today 17:06), so something upgraded it after the roll. Worth deciding which install is canonical — the stamp records whichever one actually runs.
- Not done here: making `self-update-cli` able to converge an npm-global install, and exposing an override on the hostd verb. Both are separate concerns.
