### PR TITLE
fix(hindsight-watch): a permanently-broken SPARSE operation type no longer reads green for ever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,13 +90,21 @@ now an anomaly worth investigating, not the norm.
   91 h, both banks 220 h since their last successful op — and the signal
   reported `{"status":"ok","breaches":0}`. The per-pair psql pass now also
   reads the age of the pair's most recent `completed` op, and a streak counts
-  as live when EITHER the failure is recent (unchanged for dense jobs) OR the
-  streak has reached the warn line and nothing has succeeded for
-  `CONSOLIDATION_STREAK_NO_SUCCESS_S` (24 h, measured: the longest
-  self-resolving ≥3 streak on record spans 17.64 h success-to-success). Asking
-  "has anything SUCCEEDED lately?" instead of "is the failure recent?" still
-  clears the instant a completion lands, which is what the recency guard
-  existed to protect. (#4620)
+  as live when EITHER the failure is recent (the old condition, unchanged) OR
+  the streak has reached the warn line and nothing has succeeded for
+  `CONSOLIDATION_STREAK_NO_SUCCESS_S` (48 h). The second arm is **not** scoped
+  to sparse types — nothing in the data distinguishes them — so a DENSE pair
+  that is genuinely broken past 48 h now breaches where it previously read
+  `ok`; that is intended, but it is a behaviour change, not a no-op. 48 h is
+  derived against every self-resolving failure episode visible in the
+  `async_operations` window (58 episodes, 56 recovered: p50 0.88 h, p95
+  16.16 h, max 27.67 h) and against the p99 gap between successive
+  `graph_maintenance` completions (28.47 h). That window is 30 days — all the
+  table retains — and it contains **no** recovered sparse ≥3-failure episode,
+  so the constant's doc block states that limit rather than implying a safety
+  margin the data cannot support. Asking "has anything SUCCEEDED lately?"
+  instead of "is the failure recent?" still clears the instant a completion
+  lands, which is what the recency guard existed to protect. (#4618)
 
 ## v0.21.7 — a Fable-pinned agent boots on Fable, a cron edit stops failing on its first try, and the merge queue stops ejecting innocent PRs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,25 @@ now an anomaly worth investigating, not the norm.
   `{session_id, title, started_at, source}` — falling back to the bare
   `{session_id: null}` when there is no eligible session — rather than
   `{session}`, the key no caller was ever finding.
+- **hindsight-watch: a permanently-broken SPARSE operation type no longer
+  reads green for ever.** `consolidation-failure-streak` admitted a streak
+  only when its newest FAILURE was under 2 h old
+  (`CONSOLIDATION_STREAK_RECENCY_S`) — a proxy for "still broken" tuned
+  against `consolidation`, which failed every 87 s during the 2026-07-29
+  incident. A demand-driven job produces no new failures while it is broken,
+  so the proxy structurally cannot hold its streak: live on 2026-08-12,
+  `overlord/graph_maintenance` held a streak of 19 (page line is 10) whose
+  newest failure was 37 h old and `klanker/graph_maintenance` a streak of 9 at
+  91 h, both banks 220 h since their last successful op — and the signal
+  reported `{"status":"ok","breaches":0}`. The per-pair psql pass now also
+  reads the age of the pair's most recent `completed` op, and a streak counts
+  as live when EITHER the failure is recent (unchanged for dense jobs) OR the
+  streak has reached the warn line and nothing has succeeded for
+  `CONSOLIDATION_STREAK_NO_SUCCESS_S` (24 h, measured: the longest
+  self-resolving ≥3 streak on record spans 17.64 h success-to-success). Asking
+  "has anything SUCCEEDED lately?" instead of "is the failure recent?" still
+  clears the instant a completion lands, which is what the recency guard
+  existed to protect. (#4620)
 
 ## v0.21.7 — a Fable-pinned agent boots on Fable, a cron edit stops failing on its first try, and the merge queue stops ejecting innocent PRs
 

--- a/src/hindsight-watch/evaluate.test.ts
+++ b/src/hindsight-watch/evaluate.test.ts
@@ -577,7 +577,7 @@ describe("evaluateConsolidationFailureStreak — the signal that was missing", (
     expect(v.state).toBe("ok");
   });
 
-  // ── the sparse-job blind spot (#4620) ────────────────────────────────────
+  // ── the sparse-job blind spot (#4618) ────────────────────────────────────
   //
   // Every fixture below is HARD-CODED in seconds, deliberately not derived
   // from the constants it exercises: a fixture written as
@@ -588,7 +588,7 @@ describe("evaluateConsolidationFailureStreak — the signal that was missing", (
     it("pins the constants these fixtures are written against", () => {
       // If either of these changes, the literal fixtures below stop meaning
       // what their comments say — re-derive them, do not retune this pin.
-      expect(CONSOLIDATION_STREAK_NO_SUCCESS_S).toBe(86_400); // 24h
+      expect(CONSOLIDATION_STREAK_NO_SUCCESS_S).toBe(172_800); // 48h
       expect(CONSOLIDATION_STREAK_RECENCY_S).toBe(7_200); // 2h
       expect(CONSOLIDATION_FAILURE_STREAK_WARN).toBe(3);
     });
@@ -639,7 +639,7 @@ describe("evaluateConsolidationFailureStreak — the signal that was missing", (
 
     it("does NOT fire while a success is recent — the dense case is unchanged", () => {
       // The exact shape the recency guard was added for: old failures, but the
-      // pair completed since. 23h < 24h, so the sparse arm must abstain and
+      // pair completed since. 46h < 48h, so the sparse arm must abstain and
       // the old arm already rejects the 100h-old failure.
       const v = evaluateConsolidationFailureStreak([
         sample(0, {
@@ -650,7 +650,7 @@ describe("evaluateConsolidationFailureStreak — the signal that was missing", (
                 operationType: "consolidation",
                 streak: 500,
                 newestFailureAgeS: 360_000, // 100h
-                lastCompletedAgeS: 82_800, // 23h — inside the window
+                lastCompletedAgeS: 165_600, // 46h — inside the window
               },
             ],
           }),
@@ -677,9 +677,9 @@ describe("evaluateConsolidationFailureStreak — the signal that was missing", (
             }),
           }),
         ]).state;
-      expect(at(86_399)).toBe("ok"); // 24h − 1s
-      expect(at(86_400)).toBe("ok"); // exactly 24h — strictly greater required
-      expect(at(86_401)).toBe("breach"); // 24h + 1s
+      expect(at(172_799)).toBe("ok"); // 48h − 1s
+      expect(at(172_800)).toBe("ok"); // exactly 48h — strictly greater required
+      expect(at(172_801)).toBe("breach"); // 48h + 1s
     });
 
     it("breaches when the pair has NEVER completed — no success is not a fresh one", () => {
@@ -700,10 +700,85 @@ describe("evaluateConsolidationFailureStreak — the signal that was missing", (
       ]);
       expect(v.state).toBe("breach");
       expect(v.detail).toContain("last SUCCESS NEVER");
+      expect(v.measured?.lastCompletedAgeS).toBe("never");
+    });
+
+    it("a NEVER-completed pair is still held to the clock — absence alone must not page", () => {
+      // The only clock available when nothing has ever completed is the
+      // streak's own age. Firing on absence alone would page a pair whose
+      // history simply fell out of the retention window, or a brand-new pair
+      // whose first three ops failed an hour ago and is already retrying.
+      const at = (newestFailureAgeS: number) =>
+        evaluateConsolidationFailureStreak([
+          sample(0, {
+            banks: banks({
+              streaks: [
+                {
+                  bank: "newbank",
+                  operationType: "graph_maintenance",
+                  streak: 12,
+                  newestFailureAgeS,
+                  lastCompletedAgeS: null,
+                },
+              ],
+            }),
+          }),
+        ]).state;
+      expect(at(172_799)).toBe("ok"); // 48h − 1s since the newest failure
+      expect(at(172_800)).toBe("ok"); // exactly 48h — strictly greater required
+      expect(at(172_801)).toBe("breach"); // 48h + 1s
+      // …and the recency arm still fires independently of any of this.
+      expect(at(60)).toBe("breach");
+    });
+
+    it("says UNKNOWN, and omits the key, when the row predates the field", () => {
+      // A legacy row that breaches on the RECENCY arm still reports. The
+      // distinction the operator needs is "never succeeded" vs "we did not
+      // read it": the detail must not claim the former, and `measured` must
+      // omit the key entirely rather than emit a null the reader would have
+      // to guess at.
+      const v = evaluateConsolidationFailureStreak([
+        sample(0, {
+          banks: banks({
+            streaks: [
+              {
+                bank: "overlord",
+                operationType: "consolidation",
+                streak: 12,
+                newestFailureAgeS: 60, // fresh — breaches on the old arm
+              },
+            ],
+          }),
+        }),
+      ]);
+      expect(v.state).toBe("breach");
+      expect(v.detail).toContain("last SUCCESS unknown (state predates the field)");
+      expect(v.detail).not.toContain("NEVER");
+      expect(v.measured).not.toHaveProperty("lastCompletedAgeS");
+    });
+
+    it("reports a KNOWN last success as an age, not as 'never'", () => {
+      const v = evaluateConsolidationFailureStreak([
+        sample(0, {
+          banks: banks({
+            streaks: [
+              {
+                bank: "overlord",
+                operationType: "graph_maintenance",
+                streak: 19,
+                newestFailureAgeS: 133_977,
+                lastCompletedAgeS: 791_908, // 219.97h
+              },
+            ],
+          }),
+        }),
+      ]);
+      expect(v.detail).toContain("last SUCCESS 220.0h ago");
+      expect(v.measured?.lastCompletedAgeS).toBe(791_908);
     });
 
     it("needs a real streak: 2 stale failures with no success are still not a breach", () => {
-      // The conjunction is what keeps the 24h window safe. A healthy sparse
+      // The conjunction is what keeps the 48h window safe. A healthy sparse
       // pair legitimately goes ~28h between completions (measured p99), so the
       // window alone would be noise — it is only ever asked about a pair that
       // has already failed ≥3 times in a row.
@@ -732,21 +807,26 @@ describe("evaluateConsolidationFailureStreak — the signal that was missing", (
     it("ABSTAINS on a row persisted before the field existed — unknown is not 'never'", () => {
       // A state file written by an older build has no `lastCompletedAgeS`.
       // Reading that as "never completed" would page on hydration alone.
-      const v = evaluateConsolidationFailureStreak([
-        sample(0, {
-          banks: banks({
-            streaks: [
-              {
-                bank: "overlord",
-                operationType: "graph_maintenance",
-                streak: 19,
-                newestFailureAgeS: 133_977,
-              },
-            ],
+      const at = (newestFailureAgeS: number) =>
+        evaluateConsolidationFailureStreak([
+          sample(0, {
+            banks: banks({
+              streaks: [
+                {
+                  bank: "overlord",
+                  operationType: "graph_maintenance",
+                  streak: 19,
+                  newestFailureAgeS,
+                },
+              ],
+            }),
           }),
-        }),
-      ]);
-      expect(v.state).toBe("ok");
+        ]).state;
+      expect(at(133_977)).toBe("ok"); // 37h
+      // The interesting one: an absent field must abstain even when the
+      // streak is old enough that a genuine `null` WOULD breach. `undefined`
+      // and `null` differ here, and a loose `== null` check erases that.
+      expect(at(500_000)).toBe("ok"); // 139h — a null here breaches; unknown must not
     });
   });
 

--- a/src/hindsight-watch/evaluate.test.ts
+++ b/src/hindsight-watch/evaluate.test.ts
@@ -487,6 +487,7 @@ import {
 import {
   CONSOLIDATION_FAILURE_STREAK_PAGE,
   CONSOLIDATION_FAILURE_STREAK_WARN,
+  CONSOLIDATION_STREAK_NO_SUCCESS_S,
   CONSOLIDATION_STREAK_RECENCY_S,
   PENDING_CONSOLIDATION_FLOOR,
 } from "./thresholds.js";
@@ -566,12 +567,187 @@ describe("evaluateConsolidationFailureStreak — the signal that was missing", (
               operationType: "consolidation",
               streak: 500,
               newestFailureAgeS: CONSOLIDATION_STREAK_RECENCY_S + 1,
+              // Fixed: a completion landed after the streak, 10 minutes ago.
+              lastCompletedAgeS: 600,
             },
           ],
         }),
       }),
     ]);
     expect(v.state).toBe("ok");
+  });
+
+  // ── the sparse-job blind spot (#4620) ────────────────────────────────────
+  //
+  // Every fixture below is HARD-CODED in seconds, deliberately not derived
+  // from the constants it exercises: a fixture written as
+  // `CONSOLIDATION_STREAK_NO_SUCCESS_S + 1` moves with the constant and the
+  // test can then never fail for any value of it. The two pins at the top are
+  // the tripwire that keeps the literals honest.
+  describe("a SPARSE, demand-driven op type that is 100% broken", () => {
+    it("pins the constants these fixtures are written against", () => {
+      // If either of these changes, the literal fixtures below stop meaning
+      // what their comments say — re-derive them, do not retune this pin.
+      expect(CONSOLIDATION_STREAK_NO_SUCCESS_S).toBe(86_400); // 24h
+      expect(CONSOLIDATION_STREAK_RECENCY_S).toBe(7_200); // 2h
+      expect(CONSOLIDATION_FAILURE_STREAK_WARN).toBe(3);
+    });
+
+    it("FIRES on the live 2026-08-12 shape the old guard read as healthy", () => {
+      // Read verbatim off the production `state.json` + `async_operations`:
+      //   overlord | graph_maintenance | streak 19 | newest failure 133,977s
+      //             (37.2h) | last SUCCESS 791,908s (220h) ago
+      //   klanker  | graph_maintenance | streak  9 | newest failure 328,555s
+      //             (91.3h) | last SUCCESS 791,676s (220h) ago
+      // Both failed the 2h recency guard, so the candidate list emptied and
+      // the signal reported {"status":"ok","breaches":0} while the job was
+      // completely broken. `graph_maintenance` is not a cron — it runs only
+      // when work is enqueued — so it CANNOT produce a recent failure.
+      const v = evaluateConsolidationFailureStreak([
+        sample(0, {
+          consolidation: { pending: 0, oldestAgeS: 0 },
+          banks: banks({
+            streaks: [
+              {
+                bank: "klanker",
+                operationType: "graph_maintenance",
+                streak: 9,
+                newestFailureAgeS: 328_555,
+                lastCompletedAgeS: 791_676,
+              },
+              {
+                bank: "overlord",
+                operationType: "graph_maintenance",
+                streak: 19,
+                newestFailureAgeS: 133_977,
+                lastCompletedAgeS: 791_908,
+              },
+            ],
+          }),
+        }),
+      ]);
+      expect(v.state).toBe("breach");
+      expect(v.severity).toBe("page");
+      expect(v.measured?.bank).toBe("overlord");
+      expect(v.measured?.streak).toBe(19);
+      expect(v.measured?.operationType).toBe("graph_maintenance");
+      expect(v.measured?.lastCompletedAgeS).toBe(791_908);
+      // Both pairs breach, not just the worst one.
+      expect(v.measured?.breachingPairs).toBe(2);
+      expect(v.detail).toContain("klanker/graph_maintenance×9");
+    });
+
+    it("does NOT fire while a success is recent — the dense case is unchanged", () => {
+      // The exact shape the recency guard was added for: old failures, but the
+      // pair completed since. 23h < 24h, so the sparse arm must abstain and
+      // the old arm already rejects the 100h-old failure.
+      const v = evaluateConsolidationFailureStreak([
+        sample(0, {
+          banks: banks({
+            streaks: [
+              {
+                bank: "overlord",
+                operationType: "consolidation",
+                streak: 500,
+                newestFailureAgeS: 360_000, // 100h
+                lastCompletedAgeS: 82_800, // 23h — inside the window
+              },
+            ],
+          }),
+        }),
+      ]);
+      expect(v.state).toBe("ok");
+      expect(v.measured?.streak).toBe(0);
+    });
+
+    it("fires the moment the no-success window is CROSSED, not before", () => {
+      const at = (lastCompletedAgeS: number) =>
+        evaluateConsolidationFailureStreak([
+          sample(0, {
+            banks: banks({
+              streaks: [
+                {
+                  bank: "overlord",
+                  operationType: "graph_maintenance",
+                  streak: 19,
+                  newestFailureAgeS: 133_977, // 37h — fails the recency arm
+                  lastCompletedAgeS,
+                },
+              ],
+            }),
+          }),
+        ]).state;
+      expect(at(86_399)).toBe("ok"); // 24h − 1s
+      expect(at(86_400)).toBe("ok"); // exactly 24h — strictly greater required
+      expect(at(86_401)).toBe("breach"); // 24h + 1s
+    });
+
+    it("breaches when the pair has NEVER completed — no success is not a fresh one", () => {
+      const v = evaluateConsolidationFailureStreak([
+        sample(0, {
+          banks: banks({
+            streaks: [
+              {
+                bank: "newbank",
+                operationType: "graph_maintenance",
+                streak: 12,
+                newestFailureAgeS: 500_000,
+                lastCompletedAgeS: null,
+              },
+            ],
+          }),
+        }),
+      ]);
+      expect(v.state).toBe("breach");
+      expect(v.detail).toContain("last SUCCESS NEVER");
+    });
+
+    it("needs a real streak: 2 stale failures with no success are still not a breach", () => {
+      // The conjunction is what keeps the 24h window safe. A healthy sparse
+      // pair legitimately goes ~28h between completions (measured p99), so the
+      // window alone would be noise — it is only ever asked about a pair that
+      // has already failed ≥3 times in a row.
+      const at = (streak: number) =>
+        evaluateConsolidationFailureStreak([
+          sample(0, {
+            banks: banks({
+              streaks: [
+                {
+                  bank: "overlord",
+                  operationType: "graph_maintenance",
+                  streak,
+                  newestFailureAgeS: 133_977,
+                  lastCompletedAgeS: 791_908,
+                },
+              ],
+            }),
+          }),
+        ]);
+      expect(at(2).state).toBe("ok");
+      expect(at(2).measured?.streak).toBe(0); // not even a live candidate
+      expect(at(3).state).toBe("breach");
+      expect(at(3).severity).toBe("warn");
+    });
+
+    it("ABSTAINS on a row persisted before the field existed — unknown is not 'never'", () => {
+      // A state file written by an older build has no `lastCompletedAgeS`.
+      // Reading that as "never completed" would page on hydration alone.
+      const v = evaluateConsolidationFailureStreak([
+        sample(0, {
+          banks: banks({
+            streaks: [
+              {
+                bank: "overlord",
+                operationType: "graph_maintenance",
+                streak: 19,
+                newestFailureAgeS: 133_977,
+              },
+            ],
+          }),
+        }),
+      ]);
+      expect(v.state).toBe("ok");
+    });
   });
 
   it("reports no-data — never a pass — when the per-bank block is missing", () => {

--- a/src/hindsight-watch/evaluate.ts
+++ b/src/hindsight-watch/evaluate.ts
@@ -888,7 +888,7 @@ export function evaluateConsolidationQueueAge(ring: Sample[]): Verdict {
  *    every 87 s through the 2026-07-29 incident, so "newest failure inside
  *    `CONSOLIDATION_STREAK_RECENCY_S`" tracks it exactly.
  *
- *  - **No success in a long time** (the arm added for #4620). A SPARSE,
+ *  - **No success in a long time** (the arm added in #4618). A SPARSE,
  *    demand-driven type produces no new failures while it is broken, because
  *    it only runs when work is enqueued — so arm one structurally cannot hold
  *    its streak. Measured live 2026-08-12: `overlord/graph_maintenance` held a
@@ -904,10 +904,27 @@ export function evaluateConsolidationQueueAge(ring: Sample[]): Verdict {
  * completion lands, which is the property the recency guard existed to
  * protect.
  *
- * `lastCompletedAgeS === undefined` means the row predates the field (an old
- * persisted state file), NOT that the pair never completed: the sparse arm
- * abstains rather than guess, leaving the row on the pre-existing behaviour
- * until the next probe fills the field in.
+ * **The second arm is NOT scoped to sparse types** — nothing here can tell
+ * them apart, and inventing a classifier would be a second thing to get
+ * wrong. A `consolidation` pair with ≥3 failures and no completion for
+ * `CONSOLIDATION_STREAK_NO_SUCCESS_S` therefore breaches where it previously
+ * read `ok`. That is intended: it is the same fault shape, just slower.
+ *
+ * Two non-obvious readings of the field, both load-bearing:
+ *
+ *  - `undefined` means the row predates the field (an old persisted state
+ *    file), NOT that the pair never completed. The sparse arm abstains rather
+ *    than guess, leaving the row on the pre-existing behaviour until the next
+ *    probe fills the field in.
+ *  - `null` means "no `completed` row for this pair IS VISIBLE", which is only
+ *    the same as "never completed" while operation retention is longer than
+ *    this window. Retention is configurable
+ *    (`HINDSIGHT_API_OPERATION_RETENTION_DAYS`; the sweep is disabled at its
+ *    code default of 0, and the production bank observably holds 30 days), so
+ *    the null arm carries the same age evidence the numeric arm does rather
+ *    than firing on absence alone. Under a retention shorter than this window
+ *    the numeric arm would be silently unreachable, and an unguarded null arm
+ *    would then page on every streak.
  */
 function lastSuccessPhrase(lastCompletedAgeS: number | null | undefined): string {
   if (lastCompletedAgeS === undefined) return "unknown (state predates the field)";
@@ -924,7 +941,10 @@ function isLiveStreak(s: BankFailureStreak): boolean {
   // "recent enough" test, silently promotes unknown to "never completed" and
   // pages on hydration alone.
   const last = s.lastCompletedAgeS;
-  if (last === null) return true;
+  // No visible completion: fall back to the only clock left, the streak's own
+  // age. Firing on absence alone would page on a short retention window (see
+  // the doc block) rather than on evidence.
+  if (last === null) return s.newestFailureAgeS > CONSOLIDATION_STREAK_NO_SUCCESS_S;
   return typeof last === "number" && last > CONSOLIDATION_STREAK_NO_SUCCESS_S;
 }
 

--- a/src/hindsight-watch/evaluate.ts
+++ b/src/hindsight-watch/evaluate.ts
@@ -916,15 +916,26 @@ export function evaluateConsolidationQueueAge(ring: Sample[]): Verdict {
  *    file), NOT that the pair never completed. The sparse arm abstains rather
  *    than guess, leaving the row on the pre-existing behaviour until the next
  *    probe fills the field in.
- *  - `null` means "no `completed` row for this pair IS VISIBLE", which is only
- *    the same as "never completed" while operation retention is longer than
- *    this window. Retention is configurable
- *    (`HINDSIGHT_API_OPERATION_RETENTION_DAYS`; the sweep is disabled at its
- *    code default of 0, and the production bank observably holds 30 days), so
- *    the null arm carries the same age evidence the numeric arm does rather
- *    than firing on absence alone. Under a retention shorter than this window
- *    the numeric arm would be silently unreachable, and an unguarded null arm
- *    would then page on every streak.
+ *  - `null` means "no `completed` row for this pair IS VISIBLE", which is NOT
+ *    the same as "never completed". `docker/hindsight-maintenance.sh:136`
+ *    deletes `status='completed'` rows older than
+ *    `SWITCHROOM_HINDSIGHT_RETENTION_DAYS` (default 30, unset in the fleet) —
+ *    and, per that script's own header at line 23, **never touches
+ *    failed/pending/processing rows**. So the two halves of a streak age
+ *    differently: successes are swept, the failures that define the streak are
+ *    immortal. `null` can therefore mean "the successes were deleted while the
+ *    failures were kept", and the streak query's `coalesce(…, '-infinity')`
+ *    then counts failures that predate a completion which no longer exists.
+ *
+ *    The null arm carries the same age evidence the numeric arm does rather
+ *    than firing on absence alone, which covers the honest cases — a new pair,
+ *    or a pair still actively retrying. It does NOT cover the asymmetry: those
+ *    retained failures are ancient by construction, so an age guard cannot
+ *    discriminate them. The residual is a bank that still exists and has been
+ *    idle on one op type past the retention window; a deleted bank takes its
+ *    rows with it via the cascade-delete migration. It is latent — no such pair
+ *    exists on the production bank — and closing it belongs in the streak
+ *    query, by bounding the failure scan to the retention horizon, not here.
  */
 function lastSuccessPhrase(lastCompletedAgeS: number | null | undefined): string {
   if (lastCompletedAgeS === undefined) return "unknown (state predates the field)";
@@ -942,8 +953,9 @@ function isLiveStreak(s: BankFailureStreak): boolean {
   // pages on hydration alone.
   const last = s.lastCompletedAgeS;
   // No visible completion: fall back to the only clock left, the streak's own
-  // age. Firing on absence alone would page on a short retention window (see
-  // the doc block) rather than on evidence.
+  // age. Firing on absence alone would page a pair whose successes were swept
+  // by the 30-day retention delete, or one still actively retrying, rather
+  // than on evidence. (See the doc block for the case this does NOT cover.)
   if (last === null) return s.newestFailureAgeS > CONSOLIDATION_STREAK_NO_SUCCESS_S;
   return typeof last === "number" && last > CONSOLIDATION_STREAK_NO_SUCCESS_S;
 }

--- a/src/hindsight-watch/evaluate.ts
+++ b/src/hindsight-watch/evaluate.ts
@@ -13,6 +13,7 @@ import {
   CONSOLIDATION_AGE_WARN_S,
   CONSOLIDATION_FAILURE_STREAK_PAGE,
   CONSOLIDATION_FAILURE_STREAK_WARN,
+  CONSOLIDATION_STREAK_NO_SUCCESS_S,
   CONSOLIDATION_STREAK_RECENCY_S,
   LLM_FAILURE_RATE_PAGE,
   LLM_FAILURE_RATE_WARN,
@@ -875,6 +876,59 @@ export function evaluateConsolidationQueueAge(ring: Sample[]): Verdict {
 }
 
 /**
+ * Is this streak evidence of an ONGOING fault, or a historical one?
+ *
+ * A streak is defined relative to the pair's last COMPLETED op, so without
+ * some liveness test a bank that was fixed but has had no demand since keeps
+ * its historical streak — and alerts on it — for ever. Two arms, because one
+ * question does not cover both cadences:
+ *
+ *  - **Recent failure** (the original arm, unchanged). A DENSE operation type
+ *    that is still broken keeps producing failures: `consolidation` failed
+ *    every 87 s through the 2026-07-29 incident, so "newest failure inside
+ *    `CONSOLIDATION_STREAK_RECENCY_S`" tracks it exactly.
+ *
+ *  - **No success in a long time** (the arm added for #4620). A SPARSE,
+ *    demand-driven type produces no new failures while it is broken, because
+ *    it only runs when work is enqueued — so arm one structurally cannot hold
+ *    its streak. Measured live 2026-08-12: `overlord/graph_maintenance` held a
+ *    streak of 19 whose newest failure was 37 h old and `klanker/graph_maintenance`
+ *    a streak of 9 at 91 h; both failed the 2 h window, the candidate list
+ *    emptied, and the signal reported `{"status":"ok","breaches":0}` while the
+ *    job was 100 % broken. Both pairs had gone 220 h with no successful op.
+ *
+ * The second arm asks the honest question — "has anything SUCCEEDED lately?"
+ * — instead of the proxy, and is conjoined with
+ * `CONSOLIDATION_FAILURE_STREAK_WARN` so it is only ever asked about a pair
+ * that has already failed ≥3 times in a row. It resolves the moment a
+ * completion lands, which is the property the recency guard existed to
+ * protect.
+ *
+ * `lastCompletedAgeS === undefined` means the row predates the field (an old
+ * persisted state file), NOT that the pair never completed: the sparse arm
+ * abstains rather than guess, leaving the row on the pre-existing behaviour
+ * until the next probe fills the field in.
+ */
+function lastSuccessPhrase(lastCompletedAgeS: number | null | undefined): string {
+  if (lastCompletedAgeS === undefined) return "unknown (state predates the field)";
+  if (lastCompletedAgeS === null) return "NEVER";
+  return `${(lastCompletedAgeS / 3600).toFixed(1)}h ago`;
+}
+
+function isLiveStreak(s: BankFailureStreak): boolean {
+  if (s.newestFailureAgeS <= CONSOLIDATION_STREAK_RECENCY_S) return true;
+  if (s.streak < CONSOLIDATION_FAILURE_STREAK_WARN) return false;
+  // `undefined` (a row persisted before the field existed) satisfies NEITHER
+  // disjunct and so abstains — which is only true while the null check stays
+  // STRICT. Loosening it to `== null`, or restructuring this as a negated
+  // "recent enough" test, silently promotes unknown to "never completed" and
+  // pages on hydration alone.
+  const last = s.lastCompletedAgeS;
+  if (last === null) return true;
+  return typeof last === "number" && last > CONSOLIDATION_STREAK_NO_SUCCESS_S;
+}
+
+/**
  * R6 — CONSECUTIVE terminal consolidation failures for one bank.
  *
  * The signal above, `consolidation-queue-age`, structurally cannot raise on
@@ -894,6 +948,9 @@ export function evaluateConsolidationQueueAge(ring: Sample[]): Verdict {
  *
  * `no-data` when the block is missing, never a pass — the same rule the recall
  * signals live by.
+ *
+ * Liveness is decided by `isLiveStreak` below, on TWO arms — one for dense
+ * operation types and one for sparse ones. See its doc block.
  */
 export function evaluateConsolidationFailureStreak(ring: Sample[]): Verdict {
   const signal = "consolidation-failure-streak" as const;
@@ -908,11 +965,7 @@ export function evaluateConsolidationFailureStreak(ring: Sample[]): Verdict {
         "or the container is down) — the `container` signal covers the last of those",
     };
   }
-  // A streak whose newest failure is old is not evidence of an ONGOING fault:
-  // a streak is defined relative to the last COMPLETED op, so a fixed-but-idle
-  // bank would otherwise hold its historical streak — and alert on it — for
-  // ever.
-  const live = banks.streaks.filter((s) => s.newestFailureAgeS <= CONSOLIDATION_STREAK_RECENCY_S);
+  const live = banks.streaks.filter(isLiveStreak);
   let worst: BankFailureStreak | null = null;
   for (const s of live) if (worst === null || s.streak > worst.streak) worst = s;
   if (worst === null || worst.streak < CONSOLIDATION_FAILURE_STREAK_WARN) {
@@ -943,7 +996,8 @@ export function evaluateConsolidationFailureStreak(ring: Sample[]): Verdict {
     detail:
       `bank "${worst.bank}": ${worst.streak} consecutive FAILED ${worst.operationType} ` +
       `operation(s) with no completion in between, newest ` +
-      `${Math.round(worst.newestFailureAgeS / 60)}m ago — ` +
+      `${Math.round(worst.newestFailureAgeS / 60)}m ago, last SUCCESS ` +
+      `${lastSuccessPhrase(worst.lastCompletedAgeS)} — ` +
       `warn ≥${CONSOLIDATION_FAILURE_STREAK_WARN}, page ≥${CONSOLIDATION_FAILURE_STREAK_PAGE}. ` +
       "The pending/processing queue reads EMPTY while this holds, so " +
       "`consolidation-queue-age` cannot see it." +
@@ -953,6 +1007,12 @@ export function evaluateConsolidationFailureStreak(ring: Sample[]): Verdict {
       bank: worst.bank,
       operationType: worst.operationType,
       newestFailureAgeS: worst.newestFailureAgeS,
+      // `"never"` = the pair has never completed an op; the key is absent
+      // altogether when the row predates the field, so a reader can tell
+      // "no success ever" from "we did not read it".
+      ...(worst.lastCompletedAgeS !== undefined
+        ? { lastCompletedAgeS: worst.lastCompletedAgeS ?? "never" }
+        : {}),
       breachingPairs: breaching.length,
     },
   };

--- a/src/hindsight-watch/probe.test.ts
+++ b/src/hindsight-watch/probe.test.ts
@@ -320,13 +320,35 @@ describe("probeBankConsolidation", () => {
     ]);
   });
 
-  it("DROPS a row whose last-completed field is garbage — a garbled field must not read as 'never'", () => {
+  it("ABSTAINS on a garbled last-completed field — keeps the streak, drops the field", () => {
+    // A dropped streak row reads as HEALTH, which is the exact failure this
+    // whole change exists to remove. The unreadable field is discarded; the
+    // streak and its failure age, which parsed fine, are not. Absent ≠ null:
+    // the evaluator must not read a garbled field as "never completed".
+    for (const garbage of ["NaN", "-1", "yesterday"]) {
+      expect(
+        probeBankConsolidation("c", psql(`S|b|graph_maintenance|9|900|${garbage}\nP|b|4\n`))?.streaks,
+      ).toEqual([{ bank: "b", operationType: "graph_maintenance", streak: 9, newestFailureAgeS: 900 }]);
+    }
+  });
+
+  it("accepts the pre-#4618 FIVE-field row as unknown, not as 'never'", () => {
+    // A stale container or a rolled-back query still emits the old shape.
+    // Dropping those rows would blind every signal on the block.
+    expect(probeBankConsolidation("c", psql("S|b|consolidation|7|30\nP|b|4\n"))?.streaks).toEqual([
+      { bank: "b", operationType: "consolidation", streak: 7, newestFailureAgeS: 30 },
+    ]);
+  });
+
+  it("pins the arity at BOTH ends — a 7-field row is a row we did not understand", () => {
+    // Open-ended `>= 5` would silently accept a row whose bank id contains a
+    // `|`, mis-assigning every field after it. Seven fields is not a shape
+    // this query can emit, so it is a parse failure, not a longer row.
     expect(
-      probeBankConsolidation("c", psql("S|b|graph_maintenance|9|900|NaN\nP|b|4\n"))?.streaks,
+      probeBankConsolidation("c", psql("S|b|consolidation|7|30|60|99\nP|b|4\n"))?.streaks,
     ).toEqual([]);
-    expect(
-      probeBankConsolidation("c", psql("S|b|graph_maintenance|9|900|-1\nP|b|4\n"))?.streaks,
-    ).toEqual([]);
+    // Four fields likewise: too short to carry a failure age at all.
+    expect(probeBankConsolidation("c", psql("S|b|consolidation|7\nP|b|4\n"))?.streaks).toEqual([]);
   });
 
   it("rejects a negative or non-numeric count rather than trusting it", () => {

--- a/src/hindsight-watch/probe.test.ts
+++ b/src/hindsight-watch/probe.test.ts
@@ -239,10 +239,18 @@ describe("probeBankConsolidation", () => {
   it("parses the live incident output into streaks and per-bank depth", () => {
     const out = probeBankConsolidation(
       "c",
-      psql("S|overlord|consolidation|103|668\nP|overlord|38130\nP|carrie|45\nP|klanker|0\n"),
+      psql("S|overlord|consolidation|103|668|9412\nP|overlord|38130\nP|carrie|45\nP|klanker|0\n"),
     );
     expect(out).toEqual({
-      streaks: [{ bank: "overlord", operationType: "consolidation", streak: 103, newestFailureAgeS: 668 }],
+      streaks: [
+        {
+          bank: "overlord",
+          operationType: "consolidation",
+          streak: 103,
+          newestFailureAgeS: 668,
+          lastCompletedAgeS: 9412,
+        },
+      ],
       pending: [
         { bank: "overlord", pending: 38130 },
         { bank: "carrie", pending: 45 },
@@ -265,17 +273,65 @@ describe("probeBankConsolidation", () => {
   it("skips a malformed row but keeps the rows it understood", () => {
     const out = probeBankConsolidation(
       "c",
-      psql("S|weird|bank|with|pipes|x|9\nS|overlord|consolidation|7|30\nP|overlord|12\n"),
+      psql("S|weird|bank|with|pipes|x|9|1|2\nS|overlord|consolidation|7|30|61\nP|overlord|12\n"),
     );
     expect(out?.streaks).toEqual([
-      { bank: "overlord", operationType: "consolidation", streak: 7, newestFailureAgeS: 30 },
+      {
+        bank: "overlord",
+        operationType: "consolidation",
+        streak: 7,
+        newestFailureAgeS: 30,
+        lastCompletedAgeS: 61,
+      },
     ]);
     expect(out?.pending).toEqual([{ bank: "overlord", pending: 12 }]);
   });
 
+  it("carries an EMPTY last-completed field through as null — never completed", () => {
+    // A pair whose very first op failed has no completion to age from. Null is
+    // a real state and a different one from "unreadable": the evaluator treats
+    // it as no success ever, which is a breach, so it must not be conflated
+    // with the absent field an older state file carries.
+    const out = probeBankConsolidation("c", psql("S|newbank|graph_maintenance|4|900|\nP|newbank|3\n"));
+    expect(out?.streaks).toEqual([
+      {
+        bank: "newbank",
+        operationType: "graph_maintenance",
+        streak: 4,
+        newestFailureAgeS: 900,
+        lastCompletedAgeS: null,
+      },
+    ]);
+  });
+
+  it("parses the live 2026-08-12 sparse shape, last success 220h back", () => {
+    const out = probeBankConsolidation(
+      "c",
+      psql("S|overlord|graph_maintenance|19|133977|791908\nP|overlord|0\n"),
+    );
+    expect(out?.streaks).toEqual([
+      {
+        bank: "overlord",
+        operationType: "graph_maintenance",
+        streak: 19,
+        newestFailureAgeS: 133_977,
+        lastCompletedAgeS: 791_908,
+      },
+    ]);
+  });
+
+  it("DROPS a row whose last-completed field is garbage — a garbled field must not read as 'never'", () => {
+    expect(
+      probeBankConsolidation("c", psql("S|b|graph_maintenance|9|900|NaN\nP|b|4\n"))?.streaks,
+    ).toEqual([]);
+    expect(
+      probeBankConsolidation("c", psql("S|b|graph_maintenance|9|900|-1\nP|b|4\n"))?.streaks,
+    ).toEqual([]);
+  });
+
   it("rejects a negative or non-numeric count rather than trusting it", () => {
-    expect(probeBankConsolidation("c", psql("S|b|consolidation|-1|30\nP|b|4\n"))?.streaks).toEqual([]);
-    expect(probeBankConsolidation("c", psql("S|b|consolidation|NaN|30\nP|b|4\n"))?.streaks).toEqual([]);
+    expect(probeBankConsolidation("c", psql("S|b|consolidation|-1|30|60\nP|b|4\n"))?.streaks).toEqual([]);
+    expect(probeBankConsolidation("c", psql("S|b|consolidation|NaN|30|60\nP|b|4\n"))?.streaks).toEqual([]);
   });
 });
 

--- a/src/hindsight-watch/probe.ts
+++ b/src/hindsight-watch/probe.ts
@@ -407,6 +407,15 @@ PGPASSWORD="$PW" "$PSQL" -U "$U" -h /tmp -p "$P" -d "$DB" -tAc \\
  *    finite date would silently window the count; a pair whose very first
  *    op failed must still register a streak.
  *
+ * The row also carries the age of the pair's most recent `completed` op —
+ * EMPTY when the pair has never completed one. That is the field that lets
+ * the evaluator ask "has anything succeeded lately?" instead of only "is the
+ * newest failure recent?"; the latter cannot hold the streak of a sparse,
+ * demand-driven operation type whose failures are legitimately hours or days
+ * old while the job is 100 % broken. It comes out of the same subselect shape
+ * the streak definition already pays for, so the query does not get a second
+ * pass over `async_operations`.
+ *
  * ### The depth query
  *
  * `count(*) FILTER (WHERE consolidated_at IS NULL AND fact_type IN
@@ -419,6 +428,10 @@ PGPASSWORD="$PW" "$PSQL" -U "$U" -h /tmp -p "$P" -d "$DB" -tAc \\
 const BANK_CONSOLIDATION_SH = `${PSQL_BOOTSTRAP_SH}
 PGPASSWORD="$PW" "$PSQL" -U "$U" -h /tmp -p "$P" -d "$DB" -tAc \\
   "SELECT 'S|'||a.bank_id||'|'||a.operation_type||'|'||count(*)||'|'||extract(epoch from (now()-max(a.created_at)))::bigint
+          ||'|'||coalesce(extract(epoch from (now()-(SELECT max(c.created_at) FROM async_operations c
+                                                      WHERE c.bank_id = a.bank_id
+                                                        AND c.operation_type = a.operation_type
+                                                        AND c.status = 'completed')))::bigint::text, '')
      FROM async_operations a
     WHERE a.status = 'failed'
       AND a.created_at > coalesce((SELECT max(b.created_at) FROM async_operations b
@@ -570,11 +583,28 @@ export function probeBankConsolidation(
     const t = line.trim();
     if (t === "") continue;
     const f = t.split("|");
-    if (f[0] === "S" && f.length === 5) {
+    if (f[0] === "S" && f.length === 6) {
       const streak = Number(f[3]);
       const age = Number(f[4]);
       if (!Number.isFinite(streak) || !Number.isFinite(age) || streak < 0 || age < 0) continue;
-      streaks.push({ bank: f[1], operationType: f[2], streak, newestFailureAgeS: age });
+      // Empty means the pair has never completed an op — a real state, and a
+      // DIFFERENT one from "we could not read it", so it is carried as an
+      // explicit null rather than dropped. An unparseable value drops the ROW:
+      // admitting it as null would read as "never succeeded" and could page on
+      // a garbled field.
+      let lastCompletedAgeS: number | null = null;
+      if (f[5] !== "") {
+        const completedAge = Number(f[5]);
+        if (!Number.isFinite(completedAge) || completedAge < 0) continue;
+        lastCompletedAgeS = completedAge;
+      }
+      streaks.push({
+        bank: f[1],
+        operationType: f[2],
+        streak,
+        newestFailureAgeS: age,
+        lastCompletedAgeS,
+      });
       parsedAny = true;
     } else if (f[0] === "P" && f.length === 3) {
       const n = Number(f[2]);

--- a/src/hindsight-watch/probe.ts
+++ b/src/hindsight-watch/probe.ts
@@ -387,8 +387,11 @@ PGPASSWORD="$PW" "$PSQL" -U "$U" -h /tmp -p "$P" -d "$DB" -tAc \\
  *
  * Two tagged sections on stdout, so one round trip answers both signals:
  *
- *   `S|<bank>|<operation_type>|<streak>|<newest_failure_age_seconds>`
+ *   `S|<bank>|<operation_type>|<streak>|<newest_failure_age_seconds>|<last_completed_age_seconds>`
  *   `P|<bank>|<pending_consolidation>`
+ *
+ * The sixth field is EMPTY when the pair has never completed an op. The
+ * five-field row is the pre-#4618 shape and is still parsed, as unknown.
  *
  * ### The streak query
  *
@@ -412,9 +415,12 @@ PGPASSWORD="$PW" "$PSQL" -U "$U" -h /tmp -p "$P" -d "$DB" -tAc \\
  * the evaluator ask "has anything succeeded lately?" instead of only "is the
  * newest failure recent?"; the latter cannot hold the streak of a sparse,
  * demand-driven operation type whose failures are legitimately hours or days
- * old while the job is 100 % broken. It comes out of the same subselect shape
- * the streak definition already pays for, so the query does not get a second
- * pass over `async_operations`.
+ * old while the job is 100 % broken. It reuses the same correlated-subselect
+ * SHAPE the streak definition already uses, but it is a SECOND correlated
+ * subselect and does cost a second `SubPlan` over `async_operations` — the
+ * measured price on the production database is the whole statement at 20.3 ms
+ * (`EXPLAIN (ANALYZE, TIMING OFF)`), against a 5 s probe budget, so it is
+ * affordable rather than free.
  *
  * ### The depth query
  *
@@ -583,27 +589,38 @@ export function probeBankConsolidation(
     const t = line.trim();
     if (t === "") continue;
     const f = t.split("|");
-    if (f[0] === "S" && f.length === 6) {
+    // Exactly 6 fields is the current row; exactly 5 is the pre-#4618 shape,
+    // accepted for the same reason a garbled sixth field does not drop the
+    // row — a dropped streak reads as HEALTH. Any OTHER arity is a row we did
+    // not understand (a bank id containing a `|`, a changed query) and is
+    // skipped, so the arity is pinned at both ends rather than open-ended.
+    if (f[0] === "S" && (f.length === 6 || f.length === 5)) {
       const streak = Number(f[3]);
       const age = Number(f[4]);
       if (!Number.isFinite(streak) || !Number.isFinite(age) || streak < 0 || age < 0) continue;
-      // Empty means the pair has never completed an op — a real state, and a
-      // DIFFERENT one from "we could not read it", so it is carried as an
-      // explicit null rather than dropped. An unparseable value drops the ROW:
-      // admitting it as null would read as "never succeeded" and could page on
-      // a garbled field.
-      let lastCompletedAgeS: number | null = null;
-      if (f[5] !== "") {
+      // Three states, and the tie-break matters more than it looks. EMPTY is
+      // a real reading — the pair has never completed an op. A GARBLED value
+      // is not: it becomes `undefined`, on which the evaluator's sparse arm
+      // abstains, so the STREAK still counts on the pre-existing recency
+      // behaviour. Dropping the whole row instead would delete a streak of 19
+      // from the sample, and a missing streak reads as HEALTH — the exact
+      // failure mode this signal exists to end, and the same tie-break
+      // `normalizeBankSample` makes for a row that lacks the field.
+      let lastCompletedAgeS: number | null | undefined;
+      if (f.length === 5) {
+        lastCompletedAgeS = undefined; // pre-#4618 row: unknown, not "never"
+      } else if (f[5] === "") {
+        lastCompletedAgeS = null;
+      } else {
         const completedAge = Number(f[5]);
-        if (!Number.isFinite(completedAge) || completedAge < 0) continue;
-        lastCompletedAgeS = completedAge;
+        if (Number.isFinite(completedAge) && completedAge >= 0) lastCompletedAgeS = completedAge;
       }
       streaks.push({
         bank: f[1],
         operationType: f[2],
         streak,
         newestFailureAgeS: age,
-        lastCompletedAgeS,
+        ...(lastCompletedAgeS !== undefined ? { lastCompletedAgeS } : {}),
       });
       parsedAny = true;
     } else if (f[0] === "P" && f.length === 3) {

--- a/src/hindsight-watch/run.test.ts
+++ b/src/hindsight-watch/run.test.ts
@@ -686,8 +686,8 @@ describe("formatFiring — severity in the notification shade", () => {
  * the shell text so it cannot silently answer the wrong probe.
  */
 function dockerIncident(opts: {
-  /** `(bank, op_type, streak, newest_failure_age_s)` rows */
-  streaks?: Array<[string, string, number, number]>;
+  /** `(bank, op_type, streak, newest_failure_age_s, last_completed_age_s)` rows */
+  streaks?: Array<[string, string, number, number, number | null]>;
   /** `(bank, pending_consolidation)` rows */
   pending?: Array<[string, number]>;
   /** async_operations rows in `pending`/`processing` — the OLD signal's input */
@@ -708,7 +708,9 @@ function dockerIncident(opts: {
     }
     if (sh.includes("'S|'||")) {
       const lines = [
-        ...(opts.streaks ?? []).map(([b, t, n, age]) => `S|${b}|${t}|${n}|${age}`),
+        ...(opts.streaks ?? []).map(
+          ([b, t, n, age, ok]) => `S|${b}|${t}|${n}|${age}|${ok ?? ""}`,
+        ),
         ...(opts.pending ?? [["overlord", 0]] as Array<[string, number]>).map(
           ([b, n]) => `P|${b}|${n}`,
         ),
@@ -730,7 +732,7 @@ describe("tick — the 2026-07-29 silent consolidation outage", () => {
     const run = dockerIncident({
       // The live shape, read off the production database during the incident:
       // `overlord | consolidation | 103 | 668`. Nothing else in the fleet.
-      streaks: [["overlord", "consolidation", 103, 668]],
+      streaks: [["overlord", "consolidation", 103, 668, 9412]],
       pending: [["overlord", 38130], ["carrie", 45]],
       // …and the pending/processing queue is EMPTY at the same instant. This
       // is the whole bug: the old signal's input says the fleet is healthy.
@@ -765,6 +767,41 @@ describe("tick — the 2026-07-29 silent consolidation outage", () => {
     expect(dm).toBeDefined();
     expect(dm).toContain("overlord");
     expect(dm).toContain("103 consecutive FAILED consolidation");
+  });
+
+  it("DMs on the SPARSE 2026-08-12 shape, whose failures are 37h old", async () => {
+    // End-to-end proof of the blind spot: `graph_maintenance` is
+    // demand-driven, so a totally broken job emits no recent failure and the
+    // whole tick — probe, parse, evaluate, notify — used to come back green.
+    const sent: Sent = { texts: [] };
+    spool(0);
+    const t0 = Date.parse("2026-08-12T07:00:00Z");
+    const run = dockerIncident({
+      streaks: [
+        ["overlord", "graph_maintenance", 19, 133_977, 791_908],
+        ["klanker", "graph_maintenance", 9, 328_555, 791_676],
+      ],
+      pending: [["overlord", 0], ["klanker", 0]],
+      queueDepth: 0,
+    });
+    const r = await tick({
+      statePath,
+      agentsDir,
+      notify: makeNotify(sent),
+      run,
+      fetchImpl: fakeFetch(metricsBody(1000, 10)),
+      nowFn: () => t0,
+    });
+
+    const streak = r.outcomes.find((o) => o.verdict.signal === "consolidation-failure-streak")!;
+    expect(streak.verdict.state).toBe("breach");
+    expect(streak.verdict.severity).toBe("page");
+    expect(r.exitCode).toBe(10);
+
+    const dm = sent.texts.find((t) => t.includes("consolidation-failure-streak"));
+    expect(dm).toBeDefined();
+    expect(dm).toContain("19 consecutive FAILED graph_maintenance");
+    expect(dm).toContain("last SUCCESS 220.0h ago");
   });
 
   it("stays silent on a fleet with no failure streak at all — the live healthy shape", async () => {

--- a/src/hindsight-watch/state.test.ts
+++ b/src/hindsight-watch/state.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   defaultStatePath,
   loadState,
+  normalizeBankSample,
   normalizeConsolidationSample,
   normalizeRecallSample,
   pushSample,
@@ -146,6 +147,45 @@ describe("normalizeConsolidationSample", () => {
     });
     expect(normalizeConsolidationSample({ pending: 77 })).toBeNull();
     expect(normalizeConsolidationSample({ pending: 77, oldestAgeS: Number.NaN })).toBeNull();
+  });
+});
+
+describe("normalizeBankSample — streak rows across a version upgrade", () => {
+  const row = (over: Record<string, unknown> = {}) => ({
+    bank: "overlord",
+    operationType: "graph_maintenance",
+    streak: 19,
+    newestFailureAgeS: 133_977,
+    ...over,
+  });
+
+  it("KEEPS a row written before `lastCompletedAgeS` existed, without inventing one", () => {
+    // Dropping the row would read as a SHORTER streak — health — on the
+    // upgrade tick, which is the failure mode this whole signal exists to
+    // end. Defaulting it to null would read as "never completed" and page.
+    const out = normalizeBankSample({ streaks: [row()], pending: [] });
+    expect(out?.streaks).toHaveLength(1);
+    expect(out?.streaks[0].lastCompletedAgeS).toBeUndefined();
+    expect("lastCompletedAgeS" in out!.streaks[0]).toBe(false);
+  });
+
+  it("round-trips both real states: a number and an explicit null", () => {
+    expect(
+      normalizeBankSample({ streaks: [row({ lastCompletedAgeS: 791_908 })], pending: [] })
+        ?.streaks[0].lastCompletedAgeS,
+    ).toBe(791_908);
+    expect(
+      normalizeBankSample({ streaks: [row({ lastCompletedAgeS: null })], pending: [] })?.streaks[0]
+        .lastCompletedAgeS,
+    ).toBeNull();
+  });
+
+  it("drops a row whose `lastCompletedAgeS` is garbage rather than trusting it", () => {
+    for (const bad of [-1, Number.NaN, "9412", {}]) {
+      expect(
+        normalizeBankSample({ streaks: [row({ lastCompletedAgeS: bad })], pending: [] })?.streaks,
+      ).toEqual([]);
+    }
   });
 });
 

--- a/src/hindsight-watch/state.ts
+++ b/src/hindsight-watch/state.ts
@@ -187,6 +187,19 @@ export function normalizeBankSample(x: unknown): Sample["banks"] {
   const streaks = b.streaks.filter((r): r is BankFailureStreak => {
     if (typeof r !== "object" || r === null) return false;
     const s = r as Record<string, unknown>;
+    // `lastCompletedAgeS` is deliberately tolerated as ABSENT: a state file
+    // written by a build older than the field would otherwise have every
+    // streak row dropped on the upgrade tick, and a dropped row reads as a
+    // SHORTER streak — health — not as blindness. Absent stays `undefined`,
+    // which is what makes the evaluator's sparse arm abstain rather than
+    // mistake "we never read this" for "never completed".
+    if (
+      s.lastCompletedAgeS !== undefined &&
+      s.lastCompletedAgeS !== null &&
+      !isCount(s.lastCompletedAgeS)
+    ) {
+      return false;
+    }
     return (
       typeof s.bank === "string" &&
       typeof s.operationType === "string" &&

--- a/src/hindsight-watch/thresholds.ts
+++ b/src/hindsight-watch/thresholds.ts
@@ -1050,14 +1050,30 @@ export const CONSOLIDATION_STREAK_RECENCY_S = 2 * 60 * 60;
  * ### The measurement window is 30 days, and that is a hard ceiling
  *
  * Every rate below is taken from `async_operations` on the production bank on
- * 2026-08-12, and that table holds **30 days**, not more: `min(created_at)` is
- * 2026-07-13 and NO terminal row older than 30 days by `updated_at` survives,
- * while `memory_units` in the same database goes back to 2026-04-15. Terminal
- * operations are swept by the retention job
- * (`engine/maintenance.py::_run_operation_cleanup` →
- * `prune_terminal_operations`, deleting `completed|failed|cancelled` rows by
- * `updated_at < now() - operation_retention_days`). A longer baseline is not
- * available to measure and cannot be claimed.
+ * 2026-08-12, and that table holds **30 days**, not more: `min(created_at)` for
+ * `completed` rows is 2026-07-13 — measured at 30.008 days and advancing in
+ * real time — while `memory_units` in the same database goes back to
+ * 2026-04-15. A longer baseline is not available to measure and cannot be
+ * claimed.
+ *
+ * The sweep is OURS, not the Hindsight API's:
+ * `docker/hindsight-maintenance.sh:136` runs
+ *
+ *   DELETE FROM async_operations
+ *    WHERE status='completed' AND created_at < now() - make_interval(days => N)
+ *
+ * on every maintenance tick, with `N = SWITCHROOM_HINDSIGHT_RETENTION_DAYS`
+ * defaulting to 30 (line 63) and unset in the fleet. Confirmed live in
+ * `docker logs switchroom-hindsight`: `pruned 40 completed async_operations
+ * older than 30d`. The API's own `operation_retention_days` sweep is a
+ * different mechanism and is NOT what bounds this window — it is disabled
+ * (`HINDSIGHT_API_OPERATION_RETENTION_DAYS` unset, code default 0).
+ *
+ * **The sweep is asymmetric, and that asymmetry matters below.** Only
+ * `status='completed'` is deleted; the script's own header (line 23) states
+ * that failed/pending/processing rows are NEVER touched, and the table bears
+ * it out — oldest `completed` row 30.008 days, oldest `failed` row 25.110
+ * days and ageing without bound.
  *
  * ### 48 h, and the honest limits of the derivation
  *
@@ -1105,6 +1121,29 @@ export const CONSOLIDATION_STREAK_RECENCY_S = 2 * 60 * 60;
  *    end;
  *  - it clears the instant one op completes, which is the property the
  *    recency guard existed to protect.
+ *
+ * **What doubling 24 h → 48 h costs.** Worst-case detection latency for a
+ * broken sparse job doubles with it: a job that breaks the moment after its
+ * last success is now invisible for up to 48 h rather than 24 h. That is the
+ * price of the margin argued for above, and it is paid deliberately — against
+ * the status quo of *never*, and against a 24 h line that a measured 27.67 h
+ * self-heal would have false-paged.
+ *
+ * **The retention asymmetry leaves a second, LATENT residual.** Because
+ * completions are pruned at 30 days while failures are immortal, a
+ * `lastCompletedAgeS` of `null` does not symmetrically mean "no completion in
+ * the retention window" — it can mean the successes were swept while the
+ * failures defining the streak were kept, and the streak query's
+ * `coalesce(…, '-infinity')` then counts every historical failure, including
+ * ones that predate a now-deleted success. The `newestFailureAgeS` guard on
+ * the null arm cannot catch that, because those retained failures are ancient
+ * by construction. The exposure is a bank that still EXISTS but has been idle
+ * on one op type for longer than the retention window; a deleted bank takes
+ * its rows with it via the cascade-delete migration. Latent, not live:
+ * simulating the prune at 5- and 12-day horizons surfaces no pair other than
+ * the two live `graph_maintenance` ones. Closing it properly belongs in the
+ * streak query — bounding the failure scan to the retention horizon — not in
+ * the evaluator, and is tracked separately rather than widened into this fix.
  *
  * That is a documented limitation, not a safety claim: the alternative is the
  * status quo, where a permanently-broken sparse type reads green for ever.

--- a/src/hindsight-watch/thresholds.ts
+++ b/src/hindsight-watch/thresholds.ts
@@ -1047,35 +1047,69 @@ export const CONSOLIDATION_STREAK_RECENCY_S = 2 * 60 * 60;
  * …with the pair's last SUCCESS 220 h ago in both cases. The consequence is
  * general: any permanently-broken sparse operation type reads green forever.
  *
- * **24 h, measured.** Two rates bound it, both taken from `async_operations`
- * on the production bank, 2026-08-12:
+ * ### The measurement window is 30 days, and that is a hard ceiling
  *
- *  - **Floor — how long a self-healing fault legitimately takes.** Over 90
- *    days there were 6 episodes of ≥3 consecutive failures for a pair that
- *    then RECOVERED. Measuring each episode success-to-success (the exact
- *    window this constant thresholds): max 17.64 h
- *    (`refresh_mental_model`), median 8.70 h, min 2.01 h. 24 h clears the
- *    longest observed self-heal by ~36 %, so a fault that resolves on its own
- *    does not page on the way.
- *  - **Ceiling — the incidents this must catch.** The two live
- *    `graph_maintenance` episodes are the only ≥3 streaks in that 90-day
- *    window that never recovered; both are 220 h since last success, ~9× this
- *    line.
+ * Every rate below is taken from `async_operations` on the production bank on
+ * 2026-08-12, and that table holds **30 days**, not more: `min(created_at)` is
+ * 2026-07-13 and NO terminal row older than 30 days by `updated_at` survives,
+ * while `memory_units` in the same database goes back to 2026-04-15. Terminal
+ * operations are swept by the retention job
+ * (`engine/maintenance.py::_run_operation_cleanup` →
+ * `prune_terminal_operations`, deleting `completed|failed|cancelled` rows by
+ * `updated_at < now() - operation_retention_days`). A longer baseline is not
+ * available to measure and cannot be claimed.
  *
- * The healthy p99 inter-completion gap for the sparsest type is 28.47 h,
- * ABOVE this line — deliberately not the bound used, because a healthy idle
- * pair has streak 0 and is never a candidate. The conjunction with
- * `CONSOLIDATION_FAILURE_STREAK_WARN` is what makes that safe: this window
- * only ever gets asked about a pair that has ALREADY failed ≥3 times in a row
- * with no completion in between.
+ * ### 48 h, and the honest limits of the derivation
  *
- * The residual, accepted deliberately: a pair that was broken, was fixed, and
- * has had no demand since will page 24 h after its last success, because
- * nothing has run to prove the fix. That is the honest reading of the
- * evidence — and unlike the recency guard it resolves the instant one op
- * completes.
+ *  - **Ceiling — the incidents this must catch.** Both live
+ *    `graph_maintenance` episodes are 220 h since their last success: 4.6× this
+ *    line. They are the only ≥3 streaks in the window that never recovered.
+ *
+ *  - **Floor — how long a self-healing fault legitimately takes.** Measured
+ *    over ALL 58 failure episodes in the window (56 of which recovered), each
+ *    scored success-to-success, which is exactly the span this constant
+ *    thresholds: p50 0.88 h, p95 16.16 h, **max 27.67 h** (`retain` /
+ *    `batch_retain`). 48 h clears the longest observed self-heal by 73 %.
+ *
+ *    The narrower population is reported too, because it is the one that looks
+ *    most relevant and is the most misleading: conditioning on ≥3 consecutive
+ *    failures leaves 6 recovered episodes (spans 2.01 / 4.82 / 5.99 / 8.70 /
+ *    9.75 / 17.64 h; median 7.35 h) and a max of 17.64 h. Deriving the line
+ *    from those six would put it under the 27.67 h self-heal that exists in
+ *    the same window — a margin that is an artefact of the conditioning, not a
+ *    property of the system. The wider population is the defensible one.
+ *
+ *  - **What is NOT measured, and cannot be.** Of the 8 ≥3 episodes in the
+ *    window, 5 are `refresh_mental_model`, 1 is `consolidation`, and the only
+ *    2 `graph_maintenance` ones are the unresolved live incidents. **There is
+ *    no recovered SPARSE ≥3 episode on record**, so the floor above is
+ *    measured on dense types (inter-completion p99 9.52–15.69 h) and applied
+ *    to a type whose own healthy inter-completion p99 is 28.47 h and whose max
+ *    healthy gap is 145.17 h. 48 h clears that p99 by 69 %, which is why it is
+ *    the line rather than 24 h; it does not clear the max, and nothing
+ *    sensible would.
+ *
+ * ### The residual exposure, stated rather than argued away
+ *
+ * A pair that has ALREADY breached (≥`CONSOLIDATION_FAILURE_STREAK_WARN`
+ * consecutive failures) and then goes idle IS exposed: three transient
+ * `graph_maintenance` failures followed by 48 h with no delete to enqueue work
+ * raises a warn on a pair that is not broken. For a demand-driven type the
+ * recovery clock is bounded below by DEMAND ARRIVAL, not by fault duration, so
+ * no threshold under 145.17 h removes this, and a threshold that high would
+ * not be a monitor. The exposure is bounded instead of eliminated:
+ *
+ *  - it needs a real streak first — a healthy pair that merely goes idle has
+ *    streak 0 and is never a candidate;
+ *  - it enters at `warn` (3), not `page` (10), so the noisy end is the quiet
+ *    end;
+ *  - it clears the instant one op completes, which is the property the
+ *    recency guard existed to protect.
+ *
+ * That is a documented limitation, not a safety claim: the alternative is the
+ * status quo, where a permanently-broken sparse type reads green for ever.
  */
-export const CONSOLIDATION_STREAK_NO_SUCCESS_S = 24 * 60 * 60;
+export const CONSOLIDATION_STREAK_NO_SUCCESS_S = 48 * 60 * 60;
 
 /**
  * Per-bank unconsolidated depth: the floor below which GROWTH is not worth

--- a/src/hindsight-watch/thresholds.ts
+++ b/src/hindsight-watch/thresholds.ts
@@ -1029,6 +1029,55 @@ export const CONSOLIDATION_FAILURE_STREAK_PAGE = 10;
 export const CONSOLIDATION_STREAK_RECENCY_S = 2 * 60 * 60;
 
 /**
+ * How long a pair may go with NO successful op before its already-breaching
+ * streak counts as live regardless of how old its newest failure is.
+ *
+ * `CONSOLIDATION_STREAK_RECENCY_S` above asks "is the newest FAILURE recent?"
+ * as a proxy for "is this still broken?". That proxy holds only for a job on a
+ * tight cadence — it was tuned against `consolidation`, whose incident rate
+ * was one failure every 87 s. It structurally CANNOT hold a sparse,
+ * demand-driven operation type: `graph_maintenance` runs only when work is
+ * enqueued, so it produces no new failures while it is broken and every
+ * failure it has ages out of a 2 h window within one afternoon. Measured live
+ * 2026-08-12, both banks 100 % broken and both reading `ok`:
+ *
+ *   overlord | graph_maintenance | streak 19 | newest failure 37.3 h ago
+ *   klanker  | graph_maintenance | streak  9 | newest failure 91.4 h ago
+ *
+ * …with the pair's last SUCCESS 220 h ago in both cases. The consequence is
+ * general: any permanently-broken sparse operation type reads green forever.
+ *
+ * **24 h, measured.** Two rates bound it, both taken from `async_operations`
+ * on the production bank, 2026-08-12:
+ *
+ *  - **Floor — how long a self-healing fault legitimately takes.** Over 90
+ *    days there were 6 episodes of ≥3 consecutive failures for a pair that
+ *    then RECOVERED. Measuring each episode success-to-success (the exact
+ *    window this constant thresholds): max 17.64 h
+ *    (`refresh_mental_model`), median 8.70 h, min 2.01 h. 24 h clears the
+ *    longest observed self-heal by ~36 %, so a fault that resolves on its own
+ *    does not page on the way.
+ *  - **Ceiling — the incidents this must catch.** The two live
+ *    `graph_maintenance` episodes are the only ≥3 streaks in that 90-day
+ *    window that never recovered; both are 220 h since last success, ~9× this
+ *    line.
+ *
+ * The healthy p99 inter-completion gap for the sparsest type is 28.47 h,
+ * ABOVE this line — deliberately not the bound used, because a healthy idle
+ * pair has streak 0 and is never a candidate. The conjunction with
+ * `CONSOLIDATION_FAILURE_STREAK_WARN` is what makes that safe: this window
+ * only ever gets asked about a pair that has ALREADY failed ≥3 times in a row
+ * with no completion in between.
+ *
+ * The residual, accepted deliberately: a pair that was broken, was fixed, and
+ * has had no demand since will page 24 h after its last success, because
+ * nothing has run to prove the fix. That is the honest reading of the
+ * evidence — and unlike the recency guard it resolves the instant one op
+ * completes.
+ */
+export const CONSOLIDATION_STREAK_NO_SUCCESS_S = 24 * 60 * 60;
+
+/**
  * Per-bank unconsolidated depth: the floor below which GROWTH is not worth
  * scoring, and the growth thresholds themselves.
  *

--- a/src/hindsight-watch/types.ts
+++ b/src/hindsight-watch/types.ts
@@ -269,6 +269,23 @@ export interface BankFailureStreak {
   streak: number;
   /** seconds since the NEWEST failure in the streak — the staleness guard */
   newestFailureAgeS: number;
+  /**
+   * Seconds since this pair's most recent `completed` op; `null` when the
+   * pair has NEVER completed one.
+   *
+   * The liveness evidence for a SPARSE operation type. `newestFailureAgeS`
+   * asks "is the newest failure recent?" as a proxy for "is this still
+   * broken?", which only holds for a job on a tight cadence. `graph_maintenance`
+   * is demand-driven — it runs only when work is enqueued — so its failures
+   * are routinely hours or days old while it is 100 % broken. "Has anything
+   * SUCCEEDED lately?" is the question that survives the sparse case, and it
+   * resolves the moment a completion lands.
+   *
+   * `undefined` — distinct from `null` — on a row persisted by a build older
+   * than this field. Unknown is not "never completed": the evaluator's sparse
+   * arm abstains on `undefined` rather than reading it as either state.
+   */
+  lastCompletedAgeS?: number | null;
 }
 
 /** One bank's unconsolidated-memory depth. */


### PR DESCRIPTION
## Why / job spec

`reference/jobs/fleet-stays-healthy.md` — *"the fleet detects, ranks, and
tracks its own recurring failures… the operator never has to hand-audit
turns to find what is quietly breaking."* This PR removes a case where the
detector itself was the thing quietly breaking: a broken job that reported
`{"status":"ok","breaches":0}` for as long as it stayed broken is exactly
the silent failure the spec exists to prevent.

## The defect

`consolidation-failure-streak` (R6) admitted a `(bank, operation_type)`
streak as a live breach only when its newest FAILURE was under 2 h old
(`CONSOLIDATION_STREAK_RECENCY_S`). That guard is a proxy for "still
broken", and it was tuned against `consolidation`, which failed roughly
every 87 s during the 2026-07-29 incident.

A **demand-driven** operation type produces no new failures while it is
broken, because it only runs when work is enqueued. So the proxy
structurally cannot hold its streak. Live on the production database,
2026-08-12:

| bank | op type | streak | newest failure | last success |
|---|---|---:|---:|---:|
| `overlord` | `graph_maintenance` | **19** | 37.2 h | 220 h |
| `klanker` | `graph_maintenance` | **9** | 91.3 h | 220 h |

The page line is 10. Running the **unmodified `origin/main`** evaluator
against those rows:

```json
{"state":"ok","detail":"longest live consolidation-failure streak 0 across 2 bank/op pair(s) — warn ≥3, page ≥10","measured":{"streak":0,"pairs":2}}
```

Both pairs failed the 2 h recency filter, the candidate list emptied, and
the signal reported a streak of zero while the job was 100 % broken.

**The consequence is general.** Any permanently-broken sparse operation
type reads green forever. `graph_maintenance` is the instance that
surfaced it, not the scope of the bug.

## The fix

The per-pair psql pass also reads the age of the pair's most recent
`completed` op (`lastCompletedAgeS`; empty when the pair has never
completed one). A streak counts as live when EITHER:

1. its newest failure is under `CONSOLIDATION_STREAK_RECENCY_S` (the old
   condition, byte-for-byte unchanged), **or**
2. the streak has reached the warn line (3) **and** nothing has succeeded
   for `CONSOLIDATION_STREAK_NO_SUCCESS_S` (48 h).

Asking "has anything SUCCEEDED lately?" instead of "is the failure
recent?" still clears the instant a completion lands — which is what the
recency guard existed to protect.

### This is a behaviour change, not a no-op for dense jobs

The second arm is **not** scoped to sparse types; nothing in the data
distinguishes them. A `consolidation` pair with ≥3 failures and no
completion for 48 h therefore breaches where it previously read `ok`.
That is intended — a dense job broken for two days should page — but it
is a real behaviour delta and is called out in both doc blocks and the
changelog rather than glossed as "unchanged".

### Where 48 h comes from, and what it cannot claim

Per `thresholds.ts`'s contract, the constant carries its derivation —
including the parts that are *not* measured:

- **The window is 30 days, and that is a hard ceiling.**
  `async_operations` `min(created_at)` is 2026-07-13; `memory_units` goes
  back to 2026-04-15. No terminal row is older than 30 days. Nothing about
  a longer horizon is knowable from this table.
- **Floor, from every self-resolving episode in the window** (58 episodes,
  56 recovered, all operation types, ≥1 failure): p50 0.88 h, p95
  16.16 h, max 27.67 h (`retain`/`batch_retain`). 48 h clears the observed
  max by 73 %.
- **Ceiling**: the two live `graph_maintenance` streaks are 220 h without
  a success — 4.6× the line.
- **What is NOT measured, and cannot be**: there is **no recovered sparse
  ≥3-failure episode on record**. The six ≥3 episodes that did recover are
  5 `refresh_mental_model` + 1 `consolidation` (spans 2.01 / 4.82 / 5.99 /
  8.70 / 9.75 / 17.64 h; median 7.35 h continuous, 5.99 h discrete). Their
  self-heal distribution is a **dense** distribution being applied to a
  type whose healthy inter-completion gap has p99 28.47 h and max
  145.17 h. 48 h clears that p99 by 69 %, which is why it is the line
  rather than 24 h. It does not clear the max, and nothing sensible would.
- **Residual exposure, stated rather than argued away**: a pair that is
  already breaching and then goes idle stays breaching. The recovery clock
  is bounded by demand arrival, not by a cron. That exposure is real and
  bounded by three things: it needs a genuine >=3 streak first, it enters
  at warn (3) not page (10), and it clears on the next completion.
- **What the doubling costs**: worst-case detection latency for a broken
  sparse job doubles with the constant — a job that breaks just after its
  last success is invisible for up to 48 h rather than 24 h. Paid
  deliberately, against a status quo of *never* and against a 24 h line
  that a measured 27.67 h self-heal would have false-paged.

An earlier revision of this PR derived 24 h from the six-episode
population alone. That was a margin artefact — the review caught it, a
27.67 h counterexample sits above that line, and the honest answer was to
re-derive against a defensible population *and* document the irreducible
limit, which is what the doc block now does.

## Three-state field semantics

`lastCompletedAgeS` is deliberately tri-state, and the distinction is
load-bearing:

- `number` — age of the last completion.
- `null` — no `completed` row is **visible**, which is not the same as
  "never completed". `docker/hindsight-maintenance.sh:136` deletes
  `status='completed'` rows older than `SWITCHROOM_HINDSIGHT_RETENTION_DAYS`
  (default 30, unset in the fleet) and, per that script's header at line 23,
  **never touches failed rows** — confirmed live in the logs (`pruned 40
  completed async_operations older than 30d`) and in the table (oldest
  completed row 30.008 days, oldest failed row 25.110 days and ageing).
  Breaches only if the streak is *also* older than the window; absence alone
  must not page.
- `undefined` — the row predates the field (older state file, older
  container emitting the 5-field row). **Abstains.** Reading unknown as
  "never" would page on hydration alone.

The probe *abstains* rather than dropping a row whose sixth field is
garbled or missing — a dropped streak row reads as HEALTH, which is the
very failure mode this PR removes. Row arity is pinned at exactly 5 or 6;
any other arity is a row we did not understand and is skipped.

## Cost

The added correlated subselect is a real second `SubPlan` over
`async_operations` — it is not free. Measured on the production database
with `EXPLAIN (ANALYZE, TIMING OFF)`: the whole statement runs 20.3 ms,
against a 5 s probe budget.

## Test plan

- [x] **Blindness reproduced on unmodified `origin/main` first** — the
      live-shape fixture returns `{"state":"ok","streak":0}` before the
      change and `breach`/`page` after.
- [x] **No dense regression** — a long-resolved streak (100 h-old failure,
      completion 46 h ago) still reads `ok`.
- [x] Boundary trio at 48 h − 1 s / exactly 48 h / + 1 s.
- [x] Never-completed pair, legacy row abstain, warn-line conjunction,
      garbled-field abstain, 5-field legacy arity, 7-field rejection.
- [x] End-to-end through `run.ts`: pages and the DM carries
      `"19 consecutive FAILED graph_maintenance"` / `"last SUCCESS 220.0h ago"`.
- [x] **Mutation battery, 15 mutants, 15 killed** — including flipping the
      constant in both directions, deleting either liveness arm, loosening
      `=== null` to `== null`, emitting the `measured` key
      unconditionally, collapsing the "unknown" phrase to "NEVER",
      opening the probe arity to `>= 5`, and reverting the abstain to a
      row drop. Every fixture is hard-coded in seconds and independent of
      the constants it exercises, with a pin assertion as the tripwire —
      the defect class where fixture and expectation both derive from the
      constant under test cannot recur here.
- [x] `vitest run src/hindsight-watch/` — 266 passed.
- [x] `npm run lint` — all 30 checks green.

## Scope

Single concern. The underlying `prune_stale_cooccurrences` timeout that
is *causing* the `graph_maintenance` failures is separate work and is not
touched here.

## Known limits, tracked

- **#4620 (latent)** — the retention sweep is asymmetric: completions are
  pruned at 30 days, failures never are. So a `null` last-completion can
  mean "the successes were swept while the failures were kept", and the
  streak query's `coalesce(…, '-infinity')` then counts failures predating
  a deleted completion. The null arm's age guard cannot discriminate those
  — they are ancient by construction. Not instantiable today (simulating
  the prune at 5- and 12-day horizons surfaces no pair but the two live
  `graph_maintenance` ones; a deleted bank takes its rows via the
  cascade-delete migration), and the fix belongs in the streak query
  rather than the evaluator, so it is filed rather than widened into this
  PR. Documented in both doc blocks.
- **#4621 (pre-existing on `main`)** — the recency arm's `<=` boundary at
  exactly `CONSOLIDATION_STREAK_RECENCY_S` is unpinned. Predates this
  change; filed rather than folded in.

Two earlier revisions of this PR cited the wrong retention mechanism —
first `HINDSIGHT_API_OPERATION_RETENTION_DAYS`, then
`engine/maintenance.py::_run_operation_cleanup` after proving the first
was disabled. Both are dropped. The real sweep is our own maintenance
cron, verified against the script, the container logs, and the table
before being written down.
