### PR TITLE
fix(autoaccept): select Continue with Fable on the usage-credits consent modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+### Bug fixes
+
+- **autoaccept: select Continue with Fable on the usage-credits consent modal**
+
 ## v0.21.6 — Hindsight's `graph_maintenance` sweep stops retrying a query that can never beat its own timeout
 
 ### Bug fixes

--- a/bin/autoaccept.exp
+++ b/bin/autoaccept.exp
@@ -86,8 +86,28 @@ expect {
         send "\r"
         exp_continue
     }
+    -re {Continue with Fable} {
+        # Fable-5 usage-credits consent modal:
+        #     Fable 5 runs on usage credits, purchased separately from your plan.
+        #       1. Continue with Fable 5
+        #     ❯ 2. Switch to Sonnet 5 and continue
+        #     Enter to confirm · Esc to cancel
+        # MUST precede the generic "Enter to confirm" branch below: that
+        # footer matches this modal too, and the CLI focuses option 2 by
+        # default (`defaultFocusValue:"switch"`), so a bare Return silently
+        # declines Fable and downgrades the agent to Sonnet. Select option 1
+        # by digit instead. Kept in sync with the `fable-usage-credits-consent`
+        # rule in src/agents/autoaccept.ts.
+        sleep 0.5
+        send "1\r"
+        exp_continue
+    }
     -re {Enter.{1,30}confirm} {
-        # Generic "Enter to confirm" prompt (dev channels, trust dialog)
+        # Generic "Enter to confirm" prompt (dev channels, trust dialog).
+        # NOTE: the TS poller additionally guards this catch-all against
+        # numbered selectors (NUMBERED_CHOICE_SIGNATURE). expect matches a
+        # STREAM in branch order, so here the equivalent protection is
+        # ordering: every option-selecting branch must sit above this one.
         sleep 0.8
         send "\r"
         exp_continue

--- a/src/agents/autoaccept.ts
+++ b/src/agents/autoaccept.ts
@@ -39,10 +39,131 @@ export interface PromptRule {
   name: string;
   /** regex against the captured pane text */
   match: RegExp;
+  /**
+   * Optional NEGATIVE guard. When it matches the same pane, the rule does
+   * NOT fire even though `match` hit. Used to keep broad catch-all rules
+   * (the generic "Enter to confirm") off panes where their remedy would be
+   * actively wrong — see `NUMBERED_CHOICE_SIGNATURE`.
+   */
+  notMatch?: RegExp;
   /** keystrokes to send via `tmux send-keys -t <agent>`. e.g. ["Enter"] or ["Down", "Enter"] */
   keys: string[];
+  /**
+   * Optional pane-derived keystroke resolver, for rules that must SELECT a
+   * specific labelled option rather than send a fixed sequence (the
+   * `usageCreditsMenuNav()` idiom in `wedge-watchdog.ts`). Returning `null`
+   * falls back to the static `keys`, so a rule with a resolver still has a
+   * deterministic remedy when the pane can't be parsed.
+   */
+  keysFor?: (text: string) => string[] | null;
   /** Optional: only match this prompt at most N times. Default 1. */
   maxFires?: number;
+}
+
+/**
+ * A pane presenting a NUMBERED multiple-choice selector — at least an
+ * option-1 and an option-2 row, with or without the `❯` cursor glyph.
+ *
+ * This is the negative guard on the generic "Enter to confirm" catch-all.
+ * Blind Enter on a selector does not "confirm" anything meaningful: it
+ * activates whatever row the CLI focused by default, which may be neither
+ * safe nor what the operator configured. The Fable-5 usage-credits modal is
+ * the case that proved it — its `defaultFocusValue` is `"switch"` (option 2,
+ * "Switch to Sonnet 5 and continue"), so the catch-all's bare Enter silently
+ * DECLINED Fable and downgraded every agent pinned to it, until start.sh gave
+ * up: "session-model: override 'fable' did not reach a healthy boot after 3
+ * attempts — reverting to configured default".
+ *
+ * Every selector the boot poller is meant to answer already has a dedicated,
+ * option-aware rule above the catch-all (theme, provider, MCP trust,
+ * dev-channels, fable-consent). The catch-all's remaining job is the PLAIN
+ * confirmation ("Press Enter to confirm your selection"), which has no
+ * numbered rows. So the guard costs nothing for known prompts, and for an
+ * UNKNOWN numbered chooser it deliberately prefers a visible stall (the
+ * wedge-watchdog and the operator both see it) over an invisible wrong pick.
+ */
+export const NUMBERED_CHOICE_SIGNATURE =
+  /(?=[\s\S]*^[^\S\n]*(?:❯[^\S\n]*)?1\.[^\S\n]+\S)(?=[\s\S]*^[^\S\n]*(?:❯[^\S\n]*)?2\.[^\S\n]+\S)/m;
+
+/**
+ * Claude Code's Fable-5 usage-credits consent modal:
+ *
+ *     Fable 5 now uses usage credits
+ *
+ *     Fable 5 runs on usage credits, purchased separately from your plan.
+ *
+ *       1. Continue with Fable 5
+ *     ❯ 2. Switch to Sonnet 5 and continue
+ *
+ *     Enter to confirm · Esc to cancel
+ *
+ * Two INDEPENDENT anchors, both required, so it can never false-positive on
+ * ordinary model output or on the `/rate-limit-options` menu (which also says
+ * "usage credits" but never "Continue with Fable"):
+ *   (a) the confirm-option row "Continue with Fable", which sits at the
+ *       BOTTOM of the pane with the other options and therefore cannot
+ *       scroll out of the `capture-pane` viewport (the #2218 lesson), AND
+ *   (b) the "usage credits" wording of the modal body/title.
+ *
+ * Anchor (a) is load-bearing for SPEND SAFETY, not just precision. The same
+ * CLI component renders variants whose option 1 is "Buy usage credits" /
+ * "Yes, buy usage credits" / "Request usage credits from your admin" when the
+ * org has no credit balance. Those are purchase actions and must NEVER be
+ * auto-selected; none of them contains "Continue with Fable", so this
+ * signature does not match them and the modal is simply left alone.
+ *
+ * Consent authority: selecting "Continue with Fable 5" is not the watchdog
+ * deciding to spend. This modal only renders because the session was launched
+ * on (or switched to) `fable`, which is an operator decision expressed in
+ * `switchroom.yaml` / a `/model fable` command. The keystroke re-affirms a
+ * choice the operator already made; declining it is what silently contradicts
+ * them.
+ */
+export const FABLE_CONSENT_SIGNATURE =
+  /(?=[\s\S]*Continue with Fable)(?=[\s\S]*usage credits)/i;
+
+/**
+ * Compute the keystroke sequence that selects "Continue with Fable 5" in the
+ * consent modal above, from a captured pane. Same shape as
+ * `usageCreditsMenuNav()` in `wedge-watchdog.ts`: parse the numbered option
+ * rows, locate the one we want by LABEL, and emit keys for it.
+ *
+ * The remedy is the option's own digit followed by Enter — verified by hand
+ * on a live wedged pane (finn, 2026-08-11): `1` + Enter selected "Continue
+ * with Fable 5" and the session came up on fable immediately. Digit-select is
+ * preferred over `usageCreditsMenuNav`'s relative Up/Down navigation here
+ * because the modal's default focus is option 2, so a directional plan would
+ * depend on correctly reading the `❯` cursor; the digit is absolute.
+ *
+ * Returns `null` when the row cannot be located (no numbered rows parsed, or
+ * no row labelled "Continue with Fable") — the caller then falls back to the
+ * rule's static keys.
+ */
+export function fableConsentNav(text: string): string[] | null {
+  for (const line of text.split("\n")) {
+    const m = line.match(/^\s*(❯)?\s*(\d+)\.\s+(.*\S)\s*$/);
+    if (!m) continue;
+    if (/Continue with Fable/i.test(m[3])) return [m[2], "Enter"];
+  }
+  return null;
+}
+
+/**
+ * Whether `rule` applies to this pane: `match` hits AND the optional
+ * `notMatch` guard does not. Single decision point shared by the boot poller
+ * and by any caller that needs to reason about rule applicability (e.g. the
+ * wedge-watchdog's `deferToPrompts`), so a guard can never be honoured in one
+ * place and ignored in another.
+ */
+export function ruleMatches(rule: PromptRule, text: string): boolean {
+  if (!rule.match.test(text)) return false;
+  if (rule.notMatch && rule.notMatch.test(text)) return false;
+  return true;
+}
+
+/** Keys this rule would send for this pane (resolver first, static fallback). */
+export function resolveRuleKeys(rule: PromptRule, text: string): string[] {
+  return rule.keysFor?.(text) ?? rule.keys;
 }
 
 export interface AutoacceptOptions {
@@ -172,10 +293,37 @@ export const PROMPTS: PromptRule[] = [
     maxFires: 5,
   },
   {
+    // Fable-5 usage-credits consent modal. MUST sit above the generic
+    // "Enter to confirm" catch-all: the modal's footer is "Enter to confirm
+    // · Esc to cancel", so the catch-all matches it too — and its bare Enter
+    // hits the CLI's `defaultFocusValue:"switch"`, i.e. option 2 ("Switch to
+    // Sonnet 5 and continue"), silently declining Fable. The catch-all is
+    // additionally guarded below, but rule order is the primary defence.
+    //
+    // Remedy is the option's digit + Enter, resolved from the pane by
+    // `fableConsentNav` so a reordered menu still selects the right LABEL.
+    // The static fallback is ["1", "Enter"] because "Continue with Fable 5"
+    // is option 1 in every rendering of this component, and the signature
+    // has already proved that label is on screen.
+    //
+    // maxFires is 1: consent is persisted by the CLI to
+    // `$CLAUDE_CONFIG_DIR/.claude.json` under `fableOverageConsentV2`, so a
+    // healthy boot answers this at most once per agent config.
+    name: "fable-usage-credits-consent",
+    match: FABLE_CONSENT_SIGNATURE,
+    keysFor: fableConsentNav,
+    keys: ["1", "Enter"],
+  },
+  {
     // Generic "Enter to confirm" — last because the more specific
     // matchers above should take precedence on the same screen.
+    //
+    // Guarded against numbered selectors: on those, Enter activates the
+    // CLI's default focus rather than confirming anything, which is how the
+    // Fable consent modal got auto-declined. See NUMBERED_CHOICE_SIGNATURE.
     name: "enter-to-confirm",
     match: /Enter.{1,30}confirm/,
+    notMatch: NUMBERED_CHOICE_SIGNATURE,
     keys: ["Enter"],
   },
 ];
@@ -283,14 +431,15 @@ export async function runAutoaccept(
     if (text) {
       for (const entry of rules) {
         if (entry.fired >= entry.cap) continue;
-        if (entry.rule.match.test(text)) {
+        if (ruleMatches(entry.rule, text)) {
+          const keys = resolveRuleKeys(entry.rule, text);
           entry.fired++;
           matchedThisPoll = true;
           fired.push(entry.rule.name);
           console.error(
-            `[autoaccept] ${opts.agentName}: fired ${entry.rule.name} (${entry.rule.keys.join("+")})`,
+            `[autoaccept] ${opts.agentName}: fired ${entry.rule.name} (${keys.join("+")})`,
           );
-          sendKeys(opts.agentName, entry.rule.keys);
+          sendKeys(opts.agentName, keys);
         }
       }
     }

--- a/src/agents/wedge-watchdog.ts
+++ b/src/agents/wedge-watchdog.ts
@@ -29,7 +29,15 @@
 //     quo. So we require BOTH a precise blocking-modal signature AND
 //     multi-poll stability before acting, and a cooldown after firing.
 
-import { capturePane, sendKeys, PROMPTS, type PromptRule } from "./autoaccept.js";
+import {
+  capturePane,
+  sendKeys,
+  PROMPTS,
+  ruleMatches,
+  FABLE_CONSENT_SIGNATURE,
+  fableConsentNav,
+  type PromptRule,
+} from "./autoaccept.js";
 import {
   queryPendingPermission as defaultQueryPendingPermission,
   type PendingPermissionQueryResult,
@@ -350,6 +358,10 @@ const DEFAULT_COOLDOWN_MS = 60_000;
 //     stop-hook error anyway).
 const DEFAULT_CONFIRM_MODAL_POLLS = 3;
 const DEFAULT_MANIFEST_STALL_POLLS = 60;
+// The Fable-5 usage-credits consent modal must be PRESENT for this many
+// consecutive polls before we answer it. Same shape-persistence rationale as
+// CONFIRM_MODAL (the Ink modal repaints, so it is never byte-stable).
+const DEFAULT_FABLE_CONSENT_POLLS = 3;
 // A per-tool permission prompt must be PRESENT for this many consecutive
 // polls before Esc. Same shape-persistence rationale as CONFIRM_MODAL:
 // the Ink-rendered prompt repaints so it's not byte-stable. 3 polls ≈ 15s
@@ -482,6 +494,28 @@ export interface WedgeWatchdogOptions {
    */
   confirmModalPolls?: number;
   /**
+   * Fable-5 usage-credits consent modal, detected by SHAPE persistence.
+   *
+   * This modal is a REAL mid-session gap, not just a boot one: none of the
+   * other signatures reach it. `WEDGE_FOOTER_SIGNATURE` requires a "to
+   * select" / "to navigate" / ↑↓ affordance the modal's
+   * "Enter to confirm · Esc to cancel" footer does not have;
+   * `CONFIRM_MODAL_SIGNATURE` requires a "1. Yes / 2. No" pair (option 2 here
+   * is "Switch to Sonnet 5 and continue"); `PERMISSION_PROMPT_SIGNATURE`
+   * requires "Do you want to proceed?" + "don't ask again"; and
+   * `RATE_LIMIT_MENU_SIGNATURE` requires "Stop and wait for". So a `/model
+   * fable` switch mid-session parks the agent on an unanswerable modal
+   * forever. On a shape-persistent match the watchdog selects "Continue with
+   * Fable 5" (`fableConsentNav`), which is the operator's already-expressed
+   * model choice. `null` disables this branch.
+   */
+  fableConsentSignature?: RegExp | null;
+  /**
+   * Consecutive polls the Fable consent modal must be PRESENT before we
+   * answer it. Default `SWITCHROOM_WEDGE_FABLE_POLLS` or 3.
+   */
+  fableConsentPolls?: number;
+  /**
    * Per-tool permission-prompt TUI signature, detected by SHAPE
    * persistence (the prompt continuously PRESENT across polls), same as
    * the confirmation modal. Catches a non-pre-approved MCP tool's
@@ -601,6 +635,9 @@ export interface WedgeWatchdogResult {
   /** #2471 — subset of `fires` that dismissed a confirmation modal detected
    *  by SHAPE persistence (the `/effort`-class wedge). */
   confirmModalFires: number;
+  /** Subset of `fires` that answered the Fable-5 usage-credits consent modal
+   *  by SELECTING "Continue with Fable 5" (never a "buy credits" variant). */
+  fableConsentFires: number;
   /** Subset of `fires` that dismissed a per-tool permission-prompt TUI
    *  (the config_propose_edit / hostd-verb freeze) with a safe Esc-decline. */
   permissionPromptFires: number;
@@ -669,6 +706,13 @@ export async function runWedgeWatchdog(
       : (opts.confirmModalSignature ?? CONFIRM_MODAL_SIGNATURE);
   const confirmModalPolls =
     opts.confirmModalPolls ?? envInt("SWITCHROOM_WEDGE_CONFIRM_POLLS", DEFAULT_CONFIRM_MODAL_POLLS);
+  // Fable-5 usage-credits consent modal. `null` disables; `undefined` → on.
+  const fableConsentSignature =
+    opts.fableConsentSignature === null
+      ? null
+      : (opts.fableConsentSignature ?? FABLE_CONSENT_SIGNATURE);
+  const fableConsentPolls =
+    opts.fableConsentPolls ?? envInt("SWITCHROOM_WEDGE_FABLE_POLLS", DEFAULT_FABLE_CONSENT_POLLS);
   // Per-tool permission-prompt TUI freeze (config_propose_edit / hostd verbs).
   // `null` disables the branch; `undefined` → default on.
   const permissionPromptSignature =
@@ -721,6 +765,7 @@ export async function runWedgeWatchdog(
   let rateLimitFires = 0;
   let overageCreditSelections = 0;
   let confirmModalFires = 0;
+  let fableConsentFires = 0;
   let permissionPromptFires = 0;
   let permissionPromptDeferrals = 0;
   let permissionPromptFloodHolds = 0;
@@ -730,6 +775,7 @@ export async function runWedgeWatchdog(
   // #2471 — shape-persistence counters (independent of the byte-stable
   // `stableCount`): how many CONSECUTIVE polls each shape has been PRESENT.
   let confirmModalPresent = 0;
+  let fableConsentPresent = 0;
   let permissionPromptPresent = 0;
   let manifestStallPresent = 0;
   // Byte-stability of the Manifesting pane across polls — the progress
@@ -738,6 +784,7 @@ export async function runWedgeWatchdog(
   // poll and resets the stall counter; a frozen spinner keeps it identical.
   let lastManifestKey: string | null = null;
   let confirmCooldownUntil = 0;
+  let fableCooldownUntil = 0;
   let permissionCooldownUntil = 0;
   // Log throttle for the two new "holding off on Esc" paths. They are
   // evaluated EVERY poll (deliberately — that is how we notice the moment the
@@ -781,14 +828,29 @@ export async function runWedgeWatchdog(
     // freeze. Precedence above the confirm-modal branch: its shape
     // ("1. Yes / 2. Yes, and don't ask again / 3. No") is a SUPERSET match
     // risk, so we classify it first and Esc-decline it (safe DENY).
+    //
+    // The Fable-5 usage-credits consent modal is classified BEFORE the
+    // permission/confirm/blocking branches, all of which would (if they
+    // matched at all) Esc it — and Esc here cancels the operator's own model
+    // choice. It sits below the rate-limit branch purely defensively: the two
+    // signatures are disjoint ("Stop and wait for" vs "Continue with Fable"),
+    // but the quota wall must always win if a pane ever showed both.
+    const isFableConsent =
+      !isRateLimitMenu &&
+      !!text &&
+      fableConsentSignature !== null &&
+      fableConsentSignature.test(text);
+
     const isPermissionPrompt =
       !isRateLimitMenu &&
+      !isFableConsent &&
       !!text &&
       permissionPromptSignature !== null &&
       permissionPromptSignature.test(text);
 
     const isConfirmModal =
       !isRateLimitMenu &&
+      !isFableConsent &&
       !isPermissionPrompt &&
       !!text &&
       confirmModalSignature !== null &&
@@ -796,13 +858,15 @@ export async function runWedgeWatchdog(
 
     const isBlockingModal =
       !isRateLimitMenu &&
+      !isFableConsent &&
       !isPermissionPrompt &&
       !isConfirmModal &&
       !!text &&
       signature.test(text) &&
       // Defer to the boot autoaccept poller for first-run prompts — those
-      // want Enter, not Esc.
-      !deferToPrompts.some((p) => p.match.test(text));
+      // want Enter, not Esc. `ruleMatches` (not a bare `match.test`) so a
+      // rule's negative guard is honoured here too.
+      !deferToPrompts.some((p) => ruleMatches(p, text));
 
     // #2471 — semantic no-progress tracker, INDEPENDENT of the modal chain: a
     // "Manifesting"/spinning turn that is NOT advancing is wedged despite the
@@ -967,6 +1031,42 @@ export async function runWedgeWatchdog(
         stableCount = 0;
         lastKey = null;
       }
+    } else if (isFableConsent) {
+      // SHAPE persistence (the Ink modal repaints; it is never byte-stable).
+      fableConsentPresent++;
+      // A different shape is showing — keep the other streaks neutral.
+      stableCount = 0;
+      lastKey = null;
+      permissionPromptPresent = 0;
+      confirmModalPresent = 0;
+      if (fableConsentPresent >= fableConsentPolls && now() >= fableCooldownUntil) {
+        // Select "Continue with Fable 5" by its own digit. `fableConsentNav`
+        // resolves the digit from the pane's LABELS; the ["1", "Enter"]
+        // fallback is safe because the signature has already proved the
+        // "Continue with Fable" row is on screen and it is option 1 in every
+        // rendering of this component. We never send a bare Enter: the CLI
+        // focuses option 2 ("Switch to Sonnet 5 and continue") by default, so
+        // Enter would decline the operator's configured model.
+        const nav = fableConsentNav(text) ?? ["1", "Enter"];
+        console.error(
+          `[wedge-watchdog] ${opts.agentName}: Fable-5 usage-credits consent modal present ` +
+            `${fableConsentPresent} polls ` +
+            `(~${Math.round((fableConsentPresent * pollIntervalMs) / 1000)}s) — ` +
+            `selecting "Continue with Fable 5" (${nav.join(" ")}); the session is on fable ` +
+            `because the operator configured it, and Enter/Esc here would silently decline it`,
+        );
+        try {
+          send(opts.agentName, nav);
+        } catch (err) {
+          console.error(
+            `[wedge-watchdog] ${opts.agentName}: send threw: ${(err as Error).message}`,
+          );
+        }
+        fires++;
+        fableConsentFires++;
+        fableCooldownUntil = now() + cooldownMs;
+        fableConsentPresent = 0;
+      }
     } else if (isPermissionPrompt) {
       // SHAPE persistence (the Ink-rendered prompt repaints, so it is not
       // byte-stable). Count consecutive polls the prompt has been PRESENT.
@@ -974,6 +1074,7 @@ export async function runWedgeWatchdog(
       // Keep the byte-stable machinery neutral so a later wedge starts fresh.
       stableCount = 0;
       lastKey = null;
+      fableConsentPresent = 0;
       if (permissionPromptPresent >= permissionPromptPolls && now() >= permissionCooldownUntil) {
         // Issue #2971 — card-aware gate, BEFORE any keystroke. Claude Code
         // renders this TUI AND emits the `permission_request` channel
@@ -1110,6 +1211,7 @@ export async function runWedgeWatchdog(
       stableCount = 0;
       lastKey = null;
       permissionPromptPresent = 0;
+      fableConsentPresent = 0;
       if (confirmModalPresent >= confirmModalPolls && now() >= confirmCooldownUntil) {
         console.error(
           `[wedge-watchdog] ${opts.agentName}: dismissing stuck confirmation modal ` +
@@ -1169,6 +1271,8 @@ export async function runWedgeWatchdog(
       confirmModalPresent = 0;
       // Same for the permission-prompt streak — gone means re-accumulate.
       permissionPromptPresent = 0;
+      // …and the Fable consent modal's.
+      fableConsentPresent = 0;
     }
 
     await sleep(pollIntervalMs);
@@ -1179,6 +1283,7 @@ export async function runWedgeWatchdog(
     rateLimitFires,
     overageCreditSelections,
     confirmModalFires,
+    fableConsentFires,
     permissionPromptFires,
     permissionPromptDeferrals,
     permissionPromptFloodHolds,

--- a/src/cli/autoaccept-poll.ts
+++ b/src/cli/autoaccept-poll.ts
@@ -154,7 +154,7 @@ async function main(): Promise<void> {
       floodPressure: permissionFloodAware ? undefined : null,
     });
     console.error(
-      `[autoaccept-poll] ${agentName}: wedge-watchdog returned reason=${res.reason} fires=${res.fires} rateLimitFires=${res.rateLimitFires} overageCreditSelections=${res.overageCreditSelections} confirmModalFires=${res.confirmModalFires} permissionPromptFires=${res.permissionPromptFires} permissionPromptDeferrals=${res.permissionPromptDeferrals} permissionPromptFloodHolds=${res.permissionPromptFloodHolds} permissionPromptCardlessHolds=${res.permissionPromptCardlessHolds} restartEscalations=${res.restartEscalations}`,
+      `[autoaccept-poll] ${agentName}: wedge-watchdog returned reason=${res.reason} fires=${res.fires} rateLimitFires=${res.rateLimitFires} overageCreditSelections=${res.overageCreditSelections} confirmModalFires=${res.confirmModalFires} fableConsentFires=${res.fableConsentFires} permissionPromptFires=${res.permissionPromptFires} permissionPromptDeferrals=${res.permissionPromptDeferrals} permissionPromptFloodHolds=${res.permissionPromptFloodHolds} permissionPromptCardlessHolds=${res.permissionPromptCardlessHolds} restartEscalations=${res.restartEscalations}`,
     );
   } catch (err) {
     console.error(

--- a/tests/autoaccept.test.ts
+++ b/tests/autoaccept.test.ts
@@ -19,8 +19,44 @@ import {
   PROMPTS,
   capturePane,
   sendKeys,
+  ruleMatches,
+  resolveRuleKeys,
+  fableConsentNav,
+  NUMBERED_CHOICE_SIGNATURE,
   type PromptRule,
 } from "../src/agents/autoaccept.js";
+
+/**
+ * The Fable-5 usage-credits consent modal, as rendered by Claude Code and
+ * captured from a live wedged pane (finn, 2026-08-11). The CLI's option list
+ * carries `defaultFocusValue:"switch"`, i.e. the ❯ cursor sits on option 2 —
+ * so a bare Enter here DECLINES Fable and downgrades the agent to Sonnet.
+ */
+const FABLE_CONSENT_SCREEN =
+  "  Fable 5 now uses usage credits\n" +
+  "\n" +
+  "  Fable 5 runs on usage credits, purchased separately from your plan.\n" +
+  "\n" +
+  "  Learn more: https://support.claude.com/en/articles/12429409-extra-usage\n" +
+  "\n" +
+  "    1. Continue with Fable 5\n" +
+  "  ❯ 2. Switch to Sonnet 5 and continue\n" +
+  "\n" +
+  "  Enter to confirm · Esc to cancel";
+
+/**
+ * The no-credit-balance variant of the SAME CLI component: option 1 is a
+ * PURCHASE, not a consent. Must never be auto-selected.
+ */
+const FABLE_BUY_CREDITS_SCREEN =
+  "  Fable 5 now uses usage credits\n" +
+  "\n" +
+  "  You don't have usage credits yet.\n" +
+  "\n" +
+  "    1. Buy usage credits\n" +
+  "  ❯ 2. Switch to Sonnet 5 and continue\n" +
+  "\n" +
+  "  Enter to confirm · Esc to cancel";
 
 const mockedExec = execFileSync as unknown as ReturnType<typeof vi.fn>;
 
@@ -298,7 +334,9 @@ describe("PROMPTS — regex sanity (translated from bin/autoaccept.exp)", () => 
 
   for (const { text, expected } of fixtures) {
     it(`matches the ${expected} prompt`, () => {
-      const hit = PROMPTS.find((p) => p.match.test(text));
+      // `ruleMatches`, not a bare `match.test`, so the table reflects what
+      // the dispatcher actually does (negative guards included).
+      const hit = PROMPTS.find((p) => ruleMatches(p, text));
       expect(hit?.name).toBe(expected);
     });
   }
@@ -392,6 +430,86 @@ describe("runAutoaccept — new dev-channels prompt dispatch", () => {
     });
     expect(res.fired).toContain("dev-channels");
     expect(sentKeys[0]).toEqual(["Down", "Enter"]);
+  });
+});
+
+describe("Fable-5 usage-credits consent modal", () => {
+  const catchAll = PROMPTS.find((p) => p.name === "enter-to-confirm")!;
+  const fable = PROMPTS.find((p) => p.name === "fable-usage-credits-consent")!;
+
+  it("dispatches option 1 (Continue with Fable 5), never a bare Enter", async () => {
+    const { sentKeys } = setupTmux([FABLE_CONSENT_SCREEN, ""]);
+    const res = await runAutoaccept({
+      agentName: "finn",
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 4,
+    });
+    expect(res.fired).toContain("fable-usage-credits-consent");
+    // THE bug: the pane's "Enter to confirm · Esc to cancel" footer matched
+    // the catch-all, whose bare Enter hit `defaultFocusValue:"switch"` —
+    // option 2, "Switch to Sonnet 5 and continue" — so the agent silently
+    // ran on Sonnet and start.sh eventually reverted the fable override.
+    expect(res.fired).not.toContain("enter-to-confirm");
+    expect(sentKeys).toEqual([["1", "Enter"]]);
+    expect(sentKeys).not.toContainEqual(["Enter"]);
+  });
+
+  it("the fable rule is ordered ABOVE the enter-to-confirm catch-all", () => {
+    const names = PROMPTS.map((p) => p.name);
+    expect(names.indexOf("fable-usage-credits-consent")).toBeLessThan(
+      names.indexOf("enter-to-confirm"),
+    );
+  });
+
+  it("the catch-all is guarded off any numbered selector", () => {
+    expect(catchAll.notMatch).toBe(NUMBERED_CHOICE_SIGNATURE);
+    expect(ruleMatches(catchAll, FABLE_CONSENT_SCREEN)).toBe(false);
+    // Generic shape, not just this modal: any numbered chooser carrying the
+    // confirm footer must be left to a dedicated, option-aware rule.
+    expect(
+      ruleMatches(
+        catchAll,
+        "Pick a plan\n❯ 1. Keep current plan\n  2. Upgrade\n\nEnter to confirm · Esc to cancel",
+      ),
+    ).toBe(false);
+  });
+
+  it("the catch-all still fires on a plain confirmation (no numbered rows)", () => {
+    expect(ruleMatches(catchAll, "Press Enter to confirm your selection")).toBe(true);
+  });
+
+  it("resolves the digit from the pane label, not a hardcoded position", () => {
+    // Same modal with the options renumbered — we follow the LABEL.
+    const reordered = FABLE_CONSENT_SCREEN.replace("    1. Continue with Fable 5", "    3. Continue with Fable 5");
+    expect(fableConsentNav(reordered)).toEqual(["3", "Enter"]);
+    expect(resolveRuleKeys(fable, reordered)).toEqual(["3", "Enter"]);
+  });
+
+  it("falls back to the verified ['1','Enter'] when the rows cannot be parsed", () => {
+    // Signature still hits (label + "usage credits" present) but no option
+    // row parses — the static remedy must still be the fable option.
+    const unparsed = "Fable 5 runs on usage credits · Continue with Fable 5 [1] / Switch to Sonnet [2]";
+    expect(fableConsentNav(unparsed)).toBeNull();
+    expect(ruleMatches(fable, unparsed)).toBe(true);
+    expect(resolveRuleKeys(fable, unparsed)).toEqual(["1", "Enter"]);
+  });
+
+  it("never auto-selects the 'Buy usage credits' variant (spend safety)", async () => {
+    expect(ruleMatches(fable, FABLE_BUY_CREDITS_SCREEN)).toBe(false);
+    const { sentKeys } = setupTmux([FABLE_BUY_CREDITS_SCREEN, ""]);
+    const res = await runAutoaccept({
+      agentName: "finn",
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 4,
+    });
+    // No rule may answer a purchase prompt — including the catch-all, which
+    // the numbered-selector guard keeps off it.
+    expect(res.fired).toEqual([]);
+    expect(sentKeys).toEqual([]);
   });
 });
 

--- a/tests/wedge-watchdog.test.ts
+++ b/tests/wedge-watchdog.test.ts
@@ -8,10 +8,12 @@ import {
   parseWeeklyReset,
   WEDGE_FOOTER_SIGNATURE,
   CONFIRM_MODAL_SIGNATURE,
+  RATE_LIMIT_MENU_SIGNATURE,
   PERMISSION_PROMPT_SIGNATURE,
   STOP_HOOK_ERROR_SIGNATURE,
   MANIFESTING_SIGNATURE,
 } from "../src/agents/wedge-watchdog.js";
+import { FABLE_CONSENT_SIGNATURE } from "../src/agents/autoaccept.js";
 
 // A realistic blocking-modal pane (the klanker AskUserQuestion shape).
 const WEDGE_SCREEN =
@@ -952,6 +954,95 @@ describe("runWedgeWatchdog — flood-aware permission gate", () => {
 // account for a WEEK. The new branch resolves it to the next occurrence of that
 // wall-clock time (hours away), tz-aware, while leaving the month/day form
 // untouched.
+describe("Fable-5 usage-credits consent modal (mid-session)", () => {
+  // Captured from a live wedged pane (finn, 2026-08-11). Two renderings so
+  // the fixtures exercise SHAPE persistence, not byte-stability.
+  const FABLE_A =
+    "  Fable 5 now uses usage credits\n" +
+    "\n" +
+    "  Fable 5 runs on usage credits, purchased separately from your plan.\n" +
+    "\n" +
+    "    1. Continue with Fable 5\n" +
+    "  ❯ 2. Switch to Sonnet 5 and continue\n" +
+    "\n" +
+    "  Enter to confirm · Esc to cancel";
+  const FABLE_B = FABLE_A.replace("plan.", "plan. ");
+
+  it("no pre-existing signature classifies it — this is why it wedged", () => {
+    // The footer has no "to select" / "to navigate" / ↑↓ affordance…
+    expect(WEDGE_FOOTER_SIGNATURE.test(FABLE_A)).toBe(false);
+    // …option 2 is "Switch to Sonnet 5", not "No"…
+    expect(CONFIRM_MODAL_SIGNATURE.test(FABLE_A)).toBe(false);
+    // …there is no "Do you want to proceed?" / "don't ask again"…
+    expect(PERMISSION_PROMPT_SIGNATURE.test(FABLE_A)).toBe(false);
+    // …and no "Stop and wait for" (the quota-wall anchor), despite the
+    // shared "usage credits" wording.
+    expect(RATE_LIMIT_MENU_SIGNATURE.test(FABLE_A)).toBe(false);
+    // The dedicated signature is the only one that sees it.
+    expect(FABLE_CONSENT_SIGNATURE.test(FABLE_A)).toBe(true);
+  });
+
+  it("selects 'Continue with Fable 5' after the present-streak, never Enter/Esc", async () => {
+    const { send, calls } = recordSend();
+    const res = await runWedgeWatchdog({
+      agentName: "finn",
+      fableConsentPolls: 3,
+      rateLimitSignature: null,
+      manifestStallSignature: null,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 3,
+      capture: captureFlicker([FABLE_A, FABLE_B, FABLE_A]),
+      send,
+    });
+    expect(res.fableConsentFires).toBe(1);
+    expect(res.fires).toBe(1);
+    expect(calls).toEqual([["1", "Enter"]]);
+    // Esc cancels the modal (leaving the operator's model choice unmade) and
+    // Enter picks the CLI's default focus, which is option 2.
+    expect(calls).not.toContainEqual(["Escape"]);
+    expect(calls).not.toContainEqual(["Enter"]);
+  });
+
+  it("does NOT fire before the present-streak threshold", async () => {
+    const { send, calls } = recordSend();
+    const res = await runWedgeWatchdog({
+      agentName: "finn",
+      fableConsentPolls: 3,
+      rateLimitSignature: null,
+      manifestStallSignature: null,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 2,
+      capture: captureFlicker([FABLE_A, FABLE_B]),
+      send,
+    });
+    expect(res.fableConsentFires).toBe(0);
+    expect(calls).toEqual([]);
+  });
+
+  it("with the branch disabled, nothing else touches the modal (kill switch)", async () => {
+    const { send, calls } = recordSend();
+    const res = await runWedgeWatchdog({
+      agentName: "finn",
+      fableConsentSignature: null,
+      rateLimitSignature: null,
+      manifestStallSignature: null,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 6,
+      capture: captureFlicker([FABLE_A, FABLE_B]),
+      send,
+    });
+    expect(res.fableConsentFires).toBe(0);
+    expect(res.fires).toBe(0);
+    expect(calls).toEqual([]);
+  });
+});
+
 describe("parseWeeklyReset — time-only session-cap branch (Fix 2)", () => {
   const HOUR = 3600_000;
   const WEEK = 7 * 24 * HOUR;


### PR DESCRIPTION
## Summary

An agent pinned to `model: fable` never reached a healthy fable boot. Claude Code renders a one-time consent modal on the fable path:

```
  Fable 5 now uses usage credits

  Fable 5 runs on usage credits, purchased separately from your plan.

  Learn more: https://support.claude.com/en/articles/12429409-extra-usage-for-paid-claude-plans

    1. Continue with Fable 5
  ❯ 2. Switch to Sonnet 5 and continue

  Enter to confirm · Esc to cancel
```

Two facts make this a silent downgrade rather than a visible wedge:

1. **The CLI focuses option 2, not option 1.** The option list is constructed with `defaultFocusValue:"switch"` (verified by grepping the shipped `claude` binary — exactly one occurrence, in this component; `value:"confirm"` is option 1 and `value:"switch"` is "Switch to Sonnet 5 and continue"). So bare Enter here *declines* Fable.
2. **The boot poller's catch-all sent exactly that bare Enter.** `enter-to-confirm` (`src/agents/autoaccept.ts`) matches `/Enter.{1,30}confirm/`, which the modal's `Enter to confirm · Esc to cancel` footer satisfies. The agent came up on Sonnet, the fable override was never observed healthy, and `start.sh` gave up:

```
session-model: override 'fable' did not reach a healthy boot after 3 attempts — reverting to configured default
```

Observed in production on agent `finn`, 2026-08-11. Selecting option 1 by hand on the live pane (`1` then Enter) unblocked it immediately and the session ran on fable. Consent is persisted by the CLI to `$CLAUDE_CONFIG_DIR/.claude.json` under `fableOverageConsentV2`, so it is once-per-org-per-agent-config, not once-per-boot.

## Why

Three changes, one concern:

1. **A dedicated `fable-usage-credits-consent` rule, ordered above the catch-all**, selecting the option by its own digit. `fableConsentNav()` follows the existing `usageCreditsMenuNav()` idiom: parse the numbered option rows, locate the row by **label**, emit keys for it. Static fallback `["1","Enter"]` when the rows don't parse — the remedy verified by hand.

   The label anchor is spend safety, not just precision. The same CLI component renders variants whose option 1 is `Buy usage credits` / `Yes, buy usage credits` / `Request usage credits from your admin` when the org has no balance. Those are purchases, contain no "Continue with Fable", and are therefore never matched and never auto-selected.

2. **The `enter-to-confirm` catch-all is guarded** by a new optional `PromptRule.notMatch`, set to `NUMBERED_CHOICE_SIGNATURE` (a pane presenting both an option-1 and an option-2 row). Blind Enter on a selector doesn't confirm anything — it activates whatever the CLI focused. Every selector the boot poller is meant to answer already has a dedicated option-aware rule above the catch-all; what's left for the catch-all is the plain confirmation, which has no numbered rows. For an *unknown* numbered chooser this deliberately prefers a visible stall over an invisible wrong pick.

   Note on the "two phase tables": the deployed `/opt/switchroom/autoaccept-poll.js` does contain the rule twice, but that is a **bundler artifact** (`autoaccept.ts` is inlined once for the CLI entry and once via the `wedge-watchdog.ts` import). There is exactly one `PROMPTS` table in source; fixing it once fixes both bundle copies.

3. **The mid-session gap is real, and is fixed too.** Verified against the current file: `WEDGE_FOOTER_SIGNATURE` requires a `to select` / `to navigate` / `↑/↓` affordance that the modal's footer does not have; `CONFIRM_MODAL_SIGNATURE` requires a `1. Yes` / `2. No` pair (option 2 here is "Switch to Sonnet 5"); `PERMISSION_PROMPT_SIGNATURE` requires "Do you want to proceed?" + "don't ask again"; `RATE_LIMIT_MENU_SIGNATURE` requires "Stop and wait for" (the shared "usage credits" wording is not enough). So nothing classified this modal mid-session, and a `/model fable` switch after boot would park the agent on it forever. A dedicated `FABLE_CONSENT_SIGNATURE` branch now answers it with shape persistence (3 polls, `SWITCHROOM_WEDGE_FABLE_POLLS`), selecting option 1 — never Esc, which would cancel the operator's own model choice.

**Consent authority:** selecting "Continue with Fable 5" is not the watchdog deciding to spend. The modal only renders because the session was launched on (or switched to) `fable`, which is an operator decision in `switchroom.yaml` or a `/model fable` command. The keystroke re-affirms a choice already made; declining it is what silently contradicts the operator. The purchase variants stay untouched.

Job spec: `reference/jobs/survive-reboots-and-real-life.md` — an agent must come back on the model it was configured with, and must not be silently downgraded by an unanswerable TUI.

## Test plan

`tests/autoaccept.test.ts` and `tests/wedge-watchdog.test.ts`, driven by captured pane fixtures of the real modal.

```
$ ./node_modules/.bin/vitest run tests/autoaccept.test.ts tests/wedge-watchdog.test.ts
 ✓ tests/autoaccept.test.ts (32 tests)
 ✓ tests/wedge-watchdog.test.ts (50 tests)
 Test Files  2 passed (2)
      Tests  82 passed (82)
```

What the tests now guarantee:

- Given the captured Fable-modal pane, the boot dispatcher emits **exactly** `["1","Enter"]`, fires the fable rule, and does **not** fire `enter-to-confirm` or send a bare `["Enter"]`.
- The catch-all does not match the modal, nor any numbered selector carrying the confirm footer — and still matches a plain "Press Enter to confirm your selection".
- The digit comes from the pane's label, not a hardcoded position (renumbered fixture ⇒ `["3","Enter"]`), with the `["1","Enter"]` fallback when rows don't parse.
- The `Buy usage credits` variant is answered by **nothing at all** — no rule fires, no keys are sent.
- Mid-session: none of the four pre-existing signatures match the modal (this test documents the gap), the new branch selects `["1","Enter"]` after the present-streak and sends neither Escape nor Enter, doesn't fire early, and with `fableConsentSignature: null` nothing else touches the modal.

Falsification check: with the fable rule and the `notMatch` guard removed, 4 of the new tests fail, including "dispatches option 1 (Continue with Fable 5), never a bare Enter".

`bin/autoaccept.exp` (the legacy expect wrapper behind `experimental.legacy_autoaccept_expect`) gets the matching branch above its generic `Enter to confirm` branch, per the keep-in-sync contract in both files.

## Risk

- Low. Behaviour outside the fable modal is unchanged except for the catch-all guard, which only suppresses a bare Enter on numbered selectors — all of which already have dedicated rules.
- One deliberate secondary effect: the watchdog's `deferToPrompts` check now uses `ruleMatches` (honouring `notMatch`) instead of a bare `match.test`. A mid-session numbered selector whose footer says "Enter to confirm" is therefore no longer deferred to a boot poller that has already exited; the watchdog Escs it, which is its job.
- Local `tsc --noEmit` is clean for this diff; `check-plugin-references` fails identically on pristine `origin/main` in this worktree (`telegram-plugin/render/parse.ts` TS7006, symlinked `node_modules`), i.e. pre-existing/environmental. `tests/autoaccept-poll-bundled.test.ts` requires a prior `npm run build` (`pretest` does it) and fails in a fresh worktree with no `dist/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
