### PR TITLE
chore(hindsight): tune fleet defaults — recall budget low→mid + speaker-aware retain context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+### Features
+
+- **hindsight: default recall budget low->mid + fix stale budget comment**
+
 ## v0.20.21 — recall slot floors scale with the `max_memories` cap, and release tags retag unchanged images instead of rebuilding them
 
 ### Fixed: recall slot floors now scale with the `max_memories` cap (own/additional bank crowd-out)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ now an anomaly worth investigating, not the norm.
 ### Features
 
 - **hindsight: default recall budget low->mid + fix stale budget comment**
+- **hindsight: speaker-aware retain context template ({agent}/{bank_id} resolved per-retain)**
 
 ## v0.20.21 — recall slot floors scale with the `max_memories` cap, and release tags retag unchanged images instead of rebuilding them
 

--- a/src/setup/hindsight-perf-defaults.ts
+++ b/src/setup/hindsight-perf-defaults.ts
@@ -543,10 +543,15 @@ export const HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE = 1000;
  *   comment promises "36-54% speedup, quality-identical" by sorting
  *   candidate pairs by length to avoid padding waste. Pure win on CPU.
  *
- * - MAX_CANDIDATES: vendor default 300. At our `recallBudget=low`
- *   ~100 candidates feed in and we cap to 12 final memories; scoring
- *   300 wastes ~50% of rerank CPU on candidates that will never make
- *   the top-N.
+ * - MAX_CANDIDATES: vendor default 300, lowered to 150 (below). At the
+ *   fleet's `recallBudget=mid` the engine surfaces ~300 candidates
+ *   (budget = candidate depth: low=100 / mid=300 / high=1000), so this
+ *   150 cap now BINDS — it reranks the strongest 150 and drops the rest.
+ *   That bounds rerank CPU on a shared host while still reranking deeper
+ *   than `low` (~100, which sits under the cap and is never truncated).
+ *   We cap to 12 final memories regardless, so the tail below 150 would
+ *   never make the top-N. Raise `HINDSIGHT_API_RERANKER_MAX_CANDIDATES`
+ *   to rerank the full mid pool.
  *
  * - LOCAL_MAX_CONCURRENT: vendor default 4. With 9 always-on agents
  *   that's up to 36 simultaneous CPU-bound rerank tasks on a shared

