### PR TITLE
chore: release v0.21.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+## v0.21.3 — external spend reads litellm's pre-aggregated daily table; supersedes the never-published v0.21.2
+
+<!-- Why `## v0.21.2` below is still standing rather than folded into this
+     section: v0.21.2 WAS tagged, and its `:v0.21.2` images were built and
+     pushed to ghcr, but its `release` run failed at the `images-gate` leg on
+     a transient ghcr.io login timeout — so the GitHub Release stayed a draft
+     and npm never received it. The tag and the images are real and immutable,
+     so this file stays a truthful per-tag record and that section is left
+     alone. Consequence: npm goes 0.21.1 -> 0.21.3, this section holds only
+     what landed AFTER v0.21.2 was tagged, and the v0.21.3 GitHub Release
+     notes carry the FULL user-visible delta since v0.21.1 — which is what an
+     operator upgrading from 0.21.1 actually receives. -->
+
 ### Fixes
 
 - **litellm: read external spend from a pre-aggregated daily table.** The


### PR DESCRIPTION
CHANGELOG-only consolidation for **v0.21.3**. No code changes; `package.json` untouched (stale-placeholder discipline — the git tag is the version source of truth via `scripts/build.mjs:resolveVersion()`).

## What this does

- Renames `## Unreleased` → `## v0.21.3 — external spend reads litellm's pre-aggregated daily table; supersedes the never-published v0.21.2`.
- Re-seeds a fresh empty `## Unreleased` staging block so `scripts/check-changelog-entry.mjs` keeps enforcing per-PR entries.

## The v0.21.2 heading is deliberately left standing

`v0.21.2` was tagged (`b35e45117465b97aef870acbc9f9f42c4a6c459c`) and its six `:v0.21.2` ghcr images were built and pushed, but its `release` run (31367449047) failed at `images-gate` on a transient ghcr.io login timeout in `merge-dependents (hostd)`. So the GitHub Release stayed a **draft** and npm never received it — npm `latest` is still 0.21.1.

The tag and the images are real and immutable, so folding `## v0.21.2` forward into `## v0.21.3` would leave the published `:v0.21.2` images with no changelog section describing them. It stays put, with an HTML comment recording why. Consequences, all intentional:

- npm goes **0.21.1 → 0.21.3**.
- The `## v0.21.3` section holds only what landed *after* the v0.21.2 tag (#4591).
- The v0.21.3 **GitHub Release notes** carry the full user-visible delta since v0.21.1 — the CLI 2.1.223→2.1.226 bump with `crossSessionInbound: "refuse"` (#4589), the rollout stale-host-CLI heal (#4586), the pin-restatement docs cleanup (#4590), the voice CUDA 12.9.2 base bump (#4578, #4588), and #4591 — because that is what an operator upgrading from 0.21.1 actually receives.

[skip changelog]