### PR TITLE
fix(gateway): record card sends at the transformer seam, not robustApiCall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+### Bug fixes
+
+- **gateway: record card sends at the transformer seam, not robustApiCall**
+
 ## v0.21.4 — gateway SQLite databases open read-only from foreign processes, and an orphaned-fd sweep that catches the damage when they don't
 
 ### Fixes

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -302,7 +302,7 @@ import {
 import { installEditFloodFuse, editFloodFuseConfigFromEnv } from '../edit-flood-fuse.js'
 import { createSendGate, sendGateConfigFromEnv, isSendGateShed } from '../send-gate.js'
 import { createStatsLogger, createFloodWindowObserver } from '../send-gate-observability.js'
-import { installTgPostLogger, installRichMarkdownGuard, withTgPostTags } from '../shared/bot-runtime.js'
+import { installTgPostLogger, installRichMarkdownGuard, withTgPostTags, withTgSendContext, installSystemMessageObserver } from '../shared/bot-runtime.js'
 import { installSentTextCapture } from '../shared/sent-text-capture.js'
 import {
   floodStatePath,
@@ -5603,28 +5603,25 @@ const rawRobustApiCall = createRetryApiCall({
   floodWaitRemainingMs: probeFloodWaitRemainingMs,
 })
 
-// #4571 — card/system-surface history lane. Every card the gateway posts
-// (activity card, status pin, approval/boot/issues/worker-feed cards, progress
-// lines, notices) goes through `robustApiCall`, so observing its RESOLVED
-// result is the one chokepoint that makes every posted message id resolvable
-// when the operator quote-replies to it. Never throws; see
-// system-message-observer.ts for the send-vs-edit and throttling contract.
-// Gated on the SAME condition as `initHistory` above — a non-main gateway
-// process never opens the DB, so an observer there would be pure noise.
-// The empty-body alarm (#4576) is the observer's own default — see
-// `defaultEmptyCardTextWarning` in system-message-observer.ts.
+// #4571 — card/system-surface history lane: every card the gateway posts must leave
+// a row so its id resolves when the operator quote-replies to it. #4599 moved the
+// hook off `robustApiCall` (which the `ctx.replyWithRichMessage` slash-command card
+// path bypasses entirely) onto the grammy transformer layer — see
+// `installSystemMessageObserver`, wired at bot construction, and
+// system-message-observer.ts for the send-vs-edit / throttling / alarm contract.
+// Gated as `initHistory` is: a non-main gateway never opens the DB.
 const observeSentMessage = isGatewayMain && HISTORY_ENABLED
   ? makeSystemMessageObserver({ insert: recordSystemOutbound, updateText: updateSystemOutboundText })
   : undefined
 
+// `withTgSendContext` publishes {chat_id, threadId, verb} down to the transformer layer
+// where the observer runs — how a card keeps its `kind`. Sends outside this wrapper
+// still record, just without a verb.
 const robustApiCall = <T>(
   fn: () => Promise<T>,
   opts?: Parameters<typeof rawRobustApiCall<T>>[1],
-): Promise<T> => {
-  const p = sendGate.gate(() => rawRobustApiCall(fn, opts), opts)
-  if (observeSentMessage == null) return p
-  return p.then((res) => { observeSentMessage(res, opts); return res })
-}
+): Promise<T> =>
+  sendGate.gate(() => withTgSendContext(opts, () => rawRobustApiCall(fn, opts)), opts)
 
 // Fire-and-forget wrapper for outbound surfaces that previously had
 // `.catch(() => {})` directly on `bot.api.*` calls. Resolves to undefined
@@ -22887,6 +22884,9 @@ async function initGatewayBot(): Promise<void> {
   // on the resolved Message for the shapes a response can't supply. After the fmt
   // guard so it composes OUTSIDE it. See sent-text-capture.ts.
   installSentTextCapture(bot)
+  // #4599 card-history lane: AFTER sent-text-capture so it composes outside it and
+  // can read the request-side stamp. The seam `ctx.replyWithRichMessage` can't bypass.
+  if (observeSentMessage != null) installSystemMessageObserver(bot, observeSentMessage)
   // #3620 flood fuse — installed LAST so it composes OUTERMOST: the one seam no
   // outbound call can bypass (grammY has no route to the network that skips the
   // transformer stack). Kill-switch SWITCHROOM_EDIT_FUSE=0; see edit-flood-fuse.ts.

--- a/telegram-plugin/gateway/system-message-observer.ts
+++ b/telegram-plugin/gateway/system-message-observer.ts
@@ -24,10 +24,29 @@
  * Rather than add a `recordSystemOutbound(...)` call to each of the ~110 raw
  * send sites (which is exactly the kind of per-call-site discipline that
  * decays — the `reply` path was the only site anyone remembered), this hooks
- * the ONE chokepoint every gateway outbound already goes through:
- * `gateway.ts`'s `robustApiCall` (chat-lock → send-gate → retry policy). Every
- * card send in the gateway is routed through it, enforced by the
- * `check-bot-api-wrapping` lint guard.
+ * ONE chokepoint and observes the resolved response there.
+ *
+ * WHICH chokepoint took two goes, and the first answer was wrong (#4599). This
+ * docblock used to say the hook sat on `gateway.ts`'s `robustApiCall` — "the
+ * ONE chokepoint every gateway outbound already goes through … enforced by the
+ * `check-bot-api-wrapping` lint guard". Both halves were false from the day it
+ * merged. grammY's `ctx.*` sugar builds the payload and calls `bot.api.*`
+ * itself, so `switchroomReply` — the helper every SLASH-COMMAND card answers
+ * through (`/usage`, `/model`, `/auth`, `/approvals`, `/start`, `/help`) — sends
+ * via `ctx.replyWithRichMessage` and never touches `robustApiCall`; and the
+ * lint guard could not have caught that, because its verb pattern matched only
+ * `(bot|lockedBot|ctx)\.api\.<verb>`, never mentioned `sendRichMessage`, and
+ * structurally cannot match a `ctx.replyWith*` call at all. Measured, not
+ * inferred: a live agent's `/usage` card at id 20938 left NO row while the
+ * `tg-post` transformer logged its `sendRichMessage` POST.
+ *
+ * The hook therefore lives at the grammy API TRANSFORMER layer
+ * (`installSystemMessageObserver` in `shared/bot-runtime.ts`), which grammy
+ * resolves immediately around the HTTP POST — below every helper, `ctx.*`
+ * shorthand, `lockedBot`, and `bot.api.raw`. No call shape reaches Telegram
+ * without passing through it, so no future verb can opt out the way
+ * `switchroomReply` silently did. `robustApiCall` still publishes its `verb`
+ * down to that layer (`withTgSendContext`) so cards keep their `kind`.
  *
  * The observer reads the Telegram RESPONSE, which buys three things for free:
  *   - the real `message_id` (the only thing a reply can point at),
@@ -90,7 +109,7 @@ export interface SentMessageLike {
   rich_message?: unknown
 }
 
-/** The subset of `robustApiCall`'s opts the observer reads. */
+/** The call-site metadata the observer reads (`bot-runtime.ts`'s `TgSendContext`). */
 export interface ObservedCallOpts {
   chat_id?: string
   threadId?: number
@@ -293,7 +312,7 @@ type TrackedState = { lane: 'system' | 'foreign'; lastStoredMs: number; storedLe
 
 /**
  * Build the observer. The returned function is called with the RESOLVED result
- * of every `robustApiCall` and never throws.
+ * of every outbound Bot API call (from the transformer layer) and never throws.
  */
 export function makeSystemMessageObserver(
   deps: SystemMessageObserverDeps,

--- a/telegram-plugin/shared/bot-runtime.ts
+++ b/telegram-plugin/shared/bot-runtime.ts
@@ -5,8 +5,10 @@
  * standalone foreman bot before its retirement.
  *
  * What lives here:
- *   - `installTgPostLogger` / `installRichMarkdownGuard` — the grammy API
- *     transformers every outbound call transits.
+ *   - `installTgPostLogger` / `installRichMarkdownGuard` /
+ *     `installSystemMessageObserver` — the grammy API transformers every
+ *     outbound call transits. This layer, not any caller-side wrapper, is the
+ *     one seam no `ctx.*` helper or raw `bot.api.*` call can bypass.
  *   - `makeSwitchroomExec` / `makeSwitchroomExecCombined` — factory fns for
  *     the switchroom CLI exec helpers (callers pass their own CLI path / config
  *     env so each process can be configured independently).
@@ -290,6 +292,121 @@ export function installRichMarkdownGuard(bot: Bot): void {
     }
     return prev(method, payload, signal)
   })
+}
+
+// ─── outbound send observation (#4571 / #4599) ────────────────────────────
+
+/**
+ * The call-site metadata a send observer wants but the wire payload cannot
+ * supply. Structurally the same shape as `ObservedCallOpts` in
+ * `gateway/system-message-observer.ts`; declared here so this module keeps its
+ * no-imports-from-gateway rule.
+ */
+export interface TgSendContext {
+  chat_id?: string
+  threadId?: number
+  /** The caller's own label for what this send IS (`activity-summary.send`). */
+  verb?: string
+}
+
+const sendContextStore = new AsyncLocalStorage<TgSendContext | undefined>()
+
+/**
+ * Publish the enclosing call's `{chat_id, threadId, verb}` to the API
+ * transformer layer for the duration of `fn`'s async chain. `gateway.ts`'s
+ * `robustApiCall` wraps every call it issues; anything sent outside it (a
+ * `ctx.reply*` helper, a raw `bot.api.*`) simply observes with no verb.
+ */
+export function withTgSendContext<T>(ctx: TgSendContext | undefined, fn: () => T): T {
+  return sendContextStore.run(ctx, fn)
+}
+
+/** Exposed for the transformer (and tests). Undefined outside a wrapped call. */
+export function _getTgSendContext(): TgSendContext | undefined {
+  return sendContextStore.getStore()
+}
+
+/**
+ * Install the card-history send observer as a grammy API TRANSFORMER — the
+ * real universal outbound seam (#4599).
+ *
+ * #4571 hooked the observer onto `gateway.ts`'s `robustApiCall`, and
+ * `system-message-observer.ts` claimed that was "the ONE chokepoint every
+ * gateway outbound already goes through … enforced by the
+ * `check-bot-api-wrapping` lint guard". That claim was false on both halves.
+ * grammY's `ctx.*` sugar builds the payload and calls `bot.api.*` directly, so
+ * `switchroomReply` (`gateway.ts`, the helper every SLASH-COMMAND card answers
+ * through — `/usage`, `/model`, `/auth`, `/approvals`, `/start`, `/help`) sends
+ * via `ctx.replyWithRichMessage` and never transits `robustApiCall` at all; and
+ * the lint guard could not have caught it, because its verb pattern matched
+ * only `(bot|lockedBot|ctx)\.api\.<verb>` — it never mentioned `sendRichMessage`
+ * and structurally cannot match a `ctx.replyWith*` helper.
+ *
+ * Measured, not inferred: on a live agent's buffer the `/usage` card at id
+ * 20938 left NO row, while the `tg-post` transformer in this very file logged
+ * its `sendRichMessage` POST. The transformer layer SAW the send the recorder
+ * missed. That is the whole argument for moving here: grammy resolves this
+ * chain immediately around the HTTP POST, below every helper, every `ctx.*`
+ * shorthand, `lockedBot`, and `bot.api.raw` — there is no call shape that
+ * reaches Telegram without passing through it, so no future verb can silently
+ * opt out the way `switchroomReply` did.
+ *
+ * `observe` is injected rather than imported: this module must not depend on
+ * anything under `gateway/` (see the file header). The caller keeps ownership
+ * of the history writers, the `isGatewayMain && HISTORY_ENABLED` gate, and the
+ * empty-body alarm.
+ *
+ * Only a RESOLVED, `ok:true` response is observed. grammy hands this chain the
+ * raw `ApiResponse` and converts `{ok:false}` into a thrown `GrammyError` only
+ * after the chain returns (see `installTgPostLogger`'s docblock), so a
+ * rejection arrives here as a resolved body and must be skipped — recording a
+ * Telegram error object as a card body is exactly the empty-row failure #4576
+ * was. Non-message results (`getUpdates` arrays, `getMe`, `true` from
+ * `answerCallbackQuery`) are filtered by the observer's own shape test.
+ *
+ * Pure observation: the response is returned untouched and nothing here can
+ * throw into the send path.
+ */
+export function installSystemMessageObserver(
+  bot: Bot,
+  observe: (result: unknown, opts?: TgSendContext) => void,
+): void {
+  bot.api.config.use(async (prev, method, payload, signal) => {
+    const res = await prev(method, payload, signal)
+    try {
+      const r = res as unknown as { ok?: boolean; result?: unknown }
+      if (r != null && typeof r === 'object' && r.ok === true) {
+        observe(r.result, resolveSendContext(payload))
+      }
+    } catch {
+      /* observing a send must never break the send */
+    }
+    return res
+  })
+}
+
+/**
+ * Merge the caller-published context with what the outbound PAYLOAD itself
+ * carries. The context wins where both exist (it is the caller's own intent);
+ * the payload is what keeps an unwrapped `ctx.reply*` send attributable to a
+ * chat and topic at all. The response's own `chat.id` still outranks both
+ * downstream — this is only the fallback tier.
+ */
+function resolveSendContext(payload: unknown): TgSendContext | undefined {
+  const ctx = sendContextStore.getStore()
+  const p = (payload ?? {}) as Record<string, unknown>
+  const rawChat = p.chat_id
+  const chat_id =
+    ctx?.chat_id ??
+    (typeof rawChat === 'string' || typeof rawChat === 'number' ? String(rawChat) : undefined)
+  const rawThread = p.message_thread_id
+  const threadId = ctx?.threadId ?? (typeof rawThread === 'number' ? rawThread : undefined)
+  if (chat_id == null && threadId == null && ctx?.verb == null) return undefined
+  return {
+    ...(chat_id != null ? { chat_id } : {}),
+    ...(threadId != null ? { threadId } : {}),
+    ...(ctx?.verb != null ? { verb: ctx.verb } : {}),
+  }
 }
 
 // ─── robustApiCall factory: REMOVED (#3863) ───────────────────────────────

--- a/telegram-plugin/tests/card-history-lane.test.ts
+++ b/telegram-plugin/tests/card-history-lane.test.ts
@@ -49,8 +49,13 @@ import {
   type EnvelopeBuildParams,
 } from '../gateway/inbound-router.js'
 import { makeSystemMessageObserver } from '../gateway/system-message-observer.js'
-import { Bot } from 'grammy'
-import { installRichMarkdownGuard } from '../shared/bot-runtime.js'
+import { Bot, Context } from 'grammy'
+import {
+  installRichMarkdownGuard,
+  installSystemMessageObserver,
+  makeSwitchroomReply,
+  withTgSendContext,
+} from '../shared/bot-runtime.js'
 import { installSentTextCapture } from '../shared/sent-text-capture.js'
 import { richMessage } from '../rich-send.js'
 
@@ -314,6 +319,170 @@ describe('#4576: the stored card body is NOT empty — real sendRichMessage resp
     )
     expect(cards).toHaveLength(verbs.length)
     expect(cards.filter((r) => r.text.length === 0)).toEqual([])
+  })
+})
+
+describe('#4599: the SLASH-COMMAND card path is recorded too', () => {
+  const BOT_INFO = {
+    id: 123456, is_bot: true as const, first_name: 'Test', username: 'test_bot',
+    can_join_groups: false, can_read_all_group_messages: false,
+    supports_inline_queries: false, can_connect_to_business: false,
+    has_main_web_app: false,
+  }
+
+  /**
+   * The gateway's REAL transformer stack with the observer installed exactly
+   * where gateway.ts installs it (after `installSentTextCapture`), transport
+   * stubbed to answer with the true `Message.RichMessageMessage` shape echoing
+   * the markdown that was actually POSTed.
+   *
+   * `editMessageText` re-uses the `message_id` in the payload, so an edit
+   * returns the id it edited — the shape the observer's send-vs-edit rule
+   * depends on.
+   */
+  function makeCardBot(observe: (result: unknown, opts?: { verb?: string }) => void) {
+    let nextId = 30_000
+    const posted: string[] = []
+    const fakeFetch = (async (_url: unknown, init: { body?: string } | undefined) => {
+      const payload = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
+      posted.push(String(payload.__method__ ?? ''))
+      const rich = payload.rich_message as { markdown?: unknown } | undefined
+      const id = typeof payload.message_id === 'number' ? payload.message_id : nextId++
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          result: {
+            message_id: id,
+            date: 0,
+            chat: { id: Number(CHAT), type: 'private' },
+            ...(typeof rich?.markdown === 'string'
+              ? { rich_message: { blocks: [{ type: 'paragraph', text: { text: rich.markdown } }] } }
+              : { text: String(payload.text ?? '') }),
+          },
+        }),
+      } as unknown as Response
+    }) as unknown as typeof fetch
+
+    const bot = new Bot('123456:TEST_TOKEN', { botInfo: BOT_INFO, client: { fetch: fakeFetch } })
+    installRichMarkdownGuard(bot)
+    installSentTextCapture(bot)
+    installSystemMessageObserver(bot, observe)
+    return { bot, posted }
+  }
+
+  /** A grammy Context for an inbound `/usage`, as the command handler receives it. */
+  function makeCtx(bot: Bot): Context {
+    return new Context(
+      {
+        update_id: 1,
+        message: {
+          message_id: 20_930,
+          date: 0,
+          chat: { id: Number(CHAT), type: 'private' as const },
+          from: { id: 111, is_bot: false, first_name: 'Alice' },
+          text: '/usage',
+        },
+      } as never,
+      bot.api,
+      BOT_INFO,
+    )
+  }
+
+  it('a /usage card sent via switchroomReply leaves exactly one non-empty row', async () => {
+    // THE #4599 DEFECT, pinned. `switchroomReply` answers every slash command
+    // through `ctx.replyWithRichMessage`, which builds its own payload and calls
+    // `bot.api.*` directly — it never transits `robustApiCall`, where the #4571
+    // recorder was hooked. Measured on a live agent: the `/usage` card at id
+    // 20938 left no row, so a quote-reply to it resolved to nothing. A recorder
+    // that only sees `robustApiCall` cannot pass this test.
+    const observe = makeObserver()
+    const { bot } = makeCardBot(observe)
+    const switchroomReply = makeSwitchroomReply(() => undefined)
+    const BODY = 'Usage this week — Opus 41 percent, Sonnet 12 percent'
+
+    await switchroomReply(makeCtx(bot), BODY, { html: true })
+
+    const cards = query({ chat_id: CHAT, limit: 50, include_system: true }).filter(
+      (r) => r.role === 'system',
+    )
+    expect(cards).toHaveLength(1)
+    expect(cards[0]!.text).toBe(BODY)
+
+    // …and the quote-reply the operator actually makes now resolves.
+    const resolved = resolveReplyToFromBuffer({
+      replyToMessageId: cards[0]!.message_id,
+      replyToText: undefined,
+      replyToTextEscaped: undefined,
+      historyEnabled: true,
+      replyToTextMax: REPLY_TO_TEXT_MAX,
+      lookup: boundLookup,
+    })
+    expect(resolved.replyToRole).toBe('system')
+    expect(resolved.replyToText).toBe(BODY)
+  })
+
+  it('the PLAIN ctx.reply branch of switchroomReply is recorded as well', async () => {
+    const observe = makeObserver()
+    const { bot } = makeCardBot(observe)
+    const switchroomReply = makeSwitchroomReply(() => undefined)
+
+    await switchroomReply(makeCtx(bot), 'plain notice, no markdown', {})
+
+    const cards = query({ chat_id: CHAT, limit: 50, include_system: true }).filter(
+      (r) => r.role === 'system',
+    )
+    expect(cards).toHaveLength(1)
+    expect(cards[0]!.text).toBe('plain notice, no markdown')
+  })
+
+  it('a wrapped send keeps its verb → kind, and its edits do NOT add a second row', async () => {
+    // The behaviour the move must PRESERVE: `robustApiCall` publishes its verb
+    // through `withTgSendContext`, so the 117 live `role='system'` rows keep
+    // their `kind` (`activity-summary`, `worker-feed`, …) instead of degrading
+    // to null now that the recorder no longer sits on that wrapper.
+    let clock = 1_000
+    const observe = makeObserver(() => clock)
+    const { bot } = makeCardBot(observe)
+
+    const sent = await withTgSendContext({ chat_id: CHAT, verb: 'activity-summary.send' }, () =>
+      bot.api.sendRichMessage(Number(CHAT), richMessage('Working — 3 tools')),
+    )
+    const id = (sent as { message_id: number }).message_id
+
+    clock += 60_000
+    await withTgSendContext({ chat_id: CHAT, verb: 'activity-summary.edit' }, () =>
+      bot.api.editMessageText(Number(CHAT), id, richMessage('Working — 11 tools')),
+    )
+
+    const cards = query({ chat_id: CHAT, limit: 50, include_system: true }).filter(
+      (r) => r.role === 'system',
+    )
+    expect(cards).toHaveLength(1)
+    expect(cards[0]!.message_id).toBe(id)
+    expect(cards[0]!.kind).toBe('activity-summary')
+    expect(cards[0]!.text).toBe('Working — 11 tools')
+  })
+
+  it('a Telegram REJECTION is never recorded as a card', async () => {
+    // grammy resolves the transformer chain with the raw `{ok:false}` body and
+    // only throws afterwards, so a failed send reaches the observer as a
+    // RESOLVED response. Recording its error object would be #4576 all over.
+    const observe = makeObserver()
+    const failFetch = (async () =>
+      ({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: false, error_code: 400, description: 'chat not found' }),
+      }) as unknown as Response) as unknown as typeof fetch
+    const bot = new Bot('123456:TEST_TOKEN', { botInfo: BOT_INFO, client: { fetch: failFetch } })
+    installSystemMessageObserver(bot, observe)
+
+    await expect(
+      bot.api.sendRichMessage(Number(CHAT), richMessage('never lands')),
+    ).rejects.toThrow()
+    expect(query({ chat_id: CHAT, limit: 50, include_system: true })).toHaveLength(0)
   })
 })
 

