### PR TITLE
fix(telegram): sweep /proc/self/fd for orphaned DB handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,30 @@
   SQLite DB from `bin/`, `src/`, or `telegram-plugin/hooks/` that is not marked
   with a reasoned `allow-rw-db-open:` exemption. (#4595)
 
+- **telegram: the gateway no longer writes hours of chat history into a deleted
+  file and calls it success.** When another process opened `history.db`
+  read-write and exited as the last connection, SQLite checkpointed and
+  UNLINKED the `-wal`/`-shm` sidecars out from under the gateway's long-lived
+  handle. The gateway kept writing into the now-deleted inodes for 3h06m,
+  logging a successful insert every time; the rows were never on disk and
+  vanished at the next restart. Nothing in the write path could notice — the
+  inserts return success, the boot-time writer self-check ran hours earlier,
+  and even a WAL checkpoint through the stale mapping "succeeds". The only
+  evidence is the process's own file-descriptor table, so that is what the
+  gateway now polls: every 5 minutes it walks `/proc/self/fd` for a state-dir
+  `*.db*` handle marked `(deleted)`. On a hit it logs loudly that every row
+  written since the last checkpoint is LOST, then reopens `history.db` in place
+  so new writes are durable again. The reopen does a hard close first — a plain
+  close leaves the dead descriptors open and the reopen then fails — and
+  deliberately issues no salvage checkpoint through the orphaned handle,
+  because a checkpoint through a stale mapping can corrupt the pages that did
+  land. `registry.db` gets the same detection and the same loud log but no
+  in-process reopen: its handle is captured by value into long-lived wiring, so
+  closing it would strand those consumers on a closed database; that lane names
+  the restart instead of pretending to fix itself. Silent history loss is now
+  bounded to 5 minutes rather than however long it takes someone to notice
+  missing messages.
+
 - **rollout: the host-CLI self-heal no longer fails its own verification on a
   perfectly good release binary.** The self-update proof step ran the
   downloaded artifact's `version` SUBCOMMAND, which loads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,16 +40,29 @@
   gateway now polls: every 5 minutes it walks `/proc/self/fd` for a state-dir
   `*.db*` handle marked `(deleted)`. On a hit it logs loudly that every row
   written since the last checkpoint is LOST, then reopens `history.db` in place
-  so new writes are durable again. The reopen does a hard close first — a plain
-  close leaves the dead descriptors open and the reopen then fails — and
+  so new writes are durable again. The reopen does a hard close first: bun's
+  plain `close()` is a soft close that leaves the dead descriptors open while
+  prepared statements are outstanding, and the reopened connection then LOOKS
+  healthy (the open and the WAL pragma both succeed) and throws on the first
+  WRITE. Every history statement now goes through a module-level cache that the
+  close explicitly finalizes, so the release is deterministic rather than
+  dependent on when the GC happens to run. The reopen also
   deliberately issues no salvage checkpoint through the orphaned handle,
   because a checkpoint through a stale mapping can corrupt the pages that did
   land. `registry.db` gets the same detection and the same loud log but no
   in-process reopen: its handle is captured by value into long-lived wiring, so
   closing it would strand those consumers on a closed database; that lane names
-  the restart instead of pretending to fix itself. Silent history loss is now
-  bounded to 5 minutes rather than however long it takes someone to notice
-  missing messages.
+  the restart instead of pretending to fix itself, as does any other state-dir
+  `*.db` no lane owns. The success line is gated on a post-reopen writer
+  self-check, so "writes are durable again" is a proven claim and not an
+  optimistic one; a reopen that fails says so and asks for a restart, and
+  because that failure releases the very descriptors that would have triggered
+  the next retry, the sweep also re-alarms and retries off a sticky flag on
+  every tick with no fd evidence left to go on. Fleet-health's L0 detector
+  matches the alarm as `orphaned-db-handle`. This does not recover lost rows:
+  rows already written into the orphaned WAL remain unrecoverable. What changes
+  is that the condition is now DETECTED within 5 minutes and stops accruing,
+  rather than running silently until someone notices missing messages.
 
 - **rollout: the host-CLI self-heal no longer fails its own verification on a
   perfectly good release binary.** The self-update proof step ran the

--- a/src/fleet-health/detect.test.ts
+++ b/src/fleet-health/detect.test.ts
@@ -188,6 +188,34 @@ describe("detectGatewayFindings", () => {
     expect(dup?.turn_id).toBe(`${CHAT}:_#42`);
     expect(dup?.ts).toBe("2026-07-02T21:03:00Z");
   });
+
+  // The orphaned-DB-fd sweep's alarm is the ONLY notification for the
+  // registry.db lane, which has no in-process recovery — an unmatched signature
+  // means silent data loss stays silent. The fixture is the literal line
+  // `orphaned-db-sweep.ts` emits.
+  const sweepLine =
+    "2026-08-10T03:05:00Z telegram gateway: orphaned-db-sweep DETECTED 2 deleted-inode" +
+    " DB handle(s): fd=13 /state/history.db-wal (deleted), fd=14 /state/history.db-shm" +
+    " (deleted) — another process unlinked these files while we held them open;" +
+    " every row written since the last checkpoint is LOST and further writes would" +
+    " be lost too.";
+
+  it("counts the orphaned-db-handle alarm", () => {
+    const { gw_hits, findings } = detectGatewayFindings("alpha", sweepLine);
+    expect(gw_hits["orphaned-db-handle"]).toBe(1);
+    const f = findings.find((x) => x.signal === "orphaned-db-handle");
+    expect(f?.agent).toBe("alpha");
+    expect(f?.ts).toBe("2026-08-10T03:05:00Z");
+  });
+
+  it("does not fire on the sweep's recovery or disabled-detection lines", () => {
+    const quiet = [
+      "telegram gateway: orphaned-db-sweep reopened history.db — writes are durable again",
+      "telegram gateway: orphaned-db-sweep cannot resolve stateDir=/nope — deleted-inode DB" +
+        " detection is DISABLED until it exists and is readable.",
+    ].join("\n");
+    expect(detectGatewayFindings("alpha", quiet).gw_hits["orphaned-db-handle"]).toBe(0);
+  });
 });
 
 describe("scanAgent escalation decision", () => {

--- a/src/fleet-health/detect.ts
+++ b/src/fleet-health/detect.ts
@@ -97,7 +97,14 @@ export type TurnSignal =
 export type GatewaySignal =
   | "duplicate-delivery-represent"
   | "represent-escalation"
-  | "reply-delivery-failure";
+  | "reply-delivery-failure"
+  // The gateway's orphaned-DB-fd sweep found a `*.db` handle pointing at a
+  // DELETED inode under the state dir. Every row written to that handle since
+  // the last checkpoint is gone, and the write path reported success for all of
+  // them. `history.db` self-heals in process; `registry.db` and anything else
+  // needs a restart — either way a human has to be told, which is what this
+  // signal is for. See `telegram-plugin/gateway/orphaned-db-sweep.ts`.
+  | "orphaned-db-handle";
 
 /** Signals from the standalone config/state sensors — NOT derived from an
  *  agent's turns.jsonl or gateway log. Each sensor reads a hard artifact
@@ -183,6 +190,12 @@ export const GATEWAY_SIGNATURES: Record<GatewaySignal, RegExp> = {
   "duplicate-delivery-represent": /represent duplicate-send/,
   "represent-escalation": /obligation escalation/,
   "reply-delivery-failure": /tg-post method=sendRichMessage[^\n]*status=err(?![a-z])/,
+  // Anchored on the sweep's DETECTED line, which is emitted once per tick per
+  // incident for EVERY lane (history, registry, unowned) — so the registry
+  // alarm, which has no in-process recovery at all, still reaches a human.
+  // Deliberately not anchored on the per-lane lines: those change wording as
+  // lanes are added, and one signal per incident is the right escalation rate.
+  "orphaned-db-handle": /orphaned-db-sweep DETECTED \d+ deleted-inode DB handle/,
 };
 
 /** Parse `turns.jsonl` text into records, silently skipping malformed lines
@@ -394,6 +407,7 @@ export function detectGatewayFindings(
     "duplicate-delivery-represent": 0,
     "represent-escalation": 0,
     "reply-delivery-failure": 0,
+    "orphaned-db-handle": 0,
   };
   const lines = logText.split("\n");
   for (const [name, re] of Object.entries(GATEWAY_SIGNATURES) as [

--- a/src/fleet-health/mapping.ts
+++ b/src/fleet-health/mapping.ts
@@ -84,6 +84,21 @@ export const SIGNAL_MAP: Record<L0Signal, SignalMapping> = {
     job_spec: "talk-to-agents-from-anywhere",
     signature: "reply-delivery-failure:sendRichMessage-err",
   },
+  "orphaned-db-handle": {
+    // The gateway held a `*.db` handle onto a DELETED inode: every INSERT
+    // through it reported success and none of the rows were on disk. That is
+    // `success-theater` in its purest form — the 2026-08-10 incident ran 3h06m
+    // logging a successful insert every time. severity 3: `history.db` is the
+    // durable record the fleet's own delivery accounting and restart recovery
+    // read back, and the `registry.db` lane has NO in-process recovery, so the
+    // alarm is the only thing standing between the operator and silent loss.
+    // Maps to `survive-reboots-and-real-life`: the promise this breaks is that
+    // what happened before the restart is still there after it.
+    failure_mode: "success-theater",
+    severity: 3,
+    job_spec: "survive-reboots-and-real-life",
+    signature: "orphaned-db-handle:deleted-inode-writes",
+  },
   "hang-long-stalled": {
     failure_mode: "partial",
     severity: 2,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -396,7 +396,7 @@ import {
   pruneMessagesOlderThanDays,
   hasOutboundDeliveredSince,
   hasOutboundWithText,
-  recordSystemOutbound, updateSystemOutboundText, reopenHistory,
+  recordSystemOutbound, updateSystemOutboundText, reopenHistory, getHistoryReopenFailure,
 } from '../history.js'
 import { startOrphanedDbSweep } from './orphaned-db-sweep.js'
 import { makeSystemMessageObserver } from './system-message-observer.js'
@@ -2163,7 +2163,7 @@ if (isGatewayMain) runHistoryReaperNow('boot')
 if (isGatewayMain && !STATIC) {
   setInterval(() => runHistoryReaperNow('periodic'), REGISTRY_REAPER_INTERVAL_MS).unref()
 }
-if (isGatewayMain && !STATIC) startOrphanedDbSweep({ stateDir: STATE_DIR, reopenHistory: HISTORY_ENABLED ? () => reopenHistory(STATE_DIR, HISTORY_ACCESS.historyRetentionDays ?? 30) : undefined, log: (l) => process.stderr.write(l) }) // own 5-min tick, NOT the 6h reaper: bounds silent data loss from a deleted-inode DB handle to one interval (gateway/orphaned-db-sweep.ts). Runs regardless of HISTORY_ENABLED — registry.db opens whenever isGatewayMain.
+if (isGatewayMain && !STATIC) startOrphanedDbSweep({ stateDir: STATE_DIR, reopenHistory: HISTORY_ENABLED ? () => reopenHistory(STATE_DIR, HISTORY_ACCESS.historyRetentionDays ?? 30) : undefined, historyReopenFailure: HISTORY_ENABLED ? getHistoryReopenFailure : undefined, log: (l) => process.stderr.write(l) }) // own 5-min tick, NOT the 6h reaper: bounds silent data loss from a deleted-inode DB handle to one interval (gateway/orphaned-db-sweep.ts). Runs regardless of HISTORY_ENABLED — registry.db opens whenever isGatewayMain.
 
 // ─── Approval polling ─────────────────────────────────────────────────────
 function checkApprovals(): void {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -396,8 +396,9 @@ import {
   pruneMessagesOlderThanDays,
   hasOutboundDeliveredSince,
   hasOutboundWithText,
-  recordSystemOutbound, updateSystemOutboundText,
+  recordSystemOutbound, updateSystemOutboundText, reopenHistory,
 } from '../history.js'
+import { startOrphanedDbSweep } from './orphaned-db-sweep.js'
 import { makeSystemMessageObserver } from './system-message-observer.js'
 import {
   runRegistryReaper,
@@ -2162,6 +2163,7 @@ if (isGatewayMain) runHistoryReaperNow('boot')
 if (isGatewayMain && !STATIC) {
   setInterval(() => runHistoryReaperNow('periodic'), REGISTRY_REAPER_INTERVAL_MS).unref()
 }
+if (isGatewayMain && !STATIC) startOrphanedDbSweep({ stateDir: STATE_DIR, reopenHistory: HISTORY_ENABLED ? () => reopenHistory(STATE_DIR, HISTORY_ACCESS.historyRetentionDays ?? 30) : undefined, log: (l) => process.stderr.write(l) }) // own 5-min tick, NOT the 6h reaper: bounds silent data loss from a deleted-inode DB handle to one interval (gateway/orphaned-db-sweep.ts). Runs regardless of HISTORY_ENABLED — registry.db opens whenever isGatewayMain.
 
 // ─── Approval polling ─────────────────────────────────────────────────────
 function checkApprovals(): void {

--- a/telegram-plugin/gateway/orphaned-db-sweep.ts
+++ b/telegram-plugin/gateway/orphaned-db-sweep.ts
@@ -22,29 +22,55 @@
  * WHAT THIS DOES
  * --------------
  * Every 5 minutes, walk `/proc/self/fd` and look for a link whose target is a
- * `*.db*` file inside the gateway's state dir marked `(deleted)`. On a hit:
+ * `*.db` (or `-wal`/`-shm`/`-journal` sidecar) file inside the gateway's state
+ * dir marked `(deleted)`. On a hit:
  *
  *   - Log LOUDLY that rows written since the last checkpoint are LOST. Silent
  *     data loss becomes a visible operator signal bounded to one sweep interval.
  *   - `history.db`: hard-close-drop-reopen via `reopenHistory()`. Read the long
  *     note there before touching it — a plain `close()` is NOT enough (it does
- *     not release the fds, and the reopen then fails `SQLITE_IOERR_SHORT_READ`),
- *     and there is deliberately no salvage checkpoint through the orphaned
- *     handle. If the reopen throws, we say so and ask for a restart rather than
- *     claim a recovery that did not happen.
+ *     not release the fds, and the reopened connection then throws on the first
+ *     WRITE), and there is deliberately no salvage checkpoint through the
+ *     orphaned handle. If the reopen throws, we say so and ask for a restart
+ *     rather than claim a recovery that did not happen.
  *   - `registry.db`: alarm only, RESTART REQUIRED. The registry handle
  *     (`turnsDb`) is captured BY VALUE into long-lived wiring in `gateway.ts`
  *     (the subagent-watcher options object among others), so a close-and-
  *     reassign would leave those consumers holding a CLOSED handle — strictly
  *     worse than the orphaned one. Detection without action is the honest
  *     behaviour here; the operator restarts.
+ *   - anything else `*.db` in the state dir: alarm only, RESTART REQUIRED. No
+ *     lane owns it, so the honest answer is to name the file and say so rather
+ *     than raise a data-loss alarm with no instruction attached.
+ *
+ * AND ONE THING THAT IS NOT FD-DRIVEN
+ * -----------------------------------
+ * A reopen that hard-closes the old handle and then fails to re-init leaves
+ * history NULL and the orphaned fds GONE — so fd detection can never fire
+ * again, and a "FAILED to reopen" line printed once at 03:00 would be the only
+ * record of a permanent outage. Every tick therefore also checks the sticky
+ * `getHistoryReopenFailure()` flag, alarms on it, and retries the reopen,
+ * independently of what the fd table says.
+ *
+ * WHY THE SCAN IS ASYNC
+ * ---------------------
+ * The walk is O(open fds) — measured at 10-13ms against a live gateway holding
+ * 3366 fds, and `RLIMIT_NOFILE` on the fleet is 524288, so the cost is
+ * unbounded by anything we control. A synchronous readdir+readlink loop of that
+ * shape blocks the event loop, i.e. stalls inbound Telegram handling, for a
+ * check that finds nothing 99.99% of the time. `fs/promises` `opendir` +
+ * `readlink` yields between entries, so a long scan costs latency on the sweep
+ * (which nobody is waiting for) instead of on the gateway. The alternative —
+ * probing only the known DB paths — was rejected: it cannot tell "the file is
+ * gone" from "we still hold the gone file open", which is the entire signal.
  *
  * Dependency-free on purpose (`fs` + `path` only) so it loads identically under
  * `bun test` and vitest, and so the recovery path cannot itself be broken by a
  * transitive import that touches the DB.
  */
 
-import { readdirSync, readlinkSync } from 'fs'
+import { realpathSync } from 'fs'
+import { opendir, readlink } from 'fs/promises'
 import { basename } from 'path'
 
 /** A `/proc/self/fd` entry pointing at a deleted DB file in the state dir. */
@@ -58,49 +84,80 @@ export interface OrphanedFd {
 const DELETED_SUFFIX = ' (deleted)'
 
 /**
+ * A SQLite database file or one of its sidecars, and nothing else.
+ *
+ * The previous `basename.includes('.db')` test also matched `notes.dbg`,
+ * `dump.dbf`, `history.db.bak` and `x.dbus` — an unrelated deleted temp file in
+ * the state dir would have raised a "rows are LOST" alarm. Anchored to the end
+ * of the basename so only a real `*.db` / `*.db-wal` / `*.db-shm` /
+ * `*.db-journal` matches.
+ */
+const DB_BASENAME_RE = /\.db(-wal|-shm|-journal)?$/
+
+/**
+ * Canonicalise the state dir for prefix matching against `/proc` targets.
+ *
+ * `/proc/self/fd` targets are ALWAYS fully resolved, so comparing them against
+ * a `TELEGRAM_STATE_DIR` that is a symlink (or relative) makes every
+ * `startsWith` fail and disables detection permanently — with no error, no log,
+ * and a sweep that reports "healthy" forever. Returns null when the path cannot
+ * be resolved at all, which callers surface as a warning rather than silence.
+ */
+export function resolveStateDirPrefix(stateDir: string): string | null {
+  let resolved: string
+  try {
+    resolved = realpathSync(stateDir)
+  } catch {
+    return null
+  }
+  return resolved.endsWith('/') ? resolved : resolved + '/'
+}
+
+/**
  * Scan `/proc/self/fd` for handles onto deleted DB files under `stateDir`.
  *
- * Returns `[]` — never throws — on non-Linux (no `/proc`), on an unreadable
- * `/proc/self/fd`, and for any individual fd that races closed between the
- * `readdir` and the `readlink`.
+ * Returns `[]` — never throws — on non-Linux (no `/proc`), on an unreadable or
+ * unresolvable `stateDir`, on an unreadable `/proc/self/fd`, and for any
+ * individual fd that races closed between the directory read and the
+ * `readlink`.
  *
  * A match requires ALL THREE of:
- *   1. the target is inside `stateDir` (so an unrelated deleted DB elsewhere on
- *      the box is not our problem),
+ *   1. the target is inside the CANONICAL `stateDir` (so an unrelated deleted
+ *      DB elsewhere on the box is not our problem),
  *   2. the target ends with ` (deleted)` (a healthy open WAL is NOT an orphan),
- *   3. the basename contains `.db` (an unrelated deleted temp file in the state
- *      dir must not raise a data-loss alarm).
+ *   3. the basename is a SQLite file or sidecar (an unrelated deleted temp file
+ *      in the state dir must not raise a data-loss alarm).
  */
-export function detectOrphanedDbFds(stateDir: string): OrphanedFd[] {
+export async function detectOrphanedDbFds(stateDir: string): Promise<OrphanedFd[]> {
   if (process.platform !== 'linux') return []
-  let entries: string[]
-  try {
-    entries = readdirSync('/proc/self/fd')
-  } catch {
-    return []
-  }
-  const prefix = stateDir.endsWith('/') ? stateDir : stateDir + '/'
+  const prefix = resolveStateDirPrefix(stateDir)
+  if (prefix == null) return []
   const found: OrphanedFd[] = []
-  for (const entry of entries) {
-    let target: string
-    try {
-      target = readlinkSync(`/proc/self/fd/${entry}`)
-    } catch {
-      // The fd closed underneath us (including the readdir's own fd). Not an
-      // orphan; just gone.
-      continue
+  try {
+    const dir = await opendir('/proc/self/fd')
+    for await (const entry of dir) {
+      let target: string
+      try {
+        target = await readlink(`/proc/self/fd/${entry.name}`)
+      } catch {
+        // The fd closed underneath us (including the directory handle's own
+        // fd). Not an orphan; just gone.
+        continue
+      }
+      // Parse FIRST, then filter. Doing the `slice` inside the deleted-check
+      // would make the basename test below silently do the deleted-check's job
+      // too (slicing 10 chars off a healthy `…/history.db-wal` yields `…/hist`,
+      // which fails the DB test by accident) — and an accidental guard is one
+      // nobody can mutation-test or safely refactor.
+      const deleted = target.endsWith(DELETED_SUFFIX)
+      const bare = deleted ? target.slice(0, -DELETED_SUFFIX.length) : target
+      if (!bare.startsWith(prefix)) continue
+      if (!deleted) continue
+      if (!DB_BASENAME_RE.test(basename(bare))) continue
+      found.push({ fd: Number(entry.name), target })
     }
-    // Parse FIRST, then filter. Doing the `slice` inside the deleted-check
-    // would make the `.db` test below silently do the deleted-check's job too
-    // (slicing 10 chars off a healthy `…/history.db-wal` yields `…/hist`,
-    // which fails `.includes('.db')` by accident) — and an accidental guard is
-    // one nobody can mutation-test or safely refactor.
-    const deleted = target.endsWith(DELETED_SUFFIX)
-    const bare = deleted ? target.slice(0, -DELETED_SUFFIX.length) : target
-    if (!bare.startsWith(prefix)) continue
-    if (!deleted) continue
-    if (!basename(bare).includes('.db')) continue
-    found.push({ fd: Number(entry), target })
+  } catch {
+    return found
   }
   return found
 }
@@ -118,6 +175,13 @@ export interface OrphanedDbSweepOptions {
    * the loud log still run, only the reopen is skipped.
    */
   reopenHistory?: () => void
+  /**
+   * The sticky "history is dead" flag (`history.getHistoryReopenFailure`).
+   * Checked on EVERY tick, not only when an orphaned fd is found: once a
+   * reopen has closed the old handle the fds are released, so fd detection can
+   * no longer see the outage it caused. Omit only where history is not wired.
+   */
+  historyReopenFailure?: () => string | null
   /** Log sink. The gateway passes `(l) => process.stderr.write(l)`. */
   log: (line: string) => void
 }
@@ -126,52 +190,102 @@ export interface OrphanedDbSweepOptions {
  * One sweep tick: detect, alarm, and recover. Returns the orphans found (empty
  * on the healthy path, which is every tick but the incident one).
  *
- * Never throws — a failed reopen is logged and the next tick retries.
+ * Never throws — a failed reopen is logged and the next tick retries. That
+ * promise is only meaningful because of the sticky-failure lane below: a reopen
+ * whose close succeeded but whose re-init failed releases the very fds that
+ * would have triggered the next retry.
  */
-export function runOrphanedDbSweepTick(opts: OrphanedDbSweepOptions): OrphanedFd[] {
-  const orphans = detectOrphanedDbFds(opts.stateDir)
-  if (orphans.length === 0) return orphans
+export async function runOrphanedDbSweepTick(
+  opts: OrphanedDbSweepOptions,
+): Promise<OrphanedFd[]> {
+  if (process.platform === 'linux' && resolveStateDirPrefix(opts.stateDir) == null) {
+    opts.log(
+      `telegram gateway: orphaned-db-sweep cannot resolve stateDir=${opts.stateDir} —`
+      + ` deleted-inode DB detection is DISABLED until it exists and is readable.\n`,
+    )
+  }
+  const orphans = await detectOrphanedDbFds(opts.stateDir)
+  let historyHandled = false
 
-  const names = orphans.map((o) => orphanBasename(o.target))
-  opts.log(
-    `telegram gateway: orphaned-db-sweep DETECTED ${orphans.length} deleted-inode DB handle(s): `
-    + orphans.map((o) => `fd=${o.fd} ${o.target}`).join(', ')
-    + ` — another process unlinked these files while we held them open; every row written`
-    + ` since the last checkpoint is LOST and further writes would be lost too.\n`,
-  )
+  if (orphans.length > 0) {
+    const names = orphans.map((o) => orphanBasename(o.target))
+    opts.log(
+      `telegram gateway: orphaned-db-sweep DETECTED ${orphans.length} deleted-inode DB handle(s): `
+      + orphans.map((o) => `fd=${o.fd} ${o.target}`).join(', ')
+      + ` — another process unlinked these files while we held them open; every row written`
+      + ` since the last checkpoint is LOST and further writes would be lost too.\n`,
+    )
 
-  if (names.some((n) => n.startsWith('history.db'))) {
-    if (opts.reopenHistory) {
-      try {
-        opts.reopenHistory()
+    if (names.some((n) => n.startsWith('history.db'))) {
+      historyHandled = true
+      if (opts.reopenHistory) {
+        attemptHistoryReopen(opts, 'reopened history.db')
+      } else {
         opts.log(
-          `telegram gateway: orphaned-db-sweep reopened history.db — writes are durable again;`
-          + ` rows written since the last checkpoint are NOT recoverable.\n`,
-        )
-      } catch (err) {
-        opts.log(
-          `telegram gateway: orphaned-db-sweep FAILED to reopen history.db: ${(err as Error).message}`
-          + ` — history writes are still going to a deleted inode; RESTART the gateway.\n`,
+          `telegram gateway: orphaned-db-sweep found an orphaned history.db handle but no reopen`
+          + ` is wired (history disabled) — RESTART the gateway to recover.\n`,
         )
       }
-    } else {
+    }
+
+    if (names.some((n) => n.startsWith('registry.db'))) {
       opts.log(
-        `telegram gateway: orphaned-db-sweep found an orphaned history.db handle but no reopen`
-        + ` is wired (history disabled) — RESTART the gateway to recover.\n`,
+        `telegram gateway: orphaned-db-sweep found an orphaned registry.db handle. An in-process`
+        + ` reopen is NOT safe here — the turnsDb handle is captured by value into long-lived`
+        + ` wiring, so closing it would leave those consumers on a closed handle. RESTART the`
+        + ` gateway to recover; subagent/turn rows written since the last checkpoint are LOST.\n`,
+      )
+    }
+
+    // Anything else under the state dir has no lane. Say so explicitly: an
+    // unnamed data-loss alarm with no recovery instruction is worse than none.
+    const unowned = [...new Set(names.filter(
+      (n) => !n.startsWith('history.db') && !n.startsWith('registry.db'),
+    ))]
+    if (unowned.length > 0) {
+      opts.log(
+        `telegram gateway: orphaned-db-sweep found orphaned handle(s) on ${unowned.join(', ')},`
+        + ` which no recovery lane owns — the gateway cannot reopen them in place. RESTART the`
+        + ` gateway to recover; rows written to those files since the last checkpoint are LOST.\n`,
       )
     }
   }
 
-  if (names.some((n) => n.startsWith('registry.db'))) {
-    opts.log(
-      `telegram gateway: orphaned-db-sweep found an orphaned registry.db handle. An in-process`
-      + ` reopen is NOT safe here — the turnsDb handle is captured by value into long-lived`
-      + ` wiring, so closing it would leave those consumers on a closed handle. RESTART the`
-      + ` gateway to recover; subagent/turn rows written since the last checkpoint are LOST.\n`,
-    )
+  // The fd table cannot see a history DB that is already closed and failed to
+  // re-open, so this lane runs whether or not anything was detected.
+  if (!historyHandled) {
+    const stuck = opts.historyReopenFailure?.()
+    if (stuck != null && stuck !== '') {
+      opts.log(
+        `telegram gateway: orphaned-db-sweep history.db is CLOSED and a previous reopen failed`
+        + ` (${stuck}) — every history read and write is dead and no fd evidence remains.`
+        + ` Retrying the reopen; RESTART the gateway if this keeps repeating.\n`,
+      )
+      if (opts.reopenHistory) attemptHistoryReopen(opts, 'recovered history.db')
+    }
   }
 
   return orphans
+}
+
+/**
+ * Run the wired reopen, logging honestly either way. `successVerb` distinguishes
+ * the first-detection recovery from the sticky-failure retry in the log.
+ */
+function attemptHistoryReopen(opts: OrphanedDbSweepOptions, successVerb: string): void {
+  try {
+    opts.reopenHistory?.()
+    opts.log(
+      `telegram gateway: orphaned-db-sweep ${successVerb} — writes are durable again`
+      + ` (proved by the post-reopen writer self-check); rows written since the last`
+      + ` checkpoint are NOT recoverable.\n`,
+    )
+  } catch (err) {
+    opts.log(
+      `telegram gateway: orphaned-db-sweep FAILED to reopen history.db: ${(err as Error).message}`
+      + ` — history writes are NOT durable; RESTART the gateway.\n`,
+    )
+  }
 }
 
 /** Default cadence: bounds silent loss to 5 minutes without polling cost. */
@@ -181,17 +295,20 @@ const DEFAULT_INTERVAL_MS = 5 * 60_000
  * Start the periodic sweep. Returns a `stop()` so tests can tear it down;
  * production never stops it (matches every sibling gateway interval).
  *
- * `unref()`s so the timer cannot hold the process alive past shutdown.
+ * `unref()`s so the timer cannot hold the process alive past shutdown. Ticks do
+ * not overlap: the scan is async, so a slow `/proc` walk on a process holding
+ * hundreds of thousands of fds must not stack up behind itself.
  */
 export function startOrphanedDbSweep(
   opts: OrphanedDbSweepOptions & { intervalMs?: number },
 ): () => void {
+  let running = false
   const timer = setInterval(() => {
-    try {
-      runOrphanedDbSweepTick(opts)
-    } catch {
-      /* a sweep must never take the gateway down; next tick retries */
-    }
+    if (running) return
+    running = true
+    void runOrphanedDbSweepTick(opts)
+      .catch(() => { /* a sweep must never take the gateway down; next tick retries */ })
+      .finally(() => { running = false })
   }, opts.intervalMs ?? DEFAULT_INTERVAL_MS)
   timer.unref?.()
   return () => clearInterval(timer)

--- a/telegram-plugin/gateway/orphaned-db-sweep.ts
+++ b/telegram-plugin/gateway/orphaned-db-sweep.ts
@@ -1,0 +1,198 @@
+/**
+ * Orphaned-DB-fd sweep — detect and recover from a SQLite handle that is
+ * still writing into DELETED inodes.
+ *
+ * THE FAILURE MODE
+ * ----------------
+ * The gateway holds `history.db` (bun:sqlite, WAL) open for the process
+ * lifetime. A FOREIGN process rw-opened the same DB, and on exit — as the
+ * last connection — SQLite checkpointed and UNLINKED `history.db-wal` and
+ * `history.db-shm`. Our long-lived connection kept the deleted inodes mapped
+ * and kept writing into them for 3h06m, logging success on every insert. The
+ * rows were never on disk; they vanished at the next restart. The signature is
+ * visible from the process itself:
+ *
+ *     /proc/<pid>/fd/13 -> /…/history.db-wal (deleted)
+ *
+ * Nothing in the write path can notice this: `INSERT` returns success, the
+ * boot-time `verifyHistoryWritable()` self-check already ran hours earlier, and
+ * a WAL checkpoint through the stale mapping "succeeds" too. The only in-process
+ * evidence is the fd table, so that is what we poll.
+ *
+ * WHAT THIS DOES
+ * --------------
+ * Every 5 minutes, walk `/proc/self/fd` and look for a link whose target is a
+ * `*.db*` file inside the gateway's state dir marked `(deleted)`. On a hit:
+ *
+ *   - Log LOUDLY that rows written since the last checkpoint are LOST. Silent
+ *     data loss becomes a visible operator signal bounded to one sweep interval.
+ *   - `history.db`: hard-close-drop-reopen via `reopenHistory()`. Read the long
+ *     note there before touching it — a plain `close()` is NOT enough (it does
+ *     not release the fds, and the reopen then fails `SQLITE_IOERR_SHORT_READ`),
+ *     and there is deliberately no salvage checkpoint through the orphaned
+ *     handle. If the reopen throws, we say so and ask for a restart rather than
+ *     claim a recovery that did not happen.
+ *   - `registry.db`: alarm only, RESTART REQUIRED. The registry handle
+ *     (`turnsDb`) is captured BY VALUE into long-lived wiring in `gateway.ts`
+ *     (the subagent-watcher options object among others), so a close-and-
+ *     reassign would leave those consumers holding a CLOSED handle — strictly
+ *     worse than the orphaned one. Detection without action is the honest
+ *     behaviour here; the operator restarts.
+ *
+ * Dependency-free on purpose (`fs` + `path` only) so it loads identically under
+ * `bun test` and vitest, and so the recovery path cannot itself be broken by a
+ * transitive import that touches the DB.
+ */
+
+import { readdirSync, readlinkSync } from 'fs'
+import { basename } from 'path'
+
+/** A `/proc/self/fd` entry pointing at a deleted DB file in the state dir. */
+export interface OrphanedFd {
+  fd: number
+  /** The raw readlink target, including the trailing ` (deleted)` marker. */
+  target: string
+}
+
+/** Linux marks an unlinked-but-open fd's readlink target with this suffix. */
+const DELETED_SUFFIX = ' (deleted)'
+
+/**
+ * Scan `/proc/self/fd` for handles onto deleted DB files under `stateDir`.
+ *
+ * Returns `[]` — never throws — on non-Linux (no `/proc`), on an unreadable
+ * `/proc/self/fd`, and for any individual fd that races closed between the
+ * `readdir` and the `readlink`.
+ *
+ * A match requires ALL THREE of:
+ *   1. the target is inside `stateDir` (so an unrelated deleted DB elsewhere on
+ *      the box is not our problem),
+ *   2. the target ends with ` (deleted)` (a healthy open WAL is NOT an orphan),
+ *   3. the basename contains `.db` (an unrelated deleted temp file in the state
+ *      dir must not raise a data-loss alarm).
+ */
+export function detectOrphanedDbFds(stateDir: string): OrphanedFd[] {
+  if (process.platform !== 'linux') return []
+  let entries: string[]
+  try {
+    entries = readdirSync('/proc/self/fd')
+  } catch {
+    return []
+  }
+  const prefix = stateDir.endsWith('/') ? stateDir : stateDir + '/'
+  const found: OrphanedFd[] = []
+  for (const entry of entries) {
+    let target: string
+    try {
+      target = readlinkSync(`/proc/self/fd/${entry}`)
+    } catch {
+      // The fd closed underneath us (including the readdir's own fd). Not an
+      // orphan; just gone.
+      continue
+    }
+    // Parse FIRST, then filter. Doing the `slice` inside the deleted-check
+    // would make the `.db` test below silently do the deleted-check's job too
+    // (slicing 10 chars off a healthy `…/history.db-wal` yields `…/hist`,
+    // which fails `.includes('.db')` by accident) — and an accidental guard is
+    // one nobody can mutation-test or safely refactor.
+    const deleted = target.endsWith(DELETED_SUFFIX)
+    const bare = deleted ? target.slice(0, -DELETED_SUFFIX.length) : target
+    if (!bare.startsWith(prefix)) continue
+    if (!deleted) continue
+    if (!basename(bare).includes('.db')) continue
+    found.push({ fd: Number(entry), target })
+  }
+  return found
+}
+
+/** Strip the ` (deleted)` marker and return the bare file name. */
+function orphanBasename(target: string): string {
+  return basename(target.endsWith(DELETED_SUFFIX) ? target.slice(0, -DELETED_SUFFIX.length) : target)
+}
+
+export interface OrphanedDbSweepOptions {
+  /** The gateway state dir whose DB files we own. */
+  stateDir: string
+  /**
+   * Recovery for `history.db`. Omit when history is disabled — detection and
+   * the loud log still run, only the reopen is skipped.
+   */
+  reopenHistory?: () => void
+  /** Log sink. The gateway passes `(l) => process.stderr.write(l)`. */
+  log: (line: string) => void
+}
+
+/**
+ * One sweep tick: detect, alarm, and recover. Returns the orphans found (empty
+ * on the healthy path, which is every tick but the incident one).
+ *
+ * Never throws — a failed reopen is logged and the next tick retries.
+ */
+export function runOrphanedDbSweepTick(opts: OrphanedDbSweepOptions): OrphanedFd[] {
+  const orphans = detectOrphanedDbFds(opts.stateDir)
+  if (orphans.length === 0) return orphans
+
+  const names = orphans.map((o) => orphanBasename(o.target))
+  opts.log(
+    `telegram gateway: orphaned-db-sweep DETECTED ${orphans.length} deleted-inode DB handle(s): `
+    + orphans.map((o) => `fd=${o.fd} ${o.target}`).join(', ')
+    + ` — another process unlinked these files while we held them open; every row written`
+    + ` since the last checkpoint is LOST and further writes would be lost too.\n`,
+  )
+
+  if (names.some((n) => n.startsWith('history.db'))) {
+    if (opts.reopenHistory) {
+      try {
+        opts.reopenHistory()
+        opts.log(
+          `telegram gateway: orphaned-db-sweep reopened history.db — writes are durable again;`
+          + ` rows written since the last checkpoint are NOT recoverable.\n`,
+        )
+      } catch (err) {
+        opts.log(
+          `telegram gateway: orphaned-db-sweep FAILED to reopen history.db: ${(err as Error).message}`
+          + ` — history writes are still going to a deleted inode; RESTART the gateway.\n`,
+        )
+      }
+    } else {
+      opts.log(
+        `telegram gateway: orphaned-db-sweep found an orphaned history.db handle but no reopen`
+        + ` is wired (history disabled) — RESTART the gateway to recover.\n`,
+      )
+    }
+  }
+
+  if (names.some((n) => n.startsWith('registry.db'))) {
+    opts.log(
+      `telegram gateway: orphaned-db-sweep found an orphaned registry.db handle. An in-process`
+      + ` reopen is NOT safe here — the turnsDb handle is captured by value into long-lived`
+      + ` wiring, so closing it would leave those consumers on a closed handle. RESTART the`
+      + ` gateway to recover; subagent/turn rows written since the last checkpoint are LOST.\n`,
+    )
+  }
+
+  return orphans
+}
+
+/** Default cadence: bounds silent loss to 5 minutes without polling cost. */
+const DEFAULT_INTERVAL_MS = 5 * 60_000
+
+/**
+ * Start the periodic sweep. Returns a `stop()` so tests can tear it down;
+ * production never stops it (matches every sibling gateway interval).
+ *
+ * `unref()`s so the timer cannot hold the process alive past shutdown.
+ */
+export function startOrphanedDbSweep(
+  opts: OrphanedDbSweepOptions & { intervalMs?: number },
+): () => void {
+  const timer = setInterval(() => {
+    try {
+      runOrphanedDbSweepTick(opts)
+    } catch {
+      /* a sweep must never take the gateway down; next tick retries */
+    }
+  }, opts.intervalMs ?? DEFAULT_INTERVAL_MS)
+  timer.unref?.()
+  return () => clearInterval(timer)
+}

--- a/telegram-plugin/history.ts
+++ b/telegram-plugin/history.ts
@@ -53,7 +53,17 @@ type SqliteDatabase = {
     get(...params: unknown[]): unknown
   }
   transaction(fn: (...args: unknown[]) => unknown): (...args: unknown[]) => unknown
-  close(): void
+  /**
+   * `throwOnError` is bun:sqlite's "hard close" switch. The default
+   * (`close()`) is a SOFT close that silently defers the real
+   * `sqlite3_close` while any un-finalized `Statement` still references the
+   * connection — and every one of our statements is created per-call by
+   * `requireDb().prepare(...)`, so they are only reclaimed by GC.
+   * `close(true)` instead THROWS (`database is locked`) when the close did
+   * not actually happen, which is the only way to know. Load-bearing for
+   * {@link reopenHistory}; see the long note there.
+   */
+  close(throwOnError?: boolean): void
 }
 type SqliteDatabaseConstructor = new (path: string, opts?: { create?: boolean }) => SqliteDatabase
 
@@ -473,6 +483,84 @@ export function checkpointWal(): boolean {
   } catch {
     return false
   }
+}
+
+/**
+ * Drop the current history handle and re-open the DB from its path.
+ *
+ * THE FAILURE MODE THIS RECOVERS
+ * ------------------------------
+ * A FOREIGN process rw-opens `history.db`, and on exit — as the last
+ * connection — checkpoints and UNLINKS `history.db-wal` / `-shm`. Our
+ * long-lived connection keeps the deleted inodes mapped and keeps writing into
+ * them; every INSERT still reports success and the rows are simply gone at the
+ * next restart. Signature: `/proc/<pid>/fd/N -> …/history.db-wal (deleted)`.
+ * A container restart heals it; this is that restart, in-process. Detection and
+ * the call site live in `gateway/orphaned-db-sweep.ts`.
+ *
+ * WHY `close()` IS NOT ENOUGH (measured, not assumed)
+ * ---------------------------------------------------
+ * bun:sqlite's default `close()` is a SOFT close: it defers the real
+ * `sqlite3_close` while any un-finalized `Statement` still holds the
+ * connection, and every statement here is created per-call by
+ * `requireDb().prepare(...)`, so they are only reclaimed by GC. Measured on
+ * bun 1.3.13: after a plain `db.close()` the process STILL held
+ * `h.db`, `h.db-wal (deleted)` and `h.db-shm (deleted)` in `/proc/self/fd`,
+ * and the immediate re-open then failed with `SQLITE_IOERR_SHORT_READ`
+ * (errno 522) — because SQLite's unix VFS keeps per-inode WAL-index state
+ * alive for as long as any connection to that inode is open. A naive
+ * close-and-reopen therefore turns silent row loss into a TOTAL history
+ * outage. (The same DB file opened from a SEPARATE process reads fine, which
+ * is how we know the on-disk DB is not corrupt and the poisoning is
+ * in-process.)
+ *
+ * So the close has to be a HARD one, in two steps that are both load-bearing:
+ *   1. Force statement finalization. `Bun.gc(true)` is a synchronous full
+ *      collection; without it step 2 always throws.
+ *   2. `close(true)`, which THROWS rather than silently deferring. That throw
+ *      is the determinism: if we cannot actually close, we must NOT null `db`
+ *      and pretend to have recovered — we rethrow so the sweep logs the
+ *      failure and asks for a restart, leaving the (bad but working) old
+ *      handle in place rather than a null one that fails every write.
+ *
+ * NO EXPLICIT SALVAGE CHECKPOINT
+ * ------------------------------
+ * We never issue `wal_checkpoint` through the orphaned handle. Once a new
+ * `-shm` exists on disk, our handle and any other connection are in DISJOINT
+ * locking domains and a checkpoint through the stale mapping can corrupt the
+ * main DB. Losing rows is strictly better than corrupting the ones that landed.
+ * `close()` does still run SQLite's IMPLICIT checkpoint-on-close through the
+ * old fds — a knowingly accepted residual, not an oversight: it is exactly what
+ * a clean container restart already does today, so this path is no more
+ * dangerous than the restart it replaces. (In the isolated case it also
+ * SALVAGES the orphaned rows; we do not rely on that, because the concurrent
+ * case cannot.)
+ *
+ * `initHistory` early-returns when `db != null`, so nulling is load-bearing —
+ * without it the reopen is a silent no-op and the orphaned handle keeps eating
+ * rows. The re-init re-runs the idempotent DDL/migrations, the chmod/ownership
+ * fixups, retention, and `verifyHistoryWritable()` — a free post-reopen proof
+ * that the new handle can actually persist a row.
+ *
+ * Throws if the hard close or the re-init fails. Callers must treat a throw as
+ * "history is still broken, restart required".
+ */
+export function reopenHistory(stateDir: string, retentionDays = 30): void {
+  const current = db
+  if (current != null) {
+    // Reclaim the per-call prepared statements so the hard close below can
+    // actually run. Guarded: `Bun.gc` is Bun-only and this must not be the
+    // thing that throws.
+    const gc = (globalThis as { Bun?: { gc?: (force: boolean) => void } }).Bun?.gc
+    if (typeof gc === 'function') {
+      try { gc(true) } catch { /* best-effort; close(true) below reports the truth */ }
+    }
+    // Deliberately NOT caught: a failed close means the fds are still open and
+    // a re-open would fail with SQLITE_IOERR_SHORT_READ. Propagate.
+    current.close(true)
+  }
+  db = null
+  initHistory(stateDir, retentionDays)
 }
 
 /**

--- a/telegram-plugin/history.ts
+++ b/telegram-plugin/history.ts
@@ -45,23 +45,32 @@ import { redact } from './secret-detect/redact.js'
  * The only Database APIs we touch are constructor(path, opts), exec,
  * prepare, transaction, close — all stable across bun:sqlite versions.
  */
+type SqliteStatement = {
+  run(...params: unknown[]): unknown
+  all(...params: unknown[]): unknown[]
+  get(...params: unknown[]): unknown
+  /**
+   * Release the underlying `sqlite3_stmt` NOW. This is the deterministic
+   * counterpart to waiting for GC: an un-finalized statement is exactly what
+   * makes bun:sqlite's close a deferred no-op, so {@link reopenHistory}
+   * finalizes every cached statement before closing. Optional in the type
+   * because a test double need not implement it.
+   */
+  finalize?(): void
+}
 type SqliteDatabase = {
   exec(sql: string): void
-  prepare(sql: string): {
-    run(...params: unknown[]): unknown
-    all(...params: unknown[]): unknown[]
-    get(...params: unknown[]): unknown
-  }
+  prepare(sql: string): SqliteStatement
   transaction(fn: (...args: unknown[]) => unknown): (...args: unknown[]) => unknown
   /**
    * `throwOnError` is bun:sqlite's "hard close" switch. The default
    * (`close()`) is a SOFT close that silently defers the real
    * `sqlite3_close` while any un-finalized `Statement` still references the
-   * connection — and every one of our statements is created per-call by
-   * `requireDb().prepare(...)`, so they are only reclaimed by GC.
-   * `close(true)` instead THROWS (`database is locked`) when the close did
-   * not actually happen, which is the only way to know. Load-bearing for
-   * {@link reopenHistory}; see the long note there.
+   * connection. `close(true)` instead THROWS (`database is locked`) when the
+   * close did not actually happen, which is the only way to know. Every
+   * statement this module creates goes through {@link prep} and is explicitly
+   * finalized before the close, so the close is deterministic rather than
+   * GC-dependent. Load-bearing for {@link reopenHistory}; see the note there.
    */
   close(throwOnError?: boolean): void
 }
@@ -183,6 +192,79 @@ const MAX_LIMIT = 50
 
 let db: SqliteDatabase | null = null
 let dbPath: string | null = null
+
+/**
+ * Module-level prepared-statement cache — the DETERMINISTIC half of
+ * {@link reopenHistory}.
+ *
+ * WHY THIS EXISTS (it is not a performance cache, though it is also that)
+ * ----------------------------------------------------------------------
+ * bun:sqlite's `close()` is a soft close and `close(true)` throws for as long
+ * as ANY `Statement` created from the connection is still un-finalized. Every
+ * statement in this module used to be created per-call (`requireDb().prepare(…)`)
+ * and dropped on the floor, so nothing in the process held a reference we could
+ * finalize — the only way to release them was to wait for the JS GC to collect
+ * the wrappers. `Bun.gc(true)` was therefore load-bearing AND non-deterministic:
+ * measured on bun 1.3.13, a single `gc(true)` + `close(true)` pair failed 13/20
+ * times against an empty heap and 30/30 with an arithmetic loop between the last
+ * write and the gc. A recovery path that works "most of the time" is not a
+ * recovery path.
+ *
+ * With every statement routed through {@link prep}, the module OWNS a reference
+ * to each live statement and can call `.finalize()` on it explicitly. The close
+ * then succeeds because nothing is outstanding — no collection required, no
+ * heap-shape dependence.
+ *
+ * Keyed by SQL text. The set of distinct SQL strings this module can produce is
+ * small and structural (a handful of `WHERE` shapes built from booleans), not
+ * user-derived — parameters are always bound, never interpolated. {@link MAX_CACHED_STATEMENTS}
+ * is defence-in-depth against a future caller that builds SQL in a loop.
+ */
+const stmtCache = new Map<string, SqliteStatement>()
+
+/** Cap on live cached statements; oldest is finalized and evicted past this. */
+const MAX_CACHED_STATEMENTS = 128
+
+/**
+ * Prepare (or reuse) a statement against the current connection.
+ *
+ * Every SQL string in this module goes through here. Do NOT call
+ * `db.prepare(...)` directly: a statement outside the cache is one
+ * {@link reopenHistory} cannot finalize, which silently re-introduces the
+ * GC dependence this cache exists to remove.
+ */
+function prep(sql: string): SqliteStatement {
+  const cached = stmtCache.get(sql)
+  if (cached != null) return cached
+  const stmt = requireDb().prepare(sql)
+  if (stmtCache.size >= MAX_CACHED_STATEMENTS) {
+    // Map iteration is insertion-ordered, so this evicts the oldest entry.
+    const oldestKey = stmtCache.keys().next().value
+    if (oldestKey != null) {
+      const oldest = stmtCache.get(oldestKey)
+      stmtCache.delete(oldestKey)
+      try { oldest?.finalize?.() } catch { /* already gone; nothing to release */ }
+    }
+  }
+  stmtCache.set(sql, stmt)
+  return stmt
+}
+
+/**
+ * Finalize and forget every cached statement.
+ *
+ * MUST run before any `close()` of the connection they were prepared against,
+ * and MUST leave the cache empty: a statement prepared against the OLD
+ * connection would otherwise be handed out after the reopen and operate on a
+ * dead handle. Individual `finalize()` failures are swallowed — the close is
+ * the authority on whether the release actually happened.
+ */
+function finalizeCachedStatements(): void {
+  for (const stmt of stmtCache.values()) {
+    try { stmt.finalize?.() } catch { /* best-effort; close(true) reports the truth */ }
+  }
+  stmtCache.clear()
+}
 
 /**
  * Loud, unconditional failure logging for the history writer.
@@ -310,9 +392,9 @@ export function initHistory(stateDir: string, retentionDays = 30): void {
   // (`thread_id IS NULL` / `thread_id = ?`) is unchanged.
   const LOGICAL_KEY_INDEX = 'idx_messages_logical_key'
   const logicalKeyIndexExists =
-    db
-      .prepare(`SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?`)
-      .get(LOGICAL_KEY_INDEX) != null
+    prep(`SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?`).get(
+      LOGICAL_KEY_INDEX,
+    ) != null
   if (!logicalKeyIndexExists) {
     // De-dupe rows an earlier (pre-fix) build already appended, keeping the
     // NEWEST row per logical key (highest ts, then highest rowid = the last
@@ -356,7 +438,7 @@ export function initHistory(stateDir: string, retentionDays = 30): void {
 
   if (retentionDays > 0) {
     const cutoff = Math.floor(Date.now() / 1000) - retentionDays * 86400
-    db.prepare('DELETE FROM messages WHERE ts < ?').run(cutoff)
+    prep('DELETE FROM messages WHERE ts < ?').run(cutoff)
   }
 
   // Boot-time writer self-check (2026-07-16 incident hardening). "history
@@ -401,15 +483,15 @@ export function verifyHistoryWritable(): { ok: boolean; error?: string } {
   const sentinelId = Date.now()
   try {
     // Clear any stale sentinel from a prior crashed self-check first.
-    db.prepare('DELETE FROM messages WHERE chat_id = ?').run(SENTINEL_CHAT)
-    db.prepare(
+    prep('DELETE FROM messages WHERE chat_id = ?').run(SENTINEL_CHAT)
+    prep(
       `INSERT OR REPLACE INTO messages
          (chat_id, thread_id, message_id, role, ts, text)
        VALUES (?, NULL, ?, 'assistant', ?, ?)`,
     ).run(SENTINEL_CHAT, sentinelId, Math.floor(Date.now() / 1000), 'selfcheck')
-    const row = db
-      .prepare('SELECT text FROM messages WHERE chat_id = ? AND message_id = ?')
-      .get(SENTINEL_CHAT, sentinelId) as { text?: string } | undefined
+    const row = prep(
+      'SELECT text FROM messages WHERE chat_id = ? AND message_id = ?',
+    ).get(SENTINEL_CHAT, sentinelId) as { text?: string } | undefined
     if (row?.text !== 'selfcheck') {
       return { ok: false, error: 'sentinel row not read back after insert' }
     }
@@ -419,7 +501,7 @@ export function verifyHistoryWritable(): { ok: boolean; error?: string } {
   } finally {
     // Never leave the sentinel behind, even if the SELECT/assert path threw.
     try {
-      db.prepare('DELETE FROM messages WHERE chat_id = ?').run(SENTINEL_CHAT)
+      prep('DELETE FROM messages WHERE chat_id = ?').run(SENTINEL_CHAT)
     } catch {
       /* best-effort cleanup */
     }
@@ -434,21 +516,40 @@ export function verifyHistoryWritable(): { ok: boolean; error?: string } {
  * empty instead of throwing. Do NOT use for writes — every write path goes
  * through the record* functions above so redaction and validity checks
  * cannot be bypassed.
+ *
+ * The returned `prepare` routes through the module statement cache rather than
+ * handing out the raw `Database`. That is deliberate: a statement prepared
+ * directly off the connection by an outside caller is one `reopenHistory`
+ * cannot finalize, and a single such statement is enough to make the hard close
+ * throw. Keeping the seam inside the cache keeps the reopen deterministic no
+ * matter who else reads.
  */
 export function getHistoryDbForBriefing(): {
   prepare(sql: string): { all(...params: unknown[]): unknown[] }
 } | null {
-  return db
+  if (db == null) return null
+  return {
+    prepare(sql: string) {
+      return { all: (...params: unknown[]) => prep(sql).all(...params) }
+    },
+  }
 }
 
 /**
  * For tests — close the singleton and forget it. Production code never
  * needs this; the DB is held open for the lifetime of the process.
+ *
+ * Uses the SAME deterministic hard close as {@link reopenHistory}: a soft
+ * `close()` here leaked three fds per test (`h.db`, `-wal`, `-shm`), which is
+ * how the state-dir prefix guard in the sweep test came to look covered when it
+ * was not — the leaked fds from the previous test were doing the filtering.
  */
 export function _resetForTests(): void {
+  historyReopenFailure = null
   if (db != null) {
-    db.close()
+    const current = db
     db = null
+    hardCloseDb(current)
   }
 }
 
@@ -468,7 +569,7 @@ export function _resetForTests(): void {
 export function checkpointWal(): boolean {
   if (db == null) return false
   try {
-    db.prepare('PRAGMA wal_checkpoint(TRUNCATE)').run()
+    prep('PRAGMA wal_checkpoint(TRUNCATE)').run()
     // Re-apply permissions after WAL truncation (SQLite may recreate -wal/-shm)
     if (dbPath) {
       for (const suffix of ['-shm', '-wal']) {
@@ -502,26 +603,37 @@ export function checkpointWal(): boolean {
  * ---------------------------------------------------
  * bun:sqlite's default `close()` is a SOFT close: it defers the real
  * `sqlite3_close` while any un-finalized `Statement` still holds the
- * connection, and every statement here is created per-call by
- * `requireDb().prepare(...)`, so they are only reclaimed by GC. Measured on
- * bun 1.3.13: after a plain `db.close()` the process STILL held
- * `h.db`, `h.db-wal (deleted)` and `h.db-shm (deleted)` in `/proc/self/fd`,
- * and the immediate re-open then failed with `SQLITE_IOERR_SHORT_READ`
- * (errno 522) — because SQLite's unix VFS keeps per-inode WAL-index state
- * alive for as long as any connection to that inode is open. A naive
- * close-and-reopen therefore turns silent row loss into a TOTAL history
- * outage. (The same DB file opened from a SEPARATE process reads fine, which
- * is how we know the on-disk DB is not corrupt and the poisoning is
- * in-process.)
+ * connection. Measured on bun 1.3.13: after a plain `db.close()` the process
+ * STILL held `h.db`, `h.db-wal (deleted)` and `h.db-shm (deleted)` in
+ * `/proc/self/fd`, and the reopen then produced a connection that LOOKS
+ * healthy — `new Database(...)` and `PRAGMA journal_mode = WAL` both SUCCEED —
+ * and throws on the first WRITE instead (`SQLITE_IOERR_SHORT_READ`, errno 522),
+ * because SQLite's unix VFS keeps per-inode WAL-index state alive for as long
+ * as any connection to that inode is open. A naive close-and-reopen therefore
+ * turns silent row loss into a TOTAL history outage, and does it at a point
+ * where the reopen has already "succeeded". (The same DB file opened from a
+ * SEPARATE process reads fine, which is how we know the on-disk DB is not
+ * corrupt and the poisoning is in-process.)
  *
- * So the close has to be a HARD one, in two steps that are both load-bearing:
- *   1. Force statement finalization. `Bun.gc(true)` is a synchronous full
- *      collection; without it step 2 always throws.
- *   2. `close(true)`, which THROWS rather than silently deferring. That throw
- *      is the determinism: if we cannot actually close, we must NOT null `db`
- *      and pretend to have recovered — we rethrow so the sweep logs the
- *      failure and asks for a restart, leaving the (bad but working) old
- *      handle in place rather than a null one that fails every write.
+ * So the close has to be a HARD one — {@link hardCloseDb}, in two steps that
+ * are both load-bearing:
+ *   1. FINALIZE every outstanding statement, explicitly. Every statement in
+ *      this module is created through {@link prep} and held in `stmtCache`
+ *      precisely so this step can exist: `finalizeCachedStatements()` releases
+ *      each `sqlite3_stmt` synchronously. This is the determinism. The earlier
+ *      version of this code had no cache and leaned on `Bun.gc(true)` to
+ *      collect the per-call wrappers, which is a coin flip: 13/20 failures with
+ *      an empty heap and 30/30 with an arithmetic loop before the gc.
+ *      `Bun.gc(true)` is still called, but only as belt-and-braces for a
+ *      statement some future caller creates outside the cache — correctness no
+ *      longer depends on it, and the test suite proves that by asserting the
+ *      reopen under the exact heap shape that made the gc-only version fail
+ *      every time.
+ *   2. `close(true)`, which THROWS rather than silently deferring. If we cannot
+ *      actually close we must NOT null `db` and pretend to have recovered — we
+ *      rethrow so the sweep logs the failure and asks for a restart, leaving
+ *      the (bad but working) old handle in place rather than a null one that
+ *      fails every write.
  *
  * NO EXPLICIT SALVAGE CHECKPOINT
  * ------------------------------
@@ -542,25 +654,82 @@ export function checkpointWal(): boolean {
  * fixups, retention, and `verifyHistoryWritable()` — a free post-reopen proof
  * that the new handle can actually persist a row.
  *
- * Throws if the hard close or the re-init fails. Callers must treat a throw as
- * "history is still broken, restart required".
+ * THREE FAILURE SHAPES, THREE DIFFERENT RESIDUAL STATES
+ * -----------------------------------------------------
+ * If the hard CLOSE throws, `db` is untouched: history is still lossy but
+ * functional, and the orphaned fds are still present so the sweep re-detects
+ * and retries on the next tick. If the close SUCCEEDS and the re-init throws,
+ * `db` is null and the orphaned fds are gone — the sweep's fd detector will
+ * never fire again — so that state is recorded in {@link historyReopenFailure}
+ * for the sweep to re-alarm on independently of detection. Without that flag a
+ * failed re-init is a permanent, silent history outage: strictly worse than the
+ * bug this whole path exists to fix. If the re-init succeeds but the SELF-CHECK
+ * fails, `db` is the new (readable, un-writable) handle: reads keep working,
+ * the flag is set, and the sweep keeps retrying — the state is dead for writes
+ * but there is no reason to also blind the read paths.
+ *
+ * Throws if the hard close, the re-init, or the post-reopen writer self-check
+ * fails. Callers must treat a throw as "history is still broken, restart
+ * required".
  */
 export function reopenHistory(stateDir: string, retentionDays = 30): void {
   const current = db
   if (current != null) {
-    // Reclaim the per-call prepared statements so the hard close below can
-    // actually run. Guarded: `Bun.gc` is Bun-only and this must not be the
-    // thing that throws.
-    const gc = (globalThis as { Bun?: { gc?: (force: boolean) => void } }).Bun?.gc
-    if (typeof gc === 'function') {
-      try { gc(true) } catch { /* best-effort; close(true) below reports the truth */ }
-    }
     // Deliberately NOT caught: a failed close means the fds are still open and
-    // a re-open would fail with SQLITE_IOERR_SHORT_READ. Propagate.
-    current.close(true)
+    // writes through the reopened handle would fail. Propagate with `db` intact.
+    hardCloseDb(current)
   }
   db = null
-  initHistory(stateDir, retentionDays)
+  try {
+    initHistory(stateDir, retentionDays)
+    // `initHistory` only WARNS when the self-check fails and returns normally,
+    // so without this the sweep would log "writes are durable again" on a full
+    // disk, right next to "WRITER SELF-CHECK FAILED". Prove it, don't claim it.
+    const check = verifyHistoryWritable()
+    if (!check.ok) {
+      throw new Error(`post-reopen writer self-check failed: ${check.error ?? 'unknown'}`)
+    }
+  } catch (err) {
+    historyReopenFailure = err instanceof Error ? err.message : String(err)
+    throw err
+  }
+  historyReopenFailure = null
+}
+
+/**
+ * Deterministically release a connection: finalize every statement this module
+ * owns, then hard-close.
+ *
+ * Exported for the sweep's own use and for tests that need to prove the close
+ * is real. `Bun.gc(true)` runs first as belt-and-braces for any statement
+ * created outside the cache (a future caller, or bun's own internal
+ * transaction statements); the finalize pass is what makes the close
+ * deterministic. `close(true)` is NOT caught — a deferred close is exactly the
+ * failure this function exists to surface.
+ */
+export function hardCloseDb(handle: SqliteDatabase): void {
+  finalizeCachedStatements()
+  const gc = (globalThis as { Bun?: { gc?: (force: boolean) => void } }).Bun?.gc
+  if (typeof gc === 'function') {
+    try { gc(true) } catch { /* best-effort; close(true) below reports the truth */ }
+  }
+  handle.close(true)
+}
+
+/**
+ * Sticky record of a reopen that closed the old handle successfully and then
+ * failed to re-init. Non-null means `db` is null and every read/write path is
+ * dead — a state nothing else in the process can detect, because the orphaned
+ * fds that triggered the reopen are gone.
+ *
+ * Read by the orphaned-DB sweep on EVERY tick, independently of fd detection,
+ * so the outage keeps alarming and keeps being retried.
+ */
+let historyReopenFailure: string | null = null
+
+/** The sticky reopen-failure message, or null when history is healthy. */
+export function getHistoryReopenFailure(): string | null {
+  return historyReopenFailure
 }
 
 /**
@@ -585,7 +754,7 @@ export function pruneMessagesOlderThanDays(
   if (db == null) return 0
   if (retentionDays <= 0) return 0
   const cutoffSec = (nowSec ?? Math.floor(Date.now() / 1000)) - retentionDays * 86400
-  const stmt = db.prepare(`
+  const stmt = prep(`
     DELETE FROM messages
     WHERE rowid IN (
       SELECT rowid FROM messages WHERE ts < ? LIMIT ?
@@ -660,7 +829,7 @@ export function recordInbound(args: RecordInboundArgs): void {
     )
     return
   }
-  const stmt = requireDb().prepare(`
+  const stmt = prep(`
     INSERT OR REPLACE INTO messages
       (chat_id, thread_id, message_id, role, user, user_id, ts, text, attachment_kind, group_id, reply_to_message_id, reply_to_text, forwarded_from, forwarded_from_type, forwarded_from_id, forwarded_date, forwarded_message_id)
     VALUES (?, ?, ?, 'user', ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?)
@@ -738,7 +907,7 @@ export function recordOutbound(args: RecordOutboundArgs): void {
   }
   if (validRows.length === 0) return
   const groupId = validRows[0]!.id
-  const stmt = requireDb().prepare(`
+  const stmt = prep(`
     INSERT OR REPLACE INTO messages
       (chat_id, thread_id, message_id, role, user, user_id, ts, text, attachment_kind, group_id)
     VALUES (?, ?, ?, 'assistant', NULL, NULL, ?, ?, ?, ?)
@@ -756,7 +925,7 @@ export function recordOutbound(args: RecordOutboundArgs): void {
   // (chat_id, message_id) — unique within a chat regardless of thread, the
   // same assumption `recordEdit` / `recordReaction` already make — makes the
   // promotion exact and is a no-op when no observer row exists.
-  const dropSystem = requireDb().prepare(
+  const dropSystem = prep(
     `DELETE FROM messages WHERE chat_id = ? AND message_id = ? AND role = 'system'`,
   )
   // bun:sqlite has a transaction() helper. Cheap insurance against partial
@@ -819,9 +988,8 @@ export function recordSystemOutbound(args: RecordSystemOutboundArgs): boolean {
   // blanket send observer, so a warn here would be one stderr line per API call.
   if (db == null) return false
   try {
-    const res = requireDb()
-      .prepare(`
-        INSERT INTO messages
+    const res = prep(`
+      INSERT INTO messages
           (chat_id, thread_id, message_id, role, user, user_id, ts, text, attachment_kind, group_id, kind)
         SELECT ?, ?, ?, 'system', NULL, NULL, ?, ?, NULL, NULL, ?
          WHERE NOT EXISTS (
@@ -865,11 +1033,9 @@ export function updateSystemOutboundText(args: {
   text: string
 }): boolean {
   try {
-    const res = requireDb()
-      .prepare(
-        `UPDATE messages SET text = ? WHERE chat_id = ? AND message_id = ? AND role = 'system'`,
-      )
-      .run(redact(args.text), args.chat_id, args.message_id) as { changes?: number }
+    const res = prep(
+      `UPDATE messages SET text = ? WHERE chat_id = ? AND message_id = ? AND role = 'system'`,
+    ).run(redact(args.text), args.chat_id, args.message_id) as { changes?: number }
     return (res?.changes ?? 0) > 0
   } catch {
     return false
@@ -893,12 +1059,11 @@ interface RecordEditArgs {
  * original send-time thread isn't known at edit time.
  */
 export function recordEdit(args: RecordEditArgs): void {
-  requireDb()
-    .prepare(`
-      UPDATE messages
-         SET text = ?
-       WHERE chat_id = ? AND message_id = ?
-    `)
+  prep(`
+    UPDATE messages
+       SET text = ?
+     WHERE chat_id = ? AND message_id = ?
+  `)
     // Same outbound chokepoint as recordOutbound — an edit must not
     // reintroduce a raw secret into the stored row.
     .run(redact(args.text), args.chat_id, args.message_id)
@@ -921,12 +1086,11 @@ export interface RecordReactionArgs {
  * we match on (chat_id, message_id) and ignore thread_id — same as recordEdit.
  */
 export function recordReaction(args: RecordReactionArgs): void {
-  requireDb()
-    .prepare(`
-      UPDATE messages
-         SET user_reaction = ?
-       WHERE chat_id = ? AND message_id = ?
-    `)
+  prep(`
+    UPDATE messages
+       SET user_reaction = ?
+     WHERE chat_id = ? AND message_id = ?
+  `)
     .run(args.emoji, args.chat_id, args.message_id)
 }
 
@@ -945,11 +1109,10 @@ export interface DeleteFromHistoryArgs {
  * we match on (chat_id, message_id) and ignore thread.
  */
 export function deleteFromHistory(args: DeleteFromHistoryArgs): void {
-  requireDb()
-    .prepare(`
-      DELETE FROM messages
-       WHERE chat_id = ? AND message_id = ?
-    `)
+  prep(`
+    DELETE FROM messages
+     WHERE chat_id = ? AND message_id = ?
+  `)
     .run(args.chat_id, args.message_id)
 }
 
@@ -1001,7 +1164,7 @@ export function getLatestInboundMessageId(
     }
   }
   sql += ' ORDER BY ts DESC, message_id DESC LIMIT 1'
-  const row = requireDb().prepare(sql).get(...params as any[]) as
+  const row = prep(sql).get(...params as any[]) as
     | { message_id: number }
     | undefined
   return row?.message_id ?? null
@@ -1035,11 +1198,17 @@ export function lookupMessageRoleAndText(
     includeSystem?: boolean
   },
 ): { role: MessageRole; text: string; kind: string | null } | null {
+  // History dead (a reopen that closed the old handle and failed to re-init) or
+  // never initialised → "no such row", which is the answer this caller already
+  // handles for a reaped message. A `requireDb()` throw would instead propagate
+  // into the reaction-trigger handler; the same degrade
+  // `hasOutboundDeliveredSince` / `hasOutboundWithText` already apply.
+  if (db == null) return null
   const sql =
     `SELECT role, text, kind FROM messages WHERE chat_id = ? AND message_id = ?` +
     (opts?.includeSystem === true ? '' : ` AND role <> 'system'`) +
     ` LIMIT 1`
-  const row = requireDb().prepare(sql).get(chatId, messageId) as
+  const row = prep(sql).get(chatId, messageId) as
     | { role: MessageRole; text: string | null; kind: string | null }
     | undefined
   if (!row) return null
@@ -1051,11 +1220,9 @@ export function getRecentOutboundCount(
   withinSeconds: number,
 ): number {
   const cutoff = Math.floor(Date.now() / 1000) - withinSeconds
-  const row = requireDb()
-    .prepare(
-      'SELECT COUNT(*) as cnt FROM messages WHERE chat_id = ? AND role = ? AND ts >= ?',
-    )
-    .get(chatId, 'assistant', cutoff) as { cnt: number } | undefined
+  const row = prep(
+    'SELECT COUNT(*) as cnt FROM messages WHERE chat_id = ? AND role = ? AND ts >= ?',
+  ).get(chatId, 'assistant', cutoff) as { cnt: number } | undefined
   return row?.cnt ?? 0
 }
 
@@ -1129,9 +1296,9 @@ export function hasOutboundDeliveredSince(
       }
     }
     sql += ' LIMIT 1'
-    const row = requireDb()
-      .prepare(sql)
-      .get(...(params as [unknown, ...unknown[]])) as Record<string, unknown> | undefined
+    const row = prep(sql).get(...(params as [unknown, ...unknown[]])) as
+      | Record<string, unknown>
+      | undefined
     return row != null
   } catch {
     return false
@@ -1209,9 +1376,9 @@ export function hasOutboundWithText(
     }
     // Newest first: a redelivery candidate's match is almost always recent.
     sql += ' ORDER BY ts DESC LIMIT 500'
-    const rows = requireDb()
-      .prepare(sql)
-      .all(...(params as [unknown, ...unknown[]])) as { text: string | null }[]
+    const rows = prep(sql).all(...(params as [unknown, ...unknown[]])) as {
+      text: string | null
+    }[]
     for (const r of rows) {
       const hay = normalizeDeliveryText(r.text ?? '')
       if (hay.length === 0) continue
@@ -1257,6 +1424,17 @@ export function deliveryTextMatch(hay: string, needle: string): boolean {
 }
 
 export function query(opts: QueryOptions): RecordedMessage[] {
+  // History dead or never initialised → no rows, the same result the caller
+  // gets from a genuinely empty chat. `get_recent_messages` degrades to "no
+  // history" instead of erroring the whole tool call; the operator-visible
+  // signal for the dead case is the sweep's sticky alarm, not this throw.
+  if (db == null) {
+    warnHistory(
+      'query: history DB is not open — returning no rows. If a reopen failed, the ' +
+        'orphaned-db-sweep is alarming about it every tick; RESTART the gateway.',
+    )
+    return []
+  }
   const limit = Math.min(MAX_LIMIT, Math.max(1, opts.limit ?? DEFAULT_LIMIT))
   const params: unknown[] = [opts.chat_id]
   let sql = 'SELECT * FROM messages WHERE chat_id = ?'
@@ -1276,7 +1454,7 @@ export function query(opts: QueryOptions): RecordedMessage[] {
   }
   sql += ' ORDER BY ts DESC, message_id DESC LIMIT ?'
   params.push(limit)
-  const rows = requireDb().prepare(sql).all(...params as any[]) as RecordedMessage[]
+  const rows = prep(sql).all(...params as any[]) as RecordedMessage[]
   // SELECT was DESC; flip to oldest-first for the caller.
   rows.reverse()
   return rows

--- a/telegram-plugin/tests/orphaned-db-sweep.test.ts
+++ b/telegram-plugin/tests/orphaned-db-sweep.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Outcome coverage for the orphaned-DB-fd sweep
+ * (`gateway/orphaned-db-sweep.ts` + `history.reopenHistory`).
+ *
+ * The core test REPRODUCES THE INCIDENT rather than mocking it: it opens a real
+ * history.db, checkpoints (standing in for the foreign process's exit
+ * checkpoint), unlinks the `-wal`/`-shm` out from under the live connection,
+ * and then proves both halves of the defect — the write still "succeeds", and
+ * the row is NOT in the on-disk database. No timers, no sleeps, no timing
+ * dependence.
+ *
+ * TWO MEASURED FACTS THIS TEST IS BUILT AROUND (both verified on bun 1.3.13,
+ * both of which invalidate the obvious way to write it):
+ *
+ *  1. During the orphan window a SECOND live connection to the same file cannot
+ *     be opened at all — it fails `SQLITE_IOERR_SHORT_READ`, because SQLite's
+ *     unix VFS keeps per-inode WAL-index state shared across connections in the
+ *     process. So the "is it on disk?" probe CANNOT be a second `new Database`
+ *     on the live path. It is instead a `snapshotOnDisk()` that copies
+ *     `history.db` (+ `-wal` when one exists) to a scratch dir and opens the
+ *     COPY — a different inode, and a faithful reading of what is durably on
+ *     disk. A separate PROCESS opening the original reads the same thing, which
+ *     is how we know the on-disk DB is not corrupt.
+ *
+ *  2. bun:sqlite's plain `db.close()` is a SOFT close that does not release the
+ *     fds while per-call prepared statements are un-finalized. `reopenHistory`
+ *     therefore does a hard close (`Bun.gc(true)` + `close(true)`); the
+ *     regression assertion for that is `detectOrphanedDbFds(stateDir)` being
+ *     EMPTY after recovery. A soft-close implementation leaves the deleted-inode
+ *     fds open and fails that assertion.
+ *
+ * WHAT CANNOT BE TESTED DETERMINISTICALLY HERE, and what covers it instead:
+ *
+ *  - The non-Linux early return in `detectOrphanedDbFds`. `/proc/self/fd` only
+ *    exists on Linux; the guard is a platform branch a Linux CI runner cannot
+ *    enter. Covered by code shape (a single `process.platform` check).
+ *  - The 5-minute production cadence. Asserted only as "the interval can be
+ *    started and stopped"; waiting 5 minutes would be a timing dependence, not
+ *    a proof.
+ *  - The `gateway.ts` wiring line. gateway.ts boots a live gateway on import
+ *    and is not unit-importable. Covered by `tsc --noEmit` for the call shape
+ *    and `check-gateway-line-ratchet` for the size budget.
+ *  - The no-corrupting-checkpoint property (that recovery never issues an
+ *    explicit WAL checkpoint through the orphaned handle). Enforced by CODE
+ *    SHAPE — there is no `wal_checkpoint` anywhere in `reopenHistory` — not by
+ *    an assertion. A test cannot distinguish a safe checkpoint from a
+ *    corrupting one without provoking real corruption.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, existsSync, unlinkSync, copyFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+// bun-only (this file is vitest-excluded and runs under `bun test`): the
+// on-disk snapshot probe, and the raw registry.db handle for the
+// detection-only lane.
+import { Database } from 'bun:sqlite'
+import {
+  initHistory,
+  reopenHistory,
+  recordInbound,
+  checkpointWal,
+  query,
+  verifyHistoryWritable,
+  _resetForTests,
+} from '../history.js'
+import {
+  detectOrphanedDbFds,
+  runOrphanedDbSweepTick,
+  startOrphanedDbSweep,
+} from '../gateway/orphaned-db-sweep.js'
+
+let stateDir: string
+const scratchDirs: string[] = []
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), 'orphaned-db-sweep-test-'))
+})
+
+afterEach(() => {
+  try { _resetForTests() } catch { /* an orphaned handle may refuse to close */ }
+  for (const d of scratchDirs.splice(0)) rmSync(d, { recursive: true, force: true })
+  if (existsSync(stateDir)) rmSync(stateDir, { recursive: true, force: true })
+})
+
+/**
+ * What a RESTART would see: copy the durable files to a scratch dir (a fresh
+ * inode, sidestepping the in-process WAL-index poisoning documented above) and
+ * read the copy. Deliberately does NOT go through the module singleton, whose
+ * writes may be landing in a deleted inode.
+ */
+function snapshotOnDisk(): number[] {
+  const dir = mkdtempSync(join(tmpdir(), 'orphaned-db-sweep-snap-'))
+  scratchDirs.push(dir)
+  const src = join(stateDir, 'history.db')
+  const dst = join(dir, 'history.db')
+  copyFileSync(src, dst)
+  if (existsSync(src + '-wal')) copyFileSync(src + '-wal', dst + '-wal')
+  const probe = new Database(dst)
+  try {
+    const rows = probe.prepare('SELECT message_id FROM messages ORDER BY message_id').all() as {
+      message_id: number
+    }[]
+    return rows.map((r) => r.message_id)
+  } finally {
+    probe.close()
+  }
+}
+
+/**
+ * `ts` must be recent — `initHistory`'s retention prune runs on every (re)open
+ * and would delete rows backdated past the retention window, which would make
+ * the post-reopen assertions lie.
+ */
+function inbound(messageId: number, text: string): void {
+  recordInbound({
+    chat_id: '900001',
+    thread_id: null,
+    message_id: messageId,
+    user: 'tester',
+    user_id: '900001',
+    ts: Math.floor(Date.now() / 1000),
+    text,
+  })
+}
+
+/** Unlink the WAL sidecars out from under the live connection, as the incident did. */
+function unlinkSidecars(dbFile: string): void {
+  for (const suffix of ['-wal', '-shm']) {
+    const f = dbFile + suffix
+    expect(existsSync(f)).toBe(true)
+    unlinkSync(f)
+  }
+}
+
+describe('orphaned-db-sweep — history.db recovery', () => {
+  it('reproduces the deleted-inode data loss and restores durable writes', () => {
+    const dbFile = join(stateDir, 'history.db')
+    initHistory(stateDir, 30)
+
+    // 1. A row that reaches the main DB via a checkpoint. The checkpoint stands
+    //    in for the foreign process's checkpoint-on-last-close.
+    inbound(1001, 'row A — before the unlink')
+    expect(checkpointWal()).toBe(true)
+
+    // 2. That foreign process's exit ALSO unlinked the sidecars. Our live
+    //    connection keeps the deleted inodes mapped.
+    unlinkSidecars(dbFile)
+
+    // 3. THE DEFECT, half one: the write path still reports success.
+    expect(() => inbound(1002, 'row B — into the deleted inode')).not.toThrow()
+
+    // 4. THE DEFECT, half two: row B never reached disk. What a restart would
+    //    see is A and NOT B. If SQLite's behaviour ever changes, the test's
+    //    premise fails loudly right here instead of passing vacuously.
+    expect(snapshotOnDisk()).toEqual([1001])
+
+    // 5. Detection sees the orphaned WAL handle.
+    const orphans = detectOrphanedDbFds(stateDir)
+    expect(orphans.length).toBeGreaterThan(0)
+    expect(orphans.some((o) => o.target.includes('history.db-wal'))).toBe(true)
+
+    // 6. The tick alarms loudly and reopens.
+    const lines: string[] = []
+    runOrphanedDbSweepTick({
+      stateDir,
+      reopenHistory: () => reopenHistory(stateDir, 30),
+      log: (l) => lines.push(l),
+    })
+    const log = lines.join('')
+    expect(log).toContain('LOST')
+    expect(log).toContain(`${dbFile}-wal`)
+    expect(log).toContain('reopened history.db')
+
+    // 7. THE FIX, half one: the deleted-inode handles are actually GONE. A soft
+    //    `close()` leaves them open (measured), so this is the assertion that
+    //    pins the hard close.
+    expect(detectOrphanedDbFds(stateDir)).toEqual([])
+
+    // 8. THE FIX, half two: writes are durable again — on disk, and visible to
+    //    a restart.
+    inbound(1003, 'row C — after the reopen')
+    expect(snapshotOnDisk()).toContain(1003)
+    expect(verifyHistoryWritable().ok).toBe(true)
+
+    // …and through the module's own read path after a full re-init, which is
+    // what `get_recent_messages` does on the next boot.
+    _resetForTests()
+    initHistory(stateDir, 30)
+    const texts = query({ chat_id: '900001', limit: 50 }).map((m) => m.text)
+    expect(texts).toContain('row C — after the reopen')
+  })
+
+  it('does not alarm on a healthy open DB with a live WAL', () => {
+    initHistory(stateDir, 30)
+    inbound(2001, 'healthy row')
+    // A live WAL exists and is held open — the ONLY difference from the orphan
+    // case is that it has not been unlinked.
+    expect(existsSync(join(stateDir, 'history.db-wal'))).toBe(true)
+    expect(detectOrphanedDbFds(stateDir)).toEqual([])
+
+    const lines: string[] = []
+    const orphans = runOrphanedDbSweepTick({ stateDir, log: (l) => lines.push(l) })
+    expect(orphans).toEqual([])
+    expect(lines).toEqual([])
+  })
+})
+
+describe('orphaned-db-sweep — registry.db lane', () => {
+  it('alarms and demands a restart without touching the registry handle', () => {
+    const registryFile = join(stateDir, 'registry.db')
+    const raw = new Database(registryFile, { create: true })
+    try {
+      raw.exec('PRAGMA journal_mode = WAL')
+      raw.exec('CREATE TABLE turns (id INTEGER PRIMARY KEY, note TEXT)')
+      raw.prepare('INSERT INTO turns (id, note) VALUES (?, ?)').run(1, 'before')
+      unlinkSidecars(registryFile)
+
+      const lines: string[] = []
+      // No reopenHistory wired: this lane must alarm off the state-dir prefix,
+      // not off the history.db filename.
+      const orphans = runOrphanedDbSweepTick({ stateDir, log: (l) => lines.push(l) })
+      expect(orphans.some((o) => o.target.includes('registry.db'))).toBe(true)
+      const log = lines.join('')
+      expect(log).toContain('registry.db')
+      expect(log).toContain('RESTART')
+
+      // Detection ONLY: the raw handle is left alone, so its consumers (the
+      // by-value `turnsDb` captures in gateway.ts) are never handed a closed DB.
+      expect(() =>
+        raw.prepare('INSERT INTO turns (id, note) VALUES (?, ?)').run(2, 'after'),
+      ).not.toThrow()
+    } finally {
+      raw.close()
+    }
+  })
+})
+
+describe('startOrphanedDbSweep', () => {
+  it('returns a stop() that clears the interval', () => {
+    const lines: string[] = []
+    const stop = startOrphanedDbSweep({ stateDir, log: (l) => lines.push(l), intervalMs: 5 })
+    expect(typeof stop).toBe('function')
+    expect(() => stop()).not.toThrow()
+  })
+})

--- a/telegram-plugin/tests/orphaned-db-sweep.test.ts
+++ b/telegram-plugin/tests/orphaned-db-sweep.test.ts
@@ -13,30 +13,53 @@
  * both of which invalidate the obvious way to write it):
  *
  *  1. During the orphan window a SECOND live connection to the same file cannot
- *     be opened at all — it fails `SQLITE_IOERR_SHORT_READ`, because SQLite's
- *     unix VFS keeps per-inode WAL-index state shared across connections in the
- *     process. So the "is it on disk?" probe CANNOT be a second `new Database`
- *     on the live path. It is instead a `snapshotOnDisk()` that copies
- *     `history.db` (+ `-wal` when one exists) to a scratch dir and opens the
- *     COPY — a different inode, and a faithful reading of what is durably on
- *     disk. A separate PROCESS opening the original reads the same thing, which
- *     is how we know the on-disk DB is not corrupt.
+ *     be READ from — SQLite's unix VFS keeps per-inode WAL-index state shared
+ *     across connections in the process. So the "is it on disk?" probe CANNOT
+ *     be a second `new Database` on the live path. It is instead a
+ *     `snapshotOnDisk()` that copies `history.db` (+ `-wal` when one exists) to
+ *     a scratch dir and opens the COPY — a different inode, and a faithful
+ *     reading of what is durably on disk. A separate PROCESS opening the
+ *     original reads the same thing, which is how we know the on-disk DB is not
+ *     corrupt.
  *
  *  2. bun:sqlite's plain `db.close()` is a SOFT close that does not release the
- *     fds while per-call prepared statements are un-finalized. `reopenHistory`
- *     therefore does a hard close (`Bun.gc(true)` + `close(true)`); the
+ *     fds while prepared statements are un-finalized. `hardCloseDb` therefore
+ *     FINALIZES every cached statement and then calls `close(true)`; the
  *     regression assertion for that is `detectOrphanedDbFds(stateDir)` being
- *     EMPTY after recovery. A soft-close implementation leaves the deleted-inode
- *     fds open and fails that assertion.
+ *     EMPTY after recovery.
+ *
+ * WHY THERE IS A DETERMINISM TEST UNDER AN ADVERSARIAL HEAP
+ * --------------------------------------------------------
+ * The first cut of this recovery leaned on `Bun.gc(true)` to make the
+ * un-finalized per-call statements collectable before `close(true)`. Measured
+ * on bun 1.3.13, that is NOT deterministic: with an essentially empty heap a
+ * single gc+close failed 13 times in 20, and with an ordinary arithmetic loop
+ * running between the writes and the close it failed 30 times in 30. The fix is
+ * the module-level statement cache in `history.ts`, whose entries are explicitly
+ * `.finalize()`d by `hardCloseDb`; with it, the same 30-iteration adversarial
+ * shape fails 0 times in 30 — and still 0 in 30 with `Bun.gc(true)` deleted
+ * entirely, which is the proof that the cache and not the gc is what makes the
+ * close deterministic. `'reopens deterministically under the heap shape that
+ * broke the gc-only version'` below is that measurement, pinned.
+ *
+ * NOTE ON THE `close(true)` ARGUMENT. A mutation of `close(true)` →
+ * `close()` inside `hardCloseDb` SURVIVES the incident-reproduction test: once
+ * every statement is finalized the soft close releases the fds too, so the
+ * integration test genuinely cannot see the difference. The `true` (throw on a
+ * still-busy handle) is an HONESTY property — never report a recovery that did
+ * not happen — so it is pinned one level down, on `hardCloseDb` itself, in the
+ * `describe('hardCloseDb')` block with a handle double.
  *
  * WHAT CANNOT BE TESTED DETERMINISTICALLY HERE, and what covers it instead:
  *
  *  - The non-Linux early return in `detectOrphanedDbFds`. `/proc/self/fd` only
  *    exists on Linux; the guard is a platform branch a Linux CI runner cannot
- *    enter. Covered by code shape (a single `process.platform` check).
- *  - The 5-minute production cadence. Asserted only as "the interval can be
- *    started and stopped"; waiting 5 minutes would be a timing dependence, not
- *    a proof.
+ *    enter. Every `/proc`-dependent block below is `describe.skipIf`-guarded so
+ *    a macOS developer gets a skip, not a spurious pass.
+ *  - The 5-minute production cadence. The interval itself IS asserted (see
+ *    `describe('startOrphanedDbSweep')`, which samples log output before and
+ *    after `stop()` at a 5ms cadence); only the specific 5-minute default is
+ *    left to code shape, since waiting for it would be a timing dependence.
  *  - The `gateway.ts` wiring line. gateway.ts boots a live gateway on import
  *    and is not unit-importable. Covered by `tsc --noEmit` for the call shape
  *    and `check-gateway-line-ratchet` for the size budget.
@@ -48,9 +71,19 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, existsSync, unlinkSync, copyFileSync } from 'fs'
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  unlinkSync,
+  copyFileSync,
+  openSync,
+  closeSync,
+  writeFileSync,
+  symlinkSync,
+} from 'fs'
 import { tmpdir } from 'os'
-import { join } from 'path'
+import { basename, join } from 'path'
 // bun-only (this file is vitest-excluded and runs under `bun test`): the
 // on-disk snapshot probe, and the raw registry.db handle for the
 // detection-only lane.
@@ -58,9 +91,13 @@ import { Database } from 'bun:sqlite'
 import {
   initHistory,
   reopenHistory,
+  hardCloseDb,
+  getHistoryReopenFailure,
   recordInbound,
+  recordOutbound,
   checkpointWal,
   query,
+  lookupMessageRoleAndText,
   verifyHistoryWritable,
   _resetForTests,
 } from '../history.js'
@@ -69,9 +106,20 @@ import {
   runOrphanedDbSweepTick,
   startOrphanedDbSweep,
 } from '../gateway/orphaned-db-sweep.js'
+import { GATEWAY_SIGNATURES } from '../../src/fleet-health/detect.js'
+
+/**
+ * `/proc/self/fd` is Linux-only. Without this guard every detection test would
+ * pass VACUOUSLY on macOS — `detectOrphanedDbFds` returns `[]` there by design,
+ * so `expect(...).toEqual([])` is satisfied by the platform, not the code.
+ */
+const onLinux = process.platform === 'linux'
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
 
 let stateDir: string
 const scratchDirs: string[] = []
+const openFds: number[] = []
 
 beforeEach(() => {
   stateDir = mkdtempSync(join(tmpdir(), 'orphaned-db-sweep-test-'))
@@ -79,9 +127,19 @@ beforeEach(() => {
 
 afterEach(() => {
   try { _resetForTests() } catch { /* an orphaned handle may refuse to close */ }
+  for (const fd of openFds.splice(0)) {
+    try { closeSync(fd) } catch { /* already gone */ }
+  }
   for (const d of scratchDirs.splice(0)) rmSync(d, { recursive: true, force: true })
   if (existsSync(stateDir)) rmSync(stateDir, { recursive: true, force: true })
 })
+
+/** A second temp dir, torn down with the test. */
+function scratch(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  scratchDirs.push(dir)
+  return dir
+}
 
 /**
  * What a RESTART would see: copy the durable files to a scratch dir (a fresh
@@ -90,8 +148,7 @@ afterEach(() => {
  * writes may be landing in a deleted inode.
  */
 function snapshotOnDisk(): number[] {
-  const dir = mkdtempSync(join(tmpdir(), 'orphaned-db-sweep-snap-'))
-  scratchDirs.push(dir)
+  const dir = scratch('orphaned-db-sweep-snap-')
   const src = join(stateDir, 'history.db')
   const dst = join(dir, 'history.db')
   copyFileSync(src, dst)
@@ -133,8 +190,67 @@ function unlinkSidecars(dbFile: string): void {
   }
 }
 
-describe('orphaned-db-sweep — history.db recovery', () => {
-  it('reproduces the deleted-inode data loss and restores durable writes', () => {
+/**
+ * Create a file, hold an fd on it, and unlink it — a deleted-inode fd that is
+ * NOT a database. The sweep must ignore it.
+ */
+function orphanNonDbFile(path: string): void {
+  writeFileSync(path, 'x')
+  openFds.push(openSync(path, 'r'))
+  unlinkSync(path)
+}
+
+/**
+ * Seed a `history.db` whose schema is entirely valid — every DDL statement,
+ * migration and index in `initHistory` succeeds against it — but whose
+ * `messages` table REJECTS the writer self-check's sentinel row.
+ *
+ * This is the only shape that separates "the DB opened and the schema is
+ * there" from "a row can actually be persisted", which is exactly the gap the
+ * post-reopen self-check exists to close: `initHistory` only WARNS when its own
+ * self-check fails and returns normally, so without the gate `reopenHistory`
+ * returns success on a DB that cannot take a write and the sweep logs "writes
+ * are durable again" on top of "WRITER SELF-CHECK FAILED". Uses a CHECK
+ * constraint rather than filesystem permissions deliberately: the test suite
+ * runs as root in some containers, where a chmod-based read-only fixture is
+ * silently bypassed and the test passes for the wrong reason.
+ */
+function seedSelfCheckPoisonedDb(): void {
+  const raw = new Database(join(stateDir, 'history.db'), { create: true })
+  try {
+    raw.exec(`
+      CREATE TABLE messages (
+        chat_id        TEXT    NOT NULL,
+        thread_id      INTEGER,
+        message_id     INTEGER NOT NULL,
+        role           TEXT    NOT NULL,
+        user           TEXT,
+        user_id        TEXT,
+        ts             INTEGER NOT NULL,
+        text           TEXT    NOT NULL,
+        attachment_kind TEXT,
+        group_id       INTEGER,
+        reply_to_message_id INTEGER,
+        reply_to_text  TEXT,
+        kind           TEXT,
+        PRIMARY KEY (chat_id, thread_id, message_id),
+        CHECK (text <> 'selfcheck')
+      )
+    `)
+  } finally {
+    raw.close(false)
+  }
+}
+
+/** The sorted bare file names behind a set of orphans, for exact-set assertions. */
+function orphanNames(orphans: { target: string }[]): string[] {
+  return orphans
+    .map((o) => basename(o.target.replace(/ \(deleted\)$/, '')))
+    .sort()
+}
+
+describe.skipIf(!onLinux)('orphaned-db-sweep — history.db recovery', () => {
+  it('reproduces the deleted-inode data loss and restores durable writes', async () => {
     const dbFile = join(stateDir, 'history.db')
     initHistory(stateDir, 30)
 
@@ -155,14 +271,15 @@ describe('orphaned-db-sweep — history.db recovery', () => {
     //    premise fails loudly right here instead of passing vacuously.
     expect(snapshotOnDisk()).toEqual([1001])
 
-    // 5. Detection sees the orphaned WAL handle.
-    const orphans = detectOrphanedDbFds(stateDir)
-    expect(orphans.length).toBeGreaterThan(0)
-    expect(orphans.some((o) => o.target.includes('history.db-wal'))).toBe(true)
+    // 5. Detection sees BOTH orphaned handles. The real incident had two
+    //    (`-wal` and `-shm`); asserting the exact set means a detector that
+    //    returns only the first one fails here.
+    const orphans = await detectOrphanedDbFds(stateDir)
+    expect(orphanNames(orphans)).toEqual(['history.db-shm', 'history.db-wal'])
 
     // 6. The tick alarms loudly and reopens.
     const lines: string[] = []
-    runOrphanedDbSweepTick({
+    await runOrphanedDbSweepTick({
       stateDir,
       reopenHistory: () => reopenHistory(stateDir, 30),
       log: (l) => lines.push(l),
@@ -172,16 +289,22 @@ describe('orphaned-db-sweep — history.db recovery', () => {
     expect(log).toContain(`${dbFile}-wal`)
     expect(log).toContain('reopened history.db')
 
-    // 7. THE FIX, half one: the deleted-inode handles are actually GONE. A soft
-    //    `close()` leaves them open (measured), so this is the assertion that
-    //    pins the hard close.
-    expect(detectOrphanedDbFds(stateDir)).toEqual([])
+    // …and the fleet-health L0 detector actually matches that alarm. Without
+    // this the signature and the log line drift apart silently and the
+    // alarm has no consumer.
+    expect(GATEWAY_SIGNATURES['orphaned-db-handle'].test(log)).toBe(true)
+
+    // 7. THE FIX, half one: the deleted-inode handles are actually GONE. A
+    //    close that leaves un-finalized statements behind leaves them open
+    //    (measured), so this is the assertion that pins the hard close.
+    expect(await detectOrphanedDbFds(stateDir)).toEqual([])
 
     // 8. THE FIX, half two: writes are durable again — on disk, and visible to
-    //    a restart.
+    //    a restart. And nothing is stuck.
     inbound(1003, 'row C — after the reopen')
     expect(snapshotOnDisk()).toContain(1003)
     expect(verifyHistoryWritable().ok).toBe(true)
+    expect(getHistoryReopenFailure()).toBeNull()
 
     // …and through the module's own read path after a full re-init, which is
     // what `get_recent_messages` does on the next boot.
@@ -191,23 +314,114 @@ describe('orphaned-db-sweep — history.db recovery', () => {
     expect(texts).toContain('row C — after the reopen')
   })
 
-  it('does not alarm on a healthy open DB with a live WAL', () => {
+  it('does not alarm on a healthy open DB with a live WAL', async () => {
     initHistory(stateDir, 30)
     inbound(2001, 'healthy row')
     // A live WAL exists and is held open — the ONLY difference from the orphan
     // case is that it has not been unlinked.
     expect(existsSync(join(stateDir, 'history.db-wal'))).toBe(true)
-    expect(detectOrphanedDbFds(stateDir)).toEqual([])
+    expect(await detectOrphanedDbFds(stateDir)).toEqual([])
 
     const lines: string[] = []
-    const orphans = runOrphanedDbSweepTick({ stateDir, log: (l) => lines.push(l) })
+    const orphans = await runOrphanedDbSweepTick({ stateDir, log: (l) => lines.push(l) })
     expect(orphans).toEqual([])
     expect(lines).toEqual([])
   })
+
+  it('reopens deterministically under the heap shape that broke the gc-only version', () => {
+    // The measured adversarial shape: real writes (which leave statements
+    // behind) plus ordinary arithmetic between the writes and the close. The
+    // gc-only implementation failed this 30/30; the statement cache passes it
+    // even with the gc removed. Twelve iterations keeps the test under a second
+    // while still being far past the 13/20 failure rate of the empty-heap case
+    // — a regression to gc-dependence cannot survive twelve rolls.
+    for (let i = 0; i < 12; i++) {
+      initHistory(stateDir, 30)
+      inbound(3000 + i, `row ${i}`)
+      recordOutbound({
+        chat_id: '900001',
+        thread_id: null,
+        message_ids: [4000 + i],
+        texts: [`reply ${i}`],
+      })
+      checkpointWal()
+      let churn = 0
+      for (let j = 0; j < 500_000; j++) churn += j % 7
+      expect(churn).toBeGreaterThan(0)
+      expect(() => reopenHistory(stateDir, 30)).not.toThrow()
+      expect(verifyHistoryWritable().ok).toBe(true)
+    }
+  })
 })
 
-describe('orphaned-db-sweep — registry.db lane', () => {
-  it('alarms and demands a restart without touching the registry handle', () => {
+describe.skipIf(!onLinux)('orphaned-db-sweep — detection filters', () => {
+  it('ignores deleted non-DB files in the state dir', async () => {
+    // `basename.includes('.db')` matched every one of these.
+    orphanNonDbFile(join(stateDir, 'scratch.tmp'))
+    orphanNonDbFile(join(stateDir, 'notes.dbg'))
+    orphanNonDbFile(join(stateDir, 'dump.dbf'))
+    orphanNonDbFile(join(stateDir, 'history.db.bak'))
+    orphanNonDbFile(join(stateDir, 'session.dbus'))
+
+    expect(await detectOrphanedDbFds(stateDir)).toEqual([])
+
+    const lines: string[] = []
+    await runOrphanedDbSweepTick({ stateDir, log: (l) => lines.push(l) })
+    expect(lines).toEqual([])
+  })
+
+  it('ignores a deleted DB outside the state dir', async () => {
+    // A SECOND temp dir, so the filtering is done by the prefix test and not
+    // by "there happen to be no orphaned fds at all".
+    const elsewhere = scratch('orphaned-db-sweep-elsewhere-')
+    const foreign = join(elsewhere, 'foreign.db')
+    const raw = new Database(foreign, { create: true })
+    try {
+      raw.exec('PRAGMA journal_mode = WAL')
+      raw.exec('CREATE TABLE t (id INTEGER PRIMARY KEY)')
+      raw.prepare('INSERT INTO t (id) VALUES (?)').run(1)
+      unlinkSidecars(foreign)
+
+      // The orphan is real and detectable — from its OWN dir…
+      expect(orphanNames(await detectOrphanedDbFds(elsewhere)))
+        .toEqual(['foreign.db-shm', 'foreign.db-wal'])
+      // …and invisible from ours.
+      expect(await detectOrphanedDbFds(stateDir)).toEqual([])
+    } finally {
+      raw.close(false)
+    }
+  })
+
+  it('detects through a symlinked state dir', async () => {
+    // `/proc/self/fd` targets are always fully resolved. Comparing them
+    // against an unresolved `TELEGRAM_STATE_DIR` disables detection silently
+    // and forever — the worst possible failure for a data-loss detector.
+    const linkParent = scratch('orphaned-db-sweep-link-')
+    const link = join(linkParent, 'state-link')
+    symlinkSync(stateDir, link)
+
+    initHistory(stateDir, 30)
+    inbound(5001, 'row via symlink')
+    checkpointWal()
+    unlinkSidecars(join(stateDir, 'history.db'))
+
+    expect(orphanNames(await detectOrphanedDbFds(link)))
+      .toEqual(['history.db-shm', 'history.db-wal'])
+  })
+
+  it('warns rather than reporting healthy when the state dir cannot be resolved', async () => {
+    const missing = join(stateDir, 'does-not-exist')
+    const lines: string[] = []
+    const orphans = await runOrphanedDbSweepTick({ stateDir: missing, log: (l) => lines.push(l) })
+    expect(orphans).toEqual([])
+    const log = lines.join('')
+    expect(log).toContain('cannot resolve stateDir')
+    expect(log).toContain('DISABLED')
+  })
+})
+
+describe.skipIf(!onLinux)('orphaned-db-sweep — registry.db and unowned lanes', () => {
+  it('alarms and demands a restart without touching the registry handle', async () => {
     const registryFile = join(stateDir, 'registry.db')
     const raw = new Database(registryFile, { create: true })
     try {
@@ -219,11 +433,12 @@ describe('orphaned-db-sweep — registry.db lane', () => {
       const lines: string[] = []
       // No reopenHistory wired: this lane must alarm off the state-dir prefix,
       // not off the history.db filename.
-      const orphans = runOrphanedDbSweepTick({ stateDir, log: (l) => lines.push(l) })
-      expect(orphans.some((o) => o.target.includes('registry.db'))).toBe(true)
+      const orphans = await runOrphanedDbSweepTick({ stateDir, log: (l) => lines.push(l) })
+      expect(orphanNames(orphans)).toEqual(['registry.db-shm', 'registry.db-wal'])
       const log = lines.join('')
       expect(log).toContain('registry.db')
       expect(log).toContain('RESTART')
+      expect(GATEWAY_SIGNATURES['orphaned-db-handle'].test(log)).toBe(true)
 
       // Detection ONLY: the raw handle is left alone, so its consumers (the
       // by-value `turnsDb` captures in gateway.ts) are never handed a closed DB.
@@ -231,16 +446,268 @@ describe('orphaned-db-sweep — registry.db lane', () => {
         raw.prepare('INSERT INTO turns (id, note) VALUES (?, ?)').run(2, 'after'),
       ).not.toThrow()
     } finally {
-      raw.close()
+      raw.close(false)
+    }
+  })
+
+  it('names an unowned state-dir DB instead of raising a lane-less data-loss alarm', async () => {
+    const grants = join(stateDir, 'grants.db')
+    const raw = new Database(grants, { create: true })
+    try {
+      raw.exec('PRAGMA journal_mode = WAL')
+      raw.exec('CREATE TABLE g (id INTEGER PRIMARY KEY)')
+      raw.prepare('INSERT INTO g (id) VALUES (?)').run(1)
+      unlinkSidecars(grants)
+
+      const lines: string[] = []
+      await runOrphanedDbSweepTick({
+        stateDir,
+        reopenHistory: () => { throw new Error('history lane must not run') },
+        log: (l) => lines.push(l),
+      })
+      const log = lines.join('')
+      expect(log).toContain('grants.db-wal')
+      expect(log).toContain('no recovery lane owns')
+      expect(log).toContain('RESTART')
+      // The history lane is wired but must NOT have fired for a foreign DB.
+      expect(log).not.toContain('history.db')
+    } finally {
+      raw.close(false)
     }
   })
 })
 
-describe('startOrphanedDbSweep', () => {
-  it('returns a stop() that clears the interval', () => {
+describe.skipIf(!onLinux)('orphaned-db-sweep — reopen failure lanes', () => {
+  it('reports a failed reopen honestly instead of claiming recovery', async () => {
+    initHistory(stateDir, 30)
+    inbound(6001, 'row before the unlink')
+    checkpointWal()
+    unlinkSidecars(join(stateDir, 'history.db'))
+
     const lines: string[] = []
-    const stop = startOrphanedDbSweep({ stateDir, log: (l) => lines.push(l), intervalMs: 5 })
-    expect(typeof stop).toBe('function')
-    expect(() => stop()).not.toThrow()
+    await runOrphanedDbSweepTick({
+      stateDir,
+      reopenHistory: () => { throw new Error('boom') },
+      log: (l) => lines.push(l),
+    })
+    const log = lines.join('')
+    expect(log).toContain('FAILED to reopen history.db')
+    expect(log).toContain('boom')
+    expect(log).toContain('RESTART')
+    // The success line must be gated on the reopen actually succeeding.
+    expect(log).not.toContain('writes are durable again')
+  })
+
+  it('says a history reopen is not wired when history is disabled', async () => {
+    initHistory(stateDir, 30)
+    inbound(6101, 'row before the unlink')
+    checkpointWal()
+    unlinkSidecars(join(stateDir, 'history.db'))
+
+    const lines: string[] = []
+    await runOrphanedDbSweepTick({ stateDir, reopenHistory: undefined, log: (l) => lines.push(l) })
+    const log = lines.join('')
+    expect(log).toContain('no reopen')
+    expect(log).toContain('RESTART')
+    expect(log).not.toContain('writes are durable again')
+  })
+
+  it('keeps alarming on a sticky reopen failure after the fds are gone', async () => {
+    // The nastiest shape: the close SUCCEEDED (fds released) and the re-init
+    // FAILED. There is no fd evidence left, so a purely fd-driven sweep would
+    // report healthy forever while every history read and write is dead.
+    let stuck: string | null = 'disk full'
+    const lines: string[] = []
+    const opts = {
+      stateDir,
+      reopenHistory: () => { throw new Error('still broken') },
+      historyReopenFailure: () => stuck,
+      log: (l: string) => lines.push(l),
+    }
+    expect(await detectOrphanedDbFds(stateDir)).toEqual([])
+
+    await runOrphanedDbSweepTick(opts)
+    await runOrphanedDbSweepTick(opts)
+    const log = lines.join('')
+    expect(log.match(/history\.db is CLOSED/g)?.length).toBe(2)
+    expect(log).toContain('disk full')
+
+    // …and goes quiet the moment the flag clears, so it cannot become noise
+    // the operator learns to ignore.
+    stuck = null
+    lines.length = 0
+    await runOrphanedDbSweepTick(opts)
+    expect(lines).toEqual([])
+  })
+
+  it('recovers off the sticky flag with no orphaned fd to trigger it', async () => {
+    initHistory(stateDir, 30)
+    const lines: string[] = []
+    await runOrphanedDbSweepTick({
+      stateDir,
+      reopenHistory: () => reopenHistory(stateDir, 30),
+      historyReopenFailure: () => 'previous reopen failed',
+      log: (l) => lines.push(l),
+    })
+    const log = lines.join('')
+    expect(log).toContain('history.db is CLOSED')
+    expect(log).toContain('recovered history.db')
+    expect(log).toContain('writes are durable again')
+    expect(getHistoryReopenFailure()).toBeNull()
+    expect(verifyHistoryWritable().ok).toBe(true)
+  })
+
+  it('refuses to call a reopen successful when the reopened DB cannot take a write', async () => {
+    seedSelfCheckPoisonedDb()
+    initHistory(stateDir, 30) // warns about the self-check, returns normally
+
+    expect(() => reopenHistory(stateDir, 30)).toThrow('post-reopen writer self-check failed')
+
+    // …and the sweep repeats that honestly rather than announcing durability.
+    const lines: string[] = []
+    await runOrphanedDbSweepTick({
+      stateDir,
+      reopenHistory: () => reopenHistory(stateDir, 30),
+      historyReopenFailure: getHistoryReopenFailure,
+      log: (l) => lines.push(l),
+    })
+    const log = lines.join('')
+    expect(log).toContain('FAILED to reopen history.db')
+    expect(log).not.toContain('writes are durable again')
+  })
+
+  it('clears the sticky failure once a later reopen genuinely succeeds', async () => {
+    seedSelfCheckPoisonedDb()
+    initHistory(stateDir, 30)
+    expect(() => reopenHistory(stateDir, 30)).toThrow()
+    expect(getHistoryReopenFailure()).toContain('post-reopen writer self-check failed')
+
+    // Repair the underlying cause (drop the poisoned file; the still-open
+    // handle onto it becomes an orphan, which is the sweep's other trigger)
+    // and let a tick recover.
+    for (const suffix of ['', '-wal', '-shm']) {
+      const f = join(stateDir, 'history.db' + suffix)
+      if (existsSync(f)) unlinkSync(f)
+    }
+    const lines: string[] = []
+    await runOrphanedDbSweepTick({
+      stateDir,
+      reopenHistory: () => reopenHistory(stateDir, 30),
+      historyReopenFailure: getHistoryReopenFailure,
+      log: (l) => lines.push(l),
+    })
+    expect(lines.join('')).toContain('writes are durable again')
+
+    // A flag that never clears turns the recovered state into a permanent
+    // alarm — the operator learns to ignore it, and the next real outage is
+    // invisible. The next tick must be silent.
+    expect(getHistoryReopenFailure()).toBeNull()
+    lines.length = 0
+    await runOrphanedDbSweepTick({
+      stateDir,
+      reopenHistory: () => reopenHistory(stateDir, 30),
+      historyReopenFailure: getHistoryReopenFailure,
+      log: (l) => lines.push(l),
+    })
+    expect(lines).toEqual([])
+  })
+
+  it('degrades reads to empty instead of throwing when history is dead', () => {
+    initHistory(stateDir, 30)
+    inbound(6201, 'row before the outage')
+
+    // Make the re-init genuinely impossible: replace the state DIR with a FILE
+    // so `initHistory`'s mkdir throws. The close still succeeds, so this is the
+    // real end-to-end shape of the sticky failure, not a stub.
+    rmSync(stateDir, { recursive: true, force: true })
+    writeFileSync(stateDir, 'not a directory')
+
+    expect(() => reopenHistory(stateDir, 30)).toThrow()
+    expect(getHistoryReopenFailure()).not.toBeNull()
+
+    // The read paths degrade instead of exploding through their callers.
+    expect(query({ chat_id: '900001', limit: 10 })).toEqual([])
+    expect(lookupMessageRoleAndText('900001', 6201)).toBeNull()
+
+    unlinkSync(stateDir)
+  })
+})
+
+describe('hardCloseDb', () => {
+  /**
+   * A `Database` double with bun's close semantics: `close(true)` throws when
+   * statements are still outstanding, `close()` (soft) never does. This is
+   * where the `true` argument is pinned — see the note in the file header for
+   * why the integration test cannot see it.
+   */
+  function fakeHandle(busy: boolean) {
+    const calls: (boolean | undefined)[] = []
+    return {
+      calls,
+      close(throwOnError?: boolean) {
+        calls.push(throwOnError)
+        if (throwOnError === true && busy) throw new Error('database is locked')
+      },
+      prepare() { throw new Error('unused') },
+      exec() { throw new Error('unused') },
+    }
+  }
+
+  it('closes with throwOnError so a stuck handle cannot be reported as recovered', () => {
+    const handle = fakeHandle(false)
+    hardCloseDb(handle as never)
+    // `close()` / `close(false)` would silently leave a busy handle behind and
+    // let the caller log "writes are durable again".
+    expect(handle.calls).toEqual([true])
+  })
+
+  it('propagates a close failure rather than swallowing it', () => {
+    const handle = fakeHandle(true)
+    expect(() => hardCloseDb(handle as never)).toThrow('database is locked')
+  })
+
+  it('finalizes every cached statement before closing', () => {
+    // The real determinism proof: after a hard close, re-opening and writing
+    // must work, which requires the cache to have been dropped along with the
+    // finalized statements. A cache that survived the close would hand the new
+    // connection statements bound to the old one.
+    initHistory(stateDir, 30)
+    inbound(7001, 'cached statement holder')
+    expect(verifyHistoryWritable().ok).toBe(true)
+    expect(() => reopenHistory(stateDir, 30)).not.toThrow()
+    expect(verifyHistoryWritable().ok).toBe(true)
+    expect(query({ chat_id: '900001', limit: 10 }).map((m) => m.message_id)).toEqual([7001])
+  })
+})
+
+describe('startOrphanedDbSweep', () => {
+  it('stops ticking after stop() is called', async () => {
+    // A sticky failure with no reopen wired makes every tick emit exactly one
+    // line, so the log line count IS the tick count — an observable the
+    // interval must actually drive.
+    const lines: string[] = []
+    const stop = startOrphanedDbSweep({
+      stateDir,
+      historyReopenFailure: () => 'stuck',
+      log: (l) => lines.push(l),
+      intervalMs: 5,
+    })
+    // Poll to a generous deadline rather than sampling a fixed window: under a
+    // loaded CI runner a 5ms interval can be starved, and a flaky assertion on
+    // a real property is worse than a slow one.
+    const deadline = Date.now() + 5_000
+    while (lines.length < 3 && Date.now() < deadline) await sleep(5)
+    // Multiple ticks: proves the interval repeats, not just fires once.
+    expect(lines.length).toBeGreaterThan(1)
+
+    stop()
+    // A tick is async, so one may be in flight when stop() lands. Let it settle
+    // before snapshotting — the property under test is "no NEW ticks start",
+    // not "no line is ever appended after the stop() call returns".
+    await sleep(60)
+    const atStop = lines.length
+    await sleep(250)
+    // A stop() that did not clear the interval would add ~50 more lines here.
+    expect(lines.length).toBe(atStop)
   })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -176,6 +176,10 @@ export default defineConfig({
       // PR #994.
       "**/telegram-plugin/uat/**",
       "**/telegram-plugin/tests/history.test.ts",
+      // orphaned-db-sweep.test.ts unlinks a live history.db `-wal`/`-shm` out
+      // from under an open bun:sqlite handle and probes the on-disk rows with a
+      // second bun:sqlite connection — excluded here, run via bun.
+      "**/telegram-plugin/tests/orphaned-db-sweep.test.ts",
       // reply-to-buffer-history.test.ts seeds a real history.db via bun:sqlite
       // (recordOutbound → lookup → recordInbound) — excluded here, run via bun.
       "**/telegram-plugin/tests/reply-to-buffer-history.test.ts",


### PR DESCRIPTION
## Summary

The gateway holds `history.db` (bun:sqlite, WAL) open for the process lifetime. A foreign process rw-opened the same DB and, exiting as the last connection, checkpointed and **unlinked** `history.db-wal` / `-shm`. Our handle kept the deleted inodes mapped and kept writing into them for **3h06m**, logging a successful insert every time. The rows were never on disk; they vanished at the next restart. Signature:

```
/proc/<pid>/fd/13 -> history.db-wal (deleted)
```

New `telegram-plugin/gateway/orphaned-db-sweep.ts` walks `/proc/self/fd` every 5 minutes for a state-dir `*.db*` target marked `(deleted)`. On a hit it logs loudly that rows since the last checkpoint are LOST, then:

- **`history.db`** — `reopenHistory()` hard-closes and re-inits in place, and the success line is emitted only after a post-reopen writer self-check passes.
- **`registry.db`** — alarm only, RESTART REQUIRED. `turnsDb` is captured *by value* into long-lived wiring (`gateway.ts` options object, subagent-watcher), so close-and-reassign would strand those consumers on a closed handle. Detection without action is the honest behaviour.
- **anything else `*.db` in the state dir** — alarm only, named, RESTART REQUIRED. No lane owns it, so it gets an instruction rather than a bare data-loss alarm.
- **history already closed after a failed reopen** — re-alarm and retry off a sticky flag, every tick, with no fd evidence left to detect (see below).

Fleet-health gains an `orphaned-db-handle` L0 signal (`severity 3`, `success-theater`, `survive-reboots-and-real-life`) anchored on the DETECTED line, which every lane emits — so the registry alarm, which has no in-process recovery at all, reaches a human.

`gateway.ts` gains **0 net lines** (2 modified: the import and the existing registration one-liner); the logic lives in the new module. Ratchet: 24853 vs ceiling 24805 + slack 50.

## Why

Nothing in the write path can notice this failure mode: `INSERT` returns success, the boot-time `verifyHistoryWritable()` self-check ran hours earlier, and a WAL checkpoint through the stale mapping "succeeds" too. The only in-process evidence is the fd table.

**What this does and does not buy.** It does **not** recover lost rows: rows already written into the orphaned WAL remain unrecoverable, and the sweep says so in the same breath as the recovery. What changes is that the condition is **detected within 5 minutes and stops accruing**, instead of running silently until a human notices missing messages.

**Three measured facts (bun 1.3.13) shaped the implementation — each invalidates an obvious version of this fix:**

1. bun:sqlite's plain `close()` is a **soft** close that defers the real `sqlite3_close` while prepared statements are un-finalized. After `db.close()` the process **still held** `h.db`, `h.db-wal (deleted)` and `h.db-shm (deleted)` in `/proc/self/fd`.
2. After a soft close the reopened connection **looks healthy** — `new Database(...)` and `PRAGMA journal_mode = WAL` both SUCCEED — and then throws on the first **WRITE**, because SQLite's unix VFS keeps per-inode WAL-index state alive while any connection to that inode is open. (An earlier revision of this PR claimed the open itself failed `SQLITE_IOERR_SHORT_READ`; that was wrong, and the docblock asserting it is corrected here.) A naive close-and-reopen would have turned silent row loss into a total history outage.
3. **`Bun.gc(true)` is not a mechanism.** The first cut made the un-finalized per-call statements collectable with a forced GC before `close(true)` and called that deterministic. It is not: with an essentially empty heap a single gc+close failed **13 times in 20**, and with an ordinary arithmetic loop running between the writes and the close it failed **30 times in 30**. Zero gc failed 20/20.

So the determinism now comes from a **module-level prepared-statement cache** in `history.ts`: every history statement goes through `prep(sql)`, and `hardCloseDb` explicitly `.finalize()`s every cached statement before `close(true)`. The same 30-iteration adversarial shape then fails **0 times in 30** — and still 0/30 with `Bun.gc(true)` deleted entirely, which is the proof that the cache and not the GC is doing the work. The gc call stays as belt-and-braces for a statement a future caller creates outside the cache, and is documented as exactly that. `getHistoryDbForBriefing()` now hands out a cache-routing wrapper instead of the raw `Database`, so an outside reader cannot create the one un-finalizable statement that would make the close throw.

**The sticky-failure lane.** A reopen whose close SUCCEEDS and whose re-init FAILS is the nastiest shape in this whole area: it releases the very fds that would have triggered the next detection, so a purely fd-driven sweep reports healthy forever while every history read and write is dead — a permanent, silent outage, strictly worse than the bug being fixed, and it contradicted the sweep's own "never throws, the next tick retries". `reopenHistory` now records that state in a sticky flag which the sweep re-checks, re-alarms on and retries **every tick, independently of the fd table**. `query()` and `lookupMessageRoleAndText()` degrade to `[]` / `null` when the DB is null (matching `hasOutboundDeliveredSince` / `hasOutboundWithText`) so a dead history does not throw through the reaction-trigger and `get_recent_messages` handlers.

**The scan is async.** It is O(open fds) — measured at 10-13ms against a live gateway holding 3366 fds, with `RLIMIT_NOFILE` 524288, i.e. unbounded by anything we control. A synchronous walk of that shape blocks inbound Telegram handling for a check that finds nothing 99.99% of the time, so it uses `fs/promises` `opendir` + `readlink`, which yields between entries: a long walk costs latency on the sweep (nobody is waiting) rather than on the gateway. The alternative — probing only the known DB paths — was rejected: it cannot distinguish "the file is gone" from "we still hold the gone file open", which is the entire signal.

**Two detection bugs that would have disabled it silently.** `/proc` targets are always fully resolved, so an unresolved (symlinked or relative) `TELEGRAM_STATE_DIR` made every prefix comparison fail — detection off, permanently, with no error and a sweep reporting healthy; the prefix is now `realpath`'d and an unresolvable dir warns instead. And the basename test was `basename.includes('.db')`, which also matched `notes.dbg`, `dump.dbf`, `history.db.bak` and `session.dbus` — an unrelated deleted temp file in the state dir would have raised a "rows are LOST" alarm; it is now anchored to `*.db` / `-wal` / `-shm` / `-journal`.

No explicit salvage checkpoint is issued through the orphaned handle: once a new `-shm` exists on disk the two connections are in disjoint locking domains and a checkpoint through the stale mapping can corrupt the main DB. The implicit checkpoint-on-close is a knowingly accepted residual — it is exactly what a clean container restart already does.

## Test plan

`telegram-plugin/tests/orphaned-db-sweep.test.ts` (bun lane; in the `vitest.config.ts` exclude list), **20 tests**. The core test **reproduces the incident** rather than mocking it: checkpoint, unlink the sidecars under the live handle, write, and prove via an on-disk snapshot that the write "succeeded" but the row is absent. Then it asserts recovery on both axes — durability (the next row IS on disk, `verifyHistoryWritable().ok`, and a full re-init reads it back) and **fd release** (`detectOrphanedDbFds` is empty afterwards).

Added in this round:

- **A determinism test under the adversarial heap** — 12 iterations of write + write + checkpoint + arithmetic churn + reopen, the exact shape that was 30/30 failures on the gc-only version.
- **Reopen-failure lanes**: reopen throws (asserting the success line is *absent*), history disabled (`reopenHistory: undefined`), the sticky flag re-alarming across two ticks and going quiet when it clears, a genuine end-to-end dead-history case (state dir replaced by a file so `initHistory`'s mkdir throws) proving `query()` returns `[]` and `lookupMessageRoleAndText()` returns `null`, and a **self-check-poisoned DB fixture** — a schema every DDL statement in `initHistory` accepts but which rejects the sentinel row — which separates "the schema is there" from "a row can be persisted" without relying on file permissions the root test container ignores.
- **Detection filters**: non-DB orphans (`.tmp`, `.dbg`, `.dbf`, `.db.bak`, `.dbus`), a symlinked state dir, an unresolvable state dir, and a foreign `.db` orphaned in a **second temp dir**. That last one matters: the state-dir prefix guard only *looked* covered before — the leaked fds from the previous test were doing the filtering, because `_resetForTests` soft-closed and leaked 3 fds per test. It now hard-closes.
- **Exact orphan-set assertions** (`['history.db-shm','history.db-wal']`) — the real incident had two orphaned fds and `return found.slice(0,1)` used to pass.
- **A coupling assertion** that `GATEWAY_SIGNATURES['orphaned-db-handle']` actually matches the emitted alarm, plus fleet-health fixture tests in `src/fleet-health/detect.test.ts`.
- **A real interval test**: `stop()` is asserted by sampling the tick-driven log line count before and after, not by "the returned value is a function that does not throw".
- **`describe.skipIf(!onLinux)`** on every `/proc`-dependent block, so a macOS run skips rather than passing vacuously off a platform early-return.

Ran locally:

- `bun test tests/orphaned-db-sweep.test.ts` — **20 pass, 0 fail**, 120 expects (3 consecutive runs, no flake).
- `telegram-plugin/scripts/bun-test-ci.sh` — **10958 pass, 4 skip, 1 fail**. The single failure is `approval-hold-record.test.ts` "falls back to the agent's own state dir when the shared dir is not writable": it simulates an unwritable dir with `chmod`, which cannot work for uid 0. Reproduced identically on pristine `origin/main`; environment-only, not from this diff. CI runs non-root.
- `npx vitest run src/fleet-health/` — 47 pass.
- `npm run lint` — all 26 gates green, including `tsc --noEmit`, `check-gateway-line-ratchet` (24853 vs 24805 + 50), `check-test-runner-coverage`, `check-changelog-entry`, `check-bot-api-wrapping`.

**Mutation checks.** All **19** mutations from the review were applied one at a time and the scoped suite re-run; **19/19 RED**:

| # | Mutation | Result |
|---|---|---|
| M01 | `hardCloseDb`: `close(true)` → `close()` | RED |
| M02 | `hardCloseDb`: drop `finalizeCachedStatements()` | RED |
| M03 | detect: `DB_BASENAME_RE` → loose `/\.db/` | RED |
| M04 | detect: drop the state-dir prefix filter | RED |
| M05 | detect: drop the ` (deleted)` filter | RED |
| M06 | `resolveStateDirPrefix`: no `realpath` canonicalisation | RED |
| M07 | tick: drop the unresolvable-stateDir warning | RED |
| M08 | detect: return only the first orphan | RED |
| M09 | tick: drop the sticky-failure lane | RED |
| M10 | `attemptHistoryReopen`: log success even when the reopen throws | RED |
| M11 | `reopenHistory`: drop the post-reopen writer self-check | RED |
| M12 | `reopenHistory`: never set the sticky flag | RED |
| M13 | `reopenHistory`: never clear the sticky flag | RED |
| M14 | tick: drop the unowned-DB lane | RED |
| M15 | tick: drop the history-disabled branch | RED |
| M16 | `query()`: drop the `db == null` guard | RED |
| M17 | `lookupMessageRoleAndText()`: drop the `db == null` guard | RED |
| M18 | `startOrphanedDbSweep`: `stop()` no longer clears the interval | RED |
| M19 | `_resetForTests`: soft close instead of hard close | RED |

The review was right that **M01 survived** the previous test suite, and the earlier claim that it went red was wrong — confirmed green 5/5 before the fix. The reason is real: once every statement is finalized, the soft close releases the fds too, so an integration test genuinely cannot see the difference. The `true` is an **honesty** property (never report a recovery that did not happen), so it is now pinned one level down on `hardCloseDb` with a handle double, and the docblock that asserted the false version is corrected rather than left to mislead the next reader.

## Risk

Low on the healthy path: an async `opendir` + `readlink` walk every 5 minutes, early-returning on non-Linux, with no write-path behaviour change. `reopenHistory` runs only when an orphan is detected or a previous reopen is known to have failed.

**Not "the worst case is the status quo plus a loud log"** — an earlier revision of this PR said that, and it was wrong. The genuine worst case is the close succeeding and the re-init failing, which leaves history dead with no fd evidence. That is what the sticky flag, the every-tick retry, and the null-tolerant read paths exist for, and it is now the most heavily tested lane in the file. The residual after all of that is a gateway whose history is dead *and loudly saying so every 5 minutes*, which is the state a restart fixes.

`registry.db` is deliberately detection-only. Not covered, deliberately: `SQLITE_FCNTL_PERSIST_WAL`, `immutable=1`, write-visibility canary rows, and moving off WAL — all out of scope.

Job spec: `reference/jobs/` — always available (chat history survives restarts and foreign processes).
