### PR TITLE
fix(hindsight): stop the graph_maintenance retry storm (9 attempts x a 115s query, every 30 min, per bank)

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -147,6 +147,7 @@ jobs:
               - 'tests/docker/hindsight-query-analyzer-languages.test.ts'
               - 'tests/docker/hindsight-temporal-offload-patch.test.ts'
               - 'tests/docker/hindsight-metrics-cardinality-patch.test.ts'
+              - 'tests/docker/hindsight-graph-maintenance-retry-storm.test.ts'
               - 'tests/docker/dockerfile-hindsight-bakes.test.ts'
               - '.github/workflows/docker-e2e.yml'
 
@@ -483,6 +484,21 @@ jobs:
           SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
         run: npx vitest run tests/docker/hindsight-metrics-cardinality-patch.test.ts
 
+      - name: Run the hindsight graph-maintenance retry-storm probe (RED/GREEN, must not skip)
+        # Same contract, for the graph_maintenance retry-storm fix. The bakes
+        # test is grep-on-file and cannot see the outcomes that matter here:
+        # (a) on Python 3.11 `asyncio.TimeoutError` IS builtin `TimeoutError`,
+        # which is an `OSError` SUBCLASS — so an `_is_retryable` whose OSError
+        # arm is checked first returns True regardless of `retry_timeouts`,
+        # leaving the fix silently inert while every string assertion stays
+        # green; (b) that Pass 2's committed orphan count survives a Pass-3
+        # retry instead of being clobbered to 0. Only driving the real
+        # `retry_with_backoff` / `run_graph_maintenance_job` and counting
+        # attempts + reading back the reported counters catches either.
+        env:
+          SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
+        run: npx vitest run tests/docker/hindsight-graph-maintenance-retry-storm.test.ts
+
       - name: Run the hindsight pg_search tokenizer-drift probe (RED/GREEN, must not skip)
         # Epic #4474 finding C1. The bakes test can only see that the patch TEXT
         # is present; it cannot see the outcome that matters — that the shipping
@@ -672,7 +688,7 @@ jobs:
       - name: Label-scoped teardown
         if: always()
         run: |
-          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-mm-refresh-debounce-patch hindsight-pg-search-tokenizer-drift-patch hindsight-pg-search-filter-pushdown-patch hindsight-text-search-migration-patch hindsight-graph-seed-retirement hindsight-maxitems-grammar-patch hindsight-reflect-directives-patch hindsight-recall-budget-reflect-grounding hindsight-reranker-priority-patch hindsight-query-analyzer-languages hindsight-temporal-offload-patch hindsight-pg-fsync-probe; do
+          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-mm-refresh-debounce-patch hindsight-pg-search-tokenizer-drift-patch hindsight-pg-search-filter-pushdown-patch hindsight-text-search-migration-patch hindsight-graph-seed-retirement hindsight-maxitems-grammar-patch hindsight-reflect-directives-patch hindsight-recall-budget-reflect-grounding hindsight-reranker-priority-patch hindsight-query-analyzer-languages hindsight-temporal-offload-patch hindsight-graph-maintenance-retry-storm hindsight-pg-fsync-probe; do
             ids=$(docker ps -aq --filter "label=switchroom.test=$phase" 2>/dev/null || true)
             if [ -n "$ids" ]; then docker rm -f $ids 2>/dev/null || true; fi
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,36 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+### Bug fixes
+
+- **hindsight: stop the `graph_maintenance` retry storm.** Pass 3 of the
+  graph-maintenance sweep (`prune_stale_cooccurrences`) was measured at
+  ~115s against a live bank, well past the 60s asyncpg `command_timeout`,
+  and `_is_retryable` treated the resulting `asyncio.TimeoutError` as a
+  transient connection fault — so `_SWEEP_MAX_RETRIES = 8` turned one slow
+  query into **9 full-cost attempts**, ~9 minutes of wasted DB CPU per bank
+  per 30-minute cycle, contending with live retain/recall traffic. Three
+  baked patches, all fail-loud anchor-and-replace in
+  `docker/Dockerfile.hindsight`: (A1) `retry_with_backoff` /
+  `_is_retryable` take a `retry_timeouts` flag (default `True`, so nothing
+  else changes) and the graph-maintenance sweep passes `retry_timeouts=False`
+  — a query that cannot finish inside the deadline will not finish on
+  attempt nine either. The timeout arm is checked **before** the `OSError`
+  arm because on Python 3.11 `asyncio.TimeoutError` *is* builtin
+  `TimeoutError`, which subclasses `OSError`; get that order wrong and the
+  fix is silently inert. (A2) `str(asyncio.TimeoutError())` is the empty
+  string, so 23 of 28 failed `graph_maintenance` operations recorded a blank
+  `error_message` and the storm was invisible in the operations table — the
+  worker now falls back to `<ExcClass> raised with no message (task_type=…)`.
+  (A3) Passes 2 and 3 ran in ONE transaction, so a Pass-3 timeout rolled back
+  Pass 2's completed orphan prune as well; they are now separate transactions
+  with separate retry scopes, which also makes it structurally impossible for
+  a Pass-3 retry to clobber the reported orphan count to 0. Covered by a
+  behavioural RED/GREEN probe against the pinned upstream image
+  (`tests/docker/hindsight-graph-maintenance-retry-storm.test.ts`) that counts
+  real retry attempts and reads back the reported counters — the grep-on-file
+  bakes suite cannot see either outcome.
+
 ## v0.21.5 — a native Telegram reply to a bot-sent card resolves its parent body again
 
 ### Bug fixes

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -6057,6 +6057,328 @@ print(
 )
 PYEOF
 