--- a/telegram-plugin/tests/system-message-observer.test.ts
+++ b/telegram-plugin/tests/system-message-observer.test.ts
@@ -1,7 +1,9 @@
 /**
  * system-message-observer — the card-lane recorder's pure behaviour (#4571).
  *
- * The observer hangs off gateway.ts's single `robustApiCall` chokepoint and
+ * The observer hangs off the grammy API transformer seam, installed at bot
+ * construction (#4599 moved it there from gateway.ts's `robustApiCall`, which
+ * the `ctx.replyWithRichMessage` slash-command path bypassed entirely), and
  * turns every card the gateway posts (activity summary, status pin, approval /
  * boot / issues cards, progress lines) into ONE resolvable history row. The
  * two properties that make it safe to run on the hot send path are asserted
@@ -12,12 +14,20 @@
  *   2. an id that turns out to belong to a real reply / inbound is demoted to
  *      `foreign` and never written to again.
  *
+ * Both install the observer in their OWN harness bot, so a third block at the
+ * bottom of this file pins the single PRODUCTION install line in
+ * `initGatewayBot()` — see its docblock.
+ *
  * The end-to-end proof (card posted → id resolvable → a reply pointing at it
  * is understood) needs a real bun:sqlite history.db and lives in
  * card-history-lane.test.ts (bun).
  */
 
 import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import ts from 'typescript'
 import {
   makeSystemMessageObserver,
   normalizeSendVerb,
@@ -221,5 +231,78 @@ describe('makeSystemMessageObserver', () => {
     observe(sentMessage(1, 'card 1 edited'), { chat_id: CHAT, verb: 'boot-card' })
     expect(store.rows.size).toBe(64)
     expect(store.rows.get(1)?.text).toBe('card 1 edited')
+  })
+})
+
+/**
+ * Boot-wiring pin (#4599).
+ *
+ * Every behaviour test above installs the observer in its OWN harness, so
+ * deleting the single production install line in `initGatewayBot()` leaves all
+ * of them green while ALL card recording silently vanishes — worse than
+ * pre-#4571, because the old `robustApiCall` hook is gone and the empty-body
+ * alarm now lives INSIDE the observer, so nothing would fire either. Grammy's
+ * installed transformers are anonymous fns with nothing to grip at runtime, so
+ * this is a source-level AST assertion on the boot path — the same approach
+ * `format-guard-pins.test.ts` uses for `installRichMarkdownGuard`.
+ */
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const GATEWAY_PATH = resolve(__dirname, '..', 'gateway', 'gateway.ts')
+const GATEWAY_SRC = readFileSync(GATEWAY_PATH, 'utf8')
+const gatewaySource = ts.createSourceFile(
+  GATEWAY_PATH,
+  GATEWAY_SRC,
+  ts.ScriptTarget.Latest,
+  true,
+  ts.ScriptKind.TS,
+)
+
+function findFunction(name: string): ts.FunctionDeclaration | undefined {
+  for (const s of gatewaySource.statements) {
+    if (ts.isFunctionDeclaration(s) && s.name?.text === name) return s
+  }
+  return undefined
+}
+
+function countCallsTo(root: ts.Node, name: string): number {
+  let count = 0
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === name
+    ) {
+      count++
+      // Installed on the constructed bot instance, with the real observer.
+      expect(node.arguments[0]?.getText(gatewaySource)).toBe('bot')
+      expect(node.arguments[1]?.getText(gatewaySource)).toBe('observeSentMessage')
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(root)
+  return count
+}
+
+describe('boot wiring: installSystemMessageObserver is installed on the production Bot', () => {
+  it('imports installSystemMessageObserver from ../shared/bot-runtime.js', () => {
+    // The import must exist for the boot call to resolve; a refactor that drops
+    // the import would break the seam.
+    expect(GATEWAY_SRC).toMatch(
+      /import\s*\{[^}]*\binstallSystemMessageObserver\b[^}]*\}\s*from\s*'\.\.\/shared\/bot-runtime\.js'/,
+    )
+  })
+
+  it('calls installSystemMessageObserver(bot, observeSentMessage) exactly once inside initGatewayBot()', () => {
+    const fn = findFunction('initGatewayBot')
+    expect(fn?.body).toBeDefined()
+    expect(countCallsTo(fn!.body!, 'installSystemMessageObserver')).toBe(1)
+  })
+
+  it('builds the production observer from the real history writers', () => {
+    // The install is conditional on `observeSentMessage`; pin what fills it, or
+    // the line above could survive against a permanently-undefined observer.
+    expect(GATEWAY_SRC).toMatch(
+      /const observeSentMessage = isGatewayMain && HISTORY_ENABLED\s*\n?\s*\?\s*makeSystemMessageObserver\(/,
+    )
   })
 })