--- a/src/setup/hindsight-recall-passthrough.ts
+++ b/src/setup/hindsight-recall-passthrough.ts
@@ -164,7 +164,7 @@ export interface HindsightRecallPassthrough {
  */
 export const RECALL_PASSTHROUGH_DEFAULTS = Object.freeze({
   /** vendor/hindsight-memory/settings.json `recallBudget` */
-  budget: "low" as RecallBudget,
+  budget: "mid" as RecallBudget,
   /** settings.json `recallMaxTokens` */
   maxTokens: 1024,
   /** config.py DEFAULTS `recallPreferObservations` (not in settings.json) */

--- a/src/setup/hindsight-recall-tunables.ts
+++ b/src/setup/hindsight-recall-tunables.ts
@@ -58,8 +58,10 @@ export const DEFAULT_RECALL_HOOK_TIMEOUT_SECONDS = 12;
 /**
  * switchroom smart-default for `recallMaxMemories` — the count cap on memories
  * injected per turn. The vendor ships 12 (`vendor/hindsight-memory/settings.json`
- * / `lib/config.py` DEFAULTS); switchroom tightens it to 8 (less prompt noise at
- * our `recallBudget: low`, per the 2026-05-24 recall-quality audit). This is the
+ * / `lib/config.py` DEFAULTS); switchroom tightens it to 8 (less prompt noise,
+ * per the 2026-05-24 recall-quality audit). This is a count cap on the injected
+ * set and is independent of `recallBudget` (which sets candidate DEPTH, not the
+ * final head-slice). This is the
  * value stamped into the deployed settings.json when the operator sets no
  * `memory.recall.max_memories`, so it MUST equal what the fleet ran before this
  * became a stamped-from-cascade value or turning the stamp on would move

--- a/tests/scaffold.recall-passthrough.test.ts
+++ b/tests/scaffold.recall-passthrough.test.ts
@@ -119,6 +119,24 @@ describe("recall passthrough (#3841)", () => {
       expect(RECALL_PASSTHROUGH_DEFAULTS.tagGroups).toEqual({});
     });
 
+    it("resolves the recall budget to mid when nothing overrides it", () => {
+      // Outcome assertion on the resolved value, not just the code path: with
+      // no memory.recall config the fleet default is `mid` (the low->mid tune).
+      expect(resolveHindsightRecallPassthrough(undefined).budget).toBe("mid");
+      expect(resolveHindsightRecallPassthrough({}).budget).toBe("mid");
+    });
+
+    it("lets an explicit per-agent budget override the new mid default", () => {
+      // Precedence still holds after the default moved: an agent that pins its
+      // own budget keeps winning. `low` is the exact case that must survive the
+      // default flip (env HINDSIGHT_RECALL_BUDGET is exported from this resolved
+      // value and outranks settings.json in config.py's cascade).
+      expect(resolveHindsightRecallPassthrough({ budget: "low" }).budget).toBe("low");
+      expect(resolveHindsightRecallPassthrough({ budget: "high" }).budget).toBe("high");
+      const { startSh } = scaffold(withRecall({ budget: "low" }));
+      expect(startSh).toContain("export HINDSIGHT_RECALL_BUDGET=low\n");
+    });
+
     it("matches config.py DEFAULTS for the keys settings.json does not ship", () => {
       expect(VENDOR_SETTINGS.recallPreferObservations).toBeUndefined();
       expect(VENDOR_SETTINGS.recallTranscriptFallback).toBeUndefined();
@@ -153,7 +171,7 @@ describe("recall passthrough (#3841)", () => {
       // Whole-line matches including the trailing newline: `toContain("=1")`
       // would also be satisfied by a rendered `=1024`, so a changed default
       // could sail through a substring assertion.
-      expect(startSh).toContain("export HINDSIGHT_RECALL_BUDGET=low\n");
+      expect(startSh).toContain("export HINDSIGHT_RECALL_BUDGET=mid\n");
       expect(startSh).toContain("export HINDSIGHT_RECALL_MAX_TOKENS=1024\n");
       expect(startSh).toContain("export HINDSIGHT_RECALL_PREFER_OBSERVATIONS=true\n");
       expect(startSh).toContain("export HINDSIGHT_RECALL_CONTEXT_TURNS=2\n");

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -48,16 +48,19 @@ DEFAULT_VOLATILE_SCOPE_PATTERNS = (
 DEFAULTS = {
     # Recall
     "autoRecall": True,
-    # Switchroom default: "low" — vector search only, no LLM reranking.
-    # Cuts the recall hook latency from ~5s (mid budget) to ~1-2s (low).
-    # Operators who want richer recall can set HINDSIGHT_RECALL_BUDGET=mid
-    # via per-agent env or write `recallBudget: "mid"` into the user
-    # config file. Forensics on real klanker turns showed mid-budget
-    # recall was ~5s of wall-clock latency dominated by the LLM filter
-    # pass; for chat-pattern agents the vector hits alone are fine and
-    # the 5s is the second-largest contributor to perceived dead air
-    # (after the model TTFT).
-    "recallBudget": "low",
+    # Switchroom fleet default: "mid". The budget sets candidate DEPTH — how
+    # many nodes the engine pulls across all TEMPR retrieval stages before
+    # ranking (recall_budget_fixed_low=100 / _mid=300 / _high=1000 units,
+    # hindsight_api engine/memory_engine.py). It does NOT gate the reranker:
+    # the cross-encoder runs at EVERY budget level and is bounded separately by
+    # RERANKER_MAX_CANDIDATES (HINDSIGHT_API_RERANKER_MAX_CANDIDATES, default
+    # 300), so "low" is not "vector-only, no rerank" — it is a shallower
+    # candidate pool feeding the same rerank+score pipeline. "mid" (300 nodes)
+    # is upstream's own default and the balanced point: deeper recall than
+    # "low" without "high"'s 1000-node cold-page tail. Operators who want the
+    # shallow/fast pool back set HINDSIGHT_RECALL_BUDGET=low via per-agent env
+    # or write `recallBudget: "low"` into the user config file.
+    "recallBudget": "mid",
     "recallMaxTokens": 1024,
     # Switchroom-local: cap on the number of memories injected into the
     # `<hindsight_memories>` block, regardless of token budget. Plugin v0.4.0

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -209,7 +209,17 @@ DEFAULTS = {
     "retainEveryNTurns": 10,
     "retainOverlapTurns": 2,
     "retainToolCalls": True,
-    "retainContext": "claude-code",
+    # Switchroom — speaker-aware retain context. Resolved per-retain via
+    # build_retain_payload's _resolve_template, which fills {agent} from
+    # SWITCHROOM_AGENT_NAME and {bank_id} from the target bank. Tells the
+    # consolidation LLM who is speaking on each line so first-person agent
+    # actions ("experience") are not confused with the operator's world facts.
+    "retainContext": (
+        "Transcript of Claude Code agent '{agent}' ({bank_id}). "
+        "'assistant'/tool lines are the agent's own first-person actions "
+        "(experience); 'user' lines are the human operator speaking (their "
+        "statements are world facts)."
+    ),
     "retainTags": [],
     "retainMetadata": {},
     # Switchroom-local: per-row Hindsight `observation_scopes` on every retain.

--- a/vendor/hindsight-memory/scripts/retain.py
+++ b/vendor/hindsight-memory/scripts/retain.py
@@ -549,6 +549,11 @@ def build_retain_payload(
         "bank_id": bank_id,
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "user_id": os.environ.get("HINDSIGHT_USER_ID", ""),
+        # Switchroom — the agent's own name, so a speaker-aware retainContext
+        # template can name whose first-person experience this transcript is.
+        # Empty outside switchroom (no SWITCHROOM_AGENT_NAME); a template that
+        # references {agent} then renders an empty slot, which is harmless.
+        "agent": os.environ.get("SWITCHROOM_AGENT_NAME", ""),
     }
 
     def _resolve_template(value: str) -> str:
@@ -682,7 +687,7 @@ def build_retain_payload(
         "bank_id": bank_id,
         "content": transcript,
         "document_id": document_id,
-        "context": config.get("retainContext", "claude-code"),
+        "context": _resolve_template(config.get("retainContext", "claude-code")),
         "metadata": metadata,
         "tags": tags,
         "observation_scopes": scope,

--- a/vendor/hindsight-memory/settings.json
+++ b/vendor/hindsight-memory/settings.json
@@ -6,7 +6,7 @@
   "autoRecall": true,
   "autoRetain": true,
   "retainMode": "full-session",
-  "recallBudget": "low",
+  "recallBudget": "mid",
   "recallMaxTokens": 1024,
   "recallMaxMemories": 12,
   "recallTypes": ["world", "experience"],

--- a/vendor/hindsight-memory/settings.json
+++ b/vendor/hindsight-memory/settings.json
@@ -26,7 +26,7 @@
   "retainToolCalls": true,
   "retainTags": ["{session_id}"],
   "retainMetadata": {},
-  "retainContext": "claude-code",
+  "retainContext": "Transcript of Claude Code agent '{agent}' ({bank_id}). 'assistant'/tool lines are the agent's own first-person actions (experience); 'user' lines are the human operator speaking (their statements are world facts).",
   "hindsightApiToken": null,
   "apiPort": 9077,
   "daemonIdleTimeout": 0,

--- a/vendor/hindsight-memory/tests/test_config.py
+++ b/vendor/hindsight-memory/tests/test_config.py
@@ -44,6 +44,11 @@ class TestLoadConfig:
         assert cfg["autoRetain"] is True
         assert cfg["recallBudget"] == "mid"
         assert cfg["retainEveryNTurns"] == 10
+        # Switchroom — speaker-aware retain context template (resolved
+        # per-retain by build_retain_payload). Must carry the {agent} and
+        # {bank_id} slots so the consolidation LLM can attribute speakers.
+        assert "{agent}" in cfg["retainContext"]
+        assert "{bank_id}" in cfg["retainContext"]
 
     def test_settings_json_overrides_defaults(self, tmp_path, monkeypatch):
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))

--- a/vendor/hindsight-memory/tests/test_config.py
+++ b/vendor/hindsight-memory/tests/test_config.py
@@ -42,7 +42,7 @@ class TestLoadConfig:
         cfg = load_config()
         assert cfg["autoRecall"] is True
         assert cfg["autoRetain"] is True
-        assert cfg["recallBudget"] == "low"
+        assert cfg["recallBudget"] == "mid"
         assert cfg["retainEveryNTurns"] == 10
 
     def test_settings_json_overrides_defaults(self, tmp_path, monkeypatch):
@@ -75,7 +75,7 @@ class TestLoadConfig:
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
         (tmp_path / "settings.json").write_text("not valid json{{")
         cfg = load_config()
-        assert cfg["recallBudget"] == "low"  # default still applies
+        assert cfg["recallBudget"] == "mid"  # default still applies
 
     def test_null_values_in_settings_json_not_applied(self, tmp_path, monkeypatch):
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
@@ -112,7 +112,7 @@ class TestLoadConfig:
         # HOME points to tmp_path where no .hindsight/claude-code.json exists
         monkeypatch.setenv("HOME", str(tmp_path))
         cfg = load_config()
-        assert cfg["recallBudget"] == "low"  # default
+        assert cfg["recallBudget"] == "mid"  # default
 
     def test_env_var_wins_over_user_config(self, tmp_path, monkeypatch):
         plugin_root = tmp_path / "plugin"

--- a/vendor/hindsight-memory/tests/test_hooks.py
+++ b/vendor/hindsight-memory/tests/test_hooks.py
@@ -833,6 +833,11 @@ class TestRetainHook:
             assert captured["body"].get("async") is False
 
     def test_retain_includes_context_label(self, monkeypatch, tmp_path):
+        # Switchroom — the default retainContext is now a speaker-aware
+        # template resolved per-retain: {agent} from SWITCHROOM_AGENT_NAME
+        # and {bank_id} from the target bank. Pin a known agent name so the
+        # resolved label is deterministic regardless of the ambient env.
+        monkeypatch.setenv("SWITCHROOM_AGENT_NAME", "testbot")
         messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
         transcript = make_transcript_file(tmp_path, messages)
         hook_input = make_hook_input(transcript_path=transcript)
@@ -846,7 +851,11 @@ class TestRetainHook:
         _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
 
         if "body" in captured:
-            assert captured["body"]["items"][0]["context"] == "claude-code"
+            context = captured["body"]["items"][0]["context"]
+            # Template placeholders must be resolved (no literal braces left)
+            # and the agent name must be filled in from the env.
+            assert "{" not in context and "}" not in context
+            assert "agent 'testbot'" in context
 
     def test_disabled_auto_retain_does_not_call_api(self, monkeypatch, tmp_path):
         (tmp_path / "plugin_root").mkdir(exist_ok=True)

--- a/vendor/hindsight-memory/tests/test_retain_context.py
+++ b/vendor/hindsight-memory/tests/test_retain_context.py
@@ -1,0 +1,69 @@
+"""Tests for build_retain_payload's speaker-aware retainContext template.
+
+Switchroom — retainContext is no longer the opaque constant "claude-code".
+It is a template resolved per-retain by build_retain_payload's
+_resolve_template, filling {agent} from SWITCHROOM_AGENT_NAME and {bank_id}
+from the target bank so the consolidation LLM knows whose first-person
+experience each transcript line is.
+"""
+
+import pytest
+
+from retain import build_retain_payload
+
+MESSAGES = [
+    {"role": "user", "content": "human fact"},
+    {"role": "assistant", "content": "agent action"},
+]
+
+
+def _build(config, monkeypatch, agent="klanker", bank_id="klanker-main"):
+    if agent is None:
+        monkeypatch.delenv("SWITCHROOM_AGENT_NAME", raising=False)
+    else:
+        monkeypatch.setenv("SWITCHROOM_AGENT_NAME", agent)
+    result = build_retain_payload(
+        config,
+        session_id="sess-1",
+        messages_to_retain=MESSAGES,
+        all_messages=MESSAGES,
+        bank_id=bank_id,
+        api_url="http://localhost:9077",
+        api_token=None,
+    )
+    assert result is not None
+    return result["payload"]["context"]
+
+
+def test_context_template_resolves_agent_and_bank(monkeypatch):
+    context = _build(
+        {"retainContext": "agent '{agent}' ({bank_id})"},
+        monkeypatch,
+        agent="klanker",
+        bank_id="klanker-main",
+    )
+    assert context == "agent 'klanker' (klanker-main)"
+
+
+def test_context_template_agent_empty_outside_switchroom(monkeypatch):
+    context = _build(
+        {"retainContext": "agent '{agent}'"},
+        monkeypatch,
+        agent=None,
+    )
+    assert context == "agent ''"
+
+
+def test_context_default_is_speaker_aware_and_resolved(monkeypatch):
+    # No retainContext in config → build_retain_payload falls back to the
+    # "claude-code" literal, which carries no template vars and is returned
+    # verbatim. The speaker-aware default lives in settings.json / config.py
+    # DEFAULTS and is exercised by test_config; here we assert the fallback
+    # path stays byte-stable.
+    context = _build({}, monkeypatch)
+    assert context == "claude-code"
+
+
+def test_context_plain_string_passthrough(monkeypatch):
+    context = _build({"retainContext": "just plain text"}, monkeypatch)
+    assert context == "just plain text"


### PR DESCRIPTION
## Tune hindsight fleet defaults

Two single-theme changes to the vendored hindsight plugin's fleet defaults, plus a stale-comment fix.

### 1. Default recall budget `low` → `mid`

The operative fleet default lives in **three mirrored places**, all moved to `mid`:

- `src/setup/hindsight-recall-passthrough.ts` `RECALL_PASSTHROUGH_DEFAULTS.budget` — the value rendered into every agent's `start.sh` as `export HINDSIGHT_RECALL_BUDGET=<budget>`. This env **wins the config.py cascade** (DEFAULTS → settings.json → `~/.hindsight/claude-code.json` → env), so it is the true lever.
- `vendor/hindsight-memory/settings.json` `recallBudget` — the plugin stamp re-copied into each agent's `.claude/plugins/hindsight-memory/settings.json` on every reconcile.
- `vendor/hindsight-memory/scripts/lib/config.py` DEFAULTS fallback — used only when settings.json lacks the key.

**0.9.0 fact-check (grounded in the engine, not assumed):** budget is candidate **depth** (low=100 / mid=300 / high=1000 nodes across the TEMPR stages), *not* a reranker on/off switch. The cross-encoder reranker runs at **every** budget, capped separately by `HINDSIGHT_API_RERANKER_MAX_CANDIDATES` (vendor 300; switchroom lowers to 150). The stale `config.py` comment claiming "low = vector only, no reranking" is corrected. `mid` is upstream's own default; operators who want `low` set it per-agent.

Per-agent override still wins: `resolveHindsightRecallPassthrough({budget:"low"})` → `low`, and `start.sh` emits `export HINDSIGHT_RECALL_BUDGET=low` for that agent.

### 2. Speaker-aware `retainContext` template

`retainContext` was the opaque constant `"claude-code"`. It is now a template resolved per-retain by `build_retain_payload`'s `_resolve_template` (the same path `retainTags` already uses), filling:

- `{agent}` — new template var, sourced from `SWITCHROOM_AGENT_NAME` (empty and harmless outside switchroom)
- `{bank_id}` — the target bank

so the consolidation LLM knows whose first-person experience each transcript line is: `assistant`/tool lines are the agent's own actions, `user` lines are the operator stating world facts.

### Tests

- `tests/scaffold.recall-passthrough.test.ts` — new outcome tests: default resolves to `mid`; an explicit per-agent budget still wins (both the resolver and the rendered `start.sh` export).
- `vendor/hindsight-memory/tests/test_config.py` — defaults now assert `recallBudget == "mid"` and that the default `retainContext` carries the `{agent}` / `{bank_id}` slots.
- `vendor/hindsight-memory/tests/test_retain_context.py` (new) — template resolution of `{agent}`/`{bank_id}`, empty-agent fallback, and plain-string passthrough.
- `vendor/hindsight-memory/tests/test_hooks.py` — end-to-end retain now asserts the resolved speaker-aware label instead of the old constant.

vitest passthrough suite: 28 passed. Full vendor pytest suite: 262 passed. `tsc --noEmit` clean. Full `bun run lint`: green.

### Migration note (reaches the live fleet on `switchroom apply`)

On reconcile, `installHindsightPlugin` force rm+recopies the vendored plugin tree when the deployed settings.json differs from the expected render, so each agent's stamped `recallBudget` moves to `mid`; and `start.sh` is regenerated with `export HINDSIGHT_RECALL_BUDGET=mid` (which wins the cascade regardless). Both channels land `mid` on the next apply+restart — this is **not** a new-agents-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
