### PR TITLE
fix(gateway): keep state-dir writes owned by the agent uid, not root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ now an anomaly worth investigating, not the norm.
 
 - **telegram: persist card/status messages so a quote-reply to them resolves**
 
+- **gateway: keep state-dir writes owned by the agent uid, not root**
+
 ### Fixed: hindsight's `/metrics` no longer grows a permanent series per document page
 
 - **The `endpoint` metric label is now templated on the whole path segment, so

--- a/src/util/state-owner.ts
+++ b/src/util/state-owner.ts
@@ -1,0 +1,549 @@
+/**
+ * Ownership adoption for files written into an agent's state directory.
+ *
+ * ## The problem
+ *
+ * Most switchroom agents run as their own unprivileged uid, so everything a
+ * gateway (or hook, or sidecar) writes into `~/.switchroom/agents/<name>/`
+ * is owned by that agent and nobody thinks about ownership.
+ *
+ * A ROOT-TIER agent breaks that assumption. Its container runs as uid 0, so
+ * its gateway also runs as uid 0, so every state file it creates lands
+ * `root:root` inside a directory owned by the agent's uid. Nothing breaks
+ * while every reader in that container is also root — which is exactly what
+ * makes it dangerous. The moment a non-root reader appears (the agent is
+ * downgraded off root tier, the host operator at uid 1000 reads or rotates
+ * the state, a `docker exec -u` inspection), that reader gets EACCES on a
+ * file it owns the directory of.
+ *
+ * That failure is SILENT. It is the same shape as #4371, where root-owned
+ * overlay files EACCES'd an agent's in-container schedule loader and dropped
+ * its crons for weeks with nothing in any log. `CLAUDE.md` § "Dev flow & PR
+ * hygiene" ¶2 already states the rule this module enforces mechanically:
+ * a file a root-running process writes into an agent tree MUST end up owned
+ * by that agent's uid.
+ *
+ * ## The fix
+ *
+ * One helper, used by the write paths, that makes a newly created file adopt
+ * the owner of the directory it lives in. Nothing else changes.
+ *
+ * ## Off the root path this is a no-op — by construction
+ *
+ * {@link resolveStateOwner} returns `null` immediately when
+ * `process.getuid() !== 0`, before touching the filesystem. Every other
+ * export short-circuits on that `null`. A non-root gateway therefore issues
+ * ZERO extra syscalls: no stat, no open, no chown. That matters because the
+ * overwhelming majority of the fleet is non-root and these paths sit in the
+ * hot loop (a beacon write every 5s, a heartbeat, a status-pin persist per
+ * reconcile).
+ *
+ * ## Failure is never fatal
+ *
+ * A chown can fail for reasons that are not the caller's fault — a FUSE or
+ * overlay mount that rejects it, a container without `CAP_CHOWN`, a file that
+ * vanished under us. Losing the ownership fix is a hygiene regression; losing
+ * the WRITE would drop a message or an approval. So every failure here is
+ * swallowed, logged ONCE per process (not per path — a 5-second beacon tick
+ * would otherwise fill the log), and the write proceeds.
+ *
+ * ## Symlinks are never followed
+ *
+ * Every ownership change goes through a file descriptor opened `O_NOFOLLOW`
+ * and is applied with `fchown(2)`, never a path-based `chown(2)`. A
+ * path-based chown run by root can be redirected by a symlink raced (or
+ * pre-planted) at the target and hand an attacker a root-owned chown of an
+ * arbitrary inode. `O_NOFOLLOW` + `fchown` closes that: the fd already names
+ * the inode, so there is no TOCTOU window between the check and the change.
+ * This is the same reasoning as the `fchownSync`-on-the-tempfile-fd rule in
+ * `src/util/atomic.ts`.
+ *
+ * A symlink encountered at a write or adopt target therefore yields `ELOOP`,
+ * which is treated as "skip the chown, keep the write" — fail-safe, not
+ * fail-closed.
+ */
+
+import {
+  appendFileSync,
+  closeSync,
+  constants,
+  existsSync,
+  fchownSync,
+  fstatSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  statSync,
+  type Dirent,
+  writeFileSync,
+  type MakeDirectoryOptions,
+} from "node:fs";
+import { dirname, join, relative, sep } from "node:path";
+
+import { atomicWriteFileSync } from "./atomic.js";
+
+/** Resolved target ownership for a state directory. */
+export interface StateOwner {
+  uid: number;
+  gid: number;
+}
+
+/** `O_NOFOLLOW` where the platform has it; `0` (inert) where it doesn't. */
+const NOFOLLOW = constants.O_NOFOLLOW ?? 0;
+
+/**
+ * Per-directory owner cache.
+ *
+ * A `stat(2)` per state write would be a real cost on the beacon tick, and
+ * the answer effectively never changes for a live process (the state dir's
+ * owner is fixed at scaffold time). A cached miss (`null`) is cached too, so
+ * the common "root process, root-owned dir" case also costs one stat total.
+ *
+ * Staleness is bounded and benign: if the directory's owner is changed under
+ * a running gateway, subsequent writes adopt the OLD owner until restart. The
+ * boot reconcile then corrects the tree on the next boot.
+ */
+const ownerCache = new Map<string, StateOwner | null>();
+
+let loggedFailure = false;
+
+/** Default sink — matches the gateway's existing `process.stderr.write` use. */
+function defaultLog(line: string): void {
+  process.stderr.write(line);
+}
+
+/**
+ * Log the FIRST ownership failure of the process and nothing after it.
+ *
+ * One line is enough to diagnose (the errno tells you whether it's a mount,
+ * a missing capability, or a symlink); a line per write would be thousands
+ * per day on the 5-second beacon tick.
+ */
+function noteFailure(op: string, path: string, err: unknown, log: (line: string) => void): void {
+  if (loggedFailure) return;
+  loggedFailure = true;
+  const code = (err as NodeJS.ErrnoException).code ?? "";
+  log(
+    `switchroom state-owner: ${op} could not adopt directory ownership for ${path}` +
+      `${code ? ` (${code})` : ""}: ${(err as Error).message}. ` +
+      `Continuing; state files may stay owned by the writing uid. ` +
+      `Further ownership warnings this process are suppressed.\n`,
+  );
+}
+
+/**
+ * A state file has exactly one name. More than one link to the same inode
+ * means somebody else also names it, and chowning it would change ownership
+ * of THEIR file — the hardlink analogue of the symlink escape `O_NOFOLLOW`
+ * already closes. `fs.protected_hardlinks=1` (the default on the fleet's
+ * kernels) already stops an unprivileged user linking a file they don't own,
+ * so this is defence in depth rather than the primary control.
+ *
+ * Directories are exempt: their link count is `2 + subdirectories` by
+ * construction, so `nlink > 1` says nothing about them.
+ */
+function isMultiplyLinked(st: { nlink: number; isDirectory(): boolean }): boolean {
+  return !st.isDirectory() && st.nlink > 1;
+}
+
+/** Test seam — clears the owner cache and the once-per-process log latch. */
+export function _resetStateOwnerCacheForTests(): void {
+  ownerCache.clear();
+  loggedFailure = false;
+}
+
+/**
+ * The uid/gid a file written into `dir` should end up owned by, or `null`
+ * when nothing needs to change.
+ *
+ * `null` — the overwhelmingly common case — means "do nothing", and is
+ * returned WITHOUT any filesystem call whenever the process is not root.
+ */
+export function resolveStateOwner(dir: string): StateOwner | null {
+  // Fast path, no syscalls: a non-root writer already produces files owned by
+  // the uid that owns the tree. `process.getuid` is absent on Windows.
+  if (typeof process.getuid !== "function" || process.getuid() !== 0) return null;
+
+  const cached = ownerCache.get(dir);
+  if (cached !== undefined) return cached;
+
+  let owner: StateOwner | null = null;
+  try {
+    const st = statSync(dir);
+    // A root-owned directory is already consistent with root-created files.
+    owner = st.uid === 0 && st.gid === 0 ? null : { uid: st.uid, gid: st.gid };
+  } catch {
+    // Directory missing or unreadable — callers that create it will re-resolve
+    // against the parent. Cache the miss so we don't stat on every write.
+    owner = null;
+  }
+  ownerCache.set(dir, owner);
+  return owner;
+}
+
+/**
+ * Give the inode at `path` the ownership of the directory it lives in.
+ *
+ * Use this for files created by something that cannot be routed through the
+ * write helpers below — most importantly SQLite's `-wal` / `-shm` sidecars,
+ * which are created by the SQLite C library at connection and checkpoint
+ * time, not by any `node:fs` call we control.
+ *
+ * No-op when not root, when the directory is root-owned, when the file
+ * doesn't exist, when it's a symlink, or when the file already has the right
+ * owner. Never throws.
+ */
+export function adoptStateOwnership(
+  path: string,
+  owner?: StateOwner | null,
+  log: (line: string) => void = defaultLog,
+): void {
+  const target = owner === undefined ? resolveStateOwner(dirname(path)) : owner;
+  if (!target) return;
+  let fd: number | null = null;
+  try {
+    fd = openSync(path, constants.O_RDONLY | NOFOLLOW);
+    const st = fstatSync(fd);
+    if (st.uid === target.uid && st.gid === target.gid) return;
+    if (isMultiplyLinked(st)) return;
+    fchownSync(fd, target.uid, target.gid);
+  } catch (err) {
+    // ENOENT is the normal "sidecar not created yet" case, not a fault.
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      noteFailure("adopt", path, err, log);
+    }
+  } finally {
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+}
+
+/**
+ * Ownership adoption against an ALREADY-OPEN descriptor.
+ *
+ * The best available form, and the one to prefer wherever the caller has an
+ * fd: there is no path to re-resolve, so a symlink cannot be raced in and
+ * TOCTOU is structurally impossible. Callers that write via
+ * `openSync`+`writeFileSync(fd, …)`+`rename` (the beacon, the durable
+ * tmp+rename writers) should call this on the tempfile fd BEFORE the rename,
+ * so the file is never visible at its final name under the wrong owner.
+ *
+ * `dir` is the directory whose ownership should be adopted — for a tempfile,
+ * the directory it will be renamed within.
+ *
+ * No-op when not root or when the directory is root-owned. Never throws.
+ */
+export function adoptStateOwnershipFd(
+  fd: number,
+  dir: string,
+  log: (line: string) => void = defaultLog,
+): void {
+  const owner = resolveStateOwner(dir);
+  if (!owner) return;
+  try {
+    const st = fstatSync(fd);
+    if (st.uid === owner.uid && st.gid === owner.gid) return;
+    fchownSync(fd, owner.uid, owner.gid);
+  } catch (err) {
+    noteFailure("adopt-fd", dir, err, log);
+  }
+}
+
+/**
+ * Adopt ownership of a SQLite database and both of its WAL sidecars.
+ *
+ * `history.db` / `registry.db` create `<db>-wal` and `<db>-shm` LAZILY: not
+ * at `new Database(...)` but when WAL mode is first engaged, and again after
+ * `PRAGMA wal_checkpoint(TRUNCATE)` deletes and re-creates them. Both call
+ * sites already re-apply `chmod` for exactly this reason; this rides the same
+ * hook so ownership and mode stay in step.
+ *
+ * Missing sidecars are silently skipped (see {@link adoptStateOwnership}).
+ */
+export function adoptSqliteOwnership(
+  dbPath: string,
+  log: (line: string) => void = defaultLog,
+): void {
+  const owner = resolveStateOwner(dirname(dbPath));
+  if (!owner) return;
+  for (const suffix of ["", "-wal", "-shm"]) {
+    adoptStateOwnership(dbPath + suffix, owner, log);
+  }
+}
+
+/**
+ * `mkdirSync(path, { recursive: true, ... })` that hands every directory it
+ * actually CREATES to the owner of the nearest pre-existing ancestor.
+ *
+ * `mkdirSync` with `recursive` returns the first path element it created (or
+ * `undefined` when everything already existed), which is precisely the set we
+ * need to walk: existing directories are left alone.
+ */
+export function mkdirStateSync(
+  path: string,
+  options: MakeDirectoryOptions = { recursive: true },
+  log: (line: string) => void = defaultLog,
+): void {
+  const first = mkdirSync(path, { ...options, recursive: true });
+  if (first === undefined) return; // nothing created — nothing to adopt
+  // The owner comes from the parent of the shallowest directory we created:
+  // that one already existed, so it carries the tree's intended ownership.
+  const owner = resolveStateOwner(dirname(first));
+  if (!owner) return;
+  // Adopt every component from `first` down to `path`.
+  let current = first;
+  adoptStateOwnership(current, owner, log);
+  const tail = relative(first, path);
+  if (tail === "" || tail.startsWith("..")) return;
+  for (const part of tail.split(sep)) {
+    if (part === "") continue;
+    current = join(current, part);
+    adoptStateOwnership(current, owner, log);
+  }
+}
+
+/**
+ * `writeFileSync` that leaves the file owned by the directory's owner.
+ *
+ * Off the root path this IS `writeFileSync` — same call, same arguments, no
+ * wrapper syscalls.
+ *
+ * On the root path the write goes through an `O_NOFOLLOW` descriptor so the
+ * `fchown` targets the exact inode we wrote, with no path resolved twice. If
+ * the target is a symlink (`ELOOP`), we log once and fall back to the plain
+ * write WITHOUT a chown: refusing to chown through a symlink is the security
+ * requirement, refusing to write is not — dropping a state write can drop an
+ * approval or an owed reply.
+ */
+export function writeStateFileSync(
+  path: string,
+  data: string | Buffer,
+  options?: { mode?: number },
+  log: (line: string) => void = defaultLog,
+): void {
+  const owner = resolveStateOwner(dirname(path));
+  if (!owner) {
+    writeFileSync(path, data, options);
+    return;
+  }
+  const mode = options?.mode ?? 0o666;
+  const buf = typeof data === "string" ? Buffer.from(data, "utf-8") : data;
+  let fd: number | null = null;
+  try {
+    fd = openSync(path, constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | NOFOLLOW, mode);
+    writeFileSync(fd, buf);
+    try {
+      fchownSync(fd, owner.uid, owner.gid);
+    } catch (err) {
+      noteFailure("write", path, err, log);
+    }
+  } catch (err) {
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+      fd = null;
+    }
+    // Could not open our way (symlink at the target, or an fs that rejects
+    // the flag set). The write itself must still land.
+    noteFailure("write", path, err, log);
+    writeFileSync(path, data, options);
+    return;
+  } finally {
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+}
+
+/**
+ * `appendFileSync` that leaves the file owned by the directory's owner.
+ *
+ * Appending to an EXISTING file never changes its owner, so the only case
+ * that matters is the first append, which creates the file. Off the root path
+ * this IS `appendFileSync`.
+ */
+export function appendStateFileSync(
+  path: string,
+  data: string | Buffer,
+  options?: { mode?: number },
+  log: (line: string) => void = defaultLog,
+): void {
+  const owner = resolveStateOwner(dirname(path));
+  if (!owner) {
+    appendFileSync(path, data, options);
+    return;
+  }
+  const existed = existsSync(path);
+  appendFileSync(path, data, options);
+  if (!existed) adoptStateOwnership(path, owner, log);
+}
+
+/**
+ * {@link atomicWriteFileSync} with the destination directory's ownership.
+ *
+ * The underlying primitive already flips ownership on the TEMPFILE fd before
+ * the rename, which is the only correct ordering: chowning the destination
+ * path after the rename would follow a symlink raced into place there.
+ */
+export function atomicWriteStateFileSync(
+  path: string,
+  data: string | Buffer,
+  mode = 0o600,
+  log: (line: string) => void = defaultLog,
+): void {
+  const owner = resolveStateOwner(dirname(path));
+  if (!owner) {
+    atomicWriteFileSync(path, data, mode);
+    return;
+  }
+  atomicWriteFileSync(path, data, {
+    mode,
+    uid: owner.uid,
+    gid: owner.gid,
+    onChownError: err => noteFailure("atomic-write", path, err, log),
+  });
+}
+
+/** Result of a {@link reconcileStateDirOwnership} pass. */
+export interface StateOwnershipReconcileResult {
+  /** Entries examined (files + directories). */
+  scanned: number;
+  /** Entries whose ownership was changed. */
+  adopted: number;
+  /** Symlinks skipped without being followed or chowned. */
+  symlinksSkipped: number;
+  /** True when the walk stopped early on `maxEntries` or `maxDepth`. */
+  truncated: boolean;
+}
+
+const EMPTY_RECONCILE: StateOwnershipReconcileResult = {
+  scanned: 0,
+  adopted: 0,
+  symlinksSkipped: 0,
+  truncated: false,
+};
+
+/**
+ * Bounded one-pass ownership reconcile over a state directory.
+ *
+ * ### Why this exists alongside the write helpers
+ *
+ * The helpers above fix ownership going FORWARD, at the write sites they are
+ * wired into. They do nothing about (a) the files a previously-root gateway
+ * already left behind — a live root-tier agent was measured with 1,344 of
+ * them — and (b) files created by a writer outside this process, e.g. a hook
+ * or a sidecar that also runs as root. This pass covers both.
+ *
+ * ### Why it is not a substitute for the write helpers
+ *
+ * A root gateway re-creates its state files continuously (a beacon every five
+ * seconds), so a sweep alone would be a band-aid that is stale seconds after
+ * it runs. The helpers are the fix; this is the backfill.
+ *
+ * ### Bounds — deliberate, and load-bearing
+ *
+ * - **Never follows a symlink.** A real agent state tree contains symlinks
+ *   pointing OUTSIDE the agent directory (e.g. `home/.switchroom ->
+ *   /home/<operator>/.switchroom`). Walking or chowning through one would
+ *   re-own the operator's real home. `readdir(withFileTypes)` classifies via
+ *   `lstat`, so a symlink is identified without ever being resolved, and it is
+ *   counted and skipped — not chowned, not descended into.
+ * - **Depth-capped** (`maxDepth`, default 4) — enough for the state dir's own
+ *   subdirectories (`voice-cache/`, `approved/`, `inbox/`, `buzz/`) without
+ *   turning into an unbounded tree walk.
+ * - **Entry-capped** (`maxEntries`, default 5000) — a runaway directory
+ *   (thousands of cached voice clips) cannot stall boot.
+ *
+ * Never throws. Returns a zero result without any filesystem call when the
+ * process is not root.
+ */
+export function reconcileStateDirOwnership(
+  dir: string,
+  opts: { maxDepth?: number; maxEntries?: number; log?: (line: string) => void } = {},
+): StateOwnershipReconcileResult {
+  const owner = resolveStateOwner(dir);
+  if (!owner) return { ...EMPTY_RECONCILE };
+
+  const maxDepth = opts.maxDepth ?? 4;
+  const maxEntries = opts.maxEntries ?? 5000;
+  const log = opts.log ?? defaultLog;
+  const result: StateOwnershipReconcileResult = { ...EMPTY_RECONCILE };
+
+  const walk = (current: string, depth: number): void => {
+    if (result.scanned >= maxEntries) {
+      result.truncated = true;
+      return;
+    }
+    if (depth > maxDepth) {
+      result.truncated = true;
+      return;
+    }
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch (err) {
+      noteFailure("reconcile", current, err, log);
+      return;
+    }
+    for (const entry of entries) {
+      if (result.scanned >= maxEntries) {
+        result.truncated = true;
+        return;
+      }
+      // lstat-derived: a symlink is NEVER resolved, descended, or chowned.
+      if (entry.isSymbolicLink()) {
+        result.symlinksSkipped++;
+        continue;
+      }
+      const child = join(current, entry.name);
+      result.scanned++;
+      if (adoptAndReport(child, owner, log)) result.adopted++;
+      if (entry.isDirectory()) walk(child, depth + 1);
+    }
+  };
+
+  // The state directory itself is the owner reference, so it needs no adopt.
+  walk(dir, 1);
+  return result;
+}
+
+/**
+ * Adopt and report whether anything actually changed — the reconcile pass
+ * needs the "did I change it" bit that {@link adoptStateOwnership} discards.
+ */
+function adoptAndReport(path: string, owner: StateOwner, log: (line: string) => void): boolean {
+  let fd: number | null = null;
+  try {
+    fd = openSync(path, constants.O_RDONLY | NOFOLLOW);
+    const st = fstatSync(fd);
+    if (st.uid === owner.uid && st.gid === owner.gid) return false;
+    if (isMultiplyLinked(st)) return false;
+    fchownSync(fd, owner.uid, owner.gid);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      noteFailure("reconcile", path, err, log);
+    }
+    return false;
+  } finally {
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+}