### PR DESCRIPTION
## The contradiction this PR resolves

`#4571` hooked the card-history observer onto `gateway.ts`'s `robustApiCall`, and `system-message-observer.ts` asserted that was

> the ONE chokepoint every gateway outbound already goes through … enforced by the `check-bot-api-wrapping` lint guard.

**Both halves were false the day they merged.**

1. grammY's `ctx.*` sugar builds the payload and calls `bot.api.*` itself. `switchroomReply` — the helper every SLASH-COMMAND card answers through (`/usage`, `/model`, `/auth`, `/approvals`, `/start`, `/help`) — sends via `ctx.replyWithRichMessage` (`shared/bot-runtime.ts`) and never transits `robustApiCall`.
2. The lint guard could not have caught it: its verb pattern is `\b(bot|lockedBot|ctx)\.api\.(sendMessage|…)\b` (`scripts/check-bot-api-wrapping.sh:52`). It never mentioned `sendRichMessage`, and it structurally cannot match a `ctx.replyWith*` call.

**Measured, not inferred.** On a live agent's `history.db` the `/usage` card at message id `20938` left **no row**, while the `tg-post` transformer in `shared/bot-runtime.ts` logged its `sendRichMessage` POST. The transformer layer *saw the send the recorder missed*. A quote-reply to any slash-command card therefore resolved to nothing — the exact "I can't see the message you replied to" symptom #4571 set out to kill.

