### PR TITLE
chore: release v0.21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+## v0.21.2 — Claude Code CLI 2.1.226, and an explicit refusal of its new cross-session inbox
+
 ### Documentation
 
 - **The #1978 thinking-effort guard no longer restates the claude-CLI pin.**
@@ -81,7 +83,6 @@ now an anomaly worth investigating, not the norm.
 
 ### Bug fixes
 
-- **telegram: store the card body a quote-reply needs, not an empty string**
 - **rollout: an agent-initiated roll can now heal a stale host CLI instead of
   dead-ending on the refusal.** The #4571 host-CLI-first gate refused with
   `preflight-host-cli-stale` and named `switchroom update --pin vX.Y.Z` — a
@@ -98,6 +99,16 @@ now an anomaly worth investigating, not the norm.
   what the real run would do instead. An `npm i -g` install still refuses, and
   the refusal now says plainly that an **operator** must run the command on the
   host. (#4585)
+
+## v0.21.1 — quote-replying to a card now carries the card body
+
+<!-- Filed retroactively: v0.21.1 was tagged without a consolidation commit,
+     so this entry was still sitting under `## Unreleased`. -->
+
+### Bug fixes
+
+- **telegram: store the card body a quote-reply needs, not an empty string**
+  (#4583)
 
 ## v0.21.0 — rollout now gates on the host CLI, plus telegram card persistence, gateway state-dir ownership, and hindsight `/metrics` cardinality fixes
 


### PR DESCRIPTION
## Summary

CHANGELOG consolidation for **v0.21.2**, per `skills/switchroom-release/SKILL.md` step 1. CHANGELOG-only — **no `package.json` bump** (the tag is the version source of truth; the `version` field is a deliberate placeholder).

- `## Unreleased` → `## v0.21.2 — Claude Code CLI 2.1.226, and an explicit refusal of its new cross-session inbox`
- fresh empty `## Unreleased` block re-seeded with the convention comment, so `scripts/check-changelog-entry.mjs` keeps enforcing staging for the next cycle

## Contents of v0.21.2

- **#4589** — Claude Code CLI 2.1.223 → 2.1.226 across all three lockstep pin sites, plus `"crossSessionInbound":"refuse"` in `docker/Dockerfile.base`'s baked managed settings. 2.1.224 added a UDS cross-session messaging ingress that queues a peer message as a user-role turn; with the setting unset, the resolver's `bypassPermissions` branch accepts a `selfSent` message outright, and every switchroom agent runs bypassed. Explicit refusal short-circuits that branch.
- **#4586** — `fix(rollout)`: an agent-initiated roll heals a stale `static-binary` host CLI instead of dead-ending on the `preflight-host-cli-stale` refusal.
- **#4590** — `docs`: the #1978 thinking-effort guard stops restating the claude-CLI pin.
- **#4578** / **#4588** — voice image CUDA base 12.8.1 → 12.9.2, and the last stale 12.8.1 comment reference.

## One correction beyond a plain rename

`v0.21.1` was tagged **without** a consolidation commit, so its entry (#4583, `telegram: store the card body a quote-reply needs`) was still sitting under `## Unreleased` and there was no `## v0.21.1` heading at all. A bare rename would have misattributed a shipped v0.21.1 fix to v0.21.2. This PR files it under a retroactive `## v0.21.1` heading instead. No code impact.

## Verification

- `node scripts/check-changelog-entry.mjs` → `OK — no shippable code changed`
- `node scripts/check-agent-attribution-trailers.mjs` → `OK — 1 commit(s), 1 machine-authored and attributed`
- diff is `CHANGELOG.md` only, +12/-1

[skip changelog]

Switchroom-Agent: overlord
Switchroom-Model: claude-opus-5