--- a/src/util/state-owner.ts
+++ b/src/util/state-owner.ts
@@ -520,6 +520,48 @@ export function reconcileStateDirOwnership(
 }
 
 /**
+ * {@link reconcileStateDirOwnership} plus the caller-side reporting every
+ * caller wants, so the wiring is one line at the call site instead of a
+ * try/catch + formatter inlined into a host file.
+ *
+ * Two behaviours are deliberately owned here rather than by the caller:
+ *
+ * - **Never throws.** The backfill rides the host's existing boot path, where
+ *   an unexpected throw would take the process down before it can serve. A
+ *   failed ownership sweep is a hygiene regression; a failed boot is an
+ *   outage.
+ * - **Silent when there was nothing to do.** The pass runs on every tick and
+ *   the common case (non-root process, or an already-clean tree) adopts
+ *   nothing; logging that every time would be noise. Only a real adoption or
+ *   a truncated walk is worth a line.
+ *
+ * @param dir     state directory to reconcile
+ * @param reason  free-form tick label, echoed into the log line (e.g. `boot`)
+ * @param opts.prefix  log-line prefix identifying the host process
+ * @param opts.write   sink; defaults to stderr (test seam)
+ */
+export function reconcileStateDirOwnershipLogged(
+  dir: string,
+  reason: string,
+  opts: { prefix?: string; write?: (line: string) => void } = {},
+): void {
+  const prefix = opts.prefix ?? "switchroom";
+  const write = opts.write ?? defaultLog;
+  try {
+    const own = reconcileStateDirOwnership(dir);
+    if (own.adopted > 0 || own.truncated) {
+      write(
+        `${prefix}: state-owner reconcile (${reason}) scanned=${own.scanned}` +
+          ` adopted=${own.adopted} symlinksSkipped=${own.symlinksSkipped}` +
+          ` truncated=${own.truncated}\n`,
+      );
+    }
+  } catch (err) {
+    write(`${prefix}: state-owner reconcile (${reason}) failed: ${(err as Error).message}\n`);
+  }
+}
+
+/**
  * Adopt and report whether anything actually changed — the reconcile pass
  * needs the "did I change it" bit that {@link adoptStateOwnership} discards.
  */