+# Graph-maintenance retry storm: don't retry a deterministic statement timeout,
+# don't lose the reason, don't roll back Pass 2 when Pass 3 fails.
+#
+# UPSTREAM PATCH — three defects in `graph_maintenance` / the retry helper it
+# uses, all confirmed against the pinned digest's real source. Self-verifying:
+# every anchor is asserted before replacement, so an upstream bump that
+# reformats any of these regions FAILS THE BUILD loudly rather than silently
+# dropping the fix.
+#
+# THE STORM, measured live on this fleet. `graph_maintenance` Pass 3
+# (`prune_stale_cooccurrences`) takes ~114,836 ms / 174M shared-buffer hits on
+# a production bank. The asyncpg client-side `command_timeout` is 60s
+# (HINDSIGHT_API_DB_COMMAND_TIMEOUT, applied at
+# engine/memory_engine.py:3654), so the statement is cancelled at 60s — and
+# then RETRIED, because `_SWEEP_MAX_RETRIES = 8` gives 9 attempts. Two banks x
+# every 30 minutes = ~18 minutes of wasted production DB CPU per cycle,
+# contending with live retain/recall traffic, for work that cannot possibly
+# succeed on attempt 2 when it deterministically failed on attempt 1.
+#
+# A1 — `_is_retryable` (engine/db_utils.py:57) returns True for
+# `asyncio.TimeoutError`. Retrying a statement that deterministically exceeds
+# its timeout is pure waste by construction. This adds an OPT-IN-TO-CURRENT
+# `retry_timeouts: bool = True` knob to `_is_retryable` / `retry_with_backoff`
+# (so every other caller — acquire_with_retry, vector_index_health,
+# bank_utils, memory_engine — keeps upstream behaviour byte-for-byte) and
+# passes `retry_timeouts=False` at the one call site that owns a known-slow
+# bank-wide sweep.
+#
+#   ORDER IS LOAD-BEARING, and this is the trap: on Python 3.10+ the builtin
+#   `TimeoutError` is an `OSError` SUBCLASS, and on 3.11+ (this image runs
+#   3.11.15) `asyncio.TimeoutError` IS that builtin. Upstream's single
+#   `isinstance(exc, (OSError, ConnectionError, asyncio.TimeoutError))` line
+#   therefore has TWO arms that both match a timeout. Splitting the timeout arm
+#   out and testing it FIRST is what makes `retry_timeouts=False` actually
+#   bite; leaving it after the OSError arm would make the whole fix inert while
+#   looking correct. Verified in the image:
+#     asyncio.TimeoutError is TimeoutError  -> True
+#     issubclass(TimeoutError, OSError)     -> True
+#
+# A2 — the failure was INVISIBLE. `worker/poller.py`'s generic task-failure
+# handler did `self._mark_failed(task.operation_id, str(e), task.schema)`, and
+# `str(asyncio.TimeoutError())` is the EMPTY STRING (the exception carries no
+# args). So the operation row landed as status='failed' with a BLANK
+# `error_message` and nothing anywhere said why. Measured on this fleet's live
+# bank before the fix: 23 of 28 failed `graph_maintenance` operations had an
+# empty `error_message`. `_describe_exception` guarantees a non-empty,
+# diagnostic string. Deliberately CONSERVATIVE: a non-empty `str(e)` is passed
+# through BYTE-FOR-BYTE, so existing operator surfaces that match on
+# error_message text (and `_summarise_child_error_messages`, which groups
+# siblings by exact message) are unaffected; only the previously-blank case
+# changes.
+#
+# A3 — Pass 2 and Pass 3 shared ONE transaction, so a Pass 3 timeout rolled
+# back Pass 2's completed orphan-entity prune as well: the cheap, useful pass
+# was destroyed by the expensive, failing one, every single cycle. They are
+# split into separate transactions AND separate retry scopes.
+#
+#   The separate RETRY scope is the point, not an accessory. The obvious
+#   split — one `_run_sweep` that does both, still retried as a unit — would
+#   re-run Pass 2 on every Pass 3 retry; the rerun finds 0 orphans (the first
+#   pass already committed them) and OVERWRITES the real count with 0, so the
+#   job under-reports its own work. Retrying only Pass 3 makes that
+#   impossible by construction rather than by a careful `max()`.
+#
+#   Pass 3's failure still propagates (the operation is still marked failed —
+#   this patch removes the wasted retries, it does not hide the failure), but
+#   the log line now names what Pass 2 committed before Pass 3 died.
+#
+# Guarded statically by tests/docker/dockerfile-hindsight-bakes.test.ts and
+# behaviourally (RED against unpatched upstream / GREEN patched) by
+# tests/docker/hindsight-graph-maintenance-retry-storm.test.ts.
+RUN python3 - <<'PYEOF'
+import ast
+import pathlib
+
+TAG = "switchroom hindsight graph-maintenance retry-storm patch"
+BASE = pathlib.Path("/app/api/hindsight_api")
+
+
+def apply(rel, old, new, *, count=1):
+    f = BASE / rel
+    s = f.read_text()
+    n = s.count(old)
+    assert n == count, (
+        f"{TAG}: anchor found {n}x (expected {count}) in {rel} — upstream reformatted "
+        f"this region; re-author this patch in docker/Dockerfile.hindsight. "
+        f"Anchor head: {old.splitlines()[0]!r}"
+    )
+    f.write_text(s.replace(old, new, count))
+
+
+# ---------------------------------------------------------------- A1: db_utils
+apply("engine/db_utils.py", (
+    "def _is_retryable(exc: BaseException) -> bool:\n"
+    '    """Check if an exception is retryable (transient connection issue)."""\n'
+    "    if isinstance(exc, (OSError, ConnectionError, asyncio.TimeoutError)):\n"
+    "        return True\n"
+), (
+    "def _is_retryable(exc: BaseException, retry_timeouts: bool = True) -> bool:\n"
+    '    """Check if an exception is retryable (transient connection issue).\n'
+    "\n"
+    "    switchroom: ``retry_timeouts=False`` excludes timeout-class exceptions from\n"
+    "    the retryable set. A statement that DETERMINISTICALLY exceeds the asyncpg\n"
+    "    ``command_timeout`` will exceed it again on the next attempt, so retrying it\n"
+    "    is pure wasted database CPU contending with live traffic. Defaults to True,\n"
+    "    i.e. upstream behaviour, so only callers that opt in are affected.\n"
+    "\n"
+    "    ORDER IS LOAD-BEARING. On Python 3.10+ the builtin ``TimeoutError`` is an\n"
+    "    ``OSError`` subclass, and on 3.11+ ``asyncio.TimeoutError`` IS that builtin.\n"
+    "    The timeout arm must therefore be tested BEFORE the OSError arm — otherwise\n"
+    "    ``retry_timeouts=False`` is silently swallowed by ``isinstance(exc, OSError)``\n"
+    "    and this whole fix is inert while still looking correct.\n"
+    '    """\n'
+    "    if isinstance(exc, (asyncio.TimeoutError, TimeoutError)):\n"
+    "        return retry_timeouts\n"
+    "    if isinstance(exc, (OSError, ConnectionError)):\n"
+    "        return True\n"
+))
+
+apply("engine/db_utils.py", (
+    "async def retry_with_backoff(\n"
+    "    func,\n"
+    "    max_retries: int = DEFAULT_MAX_RETRIES,\n"
+    "    base_delay: float = DEFAULT_BASE_DELAY,\n"
+    "    max_delay: float = DEFAULT_MAX_DELAY,\n"
+    "):\n"
+), (
+    "async def retry_with_backoff(\n"
+    "    func,\n"
+    "    max_retries: int = DEFAULT_MAX_RETRIES,\n"
+    "    base_delay: float = DEFAULT_BASE_DELAY,\n"
+    "    max_delay: float = DEFAULT_MAX_DELAY,\n"
+    "    retry_timeouts: bool = True,\n"
+    "):\n"
+))
+
+apply("engine/db_utils.py", (
+    "        max_delay: Maximum delay between retries (seconds)\n"
+    "\n"
+    "    Returns:\n"
+), (
+    "        max_delay: Maximum delay between retries (seconds)\n"
+    "        retry_timeouts: switchroom — when False, timeout-class exceptions are NOT\n"
+    "            retried. Defaults to True (upstream behaviour). Pass False when the\n"
+    "            wrapped statement is known to be deterministically slow, so that its\n"
+    "            timeout is a verdict rather than a transient blip.\n"
+    "\n"
+    "    Returns:\n"
+))
+
+apply("engine/db_utils.py", (
+    "        except Exception as e:\n"
+    "            if not _is_retryable(e):\n"
+    "                raise\n"
+    "            last_exception = e\n"
+), (
+    "        except Exception as e:\n"
+    "            if not _is_retryable(e, retry_timeouts=retry_timeouts):\n"
+    "                raise\n"
+    "            last_exception = e\n"
+))
+
+# ------------------------------------------------------------------ A2: poller
+apply("worker/poller.py", (
+    'def _summarise_child_error_messages(siblings: "Iterable[Any]") -> str:\n'
+), (
+    "def _describe_exception(exc: BaseException, *, context: str = \"\") -> str:\n"
+    '    """switchroom: a guaranteed-non-empty, diagnostic description of ``exc``.\n'
+    "\n"
+    "    ``str(asyncio.TimeoutError())`` is the EMPTY STRING — the exception carries\n"
+    "    no args — and the same is true of any other argless exception. Handing that\n"
+    "    straight to ``_mark_failed`` writes a BLANK ``error_message`` onto the\n"
+    "    operation row, which is the worst possible operator surface: the task reads\n"
+    "    'failed' and nothing anywhere records why. Measured on a live bank before\n"
+    "    this patch: 23 of 28 failed graph_maintenance operations had an empty\n"
+    "    ``error_message``.\n"
+    "\n"
+    "    Conservative on purpose: a non-empty ``str(exc)`` is returned BYTE-FOR-BYTE,\n"
+    "    so operator surfaces that match on error text — and\n"
+    "    ``_summarise_child_error_messages``, which groups failed siblings by exact\n"
+    "    message — are unaffected. Only the previously-blank case changes, and it\n"
+    "    gains the exception class name plus whatever context the caller supplies.\n"
+    '    """\n'
+    "    message = str(exc).strip()\n"
+    "    if message:\n"
+    "        return message\n"
+    "    described = f\"{type(exc).__name__} raised with no message\"\n"
+    "    return f\"{described} ({context})\" if context else described\n"
+    "\n"
+    "\n"
+    'def _summarise_child_error_messages(siblings: "Iterable[Any]") -> str:\n'
+))
+
+apply("worker/poller.py", (
+    "        except Exception as e:\n"
+    '            logger.error(f"Task {task.operation_id} failed: {e}")\n'
+    "            traceback.print_exc()\n"
+    "            try:\n"
+    "                await self._mark_failed(task.operation_id, str(e), task.schema)\n"
+), (
+    "        except Exception as e:\n"
+    "            # switchroom: str(e) is EMPTY for an argless exception (notably\n"
+    "            # asyncio.TimeoutError), which used to write a blank error_message.\n"
+    "            detail = _describe_exception(e, context=f\"task_type={task_type}\")\n"
+    '            logger.error(f"Task {task.operation_id} failed: {detail}")\n'
+    "            traceback.print_exc()\n"
+    "            try:\n"
+    "                await self._mark_failed(task.operation_id, detail, task.schema)\n"
+))
+
+# -------------------------------------------------------- A3: graph_maintenance
+apply("engine/graph_maintenance.py", (
+    "    async def _run_sweep() -> _SweepCounts:\n"
+    "        async with acquire_with_retry(backend) as conn:\n"
+    "            async with conn.transaction():\n"
+    "                orphan_pruned = await store.prune_orphan_entities(conn=conn, fq_table=fq_table, bank_id=bank_id)\n"
+    "                # The orphan prune above cascades cooccurrences via FK. The\n"
+    "                # explicit cooccurrence pass below catches the *stale-count*\n"
+    "                # case: both entities still exist but no current unit witnesses\n"
+    "                # them together.\n"
+    "                stale_pruned = await store.prune_stale_cooccurrences(conn=conn, fq_table=fq_table, bank_id=bank_id)\n"
+    "                return _SweepCounts(orphan_entities_pruned=orphan_pruned, stale_cooccurrences_pruned=stale_pruned)\n"
+), (
+    "    # switchroom: Pass 2 and Pass 3 run in SEPARATE transactions under SEPARATE\n"
+    "    # retry scopes. Sharing one transaction meant a Pass 3 timeout rolled back\n"
+    "    # Pass 2's completed orphan prune as well — the cheap useful pass destroyed\n"
+    "    # by the expensive failing one, every cycle. Sharing one retry scope would\n"
+    "    # additionally re-run Pass 2 on each Pass 3 retry, where it finds 0 orphans\n"
+    "    # (the first pass already committed them) and overwrites the true count with\n"
+    "    # 0. Retrying only Pass 3 makes both failure modes structurally impossible.\n"
+    "    async def _run_orphan_prune() -> int:\n"
+    "        async with acquire_with_retry(backend) as conn:\n"
+    "            async with conn.transaction():\n"
+    "                return await store.prune_orphan_entities(conn=conn, fq_table=fq_table, bank_id=bank_id)\n"
+    "\n"
+    "    async def _run_cooccurrence_prune() -> int:\n"
+    "        # The orphan prune above cascades cooccurrences via FK. This explicit\n"
+    "        # pass catches the *stale-count* case: both entities still exist but no\n"
+    "        # current unit witnesses them together.\n"
+    "        async with acquire_with_retry(backend) as conn:\n"
+    "            async with conn.transaction():\n"
+    "                return await store.prune_stale_cooccurrences(conn=conn, fq_table=fq_table, bank_id=bank_id)\n"
+))
+
+apply("engine/graph_maintenance.py", (
+    "    sweep = await retry_with_backoff(_run_sweep, max_retries=_SWEEP_MAX_RETRIES)\n"
+    "    result.orphan_entities_pruned = sweep.orphan_entities_pruned\n"
+    "    result.stale_cooccurrences_pruned = sweep.stale_cooccurrences_pruned\n"
+), (
+    "    sweep = _SweepCounts(orphan_entities_pruned=0, stale_cooccurrences_pruned=0)\n"
+    "    sweep.orphan_entities_pruned = await retry_with_backoff(_run_orphan_prune, max_retries=_SWEEP_MAX_RETRIES)\n"
+    "    # Committed and recorded BEFORE Pass 3 is attempted, so a Pass 3 failure can\n"
+    "    # neither roll this back nor zero the number that gets reported.\n"
+    "    result.orphan_entities_pruned = sweep.orphan_entities_pruned\n"
+    "    try:\n"
+    "        # switchroom: retry_timeouts=False. Pass 3 is a bank-wide sweep measured at\n"
+    "        # ~115s against a 60s asyncpg command_timeout on a production bank; a\n"
+    "        # cancelled attempt is a verdict on the statement, not a transient blip, so\n"
+    "        # the 8 further attempts were ~9 minutes of wasted DB CPU per bank per run.\n"
+    "        # Deadlocks and connection drops are still retried in full.\n"
+    "        sweep.stale_cooccurrences_pruned = await retry_with_backoff(\n"
+    "            _run_cooccurrence_prune, max_retries=_SWEEP_MAX_RETRIES, retry_timeouts=False\n"
+    "        )\n"
+    "    except Exception as e:\n"
+    "        logger.error(\n"
+    "            f\"[GRAPH_MAINT] bank={bank_id} stale-cooccurrence prune failed \"\n"
+    "            # str(e), NOT `e or ...`: the latter tests the EXCEPTION OBJECT's\n"
+    "            # truthiness (always True), so an argless TimeoutError would print an\n"
+    "            # empty message here — the very defect A2 exists to remove.\n"
+    "            f\"({type(e).__name__}: {str(e) or 'no message'}); Pass 2 already committed \"\n"
+    "            f\"{sweep.orphan_entities_pruned} orphan entities, operation_id={operation_id}\"\n"
+    "        )\n"
+    "        raise\n"
+    "    result.stale_cooccurrences_pruned = sweep.stale_cooccurrences_pruned\n"
+))
+
+# ------------------------------------------------------------------ verify
+for rel in ("engine/db_utils.py", "worker/poller.py", "engine/graph_maintenance.py"):
+    src = (BASE / rel).read_text()
+    ast.parse(src)
+
+du = (BASE / "engine/db_utils.py").read_text()
+assert du.index("isinstance(exc, (asyncio.TimeoutError, TimeoutError))") < du.index(
+    "isinstance(exc, (OSError, ConnectionError))"
+), f"{TAG}: the timeout arm must precede the OSError arm (TimeoutError is an OSError subclass) or retry_timeouts=False is inert"
+assert "asyncio.TimeoutError))" not in du.split("def _is_retryable", 1)[1].split("def retry_with_backoff", 1)[0].replace(
+    "isinstance(exc, (asyncio.TimeoutError, TimeoutError))", ""
+), f"{TAG}: a timeout arm still hides inside another isinstance tuple in _is_retryable"
+assert du.count("_is_retryable(e, retry_timeouts=retry_timeouts)") == 1, (
+    f"{TAG}: retry_with_backoff no longer threads retry_timeouts into _is_retryable"
+)
+assert du.count("if not _is_retryable(e):") == 1, (
+    f"{TAG}: expected acquire_with_retry to keep the plain (timeout-retrying) predicate"
+)
+
+po = (BASE / "worker/poller.py").read_text()
+assert "def _describe_exception(" in po, f"{TAG}: _describe_exception helper missing"
+assert "await self._mark_failed(task.operation_id, str(e), task.schema)" not in po, (
+    f"{TAG}: the generic failure path still passes a possibly-empty str(e) to _mark_failed"
+)
+assert po.count("_describe_exception(e, context=") == 1, f"{TAG}: failure path does not use _describe_exception"
+
+gm = (BASE / "engine/graph_maintenance.py").read_text()
+assert "_run_sweep" not in gm, f"{TAG}: the shared Pass 2+3 transaction survived the patch"
+assert gm.count("async def _run_orphan_prune") == 1 and gm.count("async def _run_cooccurrence_prune") == 1, (
+    f"{TAG}: the split prune helpers are missing"
+)
+assert gm.count("retry_with_backoff(") == 2, f"{TAG}: expected exactly two independent retry scopes"
+assert "retry_timeouts=False" in gm, f"{TAG}: the cooccurrence prune is still retrying timeouts"
+# Pass 2's count must be recorded before Pass 3 is even attempted, so no Pass 3
+# outcome (failure, retry, or rerun) can clobber it.
+assert gm.index("result.orphan_entities_pruned = sweep.orphan_entities_pruned") < gm.index("_run_cooccurrence_prune, max_retries="), (
+    f"{TAG}: the orphan count is recorded after Pass 3 runs and can still be clobbered"
+)
+
+print(
+    f"{TAG}: timeouts are opt-out non-retryable (order-safe against TimeoutError<:OSError); "
+    "empty-str() exceptions now yield a diagnostic error_message; graph-maintenance Pass 2/3 "
+    "split into independent transactions and retry scopes"
+)
+PYEOF
+
 # Pin the upstream `hindsight` user to UID 11000 to match
 # `HINDSIGHT_DEFAULT_UID` in src/setup/hindsight.ts (and the
 # `auth.consumers[hindsight].uid` value the operator writes in

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -1868,6 +1868,107 @@ describe("Dockerfile.hindsight shape", () => {
     );
   });
 
