### PR TITLE
fix(reconcile): make the cron-only reconcile actually cron-only (#4607)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ now an anomaly worth investigating, not the norm.
 ### Bug fixes
 
 - **autoaccept: select Continue with Fable on the usage-credits consent modal**
+- **reconcile: make the cron-only reconcile actually cron-only (#4607)**
 
 ## v0.21.6 — Hindsight's `graph_maintenance` sweep stops retrying a query that can never beat its own timeout
 

--- a/src/agents/cron-hot-reload.test.ts
+++ b/src/agents/cron-hot-reload.test.ts
@@ -22,6 +22,32 @@ describe("classifyChangeKind", () => {
     expect(classifyChangeKind("/state/agents/foo/telegram/.env")).not.toBe("cron");
   });
 
+  it("tags the telegram/cron-<hash>.source attribution sidecar as cron (#4607)", () => {
+    // The stale-artifact sweep in reconcileAgent unlinks `cron-<hash>.sh`
+    // and its `.source` sidecar in the SAME pass, so a classifier that
+    // anchors on `.sh` alone makes a cron-only reconcile reject its own
+    // cron cleanup. Both basename forms the sweep can produce:
+    expect(classifyChangeKind("/state/agents/foo/telegram/cron-0123456789ab.source")).toBe("cron");
+    expect(classifyChangeKind("/state/agents/foo/telegram/cron-0123456789ab.sh")).toBe("cron");
+    expect(classifyChangeKind("/state/agents/foo/telegram/cron-7.source")).toBe("cron");
+  });
+
+  it("does NOT over-match near-miss cron basenames (#4607 widening stays tight)", () => {
+    // The widened `\.(?:sh|source)$` alternation must not loosen the
+    // `cron-<12hex>|cron-<digits>` stem: a non-hex / wrong-length stem is
+    // not a cron artifact, and mis-tagging one would let a cron-only
+    // reconcile write an arbitrary telegram/ file unchallenged.
+    expect(classifyChangeKind("/state/agents/foo/telegram/cron-nothex.source")).toBe("other");
+    expect(classifyChangeKind("/state/agents/foo/telegram/cron-nothex.sh")).toBe("other");
+    // 12 hex chars is the Phase-D length; 11 and 13 are not.
+    expect(classifyChangeKind("/state/agents/foo/telegram/cron-0123456789a.source")).toBe("other");
+    expect(classifyChangeKind("/state/agents/foo/telegram/cron-0123456789abc.source")).toBe("other");
+    // Right stem, wrong extension.
+    expect(classifyChangeKind("/state/agents/foo/telegram/cron-0123456789ab.json")).toBe("other");
+    // `.source` outside the cron- family.
+    expect(classifyChangeKind("/state/agents/foo/telegram/access.source")).toBe("other");
+  });
+
   it("tags settings.json and .mcp.json as settings", () => {
     expect(classifyChangeKind("/state/agents/foo/.claude/settings.json")).toBe("settings");
     expect(classifyChangeKind("/state/agents/foo/.mcp.json")).toBe("settings");

--- a/src/agents/lifecycle.ts
+++ b/src/agents/lifecycle.ts
@@ -841,7 +841,12 @@ export function classifyChangeKind(path: string): ChangeKind {
   // `switchroom migrate cron-unit-names` renames them, after which only
   // the new form remains on disk. The shared regex lives in
   // `cron-unit-name.ts` so all classifiers stay in lockstep.
-  if (/\/telegram\/cron-(?:\d+|[0-9a-f]{12})\.sh$/.test(path)) return "cron";
+  // #4607: the `.source` attribution sidecar is unlinked in the SAME
+  // sweep as its `.sh` and is just as much a cron artifact, but this
+  // pattern anchored on `.sh` alone — so sweeping a stale pair classified
+  // the sidecar "other" and the cron-only bridge rejected its own cron
+  // cleanup (after performing it). Match both extensions.
+  if (/\/telegram\/cron-(?:\d+|[0-9a-f]{12})\.(?:sh|source)$/.test(path)) return "cron";
   // Cron-session (Tier-1) infrastructure: the trimmed `.claude-cron/.mcp.json`
   // (+ cron-session.sh) are rendered when a cron routes to a cheap session.
   // They are a deterministic consequence of a CRON change (the value-gate

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -6884,6 +6884,51 @@ export interface ReconcileOptions {
    * continues to run all five.
    */
   skipProfileTemplates?: boolean;
+  /**
+   * Set true when the caller wants a CRON-ONLY reconcile: only the
+   * `schedule.d/` → `cron.d/` derived surfaces (and the cron-session
+   * Tier-1 artifacts under `.claude-cron/`) may be written. Every
+   * switchroom-owned write whose path `classifyChangeKind`
+   * (`src/agents/lifecycle.ts`) does NOT classify as `"cron"` is
+   * suppressed.
+   *
+   * Why this exists (switchroom #4607). `reconcileAgentCronOnly`
+   * (`src/cli/reconcile-bridge.ts`) used to run the FULL reconcile with
+   * only `skipProfileTemplates: true`, then post-hoc reject the result
+   * if any returned change path wasn't `"cron"`. That check is a
+   * detector standing where a suppressor belongs: the writers had
+   * already committed to disk by the time it ran, so the first
+   * `schedule_add` / `schedule_remove` after any scaffold drift
+   * returned `E_RECONCILE_FAILED` *after* mutating both the overlay and
+   * the scaffold — and the retry succeeded only because the writers are
+   * content-gated and the second render was a no-op.
+   *
+   * Concretely, this option suppresses FIVE non-cron write sites inside
+   * `reconcileAgent` (the full audit behind #4607 — the issue named the
+   * first two, the other three surface on the same path):
+   *
+   *   1. `.claude/settings.json` (classified `"settings"`).
+   *   2. `.claude/agents/<sub>.md` sub-agent definitions (`"other"`) —
+   *      nested inside the settings block, so gated with it.
+   *   3. `.mcp.json` + its `ensureMcpServersTrusted` companion
+   *      (`"settings"`). The `mcpServers` map is still COMPUTED, because
+   *      `maybeWriteCronMcp` needs it: `.claude-cron/.mcp.json` is
+   *      classified `"cron"` and stays in scope.
+   *   4. `telegram/.env` bot-token refresh (`"other"`).
+   *   5. The `<agentDir>/SOUL.md` → `workspace/SOUL.md` symlink
+   *      migration (`"other"`), plus the `.claude/skills/` global-pool
+   *      symlink sync — neither of which a schedule change implies.
+   *
+   * Orthogonal to `skipProfileTemplates`, which answers a different
+   * question ("is the bundled `profiles/` tree on disk?") and is
+   * therefore kept separate rather than widened: a host-side caller can
+   * legitimately want one without the other. The in-container cron
+   * bridge passes both.
+   *
+   * The host-side full reconcile leaves this false and writes
+   * everything, as before.
+   */
+  skipNonCronWrites?: boolean;
 }
 
 /**
@@ -8422,7 +8467,13 @@ function reconcileAgentInner(
 
   // --- Reconcile settings.json ---
   const settingsPath = join(agentDir, ".claude", "settings.json");
-  if (existsSync(settingsPath)) {
+  // skipNonCronWrites (#4607): this block owns two non-cron write sites —
+  // `.claude/settings.json` (classified "settings") and the nested
+  // `.claude/agents/<sub>.md` sub-agent definitions ("other"). A cron-only
+  // reconcile must not touch either. Gated at the block head rather than at
+  // each write so the read + render work is skipped too; every binding
+  // declared inside is block-scoped and unused below.
+  if (existsSync(settingsPath) && !options.skipNonCronWrites) {
     const before = readFileSync(settingsPath, "utf-8");
     const settings = JSON.parse(before);
 
@@ -8728,13 +8779,19 @@ function reconcileAgentInner(
   // by THIS agent's config (agentConfig.bot_token ?? telegramConfig.bot_token),
   // so the interrupt window (vault has <new>.bot_token while agents.<old> lingers
   // in config) can't mis-attribute another agent's token here.
-  refreshTelegramBotTokenEnv(agentDir, resolvedBotToken, changes);
+  // skipNonCronWrites (#4607): `telegram/.env` classifies "other" — a
+  // schedule change never implies a bot-token repair.
+  if (!options.skipNonCronWrites) {
+    refreshTelegramBotTokenEnv(agentDir, resolvedBotToken, changes);
+  }
 
   // --- Reconcile global skills pool symlinks ---
   //
   // Mirrors the scaffold syncGlobalSkills call so reconcile picks up
   // added/removed entries in switchroom.yaml.
-  if (agentConfig.skills) {
+  // skipNonCronWrites (#4607): these symlinks live under `.claude/skills/`
+  // ("skill"), not the cron surface.
+  if (agentConfig.skills && !options.skipNonCronWrites) {
     syncGlobalSkills(agentDir, agentConfig.skills, switchroomConfig.switchroom.skills_dir);
   }
 
@@ -8897,7 +8954,10 @@ function reconcileAgentInner(
     const before = existsSync(mcpJsonPath)
       ? readFileSync(mcpJsonPath, "utf-8")
       : "";
-    if (after !== before) {
+    // skipNonCronWrites (#4607): `.mcp.json` classifies "settings". The
+    // `mcpServers` map above is still built because `maybeWriteCronMcp`
+    // below consumes it and `.claude-cron/.mcp.json` IS cron-classified.
+    if (after !== before && !options.skipNonCronWrites) {
       // Atomic (tmp + fsync + rename) so a crash / ENOSPC mid-write can
       // never leave a torn / truncated .mcp.json that Claude Code then
       // fails to parse — same guarantee as the M5 fix. Mode 0600
@@ -8917,7 +8977,12 @@ function reconcileAgentInner(
     // Code's per-project trust allowlist (idempotent — runs every
     // reconcile so a newly-added gdrive/hostd is trusted on the next
     // `switchroom apply`, not just at original onboarding).
-    ensureMcpServersTrusted(agentDir, Object.keys(mcpServers));
+    // skipNonCronWrites (#4607): rewrites `.claude/.claude.json`, which is
+    // only ever out of date because `.mcp.json` changed — and that write is
+    // suppressed above, so there is nothing to trust-sync here.
+    if (!options.skipNonCronWrites) {
+      ensureMcpServersTrusted(agentDir, Object.keys(mcpServers));
+    }
   }
 
   // --- Re-seed workspace bootstrap files from the profile.
@@ -9012,7 +9077,10 @@ function reconcileAgentInner(
   // --- Phase 2: symlink <agentDir>/SOUL.md → workspace/SOUL.md (migration) ---
   const agentSoulPath = join(agentDir, "SOUL.md");
   const workspaceSoulPath = join(agentDir, "workspace", "SOUL.md");
-  if (existsSync(workspaceSoulPath)) {
+  // skipNonCronWrites (#4607): the symlink migration classifies "other".
+  // It is a one-shot repair the host-side reconcile owns; a cron-only
+  // reconcile must not perform it (and used to fail on it after doing so).
+  if (existsSync(workspaceSoulPath) && !options.skipNonCronWrites) {
     if (existsSync(agentSoulPath)) {
       const stat = lstatSync(agentSoulPath);
       if (stat.isSymbolicLink()) {

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -6887,10 +6887,25 @@ export interface ReconcileOptions {
   /**
    * Set true when the caller wants a CRON-ONLY reconcile: only the
    * `schedule.d/` → `cron.d/` derived surfaces (and the cron-session
-   * Tier-1 artifacts under `.claude-cron/`) may be written. Every
-   * switchroom-owned write whose path `classifyChangeKind`
-   * (`src/agents/lifecycle.ts`) does NOT classify as `"cron"` is
-   * suppressed.
+   * Tier-1 artifacts under `.claude-cron/`) should be written.
+   *
+   * SCOPE OF THE GUARANTEE — read this before relying on it. The audit
+   * behind #4607 enumerated the `changes.push` sites reachable from
+   * `reconcileAgentInner`, so what this flag actually guarantees is:
+   *
+   *   no write whose path `classifyChangeKind` (`src/agents/lifecycle.ts`)
+   *   does NOT classify as `"cron"` can reach `result.changes`.
+   *
+   * That is exactly the invariant the bridge's post-hoc check asserts,
+   * and it is what makes #4607 unreproducible. It is NOT a blanket "this
+   * process performs no non-cron file IO": two gated writers here
+   * (`ensureMcpServersTrusted`, `syncGlobalSkills`) never reached
+   * `changes` in the first place and are suppressed on contract grounds
+   * rather than to satisfy the guard, and a handful of ungated non-cron
+   * writes on this path remain — none of them `changes`-visible, so none
+   * can regress #4607. Tracked separately; see the follow-up issue linked
+   * from #4608. Before claiming "the cron-only reconcile writes nothing
+   * else", re-audit rather than trusting this comment.
    *
    * Why this exists (switchroom #4607). `reconcileAgentCronOnly`
    * (`src/cli/reconcile-bridge.ts`) used to run the FULL reconcile with
@@ -6903,9 +6918,10 @@ export interface ReconcileOptions {
    * the scaffold — and the retry succeeded only because the writers are
    * content-gated and the second render was a no-op.
    *
-   * Concretely, this option suppresses FIVE non-cron write sites inside
-   * `reconcileAgent` (the full audit behind #4607 — the issue named the
-   * first two, the other three surface on the same path):
+   * Concretely, this option suppresses FIVE `changes`-visible non-cron
+   * write sites inside `reconcileAgent` (the `changes.push` audit behind
+   * #4607 — the issue named the first two, the other three surface on the
+   * same path):
    *
    *   1. `.claude/settings.json` (classified `"settings"`).
    *   2. `.claude/agents/<sub>.md` sub-agent definitions (`"other"`) —

--- a/src/cli/reconcile-bridge.ts
+++ b/src/cli/reconcile-bridge.ts
@@ -81,11 +81,17 @@ export function reconcileAgentCronOnly(
       { skipProfileTemplates: true, skipNonCronWrites: true },
     );
     const changes = [...result.changes];
-    // Invariant assertion, not a filter: with skipNonCronWrites the
-    // reconcile cannot write a non-cron path, so a non-cron entry here
-    // means a new writer was added without a gate. Keeping the check
-    // makes that regression loud at the first call instead of silently
-    // widening the cron-only contract.
+    // Invariant assertion, not a filter. `skipNonCronWrites` gates every
+    // known non-cron writer that reports into `changes`, so a non-cron
+    // entry HERE means a new `changes.push` writer was added without a
+    // gate. Keeping the check makes that regression loud at the first
+    // call instead of silently widening the cron-only contract.
+    //
+    // Note the reach: this can only see writes that surface in `changes`.
+    // A non-cron writer that pushes nothing is invisible to it — which is
+    // why the gate, not this check, is the fix for #4607, and why the
+    // remaining ungated `changes`-invisible writes on this path are
+    // tracked as a follow-up rather than assumed absent.
     const nonCron = changes.filter((p) => classifyChangeKind(p) !== "cron");
     if (nonCron.length > 0) {
       return {

--- a/src/cli/reconcile-bridge.ts
+++ b/src/cli/reconcile-bridge.ts
@@ -9,9 +9,10 @@
  * #1185 shipped `applyCronChangesHot` (cron-only hot-reload, no container
  * bounce). This bridge wires the broker write to that path: load config
  * (overlays applied), call `reconcileAgent`, then `applyCronChangesHot`
- * with the resulting `changes` list. All non-cron changes here would
- * indicate a logic bug — the broker's dry-run reconcile assertion
- * already gates that — so we treat them as `E_RECONCILE_FAILED`.
+ * with the resulting `changes` list. The reconcile is narrowed to the
+ * cron surface by `skipNonCronWrites` (#4607); the post-hoc non-cron
+ * check that remains is an invariant assertion over that narrowing, not
+ * the narrowing itself.
  *
  * The bridge is exported as a function so `agent-config-write.ts` can
  * accept it as a DI parameter (tests stub it).
@@ -68,17 +69,30 @@ export function reconcileAgentCronOnly(
       // A cron-only reconcile has no business re-rendering profile
       // templates anyway — schedule changes only mutate `schedule.d/` and
       // generated `cron.d/` scripts. See switchroom #1618.
-      { skipProfileTemplates: true },
+      // skipNonCronWrites: the actual cron-only opt-out (#4607). Without
+      // it this call ran the FULL reconcile and the guard below rejected
+      // the result *after* the scaffold writers had already committed to
+      // disk — so the first schedule_add/schedule_remove after any
+      // scaffold drift returned E_RECONCILE_FAILED having mutated both
+      // the overlay and the scaffold, and only the retry succeeded
+      // (content-gated writers make the second render a no-op). The flag
+      // suppresses every non-cron writer instead of detecting it late;
+      // see ReconcileOptions.skipNonCronWrites for the gated set.
+      { skipProfileTemplates: true, skipNonCronWrites: true },
     );
     const changes = [...result.changes];
-    // Defensive: refuse to silently restart on non-cron changes — the
-    // broker's contract is cron-only. If non-cron drift surfaces here,
-    // that's a logic gap, not something we should paper over.
+    // Invariant assertion, not a filter: with skipNonCronWrites the
+    // reconcile cannot write a non-cron path, so a non-cron entry here
+    // means a new writer was added without a gate. Keeping the check
+    // makes that regression loud at the first call instead of silently
+    // widening the cron-only contract.
     const nonCron = changes.filter((p) => classifyChangeKind(p) !== "cron");
     if (nonCron.length > 0) {
       return {
         ok: false,
-        error: `non-cron changes surfaced during cron-only reconcile: ${nonCron.join(", ")}`,
+        error:
+          `non-cron changes surfaced during cron-only reconcile ` +
+          `(ungated writer — see ReconcileOptions.skipNonCronWrites): ${nonCron.join(", ")}`,
       };
     }
     const r = applyCronChangesHot(agent, changes);

--- a/tests/reconcile.skip-non-cron-writes.test.ts
+++ b/tests/reconcile.skip-non-cron-writes.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Regression: switchroom #4607 — the cron-only reconcile WROTE the
+ * non-cron scaffold files it was asked not to touch, and only then
+ * rejected its own writes.
+ *
+ * `reconcileAgentCronOnly` (`src/cli/reconcile-bridge.ts`) ran the full
+ * `reconcileAgent` with only `skipProfileTemplates: true`, then post-hoc
+ * filtered `result.changes` through `classifyChangeKind` and returned
+ * `E_RECONCILE_FAILED` for anything not classified `"cron"`. The scaffold
+ * writers had no gate, so `.claude/agents/<sub>.md` and
+ * `.claude/settings.json` were already on disk by the time the guard ran:
+ * the first `schedule_add` / `schedule_remove` after any scaffold drift
+ * failed AFTER committing both the overlay delete and the scaffold
+ * rewrite, and the retry succeeded only because the writers are
+ * content-gated (second render = no-op).
+ *
+ * The fix is a real opt-out — `ReconcileOptions.skipNonCronWrites` —
+ * which suppresses every writer whose path `classifyChangeKind` does not
+ * call `"cron"`.
+ *
+ * These tests deliberately assert BOTH halves for each gated writer:
+ *   (1) the reconcile succeeds / reports no non-cron change, and
+ *   (2) the drifted file on disk is byte-identical to how it started.
+ * A test that only checked (1) would pass on the buggy code once the
+ * guard was removed, while the writes still landed.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+  readFileSync,
+  lstatSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent, reconcileAgent } from "../src/agents/scaffold.js";
+import { classifyChangeKind } from "../src/agents/lifecycle.js";
+import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+const switchroomConfig: SwitchroomConfig = {
+  agents: {},
+  telegram: telegramConfig,
+  defaults: {},
+};
+
+function makeAgentConfig(): AgentConfig {
+  return {
+    extends: "default",
+    topic_name: "Test Topic",
+    schedule: [],
+    subagents: {
+      worker: {
+        description: "Implements a task",
+        prompt: "You are the worker sub-agent.",
+      },
+    },
+  } as unknown as AgentConfig;
+}
+
+/** The option pair the in-container cron bridge passes. */
+const CRON_ONLY = { skipProfileTemplates: true, skipNonCronWrites: true } as const;
+
+describe("reconcileAgent — skipNonCronWrites (#4607)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-skip-non-cron-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("drifted sub-agent md + settings.json: cron-only reconcile succeeds AND leaves both byte-identical", () => {
+    const name = "alpha";
+    scaffoldAgent(name, makeAgentConfig(), tmpDir, telegramConfig, switchroomConfig);
+
+    const subAgentPath = join(tmpDir, name, ".claude", "agents", "worker.md");
+    const settingsPath = join(tmpDir, name, ".claude", "settings.json");
+    expect(existsSync(subAgentPath)).toBe(true);
+    expect(existsSync(settingsPath)).toBe(true);
+
+    // Drift both away from what the current template renders — the exact
+    // precondition from the issue (an agent whose scaffold predates the
+    // current subagent/settings render).
+    const driftedSubAgent =
+      readFileSync(subAgentPath, "utf-8") + "\n<!-- stale render from an older template -->\n";
+    writeFileSync(subAgentPath, driftedSubAgent, "utf-8");
+
+    const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    settings.permissions = settings.permissions ?? {};
+    settings.permissions.allow = ["Read(//stale/**)"];
+    const driftedSettings = JSON.stringify(settings, null, 2) + "\n";
+    writeFileSync(settingsPath, driftedSettings, "utf-8");
+
+    // Cron-only reconcile.
+    const result = reconcileAgent(
+      name,
+      makeAgentConfig(),
+      tmpDir,
+      telegramConfig,
+      switchroomConfig,
+      undefined,
+      CRON_ONLY,
+    );
+
+    // (1) Nothing was written. Asserted FIRST because it is the load-
+    //     bearing half: on the bug the drifted bytes were replaced by a
+    //     fresh render, and this assertion still fails even if someone
+    //     "fixes" the symptom by deleting the bridge's guard.
+    expect(readFileSync(subAgentPath, "utf-8")).toBe(driftedSubAgent);
+    expect(readFileSync(settingsPath, "utf-8")).toBe(driftedSettings);
+
+    // (2) And no non-cron change is reported — this is the list the
+    //     bridge's guard turns into E_RECONCILE_FAILED.
+    const nonCron = result.changes.filter((p) => classifyChangeKind(p) !== "cron");
+    expect(nonCron).toEqual([]);
+  });
+
+  it("drifted .mcp.json: cron-only reconcile leaves it byte-identical", () => {
+    const name = "beta";
+    scaffoldAgent(name, makeAgentConfig(), tmpDir, telegramConfig, switchroomConfig);
+
+    const mcpJsonPath = join(tmpDir, name, ".mcp.json");
+    expect(existsSync(mcpJsonPath)).toBe(true);
+    const drifted = JSON.stringify({ mcpServers: { stale: { command: "true" } } }, null, 2) + "\n";
+    writeFileSync(mcpJsonPath, drifted, "utf-8");
+
+    const result = reconcileAgent(
+      name,
+      makeAgentConfig(),
+      tmpDir,
+      telegramConfig,
+      switchroomConfig,
+      undefined,
+      CRON_ONLY,
+    );
+
+    expect(result.changes.filter((p) => classifyChangeKind(p) !== "cron")).toEqual([]);
+    expect(readFileSync(mcpJsonPath, "utf-8")).toBe(drifted);
+  });
+
+  it("missing SOUL.md symlink: cron-only reconcile does not perform the migration", () => {
+    const name = "gamma";
+    scaffoldAgent(name, makeAgentConfig(), tmpDir, telegramConfig, switchroomConfig);
+
+    const agentSoulPath = join(tmpDir, name, "SOUL.md");
+    const workspaceSoulPath = join(tmpDir, name, "workspace", "SOUL.md");
+    expect(existsSync(workspaceSoulPath)).toBe(true);
+    // Replace the symlink with a plain file — the state the migration
+    // block rewrites (and reports as a non-cron change).
+    if (existsSync(agentSoulPath) || lstatSyncSafe(agentSoulPath)) {
+      rmSync(agentSoulPath, { force: true });
+    }
+    writeFileSync(agentSoulPath, "# hand-written soul\n", "utf-8");
+
+    const result = reconcileAgent(
+      name,
+      makeAgentConfig(),
+      tmpDir,
+      telegramConfig,
+      switchroomConfig,
+      undefined,
+      CRON_ONLY,
+    );
+
+    expect(result.changes.filter((p) => classifyChangeKind(p) !== "cron")).toEqual([]);
+    expect(lstatSync(agentSoulPath).isSymbolicLink()).toBe(false);
+    expect(readFileSync(agentSoulPath, "utf-8")).toBe("# hand-written soul\n");
+  });
+
+  it("default options still write the scaffold surfaces (the gate is honest, not a global mute)", () => {
+    const name = "delta";
+    scaffoldAgent(name, makeAgentConfig(), tmpDir, telegramConfig, switchroomConfig);
+
+    const subAgentPath = join(tmpDir, name, ".claude", "agents", "worker.md");
+    const settingsPath = join(tmpDir, name, ".claude", "settings.json");
+    writeFileSync(subAgentPath, "# stale\n", "utf-8");
+    const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    settings.permissions = { allow: ["Read(//stale/**)"], deny: [] };
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
+
+    const result = reconcileAgent(
+      name,
+      makeAgentConfig(),
+      tmpDir,
+      telegramConfig,
+      switchroomConfig,
+      undefined,
+      {},
+    );
+
+    expect(result.changes).toContain(subAgentPath);
+    expect(result.changes).toContain(settingsPath);
+    expect(readFileSync(subAgentPath, "utf-8")).not.toBe("# stale\n");
+    expect(JSON.parse(readFileSync(settingsPath, "utf-8")).permissions.allow).not.toEqual([
+      "Read(//stale/**)",
+    ]);
+  });
+
+  it("cron-only reconcile still sweeps stale cron scripts (cron writes are NOT suppressed)", () => {
+    const name = "epsilon";
+    scaffoldAgent(name, makeAgentConfig(), tmpDir, telegramConfig, switchroomConfig);
+
+    // A retired cron wrapper script + sidecar, the one thing the cron-only
+    // path is still allowed (and expected) to remove.
+    const telegramDir = join(tmpDir, name, "telegram");
+    const staleScript = join(telegramDir, "cron-0123456789ab.sh");
+    const staleSidecar = join(telegramDir, "cron-0123456789ab.source");
+    writeFileSync(staleScript, "#!/bin/sh\n", "utf-8");
+    writeFileSync(staleSidecar, "stale\n", "utf-8");
+
+    const result = reconcileAgent(
+      name,
+      makeAgentConfig(),
+      tmpDir,
+      telegramConfig,
+      switchroomConfig,
+      undefined,
+      CRON_ONLY,
+    );
+
+    expect(result.changes).toContain(staleScript);
+    expect(existsSync(staleScript)).toBe(false);
+    expect(existsSync(staleSidecar)).toBe(false);
+    expect(result.changes.filter((p) => classifyChangeKind(p) !== "cron")).toEqual([]);
+  });
+});
+
+/** lstat that tolerates a broken symlink / absent path. */
+function lstatSyncSafe(p: string): boolean {
+  try {
+    lstatSync(p);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/reconcile.skip-non-cron-writes.test.ts
+++ b/tests/reconcile.skip-non-cron-writes.test.ts
@@ -15,14 +15,26 @@
  * content-gated (second render = no-op).
  *
  * The fix is a real opt-out — `ReconcileOptions.skipNonCronWrites` —
- * which suppresses every writer whose path `classifyChangeKind` does not
- * call `"cron"`.
+ * which suppresses the known writers whose paths `classifyChangeKind`
+ * does not call `"cron"`. Its load-bearing guarantee is scoped to the
+ * `changes.push` audit behind #4607 (no non-cron write can reach
+ * `result.changes`), not to "this process performs no non-cron file IO";
+ * see the option's doc-comment in `src/agents/scaffold.ts`.
  *
- * These tests deliberately assert BOTH halves for each gated writer:
- *   (1) the reconcile succeeds / reports no non-cron change, and
- *   (2) the drifted file on disk is byte-identical to how it started.
- * A test that only checked (1) would pass on the buggy code once the
- * guard was removed, while the writes still landed.
+ * These tests deliberately assert BOTH halves for each gated writer, and
+ * always in this order:
+ *   (1) the drifted file on disk is byte-identical to how it started, and
+ *   (2) the reconcile reports no non-cron change.
+ * Disk state comes FIRST in every drift case on purpose: it is the half a
+ * guard-only "fix" would not catch (a test that only checked (2) passes on
+ * the buggy code the moment the bridge's guard is deleted, while the writes
+ * still land), and for the two writers that never reach `changes` at all —
+ * `syncGlobalSkills`, `ensureMcpServersTrusted` — it is the ONLY half that
+ * can assert anything.
+ *
+ * Cases whose writer never surfaces in `changes` carry an in-test positive
+ * control: the same fixture re-reconciled with the gate off, proving the
+ * writer is genuinely reachable and the gated assertion is not vacuous.
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
@@ -32,6 +44,7 @@ import {
   existsSync,
   readFileSync,
   lstatSync,
+  mkdirSync,
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -143,8 +156,62 @@ describe("reconcileAgent — skipNonCronWrites (#4607)", () => {
       CRON_ONLY,
     );
 
-    expect(result.changes.filter((p) => classifyChangeKind(p) !== "cron")).toEqual([]);
+    // Disk state first — see case 1.
     expect(readFileSync(mcpJsonPath, "utf-8")).toBe(drifted);
+    expect(result.changes.filter((p) => classifyChangeKind(p) !== "cron")).toEqual([]);
+  });
+
+  it("placeholder telegram/.env: cron-only reconcile does NOT perform the bot-token refresh", () => {
+    // The scenario from #4607's review: an agent scaffolded while its
+    // `bot_token` was an unresolvable `vault:` reference froze the
+    // placeholder into `telegram/.env`; the operator later runs
+    // `vault set`, and the agent's next `schedule_add` would have
+    // silently rewritten `.env` (classified "other") as a side effect.
+    // A schedule change never implies a bot-token repair — that is the
+    // host reconcile's job.
+    const name = "zeta";
+    scaffoldAgent(name, makeAgentConfig(), tmpDir, telegramConfig, switchroomConfig);
+
+    const envPath = join(tmpDir, name, "telegram", ".env");
+    expect(existsSync(envPath)).toBe(true);
+    // Put the file back into the state a vault-unresolvable scaffold
+    // leaves behind: no active TELEGRAM_BOT_TOKEN= line.
+    const placeholder = "# Set your bot token: TELEGRAM_BOT_TOKEN=your-token-here\n";
+    writeFileSync(envPath, placeholder, "utf-8");
+
+    const result = reconcileAgent(
+      name,
+      makeAgentConfig(),
+      tmpDir,
+      telegramConfig,
+      switchroomConfig,
+      undefined,
+      CRON_ONLY,
+    );
+
+    // Disk state first — see case 1.
+    expect(readFileSync(envPath, "utf-8")).toBe(placeholder);
+    expect(result.changes.filter((p) => classifyChangeKind(p) !== "cron")).toEqual([]);
+
+    // Positive control, in-test: the SAME fixture with the gate off DOES
+    // refresh the token. Without this the case could pass vacuously (a
+    // fixture that never reaches the writer asserts nothing), and it is
+    // what makes the test fail if the gate at scaffold.ts's
+    // `refreshTelegramBotTokenEnv` call site is ever dropped — the first
+    // assertion above would then see the refreshed body instead of the
+    // placeholder.
+    const ungated = reconcileAgent(
+      name,
+      makeAgentConfig(),
+      tmpDir,
+      telegramConfig,
+      switchroomConfig,
+      undefined,
+      {},
+    );
+    expect(readFileSync(envPath, "utf-8")).not.toBe(placeholder);
+    expect(readFileSync(envPath, "utf-8")).toContain(telegramConfig.bot_token);
+    expect(ungated.changes).toContain(envPath);
   });
 
   it("missing SOUL.md symlink: cron-only reconcile does not perform the migration", () => {
@@ -171,9 +238,54 @@ describe("reconcileAgent — skipNonCronWrites (#4607)", () => {
       CRON_ONLY,
     );
 
-    expect(result.changes.filter((p) => classifyChangeKind(p) !== "cron")).toEqual([]);
+    // Disk state first — see case 1.
     expect(lstatSync(agentSoulPath).isSymbolicLink()).toBe(false);
     expect(readFileSync(agentSoulPath, "utf-8")).toBe("# hand-written soul\n");
+    expect(result.changes.filter((p) => classifyChangeKind(p) !== "cron")).toEqual([]);
+  });
+
+  it("newly declared global skill: cron-only reconcile does NOT sync the .claude/skills/ symlink", () => {
+    // `syncGlobalSkills` never pushes to `changes`, so the bridge's guard
+    // could never have caught it — it is gated because the contract is
+    // "cron only", not "cron only as far as the guard can see". Asserted
+    // on disk for exactly that reason.
+    const name = "eta";
+    const skillsPool = join(tmpDir, "_pool");
+    mkdirSync(join(skillsPool, "humanizer"), { recursive: true });
+    writeFileSync(join(skillsPool, "humanizer", "SKILL.md"), "# humanizer\n", "utf-8");
+    const configWithPool = {
+      ...switchroomConfig,
+      switchroom: { skills_dir: skillsPool },
+    } as unknown as SwitchroomConfig;
+
+    // Scaffold WITHOUT the skill, then reconcile with it declared — the
+    // real shape (operator adds `skills:` to switchroom.yaml; the agent's
+    // next schedule_add must not be what installs it).
+    scaffoldAgent(name, makeAgentConfig(), tmpDir, telegramConfig, configWithPool);
+    const linkPath = join(tmpDir, name, ".claude", "skills", "humanizer");
+    // lstat, not existsSync: existsSync follows the link, so a BROKEN
+    // symlink would read as "absent" and pass this vacuously.
+    expect(lstatSyncSafe(linkPath)).toBe(false);
+
+    const withSkill = { ...makeAgentConfig(), skills: ["humanizer"] } as unknown as AgentConfig;
+    const result = reconcileAgent(
+      name,
+      withSkill,
+      tmpDir,
+      telegramConfig,
+      configWithPool,
+      undefined,
+      CRON_ONLY,
+    );
+
+    // Disk state first — see case 1.
+    expect(lstatSyncSafe(linkPath)).toBe(false);
+    expect(result.changes.filter((p) => classifyChangeKind(p) !== "cron")).toEqual([]);
+
+    // Positive control: same fixture, gate off, the symlink lands. Proves
+    // the case is not passing vacuously on an unreachable writer.
+    reconcileAgent(name, withSkill, tmpDir, telegramConfig, configWithPool, undefined, {});
+    expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
   });
 
   it("default options still write the scaffold surfaces (the gate is honest, not a global mute)", () => {


### PR DESCRIPTION
Fixes #4607

## Summary

The cron-only reconcile now genuinely writes only the cron surface, instead of writing everything and then refusing its own writes.

`reconcileAgentCronOnly` (`src/cli/reconcile-bridge.ts`) ran the full `reconcileAgent` with only `skipProfileTemplates: true`, then post-hoc rejected the result if any path in `result.changes` wasn't classified `"cron"`. The scaffold writers had no skip gate, so `.claude/agents/<sub>.md` and `.claude/settings.json` were already on disk by the time the guard ran. Net effect, exactly as filed: the first `schedule_add` / `schedule_remove` after any scaffold drift returned `E_RECONCILE_FAILED` **after** committing both the overlay change and the scaffold rewrite, and the retry succeeded only because the writers are content-gated (`if (content !== before)`), making the second render a no-op.

Option (a) from the issue: a real opt-out, not a re-ordered refusal.

- **New `ReconcileOptions.skipNonCronWrites`** (`src/agents/scaffold.ts`), passed by the bridge alongside `skipProfileTemplates`.
- **`classifyChangeKind` now matches the `.source` sidecar** (`src/agents/lifecycle.ts`).
- **The post-hoc guard stays**, re-framed as an invariant assertion with an error message that names the actual cause.

## Why

Verified against source at HEAD, not the bundle. The RCA in #4607 holds exactly: `reconcile-bridge.ts:71` passed only `skipProfileTemplates`, the sub-agent writer (`scaffold.ts` ~:8657) and settings writer (~:8688) had no gate, and `classifyChangeKind` maps them to `"other"` / `"settings"`.

Job spec: `reference/jobs/get-better-the-longer-they-run.md` — agent self-authoring of its own schedule is one of the surfaces that job promises works without the operator, and "the first call always errors, the second always works" is precisely the trust leak it names.

## Judgement calls

**1. Keep or drop the post-hoc `nonCron` guard? — Kept.**
With the writes genuinely suppressed it is no longer a landmine: it can only fire if a future writer lands ungated, which is a real regression worth failing loudly on. Per the issue's condition, keeping it required suppressing *every* path that can still fire it rather than weakening it — see the audit below, which found three more than the two named. The error text now says `(ungated writer — see ReconcileOptions.skipNonCronWrites)` so the next person reads it as "a gate is missing", not "your scaffold drifted".

**2. Widen `skipProfileTemplates` instead of adding a flag? — No, added a second flag.**
Checked every call site. `skipProfileTemplates: true` is passed by exactly one production caller (`reconcile-bridge.ts`) plus test fixtures, so widening would have been behaviourally safe today. I still didn't, because the two flags answer different questions: `skipProfileTemplates` means "the bundled `profiles/` tree / vendored plugin / host skills pool are not on disk in this process" (an *environment* fact — its whole doc-comment and its regression suite `tests/reconcile.skip-profile-templates.test.ts` are written around ENOENT avoidance), whereas `skipNonCronWrites` means "this caller wants only the cron surface" (an *intent*). Folding intent into an environment probe would make a host-side caller unable to ask for one without the other, and would silently redefine what the existing #1618 tests are pinning. The in-container bridge passes both.

**3. Anything else on the cron-only path that can surface a non-cron change? — Yes, three more.**
Audited all 13 `changes.push` sites reachable from `reconcileAgentInner` (including the out-param helpers), not just the two in the issue. With `skipProfileTemplates: true` already suppressing start.sh / CLAUDE.md / workspace re-seed, the sites that could still fire the guard were:

| site | `classifyChangeKind` | in the issue? |
|---|---|---|
| `.claude/settings.json` | `settings` | yes |
| `.claude/agents/<sub>.md` | `other` | yes |
| `.mcp.json` (+ `ensureMcpServersTrusted`) | `settings` | no |
| `telegram/.env` bot-token refresh | `other` | no |
| `SOUL.md` symlink migration | `other` | no |

All five are gated. Also gated the `.claude/skills/` global-pool symlink sync — it never reaches `changes`, so it could not trip the guard, but it is a non-cron write and a schedule change does not imply a skills-pool sync.

**Scope of the claim, stated precisely.** The audit walked the `changes.push` sites, so what this PR guarantees is *no non-cron write that reaches `changes`* — which is exactly the invariant the retained guard asserts and exactly what makes #4607 unreproducible. It is not "the cron-only reconcile performs no non-cron file IO": three ungated non-cron writes that never touch `changes` remain reachable on this path (the `.resume-mode-migration-warned` marker, the legacy `CLAUDE.custom.md` move, and `initWorkspaceGitRepo`), plus `repos:` provisioning with its network `git fetch`. They are pre-existing, unchanged by this PR in either direction, and structurally cannot produce #4607's failure mode. Filed as #4609 rather than folded in here. The `skipNonCronWrites` doc-comment and the guard's comment state the scoped guarantee so the next reader does not inherit the stronger one.

Deliberately **not** gated: `maybeWriteCronMcp` → `.claude-cron/.mcp.json` and the stale `telegram/cron-*.sh` sweep. Both are cron-classified and are the writes a cron-only reconcile is *supposed* to do. The `mcpServers` map is therefore still computed under the gate, because `maybeWriteCronMcp` consumes it; only the `.mcp.json` write itself is suppressed.

**5. Host-side `pending commit` now runs narrowed too — deliberate.**
`reconcileAgentCronOnly` has one other caller: the operator-only `switchroom schedule pending commit` verb (`src/cli/agent-config-write.ts:894`), which runs on the host, not in a container. It therefore picks up `skipNonCronWrites` as well. That is correct rather than a regression: the bridge already passed `skipProfileTemplates: true` for that caller, and pre-PR the extra scaffold writes it performed were *always* followed by the guard turning them into `E_RECONCILE_FAILED` (exit 10, "committed but reconcile failed") whenever any drift existed — i.e. the drift "repair" was never a usable feature, it was #4607 firing on the host. Post-PR that call succeeds and simply leaves drift to the host reconcile that owns it. Noted here because the rest of this description frames the flag as in-container-only.

**4. Unplanned find — the `.source` sidecar was misclassified.**
The stale-artifact sweep unlinks `cron-<hash>.sh` and `cron-<hash>.source` together, but `classifyChangeKind`'s pattern anchored on `.sh` alone, so the sidecar classified `"other"`. That is the same write-then-fail shape as #4607: the cron-only reconcile deleted the pair and then rejected its own cron cleanup. Caught by the regression test (the sidecar case was written to prove cron writes are *not* suppressed and failed on the classifier instead). The pattern now matches `\.(?:sh|source)$`. Both consumers of the classifier are unaffected in the other direction: deleting a retired sidecar genuinely needs no restart.

## Test plan

New `tests/reconcile.skip-non-cron-writes.test.ts` (**7 cases**), following the layout of the sibling `tests/reconcile.skip-profile-templates.test.ts`, plus 2 new cases in `src/agents/cron-hot-reload.test.ts` (the classifier's own unit-test home).

Each drift case asserts **both** halves, disk state first:
1. the deliberately drifted file is byte-identical to how it started, and
2. `result.changes` contains no non-cron path (the list the bridge turns into `E_RECONCILE_FAILED`).

Byte-identity is asserted before the changes list in **every** drift case on purpose: it is the half a guard-only "fix" would not catch, and for the two gated writers that never reach `changes` at all (`syncGlobalSkills`, `ensureMcpServersTrusted`) it is the only half that can assert anything.

Two of the cases — `telegram/.env` and the `.claude/skills/` symlink — carry an **in-test positive control**: the same fixture re-reconciled with the gate off, proving the writer is genuinely reachable and the gated assertion is not passing vacuously. Dropping the `refreshTelegramBotTokenEnv` gate fails the `.env` case on the byte-identity assertion (`expected 'TELEGRAM_BOT_TOKEN=…' to be '# Set your bot token: …'`), verified by reverting the gate locally; dropping the `syncGlobalSkills` gate fails its case on `expected true to be false`.

The classifier tests pin the widened `\.(?:sh|source)$` pattern directly: a positive (`…/telegram/cron-0123456789ab.source` → `"cron"`) and a negative set (`cron-nothex`, 11- and 13-char stems, wrong extension, `.source` outside the `cron-` family → `"other"`) so an over-match regression fails where the classifier lives rather than only through the reconcile harness.

Proof it fails on the bug — stash the two suppressor files, keep the test:

```
× drifted sub-agent md + settings.json: ... AND leaves both byte-identical
  → AssertionError: expected '---\nname: worker...' to be '---\nname: worker...'
  - <!-- stale render from an older template -->
× drifted .mcp.json: cron-only reconcile leaves it byte-identical
× missing SOUL.md symlink: cron-only reconcile does not perform the migration
× cron-only reconcile still sweeps stale cron scripts
✓ default options still write the scaffold surfaces
  Tests  4 failed | 1 passed (5)
```

(That run predates the two cases added in review; the shape is unchanged.) The failure is the drifted marker being stripped by the rewrite — i.e. the write landing, which is the actual bug. With the fix: all cases pass. The `default options` case is the honesty control: same code path, flag off, scaffold surfaces still rewritten.

Scoped local runs, all green:
- `vitest run tests/reconcile.skip-non-cron-writes.test.ts tests/reconcile.skip-profile-templates.test.ts tests/reconcile-hooks-drift.test.ts tests/scaffold.reconcile-group.test.ts src/agents/cron-hot-reload.test.ts src/agents/cron-unit-name.test.ts src/cli/agent-config-{write,pending}.test.ts src/agents/reconcile-dry-run.test.ts` — **143 passed** (9 files)
- `npm run lint` — fully green (tsc + every guard)

CHANGELOG entry staged author-side per `.github/MERGE-QUEUE.md`.

## Risk

Low, and confined to the one caller. Behaviour with the flag off (every host-side `apply` / `agent restart` / `doctor` path) is byte-identical — the only unconditional change is the classifier widening, which reclassifies deletions of an already-retired artifact from `other` to `cron`, i.e. from "would require a restart" to "would not". Nothing on the cron-only path needs the suppressed writes: no cron content lives in `settings.json`, `.mcp.json`, `.claude/agents/*.md`, `telegram/.env`, or the `SOUL.md` link, and the host-side reconcile still owns all of them. The residual is that in-container scaffold drift now persists until the next real reconcile instead of being repaired as a side effect of an unrelated `schedule_add` — which is the correct division of labour, and previously that "repair" cost the caller an error anyway.

Deferred, with the reason stated above: #4609 — three ungated non-cron writes that never reach `changes`, pre-existing and unable to reproduce #4607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