--- a/telegram-plugin/gateway/always-allow-persist-queue.ts
+++ b/telegram-plugin/gateway/always-allow-persist-queue.ts
@@ -60,7 +60,7 @@
 
 import { writeFileSync, unlinkSync } from 'node:fs'
 import { join } from 'node:path'
-import { atomicWriteFileSync } from '../../src/util/atomic.js'
+import { atomicWriteStateFileSync } from '../../src/util/state-owner.js'
 import {
   preserveUnreadableStoreFile,
   quarantineCorruptStoreFile,
@@ -182,7 +182,7 @@ export function computeBackoffMs(attempts: number, retryAfterMs?: number): numbe
  */
 export const atomicWriteSeam = ((path, data, opts) => {
   const mode = typeof opts === 'object' && opts !== null && typeof opts.mode === 'number' ? opts.mode : 0o600
-  atomicWriteFileSync(path as string, data as string, mode)
+  atomicWriteStateFileSync(path as string, data as string, mode)
 }) as typeof writeFileSync
 
 export function createAlwaysAllowPersistQueue(

--- a/telegram-plugin/gateway/boot-beacon.ts
+++ b/telegram-plugin/gateway/boot-beacon.ts
@@ -68,7 +68,6 @@ import { randomUUID } from 'node:crypto'
 import {
   closeSync,
   fsyncSync,
-  mkdirSync,
   openSync,
   readFileSync,
   renameSync,
@@ -76,6 +75,7 @@ import {
   writeFileSync,
 } from 'node:fs'
 import { join } from 'node:path'
+import { adoptStateOwnershipFd, mkdirStateSync } from '../../src/util/state-owner.js'
 
 /** Filename under `TELEGRAM_STATE_DIR`. */
 export const BOOT_BEACON_FILE = 'gateway-beacon.json'
@@ -297,12 +297,19 @@ export function writeBootBeaconFile(stateDir: string, beacon: BootBeacon): boole
     // gateway creates it 0o700 at boot. If it were ever missing here, a
     // default-mode recreate by this 5s tick would silently loosen the
     // permissions on that whole directory.
-    mkdirSync(stateDir, { recursive: true, mode: 0o700 })
+    mkdirStateSync(stateDir, { recursive: true, mode: 0o700 })
     fd = openSync(tmp, 'w', 0o600)
     // writeFileSync (not writeSync) on the fd: it loops internally, so a short
     // write can't leave a truncated beacon that we then fsync and rename into
     // place as if it were whole.
     writeFileSync(fd, serializeBootBeacon(beacon))
+    // Ownership on the TEMPFILE FD, before the rename: a root-running gateway
+    // re-creates this file every 5s, so it is the loudest source of root-owned
+    // state in an agent-owned dir. Doing it on the fd (never a path) means no
+    // symlink can be raced in, and doing it before the rename means the file
+    // is never visible at its final name under the wrong owner. No-op off the
+    // root path.
+    adoptStateOwnershipFd(fd, stateDir)
     fsyncSync(fd)
     closeSync(fd)
     fd = undefined

--- a/telegram-plugin/gateway/gateway-heartbeat.ts
+++ b/telegram-plugin/gateway/gateway-heartbeat.ts
@@ -21,8 +21,9 @@
  * conservatively BLOCKS (re-prompt), which is the safe direction.
  */
 
-import { mkdirSync, utimesSync, writeFileSync } from 'node:fs'
+import { utimesSync } from 'node:fs'
 import { join } from 'node:path'
+import { mkdirStateSync, writeStateFileSync } from '../../src/util/state-owner.js'
 
 /** Filename under `TELEGRAM_STATE_DIR`. MUST stay in sync with
  * `GATEWAY_HEARTBEAT_FILE` in `hooks/silent-end-scan.mjs`. */
@@ -47,8 +48,8 @@ export function touchGatewayHeartbeat(stateDir: string): void {
   } catch {
     // File doesn't exist yet (or unstattable) — create it.
     try {
-      mkdirSync(stateDir, { recursive: true })
-      writeFileSync(path, `${Date.now()}\n`, { mode: 0o600 })
+      mkdirStateSync(stateDir, { recursive: true })
+      writeStateFileSync(path, `${Date.now()}\n`, { mode: 0o600 })
     } catch {
       // Best-effort — a heartbeat write failure makes the hook BLOCK
       // (re-prompt), which is the safe direction.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -660,18 +660,8 @@ import { createStatusPinApi, type PinCapableBot, type RobustApiSeam } from './st
 import { collectSweepTargets, type StalePinSweeper, type SweepTarget } from './stale-pin-sweep.js'
 import { createGatewayStalePinSweeper } from './stale-pin-sweep-wiring.js'
 import { reseedSweepLedger } from './stale-pin-sweep-store.js'
-import { atomicWriteFileSync } from '../../src/util/atomic.js'
-// Ownership choke point for state-dir writes: a ROOT-tier agent's gateway runs
-// as uid 0 and would otherwise leave root:root files in an agent-owned dir,
-// EACCESing every non-root reader. Zero-syscall no-op off the root path — see
-// src/util/state-owner.ts.
-import {
-  appendStateFileSync,
-  atomicWriteStateFileSync,
-  mkdirStateSync,
-  reconcileStateDirOwnership,
-  writeStateFileSync,
-} from '../../src/util/state-owner.js'
+// Ownership choke point for every state-dir write; zero-syscall no-op off the root path. Rationale: src/util/state-owner.ts.
+import { appendStateFileSync, atomicWriteStateFileSync, mkdirStateSync, reconcileStateDirOwnershipLogged, writeStateFileSync } from '../../src/util/state-owner.js'
 import { startWebhookIngestServer } from './webhook-ingest-server.js'
 import { recordWebhookEvent } from '../../src/web/webhook-gateway-record.js'
 
@@ -2161,24 +2151,8 @@ function runHistoryReaperNow(reason: 'boot' | 'periodic'): void {
       process.stderr.write(`telegram gateway: history-reaper (${reason}) failed: ${(err as Error).message}\n`)
     }
   }
-  // State-dir ownership backfill for files the write helpers can't reach —
-  // leftovers from a previously-root gateway, and files a sibling root process
-  // (hook, sidecar) created. Rides this EXISTING tick (boot, then 6h) rather
-  // than adding a timer; bounded and symlink-safe, and a single stat when the
-  // process isn't root. Rationale in src/util/state-owner.ts.
-  // (try/catch: this also runs on the BOOT path, where an unexpected throw
-  // would take the gateway down before it can serve.)
-  try {
-    const own = reconcileStateDirOwnership(STATE_DIR)
-    if (own.adopted > 0 || own.truncated) {
-      process.stderr.write(
-        `telegram gateway: state-owner reconcile (${reason}) scanned=${own.scanned}`
-        + ` adopted=${own.adopted} symlinksSkipped=${own.symlinksSkipped} truncated=${own.truncated}\n`,
-      )
-    }
-  } catch (err) {
-    process.stderr.write(`telegram gateway: state-owner reconcile (${reason}) failed: ${(err as Error).message}\n`)
-  }
+  // State-dir ownership backfill (never throws; rides this EXISTING boot/6h tick). See src/util/state-owner.ts.
+  reconcileStateDirOwnershipLogged(STATE_DIR, reason, { prefix: 'telegram gateway' })
 }
 // Run once at boot to catch up long-stopped agents. (#2996 P0c: gated.)
 if (isGatewayMain) runHistoryReaperNow('boot')

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -661,6 +661,17 @@ import { collectSweepTargets, type StalePinSweeper, type SweepTarget } from './s
 import { createGatewayStalePinSweeper } from './stale-pin-sweep-wiring.js'
 import { reseedSweepLedger } from './stale-pin-sweep-store.js'
 import { atomicWriteFileSync } from '../../src/util/atomic.js'
+// Ownership choke point for state-dir writes: a ROOT-tier agent's gateway runs
+// as uid 0 and would otherwise leave root:root files in an agent-owned dir,
+// EACCESing every non-root reader. Zero-syscall no-op off the root path — see
+// src/util/state-owner.ts.
+import {
+  appendStateFileSync,
+  atomicWriteStateFileSync,
+  mkdirStateSync,
+  reconcileStateDirOwnership,
+  writeStateFileSync,
+} from '../../src/util/state-owner.js'
 import { startWebhookIngestServer } from './webhook-ingest-server.js'
 import { recordWebhookEvent } from '../../src/web/webhook-gateway-record.js'
 
@@ -2150,6 +2161,24 @@ function runHistoryReaperNow(reason: 'boot' | 'periodic'): void {
       process.stderr.write(`telegram gateway: history-reaper (${reason}) failed: ${(err as Error).message}\n`)
     }
   }
+  // State-dir ownership backfill for files the write helpers can't reach —
+  // leftovers from a previously-root gateway, and files a sibling root process
+  // (hook, sidecar) created. Rides this EXISTING tick (boot, then 6h) rather
+  // than adding a timer; bounded and symlink-safe, and a single stat when the
+  // process isn't root. Rationale in src/util/state-owner.ts.
+  // (try/catch: this also runs on the BOOT path, where an unexpected throw
+  // would take the gateway down before it can serve.)
+  try {
+    const own = reconcileStateDirOwnership(STATE_DIR)
+    if (own.adopted > 0 || own.truncated) {
+      process.stderr.write(
+        `telegram gateway: state-owner reconcile (${reason}) scanned=${own.scanned}`
+        + ` adopted=${own.adopted} symlinksSkipped=${own.symlinksSkipped} truncated=${own.truncated}\n`,
+      )
+    }
+  } catch (err) {
+    process.stderr.write(`telegram gateway: state-owner reconcile (${reason}) failed: ${(err as Error).message}\n`)
+  }
 }
 // Run once at boot to catch up long-stopped agents. (#2996 P0c: gated.)
 if (isGatewayMain) runHistoryReaperNow('boot')
@@ -2670,7 +2699,7 @@ function noteAgentOutputAt(key: string, ts: number): void {
 const OBLIGATION_STORE_PATH = join(STATE_DIR, 'obligations.json')
 const obligationStoreFs = {
   readFileSync: (p: string) => readFileSync(p, 'utf8'),
-  writeFileSync: (p: string, d: string) => writeFileSync(p, d),
+  writeFileSync: (p: string, d: string) => writeStateFileSync(p, d),
   renameSync: (a: string, b: string) => renameSync(a, b),
   existsSync: (p: string) => existsSync(p),
   fsyncFileSync: fsyncPathSync, fsyncDirSync: fsyncPathSync, unlinkSync,
@@ -8402,7 +8431,7 @@ const statusPinRightsCache = new PinRightsCache()
 const STATUS_PIN_STORE_PATH = join(STATE_DIR, 'status-pins.json')
 const statusPinStoreFs = {
   readFileSync: (p: string) => readFileSync(p, 'utf8'),
-  writeFileSync: (p: string, d: string) => writeFileSync(p, d),
+  writeFileSync: (p: string, d: string) => writeStateFileSync(p, d),
   renameSync: (a: string, b: string) => renameSync(a, b),
   existsSync: (p: string) => existsSync(p),
 }
@@ -8418,7 +8447,7 @@ const statusPinPersistEnabled = !STATIC && PIN_STATUS_WHILE_WORKING
 const ACTIVITY_CARD_STORE_PATH = join(STATE_DIR, 'activity-cards-pending.json')
 const activityCardStoreFs: ActivityCardStoreFsSeam = {
   readFileSync: (p: string) => readFileSync(p, 'utf8'),
-  writeFileSync: (p: string, d: string) => writeFileSync(p, d),
+  writeFileSync: (p: string, d: string) => writeStateFileSync(p, d),
   renameSync: (a: string, b: string) => renameSync(a, b),
   existsSync: (p: string) => existsSync(p),
 }
@@ -8437,7 +8466,7 @@ const activityCardPersistEnabled = !STATIC
 const QUEUED_CARD_STORE_PATH = join(STATE_DIR, 'queued-cards-pending.json')
 const queuedCardStoreFs: QueuedCardStoreFsSeam = {
   readFileSync: (p: string) => readFileSync(p, 'utf8'),
-  writeFileSync: (p: string, d: string) => writeFileSync(p, d),
+  writeFileSync: (p: string, d: string) => writeStateFileSync(p, d),
   renameSync: (a: string, b: string) => renameSync(a, b),
   existsSync: (p: string) => existsSync(p),
 }
@@ -9072,7 +9101,7 @@ let stalePinSweepEligible = false
 const STALE_PIN_SWEEP_STORE_PATH = join(STATE_DIR, 'stale-pin-sweep.json')
 const sweepStoreFs = {
   readFileSync: (p: string) => readFileSync(p, 'utf-8'),
-  writeFileSync: (p: string, data: string) => atomicWriteFileSync(p, data, 0o600),
+  writeFileSync: (p: string, data: string) => atomicWriteStateFileSync(p, data, 0o600),
   existsSync: (p: string) => existsSync(p),
 }
 const stalePinSweeper: StalePinSweeper = createGatewayStalePinSweeper({
@@ -9170,7 +9199,7 @@ let workerActivityFeed: ReturnType<typeof createWorkerActivityFeed> | null = nul
 // ─── IPC server ───────────────────────────────────────────────────────────
 const SOCKET_PATH = process.env.SWITCHROOM_GATEWAY_SOCKET ?? join(STATE_DIR, 'gateway.sock')
 // Ensure the directory for the socket exists (#2996 P0c: gated — disk write).
-if (isGatewayMain) mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 })
+if (isGatewayMain) mkdirStateSync(STATE_DIR, { recursive: true, mode: 0o700 })
 
 // PID file + session marker. See pid-file.ts and session-marker.ts for
 // the 2026-04-22 incident that motivates these. The PID file lets the
@@ -9757,9 +9786,9 @@ if (isGatewayMain) inboundSpool = STATIC
   : createInboundSpool({
       path: join(STATE_DIR, 'inbound-spool.jsonl'),
       fs: {
-        appendFileSync: (p, d) => appendFileSync(p, d),
+        appendFileSync: (p, d) => appendStateFileSync(p, d),
         readFileSync: (p) => readFileSync(p, 'utf8'),
-        writeFileSync: (p, d) => writeFileSync(p, d),
+        writeFileSync: (p, d) => writeStateFileSync(p, d),
         renameSync: (a, b) => renameSync(a, b),
         existsSync: (p) => existsSync(p),
         statSizeSync: (p) => statSync(p).size,
@@ -12866,7 +12895,7 @@ async function publishToTelegraph(
     }
     account = created.value
     try {
-      mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 })
+      mkdirStateSync(STATE_DIR, { recursive: true, mode: 0o700 })
       writeFileSync(accountPath, JSON.stringify(account, null, 2), { mode: 0o600 })
     } catch (err) {
       process.stderr.write(`telegram gateway: telegraph cache write failed: ${(err as Error).message}\n`)
@@ -16085,7 +16114,7 @@ function spawnSwitchroomDetached(
   const logPath = join(STATE_DIR, 'detached-spawn.log')
   let outFd: number | null = null
   try {
-    mkdirSync(STATE_DIR, { recursive: true })
+    mkdirStateSync(STATE_DIR, { recursive: true })
     outFd = openSync(logPath, 'a')
     writeFileSync(logPath, `\n[${new Date().toISOString()}] spawn ${SWITCHROOM_CLI} ${fullArgs.join(' ')}\n`, { flag: 'a' })
   } catch {}
@@ -17601,9 +17630,9 @@ function buildFolderPickerDeps(): FolderPickerHandlerDeps {
 // existing on-disk lockouts age out via DEFAULT_FALLBACK_COOLDOWN_MS.
 const lockoutOps: LockoutPersistOps = {
   readFileSync: (p, enc) => readFileSync(p, enc),
-  writeFileSync: (p, data, opts) => writeFileSync(p, data, opts),
+  writeFileSync: (p, data, opts) => writeStateFileSync(p, data, opts),
   existsSync: (p) => existsSync(p),
-  mkdirSync: (p, opts) => mkdirSync(p, opts),
+  mkdirSync: (p, opts) => mkdirStateSync(p, opts),
   joinPath: (...parts) => join(...parts),
 }
 

--- a/telegram-plugin/gateway/missed-approvals-store.ts
+++ b/telegram-plugin/gateway/missed-approvals-store.ts
@@ -31,7 +31,7 @@
 
 import { unlinkSync } from 'node:fs'
 import { join } from 'node:path'
-import { atomicWriteFileSync } from '../../src/util/atomic.js'
+import { atomicWriteStateFileSync } from '../../src/util/state-owner.js'
 import {
   preserveUnreadableStoreFile,
   quarantineCorruptStoreFile,
@@ -149,7 +149,7 @@ export function createMissedApprovalsStore(
         unreadable = false
       }
       // tmp + fsync + rename — never truncate the destination in place.
-      atomicWriteFileSync(filePath, JSON.stringify(f), 0o600)
+      atomicWriteStateFileSync(filePath, JSON.stringify(f), 0o600)
     } catch (err) {
       log(`telegram gateway: missed-approvals-store write failed: ${(err as Error).message}\n`)
     }

--- a/telegram-plugin/gateway/pending-card-store.ts
+++ b/telegram-plugin/gateway/pending-card-store.ts
@@ -44,7 +44,7 @@
 
 import { unlinkSync } from 'node:fs'
 import { join } from 'node:path'
-import { atomicWriteFileSync } from '../../src/util/atomic.js'
+import { atomicWriteStateFileSync } from '../../src/util/state-owner.js'
 import {
   preserveUnreadableStoreFile,
   quarantineCorruptStoreFile,
@@ -162,7 +162,7 @@ export function createPendingCardStore(
       // tmp + fsync + rename, mode pinned to 0600 on the tempfile fd (so an
       // existing file can't keep laxer perms, and a crash mid-write leaves
       // the previous good file untouched).
-      atomicWriteFileSync(filePath, JSON.stringify(entries), 0o600)
+      atomicWriteStateFileSync(filePath, JSON.stringify(entries), 0o600)
     } catch (err) {
       log(`telegram gateway: pending-card-store write failed: ${(err as Error).message}\n`)
     }

--- a/telegram-plugin/gateway/privacy-state.ts
+++ b/telegram-plugin/gateway/privacy-state.ts
@@ -39,7 +39,7 @@ import { readFileSync, mkdirSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 
-import { atomicWriteFileSync } from '../../src/util/atomic.js'
+import { atomicWriteStateFileSync } from '../../src/util/state-owner.js'
 
 /** One half-open privacy interval. `end: null` = still open ("private now"). */
 export interface PrivacyInterval {
@@ -130,7 +130,7 @@ function writePrivacyState(state: PrivacyState, stateDir: string): void {
     /* dir may already exist / be unwritable — the write below reports */
   }
   try {
-    atomicWriteFileSync(privacyStatePath(stateDir), JSON.stringify(state), 0o600)
+    atomicWriteStateFileSync(privacyStatePath(stateDir), JSON.stringify(state), 0o600)
   } catch (err) {
     process.stderr.write(
       `telegram gateway: privacy-state write failed: ${err instanceof Error ? err.message : String(err)}\n`,

--- a/telegram-plugin/gateway/scoped-grant-store.ts
+++ b/telegram-plugin/gateway/scoped-grant-store.ts
@@ -28,7 +28,7 @@
  */
 
 import { join } from 'node:path'
-import { atomicWriteFileSync } from '../../src/util/atomic.js'
+import { atomicWriteStateFileSync } from '../../src/util/state-owner.js'
 import {
   preserveUnreadableStoreFile,
   quarantineCorruptStoreFile,
@@ -105,7 +105,7 @@ export function createScopedGrantStore(
         }
         // tmp + fsync + rename — a crash mid-persist leaves the previous
         // grant set intact rather than a torn file that reads as "no grants".
-        atomicWriteFileSync(filePath, JSON.stringify(serializeScopedGrants(store)), 0o600)
+        atomicWriteStateFileSync(filePath, JSON.stringify(serializeScopedGrants(store)), 0o600)
       } catch (err) {
         log(`telegram gateway: scoped-grant-store write failed: ${(err as Error).message}\n`)
       }

--- a/telegram-plugin/gateway/turn-active-marker.ts
+++ b/telegram-plugin/gateway/turn-active-marker.ts
@@ -38,15 +38,14 @@
 import {
   closeSync,
   existsSync,
-  mkdirSync,
   openSync,
   readFileSync,
   statSync,
   unlinkSync,
   utimesSync,
-  writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import { mkdirStateSync, writeStateFileSync } from "../../src/util/state-owner.js";
 
 export const TURN_ACTIVE_MARKER_FILE = "turn-active.json";
 
@@ -82,8 +81,8 @@ export interface TurnActiveMarker {
  */
 export function writeTurnActiveMarker(stateDir: string, marker: TurnActiveMarker): void {
   try {
-    mkdirSync(stateDir, { recursive: true });
-    writeFileSync(
+    mkdirStateSync(stateDir, { recursive: true });
+    writeStateFileSync(
       join(stateDir, TURN_ACTIVE_MARKER_FILE),
       JSON.stringify(marker, null, 2) + "\n",
       { mode: 0o600 },

--- a/telegram-plugin/history.ts
+++ b/telegram-plugin/history.ts
@@ -25,8 +25,9 @@
  * chat exists in the DB.
  */
 
-import { chmodSync, existsSync, mkdirSync } from 'fs'
+import { chmodSync, existsSync } from 'fs'
 import { join } from 'path'
+import { adoptSqliteOwnership, mkdirStateSync } from '../src/util/state-owner.js'
 import { redact } from './secret-detect/redact.js'
 
 /**
@@ -216,7 +217,7 @@ function isValidMessageId(id: unknown): id is number {
 export function initHistory(stateDir: string, retentionDays = 30): void {
   if (db != null) return
   const Database = loadDatabaseClass()
-  mkdirSync(stateDir, { recursive: true, mode: 0o700 })
+  mkdirStateSync(stateDir, { recursive: true, mode: 0o700 })
   const path = join(stateDir, 'history.db')
   dbPath = path
   db = new Database(path, { create: true })
@@ -336,6 +337,12 @@ export function initHistory(stateDir: string, retentionDays = 30): void {
     const f = path + suffix
     if (existsSync(f)) { try { chmodSync(f, 0o644) } catch { /* ignore */ } }
   }
+  // Ownership rides the same hook as the mode, for the same reason. SQLite
+  // creates `-wal`/`-shm` itself, in C, so no `node:fs` write helper can ever
+  // see them — this is the only place we get to fix their owner. A root
+  // gateway would otherwise leave root:root DB files in an agent-owned state
+  // dir and EACCES every non-root reader. No-op off the root path.
+  adoptSqliteOwnership(path)
 
   if (retentionDays > 0) {
     const cutoff = Math.floor(Date.now() / 1000) - retentionDays * 86400
@@ -458,6 +465,9 @@ export function checkpointWal(): boolean {
         const f = dbPath + suffix
         if (existsSync(f)) { try { chmodSync(f, 0o644) } catch { /* ignore */ } }
       }
+      // …and ownership with it: a TRUNCATE checkpoint DELETES and RE-CREATES
+      // the sidecars, so the owner we set at init is gone by here.
+      adoptSqliteOwnership(dbPath)
     }
     return true
   } catch {

--- a/telegram-plugin/registry/turns-schema.ts
+++ b/telegram-plugin/registry/turns-schema.ts
@@ -36,8 +36,9 @@
  *   otherwise; the gateway then resumes or reports accordingly.
  */
 
-import { chmodSync, mkdirSync } from 'fs'
+import { chmodSync } from 'fs'
 import { join } from 'path'
+import { adoptSqliteOwnership, mkdirStateSync } from '../../src/util/state-owner.js'
 
 // ---------------------------------------------------------------------------
 // bun:sqlite lazy-loader (same pattern as history.ts)
@@ -302,7 +303,7 @@ function applySchema(db: SqliteDatabase): void {
 export function openTurnsDb(agentDir: string): SqliteDatabase {
   const Database = loadDatabaseClass()
   const dir = join(agentDir, 'telegram')
-  mkdirSync(dir, { recursive: true, mode: 0o700 })
+  mkdirStateSync(dir, { recursive: true, mode: 0o700 })
   const path = join(dir, 'registry.db')
   const db = new Database(path, { create: true })
   applySchema(db)
@@ -318,6 +319,11 @@ export function openTurnsDb(agentDir: string): SqliteDatabase {
   } catch {
     /* ignore — chmod not supported on some FUSE mounts */
   }
+  // Same reasoning as the chmod above, for the owner rather than the mode:
+  // a root-running gateway must not leave root:root DB files in an
+  // agent-owned state dir. `-wal`/`-shm` are created by SQLite in C, so this
+  // hook is the only place we can reach them. No-op off the root path.
+  adoptSqliteOwnership(path)
   return db
 }
 

--- a/tests/state-owner.test.ts
+++ b/tests/state-owner.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Outcome tests for `src/util/state-owner.ts`.
+ *
+ * The bug being guarded: a root-running gateway (root-tier agents run their
+ * container, and therefore their gateway, as uid 0) writes state files into a
+ * directory owned by the agent's uid, leaving them `root:root`. A later
+ * non-root reader then EACCESes on state it owns the directory of — the same
+ * silent failure that dropped an agent's crons for weeks in #4371.
+ *
+ * So the assertions here are about the OWNER of a file on disk after a write,
+ * not about which code path ran.
+ *
+ * ## Why the ownership assertions are root-gated
+ *
+ * Only uid 0 can `chown(2)` a file to an arbitrary uid, so the outcome this
+ * module exists to produce cannot be produced — or observed — by an
+ * unprivileged process. `describe.runIf(isRoot)` runs those cases wherever
+ * the suite runs as root (agent containers, the docker e2e images) and skips
+ * them on an unprivileged runner. The NON-root behaviour — that this change
+ * is inert off the root path — is asserted unconditionally in the block
+ * below it, which is the half an unprivileged runner can actually prove.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  appendFileSync,
+  chownSync,
+  existsSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  _resetStateOwnerCacheForTests,
+  adoptSqliteOwnership,
+  adoptStateOwnership,
+  appendStateFileSync,
+  atomicWriteStateFileSync,
+  mkdirStateSync,
+  reconcileStateDirOwnership,
+  resolveStateOwner,
+  writeStateFileSync,
+} from "../src/util/state-owner.js";
+
+const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
+
+/** Two synthetic uids that exist nowhere — chown(2) does not require them to. */
+const AGENT_UID = 61234;
+const AGENT_GID = 61234;
+const OTHER_UID = 61235;
+
+let root: string;
+
+beforeEach(() => {
+  _resetStateOwnerCacheForTests();
+  root = mkdtempSync(join(tmpdir(), "state-owner-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe.runIf(isRoot)("state-owner: root writer into an agent-owned dir", () => {
+  /** A state dir owned by the agent uid, as the scaffold creates it. */
+  function agentOwnedDir(name = "telegram"): string {
+    const dir = join(root, name);
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    chownSync(dir, AGENT_UID, AGENT_GID);
+    return dir;
+  }
+
+  it("writeStateFileSync leaves the file owned by the directory owner, not root", () => {
+    const dir = agentOwnedDir();
+    const path = join(dir, "turn-active.json");
+
+    writeStateFileSync(path, '{"turnKey":"t1"}\n', { mode: 0o600 });
+
+    const st = statSync(path);
+    expect(st.uid).toBe(AGENT_UID);
+    expect(st.gid).toBe(AGENT_GID);
+    expect(readFileSync(path, "utf-8")).toBe('{"turnKey":"t1"}\n');
+    expect(st.mode & 0o777).toBe(0o600);
+  });
+
+  it("plain writeFileSync in the same place leaves it root-owned (the bug being fixed)", () => {
+    const dir = agentOwnedDir();
+    const path = join(dir, "control.json");
+
+    writeFileSync(path, "x", { mode: 0o600 });
+
+    // This is the pre-fix behaviour, pinned so the test above cannot pass
+    // vacuously (e.g. if the kernel were inheriting ownership from the dir).
+    expect(statSync(path).uid).toBe(0);
+  });
+
+  it("atomicWriteStateFileSync lands the tmp+rename file under the directory owner", () => {
+    const dir = agentOwnedDir();
+    const path = join(dir, "status-pins.json");
+
+    atomicWriteStateFileSync(path, JSON.stringify([{ pinKey: "a" }]), 0o600);
+
+    const st = statSync(path);
+    expect(st.uid).toBe(AGENT_UID);
+    expect(st.gid).toBe(AGENT_GID);
+    expect(JSON.parse(readFileSync(path, "utf-8"))).toEqual([{ pinKey: "a" }]);
+    // No tempfile left behind.
+    expect(existsSync(`${path}.tmp-${process.pid}`)).toBe(false);
+  });
+
+  it("appendStateFileSync adopts on the creating append", () => {
+    const dir = agentOwnedDir();
+    const path = join(dir, "inbound-spool.jsonl");
+
+    appendStateFileSync(path, '{"a":1}\n');
+    appendStateFileSync(path, '{"a":2}\n');
+
+    expect(statSync(path).uid).toBe(AGENT_UID);
+    expect(readFileSync(path, "utf-8")).toBe('{"a":1}\n{"a":2}\n');
+  });
+
+  it("mkdirStateSync adopts every directory it creates and leaves existing ones alone", () => {
+    const dir = agentOwnedDir();
+    // A pre-existing subdir with a deliberately different owner must survive.
+    const preexisting = join(dir, "voice-cache");
+    mkdirSync(preexisting);
+    chownSync(preexisting, OTHER_UID, OTHER_UID);
+
+    mkdirStateSync(join(dir, "buzz", "journal"), { recursive: true, mode: 0o700 });
+    mkdirStateSync(preexisting, { recursive: true });
+
+    expect(statSync(join(dir, "buzz")).uid).toBe(AGENT_UID);
+    expect(statSync(join(dir, "buzz", "journal")).uid).toBe(AGENT_UID);
+    expect(statSync(preexisting).uid).toBe(OTHER_UID);
+  });
+
+  it("adoptSqliteOwnership re-owns the db and both lazily-created sidecars", () => {
+    const dir = agentOwnedDir();
+    const db = join(dir, "history.db");
+    // Stand in for SQLite: files created in C, invisible to any node:fs seam.
+    writeFileSync(db, "SQLite format 3\0");
+    writeFileSync(`${db}-wal`, "wal");
+    // `-shm` deliberately absent — the common case between checkpoints.
+
+    adoptSqliteOwnership(db);
+
+    expect(statSync(db).uid).toBe(AGENT_UID);
+    expect(statSync(`${db}-wal`).uid).toBe(AGENT_UID);
+    expect(existsSync(`${db}-shm`)).toBe(false); // not conjured into existence
+  });
+
+  it("does nothing when the state dir is itself root-owned", () => {
+    const dir = join(root, "root-owned");
+    mkdirSync(dir);
+    const path = join(dir, "beacon.json");
+
+    writeStateFileSync(path, "{}");
+
+    expect(statSync(path).uid).toBe(0);
+    expect(resolveStateOwner(dir)).toBeNull();
+  });
+
+  describe("reconcile sweep", () => {
+    it("adopts root-owned leftovers, including nested ones", () => {
+      const dir = agentOwnedDir();
+      writeFileSync(join(dir, "gateway-beacon.json"), "{}");
+      mkdirSync(join(dir, "approved"));
+      writeFileSync(join(dir, "approved", "12345"), "");
+
+      const result = reconcileStateDirOwnership(dir);
+
+      expect(statSync(join(dir, "gateway-beacon.json")).uid).toBe(AGENT_UID);
+      expect(statSync(join(dir, "approved")).uid).toBe(AGENT_UID);
+      expect(statSync(join(dir, "approved", "12345")).uid).toBe(AGENT_UID);
+      expect(result.adopted).toBe(3);
+      expect(result.truncated).toBe(false);
+    });
+
+    it("never chowns through a symlink that escapes the agent dir", () => {
+      const dir = agentOwnedDir();
+      // The real hazard: a live state dir contains links such as
+      // `home/.switchroom -> /home/<operator>/.switchroom`. Following one
+      // would hand the operator's home to the agent uid.
+      const outsideDir = join(root, "operator-home");
+      mkdirSync(outsideDir);
+      const outsideFile = join(outsideDir, "secret.env");
+      writeFileSync(outsideFile, "x");
+      chownSync(outsideDir, OTHER_UID, OTHER_UID);
+      chownSync(outsideFile, OTHER_UID, OTHER_UID);
+
+      symlinkSync(outsideDir, join(dir, "escape-dir"));
+      symlinkSync(outsideFile, join(dir, "escape-file"));
+
+      const result = reconcileStateDirOwnership(dir);
+
+      // The link targets are untouched — neither descended into nor chowned.
+      expect(statSync(outsideDir).uid).toBe(OTHER_UID);
+      expect(statSync(outsideFile).uid).toBe(OTHER_UID);
+      // …and the links themselves were not re-owned either.
+      expect(lstatSync(join(dir, "escape-file")).uid).toBe(0);
+      expect(result.symlinksSkipped).toBe(2);
+      expect(result.adopted).toBe(0);
+    });
+
+    it("refuses to chown a hardlinked file (the non-symlink escape)", () => {
+      const dir = agentOwnedDir();
+      const outside = join(root, "outside-target");
+      writeFileSync(outside, "x");
+      chownSync(outside, OTHER_UID, OTHER_UID);
+      linkSync(outside, join(dir, "hardlinked"));
+
+      const result = reconcileStateDirOwnership(dir);
+
+      expect(statSync(outside).uid).toBe(OTHER_UID);
+      expect(result.adopted).toBe(0);
+    });
+
+    it("stops at maxEntries instead of walking an unbounded tree", () => {
+      const dir = agentOwnedDir();
+      for (let i = 0; i < 12; i++) writeFileSync(join(dir, `f${i}`), "");
+
+      const result = reconcileStateDirOwnership(dir, { maxEntries: 5 });
+
+      expect(result.scanned).toBe(5);
+      expect(result.truncated).toBe(true);
+    });
+
+    it("stops at maxDepth instead of recursing without bound", () => {
+      const dir = agentOwnedDir();
+      mkdirSync(join(dir, "a", "b", "c"), { recursive: true });
+      writeFileSync(join(dir, "a", "b", "c", "deep"), "");
+
+      const result = reconcileStateDirOwnership(dir, { maxDepth: 2 });
+
+      expect(result.truncated).toBe(true);
+      // `a` (depth 1) and `b` (depth 2) adopted; `c` and below not reached.
+      expect(statSync(join(dir, "a")).uid).toBe(AGENT_UID);
+      expect(statSync(join(dir, "a", "b")).uid).toBe(AGENT_UID);
+      expect(statSync(join(dir, "a", "b", "c")).uid).toBe(0);
+    });
+  });
+
+  it("writeStateFileSync through a symlinked target still writes, but does not chown it", () => {
+    const dir = agentOwnedDir();
+    const outside = join(root, "outside.json");
+    writeFileSync(outside, "old");
+    chownSync(outside, OTHER_UID, OTHER_UID);
+    const link = join(dir, "linked.json");
+    symlinkSync(outside, link);
+
+    writeStateFileSync(link, "new");
+
+    // Availability preserved: a dropped state write can drop an approval.
+    expect(readFileSync(outside, "utf-8")).toBe("new");
+    // Security preserved: root never chowned an inode it reached via a link.
+    expect(statSync(outside).uid).toBe(OTHER_UID);
+  });
+});
+
+describe("state-owner: non-root is inert", () => {
+  it("resolveStateOwner returns null without touching the filesystem", () => {
+    if (isRoot) {
+      // Under root the fast path can't be exercised; the root block above
+      // pins the root behaviour instead.
+      expect(resolveStateOwner(root)).toBeNull();
+      return;
+    }
+    // A path that does not exist: a filesystem-touching implementation would
+    // have to stat it, and `null` here is returned before any such call.
+    expect(resolveStateOwner(join(root, "does", "not", "exist"))).toBeNull();
+    expect(resolveStateOwner(root)).toBeNull();
+  });
+
+  it.skipIf(isRoot)("write helpers are byte- and mode-identical to the plain fs calls", () => {
+    const viaHelper = join(root, "helper.json");
+    const viaPlain = join(root, "plain.json");
+
+    writeStateFileSync(viaHelper, '{"a":1}', { mode: 0o600 });
+    writeFileSync(viaPlain, '{"a":1}', { mode: 0o600 });
+
+    expect(readFileSync(viaHelper, "utf-8")).toBe(readFileSync(viaPlain, "utf-8"));
+    expect(statSync(viaHelper).mode).toBe(statSync(viaPlain).mode);
+    expect(statSync(viaHelper).uid).toBe(statSync(viaPlain).uid);
+
+    const appHelper = join(root, "a-helper.jsonl");
+    const appPlain = join(root, "a-plain.jsonl");
+    appendStateFileSync(appHelper, "x\n");
+    appendStateFileSync(appHelper, "y\n");
+    appendFileSync(appPlain, "x\n");
+    appendFileSync(appPlain, "y\n");
+    expect(readFileSync(appHelper, "utf-8")).toBe(readFileSync(appPlain, "utf-8"));
+
+    atomicWriteStateFileSync(join(root, "atomic.json"), "{}", 0o600);
+    expect(readFileSync(join(root, "atomic.json"), "utf-8")).toBe("{}");
+
+    mkdirStateSync(join(root, "x", "y"), { recursive: true, mode: 0o700 });
+    expect(statSync(join(root, "x", "y")).isDirectory()).toBe(true);
+  });
+
+  it.skipIf(isRoot)("reconcile does no work and reports nothing", () => {
+    mkdirSync(join(root, "sub"), { recursive: true });
+    writeFileSync(join(root, "sub", "f"), "");
+
+    expect(reconcileStateDirOwnership(root)).toEqual({
+      scanned: 0,
+      adopted: 0,
+      symlinksSkipped: 0,
+      truncated: false,
+    });
+  });
+
+  it("adopt helpers never throw on a missing file", () => {
+    expect(() => adoptStateOwnership(join(root, "nope"))).not.toThrow();
+    expect(() => adoptSqliteOwnership(join(root, "nope.db"))).not.toThrow();
+  });
+});

--- a/tests/state-owner.test.ts
+++ b/tests/state-owner.test.ts
@@ -47,6 +47,7 @@ import {
   atomicWriteStateFileSync,
   mkdirStateSync,
   reconcileStateDirOwnership,
+  reconcileStateDirOwnershipLogged,
   resolveStateOwner,
   writeStateFileSync,
 } from "../src/util/state-owner.js";
@@ -246,6 +247,42 @@ describe.runIf(isRoot)("state-owner: root writer into an agent-owned dir", () =>
       expect(statSync(join(dir, "a", "b")).uid).toBe(AGENT_UID);
       expect(statSync(join(dir, "a", "b", "c")).uid).toBe(0);
     });
+
+    // The gateway wires the sweep through the *Logged wrapper, so the operator-
+    // visible outcome is the line it emits — not the result object.
+    it("the logged wrapper adopts and reports exactly one line", () => {
+      const dir = agentOwnedDir();
+      writeFileSync(join(dir, "gateway-beacon.json"), "{}");
+      const lines: string[] = [];
+
+      reconcileStateDirOwnershipLogged(dir, "boot", {
+        prefix: "telegram gateway",
+        write: line => lines.push(line),
+      });
+
+      expect(statSync(join(dir, "gateway-beacon.json")).uid).toBe(AGENT_UID);
+      expect(lines).toEqual([
+        "telegram gateway: state-owner reconcile (boot) scanned=1 adopted=1" +
+          " symlinksSkipped=0 truncated=false\n",
+      ]);
+    });
+
+    it("the logged wrapper stays silent on a pass that adopted nothing", () => {
+      // A 6-hourly tick over an already-clean tree must not add a log line —
+      // the sweep is silent unless it actually changed something.
+      const dir = agentOwnedDir();
+      const path = join(dir, "clean.json");
+      writeFileSync(path, "{}");
+      chownSync(path, AGENT_UID, AGENT_GID);
+      const lines: string[] = [];
+
+      reconcileStateDirOwnershipLogged(dir, "periodic", {
+        prefix: "telegram gateway",
+        write: line => lines.push(line),
+      });
+
+      expect(lines).toEqual([]);
+    });
   });
 
   it("writeStateFileSync through a symlinked target still writes, but does not chown it", () => {
@@ -315,6 +352,18 @@ describe("state-owner: non-root is inert", () => {
       symlinksSkipped: 0,
       truncated: false,
     });
+  });
+
+  it("the logged wrapper never throws on a missing state dir", () => {
+    // It runs on the gateway's BOOT path: a throw here would take the gateway
+    // down before it can serve, which is strictly worse than an unswept tree.
+    const lines: string[] = [];
+    expect(() =>
+      reconcileStateDirOwnershipLogged(join(root, "gone"), "boot", {
+        write: line => lines.push(line),
+      }),
+    ).not.toThrow();
+    expect(lines).toEqual([]);
   });
 
   it("adopt helpers never throw on a missing file", () => {


### PR DESCRIPTION
## Summary

Adds a single ownership choke point for gateway state-dir writes so that a gateway
running as **uid 0** leaves files owned by the uid that owns the agent directory,
not by `root:root`.

**Nothing is broken today.** Only root-tier agents run their gateway as uid 0, and
inside those containers every consumer is also root, so the root-owned files are
read fine. This is defence-in-depth against a latent failure mode, not a fix for a
live outage.

Why it is still worth fixing: a root-owned file sitting in an agent-owned overlay
EACCESes any non-root reader, and it does so *silently*. That is exactly the shape
that dropped an agent's crons for weeks (root cause of #4371). On the one root-tier
agent in the fleet the drift is already measurable — 1,344 root-owned files under
its agent dir, versus 0 for every non-root agent — and a manual `chown` sweep is
not a fix: `telegram/gateway-beacon.json` came back root-owned 12 seconds after the
sweep, because the writer keeps re-creating it.

## What changed

**New choke point — `src/util/state-owner.ts`** (in `src/util/` so both `src/` and
`telegram-plugin/` can import it; `telegram-plugin` already imports `src/util/atomic.js`):

- `resolveStateOwner(dir)` — memoised; returns `null` immediately when
  `process.getuid() !== 0`, and also when the dir is itself root-owned.
- `writeStateFileSync` / `appendStateFileSync` / `atomicWriteStateFileSync` /
  `mkdirStateSync` — drop-in replacements for the `node:fs` calls.
- `adoptStateOwnership` / `adoptStateOwnershipFd` / `adoptSqliteOwnership`.
- `reconcileStateDirOwnership(dir)` — bounded, symlink-safe backfill sweep.

**No-op off the root path, by construction.** The first thing every helper does is
`resolveStateOwner`, which returns `null` on a `process.getuid()` check alone — no
`stat`, no `open`, no `chown`. The call then falls through to the identical plain
`fs` call it replaced. Zero added syscalls in the hot path for non-root agents.

**Failure is never fatal.** Every chown is wrapped; a failure is swallowed and
logged *once per process* (a 5-second beacon tick would otherwise flood the log).
If the target path is a symlink, `openSync(..., O_NOFOLLOW)` fails — the helper
then still performs the plain write but does **not** chown. Refusing to chown
through a symlink is the security requirement; refusing to *write* is not, because
a dropped state write can drop an approval.

**Ownership is taken on an fd, never a path.** `openSync(O_NOFOLLOW)` + `fchownSync`
closes the TOCTOU window a path-based `chown` would leave open — the same rule
`src/util/atomic.ts` already applies to its tempfile. `O_NOFOLLOW` does not stop a
*hardlink*, so the helper additionally refuses to chown a non-directory with
`nlink > 1`.

**Call sites converted** (writers under `TELEGRAM_STATE_DIR`):

| File | Mechanism |
|---|---|
| `gateway-beacon.json` | `boot-beacon.ts` — `adoptStateOwnershipFd` on the tempfile fd before `rename` |
| `gateway-heartbeat` | `gateway-heartbeat.ts` — `writeStateFileSync` |
| `turn-active.json` | `turn-active-marker.ts` — `writeStateFileSync` |
| `privacy-state.json`, `pending-approval-cards.json`, `scoped-grants.json`, `missed-approvals.json`, `always-allow-persist-queue.json` | 2-line import swap: `atomicWriteFileSync` → `atomicWriteStateFileSync` |
| `obligations.json`, `status-pins.json`, `activity-cards-pending.json`, `queued-cards-pending.json`, `stale-pin-sweep.json`, `inbound-spool.jsonl`, lockout state | rebound at their **injected fs seams** in `gateway.ts` — the store modules themselves are untouched |
| `history.db`, `registry.db` (+ `-wal`/`-shm`) | `adoptSqliteOwnership` at the existing post-init and post-checkpoint chmod points |

Everything else under the state dir (`people.json`, `flood-wait.json`,
`quarantine.json`, `telegraph-account.json`, `silent-end-pending.json`,
`tool-labels-<session>.jsonl`, `429-ledger.json`, …) is covered by the reconcile
sweep rather than by a converted call site, keeping this diff small.

## SQLite sidecars

`-wal` and `-shm` are created inside SQLite's C layer, so no `node:fs` seam can
intercept them. Both DBs already had a post-open `chmod` loop over
`['', '-shm', '-wal']`; `adoptSqliteOwnership(path)` was added right after each,
and again after `wal_checkpoint(TRUNCATE)` in `checkpointWal()` because a TRUNCATE
checkpoint deletes and re-creates the sidecars.

## Startup sweep — added, bounded, symlink-safe

The write helpers are the fix; the sweep is the *backfill* for the two classes they
cannot reach: pre-existing leftovers from a period when the gateway ran as root, and
files created by sibling root processes (hooks, sidecars) that never go through this
module. It rides the **existing** `runHistoryReaperNow` tick (boot, then every 6h)
rather than adding a timer, and it is:

- depth-capped (4) and entry-capped (5000) — no unbounded tree walk;
- symlink-safe — entries are classified from `readdirSync(withFileTypes)` (an lstat),
  and a symlink is counted and skipped, never resolved, descended, or chowned. This
  matters concretely: the state dir contains symlinks pointing *outside* the agent
  dir (e.g. `home/.switchroom -> /home/kenthompson/.switchroom`), and chowning
  through one would corrupt the operator's real home;
- wrapped in try/catch on the boot path so an unexpected throw cannot take the
  gateway down before it serves.

## Test plan

`tests/state-owner.test.ts`, 17 tests. Real-ownership assertions are
`describe.runIf(isRoot)` because uid 0 is the only uid that can `chown` to an
arbitrary uid — an unprivileged runner can neither produce nor observe the outcome.
The non-root inertness block always runs.

Asserted outcomes (not just code paths):

- a file written as root into a dir owned by another uid **comes out owned by that
  uid**, with contents and mode intact — plus a **control** test that a plain
  `writeFileSync` in the same dir stays root-owned, so the fix test cannot pass
  vacuously;
- `atomicWriteStateFileSync` adopts the owner and leaves no tempfile;
- `appendStateFileSync` adopts on the creating append; `mkdirStateSync` adopts every
  dir it creates and leaves a pre-existing foreign-uid dir alone;
- `adoptSqliteOwnership` re-owns `db` + `-wal` and does not conjure a `-shm`;
- reconcile **never chowns through a symlink that escapes the dir** — the outside dir
  and file keep their original uid, `symlinksSkipped === 2`, `adopted === 0`;
- reconcile refuses to chown a hardlinked file; stops at `maxEntries` (`truncated`);
  stops at `maxDepth`;
- **non-root is unchanged**: `resolveStateOwner` returns `null` without touching the
  fs (probed with a nonexistent path), and the write helpers are byte- and
  mode-identical to the plain `fs` calls they replace.

Also run locally: full `tsc --noEmit`; `node scripts/build.mjs`; vitest boot-beacon
(32), turn-active-marker (19), status-pin-lifecycle (16); `bun test` history +
history-reaper + registry-turns + subagents + turns-writer (192 pass / 0 fail) and
the store suites (101 pass); the lint guards including the gateway line ratchet
(24845 vs 24805+50), attribution trailers, and changelog entry.

The **full** vitest suite was not run to completion locally, and deliberately so:
this worktree runs as uid 0, and a number of suites assert `EACCES`/unwritable-dir
behaviour that simply cannot occur for root (the run emits the blocked-approval
fallback logs as evidence). A root-run full suite is not a valid signal either way,
so CI is the authority here; the scoped suites above were run and are green.

## Risk

Low. Off the root path the helpers are provably inert. On the root path the worst
case is a chown that fails, which is logged once and otherwise ignored — the write
itself still happens. Nothing is chowned on the live host by this PR.

Concurrency note: another change is in flight against `history.db` persistence
(activity-card rows + a schema migration). This PR deliberately stays off message
persistence and off the schema — it touches `history.ts` only at the existing
post-init chmod block and inside `checkpointWal()`.

Job spec: `reference/jobs/survive-reboots-and-real-life.md` — the state an agent
persists has to still be readable by that agent on the next boot; and
`reference/jobs/fleet-stays-healthy.md`, whose whole premise is that "a standing
fleet of always-on specialists fails silently". A permission-denied read of an
overlay file is precisely that silent class.