## The fix

Move the hook to the transformer layer. `installSystemMessageObserver` is a grammy API transformer, which grammy resolves immediately around the HTTP POST — below every helper, every `ctx.*` shorthand, `lockedBot`, and `bot.api.raw`. No call shape reaches Telegram without passing through it, so no future verb can opt out the way `switchroomReply` silently did.

The observer function is **injected**, not imported, so `shared/bot-runtime.ts` keeps its no-imports-from-`gateway/` rule. The caller keeps ownership of the history writers, the `isGatewayMain && HISTORY_ENABLED` gate, and the empty-body alarm.

### Behaviour preserved

- `robustApiCall` now publishes `{chat_id, threadId, verb}` through `withTgSendContext` (AsyncLocalStorage), so the ~117 live `role='system'` rows keep their `kind` (`activity-summary`, `worker-feed`, `rollout-status-post`, `queued-card`, `handback-preturn`) instead of degrading to `null`.
- **Exactly one row per card.** The observer's conditional insert and its send-vs-edit rule are untouched, and the hook is MOVED rather than added — there is no second observation to de-duplicate.
- A Telegram rejection arrives here as a RESOLVED `{ok:false}` body (grammy throws only *after* the chain returns, `grammy 1.44.0 out/core/client.js:95-100`) and is skipped. Recording an error object as a card body would be #4576 all over again.
- `lockedBot` wraps the same `bot.api`, so it is covered too.
- gateway.ts is line-neutral-or-better: 24853 lines, ratchet 24805 + 50 slack.

