### PR TITLE
fix(rollout): probe a candidate CLI with --version, not `version`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,5 +79,8 @@ switchroom-checksums.txt
 # Scratch dir for tests/ci-buildx-warm-pull.test.ts when /tmp is noexec.
 .buildx-warm-test-*/
 
+# Scratch dir for src/cli/self-update-io-probe.test.ts when /tmp is noexec.
+.probe-argv-test-*/
+
 # Locally built release asset payload (#4163).
 switchroom-assets.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+### Fixes
+
+- **rollout: the host-CLI self-heal no longer fails its own verification on a
+  perfectly good release binary.** The self-update proof step ran the
+  downloaded artifact's `version` SUBCOMMAND, which loads
+  `~/.switchroom/switchroom.yaml` and enumerates agent containers — so it
+  exits 1 wherever there is no fleet config. The heal helper container
+  deliberately mounts the install prefix and nothing else, so the probe could
+  never pass there: a `pin: v0.21.3` roll refused at
+  `preflight-host-cli-stale` reporting "the downloaded v0.21.3 binary did not
+  run cleanly on this host" for an artifact whose sha256 matched and which
+  installed by hand minutes later. The probe now runs `--version`, which execs
+  the whole bundled runtime (the only thing the check proves) and touches no
+  config, docker socket or network. The check is never skipped; its verdict is
+  now three-way, so "we could not EXECUTE it here" (a `noexec` staging mount, a
+  lost +x bit, a foreign arch) is reported as a location fault instead of
+  mis-accusing the artifact and sending operators to re-download a good file.
+  (#4586)
+
 <!--
 Staging area for the NEXT release. Every PR that changes shippable code adds
 its entry HERE, under this header, in the SAME PR — grouped under `###`

--- a/src/cli/host-cli-upgrade.test.ts
+++ b/src/cli/host-cli-upgrade.test.ts
@@ -77,7 +77,7 @@ function makeIo(overrides: {
       asRoot(dest);
     },
     sha256File: () => GOOD_SHA,
-    probeBinaryVersion: () => "0.22.0",
+    probeBinary: () => ({ ok: true, version: "0.22.0" }),
     mkdirp: (d) => {
       dirs.add(d);
       asRoot(d);
@@ -278,11 +278,11 @@ describe("runHostCliUpgrade — the swap", () => {
     let calls = 0;
     const { io, files } = makeIo({
       self: {
-        probeBinaryVersion: () => {
+        probeBinary: () => {
           calls += 1;
           // First call proves the staged candidate inside performSelfUpdate;
           // the second is host-cli-upgrade re-probing the installed path.
-          return calls === 1 ? "0.22.0" : "0.21.0";
+          return { ok: true, version: calls === 1 ? "0.22.0" : "0.21.0" };
         },
       },
     });

--- a/src/cli/host-cli-upgrade.ts
+++ b/src/cli/host-cli-upgrade.ts
@@ -44,6 +44,7 @@ import { lchownSync, lstatSync, readdirSync, statSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import type { Command } from "commander";
 import {
+  describeBinaryProbeFailure,
   payloadVersionDir,
   performSelfUpdate,
   releaseAssetName,
@@ -330,12 +331,23 @@ export async function runHostCliUpgrade(
 
     // Prove the file that is NOW on the host's $PATH answers with the target —
     // `performSelfUpdate` proves the staged candidate, this proves the swap.
-    const proven = io.selfUpdate.probeBinaryVersion(binary);
-    if (!proven || `v${proven.replace(/^v/, "")}` !== pin) {
+    const proven = io.selfUpdate.probeBinary(binary);
+    if (!proven.ok) {
       return {
         ok: false,
         error:
-          `swapped ${binary} but it reports ${proven ?? "<nothing>"}, not ${pin} — ` +
+          `swapped ${binary} but ${describeBinaryProbeFailure({
+            probe: proven,
+            path: binary,
+            subject: "the installed binary",
+          })} ${result.message}`,
+      };
+    }
+    if (`v${proven.version.replace(/^v/, "")}` !== pin) {
+      return {
+        ok: false,
+        error:
+          `swapped ${binary} but it reports ${proven.version}, not ${pin} — ` +
           `the install did not land. ${result.message}`,
       };
     }

--- a/src/cli/self-update-io-probe.test.ts
+++ b/src/cli/self-update-io-probe.test.ts
@@ -1,0 +1,120 @@
+/**
+ * `defaultSelfUpdateIO().probeBinary` against a REAL executable (#4586
+ * follow-up).
+ *
+ * Every other test around self-update injects a fake `SelfUpdateIO`, so the
+ * one thing that actually broke a fleet roll — WHICH ARGV the production
+ * probe runs — was covered by nothing. On 2026-08-10 a `pin: v0.21.3` roll
+ * refused at `preflight-host-cli-stale` with "the downloaded v0.21.3 binary
+ * did not run cleanly on this host (`switchroom version` failed)". The
+ * release artifact was fine: its sha256 matched `switchroom-checksums.txt`
+ * and it ran and installed by hand minutes later.
+ *
+ * The probe ran the `version` SUBCOMMAND, which calls `getConfig()` and exits
+ * 1 with "Config error: No switchroom.yaml found" wherever there is no
+ * `~/.switchroom/switchroom.yaml`. The host-CLI heal helper container mounts
+ * the install prefix AND NOTHING ELSE (`host-cli-heal.ts` → `healHelperArgs`)
+ * — so the probe could never pass there, and the heal could never succeed.
+ *
+ * These tests execute a stub binary that reproduces exactly that asymmetry.
+ */
+
+import { describe, expect, it, afterAll } from "vitest";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { defaultSelfUpdateIO } from "./self-update-io.js";
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/**
+ * Same trick as `tests/ci-buildx-warm-pull.test.ts`: this repo's dev hosts and
+ * agent containers commonly mount /tmp `noexec`, and a test that needs to
+ * EXECUTE a stub must not fail for that unrelated reason. Probe once, fall
+ * back to a scratch dir inside the worktree.
+ */
+function execCapableBase(): string {
+  const candidate = mkdtempSync(join(tmpdir(), "probe-argv-"));
+  const probe = join(candidate, "probe.sh");
+  writeFileSync(probe, "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+  chmodSync(probe, 0o755);
+  try {
+    execFileSync(probe, { stdio: "ignore" });
+    return candidate;
+  } catch {
+    rmSync(candidate, { recursive: true, force: true });
+    return mkdtempSync(join(REPO, ".probe-argv-test-"));
+  }
+}
+
+const base = execCapableBase();
+afterAll(() => rmSync(base, { recursive: true, force: true }));
+
+/** Write `body` as an executable stub named `switchroom` and return its path. */
+function stub(body: string, mode = 0o755): string {
+  const dir = mkdtempSync(join(base, "case-"));
+  const path = join(dir, "switchroom");
+  writeFileSync(path, `#!/usr/bin/env bash\n${body}\n`, { mode });
+  chmodSync(path, mode);
+  return path;
+}
+
+describe("probeBinary argv (#4586 — the heal helper's false negative)", () => {
+  it("proves a binary that has no fleet config, exactly like the heal helper's container", () => {
+    // The real CLI's shape: `--version` is commander's flag and needs nothing;
+    // the `version` SUBCOMMAND loads ~/.switchroom/switchroom.yaml and exits 1
+    // without one. A probe that picks the subcommand cannot pass in the heal
+    // helper, which mounts no `~/.switchroom`.
+    const path = stub(
+      [
+        'if [ "$1" = "--version" ]; then echo "0.21.3"; exit 0; fi',
+        'echo "Config error: No switchroom.yaml found" >&2',
+        "exit 1",
+      ].join("\n"),
+    );
+
+    const probe = defaultSelfUpdateIO().probeBinary(path);
+
+    expect(probe).toEqual({ ok: true, version: "0.21.3" });
+  });
+
+  it("reports a binary this host cannot EXECUTE as not-executable, never as a bad artifact", () => {
+    // Mode 0644 stands in for the whole exec-refused family: a `noexec`
+    // staging mount, a lost +x bit, ENOEXEC under a foreign arch. The
+    // artifact's integrity is not in question and the message must not
+    // pretend otherwise, or the operator re-downloads a good file forever.
+    const path = stub('echo "0.21.3"; exit 0', 0o644);
+
+    const probe = defaultSelfUpdateIO().probeBinary(path);
+
+    expect(probe.ok).toBe(false);
+    if (probe.ok) throw new Error("unreachable");
+    expect(probe.kind).toBe("not-executable");
+    expect(probe.detail).toMatch(/EACCES/);
+  });
+
+  it("reports a binary that runs and fails as ran-but-failed — the one verdict that indicts the artifact", () => {
+    const path = stub('echo "boom" >&2; exit 3');
+
+    const probe = defaultSelfUpdateIO().probeBinary(path);
+
+    expect(probe.ok).toBe(false);
+    if (probe.ok) throw new Error("unreachable");
+    expect(probe.kind).toBe("ran-but-failed");
+    expect(probe.detail).toContain("exit 3");
+    expect(probe.detail).toContain("boom");
+  });
+
+  it("reports a clean exit with no parseable version as no-version", () => {
+    const path = stub('echo "not a version"; exit 0');
+
+    const probe = defaultSelfUpdateIO().probeBinary(path);
+
+    expect(probe.ok).toBe(false);
+    if (probe.ok) throw new Error("unreachable");
+    expect(probe.kind).toBe("no-version");
+  });
+});

--- a/src/cli/self-update-io.ts
+++ b/src/cli/self-update-io.ts
@@ -34,6 +34,12 @@ import type { SelfUpdateIO } from "./self-update.js";
 /** Bounded so a hung GitHub/CDN connection can't wedge an update. */
 const HTTP_TIMEOUT_MS = 60_000;
 
+/** First non-empty line of a stream, bounded — probe details go into prose. */
+function firstLine(s: string | undefined | null): string {
+  const line = `${s ?? ""}`.split("\n").map((l) => l.trim()).find((l) => l.length > 0) ?? "";
+  return line.length > 200 ? `${line.slice(0, 197)}...` : line;
+}
+
 export function defaultSelfUpdateIO(): SelfUpdateIO {
   return {
     async httpGetText(url) {
@@ -78,18 +84,63 @@ export function defaultSelfUpdateIO(): SelfUpdateIO {
       }
       return hash.digest("hex");
     },
-    probeBinaryVersion(path) {
-      const r = spawnSync(path, ["version"], {
+    probeBinary(path) {
+      // `--version`, NOT the `version` SUBCOMMAND.
+      //
+      // This is the #4586 dead end, root-caused. `switchroom version` renders
+      // the fleet health summary: it calls `getConfig()` and exits 1 with
+      // "Config error: No switchroom.yaml found" in any context that has no
+      // `~/.switchroom/switchroom.yaml`, then enumerates agent containers over
+      // the docker socket. The host-CLI heal helper deliberately mounts the
+      // install prefix AND NOTHING ELSE — no `~/.switchroom`, no docker socket
+      // (`host-cli-heal.ts`, `healHelperArgs`) — so the probe of a perfectly
+      // good release binary exited 1 there, every time, and the roll refused
+      // with "the downloaded binary did not run cleanly on this host".
+      //
+      // `--version` is commander's own flag. It still execs the artifact and
+      // loads its entire bundled runtime — which is the ONLY thing this check
+      // is trying to prove — while touching no config, no docker socket and no
+      // network. It is therefore both the cheapest and the strictly more
+      // correct proof: a non-zero exit from it indicts the binary, whereas a
+      // non-zero exit from `version` mostly indicts the environment.
+      const r = spawnSync(path, ["--version"], {
         encoding: "utf-8",
         timeout: 30_000,
         // A candidate binary must not inherit the self-update sentinel or
         // it could mask a loop guard in a future refactor.
         env: { ...process.env, SWITCHROOM_SELF_UPDATED: "" },
       });
-      if (r.status !== 0) return null;
+      // spawn itself failed: EACCES from a `noexec` staging mount or a missing
+      // +x bit, ENOEXEC from a foreign architecture, ENOENT. None of these say
+      // anything about the artifact's integrity.
+      if (r.error) {
+        const code = (r.error as NodeJS.ErrnoException).code;
+        return {
+          ok: false,
+          kind: "not-executable",
+          detail: code ? `${code}: ${r.error.message}` : r.error.message,
+        };
+      }
+      if (r.signal) {
+        return { ok: false, kind: "not-executable", detail: `killed by signal ${r.signal}` };
+      }
+      if (r.status !== 0) {
+        return {
+          ok: false,
+          kind: "ran-but-failed",
+          detail: `exit ${r.status}${firstLine(r.stderr) ? `: ${firstLine(r.stderr)}` : ""}`,
+        };
+      }
       const out = `${r.stdout ?? ""}`.trim();
       const m = out.match(/\d+\.\d+\.\d+/);
-      return m ? m[0] : null;
+      if (!m) {
+        return {
+          ok: false,
+          kind: "no-version",
+          detail: out ? `printed ${JSON.stringify(firstLine(out))}` : "printed nothing",
+        };
+      }
+      return { ok: true, version: m[0] };
     },
     mkdirp(dir) {
       mkdirSync(dir, { recursive: true });

--- a/src/cli/self-update.test.ts
+++ b/src/cli/self-update.test.ts
@@ -237,7 +237,7 @@ function makeIO(overrides: Partial<SelfUpdateIO> = {}) {
       files.set(dest, "NEW-BINARY");
     },
     sha256File: () => GOOD_SHA,
-    probeBinaryVersion: () => "0.19.28",
+    probeBinary: () => ({ ok: true, version: "0.19.28" }),
     mkdirp: (d) => void dirs.add(d),
     copyFile: (src, dest) => void files.set(dest, files.get(realpath(src)) ?? ""),
     chmodExec: () => {},
@@ -361,9 +361,38 @@ describe("performSelfUpdate", () => {
   });
 
   it("refuses a binary that cannot run on this host, BEFORE the swap", async () => {
-    const { io, files } = makeIO({ probeBinaryVersion: () => null });
-    await expect(run(io)).rejects.toThrow(/did not run cleanly/);
+    const { io, files } = makeIO({
+      probeBinary: () => ({ ok: false, kind: "ran-but-failed", detail: "exit 1" }),
+    });
+    await expect(run(io)).rejects.toThrow(/the artifact itself is faulty/);
     // The whole point: a broken binary never reaches $PATH.
+    expect(files.get("/usr/local/bin/switchroom")).toBe("OLD-BINARY");
+  });
+
+  // #4586 follow-up. Before this split, EVERY probe failure was reported as
+  // "the downloaded binary did not run cleanly on this host", which reads as
+  // "the artifact is bad" and sends the operator to re-download an artifact
+  // whose sha256 already matched. A failure to EXEC is a property of the
+  // staging location (a `noexec` mount, a lost +x bit, a foreign arch), and
+  // the message must say so or the remedy is wrong.
+  it("says the artifact is fine and the LOCATION is not, when the exec itself fails", async () => {
+    const { io, files } = makeIO({
+      probeBinary: () => ({
+        ok: false,
+        kind: "not-executable",
+        detail: "EACCES: spawnSync .../switchroom-v0.19.28.download EACCES",
+      }),
+    });
+    const err = await run(io).then(
+      () => "",
+      (e: Error) => e.message,
+    );
+    expect(err).toContain("could not EXECUTE");
+    expect(err).toContain("noexec");
+    expect(err).toContain("re-downloading will not help");
+    // It must NOT accuse the artifact.
+    expect(err).not.toContain("the artifact itself is faulty");
+    // Still refuses: an unproven binary never reaches $PATH.
     expect(files.get("/usr/local/bin/switchroom")).toBe("OLD-BINARY");
   });
 

--- a/src/cli/self-update.ts
+++ b/src/cli/self-update.ts
@@ -367,6 +367,84 @@ export function alreadySelfUpdated(env: NodeJS.ProcessEnv): boolean {
 // verify → prove → swap sequence is exercisable in a unit test with an
 // in-memory filesystem and no network.
 
+/**
+ * The outcome of executing a candidate binary to ask it its version.
+ *
+ * The `kind` split is the whole point. Before #4586's follow-up the probe
+ * returned `string | null`, so THREE different situations arrived at the
+ * caller as the same `null`:
+ *
+ *  - the artifact is genuinely broken (wrong arch, unloadable runtime),
+ *  - the artifact is fine but this process could not EXEC it where it was
+ *    staged (a `noexec` staging mount, a lost +x bit, ENOEXEC under an
+ *    emulated arch),
+ *  - the artifact ran fine but the command we chose to run needed something
+ *    the environment does not have.
+ *
+ * Only the first is "do not install this binary". The other two are
+ * environment faults, and reporting them as a bad download sends the
+ * operator to re-download an artifact that was never the problem — which is
+ * exactly the wrong-remedy dead end this type exists to prevent.
+ */
+export type BinaryProbe =
+  | { ok: true; version: string }
+  | {
+      ok: false;
+      /**
+       * `not-executable` — the exec never happened or the process was killed
+       * by a signal (EACCES from a `noexec` mount or a missing +x bit,
+       * ENOEXEC, ENOENT). Says nothing about the artifact's integrity.
+       *
+       * `ran-but-failed` — the binary executed and exited non-zero. THIS is
+       * the one that indicts the artifact, provided the probe command is one
+       * that cannot fail for environmental reasons (see
+       * `defaultSelfUpdateIO().probeBinary`).
+       *
+       * `no-version` — exited 0 but printed nothing that parses as a semver.
+       */
+      kind: "not-executable" | "ran-but-failed" | "no-version";
+      /** One bounded line naming the errno / exit code / output. */
+      detail: string;
+    };
+
+/**
+ * Operator-facing prose for a failed probe, phrased per {@link BinaryProbe}
+ * `kind` so the remedy the reader acts on is the right one.
+ *
+ * Shared by `performSelfUpdate` (probing the freshly downloaded candidate)
+ * and `host-cli-upgrade` (probing the binary after the swap) so the two can
+ * never disagree about what a probe failure means.
+ */
+export function describeBinaryProbeFailure(opts: {
+  probe: Extract<BinaryProbe, { ok: false }>;
+  /** Path that was probed. */
+  path: string;
+  /** What the probed file is, for the sentence subject. */
+  subject: string;
+}): string {
+  const { probe, path, subject } = opts;
+  switch (probe.kind) {
+    case "not-executable":
+      return (
+        `could not EXECUTE ${subject} at ${path} (${probe.detail}). This is a ` +
+        `property of WHERE it was staged, not of the artifact — the usual causes ` +
+        `are a staging directory mounted \`noexec\`, a lost execute bit, or an ` +
+        `architecture this kernel cannot run. The download's sha256 already ` +
+        `matched the release's checksums file, so re-downloading will not help.`
+      );
+    case "ran-but-failed":
+      return (
+        `${subject} at ${path} ran but exited non-zero for \`--version\` ` +
+        `(${probe.detail}) — the artifact itself is faulty.`
+      );
+    case "no-version":
+      return (
+        `${subject} at ${path} ran and exited 0 but printed no parseable version ` +
+        `(${probe.detail}) — the artifact itself is faulty.`
+      );
+  }
+}
+
 export interface SelfUpdateIO {
   /** GET a URL as text. Throws on non-2xx. */
   httpGetText(url: string): Promise<string>;
@@ -374,9 +452,15 @@ export interface SelfUpdateIO {
   httpDownload(url: string, dest: string): Promise<void>;
   /** Lowercase hex SHA256 of a file. */
   sha256File(path: string): string;
-  /** Run `<path> version` and return the printed version, or null when
-   *  the binary does not exit 0 / prints nothing parseable. */
-  probeBinaryVersion(path: string): string | null;
+  /**
+   * Execute `<path>` and read back the version it reports.
+   *
+   * Returns a THREE-state answer, not a boolean-ish `string | null`, because
+   * "the binary is bad" and "we could not execute it here" demand opposite
+   * remedies and conflating them is what dead-ended a real roll (#4586 →
+   * this fix). See {@link BinaryProbe}.
+   */
+  probeBinary(path: string): BinaryProbe;
   mkdirp(dir: string): void;
   copyFile(src: string, dest: string): void;
   chmodExec(path: string): void;
@@ -748,12 +832,19 @@ export async function performSelfUpdate(opts: {
   // artifact (impossible, but cheap to exclude), and a binary whose
   // bundled runtime this host cannot load. A CLI that cannot print its
   // own version must never reach the operator's PATH.
-  const proved = io.probeBinaryVersion(tmp);
-  if (!proved) {
+  //
+  // The check is never SKIPPED, whatever the probe says — an unproven binary
+  // does not get installed. But the message distinguishes "the artifact is
+  // bad" from "we could not run it here", because the remedies are opposite.
+  const proved = io.probeBinary(tmp);
+  if (!proved.ok) {
     io.remove(tmp);
     throw new Error(
-      `self-update: the downloaded ${plan.to} binary did not run cleanly on this host ` +
-        `(\`switchroom version\` failed) — refusing to install it. The installed CLI is unchanged.`,
+      `self-update: ${describeBinaryProbeFailure({
+        probe: proved,
+        path: tmp,
+        subject: `the downloaded ${plan.to} binary`,
+      })} Refusing to install it. The installed CLI is unchanged.`,
     );
   }
 

--- a/src/cli/update-self-update.test.ts
+++ b/src/cli/update-self-update.test.ts
@@ -76,7 +76,7 @@ function fakeIO(): SelfUpdateIO & { files: Map<string, string>; links: Map<strin
       files.set(dest, url.endsWith(".tar.gz") ? `PAYLOAD:${tag}` : "NEW");
     },
     sha256File: () => "a".repeat(64),
-    probeBinaryVersion: () => "9.9.9",
+    probeBinary: () => ({ ok: true, version: "9.9.9" }),
     mkdirp: () => {},
     copyFile: (s, d) => void files.set(d, files.get(s) ?? ""),
     chmodExec: () => {},
@@ -329,7 +329,12 @@ describe("swap → re-exec", () => {
         installProbe: STATIC_PROBE,
         selfUpdateIO: {
           ...fakeIO(),
-          probeBinaryVersion: () => null, // downloaded binary won't run
+          // downloaded binary won't run
+          probeBinary: () => ({
+            ok: false as const,
+            kind: "ran-but-failed" as const,
+            detail: "exit 1",
+          }),
         },
         latestReleaseTagFn: async () => "v9.9.9",
         runner: () => ({ status: 0 }),
@@ -341,7 +346,7 @@ describe("swap → re-exec", () => {
       });
       expect(code).toBe(1);
       expect(err).toContain("self-update-cli failed");
-      expect(err).toContain("did not run cleanly");
+      expect(err).toContain("the artifact itself is faulty");
     });
   });
 });


### PR DESCRIPTION
## Summary

The self-update proof step now probes a candidate binary with `--version`
(commander's flag) instead of the `version` **subcommand**, and returns a
typed three-way `BinaryProbe` instead of a boolean-ish `string | null`.

Fixes the dead-on-arrival agent-initiated host-CLI heal from #4586.

## Why

`performSelfUpdate` refuses to install a downloaded artifact until it has
proved the artifact runs. That probe ran the `version` **subcommand** —
which is not a version printer. It is
`withConfigError(getConfig(program))` (`src/cli/version.ts:150-152`): it
loads `~/.switchroom/switchroom.yaml`, exits 1 with
`Config error: No switchroom.yaml found` when there isn't one, and then
enumerates agent containers over the docker socket.

The host-CLI heal helper container deliberately mounts the install prefix
**and nothing else** — no `~/.switchroom`, no docker socket
(`healHelperArgs`, `src/cli/host-cli-heal.ts:169-194`). So the probe could
never pass there. A `pin: v0.21.3` roll refused at
`preflight-host-cli-stale` with

> the downloaded v0.21.3 binary did not run cleanly on this host
> (`switchroom version` failed)

for an artifact whose sha256 matched `switchroom-checksums.txt` and which
installed by hand minutes later. The heal path #4586 added could not
succeed on any host, ever — not a flake, a construction error.

### Why `--version` is strictly more correct, not merely more convenient

`--version` is commander's own flag, registered at `src/cli/index.ts:87`.
It still **execs the artifact and loads its entire bundled runtime** — which
is the only thing this check is trying to prove — while touching no config,
no docker socket and no network. The `preAction` hook never fires, because
the flag short-circuits before any action.

That difference is the whole point as *evidence*: a non-zero exit from
`--version` indicts the binary. A non-zero exit from `version` mostly
indicts the environment. The old probe was asking a question whose answer
was dominated by everything except the thing under test.

### Typed probe result

The check is never skipped and an unproven binary still never reaches
`$PATH`. But `probeBinaryVersion(path): string | null` becomes
`probeBinary(path): BinaryProbe`, because three different situations used
to arrive at the caller as the same `null` and they demand **opposite**
remedies:

| kind | meaning | remedy |
|---|---|---|
| `not-executable` | spawn failed or was signalled — EACCES from a `noexec` staging mount or a lost +x bit, ENOEXEC on a foreign arch, ENOENT | fix the staging location; the artifact is not in question |
| `ran-but-failed` | executed, exited non-zero | **this** is the one that indicts the artifact |
| `no-version` | exited 0, printed nothing parseable as a semver | indicts the artifact |

`describeBinaryProbeFailure()` renders the operator prose per kind and is
shared by `performSelfUpdate` (staged candidate) and `host-cli-upgrade`
(post-swap binary), so the two surfaces cannot drift apart on what a probe
failure means. Reporting an exec failure as "the downloaded binary did not
run cleanly" sent operators to re-download a file whose checksum had
already matched — the wrong remedy, which is what this type exists to
prevent.

## Test plan

New `src/cli/self-update-io-probe.test.ts` drives the **production**
`defaultSelfUpdateIO().probeBinary` against real stub executables. Every
other test around self-update injects a fake `SelfUpdateIO`, so the one
thing that actually broke the roll — *which argv the probe runs* — was
covered by nothing at all.

Four cases: a stub reproducing the real CLI's asymmetry (`--version`
prints and exits 0; anything else emits `Config error: No switchroom.yaml
found` and exits 1), a mode-0644 stub for the exec-refused family, a
non-zero exit, and a clean exit with unparseable output.

**Mutation check.** Reverting the argv to `["version"]` kills the first
case with the verbatim production failure:

```
- "ok": true,
- "version": "0.21.3",
+ "detail": "exit 1: Config error: No switchroom.yaml found",
+ "kind": "ran-but-failed",
+ "ok": false,
```

Scoped suite, all green:

```
✓ src/cli/self-update-io-probe.test.ts (4 tests)
✓ src/cli/host-cli-upgrade.test.ts (19 tests)
✓ src/cli/self-update.test.ts (37 tests)
✓ src/cli/update-self-update.test.ts (16 tests)
Test Files 4 passed (4) | Tests 76 passed (76)
```

`npm run lint` clean (all 26 gates, including `check-changelog-entry` and
`check-agent-attribution-trailers`).

The stub-exec harness borrows `tests/ci-buildx-warm-pull.test.ts`'s trick:
this repo's dev hosts and agent containers commonly mount `/tmp` `noexec`,
so it probes exec-capability once and falls back to a worktree scratch dir
(gitignored) — a test that must EXECUTE a stub should not red for that
unrelated reason.

## Risk

Low, and the failure direction is safe.

- The probe is strictly more permissive than before **only** for binaries
  that run fine but need a fleet config, which was never a property worth
  refusing on. It is not more permissive about anything that indicts the
  artifact: `ran-but-failed`, `no-version` and a failed exec all still
  refuse the install, and the rollback copy / swap ordering is untouched.
- `SelfUpdateIO` is an internal interface; the rename is compile-checked
  and `tsc --noEmit` passes with zero remaining `probeBinaryVersion`
  references in the tree.
- The post-swap version-equality check in `host-cli-upgrade` is unchanged
  — a swap that lands the wrong version still fails with "the install did
  not land".

Job spec: `reference/jobs/idempotent-update-and-restart.md` — "after
running `switchroom update`, the entire stack is at the version switchroom
declared". A heal step that cannot pass its own verification on a good
release binary defeats exactly that outcome.

Refs #4586
