### PR TITLE
fix(hindsight): fail-safe recall fact types + env channel for retain cadence

### DIFF
--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -396,6 +396,23 @@ ENV_OVERRIDES = {
     "HINDSIGHT_AUTO_RECALL": ("autoRecall", bool),
     "HINDSIGHT_AUTO_RETAIN": ("autoRetain", bool),
     "HINDSIGHT_RETAIN_MODE": ("retainMode", str),
+    # Switchroom-local: auto-retain cadence knobs. These had a DEFAULTS entry and
+    # a settings.json stamp (applyHindsightSettingsOverrides) but NO env channel,
+    # so env — the TOP of the config precedence chain (DEFAULTS → settings.json →
+    # ~/.hindsight/claude-code.json → env) — could not reach them at all. That
+    # broke parity with the recall knobs and left the only override paths as a
+    # settings.json rewrite (scaffold-time) or a hand-edit that `switchroom apply`
+    # re-copies away. Adding the env keys lets `memory.retain.*` (or an agent
+    # `env:` map, or a docker-exec'd retain that does not inherit the supervised
+    # env) drive them, and makes the env value authoritative when set.
+    # `retainEveryNTurns` / `retainOverlapTurns` mirror the yaml surface
+    # (`memory.retain.every_n_turns` / `.overlap_turns`); `retainContext` /
+    # `retainTags` have no yaml surface yet but gain the same env channel as the
+    # other retain knobs for consistency and exec-path overrides.
+    "HINDSIGHT_RETAIN_EVERY_N_TURNS": ("retainEveryNTurns", int),
+    "HINDSIGHT_RETAIN_OVERLAP_TURNS": ("retainOverlapTurns", int),
+    "HINDSIGHT_RETAIN_CONTEXT": ("retainContext", str),
+    "HINDSIGHT_RETAIN_TAGS": ("retainTags", list),
     # Switchroom-local: per-row observation scope on retains. Set by start.sh
     # from agents.<name>.memory.observation_scopes (cascading through
     # defaults.memory.observation_scopes) ONLY when the operator set it; unset
@@ -518,6 +535,77 @@ ENV_OVERRIDES = {
 #: src/memory/observation-scopes.ts, which the zod enum reads — widening the
 #: set means widening BOTH.
 OBSERVATION_SCOPES_VALUES = ("per_tag", "combined", "all_combinations", "shared")
+
+
+#: Switchroom-local: the fact types Hindsight's recall endpoint accepts. Sending
+#: any other value makes the 0.9.0 engine return HTTP 422 ("Invalid fact type(s):
+#: … Must be one of: experience, observation, world") — a validation that was
+#: silently tolerated before vectorize-io/hindsight#3062. A 422 fails the WHOLE
+#: recall for the turn, so an operator typo in `memory.recall.types` (e.g.
+#: "observations", "fact") would otherwise kill memory injection on EVERY turn.
+#: Verified against the live engine's 422 detail string and /openapi.json
+#: RecallRequest; widening this set means widening it server-side too.
+RECALL_FACT_TYPES = ("world", "experience", "observation")
+
+#: The recall types used when a configured `recallTypes` filters down to empty
+#: (mirrors the `recallTypes` DEFAULTS entry). Falling back to this — rather than
+#: sending an empty/invalid set — keeps recall running with the shipped behaviour
+#: instead of degrading to nothing.
+DEFAULT_RECALL_FACT_TYPES = ("world", "experience")
+
+
+def filter_recall_types(config: dict):
+    """Filter ``recallTypes`` to the set Hindsight's recall endpoint accepts.
+
+    Returns the value to send as the recall ``types`` argument. THIS FUNCTION
+    MUST NEVER RAISE: an invalid ``memory.recall.types`` value is a
+    misconfiguration, and both raising here and passing the bad value through
+    have the same catastrophic outcome — a 422 that fails the recall and drops
+    memory injection for the turn. This mirrors the degrade-don't-raise contract
+    of :func:`compute_observation_scopes` (a bad config degrades the FEATURE,
+    never loses the turn).
+
+    * ``None`` / unset → ``None``: omit the field entirely, letting the engine
+      apply its own default (world + experience). Byte-identical to the wire
+      body a pre-filter client sent.
+    * a list/tuple     → keep the members in :data:`RECALL_FACT_TYPES` (order
+      and de-duplicated), dropping every unknown value WITH a stderr warning
+      that names it. If nothing valid survives, fall back to
+      :data:`DEFAULT_RECALL_FACT_TYPES` so recall still runs.
+    * anything else     → shout and fall back to :data:`DEFAULT_RECALL_FACT_TYPES`.
+    """
+    raw = config.get("recallTypes")
+    if raw is None:
+        return None
+    if not isinstance(raw, (list, tuple)):
+        print(
+            f"[Hindsight] recallTypes={raw!r} is not a list; falling back to "
+            f"{list(DEFAULT_RECALL_FACT_TYPES)}. Set it via `memory.recall.types` "
+            "in switchroom.yaml.",
+            file=sys.stderr,
+        )
+        return list(DEFAULT_RECALL_FACT_TYPES)
+    valid = []
+    for fact_type in raw:
+        if isinstance(fact_type, str) and fact_type in RECALL_FACT_TYPES:
+            if fact_type not in valid:
+                valid.append(fact_type)
+        else:
+            print(
+                f"[Hindsight] recallTypes entry {fact_type!r} is not a valid "
+                f"Hindsight fact type ({', '.join(RECALL_FACT_TYPES)}); dropping "
+                "it. An invalid type 422s the recall and drops memory injection "
+                "for the turn — fix it via `memory.recall.types` in switchroom.yaml.",
+                file=sys.stderr,
+            )
+    if not valid:
+        print(
+            f"[Hindsight] recallTypes={raw!r} left no valid fact types after "
+            f"filtering; falling back to {list(DEFAULT_RECALL_FACT_TYPES)}.",
+            file=sys.stderr,
+        )
+        return list(DEFAULT_RECALL_FACT_TYPES)
+    return valid
 
 
 def classify_observation_scopes(config: dict):

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -59,7 +59,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from lib.bank import derive_bank_id, ensure_bank_mission
 from lib.client import HindsightClient
-from lib.config import debug_log, load_config
+from lib.config import debug_log, filter_recall_types, load_config
 from lib.content import (
     _extract_text_content,
     compose_recall_query,
@@ -2091,6 +2091,15 @@ def main():
     if recall_request_timeout <= 0:
         recall_request_timeout = 12.0
 
+    # Fail-safe the recall `types` BEFORE any bank task runs: the 0.9.0 engine
+    # 422s an invalid fact type (e.g. an operator typo "observations"/"fact" in
+    # memory.recall.types), which fails the whole recall and drops memory
+    # injection for the turn. filter_recall_types drops unknowns (shouting on
+    # stderr) and falls back to the default set if the filter empties it — it
+    # never raises. Computed once here so every bank in the fan-out sends the
+    # same validated set.
+    resolved_recall_types = filter_recall_types(config)
+
     def _make_bank_task(target_bank_id, b_tags, b_tags_match, b_tag_groups, timeout_override=None):
         def _bank_task():
             return client.recall(
@@ -2098,7 +2107,7 @@ def main():
                 query=search_query,
                 max_tokens=config.get("recallMaxTokens", 1024),
                 budget=config.get("recallBudget", "mid"),
-                types=config.get("recallTypes"),
+                types=resolved_recall_types,
                 # Upstream 962140eef — optional per-bank tag filters (resolved
                 # above the cache check; part of the cache key).
                 tags=b_tags,

--- a/vendor/hindsight-memory/scripts/tests/test_config_retain_env.py
+++ b/vendor/hindsight-memory/scripts/tests/test_config_retain_env.py
@@ -1,0 +1,99 @@
+"""Switchroom — the auto-retain cadence knobs must have an env channel.
+
+`retainEveryNTurns`, `retainOverlapTurns`, `retainContext`, and `retainTags`
+had a DEFAULTS entry and (for the cadence pair) a settings.json stamp, but NO
+entry in `ENV_OVERRIDES`. Env is the TOP of the plugin's config precedence
+chain (DEFAULTS -> settings.json -> ~/.hindsight/claude-code.json -> env), so
+without an env key an operator's `HINDSIGHT_RETAIN_*` could not reach the
+plugin at all, and a docker-exec'd retain that does not inherit the supervised
+settings could not be steered either.
+
+The outcome under test: `HINDSIGHT_RETAIN_EVERY_N_TURNS` (and its siblings)
+actually OVERRIDE the resolved config value, and env wins over the shipped
+default.
+
+Stdlib-only.
+"""
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from lib.config import DEFAULTS, ENV_OVERRIDES, load_config  # noqa: E402
+
+
+# Every retain-cadence env var, with the config key it must reach.
+RETAIN_ENV = {
+    "HINDSIGHT_RETAIN_EVERY_N_TURNS": "retainEveryNTurns",
+    "HINDSIGHT_RETAIN_OVERLAP_TURNS": "retainOverlapTurns",
+    "HINDSIGHT_RETAIN_CONTEXT": "retainContext",
+    "HINDSIGHT_RETAIN_TAGS": "retainTags",
+}
+
+
+def _load_with(env):
+    """load_config() with a hermetic environment (no plugin/user settings)."""
+    with mock.patch.dict(os.environ, env, clear=True):
+        os.environ["CLAUDE_PLUGIN_ROOT"] = os.path.join(SCRIPTS_DIR, "does-not-exist")
+        os.environ["HOME"] = os.path.join(SCRIPTS_DIR, "does-not-exist")
+        return load_config()
+
+
+class EveryRetainNameHasAChannel(unittest.TestCase):
+    def test_all_retain_env_names_are_wired(self):
+        missing = [name for name in RETAIN_ENV if name not in ENV_OVERRIDES]
+        self.assertEqual(missing, [], f"exported but never read: {missing}")
+
+    def test_each_name_maps_to_the_expected_config_key(self):
+        for name, key in RETAIN_ENV.items():
+            with self.subTest(name=name):
+                self.assertEqual(ENV_OVERRIDES[name][0], key)
+
+    def test_every_target_key_exists_in_defaults(self):
+        for name, key in RETAIN_ENV.items():
+            with self.subTest(name=name):
+                self.assertIn(key, DEFAULTS)
+
+
+class ValuesActuallyLand(unittest.TestCase):
+    """The outcome that matters: the loaded config carries the exported value."""
+
+    def test_every_n_turns_env_overrides_the_resolved_value(self):
+        # The headline outcome: HINDSIGHT_RETAIN_EVERY_N_TURNS wins over the
+        # shipped default, and lands as an int.
+        override = DEFAULTS["retainEveryNTurns"] + 5
+        cfg = _load_with({"HINDSIGHT_RETAIN_EVERY_N_TURNS": str(override)})
+        self.assertEqual(cfg["retainEveryNTurns"], override)
+        self.assertIsInstance(cfg["retainEveryNTurns"], int)
+        self.assertNotEqual(cfg["retainEveryNTurns"], DEFAULTS["retainEveryNTurns"])
+
+    def test_overlap_turns_env_overrides_the_resolved_value(self):
+        cfg = _load_with({"HINDSIGHT_RETAIN_OVERLAP_TURNS": "4"})
+        self.assertEqual(cfg["retainOverlapTurns"], 4)
+
+    def test_context_env_overrides_the_resolved_value(self):
+        cfg = _load_with({"HINDSIGHT_RETAIN_CONTEXT": "codex"})
+        self.assertEqual(cfg["retainContext"], "codex")
+
+    def test_tags_env_accepts_a_json_array(self):
+        cfg = _load_with({"HINDSIGHT_RETAIN_TAGS": '["source:transcript"]'})
+        self.assertEqual(cfg["retainTags"], ["source:transcript"])
+
+    def test_tags_env_accepts_a_comma_separated_list(self):
+        cfg = _load_with({"HINDSIGHT_RETAIN_TAGS": "a,b"})
+        self.assertEqual(cfg["retainTags"], ["a", "b"])
+
+    def test_no_retain_env_reproduces_the_default(self):
+        baseline = _load_with({})
+        for key in RETAIN_ENV.values():
+            with self.subTest(key=key):
+                self.assertEqual(baseline[key], DEFAULTS[key])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/hindsight-memory/scripts/tests/test_recall_types_filter.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_types_filter.py
@@ -1,0 +1,81 @@
+"""Switchroom — recall `types` must be fail-safe against an invalid fact type.
+
+The 0.9.0 Hindsight engine returns HTTP 422 ("Invalid fact type(s): … Must be
+one of: experience, observation, world") for an unknown recall `fact_type`,
+which fails the WHOLE recall for the turn. Before this guard, recall.py sent
+`types=config.get("recallTypes")` unvalidated, so an operator typo in
+`memory.recall.types` (e.g. "observations", "fact") would 422 and drop memory
+injection on every turn.
+
+The outcome under test: a config carrying an invalid type resolves — via
+`filter_recall_types` — to a FILTERED, valid `types` list (never a 422-bound
+call), and never raises. Mirrors the degrade-don't-raise contract of
+`compute_observation_scopes`.
+
+Stdlib-only.
+"""
+
+import os
+import sys
+import unittest
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from lib.config import (  # noqa: E402
+    DEFAULT_RECALL_FACT_TYPES,
+    RECALL_FACT_TYPES,
+    filter_recall_types,
+)
+
+
+class FilterRecallTypes(unittest.TestCase):
+    def test_valid_set_matches_the_engine(self):
+        # Guards against client/server drift: verified against the live engine's
+        # own 422 detail string ("experience, observation, world").
+        self.assertEqual(set(RECALL_FACT_TYPES), {"world", "experience", "observation"})
+
+    def test_invalid_type_is_dropped_leaving_a_valid_list(self):
+        # The exact defect: an operator typo mixed with a valid type. The bad
+        # value is dropped; the good one survives — NOT a 422-bound call.
+        resolved = filter_recall_types({"recallTypes": ["observations", "world"]})
+        self.assertEqual(resolved, ["world"])
+        for t in resolved:
+            self.assertIn(t, RECALL_FACT_TYPES)
+
+    def test_all_invalid_falls_back_to_the_default_set(self):
+        # If nothing valid survives, recall must still RUN — fall back to the
+        # shipped default rather than send an empty/invalid set.
+        resolved = filter_recall_types({"recallTypes": ["fact", "observations"]})
+        self.assertEqual(resolved, list(DEFAULT_RECALL_FACT_TYPES))
+
+    def test_valid_types_pass_through_deduplicated_in_order(self):
+        resolved = filter_recall_types(
+            {"recallTypes": ["world", "experience", "world", "observation"]}
+        )
+        self.assertEqual(resolved, ["world", "experience", "observation"])
+
+    def test_unset_returns_none_so_the_field_is_omitted(self):
+        # None -> omit `types` entirely, letting the engine apply its own default.
+        self.assertIsNone(filter_recall_types({}))
+        self.assertIsNone(filter_recall_types({"recallTypes": None}))
+
+    def test_non_list_value_falls_back_without_raising(self):
+        # A scalar where a list was expected is a config mistake, not a crash.
+        resolved = filter_recall_types({"recallTypes": "observation"})
+        self.assertEqual(resolved, list(DEFAULT_RECALL_FACT_TYPES))
+
+    def test_non_string_members_are_dropped(self):
+        resolved = filter_recall_types({"recallTypes": [None, 42, "observation"]})
+        self.assertEqual(resolved, ["observation"])
+
+    def test_never_raises_on_pathological_input(self):
+        for bad in ({}, {"recallTypes": {}}, {"recallTypes": 0}, {"recallTypes": [[]]}):
+            with self.subTest(bad=bad):
+                # Must return a value, never propagate an exception.
+                filter_recall_types(bad)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Two correctness fixes to the vendored hindsight client plugin (`vendor/hindsight-memory/scripts/`), one concern: make recall fail-safe against a config typo, and give the auto-retain cadence knobs the env channel they were missing.

### Fix 1 — recall `fact_type` whitelist
The 0.9.0 engine returns **HTTP 422** for an unknown recall `fact_type` (tolerated before vectorize-io/hindsight#3062). Verified live: `types:["fact"]` → `422 {"detail":"Invalid fact type(s): fact. Must be one of: experience, observation, world"}`; `types:["observation"]` → `200`. A 422 fails the **whole** recall for the turn.

`recall.py:2101` sent `types=config.get("recallTypes")` unvalidated, so an operator typo in `memory.recall.types` (e.g. `observations`, `fact`) would 422 and kill memory injection on **every** turn.

New `lib.config.filter_recall_types` filters `recallTypes` to `{world, experience, observation}`, drops unknowns (stderr warning naming the dropped value), and falls back to the default set (`world, experience`) if the filter empties it. It **never raises** — mirroring `compute_observation_scopes`' degrade-don't-raise contract. The filter is **identity for valid types**, so the wire body is byte-identical for correctly-configured agents.

### Fix 2 — `retain.*` env channel (`config.py` ENV_OVERRIDES)
`retainEveryNTurns` / `retainOverlapTurns` / `retainContext` / `retainTags` had a `DEFAULTS` entry (and, for the cadence pair, a settings.json stamp) but **no** entry in `ENV_OVERRIDES` — so env, the top of the precedence chain (`DEFAULTS → settings.json → ~/.hindsight/claude-code.json → env`), could not reach them at all. Added the four `HINDSIGHT_RETAIN_*` keys, restoring parity with the recall knobs. Env value is authoritative when set.

## Tests (`scripts/tests/`, stdlib + pytest, assert outcomes)
- `test_recall_types_filter.py` — an invalid type in config resolves to a filtered/valid list (not a 422-bound call); all-invalid falls back to the default; `None` omits the field; never raises on pathological input.
- `test_config_retain_env.py` — `HINDSIGHT_RETAIN_EVERY_N_TURNS` (and siblings) override the resolved config value; env wins over the default; `[]`/comma-list forms for tags.

Scoped run: `python3 -m pytest tests/ -q -k "recall or config or retain"` → **483 passed**. New files: 27 passed / 61 subtests. `py_compile` clean. The vendored plugin's CI gate is `pytest` (no ruff/flake8 for these scripts).

## Deliberately NOT done — two grounding contradictions reported instead of force-fitting

**(a) start.sh `HINDSIGHT_RETAIN_*` auto-export (Fix 2, second half).** The dispatched premise ("start.sh exports env only for `HINDSIGHT_RETAIN_MODE`; the knobs are unreachable") does not hold against HEAD:
- `profiles/_base/start.sh.hbs` exports `HINDSIGHT_AUTO_RETAIN=true` and does **not** export `HINDSIGHT_RETAIN_MODE` at all.
- The cadence **already reaches** the plugin durably via the settings.json stamp (`applyHindsightSettingsOverrides`, `scaffold.ts:3874/3902/3899/3914`), which survives `switchroom apply`.
- `retainContext` / `retainTags` have **no** `memory.retain.*` yaml surface (`schema.ts` `memory.retain` only defines `every_n_turns` / `overlap_turns`), so the "matching `memory.retain.*` mapping" for those two does not exist to map.

Auto-exporting from start.sh would be a large cross-cutting scaffold change (new resolver fields, two caller sites, `WorkspaceContext` interface, `start.sh.hbs` exports, `scaffold.*.test.ts` pins) that risks diverging from the settings.json stamp, for knobs already reaching durably — a separate concern from this plugin-correctness PR. The `config.py` ENV_OVERRIDES added here already give the cadence pair an env channel an agent `env:` map or a docker-exec'd retain can use.

**(b) Docs "fix" (Fix 3) is inverted.** The premise states live deployed config is `retainMode="full-session"`, `retainEveryNTurns=10`. Ground truth (live deployed `settings.json`): `retainMode="chunked"`, `retainEveryNTurns=8` (per-agent cascade), `retainOverlapTurns=1`. The scaffold **hardcodes** `retainMode="chunked"` (`scaffold.ts:3899`), overriding the `config.py` DEFAULTS `full-session`/`10` (which are the vendor fallback, dead for any scaffolded switchroom agent). The existing `CLAUDE.md` templates and `retain.py:~380` comment **already** correctly describe this ("chunked mode … every Nth turn … N defaults to 3 … per-agent"). Rewriting them to `full-session`/`10` would **introduce** a factual error, so no doc change was made.

## Operator step
Needs `switchroom apply` + agent restart to go live (I cannot run either).

🤖 Generated with [Claude Code](https://claude.com/claude-code)