### PR TITLE
docs(voice): fix the last stale 12.8.1 base reference in the TTS block

### DIFF
--- a/docker/Dockerfile.voice
+++ b/docker/Dockerfile.voice
@@ -89,7 +89,7 @@ RUN apt-get update \
 # CUDAExecutionProvider (server.py builds the InferenceSession with an
 # explicit CUDA->CPU provider list + graceful fallback). onnxruntime-gpu 1.20.x
 # is built for CUDA 12.x + cuDNN 9, matching this image's
-# nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04 base — no extra CUDA libs are
+# nvidia/cuda:12.9.2-cudnn-runtime-ubuntu24.04 base — no extra CUDA libs are
 # needed (STT/CTranslate2 already proves CUDA 12 + cuDNN 9 runtime are present).
 # NB: keep the base on CUDA 12 / cuDNN 9 — onnxruntime-gpu (and ctranslate2 for
 # STT) have no CUDA-13 wheels, so a CUDA-13 base would silently drop TTS+STT to


### PR DESCRIPTION
Follow-up to #4578.

#4578 bumped the voice base image to `nvidia/cuda:12.9.2-cudnn-runtime-ubuntu24.04` and its commit 727702fc synced the comment block directly above the `FROM` (lines 24/30) — but missed the onnxruntime-gpu note further down, which still named `nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04` as "this image's base" while the `FROM` on line 40 is 12.9.2.

Verified against `origin/main` at 6a0739e5 (the merge commit for #4578):
- `docker/Dockerfile.voice:40` — `FROM nvidia/cuda:12.9.2-cudnn-runtime-ubuntu24.04@sha256:070f8f26...`
- `docker/Dockerfile.voice:92` — comment said `12.8.1` (fixed here)

A repo-wide grep for `12.8.1-cudnn` / `cuda:12.8` / `CUDA 12.8` now returns only `CHANGELOG.md:1867`, which is a historical entry for #4249 ("upgraded to CUDA-12.8") and is correctly left alone.

Comment-only; no build input changes.

[skip changelog]