+  it("keeps the graph-maintenance retry-storm fix (assert-guarded, fail-loud)", () => {
+    // Three defects turned one slow statement into a recurring production
+    // incident. A1: `_is_retryable` retried a deterministic asyncpg
+    // command_timeout — 9 attempts x 2 banks every 30 minutes ≈ 18 minutes of
+    // wasted DB CPU per cycle, contending with live retain/recall. A2: the
+    // generic task-failure path passed `str(e)` to `_mark_failed`, and
+    // `str(asyncio.TimeoutError())` is the EMPTY STRING, so 23 of 28 failed
+    // graph_maintenance operations carried a blank error_message. A3: Pass 2
+    // and Pass 3 shared one transaction, so a Pass 3 timeout rolled back Pass
+    // 2's completed orphan prune.
+    //
+    // Behaviour (RED against unpatched upstream / GREEN patched) is proven in
+    // tests/docker/hindsight-graph-maintenance-retry-storm.test.ts. This pins
+    // only the shape a grep can see.
+
+    // The exact-once anchor guard (fail-loud on upstream drift).
+    expect(dockerfile).toMatch(
+      /\{TAG\}: anchor found \{n\}x \(expected \{count\}\) in \{rel\}/,
+    );
+
+    // ---- A1 ----
+    // The opt-out knob, on the predicate and on the retry helper.
+    expect(dockerfile).toContain(
+      "def _is_retryable(exc: BaseException, retry_timeouts: bool = True) -> bool:",
+    );
+    expect(dockerfile).toContain('"    retry_timeouts: bool = True,\\n"');
+    expect(dockerfile).toContain(
+      "_is_retryable(e, retry_timeouts=retry_timeouts)",
+    );
+    // The timeout arm must be SPLIT OUT of the OSError tuple, because on
+    // py3.10+ the builtin TimeoutError is an OSError subclass and on 3.11+
+    // asyncio.TimeoutError IS that builtin. A version that added the parameter
+    // but left the timeout inside the OSError tuple would carry every other
+    // literal here while retrying timeouts exactly as before.
+    expect(dockerfile).toContain(
+      '"    if isinstance(exc, (asyncio.TimeoutError, TimeoutError)):\\n"',
+    );
+    expect(dockerfile).toContain('"        return retry_timeouts\\n"');
+    expect(dockerfile).toContain(
+      '"    if isinstance(exc, (OSError, ConnectionError)):\\n"',
+    );
+    // The build asserts that ordering itself, so a re-author cannot lose it.
+    expect(dockerfile).toMatch(
+      /the timeout arm must precede the OSError arm \(TimeoutError is an OSError subclass\)/,
+    );
+    // Every other caller keeps upstream behaviour: acquire_with_retry's
+    // predicate is deliberately left retrying timeouts.
+    expect(dockerfile).toMatch(
+      /assert du\.count\("if not _is_retryable\(e\):"\) == 1,/,
+    );
+
+    // ---- A2 ----
+    expect(dockerfile).toContain("def _describe_exception(");
+    expect(dockerfile).toContain(
+      '"                await self._mark_failed(task.operation_id, detail, task.schema)\\n"',
+    );
+    expect(dockerfile).toMatch(
+      /the generic failure path still passes a possibly-empty str\(e\) to _mark_failed/,
+    );
+
+    // ---- A3 ----
+    expect(dockerfile).toContain(
+      '"    async def _run_orphan_prune() -> int:\\n"',
+    );
+    expect(dockerfile).toContain(
+      '"    async def _run_cooccurrence_prune() -> int:\\n"',
+    );
+    expect(dockerfile).toContain(
+      "_run_cooccurrence_prune, max_retries=_SWEEP_MAX_RETRIES, retry_timeouts=False",
+    );
+    // The shared-transaction helper must be GONE, not merely shadowed, and the
+    // two passes must sit in two independent retry scopes.
+    expect(dockerfile).toMatch(/assert "_run_sweep" not in gm,/);
+    expect(dockerfile).toMatch(
+      /assert gm\.count\("retry_with_backoff\("\) == 2,/,
+    );
+    // The reviewer-caught clobber: Pass 2's count is recorded BEFORE Pass 3 is
+    // attempted, so no Pass 3 retry can overwrite it with 0.
+    expect(dockerfile).toMatch(
+      /the orphan count is recorded after Pass 3 runs and can still be clobbered/,
+    );
+    // `e or ...` tests the exception OBJECT's truthiness (always True) and
+    // would reintroduce the very empty message A2 exists to remove.
+    expect(dockerfile).toContain("{str(e) or 'no message'}");
+    expect(dockerfile).not.toContain("{e or 'no message'}");
+
+    // Post-replace verification: every patched file must still parse.
+    expect(dockerfile).toContain(
+      'for rel in ("engine/db_utils.py", "worker/poller.py", "engine/graph_maintenance.py"):',
+    );
+    // The block's TAG (which every assert message and the success line
+    // interpolate) is what the behavioural probe test greps the block out by,
+    // so it must not drift.
+    expect(dockerfile).toContain(
+      'TAG = "switchroom hindsight graph-maintenance retry-storm patch"',
+    );
+    expect(dockerfile).toMatch(
+      /\{TAG\}: timeouts are opt-out non-retryable \(order-safe against TimeoutError<:OSError\)/,
+    );
+  });
+
   it("preserves upstream's start-all.sh as the post-shim CMD", () => {
     // The shim does broker auth, then `exec "$@"` which is whatever
     // CMD docker passes — must be upstream's start-all.sh so the

--- a/tests/docker/hindsight-graph-maintenance-retry-storm.test.ts
+++ b/tests/docker/hindsight-graph-maintenance-retry-storm.test.ts
@@ -1,0 +1,620 @@
+/**
+ * Behavioural proof for the graph-maintenance retry-storm patch that
+ * `docker/Dockerfile.hindsight` bakes into the pinned upstream Hindsight image.
+ *
+ * `dockerfile-hindsight-bakes.test.ts` pins the *shape* of that patch block
+ * (grep-on-file, runs everywhere). This file proves the *outcome*: it runs the
+ * same probe against unpatched upstream (must be RED) and against upstream +
+ * the patch block applied (must be GREEN). Nothing here greps the patched
+ * source — every assertion drives real shipping code and observes what it does.
+ *
+ * THE DEFECTS, in the real shipping source at the pinned digest.
+ *
+ * A production `graph_maintenance` Pass 3 (`prune_stale_cooccurrences`) was
+ * measured at ~114,836 ms / 174M shared-buffer hits against a 60s asyncpg
+ * `command_timeout`. Three separate bugs turned that one slow statement into a
+ * recurring production incident:
+ *
+ *  A1 `engine/db_utils.py:57` — `_is_retryable` returns True for
+ *     `asyncio.TimeoutError`, so a statement that DETERMINISTICALLY blows its
+ *     timeout is retried. With `_SWEEP_MAX_RETRIES = 8` that is 9 attempts, on
+ *     2 banks, every 30 minutes: ~18 minutes of wasted production DB CPU per
+ *     cycle contending with live retain/recall traffic.
+ *
+ *  A2 `worker/poller.py` — the generic failure path passed `str(e)` to
+ *     `_mark_failed`, and `str(asyncio.TimeoutError())` is the EMPTY STRING.
+ *     Operations landed as status='failed' with a blank `error_message`.
+ *     Measured on a live bank: 23 of 28 failed `graph_maintenance` operations
+ *     carried an empty `error_message`.
+ *
+ *  A3 `engine/graph_maintenance.py` — Pass 2 (orphan-entity prune) and Pass 3
+ *     shared ONE transaction, so a Pass 3 timeout rolled back Pass 2's
+ *     completed work as well. The naive split (both passes still under ONE
+ *     retry scope) has its own defect, which this probe also drives: a Pass 3
+ *     retry re-runs Pass 2, finds 0 orphans because the first pass already
+ *     committed them, and OVERWRITES the true count with 0.
+ *
+ * WHY THE SHAPE TEST IS NOT ENOUGH. A1 in particular has a silent-inert
+ * failure mode that no grep can see: on Python 3.10+ the builtin
+ * `TimeoutError` is an `OSError` SUBCLASS and on 3.11+ `asyncio.TimeoutError`
+ * IS that builtin, so a "fix" that adds the `retry_timeouts` parameter but
+ * leaves the timeout arm AFTER `isinstance(exc, OSError)` still contains every
+ * literal a bakes test greps for while retrying timeouts exactly as before.
+ * Only running the patched module catches that, which is what this file does.
+ *
+ * The probe drives the REAL `retry_with_backoff`, the REAL
+ * `WorkerPoller._execute_task_inner` failure path and the REAL
+ * `run_graph_maintenance_job` from the image, stubbing only the database and
+ * the executor — rather than re-implementing any of them here.
+ *
+ * The patch block is extracted from the Dockerfile itself rather than
+ * duplicated here, so this test cannot drift from what actually ships. It
+ * applies it by `docker exec` (not `docker build`) so it runs on daemons
+ * without buildx, and it never touches the production `switchroom-hindsight`
+ * container.
+ *
+ * SKIP DISCIPLINE: identical to `hindsight-retry-perturbation-patches.test.ts`.
+ * Locally, with no docker or no cached image, this skips (never pull a 6.4GB
+ * third-party image onto a dev box). In CI the `hindsight-probe` job pulls the
+ * pinned digest and sets SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1, under which an
+ * unavailable docker/image is a HARD FAILURE, never a green skip. Both runs
+ * assert a `PROBE_EXECUTED` sentinel so a probe that dies early can never be
+ * mistaken for a pass.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { execFileSync, execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const dockerfile = readFileSync(
+  resolve(root, "docker/Dockerfile.hindsight"),
+  "utf8",
+);
+
+const RUN_ID = randomUUID();
+const TEST_PHASE = "hindsight-graph-maintenance-retry-storm";
+
+/** The pinned upstream image, read from the Dockerfile so it can never drift. */
+const UPSTREAM_IMAGE = (() => {
+  const m = dockerfile.match(/^FROM\s+(\S+)/m);
+  if (!m) throw new Error("Dockerfile.hindsight has no FROM line");
+  return m[1];
+})();
+
+/** The patch this file proves, named by its unique in-block marker. */
+const PATCH_NAME = "graph-maintenance retry-storm patch";
+
+/**
+ * The patch block under test, pulled out of the Dockerfile's
+ * `RUN python3 - <<'PYEOF' ... PYEOF` heredocs by its unique patch name.
+ */
+function patchBlocks(): string[] {
+  const blocks = [
+    ...dockerfile.matchAll(/^RUN python3 - <<'PYEOF'\n([\s\S]*?)^PYEOF$/gm),
+  ].map((m) => m[1]);
+  const hits = blocks.filter((b) => b.includes(PATCH_NAME));
+  if (hits.length !== 1) {
+    throw new Error(
+      `Dockerfile.hindsight contains ${hits.length} "${PATCH_NAME}" RUN blocks ` +
+        `(expected exactly 1) — if the patch was deliberately removed, delete ` +
+        `this test with it.`,
+    );
+  }
+  return hits;
+}
+
+/**
+ * Python probe. Exits 0 only when every property holds; prints the offending
+ * assertions otherwise. Every printed sentinel is asserted by BOTH the RED and
+ * the GREEN case below, so the two runs are compared on the same observations.
+ */
+const PROBE = String.raw`
+import asyncio
+import json
+import sys
+
+failures = []
+
+
+def fail(msg):
+    failures.append(msg)
+
+
+from hindsight_api.engine import db_utils
+from hindsight_api.engine import graph_maintenance as gm
+
+
+# ── zero out the backoff sleeps, nothing else ─────────────────────────────
+# db_utils reaches asyncio for exactly two things: asyncio.TimeoutError in the
+# retryability predicate, and asyncio.sleep for the backoff. Swapping in a shim
+# that keeps the former and no-ops the latter makes the probe fast WITHOUT
+# reducing the retry budget, so the attempt COUNTS below are the real ones
+# (9 = _SWEEP_MAX_RETRIES 8 + 1), not a shrunken stand-in.
+class _NoSleepAsyncio:
+    TimeoutError = asyncio.TimeoutError
+
+    @staticmethod
+    async def sleep(_delay):
+        return None
+
+
+db_utils.asyncio = _NoSleepAsyncio
+
+
+class DeadlockDetectedError(Exception):
+    """Stands in for asyncpg's error class, which db_utils matches BY NAME."""
+
+
+# ══ A1: retry_with_backoff must be able to treat a timeout as a verdict ═══
+async def _count_attempts(exc_factory, **kwargs):
+    calls = []
+
+    async def _f():
+        calls.append(1)
+        raise exc_factory()
+
+    try:
+        await db_utils.retry_with_backoff(_f, max_retries=8, **kwargs)
+    except TypeError:
+        # NOT swallowed: unpatched upstream has no retry_timeouts parameter, and
+        # that must surface as the distinct "no such knob" signal below rather
+        # than being mistaken for "the function ran and made 0 attempts".
+        raise
+    except BaseException:
+        pass
+    return len(calls)
+
+
+timeout_default = asyncio.run(_count_attempts(asyncio.TimeoutError))
+print("A1_TIMEOUT_ATTEMPTS_DEFAULT", timeout_default)
+if timeout_default != 9:
+    fail("default retry_with_backoff no longer retries timeouts (%d attempts, expected 9)" % timeout_default)
+
+def _optout(exc_factory):
+    """Attempts under retry_timeouts=False; -1 when the knob does not exist."""
+    try:
+        return asyncio.run(_count_attempts(exc_factory, retry_timeouts=False))
+    except TypeError as e:
+        print("A1_NO_RETRY_TIMEOUTS_PARAM", repr(str(e)))
+        return -1
+
+
+timeout_optout = _optout(asyncio.TimeoutError)
+print("A1_TIMEOUT_ATTEMPTS_OPTOUT", timeout_optout)
+if timeout_optout != 1:
+    fail("retry_timeouts=False did not stop the retry storm (%d attempts, expected 1)" % timeout_optout)
+
+# The opt-out must be SURGICAL: a builtin TimeoutError is an OSError subclass on
+# py3.10+, so an implementation that tests the OSError arm first is inert. Drive
+# both classes, and prove the non-timeout retryables are untouched.
+builtin_optout = _optout(TimeoutError)
+print("A1_BUILTIN_TIMEOUT_ATTEMPTS_OPTOUT", builtin_optout)
+if builtin_optout != 1:
+    fail("builtin TimeoutError still retried under retry_timeouts=False (%d attempts) — the OSError arm swallowed it" % builtin_optout)
+
+for label, factory in (("deadlock", DeadlockDetectedError), ("connection", ConnectionError), ("oserror", OSError)):
+    n = _optout(factory)
+    print("A1_STILL_RETRIED_" + label.upper(), n)
+    if n != 9:
+        fail("retry_timeouts=False wrongly disabled retries for %s (%d attempts, expected 9)" % (label, n))
+
+n = _optout(ValueError)
+print("A1_NONRETRYABLE_ATTEMPTS", n)
+if n != 1:
+    fail("a non-retryable error was retried (%d attempts, expected 1)" % n)
+
+
+# ══ A2: a failed task must never record a blank error_message ════════════
+from hindsight_api.worker import poller as poller_mod
+
+
+class _NullMetrics:
+    def record_operation_result(self, *a, **k):
+        return None
+
+
+poller_mod.get_metrics_collector = lambda: _NullMetrics()
+
+
+def _drive_failure(exc):
+    """Run the REAL _execute_task_inner failure path; capture what it records."""
+    p = object.__new__(poller_mod.WorkerPoller)
+    recorded = {}
+
+    async def _run_executor(task, task_type):
+        raise exc
+
+    async def _mark_failed(operation_id, error_message, schema):
+        recorded["error_message"] = error_message
+
+    async def _mark_completed(operation_id, schema):
+        raise AssertionError("task should not have completed")
+
+    p._run_executor = _run_executor
+    p._mark_failed = _mark_failed
+    p._mark_completed = _mark_completed
+    task = poller_mod.ClaimedTask(
+        operation_id="op-probe",
+        task_dict={"type": "graph_maintenance", "bank_id": "probe"},
+        schema=None,
+    )
+    asyncio.run(p._execute_task_inner(task))
+    return recorded.get("error_message")
+
+
+msg_timeout = _drive_failure(asyncio.TimeoutError())
+print("A2_TIMEOUT_ERROR_MESSAGE", json.dumps(msg_timeout))
+if not (msg_timeout or "").strip():
+    fail("a timed-out task recorded a BLANK error_message: %r" % (msg_timeout,))
+else:
+    if "TimeoutError" not in msg_timeout:
+        fail("the recorded error_message does not name the exception class: %r" % (msg_timeout,))
+    if "graph_maintenance" not in msg_timeout:
+        fail("the recorded error_message carries no task context: %r" % (msg_timeout,))
+
+# Conservative by design: an exception that DOES have a message is passed
+# through byte-for-byte, so existing operator surfaces that match on error text
+# (and _summarise_child_error_messages, which groups siblings by exact message)
+# are unaffected.
+msg_normal = _drive_failure(RuntimeError("boom: something specific"))
+print("A2_NORMAL_ERROR_MESSAGE", json.dumps(msg_normal))
+if msg_normal != "boom: something specific":
+    fail("a normal error message was rewritten: %r" % (msg_normal,))
+
+
+# ══ A3: Pass 2 and Pass 3 must not share a transaction or a retry scope ═══
+class _Txn:
+    """Records whether the block it wrapped committed or rolled back."""
+
+    def __init__(self, log):
+        self._log = log
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self._log.append("rollback" if exc_type is not None else "commit")
+        return False
+
+
+class _Conn:
+    def __init__(self, log):
+        self._log = log
+
+    def transaction(self):
+        return _Txn(self._log)
+
+
+class _Acquire:
+    def __init__(self, log):
+        self._log = log
+
+    async def __aenter__(self):
+        return _Conn(self._log)
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _Store:
+    """Fake memories store: counts each pass and scripts Pass 3's outcome."""
+
+    def __init__(self, pass3):
+        self.orphan_calls = 0
+        self.cooccurrence_calls = 0
+        self._pass3 = pass3
+
+    async def relink_pass(self, **kwargs):
+        return {}
+
+    async def prune_orphan_entities(self, **kwargs):
+        self.orphan_calls += 1
+        # The real prune is idempotent: the FIRST call finds the orphans, every
+        # later call in the same job finds none because they are already gone.
+        return 7 if self.orphan_calls == 1 else 0
+
+    async def prune_stale_cooccurrences(self, **kwargs):
+        self.cooccurrence_calls += 1
+        outcome = self._pass3(self.cooccurrence_calls)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+
+class _Engine:
+    async def _get_backend(self):
+        return object()
+
+
+def _run_job(pass3):
+    """Drive the REAL run_graph_maintenance_job against fakes."""
+    import hindsight_api.config as config_mod
+    import hindsight_api.engine.memories as memories_mod
+    import hindsight_api.engine.memory_engine as memory_engine_mod
+
+    txn_log = []
+    store = _Store(pass3)
+    config_mod.get_config = lambda: object()
+    memories_mod.get_memories = lambda: store
+    memory_engine_mod.acquire_with_retry = lambda backend, **k: _Acquire(txn_log)
+
+    error = None
+    result = None
+    try:
+        result = asyncio.run(
+            gm.run_graph_maintenance_job(_Engine(), "probe-bank", None, operation_id="op-probe")
+        )
+    except BaseException as e:
+        error = e
+    return store, txn_log, result, error
+
+
+# --- A3a: Pass 3 times out. Pass 2's work must survive, and must not storm. ---
+store, txn_log, result, error = _run_job(lambda n: asyncio.TimeoutError())
+print("A3A_ORPHAN_PASSES", store.orphan_calls)
+print("A3A_COOCCURRENCE_PASSES", store.cooccurrence_calls)
+print("A3A_TXN_LOG", json.dumps(txn_log))
+print("A3A_ERROR", type(error).__name__ if error is not None else None)
+if store.cooccurrence_calls != 1:
+    fail("Pass 3 timeout was retried %d times — the storm is still there" % store.cooccurrence_calls)
+if store.orphan_calls != 1:
+    fail("Pass 2 ran %d times for one job — a Pass 3 retry is re-running it" % store.orphan_calls)
+if "commit" not in txn_log:
+    fail("nothing committed: Pass 2's orphan prune was rolled back by Pass 3's failure (%r)" % (txn_log,))
+if txn_log[:1] != ["commit"]:
+    fail("Pass 2 did not commit before Pass 3 ran: %r" % (txn_log,))
+if error is None:
+    fail("a failing Pass 3 silently reported success — the failure must still propagate")
+
+# --- A3b: Pass 3 fails retryably once, then succeeds. The count must hold. ---
+def _deadlock_once(n):
+    return DeadlockDetectedError("simulated") if n == 1 else 4
+
+
+store, txn_log, result, error = _run_job(_deadlock_once)
+print("A3B_ORPHAN_PASSES", store.orphan_calls)
+print("A3B_COOCCURRENCE_PASSES", store.cooccurrence_calls)
+print("A3B_RESULT", json.dumps(result, sort_keys=True))
+print("A3B_ERROR", type(error).__name__ if error is not None else None)
+if error is not None:
+    fail("a retryable Pass 3 failure was not retried: %r" % (error,))
+if store.cooccurrence_calls != 2:
+    fail("expected exactly one Pass 3 retry, saw %d attempts" % store.cooccurrence_calls)
+if store.orphan_calls != 1:
+    fail("Pass 2 re-ran on the Pass 3 retry (%d calls) — its real count gets overwritten" % store.orphan_calls)
+if (result or {}).get("orphan_entities_pruned") != 7:
+    fail(
+        "the reported orphan count was clobbered by the Pass 3 retry: %r (expected 7)"
+        % ((result or {}).get("orphan_entities_pruned"),)
+    )
+if (result or {}).get("stale_cooccurrences_pruned") != 4:
+    fail("the reported stale-cooccurrence count is wrong: %r" % ((result or {}).get("stale_cooccurrences_pruned"),))
+
+print("FAILURES", failures)
+print("PROBE_EXECUTED")
+sys.exit(1 if failures else 0)
+`;
+
+function hasDocker(): boolean {
+  try {
+    execSync("docker version --format '{{.Server.Version}}'", {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasImage(ref: string): boolean {
+  try {
+    execSync(`docker image inspect ${ref}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * CI marker. When set, this suite MUST really execute — an absent docker or
+ * an absent upstream image becomes a hard failure instead of a green skip.
+ * `.github/workflows/docker-e2e.yml` sets it after pulling the pinned digest.
+ */
+const REQUIRED = process.env.SWITCHROOM_REQUIRE_HINDSIGHT_PROBE === "1";
+
+const dockerOk = hasDocker();
+const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
+
+type ProbeResult = { status: number; stdout: string };
+
+/** Run the probe in a throwaway container, optionally patching first. */
+function runProbe(patched: boolean): ProbeResult {
+  const name = `sr-hs-gmstorm-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
+    0,
+    8,
+  )}`;
+  try {
+    execFileSync(
+      "docker",
+      [
+        "run",
+        "-d",
+        "--name",
+        name,
+        "--label",
+        `switchroom.test=${TEST_PHASE}`,
+        "--label",
+        `switchroom.test.run=${RUN_ID}`,
+        "--user",
+        "root",
+        "--network",
+        "none",
+        UPSTREAM_IMAGE,
+        "sleep",
+        "300",
+      ],
+      { stdio: ["ignore", "ignore", "pipe"] },
+    );
+
+    if (patched) {
+      for (const block of patchBlocks()) {
+        // The block is self-verifying: it asserts each upstream anchor exists
+        // exactly once and re-asserts the result, so a non-zero exit here means
+        // upstream drifted and the patch must be re-authored.
+        execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
+          input: block,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      }
+    }
+
+    const res = execFileSync(
+      "docker",
+      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
+      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
+    );
+    return { status: 0, stdout: res };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: Buffer | string };
+    return {
+      status: err.status ?? -1,
+      stdout: (err.stdout ?? "").toString(),
+    };
+  } finally {
+    try {
+      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+describe("Dockerfile.hindsight graph-maintenance retry-storm probe is real, not a silent skip", () => {
+  it("pins the upstream image by digest so the probe tests the exact shipping bytes", () => {
+    expect(UPSTREAM_IMAGE).toMatch(/@sha256:[0-9a-f]{64}$/);
+  });
+
+  it("extracts exactly the one patch block it claims to prove", () => {
+    expect(patchBlocks()).toHaveLength(1);
+  });
+
+  it("hard-fails rather than skipping when CI demands a real run", () => {
+    if (!REQUIRED) {
+      // Local/dev path: skipping is legitimate (never pull a 6.4GB image onto
+      // a dev box), but it must be visible rather than silent.
+      expect(
+        REQUIRED,
+        "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE is unset — the behavioural probe " +
+          "is advisory here. CI's hindsight-probe job sets it after pulling " +
+          `${UPSTREAM_IMAGE}.`,
+      ).toBe(false);
+      return;
+    }
+    expect(
+      dockerOk,
+      "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but the docker daemon is unreachable",
+    ).toBe(true);
+    expect(
+      imageOk,
+      `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but ${UPSTREAM_IMAGE} is not present ` +
+        "locally — the workflow must pull the pinned digest before running this suite",
+    ).toBe(true);
+  });
+});
+
+describe.skipIf(!dockerOk || !imageOk)(
+  "Dockerfile.hindsight graph-maintenance retry-storm patch changes real behaviour",
+  () => {
+    afterAll(() => {
+      // Label-scoped teardown belt (never an unlabelled bulk removal).
+      try {
+        const ids = execSync(
+          `docker ps -aq --filter label=switchroom.test.run=${RUN_ID}`,
+          { encoding: "utf8" },
+        )
+          .split("\n")
+          .filter(Boolean);
+        if (ids.length) {
+          execFileSync("docker", ["rm", "-f", ...ids], { stdio: "ignore" });
+        }
+      } catch {
+        /* nothing to clean */
+      }
+    });
+
+    it("unpatched upstream is RED — the storm, the blank error, and the clobbered count are all live", () => {
+      const { status, stdout } = runProbe(false);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED",
+      );
+      expect(status, `probe unexpectedly passed:\n${stdout}`).not.toBe(0);
+
+      // A1: upstream retries a deterministic timeout to exhaustion, and has no
+      // way to say otherwise.
+      expect(stdout).toContain("A1_TIMEOUT_ATTEMPTS_DEFAULT 9");
+      expect(stdout).toContain("A1_NO_RETRY_TIMEOUTS_PARAM");
+      expect(stdout).toContain("A1_TIMEOUT_ATTEMPTS_OPTOUT -1");
+
+      // A2: a timed-out task records an EMPTY error_message.
+      expect(stdout).toContain('A2_TIMEOUT_ERROR_MESSAGE ""');
+
+      // A3a: Pass 3's timeout storms 9 times, drags Pass 2 through 9 reruns,
+      // and every one of those transactions rolls back — Pass 2's work is lost.
+      expect(stdout).toContain("A3A_COOCCURRENCE_PASSES 9");
+      expect(stdout).toContain("A3A_ORPHAN_PASSES 9");
+      expect(stdout).toContain(
+        `A3A_TXN_LOG [${Array(9).fill('"rollback"').join(", ")}]`,
+      );
+
+      // A3b: a single retryable Pass 3 failure re-runs Pass 2 and overwrites
+      // the real orphan count with 0.
+      expect(stdout).toContain("A3B_ORPHAN_PASSES 2");
+      expect(stdout).toContain('"orphan_entities_pruned": 0');
+    }, 240_000);
+
+    it("patched is GREEN — timeouts are a verdict, failures are legible, Pass 2 survives", () => {
+      const { status, stdout } = runProbe(true);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED",
+      );
+      expect(stdout).toContain("FAILURES []");
+      expect(status, `probe failed:\n${stdout}`).toBe(0);
+
+      // A1: the opt-out bites, and bites ONLY timeouts. The default is
+      // unchanged, so every other retry_with_backoff caller in the image keeps
+      // upstream behaviour.
+      expect(stdout).toContain("A1_TIMEOUT_ATTEMPTS_DEFAULT 9");
+      expect(stdout).toContain("A1_TIMEOUT_ATTEMPTS_OPTOUT 1");
+      expect(stdout).toContain("A1_BUILTIN_TIMEOUT_ATTEMPTS_OPTOUT 1");
+      expect(stdout).toContain("A1_STILL_RETRIED_DEADLOCK 9");
+      expect(stdout).toContain("A1_STILL_RETRIED_CONNECTION 9");
+      expect(stdout).toContain("A1_STILL_RETRIED_OSERROR 9");
+
+      // A2: diagnostic, and non-empty messages are untouched.
+      expect(stdout).toMatch(
+        /A2_TIMEOUT_ERROR_MESSAGE "[^"]*TimeoutError[^"]*graph_maintenance[^"]*"/,
+      );
+      expect(stdout).toContain(
+        'A2_NORMAL_ERROR_MESSAGE "boom: something specific"',
+      );
+
+      // A3a: one Pass 3 attempt, one Pass 2 run, and Pass 2 COMMITTED before
+      // Pass 3 was even tried. The failure still propagates.
+      expect(stdout).toContain("A3A_COOCCURRENCE_PASSES 1");
+      expect(stdout).toContain("A3A_ORPHAN_PASSES 1");
+      expect(stdout).toContain('A3A_TXN_LOG ["commit", "rollback"]');
+      expect(stdout).toContain("A3A_ERROR TimeoutError");
+
+      // A3b: the retry scope covers Pass 3 only, so the real orphan count
+      // survives the retry.
+      expect(stdout).toContain("A3B_ORPHAN_PASSES 1");
+      expect(stdout).toContain("A3B_COOCCURRENCE_PASSES 2");
+      expect(stdout).toContain('"orphan_entities_pruned": 7');
+      expect(stdout).toContain('"stale_cooccurrences_pruned": 4');
+    }, 240_000);
+  },
+);


### PR DESCRIPTION
## The storm

`graph_maintenance` Pass 3 (`prune_stale_cooccurrences`) measures at
**114,836 ms / 174M shared-buffer hits** on a live production bank. The asyncpg
client-side `command_timeout` is 60s (`HINDSIGHT_API_DB_COMMAND_TIMEOUT`,
applied at `engine/memory_engine.py:3654`), so the statement is cancelled at
60s — and then **retried**, because `_is_retryable` treats
`asyncio.TimeoutError` as a transient connection fault and
`_SWEEP_MAX_RETRIES = 8` gives **9 attempts**.

Two banks (`overlord`, `klanker`) x every 30 minutes = roughly **18 minutes of
wasted production DB CPU per cycle**, contending with live retain/recall
traffic, for work that cannot possibly succeed on attempt 2 when it
deterministically failed on attempt 1. A third bank is about a week out.

This PR does **not** make Pass 3 fast — that is a separate, larger change. It
stops the query being run nine times, makes the failure legible, and stops it
destroying the useful pass that runs beside it.

## The three fixes

All three are fail-loud anchor-and-replace patch blocks in
`docker/Dockerfile.hindsight` (one new `RUN python3 - <<'PYEOF'` block): each
anchor is asserted present exactly once before replacement, and the block ends
with `ast.parse` plus post-condition asserts, so an upstream bump that
reformats any of these regions **breaks the build** rather than silently
dropping the fix.

**A1 — a deterministic timeout is a verdict, not a blip.**
`engine/db_utils.py:57` `_is_retryable` returned `True` for
`asyncio.TimeoutError`. It now takes `retry_timeouts: bool = True` — default is
upstream behaviour byte-for-byte, so `acquire_with_retry`,
`vector_index_health`, `retain/bank_utils` and `memory_engine` are all
untouched — and `engine/graph_maintenance.py` passes `retry_timeouts=False` at
the one call site that owns a known-slow bank-wide sweep.

> **The trap.** On Python 3.10+ builtin `TimeoutError` is an **`OSError`
> subclass**, and on 3.11+ (this image runs 3.11.15) `asyncio.TimeoutError`
> **IS** that builtin. Upstream's single
> `isinstance(exc, (OSError, ConnectionError, asyncio.TimeoutError))` therefore
> has two arms that both match a timeout. The timeout arm is split out and
> tested **first**; leaving it after the `OSError` arm makes the entire fix
> inert while every string assertion still passes. Verified in the image:
> `asyncio.TimeoutError is TimeoutError -> True`,
> `issubclass(TimeoutError, OSError) -> True`. A build-time assert pins the
> ordering.

**A2 — the failure was invisible.** `worker/poller.py:921` did
`await self._mark_failed(task.operation_id, str(e), task.schema)`, and
`str(asyncio.TimeoutError())` is the **empty string**. Measured on the live
bank: **23 of 28** failed `graph_maintenance` operations carried a blank
`error_message` — status `failed`, no reason anywhere. A `_describe_exception`
helper now guarantees a diagnostic string
(`TimeoutError raised with no message (task_type=graph_maintenance)`), and is
deliberately conservative: a non-empty `str(e)` is returned **byte-for-byte**,
so operator surfaces matching on error text — and
`_summarise_child_error_messages`, which groups failed siblings by exact
message — are unaffected. Only the previously-blank case changes.

**A3 — Pass 2 no longer dies with Pass 3.** `engine/graph_maintenance.py:193-202`
ran Pass 2 (orphan-entity prune) and Pass 3 in **one** transaction, so a Pass 3
timeout rolled back Pass 2's completed work every cycle. They are now separate
transactions under **separate retry scopes**.

> The separate *retry* scope is the point, not an accessory. The obvious split
> — one `_run_sweep` doing both, still retried as a unit — would re-run Pass 2
> on every Pass 3 retry, where it finds 0 orphans (the first pass already
> committed them) and **overwrites the true count with 0**. Retrying only
> Pass 3 makes that impossible by construction rather than by a careful
> `max()`. Pass 2's count is assigned to `result` *before* Pass 3 is attempted,
> pinned by a build-time index assert.

Pass 3's failure still **propagates** — the operation is still marked failed.
This PR removes the wasted retries; it does not hide the failure. The new log
line names what Pass 2 committed before Pass 3 died.

## Tests

**`tests/docker/hindsight-graph-maintenance-retry-storm.test.ts` (new)** — a
behavioural RED/GREEN probe against the pinned upstream image. Both arms run
in throwaway labelled containers; the patch block is extracted from the
Dockerfile by name and applied via `docker exec`, so the test exercises the
shipping patch text, not a copy. It drives the **real**
`db_utils.retry_with_backoff`, `WorkerPoller._execute_task_inner` and
`run_graph_maintenance_job` (only `asyncio.sleep` is stubbed, so attempt
*counts* stay real):

| | RED (unpatched) | GREEN (patched) |
|---|---|---|
| timeout attempts | 9 | **1** |
| deadlock attempts | 9 (unchanged) | 9 (unchanged) |
| recorded `error_message` | `""` | names `TimeoutError` + `task_type=graph_maintenance` |
| Pass 2 txn on Pass 3 timeout | rolled back | **committed** |
| reported orphan count after Pass 3 retry | `0` (clobbered) | **7** |

The bakes suite cannot see any of that: it is grep-on-file, so the
`TimeoutError<:OSError` inversion — the most likely way this fix rots — stays
green there. Registered in `docker-e2e.yml` under the `hindsight:` paths
filter, the `hindsight-probe` job (with `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1`,
so it cannot silently skip in CI), and the label-scoped teardown.

**`tests/docker/dockerfile-hindsight-bakes.test.ts`** gains a structural guard
pinning the anchor-guard message, the split arm literals, the build-time
ordering assert, the `_run_sweep`-is-gone and two-retry-scopes asserts, and a
positive/negative pair on `{str(e) or 'no message'}` (an `{e or 'no message'}`
would reintroduce A2 in the log line, because it tests the exception *object's*
truthiness).

Local: bakes **46/46**, probe **5/5** (RED 3.7s, GREEN 4.3s), `npm run lint`
clean.

## Deploy path

`hindsight-maintenance.sh` and every patch block are **baked into the image**
(`docker/Dockerfile.hindsight`), not bind-mounted. Landing this therefore needs
a **hindsight image rebuild and a fleet roll** to take effect — merging alone
changes nothing on the running fleet. This PR deliberately performs no build,
no restart, and no rollout.

## Out of scope

The `n_distinct`/`ANALYZE` statistics work, the paged rewrite of
`prune_stale_cooccurrences` that would make Pass 3 actually fast, and the
autovacuum scale-factor pins are all separate changes and are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