## Tests

`telegram-plugin/tests/card-history-lane.test.ts`, +4 cases in a new `#4599` describe. They drive the **real** `switchroomReply` → `ctx.replyWithRichMessage` path against the **production** transformer stack (`installRichMarkdownGuard` → `installSentTextCapture` → `installSystemMessageObserver`) with transport stubbed to answer with the true `Message.RichMessageMessage` shape:

- a `/usage` card leaves exactly one non-empty row and resolves as a quote-reply antecedent;
- the plain `ctx.reply` branch likewise;
- a wrapped send keeps its verb→kind and its edits add **no second row**;
- a rejection records nothing.

### Mutation-checked, both directions

| mutation | result |
|---|---|
| gate the transformer on "a send context is present" (i.e. the old `robustApiCall`-only semantics) | both `switchroomReply` cases FAIL (`Expected length: 1, Received length: 0`); the wrapped-send case still passes |
| drop `verb` from `withTgSendContext` | the kind assertion FAILS (`Expected: "activity-summary", Received: null`) |

Both reverted after.

## Local verification

- `npx tsc --noEmit` — clean
- `npm run lint` — all guards clean, incl. `check-gateway-line-ratchet: clean (24853 lines)`
- `bun test telegram-plugin/tests/card-history-lane.test.ts` — 15 pass / 0 fail
- `npx vitest run telegram-plugin/tests/system-message-observer.test.ts` — 11 pass
- Full `npx vitest run` — 22347 pass. The 143 failures are **pre-existing and environmental**, reproduced identically on a clean `origin/main` worktree (`tests/cli.issues.test.ts` 16/16, `tests/boot-self-test.test.ts` 6/9 — this runner is uid 0, so "root-owned dir is not writable" fixtures cannot hold). CI is the authority.

## Follow-up

`check-bot-api-wrapping.sh`'s blind spot is real and separate: adding `sendRichMessage`/`sendRichMessageDraft` to its pattern yields **zero** new violations, but adding a `ctx.reply*` pattern surfaces **31** unwrapped sites — and grammy's `Context.reply` auto-injects `message_thread_id` for topic messages (`out/context.js:676-687`), so all 31 are genuinely inside the THREAD_NOT_FOUND blast radius #1075 exists to police. That is its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)