### PR TITLE
fix(gateway): read a rich-message reply parent's body off the live update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ now an anomaly worth investigating, not the norm.
 
 - **gateway: record card sends at the transformer seam, not robustApiCall**
 
+- **gateway: read a rich-message reply parent's body off the live update**
+
 ## v0.21.4 — gateway SQLite databases open read-only from foreign processes, and an orphaned-fd sweep that catches the damage when they don't
 
 ### Fixes

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -15058,11 +15058,11 @@ export async function handleInbound(
   } = replyForwardCtx
 
   // Reply-to buffer fallback (post-reset continuity, resolveReplyToFromBuffer).
-  // On a native reply to the BOT's OWN message, Telegram delivers
-  // reply_to_message.message_id but NOT its .text — so the live reply text is
-  // empty even though we authored (and, via recordOutbound, persisted) that
-  // message to history.db (role='assistant', 30-day retention). Recover it so
-  // the antecedent survives a session reset. Fills replyToText (raw, so the
+  // On a native reply to a PLAIN bot-sent message, Telegram delivers
+  // reply_to_message.message_id but NOT its .text (a RICH parent — every card —
+  // carries rich_message and is resolved LIVE upstream since #4598), so the live
+  // reply text is empty even though we persisted it (role='assistant', 30-day
+  // retention). Recover it so it survives a reset. Fills replyToText (raw, so the
   // recordInbound write below persists it — envelope-only would leave the row
   // NULL and starve future briefings), replyToTextEscaped (channel meta), and
   // replyToRole (the reply_to_role attribute). Only when the live text is

