### PR TITLE
fix(telegram): store the card body a quote-reply needs, not an empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+### Bug fixes
+
+- **telegram: store the card body a quote-reply needs, not an empty string**
+
 ## v0.21.0 — rollout now gates on the host CLI, plus telegram card persistence, gateway state-dir ownership, and hindsight `/metrics` cardinality fixes
 
 ### Bug fixes

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -303,6 +303,7 @@ import { installEditFloodFuse, editFloodFuseConfigFromEnv } from '../edit-flood-
 import { createSendGate, sendGateConfigFromEnv, isSendGateShed } from '../send-gate.js'
 import { createStatsLogger, createFloodWindowObserver } from '../send-gate-observability.js'
 import { installTgPostLogger, installRichMarkdownGuard, withTgPostTags } from '../shared/bot-runtime.js'
+import { installSentTextCapture } from '../shared/sent-text-capture.js'
 import {
   floodStatePath,
   floodWindowsPath,
@@ -5608,6 +5609,8 @@ const rawRobustApiCall = createRetryApiCall({
 // system-message-observer.ts for the send-vs-edit and throttling contract.
 // Gated on the SAME condition as `initHistory` above — a non-main gateway
 // process never opens the DB, so an observer there would be pure noise.
+// The empty-body alarm (#4576) is the observer's own default — see
+// `defaultEmptyCardTextWarning` in system-message-observer.ts.
 const observeSentMessage = isGatewayMain && HISTORY_ENABLED
   ? makeSystemMessageObserver({ insert: recordSystemOutbound, updateText: updateSystemOutboundText })
   : undefined
@@ -22877,6 +22880,11 @@ async function initGatewayBot(): Promise<void> {
 
   bot = new Bot(TOKEN)
   installTgPostLogger(bot); installRichMarkdownGuard(bot) // #3252/#3463: universal fmt guard installed after logger (composes outermost); see installRichMarkdownGuard docblock
+  // #4571 follow-up: stamp each send's REQUEST body onto its resolved Message so
+  // the card-history observer stores what the card SAID (a sendRichMessage
+  // response carries no `text`). Installed after the fmt guard so it composes
+  // OUTSIDE it and captures the caller's body pre-escape. See sent-text-capture.ts.
+  installSentTextCapture(bot)
   // #3620 flood fuse — installed LAST so it composes OUTERMOST: the one seam no
   // outbound call can bypass (grammY has no route to the network that skips the
   // transformer stack). Kill-switch SWITCHROOM_EDIT_FUSE=0; see edit-flood-fuse.ts.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -22880,10 +22880,10 @@ async function initGatewayBot(): Promise<void> {
 
   bot = new Bot(TOKEN)
   installTgPostLogger(bot); installRichMarkdownGuard(bot) // #3252/#3463: universal fmt guard installed after logger (composes outermost); see installRichMarkdownGuard docblock
-  // #4571 follow-up: stamp each send's REQUEST body onto its resolved Message so
-  // the card-history observer stores what the card SAID (a sendRichMessage
-  // response carries no `text`). Installed after the fmt guard so it composes
-  // OUTSIDE it and captures the caller's body pre-escape. See sent-text-capture.ts.
+  // #4576 follow-up: FALLBACK card body. The observer takes the stored body off
+  // the RESPONSE (`rich_message` → `text`/`caption`); this stamps the REQUEST body
+  // on the resolved Message for the shapes a response can't supply. After the fmt
+  // guard so it composes OUTSIDE it. See sent-text-capture.ts.
   installSentTextCapture(bot)
   // #3620 flood fuse — installed LAST so it composes OUTERMOST: the one seam no
   // outbound call can bypass (grammY has no route to the network that skips the

--- a/telegram-plugin/gateway/system-message-observer.ts
+++ b/telegram-plugin/gateway/system-message-observer.ts
@@ -29,20 +29,34 @@
  * card send in the gateway is routed through it, enforced by the
  * `check-bot-api-wrapping` lint guard.
  *
- * The observer reads the Telegram RESPONSE, not the request, which buys two
- * things for free:
+ * The observer reads the Telegram RESPONSE, which buys three things for free:
  *   - the real `message_id` (the only thing a reply can point at),
- *   - the chat and forum-topic the message actually landed in.
+ *   - the chat and forum-topic the message actually landed in,
+ *   - the BODY, as Telegram RENDERED it.
  *
- * The BODY does NOT come from the response. It arrives stamped on the message
- * by the `installSentTextCapture` transformer, which captured it from the
- * outbound REQUEST (`shared/sent-text-capture.ts`). That split is the #4576
- * bug, fixed: every card goes out via Bot API 10.1 `sendRichMessage`, whose
- * response is a `Message.RichMessageMessage` carrying `rich_message.blocks`
- * and NO `text` / `caption` — so deriving the body from the response yielded
- * `''` on 100% of the rows on every agent in the fleet, and the agent could see
- * WHICH card was quote-replied to but never WHAT IT SAID. The request is the
- * one place the body is unambiguously known for every send verb.
+ * The #4576 bug was reading only ONE body field off the response. Every card
+ * goes out via Bot API 10.1 `sendRichMessage`, and the `Message` it returns is
+ * a `Message.RichMessageMessage`: the body lives under `rich_message.blocks`
+ * ("Content of the message" — Bot API `RichMessage`), and `text` / `caption`
+ * are absent. `extractSentMessage` read `msg.text ?? msg.caption ?? ''` and so
+ * stored `''` on 100% of the rows on every agent in the fleet — the agent could
+ * see WHICH card was quote-replied to but never WHAT IT SAID. The fix is to
+ * read `rich_message` too, flattened by the same renderer the inbound
+ * rich-message handler uses.
+ *
+ * Preferring the response is not just simpler, it is more FAITHFUL. The
+ * request-side body for the dominant card path has already been through
+ * `richMessage()`'s `guardAccidentalFormatting` (`rich-send.ts`), which is
+ * applied in the CALLER, so `sent_text_capture.ts` is on the wire as
+ * `sent\_text\_capture.ts` and `$12.40` as `\$12.40`. The response's
+ * `rich_message` is the parsed, rendered block tree with those escapes already
+ * resolved — i.e. what the operator actually saw on screen, which is exactly
+ * what a quote-reply antecedent should say.
+ *
+ * The request-side stamp (`shared/sent-text-capture.ts`) is kept, LAST in the
+ * precedence order, as the fallback for the shapes a response cannot supply —
+ * a rich send whose blocks render to nothing (a media-only card), or a future
+ * verb whose response omits the body. It is never preferred over the response.
  *
  * Send vs edit is NOT guessed from the verb (verb tagging is not uniform
  * across call sites and would rot). It falls out of the data: an edit returns
@@ -105,13 +119,16 @@ export interface SystemMessageObserverDeps {
   now?: () => number
   /**
    * Called when a card row is about to be written with an EMPTY body — i.e.
-   * the text-capture seam did not reach this send.
+   * neither the response nor the request-side stamp yielded anything readable.
    *
    * This is the alarm for the #4576 failure mode. That bug was silent for a
    * whole release precisely because an empty body is indistinguishable from a
    * healthy row unless someone queries `length(text)`. Fired at most ONCE per
-   * `kind` per process so a broken verb is loud in the log without becoming a
-   * per-send stderr storm. Never called with a non-empty body.
+   * `kind` (else per raw verb) per process so a broken verb is loud in the log
+   * without becoming a per-send stderr storm. Never called with a non-empty
+   * body, and never for a response that is legitimately bodiless
+   * (`isLegitimatelyBodiless`) — an alarm on `sendSticker` is noise a reader
+   * cannot act on, and noise is what teaches people to ignore the alarm.
    *
    * Defaults to `defaultEmptyCardTextWarning` (stderr). Pass an explicit
    * function to redirect it, or `() => {}` to silence it in a test.
@@ -162,13 +179,17 @@ export function normalizeSendVerb(verb: string | undefined | null): string | nul
  * all.
  *
  * `text` is resolved in strict precedence order, most authoritative first:
- *   1. the body stamped by `installSentTextCapture` from the outbound REQUEST —
- *      correct for every send verb, which is why it is first;
- *   2. `rich_message` echoed back on the response, flattened by the same
- *      renderer the inbound rich-message handler uses;
- *   3. `text` / `caption`, the plain-send shapes.
- * `''` only when all three are absent, which the observer treats as an alarm.
- * Pure.
+ *   1. `rich_message` on the RESPONSE, flattened by the same renderer the
+ *      inbound rich-message handler uses. This is Telegram's own rendering of
+ *      the block tree, so markdown escapes are already resolved — it is what
+ *      the operator saw, and it is the shape every card send returns;
+ *   2. `text` / `caption`, the plain-send and media-caption response shapes;
+ *   3. the body stamped by `installSentTextCapture` from the outbound REQUEST —
+ *      LAST, because on the dominant card path (`richMessage(body)`) it is the
+ *      guard-escaped wire form, not the body as written. It is the fallback for
+ *      responses that carry no renderable body at all.
+ * `''` only when all three are absent, which the observer treats as an alarm
+ * unless the response is legitimately bodiless. Pure.
  */
 export function extractSentMessage(
   result: unknown,
@@ -192,10 +213,48 @@ export function extractSentMessage(
         ? opts.threadId
         : null
   const text =
-    readSentText(result) ??
     (msg.rich_message != null ? extractRichMessageText(msg.rich_message) : undefined) ??
-    (typeof msg.text === 'string' ? msg.text : typeof msg.caption === 'string' ? msg.caption : '')
+    nonEmptyString(msg.text) ??
+    nonEmptyString(msg.caption) ??
+    readSentText(result) ??
+    ''
   return { chatId, messageId: id, threadId, text }
+}
+
+/** `v` when it is a non-empty string, else undefined — so an empty `text` on
+ *  the response falls THROUGH to the next precedence tier instead of pinning
+ *  the result to `''`. */
+function nonEmptyString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined
+}
+
+/**
+ * Response keys that mark a Telegram `Message` as LEGITIMATELY bodiless: the
+ * send verb that produced it has no user-visible text by construction.
+ *
+ * The empty-body alarm exists to make a recurrence of #4576 loud. It is only
+ * useful if it fires on a REGRESSION, so the verbs that are *supposed* to
+ * store an empty body — `sendSticker`, `sendAnimation`, `sendVoice`,
+ * `forwardMessage` of a media message, an uncaptioned `sendPhoto` — must not
+ * emit an alarm indistinguishable from one.
+ *
+ * Keyed on the RESPONSE SHAPE rather than on `opts.verb` deliberately: verb
+ * tagging is not uniform across call sites (`forwardMessage`,
+ * `gateway.ts`, passes none at all), so a verb allowlist would rot exactly
+ * where this needs to hold. A regressed CARD is a `rich_message` response
+ * whose blocks rendered to nothing — it carries none of these keys and still
+ * alarms. Pure.
+ */
+const BODILESS_MESSAGE_KEYS = [
+  'sticker', 'animation', 'voice', 'video_note', 'dice', 'game', 'poll',
+  'contact', 'location', 'venue', 'story', 'invoice', 'successful_payment',
+  'checklist', 'photo', 'video', 'audio', 'document', 'paid_media',
+] as const
+
+export function isLegitimatelyBodiless(result: unknown): boolean {
+  if (result == null || typeof result !== 'object') return false
+  const r = result as Record<string, unknown>
+  return BODILESS_MESSAGE_KEYS.some((k) => r[k] != null)
 }
 
 /**
@@ -216,8 +275,10 @@ export function defaultEmptyCardTextWarning(info: {
   try {
     process.stderr.write(
       `telegram gateway: card-history text capture MISSED kind=${info.kind ?? '-'} ` +
-        `chat=${info.chat_id} id=${info.message_id} — a quote-reply to this card will ` +
-        `resolve its kind but not its body (see shared/sent-text-capture.ts)\n`,
+        `chat=${info.chat_id} id=${info.message_id} — the response carried no ` +
+        `rich_message/text/caption and no request-side body was stamped, so a ` +
+        `quote-reply to this card will resolve its kind but not its body ` +
+        `(see gateway/system-message-observer.ts extractSentMessage)\n`,
     )
   } catch {
     /* a broken stderr must never break the send */
@@ -225,8 +286,10 @@ export function defaultEmptyCardTextWarning(info: {
 }
 
 /** Per-id bookkeeping. `foreign` = the id belongs to a non-system row (a real
- *  reply or an inbound); never write to it again. */
-type TrackedState = { lane: 'system' | 'foreign'; lastStoredMs: number }
+ *  reply or an inbound); never write to it again. `storedLen` is the length of
+ *  the body currently in the row — 0 means the row is a HOLE, which the edit
+ *  throttle must not preserve. */
+type TrackedState = { lane: 'system' | 'foreign'; lastStoredMs: number; storedLen: number }
 
 /**
  * Build the observer. The returned function is called with the RESOLVED result
@@ -244,8 +307,18 @@ export function makeSystemMessageObserver(
   const emptyReported = new Set<string>()
   const onEmptyText = deps.onEmptyText ?? defaultEmptyCardTextWarning
 
-  function reportEmpty(chatId: string, messageId: number, kind: string | null): void {
-    const bucket = kind ?? '<untagged>'
+  function reportEmpty(
+    chatId: string,
+    messageId: number,
+    kind: string | null,
+    verb: string | undefined,
+  ): void {
+    // Bucket on the kind, else the RAW verb, else the untagged catch-all. Using
+    // `kind ?? '<untagged>'` alone collapsed every untagged verb into one
+    // bucket, so the first bodiless untagged send in the process permanently
+    // silenced the alarm for every other untagged verb — including a real
+    // regression.
+    const bucket = kind ?? (typeof verb === 'string' && verb.length > 0 ? verb : '<untagged>')
     if (emptyReported.has(bucket)) return
     emptyReported.add(bucket)
     try {
@@ -278,7 +351,9 @@ export function makeSystemMessageObserver(
       const seen = tracked.get(key)
 
       const kind = normalizeSendVerb(opts?.verb)
-      if (sent.text.length === 0) reportEmpty(sent.chatId, sent.messageId, kind)
+      if (sent.text.length === 0 && !isLegitimatelyBodiless(result)) {
+        reportEmpty(sent.chatId, sent.messageId, kind, opts?.verb)
+      }
 
       if (seen != null) {
         if (seen.lane === 'foreign') return
@@ -287,9 +362,18 @@ export function makeSystemMessageObserver(
         // with `''` would destroy a usable quote-reply antecedent and hand the
         // agent the #4576 symptom on a row that was healthy a moment ago.
         if (sent.text.length === 0) return
-        if (t - seen.lastStoredMs < editRefreshMs) return
+        // The dual rule, and the one whose absence kept the #4576 symptom alive
+        // on a row the alarm had already given up on: ALWAYS fill an EMPTY
+        // stored body. A bodiless first observation (a media-only card, a
+        // response we could not read) inserts `''` and starts the throttle
+        // clock; the first REAL body then lands inside the 20s window and was
+        // dropped, leaving the row permanently unusable as a quote-reply
+        // antecedent. The throttle exists to cap SQLite writes on a card that
+        // is already READABLE, so it only applies once something is stored.
+        if (seen.storedLen > 0 && t - seen.lastStoredMs < editRefreshMs) return
         if (deps.updateText({ chat_id: sent.chatId, message_id: sent.messageId, text: sent.text })) {
           seen.lastStoredMs = t
+          seen.storedLen = sent.text.length
         } else {
           // The row is gone (retention prune / delete) or was promoted to a
           // real `assistant` reply by recordOutbound. Either way this id is no
@@ -307,7 +391,7 @@ export function makeSystemMessageObserver(
         text: sent.text,
       })
       if (inserted) {
-        remember(key, { lane: 'system', lastStoredMs: t })
+        remember(key, { lane: 'system', lastStoredMs: t, storedLen: sent.text.length })
         return
       }
       // A row already exists for this id and we did not create it in this
@@ -322,7 +406,11 @@ export function makeSystemMessageObserver(
         message_id: sent.messageId,
         text: sent.text,
       })
-      remember(key, { lane: refreshed ? 'system' : 'foreign', lastStoredMs: t })
+      remember(key, {
+        lane: refreshed ? 'system' : 'foreign',
+        lastStoredMs: t,
+        storedLen: refreshed ? sent.text.length : 0,
+      })
     } catch {
       /* observing a send must never break the send */
     }

--- a/telegram-plugin/gateway/system-message-observer.ts
+++ b/telegram-plugin/gateway/system-message-observer.ts
@@ -29,12 +29,20 @@
  * card send in the gateway is routed through it, enforced by the
  * `check-bot-api-wrapping` lint guard.
  *
- * The observer reads the Telegram RESPONSE, not the request, which buys three
+ * The observer reads the Telegram RESPONSE, not the request, which buys two
  * things for free:
  *   - the real `message_id` (the only thing a reply can point at),
- *   - the chat and forum-topic the message actually landed in,
- *   - the RENDERED text, which for a card is otherwise unrecoverable (it is
- *     composed from live tool activity and never persisted anywhere).
+ *   - the chat and forum-topic the message actually landed in.
+ *
+ * The BODY does NOT come from the response. It arrives stamped on the message
+ * by the `installSentTextCapture` transformer, which captured it from the
+ * outbound REQUEST (`shared/sent-text-capture.ts`). That split is the #4576
+ * bug, fixed: every card goes out via Bot API 10.1 `sendRichMessage`, whose
+ * response is a `Message.RichMessageMessage` carrying `rich_message.blocks`
+ * and NO `text` / `caption` — so deriving the body from the response yielded
+ * `''` on 100% of the rows on every agent in the fleet, and the agent could see
+ * WHICH card was quote-replied to but never WHAT IT SAID. The request is the
+ * one place the body is unambiguously known for every send verb.
  *
  * Send vs edit is NOT guessed from the verb (verb tagging is not uniform
  * across call sites and would rot). It falls out of the data: an edit returns
@@ -55,6 +63,9 @@
  * is observing.
  */
 
+import { readSentText } from '../shared/sent-text-capture.js'
+import { extractRichMessageText } from './rich-message-handler.js'
+
 /** The subset of a Telegram `Message` response this observer reads. */
 export interface SentMessageLike {
   message_id?: unknown
@@ -62,6 +73,7 @@ export interface SentMessageLike {
   message_thread_id?: unknown
   text?: unknown
   caption?: unknown
+  rich_message?: unknown
 }
 
 /** The subset of `robustApiCall`'s opts the observer reads. */
@@ -91,6 +103,20 @@ export interface SystemMessageObserverDeps {
   updateText: (args: { chat_id: string; message_id: number; text: string }) => boolean
   /** Injectable clock for the edit throttle. Defaults to `Date.now`. */
   now?: () => number
+  /**
+   * Called when a card row is about to be written with an EMPTY body — i.e.
+   * the text-capture seam did not reach this send.
+   *
+   * This is the alarm for the #4576 failure mode. That bug was silent for a
+   * whole release precisely because an empty body is indistinguishable from a
+   * healthy row unless someone queries `length(text)`. Fired at most ONCE per
+   * `kind` per process so a broken verb is loud in the log without becoming a
+   * per-send stderr storm. Never called with a non-empty body.
+   *
+   * Defaults to `defaultEmptyCardTextWarning` (stderr). Pass an explicit
+   * function to redirect it, or `() => {}` to silence it in a test.
+   */
+  onEmptyText?: (info: { chat_id: string; message_id: number; kind: string | null }) => void
 }
 
 export interface SystemMessageObserverOptions {
@@ -133,7 +159,16 @@ export function normalizeSendVerb(verb: string | undefined | null): string | nul
  *
  * The response's own `chat.id` wins over the caller's `chat_id` opt: it is what
  * Telegram actually delivered to, and several call sites pass no `chat_id` at
- * all. Pure.
+ * all.
+ *
+ * `text` is resolved in strict precedence order, most authoritative first:
+ *   1. the body stamped by `installSentTextCapture` from the outbound REQUEST —
+ *      correct for every send verb, which is why it is first;
+ *   2. `rich_message` echoed back on the response, flattened by the same
+ *      renderer the inbound rich-message handler uses;
+ *   3. `text` / `caption`, the plain-send shapes.
+ * `''` only when all three are absent, which the observer treats as an alarm.
+ * Pure.
  */
 export function extractSentMessage(
   result: unknown,
@@ -157,8 +192,36 @@ export function extractSentMessage(
         ? opts.threadId
         : null
   const text =
-    typeof msg.text === 'string' ? msg.text : typeof msg.caption === 'string' ? msg.caption : ''
+    readSentText(result) ??
+    (msg.rich_message != null ? extractRichMessageText(msg.rich_message) : undefined) ??
+    (typeof msg.text === 'string' ? msg.text : typeof msg.caption === 'string' ? msg.caption : '')
   return { chatId, messageId: id, threadId, text }
+}
+
+/**
+ * The observer's DEFAULT empty-body alarm: one stderr line naming the card kind
+ * whose text capture missed.
+ *
+ * It lives here, and is the default rather than something gateway.ts wires,
+ * for two reasons: gateway.ts is under an anti-inflation line ratchet
+ * (switchroom#2996) so new logic belongs in a module; and a caller that forgets
+ * to pass `onEmptyText` is exactly the caller that would re-ship #4576
+ * silently. Opting OUT is now the explicit act.
+ */
+export function defaultEmptyCardTextWarning(info: {
+  chat_id: string
+  message_id: number
+  kind: string | null
+}): void {
+  try {
+    process.stderr.write(
+      `telegram gateway: card-history text capture MISSED kind=${info.kind ?? '-'} ` +
+        `chat=${info.chat_id} id=${info.message_id} — a quote-reply to this card will ` +
+        `resolve its kind but not its body (see shared/sent-text-capture.ts)\n`,
+    )
+  } catch {
+    /* a broken stderr must never break the send */
+  }
 }
 
 /** Per-id bookkeeping. `foreign` = the id belongs to a non-system row (a real
@@ -177,6 +240,20 @@ export function makeSystemMessageObserver(
   const editRefreshMs = options?.editRefreshMs ?? DEFAULT_EDIT_REFRESH_MS
   const maxTracked = Math.max(1, options?.maxTracked ?? DEFAULT_MAX_TRACKED)
   const tracked = new Map<string, TrackedState>()
+  /** Kinds already reported through `onEmptyText` — one alarm per kind, per process. */
+  const emptyReported = new Set<string>()
+  const onEmptyText = deps.onEmptyText ?? defaultEmptyCardTextWarning
+
+  function reportEmpty(chatId: string, messageId: number, kind: string | null): void {
+    const bucket = kind ?? '<untagged>'
+    if (emptyReported.has(bucket)) return
+    emptyReported.add(bucket)
+    try {
+      onEmptyText({ chat_id: chatId, message_id: messageId, kind })
+    } catch {
+      /* the alarm must never break the send either */
+    }
+  }
 
   function remember(key: string, state: TrackedState): void {
     tracked.set(key, state)
@@ -200,8 +277,16 @@ export function makeSystemMessageObserver(
       const t = now()
       const seen = tracked.get(key)
 
+      const kind = normalizeSendVerb(opts?.verb)
+      if (sent.text.length === 0) reportEmpty(sent.chatId, sent.messageId, kind)
+
       if (seen != null) {
         if (seen.lane === 'foreign') return
+        // Never blank a body we already stored. A refresh whose text did not
+        // reach us is missing information, not new information — overwriting
+        // with `''` would destroy a usable quote-reply antecedent and hand the
+        // agent the #4576 symptom on a row that was healthy a moment ago.
+        if (sent.text.length === 0) return
         if (t - seen.lastStoredMs < editRefreshMs) return
         if (deps.updateText({ chat_id: sent.chatId, message_id: sent.messageId, text: sent.text })) {
           seen.lastStoredMs = t
@@ -218,7 +303,7 @@ export function makeSystemMessageObserver(
         chat_id: sent.chatId,
         thread_id: sent.threadId,
         message_id: sent.messageId,
-        kind: normalizeSendVerb(opts?.verb),
+        kind,
         text: sent.text,
       })
       if (inserted) {
@@ -228,7 +313,10 @@ export function makeSystemMessageObserver(
       // A row already exists for this id and we did not create it in this
       // process: either a real reply / inbound (leave it alone), or a card this
       // gateway posted before a restart. One probing update disambiguates —
-      // `updateText` only ever matches a `system` row.
+      // `updateText` only ever matches a `system` row. The probe WRITES, so an
+      // empty body cannot be used to run it: skip, stay untracked, and let the
+      // next observation of this id (which carries a body) do the probing.
+      if (sent.text.length === 0) return
       const refreshed = deps.updateText({
         chat_id: sent.chatId,
         message_id: sent.messageId,

--- a/telegram-plugin/shared/sent-text-capture.ts
+++ b/telegram-plugin/shared/sent-text-capture.ts
@@ -1,9 +1,28 @@
 /**
- * sent-text-capture.ts — pair a card's RENDERED body with the message id
- * Telegram assigned it (#4571 follow-up).
+ * sent-text-capture.ts — the card-body FALLBACK: stamp a send's REQUEST body
+ * onto the `Message` Telegram returned for it (#4571 / #4576 follow-up).
  *
- * The bug this exists to close
- * ---------------------------
+ * Read this first: it is NOT the primary source of the stored card body.
+ * -----------------------------------------------------------------------
+ * `system-message-observer.ts` takes the body off the RESPONSE — `rich_message`
+ * (Telegram's own rendered block tree) first, then `text` / `caption`. That is
+ * the more faithful source, and it covers every send verb the gateway writes a
+ * history row for. This module supplies the LAST tier of that precedence
+ * chain, for responses that carry no renderable body at all: a rich send whose
+ * blocks flatten to nothing (a media-only card), or a future verb whose
+ * response omits the body.
+ *
+ * Deliberately last, because the body it captures is NOT the body as written.
+ * The dominant card path is `sendRichMessage(chat, richMessage(body))`, and
+ * `richMessage()` applies `guardAccidentalFormatting` in the CALLER
+ * (`rich-send.ts`), long before any transformer seam. So what this module sees
+ * on that path is already wire-escaped: `sent_text_capture.ts` arrives as
+ * `sent\_text\_capture.ts`, `$12.40` as `\$12.40`. Escaped-but-present beats
+ * empty, which is why the tier exists at all — but it must never win over a
+ * response that resolved those escapes.
+ *
+ * The bug this exists to backstop
+ * -------------------------------
  * #4576 gave every gateway card a `role='system'` history row so a quote-reply
  * to it resolves. The row carried the right `message_id`, chat, thread and
  * `kind` — and an EMPTY `text`, on 100% of the rows, on every agent in the
@@ -11,20 +30,21 @@
  * body is non-empty (`inbound-router.ts`), so the agent learned WHICH card was
  * tapped and still could not see WHAT IT SAID. That was the entire point.
  *
- * Root cause: the observer derived the body from the Telegram RESPONSE
+ * Root cause: the observer read ONE body field off the response
  * (`msg.text ?? msg.caption`), and every card goes out through Bot API 10.1
  * `sendRichMessage`, whose response is a `Message.RichMessageMessage` — the
  * body lives under `rich_message: { blocks }`, and `text` / `caption` are
- * simply absent (`@grammyjs/types` `message.d.ts:98`, `:184`). So the extractor
- * fell through to `''` every single time.
+ * simply absent (`@grammyjs/types` `message.d.ts:94`, `:180`; Bot API
+ * `RichMessage.blocks` = "Content of the message"). So the extractor fell
+ * through to `''` every single time. Reading `rich_message` is the fix; this
+ * module is the belt to that pair of braces.
  *
  * The mechanism
  * -------------
- * Don't re-derive the body from a response shape that varies per send verb.
- * Capture it from the REQUEST, where it is unambiguously known for every verb,
- * at the one seam no outbound call can bypass: a grammY API transformer
- * (`bot.api.config.use`) — the same seam `installRichMarkdownGuard` already
- * uses, and the reason that guard is universal where `richMessage()` is not.
+ * Capture the body from the REQUEST at the one seam no outbound call can
+ * bypass: a grammY API transformer (`bot.api.config.use`) — the same seam
+ * `installRichMarkdownGuard` already uses, and the reason that guard is
+ * universal where `richMessage()` is not.
  *
  * The transformer sees the outbound payload AND the resolved response in one
  * call, so it can pair them with zero bookkeeping: no id→text map, no eviction,
@@ -145,9 +165,16 @@ export function readSentText(message: unknown): string | null {
  *
  * Install it AFTER `installRichMarkdownGuard` so it composes OUTSIDE the guard
  * (grammY's last-installed transformer runs first) and therefore captures the
- * body as the CALLER wrote it, before the accidental-formatting guard's
- * backslash escapes are applied. The stored antecedent is what the card said,
- * not the wire-escaped form of it.
+ * payload before the guard's backslash escapes are applied.
+ *
+ * Be precise about what that does and does not buy. It only avoids the
+ * TRANSFORMER's escaping pass, which matters for the call sites that build a
+ * raw `{ markdown }` and go straight to `sendRichMessage` / `editMessageText`
+ * (banners, approval and folder-picker edits — see `richMessage()`'s docblock
+ * for the list). It does NOT recover a pre-escape body for the dominant path,
+ * because `richMessage()` escapes in the CALLER, upstream of every transformer.
+ * There is no seam that can. That is precisely why this capture is the LAST
+ * tier of the observer's precedence chain rather than the first.
  */
 export function installSentTextCapture(bot: Bot): void {
   bot.api.config.use(async (prev, method, payload, signal) => {

--- a/telegram-plugin/shared/sent-text-capture.ts
+++ b/telegram-plugin/shared/sent-text-capture.ts
@@ -1,0 +1,164 @@
+/**
+ * sent-text-capture.ts — pair a card's RENDERED body with the message id
+ * Telegram assigned it (#4571 follow-up).
+ *
+ * The bug this exists to close
+ * ---------------------------
+ * #4576 gave every gateway card a `role='system'` history row so a quote-reply
+ * to it resolves. The row carried the right `message_id`, chat, thread and
+ * `kind` — and an EMPTY `text`, on 100% of the rows, on every agent in the
+ * fleet. `resolveReplyToFromBuffer` only sets `reply_to_text` when the stored
+ * body is non-empty (`inbound-router.ts`), so the agent learned WHICH card was
+ * tapped and still could not see WHAT IT SAID. That was the entire point.
+ *
+ * Root cause: the observer derived the body from the Telegram RESPONSE
+ * (`msg.text ?? msg.caption`), and every card goes out through Bot API 10.1
+ * `sendRichMessage`, whose response is a `Message.RichMessageMessage` — the
+ * body lives under `rich_message: { blocks }`, and `text` / `caption` are
+ * simply absent (`@grammyjs/types` `message.d.ts:98`, `:184`). So the extractor
+ * fell through to `''` every single time.
+ *
+ * The mechanism
+ * -------------
+ * Don't re-derive the body from a response shape that varies per send verb.
+ * Capture it from the REQUEST, where it is unambiguously known for every verb,
+ * at the one seam no outbound call can bypass: a grammY API transformer
+ * (`bot.api.config.use`) — the same seam `installRichMarkdownGuard` already
+ * uses, and the reason that guard is universal where `richMessage()` is not.
+ *
+ * The transformer sees the outbound payload AND the resolved response in one
+ * call, so it can pair them with zero bookkeeping: no id→text map, no eviction,
+ * no cross-call race. It stamps the body onto the returned `Message` under a
+ * non-enumerable, `Symbol.for`-keyed property, which:
+ *   - survives grammY's `callApi` unwrapping — the transformer chain resolves
+ *     with the raw `{ok, result}` envelope and `callApi` returns `data.result`
+ *     BY REFERENCE (grammy 1.44.0 `out/core/client.js:95-99`), so the object
+ *     the caller receives is the object we stamped;
+ *   - is invisible to `JSON.stringify`, `Object.keys`, spreads and structural
+ *     equality, so nothing that reads a `Message` today can observe it.
+ *
+ * Non-negotiable: this must never break the send it observes. Every step is
+ * defensive and the transformer's only unconditional act is `return prev(...)`.
+ */
+
+import type { Bot } from 'grammy'
+
+/**
+ * The stamp key. `Symbol.for` (not a module-local `Symbol()`) deliberately:
+ * the plugin is consumed both from source and from a bundle, and a duplicated
+ * module instance would otherwise mint a second, non-matching symbol and
+ * silently reopen the exact hole this file closes.
+ */
+export const SENT_TEXT = Symbol.for('switchroom.telegram.sentText')
+
+/** Depth cap for the rich-block walk — a hostile/odd payload cannot recurse us. */
+const MAX_BLOCK_DEPTH = 8
+
+/**
+ * Best-effort readable text out of an OUTBOUND `InputRichMessage.blocks` array.
+ *
+ * Nothing in this repo builds `{ blocks }` today (every rich send goes through
+ * `richMessage()` → `{ markdown }`), so this is purely the guard against a
+ * future adopter silently re-emptying the card lane. Bounded, allocation-shy,
+ * never throws.
+ */
+function flattenInputRichBlocks(blocks: unknown, depth: number): string {
+  if (!Array.isArray(blocks) || depth > MAX_BLOCK_DEPTH) return ''
+  const parts: string[] = []
+  for (const block of blocks) {
+    if (block == null || typeof block !== 'object') continue
+    const b = block as Record<string, unknown>
+    for (const key of ['markdown', 'html', 'text', 'caption'] as const) {
+      const v = b[key]
+      if (typeof v === 'string' && v.length > 0) parts.push(v)
+    }
+    const nested = flattenInputRichBlocks(b.blocks, depth + 1)
+    if (nested.length > 0) parts.push(nested)
+  }
+  return parts.join('\n')
+}
+
+/**
+ * The body a Telegram API request is about to POST, or null when the payload
+ * carries no user-visible text (pins, deletes, reactions, `getUpdates`, …).
+ *
+ * Shape verified against grammy 1.44.0 `out/core/api.js` and the payload notes
+ * in `installRichMarkdownGuard`: `sendRichMessage` / rich `editMessageText`
+ * put the body at `payload.rich_message.markdown`, plain sends at
+ * `payload.text`, media sends at `payload.caption`. Pure.
+ */
+export function outboundPayloadText(payload: unknown): string | null {
+  if (payload == null || typeof payload !== 'object') return null
+  const p = payload as Record<string, unknown>
+  const rich = p.rich_message
+  if (rich != null && typeof rich === 'object') {
+    const r = rich as Record<string, unknown>
+    if (typeof r.markdown === 'string') return r.markdown
+    if (typeof r.html === 'string') return r.html
+    const flat = flattenInputRichBlocks(r.blocks, 0)
+    if (flat.length > 0) return flat
+  }
+  if (typeof p.text === 'string') return p.text
+  if (typeof p.caption === 'string') return p.caption
+  return null
+}
+
+/**
+ * Stamp `text` onto a resolved API response envelope's `Message` result.
+ *
+ * Takes the raw `{ok, result}` envelope (what a transformer sees), not the
+ * unwrapped message, and no-ops on anything that isn't a single Message —
+ * `true` (pins / dropped edits / `editMessageText` on an inline message),
+ * arrays, `{ok:false}` rejections. Never throws.
+ */
+export function attachSentText(envelope: unknown, text: string): void {
+  try {
+    if (envelope == null || typeof envelope !== 'object') return
+    const env = envelope as { ok?: unknown; result?: unknown }
+    if (env.ok !== true) return
+    const result = env.result
+    if (result == null || typeof result !== 'object' || Array.isArray(result)) return
+    Object.defineProperty(result, SENT_TEXT, {
+      value: text,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    })
+  } catch {
+    /* stamping must never break the send */
+  }
+}
+
+/**
+ * Read the body stamped by {@link installSentTextCapture} off a `Message`, or
+ * null when the message did not transit a capture-installed bot (a test double,
+ * a second Bot instance, a hand-built fixture). Pure.
+ */
+export function readSentText(message: unknown): string | null {
+  if (message == null || typeof message !== 'object') return null
+  const v = (message as Record<symbol, unknown>)[SENT_TEXT]
+  return typeof v === 'string' ? v : null
+}
+
+/**
+ * Install the capture transformer on the production Bot.
+ *
+ * Install it AFTER `installRichMarkdownGuard` so it composes OUTSIDE the guard
+ * (grammY's last-installed transformer runs first) and therefore captures the
+ * body as the CALLER wrote it, before the accidental-formatting guard's
+ * backslash escapes are applied. The stored antecedent is what the card said,
+ * not the wire-escaped form of it.
+ */
+export function installSentTextCapture(bot: Bot): void {
+  bot.api.config.use(async (prev, method, payload, signal) => {
+    let text: string | null = null
+    try {
+      text = outboundPayloadText(payload)
+    } catch {
+      text = null
+    }
+    const res = await prev(method, payload, signal)
+    if (text != null) attachSentText(res, text)
+    return res
+  })
+}

--- a/telegram-plugin/tests/card-history-lane.test.ts
+++ b/telegram-plugin/tests/card-history-lane.test.ts
@@ -49,6 +49,10 @@ import {
   type EnvelopeBuildParams,
 } from '../gateway/inbound-router.js'
 import { makeSystemMessageObserver } from '../gateway/system-message-observer.js'
+import { Bot } from 'grammy'
+import { installRichMarkdownGuard } from '../shared/bot-runtime.js'
+import { installSentTextCapture } from '../shared/sent-text-capture.js'
+import { richMessage } from '../rich-send.js'
 
 const CHAT = '5550001'
 const REPLY_TO_TEXT_MAX = 200
@@ -62,9 +66,56 @@ function makeObserver(now?: () => number) {
   })
 }
 
-/** A Telegram Message response, as `robustApiCall` resolves with. */
+/**
+ * A Telegram Message response, as `robustApiCall` resolves with.
+ *
+ * NOTE (#4576): this PLAIN shape is what `sendMessage` returns. No CARD send
+ * uses it — cards go out via `sendRichMessage`, whose response carries no
+ * `text` at all. Tests that assert the card BODY must use `sentRichCard()`
+ * below; a hand-built `{ text }` fixture cannot fail on the empty-body bug.
+ */
 function sentMessage(messageId: number, text: string) {
   return { message_id: messageId, chat: { id: Number(CHAT) }, text }
+}
+
+/**
+ * The result of a REAL `sendRichMessage` through the production transformer
+ * stack (fmt guard + `installSentTextCapture`), transport stubbed to answer
+ * with the true `Message.RichMessageMessage` shape: `rich_message` blocks, and
+ * NO `text` / `caption`.
+ *
+ * This is the fixture the #4576 defect demanded: every `role='system'` row on
+ * every agent in the fleet had `length(text)=0`, because the lane's tests fed
+ * the observer a response shape production never produces.
+ */
+async function sentRichCard(messageId: number, body: string): Promise<unknown> {
+  const fakeFetch = (async () =>
+    ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        result: {
+          message_id: messageId,
+          date: 0,
+          chat: { id: Number(CHAT), type: 'private' },
+          rich_message: { blocks: [{ type: 'paragraph', text: { text: body } }] },
+        },
+      }),
+    }) as unknown as Response) as unknown as typeof fetch
+
+  const bot = new Bot('123456:TEST_TOKEN', {
+    botInfo: {
+      id: 123456, is_bot: true, first_name: 'Test', username: 'test_bot',
+      can_join_groups: false, can_read_all_group_messages: false,
+      supports_inline_queries: false, can_connect_to_business: false,
+      has_main_web_app: false,
+    },
+    client: { fetch: fakeFetch },
+  })
+  installRichMarkdownGuard(bot)
+  installSentTextCapture(bot)
+  return bot.api.sendRichMessage(Number(CHAT), richMessage(body))
 }
 
 /** The reply-antecedent lookup as gateway.ts binds it (#4571: includeSystem). */
@@ -194,6 +245,75 @@ describe('a quote-reply to the live activity card is UNDERSTOOD, end to end', ()
       lookup: boundLookup,
     })
     expect(resolved.replyToText).toBe('⚙️ Working — 11 tools, editing gateway.ts')
+  })
+})
+
+describe('#4576: the stored card body is NOT empty — real sendRichMessage response', () => {
+  it('a rich card write leaves a non-empty row, and the quote-reply carries the body', async () => {
+    const observe = makeObserver()
+    const CARD_ID = 20395
+    const BODY = '⚙️ Working — reading history.ts, 3 tools'
+
+    // The exact production path: sendRichMessage → transformer stack → observer.
+    // Its response has NO `text` field, which is what made every fleet row empty.
+    const result = await sentRichCard(CARD_ID, BODY)
+    expect((result as { text?: unknown }).text).toBeUndefined()
+    observe(result, { chat_id: CHAT, verb: 'activity-summary.send' })
+
+    const row = lookupMessageRoleAndText(CHAT, CARD_ID, { includeSystem: true })
+    expect(row?.role).toBe('system')
+    expect(row?.kind).toBe('activity-summary')
+    // The assertion the shipped bug fails: a stored body, not ''.
+    expect(row?.text.length).toBeGreaterThan(0)
+    expect(row?.text).toBe(BODY)
+
+    const resolved = resolveReplyToFromBuffer({
+      replyToMessageId: CARD_ID,
+      replyToText: undefined,
+      replyToTextEscaped: undefined,
+      historyEnabled: true,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+      lookup: boundLookup,
+    })
+    expect(resolved.replyToText).toBe(BODY)
+
+    const msg = buildInboundEnvelope(
+      makeEnvelopeParams({
+        replyToMessageId: CARD_ID,
+        replyToTextEscaped: resolved.replyToTextEscaped,
+        replyToRole: resolved.replyToRole,
+        replyToKind: resolved.replyToKind,
+      }),
+    )
+    expect(msg.meta?.reply_to_text).toBe(BODY)
+  })
+
+  it('holds for every card verb observed on the live fleet, not just the activity card', async () => {
+    const observe = makeObserver()
+    // The `kind` values measured on live agents' history.db after v0.21.0.
+    const verbs: [string, number, string][] = [
+      ['boot-card', 5082, '🟢 **overlord** is up — sonnet, 3 skills'],
+      ['worker-feed', 20404, '🛠 Worker — scoping the card-persistence defect'],
+      ['issues-card', 20405, '**3 open issues** — #4571, #4576, #4580'],
+      ['rollout-status-post', 20402, 'Rolling v0.21.0 — 4/12 agents done'],
+      ['quota-watch.fleet-roll', 20407, 'Quota 61% — resets 09:00'],
+      ['permission_request', 20406, '**Approve** `docker restart switchroom-clerk`?'],
+    ]
+    for (const [verb, id, body] of verbs) {
+      observe(await sentRichCard(id, body), { chat_id: CHAT, verb })
+    }
+    for (const [verb, id, body] of verbs) {
+      const row = lookupMessageRoleAndText(CHAT, id, { includeSystem: true })
+      expect(`${verb}:${row?.text.length ?? 0}`).not.toBe(`${verb}:0`)
+      expect(row?.text).toBe(body)
+    }
+    // No card row anywhere in the buffer is bodiless — the fleet-wide invariant
+    // the shipped release violated on 100% of its rows.
+    const cards = query({ chat_id: CHAT, limit: 100, include_system: true }).filter(
+      (r) => r.role === 'system',
+    )
+    expect(cards).toHaveLength(verbs.length)
+    expect(cards.filter((r) => r.text.length === 0)).toEqual([])
   })
 })
 

--- a/telegram-plugin/tests/sent-text-capture.test.ts
+++ b/telegram-plugin/tests/sent-text-capture.test.ts
@@ -7,7 +7,7 @@
  * `Message` with a `text` field — a shape no card send has EVER produced. Every
  * gateway card goes out via Bot API 10.1 `sendRichMessage`, whose response is a
  * `Message.RichMessageMessage`: body under `rich_message.blocks`, no `text`, no
- * `caption`. `extractSentMessage`'s `msg.text ?? msg.caption ?? ''` therefore
+ * `caption`. `extractSentMessage` read `msg.text ?? msg.caption ?? ''` and therefore
  * resolved `''` 100% of the time, and a quote-reply to a card gave the agent the
  * card's KIND but never its BODY.
  *
@@ -16,6 +16,11 @@
  * that answers with the REAL rich-message response shape, then assert the body
  * survives to the history writer. A test that builds its own `{ text }` fixture
  * cannot fail on this bug and is not a test of it.
+ *
+ * Equally: a test that hand-builds its own `{ markdown }` PAYLOAD cannot fail
+ * on the escaping bug. The production caller is `richMessage(body)`, which runs
+ * `guardAccidentalFormatting` in the CALLER — before any transformer can see it
+ * — so every send here goes THROUGH `richMessage()`, never around it.
  */
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
@@ -38,8 +43,12 @@ const CHAT = 5550001
 /**
  * The response Telegram actually returns for `sendRichMessage` — the body lives
  * in `rich_message.blocks`; `text` and `caption` are ABSENT. Verified against
- * `@grammyjs/types` 4.0.0 `message.d.ts:98` (`RichMessageMessage = CommonMessage
- * & MsgWith<"rich_message">`) and `:184` (`rich_message?: RichMessage`).
+ * `@grammyjs/types` 3.28.0 (the version `grammy@^1.44` resolves)
+ * `message.d.ts:94` (`RichMessageMessage = CommonMessage &
+ * MsgWith<"rich_message">`) and `:180` (`rich_message?: RichMessage`), and
+ * against the Bot API reference: `sendRichMessage` "On success, the sent
+ * Message is returned", `Message.rich_message: RichMessage` "Optional. Message
+ * is a rich formatted message", `RichMessage.blocks` "Content of the message".
  */
 function richMessageResponse(messageId: number, rendered: string) {
   return {
@@ -145,30 +154,34 @@ describe('attachSentText / readSentText', () => {
 
 describe('the card body survives the real send path, for every verb a card uses', () => {
   // Each row is a production card send verb reduced to the API call it makes.
-  // `expected` is the body the history row MUST end up carrying.
+  // `expected` is the body the history row MUST end up carrying — Telegram's
+  // RENDERED form, which is what the response echoes and what the operator saw.
   const cases: {
     name: string
-    body: string
+    expected: string
     send: (bot: Bot) => Promise<unknown>
     respond: (method: string) => unknown
   }[] = [
     {
       name: 'activity-summary.send / boot-card / issues-card / worker-feed (sendRichMessage)',
-      body: '⚙️ Working — reading history.ts, 3 tools',
+      expected: '⚙️ Working — reading history.ts, 3 tools',
       send: (bot) =>
         bot.api.sendRichMessage(CHAT, richMessage('⚙️ Working — reading history.ts, 3 tools')),
       respond: () => richMessageResponse(20395, '⚙️ Working — reading history.ts, 3 tools'),
     },
     {
       name: 'activity-summary.edit / rollout-status-edit (rich editMessageText)',
-      body: '⚙️ Working — 11 tools, editing gateway.ts',
+      expected: '⚙️ Working — 11 tools, editing gateway.ts',
       send: (bot) =>
         bot.api.editMessageText(CHAT, 20395, richMessage('⚙️ Working — 11 tools, editing gateway.ts')),
       respond: () => richMessageResponse(20395, '⚙️ Working — 11 tools, editing gateway.ts'),
     },
     {
+      // The one row where the sent markdown and the rendered response DIVERGE.
+      // The stored antecedent is the rendered form: `**Approve**` reaches the
+      // operator's screen as bold "Approve", and that is what they quoted.
       name: 'permission_request (sendRichMessage with an inline keyboard)',
-      body: '**Approve** `docker restart switchroom-clerk`?',
+      expected: 'Approve docker restart switchroom-clerk?',
       send: (bot) =>
         bot.api.sendRichMessage(CHAT, richMessage('**Approve** `docker restart switchroom-clerk`?'), {
           reply_markup: { inline_keyboard: [[{ text: 'Approve', callback_data: 'ok' }]] },
@@ -177,13 +190,13 @@ describe('the card body survives the real send path, for every verb a card uses'
     },
     {
       name: 'privacy-reset-alert / restart notices (plain sendMessage)',
-      body: 'Restarting — back in a moment.',
+      expected: 'Restarting — back in a moment.',
       send: (bot) => bot.api.sendMessage(CHAT, 'Restarting — back in a moment.'),
       respond: () => plainMessageResponse(20410, 'Restarting — back in a moment.'),
     },
     {
       name: 'a media card (sendPhoto caption)',
-      body: 'fleet quota, last 24h',
+      expected: 'fleet quota, last 24h',
       send: (bot) => bot.api.sendPhoto(CHAT, 'file-id', { caption: 'fleet quota, last 24h' }),
       respond: () => ({
         message_id: 20411,
@@ -203,7 +216,7 @@ describe('the card body survives the real send path, for every verb a card uses'
       // The outcome that #4576 got wrong: the extractor yields the real body.
       const extracted = extractSentMessage(result, { chat_id: String(CHAT) })
       expect(extracted).not.toBeNull()
-      expect(extracted!.text).toBe(c.body)
+      expect(extracted!.text).toBe(c.expected)
       expect(extracted!.text.length).toBeGreaterThan(0)
 
       // …and it reaches the history writer that way.
@@ -217,26 +230,79 @@ describe('the card body survives the real send path, for every verb a card uses'
       })
       observe(result, { chat_id: String(CHAT), verb: 'activity-summary.send' })
       expect(written).toHaveLength(1)
-      expect(written[0].text).toBe(c.body)
+      expect(written[0].text).toBe(c.expected)
     })
   }
 
-  it('captures the body the CALLER wrote, not the wire-escaped form', async () => {
-    // The fmt guard escapes `#` on the wire; the stored antecedent should read
-    // as the operator saw it. Capture composes outside the guard for this reason.
-    const { bot, calls } = makeBot(() => richMessageResponse(1, '#4576 landed'))
-    const result = await bot.api.sendRichMessage(CHAT, { markdown: '#4576 landed' })
-    expect((calls[calls.length - 1].body.rich_message as { markdown: string }).markdown).toBe(
-      '\\#4576 landed',
-    )
-    expect(readSentText(result)).toBe('#4576 landed')
-  })
+  /**
+   * The fidelity property, asserted through the REAL caller.
+   *
+   * `richMessage()` runs `guardAccidentalFormatting` in the CALLER, upstream of
+   * every transformer, so the request-side stamp on this path is the ESCAPED
+   * wire form and there is no seam that could make it otherwise. A test that
+   * hand-builds `{ markdown: '…' }` bypasses that and passes even when the
+   * stored body is `sent\_text\_capture.ts`. These send through `richMessage()`
+   * and assert the STORED body is the clean one — which is only true because
+   * the observer prefers the response's rendered `rich_message`.
+   */
+  const escaping: { body: string; wire: string }[] = [
+    { body: '⚙️ Working — editing sent_text_capture.ts', wire: '⚙️ Working — editing sent\\_text\\_capture.ts' },
+    { body: '💸 Spend today: $12.40 (~$0.50/turn)', wire: '💸 Spend today: \\$12.40 (~\\$0.50/turn)' },
+    { body: '#4576 landed', wire: '\\#4576 landed' },
+  ]
+  for (const { body, wire } of escaping) {
+    it(`stores ${JSON.stringify(body)} unescaped, though the wire carries ${JSON.stringify(wire)}`, async () => {
+      const { bot, calls } = makeBot(() => richMessageResponse(4576, body))
+      // The production call, verbatim: richMessage() escapes, then we send.
+      const result = await bot.api.sendRichMessage(CHAT, richMessage(body))
+
+      // Pin the premise: the wire really is escaped, so the request-side stamp
+      // cannot be the source of a clean stored body.
+      expect((calls[calls.length - 1].body.rich_message as { markdown: string }).markdown).toBe(wire)
+      expect(readSentText(result)).toBe(wire)
+
+      // The outcome: what lands in history.db round-trips unescaped.
+      const written: string[] = []
+      const observe = makeSystemMessageObserver({
+        insert: (a) => {
+          written.push(a.text)
+          return true
+        },
+        updateText: () => true,
+      })
+      observe(result, { chat_id: String(CHAT), verb: 'activity-summary.send' })
+      expect(written).toEqual([body])
+    })
+  }
 
   it('stamps nothing on the bodiless verbs, so the observer still ignores them', async () => {
     const { bot } = makeBot(() => true)
     const pinned = await bot.api.pinChatMessage(CHAT, 42)
     expect(pinned).toBe(true)
     expect(extractSentMessage(pinned, { chat_id: String(CHAT) })).toBeNull()
+  })
+})
+
+describe('the request-side stamp is the FALLBACK tier, never the preferred one', () => {
+  it('a response whose rich blocks render to nothing falls back to the stamped body', async () => {
+    // A media-only card: `rich_message` is present but flattens to '', and
+    // there is no `text` / `caption`. Without the stamp this row would be
+    // empty; with it, the escaped-but-readable request body is stored.
+    const { bot } = makeBot(() => ({
+      message_id: 20500,
+      date: 0,
+      chat: { id: CHAT, type: 'private' },
+      rich_message: { blocks: [{ type: 'anchor', name: 'top' }] },
+    }))
+    const result = await bot.api.sendRichMessage(CHAT, richMessage('fleet quota chart'))
+    expect(extractSentMessage(result, { chat_id: String(CHAT) })?.text).toBe('fleet quota chart')
+  })
+
+  it('the response wins whenever it has a body, even though a stamp is present', async () => {
+    const { bot } = makeBot(() => richMessageResponse(20501, 'rendered by Telegram'))
+    const result = await bot.api.sendRichMessage(CHAT, richMessage('written by the caller'))
+    expect(readSentText(result)).toBe('written by the caller')
+    expect(extractSentMessage(result, { chat_id: String(CHAT) })?.text).toBe('rendered by Telegram')
   })
 })
 
@@ -289,6 +355,96 @@ describe('regression: the pre-fix response shape', () => {
     observe({ message_id: 5, chat: { id: CHAT } }, { chat_id: String(CHAT), verb: 'activity-summary.edit' })
     expect(rows.get(5)).toBe('card v1')
   })
+
+  it('the edit throttle NEVER pins an empty row empty — the first real body always lands', () => {
+    // The dual of the rule above, and the gap that kept the #4576 symptom alive
+    // on a row the once-per-kind alarm had already stopped reporting: a bodiless
+    // FIRST observation inserts '' and starts the 20s throttle clock, so the
+    // real body arriving 3s later was dropped and the row stayed unusable.
+    const rows = new Map<number, string>()
+    let now = 1_000
+    const observe = makeSystemMessageObserver({
+      insert: (a) => {
+        rows.set(a.message_id, a.text)
+        return true
+      },
+      updateText: (a) => {
+        rows.set(a.message_id, a.text)
+        return true
+      },
+      now: () => now,
+      onEmptyText: () => {},
+    })
+    // Open the card with a response we could not read a body out of.
+    observe({ message_id: 7, chat: { id: CHAT } }, { chat_id: String(CHAT), verb: 'activity-summary.send' })
+    expect(rows.get(7)).toBe('')
+
+    // 3s later — well inside DEFAULT_EDIT_REFRESH_MS — the real body arrives.
+    now += 3_000
+    observe(
+      { message_id: 7, chat: { id: CHAT }, rich_message: { blocks: [{ text: { text: '⚙️ Working — 3 tools' } }] } },
+      { chat_id: String(CHAT), verb: 'activity-summary.edit' },
+    )
+    expect(rows.get(7)).toBe('⚙️ Working — 3 tools')
+
+    // …and the throttle resumes normally once there IS something to protect.
+    now += 3_000
+    observe(
+      { message_id: 7, chat: { id: CHAT }, rich_message: { blocks: [{ text: { text: '⚙️ Working — 9 tools' } }] } },
+      { chat_id: String(CHAT), verb: 'activity-summary.edit' },
+    )
+    expect(rows.get(7)).toBe('⚙️ Working — 3 tools')
+  })
+
+  it('the alarm dedup key does not collapse every UNTAGGED verb into one bucket', () => {
+    // `kind ?? '<untagged>'` meant the first bodiless send with no `verb`
+    // permanently silenced the alarm for every other untagged verb in the
+    // process — including a real regression.
+    const alarms: { kind: string | null; id: number }[] = []
+    const observe = makeSystemMessageObserver({
+      insert: () => true,
+      updateText: () => true,
+      onEmptyText: (i) => alarms.push({ kind: i.kind, id: i.message_id }),
+    })
+    // Two DIFFERENT untagged-kind verbs: `normalizeSendVerb` returns null for a
+    // blank verb, so both land in the no-kind lane.
+    observe({ message_id: 31, chat: { id: CHAT } }, { chat_id: String(CHAT), verb: '   ' })
+    observe({ message_id: 32, chat: { id: CHAT } }, { chat_id: String(CHAT) })
+    expect(alarms).toEqual([
+      { kind: null, id: 31 },
+      { kind: null, id: 32 },
+    ])
+  })
+
+  it('does not alarm on the verbs that are BODILESS by construction', () => {
+    // sendSticker / sendAnimation / sendVoice / forwardMessage-of-media all
+    // resolve a Message with no text by design. An alarm there is identical in
+    // format to a real regression and unactionable, so it teaches readers to
+    // ignore the alarm.
+    const alarms: string[] = []
+    const observe = makeSystemMessageObserver({
+      insert: () => true,
+      updateText: () => true,
+      onEmptyText: (i) => alarms.push(i.kind ?? '<none>'),
+    })
+    const bodiless = [
+      { message_id: 41, chat: { id: CHAT }, sticker: { file_id: 's', file_unique_id: 'u' } },
+      { message_id: 42, chat: { id: CHAT }, animation: { file_id: 'a', file_unique_id: 'u' } },
+      { message_id: 43, chat: { id: CHAT }, voice: { file_id: 'v', file_unique_id: 'u', duration: 2 } },
+      { message_id: 44, chat: { id: CHAT }, photo: [{ file_id: 'p', file_unique_id: 'u' }] },
+      { message_id: 45, chat: { id: CHAT }, checklist: { title: 'rollout', tasks: [] } },
+    ]
+    for (const b of bodiless) observe(b, { chat_id: String(CHAT), verb: 'sendSticker' })
+    expect(alarms).toEqual([])
+
+    // A regressed CARD is a rich_message response that rendered to nothing —
+    // it carries none of those keys, so it still alarms.
+    observe(
+      { message_id: 46, chat: { id: CHAT }, rich_message: { blocks: [] } },
+      { chat_id: String(CHAT), verb: 'activity-summary.send' },
+    )
+    expect(alarms).toEqual(['activity-summary'])
+  })
 })
 
 /**
@@ -333,7 +489,12 @@ describe('boot wiring: installSentTextCapture is on the production Bot', () => {
     expect(count).toBe(1)
   })
 
-  it('installs it AFTER the markdown guard, so it captures the pre-escape body', () => {
+  it('installs it AFTER the markdown guard, so it composes outside it', () => {
+    // Note what this does NOT claim: composing outside the guard TRANSFORMER
+    // does not yield a pre-escape body on the dominant card path, because
+    // `richMessage()` escapes in the caller (see the escaping cases above). It
+    // only matters for the call sites that build a raw `{ markdown }` and skip
+    // `richMessage()`. Kept as an ordering pin, not as a fidelity claim.
     expect(src.indexOf('installRichMarkdownGuard(bot)')).toBeLessThan(
       src.indexOf('installSentTextCapture(bot)'),
     )

--- a/telegram-plugin/tests/sent-text-capture.test.ts
+++ b/telegram-plugin/tests/sent-text-capture.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Card-body capture — wire-level outcome tests (#4576 follow-up).
+ *
+ * The defect being pinned: #4576 landed the card-history lane, and every
+ * `role='system'` row it wrote across the whole fleet had `length(text) = 0`.
+ * The lane's own tests passed because their fixtures hand-built a Telegram
+ * `Message` with a `text` field — a shape no card send has EVER produced. Every
+ * gateway card goes out via Bot API 10.1 `sendRichMessage`, whose response is a
+ * `Message.RichMessageMessage`: body under `rich_message.blocks`, no `text`, no
+ * `caption`. `extractSentMessage`'s `msg.text ?? msg.caption ?? ''` therefore
+ * resolved `''` 100% of the time, and a quote-reply to a card gave the agent the
+ * card's KIND but never its BODY.
+ *
+ * So these tests deliberately do NOT hand-build a response. They drive a REAL
+ * grammy `Bot` with the production transformer stack and a stubbed transport
+ * that answers with the REAL rich-message response shape, then assert the body
+ * survives to the history writer. A test that builds its own `{ text }` fixture
+ * cannot fail on this bug and is not a test of it.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import ts from 'typescript'
+import { Bot } from 'grammy'
+import { installTgPostLogger, installRichMarkdownGuard } from '../shared/bot-runtime.js'
+import {
+  installSentTextCapture,
+  outboundPayloadText,
+  readSentText,
+  attachSentText,
+} from '../shared/sent-text-capture.js'
+import { richMessage } from '../rich-send.js'
+import { makeSystemMessageObserver, extractSentMessage } from '../gateway/system-message-observer.js'
+
+const CHAT = 5550001
+
+/**
+ * The response Telegram actually returns for `sendRichMessage` — the body lives
+ * in `rich_message.blocks`; `text` and `caption` are ABSENT. Verified against
+ * `@grammyjs/types` 4.0.0 `message.d.ts:98` (`RichMessageMessage = CommonMessage
+ * & MsgWith<"rich_message">`) and `:184` (`rich_message?: RichMessage`).
+ */
+function richMessageResponse(messageId: number, rendered: string) {
+  return {
+    message_id: messageId,
+    date: 0,
+    chat: { id: CHAT, type: 'private' },
+    rich_message: { blocks: [{ type: 'paragraph', text: { text: rendered } }] },
+  }
+}
+
+/** A plain `sendMessage` response, for the verbs that don't go rich. */
+function plainMessageResponse(messageId: number, text: string) {
+  return { message_id: messageId, date: 0, chat: { id: CHAT, type: 'private' }, text }
+}
+
+/**
+ * A real grammy Bot wired with the PRODUCTION transformer stack in the
+ * production order (logger → fmt guard → text capture), transport stubbed. The
+ * stub answers each method from `respond`, so a test can return the true
+ * rich-message shape rather than inventing one.
+ */
+function makeBot(respond: (method: string, body: Record<string, unknown>) => unknown) {
+  const calls: { method: string; body: Record<string, unknown> }[] = []
+  const fakeFetch = (async (url: unknown, init?: { body?: unknown }) => {
+    const method = String(url).split('/').pop() ?? ''
+    const body =
+      typeof init?.body === 'string' ? (JSON.parse(init.body) as Record<string, unknown>) : {}
+    calls.push({ method, body })
+    const result = respond(method, body)
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, result }),
+    } as unknown as Response
+  }) as unknown as typeof fetch
+
+  const bot = new Bot('123456:TEST_TOKEN', {
+    botInfo: {
+      id: 123456,
+      is_bot: true,
+      first_name: 'Test',
+      username: 'test_bot',
+      can_join_groups: false,
+      can_read_all_group_messages: false,
+      supports_inline_queries: false,
+      can_connect_to_business: false,
+      has_main_web_app: false,
+    },
+    client: { fetch: fakeFetch },
+  })
+  installTgPostLogger(bot)
+  installRichMarkdownGuard(bot)
+  installSentTextCapture(bot)
+  return { bot, calls }
+}
+
+describe('outboundPayloadText — the body a request is about to POST', () => {
+  it('reads the rich-message markdown (the shape every card send uses)', () => {
+    expect(outboundPayloadText({ chat_id: 1, rich_message: { markdown: '**Working**' } })).toBe(
+      '**Working**',
+    )
+  })
+
+  it('reads html and flattens blocks for rich payloads that are not markdown', () => {
+    expect(outboundPayloadText({ rich_message: { html: '<b>hi</b>' } })).toBe('<b>hi</b>')
+    expect(
+      outboundPayloadText({
+        rich_message: { blocks: [{ text: 'top' }, { blocks: [{ text: 'nested' }] }] },
+      }),
+    ).toBe('top\nnested')
+  })
+
+  it('reads plain text and media captions', () => {
+    expect(outboundPayloadText({ text: 'restarting…' })).toBe('restarting…')
+    expect(outboundPayloadText({ caption: 'chart for July' })).toBe('chart for July')
+  })
+
+  it('returns null for the bodiless verbs (pin/delete/reaction/getUpdates)', () => {
+    expect(outboundPayloadText({ chat_id: 1, message_id: 2 })).toBeNull()
+    expect(outboundPayloadText(undefined)).toBeNull()
+    expect(outboundPayloadText('nonsense')).toBeNull()
+  })
+})
+
+describe('attachSentText / readSentText', () => {
+  it('stamps the Message inside an ok envelope, invisibly to every normal reader', () => {
+    const env = { ok: true, result: { message_id: 7, chat: { id: CHAT } } }
+    attachSentText(env, 'the card body')
+    expect(readSentText(env.result)).toBe('the card body')
+    // Invisible: no new enumerable key, JSON round-trip unchanged.
+    expect(Object.keys(env.result)).toEqual(['message_id', 'chat'])
+    expect(JSON.parse(JSON.stringify(env.result))).toEqual({ message_id: 7, chat: { id: CHAT } })
+  })
+
+  it('no-ops on the non-Message results a transformer also sees', () => {
+    expect(() => attachSentText({ ok: true, result: true }, 'x')).not.toThrow()
+    expect(() => attachSentText({ ok: false, error_code: 400 }, 'x')).not.toThrow()
+    expect(() => attachSentText(undefined, 'x')).not.toThrow()
+    expect(readSentText(true)).toBeNull()
+    expect(readSentText({ message_id: 1 })).toBeNull()
+  })
+})
+
+describe('the card body survives the real send path, for every verb a card uses', () => {
+  // Each row is a production card send verb reduced to the API call it makes.
+  // `expected` is the body the history row MUST end up carrying.
+  const cases: {
+    name: string
+    body: string
+    send: (bot: Bot) => Promise<unknown>
+    respond: (method: string) => unknown
+  }[] = [
+    {
+      name: 'activity-summary.send / boot-card / issues-card / worker-feed (sendRichMessage)',
+      body: '⚙️ Working — reading history.ts, 3 tools',
+      send: (bot) =>
+        bot.api.sendRichMessage(CHAT, richMessage('⚙️ Working — reading history.ts, 3 tools')),
+      respond: () => richMessageResponse(20395, '⚙️ Working — reading history.ts, 3 tools'),
+    },
+    {
+      name: 'activity-summary.edit / rollout-status-edit (rich editMessageText)',
+      body: '⚙️ Working — 11 tools, editing gateway.ts',
+      send: (bot) =>
+        bot.api.editMessageText(CHAT, 20395, richMessage('⚙️ Working — 11 tools, editing gateway.ts')),
+      respond: () => richMessageResponse(20395, '⚙️ Working — 11 tools, editing gateway.ts'),
+    },
+    {
+      name: 'permission_request (sendRichMessage with an inline keyboard)',
+      body: '**Approve** `docker restart switchroom-clerk`?',
+      send: (bot) =>
+        bot.api.sendRichMessage(CHAT, richMessage('**Approve** `docker restart switchroom-clerk`?'), {
+          reply_markup: { inline_keyboard: [[{ text: 'Approve', callback_data: 'ok' }]] },
+        }),
+      respond: () => richMessageResponse(20406, 'Approve docker restart switchroom-clerk?'),
+    },
+    {
+      name: 'privacy-reset-alert / restart notices (plain sendMessage)',
+      body: 'Restarting — back in a moment.',
+      send: (bot) => bot.api.sendMessage(CHAT, 'Restarting — back in a moment.'),
+      respond: () => plainMessageResponse(20410, 'Restarting — back in a moment.'),
+    },
+    {
+      name: 'a media card (sendPhoto caption)',
+      body: 'fleet quota, last 24h',
+      send: (bot) => bot.api.sendPhoto(CHAT, 'file-id', { caption: 'fleet quota, last 24h' }),
+      respond: () => ({
+        message_id: 20411,
+        date: 0,
+        chat: { id: CHAT, type: 'private' },
+        photo: [{ file_id: 'file-id', file_unique_id: 'u', width: 1, height: 1 }],
+        caption: 'fleet quota, last 24h',
+      }),
+    },
+  ]
+
+  for (const c of cases) {
+    it(`${c.name} → the observer records a NON-EMPTY body`, async () => {
+      const { bot } = makeBot(c.respond)
+      const result = await c.send(bot)
+
+      // The outcome that #4576 got wrong: the extractor yields the real body.
+      const extracted = extractSentMessage(result, { chat_id: String(CHAT) })
+      expect(extracted).not.toBeNull()
+      expect(extracted!.text).toBe(c.body)
+      expect(extracted!.text.length).toBeGreaterThan(0)
+
+      // …and it reaches the history writer that way.
+      const written: { text: string; kind: string | null }[] = []
+      const observe = makeSystemMessageObserver({
+        insert: (a) => {
+          written.push({ text: a.text, kind: a.kind })
+          return true
+        },
+        updateText: () => true,
+      })
+      observe(result, { chat_id: String(CHAT), verb: 'activity-summary.send' })
+      expect(written).toHaveLength(1)
+      expect(written[0].text).toBe(c.body)
+    })
+  }
+
+  it('captures the body the CALLER wrote, not the wire-escaped form', async () => {
+    // The fmt guard escapes `#` on the wire; the stored antecedent should read
+    // as the operator saw it. Capture composes outside the guard for this reason.
+    const { bot, calls } = makeBot(() => richMessageResponse(1, '#4576 landed'))
+    const result = await bot.api.sendRichMessage(CHAT, { markdown: '#4576 landed' })
+    expect((calls[calls.length - 1].body.rich_message as { markdown: string }).markdown).toBe(
+      '\\#4576 landed',
+    )
+    expect(readSentText(result)).toBe('#4576 landed')
+  })
+
+  it('stamps nothing on the bodiless verbs, so the observer still ignores them', async () => {
+    const { bot } = makeBot(() => true)
+    const pinned = await bot.api.pinChatMessage(CHAT, 42)
+    expect(pinned).toBe(true)
+    expect(extractSentMessage(pinned, { chat_id: String(CHAT) })).toBeNull()
+  })
+})
+
+describe('regression: the pre-fix response shape', () => {
+  it('a rich-message response with NO capture stamp still yields a body, not ""', () => {
+    // Belt-and-braces layer 2: a Message that never transited a capture-installed
+    // bot (a second Bot instance, a replayed response) falls back to flattening
+    // the echoed `rich_message` rather than storing an empty row.
+    const raw = richMessageResponse(20395, '⚙️ Working — 3 tools')
+    expect(readSentText(raw)).toBeNull()
+    expect(extractSentMessage(raw, { chat_id: String(CHAT) })?.text).toBe('⚙️ Working — 3 tools')
+  })
+
+  it('an unrecognised bodiless shape fires the empty-text alarm exactly once per kind', () => {
+    const alarms: { kind: string | null }[] = []
+    const observe = makeSystemMessageObserver({
+      insert: () => true,
+      updateText: () => true,
+      onEmptyText: (i) => alarms.push({ kind: i.kind }),
+    })
+    for (const id of [1, 2, 3]) {
+      observe({ message_id: id, chat: { id: CHAT } }, { chat_id: String(CHAT), verb: 'mystery-card' })
+    }
+    observe({ message_id: 9, chat: { id: CHAT } }, { chat_id: String(CHAT), verb: 'other-card' })
+    expect(alarms).toEqual([{ kind: 'mystery-card' }, { kind: 'other-card' }])
+  })
+
+  it('an empty refresh never blanks a body that was already stored', () => {
+    const rows = new Map<number, string>()
+    let now = 1_000
+    const observe = makeSystemMessageObserver({
+      insert: (a) => {
+        rows.set(a.message_id, a.text)
+        return true
+      },
+      updateText: (a) => {
+        rows.set(a.message_id, a.text)
+        return true
+      },
+      now: () => now,
+    })
+    observe(
+      { message_id: 5, chat: { id: CHAT }, rich_message: { blocks: [{ text: { text: 'card v1' } }] } },
+      { chat_id: String(CHAT), verb: 'activity-summary.send' },
+    )
+    expect(rows.get(5)).toBe('card v1')
+
+    now += 10 * 60_000
+    // A later edit whose body did not reach us for any reason.
+    observe({ message_id: 5, chat: { id: CHAT } }, { chat_id: String(CHAT), verb: 'activity-summary.edit' })
+    expect(rows.get(5)).toBe('card v1')
+  })
+})
+
+/**
+ * The capture only works if it is actually installed. grammY's transformers are
+ * anonymous fns with nothing to grip at runtime, so the wiring is pinned at the
+ * source level — the same approach `format-guard-pins.test.ts` uses for the
+ * markdown guard. Without this, a refactor could silently drop the seam and
+ * every card row would go back to being empty with no test turning red.
+ */
+describe('boot wiring: installSentTextCapture is on the production Bot', () => {
+  const gatewayPath = resolve(
+    dirname(fileURLToPath(import.meta.url)), '..', 'gateway', 'gateway.ts',
+  )
+  const src = readFileSync(gatewayPath, 'utf8')
+  const sourceFile = ts.createSourceFile(gatewayPath, src, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+
+  it("imports installSentTextCapture from '../shared/sent-text-capture.js'", () => {
+    expect(src).toMatch(
+      /import\s*\{[^}]*\binstallSentTextCapture\b[^}]*\}\s*from\s*'\.\.\/shared\/sent-text-capture\.js'/,
+    )
+  })
+
+  it('calls installSentTextCapture(bot) exactly once inside initGatewayBot()', () => {
+    const fn = sourceFile.statements.find(
+      (s): s is ts.FunctionDeclaration =>
+        ts.isFunctionDeclaration(s) && s.name?.text === 'initGatewayBot',
+    )
+    expect(fn?.body).toBeDefined()
+    let count = 0
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === 'installSentTextCapture'
+      ) {
+        count++
+        expect(node.arguments[0]?.getText(sourceFile)).toBe('bot')
+      }
+      ts.forEachChild(node, visit)
+    }
+    visit(fn!.body!)
+    expect(count).toBe(1)
+  })
+
+  it('installs it AFTER the markdown guard, so it captures the pre-escape body', () => {
+    expect(src.indexOf('installRichMarkdownGuard(bot)')).toBeLessThan(
+      src.indexOf('installSentTextCapture(bot)'),
+    )
+  })
+
+  it('gets the empty-body alarm WITHOUT having to wire it — it is the default', () => {
+    // gateway.ts constructs the observer with insert/updateText only (it is
+    // under the anti-inflation line ratchet, switchroom#2996). So the alarm
+    // that makes a recurrence loud instead of silent-for-a-release, as #4576
+    // was, has to be the observer's DEFAULT — opting out must be the explicit
+    // act. Asserted as behaviour, not as a source pattern.
+    const written: string[] = []
+    const stderrWrite = process.stderr.write.bind(process.stderr)
+    ;(process.stderr as unknown as { write: unknown }).write = (chunk: unknown) => {
+      written.push(String(chunk))
+      return true
+    }
+    try {
+      const observe = makeSystemMessageObserver({
+        insert: () => true,
+        updateText: () => true,
+      })
+      observe({ message_id: 991, chat: { id: 5550001 } }, { chat_id: '5550001', verb: 'boot-card' })
+    } finally {
+      ;(process.stderr as unknown as { write: unknown }).write = stderrWrite
+    }
+    expect(written.join('')).toContain('card-history text capture MISSED kind=boot-card')
+  })
+})

--- a/telegram-plugin/tests/system-message-observer.test.ts
+++ b/telegram-plugin/tests/system-message-observer.test.ts
@@ -27,8 +27,17 @@ import {
 
 const CHAT = '5550001'
 
-/** A Telegram `Message` response as the Bot API returns it from sendMessage /
- *  editMessageText. */
+/**
+ * A Telegram `Message` response as the Bot API returns it from a PLAIN
+ * `sendMessage` / `editMessageText`.
+ *
+ * These cases exercise the observer's BOOKKEEPING (one row per card, edit
+ * throttling, foreign-lane demotion), for which the body is incidental. Do NOT
+ * assert card-body behaviour through this fixture: a card never goes out as a
+ * plain message, and hand-building a `text` field is exactly what let #4576
+ * ship an empty body on 100% of the fleet's card rows. Body coverage lives in
+ * `sent-text-capture.test.ts` (real grammy stack) and `card-history-lane.test.ts`.
+ */
 function sentMessage(messageId: number, text: string, threadId?: number) {
   return {
     message_id: messageId,


### PR DESCRIPTION
## Summary

#4576 (shipped in **v0.21.0**) landed the card-history lane: every card the gateway posts gets a `role='system'` row in `telegram/history.db` so a quote-reply to it resolves. Ids, chat, thread and `kind` are all correct — but **`length(text)` is 0 on 100% of the `system` rows on every agent in the fleet** (12 agents with rows, zero counter-examples), so `resolveReplyToFromBuffer` never sets `reply_to_text`. The agent learns a card was quoted and its kind, but not what it said. The feature is half-landed.

This PR makes the stored body real, and makes the failure mode loud if it ever recurs.

Job spec: `reference/jobs/know-what-my-agent-is-doing.md` — a card the user can quote-reply to is only useful if the agent can read what the card said.

## Why this shape

**Root cause** (confirmed, matched the hypothesis): cards go out via Bot API 10.1 `sendRichMessage`, whose response is `Message.RichMessageMessage` — `rich_message: { blocks }`, with **no `text` and no `caption`** (`@grammyjs/types` 3.28.0 `message.d.ts:94,180`; Bot API: `RichMessage.blocks` = "Content of the message"). `system-message-observer.ts`'s `extractSentMessage` read `msg.text ?? msg.caption ?? ''` — one body field, on a shape that does not have it — and therefore stored `''`. The write layer (`history.ts` `recordSystemOutbound` / `updateSystemOutboundText`) was faithful all along and is unchanged.

**Fix: read the body off the RESPONSE, in a precedence chain that covers every verb.**

```
rich_message (rendered blocks) → text → caption → request-side stamp → ''
```

The response is Telegram's own rendered view of the message: block text with the wire escapes already resolved. That makes it both the most faithful source and the one that covers every verb the gateway writes a history row for — `sendRichMessage` and rich `editMessageText` supply `rich_message`, plain `sendMessage` supplies `text`, `sendPhoto`/`sendDocument` supply `caption`.

**The request-side stamp is the last tier, not the first.** `installSentTextCapture` (`telegram-plugin/shared/sent-text-capture.ts`) is a grammY transformer on `bot.api.config` — the same universal seam `installRichMarkdownGuard` uses — that reads the outbound payload body and stamps it on the resolved `Message` under a `Symbol.for` key, `enumerable: false` so nothing that reads a Message today (`JSON.stringify`, `Object.keys`, spreads) can observe it. Payload and response are in scope in one call, so the pairing needs no id→text map, no eviction, no race.

It is deliberately the *fallback* because **the body it captures is not the body as written**. The dominant card path is `sendRichMessage(chat, richMessage(body))`, and `richMessage()` applies `guardAccidentalFormatting` in the **caller** (`rich-send.ts:100`), upstream of every transformer seam. So what the capture sees on that path is already wire-escaped: `sent_text_capture.ts` arrives as `sent\_text\_capture.ts`, `$12.40` as `\$12.40`. Escaped-but-present beats empty, which is why the tier exists — but it must never win over a response that resolved those escapes. (An earlier revision of this PR claimed the stamp captured a *pre-escape* body and gave it precedence; that rationale was false on the dominant path and has been removed from the code, the docblocks and this description. Install order after the markdown guard only avoids the *transformer's* escaping pass, which matters for the handful of call sites that build a raw `{ markdown }` directly.)

The stamp is kept because it is the only tier that can serve a rich send whose blocks flatten to nothing (a media-only card), and because #4576 was itself a failure of trusting an unobserved response shape. That fallback path is pinned by a test.

**Loudness without regressing #4571:** rejecting an empty body at the write layer was considered and rejected — it would drop the row and make the id unresolvable again, which is the exact bug #4571 fixed. Instead the row is still written, and the observer fires a once-per-bucket-per-process stderr alarm (bucket = `kind ?? verb ?? '<untagged>'`, so untagged verbs do not collapse into one). Verbs whose response is bodiless *by construction* — sticker, animation, voice, video note, dice, poll, forwarded media, … — are exempt, keyed on response shape rather than verb because `forwardMessage` passes no verb at all. The alarm is the observer's **default** (`defaultEmptyCardTextWarning`), not something `gateway.ts` wires, so opting out is the explicit act. An empty body also never overwrites an already-stored one, and the per-message edit-refresh throttle is **bypassed while the stored body is still empty**, so a bodiless first observation can no longer swallow the first real body inside the 20s window.

## Test plan

The pre-existing suites all passed on this bug because their fixtures hand-built `{ text }`. New coverage drives a **real grammy `Bot`** with the production transformer order, a stub returning the true `sendRichMessage` shape, and — critically — sends that go **through the real `richMessage()`**, never around it. A test that hand-builds its own payload cannot fail on the escaping bug.

- `telegram-plugin/tests/sent-text-capture.test.ts` (new, vitest, 27 tests) — a table of production send shapes (rich send, rich edit, permission card with inline keyboard, plain `sendMessage`, `sendPhoto` caption) each asserting the extracted **and observed-insert** text equals the body; three fidelity rows (`sent_text_capture.ts`, `$12.40`, `#4576`) asserting the wire form really is escaped, that the stamp returns that escaped form, and that the stored body is nonetheless clean; the stamp winning only as a fallback (anchor-only rich blocks) and losing whenever the response has a body; the throttle never pinning a row empty; the alarm bucket not collapsing untagged verbs; no alarm on bodiless-by-construction verbs; AST/order pins that the transformer install cannot be silently dropped from `initGatewayBot()`.
- `telegram-plugin/tests/card-history-lane.test.ts` (extended, bun + real `bun:sqlite`) — asserts the response carries **no** `text`, yet the persisted row is non-empty and equals the body, and that a quote-reply to it resolves `replyToText` / `meta.reply_to_text` end-to-end. Repeated across every card verb seen on the live fleet (`boot-card`, `activity-summary`, `worker-feed`, `issues-card`, `rollout-status`, `quota-watch.fleet-roll`, `permission_request`) with `expect(cards.filter(r => r.text.length === 0)).toEqual([])`.

Mutation-checked (a test that would not fail on the bug it guards is not a test) — each mutation applied to `system-message-observer.ts` in isolation, against `sent-text-capture.test.ts`:

| mutation | result |
|---|---|
| restore stamp-first precedence (the escaped-body bug) | **5 failed** / 22 passed |
| remove the `rich_message` tier (the original #4576 bug) | **8 failed** / 19 passed |
| remove the stamp fallback tier | **1 failed** / 26 passed |
| drop the `storedLen > 0` throttle bypass | **1 failed** / 26 passed |
| revert the alarm bucket to `kind ?? '<untagged>'` | **1 failed** / 26 passed |
| drop the `isLegitimatelyBodiless` alarm exemption | **1 failed** / 26 passed |

Local: `tsc --noEmit` clean; `sent-text-capture.test.ts` 27/27; observer + edit-flood-fuse + rich-markdown-guard 32/32; `bun test card-history-lane.test.ts` 11 pass / 0 fail; the four bun history suites 96 pass / 0 fail; `npm run lint` fully green (including `check-gateway-line-ratchet`, `check-bot-api-wrapping`, `check-changelog-entry`, `check-agent-attribution-trailers`).

## Risk

Low, and bounded to the card lane.

- The transformer runs on every outbound call but only reads the payload and stamps a non-enumerable symbol; all of it is in `try`/`catch` so a stamping failure can never break a send. Bodiless verbs and non-object results (`true` from pins/deletes, arrays from `getUpdates`) are rejected before stamping.
- No migration, no schema change, no behaviour change for rows already written — existing empty rows stay empty (they are historical; nothing re-derives them). New cards carry their body from the first send after deploy.
- Existing rows' `kind`/id resolution is untouched, so the #4571 guarantee is preserved.

## Follow-ups

Three low-severity items from review are filed as **#4584** (rich-block flattening for future `{ blocks }` adopters; strengthening the install-order pin from a source `indexOf` to an AST check; native `sendChecklist` still storing an empty row — business-account-only, off-fleet, now alarm-exempt).

Refs #4576, #4584, v0.21.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
