### PR TITLE
chore: release v0.21.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+## v0.21.6 — Hindsight's `graph_maintenance` sweep stops retrying a query that can never beat its own timeout
+
 ### Bug fixes
 
 - **hindsight: stop the `graph_maintenance` retry storm.** Pass 3 of the


### PR DESCRIPTION
## Summary

CHANGELOG-only release commit for **v0.21.6**. Consolidates `## Unreleased`
into `## v0.21.6 — Hindsight's \`graph_maintenance\` sweep stops retrying a
query that can never beat its own timeout` and leaves a fresh empty Unreleased
staging block. `package.json` is untouched (placeholder discipline — the tag is
the version source of truth).

## Why

Exactly one commit merged since `v0.21.5` (`a9aceb2f`), a `fix` — no `feat`, no
breaking change — so this is a patch bump:

- `3e2b284a` #4604 fix(hindsight): stop the `graph_maintenance` retry storm

The staged Unreleased entry already described that fix accurately and in full,
so this is a pure rename + re-seed: no note was authored or edited here.

## Test plan

CI on this PR (CHANGELOG-only diff). No source change.

## Risk

None to runtime — documentation-only diff. Release-pipeline risk is covered by
the skill's gates (draft release on a pinned SHA, npm + image verification
before any rollout).