--- a/telegram-plugin/gateway/inbound-router.ts
+++ b/telegram-plugin/gateway/inbound-router.ts
@@ -254,11 +254,17 @@ export interface ReplyToBufferFallbackParams {
  * buffer so it survives a session reset (`resume_mode: handoff`), where the
  * transcript is gone.
  *
- * Since #4598 this is the SECOND line of defence, not the first: a reply to a
- * RICH parent (every card) now carries its body on `reply_to_message
- * .rich_message` and is resolved live in {@link buildReplyForwardContext},
- * so the buffer is consulted only when the live update genuinely carried no
- * readable body.
+ * Since #4598 this is the SECOND line of defence FOR THE TEXT, not the first:
+ * a reply to a RICH parent (every card) now carries its body on
+ * `reply_to_message.rich_message` and is resolved live in
+ * {@link buildReplyForwardContext}, so a live-resolved body is never
+ * overwritten from the buffer.
+ *
+ * The LOOKUP itself, however, still runs on every reply while history is on.
+ * `replyToRole` and `replyToKind` have no live-update source at all, so
+ * skipping the lookup whenever the live text resolved would strip
+ * `reply_to_role` / `reply_to_kind` from precisely the recorded-card replies
+ * the #4571 kind lane was built for.
  *
  * Returns updated `replyToText` (raw, for the SQLite `recordInbound` write —
  * envelope-only would leave the row NULL and starve future handoff briefings),
@@ -282,23 +288,32 @@ export function resolveReplyToFromBuffer(p: ReplyToBufferFallbackParams): {
   let replyToRole: 'user' | 'assistant' | 'system' | undefined
   let replyToKind: string | undefined
   const liveTextEmpty = replyToTextEscaped == null || replyToTextEscaped.length === 0
-  if (p.historyEnabled && p.replyToMessageId != null && liveTextEmpty) {
+  if (p.historyEnabled && p.replyToMessageId != null) {
     try {
       const recovered = p.lookup(p.replyToMessageId)
-      if (recovered != null && recovered.role === 'system' && recovered.kind) {
-        replyToKind = recovered.kind
-      }
-      if (recovered && recovered.text.length > 0) {
-        replyToText =
-          recovered.text.length > p.replyToTextMax
-            ? recovered.text.slice(0, p.replyToTextMax - 1) + '…'
-            : recovered.text
-        replyToTextEscaped = formatReplyToText(recovered.text, p.replyToTextMax)
+      if (recovered != null) {
+        // Role and kind are produced ONLY here — there is no live-update
+        // source for either. So the lookup runs on EVERY reply, not just the
+        // ones whose text the live update failed to carry: gating it on
+        // `liveTextEmpty` would mean a full reply to a recorded card resolved
+        // its body live (#4598) and silently lost `reply_to_role="system"` +
+        // `reply_to_kind` (#4571) — exactly the case the kind lane exists for,
+        // and the thing #4599 goes to AsyncLocalStorage lengths to record.
+        // Costs one SQLite point-read per reply.
         replyToRole = recovered.role
-      } else if (recovered) {
-        // Row exists (authorship known) but text is empty/redacted — still
-        // surface the role so the model knows whose message it is replying to.
-        replyToRole = recovered.role
+        if (recovered.role === 'system' && recovered.kind) {
+          replyToKind = recovered.kind
+        }
+        // The TEXT is still second line of defence: never overwrite a
+        // non-empty live value (a partial quote, a person's message, or a
+        // rich parent rendered off the wire).
+        if (liveTextEmpty && recovered.text.length > 0) {
+          replyToText =
+            recovered.text.length > p.replyToTextMax
+              ? recovered.text.slice(0, p.replyToTextMax - 1) + '…'
+              : recovered.text
+          replyToTextEscaped = formatReplyToText(recovered.text, p.replyToTextMax)
+        }
       }
     } catch {
       // History disabled mid-run / requireDb throws / row missing — degrade

--- a/telegram-plugin/gateway/inbound-router.ts
+++ b/telegram-plugin/gateway/inbound-router.ts
@@ -271,9 +271,11 @@ export interface ReplyToBufferFallbackParams {
  * `replyToTextEscaped` (for the channel-meta `reply_to_text`), and the
  * recovered `replyToRole` ('assistant' = the bot's own message, disambiguating
  * the "you're replying to yourself" case). Pure except for the injected
- * `lookup`. Only fills in when the live reply text is empty — never overwrites
- * a non-empty live value (a partial-quote or a reply to a person's message).
- * Degrades silently to the id-only inputs on any lookup failure.
+ * `lookup`. Only fills in the TEXT when the live reply text is empty — never
+ * overwrites a non-empty live value (a partial-quote, a reply to a person's
+ * message, or a live-rendered rich parent). Role and kind are filled in from
+ * any buffer hit regardless. Degrades silently to the id-only inputs on any
+ * lookup failure.
  */
 export function resolveReplyToFromBuffer(p: ReplyToBufferFallbackParams): {
   replyToText: string | undefined

--- a/telegram-plugin/gateway/inbound-router.ts
+++ b/telegram-plugin/gateway/inbound-router.ts
@@ -35,6 +35,7 @@ import {
 } from './inbound-interceptors.js'
 import type { InboundMessage } from './ipc-protocol.js'
 import { deriveTurnId } from './derive-turn-id.js'
+import { extractRichMessageText } from './rich-message-handler.js'
 import { formatReplyToText } from '../steering.js'
 import { fmtLocalStamp, resolveEnvTimezone } from '../shared/local-time.js'
 import { safeResolvePersonName, type PersonDirectory } from './resolve-person.js'
@@ -160,10 +161,33 @@ export function buildReplyForwardContext(p: ReplyForwardContextParams): {
   // gateway runs when neither is present. Accessed defensively in case the
   // installed grammy/@grammyjs/types predate `TextQuote`.
   const quoteText = p.ctx.message?.quote?.text
+  // Rich-message parents (#4598). Every card the gateway posts goes out via
+  // Bot API 10.1 `sendRichMessage`, so a native reply to one delivers a
+  // `reply_to_message` whose body lives under `rich_message.blocks` with
+  // `text` / `caption` ABSENT. Reading only `.text ?? .caption` therefore
+  // yielded `undefined` for 100% of card parents and pushed every such reply
+  // onto the history-buffer fallback — which cannot help when no row was ever
+  // recorded (a send while the gateway was down, or one that bypassed the
+  // recording chokepoint).
+  //
+  // Measured on the wire, not inferred: a user reply to a `sendRichMessage`
+  // card yields `reply_to_message` keys
+  // `[message_id, from, chat, date, rich_message]`, `text`/`caption` absent,
+  // `rich_message.blocks` fully populated. The older "Telegram omits the
+  // parent body" comments on this path predate rich messages.
+  //
+  // Flattened by the SAME renderer the inbound rich-message handler and the
+  // outbound card observer use, so all three agree on what a card "says".
+  // Returns `undefined` (never `''`) for an unrenderable block tree, so
+  // `resolveReplyToFromBuffer`'s `liveTextEmpty` gate still falls through to
+  // the buffer instead of pinning an empty antecedent.
+  const richParentText = extractRichMessageText(
+    (replyToMsg as { rich_message?: unknown } | undefined)?.rich_message,
+  )
   const replyToTextRaw = (quoteText != null && quoteText.length > 0)
     ? quoteText
     : replyToMsg
-      ? (replyToMsg.text ?? replyToMsg.caption ?? undefined)
+      ? (replyToMsg.text ?? replyToMsg.caption ?? richParentText ?? undefined)
       : undefined
   const replyToText = replyToTextRaw != null
     ? (replyToTextRaw.length > p.replyToTextMax
@@ -198,8 +222,11 @@ export function buildReplyForwardContext(p: ReplyForwardContextParams): {
 export interface ReplyToBufferFallbackParams {
   /** From {@link buildReplyForwardContext}. */
   replyToMessageId: number | undefined
-  /** Raw reply text off the live update (for the SQLite write); empty when the
-   *  reply target is the bot's own message (Telegram omits its text). */
+  /** Raw reply text off the live update (for the SQLite write). Empty only
+   *  when the live update carried NO readable parent body at all — a plain
+   *  `sendMessage` parent (Telegram omits `.text` on the bot's own plain
+   *  messages), or a rich parent whose blocks render to nothing. A normal
+   *  card parent now arrives populated off `rich_message` (#4598). */
   replyToText: string | undefined
   /** XML-escaped reply text for the channel meta; empty in the same case. */
   replyToTextEscaped: string | undefined
@@ -219,12 +246,19 @@ export interface ReplyToBufferFallbackParams {
 }
 
 /**
- * Reply-to buffer fallback (post-reset continuity). On a native reply to the
- * BOT's OWN message, Telegram delivers `reply_to_message.message_id` but NOT
- * its `.text` — so the live reply text is empty even though the gateway
- * authored (and, via `recordOutbound`, persisted) that message. This recovers
- * the antecedent from the local history buffer so it survives a session reset
- * (`resume_mode: handoff`), where the transcript is gone.
+ * Reply-to buffer fallback (post-reset continuity). On a native reply to a
+ * PLAIN message the bot itself sent, Telegram delivers
+ * `reply_to_message.message_id` but NOT its `.text` — so the live reply text
+ * is empty even though the gateway authored (and, via `recordOutbound`,
+ * persisted) that message. This recovers the antecedent from the local history
+ * buffer so it survives a session reset (`resume_mode: handoff`), where the
+ * transcript is gone.
+ *
+ * Since #4598 this is the SECOND line of defence, not the first: a reply to a
+ * RICH parent (every card) now carries its body on `reply_to_message
+ * .rich_message` and is resolved live in {@link buildReplyForwardContext},
+ * so the buffer is consulted only when the live update genuinely carried no
+ * readable body.
  *
  * Returns updated `replyToText` (raw, for the SQLite `recordInbound` write —
  * envelope-only would leave the row NULL and starve future handoff briefings),

--- a/telegram-plugin/tests/reply-to-buffer-fallback.test.ts
+++ b/telegram-plugin/tests/reply-to-buffer-fallback.test.ts
@@ -102,20 +102,32 @@ describe('resolveReplyToFromBuffer — reply-to buffer fallback (1a)', () => {
   })
 
   it('does NOT overwrite a non-empty LIVE reply text (reply to a person, or a partial quote)', () => {
-    const lookup = () => {
-      throw new Error('lookup must not be called when live text is present')
-    }
     const out = resolveReplyToFromBuffer({
       replyToMessageId: 9,
       replyToText: 'live raw text',
       replyToTextEscaped: 'live escaped text',
       historyEnabled: true,
       replyToTextMax: REPLY_TO_TEXT_MAX,
-      lookup,
+      lookup: () => ({ role: 'user', text: 'STALE BUFFER TEXT' }),
     })
     expect(out.replyToText).toBe('live raw text')
     expect(out.replyToTextEscaped).toBe('live escaped text')
+    // …but the lookup still supplies the ROLE, which has no live-update source.
+    expect(out.replyToRole).toBe('user')
+  })
+
+  it('a missing row does not clobber a live reply text', () => {
+    const out = resolveReplyToFromBuffer({
+      replyToMessageId: 9,
+      replyToText: 'live raw text',
+      replyToTextEscaped: 'live escaped text',
+      historyEnabled: true,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+      lookup: () => null,
+    })
+    expect(out.replyToText).toBe('live raw text')
     expect(out.replyToRole).toBeUndefined()
+    expect(out.replyToKind).toBeUndefined()
   })
 
   it('history-disabled guard: never calls lookup, degrades to id-only, does not throw', () => {
@@ -309,11 +321,13 @@ describe('buildReplyForwardContext — rich_message parent (#4598)', () => {
     expect(out.replyToText).toBe('Opus 41%')
   })
 
-  it('THE BUFFER-ONLY KILLER: the live rich body wins and the buffer is never consulted', () => {
-    // A buffer-only implementation resolves this reply from the stored row, so
-    // it returns the STALE text and calls `lookup`. Both assertions fail on
-    // such an implementation — which is the point: this is the one test in the
-    // file that a recording-side-only fix cannot pass.
+  it('THE BUFFER-ONLY KILLER: the live rich body wins over a DIFFERENT stored row', () => {
+    // A buffer-only implementation resolves this reply from the stored row and
+    // returns the STALE text — which is the point: this is the one test in the
+    // file that a recording-side-only fix cannot pass. The lookup DOES run
+    // (role/kind have no live source, see the next test) but it must not be
+    // allowed to win the text, so the stub deliberately returns a different
+    // body from the one on the wire.
     const ctx = makeCtx({ reply_to_message: richParent(9925) })
     const live = buildReplyForwardContext({
       ctx,
@@ -335,8 +349,49 @@ describe('buildReplyForwardContext — rich_message parent (#4598)', () => {
     })
 
     expect(out.replyToText).toBe(RENDERED)
+    expect(out.replyToTextEscaped).toBe(RENDERED)
     expect(out.replyToText).not.toContain('STALE BUFFER TEXT')
-    expect(lookupCalls).toBe(0)
+    // The row was consulted — for role/kind only, never for the body.
+    expect(lookupCalls).toBe(1)
+  })
+
+  it('a live-resolved rich body still carries reply_to_role AND reply_to_kind through the envelope', () => {
+    // The regression the `liveTextEmpty` gate introduced: an operator FULL-
+    // replies (no partial quote) to a live activity card whose row IS in
+    // history.db. The body now resolves live off `rich_message` — and if that
+    // short-circuits the lookup, the envelope loses `reply_to_role="system"`
+    // and `reply_to_kind="activity-summary"` entirely, killing the #4571 kind
+    // lane for exactly the case it was built for.
+    const ctx = makeCtx({ reply_to_message: richParent(9925) })
+    const live = buildReplyForwardContext({
+      ctx,
+      coalescedForwardOrigins: undefined,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+    })
+    const resolved = resolveReplyToFromBuffer({
+      replyToMessageId: live.replyToMessageId,
+      replyToText: live.replyToText,
+      replyToTextEscaped: live.replyToTextEscaped,
+      historyEnabled: true,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+      // The row IS recorded — same card, stored body.
+      lookup: () => ({ role: 'system', text: RENDERED, kind: 'activity-summary' }),
+    })
+    expect(resolved.replyToRole).toBe('system')
+    expect(resolved.replyToKind).toBe('activity-summary')
+
+    const msg = buildInboundEnvelope(
+      makeEnvelopeParams({
+        ctx,
+        replyToMessageId: live.replyToMessageId,
+        replyToTextEscaped: resolved.replyToTextEscaped,
+        replyToRole: resolved.replyToRole,
+        replyToKind: resolved.replyToKind,
+      }),
+    )
+    expect(msg.meta?.reply_to_text).toBe(RENDERED)
+    expect(msg.meta?.reply_to_role).toBe('system')
+    expect(msg.meta?.reply_to_kind).toBe('activity-summary')
   })
 
   it('carries the live rich body through to the inbound envelope', () => {

--- a/telegram-plugin/tests/reply-to-buffer-fallback.test.ts
+++ b/telegram-plugin/tests/reply-to-buffer-fallback.test.ts
@@ -25,6 +25,10 @@
  *     partial quote) over the full parent `.text`.
  *   - `buildInboundEnvelope` emits `reply_to_role` when known and `reply_to_text`
  *     from the recovered escaped form.
+ *   - `buildReplyForwardContext` reads a RICH parent's body off
+ *     `reply_to_message.rich_message` LIVE (#4598) — the only path that can
+ *     resolve a card the buffer never recorded. The last describe block pins
+ *     that, including a killer case a buffer-only implementation must fail.
  *
  * The persisted-row-non-NULL half of the 1a contract (which needs a real
  * bun:sqlite history.db) lives in reply-to-buffer-history.test.ts (bun).
@@ -205,6 +209,152 @@ describe('buildReplyForwardContext — native partial-quote preference (2a)', ()
     expect(out.replyToMessageId).toBe(102)
     expect(out.replyToText).toBeUndefined()
     expect(out.replyToTextEscaped).toBeUndefined()
+  })
+})
+
+/**
+ * Rich-message parents (#4598).
+ *
+ * Every card the gateway posts ships via Bot API 10.1 `sendRichMessage`, so a
+ * native reply to one delivers a `reply_to_message` with `rich_message.blocks`
+ * populated and `text` / `caption` ABSENT. Measured on the wire against a real
+ * bot: keys `[message_id, from, chat, date, rich_message]`.
+ *
+ * Before #4598 the body of a card antecedent was 100% buffer-sourced, so a
+ * card that never made it into `history.db` — posted while the gateway was
+ * down, or through a send path that bypassed the recording chokepoint — was
+ * permanently unresolvable no matter how the recording side was fixed. These
+ * pin the LIVE read.
+ */
+describe('buildReplyForwardContext — rich_message parent (#4598)', () => {
+  /** The shape Telegram actually delivers for a reply to a card. */
+  function richParent(message_id: number) {
+    return {
+      message_id,
+      rich_message: {
+        blocks: [
+          { type: 'paragraph', text: [{ type: 'bold', text: 'Usage' }, ' this week'] },
+          { type: 'paragraph', text: 'Opus 41% then Sonnet 12%' },
+        ],
+      },
+    }
+  }
+
+  const RENDERED = 'Usage this week\nOpus 41% then Sonnet 12%'
+
+  it('reads the parent body off rich_message when text and caption are absent', () => {
+    const ctx = makeCtx({ reply_to_message: richParent(9938) })
+    const out = buildReplyForwardContext({
+      ctx,
+      coalescedForwardOrigins: undefined,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+    })
+    expect(out.replyToMessageId).toBe(9938)
+    expect(out.replyToText).toBe(RENDERED)
+    expect(out.replyToTextEscaped).toBe(RENDERED)
+  })
+
+  it('truncates a long rich body to the cap, like every other antecedent', () => {
+    const ctx = makeCtx({
+      reply_to_message: {
+        message_id: 1,
+        rich_message: { blocks: [{ type: 'paragraph', text: 'x'.repeat(400) }] },
+      },
+    })
+    const out = buildReplyForwardContext({
+      ctx,
+      coalescedForwardOrigins: undefined,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+    })
+    expect(out.replyToText).toHaveLength(REPLY_TO_TEXT_MAX)
+    expect(out.replyToText?.endsWith('…')).toBe(true)
+  })
+
+  it('yields undefined (not empty string) for an unrenderable block tree, so the buffer still runs', () => {
+    // A thinking-only / media-stripped card renders to nothing. It must fall
+    // THROUGH to the buffer rather than pinning the antecedent to ''.
+    const ctx = makeCtx({
+      reply_to_message: { message_id: 5, rich_message: { blocks: [{ type: 'thinking' }] } },
+    })
+    const live = buildReplyForwardContext({
+      ctx,
+      coalescedForwardOrigins: undefined,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+    })
+    expect(live.replyToText).toBeUndefined()
+    expect(live.replyToTextEscaped).toBeUndefined()
+
+    const out = resolveReplyToFromBuffer({
+      replyToMessageId: live.replyToMessageId,
+      replyToText: live.replyToText,
+      replyToTextEscaped: live.replyToTextEscaped,
+      historyEnabled: true,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+      lookup: () => ({ role: 'system', text: 'stored card body', kind: 'activity-summary' }),
+    })
+    expect(out.replyToText).toBe('stored card body')
+    expect(out.replyToKind).toBe('activity-summary')
+  })
+
+  it('prefers a native partial quote over the rich parent body', () => {
+    const ctx = makeCtx({
+      reply_to_message: richParent(7),
+      quote: { text: 'Opus 41%', position: 5, is_manual: true },
+    })
+    const out = buildReplyForwardContext({
+      ctx,
+      coalescedForwardOrigins: undefined,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+    })
+    expect(out.replyToText).toBe('Opus 41%')
+  })
+
+  it('THE BUFFER-ONLY KILLER: the live rich body wins and the buffer is never consulted', () => {
+    // A buffer-only implementation resolves this reply from the stored row, so
+    // it returns the STALE text and calls `lookup`. Both assertions fail on
+    // such an implementation — which is the point: this is the one test in the
+    // file that a recording-side-only fix cannot pass.
+    const ctx = makeCtx({ reply_to_message: richParent(9925) })
+    const live = buildReplyForwardContext({
+      ctx,
+      coalescedForwardOrigins: undefined,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+    })
+
+    let lookupCalls = 0
+    const out = resolveReplyToFromBuffer({
+      replyToMessageId: live.replyToMessageId,
+      replyToText: live.replyToText,
+      replyToTextEscaped: live.replyToTextEscaped,
+      historyEnabled: true,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+      lookup: () => {
+        lookupCalls++
+        return { role: 'system', text: 'STALE BUFFER TEXT', kind: 'usage-card' }
+      },
+    })
+
+    expect(out.replyToText).toBe(RENDERED)
+    expect(out.replyToText).not.toContain('STALE BUFFER TEXT')
+    expect(lookupCalls).toBe(0)
+  })
+
+  it('carries the live rich body through to the inbound envelope', () => {
+    const ctx = makeCtx({ reply_to_message: richParent(9925) })
+    const live = buildReplyForwardContext({
+      ctx,
+      coalescedForwardOrigins: undefined,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+    })
+    const msg = buildInboundEnvelope(
+      makeEnvelopeParams({
+        ctx,
+        replyToMessageId: live.replyToMessageId,
+        replyToTextEscaped: live.replyToTextEscaped,
+      }),
+    )
+    expect(msg.meta?.reply_to_message_id).toBe('9925')
+    expect(msg.meta?.reply_to_text).toBe(RENDERED)
   })
 })
 


### PR DESCRIPTION
## Summary

A native Telegram reply to a **card** (every card ships via Bot API 10.1 `sendRichMessage`) delivers a `reply_to_message` whose body lives under `rich_message.blocks`, with `text` and `caption` absent. `buildReplyForwardContext` read only `.text ?? .caption`, so the body of a card antecedent was **100% buffer-sourced** — recovered from `history.db` or not at all.

This adds the live read: `extractRichMessageText(reply_to_message.rich_message)`, one step in the existing precedence chain.

## Why

A card the buffer never recorded is permanently unresolvable without this. Two verified classes on a live agent:

- a contiguous id gap spanning a window where **no gateway process was running** — the host-side roller posted those cards, and no recording-side fix can ever capture them;
- slash-command cards (`/usage`, `/model`, `/auth`, …), which go out via `switchroomReply` → `ctx.replyWithRichMessage` and therefore bypass the `robustApiCall` recording chokepoint entirely.

For both, the operator quote-replies and the agent gets `reply_to_message_id` with no body.

## The wire fact this rests on — measured, not assumed

The comments this PR corrects claimed Telegram omits the parent body. They predate rich messages. Probed against a real bot before writing any code (raw Bot API consumer + an MTProto user client replying to a `sendRichMessage` card):

```
reply_to_message keys: ["message_id","from","chat","date","rich_message"]
has rich_message: true
text: null
caption: null
rich_message: {"blocks":[{"type":"paragraph","text":[{"type":"bold","text":"PROBE-CARD-BODY"}," alpha bravo charlie"]},
                         {"type":"paragraph","text":"second line delta"}]}
```

## Behaviour

- Precedence unchanged and pinned by tests: `quote.text` > parent `text`/`caption` > parent `rich_message` > history buffer.
- Flattened by `extractRichMessageText`, the same renderer the inbound rich-message handler and the outbound card observer use, so all three agree on what a card "says".
- Returns `undefined`, never `''`, so an unrenderable block tree (a media-only card) still falls through to `resolveReplyToFromBuffer`'s `liveTextEmpty` gate.
- `REPLY_TO_TEXT_MAX = 200` truncation applies as for every other antecedent.

## Test plan

`telegram-plugin/tests/reply-to-buffer-fallback.test.ts`, new describe block (6 cases), including **the buffer-only killer**: a rich parent plus a `lookup` stub returning *different* stored text — asserts the envelope carries the LIVE rendering and that `lookup` was never called. A recording-side-only fix cannot pass it.

Mutation-checked: reverting the one-line precedence change fails 4 of the 6 new cases, including the killer.

```
vitest run telegram-plugin/tests/reply-to-buffer-fallback.test.ts   20 passed
npm run lint                                                        clean
```

## Risk

Low. One added term in an existing `??` chain, guarded by a renderer that already accepts `unknown` from the wire and cannot throw.

**Correction to an earlier claim in this PR body:** it previously said "nothing that was populated changes". That was false, and review caught it. Resolving the body live meant `resolveReplyToFromBuffer`'s `liveTextEmpty` gate skipped the buffer lookup entirely — and `reply_to_role` / `reply_to_kind` are produced ONLY by that lookup. An operator full-reply (no partial quote) to a live activity card whose row IS in `history.db` would have gained live text and silently LOST `reply_to_role="system"` + `reply_to_kind="activity-summary"`, killing the #4571 kind lane for exactly the case it was built for.

Fixed in this PR (`gateway/inbound-router.ts:291`): while history is on, the lookup now runs on every reply so role/kind always resolve; only the TEXT overwrite stays gated on `liveTextEmpty`. Cost is one SQLite point-read per reply. Two consequent behaviour changes, both deliberate:

- a live-resolved card antecedent keeps `reply_to_role` + `reply_to_kind` (the regression above);
- a reply whose text came from a partial quote or a person's plain message now also carries `reply_to_role`, which it previously did not. Strictly more information, same shape.

Pinned by `a live-resolved rich body still carries reply_to_role AND reply_to_kind through the envelope`. Mutation-checked: restoring the `&& liveTextEmpty` gate fails 3 cases including that one. The buffer-only killer was updated (it can no longer assert `lookupCalls === 0`) to assert the lookup ran but the text came off the LIVE path against a *different* stored body — re-verified that reverting the live-read line still kills it, so it remains unpassable by a buffer-only implementation.

Job spec: `reference/jobs/` — chat-is-source-of-truth continuity (the agent can see what the operator pointed at).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

