### PR TITLE
fix(telegram): persist card/status messages so a quote-reply to them resolves (#4571)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ now an anomaly worth investigating, not the norm.
   drops the host CLI line only once the stamp *proves* it converged; an
   unorderable version keeps the line with a confirm-host-side caveat.
 
+- **telegram: persist card/status messages so a quote-reply to them resolves**
+
 ## v0.20.22 — recall budget default moves to `mid`, speaker-aware retain context, and fail-safe recall fact-type filtering
 
 ### Features

--- a/src/cli/telegram.ts
+++ b/src/cli/telegram.ts
@@ -180,7 +180,7 @@ function readTopicsFromHistory(
           MIN(ts) AS first_ts,
           MAX(ts) AS last_ts
         FROM messages
-        WHERE chat_id = ?
+        WHERE chat_id = ? AND role <> 'system'
         GROUP BY thread_id
         ORDER BY first_ts ASC
         LIMIT ?
@@ -196,8 +196,10 @@ function readTopicsFromHistory(
     // Fetch the first-message text per (chat, thread, ts). SQLite's
     // `thread_id IS NULL` distinguishes the null row from numeric ids.
     const firstStmt = db.prepare(
+      // role <> 'system' keeps the ephemeral card lane (#4571) out of both the
+      // per-topic count and the first-message preview.
       `SELECT text, role FROM messages
-       WHERE chat_id = ? AND ts = ?
+       WHERE chat_id = ? AND ts = ? AND role <> 'system'
        AND (thread_id IS NULL AND ? IS NULL OR thread_id = ?)
        ORDER BY message_id ASC LIMIT 1`,
     );

--- a/src/web/hermes-adapter.ts
+++ b/src/web/hermes-adapter.ts
@@ -310,7 +310,10 @@ function readHistoryDb(
     try {
       const rows = db
         .prepare(
+          // role <> 'system' excludes the card lane (#4571): activity cards /
+          // status pins / approval cards are ephemeral UI, not transcript.
           `SELECT role, text, ts FROM messages
+           WHERE role <> 'system'
            ORDER BY ts DESC, rowid DESC LIMIT ?`,
         )
         .all(limit) as Array<{ role: string; text: string; ts: number }>;

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -395,7 +395,9 @@ import {
   pruneMessagesOlderThanDays,
   hasOutboundDeliveredSince,
   hasOutboundWithText,
+  recordSystemOutbound, updateSystemOutboundText,
 } from '../history.js'
+import { makeSystemMessageObserver } from './system-message-observer.js'
 import {
   runRegistryReaper,
   resolveRetentionDays as resolveRegistryRetentionDays,
@@ -5595,10 +5597,26 @@ const rawRobustApiCall = createRetryApiCall({
   floodWaitRemainingMs: probeFloodWaitRemainingMs,
 })
 
+// #4571 — card/system-surface history lane. Every card the gateway posts
+// (activity card, status pin, approval/boot/issues/worker-feed cards, progress
+// lines, notices) goes through `robustApiCall`, so observing its RESOLVED
+// result is the one chokepoint that makes every posted message id resolvable
+// when the operator quote-replies to it. Never throws; see
+// system-message-observer.ts for the send-vs-edit and throttling contract.
+// Gated on the SAME condition as `initHistory` above — a non-main gateway
+// process never opens the DB, so an observer there would be pure noise.
+const observeSentMessage = isGatewayMain && HISTORY_ENABLED
+  ? makeSystemMessageObserver({ insert: recordSystemOutbound, updateText: updateSystemOutboundText })
+  : undefined
+
 const robustApiCall = <T>(
   fn: () => Promise<T>,
   opts?: Parameters<typeof rawRobustApiCall<T>>[1],
-): Promise<T> => sendGate.gate(() => rawRobustApiCall(fn, opts), opts)
+): Promise<T> => {
+  const p = sendGate.gate(() => rawRobustApiCall(fn, opts), opts)
+  if (observeSentMessage == null) return p
+  return p.then((res) => { observeSentMessage(res, opts); return res })
+}
 
 // Fire-and-forget wrapper for outbound surfaces that previously had
 // `.catch(() => {})` directly on `bot.api.*` calls. Resolves to undefined
@@ -15048,13 +15066,18 @@ export async function handleInbound(
     replyToText,
     replyToTextEscaped,
     replyToRole,
+    replyToKind,
   } = resolveReplyToFromBuffer({
     replyToMessageId,
     replyToText: replyForwardCtx.replyToText,
     replyToTextEscaped: replyForwardCtx.replyToTextEscaped,
     historyEnabled: HISTORY_ENABLED,
     replyToTextMax: REPLY_TO_TEXT_MAX,
-    lookup: (messageId) => lookupMessageRoleAndText(chat_id, messageId),
+    // includeSystem (#4571): a quote-reply to the live activity card / a status
+    // pin / an approval card must resolve. Scoped to THIS lookup — the
+    // reaction-trigger's bot-authored predicate keeps the default (cards
+    // invisible), so its behaviour is unchanged.
+    lookup: (messageId) => lookupMessageRoleAndText(chat_id, messageId, { includeSystem: true }),
   })
 
   if (HISTORY_ENABLED) {
@@ -15132,6 +15155,7 @@ export async function handleInbound(
     replyToMessageId,
     replyToTextEscaped,
     replyToRole,
+    replyToKind,
     forwardOriginMeta,
     topicFramingEnabled: TOPIC_FRAMING_ENABLED,
     personDirectory: PERSON_DIRECTORY,

--- a/telegram-plugin/gateway/inbound-router.ts
+++ b/telegram-plugin/gateway/inbound-router.ts
@@ -208,8 +208,14 @@ export interface ReplyToBufferFallbackParams {
   /** REPLY_TO_TEXT_MAX. */
   replyToTextMax: number
   /** `lookupMessageRoleAndText` bound to the chat, or any equivalent. May
-   *  throw (e.g. requireDb when history disabled mid-run) — this is caught. */
-  lookup: (messageId: number) => { role: 'user' | 'assistant'; text: string } | null
+   *  throw (e.g. requireDb when history disabled mid-run) — this is caught.
+   *
+   *  Bind it with `includeSystem: true` (#4571) so a reply that points at a
+   *  CARD — the activity card, a status pin, an approval card — resolves
+   *  instead of returning null. `kind` carries the card family. */
+  lookup: (
+    messageId: number,
+  ) => { role: 'user' | 'assistant' | 'system'; text: string; kind?: string | null } | null
 }
 
 /**
@@ -232,15 +238,22 @@ export interface ReplyToBufferFallbackParams {
 export function resolveReplyToFromBuffer(p: ReplyToBufferFallbackParams): {
   replyToText: string | undefined
   replyToTextEscaped: string | undefined
-  replyToRole: 'user' | 'assistant' | undefined
+  replyToRole: 'user' | 'assistant' | 'system' | undefined
+  /** Card family (`activity-summary`, `approval-card`, …) when the antecedent
+   *  is a system-lane row. Undefined otherwise. #4571. */
+  replyToKind: string | undefined
 } {
   let replyToText = p.replyToText
   let replyToTextEscaped = p.replyToTextEscaped
-  let replyToRole: 'user' | 'assistant' | undefined
+  let replyToRole: 'user' | 'assistant' | 'system' | undefined
+  let replyToKind: string | undefined
   const liveTextEmpty = replyToTextEscaped == null || replyToTextEscaped.length === 0
   if (p.historyEnabled && p.replyToMessageId != null && liveTextEmpty) {
     try {
       const recovered = p.lookup(p.replyToMessageId)
+      if (recovered != null && recovered.role === 'system' && recovered.kind) {
+        replyToKind = recovered.kind
+      }
       if (recovered && recovered.text.length > 0) {
         replyToText =
           recovered.text.length > p.replyToTextMax
@@ -258,7 +271,7 @@ export function resolveReplyToFromBuffer(p: ReplyToBufferFallbackParams): {
       // silently to the id-only inputs (current behavior).
     }
   }
-  return { replyToText, replyToTextEscaped, replyToRole }
+  return { replyToText, replyToTextEscaped, replyToRole, replyToKind }
 }
 
 /** Inputs for {@link buildInboundEnvelope} — every field is an at-call
@@ -288,7 +301,11 @@ export interface EnvelopeBuildParams {
    * message, 'user' = a person's), when known — recovered from the history
    * buffer by handleInbound's reply-to fallback. Undefined when the role
    * can't be determined (e.g. text came live off the update, not the DB). */
-  replyToRole: 'user' | 'assistant' | undefined
+  replyToRole: 'user' | 'assistant' | 'system' | undefined
+  /** #4571 — when the antecedent is a CARD the gateway posted (activity card,
+   * status pin, approval card…), the card family. Emitted as `reply_to_kind`
+   * alongside `reply_to_role="system"`. */
+  replyToKind?: string | undefined
   forwardOriginMeta: Record<string, string>
   /** TOPIC_FRAMING_ENABLED — fixed constant. */
   topicFramingEnabled: boolean
@@ -390,6 +407,14 @@ export function buildInboundEnvelope(p: EnvelopeBuildParams): InboundMessage {
       // guessing the antecedent. Free: the history-buffer lookup that recovers
       // reply_to_text already returns the role. Emitted only when known.
       ...(p.replyToRole != null ? { reply_to_role: p.replyToRole } : {}),
+      // #4571 — the antecedent is one of the bot's own CARDS, not a reply.
+      // `reply_to_role="system"` + `reply_to_kind="activity-summary"` tells the
+      // agent the operator tapped the live working card (the most recent thing
+      // on their screen for most of a turn) rather than an answer, so it can
+      // read `reply_to_text` as the card body instead of reporting amnesia.
+      ...(p.replyToKind != null && p.replyToKind.length > 0
+        ? { reply_to_kind: p.replyToKind }
+        : {}),
       // Forwarded-message origin (server-stamped, attrs-only — see above).
       // forwarded_from / forwarded_from_type / forwarded_from_id /
       // forwarded_date, plus numbered _2.. siblings for a multi-origin

--- a/telegram-plugin/gateway/system-message-observer.ts
+++ b/telegram-plugin/gateway/system-message-observer.ts
@@ -1,0 +1,242 @@
+/**
+ * system-message-observer.ts — make CARD message ids resolvable (#4571).
+ *
+ * The problem
+ * -----------
+ * Only two things ever reached `history.db`: an inbound message, and an
+ * outbound that flowed through the `reply` / `stream_reply` family (which call
+ * `recordOutbound` explicitly). Everything else the gateway posts — the
+ * mid-turn activity card, the pinned status message, approval / boot / issues
+ * / worker-feed cards, `progress_update` lines, restart notices — consumed a
+ * real Telegram message id and left NO row behind. Measured on a live agent's
+ * buffer: 116 rows across a 266-id span above id 20000, i.e. ~56% of the ids
+ * in that chat were absent, clustered exactly where the cards were.
+ *
+ * That is user-visible, not cosmetic. The activity card is the most recent
+ * message on the operator's screen for most of a turn, so quote-replying to it
+ * is the natural gesture. Telegram then delivers `reply_to_message_id` pointing
+ * at a message the agent has no record of, the reply-antecedent resolver
+ * (`resolveReplyToFromBuffer`) gets `null` back, and the agent has to say "I
+ * can't see the message you replied to".
+ *
+ * The mechanism
+ * -------------
+ * Rather than add a `recordSystemOutbound(...)` call to each of the ~110 raw
+ * send sites (which is exactly the kind of per-call-site discipline that
+ * decays — the `reply` path was the only site anyone remembered), this hooks
+ * the ONE chokepoint every gateway outbound already goes through:
+ * `gateway.ts`'s `robustApiCall` (chat-lock → send-gate → retry policy). Every
+ * card send in the gateway is routed through it, enforced by the
+ * `check-bot-api-wrapping` lint guard.
+ *
+ * The observer reads the Telegram RESPONSE, not the request, which buys three
+ * things for free:
+ *   - the real `message_id` (the only thing a reply can point at),
+ *   - the chat and forum-topic the message actually landed in,
+ *   - the RENDERED text, which for a card is otherwise unrecoverable (it is
+ *     composed from live tool activity and never persisted anywhere).
+ *
+ * Send vs edit is NOT guessed from the verb (verb tagging is not uniform
+ * across call sites and would rot). It falls out of the data: an edit returns
+ * the same `message_id` it edited, so the conditional insert no-ops and the
+ * call falls through to an in-place text refresh. One row per card, forever,
+ * regardless of how many times it is edited.
+ *
+ * Cost control. The activity card is the highest-volume repeated
+ * `editMessageText` in the gateway (it climbs every few seconds for the whole
+ * turn). Refreshing its stored text on every edit would be a SQLite write per
+ * edit. So a per-message throttle (`editRefreshMs`, default 20s) keeps the hot
+ * path entirely in memory: a card edit inside the window costs one Map lookup
+ * and no DB work at all. The stored text is therefore a recent snapshot, not
+ * a byte-exact mirror of the live card — which is the right trade for a
+ * quote-reply antecedent.
+ *
+ * Nothing here throws. A failure to record a card must never break the send it
+ * is observing.
+ */
+
+/** The subset of a Telegram `Message` response this observer reads. */
+export interface SentMessageLike {
+  message_id?: unknown
+  chat?: { id?: unknown } | null
+  message_thread_id?: unknown
+  text?: unknown
+  caption?: unknown
+}
+
+/** The subset of `robustApiCall`'s opts the observer reads. */
+export interface ObservedCallOpts {
+  chat_id?: string
+  threadId?: number
+  verb?: string
+}
+
+export interface SystemMessageObserverDeps {
+  /**
+   * `history.recordSystemOutbound`. Must return true iff it inserted a NEW
+   * row, and false if any row already existed for (chat_id, message_id).
+   */
+  insert: (args: {
+    chat_id: string
+    thread_id: number | null
+    message_id: number
+    kind: string | null
+    text: string
+  }) => boolean
+  /**
+   * `history.updateSystemOutboundText`. Must return true iff it updated a row,
+   * and false when the target row is absent or is NOT a system row (i.e. the
+   * id belongs to a real reply or an inbound).
+   */
+  updateText: (args: { chat_id: string; message_id: number; text: string }) => boolean
+  /** Injectable clock for the edit throttle. Defaults to `Date.now`. */
+  now?: () => number
+}
+
+export interface SystemMessageObserverOptions {
+  /**
+   * Minimum gap between two stored-text refreshes of the SAME message. Edits
+   * inside the window are dropped without touching SQLite.
+   */
+  editRefreshMs?: number
+  /** Cap on tracked message ids before the oldest half is evicted. */
+  maxTracked?: number
+}
+
+export const DEFAULT_EDIT_REFRESH_MS = 20_000
+export const DEFAULT_MAX_TRACKED = 512
+
+/**
+ * Normalise a `robustApiCall` verb into the stored `kind` discriminator.
+ *
+ * The verb is the honest, already-present label for what a send IS
+ * (`activity-summary.send`, `boot-card`, `worker-feed`, `approval-card`), so
+ * the kind is derived rather than invented. The trailing transport suffix is
+ * stripped so a card's OPEN and its EDITs classify identically.
+ *
+ * Pure. Returns null for an absent / blank verb.
+ */
+export function normalizeSendVerb(verb: string | undefined | null): string | null {
+  if (typeof verb !== 'string') return null
+  const trimmed = verb.trim()
+  if (trimmed.length === 0) return null
+  const base = trimmed.replace(/\.(send|edit|create|post|update)$/i, '')
+  const cleaned = (base.length > 0 ? base : trimmed).slice(0, 64)
+  return cleaned.length > 0 ? cleaned : null
+}
+
+/**
+ * Extract the (chat_id, message_id, thread, text) tuple from a Telegram API
+ * result, or null when the result is not a sent/edited Message (the retry
+ * wrapper also returns `true` for pins / deletes / reactions / callback
+ * answers, and `undefined` for a swallowed benign 400).
+ *
+ * The response's own `chat.id` wins over the caller's `chat_id` opt: it is what
+ * Telegram actually delivered to, and several call sites pass no `chat_id` at
+ * all. Pure.
+ */
+export function extractSentMessage(
+  result: unknown,
+  opts?: ObservedCallOpts,
+): { chatId: string; messageId: number; threadId: number | null; text: string } | null {
+  if (result == null || typeof result !== 'object') return null
+  const msg = result as SentMessageLike
+  const id = msg.message_id
+  if (typeof id !== 'number' || !Number.isInteger(id) || id <= 0) return null
+  const rawChat = msg.chat?.id
+  const chatId =
+    rawChat != null && (typeof rawChat === 'number' || typeof rawChat === 'string')
+      ? String(rawChat)
+      : opts?.chat_id
+  if (chatId == null || chatId.length === 0) return null
+  const rawThread = msg.message_thread_id
+  const threadId =
+    typeof rawThread === 'number' && Number.isInteger(rawThread)
+      ? rawThread
+      : typeof opts?.threadId === 'number'
+        ? opts.threadId
+        : null
+  const text =
+    typeof msg.text === 'string' ? msg.text : typeof msg.caption === 'string' ? msg.caption : ''
+  return { chatId, messageId: id, threadId, text }
+}
+
+/** Per-id bookkeeping. `foreign` = the id belongs to a non-system row (a real
+ *  reply or an inbound); never write to it again. */
+type TrackedState = { lane: 'system' | 'foreign'; lastStoredMs: number }
+
+/**
+ * Build the observer. The returned function is called with the RESOLVED result
+ * of every `robustApiCall` and never throws.
+ */
+export function makeSystemMessageObserver(
+  deps: SystemMessageObserverDeps,
+  options?: SystemMessageObserverOptions,
+): (result: unknown, opts?: ObservedCallOpts) => void {
+  const now = deps.now ?? Date.now
+  const editRefreshMs = options?.editRefreshMs ?? DEFAULT_EDIT_REFRESH_MS
+  const maxTracked = Math.max(1, options?.maxTracked ?? DEFAULT_MAX_TRACKED)
+  const tracked = new Map<string, TrackedState>()
+
+  function remember(key: string, state: TrackedState): void {
+    tracked.set(key, state)
+    if (tracked.size > maxTracked) {
+      // Map iterates in insertion order — drop the oldest half in one pass so
+      // eviction is amortised O(1) rather than per-insert.
+      const drop = Math.ceil(tracked.size / 2)
+      let i = 0
+      for (const k of tracked.keys()) {
+        if (i++ >= drop) break
+        tracked.delete(k)
+      }
+    }
+  }
+
+  return function observeSentMessage(result: unknown, opts?: ObservedCallOpts): void {
+    try {
+      const sent = extractSentMessage(result, opts)
+      if (sent == null) return
+      const key = `${sent.chatId}:${sent.messageId}`
+      const t = now()
+      const seen = tracked.get(key)
+
+      if (seen != null) {
+        if (seen.lane === 'foreign') return
+        if (t - seen.lastStoredMs < editRefreshMs) return
+        if (deps.updateText({ chat_id: sent.chatId, message_id: sent.messageId, text: sent.text })) {
+          seen.lastStoredMs = t
+        } else {
+          // The row is gone (retention prune / delete) or was promoted to a
+          // real `assistant` reply by recordOutbound. Either way this id is no
+          // longer ours to write.
+          seen.lane = 'foreign'
+        }
+        return
+      }
+
+      const inserted = deps.insert({
+        chat_id: sent.chatId,
+        thread_id: sent.threadId,
+        message_id: sent.messageId,
+        kind: normalizeSendVerb(opts?.verb),
+        text: sent.text,
+      })
+      if (inserted) {
+        remember(key, { lane: 'system', lastStoredMs: t })
+        return
+      }
+      // A row already exists for this id and we did not create it in this
+      // process: either a real reply / inbound (leave it alone), or a card this
+      // gateway posted before a restart. One probing update disambiguates —
+      // `updateText` only ever matches a `system` row.
+      const refreshed = deps.updateText({
+        chat_id: sent.chatId,
+        message_id: sent.messageId,
+        text: sent.text,
+      })
+      remember(key, { lane: refreshed ? 'system' : 'foreign', lastStoredMs: t })
+    } catch {
+      /* observing a send must never break the send */
+    }
+  }
+}

--- a/telegram-plugin/history.ts
+++ b/telegram-plugin/history.ts
@@ -81,7 +81,22 @@ function loadDatabaseClass(): SqliteDatabaseConstructor {
   }
 }
 
-export type MessageRole = 'user' | 'assistant'
+/**
+ * `system` is the CARD lane (#4571): a bot→user message the gateway posted as
+ * a UI surface rather than as an answer — the mid-turn activity card, the
+ * status pin, approval / boot / issues / worker-feed cards, restart notices,
+ * `progress_update` lines. Those consume real Telegram message ids, so the
+ * operator can (and does) quote-reply to one; before this lane existed the
+ * row simply did not exist and the reply resolved to nothing.
+ *
+ * They are deliberately NOT `assistant`: every delivery-accounting predicate
+ * in this file keys on `role = 'assistant'` meaning "the user was actually
+ * answered" (`getRecentOutboundCount`, `hasOutboundDeliveredSince`,
+ * `hasOutboundWithText`), and calling a card an answer would silently suppress
+ * the silence/over-ping/represent safety nets. A distinct value keeps every
+ * existing predicate byte-identical while making the id resolvable.
+ */
+export type MessageRole = 'user' | 'assistant' | 'system'
 
 export interface RecordedMessage {
   chat_id: string
@@ -127,6 +142,14 @@ export interface RecordedMessage {
   forwarded_from_id: string | null
   forwarded_date: string | null
   forwarded_message_id: number | null
+  /**
+   * Discriminator for a `system` (card) row: the send's `verb` tag as it was
+   * passed to the gateway's retry wrapper, normalised (`activity-summary.send`
+   * → `activity-summary`). Null for `user` / `assistant` rows and for an
+   * untagged send. Surfaced to the agent as `reply_to_kind` when a native
+   * reply points at one of these messages.
+   */
+  kind: string | null
 }
 
 export interface QueryOptions {
@@ -134,6 +157,14 @@ export interface QueryOptions {
   thread_id?: number | null
   limit?: number
   before_message_id?: number
+  /**
+   * Include `system` (card) rows in the result. DEFAULT FALSE, deliberately:
+   * cards are ephemeral UI, and `get_recent_messages` renders straight into
+   * the operator-visible model context — a wall of activity-card rows there
+   * would be a regression. Card rows stay RESOLVABLE by id (see
+   * {@link lookupMessageRoleAndText}) without being LISTED.
+   */
+  include_system?: boolean
 }
 
 const DEFAULT_LIMIT = 10
@@ -212,6 +243,7 @@ export function initHistory(stateDir: string, retentionDays = 30): void {
       group_id       INTEGER,
       reply_to_message_id INTEGER,
       reply_to_text  TEXT,
+      kind           TEXT,
       PRIMARY KEY (chat_id, thread_id, message_id)
     )
   `)
@@ -232,6 +264,10 @@ export function initHistory(stateDir: string, retentionDays = 30): void {
     "forwarded_from_id TEXT",
     "forwarded_date TEXT",
     "forwarded_message_id INTEGER",
+    // #4571 — card/system-surface discriminator. Nullable with no default, so
+    // the ALTER is instant on a multi-thousand-row live DB and every existing
+    // row keeps its exact contents (SQLite backfills NULL without a rewrite).
+    "kind TEXT",
   ]) {
     try {
       db.exec(`ALTER TABLE messages ADD COLUMN ${column}`)
@@ -609,12 +645,29 @@ export function recordOutbound(args: RecordOutboundArgs): void {
       (chat_id, thread_id, message_id, role, user, user_id, ts, text, attachment_kind, group_id)
     VALUES (?, ?, ?, 'assistant', NULL, NULL, ?, ?, ?, ?)
   `)
+  // #4571 — a real reply ALWAYS wins over a provisional card row.
+  //
+  // The system-lane observer (gateway `robustApiCall`) records every sent
+  // message the moment the API resolves, which is BEFORE the caller reaches
+  // its own `recordOutbound`. `INSERT OR REPLACE` alone would not reliably
+  // overwrite that row: the unique key folds `thread_id`, and the observer
+  // derives the thread from the Telegram response (which sets
+  // `message_thread_id` on reply chains in plain supergroups) while this
+  // writer uses the gateway's own `threadId` — a mismatch would leave BOTH
+  // rows and let the card row shadow the answer for id lookups. Deleting on
+  // (chat_id, message_id) — unique within a chat regardless of thread, the
+  // same assumption `recordEdit` / `recordReaction` already make — makes the
+  // promotion exact and is a no-op when no observer row exists.
+  const dropSystem = requireDb().prepare(
+    `DELETE FROM messages WHERE chat_id = ? AND message_id = ? AND role = 'system'`,
+  )
   // bun:sqlite has a transaction() helper. Cheap insurance against partial
   // writes if the process dies mid-loop. The transaction signature is
   // typed as variadic-unknown for genericity; cast the typed callback
   // through the wider shape.
   const tx = requireDb().transaction(((rows: Array<{ id: number; text: string; attachKind: string | null }>) => {
     for (const r of rows) {
+      dropSystem.run(args.chat_id, r.id)
       stmt.run(args.chat_id, args.thread_id ?? null, r.id, ts, r.text, r.attachKind, groupId)
     }
   }) as (...args: unknown[]) => unknown)
@@ -631,6 +684,97 @@ export function recordOutbound(args: RecordOutboundArgs): void {
         `${err instanceof Error ? err.message : String(err)} — this outbound will be absent from history`,
     )
     throw err
+  }
+}
+
+export interface RecordSystemOutboundArgs {
+  chat_id: string
+  thread_id: number | null | undefined
+  message_id: number
+  /** Normalised send verb (`activity-summary`, `approval-card`, …) or null. */
+  kind: string | null | undefined
+  /** Rendered text as Telegram echoed it back. May be empty. */
+  text: string
+  /** Unix SECONDS. Defaults to now. */
+  ts?: number
+}
+
+/**
+ * Record a CARD / system-surface outbound (#4571).
+ *
+ * Conditional insert on (chat_id, message_id): if ANY row already exists for
+ * that id — a real `assistant` reply recorded by `recordOutbound`, an inbound,
+ * or a previously-recorded card — this is a no-op and returns false. That is
+ * what makes the call safe to fire from a blanket send observer that cannot
+ * distinguish a fresh send from an edit of a message it already knows: an edit
+ * returns the SAME `message_id`, hits the `NOT EXISTS` guard, and falls through
+ * to {@link updateSystemOutboundText} instead of duplicating a row per edit.
+ *
+ * Never throws — a card row is a nice-to-have, and a failure here must not
+ * break the send path it is observing. Failures are logged via `warnHistory`.
+ *
+ * Returns true iff a new row was inserted.
+ */
+export function recordSystemOutbound(args: RecordSystemOutboundArgs): boolean {
+  if (!isValidMessageId(args.message_id)) return false
+  // History disabled / not yet initialised: stay silent. This is called from a
+  // blanket send observer, so a warn here would be one stderr line per API call.
+  if (db == null) return false
+  try {
+    const res = requireDb()
+      .prepare(`
+        INSERT INTO messages
+          (chat_id, thread_id, message_id, role, user, user_id, ts, text, attachment_kind, group_id, kind)
+        SELECT ?, ?, ?, 'system', NULL, NULL, ?, ?, NULL, NULL, ?
+         WHERE NOT EXISTS (
+           SELECT 1 FROM messages WHERE chat_id = ? AND message_id = ?
+         )
+      `)
+      .run(
+        args.chat_id,
+        args.thread_id ?? null,
+        args.message_id,
+        args.ts ?? Math.floor(Date.now() / 1000),
+        // Same outbound redaction chokepoint as recordOutbound: a card body is
+        // rendered from live tool activity and can quote a secret.
+        redact(args.text),
+        args.kind ?? null,
+        args.chat_id,
+        args.message_id,
+      ) as { changes?: number }
+    return (res?.changes ?? 0) > 0
+  } catch (err) {
+    warnHistory(
+      `recordSystemOutbound: INSERT failed (chat=${args.chat_id} id=${args.message_id}): ` +
+        `${err instanceof Error ? err.message : String(err)} — a posted card will not be ` +
+        `resolvable if the operator quote-replies to it`,
+    )
+    return false
+  }
+}
+
+/**
+ * Refresh a card row's stored text in place (#4571). Only ever touches a
+ * `system` row, so an edit of a real reply can never be rewritten through this
+ * path (`recordEdit` owns that).
+ *
+ * `ts` is deliberately NOT bumped: it is the card's POST time, which is what
+ * retention prunes on. Never throws. Returns true iff a row was updated.
+ */
+export function updateSystemOutboundText(args: {
+  chat_id: string
+  message_id: number
+  text: string
+}): boolean {
+  try {
+    const res = requireDb()
+      .prepare(
+        `UPDATE messages SET text = ? WHERE chat_id = ? AND message_id = ? AND role = 'system'`,
+      )
+      .run(redact(args.text), args.chat_id, args.message_id) as { changes?: number }
+    return (res?.changes ?? 0) > 0
+  } catch {
+    return false
   }
 }
 
@@ -781,16 +925,27 @@ export function getLatestInboundMessageId(
 export function lookupMessageRoleAndText(
   chatId: string,
   messageId: number,
-): { role: 'user' | 'assistant'; text: string } | null {
-  const row = requireDb()
-    .prepare(
-      `SELECT role, text FROM messages WHERE chat_id = ? AND message_id = ? LIMIT 1`,
-    )
-    .get(chatId, messageId) as
-    | { role: 'user' | 'assistant'; text: string | null }
+  opts?: {
+    /**
+     * Also resolve `system` (card) rows. DEFAULT FALSE so the two
+     * authorship-sensitive callers — the reaction trigger's
+     * `role === 'assistant'` bot-authored predicate and the
+     * `reaction_dispatch` preview — keep their exact pre-#4571 behaviour
+     * (a card was invisible to them, and still is). The reply-antecedent
+     * resolver opts IN: that is the whole point of the card lane.
+     */
+    includeSystem?: boolean
+  },
+): { role: MessageRole; text: string; kind: string | null } | null {
+  const sql =
+    `SELECT role, text, kind FROM messages WHERE chat_id = ? AND message_id = ?` +
+    (opts?.includeSystem === true ? '' : ` AND role <> 'system'`) +
+    ` LIMIT 1`
+  const row = requireDb().prepare(sql).get(chatId, messageId) as
+    | { role: MessageRole; text: string | null; kind: string | null }
     | undefined
   if (!row) return null
-  return { role: row.role, text: row.text ?? '' }
+  return { role: row.role, text: row.text ?? '', kind: row.kind ?? null }
 }
 
 export function getRecentOutboundCount(
@@ -1007,6 +1162,8 @@ export function query(opts: QueryOptions): RecordedMessage[] {
   const limit = Math.min(MAX_LIMIT, Math.max(1, opts.limit ?? DEFAULT_LIMIT))
   const params: unknown[] = [opts.chat_id]
   let sql = 'SELECT * FROM messages WHERE chat_id = ?'
+  // #4571 — card rows are resolvable, not listable. See QueryOptions.include_system.
+  if (opts.include_system !== true) sql += " AND role <> 'system'"
   if (opts.thread_id !== undefined) {
     if (opts.thread_id === null) {
       sql += ' AND thread_id IS NULL'

--- a/telegram-plugin/tests/buzz-mirror.test.ts
+++ b/telegram-plugin/tests/buzz-mirror.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -28,6 +28,17 @@ function mirrorWith(sender: (m: OutboundToBuzzMessage) => boolean, opts?: { defa
 }
 
 const BUZZ_COORDS = { channelId: 'chan-A', eventId: 'evt-1', threadRoot: 'root-1' }
+
+// Cross-FILE isolation. `getBuzzMirror()` is a module-level singleton and the
+// last describe here boots one (`maybeBootBuzzMirror`) with no trailing reset —
+// every `beforeEach` in this file resets on the way IN, nothing resets on the
+// way OUT. `bun test` runs every file in ONE process with no guaranteed file
+// order, so a booted mirror leaks into whichever suite runs next: sendReply's
+// Buzz hook (outbound-send-path.ts:2658) then fires in suites that never wired
+// its deps and dies on `findLatestTurnForChat is not a function` (observed:
+// 43 failures in send-reply-golden.test.ts, purely from readdir order).
+// Unconditional teardown here is the only ordering-proof fix.
+afterAll(() => __resetBuzzMirrorForTests())
 
 describe('BuzzMirror.mirrorReplyDelivered — routing + S1 owner guard', () => {
   beforeEach(() => __resetBuzzMirrorForTests())

--- a/telegram-plugin/tests/card-history-lane.test.ts
+++ b/telegram-plugin/tests/card-history-lane.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Card history lane — REAL history.db end-to-end (#4571).
+ *
+ * The bug: the gateway posts activity cards, status pins, approval / boot /
+ * issues cards and progress lines as real Telegram messages that consume real
+ * message ids, but ONLY the `reply` family (which calls `recordOutbound`) ever
+ * wrote a row. Measured on a live agent's buffer: 116 rows across a 266-id
+ * span. The operator quote-replies to the activity card — the most recent
+ * message on their screen for most of a turn — Telegram delivers
+ * `reply_to_message_id` pointing at it, the buffer has nothing, and the agent
+ * answers "I can't see the message you replied to".
+ *
+ * This drives the WHOLE chain against a real bun:sqlite DB, because a stored
+ * row nobody can look up is not a fix:
+ *
+ *     robustApiCall resolves → observer → recordSystemOutbound
+ *       → lookupMessageRoleAndText({ includeSystem: true })
+ *       → resolveReplyToFromBuffer → buildInboundEnvelope
+ *       → meta.reply_to_role='system' + meta.reply_to_kind + reply_to_text
+ *
+ * plus the three regressions the lane must not cause: card rows must not be
+ * LISTED by `query()` (get_recent_messages), a real reply must always beat the
+ * provisional card row for the same id, and the schema migration must be
+ * idempotent against a live pre-#4571 DB without losing a row.
+ *
+ * Runs under `bun test` (bun:sqlite is a Bun built-in vitest can't resolve);
+ * vitest-excluded in vitest.config.ts, covered by the bun `tests/` target in
+ * telegram-plugin/scripts/bun-test-ci.sh.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { mkdtempSync, rmSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  initHistory,
+  recordInbound,
+  recordOutbound,
+  recordSystemOutbound,
+  updateSystemOutboundText,
+  lookupMessageRoleAndText,
+  query,
+  _resetForTests,
+} from '../history.js'
+import {
+  resolveReplyToFromBuffer,
+  buildInboundEnvelope,
+  type EnvelopeBuildParams,
+} from '../gateway/inbound-router.js'
+import { makeSystemMessageObserver } from '../gateway/system-message-observer.js'
+
+const CHAT = '5550001'
+const REPLY_TO_TEXT_MAX = 200
+
+/** The gateway's own wiring, verbatim: history writers behind the observer. */
+function makeObserver(now?: () => number) {
+  return makeSystemMessageObserver({
+    insert: recordSystemOutbound,
+    updateText: updateSystemOutboundText,
+    ...(now != null ? { now } : {}),
+  })
+}
+
+/** A Telegram Message response, as `robustApiCall` resolves with. */
+function sentMessage(messageId: number, text: string) {
+  return { message_id: messageId, chat: { id: Number(CHAT) }, text }
+}
+
+/** The reply-antecedent lookup as gateway.ts binds it (#4571: includeSystem). */
+function boundLookup(messageId: number) {
+  return lookupMessageRoleAndText(CHAT, messageId, { includeSystem: true })
+}
+
+function makeEnvelopeParams(overrides: Partial<EnvelopeBuildParams>): EnvelopeBuildParams {
+  return {
+    ctx: { message: { date: 1_700_000_000 } } as unknown as EnvelopeBuildParams['ctx'],
+    chat_id: CHAT,
+    messageThreadId: undefined,
+    msgId: 20268,
+    effectiveText: 'stop what you are doing and check the other repo',
+    imagePath: undefined,
+    attachment: undefined,
+    attachmentCount: 0,
+    extraMeta: {},
+    from: { id: 111, username: 'alice' },
+    access: { groups: {} },
+    isSteering: false,
+    isQueuedPrefix: false,
+    isQueuedMidTurn: false,
+    priorTurnInProgress: false,
+    secondsSinceTurnStart: undefined,
+    priorAssistantPreview: undefined,
+    replyToMessageId: undefined,
+    replyToTextEscaped: undefined,
+    replyToRole: undefined,
+    forwardOriginMeta: {},
+    topicFramingEnabled: false,
+    personDirectory: { byTelegramKey: {} },
+    isDmChatId: () => true,
+    ...overrides,
+  } as EnvelopeBuildParams
+}
+
+let stateDir: string
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), 'card-history-lane-'))
+  initHistory(stateDir, 30)
+})
+
+afterEach(() => {
+  _resetForTests()
+  if (existsSync(stateDir)) rmSync(stateDir, { recursive: true, force: true })
+})
+
+describe('a quote-reply to the live activity card is UNDERSTOOD, end to end', () => {
+  it('card posted → id resolvable → the reply carries role=system, the card kind, and its body', () => {
+    const observe = makeObserver()
+    const CARD_ID = 20267
+
+    // 1. The gateway opens the activity card. No `recordOutbound` anywhere —
+    //    this is the exact path that used to leave NO row at all.
+    observe(sentMessage(CARD_ID, '⚙️ Working — reading history.ts, 3 tools'), {
+      chat_id: CHAT,
+      verb: 'activity-summary.send',
+    })
+
+    // 2. The operator quote-replies to it. Telegram gives the id but NOT the
+    //    text (the bot authored it), so the live reply text is empty.
+    const resolved = resolveReplyToFromBuffer({
+      replyToMessageId: CARD_ID,
+      replyToText: undefined,
+      replyToTextEscaped: undefined,
+      historyEnabled: true,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+      lookup: boundLookup,
+    })
+
+    // 3. The antecedent resolves — this is the assertion the bug fails.
+    expect(resolved.replyToRole).toBe('system')
+    expect(resolved.replyToKind).toBe('activity-summary')
+    expect(resolved.replyToText).toBe('⚙️ Working — reading history.ts, 3 tools')
+
+    // 4. …and reaches the agent on the inbound envelope, so it can read the
+    //    card body instead of reporting amnesia.
+    const msg = buildInboundEnvelope(
+      makeEnvelopeParams({
+        replyToMessageId: CARD_ID,
+        replyToTextEscaped: resolved.replyToTextEscaped,
+        replyToRole: resolved.replyToRole,
+        replyToKind: resolved.replyToKind,
+      }),
+    )
+    expect(msg.meta?.reply_to_message_id).toBe(String(CARD_ID))
+    expect(msg.meta?.reply_to_role).toBe('system')
+    expect(msg.meta?.reply_to_kind).toBe('activity-summary')
+    expect(msg.meta?.reply_to_text).toBe('⚙️ Working — reading history.ts, 3 tools')
+  })
+
+  it('WITHOUT the observer the same reply resolves to nothing (the bug, pinned)', () => {
+    // No observe() call — i.e. pre-#4571 behaviour for a card send.
+    const resolved = resolveReplyToFromBuffer({
+      replyToMessageId: 20267,
+      replyToText: undefined,
+      replyToTextEscaped: undefined,
+      historyEnabled: true,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+      lookup: boundLookup,
+    })
+    expect(resolved.replyToRole).toBeUndefined()
+    expect(resolved.replyToText).toBeUndefined()
+  })
+
+  it('surfaces the LATEST card body, not the text it was opened with', () => {
+    let t = 1_000
+    const observe = makeObserver(() => t)
+    observe(sentMessage(20267, '⚙️ Working — starting'), {
+      chat_id: CHAT,
+      verb: 'activity-summary.send',
+    })
+    t += 60_000
+    observe(sentMessage(20267, '⚙️ Working — 11 tools, editing gateway.ts'), {
+      chat_id: CHAT,
+      verb: 'activity-summary.edit',
+    })
+
+    const resolved = resolveReplyToFromBuffer({
+      replyToMessageId: 20267,
+      replyToText: undefined,
+      replyToTextEscaped: undefined,
+      historyEnabled: true,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+      lookup: boundLookup,
+    })
+    expect(resolved.replyToText).toBe('⚙️ Working — 11 tools, editing gateway.ts')
+  })
+})
+
+describe('the card lane does not pollute normal history reads', () => {
+  it('query() (get_recent_messages) lists the conversation, never the cards', () => {
+    const observe = makeObserver()
+    recordInbound({
+      chat_id: CHAT,
+      thread_id: null,
+      message_id: 20200,
+      user: 'alice',
+      user_id: '111',
+      ts: 1_000,
+      text: 'what is the status of the migration?',
+    })
+    for (const id of [20209, 20210, 20212, 20213]) {
+      observe(sentMessage(id, `card ${id}`), { chat_id: CHAT, verb: 'activity-summary.send' })
+    }
+    recordOutbound({
+      chat_id: CHAT,
+      thread_id: null,
+      message_ids: [20214],
+      texts: ['Migration is applied on all three boxes.'],
+      ts: 2_000,
+    })
+
+    const listed = query({ chat_id: CHAT, limit: 50 })
+    expect(listed.map((r) => r.message_id)).toEqual([20200, 20214])
+    expect(listed.some((r) => r.role === 'system')).toBe(false)
+
+    // Opt-in still sees them — resolvable, just not listed.
+    const withCards = query({ chat_id: CHAT, limit: 50, include_system: true })
+    expect(withCards.map((r) => r.message_id).sort((a, b) => a - b)).toEqual([
+      20200, 20209, 20210, 20212, 20213, 20214,
+    ])
+  })
+
+  it('an authorship-sensitive lookup (reaction trigger) still cannot see a card', () => {
+    makeObserver()(sentMessage(20267, 'card'), { chat_id: CHAT, verb: 'activity-summary.send' })
+    // Default (no includeSystem) — the pre-#4571 contract, unchanged.
+    expect(lookupMessageRoleAndText(CHAT, 20267)).toBeNull()
+    expect(lookupMessageRoleAndText(CHAT, 20267, { includeSystem: true })?.role).toBe('system')
+  })
+})
+
+describe('a real reply always beats the provisional card row', () => {
+  it('recordOutbound promotes the id to assistant and leaves exactly one row', () => {
+    const observe = makeObserver()
+    const ID = 20261
+    // The observer fires first — it runs when the API call resolves, strictly
+    // before the caller reaches its own recordOutbound.
+    observe(sentMessage(ID, 'Migration is applied on all three boxes.'), {
+      chat_id: CHAT,
+      verb: 'reply',
+    })
+    recordOutbound({
+      chat_id: CHAT,
+      thread_id: null,
+      message_ids: [ID],
+      texts: ['Migration is applied on all three boxes.'],
+      ts: 2_000,
+    })
+
+    const rows = query({ chat_id: CHAT, limit: 50, include_system: true })
+    expect(rows.filter((r) => r.message_id === ID)).toHaveLength(1)
+    expect(rows[0]?.role).toBe('assistant')
+    // And a reply pointing at it reads as an ANSWER, not a card.
+    const resolved = resolveReplyToFromBuffer({
+      replyToMessageId: ID,
+      replyToText: undefined,
+      replyToTextEscaped: undefined,
+      historyEnabled: true,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+      lookup: boundLookup,
+    })
+    expect(resolved.replyToRole).toBe('assistant')
+    expect(resolved.replyToKind).toBeUndefined()
+  })
+
+  it('promotes even when the observer recorded a DIFFERENT thread for the id', () => {
+    // Telegram stamps message_thread_id on reply chains in plain supergroups,
+    // so the observer's thread can differ from the gateway's. The unique key
+    // folds thread_id, so without the explicit delete BOTH rows would survive
+    // and the card could shadow the answer.
+    recordSystemOutbound({
+      chat_id: CHAT,
+      thread_id: 77,
+      message_id: 20263,
+      kind: 'activity-summary',
+      text: 'card',
+    })
+    recordOutbound({
+      chat_id: CHAT,
+      thread_id: null,
+      message_ids: [20263],
+      texts: ['the real answer'],
+      ts: 2_000,
+    })
+    const rows = query({ chat_id: CHAT, limit: 50, include_system: true })
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.role).toBe('assistant')
+  })
+
+  it('a card never overwrites an inbound that already owns the id', () => {
+    recordInbound({
+      chat_id: CHAT,
+      thread_id: null,
+      message_id: 20300,
+      user: 'alice',
+      user_id: '111',
+      ts: 1_000,
+      text: 'the operator said this',
+    })
+    expect(
+      recordSystemOutbound({
+        chat_id: CHAT,
+        thread_id: null,
+        message_id: 20300,
+        kind: 'activity-summary',
+        text: 'card',
+      }),
+    ).toBe(false)
+    expect(updateSystemOutboundText({ chat_id: CHAT, message_id: 20300, text: 'card' })).toBe(false)
+    const row = lookupMessageRoleAndText(CHAT, 20300, { includeSystem: true })
+    expect(row?.role).toBe('user')
+    expect(row?.text).toBe('the operator said this')
+  })
+})
+
+describe('migration onto a live pre-#4571 history.db', () => {
+  it('adds `kind` without losing a row, and is a no-op when already migrated', () => {
+    _resetForTests()
+    const legacyDir = mkdtempSync(join(tmpdir(), 'card-history-legacy-'))
+    try {
+      // A pre-#4571 schema: no `kind` column, no logical-key index.
+      const raw = new Database(join(legacyDir, 'history.db'))
+      raw.exec(`
+        CREATE TABLE messages (
+          chat_id TEXT NOT NULL, thread_id INTEGER, message_id INTEGER NOT NULL,
+          role TEXT NOT NULL, user TEXT, user_id TEXT, ts INTEGER NOT NULL,
+          text TEXT NOT NULL, attachment_kind TEXT, group_id INTEGER,
+          PRIMARY KEY (chat_id, thread_id, message_id)
+        )
+      `)
+      const ins = raw.prepare(
+        `INSERT INTO messages (chat_id, thread_id, message_id, role, user, user_id, ts, text)
+         VALUES (?, NULL, ?, ?, ?, ?, ?, ?)`,
+      )
+      const nowSec = Math.floor(Date.now() / 1000)
+      for (let i = 0; i < 200; i++) {
+        ins.run(CHAT, 19000 + i, i % 2 === 0 ? 'user' : 'assistant', 'alice', '111', nowSec, `row ${i}`)
+      }
+      raw.close()
+
+      const countRows = () => {
+        const d = new Database(join(legacyDir, 'history.db'), { readonly: true })
+        try {
+          return (d.prepare('SELECT COUNT(*) AS c FROM messages').get() as { c: number }).c
+        } finally {
+          d.close()
+        }
+      }
+      expect(countRows()).toBe(200)
+
+      // First migration.
+      initHistory(legacyDir, 30)
+      expect(countRows()).toBe(200)
+      // The new column is usable, and every legacy row kept its exact contents.
+      expect(lookupMessageRoleAndText(CHAT, 19000)).toEqual({
+        role: 'user',
+        text: 'row 0',
+        kind: null,
+      })
+      recordSystemOutbound({
+        chat_id: CHAT,
+        thread_id: null,
+        message_id: 19500,
+        kind: 'boot-card',
+        text: 'booted',
+      })
+      _resetForTests()
+
+      // Re-run against the ALREADY-migrated file: idempotent, non-destructive.
+      initHistory(legacyDir, 30)
+      expect(countRows()).toBe(201)
+      expect(lookupMessageRoleAndText(CHAT, 19500, { includeSystem: true })).toEqual({
+        role: 'system',
+        text: 'booted',
+        kind: 'boot-card',
+      })
+      _resetForTests()
+    } finally {
+      rmSync(legacyDir, { recursive: true, force: true })
+      // Restore the per-test DB the shared afterEach expects to close.
+      initHistory(stateDir, 30)
+    }
+  })
+})

--- a/telegram-plugin/tests/system-message-observer.test.ts
+++ b/telegram-plugin/tests/system-message-observer.test.ts
@@ -1,0 +1,216 @@
+/**
+ * system-message-observer — the card-lane recorder's pure behaviour (#4571).
+ *
+ * The observer hangs off gateway.ts's single `robustApiCall` chokepoint and
+ * turns every card the gateway posts (activity summary, status pin, approval /
+ * boot / issues cards, progress lines) into ONE resolvable history row. The
+ * two properties that make it safe to run on the hot send path are asserted
+ * here against a fake writer pair:
+ *
+ *   1. an EDIT of a card it already recorded never creates a second row, and
+ *      inside the refresh window costs zero writer calls at all;
+ *   2. an id that turns out to belong to a real reply / inbound is demoted to
+ *      `foreign` and never written to again.
+ *
+ * The end-to-end proof (card posted → id resolvable → a reply pointing at it
+ * is understood) needs a real bun:sqlite history.db and lives in
+ * card-history-lane.test.ts (bun).
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  makeSystemMessageObserver,
+  normalizeSendVerb,
+  extractSentMessage,
+  DEFAULT_EDIT_REFRESH_MS,
+} from '../gateway/system-message-observer.js'
+
+const CHAT = '5550001'
+
+/** A Telegram `Message` response as the Bot API returns it from sendMessage /
+ *  editMessageText. */
+function sentMessage(messageId: number, text: string, threadId?: number) {
+  return {
+    message_id: messageId,
+    chat: { id: Number(CHAT) },
+    ...(threadId != null ? { message_thread_id: threadId } : {}),
+    text,
+  }
+}
+
+/** A writer pair backed by a Map, mirroring recordSystemOutbound /
+ *  updateSystemOutboundText's real return contract. */
+function fakeStore(seed?: Record<number, { role: 'system' | 'other'; text: string }>) {
+  const rows = new Map<number, { role: 'system' | 'other'; text: string; kind: string | null }>()
+  for (const [id, r] of Object.entries(seed ?? {})) {
+    rows.set(Number(id), { role: r.role, text: r.text, kind: null })
+  }
+  const calls = { insert: 0, update: 0 }
+  return {
+    rows,
+    calls,
+    insert(args: { message_id: number; kind: string | null; text: string }): boolean {
+      calls.insert++
+      if (rows.has(args.message_id)) return false
+      rows.set(args.message_id, { role: 'system', text: args.text, kind: args.kind })
+      return true
+    },
+    updateText(args: { message_id: number; text: string }): boolean {
+      calls.update++
+      const row = rows.get(args.message_id)
+      if (row == null || row.role !== 'system') return false
+      row.text = args.text
+      return true
+    },
+  }
+}
+
+describe('normalizeSendVerb', () => {
+  it('strips the transport suffix so a card OPEN and its EDITs classify identically', () => {
+    expect(normalizeSendVerb('activity-summary.send')).toBe('activity-summary')
+    expect(normalizeSendVerb('activity-summary.edit')).toBe('activity-summary')
+  })
+
+  it('passes a suffix-less verb through and returns null for an untagged send', () => {
+    expect(normalizeSendVerb('boot-card')).toBe('boot-card')
+    expect(normalizeSendVerb(undefined)).toBeNull()
+    expect(normalizeSendVerb('   ')).toBeNull()
+  })
+})
+
+describe('extractSentMessage', () => {
+  it('ignores non-Message results (pins/deletes/reactions return true, swallowed 400s undefined)', () => {
+    expect(extractSentMessage(true, { chat_id: CHAT })).toBeNull()
+    expect(extractSentMessage(undefined, { chat_id: CHAT })).toBeNull()
+    expect(extractSentMessage({ ok: true }, { chat_id: CHAT })).toBeNull()
+  })
+
+  it("prefers the response's own chat and thread over the caller's opts", () => {
+    const out = extractSentMessage(sentMessage(20267, 'card body', 77), {
+      chat_id: 'wrong',
+      threadId: 5,
+    })
+    expect(out).toEqual({ chatId: CHAT, messageId: 20267, threadId: 77, text: 'card body' })
+  })
+
+  it('falls back to the caller chat/thread when the response omits them', () => {
+    const out = extractSentMessage({ message_id: 9, text: 'x' }, { chat_id: CHAT, threadId: 5 })
+    expect(out).toEqual({ chatId: CHAT, messageId: 9, threadId: 5, text: 'x' })
+  })
+})
+
+describe('makeSystemMessageObserver', () => {
+  it('records a posted card once, and an EDIT of it never adds a second row', () => {
+    const store = fakeStore()
+    let now = 1_000
+    const observe = makeSystemMessageObserver({ insert: store.insert, updateText: store.updateText, now: () => now })
+
+    observe(sentMessage(20267, 'Working… reading history.ts'), {
+      chat_id: CHAT,
+      verb: 'activity-summary.send',
+    })
+    expect(store.rows.size).toBe(1)
+    expect(store.rows.get(20267)?.kind).toBe('activity-summary')
+
+    // 40 edits of the SAME card, spread well past the refresh window.
+    for (let i = 0; i < 40; i++) {
+      now += DEFAULT_EDIT_REFRESH_MS + 1
+      observe(sentMessage(20267, `Working… step ${i}`), {
+        chat_id: CHAT,
+        verb: 'activity-summary.edit',
+      })
+    }
+    // The outcome that matters: still exactly one row for that card.
+    expect(store.rows.size).toBe(1)
+    // …carrying a recent snapshot of the card body, not the stale open text.
+    expect(store.rows.get(20267)?.text).toBe('Working… step 39')
+  })
+
+  it('does no DB work at all for edits inside the refresh window', () => {
+    const store = fakeStore()
+    let now = 1_000
+    const observe = makeSystemMessageObserver({ insert: store.insert, updateText: store.updateText, now: () => now })
+
+    observe(sentMessage(30, 'open'), { chat_id: CHAT, verb: 'activity-summary.send' })
+    const afterOpen = { ...store.calls }
+
+    for (let i = 0; i < 25; i++) {
+      now += 100 // ~2.5s of a climbing activity card
+      observe(sentMessage(30, `tick ${i}`), { chat_id: CHAT, verb: 'activity-summary.edit' })
+    }
+    expect(store.calls.insert).toBe(afterOpen.insert)
+    expect(store.calls.update).toBe(afterOpen.update)
+  })
+
+  it('leaves a real reply / inbound alone and stops probing it', () => {
+    // 4242 already belongs to a non-system row (recordOutbound got there first).
+    const store = fakeStore({ 4242: { role: 'other', text: 'the real answer' } })
+    let now = 1_000
+    const observe = makeSystemMessageObserver({ insert: store.insert, updateText: store.updateText, now: () => now })
+
+    observe(sentMessage(4242, 'edited answer'), { chat_id: CHAT, verb: 'reply' })
+    expect(store.rows.get(4242)).toEqual({ role: 'other', text: 'the real answer', kind: null })
+
+    const afterProbe = { ...store.calls }
+    for (let i = 0; i < 10; i++) {
+      now += DEFAULT_EDIT_REFRESH_MS + 1
+      observe(sentMessage(4242, `edited answer ${i}`), { chat_id: CHAT, verb: 'reply' })
+    }
+    // One probing update total — then the id is marked foreign forever.
+    expect(store.calls.insert).toBe(afterProbe.insert)
+    expect(store.calls.update).toBe(afterProbe.update)
+    expect(store.rows.get(4242)?.text).toBe('the real answer')
+  })
+
+  it('demotes a card that got promoted to a real reply mid-turn', () => {
+    const store = fakeStore()
+    let now = 1_000
+    const observe = makeSystemMessageObserver({ insert: store.insert, updateText: store.updateText, now: () => now })
+
+    observe(sentMessage(55, 'card'), { chat_id: CHAT, verb: 'activity-summary.send' })
+    // recordOutbound promotes the row to a real assistant reply.
+    store.rows.set(55, { role: 'other', text: 'the real answer', kind: null })
+
+    now += DEFAULT_EDIT_REFRESH_MS + 1
+    observe(sentMessage(55, 'card edit'), { chat_id: CHAT, verb: 'activity-summary.edit' })
+    expect(store.rows.get(55)?.text).toBe('the real answer')
+
+    const after = { ...store.calls }
+    now += DEFAULT_EDIT_REFRESH_MS + 1
+    observe(sentMessage(55, 'card edit 2'), { chat_id: CHAT, verb: 'activity-summary.edit' })
+    expect(store.calls.update).toBe(after.update)
+  })
+
+  it('never throws when the writer blows up — observing a send cannot break the send', () => {
+    const observe = makeSystemMessageObserver({
+      insert: () => {
+        throw new Error('disk full')
+      },
+      updateText: () => {
+        throw new Error('disk full')
+      },
+    })
+    expect(() => observe(sentMessage(1, 'x'), { chat_id: CHAT })).not.toThrow()
+  })
+
+  it('evicts under load without losing the one-row-per-card guarantee', () => {
+    const store = fakeStore()
+    let now = 1_000
+    const observe = makeSystemMessageObserver(
+      { insert: store.insert, updateText: store.updateText, now: () => now },
+      { maxTracked: 8 },
+    )
+
+    for (let id = 1; id <= 64; id++) {
+      observe(sentMessage(id, `card ${id}`), { chat_id: CHAT, verb: 'boot-card' })
+    }
+    expect(store.rows.size).toBe(64)
+
+    // An evicted id re-observed: the insert is refused by the store, the probe
+    // finds a system row, and no duplicate appears.
+    now += DEFAULT_EDIT_REFRESH_MS + 1
+    observe(sentMessage(1, 'card 1 edited'), { chat_id: CHAT, verb: 'boot-card' })
+    expect(store.rows.size).toBe(64)
+    expect(store.rows.get(1)?.text).toBe('card 1 edited')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -179,6 +179,10 @@ export default defineConfig({
       // reply-to-buffer-history.test.ts seeds a real history.db via bun:sqlite
       // (recordOutbound → lookup → recordInbound) — excluded here, run via bun.
       "**/telegram-plugin/tests/reply-to-buffer-history.test.ts",
+      // card-history-lane.test.ts drives the #4571 card lane against a real
+      // bun:sqlite history.db (observer → recordSystemOutbound → lookup →
+      // resolveReplyToFromBuffer) — excluded here, run via bun.
+      "**/telegram-plugin/tests/card-history-lane.test.ts",
       // boot-briefing-builder.test.ts seeds a real history.db via bun:sqlite
       // (gateway boot briefing) — excluded here, run via test:bun.
       "**/telegram-plugin/tests/boot-briefing-builder.test.ts",


### PR DESCRIPTION
## Summary

Every card the gateway posts consumed a real Telegram message id and left **no row in `history.db`**. Only `recordOutbound` (the `reply` family) and `recordInbound` ever wrote. So when the operator quote-replied to the activity card — the most recent message on their screen for most of a turn — `resolveReplyToFromBuffer` returned `null` and the agent said *"I can't see the message you replied to."*

Measured on the live `overlord` buffer: above message id 20000 the table held **116 rows across a 266-id span** (~56% of ids absent), clustered exactly where the operator's quote-replies landed. Both ids actually quoted (20210, 20261) were missing.

This adds a **card lane**: one row per posted card, resolvable by id, invisible to normal history listings.

## Why this shape

- **One chokepoint, not ~110 call sites.** Every gateway outbound already goes through `gateway.ts`'s `robustApiCall` (enforced by `check-bot-api-wrapping`). The observer reads its **resolved Telegram response**, which yields the real `message_id`, the chat/topic it actually landed in, and the **rendered card text** — otherwise unrecoverable, since a card is composed from live tool activity and persisted nowhere. Per-call-site discipline is exactly what decayed to produce this bug.
- **Send vs edit is not guessed.** An edit returns the same `message_id`, so the conditional insert no-ops and falls through to an in-place text refresh. One row per card, however many times it is edited — throttled to 20s per message so the climbing activity card costs one `Map` lookup and zero SQLite writes on the hot path. Stored text is therefore a recent snapshot, not a byte-exact mirror.
- **`role = 'system'`, not `'assistant'`.** Every delivery-accounting predicate (`getRecentOutboundCount`, `hasOutboundDeliveredSince`, `hasOutboundWithText`) keys on `assistant` meaning *"the user was actually answered"*. Calling a card an answer would silently suppress the silence / over-ping / represent safety nets. A distinct value leaves every existing predicate byte-identical.
- **Resolvable without being listed.** `query()` (and therefore `get_recent_messages`) default-excludes the lane — `include_system: true` opts in. Lookup by id opts in, which is what makes the antecedent resolve. The two external readers that did **not** filter role (the web transcript tail in `src/web/hermes-adapter.ts`, the CLI topic listing in `src/cli/telegram.ts`) now do; everything else already filtered explicitly.
- **The agent is told what it replied to.** A new `reply_to_kind` meta value (`activity-summary`, `approval-card`, `boot-card`, …) rides the existing envelope, derived from the send `verb` already present at each seam.
- **Card vs real reply race.** The observer records the moment the API resolves — before the caller reaches its own `recordOutbound`. `recordOutbound` now deletes any `system` row for `(chat_id, message_id)` inside its own transaction, so a real answer always wins even if the two writers disagree about `thread_id`.

## Schema / migration

One nullable `kind TEXT` column, added **both** to `CREATE TABLE IF NOT EXISTS` and to the pre-existing duplicate-column-tolerant `ALTER TABLE` loop. Additive, instant on a multi-thousand-row live DB (SQLite backfills NULL without a rewrite), idempotent, tolerates a file already at the new schema, cannot lose a row. Covered by a test that builds the pre-#4571 schema with 200 rows and runs `initHistory` twice.

## Test plan

`telegram-plugin/tests/card-history-lane.test.ts` (bun, real `bun:sqlite`) asserts the **outcome**, end to end:

- a card posted through the observer → `resolveReplyToFromBuffer` yields `replyToRole='system'`, `replyToKind='activity-summary'`, and the card body → `buildInboundEnvelope` emits `reply_to_role` / `reply_to_kind` / `reply_to_text`;
- **a negative control pinning the bug**: without the observer, the identical reply resolves to nothing;
- the latest card body wins after edits;
- `query()` lists only the two real messages and never a card, while `include_system: true` returns all six ids;
- `recordOutbound` promotion leaves exactly one `assistant` row (including when the observer recorded a different `thread_id` for that id);
- a card never overwrites an inbound;
- migration: 200 pre-existing rows survive, `kind` is usable, second `initHistory` is a no-op.

`telegram-plugin/tests/system-message-observer.test.ts` (vitest) covers the pure mechanism: 40 edits → still one row carrying the newest body; edits inside the window → zero writer calls; a foreign id probed exactly once then never again; demotion when a card is promoted mid-turn; never throws when the writer throws; eviction under load preserves the one-row guarantee.

Local: full bun suite `10909 pass / 1 fail` — the one failure is `blocked-approval record … falls back to the agent's own state dir when the shared dir is not writable`, which cannot pass for uid 0 (root ignores the chmod) and fails identically on a clean `def77cef` checkout. `npm run lint` clean.

## Also in this PR (deliberate, one line)

`buzz-mirror.test.ts` booted the module-global mirror singleton in its last test with **no teardown**. `bun test` runs every file in one process with no guaranteed order, so it leaked into whatever ran next: `sendReply`'s Buzz hook then fired in suites that never wired its deps and died on `findLatestTurnForChat is not a function` — **43 failures in `send-reply-golden.test.ts`, purely from readdir order**. Reproduced at `def77cef` with a clean tree, so it is pre-existing, not from this change. Fixed with an unconditional `afterAll` reset because it made the suite unrunnable locally and would fire in CI the moment file ordering shifted.

## Risk

- Writes are additive and best-effort: `recordSystemOutbound` / `updateSystemOutboundText` never throw, and the observer body is wrapped — observing a send can never break the send.
- Wired only when `isGatewayMain && HISTORY_ENABLED`, the same gate as `initHistory`.
- Extra DB traffic is bounded by the 20s per-message throttle plus a 512-entry tracking map.
- Deliberately left out: no `MCP_INSTRUCTIONS` text documenting `reply_to_kind` — that budget is at 1898/1950 and the meta values are self-describing.

**Do not merge on my account** — opened for review only.
