### PR TITLE
test(gateway): de-flake the orphaned-db-sweep stop() assertion

### DIFF
--- a/telegram-plugin/tests/orphaned-db-sweep.test.ts
+++ b/telegram-plugin/tests/orphaned-db-sweep.test.ts
@@ -701,11 +701,24 @@ describe('startOrphanedDbSweep', () => {
     expect(lines.length).toBeGreaterThan(1)
 
     stop()
-    // A tick is async, so one may be in flight when stop() lands. Let it settle
-    // before snapshotting — the property under test is "no NEW ticks start",
-    // not "no line is ever appended after the stop() call returns".
-    await sleep(60)
-    const atStop = lines.length
+    // A tick is async, so one may be in flight when stop() lands — the property
+    // under test is "no NEW ticks start", not "no line is ever appended after
+    // the stop() call returns". That allowance used to be a FIXED 60ms settle
+    // window, which a loaded merge-queue runner blew straight through: the
+    // in-flight tick landed after the snapshot and the exact-equality assertion
+    // below saw atStop + 1 (#4601, two of three consecutive queue passes).
+    //
+    // Poll to QUIESCENCE instead of guessing a window. This stays a real test
+    // of the property: an uncleared 5ms interval never quiesces, so it burns
+    // the whole deadline and STILL fails the assertion below.
+    const quiesceBy = Date.now() + 5_000
+    let atStop = lines.length
+    for (;;) {
+      await sleep(40)
+      if (lines.length === atStop) break
+      atStop = lines.length
+      if (Date.now() > quiesceBy) break
+    }
     await sleep(250)
     // A stop() that did not clear the interval would add ~50 more lines here.
     expect(lines.length).toBe(atStop)

--- a/telegram-plugin/tests/orphaned-db-sweep.test.ts
+++ b/telegram-plugin/tests/orphaned-db-sweep.test.ts
@@ -700,27 +700,22 @@ describe('startOrphanedDbSweep', () => {
     // Multiple ticks: proves the interval repeats, not just fires once.
     expect(lines.length).toBeGreaterThan(1)
 
+    const atStop = lines.length
     stop()
-    // A tick is async, so one may be in flight when stop() lands — the property
-    // under test is "no NEW ticks start", not "no line is ever appended after
-    // the stop() call returns". That allowance used to be a FIXED 60ms settle
-    // window, which a loaded merge-queue runner blew straight through: the
-    // in-flight tick landed after the snapshot and the exact-equality assertion
-    // below saw atStop + 1 (#4601, two of three consecutive queue passes).
+    // The property under test is "no NEW ticks start", not "no line is ever
+    // appended after stop() returns": the tick body is async, so one tick can
+    // already be in flight when stop() lands and will still emit its line.
     //
-    // Poll to QUIESCENCE instead of guessing a window. This stays a real test
-    // of the property: an uncleared 5ms interval never quiesces, so it burns
-    // the whole deadline and STILL fails the assertion below.
-    const quiesceBy = Date.now() + 5_000
-    let atStop = lines.length
-    for (;;) {
-      await sleep(40)
-      if (lines.length === atStop) break
-      atStop = lines.length
-      if (Date.now() > quiesceBy) break
-    }
-    await sleep(250)
-    // A stop() that did not clear the interval would add ~50 more lines here.
-    expect(lines.length).toBe(atStop)
+    // The sweep's own `running` guard means AT MOST ONE can be in flight, so
+    // the tolerance is exactly one line — assert that, rather than trying to
+    // out-wait the in-flight tick and then demanding exact equality. Every
+    // fixed settle window is a guess a loaded runner beats: 60ms flaked two of
+    // three consecutive merge-queue passes and a 40ms quiescence poll flaked
+    // again on the very next one (#4601), because a tick that has not yet
+    // resolved looks identical to quiescence.
+    await sleep(400)
+    // Not a weakening: an uncleared 5ms interval adds dozens of lines here, so
+    // this still fails hard on a stop() that does not clear the timer.
+    expect(lines.length - atStop).toBeLessThanOrEqual(1)
   })
 })


### PR DESCRIPTION
## Summary

`telegram-plugin/tests/orphaned-db-sweep.test.ts:703` allowed for the one in-flight async tick that can land after `stop()` with a **fixed 60ms settle window**, then asserted exact equality on the line count. A loaded merge-queue runner blows through 60ms, the tick lands after the snapshot, and the assertion sees `atStop + 1`.

## Why now

It failed **two of three consecutive merge-queue passes** while landing an unrelated train (#4599, #4598): [31428607108](https://github.com/switchroom/switchroom/actions/runs/31428607108) and [31430925781](https://github.com/switchroom/switchroom/actions/runs/31430925781), 1 fail out of ~10 970. Neither PR touches the sweep. `bun-test` is a required sentinel, so this is an unrelated-PR merge blocker, not cosmetic noise.

The product code is not implicated: `startOrphanedDbSweep` (`gateway/orphaned-db-sweep.ts:314`) returns `() => clearInterval(timer)`, and a live 5ms interval would add ~50 lines in the 250ms window, not one.

## The fix

Snapshot the line count **before** `stop()` and assert the tail grew by **at most one line**.

The sweep's own `running` guard (`orphaned-db-sweep.ts:305-311`) means at most ONE tick can be in flight when `stop()` lands, so one line is the exact tolerance the property allows. Every fixed settle window is a guess a loaded runner beats — and a 40ms quiescence poll (the first attempt in this PR) flaked again on the very next queue pass, because a tick that has not yet resolved is indistinguishable from quiescence.

Not a weakening: an uncleared 5ms interval adds dozens of lines in the 400ms tail, so the assertion still fails hard on a `stop()` that does not clear the timer. And there is no remaining race in either direction — if the in-flight tick lands after the window, growth is 0, which also passes.

## Test plan

```
bun test telegram-plugin/tests/orphaned-db-sweep.test.ts    20 pass, 0 fail
npm run lint                                                clean
```

Mutation-checked: replacing `clearInterval(timer)` with a no-op fails the test (19 pass / 1 fail). Stress-checked: 10 consecutive local runs, 0 fail.

Closes #4601. Test-only, no shippable code change, hence `[skip changelog]`.

Job spec: `reference/jobs/` — always available (a required-check flake that blocks merges is availability of the delivery pipeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
